### PR TITLE
[SID:1971] RENAMED_RESOURCES↔MIGRATED_RESOURCES 동기화 회귀 가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -910,6 +910,13 @@ jobs:
       - name: "Verify RESERVED_FIRST_SEGMENTS sync (story #2393 regression guard)"
         run: pnpm --filter web verify:reserved-first-segments-sync
 
+      # story #1971 회귀가드: RENAMED_RESOURCES(옛 이름→신 이름)의 값이 MIGRATED_RESOURCES
+      # (bare 딥링크를 [ws]/[proj]로 채워 넣는 표)의 키에도 있는지 대조한다 — proxy.ts의
+      # redirectLegacyResourcePath는 정확히 그 판정(resourceName in MIGRATED_RESOURCES)으로
+      # bare 콜드 딥링크의 ws/proj를 채운다. #2016(epics→goals) 실사고와 동형 재발 방지.
+      - name: "Verify MIGRATED_RESOURCES sync (story #1971 regression guard)"
+        run: pnpm --filter web verify:migrated-resources-sync
+
       - name: Test
         # set -o pipefail so vitest's non-zero exit propagates through `| tail` instead
         # of being masked by tail's 0 — without it the unit-test gate was a no-op

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "verify:no-i18n-phrase-collision": "tsx scripts/verify-no-i18n-phrase-collision.ts",
     "verify:no-orphan-resource-routes": "tsx scripts/verify-no-orphan-resource-routes.ts",
     "verify:reserved-first-segments-sync": "tsx scripts/verify-reserved-first-segments-sync.ts",
+    "verify:migrated-resources-sync": "tsx scripts/verify-migrated-resources-sync.ts",
     "verify:tint-foreground-contrast": "tsx scripts/verify-tint-foreground-contrast.ts",
     "verify:no-new-tint-color-text": "tsx scripts/verify-no-new-tint-color-text.ts",
     "verify:cross-element-tint-text": "tsx scripts/verify-cross-element-tint-text.ts",

--- a/apps/web/scripts/verify-migrated-resources-sync.test.ts
+++ b/apps/web/scripts/verify-migrated-resources-sync.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { MIGRATED_RESOURCES, RENAMED_RESOURCES } from '../src/lib/legacy-resource-tables';
+import { findRenamedTargetsMissingFromMigrated } from './verify-migrated-resources-sync';
+
+describe('findRenamedTargetsMissingFromMigrated — 순수 판정 함수(AC1)', () => {
+  it('신 이름이 MIGRATED_RESOURCES 키에 있으면 위반 0건이다', () => {
+    const violations = findRenamedTargetsMissingFromMigrated(
+      { epics: 'goals' },
+      { epics: [], goals: [] },
+    );
+    expect(violations).toEqual([]);
+  });
+
+  // ⭐양성대조(AC2) — 실사고(#2016, epics→goals) 그대로 모사: RENAMED_RESOURCES엔 신 이름이
+  // 추가됐는데 MIGRATED_RESOURCES엔 그 신 이름(goals)이 빠진 상태. fix 전 코드였다면 이
+  // 케이스를 잡을 수단이 없었다 — 판정 함수가 정확히 이 모양에서 RED가 나는지 고정한다.
+  it('#2016 실사고 픽스처 — 신 이름이 MIGRATED_RESOURCES에 없으면 잡는다(양성대조)', () => {
+    const violations = findRenamedTargetsMissingFromMigrated(
+      { epics: 'goals' },
+      { epics: [] }, // goals 키 누락 — 실제 사고 당시 모양
+    );
+    expect(violations).toEqual(['goals']);
+  });
+
+  it('여러 리네임이 동시에 어긋나도 전부 잡는다', () => {
+    const violations = findRenamedTargetsMissingFromMigrated(
+      { a: 'b', c: 'd' },
+      { a: [] },
+    );
+    expect(violations).toEqual(['b', 'd']);
+  });
+
+  it('MIGRATED_RESOURCES 키가 비어 있어도(예외 상황) 안 죽고 전부 위반으로 잡는다', () => {
+    const violations = findRenamedTargetsMissingFromMigrated({ epics: 'goals' }, {});
+    expect(violations).toEqual(['goals']);
+  });
+});
+
+// story #1971 — 실 데이터(legacy-resource-tables.ts) 전수 대조. 이 테스트가 RED면 CI 가드
+// 스크립트(main())도 똑같이 RED다(같은 함수·같은 소스를 그대로 쓴다).
+describe('실 데이터(legacy-resource-tables.ts) 대조', () => {
+  it('현재 RENAMED_RESOURCES 값이 전부 MIGRATED_RESOURCES 키에 있다(#2016 재발 없음)', () => {
+    const violations = findRenamedTargetsMissingFromMigrated(RENAMED_RESOURCES, MIGRATED_RESOURCES);
+    expect(violations).toEqual([]);
+  });
+});
+
+// story #1971 AC3 — 이 가드가 못 잡는 것(스코프 밖)은 verify-migrated-resources-sync.ts 상단
+// docstring ㉠㉡㉢에 선언돼 있다: RENAMED_RESOURCES의 키(옛 이름) 쪽, RETIRED_RESOURCES의
+// 값, MIGRATED_RESOURCES 서브패스 제외 목록의 실존 여부. 함수 시그니처 자체가 `renamed:
+// Record<string,string>` 하나만 받아 RETIRED_RESOURCES를 애초에 볼 수 없게 만든다(런타임
+// 분기가 아니라 타입으로 경계를 고정 — "안 본다"고 선언한 축을 코드가 물리적으로 못 보게).

--- a/apps/web/scripts/verify-migrated-resources-sync.ts
+++ b/apps/web/scripts/verify-migrated-resources-sync.ts
@@ -1,0 +1,71 @@
+/**
+ * story #1971 회귀가드 — `legacy-resource-tables.ts`의 두 표(`RENAMED_RESOURCES`·
+ * `MIGRATED_RESOURCES`)가 손으로 따로 유지되는데, 서로 지켜야 하는 불변식이 무가드였다:
+ * **`RENAMED_RESOURCES`의 값(리네임 후 신 이름)은 반드시 `MIGRATED_RESOURCES`의 키에도
+ * 있어야 한다.** `proxy.ts`의 `redirectLegacyResourcePath`가 bare(ws/proj 세그먼트가 아직
+ * 없는) 딥링크를 `[ws]/[proj]/{resource}`로 채워 넣는 첫 관문인데, 그 판정이 정확히
+ * `resourceName in MIGRATED_RESOURCES`다 — 신 이름이 그 표에 없으면 bare 딥링크(콜드
+ * 진입·북마크·검색결과·리네임 전에 이미 뿌려진 알림)가 ws/proj를 못 채운 채 Next 자체 404로
+ * 떨어진다. `redirectRenamedResourcePath`(옛 이름→신 이름 치환)는 `segments[2]`, 즉 이미
+ * ws/proj가 채워진 경로만 보므로 이 첫 관문을 대신해 주지 않는다.
+ *
+ * ⭐실사고 전례(2026-07-27 무렵, #2016) — `epics→goals` 리네임 때 `RENAMED_RESOURCES`엔
+ * `epics: 'goals'`를 추가했지만 `MIGRATED_RESOURCES`엔 신 이름 `goals`를 안 넣었다. 결과:
+ * 옛 bare `/epics`는(옛 이름이 여전히 `MIGRATED_RESOURCES` 키라) 정상 301 두 번(legacy→
+ * renamed)을 거쳐 착지했지만, `/goals`(신 이름 그대로 오는 딥링크·북마크·검색결과)는 그
+ * 표에 키가 없어 즉시 404 — 직통 Cloud Run 호스트 실측으로 발견됐다. 이 스토리(#1971) 착수
+ * 당시엔 이미 `goals: []`가 표에 있어(별도 후속 수정으로 해소) 현재 데이터엔 위반이 없다 —
+ * 하지만 그 수정 자체가 "리네임할 때마다 사람이 두 표를 손으로 동기화해야 한다"는 불변식을
+ * 가드 없이 남겼다. 이 스크립트가 그 불변식을 CI에 고정한다.
+ *
+ * ── 스코프 밖(이 가드가 못 잡는 것) ─────────────────────────────────────────
+ *   ㉠`RENAMED_RESOURCES`의 **키**(옛 이름)가 `MIGRATED_RESOURCES`에 있는지는 안 본다 —
+ *     옛 이름은 리네임이 일어나기 전부터 이미 살아있던 리소스라 그 리소스를 만들 때 이미
+ *     `MIGRATED_RESOURCES`에 등록됐을 것이 자연스러운 순서다(리네임이 «새로 만드는» 게
+ *     아니라 «있던 것의 이름만 바꾸는» 것이므로, 키 쪽이 비는 사고는 실전례가 없다) — 값
+ *     쪽(신 이름)만 실제로 두 번 사고가 난 자리(#2016)라 그쪽만 좁게 가드한다.
+ *   ㉡`RETIRED_RESOURCES`의 값(폐기 후 목적지)은 검사 대상이 아니다 — `redirectRetiredResourcePath`도
+ *     `segments[2]`(이미 ws/proj가 채워진 경로)만 보는 동형 함수라 원칙은 같지만, 그 목적지는
+ *     항상 «이미 살아있는 다른 리소스»(예: `mockups: 'artifacts'`)라 정의상 이미
+ *     `MIGRATED_RESOURCES`(또는 그 자체가 리소스 라우트) 어딘가에 등록돼 있다는 전제가 더
+ *     강하다 — 이 스토리(#1971) AC가 명시한 «RENAMED 값→MIGRATED 키» 불변식 하나만 가드한다
+ *     (PO 승인 스코프, 향후 실사고가 나면 별도 가드로 넓힌다).
+ *   ㉢`MIGRATED_RESOURCES`의 서브패스 제외 목록(예: `docs: ['design-tokens']`)이 실제로
+ *     존재하는 정적 페이지를 가리키는지는 안 본다 — 그 축은 `verify-no-orphan-resource-routes.ts`의
+ *     라우트 실존 스캔과 겹치는 다른 관심사다.
+ */
+import { MIGRATED_RESOURCES, RENAMED_RESOURCES } from '../src/lib/legacy-resource-tables';
+
+export function findRenamedTargetsMissingFromMigrated(
+  renamed: Record<string, string>,
+  migrated: Record<string, string[]>,
+): string[] {
+  const migratedKeys = new Set(Object.keys(migrated));
+  return Object.values(renamed).filter((newName) => !migratedKeys.has(newName));
+}
+
+function main(): void {
+  const missing = findRenamedTargetsMissingFromMigrated(RENAMED_RESOURCES, MIGRATED_RESOURCES);
+
+  console.log(
+    `[AC1] RENAMED_RESOURCES 값 ${Object.keys(RENAMED_RESOURCES).length}개 · ` +
+      `MIGRATED_RESOURCES 키 ${Object.keys(MIGRATED_RESOURCES).length}개 대조`,
+  );
+
+  if (missing.length > 0) {
+    console.log(
+      `\n❌ RENAMED_RESOURCES 값이 MIGRATED_RESOURCES 키에 없다(bare ${missing
+        .map((n) => `/${n}`)
+        .join(', ')} 딥링크가 ws/proj를 못 채운 채 404) ${missing.length}건:`,
+    );
+    for (const name of missing) console.log(`  - "${name}" — legacy-resource-tables.ts의 MIGRATED_RESOURCES에 "${name}": [] 추가 필요`);
+    console.log('\n→ #2016(epics→goals) 실사고와 동형. 리네임 시 RENAMED_RESOURCES와 MIGRATED_RESOURCES를 함께 갱신할 것.');
+    process.exit(1);
+  }
+
+  console.log('OK: RENAMED_RESOURCES 값 전부 MIGRATED_RESOURCES 키에 있음(bare 신명 딥링크 404 없음)');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## 요약
원 스토리 증상(07-17, `middleware.ts 자체가 없음` → bare 딥링크 404 추정)은 그라운딩 결과 **오탐**이었다. 이 레포는 최신 Next.js의 `middleware.ts`→`proxy.ts` 명칭 변경 컨벤션을 쓰고 있고(`apps/web/src/proxy.ts`), bare 딥링크 리라이트는 실재하며 정상 동작한다.

## 크럭스 그라운딩 결과(dev 라이브 재현)
- `/board?story=X` — PO 기실측(query 보존).
- `/board?task_id=X` — 확認(`/moonklabs/sprintable/flow?task_id=X&view=list`).
- `/sprints` — 확認(`/moonklabs/sprintable/sprints`).
- `/docs/[slug]` — 확認(실 slug로 콜드 진입, subpath 보존).

전부 `redirectLegacyResourcePath`(bare→ws/proj 삽입) → `redirectRenamedResourcePath`(옛→신 이름 치환) 체인이 커버 — 제너릭 메커니즘이라 표 등록만으로 신규 리소스도 자동 커버된다.

## 남은 실 결함 — 스코프를 좁혀 여기만 고침
`RENAMED_RESOURCES`(옛 이름→신 이름)의 값이 `MIGRATED_RESOURCES`(bare→ws/proj 삽입 판정표)의 키에 반드시 있어야 하는 불변식이 **무가드**였다. `redirectLegacyResourcePath`의 첫 관문이 정확히 `resourceName in MIGRATED_RESOURCES`라, 신 이름이 그 표에 없으면 bare 콜드 딥링크(북마크·검색결과·리네임 전에 이미 뿌려진 알림)가 ws/proj를 못 채운 채 즉시 404.

**실사고 전례(#2016, 2026-07-27 무렵)** — `epics→goals` 리네임 때 `RENAMED_RESOURCES`엔 추가했는데 `MIGRATED_RESOURCES`엔 신 이름을 안 넣어서 bare `/goals`가 404났었다(코드 주석에 기록만 남고 가드는 없었음). 착수 시점엔 이미 해소돼 있었지만, "리네임할 때마다 사람이 두 표를 손으로 동기화"하는 불변식 자체는 여전히 무가드였다.

## 변경
- `scripts/verify-migrated-resources-sync.ts`(신규) — 순수 함수 `findRenamedTargetsMissingFromMigrated(renamed, migrated)` + CI 진입점. `RETIRED_RESOURCES` 값·`RENAMED_RESOURCES` 키 쪽은 명시적으로 스코프 밖(docstring에 이유 기술, PO 승인 스코프).
- `scripts/verify-migrated-resources-sync.test.ts`(신규) — **#2016 실사고를 그대로 모사한 양성대조 픽스처**(RED 고정) + 실데이터(`legacy-resource-tables.ts`) 대조.
- `package.json`/`ci.yml` — `verify:migrated-resources-sync` 스크립트+CI 스텝(기존 `verify:no-orphan-resource-routes`/`verify:reserved-first-segments-sync`와 동일 패턴).

## AC 대조
- ①불변식 가드 상륙 ✅
- ②양성대조=#2016 케이스 모사 픽스처 RED ✅(유닛테스트 + 실데이터 뮤테이션 둘 다)
- ③가드 미포착 축 선언 ✅(docstring ㉠㉡㉢ — RENAMED 키 쪽/RETIRED 값/MIGRATED 서브패스 실존)

## 검증
- `pnpm exec tsc --noEmit` / `pnpm lint`(실 CI 커맨드) — 통과(무관 파일 기존 warning 5건은 origin/develop과 diff 0, 이 PR 범위 밖)
- `pnpm build` — 통과
- `pnpm exec vitest run` — 430 files / 3483 tests 전부 통과
- `verify:no-orphan-resource-routes` / `verify:reserved-first-segments-sync` / `verify:no-new-md-breakpoint` / `verify:no-i18n-phrase-collision` — 신규 회귀 0건
- **실데이터 뮤테이션 검증**: `legacy-resource-tables.ts`에서 `goals` 항목을 임시 제거 → 가드 스크립트 직접 실행 → #2016과 동일 모양으로 RED(exit 1, `"goals"` 정확히 지목) → 원복(git status 깨끗함 확認) → GREEN 재확認

## 스크린샷
CI 전용 회귀 가드 추가라 UI 변경 없음. dev 라이브 콜드 딥링크 재현 스크린샷은 그라운딩 단계에서 PO 채널에 별도 보고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)