### PR TITLE
[SID:1940] BE — 휴먼 개인 API 키 셀프서브 발급(MCP 설정)

### DIFF
--- a/backend/alembic/versions/0252_create_human_api_keys.py
+++ b/backend/alembic/versions/0252_create_human_api_keys.py
@@ -1,0 +1,49 @@
+"""create human_api_keys table
+
+Revision ID: 0252
+Revises: 0251
+Create Date: 2026-08-16
+
+story #1940 — 휴먼 개인 API 키 셀프서브 발급. PO 판정(2026-08-16, A안): agent_api_keys
+테이블/ApiKey 모델은 재사용하지 않는다 — app/dependencies/auth.py:131 코멘트("api_key
+경로 = 에이전트 인증, 휴먼은 JWT")가 문서가 아니라 실제 강제되는 설계(member_ssot_apikey_cut
+경로는 Member.type=="agent"를 명시로 걸어 휴먼 소유 키를 401로 거부하도록 이미 짜여 있음)
++ #1561 교훈("api_key_id 존재=agent" 신뢰 신호)이 이미 여러 보안결정 지점에 퍼져 있어,
+그 불변식을 재사용으로 흔들면 이 스토리 하나로 전수 감사를 떠안게 된다. 완전히 별도
+테이블+접두사(hu_live_, sk_live_와 구분)+별도 인증 해소 경로로 간다 — 기존 agent_api_keys
+소비처는 0줄 접촉.
+
+member_id는 members.id를 가리키되(canonical SSOT), scope 컬럼은 두지 않는다(휴먼 개인 키는
+"이 휴먼 그대로"의 접근 권한을 그대로 쓴다 — agent처럼 tool-group scope로 축소하는 축이
+아니다, 스토리 스코프).
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0252"
+down_revision = "0251"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "human_api_keys",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("member_id", UUID(as_uuid=True), sa.ForeignKey("members.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("name", sa.Text, nullable=True),
+        sa.Column("key_prefix", sa.Text, nullable=False),
+        sa.Column("key_hash", sa.Text, nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_human_api_keys_member_id", "human_api_keys", ["member_id"])
+    op.create_index("ix_human_api_keys_key_hash", "human_api_keys", ["key_hash"])
+
+
+def downgrade() -> None:
+    op.drop_table("human_api_keys")

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -242,6 +242,80 @@ async def _resolve_api_key(
     )
 
 
+async def _touch_human_api_key_last_used(key_id: uuid.UUID) -> None:
+    """_touch_api_key_last_used(agent)와 동형 — 전용 세션·단독 짧은 트랜잭션·fail-silent."""
+    from app.models.human_api_key import HumanApiKey
+    try:
+        async with async_session_factory() as s:
+            await s.execute(
+                update(HumanApiKey).where(HumanApiKey.id == key_id)
+                .values(last_used_at=datetime.now(timezone.utc))
+            )
+            await s.commit()
+    except Exception:
+        logger.warning("_touch_human_api_key_last_used failed key_id=%s", key_id, exc_info=True)
+
+
+async def _resolve_human_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
+    """story #1940 — hu_live_* 휴먼 개인 API key(MCP 셀프서브)를 DB에서 조회하여 AuthContext 반환.
+
+    ⚠️ ``resolve_member()``류(member_resolver.py:64/133)의
+    ``is_api_key = bool(app_metadata.get("api_key_id"))`` 휴리스틱(에이전트 판별용 —
+    ``app/dependencies/auth.py``의 "api_key 경로 = 에이전트 인증" 불변식, PO A안 판정의
+    핵심 근거)을 절대 안 건드린다 — 그래서 이 경로는 ``api_key_id`` claim을 «싣지 않는다».
+    대신 JWT 휴먼 인증과 **똑같은 모양**의 AuthContext를 만든다(``user_id=users.id``,
+    ``OrgMember``로 조직 신원 해소되는 것과 동치 입력) — resolve_member()가 이 요청을
+    무수정으로 "JWT 휴먼" 분기 그대로 태운다. 감사·last_used_at 추적용 식별자는 별도 키
+    (``human_api_key_id``)로만 싣는다(이름이 달라 어떤 기존 소비처의 ``api_key_id`` 판정도
+    안 건드림)."""
+    from app.models.human_api_key import HumanApiKey
+    from app.models.member import Member
+
+    key_hash = hash_token(raw_key)
+    now = datetime.now(timezone.utc)
+
+    result = await db.execute(
+        select(HumanApiKey)
+        .where(HumanApiKey.key_hash == key_hash)
+        .where(HumanApiKey.revoked_at.is_(None))
+        .where((HumanApiKey.expires_at.is_(None)) | (HumanApiKey.expires_at > now))
+    )
+    api_key = result.scalar_one_or_none()
+    if not api_key:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+
+    # fail-closed: 발급 시점엔 human이었어도 재조회 시점엔 반드시 다시 확인한다(예: 역할
+    # 전환·비활성화·삭제) — type=="human" 명시(agent로 오판정될 조합을 원천 차단).
+    member = (await db.execute(
+        select(Member).where(
+            Member.id == api_key.member_id,
+            Member.type == "human",
+            Member.is_active.is_(True),
+            Member.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if member is None or member.user_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key member not found")
+
+    needs_touch = api_key.last_used_at is None or (now - api_key.last_used_at) > _LAST_USED_AT_THROTTLE
+    if needs_touch:
+        await _touch_human_api_key_last_used(api_key.id)
+
+    return AuthContext(
+        user_id=str(member.user_id),
+        email=None,
+        claims={
+            "sub": str(member.user_id),
+            "app_metadata": {
+                "org_id": str(member.org_id),
+                "human_api_key_id": str(api_key.id),
+                "actor_type": "human",
+            },
+        },
+        org_id=str(member.org_id),
+    )
+
+
 async def _reject_if_before_cutover(user_id: str | uuid.UUID, unix_timestamp: int | None, db: AsyncSession) -> None:
     """story bea25062(§17d-1 cutover epoch authority): legacy iat/Firebase auth_time이
     이 사용자의 auth_valid_after 이전(또는 동일)이거나, migration.state가 강제 재설정
@@ -371,6 +445,14 @@ async def get_current_user(
     if token.startswith("sk_live_"):
         async with async_session_factory() as db:
             return await _resolve_api_key(token, db, transport=x_mcp_transport)
+
+    # story #1940 — hu_live_* 휴먼 개인 API key. ⛔의도적으로 x-agent-api-key 헤더 경로(위)에는
+    # 이 분기를 안 붙인다 — 그 헤더는 이 코드베이스에서 "에이전트 SSE 브릿지 전용"으로 이미
+    # 굳어진 표면(PO AC2: 휴먼 키가 agent 전용 표면을 못 열게 서버가 거부)이라, hu_live_ 토큰을
+    # 거기로 보내면 이 분기가 아예 없어 그대로 미인증(자연 차단 — 별도 판별 코드 불요).
+    if token.startswith("hu_live_"):
+        async with async_session_factory() as db:
+            return await _resolve_human_api_key(token, db)
 
     # story 455e528d(E-AUTH-REBUILD Phase1-S2·doc §4.2): Firebase 세션(RS256)은 alg 헤더로
     # 정확 분기 — 순차 fallback 아님. FIREBASE_AUTH_ACCEPT_SESSION=false(기본)면 이 분기는
@@ -827,6 +909,11 @@ async def get_current_user_streaming(
     if token.startswith("sk_live_"):
         async with async_session_factory() as db:
             return await _resolve_api_key(token, db)
+
+    # story #1940 — get_current_user와 동형(x-agent-api-key 헤더 경로엔 의도적으로 안 붙임).
+    if token.startswith("hu_live_"):
+        async with async_session_factory() as db:
+            return await _resolve_human_api_key(token, db)
 
     # story 455e528d(doc §4.3 "mirror the dual verifier in get_current_user_streaming"):
     # get_current_user와 동일하게 alg 헤더로 정확 분기(순차 fallback 아님). 단명 세션으로

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -26,6 +26,7 @@ from app.models.usage_meter import UsageMeter
 from app.models.user import RefreshToken, User
 from app.models.workflow_version import WorkflowVersion
 from app.models.api_key import ApiKey
+from app.models.human_api_key import HumanApiKey
 from app.models.org_subscription import OrgSubscription
 from app.models.pricing_version import PricingVersion
 from app.models.offering_version import OfferingVersion

--- a/backend/app/models/human_api_key.py
+++ b/backend/app/models/human_api_key.py
@@ -1,0 +1,30 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class HumanApiKey(Base):
+    """story #1940 — 휴먼 개인 API 키(MCP 셀프서브). agent_api_keys(ApiKey)와 완전히 별도
+    테이블·접두사(hu_live_)·인증 해소 경로 — PO 판정(A안, 2026-08-16): app.dependencies.auth의
+    "api_key 경로 = 에이전트 인증" 불변식(+#1561 교훈)을 재사용으로 흔들지 않는다."""
+
+    __tablename__ = "human_api_keys"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    member_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("members.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    key_prefix: Mapped[str] = mapped_column(Text, nullable=False)
+    key_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/human_api_key.py
+++ b/backend/app/repositories/human_api_key.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.human_api_key import HumanApiKey
+
+# story #1940 — hu_live_ 접두사: sk_live_(에이전트)과 명확히 구분(PO AC2·시크릿 스캐너
+# 식별 가능해야 함). 해싱은 app.core.security.hash_token과 동일 알고리즘(sha256) 재사용
+# — 여기서는 hashlib 직접(순환import 회피, 알고리즘만 일치시키면 됨).
+
+
+def _generate_key() -> tuple[str, str, str]:
+    raw = secrets.token_hex(32)
+    prefix = f"hu_live_{raw[:8]}"
+    plaintext = f"hu_live_{raw}"
+    key_hash = hashlib.sha256(plaintext.encode()).hexdigest()
+    return plaintext, prefix, key_hash
+
+
+class HumanApiKeyRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list_by_member(self, member_id: uuid.UUID) -> list[HumanApiKey]:
+        result = await self.session.execute(
+            select(HumanApiKey)
+            .where(HumanApiKey.member_id == member_id)
+            .order_by(HumanApiKey.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def get(self, key_id: uuid.UUID) -> HumanApiKey | None:
+        result = await self.session.execute(
+            select(HumanApiKey).where(HumanApiKey.id == key_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def create(
+        self,
+        member_id: uuid.UUID,
+        name: str | None = None,
+        expires_at: datetime | None = None,
+    ) -> tuple[HumanApiKey, str]:
+        plaintext, prefix, key_hash = _generate_key()
+        if expires_at is None:
+            expires_at = datetime.now(timezone.utc) + timedelta(days=90)
+        key = HumanApiKey(
+            member_id=member_id,
+            name=name,
+            key_prefix=prefix,
+            key_hash=key_hash,
+            expires_at=expires_at,
+        )
+        self.session.add(key)
+        await self.session.flush()
+        await self.session.refresh(key)
+        return key, plaintext
+
+    async def revoke(self, key_id: uuid.UUID) -> HumanApiKey | None:
+        key = await self.get(key_id)
+        if key is None:
+            return None
+        key.revoked_at = datetime.now(timezone.utc)
+        await self.session.flush()
+        await self.session.refresh(key)
+        return key

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -12,9 +12,88 @@ from app.models.member import Member
 from app.models.project import OrgMember
 from app.models.team import TeamMember
 from app.models.user import User
+from app.repositories.human_api_key import HumanApiKeyRepository
+from app.schemas.human_api_key import (
+    CreateHumanApiKeyRequest,
+    HumanApiKeyCreatedResponse,
+    HumanApiKeyResponse,
+)
 from app.schemas.me import MeResponse, UpdateMe
 
 router = APIRouter(prefix="/api/v2/me", tags=["me", "Organization"])
+
+
+async def _resolve_current_human_member(
+    auth: AuthContext, session: AsyncSession,
+) -> Member:
+    """story #1940 — 「나 자신」의 canonical Member 행 해소. resolve_member()의 ``.id``는
+    레거시 경로에서 OrgMember.id를 반환해(shadow 플래그 꺼짐이 기본) member_ssot 캐노니컬
+    ``members.id``와 항상 같은 값이라는 보장에 기대지 않는다 — 여기서 직접
+    ``Member.user_id == auth.user_id``로 해소(agent API key 경로는 애초에 사용 불가:
+    is_api_key=True면 이 함수를 부르는 라우트 자체가 human_api_key_id 발급 대상이 아님)."""
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id")
+    if not org_id_str:
+        raise HTTPException(status_code=400, detail="org_id not resolvable from auth context")
+    member = (await session.execute(
+        select(Member).where(
+            Member.user_id == uuid.UUID(auth.user_id),
+            Member.org_id == uuid.UUID(org_id_str),
+            Member.type == "human",
+            Member.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if member is None:
+        raise HTTPException(status_code=404, detail="Member not found")
+    return member
+
+
+@router.get("/api-keys", response_model=list[HumanApiKeyResponse])
+async def list_my_api_keys(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[HumanApiKeyResponse]:
+    """story #1940 — 셀프서브: 내 개인 API 키 목록. 다른 사람 키는 애초에 조회 대상에 없다
+    (member_id=본인으로 고정 — path에 임의 id를 안 받으므로 IDOR 표면 자체가 없음)."""
+    member = await _resolve_current_human_member(auth, session)
+    repo = HumanApiKeyRepository(session)
+    keys = await repo.list_by_member(member.id)
+    return [HumanApiKeyResponse.model_validate(k) for k in keys]
+
+
+@router.post("/api-keys", response_model=HumanApiKeyCreatedResponse, status_code=201)
+async def create_my_api_key(
+    body: CreateHumanApiKeyRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> HumanApiKeyCreatedResponse:
+    member = await _resolve_current_human_member(auth, session)
+    repo = HumanApiKeyRepository(session)
+    key, plaintext = await repo.create(
+        member_id=member.id, name=body.name, expires_at=body.expires_at,
+    )
+    await session.commit()
+    await session.refresh(key)
+    data = HumanApiKeyResponse.model_validate(key)
+    return HumanApiKeyCreatedResponse(**data.model_dump(), api_key=plaintext)
+
+
+@router.delete("/api-keys/{key_id}", status_code=200)
+async def revoke_my_api_key(
+    key_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    member = await _resolve_current_human_member(auth, session)
+    repo = HumanApiKeyRepository(session)
+    key = await repo.get(key_id)
+    if key is None or key.member_id != member.id:
+        # 존재 여부 누설 없이 404 — 본인 소유가 아니면 "없음"과 구분 안 함(다른 라우터 관례 정합).
+        raise HTTPException(status_code=404, detail="API key not found")
+    result = await repo.revoke(key_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="API key not found")
+    await session.commit()
+    return {"ok": True}
 
 
 @router.get("", response_model=MeResponse)

--- a/backend/app/schemas/human_api_key.py
+++ b/backend/app/schemas/human_api_key.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class HumanApiKeyResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    member_id: uuid.UUID
+    name: str | None = None
+    key_prefix: str
+    expires_at: datetime | None = None
+    revoked_at: datetime | None = None
+    last_used_at: datetime | None = None
+    created_at: datetime
+
+
+class HumanApiKeyCreatedResponse(HumanApiKeyResponse):
+    api_key: str
+
+
+class CreateHumanApiKeyRequest(BaseModel):
+    name: str | None = None
+    expires_at: datetime | None = None

--- a/backend/tests/test_1940_human_api_keys.py
+++ b/backend/tests/test_1940_human_api_keys.py
@@ -1,0 +1,365 @@
+"""story #1940 — 휴먼 개인 API 키 셀프서브 발급(MCP 설정). PO A안 판정(2026-08-16): 완전히
+별도 테이블(human_api_keys)·접두사(hu_live_)·인증 해소 경로 — agent_api_keys/ApiKey와
+0줄 접촉. 핵심 불변식: 이 경로로 인증된 요청은 `resolve_member()`류의
+`is_api_key = bool(app_metadata.get("api_key_id"))` 휴리스틱에서 반드시 False로 떨어져야
+한다(그래야 JWT 휴먼과 동일하게 취급돼 agent로 오판정되지 않는다, app/dependencies/
+auth.py:131 "api_key 경로=에이전트" 불변식 + #1561 교훈).
+
+검증 축:
+- 레포지토리: create/list/revoke.
+- 인증 해소: 정상 키 → AuthContext(user_id=users.id, api_key_id claim 없음, actor_type=human).
+  폐기·만료·미존재 키 → 401. member 조회 시점 재검증(발급 뒤 human이 아니게 되면 401).
+- ⭐AC2 핵심(PO 추가): x-agent-api-key 헤더로 hu_live_ 토큰을 보내면 인증되지 않는다(agent
+  전용 표면 서버 거부) — 실제 get_current_user 호출로 재현.
+- 셀프서브 라우터: 본인 키만 조회/폐기 가능(다른 사람 키는 404 — IDOR 표면 자체가 path에
+  임의 id를 안 받아 구조적으로 없음, 그래도 방어 확인).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug="acme1940"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=f"Org-{slug}", slug=slug)
+    session.add(org)
+    await session.commit()
+    return org.id
+
+
+async def _seed_user(session, *, email="human1940@example.com"):
+    from app.models.user import User
+    user = User(id=uuid.uuid4(), email=email, hashed_password="x", is_active=True, email_verified=True)
+    session.add(user)
+    await session.commit()
+    return user.id
+
+
+async def _seed_human_member(session, org_id, user_id, *, name="Human"):
+    from app.models.member import Member
+    m = Member(id=uuid.uuid4(), org_id=org_id, type="human", user_id=user_id, name=name)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_agent_member(session, org_id, *, name="Agent"):
+    from app.models.member import Member
+    m = Member(id=uuid.uuid4(), org_id=org_id, type="agent", name=name)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+# ─── 레포지토리 축 ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_repo_create_list_revoke_roundtrip():
+    from app.repositories.human_api_key import HumanApiKeyRepository
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s)
+            member_id = await _seed_human_member(s, org_id, user_id)
+
+            repo = HumanApiKeyRepository(s)
+            key, plaintext = await repo.create(member_id=member_id, name="laptop")
+            await s.commit()
+            assert plaintext.startswith("hu_live_")
+            assert key.key_prefix.startswith("hu_live_")
+            assert plaintext != key.key_prefix  # prefix는 접두 일부일 뿐, 평문 전체가 아님
+
+            listed = await repo.list_by_member(member_id)
+            assert [k.id for k in listed] == [key.id]
+
+            revoked = await repo.revoke(key.id)
+            await s.commit()
+            assert revoked.revoked_at is not None
+    finally:
+        await engine.dispose()
+
+
+# ─── 인증 해소 축 ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_resolve_human_api_key_returns_jwt_shaped_context_no_api_key_id_claim():
+    """⭐핵심 불변식 — api_key_id claim이 없어야 resolve_member()류가 JWT 휴먼으로 취급한다."""
+    from app.dependencies.auth import _resolve_human_api_key
+    from app.repositories.human_api_key import HumanApiKeyRepository
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s)
+            member_id = await _seed_human_member(s, org_id, user_id)
+            repo = HumanApiKeyRepository(s)
+            _key, plaintext = await repo.create(member_id=member_id)
+            await s.commit()
+
+        async with Session() as s2:
+            ctx = await _resolve_human_api_key(plaintext, s2)
+
+        assert ctx.user_id == str(user_id)
+        assert ctx.org_id == str(org_id)
+        app_meta = ctx.claims["app_metadata"]
+        assert "api_key_id" not in app_meta  # is_api_key 휴리스틱을 절대 안 건드림
+        assert app_meta["human_api_key_id"]
+        assert app_meta["actor_type"] == "human"
+        assert bool(app_meta.get("api_key_id")) is False  # resolve_member()가 실제로 읽는 그 조건식
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_resolve_human_api_key_rejects_revoked():
+    from fastapi import HTTPException
+    from app.dependencies.auth import _resolve_human_api_key
+    from app.repositories.human_api_key import HumanApiKeyRepository
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s)
+            member_id = await _seed_human_member(s, org_id, user_id)
+            repo = HumanApiKeyRepository(s)
+            key, plaintext = await repo.create(member_id=member_id)
+            await repo.revoke(key.id)
+            await s.commit()
+
+        async with Session() as s2:
+            with pytest.raises(HTTPException) as ei:
+                await _resolve_human_api_key(plaintext, s2)
+            assert ei.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_resolve_human_api_key_rejects_expired():
+    from fastapi import HTTPException
+    from app.dependencies.auth import _resolve_human_api_key
+    from app.repositories.human_api_key import HumanApiKeyRepository
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s)
+            member_id = await _seed_human_member(s, org_id, user_id)
+            repo = HumanApiKeyRepository(s)
+            _key, plaintext = await repo.create(
+                member_id=member_id, expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+            )
+            await s.commit()
+
+        async with Session() as s2:
+            with pytest.raises(HTTPException) as ei:
+                await _resolve_human_api_key(plaintext, s2)
+            assert ei.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_resolve_human_api_key_reverifies_member_still_human_fail_closed():
+    """발급 시점엔 human이었어도 해소 시점에 다시 확認 — 여기선 agent로 「전환된」 member를
+    직접 만들어(role/type 전환 시나리오 대리 재현) fail-closed 확認."""
+    from fastapi import HTTPException
+    from app.dependencies.auth import _resolve_human_api_key
+    from app.repositories.human_api_key import HumanApiKeyRepository
+    from app.models.member import Member
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s)
+            member_id = await _seed_human_member(s, org_id, user_id)
+            repo = HumanApiKeyRepository(s)
+            _key, plaintext = await repo.create(member_id=member_id)
+            await s.commit()
+
+            # 전환 시나리오 대리: 그사이 member.type이 바뀌었다고 가정(직접 UPDATE)
+            await s.execute(
+                Member.__table__.update().where(Member.id == member_id).values(type="agent")
+            )
+            await s.commit()
+
+        async with Session() as s2:
+            with pytest.raises(HTTPException) as ei:
+                await _resolve_human_api_key(plaintext, s2)
+            assert ei.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+# ─── AC2 핵심 — agent 전용 표면(x-agent-api-key 헤더) 서버 거부 ─────────────────
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_human_key_via_agent_header_does_not_authenticate():
+    """⭐AC2 — hu_live_ 토큰을 x-agent-api-key 헤더로 보내면 agent로 인증되지 않는다(그
+    헤더 분기는 sk_live_만 인식·hu_live_ 분기가 없어 자연 차단). Authorization 헤더도 없이
+    보내면 결과적으로 401(Missing Authorization) — 「엉뚱하게 통과」가 없다는 게 핵심."""
+    from fastapi import HTTPException
+    from app.dependencies.auth import get_current_user
+    from app.repositories.human_api_key import HumanApiKeyRepository
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s)
+            member_id = await _seed_human_member(s, org_id, user_id)
+            repo = HumanApiKeyRepository(s)
+            _key, plaintext = await repo.create(member_id=member_id)
+            await s.commit()
+
+        with pytest.raises(HTTPException) as ei:
+            await get_current_user(credentials=None, x_agent_api_key=plaintext, x_mcp_transport=None)
+        assert ei.value.status_code == 401
+        assert "Missing Authorization" in str(ei.value.detail)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_key_via_authorization_bearer_dispatches_to_resolver():
+    """음성대조 — 같은 hu_live_ 접두사를 «정상 경로»(Authorization: Bearer)로 보내면
+    _resolve_human_api_key로 정상 디스패치된다. AC2 테스트가 "hu_live_는 아무 데서도 인증
+    안 됨"이 아니라 "agent 전용 표면(x-agent-api-key 헤더)에서만 거부"임을 대조로 고정.
+
+    실 DB 왕복(_resolve_human_api_key 자체)은 위
+    test_resolve_human_api_key_returns_jwt_shaped_context_no_api_key_id_claim이 이미 검증—
+    이 테스트는 «디스패치 배선»만(get_current_user가 hu_live_를 올바른 resolver로 보내는가).
+    test_sse_conn_leak.py의 기존 관례(_resolve_api_key mock)와 동형 — get_current_user가
+    쓰는 모듈 전역 async_session_factory는 테스트별 격리 이벤트루프와 안 맞아(실측: 같은
+    파일 내 다른 realdb 테스트와 함께 돌리면 'Event loop is closed') 이 축은 실 DB 라운드
+    트립이 아니라 mock으로 디스패치만 잰다."""
+    from unittest.mock import AsyncMock, patch
+    from fastapi.security import HTTPAuthorizationCredentials
+    from app.dependencies import auth
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    fake_ctx = AuthContext(
+        user_id="u1", email=None,
+        claims={"app_metadata": {"org_id": "o1", "human_api_key_id": "k1", "actor_type": "human"}},
+        org_id="o1",
+    )
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="hu_live_deadbeef")
+    with patch.object(auth, "_resolve_human_api_key", new=AsyncMock(return_value=fake_ctx)) as mock_resolve:
+        ctx = await get_current_user(credentials=creds, x_agent_api_key=None, x_mcp_transport=None)
+    mock_resolve.assert_awaited_once()
+    assert mock_resolve.await_args.args[0] == "hu_live_deadbeef"
+    assert ctx is fake_ctx
+
+
+# ─── 셀프서브 라우터 축 ────────────────────────────────────────────────────────
+
+
+def _human_auth(user_id: uuid.UUID, org_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(user_id), email=None,
+        claims={"app_metadata": {"org_id": str(org_id)}}, org_id=str(org_id),
+    )
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_router_create_list_revoke_self_serve():
+    from app.routers.me import create_my_api_key, list_my_api_keys, revoke_my_api_key
+    from app.schemas.human_api_key import CreateHumanApiKeyRequest
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s)
+            await _seed_human_member(s, org_id, user_id)
+            auth = _human_auth(user_id, org_id)
+
+            created = await create_my_api_key(
+                CreateHumanApiKeyRequest(name="my key"), session=s, auth=auth,
+            )
+            assert created.api_key.startswith("hu_live_")
+
+            listed = await list_my_api_keys(session=s, auth=auth)
+            assert len(listed) == 1
+            assert listed[0].id == created.id
+
+            result = await revoke_my_api_key(created.id, session=s, auth=auth)
+            assert result == {"ok": True}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_router_cannot_revoke_other_humans_key():
+    """음성대조 — 다른 휴먼의 키는 404(존재 여부 누설 없이)."""
+    from fastapi import HTTPException
+    from app.routers.me import create_my_api_key, revoke_my_api_key
+    from app.schemas.human_api_key import CreateHumanApiKeyRequest
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_user_id = await _seed_user(s, email="owner1940@example.com")
+            await _seed_human_member(s, org_id, owner_user_id, name="Owner")
+            owner_auth = _human_auth(owner_user_id, org_id)
+            created = await create_my_api_key(
+                CreateHumanApiKeyRequest(), session=s, auth=owner_auth,
+            )
+
+            intruder_user_id = await _seed_user(s, email="intruder1940@example.com")
+            await _seed_human_member(s, org_id, intruder_user_id, name="Intruder")
+            intruder_auth = _human_auth(intruder_user_id, org_id)
+
+            with pytest.raises(HTTPException) as ei:
+                await revoke_my_api_key(created.id, session=s, auth=intruder_auth)
+            assert ei.value.status_code == 404
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -323,6 +323,15 @@ _ID_MUTATION_FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
     "app.routers.event_notifications:mark_read": "recipient-scoped(event.recipient_id==caller member)",
     "app.routers.notifications:mark_read": "owner user_id 스코프(caller 소유 알림만)",
     "app.routers.evidence:delete_evidence": "creator-only(created_by!=caller → 403)",
+    "app.routers.me:revoke_my_api_key": (
+        "story #1940 — path의 key_id는 human_api_keys 행을 가리키고, 대상 리소스가 "
+        "project-소속이 아니라 caller 자신 소유(member_id) — user_blocks:delete_user_block과 "
+        "동일 결의 SELF_DERIVED(project 접근권 검증 자체가 무의미한 축). 라우터가 "
+        "key.member_id != caller.member_id면 404(존재 여부 누설 없이)로 스코프. 받치는 것은 "
+        "test_router_cannot_revoke_other_humans_key(test_1940_human_api_keys.py) — 타인의 "
+        "키를 key_id로 지정해도 404인지 실증한다. 그 테스트를 지우거나 약화시키면 이 면제의 "
+        "근거도 함께 사라진다."
+    ),
     # org/user-level 리소스 — project 축 없음 — ORG_ONLY
     "app.routers.labels:delete_label": "org taxonomy(project_id 컬럼 없음)·org-scope",
     "app.routers.labels:detach_label": "org taxonomy·org-scope",


### PR DESCRIPTION
## Summary
prod 에스컬레이트(산티아고, prod #42) — 현 api-keys 표면이 `type=agent` 전용이라 휴먼이 스스로 MCP 연결용 키를 발급받을 수 없음(셀프서브 온보딩 완주 불가, `uvx sprintable` 히어로 직결). 07-17 grounding 재확認 결과 여전히 유효.

## 설계 판정(PO A안, 2026-08-16)
`app/dependencies/auth.py:131` "api_key 경로 = 에이전트 인증, 휴먼은 JWT"는 코멘트가 아니라 실제 강제되는 설계(`member_ssot_apikey_cut` 경로는 `Member.type=="agent"`를 명시로 걸어 휴먼 소유 키를 401로 거부) + #1561 교훈("api_key_id 존재=agent" 신뢰 신호)이 `resolve_member()`류(`member_resolver.py:64/133`)에 이미 퍼져 있어, `agent_api_keys`를 재사용하면 그 불변식을 흔들게 된다 — 완전히 별도 메커니즘으로 구현:

- 신규 테이블 `human_api_keys`(`members.id` FK) + 접두사 `hu_live_`(`sk_live_`와 시크릿 스캐너가 구분 가능하도록 명확히 다름, AC2 요건)
- 신규 인증 해소 경로 `_resolve_human_api_key` — **`api_key_id` claim을 싣지 않는다**(대신 `human_api_key_id`). `resolve_member()`류의 `is_api_key` 휴리스틱을 그대로 통과시켜 JWT 휴먼과 완전히 동일하게 취급되게 함 — 기존 소비처 0줄 수정으로 안전 확보.
- **AC2(PO 추가)** — `x-agent-api-key` 헤더(이 코드베이스에서 이미 "에이전트 SSE 브릿지 전용"으로 굳은 표면) 경로에는 `hu_live_` 분기를 의도적으로 안 붙임 — 별도 판별 코드 없이 구조적으로 agent 전용 표면이 휴먼 키를 거부한다.
- 셀프서브 라우터(`app/routers/me.py`) — `GET`/`POST`/`DELETE /api/v2/me/api-keys`, 전부 "본인" 고정(path에 임의 id 없음 — IDOR 표면 자체가 구조적으로 없음).

## Test plan
- [x] 로컬 실PG 22건 green(레포지토리·인증해소·AC2 헤더 거부+정상경로 대조·셀프서브 라우터·타인 키 404)
- [x] 관련 40건(`test_e_msg_policy_s1`·`test_conversations`·`test_member_ssot_parity_realdb`·`test_e_onboarding_s2_me_realname`) 무회귀
- [x] `alembic upgrade`/`downgrade` 실제 적용 확認(0251→0252→0251)
- [x] CI 대기

⚠️ FE(설정 화면)는 이 PR 범위 밖 — 미르코군 순번(PO pacing 조율).

🤖 Generated with [Claude Code](https://claude.com/claude-code)