### PR TITLE
[BE·인가·프로젝트 스코프] GET /api/v2/tasks에 project_id 필터 신설 (#2697 클래스, story #2706)

### DIFF
--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -99,6 +99,7 @@ async def _assert_task_project_access(
 
 @router.get("", response_model=list[TaskResponse])
 async def list_tasks(
+    project_id: uuid.UUID | None = Query(default=None),
     story_id: uuid.UUID | None = Query(default=None),
     assignee_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
@@ -114,7 +115,16 @@ async def list_tasks(
     """story #2428 PR③(⓪tasks ⓐ — 라이브 실측 667건, list_tasks/list_my_tasks/get_overdue_tasks
     3-way 공유 엔드포인트): true cursor 페이지네이션 + 전체 카운트(X-Total-Count 헤더) —
     goals.py list_goals와 동일 규약(필터 適用 後·limit 適用 前 COUNT, cursor=created_at, 새
-    규약 발명 0). limit 미지정 시 기존 동작(최대 1000)과 호환."""
+    규약 발명 0). limit 미지정 시 기존 동작(최대 1000)과 호환.
+
+    story #2706(디디 3157 작업 중 부수발견): 이 엔드포인트엔 `project_id` 필터 자체가 없어
+    accessible한 «전» 프로젝트의 task가 한 응답에 섞여 나가고 있었다(#2697 「GET-by-id가
+    X-Project-Id 무시」와 같은 클래스의 목록판) — MCP `list_tasks`/`list_my_tasks`/
+    `get_overdue_tasks` 셋 다 이미 `project_id=client.require_project_id()`를 보내고
+    있었지만(sprintable_mcp/tools/tasks.py·analytics.py 실측 확認) 라우터가 그 파라미터를
+    안 받아 FastAPI가 조용히 버렸다(AC4 — 배선만으로 해소, MCP측 코드 변경 불요). 지정 시
+    `require_project_access`(#2697 판정 함수 SSOT, 새 판정 발명 0)로 접근권 검증 後 그
+    프로젝트로 좁힌다 — 미지정 시 기존 org-wide 동작 그대로(AC2, 회귀 0)."""
     # story #2262 PR②(칩 상태 배치조회) — stories.py list_stories의 ids= 패턴 미러링. Task엔
     # project_id 컬럼이 없어(story_id NN) list_in_projects와 동형으로 Story JOIN을 거쳐야
     # 접근권 스코프를 낼 수 있다 — repo.list_by_ids(org-scope만)로 앵커 조회 後, 결과의
@@ -173,11 +183,21 @@ async def list_tasks(
         # 없이 열거. round6은 story_id 벡터만 닫고 이 result-level 누출은 분리 트래킹됐다(d3e5ca89).
         # caller가 실제 접근권을 가진 project의 task로만 스코프(Task엔 project_id가 없어 Story
         # JOIN으로 환원). 접근권 0이면 빈 리스트. assignee_id/status는 그 위 추가 narrowing 필터.
-        from app.services.project_auth import accessible_project_ids_in_org
+        from app.services.project_auth import accessible_project_ids_in_org, require_project_access
 
-        accessible = await accessible_project_ids_in_org(
-            repo.session, uuid.UUID(auth.user_id), org_id
-        )
+        if project_id is not None:
+            # story #2706 AC1/AC3: project_id 지정 시 그 프로젝트로 좁힌다 — 접근권 없으면
+            # require_project_access(#2697 SSOT)가 404(존재 비노출).
+            await require_project_access(
+                repo.session, uuid.UUID(auth.user_id), project_id, org_id,
+                not_found_detail="Project not found",
+            )
+            accessible = [project_id]
+        else:
+            # AC2: 미지정 시 기존 org-wide 동작 그대로(회귀 0).
+            accessible = await accessible_project_ids_in_org(
+                repo.session, uuid.UUID(auth.user_id), org_id
+            )
         tasks, total = await repo.list_in_projects(
             accessible, assignee_id=assignee_id, status=status_filter, status_ne=status_ne,
             limit=limit, cursor=cursor_dt,

--- a/backend/tests/test_2706_mcp_tasks_project_id_passthrough.py
+++ b/backend/tests/test_2706_mcp_tasks_project_id_passthrough.py
@@ -1,0 +1,58 @@
+"""story #2706 AC4 — list_tasks/list_my_tasks/get_overdue_tasks MCP 도구가 이미 보내고 있던
+project_id가(sprintable_mcp/tools/tasks.py·analytics.py) 실제로 출력 params에 실리는지 실측
+(BE 라우터가 그동안 이 파라미터를 안 받아 조용히 버려지고 있었다 — MCP측 코드 변경은 이
+스토리 스코프에 없음, 배선만으로 해소되는지 확認하는 회귀가드)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _headers(total: int) -> dict:
+    return {"x-total-count": str(total)}
+
+
+@pytest.mark.anyio
+async def test_list_tasks_sends_project_id():
+    from sprintable_mcp.tools.tasks import ListTasksInput, list_tasks
+
+    with patch("sprintable_mcp.tools.tasks.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj-123"
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await list_tasks(ListTasksInput())
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["project_id"] == "proj-123"
+
+
+@pytest.mark.anyio
+async def test_list_my_tasks_sends_project_id():
+    from sprintable_mcp.tools.tasks import ListMyTasksInput, list_my_tasks
+
+    with patch("sprintable_mcp.tools.tasks.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj-123"
+        mock_client.member_id = "me"
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await list_my_tasks(ListMyTasksInput())
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["project_id"] == "proj-123"
+
+
+@pytest.mark.anyio
+async def test_get_overdue_tasks_sends_project_id():
+    from sprintable_mcp.tools.analytics import OverdueMemberInput, get_overdue_tasks
+
+    with patch("sprintable_mcp.tools.analytics.client") as mock_client:
+        mock_client.require_project_id = lambda: "proj-123"
+        mock_client.get_with_headers = AsyncMock(return_value=([], _headers(total=0)))
+        await get_overdue_tasks(OverdueMemberInput())
+
+    _, kwargs = mock_client.get_with_headers.call_args
+    assert kwargs["params"]["project_id"] == "proj-123"

--- a/backend/tests/test_2706_tasks_project_id_filter_realdb.py
+++ b/backend/tests/test_2706_tasks_project_id_filter_realdb.py
@@ -1,0 +1,202 @@
+"""story #2706 — GET /api/v2/tasks에 project_id 필터 신설(#2697 클래스, story #2428 PR③ 작업
+중 디디 부수발견). org-wide(story_id 미지정) 분기가 project_id 필터 자체가 없어 accessible한
+전 프로젝트 task가 한 응답에 섞여 나갔다 — project_id 지정 시 require_project_access(#2697
+SSOT, 새 판정 발명 0)로 접근권 검증 後 그 프로젝트로만 좁힌다. 미지정 시 기존 org-wide 동작
+회귀 0.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_two_projects_with_tasks(session):
+    """org에 project A(caller 접근권 O)·project B(caller 접근권 X) — 각각 story+task 2개씩."""
+    from app.models.organization import Organization
+    from app.models.pm import Story, Task
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org2706", slug=f"org2706-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="B")
+    session.add(project_a)
+    session.add(project_b)
+    await session.commit()
+
+    story_a = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="SA")
+    story_b = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="SB")
+    session.add(story_a)
+    session.add(story_b)
+    await session.commit()
+
+    base = datetime.now(timezone.utc)
+    for i in range(2):
+        session.add(Task(
+            id=uuid.uuid4(), org_id=org.id, story_id=story_a.id, title=f"a{i}",
+            created_at=base - timedelta(seconds=10 - i),
+        ))
+    for i in range(2):
+        session.add(Task(
+            id=uuid.uuid4(), org_id=org.id, story_id=story_b.id, title=f"b{i}",
+            created_at=base - timedelta(seconds=10 - i),
+        ))
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    # caller는 project A만 접근권 — project B는 미부여(negative 케이스).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "caller_id": caller_id,
+    }
+
+
+@pytest.mark.anyio
+async def test_project_id_specified_scopes_to_that_project_only():
+    """AC1 — project_id 지정 시 그 프로젝트 tasks만(count도 같은 필터)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_projects_with_tasks(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/tasks", params={"project_id": str(seeded["project_a_id"])})
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert {t["title"] for t in body} == {"a0", "a1"}
+            assert resp.headers["x-total-count"] == "2"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_id_without_access_is_404():
+    """AC3 — 접근 없는 project_id는 404(#2697 require_project_access 판정 재사용)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_projects_with_tasks(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/tasks", params={"project_id": str(seeded["project_b_id"])})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_id_unspecified_keeps_org_wide_behavior_no_regression():
+    """AC2 — 미지정 시 기존 org-wide 동작 유지(caller가 접근권 가진 project만이지만 project_id
+    자체를 지정 안 했을 때는 project A의 task만 옴 — caller가 B엔 접근권이 없으므로 org-wide
+    이지만 실질적으로 A만 보이는 게 기존 동작 그대로임을 확認)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_projects_with_tasks(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/tasks")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert {t["title"] for t in body} == {"a0", "a1"}
+            assert resp.headers["x-total-count"] == "2"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
story #2428 PR③ 작업 중 부수발견 — `GET /api/v2/tasks`(list_tasks/list_my_tasks/get_overdue_tasks 3-way 공유)엔 `project_id` 필터 파라미터 자체가 없어, org-wide 분기가 accessible한 **전** 프로젝트의 task를 한 응답에 섞어 냈다(#2697 「GET-by-id가 X-Project-Id 무시」와 같은 클래스의 목록판).

## 발견의 의미 — MCP는 이미 project_id를 보내고 있었다
`sprintable_mcp/tools/tasks.py`(`list_tasks`/`list_my_tasks`)·`analytics.py`(`get_overdue_tasks`) 셋 다 `params["project_id"] = client.require_project_id()`를 이미 실어 보내고 있었다(grep 확認) — 라우터가 그 파라미터를 안 받아 FastAPI가 조용히 버렸을 뿐. 즉 **MCP측 코드 변경 없이 BE 배선만으로 해소**된다(AC4).

## 구현
- `project_id: uuid.UUID | None = Query(default=None)` 추가.
- 지정 시 `require_project_access()`(#2697이 세운 GET/PATCH/DELETE-by-id 판정 함수 SSOT, 새 판정 발명 0)로 접근권 검증 後 그 프로젝트로 좁힘 — 무권한이면 404(존재 비노출, #2697과 동일 관례).
- 미지정 시 기존 org-wide 동작 완전 무변경(회귀 0).
- `story_id`/`ids` 분기는 스코프 밖(이미 각자 접근권 스코프됨) — AC가 요구한 org-wide 분기만.

## Test plan
- [x] `test_2706_tasks_project_id_filter_realdb.py` — AC1(지정 시 그 프로젝트만+total 일치)·AC2(미지정 무회귀)·AC3(무권한 project_id→404, #2697 판정 재사용) 실 PG.
- [x] `test_2706_mcp_tasks_project_id_passthrough.py` — AC4, 3개 MCP 도구 모두 `project_id`가 실제로 outgoing params에 실림을 mock으로 재확認(이미 보내고 있었다는 grep 결과의 실측 고정).
- [x] mutation-kill: project_id 가드 제거 → AC3(무권한 404) 테스트가 정확히 200으로 RED, 복원 후 GREEN.
- [x] 회귀 스윕(신규 alembic-migrated DB): tasks 관련 기존 realdb 파일 전부·`has_project_access 403 lint`·`mcp_path_contract_guard`·`Query sentinel lint` 전부 초록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)