### PR TITLE
[SID:2739] dev TOSS_WEBHOOK_SECRET을 manual-env-allowlist에 등재

### DIFF
--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -190,6 +190,13 @@ services:
       - key: TOSS_PAYMENTS_SECRET_KEY
         reason: dev와 동일 사유(TOSS_PAYMENTS_CLIENT_KEY 참고) — test_sk 값, Settings.toss_payments_secret_key.
         owner: TBD
+      - key: TOSS_WEBHOOK_SECRET
+        reason: >-
+          #2728 Toss 웹훅 서명 검증용 시크릿 — Secret Manager(TOSS_WEBHOOK_SECRET_DEV)에
+          이미 발급돼 있던 값. app/core/config.py Settings.toss_webhook_secret로 읽음.
+          Secret Manager 등록·Cloud Run env 수동 배선 PO(#2728 착수 時) — TOSS_PAYMENTS_*
+          3건과 동형, 등재만 누락돼 있었음(story #2739/054edff4).
+        owner: TBD
 
   sprintable-backend-prod:
     keys:


### PR DESCRIPTION
## 배경
#2728 Toss 웹훅 서명 검증 작업 때 Secret Manager(TOSS_WEBHOOK_SECRET_DEV) 등록+dev Cloud Run 수동 배선까지 했으나 `infra/manual-env-allowlist.yml` 등재를 빠뜨림. 2026-08-18 00:17 daily env 드리프트 가드가 이를 FAIL 1건으로 정상 탐지.

## 변경
- `infra/manual-env-allowlist.yml`의 `sprintable-backend-dev` 절에 `TOSS_WEBHOOK_SECRET` 항목 추가 — 기존 `TOSS_PAYMENTS_*` 3건과 동형(reason에 Secret Manager 이름·용도·수동 배선 주체 명기)
- 가드 로직/스크립트 변경 없음(가드는 설계대로 작동한 정상 사례)

## 검증
- `python3 infra/check_env_drift.py` — fix 前(`git stash`로 원복) TOSS_WEBHOOK_SECRET FAIL 재현 확인 → fix 後 `EXIT=0`, "✅ 드리프트 없음(FAIL 기준)" 재확인(음성/양성 대조 둘 다 완료)
- prod 절 무변경(prod TOSS_WEBHOOK_SECRET은 선생님 대기 항목, 이 스토리 범위 밖)

Story: #2739 (054edff4)