### PR TITLE
fix(gate_service): doc 결재 상신 알림 중복 제거 (story #373cfaa1)

### DIFF
--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -123,6 +123,10 @@ async def transition_doc(
             caller.id, role_id,
             neutral_facts={"requested_by_member_id": str(caller.id), "doc_title": doc.title},
             project_id=doc.project_id,
+            # story #373cfaa1: 이 함수가 아래서 _notify_doc_approval_requested()로 doc 전용
+            # 리치 알림(벨+카드)을 별도로 쏘므로, create_gate() generic "gate.pending_approval"
+            # 벨은 끈다(중복 제거 — 신규생성·rejected재오픈 두 경로 모두 해당).
+            notify=False,
         )
         # ⚠️재상신 RC(산티아고): uq(work_item_id,gate_type)=1 gate·terminal(approved/rejected)=immutable →
         # create_gate 멱등이 기존 **terminal gate 를 반환**해(상태필터 없음) 재상신 시 새 pending gate 0 →

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -302,6 +302,7 @@ async def _reopen_rejected_gate(
     gate_type: str,
     neutral_facts: dict[str, Any] | None,
     project_id: uuid.UUID | None,
+    notify: bool = True,
 ) -> Gate:
     """story #2150(P1) 근본수정 — create_gate()의 멱등 조회에 status 필터가 없어 rejected
     게이트를 그대로 반환했다(merge_verdict_gate.py의 ``gate_status=="rejected"`` 체크와
@@ -365,7 +366,7 @@ async def _reopen_rejected_gate(
     await session.flush()
     await session.refresh(gate)
 
-    if new_status == "pending":
+    if new_status == "pending" and notify:
         try:
             target_ids = await _resolve_gate_notification_targets(session, org_id)
             if target_ids:
@@ -399,6 +400,7 @@ async def create_gate(
     role_id: uuid.UUID,
     neutral_facts: dict[str, Any] | None = None,
     project_id: uuid.UUID | None = None,
+    notify: bool = True,
 ) -> Gate:
     """config 기반 게이트 생성 (멱등: 이미 있으면 기존 반환).
 
@@ -411,6 +413,11 @@ async def create_gate(
     workflow_line_config(wf_line_version)처럼 진짜 org-level(project 무관)일 수 있는 work_item은
     ``version.project_id``(nullable)를 그대로 넘겨 None이 나올 수 있다 — 이건 미해결이 아니라
     구조적으로 project-scoped가 아니라는 정직한 값이다.
+
+    notify: story #373cfaa1 — 호출부가 이미 자기 전용의 리치 알림(제목/본문+카드 등)을 별도로
+    보낼 때, 이 generic "gate.pending_approval" 벨과의 중복을 끄는 opt-out(기본값 True=기존
+    全 호출부 무회귀). gate_type/work_item_type별 하드코딩 대신 호출부 판단으로 남겨 이 함수의
+    공용 chokepoint 성격을 유지한다.
     """
     # 멱등: 이미 존재하면 기존 반환
     existing_r = await session.execute(
@@ -430,6 +437,7 @@ async def create_gate(
         return await _reopen_rejected_gate(
             session, existing, org_id=org_id, member_id=member_id, role_id=role_id,
             gate_type=gate_type, neutral_facts=neutral_facts, project_id=project_id,
+            notify=notify,
         )
 
     # SID 301ee45d/#2047: 반환값이 (disposition, source) — 이 범용 생성기는 disposition→status
@@ -470,7 +478,7 @@ async def create_gate(
     # pending 상태(진짜 결재 대기)일 때만 알림 — auto_passed/rejected는 즉시 확정이라 결재
     # 액션이 없다. best-effort(알림 실패가 게이트 생성 자체를 롤백하면 안 됨 — deliver_expo_
     # push/override 알림과 동일 관례).
-    if status == "pending":
+    if status == "pending" and notify:
         try:
             target_ids = await _resolve_gate_notification_targets(session, org_id)
             if target_ids:

--- a/backend/tests/test_1934_push_notification_wiring_realdb.py
+++ b/backend/tests/test_1934_push_notification_wiring_realdb.py
@@ -202,3 +202,65 @@ async def test_reopen_rejected_gate_notification_via_outbox():
             assert dn.await_args.kwargs["via_outbox"] is True
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_gate_notify_false_suppresses_generic_notification():
+    """story #373cfaa1: notify=False 호출부(예: doc.py — 자체 리치 알림을 따로 쏘는 콜사이트)는
+    create_gate()의 generic "gate.pending_approval" 벨을 받지 않는다(중복 제거 opt-out).
+    mutation-kill: doc.py의 notify=False 인자를 빼면 이 자리의 dn이 호출돼 RED가 된다."""
+    from unittest.mock import AsyncMock, patch
+    from app.services.gate_service import create_gate
+
+    org_id = uuid.uuid4()
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            await _seed_org_admin(s, org_id)
+
+            dn = AsyncMock()
+            with patch("app.services.notification_dispatch.dispatch_notification", dn):
+                gate = await create_gate(
+                    s, org_id, uuid.uuid4(), "doc", "doc_approval",
+                    uuid.uuid4(), uuid.uuid4(), notify=False,
+                )
+            assert gate.status == "pending"
+            dn.assert_not_awaited()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reopen_rejected_gate_notify_false_suppresses_generic_notification():
+    """story #373cfaa1: 재상신(rejected→pending reopen) 경로도 notify=False면 generic 벨이
+    안 나간다(doc 재상신 시 doc.py 자체 알림과의 중복 제거가 이 경로에도 동일 적용)."""
+    from unittest.mock import AsyncMock, patch
+    from app.services.gate_service import create_gate
+
+    org_id = uuid.uuid4()
+    work_item_id = uuid.uuid4()
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            await _seed_org_admin(s, org_id)
+
+            gate = await create_gate(
+                s, org_id, work_item_id, "doc", "doc_approval",
+                uuid.uuid4(), uuid.uuid4(), notify=False,
+            )
+            await s.commit()
+            from app.models.gate import set_gate_status
+            from datetime import datetime, timezone
+            set_gate_status(gate, "rejected", now=datetime.now(timezone.utc))
+            await s.commit()
+
+            dn = AsyncMock()
+            with patch("app.services.notification_dispatch.dispatch_notification", dn):
+                reopened = await create_gate(
+                    s, org_id, work_item_id, "doc", "doc_approval",
+                    uuid.uuid4(), uuid.uuid4(), notify=False,
+                )
+            assert reopened.status == "pending"
+            dn.assert_not_awaited()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_373cfaa1_doc_notify_dedup_realdb.py
+++ b/backend/tests/test_373cfaa1_doc_notify_dedup_realdb.py
@@ -1,0 +1,182 @@
+"""story #373cfaa1: doc 결재 상신 시 alarm 중복(gate.pending_approval + doc_approval_requested)
+제거 — realdb 핀. create_gate()의 generic "gate.pending_approval" 벨과 doc.py
+_notify_doc_approval_requested()의 doc 전용 "doc_approval_requested" 벨이 같은 org owner/admin
+대상에 동시 발화하던 결함(judgment 989e26d8-9491-4816-8148-bdecf69a04eb 참조) — create_gate(notify=False)
+로 generic 벨을 끄고 doc 전용 알림만 남긴다.
+
+mutation-kill: doc.py의 notify=False 인자를 빼면 아래 테스트들의 assert가 2건으로 RED가 된다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_after():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_admin(session, org_id, project_id):
+    from app.core.security import hash_password
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.user import User
+
+    session.add(Organization(id=org_id, name="Org", slug=f"org-{org_id.hex[:8]}"))
+    await session.commit()
+    session.add(Project(id=project_id, org_id=org_id, name="P"))
+    await session.commit()
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"admin-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    admin_member_id = uuid.uuid4()
+    session.add(OrgMember(id=admin_member_id, org_id=org_id, user_id=user_id, role="admin"))
+    await session.commit()
+    return admin_member_id, user_id
+
+
+async def _seed_requester(session, org_id):
+    from app.core.security import hash_password
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"req-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    member_id = uuid.uuid4()
+    session.add(OrgMember(id=member_id, org_id=org_id, user_id=user_id, role="member"))
+    await session.commit()
+    return member_id
+
+
+@pytest.mark.anyio
+async def test_doc_submit_notifies_approver_exactly_once():
+    """draft→pending 최초 상신: approver(admin)에게 Notification 정확히 1건(doc_approval_requested)
+    — gate.pending_approval 은 0건(중복 제거 실증)."""
+    from app.models.doc import Doc
+    from app.models.notification import Notification
+    from app.services.doc import transition_doc
+    from app.services.member_resolver import ResolvedMember
+
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            _admin_member_id, admin_user_id = await _seed_org_project_admin(s, org_id, project_id)
+            requester_id = await _seed_requester(s, org_id)
+            doc = Doc(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="설계",
+                      slug=f"s-{uuid.uuid4().hex[:10]}", status="draft", content="")
+            s.add(doc)
+            await s.commit()
+
+            caller = ResolvedMember(id=requester_id, user_id=uuid.uuid4(), name="req",
+                                     type="human", role="member", org_id=org_id)
+            out = await transition_doc(s, org_id, caller, doc.id, "pending")
+            await s.commit()
+            assert out.status == "pending"
+
+            rows = (await s.execute(
+                select(Notification).where(
+                    Notification.org_id == org_id,
+                    Notification.user_id == admin_user_id,
+                )
+            )).scalars().all()
+            types = [n.type for n in rows]
+            assert types == ["doc_approval_requested"], types  # gate.pending_approval 중복 0건
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_doc_resubmit_after_reject_notifies_approver_exactly_once():
+    """반려 후 재상신(rejected→pending reopen): create_gate() 내부 _reopen_rejected_gate()가
+    별도 발화 지점이라 최초상신과 다른 경로 — 여기서도 신규 Notification이 정확히 1건이어야 한다."""
+    from app.models.doc import Doc
+    from app.models.gate import Gate, set_gate_status
+    from app.models.notification import Notification
+    from app.services.doc import DOC_GATE_TYPE, DOC_GATE_WORK_ITEM_TYPE, transition_doc
+    from app.services.member_resolver import ResolvedMember
+    from datetime import datetime, timezone
+
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            _admin_member_id, admin_user_id = await _seed_org_project_admin(s, org_id, project_id)
+            requester_id = await _seed_requester(s, org_id)
+            doc = Doc(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="설계",
+                      slug=f"s-{uuid.uuid4().hex[:10]}", status="draft", content="")
+            s.add(doc)
+            await s.commit()
+
+            caller = ResolvedMember(id=requester_id, user_id=uuid.uuid4(), name="req",
+                                     type="human", role="member", org_id=org_id)
+            await transition_doc(s, org_id, caller, doc.id, "pending")
+            await s.commit()
+
+            before_count = len((await s.execute(
+                select(Notification).where(
+                    Notification.org_id == org_id, Notification.user_id == admin_user_id,
+                )
+            )).scalars().all())
+
+            gate = (await s.execute(
+                select(Gate).where(
+                    Gate.org_id == org_id, Gate.work_item_id == doc.id,
+                    Gate.work_item_type == DOC_GATE_WORK_ITEM_TYPE, Gate.gate_type == DOC_GATE_TYPE,
+                )
+            )).scalar_one()
+            set_gate_status(gate, "rejected", now=datetime.now(timezone.utc))
+            doc.status = "draft"
+            await s.commit()
+
+            await transition_doc(s, org_id, caller, doc.id, "pending")
+            await s.commit()
+
+            rows = (await s.execute(
+                select(Notification).where(
+                    Notification.org_id == org_id, Notification.user_id == admin_user_id,
+                )
+            )).scalars().all()
+            new_types = [n.type for n in rows][before_count:]
+            assert new_types == ["doc_approval_requested"], new_types
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_edg_doc_gate_inbox.py
+++ b/backend/tests/test_edg_doc_gate_inbox.py
@@ -258,3 +258,41 @@ async def test_submit_notify_fail_silent():
     session = AsyncMock(); session.execute = AsyncMock(side_effect=RuntimeError("boom"))
     await _notify_doc_approval_requested(session, uuid.uuid4(), MagicMock(id=uuid.uuid4()),
                                          uuid.uuid4(), requester_id=uuid.uuid4())
+
+
+# ─── story #373cfaa1: doc 상신 시 create_gate() generic 벨 중복 제거(notify=False) ──────
+
+@pytest.mark.anyio
+async def test_submit_calls_create_gate_with_notify_false():
+    """최초 상신(draft→pending): transition_doc이 create_gate()를 notify=False로 호출해
+    _notify_doc_approval_requested()의 doc 전용 알림과 중복되지 않게 한다.
+    mutation-kill: doc.py에서 notify=False 인자를 빼면 이 assert가 RED가 된다."""
+    org = uuid.uuid4()
+    doc = MagicMock(status="draft", id=uuid.uuid4(), title="설계 문서", project_id=uuid.uuid4())
+    session = _doc_session(doc)
+    role_id = uuid.uuid4()
+    with patch("app.services.gate_service.create_gate",
+               new=AsyncMock(return_value=MagicMock(status="pending"))) as mock_cg, \
+         patch("app.services.workflow_line_config._default_role_id",
+               new=AsyncMock(return_value=role_id)), \
+         patch("app.services.doc._notify_doc_approval_requested", new=AsyncMock()):
+        await transition_doc(session, org, _human(org), doc.id, "pending")
+    assert mock_cg.await_args.kwargs["notify"] is False
+
+
+@pytest.mark.anyio
+async def test_resubmit_calls_create_gate_with_notify_false():
+    """반려 후 재상신(rejected→pending reopen)도 동일 콜사이트라 notify=False 동일 적용."""
+    org = uuid.uuid4()
+    doc = MagicMock(status="draft", id=uuid.uuid4(), title="t", project_id=uuid.uuid4())
+    session = _doc_session(doc)
+    rejected = MagicMock(status="rejected", resolver_id=uuid.uuid4(),
+                         resolved_at=datetime(2026, 6, 26, tzinfo=timezone.utc),
+                         resolution_note="반려사유", neutral_facts=None)
+    with patch("app.services.gate_service.create_gate",
+               new=AsyncMock(return_value=rejected)) as mock_cg, \
+         patch("app.services.workflow_line_config._default_role_id",
+               new=AsyncMock(return_value=uuid.uuid4())), \
+         patch("app.services.doc._notify_doc_approval_requested", new=AsyncMock()):
+        await transition_doc(session, org, _human(org), doc.id, "pending")
+    assert mock_cg.await_args.kwargs["notify"] is False


### PR DESCRIPTION
## Summary
- `create_gate()`가 gate_type을 가리지 않고 무조건 발화하던 generic "gate.pending_approval" 벨과, `doc.py transition_doc()`이 그 직후 별도로 발화하는 doc 전용 "doc_approval_requested" 벨(+챗 카드)이 같은 org owner/admin 대상에 중복 발화하던 결함을 제거합니다(최초 상신·반려 후 재상신 두 경로 모두 해당).
- `create_gate()`/`_reopen_rejected_gate()`에 opt-out 파라미터 `notify: bool = True`를 추가(기본값 유지 — 타 6개 호출부 무회귀)하고, `doc.py`의 호출부만 `notify=False`로 넘겨 generic 벨을 끕니다.
- gate_service의 "work_item_type 불문 공용 chokepoint" 설계 원칙을 지키기 위해 gate_service 내부에 doc_approval 하드코딩 분기를 넣지 않고, 호출부 opt-out으로 처리했습니다.

## Test plan
- [x] `test_edg_doc_gate_inbox.py`: doc.py의 `create_gate()` 호출이 `notify=False`를 넘기는지(최초 상신·반려 후 재상신 양쪽) mock 기반 mutation-kill 테스트 추가
- [x] `test_1934_push_notification_wiring_realdb.py`: `create_gate()`/`_reopen_rejected_gate()`가 `notify=False`일 때 generic 벨을 스킵하는지 실PG로 검증(신규), 기존 default `notify=True` 테스트는 무회귀 확인
- [x] `test_373cfaa1_doc_notify_dedup_realdb.py`(신규): `transition_doc()` end-to-end — approver당 Notification이 정확히 1건(doc_approval_requested)임을 실PG로 검증, 최초 상신·반려 후 재상신 두 경로 모두
- [x] mutation-kill 확인: doc.py의 `notify=False`를 임시로 제거하고 재실행 → 관련 테스트 RED, 복원 후 GREEN 재확인
- [x] `pytest -k gate`(전체 gate 관련 스위트) 438 passed, 0 failed — 다른 6개 create_gate() 호출부 무회귀
- [x] 로컬 디스포저블 PG(pg16, `Base.metadata.create_all`)로 전량 검증(dev/prod 미접촉)

🤖 Generated with [Claude Code](https://claude.com/claude-code)