### PR TITLE
[SID:2401] hotfix — alembic 형제-PR 가드 shallow-fetch exit 128 크래시

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,8 +297,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # story #2401 hotfix(2026-08-17, 미르코 재현·확定): checkout(fetch-depth: 0)이 이미
+      # develop 전체 히스토리를 받은 뒤, 여기서 `--depth=1`로 다시 fetch하면(그 사이 develop
+      # tip이 움직였을 때) 그 얕은 fetch가 새 shallow 경계를 심어버린다 — 이후
+      # `git diff origin/develop...HEAD`가 merge base를 못 찾고 exit 128로 죽는다(PR #3140
+      # 실 CI에서 재현, 바쁜 밤처럼 develop이 자주 움직일 때만 터지는 타이밍 의존 버그).
+      # checkout이 이미 전체 히스토리를 갖고 있으므로 이 fetch는 "최신 tip 반영"만이
+      # 목적 — depth 제한 없이 다시 받는다(얕은 경계를 새로 심지 않음).
       - name: Fetch base branch (current tip, not PR-open-time)
-        run: git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
+        run: git fetch origin "${{ github.event.pull_request.base.ref }}"
       - name: Check alembic revision collisions against base + sibling open PRs
         working-directory: backend
         env:

--- a/backend/scripts/ci_alembic_sibling_pr_collision_check.py
+++ b/backend/scripts/ci_alembic_sibling_pr_collision_check.py
@@ -61,15 +61,29 @@ ALEMBIC_REL_DIR = Path("alembic/versions")
 FILENAME_REV_RE = re.compile(r"^(\d{4})_.*\.py$")
 
 
+def _run_git(args: list[str]) -> str:
+    """story #2401 hotfix(2026-08-17) — `subprocess.run(check=True)`가 실패하면 Python은
+    `CalledProcessError`를 던지는데, `capture_output=True`로 잡힌 stderr는 그 예외의 기본
+    `str()`에 안 실린다 — CI 로그엔 "returncode 128"만 남고 «왜»(예: "fatal: no merge base")는
+    사라진다. PR #3140 실 CI에서 정확히 이 모양으로 죽었다(shallow-fetch가 심은 경계 때문에
+    `git diff origin/develop...HEAD`가 no-merge-base로 실패 — 원인은 워크플로 fetch 스텝에서
+    같이 고쳤다). 모든 git 하위명령 호출을 이 헬퍼로 통일해 실패 시 stderr를 명시적으로
+    stdout/stderr에 찍은 뒤 fail-closed(exit 2)한다 — `_run_gh_json`이 gh 호출에 이미 쓰는
+    것과 같은 관례."""
+    result = subprocess.run(["git", *args], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        print(f"❌ git 호출 실패({' '.join(args)}, exit {result.returncode}):\n{result.stderr}", file=sys.stderr)
+        raise SystemExit(2)
+    return result.stdout
+
+
 def _git_root_prefix() -> str:
     """이 스크립트는 backend/를 cwd로 실행되는 계약이지만(위 docstring), git의 몇몇
     하위명령(`show <ref>:<path>`)은 **repo root 기준** 경로를 요구하고 다른 것들
     (`diff --relative`, `ls-tree`는 cwd 기준 pathspec을 주면 cwd 기준으로 출력)은 cwd 기준을
     쓴다 — 이 프리픽스로 둘을 오간다. GitHub API(`pulls/{n}/files`)의 `filename`도 항상
     root 기준이라 마찬가지로 이 프리픽스가 필요하다."""
-    return subprocess.run(
-        ["git", "rev-parse", "--show-prefix"], capture_output=True, text=True, check=True,
-    ).stdout.strip()
+    return _run_git(["rev-parse", "--show-prefix"]).strip()
 
 
 _ROOT_PREFIX = _git_root_prefix()
@@ -149,11 +163,10 @@ def _run_gh_json(args: list[str]) -> object:
 def _this_pr_new_files() -> list[Path]:
     """이 PR이 base 대비 새로 추가한 alembic 리비전 파일 목록(git 기준, 정본)."""
     base_ref = os.environ["PR_BASE_REF"]
-    out = subprocess.run(
-        ["git", "diff", "--relative", "--name-only", "--diff-filter=A",
+    out = _run_git(
+        ["diff", "--relative", "--name-only", "--diff-filter=A",
          f"origin/{base_ref}...HEAD", "--", str(ALEMBIC_REL_DIR)],
-        capture_output=True, text=True, check=True,
-    ).stdout
+    )
     return [Path(p) for p in out.splitlines() if p.strip()]
 
 
@@ -162,19 +175,17 @@ def _base_current_revisions() -> list[RevisionInfo]:
     이 job이 매번 fresh하게 fetch한 base 최신을 본다(축 A/B의 "PR이 못 보는 새 형제" 케이스
     중 「형제가 이미 머지돼 base 자체가 된」 경우를 여기서 잡는다)."""
     base_ref = os.environ["PR_BASE_REF"]
-    tree_out = subprocess.run(
-        ["git", "ls-tree", "-r", "--name-only", f"origin/{base_ref}", "--", str(ALEMBIC_REL_DIR)],
-        capture_output=True, text=True, check=True,
-    ).stdout
+    tree_out = _run_git(
+        ["ls-tree", "-r", "--name-only", f"origin/{base_ref}", "--", str(ALEMBIC_REL_DIR)],
+    )
     infos: list[RevisionInfo] = []
     for rel_path in tree_out.splitlines():
         rel_path = rel_path.strip()
         if not rel_path or not rel_path.endswith(".py"):
             continue
-        content = subprocess.run(
-            ["git", "show", f"origin/{base_ref}:{_ROOT_PREFIX}{rel_path}"],
-            capture_output=True, text=True, check=True,
-        ).stdout
+        content = _run_git(
+            ["show", f"origin/{base_ref}:{_ROOT_PREFIX}{rel_path}"],
+        )
         revision, down_revision = _extract_revision_vars(content)
         if revision is None:
             continue


### PR DESCRIPTION
## 재현 절차 (실 CI, PR #3140 — 미르코 확定)

1. job의 `Checkout`(`fetch-depth: 0`)이 develop 전체 히스토리를 받는다.
2. 다음 스텝 `git fetch origin develop --depth=1`이 실행되는 **그 사이** develop tip이 (다른 머지로) 움직이면, 이 shallow fetch가 이미 완전했던 히스토리 위에 새 얕은 경계를 심는다.
3. `_this_pr_new_files()`의 `git diff origin/develop...HEAD`가 공통 조상을 못 찾아 `fatal: ... no merge base`(exit 128)로 죽는다.
4. 바쁜 밤(연속 머지)일수록 2번 창이 자주 맞아떨어져 재현된다 — 조용한 develop에서는 우연히 안 걸린다(story #2401 원 QA 요청 ⑤에서 이 자리를 지목했을 때는 develop이 안 움직여 통과했었음).

로컬로 정확히 같은 시나리오(fresh clone → 이미 full history인 상태에서 이동한 브랜치를 `--depth=1`로 재fetch → diff 실패)를 재현해 확認, `--depth=1` 제거로 해소되는 것도 확認했다.

## 수정
1. **`.github/workflows/ci.yml`**: `alembic-sibling-pr-collision-check` job의 `git fetch origin "${{ ... }}" --depth=1`에서 `--depth=1` 제거 — checkout이 이미 전체 히스토리를 갖고 있어 이 fetch는 "최신 tip 반영"만이 목적이다.
2. **`backend/scripts/ci_alembic_sibling_pr_collision_check.py`**: 모든 git 하위명령 호출(`subprocess.run(..., check=True)`)이 실패 시 `CalledProcessError`를 던지는데, 그 예외의 기본 `str()`엔 캡처된 stderr가 안 실려 실제 git 에러 메시지가 CI 로그에서 안 보였다. `_run_git()` 헬퍼(기존 `_run_gh_json()`과 같은 관례 — `check=False`+명시적 stderr 출력+fail-closed exit)로 통일.

## 검증
- 재현: fresh clone → shallow re-fetch → `git diff origin/develop...HEAD` → `fatal: ... no merge base`(exit 128) 재현 확認.
- 수정: `--depth=1` 제거 후 같은 시나리오에서 diff가 exit 0으로 정상 동작 확認.
- 실 레포에서 리팩터된 스크립트 자체를 직접 실행(dry run) → 정상 SKIP(신규 alembic 리비전 없는 브랜치) exit 0 확認.
- `git diff`/`gh` 외 subprocess.run 잔존 0건(grep 확認) — 전부 `_run_git`/`_run_gh_json`으로 통일.
- YAML 문법 `python3 -c "import yaml; yaml.safe_load(...)"` 통과.
- 수정 후 3140/3141/3142 재실행 green은 머지 후 실물로 확認 예정(PO 처방 ③).

## 근거
story #2401 본문에 이번 사고 경위와 재현 절차를 추가 기록 예정. PO 승인(2026-08-16 org.moonklabs.work.decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)