### PR TITLE
[SID:2410] i18n phrase-collision 가드 — 유보된 GRANDFATHER_BASELINE 18건 정리

### DIFF
--- a/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.test.ts
@@ -262,8 +262,13 @@ describe('story #2410 — isNumberAdjacent: 이름 보간은 numberAdjacent가 �
 // 지키는지(모듈 코멘트 "CI 안전장치" 참조). 이게 없으면 이 스토리가 잡은 40건이 이 PR과
 // 다른 모든 PR을 영원히 막는다.
 describe('GRANDFATHER_BASELINE — 기존 채무는 통과, 새 충돌만 막는다', () => {
-  it('실제 첫 검거(ccWaitingGateReason/ccAgentStuck)는 baseline에 있다', () => {
-    expect(GRANDFATHER_BASELINE.has(pairKey('dashboard.ccAgentStuck', 'dashboard.ccWaitingGateReason'))).toBe(
+  // story #2410 후속(2026-08-17) — 예전엔 dashboard.ccAgentStuck/ccWaitingGateReason({gate})를
+  // 썼으나, 그 쌍은 isNumberAdjacent 정밀화로 더 이상 numberAdjacent가 아니라는 게 밝혀져
+  // GRANDFATHER_BASELINE에서 걷어냈다(위 '18건 제거' 참조) — 이 테스트가 원래 그 쌍으로
+  // 하려던 것과 같은 검증(AC7이 이미 옮겨간 자리, notification-bell.tsx의 진짜 카운터 쌍)을
+  // 그대로 재사용해 파일 안 두 테스트가 다른 예시를 들지 않게 맞춘다.
+  it('실제 첫 검거(panelTitle/bellAriaLabelCount, AC7과 동일 쌍)는 baseline에 있다', () => {
+    expect(GRANDFATHER_BASELINE.has(pairKey('inbox.panelTitle', 'inbox.bellAriaLabelCount'))).toBe(
       true,
     );
   });
@@ -284,22 +289,25 @@ describe('GRANDFATHER_BASELINE — 기존 채무는 통과, 새 충돌만 막는
 // 2026-07-31: 41번째 항목부터는 PO 승인 없이 조용히 못 들어온다. 크기를 고정해
 // 두면 누가 리뷰 없이 항목을 추가/삭제해도 이 테스트가 실패해 diff가 눈에 띈다(그 자체가
 // design:pass/qa:pass 리뷰를 거치게 만드는 자리). story #2519 — 40→38(고아 컴포넌트
-// SlackIntegrationSettingsSection 삭제로 그 전용 i18n 키 자체가 사라진 2건 제거, GRANDFATHER_
-// BASELINE 상단 주석 참조 — #2410의 판단-유보 18건과는 다른 사유).
+// SlackIntegrationSettingsSection 삭제로 그 전용 i18n 키 자체가 사라진 2건 제거).
+// story #2410 후속(2026-08-17, PO 승인) — 38→20. isNumberAdjacent 정밀화 이후 더 이상 안
+// 걸리던 18건(판단 유보 상태였던 것)을 이번에 GRANDFATHER_BASELINE에서 걷어냈다 — 유령
+// 채무를 "아직 판단 안 됨"으로 남겨 두는 것보다, 이미 내려진 결론(numberAdjacent 아님)을
+// Set에도 반영하는 쪽이 다음 사람에게 정확하다.
 describe('GRANDFATHER_BASELINE_COUNT_TEST — 41번째부터는 PO 승인, 조용한 증감을 막는다', () => {
-  it('#2367 최초 스캔 스냅샷(#2519 소스 삭제 2건 제외) 크기는 정확히 38건이다', () => {
-    expect(GRANDFATHER_BASELINE.size).toBe(38);
+  it('정리 후(#2410 후속) 크기는 정확히 20건이다', () => {
+    expect(GRANDFATHER_BASELINE.size).toBe(20);
   });
 });
 
 // story #2410(PO 지적, 2026-08-02): «선언된» 건수와 «실제로 지금 걸리는» 건수는 다른 축이다
-// (isNumberAdjacent 정밀화로 18건이 더 안 걸리게 됐다 — GRANDFATHER_BASELINE 상단 주석 참조).
-// console.log의 "안 걸림" 경고만으로는 다음 사람이 노이즈로 읽고 넘길 수 있어, 실제 저장소
-// 전체를 스캔해 «지금 몇 건이 실제로 걸리는지»를 이 테스트가 고정한다 — GRANDFATHER_BASELINE_
-// COUNT_TEST(선언 수)와 이 테스트(실 걸림 수)가 서로 다른 값을 지키는 것 자체가 그
-// 간극이 조용히 사라지지 않게 하는 자리다. story #2519 — 22→20(위와 같은 사유).
+// — 당시엔 isNumberAdjacent 정밀화로 18건이 안 걸리게 됐는데도 Set엔 그대로 남아 간극이
+// 있었다. story #2410 후속(2026-08-17)에서 그 18건을 Set에서 제거해 이제 두 수(선언 20·실
+// 걸림 20)가 같아졌다 — 그렇다고 이 테스트가 불필요해지는 건 아니다: GRANDFATHER_BASELINE_
+// COUNT_TEST(선언 수, 조용한 항목 증감 방지)와 이 테스트(실 저장소 스캔 결과, 선언과 실제가
+// 다시 벌어지면 그 자체가 신호)는 서로 다른 것을 지키는 별개의 안전장치라 계속 둔다.
 describe('GRANDFATHER_LIVE_COUNT_TEST — 「선언된 수」와 「지금 실제로 걸리는 수」는 다른 축이다', () => {
-  it('실제 저장소 스캔에서 지금 걸리는 grandfather는 20건이다(18건은 #2410으로, 2건은 #2519 소스삭제로 안 걸리게 됨)', () => {
+  it('실제 저장소 스캔에서 지금 걸리는 grandfather는 20건이다(정리 후 선언 수와 일치)', () => {
     const { grandfatherHit } = scanRepository();
     expect(grandfatherHit.size).toBe(20);
   });

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -258,12 +258,17 @@ export const EXEMPT_PAIRS = new Set<string>([
 // 고치는 일이 아니다"(AC6)를 지키는
 // 방법이다 — 여기 있는 40건 «중 실제로 몇 건이 진짜 결함인지»는 이 스토리가 판정하지 않는다.
 // 그래도 매 실행 로그에 grandfather 카운트로 찍혀 "원래 그런 것"으로 조용히 묻히지 않는다.
-// story #2410(PO 지적, 2026-08-02): 이 40건 중 18건은 이제 이 스캔에 «안 걸린다» — isNumberAdjacent
-// 정밀화(이름·런타임류 배제) 여파로, 그동안 「진짜 결함인지 몰랐던」게 아니라 「애초에 numberAdjacent가
-// 아니었던」 것으로 밝혀졌다. Set 크기(40)는 #2367 최초 스캔 스냅샷이라 그대로 두지만("아래 40건" 문단
-// 그대로), 매 실행 로그의 "안 걸림" 경고만으로는 다음 사람이 노이즈로 읽고 넘길 수 있어 여기 명시로
-// 남긴다 — 실 걸림 수(22)는 GRANDFATHER_LIVE_COUNT_TEST가 고정한다(아래).
-// 안 걸리는 18건: board.backlinksEmptyFallback<->board.backlinksEmptyScoped · canvas.resolveAction<->
+// story #2410(PO 지적, 2026-08-02): 이 40건 중 18건은 isNumberAdjacent 정밀화(이름·런타임류
+// 배제) 여파로 이 스캔에 «안 걸리게» 됐었다 — 그동안 「진짜 결함인지 몰랐던」게 아니라
+// 「애초에 numberAdjacent가 아니었던」 것으로 밝혀진 것. 당시(#2410 원 PR)엔 이 18건을 Set에서
+// 걷어낼지를 "이 PR이 정하지 않는다"로 명시 유보했었다.
+//
+// story #2410 후속(카디르, 2026-08-17, PO 승인) — 그 유보를 마저 정리한다. isNumberAdjacent
+// 정밀화 자체가 이미 "이 18건은 numberAdjacent가 아니다"라고 결론 낸 상태라, "판단 안 됨"으로
+// Set에 남겨 두는 건 실체 없는 유령 채무를 "아직 모름"으로 오독시키는 쪽이 더 나쁘다 —
+// GRANDFATHER_BASELINE(선언 40건)과 GRANDFATHER_LIVE_COUNT_TEST(실 걸림 22건)의 간극 자체가
+// 이 18건이었으므로, 걷어내면 둘이 같아진다(선언=실걸림=20, #2519의 소스삭제 2건 반영 후).
+// 제거된 18건: board.backlinksEmptyFallback<->board.backlinksEmptyScoped · canvas.resolveAction<->
 // canvas.resolvedByNote · dashboard.ccAgentStuck<->dashboard.ccWaitingGateReason ·
 // recruiter.back<->recruiter.{guideFileDeliveryNoteConnector,guideFileDeliveryNoteMcp,kitOrientingGuideBody} ·
 // recruiter.equipCreatedTitle<->recruiter.{equipDone,stepComplete} ·
@@ -273,27 +278,25 @@ export const EXEMPT_PAIRS = new Set<string>([
 // settings.slackIntegration.{mappedElsewhereHint,pendingHint}<->settings.slackIntegration.saveLabel ·
 // settings.slackIntegration.workspaceConnectedSummary<->settings.slackIntegration.workspaceLabel ·
 // standup.feedback<->standup.feedbackDialogTitle
-// ⇒ 이 18건을 GRANDFATHER_BASELINE에서 걷어낼지(진짜 결함이 아니었다고 결론)는 이 PR이 정하지 않는다
-// (AC6과 같은 판단 — 이 스토리는 정밀화만, triage는 별도).
+// 재확認(2026-08-17): 제거 후 전체 재스캔 — grandfatherHit=20(Set 크기와 일치)·newFindings=0
+// (이 18건이 「새 충돌」로 재부상하지 않았다). Set 크기 40→38(#2519)→20(이번), 실 걸림 수
+// GRANDFATHER_LIVE_COUNT_TEST 22→20(#2519)→20(이번, 변화 없음 — 애초에 이 18건은 살아있던
+// 채무가 아니었으므로).
 //
-// story #2519(2026-08-16, 고아 컴포넌트 정리) — 위 18건과는 다른 성질의 제거 2건.
-// `settings.slackIntegration.saveLabel <-> settings.slackIntegration.savePending`·
-// `settings.slackIntegration.savePending <-> settings.slackIntegration.saveRow`는 #2410
-// 이후에도 실제로 계속 걸리고 있었는데(스캔 정밀화 문제가 아니라 진짜 충돌), 그 값 자체(고아
-// 컴포넌트 `SlackIntegrationSettingsSection` 전용 i18n 네임스페이스)가 이 스토리에서 완전히
-// 삭제됐다 — "판정 보류"가 아니라 "그 문자열이 이제 존재하지 않는다"라 Set에서도 뺀다(#2410의
-// 판단 유보 대상과 다름, 소스가 사라진 건 재검토할 것도 없다). Set 크기 40→38, 실 걸림 수
-// GRANDFATHER_LIVE_COUNT_TEST 22→20.
+// story #2519(2026-08-16, 고아 컴포넌트 정리) — 위 18건과는 다른 성질의 제거 2건(이미 반영,
+// 아래 Set에는 포함 안 됨). `settings.slackIntegration.saveLabel <-> settings.slackIntegration.
+// savePending`·`settings.slackIntegration.savePending <-> settings.slackIntegration.saveRow`는
+// #2410 이후에도 실제로 계속 걸리고 있었는데(스캔 정밀화 문제가 아니라 진짜 충돌), 그 값
+// 자체(고아 컴포넌트 `SlackIntegrationSettingsSection` 전용 i18n 네임스페이스)가 그 스토리에서
+// 완전히 삭제됐다 — "판정 보류"가 아니라 "그 문자열이 이제 존재하지 않는다"라 Set에서도 뺀다
+// (#2410의 판단 유보 대상과 다름, 소스가 사라진 건 재검토할 것도 없다).
 export const GRANDFATHER_BASELINE = new Set<string>([
-  'board.backlinksEmptyFallback <-> board.backlinksEmptyScoped',
   'cage.pendingSummary <-> cage.trustScorePending',
-  'canvas.resolveAction <-> canvas.resolvedByNote',
   'chats.agent <-> chats.agentCount',
   'chats.agentCount <-> chats.agentSection',
   'chats.agentCount <-> chats.personCount',
   'chats.agentCount <-> chats.you',
   'chats.participantsOthers <-> chats.personCount',
-  'dashboard.ccAgentStuck <-> dashboard.ccWaitingGateReason',
   'dashboard.ccQueueTruncated <-> dashboard.ccWaitingTitle',
   'docs.searchResultCount <-> docs.title',
   'goals.fieldPriority <-> goals.steerCappedNote',
@@ -303,23 +306,8 @@ export const GRANDFATHER_BASELINE = new Set<string>([
   'hypotheses.target <-> retro.hTargetLine',
   'inbox.bellAriaLabelCount <-> inbox.panelTitle',
   'presence.fabLabelWorking <-> presence.panelTitle',
-  'recruiter.back <-> recruiter.guideFileDeliveryNoteConnector',
-  'recruiter.back <-> recruiter.guideFileDeliveryNoteMcp',
-  'recruiter.back <-> recruiter.kitOrientingGuideBody',
-  'recruiter.equipCreatedTitle <-> recruiter.equipDone',
-  'recruiter.equipCreatedTitle <-> recruiter.stepComplete',
-  'recruiter.equipDone <-> recruiter.guideFileDeliveryNoteConnector',
-  'recruiter.equipDone <-> recruiter.kitOrientingTitle',
-  'recruiter.guideFileDeliveryNoteConnector <-> recruiter.kitOrientingGuideBody',
-  'recruiter.guideFileDeliveryNoteConnector <-> recruiter.stepComplete',
-  'recruiter.kitOrientingTitle <-> recruiter.stepComplete',
   'retro.recConfMid <-> retro.tallyMeasuring',
-  'settings.projectCreated <-> settings.tabProjects',
-  'settings.slackIntegration.mappedElsewhereHint <-> settings.slackIntegration.saveLabel',
-  'settings.slackIntegration.pendingHint <-> settings.slackIntegration.saveLabel',
-  'settings.slackIntegration.workspaceConnectedSummary <-> settings.slackIntegration.workspaceLabel',
   'standup.blockersRollupTitle <-> standup.today',
-  'standup.feedback <-> standup.feedbackDialogTitle',
   'storage.capacityUpgrade <-> storage.capacityWarnDesc',
   'storage.delete <-> storage.deleteImpact',
   'verify.chatProofCount <-> verify.chatProofSectionTitle',


### PR DESCRIPTION
## 요약
story #2410의 핵심(정규식을 isNumberAdjacent로 좁힘, ㉠ 채택)은 이미 이전 PR(`f7cd5ed75`+`3825c7b5c`)로 상륙 완료 — 이번 PR은 그때 명시적으로 유보한 GRANDFATHER_BASELINE 정리만 마무리한다.

- 40건 스냅샷(#2519가 2건 별건 제거해 38) 중 18건은 isNumberAdjacent 정밀화로 이제 이 스캔에 안 걸리는데, "Set에서 걷어낼지는 이 PR이 정하지 않는다"로 유보돼있었음.
- 이 PR: 18건 전부 제거(38→20) — 유령 채무를 "판단 안 됨"으로 남기지 않고 이미 내려진 결론(numberAdjacent 아님)을 반영. 제거 후 재스캔 `grandfatherHit=20`(Set과 일치)·`newFindings=0`.
- count-lock 테스트(GRANDFATHER_BASELINE_COUNT_TEST·GRANDFATHER_LIVE_COUNT_TEST) 값 갱신.
- 부수 발견: 별도 sanity 테스트가 이미 안 걸리게 된 예시(`ccAgentStuck<->ccWaitingGateReason`)를 참조하던 사전 불일치를 AC7과 같은 실제 쌍(`panelTitle`/`bellAriaLabelCount`)으로 통일.

## 검증
- `pnpm exec vitest run scripts/verify-no-i18n-phrase-collision.test.ts` → 27/27.
- 전체 `pnpm exec vitest run` → 432 files / 3536 tests 전부 통과.
- `tsc --noEmit` → 0 error. `lint` → 0 error(기존 무관 warning 5건).
- CLI(`npx tsx scripts/verify-no-i18n-phrase-collision.ts`) 직접 실행 → grandfather 20건 목록 정확히 출력, 신규 충돌 0건, exit 0.
- AC3 양성대조: 기존 `#2352` 패턴 fixture 테스트('막힘'/'막힘 신호 · {n}') 제거 후에도 GREEN 유지 — 진짜 병은 여전히 잡힘.

## 근거
story #2410 본문에 계보(핵심은 이전 PR로 해소·이번 PR은 잔여 정리) + AC1~6 처리결과 전문 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)