### PR TITLE
fix(#2758): NEXT_PUBLIC_TOSS_CLIENT_KEY 배포 SSOT 배선 — 「등재≠배선」 클래스 3번째

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -171,6 +171,11 @@ jobs:
             # 'agreed' — ⛔prod도 여기서 명시하되 값 변경 0(현행값 그대로 durable화만, 별도 배포
             # 조작 없음 — "손 값을 다음 배포가 덮는다" 교훈, _BACKEND_MIN_INSTANCES류와 동일 클래스).
             echo "license_consent=agreed" >> "$GITHUB_OUTPUT"
+            # story #2758(2026-08-18, 페드루 PO 지시 — EE_ENABLED·LICENSE_CONSENT와 동형
+            # 「등재≠배선」 3번째) — Toss 결제위젯 clientKey도 배포 SSOT 어디에도 배선된 적이
+            # 없었다. ⛔prod 무접촉 — 값 반입은 심사 후 선생님 허가 축, 빈 문자열 명시만
+            # (Dockerfile ARG 기본값과 동일 — 새로 켜는 게 아니라 기존 무배선 상태 그대로).
+            echo "toss_client_key=" >> "$GITHUB_OUTPUT"
             # story #2139/#2143 후속(2026-07-23, 오르테가군 판정 — dev 게이트 GREEN 확認 後
             # 같은 날 prod 승격, "절반만 고치는 것" 방지 교정): backend 쪽을 GCE 실시간 3노드와
             # 같은 흐름에서 켠다(한쪽만 켜고 멈추면 오늘의 #2448 인시던트와 동형 반쪽 상태가
@@ -331,6 +336,17 @@ jobs:
             # 'agreed'(수동 env) — 여기서도 값 변경 0, 현행값만 durable화(prod 위 main 분기와
             # 같은 값 — dev/prod가 실제로 다른 다른 플래그들과 달리 이건 원래 같아야 하는 값).
             echo "license_consent=agreed" >> "$GITHUB_OUTPUT"
+            # story #2758(2026-08-18, 페드루 PO 지시 — EE_ENABLED·LICENSE_CONSENT와 동형
+            # 「등재≠배선」 3번째, 미르코 2754 라이브 실증이 이 마디에서 잡음) — Toss 결제위젯
+            # clientKey(publishable 값, secret 아님 — 브라우저 노출 전제)를 Secret Manager
+            # TOSS_PAYMENTS_CLIENT_KEY_DEV에서 읽어 dev만 주입(prod는 위 main 분기에서 빈
+            # 문자열 명시·무접촉). Secret Manager 접근 권한은 이 워크플로우의 GHA SA(github-
+            # actions@sprintable-494803)가 project-level roles/secretmanager.secretAccessor로
+            # 이미 보유(신규 IAM 변경 0). Setup Cloud SDK 스텝이 이미 프로젝트를 기본값으로
+            # 잡아 둬 --project 불요.
+            TOSS_CLIENT_KEY_DEV_VALUE=$(gcloud secrets versions access latest --secret="TOSS_PAYMENTS_CLIENT_KEY_DEV")
+            echo "::add-mask::${TOSS_CLIENT_KEY_DEV_VALUE}"
+            echo "toss_client_key=${TOSS_CLIENT_KEY_DEV_VALUE}" >> "$GITHUB_OUTPUT"
             # story #2139/#2143 후속(2026-07-23, 오르테가군 판정) — "백플레인 켜기" dev 1단계.
             # PRESENCE_ONLINE_REDIS_ENABLED: DB 폴백 있음(안 깨져 있음 — 켜면 신선도 개선).
             # PRESENCE_REDIS_ENABLED(chat_presence "working"): 프로세스-로컬 dict라 GCE
@@ -391,6 +407,7 @@ jobs:
           V_SSE_MULTIPLEX_ENABLED: ${{ steps.env.outputs.sse_multiplex_enabled }}
           V_EE_ENABLED: ${{ steps.env.outputs.ee_enabled }}
           V_LICENSE_CONSENT: ${{ steps.env.outputs.license_consent }}
+          V_TOSS_CLIENT_KEY: ${{ steps.env.outputs.toss_client_key }}
           V_BACKEND_PRESENCE_REDIS_ENABLED: ${{ steps.env.outputs.backend_presence_redis_enabled }}
           V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED: ${{ steps.env.outputs.backend_presence_online_redis_enabled }}
           V_BACKEND_SSE_LEASE_REDIS_ENABLED: ${{ steps.env.outputs.backend_sse_lease_redis_enabled }}
@@ -399,7 +416,7 @@ jobs:
           V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED: ${{ steps.env.outputs.backend_sse_transient_replay_enabled }}
           V_MCP_ALLOWED_HOSTS: ${{ steps.env.outputs.mcp_allowed_hosts }}
         run: |
-          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\",_MCP_ALLOWED_HOSTS=\"${V_MCP_ALLOWED_HOSTS}\",_EE_ENABLED=\"${V_EE_ENABLED}\",_LICENSE_CONSENT=\"${V_LICENSE_CONSENT}\""
+          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\",_MCP_ALLOWED_HOSTS=\"${V_MCP_ALLOWED_HOSTS}\",_EE_ENABLED=\"${V_EE_ENABLED}\",_LICENSE_CONSENT=\"${V_LICENSE_CONSENT}\",_TOSS_CLIENT_KEY=\"${V_TOSS_CLIENT_KEY}\""
           echo "substitutions=${SUBST}" >> "$GITHUB_OUTPUT"
 
       - name: Submit Cloud Build

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -49,6 +49,13 @@ ENV NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED=${NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED}
 # 였다 — 기본값 false(미설정 시 dev-safe fallback, SSE_MULTIPLEX_ENABLED와 동일 컨벤션).
 ARG NEXT_PUBLIC_EE_ENABLED=false
 ENV NEXT_PUBLIC_EE_ENABLED=${NEXT_PUBLIC_EE_ENABLED}
+# story #2758(2026-08-18) — apps/web/src/ee/components/billing/toss-checkout.ts(story #2510)가
+# 읽는 Toss 결제위젯 clientKey. manual-env-allowlist.yml에 declared_by:PO로 「등재」만 되고
+# ARG/ENV 어디에도 배선된 적이 없어(EE_ENABLED·LICENSE_CONSENT와 동형 「등재≠배선」 3번째)
+# dev FE에 값이 아예 없었다. publishable 값(secret 아님, 브라우저 노출 전제) — 기본값 빈
+# 문자열(미설정 시 dev-safe fallback, 위 컨벤션과 동일).
+ARG NEXT_PUBLIC_TOSS_CLIENT_KEY=""
+ENV NEXT_PUBLIC_TOSS_CLIENT_KEY=${NEXT_PUBLIC_TOSS_CLIENT_KEY}
 RUN pnpm build
 
 # ─── 런타임 ──────────────────────────────────────────────────────────────────

--- a/backend/tests/test_check_env_drift_code_read_axis.py
+++ b/backend/tests/test_check_env_drift_code_read_axis.py
@@ -300,7 +300,9 @@ def test_ac4_real_repo_scan_counts_are_recorded():
     # 2026-08-17 story #2728 후속으로 NEXT_PUBLIC_EE_ENABLED를 cloudbuild.yaml/GHA에 배선
     # (dev FE billing 표면 렌더 안 되던 근본원인)해 IaC-covered로 전환·high 16→15,
     # 2026-08-18 story #e6500272 후속으로 LICENSE_CONSENT도 동형 배선(backend deploy 스텝
-    # ENV_VARS)해 IaC-covered로 전환·high 15→14) — 스위트가
+    # ENV_VARS)해 IaC-covered로 전환·high 15→14,
+    # 2026-08-18 story #2758 후속으로 NEXT_PUBLIC_TOSS_CLIENT_KEY도 동형 배선(cloudbuild.yaml
+    # build-arg+GHA dev 분기 Secret Manager 주입)해 IaC-covered로 전환·high 14→13) — 스위트가
     # 실패하면 숫자가 바뀐 것, 원인을 봐야 한다. 이번 -5/+5는 SPRINTABLE_RUNTIME_ROLE·
     # SPRINTABLE_{BACKGROUND,MEMO_DISPATCHER,DISCORD_OUTBOUND,TEAMS_OUTBOUND}_POLL_INTERVAL_MS
     # 다섯이 high(미triage)에서 code_read_exempt(영구 정상)로 승격된 것 — env 드리프트
@@ -310,7 +312,7 @@ def test_ac4_real_repo_scan_counts_are_recorded():
     # 은퇴 상태). 값을 채워야 도는 게 아니라 안 채워야 지금 의도대로 도는 스위치라
     # code_read_exempt가 정확한 분류다(baseline의 "아직 triage 안 됨"과 다르다).
     assert len(highest) == 1, highest
-    assert len(high) == 14, high
+    assert len(high) == 13, high
     assert len(low) == 9, low
     assert len(exempt) == 23
 
@@ -403,13 +405,14 @@ def test_baseline_entry_without_reason_is_escalated():
 
 
 def test_repo_code_read_high_baseline_is_wellformed():
-    """저장소에 실제로 커밋된 baseline(13건, 2026-08-07 — #2510 NEXT_PUBLIC_TOSS_CLIENT_KEY
+    """저장소에 실제로 커밋된 baseline(12건, 2026-08-07 — #2510 NEXT_PUBLIC_TOSS_CLIENT_KEY
     추가로 14→15, 2026-08-17 — #2728 NEXT_PUBLIC_EE_ENABLED를 cloudbuild.yaml/GHA 배선으로
     해소해 15→14, 2026-08-18 — #e6500272 LICENSE_CONSENT를 backend deploy 스텝 배선으로
-    해소해 14→13)이 형식을 지키는지."""
+    해소해 14→13, 2026-08-18 — #2758 NEXT_PUBLIC_TOSS_CLIENT_KEY를 cloudbuild.yaml build-arg+
+    GHA dev 분기 배선으로 해소해 13→12)이 형식을 지키는지."""
     mod = _load_check_env_drift()
     baseline = mod._load_code_read_high_baseline()
-    assert len(baseline) == 13
+    assert len(baseline) == 12
     for key, entry in baseline.items():
         problem = mod._baseline_entry_expired(entry, mod._today())
         assert problem is None, f"{key}: {problem}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -57,6 +57,14 @@ substitutions:
   # 기본값 'false'(SSE_MULTIPLEX_ENABLED와 동일 컨벤션) — GHA가 dev 브랜치에서만 'true' 주입,
   # prod는 이 커밋으로 무접촉(기존 동작 그대로 유지, 명시 false로 durable화만).
   _EE_ENABLED: "false"
+  # story #2758(2026-08-18, 페드루 PO 지시 — EE_ENABLED·LICENSE_CONSENT와 동형 「등재≠배선」
+  # 3번째, 미르코 2754 라이브 실증이 이 마디에서 잡음) — apps/web/src/ee/components/billing/
+  # toss-checkout.ts(story #2510)가 읽는 Toss 결제위젯 clientKey가 manual-env-allowlist.yml에
+  # declared_by:PO로 등재만 되고 build-arg 배선이 0건이었다 — dev FE 런타임에 값이 아예 없어
+  # SDK 초기화 직전에서 막혔다. publishable 값(secret 아님, 브라우저 노출 전제) — dev-safe
+  # 기본값 빈 문자열 — GHA가 dev 브랜치에서만 Secret Manager TOSS_PAYMENTS_CLIENT_KEY_DEV를
+  # 읽어 주입. prod는 이 커밋으로 무접촉(값 반입은 심사 후 선생님 허가 축).
+  _TOSS_CLIENT_KEY: ""
   # story #e6500272 후속(2026-08-18, 페드루 PO 지시 — #3188과 동형 발견) — backend
   # `settings.is_ee_enabled`가 읽는 `LICENSE_CONSENT`도 EE_ENABLED와 동일하게 배포 SSOT
   # 어디에도 배선된 적이 없다(cloudbuild.yaml·GHA·Dockerfile 전부 무배선). dev·prod 둘 다
@@ -257,6 +265,8 @@ steps:
       - NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED=${_SSE_MULTIPLEX_ENABLED}
       - --build-arg
       - NEXT_PUBLIC_EE_ENABLED=${_EE_ENABLED}
+      - --build-arg
+      - NEXT_PUBLIC_TOSS_CLIENT_KEY=${_TOSS_CLIENT_KEY}
       - .
     env:
       - DOCKER_BUILDKIT=1

--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -601,11 +601,3 @@ code_read_high_baseline:
     reason: apps/web/src/lib/auth/firebase-client.ts·lib/db/server.ts — 기본값 없음, 미triage(위와 동일 축).
     declared_by: PO
     until: "2026-08-27"
-  - key: NEXT_PUBLIC_TOSS_CLIENT_KEY
-    reason: >-
-      apps/web/src/ee/components/billing/toss-checkout.ts(story #2510) — 기본값 없음,
-      미triage. Toss 결제위젯 SDK 초기화용 clientKey — 실 배포 時 IaC/시크릿으로 채워질
-      알려진 필수값(secret 아님, publishable 성격 — #2878의 toss_payments_client_key와
-      한 쌍이나 그건 BE Settings 축, 이건 FE 빌드타임 축이라 별도 등재).
-    declared_by: PO
-    until: "2026-08-27"


### PR DESCRIPTION
## Summary
- story #2758 [토스 심사·infra]. 미르코 2754 라이브 실증이 마지막 마디(Toss SDK 초기화 직전)에서 잡음 — dev FE 런타임에 `NEXT_PUBLIC_TOSS_CLIENT_KEY`가 아예 없었다. `cloudbuild.yaml`/`Dockerfile`/GHA 어디에도 build-arg 배선이 없이 `infra/manual-env-allowlist.yml`에 `declared_by: PO`로 「등재」만 돼 있던 상태 — 어제 잡은 EE_ENABLED(#3188)·LICENSE_CONSENT(#3192)와 정확히 같은 「등재≠배선」 클래스의 3번째. 두 PR과 동형 패턴 그대로 적용.
- `apps/web/Dockerfile`: `ARG`/`ENV NEXT_PUBLIC_TOSS_CLIENT_KEY` 신설(기본값 빈 문자열).
- `cloudbuild.yaml`: `_TOSS_CLIENT_KEY` substitution + frontend build-arg 추가.
- `.github/workflows/cloud-build.yml`: dev 분기에서 Secret Manager `TOSS_PAYMENTS_CLIENT_KEY_DEV`를 `gcloud secrets versions access`로 읽어 주입(GHA SA가 project-level `secretmanager.secretAccessor` 이미 보유 — 신규 IAM 변경 0), `::add-mask::`로 로그 마스킹. prod(main) 분기는 빈 문자열 명시(⛔prod 무접촉).
- `infra/manual-env-allowlist.yml`: 해당 엔트리 제거(IaC-covered 전환) + drift 가드 핀 갱신(high 14→13·baseline 13→12).

## Test plan
- [x] `test_check_env_drift_code_read_axis.py` 27/27 pass — 뮤테이션킬(build-arg 줄 제거 → high 13→14 RED 재현, 원복 후 재그린) 확認
- [x] 관련 배포/cloudbuild 가드 클러스터(cloudbuild·deploy_env·check_env_drift·2178) 102/102 pass — `test_deploy_backend_redis_secret_conflict.py` 무회귀(5/5, 프론트 build-arg라 bash-entrypoint 스캔 범위 밖 — EE_ENABLED와 동형 확認)
- [x] 전체 backend suite(`not destructive_schema`, realdb 제외) 4719 passed — 나머지 8건은 이 커밋과 무관한 로컬 `.mcp.json`/ref-freshness 환경 이슈(git stash 대조로 무관 확認)
- [x] `cloudbuild.yaml`·`.github/workflows/cloud-build.yml`·`infra/manual-env-allowlist.yml` 전부 YAML 파싱 클린
- [ ] CI
- [ ] 머지·dev 재배포(올리베이어군 트리거) 후 미르코군 2754 마지막 마디(Toss 위젯 표출) 재실증 — 그것으로 2754 닫힘

⛔prod: 정의만(빈 문자열 명시) — 실 키 반입·실배포는 심사 후 선생님 허가 축.

🤖 Generated with [Claude Code](https://claude.com/claude-code)