### PR TITLE
[모바일·결함] 인박스 상단바 title 글자단위 세로꺾임 fix — TopBar 슬롯 단일 정의 nowrap

### DIFF
--- a/apps/web/src/components/nav/top-bar.test.tsx
+++ b/apps/web/src/components/nav/top-bar.test.tsx
@@ -77,6 +77,42 @@ async function mount(width: number) {
   await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 }
 
+// story 6df91dce — 390px에서 title(현재 탭 이름)이 글자 단위로 세로 꺾이던 결함. jsdom엔
+// 레이아웃 엔진이 없어 실제 줄바꿈은 못 잰다 — 대신 렌더러가 title 슬롯 직계 자식에 nowrap
+// degrade(min-w-0+truncate) 클래스를 «거는지»를 고정한다. 이 클래스가 빠지면(회귀) RED.
+async function mountWithTitle(width: number) {
+  stubViewport(width);
+  const { TopBar } = await import('./top-bar');
+  const { TopBarProvider } = await import('./top-bar-context');
+  const { TopBarSlot } = await import('./top-bar-slot');
+  const { SidebarProvider } = await import('@/components/ui/sidebar');
+  await act(async () => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <TopBarProvider>
+          <SidebarProvider>
+            <TopBar />
+            <TopBarSlot title={<h1 className="text-sm font-medium">결재함아주긴탭이름제목테스트</h1>} />
+          </SidebarProvider>
+        </TopBarProvider>
+      </NextIntlClientProvider>,
+    );
+  });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('TopBar — title 슬롯 nowrap 가드 (story 6df91dce·390px 글자단위 줄바꿈 방지)', () => {
+  it('title 슬롯 컨테이너가 직계 자식(제목)에 truncate+min-w-0을 걸어 줄바꿈 대신 한 줄 말줄임으로 degrade한다', async () => {
+    vi.resetModules();
+    await mountWithTitle(390);
+    const h1 = container.querySelector('h1');
+    expect(h1).not.toBeNull();
+    const slotContainer = h1!.parentElement!;
+    expect(slotContainer.className).toContain('[&>*]:truncate');
+    expect(slotContainer.className).toContain('[&>*]:min-w-0');
+  });
+});
+
 describe('TopBar — story #2683 태블릿 전용 GNB 트리거', () => {
   it('태블릿(768px)에서는 트리거가 뜬다', async () => {
     vi.resetModules();

--- a/apps/web/src/components/nav/top-bar.tsx
+++ b/apps/web/src/components/nav/top-bar.tsx
@@ -61,7 +61,13 @@ export function TopBar({ className, orgId, orgMemberships = [], projectId, proje
           currentProjectId={projectId}
         />
       )}
-      <div className="flex min-w-0 flex-1 items-center gap-2">
+      {/* story 6df91dce — 390px에서 title(현재 탭 이름, 예 "결재함")이 contextChip+actions와
+          폭 경합에 밀려 글자 단위로 세로 꺾이던 결함(선생님 폰 첫 화면 "결/재/함"). title 슬롯은
+          <h1 className="text-sm font-medium">{...}</h1> 패턴이 인박스·rewards·chats·more·goals·
+          standup·sprints·docs 등 10+ 화면 공통이라 각 caller가 아니라 이 렌더러(슬롯 소비처)에서
+          단일 정의로 막는다 — 직계 자식(title)에 min-w-0+truncate를 걸어 flex 안에서 줄바꿈 대신
+          한 줄 말줄임으로 degrade. sidebar.tsx의 [&>span:last-child]:truncate와 동일 관례. */}
+      <div className="flex min-w-0 flex-1 items-center gap-2 [&>*]:min-w-0 [&>*]:truncate">
         {title}
       </div>
       <div className="flex shrink-0 items-center gap-1">


### PR DESCRIPTION
## 무엇을 · 왜

story 6df91dce — 390px 인박스 상단바에서 title(현재 탭 이름, 예 "결재함")이 contextChip + actions와 폭 경합에 밀려 **"결/재/함"으로 글자 단위 세로 꺾임**(선생님 폰 첫 화면). 내가 결재함 P0(2082) 390px 판정에서 «기존·별건»으로 갈라 준 그 자리.

## 변경 지점

- **`top-bar.tsx`** (슬롯 렌더러): title 슬롯 컨테이너 `flex min-w-0 flex-1 items-center gap-2` → 여기에 **`[&>*]:min-w-0 [&>*]:truncate`** 추가. 직계 자식(title)이 flex 안에서 줄바꿈 대신 한 줄 말줄임으로 degrade한다.
- **`top-bar.test.tsx`**: nowrap 가드 1건 — title 슬롯 컨테이너가 직계 자식에 truncate + min-w-0을 거는지 고정(회귀 시 RED).

## 단일 정의로 막은 이유 (형제 탭 바 grep)

`<h1 className="text-sm font-medium">{title}</h1>` title 패턴은 **inbox · rewards · chats · more · goals · standup · sprints · docs 등 10+ 화면 공통**이다(`grep -rn '<h1 className="text-sm font-medium">'`). 인박스는 경합 요소(contextChip · count · 전체읽음 · presence · bell)가 가장 많아 발현 지점일 뿐 — 결함 클래스는 공유된다. 각 caller에 nowrap을 붙이면 새 화면마다 빠뜨리는 fail-open이 되므로, **렌더러(슬롯 소비처) 한 곳**에서 막아 전 화면 + 미래 caller까지 닫는다. `sidebar.tsx`의 `[&>span:last-child]:truncate`와 동일 관례.

## AC 커버리지

- **KO · EN**: CSS-only · locale 무관 ✅
- **375 / 360 / 390**: `truncate`는 전 폭에서 동작 ✅
- **형제 탭 바 grep**: 위 10+ 화면 — 렌더러 단일 정의로 전부 보호(각 파일 미변경) ✅
- **nowrap 가드 1건**: `top-bar.test.tsx` ✅
- **라이브(긴 제목 말줄임 375/360)**: 배포 후 확認(선택 · design 게이트 self)

## 검증

- typecheck: top-bar 관련 에러 0.
- ⚠️ **jsdom 가드 테스트는 로컬 미실행** — 로컬 node_modules에 jsdom 미설치(기존 `top-bar.test.tsx` 포함 전 jsdom-env 테스트가 로컬서 동일하게 못 돎). **CI(프레시 설치)가 실행한다.** 로직: 렌더된 `h1.parentElement`(= title 슬롯 컨테이너) `className`에 `[&>*]:truncate` · `[&>*]:min-w-0` 리터럴 포함 assert — 기존 top-bar 테스트와 동일 mount 패턴.

design 게이트 = self(내 모바일 UX fix, 문자열/구조 판단이 내 설계 결정) · QA = 카디르군.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
