### PR TITLE
[SID:2766] 채팅 우측 ReadingPanel(레인 A) — docs 임베드·첨부를 모달 대신 패널로

### DIFF
--- a/apps/web/src/components/chat/attachment-file.tsx
+++ b/apps/web/src/components/chat/attachment-file.tsx
@@ -17,14 +17,23 @@ interface AttachmentFileProps {
   storyId?: string;
   label: string;
   Icon: LucideIcon;
+  /** story #2766(레인 A) — 채팅 호출부가 물려주면 클릭 시 새 탭 대신 ReadingPanel을 연다
+   * (서명 URL 자체는 패널이 직접 뜬다 — 여기선 target 정보만 전달). 생략하면(undefined,
+   * docs/kanban 등 채팅 밖 기존 호출부) 기존 window.open 다운로드 그대로 — 회귀 없음. */
+  onOpenPanel?: (target: { storedUrl: string; conversationId?: string; storyId?: string; label: string; contentType?: string | null }) => void;
+  contentType?: string | null;
 }
 
-export function AttachmentFile({ storedUrl, conversationId, storyId, label, Icon }: AttachmentFileProps) {
+export function AttachmentFile({ storedUrl, conversationId, storyId, label, Icon, onOpenPanel, contentType }: AttachmentFileProps) {
   const t = useTranslations('chats');
   const { addToast } = useToast();
   const [loading, setLoading] = useState(false);
 
   const open = useCallback(async () => {
+    if (onOpenPanel) {
+      onOpenPanel({ storedUrl, conversationId, storyId, label, contentType });
+      return;
+    }
     if (loading) return;
     setLoading(true);
     try {
@@ -48,7 +57,7 @@ export function AttachmentFile({ storedUrl, conversationId, storyId, label, Icon
     } finally {
       setLoading(false);
     }
-  }, [storedUrl, conversationId, storyId, loading, addToast, t]);
+  }, [storedUrl, conversationId, storyId, label, contentType, loading, addToast, t, onOpenPanel]);
 
   return (
     <button

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -16,6 +16,7 @@ import { AttachmentImage } from './attachment-image';
 import { AttachmentMedia } from './attachment-media';
 import { AttachmentFile } from './attachment-file';
 import { ImageLightbox, type LightboxItem } from './image-lightbox';
+import type { ReadingPanelTarget } from './reading-panel';
 import { MessageContextMenu, type CiteAction } from './message-context-menu';
 import { SenderProfilePopover } from './sender-profile-popover';
 import { PresenceDot, WORKING_RING_CLASS, type PresenceStatus } from './presence-dot';
@@ -65,6 +66,10 @@ interface ChatBubbleProps {
   /** story #2637 — chat-view.tsx가 대화당 1회 배치조회한 event_definitions 카탈로그(entityStatusByKey와
    * 동일 패턴). 생략하면(undefined) 이벤트 메시지도 BE 제네릭 폴백 텍스트로 안전하게 그려진다. */
   eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
+  /** story #2766(레인 A) — ChatView가 물려주면 doc 임베드 미리보기·비-이미지 첨부 클릭이
+   * 중앙 모달/새 탭 대신 우측 ReadingPanel을 연다. 생략하면(undefined, ThreadPanel 등 아직
+   * 안 물려주는 호출부) 기존 동작(모달·window.open) 그대로 — 회귀 없음. */
+  onOpenReadingPanel?: (target: ReadingPanelTarget) => void;
 }
 
 interface ContextMenuState {
@@ -188,9 +193,10 @@ function CopyableCode({ raw, inline, className }: { raw: string; inline: boolean
   );
 }
 
-function ChatMarkdown({ content, isMine, references, entityStatusByKey }: {
+function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenReadingPanel }: {
   content: string; isMine: boolean; references: ChatMessage['references'];
   entityStatusByKey?: Record<string, EntityStatusFetchState>;
+  onOpenReadingPanel?: (target: ReadingPanelTarget) => void;
 }) {
   const text = isMine ? 'text-primary-foreground' : 'text-foreground';
   const muted = isMine ? 'text-primary-foreground/70' : 'text-muted-foreground';
@@ -220,7 +226,11 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey }: {
         // 있어 첫 자식만 읽으면 라벨이 잘린다. 전 자식을 이어붙인다(hastNodeText가
         // 재귀로 하듯 여기도 동일 패턴).
         const label = (link!.children ?? []).map(hastNodeText).join('') || m[2]!;
-        return <EmbedCard entity_type={m[1]!} entity_id={m[2]!} title={label} status={status} />;
+        const openReadingPanel = onOpenReadingPanel
+          ? (entityType: string, entityId: string, t: string | null, s: string | null, h: string | null) =>
+              onOpenReadingPanel({ kind: 'doc', entityType, entityId, title: t, status: s, href: h })
+          : undefined;
+        return <EmbedCard entity_type={m[1]!} entity_id={m[2]!} title={label} status={status} onOpenReadingPanel={openReadingPanel} />;
       }
       return <p className={`mb-1.5 [overflow-wrap:anywhere] text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>;
     },
@@ -290,7 +300,7 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey }: {
       }
       return <a href={href} target="_blank" rel="noopener noreferrer" className={`underline underline-offset-2 ${text}`}>{children}</a>;
     },
-  }), [text, muted, codeBg, border, isMine, references, entityStatusByKey]);
+  }), [text, muted, codeBg, border, isMine, references, entityStatusByKey, onOpenReadingPanel]);
 
   if (!hasMarkdown && !hasMention) {
     return (
@@ -320,7 +330,7 @@ const LONG_PRESS_MS = 500;
 export function ChatBubble({
   message, isMine, isGrouped = false, onOpenThread, onDelete, onBlockUser, presenceStatus, isWorking = false,
   highlight = false, projectId, isCiteAnchor = false, isCiteInRange = false, citeAction, entityStatusByKey,
-  hitlAnswer = null, onRespondHitl, eventDefinitionsByKey,
+  hitlAnswer = null, onRespondHitl, eventDefinitionsByKey, onOpenReadingPanel,
 }: ChatBubbleProps) {
   const t = useTranslations('chats');
   const isAgent = message.sender_type === 'agent';
@@ -561,7 +571,7 @@ export function ChatBubble({
                 ? 'rounded-tr-sm bg-primary text-primary-foreground'
                 : 'rounded-tl-sm bg-muted text-foreground'
             }`}>
-              <ChatMarkdown content={displayContent} isMine={isMine} references={message.references} entityStatusByKey={entityStatusByKey} />
+              <ChatMarkdown content={displayContent} isMine={isMine} references={message.references} entityStatusByKey={entityStatusByKey} onOpenReadingPanel={onOpenReadingPanel} />
             </div>
           )}
 
@@ -639,6 +649,12 @@ export function ChatBubble({
                     conversationId={message.memo_id}
                     label={label}
                     Icon={getFileIcon(att.content_type)}
+                    contentType={att.content_type}
+                    onOpenPanel={
+                      onOpenReadingPanel
+                        ? (t) => onOpenReadingPanel({ kind: 'attachment', ...t })
+                        : undefined
+                    }
                   />
                 );
               })}

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -10,6 +10,7 @@ import { CommandHintNotice, type BlockedHint } from './command-hint-notice';
 import { ReferenceDropNotice, parseDroppedReferences, type DroppedReference } from './reference-drop-notice';
 import { ChatInput, type CommandTarget } from './chat-input';
 import { ThreadPanel } from './thread-panel';
+import { ReadingPanel, type ReadingPanelTarget } from './reading-panel';
 import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeToMessage, useChatSse, type SseWorkingPayload } from '@/hooks/use-chat-sse';
@@ -128,8 +129,17 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   // activeThread 열림 여부를 ref로 추적 — popstate 핸들러 stale closure 방지
   const activeThreadRef = useRef(false);
 
+  // story #2766(레인 A) — ReadingPanel도 우측 패널이라 스레드와 동일 슬롯을 공유한다(동시
+  // 2패널 레이아웃은 인계 doc에 없는 새 영역이라 짓지 않음 — 열면 서로 배타적으로 닫는다).
+  const [activeReadingPanel, setActiveReadingPanel] = useState<ReadingPanelTarget | null>(null);
+  // activeThreadRef와 동일 이유(popstate stale closure 방지) — 모바일 뒤로가기 제스처가
+  // ThreadPanel과 똑같이 이 패널도 먼저 닫아야 한다(페이지 이탈 아님).
+  const activeReadingPanelRef = useRef(false);
+
   // 스레드 열기: 현재 URL 유지한 채 history entry 추가
   const openThread = useCallback((message: ChatMessage) => {
+    activeReadingPanelRef.current = false;
+    setActiveReadingPanel(null);
     setActiveThread(message);
     activeThreadRef.current = true;
     const url = window.location.pathname + window.location.search;
@@ -140,6 +150,20 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   const closeThread = useCallback(() => {
     activeThreadRef.current = false;
     setActiveThread(null);
+  }, []);
+
+  const openReadingPanel = useCallback((target: ReadingPanelTarget) => {
+    activeThreadRef.current = false;
+    setActiveThread(null);
+    activeReadingPanelRef.current = true;
+    setActiveReadingPanel(target);
+    const url = window.location.pathname + window.location.search;
+    window.history.pushState({ _sprintableReadingPanel: true }, '', url);
+  }, []);
+
+  const closeReadingPanel = useCallback(() => {
+    activeReadingPanelRef.current = false;
+    setActiveReadingPanel(null);
   }, []);
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -339,13 +363,17 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     onReconnect: handleReconnect,
   });
 
-  // fix: popstate — 스레드 열린 상태에서만 가로채기 (Next.js 네비게이션 비간섭)
+  // fix: popstate — 스레드/리딩패널 열린 상태에서만 가로채기 (Next.js 네비게이션 비간섭)
   useEffect(() => {
     const handlePopState = (e: PopStateEvent) => {
-      if (!activeThreadRef.current) return; // 스레드 없으면 Next.js가 처리
-      // 스레드 닫기 + 현재 URL 재push → 실제 뒤로가기 취소, 채팅 화면 유지
+      // story #2766(레인 A) — 모바일 뒤로가기 제스처가 ReadingPanel도 ThreadPanel과 동일하게
+      // "페이지 이탈"이 아니라 "패널만 닫기"로 소비돼야 한다(전체화면 드로어 규약).
+      if (!activeThreadRef.current && !activeReadingPanelRef.current) return; // 둘 다 없으면 Next.js가 처리
+      // 패널 닫기 + 현재 URL 재push → 실제 뒤로가기 취소, 채팅 화면 유지
       activeThreadRef.current = false;
       setActiveThread(null);
+      activeReadingPanelRef.current = false;
+      setActiveReadingPanel(null);
       window.history.pushState(e.state ?? null, '', window.location.pathname + window.location.search);
     };
     window.addEventListener('popstate', handlePopState);
@@ -709,6 +737,11 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
 
   // CB-S9: 모바일에서 스레드 뷰로 전환 중인지 (< lg)
   const isMobileThreadView = activeThread !== null;
+  // story #2766(레인 A) — ReadingPanel도 같은 "메인 채팅 숨김" 규칙을 탄다(모바일 전체화면
+  // 드로어). ReadingPanel 자신이 이미 자체 닫기(X) 버튼을 갖고 있어(FileViewer/EntityPreviewModal
+  // 헤더) ThreadPanel처럼 별도 상단 "뒤로" 바를 새로 만들지 않는다.
+  const isMobileReadingView = activeReadingPanel !== null;
+  const isMobileRightPanelView = isMobileThreadView || isMobileReadingView;
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -731,8 +764,8 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
       {/* Body: main chat + optional thread panel (side-by-side on desktop) */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
 
-        {/* Main chat — AC8: 모바일에서 스레드 뷰 활성 시 hidden */}
-        <div className={`flex min-w-0 flex-1 flex-col overflow-hidden ${isMobileThreadView ? 'hidden lg:flex' : 'flex'}`}>
+        {/* Main chat — AC8: 모바일에서 스레드/리딩패널 뷰 활성 시 hidden */}
+        <div className={`flex min-w-0 flex-1 flex-col overflow-hidden ${isMobileRightPanelView ? 'hidden lg:flex' : 'flex'}`}>
           {/* Messages */}
           <div
             ref={scrollRef}
@@ -812,6 +845,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
                             isMine={msg.created_by === currentTeamMemberId}
                             isGrouped={isGrouped}
                             onOpenThread={openThread}
+                            onOpenReadingPanel={openReadingPanel}
                             onDelete={handleDeleteMessage}
                             onBlockUser={
                               msg.created_by !== currentTeamMemberId
@@ -943,6 +977,18 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
               requestedEntityStatusKeysRef={requestedEntityStatusKeysRef}
               setEntityStatusByKey={setEntityStatusByKey}
             />
+          </div>
+        )}
+
+        {/* story #2766(레인 A) §A1 — ReadingPanel: 데스크톱 clamp(480px,40vw,720px) 사이드 /
+            모바일 전체 뷰. ThreadPanel과 같은 슬롯이지만 폭 규격이 다르다(320px 고정이 아님
+            — 문서 가독 기준 폭). */}
+        {activeReadingPanel && (
+          <div
+            className={`flex flex-col overflow-hidden ${isMobileReadingView ? 'flex-1' : 'hidden lg:flex'}`}
+            style={isMobileReadingView ? undefined : { width: 'clamp(480px, 40vw, 720px)', flexShrink: 0 }}
+          >
+            <ReadingPanel target={activeReadingPanel} onClose={closeReadingPanel} />
           </div>
         )}
       </div>

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -312,6 +312,7 @@ export function EntityPreviewModal({
   status,
   href,
   onClose,
+  embedded = false,
 }: {
   entityType: string;
   entityId: string;
@@ -319,6 +320,11 @@ export function EntityPreviewModal({
   status: string | null;
   href: string | null;
   onClose: () => void;
+  /** story #2766(레인 A) — Dialog(중앙 모달, base DialogContent의 sm:max-w-sm 상속)가 아니라
+   * ReadingPanel(우측 패널) 안에 그대로 얹힐 때 true. fetch·헤더·본문·풋터 로직은 완전히
+   * 동일 재사용(모달 vs 패널 전환 시 별도 재구현 0) — 바뀌는 건 바깥 래퍼(Dialog vs 패널
+   * 자체 크기의 plain div)뿐이다. */
+  embedded?: boolean;
 }) {
   // story #2302 — hypothesis·evidence는 fetch 자체를 안 한다(항상 고정 ③, ENTITY_API에 항목
   // 없음) — 예전 코드는 'task'만 예외 취급해 loading을 false로 시작했는데, ENTITY_API에 없는
@@ -526,68 +532,100 @@ export function EntityPreviewModal({
     linkKind = resolvedHref ? 'own' : null;
   }
 
+  // story #2766(레인 A) — Dialog(모달)와 embedded(패널) 두 래퍼가 헤더/본문/풋터는 100%
+  // 동일 재사용한다. embedded일 땐 DialogTitle(base-ui Dialog.Title — Dialog.Root 컨텍스트
+  // 밖에서 쓰면 안전하지 않다)을 평범한 span으로 바꾸는 것만 다르다.
+  const header = (TitleTag: 'dialog-title' | 'span') => (
+    <div className="flex flex-shrink-0 items-start gap-3 border-b border-border px-6 pt-5 pb-3">
+      <div className={`flex min-w-0 flex-1 items-center gap-2 rounded-md border px-3 py-1.5 text-sm ${colorClass}`}>
+        <EntityGlyph Icon={resolveEntityIcon(entityType)} label={label} />
+        {TitleTag === 'dialog-title' ? (
+          <DialogTitle className="truncate text-sm font-semibold">{label}</DialogTitle>
+        ) : (
+          <span className="truncate text-sm font-semibold">{label}</span>
+        )}
+        {resolvedStatusLabel ? (
+          <span className="ml-auto shrink-0 rounded bg-black/10 px-1.5 py-0.5 text-xs dark:bg-white/10">{resolvedStatusLabel}</span>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="mt-0.5 shrink-0 text-muted-foreground hover:text-foreground"
+        aria-label="닫기"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+
+  const body = (
+    <div className="flex-1 overflow-y-auto px-6 py-4">
+      {loading ? (
+        <div className="flex items-center justify-center gap-2 py-8 text-xs text-muted-foreground">
+          <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          불러오는 중…
+        </div>
+      ) : notFound ? (
+        <p className="py-4 text-xs text-muted-foreground">대상을 찾을 수 없습니다.</p>
+      ) : detail && RICH_PREVIEW_TYPES.has(entityType) ? (
+        <EntityDetail entityType={entityType} entityId={entityId} detail={detail} />
+      ) : (
+        <p className="py-4 text-xs text-muted-foreground">이 엔티티는 별도 미리보기가 없습니다.</p>
+      )}
+    </div>
+  );
+
+  // Footer — story #2302 AC4: ㉠/㉡-b는 회색·기본커서로 "죽는 건 링크뿐"(카드 전체 안 죽음).
+  // 색은 회색 하나(노랑 금지 — 위 GRAY_STATE_COLOR 주석 참고), 구별은 문구로.
+  const footer = !loading && (
+    <div className="flex-shrink-0 border-t border-border px-6 py-3">
+      {notFound ? (
+        <span className="flex cursor-default items-center gap-1.5 text-sm text-muted-foreground">대상이 없습니다</span>
+      ) : resolvedHref ? (
+        <Link
+          href={resolvedHref}
+          onClick={onClose}
+          className="flex items-center gap-1.5 text-sm text-primary hover:underline"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+          {linkKind === 'via-parent' ? '담긴 곳으로 갑니다' : '전체 보기'}
+        </Link>
+      ) : (
+        <span className="flex cursor-default items-center gap-1.5 text-sm text-muted-foreground">열 수 있는 화면이 없습니다</span>
+      )}
+    </div>
+  );
+
+  if (embedded) {
+    return (
+      <div className="flex h-full flex-col overflow-hidden bg-background">
+        {header('span')}
+        {body}
+        {footer}
+      </div>
+    );
+  }
+
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
       <DialogContent className="flex max-h-[80vh] max-w-3xl flex-col overflow-hidden rounded-xl p-0" showCloseButton={false}>
-        {/* Header */}
-        <div className="flex-shrink-0 flex items-start gap-3 px-6 pt-5 pb-3 border-b border-border">
-          <div className={`flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm ${colorClass} flex-1 min-w-0`}>
-            <EntityGlyph Icon={resolveEntityIcon(entityType)} label={label} />
-            <DialogTitle className="font-semibold truncate text-sm">{label}</DialogTitle>
-            {resolvedStatusLabel ? (
-              <span className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{resolvedStatusLabel}</span>
-            ) : null}
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="shrink-0 text-muted-foreground hover:text-foreground mt-0.5"
-            aria-label="닫기"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-        {/* Scrollable body */}
-        <div className="flex-1 overflow-y-auto px-6 py-4">
-          {loading ? (
-            <div className="flex items-center gap-2 text-xs text-muted-foreground py-8 justify-center">
-              <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              불러오는 중…
-            </div>
-          ) : notFound ? (
-            <p className="text-xs text-muted-foreground py-4">대상을 찾을 수 없습니다.</p>
-          ) : detail && RICH_PREVIEW_TYPES.has(entityType) ? (
-            <EntityDetail entityType={entityType} entityId={entityId} detail={detail} />
-          ) : (
-            <p className="text-xs text-muted-foreground py-4">이 엔티티는 별도 미리보기가 없습니다.</p>
-          )}
-        </div>
-        {/* Footer — story #2302 AC4: ㉠/㉡-b는 회색·기본커서로 "죽는 건 링크뿐"(카드 전체 안
-            죽음). 색은 회색 하나(노랑 금지 — 위 GRAY_STATE_COLOR 주석 참고), 구별은 문구로. */}
-        {!loading && (
-          <div className="flex-shrink-0 px-6 py-3 border-t border-border">
-            {notFound ? (
-              <span className="flex cursor-default items-center gap-1.5 text-sm text-muted-foreground">대상이 없습니다</span>
-            ) : resolvedHref ? (
-              <Link
-                href={resolvedHref}
-                onClick={onClose}
-                className="flex items-center gap-1.5 text-sm text-primary hover:underline"
-              >
-                <ExternalLink className="h-3.5 w-3.5" />
-                {linkKind === 'via-parent' ? '담긴 곳으로 갑니다' : '전체 보기'}
-              </Link>
-            ) : (
-              <span className="flex cursor-default items-center gap-1.5 text-sm text-muted-foreground">열 수 있는 화면이 없습니다</span>
-            )}
-          </div>
-        )}
+        {header('dialog-title')}
+        {body}
+        {footer}
       </DialogContent>
     </Dialog>
   );
 }
 
-export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardData) {
+export function EmbedCard({
+  entity_type, entity_id, title, status, onOpenReadingPanel,
+}: EmbedCardData & {
+  /** story #2766(레인 A) — 채팅(ChatView)이 물려주면 doc 미리보기 아이콘 클릭이 중앙 모달
+   * 대신 우측 ReadingPanel을 연다. 생략하면(undefined, 채팅 밖의 기존 호출부들) 기존
+   * Dialog 모달 그대로 — 회귀 없음. */
+  onOpenReadingPanel?: (entityType: string, entityId: string, title: string | null, status: string | null, href: string | null) => void;
+}) {
   const [showModal, setShowModal] = useState(false);
   const [navigating, setNavigating] = useState(false);
   const router = useRouter();
@@ -657,7 +695,11 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
           </button>
           <button
             type="button"
-            onClick={(e) => { e.stopPropagation(); setShowModal(true); }}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (onOpenReadingPanel) onOpenReadingPanel(entity_type, entity_id, title, status, href);
+              else setShowModal(true);
+            }}
             className="shrink-0 rounded p-1 opacity-70 transition-opacity hover:bg-black/10 hover:opacity-100 dark:hover:bg-white/10"
             aria-label="미리보기"
             title="미리보기"
@@ -665,7 +707,7 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
             <Eye className="size-3.5" />
           </button>
         </div>
-        {showModal && (
+        {!onOpenReadingPanel && showModal && (
           <EntityPreviewModal
             entityType={entity_type}
             entityId={entity_id}

--- a/apps/web/src/components/chat/file-viewer.tsx
+++ b/apps/web/src/components/chat/file-viewer.tsx
@@ -158,7 +158,7 @@ export function FileViewer({ target, onClose }: { target: AttachmentTarget; onCl
         </button>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto">
+      <div className="focus-inset min-h-0 flex-1 overflow-auto">
         {state.kind === 'fetching' && (
           <div className="flex h-full flex-col items-center justify-center gap-2 p-6">
             <div className="h-24 w-full max-w-md animate-pulse rounded-lg bg-muted" />

--- a/apps/web/src/components/chat/file-viewer.tsx
+++ b/apps/web/src/components/chat/file-viewer.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Download, Expand, File, FileCode, FileText, Film, Image as ImageIcon, Music, X, type LucideIcon } from 'lucide-react';
+import { fetchWithAuth } from '@/lib/db/client';
+import { isNativeShell } from '@/lib/native-shell-bridge';
+import { MdBody } from '@/components/chat/embed-card';
+import type { ReadingPanelTarget } from '@/components/chat/reading-panel';
+
+type AttachmentTarget = Extract<ReadingPanelTarget, { kind: 'attachment' }>;
+
+// 인계 doc 0ef7f8ab §A2 — 포맷 라우팅 표 그대로. office는 렌더러가 없다(가짜 렌더 금지).
+type Format = 'image' | 'video' | 'audio' | 'text' | 'html' | 'pdf' | 'office' | 'unknown';
+
+function resolveFormat(contentType: string | null | undefined, label: string): Format {
+  const ct = (contentType ?? '').toLowerCase();
+  const ext = label.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? '';
+  if (ct.startsWith('image/')) return 'image';
+  if (ct.startsWith('video/')) return 'video';
+  if (ct.startsWith('audio/')) return 'audio';
+  if (ct === 'application/pdf' || ext === 'pdf') return 'pdf';
+  if (ct === 'text/html' || ext === 'html' || ext === 'htm') return 'html';
+  if (ct.startsWith('text/') || ct === 'text/markdown' || ['txt', 'md', 'markdown'].includes(ext)) return 'text';
+  if (
+    ['pptx', 'ppt', 'docx', 'doc', 'xlsx', 'xls'].includes(ext) ||
+    ct.includes('officedocument') ||
+    ct.includes('msword') ||
+    ct.includes('ms-excel') ||
+    ct.includes('ms-powerpoint')
+  ) {
+    return 'office';
+  }
+  return 'unknown';
+}
+
+const FORMAT_LABEL: Record<Format, string> = {
+  image: '이미지', video: '동영상', audio: '오디오', text: '텍스트',
+  html: 'HTML', pdf: 'PDF', office: '오피스 문서', unknown: '파일',
+};
+
+function iconFor(format: Format): LucideIcon {
+  switch (format) {
+    case 'image': return ImageIcon;
+    case 'video': return Film;
+    case 'audio': return Music;
+    case 'text': return FileText;
+    case 'html': return FileCode;
+    case 'pdf': return FileText;
+    default: return File;
+  }
+}
+
+type SignState =
+  | { kind: 'fetching' }
+  | { kind: 'denied' }
+  | { kind: 'error'; status: number; message: string }
+  | { kind: 'ready'; url: string };
+
+async function signAttachment(target: AttachmentTarget, disposition: 'inline' | 'attachment'): Promise<SignState> {
+  try {
+    const params = new URLSearchParams({ path: target.storedUrl, disposition });
+    if (target.conversationId) params.set('conversation_id', target.conversationId);
+    else if (target.storyId) params.set('story_id', target.storyId);
+    const res = await fetchWithAuth(`/api/attachments/sign?${params.toString()}`);
+    if (res.status === 403) return { kind: 'denied' };
+    const json = (await res.json().catch(() => null)) as { data?: { url?: string }; error?: { message?: string } } | null;
+    const url = json?.data?.url;
+    if (!res.ok || !url) return { kind: 'error', status: res.status, message: json?.error?.message ?? '알 수 없는 오류' };
+    return { kind: 'ready', url };
+  } catch {
+    return { kind: 'error', status: 0, message: '네트워크 오류' };
+  }
+}
+
+/**
+ * 인계 doc 0ef7f8ab §A1/§A2/§A3 — 헤더(글리프+이름+포맷배지+[⤢ 전체][⬇ 다운로드][✕]) +
+ * 포맷별 인앱 렌더 + 상태 4종. signed URL은 이 컴포넌트가 직접 뜬다(disposition=inline로
+ * 뷰용, attachment로 다운로드용 — 별도 요청, 캐시 없음 — 서명 URL은 단기 만료라 매번 새로
+ * 받는 편이 만료 이슈보다 낫다).
+ */
+export function FileViewer({ target, onClose }: { target: AttachmentTarget; onClose: () => void }) {
+  const format = resolveFormat(target.contentType, target.label);
+  const [state, setState] = useState<SignState>({ kind: 'fetching' });
+  const [downloading, setDownloading] = useState(false);
+  const nativeShell = isNativeShell();
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ kind: 'fetching' });
+    void signAttachment(target, 'inline').then((s) => { if (!cancelled) setState(s); });
+    return () => { cancelled = true; };
+  }, [target]);
+
+  const retry = useCallback(() => {
+    setState({ kind: 'fetching' });
+    void signAttachment(target, 'inline').then(setState);
+  }, [target]);
+
+  const handleDownload = useCallback(async () => {
+    if (nativeShell) return; // §A5 — RN 브리지(레인 B/#2765) 도착 전까지 웹 경로만 실행
+    if (downloading) return;
+    setDownloading(true);
+    try {
+      const s = await signAttachment(target, 'attachment');
+      if (s.kind === 'ready') {
+        const a = document.createElement('a');
+        a.href = s.url;
+        a.download = target.label;
+        a.rel = 'noopener noreferrer';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+      }
+    } finally {
+      setDownloading(false);
+    }
+  }, [target, downloading, nativeShell]);
+
+  const handleOpenFull = useCallback(() => {
+    if (state.kind === 'ready') window.open(state.url, '_blank', 'noopener,noreferrer');
+  }, [state]);
+
+  const Icon = iconFor(format);
+
+  return (
+    <>
+      <div className="flex flex-shrink-0 items-center gap-2 border-b border-border px-4 py-2.5">
+        <Icon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">{target.label}</span>
+        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{FORMAT_LABEL[format]}</span>
+        <button
+          type="button"
+          onClick={handleOpenFull}
+          disabled={state.kind !== 'ready'}
+          className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-40"
+          aria-label="전체 화면으로 열기"
+          title="전체 화면"
+        >
+          <Expand className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleDownload()}
+          disabled={downloading || nativeShell}
+          className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-40"
+          aria-label="다운로드"
+          title={nativeShell ? '앱 다운로드는 준비 중입니다' : '다운로드'}
+        >
+          <Download className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          aria-label="패널 닫기"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        {state.kind === 'fetching' && (
+          <div className="flex h-full flex-col items-center justify-center gap-2 p-6">
+            <div className="h-24 w-full max-w-md animate-pulse rounded-lg bg-muted" />
+            <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+          </div>
+        )}
+
+        {state.kind === 'denied' && (
+          <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+            <p className="text-sm text-foreground">이 첨부를 열람할 권한이 없습니다.</p>
+            <p className="text-xs text-muted-foreground">사유: 대화/스토리 참여자만 열람할 수 있습니다.</p>
+          </div>
+        )}
+
+        {state.kind === 'error' && (
+          <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+            <p className="text-sm text-foreground">불러오지 못했습니다.</p>
+            <p className="w-fit rounded-md bg-destructive-tint px-2 py-1.5 font-mono text-[10.5px] text-destructive">
+              {state.status} {state.message}
+            </p>
+            <button
+              type="button"
+              onClick={retry}
+              className="mt-1 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              다시 시도
+            </button>
+          </div>
+        )}
+
+        {state.kind === 'ready' && <FileViewerBody format={format} url={state.url} label={target.label} />}
+      </div>
+    </>
+  );
+}
+
+function FileViewerBody({ format, url, label }: { format: Format; url: string; label: string }) {
+  switch (format) {
+    case 'image':
+      // eslint-disable-next-line @next/next/no-img-element -- 서명 URL은 원격 도메인이라 next/image 정적 도메인 화이트리스트 밖(기존 lightbox와 동일 제약)
+      return <img src={url} alt={label} className="mx-auto max-h-full max-w-full object-contain p-4" />;
+    case 'video':
+      return (
+        <video controls className="mx-auto max-h-full w-full p-4">
+          <source src={url} />
+        </video>
+      );
+    case 'audio':
+      return (
+        <div className="p-4">
+          <audio controls className="w-full" src={url} />
+        </div>
+      );
+    case 'pdf':
+      return <iframe src={url} title={label} className="h-full w-full border-0" />;
+    case 'html':
+      // 미신뢰 업로드 컨텐츠 미리보기 — allow-scripts 없음(격리, CSP 준하는 최소 권한).
+      return <iframe src={url} title={label} sandbox="allow-popups" className="h-full w-full border-0 bg-white" />;
+    case 'text':
+      // key={url} — url이 바뀌면(다른 첨부로 전환) 컴포넌트를 통째로 새로 마운트해 이전
+      // 내용을 자연히 초기화한다(effect 안에서 수동 setState 리셋 없이 — react-hooks/
+      // set-state-in-effect 규율, [[feedback-detail-page-key-remount-standard]]와 동형).
+      return <TextBody key={url} url={url} />;
+    case 'office':
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+          <FileText className="size-8 text-muted-foreground" aria-hidden />
+          <p className="text-sm text-foreground">미리보기 준비 중입니다.</p>
+          <p className="text-xs text-muted-foreground">오피스 문서(pptx/docx/xlsx)는 아직 인앱 렌더를 지원하지 않습니다. 다운로드해 확인하세요.</p>
+        </div>
+      );
+    default:
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+          <File className="size-8 text-muted-foreground" aria-hidden />
+          <p className="text-sm text-foreground">이 포맷은 인앱 미리보기가 아직 없습니다.</p>
+          <p className="text-xs text-muted-foreground">다운로드해 확인하세요.</p>
+        </div>
+      );
+  }
+}
+
+/** txt/md 둘 다 MdBody(react-markdown)로 — §A2 표 그대로. */
+function TextBody({ url }: { url: string }) {
+  const [content, setContent] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then((r) => (r.ok ? r.text() : Promise.reject(new Error(String(r.status)))))
+      .then((text) => { if (!cancelled) setContent(text); })
+      .catch(() => { if (!cancelled) setFailed(true); });
+    return () => { cancelled = true; };
+  }, [url]);
+
+  if (failed) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+        <p className="text-sm text-foreground">불러오지 못했습니다.</p>
+        <p className="text-xs text-muted-foreground">텍스트 내용을 가져오는 데 실패했습니다.</p>
+      </div>
+    );
+  }
+  if (content === null) {
+    return (
+      <div className="flex flex-col gap-2 p-4">
+        <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
+      </div>
+    );
+  }
+  return (
+    <div className="p-4">
+      <MdBody content={content} />
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/file-viewer.tsx
+++ b/apps/web/src/components/chat/file-viewer.tsx
@@ -176,7 +176,7 @@ export function FileViewer({ target, onClose }: { target: AttachmentTarget; onCl
         {state.kind === 'error' && (
           <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
             <p className="text-sm text-foreground">불러오지 못했습니다.</p>
-            <p className="w-fit rounded-md bg-destructive-tint px-2 py-1.5 font-mono text-[10.5px] text-destructive">
+            <p className="w-fit rounded-md bg-destructive-tint px-2 py-1.5 font-mono text-[10.5px] text-foreground">
               {state.status} {state.message}
             </p>
             <button

--- a/apps/web/src/components/chat/reading-panel.tsx
+++ b/apps/web/src/components/chat/reading-panel.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { EntityPreviewModal } from '@/components/chat/embed-card';
+import { FileViewer } from '@/components/chat/file-viewer';
+
+/**
+ * story #2766(레인 A) — 채팅을 벗어나지 않는 우측 리딩 패널의 대상 2종.
+ * ①doc 임베드 미리보기(EntityPreviewModal embedded 재사용) ②채팅 첨부(FileViewer 신설).
+ */
+export type ReadingPanelTarget =
+  | { kind: 'doc'; entityType: string; entityId: string; title: string | null; status: string | null; href: string | null }
+  | {
+      kind: 'attachment';
+      storedUrl: string;
+      conversationId?: string;
+      storyId?: string;
+      label: string;
+      contentType?: string | null;
+    };
+
+/**
+ * 인계 doc 0ef7f8ab §A1 — thread-panel.tsx 선례(데스크톱 나란히·모바일 전체화면 드로어)를
+ * 그대로 따르되, 폭은 부모(chat-view.tsx)가 clamp(480px,40vw,720px)로 강제한다(⛔base
+ * DialogContent의 sm:max-w-sm 상속 금지 — 애초에 Dialog를 안 쓰므로 상속될 여지가 없다).
+ * 채팅 입력은 이 패널이 열려도 그대로 활성 — ThreadPanel과 달리 이 컴포넌트는 자기 폭 밖의
+ * 레이아웃(모달 아님·오버레이 아님)에 개입하지 않는다.
+ */
+export function ReadingPanel({ target, onClose }: { target: ReadingPanelTarget; onClose: () => void }) {
+  if (target.kind === 'doc') {
+    return (
+      <div className="flex h-full flex-col overflow-hidden border-l border-border bg-background">
+        <EntityPreviewModal
+          entityType={target.entityType}
+          entityId={target.entityId}
+          title={target.title}
+          status={target.status}
+          href={target.href}
+          onClose={onClose}
+          embedded
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden border-l border-border bg-background">
+      <FileViewer target={target} onClose={onClose} />
+    </div>
+  );
+}

--- a/apps/web/src/lib/native-shell-bridge.ts
+++ b/apps/web/src/lib/native-shell-bridge.ts
@@ -14,3 +14,11 @@ declare global {
 export function notifyContentPainted() {
   window.ReactNativeWebView?.postMessage(JSON.stringify({ type: 'content-painted' }));
 }
+
+// story #2766(레인 A) §A5 — 다운로드 버튼 환경 분기의 판별 신호. 레인 B(#2765)가 실제 브릿지
+// 훅(다운로드/외부 열기 postMessage 왕복)을 구현하기 전까지는, 이 판별만으로 "RN 안이면 아직
+// 다운로드 미지원(레인 B 대기)"을 정직 표시하는 데 쓴다 — 서버사이드(SSR)에서 호출하면 항상
+// false(window 없음).
+export function isNativeShell(): boolean {
+  return typeof window !== 'undefined' && Boolean(window.ReactNativeWebView);
+}


### PR DESCRIPTION
## 요약
- 인계 doc `handoff-inapp-viewer-reading-panel-2765-2766`(0ef7f8ab) **레인 A** + 시각 정본 아티팩트 27957896 반영
- 채팅에서 doc 임베드 미리보기가 모바일 폭 고정 모달로 뜨던 것을, 채팅을 벗어나지 않는 우측 ReadingPanel로 이설(⛔ base `DialogContent`의 `sm:max-w-sm` 상속 없음 — Dialog 자체를 안 씀)
- 데스크톱: `clamp(480px, 40vw, 720px)` 사이드 패널(채팅 입력 상시 활성 공존) / 모바일: 전체화면 드로어(뒤로가기 제스처가 페이지 이탈 대신 패널만 닫음 — ThreadPanel과 동형 popstate 배선)
- 첨부 클릭도 새 탭(`window.open`) 대신 같은 패널로 — FileViewer 신설, 포맷 라우팅(img/video/audio 네이티브·txt/md=MdBody·html=sandbox iframe·pdf=네이티브 iframe·office="미리보기 준비 중"+다운로드 정직 fallback)
- 상태 4종(로딩/권한거부/에러+재시도/정상 렌더)
- 회귀 0 설계: `AttachmentFile`/`EmbedCard` 둘 다 새 prop이 optional — 생략하면(docs/kanban/스레드 등 기존 호출부) 기존 동작 그대로

## 스코프
- 메인 채팅 메시지 목록만(ThreadPanel 내부 중첩 ChatBubble은 이번 스토리 범위 밖)
- 레인 B(#2765, RN 브리지 다운로드/외부열기)는 별도 PR — 이 PR은 `isNativeShell()` 판별만 추가, RN 안에서는 다운로드 버튼이 비활성+사유 표시로 정직하게 막힘

## 검증
- `pnpm type-check` / `pnpm lint` / `pnpm build` 전부 clean
- 라이브 픽셀(2테마·패널 폭·포맷별 렌더·office fallback·docs 임베드 패널 전환)은 병합 후 dev 배포 착지 확認 뒤 진행 예정(팀 표준 절차 — PR→develop→dev smoke)

## 게이트
PO AC 리뷰 → 유나 design 리뷰(시안 27957896 대조) → 카디르 QA → 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)