### PR TITLE
[SID:2402] readonly-prod 재현가능 프로비저닝 스크립트(제안 A) — 스크립트만, 실행 안 함

### DIFF
--- a/backend/scripts/provision_readonly_prod_job.sh
+++ b/backend/scripts/provision_readonly_prod_job.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# story #2402 그라운딩 제안 A(2026-08-17, 미르코·페드루 PO 승인) — sprintable-readonly-prod
+# 재프로비저닝 스크립트화.
+#
+# 배경: 이 잡은 2026-08-01 ad-hoc gcloud로 수동 생성돼(story #2399 그라운딩 중 발견 —
+# `run.googleapis.com/creator` 애노테이션으로 확認) 어떤 스크립트/자동화도 이 잡을 몰랐다
+# — 정확히 이 저장소의 `provision_migrate_job.sh` 자신이 경고하는 그 패턴("기존
+# sprintable-migrate-dev 잡은 ad-hoc gcloud로 생성되어 재현 불가능했다")의 재발이었다.
+# 실제로 이미지가 2026-08-01 커밋(f001b52b)에 16일 넘게 고정된 채 방치돼 있었고, 그 사이
+# 머지된 마이그레이션 파일(0252/0253)을 몰라 `alembic current`가 리비전 이름조차 못 읽고
+# 실패하는 것을 라이브로 재현했다(story #2402 참고).
+#
+# 잡 구성(라이브 sprintable-readonly-prod 미러, provision_migrate_job.sh와 동형 패턴):
+#   - command : sh -c 'cd /app && alembic current'   ⚠️읽기전용 — upgrade 없음, 구조로 보장
+#               (쓰기 구문을 넣을 자리 자체가 없다 — 명령이 고정 리터럴)
+#   - ALEMBIC_DATABASE_URL : 시크릿 ALEMBIC_DATABASE_URL_PROD(prod 전용, dev 변형 없음 —
+#     이 잡 자체가 prod 스키마 확認용이라 dev에선 존재 이유가 없음)
+#   - cloudsql-instances/network/vpc-egress : prod 마이그 잡과 동형
+#
+# ⚠️이 스크립트는 "생성/갱신"만 한다 — 실행(`gcloud run jobs execute`)은 별도 명시 호출로
+# 분리(story #2399의 확認↔삭제 분리 관행과 동형, 실수로 같이 실행되는 걸 막는다).
+#
+# 사용법:
+#   COMMIT_SHA=abc1234 bash backend/scripts/provision_readonly_prod_job.sh
+#   # 프로비저닝 후 실행(별도 호출):
+#   gcloud run jobs execute sprintable-readonly-prod --region=asia-northeast3 --project=sprintable-494803 --wait
+#
+# 환경변수:
+#   GCP_PROJECT        (기본: sprintable-494803)
+#   GCP_REGION         (기본: asia-northeast3)
+#   AR_REPO            (기본: sprintable)
+#   COMMIT_SHA         이미지 태그 — **필수**(story 19754b93과 동일 규율: floating tag 폴백
+#                      없음, 미지정 시 fail-fast. DRY_RUN=1 검증 시엔 예외)
+#   PROD_SQL_INSTANCE  (기본: sprintable-prod)
+#   DRY_RUN            1이면 gcloud 호출 없이 resolved config만 stdout 출력(검증용)
+
+set -euo pipefail
+
+GCP_PROJECT="${GCP_PROJECT:-sprintable-494803}"
+GCP_REGION="${GCP_REGION:-asia-northeast3}"
+AR_REPO="${AR_REPO:-sprintable}"
+DRY_RUN="${DRY_RUN:-0}"
+PROD_SQL_INSTANCE="${PROD_SQL_INSTANCE:-sprintable-prod}"
+
+JOB_NAME="sprintable-readonly-prod"
+
+if [ -z "${COMMIT_SHA:-}" ] && [ "${DRY_RUN:-0}" != "1" ]; then
+    echo "ERROR: COMMIT_SHA is not set." >&2
+    echo "Manual provisioning requires an explicit image SHA — floating tag 폴백 없음" >&2
+    echo "(story 19754b93 규율과 동일 — 이 잡 자체가 08-01 stale 고정으로 고장난 사례다)." >&2
+    echo "Usage: COMMIT_SHA=<git-sha-or-image-tag> bash $0" >&2
+    exit 1
+fi
+IMAGE_TAG="${COMMIT_SHA:-latest-prod}"
+IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/backend:${IMAGE_TAG}"
+CLOUD_SQL_INSTANCE="${GCP_PROJECT}:${GCP_REGION}:${PROD_SQL_INSTANCE}"
+ALEMBIC_SECRET_NAME="ALEMBIC_DATABASE_URL_PROD"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [readonly-prod] $*" >&2; }
+
+log "Job: ${JOB_NAME}"
+log "Image: ${IMAGE}"
+log "Cloud SQL: ${CLOUD_SQL_INSTANCE}"
+log "ALEMBIC secret: ${ALEMBIC_SECRET_NAME}"
+
+if [ "${DRY_RUN}" = "1" ]; then
+    cat <<EOF
+JOB_NAME=${JOB_NAME}
+IMAGE=${IMAGE}
+CLOUD_SQL_INSTANCE=${CLOUD_SQL_INSTANCE}
+ALEMBIC_SECRET_NAME=${ALEMBIC_SECRET_NAME}
+COMMAND=sh -c 'cd /app && alembic current'
+EOF
+    exit 0
+fi
+
+# `gcloud run jobs deploy`는 잡이 없으면 생성, 있으면 갱신(idempotent) — 라이브 잡의
+# 현재 리소스(cpu=1·memory=512Mi·maxRetries=0·timeout=300s)를 그대로 명시해 드리프트 없이
+# 재현한다.
+gcloud run jobs deploy "${JOB_NAME}" \
+    --image="${IMAGE}" \
+    --region="${GCP_REGION}" \
+    --project="${GCP_PROJECT}" \
+    --command=sh \
+    --args="-c,cd /app && alembic current" \
+    --set-secrets="ALEMBIC_DATABASE_URL=${ALEMBIC_SECRET_NAME}:latest" \
+    --set-cloudsql-instances="${CLOUD_SQL_INSTANCE}" \
+    --network=default \
+    --subnet=default \
+    --vpc-egress=private-ranges-only \
+    --execution-environment=gen2 \
+    --cpu=1 \
+    --memory=512Mi \
+    --max-retries=0 \
+    --task-timeout=300
+
+log "=== ${JOB_NAME} provisioned ==="
+log "Run(별도 호출): gcloud run jobs execute ${JOB_NAME} --region=${GCP_REGION} --project=${GCP_PROJECT} --wait"

--- a/backend/tests/test_provision_readonly_prod_job_env.py
+++ b/backend/tests/test_provision_readonly_prod_job_env.py
@@ -1,0 +1,65 @@
+"""story #2402 그라운딩 제안 A(2026-08-17) — provision_readonly_prod_job.sh 회귀가드.
+
+test_deploy_realtime_gce_env.py·test_deploy_env.py와 동일 패턴 — DRY_RUN=1 resolved config를
+파싱해 검증한다(gcloud 호출 없음).
+
+핵심 축: ①COMMIT_SHA 미지정 시 fail-fast(story 19754b93 규율 — 이 스크립트가 고치려는
+사고 자체가 stale 고정 이미지였다) ②커맨드가 정확히 `alembic current`뿐임(구조로 읽기전용
+보장 — AC3 "SELECT만 쓰기로 했다는 약속이 아니라 구조여야 한다"에 대응, upgrade가 문자열
+어디에도 없다는 것까지 확認).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "provision_readonly_prod_job.sh")
+
+
+def _resolve(extra: dict | None = None) -> dict[str, str]:
+    environ = {**os.environ, "DRY_RUN": "1"}
+    environ.pop("COMMIT_SHA", None)
+    if extra:
+        environ.update(extra)
+    proc = subprocess.run(
+        ["bash", _SCRIPT], capture_output=True, text=True, env=environ, check=True,
+    )
+    cfg: dict[str, str] = {}
+    for line in proc.stdout.strip().splitlines():
+        if "=" in line:
+            k, _, v = line.partition("=")
+            cfg[k.strip()] = v.strip()
+    return cfg
+
+
+def test_missing_commit_sha_fails_fast_without_dry_run():
+    """⭐story 19754b93 규율 — COMMIT_SHA 없이 실제 배포 시도하면 floating tag로 새지 않고
+    즉시 fail. 이 스크립트가 고치려는 사고(readonly-prod가 08-01 커밋에 16일 고정) 자체가
+    "누군가 SHA 없이 손으로 돌렸다"류가 아니라 "SHA를 명시했는데 그 뒤로 안 갱신했다"류지만,
+    그래도 이 규율 자체는 다른 모든 prod 잡 스크립트와 동일하게 지킨다."""
+    environ = {**os.environ}
+    environ.pop("COMMIT_SHA", None)
+    environ.pop("DRY_RUN", None)
+    proc = subprocess.run(["bash", _SCRIPT], capture_output=True, text=True, env=environ)
+    assert proc.returncode != 0
+    assert "COMMIT_SHA is not set" in proc.stderr
+
+
+def test_dry_run_resolves_commit_pinned_image():
+    """COMMIT_SHA 지정 시 그 커밋으로 정확히 이미지 태그가 고정된다(floating latest-prod
+    아님) — readonly-prod가 애초에 고장난 원인(수동 SHA 고정 후 방치)을 재발시키지 않으려면
+    스크립트가 «항상 최신을 명시적으로 넣게» 강제해야 한다."""
+    cfg = _resolve({"COMMIT_SHA": "deadbeef1234"})
+    assert cfg["IMAGE"] == (
+        "asia-northeast3-docker.pkg.dev/sprintable-494803/sprintable/backend:deadbeef1234"
+    )
+    assert cfg["JOB_NAME"] == "sprintable-readonly-prod"
+
+
+def test_command_is_exactly_alembic_current_no_upgrade():
+    """⭐AC3 — 읽기전용이 «구조»여야 한다. 이 스크립트가 배포할 COMMAND에 upgrade가
+    어디에도 없다는 것을 문자열 축으로 직접 확認(story #2399가 잡은 그 병 — 이름은 안전한데
+    실제 커맨드에 upgrade가 숨어있는 것 — 의 반대 축을 이 스크립트가 만들지 않는지 검증)."""
+    cfg = _resolve({"COMMIT_SHA": "deadbeef1234"})
+    assert cfg["COMMAND"] == "sh -c 'cd /app && alembic current'"
+    assert "upgrade" not in cfg["COMMAND"]


### PR DESCRIPTION
## 배경

story #2399(migrate-prod-preflight 그라운딩) 중 `sprintable-readonly-prod`(prod
`alembic_version` 읽기전용 잡)를 직접 실행해보니 2회 다 실패:
```
ERROR [alembic.util.messaging] Can't locate revision identified by '0252'
```
원인: 이미지가 `f001b52b`(2026-08-01 커밋)에 16일 넘게 고정된 채 방치돼, 그 사이 머지된
마이그레이션(0252/0253)을 모른다. `run.googleapis.com/creator` 애노테이션 확認 결과 이
잡은 ad-hoc gcloud로 수동 생성돼(2026-08-01) 어떤 스크립트/자동화도 몰랐다 — 정확히
`provision_migrate_job.sh` 자신의 주석이 경고하는 그 패턴("기존 sprintable-migrate-dev
잡은 ad-hoc gcloud로 생성되어 재현 불가능했다")의 재발.

이 발견을 story #2402([인프라] 실제 스키마가 마이그체인으로 설명 안 됨)의 살아있는
실사례로 그라운딩에 이어붙였고, 제안 A(readonly-prod 스크립트화+이미지 최신화)를 페드루
PO가 승인.

## ⚠️이 PR의 스코프 — 스크립트만, 실행 없음

카디르군의 prod 읽기 작업 중 발생한 보안사고(DSN 로그 노출, 로테이션 상신 중) 매듭 전까지
prod 잡 **실행**은 전면 보류(페드루 PO 지시, 2026-08-17). 이 PR은 재프로비저닝
**스크립트만** 추가 — `gcloud run jobs deploy`/`execute` 어느 쪽도 이 PR 작업 중 실행
안 함(DRY_RUN=1로만 검증). 실제 배포 실행은 보안사고 매듭 후 별도 승인 시점.

## 구현

`backend/scripts/provision_readonly_prod_job.sh` — `provision_migrate_job.sh`와 동형
패턴(COMMIT_SHA 필수·floating tag 폴백 없음·DRY_RUN 검증·`gcloud run jobs deploy`
idempotent). 라이브 잡의 현재 리소스(cpu=1·memory=512Mi·maxRetries=0·timeout=300s)를
명시해 드리프트 없이 재현. 커맨드는 `sh -c 'cd /app && alembic current'`뿐 — upgrade
없음, 구조로 읽기전용 보장(생성 시점의 커맨드 자체가 그 외 아무것도 못 하게).

## 검증

- 신규 3테스트(`test_provision_readonly_prod_job_env.py`, DRY_RUN 기반 — gcloud 호출 없음,
  `test_deploy_realtime_gce_env.py`와 동일 패턴): COMMIT_SHA 미지정 시 fail-fast(story
  19754b93 규율) · 커밋고정 이미지 태그 정확 해소 · 커맨드가 정확히 `alembic current`뿐(문자열
  축으로 `upgrade` 부재 직접 확認). 3/3 pass.
- **뮤테이션킬**: COMMAND의 `alembic current`를 `alembic upgrade head`로 바꿔봄 →
  `test_command_is_exactly_alembic_current_no_upgrade` 정확히 RED, 원복 후 3/3 GREEN.
- `bash -n` 문법 검사 통과.

## QA

인프라 건이라 셀프 QA 불가 — 교차 QA 필요. 단 실 배포 검증(AC — 스크립트로 갱신된 잡이
실제로 0252/0253을 읽어내는지)은 보안사고 매듭 후 실행 승인 시점에 별도로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)