### PR TITLE
[SID:2395] i18n 형제 중복 키 가드 + goals 네임스페이스 중복 2건 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -866,6 +866,12 @@ jobs:
       - name: "Verify no i18n phrase substring collision (story #2367 regression guard)"
         run: pnpm --filter web verify:no-i18n-phrase-collision
 
+      # story #2395 회귀가드: en.json/ko.json 안 같은 부모 객체에 키가 두 번 나오면(JSON
+      # 표준상 마지막 값이 조용히 이기고 에러도 경고도 없음) CI가 잡는다. AC1 실측 4건(전부
+      # `goals` 네임스페이스)을 이 PR에서 이미 제거해 baseline은 0 — 새로 생기는 것만 막는다.
+      - name: "Verify no duplicate sibling i18n keys (story #2395 regression guard)"
+        run: pnpm --filter web verify:no-duplicate-i18n-keys
+
       # story #2420 AC3 회귀가드: globals.css의 `--<family>-tint` 배경 위에서 --foreground가
       # AA(4.5)를 넘는지 «정의 시점»에 계산한다(oklch→sRGB 변환은 Yuna의 실 Chromium canvas
       # 캡처값과 대조 검증된 순수함수 — 브라우저 불요, 빠르고 결정적). 새 계열(예: --info-tint)이

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2873,10 +2873,8 @@
   "goals": {
     "title": "Goals",
     "subtitle": "Manage the big outcomes your workspace is working toward as goals.",
-    "loading": "Loading...",
     "forbiddenTitle": "Access denied",
     "forbiddenDescription": "You don't have permission to view this goal.",
-    "backToList": "Back to list",
     "newGoal": "Add Goal",
     "noProject": "No project selected.",
     "noGoals": "No goals yet",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2873,10 +2873,8 @@
   "goals": {
     "title": "목표",
     "subtitle": "워크스페이스의 주요 목표와 작업 범위를 관리합니다.",
-    "loading": "로딩 중...",
     "forbiddenTitle": "접근 권한 없음",
     "forbiddenDescription": "이 목표를 조회할 권한이 없습니다.",
-    "backToList": "목록으로 돌아가기",
     "newGoal": "목표 추가",
     "noProject": "프로젝트가 선택되지 않았습니다.",
     "noGoals": "아직 목표가 없어요",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "verify:muted-foreground-contrast": "tsx scripts/verify-muted-foreground-contrast.ts",
     "verify:no-muted-foreground-alpha": "tsx scripts/verify-no-muted-foreground-alpha.ts",
     "verify:no-raw-error-message": "tsx scripts/verify-no-raw-error-message.ts",
+    "verify:no-duplicate-i18n-keys": "tsx scripts/verify-no-duplicate-i18n-keys.ts",
     "e2e": "playwright test",
     "e2e:contrast": "playwright test contrast-guard.spec.ts",
     "e2e:ui": "playwright test --ui",

--- a/apps/web/scripts/__fixtures__/clean.json
+++ b/apps/web/scripts/__fixtures__/clean.json
@@ -1,0 +1,10 @@
+{
+  "goals": {
+    "title": "Goals",
+    "loading": "A",
+    "subtitle": "x"
+  },
+  "docs": {
+    "loading": "A"
+  }
+}

--- a/apps/web/scripts/__fixtures__/duplicate.json
+++ b/apps/web/scripts/__fixtures__/duplicate.json
@@ -1,0 +1,8 @@
+{
+  "goals": {
+    "title": "Goals",
+    "loading": "A",
+    "subtitle": "x",
+    "loading": "B"
+  }
+}

--- a/apps/web/scripts/verify-no-duplicate-i18n-keys.test.ts
+++ b/apps/web/scripts/verify-no-duplicate-i18n-keys.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { findDuplicateSiblingKeys, scanLocaleFile } from './verify-no-duplicate-i18n-keys';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// parseJsonPreservingDuplicates는 export 안 함(내부 구현) — findDuplicateSiblingKeys에 직접
+// PairsObject를 만들어 넣는 대신, scanLocaleFile로 실제 파일 스캔 경로를 통째로 검증한다.
+// 순수 판정 로직(findDuplicateSiblingKeys) 단위 테스트는 파서 결과 shape을 손으로 만들어 검증.
+
+describe('findDuplicateSiblingKeys — 순수 판정 함수', () => {
+  it('같은 부모 안 중복 키를 잡는다(값 다름)', () => {
+    const obj = { __pairs: [['a', 1], ['a', 2]] } as never;
+    const findings = findDuplicateSiblingKeys(obj, 'f.json');
+    expect(findings).toEqual([{ file: 'f.json', path: 'a', value1: 1, value2: 2, sameValue: false }]);
+  });
+
+  it('값이 같은 중복도 잡되 sameValue=true로 구분한다', () => {
+    const obj = { __pairs: [['a', 'x'], ['a', 'x']] } as never;
+    const findings = findDuplicateSiblingKeys(obj, 'f.json');
+    expect(findings[0]!.sameValue).toBe(true);
+  });
+
+  it('중첩 객체 안 중복은 부모 경로를 붙여 보고한다', () => {
+    const obj = {
+      __pairs: [['goals', { __pairs: [['loading', 'A'], ['loading', 'B']] }]],
+    } as never;
+    const findings = findDuplicateSiblingKeys(obj, 'f.json');
+    expect(findings).toEqual([{ file: 'f.json', path: 'goals.loading', value1: 'A', value2: 'B', sameValue: false }]);
+  });
+
+  it('다른 부모 밑의 같은 이름 키는 중복이 아니다(진짜 sibling만)', () => {
+    const obj = {
+      __pairs: [
+        ['a', { __pairs: [['loading', 'A']] }],
+        ['b', { __pairs: [['loading', 'B']] }],
+      ],
+    } as never;
+    const findings = findDuplicateSiblingKeys(obj, 'f.json');
+    expect(findings).toEqual([]);
+  });
+
+  it('3번 이상 반복되면 중복 건수만큼(N-1) 잡는다', () => {
+    const obj = { __pairs: [['a', 1], ['a', 2], ['a', 3]] } as never;
+    const findings = findDuplicateSiblingKeys(obj, 'f.json');
+    expect(findings).toHaveLength(2);
+  });
+});
+
+describe('scanLocaleFile — AC4 양성/음성대조(실 파일 파싱 경유)', () => {
+  const fixturesDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+
+  it('양성대조 — sibling 중복이 있는 fixture 파일에서 정확히 잡는다', () => {
+    const findings = scanLocaleFile(path.join(fixturesDir, 'duplicate.json'), 'duplicate.json');
+    expect(findings).toEqual([
+      { file: 'duplicate.json', path: 'goals.loading', value1: 'A', value2: 'B', sameValue: false },
+    ]);
+  });
+
+  it('음성대조 — 정상(중복 없는) fixture 파일은 0건(과잉살상 아님)', () => {
+    const findings = scanLocaleFile(path.join(fixturesDir, 'clean.json'), 'clean.json');
+    expect(findings).toEqual([]);
+  });
+});
+
+// story #2395 AC1 count-lock — 실제 en.json/ko.json에 sibling 중복이 baseline(0)을 넘지
+// 않는지 고정. 이 PR이 실측 4건(goals.loading·goals.backToList, en/ko 각 2쌍)을 이미 제거했다
+// — 새로 생기는 것만 막는다(alembic 형제-PR 가드 story #2401과 동일 관례).
+describe('실 en.json/ko.json — count-lock(baseline 0)', () => {
+  const messagesDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages');
+
+  it('en.json에 sibling 중복 키가 없다', () => {
+    expect(scanLocaleFile(path.join(messagesDir, 'en.json'), 'en.json')).toEqual([]);
+  });
+
+  it('ko.json에 sibling 중복 키가 없다', () => {
+    expect(scanLocaleFile(path.join(messagesDir, 'ko.json'), 'ko.json')).toEqual([]);
+  });
+});

--- a/apps/web/scripts/verify-no-duplicate-i18n-keys.ts
+++ b/apps/web/scripts/verify-no-duplicate-i18n-keys.ts
@@ -1,0 +1,204 @@
+/**
+ * story #2395([결함·FE] i18n 파일 sibling 중복 키) — 같은 부모 객체 안에서 키가 두 번 이상
+ * 나오면(JSON 표준상 마지막 값이 조용히 이긴다·에러도 경고도 없음) CI가 잡는다.
+ *
+ * `JSON.parse`는 이 정보를 근본적으로 못 준다 — 파싱 시점에 이미 마지막 값으로 collapse돼
+ * 있다(V8 내장 파서, object_pairs_hook 같은 훅 없음). 그래서 최소 recursive-descent JSON
+ * 파서를 직접 짜서 객체를 "키-값 쌍의 배열"로 파싱한다(collapse 전 원본 순서 보존) —
+ * `en.json`/`ko.json`이 실제로 이 순수-객체-트리(배열·중첩 문자열 객체) 모양이라 파서
+ * 범위를 그 수준으로 최소화했다(전체 JSON 스펙 아님, 필요한 만큼만).
+ *
+ * AC1 실측(2026-08-17, story #2395): 이 스캐너로 전수한 결과 en.json·ko.json 합쳐 정확히
+ * 4건(양쪽 2쌍씩, 전부 `goals` 네임스페이스) — `goals.loading`(값 같음, 무해)·
+ * `goals.backToList`(값 다름, PO 판정 후 현재 활성값으로 확定). 둘 다 이 PR에서 제거됨 —
+ * baseline은 0에서 시작한다(alembic 형제-PR 가드 story #2401과 동일 관례: 새로 생기는 것만
+ * 막는다, 기존 채무 grandfather 불필요 — 채무 자체가 0이었으므로).
+ *
+ * ⛔이 가드가 «못 잡는» 것(AC6):
+ *   ㉠ 배열 원소 안의 중첩 객체(예: `[{"a":1,"a":2}]`) — 이 코드베이스의 로케일 파일엔 배열이
+ *     안 쓰이지만, 만약 쓰이게 되면 이 파서는 배열 원소를 일반 JSON.parse로 처리해(간소화)
+ *     그 안의 중복은 못 잡는다. 지금은 해당 없음(실측: en/ko 전체에 배열 0개).
+ *   ㉡ 다른 로케일 파일(en/ko 외 새 언어 추가 시) — `LOCALE_FILES` 상수에 수동으로 추가해야
+ *     스캔 대상이 된다. 자동 발견 아님(파일 시스템 glob 대신 명시 목록 — 오타 방지).
+ *   ㉢ 문법 오류(잘린 JSON 등)는 이 스캐너가 아니라 기존 `JSON.parse`(빌드·i18n-key-coverage)가
+ *     먼저 잡는다 — 이 스캐너는 유효한 JSON 안의 sibling 중복만 본다.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MESSAGES_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../messages');
+const LOCALE_FILES = ['en.json', 'ko.json'];
+
+type JsonValue = string | number | boolean | null | JsonValue[] | PairsObject;
+/** 파싱 시점의 원본 [key, value] 배열 — 중복 키가 있으면 같은 key가 두 번 이상 나온다. */
+type PairsObject = { __pairs: [string, JsonValue][] };
+
+class ParseError extends Error {}
+
+function parseJsonPreservingDuplicates(text: string): PairsObject {
+  let i = 0;
+  const n = text.length;
+
+  function skipWs(): void {
+    while (i < n && /\s/.test(text[i]!)) i++;
+  }
+
+  function parseValue(): JsonValue {
+    skipWs();
+    const c = text[i];
+    if (c === '{') return parseObject();
+    if (c === '[') return parseArray();
+    if (c === '"') return parseString();
+    if (text.startsWith('true', i)) { i += 4; return true; }
+    if (text.startsWith('false', i)) { i += 5; return false; }
+    if (text.startsWith('null', i)) { i += 4; return null; }
+    return parseNumber();
+  }
+
+  function parseObject(): PairsObject {
+    i++; // {
+    const pairs: [string, JsonValue][] = [];
+    skipWs();
+    if (text[i] === '}') { i++; return { __pairs: pairs }; }
+    for (;;) {
+      skipWs();
+      const key = parseString();
+      skipWs();
+      if (text[i] !== ':') throw new ParseError(`expected ':' at ${i}`);
+      i++;
+      const value = parseValue();
+      pairs.push([key, value]);
+      skipWs();
+      if (text[i] === ',') { i++; continue; }
+      if (text[i] === '}') { i++; break; }
+      throw new ParseError(`expected ',' or '}' at ${i}`);
+    }
+    return { __pairs: pairs };
+  }
+
+  function parseArray(): JsonValue[] {
+    i++; // [
+    const arr: JsonValue[] = [];
+    skipWs();
+    if (text[i] === ']') { i++; return arr; }
+    for (;;) {
+      arr.push(parseValue());
+      skipWs();
+      if (text[i] === ',') { i++; continue; }
+      if (text[i] === ']') { i++; break; }
+      throw new ParseError(`expected ',' or ']' at ${i}`);
+    }
+    return arr;
+  }
+
+  function parseString(): string {
+    if (text[i] !== '"') throw new ParseError(`expected '"' at ${i}`);
+    i++;
+    let out = '';
+    while (text[i] !== '"') {
+      if (i >= n) throw new ParseError('unterminated string');
+      if (text[i] === '\\') {
+        i++;
+        const esc = text[i];
+        const map: Record<string, string> = { n: '\n', t: '\t', r: '\r', b: '\b', f: '\f', '"': '"', '\\': '\\', '/': '/' };
+        if (esc === 'u') {
+          out += String.fromCharCode(parseInt(text.slice(i + 1, i + 5), 16));
+          i += 5;
+        } else {
+          out += map[esc!] ?? esc!;
+          i++;
+        }
+      } else {
+        out += text[i];
+        i++;
+      }
+    }
+    i++; // closing "
+    return out;
+  }
+
+  function parseNumber(): number {
+    const start = i;
+    while (i < n && /[-+0-9.eE]/.test(text[i]!)) i++;
+    return Number(text.slice(start, i));
+  }
+
+  const result = parseValue();
+  skipWs();
+  if (!(typeof result === 'object' && result !== null && '__pairs' in result)) {
+    throw new ParseError('root is not an object');
+  }
+  return result as PairsObject;
+}
+
+export interface DuplicateFinding {
+  file: string;
+  path: string;
+  value1: JsonValue;
+  value2: JsonValue;
+  sameValue: boolean;
+}
+
+function isPairsObject(v: JsonValue): v is PairsObject {
+  return typeof v === 'object' && v !== null && !Array.isArray(v) && '__pairs' in v;
+}
+
+export function findDuplicateSiblingKeys(pairsObj: PairsObject, filename: string): DuplicateFinding[] {
+  const findings: DuplicateFinding[] = [];
+
+  function walk(obj: PairsObject, prefix: string): void {
+    const seen = new Map<string, JsonValue>();
+    for (const [key, value] of obj.__pairs) {
+      const fullPath = prefix ? `${prefix}.${key}` : key;
+      if (isPairsObject(value)) {
+        walk(value, fullPath);
+      }
+      if (seen.has(key)) {
+        findings.push({
+          file: filename, path: fullPath,
+          value1: seen.get(key)!, value2: value,
+          sameValue: JSON.stringify(seen.get(key)) === JSON.stringify(value),
+        });
+      }
+      seen.set(key, value);
+    }
+  }
+
+  walk(pairsObj, '');
+  return findings;
+}
+
+export function scanLocaleFile(filePath: string, filename: string): DuplicateFinding[] {
+  const text = readFileSync(filePath, 'utf8');
+  const parsed = parseJsonPreservingDuplicates(text);
+  return findDuplicateSiblingKeys(parsed, filename);
+}
+
+function main(): void {
+  const allFindings: DuplicateFinding[] = [];
+  for (const filename of LOCALE_FILES) {
+    const filePath = path.join(MESSAGES_DIR, filename);
+    allFindings.push(...scanLocaleFile(filePath, filename));
+  }
+
+  if (allFindings.length > 0) {
+    console.log(`❌ 같은 부모 안 sibling 중복 키 ${allFindings.length}건 발견:`);
+    for (const f of allFindings) {
+      const marker = f.sameValue ? '(값 같음 — 무해하나 죽은 무게)' : '(값 다름 — ⚠️ 화면에 안 뜨는 문구가 있다)';
+      console.log(`  - ${f.file} :: "${f.path}" ${marker}`);
+      if (!f.sameValue) {
+        console.log(`      값1(죽음): ${JSON.stringify(f.value1)}`);
+        console.log(`      값2(활성): ${JSON.stringify(f.value2)}`);
+      }
+    }
+    console.log('\n→ 중복 중 하나를 지워라(값이 다르면 어느 쪽이 정본인지 먼저 판정 — story #2395 참고).');
+    process.exit(1);
+  }
+
+  console.log(`OK: ${LOCALE_FILES.join(', ')} 전부 sibling 중복 키 0건`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## 요약
- AC1(전수): `en.json`·`ko.json`을 표준 JSON 파서가 collapse하기 전 원본으로 재파싱(중복 키를 배열로 보존하는 커스텀 파서)해 sibling 중복을 전수 스캔 — 정확히 4건(양쪽 파일 각 2쌍), 전부 `goals` 네임스페이스. 다른 네임스페이스 0건.
- AC2(값 다른 것): `goals.loading`은 값 동일(무해). `goals.backToList`는 값이 다름("Back to list"/"Back", "목록으로 돌아가기"/"목록으로") — PO 판정: 현재 실제 화면에 뜨는 값(JSON 마지막-값-승리 규칙상 짧은 쪽)을 정본으로 확定, 중복 제거. 실사용 3곳(`goals-client.tsx`·`goals/[id]/page.tsx` 2곳) 전부 이미 이 값을 보고 있어 **렌더 결과 무변경**.
- AC3: `apps/web/scripts/verify-no-duplicate-i18n-keys.ts` 신설(CI 가드, `ci.yml`에 배선) — 커스텀 recursive-descent JSON 파서로 sibling 중복을 재귀 스캔.
- AC4: 유닛테스트(순수 판정 함수 5건) + fixture 양성/음성대조(정상 파일 오탐 0) + 실 파일 count-lock(baseline 0) + 라이브 뮤테이션(더미 중복 주입 → EXIT 1 → 제거 → EXIT 0, 로컬 재현).
- AC5: "편집 도구가 조용히 collapse" 리스크는 CI 가드로 닫는다(PO 판정) — 사람이 특정 도구를 안 쓰기로 기억하는 방식 대신, 어떤 도구로 편집됐든 커밋 시점에 CI가 막는다.
- AC6: 못 잡는 것 — 배열 안 중첩 객체(현재 로케일 파일엔 배열 0개, 해당없음) · en/ko 외 새 로케일(수동으로 `LOCALE_FILES`에 추가해야 함) · 문법 오류(기존 JSON.parse/i18n-key-coverage가 먼저 잡음).

## 검증
- `pnpm exec vitest run scripts/verify-no-duplicate-i18n-keys.test.ts` — 9/9 통과.
- 전체 `pnpm exec vitest run` — 431 files / 3530 tests 전부 통과.
- `pnpm exec tsc --noEmit` — 0 error.
- `pnpm lint` — 0 error(기존 무관 warning 5건).
- 라이브 뮤테이션: `en.json`에 더미 중복 키 주입 → 가드 `EXIT 1`(정확한 위치 지목) → 제거 → `EXIT 0`.

## 근거
story #2395 description에 그라운딩·AC1/AC2 실측 표·backToList 사용처 3곳 대조 전문 기록. PO 판정(org.moonklabs.work.decision, 2026-08-16)으로 처방 승인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)