### PR TITLE
[토스 심사·앱] 사업자정보·법적 문서 앱 內 확인 경로 (#2741)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1,4 +1,14 @@
 {
+  "legal": {
+    "policiesHeading": "Policies",
+    "businessInfoHeading": "Business Information",
+    "termsOfService": "Terms of Service",
+    "privacyPolicy": "Privacy Policy",
+    "refundPolicy": "Refund Policy",
+    "ceoLabel": "CEO",
+    "registrationLabel": "Business Reg. No.",
+    "mailOrderLabel": "Mail-order Reg. No."
+  },
   "notFound": {
     "title": "Page not found",
     "description": "The page you're looking for doesn't exist or has moved",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1,4 +1,14 @@
 {
+  "legal": {
+    "policiesHeading": "약관 및 정책",
+    "businessInfoHeading": "사업자정보",
+    "termsOfService": "이용약관",
+    "privacyPolicy": "개인정보처리방침",
+    "refundPolicy": "환불정책",
+    "ceoLabel": "대표이사",
+    "registrationLabel": "사업자등록번호",
+    "mailOrderLabel": "통신판매업 신고번호"
+  },
   "notFound": {
     "title": "페이지를 찾을 수 없습니다",
     "description": "요청하신 페이지가 존재하지 않거나 이동되었습니다",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -34,6 +34,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { OperatorInput } from '@/components/ui/operator-control';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { LegalLinks, BusinessInfoBlock } from '@/components/legal/legal-footer';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { NOTIFICATION_TYPES } from '@/lib/notification-types';
@@ -115,6 +116,7 @@ function resolveSettingsTab(tab: string | null): string {
 export default function SettingsPage() {
   const t = useTranslations('settings');
   const tc = useTranslations('common');
+  const tLegal = useTranslations('legal');
   // story #2485 — projectLimitExceededError는 onboarding-form.tsx(#2484)와 동일 개념
   // (resource:"project" PLAN_LIMIT_EXCEEDED)이라 새 키를 만들지 않고 재사용한다.
   const tOnboarding = useTranslations('onboarding');
@@ -824,6 +826,21 @@ export default function SettingsPage() {
                   />
                 )}
                 <BlockedUsersSection />
+
+                <SectionCard>
+                  <SectionCardHeader>
+                    <div className="space-y-1">
+                      <h2 className="text-base font-semibold text-foreground">{tLegal('policiesHeading')}</h2>
+                    </div>
+                  </SectionCardHeader>
+                  <SectionCardBody className="space-y-4">
+                    <LegalLinks className="justify-start text-sm text-muted-foreground" />
+                    <div className="border-t border-border pt-4">
+                      <p className="mb-1.5 text-xs font-medium text-muted-foreground">{tLegal('businessInfoHeading')}</p>
+                      <BusinessInfoBlock className="justify-start text-xs text-muted-foreground" />
+                    </div>
+                  </SectionCardBody>
+                </SectionCard>
               </div>
             </TabsContent>
 

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -11,6 +11,7 @@ import { safeNextPath, SESSION_EXPIRED_REASON } from '@/lib/auth/session-redirec
 import { FIREBASE_AUTH_ENABLED } from '@/lib/auth/firebase-client';
 import { signInAndExchangeFirebaseSession } from '@/lib/auth/firebase-login-flow';
 import { notifyContentPainted } from '@/lib/native-shell-bridge';
+import { LegalFooter } from '@/components/legal/legal-footer';
 
 export default function LoginPage() {
   const t = useTranslations('login');
@@ -116,7 +117,7 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-muted">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-muted px-4 py-8">
       <div className="w-full max-w-sm space-y-6 rounded-2xl bg-background p-4 shadow-lg sm:p-8">
         <div className="flex flex-col items-center gap-3 text-center">
           <SprintableLogo
@@ -232,6 +233,7 @@ export default function LoginPage() {
           </Link>
         </p>
       </div>
+      <LegalFooter />
     </div>
   );
 }

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { DocContentRenderer } from '@/components/docs/doc-content-renderer';
 import { getCurrentLegalDocument } from '@/lib/legal-docs';
+import { BusinessInfoBlock } from '@/components/legal/legal-footer';
 
 export const metadata = { title: 'Privacy Policy — Sprintable' };
 export const revalidate = 300;
@@ -41,6 +42,10 @@ export default async function PrivacyPage() {
           {' · '}
           <Link href="/register" className="text-brand hover:text-brand/80">회원가입으로 돌아가기</Link>
         </p>
+
+        <div className="mt-4 text-center text-xs text-muted-foreground">
+          <BusinessInfoBlock className="justify-center" />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/refund-policy/page.tsx
+++ b/apps/web/src/app/refund-policy/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { DocContentRenderer } from '@/components/docs/doc-content-renderer';
 import { getCurrentLegalDocument } from '@/lib/legal-docs';
+import { BusinessInfoBlock } from '@/components/legal/legal-footer';
 
 export const metadata = { title: 'Refund Policy — Sprintable' };
 export const revalidate = 300;
@@ -41,6 +42,10 @@ export default async function RefundPolicyPage() {
           {' · '}
           <Link href="/register" className="text-brand hover:text-brand/80">회원가입으로 돌아가기</Link>
         </p>
+
+        <div className="mt-4 text-center text-xs text-muted-foreground">
+          <BusinessInfoBlock className="justify-center" />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
+import { LegalFooter } from '@/components/legal/legal-footer';
 
 function checkPasswordRules(pw: string) {
   return {
@@ -77,7 +78,7 @@ export default function RegisterPage() {
   const showRules = passwordTouched && password.length > 0;
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-muted">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-muted px-4 py-8">
       <div className="w-full max-w-sm space-y-6 rounded-2xl bg-background p-4 shadow-lg sm:p-8">
         <div className="flex flex-col items-center gap-3 text-center">
           <SprintableLogo
@@ -197,6 +198,7 @@ export default function RegisterPage() {
           </Link>
         </p>
       </div>
+      <LegalFooter />
     </div>
   );
 }

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { DocContentRenderer } from '@/components/docs/doc-content-renderer';
 import { getCurrentLegalDocument } from '@/lib/legal-docs';
+import { BusinessInfoBlock } from '@/components/legal/legal-footer';
 
 export const metadata = { title: 'Terms of Service — Sprintable' };
 export const revalidate = 300;
@@ -41,6 +42,10 @@ export default async function TermsPage() {
           {' · '}
           <Link href="/register" className="text-brand hover:text-brand/80">회원가입으로 돌아가기</Link>
         </p>
+
+        <div className="mt-4 text-center text-xs text-muted-foreground">
+          <BusinessInfoBlock className="justify-center" />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/legal/legal-footer.test.tsx
+++ b/apps/web/src/components/legal/legal-footer.test.tsx
@@ -47,11 +47,32 @@ async function mount(node: React.ReactNode) {
 }
 
 describe('LegalFooter (story #2741)', () => {
-  it('사업자정보 6종 값이 모두 화면에 렌더된다', async () => {
+  // 카디르군 QA(#3203) — 기대값을 SSOT에서 뽑으면 «값이 틀려도 GREEN»인 동어반복이라(ceo
+  // 변조 뮤테이션으로 실증), 기대값을 story #2740 정본의 «하드코딩 리터럴»로 박는다 — SSOT가
+  // 정본과 어긋나면 실제로 빨개지는 «틀릴 수 있는 표본».
+  const EXPECTED_BUSINESS_INFO = [
+    '주식회사 뭉클랩',
+    '윤도선',
+    '488-88-02579',
+    '경기도 고양시 일산동구 무궁화로 20-38, 5층 502호',
+    '070-8098-5775',
+    '제2023-고양일산동-1337호',
+  ] as const;
+
+  it('SSOT 값이 #2740 정본과 글자 단위로 일치한다 (변조 검출 · 하드코딩 대조)', () => {
+    expect(BUSINESS_INFO.companyName).toBe('주식회사 뭉클랩');
+    expect(BUSINESS_INFO.ceo).toBe('윤도선');
+    expect(BUSINESS_INFO.registrationNumber).toBe('488-88-02579');
+    expect(BUSINESS_INFO.address).toBe('경기도 고양시 일산동구 무궁화로 20-38, 5층 502호');
+    expect(BUSINESS_INFO.phone).toBe('070-8098-5775');
+    expect(BUSINESS_INFO.mailOrderNumber).toBe('제2023-고양일산동-1337호');
+  });
+
+  it('사업자정보 6종 값이 모두 화면에 렌더된다 (정본 리터럴 대조)', async () => {
     const { LegalFooter } = await import('./legal-footer');
     await mount(<LegalFooter />);
     const text = container.textContent ?? '';
-    for (const value of Object.values(BUSINESS_INFO)) {
+    for (const value of EXPECTED_BUSINESS_INFO) {
       expect(text).toContain(value);
     }
   });

--- a/apps/web/src/components/legal/legal-footer.test.tsx
+++ b/apps/web/src/components/legal/legal-footer.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+//
+// story #2741 — 앱 內 사업자정보·법적 문서 확인 경로. 「표시를 테스트」한다: 6종 값이 실제
+// 렌더 결과에 오르고, 3종 법적 문서 링크가 기존 legal 라우트로 걸리며, raw i18n 키가 새지
+// 않는지 검증(훅 배선이 아니라 화면에 나온 텍스트/href로 확인).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { BUSINESS_INFO } from '@/lib/legal/business-info';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), refresh: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/',
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.resetModules();
+});
+
+async function mount(node: React.ReactNode) {
+  await act(async () => { root.render(wrap(node)); });
+}
+
+describe('LegalFooter (story #2741)', () => {
+  it('사업자정보 6종 값이 모두 화면에 렌더된다', async () => {
+    const { LegalFooter } = await import('./legal-footer');
+    await mount(<LegalFooter />);
+    const text = container.textContent ?? '';
+    for (const value of Object.values(BUSINESS_INFO)) {
+      expect(text).toContain(value);
+    }
+  });
+
+  it('법적 문서 3종 링크가 기존 legal 라우트로 걸린다', async () => {
+    const { LegalFooter } = await import('./legal-footer');
+    await mount(<LegalFooter />);
+    const anchors = Array.from(container.querySelectorAll('a'));
+    const hrefs = anchors.map((a) => a.getAttribute('href'));
+    expect(hrefs).toContain('/terms');
+    expect(hrefs).toContain('/privacy');
+    expect(hrefs).toContain('/refund-policy');
+    const labels = anchors.map((a) => a.textContent);
+    expect(labels).toContain('이용약관');
+    expect(labels).toContain('개인정보처리방침');
+    expect(labels).toContain('환불정책');
+  });
+
+  it('raw i18n 키가 노출되지 않는다', async () => {
+    const { LegalFooter } = await import('./legal-footer');
+    await mount(<LegalFooter />);
+    const text = container.textContent ?? '';
+    expect(text).not.toMatch(
+      /legal\.|policiesHeading|businessInfoHeading|ceoLabel|registrationLabel|mailOrderLabel|termsOfService|privacyPolicy|refundPolicy/,
+    );
+  });
+});

--- a/apps/web/src/components/legal/legal-footer.tsx
+++ b/apps/web/src/components/legal/legal-footer.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+/**
+ * 법적 고지 표면 — 사업자정보(6종) + 법적 문서 링크(이용약관·개인정보처리방침·환불정책).
+ *
+ * 관례(국내 서비스): 웹/랜딩은 페이지 하단 푸터에 사업자정보 + 약관 링크(전자상거래법
+ * 제10조), 앱은 「설정 하단 약관 및 정책」. 전역 sticky 푸터로 모든 화면에 따라다니지
+ * 않는다 — 비로그인 클러스터(로그인·가입·legal)와 설정 화면에만 「확인 경로」로 둔다
+ * (story #2741).
+ *
+ * 값은 SSOT(lib/legal/business-info.ts)에서만 가져온다. 링크 목적지는 기존 legal 라우트.
+ */
+
+import Link from 'next/link';
+import { Fragment } from 'react';
+import { useTranslations } from 'next-intl';
+import { BUSINESS_INFO, LEGAL_DOC_ROUTES } from '@/lib/legal/business-info';
+
+/** 이용약관·개인정보처리방침·환불정책 링크 행. justify는 호출부에서 지정. */
+export function LegalLinks({ className = '' }: { className?: string }) {
+  const t = useTranslations('legal');
+  return (
+    <nav
+      className={`flex flex-wrap items-center gap-x-3 gap-y-1 ${className}`}
+      aria-label={t('policiesHeading')}
+    >
+      <Link href={LEGAL_DOC_ROUTES.terms} className="hover:text-foreground hover:underline">
+        {t('termsOfService')}
+      </Link>
+      <span aria-hidden className="text-muted-foreground/40">·</span>
+      <Link href={LEGAL_DOC_ROUTES.privacy} className="hover:text-foreground hover:underline">
+        {t('privacyPolicy')}
+      </Link>
+      <span aria-hidden className="text-muted-foreground/40">·</span>
+      <Link href={LEGAL_DOC_ROUTES.refundPolicy} className="hover:text-foreground hover:underline">
+        {t('refundPolicy')}
+      </Link>
+    </nav>
+  );
+}
+
+/** 사업자정보 6종 — 컴팩트 flow, 모바일에서 wrap. justify는 호출부에서 지정. */
+export function BusinessInfoBlock({ className = '' }: { className?: string }) {
+  const t = useTranslations('legal');
+  const parts = [
+    BUSINESS_INFO.companyName,
+    `${t('ceoLabel')} ${BUSINESS_INFO.ceo}`,
+    `${t('registrationLabel')} ${BUSINESS_INFO.registrationNumber}`,
+    `${t('mailOrderLabel')} ${BUSINESS_INFO.mailOrderNumber}`,
+    BUSINESS_INFO.address,
+    BUSINESS_INFO.phone,
+  ];
+  return (
+    <div className={`flex flex-wrap items-center gap-x-2 gap-y-0.5 leading-relaxed ${className}`}>
+      {parts.map((part, i) => (
+        <Fragment key={i}>
+          {i > 0 && (
+            <span aria-hidden className="text-muted-foreground/40">
+              ·
+            </span>
+          )}
+          <span>{part}</span>
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * 비로그인 클러스터(로그인·가입·legal 페이지) 하단 푸터.
+ * 사업자정보 + 법적 문서 링크를 가운데 정렬로 묶는다.
+ */
+export function LegalFooter({ className = '' }: { className?: string }) {
+  return (
+    <footer
+      className={`w-full max-w-xl px-4 text-center text-xs text-muted-foreground ${className}`}
+    >
+      <BusinessInfoBlock className="justify-center" />
+      <LegalLinks className="mt-2 justify-center" />
+    </footer>
+  );
+}

--- a/apps/web/src/components/legal/legal-footer.tsx
+++ b/apps/web/src/components/legal/legal-footer.tsx
@@ -9,6 +9,10 @@
  * (story #2741).
  *
  * 값은 SSOT(lib/legal/business-info.ts)에서만 가져온다. 링크 목적지는 기존 legal 라우트.
+ *
+ * 구분자 점(·)은 aria-hidden 순수 장식이나, #2611 가드상 text-muted-foreground 알파 변형은
+ * 금지라(모든 알파 레벨 AA 미달) 부모의 solid muted-foreground를 상속한다 — muted-alpha-ok
+ * 밸브는 큰 워터마크류(인접 텍스트 없음) 전용이라 작은 인접 구분자엔 쓰지 않는다.
  */
 
 import Link from 'next/link';
@@ -27,11 +31,11 @@ export function LegalLinks({ className = '' }: { className?: string }) {
       <Link href={LEGAL_DOC_ROUTES.terms} className="hover:text-foreground hover:underline">
         {t('termsOfService')}
       </Link>
-      <span aria-hidden className="text-muted-foreground/40">·</span>
+      <span aria-hidden>·</span>
       <Link href={LEGAL_DOC_ROUTES.privacy} className="hover:text-foreground hover:underline">
         {t('privacyPolicy')}
       </Link>
-      <span aria-hidden className="text-muted-foreground/40">·</span>
+      <span aria-hidden>·</span>
       <Link href={LEGAL_DOC_ROUTES.refundPolicy} className="hover:text-foreground hover:underline">
         {t('refundPolicy')}
       </Link>
@@ -54,11 +58,7 @@ export function BusinessInfoBlock({ className = '' }: { className?: string }) {
     <div className={`flex flex-wrap items-center gap-x-2 gap-y-0.5 leading-relaxed ${className}`}>
       {parts.map((part, i) => (
         <Fragment key={i}>
-          {i > 0 && (
-            <span aria-hidden className="text-muted-foreground/40">
-              ·
-            </span>
-          )}
+          {i > 0 && <span aria-hidden>·</span>}
           <span>{part}</span>
         </Fragment>
       ))}

--- a/apps/web/src/lib/legal/business-info.ts
+++ b/apps/web/src/lib/legal/business-info.ts
@@ -1,0 +1,37 @@
+/**
+ * 사업자정보 — 앱 內 단일 정본(SSOT).
+ *
+ * 전자상거래법 제10조(사업자의 신원·거래조건 표시 의무)에 따라 앱 안에서 확인 가능해야 하는
+ * 사업자정보 6종. 값은 사업자등록증과 동일하게 기재하며, 마케팅 랜딩(sprintable-landing
+ * 레포) 푸터 값(story #2740 정본 절)과 글자 단위로 일치한다.
+ *
+ * 앱(apps/web) 안에서는 이 파일이 유일한 정의다 — 어느 표면에서도 값을 다시 적지 않고
+ * 여기서만 가져와 렌더한다(값 사본 이중화 금지, story #2741).
+ *
+ * ⚠️ 토스페이먼츠 심사 기간 중 수정 금지 항목.
+ */
+export const BUSINESS_INFO = {
+  /** 상호 */
+  companyName: '주식회사 뭉클랩',
+  /** 대표이사 */
+  ceo: '윤도선',
+  /** 사업자등록번호 */
+  registrationNumber: '488-88-02579',
+  /** 사업장 소재지 */
+  address: '경기도 고양시 일산동구 무궁화로 20-38, 5층 502호',
+  /** 유선번호 */
+  phone: '070-8098-5775',
+  /** 통신판매업 신고번호 */
+  mailOrderNumber: '제2023-고양일산동-1337호',
+} as const;
+
+/**
+ * 법적 문서 렌더 경로. 기존 legal 라우트를 재사용한다 — 별도 사본 페이지를 만들지 않는다
+ * (story #2741 AC4). 목적지 페이지는 GET /api/v2/legal/{type}에서 실 콘텐츠를 받는다
+ * (lib/legal-docs.ts).
+ */
+export const LEGAL_DOC_ROUTES = {
+  terms: '/terms',
+  privacy: '/privacy',
+  refundPolicy: '/refund-policy',
+} as const;


### PR DESCRIPTION
## 배경
토스페이먼츠 가맹 심사 대응. 앱(app.sprintable.ai=apps/web)은 전면 로그인 구조라 심사관이 비로그인 상태에서도 사업자정보(D절)·환불정책/약관(C절)에 도달할 수 있어야 한다. 강제 sticky 푸터가 아니라 「확인할 수 있는 경로」를 둔다(선생님 방향 2026-08-18).

## 리서치 근거 (국내 관례)
- **channel.io**(B2B SaaS): 웹 푸터에 상호·대표자·사업자등록번호·전화번호 + 이용약관·개인정보처리방침 링크.
- **sprintable.ai**(자사 랜딩, #2740): 푸터에 사업자정보 6종 + 약관 링크.
- **카카오톡·당근·배달의민족**: 앱 내에서는 「설정 하단 약관 및 정책」 패턴.
- 법적 근거: 전자상거래법 제10조(사업자 신원·거래조건 표시 의무).

요지: 웹은 하단 푸터, 앱(로그인 후)은 설정 내부. 전역 sticky 푸터로 모든 화면을 따라다니지 않는다.

## 변경
- `lib/legal/business-info.ts` — 사업자정보 6종 **SSOT**. 값은 story #2740 정본과 글자 단위 동일, 앱 내 단일 정의(값 사본 이중화 금지). 심사 기간 수정 금지 항목.
- `components/legal/legal-footer.tsx` — `BusinessInfoBlock`·`LegalLinks`·`LegalFooter`. 값은 SSOT에서만, 링크 목적지는 기존 legal 라우트.
- **비로그인 클러스터**(login·register·terms·privacy·refund-policy): 하단에 확인 경로 부착.
- **로그인 후**: 설정 프로필 탭 하단 「약관 및 정책」 섹션.
- i18n `legal` 네임스페이스(ko/en 동형).
- 렌더 검증 테스트(6종 값·3종 링크·raw 키 0).

## AC 매핑
1. 리서치 근거 3+ 서비스 — 스토리 코멘트 + 본문 기재. ✅
2. 사업자정보 6종 + 법적 문서 3종 도달 — 로그인 후(설정) 1곳 + 비로그인(login/register 등) 유지. ✅
3. 2테마 × 모바일 라이브 픽셀 — **머지+dev 배포 후** 확認 예정(dev PR 프리뷰 없음). ⏳
4. 문서 링크 목적지=legal 렌더 경로, 사본 페이지 신설 없음. ✅

## 검증
- `tsc --noEmit`: 본 변경 파일 0 에러. (기존 무관 에러 1건: `ee/components/billing/toss-checkout.ts`의 `@tosspayments/tosspayments-sdk` 미설치 — develop 동일, 본 PR 무관.)
- `eslint`: 변경 파일 0 경고.
- 렌더 테스트 3/3 통과.
- 라이브 픽셀(2테마×모바일)은 dev 배포 반영 후 첨부.

관련: story #2741 · sibling landing #2740

🤖 Generated with [Claude Code](https://claude.com/claude-code)
