### PR TITLE
[SID:2477] Free 좌석 cap 우회 — pending invite 미집계 + accept 재검증 부재

### DIFF
--- a/backend/app/repositories/org_invite.py
+++ b/backend/app/repositories/org_invite.py
@@ -5,11 +5,12 @@ from datetime import datetime, timedelta, timezone
 
 from dataclasses import dataclass, field
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.models.org_invite import OrgInvite
 from app.models.organization import Organization
 from app.models.project import OrgMember, Project
@@ -227,6 +228,21 @@ class OrgInviteRepository:
             return {"ok": False, "reason": "expired"}
         if invite.email.lower() != user_email.lower():
             return {"ok": False, "reason": "email_mismatch"}
+
+        # story #2477 AC②③ — Free cap 재검증(accept 시점) + 동시 수락 레이스 방어.
+        # org_id 해시 기반 advisory xact lock으로 같은 org를 겨눈 동시 accept 트랜잭션을
+        # 직렬화(커밋/롤백 시 자동 해제, 명시적 unlock 불요) — 락을 먼저 잡아야 그 뒤에
+        # 재는 멤버 카운트를 신뢰할 수 있다(락 없이 재면 두 트랜잭션이 서로 상대의 INSERT를
+        # 못 본 채 동시에 "아직 cap 안 참"을 보고 둘 다 통과해버린다). org_id는 accept 호출
+        # 시점엔 알 수 없어(토큰만 받음) invite 조회 후인 이 지점이 최초 가능 지점이라
+        # 라우터가 아닌 여기서 처리한다. EE 미탑재(OSS) 빌드에선 import 자체가 없으므로 게이트.
+        if settings.is_ee_enabled:
+            await self.session.execute(
+                text("SELECT pg_advisory_xact_lock(hashtext(:oid))"),
+                {"oid": str(invite.organization_id)},
+            )
+            from ee.plan_limits import check_member_accept_limit  # type: ignore[import]
+            await check_member_accept_limit(self.session, invite.organization_id)
 
         # org_member 생성 (중복 시 무시)
         await self.session.execute(

--- a/backend/ee/plan_limits.py
+++ b/backend/ee/plan_limits.py
@@ -155,15 +155,43 @@ async def check_storage_capacity(session: AsyncSession, org_id, attachments: lis
 
 
 async def check_member_invite_limit(session: AsyncSession, org_id) -> None:
-    """Free: org당 member 5명 제한 (human + agent). Team/Pro는 스킵."""
+    """Free: org당 member 3명 제한 (human + agent, 현재 멤버 + pending 미만료 초대 합). Team/Pro는 스킵.
+
+    story #2477 AC① — pending invite를 안 세면 cap을 우회할 수 있었다(2명이 초대 5개를
+    만들어 전부 수락하면 3명 캡을 넘길 수 있음). 생성 단계에서 «멤버+대기중 초대» 합으로
+    선차단해 애초에 캡을 넘길 만큼의 초대가 쌓이지 못하게 한다.
+    """
     tier = await _get_org_tier(session, org_id)
     if tier != "free":
         return
     result = await session.execute(
         text(
-            "SELECT COUNT(*) FROM org_members"
-            " WHERE org_id = :oid AND deleted_at IS NULL"
+            "SELECT "
+            "(SELECT COUNT(*) FROM org_members WHERE org_id = :oid AND deleted_at IS NULL)"
+            " + (SELECT COUNT(*) FROM org_invites"
+            "     WHERE organization_id = :oid AND status = 'pending' AND expires_at > now())"
         ),
+        {"oid": str(org_id)},
+    )
+    count = result.scalar() or 0
+    if count >= FREE_LIMITS["max_members"]:
+        raise _plan_limit_error("member", FREE_LIMITS["max_members"])
+
+
+async def check_member_accept_limit(session: AsyncSession, org_id) -> None:
+    """Free: 초대 «수락» 시점 재검증(story #2477 AC②) — 현재 멤버수만 비교(대기중 초대는
+    무관, 이 호출이 성공하면 그 초대 하나가 바로 멤버로 전환되므로). Team/Pro는 스킵.
+
+    ⚠️호출부(OrgInviteRepository.accept)가 org_id 스코프 advisory xact lock을 먼저 잡은
+    뒤에 불러야 한다 — 락 없이 재면 동시에 수락하는 두 트랜잭션이 서로 상대의 INSERT를
+    못 본 채 똑같이 "아직 cap 안 참"으로 읽어 둘 다 통과해버린다(AC③ 레이스 방어는 이
+    함수가 아니라 호출부의 락이 담당).
+    """
+    tier = await _get_org_tier(session, org_id)
+    if tier != "free":
+        return
+    result = await session.execute(
+        text("SELECT COUNT(*) FROM org_members WHERE org_id = :oid AND deleted_at IS NULL"),
         {"oid": str(org_id)},
     )
     count = result.scalar() or 0

--- a/backend/tests/test_2477_free_seat_cap_bypass.py
+++ b/backend/tests/test_2477_free_seat_cap_bypass.py
@@ -254,10 +254,9 @@ async def test_2_members_plus_5_invites_all_accept_concurrently_only_1_passes_ca
         async with SessionLocal() as sess:
             repo = OrgInviteRepository(sess)
             try:
-                with _ee_on():
-                    result = await repo.accept(
-                        token=token, user_id=user_id, user_email=f"{user_id}@race2477.test"
-                    )
+                result = await repo.accept(
+                    token=token, user_id=user_id, user_email=f"{user_id}@race2477.test"
+                )
                 await sess.commit()
                 return ("ok", result)
             except Exception as exc:  # noqa: BLE001 — 성공/실패 신호를 한 채널로 모으기 위함
@@ -265,9 +264,15 @@ async def test_2_members_plus_5_invites_all_accept_concurrently_only_1_passes_ca
                 return ("err", exc)
 
     import asyncio
-    outcomes = await asyncio.gather(*[
-        _accept_one(uid, tok) for uid, tok in zip(invitee_ids, tokens)
-    ])
+    # ⚠️_ee_on()은 unittest.mock.patch로 settings.is_ee_enabled 클래스 프로퍼티를 패치한다 —
+    # asyncio.gather로 도는 태스크 각각의 안에서 열고 닫으면(겹치는 enter/exit) 한 태스크가
+    # 먼저 exit하며 원복시켜 나머지가 아직 True를 기대하는 동안 False로 새는 레이스가 생긴다
+    # (실측: 이 상태로 이 테스트 뒤에 test_push_devices_realdb가 돌면 EE off 네거티브 게이트가
+    # 새어 실패). 패치는 gather 전체를 한 번만 감싸 단일 enter/exit로 고정한다.
+    with _ee_on():
+        outcomes = await asyncio.gather(*[
+            _accept_one(uid, tok) for uid, tok in zip(invitee_ids, tokens)
+        ])
 
     successes = [o for o in outcomes if o[0] == "ok"]
     failures = [o for o in outcomes if o[0] == "err"]

--- a/backend/tests/test_2477_free_seat_cap_bypass.py
+++ b/backend/tests/test_2477_free_seat_cap_bypass.py
@@ -224,8 +224,8 @@ async def test_2_members_plus_5_invites_all_accept_concurrently_only_1_passes_ca
         for uid in existing_member_ids + invitee_ids:
             await s.execute(
                 text(
-                    "INSERT INTO users (id,email,hashed_password,is_active)"
-                    " VALUES (:id,:email,'x',true)"
+                    "INSERT INTO users (id,email,hashed_password,is_active,email_verified)"
+                    " VALUES (:id,:email,'x',true,true)"
                 ),
                 {"id": str(uid), "email": f"{uid}@race2477.test"},
             )

--- a/backend/tests/test_2477_free_seat_cap_bypass.py
+++ b/backend/tests/test_2477_free_seat_cap_bypass.py
@@ -1,0 +1,290 @@
+"""story #2477: Free 좌석 cap 우회 — pending invite 미집계 + accept 재검증 부재 fix.
+
+AC①: 초대 «생성» 시 cap 검사 = 현재 멤버 + pending invite 합.
+AC②: 초대 «수락» 시 재검증 — 수락으로 cap 초과되면 거부.
+AC③: 동시 수락 레이스 방어(advisory xact lock으로 원자적 직렬화).
+AC④: check_member_invite_limit docstring "5명" → "3명" 갱신.
+AC⑤: 양성대조 — «2명+초대5 전부수락» 시나리오가 실제로 거부됨(우회 불가) 실증.
+
+AC①④는 mock 기반 unit(빠름, 항상 실행). AC②③⑤는 real-DB 통합(asyncio.gather로 5개
+독립 세션이 진짜로 동시에 accept를 다투게 해 advisory lock의 실질적 직렬화 효과를
+증명 — mock 세션으로는 락의 존재만 확인 가능하지 실제 레이스 방어는 증명 못 함).
+DB env 없으면 skip.
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── AC④: docstring 5명→3명 갱신 ─────────────────────────────────────────────
+
+def test_check_member_invite_limit_docstring_says_3_not_5():
+    from ee.plan_limits import check_member_invite_limit
+    source = inspect.getsource(check_member_invite_limit)
+    assert "5명" not in source
+    assert "3명" in source
+
+
+# ─── AC①: 생성 시점 cap = 현재 멤버 + pending invite 합 ─────────────────────
+
+def test_check_member_invite_limit_counts_pending_invites_in_sql():
+    """count SQL에 org_invites·pending·org_members 3요소가 합산 형태로 실재."""
+    from ee.plan_limits import check_member_invite_limit
+    source = inspect.getsource(check_member_invite_limit)
+    assert "org_invites" in source
+    assert "pending" in source
+    assert "org_members" in source
+
+
+@pytest.mark.anyio
+async def test_check_member_invite_limit_rejects_when_members_plus_pending_at_cap():
+    """현재 멤버+pending 합이 cap(3) 이상이면 생성 시점에 402."""
+    from fastapi import HTTPException
+    from ee.plan_limits import check_member_invite_limit
+
+    mock_session = AsyncMock()
+    tier_result = MagicMock()
+    tier_result.first.return_value = ("free",)
+    count_result = MagicMock()
+    count_result.scalar.return_value = 3  # 2 members + 1 pending = 3 = cap
+    mock_session.execute = AsyncMock(side_effect=[tier_result, count_result])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await check_member_invite_limit(mock_session, uuid.uuid4())
+    assert exc_info.value.status_code == 402
+    assert exc_info.value.detail["code"] == "PLAN_LIMIT_EXCEEDED"
+
+
+@pytest.mark.anyio
+async def test_check_member_invite_limit_passes_when_under_cap():
+    """현재 멤버+pending 합이 cap 미만이면 통과(예외 없음)."""
+    from ee.plan_limits import check_member_invite_limit
+
+    mock_session = AsyncMock()
+    tier_result = MagicMock()
+    tier_result.first.return_value = ("free",)
+    count_result = MagicMock()
+    count_result.scalar.return_value = 2  # 1 member + 1 pending = 2 < 3
+    mock_session.execute = AsyncMock(side_effect=[tier_result, count_result])
+
+    await check_member_invite_limit(mock_session, uuid.uuid4())  # 예외 없어야 함
+
+
+# ─── AC②: accept-time 재검증 함수 존재 + 402 거부 (mock, 락 존재만 확인) ────
+
+def test_check_member_accept_limit_exists():
+    from ee.plan_limits import check_member_accept_limit
+    source = inspect.getsource(check_member_accept_limit)
+    assert "max_members" in source
+    assert "_plan_limit_error" in source or "raise" in source
+
+
+def test_accept_calls_advisory_lock_before_cap_check_in_source():
+    """accept() 소스에 pg_advisory_xact_lock이 check_member_accept_limit보다 먼저 나온다
+    (락 없이 재검증만 하면 TOCTOU 레이스가 그대로 남는다 — 순서 자체가 계약)."""
+    from app.repositories.org_invite import OrgInviteRepository
+    source = inspect.getsource(OrgInviteRepository.accept)
+    lock_pos = source.find("pg_advisory_xact_lock")
+    check_pos = source.find("check_member_accept_limit")
+    assert lock_pos != -1
+    assert check_pos != -1
+    assert lock_pos < check_pos
+
+
+@pytest.mark.anyio
+async def test_accept_rejects_when_at_cap_ee_on():
+    """EE on + 현재 멤버수가 cap(3) 이상이면 accept()가 402로 거부(mock)."""
+    from fastapi import HTTPException
+    from app.repositories.org_invite import OrgInviteRepository
+
+    org_id = uuid.uuid4()
+    invite = MagicMock()
+    invite.status = "pending"
+    invite.organization_id = org_id
+    invite.role = "member"
+    invite.email = "invitee@example.com"
+    invite.expires_at = datetime.now(timezone.utc) + timedelta(days=3)
+
+    invite_result = MagicMock()
+    invite_result.scalar_one_or_none.return_value = invite
+    tier_result = MagicMock()
+    tier_result.first.return_value = ("free",)
+    count_result = MagicMock()
+    count_result.scalar.return_value = 3  # 이미 cap
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[invite_result, MagicMock(), tier_result, count_result])
+
+    repo = OrgInviteRepository(session)
+    with patch("app.repositories.org_invite.settings") as mock_settings:
+        mock_settings.is_ee_enabled = True
+        with pytest.raises(HTTPException) as exc_info:
+            await repo.accept(token="tok", user_id=uuid.uuid4(), user_email="invitee@example.com")
+    assert exc_info.value.status_code == 402
+
+
+@pytest.mark.anyio
+async def test_accept_oss_skips_cap_check():
+    """EE off(OSS)면 advisory lock/cap 재검증 자체를 안 함(ee import 없음) — 기존 동작 무회귀."""
+    from app.repositories.org_invite import OrgInviteRepository
+
+    org_id = uuid.uuid4()
+    invite = MagicMock()
+    invite.status = "pending"
+    invite.organization_id = org_id
+    invite.role = "member"
+    invite.email = "invitee@example.com"
+    invite.expires_at = datetime.now(timezone.utc) + timedelta(days=3)
+    invite.project_ids = []
+
+    invite_result = MagicMock()
+    invite_result.scalar_one_or_none.return_value = invite
+    om_id_result = MagicMock()
+    om_id_result.scalar_one_or_none.return_value = uuid.uuid4()
+
+    session = AsyncMock()
+    # OSS 경로: invite 조회 → org_members upsert → om_id 재조회. 락/캡 쿼리 없음(2개 아닌 3개).
+    session.execute = AsyncMock(side_effect=[invite_result, MagicMock(), om_id_result])
+    session.flush = AsyncMock()
+
+    repo = OrgInviteRepository(session)
+    with patch("app.repositories.org_invite.settings") as mock_settings, \
+            patch("app.services.agent_anchor_sync.ensure_human_member", new=AsyncMock()):
+        mock_settings.is_ee_enabled = False
+        result = await repo.accept(token="tok", user_id=uuid.uuid4(), user_email="invitee@example.com")
+    assert result["ok"] is True
+
+
+# ─── AC②③⑤: real-DB — 진짜 동시 수락 레이스 + 양성대조 ─────────────────────
+
+pytestmark_realdb = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="real-DB URL(PARITY/ALEMBIC_DATABASE_URL) 미설정 — skip"
+)
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+def _ee_on():
+    from app.core.config import settings
+    return patch.object(type(settings), "is_ee_enabled", property(lambda self: True))
+
+
+@pytest.mark.anyio
+@pytestmark_realdb
+async def test_2_members_plus_5_invites_all_accept_concurrently_only_1_passes_cap():
+    """AC⑤ 양성대조(실 PG): free org에 멤버 2명이 이미 있고 pending 초대 5개가 동시에
+    수락되면(asyncio.gather, 5개 독립 세션·독립 커넥션) cap(3)을 넘길 수 있는 나머지
+    4개는 거부되고 정확히 1개만 성공해야 한다(2+1=3=cap). advisory xact lock이 없다면
+    5개 트랜잭션이 서로의 INSERT를 못 본 채 동시에 "아직 cap 안 참"을 보고 여러 개가
+    동시에 통과할 수 있다 — 이게 바로 story #2477이 잡으려는 우회 그 자체."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.repositories.org_invite import OrgInviteRepository
+
+    org_id = uuid.uuid4()
+    existing_member_ids = [uuid.uuid4() for _ in range(2)]
+    invitee_ids = [uuid.uuid4() for _ in range(5)]
+    tokens = [f"race2477-{i}-{uuid.uuid4().hex[:8]}" for i in range(5)]
+
+    engine = create_async_engine(_async_url(), pool_size=10, max_overflow=10)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with SessionLocal() as s:
+        await s.execute(text("DELETE FROM org_invites WHERE organization_id=:o"), {"o": str(org_id)})
+        await s.execute(text("DELETE FROM org_members WHERE org_id=:o"), {"o": str(org_id)})
+        await s.execute(
+            text("DELETE FROM users WHERE id = ANY(:ids)"),
+            {"ids": [str(i) for i in existing_member_ids + invitee_ids]},
+        )
+        await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(org_id)})
+        await s.execute(
+            text("INSERT INTO organizations (id,name,slug,plan) VALUES (:o,'2477 Race Org',:slug,'free')"),
+            {"o": str(org_id), "slug": f"race2477-{org_id.hex[:8]}"},
+        )
+        for uid in existing_member_ids + invitee_ids:
+            await s.execute(
+                text(
+                    "INSERT INTO users (id,email,hashed_password,is_active)"
+                    " VALUES (:id,:email,'x',true)"
+                ),
+                {"id": str(uid), "email": f"{uid}@race2477.test"},
+            )
+        for uid in existing_member_ids:
+            await s.execute(
+                text("INSERT INTO org_members (id,org_id,user_id,role) VALUES (:id,:o,:u,'member')"),
+                {"id": str(uuid.uuid4()), "o": str(org_id), "u": str(uid)},
+            )
+        now = datetime.now(timezone.utc)
+        for uid, tok in zip(invitee_ids, tokens):
+            await s.execute(
+                text(
+                    "INSERT INTO org_invites"
+                    " (id,organization_id,email,role,token,status,expires_at,project_ids)"
+                    " VALUES (:id,:o,:email,'member',:tok,'pending',:exp,'[]'::jsonb)"
+                ),
+                {
+                    "id": str(uuid.uuid4()), "o": str(org_id),
+                    "email": f"{uid}@race2477.test", "tok": tok,
+                    "exp": now + timedelta(days=7),
+                },
+            )
+        await s.commit()
+
+    async def _accept_one(user_id: uuid.UUID, token: str):
+        async with SessionLocal() as sess:
+            repo = OrgInviteRepository(sess)
+            try:
+                with _ee_on():
+                    result = await repo.accept(
+                        token=token, user_id=user_id, user_email=f"{user_id}@race2477.test"
+                    )
+                await sess.commit()
+                return ("ok", result)
+            except Exception as exc:  # noqa: BLE001 — 성공/실패 신호를 한 채널로 모으기 위함
+                await sess.rollback()
+                return ("err", exc)
+
+    import asyncio
+    outcomes = await asyncio.gather(*[
+        _accept_one(uid, tok) for uid, tok in zip(invitee_ids, tokens)
+    ])
+
+    successes = [o for o in outcomes if o[0] == "ok"]
+    failures = [o for o in outcomes if o[0] == "err"]
+
+    assert len(successes) == 1, f"cap=3(기존2+신규1)인데 {len(successes)}건 통과 — 우회 발생: {outcomes}"
+    assert len(failures) == 4
+    for _, exc in failures:
+        from fastapi import HTTPException
+        assert isinstance(exc, HTTPException)
+        assert exc.status_code == 402
+        assert exc.detail["code"] == "PLAN_LIMIT_EXCEEDED"
+
+    async with SessionLocal() as s:
+        final_count = (await s.execute(
+            text("SELECT COUNT(*) FROM org_members WHERE org_id=:o AND deleted_at IS NULL"),
+            {"o": str(org_id)},
+        )).scalar()
+        assert final_count == 3, f"최종 멤버수는 정확히 cap(3)이어야: {final_count}"
+
+    await engine.dispose()

--- a/backend/tests/test_onboarding_member_anchor_0b115f5d.py
+++ b/backend/tests/test_onboarding_member_anchor_0b115f5d.py
@@ -25,6 +25,18 @@ def _scalar_result(value):
     return r
 
 
+def _count_result(n: int):
+    r = MagicMock()
+    r.scalar.return_value = n
+    return r
+
+
+def _tier_result(tier: str | None):
+    r = MagicMock()
+    r.first.return_value = (tier,) if tier else None
+    return r
+
+
 # ─── 경로 ①: organizations.create_organization ──────────────────────────────
 
 
@@ -140,6 +152,9 @@ async def test_invite_accept_ensures_human_member():
     session.execute = AsyncMock(
         side_effect=[
             _scalar_result(invite),  # accept(): invite 조회
+            MagicMock(),             # story #2477: advisory xact lock
+            _tier_result("free"),    # story #2477: check_member_accept_limit._get_org_tier
+            _count_result(1),        # story #2477: accept-time cap 재검증(1명 < 3, 통과)
             MagicMock(),             # org_members upsert
             _scalar_result(om_id),   # _ensure_member_anchor: om_id 재조회
         ]
@@ -150,7 +165,8 @@ async def test_invite_accept_ensures_human_member():
 
     with patch(
         "app.services.agent_anchor_sync.ensure_human_member", new=AsyncMock()
-    ) as ehm:
+    ) as ehm, patch("app.repositories.org_invite.settings") as mock_settings:
+        mock_settings.is_ee_enabled = True
         result = await repo.accept(
             token="tok", user_id=user_id, user_email="invitee@example.com"
         )


### PR DESCRIPTION
## 요약
story #2477(d634a8a6): 카디르 QA(#2864)가 코드로 재확認한 갭 — Free 좌석 cap이 pending invite를 안 세고 accept 시점 재검증도 없어, 멤버 2명인 org가 초대 5개를 만들어 전부 수락하면 3명 캡을 우회할 수 있었다.

## 그라운딩(실측)
- `org_invites.py:75` — 생성 시 `check_member_invite_limit`이 **현재 멤버수만** 카운트(pending invite 미포함).
- `invite_accept.py`/`org_invite.py:accept()` — 수락 경로에 cap 재검증 **0줄**. invite가 pending이고 email이 맞으면 무조건 `org_members` INSERT.
- `ee/plan_limits.py:check_member_invite_limit` docstring이 "5명"으로 stale(실제 상수 `FREE_LIMITS["max_members"]`는 이미 3 — #2471 A1 v2.3 정책 반영됨. 동작 버그 아님, 문서만 낡음).

## 변경
1. **`check_member_invite_limit`(생성 시점)** — 카운트를 `org_members`(현재 멤버) + `org_invites WHERE status='pending' AND expires_at > now()`(대기중 초대) 합으로 확장. 생성 단계에서 선차단해 애초에 캡을 넘길 만큼의 초대가 쌓이지 못하게 함.
2. **`check_member_accept_limit`(신규, accept 시점)** — 현재 멤버수만 비교(수락 성공 시 그 초대 하나가 즉시 멤버로 전환되므로 pending 카운트는 무관).
3. **`OrgInviteRepository.accept()`** — `pending` 분기에서 org_member INSERT 직전에:
   - `pg_advisory_xact_lock(hashtext(:org_id))`로 같은 org를 겨눈 동시 accept 트랜잭션을 직렬화(커밋/롤백 시 자동 해제)
   - 그 다음 `check_member_accept_limit` 호출 — 초과 시 402 `PLAN_LIMIT_EXCEEDED`
   - 락을 먼저 안 잡으면 두 트랜잭션이 서로의 INSERT를 못 본 채 동시에 "아직 cap 안 참"을 보고 둘 다 통과하는 TOCTOU 레이스가 남는다(그게 바로 이 스토리가 잡는 우회 그 자체).
   - EE(`settings.is_ee_enabled`) 게이트 — OSS 빌드는 `ee.plan_limits` import 자체가 없으므로 무동작(기존 라우터 패턴과 동일).
4. docstring "5명"→"3명" 정정.

## 검증
- **뮤테이션킬 2건**: (a) 생성 시점 SQL에서 pending invite 합산 제거 → SQL-실재 검증 테스트 정확히 1건 RED, 원복 GREEN. (b) accept()의 advisory-lock+재검증 블록 통째 제거 → 관련 테스트 2건 정확히 RED, 원복 GREEN.
- **신규 mock 유닛 테스트 8건**(`test_2477_free_seat_cap_bypass.py`) — AC①②③④ 커버(docstring·SQL 실재·402 거부·OSS 무회귀).
- **신규 real-DB 통합 테스트 1건**(같은 파일, `PARITY_TEST_DATABASE_URL` 있을 때만 실행 — CI에서 실행됨, 로컬은 DB env 없어 skip) — **AC⑤ 양성대조 그대로**: free org에 기존 멤버 2명 + pending 초대 5개를 `asyncio.gather`로 5개 독립 세션이 진짜 동시에 수락 시도 → **정확히 1건만 성공**(2+1=3=cap), 나머지 4건은 402로 거부, 최종 멤버수 정확히 3 확認. mock으로는 락의 "존재"만 증명 가능하지 실제 레이스 방어는 real DB 동시성으로만 증명 가능해 이 축은 mock을 안 씀.
- 기존 회귀: `test_onboarding_member_anchor_0b115f5d.py::test_invite_accept_ensures_human_member`의 mock side_effect 시퀀스에 새 execute 호출 2개(잠금+재검증) 반영해 갱신, GREEN.
- 전체 invite/plan_limit/member_anchor 관련 테스트 82 pass, 2 skip(real-DB, 로컬 env 부재). **사전존재 실패 6건**(`test_e_org_multi_s3_1_org_invite.py` 4건 + `test_onboarding_member_anchor...` 무관 2건)은 이 diff와 무관 — 수정 전 clean `develop`에서 동일하게 재현 확認(로컬 mock/이벤트루프 환경 이슈로 추정, CI에서는 다를 수 있음 — 이번 PR 스코프 밖).

## 스코프 밖
- 기존에 이미 cap을 초과해 존재하는 Free org(3명 초과)는 그대로 둠 — 이 파일의 다른 모든 초과-자원 처리(storage 등)와 동일 패턴, 신규 초대/수락만 차단.