### PR TITLE
fix(stories,doc): defer personal-webhook retry to outbox (story #2687)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1872,8 +1872,12 @@ async def bulk_update_stories(
     # webhook(fire_webhooks, 아래)은 별개 채널이라 무관·그대로 유지.
     for _ev, _notify in violation_dispatch:
         try:
+            # story #2687: 단건 PATCH(:2421 부근) 와 같은 결함 — 동기 웹훅 재시도가 request-scoped
+            # db 세션의 커넥션을 붙잡아 pool(size=3+overflow=1)을 압박한다. bulk는 item마다
+            # 순차 발화라 영향이 더 큼 — outbox로 옮긴다.
             await fire_webhooks(
                 db, repo.org_id, "workflow_violation", _ev, recipient_member_ids=_notify,
+                via_outbox=True,
             )
         except Exception:  # noqa: BLE001
             pass
@@ -2414,9 +2418,14 @@ async def update_story_status(
                 m for m in (actor_id, story.assignee_id) if m is not None
             }
             try:
+                # story #2687: 동기 개인 webhook 재시도(최대 3회·1s/2s backoff)가 update_story_status
+                # 의 열린 트랜잭션 커넥션을 붙잡아(pool_size=3+overflow=1인 소형 풀) PATCH
+                # /stories/{id}/status 응답을 5초대까지 지연시키고 동시 요청의 커넥션 획득까지
+                # 지연시켰다(실측 5.0-5.4s). story #2460 §6 봉합②의 outbox 경로로 옮긴다.
                 await fire_webhooks(
                     db, org_id, "workflow_violation", _v_event,
                     recipient_member_ids=_violation_notify_ids,
+                    via_outbox=True,
                 )
             except Exception:
                 pass

--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -59,6 +59,12 @@ async def _notify_doc_approval_requested(
             body=f"'{doc.title}' 문서가 결재 대기 중입니다.",
             reference_type="gate", reference_id=gate_id,
             source_project_id=doc.project_id,
+            # story #2687: 동기 개인 webhook 재시도(최대 3회·1s/2s backoff)가 이 함수를 호출한
+            # transition_doc()의 열린 트랜잭션 커넥션을 그대로 붙잡아(pool_size=3+overflow=1인
+            # 소형 풀) 상신 요청 자체를 8~9초 지연시키고, 그 창 동안 다른 동시 요청들의 커넥션
+            # 획득도 지연시켰다(실측: PATCH /docs/{id}/transition 8.7-9.3s). story #2460 §6
+            # 봉합②의 outbox 경로로 옮겨 트랜잭션 밖에서 배달한다.
+            via_outbox=True,
         )
     except Exception:  # noqa: BLE001 — 벨 알림 실패는 상신 비중단.
         logger.warning("doc 상신 결재자 벨 알림 실패 doc=%s", doc.id, exc_info=True)

--- a/backend/tests/test_edg_doc_gate_inbox.py
+++ b/backend/tests/test_edg_doc_gate_inbox.py
@@ -247,6 +247,8 @@ async def test_submit_notifies_org_approvers():
     assert kw["reference_type"] == "gate" and kw["reference_id"] == gate_id
     # 산티아고 RC: approver 쿼리에 deleted_at 필터(삭제 owner/admin 제외).
     assert "deleted_at" in str(session.execute.await_args.args[0])
+    # story #2687: 동기 웹훅 재시도가 상신 트랜잭션 커넥션을 붙잡아 8~9초 지연 — outbox로 이관.
+    assert kw["via_outbox"] is True
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -268,17 +268,24 @@ async def test_status_nonsequential_jump_allowed_with_violation():
             return result
         session.execute = mock_execute
 
-        async with client as c:
-            resp = await c.patch(
-                f"/api/v2/stories/{STORY_ID}/status",
-                json={"status": "in-review"},
-            )
+        # story #2687: 동기 webhook 재시도(최대 3회·1s/2s backoff)가 이 요청의 db 세션
+        # 커넥션을 물고 있는 채로 돌아 PATCH 응답을 5초대까지 지연시켰다(pool_size=3+
+        # overflow=1인 소형 풀) — via_outbox=True로 outbox 경유하게 고쳤으니 그 계약을 고정.
+        fire_mock = AsyncMock()
+        with patch("app.routers.stories.fire_webhooks", fire_mock):
+            async with client as c:
+                resp = await c.patch(
+                    f"/api/v2/stories/{STORY_ID}/status",
+                    json={"status": "in-review"},
+                )
 
         assert resp.status_code == 200
         v = resp.json()["violation"]
         assert v is not None
         assert v["level"] == "warn" and v["from"] == "backlog" and v["to"] == "in-review"
         assert v["skipped"] == 2  # ready-for-dev, in-progress 건너뜀
+        fire_mock.assert_awaited_once()
+        assert fire_mock.await_args.kwargs["via_outbox"] is True
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_stories_bulk_body_contract.py
+++ b/backend/tests/test_stories_bulk_body_contract.py
@@ -108,6 +108,9 @@ async def test_bulk_nonsequential_jump_flags_violation_but_allows(monkeypatch):
     # 호출은 삭제됐다(FE 소비처 0) — webhook만 남은 실 배달 경로.
     _fire.assert_awaited_once()
     assert _fire.call_args[0][2] == "workflow_violation"
+    # story #2687: 동기 웹훅 재시도가 status 전이 요청의 db 세션 커넥션을 붙잡아 pool을
+    # 압박(pool_size=3+overflow=1) — outbox로 이관.
+    assert _fire.call_args.kwargs["via_outbox"] is True
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- story #2687 실측 패턴① 원인 fix: `_notify_doc_approval_requested`(doc 결재 상신)와 `stories.py`의 `workflow_violation` `fire_webhooks` 콜사이트(단건 PATCH + /bulk 루프) 3곳 모두 request-scoped db 세션을 물고 동기 웹훅 재시도(3회·1s/2s backoff·10s timeout)를 돌던 것을 `via_outbox=True`로 전환.
- pool_size=3+max_overflow=1인 소형 풀에서 이 재시도 루프가 커넥션을 5~9초간 붙잡아 docs/transition(8.7-9.3s)·stories/status(5.0-5.4s) 지연 및 동시 요청 커넥션 경합(산발 스파이크 후보) 을 유발한 것으로 dev DB 실측(활성 webhook_configs 3건 확인) + 코드 추적으로 확인.
- story #2460 §6의 기존 outbox opt-in 경로(`via_outbox=True`) 그대로 재사용 — 새 메커니즘 추가 없음.

## Test plan
- [x] `test_submit_notifies_org_approvers`(doc), `test_bulk_nonsequential_jump_flags_violation_but_allows`(bulk), `test_status_nonsequential_jump_allowed_with_violation`(단건) — 세 콜사이트 모두 `via_outbox=True` 계약 pin.
- [x] mutation-kill: fix 되돌리고 위 3개 테스트 RED 확인 → 재적용 후 GREEN 확인.
- [x] 관련 스위트(`test_edg_doc_gate_inbox.py`, `test_stories_bulk_body_contract.py`, `test_stories.py`, `test_s3_2_violation_warn.py`, `test_emit_story_status_changed_isolation.py`, `test_stories_bulk_route_order.py`, `test_2460_delivery_outbox.py`, `test_2138_outbox_dual_publish_guard.py`) 로컬 통과.
- [ ] CI 확인 대기.

story: entity:story:161984c8-5718-4f32-b7e5-cccae831aac2