### PR TITLE
feat(#2751): 워크포스 목록 «연결 안 됨» 배지 + CTA (설계②)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2693,6 +2693,8 @@
     "backToList": "Back to list",
     "manageAddAgent": "Add agent",
     "manageProjectsGranted": "{count} projects granted",
+    "agentNotConnected": "Not connected",
+    "viewConnectionSettings": "View connection settings",
     "accessTab": "Access",
     "matrixTitle": "Access matrix",
     "matrixDescription": "Click a cell to toggle grant/block instantly.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2693,6 +2693,8 @@
     "backToList": "목록으로",
     "manageAddAgent": "에이전트 추가",
     "manageProjectsGranted": "{count}개 프로젝트 허용",
+    "agentNotConnected": "연결 안 됨",
+    "viewConnectionSettings": "연결 설정 보기",
     "accessTab": "접근권한",
     "matrixTitle": "접근권한 매트릭스",
     "matrixDescription": "셀을 눌러 허용/차단을 즉시 토글합니다.",

--- a/apps/web/src/components/agents/agent-management-tab.tsx
+++ b/apps/web/src/components/agents/agent-management-tab.tsx
@@ -23,6 +23,12 @@ interface OrgAgent {
   name: string;
   role: string;
   is_active: boolean;
+  // story #2751(설계②) — BE `_inject_active_stories()`가 배치 주입(fan-out 없음, PO
+  // 확定 — get_verified_map()). false=stdio verify 미완주(이탈 후보) — "연결 안 됨" CTA
+  // 대상. undefined/null이면 판별 불가(예: 이 필드를 아직 안 실어보내는 옛 응답 형태
+  // 방어) — 그 경우 CTA를 안 띄운다(거짓 "연결 안 됨" 낙인 방지, 침묵 실패보다 과소표시가
+  // 안전한 방향).
+  verified?: boolean | null;
 }
 
 interface ProjectOption {
@@ -218,9 +224,20 @@ export function AgentManagementTab({ onAddAgent }: AgentManagementTabProps) {
                       <Badge variant="secondary">{t('agentMember')}</Badge>
                       <Badge variant="outline">{agent.role}</Badge>
                       <Badge variant="info">{ta('manageProjectsGranted', { count: grantCounts[agent.id] ?? 0 })}</Badge>
+                      {agent.verified === false ? (
+                        <Badge variant="warning">{ta('agentNotConnected')}</Badge>
+                      ) : null}
                     </div>
                   </Link>
                   <div className="flex shrink-0 items-center gap-2">
+                    {agent.verified === false ? (
+                      <Link
+                        href={`/organization/workforce/${agent.id}`}
+                        className="whitespace-nowrap text-xs font-medium text-primary hover:underline"
+                      >
+                        {ta('viewConnectionSettings')}
+                      </Link>
+                    ) : null}
                     {isAdmin ? (
                       <Button
                         variant="glass"

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -58,6 +58,10 @@ async def _inject_active_stories(
     """AC6: active_story_id → stories batch 조회 후 inject.
 
     #2120 AC2: online 키 배치조회(MGET 1회) → 있으면 last_seen_at override → computed_field online.
+
+    story #2751(설계②) — 이 함수는 오직 에이전트 리스트에만 호출된다(call site 확認, 아래
+    `list_team_members` 참고) — `verified` 배치 주입을 여기 같이 얹어도 human 응답에 새
+    분기를 안 만든다.
     """
     ids = {m.active_story_id for m in members if m.active_story_id}
     stories: dict[uuid.UUID, Story] = {}
@@ -69,6 +73,9 @@ async def _inject_active_stories(
     from app.services import presence_online
     online_map = await presence_online.get_online_map([m.id for m in members])
 
+    from app.services.agent_verify import get_verified_map
+    verified_map = await get_verified_map(session, [m.id for m in members])
+
     out = []
     for m in members:
         resp = TeamMemberResponse.model_validate(m)
@@ -78,6 +85,7 @@ async def _inject_active_stories(
             resp = resp.model_copy(update={
                 "active_story": ActiveStorySummary(id=s.id, title=s.title, status=s.status)
             })
+        resp = resp.model_copy(update={"verified": verified_map.get(m.id)})
         out.append(resp)
     return out
 

--- a/backend/app/schemas/team_member.py
+++ b/backend/app/schemas/team_member.py
@@ -90,6 +90,11 @@ class TeamMemberResponse(BaseModel):
     agent_status: str | None = None
     # S2-4: active_story 요약 — router에서 inject
     active_story: ActiveStorySummary | None = None
+    # story #2751(설계②) — 워크포스 목록 "연결 안 됨" CTA용. type='agent'에서만 의미 있다
+    # (router `_inject_active_stories()`가 배치 주입 — human 행에도 False가 실릴 수 있으나
+    # FE는 type='agent'에서만 이 필드를 읽는다, 소비 규약). agent_ids 목록에 없거나(빈
+    # 목록 등) 함수가 아직 안 도는 단건 경로에서만 None.
+    verified: bool | None = None
 
     # S2-3: computed presence_status — 조회 시점 실시간 계산
     @computed_field

--- a/backend/app/services/agent_verify.py
+++ b/backend/app/services/agent_verify.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import desc, select
+from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.agent_gateway import AgentEventCursor, AgentGatewaySession
@@ -219,3 +219,48 @@ async def get_verification_state(
         verify_seq is not None and acked_seq is not None and acked_seq >= verify_seq
     )
     return {"verify_seq": verify_seq, "acked_seq": acked_seq, "verified": verified, "rail": rail}
+
+
+async def get_verified_map(db: AsyncSession, agent_ids: list[uuid.UUID]) -> dict[uuid.UUID, bool]:
+    """story #2751(설계②, PO 판정 2026-08-18) — 워크포스 목록 "연결 안 됨" CTA용 배치 조회.
+
+    `get_verification_state()`와 **같은 정의**(``acked_seq >= verify_seq``, stdio 레일) —
+    두 번째 판정 기준을 새로 만들지 않는다. 다만 목록은 에이전트 수에 비례해 N번 호출하면
+    안 되므로(fan-out 금지, PO 확定 — `_inject_active_stories()`의 `Story.id.in_()` 배치와
+    동형 패턴) GROUP BY로 agent_ids 전체를 한 번에 집계한다(상수 쿼리 2회 — agent 수 무관).
+    요청한 agent_ids 전원에 대해 키가 채워진다(verify 자체를 한 번도 안 한 이탈자도
+    False — 그게 이 CTA가 잡으려는 정확히 그 집단이다).
+
+    ⚠️scope: stdio 전용(`acked_seq >= verify_seq`는 durable — 한 번 참이면 영구 유지). http
+    transport는 heartbeat freshness(`_has_fresh_heartbeat`)가 유일한 신호인데 그건 "현재
+    도달 가능"이지 "한 번이라도 연결 완료"의 durable 기록이 아니다 — http 에이전트의 durable
+    verified 신호는 신규 컬럼 없이는 못 만들어 이번 스코프 밖. 지금은 실제로 정상 연결된
+    http 에이전트가 이 map에서 False로 나올 수 있다(false positive 방향 — "이미 괜찮은데
+    CTA가 뜬다"는 눈에 띄지만 안전한 실패 모드, 반대(진짜 이탈자를 숨김)보다 낫다)."""
+    if not agent_ids:
+        return {}
+
+    verify_seq_rows = (await db.execute(
+        select(Event.recipient_id, func.max(Event.recipient_seq)).where(
+            Event.recipient_id.in_(agent_ids),
+            Event.event_type == VERIFY_EVENT_TYPE,
+            Event.recipient_seq.isnot(None),
+        ).group_by(Event.recipient_id)
+    )).all()
+    verify_seq_map = {row[0]: row[1] for row in verify_seq_rows}
+
+    acked_seq_rows = (await db.execute(
+        select(AgentEventCursor.agent_id, AgentEventCursor.acked_seq).where(
+            AgentEventCursor.agent_id.in_(agent_ids)
+        )
+    )).all()
+    acked_seq_map = {row[0]: row[1] for row in acked_seq_rows}
+
+    return {
+        agent_id: (
+            agent_id in verify_seq_map
+            and agent_id in acked_seq_map
+            and acked_seq_map[agent_id] >= verify_seq_map[agent_id]
+        )
+        for agent_id in agent_ids
+    }

--- a/backend/tests/test_2751_agent_verified_map_realdb.py
+++ b/backend/tests/test_2751_agent_verified_map_realdb.py
@@ -1,0 +1,219 @@
+"""story #2751(설계②, PO 판정 2026-08-18) realdb 검증 — 워크포스 목록 "연결 안 됨" CTA용
+배치 verified 조회(`agent_verify.get_verified_map`)가 `get_verification_state()`와 같은
+정의(acked_seq >= verify_seq)로, 에이전트 수와 무관한 상수 쿼리(GROUP BY 배치)로 맞는
+값을 내는지 실PG로 확認. 로컬 PG 미설정 시 skip(CI 관례 동일)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2751", slug=f"org2751-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id):
+    from app.models.member import AgentProjectProfile, Member
+    from app.models.project_access import ProjectAccess
+
+    member_id = uuid.uuid4()
+    session.add(Member(id=member_id, org_id=org_id, type="agent", name="agent"))
+    await session.commit()
+    session.add(AgentProjectProfile(id=uuid.uuid4(), member_id=member_id, project_id=project_id))
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, member_id=member_id, permission="granted",
+    ))
+    await session.commit()
+    return member_id
+
+
+async def _ack(session, agent_id, seq: int) -> None:
+    from app.models.agent_gateway import AgentEventCursor
+
+    session.add(AgentEventCursor(agent_id=agent_id, acked_seq=seq))
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_never_attempted_verification_returns_false():
+    """이탈자(위저드에서 runtime은 골랐지만 verify 자체를 한 번도 시도 안 함) — CTA가
+    잡아야 할 정확히 그 케이스, False로 나와야 한다(map에서 빠지지 않고 키 자체가 있음)."""
+    from app.services.agent_verify import get_verified_map
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            result = await get_verified_map(s, [agent_id])
+
+            assert result == {agent_id: False}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_verify_sent_but_never_acked_returns_false():
+    from app.services.agent_verify import get_verified_map, start_verification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            await start_verification(s, agent_id=agent_id, org_id=org_id, project_id=project_id)
+            await s.commit()
+
+            result = await get_verified_map(s, [agent_id])
+
+            assert result == {agent_id: False}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_verify_acked_at_or_above_seq_returns_true():
+    from app.services.agent_verify import get_verified_map, start_verification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            seq = await start_verification(s, agent_id=agent_id, org_id=org_id, project_id=project_id)
+            await s.commit()
+            await _ack(s, agent_id, seq)
+
+            result = await get_verified_map(s, [agent_id])
+
+            assert result == {agent_id: True}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_ack_below_seq_returns_false():
+    """acked_seq가 있어도 최신 verify_seq보다 낮으면(재시도로 새 seq가 발급됐는데 아직
+    그 새 요청은 못 ack) 미완주로 판정해야 한다."""
+    from app.services.agent_verify import get_verified_map, start_verification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            first_seq = await start_verification(s, agent_id=agent_id, org_id=org_id, project_id=project_id)
+            await s.commit()
+            await _ack(s, agent_id, first_seq)
+            # 재시도 — 새 verify 이벤트로 seq가 올라감(아직 ack 안 됨).
+            await start_verification(s, agent_id=agent_id, org_id=org_id, project_id=project_id)
+            await s.commit()
+
+            result = await get_verified_map(s, [agent_id])
+
+            assert result == {agent_id: False}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_batch_query_handles_multiple_agents_with_mixed_states_in_constant_queries():
+    """N=3 에이전트(각기 다른 상태) — 쿼리 수가 에이전트 수에 비례하지 않는지(fan-out 금지)
+    실측. `session.execute` 호출 횟수를 세어 2회(verify_seq 배치·acked_seq 배치)로 고정임을
+    직접 증명한다(PO가 명시적으로 fan-out 금지를 못박은 조건 — 문서 주장이 아니라 계측)."""
+    from unittest.mock import AsyncMock
+
+    from app.services.agent_verify import get_verified_map, start_verification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            never_verified = await _seed_agent(s, org_id, project_id)
+            fully_verified = await _seed_agent(s, org_id, project_id)
+            seq = await start_verification(s, agent_id=fully_verified, org_id=org_id, project_id=project_id)
+            await s.commit()
+            await _ack(s, fully_verified, seq)
+            sent_not_acked = await _seed_agent(s, org_id, project_id)
+            await start_verification(s, agent_id=sent_not_acked, org_id=org_id, project_id=project_id)
+            await s.commit()
+
+            original_execute = s.execute
+            call_count = {"n": 0}
+
+            async def _counting_execute(*args, **kwargs):
+                call_count["n"] += 1
+                return await original_execute(*args, **kwargs)
+
+            s.execute = AsyncMock(side_effect=_counting_execute)
+
+            result = await get_verified_map(s, [never_verified, fully_verified, sent_not_acked])
+
+            assert call_count["n"] == 2  # 에이전트 수(3)와 무관 — 상수 쿼리.
+            assert result == {
+                never_verified: False,
+                fully_verified: True,
+                sent_not_acked: False,
+            }
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_empty_agent_ids_returns_empty_dict_without_query():
+    """빈 목록이면 쿼리 자체를 안 한다(에이전트 0명인 org 등 edge case)."""
+    from app.services.agent_verify import get_verified_map
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            result = await get_verified_map(s, [])
+            assert result == {}
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -121,6 +121,11 @@ async def test_list_team_members_include_inactive_true_omits_is_active_filter_or
         mock_repo = MagicMock()
         mock_repo.list = AsyncMock(return_value=[_mock_member(type_="agent"), _mock_member(type_="agent", is_active=False)])
         app.dependency_overrides[_get_repo_read] = lambda: mock_repo
+        # story #2751 — _inject_active_stories()가 이제 get_verified_map() 배치 조회도
+        # 하므로(session.execute 재사용) 빈 결과로 명시(검증 대상 밖 — 무관 회귀 방지).
+        _verify_result = MagicMock()
+        _verify_result.all.return_value = []
+        session.execute = AsyncMock(return_value=_verify_result)
 
         async with client as c:
             resp = await c.get("/api/v2/team-members?type=agent&include_inactive=true")
@@ -145,6 +150,9 @@ async def test_list_team_members_include_inactive_omitted_preserves_default_acti
         mock_repo = MagicMock()
         mock_repo.list = AsyncMock(return_value=[_mock_member(type_="agent")])
         app.dependency_overrides[_get_repo_read] = lambda: mock_repo
+        _verify_result = MagicMock()
+        _verify_result.all.return_value = []
+        session.execute = AsyncMock(return_value=_verify_result)
 
         async with client as c:
             resp = await c.get("/api/v2/team-members?type=agent")
@@ -170,6 +178,9 @@ async def test_list_team_members_typo_param_silently_ignored_confirms_root_cause
         mock_repo = MagicMock()
         mock_repo.list = AsyncMock(return_value=[_mock_member(type_="agent")])
         app.dependency_overrides[_get_repo_read] = lambda: mock_repo
+        _verify_result = MagicMock()
+        _verify_result.all.return_value = []
+        session.execute = AsyncMock(return_value=_verify_result)
 
         async with client as c:
             resp = await c.get("/api/v2/team-members?type=agent&include_inactivee=true")  # 오타
@@ -191,6 +202,9 @@ async def test_list_team_members_include_inactive_true_omits_is_active_filter_pr
         mock_repo = MagicMock()
         mock_repo.list = AsyncMock(return_value=[_mock_member(), _mock_member(is_active=False)])
         app.dependency_overrides[_get_repo_read] = lambda: mock_repo
+        _verify_result = MagicMock()
+        _verify_result.all.return_value = []
+        session.execute = AsyncMock(return_value=_verify_result)
 
         with patch("app.routers.team_members.has_project_access", new=AsyncMock(return_value=True)):
             async with client as c:


### PR DESCRIPTION
## Summary
story #2751 설계② — PO 확定(2026-08-18) 정의: 「연결 안 됨」 = `agent_verify.py`의 `verified`(stdio ack 신호, story #2467 「10초 신호」와 동일 SoT) 배치 조회. `runtime_type IS NULL` 프록시 대신 채택한 이유: 그 false negative가 정확히 이 CTA의 타깃(runtime은 골랐지만 연결까지 못 간 이탈자)과 겹쳐 가장 필요한 사람에게 CTA가 안 보이는 역설이 됨.

- `agent_verify.get_verified_map()` 신설 — `verify_seq`/`acked_seq`를 `GROUP BY`로 배치 집계(에이전트 수 무관 상수 쿼리 2회) — `_inject_active_stories()`의 `Story.id.in_()` 배치와 동형 패턴(fan-out 금지, PO 확定 준수). 요청한 agent_ids 전원에 키가 채워짐(verify를 한 번도 안 한 이탈자도 `False`).
- http transport는 durable verified 신호가 없어(heartbeat freshness만 존재) 이번 스코프 밖 — false positive(정상 연결된 http 에이전트가 CTA 뜸) 방향만 남김(진짜 이탈자를 숨기는 반대 방향보다 안전한 실패 모드).
- `TeamMemberResponse.verified` 필드 추가(router 배치 주입, DB 컬럼 아님).
- 워크포스 목록: `verified === false` 행에 "연결 안 됨" 배지 + "연결 설정 보기" 링크(설계①의 상시 연결 설정 섹션으로 연결).
- 기존 team_members 테스트 4건 MagicMock 세션 회귀 수정(신규 `session.execute()` 배치 콜을 몰라 죽던 것 — 빈 결과 명시로 수정).

## Test plan
- [x] 신규 realdb 테스트 6건 — 이탈자(0/미시도)·미ack·재시도-미완주·성공·fan-out 금지(execute 호출횟수 계측으로 직접 증명)·빈 입력
- [x] 기존 `test_team_members.py` 31건 무회귀
- [x] `tsc --noEmit`/`eslint` clean(터치 FE 파일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)