### PR TITLE
[SID:2089] hotfix — GCB substitution 파서가 로컬 bash 변수를 자기 키로 오인(develop 배포 봉인 P0)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -646,17 +646,25 @@ steps:
         # check_realtime_relevant_diff.sh의 목록, 보수적 채택 — 공유 파일 포함 24.7%셋)가
         # 바뀌었는지 본다. 얕은 클론이면 옛 SHA가 히스토리에 없을 수 있어 unshallow를
         # 먼저 시도(실패해도 계속 — 아래 diff 성패로 최종 fail-safe 판단).
-        _CURRENT_TEMPLATE="$(gcloud compute instance-groups managed describe sprintable-realtime-gateway-dev \
+        #
+        # ⛔hotfix(2026-08-17, 페드루 P0) — 로컬 bash 변수를 언더스코어 접두(`_CURRENT_TEMPLATE`
+        # `_LAST_SHA`)로 지었다가 develop 배포가 2연속 실패했다: GCB의 substitution 파서가
+        # `${_XXX}` 패턴 전부를 자기 치환 키로 오인해("key ... is not matched in the
+        # substitution data") 빌드 자체가 안 뜬 것 — GHA 주석 파싱 함정의 GCB 사촌. 이 파일의
+        # 다른 로컬변수(`served`·`expected`·`names`, 604~617행)는 전부 언더스코어 없이 지어져
+        # 아무 문제 없이 plain `$var`로 참조되고 있다 — 그 검증된 패턴으로 맞춘다(언더스코어
+        # 제거, `$$` 이스케이프 대안보다 이 파일 관행과 일치해 위험 낮음).
+        CURRENT_TEMPLATE="$(gcloud compute instance-groups managed describe sprintable-realtime-gateway-dev \
           --region="${_AR_REGION}" --project="${PROJECT_ID}" \
           --format='value(versions[0].instanceTemplate)' 2>/dev/null | sed 's#.*/##' || echo '')"
-        _LAST_SHA="$(echo "${_CURRENT_TEMPLATE}" | grep -oE '[0-9a-f]{8}' | head -1 || echo '')"
+        LAST_SHA="$(echo "$CURRENT_TEMPLATE" | grep -oE '[0-9a-f]{8}' | head -1 || echo '')"
 
-        if [ -z "${_LAST_SHA}" ]; then
+        if [ -z "$LAST_SHA" ]; then
           echo "deploy-realtime-gce: 기존 MIG 템플릿에서 직전 SHA를 못 읽음(최초 배포이거나 이름 패턴 변경) — path-filter 건너뛰고 배포 진행"
         else
           git fetch --unshallow >/dev/null 2>&1 || true
-          if ! bash backend/scripts/check_realtime_relevant_diff.sh "${_LAST_SHA}" "${COMMIT_SHA}"; then
-            echo "skip deploy-realtime-gce: ${_LAST_SHA}..${COMMIT_SHA} 사이 realtime-관련 경로 변경 없음(story #2089 path-filter, 스킵 사유는 위 로그 참고)"
+          if ! bash backend/scripts/check_realtime_relevant_diff.sh "$LAST_SHA" "${COMMIT_SHA}"; then
+            echo "skip deploy-realtime-gce: $LAST_SHA..${COMMIT_SHA} 사이 realtime-관련 경로 변경 없음(story #2089 path-filter, 스킵 사유는 위 로그 참고)"
             exit 0
           fi
         fi

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -647,13 +647,15 @@ steps:
         # 바뀌었는지 본다. 얕은 클론이면 옛 SHA가 히스토리에 없을 수 있어 unshallow를
         # 먼저 시도(실패해도 계속 — 아래 diff 성패로 최종 fail-safe 판단).
         #
-        # ⛔hotfix(2026-08-17, 페드루 P0) — 로컬 bash 변수를 언더스코어 접두(`_CURRENT_TEMPLATE`
-        # `_LAST_SHA`)로 지었다가 develop 배포가 2연속 실패했다: GCB의 substitution 파서가
-        # `${_XXX}` 패턴 전부를 자기 치환 키로 오인해("key ... is not matched in the
-        # substitution data") 빌드 자체가 안 뜬 것 — GHA 주석 파싱 함정의 GCB 사촌. 이 파일의
-        # 다른 로컬변수(`served`·`expected`·`names`, 604~617행)는 전부 언더스코어 없이 지어져
-        # 아무 문제 없이 plain `$var`로 참조되고 있다 — 그 검증된 패턴으로 맞춘다(언더스코어
-        # 제거, `$$` 이스케이프 대안보다 이 파일 관행과 일치해 위험 낮음).
+        # ⛔hotfix(2026-08-17, 페드루 P0) — 로컬 bash 변수를 언더스코어 접두(CURRENT_TEMPLATE·
+        # LAST_SHA 앞에 밑줄을 붙인 이름)로 지었다가 develop 배포가 2연속 실패했다: GCB의
+        # substitution 파서가 밑줄로 시작하는 중괄호 치환 패턴 전부를 자기 치환 키로 오인해
+        # ("key ... is not matched in the substitution data") 빌드 자체가 안 뜬 것 — GHA
+        # 주석 파싱 함정의 GCB 사촌(⚠️이 주석 자신도 그 패턴의 리터럴 표기를 피한다 — 문자
+        # 그대로 적으면 이 주석 자체가 또 같은 함정에 걸린다, 페드루 리뷰 지적). 이 파일의
+        # 다른 로컬변수(served·expected·names, 604~617행)는 전부 언더스코어 없이 지어져
+        # 아무 문제 없이 참조되고 있다 — 그 검증된 패턴으로 맞춘다(치환 이스케이프 대안보다
+        # 이 파일 관행과 일치해 위험 낮음).
         CURRENT_TEMPLATE="$(gcloud compute instance-groups managed describe sprintable-realtime-gateway-dev \
           --region="${_AR_REGION}" --project="${PROJECT_ID}" \
           --format='value(versions[0].instanceTemplate)' 2>/dev/null | sed 's#.*/##' || echo '')"


### PR DESCRIPTION
## P0 — develop 배포가 PR#3173으로 2연속 failure 봉인됨(페드루 확認)

`gcloud builds submit` 실 에러:
```
key in the template "_CURRENT_TEMPLATE" is not matched in the substitution data
key in the template "_LAST_SHA" is not matched in the substitution data
```

## 원인

PR#3173(`deploy-realtime-gce` path-filter)이 cloudbuild.yaml의 `args: |` bash 블록
안에 순수 로컬 bash 변수를 `_CURRENT_TEMPLATE`·`_LAST_SHA`로 지었다. GCB의 substitution
파서는 사용자 정의 substitution 키의 관례(언더스코어 접두)를 따르는 `${_XXX}` 패턴을
빌드 config 전체 문자열에서 스캔해 실제 substitution 값으로 치환하려 시도하는데, 이
둘은 `substitutions:`에 선언된 적 없는(선언될 이유도 없는, 순수 지역 셸 변수) 키라
"매치 안 됨" 에러로 빌드 자체가 안 뜬 것 — **GHA 워크플로 YAML 주석/문법 함정의 GCB
사촌**.

## fix

두 변수를 언더스코어 없이 재명명(`CURRENT_TEMPLATE`·`LAST_SHA`). 이 파일 자체에 이미
검증된 선례가 있음 — `served`·`expected`·`names`(mcp 배포검증 스텝, 604~617행)가
언더스코어 없이 지어져 plain `$var`로 아무 문제 없이 쓰이고 있다. `$$` 이스케이프
(`$${_CURRENT_TEMPLATE}`) 대신 이 재명명 방식을 택한 이유 — 이 파일의 기존 관례와
일치해 향후 유지보수자가 헷갈릴 여지가 낮음.

## ⚠️검증 한계(페드루 PO 지시로 명시)

이번 사고의 실제 원인축은 **`gcloud builds submit` 자신의 substitution 파서**다 —
`python3 -c "import yaml..."`(YAML 유효성)과 `bash -n`(bash 문법)은 **둘 다 이번에
통과했지만 둘 다 이 축을 원천적으로 못 잡는다**(YAML 파서도 bash 파서도 GCB 자체
substitution 문법을 모른다). 로컬 Docker 데몬이 이번 세션 다운돼 있어 `cloud-build-local`
에뮬레이터도 못 돌렸다 — **이 fix의 최종 검증은 머지 후 다음 실제 develop Cloud Build
트리거 실행으로만 가능**하다.

## 검증(현재 가능한 범위)

- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML 유효성 통과.
- `bash -n`(step의 실제 args 문자열을 추출해) — bash 문법 통과.
- 잔존 `_CURRENT_TEMPLATE`/`_LAST_SHA` 참조 0건(grep, 주석의 사고 기록만 남음).

## QA

P0·인프라 건 — 셀프 QA 불가. **머지 후 다음 develop Cloud Build 실행이 실제 통과하는지가
진짜 검증**입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)