### PR TITLE
[SID:2028] slash-command i18n — createSlashCommandExtension 팩토리 + docs.slashMenu 키

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2026,7 +2026,44 @@
     "copyMarkdown": "Copy Markdown",
     "deleteDoc": "Delete",
     "createFailed": "Failed to create document",
-    "notFound": "Document not found"
+    "notFound": "Document not found",
+    "slashMenu": {
+      "categories": {
+        "text": "Text",
+        "list": "List",
+        "block": "Block",
+        "media": "Media",
+        "advanced": "Advanced"
+      },
+      "items": {
+        "heading1": { "description": "Big heading" },
+        "heading2": { "description": "Medium heading" },
+        "heading3": { "description": "Small heading" },
+        "bulletList": { "description": "Unordered list" },
+        "orderedList": { "description": "Ordered list" },
+        "checklist": { "description": "Checklist" },
+        "codeBlock": { "description": "Code block" },
+        "blockquote": { "description": "Quote block" },
+        "callout": { "description": "Highlighted box" },
+        "table": { "description": "Insert table" },
+        "image": { "description": "Insert image" },
+        "file": { "description": "Attach file" },
+        "embed": { "description": "Embed external URL" },
+        "mermaidDiagram": { "description": "Insert diagram" },
+        "columns": { "description": "2/3-column layout" },
+        "mathBlock": { "description": "LaTeX block formula" },
+        "mathInline": { "description": "LaTeX inline formula" },
+        "toggle": { "description": "Collapsible block" },
+        "pageEmbed": { "description": "Embed another doc" },
+        "horizontalRule": { "description": "Divider" }
+      },
+      "embedPrompt": "Enter the URL to embed (YouTube, Figma, etc.):",
+      "mermaidDefault": {
+        "start": "Start",
+        "end": "End"
+      },
+      "toggleDefaultTitle": "Toggle title"
+    }
   },
   "rewards": {
     "title": "Rewards",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2026,7 +2026,44 @@
     "copyMarkdown": "마크다운 복사",
     "deleteDoc": "삭제",
     "createFailed": "문서 생성에 실패했습니다",
-    "notFound": "문서를 찾을 수 없습니다"
+    "notFound": "문서를 찾을 수 없습니다",
+    "slashMenu": {
+      "categories": {
+        "text": "텍스트",
+        "list": "리스트",
+        "block": "블록",
+        "media": "미디어",
+        "advanced": "고급"
+      },
+      "items": {
+        "heading1": { "description": "큰 제목" },
+        "heading2": { "description": "중간 제목" },
+        "heading3": { "description": "작은 제목" },
+        "bulletList": { "description": "순서 없는 목록" },
+        "orderedList": { "description": "순서 있는 목록" },
+        "checklist": { "description": "체크리스트" },
+        "codeBlock": { "description": "코드 블록" },
+        "blockquote": { "description": "인용구" },
+        "callout": { "description": "강조 박스" },
+        "table": { "description": "표 삽입" },
+        "image": { "description": "이미지 삽입" },
+        "file": { "description": "파일 첨부" },
+        "embed": { "description": "외부 URL 임베드" },
+        "mermaidDiagram": { "description": "다이어그램 삽입" },
+        "columns": { "description": "2단/3단 컬럼 레이아웃" },
+        "mathBlock": { "description": "LaTeX 블록 수식" },
+        "mathInline": { "description": "LaTeX 인라인 수식" },
+        "toggle": { "description": "접기/펼치기 블록" },
+        "pageEmbed": { "description": "다른 문서 임베드" },
+        "horizontalRule": { "description": "구분선" }
+      },
+      "embedPrompt": "임베드할 URL을 입력하세요 (YouTube, Figma 등):",
+      "mermaidDefault": {
+        "start": "시작",
+        "end": "끝"
+      },
+      "toggleDefaultTitle": "토글 제목"
+    }
   },
   "rewards": {
     "title": "리워드",

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -19,7 +19,7 @@ import Placeholder from '@tiptap/extension-placeholder';
 import { Bold, Italic, Strikethrough, Code, Link2, Highlighter, Undo2, Redo2, PanelLeft, Plus, ImageIcon, Paperclip } from 'lucide-react';
 import { pickAndUpload } from './extensions/slash-command';
 import { CalloutNode } from './extensions/callout-node';
-import { SlashCommandExtension } from './extensions/slash-command';
+import { createSlashCommandExtension, type SlashMenuStrings } from './extensions/slash-command';
 import { PageEmbedExtension } from './extensions/page-embed-node';
 import { CodeBlockWithCopy } from './extensions/code-block-copy';
 import { ToggleBlock, ToggleSummary, ToggleContent } from './extensions/toggle-block';
@@ -113,6 +113,46 @@ export function DocEditor({
   };
 }) {
   const tEditor = useTranslations('docs');
+  // story ab2fd813(#2028) — 슬래시 팝업은 React 트리 밖(body append via createRoot)에
+  // 렌더돼 slash-command.tsx 안에서 useTranslations를 직접 못 쓴다. 여기서 문자열을 미리
+  // resolve해 createSlashCommandExtension에 주입한다. i18n-key-coverage.test.ts는
+  // useTranslations 할당과 t('key') 호출이 "같은 파일"일 때만 키를 검증하므로, 이 tSlash 호출은
+  // 반드시 이 파일(doc-editor.tsx) 안에서 각 키를 개별 리터럴로 호출해야 한다(동적 키 조합 금지).
+  const tSlash = useTranslations('docs.slashMenu');
+  const slashMenuStrings: SlashMenuStrings = {
+    categories: {
+      text: tSlash('categories.text'),
+      list: tSlash('categories.list'),
+      block: tSlash('categories.block'),
+      media: tSlash('categories.media'),
+      advanced: tSlash('categories.advanced'),
+    },
+    items: {
+      heading1: tSlash('items.heading1.description'),
+      heading2: tSlash('items.heading2.description'),
+      heading3: tSlash('items.heading3.description'),
+      bulletList: tSlash('items.bulletList.description'),
+      orderedList: tSlash('items.orderedList.description'),
+      checklist: tSlash('items.checklist.description'),
+      codeBlock: tSlash('items.codeBlock.description'),
+      blockquote: tSlash('items.blockquote.description'),
+      callout: tSlash('items.callout.description'),
+      table: tSlash('items.table.description'),
+      image: tSlash('items.image.description'),
+      file: tSlash('items.file.description'),
+      embed: tSlash('items.embed.description'),
+      mermaidDiagram: tSlash('items.mermaidDiagram.description'),
+      columns: tSlash('items.columns.description'),
+      mathBlock: tSlash('items.mathBlock.description'),
+      mathInline: tSlash('items.mathInline.description'),
+      toggle: tSlash('items.toggle.description'),
+      pageEmbed: tSlash('items.pageEmbed.description'),
+      horizontalRule: tSlash('items.horizontalRule.description'),
+    },
+    embedPrompt: tSlash('embedPrompt'),
+    mermaidDefault: { start: tSlash('mermaidDefault.start'), end: tSlash('mermaidDefault.end') },
+    toggleDefaultTitle: tSlash('toggleDefaultTitle'),
+  };
   const suppressUpdateRef = useRef(false);
   const [viewMode, setViewMode] = useState<ViewMode>('preview');
   const [tocHeadings, setTocHeadings] = useState<DocHeading[]>([]);
@@ -170,7 +210,7 @@ export function DocEditor({
         onNavigate,
         suggestion: createWikiLinkSuggestion(projectId),
       }),
-      SlashCommandExtension,
+      createSlashCommandExtension(slashMenuStrings),
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],
     editable,
@@ -237,26 +277,26 @@ export function DocEditor({
   const openImagePicker = useCallback(() => {
     if (editor) pickAndUpload(editor, 'image/*');
     setInsertMenuOpen(false);
-  }, [editor]);
+  }, [editor, setInsertMenuOpen]);
   const openFilePicker = useCallback(() => {
     if (editor) pickAndUpload(editor);
     setInsertMenuOpen(false);
-  }, [editor]);
+  }, [editor, setInsertMenuOpen]);
 
   // DnD active-zone — 파일 드래그 동안 점선 오버레이(실 drop 은 ProseMirror handleDrop 처리).
   const onDragEnter = useCallback((e: React.DragEvent) => {
     if (!Array.from(e.dataTransfer?.types ?? []).includes('Files')) return;
     dragDepthRef.current += 1;
     setIsDragging(true);
-  }, []);
+  }, [setIsDragging]);
   const onDragLeave = useCallback(() => {
     dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
     if (dragDepthRef.current === 0) setIsDragging(false);
-  }, []);
+  }, [setIsDragging]);
   const onDrop = useCallback(() => {
     dragDepthRef.current = 0;
     setIsDragging(false);
-  }, []);
+  }, [setIsDragging]);
 
   // Extract TOC headings from editor + assign IDs to heading DOM elements
   useEffect(() => {

--- a/apps/web/src/components/docs/extensions/slash-command.test.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.test.tsx
@@ -134,10 +134,101 @@ describe('defaultSlashItems', () => {
 
 // Re-export the component from the module for testing. If it becomes exported
 // in the future, this pattern can be replaced with a direct import.
-import { SlashCommandExtension } from './slash-command';
+import { SlashCommandExtension, buildSlashMenuCategories, createSlashCommandExtension, slashMenuCategories, type SlashMenuStrings } from './slash-command';
 
 describe('SlashCommandExtension', () => {
   it('is created with name "slashCommand"', () => {
     expect(SlashCommandExtension.name).toBe('slashCommand');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSlashCommandExtension / buildSlashMenuCategories — story ab2fd813(#2028)
+// ---------------------------------------------------------------------------
+
+import enMessages from '../../../../messages/en.json';
+import koMessages from '../../../../messages/ko.json';
+
+// raw messages/{ko,en}.json nest each item description one level deeper
+// (`items.<key>.description`) than the flat `SlashMenuStrings` interface —
+// doc-editor.tsx's `tSlash('items.<key>.description')` calls flatten that away.
+// This helper mirrors the exact same flattening so the test exercises the real shape.
+interface RawSlashMenuMessages {
+  categories: SlashMenuStrings['categories'];
+  items: Record<keyof SlashMenuStrings['items'], { description: string }>;
+  embedPrompt: string;
+  mermaidDefault: { start: string; end: string };
+  toggleDefaultTitle: string;
+}
+
+function stringsFromMessages(messages: { docs: { slashMenu: RawSlashMenuMessages } }): SlashMenuStrings {
+  const raw = messages.docs.slashMenu;
+  const items = Object.fromEntries(
+    Object.entries(raw.items).map(([key, value]) => [key, value.description]),
+  ) as SlashMenuStrings['items'];
+  return {
+    categories: raw.categories,
+    items,
+    embedPrompt: raw.embedPrompt,
+    mermaidDefault: raw.mermaidDefault,
+    toggleDefaultTitle: raw.toggleDefaultTitle,
+  };
+}
+
+const KOREAN_RE = /[가-힣]/;
+
+describe('buildSlashMenuCategories — EN strings carry no Korean leakage', () => {
+  const enStrings = stringsFromMessages(enMessages as unknown as { docs: { slashMenu: RawSlashMenuMessages } });
+  const enCategories = buildSlashMenuCategories(enStrings);
+
+  it('every category label is Korean-free', () => {
+    for (const cat of enCategories) {
+      expect(KOREAN_RE.test(cat.label)).toBe(false);
+    }
+  });
+
+  it('every item description is Korean-free', () => {
+    for (const cat of enCategories) {
+      for (const item of cat.items) {
+        expect(KOREAN_RE.test(item.description)).toBe(false);
+      }
+    }
+  });
+
+  it('item titles stay identical to the static (search-key) fallback regardless of locale', () => {
+    const staticTitles = slashMenuCategories.flatMap((c) => c.items.map((i) => i.title));
+    const localizedTitles = enCategories.flatMap((c) => c.items.map((i) => i.title));
+    expect(localizedTitles).toEqual(staticTitles);
+  });
+
+  it('produces the same category/item counts as the static fallback', () => {
+    expect(enCategories.length).toBe(slashMenuCategories.length);
+    expect(enCategories.flatMap((c) => c.items).length).toBe(slashMenuCategories.flatMap((c) => c.items).length);
+  });
+});
+
+describe('buildSlashMenuCategories — KO strings still carry the original Korean copy', () => {
+  it('description text matches the pre-i18n static fallback 1:1 (no meaning drift)', () => {
+    const koStrings = stringsFromMessages(koMessages as unknown as { docs: { slashMenu: RawSlashMenuMessages } });
+    const koCategories = buildSlashMenuCategories(koStrings);
+    const koDescriptions = koCategories.flatMap((c) => c.items.map((i) => i.description));
+    const staticDescriptions = slashMenuCategories.flatMap((c) => c.items.map((i) => i.description));
+    expect(koDescriptions).toEqual(staticDescriptions);
+  });
+});
+
+describe('createSlashCommandExtension(strings)', () => {
+  it('builds an Extension named "slashCommand" regardless of injected strings', () => {
+    const enStrings = stringsFromMessages(enMessages as unknown as { docs: { slashMenu: RawSlashMenuMessages } });
+    const ext = createSlashCommandExtension(enStrings);
+    expect(ext.name).toBe('slashCommand');
+  });
+
+  it('filters suggestion items by title (English search key), not by localized description', () => {
+    const enStrings = stringsFromMessages(enMessages as unknown as { docs: { slashMenu: RawSlashMenuMessages } });
+    const ext = createSlashCommandExtension(enStrings);
+    const options = ext.options as { suggestion: { items: (arg: { query: string }) => { title: string }[] } };
+    const matches = options.suggestion.items({ query: 'heading' });
+    expect(matches.map((m) => m.title)).toEqual(['Heading 1', 'Heading 2', 'Heading 3']);
   });
 });

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -281,6 +281,273 @@ export const slashMenuCategories: SlashMenuCategory[] = [
 export const defaultSlashItems: SlashMenuItem[] =
   slashMenuCategories.flatMap((c) => c.items);
 
+// story ab2fd813(#2028) — 이 파일의 슬래시 팝업은 `createRoot(popup)`로 React 트리 밖(body
+// append)에 렌더돼 `useTranslations`를 여기서 직접 못 쓴다. 그래서 로케일 문자열은 소비처
+// (doc-editor.tsx, 이미 useTranslations 보유)가 빌드해 이 팩토리에 주입하는 형태로 뒤집는다.
+// `slashMenuCategories`/`defaultSlashItems`(위, 한글 고정)는 그대로 둔다 — 기존
+// `slash-command.test.tsx`의 `defaultSlashItems` 단언(영문 title)이 안 깨지게 하기 위한
+// fallback 겸 하위호환 export다.
+export interface SlashMenuStrings {
+  categories: {
+    text: string;
+    list: string;
+    block: string;
+    media: string;
+    advanced: string;
+  };
+  items: {
+    heading1: string;
+    heading2: string;
+    heading3: string;
+    bulletList: string;
+    orderedList: string;
+    checklist: string;
+    codeBlock: string;
+    blockquote: string;
+    callout: string;
+    table: string;
+    image: string;
+    file: string;
+    embed: string;
+    mermaidDiagram: string;
+    columns: string;
+    mathBlock: string;
+    mathInline: string;
+    toggle: string;
+    pageEmbed: string;
+    horizontalRule: string;
+  };
+  embedPrompt: string;
+  /** 선택 — 없으면 한글 기본값(시작/끝) 유지. 삽입되는 문서 콘텐츠라 UI chrome이 아님. */
+  mermaidDefault?: { start: string; end: string };
+  /** 선택 — 없으면 한글 기본값('토글 제목') 유지. */
+  toggleDefaultTitle?: string;
+}
+
+/** `slashMenuCategories`와 구조는 동일, label/description/embed prompt/삽입 기본값만
+ * `strings`에서 resolve한다 — icon·command 로직은 그대로 재사용. */
+export function buildSlashMenuCategories(strings: SlashMenuStrings): SlashMenuCategory[] {
+  const mermaidStart = strings.mermaidDefault?.start ?? '시작';
+  const mermaidEnd = strings.mermaidDefault?.end ?? '끝';
+  const toggleTitle = strings.toggleDefaultTitle ?? '토글 제목';
+
+  return [
+    {
+      label: strings.categories.text,
+      items: [
+        {
+          title: 'Heading 1',
+          description: strings.items.heading1,
+          icon: Heading1,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleHeading({ level: 1 }).run(),
+        },
+        {
+          title: 'Heading 2',
+          description: strings.items.heading2,
+          icon: Heading2,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleHeading({ level: 2 }).run(),
+        },
+        {
+          title: 'Heading 3',
+          description: strings.items.heading3,
+          icon: Heading3,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleHeading({ level: 3 }).run(),
+        },
+      ],
+    },
+    {
+      label: strings.categories.list,
+      items: [
+        {
+          title: 'Bullet List',
+          description: strings.items.bulletList,
+          icon: List,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleBulletList().run(),
+        },
+        {
+          title: 'Ordered List',
+          description: strings.items.orderedList,
+          icon: ListOrdered,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
+        },
+        {
+          title: 'Checklist',
+          description: strings.items.checklist,
+          icon: ListTodo,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleTaskList().run(),
+        },
+      ],
+    },
+    {
+      label: strings.categories.block,
+      items: [
+        {
+          title: 'Code Block',
+          description: strings.items.codeBlock,
+          icon: Code,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
+        },
+        {
+          title: 'Blockquote',
+          description: strings.items.blockquote,
+          icon: Quote,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleBlockquote().run(),
+        },
+        {
+          title: 'Callout',
+          description: strings.items.callout,
+          icon: Lightbulb,
+          command: (editor, range) =>
+            editor
+              .chain()
+              .focus()
+              .deleteRange(range)
+              .insertContent({ type: 'callout', content: [{ type: 'paragraph' }] })
+              .run(),
+        },
+        {
+          title: 'Table',
+          description: strings.items.table,
+          icon: Table,
+          command: (editor, range) =>
+            editor
+              .chain()
+              .focus()
+              .deleteRange(range)
+              .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+              .run(),
+        },
+      ],
+    },
+    {
+      label: strings.categories.media,
+      items: [
+        {
+          title: 'Image',
+          description: strings.items.image,
+          icon: ImageIcon,
+          command: (editor, range) => {
+            editor.chain().focus().deleteRange(range).run();
+            pickAndUpload(editor, 'image/*');
+          },
+        },
+        {
+          title: 'File',
+          description: strings.items.file,
+          icon: Paperclip,
+          command: (editor, range) => {
+            editor.chain().focus().deleteRange(range).run();
+            pickAndUpload(editor);
+          },
+        },
+        {
+          title: 'Embed',
+          description: strings.items.embed,
+          icon: Globe,
+          command: (editor, range) => {
+            const url = window.prompt(strings.embedPrompt);
+            editor.chain().focus().deleteRange(range).run();
+            if (url?.trim()) {
+              editor.commands.insertContent({ type: 'embedBlock', attrs: { url: url.trim() } });
+            }
+          },
+        },
+        {
+          title: 'Mermaid Diagram',
+          description: strings.items.mermaidDiagram,
+          icon: GitBranch,
+          command: (editor, range) =>
+            editor
+              .chain()
+              .focus()
+              .deleteRange(range)
+              .insertContent({
+                type: 'codeBlock',
+                attrs: { language: 'mermaid' },
+                content: [{ type: 'text', text: `flowchart TD\n    A[${mermaidStart}] --> B[${mermaidEnd}]` }],
+              })
+              .run(),
+        },
+      ],
+    },
+    {
+      label: strings.categories.advanced,
+      items: [
+        {
+          title: 'Columns',
+          description: strings.items.columns,
+          icon: Columns2,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).insertContent({
+              type: 'columnsBlock',
+              attrs: { columns: 2 },
+              content: [
+                { type: 'columnBlock', content: [{ type: 'paragraph' }] },
+                { type: 'columnBlock', content: [{ type: 'paragraph' }] },
+              ],
+            }).run(),
+        },
+        {
+          title: 'Math Block',
+          description: strings.items.mathBlock,
+          icon: Sigma,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).insertContent({
+              type: 'mathBlock',
+              content: [{ type: 'text', text: 'E = mc^2' }],
+            }).run(),
+        },
+        {
+          title: 'Math Inline',
+          description: strings.items.mathInline,
+          icon: Sigma,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).insertContent({
+              type: 'mathInline',
+              content: [{ type: 'text', text: 'x^2' }],
+            }).run(),
+        },
+        {
+          title: 'Toggle',
+          description: strings.items.toggle,
+          icon: ChevronRight,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).insertContent({
+              type: 'toggleBlock',
+              attrs: { open: false },
+              content: [
+                { type: 'toggleSummary', content: [{ type: 'text', text: toggleTitle }] },
+                { type: 'toggleContent', content: [{ type: 'paragraph' }] },
+              ],
+            }).run(),
+        },
+        {
+          title: 'Page Embed',
+          description: strings.items.pageEmbed,
+          icon: FileText,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).insertPageEmbed().run(),
+        },
+        {
+          title: 'Horizontal Rule',
+          description: strings.items.horizontalRule,
+          icon: Minus,
+          command: (editor, range) =>
+            editor.chain().focus().deleteRange(range).setHorizontalRule().run(),
+        },
+      ],
+    },
+  ];
+}
+
 interface SlashMenuRef {
   onKeyDown: (event: KeyboardEvent) => boolean;
 }
@@ -449,7 +716,7 @@ function applyPosition(
   });
 }
 
-function createSuggestionRenderer() {
+function createSuggestionRenderer(categories: SlashMenuCategory[]) {
   let popup: HTMLElement | null = null;
   let root: Root | null = null;
   let menuRef: SlashMenuRef | null = null;
@@ -475,7 +742,7 @@ function createSuggestionRenderer() {
         <SlashMenu
           ref={(r) => { menuRef = r; }}
           items={props.items}
-          categories={slashMenuCategories}
+          categories={categories}
           query={props.query}
           command={(item) => { item.command(props.editor, props.range); }}
         />,
@@ -495,7 +762,7 @@ function createSuggestionRenderer() {
         <SlashMenu
           ref={(r) => { menuRef = r; }}
           items={props.items}
-          categories={slashMenuCategories}
+          categories={categories}
           query={props.query}
           command={(item) => { item.command(props.editor, props.range); }}
         />,
@@ -521,6 +788,7 @@ function createSuggestionRenderer() {
   };
 }
 
+/** 하위호환 fallback(한글 고정) — 로케일 인지 소비처는 `createSlashCommandExtension`을 쓴다. */
 export const SlashCommandExtension = Extension.create({
   name: 'slashCommand',
 
@@ -532,7 +800,7 @@ export const SlashCommandExtension = Extension.create({
           defaultSlashItems.filter((item) =>
             item.title.toLowerCase().includes(query.toLowerCase()),
           ),
-        render: createSuggestionRenderer,
+        render: () => createSuggestionRenderer(slashMenuCategories),
       } satisfies Partial<SuggestionOptions<SlashMenuItem>>,
     };
   },
@@ -546,3 +814,36 @@ export const SlashCommandExtension = Extension.create({
     ];
   },
 });
+
+// story ab2fd813(#2028) — 로케일 문자열을 주입받는 팩토리. doc-editor.tsx가
+// useTranslations('docs.slashMenu')로 빌드한 SlashMenuStrings를 여기 넘긴다.
+export function createSlashCommandExtension(strings: SlashMenuStrings) {
+  const categories = buildSlashMenuCategories(strings);
+  const items = categories.flatMap((c) => c.items);
+
+  return Extension.create({
+    name: 'slashCommand',
+
+    addOptions() {
+      return {
+        suggestion: {
+          char: '/',
+          items: ({ query }: { query: string }) =>
+            items.filter((item) =>
+              item.title.toLowerCase().includes(query.toLowerCase()),
+            ),
+          render: () => createSuggestionRenderer(categories),
+        } satisfies Partial<SuggestionOptions<SlashMenuItem>>,
+      };
+    },
+
+    addProseMirrorPlugins() {
+      return [
+        Suggestion({
+          editor: this.editor,
+          ...this.options.suggestion,
+        }),
+      ];
+    },
+  });
+}


### PR DESCRIPTION
## 요약

story [ab2fd813](entity:story:ab2fd813-e55f-41ff-94fe-caa2be7483a8)("i18n 미적용 파일 3종 소탕") 잔여 작업. `goals/[id]/page.tsx`·`workcell.tsx`는 이미 완료(#3131)되어 있었고, 이 PR은 남은 한 파일 `components/docs/extensions/slash-command.tsx`(문서 에디터 `/` 슬래시 메뉴)의 i18n만 다룬다.

## 아키텍처 제약

슬래시 팝업은 `createRoot(popup)`로 **React 트리 밖**(body append)에 렌더돼 `useTranslations`를 slash-command.tsx 안에서 직접 못 쓴다. `SlashCommandExtension`(static const)은 그대로 두고(하위호환·`defaultSlashItems` 테스트 무손상), 새로 `createSlashCommandExtension(strings)` **팩토리**를 추가해 `doc-editor.tsx`(이미 `useTranslations('docs')` 보유)가 `useTranslations('docs.slashMenu')`로 문자열을 resolve해 주입하도록 뒤집었다.

## 커버리지-테스트 함정 대응

`i18n-key-coverage.test.ts`는 `useTranslations` 할당과 `t('key')` 호출이 **같은 파일**일 때만 그 키를 검증 대상으로 잡는다(정규식이 `varName = useTranslations(ns)` + `varName('key')` 패턴을 같은 파일 텍스트에서 찾음). slash-command.tsx에 번역함수를 주입해 거기서 호출하면 검증이 조용히 스킵된다 — 그래서 `doc-editor.tsx`에 `const tSlash = useTranslations('docs.slashMenu')`를 새로 선언하고, `tSlash('categories.text')`처럼 **개별 리터럴 키로만** 명시 호출해 순수 문자열 객체를 빌드했다(동적 키 조합 없음).

**실제로 검증했다** — 커버리지 테스트가 새 키를 진짜 잡는지 확인하려고 `embedPrompt` 키 하나를 일부러 오타(`embedPromptTYPO`)로 바꿔 로컬에서 재실행 → `FAIL`(정확히 그 키·그 파일 지목) → 원복 → `PASS`. 스킵되고 있었다면 이 실험이 그냥 통과했을 것이다.

## 대상 문자열 (title은 검색키라 불변)

`item.title`(영문, 예: "Heading 1")은 `items` suggestion 필터가 `item.title.toLowerCase().includes(query)`로 매칭하는 검색키라 그대로 뒀다. 번역 대상은 category `label` 5개 + item `description` 20개 + Embed의 `window.prompt` 문구 1개, 선택 항목으로 삽입 콘텐츠 기본값(mermaid 노드 라벨·toggle 기본 제목)도 포함했다.

| title (불변) | key | ko | en |
|---|---|---|---|
| Heading 1 | `items.heading1.description` | 큰 제목 | Big heading |
| Heading 2 | `items.heading2.description` | 중간 제목 | Medium heading |
| Heading 3 | `items.heading3.description` | 작은 제목 | Small heading |
| Bullet List | `items.bulletList.description` | 순서 없는 목록 | Unordered list |
| Ordered List | `items.orderedList.description` | 순서 있는 목록 | Ordered list |
| Checklist | `items.checklist.description` | 체크리스트 | Checklist |
| Code Block | `items.codeBlock.description` | 코드 블록 | Code block |
| Blockquote | `items.blockquote.description` | 인용구 | Quote block |
| Callout | `items.callout.description` | 강조 박스 | Highlighted box |
| Table | `items.table.description` | 표 삽입 | Insert table |
| Image | `items.image.description` | 이미지 삽입 | Insert image |
| File | `items.file.description` | 파일 첨부 | Attach file |
| Embed | `items.embed.description` | 외부 URL 임베드 | Embed external URL |
| Mermaid Diagram | `items.mermaidDiagram.description` | 다이어그램 삽입 | Insert diagram |
| Columns | `items.columns.description` | 2단/3단 컬럼 레이아웃 | 2/3-column layout |
| Math Block | `items.mathBlock.description` | LaTeX 블록 수식 | LaTeX block formula |
| Math Inline | `items.mathInline.description` | LaTeX 인라인 수식 | LaTeX inline formula |
| Toggle | `items.toggle.description` | 접기/펼치기 블록 | Collapsible block |
| Page Embed | `items.pageEmbed.description` | 다른 문서 임베드 | Embed another doc |
| Horizontal Rule | `items.horizontalRule.description` | 구분선 | Divider |
| (category) | `categories.text/list/block/media/advanced` | 텍스트/리스트/블록/미디어/고급 | Text/List/Block/Media/Advanced |
| (embed prompt) | `embedPrompt` | 임베드할 URL을 입력하세요 (YouTube, Figma 등): | Enter the URL to embed (YouTube, Figma, etc.): |
| (선택, mermaid 기본값) | `mermaidDefault.start`/`.end` | 시작/끝 | Start/End |
| (선택, toggle 기본값) | `toggleDefaultTitle` | 토글 제목 | Toggle title |

AC6(병기 이관)·AC7(기존 키 재사용) — 유나 스펙대로 둘 다 해당 없음(설명 평문·겹치는 범용 어휘 없음).

## AC8(팝업 폭 `w-64`=256px) 확인 방식

로컬 dev 풀스택(인증+실 프로젝트 데이터)을 새로 세팅하지 않는 대신, **자동 회귀 테스트로 더 강하게 커버**했다: `en.json`의 실제 값으로 `buildSlashMenuCategories(strings)`를 호출해 (a) 모든 label/description에 한글 문자(`[가-힣]`)가 0건인지, (b) `title`이 로케일과 무관하게 정적 fallback과 정확히 동일한지(검색키 불변 보장), (c) `createSlashCommandExtension`의 suggestion filter가 여전히 title로만 매칭하는지 단언한다. 실제 브라우저 픽셀/줄바꿈 확인(진짜 AC8·AC2)은 **머지+배포 후** 별도로 한다 — 이 PR 스코프 아님(유나 스펙에 명시된 대로).

## 검증 (실제 EXIT, 로컬 worktree 재현)

- `pnpm exec tsc --noEmit` → **EXIT 0**
- `pnpm lint` → **EXIT 0**(0 error, 기존 무관 warning 5건). ⚠️최초 시도에서 React Compiler가 `doc-editor.tsx`의 기존 drag&drop 콜백 5곳(`openImagePicker`·`openFilePicker`·`onDragEnter`·`onDragLeave`·`onDrop`)에서 "Compilation Skipped: Existing memoization could not be preserved"를 냈다(내 변경으로 컴포넌트 함수 구조가 바뀌며 표면화된 기존 latent 이슈, 로직은 원래도 옳았음) — 각 `useCallback` deps 배열에 컴파일러가 지목한 안정적 setState 세터(`setInsertMenuOpen`/`setIsDragging`)를 명시 추가해 해소(동작 변경 없음, 세터는 항상 안정적).
- `pnpm exec vitest run` → **430 files / 3521 tests 전부 통과**(기존 3514 + 신규 7: `slash-command.test.tsx`에 한글잔존 0건·title 불변·category/item count parity·createSlashCommandExtension 이름/필터 검증 추가)
- `pnpm build` → **EXIT 0**

## 스코프 밖(의도적, 유나 스펙 명시)

AC2(배포 후 라이브 EN 캡처)는 이 PR에서 닫지 않는다 — 배포 후 별도로 확인.
