### PR TITLE
[SID:2780] 뷰어 확장 — 엔티티 임베드 공통 «패널로 열기»

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -228,7 +228,7 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenRe
         const label = (link!.children ?? []).map(hastNodeText).join('') || m[2]!;
         const openReadingPanel = onOpenReadingPanel
           ? (entityType: string, entityId: string, t: string | null, s: string | null, h: string | null) =>
-              onOpenReadingPanel({ kind: 'doc', entityType, entityId, title: t, status: s, href: h })
+              onOpenReadingPanel({ kind: 'entity', entityType, entityId, title: t, status: s, href: h })
           : undefined;
         return <EmbedCard entity_type={m[1]!} entity_id={m[2]!} title={label} status={status} onOpenReadingPanel={openReadingPanel} />;
       }

--- a/apps/web/src/components/chat/embed-card.link-states.test.tsx
+++ b/apps/web/src/components/chat/embed-card.link-states.test.tsx
@@ -344,14 +344,13 @@ describe('story #2614 AC1/AC3 — artifact(부모 없는 독립 목업)는 몸�
   });
 });
 
-// story #2614 AC3 — "이 엔티티는 별도 미리보기가 없습니다" 문구는 지원 타입(RICH_PREVIEW_TYPES:
-// story/epic/doc/artifact/hypothesis)에서 뜨면 회귀다. sprint/task/evidence/asset은 의도적으로
-// 이 Set 밖(sprint=own-href로 이미 열림+몸통에 보여줄 게 없음, task/evidence=via-parent로 이미
-// 열림, asset=별도 스토리지 화면). 이 테스트는 그 경계 자체를 고정한다.
-describe('story #2614 AC3 — "미리보기 없음" 문구는 미지원 타입(sprint)에만 정직하게 남는다', () => {
-  // story #2642(BE #3044) — sprint도 이제 ENTITY_API에 항목이 생겨 자기 org_slug/project_slug를
-  // fetch한다(href 계산 재료로만 — RICH_PREVIEW_TYPES는 무변경, 몸통은 여전히 "미리보기 없음").
-  it('sprint — org_slug 없이 fetch 성공(옛 응답 모양·미백필 등)하면 여전히 "미리보기 없음"+bare href로 우아하게 폴백한다(회귀 아님)', async () => {
+// story #2780 — sprint/task가 RICH_PREVIEW_TYPES에 편입됐다(§3/페드루 판정: "있으면 열고
+// 없으면 안 연다" — TaskResponse/SprintResponse 실측상 title·status가 있어 편입). 이 가드의
+// 취지("미리보기 없음" 문구는 실제로 보여줄 내용이 없을 때만 뜬다, #2614 AC3)는 안 바뀌었다 —
+// 새 전제: RICH 타입이어도 detail에 필요한 필드(title)가 없으면 여전히 이 문구가 뜬다(카디르
+// QA 발견 — 편입 직후엔 이 문구 대신 완전 공백이 떴었다, embed-card.tsx richContent 가드로 수정).
+describe('story #2780 — "미리보기 없음" 문구는 "실제로 보여줄 내용이 없을 때" 정직하게 뜬다(미지원 타입이든, RICH 타입인데 필드가 없든)', () => {
+  it('sprint(#2780로 RICH 편입) — title 없는 옛 응답 모양(미백필 등)이면 몸통이 공백 아닌 "미리보기 없음"+bare href로 우아하게 폴백한다', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: {} }) }));
     await act(async () => {
       root.render(<EmbedCard entity_type="sprint" entity_id="sp1" title="스프린트 3" status={null} />);
@@ -360,6 +359,20 @@ describe('story #2614 AC3 — "미리보기 없음" 문구는 미지원 타입(s
     await flush();
     expect(document.body.textContent).toContain('이 엔티티는 별도 미리보기가 없습니다');
     expect(document.querySelector('a[href="/sprints?id=sp1"]')).not.toBeNull();
+  });
+
+  it('sprint(#2780) — title·status·기간이 실려 오면 RICH 몸통(뱃지)이 렌더되고 "미리보기 없음"은 안 뜬다', async () => {
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({ data: { title: '스프린트 5', status: 'active', start_date: '2026-08-01', end_date: '2026-08-14' } }),
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="sprint" entity_id="sp3" title="스프린트 5" status={null} />);
+    });
+    await openCard();
+    await flush();
+    expect(document.body.textContent).not.toContain('이 엔티티는 별도 미리보기가 없습니다');
+    expect(document.body.textContent).toContain('2026-08-01 ~ 2026-08-14');
   });
 
   it('sprint — fetch 자체가 실패하면(대상 사라짐 등) "대상을 찾을 수 없습니다"로 정직하게 갈린다(#2642로 sprint도 fetch-eligible 승격 — 이전엔 이 갈래가 아예 없었다)', async () => {

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -218,7 +218,10 @@ export const MdBody = ({ content }: { content: string }) => (
   </ReactMarkdown>
 );
 
-function EntityDetail({ entityType, entityId, detail }: { entityType: string; entityId: string; detail: Record<string, unknown> }) {
+// story #2780 — 컴포넌트가 아니라 순수 함수로 둔다: 호출부(embed-card 모달 body)가 반환값이
+// null인지(=보여줄 내용 없음) 직접 검사해야 하는데, JSX `<EntityDetail/>` 호출은 그 반환값을
+// 렌더 트리 밖에서 들여다볼 수 없다(엘리먼트 서술자는 항상 non-null이다 — 안이 null이어도).
+function renderEntityDetail(entityType: string, entityId: string, detail: Record<string, unknown>): React.ReactNode | null {
   if (entityType === 'story') {
     const d = detail as { status?: string; priority?: string; story_points?: number; description?: string; acceptance_criteria?: string };
     const statusLabel = d.status ? translateEntityStatus('story', d.status) : null;
@@ -600,6 +603,12 @@ export function EntityPreviewModal({
     </div>
   );
 
+  // story #2780 QA(카디르) 발견 — RICH 타입인데 detail에 필요한 필드가 없으면(예: title 없는
+  // sprint) EntityDetail이 null을 반환해 몸통이 완전 공백이었다(옛 "미리보기 없음" 문구보다
+  // 덜 정직한 새 위반형). "RICH 타입인가"가 아니라 "실제로 보여줄 내용이 있는가"로 이
+  // 문구를 하나로 통일한다 — 한 번만 계산해 조건과 렌더 양쪽에 쓴다(이중 호출 금지).
+  const richContent = detail && RICH_PREVIEW_TYPES.has(entityType) ? renderEntityDetail(entityType, entityId, detail) : null;
+
   const body = (
     <div className="flex-1 overflow-y-auto px-6 py-4">
       {loading ? (
@@ -609,8 +618,8 @@ export function EntityPreviewModal({
         </div>
       ) : notFound ? (
         <p className="py-4 text-xs text-muted-foreground">대상을 찾을 수 없습니다.</p>
-      ) : detail && RICH_PREVIEW_TYPES.has(entityType) ? (
-        <EntityDetail entityType={entityType} entityId={entityId} detail={detail} />
+      ) : richContent !== null ? (
+        richContent
       ) : (
         <p className="py-4 text-xs text-muted-foreground">이 엔티티는 별도 미리보기가 없습니다.</p>
       )}

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -123,11 +123,10 @@ const ENTITY_API: Record<string, (id: string) => string> = {
   story: (id) => `/api/stories/${id}`,
   epic: (id) => `/api/goals/${id}`,
   asset: (id) => `/api/assets/${id}`,
-  // story #2642 — sprint는 own-href(getEntityHref)라 이전엔 몸통 fetch 자체가 없었다(제목·기간
-  // 외 보여줄 게 없다는 판단, RICH_PREVIEW_TYPES 밖 그대로 유지). 그런데 크로스프로젝트 직행
-  // URL을 지으려면 sprint 자신의 org_slug/project_slug(BE #3044, SprintResponse 확장)를 알아야
-  // 해서 fetch 자체는 필요해졌다 — 몸통 렌더는 여전히 "미리보기 없음"(RICH_PREVIEW_TYPES 무변경,
-  // 아래 href 계산에서만 이 detail을 쓴다).
+  // story #2642 — sprint는 own-href(getEntityHref)라 당시엔 몸통 fetch 자체가 없었다. 크로스
+  // 프로젝트 직행 URL을 지으려면 sprint 자신의 org_slug/project_slug(BE #3044, SprintResponse
+  // 확장)를 알아야 해서 fetch가 필요해졌고, #2780에서 title·status·기간이 실제로 응답에
+  // 있음을 확認해 RICH_PREVIEW_TYPES에 편입(EntityDetail sprint 분기).
   sprint: (id) => `/api/sprints/${id}`,
   // story #2302 — task.story_id(항상 유일 부모)·artifact.{story_id,epic_id,doc_id}(최대 1개,
   // 전부 nullable)를 읽어 ②/③을 레코드 단위로 판정하는 재료.
@@ -151,7 +150,8 @@ const ENTITY_API: Record<string, (id: string) => string> = {
 // 의도적으로 이 Set 밖 — "미리보기 없음" 문구가 정확한 그 드문 경우(AC3의 "진짜 없는 것"에
 // sprint도 포함). 새 합성 가능 타입을 추가하면 이 Set도 같이 넓히거나(몸통 있음), 의도적으로
 // 빼면서 그 이유를 여기 한 줄 남길 것 — «만들 수 있는데 못 여는» 사각을 다시 만들지 않도록.
-const RICH_PREVIEW_TYPES = new Set(['story', 'epic', 'doc', 'artifact', 'hypothesis']);
+// story #2780 — task·sprint 편입(§3/페드루 판정, EntityDetail 주석 그대로 근거).
+const RICH_PREVIEW_TYPES = new Set(['story', 'epic', 'doc', 'artifact', 'hypothesis', 'task', 'sprint']);
 
 // story #2118(E-DG-REAL, 페드루 리뷰) — "폴백이 정직하다"(크래시 안 남)는 "클릭에 값이
 // 있다"는 뜻이 아니다. RICH_PREVIEW도 ENTITY_API fetch 전략도 own-href(getEntityHref)도
@@ -295,6 +295,44 @@ function EntityDetail({ entityType, entityId, detail }: { entityType: string; en
           </div>
         )}
         {d.statement && <MdBody content={d.statement} />}
+      </div>
+    );
+  }
+
+  // story #2780 — 인계 §3/페드루 판정(d8347c43 원칙="빈 모달 여는 거짓 금지"는 유지, 전제만
+  // 변화): task/sprint는 여태 RICH_PREVIEW_TYPES 밖이었으나(그때는 보여줄 내용이 없었다)
+  // TaskResponse/SprintResponse 실측(backend/app/schemas/task.py·sprint.py) 결과 title·status
+  // (+task는 story_id 부모링크·sprint는 start/end_date)가 실제로 있다 — 「있으면 열고 없으면
+  // 안 연다」로 이번엔 포함. 필드가 없으면(과거처럼) 여전히 null 반환 — 진입점을 억지로 안 만든다.
+  if (entityType === 'task') {
+    const d = detail as { title?: string; status?: string; story_id?: string };
+    if (!d.title) return null;
+    const statusLabel = d.status ? translateEntityStatus('task', d.status) : null;
+    const parentHref = d.story_id ? getEntityHref('story', d.story_id) : null;
+    return (
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-1.5">
+          {statusLabel && <MdBadge label={statusLabel} />}
+        </div>
+        {parentHref && (
+          <a href={parentHref} className="text-xs text-primary hover:underline">
+            부모 스토리 보기 →
+          </a>
+        )}
+      </div>
+    );
+  }
+
+  if (entityType === 'sprint') {
+    const d = detail as { title?: string; status?: string; start_date?: string; end_date?: string };
+    if (!d.title) return null;
+    const statusLabel = d.status ? translateEntityStatus('sprint', d.status) : null;
+    const period = d.start_date && d.end_date ? `${d.start_date} ~ ${d.end_date}` : null;
+    if (!statusLabel && !period) return null;
+    return (
+      <div className="flex flex-wrap items-center gap-1.5">
+        {statusLabel && <MdBadge label={statusLabel} />}
+        {period && <MdBadge label={period} />}
       </div>
     );
   }
@@ -673,6 +711,24 @@ export function EmbedCard({
     </div>
   );
 
+  // story #2780 — 인계 handoff-entity-embed-reading-panel-2780 §2/§7: 채팅 컨텍스트
+  // (onOpenReadingPanel 제공)에서는 «여는 동선»이 타입 무관 하나다 — doc의 기존 이중 버튼
+  // (주클릭=이동·eye=미리보기)도 포함해 전부 이 단일 클릭 하나로 합친다(전체 보기는 패널
+  // 자신의 명시 액션으로 이동, EntityPreviewModal 풋터 링크가 이미 그 역할). 채팅 밖 호출부
+  // (onOpenReadingPanel 미제공 — chat-input.tsx 작성 중 미리보기 등)는 아래 타입별 기존
+  // 분기를 그대로 유지(회귀 0).
+  if (onOpenReadingPanel) {
+    return (
+      <button
+        type="button"
+        onClick={() => onOpenReadingPanel(entity_type, entity_id, title, status, href)}
+        className="block w-full text-left transition-opacity hover:opacity-80"
+      >
+        {inner}
+      </button>
+    );
+  }
+
   if (entity_type === 'doc') {
     // story #1996(no-sloppy): 전체 카드가 항상 이동만 해 EntityPreviewModal(doc content 렌더
     // 이미 지원, EntityDetail의 doc 분기)에 도달할 방법이 없었다 — 주 클릭=이동(기존 UX 유지)·
@@ -697,8 +753,7 @@ export function EmbedCard({
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              if (onOpenReadingPanel) onOpenReadingPanel(entity_type, entity_id, title, status, href);
-              else setShowModal(true);
+              setShowModal(true);
             }}
             className="shrink-0 rounded p-1 opacity-70 transition-opacity hover:bg-black/10 hover:opacity-100 dark:hover:bg-white/10"
             aria-label="미리보기"
@@ -707,7 +762,7 @@ export function EmbedCard({
             <Eye className="size-3.5" />
           </button>
         </div>
-        {!onOpenReadingPanel && showModal && (
+        {showModal && (
           <EntityPreviewModal
             entityType={entity_type}
             entityId={entity_id}

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -309,11 +309,14 @@ function EntityDetail({ entityType, entityId, detail }: { entityType: string; en
     if (!d.title) return null;
     const statusLabel = d.status ? translateEntityStatus('task', d.status) : null;
     const parentHref = d.story_id ? getEntityHref('story', d.story_id) : null;
+    if (!statusLabel && !parentHref) return null;
     return (
       <div className="space-y-2">
-        <div className="flex flex-wrap items-center gap-1.5">
-          {statusLabel && <MdBadge label={statusLabel} />}
-        </div>
+        {statusLabel && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <MdBadge label={statusLabel} />
+          </div>
+        )}
         {parentHref && (
           <a href={parentHref} className="text-xs text-primary hover:underline">
             부모 스토리 보기 →

--- a/apps/web/src/components/chat/reading-panel.tsx
+++ b/apps/web/src/components/chat/reading-panel.tsx
@@ -4,11 +4,12 @@ import { EntityPreviewModal } from '@/components/chat/embed-card';
 import { FileViewer } from '@/components/chat/file-viewer';
 
 /**
- * story #2766(레인 A) — 채팅을 벗어나지 않는 우측 리딩 패널의 대상 2종.
- * ①doc 임베드 미리보기(EntityPreviewModal embedded 재사용) ②채팅 첨부(FileViewer 신설).
+ * story #2766(레인 A)·#2780(엔티티 확장) — 채팅을 벗어나지 않는 우측 리딩 패널의 대상 2형태.
+ * ①엔티티 읽기 뷰(story/epic/doc/hypothesis/artifact/task/sprint — EntityPreviewModal embedded
+ * 재사용, 타입별 분기는 그 내부(EntityDetail)에만 있다) ②채팅 첨부(FileViewer).
  */
 export type ReadingPanelTarget =
-  | { kind: 'doc'; entityType: string; entityId: string; title: string | null; status: string | null; href: string | null }
+  | { kind: 'entity'; entityType: string; entityId: string; title: string | null; status: string | null; href: string | null }
   | {
       kind: 'attachment';
       storedUrl: string;
@@ -26,7 +27,7 @@ export type ReadingPanelTarget =
  * 레이아웃(모달 아님·오버레이 아님)에 개입하지 않는다.
  */
 export function ReadingPanel({ target, onClose }: { target: ReadingPanelTarget; onClose: () => void }) {
-  if (target.kind === 'doc') {
+  if (target.kind === 'entity') {
     return (
       <div className="flex h-full flex-col overflow-hidden border-l border-border bg-background">
         <EntityPreviewModal


### PR DESCRIPTION
## 요약
- 인계 handoff-entity-embed-reading-panel-2780 §2/§3/§7 반영. 선생님 질문("스토리 전체보기는 화면 이동 — 개별 코딩인지?")의 실체 = story 등 엔티티가 여전히 채팅을 벗어나던 것(doc만 리딩 패널 대상이던 #2766 레인 A의 반쪽)
- `EmbedCard`에 `onOpenReadingPanel` 제공 시(채팅 컨텍스트) **단일 클릭 → 단일 호출**로 통합 — doc의 기존 이중 버튼(주클릭=이동·eye=미리보기)도 흡수. 채팅 밖 호출부(콜백 미제공, 예: 작성 중 미리보기)는 기존 타입별 분기 그대로(회귀 0)
- §7 완료 판별(여는 트리거 타입 분기 0): `grep -n "onOpenReadingPanel(entity_type" embed-card.tsx` → 정확히 1곳

## 그라운딩 중 발견 · PO 확定
- §1 서술("그 외 엔티티는 클릭→router.push 이탈")이 실코드와 달랐음(실측 보고, PO 접수) — 진짜 갭은 "모달이지 패널이 아니다"뿐, story/epic/hypothesis/artifact는 이미 Dialog 미리보기가 있었음(#2614)
- task/sprint: 과거 #2118(페드루 판정) "빈 모달 여는 거짓 금지"로 RICH_PREVIEW_TYPES 제외돼 있었으나, TaskResponse/SprintResponse 스키마 실측(title·status·story_id/기간 실재) 결과 「있으면 열고 없으면 안 연다」 원칙 그대로 편입(오늘 PO 재확定)

## 스코프 밖(별도 확인 필요 · PO에 보고 예정)
- `asset` 타입은 `EmbedCard`가 아니라 별도 컴포넌트(`asset-embed-card.tsx`)로 렌더되어 이번 패널 배선 밖 — §2가 "asset도 FileViewer로"라 언급했으나 §3 표/§7 완료 판별엔 없어 이번 스코프에서 제외

## 검증
- `pnpm type-check` / `pnpm lint` / `pnpm build` 전부 clean(신규 worktree에서 재검증)
- 라이브 픽셀 검증 진행 예정(story/epic 임베드 클릭 → 패널 오픈, 2테마)

## 게이트
PO AC 리뷰 → 카디르 QA(라이브 픽셀) → 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)