### PR TITLE
feat(canvas): MCP sprintable_import_image_artifact — base64 원콜 이미지 임포트 (#2707)

### DIFF
--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import base64
+import binascii
+import re
 import uuid
 from datetime import datetime
 
@@ -12,12 +15,15 @@ from app.dependencies.auth import AuthContext, get_current_user, get_scope_conte
 from app.dependencies.database import get_db
 from app.models.asset import Asset
 from app.services.artifact_image_url import _canonicalize_props, sign_image_srcs_in_nodes
+from app.services.asset_registry import DEFAULT_CONTAINER
+from app.services.storage import get_storage_provider
 from app.models.visual_artifact import (
     ArtifactComment, ArtifactExport, ArtifactNode, ArtifactSpecPin, ArtifactVersion, VisualArtifact,
 )
 from app.schemas.visual_artifact import (
     ArtifactCommentResponse,
     ArtifactExportResponse,
+    ArtifactNodeIn,
     ArtifactNodeOperation,
     ArtifactNodeOut,
     ArtifactVersionSummary,
@@ -29,6 +35,7 @@ from app.schemas.visual_artifact import (
     EditArtifactRequest,
     ExportUploadUrlRequest,
     ExportUploadUrlResponse,
+    ImportImageArtifactRequest,
     SpecPinResponse,
     UpdateSpecPinRequest,
     VisualArtifactDetail,
@@ -37,6 +44,13 @@ from app.schemas.visual_artifact import (
 from app.services.member_resolver import filter_org_member_ids
 from app.services.notification_dispatch import dispatch_notification
 from app.services.project_auth import assert_target_in_caller_org
+
+# story 64010b05 FE 라우트(apps/web import-image/route.ts)와 동일 상수(포팅판 — 20MB, 첨부
+# 100MB보다 보수적). 이 파일 안에서만 쓰는 로컬 상수라 GCS host 문자열도 artifact_image_url.py/
+# asset_registry.py와 같은 값을 여기 한 번 더 든다(이 두 파일의 기존 중복 관례 그대로 — 새 SSOT
+# 발명 0).
+_MAX_IMPORT_IMAGE_BYTES = 20 * 1024 * 1024
+_GCS_HOST = "storage.googleapis.com"
 
 router = APIRouter(prefix="/api/v2/visual-artifacts", tags=["visual-artifacts", "Work"])
 
@@ -185,6 +199,48 @@ async def create_artifact(
         nodes=node_outs,
     )
     return _ok(detail.model_dump(mode="json"), status=201)
+
+
+@router.post("/import-image", status_code=201)
+async def import_image_artifact(
+    body: ImportImageArtifactRequest,
+    auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """story b6b9c52d(#2707 부수) — MCP `sprintable_import_image_artifact` 전용 원콜 입구
+    (base64 in → artifact out). FE import-image 라우트(story 64010b05, apps/web
+    api/visual-artifacts/import-image/route.ts)의 서버사이드 GCS 업로드 로직을 포팅하고, 그 뒤를
+    이어 `create_artifact()`를 내부 함수 호출로 그대로 재사용(DB write 로직 사본 발명 0 — 두
+    갈래가 다시 어긋나면 create_artifact 한쪽만 고치고 여기를 잊는 사고가 난다는 뜻이니, 이
+    엔드포인트를 건드릴 땐 그 함수도 같이 봐야 한다)."""
+    if not body.content_type.startswith("image/"):
+        return _err("VALIDATION_ERROR", "content_type must be an image/* type", 400)
+    try:
+        image_bytes = base64.b64decode(body.image_base64, validate=True)
+    except (binascii.Error, ValueError):
+        return _err("VALIDATION_ERROR", "image_base64 is not valid base64", 400)
+    if len(image_bytes) > _MAX_IMPORT_IMAGE_BYTES:
+        return _err("VALIDATION_ERROR", "image too large (max 20MB)", 413)
+
+    org_id, project_id = scope["org_id"], scope["project_id"]
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    safe_title = re.sub(r"[^\w.-]+", "_", body.title).strip("_")[:128] or "image"
+    object_path = f"org/{org_id}/project/{project_id}/canvas-import/{uuid.uuid4()}-{safe_title}"
+    uploaded = await get_storage_provider().put_object(
+        DEFAULT_CONTAINER, object_path, image_bytes, content_type=body.content_type,
+    )
+    if not uploaded:
+        return _err("UPSTREAM_ERROR", "image upload failed", 502)
+
+    canonical_url = f"https://{_GCS_HOST}/{DEFAULT_CONTAINER}/{object_path}"
+    create_body = CreateArtifactRequest(
+        title=body.title, story_id=body.story_id, doc_id=body.doc_id, source="imported",
+        nodes=[ArtifactNodeIn(type="html_blob", props={"src": canonical_url})],
+    )
+    return await create_artifact(create_body, auth=auth, scope=scope, session=session)
 
 
 async def _get_artifact_or_404(

--- a/backend/app/schemas/visual_artifact.py
+++ b/backend/app/schemas/visual_artifact.py
@@ -72,6 +72,18 @@ class CreateArtifactRequest(BaseModel):
         return v
 
 
+class ImportImageArtifactRequest(BaseModel):
+    """story b6b9c52d(#2707 부수) — MCP `import_image_artifact` 입구. FE
+    `apps/web/src/app/api/visual-artifacts/import-image/route.ts`(story 64010b05)의 base64 포팅판
+    — Bash/HTTP 클라이언트가 없는 에이전트는 그 라우트를 스스로 못 타므로(2단계 curl 수동 플로우
+    불가), base64 인라인 한 번으로 업로드+artifact 생성까지 묶는다."""
+    title: str
+    image_base64: str
+    content_type: str
+    story_id: uuid.UUID | None = None
+    doc_id: uuid.UUID | None = None
+
+
 class ArtifactVersionSummary(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     id: uuid.UUID

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -401,6 +401,10 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
     "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
     "sprintable_delete_spec_pin",
+    # story b6b9c52d(#2707 부수): sprintable_import_image_artifact — base64 원콜 이미지 임포트
+    # 신설(Bash/HTTP 클라이언트 없는 에이전트용 create_artifact 대안). tool_group()은 "artifact"
+    # substring 매칭으로 이미 "canvas" 그룹 귀속(신규 매핑 불요).
+    "sprintable_import_image_artifact",
     # story #1922: sprintable_delete_artifact — artifact soft delete(생성자 전용) 전용 신설.
     # #2010(sprintable_transition_goal)이 이 SSOT 목록 등록을 처음 커밋에서 빠뜨려 role-template
     # picker 카탈로그/신규 에이전트 채용 치트시트에서 누락됐던 갭(follow-up 커밋 8126465e로 정정)을

--- a/backend/app/services/storage/base.py
+++ b/backend/app/services/storage/base.py
@@ -2,6 +2,12 @@
 
 D3 결정: BE 범위 = attachment_context 실사용인 **read + sign 만**. put/delete 는 FE 업로드
 경로 전담(BE 미사용) → dead surface 회피(YAGNI). 후속에서 필요 시 확장.
+
+story b6b9c52d(2026-08-17, #2707 후속) — 그 "후속"이 처음 실현됐다. MCP 서버는 FastAPI
+백엔드와 HTTP로만 통신하는 별도 프로세스라 Next.js FE의 put 경로를 호출할 방법이 없어,
+`POST /api/v2/visual-artifacts/import-image`(sprintable_import_image_artifact MCP 도구
+전용, `routers/visual_artifacts.py`)가 BE 런타임에서 처음 `put_object`를 호출한다 — D3의
+"put=FE 전담" 원칙에 대한 의도적 예외(구조적으로 불가피, dead surface 아님).
 """
 from __future__ import annotations
 

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -37,11 +37,12 @@ from .tools.judgments import AddJudgmentInput, ListJudgmentsInput, add_judgment,
 from .tools.session_context import SessionContextInput, get_session_context
 from .tools.visual_artifacts import (
     AddArtifactCommentInput, CreateArtifactInput, CreateSpecPinInput, DeleteArtifactInput,
-    DeleteSpecPinInput, EditArtifactInput, GetArtifactInput, ListArtifactCommentsInput,
-    ListArtifactsInput, ListSpecPinsInput, ProposeCanonicalInput, UpdateSpecPinInput,
+    DeleteSpecPinInput, EditArtifactInput, GetArtifactInput, ImportImageArtifactInput,
+    ListArtifactCommentsInput, ListArtifactsInput, ListSpecPinsInput, ProposeCanonicalInput,
+    UpdateSpecPinInput,
     add_artifact_comment, create_artifact, create_spec_pin, delete_artifact, delete_spec_pin,
-    edit_artifact, get_artifact, list_artifact_comments, list_artifacts, list_spec_pins,
-    propose_canonical_version, update_spec_pin,
+    edit_artifact, get_artifact, import_image_artifact, list_artifact_comments, list_artifacts,
+    list_spec_pins, propose_canonical_version, update_spec_pin,
 )
 from .tools.agent_runs import (
     EmitEventInput, PollEventsInput, UpdateRunStatusInput,
@@ -693,15 +694,28 @@ _TOOL_DEFS: list[tuple] = [
      " 산출물인지 붙어야 검색·backlink·evidence로 나중에 다시 찾긴다). standalone(둘 다 생략)도"
      " 정당한 사용이다 — 강제 아님, 지금 맥락에 붙일 story/doc이 실제로 없으면 그냥 생략."
      " ⭐스크린샷/이미지 증거(story #2707) — base64를 이 도구 호출에 직접 싣지 말 것(토큰 폭증)."
-     " 2단계로: ①먼저 `POST $SPRINTABLE_API_URL/api/visual-artifacts/import-image`를 curl 등으로"
+     " Bash/HTTP 클라이언트 접근이 있는 에이전트는 2단계로: ①먼저"
+     " `POST $SPRINTABLE_API_URL/api/visual-artifacts/import-image`를 curl 등으로"
      " 직접 호출(multipart/form-data, 필드명 `file`, 헤더 `Authorization: Bearer $AGENT_API_KEY`)해"
      " GCS url을 받는다(예: `curl -F file=@screenshot.png -H \"Authorization: Bearer $AGENT_API_KEY\""
      " $SPRINTABLE_API_URL/api/visual-artifacts/import-image`) ②그 url을 이 도구의"
      " `nodes=[{\"type\": \"html_blob\", \"props\": {\"src\": \"<①의 url>\"}}]`로 넣어 호출하면"
-     " FE가 자동으로 image 포맷으로 렌더한다. (Bash/HTTP 클라이언트 접근이 없는 에이전트는 ①을"
-     " 스스로 못 탄다 — 그 경우는 이 경로 대상이 아님.)"
+     " FE가 자동으로 image 포맷으로 렌더한다. Bash/HTTP 클라이언트 접근이 없는 에이전트는 그 ①을"
+     " 스스로 못 타므로 대신 sprintable_import_image_artifact(작은 이미지 전용, 원콜)를 쓴다."
      " source는 \"created\"(기본) 또는 \"imported\"만 허용(다른 값은 422).",
      CreateArtifactInput, create_artifact),
+    ("sprintable_import_image_artifact",
+     "[일감] base64 이미지 한 번으로 업로드+artifact 생성을 원콜로 처리(story b6b9c52d) —"
+     " Bash/HTTP 클라이언트 접근이 없어 sprintable_create_artifact의 2단계 curl 플로우를 스스로"
+     " 못 타는 에이전트 전용 대안. ⭐스크린샷/시안/아이콘 등 **작은** 이미지 증거를 산출물로 남길"
+     " 때 이 도구로 — 단, image_base64는 도구 호출 인자 텍스트로 그대로 실리므로 호출하는 에이전트"
+     " 자신의 최대 출력 토큰 한도가 실질 상한이다(대략 수백 KB 이하 이미지 권장). BE 자체는"
+     " 최대 20MB까지 받지만, 그보다 큰 이미지는 이 도구로 못 보내니 Bash/HTTP 클라이언트가 있는"
+     " 에이전트라면 sprintable_create_artifact의 2단계 curl 플로우를 대신 쓴다."
+     " content_type은 image/*여야 함(아니면 422). story_id/doc_id(선택, sprintable_create_artifact와"
+     " 동형) — 맥락이 있으면 잇는 것을 권장, standalone도 정당. 반환은 get_artifact와 동형"
+     " artifact 상세(FE-import와 동일하게 렌더).",
+     ImportImageArtifactInput, import_image_artifact),
     ("sprintable_get_artifact",
      "[일감] 시각 산출물 단건 조회(latest 버전 + nodes). ⭐편집/코멘트/핀 작업 전 먼저 현재 상태(노드"
      " 구조·프레임)를 확인할 때.",

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -134,6 +134,21 @@ class ProposeCanonicalInput(SprintableInput):
     version_number: int
 
 
+class ImportImageArtifactInput(SprintableInput):
+    """story b6b9c52d(#2707 부수) — Bash/HTTP 클라이언트 접근이 없는 에이전트도 base64 한
+    번으로 이미지 artifact를 만들 수 있게 하는 입구(create_artifact 자체 docstring의 2단계
+    curl 수동 플로우를 못 타는 에이전트 대상). 실전 주의: image_base64는 도구 호출 인자
+    텍스트로 그대로 실려 나가므로, 호출하는 에이전트 자신의 최대 출력 토큰 한도가 실질
+    상한이다 — 작은 스케치/아이콘(대략 수백 KB 이하) 용도로 한정. 그보다 큰 이미지(최대
+    20MB까지 BE는 받음)는 create_artifact 자체 설명에 있는 2단계 curl 플로우(Bash/HTTP
+    클라이언트가 있는 에이전트 전용)를 계속 쓴다."""
+    title: str
+    image_base64: str
+    content_type: str
+    story_id: str | None = None
+    doc_id: str | None = None
+
+
 class ListArtifactsInput(SprintableInput):
     # 프로젝트 스코프는 서버-파생(키 컨텍스트·비-caller-suppliable) — 아래 필터만 선택 지정.
     story_id: str | None = None
@@ -165,6 +180,24 @@ async def create_artifact(args: CreateArtifactInput) -> list[TextContent]:
         if args.canvas_bounds:
             body["canvas_bounds"] = args.canvas_bounds.model_dump(exclude_none=True)
         result = await client.post("/api/v2/visual-artifacts", json=body)
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def import_image_artifact(args: ImportImageArtifactInput) -> list[TextContent]:
+    """base64 이미지 한 번으로 업로드+artifact 생성을 원콜로 묶는다(story b6b9c52d) — BE
+    `/import-image`가 GCS 업로드부터 create_artifact 위임까지 내부에서 전부 처리, 반환은
+    get_artifact/list_artifacts와 동형 artifact 상세(FE-import(source="imported")와 동일 렌더)."""
+    try:
+        body: dict = {
+            "title": args.title, "image_base64": args.image_base64, "content_type": args.content_type,
+        }
+        if args.story_id:
+            body["story_id"] = args.story_id
+        if args.doc_id:
+            body["doc_id"] = args.doc_id
+        result = await client.post("/api/v2/visual-artifacts/import-image", json=body)
         return ok(result)
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -107,6 +107,7 @@ EXPECTED_TOOLS = {
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
+    "sprintable_import_image_artifact",
     "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
     "sprintable_delete_spec_pin", "sprintable_delete_artifact",
     # events (2) — story #2634: 이벤트 레지스트리 발행/카탈로그 조회.
@@ -138,7 +139,7 @@ def test_total_tool_count():
     # 119→121. story #2668(B3): sprintable_submit_for_approval 1종 신설(문서 결재 상신
     # REST를 MCP로 노출 — 도구 목록에 없어 에이전트가 발견 못 하던 것) — 121→122.
     # story #2709: sprintable_request_decision 1종 신설(AskUserQuestion 블로킹 대체) — 122→123.
-    assert len(_TOOLS) == 123
+    assert len(_TOOLS) == 124  # story b6b9c52d(#2707 부수): sprintable_import_image_artifact 신설 123→124
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_037a8aa8_agent_discoverability.py
+++ b/backend/tests/test_037a8aa8_agent_discoverability.py
@@ -17,7 +17,7 @@ _CANVAS_TOOL_NAMES = (
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
     "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
-    "sprintable_delete_spec_pin",
+    "sprintable_delete_spec_pin", "sprintable_import_image_artifact",
 )
 
 

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -69,16 +69,17 @@ async def test_registered_standup_history_tool_still_accepts_known_args():
 
 
 def test_all_registered_tools_share_the_same_lockdown():
-    """AC2 카운트 — `_TOOL_DEFS` 122개 + ping 1개 = 123개(story #2634: sprintable_publish_event/
+    """AC2 카운트 — `_TOOL_DEFS` 123개 + ping 1개 = 124개(story #2634: sprintable_publish_event/
     sprintable_list_event_definitions 추가로 117→119. story #2636: sprintable_register_
     event_definition/sprintable_update_event_definition 추가로 119→121. story #2668:
     sprintable_submit_for_approval 추가로 121→122. story #2709: sprintable_request_decision
-    추가로 122→123) 전부 arg_model이
+    추가로 122→123. story b6b9c52d(#2707 부수): sprintable_import_image_artifact 추가로
+    123→124) 전부 arg_model이
     extra=forbid로 잠겨 있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
     from sprintable_mcp import server as srv
 
     tools = srv.mcp._tool_manager.list_tools()
-    assert len(tools) == 123
+    assert len(tools) == 124
     unlocked = [
         t.name for t in tools
         if t.fn_metadata.arg_model.model_config.get("extra") != "forbid"

--- a/backend/tests/test_b6b9c52d_mcp_import_image_artifact_realdb.py
+++ b/backend/tests/test_b6b9c52d_mcp_import_image_artifact_realdb.py
@@ -77,7 +77,7 @@ def _client_for(app):
 
 async def _setup_app(app, Session, org_id, project_id, user_id=None):
     from app.dependencies.auth import AuthContext, get_current_user
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     async def _db():
         async with Session() as s:
@@ -94,7 +94,7 @@ async def _setup_app(app, Session, org_id, project_id, user_id=None):
             claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
         )
 
-    app.dependency_overrides[get_db] = _db
+    override_db_and_read(app, _db)
     app.dependency_overrides[get_current_user] = _auth
 
 

--- a/backend/tests/test_b6b9c52d_mcp_import_image_artifact_realdb.py
+++ b/backend/tests/test_b6b9c52d_mcp_import_image_artifact_realdb.py
@@ -1,0 +1,248 @@
+"""story b6b9c52d(#2707 부수) — MCP `sprintable_import_image_artifact` 전용 원콜 이미지 임포트
+BE 엔드포인트(`POST /api/v2/visual-artifacts/import-image`). crux: content-type/size 검증·
+base64 디코드 실패 처리·업로드→create_artifact 위임 왕복(source=imported·html_blob 노드·
+canonical url)·story_id cross-org 스코프 차단(create_artifact의 _assert_link_target_in_scope
+재사용 확인, C1-S3 crux①과 동형)."""
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.pm import Story
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+    project_b = Project(id=uuid.uuid4(), org_id=org_b.id, name="Org B Project")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    story_a = Story(id=uuid.uuid4(), org_id=org_a.id, project_id=project_a.id, title="Story A", status="backlog")
+    story_b = Story(id=uuid.uuid4(), org_id=org_b.id, project_id=project_b.id, title="Story B", status="backlog")
+    session.add_all([story_a, story_b])
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "project_a_id": project_a.id,
+        "story_a_id": story_a.id, "story_b_id": story_b.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, project_id, user_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _post_import(client, **body):
+    return await client.post("/api/v2/visual-artifacts/import-image", json=body)
+
+
+@pytest.mark.anyio
+async def test_import_image_rejects_non_image_content_type():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_import(
+                client, title="Sketch",
+                image_base64=base64.b64encode(b"fake-bytes").decode(),
+                content_type="text/plain",
+            )
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_import_image_rejects_invalid_base64():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_import(
+                client, title="Sketch", image_base64="not-valid-base64-!!!", content_type="image/png",
+            )
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_import_image_rejects_oversized_payload():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            oversized = os.urandom(20 * 1024 * 1024 + 1)
+            resp = await _post_import(
+                client, title="Sketch",
+                image_base64=base64.b64encode(oversized).decode(), content_type="image/png",
+            )
+            assert resp.status_code == 413, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_import_image_success_creates_artifact_with_canonical_url():
+    """crux②③⑤: 업로드→create_artifact 위임 왕복 — source=imported·html_blob 노드·
+    props.src가 canonical GCS url 형태(서명 쿼리 없음, artifact_image_url.py 컨벤션과 동형)."""
+    from app.main import app
+    from app.services.asset_registry import DEFAULT_CONTAINER
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            image_bytes = os.urandom(1024)
+            resp = await _post_import(
+                client, title="Sketch v1",
+                image_base64=base64.b64encode(image_bytes).decode(), content_type="image/png",
+                story_id=str(seeded["story_a_id"]),
+            )
+            assert resp.status_code == 201, resp.text
+            data = resp.json()["data"]
+            assert data["source"] == "imported"
+            assert data["story_id"] == str(seeded["story_a_id"])
+            assert len(data["nodes"]) == 1
+            node = data["nodes"][0]
+            assert node["type"] == "html_blob"
+            # 응답의 props.src는 항상 신선 서명본(story #2711 AC1 — read 경로가 raw를 그대로
+            # 주지 않는다) — canonical raw 저장을 검증하려면 DB를 직접 봐야 한다(아래).
+            assert "canvas-import/" in node["props"]["src"]
+
+            from app.models.visual_artifact import ArtifactNode
+            from sqlalchemy import select
+            async with Session() as verify_session:
+                stored_node = (await verify_session.execute(
+                    select(ArtifactNode).where(ArtifactNode.artifact_id == uuid.UUID(data["id"]))
+                )).scalar_one()
+            stored_src = stored_node.props["src"]
+            assert stored_src.startswith(
+                f"https://storage.googleapis.com/{DEFAULT_CONTAINER}/org/{seeded['org_a_id']}/"
+                f"project/{seeded['project_a_id']}/canvas-import/"
+            )
+            assert "?" not in stored_src  # raw canonical — 서명 쿼리스트링 없음(write 경로 canonicalize)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_import_image_cross_org_story_link_blocked():
+    """crux①: Org A caller가 Org B story_id로 연결 시도 → 404(create_artifact의
+    _assert_link_target_in_scope 위임 재사용 확인 — C1-S3 crux①과 동형 축)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_import(
+                client, title="Injected",
+                image_base64=base64.b64encode(os.urandom(16)).decode(), content_type="image/png",
+                story_id=str(seeded["story_b_id"]),
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -79,6 +79,7 @@ def test_tool_names_and_param_models_untouched():
     story #2636: sprintable_register_event_definition/sprintable_update_event_definition
     2종 신설(org 커스텀 이벤트 등록/수정) — 118→120. story #2668(B3): sprintable_submit_
     for_approval 1종 신설(문서 결재 상신 MCP 발견 경로) — 120→121. story #2709: sprintable_
-    request_decision 1종 신설(AskUserQuestion 블로킹 대체) — 121→122."""
-    assert len(_TOOL_DEFS) == 122
+    request_decision 1종 신설(AskUserQuestion 블로킹 대체) — 121→122. story b6b9c52d(#2707
+    부수): sprintable_import_image_artifact 1종 신설(base64 원콜 이미지 임포트) — 122→123."""
+    assert len(_TOOL_DEFS) == 123
     assert all(name.startswith("sprintable_") for name in _TOOLS)


### PR DESCRIPTION
## Summary
story b6b9c52d(#2707)의 «한계» 절이 명시적으로 후속으로 미뤄둔 항목 — Bash/HTTP 클라이언트
접근이 없는 순수 MCP-tool-only 에이전트도 이미지를 artifact로 남길 수 있게 하는 신규 MCP 도구.

- `POST /api/v2/visual-artifacts/import-image` 신설 — FE import-image 라우트(story
  64010b05)의 서버사이드 GCS 업로드 로직을 포팅하고, 그 뒤를 `create_artifact()` 직접 함수
  호출로 이어(DB write 로직 사본 발명 0).
- MCP `sprintable_import_image_artifact` — 위 엔드포인트의 얇은 wrapper(base64 in → artifact
  상세 out, get_artifact와 동형 응답).
- `sprintable_create_artifact` 도구 설명에 "Bash/HTTP 클라이언트 없는 에이전트는 이 신규
  도구를 대신 쓴다"는 안내 추가(양방향 교차참조).

## 이름+수 스윕(신규 MCP 도구라 필수)
- `tests/mcp/test_contract.py`: `EXPECTED_TOOLS`에 추가 + `assert len(_TOOLS)` 123→124
- `app/services/mcp_toolset.py`: `ALL_TOOL_NAMES`에 추가(`tool_group()`/`is_destructive()`는
  "artifact" substring·"sprintable_delete" prefix 매칭이라 신규 매핑 불요 — 자동 귀속 확인)
- `tests/test_037a8aa8_agent_discoverability.py`: `_CANVAS_TOOL_NAMES` 11→12,
  `test_canvas_tool_descriptions_have_usage_trigger` 통과(⭐트리거 라인 포함) 확인

## ④ MCP payload 실한도(페드루 명시 요건)
실측 결론: base64는 도구 호출 인자 텍스트로 그대로 실려 나가므로 **실질 상한은 BE(20MB까지
받음)가 아니라 호출하는 에이전트 자신의 최대 출력 토큰 한도** — 몇 자릿수 더 작다(20MB
base64 ≈ 27M 문자 ≈ 수백만 토큰, 어떤 모델의 단일 출력으로도 불가능). 그래서:
- 이 도구는 **작은 이미지(스케치/아이콘, 대략 수백 KB 이하) 전용**으로 설계·문서화했다(도구
  description에 명시).
- 20MB급 큰 이미지는 **신규 fallback을 만들 필요가 없다** — `sprintable_create_artifact`
  자체 설명에 이미 있는 2단계 curl 업로드 플로우(Bash/HTTP 클라이언트 있는 에이전트 전용)가
  정확히 그 fallback이다. 서명 업로드 2단계는 이미 존재하는 경로라 이 PR에서 새로 만들지
  않았다.
- BE 자체의 20MB 검증(413)은 그대로 유지 — FE import-image 라우트와 parity, MCP 도구 자신의
  실사용 한도와는 별개 축.

## 판단 콜 — D3(storage put=FE 전담) 경계 확장
`storage/base.py`의 D3 결정은 "BE는 read+sign만, put/delete는 FE 전담(YAGNI)"이라 명시했었다.
이 PR이 처음으로 **BE 런타임 경로에서 `put_object`를 호출**(기존엔 `doc_asset_backfill.py`
백필 전용)한다 — MCP 서버가 FastAPI 백엔드와 HTTP로만 통신하고(별도 프로세스, `app.*` 직접
import 불가) Next.js FE 라우트를 호출할 방법이 없어, base64 원콜 지원이 필요하다면 이 확장이
구조적으로 불가피했다(page.md 우회 경로 없음). Pedro 5-point spec②의 명시적 지시.

## Test plan
- [x] 신규 realdb 테스트 5건(`tests/test_b6b9c52d_mcp_import_image_artifact_realdb.py`) —
  content-type 검증·base64 디코드 실패·20MB 초과·성공 왕복(canonical url 저장 확인)·story_id
  cross-org 스코프 차단(create_artifact의 `_assert_link_target_in_scope` 위임 재사용)
- [x] 뮤테이션-킬 확인(로컬): content-type 체크 제거→테스트 잡음, size 체크 제거→테스트
  잡음, story_id 드롭→success/cross-org 테스트 둘 다 잡음. 전부 복원 후 재확인 GREEN.
- [x] 기존 canvas/visual-artifact/security 스위트 회귀 없음(로컬 create_all 스키마+
  disposable PG, destructive_schema 마커 파일과 격리 실행 — role_templates/team_members
  seed 데이터 없는 19건은 스키마-only 한계로 실패, 이 PR 코드와 무관·CI가 최종 판정)
- [ ] CI green

## 정리 필요(비차단, 참고)
story b6b9c52d 본문에 남은 TEMP-QA 아티팩트 `e63c2260-86a7-48f8-adcc-c1995f20baf4` — 생성자
전용 삭제라 제 권한 밖(생성자=미르코/그라운딩 세션). 삭제 필요.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>