### PR TITLE
[BE·FE·결재] 근거 열람(evidence_viewed) 서버 강제 — 고위험 승인 API 우회 봉인 (story #2027 AC2)

### DIFF
--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -253,3 +253,57 @@ describe('GateDetailPage — 보류(논의 필요)·오클릭 정정 (story #263
     expect(buttons.some((t) => t?.includes(koMessages.cage.gateUndo))).toBe(false);
   });
 });
+
+// story #2027 AC2(페드루 PO 처방 2026-08-16) — BE가 고위험(risk_grade=high) 게이트 승인에
+// evidence_viewed=true를 강제하기 시작했다. FE가 이 값을 안 보내면 서명 플로우를 거쳐도
+// 서버가 422로 막는다 — 이 스위트는 "서명 플로우를 거치면 실제로 true가 실리는지"와
+// "저위험 플레인 버튼은 안 실려도(false) 무관한지" 둘 다 고정한다.
+describe('GateDetailPage — evidence_viewed 서버 계약 (story #2027 AC2)', () => {
+  async function mountCapturingTransition(gateFixture: GateItem) {
+    const calls: { url: string; method?: string; body?: string }[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method, body: init?.body as string | undefined });
+      if (url === '/api/gates/gate-1' && !init) return { ok: true, status: 200, json: async () => ({ data: gateFixture }) };
+      if (url === '/api/gates/gate-1/transition') return { ok: true, json: async () => ({ data: gateFixture }) };
+      if (url === '/api/gates/gate-1') return { ok: true, status: 200, json: async () => ({ data: gateFixture }) };
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { default: GateDetailPage } = await import('./page');
+    const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+    await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    return calls;
+  }
+
+  it('고위험(서명 플로우) 승인 — 근거 열람 체크 + 사유 입력 후 클릭하면 evidence_viewed:true가 실린다', async () => {
+    const calls = await mountCapturingTransition(gate({ can_approve: true, risk_grade: 'high' }));
+
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    const textarea = container.querySelector('#gate-sig-reason') as HTMLTextAreaElement;
+    expect(checkbox).toBeTruthy();
+    expect(textarea).toBeTruthy();
+
+    await act(async () => { checkbox.click(); });
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!;
+      setter.call(textarea, '근거 확인함');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const approveBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes(koMessages.cage.sigApproveAndSign));
+    expect(approveBtn?.hasAttribute('disabled')).toBe(false);
+    await act(async () => { approveBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    const transitionCall = calls.find((c) => c.url === '/api/gates/gate-1/transition');
+    expect(JSON.parse(transitionCall?.body ?? '{}')).toMatchObject({ status: 'approved', evidence_viewed: true });
+  });
+
+  it('저위험(플레인 버튼) 승인 — evidence_viewed:false로 실려도(안 봤어도) 그대로 통과 경로(회귀 없음)', async () => {
+    const calls = await mountCapturingTransition(gate({ can_approve: true, risk_grade: 'low' }));
+    const approveBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes(koMessages.cage.gateApprove));
+    await act(async () => { approveBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    const transitionCall = calls.find((c) => c.url === '/api/gates/gate-1/transition');
+    expect(JSON.parse(transitionCall?.body ?? '{}')).toMatchObject({ status: 'approved', evidence_viewed: false });
+  });
+});

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -108,7 +108,7 @@ export default function GateDetailPage() {
   // 뷰어) 아래에서 읽기전용 사유 문구로 분기한다(무권한 상태에서 액션 버튼 자체를 렌더하지 않음).
   const canAct = needsAction && gate?.can_approve === true;
 
-  const transition = useCallback(async (status: 'approved' | 'rejected', note?: string) => {
+  const transition = useCallback(async (status: 'approved' | 'rejected', note?: string, evidenceViewed?: boolean) => {
     if (!gate) return;
     setResolving(true);
     setTransitionError(null);
@@ -116,7 +116,11 @@ export default function GateDetailPage() {
       const res = await fetchWithAuth(`/api/gates/${gate.id}/transition`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status, note: note?.trim() || null }),
+        // story #2027 AC2: evidence_viewed는 GateSignatureApproval의 onApprove가 호출될 때만
+        // 실려온다(그 컴포넌트 자체가 canSign=evidenceViewed&&reason로 버튼을 막아 이 콜백에
+        // 도달했다는 사실 자체가 열람 확인 — 아래 저위험 경로는 안 보내 undefined→백엔드가
+        // risk_grade=='high'가 아니면 아예 안 봄).
+        body: JSON.stringify({ status, note: note?.trim() || null, evidence_viewed: evidenceViewed ?? false }),
       });
       // story #1990: push()는 콜드-진입 합성 스택([parentTab, target])에 세번째 엔트리를
       // 쌓아 브라우저 BACK 1회가 이 상세를 재진입시키는 트랩을 만든다(§3.2 재진입 트랩).
@@ -252,7 +256,7 @@ export default function GateDetailPage() {
                 gate={gate}
                 resolving={resolving}
                 error={transitionError}
-                onApprove={(reason) => void transition('approved', reason)}
+                onApprove={(reason) => void transition('approved', reason, true)}
                 onReject={(reason) => void transition('rejected', reason)}
                 onDiscuss={(reason) => void discuss(reason)}
               />

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -108,14 +108,16 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalR
 
   useEffect(() => { void fetchGate(); }, [fetchGate]);
 
-  const transition = async (status: 'approved' | 'rejected', note?: string) => {
+  const transition = async (status: 'approved' | 'rejected', note?: string, evidenceViewed?: boolean) => {
     setResolving(true);
     setTransitionError(null);
     try {
       const res = await fetchWithAuth(`/api/gates/${target.gate_id}/transition`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status, note: note?.trim() || null }),
+        // story #2027 AC2 — gates/[id]/page.tsx와 동일 계약(evidence_viewed는 고위험 서명
+        // 플로우 onApprove에서만 true로 실린다, 아래 ApprovalRequestBody 배선 참조).
+        body: JSON.stringify({ status, note: note?.trim() || null, evidence_viewed: evidenceViewed ?? false }),
       });
       if (res.ok) { await fetchGate(); return; }
       const body = await res.json().catch(() => null) as { error?: { message?: string } } | null;
@@ -172,7 +174,7 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalR
           gate={state.gate}
           resolving={resolving}
           transitionError={transitionError}
-          onApprove={(reason) => void transition('approved', reason)}
+          onApprove={(reason, evidenceViewed) => void transition('approved', reason, evidenceViewed)}
           onReject={(reason) => void transition('rejected', reason)}
           onDiscuss={(reason) => void discuss(reason)}
           onDiscussClick={() => setDiscussDialogOpen(true)}
@@ -199,7 +201,7 @@ function ApprovalRequestBody({
   gate: GateItem;
   resolving: boolean;
   transitionError: string | null;
-  onApprove: (reason?: string) => void;
+  onApprove: (reason?: string, evidenceViewed?: boolean) => void;
   onReject: (reason?: string) => void;
   /** story #2631 — 고위험(서명) 플로우가 이미 가진 사유 필드를 그대로 재사용해 직접 제출. */
   onDiscuss: (reason: string) => void;
@@ -327,7 +329,9 @@ function ApprovalRequestBody({
           gate={gate}
           resolving={resolving}
           error={transitionError}
-          onApprove={onApprove}
+          // story #2027 AC2: GateSignatureApproval의 canSign이 evidenceViewed&&reason로 버튼을
+          // 막아서 이 콜백에 닿았다는 사실 자체가 열람 확인 — gates/[id]/page.tsx와 동일 계약.
+          onApprove={(reason) => onApprove(reason, true)}
           onReject={onReject}
           onDiscuss={onDiscuss}
           compact

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -710,7 +710,7 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     const transitionCall = fetchMock.mock.calls.find((call: unknown[]) => (call[0] as string).includes('/transition'));
     expect(transitionCall).toBeDefined();
-    expect(JSON.parse((transitionCall![1] as { body: string }).body)).toEqual({ status: 'approved', note: null });
+    expect(JSON.parse((transitionCall![1] as { body: string }).body)).toEqual({ status: 'approved', note: null, evidence_viewed: false });
     expect(container.textContent).toContain('처리됨');
     expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent?.includes('승인'))).toBe(false);
   });
@@ -763,7 +763,7 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
 
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     const transitionCall = fetchMock.mock.calls.find((call: unknown[]) => (call[0] as string).includes('/transition'));
-    expect(JSON.parse((transitionCall![1] as { body: string }).body)).toEqual({ status: 'approved', note: '근거 확인함, 승인' });
+    expect(JSON.parse((transitionCall![1] as { body: string }).body)).toEqual({ status: 'approved', note: '근거 확인함, 승인', evidence_viewed: true });
   });
 
   it('이미 처리된 게이트(status=approved)는 버튼 없이 처리됨 상태만 보인다', async () => {

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -344,7 +344,7 @@ describe('ApprovalsQueue', () => {
 
     const postCall = calls.find((c) => c.method === 'POST');
     expect(postCall?.url).toBe('/api/gates/g-low/transition');
-    expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'approved', note: null });
+    expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'approved', note: null, evidence_viewed: false });
 
     expect(container.textContent).toContain(koMessages.cage.queueResolvedApproved);
     expect(container.textContent).toContain(koMessages.cage.queueViewRecord);
@@ -390,7 +390,7 @@ describe('ApprovalsQueue', () => {
     const rejectButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.sigRequestChanges));
     await act(async () => { rejectButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     const postCall = calls.find((c) => c.method === 'POST');
-    expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'rejected', note: null });
+    expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'rejected', note: null, evidence_viewed: false });
     expect(container.textContent).toContain(koMessages.cage.queueResolvedRejected);
   });
 
@@ -604,7 +604,7 @@ describe('ApprovalsQueue', () => {
 
       const postCall = calls.find((c) => c.method === 'POST' && c.url.includes('/transition'));
       expect(postCall?.url).toBe('/api/gates/g-sig-approve/transition');
-      expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'approved', note: '근거 확認·서명 사유' });
+      expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'approved', note: '근거 확認·서명 사유', evidence_viewed: true });
       expect(document.body.querySelector('[data-slot="dialog-content"]')).toBeFalsy();
       expect(container.textContent).toContain(koMessages.cage.queueResolvedApproved);
     });
@@ -623,7 +623,7 @@ describe('ApprovalsQueue', () => {
       await act(async () => { rejectButtons[0]?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
 
       const postCall = calls.find((c) => c.method === 'POST' && c.url.includes('/transition'));
-      expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'rejected', note: '재작업 필요' });
+      expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'rejected', note: '재작업 필요', evidence_viewed: false });
       expect(container.textContent).toContain(koMessages.cage.queueResolvedRejected);
     });
 

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -198,14 +198,16 @@ export function ApprovalsQueue() {
   // 동일 엔드포인트·body. story 22affaf2 — 고위험 서명 플로우(GateSignatureApproval)도
   // 이제 이 함수를 그대로 쓴다(note=서명 사유) — 별도 함수를 새로 짓지 않는다(canonical
   // 상세의 transition()과 body shape을 1:1로 맞춘 이유이기도 함).
-  const resolveGate = async (id: string, status: 'approved' | 'rejected', note: string | null = null) => {
+  const resolveGate = async (id: string, status: 'approved' | 'rejected', note: string | null = null, evidenceViewed?: boolean) => {
     setResolvingIds((prev) => new Set(prev).add(id));
     setGateErrors((prev) => { const next = { ...prev }; delete next[id]; return next; });
     try {
       const res = await fetch(`/api/gates/${id}/transition`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status, note: note?.trim() || null }),
+        // story #2027 AC2 — gates/[id]/page.tsx와 동일 계약(evidence_viewed는 고위험 서명
+        // 플로우 onApprove에서만 true로 실린다, 아래 GateSignatureApproval 배선 참조).
+        body: JSON.stringify({ status, note: note?.trim() || null, evidence_viewed: evidenceViewed ?? false }),
       });
       if (res.ok) {
         setResolvedGates((prev) => ({ ...prev, [id]: status }));
@@ -467,7 +469,7 @@ export function ApprovalsQueue() {
               gate={signatureGate}
               resolving={resolvingIds.has(signatureGate.id)}
               error={gateErrors[signatureGate.id]}
-              onApprove={(reason) => void resolveGate(signatureGate.id, 'approved', reason)}
+              onApprove={(reason) => void resolveGate(signatureGate.id, 'approved', reason, true)}
               onReject={(reason) => void resolveGate(signatureGate.id, 'rejected', reason)}
             />
           ) : null}

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -88,6 +88,13 @@ class GateTransitionRequest(BaseModel):
     status: str
     resolver_id: uuid.UUID | None = None  # ⚠️RC#1: 무시됨(서버가 인증 caller 로 강제)·하위호환 잔류.
     note: str | None = None
+    # story #2027 AC2(까심 QA 적출·2026-07-20, 페드루 PO 처방 2026-08-16): 고위험 게이트의
+    # "근거 열람" 요건도 note와 동형으로 서버가 강제한다 — 클라이언트가 「봤다」고 선언한
+    # 값을 그대로 신뢰하는 것뿐이라 완전한 증명은 아니지만(서버는 실제 열람 여부를 관측할
+    # 수 없다), 최소한 「보냈다」는 사실 자체가 UI 경유를 강제한다(직접 API 호출은 이 필드를
+    # 몰라 기본값 False로 막힌다 — AC1의 note 강제와 같은 방어선). 기본값 False = 안 보내면
+    # 고위험에서 막힘(저위험은 아래 강제 블록이 risk_grade=="high"일 때만 돌아 무관).
+    evidence_viewed: bool = False
 
     @field_validator("status")
     @classmethod
@@ -870,11 +877,18 @@ async def transition_gate_endpoint(
     # (derive_risk_grade+get_org_posture) 재사용(DRY·N+1 0 — org당 posture 1쿼리).
     if body.status == "approved" and _gate is not None:
         _posture = await get_org_posture(session, org_id)
-        if derive_risk_grade(_posture, _gate.gate_type) == "high" and not (body.note or "").strip():
-            raise HTTPException(
-                status_code=422,
-                detail="고위험(risk_grade=high) 게이트 승인은 사유(note) 입력이 필수입니다.",
-            )
+        if derive_risk_grade(_posture, _gate.gate_type) == "high":
+            if not (body.note or "").strip():
+                raise HTTPException(
+                    status_code=422,
+                    detail="고위험(risk_grade=high) 게이트 승인은 사유(note) 입력이 필수입니다.",
+                )
+            # story #2027 AC2: note와 같은 자리 — 근거 열람(evidence_viewed) 확인도 서버가 강제.
+            if body.evidence_viewed is not True:
+                raise HTTPException(
+                    status_code=422,
+                    detail="고위험(risk_grade=high) 게이트 승인은 근거 열람 확인(evidence_viewed=true)이 필수입니다.",
+                )
     # ⭐S23 RC① + RC#1(방어심층): resolver_id 를 **전 status 무조건 인증 caller 로 강제**(body 무시).
     # body 조작(타인 UUID)으로 SoD(approver≠owner) 우회·confirmed_by_member_id 위조 차단.
     _resolver_id = resolved.id

--- a/backend/tests/test_2027_gate_approval_reason_enforce.py
+++ b/backend/tests/test_2027_gate_approval_reason_enforce.py
@@ -187,7 +187,11 @@ async def test_realdb_high_risk_approve_without_note_422_and_no_mutation():
 @pytest.mark.anyio
 async def test_realdb_high_risk_approve_with_note_persists_resolution_note():
     """같은 고위험 조합에 note 를 실어 보내면 200·resolution_note 가 실제로 저장된다(재조회로 확인
-    — story #2027 이전엔 approved 전이가 resolution_note 를 rejected 전용 분기라 저장하지 않았다)."""
+    — story #2027 이전엔 approved 전이가 resolution_note 를 rejected 전용 분기라 저장하지 않았다).
+
+    AC2(2026-08-16) 후속 — evidence_viewed:true도 함께 실어야 한다(note만으론 이제 부족,
+    아래 test_realdb_high_risk_approve_with_note_but_no_evidence_viewed_422_and_no_mutation
+    이 그 축을 별도로 고정)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -203,7 +207,7 @@ async def test_realdb_high_risk_approve_with_note_persists_resolution_note():
             note = "PR diff 전체 + CI green 확인, 마이그레이션 없음 확인 후 승인"
             resp = await client.post(
                 f"/api/v2/gates/{gate_id}/transition",
-                json={"status": "approved", "note": note},
+                json={"status": "approved", "note": note, "evidence_viewed": True},
             )
             assert resp.status_code == 200, resp.text
             assert resp.json()["resolution_note"] == note, resp.json()
@@ -244,6 +248,111 @@ async def test_realdb_low_risk_approve_without_note_still_succeeds():
             assert resp.status_code == 200, resp.text
             assert resp.json()["status"] == "approved", resp.json()
             assert resp.json()["resolution_note"] is None, resp.json()
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── AC2(페드루 PO 처방, 2026-08-16) — 근거 열람(evidence_viewed)도 note와 같은 자리에서
+# 서버 강제. FE는 GateSignatureApproval의 canSign(evidenceViewed&&reason)이 버튼을 막아
+# "화면상"으로만 강제하고 있었다 — AC1의 note와 동일한 API 직접호출 우회가 가능했다.
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_high_risk_approve_with_note_but_no_evidence_viewed_422_and_no_mutation():
+    """note는 실어도 evidence_viewed를 안 보내면(기본값 False) 422 — AC1(note)만으론 우회
+    막이가 반쪽이었다는 것을 그대로 보인다. 뮤테이션 0 확인(재조회)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded, gate_id = await _seed_gate(
+                s, posture="conservative", gate_type="pr_review", story_title="근거미확인 승인 시도",
+            )
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "approved", "note": "사유는 적었지만 근거는 안 봤다"},
+            )
+            assert resp.status_code == 422, resp.text
+            assert "근거 열람" in resp.json()["error"]["message"], resp.json()
+
+            recheck = await client.get(f"/api/v2/gates/{gate_id}")
+            assert recheck.status_code == 200, recheck.text
+            body = recheck.json()
+            assert body["status"] == "pending", body
+            assert body["resolution_note"] is None, body
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_high_risk_approve_with_note_and_evidence_viewed_true_persists():
+    """note + evidence_viewed:true 둘 다 실으면(FE 서명 플로우가 실제로 보내는 형태) 200·저장."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded, gate_id = await _seed_gate(
+                s, posture="conservative", gate_type="pr_review", story_title="근거확인 승인",
+            )
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            note = "PR diff + CI green + 근거 패널 확인 후 승인"
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "approved", "note": note, "evidence_viewed": True},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] == "approved", resp.json()
+            assert resp.json()["resolution_note"] == note, resp.json()
+
+            recheck = await client.get(f"/api/v2/gates/{gate_id}")
+            assert recheck.status_code == 200, recheck.text
+            assert recheck.json()["status"] == "approved", recheck.json()
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_low_risk_approve_without_evidence_viewed_still_succeeds():
+    """저위험은 evidence_viewed 없이도(기본값 False) 기존대로 200 — AC4 과도 강제 금지가
+    note뿐 아니라 evidence_viewed에도 동일하게 적용됨을 고정."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded, gate_id = await _seed_gate(
+                s, posture="permissive", gate_type="merge", story_title="저위험 승인(근거미확인)",
+            )
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition", json={"status": "approved"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] == "approved", resp.json()
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_2082_artifact_canonicalize_gate_inbox.py
+++ b/backend/tests/test_2082_artifact_canonicalize_gate_inbox.py
@@ -234,10 +234,10 @@ async def test_realdb_artifact_canonicalize_gate_approve_processes_server_side()
             ):
                 resp = await client.post(
                     f"/api/v2/gates/{gate_id}/transition",
-                    # note는 risk_grade=high 게이트 타입의 approve 서버측 강제 사유(story #2027)를
-                    # 무해하게 만족시키기 위함 — 이 테스트의 검증 대상(project_id 배치 해소 회귀)과
-                    # 무관한 별개 정책이라 우회하지 않고 그냥 채운다.
-                    json={"status": "approved", "note": "test approve"},
+                    # note+evidence_viewed는 risk_grade=high 게이트 타입의 approve 서버측 강제
+                    # (story #2027 AC1/AC2)를 무해하게 만족시키기 위함 — 이 테스트의 검증 대상
+                    # (project_id 배치 해소 회귀)과 무관한 별개 정책이라 우회하지 않고 그냥 채운다.
+                    json={"status": "approved", "note": "test approve", "evidence_viewed": True},
                 )
             assert resp.status_code == 200, resp.text
             assert resp.json()["status"] == "approved"

--- a/backend/tests/test_2198_non_doc_gate_authz_realdb.py
+++ b/backend/tests/test_2198_non_doc_gate_authz_realdb.py
@@ -166,7 +166,9 @@ async def test_transition_non_doc_gate_forbidden_for_member_allowed_for_owner():
         # 자격자(project owner) → 승인 성공.
         async with Session() as s:
             resp = await transition_gate_endpoint(
-                id=gate_id, body=GateTransitionRequest(status="approved", note="승인 사유"),
+                # story #2027 AC2: note+evidence_viewed 동봉 — 이 파일의 관심사(#2198 인가)와
+                # 무관한 고위험 사유-강제 가드를 우회.
+                id=gate_id, body=GateTransitionRequest(status="approved", note="승인 사유", evidence_viewed=True),
                 background_tasks=BackgroundTasks(), session=s, org_id=ORG, auth=_auth(OWNER_USER),
             )
         assert resp.status == "approved"
@@ -215,7 +217,9 @@ async def test_transition_doc_approval_gate_still_unaffected():
             gate_id = gate.id
         async with Session() as s:
             resp = await transition_gate_endpoint(
-                id=gate_id, body=GateTransitionRequest(status="approved", note="doc 승인"),
+                # story #2027 AC2: note+evidence_viewed 동봉 — 이 파일의 관심사(#2198 인가)와
+                # 무관한 고위험 사유-강제 가드를 우회.
+                id=gate_id, body=GateTransitionRequest(status="approved", note="doc 승인", evidence_viewed=True),
                 background_tasks=BackgroundTasks(), session=s, org_id=ORG, auth=_auth(OWNER_USER),
             )
         assert resp.status == "approved"  # doc_approval 경로는 #2198 변경으로 인한 영향 0.
@@ -272,7 +276,9 @@ async def test_transition_artifact_canonicalize_gate_human_only_not_project_owne
             gate_id_holder["id"] = gate.id
         async with Session() as s:
             resp = await transition_gate_endpoint(
-                id=gate_id_holder["id"], body=GateTransitionRequest(status="approved", note="정본화 승인"),
+                # story #2027 AC2: note+evidence_viewed 동봉 — 이 파일의 관심사(#2198 인가)와
+                # 무관한 고위험 사유-강제 가드를 우회.
+                id=gate_id_holder["id"], body=GateTransitionRequest(status="approved", note="정본화 승인", evidence_viewed=True),
                 background_tasks=BackgroundTasks(), session=s, org_id=ORG, auth=_auth(MEMBER_USER),
             )
         assert resp.status == "approved"

--- a/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
+++ b/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
@@ -176,9 +176,9 @@ async def test_transition_gate_endpoint_wakes_after_commit(monkeypatch):
                  patch("app.services.conversation_webhook.deliver_injected_event_webhook", _fake_deliver):
                 bg = BackgroundTasks()
                 # story #2027: gate_type="custom_review"는 risk 매트릭스 폴백(미분류→고위험)이라
-                # 이 파일의 관심사(wake 배선)와 무관한 사유-강제 가드를 note로 우회.
+                # 이 파일의 관심사(wake 배선)와 무관한 사유-강제 가드를 note+evidence_viewed로 우회.
                 await transition_gate_endpoint(
-                    id=seeded["gate"], body=GateTransitionRequest(status="approved", note="테스트 사유"),
+                    id=seeded["gate"], body=GateTransitionRequest(status="approved", note="테스트 사유", evidence_viewed=True),
                     background_tasks=bg,
                     session=s2, org_id=seeded["org"],
                     auth=type("A", (), {"user_id": str(uuid.uuid4())})(),

--- a/backend/tests/test_e_canvas_c4_s8_canonicalize_realdb.py
+++ b/backend/tests/test_e_canvas_c4_s8_canonicalize_realdb.py
@@ -247,11 +247,12 @@ async def test_approve_sets_anchor_version_and_notifies_creator():
         await _setup_transition_app(app, Session, seeded["org_id"], seeded["approver_user_id"])
         client = _client_for(app)
         try:
-            # story #2027: gate_type="artifact_canonicalize"는 risk 매트릭스 폴백(미분류→고위험)이라
-            # 이 파일의 관심사(anchor_version 배선)와 무관한 사유-강제 가드를 note로 우회.
+            # story #2027 AC1/AC2: gate_type="artifact_canonicalize"는 risk 매트릭스 폴백
+            # (미분류→고위험)이라 이 파일의 관심사(anchor_version 배선)와 무관한 사유-강제
+            # 가드를 note+evidence_viewed로 우회.
             resp = await client.post(
                 f"/api/v2/gates/{gate_id}/transition",
-                json={"status": "approved", "note": "테스트 사유"},
+                json={"status": "approved", "note": "테스트 사유", "evidence_viewed": True},
             )
             assert resp.status_code == 200, resp.text
         finally:

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -43,8 +43,8 @@ async def test_gate_transition_forces_resolver_id_to_caller(monkeypatch):
     monkeypatch.setattr(gm, "transition_gate", _fake_transition)
     monkeypatch.setattr(gm.GateResponse, "model_validate", staticmethod(lambda g: g))
     # story #2027: gate_type="merge"는 risk 매트릭스상 고위험(_HIGH_RISK_GATE_TYPES)이라 이 파일의
-    # 관심사(resolver_id 강제)와 무관한 사유-강제 가드를 note로 우회.
-    body = gm.GateTransitionRequest(status="approved", resolver_id=spoofed, note="테스트 사유")
+    # 관심사(resolver_id 강제)와 무관한 사유-강제 가드를 note+evidence_viewed로 우회.
+    body = gm.GateTransitionRequest(status="approved", resolver_id=spoofed, note="테스트 사유", evidence_viewed=True)
     # 48f064e5: 엔드포인트가 doc-gate authz용 게이트 로드 → 비-doc 게이트 반환으로 그 분기 skip.
     _sess = AsyncMock()
     _gr = MagicMock()

--- a/backend/tests/test_gate_can_approve_48f064e5.py
+++ b/backend/tests/test_gate_can_approve_48f064e5.py
@@ -68,9 +68,9 @@ async def _call(resolved, *, execute_results, has_access=None, status="approved"
         for p in patches:
             stack.enter_context(p)
         result = await transition_gate_endpoint(
-            # note 동봉: risk_grade 폴백(미분류 gate_type→고위험)이 이 authz 테스트의 관심사가
-            # 아닌 사유-강제 가드에 걸리지 않도록.
-            id=uuid.uuid4(), body=GateTransitionRequest(status=status, note="테스트 사유"),
+            # note+evidence_viewed 동봉: risk_grade 폴백(미분류 gate_type→고위험)이 이 authz
+            # 테스트의 관심사가 아닌 사유-강제 가드(story #2027 AC1/AC2)에 걸리지 않도록.
+            id=uuid.uuid4(), body=GateTransitionRequest(status=status, note="테스트 사유", evidence_viewed=True),
             background_tasks=BackgroundTasks(),
             session=session, org_id=uuid.uuid4(), auth=auth,
         )

--- a/backend/tests/test_gate_transition_human_only.py
+++ b/backend/tests/test_gate_transition_human_only.py
@@ -32,10 +32,11 @@ def _resolved(member_type: str) -> ResolvedMember:
 
 async def _call(status: str, member_type: str):
     org_id = uuid.uuid4()
-    # story #2027: note 동봉 — 이 테스트는 휴먼/에이전트 authz만 검증(risk_grade 무관). note 없으면
-    # gate_type="merge_approval"이 risk 매트릭스 두 세트 어디에도 없어 폴백(보수적 고위험)으로 떨어져
-    # approve 가 새 사유-강제 가드에 걸린다 — 이 파일의 관심사가 아니므로 note 로 그 분기를 우회한다.
-    body = GateTransitionRequest(status=status, resolver_id=uuid.uuid4(), note="테스트 사유")
+    # story #2027: note+evidence_viewed 동봉 — 이 테스트는 휴먼/에이전트 authz만 검증(risk_grade
+    # 무관). 둘 다 없으면 gate_type="merge_approval"이 risk 매트릭스 두 세트 어디에도 없어 폴백
+    # (보수적 고위험)으로 떨어져 approve 가 새 사유-강제 가드(AC1/AC2)에 걸린다 — 이 파일의
+    # 관심사가 아니므로 둘 다 채워 그 분기를 우회한다.
+    body = GateTransitionRequest(status=status, resolver_id=uuid.uuid4(), note="테스트 사유", evidence_viewed=True)
     session = AsyncMock()
     # 48f064e5: 엔드포인트가 doc-gate authz용 게이트 로드 → 비-doc 게이트 반환(merge 등)으로 그 분기 skip.
     # #2198: non-doc 분기가 work_item_type/work_item_id 를 읽으므로 SimpleNamespace 에 명시(누락

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -76,9 +76,9 @@ async def test_transition_forces_resolver_ignoring_body():
          patch.object(mod, "transition_gate", _fake_transition), \
          patch.object(mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)):
         # story #2027: _non_doc_gate_session()의 gate_type="merge"는 고위험(_HIGH_RISK_GATE_TYPES)이라
-        # 이 파일의 관심사(resolver_id 강제)와 무관한 사유-강제 가드를 note로 우회.
+        # 이 파일의 관심사(resolver_id 강제)와 무관한 사유-강제 가드를 note+evidence_viewed로 우회.
         await transition_gate_endpoint(
-            id=uuid.uuid4(), body=GateTransitionRequest(status="approved", resolver_id=forged, note="테스트 사유"),
+            id=uuid.uuid4(), body=GateTransitionRequest(status="approved", resolver_id=forged, note="테스트 사유", evidence_viewed=True),
             background_tasks=BackgroundTasks(),
             session=_non_doc_gate_session(), org_id=uuid.uuid4(),
             auth=SimpleNamespace(user_id=str(uuid.uuid4())))


### PR DESCRIPTION
## 무엇을 왜

story #2027 AC1(사유 note 서버 강제)은 이미 랜딩됐다. AC2 — "근거 열람" 요건은
`GateSignatureApproval`의 `canSign = evidenceViewed && reason.trim()` 버튼 disable로만
있었고 서버는 무검증이었다. note는 이제 강제되지만, `POST /gates/{id}/transition`을
직접 호출하면 note만 채우고 evidence_viewed 없이도 고위험 게이트가 그대로 승인됐다 —
AC1이 우회의 절반만 막은 상태.

## 이번 PR에서 한 일

**BE**
- `GateTransitionRequest`에 `evidence_viewed: bool = False` 추가.
- `transition_gate_endpoint`의 note 강제 블록(risk_grade=='high' && status=='approved')
  바로 아래, 같은 조건에서 `evidence_viewed is not True`면 422 — AC1과 동일한 자리·동일
  관례(신규 규칙 아님). 서버가 실제 열람을 관측할 수는 없지만(클라이언트 선언 신뢰), 최소한
  "안 보냈다"=기본값 False로 API 직접호출 우회를 막는다.

**FE (같은 PR로 묶은 이유는 아래 "배포 순서" 참조)**
- `gates/[id]/page.tsx`·`approval-request-card.tsx` 둘 다 `GateSignatureApproval`을
  공유 재사용하는데, 그 컴포넌트의 `onApprove(reason)`은 canSign(evidenceViewed 확인됨)을
  통과해야만 호출된다 — 그 사실 자체가 열람 확인이므로, 두 소비처의 `onApprove` wrapper에서
  `evidence_viewed: true`를 실어 보낸다. 저위험 플레인 버튼 경로는 그대로 안 보냄(기본
  False, 저위험은 검사 자체가 없어 무관 — AC4).

## 배포 순서 판단 (페드루 PO 지시)

BE만 먼저 배포하면 FE가 아직 evidence_viewed를 안 보내 **고위험 서명 승인 전체가 422로
깨진다**(라이브 dogfood 중인 기능) — FE 커밋을 같은 PR에 묶거나 FE가 먼저 합의해야 한다는
선택지 중, 이 레포에 BE/FE가 같이 있어 **같은 PR로 묶는 쪽**을 택했다(회귀 창 자체를
없앰).

## 테스트

- [x] `tests/test_2027_gate_approval_reason_enforce.py`(BE, 실 PG) — 신규 3건(note 있어도
  evidence_viewed 없으면 422+뮤테이션 0, 둘 다 있으면 200+저장, 저위험은 여전히 둘 다 없이
  통과) + 기존 AC1 테스트 시그니처 갱신(evidence_viewed 동반). mutation-kill: BE 체크
  제거→RED 확인 후 원복.
- [x] 인접 회귀 스윕 — note-only로 고위험 우회하던 기존 테스트 7개(test_2082·test_ccbcd9da·
  test_edg_s23·test_gate_can_approve_48f064e5×2·test_gate_transition_human_only·
  test_rc1_body_trust_actor) 전부 evidence_viewed=True 동반으로 갱신, 전 gate 계열
  81건 통과(깨끗한 alembic-migrated 로컬 PG 기준).
- [x] `gates/[id]/page.test.tsx`(FE, vitest) — 신규 2건: 고위험 서명 플로우(체크박스+사유
  입력 후 클릭)가 실제로 `evidence_viewed:true`를 싣는지, 저위험 플레인 버튼은
  `false`로도 그대로 통과하는지. mutation-kill: wrapper의 `true` 하드코딩 제거→RED
  확인 후 원복. 기존 22건(두 컴포넌트) 무회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)