### PR TITLE
[SID:2028] Workcell 패널 i18n 배선 (하드코딩 한글 → useTranslations)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3957,5 +3957,29 @@
     "learnMore": "Learn more",
     "previousNotes": "Previous notes",
     "previousNotesListDesc": "Previous release notes"
+  },
+  "workcell": {
+    "briefQuestion": "What · Why (the promise)",
+    "briefGoal": "Goal",
+    "briefDod": "DoD",
+    "briefRoles": "Roles",
+    "briefOwner": "Owner",
+    "briefAgent": "Agent",
+    "runQuestion": "How far · What's needed (current activity, not a progress bar)",
+    "runNow": "Now",
+    "runStage": "Stage",
+    "runTools": "Tools",
+    "runScopes": "Scopes",
+    "runBlocked": "Blocked",
+    "none": "None",
+    "runNextNeed": "Next need",
+    "evidenceQuestion": "Proof (reuses Proof Capsule · done = evidence, not a label)",
+    "evidenceEmpty": "No evidence yet",
+    "conversationQuestion": "Work-scoped thread (not global chat)",
+    "viewRun": "Run",
+    "viewEvidence": "Evidence",
+    "viewDecision": "Decision",
+    "conversationEmpty": "No messages yet",
+    "conversationFooter": "Only directives, decisions, evidence, and change requests scoped to this work. Switching views (Run/Evidence/Decision) = same thread, different lens."
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3957,5 +3957,29 @@
     "learnMore": "자세히 보기",
     "previousNotes": "이전 노트",
     "previousNotesListDesc": "이전 릴리즈 노트 목록"
+  },
+  "workcell": {
+    "briefQuestion": "무엇을 · 왜 (약속)",
+    "briefGoal": "목표",
+    "briefDod": "완료정의",
+    "briefRoles": "권한",
+    "briefOwner": "책임",
+    "briefAgent": "실행",
+    "runQuestion": "어디까지 · 무엇이 필요 (현재 행위, 진행률바 아님)",
+    "runNow": "지금",
+    "runStage": "단계",
+    "runTools": "도구",
+    "runScopes": "권한",
+    "runBlocked": "막힘",
+    "none": "없음",
+    "runNextNeed": "다음 요구",
+    "evidenceQuestion": "증명 (Proof Capsule 재사용 · done=라벨 아니라 증거)",
+    "evidenceEmpty": "아직 증거 없음",
+    "conversationQuestion": "작업-귀속 스레드 (전역 chat 아님)",
+    "viewRun": "실행",
+    "viewEvidence": "증거",
+    "viewDecision": "결정",
+    "conversationEmpty": "아직 메시지가 없습니다",
+    "conversationFooter": "이 작업에 귀속된 지시·판단·증거·수정요청만. 뷰 전환(실행/증거/결정)=같은 스레드 다른 렌즈."
   }
 }

--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -2,7 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
+import type { ReactElement } from 'react';
 import { Workcell, type WorkcellProps } from './workcell';
+
+// Workcell이 useTranslations('workcell')을 쓰므로 렌더에 NextIntlClientProvider 필수.
+// ko 로케일로 감싸 기존 한글 스냅샷 단언을 그대로 유지한다(KO 회귀 대조 = AC3).
+function renderKo(ui: ReactElement): string {
+  return renderToStaticMarkup(
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}
 
 const BASE: WorkcellProps = {
   title: '결제 복구 플로우 — 재시도 로직',
@@ -28,7 +39,7 @@ const BASE: WorkcellProps = {
 
 describe('Workcell (4층 — Brief/Run/Evidence/Conversation)', () => {
   it('renders all four layer labels', () => {
-    const markup = renderToStaticMarkup(<Workcell {...BASE} />);
+    const markup = renderKo(<Workcell {...BASE} />);
     expect(markup).toContain('Brief');
     expect(markup).toContain('Run');
     expect(markup).toContain('Evidence');
@@ -36,13 +47,13 @@ describe('Workcell (4층 — Brief/Run/Evidence/Conversation)', () => {
   });
 
   it('renders the header title and state label together (색만으로 의미 전달 금지)', () => {
-    const markup = renderToStaticMarkup(<Workcell {...BASE} />);
+    const markup = renderKo(<Workcell {...BASE} />);
     expect(markup).toContain(BASE.title);
     expect(markup).toContain('실행 중');
   });
 
   it('renders Brief goal/dod/owner/agent', () => {
-    const markup = renderToStaticMarkup(<Workcell {...BASE} />);
+    const markup = renderKo(<Workcell {...BASE} />);
     expect(markup).toContain('실패한 결제를 재시도로 복구');
     expect(markup).toContain('AC 4 충족');
     expect(markup).toContain('책임 윤재');
@@ -52,7 +63,7 @@ describe('Workcell (4층 — Brief/Run/Evidence/Conversation)', () => {
 
 describe('Workcell Run layer (진행률바 0 — 현재행위+다음요구만)', () => {
   it('renders "지금:" current action and "다음 요구" next-need, never a percentage progress bar', () => {
-    const markup = renderToStaticMarkup(<Workcell {...BASE} />);
+    const markup = renderKo(<Workcell {...BASE} />);
     expect(markup).toContain('지금: 재시도 로직 검증 테스트 작성 중');
     expect(markup).toContain('다음 요구');
     expect(markup).toContain('까심군 QA 리뷰 대기');
@@ -65,17 +76,17 @@ describe('Workcell Run layer (진행률바 0 — 현재행위+다음요구만)',
   });
 
   it('shows "없음" for blocked when null, and the blocked value when present (never hidden — 도크트린 ③)', () => {
-    const clean = renderToStaticMarkup(<Workcell {...BASE} run={{ ...BASE.run, blocked: null }} />);
+    const clean = renderKo(<Workcell {...BASE} run={{ ...BASE.run, blocked: null }} />);
     expect(clean).toContain('없음');
 
-    const blocked = renderToStaticMarkup(<Workcell {...BASE} run={{ ...BASE.run, blocked: '의존 대기 중' }} />);
+    const blocked = renderKo(<Workcell {...BASE} run={{ ...BASE.run, blocked: '의존 대기 중' }} />);
     expect(blocked).toContain('의존 대기 중');
   });
 });
 
 describe('Workcell Evidence layer (Proof Capsule 재사용 · null=정직한 빈 상태)', () => {
   it('shows an honest empty state when evidence is null (no fabricated claim)', () => {
-    const markup = renderToStaticMarkup(<Workcell {...BASE} evidence={null} />);
+    const markup = renderKo(<Workcell {...BASE} evidence={null} />);
     expect(markup).toContain('아직 증거 없음');
   });
 
@@ -103,12 +114,12 @@ describe('Workcell Evidence layer (Proof Capsule 재사용 · null=정직한 빈
 
 describe('Workcell Conversation layer (작업-귀속 · 전역 chat과 분리 · 뷰 가소성)', () => {
   it('shows an honest empty state when there are no messages', () => {
-    const markup = renderToStaticMarkup(<Workcell {...BASE} conversation={{ view: 'run', messages: [] }} />);
+    const markup = renderKo(<Workcell {...BASE} conversation={{ view: 'run', messages: [] }} />);
     expect(markup).toContain('아직 메시지가 없습니다');
   });
 
   it('renders all three view-toggle labels (실행/증거/결정) and the real messages with author+body', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderKo(
       <Workcell
         {...BASE}
         conversation={{

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { ProofAvatar, ProofCapsule, type ProofCapsuleProps, type ProofState } from '@/components/proof-capsule/proof-capsule';
 
@@ -59,9 +60,6 @@ export interface WorkcellProps {
   className?: string;
 }
 
-const VIEW_LABEL: Record<WorkcellConversationView, string> = {
-  run: '실행', evidence: '증거', decision: '결정',
-};
 
 const STATE_TONE: Record<ProofState, string> = {
   blue: 'text-proof-blue', amber: 'text-proof-amber', green: 'text-proof-green', red: 'text-proof-red',
@@ -113,22 +111,23 @@ function LayerLabel({ title, question, className }: { title: string; question: s
 }
 
 function BriefLayer({ brief }: { brief: WorkcellBrief }) {
+  const t = useTranslations('workcell');
   return (
     <div className="border-b border-proof-line-soft px-4.5 py-3.5">
-      <LayerLabel title="Brief" question="무엇을 · 왜 (약속)" className="mb-2.5" />
+      <LayerLabel title="Brief" question={t('briefQuestion')} className="mb-2.5" />
       <div className="flex gap-2 text-[13px] leading-[1.5] text-proof-ink-2">
-        <span className="w-16 shrink-0 pt-px text-[11px] text-proof-faint">목표</span>
+        <span className="w-16 shrink-0 pt-px text-[11px] text-proof-faint">{t('briefGoal')}</span>
         <span className="text-proof-ink">{brief.goal}</span>
       </div>
       <div className="mt-1.5 flex gap-2 text-[13px] leading-[1.5] text-proof-ink-2">
-        <span className="w-16 shrink-0 pt-px text-[11px] text-proof-faint">완료정의</span>
+        <span className="w-16 shrink-0 pt-px text-[11px] text-proof-faint">{t('briefDod')}</span>
         <span className="text-proof-ink">{brief.dod}</span>
       </div>
       <div className="mt-1.5 flex flex-wrap items-center gap-2 gap-y-1.5 text-[13px] leading-[1.5] text-proof-ink-2">
-        <span className="w-16 shrink-0 pt-px text-[11px] text-proof-faint">권한</span>
-        <span className="inline-flex items-center gap-1.5"><ProofAvatar label={brief.owner.name.slice(0, 1)} size={18} />책임 {brief.owner.name}</span>
+        <span className="w-16 shrink-0 pt-px text-[11px] text-proof-faint">{t('briefRoles')}</span>
+        <span className="inline-flex items-center gap-1.5"><ProofAvatar label={brief.owner.name.slice(0, 1)} size={18} />{t('briefOwner')} {brief.owner.name}</span>
         {brief.agent ? (
-          <span className="inline-flex items-center gap-1.5"><ProofAvatar label={brief.agent.initial} isAgent size={18} />실행 {brief.agent.name}</span>
+          <span className="inline-flex items-center gap-1.5"><ProofAvatar label={brief.agent.initial} isAgent size={18} />{t('briefAgent')} {brief.agent.name}</span>
         ) : null}
         {brief.scopes && brief.scopes.length > 0 ? (
           <span className="font-mono text-[10.5px] text-proof-ink-3">{brief.scopes.join(' · ')}</span>
@@ -139,34 +138,36 @@ function BriefLayer({ brief }: { brief: WorkcellBrief }) {
 }
 
 function RunLayer({ run }: { run: WorkcellRun }) {
+  const t = useTranslations('workcell');
   return (
     <div className="border-b border-proof-line-soft px-4.5 py-3.5">
-      <LayerLabel title="Run" question="어디까지 · 무엇이 필요 (현재 행위, 진행률바 아님)" className="mb-2.5" />
-      <div className="mb-2 text-[13.5px] font-semibold text-proof-ink">지금: {run.now}</div>
+      <LayerLabel title="Run" question={t('runQuestion')} className="mb-2.5" />
+      <div className="mb-2 text-[13.5px] font-semibold text-proof-ink">{t('runNow')}: {run.now}</div>
       <div className="mb-2.5 flex flex-wrap gap-3.5 text-[11px] text-proof-ink-3">
-        <span>단계 <b className="font-semibold text-proof-ink-2">{run.stage}</b></span>
-        {run.tools.length > 0 ? <span className="font-mono text-[10.5px]">도구 {run.tools.join(', ')}</span> : null}
-        {run.scopes.length > 0 ? <span className="font-mono text-[10.5px]">권한 {run.scopes.join(', ')}</span> : null}
+        <span>{t('runStage')} <b className="font-semibold text-proof-ink-2">{run.stage}</b></span>
+        {run.tools.length > 0 ? <span className="font-mono text-[10.5px]">{t('runTools')} {run.tools.join(', ')}</span> : null}
+        {run.scopes.length > 0 ? <span className="font-mono text-[10.5px]">{t('runScopes')} {run.scopes.join(', ')}</span> : null}
       </div>
       <div className="mb-2 text-[11.5px] text-proof-ink-3">
-        막힘: <b className={cn('font-semibold', run.blocked ? 'text-proof-amber' : 'text-proof-ink-2')}>{run.blocked ?? '없음'}</b>
+        {t('runBlocked')}: <b className={cn('font-semibold', run.blocked ? 'text-proof-amber' : 'text-proof-ink-2')}>{run.blocked ?? t('none')}</b>
       </div>
       <div className="flex items-center gap-1.5 rounded-[6px] border border-proof-blue/25 bg-proof-blue-soft px-2.5 py-1.5 text-[12.5px] text-proof-blue">
-        → 다음 요구: <b className="font-bold">{run.nextNeed}</b>
+        → {t('runNextNeed')}: <b className="font-bold">{run.nextNeed}</b>
       </div>
     </div>
   );
 }
 
 function EvidenceLayer({ evidence }: { evidence: ProofCapsuleProps | null }) {
+  const t = useTranslations('workcell');
   return (
     <div className="border-b border-proof-line-soft px-4.5 py-3.5">
-      <LayerLabel title="Evidence" question="증명 (Proof Capsule 재사용 · done=라벨 아니라 증거)" className="mb-2.5" />
+      <LayerLabel title="Evidence" question={t('evidenceQuestion')} className="mb-2.5" />
       {evidence ? (
         <ProofCapsule {...evidence} />
       ) : (
         <p className="rounded-[6px] border border-dashed border-proof-line bg-proof-sunk px-3 py-2.5 text-[11.5px] text-proof-faint">
-          아직 증거 없음
+          {t('evidenceEmpty')}
         </p>
       )}
     </div>
@@ -174,11 +175,15 @@ function EvidenceLayer({ evidence }: { evidence: ProofCapsuleProps | null }) {
 }
 
 function ConversationLayer({ conversation }: { conversation: WorkcellConversation }) {
+  const t = useTranslations('workcell');
   const [view, setView] = useState<WorkcellConversationView>(conversation.view);
+  const viewLabel: Record<WorkcellConversationView, string> = {
+    run: t('viewRun'), evidence: t('viewEvidence'), decision: t('viewDecision'),
+  };
   return (
     <div className="px-4.5 py-3.5">
       <div className="mb-2.5 flex items-center gap-2">
-        <LayerLabel title="Conversation" question="작업-귀속 스레드 (전역 chat 아님)" />
+        <LayerLabel title="Conversation" question={t('conversationQuestion')} />
         <div className="ml-auto inline-flex overflow-hidden rounded-[6px] border border-proof-line">
           {(['run', 'evidence', 'decision'] as const).map((v) => (
             <button
@@ -190,13 +195,13 @@ function ConversationLayer({ conversation }: { conversation: WorkcellConversatio
                 v === view ? 'bg-proof-sunk font-semibold text-proof-ink' : 'text-proof-ink-3',
               )}
             >
-              {VIEW_LABEL[v]}
+              {viewLabel[v]}
             </button>
           ))}
         </div>
       </div>
       {conversation.messages.length === 0 ? (
-        <p className="text-[11.5px] text-proof-faint">아직 메시지가 없습니다</p>
+        <p className="text-[11.5px] text-proof-faint">{t('conversationEmpty')}</p>
       ) : (
         <div className="space-y-1">
           {conversation.messages.map((m, i) => (
@@ -211,7 +216,7 @@ function ConversationLayer({ conversation }: { conversation: WorkcellConversatio
         </div>
       )}
       <p className="mt-2 text-[10px] text-proof-faint">
-        이 작업에 귀속된 지시·판단·증거·수정요청만. 뷰 전환(실행/증거/결정)=같은 스레드 다른 렌즈.
+        {t('conversationFooter')}
       </p>
     </div>
   );


### PR DESCRIPTION
## 무엇을

story **SID 2028** «i18n 미적용 파일 3종 소탕» 중 **workcell.tsx** 처리분. `story-detail-panel`에서 렌더되는 Workcell 4층 패널(Brief / Run / Evidence / Conversation)의 하드코딩 한글 22개소를 `useTranslations('workcell')`로 이행한다.

## 왜

`useTranslations` 호출이 0회인데 렌더 문자열이 전량 한글 → EN 로케일에서 목표 상세 우측 패널이 한글로 고정 노출(댄 어윈 v11 촬영 중 실측된 결함 클래스).

## 변경

- `workcell.tsx`: 라벨(목표/완료정의/권한) · 뷰토글(실행/증거/결정) · 레이어 설명(question) · 실행층(지금/단계/도구/막힘/없음/다음 요구) · 빈 상태(증거 없음·메시지 없음) · 푸터 전량 `t()` 경유. 렌더 한글 0(jsdoc 주석만 잔존). 모듈 레벨 `VIEW_LABEL` 상수는 컴포넌트 내부 t() 맵으로 이동.
- `messages/en.json` · `messages/ko.json`: `workcell` 네임스페이스 22키 추가, 양쪽 parity 유지.
- `workcell.test.tsx`: 모든 렌더를 `NextIntlClientProvider(ko)`로 래핑 — 기존 한글 스냅샷 단언이 그대로 KO 회귀 대조(AC3) 역할.

## AC 커버리지

- **AC1** (렌더 문자열 전부 t 경유, ko/en 키 추가): ✅ workcell.tsx 완료. (slash-command는 분리 — 아래.)
- **AC2** (EN 라이브 브라우저 확認, 한글 잔존 0): ⏳ dev 프리뷰 배포 없음 → **머지+dev 배포 反映 後** 라이브 픽셀 확認(카디르 QA + 나). 정적으로는 렌더 한글 0 확認.
- **AC3** (KO 회귀 0): ✅ 테스트가 ko 렌더로 기존 한글 문구 단언 유지.
- **AC4** (dead code `agent-api-keys-section.tsx` 제거): ✅ 이미 삭제됨(파일 부재·정적/동적 참조 0) — 확認만.
- **AC6** (병기 1:1 이관 금지): 해당 없음 — workcell 문자열은 설명형이고 `목표 (Objective)`류 병기 없음.
- **AC7** (기존 키 재사용): 검토함 — workcell 문자열은 범용 어휘(삭제/취소 등)와 겹치지 않아 신규 네임스페이스가 맞음.
- **AC8** (EN 레이아웃 검수): `완료정의` EN 라벨을 **"DoD"**로 축약 — w-16(64px) 라벨 칼럼에 "Definition of Done"은 넘침(디자인 판단). 나머지 라벨(Goal/Roles/Stage 등) 폭 안전.

## 범위 분리

- **SID 2019 · 2084(목표 상세 `goals/[id]/page.tsx`)**: 이미 해소 확認됨(next-intl 배선 완료·EN 라이브 영문 확認). 이 PR 범위 밖.
- **slash-command.tsx(문서 에디터 슬래시 메뉴)**: tiptap Suggestion static 배열 + `createRoot`(React 트리 밖) 팝업이라 훅 직삽 불가 → 팩토리 주입 인프라가 필요(SID 2017이 «인프라 스코프밖»으로 미룬 자리). **미르코군 구현 레인으로 분리**, 스펙 별도 핸드오프.

## 검증

- `vitest run`: workcell.test · i18n-key-coverage · i18n-template-key-coverage · verify-no-i18n-phrase-collision — **38 passed**.
- typecheck: workcell 관련 에러 0.

design 게이트는 self-owned(내 디자인 컴포넌트)이므로 QA(카디르군)만 별도로 청한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
