### PR TITLE
[SID:2403] billing-tab toTierId — 레거시 Polar 'pro'를 'business'로 매핑

### DIFF
--- a/apps/web/src/ee/components/billing/billing-tab.test.tsx
+++ b/apps/web/src/ee/components/billing/billing-tab.test.tsx
@@ -109,6 +109,23 @@ describe('BillingTab — 결제②-D 4티어 재편', () => {
     expect(container.textContent).toContain('업그레이드');
   });
 
+  // story #2403 후속(2026-08-17) — prod org_subscriptions 실측(tier='pro' 3건 실존) 기반
+  // 회귀가드. toTierId()가 'pro'를 몰라 TIER_ORDER.includes 실패 → 'free'로 조용히 폴백하면
+  // 유료 결제 중인 조직이 화면엔 무료로 보인다(실해악). DOM 셀렉터는 팩 섹션도 카드와 같은
+  // className을 재사용해 불안정(6개 매치, 카드 4개 아님) — 대신 textContent의 문서 순서로
+  // "현재 이용 중" 배지가 Free~Starter 구간엔 없고 Business 헤딩 이후(마지막 티어라 다음
+  // 헤딩 없음)에만 있는지를 인덱스로 가른다.
+  it('tier="pro"(레거시 Polar)는 Free가 아니라 Business로 매핑된다', async () => {
+    await mount(async () => statusResponse({ tier: 'pro' }));
+    const text = container.textContent ?? '';
+    const starterIdx = text.indexOf('Starter');
+    const businessIdx = text.indexOf('Business');
+    const badgeIdx = text.indexOf('현재 이용 중');
+    expect(businessIdx).toBeGreaterThan(starterIdx); // TIER_ORDER상 Business가 마지막
+    expect(badgeIdx).toBeGreaterThan(businessIdx); // 배지가 Business 헤딩 뒤(=그 카드 안)에만 있음
+    expect(text.indexOf('현재 이용 중', badgeIdx + 1)).toBe(-1); // 딱 1번만(Free에 안 붙음)
+  });
+
   it('현재 tier가 팩 구매 불가(Free)면 팩 섹션을 숨긴다', async () => {
     await mount(async () => statusResponse({ tier: 'free' }));
     expect(container.textContent).not.toContain('추가 팩');

--- a/apps/web/src/ee/components/billing/billing-tab.tsx
+++ b/apps/web/src/ee/components/billing/billing-tab.tsx
@@ -58,6 +58,13 @@ interface BillingStatus {
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
 function toTierId(raw: string | undefined): TierId {
+  // story #2403 후속(2026-08-17) — prod org_subscriptions 실측: tier='pro'(레거시 Polar,
+  // v2.2 D5가 은퇴시킨 이름) 조직이 3건 실존. TIER_ORDER에 'pro'가 없어 이 매핑 없이는
+  // 유료 결제 중인 조직이 조용히 "Free"로 렌더됐다(실해악 — 화면만 틀리고 청구는 계속됨).
+  // 'business'로 매핑하는 근거: migration 0228이 이미 pricing_versions에 동일 판단을
+  // 적용했다(`UPDATE pricing_versions SET tier = 'business' WHERE tier = 'pro'`) — 이름
+  // 재사용 금지(D12)는 신규 의미 부여 금지이지, 레거시 데이터 표시 매핑까지 막지 않는다.
+  if (raw === 'pro') return 'business';
   return raw != null && (TIER_ORDER as readonly string[]).includes(raw) ? (raw as TierId) : 'free';
 }
 


### PR DESCRIPTION
## P0 — 실해악(prod 실측 확認)

story #2403 그라운딩(오늘)에서 발견: v2.3 신 청구 UI(`billing-tab.tsx`, `TIER_ORDER`=free/starter/team/business)에 은퇴된 `pro` 이름 자리가 없어, `toTierId()`가 이 값을 가진 조직을 조용히 `free`로 폴백시킨다.

**prod 실측(페드루 PO 승인, 읽기전용 `sprintable-readonly-prod` job, SQLAlchemy 경유+예외 원문 미출력 방어 스크립트)**: `org_subscriptions` 전체가 3행뿐이고 **전부 `tier='pro'`** — 즉 prod의 현재 유료 구독 전부가 이 UI에서 Free로 보이고 있었다. 화면만 틀린 게 아니라 실제 유료 고객 경험 문제.

## 처방

`'pro'` → `'business'` 매핑 추가. 근거: migration `0228_billing_v2_3_tier_model_offering_catalog.py`가 `pricing_versions`에 이미 동일 판단을 적용한 선례(`UPDATE pricing_versions SET tier = 'business' WHERE tier = 'pro'`). 정책 v2.3 D12의 "pro 이름 재사용 금지"는 신규 의미 부여 금지이지, 레거시 데이터의 표시 매핑 자체를 막는 게 아니다.

## 검증

- 신규 테스트: `tier='pro'`로 마운트 후 "현재 이용 중" 배지가 Business 카드에만 붙는 것을 텍스트 인덱스 순서로 확認(DOM 클래스 셀렉터는 팩 섹션이 같은 className을 재사용해 불안정 — 6개 매치, 카드 4개 아님).
- 뮤테이션킬: 매핑 제거 → 정확한 이유로 RED(배지가 Free~Starter 구간에 위치). 원복 → GREEN.
- 20/20 통과(billing-tab.test.tsx 전체).

## QA
prod 실측이 포함된 P0 건 — 셀프 QA 불가, 교차 QA 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)