### PR TITLE
[SID:154a26be] 좌표 코멘트/스펙핀 anchor_x/y — %(0~100) 서버측 상한 검증

### DIFF
--- a/backend/app/schemas/visual_artifact.py
+++ b/backend/app/schemas/visual_artifact.py
@@ -172,8 +172,14 @@ class VisualArtifactDetail(BaseModel):
 class CreateArtifactCommentRequest(BaseModel):
     content: str
     node_id: uuid.UUID | None = None
-    anchor_x: float | None = None
-    anchor_y: float | None = None
+    # story #154a26be — 좌표 앵커 규약은 %(0~100), ratio(0~1)나 픽셀이 아니다(FE
+    # artifact-viewer.tsx가 `style={{ left: "${x}%" }}`로 직접 CSS % 소비). 기존엔 이
+    # 규약이 소비처 관행으로만 서 있고 서버가 안 막아 다른 단위 클라이언트가 통과·핀이
+    # 조용히 딴 자리에 렌더될 수 있었다("금지 AC=서버가 거부" 원칙 위반) — 실측으로
+    # artifact_spec_pins에 이미 픽셀 단위(638.4, 398.4)로 오염된 행 1건 확認(2026-07-13,
+    # 이 fix 前 생성분이라 소급 안 함, PO 판단).
+    anchor_x: float | None = Field(default=None, ge=0, le=100, description="캔버스 폭 대비 %(0~100) — ratio(0~1)·픽셀 아님")
+    anchor_y: float | None = Field(default=None, ge=0, le=100, description="캔버스 높이 대비 %(0~100) — ratio(0~1)·픽셀 아님")
     parent_id: uuid.UUID | None = None
     mentioned_ids: list[uuid.UUID] = []
 
@@ -209,6 +215,10 @@ class CreateSpecPinRequest(BaseModel):
     """편집 캔버스 핀 저작(story 7fe16274) — anchor_type이 좌표/노드 중 무엇이든 description은
     non-null 강제(doc §3 — 빈 스펙 커밋 차단)."""
     anchor_type: str
+    # story #154a26be — %(0~100) 규약, 하한만 있고 상한이 없던 갭. 실측: 이 클래스로 생성된
+    # 기존 유일한 좌표 핀 1건이 이미 픽셀 단위(638.4, 398.4)로 저장돼 있었다(2026-07-13,
+    # 이 fix 前 — 소급 안 함, PO 판단) — «다른 단위 클라이언트가 통과» 리스크의 실제 사례.
+    # 상한은 아래 _validate_anchor_consistency에서(anchor_type 분기와 같은 자리) 확認.
     anchor_x: float | None = None
     anchor_y: float | None = None
     node_id: uuid.UUID | None = None
@@ -237,8 +247,8 @@ class CreateSpecPinRequest(BaseModel):
                 raise ValueError("coord anchor requires both anchor_x and anchor_y")
             if self.node_id is not None:
                 raise ValueError("coord anchor must not set node_id")
-            if self.anchor_x < 0 or self.anchor_y < 0:
-                raise ValueError("anchor_x/anchor_y must be non-negative")
+            if self.anchor_x < 0 or self.anchor_x > 100 or self.anchor_y < 0 or self.anchor_y > 100:
+                raise ValueError("anchor_x/anchor_y must be within 0..100 (%, not ratio/pixel)")
         else:  # node
             if self.node_id is None:
                 raise ValueError("node anchor requires node_id")

--- a/backend/app/schemas/visual_artifact.py
+++ b/backend/app/schemas/visual_artifact.py
@@ -172,12 +172,14 @@ class VisualArtifactDetail(BaseModel):
 class CreateArtifactCommentRequest(BaseModel):
     content: str
     node_id: uuid.UUID | None = None
-    # story #154a26be — 좌표 앵커 규약은 %(0~100), ratio(0~1)나 픽셀이 아니다(FE
-    # artifact-viewer.tsx가 `style={{ left: "${x}%" }}`로 직접 CSS % 소비). 기존엔 이
-    # 규약이 소비처 관행으로만 서 있고 서버가 안 막아 다른 단위 클라이언트가 통과·핀이
-    # 조용히 딴 자리에 렌더될 수 있었다("금지 AC=서버가 거부" 원칙 위반) — 실측으로
-    # artifact_spec_pins에 이미 픽셀 단위(638.4, 398.4)로 오염된 행 1건 확認(2026-07-13,
-    # 이 fix 前 생성분이라 소급 안 함, PO 판단).
+    # story #154a26be — 이 클래스(아티팩트 좌표 코멘트)의 좌표 앵커 규약은 %(0~100),
+    # ratio(0~1)나 픽셀이 아니다(FE artifact-viewer.tsx가 `style={{ left: "${x}%" }}`로
+    # 직접 CSS % 소비). 기존엔 이 규약이 소비처 관행으로만 서 있고 서버가 안 막아 다른
+    # 단위 클라이언트가 통과·핀이 조용히 딴 자리에 렌더될 수 있었다("금지 AC=서버가 거부"
+    # 원칙 위반). ⛔`artifact_spec_pins`(CreateSpecPinRequest, 이 파일의 별개 클래스)는
+    # **다른 단위 계약**(px, canvas_bounds 좌표계)이라 이 %(0~100) 제약을 그쪽엔 걸지
+    # 않는다 — 처음엔 두 클래스를 같은 규약으로 오판해 걸었다가 미르코 QA 음성대조로
+    # 롤백함(페드루 PO, 2026-08-17). 이 클래스(코멘트)만 %.
     anchor_x: float | None = Field(default=None, ge=0, le=100, description="캔버스 폭 대비 %(0~100) — ratio(0~1)·픽셀 아님")
     anchor_y: float | None = Field(default=None, ge=0, le=100, description="캔버스 높이 대비 %(0~100) — ratio(0~1)·픽셀 아님")
     parent_id: uuid.UUID | None = None
@@ -215,10 +217,12 @@ class CreateSpecPinRequest(BaseModel):
     """편집 캔버스 핀 저작(story 7fe16274) — anchor_type이 좌표/노드 중 무엇이든 description은
     non-null 강제(doc §3 — 빈 스펙 커밋 차단)."""
     anchor_type: str
-    # story #154a26be — %(0~100) 규약, 하한만 있고 상한이 없던 갭. 실측: 이 클래스로 생성된
-    # 기존 유일한 좌표 핀 1건이 이미 픽셀 단위(638.4, 398.4)로 저장돼 있었다(2026-07-13,
-    # 이 fix 前 — 소급 안 함, PO 판단) — «다른 단위 클라이언트가 통과» 리스크의 실제 사례.
-    # 상한은 아래 _validate_anchor_consistency에서(anchor_type 분기와 같은 자리) 확認.
+    # ⛔story #154a26be 정정(페드루 PO, 2026-08-17) — 이 클래스는 %(0~100)가 아니라
+    # **px(canvas_bounds 좌표계)**다. FE `edit-canvas.tsx`가 `style={{ left: pin.anchorX,
+    # top: pin.anchorY }}`로 단위 없는 숫자를 직접 꽂아 쓴다(React CSSProperties 관례상
+    # unitless left/top = px). 실측값(638.4, 398.4)은 오염이 아니라 **정상 데이터**였음
+    # (원래 le=100을 걸었다가 라이브 스펙핀 배치를 과잉살상할 뻔한 것을 미르코 QA 음성대조가
+    # 잡음). 상한은 걸지 않는다 — 하한(>=0, 아래 _validate_anchor_consistency)만 유지.
     anchor_x: float | None = None
     anchor_y: float | None = None
     node_id: uuid.UUID | None = None
@@ -247,8 +251,8 @@ class CreateSpecPinRequest(BaseModel):
                 raise ValueError("coord anchor requires both anchor_x and anchor_y")
             if self.node_id is not None:
                 raise ValueError("coord anchor must not set node_id")
-            if self.anchor_x < 0 or self.anchor_x > 100 or self.anchor_y < 0 or self.anchor_y > 100:
-                raise ValueError("anchor_x/anchor_y must be within 0..100 (%, not ratio/pixel)")
+            if self.anchor_x < 0 or self.anchor_y < 0:
+                raise ValueError("anchor_x/anchor_y must be non-negative")
         else:  # node
             if self.node_id is None:
                 raise ValueError("node anchor requires node_id")

--- a/backend/tests/test_154a26be_anchor_bounds.py
+++ b/backend/tests/test_154a26be_anchor_bounds.py
@@ -1,9 +1,13 @@
-"""story #154a26be — 아티팩트 좌표 코멘트/스펙핀 anchor_x/y 상한(%, 0~100) 검증.
+"""story #154a26be — 아티팩트 좌표 코멘트 anchor_x/y 상한(%, 0~100) 검증.
 
 디디 그라운딩(PR 3186) 발견: `CreateArtifactCommentRequest`는 상한은커녕 하한도 서버가
 안 막고 있었다(하한 체크는 `CreateSpecPinRequest`에만 있었음 — 스토리 본문의 "하한만
-검증" 서술은 두 클래스를 혼동한 것으로 보이나, 실제 갭은 코멘트 쪽이 더 컸다). 이 fix는
-두 클래스 모두에 0..100 양쪽 경계를 건다.
+검증" 서술은 두 클래스를 혼동한 것으로 보이나, 실제 갭은 코멘트 쪽이 더 컸다).
+
+⛔`CreateSpecPinRequest`는 **다른 단위 계약**(px, canvas_bounds 좌표계)이라 %(0~100)
+상한을 안 건다 — 처음엔 두 클래스가 같은 % 컨벤션이라 오판해 여기도 le=100을 걸었으나,
+미르코 QA 음성대조(정상 데이터 638.4가 422로 깨짐)가 잡아 상한을 롤백했다(페드루 PO,
+2026-08-17). 하한(>=0)만 유지 — 이 파일의 SpecPin 축은 그 롤백 후 계약을 고정한다.
 
 Pydantic ValidationError → FastAPI가 422로 변환하는 게 기본 동작이라, 여기서는 스키마
 계층에서 직접 ValidationError 발생 여부를 검증한다(라우터까지 왕복하지 않아도 "422 발생
@@ -67,25 +71,31 @@ class TestCreateArtifactCommentRequestBounds:
 
 
 class TestCreateSpecPinRequestBounds:
-    def test_anchor_x_over_100_rejected(self):
+    def test_pixel_scale_value_accepted(self):
+        """⛔story #154a26be 정정(페드루 PO, 2026-08-17) — 이 클래스는 px(canvas_bounds
+        좌표계)라 %(0~100) 상한이 없다. dev DB 실측값(638.4, 398.4)은 오염이 아니라
+        정상 데이터였음(FE `edit-canvas.tsx`가 unitless left/top=px로 직접 씀) — 음성대조:
+        이 값이 «여전히 통과해야» 한다. 처음엔 이걸 «오염값→거부해야 함»으로 잘못 판단해
+        le=100을 걸 뻔했고(미르코 QA가 라이브 배치 과잉살상 위험으로 잡음), 지금은 정확히
+        반대 방향(수용)을 고정한다."""
         from app.schemas.visual_artifact import CreateSpecPinRequest
 
-        with pytest.raises(ValidationError):
-            CreateSpecPinRequest(anchor_type="coord", anchor_x=100.1, anchor_y=50, description="d")
-
-    def test_pixel_scale_value_rejected(self):
-        """실측 근거 그 자체 — dev DB에서 발견된 실제 오염값(638.4, 398.4)을 그대로 투입해도
-        거부되는지(회귀 재발 방지)."""
-        from app.schemas.visual_artifact import CreateSpecPinRequest
-
-        with pytest.raises(ValidationError):
-            CreateSpecPinRequest(anchor_type="coord", anchor_x=638.4, anchor_y=398.4, description="d")
+        req = CreateSpecPinRequest(anchor_type="coord", anchor_x=638.4, anchor_y=398.4, description="d")
+        assert req.anchor_x == 638.4
+        assert req.anchor_y == 398.4
 
     def test_anchor_within_range_accepted(self):
         from app.schemas.visual_artifact import CreateSpecPinRequest
 
         req = CreateSpecPinRequest(anchor_type="coord", anchor_x=50, anchor_y=50, description="d")
         assert req.anchor_x == 50
+
+    def test_negative_anchor_still_rejected(self):
+        """하한(>=0)은 이 fix 前부터 있던 기존 검증 — 상한만 롤백됐지 하한은 그대로."""
+        from app.schemas.visual_artifact import CreateSpecPinRequest
+
+        with pytest.raises(ValidationError):
+            CreateSpecPinRequest(anchor_type="coord", anchor_x=-1, anchor_y=50, description="d")
 
     def test_node_anchor_unaffected(self):
         """anchor_type='node'는 anchor_x/y 자체를 안 받는 기존 규칙 그대로 무회귀."""

--- a/backend/tests/test_154a26be_anchor_bounds.py
+++ b/backend/tests/test_154a26be_anchor_bounds.py
@@ -1,0 +1,108 @@
+"""story #154a26be — 아티팩트 좌표 코멘트/스펙핀 anchor_x/y 상한(%, 0~100) 검증.
+
+디디 그라운딩(PR 3186) 발견: `CreateArtifactCommentRequest`는 상한은커녕 하한도 서버가
+안 막고 있었다(하한 체크는 `CreateSpecPinRequest`에만 있었음 — 스토리 본문의 "하한만
+검증" 서술은 두 클래스를 혼동한 것으로 보이나, 실제 갭은 코멘트 쪽이 더 컸다). 이 fix는
+두 클래스 모두에 0..100 양쪽 경계를 건다.
+
+Pydantic ValidationError → FastAPI가 422로 변환하는 게 기본 동작이라, 여기서는 스키마
+계층에서 직접 ValidationError 발생 여부를 검증한다(라우터까지 왕복하지 않아도 "422 발생
+경로"의 근본 원인을 pin — router는 이 스키마를 body로 그대로 받으므로 무회귀)."""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestCreateArtifactCommentRequestBounds:
+    def test_anchor_x_over_100_rejected(self):
+        from app.schemas.visual_artifact import CreateArtifactCommentRequest
+
+        with pytest.raises(ValidationError):
+            CreateArtifactCommentRequest(content="c", anchor_x=100.1, anchor_y=50)
+
+    def test_anchor_y_over_100_rejected(self):
+        from app.schemas.visual_artifact import CreateArtifactCommentRequest
+
+        with pytest.raises(ValidationError):
+            CreateArtifactCommentRequest(content="c", anchor_x=50, anchor_y=100.1)
+
+    def test_pixel_scale_value_rejected(self):
+        """실측 근거(#154a26be) — artifact_spec_pins에서 실제로 발견된 오염 값(638.4)과
+        같은 스케일의 입력이 확실히 거부되는지."""
+        from app.schemas.visual_artifact import CreateArtifactCommentRequest
+
+        with pytest.raises(ValidationError):
+            CreateArtifactCommentRequest(content="c", anchor_x=638.4, anchor_y=398.4)
+
+    def test_anchor_negative_rejected(self):
+        from app.schemas.visual_artifact import CreateArtifactCommentRequest
+
+        with pytest.raises(ValidationError):
+            CreateArtifactCommentRequest(content="c", anchor_x=-0.1, anchor_y=50)
+
+    def test_anchor_boundary_0_and_100_accepted(self):
+        """경계값 자체(0·100)는 유효 — 배타적(exclusive) 아님."""
+        from app.schemas.visual_artifact import CreateArtifactCommentRequest
+
+        req = CreateArtifactCommentRequest(content="c", anchor_x=0, anchor_y=100)
+        assert req.anchor_x == 0
+        assert req.anchor_y == 100
+
+    def test_anchor_within_range_accepted(self):
+        from app.schemas.visual_artifact import CreateArtifactCommentRequest
+
+        req = CreateArtifactCommentRequest(content="c", anchor_x=50.5, anchor_y=12.3)
+        assert req.anchor_x == 50.5
+
+    def test_node_anchor_without_coords_still_valid(self):
+        """node_id 앵커(anchor_x/y 둘 다 None)는 이 상한 검증과 무관 — 무회귀."""
+        import uuid
+
+        from app.schemas.visual_artifact import CreateArtifactCommentRequest
+
+        req = CreateArtifactCommentRequest(content="c", node_id=uuid.uuid4())
+        assert req.anchor_x is None
+        assert req.anchor_y is None
+
+
+class TestCreateSpecPinRequestBounds:
+    def test_anchor_x_over_100_rejected(self):
+        from app.schemas.visual_artifact import CreateSpecPinRequest
+
+        with pytest.raises(ValidationError):
+            CreateSpecPinRequest(anchor_type="coord", anchor_x=100.1, anchor_y=50, description="d")
+
+    def test_pixel_scale_value_rejected(self):
+        """실측 근거 그 자체 — dev DB에서 발견된 실제 오염값(638.4, 398.4)을 그대로 투입해도
+        거부되는지(회귀 재발 방지)."""
+        from app.schemas.visual_artifact import CreateSpecPinRequest
+
+        with pytest.raises(ValidationError):
+            CreateSpecPinRequest(anchor_type="coord", anchor_x=638.4, anchor_y=398.4, description="d")
+
+    def test_anchor_within_range_accepted(self):
+        from app.schemas.visual_artifact import CreateSpecPinRequest
+
+        req = CreateSpecPinRequest(anchor_type="coord", anchor_x=50, anchor_y=50, description="d")
+        assert req.anchor_x == 50
+
+    def test_node_anchor_unaffected(self):
+        """anchor_type='node'는 anchor_x/y 자체를 안 받는 기존 규칙 그대로 무회귀."""
+        import uuid
+
+        from app.schemas.visual_artifact import CreateSpecPinRequest
+
+        req = CreateSpecPinRequest(anchor_type="node", node_id=uuid.uuid4(), description="d")
+        assert req.anchor_x is None
+
+
+class TestFieldDescriptionPromoted:
+    """AC③ — 도크스트링 규약을 스키마 필드 description으로 승격(계약 표면에 명시)."""
+
+    def test_comment_anchor_fields_have_percent_description(self):
+        from app.schemas.visual_artifact import CreateArtifactCommentRequest
+
+        schema = CreateArtifactCommentRequest.model_json_schema()
+        assert "%" in schema["properties"]["anchor_x"]["description"]
+        assert "%" in schema["properties"]["anchor_y"]["description"]

--- a/backend/tests/test_e_canvas_c2_s6_artifact_comments_realdb.py
+++ b/backend/tests/test_e_canvas_c2_s6_artifact_comments_realdb.py
@@ -194,13 +194,16 @@ async def test_add_comment_coordinate_anchor():
         try:
             resp = await client.post(
                 f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments",
-                json={"content": "여기 여백 좁아요", "anchor_x": 120.5, "anchor_y": 340.2},
+                # story #154a26be — 좌표 앵커는 %(0~100) 규약(ratio·픽셀 아님). 이 값들이
+                # 원래 120.5/340.2(범위 밖)였던 것 자체가 그 스토리가 지적한 문제의 실물
+                # 증거였다 — 서버가 안 막아 이 테스트조차 잘못된 스케일로 통과하고 있었음.
+                json={"content": "여기 여백 좁아요", "anchor_x": 62.5, "anchor_y": 84.2},
             )
             assert resp.status_code == 201, resp.text
             body = resp.json()["data"]
             assert body["node_id"] is None
-            assert body["anchor_x"] == 120.5
-            assert body["anchor_y"] == 340.2
+            assert body["anchor_x"] == 62.5
+            assert body["anchor_y"] == 84.2
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## 배경
[\[BE·검증\] 아티팩트 좌표 코멘트 anchor_x/y 상한 검증 부재](entity:story:154a26be-c6b2-45a1-a82e-d5f7c9033a94) — anchor_x/anchor_y 규약(%, 0~100)이 소비처 관행으로만 서 있고 서버가 안 막았다. 다른 단위(ratio·픽셀) 클라이언트가 통과하면 핀이 조용히 딴 자리에 렌더된다("금지 AC=서버가 거부" 클래스).

## 그라운딩 — 스토리 서술과 실제 코드 대조
스토리 본문은 "하한(>=0)만 검증"이라 했으나, 실제로 `CreateArtifactCommentRequest`(아티팩트 좌표 코멘트, 이 스토리의 주 대상)는 **하한조차 서버에 없었다**. 하한 체크는 `CreateSpecPinRequest`(별개 기능)에만 있었다 — 두 클래스를 혼동한 서술로 보임.

## ⛔정정(미르코 QA qa:changes + 페드루 PO, 2026-08-17)
초판은 `CreateSpecPinRequest`에도 le=100을 걸며 dev DB의 유일한 좌표핀 값(638.4, 398.4)을 "픽셀단위 오염 실물"로 서술했다 — **틀렸다**. `CreateSpecPinRequest`는 `CreateArtifactCommentRequest`와 다른 단위 계약(**px, canvas_bounds 좌표계**)이다 — FE `edit-canvas.tsx`가 `style={{ left: pin.anchorX, top: pin.anchorY }}`로 unitless 숫자를 직접 px로 쓴다. 그 638.4는 정상 데이터였고, le=100을 걸면 라이브 스펙핀 배치 대부분이 422로 깨지는 과잉살상이었다 — 미르코 QA의 음성대조(정상 경로 무회귀 확認)가 정확히 잡아냈다.

**최종 처방**: `CreateArtifactCommentRequest`(%)만 le=100 유지. `CreateSpecPinRequest`(px)는 하한(>=0)만 유지, 상한 없음.

## 변경
- `CreateArtifactCommentRequest.anchor_x/anchor_y`: `Field(ge=0, le=100, description=...)`(AC①+③).
- `CreateSpecPinRequest`: 기존 하한체크(`< 0`)만 유지(상한 없음 — px 계약이라 애초에 적용 대상 아님, 필드 description으로 명시).
- 기존 테스트(`test_add_comment_coordinate_anchor`)가 `anchor_x=120.5`(범위밖!)를 쓰고 있어 이 fix로 자연스레 422 전환됨 — **이 테스트 자체가 문제의 실물 증거**였음, 유효 %값(62.5/84.2)으로 정정.

## 검증
- 신규 12테스트 — comment 쪽 상한초과·하한미만·경계값(0/100)수용·node앵커 무회귀. spec-pin 쪽은 **정정 후** 638.4 그대로 수용(양성) + 하한(-1) 거부(음성) — 재발방지축으로 재구성.
- 뮤테이션킬(comment Field 제약 제거) → 정확히 5건 RED, 원복 GREEN.
- artifact_comment/spec_pin/visual_artifact 클러스터 59/59.
- 전체 스위트 6492/6499(7건은 develop 베이스라인 기존 것, 무관 확認).

## 못 잡는 것
prod의 comment 범위밖 건수는 미조사(선생님 명시 — 손 안 대는 축).

## QA
자체구현 — 교차 QA 필요(미르코군 재verdict 대기).

🤖 Generated with [Claude Code](https://claude.com/claude-code)