### PR TITLE
fix(notifications): dispatch_notification via_outbox 클래스 마감 — 17건 전환 + 기본값 flip (story #2696)

### DIFF
--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -500,6 +500,9 @@ async def close_sprint(
                 # story #1953: 이미 `if sprint.project_id and ...`로 non-null 확인된 후라
                 # 신규 조회 없이 그대로 실음.
                 source_project_id=sprint.project_id,
+                # story #2696([클래스 마감]): 요청 트랜잭션 안 동기 webhook POST 결함 클래스
+                # (#2687/#2688/#373cfaa1/#2694) 예방 — outbox 이관.
+                via_outbox=True,
             )
     await _attach_org_project_slugs(db, org_id, [sprint])
     return SprintResponse.model_validate(sprint)

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -2627,6 +2627,8 @@ async def add_comment(
                 "content": content,
                 "author_member_id": str(created_by),
             },
+            # story #2696: outbox 이관(동일 결함 클래스 예방).
+            via_outbox=True,
         )
 
     return CommentResponse.model_validate(comment)

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -254,6 +254,8 @@ async def update_task(
                 # story #1953(P1a-S3): task는 항상 story 소속(story_id NOT NULL) — 신규 조회
                 # 없이 FK 그대로 payload에 실음(향후 story_detail 폴백 승격 발판).
                 story_id=task.story_id,
+                # story #2696: outbox 이관(동일 결함 클래스 예방).
+                via_outbox=True,
             )
     await _attach_has_evidence(db, [task])
     await _attach_org_project_slugs(db, org_id, [task])

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -400,6 +400,8 @@ async def create_team_member(
                 # story #1953: 신규 에이전트(member) 자신의 project_id — TeamMember.project_id
                 # NOT NULL, 신규 조회 없이 그대로 실음.
                 source_project_id=member.project_id,
+                # story #2696: outbox 이관(동일 결함 클래스 예방).
+                via_outbox=True,
             )
 
     # AC3: agent 생성 시 API key 자동 생성 + response에 포함

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -112,6 +112,8 @@ async def _notify_artifact_created(
         body="새 시각 산출물이 생성됐습니다.",
         reference_type="visual_artifact", reference_id=artifact.id,
         source_project_id=project_id,
+        # story #2696: outbox 이관(동일 결함 클래스 예방).
+        via_outbox=True,
     )
 
 
@@ -471,6 +473,8 @@ async def add_artifact_comment(
             reference_type="visual_artifact",
             reference_id=artifact.id,
             source_project_id=project_id,
+            # story #2696: outbox 이관(동일 결함 클래스 예방).
+            via_outbox=True,
         )
 
     return _ok(ArtifactCommentResponse.model_validate(comment).model_dump(mode="json"), status=201)
@@ -804,6 +808,8 @@ async def complete_png_export(
             body="PNG export가 완료됐습니다.",
             reference_type="visual_artifact", reference_id=artifact.id,
             source_project_id=project_id,
+            # story #2696: outbox 이관(동일 결함 클래스 예방).
+            via_outbox=True,
         )
 
     resp = await _export_response(session, export, version_number, container=container)
@@ -869,6 +875,8 @@ async def create_html_export(
             body="HTML export가 완료됐습니다.",
             reference_type="visual_artifact", reference_id=artifact.id,
             source_project_id=project_id,
+            # story #2696: outbox 이관(동일 결함 클래스 예방).
+            via_outbox=True,
         )
 
     resp = await _export_response(session, export, version_number, container=container)
@@ -1057,6 +1065,8 @@ async def _notify_artifact_updated(
             body="artifact가 새 버전으로 갱신됐습니다.",
             reference_type="visual_artifact", reference_id=artifact.id,
             source_project_id=project_id,
+            # story #2696: outbox 이관(동일 결함 클래스 예방).
+            via_outbox=True,
         )
 
 

--- a/backend/app/services/agent_dispatch.py
+++ b/backend/app/services/agent_dispatch.py
@@ -184,6 +184,9 @@ async def _finalize_dispatch(
             # story #1953: project_id는 이미 함수 파라미터로 갖고 있음(신규 조회 0).
             source_project_id=project_id,
             sprint_id=_sprint_id,
+            # story #2696: outbox 이관(동일 결함 클래스 예방) — in-app Event INSERT/
+            # assign_recipient_seq()는 via_outbox와 무관하게 그대로 동기(webhook 배달만 지연).
+            via_outbox=True,
         )
 
     if commit:

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -255,6 +255,8 @@ async def dispatch_approval_result_reply(
                     body=resolution_note or f"'{doc.title}' 문서가 {decision_label}됐습니다.",
                     reference_type="gate", reference_id=gate_id,
                     source_project_id=doc.project_id,
+                    # story #2696: outbox 이관(동일 결함 클래스 예방).
+                    via_outbox=True,
                 )
     except Exception:  # noqa: BLE001 — 벨 알림 실패는 카드 배달과 독립.
         logger.warning(
@@ -342,6 +344,8 @@ async def dispatch_approval_discussion_reply(
                     body=reason or f"'{doc.title}' 문서 결재에 대해 논의를 요청받았습니다.",
                     reference_type="gate", reference_id=gate_id,
                     source_project_id=doc.project_id,
+                    # story #2696: outbox 이관(동일 결함 클래스 예방).
+                    via_outbox=True,
                 )
     except Exception:  # noqa: BLE001 — 벨 알림 실패는 카드 배달과 독립.
         logger.warning(

--- a/backend/app/services/goal_events.py
+++ b/backend/app/services/goal_events.py
@@ -79,6 +79,8 @@ async def _emit(
                 reference_type="epic",
                 reference_id=uuid.UUID(event_data["epic_id"]),
                 source_project_id=uuid.UUID(event_data["project_id"]),
+                # story #2696: outbox 이관(동일 결함 클래스 예방).
+                via_outbox=True,
             )
         except Exception:
             pass

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -57,16 +57,21 @@ async def _deliver_personal_webhooks(
     reference_id: uuid.UUID | None = None,
     context: dict | None = None,
     muted_member_ids: set[uuid.UUID] | None = None,
-    via_outbox: bool = False,
+    via_outbox: bool = True,
 ) -> None:
-    """story #2460(§6 봉합②, PO 스코프 확定 2026-08-05): outbox 경유는 **opt-in**이다
-    (``via_outbox=True``) — dispatch_notification 호출부 중 story_status_events.py·
-    conversations.py send_message(멘션·메시지 알림) 둘만 켠다. 나머지 dispatch_notification
-    호출부는 기본값 False로 기존과 동일하게 즉시 POST한다(behavior 무변경).
-    ``via_outbox=True``면 즉시 POST 대신 `delivery_jobs`에 job row만 insert(caller
-    세션·트랜잭션에 실림, commit은 caller 책임 — at-least-once) — 실 배달은
-    `delivery_dispatcher.py` 워커가 자기 세션으로 `_deliver_personal_webhooks_now()`를
-    수행한다(요청 트랜잭션 밖에서 외부 I/O)."""
+    """story #2696([클래스 마감]) — 기본값을 outbox(``via_outbox=True``)로 뒤집었다.
+    #2687→#2688→#373cfaa1→#2694로 「호출부 트랜잭션 안에서 동기 개인 webhook POST(최대 3회
+    재시도·1s/2s backoff)를 문다」 결함이 4번 반복됐다 — 원인은 인스턴스가 아니라 「기본값이
+    동기」인 것 자체였다(#2696 AC1 그라운딩: 동기 완료를 전제하는 호출부·테스트 0건 확認 후
+    flip). 이제 새 호출부는 아무것도 안 넘겨도 자동으로 안전하다 — 동기가 필요하면
+    ``via_outbox=False``를 **명시**(사유 주석 필수 — 현재 그런 자리 0곳, count-lock 가드로
+    고정: test_2696_via_outbox_default_flip_guard.py 참고).
+
+    ``via_outbox=True``(기본값)면 개인 webhook·Expo push 실배달을 이 호출 안에서 하지 않고
+    outbox(`delivery_jobs`)에 적재만 한다 — in-app Notification/Event INSERT(아래 본문)는
+    원래도 순수 DB write라 이 플래그와 무관하게 그대로 caller의 트랜잭션에 실린다(바꿀 이유
+    없음). 실 배달은 `delivery_dispatcher.py` 워커가 자기 세션으로 별도 수행한다(요청
+    트랜잭션 밖에서 외부 I/O)."""
     if not member_ids:
         return
     if via_outbox:
@@ -228,16 +233,16 @@ async def dispatch_notification(
     context: dict | None = None,
     story_id: uuid.UUID | None = None,
     sprint_id: uuid.UUID | None = None,
-    via_outbox: bool = False,
+    via_outbox: bool = True,
 ) -> None:
     """notification_settings 필터 후 enabled member에게 알림 발송.
 
-    ``via_outbox``(story #2460, §6 봉합②): True면 개인 webhook·Expo push 실배달을 이 호출
-    안에서 하지 않고 outbox(`delivery_jobs`)에 적재만 한다 — in-app Notification/Event
-    INSERT(아래 본문)는 원래도 순수 DB write라 이 플래그와 무관하게 그대로 caller의
-    트랜잭션에 실린다(바꿀 이유 없음). opt-in 스코프는 story_status_events.py·
-    conversations.py send_message 두 콜사이트뿐(PO 확定) — 기본 False로 다른 12+ 콜사이트는
-    behavior 무변경.
+    ``via_outbox``: 기본값 True(story #2696 — 자세한 배경은 `_deliver_personal_webhooks`
+    docstring 참고). True면 개인 webhook·Expo push 실배달을 이 호출 안에서 하지 않고
+    outbox(`delivery_jobs`)에 적재만 한다 — in-app Notification/Event INSERT(아래 본문)는
+    원래도 순수 DB write라 이 플래그와 무관하게 그대로 caller의 트랜잭션에 실린다(바꿀 이유
+    없음). 동기 즉시-POST가 필요한 자리만 ``via_outbox=False``를 명시(사유 주석 필수 — 현재
+    그런 자리 0곳).
 
     human 멤버: Notification 테이블 INSERT (in-app 알림)
     agent 멤버: events 테이블 INSERT (event_type=dispatched, status=pending)

--- a/backend/app/services/story_assignee_events.py
+++ b/backend/app/services/story_assignee_events.py
@@ -190,6 +190,8 @@ async def emit_story_assignee_changed(
                 reference_type="story",
                 reference_id=story.id,
                 source_project_id=story.project_id,
+                # story #2696: outbox 이관(동일 결함 클래스 예방).
+                via_outbox=True,
             )
     if actor_id:
         try:

--- a/backend/app/services/workflow_fallback_notify.py
+++ b/backend/app/services/workflow_fallback_notify.py
@@ -100,6 +100,8 @@ async def fallback_notify(
             reference_type="story", reference_id=story_id,
             # story #1953: sr.project_id NOT NULL — 신규 조회 없이 그대로 실음.
             source_project_id=sr.project_id,
+            # story #2696: outbox 이관(동일 결함 클래스 예방).
+            via_outbox=True,
         )
 
     # idempotent marker(통지 0명이어도 기록 — 재통지 방지). ⭐status 변경 없음(rollback 0).

--- a/backend/app/services/workflow_parallel_approval.py
+++ b/backend/app/services/workflow_parallel_approval.py
@@ -137,6 +137,8 @@ async def _notify_parallel_gate_approvers(
             body=f"{step_run.entity_type} 항목의 {gate.gate_type} 결재가 대기 중입니다.",
             reference_type="gate", reference_id=gate.id,
             source_project_id=step_run.project_id,
+            # story #2696: outbox 이관(동일 결함 클래스 예방).
+            via_outbox=True,
         )
     except Exception:  # noqa: BLE001 — 알림 실패는 게이트 생성 비중단.
         logger.warning("parallel gate 승인자 알림 실패 gate=%s", gate.id, exc_info=True)
@@ -345,6 +347,8 @@ async def reassign_approver(
             # story #1953: target(WorkflowLineStepApproval).project_id NOT NULL — 신규 조회
             # 없이 그대로 실음.
             source_project_id=target.project_id,
+            # story #2696: outbox 이관(동일 결함 클래스 예방).
+            via_outbox=True,
         )
     except Exception:  # noqa: BLE001 — notification 실패는 비중단(재지정 자체는 성공).
         pass

--- a/backend/ee/services/expo_push.py
+++ b/backend/ee/services/expo_push.py
@@ -106,16 +106,14 @@ async def deliver_expo_push(
     project_id: uuid.UUID | None = None,
     story_id: uuid.UUID | None = None,
     sprint_id: uuid.UUID | None = None,
-    via_outbox: bool = False,
+    via_outbox: bool = True,
 ) -> None:
-    """story #2460(§6 봉합②, PO 스코프 확定 2026-08-05): outbox 경유는 **opt-in**이다
-    (``via_outbox=True``) — dispatch_notification 호출부 중 story_status_events.py·
-    conversations.py send_message 둘만 켠다. 나머지 dispatch_notification 호출부는 기본값
-    False로 기존과 동일하게 이 함수 안에서 즉시 발송한다(behavior 무변경).
-    ``via_outbox=True``면 즉시 발송 대신 `delivery_jobs`에 job row만 insert(caller
-    세션·트랜잭션에 실림, commit은 caller 책임 — at-least-once) — 실 발송은
-    `delivery_dispatcher.py` 워커가 자기 세션으로 `_deliver_expo_push_now()`를 수행한다
-    (요청 트랜잭션 밖에서 외부 I/O)."""
+    """story #2696: 기본값 True(자세한 배경은 notification_dispatch._deliver_personal_webhooks
+    docstring 참고) — dispatch_notification의 유일한 호출부가 항상 explicit via_outbox를
+    전달하므로 이 자리는 defense-in-depth. ``via_outbox=True``(기본값)면 즉시 발송 대신
+    `delivery_jobs`에 job row만 insert(caller 세션·트랜잭션에 실림, commit은 caller 책임 —
+    at-least-once) — 실 발송은 `delivery_dispatcher.py` 워커가 자기 세션으로
+    `_deliver_expo_push_now()`를 수행한다(요청 트랜잭션 밖에서 외부 I/O)."""
     if not member_ids:
         return
     if via_outbox:

--- a/backend/tests/test_2460_delivery_outbox.py
+++ b/backend/tests/test_2460_delivery_outbox.py
@@ -1,8 +1,12 @@
 """story #2460(§6 봉합②): 웹훅/푸시 배달 트랜잭셔널 아웃박스 테스트.
 
-PO 확定 스코프(2026-08-05): ①story_status_events ②conversations send_message 두 콜사이트만
-outbox 경유(via_outbox=True) — 나머지 12+ dispatch_notification/fire_webhooks 콜사이트는
-기본값 False로 즉시 배달(behavior 무변경). 이 파일은 그 opt-in 라우팅 자체와, 워커
+원 PO 확定 스코프(2026-08-05): story_status_events·conversations send_message 두 콜사이트만
+opt-in outbox, 나머지는 기본값 False(즉시 배달). story #2696([클래스 마감], 2026-08-16)에서
+이 스코프가 뒤집혔다 — #2687→#2688→#373cfaa1→#2694로 "호출부 트랜잭션 안 동기 webhook POST"
+결함이 4번 반복되며 원인이 "기본값이 동기"인 것 자체로 판명, AC1 그라운딩(동기 완료 전제
+호출부 0건 확認) 후 dispatch_notification의 via_outbox 기본값을 **True**로 뒤집었다 — 이제
+동기가 필요한 자리만 via_outbox=False를 명시한다. fire_webhooks(org_webhook, 이 파일의
+별개 축)는 이 스토리 스코프 밖이라 기본값 False 그대로. 이 파일은 그 라우팅 자체와, 워커
 (delivery_dispatcher.py)의 claim/배달/재시도 FSM을 correctness 축(중복·유실·순서·재시도)으로
 검증한다. ⛔공유 dev 백엔드에 대한 부하테스트는 이 파일 스코프 밖(PO 명시 금지) — 전부
 mock 세션 또는 로컬 PG로만 검증한다.
@@ -119,8 +123,12 @@ async def test_dispatch_notification_via_outbox_propagates_to_both_channels(mock
 
 
 @pytest.mark.anyio
-async def test_dispatch_notification_default_via_outbox_false(mock_session, org_id):
-    """기본값(via_outbox 미지정)이 기존 12+ 콜사이트 계약대로 False로 전파돼야 한다."""
+async def test_dispatch_notification_default_via_outbox_true(mock_session, org_id):
+    """story #2696: 이 테스트는 원래 "기본값=False"를 고정하던 자리였다 — 그 목적 자체가
+    #2696의 flip으로 뒤집혔으므로 은퇴하지 않고 새 계약(기본값=True)으로 개정한다(이름도
+    함께 바꿔 과거 이름이 현재 코드와 모순되는 채로 남지 않게 — Pedro 리뷰 지적,
+    2026-08-16). via_outbox 미지정(기본값)이 _deliver_personal_webhooks에 True로
+    전파되는지가 지금부터의 계약이다."""
     from app.services.notification_dispatch import dispatch_notification
 
     member_id = uuid.uuid4()
@@ -142,7 +150,7 @@ async def test_dispatch_notification_default_via_outbox_false(mock_session, org_
             target_member_ids=[member_id], title="t",
         )
 
-    assert mock_wh.call_args.kwargs["via_outbox"] is False
+    assert mock_wh.call_args.kwargs["via_outbox"] is True
 
 
 # ─── delivery_dispatcher: kind별 라우팅 + 성공/실패 FSM ──────────────────────

--- a/backend/tests/test_2696_explicit_outbox_call_sites.py
+++ b/backend/tests/test_2696_explicit_outbox_call_sites.py
@@ -1,0 +1,78 @@
+"""story #2696(커밋1 — 기본값 flip 없이 안전 착륙분): #2694 AC② 인벤토리가 찾은 잔존 동기
+dispatch_notification 17건 전량에 ``via_outbox=True``를 명시로 전환한다(#2687→#2688→
+#373cfaa1→#2694로 4번 반복된 "호출부 트랜잭션 안 동기 webhook POST" 결함 클래스 마감).
+
+AST 기반 — 각 (파일, 함수) 자리의 dispatch_notification(...) 호출이 실제로 via_outbox=True를
+넘기는지 소스를 직접 스캔한다. 라인번호 변경에 안전하고, 누군가 나중에 이 kwarg를 지우면
+바로 RED가 된다(mutation-kill)."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_APP = Path(__file__).resolve().parent.parent / "app"
+
+# (상대경로, 함수명) — story #2694 AC② 인벤토리의 잔존 17건.
+_CALL_SITES: list[tuple[str, str]] = [
+    ("routers/sprints.py", "close_sprint"),
+    ("routers/tasks.py", "update_task"),
+    ("routers/stories.py", "add_comment"),
+    ("routers/visual_artifacts.py", "_notify_artifact_created"),
+    ("routers/visual_artifacts.py", "add_artifact_comment"),
+    ("routers/visual_artifacts.py", "complete_png_export"),
+    ("routers/visual_artifacts.py", "create_html_export"),
+    ("routers/visual_artifacts.py", "_notify_artifact_updated"),
+    ("routers/team_members.py", "create_team_member"),
+    ("services/workflow_parallel_approval.py", "reassign_approver"),
+    ("services/story_assignee_events.py", "emit_story_assignee_changed"),
+    ("services/workflow_fallback_notify.py", "fallback_notify"),
+    ("services/approval_delivery.py", "dispatch_approval_result_reply"),
+    ("services/approval_delivery.py", "dispatch_approval_discussion_reply"),
+    ("services/workflow_parallel_approval.py", "_notify_parallel_gate_approvers"),
+    ("services/agent_dispatch.py", "_finalize_dispatch"),
+    ("services/goal_events.py", "_emit"),
+]
+
+
+def _dispatch_notification_calls_in_function(rel_path: str, func_name: str) -> list[ast.Call]:
+    src = (_APP / rel_path).read_text(encoding="utf-8")
+    tree = ast.parse(src, filename=rel_path)
+    calls: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == func_name:
+            for sub in ast.walk(node):
+                if (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Name)
+                    and sub.func.id == "dispatch_notification"
+                ):
+                    calls.append(sub)
+    return calls
+
+
+def test_all_2694_inventory_call_sites_exist_and_are_found():
+    """양성대조 — 스캐너 자체가 무력화돼 아래 test가 공허통과하는 것 방지(17곳 전부 최소
+    1개 dispatch_notification 호출을 실제로 찾아내는지)."""
+    missing = []
+    for rel_path, func_name in _CALL_SITES:
+        calls = _dispatch_notification_calls_in_function(rel_path, func_name)
+        if not calls:
+            missing.append(f"{rel_path}:{func_name}")
+    assert not missing, f"dispatch_notification 호출을 못 찾음(함수명/구조 변경?): {missing}"
+
+
+def test_all_17_inventory_call_sites_pass_via_outbox_true():
+    """mutation-kill — 17곳 전부 via_outbox=True를 명시로 넘기는지. 아무 자리에서
+    via_outbox=True를 지우면(또는 False로 바꾸면) 이 assert가 RED가 된다."""
+    violations = []
+    for rel_path, func_name in _CALL_SITES:
+        for call in _dispatch_notification_calls_in_function(rel_path, func_name):
+            has_true = any(
+                kw.arg == "via_outbox" and isinstance(kw.value, ast.Constant) and kw.value.value is True
+                for kw in call.keywords
+            )
+            if not has_true:
+                violations.append(f"{rel_path}:{func_name}:{call.lineno}")
+    assert not violations, (
+        f"via_outbox=True 명시가 빠진 자리(동일 결함 클래스 재발 위험): {violations}"
+    )

--- a/backend/tests/test_2696_via_outbox_default_flip_guard.py
+++ b/backend/tests/test_2696_via_outbox_default_flip_guard.py
@@ -1,0 +1,92 @@
+"""story #2696([클래스 마감]) — dispatch_notification의 via_outbox 기본값을 True로 뒤집었다
+(#2687→#2688→#373cfaa1→#2694로 4번 반복된 "호출부 트랜잭션 안 동기 webhook POST" 결함의
+근본원인이 "기본값이 동기"인 것 자체였다는 판단, AC1 그라운딩으로 동기 완료 전제 호출부 0건
+확認 후 승인).
+
+이 파일은 두 축을 고정한다:
+①signature 축 — 기본값 자체가 True인지(다시 뒤집혀도 즉시 RED).
+②count-lock 축 — backend 전역에서 ``via_outbox=False``를 «명시»하는 자리가 늘지 않는지
+(현재 0곳 — 늘면 그 자리에 사유 주석과 함께 이 baseline을 의식적으로 올려야 한다)."""
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+_BACKEND_APP = Path(__file__).resolve().parent.parent / "app"
+_BACKEND_EE = Path(__file__).resolve().parent.parent / "ee"
+
+# count-lock baseline — 의식적으로만 올린다(늘어나면 왜 필요한지 사유 주석을 그 콜사이트에 남길 것).
+_EXPLICIT_SYNC_OPT_OUT_BASELINE = 0
+
+
+def _find_explicit_via_outbox_false(root: Path) -> list[str]:
+    """AST 기반 — ``via_outbox=False`` 키워드 인자를 넘기는 호출을 전부 찾는다(토큰경계 안전 —
+    substring grep이 아니라 실제 AST Call 노드의 keyword만 본다)."""
+    hits: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        try:
+            src = path.read_text(encoding="utf-8")
+            tree = ast.parse(src, filename=str(path))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for kw in node.keywords:
+                if kw.arg == "via_outbox" and isinstance(kw.value, ast.Constant) and kw.value.value is False:
+                    hits.append(f"{path.relative_to(root.parent)}:{node.lineno}")
+    return hits
+
+
+def test_dispatch_notification_default_via_outbox_is_true():
+    """signature 축 — mock을 어떻게 짜든 이 한 줄이 기본값 회귀를 직접 잡는다."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    default = inspect.signature(dispatch_notification).parameters["via_outbox"].default
+    assert default is True, (
+        "dispatch_notification(via_outbox=...) 기본값이 True가 아니다 — story #2696 flip이 "
+        "되돌려졌다(#2687/#2688/#373cfaa1/#2694와 같은 클래스 재발 위험)."
+    )
+
+
+def test_deliver_personal_webhooks_default_via_outbox_is_true():
+    from app.services.notification_dispatch import _deliver_personal_webhooks
+
+    default = inspect.signature(_deliver_personal_webhooks).parameters["via_outbox"].default
+    assert default is True
+
+
+def test_deliver_expo_push_default_via_outbox_is_true():
+    from ee.services.expo_push import deliver_expo_push
+
+    default = inspect.signature(deliver_expo_push).parameters["via_outbox"].default
+    assert default is True
+
+
+def test_no_new_explicit_sync_opt_out_call_sites():
+    """count-lock 축 — backend/app·backend/ee 전역에서 via_outbox=False 명시 호출이 baseline(0)을
+    넘지 않는지 고정. mutation-kill: 아무 콜사이트에 via_outbox=False를 추가하면 이 테스트가
+    RED가 된다(직접 확인 — 임시로 fixture 파일에 추가해 재현)."""
+    hits = _find_explicit_via_outbox_false(_BACKEND_APP) + _find_explicit_via_outbox_false(_BACKEND_EE)
+    assert len(hits) == _EXPLICIT_SYNC_OPT_OUT_BASELINE, (
+        f"via_outbox=False 명시 호출이 baseline({_EXPLICIT_SYNC_OPT_OUT_BASELINE})을 벗어났다: {hits}\n"
+        "동기가 정말 필요하면 그 콜사이트에 사유 주석을 남기고 이 baseline을 의식적으로 올릴 것."
+    )
+
+
+def test_ast_scan_catches_explicit_false_fixture():
+    """AST 스캐너 자체의 양성대조 — 실제로 via_outbox=False를 넘기는 코드가 있으면 잡히는지
+    고정 fixture 소스로 검증(스캐너가 무력화돼 위 count-lock이 공허통과하는 것 방지)."""
+    import tempfile
+
+    fixture_src = (
+        "async def f():\n"
+        "    await dispatch_notification(db, org_id=x, event_type='y', "
+        "target_member_ids=[], title='t', via_outbox=False)\n"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        (tmp_path / "fixture_mod.py").write_text(fixture_src, encoding="utf-8")
+        hits = _find_explicit_via_outbox_false(tmp_path)
+    assert len(hits) == 1

--- a/backend/tests/test_e_canvas_c0s2_comment_agent_webhook_realdb.py
+++ b/backend/tests/test_e_canvas_c0s2_comment_agent_webhook_realdb.py
@@ -5,6 +5,11 @@
 전달" 전제)하나 그 webhook 발송은 휴먼 전용(_deliver_personal_webhooks·m.type!='agent')이라
 comment.created가 webhook-agent에 **미도달**(죽은 경로). fix: agent(활성 webhook)도 webhook 발송
 (Event-skip 유지·이중배달 0)로 부활.
+
+story #2696: via_outbox 기본값이 True로 바뀌어(outbox 이관) 이 파일이 검증하는 "한 호출 안에서
+webhook까지 도달" 전제(_post_with_retry 직접 캡처)가 깨지므로 via_outbox=False를 명시해
+즉시-배달 경로를 그대로 검증한다 — 이 파일의 관심사는 라우팅 결정(agent도 대상에 포함되는가·
+payload 형식)이지 outbox 자체가 아니다.
 """
 from __future__ import annotations
 
@@ -117,6 +122,7 @@ async def test_comment_created_reaches_agent_webhook():
                     reference_type="story",
                     reference_id=uuid.uuid4(),
                     source_project_id=seeded["project_id"],
+                    via_outbox=False,
                 )
                 await s.commit()
 
@@ -180,6 +186,7 @@ async def test_agent_webhook_payload_carries_reaction_context():
                     reference_type="story", reference_id=story_id, source_project_id=project_id,
                     context={"story_id": str(story_id), "comment_id": str(comment_id),
                              "content": "확인 바람", "author_member_id": str(author_id)},
+                             via_outbox=False,
                 )
                 await s.commit()
 

--- a/backend/tests/test_expo_push_ee.py
+++ b/backend/tests/test_expo_push_ee.py
@@ -2,7 +2,12 @@
 
 발송기 로직: ticket 파싱·배치(≤100)·DeviceNotRegistered→is_active=false·mute 필터·best-effort.
 dispatch_notification 경로 실구동은 test_expo_push_realdb 가 커버.
-"""
+
+story #2696: via_outbox 기본값이 True로 바뀌어(outbox 이관) 이 파일이 검증하는 즉시-발송
+경로(_expo_send_chunk 직접 호출·dead-token 즉시 반영)에 도달하려면 via_outbox=False를
+명시해야 한다 — 이 파일의 관심사는 발송기 자체 메커니즘이지 outbox 라우팅이 아니다. outbox
+경로에서도 동일한 dead-token 처리(_finalize_expo_push_dead_tokens)가 delivery_dispatcher.py
+워커를 통해 수행됨을 확認(코드 read) — 기능 갭 없음, 순수 배달 타이밍만 이관."""
 from __future__ import annotations
 
 import uuid
@@ -150,6 +155,7 @@ async def test_batches_over_100():
     with patch("ee.services.expo_push._expo_send_chunk", new=_fake_chunk):
         await expo.deliver_expo_push(
             db, uuid.uuid4(), [devices[0].member_id], title="T", body="B", event_type="e",
+            via_outbox=False,
         )
     assert sizes == [100, 100, 50]  # 250 → 100/100/50 청크
 
@@ -173,6 +179,7 @@ async def test_deactivates_device_not_registered():
     with patch("ee.services.expo_push._expo_send_chunk", new=_fake_chunk):
         await expo.deliver_expo_push(
             db, uuid.uuid4(), [good.member_id, bad.member_id], title="T", body=None, event_type="e",
+            via_outbox=False,
         )
     # select 1 + update 1 = execute 2회, flush 1회(만료 반영)
     assert db.execute.await_count == 2
@@ -184,7 +191,7 @@ async def test_no_deactivation_when_all_ok():
     dev = _dev("ExponentPushToken[GOOD]")
     db = _mock_db([dev])
     with patch("ee.services.expo_push._expo_send_chunk", new=AsyncMock(return_value=[{"status": "ok"}])):
-        await expo.deliver_expo_push(db, uuid.uuid4(), [dev.member_id], title="T", body="B", event_type="e")
+        await expo.deliver_expo_push(db, uuid.uuid4(), [dev.member_id], title="T", body="B", event_type="e", via_outbox=False)
     # dead 없음 → update/flush 미실행(select 1회만)
     assert db.execute.await_count == 1
     db.flush.assert_not_awaited()
@@ -198,6 +205,7 @@ async def test_skips_when_all_muted():
     with patch("ee.services.expo_push._expo_send_chunk", new=sent):
         await expo.deliver_expo_push(
             db, uuid.uuid4(), [m], title="T", body="B", event_type="e", muted_member_ids={m},
+            via_outbox=False,
         )
     # 전원 mute → 조기 return: device 조회도 발송도 없음
     db.execute.assert_not_awaited()
@@ -209,7 +217,7 @@ async def test_no_send_when_no_devices():
     db = _mock_db([])  # select → 0 devices
     sent = AsyncMock()
     with patch("ee.services.expo_push._expo_send_chunk", new=sent):
-        await expo.deliver_expo_push(db, uuid.uuid4(), [uuid.uuid4()], title="T", body="B", event_type="e")
+        await expo.deliver_expo_push(db, uuid.uuid4(), [uuid.uuid4()], title="T", body="B", event_type="e", via_outbox=False)
     sent.assert_not_awaited()  # 디바이스 0 → 발송 없음
 
 
@@ -233,6 +241,7 @@ async def test_deliver_expo_push_includes_org_project_story_sprint_in_data_paylo
             db, org_id, [dev.member_id], title="T", body="B", event_type="task_completed",
             reference_type="task", reference_id=uuid.uuid4(),
             project_id=project_id, story_id=story_id,
+            via_outbox=False,
         )
     assert len(captured) == 1
     data = captured[0]["data"]
@@ -246,4 +255,4 @@ async def test_best_effort_swallows_exceptions():
     db = AsyncMock()
     db.execute = AsyncMock(side_effect=RuntimeError("db down"))
     # 예외가 전파되면 알림 파이프라인이 되돌려짐 — best-effort 로 삼켜야 함(예외 안 남).
-    await expo.deliver_expo_push(db, uuid.uuid4(), [uuid.uuid4()], title="T", body="B", event_type="e")
+    await expo.deliver_expo_push(db, uuid.uuid4(), [uuid.uuid4()], title="T", body="B", event_type="e", via_outbox=False)

--- a/backend/tests/test_expo_push_realdb.py
+++ b/backend/tests/test_expo_push_realdb.py
@@ -2,7 +2,10 @@
 
 AC1(dispatch_notification 경로 발송·비-EE 무동작) + AC2(DeviceNotRegistered→is_active=false 왕복).
 실 PG + 실 파이프라인(dispatch_notification) 구동, Expo HTTP 만 mock(토큰별 ticket 반환). DB env 없으면 skip.
-"""
+
+story #2696: via_outbox 기본값이 True로 바뀌어 이 테스트가 노리는 "한 요청 안에서 발송+만료
+왕복까지 끝남" 전제가 깨지므로(outbox는 job만 쌓고 실 발송은 delivery_dispatcher 워커가
+별도 폴링으로 함) via_outbox=False를 명시해 즉시-발송 경로를 그대로 검증한다."""
 from __future__ import annotations
 
 import json
@@ -119,6 +122,7 @@ async def test_dispatch_notification_sends_expo_and_expires_dead_token_realdb():
                 await dispatch_notification(
                     s, org_id=ORG, event_type="gate_pending",
                     target_member_ids=[MEMBER_X], title="게이트 대기", body="승인 필요",
+                    via_outbox=False,
                 )
             await s.commit()
 

--- a/backend/tests/test_notification_dispatch.py
+++ b/backend/tests/test_notification_dispatch.py
@@ -1,4 +1,11 @@
-"""E-EVENTBUS P3 S8: 이벤트→알림 설정 필터 엔진 테스트."""
+"""E-EVENTBUS P3 S8: 이벤트→알림 설정 필터 엔진 테스트.
+
+story #2696: 이 파일의 관심사는 설정 필터 엔진(누가 Notification을 받는가)이지 outbox
+배달 메커니즘이 아니다 — 기본값이 via_outbox=True로 바뀌면서 human 대상마다 DeliveryJob
+add()가 하나씩 더 붙어(webhook config 존재 여부와 무관하게, 실제 필터는 워커가 배달
+시점에 함) mock_session.add 카운트 assert가 깨지므로, 모든 호출에 via_outbox=False를
+명시해 이 파일의 검증 범위를 원래대로 좁힌다(outbox 자체는 test_2460_delivery_outbox.py·
+test_2696_via_outbox_default_flip_guard.py가 별도로 고정)."""
 from __future__ import annotations
 
 import uuid
@@ -82,6 +89,7 @@ async def test_disabled_setting_skips_notification(mock_session, org_id):
         event_type="memo_received",
         target_member_ids=[member_id],
         title="테스트 메모",
+        via_outbox=False,
     )
 
     mock_session.add.assert_not_called()
@@ -109,6 +117,7 @@ async def test_no_setting_defaults_to_enabled(mock_session, org_id):
         event_type="memo_received",
         target_member_ids=[member_id],
         title="테스트 메모",
+        via_outbox=False,
     )
 
     mock_session.add.assert_called_once()
@@ -144,6 +153,7 @@ async def test_enabled_setting_creates_notification(mock_session, org_id):
         body="알림 내용",
         reference_type="memo",
         reference_id=uuid.uuid4(),
+        via_outbox=False,
     )
 
     mock_session.add.assert_called_once()
@@ -184,6 +194,7 @@ async def test_grant_only_human_gets_notification(mock_session, org_id):
         body="내용",
         reference_type="epic",
         reference_id=uuid.uuid4(),
+        via_outbox=False,
     )
 
     # org_member.user_id 기반 Notification 생성 (silent drop 아님)
@@ -223,6 +234,7 @@ async def test_human_dispatched_event_gets_delivered_at_stamped(mock_session, or
         body="pending → in-progress",
         reference_type="story",
         reference_id=uuid.uuid4(),
+        via_outbox=False,
     )
     after = datetime.now(timezone.utc)
 
@@ -252,6 +264,7 @@ async def test_empty_target_skips_all(mock_session, org_id):
         event_type="memo_received",
         target_member_ids=[],
         title="빈 대상",
+        via_outbox=False,
     )
 
     mock_session.execute.assert_not_called()
@@ -281,6 +294,7 @@ async def test_mixed_settings_only_enabled_gets_notification(mock_session, org_i
         event_type="memo_received",
         target_member_ids=[member_on, member_off],
         title="복수 대상 테스트",
+        via_outbox=False,
     )
 
     assert mock_session.add.call_count == 1
@@ -310,6 +324,7 @@ async def test_dispatch_dedups_multiproject_view_rows(mock_session, org_id):
         event_type="story_assigned",
         target_member_ids=[member_id],
         title="스토리 담당자로 지정됨",
+        via_outbox=False,
     )
 
     notifs = [c.args[0] for c in mock_session.add.call_args_list if isinstance(c.args[0], Notification)]
@@ -362,6 +377,7 @@ async def test_dispatch_agent_routed_to_source_project(mock_session, org_id, mon
         reference_type="story",
         reference_id=uuid.uuid4(),
         source_project_id=p2,  # 트리거 프로젝트
+        via_outbox=False,
     )
 
     events = [c.args[0] for c in mock_session.add.call_args_list if isinstance(c.args[0], Event)]
@@ -397,6 +413,7 @@ async def test_dispatch_agent_no_source_falls_back_first_row(mock_session, org_i
         title="작업 전달",
         reference_type="story",
         reference_id=uuid.uuid4(),
+        via_outbox=False,
     )
 
     events = [c.args[0] for c in mock_session.add.call_args_list if isinstance(c.args[0], Event)]
@@ -439,6 +456,7 @@ async def test_dispatch_passes_source_project_id_to_expo_push(mock_session, org_
             target_member_ids=[member_id], title="담당자 지정",
             reference_type="story", reference_id=uuid.uuid4(),
             source_project_id=project_id,
+            via_outbox=False,
         )
 
     assert mock_push.await_args.kwargs["project_id"] == project_id
@@ -471,6 +489,7 @@ async def test_dispatch_infers_project_id_when_members_share_single_project(
             mock_session, org_id=org_id, event_type="agent_joined",
             target_member_ids=[member_id], title="새 에이전트",
             reference_type="team_member", reference_id=uuid.uuid4(),
+            via_outbox=False,
         )
 
     assert mock_push.await_args.kwargs["project_id"] == project_id
@@ -509,6 +528,7 @@ async def test_dispatch_project_id_none_when_members_span_multiple_projects(
             mock_session, org_id=org_id, event_type="agent_joined",
             target_member_ids=[m1, m2], title="새 에이전트",
             reference_type="team_member", reference_id=uuid.uuid4(),
+            via_outbox=False,
         )
 
     assert mock_push.await_args.kwargs["project_id"] is None
@@ -536,6 +556,7 @@ async def test_dispatch_passes_story_id_and_sprint_id_through_to_expo_push(mock_
             target_member_ids=[member_id], title="작업 완료",
             reference_type="task", reference_id=uuid.uuid4(),
             story_id=story_id, sprint_id=sprint_id,
+            via_outbox=False,
         )
 
     assert mock_push.await_args.kwargs["story_id"] == story_id

--- a/backend/tests/test_personal_webhook_96af343e.py
+++ b/backend/tests/test_personal_webhook_96af343e.py
@@ -2,7 +2,11 @@
 
 dispatch_notification 이 in-app 만 보내고 개인 WebhookConfig 로 POST 안 하던 것(2겹 근본)을
 옵션 C(flush 타이밍·best-effort)로 보강. agent SSE 경로(route_dispatch_event)는 미변경.
-"""
+
+story #2696: via_outbox 기본값이 True로 바뀌어(outbox 이관) 이 파일이 검증하는 동기 즉시-POST
+경로(_post_with_retry 직접 호출)에 도달하려면 via_outbox=False를 명시해야 한다 — 이 파일의
+관심사가 outbox 자체가 아니라 sync 배달 메커니즘(SSRF·HMAC·Discord 포맷·mute 필터)이라 그대로
+False로 고정한다."""
 from __future__ import annotations
 
 import uuid
@@ -42,7 +46,7 @@ async def test_personal_webhook_posts_for_active_config():
     with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock) as mpost, \
          patch("app.core.ssrf.validate_webhook_url_async", new_callable=AsyncMock):
         mpost.return_value = True
-        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body="B", event_type="story_assigned")
+        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body="B", event_type="story_assigned", via_outbox=False)
     mpost.assert_awaited_once()
     args = mpost.await_args.args
     assert args[0] == cfg.url and args[2] == "sek"  # url, secret
@@ -57,7 +61,7 @@ async def test_personal_webhook_skips_muted():
     db.execute = AsyncMock(side_effect=[_scalars([cfg]), _scalars([cfg.member_id])])  # muted
     with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock) as mpost, \
          patch("app.core.ssrf.validate_webhook_url_async", new_callable=AsyncMock):
-        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body=None, event_type="e")
+        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body=None, event_type="e", via_outbox=False)
     mpost.assert_not_awaited()
 
 
@@ -70,7 +74,7 @@ async def test_personal_webhook_discord_format_no_secret():
     db.execute = AsyncMock(side_effect=[_scalars([cfg]), _scalars([])])
     with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock) as mpost, \
          patch("app.core.ssrf.validate_webhook_url_async", new_callable=AsyncMock):
-        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="Hi", body="x", event_type="e")
+        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="Hi", body="x", event_type="e", via_outbox=False)
     payload, secret = mpost.await_args.args[1], mpost.await_args.args[2]
     assert "content" in payload and secret is None
 
@@ -84,7 +88,7 @@ async def test_personal_webhook_ssrf_reject_skips():
     db.execute = AsyncMock(side_effect=[_scalars([cfg]), _scalars([])])
     with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock) as mpost, \
          patch("app.core.ssrf.validate_webhook_url_async", new_callable=AsyncMock, side_effect=ValueError("blocked")):
-        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body=None, event_type="e")
+        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body=None, event_type="e", via_outbox=False)
     mpost.assert_not_awaited()
 
 
@@ -95,7 +99,7 @@ async def test_personal_webhook_no_config_noop():
     db = AsyncMock()
     db.execute = AsyncMock(side_effect=[_scalars([])])  # no configs
     with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock) as mpost:
-        await _deliver_personal_webhooks(db, org, [uuid.uuid4()], title="T", body=None, event_type="e")
+        await _deliver_personal_webhooks(db, org, [uuid.uuid4()], title="T", body=None, event_type="e", via_outbox=False)
     mpost.assert_not_awaited()
     assert db.execute.await_count == 1  # configs 조회만
 
@@ -110,12 +114,12 @@ async def test_personal_webhook_post_failure_swallowed():
     with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock, side_effect=RuntimeError("boom")), \
          patch("app.core.ssrf.validate_webhook_url_async", new_callable=AsyncMock):
         # 예외 전파 없이 정상 반환해야 함
-        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body=None, event_type="e")
+        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body=None, event_type="e", via_outbox=False)
 
 
 @pytest.mark.anyio
 async def test_empty_member_ids_noop():
     db = AsyncMock()
     db.execute = AsyncMock()
-    await _deliver_personal_webhooks(db, uuid.uuid4(), [], title="T", body=None, event_type="e")
+    await _deliver_personal_webhooks(db, uuid.uuid4(), [], title="T", body=None, event_type="e", via_outbox=False)
     db.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary
#2687→#2688→#373cfaa1→#2694로 4번 반복된 "호출부 트랜잭션 안 동기 webhook POST" 결함 클래스를 마감합니다. 커밋 2개로 분리(로컬 realdb 판정력 한계 때문에 CI를 판정자로 삼기 위함 — PO 승인 방식):

**커밋 1 (`98eb18664`)** — #2694 AC② 인벤토리가 찾은 잔존 동기 dispatch_notification 17건 전량에 `via_outbox=True` 명시 전환(기본값 변경 없음·안전한 착륙분). AST 기반 pin 테스트로 17곳 전부 확인(mutation-kill 로컬 검증).

**커밋 2 (`b8728a024`)** — `dispatch_notification`의 `via_outbox` 기본값을 `True`로 뒤집습니다(2026-08-05 PO 스코프 확定을 뒤집는 결정 — 4회 반복 실증이 그 리스크를 충분히 눌렀다는 판단, 스토리 judgment에 그라운딩 기록). AC1 그라운딩: 동기 완료를 전제하는 호출부 0건 확認(in-app Notification/Event write는 이 플래그와 무관하게 항상 동기 — 외부 webhook/push POST만 지연됨). 로컬 스윕에서 확定 실패였던 3개 테스트 파일(`test_notification_dispatch.py`·`test_personal_webhook_96af343e.py`·`test_2460_delivery_outbox.py`)을 개정했습니다.

**로컬 create_all/alembic 스키마 정합 한계**: 전체 로컬 스윕에서 ~29개 realdb 접미 파일이 "organizations 테이블 없음" 류로 실패했으나, 격리 재실행하면 통과합니다(배치 실행 중 destructive-schema 리셋 테스트가 제 로컬 임시 스키마를 지우고 재구축을 안 해서 생기는 순서 의존 노이즈) — 반복 결함 클래스([테스트인프라] create_all 격리 테스트의 모델 미등재 계보, story 3a4440d9)로 판단, CI(실 마이그 스키마)가 진짜 판정자입니다.

## Test plan
- [x] AST 기반 pin: 17개 콜사이트 전부 `via_outbox=True` 명시 확認(`test_2696_explicit_outbox_call_sites.py`) — mutation-kill 확認
- [x] 기본값 signature pin + count-lock 가드(`test_2696_via_outbox_default_flip_guard.py`) — mutation-kill 확認
- [x] 확定 3개 테스트 파일 개정 + 재검증(28/28 GREEN)
- [x] `test_2460_delivery_outbox.py`의 목적이 뒤집힌 테스트(`default_via_outbox_false`)를 삭제 대신 이름·assert·사유 주석과 함께 개정(`default_via_outbox_true`)
- [x] 로컬 디스포저블 PG로 non-realdb 스윕 736 passed(추가 회귀 0)
- [x] realdb 스윕 실패는 격리 재실행으로 로컬 스키마 정합 문제임을 확認(코드 회귀 아님) — CI가 최종 판정
- [x] dev/prod 미접촉

## AC 잔여
- AC1: 완료(그라운딩 — 스토리 judgment 참고)
- AC2: 완료(commit 1로 17건 전환, 회귀 0 로컬 확認)
- AC3: 카운트락 가드 완료(baseline 0)
- AC4(dev 배포 후 실측 2건): merge/배포 후 착수
- AC5: 남긴 동기 자리 0곳(스토리 본문에 명시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)