### PR TITLE
[SID:2689] 콜드 재진입 슬로우 — raw fetch 8곳을 fetchWithAuth로 전환(401 재시도 커버리지 갭 fix)

### DIFF
--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -12,6 +12,7 @@ import { ApprovalsQueue } from '@/components/inbox/approvals-queue';
 import { AttentionQueueView } from '@/components/attention-queue/attention-queue-view';
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
 import { useToast, ToastContainer } from '@/components/ui/toast';
+import { fetchWithAuth } from '@/lib/db/client';
 import {
   getInboxNotificationLabel,
   getNotificationReasonKey,
@@ -164,7 +165,9 @@ async function fetchInboxNotifications(typeFilter: string, cursor?: string | nul
   if (typeFilter) params.set('type', typeFilter);
   if (cursor) params.set('cursor', cursor);
 
-  const res = await fetch(`/api/notifications?${params}`);
+  // story #2689 — 콜드 재진입 시 raw fetch는 401을 재시도 없이 삼켜(!res.ok=>null) 알림
+  // 목록이 빈 채로 남았다. fetchWithAuth로 401→refresh→재시도 경로에 태운다.
+  const res = await fetchWithAuth(`/api/notifications?${params}`);
   if (!res.ok) return null;
 
   const json = await res.json();
@@ -258,7 +261,9 @@ export default function InboxPage() {
   useEffect(() => {
     if (!currentTeamMemberId || !projectId) return;
     const params = new URLSearchParams({ project_id: projectId, member_id: currentTeamMemberId, limit: '10' });
-    fetch(`/api/workflow-executions?${params.toString()}`)
+    // story #2689 — 콜드 재진입 시 raw fetch는 401을 재시도 없이 삼켜(r.ok?...:null) 워크플로우
+    // 실행 목록이 빈 채로 남았다. fetchWithAuth로 401→refresh→재시도 경로에 태운다.
+    fetchWithAuth(`/api/workflow-executions?${params.toString()}`)
       .then((r) => r.ok ? r.json() : null)
       .then((json) => {
         if (json?.items) setWorkflowExecs(json.items as WorkflowExecItem[]);

--- a/apps/web/src/components/inbox/decisions-waiting.tsx
+++ b/apps/web/src/components/inbox/decisions-waiting.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { CheckCircle2, X, AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { fetchWithAuth } from '@/lib/db/client';
 
 // Operator Cockpit Phase A2-MIN — pending decisions panel.
 // Reads from /api/inbox (inbox_items) and lets the operator resolve or dismiss
@@ -65,7 +66,11 @@ export function DecisionsWaiting({ onChange }: DecisionsWaitingProps = {}) {
   const fetchItems = useCallback(async () => {
     setError(null);
     try {
-      const res = await fetch('/api/inbox?state=pending');
+      // story #2689 — 콜드 재진입 시 raw fetch는 401을 재시도 없이 삼켜(아래 return) 이
+      // 패널이 영구히 비어 보였다. fetchWithAuth로 401→refresh→재시도 경로에 태운다 — 그래도
+      // 401이면(refresh 자체 실패) signalSessionExpired가 이미 전역 다이얼로그를 띄우므로
+      // 여기선 그대로 조용히 return.
+      const res = await fetchWithAuth('/api/inbox?state=pending');
       if (!res.ok) {
         if (res.status === 401) return;
         setError('fetch_failed');

--- a/apps/web/src/components/org-briefing/now-face.tsx
+++ b/apps/web/src/components/org-briefing/now-face.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { CheckCircle2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { fetchWithAuth } from '@/lib/db/client';
 import { cn } from '@/lib/utils';
 import {
   buildNowFace, parseCompletionNotifications, parseMyActions,
@@ -24,9 +25,11 @@ interface NowFaceLoad {
 }
 
 async function loadNowFace(t: NowFaceTranslator): Promise<NowFaceLoad> {
+  // story #2689 — 콜드 재진입 시 raw fetch는 401을 재시도 없이 삼켜(!r.ok=>null) "지금" 면이
+  // 빈 채로 60초 REFRESH_MS까지 안 채워졌다. fetchWithAuth로 401→refresh→재시도 경로에 태운다.
   const [ma, notifs] = await Promise.all([
-    fetch('/api/dashboard/my-actions').then((r) => (r.ok ? r.json() : null)).catch(() => null),
-    fetch('/api/notifications?type=task_completed&unread=true').then((r) => (r.ok ? r.json() : null)).catch(() => null),
+    fetchWithAuth('/api/dashboard/my-actions').then((r) => (r.ok ? r.json() : null)).catch(() => null),
+    fetchWithAuth('/api/notifications?type=task_completed&unread=true').then((r) => (r.ok ? r.json() : null)).catch(() => null),
   ]);
   const raw = parseMyActions(ma);
   return {

--- a/apps/web/src/components/storage/storage-capacity-banner.test.tsx
+++ b/apps/web/src/components/storage/storage-capacity-banner.test.tsx
@@ -61,3 +61,39 @@ describe('StorageCapacityBanner — 아이콘 색 유지 (story #2513 회귀가�
     expect(icon?.getAttribute('class')).toContain('text-destructive');
   });
 });
+
+// story #2689(콜드 재진입 슬로우) — raw fetch였을 때는 마운트 시 401을 맞으면 재시도 없이
+// `if (!res.ok) return`으로 조용히 삼켜(폴링도 없는 마운트 1회뿐) 배너가 영원히 안 떴다.
+// fetchWithAuth로 바꾼 뒤엔 401→refresh→재시도 경로를 타 결국 뜬다 — 이 축을 고정한다.
+describe('StorageCapacityBanner — 콜드 재진입(401→refresh→재시도) 후 배너가 뜬다(story #2689)', () => {
+  it('첫 요청이 401이어도 fetchWithAuth의 refresh 재시도로 결국 배너가 렌더된다', async () => {
+    let callCount = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : String(input);
+      if (url.includes('/api/auth/refresh')) {
+        return new Response(JSON.stringify({ data: { access_token: 'new-at', refresh_token: 'new-rt', token_type: 'bearer' } }), {
+          status: 200, headers: { 'content-type': 'application/json' },
+        });
+      }
+      callCount += 1;
+      if (callCount === 1) return new Response(null, { status: 401 });
+      return new Response(JSON.stringify({ data: { used_bytes: 100, limit_bytes: 100, percentage: 100 } }), {
+        status: 200, headers: { 'content-type': 'application/json' },
+      });
+    }));
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <StorageCapacityBanner />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const alertEl = container.querySelector('[role="alert"]');
+    expect(alertEl).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/storage/storage-capacity-banner.tsx
+++ b/apps/web/src/components/storage/storage-capacity-banner.tsx
@@ -7,6 +7,7 @@ import { AlertOctagon, AlertTriangle, X } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { fetchWithAuth } from '@/lib/db/client';
 import { isEEEnabled } from '@/lib/ee';
 import { formatStorageSize } from '@/lib/storage/format';
 import { cn } from '@/lib/utils';
@@ -51,7 +52,9 @@ export function StorageCapacityBanner() {
     let cancelled = false;
     void (async () => {
       try {
-        const res = await fetch('/api/assets/storage-usage');
+        // story #2689 — 콜드 재진입 시 raw fetch는 401을 재시도 없이 삼킨다(폴링 없음, 마운트
+        // 1회뿐이라 다시 안 뜬다). fetchWithAuth로 401→refresh→재시도 경로에 태운다.
+        const res = await fetchWithAuth('/api/assets/storage-usage');
         if (!res.ok) return;
         const json = (await res.json()) as {
           data?: { used_bytes?: number; limit_bytes?: number; percentage?: number };

--- a/apps/web/src/components/storage/storage-capacity-toast-provider.tsx
+++ b/apps/web/src/components/storage/storage-capacity-toast-provider.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { ToastContainer, useToast } from '@/components/ui/toast';
+import { fetchWithAuth } from '@/lib/db/client';
 
 /** 세션 1회 가드 — 같은 세션 새로고침 시 토스트 재노출 방지. */
 const TOAST_SHOWN_KEY = 'storage-capacity-toast-shown';
@@ -36,7 +37,10 @@ export function StorageCapacityToastProvider({ children }: { children: React.Rea
     let cancelled = false;
     void (async () => {
       try {
-        const res = await fetch('/api/assets/storage-usage');
+        // story #2689 — 콜드 재진입(만료 access token) 시 raw fetch는 401을 재시도 없이
+        // 삼켜(!res.ok=>return) ranRef가 이미 true라 이 세션 안엔 다시는 안 뜬다(폴링도 없음,
+        // §S8 "세션 1회"). fetchWithAuth로 바꿔 401→refresh→재시도 경로에 태운다.
+        const res = await fetchWithAuth('/api/assets/storage-usage');
         if (!res.ok) return;
         const json = (await res.json()) as { data?: { percentage?: number } };
         const pct = json.data?.percentage;

--- a/apps/web/src/lib/db/client.test.ts
+++ b/apps/web/src/lib/db/client.test.ts
@@ -34,3 +34,46 @@ describe('fetchWithAuth — 세션만료 신호 후 단락(#2160)', () => {
     expect(res.status).toBe(401);
   });
 });
+
+// story #2689(콜드 재진입 슬로우) — 그라운딩 중 핵심 질문: 콜드 재진입 시 GNB 마운트 시점에
+// 동시에 쏘는 여러 fetchWithAuth 호출이 전부 401을 맞으면, refresh가 N번 각각 도는지 1번만
+// 도는지. `_refreshing`(모듈 스코프 공유 promise) single-flight 설계가 실제로 그렇게 동작
+// 하는지를 "추측 금지"(스토리 AC①) 원칙에 맞춰 직접 고정한다 — 응답 지연을 넣어 진짜 동시
+// 호출 사이 레이스 창을 만든다(지연 없으면 매 await 지점마다 우연히 순차화돼 검증력이 약함).
+describe('fetchWithAuth — 동시 401 N건 → refresh single-flight(story #2689 AC②)', () => {
+  it('서로 다른 URL 3개가 동시에 401을 맞아도 /api/auth/refresh는 정확히 1번만 호출된다', async () => {
+    let refreshCallCount = 0;
+    const inFlightPerUrl = new Map<string, number>();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url ?? String(input);
+      if (url.includes('/api/auth/refresh')) {
+        refreshCallCount += 1;
+        // 실 네트워크 왕복을 흉내(지연) — 지연이 없으면 이벤트루프상 순차 처리처럼 보여 동시성
+        // 검증력이 약해진다(레이스 창을 실제로 만들어야 single-flight가 진짜 효과가 있는지 안다).
+        await new Promise((r) => setTimeout(r, 20));
+        return new Response(JSON.stringify({ data: { access_token: 'new-at', refresh_token: 'new-rt', token_type: 'bearer' } }), {
+          status: 200, headers: { 'content-type': 'application/json' },
+        });
+      }
+      const calls = (inFlightPerUrl.get(url) ?? 0) + 1;
+      inFlightPerUrl.set(url, calls);
+      // 이 URL로의 첫 호출(콜드 재진입 원 요청)만 401 — 재시도(refresh 후 두 번째 호출)는 200.
+      if (calls === 1) return new Response(null, { status: 401 });
+      return new Response(JSON.stringify({ data: { ok: true, url } }), {
+        status: 200, headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const [a, b, c] = await Promise.all([
+      fetchWithAuth('/api/gates?status=pending'),
+      fetchWithAuth('/api/event-notifications/unread-count'),
+      fetchWithAuth('/api/conversations/unread-count'),
+    ]);
+
+    expect(refreshCallCount).toBe(1);
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(c.status).toBe(200);
+  });
+});

--- a/apps/web/src/lib/release-notes.ts
+++ b/apps/web/src/lib/release-notes.ts
@@ -1,3 +1,5 @@
+import { fetchWithAuth } from '@/lib/db/client';
+
 export interface ReleaseNoteItem {
   text: string;
   href?: string;
@@ -21,7 +23,10 @@ export interface ReleaseNote {
  */
 export async function fetchReleaseNotes(): Promise<ReleaseNote[]> {
   try {
-    const res = await fetch('/api/release-notes', { credentials: 'same-origin' });
+    // story #2689 — 콜드 재진입 시 raw fetch는 401을 재시도 없이 삼켜(!res.ok=>[]) 릴리즈
+    // 노트 게이트가 조용히 안 뜨는(빈 배열이라 gate auto-open 대상 자체가 없어짐) 결과였다.
+    // fetchWithAuth로 401→refresh→재시도 경로에 태운다.
+    const res = await fetchWithAuth('/api/release-notes', { credentials: 'same-origin' });
     if (!res.ok) return [];
     const body = (await res.json()) as { data?: ReleaseNote[] };
     return Array.isArray(body?.data) ? body.data : [];


### PR DESCRIPTION
## 요약
#2687 패턴③(선생님 단서: 앱 강제종료 후 재진입) 그라운딩. 디디 BE 결론: BE엔 손댈 결함 없음(refresh atomic rotation·grace-window·lock/backoff 지연 0). FE 축을 이 스토리가 실측+처방한다.

## 실측①(AC①) — dev /inbox 콜드 진입, 유효세션
Performance Resource Timing으로 GNB 마운트 시점 9개 요청 전부 확인: start 619~623ms에 병렬 fan-out, 820~1230ms에 전부 완료. **직렬 폭포(waterfall)는 없음** — 이 축은 이미 건강했다.

## dedup 정밀검증(AC②) — vitest, 실 레이스 창 포함
`fetchWithAuth`의 `_refreshing` 모듈스코프 single-flight를 3개 URL 동시 401로 직접 테스트 — refresh는 정확히 1번만 호출됨(`client.test.ts` 신규). 뮤테이션으로 가드를 꺼서(`if(false)`) 이 테스트가 실제로 0회를 잡아내는지도 확인(discriminating power 검증, 커밋 안 함). **결론: dedup은 이미 정확히 동작한다.**

## 진짜 원인(정적+실측 교차확認)
GNB/inbox 콜드마운트 9개 요청 중 절반가량이 애초에 `fetchWithAuth`를 안 거치고 raw `fetch`를 쓴다 — `if (!res.ok) return`류로 401을 재시도 없이 삼킨다(storage 배너는 폴링조차 없어 세션 내내 다시 안 뜬다). **"N개가 각각 refresh를 쏜다"는 원 가설이 아니라 "여러 곳이 refresh 자체를 안 탄다"가 실제 결함** — 위젯별로 다음 트리거(visibility/poll)가 올 때까지 빈 채로 남아 "전체적으로 뒤지게 느림"으로 체감된다.

## fix(AC③) — 8개 호출부를 fetchWithAuth로 전환(로직 변경 없음, 드롭인 치환)
- `storage-capacity-toast-provider.tsx` / `storage-capacity-banner.tsx` — `/api/assets/storage-usage`
- `decisions-waiting.tsx` — `/api/inbox?state=pending`
- `now-face.tsx` — `/api/dashboard/my-actions`·`/api/notifications?type=task_completed`
- `inbox/page.tsx` — `/api/notifications`·`/api/workflow-executions`
- `lib/release-notes.ts` — `/api/release-notes`

## 검증
- `pnpm exec tsc --noEmit` / `pnpm exec eslint` — 통과, 0 warning
- `pnpm build` — 통과
- `pnpm exec vitest run` — 429 files / 3500 tests 전부 통과(신규 3건 포함)
- **RED→GREEN**: `storage-capacity-banner.tsx`만 `git stash`로 되돌려 신규 401-재시도 테스트가 RED 확인(배너가 영영 안 뜸) → 복원 → GREEN 재확認

## ⚠️미해결 — done-gate의 "재실측 수치(전/후)"
`sp_at`은 httpOnly라 브라우저 JS/puppeteer로 위조 불가(access token 60분 TTL 자연만료 대기가 유일한 정공법). 이 PR엔 실제 만료 토큰으로 재현한 전/후 수치가 없다 — 메커니즘 수준 증명(위 dedup 테스트+정적 grep 전수)은 확고하나, "느림" 체감의 진짜 전/후 라이브 숫자는 PO 상신 후 후속 조치(자연만료 대기 테스트, 또는 BE 쪽 강제만료 백도어 필요 여부) 협의 예정.

## 스크린샷
로직 전용(fetch 함수 치환) — UI 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)