### PR TITLE
[SID:2708] visual-artifacts 19 라우트 X-Project-Id 헤더 무시 — 갤러리 빈 화면 근본수정

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -585,12 +585,22 @@ async def _resolve_verified_org_id(
     auth: AuthContext,
     x_org_id: str | None,
     request: Request | None,
+    *,
+    skip_key_scope_check: bool = False,
 ) -> uuid.UUID:
     """``get_verified_org_id``/``get_verified_org_id_no_project_gate`` 공유 atom — X-Org-Id 헤더
     fallback 시 DB membership 검증까지의 org_id 해소. X-Project-Id 프로젝트-멤버십 체크는
-    여기 없다(호출부가 필요할 때만 추가로 얹는다 — 아래 두 함수 참고)."""
+    여기 없다(호출부가 필요할 때만 추가로 얹는다 — 아래 두 함수 참고).
+
+    story #2708(2026-08-17, 페드루 PO 판정) — ``skip_key_scope_check``는 story b4027b2e가 세운
+    별개 보안축(API키 **toolgroup** scope, 예 canvas/docs)을 건너뛴다 — org/project **멤버십**
+    검증(has_project_access)과는 무관, 그건 아래서 항상 선다. 이 파라미터는 내부 전용(plain
+    함수 인자, FastAPI Depends() 그래프에 직접 노출 안 됨) — Header/Query로 새는 걸 막기 위해
+    공개 dependency 쪽(get_scope_context 계열)에서 얇은 wrapper 둘로 분기하고, 이 함수
+    자체에는 bare bool 파라미터를 절대 노출하지 않는다(그러면 `?skip_key_scope_check=true`
+    쿼리로 호출자가 자기 자신의 toolgroup 게이트를 끌 수 있는 구멍이 열린다)."""
     # API Key scope 체크 (request 있을 때만 — 직접 단위 테스트 호출 시 스킵)
-    if request is not None:
+    if request is not None and not skip_key_scope_check:
         _check_api_key_scope(auth, request.method, request.url.path)
 
     jwt_org_id = auth.claims.get("app_metadata", {}).get("org_id")
@@ -635,18 +645,25 @@ async def get_verified_org_id_no_project_gate(
     return await _resolve_verified_org_id(auth, x_org_id, request)
 
 
-async def get_verified_org_id(
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
-    x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
-    request: Request = None,
+async def _resolve_verified_org_id_with_project(
+    auth: AuthContext,
+    x_org_id: str | None,
+    x_project_id: str | None,
+    request: Request | None,
+    *,
+    skip_key_scope_check: bool = False,
 ) -> uuid.UUID:
-    """org_id 추출 — X-Org-Id 헤더 fallback 시 DB membership 검증, X-Project-Id 헤더 시 project 소속 검증.
-    API Key 경로는 HTTP method 기반 scope 자동 체크.
+    """``get_verified_org_id``/``get_verified_org_id_no_key_scope_check`` 공유 core.
+
+    org_id 추출 — X-Org-Id 헤더 fallback 시 DB membership 검증, X-Project-Id 헤더 시 project 소속 검증.
+    ``skip_key_scope_check=False``(기본)면 API Key 경로는 HTTP method/path 기반 toolgroup scope
+    자동 체크(story b4027b2e) — 이 축은 project 멤버십 검증과 독립이라 always-on.
 
     story #2459(§6 봉합①): 요청-수명 ``Depends(get_db)`` 대신 검증마다 전용 단명 세션 —
     get_current_user와 동일 근거(호출 대상이 전부 읽기 전용, #2457로 이미 성립)."""
-    org_id = await _resolve_verified_org_id(auth, x_org_id, request)
+    org_id = await _resolve_verified_org_id(
+        auth, x_org_id, request, skip_key_scope_check=skip_key_scope_check
+    )
 
     # X-Project-Id 헤더 = per-request 프로젝트 스코프 **override**(d802da27/85614dd9).
     # JWT project_id 는 탭 공유라, 같은 유저가 여러 프로젝트 탭을 열어도 mutation 이 JWT 의 단일
@@ -657,7 +674,8 @@ async def get_verified_org_id(
     # ⚠️ 보안 critical: 헤더 프로젝트는 **반드시 has_project_access 멤버십 검증**(team_member ∪
     # grant ∪ owner/admin). 미검증 시 헤더로 org 내 임의 프로젝트를 mutation 하는 권한상승 취약점.
     # (기존 코드는 JWT project_id 부재 시에만·_verify_project_in_org=project∈org 만 봐서 멤버 아닌
-    # 프로젝트도 통과하던 갭.) 멤버십 미달이면 403.
+    # 프로젝트도 통과하던 갭.) 멤버십 미달이면 403. ⚠️ skip_key_scope_check와 무관하게 항상 선다
+    # (toolgroup scope 면제와 project 멤버십 검증은 독립된 두 축 — story #2708 PO 판정).
     if x_project_id:
         try:
             header_project_id = uuid.UUID(x_project_id)
@@ -674,6 +692,39 @@ async def get_verified_org_id(
         auth.claims.setdefault("app_metadata", {})["project_id"] = str(header_project_id)
 
     return org_id
+
+
+async def get_verified_org_id(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
+    request: Request = None,
+) -> uuid.UUID:
+    """org_id 추출 — X-Org-Id 헤더 fallback 시 DB membership 검증, X-Project-Id 헤더 시 project 소속 검증.
+    API Key 경로는 HTTP method 기반 scope 자동 체크.
+
+    story #2459(§6 봉합①): 요청-수명 ``Depends(get_db)`` 대신 검증마다 전용 단명 세션 —
+    get_current_user와 동일 근거(호출 대상이 전부 읽기 전용, #2457로 이미 성립)."""
+    return await _resolve_verified_org_id_with_project(auth, x_org_id, x_project_id, request)
+
+
+async def get_verified_org_id_no_key_scope_check(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
+    request: Request = None,
+) -> uuid.UUID:
+    """``get_verified_org_id``와 동일하나 API키 **toolgroup** scope 체크(story b4027b2e)만
+    건너뛴다 — org/project **멤버십** 검증(has_project_access)은 그대로 항상 선다.
+
+    story #2708(2026-08-17, 페드루 PO 판정) — visual_artifacts.py의 read 7라우트가
+    project_id 헤더 인식(이 스토리의 목적)을 얻으면서도, b4027b2e가 테스트로 pin까지 한
+    「read는 toolgroup scope 면제」 의도적 동작을 안 깨야 한다. 두 축(project 접근 판정 vs
+    toolgroup 판정)은 원래 독립이라 판정 함수는 각각 한 곳(_check_api_key_scope·
+    has_project_access)씩 그대로 — 이 함수는 그 둘을 조합만 다르게 하는 얇은 wrapper."""
+    return await _resolve_verified_org_id_with_project(
+        auth, x_org_id, x_project_id, request, skip_key_scope_check=True
+    )
 
 
 async def get_project_scoped_org_id(
@@ -863,22 +914,51 @@ async def _verify_project_in_org(
         )
 
 
+async def _resolve_scope_context(
+    auth: AuthContext,
+    x_org_id: str | None,
+    x_project_id: str | None,
+    request: Request | None,
+    *,
+    skip_key_scope_check: bool = False,
+) -> dict:
+    """``get_scope_context``/``get_scope_context_no_key_scope_check`` 공유 core."""
+    org_id = await _resolve_verified_org_id_with_project(
+        auth, x_org_id, x_project_id, request, skip_key_scope_check=skip_key_scope_check
+    )
+    jwt_project_id = auth.claims.get("app_metadata", {}).get("project_id")
+    project_id_raw = jwt_project_id or x_project_id
+    project_id = uuid.UUID(str(project_id_raw)) if project_id_raw else None
+    return {"org_id": org_id, "project_id": project_id, "user_id": auth.user_id}
+
+
 async def get_scope_context(
     auth: AuthContext = Depends(get_current_user),
     x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
     x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
     request: Request = None,
 ) -> dict:
-    """org_id + project_id 컨텍스트를 한번에 추출 — 헤더 fallback 시 membership/소속 검증.
+    """org_id + project_id 컨텍스트를 한번에 추출 — 헤더 fallback 시 membership/소속 검증
+    (org·project 멤버십 + API키 toolgroup scope 전부 always-on).
 
     story #2459(§6 봉합①): get_verified_org_id가 이제 자체 단명 세션을 쓰므로 이 함수는
     db 의존 자체가 불요."""
-    # x_project_id를 get_verified_org_id에 전달해서 project 소속 검증도 위임
-    org_id = await get_verified_org_id(auth=auth, x_org_id=x_org_id, x_project_id=x_project_id, request=request)
-    jwt_project_id = auth.claims.get("app_metadata", {}).get("project_id")
-    project_id_raw = jwt_project_id or x_project_id
-    project_id = uuid.UUID(str(project_id_raw)) if project_id_raw else None
-    return {"org_id": org_id, "project_id": project_id, "user_id": auth.user_id}
+    return await _resolve_scope_context(auth, x_org_id, x_project_id, request)
+
+
+async def get_scope_context_no_key_scope_check(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
+    request: Request = None,
+) -> dict:
+    """``get_scope_context``와 동일(org/project 멤버십 검증 always-on)하나 API키 toolgroup
+    scope 체크(story b4027b2e)만 건너뛴다 — read 전용 라우트에서 쓴다(story #2708, PO 판정).
+
+    org/project 접근 판정(has_project_access)과 toolgroup 판정(_check_api_key_scope)은
+    독립된 두 축이고, 각 축의 판정 함수는 여전히 한 곳씩이다 — 이 함수는 조합만 다르게
+    하는 얇은 wrapper(사본 최소화)."""
+    return await _resolve_scope_context(auth, x_org_id, x_project_id, request, skip_key_scope_check=True)
 
 
 # ─── SSE/스트림 전용 auth (커넥션 비점유) ──────────────────────────────────────

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -8,7 +8,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_scope_context, get_scope_context_no_key_scope_check
 from app.dependencies.database import get_db
 from app.models.asset import Asset
 from app.services.artifact_image_url import _canonicalize_props, sign_image_srcs_in_nodes
@@ -49,13 +49,19 @@ def _err(code: str, message: str, status: int) -> JSONResponse:
     return JSONResponse({"data": None, "error": {"code": code, "message": message}, "meta": None}, status_code=status)
 
 
-def _get_org_project(auth: AuthContext) -> tuple[uuid.UUID | None, uuid.UUID | None]:
-    meta = auth.claims.get("app_metadata", {})
-    o = meta.get("org_id")
-    p = meta.get("project_id")
-    if not o or not p:
-        return None, None
-    return uuid.UUID(str(o)), uuid.UUID(str(p))
+# story #2708(2026-08-17, 페드루 PO 판정) — _get_org_project(auth) 헬퍼를 걷어냈다. 그 헬퍼는
+# auth.claims의 JWT app_metadata.project_id만 읽어 X-Project-Id 헤더를 아예 몰랐다(파라미터로도
+# 안 받음) — 브라우저가 현재 보고 있는 프로젝트와 무관하게 JWT에 구워진(다른/기본) project_id로
+# 조용히 스코프해, 아티팩트 갤러리가 실재 60+건을 두고 「No artifacts collected yet」로 빈
+# 화면을 보였다(원 인시던트, 유나 라이브 판별). 이 파일 19곳 전부가 같은 헬퍼를 썼다 — 판정을
+# 한 곳(get_scope_context, auth.py)으로 통일한다(들쭉날쭉 금지 원칙, story 22caa39b와 동형).
+#
+# get_scope_context()는 내부에서 get_verified_org_id(x_project_id=...)를 거치므로 헤더로 지정한
+# 프로젝트가 has_project_access(team_member ∪ grant ∪ owner/admin)로 **이미 멤버십 검증**된다
+# (auth.py get_verified_org_id 참조) — 헤더를 열어주는 대신 IDOR을 새로 여는 일은 없다. 19곳
+# 전부 `scope: dict = Depends(get_scope_context)`를 받아 `scope["org_id"]`/`scope["project_id"]`로
+# 읽는다(MCP/API키 경로는 x_project_id 헤더가 없으므로 기존처럼 키에 구운 JWT project_id가
+# 그대로 이김 — get_scope_context 내부 `jwt_project_id or x_project_id` 순서 그대로).
 
 
 _LINK_TABLES = {"story_id": "stories", "epic_id": "goals", "doc_id": "docs"}
@@ -123,10 +129,10 @@ async def _notify_artifact_created(
 async def create_artifact(
     body: CreateArtifactRequest,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
 
@@ -270,9 +276,10 @@ async def _load_detail(session: AsyncSession, artifact: VisualArtifact, version_
 async def get_artifact(
     id: uuid.UUID,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context_no_key_scope_check),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -288,9 +295,10 @@ async def get_artifact(
 async def list_artifact_versions(
     id: uuid.UUID,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context_no_key_scope_check),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -310,10 +318,11 @@ async def get_artifact_version(
     id: uuid.UUID,
     version_number: int,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context_no_key_scope_check),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """무-mutate 버전 조회 — 미르코 §6-1 갭 지적 대응(mockup은 restore=즉시 라이브 덮어씀)."""
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -334,6 +343,7 @@ async def list_artifacts(
     limit: int = Query(default=500, ge=1, le=1000),
     cursor: str | None = Query(default=None, description="ISO 8601 created_at, fetch before this time — 이전 페이지 meta.next_cursor 값 그대로"),
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context_no_key_scope_check),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """story #2428 PR④(ⓐ) — 예전엔 limit이 아예 없어 project 전체 artifact가 조용히 다
@@ -347,7 +357,7 @@ async def list_artifacts(
     # doc_id 미지정 호출(파라미터 없는 목록 조회)이 org 전체 artifact를 반환했다(cross-project
     # 노출·미르코 라이브 실측). create_artifact/get_artifact와 동형으로 JWT/API키 컨텍스트의
     # project_id(비-caller-suppliable)로 항상 스코프.
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
 
@@ -415,11 +425,11 @@ async def list_artifacts(
 async def delete_artifact(
     id: uuid.UUID,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     """생성자만 삭제 가능(Evidence 패턴 계승 — "누가 주어인가"). soft delete."""
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -445,13 +455,14 @@ async def list_artifact_comments(
     limit: int = Query(default=50, le=200),
     cursor: str | None = Query(default=None, description="ISO 8601 created_at, fetch after this time — 이전 페이지 meta.next_cursor 값 그대로(오래된순 정렬이라 forward-cursor)"),
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context_no_key_scope_check),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """story #2428 PR④(ⓐ) — limit은 있었으나 total/has_more가 없어 잘렸는지 호출자가 알 수
     없었다(활발한 토론 스레드는 챗 스레드와 동형 무한성장 위험). list_artifacts와 동일하게
     limit+1 오버페치 + has_more/next_cursor body meta(docs.py 정본 규약 A) — 정렬이 오래된순
     (asc)이라 next_cursor는 "이 시각 이후"로 이어가는 forward cursor."""
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -486,10 +497,10 @@ async def add_artifact_comment(
     id: uuid.UUID,
     body: CreateArtifactCommentRequest,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -549,10 +560,10 @@ async def resolve_artifact_comment(
     id: uuid.UUID,
     comment_id: uuid.UUID,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -586,9 +597,10 @@ async def resolve_artifact_comment(
 async def list_spec_pins(
     id: uuid.UUID,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context_no_key_scope_check),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -609,10 +621,10 @@ async def create_spec_pin(
     id: uuid.UUID,
     body: CreateSpecPinRequest,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -664,10 +676,10 @@ async def update_spec_pin(
     pin_id: uuid.UUID,
     body: UpdateSpecPinRequest,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -686,10 +698,10 @@ async def delete_spec_pin(
     id: uuid.UUID,
     pin_id: uuid.UUID,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -790,14 +802,14 @@ async def create_export_upload_url(
     version_number: int,
     body: ExportUploadUrlRequest,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     from datetime import datetime, timedelta, timezone
 
     from app.services.storage import get_storage_provider
 
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -826,12 +838,12 @@ async def complete_png_export(
     version_number: int,
     body: CompleteExportRequest,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     from app.services.storage import get_storage_provider
 
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -885,14 +897,14 @@ async def create_html_export(
     id: uuid.UUID,
     version_number: int,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     """self-contained HTML export — 렌더 불요(nodes 트리를 BE가 직렬화), client-trust 이슈 없어
     즉시 put_object(유나 UX②: as-authored — 별도 재테마 없이 저장된 props 그대로 직렬화)."""
     from app.services.storage import get_storage_provider
 
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -976,9 +988,10 @@ async def list_artifact_exports(
     id: uuid.UUID,
     version_number: int | None = Query(default=None),
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context_no_key_scope_check),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -1143,12 +1156,12 @@ async def edit_artifact(
     id: uuid.UUID,
     body: EditArtifactRequest,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     """딸깍 편집(FE) + MCP 편집(에이전트) 공용 엔드포인트 — 요소 add/update/delete를 적용해
     새 버전을 만든다(무-mutate 버전 원칙 계승)."""
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)
@@ -1198,14 +1211,14 @@ async def propose_canonical_version(
     id: uuid.UUID,
     version_number: int,
     auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
     session: AsyncSession = Depends(get_db),
-    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     """정본으로 제안 — AI는 제안만(MCP도 동일 엔드포인트), 승인은 always-HITL(gate_service).
     이미 pending 제안이 있으면 멱등(create_gate 자체 멱등 재사용)."""
     from app.services.gate_service import create_gate
 
-    org_id, project_id = _get_org_project(auth)
+    org_id, project_id = scope["org_id"], scope["project_id"]
     if not org_id or not project_id:
         return _err("FORBIDDEN", "org_id/project_id required", 403)
     artifact = await _get_artifact_or_404(session, org_id, project_id, id)

--- a/backend/tests/test_2642_entity_slug_exposure.py
+++ b/backend/tests/test_2642_entity_slug_exposure.py
@@ -345,10 +345,11 @@ async def test_evidence_get_carries_org_project_slug():
 
 # ── Artifact axis ────────────────────────────────────────────────────────────
 async def test_artifact_get_carries_own_org_project_slug_no_parent_hop():
-    """create_artifact/get_artifact를 직접 호출(다른 축과 동형) — create_artifact의
-    `_write_scope_check: Depends(get_verified_org_id)`는 실 DI 그래프 밖에서 org.id를 그대로
-    넘겨 우회(HTTP 라운드트립의 bearer-key 해소 복잡도 불필요 — 이 스토리 스코프는 slug
-    부착 로직 검증이지 인증 배선 자체가 아니다)."""
+    """create_artifact/get_artifact를 직접 호출(다른 축과 동형) — story #2708(2026-08-17)로
+    `_write_scope_check: Depends(get_verified_org_id)`가 `scope: dict = Depends(get_scope_context)`
+    로 교체됨에 따라, 실 DI 그래프 밖에서 그 dict를 그대로 넘겨 우회(HTTP 라운드트립의
+    bearer-key 해소 복잡도 불필요 — 이 스토리 스코프는 slug 부착 로직 검증이지 인증 배선
+    자체가 아니다)."""
     from app.models.visual_artifact import VisualArtifact
     from app.routers.visual_artifacts import CreateArtifactRequest, create_artifact, get_artifact
     from app.schemas.visual_artifact import ArtifactNodeIn
@@ -361,18 +362,19 @@ async def test_artifact_get_carries_own_org_project_slug_no_parent_hop():
 
             auth = _auth(agent_id, org.id)
             auth.claims["app_metadata"]["project_id"] = str(project.id)
+            scope = {"org_id": org.id, "project_id": project.id, "user_id": auth.user_id}
 
             create_resp = await create_artifact(
                 body=CreateArtifactRequest(
                     title="Diagram", source="created",
                     nodes=[ArtifactNodeIn(type="text", props={"content": "hi"})],
                 ),
-                auth=auth, session=s, _write_scope_check=org.id,
+                auth=auth, session=s, scope=scope,
             )
             import json
             artifact_id = uuid.UUID(json.loads(create_resp.body)["data"]["id"])
 
-            get_resp = await get_artifact(id=artifact_id, auth=auth, session=s)
+            get_resp = await get_artifact(id=artifact_id, auth=auth, scope=scope, session=s)
             body = json.loads(get_resp.body)["data"]
             assert body["org_slug"] == org.slug
             assert body["project_slug"] == "art-proj"

--- a/backend/tests/test_2708_visual_artifacts_x_project_id_header_realdb.py
+++ b/backend/tests/test_2708_visual_artifacts_x_project_id_header_realdb.py
@@ -1,0 +1,260 @@
+"""story #2708 — 아티팩트 갤러리(/artifacts)가 60+건 존재하는데 「No artifacts collected yet」로
+빈 화면. 근본원인: `_get_org_project(auth)`가 JWT app_metadata.project_id만 읽고 X-Project-Id
+헤더를 아예 몰랐다(파라미터로도 안 받음) — 브라우저가 실제로 보고 있는 프로젝트와 무관하게
+JWT에 구워진(다른/기본) project_id로 조용히 스코프해 빈 배열을 냈다(유나 라이브 판별).
+
+처방: visual_artifacts.py 19개 라우트 전부 `get_scope_context`(read 7곳은 API키 toolgroup
+scope 체크만 생략한 `get_scope_context_no_key_scope_check`) 경유로 통일 — X-Project-Id 헤더를
+우선 적용하되 has_project_access 멤버십 검증은 항상 선다(read/write 공통).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _seed_two_projects(session):
+    """org에 project A(caller 접근권 O, 아티팩트 3건 시딩·유나 재현의 60+건 대리값)·
+    project B(caller 접근권 X — 음성대조), 그리고 caller가 속하지 않은 org C·project D
+    (cross-org 헤더 거부 음성대조)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+    from app.models.visual_artifact import VisualArtifact
+
+    org = Organization(id=uuid.uuid4(), name="Org2708", slug=f"org2708-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="A(갤러리)")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="B(접근권없음)")
+    session.add(project_a)
+    session.add(project_b)
+    await session.commit()
+
+    for i in range(3):
+        session.add(VisualArtifact(
+            id=uuid.uuid4(), org_id=org.id, project_id=project_a.id,
+            title=f"artifact-{i}", created_by=uuid.uuid4(),
+        ))
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    # caller는 project A만 접근권 — project B는 미부여(음성대조).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    # 타 org(cross-org 헤더 거부 음성대조) — caller는 이 org 소속이 아님.
+    org_c = Organization(id=uuid.uuid4(), name="OrgC", slug=f"orgc-{uuid.uuid4().hex[:8]}")
+    session.add(org_c)
+    await session.commit()
+    project_d = Project(id=uuid.uuid4(), org_id=org_c.id, name="D(타org)")
+    session.add(project_d)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "caller_id": caller_id, "project_d_id": project_d.id,
+    }
+
+
+async def _setup_app_jwt_with_stale_project(app, Session, org_id, caller_id, stale_project_id):
+    """JWT에 프로젝트 A/B와 무관한 stale project_id가 구워진 상태를 재현(원 인시던트 —
+    브라우저 세션 발급 시점의 기본/구 프로젝트) — X-Project-Id 헤더로 override되는지가
+    이 스토리의 핵심 검증축."""
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(caller_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(stale_project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_gallery_bare_list_positive_x_project_id_header_wins_over_stale_jwt():
+    """양성대조(유나 재현 그대로) — JWT엔 stale(무관) project_id가 구워져 있지만, 갤러리가
+    보내는 X-Project-Id 헤더(project A)가 이겨 실 아티팩트(3건, 60+건의 대리값)가 보인다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_projects(s)
+        stale = uuid.uuid4()  # JWT에 구워진, 실제로 존재하지도 않는 "다른" project
+        await _setup_app_jwt_with_stale_project(app, Session, seeded["org_id"], seeded["caller_id"], stale)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/visual-artifacts",
+                headers={"X-Project-Id": str(seeded["project_a_id"])},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body["data"]) == 3, "갤러리가 실 아티팩트를 못 봄 — 원 버그 재현"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_read_route_negative_no_access_to_header_project_403():
+    """음성대조 ② — caller가 접근권 없는 project_id(B)를 헤더로 지정하면 read 라우트도
+    403(project 멤버십 검증은 toolgroup scope 면제와 무관하게 항상 선다, PO 조건②)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_projects(s)
+        await _setup_app_jwt_with_stale_project(
+            app, Session, seeded["org_id"], seeded["caller_id"], seeded["project_a_id"]
+        )
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/visual-artifacts",
+                headers={"X-Project-Id": str(seeded["project_b_id"])},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_read_route_negative_cross_org_project_header_rejected():
+    """음성대조 — 타 org(org_c)의 project_id(D)를 헤더로 지정하면 거부된다(cross-org 헤더
+    악용 방지, PO 조건④)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_projects(s)
+        await _setup_app_jwt_with_stale_project(
+            app, Session, seeded["org_id"], seeded["caller_id"], seeded["project_a_id"]
+        )
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/visual-artifacts",
+                headers={"X-Project-Id": str(seeded["project_d_id"])},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_read_route_toolgroup_scope_still_exempt_for_api_key():
+    """read 라우트는 project 멤버십 검증은 서지만, API키 toolgroup scope 체크(story b4027b2e)는
+    여전히 면제된다(PO 조건① — scope 미보유 API키라도 read는 통과) — 회귀 확認."""
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_projects(s)
+
+        async def _db():
+            async with Session() as s:
+                try:
+                    yield s
+                    await s.commit()
+                except Exception:
+                    await s.rollback()
+                    raise
+
+        async def _auth():
+            return AuthContext(
+                user_id=str(seeded["caller_id"]), email=None,
+                claims={"app_metadata": {
+                    "org_id": str(seeded["org_id"]), "project_id": str(seeded["project_a_id"]),
+                    "api_key_id": str(uuid.uuid4()), "scope": ["docs"],
+                }},
+            )
+
+        app.dependency_overrides[get_db] = _db
+        app.dependency_overrides[get_current_user] = _auth
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/visual-artifacts")
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()["data"]) == 3
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2708_visual_artifacts_x_project_id_header_realdb.py
+++ b/backend/tests/test_2708_visual_artifacts_x_project_id_header_realdb.py
@@ -112,7 +112,7 @@ async def _setup_app_jwt_with_stale_project(app, Session, org_id, caller_id, sta
     브라우저 세션 발급 시점의 기본/구 프로젝트) — X-Project-Id 헤더로 override되는지가
     이 스토리의 핵심 검증축."""
     from app.dependencies.auth import AuthContext, get_current_user
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     async def _db():
         async with Session() as s:
@@ -129,7 +129,7 @@ async def _setup_app_jwt_with_stale_project(app, Session, org_id, caller_id, sta
             claims={"app_metadata": {"org_id": str(org_id), "project_id": str(stale_project_id)}},
         )
 
-    app.dependency_overrides[get_db] = _db
+    override_db_and_read(app, _db)
     app.dependency_overrides[get_current_user] = _auth
 
 
@@ -220,7 +220,7 @@ async def test_read_route_toolgroup_scope_still_exempt_for_api_key():
     """read 라우트는 project 멤버십 검증은 서지만, API키 toolgroup scope 체크(story b4027b2e)는
     여전히 면제된다(PO 조건① — scope 미보유 API키라도 read는 통과) — 회귀 확認."""
     from app.dependencies.auth import AuthContext, get_current_user
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -246,7 +246,7 @@ async def test_read_route_toolgroup_scope_still_exempt_for_api_key():
                 }},
             )
 
-        app.dependency_overrides[get_db] = _db
+        override_db_and_read(app, _db)
         app.dependency_overrides[get_current_user] = _auth
         client = _client_for(app)
         try:


### PR DESCRIPTION
## 요약
아티팩트 갤러리(/artifacts)가 실 아티팩트 60+건을 두고 「No artifacts collected yet」 빈 화면. 근본원인: `visual_artifacts.py`의 `_get_org_project(auth)` 헬퍼가 JWT `app_metadata.project_id`(정적으로 구워진 값)만 읽고 X-Project-Id 헤더를 파라미터로도 안 받음 — 브라우저가 실제로 보는 프로젝트와 무관하게 JWT의 stale project_id로 조용히 스코프. MCP/API키는 키 발급 시 project_id가 정확히 구워져 정상 조회됐음.

## ⚠️scope 확장(PO 판정)
원 요청은 갤러리(bare-list) 한정이었으나, 그라운딩 중 같은 헬퍼가 이 파일 **19곳 전부**에서 재사용됨을 발견 — 「판정 함수 한 곳」 원칙(story 22caa39b와 동형)에 따라 19곳 전체를 한 번에 고침.

## 19곳 전수 목록
**write(12, 기존 `get_verified_org_id` 스코프체크 유지)**: create_artifact · delete_artifact · add_artifact_comment · resolve_artifact_comment · create_spec_pin · update_spec_pin · delete_spec_pin · create_export_upload_url · complete_png_export · create_html_export · edit_artifact · propose_canonical_version

**read(7, toolgroup scope 체크 면제 유지)**: get_artifact · list_artifact_versions · get_artifact_version · list_artifacts(갤러리 bare-list) · list_artifact_comments · list_spec_pins · list_artifact_exports

## 처방
- 판정을 `get_scope_context`(auth.py, 기존 canonical) 하나로 통일 — 내부에서 `get_verified_org_id(x_project_id=...)`가 이미 `has_project_access` 멤버십 검증을 수행하므로 헤더를 열어도 IDOR 신규 발생 없음.
- **보안 축 보존**: story b4027b2e가 read 라우트에 대해 의도적으로 면제해온 API키 toolgroup scope 체크(project 멤버십과 독립된 별개 축)를 안 깨기 위해 `get_scope_context_no_key_scope_check`(read 7곳 전용) 변형 신설 — project 멤버십 검증은 read/write 공통 always-on, toolgroup scope 체크만 write 12곳에 한정. bare bool 파라미터를 Depends() 그래프에 직접 노출하면 `?skip_key_scope_check=true` 쿼리로 새는 구멍이 생기므로, private core 함수로만 스레딩하고 공개 dependency는 named wrapper 2개로 분리.

## 검증
- 신규 `test_2708_visual_artifacts_x_project_id_header_realdb.py`(4건, real PG): 양성대조(유나 재현 그대로 — JWT stale project_id인데 X-Project-Id 헤더가 이겨 실 아티팩트 3건 보임)·음성대조 2종(같은 org 접근권없는 project 헤더→403·타 org project 헤더→403)·toolgroup scope 면제 회귀(API키 docs scope로도 read 통과).
- 뮤테이션킬: 헤더→claims override 로직 무력화 → 양성대조만 정확히 RED, 나머지 3건 무영향. 원복 → 4/4 GREEN.
- 기존 회귀 스위트(visual_artifact·e_canvas·sec_s8·1920·scope_group·2711·b4027b2e) 264/264 → 이번 fix 반영 후 610/610(auth-context 계열까지 확장) 전부 GREEN.
- MCP 경로 무회귀: x_project_id 헤더가 없을 때(MCP 표준 호출) `jwt_project_id or x_project_id`에서 JWT/API키에 구운 값이 그대로 이김(claims 미변형 확認, 조건③).

## QA
제 자신의 인프라·인가 건이라 셀프 QA 불가 — 교차 QA 필요(보안 관련이라 특히 신중 부탁).

🤖 Generated with [Claude Code](https://claude.com/claude-code)