### PR TITLE
[SID:2295] readiness 신설 — 캐시된 pg_listen 연결상태로 DB 프록시 죽음 감지

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.database import get_db
+from app.services import realtime_readiness
 
 router = APIRouter(prefix="/api/v2", tags=["health"])
 
@@ -14,12 +15,47 @@ async def ping():
 
 
 @router.get("/health")
-async def health_check(db: AsyncSession = Depends(get_db)):
-    """AC2: GET /api/v2/health — DB 연결 포함 헬스체크 (AC3)."""
+async def health_check(response: Response, db: AsyncSession = Depends(get_db)):
+    """AC2: GET /api/v2/health — DB 연결 포함 헬스체크 (AC3).
+
+    story #2295 별개 fix(2026-08-17, 카디르 QA 적발) — 이 엔드포인트가 원래 DB 조회
+    실패를 `db` 필드에만 담고 top-level `status`·HTTP status code는 항상 "ok"/200으로
+    고정 반환했다(호출자가 status만 보면 DB 장애를 절대 못 봄 — 이 스토리 자체가 고치려는
+    "HEALTHY≠일할 수 있음" 병을 이 엔드포인트 자신이 앓고 있었다). `db` 필드 체크(예:
+    setup_dns.sh)는 이미 문자열 매칭이라 무영향, `check_http ... 200` 기대 스크립트는
+    DB가 정상일 때만 여전히 200 — DB가 실제로 죽었을 때만 그 스크립트가 이제 정확히
+    실패를 본다(이게 이 fix의 목적).
+    """
     db_status = "ok"
     try:
         await db.execute(text("SELECT 1"))
     except Exception as exc:
         db_status = f"error: {type(exc).__name__}"
 
+    if db_status != "ok":
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return {"status": "error", "version": "v2", "db": db_status}
+
     return {"status": "ok", "version": "v2", "db": db_status}
+
+
+@router.get("/ready")
+async def readiness_check(response: Response):
+    """story #2295 — 「응답하는가」(/ping)와 「일할 수 있는가」를 가른다.
+
+    이 엔드포인트는 **DB를 조회하지 않는다**(AC3, 체크당 쿼리 0) — `/health`처럼 매 체크마다
+    `SELECT 1`을 날리면 그 자체가 DB 부하이고, DB가 잠깐 흔들리면 멀쩡한 인스턴스까지 전부
+    UNHEALTHY로 떨어뜨려 부분장애를 전면장애로 증폭시킨다(스토리 본문이 명시적으로 "안 하는
+    것"으로 선언한 그 함정). 대신 `pg_pubsub.listen_loop()`가 **이미** 갖고 있는 연결
+    성공/실패 상태기계(자기 재연결 목적으로 원래도 추적하던 사실)를 그대로 읽어 응답한다 —
+    「캐시된 사실을 답한다」(스토리 본문 "하는 것 ②").
+
+    realtime-gateway(GCE MIG, `provision_realtime_gclb.sh`)에서 GCLB healthcheck target을
+    이 엔드포인트로 돌린다 — cloud-sql-proxy가 죽어 `listen_loop()`의 재연결이 계속
+    실패하면(AC4 임계값 이상) 이 응답이 UNHEALTHY로 바뀌어 LB가 그 인스턴스를 빼게 된다
+    (원 인시던트 2026-07-28: 죽은 proxy가 `/ping`으로는 절대 안 보였던 그 자리).
+    """
+    healthy, detail = realtime_readiness.is_ready()
+    if not healthy:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    return {"ready": healthy, **detail}

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -26,6 +26,8 @@ import uuid
 from collections.abc import Coroutine
 from typing import Any
 
+from app.services import realtime_readiness
+
 logger = logging.getLogger(__name__)
 
 INSTANCE_ID: str = str(uuid.uuid4())
@@ -201,6 +203,7 @@ async def listen_loop() -> None:
             await conn.add_listener(_CHANNEL, _on_notification)
             delay = 1.0  # 연결 성공 시 backoff 리셋
             logger.info("pg_listen connected")
+            realtime_readiness.mark_connected()  # story #2295 — readiness 캐시 갱신(DB 왕복 0)
             # 커넥션 유지 — CancelledError까지 대기
             while True:
                 await asyncio.sleep(30)
@@ -209,6 +212,7 @@ async def listen_loop() -> None:
             break
         except Exception as exc:
             logger.warning("pg_listen error: %s — reconnecting in %.1fs", exc, delay)
+            realtime_readiness.mark_disconnected(f"{type(exc).__name__}: {exc}")
         finally:
             if conn is not None:
                 try:

--- a/backend/app/services/realtime_readiness.py
+++ b/backend/app/services/realtime_readiness.py
@@ -1,0 +1,78 @@
+"""story #2295 — 「응답하는가」(/ping)와 「일할 수 있는가」를 가르는 readiness 신호.
+
+2026-07-28 인시던트(민 실증, dev): `realtime-gateway` GCE 인스턴스 재부팅 후
+`cloud-sql-proxy`가 스테일 소켓(`bind: address already in use`)으로 크래시루프 —
+그런데 GCLB 헬스체크(`/ping`, DB 미조회)는 계속 HEALTHY를 줬다. 「프로세스가 응답한다」와
+「DB에 붙어 일할 수 있다」는 다른 질문인데 하나로 재고 있었다.
+
+⛔안 하는 것(스토리 본문 명시) — 이 모듈은 **DB를 직접 조회하지 않는다**. 헬스체크마다
+`SELECT 1`을 날리면 그 자체가 DB 부하고, DB가 잠깐 흔들리면 멀쩡한 인스턴스까지 전부
+UNHEALTHY로 떨어뜨려 부분장애를 전면장애로 증폭시킨다.
+
+하는 것 — `app.services.pg_pubsub.listen_loop()`가 **이미** 자기 재연결 목적으로 갖고
+있던 연결 성공/실패 상태를 이 모듈이 기록만 해두고(모듈 레벨 변수, DB 왕복 0), 아무 때나
+그 「캐시된 사실」을 읽어 답한다.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+# AC4(카디르 제안, 근거): listen_loop()의 재연결 backoff는 1s→2s→4s→8s→16s→30s(cap)로
+# 자란다. 유예시간을 그 backoff 자체의 수렴값(30s)으로 맞추면 — 연결이 끊긴 순간부터
+# 최소 5회(1+2+4+8+16=31s)의 재연결 시도가 그 안에 들어간다 — 「한 번 실패했다고 바로
+# UNHEALTHY」가 아니라 「backoff가 스스로 회복할 기회를 다 쓰고도 여전히 안 되면」이라는
+# 뜻이 된다. 임의 숫자가 아니라 기존 재시도 스케줄 자체를 유예 기준으로 재사용한 것 — 새
+# 임계값 체계를 따로 발명하지 않는다.
+UNHEALTHY_GRACE_SECONDS = 30.0
+
+_connected: bool = False
+_disconnected_since: datetime | None = None
+_last_error: str | None = None
+
+
+def mark_connected() -> None:
+    """listen_loop()이 연결(재)성공 시 호출."""
+    global _connected, _disconnected_since, _last_error
+    _connected = True
+    _disconnected_since = None
+    _last_error = None
+
+
+def mark_disconnected(error: str) -> None:
+    """listen_loop()이 연결 실패/끊김을 감지했을 때 호출 — 최초 실패 시점만 기록."""
+    global _connected, _disconnected_since, _last_error
+    was_connected = _connected
+    _connected = False
+    _last_error = error
+    if was_connected or _disconnected_since is None:
+        _disconnected_since = datetime.now(UTC)
+
+
+def is_ready() -> tuple[bool, dict]:
+    """readiness 판정 — DB/네트워크 왕복 0, 모듈 상태 읽기만.
+
+    연결이 살아있으면 즉시 ready. 끊겼어도 `UNHEALTHY_GRACE_SECONDS` 유예 안이면
+    (listen_loop()의 backoff가 아직 재시도 중일 수 있으므로) 아직 ready로 본다 — 이래야
+    반짝 끊김 한 번에 LB가 인스턴스를 바로 빼는 flapping을 피한다(스토리 AC4 요구).
+    """
+    if _connected:
+        return True, {"pg_listen": "connected"}
+
+    if _disconnected_since is None:
+        # listen_loop()이 아직 첫 연결을 시도한 적 없음(기동 직후) — fail-open으로
+        # 시작 직후 헬스체크가 즉시 실패하는 것을 막는다(정상 기동 유예).
+        return True, {"pg_listen": "not_yet_connected"}
+
+    elapsed = (datetime.now(UTC) - _disconnected_since).total_seconds()
+    if elapsed <= UNHEALTHY_GRACE_SECONDS:
+        return True, {
+            "pg_listen": "reconnecting",
+            "disconnected_for_seconds": round(elapsed, 1),
+            "last_error": _last_error,
+        }
+
+    return False, {
+        "pg_listen": "disconnected",
+        "disconnected_for_seconds": round(elapsed, 1),
+        "last_error": _last_error,
+    }

--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -810,4 +810,4 @@ fi
 log "=== Deployment submitted ==="
 log "Instance template: ${TEMPLATE_NAME}"
 log "MIG: ${MIG_NAME} (region ${GCP_REGION})"
-log "Health check target: /api/v2/ping (DB 미조회, GCLB 나머지 스택은 provision_realtime_gclb.sh 참조)"
+log "Health check target: /api/v2/ready (DB 미조회·캐시된 연결상태, story #2295 — GCLB 나머지 스택은 provision_realtime_gclb.sh 참조)"

--- a/backend/scripts/provision_realtime_gclb.sh
+++ b/backend/scripts/provision_realtime_gclb.sh
@@ -14,7 +14,7 @@
 # 스텝④의 add-backend는 실재하는 instance-group을 요구하므로 **deploy_realtime_gce.sh
 # (MIG 생성)가 먼저, 이 스크립트(GCLB 프로비저닝)가 그 다음**이 맞다.
 #
-# 실행 순서: ① 방화벽(GCLB 헬스체크 프로브 대역 허용) → ② 헬스체크(/api/v2/ping)
+# 실행 순서: ① 방화벽(GCLB 헬스체크 프로브 대역 허용) → ② 헬스체크(/api/v2/ready, story #2295)
 #           → ③ 백엔드서비스(timeout=3600!) → ④ MIG를 백엔드로 부착
 #           → ⑤ URL맵 → ⑥ 타겟프록시 → ⑦ 전역 고정IP → ⑧ 포워딩규칙
 #
@@ -77,7 +77,7 @@ if [ "${DRY_RUN}" = "1" ]; then
     cat <<EOF
 ENV=${ENV}
 FW_RULE_NAME=${FW_RULE_NAME}
-HEALTH_CHECK_NAME=${HEALTH_CHECK_NAME} (target: /api/v2/ping, DB 미조회 — PR-A 확認됨)
+HEALTH_CHECK_NAME=${HEALTH_CHECK_NAME} (target: /api/v2/ready, DB 미조회·캐시된 연결상태 — story #2295)
 BACKEND_SERVICE_NAME=${BACKEND_SERVICE_NAME} (timeout=${BACKEND_TIMEOUT_SEC}s, draining=${DRAINING_TIMEOUT_SEC}s)
 MIG_NAME=${MIG_NAME}
 URL_MAP_NAME=${URL_MAP_NAME}
@@ -102,20 +102,40 @@ else
     log "Firewall rule ${FW_RULE_NAME} already exists — skip"
 fi
 
-# ── ② 헬스체크 — /api/v2/ping (DB 안 타는 엔드포인트, PR-A에서 이미 구현·배포됨).
-#    /api/v2/health 아님 — 그건 DB 조회가 걸려 있어 콜드/DB부하 시 오탐 우려(설계 doc 명시). ──
+# ── ② 헬스체크 — story #2295(2026-08-17) target 전환: /api/v2/ping → /api/v2/ready.
+#
+# 이력 — 왜 /ping이었나(PR-A~C, 2026-07): /api/v2/health(DB SELECT 1 조회)는 콜드/DB부하 시
+# 오탐 우려(설계 doc 명시)라 DB 미조회 /ping을 골랐다. 그런데 그 선택의 부작용이 2026-07-28
+# 인시던트로 드러났다 — /ping은 "앱 프로세스가 응답하는가"만 재서, cloud-sql-proxy가 스테일
+# 소켓으로 크래시루프 중이어도(=이 인스턴스는 일을 못 한다) LB가 계속 HEALTHY로 봤다(story
+# #2295 원문 실측). ⛔"DB 부하 우려"라는 /ping의 원래 근거는 여전히 옳다 — 그래서 /health로
+# 되돌리지 않는다. 대신 신설된 /api/v2/ready(story #2295)가 DB를 조회하지 않으면서도(체크당
+# 쿼리 0 — pg_pubsub.listen_loop()가 이미 자기 재연결 목적으로 추적하던 연결상태를 캐시된
+# 사실로 읽기만 한다) "일할 수 있는가"를 답한다 — /ping의 DB 부하 우려와 /health의 오탐 우려
+# 둘 다 재도입하지 않는 제3의 선택.
+#
+# 멱등 — 이미 있으면(구 /ping 타깃 포함) request-path를 조회해 다르면 update, 같으면 skip.
 if ! gcloud compute health-checks describe "${HEALTH_CHECK_NAME}" --project="${GCP_PROJECT}" >/dev/null 2>&1; then
-    log "Creating health check ${HEALTH_CHECK_NAME} → /api/v2/ping"
+    log "Creating health check ${HEALTH_CHECK_NAME} → /api/v2/ready"
     gcloud compute health-checks create http "${HEALTH_CHECK_NAME}" \
         --project="${GCP_PROJECT}" \
         --port=8000 \
-        --request-path=/api/v2/ping \
+        --request-path=/api/v2/ready \
         --check-interval=10s \
         --timeout=5s \
         --healthy-threshold=2 \
         --unhealthy-threshold=3
 else
-    log "Health check ${HEALTH_CHECK_NAME} already exists — skip"
+    _current_path=$(gcloud compute health-checks describe "${HEALTH_CHECK_NAME}" \
+        --project="${GCP_PROJECT}" --format='value(httpHealthCheck.requestPath)')
+    if [ "${_current_path}" != "/api/v2/ready" ]; then
+        log "Health check ${HEALTH_CHECK_NAME} exists with stale target (${_current_path}) — updating to /api/v2/ready"
+        gcloud compute health-checks update http "${HEALTH_CHECK_NAME}" \
+            --project="${GCP_PROJECT}" \
+            --request-path=/api/v2/ready
+    else
+        log "Health check ${HEALTH_CHECK_NAME} already targets /api/v2/ready — skip"
+    fi
 fi
 
 # ── ③ 백엔드서비스 — ⚠️timeout=3600 명시(기본 30 그대로 두면 Cloud Run보다 퇴보). ──

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -8,24 +8,97 @@ def anyio_backend():
     return "asyncio"
 
 
+def _override_db(app, mock_session):
+    from app.dependencies.database import get_db
+
+    async def _override():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = _override
+    return app
+
+
 @pytest.mark.anyio
 async def test_health_returns_200():
-    """AC2: GET /api/v2/health → 200 응답."""
+    """AC2: GET /api/v2/health → 200 응답(DB 정상)."""
     from app.main import app
 
-    with patch("app.routers.health.get_db") as mock_get_db:
-        mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(return_value=None)
-
-        async def _override():
-            yield mock_session
-
-        mock_get_db.return_value = _override()
-
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=None)
+    _override_db(app, mock_session)
+    try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get("/api/v2/health")
+    finally:
+        app.dependency_overrides.clear()
 
     assert response.status_code == 200
     body = response.json()
     assert body["status"] == "ok"
     assert body["version"] == "v2"
+
+
+@pytest.mark.anyio
+async def test_health_returns_503_when_db_fails():
+    """story #2295 별개 fix(카디르 QA 적발) — 이 엔드포인트가 원래 DB 실패에도 top-level
+    status를 "ok"로, HTTP를 200으로 고정 반환했다(db 필드에만 에러가 실려 호출자가 status만
+    보면 절대 못 잡음). 이제 DB 조회 실패 시 503+status:"error"로 정직하게 반영한다."""
+    from app.main import app
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(side_effect=ConnectionRefusedError("db down"))
+    _override_db(app, mock_session)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/api/v2/health")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "error"
+    assert "ConnectionRefusedError" in body["db"]
+
+
+@pytest.mark.anyio
+async def test_ready_returns_200_when_pg_listen_connected():
+    """story #2295 AC — /ready는 DB를 조회하지 않고 pg_pubsub의 캐시된 연결상태만 읽는다."""
+    from app.main import app
+    from app.services import realtime_readiness as rr
+
+    rr.mark_connected()
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/api/v2/ready")
+    finally:
+        rr._connected = False
+        rr._disconnected_since = None
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ready"] is True
+    assert body["pg_listen"] == "connected"
+
+
+@pytest.mark.anyio
+async def test_ready_returns_503_when_pg_listen_disconnected_past_grace(monkeypatch):
+    """story #2295 AC1 — 원 인시던트(cloud-sql-proxy 죽음)를 이 엔드포인트가 이제 UNHEALTHY로
+    본다는 것을 직접 재현: 연결이 끊긴 채 유예시간을 넘기면 503."""
+    from app.main import app
+    from app.services import realtime_readiness as rr
+
+    monkeypatch.setattr(rr, "UNHEALTHY_GRACE_SECONDS", 0.0)
+    rr.mark_connected()
+    rr.mark_disconnected("bind: address already in use")
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/api/v2/ready")
+    finally:
+        rr._connected = False
+        rr._disconnected_since = None
+        rr._last_error = None
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["ready"] is False
+    assert body["pg_listen"] == "disconnected"

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -9,12 +9,14 @@ def anyio_backend():
 
 
 def _override_db(app, mock_session):
-    from app.dependencies.database import get_db
+    # story #2451 §6 Phase3(디디 QA 지적, 2026-08-17) — get_db만 걸고 get_read_db를 빠뜨리는
+    # 클래스의 회귀를 override_db_and_read 헬퍼 하나로 구조적으로 막는다(conftest.py 참조).
+    from tests.conftest import override_db_and_read
 
     async def _override():
         yield mock_session
 
-    app.dependency_overrides[get_db] = _override
+    override_db_and_read(app, _override)
     return app
 
 

--- a/backend/tests/test_proxy.py
+++ b/backend/tests/test_proxy.py
@@ -66,23 +66,32 @@ async def test_cors_allows_sprintable_ai():
 
 @pytest.mark.anyio
 async def test_health_via_proxy_path():
-    """AC5: /api/v2/health → FastAPI 정상 응답."""
+    """AC5: /api/v2/health → FastAPI 정상 응답.
+
+    story #2295(카디르 QA) — `patch("app.routers.health.get_db")`는 FastAPI가
+    `Depends(get_db)`를 라우트 등록 시점에 이미 캡처해 두므로 이후 모듈 속성을 patch해도
+    실제 의존성 해석엔 반영되지 않는 사문(死文) 패턴이었다(늘 진짜 전역 테스트 DB를 탔을
+    뿐 — 예전엔 `/health`가 DB 성패 무관 항상 200을 반환해 이 갭이 안 드러났었다. 이제
+    `/health`가 DB 실패 시 정직하게 503을 반환하면서 이 사문 mock의 무효함이 표면화됐다).
+    `app.dependency_overrides`(FastAPI 정본 오버라이드 경로)로 교체."""
+    from app.dependencies.database import get_db
     from app.main import app
 
-    with patch("app.routers.health.get_db") as mock_get_db:
-        mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(return_value=None)
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=None)
 
-        async def _override():
-            yield mock_session
+    async def _override():
+        yield mock_session
 
-        mock_get_db.return_value = _override()
-
+    app.dependency_overrides[get_db] = _override
+    try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(
                 "/api/v2/health",
                 headers={"Origin": "http://localhost:3000", "Authorization": "Bearer test-token"},
             )
+    finally:
+        app.dependency_overrides.clear()
 
     assert response.status_code == 200
     body = response.json()

--- a/backend/tests/test_proxy.py
+++ b/backend/tests/test_proxy.py
@@ -73,9 +73,10 @@ async def test_health_via_proxy_path():
     실제 의존성 해석엔 반영되지 않는 사문(死文) 패턴이었다(늘 진짜 전역 테스트 DB를 탔을
     뿐 — 예전엔 `/health`가 DB 성패 무관 항상 200을 반환해 이 갭이 안 드러났었다. 이제
     `/health`가 DB 실패 시 정직하게 503을 반환하면서 이 사문 mock의 무효함이 표면화됐다).
-    `app.dependency_overrides`(FastAPI 정본 오버라이드 경로)로 교체."""
-    from app.dependencies.database import get_db
+    `override_db_and_read`(FastAPI 정본 오버라이드 경로 + get_read_db 동시 배선, 디디 QA
+    지적 2026-08-17 — story #2451 §6 Phase3 재발 클래스)로 교체."""
     from app.main import app
+    from tests.conftest import override_db_and_read
 
     mock_session = AsyncMock()
     mock_session.execute = AsyncMock(return_value=None)
@@ -83,7 +84,7 @@ async def test_health_via_proxy_path():
     async def _override():
         yield mock_session
 
-    app.dependency_overrides[get_db] = _override
+    override_db_and_read(app, _override)
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(

--- a/backend/tests/test_realtime_main_external_contracts.py
+++ b/backend/tests/test_realtime_main_external_contracts.py
@@ -22,10 +22,10 @@ def anyio_backend():
     return "asyncio"
 
 
-def test_gclb_health_check_path_responds_200():
-    """provision_realtime_gclb.sh:112 --request-path=/api/v2/ping 과 대조 — 이 경로가
-    없으면 GCLB가 이 서비스를 영구 UNHEALTHY로 판정해 502를 낸다(2026-07-25 실제 배포
-    실패로 확認된 실패 모드)."""
+def test_ping_endpoint_still_served():
+    """`/api/v2/ping`은 story #2295 이후에도 이 서비스가 계속 서빙한다(CLI `npx sprintable
+    connect` 호환·loadtest generator_selfcheck.js의 무부하 self-check가 여전히 이 경로에
+    의존) — GCLB의 «헬스체크 타깃»에서만 빠졌을 뿐, 엔드포인트 자체를 없앤 게 아니다."""
     import app.realtime_main as rm
 
     with TestClient(rm.app) as client:
@@ -34,9 +34,33 @@ def test_gclb_health_check_path_responds_200():
     assert response.json() == {"ok": True}
 
 
+def test_gclb_health_check_path_responds_200():
+    """story #2295(2026-08-17) — provision_realtime_gclb.sh:123 --request-path=/api/v2/ready
+    와 대조(구 target /ping은 위 test_ping_endpoint_still_served로 이관). 이 경로가 없으면
+    GCLB가 이 서비스를 영구 UNHEALTHY로 판정해 502를 낸다(2026-07-25 실제 배포 실패로
+    확認된 실패 모드 그대로 — target만 /ping에서 옮겨졌을 뿐 같은 계약).
+
+    TestClient는 lifespan의 `listen_loop()` background task를 실제로 못 돌리므로(pg_pubsub이
+    아직 첫 연결 시도 前) realtime_readiness의 fail-open 상태("not_yet_connected")를 탄다 —
+    이건 버그가 아니라 story #2295 설계 그대로("정상 기동 유예" — realtime_readiness.py 참조):
+    막 뜬 인스턴스가 아직 연결도 못 시도했는데 즉시 UNHEALTHY로 떨어지면 그게 더 나쁘다."""
+    import app.realtime_main as rm
+
+    with TestClient(rm.app) as client:
+        response = client.get("/api/v2/ready")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ready"] is True
+
+
 def test_gclb_health_check_path_matches_provision_script():
     """provision_realtime_gclb.sh의 --request-path 값 자체가 바뀌면 이 pin도 같이 갱신돼야
-    한다 — 두 파일이 서로 다른 경로를 말하게 되는 드리프트를 잡는다."""
+    한다 — 두 파일이 서로 다른 경로를 말하게 되는 드리프트를 잡는다.
+
+    story #2295(2026-08-17) — /api/v2/ping → /api/v2/ready로 target 전환(DB 프록시가 죽어도
+    /ping은 HEALTHY를 계속 주던 인시던트 해소). health.router가 두 서비스(backend·realtime)
+    공유 라우터라 /ready도 이미 서빙되고 있음(app/routers/health.py 참조) — 이 pin은 스크립트가
+    실제로 그 경로를 쓰는지만 고정."""
     import pathlib
 
     script = (
@@ -45,7 +69,10 @@ def test_gclb_health_check_path_matches_provision_script():
     )
     assert script.exists()
     source = script.read_text()
-    assert "--request-path=/api/v2/ping" in source, (
+    assert "--request-path=/api/v2/ready" in source, (
         "provision_realtime_gclb.sh의 헬스체크 경로가 바뀌었다 — "
         "realtime_main.py가 그 경로를 여전히 서빙하는지 재확認 필요"
+    )
+    assert "--request-path=/api/v2/ping" not in source, (
+        "구 target(/ping)이 스크립트에 여전히 남아 있다 — story #2295 전환이 불완전"
     )

--- a/backend/tests/test_realtime_readiness.py
+++ b/backend/tests/test_realtime_readiness.py
@@ -1,0 +1,78 @@
+"""story #2295 — realtime_readiness 모듈 단위 테스트. 순수 상태기계, DB/네트워크 0."""
+import time
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    """모듈 레벨 전역이라 테스트 간 오염 방지 — 매 테스트 전후 리셋."""
+    from app.services import realtime_readiness as rr
+    rr._connected = False
+    rr._disconnected_since = None
+    rr._last_error = None
+    yield
+    rr._connected = False
+    rr._disconnected_since = None
+    rr._last_error = None
+
+
+def test_initial_state_is_ready_not_yet_connected():
+    """AC — 기동 직후(첫 연결 시도 前)는 fail-open으로 ready(정상 기동 유예)."""
+    from app.services import realtime_readiness as rr
+
+    healthy, detail = rr.is_ready()
+    assert healthy is True
+    assert detail["pg_listen"] == "not_yet_connected"
+
+
+def test_connected_is_ready():
+    from app.services import realtime_readiness as rr
+
+    rr.mark_connected()
+    healthy, detail = rr.is_ready()
+    assert healthy is True
+    assert detail["pg_listen"] == "connected"
+
+
+def test_disconnected_within_grace_still_ready():
+    """AC4 — 끊긴 직후(유예시간 안)는 아직 ready — backoff 재시도가 진행 중일 수 있어서
+    반짝 끊김 한 번에 바로 UNHEALTHY로 flapping하지 않는다."""
+    from app.services import realtime_readiness as rr
+
+    rr.mark_connected()
+    rr.mark_disconnected("ConnectionRefusedError: test")
+    healthy, detail = rr.is_ready()
+    assert healthy is True
+    assert detail["pg_listen"] == "reconnecting"
+    assert detail["last_error"] == "ConnectionRefusedError: test"
+
+
+def test_disconnected_past_grace_is_not_ready(monkeypatch):
+    """AC1 — 유예시간을 넘어서도 재연결 못 하면 UNHEALTHY. 실제로 30초를 기다리지 않고
+    UNHEALTHY_GRACE_SECONDS를 낮춰 경계를 물린다."""
+    from app.services import realtime_readiness as rr
+
+    monkeypatch.setattr(rr, "UNHEALTHY_GRACE_SECONDS", 0.05)
+    rr.mark_connected()
+    rr.mark_disconnected("stale socket: bind: address already in use")
+    time.sleep(0.1)
+    healthy, detail = rr.is_ready()
+    assert healthy is False
+    assert detail["pg_listen"] == "disconnected"
+    assert "stale socket" in detail["last_error"]
+
+
+def test_reconnect_after_disconnect_clears_state():
+    """연결이 끊겼다가 다시 성공하면 disconnected_since가 리셋된다(다음 끊김이 새 유예
+    창을 받는다 — 누적되지 않음)."""
+    from app.services import realtime_readiness as rr
+
+    rr.mark_connected()
+    rr.mark_disconnected("blip")
+    assert rr._disconnected_since is not None
+    rr.mark_connected()
+    healthy, detail = rr.is_ready()
+    assert healthy is True
+    assert detail["pg_listen"] == "connected"
+    assert rr._disconnected_since is None


### PR DESCRIPTION
## 요약
2026-07-28 인시던트(민, dev) — cloud-sql-proxy가 스테일 소켓으로 크래시루프 중이었는데 GCLB healthcheck(`/api/v2/ping`, DB 미조회)는 계속 HEALTHY를 줘 죽은 인스턴스가 트래픽을 계속 받았다. 「응답하는가」와 「일할 수 있는가」를 가른다.

## 설계(PO 승인)
- `/ping`의 DB-미조회 선택 자체는 정당(콜드/부하 시 오탐 방지, 이미 문서화된 트레이드오프) — 되돌리지 않음.
- `pg_pubsub.listen_loop()`가 이미 자기 재연결용으로 갖고 있던 연결성공/실패 상태를 `realtime_readiness` 모듈에 기록만(DB 왕복 0) → 신규 `GET /api/v2/ready`가 그 캐시된 사실을 읽어 응답.
- 유예시간(`UNHEALTHY_GRACE_SECONDS=30`)은 `listen_loop()` 자체의 backoff 수렴값(1+2+4+8+16=31s) 재사용 — 임의 숫자 아님, 최소 5회 재연결 기회를 준 뒤에도 안 되면 UNHEALTHY.
- `provision_realtime_gclb.sh`의 healthcheck target을 `/ping`→`/ready`로 전환 — create-if-not-exists 스크립트라 이미 존재하는 리소스는 그냥 skip되던 것을, 경로 비교 후 update하는 reconcile 분기를 추가해 실 라이브 리소스도 실제로 전환되게 함.

## 별개 fix(같은 PR, 발견 즉시 수정, 별도 절)
`GET /api/v2/health`가 DB 조회 실패해도 항상 `status:"ok"`/200을 반환하던 버그(이 스토리 자신이 고치려는 병을 이 엔드포인트 자신이 앓고 있었음) — 이제 DB 실패 시 503+`status:"error"`.

## 부수 발견
`test_health.py`·`test_proxy.py`의 `patch("app.routers.health.get_db")`가 FastAPI가 라우트 등록 시점에 이미 캡처한 Depends 콜러블에 영향 못 주는 사문 패턴이었음(항상 진짜 전역 테스트 DB를 탔음) — `app.dependency_overrides`로 교체.

## 검증
- 신규 9테스트(`test_realtime_readiness.py` 5+`test_health.py` 4) 전부 통과.
- 뮤테이션킬: grace-period 체크 무력화 → 정확히 2건 RED, 원복 → GREEN.
- `test_realtime_main_external_contracts.py`의 GCLB 계약 pin을 `/ping`→`/ready`로 갱신(구 target은 별도 테스트로 "여전히 서빙됨"만 확認 — CLI/loadtest가 계속 씀).
- 회귀 스윕(health/readiness/pubsub/proxy/realtime_main) 42/42 통과.
- bash 문법(`bash -n`) 양쪽 스크립트 통과, YAML 무관(순수 셸).

## ⚠️ 남은 것 — AC1 라이브 실증
Pedro 지시 조건(①MIG 인스턴스 1대만·다른 인스턴스 healthy 유지 ②kill 직전 팀conv 공지 ③복구절차 준비)을 지켜 별도 신중한 단계로 진행 예정 — 이 PR 자체는 코드/스크립트만, 실제 dev GCE에서 cloud-sql-proxy를 강제 kill해 `/ready`가 UNHEALTHY로 떨어지는 것까지 보이는 건 머지 후(또는 리뷰 병행) 별도로.

## QA
제 자신의 인프라 건이라 셀프 QA 불가 — 교차 QA 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)