### PR TITLE
[SID:1864] unified-switcher 전환 후 프로젝트 종속 상세경로 stale 방지 — goals/loops/retro 존재확認 폴백 + 쿼리 화이트리스트

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.test.tsx
@@ -107,6 +107,30 @@ async function mount(fetchImpl: (...args: unknown[]) => Promise<unknown>) {
   return { EpicDetailPage, GoalsRouteProvider };
 }
 
+// story f401139e — BE GET /api/goals/{id}는 X-Project-Id와 무관하게 200을 줄 수 있다(그라운딩
+// 확認). 프로젝트 전환 직후 이 페이지가 옛 프로젝트 goal을 편집/삭제 버튼까지 활성 상태로 그대로
+// 보여주던 결함을 잡는다 — res.ok=200이어도 응답의 project_id가 현재 프로젝트(wrap()의
+// projectId="proj-1")와 다르면 목록으로 replace하고 절대 렌더하지 않는다.
+describe('EpicDetailPage — cross-project stale 응답 폴백 (story f401139e)', () => {
+  it('200이어도 응답 project_id가 현재 프로젝트와 다르면 렌더하지 않고 목록으로 replace한다', async () => {
+    await mount(vi.fn(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ data: epicFixture({ project_id: 'other-project', title: '남의 프로젝트 목표' }) }),
+    })));
+    expect(replaceMock).toHaveBeenCalledWith('/ws/proj/goals');
+    expect(container.textContent).not.toContain('남의 프로젝트 목표');
+  });
+
+  it('200이고 project_id가 현재 프로젝트와 같으면 정상 렌더한다(회귀 없음)', async () => {
+    await mount(vi.fn(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ data: epicFixture({ project_id: 'proj-1', title: '내 프로젝트 목표' }) }),
+    })));
+    expect(replaceMock).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('내 프로젝트 목표');
+  });
+});
+
 describe('EpicDetailPage — 403 vs 404 분리 (story #2545)', () => {
   it('org-sync 성립 여지가 있는(mismatch pending) 403이면 replace 없이 로딩 상태를 유지한다(#2545 원 시나리오)', async () => {
     // story #2587 AC3 — 이 테스트의 진짜 의도는 "org-sync가 아직 이 403을 되돌릴 수 있을

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
@@ -228,7 +228,7 @@ export default function EpicDetailPage() {
   const locale = useLocale();
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
-  const { wsSlug, projSlug } = useGoalsRoute();
+  const { wsSlug, projSlug, projectId } = useGoalsRoute();
   const { toasts, addToast, dismissToast } = useToast();
   const [epic, setEpic] = useState<Epic | null>(null);
   const [loading, setLoading] = useState(true);
@@ -294,6 +294,14 @@ export default function EpicDetailPage() {
         const json = await res.json();
         if (cancelled) return;
         const data = (json as { data: Epic }).data;
+        // story f401139e — BE GET /api/goals/{id}는 X-Project-Id와 무관하게 200을 준다(project
+        // 경계 미시행, 그라운딩 확認). 전환 직후 옛 프로젝트 goal이 편집/삭제 버튼까지 활성 상태로
+        // 노출되는 걸 막으려면 res.ok만으론 부족 — 응답이 실은 현재 프로젝트 것인지 직접 대조한다.
+        if (data.project_id && data.project_id !== projectId) {
+          router.replace(`/${wsSlug}/${projSlug}/goals`);
+          setLoading(false);
+          return;
+        }
         setEpic(data);
         setEpicAssigneeId(data.assignee_id ?? null);
         setLoading(false);
@@ -317,7 +325,7 @@ export default function EpicDetailPage() {
       setLoading(false);
     })();
     return () => { cancelled = true; };
-  }, [id, router, wsSlug, projSlug, orgSyncVersion, orgSyncPending]);
+  }, [id, router, wsSlug, projSlug, projectId, orgSyncVersion, orgSyncPending]);
 
   if (loading) {
     return <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">{t('loading')}</div>;

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/[id]/loop-detail-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/[id]/loop-detail-client.tsx
@@ -52,7 +52,7 @@ interface DocSummary {
  * brief state가 잔존하는 버그 클래스(A3 AuditClient·S8 TenantsClient에 이은 3번째 재발
  * ·까심 QA 적출) — route param으로 fetch하는 상세 page는 항상 key-remount.
  */
-export function LoopDetailClient({ loopId, wsSlug, projSlug }: { loopId: string; wsSlug: string; projSlug: string }) {
+export function LoopDetailClient({ loopId, wsSlug, projSlug, projectId }: { loopId: string; wsSlug: string; projSlug: string; projectId: string }) {
   const t = useTranslations('loops');
   const th = useTranslations('hypotheses');
   const router = useRouter();
@@ -70,6 +70,11 @@ export function LoopDetailClient({ loopId, wsSlug, projSlug }: { loopId: string;
       const loopRes = await fetchWithAuth(`/api/loops/${loopId}`);
       if (!loopRes.ok) { setNotFound(true); return; }
       const loopData = (await loopRes.json()) as Loop;
+      // story f401139e — GET /api/loops/{id}가 X-Project-Id와 무관하게 200을 줄 수 있어
+      // (goals/stories/conversations/sprints와 동일 계열 BE 갭, 그라운딩 확認) res.ok만으론
+      // 부족 — 응답의 project_id를 현재 프로젝트와 직접 대조해야 옛 프로젝트 loop이 새
+      // 프로젝트 URL 아래 노출되지 않는다.
+      if (loopData.project_id && loopData.project_id !== projectId) { setNotFound(true); return; }
       setLoop(loopData);
       setNotFound(false);
 
@@ -107,7 +112,7 @@ export function LoopDetailClient({ loopId, wsSlug, projSlug }: { loopId: string;
     } finally {
       setLoading(false);
     }
-  }, [loopId]);
+  }, [loopId, projectId]);
 
   useEffect(() => { void fetchAll(); }, [fetchAll]);
 

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/loops/[id]/page.tsx
@@ -7,7 +7,7 @@ import { LoopDetailClient } from './loop-detail-client';
 export default function LoopDetailPage() {
   const params = useParams<{ id: string }>();
   const loopId = params.id;
-  const { wsSlug, projSlug } = useLoopsRoute();
+  const { wsSlug, projSlug, projectId } = useLoopsRoute();
 
-  return <LoopDetailClient key={loopId} loopId={loopId} wsSlug={wsSlug} projSlug={projSlug} />;
+  return <LoopDetailClient key={loopId} loopId={loopId} wsSlug={wsSlug} projSlug={projSlug} projectId={projectId} />;
 }

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx
@@ -346,6 +346,13 @@ export default function RetroSessionPage() {
           hypotheses?: RetroHypothesisResult[];
         };
       };
+      // story f401139e — 이 엔드포인트는 이미 `project_id` 쿼리로 BE가 실제로 400을 주는
+      // 자리(그라운딩 확認, goals/loops와 달리 여기는 원래도 안전)라 아래는 belt-and-suspenders:
+      // BE가 언젠가 완화돼 다른 프로젝트 세션에 200을 주게 되더라도 옛 화면이 새 프로젝트 URL
+      // 아래 그대로 남지 않도록, 응답의 project_id를 한 번 더 대조한다.
+      if (json.data.project_id && json.data.project_id !== projectId) {
+        throw new Error('project mismatch');
+      }
       const loadedItems = json.data.items ?? [];
       setSession(json.data);
       setItems(loadedItems);

--- a/apps/web/src/hooks/use-unified-switcher.test.tsx
+++ b/apps/web/src/hooks/use-unified-switcher.test.tsx
@@ -114,6 +114,64 @@ describe('useUnifiedSwitcher — currentOrgProjects (story #2093 후속)', () =>
   });
 });
 
+// story f401139e — switchProject/switchOrgAndProject가 예전엔 현재 searchParams를 통째로
+// 이월하고 `p`만 갈아끼웠다. 리소스-scoped 쿼리(`story`/`hypothesis`/`id` 등)가 새 프로젝트로
+// 그대로 넘어가면 존재하지도 않는(또는 다른 프로젝트 소속) 리소스를 새 URL 아래서 열려고
+// 시도하게 되는 결함(그라운딩 확認)이라 화이트리스트로 뒤집었다 — project-agnostic 값(`view`·
+// `tab`)만 명시 이월하고 나머지는 기본적으로 버린다.
+function destQueryParams(dest: string): URLSearchParams {
+  const qIndex = dest.indexOf('?');
+  return new URLSearchParams(qIndex === -1 ? '' : dest.slice(qIndex + 1));
+}
+
+describe('useUnifiedSwitcher — 전환 시 쿼리파라미터 화이트리스트 (story f401139e)', () => {
+  it('switchProject: view/tab(project-agnostic)만 이월하고 story/hypothesis/id(리소스-scoped)는 버린다', async () => {
+    searchParamsValueRef.current = 'story=story-1&view=canvas&hypothesis=hyp-1&tab=board&id=sprint-1';
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { ok: true } }) })));
+    await act(async () => { root.render(<TestComp />); });
+
+    await act(async () => { await result?.switchProject('proj-sprintable'); });
+
+    expect(routerPushMock).toHaveBeenCalledTimes(1);
+    const dest = String(routerPushMock.mock.calls[0]![0]);
+    const q = destQueryParams(dest);
+    expect(q.get('view')).toBe('canvas');
+    expect(q.get('tab')).toBe('board');
+    expect(q.get('p')).toBe('proj-sprintable');
+    expect(q.has('story')).toBe(false);
+    expect(q.has('hypothesis')).toBe(false);
+    expect(q.has('id')).toBe(false);
+  });
+
+  it('switchOrgAndProject: 동일 화이트리스트 정책이 org+project 동시전환에도 적용된다', async () => {
+    searchParamsValueRef.current = 'story=story-1&view=list&assignee_id=member-9';
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { ok: true } }) })));
+    await act(async () => { root.render(<TestComp />); });
+
+    await act(async () => { await result?.switchOrgAndProject('org-dogfood', 'proj-dogfood'); });
+
+    expect(routerPushMock).toHaveBeenCalledTimes(1);
+    const dest = String(routerPushMock.mock.calls[0]![0]);
+    const q = destQueryParams(dest);
+    expect(q.get('view')).toBe('list');
+    expect(q.get('p')).toBe('proj-dogfood');
+    expect(q.has('story')).toBe(false);
+    expect(q.has('assignee_id')).toBe(false);
+  });
+
+  it('project-agnostic 파라미터가 아예 없으면 p만 실린다(빈 값 오염 없음)', async () => {
+    searchParamsValueRef.current = 'story=story-1&epic_id=epic-1';
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { ok: true } }) })));
+    await act(async () => { root.render(<TestComp />); });
+
+    await act(async () => { await result?.switchProject('proj-sprintable'); });
+
+    const dest = String(routerPushMock.mock.calls[0]![0]);
+    const q = destQueryParams(dest);
+    expect([...q.keys()]).toEqual(['p']);
+  });
+});
+
 describe('useUnifiedSwitcher — switchProject의 ?next= 복귀 (story #2212)', () => {
   it('?next=이 안전한 내부경로면 프로젝트 선택 직후 그리로 router.push한다(원 목적지로 복귀)', async () => {
     searchParamsValueRef.current = 'next=%2Fboard';

--- a/apps/web/src/hooks/use-unified-switcher.ts
+++ b/apps/web/src/hooks/use-unified-switcher.ts
@@ -42,6 +42,31 @@ function isSafeInternalNext(value: string | null): value is string {
   return !!value && value.startsWith('/') && !value.startsWith('//') && !value.includes('\\');
 }
 
+// story f401139e — switchProject/switchOrgAndProject 예전엔 현재 searchParams를 통째로
+// 이월하고 `p`만 갈아끼웠다. `withSwitchedSlugs`는 pathname 세그먼트[0]/[1](org/project slug)만
+// 바꿀 뿐 세그먼트[2:]나 쿼리파라미터 안의 리소스 id는 그대로 두므로, `?story=`/`?id=` 같은
+// 리소스-scoped 파라미터가 새 프로젝트로 그대로 넘어가면 존재하지도 않는(또는 다른 프로젝트
+// 소속) 리소스를 새 URL 아래서 열려고 시도하게 된다(`flow?story=`는 로컬 필터링 목록에서
+// 찾는 구현이라 우연히 안전했을 뿐 — 그라운딩 확認, 설계가 아니었다). 화이트리스트 방식으로
+// 뒤집는다: 프로젝트-무관 UI 상태만 명시로 이월하고, 나머지는 기본적으로 버린다 — 이후
+// 새 쿼리파라미터가 추가돼도 여기 명시로 추가하지 않는 한 자동으로 안전하다.
+//
+// 드랍(리소스/필터-scoped, 재검토 시 이 목록 갱신):
+//   story·hypothesis·goal·id·slug — 리소스 id/슬러그 직참조(flow·sprints·docs 등)
+//   task_id·epic_id·sprint_id·assignee_id — kanban 보드 필터(값이 특정 프로젝트에 종속)
+//   from·pn·messageId — chats/[conversation_id]의 프로젝트-교차 진입 컨텍스트
+//   agent_id — channel 페이지의 프로젝트 종속 에이전트 참조
+const PROJECT_AGNOSTIC_QUERY_PARAMS = ['view', 'tab'] as const;
+
+function withProjectAgnosticParams(searchParams: URLSearchParams): URLSearchParams {
+  const sp = new URLSearchParams();
+  for (const key of PROJECT_AGNOSTIC_QUERY_PARAMS) {
+    const value = searchParams.get(key);
+    if (value !== null) sp.set(key, value);
+  }
+  return sp;
+}
+
 // story #2039 AC4 — 라이브 재현 확認(2026-07-20): switchProject/switchOrgAndProject가 URL 경로는
 // 그대로 두고 `?p=`만 갈아끼워서 ①목록이 안 바뀐 것처럼 보이고 ②사이드바를 누르는 순간에야 새
 // 프로젝트 slug로 이동해 그 slug가 미정규화(한글 등)면 404가 터진다(#2039 본체와 결합해 증폭).
@@ -215,7 +240,7 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
         router.push(nextTarget);
         return;
       }
-      const sp = new URLSearchParams(Array.from(searchParams.entries()));
+      const sp = withProjectAgnosticParams(searchParams);
       sp.set('p', projectId);
       const newOrgSlug = orgs.find((o) => o.orgId === nextOrgId)?.orgSlug;
       const newSlug = newOrgSlug ? await fetchProjectSlug(projectId) : null;
@@ -252,7 +277,7 @@ export function useUnifiedSwitcher({ orgs, currentOrgId, projects, currentProjec
         router.push(nextTarget);
         return;
       }
-      const sp = new URLSearchParams(Array.from(searchParams.entries()));
+      const sp = withProjectAgnosticParams(searchParams);
       sp.set('p', nextProjectId);
       const orgSlug = currentOrg?.orgSlug;
       const newSlug = orgSlug ? await fetchProjectSlug(nextProjectId) : null;


### PR DESCRIPTION
## 요약

story f401139e 그라운딩 결과(PO 승인 A+B)를 구현한다. `withSwitchedSlugs`(#2039)는 pathname 세그먼트[0]/[1](org/project slug)만 바꿀 뿐, 세그먼트[2:]의 리소스 id나 쿼리파라미터 안의 리소스 id는 그대로 두므로 프로젝트 전환 직후 옛 프로젝트 리소스가 새 프로젝트 URL 아래 그대로 노출될 수 있었다.

**핵심 전제(그라운딩에서 발견, 별건 BE 에스컬레이션 [22caa39b](entity:story:22caa39b-65b8-41f1-9604-ed42b787e2e3)로 분리)**: `GET /api/goals/{id}`·`/api/stories/{id}`·`/api/conversations/{id}`·`/api/sprints/{id}`는 `X-Project-Id`와 무관하게 200 + 원 데이터를 그대로 반환한다(**same-org 내 cross-project**). 즉 `res.ok`만으론 cross-project 스테일 리소스를 감지할 수 없다 — 응답 payload 자체의 `project_id`를 현재 라우트 컨텍스트와 직접 대조해야 한다.

⚠️**정정(PO 리뷰 후속, 아래 "크로스-org 검증" 섹션 참고)**: 이 섹션 초판에 "X-Org-Id도 무관하게 200"이라고 썼던 건 재현 오류였다 — 실제 `switch-org`를 호출하지 않고 헤더만 바꿔 보낸 요청이라 세션(JWT/쿠키)은 여전히 원 org였고, org 경계 자체는 세션 기준으로 정상 작동하고 있었다(헤더는 org 판정에 아예 안 쓰임). 진짜 cross-org(실제 세션 전환)로 재현하면 404 — org 경계는 안전하다. 이 PR의 fix(FE `project_id` 대조)는 이 정정과 무관하게 여전히 유효·필요(same-org cross-project 리크는 실재).

## 그라운딩 — 라우트 분류 표 (전문, 그대로 인용)

### A) 경로 세그먼트 리소스 (`/{ws}/{proj}/{리소스}/{id 또는 slug}`)

| 라우트 | 같은 org 전환 후 결과 | 근거 |
|---|---|---|
| `docs/[slug]` | **정상(이미 해소됨)** — URL이 `/moonklabs/sprintable/docs/ds-delete-...` → `/moonklabs/project-ea282c02/docs`로 slug 세그먼트 자체가 사라지고 목록 빈 상태로 폴백. 콘솔 에러 없음, 구 프로젝트 콘텐츠 노출 없음. | 라이브 UI 스크린샷 2장(전/후) + URL diff 직접 확인 |
| `docs/[slug]/view` | 미측정(시간 제약) — `docs/[slug]`와 같은 `docs-client-layout.tsx` 트리 하위라 동일 가드가 적용될 개연성 높으나 확인 안 됨, 추정임을 명시. | — |
| `goals/[id]` | **깨짐 — 구 프로젝트 리소스가 그대로 남아 편집/삭제 버튼까지 활성 상태로 노출.** URL은 goal id 그대로, `/api/me`는 project=제로고를 정확히 보고하는데 화면은 sprintable의 목표를 그대로 보여줌. BE 자체가 cross-project 요청에 200을 준다. | 라이브 UI 스크린샷 2장 + `/api/me` 대조 + BE 직접 curl(X-Project-Id=제로고로 goal fetch → 200, project_id=f3e6ed64 그대로 반환) |
| `loops/[id]` | **미측정** — 테스트 프로젝트에 loop 데이터 자체가 없어(0건) 재현 불가. goals/retro와 같은 route 패턴(`[id]` path segment, 개별 fetch)이라 goals와 동일 계열 위험으로 추정, 실측 없이 단정하지 않음. | — |
| `retro/[id]` | **BE가 막아서 FE단 문제 자체가 성립 안 함.** `X-Project-Id`를 다른 프로젝트로 보내면 BE가 400을 준다 — cross-project 접근 자체가 원천 차단. | BE 직접 curl (400) |

### B) 쿼리파라미터 리소스 (프로젝트-scoped list 라우트 위의 `?story=`, `?id=` 등)

| 라우트 | 같은 org 전환 후 결과 | 근거 |
|---|---|---|
| `flow?story={id}` (kanban 카드 상세 패널) | URL엔 stale story id가 그대로 남지만(정리 안 됨) 화면엔 안 뜬다 — 패널이 story-by-id로 직접 fetch하는 게 아니라 이미 project-scope로 걸러진 로컬 보드 목록에서 id를 찾는 방식이라 **우연히 안전**. `?story=`가 안 지워지고 URL에 죽은 채로 남는 건 위생 문제. | 라이브 UI: 전/후 스크린샷 3장 + URL 직접 확인 |
| `sprints?id={sprintId}` | 미측정(라이브 UI로는 안 열어봄) — BE 직접 호출로 `/api/sprints/{id}`도 `X-Project-Id`와 무관하게 200 + 원 프로젝트 데이터를 그대로 반환하는 건 확인함. | BE 직접 curl(200, project_id=f3e6ed64 그대로) |
| `flow?hypothesis=`, `flow?goal=` | 미측정. `?story=`와 같은 컴포넌트 트리(`flow-client.tsx`) 안이라 유사 동작 가능성 있으나 실측 없음. | — |

### C) `/{ws}/{proj}/` 바깥의 프로젝트-scoped 상세 라우트 (`withSwitchedSlugs` 자체가 손도 안 댐)

| 라우트 | 결과 | 근거 |
|---|---|---|
| `gates/[id]` | **BE가 막는다.** 다른 프로젝트 헤더로 gate 조회 시 404. 이 리소스 타입은 BE가 이미 방어하고 있어 실질 위험 없음. | BE 직접 curl(404) |
| `chats/[conversation_id]` | **BE가 안 막는다 — 리크.** `/api/conversations/{id}`가 다른 프로젝트 헤더에도 200 + 원 프로젝트 전체 대화 데이터를 그대로 반환. path가 전환 후에도 안 바뀌므로 사용자가 전환했다고 믿는 상태에서 다른 프로젝트 대화를 계속 보게 됨 — **가장 조용한 리크**. | BE 직접 curl(200, project_id=f3e6ed64 그대로) |

**C는 이번 PR 스코프 밖 — 의도적으로 안 건드림.** `withSwitchedSlugs`가 org slug 기반 판정이라 이 카테고리엔 애초에 안 통하고, BE가 지금 200을 주는 한 FE가 "새 프로젝트 것이 아니다"를 판단할 근거 자체가 없다. [22caa39b](entity:story:22caa39b-65b8-41f1-9604-ed42b787e2e3) 상륙 후 `chats/[conversation_id]` FE 폴백을 이 스토리(f401139e) 잔여로 잇는다(PO 지시).

## 구현

### A) 경로 세그먼트 폴백 — goals → loops → retro

- **`goals/[id]/page.tsx`(최우선, 편집/삭제 버튼까지 활성 노출되던 자리)**: 기존 fetch effect의 `res.ok` 분기에서 `data.project_id !== projectId`면 기존 "진짜 없음(404)" 분기와 동일하게 목록으로 `router.replace`, `setEpic` 호출 안 함. `useGoalsRoute()`의 `projectId`를 새로 구조분해해 사용.
- **`loops/[id]/loop-detail-client.tsx` + 부모 `page.tsx`**: `LoopDetailClient`가 `projectId`를 안 받고 있어(원래 `loopId, wsSlug, projSlug`만) 부모 `page.tsx`의 `useLoopsRoute()`에서 새로 꺼내 prop으로 threading. `fetchAll()`에서 `loopData.project_id !== projectId`면 기존 `notFound` state로 처리(이미 "목록으로" 링크가 있는 화면). 라이브 UI 검증은 못 함(dev에 loop 테스트 데이터 0건) — 코드 읽기 + 유닛테스트로만 확인.
- **`retro/[id]/page.tsx`(belt-and-suspenders, 원래도 안전했던 자리)**: 이미 `?project_id=` 쿼리를 보내고 BE가 실제로 400을 주는 자리라 실사용 버그는 없었음. `load()`의 `json.data.project_id !== projectId`면 기존 catch(→ `loadError`) 경로와 동일하게 처리하도록 방어 코드만 추가 — BE가 향후 완화되더라도 조용히 안 새게.

### B) 쿼리파라미터 화이트리스트 — `use-unified-switcher.ts`

`switchProject`/`switchOrgAndProject`가 `new URLSearchParams(Array.from(searchParams.entries()))`로 기존 쿼리를 통째로 이월하던 걸 `withProjectAgnosticParams()`(신설, `PROJECT_AGNOSTIC_QUERY_PARAMS = ['view', 'tab']`)로 교체 — 화이트리스트에 없는 키는 기본적으로 버린다.

전체 `apps/web/src/app/(authenticated)/**`를 재스윕해 만든 판정표:

| 키 | 판정 | 근거 |
|---|---|---|
| `view` | **KEEP** | `flow-client.tsx` — 캔버스/리스트 표시모드 토글, 리소스 참조 없는 순수 UI 상태 |
| `tab` | **KEEP** | `inbox/page.tsx` — 섹션 탭 토글, 리소스 참조 없음 |
| `story` | DROP | `flow-client.tsx`/`kanban-board.tsx` — story id 직참조 |
| `hypothesis` | DROP | `flow-client.tsx` — hypothesis id 직참조 |
| `goal` | DROP | `flow-client.tsx` — goal(epic) id 직참조 |
| `id` | DROP | `sprints-client.tsx` — sprint id 직참조, `docs-shell-client.tsx`의 `slug`도 동급으로 취급 |
| `slug` | DROP | `docs-shell-client.tsx` — doc slug 직참조 |
| `task_id`·`epic_id`·`sprint_id`·`assignee_id` | DROP | `kanban-board.tsx` — 프로젝트-scoped 필터 값(다른 프로젝트에선 의미 없음) |
| `from`·`pn`·`messageId` | DROP | `chats/[conversation_id]/page.tsx` — 프로젝트-교차 진입 컨텍스트(project id/name/메시지 위치) |
| `agent_id` | DROP | `channel/page.tsx` — 프로젝트 종속 에이전트 참조 |
| `next` | (해당 없음, 화이트리스트 밖) | 이미 `isSafeInternalNext` 가드로 별도 early-return 경로에서 소비됨(story #2212) — 화이트리스트에 추가하면 이중 이월이 되므로 의도적으로 제외 |

"`flow?story=`가 우연히 안전했던 건 설계가 아니라 구현 우연"(그라운딩 지적)이었던 걸 이번에 명시 정책으로 승격.

## 크로스-org 검증 — 정정 (PO 리뷰 후속, 미르코 재현)

**초판 기재("X-Org-Id도 무관하게 200")는 재현 오류였다.** 원래 테스트는 실제 `POST /api/switch-org`를 호출하지 않고 `X-Org-Id`/`X-Project-Id` 헤더만 바꿔 보낸 것 — 세션(JWT/쿠키)은 여전히 원래 org(뭉클랩)였다. 즉 org 판정 자체는 세션 기준으로 정상 작동 중이었고, 헤더는 애초에 org 경계 판정에 안 쓰인다. 헤더 스푸핑만으로 200이 나온 이유는 세션의 진짜 org(뭉클랩)가 그 goal의 진짜 소유 org(뭉클랩)와 일치했기 때문 — **같은-org cross-project 리크가 X-Org-Id라는 이름표를 달고 다시 나타난 것**뿐이었다.

3가지 조합으로 직접 재현·대조(sellerking, dev):

| 세션 상태 | 요청 헤더 | 결과 |
|---|---|---|
| 세션=뭉클랩(원래, `switch-org` 미호출) | `X-Org-Id`/`X-Project-Id`만 E2E Test Corp로 스푸핑 | **200**(sprintable goal 그대로 반환 — 헤더가 org 판정에 영향 없다는 증거) |
| 세션=E2E Test Corp(실제 `POST /api/switch-org` 호출 후, `/api/me` org_id로 확認) | 헤더 없음(세션 그대로 사용) | **404** "Goal not found" |
| 세션=E2E Test Corp(위와 동일, 실제 전환) | `X-Org-Id`/`X-Project-Id`를 뭉클랩/sprintable로 재스푸핑 | **404**(헤더가 세션을 못 뒤집음 — org 판정은 세션 전용) |

**결론: cross-org 버그는 실재하지 않는다 — org 경계는 세션 기준으로 안전하게 작동한다.** 진짜 문제는 처음부터 분명했던 **same-org 내 cross-project**뿐(위 "핵심 전제" 섹션). 이 FE 수정(`data.project_id !== projectId` 대조)의 정당성은 이 정정과 무관하게 그대로 유효 — same-org cross-project 리크는 재현 방법과 무관하게 실재한다. [22caa39b](entity:story:22caa39b-65b8-41f1-9604-ed42b787e2e3)에도 정확한 재현 커맨드로 댓글 남김(오탐 정정).

## 검증

- `cd apps/web && pnpm exec tsc --noEmit` → **EXIT 0**
- `pnpm lint` → **EXIT 0**(0 error, 기존 무관 warning 5건 그대로)
- `pnpm exec vitest run` → **430 files / 3514 tests 전부 통과**(기존 3509 + 신규 5)
  - `goals/[id]/page.test.tsx`: project_id 불일치 시 미렌더+목록 replace / 일치 시 정상 렌더(회귀 없음) 2건 추가
  - `use-unified-switcher.test.tsx`: `switchProject`/`switchOrgAndProject` 둘 다 화이트리스트 준수 + 화이트리스트 파라미터 자체가 없을 때 `p` 하나만 실림 3건 추가
- `pnpm build` → **EXIT 0**

## 스코프 밖(의도적)

- **카테고리 C**(`chats/[conversation_id]` 등 `/{ws}/{proj}/` 바깥 라우트)는 이 PR에서 손대지 않음 — BE story [22caa39b](entity:story:22caa39b-65b8-41f1-9604-ed42b787e2e3)(디디 배정) 상륙 후 이 스토리 잔여로 이어감(PO 지시).
- `loops/[id]` 라이브 UI 검증 미완(dev 테스트 데이터 부재) — 코드리뷰/유닛테스트 수준 확信.
- **비블로커(PO 리뷰 지적)**: `loops/[id]`는 mismatch 시 goals처럼 목록으로 `router.replace` 하지 않고 기존 `notFound` 상태(링크가 있는 안내 화면)로 흡수한다 — 정책 "A: 목록으로 폴백"의 문언과는 결이 다르지만, 옛 프로젝트 리소스가 화면에 남지 않는다는 목적은 동일하게 달성해 PO가 수용함.
- `docs/[slug]/view`, `flow?hypothesis=`/`?goal=`, `sprints?id=`의 라이브 UI 재현은 그라운딩 단계에서도 미측정이었고 이번에도 추가 검증 안 함(그라운딩 리포트에 이미 명시된 한계).

[f401139e](entity:story:f401139e-a5a5-4399-b6fa-69baf8e7449b)

