### PR TITLE
[BE·MCP] tasks 3-way 공유 엔드포인트 limit·has_more 배선 (story #2428 PR③, ⓐ 착수)

### DIFF
--- a/backend/app/repositories/task.py
+++ b/backend/app/repositories/task.py
@@ -1,6 +1,7 @@
 import uuid
+from datetime import datetime
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.pm import Story, Task
@@ -17,26 +18,48 @@ class TaskRepository(BaseRepository[Task]):
         *,
         assignee_id: uuid.UUID | None = None,
         status: str | None = None,
-        limit: int = 1000,
-    ) -> list[Task]:
+        status_ne: str | None = None,
+        limit: int | None = None,
+        cursor: datetime | None = None,
+    ) -> tuple[list[Task], int]:
         """d3e5ca89(SEC fast-follow): org-wide task 조회를 caller 접근권 project 집합으로
         result-level 스코프. Task엔 project_id 컬럼이 없어(story_id NN) Story JOIN으로 project를
         환원한다. project_ids가 비면(접근권 0개) 빈 리스트 — org 전체 task title/assignee_id/
-        status가 새던 result-level 누출을 봉인. assignee_id/status는 추가 narrowing 필터."""
+        status가 새던 result-level 누출을 봉인. assignee_id/status는 추가 narrowing 필터.
+
+        story #2428 PR③(⓪tasks ⓐ, 라이브 실측 667건): (tasks, total)로 확장 — goals.py
+        list_goals의 «필터 適用 後·limit 適用 前 COUNT + cursor(created_at)» 규약 그대로
+        (새 규약 발명 0). JOIN이 있어 BaseRepository.list_paginated()의 범용 `**filters`
+        (단순 동등비교만 지원)로는 대체 불가해 이 메서드 자체를 확장한다.
+
+        status_ne: get_overdue_tasks MCP 도구가 이미 `status_ne=done`을 보내고 있었으나
+        (sprintable_mcp/tools/analytics.py) 이 라우터가 그 파라미터를 아예 안 받아 FastAPI가
+        조용히 버렸다(완료 포함 전체가 나가던 기존 결함 — 이번 PR로 실제 배선)."""
         if not project_ids:
-            return []
+            return [], 0
+        conds = [
+            self._org_filter(),
+            Task.deleted_at.is_(None),
+            Story.project_id.in_(project_ids),
+        ]
+        if assignee_id is not None:
+            conds.append(Task.assignee_id == assignee_id)
+        if status is not None:
+            conds.append(Task.status == status)
+        if status_ne is not None:
+            conds.append(Task.status != status_ne)
+
+        count_q = select(func.count()).select_from(Task).join(Story, Story.id == Task.story_id).where(*conds)
+        total = int((await self.session.execute(count_q)).scalar_one() or 0)
+
         q = (
             select(Task)
             .join(Story, Story.id == Task.story_id)
-            .where(
-                self._org_filter(),
-                Task.deleted_at.is_(None),
-                Story.project_id.in_(project_ids),
-            )
+            .where(*conds)
+            .order_by(Task.created_at.desc(), Task.id.desc())
         )
-        if assignee_id is not None:
-            q = q.where(Task.assignee_id == assignee_id)
-        if status is not None:
-            q = q.where(Task.status == status)
-        result = await self.session.execute(q.limit(limit))
-        return list(result.scalars().all())
+        if cursor is not None:
+            q = q.where(Task.created_at < cursor)
+        q = q.limit(limit if limit is not None else 1000)
+        result = await self.session.execute(q)
+        return list(result.scalars().all()), total

--- a/backend/app/repositories/task.py
+++ b/backend/app/repositories/task.py
@@ -27,10 +27,15 @@ class TaskRepository(BaseRepository[Task]):
         환원한다. project_ids가 비면(접근권 0개) 빈 리스트 — org 전체 task title/assignee_id/
         status가 새던 result-level 누출을 봉인. assignee_id/status는 추가 narrowing 필터.
 
-        story #2428 PR③(⓪tasks ⓐ, 라이브 실측 667건): (tasks, total)로 확장 — goals.py
-        list_goals의 «필터 適用 後·limit 適用 前 COUNT + cursor(created_at)» 규약 그대로
-        (새 규약 발명 0). JOIN이 있어 BaseRepository.list_paginated()의 범용 `**filters`
-        (단순 동등비교만 지원)로는 대체 불가해 이 메서드 자체를 확장한다.
+        story #2428 PR③(⓪tasks ⓐ, 라이브 실측 667건): (tasks, total)로 확장 —
+        story.py::list()가 세운 규약(#2537 docstring: "count는 필터 適用 後·limit 適用 前
+        계산 — cursor 필터까지 포함해야 「이 필터 조건에서 남은 전체 건수」가 정확하다")
+        그대로(새 규약 발명 0). ⚠️페드루 AC 리뷰(2026-08-17) 지적 — 최초 구현은 cursor를
+        count_q 앞에 안 넣어 2페이지째부터 total이 «cursor 이전 포함 grand total»로
+        고정돼 마지막 페이지에서도 has_more=True가 영구 참이 되는 결함이었다(BaseRepository.
+        list_paginated()의 "페이지 무관 grand total" 시맨틱을 무심코 따라간 것 — 이 메서드는
+        JOIN이 있어 그 범용 메서드를 안 쓰므로 story.py 규약을 직접 재현해야 했다). cursor를
+        conds에 포함시켜 count_q/q 둘 다 같은 조건을 보게 고쳤다.
 
         status_ne: get_overdue_tasks MCP 도구가 이미 `status_ne=done`을 보내고 있었으나
         (sprintable_mcp/tools/analytics.py) 이 라우터가 그 파라미터를 아예 안 받아 FastAPI가
@@ -48,6 +53,8 @@ class TaskRepository(BaseRepository[Task]):
             conds.append(Task.status == status)
         if status_ne is not None:
             conds.append(Task.status != status_ne)
+        if cursor is not None:
+            conds.append(Task.created_at < cursor)
 
         count_q = select(func.count()).select_from(Task).join(Story, Story.id == Task.story_id).where(*conds)
         total = int((await self.session.execute(count_q)).scalar_one() or 0)
@@ -57,9 +64,7 @@ class TaskRepository(BaseRepository[Task]):
             .join(Story, Story.id == Task.story_id)
             .where(*conds)
             .order_by(Task.created_at.desc(), Task.id.desc())
+            .limit(limit if limit is not None else 1000)
         )
-        if cursor is not None:
-            q = q.where(Task.created_at < cursor)
-        q = q.limit(limit if limit is not None else 1000)
         result = await self.session.execute(q)
         return list(result.scalars().all()), total

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -1,6 +1,7 @@
 import uuid
+from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -101,11 +102,19 @@ async def list_tasks(
     story_id: uuid.UUID | None = Query(default=None),
     assignee_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
+    status_ne: str | None = Query(default=None, description="이 status가 아닌 것만(예: done 제외 — 미완료 목록, get_overdue_tasks가 사용)"),
     ids: str | None = Query(default=None, description="comma-separated task ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관, story #2262 PR② 칩 상태 배치조회)"),
+    limit: int | None = Query(default=None, ge=1, le=2000),
+    cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch before this time"),
+    response: Response = None,  # type: ignore[assignment]
     repo: TaskRepository = Depends(_get_repo_read),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> list[TaskResponse]:
+    """story #2428 PR③(⓪tasks ⓐ — 라이브 실측 667건, list_tasks/list_my_tasks/get_overdue_tasks
+    3-way 공유 엔드포인트): true cursor 페이지네이션 + 전체 카운트(X-Total-Count 헤더) —
+    goals.py list_goals와 동일 규약(필터 適用 後·limit 適用 前 COUNT, cursor=created_at, 새
+    규약 발명 0). limit 미지정 시 기존 동작(최대 1000)과 호환."""
     # story #2262 PR②(칩 상태 배치조회) — stories.py list_stories의 ids= 패턴 미러링. Task엔
     # project_id 컬럼이 없어(story_id NN) list_in_projects와 동형으로 Story JOIN을 거쳐야
     # 접근권 스코프를 낼 수 있다 — repo.list_by_ids(org-scope만)로 앵커 조회 後, 결과의
@@ -139,6 +148,15 @@ async def list_tasks(
         await _attach_org_project_slugs(repo.session, org_id, tasks)
         return [TaskResponse.model_validate(t) for t in tasks]
 
+    cursor_dt: datetime | None = None
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except (ValueError, TypeError) as exc:
+            raise HTTPException(
+                status_code=400, detail="invalid cursor: expected ISO 8601 datetime"
+            ) from exc
+
     # story_id 지정 시: round6(#2072)에서 _assert_task_project_access(기존 G-fix 재사용)로
     # caller의 story project 접근권을 직접 검증(단일 story 스코프).
     if story_id is not None:
@@ -148,7 +166,7 @@ async def list_tasks(
             filters["assignee_id"] = assignee_id
         if status_filter:
             filters["status"] = status_filter
-        tasks = await repo.list(**filters)
+        tasks, total = await repo.list_paginated(limit=limit, cursor=cursor_dt, **filters)
     else:
         # d3e5ca89(SEC fast-follow): story_id 미지정(org-wide) 분기는 예전엔 org 전체 task를
         # result-level로 흘렸다 — 같은 org 다른 project의 task title/assignee_id/status를 접근권
@@ -160,11 +178,16 @@ async def list_tasks(
         accessible = await accessible_project_ids_in_org(
             repo.session, uuid.UUID(auth.user_id), org_id
         )
-        tasks = await repo.list_in_projects(
-            accessible, assignee_id=assignee_id, status=status_filter
+        tasks, total = await repo.list_in_projects(
+            accessible, assignee_id=assignee_id, status=status_filter, status_ne=status_ne,
+            limit=limit, cursor=cursor_dt,
         )
     await _attach_has_evidence(repo.session, tasks)
     await _attach_org_project_slugs(repo.session, org_id, tasks)
+    if response is not None:
+        response.headers["X-Total-Count"] = str(total)
+        if tasks:
+            response.headers["X-Next-Cursor"] = tasks[-1].created_at.isoformat()
     return [TaskResponse.model_validate(t) for t in tasks]
 
 

--- a/backend/sprintable_mcp/tools/analytics.py
+++ b/backend/sprintable_mcp/tools/analytics.py
@@ -24,6 +24,8 @@ class SprintFilterInput(SprintableInput):
 
 class OverdueMemberInput(SprintableInput):
     member_id: str | None = None
+    limit: int | None = None
+    cursor: str | None = None  # 이전 호출의 X-Next-Cursor 헤더 값을 그대로 넘기면 다음 페이지.
 
 
 class ActivityInput(SprintableInput):
@@ -113,12 +115,23 @@ async def get_unassigned_stories(args: SprintFilterInput) -> list[TextContent]:
 
 
 async def get_overdue_tasks(args: OverdueMemberInput) -> list[TextContent]:
-    """미완료 태스크 목록."""
+    """미완료 태스크 목록.
+
+    story #2428 PR③ 부수발견: `status_ne=done`은 이 도구가 늘 보내고 있었으나 BE
+    `GET /api/v2/tasks`가 그 파라미터를 아예 안 받아(FastAPI가 조용히 버림) 완료
+    포함 전체가 나가던 결함이었다 — 이번 PR에서 라우터에 status_ne를 실제로 배선해
+    바로잡음(app/routers/tasks.py)."""
     try:
         params: dict = {"project_id": client.require_project_id(), "status_ne": "done"}
         if args.member_id:
             params["assignee_id"] = args.member_id
-        return ok(await client.get("/api/v2/tasks", params=params))
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
+        items, headers = await client.get_with_headers("/api/v2/tasks", params=params)
+        has_more, next_cursor = _has_more_from_headers(headers, items)
+        return ok_paginated(items, has_more=has_more, next_cursor=next_cursor, tool_name="sprintable_get_overdue_tasks")
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/sprintable_mcp/tools/core.py
+++ b/backend/sprintable_mcp/tools/core.py
@@ -26,7 +26,8 @@ class UnlockFilesInput(SprintableInput):
 
 
 async def list_team_members(args: SprintableInput) -> list[TextContent]:
-    """프로젝트 팀 멤버 목록 조회."""
+    """프로젝트 팀 멤버 목록 조회. story #2428 ⓑ: limit 없음(의도) — 팀 로스터 크기가
+    자연 상한(standup_missing과 동형 축, 페드루 확定 2026-08-17)."""
     try:
         params: dict = {"project_id": client.require_project_id()}
         return ok(await client.get("/api/v2/members", params=params))

--- a/backend/sprintable_mcp/tools/projects.py
+++ b/backend/sprintable_mcp/tools/projects.py
@@ -19,7 +19,9 @@ class ListProjectsInput(BaseModel):
 
 async def list_projects(_args: ListProjectsInput) -> list:
     """caller 키(member)가 접근 가능한 프로젝트 열거(id·이름·org) — 무권한/타조직 프로젝트는
-    미노출(존재 유출 오라클 0). 신규 BE 로직 0 — 기존 GET /api/v2/projects(정책B) 얇은 래핑."""
+    미노출(존재 유출 오라클 0). 신규 BE 로직 0 — 기존 GET /api/v2/projects(정책B) 얇은 래핑.
+    story #2428 ⓑ: limit 없음(의도) — org당 프로젝트 개수가 자연 상한(standup_missing과
+    동형 축, 페드루 확定 2026-08-17)."""
     try:
         result = await client.get("/api/v2/projects")
         return ok(result)

--- a/backend/sprintable_mcp/tools/standup.py
+++ b/backend/sprintable_mcp/tools/standup.py
@@ -109,7 +109,8 @@ async def save_standup(args: SaveStandupInput) -> list[TextContent]:
 
 
 async def list_standup_entries(args: ListStandupEntriesInput) -> list[TextContent]:
-    """날짜 기준 스탠드업 목록 조회."""
+    """날짜 기준 스탠드업 목록 조회. story #2428 ⓑ: limit 없음(의도) — (project×특정 날짜)
+    조합이라 standup_missing과 완전 동형 축으로 자연 상한(페드루 확定 2026-08-17)."""
     try:
         return ok(await client.get("/api/v2/standups", params={"project_id": client.require_project_id(), "date": args.date}))
     except Exception as exc:

--- a/backend/sprintable_mcp/tools/tasks.py
+++ b/backend/sprintable_mcp/tools/tasks.py
@@ -5,18 +5,23 @@ from __future__ import annotations
 from mcp.types import TextContent
 
 from ..api_client import client
-from ..response import err, ok
+from ..response import err, ok, ok_paginated
 from ..schemas import SprintableInput, TaskStatus
+from .stories import _has_more_from_headers
 
 
 class ListTasksInput(SprintableInput):
     story_id: str | None = None
     assignee_id: str | None = None
     status: TaskStatus | None = None
+    limit: int | None = None
+    cursor: str | None = None  # 이전 호출의 X-Next-Cursor 헤더 값을 그대로 넘기면 다음 페이지.
 
 
 class ListMyTasksInput(SprintableInput):
     assignee_id: str | None = None
+    limit: int | None = None
+    cursor: str | None = None
 
 
 class GetTaskInput(SprintableInput):
@@ -53,7 +58,13 @@ async def list_tasks(args: ListTasksInput) -> list[TextContent]:
             params["assignee_id"] = args.assignee_id
         if args.status:
             params["status"] = args.status.value
-        return ok(await client.get("/api/v2/tasks", params=params))
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
+        items, headers = await client.get_with_headers("/api/v2/tasks", params=params)
+        has_more, next_cursor = _has_more_from_headers(headers, items)
+        return ok_paginated(items, has_more=has_more, next_cursor=next_cursor, tool_name="sprintable_list_tasks")
     except Exception as exc:
         return err(str(exc))
 
@@ -63,7 +74,13 @@ async def list_my_tasks(args: ListMyTasksInput) -> list[TextContent]:
     try:
         assignee = args.assignee_id or client.member_id
         params: dict = {"assignee_id": assignee, "project_id": client.require_project_id()}
-        return ok(await client.get("/api/v2/tasks", params=params))
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
+        items, headers = await client.get_with_headers("/api/v2/tasks", params=params)
+        has_more, next_cursor = _has_more_from_headers(headers, items)
+        return ok_paginated(items, has_more=has_more, next_cursor=next_cursor, tool_name="sprintable_list_my_tasks")
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -239,7 +239,8 @@ async def edit_artifact(args: EditArtifactInput) -> list[TextContent]:
 
 async def list_spec_pins(args: ListSpecPinsInput) -> list[TextContent]:
     """artifact 최신 버전의 스펙 핀 목록 조회(description pane 저작 대상) — 코멘트와 달리
-    작성자/시간 속성 없음(감시금지)."""
+    작성자/시간 속성 없음(감시금지). story #2428 ⓑ: limit 없음(의도) — 「최신 버전」 단건
+    스코프라 그 버전 스펙 분량으로 자연 상한(standup_missing과 동형 축, 페드루 확定 2026-08-17)."""
     try:
         result = await client.get(f"/api/v2/visual-artifacts/{args.artifact_id}/pins")
         return ok(result)

--- a/backend/sprintable_mcp/tools/webhooks.py
+++ b/backend/sprintable_mcp/tools/webhooks.py
@@ -27,7 +27,8 @@ class DeleteWebhookConfigInput(SprintableInput):
 
 
 async def list_webhook_configs(args: ListWebhookConfigsInput) -> list[TextContent]:
-    """Webhook config 목록 조회."""
+    """Webhook config 목록 조회. story #2428 ⓑ: limit 없음(의도) — caller-scope(멤버당
+    사실상 1개, upsert 시맨틱)라 자연 상한(standup_missing과 동형 축, 페드루 확定 2026-08-17)."""
     params: dict = {}
     if args.project_id:
         params["project_id"] = args.project_id

--- a/backend/tests/test_2428_pr3_mcp_tasks_pagination.py
+++ b/backend/tests/test_2428_pr3_mcp_tasks_pagination.py
@@ -1,0 +1,96 @@
+"""story #2428 PR③ — list_tasks·list_my_tasks·get_overdue_tasks MCP 배선(3-way 공유
+GET /api/v2/tasks). BE 축(X-Total-Count 실 total·status_ne 실배선)은
+test_2428_pr3_tasks_pagination_realdb.py가 커버 — 여기는 MCP 도구가 헤더를 정확히
+읽어 has_more/limit/cursor를 전달하는지만 mock으로 고정."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _headers(total: int, next_cursor: str | None = None) -> dict:
+    h = {"x-total-count": str(total)}
+    if next_cursor is not None:
+        h["x-next-cursor"] = next_cursor
+    return h
+
+
+@pytest.mark.anyio
+async def test_list_tasks_signals_has_more():
+    from sprintable_mcp.tools.tasks import ListTasksInput, list_tasks
+
+    items = [{"id": "t1"}]
+    with patch("sprintable_mcp.tools.tasks.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=667, next_cursor="0:xyz")))
+        out = await list_tasks(ListTasksInput())
+
+    parsed = json.loads(out[0].text)
+    assert parsed == items
+    assert len(out) == 2
+    assert "0:xyz" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_list_tasks_passes_limit_cursor_through():
+    from sprintable_mcp.tools.tasks import ListTasksInput, list_tasks
+
+    with patch("sprintable_mcp.tools.tasks.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await list_tasks(ListTasksInput(limit=20, cursor="0:abc"))
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["limit"] == 20
+    assert kwargs["params"]["cursor"] == "0:abc"
+
+
+@pytest.mark.anyio
+async def test_list_my_tasks_signals_has_more():
+    from sprintable_mcp.tools.tasks import ListMyTasksInput, list_my_tasks
+
+    items = [{"id": "t1"}]
+    with patch("sprintable_mcp.tools.tasks.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.member_id = "me"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=12, next_cursor="0:xyz")))
+        out = await list_my_tasks(ListMyTasksInput())
+
+    assert len(out) == 2
+    assert "0:xyz" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_get_overdue_tasks_still_sends_status_ne_done_and_signals_has_more():
+    from sprintable_mcp.tools.analytics import OverdueMemberInput, get_overdue_tasks
+
+    items = [{"id": "t1"}]
+    with patch("sprintable_mcp.tools.analytics.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=4, next_cursor="0:xyz")))
+        out = await get_overdue_tasks(OverdueMemberInput())
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["status_ne"] == "done"
+    assert len(out) == 2
+    assert "0:xyz" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_get_overdue_tasks_no_has_more_when_covered():
+    from sprintable_mcp.tools.analytics import OverdueMemberInput, get_overdue_tasks
+
+    items = [{"id": "t1"}, {"id": "t2"}]
+    with patch("sprintable_mcp.tools.analytics.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=2)))
+        out = await get_overdue_tasks(OverdueMemberInput())
+
+    assert len(out) == 1

--- a/backend/tests/test_2428_pr3_tasks_pagination_realdb.py
+++ b/backend/tests/test_2428_pr3_tasks_pagination_realdb.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -97,14 +98,27 @@ async def _seed(session, *, n_todo: int = 3, n_done: int = 2):
     session.add(story)
     await session.commit()
 
+    # 단일 트랜잭션 내 여러 row는 Postgres now()가 전부 동일값이라(server_default=func.now())
+    # created_at 커서 비교(<)가 동일-timestamp 행을 스킵한다 — 명시 override로 결정적 스태거.
+    base = datetime.now(timezone.utc)
+    total = n_todo + n_done
     task_ids = []
+    seq = 0
     for i in range(n_todo):
-        t = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title=f"todo-{i}", status="todo")
+        t = Task(
+            id=uuid.uuid4(), org_id=org.id, story_id=story.id, title=f"todo-{i}", status="todo",
+            created_at=base - timedelta(seconds=total - seq),
+        )
         session.add(t)
         task_ids.append(t.id)
+        seq += 1
     for i in range(n_done):
-        t = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title=f"done-{i}", status="done")
+        t = Task(
+            id=uuid.uuid4(), org_id=org.id, story_id=story.id, title=f"done-{i}", status="done",
+            created_at=base - timedelta(seconds=total - seq),
+        )
         session.add(t)
+        seq += 1
     await session.commit()
 
     caller_id = uuid.uuid4()
@@ -210,6 +224,59 @@ async def test_no_limit_returns_all_and_total_matches_page():
             assert resp.status_code == 200, resp.text
             assert len(resp.json()) == 5
             assert resp.headers["x-total-count"] == "5"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_wide_last_page_x_total_count_matches_remaining_not_grand_total():
+    """페드루 AC 리뷰(2026-08-17) 지적 — count_q가 cursor를 안 보면 마지막 페이지에서도
+    X-Total-Count가 grand total(5)로 고정돼 has_more(=total>len(items))가 영구 참이 된다.
+    5건을 limit=2로 3페이지 끝까지 실제로 걸어(org-wide 분기), 마지막 페이지에서
+    X-Total-Count == len(items)(=has_more False로 정확히 떨어짐)까지 확認한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n_todo=3, n_done=2)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            # sprintable_mcp/tools/stories.py::_has_more_from_headers 규약 그대로 —
+            # X-Next-Cursor는 결과가 있으면 "항상" 실리므로(진짜 다음 페이지 유무와 무관)
+            # 헤더 존재가 아니라 has_more=(X-Total-Count > 이번 페이지 건수)로 멈춘다.
+            seen_ids: set[str] = set()
+            cursor = None
+            pages = 0
+            last_total = None
+            last_len = None
+            while True:
+                params = {"limit": 2}
+                if cursor:
+                    params["cursor"] = cursor
+                resp = await client.get("/api/v2/tasks", params=params)
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                pages += 1
+                seen_ids.update(t["id"] for t in body)
+                last_total = int(resp.headers["x-total-count"])
+                last_len = len(body)
+                has_more = last_total > last_len
+                cursor = resp.headers.get("x-next-cursor")
+                if not has_more or not body:
+                    break
+                assert pages < 10, "무한 루프 방지"
+
+            assert len(seen_ids) == 5, f"5건이 페이지 전체에 걸쳐 정확히 다 나와야(중복/누락 0): {seen_ids}"
+            assert pages == 3, f"5건/limit=2 → 3페이지(2+2+1)여야: {pages}"
+            assert last_total == last_len, (
+                f"마지막 페이지 X-Total-Count({last_total})가 그 페이지 건수({last_len})와 "
+                f"같아야 has_more=False로 정확히 떨어진다 — grand total(5) 고정이면 여기서 어긋남"
+            )
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_2428_pr3_tasks_pagination_realdb.py
+++ b/backend/tests/test_2428_pr3_tasks_pagination_realdb.py
@@ -1,0 +1,217 @@
+"""story #2428 PR③(⓪tasks ⓐ) — GET /api/v2/tasks에 limit/cursor/X-Total-Count/status_ne 배선,
+실 Postgres 검증. 라이브 실측 667건(현재 dev org) — list_tasks/list_my_tasks/get_overdue_tasks
+3-way 공유 엔드포인트라 이 한 판 수정이 셋 다 해소한다.
+
+축:
+1. project_id 미지정(org-wide, list_in_projects 분기) — X-Total-Count가 limit truncation에도
+   진짜 전체를 유지.
+2. status_ne — get_overdue_tasks가 이미 보내고 있었으나 라우터가 안 받아 조용히 버려지던
+   부수발견 결함의 실제 배선 확認(done 제외).
+3. story_id 지정(list_paginated 분기) — 같은 X-Total-Count 계약.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed(session, *, n_todo: int = 3, n_done: int = 2):
+    from app.models.organization import Organization
+    from app.models.pm import Story, Task
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org2428T", slug=f"org2428t-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S")
+    session.add(story)
+    await session.commit()
+
+    task_ids = []
+    for i in range(n_todo):
+        t = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title=f"todo-{i}", status="todo")
+        session.add(t)
+        task_ids.append(t.id)
+    for i in range(n_done):
+        t = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title=f"done-{i}", status="done")
+        session.add(t)
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "story_id": story.id, "caller_id": caller_id, "task_ids": task_ids}
+
+
+@pytest.mark.anyio
+async def test_org_wide_x_total_count_is_real_total_when_truncated():
+    """list_in_projects 분기 — limit=1로 잘려도 X-Total-Count는 진짜 전체(5)를 유지."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n_todo=3, n_done=2)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/tasks", params={"limit": 1})
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()) == 1
+            assert resp.headers["x-total-count"] == "5", dict(resp.headers)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_status_ne_excludes_done_get_overdue_tasks_contract():
+    """get_overdue_tasks가 이미 보내던 status_ne=done이 실제로 적용되는지(부수발견 결함 fix)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n_todo=3, n_done=2)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/tasks", params={"status_ne": "done"})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body) == 3, body
+            assert all(t["status"] != "done" for t in body)
+            assert resp.headers["x-total-count"] == "3"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_id_scoped_branch_x_total_count():
+    """story_id 지정(list_paginated 분기) — 같은 X-Total-Count 계약."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n_todo=3, n_done=2)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/tasks", params={"story_id": str(seeded["story_id"]), "limit": 2})
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()) == 2
+            assert resp.headers["x-total-count"] == "5"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_limit_returns_all_and_total_matches_page():
+    """limit 미지정(기존 동작 무회귀) — 5건 다 오고 X-Total-Count도 5."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n_todo=3, n_done=2)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/tasks")
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()) == 5
+            assert resp.headers["x-total-count"] == "5"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## 무엇을 왜

story #2428 ② 11개 분류표(ⓐ 6개 실질 BE 5건 / ⓑ 5개 자연상한)를 페드루가 확定. 이 PR은
ⓐ 중 라이브 실측 낙폭이 가장 큰(667건, 현 dev org) tasks 계열부터 — `list_tasks`·
`list_my_tasks`·`get_overdue_tasks` 3개 MCP 도구가 전부 `GET /api/v2/tasks`(같은 라우터
함수)를 공유해 BE 한 판 수정으로 셋 다 해소된다.

## 이번 PR에서 한 일

- **`app/routers/tasks.py list_tasks`**: `limit`/`cursor` Query + `X-Total-Count`/
  `X-Next-Cursor` 헤더 — `app/routers/goals.py list_goals`와 **완전히 동일한 규약**
  (필터 適用 後·limit 適用 前 COUNT, cursor=created_at) — 새 규약 발명 0(페드루 조건②).
  - `story_id` 지정 분기(단순 동등비교 필터만)는 `BaseRepository.list_paginated()`(범용
    메서드, 이미 존재)를 그대로 재사용 — 신규 코드 0.
  - org-wide 분기(`list_in_projects`, Story JOIN 필요)는 범용 메서드가 JOIN을 지원 안 해
    `TaskRepository.list_in_projects()` 자체를 `(tasks, total)`로 확장(같은 규약).
- **부수발견 fix**: `get_overdue_tasks` MCP 도구가 이미 `status_ne=done`을 보내고 있었으나
  (`sprintable_mcp/tools/analytics.py`, 이번 세션 이전부터) `list_tasks` 라우터가 그
  파라미터를 아예 안 받아 FastAPI가 조용히 버렸다 — **완료 포함 전체가 계속 나가던 결함**.
  `status_ne` Query 파라미터 신설로 실제 배선(별건 발견, 이 PR과 같은 함수라 같이 fix).
- **ⓑ 5개 문서화**(페드루 조건①): `list_team_members`/`list_projects`/
  `list_webhook_configs`/`list_spec_pins`/`list_standup_entries` — 각 도구 docstring에
  "왜 limit이 없는지"(자연상한 축, `standup_missing` 판례와 동형) 한 줄씩 명시. 스토리
  본문에도 분류표 그대로 기재됨.

## 부수 발견(스코프 밖, 참고용)

`list_tasks` 라우터에 애초에 `project_id` 필터 자체가 없다 — MCP 도구들이 `project_id`를
보내고 있지만 조용히 버려지고, 대신 caller의 **전체 접근권 project 집합**(org-wide
accessible)으로 스코프된다. 멀티프로젝트 에이전트가 `list_tasks`를 부르면 "현재
프로젝트"가 아니라 접근 가능한 모든 프로젝트의 task가 섞여 나올 수 있다는 뜻 — 페이지네이션
과는 별개의 스코핑 이슈라 이 PR에서 건드리지 않음(페드루에게 별도 보고).

## 테스트

- [x] `tests/test_2428_pr3_tasks_pagination_realdb.py`(신규, 실 PG) — 4건: org-wide 분기
  X-Total-Count 진짜 total(limit truncation에도), status_ne=done 실배선(부수발견 fix
  확認), story_id 분기 X-Total-Count, limit 미지정 무회귀. mutation-kill: status_ne 절
  제거→RED, X-Total-Count 위조→RED, 둘 다 확인 후 원복.
- [x] `tests/test_2428_pr3_mcp_tasks_pagination.py`(신규) — 5건: `list_tasks`/
  `list_my_tasks`/`get_overdue_tasks` has_more 신호·limit/cursor 통과·status_ne=done
  유지 확認.
- [x] 인접 회귀 스윕(로컬 disposable PG, tasks 관련 12개 파일, 107건) — 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)