### PR TITLE
[BE·MCP] list_stories/list_backlog/search_stories에 limit·cursor·has_more 배선 (story #2428 PR #1/N)

### DIFF
--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -244,8 +244,14 @@ class StoryRepository(BaseRepository[Story]):
         story_number: int | None = None,
         q: str | None = None,
         unattached: bool = False,
-    ) -> list[Story]:
+    ) -> tuple[list[Story], int]:
         """sprint 미배정 + 삭제되지 않은 스토리만 서버사이드 필터.
+
+        story #2428: `(stories, total)` 튜플을 반환한다(list()/list_board()와 동형 — 필터
+        適用 後·limit 適用 前 실 COUNT). 예전엔 total 자체를 안 내(X-Total-Count 헤더 부재)
+        MCP `sprintable_list_backlog`가 「더 있는지」를 알 방법이 없었다 — 카디르가 200건
+        요청 大비 이 분기가 1000건(자연 상한)까지 조용히 다 실어 320만자 응답을 낸 것도 이
+        갭의 다른 얼굴(list_backlog 호출부는 이 사실 자체를 몰랐다).
 
         story #2188 형제(2026-07-25, 오르테가군 판정) — board 분기(#2489)와 같은 결함 클래스:
         이 분기도 epic_id/assignee_id/status/story_number/q를 받기만 하고 무시했다. 필터
@@ -280,8 +286,12 @@ class StoryRepository(BaseRepository[Story]):
             query = query.where(_title_search_filter(q))
         if unattached:
             query = query.where(_unattached_clause())
+
+        count_q = select(func.count()).select_from(query.subquery())
+        total = (await self.session.execute(count_q)).scalar_one()
+
         result = await self.session.execute(query.limit(limit))
-        return list(result.scalars().all())
+        return list(result.scalars().all()), total
 
     async def transition_status(self, id: uuid.UUID) -> Story:
         story = await self.get(id)

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -204,10 +204,15 @@ async def list_stories(
         # ⚠️ cursor는 안 넘긴다 — #2190은 이 분기와 무관함이 밝혀졌다(list_backlog
         # docstring 참조: /api/stories/backlog 프록시가 status를 강제 부착해 실제로는
         # board 분기로 감).
-        stories = await repo.list_backlog(
+        # story #2428: list_backlog가 이제 (stories, total) — X-Total-Count로 호출부가
+        # "더 있는지"를 알 수 있게 한다(이 분기는 cursor 미지원, 위 docstring 참조 — 더
+        # 필요하면 limit을 올려 재호출하는 것이 유일한 다음 페이지 수단).
+        stories, total = await repo.list_backlog(
             project_id, limit=limit, epic_id=epic_id, assignee_id=assignee_id,
             status=status_filter, story_number=story_number, q=q, unattached=unattached,
         )
+        if response is not None:
+            response.headers["X-Total-Count"] = str(total)
         await _attach_assignee_ids(repo.session, repo.org_id, stories)
         await _attach_has_evidence(repo.session, stories)
         await _attach_has_hypothesis_or_goal(repo.session, stories)

--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -279,6 +279,7 @@ class SprintableClient:
         json: dict | None = None,
         params: dict | None = None,
         unwrap: bool = True,
+        return_headers: bool = False,
     ) -> Any:
         url = f"{self._base_url}{path}"
         # E-MCP-HTTP S1: effective 키 = per-request override(http 멀티테넌트) ∨ env 단일키(stdio·무회귀).
@@ -335,14 +336,23 @@ class SprintableClient:
         # 같은 이유로 이 함수를 공유하는 **command_gate도 처음부터 MCP 경로에서 안 보였다**
         # (이번에 같이 드러난 기존 버그 — 별도로 새로 만든 게 아니다). unwrap=False를 넘기면
         # 언래핑하지 않고 전체를 그대로 반환한다(소수 호출부 — sibling 키가 필요한 곳만 씀).
-        if not unwrap:
-            return data
-        if isinstance(data, dict) and "data" in data:
-            return data["data"]
+        if unwrap and isinstance(data, dict) and "data" in data:
+            data = data["data"]
+        # story #2428: X-Total-Count/X-Next-Cursor(stories.py 계열 — 헤더 기반 페이지네이션,
+        # docs.py/notifications.py의 body meta{has_more,next_cursor} 규약과 wire shape가 다름)를
+        # 읽으려는 호출부용. httpx.Headers는 대소문자 무관 dict-like — 그대로 넘긴다.
+        if return_headers:
+            return data, resp.headers
         return data
 
     async def get(self, path: str, *, params: dict | None = None) -> Any:
         return await self.request("GET", path, params=params)
+
+    async def get_with_headers(self, path: str, *, params: dict | None = None) -> tuple[Any, Any]:
+        """story #2428 — X-Total-Count/X-Next-Cursor 헤더로 페이지네이션을 신호하는
+        엔드포인트(stories.py 계열)용. `(body, headers)` 튜플 반환 — headers는 httpx.Headers
+        (대소문자 무관 접근)."""
+        return await self.request("GET", path, params=params, return_headers=True)
 
     async def post(self, path: str, *, json: dict | None = None) -> Any:
         return await self.request("POST", path, json=json or {})

--- a/backend/sprintable_mcp/response.py
+++ b/backend/sprintable_mcp/response.py
@@ -25,3 +25,31 @@ def ok(data: object) -> list[TextContent]:
 def err(msg: str) -> list[TextContent]:
     """오류 응답 — ok()와 동일한 list[TextContent] 반환. 에러 prefix로 에이전트 구분."""
     return [TextContent(type="text", text=f"Error: {msg}")]
+
+
+def ok_paginated(
+    items: list,
+    *,
+    has_more: bool,
+    next_cursor: str | None,
+    tool_name: str,
+    cursor_param: str = "cursor",
+) -> list[TextContent]:
+    """story #2428 — docs.py list_docs/notifications.py check_notifications가 이미 쓰는
+    「더 있으면 2차 텍스트 블록으로 안내」 관례의 공용화(그 두 곳은 각자 복제해 두고 있었다 —
+    새로 만드는 이 계열 도구는 여기서부터 공유). 조용히 자르지 않는다는 것이 이 스토리의
+    본체 — has_more=True인데 next_cursor가 없으면(호출부 실수) 안내 문구 없이 items만
+    돌려주는 대신 명시로 알 수 있게 그 사실 자체를 문구에 남긴다."""
+    blocks = ok(items)
+    if has_more:
+        cursor_hint = (
+            f'{cursor_param}="{next_cursor}"' if next_cursor else f"{cursor_param}(서버가 next_cursor를 안 줌 — 호출부 확인 필요)"
+        )
+        blocks.append(TextContent(
+            type="text",
+            text=(
+                f"※ 더 있음 — 이 응답은 {len(items)}건까지만 포함(전량 아님). "
+                f"다음 페이지: {tool_name}를 {cursor_hint}로 다시 호출."
+            ),
+        ))
+    return blocks

--- a/backend/sprintable_mcp/tools/analytics.py
+++ b/backend/sprintable_mcp/tools/analytics.py
@@ -5,8 +5,9 @@ from mcp.types import TextContent
 from pydantic import AliasChoices, ConfigDict, Field
 
 from ..api_client import client
-from ..response import err, ok
+from ..response import err, ok, ok_paginated
 from ..schemas import SprintableInput
+from .stories import _has_more_from_headers
 
 
 class MemberIdInput(SprintableInput):
@@ -46,6 +47,8 @@ class AgentStatsInput(SprintableInput):
 
 class SearchStoriesInput(SprintableInput):
     query: str
+    limit: int | None = None
+    cursor: str | None = None  # 이전 호출의 X-Next-Cursor 헤더 값을 그대로 넘기면 다음 페이지.
 
 
 async def get_project_overview(args: SprintableInput) -> list[TextContent]:
@@ -75,7 +78,14 @@ async def get_sprint_velocity_history(args: SprintableInput) -> list[TextContent
 async def search_stories(args: SearchStoriesInput) -> list[TextContent]:
     """스토리 제목 검색."""
     try:
-        return ok(await client.get("/api/v2/stories", params={"project_id": client.require_project_id(), "q": args.query}))
+        params: dict = {"project_id": client.require_project_id(), "q": args.query}
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
+        items, headers = await client.get_with_headers("/api/v2/stories", params=params)
+        has_more, next_cursor = _has_more_from_headers(headers, items)
+        return ok_paginated(items, has_more=has_more, next_cursor=next_cursor, tool_name="sprintable_search_stories")
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -6,9 +6,26 @@ from __future__ import annotations
 from mcp.types import CallToolResult, TextContent
 
 from ..api_client import client
-from ..response import err, ok
+from ..response import err, ok, ok_paginated
 from ..schemas import SprintableInput, StoryPoints, StoryPriority, StoryStatus
 from .attachments import upload_attachments
+
+
+def _has_more_from_headers(headers, items: list) -> tuple[bool, str | None]:
+    """story #2428 — stories.py 계열은 X-Total-Count/X-Next-Cursor **헤더**로 페이지네이션을
+    신호한다(docs.py/notifications.py의 body meta{has_more} 규약과 wire shape가 다름). BE가
+    X-Next-Cursor를 «항상»(결과가 있으면) 싣기 때문에(app/routers/goals.py·stories.py — 실제
+    다음 페이지 유무와 무관하게 `if items:`만 조건) 그 헤더의 존재 자체는 has_more 신호가
+    아니다 — X-Total-Count와 이번 응답 건수를 비교해야 진짜 «더 있음»을 안다."""
+    total_raw = headers.get("x-total-count")
+    next_cursor = headers.get("x-next-cursor")
+    if total_raw is None:
+        return False, next_cursor
+    try:
+        total = int(total_raw)
+    except (TypeError, ValueError):
+        return False, next_cursor
+    return total > len(items), next_cursor
 
 
 class ListStoriesInput(SprintableInput):
@@ -17,6 +34,15 @@ class ListStoriesInput(SprintableInput):
     status: StoryStatus | None = None
     priority: StoryPriority | None = None
     assignee_id: str | None = None
+    limit: int | None = None
+    cursor: str | None = None  # 이전 호출의 X-Next-Cursor 헤더 값을 그대로 넘기면 다음 페이지.
+
+
+class ListBacklogInput(SprintableInput):
+    limit: int | None = None
+    # story #2428: cursor 없음 — 이 분기(list_backlog)는 cursor pagination 자체를 지원 안 한다
+    # (app/repositories/story.py list_backlog() docstring — #2489/board 분기와 갈라진 지점).
+    # 더 필요하면 limit을 올려 재호출하는 것이 유일한 다음 페이지 수단.
 
 
 class AddStoryInput(SprintableInput):
@@ -123,20 +149,41 @@ async def list_stories(args: ListStoriesInput) -> list[TextContent]:
             params["priority"] = args.priority.value
         if args.assignee_id:
             params["assignee_id"] = args.assignee_id
-        return ok(await client.get("/api/v2/stories", params=params))
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
+        items, headers = await client.get_with_headers("/api/v2/stories", params=params)
+        has_more, next_cursor = _has_more_from_headers(headers, items)
+        return ok_paginated(items, has_more=has_more, next_cursor=next_cursor, tool_name="sprintable_list_stories")
     except Exception as exc:
         return err(str(exc))
 
 
-async def list_backlog(args: SprintableInput) -> list[TextContent]:
+async def list_backlog(args: ListBacklogInput) -> list[TextContent]:
     """백로그 스토리 목록 (스프린트 미배정)."""
     # b5870c4c: 전용 `/stories/backlog` 라우트 부재 → `/{id}` 로 shadow 돼 422(id="backlog" 非-UUID).
     # 기존 list 엔드포인트 + `no_sprint` 필터(server-side repo.list_backlog·sprint 미배정·docstring 정합) 재사용.
     # ⚠️ no_sprint 는 project_id 와 함께여야 backlog 분기 동작(stories.py list_stories).
     try:
-        return ok(await client.get(
-            "/api/v2/stories", params={"project_id": client.require_project_id(), "no_sprint": "true"}
-        ))
+        params: dict = {"project_id": client.require_project_id(), "no_sprint": "true"}
+        if args.limit:
+            params["limit"] = args.limit
+        items, headers = await client.get_with_headers("/api/v2/stories", params=params)
+        # story #2428: 이 분기는 X-Next-Cursor를 안 싣는다(cursor 미지원 — ListBacklogInput 주석
+        # 참조) — ok_paginated의 cursor 문구는 여기서 오해를 부르므로 쓰지 않고 limit 재호출을
+        # 직접 안내한다.
+        has_more, _ = _has_more_from_headers(headers, items)
+        blocks = ok(items)
+        if has_more:
+            blocks.append(TextContent(
+                type="text",
+                text=(
+                    f"※ 더 있음 — 이 응답은 {len(items)}건까지만 포함(전량 아님). "
+                    f"이 도구는 cursor를 지원 안 함 — limit을 올려 sprintable_list_backlog를 다시 호출."
+                ),
+            ))
+        return blocks
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/tests/test_2428_list_backlog_total_count_realdb.py
+++ b/backend/tests/test_2428_list_backlog_total_count_realdb.py
@@ -1,0 +1,140 @@
+"""story #2428 — 실 PG. list_backlog 분기(no_sprint+project_id)가 이제 (stories, total)을
+반환해 X-Total-Count에 실 COUNT(limit 適用 前)를 싣는다. 예전엔 이 분기가 total 자체를
+안 내(list_backlog()가 list만 반환) MCP sprintable_list_backlog가 「더 있는지」를 알 방법이
+없었다 — 카디르가 200건 요청 大비 1000건(자연 상한)까지 조용히 다 실어 320만자 응답을 낸
+것도 이 갭의 다른 얼굴. limit truncation이 있어도 X-Total-Count가 len(items)로 위조되지
+않고 진짜 전체 건수를 유지하는지가 이 테스트의 본체(test_2233의 goals 대응 테스트와 동형)."""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _auth(agent_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(agent_id), email=None, claims={"app_metadata": {}})
+
+
+async def _seed(session, n: int = 3):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted"))
+    await session.commit()
+
+    story_ids = []
+    for i in range(n):
+        s = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title=f"S{i}", status="backlog", story_number=i + 1)
+        session.add(s)
+        story_ids.append(s.id)
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id, "story_ids": story_ids}
+
+
+async def _call_list_stories(session, org_id, agent_id, response, **kwargs):
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import list_stories
+
+    repo = StoryRepository(session, org_id)
+    params = dict(
+        project_id=None, epic_id=None, sprint_id=None, assignee_id=None,
+        status_filter=None, no_sprint=False, ids=None, story_number=None, q=None, limit=1000,
+        cursor=None, response=response,
+    )
+    params.update(kwargs)
+    return await list_stories(repo=repo, auth=_auth(agent_id), **params)
+
+
+async def test_x_total_count_is_real_total_not_page_length_when_truncated():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=3)
+        async with Session() as s:
+            response = MagicMock()
+            response.headers = {}
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"], response,
+                project_id=seeded["project_id"], no_sprint=True, limit=1,
+            )
+            assert len(result) == 1, "limit=1이니 페이지는 1건이어야"
+            assert response.headers["X-Total-Count"] == "3", (
+                f"limit truncation이 있어도 진짜 전체(3)를 실어야: {response.headers}"
+            )
+    finally:
+        await engine.dispose()
+
+
+async def test_x_total_count_matches_page_when_not_truncated():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=2)
+        async with Session() as s:
+            response = MagicMock()
+            response.headers = {}
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"], response,
+                project_id=seeded["project_id"], no_sprint=True, limit=1000,
+            )
+            assert len(result) == 2
+            assert response.headers["X-Total-Count"] == "2"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2428_mcp_stories_header_pagination.py
+++ b/backend/tests/test_2428_mcp_stories_header_pagination.py
@@ -1,0 +1,148 @@
+"""story #2428: stories.py 계열(list_stories/list_backlog) + analytics.py search_stories는
+docs.py의 body-{data,meta} 규약과 wire shape가 다르다(X-Total-Count/X-Next-Cursor **헤더**).
+BE가 X-Next-Cursor를 결과가 있으면 무조건 싣기 때문에(app/routers/stories.py list_stories —
+실제 다음 페이지 유무와 무관) 헤더의 존재 자체가 has_more 신호가 아님을 여기서 고정한다:
+_has_more_from_headers는 X-Total-Count > len(items) 로만 판단해야 한다(test_mcp_docs_2191_shape.py와
+동형 — has_more=False면 안내 블록 없음, True면 2번째 텍스트 블록으로 안내).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _headers(total: int, next_cursor: str | None = None) -> dict:
+    h = {"x-total-count": str(total)}
+    if next_cursor is not None:
+        h["x-next-cursor"] = next_cursor
+    return h
+
+
+@pytest.mark.anyio
+async def test_list_stories_no_has_more_when_total_equals_page():
+    from sprintable_mcp.tools.stories import ListStoriesInput, list_stories
+
+    items = [{"id": "s1"}, {"id": "s2"}]
+    with patch("sprintable_mcp.tools.stories.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.org_id = None
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=2, next_cursor="2026-01-01T00:00:00")))
+        out = await list_stories(ListStoriesInput())
+
+    parsed = json.loads(out[0].text)
+    assert parsed == items
+    assert len(out) == 1  # X-Next-Cursor가 존재해도 total<=len(items)면 안내 없음
+
+
+@pytest.mark.anyio
+async def test_list_stories_signals_has_more_when_total_exceeds_page():
+    from sprintable_mcp.tools.stories import ListStoriesInput, list_stories
+
+    items = [{"id": "s1"}]
+    with patch("sprintable_mcp.tools.stories.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.org_id = None
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=5, next_cursor="2026-01-01T00:00:00")))
+        out = await list_stories(ListStoriesInput())
+
+    assert len(out) == 2
+    assert "2026-01-01T00:00:00" in out[1].text
+    assert "더 있음" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_list_stories_passes_limit_and_cursor_through():
+    from sprintable_mcp.tools.stories import ListStoriesInput, list_stories
+
+    with patch("sprintable_mcp.tools.stories.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.org_id = None
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await list_stories(ListStoriesInput(limit=50, cursor="0:abc"))
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["limit"] == 50
+    assert kwargs["params"]["cursor"] == "0:abc"
+
+
+@pytest.mark.anyio
+async def test_list_backlog_no_has_more_when_total_equals_page():
+    from sprintable_mcp.tools.stories import ListBacklogInput, list_backlog
+
+    items = [{"id": "s1"}]
+    with patch("sprintable_mcp.tools.stories.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=1)))
+        out = await list_backlog(ListBacklogInput())
+
+    parsed = json.loads(out[0].text)
+    assert parsed == items
+    assert len(out) == 1
+
+
+@pytest.mark.anyio
+async def test_list_backlog_signals_has_more_without_cursor_language():
+    """이 분기는 cursor 미지원 — 안내는 next_cursor가 아니라 limit 재호출을 가리켜야 한다."""
+    from sprintable_mcp.tools.stories import ListBacklogInput, list_backlog
+
+    items = [{"id": "s1"}]
+    with patch("sprintable_mcp.tools.stories.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        # BE가 이 분기에선 X-Next-Cursor를 아예 안 싣는다(라우터: 이 branch는 total만 세팅).
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=10)))
+        out = await list_backlog(ListBacklogInput())
+
+    assert len(out) == 2
+    assert "x-next-cursor" not in out[1].text.lower()  # 실제 cursor 값 힌트는 없음(cursor 미지원 언급만)
+    assert "limit" in out[1].text
+    assert "더 있음" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_list_backlog_passes_limit_through_no_cursor_field():
+    from sprintable_mcp.tools.stories import ListBacklogInput, list_backlog
+
+    with patch("sprintable_mcp.tools.stories.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await list_backlog(ListBacklogInput(limit=25))
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["limit"] == 25
+    assert "cursor" not in kwargs["params"]
+
+
+@pytest.mark.anyio
+async def test_search_stories_signals_has_more_via_headers():
+    from sprintable_mcp.tools.analytics import SearchStoriesInput, search_stories
+
+    items = [{"id": "s1"}]
+    with patch("sprintable_mcp.tools.analytics.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=3, next_cursor="0:xyz")))
+        out = await search_stories(SearchStoriesInput(query="hello"))
+
+    parsed = json.loads(out[0].text)
+    assert parsed == items
+    assert len(out) == 2
+    assert "0:xyz" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_search_stories_no_has_more_when_covered():
+    from sprintable_mcp.tools.analytics import SearchStoriesInput, search_stories
+
+    items = [{"id": "s1"}, {"id": "s2"}]
+    with patch("sprintable_mcp.tools.analytics.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=2)))
+        out = await search_stories(SearchStoriesInput(query="hello"))
+
+    assert len(out) == 1

--- a/backend/tests/test_2619_title_search_tokenized_and_match.py
+++ b/backend/tests/test_2619_title_search_tokenized_and_match.py
@@ -196,7 +196,7 @@ async def test_list_backlog_uses_same_tokenized_and_match():
             seeded = await _seed(s)
         async with Session() as s:
             repo = StoryRepository(s, seeded["org_id"])
-            stories = await repo.list_backlog(
+            stories, _total = await repo.list_backlog(
                 project_id=seeded["project_id"], q="무인간 대화 체인 게이트",
             )
             assert {st.id for st in stories} == {seeded["story_chain_gate"]}

--- a/backend/tests/test_2645_story_number_search_or_match.py
+++ b/backend/tests/test_2645_story_number_search_or_match.py
@@ -295,7 +295,7 @@ async def test_list_backlog_number_search_matches():
         async with Session() as s:
             repo = StoryRepository(s, seeded["org_id"])
             n = seeded["story_by_number_only_number"]
-            stories = await repo.list_backlog(project_id=seeded["project_id"], q=str(n))
+            stories, _total = await repo.list_backlog(project_id=seeded["project_id"], q=str(n))
             assert {st.id for st in stories} == {seeded["story_by_number_only"]}
     finally:
         await engine.dispose()

--- a/backend/tests/test_e_mcp_opt_ff6cb90d_require_project_id_enforcement.py
+++ b/backend/tests/test_e_mcp_opt_ff6cb90d_require_project_id_enforcement.py
@@ -94,7 +94,7 @@ async def test_tool_call_succeeds_when_unambiguous():
     from sprintable_mcp.tools.stories import ListStoriesInput, list_stories
 
     client._project_id = "proj-a"
-    with patch.object(client, "get", new=AsyncMock(return_value=[{"id": "s1"}])):
+    with patch.object(client, "get_with_headers", new=AsyncMock(return_value=([{"id": "s1"}], {"x-total-count": "1"}))):
         try:
             result = await list_stories(ListStoriesInput())
         finally:

--- a/backend/tests/test_mcp_list_backlog_b5870c4c.py
+++ b/backend/tests/test_mcp_list_backlog_b5870c4c.py
@@ -20,13 +20,13 @@ async def test_list_backlog_targets_existing_endpoint_with_no_sprint(monkeypatch
         def require_project_id(self):  # E-MCP-OPT ff6cb90d: 툴이 이제 이 메서드를 씀.
             return self.project_id
 
-        async def get(self, path, params=None):
+        async def get_with_headers(self, path, params=None):
             captured["path"] = path
             captured["params"] = params or {}
-            return []
+            return [], {"x-total-count": "0"}
 
     monkeypatch.setattr(st, "client", _FakeClient())
-    await st.list_backlog(None)
+    await st.list_backlog(st.ListBacklogInput())
 
     # 부재 라우트(/stories/backlog) 호출 금지 — /{id} shadow→422 의 근본.
     assert captured["path"] == "/api/v2/stories", captured


### PR DESCRIPTION
## 무엇을 왜

`sprintable_search_stories`/`sprintable_list_stories`를 에이전트가 부르면 응답이 최대
1.1MB까지 조용히 커져 컨텍스트를 통째로 태우는데(카디르가 실측 재현), 호출부에는 이를
막을 `limit` 인자 자체가 없었다(`#2412`가 「모르는 인자 거부」를 배포한 지 5분 만에
PO 자신의 `search_stories(..., limit=5)` 습관을 잡으며 드러남).

story #2428 AC 대상 21개 도구 중 페드루가 우선순위로 지정한 「시간에 따라 누적되는」 5개
(`list_backlog`·`list_stories`·`search_stories`·`poll_events`·`get_overdue_tasks`) 중,
같은 백엔드(`GET /api/v2/stories`)를 공유하는 3개 — `list_stories`·`list_backlog`·
`search_stories` — 를 이 PR로 먼저 배선한다.

## 이번 PR에서 한 일

- `ListStoriesInput`/`ListBacklogInput`/`SearchStoriesInput`에 `limit`(공통)·`cursor`
  (list_stories/search_stories만 — list_backlog 분기는 BE가 cursor 자체를 지원 안 함,
  아래 참조) 추가. 이름은 기존 관례 그대로 재사용(docs.py `cursor`, hypotheses/
  notifications/audit/chat `limit`) — 새 이름 안 만듦.
- `has_more` 판정: BE(`app/routers/stories.py list_stories`)가 `X-Next-Cursor` 헤더를
  결과가 있으면 무조건 싣는다(실제 다음 페이지 유무와 무관, `if items:`만 조건) — 그래서
  헤더 **존재**는 신호가 아니고 `X-Total-Count > len(items)`로만 판정해야 한다.
  `_has_more_from_headers()`로 고정, mutation-kill 검증(「존재하면 has_more」로 되돌려
  테스트가 RED 되는 것 확인 후 원복).
- `api_client.py`에 `get_with_headers()` 추가(응답 헤더까지 반환) + `response.py`에
  `ok_paginated()` 추가(docs.py/notifications.py가 각자 복제해 두던 「더 있음 안내」
  패턴을 공용화).
- `list_backlog`(`no_sprint` 분기)는 repo 메서드가 애초에 total 자체를 안 냈다(카디르가
  재현한 320만자 사고의 다른 얼굴 — 자연 상한 1000건까지 조용히 다 실었다). 
  `StoryRepository.list_backlog()`를 `list[Story]` → `(list[Story], int)`로 바꾸고
  라우터가 `X-Total-Count`를 싣게 했다. 이 분기는 cursor를 지원 안 해(기존 docstring
  결정, `#2190` 스코프 밖으로 확인된 자리) 안내 문구도 cursor 값이 아니라 「limit을
  올려 재호출」을 가리킨다.
- 기본값(AC3): 두지 않음 — `limit` 미지정 시 서버 기본(1000)을 그대로 쓴다. 기존 호출
  결과가 갑자기 줄어드는 회귀를 피하기 위해서고, 대신 `has_more` 신호가 있으니 「범위가
  없는데 있다고 믿는」 `#2412`류 병은 재현되지 않는다.
- 공유 primitive(`StoryRepository.list_backlog()`) 반환형 변경 — CI 반응형 fix-repush
  대신 직접 호출부 전수 grep(4곳: 라우터 1 + 테스트 3 — `test_2619_title_search_tokenized_and_match.py`
  / `test_2645_story_number_search_or_match.py` / `test_mcp_list_backlog_b5870c4c.py`)해
  전부 튜플 언패킹으로 사전 갱신.

## 미룬 것 (story #2428 설명에도 전문 기재)

- **`poll_events`·`get_overdue_tasks`** — 백엔드 자체가 페이지네이션 미지원
  (`/api/v2/events/pending`·`/api/v2/tasks` 둘 다 limit/count 파라미터 없음,
  `TaskRepository`에 페이지 메서드 부재). MCP 스키마만 고쳐서 될 일이 아니라 BE 작업이
  별도로 필요 — story AC6이 「특히 보라」고 지목한 그 둘이 정확히 「MCP 배선만으론 안 되는」
  둘이었다. 후속 스토리 대상.
- **나머지 16개** — `list_tasks`·`list_my_tasks`·`list_goals`·`list_epics`·`list_sprints`·
  `search_docs`·`get_blocked_stories`·`get_unassigned_stories`·`list_team_members`·
  `list_projects`·`list_artifacts`·`list_artifact_comments`·`list_spec_pins`·
  `list_standup_entries`·`list_retro_sessions`·`list_webhook_configs` — 스코프 밖
  (페드루 지시), 후속 PR 대상.
- AC1의 「기존에 제한이 있는 5개」 전체 확정과 AC7(26개 선정 근거)은 이 PR 스코프 밖 —
  이 3개가 기존 `limit`/`cursor` 이름을 재사용했다는 사실로 이름 축 회귀는 없음만 확인.

## 테스트

- [x] `tests/test_2428_mcp_stories_header_pagination.py` — mock 기반 8건(list_stories/
  list_backlog/search_stories의 has_more 판정·limit/cursor 통과·backlog는 cursor 문구
  없이 limit 안내). mutation-kill: `_has_more_from_headers`를 「cursor 존재=has_more」로
  되돌려 2건 RED 확인 후 원복.
- [x] `tests/test_2428_list_backlog_total_count_realdb.py` — 실 PG 2건(limit truncation 시
  X-Total-Count가 진짜 전체를 유지). mutation-kill: 헤더를 `len(stories)`로 위조해 RED
  확인 후 원복.
- [x] 기존 회귀 스윕(로컬 disposable PG, `test_2188_*`·`test_2189_*`·`test_2619_*`·
  `test_2645_*`·`test_mcp_list_backlog_b5870c4c.py`·`test_e_mcp_opt_ff6cb90d_*`·
  `test_stories.py` 등 160건) — 전부 통과(무관한 사전 실패 1건은 baseline에서도 재현
  확인 — team_members VIEW가 필요한 realdb 테스트가 create_all 기반 임시 스키마에서
  구조적으로 못 도는 환경 아티팩트, 이 PR과 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)