### PR TITLE
fix(events): publish_event이 org 비회원 UUID를 거부 — 유령 대화+reach=1 거짓 성공 차단 (story #2693)

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1034,6 +1034,7 @@ async def publish_registry_event(
     from app.services.event_routing_resolver import (
         InvalidWorkItemReferenceError,
         MissingRoutingPayloadFieldError,
+        UnknownRoutingMemberError,
         resolve_routing_leg,
     )
 
@@ -1044,16 +1045,34 @@ async def publish_registry_event(
         broadcast_ids = await resolve_routing_leg(
             definition.routing["broadcast"], payload=body.payload, org_id=org_id, db=db,
         )
-    except (MissingRoutingPayloadFieldError, InvalidWorkItemReferenceError) as e:
+    except (MissingRoutingPayloadFieldError, InvalidWorkItemReferenceError, UnknownRoutingMemberError) as e:
         raise HTTPException(
             status_code=400,
             detail={"code": "invalid_payload", "message": str(e), "errors": [str(e)]},
         ) from e
 
     if body.extra_broadcast_member_ids:
+        # story #2693(AC2): payload_field routing과 동일 검증 — 예전엔 filter_org_member_ids로
+        # 비회원 id를 조용히 걸러내고(silent drop) 발행을 그대로 진행했다. AC1의 원자성
+        # 요구(비회원이면 conv/msg 어느 것도 만들지 않는다)와 일관되게, 여기도 걸러내는 대신
+        # 하나라도 비회원이면 명시 거부한다(조용한 유실 금지 — MissingRoutingPayloadFieldError와
+        # 동일 철학).
         from app.services.member_resolver import filter_org_member_ids
 
-        broadcast_ids |= await filter_org_member_ids(set(body.extra_broadcast_member_ids), org_id, db)
+        requested_extra = set(body.extra_broadcast_member_ids)
+        valid_extra = await filter_org_member_ids(requested_extra, org_id, db)
+        unknown_extra = requested_extra - valid_extra
+        if unknown_extra:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "invalid_payload",
+                    "message": f"extra_broadcast_member_ids에 이 org의 실존 회원이 아닌 id가 있습니다: "
+                               f"{sorted(str(i) for i in unknown_extra)}",
+                    "errors": [str(i) for i in unknown_extra],
+                },
+            )
+        broadcast_ids |= valid_extra
 
     try:
         project_id = await _resolve_event_project_id(db, org_id=org_id, payload=body.payload)

--- a/backend/app/services/event_routing_resolver.py
+++ b/backend/app/services/event_routing_resolver.py
@@ -24,6 +24,16 @@ class MissingRoutingPayloadFieldError(ValueError):
     빈 집합으로 넘기지 않고 발행 시점에 명시 오류(story #2633 AC4 "조용한 유실 금지")."""
 
 
+class UnknownRoutingMemberError(ValueError):
+    """story #2693(PO 자체 사고, customer-zero) — kind=payload_field로 받은 member_id가
+    문법적으로는 유효한 UUID지만 이 org의 실존 회원이 아님. 예전엔 그대로 통과시켜
+    `_get_or_create_event_conversation`이 그 UUID를 참가자로 앉힌 «유령 conversation»을
+    만들고 메시지까지 저장했다(reach=1 거짓 성공 — ConversationParticipant.member_id에
+    FK가 없어 존재하지 않는 member_id도 조용히 insert된다, story #2697 그라운딩에서
+    확인된 사실과 동형 갭). 여기서 막으면(caller가 conv/msg 어느 것도 만들기 전) 원자성이
+    자연히 보장된다 — publish_event()의 routing 해석 지점이 그 어떤 DB write보다 먼저다."""
+
+
 class InvalidWorkItemReferenceError(ValueError):
     """work_item_id/goal_id/payload_field UUID 값이 문법적으로 유효한 UUID가 아님 — story
     #2675: event_definition_registry.validate_event_payload가 format:uuid를 이제 집행하지만,
@@ -139,7 +149,15 @@ async def resolve_routing_leg(
             raise MissingRoutingPayloadFieldError(
                 f"routing이 요구하는 payload.{field}가 없거나 비었습니다."
             )
-        return {_parse_uuid(value, field_name=field)}
+        member_id = _parse_uuid(value, field_name=field)
+        from app.services.member_resolver import filter_org_member_ids
+
+        valid = await filter_org_member_ids({member_id}, org_id, db)
+        if not valid:
+            raise UnknownRoutingMemberError(
+                f"routing이 요구하는 payload.{field}({member_id})가 이 org의 실존 회원이 아닙니다."
+            )
+        return valid
 
     resolver = _SERVER_DERIVED_RESOLVERS[leg["target"]]
     return await resolver(db, org_id=org_id, payload=payload)

--- a/backend/tests/test_2693_publish_event_unknown_member_400.py
+++ b/backend/tests/test_2693_publish_event_unknown_member_400.py
@@ -1,0 +1,328 @@
+"""story #2693([BE·이벤트] publish_event notify_member_id가 org 비회원 UUID여도 400 대신
+«유령 대화» 생성+reach=1 거짓 성공) — PO 자체 사고(customer-zero) 재현+수정.
+
+배경: `resolve_routing_leg`의 `kind="payload_field"` 분기가 payload에서 뽑은 UUID를
+문법(파싱) 검증만 하고 **이 org의 실존 회원인지는 확認하지 않았다** — 존재하지 않는
+member_id도 그대로 escalation/broadcast 대상에 섞여 `_get_or_create_event_conversation`이
+그 UUID를 참가자로 앉힌 conversation을 만들고 메시지까지 저장했다(ConversationParticipant.
+member_id에 FK가 없어 조용히 통과 — story #2697 그라운딩에서 이미 확인된 동형 갭).
+`extra_broadcast_member_ids`도 같은 결함 클래스였다(filter_org_member_ids로 걸러내되
+그냥 조용히 drop하고 발행을 진행 — "존재 안 하면 거부"가 아니라 "존재하는 것만 취급").
+
+검증 축(AC):
+  ①payload_field routing이 해석한 member_id가 이 org의 활성 회원이 아니면 400 — 이벤트·
+    conversation·메시지 어느 것도 생성되지 않는다(원자성 실측: routing 해석이 그 어떤
+    DB write보다 먼저라 라우터 함수 자체가 자연히 이 성질을 갖는다).
+  ②extra_broadcast_member_ids도 동일 검증(더 이상 silent drop 아님).
+  ③양성대조: 존재하는 회원 UUID → 기존 동작 그대로(회귀 0, test_2633이 이미 커버 — 여기선
+    extra_broadcast_member_ids 축만 보강).
+  ④mutation-kill: existence check를 되돌리면 정확히 이 결함(유령 conversation 생성)이
+    재현되는지 확인(별도 절 — 코드 레벨에서 수행, 테스트 파일엔 결과만 남김).
+
+AC4(이미 생긴 유령 conversation 정리 방침)는 코드 스코프 밖 — story 본문에 1줄로 기록.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _load_seed_definitions():
+    import importlib.util
+    import os
+
+    spec = importlib.util.spec_from_file_location(
+        "_m0245c2693", os.path.join(os.path.dirname(__file__), "..", "alembic", "versions", "0245_event_definitions.py"),
+    )
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return {key: (payload_schema, routing) for key, payload_schema, routing in m._SEED}
+
+
+async def _seed_preset_definitions(session):
+    from app.models.event_definition import EventDefinition
+
+    for key, (payload_schema, routing) in _load_seed_definitions().items():
+        session.add(EventDefinition(
+            id=uuid.uuid4(), key=key, org_id=None, payload_schema=payload_schema, routing=routing,
+        ))
+    await session.commit()
+
+
+async def _seed_org_project(session, *, slug="acme2693"):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2693", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, assignee_id=None, human_owner_member_id=None):
+    from app.models.pm import Story
+
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="S",
+        assignee_id=assignee_id, human_owner_member_id=human_owner_member_id,
+    )
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+def _fake_request(*, project_id_header: uuid.UUID | None = None) -> "StarletteRequest":
+    from starlette.requests import Request as StarletteRequest
+
+    headers = []
+    if project_id_header is not None:
+        headers.append((b"x-project-id", str(project_id_header).encode()))
+    return StarletteRequest(scope={"type": "http", "headers": headers})
+
+
+async def _counts(session):
+    from sqlalchemy import func, select
+    from app.models.conversation import Conversation, ConversationMessage
+
+    conv_count = (await session.execute(select(func.count()).select_from(Conversation))).scalar_one()
+    msg_count = (await session.execute(select(func.count()).select_from(ConversationMessage))).scalar_one()
+    return conv_count, msg_count
+
+
+# ─── ① payload_field routing — 비회원 UUID → 400, 원자성(conv/msg 0건 생성) ─────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_unknown_assignee_member_id_400_no_ghost_conversation():
+    """PO 원 사고의 직접 재현 — preset.work.assigned의 assignee_member_id(kind=payload_field)
+    가 syntactically-valid하지만 이 org에 없는 UUID → 400, conversation/message 0건 생성."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_definitions(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            story_id = await _seed_story(s, org_id, project_id)
+            ghost_id = uuid.uuid4()  # 이 org 어디에도 없는 UUID(PO 실사고와 동형)
+
+            before = await _counts(s)
+            body = EventPublishRequest(
+                definition_key="preset.work.assigned",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "assignee_member_id": str(ghost_id),
+                },
+            )
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+            assert ei.value.detail["code"] == "invalid_payload"
+            assert str(ghost_id) in ei.value.detail["message"]
+
+            after = await _counts(s)
+            assert after == before, "비회원 UUID 거부 시 conversation/message가 하나도 생기면 안 됨(원자성)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_known_assignee_member_id_200_no_regression():
+    """양성대조 — 실존 회원이면 기존 동작 그대로(test_2633과 동형, 여기선 원자성 카운트도 같이 확인)."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_definitions(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            assignee_id = await _seed_agent(s, org_id, project_id, name="assignee")
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=assignee_id)
+
+            before = await _counts(s)
+            body = EventPublishRequest(
+                definition_key="preset.work.assigned",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "assignee_member_id": str(assignee_id),
+                },
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert resp["escalation_member_ids"] == [str(assignee_id)]
+
+            after = await _counts(s)
+            assert after[0] == before[0] + 1  # conversation 1건 생성
+            assert after[1] == before[1] + 1  # message 1건 생성
+    finally:
+        await engine.dispose()
+
+
+# ─── ② extra_broadcast_member_ids — 비회원 id 포함 시 400, 원자성 ───────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_unknown_extra_broadcast_member_id_400_no_ghost_conversation():
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_definitions(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            stakeholder_id = await _seed_agent(s, org_id, project_id, name="stakeholder")
+            story_id = await _seed_story(s, org_id, project_id, human_owner_member_id=stakeholder_id)
+            ghost_id = uuid.uuid4()
+
+            before = await _counts(s)
+            body = EventPublishRequest(
+                definition_key="preset.gate.verdict",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "gate_type": "merge", "verdict": "approved",
+                },
+                extra_broadcast_member_ids=[ghost_id],
+            )
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+            assert ei.value.detail["code"] == "invalid_payload"
+            assert str(ghost_id) in ei.value.detail["message"]
+
+            after = await _counts(s)
+            assert after == before
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_known_extra_broadcast_member_id_200_no_regression():
+    """양성대조 — 실존 회원의 extra_broadcast_member_ids는 broadcast에 정상 합류(무회귀)."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_definitions(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            stakeholder_id = await _seed_agent(s, org_id, project_id, name="stakeholder")
+            extra_id = await _seed_agent(s, org_id, project_id, name="extra")
+            story_id = await _seed_story(s, org_id, project_id, human_owner_member_id=stakeholder_id)
+
+            body = EventPublishRequest(
+                definition_key="preset.gate.verdict",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "gate_type": "merge", "verdict": "approved",
+                },
+                extra_broadcast_member_ids=[extra_id],
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert str(extra_id) in resp["broadcast_member_ids"]
+            assert str(stakeholder_id) in resp["broadcast_member_ids"]
+    finally:
+        await engine.dispose()
+
+
+# ─── resolve_routing_leg 단위 — 존재 검증 자체의 최소 재현 ──────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_resolve_routing_leg_payload_field_unknown_member_raises():
+    from app.services.event_routing_resolver import UnknownRoutingMemberError, resolve_routing_leg
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, _project_id = await _seed_org_project(s)
+            ghost_id = uuid.uuid4()
+            with pytest.raises(UnknownRoutingMemberError):
+                await resolve_routing_leg(
+                    {"kind": "payload_field", "target": "assignee", "member_id_field": "assignee_member_id"},
+                    payload={"assignee_member_id": str(ghost_id)},
+                    org_id=org_id, db=s,
+                )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_resolve_routing_leg_payload_field_known_member_returns_id_no_regression():
+    from app.services.event_routing_resolver import resolve_routing_leg
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            member_id = await _seed_agent(s, org_id, project_id)
+            ids = await resolve_routing_leg(
+                {"kind": "payload_field", "target": "assignee", "member_id_field": "assignee_member_id"},
+                payload={"assignee_member_id": str(member_id)},
+                org_id=org_id, db=s,
+            )
+            assert ids == {member_id}
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- PO 자체 사고(customer-zero, 2026-08-17 00:46 KST): `org.moonklabs.work.decision` 발행 시 `notify_member_id`에 존재하지 않는 UUID를 넣었는데 서버가 거부하지 않고 conversation을 새로 만들어 메시지를 실제로 저장 — 발신자는 `broadcast_member_ids`에 그 유령 UUID가 찍힌 응답을 받고 "도달했다"고 믿는다(`zero_reach_warning=false`).
- 근본: `resolve_routing_leg()`의 `kind="payload_field"` 분기가 payload에서 뽑은 UUID를 **문법(파싱) 검증만** 하고 이 org의 실존 회원인지는 확인하지 않았다. `ConversationParticipant.member_id`에 FK가 없어(story #2697 그라운딩에서 이미 확인된 동형 갭) 존재하지 않는 member_id도 조용히 participant로 insert됨.
- `extra_broadcast_member_ids`도 같은 결함 클래스 — `filter_org_member_ids`로 비회원을 걸러내되 그냥 조용히 drop하고 발행을 그대로 진행했다.

## Fix
- `event_routing_resolver.py`: payload_field 분기에 `filter_org_member_ids` 실존 검증 추가 — 비회원이면 `UnknownRoutingMemberError`(신규)로 즉시 거부.
- `events.py`: 그 예외를 기존 400 매핑에 합류. `extra_broadcast_member_ids`도 silent drop 대신 하나라도 비회원이면 400(조용한 유실 금지 — `MissingRoutingPayloadFieldError`와 동일 철학).
- 원자성은 라우터 구조 자체가 보장 — routing 해석(검증 포함)이 conversation/message 그 어떤 DB write보다 먼저라 별도 트랜잭션 경계 없이도 거부 시 아무것도 안 만들어짐.

## Test plan
- [x] `test_2693_publish_event_unknown_member_400.py`(신규 6건): payload_field·extra_broadcast_member_ids 양쪽 음성대조(400+원자성 카운트 실측)/양성대조(무회귀) 짝 + `resolve_routing_leg` 단위 검증
- [x] mutation-kill 전건 확인(원복 시 정확한 RED 재현 후 복원)
- [x] 관련 realdb 회귀 스윕 59/59 green
- [x] py_compile 클린, dev/prod 미접촉(로컬 disposable PG)

## AC4(이미 생긴 유령 conversation 정리)
코드 스코프 밖 — 식별 쿼리는 `ConversationParticipant.member_id`가 `team_members`/`org_members` 어디에도 없는 행 조인으로 찾을 수 있음. 정리 방침은 PO 판단(삭제 or 방치) — 이번 PR은 예방만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)