### PR TITLE
[SID:2082] 결재함 큐 카드 — 고위험 인라인 승인(서명 모달) + 전 위험도 통합 액션 레이아웃

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3625,6 +3625,7 @@
     "overrideConfirm": "Override",
     "overriddenTag": "Owner override · SoD bypassed",
     "gateUndo": "Undo",
+    "gateUndoRemaining": "Undo available for {minutes} more min",
     "gateDiscussTitle": "Hold for discussion",
     "gateDiscussDescription": "Leaves the gate neither approved nor rejected. The requester will be notified with your reason.",
     "gateDiscussReasonLabel": "Reason for discussion",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3625,6 +3625,7 @@
     "overrideConfirm": "강제 실행",
     "overriddenTag": "Owner 강제 · SoD 우회",
     "gateUndo": "취소(오클릭 정정)",
+    "gateUndoRemaining": "{minutes}분 내 취소 가능",
     "gateDiscussTitle": "보류(논의 필요)",
     "gateDiscussDescription": "승인도 반려도 아닌 상태로 남깁니다. 상신자에게 사유가 전달됩니다.",
     "gateDiscussReasonLabel": "논의 사유",

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -289,28 +289,44 @@ describe('ApprovalsQueue', () => {
     });
   }
 
-  it('AC — 저위험(risk_grade=low)·승인권한 있는 gate는 인라인 승인/반려 버튼이 뜬다', async () => {
+  it('AC — 저위험(risk_grade=low)·승인권한 있는 gate는 인라인 승인/변경요청 버튼이 뜬다', async () => {
     mockFetches([lowRiskActionable()], []);
     await mount();
     const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
     expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(true);
-    expect(buttons.some((t) => t?.includes(koMessages.cage.gateReject))).toBe(true);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.sigRequestChanges))).toBe(true);
   });
 
-  it('AC "고위험 항목 인라인 승인 버튼 0" — risk_grade=high는 인라인 버튼이 아예 없고 행 전체가 상세 이동 버튼 하나뿐이다', async () => {
+  // story 22affaf2(PO 결정, 2026-08-16) — 구 #1961 AC "고위험 항목 인라인 승인 버튼 0"을
+  // 뒤집는다: 결재함 목록이 「전부 고위험」인 실사용에서 인라인이 아예 안 뜨는 게 이 P0의
+  // 실체였다(미르코 dev 실측). 이제 고위험도 인라인 카드를 받되, primary는 원탭이 아니라
+  // 서명 모달을 여는 진입점이다(승인 자체는 여전히 근거열람+사유 게이팅, 아래 별도 테스트).
+  it('AC(신규, 22affaf2) — risk_grade=high도 인라인 카드를 받는다·primary 라벨은 "승인하고 서명"(원탭 아님)', async () => {
     mockFetches([lowRiskActionable({ id: 'g-high', risk_grade: 'high' })], []);
     await mount();
     const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
-    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
-    expect(buttons.some((t) => t?.includes(koMessages.cage.gateReject))).toBe(false);
-    expect(container.querySelectorAll('button').length).toBe(1);
+    // "승인하고 서명"은 "승인"을 부분문자열로 포함하므로 정확히 일치하는 버튼이 없는지로 판정한다
+    // (원탭 전용 "승인" 단독 버튼이 안 남아있어야 함 — 서명 게이팅 우회 경로가 없다는 뜻).
+    expect(buttons.some((t) => t === koMessages.cage.sigApproveAndSign)).toBe(true);
+    expect(buttons.some((t) => t === koMessages.cage.gateApprove)).toBe(false);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.sigRequestChanges))).toBe(true);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateDiscussSubmit))).toBe(true);
   });
 
-  it('risk_grade가 unknown(미배선)이어도 인라인 버튼이 안 뜬다(보수적 고위험 취급, gate-risk.ts 정책)', async () => {
+  it('AC(신규, 22affaf2) — risk_grade=high에서 primary("승인하고 서명") 클릭은 즉시 transition을 안 부르고 서명 모달을 연다', async () => {
+    const calls = mockFetches([lowRiskActionable({ id: 'g-high2', risk_grade: 'high' })], []);
+    await mount();
+    const signBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.sigApproveAndSign));
+    await act(async () => { signBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(calls.filter((c) => c.method === 'POST')).toHaveLength(0);
+    expect(document.body.querySelector('[data-slot="dialog-content"]')).toBeTruthy();
+  });
+
+  it('unknown(risk_grade 미배선)도 이제 인라인 카드를 받되 고위험과 동형(서명 모달, 원탭 아님) — 보수적 취급 유지', async () => {
     mockFetches([lowRiskActionable({ id: 'g-unknown', risk_grade: null })], []);
     await mount();
     const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
-    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.sigApproveAndSign))).toBe(true);
   });
 
   it('can_approve=false면 저위험이어도 인라인 버튼이 안 뜬다(per-caller 권한 게이팅)', async () => {
@@ -368,10 +384,10 @@ describe('ApprovalsQueue', () => {
     expect(calls.filter((c) => c.method === 'POST')).toHaveLength(1);
   });
 
-  it('반려 클릭 시 status=rejected로 호출하고 반려됨 배지를 보인다', async () => {
+  it('변경 요청 클릭 시(저위험) status=rejected로 호출하고 반려됨 배지를 보인다', async () => {
     const calls = mockFetches([lowRiskActionable({ id: 'g-rej' })], []);
     await mount();
-    const rejectButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.gateReject));
+    const rejectButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.sigRequestChanges));
     await act(async () => { rejectButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     const postCall = calls.find((c) => c.method === 'POST');
     expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'rejected', note: null });
@@ -517,9 +533,116 @@ describe('ApprovalsQueue', () => {
   it('AC 음성대조 — 반려 직후(아직 승인/취소 안 됨)엔 취소 버튼이 즉시 뜨지 않다가, 반려 완료 후엔 뜬다', async () => {
     mockFetches([lowRiskActionable({ id: 'g-reject-undo' })], []);
     await mount();
-    const rejectButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.gateReject));
+    const rejectButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.sigRequestChanges));
     expect([...container.querySelectorAll('button')].some((b) => b.textContent?.includes(koMessages.cage.gateUndo))).toBe(false);
     await act(async () => { rejectButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect([...container.querySelectorAll('button')].some((b) => b.textContent?.includes(koMessages.cage.gateUndo))).toBe(true);
+  });
+
+  // story 22affaf2(유나 design③) — 고위험 인라인 서명 모달. canonical 상세와 동일 컴포넌트
+  // (GateSignatureApproval)를 nav 없이 Dialog로 연다. base-ui Dialog는 document.body에
+  // 포탈되므로(#2354 교훈) [data-slot="dialog-content"]로 스코프한다(위 보류 다이얼로그
+  // 테스트와 동일 관례).
+  describe('고위험 인라인 서명 모달(22affaf2)', () => {
+    function highRiskActionable(overrides: Partial<GateItem> = {}): GateItem {
+      return gate({
+        id: 'g-sig', gate_type: 'merge_gate', status: 'pending', requires_human: true,
+        can_approve: true, risk_grade: 'high', work_item_summary: { title: '고위험 항목', slug: null },
+        ...overrides,
+      });
+    }
+
+    async function openSignatureDialog() {
+      const signBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.cage.sigApproveAndSign);
+      await act(async () => { signBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      const dialog = document.body.querySelector('[data-slot="dialog-content"]');
+      expect(dialog).toBeTruthy();
+      return dialog!;
+    }
+
+    it('근거 열람 체크+사유 둘 다 없으면 [승인하고 서명] 비활성(canonical 상세와 동형 서명 게이팅 — 서명 생략 우회 경로 없음)', async () => {
+      mockFetches([highRiskActionable()], []);
+      await mount();
+      const dialog = await openSignatureDialog();
+      const signButton = Array.from(dialog.querySelectorAll('button')).find((b) => b.textContent === koMessages.cage.sigApproveAndSign) as HTMLButtonElement;
+      expect(signButton.disabled).toBe(true);
+    });
+
+    it('근거 열람 체크박스만으론 부족·사유까지 채워야 [승인하고 서명]이 풀린다', async () => {
+      mockFetches([highRiskActionable({ id: 'g-sig-evidence' })], []);
+      await mount();
+      const dialog = await openSignatureDialog();
+      const checkbox = dialog.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      await act(async () => {
+        checkbox.click();
+      });
+      const signButton = Array.from(dialog.querySelectorAll('button')).find((b) => b.textContent === koMessages.cage.sigApproveAndSign) as HTMLButtonElement;
+      expect(signButton.disabled).toBe(true); // 사유 아직 없음
+      const textarea = dialog.querySelector('textarea') as HTMLTextAreaElement;
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+        setter.call(textarea, '근거 확認 완료');
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+      expect(signButton.disabled).toBe(false);
+    });
+
+    it('서명 완료 시 note=사유로 transition POST·모달이 닫히고 큐 카드가 완료 상태로 즉시 바뀐다(재조회 없이)', async () => {
+      const calls = mockFetches([highRiskActionable({ id: 'g-sig-approve' })], []);
+      await mount();
+      const dialog = await openSignatureDialog();
+      const checkbox = dialog.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      await act(async () => { checkbox.click(); });
+      const textarea = dialog.querySelector('textarea') as HTMLTextAreaElement;
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+        setter.call(textarea, '근거 확認·서명 사유');
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+      const signButton = Array.from(dialog.querySelectorAll('button')).find((b) => b.textContent === koMessages.cage.sigApproveAndSign) as HTMLButtonElement;
+      await act(async () => { signButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+      const postCall = calls.find((c) => c.method === 'POST' && c.url.includes('/transition'));
+      expect(postCall?.url).toBe('/api/gates/g-sig-approve/transition');
+      expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'approved', note: '근거 확認·서명 사유' });
+      expect(document.body.querySelector('[data-slot="dialog-content"]')).toBeFalsy();
+      expect(container.textContent).toContain(koMessages.cage.queueResolvedApproved);
+    });
+
+    it('모달 안 [변경 요청]은 근거 열람 없이도(사유만 있으면) status=rejected로 note와 함께 제출한다', async () => {
+      const calls = mockFetches([highRiskActionable({ id: 'g-sig-reject' })], []);
+      await mount();
+      const dialog = await openSignatureDialog();
+      const textarea = dialog.querySelector('textarea') as HTMLTextAreaElement;
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+        setter.call(textarea, '재작업 필요');
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+      const rejectButtons = Array.from(dialog.querySelectorAll('button')).filter((b) => b.textContent === koMessages.cage.sigRequestChanges);
+      await act(async () => { rejectButtons[0]?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+      const postCall = calls.find((c) => c.method === 'POST' && c.url.includes('/transition'));
+      expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'rejected', note: '재작업 필요' });
+      expect(container.textContent).toContain(koMessages.cage.queueResolvedRejected);
+    });
+
+    it('큐 카드의 행2 [변경 요청] 버튼을 직접 눌러도(모달을 열지 않고) 고위험은 여전히 모달을 연다(서명 우회 경로 없음)', async () => {
+      const calls = mockFetches([highRiskActionable({ id: 'g-sig-reject-entry' })], []);
+      await mount();
+      const rejectEntry = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.sigRequestChanges));
+      await act(async () => { rejectEntry?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(calls.filter((c) => c.method === 'POST')).toHaveLength(0);
+      expect(document.body.querySelector('[data-slot="dialog-content"]')).toBeTruthy();
+    });
+  });
+
+  // story 22affaf2(유나 design⑤) — undo 어포던스에 "N분 내 취소 가능" 힌트가 버튼과 함께 뜬다.
+  it('AC(신규, 22affaf2) — 인라인 승인 직후 "N분 내 취소 가능" 힌트가 취소 버튼과 함께 뜬다', async () => {
+    mockFetches([lowRiskActionable({ id: 'g-hint' })], []);
+    await mount();
+    const approveButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.gateApprove));
+    await act(async () => { approveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.textContent).toContain(koMessages.cage.gateUndoRemaining.replace('{minutes}', '5'));
   });
 });

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -6,11 +6,13 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { CheckCircle, XCircle } from 'lucide-react';
 import { deriveRiskLevel, usesSignatureFlow } from '@/components/cage/gate-risk';
 import { gateNeedsAction } from '@/components/cage/gate-evidence';
 import { GateUndoButton, UNDO_WINDOW_MS } from '@/components/cage/gate-undo-button';
 import { GateDiscussDialog } from '@/components/cage/gate-discuss-dialog';
+import { GateSignatureApproval } from '@/components/cage/gate-signature-approval';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateInboxItem, GateItem, HitlInboxItem } from '@/components/kanban/types';
 
@@ -66,11 +68,14 @@ function isCanonicalizeGate(gate: GateItem): boolean {
 function needsAction(gate: GateItem): boolean {
   return gate.status === 'pending' && (gateNeedsAction(gate) || isDocGate(gate) || isCanonicalizeGate(gate));
 }
-// story #1961 AC — "고위험 항목 인라인 승인 버튼 0". risk==='low' 확정일 때만 이 큐 안에서
-// 바로 승인/반려한다(gate-risk.ts usesSignatureFlow와 동일 경계 — high·unknown은 원탭 대상
-// 아님, 클릭하면 canonical 상세의 서명 플로우로 간다).
+// story 22affaf2(PO 결정, 2026-08-16) — 구 #1961 AC "고위험 항목 인라인 승인 버튼 0"을
+// 뒤집는다: 「함에서 승인/거절 못 함」의 실체가 고위험 인라인 부재였다(저위험은 이미
+// #1961/#2631로 인라인 완비). 이제 위험도와 무관하게 인라인 처리 가능 — 고위험은
+// GateSignatureApproval을 큐 안에서 Dialog로 열어 서명 플로우(근거열람+사유 없인 승인
+// 비활성)를 그대로 거친다(서명 생략이 아니다, 아래 렌더 분기 참조). usesSignatureFlow는
+// 이제 "인라인 가능 여부"가 아니라 "그 인라인이 원탭인지 서명모달인지"만 가른다.
 function canInlineResolve(gate: GateItem): boolean {
-  return needsAction(gate) && gate.can_approve === true && !usesSignatureFlow(deriveRiskLevel(gate)) && !isHeld(gate);
+  return needsAction(gate) && gate.can_approve === true && !isHeld(gate);
 }
 
 // AC §3.1 "노화 표시" — BE 신규 필드 불요, 기존 created_at으로 직접 계산(오르테가군 판정).
@@ -78,6 +83,17 @@ function formatAge(createdAt: string, t: ReturnType<typeof useTranslations>): st
   const days = Math.floor((Date.now() - new Date(createdAt).getTime()) / 86_400_000);
   if (days <= 0) return t('queueAgeToday');
   return t('queueAgeDays', { days });
+}
+
+// story 22affaf2(유나 design⑤) — undo 어포던스에 "N분 내 취소 가능" 미세 힌트를 곁들인다
+// (안전망 인지 자체가 오발 방지의 일부 — 버튼만 덜렁 있는 것보다 "아직 취소 가능한 창"임을
+// 명시). 5분 경과분은 null(호출부가 이미 UNDO_WINDOW_MS로 버튼 자체를 안 그린다 — 힌트도
+// 버튼과 같은 조건으로 사라진다).
+function formatUndoRemaining(resolvedAtMs: number, t: ReturnType<typeof useTranslations>): string | null {
+  const remainingMs = UNDO_WINDOW_MS - (Date.now() - resolvedAtMs);
+  if (remainingMs <= 0) return null;
+  const minutes = Math.max(1, Math.ceil(remainingMs / 60_000));
+  return t('gateUndoRemaining', { minutes });
 }
 
 export function ApprovalsQueue() {
@@ -113,6 +129,14 @@ export function ApprovalsQueue() {
   const [discussTargetId, setDiscussTargetId] = useState<string | null>(null);
   const [discussSubmitting, setDiscussSubmitting] = useState(false);
   const [discussError, setDiscussError] = useState<string | null>(null);
+  // story 22affaf2 — 고위험 인라인 서명 모달. 목록이라 한 번에 하나만 연다(대상 id 하나로
+  // 충분, discussTargetId와 동형). resolving/error는 resolvingIds/gateErrors를 그대로
+  // 공유한다(별도 병렬 state를 새로 만들지 않는다 — 이 컴포넌트 전체가 이미 id 키로
+  // 추적하는 관례를 그대로 따른다).
+  const [signatureTargetId, setSignatureTargetId] = useState<string | null>(null);
+  const signatureGate = signatureTargetId
+    ? (items.find((it) => !isHitl(it) && it.id === signatureTargetId) as GateItem | undefined)
+    : undefined;
 
   const discuss = async (id: string, reason: string) => {
     setDiscussSubmitting(true);
@@ -170,21 +194,25 @@ export function ApprovalsQueue() {
     }
   };
 
-  // story #1961(P2-S5) — 저위험 gate 원탭 승인/반려. gates/[id]/page.tsx의 저위험 분기(근거·
-  // 사유 없는 단순 transition)와 동일 엔드포인트·body — 서명 플로우(usesSignatureFlow)는
-  // canInlineResolve가 이미 걸러 이 함수에 안 들어온다.
-  const resolveGate = async (id: string, status: 'approved' | 'rejected') => {
+  // story #1961(P2-S5) — 저위험 gate 원탭 승인/반려, gates/[id]/page.tsx의 transition()과
+  // 동일 엔드포인트·body. story 22affaf2 — 고위험 서명 플로우(GateSignatureApproval)도
+  // 이제 이 함수를 그대로 쓴다(note=서명 사유) — 별도 함수를 새로 짓지 않는다(canonical
+  // 상세의 transition()과 body shape을 1:1로 맞춘 이유이기도 함).
+  const resolveGate = async (id: string, status: 'approved' | 'rejected', note: string | null = null) => {
     setResolvingIds((prev) => new Set(prev).add(id));
     setGateErrors((prev) => { const next = { ...prev }; delete next[id]; return next; });
     try {
       const res = await fetch(`/api/gates/${id}/transition`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status, note: null }),
+        body: JSON.stringify({ status, note: note?.trim() || null }),
       });
       if (res.ok) {
         setResolvedGates((prev) => ({ ...prev, [id]: status }));
         setResolvedAtMs((prev) => ({ ...prev, [id]: Date.now() }));
+        // story 22affaf2 — 서명 모달을 거친 성공이면 그 자리서 닫는다(다른 gate의 모달을
+        // 잘못 닫지 않도록 대상 id 일치 확認).
+        setSignatureTargetId((cur) => (cur === id ? null : cur));
       } else {
         const body = await res.json().catch(() => null) as { error?: { message?: string } } | null;
         setGateErrors((prev) => ({ ...prev, [id]: body?.error?.message ?? t('gateTransitionErrorGeneric') }));
@@ -275,10 +303,11 @@ export function ApprovalsQueue() {
           </>
         );
 
-        // story #1961(P2-S5) — 저위험이면서 아직 인라인으로 안 끝난 항목만 이 2단 구조(제목=
-        // 상세 이동 버튼 + 그 아래 승인/반려 행)로 렌더한다. 그 외(고위험·unknown·held·이미
-        // 인라인 처리됨)는 기존 그대로 «행 전체가 상세로 가는 단일 버튼»— 고위험 항목엔
-        // 인라인 승인 버튼이 «아예 안 생긴다»(AC, 새 분기 자체를 안 탐).
+        // story 22affaf2 — canInlineResolve(can_approve && needsAction && !held)를 만족하는
+        // 항목만 이 2단 구조(제목=상세 이동 버튼 + 그 아래 승인/거절/보류 행)로 렌더한다 —
+        // 이제 위험도와 무관(구 #1961 AC "고위험 인라인 0"은 이 스토리로 뒤집혔다, 위
+        // canInlineResolve 주석 참조). 그 외(unknown 미배선·held·권한없음·이미 인라인
+        // 처리됨)만 기존 그대로 «행 전체가 상세로 가는 단일 버튼».
         if (!inlineResolvable) {
           if (resolved) {
             return (
@@ -308,9 +337,12 @@ export function ApprovalsQueue() {
                     {t('queueViewRecord')}
                   </Link>
                 </div>
-                {/* story #2631 — 오클릭 정정(방금 본인이 이 세션에서 해소한 게이트, 5분 창). */}
+                {/* story #2631 — 오클릭 정정(방금 본인이 이 세션에서 해소한 게이트, 5분 창).
+                    story 22affaf2(유나 design⑤) — 남은 시간 힌트를 버튼 옆에 subtle하게
+                    곁들인다(안전망 인지 자체가 오발 방지의 일부). */}
                 {resolvedAtMs[gate.id] && Date.now() - resolvedAtMs[gate.id]! < UNDO_WINDOW_MS ? (
-                  <div className="mt-2 flex justify-end">
+                  <div className="mt-2 flex items-center justify-end gap-2">
+                    <span className="text-[11px] text-muted-foreground">{formatUndoRemaining(resolvedAtMs[gate.id]!, t)}</span>
                     <GateUndoButton gateId={gate.id} onUndone={() => undoGate(gate.id)} />
                   </div>
                 ) : null}
@@ -328,6 +360,23 @@ export function ApprovalsQueue() {
             </button>
           );
         }
+
+        // story 22affaf2(유나 design①③) — 저위험 원탭·고위험 서명모달 둘 다 이 하나의 카드
+        // chrome을 쓴다(분기는 primary 라벨+onClick만 — 새 카드 컴포넌트를 만들지 않는다).
+        // isSigFlow===true면 [승인하고 서명]/[변경 요청] 둘 다 서명 모달을 여는 것으로
+        // 통일한다(canonical 상세와 동형 — GateSignatureApproval 화면 하나가 승인/거절
+        // 둘 다 담당, canSign이 서명 생략을 막는다). 저위험은 기존처럼 즉시 transition.
+        const isSigFlow = usesSignatureFlow(deriveRiskLevel(gate));
+        const disabled = resolvingIds.has(gate.id);
+        const primaryLabel = isSigFlow ? t('sigApproveAndSign') : t('gateApprove');
+        const primaryOnClick = () => {
+          if (isSigFlow) setSignatureTargetId(gate.id);
+          else void resolveGate(gate.id, 'approved');
+        };
+        const rejectOnClick = () => {
+          if (isSigFlow) setSignatureTargetId(gate.id);
+          else void resolveGate(gate.id, 'rejected');
+        };
 
         return (
           <div key={gate.id} className="rounded-xl border border-border bg-card px-4 py-3">
@@ -347,35 +396,41 @@ export function ApprovalsQueue() {
                 {t('gateTransitionError', { reason: gateErrors[gate.id] })}
               </p>
             ) : null}
-            <div className="mt-2 flex justify-end gap-1.5 border-t border-border pt-2">
+            {/* story 22affaf2(유나 design①) — 모바일(≤390px) 2단 스택: 행1=primary 전폭,
+                행2=변경요청+보류 각 flex-1. 데스크톱(≥sm)=단일 우측정렬 행, primary 최우측.
+                order 유틸+wrapper의 sm:contents로 DOM은 한 세트만 유지한다(버튼 중복 렌더
+                금지 — 테스트·접근성 트리 둘 다 단일 소스여야 함). */}
+            <div className="mt-2 flex flex-col gap-1.5 border-t border-border pt-2 sm:flex-row sm:items-center sm:justify-end">
+              <div className="order-2 flex gap-1.5 sm:contents">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="order-1 h-8 flex-1 gap-1 text-muted-foreground hover:text-destructive hover:ring-1 hover:ring-inset hover:ring-destructive/60 sm:order-1 sm:flex-none"
+                  disabled={disabled}
+                  onClick={rejectOnClick}
+                >
+                  <XCircle className="size-3.5" />
+                  {t('sigRequestChanges')}
+                </Button>
+                {/* story #2631(PO 결정③) — 「보류(논의 필요)」는 결재함 전 게이트 타입 단일 표면. */}
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="order-2 h-8 flex-1 text-muted-foreground sm:order-2 sm:flex-none"
+                  disabled={disabled}
+                  onClick={() => setDiscussTargetId(gate.id)}
+                >
+                  {t('gateDiscussSubmit')}
+                </Button>
+              </div>
               <Button
                 size="sm"
-                variant="ghost"
-                className="h-8 gap-1 text-muted-foreground hover:text-destructive hover:ring-1 hover:ring-inset hover:ring-destructive/60"
-                disabled={resolvingIds.has(gate.id)}
-                onClick={() => void resolveGate(gate.id, 'rejected')}
-              >
-                <XCircle className="size-3.5" />
-                {t('gateReject')}
-              </Button>
-              <Button
-                size="sm"
-                className="h-8 gap-1"
-                disabled={resolvingIds.has(gate.id)}
-                onClick={() => void resolveGate(gate.id, 'approved')}
+                className="order-1 h-9 w-full gap-1.5 sm:order-3 sm:h-8 sm:w-auto"
+                disabled={disabled}
+                onClick={primaryOnClick}
               >
                 <CheckCircle className="size-3.5" />
-                {resolvingIds.has(gate.id) ? '...' : t('gateApprove')}
-              </Button>
-              {/* story #2631(PO 결정③) — 「보류(논의 필요)」는 결재함 전 게이트 타입 단일 표면. */}
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-8 text-muted-foreground"
-                disabled={resolvingIds.has(gate.id)}
-                onClick={() => setDiscussTargetId(gate.id)}
-              >
-                {t('gateDiscussSubmit')}
+                {disabled && !isSigFlow ? '...' : primaryLabel}
               </Button>
             </div>
           </div>
@@ -388,6 +443,32 @@ export function ApprovalsQueue() {
         submitting={discussSubmitting}
         error={discussError}
       />
+      {/* story 22affaf2(유나 design③) — 고위험 인라인 서명 모달. canonical 상세와 동일
+          컴포넌트(GateSignatureApproval)를 nav 없이 Dialog로 연다 — 어휘·게이팅(canSign)
+          둘 다 상세와 1:1이라 화면마다 다른 규칙을 새로 만들지 않는다. */}
+      <Dialog
+        open={signatureGate !== undefined}
+        onOpenChange={(open) => {
+          if (!open && !(signatureTargetId && resolvingIds.has(signatureTargetId))) setSignatureTargetId(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {signatureGate ? (signatureGate.work_item_summary?.title ?? `#${signatureGate.work_item_id.slice(0, 8)}`) : ''}
+            </DialogTitle>
+          </DialogHeader>
+          {signatureGate ? (
+            <GateSignatureApproval
+              gate={signatureGate}
+              resolving={resolvingIds.has(signatureGate.id)}
+              error={gateErrors[signatureGate.id]}
+              onApprove={(reason) => void resolveGate(signatureGate.id, 'approved', reason)}
+              onReject={(reason) => void resolveGate(signatureGate.id, 'rejected', reason)}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## 요약

story [22affaf2](entity:story:22affaf2-2cfb-4e5a-96df-404dce4bf432) — 선생님 실사용 지적("결재함에서 승인/거절 버튼도 딥링크도 없다", 2026-07-21). 미르코 dev 재실측(08-16)으로 딥링크·상세 액션은 이미 있음을 확認했고, 실체는 구 #1961 AC "고위험 항목 인라인 승인 버튼 0" — 실사용 큐가 전부 고위험이라 인라인이 아예 안 뜨는 화면이었다. PO 결정(2026-08-16)으로 이 경계를 연다.

## 변경

- **`canInlineResolve`**: 저위험 전용(`!usesSignatureFlow`) → 전 위험도. 고위험/unknown은 `GateSignatureApproval`(canonical 상세와 동일 컴포넌트)을 큐 안에서 `Dialog`로 인라인 오픈 — `canSign`(근거열람+사유) 게이팅 그대로라 서명 생략이 아니다. 큐 카드의 [승인하고 서명]·[변경 요청] 둘 다 이 모달을 연다(상세와 동형 — 우회 경로 없음, 테스트로 고정).
- **카드 액션 레이아웃 단일화(유나 design)**: 저위험 원탭·고위험 서명모달 둘 다 같은 카드 chrome — 분기는 primary 라벨+onClick만. 모바일(≤390px) 2단 스택(행1=primary 전폭 h-9, 행2=변경요청+보류 각 flex-1) / 데스크톱(≥sm) 단일 우측정렬 행(primary 최우측, 기존 순서 보존). `order`/`sm:order-*` 유틸 + wrapper의 `sm:contents`로 DOM은 한 세트만 유지(버튼 중복 렌더 없음 — jsdom 테스트가 버튼 개수를 세는 기존 assertion들과도 충돌 없음).
- **어휘 통일**: 저위험 reject 라벨 "반려"(`gateReject`) → "변경 요청"(`sigRequestChanges`, 상세 서명 모달과 동일 키 재사용) — 화면 둘이 다른 말을 쓰면 안 된다는 PO 요건.
- **undo 어포던스 강화**: "{minutes}분 내 취소 가능" 힌트를 `GateUndoButton` 옆에 추가(새 키 `gateUndoRemaining`, ko/en 둘 다) — 안전망 인지 자체가 오발 방지의 일부.

## 스코프 밖

- 위험도 재분류·SLA 정렬 불변.
- BE 계약(`/transition`·`/discuss` 엔드포인트)은 상세와 동일 재사용 — 신규 배선 없음.
- AC3 실기기 라이브(고위험 카드 서명 완주, 390px 클립 0)는 배포 후 PO가 직접 확認(휴먼 세션 필요).

## 검증

- `pnpm exec tsc --noEmit` → **EXIT 0**
- `pnpm lint` → **EXIT 0**(0 error, 기존 무관 warning 5건)
- `pnpm exec vitest run` → **432 files / 3543 tests 전부 통과**(기존 3537 + 신규 6: 서명 게이팅(체크박스+사유 둘 다 있어야 승인 버튼 풀림)·모달 경유 승인/거절이 정확한 note로 POST·큐 진입점에서 서명 우회 불가·undo 힌트)
- `pnpm build` → **EXIT 0**
- `approvals-queue.test.tsx` 기존 스위트 중 구 AC(고위험 인라인 0·unknown 인라인 0)를 새 동작(인라인 받되 서명모달 경유)으로 대체 — 나머지 31건은 무수정 통과(레이블 변경분 2건만 텍스트 갱신).

## 참고

- 스토리 본문에 유나 design 규격 전문(카드 배치·시안 511bc035 재사용·서명 모달·보류·취소창 어포던스) 기록됨.
- design 게이트 = 유나, QA = 카디르.