### PR TITLE
feat(#2467 respec): 10초 내 살아있음 신호 — polling 철거, SSE push로 교체

### DIFF
--- a/apps/web/src/app/onboarding/verify-rail.test.tsx
+++ b/apps/web/src/app/onboarding/verify-rail.test.tsx
@@ -235,3 +235,61 @@ describe('useVerificationRail — story #4cdad425 (검증 타임아웃 진단 �
     unmount();
   });
 });
+
+// story #2467 respec — SSE push가 재조회를 "트리거"하는 것이지 타이머가 반복 도는 게 아님을
+// 직접 증명한다. useSseNotifications를 모킹해 onExtraEvent 콜백을 손으로 쥐고 실행 —
+// 그 호출 하나가 fetch 1회를 유발하는지, 그리고 시간 경과만으로는(콜백 없이) fetch가 안
+// 늘어나는지(=반복 타이머 부재) 둘 다 확인한다.
+vi.mock('@/hooks/use-sse-notifications', () => ({
+  useSseNotifications: vi.fn(),
+}));
+
+describe('useVerificationRail — story #2467 respec (SSE push가 재조회를 트리거·polling 아님)', () => {
+  const opts = { agentId: 'a1', transport: 'stdio' as const, enabled: true, configCopiedDone: false };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    global.fetch = vi.fn(async () => ({ ok: false, json: async () => ({}) })) as unknown as typeof fetch;
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('시간만 흘러선 재조회가 안 늘어난다(반복 타이머 없음) — SSE push가 와야 늘어난다', async () => {
+    const { useSseNotifications } = await import('@/hooks/use-sse-notifications');
+    let capturedOnExtraEvent: ((eventName: string, data: unknown) => void) | undefined;
+    (useSseNotifications as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (o: { onExtraEvent?: typeof capturedOnExtraEvent }) => { capturedOnExtraEvent = o.onExtraEvent; },
+    );
+
+    function Harness2({ o }: { o: Parameters<typeof useVerificationRail>[0] }) {
+      useVerificationRail(o);
+      return null;
+    }
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={ko} timeZone="Asia/Seoul"><Harness2 o={opts} /></NextIntlClientProvider>,
+      );
+    });
+
+    const callsAfterMount = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(callsAfterMount).toBeGreaterThan(0); // 마운트 1회 스냅샷
+
+    // 시간만 30초 흘려도(과거 2.5s 폴링이면 12번 더 늘었을 시간) 추가 fetch 없음.
+    act(() => { vi.advanceTimersByTime(30_000); });
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsAfterMount);
+
+    // SSE push 도착(mock onExtraEvent 직접 호출) → 그 즉시 단발 재조회 1회.
+    act(() => { capturedOnExtraEvent?.('onboarding.rail_signal', { agent_id: 'a1', state: 'mcp_reachable' }); });
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsAfterMount + 1);
+
+    // 다른 agent_id의 신호는 무시(내 재조회 트리거 아님).
+    act(() => { capturedOnExtraEvent?.('onboarding.rail_signal', { agent_id: 'someone-else', state: 'verified' }); });
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsAfterMount + 1);
+
+    act(() => root.unmount());
+  });
+});

--- a/apps/web/src/app/onboarding/verify-rail.tsx
+++ b/apps/web/src/app/onboarding/verify-rail.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 
 import { fetchWithAuth } from '@/lib/db/client';
+import { useSseNotifications } from '@/hooks/use-sse-notifications';
 
 export type RailStatus = 'pending' | 'active' | 'done' | 'failed';
 
@@ -29,10 +30,12 @@ export type RailState = (typeof RAIL_ORDER)[number];
 /** E-MCP-OPT S3: 호스팅(http) transport 축소 레일 — event_delivered/ack 없음(구조적으로 불가·BE agent_verify.py). */
 export const HTTP_RAIL_ORDER = ['config_copied', 'waiting', 'mcp_reachable', 'verified'] as const;
 
-/** story #4cdad425(prod 에스컬레이트) — 검증이 이 시간(ms) 안에 verified로 안 넘어가면 «진단 힌트»를
- * 띄운다. 근본: 설정만 붙이고 Claude Code를 재시작 안 하면 폴링이 영원히 pending에 머물러
- * 실유저가 5회 재시도했다(무한 폴링 가림). 폴링 자체는 계속 돈다(성공하면 힌트는 자동으로 사라짐). */
-export const VERIFY_TIMEOUT_MS = 60_000;
+/** story #2467 respec(2026-08-18, 「10초 내 살아있음 신호」 의무) — 원래 60s(story #4cdad425
+ * polling 진단힌트)였으나, 신호 의무 프로토콜로는 연결 직후 10초가 "살아있다는 첫 신호"의
+ * 상한이다(재실측 #2748: 순수 왕복 6.5초 — 10초는 그 위 여유). 10초 안에 mcp_reachable/verified
+ * SSE push가 안 오면 «미도달 + 진단 힌트»를 정직히 띄운다(#2404 클래스 재발 방지 — 침묵을
+ * "대기 중"으로 영원히 두지 않음). SSE push는 늦게라도 도착하면 이 힌트를 자동으로 감춘다. */
+export const VERIFY_TIMEOUT_MS = 10_000;
 
 export interface DisplayStep {
   state: RailState;
@@ -200,7 +203,6 @@ export interface UseVerificationRailOptions {
    * 동적)·recruiter: 항상 true(STEP4 번들 다운로드 완주 시점이라 이미 완료로 간주, 기존
    * recruiter-client.tsx 주석 "번들 다운로드=STEP3 완주로 이미 완료" 그대로 보존). */
   configCopiedDone: boolean;
-  pollIntervalMs?: number;
 }
 
 export interface UseVerificationRailResult {
@@ -253,15 +255,20 @@ export function computeShowVerifyExamplePrompt(transport: Transport | null, veri
  * (hasCopied && !beSteps일 때 pending을 active로 덮어쓰던 것). #2407 조사 中 미르코 라이브
  * 실측(http 축, story #2422/#2423 인접 조사)이 확認: `heartbeat_fresh` 하나가 http 레일
  * 전체를 한 번에 뒤집는 구조라 애초에 "부분 상태"가 정의돼 있지 않다 — 그 보정은 첫 폴
- * 응답 前(~pollIntervalMs) 잠깐의 화면 표시일 뿐 실제 관측 가능한 차이를 만들지 않았다.
+ * 응답 前 잠깐의 화면 표시일 뿐 실제 관측 가능한 차이를 만들지 않았다.
  * PO 판정(2026-08-02): 결함이 아니라 설계 그대로 — 제거해도 관측 가능한 손실이 없다.
+ *
+ * story #2467 respec(2026-08-18) — 2.5초 setInterval polling 철거. 「살아있음 신호」는 이제
+ * BE가 push하는 named SSE 이벤트(`onboarding.rail_signal` — agent_gateway.py 두 지점:
+ * ①/stream 연결 직후 자동 verify 기동→mcp_reachable ②/events/ack에서 verify round-trip
+ * 완료→verified)로만 받는다. 재조회(GET verification-status)는 ⓐ마운트 시 1회(재로드/재진입
+ * 복원용) ⓑSSE push 도착 시 1회, 둘 다 반복 타이머가 아니라 이벤트 트리거 단발 호출이다.
  */
 export function useVerificationRail({
   agentId,
   transport,
   enabled,
   configCopiedDone,
-  pollIntervalMs = 2500,
 }: UseVerificationRailOptions): UseVerificationRailResult {
   const t = useTranslations('onboarding');
   const [beSteps, setBeSteps] = useState<RawStep[] | null>(null);
@@ -282,13 +289,27 @@ export function useVerificationRail({
     }
   }, []);
 
+  // 마운트/transport전환 1회 스냅샷 — 반복 타이머 아님(재로드 시 이미 진행된 상태 복원용).
   useEffect(() => {
     if (!enabled || !agentId || !transport) return;
     setBeSteps(null); // transport 전환 시 이전 transport의 레일 상태가 새 레일에 새는 것 방지
     void pollStatus(agentId, transport);
-    const iv = setInterval(() => void pollStatus(agentId, transport), pollIntervalMs);
-    return () => clearInterval(iv);
-  }, [enabled, agentId, transport, pollIntervalMs, pollStatus]);
+  }, [enabled, agentId, transport, pollStatus]);
+
+  // story #2467 respec — 살아있음 신호 수신(SSE push) → 그 즉시 단발 재조회. 반복 타이머 없음
+  // (grep 검산 대상: 이 파일에 setInterval 0).
+  const handleRailSignal = useCallback((_eventName: string, data: unknown) => {
+    const payload = data as { agent_id?: string } | null;
+    if (!enabled || !agentId || !transport) return;
+    if (!payload || payload.agent_id !== agentId) return; // 다른 에이전트의 신호는 무시
+    void pollStatus(agentId, transport);
+  }, [enabled, agentId, transport, pollStatus]);
+
+  useSseNotifications({
+    enabled: enabled && Boolean(agentId) && Boolean(transport),
+    extraEventNames: ['onboarding.rail_signal'],
+    onExtraEvent: handleRailSignal,
+  });
 
   // story #4cdad425 — 진단 힌트 타이머. 폴링이 시작되면(또는 transport 전환·수동 재시도로 verifyNonce가
   // 오르면) 재무장하고, VERIFY_TIMEOUT_MS 지나도 verified가 안 되면 timedOut을 켠다. 폴링은 멈추지

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -541,8 +541,25 @@ async def agent_stream(
                     org_id=uuid.UUID(org_id_str), session_id=session_id,
                     runtime=tm.runtime_type or DEFAULT_RUNTIME, transport="stdio",
                 )
+                # story #2467 respec — 연결 즉시 자동 verify 라운드트립 기동(사람의 "Run test"
+                # 클릭 불요 — 커넥터의 "10초 내 살아있음 신호" 의무는 이 라운드트립의 ack로
+                # 충족된다, sse_bridge.py 의 자동 ack 재사용·발명 0). 이미 verified 인 재연결은
+                # 재트리거 안 함(매 재접속마다 이벤트 스팸 방지).
+                from app.services.agent_verify import get_verification_state, start_verification
+                _prior_verify = await get_verification_state(_pdb, agent_id, transport="stdio")
+                _newly_started = not _prior_verify["verified"]
+                if _newly_started:
+                    await start_verification(
+                        _pdb, agent_id=agent_id, org_id=tm.org_id, project_id=tm.project_id,
+                    )
                 await _pdb.commit()
             _presence_wired = True
+            if _newly_started:
+                # AC2: mcp_reachable 신호 — commit 성공 후에만(쓰기 실패 시 헛신호 방지).
+                from app.services.agent_verify import push_verification_signal
+                await push_verification_signal(
+                    org_id=tm.org_id, agent_id=agent_id, state="mcp_reachable", transport="stdio",
+                )
             # story #2602 Fix①/②의 기준점 — 이 시점 이후의 last_seen_at 전진만 "내 connect
             # write 이후에 일어난 일"로 인정한다(내 connect write 자체는 위에서 이미 커밋됨).
             # Fix①: 연결 단위 무장 상태(전진을 한 번이라도 봤는지) — arm 후 stale 전환 시만 skip.
@@ -730,6 +747,7 @@ async def ack_event(
         raise HTTPException(status_code=403, detail="API key required")
 
     agent_id = uuid.UUID(auth.user_id)
+    _newly_verified_org_id: uuid.UUID | None = None
 
     # UPSERT acked_seq (ë ëì ê°ë§ ê°±ì )
     existing = (await db.execute(
@@ -768,7 +786,7 @@ async def ack_event(
         from app.services.agent_verify import VERIFY_EVENT_TYPE
         from app.services.onboarding_funnel import emit_onboarding_event
         _verify_done = (await db.execute(
-            select(Event.id).where(
+            select(Event.id, Event.org_id).where(
                 Event.recipient_id == agent_id,
                 Event.event_type == VERIFY_EVENT_TYPE,
                 Event.recipient_seq.isnot(None),
@@ -798,6 +816,15 @@ async def ack_event(
                 db, "verified", agent_id=agent_id,
                 session_id=_seam_session_id, meta=_seam_meta,
             )
+            _newly_verified_org_id = _verify_done.org_id
 
     await db.commit()
+
+    if _newly_verified_org_id is not None:
+        # story #2467 respec — verified 신호(commit 성공 후에만 push, 헛신호 방지).
+        from app.services.agent_verify import push_verification_signal
+        await push_verification_signal(
+            org_id=_newly_verified_org_id, agent_id=agent_id, state="verified", transport="stdio",
+        )
+
     return {"acked_seq": body.seq}

--- a/backend/app/services/agent_verify.py
+++ b/backend/app/services/agent_verify.py
@@ -43,6 +43,20 @@ RAIL_STATES = ("config_copied", "waiting", "mcp_reachable", "event_delivered", "
 HTTP_RAIL_STATES = ("config_copied", "waiting", "mcp_reachable", "verified")
 
 
+async def push_verification_signal(
+    *, org_id: uuid.UUID, agent_id: uuid.UUID, state: str, transport: str = "stdio",
+) -> None:
+    """story #2467 respec — polling 대체 SSE push. verify-rail 상태 전이(mcp_reachable·verified)를
+    org 멤버 전원에게 브로드캐스트(presence push_to_org_members 와 동형 패턴 — 발명 0). FE 는
+    `onboarding.rail_signal` named 이벤트를 구독해 GET 재조회 없이 직접 렌더한다."""
+    from app.routers.events import push_to_org_members
+
+    await push_to_org_members(
+        str(org_id), "onboarding.rail_signal",
+        {"agent_id": str(agent_id), "state": state, "transport": transport},
+    )
+
+
 def build_verification_rail(
     *,
     verify_seq: int | None,

--- a/backend/tests/test_2143_agent_stream_legacy_push_id_omission.py
+++ b/backend/tests/test_2143_agent_stream_legacy_push_id_omission.py
@@ -85,6 +85,15 @@ async def test_legacy_direct_push_frame_has_no_id_line(monkeypatch):
     monkeypatch.setattr(
         "app.services.onboarding_funnel.emit_onboarding_event", AsyncMock()
     )
+    # story #2467: /stream 연결 시 자동 verify 기동(신규 배선) — 이 테스트는 legacy id-omission
+    # 프레임 형태만 검증하므로 verify 축은 no-op(이미 verified로 봐 재트리거 안 함, 다른
+    # 무관 side-effect들과 동일한 격리 원칙).
+    monkeypatch.setattr(
+        "app.services.agent_verify.get_verification_state",
+        AsyncMock(return_value={"verify_seq": None, "acked_seq": None, "verified": True, "rail": []}),
+    )
+    monkeypatch.setattr("app.services.agent_verify.start_verification", AsyncMock())
+    monkeypatch.setattr("app.services.agent_verify.push_verification_signal", AsyncMock())
     monkeypatch.setattr("app.services.presence_online.mark_online", AsyncMock())
     monkeypatch.setattr("app.services.presence_events.emit_presence", AsyncMock())
     monkeypatch.setattr(ag, "_mark_agent_disconnected", AsyncMock())

--- a/backend/tests/test_2381_ac4_live_wake_delivery_realdb.py
+++ b/backend/tests/test_2381_ac4_live_wake_delivery_realdb.py
@@ -87,6 +87,16 @@ def _patch_side_effects(monkeypatch):
     monkeypatch.setattr(
         "app.services.onboarding_funnel.emit_onboarding_event", AsyncMock()
     )
+    # story #2467: /stream 연결 시 자동 verify 기동(신규 배선) — 이 스토리는 wake 배달 순수성만
+    # 관측 대상이다. 패치 없이 두면 매번 새로 seed하는 미검증 agent가 connection_test 이벤트를
+    # 자동으로 하나 더 만들어(backfill로 주워짐) "wake 없이도 도착"이라는 거짓 양성을 만든다
+    # (test_2143 선례와 동일 원칙 — 이미 verified로 보아 재트리거 안 함).
+    monkeypatch.setattr(
+        "app.services.agent_verify.get_verification_state",
+        AsyncMock(return_value={"verify_seq": None, "acked_seq": None, "verified": True, "rail": []}),
+    )
+    monkeypatch.setattr("app.services.agent_verify.start_verification", AsyncMock())
+    monkeypatch.setattr("app.services.agent_verify.push_verification_signal", AsyncMock())
     monkeypatch.setattr("app.services.presence_online.mark_online", AsyncMock())
     monkeypatch.setattr("app.services.presence_events.emit_presence", AsyncMock())
     monkeypatch.setattr("app.services.sse_lease.acquire", AsyncMock(return_value=None))

--- a/backend/tests/test_2467_verify_signal_seam.py
+++ b/backend/tests/test_2467_verify_signal_seam.py
@@ -1,0 +1,87 @@
+"""story #2467 respec — 「10초 내 살아있음 신호」: polling(setInterval) 철거 + SSE push 배선 가드.
+
+무거운 경로(SSE 제너레이터 lifecycle·ack 핫패스)는 test_ob4b_funnel_seams.py 관례를 따라
+source-inspection으로 배선을 고정한다. push_verification_signal 자체는 순수 단위 검증.
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── BE: /stream 연결 시 자동 verify 기동(재연결 스팸 방지 게이트 포함) ──────────
+
+def test_stream_connect_auto_starts_verify_when_not_yet_verified():
+    from app.routers import agent_gateway
+    src = inspect.getsource(agent_gateway)
+    assert "get_verification_state(_pdb, agent_id" in src
+    assert "_newly_started = not _prior_verify[\"verified\"]" in src
+    assert "if _newly_started:" in src
+    assert "start_verification(" in src
+    # 재연결 스팸 방지 — verified 인 상태에서 재접속 시 start_verification 재호출 금지(게이트 존재).
+    assert "await start_verification(" in src
+
+
+def test_stream_connect_pushes_mcp_reachable_only_when_newly_started():
+    from app.routers import agent_gateway
+    src = inspect.getsource(agent_gateway)
+    assert 'state="mcp_reachable"' in src
+    # commit 성공 후에만 push(헛신호 방지) — _pdb.commit() 다음 줄들에 위치.
+    idx_commit = src.index("await _pdb.commit()")
+    idx_push = src.index('state="mcp_reachable"')
+    assert idx_push > idx_commit
+
+
+# ─── BE: ack 완료 시 verified push(commit 후에만, 무조건 아님) ──────────────────
+
+def test_ack_pushes_verified_only_inside_seam_guard():
+    from app.routers import agent_gateway
+    src = inspect.getsource(agent_gateway.ack_event)
+    assert "_newly_verified_org_id: uuid.UUID | None = None" in src
+    assert "if _verify_done:" in src
+    assert "_newly_verified_org_id = _verify_done.org_id" in src
+    # push는 db.commit() 이후에만(트랜잭션 실패 시 헛신호 방지).
+    idx_commit = src.index("await db.commit()")
+    idx_push = src.index('state="verified"')
+    assert idx_push > idx_commit
+    idx_guard = src.index("if _newly_verified_org_id is not None:")
+    assert idx_guard < idx_push
+
+
+# ─── BE: push_verification_signal 순수 단위 검증 ───────────────────────────────
+
+@pytest.mark.anyio
+async def test_push_verification_signal_calls_push_to_org_members():
+    from app.services.agent_verify import push_verification_signal
+
+    org_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    with patch("app.routers.events.push_to_org_members", new=AsyncMock()) as mock_push:
+        await push_verification_signal(org_id=org_id, agent_id=agent_id, state="verified", transport="stdio")
+        mock_push.assert_awaited_once()
+        args, kwargs = mock_push.await_args
+        assert args[0] == str(org_id)
+        assert args[1] == "onboarding.rail_signal"
+        assert args[2] == {"agent_id": str(agent_id), "state": "verified", "transport": "stdio"}
+
+
+# ─── FE: verify-rail.tsx polling(setInterval) 완전 철거 검산 ───────────────────
+
+def test_verify_rail_has_zero_setinterval():
+    """AC1 — 「옛 값의 부재」로 검산: 2.5s setInterval 폴링 코드 0."""
+    repo_root = Path(__file__).resolve().parents[2]
+    rail_path = repo_root / "apps/web/src/app/onboarding/verify-rail.tsx"
+    src = rail_path.read_text(encoding="utf-8")
+    assert "setInterval(" not in src  # 실호출만(설명 주석의 "setInterval" 단어 자체는 허용)
+    assert "pollIntervalMs" not in src
+    assert "useSseNotifications" in src
+    assert "onboarding.rail_signal" in src

--- a/backend/tests/test_agent_gateway.py
+++ b/backend/tests/test_agent_gateway.py
@@ -88,6 +88,10 @@ async def test_ack_creates_cursor():
 
     session = AsyncMock()
     existing_result = MagicMock(); existing_result.scalar_one_or_none.return_value = None
+    # story #2467: ack 핸들러가 새로 추가한 verify-seam 조회(`.first()`)도 이 mock을 공유한다 —
+    # 이 테스트엔 connection_test 이벤트가 없으므로 명시 None(그래야 push_verification_signal이
+    # real DB(async_session_factory)를 타지 않는다 — MagicMock 기본 auto-truthy가 아니라).
+    existing_result.first.return_value = None
     session.execute = AsyncMock(return_value=existing_result)
     session.add = MagicMock()
     session.commit = AsyncMock()
@@ -126,6 +130,8 @@ async def test_ack_updates_cursor_if_higher():
 
     session = AsyncMock()
     result = MagicMock(); result.scalar_one_or_none.return_value = existing_cursor
+    # story #2467: verify-seam 조회 공유 mock — 이 테스트엔 connection_test 이벤트가 없다.
+    result.first.return_value = None
     session.execute = AsyncMock(return_value=result)
     session.commit = AsyncMock()
 

--- a/backend/tests/test_event1config_ack_retire.py
+++ b/backend/tests/test_event1config_ack_retire.py
@@ -40,6 +40,10 @@ async def test_ack_issues_delivered_update_on_events():
     cursor = SimpleNamespace(acked_seq=0, updated_at=None, agent_id=agent_id)
     sel_result = MagicMock()
     sel_result.scalar_one_or_none.return_value = cursor
+    # story #2467: ack 핸들러의 verify-seam 조회(`.first()`)도 이 mock을 공유한다 — 이
+    # 테스트엔 connection_test 이벤트가 없으므로 명시 None(그래야 push_verification_signal이
+    # real DB(async_session_factory)를 안 탄다).
+    sel_result.first.return_value = None
 
     executed: list = []
 


### PR DESCRIPTION
## Summary
- story #2467 respec(2026-08-18, PO): 「붙은 에이전트는 10초 내 살아있음 신호를 낸다」 — 원판(verify-rail.tsx 2.5s setInterval polling)이 오늘 결재된 「정신병 제로」 제약(polling/heartbeat 금지·SSE 이벤트 결)과 충돌한다는 재실측(#2748)의 직접 산출.
- **BE**(`agent_gateway.py`, 발명 0): `/stream` 연결 직후 자동 verify 라운드트립 기동(기존 커넥터의 자동 ack 재사용 — sse_bridge.py 무변경, 사람의 수동 "Run test" 클릭 불요). `mcp_reachable`/`verified` 두 지점에서 `onboarding.rail_signal` named SSE 이벤트를 기존 `push_to_org_members` 헬퍼로 push(presence와 동형 패턴).
- **FE**(`verify-rail.tsx`): `setInterval` 완전 철거. 마운트 1회 스냅샷 + SSE push 도착 시 단발 재조회로 교체. `VERIFY_TIMEOUT_MS` 60s→10s.

## Test plan
- [x] `pnpm typecheck`/`eslint` — clean
- [x] FE vitest(`src/app/onboarding` + recruiter, useVerificationRail 공유 소비처) — 127 passed, 신규 테스트로 "시간만 흘러선 재조회 0·SSE push만 재조회 1회" 양방향 실증(mutation self-check)
- [x] BE pytest 전체(`-m "not destructive_schema" -k "not realdb"`) — 4720 passed(사전 존재 로컬 `.mcp.json` 무관 7건 제외, git stash 대조로 무관 확認). 회귀 3건 발견 즉시 fix(`test_agent_gateway.py`·`test_event1config_ack_retire.py`·`test_2143_...py` — 새 verify-seam 조회를 mock 세션이 `.first()` 미설정으로 실 DB를 탈 뻔한 것, 셋 다 mock 보정으로 해소)
- [x] 신규 `test_2467_verify_signal_seam.py` — source-inspection 배선가드 + `push_verification_signal` 단위 검증
- [ ] 머지 후(AC2/AC3/AC5, #2441 AC5와 같은 결): dev 배포 후 라이브 SSE 왕복 실증 + 강제-실패 대조(무신호 에이전트 10s 미도달 표시) + paste→verified 전/후 실측 — 별도로 진행 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)