### PR TITLE
[SID:2187] 보드/백로그 — is_excluded 카드 숨김 + 임시 QA카드 관례 문서화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,30 @@ already treats non-`SUCCESS` conclusions as blocking regardless of this tooling 
 risk here is a human/agent being told "clear to merge" by a script when the actual gate
 is still red. `skipping` is excluded — it's a conditionally-skipped job (e.g. "Main
 Alembic preflight" when its precondition doesn't apply), not a blocked one.
+
+## Live-QA temporary story cards (story #2187)
+
+Live verification sometimes needs a real story to click through/observe SSE against,
+without touching an actual product story. `DELETE /api/v2/stories/{id}` is human-only
+(agent API keys get 403) by design — an agent that creates a throwaway card **cannot
+clean it up itself**. Without a convention, these accumulate on the board forever and
+inflate "how much is left" counts (exactly the class of defect this story reports).
+
+**When creating one:**
+- Prefix the title with `[TEMP-QA]` (or an equally unambiguous marker — existing
+  examples use `[TEST-PROBE·삭제예정]` / `[삭제 대상 — ...]`, `[TEMP-QA]` is preferred
+  going forward for grep-ability).
+- Immediately mark it `is_excluded: true` (`sprintable_update_story` or the equivalent
+  API field) — do this in the same turn you create the card, not as a follow-up. The
+  board/backlog UI (`kanban-board.tsx`, story #2187) filters `is_excluded` cards out of
+  every column unconditionally, so this is what actually keeps the card from inflating
+  visible counts; `command_center`/analytics already excluded it before this story.
+
+**When cleaning up:**
+- You cannot delete it yourself. Don't leave the request implicit in a chat message that
+  will scroll away — batch pending `[TEMP-QA]` deletions and ask the PO for a bulk
+  delete once per branch of work (not per-card), e.g. at the end of a live-verification
+  session. `gh`/Sprintable search for the `[TEMP-QA]` prefix to compile the list.
+- Do not request agent delete-permission as a workaround (rejected direction — see story
+  #2187 AC4: the human-only block is an intentional safeguard against an agent deleting
+  someone else's work, and throwaway-card convenience isn't worth trading that away).

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -874,6 +874,8 @@
     "filterAll": "All",
     "filterMembers": "Members",
     "filterAgents": "Agents",
+    "excludedCountBadge": "{count} hidden",
+    "excludedCountTitle": "Live-QA throwaway cards etc. — hidden from views/metrics (not deleted)",
     "sprints": "Sprints",
     "epics": "Goals",
     "manageSprints": "Manage sprints →",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -874,6 +874,8 @@
     "filterAll": "전체",
     "filterMembers": "멤버",
     "filterAgents": "에이전트",
+    "excludedCountBadge": "{count}건 숨김",
+    "excludedCountTitle": "라이브 QA 임시 카드 등 — 지표·화면에서 숨김 처리됨(삭제 아님)",
     "sprints": "스프린트",
     "epics": "목표",
     "manageSprints": "스프린트 관리 →",

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.loadmore.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.loadmore.test.tsx
@@ -153,3 +153,91 @@ describe('SprintsClient — 백로그/스프린트 스토리 「더 보기」(st
     expect(cursorCall).not.toContain(`cursor=${CURSOR_WITH_PLUS}`);
   });
 });
+
+describe('SprintsClient — is_excluded 스토리 무조건 숨김(story #2187 후속, 카디르 QA changes-requested·PR#3153)', () => {
+  it('백로그 초기 로드에서 is_excluded=true 카드는 목록에도 "배정" 대상에도 안 뜬다', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/api/sprints?project_id=')) return { ok: true, json: async () => ({ data: [SPRINT] }) };
+      if (url.includes('/burndown')) return { ok: true, json: async () => ({ data: null }) };
+      if (url.includes('/api/stories?project_id=')) return { ok: true, json: async () => ({ data: [], meta: { hasMore: false, nextCursor: null } }) };
+      if (url.includes('/api/stories/backlog')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [
+              { id: 'b1', title: 'Backlog 정상', is_excluded: false },
+              { id: 'b2', title: 'Backlog 삭제대상', is_excluded: true },
+            ],
+            meta: { hasMore: false, nextCursor: null },
+          }),
+        };
+      }
+      return { ok: false, json: async () => null };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await mountAndSelect();
+
+    expect(container.textContent).toContain('Backlog 정상');
+    expect(container.textContent).not.toContain('Backlog 삭제대상');
+  });
+
+  it('스프린트 편입 스토리 초기 로드에서도 is_excluded=true 카드는 숨는다', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/api/sprints?project_id=')) return { ok: true, json: async () => ({ data: [SPRINT] }) };
+      if (url.includes('/burndown')) return { ok: true, json: async () => ({ data: null }) };
+      if (url.includes('/api/stories/backlog')) return { ok: true, json: async () => ({ data: [], meta: { hasMore: false, nextCursor: null } }) };
+      if (url.includes('/api/stories?project_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [
+              { id: 's1', title: 'Sprint 정상', is_excluded: false },
+              { id: 's2', title: 'Sprint 삭제대상', is_excluded: true },
+            ],
+            meta: { hasMore: false, nextCursor: null },
+          }),
+        };
+      }
+      return { ok: false, json: async () => null };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await mountAndSelect();
+
+    expect(container.textContent).toContain('Sprint 정상');
+    expect(container.textContent).not.toContain('Sprint 삭제대상');
+  });
+
+  it('loadMore로 추가 페이지를 append할 때도 is_excluded=true 카드는 걸러진다(backlog)', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/api/sprints?project_id=')) return { ok: true, json: async () => ({ data: [SPRINT] }) };
+      if (url.includes('/burndown')) return { ok: true, json: async () => ({ data: null }) };
+      if (url.includes('/api/stories?project_id=')) return { ok: true, json: async () => ({ data: [], meta: { hasMore: false, nextCursor: null } }) };
+      if (url.includes('/api/stories/backlog') && !url.includes('cursor=')) {
+        return { ok: true, json: async () => ({ data: [{ id: 'b1', title: 'Backlog 1페이지', is_excluded: false }], meta: { hasMore: true, nextCursor: CURSOR_WITH_PLUS } }) };
+      }
+      if (url.includes('/api/stories/backlog') && url.includes('cursor=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [
+              { id: 'b2', title: 'Backlog 2페이지 정상', is_excluded: false },
+              { id: 'b3', title: 'Backlog 2페이지 삭제대상', is_excluded: true },
+            ],
+            meta: { hasMore: false, nextCursor: null },
+          }),
+        };
+      }
+      return { ok: false, json: async () => null };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await mountAndSelect();
+    const loadMoreBtn = findLoadMoreButtons().find((b) => !b.disabled)!;
+    await act(async () => { loadMoreBtn.click(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('Backlog 2페이지 정상');
+    expect(container.textContent).not.toContain('Backlog 2페이지 삭제대상');
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
@@ -74,6 +74,15 @@ interface Story {
   status: string;
   story_points: number | null;
   sprint_id: string | null;
+  is_excluded?: boolean;
+}
+
+// story #2187 후속(카디르 QA changes-requested, PR#3153) — 이 화면은 KanbanBoard를 거치지
+// 않고 /api/stories(/backlog)를 직접 fetch하므로 is_excluded 무조건 필터가 안 걸렸다. 필터만
+// 거는 kanban-board.tsx와 달리 여기는 "배정" 버튼까지 있어 삭제 대상 카드가 실 스프린트에
+// 편입될 수 있는 위험이 더 크다 — 같은 규약을 그대로 이식.
+function excludeHidden(stories: Story[]): Story[] {
+  return stories.filter((s) => !s.is_excluded);
 }
 
 interface BurndownData {
@@ -445,13 +454,13 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
       }
       if (storiesRes.ok) {
         const json = await storiesRes.json() as { data?: Story[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
-        setSprintStories(json.data ?? []);
+        setSprintStories(excludeHidden(json.data ?? []));
         setSprintStoriesHasMore(json.meta?.hasMore ?? false);
         setSprintStoriesNextCursor(json.meta?.nextCursor ?? null);
       }
       if (backlogRes.ok) {
         const json = await backlogRes.json() as { data?: Story[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
-        setBacklogStories(json.data ?? []);
+        setBacklogStories(excludeHidden(json.data ?? []));
         setBacklogHasMore(json.meta?.hasMore ?? false);
         setBacklogNextCursor(json.meta?.nextCursor ?? null);
       }
@@ -471,7 +480,7 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
       const res = await fetch(`/api/stories?project_id=${projectId}&sprint_id=${selected.id}&limit=20&cursor=${encodeURIComponent(sprintStoriesNextCursor)}`);
       if (res.ok) {
         const json = await res.json() as { data?: Story[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
-        setSprintStories((prev) => [...prev, ...(json.data ?? [])]);
+        setSprintStories((prev) => [...prev, ...excludeHidden(json.data ?? [])]);
         setSprintStoriesHasMore(json.meta?.hasMore ?? false);
         setSprintStoriesNextCursor(json.meta?.nextCursor ?? null);
       } else {
@@ -494,7 +503,7 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
       const res = await fetch(`/api/stories/backlog?project_id=${projectId}&limit=20&cursor=${encodeURIComponent(backlogNextCursor)}`);
       if (res.ok) {
         const json = await res.json() as { data?: Story[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
-        setBacklogStories((prev) => [...prev, ...(json.data ?? [])]);
+        setBacklogStories((prev) => [...prev, ...excludeHidden(json.data ?? [])]);
         setBacklogHasMore(json.meta?.hasMore ?? false);
         setBacklogNextCursor(json.meta?.nextCursor ?? null);
       } else {

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -559,3 +559,35 @@ describe('KanbanBoard — org-sync 성공 後 재요청 (story #2545)', () => {
     expect(storiesCalls).toBeGreaterThan(callsAfterMount); // 재요청 — 이전엔 안 늘었다(RED)
   });
 });
+
+// story #2187 — 라이브 QA 임시 카드([TEMP-QA] 등)는 삭제가 휴먼 전용이라 만든 쪽이 못 치운다.
+// PO가 is_excluded=true로 마킹해도 보드가 그 필드를 안 보면 화면엔 그대로 남아 "«남은 일»을
+// 과장"한다(#2187 관측 그대로) — 화면이 실제로 이 플래그를 존중해 숨기는지 회귀가드한다.
+describe('KanbanBoard — is_excluded 카드 숨김(story #2187)', () => {
+  it('is_excluded=true인 카드는 컬럼에 렌더되지 않는다 — 형제 카드(제외 아님)는 그대로 보인다', async () => {
+    stubFetch([
+      { id: 's-hidden', title: '[TEMP-QA] 검증용 임시 카드', status: 'backlog', priority: 'medium', is_excluded: true },
+      { id: 's-visible', title: '진짜 백로그 항목', status: 'backlog', priority: 'medium', is_excluded: false },
+    ]);
+    await mount();
+    const html = container.innerHTML;
+    expect(html).not.toContain('[TEMP-QA] 검증용 임시 카드');
+    expect(html).toContain('진짜 백로그 항목');
+  });
+
+  it('is_excluded 카드가 있으면 "N건 숨김" 배지가 정확한 수로 뜬다 — 없으면 배지 자체가 없다', async () => {
+    stubFetch([
+      { id: 's-hidden-1', title: '[TEMP-QA] 1', status: 'backlog', priority: 'medium', is_excluded: true },
+      { id: 's-hidden-2', title: '[TEMP-QA] 2', status: 'ready-for-dev', priority: 'medium', is_excluded: true },
+      { id: 's-visible', title: '진짜 항목', status: 'backlog', priority: 'medium', is_excluded: false },
+    ]);
+    await mount();
+    expect(container.textContent).toContain('2건 숨김');
+  });
+
+  it('is_excluded 카드가 하나도 없으면 "숨김" 배지가 렌더되지 않는다(과잉 배지 금지)', async () => {
+    stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', is_excluded: false }]);
+    await mount();
+    expect(container.textContent).not.toContain('숨김');
+  });
+});

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -576,7 +576,12 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
       .catch(() => {});
   }, [searchParams, stories, handleStoryClick]);
 
+  // story #2187 — is_excluded=true(라이브 QA 임시 카드 등)는 무조건 숨긴다. 다른 필터와 달리
+  // 토글이 없다 — 삭제 권한이 없어 화면에서라도 항상 빠져야 「«남은 일»을 과장」하지 않는다.
+  const excludedCount = stories.filter((s) => s.is_excluded).length;
+
   const filteredStories = stories.filter((s) => {
+    if (s.is_excluded) return false;
     if (selectedEpicId && s.epic_id !== selectedEpicId) return false;
     // 9f25e74a AC1: assignee 필터는 서버사이드(fetchStoriesByStatus ?assignee_id=)로 이관 — 클라 이중필터 제거(done 페이지네이션 경계 AC2 동시 해소).
     if (assigneeTypeFilter) {
@@ -1218,6 +1223,18 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                 </div>
               </DropdownMenuContent>
             </DropdownMenu>
+          )}
+
+          {/* story #2187 — is_excluded 카드가 조용히 사라지면 "삭제 대상" 카드의 존재 자체를
+              아무도 모르게 된다(만든 쪽도 못 치우는데 아무도 안 보면 영영 안 놓인다) — 그래서
+              숨긴 수를 항상 보이는 어포던스로 남긴다. */}
+          {excludedCount > 0 && (
+            <span
+              title={t('excludedCountTitle')}
+              className="ml-1 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground"
+            >
+              {t('excludedCountBadge', { count: excludedCount })}
+            </span>
           )}
         </div>
 

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -34,6 +34,11 @@ export interface KanbanStory {
   human_verified?: boolean | null;
   human_verified_by?: string | null;
   human_verified_at?: string | null;
+  // story #2187 — 라이브 QA가 만든 임시 카드([TEMP-QA] 등)는 삭제가 휴먼 전용(에이전트 API키
+  // 403)이라 만든 쪽이 못 치운다. PO가 우선 is_excluded=true로 마킹해 analytics/command_center
+  // 지표에서는 뺐으나(#2187 관측) 보드/백로그 화면은 그 플래그를 안 봐 그대로 남아 있었다 —
+  // 이 필드로 화면도 존중해 숨긴다(삭제 아닌 숨김, DB엔 남음).
+  is_excluded?: boolean;
 }
 
 export interface GateItem {


### PR DESCRIPTION
## 배경

story [b8157376(#2187)](entity:story:b8157376-a564-45f8-adaf-94557d813350) — 라이브 QA가 만든 임시 카드는 story 삭제가 휴먼 전용(에이전트 API키 403)이라 만든 쪽이 못 치운다. PO가 3건(#2126·#2159·#2186)을 `is_excluded=true`로 마킹해 command_center/analytics 지표에서는 뺐으나, 보드/백로그 화면(`apps/web`)엔 그 필드 참조가 0건이라 화면엔 그대로 남아 있었다 — "보드가 남은 일을 과장한다"는 실제 증상의 원인.

## PO 방향 확定
- **(b) FE가 is_excluded를 존중해 화면에서 숨김** 채택 — 값 싸고 즉효.
- (c) 만료 자가회수(별도 기능 신설)는 이 판 아님, 필요 시 후속.
- **(d) 삭제 권한 개방은 명시 배제**(AC4) — 휴먼전용 차단은 "에이전트가 남의 일을 지우는 것"을 막는 의도된 안전장치, 임시카드 편의와 교환하지 않는다.

## 변경

1. **`KanbanStory.is_excluded` 필드 추가** — BE `StoryResponse`엔 이미 `is_excluded: bool = False`로 존재(`/api/stories` 프록시가 그대로 통과), FE 타입에만 없었다.
2. **`kanban-board.tsx`**: `filteredStories` 체인 최상단에 `is_excluded` 무조건 제외 추가(다른 필터와 달리 토글 없음 — 삭제 권한이 없으니 화면에서라도 항상 빠져야 함). "N건 숨김" 배지를 필터바에 추가 — 조용히 사라지면 "삭제 대상" 카드의 존재 자체를 아무도 모르게 되므로(만든 쪽도 못 치우는데 아무도 안 보면 영영 안 놓인다) 항상 보이는 어포던스로.
3. **`AGENTS.md`**: 임시 QA카드 관례 신설 — 만들 때(`[TEMP-QA]` 제목 + 그 자리에서 즉시 `is_excluded=true`)/치울 때(선생님께 일괄 삭제 요청, 카드마다 아니라 분기 1회).

## 스코프 밖
- 즉시분 3건(#2126·#2159·#2186) 실제 삭제는 휴먼 권한 — 페드루가 다음 보고에 묶어 선생님께 상신.
- (c) 만료 자가회수 기능 신설.

## 검증
- `pnpm exec tsc --noEmit` → EXIT 0
- `pnpm lint` → EXIT 0(0 error, 기존 무관 warning 5건)
- `pnpm exec vitest run` → 433파일/3557테스트 전부 통과(신규 3: is_excluded 미렌더+형제카드 정상렌더·배지 정확한 카운트·0건일 때 배지 없음)
- `pnpm build` → EXIT 0