### PR TITLE
[SID:2157] dev dual_publish 해제 — 3주째 방치된 조건부 해제 집행

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -288,7 +288,15 @@ jobs:
             # realtime 쪽 값(EVENT_BROKER_REDIS_DISPATCH_ENABLED 포함)은 cloudbuild.yaml의
             # deploy-realtime 스텝이 이미 dev 전용 가드 안에서 직접 명시(변수 아님).
             echo "redis_url=redis://10.164.120.243:6379" >> "$GITHUB_OUTPUT"
-            echo "backend_redis_dual_publish_enabled=true" >> "$GITHUB_OUTPUT"
+            # story #2157 해제 판(2026-08-17, 미르코 그라운딩·페드루 확定) — dual_publish는
+            # #2123 cutover(2026-07-25 15:43 KST)의 롤백 안전망이었다. 해제 조건 3개(①72h
+            # 무사고=Redis 배달 오류 신규 클래스 0 ②PG_LISTEN 재활성 0회 ③SSOT 경유) 전부
+            # 실측 PASS(Cloud Logging 21일간 redis 오류 0건·git log 이후 PG_LISTEN 롤백 커밋
+            # 0건) — 3주째 방치돼 있던 조건부 해제를 여기서 dev부터 집행한다. PG_LISTEN이 이미
+            # 꺼져 있어 이 스위치가 켜져 있어도 롤백 경로 자체가 무의미했다(pg_notify는 무조건
+            # 나가지만 듣는 프로세스가 0개 — 원 스토리 ④). prod(위 main 분기)는 별도 판단 —
+            # 여기서 안 건드림.
+            echo "backend_redis_dual_publish_enabled=false" >> "$GITHUB_OUTPUT"
             # story #2123 S0-b(2026-07-23, 오르테가군 판정): wake_agent()의 크로스인스턴스
             # 배달이 #2122 머지 이후에도 무효였던 이유 — 이 발행측 스위치(agent_gateway.py:224
             # 게이팅)가 꺼져 있어 event_broker를 계속 우회했다(직접 pg_notify만, Redis 미발행).


### PR DESCRIPTION
## ⛔ 머지 보류 — 08-18T03:49Z 이후

**머지 보류 사유**: story #2182(dev SSE 502 그라운딩, instance-redistribution-type=NONE
처방 적용됨) 24h done-gate 관측 창이 진행 중이다. `cloudbuild.yaml`에서 `deploy-backend`와
`deploy-realtime-gce`(#2182 관측 대상 realtime-gateway-dev MIG의 배포 스텝)가 같은
파이프라인 트리거 안에서 병렬로 돈다 — 이 PR이 develop에 머지되면 dual_publish 값 자체와
무관하게 그 배포가 realtime-gateway-dev를 새 템플릿으로 rolling-update시켜 관측 창을
오염시킨다(자발적 PROACTIVE 재분배 인과와 배포發 rolling-update 인과가 섞여 502 원인
귀속이 흐려짐).

**해제 예정 시각**: 2026-08-17T03:49 UTC + 24h = **2026-08-18T03:49 UTC 이후**. 그 전엔
게이트(리뷰·QA)까지 통과시켜 두고 머지만 미룬다 — 페드루 확定 후 실행.

## 무엇을 왜

story #2157 — org 이벤트 팬아웃이 멤버 N배(현재 18배)로 터지는 구조적 비용 중 ④(pg_notify
N회, dual_publish 여부와 무관)는 #2123 cutover로 PG LISTEN이 전 층에서 꺼진 뒤로 순수
낭비가 됐다. `DUAL_PUBLISH`는 그 cutover의 롤백 안전망이었고, 원 스토리가 해제 조건 3개를
숫자로 미리 못박아 뒀다(결과 보고 판단하지 않기 위해):

```
① cutover(2026-07-25 15:43 KST) 後 72시간 무사고 — Redis 배달 오류 신규 클래스 0
② 그 기간 PG_LISTEN 재활성(롤백) 0회
③ 해제는 손 gcloud 금지 — 배포 SSOT(cloudbuild.yaml·GHA)에서 내린다
```

72h 시점(2026-07-27 15:43 KST)은 이미 3주 지났으나, dev/prod 두 분기 모두 조건부 해제
로직 자체가 없이 무조건 `true`가 하드코딩돼 있었다(방치의 실체).

## 그라운딩(2026-08-17, 미르코)

- ① Redis 배달 오류: Cloud Logging `severity>=WARNING`, `textPayload:"redis"` — backend-prod·
  backend-dev 둘 다 21일(cutover 전체 구간 커버) 조회, **0건**.
- ② PG_LISTEN 롤백: `git log --since="2026-07-25 15:43" -- .github/workflows/cloud-build.yml
  cloudbuild.yaml` — PG_LISTEN_ENABLED를 true로 되돌린 커밋 **0건**. 라이브 `gcloud run
  services describe`도 prod·dev 둘 다 현재 `PG_LISTEN_ENABLED=false`로 일치(롤백 흔적 없음).
- ③ SSOT 확認: 실제 값의 출처는 `cloudbuild.yaml`이 아니라 이 워크플로우의 env-결정
  스텝(`echo "backend_redis_dual_publish_enabled=true"`) — dev(REF_NAME != main 분기)·
  prod(REF_NAME == main 분기) 둘 다 무조건 true였다.

**⇒ 3개 조건 전부 PASS.**

## 이번 PR에서 한 일

- dev 분기(REF_NAME != main)의 `backend_redis_dual_publish_enabled`를 `true`→`false`.
- prod 분기(REF_NAME == main, 위쪽)는 이 PR에서 안 건드림 — dev 우선 단계적 승격.
- 리스크: dev의 Redis 소비 경로가 발행을 못 받게 됨 — 그러나 PG_LISTEN이 이미 꺼져 있어
  이 스위치가 만드는 "롤백 안전망" 자체가 3주째 무의미했다(그게 이 판의 요지). 실질 리스크는
  이미 0.

## 검증

- YAML 파싱 확認(`yaml.safe_load`) — 문법 정상.
- 이 GHA 워크플로우 파일의 bash 로직을 커버하는 기존 pytest 하네스 없음(deploy_realtime_gce.sh와
  달리 mock 실행 인프라 미존재) — 이 값 하나만 바뀌는 단순 diff라 새 하네스 신설은 과함,
  실 검증은 다음 dev 배포 후 `gcloud run services describe sprintable-backend-dev`로
  `EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=false` 확認으로 대신함(머지 후 자연 배포 시).

## Story link

story #2157: [\[E-ARCH·성능\] org 이벤트 팬아웃이 멤버 N배로 터짐](https://sprintable-app-url/stories/58729b25-9105-4f4b-a1e3-49384707033c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)