### PR TITLE
fix(#2728): billing 탭 직접 백엔드 호출을 same-origin 프록시로 수렴

### DIFF
--- a/apps/web/src/app/api/billing/status/route.ts
+++ b/apps/web/src/app/api/billing/status/route.ts
@@ -1,0 +1,12 @@
+import { proxyToFastapiWrapped } from '@/lib/fastapi-proxy';
+
+/**
+ * GET /api/billing/status — story #40659941(#2728 픽셀 검증 블로커). billing-tab.tsx가
+ * `NEXT_PUBLIC_FASTAPI_URL`로 브라우저에서 직접 fetch하던 것을 이 프록시로 수렴한다 —
+ * checkout/customer-key 프록시(같은 디렉토리)와 동일 이유: X-Org-Id 인터셉터(same-origin
+ * /api/* 전용, #2497)+CSP connect-src(브라우저가 백엔드 origin에 직접 못 붙음, 이 스토리의
+ * 실 원인) 둘 다 프록시 경유일 때만 적용된다.
+ */
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapiWrapped(request, '/api/v2/billing/status');
+}

--- a/apps/web/src/app/api/platform-settings/route.ts
+++ b/apps/web/src/app/api/platform-settings/route.ts
@@ -1,0 +1,12 @@
+import { proxyToFastapiWrapped } from '@/lib/fastapi-proxy';
+
+/**
+ * GET /api/platform-settings — story #40659941(#2728 픽셀 검증 블로커). billing-tab.tsx가
+ * `NEXT_PUBLIC_FASTAPI_URL`로 브라우저에서 직접 fetch하던 것을 이 프록시로 수렴한다(billing/
+ * status 프록시와 동일 이유 — X-Org-Id 인터셉터+CSP connect-src 둘 다 프록시 경유 전용).
+ * mutation은 공개 API에 없음(story #2728 — internal-api require_operator 전용) — 이 프록시도
+ * GET만 노출.
+ */
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapiWrapped(request, '/api/v2/platform-settings');
+}

--- a/apps/web/src/ee/components/billing/billing-tab.test.tsx
+++ b/apps/web/src/ee/components/billing/billing-tab.test.tsx
@@ -28,16 +28,21 @@ vi.mock('./toss-checkout', () => ({
 let container: HTMLDivElement;
 let root: Root;
 
+// story #40659941(#2728 픽셀 검증 블로커) — FASTAPI_URL 직접 fetch를 same-origin 프록시로
+// 수렴한 뒤부터 응답이 proxyToFastapiWrapped의 {data:...} 봉투를 쓴다(customer-key/checkout
+// 프록시와 동일 계약) — mock도 그 봉투 그대로 재현.
 function statusResponse(overrides: Partial<{ tier: string; can_manage: boolean }> = {}) {
   return {
     ok: true,
     json: async () => ({
-      org_id: 'org-1',
-      tier: overrides.tier ?? 'free',
-      billing_cycle: null,
-      status: 'active',
-      current_period_end: null,
-      can_manage: overrides.can_manage ?? true,
+      data: {
+        org_id: 'org-1',
+        tier: overrides.tier ?? 'free',
+        billing_cycle: null,
+        status: 'active',
+        current_period_end: null,
+        can_manage: overrides.can_manage ?? true,
+      },
     }),
   };
 }
@@ -50,8 +55,10 @@ function platformSettingsResponse(overrides: Partial<{ billing_price_public: boo
   return {
     ok: true,
     json: async () => ({
-      billing_price_public: overrides.billing_price_public ?? true,
-      billing_checkout_enabled: overrides.billing_checkout_enabled ?? true,
+      data: {
+        billing_price_public: overrides.billing_price_public ?? true,
+        billing_checkout_enabled: overrides.billing_checkout_enabled ?? true,
+      },
     }),
   };
 }

--- a/apps/web/src/ee/components/billing/billing-tab.tsx
+++ b/apps/web/src/ee/components/billing/billing-tab.tsx
@@ -26,6 +26,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { fetchWithAuth } from '@/lib/db/client';
 import { PricingPlanCard } from './pricing-plan-card';
 import { PricingLimitsTable } from './pricing-limits-table';
 import { PricingPacks, type PackKind } from './pricing-packs';
@@ -55,8 +56,6 @@ interface BillingStatus {
   can_manage: boolean;
 }
 
-const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
-
 function toTierId(raw: string | undefined): TierId {
   // story #2403 후속(2026-08-17) — prod org_subscriptions 실측: tier='pro'(레거시 Polar,
   // v2.2 D5가 은퇴시킨 이름) 조직이 3건 실존. TIER_ORDER에 'pro'가 없어 이 매핑 없이는
@@ -85,9 +84,12 @@ export function BillingTab({ orgId }: { orgId: string }) {
 
   const refetchStatus = () => {
     setLoading(true);
-    fetch(`${FASTAPI_URL()}/api/v2/billing/status`, { credentials: 'include' })
-      .then((r) => r.json() as Promise<BillingStatus>)
-      .then(setStatus)
+    // story #40659941(#2728 픽셀 검증 블로커) — FASTAPI_URL 직접 fetch는 CSP connect-src에
+    // 막힌다(브라우저→백엔드 origin 직행 금지). same-origin /api 프록시 경유로 수렴 +
+    // fetchWithAuth(콜드마운트 자동발화 GET이라 raw fetch 금지, #2689/#2691 가드).
+    fetchWithAuth('/api/billing/status', { credentials: 'include' })
+      .then((r) => r.json() as Promise<{ data: BillingStatus }>)
+      .then((json) => setStatus(json.data))
       .catch(() => setError(t('loadError')))
       .finally(() => setLoading(false));
   };
@@ -101,9 +103,9 @@ export function BillingTab({ orgId }: { orgId: string }) {
     // story #2728 — 미기입/fetch 실패 시 안전측 기본값(둘 다 false, 노출 안 함)으로
     // 폴백한다. "못 읽으면 일단 켜서 보여준다"는 이 스위치의 존재 이유(prod 결제표면
     // 전면 차단)를 정반대로 무력화한다.
-    fetch(`${FASTAPI_URL()}/api/v2/platform-settings`, { credentials: 'include' })
-      .then((r) => r.ok ? (r.json() as Promise<PlatformSettings>) : null)
-      .then((v) => setPlatformSettings(v ?? { billing_price_public: false, billing_checkout_enabled: false }))
+    fetchWithAuth('/api/platform-settings', { credentials: 'include' })
+      .then((r) => r.ok ? (r.json() as Promise<{ data: PlatformSettings }>) : null)
+      .then((json) => setPlatformSettings(json?.data ?? { billing_price_public: false, billing_checkout_enabled: false }))
       .catch(() => setPlatformSettings({ billing_price_public: false, billing_checkout_enabled: false }));
   }, []);
 


### PR DESCRIPTION
## Summary
- story #40659941 [FE·블로커] (#2728 픽셀 검증 블로커). CSP `connect-src`가 브라우저→백엔드 origin 직접 호출을 차단 — billing 탭만 `FASTAPI_URL`로 직접 fetch해서 저만 죽었다(다른 화면은 전부 이미 `/api` 프록시 경유). `NEXT_PUBLIC_FASTAPI_URL` 배선 자체는 정상이었다(#2728 후속 조사, 제가 반증해서 그 처방은 무효화됨 — PR #3188 참고).
- 정공법: CSP에 origin 추가(밴드에이드, prod CSP에서도 같은 운명이라 어차피 본체를 고쳐야 함) 대신 billing 탭을 기존 프록시 패턴으로 수렴.

## 축별 처리
① **ee/ 하위 FASTAPI_URL 직접 호출 전수(수+목록)**: 정확히 2건 — `billing-tab.tsx`의 `billing/status`·`platform-settings`. (`toss-checkout.ts`는 이미 `/api/billing/customer-key`·`/api/billing/checkout` 프록시 경유 — 손 안 댐.)
② **기존 프록시 패턴 재사용**: `customer-key`/`checkout` 프록시와 동일 패턴으로 신규 2개.
   - `GET /api/billing/status` → `/api/v2/billing/status`
   - `GET /api/platform-settings` → `/api/v2/platform-settings`
   둘 다 `proxyToFastapiWrapped` 재사용(X-Org-Id 인터셉터+CSP 우회 없이 통과, 신규 인가 로직 0).
③ **직접 호출 0 수렴 grep 검산**: `grep -rn FASTAPI_URL apps/web/src/ee/` → 코드 0건(설명 주석 1건만).
④ **CSP 무접촉**: 이미 정상 작동 중인 가드 — 이 fix가 우회하지 않고 정공법으로 맞춘다.

## 부수 발견(가드가 실제로 잡음)
`fetch('/api/*')` 상대경로로 바뀌면서 raw-fetch 가드(#2689/#2691, 콜드마운트 자동발화 GET에 `fetchWithAuth` 강제)가 신규 위반 2건을 정확히 잡아냄 — `fetchWithAuth(@/lib/db/client)`로 전환해 401-재시도-갱신 계약도 같이 확보(가드 재실행 0건 확認).

## Test plan
- [x] `billing-tab.test.tsx` mock을 프록시 봉투(`{data:...}`)로 갱신, 23/23 pass.
- [x] 뮤테이션킬: unwrap(`json.data`) 제거 → 정확히 4건 RED(원인: 이중포장 오분류), 원복 후 재그린.
- [x] `pnpm verify:no-new-raw-fetch-api` — fetchWithAuth 전환 전 신규 위반 2건 확인→전환 후 0건.
- [x] `pnpm verify:no-orphan-resource-routes`·`verify:reserved-first-segments-sync`·`verify:migrated-resources-sync` 전부 그린(무관 회귀 없음).
- [x] `bunx tsc --noEmit` 클린(무관 기존 에러 1건만), `bunx eslint` 클린.
- [ ] CI
- [ ] 머지·재배포 후 유나 픽셀 재개(billing 탭 직접호출 소거 확認)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>