### PR TITLE
fix(#2721): artifact backlinks — READ 축 신설(WRITE는 이미 배선됨)

### DIFF
--- a/apps/web/src/app/api/visual-artifacts/[id]/backlinks/route.ts
+++ b/apps/web/src/app/api/visual-artifacts/[id]/backlinks/route.ts
@@ -1,0 +1,27 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors, type ApiMeta } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/**
+ * GET /api/visual-artifacts/{id}/backlinks — story #2721(아티팩트·원장 1급화 1단): 이
+ * artifact를 가리키는 것들(chat_message/doc/story source) 목록. stories.py의 backlinks
+ * 프록시와 동형(BE convention-A {data,meta} 언랩 — activities/route.ts 이중포장 사고와 같은
+ * 자리라 처음부터 raw json.data ?? json 패턴으로 짓는다) — 이 파일의 다른 GET들처럼
+ * `getAuthContext`+`proxyToFastapi`(단순 문자열 경로, `[id]` 세그먼트 치환 불요).
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, `/api/v2/visual-artifacts/${id}/backlinks`);
+    if (!_r.ok) return _r;
+    const beJson = (await _r.json()) as { data?: unknown; meta?: ApiMeta };
+    return apiSuccess(beJson.data ?? beJson, beJson.meta);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -11,6 +11,7 @@ import { SpecPinMarker } from './spec-pin-marker';
 import { CommentThreadCard } from './comment-thread-card';
 import { DescriptionPane } from './description-pane';
 import { ExportDialog } from './export-dialog';
+import { EntityBacklinksSection } from '@/components/shared/entity-backlinks-section';
 import type { ArtifactVersion, MemberRef, VisualArtifact } from '@/services/canvas';
 import type { ArtifactNode } from '@/services/canvas-nodes';
 import type { CommentThread } from '@/services/canvas-comments';
@@ -257,6 +258,10 @@ export function ArtifactViewer({
             ))}
           </div>
         ) : null}
+        {/* story #2721(아티팩트·원장 1급화 1단) — 「이것을 가리키는 것들」. 신규 뷰어 0(기존
+         * EntityBacklinksSection 재사용, doc/story와 동형) — 뷰어가 곧 상세 표면이라 여기 마운트
+         * (ArtifactExpandDialog는 순수 캔버스 프리뷰라 대상 아님). */}
+        <EntityBacklinksSection entityType="artifact" entityId={artifact.id} />
       </div>
       <ExportDialog
         open={exportOpen}

--- a/apps/web/src/components/shared/entity-backlinks-section.tsx
+++ b/apps/web/src/components/shared/entity-backlinks-section.tsx
@@ -65,12 +65,13 @@ const EXCLUDE_LABEL_KEYS: Record<string, string> = {
 /** BacklinksEntityType → BE 라우트 세그먼트. 불규칙복수(story→stories)라 순수 접미사 파생이
  * 아닌 조회 테이블로 연다 — PROJECT_ID_RESOLVERS와 같은 성격(종류-분기가 아니라 표기 파생).
  *
- * ⛔이 맵의 키 집합은 BE `backlinks.py::BACKLINKS_ALLOWED_TARGET_TYPES`(현재
- * `frozenset({"doc", "story"})`)와 **글자 그대로 같은 집합**이어야 한다 — 미리 늘리지 않는다.
- * epic 등 나머지 registry 타입이 거기 없는 이유는 "라우트가 없어서"가 아니라 그 라우터들에
- * `_require_doc_project_access`/`_assert_story_project_access`와 동형인 TARGET
+ * ⛔이 맵의 키 집합은 BE `backlinks.py::BACKLINKS_ALLOWED_TARGET_TYPES`(story #2721부터
+ * `frozenset({"doc", "story", "artifact"})`)와 **글자 그대로 같은 집합**이어야 한다 — 미리
+ * 늘리지 않는다. epic 등 나머지 registry 타입이 거기 없는 이유는 "라우트가 없어서"가 아니라
+ * 그 라우터들에 `_require_doc_project_access`/`_assert_story_project_access`와 동형인 TARGET
  * project-access 선-게이트가 아직 없어서다(PO 확認, 2026-07-28) — 게이트 없이 여기 먼저
- * 추가하면 화면이 "게이트 없는 라우트"를 부르게 된다.
+ * 추가하면 화면이 "게이트 없는 라우트"를 부르게 된다. artifact는 story #2721이 그 동형 게이트
+ * (`_get_artifact_or_404`, 기존 project-access 계약 재사용)를 세운 뒤 여기 추가한 것.
  *
  * ⛔이 맵은 **임시**다 — BE가 언젠가 client 입력을 받는 단일 generic
  * `/entities/{type}/{id}/backlinks` 라우트로 접으면(PO가 `UnsupportedBacklinkTargetTypeError`
@@ -83,6 +84,7 @@ const EXCLUDE_LABEL_KEYS: Record<string, string> = {
 const ENTITY_ROUTE_SEGMENT = {
   story: 'stories',
   doc: 'docs',
+  artifact: 'visual-artifacts',
 } as const satisfies Record<string, string>;
 
 export type BacklinksEntityType = keyof typeof ENTITY_ROUTE_SEGMENT;

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -291,6 +291,40 @@ async def get_artifact(
     return _ok(detail.model_dump(mode="json"))
 
 
+@router.get("/{id}/backlinks")
+async def get_artifact_backlinks(
+    id: uuid.UUID,
+    limit: int = Query(default=30, ge=1, le=200),
+    before: str | None = Query(default=None),
+    auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context_no_key_scope_check),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """GET /api/v2/visual-artifacts/{id}/backlinks — story #2721(아티팩트 원장 1급화 1단).
+    이 artifact를 가리키는 chat_message/doc/story 목록(역방향) — stories.py의
+    get_story_backlinks와 동형(`list_entity_backlinks` 코어 그대로 재사용, 새 쿼리 발명 0).
+    TARGET 접근 게이트는 이 파일 기존 관례인 `_get_artifact_or_404`(org_id+project_id 404,
+    story #2266 §8①이 요구하는 "호출부가 TARGET 접근을 이미 검증" 계약 충족).
+
+    WRITE(entity_references에 target_type=artifact 저장)는 이미 배선돼 있었다(reference_
+    registry.ENTITY_RESOLVERS에 artifact가 이미 등재 — 그라운딩 실PG 실증) — 이 엔드포인트가
+    이 스토리의 유일한 신규 로직이다. 이 파일 다른 GET들과 동형으로 `get_scope_context_no_key_
+    scope_check`(read 전용 — story #2708 판정) 사용."""
+    org_id, project_id = scope["org_id"], scope["project_id"]
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+
+    from app.services.backlinks import list_entity_backlinks
+    result = await list_entity_backlinks(
+        session, org_id=org_id, target_type="artifact", target_id=id,
+        auth=auth, limit=limit, cursor=before,
+    )
+    return _ok(result["data"], meta=result["meta"])
+
+
 @router.get("/{id}/versions")
 async def list_artifact_versions(
     id: uuid.UUID,

--- a/backend/app/services/backlinks.py
+++ b/backend/app/services/backlinks.py
@@ -185,6 +185,7 @@ from app.models.doc import Doc
 from app.models.meeting import Meeting
 from app.models.pm import Story
 from app.models.reference import Reference
+from app.models.visual_artifact import VisualArtifact
 from app.services.conversation_auth import conversation_readable_predicate
 from app.services.member_resolver import ResolvedMember, lookup_members_by_ids
 from app.services.project_auth import (
@@ -266,11 +267,16 @@ async def _chat_predicate_inputs(
 # 구멍»이 생긴다 — 이 함수는 TARGET 접근 검증을 스스로 하지 않고(§8①) 호출부(라우터)가
 # 이미 검증했다는 전제로 짜여 있기 때문(위 docstring 참조). 그래서 "이 타입은 호출부가 실제로
 # 게이트를 세웠다"를 이 allowlist가 보증한다 — 코드 레벨 계약이지 편의 목록이 아니다.
-BACKLINKS_ALLOWED_TARGET_TYPES = frozenset({"doc", "story"})
+BACKLINKS_ALLOWED_TARGET_TYPES = frozenset({"doc", "story", "artifact"})
 # ⛔registry(reference_registry.ENTITY_RESOLVERS)의 나머지 타입(epic 등)이 여기 없는 이유는
 # "의도적 제외"가 아니라 **게이트 미비**다 — 그 타입들의 라우터에 아직 이 함수와 동형인
 # TARGET project-access 선-게이트(docs.py._require_doc_project_access ·
 # stories.py._assert_story_project_access)가 없다. 게이트가 서는 순서대로 여기 추가한다.
+# story #2721(2026-08-17): artifact 추가 — visual_artifacts.py의 `_get_artifact_or_404`가
+# 이미 동형 TARGET project-access 게이트(org_id+project_id 조합 404)라 그대로 재사용,
+# 새 게이트 발명 0. WRITE(entity_references에 target_type=artifact 저장)는 reference_registry.
+# ENTITY_RESOLVERS에 이미 등재돼 실측 확認됨(그라운딩) — 이 스토리는 READ(backlinks 조회)
+# 축만 연다.
 
 
 class UnsupportedBacklinkTargetTypeError(ValueError):
@@ -291,7 +297,7 @@ class UnsupportedBacklinkTargetTypeError(ValueError):
 # 목록과 같은 목록을 쓴다, 별도 목록을 만들지 않는다") — 이 dict의 키를 늘릴 땐 반드시
 # BACKLINKS_ALLOWED_TARGET_TYPES도 같이 늘어 있어야 한다(파생이 아니라 하드코딩인 이유: model
 # 클래스 자체는 registry가 담을 수 없는 타입정보라 여기 한 곳에만 둔다).
-_ZERO_REF_MODELS: dict[str, type] = {"doc": Doc, "story": Story}
+_ZERO_REF_MODELS: dict[str, type] = {"doc": Doc, "story": Story, "artifact": VisualArtifact}
 
 
 async def count_zero_referenced_entities(

--- a/backend/tests/test_2266_story_backlinks_realdb.py
+++ b/backend/tests/test_2266_story_backlinks_realdb.py
@@ -191,9 +191,22 @@ async def test_list_entity_backlinks_rejects_unsupported_target_type():
 
 @pytest.mark.anyio
 async def test_backlinks_allowlist_contains_exactly_doc_and_story():
-    """이번 판 허용목록은 정확히 {doc, story}뿐 — 다음 판(epic 등)이 늘리기 전까지 고정."""
+    """story #2721(2026-08-17)이 artifact를 추가 — 허용목록은 정확히 {doc, story, artifact}뿐
+    (다음 판이 늘리기 전까지 고정, 함수명은 이력 보존을 위해 유지)."""
     from app.services.backlinks import BACKLINKS_ALLOWED_TARGET_TYPES
-    assert BACKLINKS_ALLOWED_TARGET_TYPES == frozenset({"doc", "story"})
+    assert BACKLINKS_ALLOWED_TARGET_TYPES == frozenset({"doc", "story", "artifact"})
+
+
+def test_zero_ref_models_key_set_matches_allowlist():
+    """story #2721 — backlinks.py 자기 주석("_ZERO_REF_MODELS의 키를 늘릴 땐 반드시
+    BACKLINKS_ALLOWED_TARGET_TYPES도 같이 늘어야 한다")이 지금까지 코드로 강제된 적이 없었다
+    (grep 확認 — 이 테스트가 최초). count_zero_referenced_entities()가 `_ZERO_REF_MODELS
+    [target_type]`을 BACKLINKS_ALLOWED_TARGET_TYPES 전체에 대해 순회하므로, 두 집합이 어긋나면
+    한쪽만 늘어도 조용히 넘어가는 게 아니라 **KeyError로 즉시 죽는다**(런타임 크래시 —
+    다음 사람이 한쪽만 고치면 이 함수가 다음 cron 실행에서 바로 터진다) — 그 자리를 이 테스트가
+    push 前에 잡는다."""
+    from app.services.backlinks import _ZERO_REF_MODELS, BACKLINKS_ALLOWED_TARGET_TYPES
+    assert set(_ZERO_REF_MODELS) == BACKLINKS_ALLOWED_TARGET_TYPES
 
 
 # ─── ②story TARGET 게이트 — AC2 money test(권한 대조: 있음 vs 없음) ────────────

--- a/backend/tests/test_2721_artifact_backlinks_realdb.py
+++ b/backend/tests/test_2721_artifact_backlinks_realdb.py
@@ -1,0 +1,315 @@
+"""story #2721(아티팩트·원장 1급화 1단) — `GET /api/v2/visual-artifacts/{id}/backlinks` 실PG
+검증.
+
+그라운딩(2026-08-17, 디디)이 확認한 사실: WRITE(entity_references에 target_type=artifact
+저장)는 이미 배선돼 있었다(reference_registry.ENTITY_RESOLVERS에 artifact가 이미 등재 —
+직접 실PG 왕복으로 실증됨, `insert_chat_mentions`로 채팅 메시지 안 `entity:artifact:` 토큰이
+그대로 저장됨). 이 스토리의 유일한 신규 로직은 READ(backlinks 조회) — `BACKLINKS_ALLOWED_
+TARGET_TYPES`에 artifact 추가 + `GET /{id}/backlinks` 엔드포인트 신설뿐이다.
+
+커버:
+  AC1: 채팅 메시지의 entity:artifact: 참조 → entity_references 저장(이미 됨, 회귀가드로
+       재확認) + 이 엔드포인트가 그 참조를 목록으로 되돌려줌.
+  AC3: 기존 참조 계약(#2679 origin·#2702 explicit) 무회귀 — auto 참조는 응답에서 빠짐.
+  AC4: 존재하지 않는 artifact 404, project 접근 없으면 404(existence-non-disclosure,
+       `_get_artifact_or_404`의 기존 계약 그대로 상속 — 새 인가 로직 발명 0).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+# ─── seeding ────────────────────────────────────────────────────────────────
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2721", slug=f"org2721-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id):
+    from app.models.member import AgentProjectProfile, Member
+    from app.models.project_access import ProjectAccess
+
+    member_id = uuid.uuid4()
+    session.add(Member(id=member_id, org_id=org_id, type="agent", name="agent"))
+    await session.commit()
+    session.add(AgentProjectProfile(id=uuid.uuid4(), member_id=member_id, project_id=project_id))
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, member_id=member_id, permission="granted",
+    ))
+    await session.commit()
+    return member_id
+
+
+async def _seed_artifact(session, org_id, project_id, created_by, title="아티팩트"):
+    from app.models.visual_artifact import VisualArtifact
+
+    artifact = VisualArtifact(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, created_by=created_by,
+    )
+    session.add(artifact)
+    await session.commit()
+    return artifact
+
+
+async def _seed_conversation(session, org_id, project_id, member_ids, created_by):
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type="group",
+        title="T", created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+async def _seed_message(session, conversation_id, sender_id, content="본문"):
+    from app.models.conversation import ConversationMessage
+    msg = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conversation_id, sender_id=sender_id, content=content,
+        created_at=datetime.now(UTC),
+    )
+    session.add(msg)
+    await session.commit()
+    return msg
+
+
+async def _make_reference(
+    session, org_id, source_type, source_id, target_type, target_id, created_by,
+    origin="explicit", form="mention",
+):
+    from app.models.reference import Reference
+    ref = Reference(
+        id=uuid.uuid4(), org_id=org_id, source_type=source_type, source_field="body",
+        source_id=source_id, target_type=target_type, target_id=target_id, form=form,
+        origin=origin, created_by=created_by,
+    )
+    session.add(ref)
+    await session.commit()
+    return ref
+
+
+def _agent_auth(agent_id, org_id, project_id):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {
+            "org_id": str(org_id), "project_id": str(project_id), "api_key_id": str(uuid.uuid4()),
+        }},
+    )
+
+
+async def _setup_app(app, Session, agent_id, org_id, project_id):
+    from app.dependencies.auth import get_current_user
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return _agent_auth(agent_id, org_id, project_id)
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+# ─── AC1 — 실 왕복: 채팅 메시지의 entity:artifact 참조 → entity_references → backlinks ──
+
+@pytest.mark.anyio
+async def test_chat_message_artifact_mention_appears_in_backlinks():
+    from app.main import app
+    from app.services.mention_parser import insert_chat_mentions
+    from app.services.reference_token import build_reference_token
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            artifact = await _seed_artifact(s, org_id, project_id, agent_id)
+            conv_id = await _seed_conversation(s, org_id, project_id, [agent_id], created_by=agent_id)
+
+            # 실 send_message() 경로는 ConversationMessage를 먼저 만든 뒤 그 id로
+            # insert_chat_mentions를 부른다(mention_parser.py는 참조-write 헬퍼일 뿐 메시지
+            # 자체를 만들지 않는다) — 여기서도 같은 순서로 진짜 메시지 행을 먼저 심는다.
+            token = build_reference_token("artifact", artifact.id, artifact.title)
+            msg = await _seed_message(s, conv_id, agent_id, content=f"참고: {token}")
+            result = await insert_chat_mentions(
+                s, org_id=org_id, message_id=msg.id, content=msg.content, created_by=agent_id,
+            )
+            await s.commit()
+            assert result.stored == 1, "그라운딩이 확認한 WRITE 배선 자체가 회귀하면 여기서 잡힌다"
+            msg_id = msg.id
+
+        await _setup_app(app, Session, agent_id, org_id, project_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/visual-artifacts/{artifact.id}/backlinks")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            source_ids = {item["source_id"] for item in body["data"]}
+            assert str(msg_id) in source_ids
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── AC3 — 기존 참조 계약 무회귀(#2679 origin 필터) ─────────────────────────────
+
+@pytest.mark.anyio
+async def test_backlinks_excludes_auto_origin_includes_explicit():
+    """#2679가 세운 origin 필터가 artifact target에도 동형 적용되는지 — story/doc 대상으로 이미
+    검증된 필터 로직을 target_type 파라미터만 바꿔 재사용하는 것이라(재구현 0) 이 축이 새로
+    깨질 이유는 구조적으로 없지만, "artifact를 처음 여는 이 PR이 그 불변식을 실제로 상속받는가"
+    자체가 이 스토리 AC3의 요구사항이라 직접 확認한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            artifact = await _seed_artifact(s, org_id, project_id, agent_id)
+            conv_id = await _seed_conversation(s, org_id, project_id, [agent_id], created_by=agent_id)
+            auto_msg = await _seed_message(s, conv_id, agent_id, content="auto")
+            explicit_msg = await _seed_message(s, conv_id, agent_id, content="explicit")
+
+            await _make_reference(
+                s, org_id, "chat_message", auto_msg.id, "artifact", artifact.id, agent_id, origin="auto",
+            )
+            await _make_reference(
+                s, org_id, "chat_message", explicit_msg.id, "artifact", artifact.id, agent_id,
+                origin="explicit",
+            )
+
+        await _setup_app(app, Session, agent_id, org_id, project_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/visual-artifacts/{artifact.id}/backlinks")
+            assert resp.status_code == 200, resp.text
+            source_ids = {item["source_id"] for item in resp.json()["data"]}
+            assert str(auto_msg.id) not in source_ids, "auto 참조가 새면 #2679 회귀"
+            assert str(explicit_msg.id) in source_ids, "explicit 참조는 그대로 떠야 함"
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── AC4 — 존재/접근 게이트(existence-non-disclosure) ──────────────────────────
+
+@pytest.mark.anyio
+async def test_nonexistent_artifact_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        await _setup_app(app, Session, agent_id, org_id, project_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/visual-artifacts/{uuid.uuid4()}/backlinks")
+            assert resp.status_code == 404
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_artifact_in_other_project_returns_404_not_cross_project_leak():
+    """SEC-S8류(story 83ea3d6a) 선례 — org는 같은데 project가 다른 artifact_id를 직접 조회하면
+    404(existence-non-disclosure, `_get_artifact_or_404`의 org_id+project_id 이중 필터 그대로
+    상속). 이 스토리가 새 크로스-project 구멍을 열지 않는지 실측."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_a = await _seed_org_project(s)
+            from app.models.project import Project
+            project_b = Project(id=uuid.uuid4(), org_id=org_id, name="ProjectB")
+            s.add(project_b)
+            await s.commit()
+
+            agent_in_a = await _seed_agent(s, org_id, project_a)
+            artifact_in_b = await _seed_artifact(s, org_id, project_b.id, agent_in_a)
+
+        await _setup_app(app, Session, agent_in_a, org_id, project_a)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/visual-artifacts/{artifact_in_b.id}/backlinks")
+            assert resp.status_code == 404
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story #2721 [아티팩트·원장 1급화 1단]. 그라운딩 결과 entity_references WRITE는 `reference_registry.ENTITY_RESOLVERS`에 artifact가 이미 등재돼 있었다 — 이 PR의 신규 작업은 READ(backlinks 조회) 축뿐.
- BE: `backlinks.py`의 `BACKLINKS_ALLOWED_TARGET_TYPES`+`_ZERO_REF_MODELS` 양쪽에 artifact 페어링 추가(한쪽만 추가하면 KeyError 크래시 — 신규 가드테스트로 봉합). `visual_artifacts.py`에 `GET /{id}/backlinks` 신설(`_get_artifact_or_404`+`list_entity_backlinks`+`_ok` 재사용, 신규 인가로직 0).
- FE: proxy route `apps/web/src/app/api/visual-artifacts/[id]/backlinks/route.ts` 신설(stories/docs 프록시와 동형) + `entity-backlinks-section.tsx`의 `ENTITY_ROUTE_SEGMENT`에 artifact 등록 + `artifact-viewer.tsx`(실 상세 표면 — `ArtifactExpandDialog`는 순수 프리뷰라 제외)에 마운트.

## 이름+수 양축 스윕 체크
- 이번 변경은 기존 enum류(gate_type/tool name 등) 값 추가가 아니라 신규 target_type 1건 추가 — 영향받는 레지스트리는 `BACKLINKS_ALLOWED_TARGET_TYPES`(name-keyed)와 `_ZERO_REF_MODELS`(name-keyed dict) 2개뿐, 하드코딩 count 어서션은 grep으로 확인 결과 없음(`test_2266_story_backlinks_realdb.py`의 `test_backlinks_allowlist_contains_exactly_doc_and_story`가 유일한 count성 테스트라 3-member로 직접 갱신 완료).
- FE `ENTITY_ROUTE_SEGMENT`도 동형 name-keyed map — count 어서션 없음, 갱신 완료.

## Test plan
- [x] `test_2721_artifact_backlinks_realdb.py` 신규 4건(AC1 실왕복/AC3 origin 필터 무회귀/AC4 404×2) 실PG 그린
- [x] `test_2266_story_backlinks_realdb.py`의 allowlist count 테스트 갱신 + 신규 `test_zero_ref_models_key_set_matches_allowlist`(페어링 가드) — mutation-kill 확인
- [x] mutation-kill: 엔드포인트에서 artifact를 allowlist에서 빼면 미처리 500(기존 stories/docs 동형 선례, 신규 갭 아님) 확인
- [x] FE: `bunx tsc --noEmit` 클린(무관 기존 에러 1건만), `bunx eslint` 클린
- [ ] CI

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>