### PR TITLE
fix(#2728): dev FE 빌드에 NEXT_PUBLIC_EE_ENABLED 배선 — prod 무접촉

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -159,6 +159,12 @@ jobs:
             # prod에 얹지 않는다 — develop→main 48커밋 일괄승격에 검증 안 된 롤백 플래그를
             # 섞으면 문제 발생 시 원인 격리가 안 된다. dev 실측 후 별도 판단.
             echo "sse_multiplex_enabled=false" >> "$GITHUB_OUTPUT"
+            # story #2728 후속(2026-08-17, 페드루 PO 지시) — NEXT_PUBLIC_EE_ENABLED가 이 파이프라인
+            # 어디에도 배선된 적이 없어(cloudbuild.yaml·Dockerfile 전부 무배선) dev FE billing 표면이
+            # 아예 안 떴다. prod는 이 커밋으로 무접촉(값을 새로 켜는 게 아니라 기존 동작 그대로
+            # 명시 false로 durable화만 — Toss 심사 前 결제 표면은 여전히 이 값과 무관하게
+            # platform_settings.billing_checkout_enabled 서버측 게이트가 막는다, #2728 별건 PR).
+            echo "ee_enabled=false" >> "$GITHUB_OUTPUT"
             # story #2139/#2143 후속(2026-07-23, 오르테가군 판정 — dev 게이트 GREEN 확認 後
             # 같은 날 prod 승격, "절반만 고치는 것" 방지 교정): backend 쪽을 GCE 실시간 3노드와
             # 같은 흐름에서 켠다(한쪽만 켜고 멈추면 오늘의 #2448 인시던트와 동형 반쪽 상태가
@@ -308,6 +314,12 @@ jobs:
             # 전제. 3개 소비 훅(use-sse-notifications·use-chat-sse·use-team-presence)이 이
             # 값 하나로 공유 커넥션 vs 독립 커넥션을 가른다(realtime-provider.tsx).
             echo "sse_multiplex_enabled=true" >> "$GITHUB_OUTPUT"
+            # story #2728 후속(2026-08-17, 페드루 PO 지시) — 선생님 기결정 "결제는 dev에서 구현·
+            # 검증" 집행 전제조건. NEXT_PUBLIC_EE_ENABLED가 여태 이 파이프라인 어디에도 배선된
+            # 적이 없어(cloudbuild.yaml build-arg·Dockerfile ARG 전부 무배선, grep 확認) dev FE
+            # billing 표면(settings/page.tsx의 isEEEnabled() 게이트)이 아예 렌더 안 됐다 — dev만
+            # 켠다(prod는 위 main 분기에서 명시 false, 무접촉).
+            echo "ee_enabled=true" >> "$GITHUB_OUTPUT"
             # story #2139/#2143 후속(2026-07-23, 오르테가군 판정) — "백플레인 켜기" dev 1단계.
             # PRESENCE_ONLINE_REDIS_ENABLED: DB 폴백 있음(안 깨져 있음 — 켜면 신선도 개선).
             # PRESENCE_REDIS_ENABLED(chat_presence "working"): 프로세스-로컬 dict라 GCE
@@ -366,6 +378,7 @@ jobs:
           V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED: ${{ steps.env.outputs.backend_redis_dual_publish_enabled }}
           V_BACKEND_FANOUT_WAKE_REDIS_ENABLED: ${{ steps.env.outputs.backend_fanout_wake_redis_enabled }}
           V_SSE_MULTIPLEX_ENABLED: ${{ steps.env.outputs.sse_multiplex_enabled }}
+          V_EE_ENABLED: ${{ steps.env.outputs.ee_enabled }}
           V_BACKEND_PRESENCE_REDIS_ENABLED: ${{ steps.env.outputs.backend_presence_redis_enabled }}
           V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED: ${{ steps.env.outputs.backend_presence_online_redis_enabled }}
           V_BACKEND_SSE_LEASE_REDIS_ENABLED: ${{ steps.env.outputs.backend_sse_lease_redis_enabled }}
@@ -374,7 +387,7 @@ jobs:
           V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED: ${{ steps.env.outputs.backend_sse_transient_replay_enabled }}
           V_MCP_ALLOWED_HOSTS: ${{ steps.env.outputs.mcp_allowed_hosts }}
         run: |
-          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\",_MCP_ALLOWED_HOSTS=\"${V_MCP_ALLOWED_HOSTS}\""
+          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\",_MCP_ALLOWED_HOSTS=\"${V_MCP_ALLOWED_HOSTS}\",_EE_ENABLED=\"${V_EE_ENABLED}\""
           echo "substitutions=${SUBST}" >> "$GITHUB_OUTPUT"
 
       - name: Submit Cloud Build

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -44,6 +44,11 @@ ENV NEXT_PUBLIC_GA4_MEASUREMENT_ID=${NEXT_PUBLIC_GA4_MEASUREMENT_ID}
 # 안 돼 별도 판단으로 미룬다. 기본값 false(미설정 시 dev-safe fallback).
 ARG NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED=false
 ENV NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED=${NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED}
+# story #2728 후속(2026-08-17) — apps/web/src/lib/ee.ts의 isEEEnabled()가 읽는 빌드타임
+# 인라인 값. 여태 ARG/ENV 어디에도 배선된 적이 없어 dev/prod 둘 다 항상 undefined(=false)
+# 였다 — 기본값 false(미설정 시 dev-safe fallback, SSE_MULTIPLEX_ENABLED와 동일 컨벤션).
+ARG NEXT_PUBLIC_EE_ENABLED=false
+ENV NEXT_PUBLIC_EE_ENABLED=${NEXT_PUBLIC_EE_ENABLED}
 RUN pnpm build
 
 # ─── 런타임 ──────────────────────────────────────────────────────────────────

--- a/backend/tests/test_check_env_drift_code_read_axis.py
+++ b/backend/tests/test_check_env_drift_code_read_axis.py
@@ -296,7 +296,9 @@ def test_ac4_real_repo_scan_counts_are_recorded():
     )
     # 정확한 숫자 고정(2026-07-28, 2026-07-31 ⑤ DI-패턴 후속으로 high 15→20,
     # 2026-08-02 story #2422 후속으로 high 20→15·exempt 18→23 갱신,
-    # 2026-08-07 story #2510 NEXT_PUBLIC_TOSS_CLIENT_KEY 신설로 high 15→16) — 스위트가
+    # 2026-08-07 story #2510 NEXT_PUBLIC_TOSS_CLIENT_KEY 신설로 high 15→16,
+    # 2026-08-17 story #2728 후속으로 NEXT_PUBLIC_EE_ENABLED를 cloudbuild.yaml/GHA에 배선
+    # (dev FE billing 표면 렌더 안 되던 근본원인)해 IaC-covered로 전환·high 16→15) — 스위트가
     # 실패하면 숫자가 바뀐 것, 원인을 봐야 한다. 이번 -5/+5는 SPRINTABLE_RUNTIME_ROLE·
     # SPRINTABLE_{BACKGROUND,MEMO_DISPATCHER,DISCORD_OUTBOUND,TEAMS_OUTBOUND}_POLL_INTERVAL_MS
     # 다섯이 high(미triage)에서 code_read_exempt(영구 정상)로 승격된 것 — env 드리프트
@@ -306,7 +308,7 @@ def test_ac4_real_repo_scan_counts_are_recorded():
     # 은퇴 상태). 값을 채워야 도는 게 아니라 안 채워야 지금 의도대로 도는 스위치라
     # code_read_exempt가 정확한 분류다(baseline의 "아직 triage 안 됨"과 다르다).
     assert len(highest) == 1, highest
-    assert len(high) == 16, high
+    assert len(high) == 15, high
     assert len(low) == 9, low
     assert len(exempt) == 23
 
@@ -399,11 +401,12 @@ def test_baseline_entry_without_reason_is_escalated():
 
 
 def test_repo_code_read_high_baseline_is_wellformed():
-    """저장소에 실제로 커밋된 baseline(15건, 2026-08-07 — #2510 NEXT_PUBLIC_TOSS_CLIENT_KEY
-    추가로 14→15)이 형식을 지키는지."""
+    """저장소에 실제로 커밋된 baseline(14건, 2026-08-07 — #2510 NEXT_PUBLIC_TOSS_CLIENT_KEY
+    추가로 14→15, 2026-08-17 — #2728 NEXT_PUBLIC_EE_ENABLED를 cloudbuild.yaml/GHA 배선으로
+    해소해 15→14)이 형식을 지키는지."""
     mod = _load_check_env_drift()
     baseline = mod._load_code_read_high_baseline()
-    assert len(baseline) == 15
+    assert len(baseline) == 14
     for key, entry in baseline.items():
         problem = mod._baseline_entry_expired(entry, mod._today())
         assert problem is None, f"{key}: {problem}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -49,6 +49,14 @@ substitutions:
   # 미비활성으로 PgBouncer 아래서 prepared statement reuse 깨짐, #1314류 재발).
   _BACKEND_DB_PGBOUNCER: 'false'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
+  # story #2728 후속(2026-08-17, 페드루 PO 지시) — 유나 실측: dev FE 빌드가 NEXT_PUBLIC_
+  # EE_ENABLED 자체를 build-arg/Dockerfile ARG 어디에도 배선한 적이 없어(grep 확認 — 이
+  # substitution·GHA·Dockerfile 전부 무배선) billing 표면이 dev서 아예 렌더 안 됐다. 배포
+  # SSOT/과거 스토리 grep으로 "의도된 결정"이 아님을 확認(manual-env-allowlist.yml에
+  # declared_by:PO·미triage로만 남아있던 값 — 코드로 differentiate된 적이 없다). dev-safe
+  # 기본값 'false'(SSE_MULTIPLEX_ENABLED와 동일 컨벤션) — GHA가 dev 브랜치에서만 'true' 주입,
+  # prod는 이 커밋으로 무접촉(기존 동작 그대로 유지, 명시 false로 durable화만).
+  _EE_ENABLED: "false"
   # story #2078(E-ARCH 0단계) — SSE 멀티플렉서 롤백 플래그. dev-safe 기본값 'false'(수동
   # `gcloud builds submit` override 없을 때 안전). GHA가 dev 브랜치에서만 'true' 주입 —
   # prod는 develop→main 일괄승격에 검증 안 된 플래그를 얹지 않는다(오르테가군 판정,
@@ -240,6 +248,8 @@ steps:
       - NEXT_PUBLIC_GA4_MEASUREMENT_ID=${_GA4_MEASUREMENT_ID}
       - --build-arg
       - NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED=${_SSE_MULTIPLEX_ENABLED}
+      - --build-arg
+      - NEXT_PUBLIC_EE_ENABLED=${_EE_ENABLED}
       - .
     env:
       - DOCKER_BUILDKIT=1

--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -576,10 +576,6 @@ code_read_high_baseline:
     reason: apps/web/src/lib/auth/cookies.ts 등 — 기본값 없음, 미triage.
     declared_by: PO
     until: "2026-08-27"
-  - key: NEXT_PUBLIC_EE_ENABLED
-    reason: apps/web/src/lib/ee.ts — 기본값 없음, 미triage(기능 플래그 추정).
-    declared_by: PO
-    until: "2026-08-27"
   - key: NEXT_PUBLIC_FIREBASE_API_KEY
     reason: >-
       apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage. NEXT_PUBLIC_*


### PR DESCRIPTION
## Summary
- story #2728 하위 작업(별도 스토리 없음, PO 직접 지시). 유나 실측: dev FE 빌드가 non-EE라 billing 표면이 dev서 아예 렌더 안 됨 — 선생님 기결정("결제는 dev서 구현·검증")과 충돌.
- **그라운딩 결론: "의도된 결정"이 아니었다.** `NEXT_PUBLIC_EE_ENABLED`가 `cloudbuild.yaml` build-arg·`apps/web/Dockerfile` ARG/ENV·`.github/workflows/cloud-build.yml` 셋 다 어디에도 배선된 적이 없어 dev/prod 동일하게 build-time `undefined`(=`false`)였다. `infra/manual-env-allowlist.yml`에 `declared_by: PO`·"미triage"로만 존재했을 뿐 — 코드로 dev/prod를 differentiate한 적이 0건이었다(둘 다 항상 false였다는 뜻, "prod는 EE인데 dev만 non-EE"가 아니라).

## 변경
- `cloudbuild.yaml`: `_EE_ENABLED` substitution(dev-safe 기본값 `'false'`, 기존 `_SSE_MULTIPLEX_ENABLED`와 동일 컨벤션) + frontend build-arg 추가.
- `apps/web/Dockerfile`: `ARG`/`ENV NEXT_PUBLIC_EE_ENABLED` 신설.
- `.github/workflows/cloud-build.yml`: dev 분기만 `ee_enabled=true`, main(prod) 분기는 명시 `false`(**⛔prod 빌드 값 무접촉** — 새로 켜는 게 아니라 기존 동작 그대로 durable화만).
- `infra/manual-env-allowlist.yml`의 `code_read_high_baseline`에서 `NEXT_PUBLIC_EE_ENABLED` 엔트리 제거(이제 IaC-covered — 더 이상 미triage 아님) + `test_check_env_drift_code_read_axis.py` 핀 카운트 갱신(high 16→15, baseline 15→14).

## ⚠️ 참고(범위 밖, Pedro에게 별도 보고)
같은 `code_read_high_baseline`에 `LICENSE_CONSENT`(BE `is_ee_enabled` 게이트, `apps/web/src/lib/ee-enabled.ts`가 읽음)도 동일하게 미배선 상태로 남아있다. `settings/page.tsx`가 쓰는 FE 렌더 게이트(`@/lib/ee`의 `isEEEnabled`)와는 별개 함수/별개 env var — 이 PR로 billing 탭이 dev에서 뜨더라도, 실제 billing 데이터/오퍼레이션이 이 별도 BE 게이트에 여전히 걸릴 수 있다(이전 세션 기록상 "infra/PO lane"으로만 알려져 있었으나, 실제로는 backend deploy 스텝이 이미 `--update-env-vars`(additive)로 이런 류 값을 코드화하고 있어 이 PR과 같은 방식으로 배선 가능해 보인다 — 필요하면 후속 판단). 이번 PR은 Pedro가 명시 지시한 FE 렌더 게이트만 다룬다.

## Test plan
- [x] `test_check_env_drift_code_read_axis.py` 27/27 pass — 뮤테이션킬(build-arg 줄 제거 → high 15→16 RED 재현, 원복 후 재그린) 확인.
- [x] 관련 배포/cloudbuild 가드 클러스터(`cloudbuild`·`deploy_env`·`check_env_drift`·`2178`) 102/102 pass.
- [x] `cloudbuild.yaml`·`.github/workflows/cloud-build.yml`·`infra/manual-env-allowlist.yml` 전부 YAML 파싱 클린.
- [ ] CI
- [ ] 머지·재배포 후 유나 픽셀 검증(Pedro 지시대로 다음 단계)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>