### PR TITLE
fix(authz): conversations.py SSOT 통일 + 판정 함수 한 곳(require_project_access) (story #2697)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -240,7 +240,13 @@ async def _effective_org_role(
 
 async def _conversation_has_human_participant(conversation_id: uuid.UUID, db: AsyncSession) -> bool:
     """대화에 휴먼 참가자가 있으면 True(=private·admin 우회 금지).
-    보수적: agent team_member로 확정 안 된 참가자는 human 간주(grant-only/미앵커 휴먼 포함)."""
+    보수적: agent team_member로 확정 안 된 참가자는 human 간주(grant-only/미앵커 휴먼 포함).
+
+    story #2697: get_conversation()은 더 이상 이 함수를 안 쓴다(conversation_readable_
+    predicate SSOT로 이관) — 하지만 attachments.py의 authorize 엔드포인트가 여전히 이
+    정확한 함수를 직접 import해 자신의 admin-bypass 판정에 쓴다(별도 콜사이트, 삭제 시
+    ImportError). 그래서 이 함수는 존치 — 삭제가 아니라 "소비자 하나만 이관"이 맞는
+    변경이었다(#2697 첫 시도에서 삭제했다가 test_attachment_authorize_a54ddc16.py로 잡힘)."""
     pids = (await db.execute(
         select(ConversationParticipant.member_id).where(ConversationParticipant.conversation_id == conversation_id)
     )).scalars().all()
@@ -1455,21 +1461,20 @@ async def get_conversation(
     if conv is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    sender = await _resolve_member(auth, org_id, db, project_id=None)
-    is_admin = await _effective_org_role(
-        auth, org_id, db, sender, project_id=conv.project_id,
-    ) in ("owner", "admin")
-    # admin이어도 휴먼 참가(private) 대화면 participant 체크 폴백
-    if (not is_admin) or await _conversation_has_human_participant(conversation_id, db):
-        sender = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
-        participant = (await db.execute(
-            select(ConversationParticipant.id).where(
-                ConversationParticipant.conversation_id == conversation_id,
-                ConversationParticipant.member_id == sender.id,
-            )
-        )).scalar_one_or_none()
-        if participant is None:
-            raise HTTPException(status_code=403, detail="Not a participant")
+    # story #2697: get_conversation이 conversation_readable_predicate SSOT(§6회차 — backlinks.py·
+    # list_conversations·_can_read_conversation이 이미 쓰는 canonical judge)로 안 옮겨간 마지막
+    # 소비자였다(reviewer round-5 verdict가 이 자리를 스코프 밖으로 남겼던 것 — 여기서 마저
+    # 닫는다). _effective_org_role의 사전 해소(TOCTOU류·project_scope.py 문서와 동일 클래스) +
+    # 별도 participant SELECT 대신 이미 검증된 SSOT를 그대로 재사용한다(재구현 0) — 판정 자체
+    # (participant∧project-access-valid ∨ ¬human-participant∧admin-bypass)는 불변, 소싱만
+    # 통일. 404로 존재-비노출(구 403 "Not a participant"는 참가여부를 노출했다 — 다른 리소스
+    # (goals·stories·sprints·retros·gates) 다수 관례에 맞춰 통일, story #2697 AC②).
+    if not await _can_read_conversation(
+        conversation_id, db, auth, org_id, _conv_project_id=conv.project_id,
+    ):
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    sender = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
 
     # 270c87e6: caller의 mute 상태 노출(FE 토글 초기 상태·#1426). 비참여자(admin-bypass agent-only)는 False.
     # story #1976: 같은 단건 조회에 last_read_at도 편승(신규 쿼리 아님) — unread_count는 참여자일 때만 계산.

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -40,6 +40,7 @@ from app.services.project_auth import (
     has_project_access,
     is_org_owner,
     is_org_owner_or_admin,
+    require_project_access,
 )
 
 
@@ -226,8 +227,9 @@ async def create_gate_endpoint(
     # fail-closed(②): 통과는 KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES(명시 allowlist)에 있을 때만 —
     # PROJECT_SCOPED_WORK_ITEM_TYPES에도 그 목록에도 없는 미분류 타입은 기본값이 거부다.
     if project_id is not None:
-        if not await has_project_access(session, uuid.UUID(_auth.user_id), project_id, org_id):
-            raise HTTPException(status_code=404, detail="Project not found")
+        # story #2697: require_project_access(전 리소스 공용 판정 함수)로 위임(재구현 0).
+        await require_project_access(session, uuid.UUID(_auth.user_id), project_id, org_id,
+                                      not_found_detail="Project not found")
     elif not is_known_project_agnostic_work_item_type(body.work_item_type):
         raise HTTPException(status_code=404, detail="Project not found")
     gate = await create_gate(
@@ -798,8 +800,10 @@ async def get_gate_endpoint(
     # 안에서 해소 안 되는 것은 이 gate 자체가 가리키는 대상이 이 org에 없다는 뜻이라 거부.
     # fail-closed(②): 통과는 KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES 명시 allowlist에 있을 때만.
     if project_id is not None:
-        if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
-            raise HTTPException(status_code=404, detail="Gate not found")
+        # story #2697: require_project_access(전 리소스 공용 판정 함수)로 위임 — 이 파일이
+        # goals/stories/sprints/retros가 수렴한 원본 레퍼런스 패턴이었다(재구현 0).
+        await require_project_access(session, uuid.UUID(auth.user_id), project_id, org_id,
+                                      not_found_detail="Gate not found")
     elif not is_known_project_agnostic_work_item_type(gate.work_item_type):
         raise HTTPException(status_code=404, detail="Gate not found")
 

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -17,7 +17,7 @@ from app.dependencies.auth import AuthContext, enforce_body_context, get_current
 from app.dependencies.database import get_db, get_read_db
 from app.repositories.goal import GoalRepository
 from app.schemas.goal import GoalCreate, GoalProgressResponse, GoalResponse, GoalUpdate, GoalWithGlanceResponse
-from app.services.project_auth import has_project_access
+from app.services.project_auth import has_project_access, require_project_access
 
 router = APIRouter(tags=["goals", "Work"])
 
@@ -221,9 +221,9 @@ async def get_goal(
     goal = await repo.get(id)
     if goal is None:
         raise HTTPException(status_code=404, detail="Goal not found")
-    # #2237: 형제(update_goal)와 동일한 project 접근권 가드 추가(기존엔 org-scope만 봤다).
-    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), goal.project_id, repo.org_id):
-        raise HTTPException(status_code=404, detail="Goal not found")
+    # #2237/#2697: 형제(update_goal)와 동일한 project 접근권 가드(판정 함수 한 곳).
+    await require_project_access(repo.session, uuid.UUID(auth.user_id), goal.project_id, repo.org_id,
+                                  not_found_detail="Goal not found")
     await _attach_org_project_slugs(repo.session, repo.org_id, [goal])
     return GoalResponse.model_validate(goal)
 
@@ -381,8 +381,8 @@ async def update_goal(
     # title/goal/전략까지 무가드로 덮어쓸 수 있었다(PATH_ID 뮤테이션 project-scope IDOR). resolved
     # -resource(현 goal의 실 project_id)에 has_project_access 사전검증(404·존재 비노출·body-claimed
     # 금지). GoalUpdate엔 project_id 필드 없어 cross-project 이동 경로는 원천 부재.
-    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), current.project_id, repo.org_id):
-        raise HTTPException(status_code=404, detail="Goal not found")
+    await require_project_access(repo.session, uuid.UUID(auth.user_id), current.project_id, repo.org_id,
+                                  not_found_detail="Goal not found")
     data = body.model_dump(exclude_unset=True)
     # ⭐RC#2(D1' 봉인): goal status(lifecycle) **변경**은 generic PATCH 금지 — 전용 transition 엔드포인트
     # (POST /goals/{id}/transition)가 FSM(_GOAL_VALID_TRANSITIONS)+SoD+overlay-gate 보유. generic 으로
@@ -478,9 +478,9 @@ async def get_goal_progress(
     goal = await repo.get(id)
     if goal is None:
         raise HTTPException(status_code=404, detail="Goal not found")
-    # #2237: 형제(update_goal)와 동일한 project 접근권 가드 추가(기존엔 org-scope만 봤다).
-    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), goal.project_id, repo.org_id):
-        raise HTTPException(status_code=404, detail="Goal not found")
+    # #2237/#2697: 형제(update_goal)와 동일한 project 접근권 가드(판정 함수 한 곳).
+    await require_project_access(repo.session, uuid.UUID(auth.user_id), goal.project_id, repo.org_id,
+                                  not_found_detail="Goal not found")
     return await repo.get_progress(id)
 
 
@@ -499,8 +499,8 @@ async def get_goal_reference_candidates(
     goal = await repo.get(id)
     if goal is None:
         raise HTTPException(status_code=404, detail="Goal not found")
-    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), goal.project_id, repo.org_id):
-        raise HTTPException(status_code=404, detail="Goal not found")
+    await require_project_access(repo.session, uuid.UUID(auth.user_id), goal.project_id, repo.org_id,
+                                  not_found_detail="Goal not found")
 
     from app.services.reference_semantic_candidates import list_candidates_for_epic_stories
 

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -12,7 +12,7 @@ from app.services import hypothesis as hyp_svc
 from app.services import retro_hypothesis_seed as seed_svc
 from app.services import retro_synthesis as synth_svc
 from app.services.member_resolver import canonicalize_member_id, lookup_members_by_ids, resolve_member
-from app.services.project_auth import has_project_access
+from app.services.project_auth import has_project_access, require_project_access
 from app.repositories.retro import (
     RetroActionRepository,
     RetroItemRepository,
@@ -80,8 +80,9 @@ async def _require_retro_project_access(
     if retro is None:
         raise HTTPException(status_code=404, detail="Retro session not found")
     # ⛔story #2342(2026-07-30): 무권한을 403이 아닌 404로 — stories.py와 동일 존재 비노출 규율.
-    if not await has_project_access(session, user_id, retro.project_id, org_id):
-        raise HTTPException(status_code=404, detail="Retro session not found")
+    # story #2697: require_project_access(전 리소스 공용 판정 함수)로 위임(재구현 0).
+    await require_project_access(session, user_id, retro.project_id, org_id,
+                                  not_found_detail="Retro session not found")
     return retro
 
 
@@ -112,8 +113,8 @@ async def list_sessions(
     if project_id is not None:
         # 명시 필터 시 그 프로젝트 접근권 선검증(무권한 project_id로 org 존재 여부 탐색 차단).
         # ⛔story #2342(2026-07-30): 무권한을 403이 아닌 404로 통일.
-        if not await has_project_access(db, user_id, project_id, repo.org_id):
-            raise HTTPException(status_code=404, detail="Project not found")
+        await require_project_access(db, user_id, project_id, repo.org_id,
+            not_found_detail="Project not found")
     filters: dict = {}
     if project_id:
         filters["project_id"] = project_id
@@ -137,8 +138,8 @@ async def create_session(
 ) -> SessionListResponse:
     # body.project_id 를 검증 없이 신뢰하면 무권한 project 에 session 을 심는 mutation IDOR.
     # ⛔story #2342(2026-07-30): 무권한을 403이 아닌 404로 통일.
-    if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
-        raise HTTPException(status_code=404, detail="Project not found")
+    await require_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id,
+        not_found_detail="Project not found")
     # 까심 QA(#1880 embed-switch 中 실 Postgres 재현) — body.sprint_id가 실제 body.project_id
     # 소속인지 검증하는 FK/CHECK가 없어 project A 세션에 project B sprint를 링크 가능했다.
     # embed(session.project_id로 스코프)와 별도 /sprints/{id}/hypotheses(sprint의 실제
@@ -192,8 +193,8 @@ async def get_or_create_session_by_sprint(
     if sprint is None:
         raise HTTPException(status_code=404, detail="Sprint not found")
     # ⛔story #2342(2026-07-30): 무권한을 403이 아닌 404로 통일.
-    if not await has_project_access(db, uuid.UUID(auth.user_id), sprint.project_id, org_id):
-        raise HTTPException(status_code=404, detail="Project not found")
+    await require_project_access(db, uuid.UUID(auth.user_id), sprint.project_id, org_id,
+        not_found_detail="Project not found")
 
     existing = (
         await db.execute(

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -126,12 +126,12 @@ async def list_sprints(
     # 전부 org-scope만이고 project-scope 0이던 것 중 하나 — project_id 미지정 시 caller의
     # project 접근권과 무관하게 org 전체 sprint가 노출됐다. project_id 지정 시엔 접근권 검증,
     # 미지정 시엔 accessible_project_ids_in_org로 필터(완전봉인, Z-standup 패턴 동형).
-    from app.services.project_auth import accessible_project_ids_in_org, has_project_access
+    from app.services.project_auth import accessible_project_ids_in_org, require_project_access
 
     filters: dict = {}
     if project_id:
-        if not await has_project_access(repo.session, uuid.UUID(auth.user_id), project_id, repo.org_id):
-            raise HTTPException(status_code=404, detail="Project not found")
+        await require_project_access(repo.session, uuid.UUID(auth.user_id), project_id, repo.org_id,
+            not_found_detail="Project not found")
         filters["project_id"] = project_id
     if status_filter:
         filters["status"] = status_filter
@@ -153,9 +153,9 @@ async def create_sprint(
 ) -> SprintResponse:
     # E-SECURITY SEC-S8(story 83ea3d6a) CC: body.project_id에 접근권 검증 없이 caller가
     # 임의 org-내 project에 sprint를 생성할 수 있었다.
-    from app.services.project_auth import has_project_access
-    if not await has_project_access(session, uuid.UUID(auth.user_id), body.project_id, org_id):
-        raise HTTPException(status_code=404, detail="Project not found")
+    from app.services.project_auth import require_project_access
+    await require_project_access(session, uuid.UUID(auth.user_id), body.project_id, org_id,
+        not_found_detail="Project not found")
 
     repo = SprintRepository(session, org_id)
     # 8a2bbda2: 날짜에서 duration 산출 저장(dates 단일진실·신규 정합). 날짜 없으면 model default(14).
@@ -192,12 +192,12 @@ async def get_sprint(
 ) -> SprintResponse:
     # E-SECURITY SEC-S8(story 83ea3d6a) CC: sprint id-scoped 조회에 project 접근권 검증 없이
     # org 내 어느 project의 sprint든 조회 가능했다.
-    from app.services.project_auth import has_project_access
+    from app.services.project_auth import require_project_access
     sprint = await repo.get(id)
     if sprint is None:
         raise HTTPException(status_code=404, detail="Sprint not found")
-    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
-        raise HTTPException(status_code=404, detail="Sprint not found")
+    await require_project_access(repo.session, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id,
+        not_found_detail="Sprint not found")
     await _attach_org_project_slugs(repo.session, repo.org_id, [sprint])
     return SprintResponse.model_validate(sprint)
 
@@ -217,16 +217,14 @@ async def list_sprint_hypotheses(
 ) -> list[SprintHypothesisItem]:
     # E-SECURITY SEC-S8(story 83ea3d6a) CC: read-쌍둥이(POST declare_sprint_hypothesis는 이미
     # resolve_member(project_id=)로 검증하는데 이 GET은 검증 없이 미러링 안 됐던 갭 — 발견즉시수정.
-    from app.services.project_auth import has_project_access
+    from app.services.project_auth import require_project_access
     sprint = await repo.get(id)
     if sprint is None:
         raise HTTPException(
             status_code=404, detail={"code": "SPRINT_NOT_FOUND", "message": "스프린트를 찾을 수 없습니다."}
         )
-    if not await has_project_access(session, uuid.UUID(auth.user_id), sprint.project_id, org_id):
-        raise HTTPException(
-            status_code=404, detail={"code": "SPRINT_NOT_FOUND", "message": "스프린트를 찾을 수 없습니다."}
-        )
+    await require_project_access(session, uuid.UUID(auth.user_id), sprint.project_id, org_id,
+        not_found_detail={"code": "SPRINT_NOT_FOUND", "message": "스프린트를 찾을 수 없습니다."})
     items = await hypothesis_svc.list_hypotheses(
         session, org_id, sprint.project_id, sprint_id=id, limit=200
     )
@@ -288,12 +286,12 @@ async def update_sprint(
 ) -> SprintResponse:
     # E-SECURITY SEC-S8(story 83ea3d6a) CC: PATCH가 project 접근권 검증 없이 org 내 어느
     # project의 sprint든 갱신 가능했다(report_doc_id Z-fix는 별개 갭 — 이건 sprint 자체 접근권).
-    from app.services.project_auth import has_project_access
+    from app.services.project_auth import require_project_access
     _scope_sprint = await repo.get(id)
     if _scope_sprint is None:
         raise HTTPException(status_code=404, detail="Sprint not found")
-    if not await has_project_access(session, uuid.UUID(auth.user_id), _scope_sprint.project_id, org_id):
-        raise HTTPException(status_code=404, detail="Sprint not found")
+    await require_project_access(session, uuid.UUID(auth.user_id), _scope_sprint.project_id, org_id,
+        not_found_detail="Sprint not found")
 
     data = body.model_dump(exclude_unset=True)
     # E-SECURITY SEC-S8(story 83ea3d6a) Z(까심 전수스윕): report_doc_id가 sprint의 project 소속인지
@@ -514,12 +512,12 @@ async def kickoff_sprint(
 ) -> dict:
     # E-SECURITY SEC-S8(story 83ea3d6a) CC: project 접근권 검증 없이 org 내 어느 project의
     # sprint든 kickoff 발동 가능했다.
-    from app.services.project_auth import has_project_access
+    from app.services.project_auth import require_project_access
     sprint = await repo.get(id)
     if sprint is None:
         raise HTTPException(status_code=404, detail="Sprint not found")
-    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
-        raise HTTPException(status_code=404, detail="Sprint not found")
+    await require_project_access(repo.session, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id,
+        not_found_detail="Sprint not found")
     # Notification dispatch is Phase D — return stub for Phase B
     return {"notified": 0, "sprint_id": str(id), "message": body.message}
 
@@ -534,12 +532,12 @@ async def sprint_summary(
     """GET /api/v2/sprints/{id}/summary — 스프린트 스토리 상태별 집계 (AC3 S-STANDUP-FIX)."""
     # E-SECURITY SEC-S8(story 83ea3d6a) CC: project 접근권 검증 없이 남의 project sprint의
     # 스토리 상태별 집계가 노출됐다.
-    from app.services.project_auth import has_project_access
+    from app.services.project_auth import require_project_access
     sprint = await repo.get(id)
     if sprint is None:
         raise HTTPException(status_code=404, detail="Sprint not found")
-    if not await has_project_access(db, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
-        raise HTTPException(status_code=404, detail="Sprint not found")
+    await require_project_access(db, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id,
+        not_found_detail="Sprint not found")
 
     stories_result = await db.execute(
         select(Story.status, Story.story_points).where(Story.sprint_id == id)
@@ -581,12 +579,12 @@ async def checkin_sprint(
 ) -> dict:
     # E-SECURITY SEC-S8(story 83ea3d6a) CC: project 접근권 검증 없이 남의 project sprint의
     # standup 미제출자 명단(이름 포함)이 노출됐다.
-    from app.services.project_auth import has_project_access
+    from app.services.project_auth import require_project_access
     sprint = await repo.get(id)
     if sprint is None:
         raise HTTPException(status_code=404, detail="Sprint not found")
-    if not await has_project_access(db, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
-        raise HTTPException(status_code=404, detail="Sprint not found")
+    await require_project_access(db, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id,
+        not_found_detail="Sprint not found")
 
     try:
         checkin_date = date_type.fromisoformat(date)

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -420,11 +420,15 @@ async def _assert_story_project_access(
     이 파일 전체에서 통일한다(participation.py의 동명 헬퍼·gates.py get_gate_endpoint가 이미
     이 규율이었다 — 「같은 엔티티가 경로마다 다른 답」을 내던 것이 진짜 결함이었다). 조직
     경계(다른 org)는 이 함수 호출 前에 이미 404로 막혀 있다(repo.get()의 org 필터) — 이 함수가
-    새로 여는 것은 「조직 안·프로젝트 밖」 하나뿐이고, 그 답도 이제 404다."""
-    from app.services.project_auth import has_project_access
+    새로 여는 것은 「조직 안·프로젝트 밖」 하나뿐이고, 그 답도 이제 404다.
 
-    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
-        raise HTTPException(status_code=404, detail="Story not found")
+    story #2697: 구현을 project_auth.require_project_access(전 리소스 공용 판정 함수)로
+    위임 — #2322가 이 파일 안에서 먼저 정한 404 규율을 이제 goals.py/sprints.py/retros.py도
+    같은 함수로 공유한다(재구현 0)."""
+    from app.services.project_auth import require_project_access
+
+    await require_project_access(session, uuid.UUID(auth.user_id), project_id, org_id,
+                                  not_found_detail="Story not found")
 
 
 async def _upsert_assignee_participation(

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -396,6 +396,24 @@ async def has_project_access(
     return bool(result.scalar_one_or_none())
 
 
+async def require_project_access(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID,
+    org_id: uuid.UUID,
+    *,
+    not_found_detail: object = "Resource not found",
+) -> None:
+    """story #2697([BE·인가·프로젝트 스코프]) — GET/PATCH/DELETE-by-id 판정 함수 한 곳.
+
+    goals.py/stories.py/sprints.py/retros.py가 각자 ``if not await has_project_access(...):
+    raise HTTPException(404, "X not found")`` 3줄을 리소스마다 복제하고 있었다(리소스 타입별
+    404/403 들쭉날쭉의 근원 — 「막는 쪽과 하는 쪽이 다른 걸 본다」 클래스). 이 헬퍼로 수렴:
+    실패 시 항상 404(존재-비노출 — 다수 관례, gates.py의 기존 설계 원칙과 동일)."""
+    if not await has_project_access(session, user_id, project_id, org_id):
+        raise HTTPException(status_code=404, detail=not_found_detail)
+
+
 async def is_org_owner_or_admin(
     session: AsyncSession,
     user_id: uuid.UUID,

--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -52,6 +52,13 @@ PROJECT_PARAM_RE = re.compile(
 
 PROJECT_GUARD_FUNCTIONS: frozenset[str] = frozenset({
     "has_project_access",
+    # story #2697([BE·인가·프로젝트 스코프]) — goals/stories/sprints/retros/gates가 각자
+    # 복제하던 `if not await has_project_access(...): raise HTTPException(404, ...)` 3줄을
+    # `project_auth.require_project_access`(SSOT, has_project_access를 내부에서 호출)로
+    # 수렴했다. 스캐너가 이 이름을 모르면 그 라우트들이 (has_project_access를 더 이상 직접
+    # 안 부르므로) «미가드»로 오탐 — 이 목록에 새 헬퍼가 편입 안 되면 그게 사각이 된다(까심
+    # i18n 가드·이 파일 86행 주석과 동일 규율: 헬퍼 리네임/도입 시 이 목록 동반 갱신 필수).
+    "require_project_access",
     # story #2340 실측(2026-08-02, 디디) — 이름·실동작 둘 다 project-scope 가드(project_id를
     # 받아 그 project의 role을 검사)인데 이 목록에서만 누락돼 있었다(GUARD_FUNCTIONS(identity
     # 축)엔 있었다 — 두 목록이 서로 다른 걸 보는 것 자체는 설계지만, 이 함수는 어느 쪽에도

--- a/backend/tests/test_1968_gate_project_id_threading.py
+++ b/backend/tests/test_1968_gate_project_id_threading.py
@@ -130,7 +130,7 @@ async def test_generic_gate_endpoint_threads_resolved_project_id():
 
     with patch.object(gates_mod, "resolve_work_item_project_id",
                        AsyncMock(return_value=project_id)) as resolve_spy, \
-         patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)), \
+         patch("app.services.project_auth.has_project_access", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "create_gate", AsyncMock(return_value=gate)) as create_spy, \
          patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
         await create_gate_endpoint(body=body, session=session, org_id=org_id, _auth=auth)

--- a/backend/tests/test_1970_gate_single_get.py
+++ b/backend/tests/test_1970_gate_single_get.py
@@ -179,7 +179,8 @@ async def test_get_gate_endpoint_404_no_project_access():
 
     with patch.object(gates_mod, "resolve_work_item_project_id",
                        AsyncMock(return_value=project_id)) as resolve_spy, \
-         patch.object(gates_mod, "has_project_access", AsyncMock(return_value=False)) as access_spy:
+         patch("app.services.project_auth.has_project_access",
+               AsyncMock(return_value=False)) as access_spy:
         with pytest.raises(HTTPException) as exc_info:
             await get_gate_endpoint(id=gate_id, session=session, org_id=org_id, auth=auth)
 
@@ -201,7 +202,7 @@ async def test_get_gate_endpoint_200_populates_project_id_and_summary():
 
     with patch.object(gates_mod, "resolve_work_item_project_id",
                        AsyncMock(return_value=project_id)), \
-         patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)), \
+         patch("app.services.project_auth.has_project_access", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "_resolve_work_item_summary",
                        AsyncMock(return_value=WorkItemSummary(title="설계 문서", slug="design-doc"))):
         result = await get_gate_endpoint(id=gate_id, session=session, org_id=org_id, auth=auth)

--- a/backend/tests/test_1972_gate_risk_grade.py
+++ b/backend/tests/test_1972_gate_risk_grade.py
@@ -184,7 +184,7 @@ async def test_get_gate_endpoint_populates_risk_grade():
 
     with patch.object(gates_mod, "resolve_work_item_project_id",
                        AsyncMock(return_value=project_id)), \
-         patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)), \
+         patch("app.services.project_auth.has_project_access", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "_resolve_work_item_summary", AsyncMock(return_value=None)), \
          patch.object(gates_mod, "get_org_posture", AsyncMock(return_value="balanced")) as posture_spy:
         result = await get_gate_endpoint(id=gate_id, session=session, org_id=org_id, auth=auth)
@@ -207,7 +207,7 @@ async def test_get_gate_endpoint_risk_grade_low_permissive():
 
     with patch.object(gates_mod, "resolve_work_item_project_id",
                        AsyncMock(return_value=project_id)), \
-         patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)), \
+         patch("app.services.project_auth.has_project_access", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "_resolve_work_item_summary", AsyncMock(return_value=None)), \
          patch.object(gates_mod, "get_org_posture", AsyncMock(return_value="permissive")):
         result = await get_gate_endpoint(id=gate_id, session=session, org_id=org_id, auth=auth)

--- a/backend/tests/test_2697_conversation_project_scope_realdb.py
+++ b/backend/tests/test_2697_conversation_project_scope_realdb.py
@@ -1,0 +1,230 @@
+"""story #2697 — get_conversation() 인가 SSOT 통일(conversation_readable_predicate 경유) +
+프로젝트 스코프 음성대조 realdb 실증.
+
+배경: get_conversation()이 conversation_readable_predicate SSOT(§6회차 — backlinks.py·
+list_conversations·_can_read_conversation이 이미 쓰던 canonical judge)로 안 옮겨간 마지막
+소비자였다(_effective_org_role의 사전 해소 + 별도 participant SELECT를 썼다). #2697에서
+_can_read_conversation()으로 통일하고, 403("Not a participant")을 다른 리소스(goals·
+stories·sprints·retros·gates) 다수 관례에 맞춰 404(존재-비노출)로 바꿨다.
+
+이 파일은 그 마이그레이션의 endpoint 레벨 회귀 0(admin bypass 유지·human-participant
+privacy carve-out 유지)와, 스토리의 원 관심사(same-org cross-project read)를 실PG로
+직접 검증한다. predicate 자체의 세부 의미론(admin_bypass_eligible atom·project_access_
+valid revoke barrier 등)은 test_1994_backlink_api_realdb.py가 이미 훨씬 깊게 커버 —
+여기서는 재검증하지 않는다(중복 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_human(session, *, org_id, project_id, role="member"):
+    """휴먼 1명: users+org_members+team_members를 같은 id로(E-MEMBER-SSOT AC2-1 불변식 —
+    members.id == org_members.id를 로컬 create_all에서 수동으로 재현)."""
+    from app.core.security import hash_password
+    from app.models.project import OrgMember
+    from app.models.team import TeamMember
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    member_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"u-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    session.add(OrgMember(id=member_id, org_id=org_id, user_id=user_id, role=role))
+    session.add(TeamMember(
+        id=member_id, org_id=org_id, project_id=project_id, user_id=user_id,
+        type="human", name=f"h-{member_id.hex[:6]}", role=("owner" if role == "owner" else "member"),
+    ))
+    await session.commit()
+    return user_id, member_id
+
+
+async def _seed_agent(session, *, org_id, project_id):
+    from app.models.team import TeamMember
+
+    member_id = uuid.uuid4()
+    session.add(TeamMember(
+        id=member_id, org_id=org_id, project_id=project_id, user_id=None,
+        type="agent", name=f"a-{member_id.hex[:6]}", role="member",
+    ))
+    await session.commit()
+    return member_id
+
+
+async def _seed_conversation(session, *, org_id, project_id, participant_ids):
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv_id = uuid.uuid4()
+    session.add(Conversation(
+        id=conv_id, org_id=org_id, project_id=project_id, type="group",
+        title="t", created_by=participant_ids[0] if participant_ids else None,
+    ))
+    await session.commit()
+    for mid in participant_ids:
+        session.add(ConversationParticipant(id=uuid.uuid4(), conversation_id=conv_id, member_id=mid))
+    await session.commit()
+    return conv_id
+
+
+def _auth_for(user_id):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=None)
+
+
+@pytest.mark.anyio
+async def test_admin_nonparticipant_agent_only_conv_still_200_after_migration():
+    """회귀 0: org admin이 참가 안 한 agent-only 대화는 여전히 200(admin-bypass 유지)."""
+    from app.routers.conversations import get_conversation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.organization import Organization
+            from app.models.project import Project
+            org_id, project_id = uuid.uuid4(), uuid.uuid4()
+            s.add(Organization(id=org_id, name="Org", slug=f"org-{org_id.hex[:8]}"))
+            await s.commit()
+            s.add(Project(id=project_id, org_id=org_id, name="P"))
+            await s.commit()
+            admin_user_id, _admin_member_id = await _seed_human(s, org_id=org_id, project_id=project_id, role="admin")
+            a1 = await _seed_agent(s, org_id=org_id, project_id=project_id)
+            a2 = await _seed_agent(s, org_id=org_id, project_id=project_id)
+            conv_id = await _seed_conversation(s, org_id=org_id, project_id=project_id, participant_ids=[a1, a2])
+
+            resp = await get_conversation(conv_id, db=s, auth=_auth_for(admin_user_id), org_id=org_id)
+            assert resp.id == conv_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_admin_nonparticipant_human_conv_now_404_not_403():
+    """§ 상태코드 통일: admin 비참가 + 휴먼 참가(private) 대화 — 구 403 "Not a participant"가
+    다른 리소스 다수 관례(존재-비노출)에 맞춰 404가 됐다(story #2697 AC②)."""
+    from fastapi import HTTPException
+    from app.routers.conversations import get_conversation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.organization import Organization
+            from app.models.project import Project
+            org_id, project_id = uuid.uuid4(), uuid.uuid4()
+            s.add(Organization(id=org_id, name="Org", slug=f"org-{org_id.hex[:8]}"))
+            await s.commit()
+            s.add(Project(id=project_id, org_id=org_id, name="P"))
+            await s.commit()
+            admin_user_id, _ = await _seed_human(s, org_id=org_id, project_id=project_id, role="admin")
+            other_human_user_id, other_human_id = await _seed_human(s, org_id=org_id, project_id=project_id)
+            agent = await _seed_agent(s, org_id=org_id, project_id=project_id)
+            conv_id = await _seed_conversation(
+                s, org_id=org_id, project_id=project_id, participant_ids=[other_human_id, agent],
+            )
+
+            with pytest.raises(HTTPException) as ei:
+                await get_conversation(conv_id, db=s, auth=_auth_for(admin_user_id), org_id=org_id)
+            assert ei.value.status_code == 404, f"privacy carve-out 유지되나 상태코드는 404여야: {ei.value.status_code}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonadmin_member_of_different_project_cannot_read_conversation():
+    """story #2697 핵심 — same-org cross-project read. 이 대화의 project(A)에 접근권이 아예
+    없는(다른 project B에만 소속된) 비-admin 멤버가 conversation_id만 알고 GET → 404여야
+    한다(«ID만 알면 타 프로젝트 데이터가 200» 결함 클래스의 conversations 축)."""
+    from fastapi import HTTPException
+    from app.routers.conversations import get_conversation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.organization import Organization
+            from app.models.project import Project
+            org_id = uuid.uuid4()
+            project_a, project_b = uuid.uuid4(), uuid.uuid4()
+            s.add(Organization(id=org_id, name="Org", slug=f"org-{org_id.hex[:8]}"))
+            await s.commit()
+            s.add(Project(id=project_a, org_id=org_id, name="A"))
+            s.add(Project(id=project_b, org_id=org_id, name="B"))
+            await s.commit()
+            # outsider: project B 소속뿐(project A 접근권 0) — non-admin.
+            outsider_user_id, _outsider_id = await _seed_human(s, org_id=org_id, project_id=project_b)
+            a1 = await _seed_agent(s, org_id=org_id, project_id=project_a)
+            a2 = await _seed_agent(s, org_id=org_id, project_id=project_a)
+            conv_id = await _seed_conversation(
+                s, org_id=org_id, project_id=project_a, participant_ids=[a1, a2],
+            )
+
+            with pytest.raises(HTTPException) as ei:
+                await get_conversation(conv_id, db=s, auth=_auth_for(outsider_user_id), org_id=org_id)
+            assert ei.value.status_code == 404, (
+                f"project B 소속 비-admin이 project A의 대화를 읽을 수 있으면 안 됨 — got {ei.value.status_code}"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_own_participation_still_reads_own_conversation():
+    """무회귀: 실제 참가자 본인은 여전히 정상 200(admin 여부 무관)."""
+    from app.routers.conversations import get_conversation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.organization import Organization
+            from app.models.project import Project
+            org_id, project_id = uuid.uuid4(), uuid.uuid4()
+            s.add(Organization(id=org_id, name="Org", slug=f"org-{org_id.hex[:8]}"))
+            await s.commit()
+            s.add(Project(id=project_id, org_id=org_id, name="P"))
+            await s.commit()
+            member_user_id, member_id = await _seed_human(s, org_id=org_id, project_id=project_id)
+            agent = await _seed_agent(s, org_id=org_id, project_id=project_id)
+            conv_id = await _seed_conversation(
+                s, org_id=org_id, project_id=project_id, participant_ids=[member_id, agent],
+            )
+
+            resp = await get_conversation(conv_id, db=s, auth=_auth_for(member_user_id), org_id=org_id)
+            assert resp.id == conv_id
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2697_conversation_project_scope_realdb.py
+++ b/backend/tests/test_2697_conversation_project_scope_realdb.py
@@ -54,36 +54,61 @@ async def _session_factory():
 
 
 async def _seed_human(session, *, org_id, project_id, role="member"):
-    """휴먼 1명: users+org_members+team_members를 같은 id로(E-MEMBER-SSOT AC2-1 불변식 —
-    members.id == org_members.id를 로컬 create_all에서 수동으로 재현)."""
+    """휴먼 1명 — team_members는 실 배포 스키마에서 members ⋈ project_access VIEW라
+    직접 INSERT가 불가능하다("cannot insert into view") — anchor 경로(members/org_members/
+    project_access)로만 영속한다(test_1994_backlink_api_realdb.py `_make_human_member`/
+    `_make_org_owner`와 동형 패턴, 가드 test_no_team_members_view_dml_in_tests가 요구).
+
+    org owner/admin은 project_access 없이도 has_project_access의 org-wide 분기로 항상
+    통과하므로(project_auth.py SSOT) ProjectAccess를 skip — 비-admin만 명시 grant."""
     from app.core.security import hash_password
+    from app.models.member import Member
     from app.models.project import OrgMember
-    from app.models.team import TeamMember
+    from app.models.project_access import ProjectAccess
     from app.models.user import User
 
     user_id = uuid.uuid4()
-    member_id = uuid.uuid4()
     session.add(User(
         id=user_id, email=f"u-{user_id.hex[:8]}@test.com",
         hashed_password=hash_password("x"), is_active=True, email_verified=True,
     ))
     await session.commit()
-    session.add(OrgMember(id=member_id, org_id=org_id, user_id=user_id, role=role))
-    session.add(TeamMember(
-        id=member_id, org_id=org_id, project_id=project_id, user_id=user_id,
-        type="human", name=f"h-{member_id.hex[:6]}", role=("owner" if role == "owner" else "member"),
-    ))
+
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role=role)
+    session.add(om)
     await session.commit()
-    return user_id, member_id
+
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user_id, name=f"h-{om.id.hex[:6]}")
+    session.add(m)
+    await session.commit()
+
+    if role not in ("owner", "admin"):
+        session.add(ProjectAccess(
+            id=uuid.uuid4(), project_id=project_id, org_member_id=om.id, member_id=m.id,
+            permission="granted", role=role,
+        ))
+        await session.commit()
+    return user_id, m.id
 
 
 async def _seed_agent(session, *, org_id, project_id):
-    from app.models.team import TeamMember
+    """에이전트 1명 — members + agent_project_profiles(뷰 런타임 조인) + project_access(grant,
+    has_project_access의 에이전트 branch가 요구) 3-write(`_make_agent_member`와 동형)."""
+    from app.models.member import AgentProjectProfile, Member
+    from app.models.project_access import ProjectAccess
 
     member_id = uuid.uuid4()
-    session.add(TeamMember(
-        id=member_id, org_id=org_id, project_id=project_id, user_id=None,
-        type="agent", name=f"a-{member_id.hex[:6]}", role="member",
+    session.add(Member(
+        id=member_id, org_id=org_id, type="agent", user_id=None, name=f"a-{member_id.hex[:6]}",
+    ))
+    await session.commit()
+
+    session.add(AgentProjectProfile(id=uuid.uuid4(), member_id=member_id, project_id=project_id))
+    await session.commit()
+
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, org_member_id=None, member_id=member_id,
+        permission="granted", role="member",
     ))
     await session.commit()
     return member_id

--- a/backend/tests/test_2697_project_scope_judge_count_lock.py
+++ b/backend/tests/test_2697_project_scope_judge_count_lock.py
@@ -1,0 +1,176 @@
+"""story #2697([BE·인가·프로젝트 스코프]) — 판정 함수 한 곳 카운트락.
+
+GET/PATCH/DELETE-by-id 라우터들이 각자 `if not await has_project_access(...): raise
+HTTPException(...)` 3줄을 복제하던 것(리소스 타입별 404/403 들쭉날쭉의 근원)을
+`project_auth.require_project_access`(SSOT)로 수렴했다 — goals.py 4곳·stories.py
+`_assert_story_project_access`·sprints.py 8곳·retros.py 4곳·gates.py 2곳(스토리 원 제목이
+지목한 5개 리소스: goals·stories·conversations·sprints, 참고 리소스 retros·gates).
+
+⚠️스코프 정직 고지: AST 전수 스캔 결과 이 정확한 인라인 패턴이 backend/app 전역에 baseline
+59건 더 있다(docs.py·standups.py·attachments.py·assets.py·agent_runs.py·evidence.py·
+file_locks.py·meetings.py·workflow_templates.py 등 20+ 파일) — #2697 PO 승인 스코프(좁음,
+conversations.py 실결함 + 상태코드 통일 + 음성대조 테스트)는 이 전체를 수렴하지 않는다.
+baseline=0으로 두면 "다 고쳤다"는 거짓 신호가 된다 — 실측 59를 그대로 고정한다(#2694
+AC②가 #2696을 낳은 것과 동형 — 이번엔 마감 없이 스토리 본문에 후속 후보 목록만 남긴다).
+이 59 안에는 goals.py:113(list 엔드포인트 쿼리필터, by-id 아님)·goals.py:331(steer_dispatch
+커밋 뮤테이션, 이미 404로 존재 확인된 後의 의도된 403)·stories.py 1600/2234(delete_story의
+SEC-S3 의도된 403 — 이 스토리 스코프 밖 기존 결정)처럼 «raise하지만 이 스토리가 다루는
+GET-by-id 존재-비노출 클래스가 아닌» 정당한 잔존도 섞여 있다 — baseline은 그 구분 없이
+전체 카운트를 고정해, 늘면(신규든 회귀든) 사람이 다시 살펴보게 한다."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_APP = Path(__file__).resolve().parent.parent / "app"
+
+# 2026-08-16 실측(develop HEAD 5dcdd75e 기준) — 정확한 자리를 고정해 "어디가 늘었는지"를
+# count 불일치가 아니라 diff로 바로 보여준다. 늘어나면 왜 늘었는지 검토 후 의식적으로만 올릴 것.
+_KNOWN_HITS = {
+    "app/dependencies/auth.py:823",
+    "app/dependencies/project_scope.py:61",
+    "app/dependencies/project_scope.py:71",
+    "app/routers/activity_logs.py:97",
+    "app/routers/activity_stream.py:41",
+    "app/routers/agent_runs.py:65",
+    "app/routers/agent_runs.py:106",
+    "app/routers/agent_runs.py:159",
+    "app/routers/analytics.py:47",
+    "app/routers/assets.py:146",
+    "app/routers/assets.py:252",
+    "app/routers/assets.py:300",
+    "app/routers/attachments.py:198",
+    "app/routers/auth.py:1557",
+    "app/routers/context_pack.py:50",
+    "app/routers/current_project.py:79",
+    "app/routers/docs.py:339",
+    "app/routers/docs.py:373",
+    "app/routers/docs.py:412",
+    "app/routers/docs.py:434",
+    "app/routers/docs.py:697",
+    "app/routers/docs.py:970",
+    "app/routers/docs.py:1095",
+    "app/routers/entities.py:316",
+    "app/routers/evidence.py:112",
+    "app/routers/file_locks.py:295",
+    "app/routers/gate_config.py:75",
+    "app/routers/glance.py:120",
+    "app/routers/goals.py:113",
+    "app/routers/goals.py:331",
+    "app/routers/meetings.py:37",
+    "app/routers/meetings.py:65",
+    "app/routers/members.py:54",
+    "app/routers/oss.py:34",
+    "app/routers/policy_documents.py:29",
+    "app/routers/project_settings.py:27",
+    "app/routers/reference_candidates.py:40",
+    "app/routers/references.py:153",
+    "app/routers/rewards.py:47",
+    "app/routers/standups.py:176",
+    "app/routers/standups.py:294",
+    "app/routers/standups.py:340",
+    "app/routers/standups.py:355",
+    "app/routers/standups.py:423",
+    "app/routers/stories.py:1600",
+    "app/routers/stories.py:2234",
+    "app/routers/team_members.py:180",
+    "app/routers/team_members.py:592",
+    "app/routers/workflow_executions.py:70",
+    "app/routers/workflow_report.py:158",
+    "app/routers/workflow_templates.py:104",
+    "app/routers/workflow_trigger.py:45",
+    "app/services/loop.py:92",
+    "app/services/member_resolver.py:77",
+    "app/services/member_resolver.py:93",
+    "app/services/member_resolver.py:157",
+    "app/services/member_resolver.py:173",
+    "app/services/project_auth.py:413",
+    "app/services/workflow_parallel_approval.py:308",
+}
+_RAW_INLINE_RAISE_BASELINE = len(_KNOWN_HITS)
+
+
+def _find_raw_inline_raise_patterns() -> list[str]:
+    """`if not await has_project_access(...):` 바로 다음 줄(들)이 `raise HTTPException(...)`인
+    자리를 찾는다 — require_project_access로 수렴 안 한 잔존 인라인 판정."""
+    hits: list[str] = []
+    for path in sorted(_APP.rglob("*.py")):
+        try:
+            src = path.read_text(encoding="utf-8")
+            tree = ast.parse(src, filename=str(path))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            test = node.test
+            # `not await has_project_access(...)` 패턴만 겨냥(양성 boolean 사용 — list
+            # comprehension·reason-string 반환 등 raise 아닌 자리는 대상 아님, 의도적 제외).
+            is_target = (
+                isinstance(test, ast.UnaryOp)
+                and isinstance(test.op, ast.Not)
+                and isinstance(test.operand, ast.Await)
+                and isinstance(test.operand.value, ast.Call)
+                and isinstance(test.operand.value.func, ast.Name)
+                and test.operand.value.func.id == "has_project_access"
+            )
+            if not is_target:
+                continue
+            body_is_raise = (
+                len(node.body) == 1
+                and isinstance(node.body[0], ast.Raise)
+            )
+            if body_is_raise:
+                hits.append(f"{path.relative_to(_APP.parent)}:{node.lineno}")
+    return hits
+
+
+def test_require_project_access_helper_exists_and_is_importable():
+    """양성대조 — SSOT 헬퍼 자체가 존재하는지(스캐너가 무력화돼도 이 자리는 잡는다)."""
+    from app.services.project_auth import require_project_access
+    import inspect
+
+    assert inspect.iscoroutinefunction(require_project_access)
+    sig = inspect.signature(require_project_access)
+    assert "not_found_detail" in sig.parameters
+
+
+def test_no_new_raw_inline_project_access_raise_patterns():
+    """count-lock — raw 인라인 `if not await has_project_access(...): raise` 패턴이
+    baseline(0)을 넘지 않는지. mutation-kill: 아무 라우터에 그 패턴을 추가하면 RED."""
+    hits = _find_raw_inline_raise_patterns()
+    assert set(hits) - _KNOWN_HITS == set(), f"신규 잔존(baseline에 없던 자리): {set(hits) - _KNOWN_HITS}"
+    assert len(hits) == _RAW_INLINE_RAISE_BASELINE, (
+        f"require_project_access로 안 수렴한 인라인 raise 패턴: {hits}\n"
+        "정말 raw가 필요하면 사유 주석 남기고 이 baseline을 의식적으로 올릴 것."
+    )
+
+
+def test_ast_scan_catches_raw_pattern_fixture():
+    """스캐너 자체의 양성대조 — 실제로 그 패턴이 있는 fixture는 잡히는지(공허통과 방지)."""
+    import tempfile
+
+    fixture_src = (
+        "async def f(session, user_id, project_id, org_id):\n"
+        "    if not await has_project_access(session, user_id, project_id, org_id):\n"
+        "        raise HTTPException(status_code=404, detail='x')\n"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        (tmp_path / "fixture_router.py").write_text(fixture_src, encoding="utf-8")
+        tree = ast.parse(fixture_src)
+        found = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            test = node.test
+            if (
+                isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not)
+                and isinstance(test.operand, ast.Await)
+                and isinstance(test.operand.value, ast.Call)
+                and isinstance(test.operand.value.func, ast.Name)
+                and test.operand.value.func.id == "has_project_access"
+                and len(node.body) == 1 and isinstance(node.body[0], ast.Raise)
+            ):
+                found = True
+        assert found, "스캐너 로직 자체가 이 fixture 패턴을 못 잡는다면 count-lock이 공허통과함"

--- a/backend/tests/test_2697_project_scope_judge_count_lock.py
+++ b/backend/tests/test_2697_project_scope_judge_count_lock.py
@@ -24,8 +24,12 @@ from pathlib import Path
 
 _APP = Path(__file__).resolve().parent.parent / "app"
 
-# 2026-08-16 실측(develop HEAD 5dcdd75e 기준) — 정확한 자리를 고정해 "어디가 늘었는지"를
-# count 불일치가 아니라 diff로 바로 보여준다. 늘어나면 왜 늘었는지 검토 후 의식적으로만 올릴 것.
+# 2026-08-16 실측(develop HEAD 2a5a1cbfb 기준, #2696 merge 후 재측 — team_members.py:592→594·
+# workflow_parallel_approval.py:308→310는 #2696의 via_outbox=True 라인 삽입에 의한 순수
+# 줄번호 드리프트였다(카디르 최초 리포트는 "신규 잔존"으로 읽었으나 git diff로 대조한 결과
+# 헬퍼 미전환 신규 발생이 아니라 그 두 자리였음 그대로임을 확인 — count=59 불변, 그 2건만
+# 좌표 이동) — 정확한 자리를 고정해 "어디가 늘었는지"를 count 불일치가 아니라 diff로 바로
+# 보여준다. 진짜로 늘어나면 왜 늘었는지 검토 후 의식적으로만 올릴 것.
 _KNOWN_HITS = {
     "app/dependencies/auth.py:823",
     "app/dependencies/project_scope.py:61",
@@ -74,7 +78,7 @@ _KNOWN_HITS = {
     "app/routers/stories.py:1600",
     "app/routers/stories.py:2234",
     "app/routers/team_members.py:180",
-    "app/routers/team_members.py:592",
+    "app/routers/team_members.py:594",
     "app/routers/workflow_executions.py:70",
     "app/routers/workflow_report.py:158",
     "app/routers/workflow_templates.py:104",
@@ -85,7 +89,7 @@ _KNOWN_HITS = {
     "app/services/member_resolver.py:157",
     "app/services/member_resolver.py:173",
     "app/services/project_auth.py:413",
-    "app/services/workflow_parallel_approval.py:308",
+    "app/services/workflow_parallel_approval.py:310",
 }
 _RAW_INLINE_RAISE_BASELINE = len(_KNOWN_HITS)
 

--- a/backend/tests/test_chat_visibility_admin_bypass.py
+++ b/backend/tests/test_chat_visibility_admin_bypass.py
@@ -4,13 +4,25 @@ admin-bypass(owner/admin org-level 조회)를 **agent-only 대화로 한정**한
 근본: org owner/admin이 participant 우회로 남의 휴먼↔에이전트 사적 DM을 열람.
 정책(PO APPROVE): 참가자에 휴먼이 있으면 private → participant만 조회(owner/admin도 우회 금지).
 휴먼 없음(agent-only·팀운영)이면 admin 조회 허용. 본인 참여 대화는 항상 정상.
-보수적 human 판별: TeamMember.type='agent'로 확정된 id만 agent, 나머지 전부 human
-(grant-only OrgMember·미앵커 휴먼·봉희신류 포함).
+
+story #2697: get_conversation()이 자체 `_effective_org_role`+`_conversation_has_human_
+participant`(bespoke, pre-resolve TOCTOU류)를 쓰던 것을 `_can_read_conversation`
+(conversation_readable_predicate SSOT — backlinks.py·list_conversations가 이미 쓰던 것)로
+통일했다. `_conversation_has_human_participant` **함수 자체는 존치**(conversations.py에
+그대로 남음) — attachments.py의 authorize 엔드포인트가 여전히 이 함수를 직접 import해
+자기 admin-bypass 판정에 쓰는 별도 소비자였다(test_attachment_authorize_a54ddc16.py로
+발견 — 처음엔 삭제했다가 그 파일의 3개 테스트가 ImportError로 잡아줬다). get_conversation()
+만 predicate SSOT로 이관·이 함수를 더 이상 호출 안 함. get_conversation() 엔드포인트 레벨
+회귀(admin-bypass 유지·403→404 통일·cross-project 음성대조)는
+test_2697_conversation_project_scope_realdb.py로 이관했다 — 이 파일은 그 마이그레이션과
+무관한 `_conversations_with_human_participant`(list_conversations의 배치 헬퍼, 미변경)와
+`list_messages`(별도 함수, 미변경) 테스트만 남긴다. `_conversation_has_human_participant`
+자체의 단위테스트(CP1-3)는 test_conv_human_participant_realdb.py(실 VIEW 락)가 이미
+있으므로 여기서 재작성하지 않는다.
 
 테스트 전략:
-- 헬퍼(_conversation_has_human_participant / _conversations_with_human_participant)는
-  라우팅 mock으로 직접 검증(CP1/CP2/CP3 핵심 로직).
-- 3엔드포인트(detail/messages/list) 일관성은 헬퍼 게이트 호출 경로로 검증(CP4/CP5).
+- CP5: `_conversations_with_human_participant`(배치 헬퍼)는 라우팅 mock으로 직접 검증.
+- CP5(messages): list_messages의 admin-bypass/private 일관성(이 스토리에서 안 건드림).
 """
 from __future__ import annotations
 
@@ -19,22 +31,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from datetime import datetime, timezone
-
 
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
-
-
-def _make_conv(*, conv_id, org_id, project_id, conv_type="dm"):
-    """ConversationResponse.model_validate가 통과하도록 유효 필드를 가진 conv 객체."""
-    from types import SimpleNamespace
-    now = datetime(2026, 6, 8, tzinfo=timezone.utc)
-    return SimpleNamespace(
-        id=conv_id, project_id=project_id, org_id=org_id, type=conv_type,
-        title="대화", status="open", created_by=conv_id, created_at=now, updated_at=now,
-    )
 
 
 # ─── 라우팅 mock: 컴파일 statement의 from-entity로 결과 분기 ────────────────────
@@ -78,66 +78,6 @@ def _routing_db(*, participant_rows, agent_ids):
     return db
 
 
-# ─── CP1: team_member 휴먼 참가 → private(휴먼 있음) ──────────────────────────
-
-@pytest.mark.anyio
-async def test_cp1_team_member_human_is_private():
-    """admin 비참가 + team_member 휴먼 참가 대화 → has_human=True(=private·403 폴백)."""
-    from app.routers.conversations import _conversation_has_human_participant
-
-    conv = uuid.uuid4()
-    human = uuid.uuid4()
-    agent = uuid.uuid4()
-    db = _routing_db(
-        participant_rows=[(conv, human), (conv, agent)],
-        agent_ids={agent},  # human은 agent 확정 아님 → human
-    )
-    assert await _conversation_has_human_participant(conv, db) is True
-
-
-# ─── CP2: grant-only OrgMember 휴먼(team_member agent 아님) → 보수적 human ──────
-
-@pytest.mark.anyio
-async def test_cp2_grant_only_human_conservative_private():
-    """grant-only OrgMember 휴먼(봉희신류·team_member agent 아님) 참가 → 보수적으로 human → private."""
-    from app.routers.conversations import _conversation_has_human_participant
-
-    conv = uuid.uuid4()
-    grant_only_human = uuid.uuid4()  # team_members에 agent로 없음
-    agent = uuid.uuid4()
-    db = _routing_db(
-        participant_rows=[(conv, grant_only_human), (conv, agent)],
-        agent_ids={agent},  # grant_only_human은 agent 확정 외 → human
-    )
-    assert await _conversation_has_human_participant(conv, db) is True
-
-
-# ─── CP3: agent-only 대화 → admin 조회 허용 ──────────────────────────────────
-
-@pytest.mark.anyio
-async def test_cp3_agent_only_allows_admin():
-    """참가자 전부 type='agent' → has_human=False(=admin 200 허용)."""
-    from app.routers.conversations import _conversation_has_human_participant
-
-    conv = uuid.uuid4()
-    a1, a2 = uuid.uuid4(), uuid.uuid4()
-    db = _routing_db(
-        participant_rows=[(conv, a1), (conv, a2)],
-        agent_ids={a1, a2},
-    )
-    assert await _conversation_has_human_participant(conv, db) is False
-
-
-@pytest.mark.anyio
-async def test_empty_participants_not_private():
-    """참가자 없음(엣지) → has_human=False(헬퍼는 admin 폴백 안 함·404/참가체크는 호출부 책임)."""
-    from app.routers.conversations import _conversation_has_human_participant
-
-    conv = uuid.uuid4()
-    db = _routing_db(participant_rows=[], agent_ids=set())
-    assert await _conversation_has_human_participant(conv, db) is False
-
-
 # ─── CP5: batch 헬퍼(list_conversations) — agent-only만 통과 ──────────────────
 
 @pytest.mark.anyio
@@ -169,179 +109,6 @@ async def test_cp5_batch_empty_input():
     db.execute = AsyncMock(side_effect=AssertionError("should not query on empty input"))
     assert await _conversations_with_human_participant([], db) == set()
 
-
-# ─── CP4 + 3엔드포인트 일관성: detail/messages가 휴먼 참가 시 participant 폴백 ──
-
-def _admin_routing_db(*, conv, project_id, participant_member_ids, agent_ids, admin_role="admin",
-                      requester_is_participant):
-    """detail/messages 엔드포인트 통합 mock.
-
-    - Conversation 조회 → conv (project_id 포함)
-    - _resolve_member(TeamMember) → admin sender
-    - _effective_org_role(OrgMember.role) → admin_role
-    - 헬퍼 participant/agent 조회 → human 판별
-    - participant 체크 → requester_is_participant
-    - story #2009: get_conversation이 `_fetch_conversation_participants`(participants 배치
-      + lookup_members_by_ids + runtime_type 배치)를 추가로 호출 — 컬럼명 기반으로 정밀 분기.
-    """
-    from collections import namedtuple
-
-    sender = MagicMock()
-    sender.id = uuid.uuid4()
-    sender.role = "member"  # raw project role 낮음 — org에서 admin 상속
-    sender.type = "human"
-    sender.name = "admin user"
-
-    ParticipantRow = namedtuple("ParticipantRow", ["conversation_id", "member_id"])
-    RuntimeTypeRow = namedtuple("RuntimeTypeRow", ["id", "runtime_type"])
-
-    def _resolved_member_mock(mid):
-        m = MagicMock()
-        m.id = mid
-        m.user_id = uuid.uuid4()
-        m.name = f"member-{str(mid)[:8]}"
-        m.type = "agent" if mid in agent_ids else "human"
-        m.role = "member"
-        m.org_id = conv.org_id
-        m.project_id = project_id
-        m.avatar_url = None
-        return m
-
-    async def _execute(stmt, *a, **k):
-        sql = str(stmt).lower()
-        cols = list(stmt.selected_columns) if hasattr(stmt, "selected_columns") else []
-        col_names = {c.name for c in cols} if cols else set()
-
-        # Conversation 단건 조회(participant 테이블 미포함 + conversations FROM)
-        if "from conversations" in sql and "conversation_participants" not in sql:
-            res = MagicMock()
-            res.scalar_one_or_none.return_value = conv
-            return res
-        if "org_members" in sql:
-            res = MagicMock()
-            res.scalar_one_or_none.return_value = admin_role
-            return res
-        if "conversation_participants" in sql:
-            if col_names == {"conversation_id", "member_id"}:
-                # story #2009: `_fetch_conversation_participants`(및 `_conversations_with_human_
-                # participant`)의 배치 조회 — attribute+tuple 겸용 namedtuple로 실 Row 흉내.
-                return _rows_all([
-                    ParticipantRow(conversation_id=conv.id, member_id=mid)
-                    for mid in participant_member_ids
-                ])
-            if col_names == {"muted_at", "last_read_at"}:
-                # 270c87e6/#1976: caller mute/read-state 조회 — one_or_none() 사용.
-                res = MagicMock()
-                row = MagicMock()
-                row.muted_at = None
-                row.last_read_at = None
-                res.one_or_none.return_value = row if requester_is_participant else None
-                return res
-            # 단건: member_id 헬퍼(1-col) 또는 participant 체크(scalar_one_or_none)
-            res = MagicMock()
-            res.scalars.return_value.all.return_value = list(participant_member_ids)
-            res.scalar_one_or_none.return_value = (uuid.uuid4() if requester_is_participant else None)
-            return res
-        if "team_members" in sql:
-            # 4용도: _resolve_member(sender) / 헬퍼 agent 확정(1-col) /
-            # story #2009 lookup_members_by_ids(full-row) / runtime_type 배치(2-col).
-            if col_names == {"id", "runtime_type"}:
-                return _rows_all([
-                    RuntimeTypeRow(id=mid, runtime_type=("claude_code" if mid in agent_ids else None))
-                    for mid in participant_member_ids
-                ])
-            if col_names == {"id"} and "type" in sql and ("in (" in sql or "in(" in sql):
-                return _scalars_all(list(agent_ids))
-            if "team_members.id in" in sql or "team_members.id in(" in sql:
-                # story #2009: lookup_members_by_ids(전체 컬럼 select, id IN 필터).
-                return _scalars_all([_resolved_member_mock(mid) for mid in participant_member_ids])
-            # _resolve_member: user_id/org_id(/project_id) 등치 필터, id IN 아님.
-            res = MagicMock()
-            res.scalars.return_value.first.return_value = sender
-            return res
-        res = MagicMock()
-        res.scalars.return_value.all.return_value = []
-        res.scalar_one_or_none.return_value = None
-        return res
-
-    db = AsyncMock()
-    db.execute = AsyncMock(side_effect=_execute)
-    return db, sender
-
-
-@pytest.mark.anyio
-async def test_cp4_admin_own_participation_passes_detail():
-    """CP4: admin이 휴먼 참가 대화에 본인도 참가 → 정상 통과(403 아님)."""
-    from app.routers.conversations import get_conversation
-    from app.dependencies.auth import AuthContext  # noqa: F401
-
-    org_id = uuid.uuid4()
-    project_id = uuid.uuid4()
-    conv = _make_conv(conv_id=uuid.uuid4(), org_id=org_id, project_id=project_id, conv_type="dm")
-
-    human = uuid.uuid4()
-    agent = uuid.uuid4()
-    db, sender = _admin_routing_db(
-        conv=conv, project_id=project_id,
-        participant_member_ids=[human, agent], agent_ids={agent},
-        requester_is_participant=True,  # admin 본인 참가
-    )
-    auth = MagicMock()
-    auth.user_id = str(uuid.uuid4())
-    auth.claims = {"app_metadata": {}}
-
-    # participant이므로 403 안 남
-    resp = await get_conversation(conv.id, db=db, auth=auth, org_id=org_id)  # type: ignore[arg-type]
-    assert resp is not None
-
-
-@pytest.mark.anyio
-async def test_cp4_admin_nonparticipant_human_conv_403_detail():
-    """CP1/CP5(detail): admin 비참가 + 휴먼 참가 대화 → 403(private participant only)."""
-    from fastapi import HTTPException
-    from app.routers.conversations import get_conversation
-
-    org_id = uuid.uuid4()
-    project_id = uuid.uuid4()
-    conv = _make_conv(conv_id=uuid.uuid4(), org_id=org_id, project_id=project_id, conv_type="dm")
-
-    human = uuid.uuid4()
-    agent = uuid.uuid4()
-    db, sender = _admin_routing_db(
-        conv=conv, project_id=project_id,
-        participant_member_ids=[human, agent], agent_ids={agent},
-        requester_is_participant=False,  # admin 비참가
-    )
-    auth = MagicMock()
-    auth.user_id = str(uuid.uuid4())
-    auth.claims = {"app_metadata": {}}
-
-    with pytest.raises(HTTPException) as ei:
-        await get_conversation(conv.id, db=db, auth=auth, org_id=org_id)  # type: ignore[arg-type]
-    assert ei.value.status_code == 403
-
-
-@pytest.mark.anyio
-async def test_cp3_admin_nonparticipant_agent_only_conv_200_detail():
-    """CP3(detail): admin 비참가 + agent-only 대화 → 통과(admin-bypass 허용)."""
-    from app.routers.conversations import get_conversation
-
-    org_id = uuid.uuid4()
-    project_id = uuid.uuid4()
-    conv = _make_conv(conv_id=uuid.uuid4(), org_id=org_id, project_id=project_id, conv_type="group")
-
-    a1, a2 = uuid.uuid4(), uuid.uuid4()
-    db, sender = _admin_routing_db(
-        conv=conv, project_id=project_id,
-        participant_member_ids=[a1, a2], agent_ids={a1, a2},  # agent-only
-        requester_is_participant=False,  # admin 비참가지만 agent-only → 허용
-    )
-    auth = MagicMock()
-    auth.user_id = str(uuid.uuid4())
-    auth.claims = {"app_metadata": {}}
-
-    resp = await get_conversation(conv.id, db=db, auth=auth, org_id=org_id)  # type: ignore[arg-type]
-    assert resp is not None
 
 
 def _messages_routing_db(*, conv_id, project_id, participant_member_ids, agent_ids,

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -448,13 +448,15 @@ async def test_get_conversation_200_returns_project_id():
         member_result = MagicMock()
         member_result.scalars.return_value.first.return_value = mock_member
 
-        # #1262: admin-bypass=agent-only 한정 — 휴먼 판별 헬퍼가 참가자/agent 조회.
-        # 본 테스트는 agent-only 대화로 두어 owner org-level 접근(우회 허용)을 검증.
-        agent_id = uuid.uuid4()
-        pids_result = MagicMock()
-        pids_result.scalars.return_value.all.return_value = [agent_id]
-        agents_result = MagicMock()
-        agents_result.scalars.return_value.all.return_value = [agent_id]  # 전원 agent 확정
+        # story #2697: get_conversation이 _can_read_conversation(conversation_readable_predicate
+        # SSOT)로 통일된 후의 실 쿼리 순서 — ①_resolve_member(project_id=None, SSOT 내부)
+        # ②has_project_access(project_access_valid atom) ③predicate 자체(admin_bypass_eligible이
+        # agent-only 대화라 True로 correlate) ④_resolve_member 재해소(gate 통과 後, project_id=
+        # conv.project_id) ⑤muted/read-state ⑥participants 배치.
+        access_valid_result = MagicMock()
+        access_valid_result.scalar_one_or_none.return_value = True  # has_project_access(owner 4-branch)
+        predicate_result = MagicMock()
+        predicate_result.scalar_one.return_value = True  # agent-only 대화 + owner → predicate True
 
         # 270c87e6: detail이 caller (muted_at, last_read_at) 조회 1건 추가(story #1976: last_read_at
         # 편승) — 비참여(agent-only)면 row 자체가 None(=미mute·unread_count 계산 스킵).
@@ -469,7 +471,8 @@ async def test_get_conversation_200_returns_project_id():
         participants_result.all.return_value = []
 
         session.execute = AsyncMock(side_effect=[
-            conv_result, member_result, pids_result, agents_result, muted_result, participants_result,
+            conv_result, member_result, access_valid_result, predicate_result,
+            member_result, muted_result, participants_result,
         ])
 
         async with client as c:

--- a/backend/tests/test_e_security_sec_s8_v_conversation_agent_admin_bypass_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_v_conversation_agent_admin_bypass_realdb.py
@@ -136,8 +136,11 @@ async def _setup_app_agent(app, Session, agent_id, org_id):
 
 @pytest.mark.anyio
 async def test_mixed_role_agent_cannot_get_conversation_without_project_grant():
-    """V 재현: project_x=admin·project_y=grant 0인 에이전트가 project_y 대화 GET → 403
-    (기존엔 admin-bypass가 임의 row role로 통과해 200이었음)."""
+    """V 재현: project_x=admin·project_y=grant 0인 에이전트가 project_y 대화 GET → 404
+    (기존엔 admin-bypass가 임의 row role로 통과해 200이었음). story #2697: get_conversation()이
+    conversation_readable_predicate SSOT로 이관되며 이 엔드포인트의 거부 상태코드가 403("Not a
+    participant")→404(존재-비노출 — 다른 리소스 다수 관례와 통일)로 바뀌었다. list_messages
+    (아래 두 번째 테스트)는 #2697이 안 건드린 별도 경로라 403 그대로."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -149,7 +152,7 @@ async def test_mixed_role_agent_cannot_get_conversation_without_project_grant():
         client = _client_for(app)
         try:
             resp = await client.get(f"/api/v2/conversations/{seeded['conv_y_id']}")
-            assert resp.status_code == 403, resp.text
+            assert resp.status_code == 404, resp.text
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -81,12 +81,15 @@ def _mock_vote() -> MagicMock:
 
 
 def _allow_project_access():
-    """has_project_access를 True로 patch(router-local import 경로) — session-scope pre-check용."""
-    return patch("app.routers.retros.has_project_access", new=AsyncMock(return_value=True))
+    """has_project_access를 True로 patch — story #2697: 라우터가 이제 전부
+    require_project_access(project_auth.py SSOT)를 경유하고, 그 함수는 같은 모듈 안에서
+    has_project_access를 bare name으로 부른다 — router-local import가 아니라 진짜 소스
+    (app.services.project_auth.has_project_access)를 patch해야 라우터 무관하게 먹힌다."""
+    return patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True))
 
 
 def _deny_project_access():
-    return patch("app.routers.retros.has_project_access", new=AsyncMock(return_value=False))
+    return patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=False))
 
 
 def _mock_resolve_member(member_id: uuid.UUID | None = None, member_type: str = "human"):


### PR DESCRIPTION
## Summary
- **conversations.py 진짜 결함 수정**: `get_conversation()`이 `conversation_readable_predicate` SSOT(backlinks.py·list_conversations·`_can_read_conversation`이 이미 쓰던 것)로 안 옮겨간 마지막 소비자였음(리뷰어가 이전 라운드에서 명시적으로 스코프 밖으로 남겨둔 자리) — `_can_read_conversation`로 통일. 403("Not a participant")→404(존재-비노출, 다른 리소스 다수 관례)로 상태코드 통일.
- **판정 함수 한 곳**: `project_auth.require_project_access()` 신설 — goals.py 4곳·stories.py `_assert_story_project_access`·sprints.py 8곳·retros.py `_require_retro_project_access`·gates.py 2곳이 각자 인라인 복제하던 `if not await has_project_access(...): raise HTTPException(404, ...)` 3줄을 전부 이 함수로 수렴.
- **원 리포트 전제 정정**: 라이브 dev 실측(제 agent key, 비-admin) 결과 원래 리포트된 cross-project "200 leak"은 **org owner/admin 계정**에서만 재현됨 — `has_project_access`의 owner/admin 전-프로젝트 가시성은 의도된 정책이지 누락된 체크가 아니었음(PO 확認: sellerking=admin). goals/stories/sprints/retros/gates는 비-admin의 cross-project 읽기를 이미 올바르게 차단하고 있었고, **conversations.py만 진짜 갭**(has_project_access 호출 자체가 없었음, participant-only 로직)이었음.
- `_conversation_has_human_participant`는 삭제 대신 존치 — attachments.py의 authorize 엔드포인트가 별도 소비자로 여전히 직접 import(처음 삭제했다가 `test_attachment_authorize_a54ddc16.py`의 ImportError로 잡혀 복원).

## Test plan
- [x] `test_2697_conversation_project_scope_realdb.py`(신규): admin+agent-only 대화 200 무회귀·admin+human-participant 대화 404(구 403)·**same-org cross-project 비-admin 멤버 404**(스토리 핵심 관심사)·본인 참여자 200 — 전부 실PG
- [x] `test_2697_project_scope_judge_count_lock.py`(신규): AST 기반 — `require_project_access` 헬퍼 존재 pin + 잔존 인라인 raise 패턴 count-lock(baseline 59건 정직 고지, 이 스토리가 «다 고쳤다»고 주장 안 함) + 스캐너 양성대조
- [x] `test_chat_visibility_admin_bypass.py`/`test_conversations.py`/`test_retros.py`: 마이그레이션에 맞춰 개정(CP1-3 제거는 test_conv_human_participant_realdb.py 중복 커버로 대체, mock 쿼리 순서 갱신, `has_project_access` patch 타겟을 router-local에서 진짜 SSOT 소스로 수정)
- [x] `pytest -k "goal or story or sprint or retro or gate or conversation"`(non-realdb) 1063 passed — goals/stories/sprints/retros/gates/conversations 관련 회귀 0(개별 격리 재확인으로 로컬 schema 노이즈와 구분)
- [x] dev/prod 미접촉(라이브 repro는 read-only GET, 제 own agent key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)