### PR TITLE
[BE·MCP] sprints/retros/artifacts 나머지 4 ⓐ 도구 pagination + list_paginated() 공용 fix (story #2428 PR④)

### DIFF
--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -70,7 +70,13 @@ class BaseRepository(Generic[T]):
 
         - order_by: 단조 컬럼 화이트리스트(created_at/updated_at). 그 외는 created_at로 폴백.
         - cursor: 직전 페이지 마지막 row의 order_by 값(datetime). desc 페이지네이션(< cursor).
-        - total: 페이지와 무관한 필터링 전체 개수(silent-truncation을 호출자가 인지하도록).
+        - total: 필터+cursor 適用 後·limit 適用 前 전체 개수("이 필터+커서 조건에서 남은 전체
+          건수" — story.py::list()가 세운 규약, #2537). ⚠️페드루 AC 리뷰(story #2428 PR③,
+          2026-08-17, TaskRepository.list_in_projects()에서 먼저 잡힘)로 발견 — 이 공용
+          메서드가 최초엔 cursor를 count 쿼리에서 빠뜨려(q에만 붙임) 마지막 페이지에서도
+          total이 cursor-무관 grand total로 고정, has_more(=total>len(items))가 영구 참이
+          되는 결함이었다. cursor를 conds에 넣어 count_q/q 둘 다 같은 조건을 보게 고쳤다 —
+          이 메서드를 쓰는 모든 소비자(GoalRepository.list_goals 등)에 소급 적용된다.
         - limit: None이면 기존 list()와 동일하게 1000 cap. 지정 시 그만큼만 반환(over-fetch는 호출자 책임).
         반환: (rows, total).
         """
@@ -80,23 +86,22 @@ class BaseRepository(Generic[T]):
         for attr, val in filters.items():
             conds.append(getattr(self.model, attr) == val)
 
-        # 전체 카운트(페이지네이션 무관) — 1000+ 잘림을 호출자가 알 수 있게 한다.
+        if order_by not in self._orderable_fields():
+            order_by = "created_at"
+        order_col = getattr(self.model, order_by)
+
+        if cursor is not None:
+            conds.append(order_col < cursor)
+
+        # 전체 카운트(필터+cursor 適用 後) — 1000+ 잘림 및 "마지막 페이지"를 호출자가 인지하도록.
         count_result = await self.session.execute(
             select(func.count()).select_from(self.model).where(*conds)
         )
         total = int(count_result.scalar_one() or 0)
 
-        if order_by not in self._orderable_fields():
-            order_by = "created_at"
-        order_col = getattr(self.model, order_by)
-
         q = select(self.model).where(*conds).order_by(
             order_col.desc(), self.model.id.desc()  # type: ignore[attr-defined]
         )
-
-        if cursor is not None:
-            q = q.where(order_col < cursor)
-
         q = q.limit(limit if limit is not None else 1000)
         result = await self.session.execute(q)
         return list(result.scalars().all()), total

--- a/backend/app/repositories/retro.py
+++ b/backend/app/repositories/retro.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy import func, select, text, update
@@ -19,6 +20,38 @@ from app.repositories.base import BaseRepository
 class RetroSessionRepository(BaseRepository[RetroSession]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(RetroSession, session, org_id)
+
+    async def list_in_projects(
+        self,
+        project_ids: list[uuid.UUID],
+        *,
+        sprint_id: uuid.UUID | None = None,
+        limit: int | None = None,
+        cursor: datetime | None = None,
+    ) -> tuple[list[RetroSession], int]:
+        """story #2428 PR④(ⓐ) — list_sessions의 project_id 미지정(org-wide) 분기 전용.
+        SprintRepository.list_in_projects()와 동형(project_id 컬럼 직접 IN, cursor는 conds에
+        포함해 count_q/q 공유 — story.py 규약·base.py list_paginated() fix와 동일 모양).
+        기존 코드는 org-wide일 때 세션마다 has_project_access를 개별 호출하는 post-filter라
+        DB-level limit/cursor와 결합하면 페이지 건수가 다시 줄어드는 함정이 있었다."""
+        if not project_ids:
+            return [], 0
+        conds = [self._org_filter(), RetroSession.project_id.in_(project_ids)]
+        if sprint_id is not None:
+            conds.append(RetroSession.sprint_id == sprint_id)
+        if cursor is not None:
+            conds.append(RetroSession.created_at < cursor)
+
+        count_q = select(func.count()).select_from(RetroSession).where(*conds)
+        total = int((await self.session.execute(count_q)).scalar_one() or 0)
+
+        q = (
+            select(RetroSession).where(*conds)
+            .order_by(RetroSession.created_at.desc(), RetroSession.id.desc())
+            .limit(limit if limit is not None else 1000)
+        )
+        result = await self.session.execute(q)
+        return list(result.scalars().all()), total
 
     async def set_phase(self, id: uuid.UUID, new_phase: str) -> RetroSession:
         """B1: 인접 양방향(collect↔vote↔action) + action→closed 편도만 허용. closed는

--- a/backend/app/repositories/sprint.py
+++ b/backend/app/repositories/sprint.py
@@ -1,6 +1,7 @@
 import uuid
+from datetime import datetime
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.pm import Sprint, Story
@@ -10,6 +11,40 @@ from app.repositories.base import BaseRepository
 class SprintRepository(BaseRepository[Sprint]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(Sprint, session, org_id)
+
+    async def list_in_projects(
+        self,
+        project_ids: list[uuid.UUID],
+        *,
+        status: str | None = None,
+        limit: int | None = None,
+        cursor: datetime | None = None,
+    ) -> tuple[list[Sprint], int]:
+        """story #2428 PR④(ⓐ) — list_sprints의 project_id 미지정(org-wide) 분기 전용.
+        기존 코드는 `repo.list()`로 org 전체를 끌어온 뒤 Python에서 accessible project_id로
+        post-filter했다(SEC-S8) — DB-level limit/cursor를 곧이곧대로 얹으면 그 post-filter가
+        페이지 건수를 다시 줄여 X-Total-Count/has_more가 어긋난다(TaskRepository.
+        list_in_projects()가 이미 겪은 것과 동형 함정, 거긴 Story JOIN이 필요했지만 Sprint는
+        project_id 컬럼이 있어 직접 IN). cursor는 conds에 포함(count_q/q 공유) — story.py
+        규약 그대로(#2537), 3157/base.py list_paginated() fix와 동일 모양."""
+        if not project_ids:
+            return [], 0
+        conds = [self._org_filter(), Sprint.project_id.in_(project_ids)]
+        if status is not None:
+            conds.append(Sprint.status == status)
+        if cursor is not None:
+            conds.append(Sprint.created_at < cursor)
+
+        count_q = select(func.count()).select_from(Sprint).where(*conds)
+        total = int((await self.session.execute(count_q)).scalar_one() or 0)
+
+        q = (
+            select(Sprint).where(*conds)
+            .order_by(Sprint.created_at.desc(), Sprint.id.desc())
+            .limit(limit if limit is not None else 1000)
+        )
+        result = await self.session.execute(q)
+        return list(result.scalars().all()), total
 
     async def activate(self, id: uuid.UUID) -> Sprint:
         sprint = await self.get(id)

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy import select
@@ -12,7 +13,7 @@ from app.services import hypothesis as hyp_svc
 from app.services import retro_hypothesis_seed as seed_svc
 from app.services import retro_synthesis as synth_svc
 from app.services.member_resolver import canonicalize_member_id, lookup_members_by_ids, resolve_member
-from app.services.project_auth import has_project_access, require_project_access
+from app.services.project_auth import require_project_access
 from app.repositories.retro import (
     RetroActionRepository,
     RetroItemRepository,
@@ -105,27 +106,51 @@ async def _require_item_in_session(
 async def list_sessions(
     project_id: uuid.UUID | None = Query(default=None),
     sprint_id: uuid.UUID | None = Query(default=None),
+    limit: int | None = Query(default=None, ge=1, le=2000),
+    cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch before this time"),
+    response: Response = None,  # type: ignore[assignment]
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> list[SessionListResponse]:
+    """story #2428 PR④(ⓐ): goals.py/tasks.py/list_sprints와 동일 규약 — true cursor
+    페이지네이션 + 전체 카운트(X-Total-Count 헤더). limit 미지정 시 기존 동작(최대 1000)과
+    호환."""
     user_id = uuid.UUID(auth.user_id)
     if project_id is not None:
         # 명시 필터 시 그 프로젝트 접근권 선검증(무권한 project_id로 org 존재 여부 탐색 차단).
         # ⛔story #2342(2026-07-30): 무권한을 403이 아닌 404로 통일.
         await require_project_access(db, user_id, project_id, repo.org_id,
             not_found_detail="Project not found")
-    filters: dict = {}
+
+    cursor_dt: datetime | None = None
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except (ValueError, TypeError) as exc:
+            raise HTTPException(
+                status_code=400, detail="invalid cursor: expected ISO 8601 datetime"
+            ) from exc
+
     if project_id:
-        filters["project_id"] = project_id
-    if sprint_id:
-        filters["sprint_id"] = sprint_id
-    sessions = await repo.list(**filters)
-    if project_id is None:
-        # project_id 생략 시 org 전체 세션이 나오던 갭 — 각 세션의 실제 project 접근권으로 필터.
-        sessions = [
-            s for s in sessions if await has_project_access(db, user_id, s.project_id, repo.org_id)
-        ]
+        filters: dict = {"project_id": project_id}
+        if sprint_id:
+            filters["sprint_id"] = sprint_id
+        sessions, total = await repo.list_paginated(limit=limit, cursor=cursor_dt, **filters)
+    else:
+        # project_id 생략 시 org 전체 세션이 나오던 갭(기존 has_project_access post-filter) —
+        # accessible_project_ids_in_org로 SQL-level IN 스코프(list_in_projects, list_sprints와
+        # 동형) — DB-level limit/cursor와 post-filter가 충돌하는 함정 회피.
+        from app.services.project_auth import accessible_project_ids_in_org
+        accessible = list(await accessible_project_ids_in_org(db, user_id, repo.org_id))
+        sessions, total = await repo.list_in_projects(
+            accessible, sprint_id=sprint_id, limit=limit, cursor=cursor_dt
+        )
+
+    if response is not None:
+        response.headers["X-Total-Count"] = str(total)
+        if sessions:
+            response.headers["X-Next-Cursor"] = sessions[-1].created_at.isoformat()
     return [SessionListResponse.model_validate(s) for s in sessions]
 
 

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date as date_type, datetime
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, model_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -119,27 +119,52 @@ async def _attach_org_project_slugs(session: AsyncSession, org_id: uuid.UUID, sp
 async def list_sprints(
     project_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
+    limit: int | None = Query(default=None, ge=1, le=2000),
+    cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch before this time"),
+    response: Response = None,  # type: ignore[assignment]
     repo: SprintRepository = Depends(_get_repo_read),
     auth: AuthContext = Depends(get_current_user),
 ) -> list[SprintResponse]:
+    """story #2428 PR④(ⓐ): goals.py/tasks.py와 동일 규약(필터 適用 後·limit 適用 前 COUNT,
+    cursor=created_at) — true cursor 페이지네이션 + 전체 카운트(X-Total-Count 헤더). limit
+    미지정 시 기존 동작(최대 1000)과 호환."""
     # E-SECURITY SEC-S8(story 83ea3d6a) CC(선생님 "sprint org-level=갭" 확定): 라우터 13개
     # 전부 org-scope만이고 project-scope 0이던 것 중 하나 — project_id 미지정 시 caller의
     # project 접근권과 무관하게 org 전체 sprint가 노출됐다. project_id 지정 시엔 접근권 검증,
-    # 미지정 시엔 accessible_project_ids_in_org로 필터(완전봉인, Z-standup 패턴 동형).
+    # 미지정 시엔 accessible_project_ids_in_org로 필터.
     from app.services.project_auth import accessible_project_ids_in_org, require_project_access
 
-    filters: dict = {}
+    cursor_dt: datetime | None = None
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except (ValueError, TypeError) as exc:
+            raise HTTPException(
+                status_code=400, detail="invalid cursor: expected ISO 8601 datetime"
+            ) from exc
+
     if project_id:
         await require_project_access(repo.session, uuid.UUID(auth.user_id), project_id, repo.org_id,
             not_found_detail="Project not found")
-        filters["project_id"] = project_id
-    if status_filter:
-        filters["status"] = status_filter
-    sprints = await repo.list(**filters)
-    if not project_id:
-        accessible = set(await accessible_project_ids_in_org(repo.session, uuid.UUID(auth.user_id), repo.org_id))
-        sprints = [s for s in sprints if s.project_id in accessible]
+        filters: dict = {"project_id": project_id}
+        if status_filter:
+            filters["status"] = status_filter
+        sprints, total = await repo.list_paginated(limit=limit, cursor=cursor_dt, **filters)
+    else:
+        # accessible_project_ids_in_org로 SQL-level IN 스코프(list_in_projects) — 예전 Python
+        # post-filter 방식(SEC-S8 최초 fix)은 DB-level limit/cursor와 결합하면 페이지 건수가
+        # post-filter로 다시 줄어 X-Total-Count/has_more가 어긋난다(TaskRepository.
+        # list_in_projects와 동형 함정 회피).
+        accessible = list(await accessible_project_ids_in_org(repo.session, uuid.UUID(auth.user_id), repo.org_id))
+        sprints, total = await repo.list_in_projects(
+            accessible, status=status_filter, limit=limit, cursor=cursor_dt
+        )
+
     await _attach_org_project_slugs(repo.session, repo.org_id, sprints)
+    if response is not None:
+        response.headers["X-Total-Count"] = str(total)
+        if sprints:
+            response.headers["X-Next-Cursor"] = sprints[-1].created_at.isoformat()
     return [SprintResponse.model_validate(s) for s in sprints]
 
 

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
@@ -39,8 +40,8 @@ from app.services.project_auth import assert_target_in_caller_org
 router = APIRouter(prefix="/api/v2/visual-artifacts", tags=["visual-artifacts", "Work"])
 
 
-def _ok(data: object, status: int = 200) -> JSONResponse:
-    return JSONResponse({"data": data, "error": None, "meta": None}, status_code=status)
+def _ok(data: object, status: int = 200, meta: dict | None = None) -> JSONResponse:
+    return JSONResponse({"data": data, "error": None, "meta": meta}, status_code=status)
 
 
 def _err(code: str, message: str, status: int) -> JSONResponse:
@@ -324,9 +325,18 @@ async def list_artifacts(
     epic_id: uuid.UUID | None = Query(default=None),
     doc_id: uuid.UUID | None = Query(default=None),
     ids: str | None = Query(default=None, description="comma-separated artifact ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관, story #2262 PR② 칩 상태 배치조회)"),
+    limit: int = Query(default=500, ge=1, le=1000),
+    cursor: str | None = Query(default=None, description="ISO 8601 created_at, fetch before this time — 이전 페이지 meta.next_cursor 값 그대로"),
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
+    """story #2428 PR④(ⓐ) — 예전엔 limit이 아예 없어 project 전체 artifact가 조용히 다
+    나왔다(무제한 위험). docs.py list_docs와 동일 규약(정본 규약 A — limit+1 오버페치 +
+    has_more/next_cursor body meta, `_doc_page_envelope` 참조) — 이 라우터는 stories.py/
+    goals.py 계열의 X-Total-Count 헤더 봉투가 아니라 이미 `{data,error,meta}` 자체 봉투를
+    쓰고 있어(위 `_ok`) 그 家族(docs.py)을 그대로 따른다(새 규약 발명 0). COUNT 쿼리 없이
+    limit+1개만 더 읽어 판정하므로 base.py list_paginated()류의 «count에 cursor 누락»
+    결함 클래스 자체가 구조적으로 없다."""
     # E-SECURITY SEC-S8(story 83ea3d6a) G(N): project_id 필터가 아예 없어 story_id/epic_id/
     # doc_id 미지정 호출(파라미터 없는 목록 조회)이 org 전체 artifact를 반환했다(cross-project
     # 노출·미르코 라이브 실측). create_artifact/get_artifact와 동형으로 JWT/API키 컨텍스트의
@@ -334,6 +344,16 @@ async def list_artifacts(
     org_id, project_id = _get_org_project(auth)
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
+
+    cursor_dt: datetime | None = None
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except (ValueError, TypeError) as exc:
+            raise HTTPException(
+                status_code=400, detail="invalid cursor: expected ISO 8601 datetime"
+            ) from exc
+
     q = select(VisualArtifact).where(
         VisualArtifact.org_id == org_id, VisualArtifact.project_id == project_id,
         VisualArtifact.deleted_at.is_(None),
@@ -349,24 +369,40 @@ async def list_artifacts(
         except ValueError:
             raise HTTPException(status_code=422, detail="invalid artifact id in ids")
         if not artifact_ids:
-            return _ok([])
+            return _ok([], meta={"has_more": False, "next_cursor": None})
         if len(artifact_ids) > 200:
             raise HTTPException(status_code=422, detail="too many ids (max 200)")
         q = q.where(VisualArtifact.id.in_(artifact_ids))
+        rows = (await session.execute(q)).scalars().all()
+        unresolved_counts = await _count_unresolved_comments(session, [r.id for r in rows])
+        for r in rows:
+            r.unresolved_comment_count = unresolved_counts.get(r.id, 0)
+        return _ok(
+            [VisualArtifactSummary.model_validate(r).model_dump(mode="json") for r in rows],
+            meta={"has_more": False, "next_cursor": None},
+        )
     if story_id is not None:
         q = q.where(VisualArtifact.story_id == story_id)
     if epic_id is not None:
         q = q.where(VisualArtifact.epic_id == epic_id)
     if doc_id is not None:
         q = q.where(VisualArtifact.doc_id == doc_id)
-    q = q.order_by(VisualArtifact.created_at.desc())
-    rows = (await session.execute(q)).scalars().all()
+    if cursor_dt is not None:
+        q = q.where(VisualArtifact.created_at < cursor_dt)
+    q = q.order_by(VisualArtifact.created_at.desc()).limit(limit + 1)
+    fetched = (await session.execute(q)).scalars().all()
+    has_more = len(fetched) > limit
+    rows = fetched[:limit]
+    next_cursor = rows[-1].created_at.isoformat() if has_more and rows else None
     # story #2262 AC9②: 페이지 전체를 쿼리 1회로 해소(N+1 방지, #2619와 동형) — artifact마다
     # 따로 COUNT 왕복하지 않는다.
     unresolved_counts = await _count_unresolved_comments(session, [r.id for r in rows])
     for r in rows:
         r.unresolved_comment_count = unresolved_counts.get(r.id, 0)
-    return _ok([VisualArtifactSummary.model_validate(r).model_dump(mode="json") for r in rows])
+    return _ok(
+        [VisualArtifactSummary.model_validate(r).model_dump(mode="json") for r in rows],
+        meta={"has_more": has_more, "next_cursor": next_cursor},
+    )
 
 
 @router.delete("/{id}")
@@ -401,20 +437,42 @@ async def delete_artifact(
 async def list_artifact_comments(
     id: uuid.UUID,
     limit: int = Query(default=50, le=200),
+    cursor: str | None = Query(default=None, description="ISO 8601 created_at, fetch after this time — 이전 페이지 meta.next_cursor 값 그대로(오래된순 정렬이라 forward-cursor)"),
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
+    """story #2428 PR④(ⓐ) — limit은 있었으나 total/has_more가 없어 잘렸는지 호출자가 알 수
+    없었다(활발한 토론 스레드는 챗 스레드와 동형 무한성장 위험). list_artifacts와 동일하게
+    limit+1 오버페치 + has_more/next_cursor body meta(docs.py 정본 규약 A) — 정렬이 오래된순
+    (asc)이라 next_cursor는 "이 시각 이후"로 이어가는 forward cursor."""
     org_id, project_id = _get_org_project(auth)
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
     if artifact is None:
         return _err("NOT_FOUND", "Artifact not found", 404)
-    rows = (await session.execute(
-        select(ArtifactComment).where(ArtifactComment.artifact_id == id)
-        .order_by(ArtifactComment.created_at.asc()).limit(limit)
-    )).scalars().all()
-    return _ok([ArtifactCommentResponse.model_validate(r).model_dump(mode="json") for r in rows])
+
+    cursor_dt: datetime | None = None
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except (ValueError, TypeError) as exc:
+            raise HTTPException(
+                status_code=400, detail="invalid cursor: expected ISO 8601 datetime"
+            ) from exc
+
+    q = select(ArtifactComment).where(ArtifactComment.artifact_id == id)
+    if cursor_dt is not None:
+        q = q.where(ArtifactComment.created_at > cursor_dt)
+    q = q.order_by(ArtifactComment.created_at.asc()).limit(limit + 1)
+    fetched = (await session.execute(q)).scalars().all()
+    has_more = len(fetched) > limit
+    rows = fetched[:limit]
+    next_cursor = rows[-1].created_at.isoformat() if has_more and rows else None
+    return _ok(
+        [ArtifactCommentResponse.model_validate(r).model_dump(mode="json") for r in rows],
+        meta={"has_more": has_more, "next_cursor": next_cursor},
+    )
 
 
 @router.post("/{id}/comments", status_code=201)

--- a/backend/sprintable_mcp/tools/retro.py
+++ b/backend/sprintable_mcp/tools/retro.py
@@ -6,15 +6,17 @@ from typing import Literal
 from mcp.types import TextContent
 
 from ..api_client import client
-from ..response import err, ok
+from ..response import err, ok, ok_paginated
 from ..schemas import SprintableInput
+from .stories import _has_more_from_headers
 
 RetroPhase = Literal["collect", "group", "vote", "discuss", "action", "closed"]
 RetroCategory = Literal["good", "bad", "improve"]
 
 
 class ListRetroSessionsInput(SprintableInput):
-    pass
+    limit: int | None = None
+    cursor: str | None = None  # 이전 호출의 X-Next-Cursor 헤더 값을 그대로 넘기면 다음 페이지.
 
 
 class CreateRetroSessionInput(SprintableInput):
@@ -54,7 +56,14 @@ class ExportRetroInput(SprintableInput):
 async def list_retro_sessions(args: ListRetroSessionsInput) -> list[TextContent]:
     """레트로 세션 목록 조회."""
     try:
-        return ok(await client.get("/api/v2/retros", params={"project_id": client.require_project_id()}))
+        params: dict = {"project_id": client.require_project_id()}
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
+        items, headers = await client.get_with_headers("/api/v2/retros", params=params)
+        has_more, next_cursor = _has_more_from_headers(headers, items)
+        return ok_paginated(items, has_more=has_more, next_cursor=next_cursor, tool_name="sprintable_list_retro_sessions")
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/sprintable_mcp/tools/sprints.py
+++ b/backend/sprintable_mcp/tools/sprints.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 from mcp.types import TextContent
 
 from ..api_client import client
-from ..response import err, ok
+from ..response import err, ok, ok_paginated
 from ..schemas import SprintStatus, SprintableInput
+from .stories import _has_more_from_headers
 
 
 class ListSprintsInput(SprintableInput):
     status: SprintStatus | None = None
+    limit: int | None = None
+    cursor: str | None = None  # 이전 호출의 X-Next-Cursor 헤더 값을 그대로 넘기면 다음 페이지.
 
 
 class SprintIdInput(SprintableInput):
@@ -38,7 +41,13 @@ async def list_sprints(args: ListSprintsInput) -> list[TextContent]:
         params: dict = {"project_id": client.require_project_id()}
         if args.status:
             params["status"] = args.status.value
-        return ok(await client.get("/api/v2/sprints", params=params))
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
+        items, headers = await client.get_with_headers("/api/v2/sprints", params=params)
+        has_more, next_cursor = _has_more_from_headers(headers, items)
+        return ok_paginated(items, has_more=has_more, next_cursor=next_cursor, tool_name="sprintable_list_sprints")
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -8,8 +8,19 @@ from __future__ import annotations
 from mcp.types import TextContent
 
 from ..api_client import client
-from ..response import err, ok
+from ..response import err, ok, ok_paginated
 from ..schemas import SprintableInput
+
+
+def _unwrap_data_meta(result: object) -> tuple[list, dict]:
+    """story #2428 PR④ — GET /api/v2/visual-artifacts·/comments는 stories.py 계열의
+    X-Total-Count 헤더가 아니라 docs.py `_unwrap_docs_page`와 동형인 body
+    `{data, meta:{has_more,next_cursor}}` 봉투를 쓴다 — 그 헬퍼와 동일 컨벤션을 그대로
+    미러링(client.get() 사용, 새 규약 발명 0). 구 bare-array 응답(롤백/미갱신 BE)도
+    하위호환으로 통과시킨다."""
+    if isinstance(result, dict) and "data" in result:
+        return result["data"], (result.get("meta") or {})
+    return (result if isinstance(result, list) else []), {}
 
 
 class ArtifactNodeInput(SprintableInput):
@@ -47,6 +58,8 @@ class GetArtifactInput(SprintableInput):
 
 class ListArtifactCommentsInput(SprintableInput):
     artifact_id: str
+    limit: int | None = None
+    cursor: str | None = None  # 이전 호출의 meta.next_cursor 값을 그대로 넘기면 다음 페이지.
 
 
 class AddArtifactCommentInput(SprintableInput):
@@ -122,6 +135,8 @@ class ListArtifactsInput(SprintableInput):
     story_id: str | None = None
     epic_id: str | None = None
     doc_id: str | None = None
+    limit: int | None = None
+    cursor: str | None = None  # 이전 호출의 meta.next_cursor 값을 그대로 넘기면 다음 페이지.
 
 
 async def create_artifact(args: CreateArtifactInput) -> list[TextContent]:
@@ -163,7 +178,8 @@ async def get_artifact(args: GetArtifactInput) -> list[TextContent]:
 async def list_artifacts(args: ListArtifactsInput) -> list[TextContent]:
     """현재 프로젝트의 시각 산출물 목록 조회 — story_id/epic_id/doc_id로 필터 가능(미지정 시
     프로젝트 전체). 각 항목은 artifact 메타(title·story/epic/doc 연결·latest 버전 번호)만 반환하며
-    노드 트리는 미포함 — 특정 artifact의 nodes/상세는 get_artifact로 조회."""
+    노드 트리는 미포함 — 특정 artifact의 nodes/상세는 get_artifact로 조회. 더 있으면(has_more)
+    다음 페이지 안내가 별도 텍스트 블록으로 붙는다."""
     try:
         params: dict = {}
         if args.story_id:
@@ -172,18 +188,36 @@ async def list_artifacts(args: ListArtifactsInput) -> list[TextContent]:
             params["epic_id"] = args.epic_id
         if args.doc_id:
             params["doc_id"] = args.doc_id
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
         result = await client.get("/api/v2/visual-artifacts", params=params)
-        return ok(result)
+        items, meta = _unwrap_data_meta(result)
+        return ok_paginated(
+            items, has_more=bool(meta.get("has_more")), next_cursor=meta.get("next_cursor"),
+            tool_name="sprintable_list_artifacts",
+        )
     except Exception as exc:
         return err(str(exc))
 
 
 async def list_artifact_comments(args: ListArtifactCommentsInput) -> list[TextContent]:
     """artifact 코멘트 스레드 조회(요소/좌표 앵커·resolve 상태 포함) — 휴먼 딸깍 피드백을
-    에이전트가 읽고 반응하는 왕복 입구."""
+    에이전트가 읽고 반응하는 왕복 입구. 더 있으면(has_more) 다음 페이지 안내가 별도 텍스트
+    블록으로 붙는다(오래된순 정렬 — cursor는 "이 시각 이후"로 이어달림)."""
     try:
-        result = await client.get(f"/api/v2/visual-artifacts/{args.artifact_id}/comments")
-        return ok(result)
+        params: dict = {}
+        if args.limit:
+            params["limit"] = args.limit
+        if args.cursor:
+            params["cursor"] = args.cursor
+        result = await client.get(f"/api/v2/visual-artifacts/{args.artifact_id}/comments", params=params)
+        items, meta = _unwrap_data_meta(result)
+        return ok_paginated(
+            items, has_more=bool(meta.get("has_more")), next_cursor=meta.get("next_cursor"),
+            tool_name="sprintable_list_artifact_comments",
+        )
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -16,7 +16,7 @@ def _unwrap_data_meta(result: object) -> tuple[list, dict]:
     """story #2428 PR④ — GET /api/v2/visual-artifacts·/comments는 stories.py 계열의
     X-Total-Count 헤더가 아니라 docs.py `_unwrap_docs_page`와 동형인 body
     `{data, meta:{has_more,next_cursor}}` 봉투를 쓴다 — 그 헬퍼와 동일 컨벤션을 그대로
-    미러링(client.get() 사용, 새 규약 발명 0). 구 bare-array 응답(롤백/미갱신 BE)도
+    미러링(get 메서드 그대로 사용, 새 규약 발명 0). 구 bare-array 응답(롤백/미갱신 BE)도
     하위호환으로 통과시킨다."""
     if isinstance(result, dict) and "data" in result:
         return result["data"], (result.get("meta") or {})

--- a/backend/tests/test_2428_pr4_be_pagination_realdb.py
+++ b/backend/tests/test_2428_pr4_be_pagination_realdb.py
@@ -1,0 +1,500 @@
+"""story #2428 PR④(ⓐ 나머지 4건) — list_sprints/list_retro_sessions/list_artifacts/
+list_artifact_comments 페이지네이션 실 Postgres 검증.
+
+sprints/retros는 stories.py/goals.py/tasks.py와 동형인 X-Total-Count/X-Next-Cursor 헤더
+규약(project_id 지정 시 list_paginated 위임, 미지정 시 SQL-level IN 스코프인
+list_in_projects 신설분). visual_artifacts는 이미 자체 `{data,meta}` 봉투를 쓰고 있어 그
+가족(docs.py 정본 규약 A — limit+1 오버페치 + has_more/next_cursor body meta)을 그대로
+따른다(새 규약 발명 0)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_org(app, Session, user_id, org_id):
+    """org_id만 claims에 싣는 표준 harness(sprints/retros — get_verified_org_id 경유)."""
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _setup_app_org_project(app, Session, user_id, org_id, project_id):
+    """org_id+project_id를 claims에 함께 싣는 harness(visual_artifacts — `_get_org_project`가
+    claims.app_metadata.project_id를 직접 읽음, DB 조회 없음 — test_2262_artifact_
+    unresolved_comment_count_realdb.py의 `_setup_app_human`과 동형)."""
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _seed_org_project_caller(session):
+    """org+project+caller(project_access 부여) — sprints/retros org-wide IN-scope 테스트용."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org2428PR4B", slug=f"org2428pr4b-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "caller_id": caller_id}
+
+
+def _stagger(base: datetime, total: int, seq: int) -> datetime:
+    return base - timedelta(seconds=total - seq)
+
+
+# ─── list_sprints ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_sprints_project_scoped_last_page_x_total_count_matches_remaining():
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_caller(s)
+            base = datetime.now(timezone.utc)
+            for i in range(5):
+                s.add(Sprint(
+                    id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                    title=f"sprint-{i}", created_at=_stagger(base, 5, i),
+                ))
+            await s.commit()
+        await _setup_app_org(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            seen_ids: set[str] = set()
+            cursor = None
+            pages = 0
+            last_total = last_len = None
+            while True:
+                params = {"project_id": str(seeded["project_id"]), "limit": 2}
+                if cursor:
+                    params["cursor"] = cursor
+                resp = await client.get("/api/v2/sprints", params=params)
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                pages += 1
+                seen_ids.update(x["id"] for x in body)
+                last_total = int(resp.headers["x-total-count"])
+                last_len = len(body)
+                has_more = last_total > last_len
+                cursor = resp.headers.get("x-next-cursor")
+                if not has_more or not body:
+                    break
+                assert pages < 10
+            assert len(seen_ids) == 5
+            assert pages == 3
+            assert last_total == last_len
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_sprints_org_wide_excludes_inaccessible_project():
+    """project_id 미지정(org-wide) — accessible_project_ids_in_org SQL-level IN 스코프가
+    caller 접근권 밖 project의 sprint를 실제로 배제하는지 실 PG로 확認(SEC-S8 계약,
+    list_in_projects 신설분)."""
+    from app.main import app
+    from app.models.pm import Sprint
+    from app.models.project import Project
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_caller(s)
+            other_project = Project(id=uuid.uuid4(), org_id=seeded["org_id"], name="OtherP")
+            s.add(other_project)
+            await s.commit()
+            base = datetime.now(timezone.utc)
+            for i in range(3):
+                s.add(Sprint(
+                    id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                    title=f"mine-{i}", created_at=_stagger(base, 3, i),
+                ))
+            s.add(Sprint(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=other_project.id, title="not-mine"))
+            await s.commit()
+        await _setup_app_org(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/sprints")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert {x["title"] for x in body} == {"mine-0", "mine-1", "mine-2"}
+            assert resp.headers["x-total-count"] == "3"
+
+            # cursor 페이지 끝까지 걸어 last-page has_more=False까지 확認(list_in_projects의
+            # count_q가 cursor 누락이면 마지막 페이지에서도 total=3 grand-total 고정으로
+            # has_more가 영구 참이 될 것 — base.py/task.py와 동형 mutation-kill 대상).
+            seen_ids: set[str] = set()
+            cursor = None
+            pages = 0
+            last_total = last_len = None
+            while True:
+                params = {"limit": 2}
+                if cursor:
+                    params["cursor"] = cursor
+                resp = await client.get("/api/v2/sprints", params=params)
+                assert resp.status_code == 200, resp.text
+                page = resp.json()
+                pages += 1
+                seen_ids.update(x["id"] for x in page)
+                last_total = int(resp.headers["x-total-count"])
+                last_len = len(page)
+                has_more = last_total > last_len
+                cursor = resp.headers.get("x-next-cursor")
+                if not has_more or not page:
+                    break
+                assert pages < 10
+            assert len(seen_ids) == 3
+            assert pages == 2
+            assert last_total == last_len
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── list_retro_sessions ────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_retro_sessions_project_scoped_last_page_x_total_count_matches_remaining():
+    from app.main import app
+    from app.models.retro import RetroSession
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_caller(s)
+            base = datetime.now(timezone.utc)
+            for i in range(5):
+                s.add(RetroSession(
+                    id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                    title=f"retro-{i}", created_at=_stagger(base, 5, i),
+                ))
+            await s.commit()
+        await _setup_app_org(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            seen_ids: set[str] = set()
+            cursor = None
+            pages = 0
+            last_total = last_len = None
+            while True:
+                params = {"project_id": str(seeded["project_id"]), "limit": 2}
+                if cursor:
+                    params["cursor"] = cursor
+                resp = await client.get("/api/v2/retros", params=params)
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                pages += 1
+                seen_ids.update(x["id"] for x in body)
+                last_total = int(resp.headers["x-total-count"])
+                last_len = len(body)
+                has_more = last_total > last_len
+                cursor = resp.headers.get("x-next-cursor")
+                if not has_more or not body:
+                    break
+                assert pages < 10
+            assert len(seen_ids) == 5
+            assert pages == 3
+            assert last_total == last_len
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_retro_sessions_org_wide_excludes_inaccessible_project():
+    from app.main import app
+    from app.models.retro import RetroSession
+    from app.models.project import Project
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_caller(s)
+            other_project = Project(id=uuid.uuid4(), org_id=seeded["org_id"], name="OtherP")
+            s.add(other_project)
+            await s.commit()
+            base = datetime.now(timezone.utc)
+            for i in range(3):
+                s.add(RetroSession(
+                    id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                    title=f"mine-{i}", created_at=_stagger(base, 3, i),
+                ))
+            s.add(RetroSession(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=other_project.id, title="not-mine"))
+            await s.commit()
+        await _setup_app_org(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/retros")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert {x["title"] for x in body} == {"mine-0", "mine-1", "mine-2"}
+            assert resp.headers["x-total-count"] == "3"
+
+            seen_ids: set[str] = set()
+            cursor = None
+            pages = 0
+            last_total = last_len = None
+            while True:
+                params = {"limit": 2}
+                if cursor:
+                    params["cursor"] = cursor
+                resp = await client.get("/api/v2/retros", params=params)
+                assert resp.status_code == 200, resp.text
+                page = resp.json()
+                pages += 1
+                seen_ids.update(x["id"] for x in page)
+                last_total = int(resp.headers["x-total-count"])
+                last_len = len(page)
+                has_more = last_total > last_len
+                cursor = resp.headers.get("x-next-cursor")
+                if not has_more or not page:
+                    break
+                assert pages < 10
+            assert len(seen_ids) == 3
+            assert pages == 2
+            assert last_total == last_len
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── list_artifacts ─────────────────────────────────────────────────────────
+
+
+async def _make_artifact(session, org_id, project_id, created_at, title="A"):
+    from app.models.visual_artifact import ArtifactVersion, VisualArtifact
+    artifact = VisualArtifact(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        source="created", latest_version_number=1, created_by=uuid.uuid4(), created_at=created_at,
+    )
+    session.add(artifact)
+    await session.flush()
+    session.add(ArtifactVersion(id=uuid.uuid4(), artifact_id=artifact.id, version_number=1))
+    await session.commit()
+    return artifact
+
+
+@pytest.mark.anyio
+async def test_list_artifacts_limit_plus_one_overfetch_has_more_and_last_page_false():
+    from app.main import app
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+            s.add(project)
+            await s.commit()
+            base = datetime.now(timezone.utc)
+            for i in range(5):
+                await _make_artifact(s, org.id, project.id, _stagger(base, 5, i), title=f"a{i}")
+        await _setup_app_org_project(app, Session, uuid.uuid4(), org.id, project.id)
+        client = _client_for(app)
+        try:
+            seen_ids: set[str] = set()
+            cursor = None
+            pages = 0
+            last_meta = None
+            while True:
+                params = {"limit": 2}
+                if cursor:
+                    params["cursor"] = cursor
+                resp = await client.get("/api/v2/visual-artifacts", params=params)
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                pages += 1
+                seen_ids.update(x["id"] for x in body["data"])
+                last_meta = body["meta"]
+                cursor = last_meta.get("next_cursor")
+                if not last_meta.get("has_more") or not body["data"]:
+                    break
+                assert pages < 10
+            assert len(seen_ids) == 5
+            assert pages == 3
+            assert last_meta["has_more"] is False
+            assert last_meta["next_cursor"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── list_artifact_comments ─────────────────────────────────────────────────
+
+
+async def _make_comment(session, org_id, project_id, artifact_id, created_at, content="c"):
+    from app.models.visual_artifact import ArtifactComment
+    c = ArtifactComment(
+        id=uuid.uuid4(), artifact_id=artifact_id, org_id=org_id, project_id=project_id,
+        content=content, created_by=uuid.uuid4(), created_at=created_at,
+    )
+    session.add(c)
+    await session.commit()
+    return c
+
+
+@pytest.mark.anyio
+async def test_list_artifact_comments_limit_plus_one_overfetch_forward_cursor_last_page_false():
+    from app.main import app
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+            s.add(project)
+            await s.commit()
+            artifact = await _make_artifact(s, org.id, project.id, datetime.now(timezone.utc), title="art")
+            base = datetime.now(timezone.utc)
+            # 오래된순(asc) 정렬 — i=0이 가장 오래됨(가장 먼저 나와야).
+            for i in range(5):
+                await _make_comment(s, org.id, project.id, artifact.id, _stagger(base, 5, i), content=f"c{i}")
+        await _setup_app_org_project(app, Session, uuid.uuid4(), org.id, project.id)
+        client = _client_for(app)
+        try:
+            seen_ids: set[str] = set()
+            cursor = None
+            pages = 0
+            last_meta = None
+            while True:
+                params = {"limit": 2}
+                if cursor:
+                    params["cursor"] = cursor
+                resp = await client.get(f"/api/v2/visual-artifacts/{artifact.id}/comments", params=params)
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                pages += 1
+                seen_ids.update(x["id"] for x in body["data"])
+                last_meta = body["meta"]
+                cursor = last_meta.get("next_cursor")
+                if not last_meta.get("has_more") or not body["data"]:
+                    break
+                assert pages < 10
+            assert len(seen_ids) == 5
+            assert pages == 3
+            assert last_meta["has_more"] is False
+            assert last_meta["next_cursor"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2428_pr4_be_pagination_realdb.py
+++ b/backend/tests/test_2428_pr4_be_pagination_realdb.py
@@ -82,7 +82,7 @@ async def _setup_app_org_project(app, Session, user_id, org_id, project_id):
     claims.app_metadata.project_id를 직접 읽음, DB 조회 없음 — test_2262_artifact_
     unresolved_comment_count_realdb.py의 `_setup_app_human`과 동형)."""
     from app.dependencies.auth import AuthContext, get_current_user
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     async def _db():
         async with Session() as s:
@@ -99,7 +99,7 @@ async def _setup_app_org_project(app, Session, user_id, org_id, project_id):
             claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
         )
 
-    app.dependency_overrides[get_db] = _db
+    override_db_and_read(app, _db)
     app.dependency_overrides[get_current_user] = _auth
 
 

--- a/backend/tests/test_2428_pr4_list_paginated_shared_fix_realdb.py
+++ b/backend/tests/test_2428_pr4_list_paginated_shared_fix_realdb.py
@@ -1,0 +1,177 @@
+"""story #2428 PR④ — BaseRepository.list_paginated() 공용 fix 양성대조(실 Postgres).
+
+페드루 AC 리뷰(2026-08-17, PR③/#3157에서 최초 발견) — `list_paginated()` 자체가 count_q에
+cursor를 안 넣어 마지막 페이지에서도 has_more(=X-Total-Count>len(items))가 영구 참이던
+결함. TaskRepository.list_in_projects()는 이 공용 메서드를 안 쓰고 자체 구현이라 별도 fix가
+필요했지만, `GoalRepository.list_goals()`는 기본 order_by 분기에서 `super().list_paginated()`를
+그대로 위임한다 — 즉 이미 머지·QA-approved된 list_goals가 같은 결함을 갖고 있었다.
+
+이 파일은 공용 fix(app/repositories/base.py)가 **실제로 그 기존 소비자(list_goals)를
+고쳤다**는 양성대조 하나(페드루 조건②) — GET /api/v2/goals를 limit=2로 3페이지 끝까지
+실제로 걸어 마지막 페이지에서 X-Total-Count == 그 페이지 건수임을 확認한다.
+
+tasks.py의 story_id 스코프 분기(#3157)도 `repo.list_paginated()`를 그대로 호출하므로
+(app/routers/tasks.py — `tasks, total = await repo.list_paginated(limit=limit,
+cursor=cursor_dt, **filters)`) 이 공용 fix로 동일하게 소급 커버된다 — 별도 테스트 불요
+(조건③, cross-check만).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed(session, *, n: int = 5):
+    from app.models.organization import Organization
+    from app.models.pm import Goal
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org2428PR4", slug=f"org2428pr4-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    # 단일 트랜잭션 내 다건은 Postgres now()가 동일값이라(server_default=func.now())
+    # created_at 커서 비교(<)가 동일-timestamp 행을 스킵한다 — 명시 override로 결정적 스태거
+    # (test_2428_pr3_tasks_pagination_realdb.py와 동형 대책).
+    base = datetime.now(timezone.utc)
+    for i in range(n):
+        g = Goal(
+            id=uuid.uuid4(), org_id=org.id, project_id=project.id, title=f"goal-{i}",
+            created_at=base - timedelta(seconds=n - i),
+        )
+        session.add(g)
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "caller_id": caller_id}
+
+
+@pytest.mark.anyio
+async def test_list_goals_last_page_x_total_count_matches_remaining_not_grand_total():
+    """공용 list_paginated() fix 양성대조 — 5건을 limit=2로 GET /api/v2/goals 페이지 끝까지
+    실제로 걸어, 마지막 페이지에서 X-Total-Count == 그 페이지 건수(has_more=False로 정확히
+    떨어짐)까지 확認한다. fix 前엔 이 assert가 실패했을 것(3157과 동일 실패 모양)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, n=5)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            seen_ids: set[str] = set()
+            cursor = None
+            pages = 0
+            last_total = None
+            last_len = None
+            while True:
+                params = {"limit": 2}
+                if cursor:
+                    params["cursor"] = cursor
+                resp = await client.get("/api/v2/goals", params=params)
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                pages += 1
+                seen_ids.update(g["id"] for g in body)
+                last_total = int(resp.headers["x-total-count"])
+                last_len = len(body)
+                has_more = last_total > last_len
+                cursor = resp.headers.get("x-next-cursor")
+                if not has_more or not body:
+                    break
+                assert pages < 10, "무한 루프 방지"
+
+            assert len(seen_ids) == 5, f"5건이 페이지 전체에 걸쳐 정확히 다 나와야: {seen_ids}"
+            assert pages == 3, f"5건/limit=2 → 3페이지(2+2+1)여야: {pages}"
+            assert last_total == last_len, (
+                f"마지막 페이지 X-Total-Count({last_total})가 그 페이지 건수({last_len})와 "
+                f"같아야 has_more=False로 정확히 떨어진다 — grand total(5) 고정이면 여기서 어긋남"
+            )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2428_pr4_mcp_remaining_tools_pagination.py
+++ b/backend/tests/test_2428_pr4_mcp_remaining_tools_pagination.py
@@ -1,0 +1,191 @@
+"""story #2428 PR④ — list_sprints·list_retro_sessions·list_artifacts·list_artifact_comments
+MCP 도구 배선 mock 테스트. BE 축(X-Total-Count 실 total·body meta 실배선)은
+test_2428_pr4_be_pagination_realdb.py가 커버 — 여기는 MCP 도구가 헤더/body-meta를 정확히
+읽어 has_more/limit/cursor를 전달하는지만 mock으로 고정."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _headers(total: int, next_cursor: str | None = None) -> dict:
+    h = {"x-total-count": str(total)}
+    if next_cursor is not None:
+        h["x-next-cursor"] = next_cursor
+    return h
+
+
+# ─── list_sprints (헤더 규약) ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_sprints_signals_has_more():
+    from sprintable_mcp.tools.sprints import ListSprintsInput, list_sprints
+
+    items = [{"id": "s1"}]
+    with patch("sprintable_mcp.tools.sprints.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=15, next_cursor="0:xyz")))
+        out = await list_sprints(ListSprintsInput())
+
+    parsed = json.loads(out[0].text)
+    assert parsed == items
+    assert len(out) == 2
+    assert "0:xyz" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_list_sprints_passes_limit_cursor_through():
+    from sprintable_mcp.tools.sprints import ListSprintsInput, list_sprints
+
+    with patch("sprintable_mcp.tools.sprints.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await list_sprints(ListSprintsInput(limit=5, cursor="0:abc"))
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["limit"] == 5
+    assert kwargs["params"]["cursor"] == "0:abc"
+
+
+@pytest.mark.anyio
+async def test_list_sprints_no_has_more_when_covered():
+    from sprintable_mcp.tools.sprints import ListSprintsInput, list_sprints
+
+    items = [{"id": "s1"}, {"id": "s2"}]
+    with patch("sprintable_mcp.tools.sprints.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=2)))
+        out = await list_sprints(ListSprintsInput())
+
+    assert len(out) == 1
+
+
+# ─── list_retro_sessions (헤더 규약) ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_retro_sessions_signals_has_more():
+    from sprintable_mcp.tools.retro import ListRetroSessionsInput, list_retro_sessions
+
+    items = [{"id": "r1"}]
+    with patch("sprintable_mcp.tools.retro.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=6, next_cursor="0:xyz")))
+        out = await list_retro_sessions(ListRetroSessionsInput())
+
+    parsed = json.loads(out[0].text)
+    assert parsed == items
+    assert len(out) == 2
+    assert "0:xyz" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_list_retro_sessions_passes_limit_cursor_through():
+    from sprintable_mcp.tools.retro import ListRetroSessionsInput, list_retro_sessions
+
+    with patch("sprintable_mcp.tools.retro.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj"
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await list_retro_sessions(ListRetroSessionsInput(limit=5, cursor="0:abc"))
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["limit"] == 5
+    assert kwargs["params"]["cursor"] == "0:abc"
+
+
+# ─── list_artifacts (body meta 규약) ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_artifacts_signals_has_more_from_body_meta():
+    from sprintable_mcp.tools.visual_artifacts import ListArtifactsInput, list_artifacts
+
+    shape = {"data": [{"id": "a1"}], "error": None, "meta": {"has_more": True, "next_cursor": "2026-08-17T00:00:00+00:00"}}
+    with patch("sprintable_mcp.tools.visual_artifacts.client") as mock_client:
+        mock_client.get = AsyncMock(return_value=shape)
+        out = await list_artifacts(ListArtifactsInput())
+
+    parsed = json.loads(out[0].text)
+    assert parsed == shape["data"]
+    assert len(out) == 2
+    assert "2026-08-17T00:00:00+00:00" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_list_artifacts_no_has_more_when_last_page():
+    from sprintable_mcp.tools.visual_artifacts import ListArtifactsInput, list_artifacts
+
+    shape = {"data": [{"id": "a1"}], "error": None, "meta": {"has_more": False, "next_cursor": None}}
+    with patch("sprintable_mcp.tools.visual_artifacts.client") as mock_client:
+        mock_client.get = AsyncMock(return_value=shape)
+        out = await list_artifacts(ListArtifactsInput())
+
+    assert len(out) == 1
+
+
+@pytest.mark.anyio
+async def test_list_artifacts_passes_limit_cursor_through():
+    from sprintable_mcp.tools.visual_artifacts import ListArtifactsInput, list_artifacts
+
+    shape = {"data": [], "error": None, "meta": {"has_more": False, "next_cursor": None}}
+    with patch("sprintable_mcp.tools.visual_artifacts.client") as mock_client:
+        mock_client.get = AsyncMock(return_value=shape)
+        await list_artifacts(ListArtifactsInput(limit=5, cursor="2026-08-17T00:00:00+00:00"))
+
+    _, kwargs = mock_client.get.call_args
+    assert kwargs["params"]["limit"] == 5
+    assert kwargs["params"]["cursor"] == "2026-08-17T00:00:00+00:00"
+
+
+@pytest.mark.anyio
+async def test_list_artifacts_bare_array_backcompat():
+    """구 bare-array 응답(롤백/미갱신 BE)도 하위호환으로 통과 — meta 없으면 has_more=False."""
+    from sprintable_mcp.tools.visual_artifacts import ListArtifactsInput, list_artifacts
+
+    with patch("sprintable_mcp.tools.visual_artifacts.client") as mock_client:
+        mock_client.get = AsyncMock(return_value=[{"id": "a1"}])
+        out = await list_artifacts(ListArtifactsInput())
+
+    parsed = json.loads(out[0].text)
+    assert parsed == [{"id": "a1"}]
+    assert len(out) == 1
+
+
+# ─── list_artifact_comments (body meta 규약) ─────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_artifact_comments_signals_has_more_from_body_meta():
+    from sprintable_mcp.tools.visual_artifacts import ListArtifactCommentsInput, list_artifact_comments
+
+    shape = {"data": [{"id": "c1"}], "error": None, "meta": {"has_more": True, "next_cursor": "2026-08-17T00:00:00+00:00"}}
+    with patch("sprintable_mcp.tools.visual_artifacts.client") as mock_client:
+        mock_client.get = AsyncMock(return_value=shape)
+        out = await list_artifact_comments(ListArtifactCommentsInput(artifact_id="art-1"))
+
+    parsed = json.loads(out[0].text)
+    assert parsed == shape["data"]
+    assert len(out) == 2
+
+
+@pytest.mark.anyio
+async def test_list_artifact_comments_passes_limit_cursor_through():
+    from sprintable_mcp.tools.visual_artifacts import ListArtifactCommentsInput, list_artifact_comments
+
+    shape = {"data": [], "error": None, "meta": {"has_more": False, "next_cursor": None}}
+    with patch("sprintable_mcp.tools.visual_artifacts.client") as mock_client:
+        mock_client.get = AsyncMock(return_value=shape)
+        await list_artifact_comments(ListArtifactCommentsInput(artifact_id="art-1", limit=5, cursor="2026-08-17T00:00:00+00:00"))
+
+    args, kwargs = mock_client.get.call_args
+    assert args[0] == "/api/v2/visual-artifacts/art-1/comments"
+    assert kwargs["params"]["limit"] == 5
+    assert kwargs["params"]["cursor"] == "2026-08-17T00:00:00+00:00"

--- a/backend/tests/test_mcp_retro_paths.py
+++ b/backend/tests/test_mcp_retro_paths.py
@@ -28,10 +28,13 @@ def _client(**methods):
 
 
 async def test_list_retro_sessions_calls_real_path():
-    client = _client(get=[])
+    """story #2428 PR④: X-Total-Count/X-Next-Cursor 헤더 기반 페이지네이션으로 전환 —
+    client.get 대신 client.get_with_headers를 호출한다."""
+    client = _client()
+    client.get_with_headers = AsyncMock(return_value=([], {"x-total-count": "0"}))
     with patch.object(r, "client", client):
         await r.list_retro_sessions(r.ListRetroSessionsInput())
-    assert client.get.call_args.args[0] == "/api/v2/retros"
+    assert client.get_with_headers.call_args.args[0] == "/api/v2/retros"
 
 
 async def test_create_retro_session_calls_real_path():

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -153,19 +153,26 @@ async def test_list_retro_sessions_200():
 
 @pytest.mark.anyio
 async def test_list_retro_sessions_no_project_id_filters_by_access():
-    """project_id 생략 시 org 전체가 아니라 has_project_access 통과분만 반환(#1801 스윕)."""
+    """project_id 생략 시 org 전체가 아니라 accessible project 스코프만 반환(#1801 스윕).
+
+    story #2428 PR④(2026-08-17): org-wide 분기가 세션마다 has_project_access를 개별
+    호출하는 Python post-filter에서 accessible_project_ids_in_org 기반 SQL-level IN
+    스코프(RetroSessionRepository.list_in_projects)로 바뀌었다 — 같은 최종 계약(무권한
+    project의 세션은 안 보임)을 새 seam(accessible_project_ids_in_org)으로 고정."""
     client, session, app = await _client()
     try:
         accessible = _mock_session(project_id=PROJECT_ID)
-        inaccessible = _mock_session(project_id=OTHER_PROJECT_ID)
-        mock_result = MagicMock()
-        mock_result.scalars.return_value.all.return_value = [accessible, inaccessible]
-        session.execute = AsyncMock(return_value=mock_result)
 
-        async def fake_access(_db, _user_id, project_id, _org_id):
-            return project_id == PROJECT_ID
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 1
+        item_result = MagicMock()
+        item_result.scalars.return_value.all.return_value = [accessible]
+        session.execute = AsyncMock(side_effect=[count_result, item_result])
 
-        with patch("app.routers.retros.has_project_access", new=AsyncMock(side_effect=fake_access)):
+        with patch(
+            "app.services.project_auth.accessible_project_ids_in_org",
+            new=AsyncMock(return_value=[PROJECT_ID]),
+        ):
             async with client as c:
                 resp = await c.get("/api/v2/retros")
 


### PR DESCRIPTION
## Summary
story #2428 ⓐ 나머지 4건(`list_sprints`/`list_retro_sessions`/`list_artifacts`/`list_artifact_comments`) 페이지네이션 배선 + 그 과정에서 발견한 `BaseRepository.list_paginated()` 공용 결함 fix.

## ⓐ 4건 배선
- `list_sprints`/`list_retro_sessions`: goals.py/tasks.py와 동일 규약(limit/cursor/X-Total-Count/X-Next-Cursor 헤더, 필터 適用 後·limit 適用 前 COUNT에 cursor 포함). org-wide(project_id 미지정) 분기는 기존 Python post-filter(`has_project_access`/`accessible_project_ids_in_org` 후처리)를 각 리포지토리의 신규 `list_in_projects()`(SQL-level `project_id IN (...)`)로 교체 — DB-level limit/cursor와 post-filter가 결합하면 페이지 건수가 다시 줄어드는 함정(TaskRepository와 동형) 회피.
- `list_artifacts`/`list_artifact_comments`: `visual_artifacts.py`가 이미 자체 `{data,error,meta}` 봉투를 쓰고 있어(stories.py 계열의 헤더 규약과 wire shape가 다름) 그 가족(docs.py 정본 규약 A — limit+1 오버페치 + `meta.has_more`/`next_cursor`)을 그대로 미러링. COUNT 쿼리 없이 오버페치만으로 판정하므로 아래 결함 클래스가 구조적으로 없음.

## ⚠️ QA-approved 코드 변경 — `BaseRepository.list_paginated()`
list_sprints/list_retro_sessions 구현 중 발견: 이 공용 메서드의 `count_q`가 애초 cursor 조건을 안 봤다(item-fetch `q`에만 붙음) — 마지막 페이지에서도 `X-Total-Count`가 cursor-무관 grand total로 고정돼 `has_more`(`=total>len(items)`)가 영구 참이 되는 결함. **story #2428 PR③(#3157)에서 페드루군이 `TaskRepository.list_in_projects()`(자체 구현, 이 공용 메서드 미사용)에서 먼저 잡은 것과 정확히 같은 결함 클래스**가, 그 메서드를 그대로 위임하는 **이미 머지·QA-approved된 `GoalRepository.list_goals`(#3151)**에도 있었다.

페드루군 승인(2026-08-17, 조건 3개 — 전부 반영):
1. **이 변경이 QA-approved 코드를 건드린다는 것**을 여기 명시. 동작 변화는 "마지막 페이지 `has_more`가 정확히 `False`로 떨어짐" 하나뿐 — 기존 호출부(cursor 없이 부르는 모든 곳, 즉 오늘까지의 실사용 전부) 회귀 없음.
2. **양성대조**: `test_2428_pr4_list_paginated_shared_fix_realdb.py`가 `GET /api/v2/goals`를 limit=2로 3페이지 끝까지 실제로 걸어 마지막 페이지 `X-Total-Count == 그 페이지 건수`를 실 PG로 확認(공용 fix가 기존 소비자를 실제로 고쳤다는 증거) — mutation-kill로 이 fix 자체를 되돌리면 이 테스트가 RED로 떨어짐을 확인 후 복원.
3. **cross-check**: #3157(tasks.py story_id 스코프 분기)도 `repo.list_paginated()`를 그대로 호출 — 이 공용 fix로 동일하게 소급 커버됨(별도 대응 불요, PR 순서 무관하게 base.py 레벨에서 해소).

## 부수발견(스코프 밖, 참고용)
MCP `api_client.py`의 `client.get()`이 응답이 `{"data": ...}` 형태 dict면 **무조건** `data`만 남기고 sibling(예: `meta`)을 통째로 버린다(`request()`의 `unwrap=True` 기본 동작). `docs.py`의 `list_docs` MCP 도구가 바로 이 `{data, meta:{has_more,...}}` 봉투에 의존하는데, 프로덕션 경로에서는 `client.get()`을 거치는 한 `meta`가 항상 스트립되어 `has_more` 안내가 도달하지 못하는 것으로 코드상 보인다(기존 단위 테스트는 `client.get`을 직접 mock해 실 unwrap 로직을 우회하므로 이 결함을 못 잡음). 이번 PR의 `list_artifacts`/`list_artifact_comments`는 그 확립된 관례(및 그 관례에 의존하는 기존 테스트 더블)를 그대로 따랐을 뿐 — 새 결함을 만들지 않았지만 같은 특성을 물려받는다. 별도 판단·스토리 필요.

## Test plan
- [x] `test_2428_pr4_be_pagination_realdb.py` — sprints/retros 프로젝트 스코프·org-wide(접근권 배제) 양쪽 + 마지막 페이지 `has_more=False` 실 PG. artifacts/comments limit+1 오버페치 3페이지 완주.
- [x] `test_2428_pr4_mcp_remaining_tools_pagination.py` — MCP 4개 도구 wiring(mock).
- [x] `test_2428_pr4_list_paginated_shared_fix_realdb.py` — list_goals 양성대조.
- [x] 신규 `list_in_projects()` 2건(sprint/retro) + base.py fix + artifacts 오버페치 로직 전부 mutation-kill(코드 되돌려 RED 확인 후 복원).
- [x] 회귀 스윕: test_retros.py/test_sprints.py/test_epics.py/visual_artifacts 관련 realdb 14개 파일 — 실패 전부 stash 대조로 기존환경 문제(disposable DB 오염) 확認, 순수 회귀 2건(test_retros.py 1·test_mcp_retro_paths.py 1)은 새 구현에 맞춰 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)