### PR TITLE
[SID:2709] 에이전트 블로킹 질문 → 비동기 결정 요청(gate 사이클)

### DIFF
--- a/backend/app/models/hitl_config.py
+++ b/backend/app/models/hitl_config.py
@@ -18,7 +18,13 @@ from app.core.database import Base
 
 POSTURES = frozenset({"conservative", "balanced", "permissive"})
 DISPOSITIONS = frozenset({"allow_auto", "ask", "deny"})
-GATE_TYPES = frozenset({"pr_review", "qa", "merge", "deploy", "workflow_config_publish"})
+# story #2709(2026-08-17) — agent_decision_request 포함: gates.py의 GateCreateRequest 필드
+# validator가 이 세트만 통과시켜 등재 필요. _ALWAYS_MANUAL_GATE_TYPES(gate_service.py)가
+# posture 무관 항상 pending으로 덮으므로 여기 등재가 disposition 자동판정에 실제로 영향은
+# 안 준다 — 순수히 「generic POST /api/v2/gates로 생성 허용」 관문 통과 목적.
+GATE_TYPES = frozenset({
+    "pr_review", "qa", "merge", "deploy", "workflow_config_publish", "agent_decision_request",
+})
 
 _POSTURE_DEFAULT: dict[str, str] = {
     "conservative": "ask",

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.auth import get_current_user, get_scope_context, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import Doc
 from app.models.gate import Gate, is_valid_transition
@@ -255,6 +255,78 @@ async def create_gate_endpoint(
     # 트리거 미확定인 MissingGreenlet 클래스(unloaded attr sync 직렬화) 전체를 이 자리서 차단.
     await session.refresh(gate)
     return GateResponse.model_validate(gate)
+
+
+class DecisionRequestCreate(BaseModel):
+    question: str
+    options: list[str] | None = None
+    assumption: str
+    related_work_item_type: str | None = None
+    related_work_item_id: uuid.UUID | None = None
+
+
+@router.post("/decisions", response_model=GateResponse, status_code=201)
+async def create_decision_request(
+    body: DecisionRequestCreate,
+    session: AsyncSession = Depends(get_db),
+    scope: dict = Depends(get_scope_context),
+    auth=Depends(get_current_user),
+) -> GateResponse:
+    """story #2709(2026-08-17) — 에이전트의 블로킹 질문을 비동기 결정 요청으로 승격.
+    AskUserQuestion류 훅 봉인(story #2701 후속)의 dogfood 교체 대상 — 새 게이트 메커니즘
+    발명 0(create_gate/gate_type 등재/알림배관 전부 기존 재사용), 이 엔드포인트 자체만
+    신규(캐스팅 글루 — 호출자 신원+standalone self-referencing anchor를 서버가 원자적으로
+    한 번에 만들어 준다, MCP 클라이언트가 role_id 같은 내부 개념을 몰라도 되게).
+
+    self-referencing anchor(PO 판정, 2026-08-17): work_item_id==gate.id로 클라 uuid4 선생성
+    없이 서버가 1 INSERT로 원자 생성(생성 後 UPDATE 2단계 금지). work_item_type=
+    "agent_decision"(KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES 등재 필수 —
+    안 하면 GET /gates/{id}가 전수 fail-closed 404, 전수 grep으로 발견)."""
+    org_id, project_id = scope["org_id"], scope["project_id"]
+    if not org_id or not project_id:
+        raise HTTPException(status_code=403, detail="org_id/project_id required")
+
+    gate_id = uuid.uuid4()
+    caller_id = uuid.UUID(auth.user_id)
+
+    from app.services.workflow_line_config import _default_role_id
+    # doc.py의 동일 관례 재사용(role_id는 _ALWAYS_MANUAL_GATE_TYPES라 disposition 결과에
+    # 실제 영향 없음 — 기본 role 없으면 self-referencing anchor 자체를 placeholder로).
+    role_id = await _default_role_id(session, org_id) or gate_id
+
+    neutral_facts: dict[str, Any] = {
+        "question": body.question,
+        "options": body.options,
+        "assumption": body.assumption,
+        "requested_by_member_id": str(caller_id),
+        "project_id": str(project_id),
+    }
+    if body.related_work_item_type and body.related_work_item_id:
+        neutral_facts["related_work_item_type"] = body.related_work_item_type
+        neutral_facts["related_work_item_id"] = str(body.related_work_item_id)
+
+    gate = await create_gate(
+        session=session,
+        org_id=org_id,
+        work_item_id=gate_id,
+        work_item_type="agent_decision",
+        gate_type="agent_decision_request",
+        member_id=caller_id,
+        role_id=role_id,
+        neutral_facts=neutral_facts,
+        project_id=project_id,
+        gate_id=gate_id,
+    )
+    await session.commit()
+    await session.refresh(gate)
+    resp = GateResponse.model_validate(gate)
+    resp.project_id = project_id
+    # story #1972 SSOT 재사용(제네릭 create_gate_endpoint가 이 필드를 아예 안 채우는 기존
+    # 갭을 여기서까지 상속하면 FE deriveRiskLevel이 null→'unknown'으로 읽어 low 등재의
+    # 목적(원탭 승인)이 생성 응답 자체에서는 무효화된다 — 자체 신규 테스트로 발견·직접 수정).
+    _posture = await get_org_posture(session, org_id)
+    resp.risk_grade = derive_risk_grade(_posture, gate.gate_type)
+    return resp
 
 
 async def _non_doc_gate_approvable(

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -448,6 +448,20 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
         DeepLinkManifestEntry(
+            # story #2709: 비동기 결정 요청(agent_decision_request) 해소 결과가 human 상신자에게
+            # 회신되는 벨 알림 — doc_approval_resolved와 완전 동형(dispatch_approval_result_reply
+            # 파라미터화 재사용, gate 경유·reference_id=gate_id·읽기전용 FYI).
+            app=DeepLinkAppFields(
+                type="agent_decision_resolved", target="gate_detail", parent_tab=ParentTab.approvals,
+                target_promotion_pending=True,
+            ),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+        DeepLinkManifestEntry(
             # story #2631: 「보류(논의 필요)」 요청이 doc 결재 상신자에게 회신되는 벨 알림 —
             # doc_approval_resolved와 동형(gate 경유·reference_id=gate_id)이나 게이트가 아직
             # 결정 안 나고 pending인 채로 "3안 논의 요청"을 받은 것이라, 결재자가 그 카드로

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -179,17 +179,25 @@ async def dispatch_approval_result_reply(
     db: AsyncSession,
     *,
     org_id: uuid.UUID,
-    doc: Doc,
+    work_item_type: str,
+    work_item_id: uuid.UUID,
+    project_id: uuid.UUID,
+    title: str,
     gate_id: uuid.UUID,
     requester_id: uuid.UUID,
     resolver_id: uuid.UUID,
     decision: str,
     resolution_note: str | None,
+    event_type: str = "doc_approval_resolved",
 ) -> None:
     """story #2624: 게이트 해소(승인/반려) 결과를 상신자에게 회신 — dispatch_approval_
     request_cards의 반대 방향(승인자→상신자). P2(#3007)는 상신→승인자 카드 전방 경로만
     만들었고 해소→상신자 회신 후방 경로가 없어, 상신자가 게이트를 폴링해야만 결과를 알 수
     있었다(선생님 직접 지적, 실사례 2026-08-13 07:20 반려·상신자 무통지).
+
+    story #2709(2026-08-17) — doc 전용(`doc: Doc` 객체)이던 시그니처를 일반화했다(새 함수
+    발명 0, 파라미터화). `agent_decision_request`처럼 work_item이 Doc이 아니거나(또는
+    work_item이 gate 자기참조뿐인 standalone) 호출부는 자기가 가진 값을 그대로 넘긴다.
 
     상신자↔해소자 기존 DM(같은 dm_pair_key — get_or_create가 인자 순서 무관하게 같은 방을
     찾는다)에 message_kind="result" 카드 게시 + 기존 _dispatch_conversation_event 재사용
@@ -200,7 +208,7 @@ async def dispatch_approval_result_reply(
 
     해소자 본인이 상신자인 경우(SoD가 정상적으로 막지만 방어심층) 자기-알림 스킵(AC3).
     """
-    if not doc.project_id or resolver_id == requester_id:
+    if not project_id or resolver_id == requester_id:
         return
 
     from app.routers.conversations import _dispatch_conversation_event
@@ -208,18 +216,18 @@ async def dispatch_approval_result_reply(
 
     resolver = (await lookup_members_by_ids({resolver_id}, db)).get(resolver_id)
     if resolver is None:
-        logger.warning("approval-result 회신 스킵 — resolver 미확인 doc=%s", doc.id)
+        logger.warning("approval-result 회신 스킵 — resolver 미확인 work_item=%s", work_item_id)
         return
 
     decision_label = "승인" if decision == "approved" else "반려"
-    content = f"'{doc.title}' 문서 결재 결과: {decision_label}"
+    content = f"'{title}' 결재 결과: {decision_label}"
     if resolution_note:
         content += f"\n사유: {resolution_note}"
 
     try:
         async with db.begin_nested():
             conv = await _get_or_create_approval_dm(
-                db, org_id=org_id, project_id=doc.project_id,
+                db, org_id=org_id, project_id=project_id,
                 requester_id=requester_id, approver_id=resolver_id,
             )
             msg = ConversationMessage(
@@ -234,8 +242,8 @@ async def dispatch_approval_result_reply(
                         "expects_response": False,
                     },
                     "approval_target": {
-                        "work_item_type": "doc",
-                        "work_item_id": str(doc.id),
+                        "work_item_type": work_item_type,
+                        "work_item_id": str(work_item_id),
                         "gate_id": str(gate_id),
                         "decision": decision,
                         "resolution_note": resolution_note,
@@ -247,8 +255,8 @@ async def dispatch_approval_result_reply(
             await _dispatch_conversation_event(db, conv, msg, org_id, resolver)
     except Exception:  # noqa: BLE001 — best-effort, 회신 실패가 해소를 막지 않음.
         logger.warning(
-            "approval-result 회신 배달 실패 doc=%s requester=%s",
-            doc.id, requester_id, exc_info=True,
+            "approval-result 회신 배달 실패 work_item=%s requester=%s",
+            work_item_id, requester_id, exc_info=True,
         )
         # ⛔카디르 QA(#3015): 여기 `return`이 있으면 DM 실패가 아래 벨 알림까지 같이
         # 죽인다 — "별개 SAVEPOINT·독립"이라는 이 함수의 약속과 정반대(단방향 의존).
@@ -264,19 +272,19 @@ async def dispatch_approval_result_reply(
             async with db.begin_nested():
                 from app.services.notification_dispatch import dispatch_notification
                 await dispatch_notification(
-                    db, org_id=org_id, event_type="doc_approval_resolved",
+                    db, org_id=org_id, event_type=event_type,
                     target_member_ids=[requester_id],
-                    title=f"문서 결재 결과: {decision_label}",
-                    body=resolution_note or f"'{doc.title}' 문서가 {decision_label}됐습니다.",
+                    title=f"결재 결과: {decision_label}",
+                    body=resolution_note or f"'{title}'가 {decision_label}됐습니다.",
                     reference_type="gate", reference_id=gate_id,
-                    source_project_id=doc.project_id,
+                    source_project_id=project_id,
                     # story #2696: outbox 이관(동일 결함 클래스 예방).
                     via_outbox=True,
                 )
     except Exception:  # noqa: BLE001 — 벨 알림 실패는 카드 배달과 독립.
         logger.warning(
-            "approval-result 벨 알림 실패 doc=%s requester=%s",
-            doc.id, requester_id, exc_info=True,
+            "approval-result 벨 알림 실패 work_item=%s requester=%s",
+            work_item_id, requester_id, exc_info=True,
         )
 
 

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -67,7 +67,14 @@ RiskGrade = Literal["low", "high"]
 # 있었는데 그 사실을 아무 코드도 "doc_approval=high"라고 선언하지 않고 있었다. low로
 # 등재하지 않는다(신중 결재 취지 훼손, PO 명시 판단) — high로 명시.
 _HIGH_RISK_GATE_TYPES: frozenset[str] = frozenset({"merge", "deploy", "workflow_config_publish", DOC_GATE_TYPE})
-_LOW_RISK_GATE_TYPES: frozenset[str] = frozenset({"pr_review", "qa"})
+#
+# story #2709(2026-08-17, PO 판정) — agent_decision_request를 명시 low 등재. 미등재=폴백(§2.3
+# 보수적 high)에 기대는 게 안전한 기본값이 아니라는 것을 story #6c89e40d(doc_approval 미등재
+# 실사고)가 오늘 이미 증명했다. 이 게이트는 되돌릴 수 없는 액션을 그 자신이 트리거하지
+# 않는다(에이전트가 이미 자기 가정대로 진행 중인 결정의 사후/병행 확인일 뿐 — 진짜 위험한
+# 액션은 merge/deploy/doc_approval 같은 그 자신의 게이트가 따로 막는다) — 신중 결재(서명
+# 의식)를 강제하면 "빠른 비동기 확인"이라는 이 기능의 존재 이유와 정면 충돌한다.
+_LOW_RISK_GATE_TYPES: frozenset[str] = frozenset({"pr_review", "qa", "agent_decision_request"})
 
 
 def derive_risk_grade(posture: str | None, gate_type: str) -> RiskGrade:
@@ -202,7 +209,14 @@ _DISPOSITION_TO_STATUS: dict[str, str] = {
 PROJECT_SCOPED_WORK_ITEM_TYPES: frozenset[str] = frozenset(
     {"story", "task", "doc", "visual_artifact", "loop", "hypothesis", "epic", "sprint"}
 )
-KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES: frozenset[str] = frozenset({"wf_line_version"})
+KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES: frozenset[str] = frozenset({
+    "wf_line_version",
+    # story #2709(2026-08-17) — self-referencing standalone anchor(work_item_id==gate.id, work
+    # item 없는 순수 질문). resolve_work_item_project_id()가 이 타입에 대응하는 실 테이블이
+    # 없어 항상 None을 준다 — 여기 미등재였다면 gates.py의 fail-closed 분기(#2237)가 모든
+    # GET /gates/{id}를 404로 거부했을 것(전수 grep으로 발견, 실제 배선 전 확認).
+    "agent_decision",
+})
 
 
 def is_project_scoped_work_item_type(work_item_type: str) -> bool:
@@ -297,8 +311,11 @@ async def resolve_work_item_project_id(
 # 미등록(doc_approval과 동일 선례. org gate override 설정 대상에서 제외=애초에 자동화 불가 명시).
 # 'artifact_canonicalize'(E-CANVAS C4-S8): 정본화=계약(§1) — org auto posture 무관 항상 HITL.
 _ALWAYS_MANUAL_GATE_TYPES: frozenset[str] = frozenset(
-    {"doc_approval", "loop_decision", "artifact_canonicalize"}
+    {"doc_approval", "loop_decision", "artifact_canonicalize", "agent_decision_request"}
 )
+# ⚠️story #2709 — agent_decision_request가 항상 manual(=posture 무관 항상 pending)인 이유:
+# 이 게이트는 "사람의 판단"이 존재 이유인데, org posture가 permissive라고 자동 allow_auto가
+# 걸리면 질문 자체가 응답 없이 자동 승인돼 버린다 — 애초에 물을 이유가 없어진다.
 
 
 async def _reopen_rejected_gate(
@@ -410,8 +427,15 @@ async def create_gate(
     neutral_facts: dict[str, Any] | None = None,
     project_id: uuid.UUID | None = None,
     notify: bool = True,
+    gate_id: uuid.UUID | None = None,
 ) -> Gate:
     """config 기반 게이트 생성 (멱등: 이미 있으면 기존 반환).
+
+    gate_id: story #2709(2026-08-17, PO 판정) — self-referencing standalone anchor(work_item이
+    없는 순수 질문류 gate_type)를 위한 파라미터. 호출측(MCP 도구)이 uuid4를 미리 만들어
+    이 인자와 work_item_id 둘에 **같은 값**을 넣으면, 별도 UPDATE 없이 1 INSERT로 gate.id==
+    gate.work_item_id가 성립(생성 後 2단계 갱신 금지, 원자성). 미지정 시(기존 18곳 전부)
+    기존 그대로 내부에서 uuid.uuid4() 생성 — 무회귀.
 
     project_id: story #1953(P1a-S3)이 처음 배선·story #1968(P1a-S3 잔여)이 완성 — gate.pending_
     approval 알림 payload의 project_id 보강용(선택적). create_gate()는 gate_type/work_item_type을
@@ -460,7 +484,7 @@ async def create_gate(
         status = "pending"
 
     gate = Gate(
-        id=uuid.uuid4(),
+        id=gate_id or uuid.uuid4(),
         org_id=org_id,
         work_item_id=work_item_id,
         work_item_type=work_item_type,
@@ -1050,14 +1074,18 @@ async def _notify_doc_gate_requester(session: AsyncSession, gate: Gate, new_stat
     만들었고 해소→상신자 회신 후방 경로가 없어, 상신자가 게이트를 폴링해야만 결과를
     알 수 있었다(선생님 직접 지적, 실사례 2026-08-13 07:20 반려·상신자 무통지).
 
+    story #2709(2026-08-17) — agent_decision_request도 이 함수를 탄다(함수명은 이력 보존을
+    위해 유지·내부만 gate_type 분기, 새 함수 발명 0). doc은 Doc row에서 title/project_id를
+    읽지만, agent_decision_request는 work_item이 곧 gate 자기참조(standalone anchor)라 Doc
+    row가 없다 — title=neutral_facts["question"], project_id=neutral_facts["project_id"](발행
+    시점에 넣어 둠, Gate 모델 자체엔 project_id 컬럼이 없어 이 필드에만 존재).
+
     best-effort — 이 함수의 실패가 게이트 해소 자체를 막지 않는다(호출부 transition_gate
     가 이 함수를 await만 하고 별도 격리는 하지 않으므로, 예외를 여기서 전부 삼킨다 —
     approval_delivery.dispatch_approval_result_reply 자체도 내부에서 SAVEPOINT로 이미
     격리하지만, requester_id 파싱 등 그 앞 단계도 안전해야 한다)."""
     try:
         from app.services.doc import DOC_GATE_TYPE, DOC_GATE_WORK_ITEM_TYPE
-        if gate.work_item_type != DOC_GATE_WORK_ITEM_TYPE or gate.gate_type != DOC_GATE_TYPE:
-            return
         if new_status not in ("approved", "rejected") or gate.resolver_id is None:
             return
 
@@ -1067,19 +1095,34 @@ async def _notify_doc_gate_requester(session: AsyncSession, gate: Gate, new_stat
             return
         requester_id = uuid.UUID(str(requester_raw))
 
-        from app.models.doc import Doc
-        doc = (await session.execute(
-            select(Doc).where(Doc.id == gate.work_item_id, Doc.org_id == gate.org_id)
-        )).scalar_one_or_none()
-        if doc is None:
-            return
-
         from app.services.approval_delivery import dispatch_approval_result_reply
-        await dispatch_approval_result_reply(
-            session, org_id=gate.org_id, doc=doc, gate_id=gate.id,
-            requester_id=requester_id, resolver_id=gate.resolver_id,
-            decision=new_status, resolution_note=gate.resolution_note,
-        )
+
+        if gate.work_item_type == DOC_GATE_WORK_ITEM_TYPE and gate.gate_type == DOC_GATE_TYPE:
+            from app.models.doc import Doc
+            doc = (await session.execute(
+                select(Doc).where(Doc.id == gate.work_item_id, Doc.org_id == gate.org_id)
+            )).scalar_one_or_none()
+            if doc is None or not doc.project_id:
+                return
+            await dispatch_approval_result_reply(
+                session, org_id=gate.org_id, work_item_type="doc", work_item_id=doc.id,
+                project_id=doc.project_id, title=doc.title, gate_id=gate.id,
+                requester_id=requester_id, resolver_id=gate.resolver_id,
+                decision=new_status, resolution_note=gate.resolution_note,
+            )
+        elif gate.gate_type == "agent_decision_request":
+            project_id_raw = facts.get("project_id")
+            question = facts.get("question")
+            if not project_id_raw or not question:
+                return
+            await dispatch_approval_result_reply(
+                session, org_id=gate.org_id, work_item_type=gate.work_item_type,
+                work_item_id=gate.work_item_id, project_id=uuid.UUID(str(project_id_raw)),
+                title=str(question), gate_id=gate.id,
+                requester_id=requester_id, resolver_id=gate.resolver_id,
+                decision=new_status, resolution_note=gate.resolution_note,
+                event_type="agent_decision_resolved",
+            )
     except Exception:  # noqa: BLE001 — best-effort, 회신 실패가 게이트 해소를 막지 않는다.
         logger.warning(
             "approval-result 상신자 회신 실패 gate=%s", gate.id, exc_info=True,

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -1109,6 +1109,10 @@ async def _notify_doc_gate_requester(session: AsyncSession, gate: Gate, new_stat
                 project_id=doc.project_id, title=doc.title, gate_id=gate.id,
                 requester_id=requester_id, resolver_id=gate.resolver_id,
                 decision=new_status, resolution_note=gate.resolution_note,
+                # story #2709 — 딥링크 계약 정적 스캐너(deeplink_contract_lib)가 event_type을
+                # 파라미터 default가 아니라 매 호출부 명시 리터럴로만 정적 해석한다 — default
+                # 값에 기대면 UnresolvedDispatchCallError. 값 자체는 원래 default와 동일(무회귀).
+                event_type="doc_approval_resolved",
             )
         elif gate.gate_type == "agent_decision_request":
             project_id_raw = facts.get("project_id")

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -92,6 +92,11 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 동형(자기 작업에 self-proof 첨부 = 데이터 파괴 아닌 협업/증명 유틸) — 어떤 역할의 working
     # agent든 default_tool_groups 무관하게 done 첨부해야 하므로 always-allow.
     "sprintable_add_evidence",
+    # story #2709(AskUserQuestion 블로킹 대체): request_decision — 어떤 역할의 에이전트든
+    # 판단이 필요한 순간 도메인 무관하게 써야 하는 협업 도구(link_gate_to_task/add_evidence와
+    # 동일 논리 — 특정 work_item 도메인에 묶이지 않는 self-scope 발행 유틸). vendored 사본과
+    # 동기화 필수(sprintable_mcp/toolset.py).
+    "sprintable_request_decision",
     # story #2268(D단계, E-CONNECT — "판단 칸"): add_judgment/list_judgments — 판단/철회는
     # work_item_ids(다건 또는 0건 general)에 걸치는 cross-cutting 기록이라 add_evidence와
     # 동일 논리로 core 취급. vendored 사본과 동기화 필수(sprintable_mcp/toolset.py).
@@ -384,6 +389,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_link_gate_to_task", "sprintable_list_agent_cards",
     # evidence (E-VERIFY V0-S1)
     "sprintable_add_evidence",
+    # 비동기 결정 요청 (story #2709, AskUserQuestion 블로킹 대체)
+    "sprintable_request_decision",
     # 판단 칸 (story #2268, D단계)
     "sprintable_add_judgment", "sprintable_list_judgments",
     # 세션 시작 컨텍스트 (story #2268, C-10)

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -31,6 +31,7 @@ from .toolset import is_tool_allowed
 from .tools.a2a import (
     LinkGateToTaskInput, ListAgentCardsInput, link_gate_to_task, list_agent_cards,
 )
+from .tools.decisions import RequestDecisionInput, request_decision
 from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.judgments import AddJudgmentInput, ListJudgmentsInput, add_judgment, list_judgments
 from .tools.session_context import SessionContextInput, get_session_context
@@ -647,6 +648,13 @@ _TOOL_DEFS: list[tuple] = [
      " 위임할 때(예: PR 완료 후 QA 담당 조회) 이 도구로 먼저 발견한 뒤"
      " sprintable_send_chat_message로 청한다.",
      ListAgentCardsInput, list_agent_cards),
+    # 비동기 결정 요청 (1) — story #2709(AskUserQuestion 블로킹 대체)
+    ("sprintable_request_decision",
+     "[⛔AskUserQuestion 대신 이걸 쓸 것] 사람 판단이 필요할 때 블로킹으로 기다리지 말고 이"
+     " 도구로 결정을 발행한 뒤 assumption대로 즉시 계속 일한다. 결재함+해당 채팅에 카드로"
+     " 뜨고(원탭 승인 — 서명/근거열람 불요), 사람이 답하면 poll_events로 회신이 온다(approve="
+     " 가정 확인, reject=note에 실제 답 — 자유텍스트로 옴). options는 힌트일 뿐 강제 아님.",
+     RequestDecisionInput, request_decision),
     # Evidence 자기증명 (1) — E-VERIFY V0-S1
     ("sprintable_add_evidence",
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -650,7 +650,7 @@ _TOOL_DEFS: list[tuple] = [
      ListAgentCardsInput, list_agent_cards),
     # 비동기 결정 요청 (1) — story #2709(AskUserQuestion 블로킹 대체)
     ("sprintable_request_decision",
-     "[⛔AskUserQuestion 대신 이걸 쓸 것] 사람 판단이 필요할 때 블로킹으로 기다리지 말고 이"
+     "⛔AskUserQuestion 대신 이걸 쓸 것 — 사람 판단이 필요할 때 블로킹으로 기다리지 말고 이"
      " 도구로 결정을 발행한 뒤 assumption대로 즉시 계속 일한다. 결재함+해당 채팅에 카드로"
      " 뜨고(원탭 승인 — 서명/근거열람 불요), 사람이 답하면 poll_events로 회신이 온다(approve="
      " 가정 확인, reject=note에 실제 답 — 자유텍스트로 옴). options는 힌트일 뿐 강제 아님.",

--- a/backend/sprintable_mcp/tools/decisions.py
+++ b/backend/sprintable_mcp/tools/decisions.py
@@ -1,0 +1,39 @@
+"""비동기 결정 요청(story #2709) — AskUserQuestion류 블로킹 질문을 논블로킹 결재 사이클로
+승격. 새 게이트 메커니즘 발명 0(Gate/approval-request-card/approvals-queue 전부 재사용) —
+`POST /api/v2/gates/decisions`가 self-referencing standalone anchor를 원자 생성하는 것만
+신규. 답변은 기존 `poll_events`가 실어나른다(별도 왕복 배관 불요, gate_service.py의
+`_notify_doc_gate_requester` 일반화가 이미 `_dispatch_conversation_event`→Event INSERT를
+탄다)."""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput
+
+
+class RequestDecisionInput(SprintableInput):
+    question: str
+    assumption: str  # 필수 — 답을 못 받아도 이 가정으로 계속 진행한다는 선언.
+    options: list[str] | None = None  # 힌트로만 렌더(강제 아님) — 사람은 자유텍스트로도 답함.
+    related_work_item_type: str | None = None
+    related_work_item_id: str | None = None
+
+
+async def request_decision(args: RequestDecisionInput) -> list[TextContent]:
+    """사람 판단이 필요한 순간, AskUserQuestion처럼 블로킹 대기하지 말고 이 도구로 결정을
+    발행한 뒤 즉시 `assumption`대로 계속 일한다 — 결재함+해당 채팅에 카드로 뜨고(approve=
+    가정 확인, reject=note에 실제 답), 답이 오면 poll_events로 왕복한다. 즉답을 강제하지
+    않는다(원탭 승인 — 서명/근거열람 불요, 빠른 확인이 이 도구의 존재 이유)."""
+    try:
+        body: dict = {"question": args.question, "assumption": args.assumption}
+        if args.options:
+            body["options"] = args.options
+        if args.related_work_item_type and args.related_work_item_id:
+            body["related_work_item_type"] = args.related_work_item_type
+            body["related_work_item_id"] = args.related_work_item_id
+        result = await client.post("/api/v2/gates/decisions", json=body)
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -78,6 +78,10 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 유틸이라 단일 도메인 그룹에 못 묶음. link_gate_to_task와 동일 논리로 core 취급(백엔드
     # SSOT와 동기화, app/services/mcp_toolset.py 참고).
     "sprintable_add_evidence",
+    # story #2709(AskUserQuestion 블로킹 대체): request_decision — 어떤 역할의 에이전트든
+    # 판단이 필요한 순간 도메인 무관하게 써야 하는 협업 도구(link_gate_to_task/add_evidence와
+    # 동일 논리). 백엔드 SSOT와 동기화 필수(app/services/mcp_toolset.py).
+    "sprintable_request_decision",
     # story #2268(D단계, E-CONNECT — "판단 칸"): add_judgment/list_judgments — 판단/철회는
     # work_item_ids(다건 또는 0건 general)에 걸치는 cross-cutting 기록이라 add_evidence와
     # 동일 논리로 core 취급(백엔드 SSOT와 동기화, app/services/mcp_toolset.py 참고).

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -94,6 +94,8 @@ EXPECTED_TOOLS = {
     "sprintable_link_gate_to_task",
     # a2a 발견 (1) — E-AGENT-ONBOARD·A2A발견 P0-1(story #2597)
     "sprintable_list_agent_cards",
+    # 비동기 결정 요청 (1) — story #2709(AskUserQuestion 블로킹 대체)
+    "sprintable_request_decision",
     # evidence (1) — E-VERIFY V0-S1
     "sprintable_add_evidence",
     # 판단 칸 (2) — story #2268(D단계, E-CONNECT)
@@ -135,7 +137,8 @@ def test_total_tool_count():
     # event_definition/sprintable_update_event_definition 2종 신설(org 커스텀 등록/수정) —
     # 119→121. story #2668(B3): sprintable_submit_for_approval 1종 신설(문서 결재 상신
     # REST를 MCP로 노출 — 도구 목록에 없어 에이전트가 발견 못 하던 것) — 121→122.
-    assert len(_TOOLS) == 122
+    # story #2709: sprintable_request_decision 1종 신설(AskUserQuestion 블로킹 대체) — 122→123.
+    assert len(_TOOLS) == 123
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_1972_gate_risk_grade.py
+++ b/backend/tests/test_1972_gate_risk_grade.py
@@ -8,7 +8,7 @@ SSOT: doc `gate-risk-ux-classification-criteria` §2 판정표(1차 축=posture,
 단일 쿼리만 수행한다(doc §4 "경계 명확화").
 
 테스트 구성:
-- derive_risk_grade 순수 함수 매트릭스(posture 4종 × gate_type 6종 = 24 조합, doc §2 표 그대로
+- derive_risk_grade 순수 함수 매트릭스(posture 4종 × gate_type 7종 = 28 조합, doc §2 표 그대로
   literal 명시 — 구현 로직을 그대로 미러링하지 않고 스펙을 직접 기술).
 - get_org_posture 쿼리 형태(단일 쿼리·OrgGatePolicy만 대상) + resolve_disposition 비호출 구조 확인.
 - list_gates/get_gate_endpoint 라우트(mocked session) risk_grade enrich 배선.
@@ -47,9 +47,9 @@ def _scalar_result(value):
 # ── derive_risk_grade 순수 함수 매트릭스(doc §2 표 그대로) ──────────────────────
 
 # doc §2.1(1차 축=posture)·§2.2(2차 축=gate_type, posture 미확定일 때만)·§2.3(폴백=보수적 고위험)을
-# 표 그대로 옮긴 literal 매트릭스. gate_type 6종(pr_review/qa/merge/deploy/workflow_config_publish/
+# 표 그대로 옮긴 literal 매트릭스. gate_type 7종(pr_review/qa/merge/deploy/workflow_config_publish/
 # doc_approval) + 진짜 미분류 gate_type 대리값("_未來_unclassified_gate_type")으로 폴백 케이스까지
-# 커버 = posture 4종(conservative/permissive/balanced/None) × gate_type 7종 = 28 조합.
+# 커버 = posture 4종(conservative/permissive/balanced/None) × gate_type 8종 = 32 조합.
 #
 # ⛔story #6c89e40d(페드루 PO 판정 2026-08-17, ⓐ'): doc_approval은 원래 이 매트릭스에서 "폴백
 # 대리값" 역할이었다(과거 어느 세트에도 없어 미분류 폴백과 값이 우연히 같았을 뿐) — 이제
@@ -69,6 +69,7 @@ _RISK_GRADE_MATRIX: list[tuple[str | None, str, str]] = [
     ("conservative", "deploy", "high"),
     ("conservative", "workflow_config_publish", "high"),
     ("conservative", "doc_approval", "high"),
+    ("conservative", "agent_decision_request", "high"),  # story #2709
     ("conservative", _UNCLASSIFIED_GATE_TYPE, "high"),
     # posture=permissive → 항상 low(gate_type 무관, §2.1)
     ("permissive", "pr_review", "low"),
@@ -77,6 +78,7 @@ _RISK_GRADE_MATRIX: list[tuple[str | None, str, str]] = [
     ("permissive", "deploy", "low"),
     ("permissive", "workflow_config_publish", "low"),
     ("permissive", "doc_approval", "low"),
+    ("permissive", "agent_decision_request", "low"),  # story #2709
     ("permissive", _UNCLASSIFIED_GATE_TYPE, "low"),
     # posture=balanced → 2차 축(gate_type, §2.2) + 폴백(§2.3)
     ("balanced", "pr_review", "low"),
@@ -85,6 +87,11 @@ _RISK_GRADE_MATRIX: list[tuple[str | None, str, str]] = [
     ("balanced", "deploy", "high"),
     ("balanced", "workflow_config_publish", "high"),
     ("balanced", "doc_approval", "high"),  # 2차 축 명시 등재(더 이상 폴백 아님, ⓐ')
+    # story #2709 — agent_decision_request는 _LOW_RISK_GATE_TYPES에 명시 등재(gate_service.py) —
+    # doc_approval과 반대로 low(2차 축에서 직접, 폴백 아님). 근거: 이 gate는 되돌릴 수 없는
+    # 액션을 그 자신이 트리거하지 않는다(에이전트가 이미 자기 가정대로 진행 중인 결정의
+    # 사후확인일 뿐) — 서명 마찰이 "빠른 비동기 확인"이라는 존재 이유와 충돌한다.
+    ("balanced", "agent_decision_request", "low"),
     ("balanced", _UNCLASSIFIED_GATE_TYPE, "high"),  # 폴백: 진짜 미분류 gate_type → 보수적 고위험
     # posture=None(미설정 row 없음) → 2차 축(gate_type, §2.2) + 폴백(§2.3)
     (None, "pr_review", "low"),
@@ -93,6 +100,7 @@ _RISK_GRADE_MATRIX: list[tuple[str | None, str, str]] = [
     (None, "deploy", "high"),
     (None, "workflow_config_publish", "high"),
     (None, "doc_approval", "high"),  # 2차 축 명시 등재(더 이상 폴백 아님, ⓐ')
+    (None, "agent_decision_request", "low"),  # story #2709 — balanced와 동일(§2.2 2차 축)
     (None, _UNCLASSIFIED_GATE_TYPE, "high"),  # 폴백: 진짜 미분류 gate_type → 보수적 고위험
 ]
 
@@ -115,12 +123,12 @@ def test_doc_approval_is_explicitly_high_risk_not_fallback():
 
 
 def test_derive_risk_grade_matrix_covers_all_gate_types():
-    """GATE_TYPES(5종) 전부가 매트릭스에 등장하는지 자기표면화(신규 gate_type 확장 시 매트릭스
+    """GATE_TYPES(6종) 전부가 매트릭스에 등장하는지 자기표면화(신규 gate_type 확장 시 매트릭스
     drift 방지 — feedback_one_directional_check_vacuous_pass 교훈: EXPECTED-actual 방향도 확인)."""
     from app.models.hitl_config import GATE_TYPES
 
     covered = {gt for _, gt, _ in _RISK_GRADE_MATRIX}
-    assert GATE_TYPES <= covered  # 5종 전부 매트릭스에 있어야 함
+    assert GATE_TYPES <= covered  # 6종 전부 매트릭스에 있어야 함
     assert "doc_approval" in covered  # 이제 명시 등재 케이스로 커버
     assert _UNCLASSIFIED_GATE_TYPE in covered  # 폴백(진짜 미분류) 경로도 별도로 커버
 

--- a/backend/tests/test_2237_work_item_type_classification_exhaustive.py
+++ b/backend/tests/test_2237_work_item_type_classification_exhaustive.py
@@ -22,6 +22,8 @@ import pytest
 #   app/services/merge_verdict_gate.py         "story"
 #   app/services/loop.py                       "loop"
 #   app/services/workflow_line_config.py       "wf_line_version"  (WORKFLOW_LINE_VERSION_WORK_ITEM_TYPE)
+#   app/routers/gates.py create_decision_request "agent_decision"  (story #2709, self-referencing
+#                                               standalone anchor — work_item_id==gate.id)
 #   app/services/workflow_parallel_approval.py step_run.entity_type — 정의역(app/models/workflow_line.py
 #                                               ENTITY_TYPES) = {story, doc, hypothesis, epic, sprint}
 #   app/routers/gates.py 제네릭 create_gate_endpoint — task 포함(resolve_work_item_project_id가
@@ -32,7 +34,7 @@ import pytest
 _KNOWN_PROJECT_SCOPED = frozenset(
     {"story", "task", "doc", "visual_artifact", "loop", "hypothesis", "epic", "sprint"}
 )
-_KNOWN_PROJECT_AGNOSTIC = frozenset({"wf_line_version"})
+_KNOWN_PROJECT_AGNOSTIC = frozenset({"wf_line_version", "agent_decision"})
 
 
 def test_project_scoped_set_matches_hand_audited_inventory():

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -69,15 +69,16 @@ async def test_registered_standup_history_tool_still_accepts_known_args():
 
 
 def test_all_registered_tools_share_the_same_lockdown():
-    """AC2 카운트 — `_TOOL_DEFS` 121개 + ping 1개 = 122개(story #2634: sprintable_publish_event/
+    """AC2 카운트 — `_TOOL_DEFS` 122개 + ping 1개 = 123개(story #2634: sprintable_publish_event/
     sprintable_list_event_definitions 추가로 117→119. story #2636: sprintable_register_
     event_definition/sprintable_update_event_definition 추가로 119→121. story #2668:
-    sprintable_submit_for_approval 추가로 121→122) 전부 arg_model이
+    sprintable_submit_for_approval 추가로 121→122. story #2709: sprintable_request_decision
+    추가로 122→123) 전부 arg_model이
     extra=forbid로 잠겨 있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
     from sprintable_mcp import server as srv
 
     tools = srv.mcp._tool_manager.list_tools()
-    assert len(tools) == 122
+    assert len(tools) == 123
     unlocked = [
         t.name for t in tools
         if t.fn_metadata.arg_model.model_config.get("extra") != "forbid"

--- a/backend/tests/test_2624_approval_result_reply.py
+++ b/backend/tests/test_2624_approval_result_reply.py
@@ -98,7 +98,7 @@ async def test_human_requester_gets_dm_and_bell():
             nd_mod.dispatch_notification = dn
             try:
                 await dispatch_approval_result_reply(
-                    s, org_id=org_id, doc=doc, gate_id=gate_id,
+                    s, org_id=org_id, work_item_type="doc", work_item_id=doc.id, project_id=project_id, title=doc.title, gate_id=gate_id,
                     requester_id=requester_id, resolver_id=resolver_id,
                     decision="rejected", resolution_note="사유: 재작성 필요",
                 )
@@ -157,7 +157,7 @@ async def test_agent_requester_gets_dm_but_no_bell():
             nd_mod.dispatch_notification = dn
             try:
                 await dispatch_approval_result_reply(
-                    s, org_id=org_id, doc=doc, gate_id=gate_id,
+                    s, org_id=org_id, work_item_type="doc", work_item_id=doc.id, project_id=project_id, title=doc.title, gate_id=gate_id,
                     requester_id=requester_id, resolver_id=resolver_id,
                     decision="approved", resolution_note=None,
                 )
@@ -195,7 +195,7 @@ async def test_self_resolve_skips_notification():
             doc = await _seed_doc(s, org_id, project_id)
 
             await dispatch_approval_result_reply(
-                s, org_id=org_id, doc=doc, gate_id=uuid.uuid4(),
+                s, org_id=org_id, work_item_type="doc", work_item_id=doc.id, project_id=project_id, title=doc.title, gate_id=uuid.uuid4(),
                 requester_id=same_id, resolver_id=same_id,
                 decision="approved", resolution_note=None,
             )
@@ -227,13 +227,13 @@ async def test_second_resolution_reuses_existing_dm():
             doc2 = await _seed_doc(s, org_id, project_id, title="문서2")
 
             await dispatch_approval_result_reply(
-                s, org_id=org_id, doc=doc1, gate_id=uuid.uuid4(),
+                s, org_id=org_id, work_item_type="doc", work_item_id=doc1.id, project_id=project_id, title=doc1.title, gate_id=uuid.uuid4(),
                 requester_id=requester_id, resolver_id=resolver_id,
                 decision="approved", resolution_note=None,
             )
             await s.commit()
             await dispatch_approval_result_reply(
-                s, org_id=org_id, doc=doc2, gate_id=uuid.uuid4(),
+                s, org_id=org_id, work_item_type="doc", work_item_id=doc2.id, project_id=project_id, title=doc2.title, gate_id=uuid.uuid4(),
                 requester_id=requester_id, resolver_id=resolver_id,
                 decision="rejected", resolution_note="두번째",
             )
@@ -277,7 +277,7 @@ async def test_dm_delivery_failure_does_not_block_bell_notification():
                     new=AsyncMock(side_effect=RuntimeError("DM dispatch boom")),
                 ):
                     await dispatch_approval_result_reply(
-                        s, org_id=org_id, doc=doc, gate_id=gate_id,
+                        s, org_id=org_id, work_item_type="doc", work_item_id=doc.id, project_id=project_id, title=doc.title, gate_id=gate_id,
                         requester_id=requester_id, resolver_id=resolver_id,
                         decision="rejected", resolution_note="사유",
                     )

--- a/backend/tests/test_2624_gate_requester_reply_gating.py
+++ b/backend/tests/test_2624_gate_requester_reply_gating.py
@@ -89,7 +89,7 @@ async def test_doc_not_found_is_noop_no_delivery_call():
 @pytest.mark.anyio
 async def test_valid_gate_calls_delivery_with_correct_args():
     session = AsyncMock()
-    fake_doc = SimpleNamespace(id=uuid.uuid4(), title="T")
+    fake_doc = SimpleNamespace(id=uuid.uuid4(), title="T", project_id=uuid.uuid4())
     result = AsyncMock()
     result.scalar_one_or_none = lambda: fake_doc
     session.execute = AsyncMock(return_value=result)
@@ -103,7 +103,10 @@ async def test_valid_gate_calls_delivery_with_correct_args():
     mock_dispatch.assert_awaited_once()
     kw = mock_dispatch.await_args.kwargs
     assert kw["org_id"] == gate.org_id
-    assert kw["doc"] is fake_doc
+    assert kw["work_item_type"] == "doc"
+    assert kw["work_item_id"] == fake_doc.id
+    assert kw["project_id"] == fake_doc.project_id
+    assert kw["title"] == fake_doc.title
     assert kw["gate_id"] == gate.id
     assert kw["requester_id"] == requester_id
     assert kw["resolver_id"] == gate.resolver_id
@@ -115,7 +118,7 @@ async def test_valid_gate_calls_delivery_with_correct_args():
 async def test_delivery_exception_swallowed_best_effort():
     """dispatch_approval_result_reply가 터져도 게이트 해소 자체(호출부)로 예외가 새지 않는다."""
     session = AsyncMock()
-    fake_doc = SimpleNamespace(id=uuid.uuid4(), title="T")
+    fake_doc = SimpleNamespace(id=uuid.uuid4(), title="T", project_id=uuid.uuid4())
     result = AsyncMock()
     result.scalar_one_or_none = lambda: fake_doc
     session.execute = AsyncMock(return_value=result)

--- a/backend/tests/test_2628_approval_dm_participant_set_lookup.py
+++ b/backend/tests/test_2628_approval_dm_participant_set_lookup.py
@@ -285,7 +285,7 @@ async def test_fix_applies_bidirectionally_request_and_result_reply():
             )
             await s.commit()
             await dispatch_approval_result_reply(
-                s, org_id=org_id, doc=doc, gate_id=gate_id,
+                s, org_id=org_id, work_item_type="doc", work_item_id=doc.id, project_id=project_id, title=doc.title, gate_id=gate_id,
                 requester_id=requester_id, resolver_id=approver_id,
                 decision="approved", resolution_note=None,
             )

--- a/backend/tests/test_2709_agent_decision_request.py
+++ b/backend/tests/test_2709_agent_decision_request.py
@@ -1,0 +1,285 @@
+"""story #2709 — 에이전트의 블로킹 질문을 비동기 결정 요청으로 승격.
+
+self-referencing standalone anchor(work_item_id==gate.id, work_item_type=
+"agent_decision")가 create_gate()의 멱등 조회(work_item_id+
+work_item_type+gate_type)와 충돌 없이 항상 유일한 새 gate를 만드는지(PO 조건ⓑ) +
+KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES 미등재 시 재발했을 fail-closed 404(전수 grep으로
+발견한 그 자리)가 지금은 안 걸리는지를 real PG로 검증한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2709", slug=f"org2709-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+@pytest.mark.anyio
+async def test_self_referencing_anchor_gate_id_equals_work_item_id():
+    """gate.id == gate.work_item_id — 1 INSERT 원자 생성(생성 後 UPDATE 2단계 아님)."""
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            caller_id = uuid.uuid4()
+            gate_id = uuid.uuid4()
+
+            gate = await create_gate(
+                session=s, org_id=org_id, work_item_id=gate_id,
+                work_item_type="agent_decision",
+                gate_type="agent_decision_request",
+                member_id=caller_id, role_id=gate_id,
+                neutral_facts={"question": "A or B?", "assumption": "A", "requested_by_member_id": str(caller_id), "project_id": str(project_id)},
+                project_id=project_id, gate_id=gate_id, notify=False,
+            )
+            await s.commit()
+
+            assert gate.id == gate_id
+            assert gate.work_item_id == gate_id
+            assert gate.status == "pending", "agent_decision_request는 _ALWAYS_MANUAL — posture 무관 항상 pending"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_two_distinct_decision_requests_never_collide():
+    """PO 조건ⓑ — 서로 다른 uuid4로 만든 두 standalone anchor는 create_gate()의 멱등 조회에
+    걸리지 않고 각각 독립된 gate로 생성된다(항상 유일, «사실상 no-op 없음» 실증)."""
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            caller_id = uuid.uuid4()
+
+            gate_id_1 = uuid.uuid4()
+            gate1 = await create_gate(
+                session=s, org_id=org_id, work_item_id=gate_id_1,
+                work_item_type="agent_decision",
+                gate_type="agent_decision_request",
+                member_id=caller_id, role_id=gate_id_1,
+                neutral_facts={"question": "Q1", "assumption": "A1"},
+                project_id=project_id, gate_id=gate_id_1, notify=False,
+            )
+            await s.commit()
+
+            gate_id_2 = uuid.uuid4()
+            gate2 = await create_gate(
+                session=s, org_id=org_id, work_item_id=gate_id_2,
+                work_item_type="agent_decision",
+                gate_type="agent_decision_request",
+                member_id=caller_id, role_id=gate_id_2,
+                neutral_facts={"question": "Q2", "assumption": "A2"},
+                project_id=project_id, gate_id=gate_id_2, notify=False,
+            )
+            await s.commit()
+
+            assert gate1.id != gate2.id
+            assert gate1.neutral_facts["question"] == "Q1"
+            assert gate2.neutral_facts["question"] == "Q2"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_repeated_gate_id_is_idempotent_no_op():
+    """호출측이 실수로(또는 재시도로) 같은 gate_id를 두 번 넘기면 — create_gate() 자체의
+    기존 멱등 로직(work_item_id+work_item_type+gate_type 조합)이 그대로 적용돼 새 행을
+    또 안 만들고 기존 gate를 반환한다(회귀 없음, PO가 스코프 밖으로 明示한 "발행측 재발행
+    판단"과는 별개 축 — 이건 순수 create_gate() 계약)."""
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            caller_id = uuid.uuid4()
+            gate_id = uuid.uuid4()
+
+            gate_a = await create_gate(
+                session=s, org_id=org_id, work_item_id=gate_id,
+                work_item_type="agent_decision",
+                gate_type="agent_decision_request",
+                member_id=caller_id, role_id=gate_id,
+                neutral_facts={"question": "Q", "assumption": "A"},
+                project_id=project_id, gate_id=gate_id, notify=False,
+            )
+            await s.commit()
+
+            gate_b = await create_gate(
+                session=s, org_id=org_id, work_item_id=gate_id,
+                work_item_type="agent_decision",
+                gate_type="agent_decision_request",
+                member_id=caller_id, role_id=gate_id,
+                neutral_facts={"question": "Q(다시 시도)", "assumption": "A"},
+                project_id=project_id, gate_id=gate_id, notify=False,
+            )
+            await s.commit()
+
+            assert gate_a.id == gate_b.id
+            # 기존 gate 그대로 반환 — 두번째 호출의 neutral_facts로 덮어쓰지 않는다(멱등=no-op).
+            assert gate_b.neutral_facts["question"] == "Q"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_known_project_agnostic_registration_prevents_404():
+    """전수 grep으로 발견한 그 블로커의 회귀가드 — agent_decision이
+    KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES에 없으면 GET /gates/{id}의 fail-closed 분기(#2237)가
+    모든 조회를 404로 거부했을 것이다."""
+    from app.services.gate_service import (
+        KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES,
+        is_known_project_agnostic_work_item_type,
+    )
+
+    assert "agent_decision" in KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES
+    assert is_known_project_agnostic_work_item_type("agent_decision") is True
+
+
+async def _setup_app_jwt(app, Session, org_id, project_id, caller_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(caller_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.anyio
+async def test_http_endpoint_creates_pending_low_risk_decision_gate():
+    """`POST /api/v2/gates/decisions`(신규 엔드포인트) 실 HTTP 왕복 — 응답이 self-referencing
+    anchor(id==work_item_id)·status=pending(항상 manual)·risk_grade=low(원탭 승인, 서명
+    플로우 면제)임을 확認한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+        caller_id = uuid.uuid4()
+        await _setup_app_jwt(app, Session, org_id, project_id, caller_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/gates/decisions",
+                json={"question": "approach A or B?", "assumption": "A", "options": ["A", "B"]},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["id"] == body["work_item_id"]
+            assert body["status"] == "pending"
+            assert body["gate_type"] == "agent_decision_request"
+            assert body["work_item_type"] == "agent_decision"
+            assert body["risk_grade"] == "low", "PO 조건① — 서명플로우 면제(원탭 승인)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_http_endpoint_missing_org_or_project_403():
+    """음성대조 — org_id/project_id를 못 얻으면(예: X-Project-Id 없는 API키 컨텍스트에서
+    project 미해소) 403(get_scope_context 경유, 조용히 통과 안 함)."""
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.main import app
+    from tests.conftest import override_db_and_read
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id = await _seed_org_project(s)
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        async def _auth():
+            return AuthContext(
+                user_id=str(uuid.uuid4()), email=None,
+                claims={"app_metadata": {"org_id": str(org_id)}},  # project_id 없음
+            )
+
+        override_db_and_read(app, _db)
+        app.dependency_overrides[get_current_user] = _auth
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/gates/decisions",
+                json={"question": "Q", "assumption": "A"},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_deeplink_manifest_contract.py
+++ b/backend/tests/test_deeplink_manifest_contract.py
@@ -88,14 +88,15 @@ def test_conversation_mention_lands_in_chat_tab():
     assert entry.app.parent_tab == ParentTab.chat
 
 
-def test_manifest_covers_all_28_dispatch_notification_event_types():
+def test_manifest_covers_all_29_dispatch_notification_event_types():
     """AC1 회귀 고정: story #1951 GATE1 전수 조사에서 확인한 dispatch_notification()
     event_type 리터럴이 전부 등재돼 있어야 한다. 새 알림 타입이 코드에 추가되고
     이 집합이 갱신 안 되면 이 테스트가 알려준다(양방향 대조 — 매니페스트 초과분도 잡음).
     story #2617: conversation.unsupervised_chain_expired 신설로 24→25.
     story #2624: doc_approval_resolved 신설로 25→26.
     story #2630: conversation.circuit_breaker_opened 신설로 26→27.
-    story #2631: doc_approval_discussion_requested 신설로 27→28."""
+    story #2631: doc_approval_discussion_requested 신설로 27→28.
+    story #2709: agent_decision_resolved 신설로 28→29."""
     expected = {
         "sprint_closed", "task_completed", "story_assigned", "comment.created",
         "artifact.created", "artifact.exported", "artifact.updated", "artifact.canonicalized",
@@ -105,6 +106,7 @@ def test_manifest_covers_all_28_dispatch_notification_event_types():
         "doc_approval_requested", "handoff_fallback", "story_status_changed",
         "conversation.unsupervised_chain_expired", "doc_approval_resolved",
         "conversation.circuit_breaker_opened", "doc_approval_discussion_requested",
+        "agent_decision_resolved",
     }
     actual = {e.app.type for e in DEEPLINK_MANIFEST.entries}
     missing = expected - actual

--- a/backend/tests/test_deeplink_manifest_endpoint.py
+++ b/backend/tests/test_deeplink_manifest_endpoint.py
@@ -49,7 +49,8 @@ async def test_deeplink_manifest_endpoint_returns_200_with_schema_version_and_lo
     # story #2624: doc_approval_resolved 신설로 34→35.
     # story #2630: conversation.circuit_breaker_opened 신설로 35→36.
     # story #2631: doc_approval_discussion_requested 신설로 36→37.
-    assert isinstance(body["entries"], list) and len(body["entries"]) == 37
+    # story #2709: agent_decision_resolved 신설로 37→38.
+    assert isinstance(body["entries"], list) and len(body["entries"]) == 38
 
     # 미르코 point ②: lookup_key = f"{type}:{entity_type}" (구분자 ":") 서빙 시점 파생.
     story_entry = next(

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -22,6 +22,8 @@ _CORE_NO_PREFIX = {
     "sprintable_lock_files", "sprintable_unlock_files", "sprintable_link_gate_to_task",
     "sprintable_add_evidence", "sprintable_list_projects", "sprintable_set_default_project",
     "sprintable_add_judgment", "sprintable_list_judgments",
+    # story #2709: request_decision — link_gate_to_task/add_evidence와 동일 근거로 core.
+    "sprintable_request_decision",
     "sprintable_get_session_context",
     # story #2597: list_agent_cards — mcp_toolset.py _ALWAYS_ALLOWED와 동기화(core 취급 사유는
     # 거기 주석 참조 — 어떤 role이든 필요한 cross-cutting 발견 유틸, 단일 축 아님).
@@ -76,6 +78,7 @@ def test_tool_names_and_param_models_untouched():
     sprintable_list_event_definitions 2종 신설(이벤트 레지스트리 발행/카탈로그) — 116→118.
     story #2636: sprintable_register_event_definition/sprintable_update_event_definition
     2종 신설(org 커스텀 이벤트 등록/수정) — 118→120. story #2668(B3): sprintable_submit_
-    for_approval 1종 신설(문서 결재 상신 MCP 발견 경로) — 120→121."""
-    assert len(_TOOL_DEFS) == 121
+    for_approval 1종 신설(문서 결재 상신 MCP 발견 경로) — 120→121. story #2709: sprintable_
+    request_decision 1종 신설(AskUserQuestion 블로킹 대체) — 121→122."""
+    assert len(_TOOL_DEFS) == 122
     assert all(name.startswith("sprintable_") for name in _TOOLS)


### PR DESCRIPTION
## 무엇을 왜
AskUserQuestion의 블로킹 대기를 논블로킹 결재 사이클로 치환한다 — 오늘(2026-08-17) 이 세션 자체에서 AskUserQuestion이 80분 세션 정지를 냈고(같은 날 2회), fleet 훅(story #2701 후속, exit 2 차단)은 우리 팀만 막는다 — 이건 고객 에이전트 팀도 겪는 문제라 제품으로 풀어야 한다(PO 판정).

스펙 doc: [비동기 결정 요청 스펙 — story #2709](entity:doc:cdb33718-d6a2-4646-8722-64dfdac1b13e)

## 새 개념 발명 0
`Gate`/`create_gate`/`transition_gate`/`approval-request-card.tsx`(#2118)/`GateSignatureApproval`의 reason 텍스트+보류 3버튼(#2631)/`approvals-queue.tsx`의 `formatAge` SLA 표시(#1973) 전부 그대로 재사용. 진짜 신규는 `POST /api/v2/gates/decisions`(서버가 호출자 신원+self-referencing anchor를 원자 생성 — MCP 클라이언트가 role_id 개념을 몰라도 되게) + MCP 도구 하나뿐.

## 이번 PR에서 한 일
- `gate_type="agent_decision_request"` **명시 low 등재**(서명플로우 면제, 원탭 승인) — 근거: 오늘 이 세션의 story #6c89e40d(doc_approval 미등재→우연히 폴백 high→note-422 실사고)가 정확한 반례. "미등재는 안전한 기본값이 아니다"를 직접 겪은 뒤라 이번엔 명시 등재. `_ALWAYS_MANUAL_GATE_TYPES`도 등재(org posture가 사람 질문을 자동승인하면 안 됨).
- self-referencing standalone anchor: `work_item_id == gate.id`, `work_item_type="agent_decision"`(원래 계획한 `agent_decision_request_standalone`은 실 DB 에러로 발견 — `work_item_type` 컬럼이 `varchar(20)`이라 안 들어감, 줄임). `KNOWN_PROJECT_AGNOSTIC_WORK_ITEM_TYPES`에 등재 — 전 `gate.work_item_type` 스위치 자리 전수 grep 먼저 하고서(PO 조건ⓐ) 이 한 곳만 미등재 시 `GET /gates/{id}`가 전수 404(#2237 fail-closed 분기)임을 발견.
- `dispatch_approval_result_reply()`를 doc 전용(`doc: Doc` 객체)에서 파라미터화로 일반화(새 함수 0). 자기 docstring이 이미 "Event INSERT"라고 명시한 그 경로를 그대로 타 — `poll_events`가 이미 이 회신을 실어나른다(새 배관 0).
- 신규 엔드포인트가 `GateResponse.risk_grade`를 채움 — 이 엔드포인트가 모델로 삼은 제네릭 `create_gate_endpoint`가 애초에 이 필드를 안 채우는 기존 갭이 있었는데(`get_gate_endpoint`만 채움), 제 신규 테스트가 직접 발견(안 채우면 FE가 null→'unknown'으로 읽어 low 등재의 목적=원탭 승인이 생성 응답 자체에서 무효화됨).

## 검증
- 신규 6테스트(real PG): self-referencing anchor 메커닉스·서로 다른 두 요청 충돌 없음·같은 gate_id 재호출 멱등(create_gate 기존 로직, 새 로직 아님)·KNOWN_PROJECT_AGNOSTIC 등재 자체·신규 엔드포인트 HTTP 왕복(pending+low risk_grade)+403 음성대조.
- 뮤테이션킬: low 등재 제거→정확히 그 테스트만 RED(high로 떨어짐 확認)·KNOWN_PROJECT_AGNOSTIC 등재 제거→정확히 그 테스트만 RED. 둘 다 원복 GREEN.
- 기존 3개 테스트 파일이 `dispatch_approval_result_reply(doc=...)` 구시그니처 직접호출이라 갱신 필요 — 새 시그니처로 전환, 21/21 통과.
- 회귀: gate/hitl/approval/apikey 관련 500 passed, 0 failed.

## 이 PR에서 안 한 것(명시)
- `askuserquestion-relay.py`(`~/.claude/hooks/`, 이 레포 밖) 안내문구 갱신 — 지금 갱신하면 아직 프로덕션에 없는 도구를 부르라고 안내하는 꼴이라 배포 후로 미룸.
- 다중선택지 버튼 UI — reason 텍스트로 1차 커버, 사용량 신호 나오면 후속.

## QA
제 자신의 구현이라 셀프 QA 불가 — 교차 QA 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)