### PR TITLE
[SID:2711] image artifact props.src — 응답 직전 signed_read_url 교체

### DIFF
--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.asset import Asset
+from app.services.artifact_image_url import _canonicalize_props, sign_image_srcs_in_nodes
 from app.models.visual_artifact import (
     ArtifactComment, ArtifactExport, ArtifactNode, ArtifactSpecPin, ArtifactVersion, VisualArtifact,
 )
@@ -155,14 +156,17 @@ async def create_artifact(
     for n in body.nodes:
         node = ArtifactNode(
             id=n.id or uuid.uuid4(), artifact_id=artifact.id, version_id=version.id,
-            type=n.type, props=n.props, parent_id=n.parent_id, sort_order=n.sort_order,
-            description=n.description,
+            type=n.type, props=_canonicalize_props(n.props), parent_id=n.parent_id,
+            sort_order=n.sort_order, description=n.description,
         )
         session.add(node)
         nodes.append(node)
     await session.flush()
 
     await _notify_artifact_created(session, artifact, org_id=org_id, project_id=project_id, creator_id=created_by)
+
+    node_outs = [ArtifactNodeOut.model_validate(n) for n in nodes]
+    await sign_image_srcs_in_nodes(node_outs)  # story #2711 AC1 — 응답 직전 신선 서명(url 미저장)
 
     detail = VisualArtifactDetail(
         id=artifact.id, org_id=artifact.org_id, project_id=artifact.project_id, title=artifact.title,
@@ -172,7 +176,7 @@ async def create_artifact(
         created_by=artifact.created_by, created_at=artifact.created_at, updated_at=artifact.updated_at,
         version_number=version.version_number, version_summary=version.summary,
         version_source_comment_id=version.source_comment_id, canvas_bounds=version.canvas_bounds,
-        nodes=[ArtifactNodeOut.model_validate(n) for n in nodes],
+        nodes=node_outs,
     )
     return _ok(detail.model_dump(mode="json"), status=201)
 
@@ -246,6 +250,8 @@ async def _load_detail(session: AsyncSession, artifact: VisualArtifact, version_
 
     org_slug = await resolve_org_slug(session, artifact.org_id)
     project_slug_map = await resolve_project_slugs(session, {artifact.project_id})
+    node_outs = [ArtifactNodeOut.model_validate(n) for n in node_rows]
+    await sign_image_srcs_in_nodes(node_outs)  # story #2711 AC1 — 응답 직전 신선 서명(url 미저장)
     return VisualArtifactDetail(
         id=artifact.id, org_id=artifact.org_id, project_id=artifact.project_id, title=artifact.title,
         story_id=artifact.story_id, epic_id=artifact.epic_id, doc_id=artifact.doc_id,
@@ -254,7 +260,7 @@ async def _load_detail(session: AsyncSession, artifact: VisualArtifact, version_
         created_by=artifact.created_by, created_at=artifact.created_at, updated_at=artifact.updated_at,
         version_number=version.version_number, version_summary=version.summary,
         version_source_comment_id=version.source_comment_id, canvas_bounds=version.canvas_bounds,
-        nodes=[ArtifactNodeOut.model_validate(n) for n in node_rows],
+        nodes=node_outs,
         unresolved_comment_count=unresolved_counts.get(artifact.id, 0),
         org_slug=org_slug, project_slug=project_slug_map.get(artifact.project_id),
     )
@@ -1031,8 +1037,9 @@ async def _apply_artifact_edit(
         if op.op == "add":
             new_id = op.id or uuid.uuid4()
             working[new_id] = {
-                "type": op.type or "text", "props": op.props or {}, "parent_id": op.parent_id,
-                "sort_order": op.sort_order or 0, "description": op.description,
+                "type": op.type or "text", "props": _canonicalize_props(op.props or {}),
+                "parent_id": op.parent_id, "sort_order": op.sort_order or 0,
+                "description": op.description,
             }
         elif op.op == "update":
             if op.id is None or op.id not in working:
@@ -1041,7 +1048,10 @@ async def _apply_artifact_edit(
             if op.type is not None:
                 node["type"] = op.type
             if op.props is not None:
-                node["props"] = op.props
+                # story #2711 ⓑ — 클라가 get으로 받은 서명 url을 그대로 되보내는 왕복이
+                # 가장 흔한 경로(에이전트가 노드를 읽고 다른 필드만 고쳐 되보낼 때 props는
+                # 건드리지 않았어도 그대로 전달되는 경우 포함) — 여기서 반드시 raw로 되돌린다.
+                node["props"] = _canonicalize_props(op.props)
             if op.parent_id is not None:
                 node["parent_id"] = op.parent_id
             if op.sort_order is not None:

--- a/backend/app/services/artifact_image_url.py
+++ b/backend/app/services/artifact_image_url.py
@@ -1,0 +1,79 @@
+"""story #2711 — image artifact `props.src`가 raw 무서명 GCS url이라 렌더가 403 나던 결함의
+근본수정. `artifact_exports`(PNG export, visual_artifacts.py `_export_response`)가 이미 쓰는
+패턴("url은 저장 안 하고 응답 시점마다 signed_read_url을 새로 발급") 그대로 image 노드
+`props.src`에도 적용한다.
+
+⚠️ ⓐ(페드루 명시) — 「우리 버킷 host 매칭」 판정은 이 파일의 `_our_bucket_object_path()`
+하나로 좁힌다. 외부 이미지 url(사용자가 임의 http url을 props.src에 넣은 경우 등)을 잘못
+서명하려 들면 IAM 호출이 엉뚱한 리소스를 겨누거나 조용히 실패한다 — read(서명 발급)·write
+(canonicalize) 양쪽이 반드시 이 판정 하나만 거친다(사본 두 곳 발명 금지).
+
+⚠️ ⓑ(페드루 명시) — 왕복 오염 가드. get(서명 url 포함 응답)을 받은 클라이언트가 그 노드를
+그대로 edit으로 되보내면, 서명 쿼리스트링(`X-Goog-...`)이 그대로 저장돼 만료 後 깨진 url이
+영속화된다. `_canonicalize_props()`가 저장 직전에 항상 raw(무쿼리) 형태로 되돌린다 — 이
+모듈이 read/write 양쪽 진입점 전부에서 호출돼야 이 가드가 성립한다(호출 누락 = 결함 재발).
+"""
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+from urllib.parse import urlsplit
+
+_BUCKET = os.environ.get("GCS_MEMO_ATTACHMENTS_BUCKET", "sprintable-memo-attachments")
+_HOST = "storage.googleapis.com"
+_PREFIX = f"/{_BUCKET}/"
+_SIGNED_READ_TTL = timedelta(minutes=15)
+
+
+def _our_bucket_object_path(url: str) -> str | None:
+    """url이 우리 버킷을 가리키면(raw든 서명 쿼리가 붙었든) canonical object_path를
+    반환(쿼리스트링은 urlsplit이 이미 분리해 자동 배제) — 아니면(외부 url·빈 값 등) None.
+    read(서명)·write(canonicalize) 양쪽이 이 함수 하나만 거친다(ⓐ)."""
+    if not url:
+        return None
+    parts = urlsplit(url)
+    if parts.netloc != _HOST or not parts.path.startswith(_PREFIX):
+        return None
+    return parts.path[len(_PREFIX):]
+
+
+def _canonicalize_props(props: dict | None) -> dict | None:
+    """저장 직전 호출(write 경로) — props.src가 우리 버킷 url(서명 쿼리 포함 가능)이면
+    raw canonical url로 되돌린다(ⓑ 왕복 오염 가드). 외부 url·src 없음·이미 raw면 원본
+    그대로(불필요한 dict 복사 회피)."""
+    if not props or not isinstance(props.get("src"), str):
+        return props
+    object_path = _our_bucket_object_path(props["src"])
+    if object_path is None:
+        return props
+    canonical_url = f"https://{_HOST}/{_BUCKET}/{object_path}"
+    if canonical_url == props["src"]:
+        return props
+    return {**props, "src": canonical_url}
+
+
+async def _sign_image_props(props: dict | None) -> dict | None:
+    """응답 직전 호출(read 경로) — props.src가 우리 버킷 raw url이면 signed_read_url로
+    교체(AC1). url 자체는 저장 안 하므로(canonicalize_props가 write에서 항상 raw로 되돌림)
+    매 응답마다 신선하게 발급 — export 경로(list_artifact_exports)와 동일 메커니즘이라
+    만료 문제가 원천적으로 없다. 서명 실패는 best-effort(기존 raw url 반환 유지, export
+    경로의 signed_read_url 자체가 실패 시 None을 주는 것과 동형 관례)."""
+    if not props or not isinstance(props.get("src"), str):
+        return props
+    object_path = _our_bucket_object_path(props["src"])
+    if object_path is None:
+        return props
+    from app.services.storage import get_storage_provider
+
+    signed = await get_storage_provider().signed_read_url(_BUCKET, object_path, ttl=_SIGNED_READ_TTL)
+    if signed is None:
+        return props
+    return {**props, "src": signed}
+
+
+async def sign_image_srcs_in_nodes(nodes: list) -> None:
+    """`ArtifactNodeOut` 리스트를 in-place로 순회하며 각 노드의 props.src를 서명 url로
+    교체(AC1) — get_artifact/get_artifact_version/create_artifact 응답·list_artifacts가
+    이 함수 하나만 호출하면 된다."""
+    for node in nodes:
+        node.props = await _sign_image_props(node.props)

--- a/backend/tests/test_2711_artifact_image_signed_url.py
+++ b/backend/tests/test_2711_artifact_image_signed_url.py
@@ -1,0 +1,142 @@
+"""story #2711 — image artifact props.src가 raw 무서명 GCS url이라 렌더가 403 나던 결함.
+
+축:
+- AC1: 우리 버킷 raw url은 응답 직전 signed_read_url로 교체된다.
+- AC2(ⓐ): 「우리 버킷 host」 판정 함수 하나로 좁혀, 외부 url은 절대 서명 시도하지 않는다.
+- AC3(ⓑ): 왕복 오염 가드 — 서명 쿼리가 붙은 url이 들어와도 저장 시점엔 항상 raw로 되돌린다.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.artifact_image_url import (
+    _BUCKET,
+    _canonicalize_props,
+    _our_bucket_object_path,
+    _sign_image_props,
+    sign_image_srcs_in_nodes,
+)
+
+_RAW = f"https://storage.googleapis.com/{_BUCKET}/org/o1/project/p1/canvas-import/abc-shot.png"
+_SIGNED = _RAW + "?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Signature=deadbeef"
+_EXTERNAL = "https://example.com/some-other-image.png"
+
+
+# ── ⓐ 버킷-host 판정 (단일 함수) ────────────────────────────────────────────
+
+def test_our_bucket_object_path_extracts_path_from_raw_url():
+    assert _our_bucket_object_path(_RAW) == "org/o1/project/p1/canvas-import/abc-shot.png"
+
+
+def test_our_bucket_object_path_strips_signed_query():
+    """서명 쿼리스트링이 붙어 있어도(왕복으로 되돌아온 값) 같은 object_path를 뽑는다."""
+    assert _our_bucket_object_path(_SIGNED) == "org/o1/project/p1/canvas-import/abc-shot.png"
+
+
+def test_our_bucket_object_path_returns_none_for_external_url():
+    assert _our_bucket_object_path(_EXTERNAL) is None
+
+
+def test_our_bucket_object_path_returns_none_for_empty():
+    assert _our_bucket_object_path("") is None
+    assert _our_bucket_object_path(None) is None  # type: ignore[arg-type]
+
+
+# ── ⓑ 왕복 오염 가드 — write 경로(_canonicalize_props) ──────────────────────
+
+def test_canonicalize_props_strips_signed_query_back_to_raw():
+    props = {"src": _SIGNED}
+    result = _canonicalize_props(props)
+    assert result["src"] == _RAW
+    assert "X-Goog-Signature" not in result["src"]
+
+
+def test_canonicalize_props_passes_through_external_url_unchanged():
+    props = {"src": _EXTERNAL}
+    result = _canonicalize_props(props)
+    assert result["src"] == _EXTERNAL
+
+
+def test_canonicalize_props_passes_through_props_without_src():
+    props = {"html": "<div>hi</div>"}
+    result = _canonicalize_props(props)
+    assert result == props
+
+
+def test_canonicalize_props_handles_none():
+    assert _canonicalize_props(None) is None
+
+
+def test_canonicalize_props_mutation_kill_disabled_guard_leaves_signature():
+    """⭐뮤테이션킬 — 가드가 없으면(no-op) 서명 쿼리가 그대로 남는다는 것을 대조로 확認,
+    이 테스트 자체는 실제 가드가 켜져 있을 때 정상 통과해야 한다(음성 대조 아님·본 동작 확認)."""
+    props = {"src": _SIGNED}
+    result = _canonicalize_props(props)
+    assert "?" not in result["src"], "서명 쿼리스트링이 저장 경로까지 살아남음 — 왕복 오염 가드 작동 안 함"
+
+
+# ── AC1 — read 경로(_sign_image_props/sign_image_srcs_in_nodes) ─────────────
+
+@pytest.mark.anyio
+async def test_sign_image_props_replaces_our_bucket_raw_url():
+    with patch("app.services.storage.get_storage_provider") as mock_get_provider:
+        mock_provider = AsyncMock()
+        mock_provider.signed_read_url = AsyncMock(return_value="https://signed.example/fresh?sig=x")
+        mock_get_provider.return_value = mock_provider
+
+        result = await _sign_image_props({"src": _RAW})
+
+        assert result["src"] == "https://signed.example/fresh?sig=x"
+        mock_provider.signed_read_url.assert_called_once()
+        call_args = mock_provider.signed_read_url.call_args
+        assert call_args.args[0] == _BUCKET
+        assert call_args.args[1] == "org/o1/project/p1/canvas-import/abc-shot.png"
+
+
+@pytest.mark.anyio
+async def test_sign_image_props_never_signs_external_url():
+    """⭐ⓐ 핵심 — 외부 url은 signed_read_url 자체를 호출하지 않는다(오서명 방지)."""
+    with patch("app.services.storage.get_storage_provider") as mock_get_provider:
+        mock_provider = AsyncMock()
+        mock_provider.signed_read_url = AsyncMock(return_value="should-not-be-called")
+        mock_get_provider.return_value = mock_provider
+
+        result = await _sign_image_props({"src": _EXTERNAL})
+
+        assert result["src"] == _EXTERNAL
+        mock_provider.signed_read_url.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_sign_image_props_best_effort_on_signing_failure():
+    """서명 발급 실패(None) 시 raw url이라도 그대로 남긴다(export 경로와 동형 best-effort)."""
+    with patch("app.services.storage.get_storage_provider") as mock_get_provider:
+        mock_provider = AsyncMock()
+        mock_provider.signed_read_url = AsyncMock(return_value=None)
+        mock_get_provider.return_value = mock_provider
+
+        result = await _sign_image_props({"src": _RAW})
+
+        assert result["src"] == _RAW
+
+
+@pytest.mark.anyio
+async def test_sign_image_srcs_in_nodes_mutates_in_place():
+    class _FakeNode:
+        def __init__(self, props):
+            self.props = props
+
+    nodes = [_FakeNode({"src": _RAW}), _FakeNode({"html": "<div/>"}), _FakeNode(None)]
+
+    with patch("app.services.storage.get_storage_provider") as mock_get_provider:
+        mock_provider = AsyncMock()
+        mock_provider.signed_read_url = AsyncMock(return_value="https://signed.example/x")
+        mock_get_provider.return_value = mock_provider
+
+        await sign_image_srcs_in_nodes(nodes)
+
+        assert nodes[0].props["src"] == "https://signed.example/x"
+        assert nodes[1].props == {"html": "<div/>"}
+        assert nodes[2].props is None


### PR DESCRIPTION
## 무엇을 왜

story #2711 그라운딩(2026-08-17, 미르코) — story #2707(에이전트 시각증거 MCP 경로) 유나군
AC2 실픽셀 검증에서 렌더 FAIL 발견(아티팩트 e63c2260, naturalWidth=0). 원인 추적 결과
**에이전트 경로만의 문제가 아니라 image-format artifact 렌더 전체의 결함**으로 확認:

```
① gcs.ts:39 putObject() — raw 무서명 url 반환(https://storage.googleapis.com/...)
② import-artifact-dialog.tsx(사람 경로)·에이전트 경로 둘 다 같은 /api/visual-artifacts/
   import-image를 거쳐 이 raw url을 받음 — source 구분 없음
③ ArtifactStage(artifact-stage.tsx:441) <img src={content}>가 raw url을 그대로 렌더
④ 직접 curl로 재현: raw url HTTP 403(버킷 실제로 private) — 코드 판독 아니라 실측
```

레포엔 이미 이 문제를 푼 패턴이 있다 — `artifact_exports`(PNG export) 경로가
`list_artifact_exports`(visual_artifacts.py:770-777)에서 **매 GET 응답마다 signed_read_url을
새로 발급**(url 자체 미저장, durable한 건 object path뿐)해 만료 문제를 원천 회피한다. 이
PR은 같은 패턴을 image 노드 `props.src`에도 적용한다.

## 이번 PR에서 한 일

- `backend/app/services/artifact_image_url.py` 신설:
  - `_our_bucket_object_path()` — 「우리 버킷 host 매칭」 판정 **단일 함수**(외부 url 오서명
    방지, 페드루 명시 ⓐ). read/write 양쪽이 이 함수 하나만 거침.
  - `_canonicalize_props()` — **왕복 오염 가드**(ⓑ): get(서명 url 포함 응답)→edit(그대로
    되보냄) 시나리오에서 서명 쿼리스트링이 영속 저장되지 않도록 저장 직전 raw로 되돌림.
  - `_sign_image_props`/`sign_image_srcs_in_nodes` — read 경로, export와 동일 sign-on-read.
- write 지점 4곳(`create_artifact` + `edit_artifact`의 add/update 2곳 — 기존 노드 그대로
  이관하는 지점은 이미 canonical이라 대상 아님) 전부 `_canonicalize_props()` 경유.
- read 지점 2곳(`create_artifact` 응답 + `_load_detail` — `get_artifact`/`get_artifact_version`
  /`edit_artifact` 응답이 공유) 전부 `sign_image_srcs_in_nodes()` 경유. `list_artifacts`는
  nodes를 포함 안 해 대상 아님(스토리 설명 확認).

## 테스트

- [x] `tests/test_2711_artifact_image_signed_url.py`(신규 13건) — 버킷-host 판정(raw/서명
  둘 다 같은 object_path·외부 url None)·canonicalize(서명 쿼리 스트립·외부 url 통과)·
  sign(우리 버킷만 서명 호출·외부 url은 `signed_read_url` 자체 미호출로 확認·서명실패
  best-effort)·`sign_image_srcs_in_nodes` in-place mutation. **뮤테이션킬**: ⓑ 가드를
  no-op으로 무력화 → 정확히 2건 RED → 원복 GREEN.
- [x] 인접 회귀(E-CANVAS C1-S3/S5·SEC-S8·#1920·scope-group) 71 passed·2 failed — 그 2건
  (`test_comment_event_propagation_to_creator`·`test_ac4_human_edits_agent_creator_notified`)
  은 **develop HEAD에서 동일 fresh 없이 재현**(baseline worktree 대조 확認) — 이 PR과 무관한
  기존 결함.
- [x] Python 문법(`py_compile`) 정상.

## 남은 것 (이 PR 스코프 밖, story #2711 AC4/5)

- e63c2260(story #2707 검증 재료)이 이 fix 배포 후 실제로 렌더되는 것 — 유나군 라이브
  재확認 예정(머지·배포 後).
- 기존 image artifact(있다면)가 이 fix로 회복되는지 최소 1건 라이브 확認 — 배포 後.
- PR#3167(story #2707 문서화, 머지 보류 중)은 이 fix 머지 後 재검증 PASS 나오면 보류 해제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)