### PR TITLE
[SID:2089] realtime path-filter — backend-only 머지가 GCE MIG 재배포 안 시키게

### DIFF
--- a/backend/scripts/check_realtime_relevant_diff.sh
+++ b/backend/scripts/check_realtime_relevant_diff.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# story #2089 (a) — realtime path-filter.
+#
+# #2182 그라운딩(미르코, 2026-08-17)에서 실측: 최근 2주 backend 변경 커밋 162개 중
+# realtime이 실제로 참조하는 파일을 건드린 건 40개(24.7%)뿐이었다 — 즉 오늘까지의 502
+# rolling의 75.3%는 "realtime 코드가 실제로 안 바뀐 커밋"이 deploy-realtime-gce를 무조건
+# 재실행시켜 생긴 것이었다. 이 스크립트는 두 커밋 사이에 그 경로가 바뀌었는지만 판별한다
+# — 판별해서 실제 배포/스킵을 결정하는 건 호출부(cloudbuild.yaml)의 몫이다.
+#
+# 경로 목록은 **보수적으로**(페드루 PO 판정, 2026-08-17) 채택했다 — realtime 전용 코드
+# (events.py·agent_gateway.py 등)만으론 11.1%까지 좁힐 수 있었지만, auth.py·database.py
+# 같은 "backend 전역도 같이 쓰지만 realtime도 실제로 부르는" 공유 파일까지 넣은 24.7% 셋을
+# 썼다 — 좁히면 "공유 파일이 바뀌었는데 realtime 동작도 같이 바뀌었을 수 있는데 배포를
+# 안 하는" stale binary 미탐 위험이 있기 때문("빈도"보다 "정확성"을 우선한다는 판정).
+#
+# exit 0 = 배포해야 함(관련 경로 변경 있음 — 또는 판별 자체가 불가능해 안전하게 배포 쪽을
+#          택함, "필터가 실수로 좁아도 조용히 안 새게"라는 PO 요구사항의 구현).
+# exit 1 = 스킵해도 됨(관련 경로 변경이 확실히 없을 때만).
+#
+# 사용법:
+#   backend/scripts/check_realtime_relevant_diff.sh <from_sha> [<to_sha=HEAD>]
+#   FROM_SHA를 생략하면(빈 문자열) 판별 불가로 간주 — exit 0(배포 쪽).
+#
+# ⚠️git fetch/unshallow는 호출부(cloudbuild.yaml)가 필요하면 이 스크립트 호출 전에 직접
+# 한다 — 이 스크립트 자체는 순수 git diff 판별만 하고 네트워크 I/O를 하지 않는다(테스트
+# 용이성 — 로컬 임시 git repo만으로 이 스크립트 전체를 검증할 수 있어야 한다).
+
+set -uo pipefail  # ⚠️-e 없음 — git diff 실패를 우리가 직접 잡아 fail-safe 분기로 보낸다
+
+REALTIME_RELEVANT_PATHS=(
+    "backend/app/realtime_main.py"
+    "backend/app/routers/agent_gateway.py"
+    "backend/app/routers/events.py"
+    "backend/app/routers/health.py"
+    "backend/app/dependencies/auth.py"
+    "backend/app/core/database.py"
+    "backend/app/core/shutdown.py"
+    "backend/app/dependencies/database.py"
+    "backend/app/models/agent_gateway.py"
+    "backend/app/models/event.py"
+    "backend/app/models/organization.py"
+    "backend/app/models/team.py"
+    "backend/app/services/agent_onboarding_config.py"
+    "backend/app/dependencies/ownership.py"
+    "backend/app/services/member_resolver.py"
+    "backend/app/services/realtime_readiness.py"
+    "backend/app/core/config.py"
+    "backend/app/core/logging_config.py"
+    "backend/app/core/rate_limit.py"
+    "backend/app/services/pg_pubsub.py"
+    "backend/scripts/deploy_realtime_gce.sh"
+    "backend/scripts/provision_realtime_gclb.sh"
+)
+
+FROM_SHA="${1:-}"
+TO_SHA="${2:-HEAD}"
+
+if [ -z "${FROM_SHA}" ]; then
+    echo "check_realtime_relevant_diff: FROM_SHA 미지정 — 판별 불가, 안전하게 배포 쪽(exit 0)" >&2
+    exit 0
+fi
+
+_DIFF_OUTPUT="$(git diff --name-only "${FROM_SHA}...${TO_SHA}" -- "${REALTIME_RELEVANT_PATHS[@]}" 2>&1)"
+_DIFF_RC=$?
+
+if [ "${_DIFF_RC}" -ne 0 ]; then
+    echo "check_realtime_relevant_diff: git diff ${FROM_SHA}...${TO_SHA} 실패(rc=${_DIFF_RC}: ${_DIFF_OUTPUT}) — 판별 불가, 안전하게 배포 쪽(exit 0)" >&2
+    exit 0
+fi
+
+if [ -z "${_DIFF_OUTPUT}" ]; then
+    echo "check_realtime_relevant_diff: ${FROM_SHA}..${TO_SHA} 사이 realtime-관련 경로 변경 없음 — 스킵 가능(exit 1)" >&2
+    exit 1
+fi
+
+echo "check_realtime_relevant_diff: realtime-관련 경로 변경 있음 —" >&2
+echo "${_DIFF_OUTPUT}" >&2
+exit 0

--- a/backend/tests/test_check_realtime_relevant_diff.py
+++ b/backend/tests/test_check_realtime_relevant_diff.py
@@ -1,0 +1,105 @@
+"""story #2089 (a) — check_realtime_relevant_diff.sh 회귀가드.
+
+#2182 그라운딩(2026-08-17)에서 실측: backend 변경 커밋의 75.3%는 realtime이 실제로
+참조하는 파일을 안 건드렸는데도 deploy-realtime-gce가 매번 재실행돼 rolling(502 버스트)을
+유발했다. 이 스크립트(cloudbuild.yaml deploy-realtime-gce 스텝에서 호출)는 그 판별만
+한다 — 순수 git diff 로직이라 임시 git repo만으로 전체 경로(관련 있음/없음/판별불가)를
+검증할 수 있다(gcloud 목업 불요, deploy_realtime_gce.sh 자체 테스트들과 다른 축).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "check_realtime_relevant_diff.sh")
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, check=True,
+        env={**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t.com",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t.com"},
+    )
+
+
+def _init_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    for rel in (
+        "backend/app/realtime_main.py",
+        "backend/app/routers/agent_gateway.py",
+        "backend/app/routers/other_unrelated_router.py",
+        "apps/web/src/components/unrelated.tsx",
+    ):
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("v1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    base_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    return repo, base_sha
+
+
+def _run(repo, from_sha, to_sha="HEAD"):
+    return subprocess.run(
+        ["bash", _SCRIPT, from_sha, to_sha], cwd=str(repo),
+        capture_output=True, text=True,
+    )
+
+
+def test_relevant_path_changed_exits_0_deploy(tmp_path):
+    """⭐realtime 전용 파일(agent_gateway.py)이 바뀌면 배포해야 함(exit 0)."""
+    repo, base_sha = _init_repo(tmp_path)
+    (repo / "backend/app/routers/agent_gateway.py").write_text("v2\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "touch realtime router")
+
+    proc = _run(repo, base_sha)
+    assert proc.returncode == 0, f"관련 경로 변경인데 스킵 판정 — stderr={proc.stderr!r}"
+
+
+def test_irrelevant_path_only_exits_1_skip(tmp_path):
+    """⭐realtime과 무관한 파일만 바뀌면 스킵 가능(exit 1) — #2182가 겨눈 그 케이스."""
+    repo, base_sha = _init_repo(tmp_path)
+    (repo / "backend/app/routers/other_unrelated_router.py").write_text("v2\n")
+    (repo / "apps/web/src/components/unrelated.tsx").write_text("v2\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "touch unrelated files only")
+
+    proc = _run(repo, base_sha)
+    assert proc.returncode == 1, f"무관 경로만 변경인데 배포 판정 — stderr={proc.stderr!r}"
+
+
+def test_shared_conservative_path_auth_py_counts_as_relevant(tmp_path):
+    """PO 판정(2026-08-17) — 보수적 채택. auth.py(공유 파일)도 realtime-관련으로 잡혀야
+    한다(11.1%로 좁히면 stale binary 미탐 위험 — PO가 명시적으로 기각한 선택지)."""
+    repo, base_sha = _init_repo(tmp_path)
+    (repo / "backend/app/dependencies").mkdir(parents=True, exist_ok=True)
+    (repo / "backend/app/dependencies/auth.py").write_text("v1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "add auth.py")
+    auth_added_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    (repo / "backend/app/dependencies/auth.py").write_text("v2\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "touch auth.py")
+
+    proc = _run(repo, auth_added_sha)
+    assert proc.returncode == 0, f"공유 파일(auth.py) 변경인데 스킵 판정 — stderr={proc.stderr!r}"
+
+
+def test_missing_from_sha_is_fail_safe_deploy(tmp_path):
+    """FROM_SHA 미지정 = 판별 불가 — 조용히 스킵하면 안 되고 배포 쪽(exit 0)."""
+    repo, _base_sha = _init_repo(tmp_path)
+    proc = _run(repo, "")
+    assert proc.returncode == 0
+
+
+def test_unresolvable_from_sha_is_fail_safe_deploy(tmp_path):
+    """⭐git diff 자체가 실패하는 경우(옛 SHA가 히스토리에 없음 — 얕은 클론 등)도
+    fail-safe로 배포 쪽(exit 0)이어야 한다 — 「필터가 실수로 좁아도 조용히 안 새게」
+    라는 PO 요구사항의 핵심 축(스킵은 확실할 때만)."""
+    repo, _base_sha = _init_repo(tmp_path)
+    proc = _run(repo, "0000000000000000000000000000000000dead")
+    assert proc.returncode == 0, f"판별 불가(unresolvable SHA)인데 스킵 판정 — stderr={proc.stderr!r}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -634,6 +634,33 @@ steps:
           echo "skip deploy-realtime-gce: dev 전용 하드게이트(story #2185) — prod GCE는 사람이 직접 배포한다"
           exit 0
         fi
+
+        # story #2089 (a) — realtime path-filter(페드루 PO 판정, 2026-08-17). #2182
+        # 그라운딩에서 오늘까지의 502 rolling 중 75.3%가 "realtime 코드가 실제로 안 바뀐
+        # 커밋"에서 유발됐음을 실측(2주 162커밋 대조) — 매 develop 머지가 무조건 이
+        # 스텝을 재실행시키던 걸 여기서 끊는다. 별도 GCB 트리거로 안 쪼갠다(SSOT 유지,
+        # 페드루 지시) — 기존 파이프라인 안 조건부 스텝 그대로.
+        #
+        # 판별 기준: 현재 MIG가 물고 있는 인스턴스 템플릿 이름에서 직전 배포 SHA를 뽑아,
+        # 그 SHA부터 이번 COMMIT_SHA까지 realtime-관련 경로(backend/scripts/
+        # check_realtime_relevant_diff.sh의 목록, 보수적 채택 — 공유 파일 포함 24.7%셋)가
+        # 바뀌었는지 본다. 얕은 클론이면 옛 SHA가 히스토리에 없을 수 있어 unshallow를
+        # 먼저 시도(실패해도 계속 — 아래 diff 성패로 최종 fail-safe 판단).
+        _CURRENT_TEMPLATE="$(gcloud compute instance-groups managed describe sprintable-realtime-gateway-dev \
+          --region="${_AR_REGION}" --project="${PROJECT_ID}" \
+          --format='value(versions[0].instanceTemplate)' 2>/dev/null | sed 's#.*/##' || echo '')"
+        _LAST_SHA="$(echo "${_CURRENT_TEMPLATE}" | grep -oE '[0-9a-f]{8}' | head -1 || echo '')"
+
+        if [ -z "${_LAST_SHA}" ]; then
+          echo "deploy-realtime-gce: 기존 MIG 템플릿에서 직전 SHA를 못 읽음(최초 배포이거나 이름 패턴 변경) — path-filter 건너뛰고 배포 진행"
+        else
+          git fetch --unshallow >/dev/null 2>&1 || true
+          if ! bash backend/scripts/check_realtime_relevant_diff.sh "${_LAST_SHA}" "${COMMIT_SHA}"; then
+            echo "skip deploy-realtime-gce: ${_LAST_SHA}..${COMMIT_SHA} 사이 realtime-관련 경로 변경 없음(story #2089 path-filter, 스킵 사유는 위 로그 참고)"
+            exit 0
+          fi
+        fi
+
         GCP_PROJECT="${PROJECT_ID}" GCP_REGION="${_AR_REGION}" COMMIT_SHA="${COMMIT_SHA}" \
           bash backend/scripts/deploy_realtime_gce.sh dev
     waitFor: [run-migrate-job]


### PR DESCRIPTION
## 배경 — #2182 그라운딩(2026-08-17, 미르코)에서 확定된 잔여 원인

오늘 #2182(SSE 83%→503→502) 판정: PROACTIVE 자발 재분배 축은 닫혔지만, 잔여 502 전부가
「develop 머지마다 deploy-realtime-gce가 같이 도는 rolling」으로 귀속됐다. 그 구조 자체를
끊는 게 이 PR.

**실측(최근 2주 backend 변경 커밋 162개 대조, read-only git 순회)**:
```
realtime 전용 파일만(events.py·agent_gateway.py·realtime_main.py·pg_pubsub.py·
  realtime_readiness.py) 건드린 커밋: 18/162 = 11.1%
realtime이 의존하는 공유 파일(auth.py·database.py·config.py 등)까지 포함: 40/162 = 24.7%
```
즉 오늘까지의 502 rolling의 **75.3%(보수 기준)~88.9%(협소 기준)는 realtime 코드가 실제로
안 바뀐 커밋**에서 유발된 것.

## 페드루 PO 판정(2026-08-17) — 형태 확定

1. **(a) 트리거/path-filter만 먼저 적용** — story #2089 원안(이미지 분리, blast radius
   축소)은 별도 판으로 보류(story #2089에 그 갈림 그대로 기록됨).
2. **별도 GCB 트리거로 안 쪼갠다** — 트리거 리소스를 늘리면 SSOT가 갈라진다. 기존
   cloudbuild.yaml 파이프라인 안 **조건부 스텝**으로 유지.
3. **필터는 보수 쪽(24.7% 셋) 채택** — 11.1%(전용 파일만)는 "공유 파일이 바뀌었는데
   realtime 동작도 같이 바뀌었을 수 있는데 배포를 안 하는" stale binary 미탐 위험이라 기각.
4. 판별이 "막는 쪽"이므로 — 필터가 실수로 좁아도 조용히 안 새게, **판별 불가 시 배포 쪽**
   (fail-safe), 스킵 시 스킵 사유(diff 요약)를 빌드 로그에 찍는다.

## 필터 대상 경로 목록(22개, `backend/scripts/check_realtime_relevant_diff.sh`)

```
backend/app/realtime_main.py
backend/app/routers/agent_gateway.py
backend/app/routers/events.py
backend/app/routers/health.py
backend/app/dependencies/auth.py
backend/app/core/database.py
backend/app/core/shutdown.py
backend/app/dependencies/database.py
backend/app/models/agent_gateway.py
backend/app/models/event.py
backend/app/models/organization.py
backend/app/models/team.py
backend/app/services/agent_onboarding_config.py
backend/app/dependencies/ownership.py
backend/app/services/member_resolver.py
backend/app/services/realtime_readiness.py
backend/app/core/config.py
backend/app/core/logging_config.py
backend/app/core/rate_limit.py
backend/app/services/pg_pubsub.py
backend/scripts/deploy_realtime_gce.sh
backend/scripts/provision_realtime_gclb.sh
```
(`app/realtime_main.py`가 마운트하는 `agent_gateway`·`events`·`health` 3개 라우터의
1-depth import 그래프 + 그 라우터들이 부르는 공유 서비스/모델/core 파일 + 배포 스크립트
자신. 이 PR이 그대로 이 목록 기준으로 자기자신도 커버함 — `deploy_realtime_gce.sh`가
바뀌면 당연히 재배포해야 하므로.)

## 구현

- **`backend/scripts/check_realtime_relevant_diff.sh`**(신규) — 순수 git diff 판별만
  하는 스크립트(gcloud 호출 없음 — 테스트 용이성). `<from_sha> [<to_sha=HEAD>]`를 받아
  위 경로 목록에 변경이 있으면 exit 0(배포), 없으면 exit 1(스킵), FROM_SHA 미지정이거나
  git diff 자체가 실패하면(옛 SHA가 얕은 클론 히스토리에 없는 등) exit 0(fail-safe, 판별
  불가는 배포 쪽).
- **`cloudbuild.yaml`의 `deploy-realtime-gce` 스텝** — 기존 `_DEPLOY_ENV=="dev"` 게이트
  뒤에 조건 추가: 현재 MIG(`sprintable-realtime-gateway-dev`)가 물고 있는 인스턴스 템플릿
  이름에서 직전 배포 SHA를 뽑고(`versions[0].instanceTemplate` → 8자리 hex 추출),
  `git fetch --unshallow`(얕은 클론 대비, 실패해도 계속) 後 위 스크립트로 판별. 스킵이면
  `echo "skip deploy-realtime-gce: ..."` + `exit 0`(스텝 자체는 성공/초록 처리 — PO 명시
  요구사항). 기존 MIG 템플릿에서 SHA를 못 읽으면(최초 배포 등) path-filter 자체를
  건너뛰고 배포(fail-safe).

## 검증

- 신규 5테스트(`test_check_realtime_relevant_diff.py`, 임시 git repo 기반 — gcloud 목업
  불요): 관련 경로 변경→exit 0 · 무관 경로만→exit 1 · 보수 채택 검증(auth.py도 관련으로
  잡힘) · FROM_SHA 미지정→fail-safe exit 0 · git diff 실패(unresolvable SHA)→fail-safe
  exit 0. 5/5 pass.
- **뮤테이션킬 2건**: ①diff-실패 fail-safe 분기를 무력화(exit 0→exit 1로 변경) → 그 축
  테스트 정확히 RED, 원복 GREEN. ②"관련 경로 있음" 판정 자체를 무력화(항상 스킵 분기로
  보냄) → positive 테스트 2건 정확히 RED, 원복 GREEN.
- `cloudbuild.yaml` YAML 파싱 유효성 확認(`python3 -c "import yaml; yaml.safe_load(...)"`).
- `bash -n`으로 신규 스크립트 문법 검사 통과.

## 예상 효과

path-filter 적용 후 deploy-realtime-gce 실행(=rolling 유발) 빈도는 오늘 ~100%(매 dev
develop 머지)에서 **24.7% 수준**으로 하강 예상(2주 실측 기준). #2182의 다음 관측
window에서 이 하강이 실제로 재현되는지는 별도 후속 확認 필요(이 PR 스코프 밖).

## QA

제 자신의 인프라 건이라 셀프 QA 불가 — 교차 QA 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)