### PR TITLE
[DRYRUN][SID:2408] branch protection 검증용 — 실 머지 안 함, 검증 후 close

### DIFF
--- a/DRYRUN_NOTE_DELETE_ME.md
+++ b/DRYRUN_NOTE_DELETE_ME.md
@@ -1,0 +1,1 @@
+# dry-run marker for story #2408(15953d1f) branch protection verification — no functional change, PR will be closed without merge


### PR DESCRIPTION
story #2408(15953d1f) ㉡ 집행(axis⑤) dry 검증 전용 — required review 제거+QA/Design review gate+Lint,TypeCheck,Test,Build 필수화+enforce_admins=true 후 실제로 리뷰 없이 게이트만으로 머지 가능 상태가 되는지 확認. **실 머지 안 함 — 검증 후 close.**