### PR TITLE
[SID:82593fb0] pricing_versions DEPRECATED 명시 — 코드 동작 무변경

### DIFF
--- a/backend/app/models/org_subscription.py
+++ b/backend/app/models/org_subscription.py
@@ -38,6 +38,10 @@ class OrgSubscription(Base):
     checkout_claimed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # E-ADMIN B1: grandfather — 가입(플랜변경)시점 pricing_version 참조. free tier·백필 전
     # 기존 구독은 NULL(0146은 구조만, 값 백필은 가격 확정 후 별도 마이그).
+    # ⛔VESTIGE(story #2731/82593fb0, 2026-08-18) — offering_version_id(아래)가 이 컬럼을
+    # 완전히 대체했다. 이 컬럼을 채우거나 읽는 코드는 전수 grep 0건(app/models/
+    # pricing_version.py의 DEPRECATED 표기 참고) — DROP은 story #70bc4bc3(prod 스키마
+    # 불일치 판별)에 종속돼 미루되, 신규 코드는 이 컬럼을 쓰지 말 것.
     pricing_version_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("pricing_versions.id"), nullable=True
     )

--- a/backend/app/models/pricing_version.py
+++ b/backend/app/models/pricing_version.py
@@ -1,4 +1,20 @@
-"""가격 버전 이력(E-ADMIN B1, story 553fc58d) — team/pro 유료 tier의 가격 변경 이력.
+"""⛔DEPRECATED(story #2731/82593fb0, 2026-08-18 그라운딩) — v2.3 이행 후 `offering_versions`
+(migration 0228, `app/models/offering_version.py`)가 실 가격/과금 결정 축을 전부 대체했다.
+그라운딩 실측: 이 클래스(`PricingVersion`)를 import하는 곳은 이 파일과 `models/__init__.py`
+(등록용) 뿐 — 어떤 router·service·repository도 쿼리하지 않는다(전수 grep, 0건). FE도 무접촉.
+잔존 참조는 딱 둘: ①`org_subscriptions.pricing_version_id`(FK, nullable) — 컬럼은 있으나
+아무 코드도 채우거나 읽지 않는 순수 vestige(grep 0건) ②sprintable-admin(internal-api)의
+CRUD write 경로 — prod는 `PRICING_VERSIONS_ENABLED=false`로 완전 게이트오프(2026-07-09
+부팅실패 발견 이후)돼 있으나 **dev는 env override가 없어 기본값 True로 여전히 라이브**
+(admin-web `/pricing` 다이얼로그로 새 행 생성 가능) — 단 그렇게 만든 행을 읽는 코드가
+없어 실제 가격에 영향 0.
+
+**DROP 안 함** — story #70bc4bc3("P0급 잠재·prod DB: alembic_version(0253)과 pricing_versions
+실 스키마 불일치 — prod pre-0228 형상·polar_price_id 잔존 판별")이 이 테이블 자체를 대상으로
+진행 중이라 스키마 변경은 그쪽 판별에 종속. 이 docstring 갱신은 순수 문서화(코드 동작 무변경).
+
+---
+가격 버전 이력(E-ADMIN B1, story 553fc58d) — team/pro 유료 tier의 가격 변경 이력.
 
 **append-only**: 가격 값이 담긴 행은 절대 UPDATE되지 않는다. 가격이 바뀌면 새 행을
 INSERT하고, 직전 "열린"(effective_to IS NULL) 행의 effective_to를 새 행의 effective_from


### PR DESCRIPTION
## 배경
story #2731(82593fb0) — pricing_versions(구)↔offering_versions(신) 이원화 정리 그라운딩.

## 그라운딩 실측(①)
- `PricingVersion` 클래스를 import하는 곳: `pricing_version.py` 자신 + `models/__init__.py`(등록용) 뿐 — router/service/repository 0건(전수 grep).
- 문자열 `pricing_versions` 매치 9개 파일 중 실제 코드 참조는 `org_subscription.py`의 FK 컬럼 정의 1건뿐 — 나머지 8개는 전부 "동형/동일 패턴" docstring 코멘트.
- `org_subscriptions.pricing_version_id`(FK) — 컬럼은 존재하나 채우거나 읽는 코드 0건(grep).
- FE(`apps/web`) 무접촉.
- **잔존**: sprintable-admin(internal-api) CRUD write 경로는 여전히 실재 — prod는 `PRICING_VERSIONS_ENABLED=false`(2026-07-09 부팅실패 발견 이후 명시 게이트오프, Cloud Run env 실측 확認), **dev는 override 없어 기본값 True로 여전히 라이브**(admin-web `/pricing` 다이얼로그로 새 행 생성 가능 — 단 그 행을 읽는 코드가 없어 실제 가격에 영향 0).

## 변경
- `pricing_version.py` 모델 docstring 최상단에 DEPRECATED 마커 + 위 실측 요약 추가.
- `org_subscription.py`의 `pricing_version_id` FK 컬럼에 vestige 코멘트 추가.
- **DROP 안 함** — story #70bc4bc3(prod alembic_version(0253)↔실 스키마 불일치 판별, pre-0228 형상·polar_price_id 잔존)이 이 테이블 자체를 대상으로 진행 중이라 스키마 변경은 그쪽 판별에 종속. 이 PR은 순수 문서화, 코드 동작 무변경.

## 검증
- 문법 확認(`ast.parse` + import) 클린.
- `pricing_version`/`org_subscription` 관련 로컬 테스트 6건 실패 — **사전존재·무관** 확認(동일 실패가 clean develop에서도 재현, `organizations.plan` 컬럼 부재로 인한 별개 이슈).

## QA
문서 전용 변경 — 리스크 낮음.