### PR TITLE
fix(onboarding): thread session_id + meta.flow onto BE 'verified' funnel event (#2430)

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -712,7 +712,7 @@ async def agent_stream(
     )
 
 
-# âââ POST /api/v2/agent/events/ack ââââââââââââââââââââââââââââââââââââââââââââ
+# ─── POST /api/v2/agent/events/ack ────────────────────────────────────────────
 
 class AckRequest(BaseModel):
     seq: int
@@ -724,7 +724,7 @@ async def ack_event(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """ìì´ì í¸ê° ì²ë¦¬ ìë£í gateway_seq ACK â agent_event_cursors ê°±ì ."""
+    """에이전트가 처리 완료한 gateway_seq ACK — agent_event_cursors 갱신."""
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
     if not is_api_key:
         raise HTTPException(status_code=403, detail="API key required")
@@ -764,6 +764,7 @@ async def ack_event(
     # OB-4 seam: 새로 ack된 범위(prior_acked < seq <= body.seq)에 verify connection_test 가 있으면
     # ack_received + verified 발화(verify 라운드트립 완료·funnel·non-blocking·verify-ack에만 한정).
     if body.seq > prior_acked:
+        from app.models.onboarding_event import OnboardingEvent
         from app.services.agent_verify import VERIFY_EVENT_TYPE
         from app.services.onboarding_funnel import emit_onboarding_event
         _verify_done = (await db.execute(
@@ -776,8 +777,27 @@ async def ack_event(
             ).limit(1)
         )).first()
         if _verify_done:
-            await emit_onboarding_event(db, "ack_received", agent_id=agent_id)
-            await emit_onboarding_event(db, "verified", agent_id=agent_id)
+            # story #2430 — 이 ack 요청은 에이전트 런타임이 보내 브라우저의 session_id를 모른다.
+            # FE `verify_started`가 이미 같은 agent_id 행에 session_id(sessionStorage 조인 키)와
+            # meta.flow(onboarding|recruit)를 함께 실어 둔다(onboarding-telemetry.ts) — 그 「가장
+            # 최근」행을 조회해 그대로 이식한다(새 요청 필드·FE 변경 0, 순수 BE 조회 1회 추가).
+            # 여러 번 재시도(타임아웃 뒤 재검증)해도 ORDER BY server_ts DESC로 최신 시도가 이긴다.
+            _seam_source = (await db.execute(
+                select(OnboardingEvent.session_id, OnboardingEvent.meta).where(
+                    OnboardingEvent.agent_id == agent_id,
+                    OnboardingEvent.event == "verify_started",
+                ).order_by(OnboardingEvent.server_ts.desc()).limit(1)
+            )).first()
+            _seam_session_id = _seam_source.session_id if _seam_source else None
+            _seam_meta = _seam_source.meta if _seam_source else None
+            await emit_onboarding_event(
+                db, "ack_received", agent_id=agent_id,
+                session_id=_seam_session_id, meta=_seam_meta,
+            )
+            await emit_onboarding_event(
+                db, "verified", agent_id=agent_id,
+                session_id=_seam_session_id, meta=_seam_meta,
+            )
 
     await db.commit()
     return {"acked_seq": body.seq}

--- a/backend/tests/test_2430_onboarding_verified_session_flow_realdb.py
+++ b/backend/tests/test_2430_onboarding_verified_session_flow_realdb.py
@@ -1,0 +1,204 @@
+"""story #2430 — 그라운딩 재정의(2026-08-17, 페드루 PO 판정): 전제("성공 이벤트가 없다")는
+이미 낡았다(BE `agent_gateway.py`의 OB-4 seam이 이미 `"verified"`를 발화한다, agent_verify.py의
+동일 ack 신호에서). 실 남은 갭 2건만 처리한다:
+  ①`meta.flow`(onboarding vs recruit) 판별자 부재 — FE 4종엔 이미 있는데 BE emit엔 없었다.
+  ②`session_id`(funnel 조인 키) 미기입 — 컬럼은 이미 있는데 이 호출부만 안 채웠다.
+
+이 ack 요청은 에이전트 런타임이 보낸다(브라우저 session_id를 모른다) — FE `verify_started`가
+이미 같은 agent_id로 session_id+meta.flow를 실어 둔 최신 행을 조회해 그대로 이식한다(새 FE
+변경 0·새 request 필드 0, 순수 BE 조회 1회 추가).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2430", slug=f"org2430-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id):
+    from app.models.member import AgentProjectProfile, Member
+    from app.models.project_access import ProjectAccess
+
+    member_id = uuid.uuid4()
+    session.add(Member(id=member_id, org_id=org_id, type="agent", name="agent"))
+    await session.commit()
+    session.add(AgentProjectProfile(id=uuid.uuid4(), member_id=member_id, project_id=project_id))
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, member_id=member_id, permission="granted",
+    ))
+    await session.commit()
+    return member_id
+
+
+def _agent_auth(agent_id):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}},
+    )
+
+
+async def _setup_app(app, Session, agent_id):
+    from app.dependencies.auth import get_current_user
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return _agent_auth(agent_id)
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.anyio
+async def test_verified_and_ack_received_inherit_session_id_and_flow_from_verify_started():
+    """AC — verify_started(FE, session_id+meta.flow='recruit' 보유)가 먼저 있고, 그 뒤 ack가
+    완료되면 새로 발화된 verified/ack_received 행이 같은 session_id·meta.flow를 물려받는다."""
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.onboarding_event import OnboardingEvent
+    from app.services.agent_verify import start_verification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            expected_session_id = uuid.uuid4()
+            s.add(OnboardingEvent(
+                id=uuid.uuid4(), event="verify_started", agent_id=agent_id,
+                session_id=expected_session_id, meta={"flow": "recruit"},
+            ))
+            await s.commit()
+
+            seq = await start_verification(s, agent_id=agent_id, org_id=org_id, project_id=project_id)
+            await s.commit()
+
+        await _setup_app(app, Session, agent_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/agent/events/ack", json={"seq": seq})
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(OnboardingEvent).where(
+                    OnboardingEvent.agent_id == agent_id,
+                    OnboardingEvent.event.in_(("ack_received", "verified")),
+                )
+            )).scalars().all()
+            by_event = {r.event: r for r in rows}
+            assert set(by_event) == {"ack_received", "verified"}
+            for ev in ("ack_received", "verified"):
+                assert by_event[ev].session_id == expected_session_id, f"{ev} session_id 미상속"
+                assert by_event[ev].meta == {"flow": "recruit"}, f"{ev} meta.flow 미상속"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_verified_gracefully_degrades_when_no_verify_started_row_exists():
+    """음성대조 — verify_started 행이 아예 없으면(API 전용 발급 등) session_id/meta 조회가
+    None으로 조용히 degrade한다(크래시·422 없음, fail-silent 철학 유지)."""
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.onboarding_event import OnboardingEvent
+    from app.services.agent_verify import start_verification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            seq = await start_verification(s, agent_id=agent_id, org_id=org_id, project_id=project_id)
+            await s.commit()
+
+        await _setup_app(app, Session, agent_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/agent/events/ack", json={"seq": seq})
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(OnboardingEvent).where(
+                    OnboardingEvent.agent_id == agent_id,
+                    OnboardingEvent.event == "verified",
+                )
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].session_id is None
+            assert rows[0].meta == {}
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2430_onboarding_verified_session_flow_realdb.py
+++ b/backend/tests/test_2430_onboarding_verified_session_flow_realdb.py
@@ -163,6 +163,77 @@ async def test_verified_and_ack_received_inherit_session_id_and_flow_from_verify
 
 
 @pytest.mark.anyio
+async def test_verified_inherits_latest_verify_started_row_on_retry_not_the_first():
+    """미르코 QA(2026-08-17) — PO가 명시한 «재시도 시 최신 행 승리»(ORDER BY server_ts DESC) 축은
+    단일 verify_started 행 시딩으로는 실제로 갈라지지 않는다(오름차순으로 잘못 바뀌어도 통과
+    했을 것). 같은 agent_id에 verify_started 행을 **두 번**(오래된 것 flow='onboarding', 최신
+    것 flow='recruit') 시딩해 최신 쪽이 이긴다는 것을 직접 재현한다 — 별도 session/commit으로
+    서버 트랜잭션 시작 시각을 벌려(같은 트랜잭션 내 func.now()는 고정값이라 순서 보장 안 됨,
+    이 세션 다른 realdb 테스트들과 동일 원칙) server_ts 순서를 실측 보장한다."""
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.onboarding_event import OnboardingEvent
+    from app.services.agent_verify import start_verification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        # 오래된 시도(첫 verify_started) — 자기 트랜잭션에서 커밋해 server_ts를 확정시킨다.
+        stale_session_id = uuid.uuid4()
+        async with Session() as s:
+            s.add(OnboardingEvent(
+                id=uuid.uuid4(), event="verify_started", agent_id=agent_id,
+                session_id=stale_session_id, meta={"flow": "onboarding"},
+            ))
+            await s.commit()
+
+        # 최신 시도(재시도) — 별도 트랜잭션이라 server_ts가 위 행보다 반드시 뒤(같은 트랜잭션
+        # 안이었다면 func.now()가 고정값이라 이 테스트 자체가 성립하지 않았을 것).
+        latest_session_id = uuid.uuid4()
+        async with Session() as s:
+            s.add(OnboardingEvent(
+                id=uuid.uuid4(), event="verify_started", agent_id=agent_id,
+                session_id=latest_session_id, meta={"flow": "recruit"},
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            seq = await start_verification(s, agent_id=agent_id, org_id=org_id, project_id=project_id)
+            await s.commit()
+
+        await _setup_app(app, Session, agent_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/agent/events/ack", json={"seq": seq})
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(OnboardingEvent).where(
+                    OnboardingEvent.agent_id == agent_id,
+                    OnboardingEvent.event.in_(("ack_received", "verified")),
+                )
+            )).scalars().all()
+            by_event = {r.event: r for r in rows}
+            assert set(by_event) == {"ack_received", "verified"}
+            for ev in ("ack_received", "verified"):
+                assert by_event[ev].session_id == latest_session_id, (
+                    f"{ev}가 오래된 시도(stale_session_id)를 물려받음 — ORDER BY DESC가 안 지켜짐"
+                )
+                assert by_event[ev].session_id != stale_session_id
+                assert by_event[ev].meta == {"flow": "recruit"}, f"{ev} meta.flow가 최신 시도 값이 아님"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_verified_gracefully_degrades_when_no_verify_started_row_exists():
     """음성대조 — verify_started 행이 아예 없으면(API 전용 발급 등) session_id/meta 조회가
     None으로 조용히 degrade한다(크래시·422 없음, fail-silent 철학 유지)."""


### PR DESCRIPTION
## Summary
[온보딩 깔때기에 «성공» 이벤트가 없다 — verify_started 뒤의 침묵이 «완주»인지 «이탈»인지 구별되지 않는다](entity:story:e22d0cc7-eda9-41a3-a1bf-b52a74d04c79) — 그라운딩 결과 재정의된 작은 판.

## Grounding — 스토리 전제가 낡았음을 실측으로 확認
스토리는 "verify_started 뒤 성공 이벤트가 없다"를 전제했지만, `agent_gateway.py`의 OB-4 seam(`/api/v2/agent/events/ack`)이 이미 `emit_onboarding_event(db, "verified", agent_id=agent_id)`를 발화하고 있었다 — 정확히 FE `useVerificationRail`이 폴링하는 것과 같은 신호(`agent_verify.py`의 `acked_seq >= verify_seq`, connection_test event ack)에서. recruiter-client.tsx도 같은 hook을 써서 recruit 흐름도 이미 커버.

실 남은 갭은 **어휘 계약 불일치 2건**:
1. BE emit에 `meta.flow`(onboarding|recruit) 판별자 없음(FE 4종엔 있는데).
2. `session_id`(OnboardingEvent 컬럼 이미 존재) 미기입.

## Fix
ack 요청은 에이전트 런타임이 보내 브라우저의 session_id를 모른다 — FE `verify_started`가 이미 같은 agent_id 행에 session_id+meta.flow를 실어 둔다는 사실을 이용해, ack 처리 시점에 그 agent_id의 **가장 최근** `verify_started` 행을 조회해 `ack_received`/`verified` emit에 그대로 이식한다. 새 FE 변경 0·새 request 필드 0 — 순수 BE SELECT 1회 추가.

부수(발견 즉시 수정): 편집 중인 바로 그 두 줄(섹션 구분 주석 + 함수 docstring)이 Latin-1/UTF-8 이중 인코딩으로 맹글드돼 있어 같이 복원함(무관한 파일 전역 정리는 안 함).

## Verification
- 신규 `test_2430_onboarding_verified_session_flow_realdb.py`: 실 왕복(seed verify_started with session_id+flow='recruit' → start_verification → 실 HTTP `/events/ack` → 결과 행 확認) + 양성대조(verify_started 없으면 None/{} degrade) 2/2 pass.
- **뮤테이션**: `session_id=`/`meta=` kwarg를 emit 호출에서 제거 → `None != expected_session_id`로 정확히 RED. 복원 후 재통과 확認.
- 관련 회귀 스윕: `test_agent_gateway.py`+`test_gateway_ack_realdb.py` 33 passed, 2 skipped(무관 — DATABASE_URL 미설정 raw-asyncpg 축).
- ruff clean(신규 라인 기준 — agent_gateway.py 전역의 기존 22건은 무관).
- 동작 변경 없음(emit은 여전히 fire-and-forget/non-blocking — 순수 관측 추가).

## Test plan
- [x] 실PG 왕복+양성대조 2/2
- [x] 뮤테이션 RED 확認
- [x] 관련 파일 무회귀
- [x] ruff clean(신규 라인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)