### PR TITLE
[SID:2679] 채팅 #엔티티 피커 — 능동 탐색 없는 Enter는 수락 안 함(전송 키 충돌 fix)

### DIFF
--- a/apps/web/src/components/chat/chat-input-entity-tokens.ts
+++ b/apps/web/src/components/chat/chat-input-entity-tokens.ts
@@ -18,6 +18,17 @@ export function getEntityQuery(value: string, cursorPos: number): string | null 
   return m ? m[1]! : null;
 }
 
+// story d6f8e025 — Enter는 채팅에서 전송 키를 겸한다. "#3086"까지 타이핑하고 아직 스페이스를
+// 안 친 채로(=피커가 열린 채로) 전송하려고 Enter를 누르면, 화살표로 후보를 능동 선택한 적이
+// 없어도(entityIndex는 새 결과 도착 시 자동으로 0번을 가리킨다) 그 최상위 후보가 조용히
+// 토큰으로 삽입돼버렸다(실사례: backlink 오염). hasNavigated(moveUp/moveDown을 최소 1회
+// 거쳤는지)가 true일 때만 Enter가 수락한다 — Tab은 전송 키가 아니라 위험이 없어 늘 수락.
+export function shouldAcceptEntityPickerSelection(key: string, hasNavigated: boolean): boolean {
+  if (key === 'Tab') return true;
+  if (key === 'Enter') return hasNavigated;
+  return false;
+}
+
 // story #2292(보안·critical) — 링크 텍스트(markdown `[text](url)`의 text 부분) escape.
 // `[ ] ( ) \` 와 개행이 markdown-link 토큰 구조를 변조(예 `x](https://phish)[y` → 외부
 // phishing 링크 렌더)하는 걸 차단한다. ⛔형제 함수(applyEntity·applyAsset)가 이 상수 하나를

--- a/apps/web/src/components/chat/chat-input-entity-tokens.ts
+++ b/apps/web/src/components/chat/chat-input-entity-tokens.ts
@@ -29,6 +29,14 @@ export function shouldAcceptEntityPickerSelection(key: string, hasNavigated: boo
   return false;
 }
 
+// story d6f8e025(유나 design 지적, PO 판정) — 위 shouldAcceptEntityPickerSelection이 Enter를
+// hasNavigated 전엔 안 받아주는데, 화면이 0번 후보를 늘 하이라이트/aria-selected로 보여주면
+// 어포던스가 실제 동작과 어긋난다("선택된 것처럼 보이는데 Enter는 다르게 동작"). 화살표로
+// 능동 탐색하기 전엔 어떤 후보도 시각적으로 "선택됨"이 아니어야 한다.
+export function shouldHighlightEntityCandidate(idx: number, entityIndex: number, hasNavigated: boolean): boolean {
+  return hasNavigated && idx === entityIndex;
+}
+
 // story #2292(보안·critical) — 링크 텍스트(markdown `[text](url)`의 text 부분) escape.
 // `[ ] ( ) \` 와 개행이 markdown-link 토큰 구조를 변조(예 `x](https://phish)[y` → 외부
 // phishing 링크 렌더)하는 걸 차단한다. ⛔형제 함수(applyEntity·applyAsset)가 이 상수 하나를

--- a/apps/web/src/components/chat/chat-input.entity-picker-enter-guard.test.ts
+++ b/apps/web/src/components/chat/chat-input.entity-picker-enter-guard.test.ts
@@ -1,0 +1,28 @@
+/**
+ * story d6f8e025 — Enter는 채팅 전송 키를 겸한다. "#3086"까지 타이핑하고 화살표로 후보를
+ * 능동 선택한 적 없이(entityIndex는 새 결과 도착 시 자동으로 0번을 가리킨다) Enter를
+ * 눌러 전송하려던 것이 조용히 최상위 후보를 토큰으로 삽입해버린 실사례(backlink 오염)를
+ * 재발 안 되게 고정한다.
+ */
+import { describe, expect, it } from 'vitest';
+import { shouldAcceptEntityPickerSelection } from './chat-input-entity-tokens';
+
+describe('shouldAcceptEntityPickerSelection', () => {
+  it('능동 탐색(화살표) 없이 Enter — 수락하지 않는다(전송 의도로 취급)', () => {
+    expect(shouldAcceptEntityPickerSelection('Enter', false)).toBe(false);
+  });
+
+  it('화살표로 최소 1회 탐색한 뒤 Enter — 수락한다(참조 의도로 취급)', () => {
+    expect(shouldAcceptEntityPickerSelection('Enter', true)).toBe(true);
+  });
+
+  it('Tab은 능동 탐색 여부와 무관하게 늘 수락한다(전송 키가 아니라 위험 없음)', () => {
+    expect(shouldAcceptEntityPickerSelection('Tab', false)).toBe(true);
+    expect(shouldAcceptEntityPickerSelection('Tab', true)).toBe(true);
+  });
+
+  it('그 외 키는 수락하지 않는다', () => {
+    expect(shouldAcceptEntityPickerSelection('Escape', true)).toBe(false);
+    expect(shouldAcceptEntityPickerSelection('a', true)).toBe(false);
+  });
+});

--- a/apps/web/src/components/chat/chat-input.entity-picker-enter-guard.test.ts
+++ b/apps/web/src/components/chat/chat-input.entity-picker-enter-guard.test.ts
@@ -5,7 +5,7 @@
  * 재발 안 되게 고정한다.
  */
 import { describe, expect, it } from 'vitest';
-import { shouldAcceptEntityPickerSelection } from './chat-input-entity-tokens';
+import { shouldAcceptEntityPickerSelection, shouldHighlightEntityCandidate } from './chat-input-entity-tokens';
 
 describe('shouldAcceptEntityPickerSelection', () => {
   it('능동 탐색(화살표) 없이 Enter — 수락하지 않는다(전송 의도로 취급)', () => {
@@ -24,5 +24,18 @@ describe('shouldAcceptEntityPickerSelection', () => {
   it('그 외 키는 수락하지 않는다', () => {
     expect(shouldAcceptEntityPickerSelection('Escape', true)).toBe(false);
     expect(shouldAcceptEntityPickerSelection('a', true)).toBe(false);
+  });
+});
+
+// story d6f8e025(유나 design 지적, PO 판정) — 어포던스(화면 하이라이트/aria-selected)가
+// shouldAcceptEntityPickerSelection의 실제 동작(Enter 미탐색 시 미수락)과 어긋나면 안 된다.
+describe('shouldHighlightEntityCandidate', () => {
+  it('능동 탐색 전엔 0번 후보도 하이라이트/aria-selected 되지 않는다', () => {
+    expect(shouldHighlightEntityCandidate(0, 0, false)).toBe(false);
+  });
+
+  it('화살표로 탐색한 뒤엔 현재 entityIndex 위치만 하이라이트된다', () => {
+    expect(shouldHighlightEntityCandidate(0, 0, true)).toBe(true);
+    expect(shouldHighlightEntityCandidate(1, 0, true)).toBe(false);
   });
 });

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -22,7 +22,8 @@ import { ENTITY_ICONS } from './embed-card';
 import { translateEntityStatus } from './entity-status-labels';
 import { AssetPickerPopover } from './asset-picker-popover';
 import {
-  applyEntity, entityTypeLabel, escapeMarkdownLinkText, getEntityQuery, groupEntitiesByType, type EntityResult,
+  applyEntity, entityTypeLabel, escapeMarkdownLinkText, getEntityQuery, groupEntitiesByType,
+  shouldAcceptEntityPickerSelection, type EntityResult,
 } from './chat-input-entity-tokens';
 import { useEntityPicker } from '@/hooks/use-entity-picker';
 import { fetchWithAuth } from '@/lib/db/client';
@@ -360,8 +361,19 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
     if (entityPicker.entityResults.length > 0) {
       if (e.key === 'ArrowDown') { e.preventDefault(); entityPicker.moveDown(); return; }
       if (e.key === 'ArrowUp') { e.preventDefault(); entityPicker.moveUp(); return; }
-      // §5.2 select 가드: async 윈도우서 index가 범위 밖이면 undefined select 방지(클램프+존재 체크).
-      if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); const ent = entityPicker.entityResults[entityPicker.entityIndex] ?? entityPicker.entityResults[0]; if (ent) selectEntity(ent); return; }
+      // story d6f8e025 — shouldAcceptEntityPickerSelection: 화살표로 능동 탐색한 적 없이
+      // Enter를 누르면(전송 키를 겸함) 수락하지 않는다 — preventDefault 없이 통과시켜
+      // 아래 일반 Enter=전송 분기가 받게 한다. Tab은 늘 수락(전송 키가 아니라 위험 없음).
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        if (shouldAcceptEntityPickerSelection(e.key, entityPicker.hasNavigated)) {
+          // §5.2 select 가드: async 윈도우서 index가 범위 밖이면 undefined select 방지(클램프+존재 체크).
+          e.preventDefault();
+          const ent = entityPicker.entityResults[entityPicker.entityIndex] ?? entityPicker.entityResults[0];
+          if (ent) selectEntity(ent);
+          return;
+        }
+        entityPicker.close();
+      }
       if (e.key === 'Escape') { entityPicker.close(); return; }
     }
     if (mentionMembers.length > 0) {

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -23,7 +23,7 @@ import { translateEntityStatus } from './entity-status-labels';
 import { AssetPickerPopover } from './asset-picker-popover';
 import {
   applyEntity, entityTypeLabel, escapeMarkdownLinkText, getEntityQuery, groupEntitiesByType,
-  shouldAcceptEntityPickerSelection, type EntityResult,
+  shouldAcceptEntityPickerSelection, shouldHighlightEntityCandidate, type EntityResult,
 } from './chat-input-entity-tokens';
 import { useEntityPicker } from '@/hooks/use-entity-picker';
 import { fetchWithAuth } from '@/lib/db/client';
@@ -603,9 +603,13 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
                   type="button"
                   id={`entity-opt-${idx}`}
                   role="option"
-                  aria-selected={idx === entityPicker.entityIndex}
+                  /* story d6f8e025(유나 design 지적) — 하이라이트/aria-selected를 hasNavigated에
+                     게이트한다: 어포던스(화면에 "선택됨"으로 보임)가 실제 동작(Enter가 이걸
+                     수락하는지)과 어긋나면 안 된다. 화살표로 능동 탐색 전엔 0번이 시각적으로도
+                     "선택 안 됨" 상태라야 Enter=전송이 놀라움 없다. */
+                  aria-selected={shouldHighlightEntityCandidate(idx, entityPicker.entityIndex, entityPicker.hasNavigated)}
                   onMouseDown={(e) => { e.preventDefault(); selectEntity(entity); }}
-                  className={`flex w-full items-center px-3 py-2 text-left text-sm transition ${idx === entityPicker.entityIndex ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
+                  className={`flex w-full items-center px-3 py-2 text-left text-sm transition ${shouldHighlightEntityCandidate(idx, entityPicker.entityIndex, entityPicker.hasNavigated) ? 'bg-accent text-foreground font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
                 >
                   {/* ㉠: 종류는 위 머리글의 «글자»가 1차 신호 — 이 아이콘은 어디까지나 보조. */}
                   <EntityIcon className="mr-1.5 size-3.5 shrink-0" aria-hidden />

--- a/apps/web/src/hooks/use-entity-picker.ts
+++ b/apps/web/src/hooks/use-entity-picker.ts
@@ -33,6 +33,12 @@ export function useEntityPicker(projectId: string | undefined) {
   const [entityQuery, setEntityQuery] = useState<string | null>(null);
   const [entityResults, setEntityResults] = useState<EntityResult[]>([]);
   const [entityIndex, setEntityIndex] = useState(0);
+  // story d6f8e025 — Enter는 메시지 전송 키를 겸한다. 피커가 열려 있다는 이유만으로(사용자가
+  // 화살표로 후보를 능동 선택한 적 없이) Enter를 "수락"으로 해석하면, "#3086"까지 타이핑하고
+  // 전송하려던 Enter가 조용히 최상위 후보를 토큰으로 삽입해버린다(실사례: backlink 오염).
+  // hasNavigated가 true일 때만(moveUp/moveDown을 최소 1회 거친 뒤에만) Enter/Tab이 수락한다 —
+  // 새 후보 집합이 도착할 때마다(entityIndex가 0으로 리셋되는 바로 그 지점) 같이 리셋한다.
+  const [hasNavigated, setHasNavigated] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -50,6 +56,7 @@ export function useEntityPicker(projectId: string | undefined) {
           if (cancelled) return;
           setEntityResults(groupEntitiesByType(parseEntitySearchResults(json)));
           setEntityIndex(0);
+          setHasNavigated(false);
         })
         .catch(() => {});
     }, 200);
@@ -60,11 +67,12 @@ export function useEntityPicker(projectId: string | undefined) {
     entityQuery,
     entityResults,
     entityIndex,
+    hasNavigated,
     /** 입력 텍스트가 `#쿼리`로 바뀔 때마다 호출 — null이면 피커를 닫는다. */
     setEntityQuery,
-    close: () => { setEntityQuery(null); setEntityResults([]); },
-    moveDown: () => setEntityIndex((i) => (entityResults.length ? (i + 1) % entityResults.length : 0)),
-    moveUp: () => setEntityIndex((i) => (entityResults.length ? (i - 1 + entityResults.length) % entityResults.length : 0)),
+    close: () => { setEntityQuery(null); setEntityResults([]); setHasNavigated(false); },
+    moveDown: () => { setHasNavigated(true); setEntityIndex((i) => (entityResults.length ? (i + 1) % entityResults.length : 0)); },
+    moveUp: () => { setHasNavigated(true); setEntityIndex((i) => (entityResults.length ? (i - 1 + entityResults.length) % entityResults.length : 0)); },
     /** 선택 결과 텍스트/caret을 돌려주고 피커를 닫는다 — text state 반영·refocus는 호출부 책임
      * (호출부마다 textarea ref가 다르므로 hook이 DOM을 직접 만지지 않는다). */
     selectAndApply(entity: EntityResult, value: string, cursorPos: number): { text: string; caretPos: number } {


### PR DESCRIPTION
## 요약

story [d6f8e025](entity:story:d6f8e025-9e3a-407f-bebe-b1703a6bb90d) 그라운딩 결과, FE 레이어 원인의 fix. BE(`mention_parser.py`)는 무죄로 확認됨(채팅 write-path는 명시 브라켓 토큰만 인식, bare `#숫자` 자동 해소는 story description/AC 필드 전용이라 채팅과 무관) — 실제 원인은 `#` 엔티티 피커의 키보드 핸들링.

## 근본

`getEntityQuery`(`chat-input-entity-tokens.ts`)가 커서 바로 앞이 `#숫자`(뒤에 공백 없음)면 피커를 연다. 검색 결과가 도착하면 `entityIndex`가 자동으로 0(최상위)을 가리킨다 — 사용자가 화살표로 능동 탐색한 적이 없어도. `Enter`(또는 `Tab`)를 누르면 그 최상위 후보를 무조건 수락해 브라켓 토큰을 삽입했다. **문제는 Enter가 메시지 전송 키를 겸한다는 것** — "#3086"까지 타이핑하고 전송하려고 Enter를 누르면, 전송 대신 최상위 후보가 조용히 토큰으로 삽입돼 실제 참조/backlink로 저장된다(실사례: 유나가 내부 노트를 "#숫자"로 언급했다가 무관한 스토리·doc에 3연속 오참조).

## fix

`use-entity-picker.ts`에 `hasNavigated`(moveUp/moveDown을 최소 1회 거쳤는지) state 추가 — 새 결과 집합이 도착할 때(entityIndex가 0으로 리셋되는 그 지점)마다 같이 리셋한다. `chat-input-entity-tokens.ts`에 순수 함수 `shouldAcceptEntityPickerSelection(key, hasNavigated)` 추가(이 파일의 기존 관례 — `getEntityQuery`/`applyEntity` 등과 동일하게 순수 함수로 분리해 직접 테스트 가능하게): `Tab`은 늘 수락(전송 키가 아니라 위험 없음), `Enter`는 `hasNavigated`가 true일 때만 수락. `chat-input.tsx`의 keydown 핸들러가 이 술어로 분기 — 수락 안 되면 `entityPicker.close()`만 하고 `return` 없이 통과시켜, 그 아래 일반 `Enter=전송` 분기(line 376)가 정상 처리하게 한다.

이 코드베이스에 `@testing-library/react`/`renderHook`이 아예 없어(순수 함수 추출 테스트가 이 파일들의 기존 관례) hook state 자체보다 그 위에서 파생되는 결정 로직을 순수 함수로 뽑아 테스트했다.

## 검증

- `pnpm exec tsc --noEmit` → **EXIT 0**
- `pnpm lint` → **EXIT 0**(0 error, 기존 무관 warning 5건)
- `pnpm exec vitest run` → **431 files / 3525 tests 전부 통과**(기존 3521 + 신규 4: `chat-input.entity-picker-enter-guard.test.ts`)
- `pnpm build` → **EXIT 0**

## 스코프 밖(같은 스토리, 별도 그라운딩·PR 예정)

PO 실측으로 확인된 **에이전트/MCP 경로의 별도 층**(MCP `sprintable_send_chat_message`로 mentions 파라미터 없이 보낸 평문도 저장 시 토큰으로 바뀜)은 이 PR의 원인(FE 키보드 핸들링)과 무관한 별도 메커니즘 — FE fix 머지 후 별도로 그라운딩해 상신 예정(PO 지시 순서).