### PR TITLE
[SID:2722] evidence·게이트 근거가 아티팩트 특정 버전을 가리키게 — 버전 pin

### DIFF
--- a/apps/web/src/components/verify/evidence-section.test.tsx
+++ b/apps/web/src/components/verify/evidence-section.test.tsx
@@ -198,3 +198,96 @@ describe('EvidenceSection — 증거 연결 POST(긴급 정정 2026-07-28: 봉�
     expect(container.textContent).toContain('증거 연결 실패');
   });
 });
+
+describe('EvidenceSection — 아티팩트 버전 pin(story #2722 AC2)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => { root.unmount(); });
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('artifact_id+artifact_version_number가 있는 evidence는 링크가 아니라 버튼(그 버전 열기)으로 렌더된다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/evidence?')) {
+        return new Response(JSON.stringify({
+          data: [{
+            id: 'ev-artifact-1', org_id: 'org-1', work_item_id: 's1', work_item_type: 'story',
+            type: 'report', ref: 'entity:artifact:art-1', source: null, note: '재검증 근거',
+            created_by: 'member-1', created_at: '2026-08-17T00:00:00Z',
+            artifact_version_id: 'ver-2', artifact_id: 'art-1', artifact_version_number: 2,
+          }],
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response('{}', { status: 200 });
+    }));
+    await act(async () => {
+      root.render(wrap(
+        <EvidenceSection workItemId="s1" workItemType="story" selfReported={true} humanVerified={null} humanVerifiedBy={null} humanVerifiedAt={null} />,
+      ));
+    });
+    const toggleBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('근거 보기'));
+    await act(async () => { toggleBtn!.click(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('재검증 근거');
+    const anchors = Array.from(container.querySelectorAll('a')).filter((a) => a.textContent?.includes('재검증 근거'));
+    expect(anchors).toHaveLength(0); // <a href=ref>로 렌더되면 안 됨(외부 링크 아니라 버전 pin 열기)
+    const evidenceBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('재검증 근거'));
+    expect(evidenceBtn).toBeTruthy();
+  });
+
+  it('클릭하면 pin된 버전(latest 아님)으로 아티팩트 상세를 조회한다', async () => {
+    const versionDetailCalls: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/evidence?')) {
+        return new Response(JSON.stringify({
+          data: [{
+            id: 'ev-artifact-1', org_id: 'org-1', work_item_id: 's1', work_item_type: 'story',
+            type: 'report', ref: 'entity:artifact:art-1', source: null, note: '재검증 근거',
+            created_by: 'member-1', created_at: '2026-08-17T00:00:00Z',
+            artifact_version_id: 'ver-1', artifact_id: 'art-1', artifact_version_number: 1,
+          }],
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url.includes('/versions/1')) {
+        versionDetailCalls.push(url);
+        return new Response(JSON.stringify({
+          data: {
+            id: 'art-1', title: '재검증 대상', story_id: 's1', epic_id: null, doc_id: null,
+            source: 'created', latest_version_number: 3, anchor_version: null,
+            created_by: 'member-1', created_at: '2026-08-17T00:00:00Z',
+            version_number: 1, version_summary: 'v1',
+            nodes: [{ id: 'n1', type: 'html_blob', props: { html: '<div>v1</div>' }, parent_id: null, sort_order: 0 }],
+          },
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url.includes('/versions')) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    }));
+    await act(async () => {
+      root.render(wrap(
+        <EvidenceSection workItemId="s1" workItemType="story" selfReported={true} humanVerified={null} humanVerifiedBy={null} humanVerifiedAt={null} />,
+      ));
+    });
+    const toggleBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('근거 보기'));
+    await act(async () => { toggleBtn!.click(); await Promise.resolve(); await Promise.resolve(); });
+
+    const evidenceBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('재검증 근거'));
+    await act(async () => { evidenceBtn!.click(); await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    // artifact_version_number=1(pin된 값)로 조회했는지 — latest(3)로 조회했으면 이 스토리의
+    // 존재 이유(«그 시각 고정») 자체가 깨진다.
+    expect(versionDetailCalls.some((u) => u.includes('/art-1/versions/1'))).toBe(true);
+  });
+});

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -3,12 +3,18 @@
 import { useCallback, useState } from 'react';
 import {
   Check, ChevronDown, ChevronUp, ExternalLink, Link2, Paperclip, Plus,
-  GitPullRequest, Rocket, TrendingUp, FileText, CheckCircle2,
+  GitPullRequest, Rocket, TrendingUp, FileText, CheckCircle2, Frame,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { formatRelativeTime } from '@/lib/storage/format';
 import { deriveTrustStage, type EvidenceItem, type EvidenceType } from '@/services/verify';
+import {
+  adaptArtifactDetail, getArtifactVersionDetail,
+  type ArtifactFormat, type BeArtifactVersionSummary,
+} from '@/services/canvas';
+import { ArtifactExpandDialog } from '@/components/canvas/artifact-expand-dialog';
+import { type GalleryTimelineVersion } from '@/components/canvas/artifact-gallery-timeline';
 
 const VISIBLE_LIMIT = 4;
 
@@ -93,6 +99,37 @@ export function EvidenceSection({
     if (!expanded && items === null) { void fetchEvidence(); }
     setExpanded((v) => !v);
   };
+
+  // story #2722(아티팩트·evidence 버전 pin, AC2) — evidence가 아티팩트를 근거로 삼았으면
+  // "그 시각 고정된 버전"으로 열린다(현행 최신이 아니라). artifact-gallery-view.tsx의
+  // handleOpenArtifact/ArtifactExpandDialog 왕복을 그대로 재사용(새 발명 0).
+  const [expandTarget, setExpandTarget] = useState<{
+    artifactId: string; format: ArtifactFormat; content: string; title: string;
+    canvasBounds?: { w: number; h: number } | null;
+    versionNumber: number; versions: GalleryTimelineVersion[];
+  } | null>(null);
+
+  const handleOpenArtifact = useCallback(async (artifactId: string, versionNumber: number, title: string) => {
+    const [detail, versionListRes] = await Promise.all([
+      getArtifactVersionDetail(artifactId, versionNumber),
+      fetch(`/api/visual-artifacts/${artifactId}/versions`),
+    ]);
+    if (!detail) return;
+    const { artifact, versions } = adaptArtifactDetail(detail);
+    const content = versions[0]?.content;
+    if (!content) return;
+    const versionList: BeArtifactVersionSummary[] = versionListRes.ok
+      ? ((await versionListRes.json()) as { data?: BeArtifactVersionSummary[] }).data ?? []
+      : [];
+    const mappedVersions: GalleryTimelineVersion[] = versionList
+      .slice()
+      .sort((a, b) => a.version_number - b.version_number)
+      .map((v) => ({ versionNumber: v.version_number, summary: v.summary, isAnchor: v.version_number === artifact.anchor_version }));
+    setExpandTarget({
+      artifactId, format: artifact.format, content, title,
+      canvasBounds: versions[0]?.canvasBounds, versionNumber, versions: mappedVersions,
+    });
+  }, []);
 
   // story #2258 — 증거연결: BE(create_evidence)는 이미 있었는데 화면이 부르지 않던 경로.
   const [showAddForm, setShowAddForm] = useState(false);
@@ -193,11 +230,26 @@ export function EvidenceSection({
                     const Icon = TYPE_ICON[item.type] ?? Link2;
                     const linkable = isLinkableRef(item.ref);
                     const primaryText = item.note || item.ref;
+                    // story #2722(AC2) — 아티팩트 근거는 그 시각 고정된 버전으로 열린다(현행
+                    // 최신 아님). artifact_version_id가 null이면 "버전 미상"인 구 데이터라
+                    // 이 분기를 못 타고 기존 링크/텍스트 렌더로 폴백한다(정직 표기).
+                    const pinnedArtifact = item.artifact_id != null && item.artifact_version_number != null
+                      ? { id: item.artifact_id, versionNumber: item.artifact_version_number }
+                      : null;
                     return (
                       <li key={item.id} className="flex items-start gap-2 rounded-md px-1.5 py-1 hover:bg-muted/40">
                         <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
                         <div className="min-w-0 flex-1">
-                          {linkable ? (
+                          {pinnedArtifact ? (
+                            <button
+                              type="button"
+                              onClick={() => void handleOpenArtifact(pinnedArtifact.id, pinnedArtifact.versionNumber, primaryText)}
+                              className="flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
+                            >
+                              <span className="truncate">{primaryText}</span>
+                              <Frame className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden />
+                            </button>
+                          ) : linkable ? (
                             <a
                               href={item.ref}
                               target="_blank"
@@ -290,6 +342,19 @@ export function EvidenceSection({
           </div>
         ) : null}
       </div>
+      {expandTarget ? (
+        <ArtifactExpandDialog
+          open={expandTarget !== null}
+          onOpenChange={(next) => { if (!next) setExpandTarget(null); }}
+          title={expandTarget.title}
+          format={expandTarget.format}
+          content={expandTarget.content}
+          canvasBounds={expandTarget.canvasBounds}
+          versions={expandTarget.versions}
+          selectedVersion={expandTarget.versionNumber}
+          onSelectVersion={(versionNumber) => void handleOpenArtifact(expandTarget.artifactId, versionNumber, expandTarget.title)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/services/canvas';
 import { ArtifactExpandDialog } from '@/components/canvas/artifact-expand-dialog';
 import { type GalleryTimelineVersion } from '@/components/canvas/artifact-gallery-timeline';
+import { fetchWithAuth } from '@/lib/db/client';
 
 const VISIBLE_LIMIT = 4;
 
@@ -112,7 +113,7 @@ export function EvidenceSection({
   const handleOpenArtifact = useCallback(async (artifactId: string, versionNumber: number, title: string) => {
     const [detail, versionListRes] = await Promise.all([
       getArtifactVersionDetail(artifactId, versionNumber),
-      fetch(`/api/visual-artifacts/${artifactId}/versions`),
+      fetchWithAuth(`/api/visual-artifacts/${artifactId}/versions`),
     ]);
     if (!detail) return;
     const { artifact, versions } = adaptArtifactDetail(detail);

--- a/apps/web/src/services/verify.ts
+++ b/apps/web/src/services/verify.ts
@@ -16,6 +16,11 @@ export interface EvidenceItem {
   org_id: string;
   work_item_id: string;
   work_item_type: 'story' | 'task';
+  /** story #2722 — 아티팩트를 근거로 삼은 evidence만 채워짐. artifact_version_id가 null이면
+   * 나머지 둘도 null(버전 미상 — 구 데이터 또는 아티팩트 근거 아님). */
+  artifact_version_id: string | null;
+  artifact_id: string | null;
+  artifact_version_number: number | null;
 }
 
 /**

--- a/backend/alembic/versions/0254_evidence_artifact_version_pin.py
+++ b/backend/alembic/versions/0254_evidence_artifact_version_pin.py
@@ -1,0 +1,54 @@
+"""story #2722(아티팩트·evidence 버전 pin) — evidence.artifact_version_id 신설.
+
+evidence가 아티팩트를 근거로 삼을 때 지금은 `ref`(자유형식 텍스트, `entity:artifact:<uuid>`
+또는 claude.ai 링크 등 무엇이든 들어갈 수 있음)뿐이라 "어느 버전을 봤는가"가 원장에 안
+남는다 — 아티팩트가 그 뒤 새 버전으로 바뀌면 근거가 조용히 달라져 보인다.
+
+FK는 `artifact_versions.id` 하나만 둔다(`visual_artifact_id`를 evidence에 별도로 두지
+않음) — `artifact_versions.artifact_id`가 NOT NULL FK로 이미 `visual_artifacts.id`를
+함의하므로, 별도 컬럼은 비정규화(같은 사실을 두 곳에 저장)가 된다. 조회는 evidence→
+artifact_versions(1-hop)→visual_artifacts(1-hop)로 충분.
+
+nullable, ON DELETE SET NULL: 이 스토리는 신규 evidence부터 pin을 시작하는 것이 목적이고
+소급 백필은 스코프 밖(PO 판정, 2026-08-17) — 기존 행은 전부 NULL(=버전 미상)로 정직하게
+남는다. 아티팩트/버전이 나중에 삭제돼도 evidence 행 자체는 살아있어야 하므로 CASCADE가
+아니라 SET NULL(근거였다는 사실 자체는 evidence.ref에 여전히 남을 수 있으니 파괴 안 함).
+
+Revision ID: 0254
+Revises: 0253
+Create Date: 2026-08-17
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0254"
+down_revision = "0253"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "evidence",
+        sa.Column("artifact_version_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_evidence_artifact_version_id",
+        "evidence",
+        "artifact_versions",
+        ["artifact_version_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_evidence_artifact_version_id",
+        "evidence",
+        ["artifact_version_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_evidence_artifact_version_id", table_name="evidence")
+    op.drop_constraint("fk_evidence_artifact_version_id", "evidence", type_="foreignkey")
+    op.drop_column("evidence", "artifact_version_id")

--- a/backend/app/models/evidence.py
+++ b/backend/app/models/evidence.py
@@ -7,7 +7,7 @@ done의 검사지가 아니라 에이전트가 자기 완결을 표현하는 서
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, String, Text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -34,4 +34,11 @@ class Evidence(Base):
     created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    # story #2722(아티팩트·evidence 버전 pin) — 이 evidence가 아티팩트를 근거로 삼을 때
+    # "그 시각의 그 버전"을 고정한다. artifact_versions.artifact_id가 이미 visual_artifacts를
+    # 함의하므로 별도 visual_artifact_id 컬럼은 안 둔다(비정규화 회피). NULL=버전 미상
+    # (구 데이터이거나 아티팩트를 근거로 안 삼은 evidence) — 소급 백필 없음.
+    artifact_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("artifact_versions.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/routers/evidence.py
+++ b/backend/app/routers/evidence.py
@@ -11,6 +11,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.evidence import _CLIENT_CREATABLE_TYPES, Evidence
 from app.models.pm import Story, Task
+from app.models.visual_artifact import ArtifactVersion, VisualArtifact
 from app.services.member_resolver import resolve_member
 from app.services.project_auth import has_project_access
 from app.services.reference_registry import _project_id_of_evidence
@@ -27,6 +28,12 @@ class EvidenceCreateRequest(BaseModel):
     ref: str
     source: str | None = None
     note: str | None = None
+    # story #2722(아티팩트·evidence 버전 pin) — 이 evidence가 아티팩트를 근거로 삼을 때
+    # 명시 필드로 준다(ref 문자열을 서버가 파싱해 추측하지 않는다 — 파싱 실패 시 조용한
+    # 미기입 위험을 피하려는 의도적 선택, story 상신 스케치 참고). 버전은 여기서 선택하지
+    # 않는다 — "그 시각의 latest"를 서버가 항상 resolve해 고정한다(③pin 시점 규칙, 클라
+    # 위임 시 취지가 샌다).
+    artifact_id: uuid.UUID | None = None
 
     @field_validator("work_item_type")
     @classmethod
@@ -53,6 +60,15 @@ class EvidenceResponse(BaseModel):
     org_id: uuid.UUID
     work_item_id: uuid.UUID
     work_item_type: str
+    artifact_version_id: uuid.UUID | None = None
+    """story #2722 — NULL="버전 미상"(구 데이터 또는 아티팩트 근거 아님), 값 있으면 evidence
+    생성 시각에 서버가 고정한 그 버전."""
+    artifact_id: uuid.UUID | None = None
+    artifact_version_number: int | None = None
+    """story #2722 — artifact_version_id 하나로는 FE가 기존 ArtifactExpandDialog 왕복
+    (artifactId+versionNumber 필요, artifact-gallery-view.tsx의 handleOpenArtifact와 동일
+    계약)을 못 채운다 — evidence.artifact_version_id → artifact_versions 1-hop 조인 결과를
+    denorm으로 얹는다(둘 다 artifact_version_id가 있을 때만 채워짐, 새 컬럼 아님)."""
     type: str
     ref: str
     source: str | None
@@ -86,9 +102,14 @@ class EvidenceResponse(BaseModel):
 async def _assert_work_item_access(
     session: AsyncSession, work_item_id: uuid.UUID, work_item_type: str,
     caller_id: uuid.UUID, org_id: uuid.UUID,
-) -> None:
+) -> uuid.UUID:
     """work_item 존재 + caller의 project 접근권 검증(mutation 대상 project-scope 강제
-    — [[feedback_mutation_target_resource_project_scope]] 동형)."""
+    — [[feedback_mutation_target_resource_project_scope]] 동형).
+
+    story #2722 — project_id를 반환하도록 확장(기존 호출부는 반환값 무시라 무회귀).
+    create_evidence가 artifact_id를 받을 때 그 아티팩트가 이 work_item과 같은
+    project 소속인지 검증하는 데 재사용(cross-project artifact 근거 금지 —
+    _get_artifact_or_404의 project_id 필터와 동일 근거, visual_artifacts.py:190-200 참고)."""
     if work_item_type == "story":
         story = (await session.execute(
             select(Story).where(Story.id == work_item_id, Story.org_id == org_id)
@@ -112,6 +133,60 @@ async def _assert_work_item_access(
     if not await has_project_access(session, caller_id, project_id, org_id):
         raise HTTPException(status_code=403, detail="No access to this project")
 
+    return project_id
+
+
+async def _resolve_latest_artifact_version_id(
+    session: AsyncSession, artifact_id: uuid.UUID, org_id: uuid.UUID, project_id: uuid.UUID,
+) -> uuid.UUID:
+    """story #2722 — evidence 생성 시각의 latest ArtifactVersion을 서버가 조회해 고정한다
+    (③pin 시점 규칙: 클라이언트에 버전 선택을 맡기면 "그 순간 최신을 근거로 봤다"는 취지가
+    샌다). org_id+project_id로 스코프(cross-org/cross-project artifact 근거 금지 —
+    visual_artifacts.py:_get_artifact_or_404와 동일 근거)."""
+    artifact = (await session.execute(
+        select(VisualArtifact).where(
+            VisualArtifact.id == artifact_id, VisualArtifact.org_id == org_id,
+            VisualArtifact.project_id == project_id, VisualArtifact.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if artifact is None:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+
+    latest = (await session.execute(
+        select(ArtifactVersion).where(ArtifactVersion.artifact_id == artifact_id)
+        .order_by(ArtifactVersion.version_number.desc()).limit(1)
+    )).scalar_one_or_none()
+    if latest is None:
+        raise HTTPException(status_code=404, detail="Artifact has no versions")
+    return latest.id
+
+
+async def _attach_artifact_denorm(
+    session: AsyncSession, items: list[Evidence],
+) -> list[EvidenceResponse]:
+    """story #2722 — artifact_version_id가 있는 evidence들의 artifact_id/version_number를
+    한 번의 IN 쿼리로 조회해 붙인다(리스트 크기만큼 N+1 안 함)."""
+    version_ids = {e.artifact_version_id for e in items if e.artifact_version_id is not None}
+    version_map: dict[uuid.UUID, ArtifactVersion] = {}
+    if version_ids:
+        rows = (await session.execute(
+            select(ArtifactVersion).where(ArtifactVersion.id.in_(version_ids))
+        )).scalars().all()
+        version_map = {v.id: v for v in rows}
+
+    out = []
+    for e in items:
+        version = version_map.get(e.artifact_version_id) if e.artifact_version_id else None
+        out.append(
+            EvidenceResponse.model_validate(e, from_attributes=True).model_copy(
+                update={
+                    "artifact_id": version.artifact_id if version else None,
+                    "artifact_version_number": version.version_number if version else None,
+                }
+            )
+        )
+    return out
+
 
 @router.post("", response_model=EvidenceResponse, status_code=201)
 async def create_evidence(
@@ -119,15 +194,24 @@ async def create_evidence(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
-) -> Evidence:
+) -> EvidenceResponse:
     caller = await resolve_member(auth, org_id, session)
-    await _assert_work_item_access(session, body.work_item_id, body.work_item_type, caller.id, org_id)
+    project_id = await _assert_work_item_access(
+        session, body.work_item_id, body.work_item_type, caller.id, org_id
+    )
+
+    artifact_version_id = None
+    if body.artifact_id is not None:
+        artifact_version_id = await _resolve_latest_artifact_version_id(
+            session, body.artifact_id, org_id, project_id
+        )
 
     evidence = Evidence(
         id=uuid.uuid4(),
         org_id=org_id,
         work_item_id=body.work_item_id,
         work_item_type=body.work_item_type,
+        artifact_version_id=artifact_version_id,
         type=body.type,
         ref=body.ref,
         source=body.source,
@@ -137,7 +221,8 @@ async def create_evidence(
     session.add(evidence)
     await session.commit()
     await session.refresh(evidence)
-    return evidence
+    [denorm] = await _attach_artifact_denorm(session, [evidence])
+    return denorm
 
 
 @router.get("", response_model=list[EvidenceResponse])
@@ -147,7 +232,7 @@ async def list_evidence(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
-) -> list[Evidence]:
+) -> list[EvidenceResponse]:
     if work_item_type not in _WORK_ITEM_TYPES:
         raise HTTPException(status_code=400, detail=f"work_item_type must be one of {sorted(_WORK_ITEM_TYPES)}")
 
@@ -161,7 +246,8 @@ async def list_evidence(
             Evidence.work_item_type == work_item_type,
         ).order_by(Evidence.created_at.asc())
     )
-    return list(result.scalars().all())
+    items = list(result.scalars().all())
+    return await _attach_artifact_denorm(session, items)
 
 
 @router.get("/{id}", response_model=EvidenceResponse)
@@ -199,7 +285,8 @@ async def get_evidence(
     org_slug = await resolve_org_slug(session, org_id)
     project_slug_map = await resolve_project_slugs(session, {project_id})
 
-    return EvidenceResponse.model_validate(evidence, from_attributes=True).model_copy(
+    [denorm] = await _attach_artifact_denorm(session, [evidence])
+    return denorm.model_copy(
         update={
             "resolved_story_id": resolved_story_id,
             "org_slug": org_slug,

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -658,7 +658,9 @@ _TOOL_DEFS: list[tuple] = [
     # Evidence 자기증명 (1) — E-VERIFY V0-S1
     ("sprintable_add_evidence",
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"
-     " 남김. 선택제(첨부 안 해도 무불이익).",
+     " 남김. 선택제(첨부 안 해도 무불이익). 아티팩트를 근거로 삼을 땐 artifact_id를 같이 주면"
+     " 그 시각의 버전이 자동 고정된다(그 뒤 아티팩트가 새 버전으로 바뀌어도 이 evidence의"
+     " 근거는 안 흔들림).",
      AddEvidenceInput, add_evidence),
     # 판단 칸 (2) — story #2268(D단계, E-CONNECT)
     ("sprintable_add_judgment",

--- a/backend/sprintable_mcp/tools/evidence.py
+++ b/backend/sprintable_mcp/tools/evidence.py
@@ -15,6 +15,11 @@ class AddEvidenceInput(SprintableInput):
     ref: str
     source: str | None = None
     note: str | None = None
+    # story #2722(아티팩트·evidence 버전 pin) — 이 evidence가 아티팩트를 근거로 삼을 때 그
+    # 아티팩트의 id. 버전은 여기서 고르지 않는다 — 서버가 이 호출 시각의 latest 버전을
+    # 조회해 고정한다(같은 아티팩트가 나중에 새 버전으로 바뀌어도 이 evidence의 근거는
+    # 그대로 남는다).
+    artifact_id: str | None = None
 
 
 async def add_evidence(args: AddEvidenceInput) -> list[TextContent]:
@@ -31,6 +36,8 @@ async def add_evidence(args: AddEvidenceInput) -> list[TextContent]:
             payload["source"] = args.source
         if args.note is not None:
             payload["note"] = args.note
+        if args.artifact_id is not None:
+            payload["artifact_id"] = args.artifact_id
         result = await client.post("/api/v2/evidence", json=payload)
         return ok(result)
     except Exception as exc:

--- a/backend/tests/test_2722_evidence_artifact_version_pin_realdb.py
+++ b/backend/tests/test_2722_evidence_artifact_version_pin_realdb.py
@@ -114,7 +114,7 @@ def _auth_override(member_id, org_id):
 
 async def _setup_app(app, Session, member_id, org_id):
     from app.dependencies.auth import get_current_user, get_verified_org_id
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     async def _db():
         async with Session() as s:
@@ -123,7 +123,7 @@ async def _setup_app(app, Session, member_id, org_id):
     async def _org():
         return org_id
 
-    app.dependency_overrides[get_db] = _db
+    override_db_and_read(app, _db)
     app.dependency_overrides[get_current_user] = _auth_override(member_id, org_id)
     app.dependency_overrides[get_verified_org_id] = _org
 

--- a/backend/tests/test_2722_evidence_artifact_version_pin_realdb.py
+++ b/backend/tests/test_2722_evidence_artifact_version_pin_realdb.py
@@ -1,0 +1,277 @@
+"""story #2722(아티팩트·evidence 버전 pin) — evidence가 아티팩트를 근거로 삼을 때 그 시각의
+버전을 서버가 resolve해 고정하는지 실 Postgres로 검증.
+
+test_e_verify_v0_s1_evidence_realdb.py와 동형 셋업(팀레벨 뷰 의존이라 create_all 부적합)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요 — alembic upgrade heads 적용된 DB"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org + project + agent(grant된) + story + artifact(2버전)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.pm import Story
+    from app.models.visual_artifact import ArtifactVersion, VisualArtifact
+
+    org = Organization(id=uuid.uuid4(), name="2722 Org", slug=f"s2722-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="2722 Project")
+    other_project = Project(id=uuid.uuid4(), org_id=org.id, name="2722 Other Project")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Evidence Agent", is_active=True)
+    session.add_all([project, other_project, agent])
+    await session.commit()
+
+    grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    other_grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=other_project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    session.add_all([grant, other_grant])
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="2722 Story", status="in-progress")
+    session.add(story)
+    await session.commit()
+
+    artifact = VisualArtifact(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="2722 Artifact",
+        latest_version_number=2,
+    )
+    other_project_artifact = VisualArtifact(
+        id=uuid.uuid4(), org_id=org.id, project_id=other_project.id, title="2722 Other-Project Artifact",
+    )
+    session.add_all([artifact, other_project_artifact])
+    await session.commit()
+
+    v1 = ArtifactVersion(id=uuid.uuid4(), artifact_id=artifact.id, version_number=1)
+    v2 = ArtifactVersion(id=uuid.uuid4(), artifact_id=artifact.id, version_number=2)
+    other_v1 = ArtifactVersion(id=uuid.uuid4(), artifact_id=other_project_artifact.id, version_number=1)
+    session.add_all([v1, v2, other_v1])
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "agent_id": agent.id,
+        "story_id": story.id, "artifact_id": artifact.id,
+        "v1_id": v1.id, "v2_id": v2.id,
+        "other_project_artifact_id": other_project_artifact.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _auth_override(member_id, org_id):
+    async def _auth():
+        from app.dependencies.auth import AuthContext
+        return AuthContext(
+            user_id=str(member_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+    return _auth
+
+
+async def _setup_app(app, Session, member_id, org_id):
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            yield s
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth_override(member_id, org_id)
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_evidence_with_artifact_id_pins_latest_version():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seed = await _seed(s)
+
+        await _setup_app(app, Session, seed["agent_id"], seed["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(seed["story_id"]), "work_item_type": "story",
+                "type": "report", "ref": "entity:artifact:" + str(seed["artifact_id"]),
+                "artifact_id": str(seed["artifact_id"]),
+            })
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            # 시딩 시점 latest는 v2(version_number=2) — v1이 아니라 v2가 고정돼야 한다.
+            assert body["artifact_version_id"] == str(seed["v2_id"])
+            # FE가 ArtifactExpandDialog 왕복(artifactId+versionNumber)에 쓰는 denorm 필드.
+            assert body["artifact_id"] == str(seed["artifact_id"])
+            assert body["artifact_version_number"] == 2
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_evidence_without_artifact_id_leaves_version_unpinned():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seed = await _seed(s)
+
+        await _setup_app(app, Session, seed["agent_id"], seed["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(seed["story_id"]), "work_item_type": "story",
+                "type": "url", "ref": "https://example.com/unrelated",
+            })
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["artifact_version_id"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_new_version_after_evidence_created_does_not_retroactively_change_pin():
+    """③pin 시점 규칙의 핵심 — evidence 생성 後 아티팩트가 v3로 바뀌어도 이미 생성된
+    evidence의 artifact_version_id는 v2(생성 당시 latest)에 그대로 고정돼야 한다."""
+    from app.main import app
+    from app.models.visual_artifact import ArtifactVersion
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seed = await _seed(s)
+
+        await _setup_app(app, Session, seed["agent_id"], seed["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(seed["story_id"]), "work_item_type": "story",
+                "type": "report", "ref": "entity:artifact:" + str(seed["artifact_id"]),
+                "artifact_id": str(seed["artifact_id"]),
+            })
+            evidence_id = resp.json()["id"]
+            assert resp.json()["artifact_version_id"] == str(seed["v2_id"])
+
+            async with Session() as s:
+                v3 = ArtifactVersion(id=uuid.uuid4(), artifact_id=seed["artifact_id"], version_number=3)
+                s.add(v3)
+                await s.commit()
+
+            get_resp = await client.get(f"/api/v2/evidence/{evidence_id}")
+            assert get_resp.status_code == 200
+            assert get_resp.json()["artifact_version_id"] == str(seed["v2_id"]), (
+                "pin은 생성 시각 고정 — 이후 신규 버전이 조용히 근거를 바꿔선 안 된다"
+            )
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_project_artifact_id_rejected():
+    """agent가 접근권을 가진 다른 project 소속이라도 work_item과 다른 project의 artifact를
+    근거로 못 삼는다(cross-project artifact 근거 금지, visual_artifacts.py:_get_artifact_or_404
+    와 동일 근거) — 404(존재 비노출)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seed = await _seed(s)
+
+        await _setup_app(app, Session, seed["agent_id"], seed["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(seed["story_id"]), "work_item_type": "story",
+                "type": "report", "ref": "cross-project-attempt",
+                "artifact_id": str(seed["other_project_artifact_id"]),
+            })
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_artifact_id_rejected():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seed = await _seed(s)
+
+        await _setup_app(app, Session, seed["agent_id"], seed["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(seed["story_id"]), "work_item_type": "story",
+                "type": "report", "ref": "fake",
+                "artifact_id": str(uuid.uuid4()),
+            })
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## 배경

[아티팩트·evidence 버전 pin](entity:story:61c53944-d6ec-4429-ae34-fda6a24ca3a4) — 지금까지 evidence가 아티팩트를 근거로 삼아도 `ref`(자유형식 텍스트)뿐이라 "어느 버전이 판정 근거였는지" 원장에 안 남았다. 카디르 그라운딩 스케치(스토리 상신·PO 승인, 2026-08-17) 그대로 구현.

## 설계 요지(스케치 그대로)

- **FK 단일**: `evidence.artifact_version_id`(nullable UUID FK → `artifact_versions.id`)만 신설. `artifact_versions.artifact_id`가 이미 `visual_artifacts`를 함의하므로 별도 컬럼 안 둠(비정규화 회피).
- **pin 시점 규칙**: 클라이언트가 버전을 고르지 않는다 — `POST /api/v2/evidence`가 `artifact_id`(선택)를 받으면 **그 호출 시각의 latest ArtifactVersion을 서버가 조회해 고정**한다. 클라 위임 시 "그 순간 최신을 근거로 봤다"는 취지가 샌다.
- **미기입은 정직 표기**: 구 evidence는 `artifact_version_id=NULL`("버전 미상") 그대로 — 소급 백필 없음(마이그레이션은 nullable ADD COLUMN만).

## 변경

**BE**: migration 0254(nullable+FK+index만) · `EvidenceCreateRequest.artifact_id`(선택) · `_resolve_latest_artifact_version_id`(cross-project 404) · `EvidenceResponse`에 `artifact_version_id`/`artifact_id`/`artifact_version_number`(뒤 둘은 FE denorm, N+1 없이 IN쿼리 1회) · MCP `sprintable_add_evidence`에 `artifact_id` 통과(신규 도구 아님).

**FE**: `evidence-section.tsx` — 아티팩트 근거는 외부 링크가 아니라 버튼으로, 클릭 시 **pin된 그 버전**으로 `ArtifactExpandDialog`가 열린다(`artifact-gallery-view.tsx`의 `handleOpenArtifact` 왕복 그대로 재사용, 새 컴포넌트 0). 구 데이터(`artifact_version_id=null`)는 기존 링크 렌더 폴백.

## 검증

- BE 신규 5(latest pin·미지정 시 null·**재생성 후 재조회해도 pin 불변**[이 스토리의 존재 이유]·cross-project 404·존재하지 않는 artifact_id 404) + evidence 회귀 64 + 전체 스위트 6443/6450 pass(7 실패는 develop 베이스라인에 이미 있던 로컬 `.mcp.json`/live-dev 의존 테스트, 무관 확인 — stash로 재확인).
- FE 신규 2(버튼 렌더+pin된 버전으로 조회, latest 아님) + verify/canvas 회귀 177/177 + tsc/eslint clean.
- 뮤테이션킬 BE(resolve-latest 제거 → 4/5 정확한 이유로 RED)+FE(분기 무력화 → 2/2 RED), 둘 다 원복 GREEN.

## AC 대조

1. ✅ evidence/게이트 근거가 artifact version id 저장(real PG 5테스트)+구 링크는 미상(NULL) 표기.
2. ✅ FE: evidence 클릭 시 해당 버전 렌더(latest 아님 — 뮤테이션킬로 직접 증명).
3. ✅ 기존 evidence 흐름 무회귀(64+177 pass).
4. 못 잡는 것: 구 evidence 소급 백필은 스코프 밖(PO 판정) — FE "버전 미상" 표기 UI 자체는 이 PR엔 없음(현재 링크 폴백이 이미 그 자리를 채움, 별도 배지가 필요하면 후속).

## QA

교차 QA 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)