### PR TITLE
[SID:2701] 호스티드 MCP env를 배포 파이프라인 SSOT로 — AC3 잔여

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -187,6 +187,10 @@ jobs:
             # ⚠️승격 병합(promo/backplane-20260723): 위 백플레인 3플래그(develop)와 이 REALTIME_URL
             # 전환(main #2439)은 서로 무관한 prod env 출력이라 둘 다 보존한다.
             echo "realtime_url=https://realtime.sprintable.ai" >> "$GITHUB_OUTPUT"
+            # story #2701(2026-08-17) — sprintable-mcp-prod의 라이브 실측(gcloud describe)
+            # 그대로 durable화. dev엔 이 값이 없다(아래 dev 분기 참조, 조용히 맞추지 않음 —
+            # dev는 CORS/host allowlist 자체가 아직 필요하지 않다는 뜻으로 실측된 그대로 둔다).
+            echo "mcp_allowed_hosts=sprintable-mcp-prod-787818285179.asia-northeast3.run.app,mcp.sprintable.ai" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
@@ -307,6 +311,11 @@ jobs:
             # 없어 까심군이 사용자 경로 재측정을 못 하고 있었다. dev만 켠다(#2158 취지 자체가
             # "손 gcloud로 안 켠다"라 SSOT 경유 필수).
             echo "backend_sse_transient_replay_enabled=true" >> "$GITHUB_OUTPUT"
+            # story #2701(2026-08-17) — dev sprintable-mcp의 라이브 실측(gcloud describe)엔
+            # MCP_ALLOWED_HOSTS 자체가 없다(prod 분기 참조) — 명시로 빈 값을 두지 않는다.
+            # cloudbuild.yaml deploy-mcp가 이 값이 비어 있으면 그 env var 자체를 안 실어(조건
+            # 분기), dev 서비스에 새로 빈 문자열 env가 안 생긴다(오늘 실측 그대로 무변경).
+            echo "mcp_allowed_hosts=" >> "$GITHUB_OUTPUT"
           fi
 
       # story #2827 P0 핫픽스 2차(2026-08-03, 페드루 dispatch-test 실측) — 1차 핫픽스가 조립
@@ -345,8 +354,9 @@ jobs:
           V_FRONTEND_MIN_INSTANCES: ${{ steps.env.outputs.frontend_min_instances }}
           V_FRONTEND_MAX_INSTANCES: ${{ steps.env.outputs.frontend_max_instances }}
           V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED: ${{ steps.env.outputs.backend_sse_transient_replay_enabled }}
+          V_MCP_ALLOWED_HOSTS: ${{ steps.env.outputs.mcp_allowed_hosts }}
         run: |
-          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\""
+          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\",_MCP_ALLOWED_HOSTS=\"${V_MCP_ALLOWED_HOSTS}\""
           echo "substitutions=${SUBST}" >> "$GITHUB_OUTPUT"
 
       - name: Submit Cloud Build

--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -190,7 +190,17 @@ jobs:
             # story #2701(2026-08-17) — sprintable-mcp-prod의 라이브 실측(gcloud describe)
             # 그대로 durable화. dev엔 이 값이 없다(아래 dev 분기 참조, 조용히 맞추지 않음 —
             # dev는 CORS/host allowlist 자체가 아직 필요하지 않다는 뜻으로 실측된 그대로 둔다).
-            echo "mcp_allowed_hosts=sprintable-mcp-prod-787818285179.asia-northeast3.run.app,mcp.sprintable.ai" >> "$GITHUB_OUTPUT"
+            # ⛔fix(디디 교차QA, 2026-08-17): 실값이 호스트 둘을 콤마로 이었는데, 이 문자열이
+            # `gcloud builds submit --substitutions=` 조립(SUBST=, 아래)에 그대로 들어가면 그
+            # 조립 자체가 "key=value,key=value,..." 콤마 목록이라 값 안의 콤마가 다음
+            # substitution의 시작으로 오인돼(gcloud ArgDict 파서는 순수 split(',')·따옴표
+            # 이스케이프 무시) prod 배포가 CLI 파싱 단계에서 죽는다. dev는 이 값이 빈
+            # 문자열이라 이 함정이 안 드러났었다(검증은 "그 값들에 대해서만" 유효했다는
+            # 정확한 사례). 파이프라인 구간(GHA output→SUBST→cloudbuild substitution)은
+            # `|`로 나르고, cloudbuild.yaml deploy-mcp 스텝 안에서 실제 env var로 쓸 때만
+            # `tr '|' ','`로 콤마 복원한다(앱이 받는 최종 env var 값 자체는 무변경 — MCP_ALLOWED_HOSTS
+            # 는 여전히 콤마구분).
+            echo "mcp_allowed_hosts=sprintable-mcp-prod-787818285179.asia-northeast3.run.app|mcp.sprintable.ai" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -558,9 +558,21 @@ steps:
         # 안 싣는다 — 명시로 빈 값을 실으면 "값 없음"과 "빈 문자열"이 앱 입장에서 다른 뜻일 수
         # 있어(예: allowlist 빈 배열=전부 거부 vs 미설정=검증 스킵) 오늘 실측 그대로(dev엔 이
         # 키가 없다)를 보존한다.
-        ENV_VARS="MCP_TRANSPORT=http,SPRINTABLE_API_URL=${_FASTAPI_URL}"
+        #
+        # ⛔fix(디디 교차QA, 2026-08-17) — prod 실값(mcp.sprintable.ai 등 호스트 둘을 콤마로
+        # 이은 문자열)이 이 파이프라인을 두 겹으로 지난다: ①GHA→cloudbuild `--substitutions=`
+        # 조립(그 자체가 comma-분리 ArgDict) ②아래 `--update-env-vars=`(마찬가지로 comma-분리
+        # ArgDict). 값 안의 콤마가 둘 중 어느 층에서든 "다음 key=value의 시작"으로 오인되면
+        # CLI 파싱이 죽는다(dev는 이 값이 비어 있어 검증 경로에서 안 드러났던 함정). ①은 GHA
+        # output을 `|` 구분자로 나르는 것으로 이미 해소(위 cloud-build.yml 주석 참조·
+        # ${_MCP_ALLOWED_HOSTS}는 여기 도달할 때 이미 `|`-구분 상태). ②는 gcloud의 커스텀
+        # ArgDict 구분자 이스케이프(`gcloud topic escaping`) — 아래서 `^;^` 접두로 이 플래그의
+        # 구분자를 `,`에서 `;`로 바꿔, 값 안의 콤마가 안전한 리터럴이 되게 한다(모든 하위
+        # key=value를 `;`로 나열).
+        ENV_VARS="MCP_TRANSPORT=http;SPRINTABLE_API_URL=${_FASTAPI_URL}"
         if [ -n "${_MCP_ALLOWED_HOSTS}" ]; then
-          ENV_VARS="$${ENV_VARS},MCP_ALLOWED_HOSTS=${_MCP_ALLOWED_HOSTS}"
+          MCP_ALLOWED_HOSTS_COMMA=$(printf '%s' "${_MCP_ALLOWED_HOSTS}" | tr '|' ',')
+          ENV_VARS="$${ENV_VARS};MCP_ALLOWED_HOSTS=$${MCP_ALLOWED_HOSTS_COMMA}"
         fi
         # AGENT_API_KEY — story #2701(PO 판정, 2026-08-17): plain substitution 금지(cloudbuild.yaml은
         # git 파일 — API 키 평문 커밋 사고 방지). dev/prod 각자 라이브 값을 그대로 Secret Manager로
@@ -574,7 +586,7 @@ steps:
         gcloud run services update sprintable-mcp-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \
           --region=${_AR_REGION} \
-          --update-env-vars="$${ENV_VARS}" \
+          --update-env-vars="^;^$${ENV_VARS}" \
           --update-secrets="AGENT_API_KEY=$${AGENT_KEY_SECRET}:latest" \
           --quiet
         # 검산: 「배포 success」가 아니라 «서빙 이미지가 backend 와 같은 태그인가»로 잰다.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,6 +10,9 @@ substitutions:
   _AR_REPO: sprintable
   _DEPLOY_ENV: dev
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
+  # story #2701 — dev-safe 기본값(빈 문자열 = 이 env var 자체를 안 싣는다, 아래 deploy-mcp
+  # 참조). GHA cloud-build.yml이 prod에서만 실값으로 override.
+  _MCP_ALLOWED_HOSTS: ''
   _BACKEND_MIN_INSTANCES: '1'
   # ⚠️ default '1'(아래) = _DEPLOY_ENV:dev default 와 정합한 **dev-safe fallback**(수동 `gcloud builds submit`
   #    override 없을 때 무리한 maxScale 재현 차단). GHA cloud-build.yml 이 per-env override(prod=5·dev=8, #2074 응급).
@@ -527,14 +530,21 @@ steps:
   #  두 가지를 가리켜, 처음엔 그쪽을 원인으로 짚었다가 이미지 태그를 열어 보고 갈렸다.)
   # ⇒ 그래서 오늘 고친 MCP 인자 검증(#2412)이 **정작 그 도구를 쓰는 서버에는 안 닿아 있었다.**
   #
-  # ⚠️이 스텝이 **하지 않는 것**(선언): `services update --image` 만 쓰므로 **환경변수는 안 건드린다.**
-  # mcp 서비스의 env 는 지금도 파이프라인 밖(손 설정)이다 — 그 SSOT 화는 별건이다.
-  # `run deploy` 를 안 쓰는 이유가 이것이다: 지정 안 한 설정이 기본값으로 되돌아가면
-  # 「배포가 손 고침을 지우는」 쪽 사고가 난다(deploy-realtime 주석의 #2078 사례와 같은 병).
+  # ⚠️story #2701(2026-08-17) 후속 — 위 #2426이 「env는 파이프라인 밖(손 설정)」이라 선언했던
+  # 그 잔여를 여기서 닫는다. SSOT 위치 = 이 스텝(플레인 값)+아래 AGENT_API_KEY 시크릿
+  # (MCP_AGENT_API_KEY_DEV/MCP_AGENT_API_KEY_PROD, Secret Manager) — backend/realtime 스텝과
+  # 동일 관례(--update-env-vars additive·--update-secrets, --set-env-vars/--env-vars-file
+  # 전체교체 금지 그대로 승계). `services update`→`run deploy`로 바꾸지 않는다(이미지 갱신
+  # 방식 자체는 위 #2426 판단 그대로 유효 — env만 추가 배선).
+  #
+  # AC1 census(2026-08-17, gcloud describe 실측, 값은 기록 안 함— 이름만):
+  #   dev  = MCP_TRANSPORT · SPRINTABLE_API_URL · AGENT_API_KEY(시크릿화 대상)
+  #   prod = 위 셋 + MCP_ALLOWED_HOSTS(dev엔 없음 — CORS/host allowlist가 아직 dev엔
+  #          불필요하다는 뜻으로 실측된 그대로 두고 조용히 안 맞춘다, 위 GHA 주석 참조)
   #
   # ⚠️realtime 과 달리 **prod 게이트를 두지 않는다** — `sprintable-mcp-prod` 는 이미 존재하고
   # 실제로 요청을 받고 있다(2026-08-02 실측). backend-prod 가 이 파이프라인으로 갱신되는데
-  # mcp-prod 만 안 따라가는 것이 바로 이 스토리가 없애려는 «불일치»다.
+  # mcp-prod 만 안 따라가는 것이 바로 #2426이 없애려던 «불일치»다.
   - id: deploy-mcp
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
     entrypoint: bash
@@ -542,9 +552,30 @@ steps:
       - -c
       - |
         set -euo pipefail
+        # story #2701: MCP_TRANSPORT·SPRINTABLE_API_URL은 dev/prod 공통 배선(SPRINTABLE_API_URL은
+        # 이 파일 다른 스텝의 _FASTAPI_URL과 값 동일 — 새 substitution 안 만들고 재사용).
+        # MCP_ALLOWED_HOSTS는 dev에서 빈 문자열(_MCP_ALLOWED_HOSTS 기본값)이면 그 키 자체를
+        # 안 싣는다 — 명시로 빈 값을 실으면 "값 없음"과 "빈 문자열"이 앱 입장에서 다른 뜻일 수
+        # 있어(예: allowlist 빈 배열=전부 거부 vs 미설정=검증 스킵) 오늘 실측 그대로(dev엔 이
+        # 키가 없다)를 보존한다.
+        ENV_VARS="MCP_TRANSPORT=http,SPRINTABLE_API_URL=${_FASTAPI_URL}"
+        if [ -n "${_MCP_ALLOWED_HOSTS}" ]; then
+          ENV_VARS="$${ENV_VARS},MCP_ALLOWED_HOSTS=${_MCP_ALLOWED_HOSTS}"
+        fi
+        # AGENT_API_KEY — story #2701(PO 판정, 2026-08-17): plain substitution 금지(cloudbuild.yaml은
+        # git 파일 — API 키 평문 커밋 사고 방지). dev/prod 각자 라이브 값을 그대로 Secret Manager로
+        # 1회 이관(MCP_AGENT_API_KEY_DEV/_PROD, 키 회전 아님·사본 이동)해 backend deploy-backend
+        # 스텝의 DATABASE_URL_* secretKeyRef 관례를 그대로 재사용한다.
+        if [ "${_DEPLOY_ENV}" == "prod" ]; then
+          AGENT_KEY_SECRET="MCP_AGENT_API_KEY_PROD"
+        else
+          AGENT_KEY_SECRET="MCP_AGENT_API_KEY_DEV"
+        fi
         gcloud run services update sprintable-mcp-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \
           --region=${_AR_REGION} \
+          --update-env-vars="$${ENV_VARS}" \
+          --update-secrets="AGENT_API_KEY=$${AGENT_KEY_SECRET}:latest" \
           --quiet
         # 검산: 「배포 success」가 아니라 «서빙 이미지가 backend 와 같은 태그인가»로 잰다.
         served=$(gcloud run services describe sprintable-mcp-${_DEPLOY_ENV} \
@@ -556,7 +587,11 @@ steps:
           echo "  기대: $expected"
           exit 1
         fi
+        # story #2701 AC3 양성대조 일부: env 이름 목록이 배포 전후 동일한지(값은 안 찍음).
+        names=$(gcloud run services describe sprintable-mcp-${_DEPLOY_ENV} \
+          --region=${_AR_REGION} --format='value(spec.template.spec.containers[0].env[].name)')
         echo "OK: sprintable-mcp-${_DEPLOY_ENV} = backend:${COMMIT_SHA}"
+        echo "OK: sprintable-mcp-${_DEPLOY_ENV} env names = $names"
     waitFor: [run-migrate-job]
 
   # story #2185(2026-07-27) — GCE MIG(realtime-gateway) 자동배포. deploy-realtime(위, Cloud


### PR DESCRIPTION
## 요약
story #2426(호스티드 MCP 자동배포)이 남긴 AC3 잔여 — MCP Cloud Run 서비스의 env(MCP_TRANSPORT/SPRINTABLE_API_URL/AGENT_API_KEY/MCP_ALLOWED_HOSTS)가 지금도 손 설정이라, 누군가 `--env-vars-file`로 전체교체하거나 서비스를 재생성하면 조용히 사라지는 리스크.

## AC1 census(gcloud describe, 이름만)
- `sprintable-mcp-dev`: `MCP_TRANSPORT` · `SPRINTABLE_API_URL` · `AGENT_API_KEY`
- `sprintable-mcp-prod`: 위 셋 + `MCP_ALLOWED_HOSTS`(dev엔 없음 — 조용히 안 맞추고 명시로 기록)

## AGENT_API_KEY → Secret Manager(PO 판정, 산티아고군 동의)
plain env로만 서빙 중이던 실 API 키값을 `MCP_AGENT_API_KEY_DEV`/`MCP_AGENT_API_KEY_PROD` 신규 secret으로 이관(회전 아님, 사본 이동만). 값은 `gcloud describe`→json 파싱→`gcloud secrets create --data-file=<임시파일>` 파이프라인으로 직접 전달, 임시파일은 생성 직후 `shred -u`로 삭제 — 제 터미널 출력에 값이 단 한 번도 안 찍혔음. IAM: 두 MCP 서비스 다 default compute SA로 서빙 중이고 이미 프로젝트 레벨 secretAccessor 보유(추가 grant 불요, 확認 완료).

## 구현
- `deploy-mcp` 스텝을 `--update-env-vars`(additive, backend/realtime 관례 그대로)+`--update-secrets`로 확장 — `--set-env-vars`/`--env-vars-file` 전체교체 금지.
- `MCP_ALLOWED_HOSTS`는 비어있으면(dev) 그 키 자체를 안 실음 — "값 없음"과 "빈 문자열"이 다른 뜻일 수 있어 오늘 실측 상태를 그대로 보존.
- `.github/workflows/cloud-build.yml`에 `mcp_allowed_hosts` per-env output 신설.
- "env는 파이프라인 밖" 주석 제거, SSOT 위치로 대체.
- 배포 후 env 이름 목록을 CI 로그에 남겨(값 제외) AC3 양성대조 증거를 자동 축적.

## 검증
- YAML 문법 양쪽 파일 통과.
- `$${VAR}` 이스케이핑(story #2423이 지목한 함정) 신규 3곳 전부 재확認.
- ⚠️ 실 배포·라이브 왕복 검증은 CI/CD merge 트리거에서만(prod 영향 회피 위해 로컬에서 gcloud builds submit 직접 실행 안 함) — 머지 후 dev 배포 라이브 왕복이 최종 AC3 확認.

## 스코프 밖
PyPI 로컬 패키지 트랙(#2257 AC6 그대로 승계).

## QA
제 자신의 인프라 건이라 셀프 QA 불가 — 미르코/디디 교차 QA 요청.

🤖 Generated with [Claude Code](https://claude.com/claude-code)