### PR TITLE
[SID:2182] realtime-gateway MIG create에 instance-redistribution-type=none 명시

### DIFF
--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -662,13 +662,19 @@ if gcloud compute instance-groups managed describe "${MIG_NAME}" \
             --quiet
 
         # ③ create — 신규 MIG(재생성 경로).
+        # story #2182(2026-08-17, 미르코 실측) — regional MIG의 silent default는
+        # instance-redistribution-type=proactive다. SSE는 long-lived라 이 자발적 zone
+        # 재분배(관측 주기 ~1~2h)가 시작될 때마다 1~3분 내 502 버스트가 뜬다는 것을 분단위
+        # 상관대조+음성대조(재분배 없는 구간 502=0건)로 확定했다 — --instance-redistribution-type
+        # 을 명시 안 하면 이 create 경로(강제재생성)를 탈 때마다 proactive로 도로 돌아간다.
         log "Creating MIG ${MIG_NAME} (size ${TARGET_SIZE}, zones ${ZONES}, no autoscaling)"
         gcloud compute instance-groups managed create "${MIG_NAME}" \
             --project="${GCP_PROJECT}" \
             --region="${GCP_REGION}" \
             --template="${TEMPLATE_NAME}" \
             --size="${TARGET_SIZE}" \
-            --zones="${ZONES}"
+            --zones="${ZONES}" \
+            --instance-redistribution-type=none
     else
         # 기본 경로 — MIG 객체를 그대로 두고 인스턴스 템플릿만 교체(rolling-update).
         # backend-service 부착·named-ports는 MIG 객체 자체의 속성이라 이 경로에서 전혀 안
@@ -717,13 +723,15 @@ if gcloud compute instance-groups managed describe "${MIG_NAME}" \
         fi
     fi
 else
+    # story #2182 — 위 create 경로와 동일 이유(silent default=proactive → SSE 502).
     log "Creating MIG ${MIG_NAME} (size ${TARGET_SIZE}, zones ${ZONES}, no autoscaling)"
     gcloud compute instance-groups managed create "${MIG_NAME}" \
         --project="${GCP_PROJECT}" \
         --region="${GCP_REGION}" \
         --template="${TEMPLATE_NAME}" \
         --size="${TARGET_SIZE}" \
-        --zones="${ZONES}"
+        --zones="${ZONES}" \
+        --instance-redistribution-type=none
 fi
 
 # story #2142(2026-07-23, 오르테가 적발) 근본수정 — named-ports는 MIG 객체 자체의 속성(인스턴스

--- a/backend/tests/test_deploy_gce_redistribution_type_none.py
+++ b/backend/tests/test_deploy_gce_redistribution_type_none.py
@@ -1,0 +1,106 @@
+"""story #2182(2026-08-17, 미르코 실측) — deploy_realtime_gce.sh의 MIG create 호출 2곳
+회귀가드(mock gcloud).
+
+배경: regional MIG의 silent default는 instance-redistribution-type=proactive다. SSE는
+long-lived라 이 자발적 zone 재분배가 시작될 때마다 1~3분 내 502 버스트가 뜨는 것을
+분단위 상관대조+음성대조(재분배 없는 구간 502=0건)로 확定했다. dev MIG의 라이브 값은
+--instance-redistribution-type=none으로 이미 전환했으나, 그 값은 create 경로(신규 생성·
+FORCE_MIG_RECREATE 강제재생성)를 다시 타면 스크립트가 명시하지 않는 한 도로 proactive로
+되돌아간다 — 이 테스트는 그 명시가 실제로 두 create 호출 모두에 실려 나가는지 고정한다.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+
+_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "deploy_realtime_gce.sh")
+
+
+def _mock_gcloud_script(*, mig_exists: bool) -> str:
+    mig_describe_exit = 0 if mig_exists else 1
+    return textwrap.dedent(f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        args="$*"
+        echo "MOCK_GCLOUD_CALL: $args" >> "${{MOCK_GCLOUD_LOG}}"
+
+        case "$args" in
+            *"instance-templates describe"*)
+                exit 0  # 템플릿 이미 존재 — create 스킵.
+                ;;
+            *"instance-groups managed describe"*"format=json(distributionPolicy.zones)"*)
+                echo '{{"distributionPolicy": {{"zones": [{{"zone": "z1"}}, {{"zone": "z2"}}, {{"zone": "z3"}}]}}}}'
+                exit 0
+                ;;
+            *"instance-groups managed describe"*)
+                exit {mig_describe_exit}
+                ;;
+            *"instance-groups managed create"*)
+                echo "$args" >> "${{MOCK_CREATE_ARGS_FILE}}"
+                exit 0
+                ;;
+            *"rolling-action start-update"*)
+                exit 0
+                ;;
+            *"set-named-ports"*)
+                exit 0
+                ;;
+            *"backend-services describe"*)
+                echo "https://.../instanceGroups/${{MIG_NAME:-mig}}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        """)
+
+
+def _run_script(tmp_path, *, mig_exists: bool, force_recreate: bool = False):
+    mock_bin_dir = tmp_path / "mockbin"
+    mock_bin_dir.mkdir()
+    gcloud_path = mock_bin_dir / "gcloud"
+    gcloud_path.write_text(_mock_gcloud_script(mig_exists=mig_exists))
+    gcloud_path.chmod(0o755)
+
+    log_file = tmp_path / "mock_calls.log"
+    create_args_file = tmp_path / "create_args.txt"
+    log_file.write_text("")
+    create_args_file.write_text("")
+
+    env = {
+        **os.environ,
+        "PATH": f"{mock_bin_dir}:{os.environ['PATH']}",
+        "DRY_RUN": "0",
+        "COMMIT_SHA": "deadbeef",
+        "MIG_NAME": "sprintable-realtime-gateway-dev",
+        "MOCK_GCLOUD_LOG": str(log_file),
+        "MOCK_CREATE_ARGS_FILE": str(create_args_file),
+    }
+    if force_recreate:
+        env["FORCE_MIG_RECREATE"] = "1"
+
+    proc = subprocess.run(
+        ["bash", _SCRIPT, "dev"],
+        capture_output=True, text=True, env=env,
+    )
+    create_args = create_args_file.read_text().strip()
+    return proc, create_args
+
+
+def test_fresh_mig_create_includes_redistribution_type_none(tmp_path):
+    """⭐신규 MIG(존재하지 않는 경우) create 호출에 --instance-redistribution-type=none이
+    실린다 — 이게 빠지면 silent default(proactive)로 502 버스트 재발."""
+    proc, create_args = _run_script(tmp_path, mig_exists=False)
+    assert "--instance-redistribution-type=none" in create_args, (
+        f"신규 MIG create에 플래그 누락 — got: {create_args!r} (stdout={proc.stdout!r})"
+    )
+
+
+def test_force_recreate_mig_create_includes_redistribution_type_none(tmp_path):
+    """⭐FORCE_MIG_RECREATE=1(강제재생성) 경로도 동일 — delete 後 create 호출에 실려야 한다."""
+    proc, create_args = _run_script(tmp_path, mig_exists=True, force_recreate=True)
+    assert "--instance-redistribution-type=none" in create_args, (
+        f"강제재생성 create에 플래그 누락 — got: {create_args!r} (stdout={proc.stdout!r})"
+    )


### PR DESCRIPTION
## 무엇을 왜

story #2182 그라운딩(2026-08-17, 미르코) — dev SSE의 지배적 실패모드였던 502를 GCE MIG의
PROACTIVE 인스턴스 재분배 사이클과 분단위로 상관대조(3개 독립 사이클 전부 인스턴스 생성
후 1~3분 내 502 버스트, 사이클 사이 조용한 구간은 502=0건 — 음성대조)해 인과를 확定했다.

`instance-redistribution-type`이 PROACTIVE였던 건 의도된 선택이 아니라 — 이 스크립트
어디에도 플래그가 없어 GCP regional MIG의 silent default가 그대로 방치돼 있었다.

dev MIG 라이브 값은 페드루 승인 하에 이미 `gcloud ... update --instance-redistribution-type=none`
으로 즉시 적용·서비스 무영향 확認(3/3 healthy 유지, `/api/v2/ping` 5연속 200) — 이 PR은
그 값이 **재생성 시에도 유지**되도록 스크립트 SSOT에 반영하는 후속.

## 이번 PR에서 한 일

- `deploy_realtime_gce.sh`의 두 `instance-groups managed create` 호출(FORCE_MIG_RECREATE
  강제재생성 경로·신규 첫 생성 경로) 모두에 `--instance-redistribution-type=none` 추가 —
  누락 시 다음 재생성 때 silent default(proactive)로 되돌아가 502가 재발한다는 것을 주석에
  명시.
- 라이브 값 자체(이미 적용됨)는 이 PR과 무관 — 이 PR은 재생성 경로에서의 "도로 돌아감" 방지.

## 테스트

- [x] `tests/test_deploy_gce_redistribution_type_none.py`(신규, mock gcloud) — 신규 MIG
  create·FORCE_MIG_RECREATE 강제재생성 create 둘 다 플래그 포함 확認. mutation-kill: 신규
  create 경로의 플래그를 제거 → 해당 테스트만 정확히 RED(강제재생성 테스트는 별도 create
  호출이라 영향 없음 확認) → 원복 후 GREEN.
- [x] 인접 회귀: `test_deploy_realtime_gce_env.py`·`test_deploy_gce_rolling_update_maxsurge_failfast.py`·
  `test_deploy_gce_template_pruning.py` 포함 54/54 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)