### PR TITLE
fix(gate_service): defer gate.pending_approval webhook to outbox (story #2688)

### DIFF
--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -377,6 +377,9 @@ async def _reopen_rejected_gate(
                     body=f"{gate_type} 게이트가 재제출되어 다시 승인/거부를 기다리고 있습니다.",
                     reference_type="gate", reference_id=gate.id,
                     source_project_id=project_id,
+                    # story #2688: create_gate()의 신규-gate 경로(:475 부근)와 동일 결함 —
+                    # 재상신(rejected→pending re-open) 경로도 동기 웹훅이 트랜잭션을 물었다.
+                    via_outbox=True,
                 )
         except Exception:
             logger.warning(
@@ -479,6 +482,11 @@ async def create_gate(
                     body=f"{gate_type} 게이트가 승인/거부를 기다리고 있습니다.",
                     reference_type="gate", reference_id=gate.id,
                     source_project_id=project_id,
+                    # story #2688: 동기 개인 webhook 실POST가 create_gate() 호출부(예:
+                    # docs/{id}/transition draft→pending)의 열린 트랜잭션 커넥션을 붙잡아
+                    # 요청을 초 단위로 지연시켰다(실측 2.7s→220ms). story #2460 §6 봉합②
+                    # outbox 경로 재사용.
+                    via_outbox=True,
                 )
         except Exception:
             logger.warning(

--- a/backend/tests/test_1934_push_notification_wiring_realdb.py
+++ b/backend/tests/test_1934_push_notification_wiring_realdb.py
@@ -131,3 +131,74 @@ async def test_create_gate_auto_passed_does_not_notify():
                 assert notif is None
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_gate_pending_notification_via_outbox():
+    """story #2688: create_gate()의 dispatch_notification 콜이 via_outbox=True를 넘기는지 pin.
+
+    동기 개인 webhook POST가 create_gate() 호출부(예: docs/{id}/transition draft→pending)의
+    열린 트랜잭션 커넥션을 붙잡아 2.7s대 지연을 유발했다(실측·story #2687과 동일 결함 클래스).
+    Notification INSERT 자체(위 test_create_gate_pending_notifies_org_admin)는 via_outbox와
+    무관하게 그대로 발생 — 이 테스트는 그 위에 얹힌 배달 채널 계약만 별도로 고정한다."""
+    from unittest.mock import AsyncMock, patch
+    from app.services.gate_service import create_gate
+
+    org_id = uuid.uuid4()
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            await _seed_org_admin(s, org_id)
+
+            dn = AsyncMock()
+            with patch("app.services.notification_dispatch.dispatch_notification", dn):
+                gate = await create_gate(
+                    s, org_id, uuid.uuid4(), "story", "pr_review",
+                    uuid.uuid4(), uuid.uuid4(),
+                )
+            assert gate.status == "pending"
+            dn.assert_awaited_once()
+            assert dn.await_args.kwargs["via_outbox"] is True
+            assert dn.await_args.kwargs["event_type"] == "gate.pending_approval"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reopen_rejected_gate_notification_via_outbox():
+    """story #2688: 재상신(rejected→pending re-open) 경로도 동일 결함·동일 fix.
+
+    _reopen_rejected_gate()는 create_gate()가 기존 rejected(terminal) gate를 발견했을 때
+    타는 별도 콜사이트 — 새 gate 생성과 나란한 두 번째 dispatch_notification 호출."""
+    from unittest.mock import AsyncMock, patch
+    from app.services.gate_service import create_gate
+
+    org_id = uuid.uuid4()
+    work_item_id = uuid.uuid4()
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            await _seed_org_admin(s, org_id)
+
+            # 1차: rejected 상태 gate를 만든다(알림 무시 — 이 테스트의 관심사는 재상신 쪽).
+            gate = await create_gate(
+                s, org_id, work_item_id, "story", "pr_review",
+                uuid.uuid4(), uuid.uuid4(),
+            )
+            await s.commit()
+            from app.models.gate import set_gate_status
+            from datetime import datetime, timezone
+            set_gate_status(gate, "rejected", now=datetime.now(timezone.utc))
+            await s.commit()
+
+            dn = AsyncMock()
+            with patch("app.services.notification_dispatch.dispatch_notification", dn):
+                reopened = await create_gate(
+                    s, org_id, work_item_id, "story", "pr_review",
+                    uuid.uuid4(), uuid.uuid4(),
+                )
+            assert reopened.status == "pending"
+            dn.assert_awaited_once()
+            assert dn.await_args.kwargs["via_outbox"] is True
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story #2688 — #2687이 못 잡은, doc transition 잔여 2.5s의 실제 원인.
- `create_gate()`(:475)·`_reopen_rejected_gate()`(:373) 각각의 `dispatch_notification(event_type="gate.pending_approval", ...)`가 `via_outbox` 없이(기본 False=동기) 개인 webhook POST를 호출부 트랜잭션 안에서 그대로 실행하고 있었음. doc.py의 `_notify_doc_approval_requested`(#2687에서 이미 고침)와는 별개의 두 번째 콜사이트.
- dev DB(실 배포 이미지)에서 real-app-code 프로파일링(SQLAlchemy cursor-level 타이밍) — 107개 SQL문 합계 330ms인데 총 2.7s, gap 1.8s가 webhook targets SELECT 직후 무-SQL 구간(httpx POST 시그니처)과 일치. via_outbox=True 런타임 강제 재실측(코드 미배포) → warm 기준 ~220ms로 확인.

## Test plan
- [x] `test_1934_push_notification_wiring_realdb.py`에 신규 2건(create_gate·reopen 각각 `via_outbox=True` pin) — mutation-kill(fix 되돌리면 KeyError로 RED).
- [x] gate 관련 34개 테스트 파일 로컬 회귀(신선 disposable PG, 2회 검증) — 실패 18건은 fix 적용 전/후 동일하게 재현되는 사전존재 테스트-인프라 문제(예: `test_2237_gate_create_project_scope_realdb.py`의 `projects.violation_level` NOT NULL — destructive-reset 픽스처의 schema rebuild가 alembic server_default를 못 따라감)로 이 변경과 무관함을 baseline 대조로 확인.
- [ ] CI 확인 대기(페드루군 재출근 후 게이트).

story: entity:story:e15df4d6-25ab-4bc0-ba78-767d481a7ad4