### PR TITLE
[SID:2686] 벨/인박스 즉시 정합 — conversation.read SSE 수신 시 unread-count 즉시 재fetch(FE 절반)

### DIFF
--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -237,3 +237,61 @@ describe('NotificationBell — sync_status 배너(story #2201)', () => {
     expect(container.textContent).not.toContain('일부 지난 알림은 표시되지 않았습니다');
   });
 });
+
+// story #2686(축D) — 채팅 mark-read가 그 대화의 event-notification read_at을 BE에서
+// 동기(디디 계약)하는데, 벨이 그걸 "즉시" 반영하려면 conversation.read SSE 수신 시 unread-count를
+// 재fetch해야 한다(기존 30초 폴링만으론 AC①의 "즉시" 성립이 늦다). 30초를 기다리지 않고도
+// 반영되는지를 정확히 그 축으로 고정한다 — 폴링이 언젠가 따라잡는 것과는 다른 결함 클래스.
+describe('NotificationBell — conversation.read SSE 즉시 unread-count 재fetch(story #2686)', () => {
+  it('conversation.read를 받으면 폴링(30초)을 기다리지 않고 unread-count를 다시 fetch해 배지를 갱신한다', async () => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    let unreadCountCallCount = 0;
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/event-notifications/unread-count')) {
+        unreadCountCallCount += 1;
+        // 두 번째 호출(=conversation.read 이후 재fetch)부터 감소된 값을 준다 — 재fetch가
+        // "실제로" 일어났는지(단순 로컬 감산이 아니라 서버 truth 재조회인지)까지 구분한다.
+        return new Response(JSON.stringify({ count: unreadCountCallCount === 1 ? 3 : 1 }), {
+          status: 200, headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/event-notifications?')) {
+        return new Response(JSON.stringify({ data: [], meta: { hasMore: false } }), {
+          status: 200, headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ count: 0 }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }));
+
+    await openBell();
+    await act(async () => { await Promise.resolve(); });
+    const bellButton = container.querySelector('button[aria-expanded]') as HTMLButtonElement;
+    expect(bellButton.getAttribute('aria-label')).toContain('3');
+
+    const beforeCount = unreadCountCallCount;
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => {
+      es.emit('conversation.read', { conversation_id: 'conv-1', member_id: 'me-1', last_read_at: '2026-08-16T00:00:00Z', unread_count: 0 });
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(unreadCountCallCount).toBe(beforeCount + 1);
+    expect(bellButton.getAttribute('aria-label')).toContain('1');
+  });
+
+  it('sync_status 등 다른 extra 이벤트는 unread-count를 재fetch하지 않는다(과잉살상 금지 음성대조)', async () => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    stubFetchSequenceByOffset({ 0: { items: [], hasMore: false } });
+    await openBell();
+
+    const es = FakeEventSource.instances[0]!;
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const beforeCalls = fetchMock.mock.calls.length;
+    await act(async () => { es.emit('sync_status', { complete: true, reason: null, returned: 0 }); });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(fetchMock.mock.calls.length).toBe(beforeCalls);
+  });
+});

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -136,7 +136,12 @@ function isSyncDegraded(data: SseSyncStatus): boolean {
   return !data.complete && data.reason !== null && data.reason !== 'no_cursor';
 }
 
-const SYNC_STATUS_EVENT_NAMES = ['sync_status'];
+// story #2686(축D) — 채팅 mark-read가 그 대화의 event-notification read_at을 서버에서
+// 동기하도록 BE가 확장됐다(디디 계약). 벨은 기존 30초 폴링+visibility로도 결국 반영되지만
+// (안전망, 아래 useEffect 그대로 유지), conversation.read SSE(conversations.py
+// mark_conversation_read가 이미 본인 커넥션에 쏘는 기존 payload — 새 필드 불요)를 받는 즉시
+// unread-count를 재fetch하면 "채팅 읽자마자 벨이 준다"가 30초 대기 없이 성립한다.
+const BELL_EXTRA_EVENT_NAMES = ['sync_status', 'conversation.read'];
 
 async function fetchUnreadCount(projectId?: string): Promise<number> {
   const params = projectId ? `?project_id=${projectId}` : '';
@@ -401,19 +406,28 @@ export function NotificationBell() {
   }, [t]);
 
   // story #2201 — sync_status는 SseEventNotification 계약과 무관한 별도 이벤트라
-  // extraEventNames/onExtraEvent로 구독한다(핸들러 파이프라인을 안 건드림).
-  const handleSyncStatus = useCallback((eventName: string, data: unknown) => {
-    if (eventName !== 'sync_status') return;
-    const parsed = data as Partial<SseSyncStatus>;
-    if (typeof parsed.complete !== 'boolean') return;
-    setSyncDegraded(isSyncDegraded(parsed as SseSyncStatus));
-  }, []);
+  // extraEventNames/onExtraEvent로 구독한다(핸들러 파이프라인을 안 건드림). story #2686(축D) —
+  // conversation.read도 같은 축(별도 계약, 같은 커넥션)으로 추가 — 채팅을 읽으면 BE가 그
+  // 대화의 event-notification read_at도 동기하므로, 이 신호를 받는 즉시 unread-count를
+  // 서버 truth로 재fetch한다(payload 자체는 안 읽는다 — 벨 카운트를 그 payload에서 역산하지
+  // 않고 항상 재조회, 30초 폴링·mark_read PATCH 후 재조회와 동일 관례).
+  const handleExtraEvent = useCallback((eventName: string, data: unknown) => {
+    if (eventName === 'sync_status') {
+      const parsed = data as Partial<SseSyncStatus>;
+      if (typeof parsed.complete !== 'boolean') return;
+      setSyncDegraded(isSyncDegraded(parsed as SseSyncStatus));
+      return;
+    }
+    if (eventName === 'conversation.read') {
+      void fetchUnreadCount(projectId ?? undefined).then(setUnreadCount);
+    }
+  }, [projectId]);
 
   useSseNotifications({
     onNotification: handleSseNotification,
     memberId: currentTeamMemberId,
-    extraEventNames: SYNC_STATUS_EVENT_NAMES,
-    onExtraEvent: handleSyncStatus,
+    extraEventNames: BELL_EXTRA_EVENT_NAMES,
+    onExtraEvent: handleExtraEvent,
   });
 
   // unread count 폴링 (30초 — SSE 실패 보완)


### PR DESCRIPTION
## 요약
축D(E-CHAT-REALTIME, 유나 재그라운딩 doc 52c5bc5c) — "채팅 노티 받고 들어왔는데 잔상" 근본 fix의 **FE 절반**. BE 절반(디디, 별도 PR)은 `mark_conversation_read`가 그 대화의 event-notification `Event.read_at`도 동기(source_entity_id join·recipient_id 스코프·up_to 경계·멱등)하도록 확장한다.

## 계약 그라운딩 요약(PO 승인 완료)
- **매칭 축**: `Event.event_type IN ('conversation.message_created','conversation:mention') AND Event.source_entity_id == ConversationMessage.id AND ConversationMessage.conversation_id == :conv AND Event.recipient_id == sender.id AND Event.read_at IS NULL` — `event_notifications.py`의 `_is_hidden_notification`이 이미 쓰는 correlate 패턴 재사용, 새 축 발명 없음.
- **up_to 경계**: `ConversationMessage.created_at <= new_last_read_at`(GREATEST 래칫 후 값)까지만 — "일부만 읽음" 호출이 미래 메시지 알림까지 앞당겨 읽음 처리하는 과잉살상 방지.
- 전문은 PO/디디 채팅 스레드 참고.

## 이 PR(FE) 변경
`notification-bell.tsx`는 이미 30초 폴링+visibility 안전망이 있지만(AC①의 "즉시" 성립엔 최대 30초 지연), 채팅 mark-read가 이미 본인 커넥션에 쏘는 `conversation.read` SSE(conversations.py, **payload 확장 불요** — 서버 truth 재조회 방식이라 payload 값 자체는 안 읽음)를 `useSseNotifications`의 `extraEventNames`/`onExtraEvent`(`sync_status`와 동일 확장축, 신규 EventSource 없음)로 구독 추가해 수신 즉시 `fetchUnreadCount()` 재fetch.

## AC 대조(FE 몫)
- ①채팅 읽으면 그 대화發 알림이 벨/인박스에서 즉시 읽음 처리 ✅(SSE 수신 즉시 재fetch, 30초 대기 불요)
- ②다른 대화·비채팅 알림 불변 ✅(BE 매칭 축 책임 — FE는 항상 서버 truth 재조회라 과잉살상 여지 없음)
- ③멱등 ✅(BE 책임, `read_at IS NULL` 조건)
- ④기존 알림 흐름 무회귀 ✅(sync_status 등 다른 extra 이벤트는 재fetch 안 함을 음성대조로 고정)

## 검증
- `pnpm exec tsc --noEmit` / `pnpm exec eslint` — 통과, 0 warning
- `pnpm build` — 통과
- `pnpm exec vitest run` — 430 files / 3501 tests 전부 통과(신규 2건 포함)
- **RED→GREEN**: `notification-bell.tsx`만 `git stash`로 되돌려 신규 테스트가 정확히 "SSE 수신 후 재fetch 호출 수 불변" 모양으로 RED(음성대조 `sync_status` 테스트는 그대로 GREEN 유지) → 복원 → GREEN 재확認

## done-gate
BE 절반(디디 PR) 머지 후 dev 라이브 — 노티 받고 진입→벨 카운트 즉시 감소 실측 필요. 이 PR만으론 실제 read_at 동기가 안 일어나므로(BE 미착지) 단독으로는 관찰 가능한 사용자 체감 변화 없음(회귀 아님 — SSE 이벤트 자체가 아직 전혀 안 옴).

## 스크린샷
로직 전용(폴링 보완 축, 새 UI 없음) — UI 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)