### PR TITLE
[SID:4cdad425] fix(recruit): 채용 위저드 STEP5에 검증 안내 3종 확장 (prod 표면)

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.test.tsx
@@ -311,6 +311,32 @@ describe('recruiter-client STEP5 — story #2410 ③-1(verifiedBanner)', () => {
   });
 });
 
+// story #4cdad425(prod 에스컬레이트) — 실유저가 탄 표면이 여기(채용 위저드 STEP5)였다(Backend Engineer
+// 채용 1호). connect-step(#3114)에만 넣었던 검증 안내 3종(재시작·대기·타임아웃)을 이 표면에도 넣는다.
+// 이 컴포넌트는 STEP5까지의 마운트가 불가한 거대 위저드라 소스 텍스트 수준으로 pin(이 파일의 기존 관례).
+// 실제 렌더 로직(조건 ↔ 훅 출력 대응)은 connect-step.test.tsx가 DOM 마운트로 덮는다 — 같은 useVerificationRail·
+// 같은 tOnboarding 키를 쓰므로 로직은 동일하고, 여기서는 «이 표면에 그 JSX가 실제로 있는가»를 지킨다.
+describe('recruiter-client STEP5 — story #4cdad425 (검증 안내 3종: 재시작·대기·타임아웃)', () => {
+  const source = readFileSync(fileURLToPath(new URL('./recruiter-client.tsx', import.meta.url)), 'utf-8');
+
+  it('① 재시작 안내를 connect-step과 같은 onboarding 키로 렌더한다(설정 저장 후 Claude Code 재시작)', () => {
+    expect(source).toContain("tOnboarding('restartAfterConfig')");
+  });
+
+  it('② 대기 표시는 awaitingVerification && !timedOut로 게이팅된다(폴링 중에만·verified/timeout이면 사라짐)', () => {
+    expect(source).toMatch(/\{awaitingVerification && !timedOut && \([\s\S]{0,300}tOnboarding\('verifyWaiting'\)/);
+  });
+
+  it('③ 타임아웃 힌트는 timedOut으로 게이팅되고 제목+본문 두 키를 쓴다(진단 힌트)', () => {
+    expect(source).toMatch(/\{timedOut && \([\s\S]{0,400}tOnboarding\('verifyTimeoutTitle'\)[\s\S]{0,250}tOnboarding\('verifyTimeoutHint'\)/);
+  });
+
+  it('대기와 타임아웃은 timedOut 한 축으로 상호배타된다(동시에 안 뜸)', () => {
+    expect(source).toContain('awaitingVerification && !timedOut');
+    expect(source).toMatch(/\{timedOut && \(/);
+  });
+});
+
 // story #2433(A/B) — 미르코 실측(codex 표본, 2026-08-03): 위저드에서 런타임을 골라 채용해도
 // 관리화면엔 "런타임 타입: 미설정"으로 떴다(A) + "역할 없이(키만)"는 실행환경(런타임) 단계
 // 자체가 스킵됐다(B). 소스 텍스트 수준으로 pin(이 파일의 기존 관례 — 컴포넌트 전체 마운트

--- a/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/recruiter/recruiter-client.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 import {
   Check, CheckCircle2, Copy, Download, RefreshCw, ChevronLeft, Info, Sparkles,
-  Palette, Cog, Search, ClipboardList, Briefcase, IdCard,
+  Palette, Cog, Search, ClipboardList, Briefcase, IdCard, RotateCw, Loader2,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -772,7 +772,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
     enabled: step === 5 && Boolean(recruitResult),
     configCopiedDone: true,
   });
-  const { displaySteps, verified, verifying } = rail;
+  const { displaySteps, verified, verifying, awaitingVerification, timedOut } = rail;
   const handleCopyVerifyPrompt = rail.handleCopyVerifyPrompt;
 
   // story(2026-08-02, 채용 흐름 텔레메트리 부재) — connect-step.tsx는 config_copied·
@@ -1460,6 +1460,14 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                 )}
               </p>
 
+              {/* story #4cdad425(prod 에스컬레이트) — 실유저가 탄 표면(채용 위저드·recruit)이 이곳이다.
+                  connect-step(#3114)에만 넣었던 「Claude Code 재시작」 명시 안내를 여기에도 둔다 —
+                  설정만 붙이고 재시작 안 하면 검증이 영원히 pending(무한 폴링). info 톤(미확認≠에러). */}
+              <div className="flex items-start gap-2 rounded-md border border-info-border bg-info-tint px-3 py-2.5 text-xs text-foreground">
+                <RotateCw className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+                <span>{tOnboarding('restartAfterConfig')}</span>
+              </div>
+
               {/* story #2404(AC5, PO 확定) — "설정만 넣으면 자동으로 된다"는 오해가 무한 대기의
                   실원인이었다(검증은 실제 tool 호출로만 완료됨). 대기 문구를 지우고 "지금 할 일"을
                   복사 가능한 한 줄로 그 자리에 쥐여 준다. */}
@@ -1486,6 +1494,22 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
                 </Button>
               </div>
               <VerifyRail steps={displaySteps} />
+              {/* story #4cdad425 ② — 폴링 중 화면이 침묵하면(무한 폴링 가림) 실유저는 멈췄다고 느껴
+                  재시도한다(prod 5회). 확인 중임을 명시. verified/timeout이면 자동으로 사라진다. */}
+              {awaitingVerification && !timedOut && (
+                <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" aria-hidden />
+                  {tOnboarding('verifyWaiting')}
+                </p>
+              )}
+              {/* story #4cdad425 ③ — 타임아웃(~60s) 시 침묵 대신 진단 힌트. info 톤(연결이 아직 «확인
+                  안 됨»이지 «실패»가 아님·빨강 안 씀). text-foreground on info-tint(#2420). */}
+              {timedOut && (
+                <div role="status" aria-live="polite" className="rounded-md border border-info-border bg-info-tint px-3 py-2.5 text-xs text-foreground">
+                  <p className="font-medium">{tOnboarding('verifyTimeoutTitle')}</p>
+                  <p className="mt-1">{tOnboarding('verifyTimeoutHint')}</p>
+                </div>
+              )}
               {/* story #2404(AC5, PO 확定) — "이미 가능한데 사용자가 모르는" 상태를 없앤다. 처음부터
                   보인다(폴링 실패 N회 뒤가 아님) — 검증은 관문이 아니라 확인일 뿐이라는 것 자체가
                   즉시 알려져야 하는 사실이다. 주 동선(위 예시 프롬프트)보다 약하게(muted). */}


### PR DESCRIPTION
## 요약
prod 에스컬레이트 **표면 정정** — 실유저가 탄 곳은 **채용 위저드(recruiter-client STEP5)**였다(Backend Engineer 채용 1호·디디 dogfood 모두 recruit). #3114는 `connect-step`(/onboarding)만 덮었고, 공유 `useVerificationRail`은 상태만 노출하지 «그리는 JSX»는 소비처마다 별도라 채용 위저드엔 안내가 없었다(내 표면 실측서 짚음·PO 확定 「고친 자리 ≠ 아픈 자리」).

## 변경
동일 검증 안내 3종을 recruiter STEP5에 확장(동일 onboarding i18n 키·동일 info 톤):
- ① config 안내 뒤 **「Claude Code 재시작」 명시**
- ② 폴링 중 **「연결 확인 중 · 자동 재시도」 대기 표시**
- ③ 타임아웃(~60s) **진단 힌트**

## 검증
- recruiter 48 테스트 통과(신규 4: 재시작·대기·타임아웃·상호배타)·타입·eslint·tint 18쌍 AA.
- **뮤테이션 양성대조**: restartAfterConfig 소거 시 ① 실패 확認(소스-텍스트 가드가 진짜 잡는다).
- 소스-텍스트 pin(이 위저드는 STEP5까지 마운트 불가 — 파일 기존 관례). 실제 렌더 로직은 connect-step DOM 테스트가 덮음(같은 rail·키).

라이브 검증(recruit 표면·원 사고 재현 축) + done E2E(admin 에이전트 생성)는 이 상륙 후 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
