### PR TITLE
[SID:2750] 한국어 조직명 slug 자동파생 실패 — 무설명 disabled 제거

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1001,6 +1001,7 @@
     "orgNamePlaceholder": "e.g. Moonklabs",
     "slug": "URL Slug",
     "slugPlaceholder": "e.g. moonklabs",
+    "slugManualRequired": "We couldn't auto-generate a slug from that name. Enter one above using lowercase letters, numbers, and hyphens.",
     "createProject": "Create First Project",
     "projectSubtitle": "Create the first project for {orgName}.",
     "projectName": "Project Name",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1001,6 +1001,7 @@
     "orgNamePlaceholder": "예: Moonklabs",
     "slug": "URL 슬러그",
     "slugPlaceholder": "예: moonklabs",
+    "slugManualRequired": "조직명에서 슬러그를 자동으로 만들 수 없어요. 위 칸에 영문 소문자, 숫자, 하이픈으로 직접 입력해 주세요.",
     "createProject": "첫 프로젝트 만들기",
     "projectSubtitle": "{orgName}의 첫 프로젝트를 만들어보세요.",
     "projectName": "프로젝트 이름",

--- a/apps/web/src/app/onboarding/onboarding-form.korean-slug.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.korean-slug.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+//
+// story #2750 — 디디 라이브 재현(2748 재실측, 2026-08-18): 온보딩 1/4에서 조직 이름을
+// 한국어로만 입력(예: 「우리팀」)하면 handleOrgNameChange의 자동 slug 파생 정규식
+// (`[^a-z0-9\s-]` 제거)이 한글을 전부 걸러내 orgSlug가 빈 문자열로 남는다. 그 상태에서
+// 「조직 만들기」 버튼이 disabled인데 왜 막혔는지 화면에 안내가 0이었다(무설명 disabled) —
+// 한국 시장 제품의 온보딩 첫 화면 이탈 직결. 실제로 폼을 마운트하고 한글만 입력해
+// 안내 문구가 뜨는지·수동 slug 입력으로 막힘이 풀리는지를 단언한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { OnboardingForm } from './onboarding-form';
+import koMessages from '../../../messages/ko.json';
+import enMessages from '../../../messages/en.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(locale: 'ko' | 'en') {
+  const messages = locale === 'ko' ? koMessages : enMessages;
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages} timeZone="Asia/Seoul">
+      <OnboardingForm />
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) };
+    if (url === '/api/organizations') {
+      return { ok: true, json: async () => ({ data: { id: 'org-korean-1', slug: 'woorim' } }) };
+    }
+    throw new Error('unexpected fetch: ' + url);
+  }));
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+function setNativeValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe.each([
+  ['ko', koMessages] as const,
+  ['en', enMessages] as const,
+])('OnboardingForm — 한국어 조직명 slug 자동파생 실패 안내 (story #2750, locale=%s)', (locale, messages) => {
+  it('한글만으로 조직명을 입력하면 slug가 비고, 무설명이 아니라 안내 문구가 뜨며, 버튼은 disabled 유지', async () => {
+    await act(async () => { root.render(wrap(locale)); });
+
+    const [nameInput, slugInput] = [...container.querySelectorAll('input')] as HTMLInputElement[];
+    await act(async () => { setNativeValue(nameInput, '우리팀'); });
+
+    expect(slugInput.value).toBe(''); // 자동 파생이 한글을 전부 걸러내 빈 값
+    expect(container.textContent).toContain(messages.onboarding.slugManualRequired);
+
+    const createBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === messages.onboarding.createOrg);
+    expect(createBtn?.disabled).toBe(true);
+  });
+
+  it('안내를 따라 slug를 직접 입력하면 막힘이 풀려 조직 생성까지 완주한다', async () => {
+    await act(async () => { root.render(wrap(locale)); });
+
+    const [nameInput, slugInput] = [...container.querySelectorAll('input')] as HTMLInputElement[];
+    await act(async () => { setNativeValue(nameInput, '우리팀'); });
+    await act(async () => { setNativeValue(slugInput, 'woorim'); });
+
+    expect(container.textContent).not.toContain(messages.onboarding.slugManualRequired);
+
+    const createBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === messages.onboarding.createOrg);
+    expect(createBtn?.disabled).toBe(false);
+
+    await act(async () => { createBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const fetchMock = vi.mocked(fetch);
+    const orgCall = fetchMock.mock.calls.find((c) => c[0] === '/api/organizations');
+    expect(orgCall).not.toBeUndefined();
+    expect(JSON.parse((orgCall![1] as RequestInit).body as string)).toEqual({ name: '우리팀', slug: 'woorim' });
+  });
+});

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -364,6 +364,12 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
                 // ⚠️Phase2 i18n·#2485 — 클라 측 정규식 검증 문구가 하드코딩 한국어다(t() 아님,
                 // 서버 응답과 무관 — raw 서버 누수는 아님). #2484 스코프 밖, 유나 design 확認.
                 <p className="text-xs text-destructive">영소문자, 숫자, 하이픈만 사용 가능합니다</p>
+              ) : !orgSlug && orgName.trim() ? (
+                // story #2750 — 조직명이 한글 등 비-ASCII로만 이뤄지면 handleOrgNameChange의
+                // 자동 파생(로마자/숫자만 남기는 정규식)이 전부 걸러내 orgSlug가 빈 문자열로
+                // 남는다. 그 상태에서 아래 버튼이 무설명 disabled로 남던 것이 이 스토리의 근본
+                // 결함 — 이미 존재하는 수동 slug 입력 칸(바로 위)으로 안내해 막힘을 뚫는다.
+                <p className="text-xs text-destructive">{t('slugManualRequired')}</p>
               ) : (
                 <p className="text-xs text-muted-foreground">sprintable.app/{orgSlug || '...'}</p>
               )}


### PR DESCRIPTION
## Summary
- **근본원인**: `onboarding-form.tsx`의 `handleOrgNameChange`가 조직명에서 slug를 자동 파생할 때 `[^a-z0-9\s-]` 정규식으로 비-ASCII 문자를 전부 제거한다 — 조직명을 한국어로만 입력(예: 「우리팀」)하면 `orgSlug`가 빈 문자열로 남고, 「조직 만들기」 버튼이 **아무 설명 없이 disabled**로 남아 온보딩 1/4에서 진행 불가.
- **처방 방향(로마자 변환/폴백/직접 입력 유도 중 선택)**: 직접 입력 유도. 이미 존재하는 수동 slug 입력 칸으로 안내 문구를 붙였다 — 로마자 변환 라이브러리 불요, 결과 slug가 항상 사용자 의도와 일치(자동 로마자 변환은 오번역/충돌 위험), 최소 변경.
- `orgName`은 있는데 자동파생 결과가 빈 `orgSlug`인 상태를 별도 분기로 구분해 `onboarding.slugManualRequired`(ko/en 신규 키) 안내를 노출. 기존 `orgSlug && !slugValid` 분기(하드코딩 한국어 에러 메시지, story #2485에서 이미 스코프 밖으로 분리된 사안)는 건드리지 않음.

## Scope 밖(의도적)
- `orgSlug && !slugValid`의 하드코딩 한국어 에러 문구(#2485에서 유나 design 확認 대기 중으로 명시 등재) — 이 PR과 다른 결함, 손대지 않음.

## Test plan
- [x] `npx vitest run src/app/onboarding/` — 51/51 pass (신규 `onboarding-form.korean-slug.test.tsx` 4케이스 포함: ko/en × 안내노출+disabled / 수동입력 후 해소+API payload 검증)
- [x] i18n parity/coverage suites — 40/40 pass
- [x] `pnpm lint` — 0 error
- [x] `pnpm build` — exit 0
- [ ] **dev 라이브 실측(실제 한글 조직명으로 org 생성 완주)** — `/onboarding`이 인증 보호 라우트라 로컬에선 세션 없이 재현 불가. develop 머지→dev 자동배포 후 실계정으로 한글 조직명 온보딩 완주까지 확認해 스토리에 evidence로 남기고 회신 예정(story #2745와 동일 절차).