### PR TITLE
[SID:2224] /flow 갈래 화면 — goals fetch 401/5xx 삼킴 fix(목표 0개 실데이터 미배선)

### DIFF
--- a/apps/web/src/components/flow/next-maker-screen.test.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.test.tsx
@@ -427,3 +427,34 @@ describe('NextMakerScreen — org-sync 성공 後 재요청 (story #2545)', () =
     expect(goalsCallsAfterBump).toBeGreaterThan(goalsCallsAfterMount); // 재요청 — 이전엔 안 늘었다(RED)
   });
 });
+
+// story #2224 후속(2026-08-16, 미르코) — dev 실측(활성 목표 39건인데 화면은 "목표 0개")의
+// 근본원인 회귀가드. fetchAllPages가 `if (!res.ok) break`로 실패를 «페이지네이션 끝»과
+// 구분 없이 삼켜, 어떤 실패든(이번엔 401·일반화하면 5xx도 동형) items=[]가 "정상 0건"인
+// 화면(목표 0개 중 0개)으로 조용히 렌더됐다 — 에러 표시도 콘솔도 없이. 이 가드는 goals 응답이
+// 실패할 때 그 조용한 "0개"가 아니라 정직한 에러 화면(nextMakerError)이 뜨는지를 고정한다
+// (RED였다면 이 테스트는 "목표 0개 중 0개"가 뜨는 것을 보고 통과해 버렸을 것 — 그래서 이
+// 가드는 "에러 문구가 있다"뿐 아니라 "0개 문구가 없다"도 함께 확認한다).
+describe('NextMakerScreen — 실패를 "0건"으로 삼키지 않는다(story #2224 후속)', () => {
+  it('goals 응답이 실패(5xx)면 "목표 0개"가 아니라 에러 화면이 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/goals?')) return { ok: false, status: 500, json: async () => null } as Response;
+      // 다른 병렬 호출은 정상 응답 — goals 실패 «단독»이 원인임을 못박는다.
+      if (url.startsWith('/api/stories?')) return jsonResponse({ data: [], meta: { hasMore: false, nextCursor: null, limit: 100 } });
+      if (url.startsWith('/api/reference-candidates/next-up')) return jsonResponse([]);
+      if (url.startsWith('/api/analytics/epics-progress-lane')) {
+        return jsonResponse({ data: { epics: {}, zones: {}, stall_threshold_hours: 168, stories_without_epic: 0 } });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }));
+
+    await act(async () => {
+      root.render(wrap(<NextMakerScreen projectId="p1" memberMap={{}} onSelectStory={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(container.textContent).toContain('다음을 불러오지 못했습니다');
+    expect(container.textContent).not.toContain('목표 0개');
+  });
+});

--- a/apps/web/src/components/flow/next-maker-screen.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.tsx
@@ -47,12 +47,21 @@ const ACTIVE_STATUSES = ['backlog', 'ready-for-dev', 'in-progress', 'in-review']
 const PAGE_LIMIT = 100; // /api/goals, /api/stories FE 프록시 상한(parseCursorPageInput maxLimit).
 const SAFETY_MAX_PAGES = 50; // 무한루프 방어 — 100*50=5000건, 오늘 이 project 규모를 넉넉히 상회.
 
+// story #2224 후속(2026-08-16, 미르코 그라운딩) — dev 실측: 활성 목표 39건이 존재하는데
+// 화면은 "목표 0개"로 떴다(정직한 빈 화면 아님 — 실데이터 미배선). 원인: 이 루프가 이
+// 파일의 다른 fetch(next-up·epics-progress-lane)와 달리 맨 fetch()를 썼다 — 토큰이 막
+// 만료된 타이밍이면 401이 오는데 `if (!res.ok) break`가 그걸 "페이지네이션 끝"으로 조용히
+// 삼켜 items=[]를 정상 결과처럼 반환했다(에러 0·콘솔 0). 오늘 이미 한 번 고친 그 클래스
+// (PR#3123, raw fetch 401 swallow)와 동일 결함 — fetchWithAuth로 바꿔 401을 자동
+// refresh+재시도하게 하고, 재시도 후에도 non-ok면(진짜 실패) 조용히 끝내지 않고 던져서
+// 위 useEffect의 catch가 kind:'error'로 잡게 한다 — "0건"과 "못 가져왔다"를 더는 같은
+// 화면으로 안 보여준다.
 async function fetchAllPages<T>(urlBuilder: (cursor: string | null) => string, source: string): Promise<T[]> {
   const items: T[] = [];
   let cursor: string | null = null;
   for (let page = 0; page < SAFETY_MAX_PAGES; page += 1) {
-    const res = await fetch(urlBuilder(cursor));
-    if (!res.ok) break;
+    const res = await fetchWithAuth(urlBuilder(cursor));
+    if (!res.ok) throw new Error(`${source}: HTTP ${res.status}`);
     const json: Envelope<T[]> = await res.json();
     const rows = Array.isArray(json.data) ? json.data : [];
     items.push(...rows);


### PR DESCRIPTION
## 배경

story [055ea1f8(#2224, S2-1)](entity:story:055ea1f8-40c0-4c6c-ab9a-21cd0c282532) — dev 실측(2026-08-16): sprintable 프로젝트에 활성 목표 39건이 존재하는데 `/flow` 화면은 "목표 0개 중 0개"로 완전 빈 상태였다. 블루프린트 v4 §5-1이 말하는 "정직한 빈 화면"(진짜 0건일 때만 유효)이 아니라, 실데이터가 화면에 조용히 안 실린 결함으로 판단 — PO 확認 후 이 PR로 착수.

## 근본원인

`NextMakerScreen`의 `fetchAllPages()`가 같은 파일의 다른 fetch(`next-up`·`epics-progress-lane`)와 달리 `fetchWithAuth`가 아닌 맨 `fetch()`를 썼다. 페이지네이션 루프의 `if (!res.ok) break`가 **어떤 실패든**(토큰이 막 만료된 타이밍의 401 포함) "페이지네이션 끝"과 구분 없이 삼켜 `items=[]`를 정상 결과처럼 반환했다 — 에러도 콘솔 로그도 없이. 오늘 이 세션에서 이미 한 번 고친 결함 클래스(PR#3123, raw fetch 401 swallow)와 동일한 모양이 다른 화면에도 있었다.

## 처방

- `fetch()` → `fetchWithAuth()`로 교체 — 401을 자동 refresh+재시도.
- 재시도 후에도 non-ok면(진짜 실패) 조용히 `break`하지 않고 `throw` — 바깥 `useEffect`의 catch가 `kind:'error'`로 잡아 정직한 에러 화면(`nextMakerError`)을 보이게 한다. "0건"과 "못 가져왔다"를 더는 같은 화면으로 안 보여준다.

## 검증

- **RED/GREEN 직접 재현**: 수정을 임시로 되돌린 채 새 회귀테스트를 돌려 — 실제 dev 증상과 byte-동일한 문구("목표 0개 중 0개에 「다음」이 정해지지 않았습니다")로 실패하는 것을 확認한 뒤, 수정을 재적용해 통과하는 것까지 확認(단순 코드리뷰가 아니라 실제 재현+원복 검증).
- `pnpm exec tsc --noEmit` → EXIT 0
- `pnpm lint` → EXIT 0(0 error, 기존 무관 warning 5건)
- `pnpm exec vitest run` → 433파일/3555테스트 전부 통과(신규 1: goals 5xx 응답 시 "0개"가 아니라 에러 화면이 뜨는지)
- `pnpm build` → EXIT 0

## 참고
- `fetchAllStoriesByStatus`(같은 `fetchAllPages` 헬퍼 사용)도 동일 결함에 걸려 있었다 — 한 번의 수정으로 goals·stories 두 fetch 경로 모두 해소.
- 라이브 재검증(dev 배포 후 실제로 39건이 그려지는지)은 배포 후 별도 확認 예정.