### PR TITLE
[FE·결재] doc-gate-section approve에 GateSignatureApproval 배선 + doc_approval high 세트 명시 등재

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1855,6 +1855,7 @@
     "docGateRequestReview": "Request review",
     "docGateRequestReviewHint": "Request a review and the assigned reviewer will approve or reject this document.",
     "docGateApprove": "Approve",
+    "docGateTransitionErrorGeneric": "Failed to process the gate. Please try again.",
     "docGateReject": "Reject",
     "docGateRejectModalTitle": "Reject review",
     "docGateRejectReasonLabel": "Rejection reason (shared with the author)",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1855,6 +1855,7 @@
     "docGateRequestReview": "검토 요청",
     "docGateRequestReviewHint": "이 문서를 검토 요청하면 지정 검토자가 승인/반려합니다.",
     "docGateApprove": "승인",
+    "docGateTransitionErrorGeneric": "게이트 처리에 실패했습니다. 다시 시도해 주세요.",
     "docGateReject": "반려",
     "docGateRejectModalTitle": "검토 반려",
     "docGateRejectReasonLabel": "반려 사유 (작성자에게 전달됩니다)",

--- a/apps/web/scripts/tint-color-text-baseline.json
+++ b/apps/web/scripts/tint-color-text-baseline.json
@@ -48,7 +48,13 @@
     "미르코가 approvals-queue.tsx의 승인 버튼을 hover:text-success→hover:text-foreground로",
     "고쳤다(#2590 TIER3와 동일 패턴을 놓친 자리 — rest는 ghost버튼=투명 배경이라 실위반 아니고,",
     "tint는 hover-only인데 same-literal 스캐너가 rest/hover를 못 가려 flag). 리터럴이 바뀌어",
-    "re-key만 필요(PO 판정, 이 PR의 실 e2e(B) 가드가 fix 전/후를 실 픽셀로 이미 교차검증함)."
+    "re-key만 필요(PO 판정, 이 PR의 실 e2e(B) 가드가 fix 전/후를 실 픽셀로 이미 교차검증함).",
+    "",
+    "story #6c89e40d(2026-08-17) 재키잉 — 위 두 사례(workflow-line-editor-section.tsx·",
+    "approvals-queue.tsx)와 완전히 같은 이유·같은 오탐: doc-gate-section.tsx의 doc 결재",
+    "approve 버튼을 hover:text-success→hover:text-foreground로 고쳤다(rest는 ghost버튼=",
+    "투명 배경이라 실위반 아니고, tint는 hover-only인데 same-literal 스캐너가 rest/hover를",
+    "못 가려 flag). 리터럴이 바뀌어 re-key만 필요(페드루 PO 판정)."
   ],
   "keys": [
     "app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx::success::border-success bg-success-tint text-success",
@@ -65,7 +71,7 @@
     "components/docs/doc-gate-section.tsx::destructive::bg-destructive/10 text-destructive",
     "components/docs/doc-gate-section.tsx::info::bg-info-tint text-info",
     "components/docs/doc-gate-section.tsx::success::bg-success-tint text-success",
-    "components/docs/doc-gate-section.tsx::success::h-7 gap-1 text-success hover:bg-success-tint hover:text-success",
+    "components/docs/doc-gate-section.tsx::success::h-7 gap-1 text-success hover:bg-success-tint hover:text-foreground",
     "components/docs/extensions/file-node.tsx::destructive::flex h-[38px] w-[38px] flex-shrink-0 items-center justify-center rounded-md bg-destructive/10 text-destructive",
     "components/hypotheses/hypothesis-gate-badge.tsx::success::h-7 gap-1 text-success hover:bg-success-tint hover:text-success",
     "components/inbox/approvals-queue.tsx::success::h-7 gap-1 text-success hover:bg-success-tint hover:text-foreground",

--- a/apps/web/src/components/docs/doc-gate-section.test.tsx
+++ b/apps/web/src/components/docs/doc-gate-section.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+//
+// story #6c89e40d(페드루 PO 판정 2026-08-17, ⓑ) — doc-gate-section의 approve()가 note/
+// evidence_viewed 없이 PATCH를 쐈다(dev 08-15 실사고, gate 5a34ef7f가 정확히 이 경로로
+// 422). GateSignatureApproval을 canonical(gates/[id]/page.tsx·approvals-queue.tsx)과
+// 동일 패턴으로 배선했는지 — high-risk gate에서 승인 버튼이 서명 다이얼로그를 열고,
+// bare fetch(note 없는 approve)를 더 이상 쏘지 않는지 고정한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import type { GateItem } from '@/components/kanban/types';
+
+const { useDashboardContextMock } = vi.hoisted(() => ({
+  useDashboardContextMock: vi.fn(),
+}));
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+function gate(overrides: Partial<GateItem>): GateItem {
+  return {
+    id: 'gate-1',
+    org_id: 'org-1',
+    work_item_id: 'doc-1',
+    work_item_type: 'doc',
+    gate_type: 'doc_approval',
+    status: 'pending',
+    resolver_id: null,
+    resolved_at: null,
+    resolution_note: null,
+    neutral_facts: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    source: 'gate',
+    can_approve: true,
+    risk_grade: 'high',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'member-1' });
+});
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function renderSection(pendingGate: GateItem) {
+  const { DocGateSection } = await import('./doc-gate-section');
+  const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+    if (typeof url === 'string' && url.includes('/api/gates?')) {
+      return new Response(JSON.stringify([pendingGate]), { status: 200 });
+    }
+    if (typeof url === 'string' && url.includes('/revisions')) {
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }
+    if (typeof url === 'string' && url.includes('/team-members')) {
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }
+    // gate transition — 이 테스트 스위트가 감시할 호출.
+    return new Response(JSON.stringify({ data: { ...pendingGate, status: 'approved' } }), { status: 200 });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  await act(async () => {
+    root.render(wrap(
+      <DocGateSection docId="doc-1" status="pending" onTransitioned={() => {}} />,
+    ));
+  });
+  // load()의 3개 병렬 fetch가 끝날 때까지 마이크로태스크 flush.
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+  return fetchMock;
+}
+
+describe('DocGateSection — high-risk(risk_grade=high) 승인은 서명 플로우를 거친다', () => {
+  it('승인 버튼 클릭이 note 없는 bare transition을 쏘지 않고 서명 다이얼로그를 연다', async () => {
+    const fetchMock = await renderSection(gate({}));
+
+    const callCountBeforeClick = fetchMock.mock.calls.length;
+
+    const approveBtn = Array.from(container.querySelectorAll('button'))
+      .find((b) => b.textContent?.includes('승인'));
+    expect(approveBtn).toBeTruthy();
+
+    await act(async () => {
+      approveBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // 다이얼로그를 여는 것만으로는 어떤 fetch도 추가로 안 나가야 한다(예전 bare approve()는
+    // 클릭 즉시 note 없이 transition을 쐈다 — 그 회귀가 다시 생기면 여기서 잡힌다).
+    expect(fetchMock.mock.calls.length).toBe(callCountBeforeClick);
+
+    // GateSignatureApproval의 근거 열람 체크박스/사유 textarea가 실제로 렌더됐는지(서명
+    // 플로우로 정확히 분기됐다는 증거 — 단순히 "클릭해도 안 터진다"만으론 부족).
+    // Dialog(base-ui)는 container 밖 document.body로 portal된다(approvals-queue.tsx의
+    // 서명 Dialog와 동일 구조 — gates/[id]/page.test.tsx의 discuss dialog 케이스 참조).
+    const checkbox = document.body.querySelector('[data-slot="dialog-content"] input[type="checkbox"]');
+    const textarea = document.body.querySelector('[data-slot="dialog-content"] #gate-sig-reason');
+    expect(checkbox).toBeTruthy();
+    expect(textarea).toBeTruthy();
+  });
+
+  it('서명 다이얼로그에서 근거열람+사유 입력 후 승인하면 evidence_viewed:true+note가 실린다', async () => {
+    const fetchMock = await renderSection(gate({}));
+
+    const approveBtn = Array.from(container.querySelectorAll('button'))
+      .find((b) => b.textContent?.includes('승인'));
+    await act(async () => {
+      approveBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const checkbox = document.body.querySelector('[data-slot="dialog-content"] input[type="checkbox"]') as HTMLInputElement;
+    const textarea = document.body.querySelector('[data-slot="dialog-content"] #gate-sig-reason') as HTMLTextAreaElement;
+
+    await act(async () => {
+      checkbox.click();
+    });
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!;
+      setter.call(textarea, '근거 확인함');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const signButtons = Array.from(document.body.querySelectorAll('[data-slot="dialog-content"] button'))
+      .filter((b) => b.textContent?.includes('승인하고 서명'));
+    expect(signButtons.length).toBeGreaterThan(0);
+    const signBtn = signButtons[0]!;
+    expect((signBtn as HTMLButtonElement).disabled).toBe(false);
+
+    await act(async () => {
+      signBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const transitionCall = fetchMock.mock.calls.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('/transition'),
+    );
+    expect(transitionCall).toBeTruthy();
+    const body = JSON.parse((transitionCall![1] as RequestInit).body as string);
+    expect(body.status).toBe('approved');
+    expect(body.evidence_viewed).toBe(true);
+    expect(body.note).toBe('근거 확인함');
+  });
+});

--- a/apps/web/src/components/docs/doc-gate-section.tsx
+++ b/apps/web/src/components/docs/doc-gate-section.tsx
@@ -83,7 +83,7 @@ export function DocGateSection({
   const [auditOpen, setAuditOpen] = useState(false); // 기본 접힘(본문 우선·이력 secondary)
   const [rejectOpen, setRejectOpen] = useState(false);
   const [note, setNote] = useState('');
-  // story #6c89e40d(페드루 PO 판정 2026-08-17, ⓑ) — doc_approval이 ⓐ'로 high 세트에 명시
+  // story #6c89e40d(페드루 PO 판정 2026-08-17, ⓑ) — doc_approval이 ⓐ항목(하위 처방)으로 high 세트에 명시
   // 등재되며 usesSignatureFlow가 항상 true가 되므로, 결재함 카드(approvals-queue.tsx)와
   // 동일 패턴(canonical GateSignatureApproval을 Dialog로) 그대로 배선한다 — 새 UI 발명 0.
   const [sigOpen, setSigOpen] = useState(false);
@@ -259,7 +259,11 @@ export function DocGateSection({
               <Button
                 size="sm"
                 variant="ghost"
-                className="h-7 gap-1 text-success hover:bg-success-tint hover:text-success"
+                // story #9853aa2f(§AC7 가드, 페드루 지적 2026-08-17) — tint 배경 위 계열색
+                // 글자는 hover 순간 대비 최저점(#2420 규칙). approvals-queue.tsx:268/
+                // workflow-line-editor-section.tsx:227과 동일 처방(rest=text-success 유지,
+                // hover만 text-foreground)으로 통일 — 새 패턴 발명 0.
+                className="h-7 gap-1 text-success hover:bg-success-tint hover:text-foreground"
                 disabled={busy}
                 onClick={() => { if (isSigFlow) { setSigError(null); setSigOpen(true); } else approve(); }}
               >

--- a/apps/web/src/components/docs/doc-gate-section.tsx
+++ b/apps/web/src/components/docs/doc-gate-section.tsx
@@ -8,9 +8,11 @@ import {
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateItem } from '@/components/kanban/types';
+import { deriveRiskLevel, usesSignatureFlow } from '@/components/cage/gate-risk';
+import { GateSignatureApproval } from '@/components/cage/gate-signature-approval';
 
 import { fetchWithAuth } from '@/lib/db/client';
 
@@ -81,6 +83,11 @@ export function DocGateSection({
   const [auditOpen, setAuditOpen] = useState(false); // 기본 접힘(본문 우선·이력 secondary)
   const [rejectOpen, setRejectOpen] = useState(false);
   const [note, setNote] = useState('');
+  // story #6c89e40d(페드루 PO 판정 2026-08-17, ⓑ) — doc_approval이 ⓐ'로 high 세트에 명시
+  // 등재되며 usesSignatureFlow가 항상 true가 되므로, 결재함 카드(approvals-queue.tsx)와
+  // 동일 패턴(canonical GateSignatureApproval을 Dialog로) 그대로 배선한다 — 새 UI 발명 0.
+  const [sigOpen, setSigOpen] = useState(false);
+  const [sigError, setSigError] = useState<string | null>(null);
 
   const load = useCallback(async (signal?: AbortSignal) => {
     const [gates, revsJson, membersJson] = await Promise.all([
@@ -132,8 +139,10 @@ export function DocGateSection({
   };
 
   // gate-row resolution transition(approved/rejected). 성공 시 BE가 doc.status를 confirmed/denied로 flip.
-  const gateTransition = async (body: Record<string, unknown>): Promise<boolean> => {
-    if (!gate || busy) return false;
+  // story #6c89e40d — 실 envelope({data,error,meta}, story #2500 교정)에서 에러 문구를 뽑아
+  // 반환한다(gates/[id]/page.tsx transition()과 동일 파싱 — body.detail은 항상 죽어있던 필드).
+  const gateTransition = async (body: Record<string, unknown>): Promise<{ ok: boolean; error?: string }> => {
+    if (!gate || busy) return { ok: false };
     setBusy(true);
     try {
       const res = await fetch(`/api/gates/${gate.id}/transition`, {
@@ -141,10 +150,13 @@ export function DocGateSection({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       });
-      if (res.ok) { onTransitioned(); await load(); return true; }
-      return false;
+      if (res.ok) { onTransitioned(); await load(); return { ok: true }; }
+      const resBody = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+      return { ok: false, error: resBody?.error?.message ?? t('docGateTransitionErrorGeneric') };
     } finally { setBusy(false); }
   };
+
+  const isSigFlow = gate ? usesSignatureFlow(deriveRiskLevel(gate)) : false;
 
   const approve = () => {
     if (!currentTeamMemberId) return;
@@ -153,8 +165,28 @@ export function DocGateSection({
 
   const submitReject = async () => {
     if (!currentTeamMemberId) return;
-    const ok = await gateTransition({ status: 'rejected', resolver_id: currentTeamMemberId, note: note.trim() || null });
+    const { ok } = await gateTransition({ status: 'rejected', resolver_id: currentTeamMemberId, note: note.trim() || null });
     if (ok) { setRejectOpen(false); setNote(''); } // 실패 시 모달 유지·재시도 허용
+  };
+
+  // story #6c89e40d(ⓑ) — GateSignatureApproval 하나가 승인/반려 둘 다 담당(canonical과 동형).
+  // approve만 evidence_viewed=true(canSign 게이팅 자체가 열람 확인 — gates/[id]/page.tsx와 동일 근거).
+  const sigApprove = async (reason: string) => {
+    if (!currentTeamMemberId) return;
+    setSigError(null);
+    const { ok, error } = await gateTransition({
+      status: 'approved', resolver_id: currentTeamMemberId, note: reason.trim() || null, evidence_viewed: true,
+    });
+    if (ok) setSigOpen(false); else setSigError(error ?? null);
+  };
+
+  const sigReject = async (reason: string) => {
+    if (!currentTeamMemberId) return;
+    setSigError(null);
+    const { ok, error } = await gateTransition({
+      status: 'rejected', resolver_id: currentTeamMemberId, note: reason.trim() || null,
+    });
+    if (ok) setSigOpen(false); else setSigError(error ?? null);
   };
 
   // audit 타임라인 이벤트(display 병합): revision = 검토요청/재검토요청, gate resolution = 승인/반려(+사유).
@@ -219,7 +251,7 @@ export function DocGateSection({
                 variant="ghost"
                 className="h-7 gap-1 text-muted-foreground hover:text-destructive hover:ring-1 hover:ring-inset hover:ring-destructive/60"
                 disabled={busy}
-                onClick={() => setRejectOpen(true)}
+                onClick={() => { if (isSigFlow) { setSigError(null); setSigOpen(true); } else setRejectOpen(true); }}
               >
                 <XCircle className="size-3.5" />
                 {t('docGateReject')}
@@ -229,7 +261,7 @@ export function DocGateSection({
                 variant="ghost"
                 className="h-7 gap-1 text-success hover:bg-success-tint hover:text-success"
                 disabled={busy}
-                onClick={approve}
+                onClick={() => { if (isSigFlow) { setSigError(null); setSigOpen(true); } else approve(); }}
               >
                 <CheckCircle className="size-3.5" />
                 {t('docGateApprove')}
@@ -347,6 +379,26 @@ export function DocGateSection({
                 {busy ? '...' : t('docGateRejectConfirm')}
               </Button>
             </div>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+
+      {/* story #6c89e40d(ⓑ) — 고위험 서명 모달. approvals-queue.tsx와 동일 컴포넌트를 동일
+          Dialog 패턴으로(canonical 상세와 1:1, 새 UI 발명 0). */}
+      {sigOpen && gate ? (
+        <Dialog open={sigOpen} onOpenChange={(open) => { if (!open && !busy) setSigOpen(false); }}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{t('docGateLabel')}</DialogTitle>
+            </DialogHeader>
+            <GateSignatureApproval
+              gate={gate}
+              resolving={busy}
+              error={sigError}
+              onApprove={(reason) => void sigApprove(reason)}
+              onReject={(reason) => void sigReject(reason)}
+              compact
+            />
           </DialogContent>
         </Dialog>
       ) : null}

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -28,6 +28,7 @@ from app.models.doc import Doc
 from app.models.gate import Gate, is_valid_transition, set_gate_status
 from app.models.hitl_config import OrgGatePolicy
 from app.models.hypothesis import Hypothesis
+from app.services.doc import DOC_GATE_TYPE
 from app.models.loop import LoopRun
 from app.models.pm import Goal, Sprint, Story, Task
 from app.models.visual_artifact import VisualArtifact
@@ -57,7 +58,15 @@ logger = logging.getLogger(__name__)
 RiskGrade = Literal["low", "high"]
 
 # 2차 축(doc §2.2): posture가 미확定(balanced/미설정)일 때만 참조.
-_HIGH_RISK_GATE_TYPES: frozenset[str] = frozenset({"merge", "deploy", "workflow_config_publish"})
+#
+# story #6c89e40d(페드루 PO 판정 2026-08-17, ⓐ'): doc_approval은 지금까지 이 세트 어디에도
+# 없어 폴백(§2.3 안전판)에 «의존»해서만 high였다 — 실사용 타입이 우연히 폴백과 값이 같다는
+# 사실에 기대는 것과 명시 등재는 다르다(폴백은 "미분류 신규 타입"을 위한 것이지 이미 아는
+# 타입을 위한 것이 아니다). doc-gate-section.tsx의 note-422 실사고(dev 08-15, gate
+# 5a34ef7f)가 정확히 이 간극에서 났다 — FE가 note/evidence_viewed를 안 보내는 채로 배선돼
+# 있었는데 그 사실을 아무 코드도 "doc_approval=high"라고 선언하지 않고 있었다. low로
+# 등재하지 않는다(신중 결재 취지 훼손, PO 명시 판단) — high로 명시.
+_HIGH_RISK_GATE_TYPES: frozenset[str] = frozenset({"merge", "deploy", "workflow_config_publish", DOC_GATE_TYPE})
 _LOW_RISK_GATE_TYPES: frozenset[str] = frozenset({"pr_review", "qa"})
 
 

--- a/backend/tests/test_1972_gate_risk_grade.py
+++ b/backend/tests/test_1972_gate_risk_grade.py
@@ -47,9 +47,20 @@ def _scalar_result(value):
 # ── derive_risk_grade 순수 함수 매트릭스(doc §2 표 그대로) ──────────────────────
 
 # doc §2.1(1차 축=posture)·§2.2(2차 축=gate_type, posture 미확定일 때만)·§2.3(폴백=보수적 고위험)을
-# 표 그대로 옮긴 literal 매트릭스. gate_type 5종(pr_review/qa/merge/deploy/workflow_config_publish) +
-# 신규/미분류 gate_type 대리값("doc_approval")으로 폴백 케이스까지 커버 = posture 4종(conservative/
-# permissive/balanced/None) × gate_type 6종 = 24 조합.
+# 표 그대로 옮긴 literal 매트릭스. gate_type 6종(pr_review/qa/merge/deploy/workflow_config_publish/
+# doc_approval) + 진짜 미분류 gate_type 대리값("_未來_unclassified_gate_type")으로 폴백 케이스까지
+# 커버 = posture 4종(conservative/permissive/balanced/None) × gate_type 7종 = 28 조합.
+#
+# ⛔story #6c89e40d(페드루 PO 판정 2026-08-17, ⓐ'): doc_approval은 원래 이 매트릭스에서 "폴백
+# 대리값" 역할이었다(과거 어느 세트에도 없어 미분류 폴백과 값이 우연히 같았을 뿐) — 이제
+# `_HIGH_RISK_GATE_TYPES`에 명시 등재됐으므로 더 이상 폴백 케이스가 아니다(2차 축에서 직접
+# high로 걸림, doc §2.2). 폴백(§2.3) 자체는 여전히 살아있는 안전판이라 그 경로는 진짜
+# 미분류 값(`_UNCLASSIFIED_GATE_TYPE`)으로 별도 커버한다 — doc_approval을 폴백 대리값에서
+# 빼는 것으로 "이제 폴백 안 탄다"는 사실이 매트릭스에서도 드러나야 한다(회귀가 생기면
+# 매트릭스가 그 자리에서 doc_approval을 다시 «폴백에 의존»하는 값으로 잘못 해석하게 두지 않기
+# 위함).
+_UNCLASSIFIED_GATE_TYPE = "_미래_unclassified_gate_type"
+
 _RISK_GRADE_MATRIX: list[tuple[str | None, str, str]] = [
     # posture=conservative → 항상 high(gate_type 무관, §2.1)
     ("conservative", "pr_review", "high"),
@@ -58,6 +69,7 @@ _RISK_GRADE_MATRIX: list[tuple[str | None, str, str]] = [
     ("conservative", "deploy", "high"),
     ("conservative", "workflow_config_publish", "high"),
     ("conservative", "doc_approval", "high"),
+    ("conservative", _UNCLASSIFIED_GATE_TYPE, "high"),
     # posture=permissive → 항상 low(gate_type 무관, §2.1)
     ("permissive", "pr_review", "low"),
     ("permissive", "qa", "low"),
@@ -65,20 +77,23 @@ _RISK_GRADE_MATRIX: list[tuple[str | None, str, str]] = [
     ("permissive", "deploy", "low"),
     ("permissive", "workflow_config_publish", "low"),
     ("permissive", "doc_approval", "low"),
+    ("permissive", _UNCLASSIFIED_GATE_TYPE, "low"),
     # posture=balanced → 2차 축(gate_type, §2.2) + 폴백(§2.3)
     ("balanced", "pr_review", "low"),
     ("balanced", "qa", "low"),
     ("balanced", "merge", "high"),
     ("balanced", "deploy", "high"),
     ("balanced", "workflow_config_publish", "high"),
-    ("balanced", "doc_approval", "high"),  # 폴백: 미분류 gate_type → 보수적 고위험
+    ("balanced", "doc_approval", "high"),  # 2차 축 명시 등재(더 이상 폴백 아님, ⓐ')
+    ("balanced", _UNCLASSIFIED_GATE_TYPE, "high"),  # 폴백: 진짜 미분류 gate_type → 보수적 고위험
     # posture=None(미설정 row 없음) → 2차 축(gate_type, §2.2) + 폴백(§2.3)
     (None, "pr_review", "low"),
     (None, "qa", "low"),
     (None, "merge", "high"),
     (None, "deploy", "high"),
     (None, "workflow_config_publish", "high"),
-    (None, "doc_approval", "high"),  # 폴백: 미분류 gate_type → 보수적 고위험
+    (None, "doc_approval", "high"),  # 2차 축 명시 등재(더 이상 폴백 아님, ⓐ')
+    (None, _UNCLASSIFIED_GATE_TYPE, "high"),  # 폴백: 진짜 미분류 gate_type → 보수적 고위험
 ]
 
 
@@ -89,6 +104,16 @@ def test_derive_risk_grade_matrix(posture, gate_type, expected):
     assert derive_risk_grade(posture, gate_type) == expected
 
 
+def test_doc_approval_is_explicitly_high_risk_not_fallback():
+    """story #6c89e40d(ⓐ') — doc_approval이 `_HIGH_RISK_GATE_TYPES`에 실제로 들어있는지 직접
+    확認(단순 값 매트릭스 통과만으로는 "폴백이 우연히 같은 값"과 "명시 등재" 둘을 구분 못 함 —
+    바로 이 간극에서 dev 08-15 실사고(gate 5a34ef7f)가 났다)."""
+    from app.services.gate_service import _HIGH_RISK_GATE_TYPES, _LOW_RISK_GATE_TYPES
+
+    assert "doc_approval" in _HIGH_RISK_GATE_TYPES
+    assert "doc_approval" not in _LOW_RISK_GATE_TYPES  # PO 명시 판단: low로 옮기지 않는다
+
+
 def test_derive_risk_grade_matrix_covers_all_gate_types():
     """GATE_TYPES(5종) 전부가 매트릭스에 등장하는지 자기표면화(신규 gate_type 확장 시 매트릭스
     drift 방지 — feedback_one_directional_check_vacuous_pass 교훈: EXPECTED-actual 방향도 확인)."""
@@ -96,7 +121,8 @@ def test_derive_risk_grade_matrix_covers_all_gate_types():
 
     covered = {gt for _, gt, _ in _RISK_GRADE_MATRIX}
     assert GATE_TYPES <= covered  # 5종 전부 매트릭스에 있어야 함
-    assert "doc_approval" in covered  # 폴백(미분류) 대리값도 있어야 함
+    assert "doc_approval" in covered  # 이제 명시 등재 케이스로 커버
+    assert _UNCLASSIFIED_GATE_TYPE in covered  # 폴백(진짜 미분류) 경로도 별도로 커버
 
 
 # ── get_org_posture 쿼리 형태 + resolve_disposition 비호출 구조 확인 ─────────────


### PR DESCRIPTION
## Summary
실사고 확定(페드루군 dev 로그 실측, 08-15, gate 5a34ef7f) — `doc-gate-section.tsx`의 approve()가 note/evidence_viewed 없이 `POST /gates/{id}/transition`을 호출, `doc_approval`이 `_HIGH_RISK_GATE_TYPES`/`_LOW_RISK_GATE_TYPES` 어디에도 명시 등재돼 있지 않아 「미분류 폴백」(§2.3 안전판, 우연히 high와 같은 값)에 의존해서만 high였다 — balanced posture(현 dev org 실측값)에서 그 폴백이 걸려 story #2027의 note+evidence_viewed 필수 422가 실제로 매번 났다(gate 5a34ef7f는 그 결과 reject로 우회 종결).

## PO 처방(ⓐ'+ⓑ)
- **ⓐ' `gate_service.py`**: `doc_approval`을 `_HIGH_RISK_GATE_TYPES`에 명시 등재(폴백 의존 제거) — low 세트로는 옮기지 않음(신중 결재 취지 유지, PO 명시 판단).
- **ⓑ `doc-gate-section.tsx`**: `gates/[id]/page.tsx`·`approvals-queue.tsx`가 이미 쓰는 `GateSignatureApproval`을 동일 Dialog 패턴(결재함 큐와 동형)으로 배선 — 새 UI 발명 0. `gateTransition()`도 실 `{data,error,meta}` envelope에서 에러 문구를 뽑도록 교정(story #2500이 다른 곳에서 이미 고친 `body.detail` 죽은 필드 함정을 여기서도 동시에 봉합).

## 부수 — 테스트 매트릭스 정합
`test_1972_gate_risk_grade.py`는 `doc_approval`을 「미분류 폴백 대리값」으로 써 왔다(과거 실제로 미분류였으니까) — 이제 명시 등재됐으므로 그 역할을 새 합성 미분류 타입으로 넘기고, `doc_approval`이 진짜로 세트에 있는지(폴백이 아니라 등재)를 직접 확認하는 테스트를 추가했다.

## Test plan
- [x] BE: `test_1972_gate_risk_grade.py`(매트릭스 갱신+신규 명시등재 확認) 전부 초록. `test_2027_gate_approval_reason_enforce.py`·`test_2043_ac3_hitl_reason_enforce.py`·doc-gate cascade 계열 전부 무회귀.
- [x] FE: 신규 `doc-gate-section.test.tsx` — high-risk gate에서 승인 클릭 시 note 없는 bare fetch 대신 서명 다이얼로그가 열리는 것, 근거열람+사유 입력 후 제출 시 `evidence_viewed:true`+`note`가 실제로 실리는 것 둘 다 고정.
- [x] BE/FE mutation-kill 각각(BE: high 세트에서 doc_approval 제거 → 재확認 테스트 RED. FE: 서명 분기 우회 → 두 신규 테스트 다 RED) 후 복원·재확認 GREEN.
- [x] `tsc --noEmit`·`eslint` 신규/변경 파일 클린(기존 무관 에러 1건만, toss-payments 패키지 미설치 — 이 PR과 무관).
- [x] approvals-queue/gates 상세/approval-request-card 등 GateSignatureApproval 기존 소비처 전체 스위트 무회귀(150 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)