### PR TITLE
fix(#2761): delivery_jobs 원자적 claim — pending→claimed 단일 UPDATE

### DIFF
--- a/backend/alembic/versions/0256_delivery_jobs_claimed_status.py
+++ b/backend/alembic/versions/0256_delivery_jobs_claimed_status.py
@@ -50,6 +50,11 @@ def downgrade() -> None:
         "ix_delivery_jobs_pending", "delivery_jobs", ["id"],
         postgresql_where=sa.text("status = 'pending'"),
     )
+    # PO 리뷰(2026-08-18) — 'claimed' row가 존재하는 채로 OLD_CK를 재생성하면 그 즉시 CHECK
+    # 위반으로 실패한다(로컬 검증은 빈 테이블이라 놓쳤다). OLD_CK가 'claimed'를 모르므로
+    # 먼저 pending으로 정규화 — at-least-once 계약상 claimed는 언젠가 재시도될 값이라
+    # pending 복귀가 안전한 유일한 다운그레이드 경로.
+    op.execute("UPDATE delivery_jobs SET status = 'pending', claimed_at = NULL WHERE status = 'claimed'")
     op.drop_constraint("ck_delivery_jobs_status", "delivery_jobs", type_="check")
     op.create_check_constraint("ck_delivery_jobs_status", "delivery_jobs", _OLD_CK)
     op.drop_column("delivery_jobs", "claimed_at")

--- a/backend/alembic/versions/0256_delivery_jobs_claimed_status.py
+++ b/backend/alembic/versions/0256_delivery_jobs_claimed_status.py
@@ -1,0 +1,55 @@
+"""story #2761(P1·prod 실사용 제보) — delivery_jobs 원자적 claim 배선. 근본원인: `_claim_batch()`가
+attempts만 올리고 status는 'pending' 그대로 둬(FOR UPDATE SKIP LOCKED는 그 트랜잭션이 열려 있는
+"그 순간"만 막음), 배달(외부 I/O)이 poll 주기(2s)를 넘으면 다른 워커 인스턴스가 같은 job을
+재집는다 — prod backend minScale=3 독립 인스턴스가 각자 폴링해 "정확히 3번" 중복 발송으로
+드러났다(미르코 그라운딩·PO 처방 승인 2026-08-18).
+
+이 마이그는 'claimed' status 값 + claimed_at 타임스탬프 컬럼을 더해, claim 자체를
+`UPDATE ... WHERE status='pending' ... RETURNING`(FOR UPDATE SKIP LOCKED 서브쿼리)
+하나의 원자적 문으로 만들 수 있게 한다 — status 전이가 attempts 증가와 같은 UPDATE 안에서
+일어나 재집기 창이 구조적으로 닫힌다. claimed_at은 크래시 복구(reaper: 만료된 claimed →
+pending, at-least-once 보존)의 기준값.
+
+Revision ID: 0256
+Revises: 0255
+Create Date: 2026-08-18
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0256"
+down_revision = "0255"
+branch_labels = None
+depends_on = None
+
+_OLD_CK = "status IN ('pending', 'delivered', 'failed')"
+_NEW_CK = "status IN ('pending', 'claimed', 'delivered', 'failed')"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "delivery_jobs",
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.drop_constraint("ck_delivery_jobs_status", "delivery_jobs", type_="check")
+    op.create_check_constraint("ck_delivery_jobs_status", "delivery_jobs", _NEW_CK)
+    # 워커 폴링 축 부분 인덱스도 claimed 상태 존재를 반영 — reaper가 "claimed 중 만료된 것"을
+    # 스캔할 때도 이 인덱스가 커버(WHERE status IN ('pending','claimed')로 확장).
+    op.drop_index("ix_delivery_jobs_pending", table_name="delivery_jobs")
+    op.create_index(
+        "ix_delivery_jobs_pending", "delivery_jobs", ["id"],
+        postgresql_where=sa.text("status IN ('pending', 'claimed')"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_delivery_jobs_pending", table_name="delivery_jobs")
+    op.create_index(
+        "ix_delivery_jobs_pending", "delivery_jobs", ["id"],
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+    op.drop_constraint("ck_delivery_jobs_status", "delivery_jobs", type_="check")
+    op.create_check_constraint("ck_delivery_jobs_status", "delivery_jobs", _OLD_CK)
+    op.drop_column("delivery_jobs", "claimed_at")

--- a/backend/app/models/delivery_job.py
+++ b/backend/app/models/delivery_job.py
@@ -31,13 +31,23 @@ class DeliveryJob(Base):
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # story #2761 — claim 시각(reaper 기준값). 'claimed' 상태로 전이할 때만 채워진다(그 밖엔 NULL).
+    claimed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     __table_args__ = (
         CheckConstraint(
             "kind IN ('org_webhook', 'personal_webhook', 'expo_push')", name="ck_delivery_jobs_kind"
         ),
-        CheckConstraint("status IN ('pending', 'delivered', 'failed')", name="ck_delivery_jobs_status"),
-        # 워커 폴링 축 — pending 부분 인덱스(event_outbox.ix_event_outbox_pending과 동형: 대부분의
-        # row가 곧 delivered/failed로 빠지므로 미해결 row는 항상 소수, 부분 인덱스로 스캔 최소화).
-        Index("ix_delivery_jobs_pending", "id", postgresql_where=text("status = 'pending'")),
+        # story #2761 — 'claimed' 추가: claim(attempts+1)과 status 전이가 같은 원자적 UPDATE
+        # 안에서 일어나야 재집기 창이 닫힌다(0256 마이그 참조 — 근본원인·prod 3중복 실사고).
+        CheckConstraint(
+            "status IN ('pending', 'claimed', 'delivered', 'failed')", name="ck_delivery_jobs_status"
+        ),
+        # 워커 폴링 축 — pending/claimed 부분 인덱스(event_outbox.ix_event_outbox_pending과 동형:
+        # 대부분의 row가 곧 delivered/failed로 빠지므로 미해결 row는 항상 소수, 부분 인덱스로
+        # 스캔 최소화). claimed도 포함하는 이유 — reaper가 만료된 claimed를 이 인덱스로 찾는다.
+        Index(
+            "ix_delivery_jobs_pending", "id",
+            postgresql_where=text("status IN ('pending', 'claimed')"),
+        ),
     )

--- a/backend/app/services/delivery_dispatcher.py
+++ b/backend/app/services/delivery_dispatcher.py
@@ -12,18 +12,24 @@ SKIP LOCKED)과 실 배달(외부 I/O)을 **분리**한다 — claim은 즉시 c
 하면 §6이 막 닫은 "커넥션을 오래 쥔 채 외부 I/O" 클래스를 이 워커 자신이 재현하게 된다(PO
 2026-08-05 명시 지시 — "worker loop은 세션 짧게 잡고, 외부 I/O 中 트랜잭션 안 잡게").
 
-claim은 진짜 락이 아니다(attempts만 증가시키고 status는 pending 그대로 둔다) — FOR UPDATE
-SKIP LOCKED는 claim 트랜잭션이 열려 있는 "그 순간"의 동시 폴링만 막고, 그 트랜잭션이 끝난
-뒤 재폴링까지는 못 막는다. 즉 두 인스턴스가 좁은 창 안에서 겹치면 같은 job을 중복 배달할 수
-있다 — AC가 명시 허용하는 범위(at-least-once, exactly-once 아님)라 의도적으로 더 무거운 락은
-안 쓴다.
+⛔story #2761(P1·prod 실사용 제보, 2026-08-18) — 위 문단이 서술하던 "claim은 진짜 락이 아니다"
+설계가 실사고로 드러났다: attempts만 올리고 status는 pending 그대로 두는 원래 설계는 FOR UPDATE
+SKIP LOCKED가 claim 트랜잭션이 열려 있는 "그 순간"만 막고, 그 트랜잭션이 끝난 뒤(commit 즉시)
+재폴링까지는 못 막았다 — prod backend minScale=3(독립 인스턴스 3개가 각자 2s 주기 폴링)에서
+배달(외부 I/O)이 poll 주기를 넘을 때마다 "정확히 3번" 중복 발송으로 실사용자에게 드러났다
+(미르코 그라운딩·PO 처방 승인). 지금은 claim 자체가 `status: pending→claimed`를 attempts
+증가와 **같은 원자적 UPDATE**(WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED))로 수행한다 —
+그 UPDATE가 커밋된 순간부터 이 job은 더 이상 pending SELECT에 안 잡히므로 재집기 창 자체가
+없다(0256 마이그·`_claim_batch()` 참조). 크래시(claim 후 워커가 죽는 등)로 인한 유실은
+`_reap_expired_claims()`(claimed_at 타임아웃 → pending 복귀)로 방어 — at-least-once 계약은
+그대로 유지, "무기한 claimed로 낙인" 클래스만 새로 만들지 않는다.
 """
 from __future__ import annotations
 
 import asyncio
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select, update
 
@@ -33,37 +39,62 @@ _BATCH_SIZE = 20
 _POLL_INTERVAL = 2.0  # AC "near-real-time cadence" — event_broker.outbox_dispatcher_loop() 1s와 동급대.
 _MAX_ATTEMPTS = 5
 _CONCURRENCY = 5  # 배치 내 job들을 짧은 세션끼리 병렬 배달(커넥션 풀 예산 고려한 상한).
+# story #2761 — claimed로 낙인찍힌 뒤 워커가 크래시(재배포·OOM 등)해 delivered/재-pending 전이가
+# 영영 안 오면 그 job은 무기한 claimed로 죽는다. 이 타임아웃을 넘긴 claimed는 reaper가 pending
+# 으로 되돌린다(at-least-once 보존). 값 산정: 개별 target 배달 최대 10s(웹훅/expo push 타임아웃,
+# 클래스 docstring) × 배치 내 청크 순회(_CONCURRENCY=5 병렬이라 배치 20건은 최대 4청크) 여유
+# + poll 주기 2s 자체의 지터 — 45s면 정상 배달은 절대 못 넘기고, 죽은 워커의 job은 45~<poll
+# 주기+45>s 안에 회수된다(reaper가 매 tick 도므로 최악 case ≈ 45+2s).
+_CLAIM_TIMEOUT_SECONDS = 45
 
 
 async def _claim_batch(limit: int = _BATCH_SIZE) -> list[dict]:
-    """FOR UPDATE SKIP LOCKED로 pending job 배치를 골라 attempts만 증가시키고 바로 commit —
-    lock을 짧게만 쥔다(배달은 여기서 안 함). 반환은 세션-독립적인 순수 dict라 다음 단계가 이
-    세션을 물고 다닐 필요가 없다."""
+    """pending→claimed 전이와 attempts 증가를 **같은 원자적 UPDATE**로 수행 — FOR UPDATE
+    SKIP LOCKED 서브쿼리로 후보를 고르고, 그 UPDATE 자체가 이 job들을 즉시 pending SELECT에서
+    빼버린다(story #2761 — 이 원자성이 빠져 있던 것이 prod 3중복의 근본원인). 반환은
+    세션-독립적인 순수 dict라 다음 단계가 이 세션을 물고 다닐 필요가 없다."""
     from app.core.database import async_session_factory
     from app.models.delivery_job import DeliveryJob
 
+    now = datetime.now(timezone.utc)
     async with async_session_factory() as session:
-        rows = (await session.execute(
-            select(DeliveryJob)
+        candidate_ids = (
+            select(DeliveryJob.id)
             .where(DeliveryJob.status == "pending")
             .order_by(DeliveryJob.created_at.asc())
             .limit(limit)
             .with_for_update(skip_locked=True)
+        )
+        rows = (await session.execute(
+            update(DeliveryJob)
+            .where(DeliveryJob.id.in_(candidate_ids))
+            .values(status="claimed", claimed_at=now, attempts=DeliveryJob.attempts + 1)
+            .returning(DeliveryJob)
         )).scalars().all()
-        if not rows:
-            await session.commit()
-            return []
-        claimed = [
+        await session.commit()
+        return [
             {"id": r.id, "org_id": r.org_id, "kind": r.kind, "payload": dict(r.payload), "attempts": r.attempts}
             for r in rows
         ]
-        await session.execute(
+
+
+async def _reap_expired_claims() -> int:
+    """story #2761 — claimed_at이 _CLAIM_TIMEOUT_SECONDS를 넘긴(=워커가 claim 후 죽은 것으로
+    간주) job을 pending으로 되돌려 재집힐 수 있게 한다. attempts는 이미 claim 시점에 올라간
+    값 그대로 유지(재시도 횟수 계산에 이 죽은 시도도 포함 — _MAX_ATTEMPTS 도달로 자연 수렴).
+    반환값은 회수 건수(로그·테스트 관측용)."""
+    from app.core.database import async_session_factory
+    from app.models.delivery_job import DeliveryJob
+
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=_CLAIM_TIMEOUT_SECONDS)
+    async with async_session_factory() as session:
+        result = await session.execute(
             update(DeliveryJob)
-            .where(DeliveryJob.id.in_([r["id"] for r in claimed]))
-            .values(attempts=DeliveryJob.attempts + 1)
+            .where(DeliveryJob.status == "claimed", DeliveryJob.claimed_at < cutoff)
+            .values(status="pending", claimed_at=None)
         )
         await session.commit()
-        return claimed
+        return result.rowcount or 0
 
 
 def _uuid_or_none(v: str | None) -> uuid.UUID | None:
@@ -174,7 +205,10 @@ async def _deliver_one(job: dict) -> None:
                 next_status = "pending" if attempts < _MAX_ATTEMPTS else "failed"
                 await session.execute(
                     update(DeliveryJob).where(DeliveryJob.id == job_id).values(
-                        status=next_status, last_error=str(exc)[:1000],
+                        # claimed_at=None: pending 복귀 시 이전 claim 흔적을 지운다(reaper가
+                        # status만 보므로 기능적 영향은 없지만, 재-claim 시 새 claimed_at으로
+                        # 다시 채워지기 전까지 stale 값이 남는 것을 피한다).
+                        status=next_status, last_error=str(exc)[:1000], claimed_at=None,
                     )
                 )
                 await session.commit()
@@ -183,17 +217,23 @@ async def _deliver_one(job: dict) -> None:
 
 
 async def delivery_dispatcher_loop() -> None:
-    """claim(짧은 트랜잭션) → 배달(짧은 세션, 외부 I/O) → 상태갱신을 tick마다 반복.
+    """reap(만료된 claimed → pending) → claim(짧은 트랜잭션) → 배달(짧은 세션, 외부 I/O) →
+    상태갱신을 tick마다 반복.
 
+    story #2761 — reap을 매 tick claim 直前에 둔다(모든 인스턴스가 동등하게 reaper 역할도
+    겸함 — 단일 인스턴스에 reaper를 몰아주는 특별 경로 없음, 인스턴스 수 무관하게 동작).
     정상 tick 사이 ``_POLL_INTERVAL`` 고정 폴링. listen_loop()/event_broker.outbox_dispatcher_loop()
     와 동형 에러 backoff(1s→2s→...→30s)."""
     logger.info(
-        "delivery_dispatcher starting (poll_interval=%.1fs batch=%d concurrency=%d)",
-        _POLL_INTERVAL, _BATCH_SIZE, _CONCURRENCY,
+        "delivery_dispatcher starting (poll_interval=%.1fs batch=%d concurrency=%d claim_timeout=%.0fs)",
+        _POLL_INTERVAL, _BATCH_SIZE, _CONCURRENCY, _CLAIM_TIMEOUT_SECONDS,
     )
     delay = 1.0
     while True:
         try:
+            reaped = await _reap_expired_claims()
+            if reaped:
+                logger.warning("delivery_dispatcher: reaped %d expired claim(s) back to pending", reaped)
             claimed = await _claim_batch()
             if not claimed:
                 await asyncio.sleep(_POLL_INTERVAL)

--- a/backend/tests/test_2761_delivery_claim_race_realdb.py
+++ b/backend/tests/test_2761_delivery_claim_race_realdb.py
@@ -1,0 +1,240 @@
+"""story #2761(P1·prod 실사용 제보) realdb 검증 — 원자적 claim이 재집기 창을 실제로 닫는지.
+
+prod 실사고: `_claim_batch()`가 attempts만 올리고 status는 'pending' 그대로 둬(FOR UPDATE SKIP
+LOCKED는 그 트랜잭션이 열려 있는 "그 순간"만 막음), 배달(외부 I/O)이 poll 주기를 넘으면 다음
+poll 사이클(또는 동시에 도는 다른 인스턴스)이 같은 pending row를 재집었다 — minScale=3에서
+"정확히 3번" 중복 발송으로 드러났다(미르코 그라운딩).
+
+이 파일의 핵심 대조:
+  ①`_buggy_claim_like_old_code()` — fix 前 패턴(SELECT FOR UPDATE SKIP LOCKED + attempts만
+    증가, status 불변)을 그대로 재현 → 느린 배달(poll 주기 초과)을 흉내낸 "다음 poll 사이클"
+    호출에서 같은 row가 다시 잡힘을 실증(중복 재현).
+  ②실제 `_claim_batch()` — 같은 시나리오에서 두 번째 호출이 빈 리스트를 반환(재집기 0건)을
+    실증(fix 후 정확 1회).
+  ③진짜 동시성(두 세션이 같은 순간에 FOR UPDATE SKIP LOCKED) — 겹침 0, 커버리지 100%.
+
+⛔공유 dev 백엔드 접속 없음 — 로컬 Postgres(``PARITY_TEST_DATABASE_URL``)만 사용. 미설정 시
+skip. engine/session은 fixture가 아니라 테스트 본문에서 직접 생성(story #2459 realdb 관례 —
+async-generator fixture는 pytest-asyncio/anyio loop 불일치로 asyncpg가 죽는다).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="realdb 테스트는 로컬 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _clean_delivery_jobs(engine) -> None:
+    from app.models.delivery_job import DeliveryJob
+
+    async with engine.begin() as conn:
+        await conn.execute(DeliveryJob.__table__.delete())
+
+
+async def _buggy_claim_like_old_code(engine, org_id: uuid.UUID, limit: int = 20) -> list[uuid.UUID]:
+    """fix 前 `_claim_batch()`의 정확한 재현 — SELECT ... FOR UPDATE SKIP LOCKED로 후보를
+    골라 attempts만 올리고 커밋한다. status는 절대 안 건드린다(그게 버그였다) — 그래서
+    커밋 순간 락이 풀리고, row는 여전히 'pending'이라 다음 호출이 또 집는다."""
+    from app.models.delivery_job import DeliveryJob
+
+    async with AsyncSession(engine) as session:
+        candidate_ids = (
+            select(DeliveryJob.id)
+            .where(DeliveryJob.status == "pending", DeliveryJob.org_id == org_id)
+            .order_by(DeliveryJob.created_at.asc())
+            .limit(limit)
+            .with_for_update(skip_locked=True)
+        )
+        rows = (await session.execute(
+            update(DeliveryJob)
+            .where(DeliveryJob.id.in_(candidate_ids))
+            .values(attempts=DeliveryJob.attempts + 1)  # ⛔status 전이 없음 — 재현하려는 결함 그 자체.
+            .returning(DeliveryJob.id)
+        )).scalars().all()
+        await session.commit()
+        return list(rows)
+
+
+# ─── ①fix 前 패턴: 느린 배달(poll 주기 초과) → 다음 poll 사이클이 재집음(중복 재현) ──────
+
+@pytest.mark.anyio
+async def test_pre_fix_claim_pattern_reclaims_same_pending_rows_before_delivery_finishes():
+    """느린 배달 모킹 = 배달(외부 I/O)이 끝나기 전에 "다음 poll 사이클"이 도는 상황을 두 번의
+    순차 호출로 흉내낸다(각 호출은 짧은 트랜잭션 — commit 즉시 락 해제, 실제 poll 루프와 동형).
+    old 패턴은 status를 안 바꾸므로 두 번째 호출도 같은 row를 또 집는다 — prod 3중복의 근본원인
+    그 자체를 이 회귀 가드가 직접 재현한다."""
+    from app.models.delivery_job import DeliveryJob
+
+    engine = create_async_engine(_async_url())
+    try:
+        await _clean_delivery_jobs(engine)
+        org_id = uuid.uuid4()
+        async with AsyncSession(engine) as session:
+            for i in range(3):
+                session.add(DeliveryJob(org_id=org_id, kind="org_webhook", payload={"seq": i}))
+            await session.commit()
+
+        first_poll = await _buggy_claim_like_old_code(engine, org_id)
+        assert len(first_poll) == 3
+
+        # "배달이 poll 주기를 넘는다" = 아직 delivered/failed로 전이 안 된 채 다음 poll이 돎.
+        second_poll = await _buggy_claim_like_old_code(engine, org_id)
+        assert set(second_poll) == set(first_poll)  # ⛔중복 재현: 정확히 같은 3건이 또 잡힘.
+    finally:
+        await engine.dispose()
+
+
+# ─── ②fix 後: 같은 시나리오에서 재집기 0건(정확히 1회) ──────────────────────────────
+
+@pytest.mark.anyio
+async def test_claim_batch_prevents_reclaim_before_delivery_finishes(monkeypatch):
+    """①과 완전히 같은 시나리오(느린 배달 = 두 번째 poll이 첫 poll의 배달 완료 前 도착)를
+    실제 `_claim_batch()`로 재생 — status가 'pending'→'claimed'로 같은 원자적 UPDATE 안에서
+    전이되므로 두 번째 호출은 빈 리스트를 반환해야 한다(fix 후 정확 1회의 핵심 증거)."""
+    from app.models.delivery_job import DeliveryJob
+    from app.services.delivery_dispatcher import _claim_batch
+
+    engine = create_async_engine(_async_url())
+    try:
+        await _clean_delivery_jobs(engine)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        monkeypatch.setattr("app.core.database.async_session_factory", factory)
+
+        org_id = uuid.uuid4()
+        async with AsyncSession(engine) as session:
+            for i in range(3):
+                session.add(DeliveryJob(org_id=org_id, kind="org_webhook", payload={"seq": i}))
+            await session.commit()
+
+        first_poll = await _claim_batch(limit=10)
+        mine_first = [j for j in first_poll if j["org_id"] == org_id]
+        assert len(mine_first) == 3
+        assert {j["attempts"] for j in mine_first} == {1}
+
+        # 배달이 아직 안 끝난 상태(delivered/failed 전이 없음)에서 다음 poll 사이클 도착.
+        second_poll = await _claim_batch(limit=10)
+        mine_second = [j for j in second_poll if j["org_id"] == org_id]
+        assert mine_second == []  # ⛔재집기 0건 — status='claimed'라 pending SELECT에 안 잡힘.
+
+        async with AsyncSession(engine) as verify:
+            rows = (await verify.execute(
+                select(DeliveryJob).where(DeliveryJob.org_id == org_id)
+            )).scalars().all()
+        assert {r.status for r in rows} == {"claimed"}
+        assert {r.attempts for r in rows} == {1}  # 재집기가 없었으니 attempts도 안 더 올라감.
+        assert all(r.claimed_at is not None for r in rows)
+    finally:
+        await engine.dispose()
+
+
+# ─── ③진짜 동시성: 두 세션이 같은 순간에 claim — 겹침 0, 유실 0 ──────────────────────
+
+@pytest.mark.anyio
+async def test_concurrent_claim_batches_no_overlap_no_loss(monkeypatch):
+    """두 워커 인스턴스가 정말 동시에(FOR UPDATE SKIP LOCKED가 겹치는 순간) 폴링해도 같은
+    job을 안 집는다 — story #2761 AC "동시 워커 2+" 요건의 직접 증거."""
+    import asyncio
+
+    from app.models.delivery_job import DeliveryJob
+    from app.services.delivery_dispatcher import _claim_batch
+
+    engine = create_async_engine(_async_url())
+    try:
+        await _clean_delivery_jobs(engine)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        monkeypatch.setattr("app.core.database.async_session_factory", factory)
+
+        org_id = uuid.uuid4()
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            job_objs = [
+                DeliveryJob(org_id=org_id, kind="org_webhook", payload={"seq": i}) for i in range(10)
+            ]
+            for j in job_objs:
+                session.add(j)
+            await session.commit()
+            all_ids = {j.id for j in job_objs}
+
+        results = await asyncio.gather(
+            _claim_batch(limit=5), _claim_batch(limit=5), _claim_batch(limit=5),
+        )
+        claimed_ids_per_worker = [
+            {j["id"] for j in r if j["org_id"] == org_id} for r in results
+        ]
+        union_ids = set().union(*claimed_ids_per_worker)
+
+        for i in range(len(claimed_ids_per_worker)):
+            for j in range(i + 1, len(claimed_ids_per_worker)):
+                assert claimed_ids_per_worker[i] & claimed_ids_per_worker[j] == set()  # 겹침 0.
+        assert union_ids == all_ids  # 유실 0 — 10건 전부 누군가 정확히 한 번씩 집음.
+    finally:
+        await engine.dispose()
+
+
+# ─── ④크래시 복구: claimed_at 타임아웃 → reaper가 pending으로 되돌림(at-least-once 보존) ───
+
+@pytest.mark.anyio
+async def test_reap_expired_claims_returns_stale_claimed_jobs_to_pending(monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    from app.models.delivery_job import DeliveryJob
+    from app.services.delivery_dispatcher import _reap_expired_claims
+
+    engine = create_async_engine(_async_url())
+    try:
+        await _clean_delivery_jobs(engine)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        monkeypatch.setattr("app.core.database.async_session_factory", factory)
+
+        org_id = uuid.uuid4()
+        stale_cutoff = datetime.now(timezone.utc) - timedelta(seconds=999)
+        fresh_claimed_at = datetime.now(timezone.utc)
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            stale = DeliveryJob(
+                org_id=org_id, kind="org_webhook", payload={"x": "stale"},
+                status="claimed", claimed_at=stale_cutoff, attempts=1,
+            )
+            fresh = DeliveryJob(
+                org_id=org_id, kind="org_webhook", payload={"x": "fresh"},
+                status="claimed", claimed_at=fresh_claimed_at, attempts=1,
+            )
+            session.add_all([stale, fresh])
+            await session.commit()
+            stale_id, fresh_id = stale.id, fresh.id
+
+        reaped = await _reap_expired_claims()
+        assert reaped >= 1
+
+        async with AsyncSession(engine) as verify:
+            stale_row = (await verify.execute(
+                select(DeliveryJob).where(DeliveryJob.id == stale_id)
+            )).scalar_one()
+            fresh_row = (await verify.execute(
+                select(DeliveryJob).where(DeliveryJob.id == fresh_id)
+            )).scalar_one()
+        assert stale_row.status == "pending"  # 만료된 claim은 회수됨.
+        assert stale_row.claimed_at is None
+        assert fresh_row.status == "claimed"  # 방금 claim된 건 그대로(오탐 회수 없음).
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
story #2761(P1·prod 실사용 제보) — prod backend minScale=3 독립 인스턴스가 같은 delivery_jobs row를 재집어 "정확히 3번" 중복 발송(웹훅/Expo push)하던 근본원인 fix.

- `_claim_batch()`가 attempts만 올리고 status는 pending 그대로 뒀던 것을, status 전이(pending→claimed)를 attempts 증가와 같은 원자적 `UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED) ... RETURNING`으로 통합
- 0256 마이그: `claimed_at` 컬럼 + status CHECK에 `'claimed'` 추가 + pending 부분 인덱스를 `('pending','claimed')`로 확장
- `_reap_expired_claims()`: claimed_at 45s 타임아웃 → pending 복귀(크래시 시 at-least-once 보존), `delivery_dispatcher_loop()`가 매 tick reap 먼저 수행
- 적용 대상 = delivery_jobs 전 kind(org_webhook/personal_webhook/expo_push) 공통

⛔prod 반영은 정규 승격 절차 — 이 PR은 dev만.

## Test plan
- [x] 로컬 PG16 `alembic upgrade head`/`downgrade -1`/재-upgrade 클린 적용 확인
- [x] `test_2761_delivery_claim_race_realdb.py` 신규 4건 — fix 前 패턴(status 불변)으로 중복 재현 실증 → 실제 `_claim_batch()`로 재집기 0건(정확 1회) 실증, 3-way 동시 claim 겹침 0/유실 0, reaper 왕복
- [x] 기존 `test_2460_delivery_outbox_realdb.py` 6건 무회귀
- [x] 전체 백엔드 스위트 실행 — 16건 실패는 `git stash` 비교로 전부 pre-existing 확인(`.mcp.json` 로컬경로 검사·eventbus SSE hang·`test_2268_session_context_realdb` env-var 미설정 — delivery_job 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)