### PR TITLE
[SID:2745] 이중 결함 — 익명 첫 진입 세션만료 오탐 + 옛 포지셔닝 카피 잔존

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -938,7 +938,7 @@
   },
   "login": {
     "title": "Sprintable",
-    "subtitle": "AI-powered sprint management",
+    "subtitle": "The organization OS that closes open loops",
     "sessionExpired": "Your session expired and you were signed out. Please sign in again.",
     "google": "Continue with Google",
     "email": "Email",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -938,7 +938,7 @@
   },
   "login": {
     "title": "Sprintable",
-    "subtitle": "AI 기반 스프린트 관리 도구",
+    "subtitle": "열린 루프를 닫는 조직 OS",
     "sessionExpired": "세션이 만료되어 로그아웃되었습니다. 다시 로그인해 주세요.",
     "google": "Google로 계속",
     "email": "이메일",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,8 +7,12 @@ import { GoogleAnalytics } from '@/components/google-analytics';
 import { resolveAppUrl } from '@/services/app-url';
 import "./globals.css";
 
-const SITE_TITLE = "Sprintable — The PM tool where agents are teammates";
-const SITE_DESCRIPTION = "AI-powered sprint management. Kanban, memos, standups, retros, MCP server — with AI agents as first-class team members.";
+// story #2745(선생님 지적 2026-08-18, PR#3202 리뷰 유나 확認) — "PM tool"/"AI-powered sprint
+// management"는 옛 포지셔닝(우리는 PM 툴이 아니다). login.subtitle과 같은 철학 정본(개인이
+// 아니라 조직·열린 루프를 닫는다·조직을 위한 워크스페이스 OS)에서 도출 — title은 sprintable-landing
+// 정본 <title>과 동일(이미 선생님 승인).
+const SITE_TITLE = "Sprintable — Ship with AI agents";
+const SITE_DESCRIPTION = "The organization OS that closes open loops. Kanban, memos, standups, retros, MCP server — with AI agents as first-class team members.";
 
 const geistMono = Geist_Mono({
   variable: "--font-mono",

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -6,9 +6,10 @@ import type { MetadataRoute } from 'next';
 // 색(인디고, 핸드오프 §6-2) #42549B로. 아이콘 파일은 경로 그대로 in-place 교체(§5).
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: 'Sprintable — The PM tool where agents are teammates',
+    // story #2745 — layout.tsx SITE_TITLE/SITE_DESCRIPTION과 동일 정본(같은 이유로 동시 갱신).
+    name: 'Sprintable — Ship with AI agents',
     short_name: 'Sprintable',
-    description: 'AI-powered sprint management. Kanban, memos, standups, retros, MCP server — with AI agents as first-class team members.',
+    description: 'The organization OS that closes open loops. Kanban, memos, standups, retros, MCP server — with AI agents as first-class team members.',
     start_url: '/',
     display: 'standalone',
     background_color: '#FFFFFF',

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -117,9 +117,10 @@ describe('proxy', () => {
     }
   });
 
-  it('redirects to login when no sp_at cookie and refresh fails', async () => {
+  it('redirects to login with reason=session_expired when sp_rt exists but refresh is rejected — real expiry (story #2745 AC2)', async () => {
+    // sp_rt가 실재했다가 백엔드가 401로 명시 거부한 경우만 "만료"라 부를 근거가 있다.
     mockFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
-    const response = await middleware(makeRequest('/dashboard'));
+    const response = await middleware(makeRequest('/dashboard', { sp_rt: 'dead-rt' }));
     expect(response.status).toBe(307);
     // AC3(551bbbee): hard /login 대신 next 보존 + reason 배너 계약. graceful 세션 만료 UX.
     const loc = response.headers.get('location') ?? '';
@@ -128,14 +129,17 @@ describe('proxy', () => {
     expect(loc).toContain('reason=session_expired');
   });
 
-  it('redirects to login when no sp_at and no sp_rt cookie', async () => {
+  it('redirects to login WITHOUT reason=session_expired when no sp_at and no sp_rt cookie — anonymous first visit (story #2745 AC1, 선생님 지적)', async () => {
+    // 근본 버그: sp_at/sp_rt/활성계정 금고 중 아무 신호도 없는 익명 첫 방문자가 보호 라우트에
+    // 진입해도 예전엔 loginRedirect가 무조건 reason=session_expired를 붙였다 — "만료"는 살아있던
+    // 세션이 죽었다는 주장인데, 애초에 세션이 없었으면 성립하지 않는다. 재현: /legal/refund 같은
+    // 보호 라우트에 쿠키 0개 브라우저로 진입(선생님 실측 2026-08-18).
     const response = await middleware(makeRequest('/dashboard'));
     expect(response.status).toBe(307);
-    // AC3(551bbbee): hard /login 대신 next 보존 + reason 배너 계약. graceful 세션 만료 UX.
     const loc = response.headers.get('location') ?? '';
     expect(loc).toContain('https://app.example.com/login?');
     expect(loc).toContain(`next=${encodeURIComponent('/dashboard')}`);
-    expect(loc).toContain('reason=session_expired');
+    expect(loc).not.toContain('reason=session_expired');
   });
 
   it('clears sp_at/sp_rt cookies on definitive refresh failure — UI path (story e5225c0a P0)', async () => {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -427,14 +427,27 @@ function buildRefreshedHeaders(
   return headers;
 }
 
-/** AC3: 인증 실패 → /login?next=<현재경로>&reason=session_expired (login 배너 + 작업 보존 복귀). */
-function loginRedirect(request: NextRequest): NextResponse {
+// story #2745(선생님 지적 2026-08-18) — sp_at/sp_rt/활성계정 금고 중 아무 신호도 없는 «익명 첫
+// 진입»까지 loginRedirect가 무조건 reason=session_expired를 실어 보내던 것이 근본원인이었다
+// (재현: /legal/refund 같은 보호 라우트에 쿠키 0개 브라우저로 진입 → /login 리다이렉트에 «세션이
+// 만료되어…» 토스트). "만료"는 살아있던 세션이 죽었다는 주장인데, 애초에 세션 신호가 하나도
+// 없었으면 그 주장이 성립하지 않는다 — sp_at·sp_rt·활성계정 금고(sp_acct_rt_<id>) 중 하나라도
+// 있었을 때만 "만료"라 부를 근거가 있다.
+function hadAnySessionSignal(request: NextRequest): boolean {
+  if (request.cookies.get(SP_AT_COOKIE)?.value) return true;
+  if (request.cookies.get(SP_RT_COOKIE)?.value) return true;
+  const activeAccountId = request.cookies.get(ACTIVE_ACCOUNT_COOKIE)?.value;
+  return Boolean(activeAccountId && request.cookies.get(`${VAULT_PREFIX}${activeAccountId}`)?.value);
+}
+
+/** AC3: 인증 실패 → /login?next=<현재경로>(&reason=session_expired — 실제로 세션이 있었을 때만). */
+function loginRedirect(request: NextRequest, sessionExpired: boolean): NextResponse {
   const url = request.nextUrl.clone();
   const nextTarget = request.nextUrl.pathname + request.nextUrl.search;
   url.pathname = '/login';
   url.search = '';
   url.searchParams.set('next', nextTarget); // searchParams.set 이 encode
-  url.searchParams.set('reason', SESSION_EXPIRED_REASON);
+  if (sessionExpired) url.searchParams.set('reason', SESSION_EXPIRED_REASON);
   return NextResponse.redirect(url);
 }
 
@@ -444,8 +457,10 @@ function loginRedirect(request: NextRequest): NextResponse {
 // 시도할 여지를 남긴다(㉢ 수정 — 일시 장애로 멀쩡한 세션이 영구 삭제되던 것). refreshMatchesActive
 // =false(RC2, superseded 계정의 늦은 refresh)는 refresh 자체는 성공이므로 쿠키를 그대로 둔다 —
 // 이 세 실패 사유를 여기서 한 번만 구분해 양쪽 호출부의 분기를 통일한다.
-function handleUnauthenticated(request: NextRequest, isApiPath: boolean, clearCookies: boolean): NextResponse {
-  const response = isApiPath ? NextResponse.next({ request }) : loginRedirect(request);
+// sessionExpired(story #2745): 호출부가 hadAnySessionSignal() 등으로 판정해 넘긴다 — 세션 신호가
+// 애초에 없었던 익명 첫 진입은 false로 넘어와 loginRedirect가 reason을 안 붙인다.
+function handleUnauthenticated(request: NextRequest, isApiPath: boolean, clearCookies: boolean, sessionExpired: boolean): NextResponse {
+  const response = isApiPath ? NextResponse.next({ request }) : loginRedirect(request, sessionExpired);
   if (clearCookies) clearAuthCookies(response);
   return response;
 }
@@ -581,11 +596,14 @@ export async function proxy(request: NextRequest) {
   const accessToken = request.cookies.get(SP_AT_COOKIE)?.value;
 
   if (!accessToken) {
+    // story #2745: accessToken이 원래 없는 이 분기는 "익명 첫 진입"과 "쿠키 다 지워진 죽은 세션"이
+    // 섞여 있다 — sp_rt/활성계정 금고 신호로 실제 판정(둘 다 없으면 애초에 세션이 없었던 것).
+    const sessionExpired = hadAnySessionSignal(request);
     const outcome = await tryRefreshViaFastapi(request);
-    if (outcome.kind !== 'ok') return handleUnauthenticated(request, isApiPath, outcome.kind === 'invalid');
+    if (outcome.kind !== 'ok') return handleUnauthenticated(request, isApiPath, outcome.kind === 'invalid', sessionExpired);
     // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
     if (!(await refreshMatchesActive(request, outcome.accessToken))) {
-      return handleUnauthenticated(request, isApiPath, false);
+      return handleUnauthenticated(request, isApiPath, false, sessionExpired);
     }
     return respondWithRefreshedToken(request, pathname, outcome, isApiPath);
   }
@@ -593,12 +611,13 @@ export async function proxy(request: NextRequest) {
   const claims = await verifyAccessToken(accessToken);
 
   if (!claims) {
-    // access token invalid/expired — try refresh
+    // access token invalid/expired — try refresh. accessToken 쿠키가 실재했으므로(이 분기 진입
+    // 조건) 이건 항상 진짜 "만료"다 — sessionExpired=true 고정.
     const outcome = await tryRefreshViaFastapi(request);
-    if (outcome.kind !== 'ok') return handleUnauthenticated(request, isApiPath, outcome.kind === 'invalid');
+    if (outcome.kind !== 'ok') return handleUnauthenticated(request, isApiPath, outcome.kind === 'invalid', true);
     // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
     if (!(await refreshMatchesActive(request, outcome.accessToken))) {
-      return handleUnauthenticated(request, isApiPath, false);
+      return handleUnauthenticated(request, isApiPath, false, true);
     }
     return respondWithRefreshedToken(request, pathname, outcome, isApiPath);
   }


### PR DESCRIPTION
## Summary
- **버그①**: `proxy.ts`의 `loginRedirect`가 `sp_at`/`sp_rt`/활성계정 금고(vault) 중 아무 세션 신호도 없는 익명 첫 진입까지 무조건 `reason=session_expired`를 실어 보내던 것이 근본원인 — 재현: 보호 라우트(`/legal/refund` 등)에 쿠키 0개 브라우저로 진입 시 `/login` 리다이렉트에 "세션이 만료되어…" 배너 오표출. `hadAnySessionSignal()`로 "살아있던 세션이 죽음" vs "애초에 세션이 없었음"을 구분 — 후자는 배너 없이 조용히 `/login`으로만 보낸다.
- **버그②**: `login.subtitle`(ko/en)이 여전히 "AI 기반 스프린트 관리 도구"(PM 툴 계열 옛 포지셔닝). PO가 스토리에 명시한 카피 철학 정본(개인이 아니라 조직 · 열린 루프를 닫는다 · 조직을 위한 워크스페이스 OS — landing eyebrow "Organization OS"와 같은 결)에서 도출해 교체:
  - ko: "열린 루프를 닫는 조직 OS"
  - en: "The organization OS that closes open loops"
- `proxy.test.ts` 두 테스트를 실제 시나리오로 정정 — 기존 테스트가 "익명 첫 진입도 reason=session_expired여야 한다"는 잘못된 기대값을 그대로 고정하고 있었다(버그가 스펙처럼 박제된 사례).

## Scope 밖(의도적)
- `(authenticated)/layout.tsx`·`session-expired-dialog.tsx`의 `buildLoginRedirect` 호출부는 안 건드림 — 둘 다 "이미 인증된 앱 쉘 안에서 세션이 죽은" 경우만 도달 가능해 항상 진짜 만료다.

## Test plan
- [x] `npx vitest run src/proxy.test.ts` — 69/69 pass (신규/정정 케이스 포함)
- [x] `npx vitest run` i18n parity/coverage suites (i18n.test.ts, i18n-key-coverage.test.ts, i18n-template-key-coverage.test.ts, verify-no-i18n-phrase-collision.test.ts, verify-no-duplicate-i18n-keys.test.ts) — 40/40 pass
- [x] `pnpm lint` — 0 error (기존 무관 파일 warning 5건은 이 PR 밖)
- [x] `pnpm build` — exit 0
- [x] 로컬 `next dev`로 curl 재현: 쿠키 0개 → `/login?next=...`(reason 없음) / `sp_rt` 존재+거부 → `reason=session_expired` 유지
- [x] Puppeteer 라이브 픽셀: ko/en × light/dark 4콤보 — 익명 진입 시 배너 없음, 신규 subtitle 정상 렌더, 실제 만료 시 배너 정상 표출

## 카피 확定 여부
`login.subtitle` 최종 문안은 스토리 규정대로 유나군 design 리뷰 게이트 대상 — 이 PR의 카피는 초안.