### PR TITLE
[SID:1978] SSE 커버리지 안정화 — 목록 진입/백그라운드 복귀 리프레시

### DIFF
--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -24,9 +24,13 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock, replace: vi.fn() }),
 }));
 
-// use-chat-sse는 EventSource(jsdom 미구현)를 쓰므로 no-op으로 목.
+// use-chat-sse는 EventSource(jsdom 미구현)를 쓰므로 no-op으로 목 — 단, story #1978은 정확히
+// onReconnect 배선을 검증해야 하니 마지막 호출의 옵션을 캡처해 테스트에서 직접 불러낸다
+// (SSE 백오프/타이머 전체를 재현하지 않는다 — sse-multiplexer.test.tsx가 이미 그 축은
+// "실제 재연결 타이밍은 별도"로 선언하고 옵션 배선만 고정하는 동일 관례).
+const { useChatSseMock } = vi.hoisted(() => ({ useChatSseMock: vi.fn() }));
 vi.mock('@/hooks/use-chat-sse', () => ({
-  useChatSse: () => {},
+  useChatSse: (opts: unknown) => { useChatSseMock(opts); },
 }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -47,6 +51,7 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   pushMock.mockClear();
+  useChatSseMock.mockClear();
   useDashboardContextMock.mockReturnValue({ role: 'member' });
 });
 
@@ -66,6 +71,12 @@ function stubFetch(outsideProject: unknown[]) {
     }
     return { ok: false, status: 404, json: async () => null };
   }));
+}
+
+// story #1978 — /api/conversations? 호출 횟수만 센다(목록 백필 재fetch가 실제로 일어났는지).
+// /api/conversations/recent-outside-project는 별개 축(마운트 1회 전용, 이 스토리 스코프 밖)이라 안 센다.
+function countMyConversationsFetchCalls(fetchMock: ReturnType<typeof vi.fn>): number {
+  return fetchMock.mock.calls.filter(([url]) => (url as string).includes('/api/conversations?') && !(url as string).includes('recent-outside-project')).length;
 }
 
 async function mount() {
@@ -125,5 +136,51 @@ describe('ChatListView — 다른 프로젝트 섹션 (story #2168 PR-②)', () 
     await act(async () => { row!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
 
     expect(sessionStorage.getItem('sprintable_pending_toast')).toBe('sprintable-content 프로젝트로 이동');
+  });
+});
+
+// story #1978(트랙C) — SSE 드롭 후 놓친 conversation.message_created가 목록에 미백필되던
+// 두 구멍(재연결·백그라운드 복귀)을 고정한다. useChatSse는 위에서 옵션 캡처용으로만 목했으므로
+// 실제 SSE 백오프/타이머는 재현하지 않는다 — onReconnect 콜백이 넘어왔는지, 그리고 그 콜백을
+// 직접 불렀을 때 실제로 재fetch가 도는지만 검증한다(배선 고정).
+describe('ChatListView — SSE 재연결·백그라운드 복귀 재fetch (story #1978)', () => {
+  it('useChatSse에 onReconnect가 넘어가고, 그걸 부르면 목록이 재fetch된다(AC①)', async () => {
+    stubFetch([]);
+    await mount();
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const beforeCount = countMyConversationsFetchCalls(fetchMock);
+
+    const opts = useChatSseMock.mock.calls.at(-1)?.[0] as { onReconnect?: () => void } | undefined;
+    expect(typeof opts?.onReconnect).toBe('function');
+    await act(async () => { opts!.onReconnect!(); });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(countMyConversationsFetchCalls(fetchMock)).toBe(beforeCount + 1);
+  });
+
+  it('탭이 백그라운드에서 복귀(visibilitychange, hidden=false)하면 목록이 재fetch된다(AC①)', async () => {
+    stubFetch([]);
+    await mount();
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const beforeCount = countMyConversationsFetchCalls(fetchMock);
+
+    await act(async () => { document.dispatchEvent(new Event('visibilitychange')); });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(countMyConversationsFetchCalls(fetchMock)).toBe(beforeCount + 1);
+  });
+
+  it('탭이 백그라운드로 갈 때(hidden=true)는 재fetch하지 않는다(불필요 호출 억제, AC③)', async () => {
+    stubFetch([]);
+    await mount();
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const beforeCount = countMyConversationsFetchCalls(fetchMock);
+
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+    await act(async () => { document.dispatchEvent(new Event('visibilitychange')); });
+    await act(async () => { await Promise.resolve(); });
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
+
+    expect(countMyConversationsFetchCalls(fetchMock)).toBe(beforeCount);
   });
 });

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -398,11 +398,33 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
     if (agentLoadedRef.current) setAllConversations(applyRead);
   }, []);
 
+  // story #1978(트랙C) — SSE 드롭 후 놓친 conversation.message_created는 이 목록에 영영
+  // 반영 안 됐다(handleConversationMessage는 살아있는 이벤트에만 반응). chat-view.tsx의
+  // handleReconnect(fetchMessages 재호출)와 동형 — "재연결됐다"는 신호를 받으면 목록을
+  // 통째로 다시 가져와 서버 truth로 백필한다. agent 탭은 이미 연 적 있을 때만(lazy 유지 원칙,
+  // loadAgentConversationsOnce와 동일 가드).
+  const handleReconnect = useCallback(() => {
+    void fetchConversations(0, false);
+    if (agentLoadedRef.current) void fetchAllConversations(0, false);
+  }, [fetchConversations, fetchAllConversations]);
+
   useChatSse({
     currentTeamMemberId,
     onConversationMessage: handleConversationMessage,
     onConversationRead: handleConversationRead,
+    onReconnect: handleReconnect,
   });
+
+  // story #1978(트랙C) — onReconnect(SSE 커넥션 자체의 재연결)와는 다른 축: 탭이 백그라운드에
+  // 있는 동안엔 SSE가 안 끊겨도(브라우저가 살려둘 수 있음) 목록이 갱신 안 됐을 수 있다.
+  // use-chat-unread-total.ts와 동일 패턴(document.visibilitychange, !document.hidden에서만).
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (!document.hidden) handleReconnect();
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [handleReconnect]);
 
   const handleCreated = (conversationId: string) => {
     setShowModal(false);

--- a/apps/web/src/hooks/use-chat-unread-total.test.tsx
+++ b/apps/web/src/hooks/use-chat-unread-total.test.tsx
@@ -110,3 +110,33 @@ describe('useChatUnreadTotal — story #2078 결함수정(Provider 자식 위치
     expect(instances).toHaveLength(1);
   });
 });
+
+// story #1978(트랙C) — onReconnect가 없어서 SSE 재연결(포그라운드 복귀 등) 시 total이 서버
+// truth로 재동기화되지 않던 drift 구멍. sse-multiplexer.test.tsx와 동일 관례(실제 백오프
+// 타이머 재현은 다른 테스트의 몫 — 여기선 useChatSse를 목해 onReconnect 배선만 직접 고정한다).
+describe('useChatUnreadTotal — onReconnect 배선(story #1978)', () => {
+  it('useChatSse에 onReconnect가 넘어가고, 그걸 부르면 unread-count를 다시 fetch한다', async () => {
+    vi.resetModules();
+    const useChatSseMock = vi.fn();
+    vi.doMock('./use-chat-sse', () => ({ useChatSse: (opts: unknown) => { useChatSseMock(opts); return { connected: true }; } }));
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ count: 0 }) }));
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    const { useChatUnreadTotal } = await import('./use-chat-unread-total');
+    function Consumer() {
+      useChatUnreadTotal('member-1');
+      return null;
+    }
+    await act(async () => { root.render(<Consumer />); });
+    await act(async () => { await Promise.resolve(); });
+
+    const beforeCount = fetchMock.mock.calls.length;
+    const opts = useChatSseMock.mock.calls.at(-1)?.[0] as { onReconnect?: () => void } | undefined;
+    expect(typeof opts?.onReconnect).toBe('function');
+    await act(async () => { opts!.onReconnect!(); });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(fetchMock.mock.calls.length).toBe(beforeCount + 1);
+    vi.doUnmock('./use-chat-sse');
+  });
+});

--- a/apps/web/src/hooks/use-chat-unread-total.ts
+++ b/apps/web/src/hooks/use-chat-unread-total.ts
@@ -54,6 +54,12 @@ export function useChatUnreadTotal(currentTeamMemberId?: string): number {
     currentTeamMemberId,
     onConversationMessage: () => setTotal((prev) => prev + 1),
     onConversationRead: () => fetchTotalRef.current?.(),
+    // story #1978(트랙C) — SSE 드롭 중 놓친 conversation.message_created는 낙관 +1이 못 따라오니
+    // 재연결 시 서버 truth로 스냅해 drift를 없앤다. visibility/focus(위)는 이미 있었지만 그건
+    // "탭이 백그라운드였다 포그라운드로" 축이고, 이건 "SSE 커넥션 자체가 끊겼다 재연결됐다"
+    // 축이라 서로 다른 트리거다(탭은 계속 보이는데 네트워크만 끊겼다 복구된 경우 visibility는
+    // 안 fire하지만 onReconnect는 fire한다).
+    onReconnect: () => fetchTotalRef.current?.(),
   });
 
   return total;


### PR DESCRIPTION
## 요약
유나 재그라운딩(doc 52c5bc5c)으로 AC가 정확히 2구멍으로 좁혀졌다. 07-17 가정 다수는 이미 기착지(스레드 뷰는 `chat-view.tsx`의 `handleReconnect`가 이미 재연결 시 `fetchMessages` 재호출) — 스레드 뷰는 이번 스토리에서 무접촉.

## 변경
- `chat-list-view.tsx`: `onReconnect`·`visibilitychange` 재fetch 둘 다 부재 — SSE 드롭 중 놓친 `conversation.message_created`가 목록에 영영 미백필됐다. `chat-view.tsx`의 `handleReconnect`(`fetchMessages`)와 동형 패턴으로 `handleReconnect` 추가(내 목록 + 이미 연 적 있는 agent 탭 재fetch) → `useChatSse`의 `onReconnect`에 배선. 별도로 `visibilitychange`(백그라운드→포그라운드, SSE 커넥션 자체는 안 끊긴 채 탭만 숨겨졌던 경우 — `onReconnect`가 안 잡는 축)도 같은 핸들러로 연결(`use-chat-unread-total.ts` 기존 패턴과 동일).
- `use-chat-unread-total.ts`(GNB 채팅 총합): `onReconnect` 부재 — 포그라운드 재연결 시 낙관 증분(+1)만으로는 놓친 메시지가 누적 drift. `onReconnect`에 기존 `fetchTotalRef`(서버 truth 재fetch)를 배선.

## AC 대조
- ①SSE 드롭→복귀 시 chat-list-view가 놓친 메시지 즉시 백필 ✅(onReconnect+visibilitychange 둘 다 배선)
- ②재연결 시 GNB 총합이 서버 truth로 스냅(드리프트 0) ✅(onReconnect→fetchTotalRef)
- ③중복 fetch 증가 0 ✅(hidden=true 시 재fetch 안 함을 음성대조 테스트로 고정)
- ④기존 스레드 뷰 무회귀 ✅(chat-view.tsx 무접촉)
- done-gate: dev 라이브 — 유나가 드롭→복귀 재fetch 검증(그라운딩 리드 몫 선언분, 이 PR 스코프 밖)

## 검증
- `pnpm exec tsc --noEmit` / `pnpm exec eslint` — 통과, 0 warning
- `pnpm build` — 통과
- `pnpm exec vitest run` — 430 files / 3487 tests 전부 통과(신규 4건 포함)
- **RED→GREEN**: 소스 fix 2파일(`chat-list-view.tsx`/`use-chat-unread-total.ts`)을 `git stash`로 되돌려 신규 테스트 3건이 RED(hidden=true 음성대조는 그대로 GREEN 유지, "불필요 재fetch 억제"가 fix 이전에도 참이라는 사실 확認) → 복원 → GREEN 재확認

## 스크린샷
로직 전용 변경(폴링 제거 아님·시안 불요, 스토리 본문 명시) — UI 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)