### PR TITLE
[SID:2765] 레인 B·웹 — 다운로드/외부 열기 postMessage 브리지 훅

### DIFF
--- a/apps/web/src/components/chat/file-viewer.tsx
+++ b/apps/web/src/components/chat/file-viewer.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Download, Expand, File, FileCode, FileText, Film, Image as ImageIcon, Music, X, type LucideIcon } from 'lucide-react';
 import { fetchWithAuth } from '@/lib/db/client';
-import { isNativeShell } from '@/lib/native-shell-bridge';
+import { downloadAsset, openExternal } from '@/lib/native-shell-bridge';
 import { MdBody } from '@/components/chat/embed-card';
 import type { ReadingPanelTarget } from '@/components/chat/reading-panel';
 
@@ -82,7 +82,6 @@ export function FileViewer({ target, onClose }: { target: AttachmentTarget; onCl
   const format = resolveFormat(target.contentType, target.label);
   const [state, setState] = useState<SignState>({ kind: 'fetching' });
   const [downloading, setDownloading] = useState(false);
-  const nativeShell = isNativeShell();
 
   useEffect(() => {
     let cancelled = false;
@@ -96,28 +95,22 @@ export function FileViewer({ target, onClose }: { target: AttachmentTarget; onCl
     void signAttachment(target, 'inline').then(setState);
   }, [target]);
 
+  // story #2765(레인 B) — downloadAsset이 환경을 스스로 판별한다(RN 셸=postMessage 브리지
+  // /브라우저=<a download>). 레인 A 시점의 "RN이면 비활성" 특례는 브리지가 실제로 붙었으니
+  // 더 이상 없다 — 항상 실행 가능.
   const handleDownload = useCallback(async () => {
-    if (nativeShell) return; // §A5 — RN 브리지(레인 B/#2765) 도착 전까지 웹 경로만 실행
     if (downloading) return;
     setDownloading(true);
     try {
       const s = await signAttachment(target, 'attachment');
-      if (s.kind === 'ready') {
-        const a = document.createElement('a');
-        a.href = s.url;
-        a.download = target.label;
-        a.rel = 'noopener noreferrer';
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-      }
+      if (s.kind === 'ready') downloadAsset(s.url, target.label);
     } finally {
       setDownloading(false);
     }
-  }, [target, downloading, nativeShell]);
+  }, [target, downloading]);
 
   const handleOpenFull = useCallback(() => {
-    if (state.kind === 'ready') window.open(state.url, '_blank', 'noopener,noreferrer');
+    if (state.kind === 'ready') openExternal(state.url);
   }, [state]);
 
   const Icon = iconFor(format);
@@ -141,10 +134,10 @@ export function FileViewer({ target, onClose }: { target: AttachmentTarget; onCl
         <button
           type="button"
           onClick={() => void handleDownload()}
-          disabled={downloading || nativeShell}
+          disabled={downloading}
           className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-40"
           aria-label="다운로드"
-          title={nativeShell ? '앱 다운로드는 준비 중입니다' : '다운로드'}
+          title="다운로드"
         >
           <Download className="h-4 w-4" />
         </button>

--- a/apps/web/src/lib/native-shell-bridge.ts
+++ b/apps/web/src/lib/native-shell-bridge.ts
@@ -15,10 +15,46 @@ export function notifyContentPainted() {
   window.ReactNativeWebView?.postMessage(JSON.stringify({ type: 'content-painted' }));
 }
 
-// story #2766(레인 A) §A5 — 다운로드 버튼 환경 분기의 판별 신호. 레인 B(#2765)가 실제 브릿지
-// 훅(다운로드/외부 열기 postMessage 왕복)을 구현하기 전까지는, 이 판별만으로 "RN 안이면 아직
-// 다운로드 미지원(레인 B 대기)"을 정직 표시하는 데 쓴다 — 서버사이드(SSR)에서 호출하면 항상
-// false(window 없음).
+// story #2766(레인 A) §A5 — 다운로드 버튼 환경 분기의 판별 신호. 서버사이드(SSR)에서
+// 호출하면 항상 false(window 없음).
 export function isNativeShell(): boolean {
   return typeof window !== 'undefined' && Boolean(window.ReactNativeWebView);
+}
+
+// story #2765(레인 B) §2 — 웹↔셸 postMessage 계약. content-painted와 동일한 명시 스키마
+// 관례(sprintable-mobile App.js:746 onMessage의 type 스위치가 소비). url은 항상
+// disposition=attachment(다운로드) 또는 inline(외부 열기) 서명 URL — 단명이라 호출 직전에
+// 새로 발급한 것만 넘긴다(캐시된 URL 재사용 금지).
+function downloadViaShell(url: string, filename: string) {
+  window.ReactNativeWebView?.postMessage(JSON.stringify({ type: 'download', url, filename }));
+}
+
+function openExternalViaShell(url: string) {
+  window.ReactNativeWebView?.postMessage(JSON.stringify({ type: 'open-external', url }));
+}
+
+/**
+ * 환경 분기 훅(레인 A가 호출) — RN 셸 안이면 postMessage로 위임(레인 B가 실제 저장/공유를
+ * 수행), 일반 브라우저면 기존 `<a download>` 경로 그대로(회귀 0).
+ */
+export function downloadAsset(url: string, filename: string) {
+  if (isNativeShell()) {
+    downloadViaShell(url, filename);
+    return;
+  }
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.rel = 'noopener noreferrer';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+export function openExternal(url: string) {
+  if (isNativeShell()) {
+    openExternalViaShell(url);
+    return;
+  }
+  window.open(url, '_blank', 'noopener,noreferrer');
 }


### PR DESCRIPTION
## 요약
- 인계 handoff-viewer-lane-b-native-bridge-2765 §2·§3 반영. 레인 A(#2766, 머지 완)가 만든 "RN이면 다운로드 준비 중" 특례를 실제 브리지로 채운다
- `native-shell-bridge.ts`: `downloadAsset(url, filename)` / `openExternal(url)` — RN 셸이면 `{type:'download',url,filename}` / `{type:'open-external',url}` postMessage(content-painted와 동일 명시 스키마 관례), 일반 브라우저는 기존 `<a download>`/`window.open` 그대로(회귀 0)
- `file-viewer.tsx`: 다운로드 버튼의 "RN이면 비활성" 조건 제거 — 브리지가 실제로 붙었으니 항상 실행 가능

## 스코프
- 이 PR은 **apps/web 축만**. sprintable-mobile 쪽 셸 핸들러(App.js `onMessage` + expo-file-system/expo-sharing)는 별 레포·별 PR(moonklabs/sprintable-mobile#feat/2765-lane-b-native-bridge) — 인계 규격이 명시한 "레인 A와 별 PR·별 검증" 원칙을 레인 B 내부(웹/셸)에도 그대로 적용
- ⛔ 실기기(macOS/iOS/Android) 검증은 셸 쪽 EAS 재빌드 완료 후 가능 — 이 PR 단독으로는 웹 코드 경로만 확인됨(브라우저 경로는 회귀 없음, RN 경로는 postMessage 발신까지만 이 레포 책임)

## 검증
- `pnpm type-check` / `pnpm lint` / `pnpm build` 전부 clean

## 게이트
PO AC 리뷰 → 카디르 QA(실기기 evidence는 셸 PR 착지 후) → 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)