### PR TITLE
fix(gate_service): artifact.canonicalized/gate_overridden 알림 outbox 이관 (story #2694)

### DIFF
--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -1125,6 +1125,10 @@ async def _resolve_artifact_canonicalize_gate(session: AsyncSession, gate: Gate,
                 body=f"v{version_number}이(가) 정본으로 확定됐습니다." if version_number else None,
                 reference_type="visual_artifact", reference_id=artifact.id,
                 source_project_id=artifact.project_id,
+                # story #2694: #2688(create_gate 2콜)과 동일 결함 클래스 — 이 호출부(transition_gate
+                # → _resolve_artifact_canonicalize_gate)도 요청의 열린 트랜잭션 커넥션 안에서
+                # 동기 개인 webhook 재시도(최대 3회·1s/2s backoff)를 그대로 문다. outbox 이관.
+                via_outbox=True,
             )
     else:  # rejected — info 재논의(§5: destructive 색 절대 금지). 사유=코멘트로 제안자에게 전파.
         if gate.resolution_note and requested_by:
@@ -1399,6 +1403,9 @@ async def override_gate(
                         session, org_id, gate.work_item_type, gate.work_item_id,
                     )
                 ),
+                # story #2694: #2688과 동일 결함 클래스 — override_gate() 호출부도 요청의 열린
+                # 트랜잭션 커넥션 안에서 동기 개인 webhook 재시도를 문다. outbox 이관.
+                via_outbox=True,
             )
         except Exception:  # noqa: BLE001 — notification 실패는 비중단(override 자체는 성공).
             pass

--- a/backend/tests/test_1934_push_notification_wiring_realdb.py
+++ b/backend/tests/test_1934_push_notification_wiring_realdb.py
@@ -264,3 +264,84 @@ async def test_reopen_rejected_gate_notify_false_suppresses_generic_notification
             dn.assert_not_awaited()
     finally:
         await engine.dispose()
+
+
+# ─── story #2694: gate_service 잔존 동기 dispatch_notification 2콜(#2688과 동일 클래스) ──────
+
+@pytest.mark.anyio
+async def test_resolve_artifact_canonicalize_gate_notification_via_outbox():
+    """artifact.canonicalized 알림(_resolve_artifact_canonicalize_gate, transition_gate 호출부
+    안에서 발화 — 요청의 열린 트랜잭션 커넥션을 무는 동일 결함 클래스)도 via_outbox=True로
+    옮겨졌는지 pin. mutation-kill: via_outbox=True를 빼면 이 assert가 RED가 된다."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from app.models.visual_artifact import VisualArtifact
+    from app.services.gate_service import _resolve_artifact_canonicalize_gate
+
+    org_id = uuid.uuid4()
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            artifact_id = uuid.uuid4()
+            creator_id = uuid.uuid4()
+            s.add(VisualArtifact(
+                id=artifact_id, org_id=org_id, project_id=uuid.uuid4(),
+                title="mock artifact", created_by=creator_id,
+            ))
+            await s.commit()
+
+            gate = MagicMock(
+                work_item_type="visual_artifact", gate_type="artifact_canonicalize",
+                work_item_id=artifact_id, org_id=org_id,
+                neutral_facts={"version_number": 2, "requested_by_member_id": str(creator_id)},
+                resolver_id=uuid.uuid4(),
+            )
+
+            dn = AsyncMock()
+            with patch("app.services.notification_dispatch.dispatch_notification", dn):
+                await _resolve_artifact_canonicalize_gate(s, gate, "approved")
+            dn.assert_awaited_once()
+            assert dn.await_args.kwargs["via_outbox"] is True
+            assert dn.await_args.kwargs["event_type"] == "artifact.canonicalized"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_override_gate_notification_via_outbox():
+    """gate_overridden 알림(override_gate, owner 강제결정 경로)도 via_outbox=True로 옮겨졌는지
+    pin. 발화 조건(targets=requester+bypassed approver)을 채우려면 pending
+    WorkflowLineStepApproval row 1건이 필요(override_gate의 기존 발화 조건 — 이 스토리 스코프
+    밖이라 그대로 재사용). transition_gate 자체(FSM+line 배선)는 이 테스트의 관심사가
+    아니므로 no-op 처리."""
+    from unittest.mock import AsyncMock, patch
+    from app.models.gate import Gate
+    from app.models.workflow_line import WorkflowLineStepApproval
+    from app.services.gate_service import override_gate
+
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            gate_id = uuid.uuid4()
+            s.add(Gate(
+                id=gate_id, org_id=org_id, work_item_id=uuid.uuid4(), work_item_type="task",
+                gate_type="qa", status="pending", requires_human=True,
+            ))
+            s.add(WorkflowLineStepApproval(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id,
+                step_run_id=uuid.uuid4(), gate_id=gate_id, approval_group_id=uuid.uuid4(),
+                approver_member_id=uuid.uuid4(), approver_member_type="human",
+                requested_by_member_id=uuid.uuid4(), status="pending",
+            ))
+            await s.commit()
+
+            dn = AsyncMock()
+            with patch("app.services.gate_service.transition_gate", new=AsyncMock()), \
+                 patch("app.services.notification_dispatch.dispatch_notification", dn):
+                await override_gate(s, org_id, gate_id, uuid.uuid4(), "approved", "긴급 강제결정")
+            dn.assert_awaited_once()
+            assert dn.await_args.kwargs["via_outbox"] is True
+            assert dn.await_args.kwargs["event_type"] == "gate_overridden"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- #2688(PR #3124)과 동일 결함 클래스: `_resolve_artifact_canonicalize_gate()`(artifact.canonicalized)와 `override_gate()`(gate_overridden)의 `dispatch_notification()` 호출이 호출부(둘 다 `transition_gate`/`override_gate` — 요청의 열린 트랜잭션) 안에서 동기 개인 webhook 재시도(최대 3회·1s/2s backoff)를 그대로 물고 있었습니다.
- 두 콜 모두 `via_outbox=True` 추가(기존 create_gate/doc.py와 동일 패턴 재사용).
- AC②(스토리 본문 참고): backend 전역 dispatch_notification 콜사이트 grep 인벤토리 — 잔존 동기 호출 17건을 목록+사유로 스토리에 박제(이 PR 범위 밖, 규모상 별도 백로그 후보).
- AC③: 이 두 경로(artifact_canonicalize approve·gate override)는 휴먼 전용 엔드포인트(`_authorize_gate_approve_equivalent`, 에이전트 403)라 라이브 dev 실측을 에이전트가 직접 트리거할 수 없습니다 — 대체 근거(동일 메커니즘의 기존 dev 실측치 #2687/#2688/e15df4d6: 9s→3.76s→2.53s→0.59s)를 스토리 본문에 명시했습니다.

## Test plan
- [x] `test_1934_push_notification_wiring_realdb.py`: 두 콜 각각 pin 테스트 신규(`test_resolve_artifact_canonicalize_gate_notification_via_outbox`·`test_override_gate_notification_via_outbox`) — 실PG로 `via_outbox=True` 검증
- [x] mutation-kill 확인: 두 곳 모두 `via_outbox=True`를 임시로 제거 → 두 테스트 모두 clean `KeyError` RED, 복원 후 GREEN 재확인
- [x] `pytest -k gate`(전체 gate 관련 스위트) 436 passed, 0 failed — 무회귀
- [x] 로컬 디스포저블 PG(pg16, `Base.metadata.create_all` + `app.models.workflow_line` 명시 import)로 전량 검증(dev/prod 미접촉)

🤖 Generated with [Claude Code](https://claude.com/claude-code)