### PR TITLE
[SID:2285] CI 취소가 통과처럼 읽히지 않게 — bucket!=pass 관례 + 실측 근거 + durations summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,6 +641,11 @@ jobs:
     # (backend-test의 필수 판정 근거) cascade로 스킵된다.
     if: always()
     runs-on: ubuntu-latest
+    # story #2285 AC4(2026-08-17 실측, develop 최근 10런): 각 샤드 4~6분 → 천장 25분 대비
+    # 여유 19~21분. 이 값은 story #2293(destructive-schema를 이 job으로 4-way 샤딩)이 옮겨온
+    # 뒤의 실측이라, 그 전(같은 job이 94개를 순차로 다 돌던 시절, 15m58s~18m32s·여유 6.5분)과
+    # 는 다른 상태다. 재검 기준: 이 샤드의 p95가 15분을 넘으면 값을 다시 본다(⛔"자주 터지니
+    # 올린다"가 아니라 근거 먼저 — story #2285 AC4).
     timeout-minutes: 25
     strategy:
       fail-fast: false  # 한 샤드 실패가 다른 샤드를 취소하면 "어디까지 진짜 돌았는지"가 흐려진다
@@ -744,6 +749,10 @@ jobs:
     # exit 1로, 94개 중 하나라도 실패/샤드가 안 돌면 이 필수 체크 자체가 빨개지게 만든다
     # (GitHub의 기본 `needs`-실패-시-skip에만 기대면 "필수 체크가 skipped로 조용히 안
     # 걸리는" 위험이 있다 — 파울로군 지적).
+    #
+    # story #2285 AC4(2026-08-17 실측, develop 최근 10런): 이 job 본체(non-destructive
+    # pytest, story #2293 이관 후) 7~8분 → 천장 25분 대비 여유 17~18분. 재검 기준: p95가
+    # 15분을 넘으면 값을 다시 본다.
     timeout-minutes: 25
 
     services:
@@ -794,7 +803,25 @@ jobs:
 
       - name: Run pytest (non-destructive, real-PG auto-discovered via marker)
         working-directory: backend
-        run: uv run pytest -q -m "not destructive_schema"
+        run: |
+          set -o pipefail
+          uv run pytest -q -m "not destructive_schema" --durations=20 2>&1 | tee /tmp/pytest_output.log
+
+      # story #2285 AC5: 넘쳤을 때(취소) 무엇이 시간을 먹었는지 최소한이라도 보이게 —
+      # --durations=20이 정상 완주 시엔 정확한 breakdown을 준다. ⛔한계를 그대로 적는다: job이
+      # 25분 천장에 «중간에» 취소되면 이 스텝(과 --durations 출력 자체)도 같이 죽는다 — GitHub
+      # Actions는 타임아웃-취소 시 이후 스텝을 실행할 방법을 안 준다(`if: always()`도 못 막음).
+      # 그래서 이건 "정상 완주했지만 느려지는 중"을 조기에 보이게 하는 것까지가 이 스텝의
+      # 몫 — 그 이상(취소 순간의 실시간 heartbeat 등)은 짓지 않는다(AC6).
+      - name: Slowest tests summary (story #2285 AC5)
+        if: always()
+        run: |
+          {
+            echo "## Backend pytest — slowest 20 (여유: 천장 25분, 08-17 실측 본체 7~8분)"
+            echo '```'
+            awk '/slowest 20 durations/,0' /tmp/pytest_output.log 2>/dev/null || echo "(durations 출력 없음 — 타임아웃-취소로 이 스텝 자체가 못 돌았을 가능성)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   ci:
     name: Lint, Type Check, Test, Build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,15 @@ Notes:
   the full UUID. Resolve it from the story in Sprintable.
 - A non-blocking advisory check (`.github/workflows/sid-link-check.yml`) emits a warning
   when a PR has neither carrier. It never blocks merge.
+
+## Checking whether a PR's CI is actually green (story #2285)
+
+When confirming PR status programmatically, count anything whose `bucket` isn't `pass`
+as blocking: `gh pr checks <PR> --json name,bucket,link | jq -r '.[] | select(.bucket!="pass")'`.
+Filtering on `conclusion == "FAILURE"` alone misses `CANCELLED`/`TIMED_OUT`/`ACTION_REQUIRED` —
+those read as an empty "failures" list even though the check is not passing (PR #2570,
+2026-07-28: a `Backend pytest` run hit its 25-minute ceiling and was cancelled, and a
+`FAILURE`-only filter reported zero failures). GitHub's branch-protection merge gate
+already treats non-`SUCCESS` conclusions as blocking regardless of this tooling gap — the
+risk here is a human/agent being told "clear to merge" by a script when the actual gate
+is still red.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,12 @@ Notes:
 ## Checking whether a PR's CI is actually green (story #2285)
 
 When confirming PR status programmatically, count anything whose `bucket` isn't `pass`
-as blocking: `gh pr checks <PR> --json name,bucket,link | jq -r '.[] | select(.bucket!="pass")'`.
+as blocking: `gh pr checks <PR> --json name,bucket,link | jq -r '.[] | select(.bucket!="pass" and .bucket!="skipping")'`.
 Filtering on `conclusion == "FAILURE"` alone misses `CANCELLED`/`TIMED_OUT`/`ACTION_REQUIRED` —
 those read as an empty "failures" list even though the check is not passing (PR #2570,
 2026-07-28: a `Backend pytest` run hit its 25-minute ceiling and was cancelled, and a
 `FAILURE`-only filter reported zero failures). GitHub's branch-protection merge gate
 already treats non-`SUCCESS` conclusions as blocking regardless of this tooling gap — the
 risk here is a human/agent being told "clear to merge" by a script when the actual gate
-is still red.
+is still red. `skipping` is excluded — it's a conditionally-skipped job (e.g. "Main
+Alembic preflight" when its precondition doesn't apply), not a blocked one.


### PR DESCRIPTION
## 요약
그라운딩 결과 3주 사이 대부분 해소돼있었음(story #2293의 destructive-schema 샤딩이 AC1 fail-closed 체인과 AC4 시간여유를 같이 풀어놓음, 2026-08-17 실측: 여유 6.5분→17~21분). PO 판정으로 스코프를 작게 확定 — 남은 것만 처리.

- **AC2**: `AGENTS.md`에 절 신설 — `gh pr checks --json bucket`으로 `bucket!=pass`를 세는 관례(PR #2570 사례가 근거: `conclusion=="FAILURE"`만 거르면 CANCELLED가 빈 배열로 읽혀 통과처럼 보임).
- **AC4**: `ci.yml`의 `backend-test-destructive`·`backend-test` 두 job `timeout-minutes: 25` 위에 2026-08-17 실측치(샤드4~6분/여유19~21분, 본체7~8분/여유17~18분)+재검기준(p95>15분) 주석.
- **AC5**: `backend-test`의 pytest 스텝에 `--durations=20` + 후속 스텝이 GITHUB_STEP_SUMMARY에 markdown block으로 적재. 정직한 한계 명시 — job이 타임아웃으로 «중간에» 취소되면 이 스텝도 같이 죽음(GitHub Actions 구조적 한계, if:always()도 못 막음) — "완주했지만 느려지는 중"을 조기에 보이는 것까지가 몫.
- **AC6**: 스토리 본문에 위 한계+범위 밖(원인규명 별건) 명시.

## 검증
- YAML 문법 `python3 -c "import yaml; yaml.safe_load(...)"` 통과.
- `--durations=20` 출력 포맷을 로컬 real PG로 직접 재현(정확히 `slowest 20 durations` 헤더) + GITHUB_STEP_SUMMARY용 awk 추출 패턴이 그 출력에서 정확히 잘라내는지 검증 완료.
- AC1/AC3 그라운딩 근거: story 본문에 develop 브랜치보호 required contexts 실측·backend-test의 기존 `!= 'success'` 게이트 코드 인용·최근 10개런 job 소요시간 실측 표 전문 기록.

## 근거
story #2285 본문에 그라운딩 전문·PO 판정(2026-08-16)·AC6 한계 선언 전부 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)