### PR TITLE
[BE·MCP] poll_events pagination — story #2428 마지막 ⓐ (PR⑤)

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -726,6 +726,12 @@ async def _route_dispatch_bg(event_id: uuid.UUID) -> None:
             )
 
 
+# story #2428 PR⑤ QA(카디르, 2026-08-17): limit 상수를 라우터 함수 밖으로 빼 테스트가 실제로
+# 「cap 걸림 + has_more」 경계를 작은 값으로 주입해 검증할 수 있게 한다(1000건 넘게 실제로
+# 시딩하지 않고도) — PO 처방 ⓒ.
+_PENDING_EVENTS_DEFAULT_LIMIT = 1000
+
+
 @router.get("/pending", response_model=list[EventResponse])
 async def get_pending_events(
     recipient_id: uuid.UUID = Query(...),
@@ -756,6 +762,15 @@ async def get_pending_events(
     엔드포인트는 «읽으면 준다」가 아니라 「pending으로 남는다」— cursor 없이 다시 부르면 같은
     상위 N건이 그대로 다시 온다(browse형과 다른 이 도구 특유의 함정, poll_events MCP 도구
     안내 문구에서 명시).
+
+    ⚠️의도적 행동 변경(카디르 QA 2026-08-17, PO 처방): `limit` 미지정 시 이전엔 진짜 무제한
+    이었으나 지금은 `_PENDING_EVENTS_DEFAULT_LIMIT`(1000)으로 잘린다 — 이건 «무회귀»가
+    아니라 이 스토리(#2428) 본체가 명시적으로 요구하는 처방 그 자체다("조용히 자르는 기본값만
+    넣으면... #2412의 병을 그대로 재현" — AC2/AC3). 무제한을 그대로 두는 게 아니라 **잘렸으면
+    호출자가 알 수 있게**(`X-Total-Count`가 진짜 남은 건수, `total > len(items)`면 has_more)
+    하는 것이 처방이었다. 계약: **limit 미지정 = 기본 1000 cap + X-Total-Count/has_more로
+    잘림 신호**(이전 「무제한」 계약은 폐기 — 이 엔드포인트의 유일한 소비자인 MCP `poll_events`
+    가 has_more를 이미 소비하므로 이 변경으로 조용히 깨지는 소비자 없음, 전수 grep 확認).
     """
     await assert_caller_is_member(
         recipient_id, auth, db, org_id, detail="Cannot read another member's events",
@@ -786,7 +801,10 @@ async def get_pending_events(
     count_result = await db.execute(select(func.count()).select_from(Event).where(*conds))
     total = int(count_result.scalar_one() or 0)
 
-    q = select(Event).where(*conds).order_by(Event.created_at.asc()).limit(limit if limit is not None else 1000)
+    q = (
+        select(Event).where(*conds).order_by(Event.created_at.asc())
+        .limit(limit if limit is not None else _PENDING_EVENTS_DEFAULT_LIMIT)
+    )
     result = await db.execute(q)
     events = result.scalars().all()
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -22,10 +22,10 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import and_, delete, or_, select, update
+from sqlalchemy import and_, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import (
@@ -731,6 +731,9 @@ async def get_pending_events(
     recipient_id: uuid.UUID = Query(...),
     event_type: str | None = Query(default=None),
     include_recent_delivered_minutes: int = Query(default=30, le=120),
+    limit: int | None = Query(default=None, ge=1, le=2000),
+    cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch after this time(오래된순 정렬 forward-cursor)"),
+    response: Response = None,  # type: ignore[assignment]
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
@@ -744,6 +747,15 @@ async def get_pending_events(
     auth·recipient 검증 없이 읽을 수 있었다 — mark_delivered(write)는 recipient==caller로
     닫혔는데 같은 recipient 축의 이 read fallback이 열려있었다. 동일 패턴(순수 self, admin
     대리열람 흐름 없음)으로 닫는다.
+
+    story #2428 ⓐ: `.limit()`이 아예 없어 pending 무한 누적 위험(만료/reaper는 status=
+    delivered에만 있고 pending 자체는 cap이 없음 — 페드루/디디 그라운딩 2026-08-17). goals.py
+    규약 그대로(필터 適用 後·limit 適用 前 COUNT에 cursor 포함) limit/cursor/X-Total-Count
+    추가. 정렬이 오래된순(asc)이라 cursor는 forward(`created_at > cursor`, artifact_comments와
+    동형). ⚠️MCP 계층엔 mark_delivered를 부르는 도구가 없어(poll_events는 순수 read) 이
+    엔드포인트는 «읽으면 준다」가 아니라 「pending으로 남는다」— cursor 없이 다시 부르면 같은
+    상위 N건이 그대로 다시 온다(browse형과 다른 이 도구 특유의 함정, poll_events MCP 도구
+    안내 문구에서 명시).
     """
     await assert_caller_is_member(
         recipient_id, auth, db, org_id, detail="Cannot read another member's events",
@@ -753,17 +765,35 @@ async def get_pending_events(
         Event.status == "pending",
         and_(Event.status == "delivered", Event.delivered_at >= cutoff),
     )
-    filters = [
+    conds = [
         Event.org_id == org_id,
         Event.recipient_id == recipient_id,
         status_filter,
     ]
     if event_type:
-        filters.append(Event.event_type == event_type)
-    result = await db.execute(
-        select(Event).where(*filters).order_by(Event.created_at.asc())
-    )
+        conds.append(Event.event_type == event_type)
+
+    cursor_dt: datetime | None = None
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except (ValueError, TypeError) as exc:
+            raise HTTPException(
+                status_code=400, detail="invalid cursor: expected ISO 8601 datetime"
+            ) from exc
+        conds.append(Event.created_at > cursor_dt)
+
+    count_result = await db.execute(select(func.count()).select_from(Event).where(*conds))
+    total = int(count_result.scalar_one() or 0)
+
+    q = select(Event).where(*conds).order_by(Event.created_at.asc()).limit(limit if limit is not None else 1000)
+    result = await db.execute(q)
     events = result.scalars().all()
+
+    if response is not None:
+        response.headers["X-Total-Count"] = str(total)
+        if events:
+            response.headers["X-Next-Cursor"] = events[-1].created_at.isoformat()
     return [EventResponse.model_validate(e) for e in events]
 
 

--- a/backend/sprintable_mcp/tools/agent_runs.py
+++ b/backend/sprintable_mcp/tools/agent_runs.py
@@ -42,6 +42,8 @@ class UpdateRunStatusInput(SprintableInput):
 class PollEventsInput(SprintableInput):
     recipient_id: str | None = None
     event_type: str | None = None
+    limit: int | None = None
+    cursor: str | None = None  # 이전 호출의 X-Next-Cursor 헤더 값을 그대로 넘기면 다음 페이지.
 
 
 async def emit_event(args: EmitEventInput) -> list[TextContent]:
@@ -76,13 +78,35 @@ async def update_run_status(args: UpdateRunStatusInput) -> list[TextContent]:
 
 
 async def poll_events(args: PollEventsInput) -> list[TextContent]:
-    """에이전트 수신 대기 이벤트 폴링."""
+    """에이전트 수신 대기 이벤트 폴링. 더 있으면(has_more) 다음 페이지 안내가 별도 텍스트
+    블록으로 붙는다 — 단 이 도구는 순수 read(이 MCP 계층엔 mark_delivered를 부르는 도구가
+    없음)라 다른 list_* 도구와 달리 cursor 없이 그냥 다시 부르면 같은 상위 N건이 그대로
+    다시 온다(«비워지지» 않음). 안내 문구가 그 함정을 명시한다."""
+    from .stories import _has_more_from_headers
+
     recipient = args.recipient_id or client.member_id
     params: dict = {"recipient_id": recipient}
     if args.event_type:
         params["event_type"] = args.event_type
+    if args.limit:
+        params["limit"] = args.limit
+    if args.cursor:
+        params["cursor"] = args.cursor
     try:
-        data = await client.get("/api/v2/events/pending", params=params)
-        return ok(data or [])
+        items, headers = await client.get_with_headers("/api/v2/events/pending", params=params)
+        has_more, next_cursor = _has_more_from_headers(headers, items)
+        blocks = ok(items)
+        if has_more:
+            cursor_hint = f'cursor="{next_cursor}"' if next_cursor else "cursor(서버가 next_cursor를 안 줌 — 호출부 확인 필요)"
+            blocks.append(TextContent(
+                type="text",
+                text=(
+                    f"※ 더 있음 — 이 응답은 {len(items)}건까지만 포함(전량 아님). "
+                    f"이 도구는 mark_delivered를 부르지 않는 순수 read라 cursor 없이 다시 불러도 같은 상위 "
+                    f"{len(items)}건이 그대로 다시 온다(pending이 비워지지 않음) — 나머지를 보려면 "
+                    f"poll_events를 {cursor_hint}로 다시 호출."
+                ),
+            ))
+        return blocks
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/test_2428_pr5_mcp_poll_events_pagination.py
+++ b/backend/tests/test_2428_pr5_mcp_poll_events_pagination.py
@@ -1,0 +1,80 @@
+"""story #2428 PR⑤ — poll_events MCP 도구 배선 mock 테스트. BE 축(X-Total-Count 실 total)은
+test_2428_pr5_poll_events_pagination_realdb.py가 커버 — 여기는 MCP 도구가 헤더를 정확히
+읽어 has_more/limit/cursor를 전달하고, 이 도구 특유의 «다시 불러도 안 비워짐» 안내 문구를
+내는지만 mock으로 고정."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _headers(total: int, next_cursor: str | None = None) -> dict:
+    h = {"x-total-count": str(total)}
+    if next_cursor is not None:
+        h["x-next-cursor"] = next_cursor
+    return h
+
+
+@pytest.mark.anyio
+async def test_poll_events_signals_has_more_with_consume_aware_hint():
+    from sprintable_mcp.tools.agent_runs import PollEventsInput, poll_events
+
+    items = [{"id": "e1"}, {"id": "e2"}]
+    with patch("sprintable_mcp.tools.agent_runs.client") as mock_client:
+        mock_client.member_id = "me"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=5, next_cursor="0:xyz")))
+        out = await poll_events(PollEventsInput())
+
+    parsed = json.loads(out[0].text)
+    assert parsed == items
+    assert len(out) == 2
+    assert "0:xyz" in out[1].text
+    # consume형 특유 안내 — cursor 없이 다시 불러도 안 비워진다는 것을 명시.
+    assert "비워지지 않" in out[1].text
+
+
+@pytest.mark.anyio
+async def test_poll_events_no_has_more_when_covered():
+    from sprintable_mcp.tools.agent_runs import PollEventsInput, poll_events
+
+    items = [{"id": "e1"}]
+    with patch("sprintable_mcp.tools.agent_runs.client") as mock_client:
+        mock_client.member_id = "me"
+        mock_client.get_with_headers = AsyncMock(return_value=(items, _headers(total=1)))
+        out = await poll_events(PollEventsInput())
+
+    assert len(out) == 1
+
+
+@pytest.mark.anyio
+async def test_poll_events_passes_limit_cursor_through():
+    from sprintable_mcp.tools.agent_runs import PollEventsInput, poll_events
+
+    with patch("sprintable_mcp.tools.agent_runs.client") as mock_client:
+        mock_client.member_id = "me"
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await poll_events(PollEventsInput(limit=5, cursor="2026-08-17T00:00:00+00:00"))
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["limit"] == 5
+    assert kwargs["params"]["cursor"] == "2026-08-17T00:00:00+00:00"
+
+
+@pytest.mark.anyio
+async def test_poll_events_defaults_recipient_to_own_member_id():
+    from sprintable_mcp.tools.agent_runs import PollEventsInput, poll_events
+
+    with patch("sprintable_mcp.tools.agent_runs.client") as mock_client:
+        mock_client.member_id = "my-member-id"
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await poll_events(PollEventsInput())
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["recipient_id"] == "my-member-id"

--- a/backend/tests/test_2428_pr5_poll_events_pagination_realdb.py
+++ b/backend/tests/test_2428_pr5_poll_events_pagination_realdb.py
@@ -1,0 +1,159 @@
+"""story #2428 PR⑤(마지막 ⓐ) — `poll_events`(`GET /api/v2/events/pending`) 페이지네이션 실
+Postgres 검증.
+
+그라운딩(디디·페드루, 2026-08-17): `.limit()` 자체가 없어 pending이 무한 누적 가능(만료/
+reaper는 status=delivered에만 있음). goals.py/tasks.py와 동일 규약(필터 適用 後·limit
+適用 前 COUNT에 cursor 포함) — 단 정렬이 오래된순(asc, get_pending_events 기존 결정 무변경)
+이라 cursor는 forward(`created_at > cursor`, artifact_comments와 동형).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_human,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_pending_event(session, org_id, project_id, recipient_id, created_at, event_type="test.event"):
+    from app.models.event import Event
+    e = Event(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, event_type=event_type,
+        recipient_id=recipient_id, recipient_type="human", payload={}, status="pending",
+        created_at=created_at,
+    )
+    session.add(e)
+    await session.commit()
+    return e
+
+
+def _stagger(base: datetime, total: int, seq: int) -> datetime:
+    return base - timedelta(seconds=total - seq)
+
+
+@pytest.mark.anyio
+async def test_get_pending_events_last_page_x_total_count_matches_remaining():
+    """5건을 limit=2로 3페이지 끝까지 실제로 걸어(오래된순 forward-cursor), 마지막 페이지에서
+    X-Total-Count == 그 페이지 건수(has_more=False로 정확히 떨어짐)까지 확認."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            recipient_id, user_id = await _make_human_member(s, org.id, project.id)
+            base = datetime.now(timezone.utc)
+            for i in range(5):
+                await _make_pending_event(s, org.id, project.id, recipient_id, _stagger(base, 5, i))
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            seen_ids: set[str] = set()
+            cursor = None
+            pages = 0
+            last_total = last_len = None
+            while True:
+                params = {"recipient_id": str(recipient_id), "limit": 2}
+                if cursor:
+                    params["cursor"] = cursor
+                resp = await client.get("/api/v2/events/pending", params=params)
+                assert resp.status_code == 200, resp.text
+                body = resp.json()
+                pages += 1
+                seen_ids.update(x["id"] for x in body)
+                last_total = int(resp.headers["x-total-count"])
+                last_len = len(body)
+                has_more = last_total > last_len
+                cursor = resp.headers.get("x-next-cursor")
+                if not has_more or not body:
+                    break
+                assert pages < 10
+            assert len(seen_ids) == 5
+            assert pages == 3
+            assert last_total == last_len
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_pending_events_no_limit_returns_all_and_total_matches():
+    """limit 미지정(기존 동작 무회귀) — 다 오고 X-Total-Count도 같은 값."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            recipient_id, user_id = await _make_human_member(s, org.id, project.id)
+            base = datetime.now(timezone.utc)
+            for i in range(3):
+                await _make_pending_event(s, org.id, project.id, recipient_id, _stagger(base, 3, i))
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/events/pending", params={"recipient_id": str(recipient_id)})
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()) == 3
+            assert resp.headers["x-total-count"] == "3"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_pending_events_invalid_cursor_400():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            recipient_id, user_id = await _make_human_member(s, org.id, project.id)
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/events/pending", params={"recipient_id": str(recipient_id), "cursor": "not-a-datetime"}
+            )
+            assert resp.status_code == 400
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2428_pr5_poll_events_pagination_realdb.py
+++ b/backend/tests/test_2428_pr5_poll_events_pagination_realdb.py
@@ -108,8 +108,10 @@ async def test_get_pending_events_last_page_x_total_count_matches_remaining():
 
 
 @pytest.mark.anyio
-async def test_get_pending_events_no_limit_returns_all_and_total_matches():
-    """limit 미지정(기존 동작 무회귀) — 다 오고 X-Total-Count도 같은 값."""
+async def test_get_pending_events_no_limit_under_default_cap_returns_all():
+    """limit 미지정 + 건수가 기본 cap 밑이면(3 < 1000) 다 오고 X-Total-Count도 같은 값 —
+    카디르 QA(2026-08-17) PO 처방: 이 케이스는 "무회귀" 주장이 아니라 cap 밑에서는 cap이
+    안 보인다는 것만 확認한다(cap 자체의 존재는 아래 boundary 테스트가 별도로 잰다)."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -128,6 +130,45 @@ async def test_get_pending_events_no_limit_returns_all_and_total_matches():
             assert resp.status_code == 200, resp.text
             assert len(resp.json()) == 3
             assert resp.headers["x-total-count"] == "3"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_pending_events_no_limit_hits_default_cap_signals_has_more(monkeypatch):
+    """카디르 QA(2026-08-17) 지적 — «무회귀» 주장이 실제로는 회귀(암묵적 1000 cap)였다. 이제
+    이 엔드포인트 계약은 "limit 미지정 = 기본 cap + X-Total-Count/has_more로 잘림 신호"다
+    (무제한 유지가 아니라 잘림을 호출자가 알 수 있게 하는 것이 story #2428의 처방 그 자체).
+    1000+건을 실제로 시딩하지 않고 `_PENDING_EVENTS_DEFAULT_LIMIT`를 테스트로 낮춰 그 경계를
+    실제로 물린다(PO 처방 ⓒ) — cap이 걸려도 X-Total-Count는 진짜 전체 건수(5)를 유지하고
+    바디는 cap(2)만큼만 옴을 확認."""
+    from app.main import app
+    from app.routers import events as events_module
+
+    monkeypatch.setattr(events_module, "_PENDING_EVENTS_DEFAULT_LIMIT", 2)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            recipient_id, user_id = await _make_human_member(s, org.id, project.id)
+            base = datetime.now(timezone.utc)
+            for i in range(5):
+                await _make_pending_event(s, org.id, project.id, recipient_id, _stagger(base, 5, i))
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            # limit 파라미터 자체를 안 준다 — «기본값이 무제한이 아니라 cap이다»가 검증 대상.
+            resp = await client.get("/api/v2/events/pending", params={"recipient_id": str(recipient_id)})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body) == 2, "기본 cap(테스트 주입값 2)만큼만 와야"
+            assert resp.headers["x-total-count"] == "5", "cap이 걸려도 X-Total-Count는 진짜 전체를 유지"
+            assert int(resp.headers["x-total-count"]) > len(body), "has_more 판정식(total>len)이 True여야"
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_eventbus_s1.py
+++ b/backend/tests/test_eventbus_s1.py
@@ -336,22 +336,28 @@ async def test_recipient_type_resolved_from_db(client, mock_session):
 
 @pytest.mark.anyio
 async def test_get_pending_filters_by_org(client, mock_session, org_id):
-    """GET /pending 은 verified org_id 내 이벤트만 반환해야 함."""
+    """GET /pending 은 verified org_id 내 이벤트만 반환해야 함.
+
+    story #2428 ⓐ 페이지네이션 추가(2026-08-17) — count_q 1건이 늘어 execute가 2번(count+item)
+    불린다(goals.py/tasks.py와 동일 규약). count_result/item_result를 side_effect로 갈라서
+    두 호출 모양을 각각 맞춘다."""
     recipient_id = uuid.uuid4()
     event_same_org = _make_event(recipient_id=recipient_id, org_id=org_id, status="pending")
 
+    count_result = MagicMock()
+    count_result.scalar_one.return_value = 1
     scalars_mock = MagicMock()
     scalars_mock.all.return_value = [event_same_org]
-    result_mock = MagicMock()
-    result_mock.scalars.return_value = scalars_mock
-    mock_session.execute.return_value = result_mock
+    item_result = MagicMock()
+    item_result.scalars.return_value = scalars_mock
+    mock_session.execute.side_effect = [count_result, item_result]
 
     with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
                return_value=None):
         resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
     assert resp.status_code == 200
     # execute 호출 시 org_id 필터가 쿼리에 포함됐는지 — 실제 SQL은 mock이므로 호출 여부로 확인
-    mock_session.execute.assert_called_once()
+    assert mock_session.execute.call_count == 2
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
story #2428의 마지막 열린 축 — `poll_events`(`GET /api/v2/events/pending`)에 limit/cursor/X-Total-Count 배선.

## 그라운딩
- `.limit()` 자체가 없어 pending 무한 누적 가능 — 만료/reaper는 `status=delivered`(오래된 배달완료 정리)에만 있고 `pending` 자체엔 cap이 없다(코드 확認, grep 0건).
- 라이브 실측(제 recipient_id, 현재 0건)은 "지금 작다"만 증명 — 원 스토리 AC6이 이 도구를 애초에 "시간에 따라 누적" 위험군으로 지목한 근거(cap 부재)는 그대로. `list_sprints`(15건인데도 ⓐ 판정된 그 기준 — 현재 건수 아니라 성장축)와 동형.
- BE: goals.py 규약 그대로(필터 適用 後·limit 適用 前 COUNT에 cursor 포함). 정렬은 기존 오래된순(asc) 무변경 — cursor는 forward(`created_at > cursor`, artifact_comments와 동형).

## ⚠️의도적 행동 변경 — limit 미지정 = 기본 cap(카디르 QA 지적, PO 처방 반영)
카디르 QA가 잡음: 최초 커밋은 "limit 미지정 시 기존 동작 그대로(무회귀)"라 주장했으나, 실제로는 `limit(limit if limit is not None else 1000)`이 암묵적으로 1000건 cap을 신설한 **회귀**였다(develop 원본엔 `.limit()` 자체가 없어 완전 무제한). "무회귀" 테스트도 3건만 시딩해 이 경계를 전혀 못 잡았다.

PO 처방으로 이걸 되돌리지 않고(무제한 보존 = 이 스토리가 없애려는 병 그 자체) **정직하게 재정의**했다:
- 계약: **limit 미지정 = 기본 cap(`_PENDING_EVENTS_DEFAULT_LIMIT`, 1000) + X-Total-Count/has_more로 잘림 신호** — "무제한"이 아니라 "잘렸으면 안다"가 이 스토리의 처방.
- cap을 모듈 상수로 분리해 테스트가 실제로 그 경계를 물게(1000+건 시딩 없이 `monkeypatch`로 작은 값 주입) — 새 boundary 테스트 추가, mutation-kill 검증.
- 이 엔드포인트의 유일한 소비자(전수 grep 확認 — FE/스케줄러 등 다른 소비자 0건)인 MCP `poll_events`는 이미 has_more를 소비하므로 이 cap 변경으로 조용히 깨지는 소비자 없음.

## consume형 vs browse형 (페드루군 지적 반영)
이 MCP 계층엔 `mark_delivered`를 부르는 도구가 없다(`poll_events`는 순수 read) — 즉 cursor 없이 다시 불러도 pending이 «비워지지» 않고 같은 상위 N건이 그대로 다시 온다. `list_*` 계열의 일반 `ok_paginated()` browse형 문구를 그대로 재사용하면 오도 가능해, `poll_events` 전용 안내로 그 함정을 명시했다: "이 도구는 mark_delivered를 부르지 않는 순수 read라 cursor 없이 다시 불러도 같은 상위 N건이 그대로 다시 온다."

## 로컬 검증 노트
기존 재사용 디스포저블 DB가 pre-0088(`team_members`가 VIEW 아닌 물리 테이블)로 드러나 이 경로(FK `events.recipient_id → team_members.id`)를 전혀 실증 못 하는 상태였다 — pg@16용 pgvector 소스빌드 후 `alembic upgrade head`로 신규 마이그된 DB를 만들어 재검증(`team_members` relkind='v' 확認 후 재실행, 전부 초록).

## Test plan
- [x] `test_2428_pr5_poll_events_pagination_realdb.py` — 5건 limit=2 3페이지 완주(마지막 페이지 has_more=False)·**limit 미지정+cap 밑(3건)이면 다 옴**·**limit 미지정+cap 경계(monkeypatch cap=2, 5건 시딩) → cap만큼만 오고 X-Total-Count는 진짜 전체 유지**·invalid cursor 400. 신규 alembic-migrated DB로 실측.
- [x] `test_2428_pr5_mcp_poll_events_pagination.py` — MCP 도구 wiring + consume형 안내 문구(mock).
- [x] count_q cursor 포함 로직 + cap boundary 로직 둘 다 mutation-kill(되돌려 RED 확인 후 복원).
- [x] `test_eventbus_s1.py::test_get_pending_filters_by_org` — execute 호출 수 변화(count_q 추가)에 맞춰 갱신.
- [x] 회귀 스윕(신규 마이그된 DB): agent_runs·eventbus·mcp_path_contract_guard·get_read_db lint·Query sentinel lint 전부 초록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
