### PR TITLE
[SID:2082] 결재함 큐 카드 후속 — 제목 truncate w-full + 모바일 행 순서 DOM 단언

### DIFF
--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -645,4 +645,42 @@ describe('ApprovalsQueue', () => {
     await act(async () => { approveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(container.textContent).toContain(koMessages.cage.gateUndoRemaining.replace('{minutes}', '5'));
   });
+
+  // story 22affaf2 — PO 스크린샷(390px)과 유나 실측이 "행1이 뭔가"를 놓고 서로 다른 사실을
+  // 보고했다(뷰포트/하이드레이션 타이밍 차이 가능성, PO). jsdom엔 실 레이아웃 엔진이 없어
+  // getBoundingClientRect로는 못 가른다 — 코드가 정본이므로, 모바일(no-prefix, `sm:` 아닌)
+  // order 유틸 클래스 값 자체를 DOM에서 읽어 "primary가 order 수치상 더 앞인가"를 고정한다.
+  // Tailwind에서 order 숫자가 작을수록 flex-col(모바일)에서 위에 온다 — 유나 규격="primary 위".
+  function mobileOrderOf(el: Element): number {
+    const cls = (el.getAttribute('class') ?? '').split(/\s+/);
+    const token = cls.find((c) => /^order-\d+$/.test(c)); // "sm:order-3" 등 prefixed는 제외
+    if (!token) throw new Error(`no bare order-N class on: ${cls.join(' ')}`);
+    return Number(token.replace('order-', ''));
+  }
+
+  it('AC(신규, 22affaf2) — 모바일(no-prefix order) 기준 primary가 변경요청/보류보다 order 수치가 작아 위(행1)에 온다', async () => {
+    const highRiskGate = gate({
+      id: 'g-order-high', work_item_id: 'w-order-high', gate_type: 'merge_gate', status: 'pending',
+      requires_human: true, can_approve: true, risk_grade: 'high',
+      work_item_summary: { title: '고위험 항목', slug: null },
+    });
+    mockFetches([lowRiskActionable({ id: 'g-order-low' }), highRiskGate], []);
+    await mount();
+    // exact textContent 일치로 검색(gateApprove="승인"이 sigApproveAndSign="승인하고 서명"의
+    // 부분문자열이라 includes()면 잘못된 버튼이 잡힐 수 있다).
+    for (const label of [koMessages.cage.gateApprove, koMessages.cage.sigApproveAndSign]) {
+      const primary = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === label);
+      expect(primary).toBeTruthy();
+      const actionRow = primary!.parentElement!;
+      const rejectBtn = Array.from(actionRow.querySelectorAll('button')).find((b) => b.textContent === koMessages.cage.sigRequestChanges);
+      const holdBtn = Array.from(actionRow.querySelectorAll('button')).find((b) => b.textContent === koMessages.cage.gateDiscussSubmit);
+      expect(rejectBtn && holdBtn).toBeTruthy();
+      // reject/hold 자신의 order-N은 그 둘을 감싼 wrapper div(order-2, sm:contents) 안에서
+      // «서로»의 순서일 뿐 — primary와 견줄 기준은 그 wrapper 자체의(actionRow 기준) order다.
+      const wrapper = rejectBtn!.parentElement!;
+      expect(wrapper).toBe(holdBtn!.parentElement);
+      expect(wrapper.parentElement).toBe(actionRow);
+      expect(mobileOrderOf(primary!)).toBeLessThan(mobileOrderOf(wrapper));
+    }
+  });
 });

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -296,7 +296,11 @@ export function ApprovalsQueue() {
               ) : null}
               <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">{formatAge(gate.created_at, t)}</span>
             </div>
-            <p className="truncate text-sm text-foreground">
+            {/* PO 실측(390px, 2026-08-16) — items-start 부모(flex-col)에서 truncate는 자기
+                content 폭까지 shrink-to-fit돼 ellipsis가 걸릴 폭 기준 자체가 없다(카드
+                우변에서 그냥 잘림). w-full로 폭을 부모 카드 전체로 고정해야 truncate가 실제로
+                동작한다. */}
+            <p className="w-full truncate text-sm text-foreground">
               {gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`}
             </p>
             {orgName ? <p className="text-[11px] text-muted-foreground">{orgName}</p> : null}


### PR DESCRIPTION
## 배경

PO 실측(390px 스크린샷)과 유나 실측이 "고위험 카드의 행1이 뭔가"를 놓고 서로 다른 사실을 보고(뷰포트/하이드레이션 타이밍 차이 가능성, PO 판단). 코드가 정본이므로 vitest DOM 단언으로 고정.

## 변경

1. **제목 truncate 폭 고정**: 카드 제목 `<p className="truncate">`가 `items-start`(flex-col) 부모 안에서 shrink-to-fit돼 truncate가 걸릴 폭 기준 자체가 없었다(긴 문서 제목이 카드 우변에서 ellipsis 없이 그냥 잘림, PO 390px 실측). `w-full` 추가.
2. **모바일 행 순서 DOM 단언 신설**: Tailwind의 no-prefix(`order-N`, `sm:` 아닌) 유틸이 모바일(flex-col)에서의 실제 시각 순서를 결정한다는 사실을 이용해, primary 버튼의 order 값이 [변경 요청·보류] wrapper의 order 값보다 작은지(=위/행1에 옴) 저위험·고위험 둘 다 DOM에서 직접 확인.

**결론**: 코드는 이미 유나 규격대로였음(primary가 order상 앞섬 = 행1). PO 스크린샷은 다른 조건(다른 뷰포트/하이드레이션 타이밍)에서 찍힌 것으로 보임 — 코드 변경 없이 회귀가드만 추가.

## 검증
- `pnpm exec tsc --noEmit` → EXIT 0
- `pnpm lint` → EXIT 0(0 error, 기존 무관 warning 5건)
- `pnpm exec vitest run` → 432파일/3544테스트 전부 통과(신규 1: 모바일 order DOM 단언)
- `pnpm build` → EXIT 0

## 참고
- story [22affaf2](entity:story:22affaf2-2cfb-4e5a-96df-404dce4bf432) 후속(PO 지시, 2026-08-16) — 원 PR #3139는 이미 머지·배포됨.
- design 재확認(유나) → QA(카디르, 짧게) → 머지 → story done.