### PR TITLE
[SID:f6d1bbaa] 재봉합 stamp 정합 가드 — migrate.sh precheck (#70bc4bc3 재발 차단)

### DIFF
--- a/backend/scripts/jobs/check_stamp_chain_integrity.py
+++ b/backend/scripts/jobs/check_stamp_chain_integrity.py
@@ -1,0 +1,176 @@
+"""story #f6d1bbaa — 재봉합(down_revision 임시 재봉합) stamp 정합 가드.
+
+## 배경 — 이 가드가 막으려는 정확한 사고 클래스(#70bc4bc3)
+마이그 개발 中 "이번 승격에서 일부 리비전을 임시 제외"하려 뒤쪽 리비전의 down_revision을
+앞으로 재봉합(예: 0236을 0227에 직결, 0228~0235 건너뜀)하는 경우가 있다. 그 재봉합
+이미지로 migrate job이 실행되면 alembic_version이 "0236"으로 stamp된다. 나중에 재봉합이
+풀려 정본 체인(0227→0228→…→0235→0236)이 복원되면, `alembic upgrade heads`는 "현재
+stamp(0236)가 0228~0235의 하류이니 그것들은 이미 적용됐다"고 **영구히 오판**한다 —
+실제로는 그 DDL이 단 한 번도 실행되지 않았는데도.
+
+## 탐지 방법
+alembic ScriptDirectory로 "현재 DB stamp → base"까지의 조상 리비전 전체를 얻는다(재봉합이
+복원된 **현재** 코드 기준 정본 체인 — 즉 재봉합 당시가 아니라 지금 시점 기준으로 "이
+stamp라면 마땅히 거쳤어야 할" 리비전 목록). 그 순서대로 각 리비전 파일의 upgrade()
+함수를 AST로 정적 파싱(**실행 안 함**)해 `op.create_table("X", ...)`→테이블 X 추가,
+`op.add_column("X", sa.Column("Y", ...))`→컬럼 X.Y 추가, `op.drop_table`/`op.drop_column`
+→ 제거로 시뮬레이션해 "지금 head까지 정상 실행됐다면 존재해야 할 테이블/컬럼의 최종
+스냅샷"을 조립한다. 이 스냅샷을 live information_schema와 대조 — 하나라도 없으면 FAIL.
+
+## 못 잡는 것(명시, 페드루 요구사항)
+- **DROP/RENAME/데이터 백필만 하는 리비전**: create_table/add_column 시그널이 없으면
+  판별 근거가 없다 — 그런 리비전 하나만 통째로 스킵돼도 이 가드는 못 잡는다.
+- **존재는 하지만 스펙(nullable·타입·CHECK·FK)이 틀린 경우**: 존재 여부만 본다 —
+  internal-api의 assert_schema_contract(컬럼 타입까지 대조)보다 얕은 레벨의 가드다.
+- **`op.execute("CREATE TABLE ...")`류 raw SQL DDL**: AST가 문자열 리터럴 안의 SQL은
+  파싱하지 않는다 — `op.create_table`/`op.add_column`/`op.drop_table`/`op.drop_column`
+  함수 호출 패턴만 인식한다.
+- **인덱스·제약·시퀀스 이름 자체의 변경**: 추적 대상이 테이블/컬럼 존재뿐이다(이게
+  바로 `alembic check`이 이 코드베이스에서 실용성이 없는 이유이기도 함 — 인덱스 명명
+  컨벤션 드리프트가 오래 누적돼 노이즈가 압도적이다. 이 가드는 그 노이즈를 피하려
+  의도적으로 훨씬 좁은 신호만 본다).
+- **매우 이른 시점에 만들어졌다가 이후 drop된 테이블이 raw SQL로 drop된 경우**: 현재
+  코드베이스 전수 확認 결과 drop_table/drop_column은 전부 op.* 함수 사용 — 위험 낮음,
+  그러나 보장은 아님.
+
+## 실행 위치
+`scripts/migrate.sh`에서 다른 precheck(EE-stamp·0183a fork)와 같은 자리 — `alembic
+upgrade heads` 직전, prod 실 DB 대상. **self-heal 안 함**(0183a 패턴과 다름) — 이 정합
+위반은 원인이 다양할 수 있어 자동 stamp 재조정이 오히려 새 드리프트를 만들 위험이
+있다. FAIL 시 migrate job 자체를 죽여 배포를 막는다(사람이 봐야 하는 실패로 남김 —
+#70bc4bc3처럼 조용히 넘어가면 다음 크래시까지 아무도 모른다).
+
+## 양성대조
+tests/test_f6d1bbaa_stamp_integrity_guard.py — 이 사고의 실제 이상상태를 그대로
+재현해 먹이면 이 스크립트가 정확히 FAIL(exit 1)이어야 한다. 정상 dev DB(전체 순차
+적용)에서는 PASS.
+
+사용: `ALEMBIC_DATABASE_URL`(psycopg2, migrate.sh 계약과 동일) + alembic.ini가 있는
+CWD에서 실행.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+
+
+def _extract_ddl_ops(upgrade_src: str) -> list[tuple[str, str, str | None]]:
+    """upgrade() 함수 소스에서 (op, table, column|None) 튜플 목록을 순서대로 추출.
+    op는 'create_table'|'add_column'|'drop_table'|'drop_column'."""
+    tree = ast.parse(upgrade_src)
+    ops: list[tuple[str, str, str | None]] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:
+            self.generic_visit(node)
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) and func.value.id == "op"):
+                return
+            fname = func.attr
+            args = node.args
+            if fname == "create_table" and args and isinstance(args[0], ast.Constant):
+                ops.append(("create_table", args[0].value, None))
+            elif fname == "add_column" and len(args) >= 2 and isinstance(args[0], ast.Constant):
+                table = args[0].value
+                col_node = args[1]
+                if isinstance(col_node, ast.Call) and col_node.args and isinstance(col_node.args[0], ast.Constant):
+                    ops.append(("add_column", table, col_node.args[0].value))
+            elif fname == "drop_table" and args and isinstance(args[0], ast.Constant):
+                ops.append(("drop_table", args[0].value, None))
+            elif fname == "drop_column" and len(args) >= 2 and isinstance(args[0], ast.Constant) and isinstance(args[1], ast.Constant):
+                ops.append(("drop_column", args[0].value, args[1].value))
+
+    Visitor().visit(tree)
+    return ops
+
+
+def _get_upgrade_source(filepath: str) -> str:
+    tree = ast.parse(open(filepath).read())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "upgrade":
+            return ast.unparse(node)
+    return ""
+
+
+def build_expected_snapshot(script: ScriptDirectory, current_stamp_revs: list[str]) -> tuple[set[str], set[tuple[str, str]]]:
+    """current_stamp_revs(현재 DB의 alembic_version 값들)의 조상 체인을 base부터
+    현재까지 순서대로 walk하며 create/drop을 시뮬레이션 — 최종 기대 스냅샷 반환."""
+    tables: set[str] = set()
+    columns: set[tuple[str, str]] = set()
+
+    ancestry = list(script.iterate_revisions(current_stamp_revs, "base"))
+    ancestry.reverse()  # base(가장 오래됨) → 현재 stamp 순서로.
+
+    for rev in ancestry:
+        if rev is None:
+            continue
+        upgrade_src = _get_upgrade_source(rev.path)
+        if not upgrade_src:
+            continue
+        for op_name, table, col in _extract_ddl_ops(upgrade_src):
+            if op_name == "create_table":
+                tables.add(table)
+            elif op_name == "add_column":
+                columns.add((table, col))
+            elif op_name == "drop_table":
+                tables.discard(table)
+                columns = {(t, c) for (t, c) in columns if t != table}
+            elif op_name == "drop_column":
+                columns.discard((table, col))
+    return tables, columns
+
+
+def main() -> int:
+    cfg = Config("alembic.ini")
+    script = ScriptDirectory.from_config(cfg)
+
+    # migrate.sh 계약(스크립트 상단 docstring)은 ALEMBIC_DATABASE_URL(psycopg2, sync)만
+    # 보장한다 — DATABASE_URL(asyncpg)은 migrate job 환경에 없을 수 있어 KeyError로 죽는다.
+    engine = create_engine(os.environ["ALEMBIC_DATABASE_URL"])
+    with engine.connect() as conn:
+        try:
+            current_revs = [row[0] for row in conn.execute(text("SELECT version_num FROM alembic_version"))]
+        except Exception:
+            print("[stamp-integrity] alembic_version 테이블 없음(최초 배포 등) — no-op.")
+            return 0
+
+        if not current_revs:
+            print("[stamp-integrity] stamp 없음 — no-op.")
+            return 0
+
+        expected_tables, expected_columns = build_expected_snapshot(script, current_revs)
+
+        inspector = inspect(engine)
+        live_tables = set(inspector.get_table_names())
+
+        missing_tables = sorted(expected_tables - live_tables)
+        missing_columns = []
+        for table, col in sorted(expected_columns):
+            if table not in live_tables:
+                continue  # 테이블 자체 부재는 이미 missing_tables에 잡힘 — 중복 보고 방지.
+            live_cols = {c["name"] for c in inspector.get_columns(table)}
+            if col not in live_cols:
+                missing_columns.append(f"{table}.{col}")
+
+    if missing_tables or missing_columns:
+        print("[stamp-integrity] FAIL — 현재 alembic_version이 함의하는 리비전 중 일부의 DDL이 "
+              "live 스키마에 없다(재봉합 stamp 정합 위반 클래스 — story #70bc4bc3 참고).", file=sys.stderr)
+        if missing_tables:
+            print(f"  누락 테이블: {missing_tables}", file=sys.stderr)
+        if missing_columns:
+            print(f"  누락 컬럼: {missing_columns}", file=sys.stderr)
+        print("  이 정합 위반은 self-heal 안 함 — 원인 조사 후 정정 마이그(예: #70bc4bc3의 "
+              "0253a 패턴 — 원본 upgrade() 재호출) 작성 필요.", file=sys.stderr)
+        return 1
+
+    print("[stamp-integrity] PASS — 조상 리비전 전체의 DDL 산출물이 live 스키마와 일치.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/migrate.sh
+++ b/backend/scripts/migrate.sh
@@ -148,5 +148,18 @@ else
   echo "[migrate] prod-fork precheck: no action needed."
 fi
 
+# story #70bc4bc3 후속(2026-08-18) — **재봉합 stamp 정합 가드**: 마이그 개발 中 일부
+# 리비전을 임시 제외하려 뒤쪽 리비전의 down_revision을 재봉합했다가 나중에 정본 체인을
+# 복원하면, 그 임시 재봉합 이미지로 이미 실행된 prod의 alembic_version은 "복원된 정본
+# 체인 기준 이미 지난 리비전들"을 실제로는 실행한 적이 없는 채로 영구히 오판된다
+# (#70bc4bc3 실사고 — 0228~0235·0237~0239·0242 총 12개 리비전이 이 방식으로 5주+
+# 조용히 미실행 상태였음, hypotheses 500이 실사용자에게 실제로 발생 중이었다).
+#
+# EE-stamp·0183a fork precheck와 달리 **self-heal 안 함** — 이 정합 위반은 원인이
+# 다양할 수 있어 자동 stamp 재조정이 오히려 새 드리프트를 만들 위험이 있다. FAIL 시
+# migrate job 자체를 죽여 배포를 막는다 — 사람이 봐야 하는 실패로 남긴다.
+echo "[migrate] stamp-chain-integrity precheck: verifying ancestry DDL artifacts..."
+python3 scripts/jobs/check_stamp_chain_integrity.py
+
 echo "Running: alembic upgrade heads"
 exec alembic upgrade heads

--- a/backend/tests/test_f6d1bbaa_stamp_integrity_guard.py
+++ b/backend/tests/test_f6d1bbaa_stamp_integrity_guard.py
@@ -1,0 +1,98 @@
+"""story #f6d1bbaa — check_stamp_chain_integrity.py 양성/음성대조(실 PG).
+
+페드루 요구사항: 「이번 사고 상태(0228~ 미실행+마커 전진)를 그대로 먹이면 빨강이
+떠야 가드가 실재하는 것」. 이 테스트는 #70bc4bc3 실사고를 정확히 재현하는 DB를
+만들어(0227까지 정상 적용 → 0236/0240/0243만 직접 실행 후 stamp, 실 로그가 보여준
+순서 그대로) 가드를 돌린다.
+
+`PARITY_TEST_DATABASE_URL`/`ALEMBIC_DATABASE_URL` 미설정 시 skip(다른 realdb 테스트와
+동일 컨벤션). destructive_schema 마커로 conftest의 auto-reset 픽스처를 탄다."""
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from alembic.runtime.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not _REAL_DB_URL, reason="PARITY_TEST_DATABASE_URL/ALEMBIC_DATABASE_URL 미설정")
+
+_BACKEND_DIR = Path(__file__).parent.parent
+_VERSIONS_DIR = _BACKEND_DIR / "alembic" / "versions"
+_GUARD_SCRIPT = _BACKEND_DIR / "scripts" / "jobs" / "check_stamp_chain_integrity.py"
+
+
+def _apply_upgrade_directly(url: str, filename_prefix: str) -> None:
+    """지정 접두사로 시작하는 리비전 파일 하나를 alembic 체인과 무관하게 직접
+    upgrade()만 실행(#70bc4bc3 재봉합 사고 재현용 — 특정 리비전만 골라 물리 적용)."""
+    matches = list(_VERSIONS_DIR.glob(f"{filename_prefix}*.py"))
+    assert len(matches) == 1, f"{filename_prefix}: {len(matches)}개 매치(1개여야 함)"
+    engine = create_engine(url)
+    with engine.connect() as conn:
+        ctx = MigrationContext.configure(conn)
+        op_obj = Operations(ctx)
+        import alembic.op as op_module
+        op_module._proxy = op_obj
+        spec = importlib.util.spec_from_file_location("m", str(matches[0]))
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        m.upgrade()
+        conn.commit()
+    engine.dispose()
+
+
+def _run_alembic(url: str, *args: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "ALEMBIC_DATABASE_URL": url}
+    return subprocess.run(
+        ["uv", "run", "alembic", *args], cwd=_BACKEND_DIR, env=env,
+        capture_output=True, text=True,
+    )
+
+
+def _run_guard(url: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "ALEMBIC_DATABASE_URL": url}
+    return subprocess.run(
+        [sys.executable, str(_GUARD_SCRIPT)], cwd=_BACKEND_DIR, env=env,
+        capture_output=True, text=True,
+    )
+
+
+@pytest.mark.destructive_schema
+def test_positive_control_incident_state_is_red():
+    """#70bc4bc3 실사고 그대로 재현 — 0227까지 정상, 이후 0236/0240/0243만 직접
+    실행+stamp(재봉합 이미지 그대로), 나머지는 정상 upgrade. 가드는 반드시 FAIL(exit 1)."""
+    url = _REAL_DB_URL
+    r = _run_alembic(url, "upgrade", "0227")
+    assert r.returncode == 0, r.stderr
+
+    _apply_upgrade_directly(url, "0236_")
+    _apply_upgrade_directly(url, "0240_")
+    _apply_upgrade_directly(url, "0241_")
+    _apply_upgrade_directly(url, "0243_")
+
+    r = _run_alembic(url, "stamp", "0243")
+    assert r.returncode == 0, r.stderr
+    r = _run_alembic(url, "upgrade", "head")
+    assert r.returncode == 0, r.stderr
+
+    guard = _run_guard(url)
+    assert guard.returncode == 1, f"양성대조 실패 — 가드가 이상상태를 못 잡음:\n{guard.stdout}\n{guard.stderr}"
+    assert "offering_versions" in guard.stderr
+    assert "hypotheses.superseded_by_hypothesis_id" in guard.stderr
+
+
+@pytest.mark.destructive_schema
+def test_negative_control_normal_full_chain_is_green():
+    """정상 dev 시나리오 — 전체 체인 순차 적용(스킵 없음). 가드는 반드시 PASS(exit 0)."""
+    url = _REAL_DB_URL
+    r = _run_alembic(url, "upgrade", "head")
+    assert r.returncode == 0, r.stderr
+
+    guard = _run_guard(url)
+    assert guard.returncode == 0, f"음성대조 실패 — 정상 DB인데 가드가 오탐:\n{guard.stdout}\n{guard.stderr}"


### PR DESCRIPTION
## 배경
[\[프로세스·가드\] 마이그레이션 «재봉합»이 prod 마커만 전진시키는 클래스 — stamp 정합 가드/체크리스트 부재](entity:story:f6d1bbaa-6e07-4971-9eb4-280a8ff63a34) — [\[P0급 잠재·prod DB\] alembic_version(0253)과 pricing_versions 실 스키마(pre-0228 형상·polar_price_id 잔존)가 불일치 — 다음 마이그레이션 실행의 지뢰](entity:story:70bc4bc3-ec5e-4228-9c3a-0ea712a85449)에서 완전 특定한 사고 클래스(재봉합 후 정본 복원 시 prod stamp 미재정합)의 재발 방지 본체.

## 처방
`scripts/jobs/check_stamp_chain_integrity.py`(신설) — 현재 DB의 `alembic_version`이 함의하는 조상 리비전 전체를 AST로 정적 파싱(**실행 안 함**)해 `op.create_table`/`add_column`/`drop_table`/`drop_column`을 시뮬레이션한 "최종 기대 스냅샷"을 live `information_schema`와 대조. 하나라도 없으면 FAIL.

`scripts/migrate.sh`에 EE-stamp·0183a fork precheck와 같은 자리로 배선(`alembic upgrade heads` 직전). **self-heal 안 함** — FAIL 시 migrate job 자체를 죽여 배포를 막는다.

## 못 잡는 것(명시)
DROP/RENAME/데이터 백필만 하는 리비전, 존재는 하지만 스펙(nullable·타입·CHECK·FK)이 틀린 경우, raw SQL DDL, 인덱스/제약 이름 변경.

## CI 위치 — develop PR vs main 승격
**PR-time(develop CI)이 아니라 migrate.sh 내부**(매 prod 배포 시 실 DB 대상)로 결정 — 이 클래스는 DB의 히스토리 상태에서만 발현되고, PR-time 체크는 항상 fresh ephemeral DB를 쓰므로(스킵 자체가 원천적으로 안 생김) 구조적으로 못 잡는다.

## 검증(페드루 요구사항 — 양성대조가 실패할 수 있어야)
- 실 PG 2건: ①양성대조 — #70bc4bc3 실사고 정확 재현 → FAIL 확認 ②음성대조 — 정상 전체체인 → PASS 확認.
- **가드 자체 뮤테이션킬** — FAIL 감지 무력화 시 정확히 양성대조 1건만 RED.
- 전체 스위트 6493/6499(6건 무관 베이스라인).
- `scripts/` 루트 이미지제외 린트에 처음 걸려 `scripts/jobs/`로 이동해 해소(운영 DB 접속 스크립트는 배포 이미지 필수).

## QA
자체구현 — 교차 QA 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)