### PR TITLE
[SID:2089] hotfix 2차 — GCB built-in substitution 검사(대문자) 회피, 소문자화

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -647,26 +647,25 @@ steps:
         # 바뀌었는지 본다. 얕은 클론이면 옛 SHA가 히스토리에 없을 수 있어 unshallow를
         # 먼저 시도(실패해도 계속 — 아래 diff 성패로 최종 fail-safe 판단).
         #
-        # ⛔hotfix(2026-08-17, 페드루 P0) — 로컬 bash 변수를 언더스코어 접두(CURRENT_TEMPLATE·
-        # LAST_SHA 앞에 밑줄을 붙인 이름)로 지었다가 develop 배포가 2연속 실패했다: GCB의
-        # substitution 파서가 밑줄로 시작하는 중괄호 치환 패턴 전부를 자기 치환 키로 오인해
-        # ("key ... is not matched in the substitution data") 빌드 자체가 안 뜬 것 — GHA
-        # 주석 파싱 함정의 GCB 사촌(⚠️이 주석 자신도 그 패턴의 리터럴 표기를 피한다 — 문자
-        # 그대로 적으면 이 주석 자체가 또 같은 함정에 걸린다, 페드루 리뷰 지적). 이 파일의
-        # 다른 로컬변수(served·expected·names, 604~617행)는 전부 언더스코어 없이 지어져
-        # 아무 문제 없이 참조되고 있다 — 그 검증된 패턴으로 맞춘다(치환 이스케이프 대안보다
-        # 이 파일 관행과 일치해 위험 낮음).
-        CURRENT_TEMPLATE="$(gcloud compute instance-groups managed describe sprintable-realtime-gateway-dev \
+        # ⛔hotfix 2차(2026-08-17, 페드루 P0) — 1차 fix(언더스코어 제거)로도 여전히 막혔다:
+        # GCB는 밑줄 없는 대문자 이름도 built-in substitution 후보로 검사한다("not a valid
+        # built-in substitution" 에러) — 즉 밑줄 유무와 무관하게 대문자 이름 자체가 GCB run
+        # 블록에서 위험하다. 이 파일의 다른 로컬변수(served·expected·names, 604~617행)가
+        # 안전했던 진짜 이유는 밑줄이 없어서가 아니라 **소문자**였기 때문 — 그 관행과 완전히
+        # 동형으로 맞춘다(대문자→소문자, 파서의 두 층 모두 회피). 교훈: 이 run 블록 안에서
+        # 새로 짓는 로컬 셸 변수는 소문자로만 짓는다(대문자는 사용자 substitution이든
+        # built-in이든 GCB 자체 치환 후보로 스캔된다).
+        current_template="$(gcloud compute instance-groups managed describe sprintable-realtime-gateway-dev \
           --region="${_AR_REGION}" --project="${PROJECT_ID}" \
           --format='value(versions[0].instanceTemplate)' 2>/dev/null | sed 's#.*/##' || echo '')"
-        LAST_SHA="$(echo "$CURRENT_TEMPLATE" | grep -oE '[0-9a-f]{8}' | head -1 || echo '')"
+        last_sha="$(echo "$current_template" | grep -oE '[0-9a-f]{8}' | head -1 || echo '')"
 
-        if [ -z "$LAST_SHA" ]; then
+        if [ -z "$last_sha" ]; then
           echo "deploy-realtime-gce: 기존 MIG 템플릿에서 직전 SHA를 못 읽음(최초 배포이거나 이름 패턴 변경) — path-filter 건너뛰고 배포 진행"
         else
           git fetch --unshallow >/dev/null 2>&1 || true
-          if ! bash backend/scripts/check_realtime_relevant_diff.sh "$LAST_SHA" "${COMMIT_SHA}"; then
-            echo "skip deploy-realtime-gce: $LAST_SHA..${COMMIT_SHA} 사이 realtime-관련 경로 변경 없음(story #2089 path-filter, 스킵 사유는 위 로그 참고)"
+          if ! bash backend/scripts/check_realtime_relevant_diff.sh "$last_sha" "${COMMIT_SHA}"; then
+            echo "skip deploy-realtime-gce: $last_sha..${COMMIT_SHA} 사이 realtime-관련 경로 변경 없음(story #2089 path-filter, 스킵 사유는 위 로그 참고)"
             exit 0
           fi
         fi


### PR DESCRIPTION
## P0 2차 — 1차 hotfix(#3177, 머지됨 90df2af7)가 다른 층에서 또 실패

실 에러: `key "CURRENT_TEMPLATE" is not a valid built-in substitution`

1차 fix는 언더스코어 접두(`_CURRENT_TEMPLATE`)를 제거해 **사용자 정의 substitution** 층은
피했지만, GCB는 그와 별개로 **밑줄 없는 대문자 이름**도 built-in substitution(`COMMIT_SHA`
류) 후보로 검사한다는 걸 놓쳤다 — `CURRENT_TEMPLATE`·`LAST_SHA`가 대문자였던 게 원인.

## fix

`current_template`·`last_sha`로 소문자화. 이 파일의 기존 검증된 로컬변수(`served`·
`expected`·`names`, 604~617행)가 안전했던 진짜 이유는 "언더스코어가 없어서"가 아니라
**"소문자였기 때문"**이었다 — 그 관행과 완전히 동형으로 맞춰 사용자 substitution·built-in
두 층 모두 우회한다.

## 검증

- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML 유효성 통과.
- `bash -n`(step args 추출) — bash 문법 통과.
- 대문자 형태(`CURRENT_TEMPLATE`/`LAST_SHA`) 잔존 0건(grep).

## ⚠️검증 한계(1차와 동일)

이번에도 `gcloud builds submit` 자신의 substitution 파서가 실 원인축이고, YAML/bash 검사
어느 쪽도 이 축을 원천적으로 못 잡는다 — 로컬 Docker 다운으로 `cloud-build-local`도
불가능. **최종 검증은 머지 후 다음 실제 develop Cloud Build 트리거 실행.**

## QA

P0 — 셀프 QA 불가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)