### PR TITLE
[BE·MCP] list_goals/get_blocked·unassigned_stories/search_docs에 limit·has_more 배선 (story #2428 PR#2)

### DIFF
--- a/backend/sprintable_mcp/tools/analytics.py
+++ b/backend/sprintable_mcp/tools/analytics.py
@@ -20,6 +20,8 @@ class WorkloadInput(SprintableInput):
 
 class SprintFilterInput(SprintableInput):
     sprint_id: str | None = None
+    limit: int | None = None
+    cursor: str | None = None  # 이전 호출의 X-Next-Cursor 헤더 값을 그대로 넘기면 다음 페이지.
 
 
 class OverdueMemberInput(SprintableInput):
@@ -96,7 +98,13 @@ async def get_blocked_stories(args: SprintFilterInput) -> list[TextContent]:
         params: dict = {"project_id": client.require_project_id(), "status": "in-review"}
         if args.sprint_id:
             params["sprint_id"] = args.sprint_id
-        return ok(await client.get("/api/v2/stories", params=params))
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
+        items, headers = await client.get_with_headers("/api/v2/stories", params=params)
+        has_more, next_cursor = _has_more_from_headers(headers, items)
+        return ok_paginated(items, has_more=has_more, next_cursor=next_cursor, tool_name="sprintable_get_blocked_stories")
     except Exception as exc:
         return err(str(exc))
 
@@ -107,7 +115,13 @@ async def get_unassigned_stories(args: SprintFilterInput) -> list[TextContent]:
         params: dict = {"project_id": client.require_project_id(), "unassigned": "true"}
         if args.sprint_id:
             params["sprint_id"] = args.sprint_id
-        return ok(await client.get("/api/v2/stories", params=params))
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
+        items, headers = await client.get_with_headers("/api/v2/stories", params=params)
+        has_more, next_cursor = _has_more_from_headers(headers, items)
+        return ok_paginated(items, has_more=has_more, next_cursor=next_cursor, tool_name="sprintable_get_unassigned_stories")
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/sprintable_mcp/tools/docs.py
+++ b/backend/sprintable_mcp/tools/docs.py
@@ -25,6 +25,7 @@ class GetDocInput(SprintableInput):
 class SearchDocsInput(SprintableInput):
     query: str
     tags: list[str] | None = None
+    limit: int | None = None  # BE search_full_text 분기는 결과 자체가 min(limit, 50)로 상한 — cursor는 없음(관련도순 정렬이라 페이지 이어달리기 불가, 아래 함수 docstring 참조).
 
 
 class CreateDocInput(SprintableInput):
@@ -133,9 +134,23 @@ async def search_docs(args: SearchDocsInput) -> list[TextContent]:
         params: dict = {"project_id": client.require_project_id(), "q": args.query}
         if args.tags:
             params["tags"] = ",".join(args.tags)
+        if args.limit:
+            params["limit"] = args.limit
         result = await client.get("/api/v2/docs", params=params)
         items, _meta = _unwrap_docs_page(result)
-        return ok(items)
+        # has_more는 이 분기에서 BE가 항상 False로 고정해 보낸다(위 docstring) — 그래도 결과가
+        # BE 상한(min(limit,50))에 딱 걸쳤을 수 있어 그 사실만 안내(다음 페이지 제안 아님,
+        # cursor 자체가 없어 "더 좁혀 재검색"만 유효한 다음 수).
+        blocks = ok(items)
+        if args.limit and len(items) >= min(args.limit, 50):
+            blocks.append(TextContent(
+                type="text",
+                text=(
+                    f"※ 결과가 상한({min(args.limit, 50)}건)에 걸쳤을 수 있음 — 이 도구는 cursor를 "
+                    f"지원 안 함(관련도순 정렬이라 페이지 이어달리기 불가). query를 좁혀 재검색할 것."
+                ),
+            ))
+        return blocks
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/sprintable_mcp/tools/goals.py
+++ b/backend/sprintable_mcp/tools/goals.py
@@ -17,12 +17,14 @@ from mcp.types import TextContent
 from pydantic import AliasChoices, ConfigDict, Field
 
 from ..api_client import client
-from ..response import err, ok
+from ..response import err, ok, ok_paginated
 from ..schemas import GoalStatus, SprintableInput, StoryPriority
+from .stories import _has_more_from_headers
 
 
 class ListGoalsInput(SprintableInput):
-    pass
+    limit: int | None = None
+    cursor: str | None = None  # 이전 호출의 X-Next-Cursor 헤더 값을 그대로 넘기면 다음 페이지.
 
 
 class AddGoalInput(SprintableInput):
@@ -62,9 +64,16 @@ class UpdateGoalInput(SprintableInput):
 
 
 async def list_goals(args: ListGoalsInput) -> list[TextContent]:
-    """목표 목록 조회."""
+    """목표 목록 조회(별칭: sprintable_list_epics — 같은 함수, server.py 참고)."""
     try:
-        return ok(await client.get("/api/v2/goals", params={"project_id": client.require_project_id()}))
+        params: dict = {"project_id": client.require_project_id()}
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
+        items, headers = await client.get_with_headers("/api/v2/goals", params=params)
+        has_more, next_cursor = _has_more_from_headers(headers, items)
+        return ok_paginated(items, has_more=has_more, next_cursor=next_cursor, tool_name="sprintable_list_goals")
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/tests/test_2428_pr2_mechanical_5_tools_pagination.py
+++ b/backend/tests/test_2428_pr2_mechanical_5_tools_pagination.py
@@ -1,0 +1,157 @@
+"""story #2428 PR#2 — ① 즉시 가능(BE 이미 준비됨) 5개: list_goals(+alias list_epics 동일 함수)·
+get_blocked_stories·get_unassigned_stories·search_docs.
+
+전부 기존 BE 인프라 재사용(신규 BE 변경 0):
+- list_goals: app/routers/goals.py list_goals가 이미 limit/cursor/X-Total-Count/X-Next-Cursor 보유.
+- get_blocked_stories/get_unassigned_stories: story #2428 PR#1이 이미 고친 GET /api/v2/stories
+  (X-Total-Count/X-Next-Cursor 헤더 규약) 재사용 — stories.py의 _has_more_from_headers 그대로.
+- search_docs: BE search_full_text 분기가 이미 limit(min(limit,50) 상한)을 받는다. cursor는
+  설계상 없음(관련도순 정렬) — has_more 안내 대신 "상한 걸쳤을 수 있음" 문구로 대체.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _headers(total: int, next_cursor: str | None = None) -> dict:
+    h = {"x-total-count": str(total)}
+    if next_cursor is not None:
+        h["x-next-cursor"] = next_cursor
+    return h
+
+
+@pytest.mark.anyio
+async def test_list_goals_signals_has_more_via_headers():
+    from sprintable_mcp.tools.goals import ListGoalsInput, list_goals
+
+    items = [{"id": "g1"}]
+    with patch("sprintable_mcp.tools.goals.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=5, next_cursor="2026-01-01T00:00:00")))
+        out = await list_goals(ListGoalsInput())
+
+    parsed = json.loads(out[0].text)
+    assert parsed == items
+    assert len(out) == 2
+    assert "2026-01-01T00:00:00" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_list_goals_no_has_more_when_covered():
+    from sprintable_mcp.tools.goals import ListGoalsInput, list_goals
+
+    items = [{"id": "g1"}, {"id": "g2"}]
+    with patch("sprintable_mcp.tools.goals.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=2)))
+        out = await list_goals(ListGoalsInput())
+
+    assert len(out) == 1
+
+
+@pytest.mark.anyio
+async def test_list_goals_passes_limit_and_cursor_through():
+    from sprintable_mcp.tools.goals import ListGoalsInput, list_goals
+
+    with patch("sprintable_mcp.tools.goals.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await list_goals(ListGoalsInput(limit=25, cursor="0:abc"))
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["limit"] == 25
+    assert kwargs["params"]["cursor"] == "0:abc"
+
+
+@pytest.mark.anyio
+async def test_get_blocked_stories_signals_has_more():
+    from sprintable_mcp.tools.analytics import SprintFilterInput, get_blocked_stories
+
+    items = [{"id": "s1"}]
+    with patch("sprintable_mcp.tools.analytics.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=9, next_cursor="0:xyz")))
+        out = await get_blocked_stories(SprintFilterInput())
+
+    assert len(out) == 2
+    assert "0:xyz" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_get_unassigned_stories_signals_has_more():
+    from sprintable_mcp.tools.analytics import SprintFilterInput, get_unassigned_stories
+
+    items = [{"id": "s1"}]
+    with patch("sprintable_mcp.tools.analytics.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=9, next_cursor="0:xyz")))
+        out = await get_unassigned_stories(SprintFilterInput())
+
+    assert len(out) == 2
+    assert "0:xyz" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_get_blocked_stories_passes_limit_and_status_filter():
+    from sprintable_mcp.tools.analytics import SprintFilterInput, get_blocked_stories
+
+    with patch("sprintable_mcp.tools.analytics.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await get_blocked_stories(SprintFilterInput(limit=10))
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["limit"] == 10
+    assert kwargs["params"]["status"] == "in-review"
+
+
+@pytest.mark.anyio
+async def test_search_docs_no_cap_warning_when_under_limit():
+    from sprintable_mcp.tools.docs import SearchDocsInput, search_docs
+
+    new_shape = {"data": [{"id": "d1"}], "meta": {"has_more": False, "next_cursor": None}}
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get = AsyncMock(return_value=new_shape)
+        out = await search_docs(SearchDocsInput(query="hello", limit=50))
+
+    parsed = json.loads(out[0].text)
+    assert parsed == new_shape["data"]
+    assert len(out) == 1  # 1건 << limit=50이니 상한 경고 없음
+
+
+@pytest.mark.anyio
+async def test_search_docs_warns_when_result_hits_cap():
+    from sprintable_mcp.tools.docs import SearchDocsInput, search_docs
+
+    items = [{"id": f"d{i}"} for i in range(5)]
+    new_shape = {"data": items, "meta": {"has_more": False, "next_cursor": None}}
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get = AsyncMock(return_value=new_shape)
+        out = await search_docs(SearchDocsInput(query="hello", limit=5))
+
+    assert len(out) == 2
+    assert "상한" in out[1].text
+    assert "cursor" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_search_docs_passes_limit_through():
+    from sprintable_mcp.tools.docs import SearchDocsInput, search_docs
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get = AsyncMock(return_value={"data": [], "meta": {"has_more": False, "next_cursor": None}})
+        await search_docs(SearchDocsInput(query="hello", limit=30))
+
+    _, kwargs = mock_client.get.call_args
+    assert kwargs["params"]["limit"] == 30


### PR DESCRIPTION
## 무엇을 왜

story #2428 PR#1(#3151)이 「시간에 따라 누적되는」 5개 중 3개(list_stories/list_backlog/
search_stories)를 먼저 처리했다. 페드루 지시로 나머지 16개를 그라운딩한 결과 — "같은 병
(21개)"이지만 처방은 하나가 아니었다:

- ① BE가 이미 준비돼 있어 MCP 배선만으로 끝나는 것
- ② BE 자체에 limit/total 인프라가 없어 신규 배선이 필요한 것(project 전체 무제한 위험군
  vs caller당 자연상한군으로 다시 갈림 — poll_events/get_overdue_tasks와 같은 부류)

이 PR은 ①의 5개(실질 3개 구현 + list_epics는 list_goals의 별칭이라 자동 포함)만 가른다.
②(11개)는 스코프 밖 — 아래 "미룬 것" 참조.

## 이번 PR에서 한 일

- **`list_goals`**(별칭 `list_epics` — server.py에서 같은 함수 재사용, 로직 복제 0):
  `app/routers/goals.py`의 `list_goals`가 story #1200 근절 작업으로 이미 `limit`/`cursor`/
  `X-Total-Count`/`X-Next-Cursor`를 보유 — story #2428 PR#1의 `_has_more_from_headers`를
  그대로 재사용(같은 헤더 계약, stories.py와 동형).
- **`get_blocked_stories`/`get_unassigned_stories`**: 둘 다 `GET /api/v2/stories`의 얇은
  필터 래핑(status=in-review / unassigned=true)이라, PR#1이 이미 그 엔드포인트에 심은
  X-Total-Count/X-Next-Cursor의 덕을 자동으로 본다 — `limit`/`cursor` 인자 추가 + has_more
  배선만.
- **`search_docs`**: BE `search_full_text` 분기가 이미 `limit`(내부적으로 `min(limit,50)`
  상한)을 받는다. cursor는 설계상 없음(관련도순 정렬이라 페이지 이어달리기 불가 — #2191
  기존 결정, `list_docs`의 body-cursor 규약과 무관) — `has_more` 안내 대신 "결과가 상한에
  걸쳤을 수 있음 — query를 좁혀 재검색" 문구로 그 한계를 정직하게 알린다.

## 미룬 것 (story #2428 설명에도 전문 기재, PO 확定)

11개 — 페드루 지시로 착수 시점(다음 PR)에 표로 재분류 예정:
- **ⓐ 무제한 위험 실재**(project 전체 무한 성장, BE limit/total 신설 필요) — `list_tasks`·
  `list_my_tasks`(`get_overdue_tasks`와 같은 `/api/v2/tasks`, 이미 걸려 있던 이유 그대로
  공유)·`list_sprints`·`list_artifacts`·`list_retro_sessions`.
- **ⓑ 자연상한 후보**(caller/artifact/day 단위로 이미 소수건, `standup_missing` 판례처럼
  「상한 근거 명시 후 안 짓는다」로 닫을 가능성) — `list_team_members`·`list_projects`·
  `list_webhook_configs`·`list_spec_pins`·`list_standup_entries`·`list_artifact_comments`
  (limit=50 기본값은 있으나 total/has_more 없음, ⓐ/ⓑ 경계 사례).

## 테스트

- [x] `tests/test_2428_pr2_mechanical_5_tools_pagination.py`(신규) — 9건: `list_goals`
  has_more/limit·cursor 통과 3건, `get_blocked_stories`/`get_unassigned_stories` has_more
  2건 + limit·필터 유지 1건, `search_docs` 상한-경고 유/무 2건 + limit 통과 1건.
  mutation-kill: `search_docs`의 상한-경고 조건 제거→RED 확인 후 원복(BE 헤더 기반
  has_more 판정은 PR#1에서 이미 mutation-kill 검증된 `_has_more_from_headers` 그대로
  재사용이라 재검증 생략).
- [x] 인접 회귀 스윕(로컬, MCP tools/goals·docs·analytics·stories 소비 테스트 10개 파일,
  79건) — 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)