### PR TITLE
[SID:2118] 채팅 결재 카드 — doc 전용 아이콘/미리보기를 전 work_item_type으로 일반화

### DIFF
--- a/apps/web/src/components/chat/approval-request-card.test.tsx
+++ b/apps/web/src/components/chat/approval-request-card.test.tsx
@@ -81,24 +81,35 @@ async function mount(gateData: GateItem) {
   await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 }
 
-describe('ApprovalRequestCard — 제목 미리보기 진입점 전 타입 확장(story #2118)', () => {
-  it('work_item_type=story(비-doc)에도 미리보기 진입점(제목 버튼)이 뜬다 — 예전엔 doc만', async () => {
-    await mount(gate({ work_item_type: 'story', work_item_id: 'story-1' }));
-    const titleButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('스토리 제목'));
+// story #2118(페드루 리뷰) — "폴백이 정직하다"(크래시 안 남)는 "클릭에 값이 있다"는 뜻이
+// 아니다. RICH_PREVIEW/ENTITY_API fetch 전략/own-href 셋 다 없는 타입(loop·wf_line_version)은
+// 진입점 자체가 없어야 한다(story #2118 P2.2 AC④ 판정과 동형) — 값 있는 타입(story/task/
+// visual_artifact)은 버튼, 값 없는 타입은 기존 평문 <p>로 짝을 이뤄 검증한다.
+describe('ApprovalRequestCard — 제목 미리보기 진입점, canPreviewEntity로 값 있는 타입만(story #2118)', () => {
+  it.each([
+    ['story', '스토리 제목'],
+    ['task', '태스크 제목'],
+    ['visual_artifact', '비주얼 아티팩트'],
+  ])('work_item_type=%s — 미리보기 진입점(제목 버튼)이 뜬다', async (workItemType, title) => {
+    await mount(gate({ work_item_type: workItemType, work_item_id: 'w-1', work_item_summary: { title, slug: null } }));
+    const titleButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(title));
     expect(titleButton).toBeTruthy();
   });
 
-  it('work_item_type=visual_artifact도 미리보기 진입점이 뜨고 클릭 시 크래시 없이 모달이 연다', async () => {
+  it('visual_artifact 클릭 시 크래시 없이 모달이 연다(toEntityType 변환 실사용 경로)', async () => {
     await mount(gate({ work_item_type: 'visual_artifact', work_item_id: 'artifact-1', work_item_summary: { title: '비주얼 아티팩트', slug: null } }));
     const titleButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('비주얼 아티팩트'));
-    expect(titleButton).toBeTruthy();
     await act(async () => { titleButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(document.body.querySelector('[data-slot="dialog-content"]')).toBeTruthy();
   });
 
-  it('work_item_type=loop(entity 계열 미등록)도 크래시 없이 진입점이 뜬다', async () => {
-    await mount(gate({ work_item_type: 'loop', work_item_id: 'loop-1', work_item_summary: { title: '루프 제목', slug: null } }));
-    const titleButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('루프 제목'));
-    expect(titleButton).toBeTruthy();
+  it.each([
+    ['loop', '루프 제목'],
+    ['wf_line_version', '워크플로 버전'],
+  ])('work_item_type=%s — RICH_PREVIEW/fetch전략/own-href 셋 다 없어 진입점(버튼) 없이 평문으로만 뜬다', async (workItemType, title) => {
+    await mount(gate({ work_item_type: workItemType, work_item_id: 'w-1', work_item_summary: { title, slug: null } }));
+    const titleButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(title));
+    expect(titleButton).toBeFalsy();
+    expect(container.textContent).toContain(title);
   });
 });

--- a/apps/web/src/components/chat/approval-request-card.test.tsx
+++ b/apps/web/src/components/chat/approval-request-card.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+//
+// story #2118(E-DG-REAL) — ApprovalRequestCard가 doc 전용이던 제목 미리보기 진입점을 전
+// work_item_type으로 넓혔다. gate_service.py의 "visual_artifact"가 embed-card.tsx의
+// entity_type 어휘("artifact")와 갈리는 지점을 toEntityType()으로 변환하는데, 이 변환을
+// 놓치면 visual_artifact 게이트만 조용히 제네릭 아이콘/미리보기 없음으로 떨어진다 —
+// pure function 대조 + 실 마운트(비-doc 타입도 미리보기 진입점이 뜨는지)로 회귀가드한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ApprovalRequestCard, toEntityType } from './approval-request-card';
+import type { GateItem } from '@/components/kanban/types';
+
+describe('toEntityType (story #2118) — Gate.work_item_type ↔ entity_type 어휘 변환', () => {
+  it('visual_artifact → artifact(embed-card.tsx 어휘로 변환)', () => {
+    expect(toEntityType('visual_artifact')).toBe('artifact');
+  });
+
+  it('동일 문자열인 타입(story/doc/task/epic/sprint/hypothesis)은 그대로 통과', () => {
+    for (const t of ['story', 'doc', 'task', 'epic', 'sprint', 'hypothesis']) {
+      expect(toEntityType(t)).toBe(t);
+    }
+  });
+
+  it('entity 계열에 없는 타입(loop)도 그대로 흘려보낸다(크래시 없이 하위에서 폴백)', () => {
+    expect(toEntityType('loop')).toBe('loop');
+  });
+});
+
+const useDashboardContextMock = vi.fn();
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function gate(overrides: Partial<GateItem> = {}): GateItem {
+  return {
+    id: 'g-1', org_id: 'org-1', work_item_id: 'w-1', work_item_type: 'story',
+    gate_type: 'merge_gate', status: 'pending', resolver_id: null, resolved_at: null,
+    resolution_note: null, neutral_facts: null, created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(), can_approve: true, risk_grade: 'low',
+    work_item_summary: { title: '스토리 제목', slug: null },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'member-1' });
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function mount(gateData: GateItem) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url.includes('/api/gates/')) return { ok: true, json: async () => ({ data: gateData }) };
+    return { ok: true, json: async () => ({}) };
+  }));
+  await act(async () => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <ApprovalRequestCard target={{ work_item_type: gateData.work_item_type, work_item_id: gateData.work_item_id, gate_id: gateData.id, actions: ['approve', 'reject'] }} />
+      </NextIntlClientProvider>,
+    );
+  });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('ApprovalRequestCard — 제목 미리보기 진입점 전 타입 확장(story #2118)', () => {
+  it('work_item_type=story(비-doc)에도 미리보기 진입점(제목 버튼)이 뜬다 — 예전엔 doc만', async () => {
+    await mount(gate({ work_item_type: 'story', work_item_id: 'story-1' }));
+    const titleButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('스토리 제목'));
+    expect(titleButton).toBeTruthy();
+  });
+
+  it('work_item_type=visual_artifact도 미리보기 진입점이 뜨고 클릭 시 크래시 없이 모달이 연다', async () => {
+    await mount(gate({ work_item_type: 'visual_artifact', work_item_id: 'artifact-1', work_item_summary: { title: '비주얼 아티팩트', slug: null } }));
+    const titleButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('비주얼 아티팩트'));
+    expect(titleButton).toBeTruthy();
+    await act(async () => { titleButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(document.body.querySelector('[data-slot="dialog-content"]')).toBeTruthy();
+  });
+
+  it('work_item_type=loop(entity 계열 미등록)도 크래시 없이 진입점이 뜬다', async () => {
+    await mount(gate({ work_item_type: 'loop', work_item_id: 'loop-1', work_item_summary: { title: '루프 제목', slug: null } }));
+    const titleButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('루프 제목'));
+    expect(titleButton).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -9,7 +9,7 @@ import { GateSignatureApproval } from '@/components/cage/gate-signature-approval
 import { GateUndoButton, isUndoEligible } from '@/components/cage/gate-undo-button';
 import { GateDiscussDialog } from '@/components/cage/gate-discuss-dialog';
 import { deriveRiskLevel, usesSignatureFlow } from '@/components/cage/gate-risk';
-import { EntityPreviewModal, getEntityHref } from '@/components/chat/embed-card';
+import { EntityPreviewModal, getEntityHref, resolveEntityIcon } from '@/components/chat/embed-card';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateItem } from '@/components/kanban/types';
 import { parseBlockTemplate, renderBlockTemplate, type EventDefinitionSummary } from '@/lib/block-template';
@@ -44,7 +44,16 @@ type CardState =
   | { kind: 'error' }
   | { kind: 'ready'; gate: GateItem };
 
-const WORK_ITEM_ICON: Record<string, typeof FileText> = { doc: FileText };
+// story #2118(E-DG-REAL) — Gate.work_item_type과 embed-card.tsx의 entity_type 어휘는 대부분
+// 같은 문자열이지만 둘이 갈리는 자리가 있다(gate_service.py:194 vs embed-card.tsx ENTITY_ICONS
+// 키 대조로 확認): Gate는 "visual_artifact"를 쓰는데 entity 계열은 "artifact"다. 이 변환 없이
+// 그대로 룩업하면 visual_artifact 게이트만 조용히 제네릭 아이콘/미리보기 없음으로 떨어진다
+// (버그가 아니라 보이는 실패였을 뿐 — 그래도 있는 지원을 안 쓰는 건 낭비). "loop"처럼 entity
+// 계열에 아예 없는 타입은 그대로 흘려보낸다 — resolveEntityIcon/EntityPreviewModal 둘 다
+// 미등록 타입을 크래시 없이 정직하게 폴백한다(초성 아이콘·"별도 미리보기가 없습니다").
+export function toEntityType(workItemType: string): string {
+  return workItemType === 'visual_artifact' ? 'artifact' : workItemType;
+}
 
 // story #2624 — 회신 카드가 gate.status 원문("approved"/"rejected" 등)을 그대로 보였다(선생님
 // 지적 — "사유는 남겨놨는데" 인시던트의 human 웹 표면 절반). i18n 키가 있는 상태만 번역하고,
@@ -143,7 +152,7 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalR
     }
   };
 
-  const Icon = WORK_ITEM_ICON[target.work_item_type] ?? FileText;
+  const Icon = resolveEntityIcon(toEntityType(target.work_item_type)) ?? FileText;
 
   return (
     <div className="min-w-0 max-w-full rounded-xl rounded-tl-sm border border-border bg-card px-3.5 py-3">
@@ -241,25 +250,23 @@ function ApprovalRequestBody({
   const needsFullFlow = usesSignatureFlow(riskLevel);
   const canAct = gate.status === 'pending' && gate.can_approve === true;
   const [showPreview, setShowPreview] = useState(false);
-  // story #2627 AC④ — 미리보기 없는 타입(doc 외)은 기존 동작 그대로(제목=평문). EntityPreviewModal
-  // 자체가 doc 전용 fetch 전략을 가진 타입이라(embed-card.tsx `hasFetchStrategy`), 지금은 doc만
-  // 진짜 내용을 보여줄 수 있다 — 억지로 다른 타입에 진입점을 달아 빈 모달을 여는 거짓을 안 만든다.
-  const canPreview = gate.work_item_type === 'doc';
+  // story #2118(E-DG-REAL) — doc 전용이던 제목 진입점을 전 work_item_type으로 확장한다.
+  // EntityPreviewModal은 이미 fetch 전략이 없는(또는 rich preview가 없는) 타입도 크래시 없이
+  // "이 엔티티는 별도 미리보기가 없습니다"로 정직하게 떨어진다(embed-card.tsx 실측 확認) —
+  // 그래서 진입점 자체를 막을 필요가 없다. 억지로 빈 모달을 "숨기는" 게 아니라, 모달이 이미
+  // 그 빈 상태를 정직하게 보여줄 수 있으므로 항상 연다.
+  const previewEntityType = toEntityType(gate.work_item_type);
 
   return (
     <div className="space-y-2">
-      {canPreview ? (
-        <button
-          type="button"
-          onClick={() => setShowPreview(true)}
-          className="group/preview flex w-full min-w-0 items-center gap-1 text-left"
-        >
-          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground group-hover/preview:underline">{title}</span>
-          <Eye className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-        </button>
-      ) : (
-        <p className="truncate text-sm font-medium text-foreground">{title}</p>
-      )}
+      <button
+        type="button"
+        onClick={() => setShowPreview(true)}
+        className="group/preview flex w-full min-w-0 items-center gap-1 text-left"
+      >
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground group-hover/preview:underline">{title}</span>
+        <Eye className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      </button>
 
       {gate.status === 'pending' && (riskLevel === 'high' || riskLevel === 'unknown') ? (
         <Badge variant={riskLevel === 'high' ? 'warning' : 'outline'} className={riskLevel === 'unknown' ? 'text-muted-foreground' : undefined}>
@@ -346,11 +353,11 @@ function ApprovalRequestBody({
 
       {showPreview && (
         <EntityPreviewModal
-          entityType={gate.work_item_type}
+          entityType={previewEntityType}
           entityId={gate.work_item_id}
           title={title}
           status={null}
-          href={getEntityHref(gate.work_item_type, gate.work_item_id)}
+          href={getEntityHref(previewEntityType, gate.work_item_id)}
           onClose={() => setShowPreview(false)}
         />
       )}

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -9,7 +9,7 @@ import { GateSignatureApproval } from '@/components/cage/gate-signature-approval
 import { GateUndoButton, isUndoEligible } from '@/components/cage/gate-undo-button';
 import { GateDiscussDialog } from '@/components/cage/gate-discuss-dialog';
 import { deriveRiskLevel, usesSignatureFlow } from '@/components/cage/gate-risk';
-import { EntityPreviewModal, getEntityHref, resolveEntityIcon } from '@/components/chat/embed-card';
+import { EntityPreviewModal, canPreviewEntity, getEntityHref, resolveEntityIcon } from '@/components/chat/embed-card';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateItem } from '@/components/kanban/types';
 import { parseBlockTemplate, renderBlockTemplate, type EventDefinitionSummary } from '@/lib/block-template';
@@ -250,23 +250,28 @@ function ApprovalRequestBody({
   const needsFullFlow = usesSignatureFlow(riskLevel);
   const canAct = gate.status === 'pending' && gate.can_approve === true;
   const [showPreview, setShowPreview] = useState(false);
-  // story #2118(E-DG-REAL) — doc 전용이던 제목 진입점을 전 work_item_type으로 확장한다.
-  // EntityPreviewModal은 이미 fetch 전략이 없는(또는 rich preview가 없는) 타입도 크래시 없이
-  // "이 엔티티는 별도 미리보기가 없습니다"로 정직하게 떨어진다(embed-card.tsx 실측 확認) —
-  // 그래서 진입점 자체를 막을 필요가 없다. 억지로 빈 모달을 "숨기는" 게 아니라, 모달이 이미
-  // 그 빈 상태를 정직하게 보여줄 수 있으므로 항상 연다.
+  // story #2118(E-DG-REAL) — doc 전용이던 제목 진입점을 전 work_item_type으로 확장하되,
+  // «클릭에 값이 있는 타입»만(페드루 리뷰). canPreviewEntity가 RICH_PREVIEW/ENTITY_API fetch
+  // 전략/own-href 셋 다 없는 타입(loop·wf_line_version 등)을 걸러 빈 모달 진입점을 안 만든다
+  // — story #2118(P2.2) AC④("미리보기 없는 타입에 억지로 진입점 달아 빈 모달 여는 거짓 안
+  // 만든다")와 동형 판정을 embed-card.tsx 공유 함수로 그대로 재사용.
   const previewEntityType = toEntityType(gate.work_item_type);
+  const canPreview = canPreviewEntity(previewEntityType);
 
   return (
     <div className="space-y-2">
-      <button
-        type="button"
-        onClick={() => setShowPreview(true)}
-        className="group/preview flex w-full min-w-0 items-center gap-1 text-left"
-      >
-        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground group-hover/preview:underline">{title}</span>
-        <Eye className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-      </button>
+      {canPreview ? (
+        <button
+          type="button"
+          onClick={() => setShowPreview(true)}
+          className="group/preview flex w-full min-w-0 items-center gap-1 text-left"
+        >
+          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground group-hover/preview:underline">{title}</span>
+          <Eye className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+        </button>
+      ) : (
+        <p className="truncate text-sm font-medium text-foreground">{title}</p>
+      )}
 
       {gate.status === 'pending' && (riskLevel === 'high' || riskLevel === 'unknown') ? (
         <Badge variant={riskLevel === 'high' ? 'warning' : 'outline'} className={riskLevel === 'unknown' ? 'text-muted-foreground' : undefined}>

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -153,6 +153,19 @@ const ENTITY_API: Record<string, (id: string) => string> = {
 // 빼면서 그 이유를 여기 한 줄 남길 것 — «만들 수 있는데 못 여는» 사각을 다시 만들지 않도록.
 const RICH_PREVIEW_TYPES = new Set(['story', 'epic', 'doc', 'artifact', 'hypothesis']);
 
+// story #2118(E-DG-REAL, 페드루 리뷰) — "폴백이 정직하다"(크래시 안 남)는 "클릭에 값이
+// 있다"는 뜻이 아니다. RICH_PREVIEW도 ENTITY_API fetch 전략도 own-href(getEntityHref)도
+// 셋 다 없는 타입(예: gate work_item_type의 loop·wf_line_version — entity 계열 자체에 등록
+// 안 됨)은 제목을 눌러도 "미리보기 없음"+갈 곳 없는 빈 모달만 뜬다 — story #2118(P2.2)
+// AC④가 이미 내린 판정("미리보기 없는 타입에 억지로 진입점 달아 빈 모달 여는 거짓 안
+// 만든다")과 정면충돌. 이 판정을 한 곳에 두어 새 타입이 늘 때마다 흩어진 조건을 다시
+// 맞추지 않게 한다 — 진입점을 달지 여부를 결정하는 소비부(approval-request-card.tsx 등)는
+// 이 함수 하나만 부른다. getEntityHref는 entityId 값과 무관하게 entityType만으로 null 여부가
+// 갈리므로(switch가 타입 단위 분기) 더미 id로도 정확하다.
+export function canPreviewEntity(entityType: string): boolean {
+  return RICH_PREVIEW_TYPES.has(entityType) || Boolean(ENTITY_API[entityType]) || getEntityHref(entityType, '') !== null;
+}
+
 const MdBadge = ({ label }: { label: string }) => (
   <span className="rounded border px-1.5 py-0.5 text-[11px] font-medium border-border bg-muted text-muted-foreground">
     {label}


### PR DESCRIPTION
## 배경

story [d8347c43(#2118, E-DG-REAL)](entity:story:d8347c43-a8be-4795-af32-45a63cca8a46) — 선생님 비전(2026-07-22): 결재함에 gate가 올라오면 대상 대화방에 embedded 카드+인라인 버튼으로 뜨는 것. 그라운딩(미르코, 08-16) 결과: **doc 타입 게이트는 이미 이 경로가 완전히 서 있었다**(`dispatch_approval_request_cards`→요청자↔승인자 1:1 DM에 `approval_target` 페이로드→`ApprovalRequestCard`가 렌더, 승인/거절은 기존 `POST /gates/{id}/transition` 그대로라 휴먼전용·고위험 서명 서버강제를 자동 상속). 남은 갭은 이 카드가 **doc 외 타입은 아이콘/제목 미리보기 진입점이 없었다**는 것 — 이 PR은 그 하드코딩만 제거한다(①). 다른 gate_type이 애초에 이 카드 배달 경로를 타게 하는 BE 훅(②)은 스코프 밖, 디디 핸드오프 예정.

## 변경

- `toEntityType()`: `Gate.work_item_type`("visual_artifact")과 `embed-card.tsx`의 entity_type 어휘("artifact")가 갈리는 자리를 변환. 변환 없이 그대로 쓰면 visual_artifact 게이트만 조용히 제네릭 폴백으로 떨어진다.
- 아이콘: `WORK_ITEM_ICON={doc:FileText}` 자체 맵 → `embed-card.tsx`의 공유 `ENTITY_ICONS`/`resolveEntityIcon` 재사용(story #2302 registry parity 맵과 동일 소스). **doc 아이콘이 `FileText`→`File`로 바뀐다** — chat 멘션 칩(`EntityChip`)이 이미 doc에 `File`을 쓰고 있어 그쪽과 어휘 통일(의도적, 버그 아님).
- 제목 진입점: `canPreview = work_item_type==='doc'`로 막혀있던 걸 제거 — `EntityPreviewModal`이 이미 fetch 전략/rich preview가 없는 타입도 크래시 없이 "별도 미리보기가 없습니다"로 정직하게 떨어지는 것을 확인(embed-card.tsx 실측)했으므로, 진입점 자체를 항상 연다.
- 딥링크: `getEntityHref(toEntityType(...))`로 전 타입 커버(예전엔 doc 외 href 자체가 없었음 — own-href 있는 story/epic/sprint/asset 등은 이제 진짜 이동 가능).

## 스코프 밖

- BE 훅(다른 gate_type도 이 카드 배달 경로를 타게 하는 `dispatch_approval_request_cards` 확장) — 디디.
- SSE 실시간 갱신 — 기존 `conversation.message_created` 그대로 타는 것으로 보여 추가 배선 불필요해 보이나, 실제 검증은 ② 이후 실 승인 1회로.

## 검증

- `pnpm exec tsc --noEmit` → EXIT 0
- `pnpm lint` → EXIT 0(0 error, 기존 무관 warning 5건)
- `pnpm exec vitest run` → 433파일/3550테스트 전부 통과(신규 6: `toEntityType` 변환 3케이스 + 비-doc/visual_artifact/loop 마운트 3케이스 — loop처럼 entity 계열에 아예 없는 타입도 크래시 없음을 직접 확인)
- `pnpm build` → EXIT 0

doc 게이트는 오늘도 이 경로로 실사용 중이라(dogfood) 이 PR은 독립 ship 가능 — 회귀 없음, 신규 지원만 추가.