### PR TITLE
[SID:f6d1bbaa] develop CI 빨강 fix — 양성대조 테스트가 0253a 자기치유에 물려 사라짐

### DIFF
--- a/backend/tests/test_f6d1bbaa_stamp_integrity_guard.py
+++ b/backend/tests/test_f6d1bbaa_stamp_integrity_guard.py
@@ -5,6 +5,19 @@
 만들어(0227까지 정상 적용 → 0236/0240/0243만 직접 실행 후 stamp, 실 로그가 보여준
 순서 그대로) 가드를 돌린다.
 
+⛔fix(2026-08-18, 페드루 진단) — 0253a(이 사고의 정정 마이그, PR #3196)가 develop에
+merge된 후 이 테스트가 **자기충족적으로 사라지는** 버그가 있었다: 원래 `alembic
+upgrade head`로 마무리했는데, develop head가 0253a를 포함하게 되면서 그 업그레이드
+경로 자체가 0253a의 self-heal 로직을 실행해버려(0253a의 존재 이유가 정확히 이
+상태를 고치는 것이므로) 가드가 실행되는 시점엔 이미 스키마가 치유된 뒤였다 — 가드가
+아니라 **테스트 픽스처가 체인 진화에 물린 것**(실측: `alembic upgrade head` 後
+`offering_versions` 테이블이 실제로 생겨 있었음, 가드 판정 자체는 정상 PASS).
+`alembic upgrade head` 대신 **0253a 바로 앞(down_revision)까지만** upgrade — prod의
+실제 사고 창(정정 마이그가 세상에 존재하기 전, 5주+ 그 상태로 멈춰 있던 순간)을
+정확히 재현한다. "0253a"라는 리터럴 문자열을 하드코딩하지 않고 ScriptDirectory로
+동적 조회 — 이 상수가 나중에 리넘버되거나 체인이 더 진화해도 "정정 마이그 바로
+앞"이라는 의미 자체는 항상 정확하다.
+
 `PARITY_TEST_DATABASE_URL`/`ALEMBIC_DATABASE_URL` 미설정 시 skip(다른 realdb 테스트와
 동일 컨벤션). destructive_schema 마커로 conftest의 auto-reset 픽스처를 탄다."""
 from __future__ import annotations
@@ -16,8 +29,10 @@ import sys
 from pathlib import Path
 
 import pytest
-from alembic.runtime.migration import MigrationContext
+from alembic.config import Config
 from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
@@ -26,6 +41,16 @@ pytestmark = pytest.mark.skipif(not _REAL_DB_URL, reason="PARITY_TEST_DATABASE_U
 _BACKEND_DIR = Path(__file__).parent.parent
 _VERSIONS_DIR = _BACKEND_DIR / "alembic" / "versions"
 _GUARD_SCRIPT = _BACKEND_DIR / "scripts" / "jobs" / "check_stamp_chain_integrity.py"
+
+
+def _revision_before_replay_fix() -> str:
+    """0253a(정정 마이그) 바로 앞(down_revision) 리비전 id를 동적 조회 — "0253"을
+    문자열로 박지 않아 향후 리넘버에도 안전하다."""
+    cfg = Config(str(_BACKEND_DIR / "alembic.ini"))
+    script = ScriptDirectory.from_config(cfg)
+    rev = script.get_revision("0253a")
+    assert rev is not None and rev.down_revision is not None
+    return str(rev.down_revision)
 
 
 def _apply_upgrade_directly(url: str, filename_prefix: str) -> None:
@@ -66,7 +91,9 @@ def _run_guard(url: str) -> subprocess.CompletedProcess:
 @pytest.mark.destructive_schema
 def test_positive_control_incident_state_is_red():
     """#70bc4bc3 실사고 그대로 재현 — 0227까지 정상, 이후 0236/0240/0243만 직접
-    실행+stamp(재봉합 이미지 그대로), 나머지는 정상 upgrade. 가드는 반드시 FAIL(exit 1)."""
+    실행+stamp(재봉합 이미지 그대로), 나머지는 **0253a(정정 마이그) 바로 앞까지만**
+    정상 upgrade(그 뒤로 가면 0253a의 self-heal이 실행돼 이 테스트가 검증하려는
+    "치유 前" 상태를 못 만든다 — 위 모듈 docstring 참고). 가드는 반드시 FAIL(exit 1)."""
     url = _REAL_DB_URL
     r = _run_alembic(url, "upgrade", "0227")
     assert r.returncode == 0, r.stderr
@@ -78,7 +105,8 @@ def test_positive_control_incident_state_is_red():
 
     r = _run_alembic(url, "stamp", "0243")
     assert r.returncode == 0, r.stderr
-    r = _run_alembic(url, "upgrade", "head")
+    stop_before_fix = _revision_before_replay_fix()
+    r = _run_alembic(url, "upgrade", stop_before_fix)
     assert r.returncode == 0, r.stderr
 
     guard = _run_guard(url)


### PR DESCRIPTION
## 배경
develop CI(e300e2f0 합류판)에서 \`test_positive_control_incident_state_is_red\`가 실패 — 페드루 진단 요청.

## 진단 결과: 가드 본체 정상, 테스트 픽스처가 체인 진화에 물림
0253a(#3196)가 develop에 merge된 후, 이 테스트의 마지막 스텝(\`alembic upgrade head\`)이 0253a까지 실제로 실행 — 0253a의 존재 이유가 정확히 "이 상태를 감지해 고치는 것"이라, 가드가 돌기도 전에 스키마가 self-heal됨. 실측: \`upgrade head\` 직후 \`offering_versions\` 테이블이 실제로 생겨 있었고, 가드는 그 치유된 스키마를 보고 정확히 PASS 반환 — **가드는 완전히 정상**, 테스트 픽스처만 무의미해진 것.

## 처방
마지막 스텝을 \`alembic upgrade head\` 대신 0253a 바로 앞(down_revision, ScriptDirectory로 동적 조회 — 리터럴 하드코딩 아님)까지만 upgrade. prod의 실제 사고 창을 정확히 재현.

## 검증
- 양성/음성대조 재확認 GREEN.
- 가드 자체 뮤테이션킬 재확認 — FAIL 감지 무력화 시 이 fix된 테스트만 정확히 RED(fix가 여전히 진짜 탐지력을 검증함을 확認).
- 전체 스위트 무관 6건만(신규 실패 0).

## QA
자체구현 — 교차 QA 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)