### PR TITLE
[BE·결재] merge gate 승인요청 카드를 approver 1:1 DM에 배달 (story #2118 E-DG-REAL ②)

### DIFF
--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -96,21 +96,34 @@ async def dispatch_approval_request_cards(
     db: AsyncSession,
     *,
     org_id: uuid.UUID,
-    doc: Doc,
+    work_item_type: str,
+    work_item_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    title: str,
     gate_id: uuid.UUID,
     requester_id: uuid.UUID,
     approver_ids: list[uuid.UUID],
 ) -> None:
     """승인자별 DM에 message_kind="request" 카드 메시지 게시 + SSE 이벤트(AC1/AC2).
 
-    승인자별 SAVEPOINT 격리 — 한 승인자 배달 실패(예: DM insert 레이스)가 나머지 승인자
-    배달이나, 이 함수를 부르는 doc 상신 트랜잭션(gate 생성·doc.status='pending') 자체를
-    poison 하지 않는다([[feedback_savepoint_failopen_session_poison]] — bare flush 실패
-    후 세션 오염이 후속 write를 통째로 삼키는 클래스).
+    story #2118(E-DG-REAL ②, 2026-08-16) 이전엔 ``doc: Doc``을 직접 받는 doc 전용 함수였다 —
+    호출부(merge_verdict_gate.py 등 다른 gate_type)가 doc 객체를 갖고 있지 않아 그대로 확장할
+    수 없었다. work_item_type/work_item_id/project_id/title로 일반화(함수 로직 자체는 무변경 —
+    doc 전용 필드 참조 4곳을 파라미터로 치환한 것뿐). FE(approval-request-card.tsx, #3149)는
+    이미 work_item_type 제네릭으로 렌더하고, 카드 title 자체는 GET /api/gates/{id}의
+    work_item_summary(gates.py _resolve_work_item_summary — doc/story/task 지원)에서 오므로
+    이 함수의 ``title``은 메시지 본문(chat bubble text)에만 쓰인다(카드 렌더 값 아님).
 
-    project_id 없는 doc(비정상 상태)은 배달 스킵(무대상, 조용히 반환).
+    승인자별 SAVEPOINT 격리 — 한 승인자 배달 실패(예: DM insert 레이스)가 나머지 승인자
+    배달이나, 이 함수를 부르는 caller의 게이트 생성 트랜잭션 자체를 poison 하지 않는다
+    ([[feedback_savepoint_failopen_session_poison]] — bare flush 실패 후 세션 오염이 후속
+    write를 통째로 삼키는 클래스).
+
+    project_id 없는 work_item(비정상 상태 또는 project-무관 work_item_type)은 배달 스킵
+    (무대상, 조용히 반환) — project 없이는 `_get_or_create_approval_dm`의 DM project_id를
+    채울 수 없다.
     """
-    if not doc.project_id or not approver_ids:
+    if not project_id or not approver_ids:
         return
 
     from app.routers.conversations import _dispatch_conversation_event
@@ -118,7 +131,9 @@ async def dispatch_approval_request_cards(
 
     requester = (await lookup_members_by_ids({requester_id}, db)).get(requester_id)
     if requester is None:
-        logger.warning("approval-request 카드 배달 스킵 — requester 미확인 doc=%s", doc.id)
+        logger.warning(
+            "approval-request 카드 배달 스킵 — requester 미확인 %s=%s", work_item_type, work_item_id,
+        )
         return
 
     for approver_id in approver_ids:
@@ -127,14 +142,14 @@ async def dispatch_approval_request_cards(
                 conv = await _get_or_create_approval_dm(
                     db,
                     org_id=org_id,
-                    project_id=doc.project_id,
+                    project_id=project_id,
                     requester_id=requester_id,
                     approver_id=approver_id,
                 )
                 msg = ConversationMessage(
                     conversation_id=conv.id,
                     sender_id=requester_id,
-                    content=f"'{doc.title}' 문서 결재 요청",
+                    content=f"'{title}' 결재 요청",
                     mentioned_ids=[approver_id],
                     msg_metadata={
                         "activation": {
@@ -143,8 +158,8 @@ async def dispatch_approval_request_cards(
                             "expects_response": True,
                         },
                         "approval_target": {
-                            "work_item_type": "doc",
-                            "work_item_id": str(doc.id),
+                            "work_item_type": work_item_type,
+                            "work_item_id": str(work_item_id),
                             "gate_id": str(gate_id),
                             "actions": ["approve", "reject"],
                         },
@@ -155,8 +170,8 @@ async def dispatch_approval_request_cards(
                 await _dispatch_conversation_event(db, conv, msg, org_id, requester)
         except Exception:  # noqa: BLE001 — best-effort, 개별 승인자 실패가 상신을 막지 않음.
             logger.warning(
-                "approval-request 카드 배달 실패 doc=%s approver=%s",
-                doc.id, approver_id, exc_info=True,
+                "approval-request 카드 배달 실패 %s=%s approver=%s",
+                work_item_type, work_item_id, approver_id, exc_info=True,
             )
 
 

--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -72,7 +72,8 @@ async def _notify_doc_approval_requested(
     try:
         from app.services.approval_delivery import dispatch_approval_request_cards
         await dispatch_approval_request_cards(
-            session, org_id=org_id, doc=doc, gate_id=gate_id,
+            session, org_id=org_id, work_item_type=DOC_GATE_WORK_ITEM_TYPE, work_item_id=doc.id,
+            project_id=doc.project_id, title=doc.title, gate_id=gate_id,
             requester_id=requester_id, approver_ids=approver_ids,
         )
     except Exception:  # noqa: BLE001 — 카드 배달 실패는 상신 비중단(Gate inbox 폴백 항상 존재).

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -376,6 +376,18 @@ async def evaluate_merge_gate(
     # story #1968: 이 함수는 story_id(uuid)만 갖고 Story 객체를 로드하지 않으므로(participation/
     # verdict/trust 경로 전부 story_id만 소비) resolve_work_item_project_id()로 신규 조회.
     project_id = await resolve_work_item_project_id(session, org_id, "story", story_id)
+    # story #2118(E-DG-REAL ②): create_gate()가 이미 pending인 기존 gate를 멱등 반환할 때(예:
+    # report-done/board-preflight가 이 함수를 반복 호출)마다 승인요청 카드를 중복 배달하지 않으려면
+    # "이 호출에서 방금 pending이 됐는지"(신규 생성 또는 rejected/voided→재오픈)를 알아야 한다 —
+    # create_gate()는 그 신호를 반환하지 않으므로(반환형 변경은 8개 호출부 전체에 영향, 스코프 밖)
+    # 호출 *전* 상태를 가볍게 먼저 조회해 비교한다(create_gate 내부의 멱등 조회와 동형 SELECT,
+    # 신규 인덱스 불필요 — uq(work_item_id, work_item_type, gate_type) 이미 있음).
+    _prior_status = (await session.execute(
+        select(Gate.status).where(
+            Gate.org_id == org_id, Gate.work_item_id == story_id,
+            Gate.work_item_type == "story", Gate.gate_type == MERGE_GATE_TYPE,
+        )
+    )).scalar_one_or_none()
     gate = await create_gate(
         session,
         org_id,
@@ -416,6 +428,34 @@ async def evaluate_merge_gate(
             "merge gate re-opened on resubmit story=%s gate=%s prior=%s",
             story_id, gate.id, prior["status"],
         )
+
+    # story #2118(E-DG-REAL ②) — doc.py의 dispatch_approval_request_cards(#2604) 패턴을 merge
+    # gate까지 확장: 이 호출에서 gate가 «방금» pending이 된 경우만(_prior_status와 비교, 위 주석
+    # 참조) 승인자별 1:1 DM에 카드를 배달한다. 승인 자격자 = project owner/admin(project_id
+    # 해소 실패 시 org owner/admin — project_auth.list_gate_approver_ids, gates.py
+    # _non_doc_gate_approvable과 동일 규칙). 카드 배달 자체는 best-effort(project_auth 조회
+    # 실패가 게이트 생성/decision을 막지 않음) — doc.py와 동일 관례.
+    if gate.status == "pending" and _prior_status != "pending":
+        try:
+            from app.models.pm import Story
+            from app.services.approval_delivery import dispatch_approval_request_cards
+            from app.services.project_auth import list_gate_approver_ids
+
+            story_title = (await session.execute(
+                select(Story.title).where(Story.id == story_id, Story.org_id == org_id)
+            )).scalar_one_or_none() or f"#{str(story_id)[:8]}"
+            approver_ids = await list_gate_approver_ids(
+                session, org_id, project_id, exclude_id=member_id,
+            )
+            await dispatch_approval_request_cards(
+                session, org_id=org_id, work_item_type="story", work_item_id=story_id,
+                project_id=project_id, title=story_title, gate_id=gate.id,
+                requester_id=member_id, approver_ids=approver_ids,
+            )
+        except Exception:  # noqa: BLE001 — 카드 배달 실패는 게이트 생성/decision을 막지 않음.
+            logger.warning(
+                "merge gate 승인요청 카드 배달 실패 story=%s gate=%s", story_id, gate.id, exc_info=True,
+            )
 
     # 4. 정책 + 증거(CI/PR) + outcome trust 합성 decision.
     decision, reason = _decide(

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -454,6 +454,72 @@ async def is_org_owner_or_admin(
     return row.scalar_one_or_none() is not None
 
 
+async def list_gate_approver_ids(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    *,
+    exclude_id: uuid.UUID | None = None,
+) -> list[uuid.UUID]:
+    """story #2118(E-DG-REAL ②) — 비-doc gate_type(merge/pr_review/qa/deploy 등)의 승인 자격자
+    전원 나열. gates.py `_non_doc_gate_approvable`(단건 판정: project owner/admin effective role
+    ∪ org owner/admin floor, project_id 없으면 org owner/admin만)와 **같은 규칙**을 listing
+    방향으로 뒤집은 것 — 새 규칙 발명 아님(재구현 금지 원칙, SSOT는 여전히 `get_project_role`/
+    `_non_doc_gate_approvable`이고 이 함수는 그 판정을 만족하는 human 전원을 나열할 뿐).
+
+    반환값은 `org_members.id`(doc.py `_notify_doc_approval_requested`의 approver_ids와 동일
+    id 공간 — `dispatch_notification`/`_get_or_create_approval_dm`/approval_delivery.py가 이미
+    그 공간을 소비하므로 재사용, 새 타입 발명 없음). human 전용(`is_org_owner_or_admin`과 동일
+    NOT EXISTS agent-배제 가드).
+
+    artifact_canonicalize(role 제약 없음 — gates.py `_non_doc_can_approve` 주석 참조)는 이
+    헬퍼 대상이 아니다 — 그 gate_type은 «누구나 승인 가능」이라 카드 배달 대상이 「project
+    구성원 전체」가 되어버려 이 헬퍼의 owner/admin 좁히기와 의미가 다르다(스코프 밖, 별도 판단 필요)."""
+    if project_id is not None:
+        rows = await session.execute(
+            text(
+                """
+                SELECT DISTINCT om.id
+                FROM org_members om
+                JOIN projects p ON p.org_id = om.org_id
+                WHERE p.id = :pid AND om.deleted_at IS NULL
+                  AND NOT EXISTS (
+                    SELECT 1 FROM members m
+                    WHERE m.user_id = om.user_id AND m.org_id = om.org_id AND m.type = 'agent'
+                  )
+                  AND (
+                    om.role IN ('owner', 'admin')
+                    OR EXISTS (
+                      SELECT 1 FROM project_access pa
+                      WHERE pa.project_id = :pid AND pa.permission = 'granted'
+                        AND pa.org_member_id = om.id AND pa.role IN ('owner', 'admin')
+                    )
+                  )
+                """
+            ),
+            {"pid": project_id},
+        )
+    else:
+        rows = await session.execute(
+            text(
+                """
+                SELECT om.id FROM org_members om
+                WHERE om.org_id = :org_id AND om.deleted_at IS NULL
+                  AND om.role IN ('owner', 'admin')
+                  AND NOT EXISTS (
+                    SELECT 1 FROM members m
+                    WHERE m.user_id = om.user_id AND m.org_id = om.org_id AND m.type = 'agent'
+                  )
+                """
+            ),
+            {"org_id": org_id},
+        )
+    ids = [r[0] for r in rows.all()]
+    if exclude_id is not None:
+        ids = [i for i in ids if i != exclude_id]
+    return ids
+
+
 async def is_org_owner(
     session: AsyncSession,
     user_id: uuid.UUID,

--- a/backend/tests/test_2118_merge_gate_approval_cards_realdb.py
+++ b/backend/tests/test_2118_merge_gate_approval_cards_realdb.py
@@ -145,6 +145,75 @@ async def test_list_gate_approver_ids_project_none_falls_back_to_org_owner_admin
         await engine.dispose()
 
 
+async def _seed_org_member_with_uid(session, org_id, *, role="member"):
+    """parity 테스트 전용 — user_id를 함께 반환한다(_non_doc_gate_approvable은 org_members.id가
+    아니라 .user_id를 받는 단건 판정 함수라 listing 결과(.id)와 다른 id 공간)."""
+    from app.models.project import OrgMember
+
+    user_id = uuid.uuid4()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role=role)
+    session.add(om)
+    await session.commit()
+    return om.id, user_id
+
+
+@pytest.mark.anyio
+async def test_list_gate_approver_ids_parity_with_single_item_judge():
+    """페드루 PO AC 리뷰(2026-08-16) — list_gate_approver_ids(listing)가 gates.py
+    _non_doc_gate_approvable(단건 판정)과 «같은 규칙»이라는 주장은 docstring뿐이었다(규칙이
+    한쪽만 바뀌면 조용히 어긋나는 자리 — 「막는 쪽과 하는 쪽이 다른 걸 본다」 클래스, #2198과
+    동형). 시드된 멤버 전원에 대해 두 방향(listing 포함 여부 == 단건 판정 결과)을 단언해
+    어느 쪽이 바뀌어도 이 테스트가 빨개지게 고정한다."""
+    from app.routers.gates import _non_doc_gate_approvable
+    from app.services.project_auth import list_gate_approver_ids
+
+    engine, Session = await _engine_and_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            _other_org_id, other_project_id = None, None
+            from app.models.project import Project
+            other_project = Project(id=uuid.uuid4(), org_id=org_id, name="P2")
+            s.add(other_project)
+            await s.commit()
+            other_project_id = other_project.id
+
+            members = {}
+            members["project_owner"], uid_project_owner = await _seed_org_member_with_uid(s, org_id, role="member")
+            await _seed_project_access(s, project_id, members["project_owner"], role="owner")
+
+            members["project_admin"], uid_project_admin = await _seed_org_member_with_uid(s, org_id, role="member")
+            await _seed_project_access(s, project_id, members["project_admin"], role="admin")
+
+            members["project_plain_member"], uid_project_plain = await _seed_org_member_with_uid(s, org_id, role="member")
+            await _seed_project_access(s, project_id, members["project_plain_member"], role="member")
+
+            members["org_owner_floor"], uid_org_owner = await _seed_org_member_with_uid(s, org_id, role="owner")
+            members["org_admin_floor"], uid_org_admin = await _seed_org_member_with_uid(s, org_id, role="admin")
+            members["no_access"], uid_no_access = await _seed_org_member_with_uid(s, org_id, role="member")
+
+            members["other_project_owner"], uid_other_project_owner = await _seed_org_member_with_uid(s, org_id, role="member")
+            await _seed_project_access(s, other_project_id, members["other_project_owner"], role="owner")
+
+            uids = {
+                "project_owner": uid_project_owner, "project_admin": uid_project_admin,
+                "project_plain_member": uid_project_plain, "org_owner_floor": uid_org_owner,
+                "org_admin_floor": uid_org_admin, "no_access": uid_no_access,
+                "other_project_owner": uid_other_project_owner,
+            }
+
+        async with Session() as s:
+            listing = set(await list_gate_approver_ids(s, org_id, project_id))
+            for label, member_id in members.items():
+                judged = await _non_doc_gate_approvable(s, uids[label], org_id, project_id)
+                in_listing = member_id in listing
+                assert judged == in_listing, (
+                    f"{label}: 단건 판정={judged} vs listing 포함={in_listing} — 두 함수가 갈렸다"
+                )
+    finally:
+        await engine.dispose()
+
+
 async def _seed_story_with_participation(session, *, org, project, story_id, member, role_id):
     from app.models.participation import Participation, ParticipationRole
     from app.models.pm import Story

--- a/backend/tests/test_2118_merge_gate_approval_cards_realdb.py
+++ b/backend/tests/test_2118_merge_gate_approval_cards_realdb.py
@@ -1,0 +1,258 @@
+"""story #2118(E-DG-REAL) ②BE 훅 — 실 PG.
+
+doc.py 전용이던 dispatch_approval_request_cards(#2604)를 merge gate까지 확장한 것을 검증한다.
+축 두 개:
+1. project_auth.list_gate_approver_ids — gates.py `_non_doc_gate_approvable`(단건 판정)과
+   같은 규칙(project owner/admin ∪ org owner/admin floor, project_id 없으면 org owner/admin만)의
+   listing 방향 뒤집기.
+2. merge_verdict_gate.evaluate_merge_gate — gate가 이 호출에서 «방금» pending이 된 경우만
+   승인자 DM에 카드를 배달(반복 호출 시 중복 배달 없음, _prior_status 가드).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    return _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+
+
+async def _engine_and_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2118", slug=f"org2118-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_org_member(session, org_id, project_id=None, *, role="member"):
+    """OrgMember(역할판정용) + 같은 id의 TeamMember(대화 FK용 — 실 마이그된 스키마의
+    team_members VIEW를 create_all이 real table로 만드는 이 테스트 한정 필요, doc.py/
+    approval_delivery.py 소비 코드가 conversations.created_by/conversation_participants.
+    member_id를 이 id 공간으로 기대하는 것과 동형 — test_2604의 _seed_human과 같은 이유)."""
+    from app.models.project import OrgMember
+    from app.models.team import TeamMember
+
+    member_id = uuid.uuid4()
+    om = OrgMember(id=member_id, org_id=org_id, user_id=uuid.uuid4(), role=role)
+    session.add(om)
+    if project_id is not None:
+        session.add(TeamMember(
+            id=member_id, org_id=org_id, project_id=project_id, type="human",
+            name="approver", is_active=True,
+        ))
+    await session.commit()
+    return om.id
+
+
+async def _seed_project_access(session, project_id, org_member_id, *, role="owner"):
+    from app.models.project_access import ProjectAccess
+
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, org_member_id=org_member_id,
+        role=role, permission="granted",
+    ))
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_list_gate_approver_ids_project_scoped_owner_admin_union():
+    from app.services.project_auth import list_gate_approver_ids
+
+    engine, Session = await _engine_and_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            project_owner = await _seed_org_member(s, org_id, role="member")  # org role=member
+            await _seed_project_access(s, project_id, project_owner, role="owner")  # project owner
+            org_admin = await _seed_org_member(s, org_id, role="admin")  # org-wide admin floor, no explicit grant
+            plain_member = await _seed_org_member(s, org_id, role="member")  # neither → excluded
+
+        async with Session() as s:
+            approver_ids = set(await list_gate_approver_ids(s, org_id, project_id))
+            assert approver_ids == {project_owner, org_admin}
+            assert plain_member not in approver_ids
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_gate_approver_ids_excludes_given_id():
+    from app.services.project_auth import list_gate_approver_ids
+
+    engine, Session = await _engine_and_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester = await _seed_org_member(s, org_id, role="owner")
+
+        async with Session() as s:
+            approver_ids = await list_gate_approver_ids(s, org_id, project_id, exclude_id=requester)
+            assert requester not in approver_ids
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_gate_approver_ids_project_none_falls_back_to_org_owner_admin():
+    from app.services.project_auth import list_gate_approver_ids
+
+    engine, Session = await _engine_and_session()
+    try:
+        async with Session() as s:
+            org_id, _project_id = await _seed_org_project(s)
+            org_owner = await _seed_org_member(s, org_id, role="owner")
+            plain_member = await _seed_org_member(s, org_id, role="member")
+
+        async with Session() as s:
+            approver_ids = set(await list_gate_approver_ids(s, org_id, None))
+            assert org_owner in approver_ids
+            assert plain_member not in approver_ids
+    finally:
+        await engine.dispose()
+
+
+async def _seed_story_with_participation(session, *, org, project, story_id, member, role_id):
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+
+    session.add_all([
+        ParticipationRole(id=role_id, org_id=org, key="implementation", label="구현", is_default=True),
+        Story(id=story_id, org_id=org, project_id=project, title="#2118 머지 게이트 카드", status="in-review", story_points=3),
+    ])
+    await session.commit()
+    session.add(Participation(id=uuid.uuid4(), org_id=org, story_id=story_id, member_id=member, role_id=role_id))
+    await session.commit()
+
+
+async def _seed_implementer_member(session, org_id, project_id):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent",
+        name="디디", is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_dispatches_approval_card_on_first_pending():
+    from sqlalchemy import select
+    from app.models.conversation import Conversation, ConversationMessage
+    from app.models.hitl_config import OrgGatePolicy
+    from app.services.merge_verdict_gate import ASK_HUMAN, evaluate_merge_gate
+
+    engine, Session = await _engine_and_session()
+    org_id, project_id, story_id = None, None, uuid.uuid4()
+    role_id = uuid.uuid4()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            implementer_id = await _seed_implementer_member(s, org_id, project_id)
+            approver_id = await _seed_org_member(s, org_id, project_id, role="owner")
+            await _seed_story_with_participation(
+                s, org=org_id, project=project_id, story_id=story_id,
+                member=implementer_id, role_id=role_id,
+            )
+            s.add(OrgGatePolicy(org_id=org_id, posture="conservative"))
+            await s.commit()
+
+        async with Session() as s:
+            decision = await evaluate_merge_gate(
+                s, org_id, story_id, pr_number=0, repo="", ci_result=None, pr_result=None,
+            )
+            await s.commit()
+
+        assert decision.decision == ASK_HUMAN
+        assert decision.gate_id is not None
+
+        async with Session() as s:
+            convs = (await s.execute(select(Conversation).where(Conversation.org_id == org_id))).scalars().all()
+            assert len(convs) == 1, "승인자 1명 → DM 1개"
+            msgs = (await s.execute(select(ConversationMessage))).scalars().all()
+            assert len(msgs) == 1
+            target = msgs[0].msg_metadata["approval_target"]
+            assert target["work_item_type"] == "story"
+            assert target["work_item_id"] == str(story_id)
+            assert target["gate_id"] == str(decision.gate_id)
+            assert target["actions"] == ["approve", "reject"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_no_duplicate_card_on_repeat_pending_call():
+    """mutation-kill 대상 — _prior_status 가드가 없으면 이 테스트가 RED(메시지 2건)로 잡는다."""
+    from sqlalchemy import select
+    from app.models.conversation import ConversationMessage
+    from app.models.hitl_config import OrgGatePolicy
+    from app.services.merge_verdict_gate import evaluate_merge_gate
+
+    engine, Session = await _engine_and_session()
+    story_id = uuid.uuid4()
+    role_id = uuid.uuid4()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            implementer_id = await _seed_implementer_member(s, org_id, project_id)
+            await _seed_org_member(s, org_id, project_id, role="owner")
+            await _seed_story_with_participation(
+                s, org=org_id, project=project_id, story_id=story_id,
+                member=implementer_id, role_id=role_id,
+            )
+            s.add(OrgGatePolicy(org_id=org_id, posture="conservative"))
+            await s.commit()
+
+        async with Session() as s:
+            await evaluate_merge_gate(
+                s, org_id, story_id, pr_number=0, repo="", ci_result=None, pr_result=None,
+            )
+            await s.commit()
+
+        # 두 번째 호출 — 게이트는 이미 pending(아직 해소 안 됨). 새 카드가 또 나가면 안 된다.
+        async with Session() as s:
+            await evaluate_merge_gate(
+                s, org_id, story_id, pr_number=0, repo="", ci_result=None, pr_result=None,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            msgs = (await s.execute(select(ConversationMessage))).scalars().all()
+            assert len(msgs) == 1, f"반복 호출로 카드가 중복 배달됨: {len(msgs)}건"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2604_approval_request_cards.py
+++ b/backend/tests/test_2604_approval_request_cards.py
@@ -92,7 +92,8 @@ async def test_dispatch_creates_dm_and_request_card_per_approver():
             gate_id = uuid.uuid4()
 
             await dispatch_approval_request_cards(
-                s, org_id=org_id, doc=doc, gate_id=gate_id,
+                s, org_id=org_id, work_item_type="doc", work_item_id=doc.id,
+                project_id=doc.project_id, title=doc.title, gate_id=gate_id,
                 requester_id=requester_id, approver_ids=[approver1, approver2],
             )
             await s.commit()
@@ -144,12 +145,14 @@ async def test_second_approval_reuses_existing_dm_not_new_room():
             doc2 = await _seed_doc(s, org_id, project_id, title="문서2")
 
             await dispatch_approval_request_cards(
-                s, org_id=org_id, doc=doc1, gate_id=uuid.uuid4(),
+                s, org_id=org_id, work_item_type="doc", work_item_id=doc1.id,
+                project_id=doc1.project_id, title=doc1.title, gate_id=uuid.uuid4(),
                 requester_id=requester_id, approver_ids=[approver_id],
             )
             await s.commit()
             await dispatch_approval_request_cards(
-                s, org_id=org_id, doc=doc2, gate_id=uuid.uuid4(),
+                s, org_id=org_id, work_item_type="doc", work_item_id=doc2.id,
+                project_id=doc2.project_id, title=doc2.title, gate_id=uuid.uuid4(),
                 requester_id=requester_id, approver_ids=[approver_id],
             )
             await s.commit()
@@ -183,7 +186,8 @@ async def test_one_approver_failure_does_not_poison_session_for_others():
             doc = await _seed_doc(s, org_id, project_id)
 
             await dispatch_approval_request_cards(
-                s, org_id=org_id, doc=doc, gate_id=uuid.uuid4(),
+                s, org_id=org_id, work_item_type="doc", work_item_id=doc.id,
+                project_id=doc.project_id, title=doc.title, gate_id=uuid.uuid4(),
                 requester_id=requester_id, approver_ids=[nonexistent_approver, good_approver],
             )
             # poison 됐다면 이 commit이나 후속 write가 즉시 실패한다.
@@ -218,7 +222,8 @@ async def test_no_approvers_no_dm_created():
             doc = await _seed_doc(s, org_id, project_id)
 
             await dispatch_approval_request_cards(
-                s, org_id=org_id, doc=doc, gate_id=uuid.uuid4(),
+                s, org_id=org_id, work_item_type="doc", work_item_id=doc.id,
+                project_id=doc.project_id, title=doc.title, gate_id=uuid.uuid4(),
                 requester_id=requester_id, approver_ids=[],
             )
             await s.commit()

--- a/backend/tests/test_2628_approval_dm_participant_set_lookup.py
+++ b/backend/tests/test_2628_approval_dm_participant_set_lookup.py
@@ -279,7 +279,8 @@ async def test_fix_applies_bidirectionally_request_and_result_reply():
             gate_id = uuid.uuid4()
 
             await dispatch_approval_request_cards(
-                s, org_id=org_id, doc=doc, gate_id=gate_id,
+                s, org_id=org_id, work_item_type="doc", work_item_id=doc.id,
+                project_id=doc.project_id, title=doc.title, gate_id=gate_id,
                 requester_id=requester_id, approver_ids=[approver_id],
             )
             await s.commit()


### PR DESCRIPTION
## 무엇을 왜

story #2118 — 결재함에 gate를 올리면 대상 conversation(요청자↔승인자 1:1 DM)에 embedded
카드로 뜨고 인라인 버튼(승인/거절)으로 바로 액션하는 게 완결된 제품이라는 선생님 비전
(2026-07-22 dogfood). ①FE(미르코, `approval-request-card.tsx` 제네릭화)는 PR #3149로
이미 in-review. 이 PR은 ②BE 훅 — doc.py 상신(#2604)만 갖고 있던 승인요청 챗 카드 배달을
merge gate까지 확장한다.

## 그라운딩

- `dispatch_approval_request_cards()`(approval_delivery.py, #2604)는 `doc: Doc`을 직접
  받는 doc 전용 함수였다 — merge_verdict_gate.py는 doc 객체가 없어 그대로 재사용 불가.
- FE 카드(`approval-request-card.tsx`)는 이미 `target.work_item_type` 제네릭으로 렌더
  하고, 카드 타이틀은 `GET /api/gates/{id}`의 `work_item_summary`(gates.py
  `_resolve_work_item_summary` — doc/story/task 지원, story #1970)에서 온다 — FE 쪽은
  merge gate(work_item_type="story") 카드를 받을 준비가 이미 돼 있었다.
- 승인 자격(비-doc gate_type): gates.py `_non_doc_gate_approvable`(project owner/admin,
  project_id 미해소 시 org owner/admin) — 이 판정을 만족하는 human 전원을 나열하는
  listing 헬퍼가 없어 신규 작성.

## 이번 PR에서 한 일

- **`approval_delivery.dispatch_approval_request_cards()` 제네릭화**: `doc: Doc` →
  `work_item_type/work_item_id/project_id/title`. 함수 로직 자체는 무변경(doc 필드
  참조 4곳을 파라미터로 치환) — doc.py 호출부도 새 시그니처로 갱신(회귀 없음, 기존
  realdb 테스트 4개 시그니처만 갱신해 그대로 통과).
- **`project_auth.list_gate_approver_ids()` 신규**: `_non_doc_gate_approvable`(단건
  판정)과 동일 규칙의 listing 방향 — project owner/admin ∪ org owner/admin floor,
  project_id 없으면 org owner/admin만. 반환값은 doc.py가 이미 쓰는 것과 같은 id 공간
  (`org_members.id` — `resolve_member()`의 휴먼 SSOT).
- **`merge_verdict_gate.evaluate_merge_gate()` 훅**: gate가 pending으로 확정된 직후,
  `list_gate_approver_ids` + `dispatch_approval_request_cards`로 카드 배달(work_item_type=
  "story", requester=구현자 participation.member_id). best-effort(카드 배달 실패가 게이트
  생성/decision을 막지 않음 — doc.py와 동일 관례).
- **중복 배달 방지**: `create_gate()`는 이미 pending인 기존 gate를 멱등 반환하므로,
  report-done/board-preflight가 같은 스토리에 반복 호출하면(예: CI 재트리거) 매번 카드가
  또 나갈 위험이 있다 — 호출 *직전* gate 상태를 가볍게 SELECT해 "이 호출에서 방금
  pending이 됐는지"(신규 생성 또는 rejected/voided→재오픈)만 배달 트리거로 삼는다.
  `create_gate()` 자체의 반환형은 무변경(8개 호출부 전체에 영향이라 스코프 밖).

## 라이브 검증 메모

report-done(stage=merge) 호출로 dev에서 실제 gate가 도는 것(`gate_decision: ask_human`)은
확인했으나, **이 PR의 코드는 아직 dev에 배포되지 않은 상태**에서 시도해 카드 배달 자체는
이번 라이브 시도로는 검증되지 않았다(당연한 결과 — 배포 전이라 옛 코드가 응답한 것).
카드가 실제로 approver의 1:1 DM에 뜨고 `POST /gates/{id}/transition`으로 해소되는지는
**병합·배포 후** dev에서 재확認이 필요 — 버튼 액션(승인/거절)은 human-only(에이전트 403,
E-DG 불변식)라 그 마지막 단계는 사람 계정으로 확인해야 한다(에이전트가 직접 클릭 검증 불가).

## 테스트

- [x] `tests/test_2118_merge_gate_approval_cards_realdb.py`(신규, 실 PG) — `list_gate_approver_ids`
  3건(project owner/admin 합집합, exclude_id, project_id=None→org 폴백) + merge gate 통합
  2건(첫 pending 전이 시 카드 배달·approval_target 계약 확인, 반복 호출 시 미중복). 반복호출
  가드는 mutation-kill 확認(가드 제거→2건 배달 RED→원복).
- [x] `tests/test_2604_approval_request_cards.py`·`test_2628_approval_dm_participant_set_lookup.py`
  — 시그니처 변경 반영, 4/1건 통과 확認(doc 경로 무회귀).
- [x] 인접 회귀 스윕(로컬 disposable PG, gate/merge-verdict/doc-approval 계열 21개 파일,
  207건) — 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)