### PR TITLE
[온보딩·FE] 첫 스프린트 시작 무설명 무반응 제거 — 날짜 pre-fill + 침묵→명시 (#2755)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3199,6 +3199,7 @@
     "loadMoreError": "Couldn't load more. Please try again.",
     "saveDraft": "Save draft",
     "activateBlocked": "Activating requires at least 1 hypothesis to test.",
+    "missingRequired": "Enter a name, start date, and end date.",
     "declareSectionTitle": "Hypotheses to test",
     "declareRequiredBadge": "≥ 1 required",
     "declareCount": "{count} declared",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3199,6 +3199,7 @@
     "loadMoreError": "더 불러오지 못했습니다. 다시 시도해 주세요.",
     "saveDraft": "임시저장",
     "activateBlocked": "활성화하려면 검증할 가설이 최소 1개 필요합니다.",
+    "missingRequired": "이름·시작일·종료일을 입력하세요.",
     "declareSectionTitle": "검증할 가설",
     "declareRequiredBadge": "≥ 1 필수",
     "declareCount": "{count} 선언됨",

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.create-silent.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.create-silent.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+//
+// story #2755 — fresh 조직의 첫 스프린트 시작이 «무설명 무반응»이던 결함의 «표시»를 테스트한다:
+// ①날짜 2칸이 pre-fill되어 fresh 유저가 빈 날짜 벽에 안 막힌다 ②미충족(이름/가설) 상태로
+// 「스프린트 시작」을 클릭하면 «조용한 no-op»이 아니라 사유 메시지가 화면에 뜨고, /api/sprints
+// POST는 나가지 않는다(무설명 무반응 → 명시 no-submit). 훅이 아니라 렌더 결과/네트워크로 확認.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../../../messages/ko.json';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/',
+}));
+
+// HypothesisDeclarationSection·CreateDialog가 쓰는 fetchWithAuth — 가설 목록은 빈 배열로.
+vi.mock('@/lib/db/client', () => ({
+  fetchWithAuth: vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) })),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+function setNativeValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function sprintsPosted(): boolean {
+  return fetchMock.mock.calls.some((c) => String(c[0]).includes('/api/sprints'));
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ data: { id: 'sp-1' } }), text: async () => '' }));
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+async function mount() {
+  const { CreateDialog } = await import('./sprints-client');
+  await act(async () => {
+    root.render(wrap(<CreateDialog projectId="proj-1" onCreated={() => {}} onClose={() => {}} />));
+  });
+  // 마운트 직후 가설 목록 fetch 등 microtask flush
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+function activateButton(): HTMLButtonElement {
+  const label = koMessages.sprints.activate; // '스프린트 시작'
+  const btn = [...document.body.querySelectorAll('button')].find((b) => (b.textContent || '').trim() === label);
+  if (!btn) throw new Error('activate 버튼을 찾지 못함');
+  return btn as HTMLButtonElement;
+}
+
+async function clickActivate() {
+  await act(async () => { activateButton().dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('CreateDialog — 첫 스프린트 시작 침묵 금지 (story #2755)', () => {
+  it('시작일·종료일이 pre-fill되어 빈 날짜 벽이 사라진다', async () => {
+    await mount();
+    const dates = [...document.body.querySelectorAll('input[type=date]')] as HTMLInputElement[];
+    expect(dates.length).toBe(2);
+    expect(dates[0]!.value).toMatch(/^\d{4}-\d{2}-\d{2}$/); // startDate
+    expect(dates[1]!.value).toMatch(/^\d{4}-\d{2}-\d{2}$/); // endDate
+    expect(dates[1]!.value > dates[0]!.value).toBe(true);   // 종료 > 시작
+  });
+
+  it('이름 없이 「스프린트 시작」 클릭 → 무설명 no-op이 아니라 missingRequired가 뜨고 POST 미발화', async () => {
+    await mount();
+    // 기본 상태: 이름 빈칸·날짜 pre-fill·가설 0
+    await clickActivate();
+    expect(document.body.textContent).toContain(koMessages.sprints.missingRequired);
+    expect(sprintsPosted()).toBe(false);
+  });
+
+  it('이름+기본날짜 있으나 가설 0개로 「스프린트 시작」 클릭 → activateBlocked가 뜨고 POST 미발화(게이트 유지)', async () => {
+    await mount();
+    const titleInput = document.body.querySelector('input[type=text]') as HTMLInputElement;
+    await act(async () => { setNativeValue(titleInput, '스프린트 1'); });
+    await clickActivate();
+    expect(document.body.textContent).toContain(koMessages.sprints.activateBlocked);
+    expect(sprintsPosted()).toBe(false);
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
@@ -134,11 +134,26 @@ interface CreateDialogProps {
   onClose: () => void;
 }
 
-function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
+// story #2755 — fresh 조직의 첫 스프린트 시작이 «무설명 무반응»이던 근본: startDate/endDate가 빈
+// 값 기본이라(type=date·pre-fill 없음) 이름+목표만 채운 fresh 유저가 disabled 벽에 막혔다. 오늘
+// ~+13일(2주 inclusive) 기본값을 주어 침묵 blocker를 없앤다(둘 다 편집 가능). ⚠️UTC(toISOString)
+// 대신 로컬 시계로 YYYY-MM-DD를 조립해 자정 부근 하루 밀림을 피한다.
+const SPRINT_DEFAULT_SPAN_DAYS = 13;
+function localDateISO(offsetDays = 0): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+// story #2755 테스트 접근용 export(내부 사용 불변) — «침묵 금지» 렌더 검증(loud validation) 대상.
+export function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
   const t = useTranslations('sprints');
   const [title, setTitle] = useState('');
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
+  const [startDate, setStartDate] = useState(() => localDateISO(0));
+  const [endDate, setEndDate] = useState(() => localDateISO(SPRINT_DEFAULT_SPAN_DAYS));
   const [goal, setGoal] = useState('');
   const [capacity, setCapacity] = useState('');
   const [teamSize, setTeamSize] = useState('');
@@ -151,8 +166,10 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
   const declaredCount = declarations.filter(isDeclarationComplete).length;
 
   const handleSubmit = async (activateAfterCreate: boolean) => {
-    if (!title.trim() || !startDate || !endDate) return;
-    if (activateAfterCreate && declaredCount === 0) return;
+    // story #2755 — 침묵 금지: 미충족 조건을 조용히 return하지 않고 사유를 화면에 올린다(아래
+    // role=alert 배너). 게이트(가설 ≥1) 자체는 유지하되, «왜 안 되는지»를 클릭이 항상 말하게 한다.
+    if (!title.trim() || !startDate || !endDate) { setError(t('missingRequired')); return; }
+    if (activateAfterCreate && declaredCount === 0) { setError(t('activateBlocked')); return; }
     setSubmitting(true);
     setError(null);
     try {
@@ -310,10 +327,13 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
             </span>
             <div className="flex gap-2">
               <Button type="button" variant="ghost" size="sm" onClick={onClose}>{t('cancel')}</Button>
-              <Button type="button" variant="outline" size="sm" disabled={submitting || !title.trim() || !startDate || !endDate} onClick={() => void handleSubmit(false)}>
+              {/* story #2755 — disabled를 submitting만으로 좁혀 «클릭이 항상 handleSubmit을 실행»
+                  하게 한다(무설명 disabled 제거). 미충족 필드는 handleSubmit이 setError로 사유를
+                  띄운다. 연타/중복 제출은 submitting 가드로 커버. */}
+              <Button type="button" variant="outline" size="sm" disabled={submitting} onClick={() => void handleSubmit(false)}>
                 {t('saveDraft')}
               </Button>
-              <Button type="button" size="sm" disabled={submitting || !title.trim() || !startDate || !endDate || declaredCount === 0} onClick={() => void handleSubmit(true)}>
+              <Button type="button" size="sm" disabled={submitting} onClick={() => void handleSubmit(true)}>
                 {submitting ? '...' : t('activate')}
               </Button>
             </div>


### PR DESCRIPTION
## 배경
fresh 조직에서 /sprints → 첫 스프린트 시작하기 모달에 이름+목표를 채우고 «스프린트 시작»을 눌러도 네트워크 요청 0·에러 0·무반응 (#2755). 신규 팀의 «가설 선언» 관문(제품 철학 첫 화면)이라 이탈 직결.

## 원인 (코드 실측)
- startDate/endDate가 빈 값 기본(type=date·pre-fill 없음) → 이름+목표만 채운 fresh 유저는 버튼이 disabled로 막힘.
- «스프린트 시작»(activate) disabled = `submitting || !title || !startDate || !endDate || declaredCount===0`. disabled 버튼은 onClick 미발화 → 네트워크 0·화면 그대로.
- handleSubmit의 미충족 가드가 조용히 return. 유일 힌트 activateBlocked는 가설 케이스만·subtle. **날짜 미입력엔 메시지 0 = 완전 침묵.**
- (관측 정정) «눌리는데 침묵»이 아니라 «disabled인데 disabled로 안 보임». enabled면 무조건 POST 발화.

## 변경
- **날짜 pre-fill**: 시작=오늘·종료=+13일(2주 inclusive·편집 가능). 빈 날짜 침묵 blocker 제거.
- **침묵→명시**: handleSubmit silent return → `setError`(기존 role=alert 배너 재사용). 신규 키 `missingRequired`(ko/en).
- **클릭이 항상 사유를 말함**: activate/saveDraft disabled를 `submitting`만으로 좁힘. 연타/중복 제출은 submitting 가드로 커버.
- **게이트 유지**: 가설 ≥1 활성화 게이트(E-SPRINT-LOOP sprint-open 定·"sprint-able" 철학)는 안 건드림 — «침묵»만 제거(PO 승인).

## AC 매핑
1. 이름+목표(+기본날짜)로 진행 가능·부족 시 «무엇이 왜 필요한지»가 화면에 표시(missingRequired/activateBlocked). ✅
2. 제출 실패 시 침묵 금지 — 검증 메시지 표면화. ✅
3. dev 라이브 fresh 조직 완주 + ko/en — 머지+dev 배포 후. ⏳

## 검증
- tsc: 변경 파일 0에러(기존 무관 EE tosspayments SDK 1건은 develop 동일). eslint 0.
- 렌더 테스트 3/3(`sprints-client.create-silent.test.tsx`): 날짜 pre-fill·이름 없이 클릭→missingRequired+POST 미발화·가설0→activateBlocked+POST 미발화 — «침묵→명시 + 게이트 유지» 행동 실증(POST 미발화까지 단언).
- 라이브(fresh 조직·2테마·ko/en)는 dev 배포 반영 후 첨부.

관련: story #2755 · 동일 클래스 #2750(무설명 disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
