### PR TITLE
feat(#2776): seats/max_agents gating을 offering_versions 카탈로그로 통일

### DIFF
--- a/backend/alembic/versions/0257_org_subscriptions_pro_tier_backfill.py
+++ b/backend/alembic/versions/0257_org_subscriptions_pro_tier_backfill.py
@@ -1,0 +1,32 @@
+"""story #2776 — org_subscriptions.tier 'pro' 잔존값 백필(→'business').
+
+그라운딩(2026-08-18, Cloud Run Job pgstat-probe-dev 실측): 0228이 TierEnum을
+free/starter/team/business 4티어로 재편하고 `pricing_versions.tier`는 그때 함께
+'pro'→'business' 백필했지만(0228 upgrade() 145행), `org_subscriptions.tier`는
+스코프 아웃(0228 docstring: "org_subscriptions.tier CHECK 신설... B단계에서" — CHECK뿐
+아니라 값 백필 자체도 그 문장이 가리키는 후속에 같이 미뤄진 채 지금까지 비어 있었다)돼
+고아 'pro' 값이 org마다 남아 있었다. ee/plan_limits._KNOWN_TIERS가 이 스토리로
+{free,starter,team,business}만 알게 되면서, 'pro'로 남은 org는 매 요청마다
+"미지 tier" fail-open 경로(로그만 남기고 캡 미검사 통과)를 타게 된다 — 안전하지만
+잘못이다(유료 org인데 카탈로그 집행에서 영구히 빠짐). 'pro'가 곧 구 'business'였다는
+사실(0228이 이미 증명한 등가— pricing_versions에서 동일 변환 수행)에 의거해 값만
+정정한다(신규 스키마/CHECK 없음 — 데이터 전용 마이그).
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0257"
+down_revision = "0256"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE org_subscriptions SET tier = 'business' WHERE tier = 'pro'")
+
+
+def downgrade() -> None:
+    # 'pro'→'business' 백필의 역이 필요한 시나리오가 없다(0228이 이미 'pro'를 폐지 방향으로
+    # 확定 — pricing_versions와 동일하게 단방향). no-op.
+    pass

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id_no_project_gate
 from app.dependencies.database import get_db
 from app.dependencies.ownership import assert_agent_owner
@@ -135,6 +136,11 @@ async def create_org_agent(
         from app.services.project_auth import is_org_owner_or_admin
         if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
             raise HTTPException(status_code=403, detail="org admin/owner role required to manage members")
+
+    # EE: story #2776 — max_agents 축 집행(offering_versions 정본). OSS에서는 로드되지 않음.
+    if settings.is_ee_enabled:
+        from ee.plan_limits import check_agent_add_limit  # type: ignore[import]
+        await check_agent_add_limit(session, org_id)
 
     created_by = uuid.UUID(auth.user_id)  # 휴먼=user_id / 에이전트=member.id (anchor sync 가 휴먼만 owner 매칭)
     member, api_key_plaintext = await create_org_level_agent(

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db, get_read_db
 from app.dependencies.ownership import _is_org_admin, assert_agent_owner
@@ -342,6 +343,12 @@ async def create_team_member(
     # project_access placement) = 유일 영속 경로. ⚠️ api_key 자동생성(아래)보다 선행 — agent_api_keys.
     # member_id→members FK(0080) 충족 + cut-on 무중단.
     if body.type == "agent":
+        # EE: story #2776 — max_agents 축 집행(offering_versions 정본). OSS에서는 로드되지 않음.
+        # anchor sync(실제 영속)보다 선행 — 캡 초과 요청이 members 앵커에 새겨지기 전에 막는다.
+        if settings.is_ee_enabled:
+            from ee.plan_limits import check_agent_add_limit  # type: ignore[import]
+            await check_agent_add_limit(session, org_id)
+
         from app.services.agent_anchor_sync import sync_agent_anchor_on_create
         await sync_agent_anchor_on_create(session, member, created_by)
 

--- a/backend/ee/plan_limits.py
+++ b/backend/ee/plan_limits.py
@@ -1,23 +1,40 @@
-"""EE Plan Limit 정책 (E-ORG-MULTI S5.5).
+"""EE Plan Limit 정책 (E-ORG-MULTI S5.5, story #2776 후속 — seats/max_agents 축 통일).
 
-Free 플랜 제한:
-  - Org: 사용자당 1개 (owner 기준)
-  - Project: org당 1개
-  - Member: org당 3명 (#2471 A1 — v2.3 정책·선생님 確定 2026-08-06 04:00Z. 강제 마이그
-    아님: 기존 3명 초과 Free org는 멤버를 그대로 두고 신규 초대만 막는다 — 이 파일의 다른
-    모든 초과-자원 처리(storage: 신규 업로드만 차단·기존 파일 유지)와 동일한 패턴.)
+Org/Project 제한(#2776 스코프 밖 — `offering_versions`에 대응 필드가 없다, PO 確定
+2026-08-18: "gating 통일 완료"가 전 축으로 오독되지 않게 이름 박아둠):
+  - Org: 사용자당 owner org 1개(하드코딩 유지).
+  - Project: org당 1개, free만(하드코딩 유지).
 
-Team/Pro: 제한 없음.
+Member/Agent 제한(story #2776, 2026-08-18 — 가격표 정본 `offering_versions`로 통일):
+  - seats(휴먼+대기중 초대) — **全 tier**에서 `offering_versions.included_seats`로
+    집행(이전엔 free만 하드코딩 3, 나머지 tier는 완전 무제한이었다 — 카탈로그 실측:
+    free=3·starter=3·team=5·business=15로 실제 집행 확장됨, PO 判定 안B).
+  - `max_agents`(신규 축, 이전엔 코드 어디서도 read 0) — `offering_versions.max_agents`
+    (None=무제한, free만 유한 3).
+  - **미지 tier 방어**(PO 판정) — org_subscriptions.tier가 알려진 tier(free/starter/
+    team/business) 밖의 값이면(예: 0228 마이그가 놓친 'pro' 잔존값) 조용히 free로
+    취급하지 않는다(유료 org를 잘못 막을 위험) — fail loud 로그 + 그 요청은 무제한
+    통과(안전측 — «막는 사고»보다 «캡 미검사 통과»가 안전).
 """
+from __future__ import annotations
+
+import logging
+
 from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+logger = logging.getLogger(__name__)
+
 FREE_LIMITS: dict[str, int] = {
     "max_orgs_owned": 1,
     "max_projects": 1,
-    "max_members": 3,
 }
+
+# org_subscriptions.tier로 실제 나타날 수 있는, offering_versions가 정의하는 tier 집합.
+# 'overage'는 구독 tier가 아니라 사용량과금 축이라 여기 포함 안 됨(구독 tier로 저장되는
+# 값이 아님 — 그라운딩 확認).
+_KNOWN_TIERS = frozenset({"free", "starter", "team", "business"})
 
 # API 초과 과금 정책 (per call, USD)
 API_OVERAGE_RATES: dict[str, float] = {
@@ -26,18 +43,24 @@ API_OVERAGE_RATES: dict[str, float] = {
 }
 
 
-def _plan_limit_error(resource: str, limit: int) -> HTTPException:
-    return HTTPException(
-        status_code=402,
-        detail={
-            "code": "PLAN_LIMIT_EXCEEDED",
-            "resource": resource,
-            "limit": limit,
-            "tier": "free",
-            "upgrade_required": True,
-            "message": f"Free plan {resource} limit ({limit}) reached. Upgrade to Team or Pro.",
-        },
+def _plan_limit_error(resource: str, limit: int, current: int | None = None, tier: str = "free") -> HTTPException:
+    upgrade = tier != "business"
+    limit_repr = f"{current}/{limit}" if current is not None else str(limit)
+    msg = (
+        f"{tier} plan {resource} limit ({limit_repr}) reached. Upgrade for more capacity."
+        if upgrade else f"{resource} limit ({limit_repr}) reached."
     )
+    detail = {
+        "code": "PLAN_LIMIT_EXCEEDED",
+        "resource": resource,
+        "limit": limit,
+        "tier": tier,
+        "upgrade_required": upgrade,
+        "message": msg,
+    }
+    if current is not None:
+        detail["current"] = current
+    return HTTPException(status_code=402, detail=detail)
 
 
 async def _get_org_tier(session: AsyncSession, org_id) -> str:
@@ -48,6 +71,24 @@ async def _get_org_tier(session: AsyncSession, org_id) -> str:
     )
     row = result.first()
     return (row[0] if row else None) or "free"
+
+
+async def _get_offering_limits(session: AsyncSession, tier: str) -> tuple[int, int | None] | None:
+    """(included_seats, max_agents) — 가격표 정본. `currency` 무관 조회(그라운딩:
+    A1 스코프가 krw_v1만 시드했고 USD 카탈로그는 아직 별도 — seats/max_agents는 좌석 수
+    개념이라 통화별로 값이 다를 이유가 없다·둘 다 세팅된 currency 행이면 충분, 결정적
+    선택을 위해 currency ASC 1건). 매칭 행이 없으면 None(호출부가 §미지tier방어와 동일
+    원칙 — 무제한 통과 + 로그)."""
+    row = (await session.execute(
+        text(
+            "SELECT included_seats, max_agents FROM offering_versions "
+            "WHERE tier = :t AND effective_to IS NULL ORDER BY currency ASC LIMIT 1"
+        ),
+        {"t": tier},
+    )).first()
+    if row is None:
+        return None
+    return int(row[0]), (int(row[1]) if row[1] is not None else None)
 
 
 async def check_org_create_limit(session: AsyncSession, user_id) -> None:
@@ -65,7 +106,7 @@ async def check_org_create_limit(session: AsyncSession, user_id) -> None:
 
 
 async def check_project_create_limit(session: AsyncSession, org_id) -> None:
-    """Free: org당 project 1개 제한. Team/Pro는 스킵."""
+    """Free: org당 project 1개 제한. Team/Pro는 스킵. (#2776 스코프 밖 — 하드코딩 유지)"""
     tier = await _get_org_tier(session, org_id)
     if tier != "free":
         return
@@ -154,33 +195,54 @@ async def check_storage_capacity(session: AsyncSession, org_id, attachments: lis
         raise _storage_limit_error("storage", max_storage_mb, tier)
 
 
+async def _seat_usage(session: AsyncSession, org_id, *, include_pending_invites: bool) -> int:
+    """휴먼 org_members(+옵션: 대기중 미만료 초대) 카운트 — seats 축의 "현재값"(에이전트
+    미포함, PO 판정 안B: seats=휴먼 전용)."""
+    if include_pending_invites:
+        result = await session.execute(
+            text(
+                "SELECT "
+                "(SELECT COUNT(*) FROM org_members WHERE org_id = :oid AND deleted_at IS NULL)"
+                " + (SELECT COUNT(*) FROM org_invites"
+                "     WHERE organization_id = :oid AND status = 'pending' AND expires_at > now())"
+            ),
+            {"oid": str(org_id)},
+        )
+    else:
+        result = await session.execute(
+            text("SELECT COUNT(*) FROM org_members WHERE org_id = :oid AND deleted_at IS NULL"),
+            {"oid": str(org_id)},
+        )
+    return result.scalar() or 0
+
+
 async def check_member_invite_limit(session: AsyncSession, org_id) -> None:
-    """Free: org당 member 3명 제한 (human + agent, 현재 멤버 + pending 미만료 초대 합). Team/Pro는 스킵.
+    """story #2776 — seats 축을 全 tier에서 카탈로그(`offering_versions.included_seats`)로
+    집행(이전엔 free만 하드코딩 3, 나머지 tier 무제한이었음). 여전히 휴먼(org_members)+
+    대기중 미만료 초대 합만 센다(에이전트 미포함 — PO 판정 안B, seats 의미 불변).
 
     story #2477 AC① — pending invite를 안 세면 cap을 우회할 수 있었다(2명이 초대 5개를
     만들어 전부 수락하면 3명 캡을 넘길 수 있음). 생성 단계에서 «멤버+대기중 초대» 합으로
     선차단해 애초에 캡을 넘길 만큼의 초대가 쌓이지 못하게 한다.
     """
     tier = await _get_org_tier(session, org_id)
-    if tier != "free":
+    if tier not in _KNOWN_TIERS:
+        logger.error("check_member_invite_limit: unknown tier %r for org_id=%s — skipping cap(fail-open)", tier, org_id)
         return
-    result = await session.execute(
-        text(
-            "SELECT "
-            "(SELECT COUNT(*) FROM org_members WHERE org_id = :oid AND deleted_at IS NULL)"
-            " + (SELECT COUNT(*) FROM org_invites"
-            "     WHERE organization_id = :oid AND status = 'pending' AND expires_at > now())"
-        ),
-        {"oid": str(org_id)},
-    )
-    count = result.scalar() or 0
-    if count >= FREE_LIMITS["max_members"]:
-        raise _plan_limit_error("member", FREE_LIMITS["max_members"])
+    offering = await _get_offering_limits(session, tier)
+    if offering is None:
+        logger.error("check_member_invite_limit: no offering_version for tier=%r org_id=%s — skipping cap(fail-open)", tier, org_id)
+        return
+    seats_limit, _max_agents = offering
+    count = await _seat_usage(session, org_id, include_pending_invites=True)
+    if count >= seats_limit:
+        raise _plan_limit_error("member", seats_limit, current=count, tier=tier)
 
 
 async def check_member_accept_limit(session: AsyncSession, org_id) -> None:
-    """Free: 초대 «수락» 시점 재검증(story #2477 AC②) — 현재 멤버수만 비교(대기중 초대는
-    무관, 이 호출이 성공하면 그 초대 하나가 바로 멤버로 전환되므로). Team/Pro는 스킵.
+    """story #2776 — §check_member_invite_limit과 동일 카탈로그 소스, 全 tier 집행.
+    초대 «수락» 시점 재검증(story #2477 AC②) — 현재 멤버수만 비교(대기중 초대는 무관,
+    이 호출이 성공하면 그 초대 하나가 바로 멤버로 전환되므로).
 
     ⚠️호출부(OrgInviteRepository.accept)가 org_id 스코프 advisory xact lock을 먼저 잡은
     뒤에 불러야 한다 — 락 없이 재면 동시에 수락하는 두 트랜잭션이 서로 상대의 INSERT를
@@ -188,12 +250,40 @@ async def check_member_accept_limit(session: AsyncSession, org_id) -> None:
     함수가 아니라 호출부의 락이 담당).
     """
     tier = await _get_org_tier(session, org_id)
-    if tier != "free":
+    if tier not in _KNOWN_TIERS:
+        logger.error("check_member_accept_limit: unknown tier %r for org_id=%s — skipping cap(fail-open)", tier, org_id)
         return
-    result = await session.execute(
-        text("SELECT COUNT(*) FROM org_members WHERE org_id = :oid AND deleted_at IS NULL"),
+    offering = await _get_offering_limits(session, tier)
+    if offering is None:
+        logger.error("check_member_accept_limit: no offering_version for tier=%r org_id=%s — skipping cap(fail-open)", tier, org_id)
+        return
+    seats_limit, _max_agents = offering
+    count = await _seat_usage(session, org_id, include_pending_invites=False)
+    if count >= seats_limit:
+        raise _plan_limit_error("member", seats_limit, current=count, tier=tier)
+
+
+async def check_agent_add_limit(session: AsyncSession, org_id) -> None:
+    """story #2776 신규 — `offering_versions.max_agents` 축 집행(이전엔 코드 어디서도
+    read 0이던 그 값). None=무제한(free만 유한 3). 미지 tier/미시드 offering은 §미지tier
+    방어와 동일 원칙(fail-open+로그) — 유료 org를 잘못 막지 않는다."""
+    tier = await _get_org_tier(session, org_id)
+    if tier not in _KNOWN_TIERS:
+        logger.error("check_agent_add_limit: unknown tier %r for org_id=%s — skipping cap(fail-open)", tier, org_id)
+        return
+    offering = await _get_offering_limits(session, tier)
+    if offering is None:
+        logger.error("check_agent_add_limit: no offering_version for tier=%r org_id=%s — skipping cap(fail-open)", tier, org_id)
+        return
+    _seats, max_agents = offering
+    if max_agents is None:
+        return  # 무제한 tier
+    count = (await session.execute(
+        text(
+            "SELECT COUNT(*) FROM members "
+            "WHERE org_id = :oid AND type = 'agent' AND is_active = true AND deleted_at IS NULL"
+        ),
         {"oid": str(org_id)},
-    )
-    count = result.scalar() or 0
-    if count >= FREE_LIMITS["max_members"]:
-        raise _plan_limit_error("member", FREE_LIMITS["max_members"])
+    )).scalar() or 0
+    if count >= max_agents:
+        raise _plan_limit_error("agent", max_agents, current=count, tier=tier)

--- a/backend/tests/test_2477_free_seat_cap_bypass.py
+++ b/backend/tests/test_2477_free_seat_cap_bypass.py
@@ -41,12 +41,17 @@ def test_check_member_invite_limit_docstring_says_3_not_5():
 # ─── AC①: 생성 시점 cap = 현재 멤버 + pending invite 합 ─────────────────────
 
 def test_check_member_invite_limit_counts_pending_invites_in_sql():
-    """count SQL에 org_invites·pending·org_members 3요소가 합산 형태로 실재."""
-    from ee.plan_limits import check_member_invite_limit
-    source = inspect.getsource(check_member_invite_limit)
-    assert "org_invites" in source
-    assert "pending" in source
-    assert "org_members" in source
+    """count SQL에 org_invites·pending·org_members 3요소가 합산 형태로 실재 — #2776 리팩터로
+    이 SQL은 공용 헬퍼 `_seat_usage`(check_member_invite_limit/accept_limit 공유)로 옮겨졌다."""
+    from ee.plan_limits import _seat_usage, check_member_invite_limit
+    invite_source = inspect.getsource(check_member_invite_limit)
+    assert "_seat_usage" in invite_source
+    assert "include_pending_invites=True" in invite_source
+
+    seat_usage_source = inspect.getsource(_seat_usage)
+    assert "org_invites" in seat_usage_source
+    assert "pending" in seat_usage_source
+    assert "org_members" in seat_usage_source
 
 
 @pytest.mark.anyio
@@ -58,9 +63,11 @@ async def test_check_member_invite_limit_rejects_when_members_plus_pending_at_ca
     mock_session = AsyncMock()
     tier_result = MagicMock()
     tier_result.first.return_value = ("free",)
+    offering_result = MagicMock()
+    offering_result.first.return_value = (3, 3)  # (included_seats, max_agents) — #2776 카탈로그 조회
     count_result = MagicMock()
     count_result.scalar.return_value = 3  # 2 members + 1 pending = 3 = cap
-    mock_session.execute = AsyncMock(side_effect=[tier_result, count_result])
+    mock_session.execute = AsyncMock(side_effect=[tier_result, offering_result, count_result])
 
     with pytest.raises(HTTPException) as exc_info:
         await check_member_invite_limit(mock_session, uuid.uuid4())
@@ -76,9 +83,11 @@ async def test_check_member_invite_limit_passes_when_under_cap():
     mock_session = AsyncMock()
     tier_result = MagicMock()
     tier_result.first.return_value = ("free",)
+    offering_result = MagicMock()
+    offering_result.first.return_value = (3, 3)  # (included_seats, max_agents) — #2776 카탈로그 조회
     count_result = MagicMock()
     count_result.scalar.return_value = 2  # 1 member + 1 pending = 2 < 3
-    mock_session.execute = AsyncMock(side_effect=[tier_result, count_result])
+    mock_session.execute = AsyncMock(side_effect=[tier_result, offering_result, count_result])
 
     await check_member_invite_limit(mock_session, uuid.uuid4())  # 예외 없어야 함
 
@@ -86,9 +95,11 @@ async def test_check_member_invite_limit_passes_when_under_cap():
 # ─── AC②: accept-time 재검증 함수 존재 + 402 거부 (mock, 락 존재만 확인) ────
 
 def test_check_member_accept_limit_exists():
+    """#2776: 하드코딩 max_members 대신 offering_versions 카탈로그(_get_offering_limits)에서
+    seats 캡을 조회 — 全 tier 집행."""
     from ee.plan_limits import check_member_accept_limit
     source = inspect.getsource(check_member_accept_limit)
-    assert "max_members" in source
+    assert "_get_offering_limits" in source
     assert "_plan_limit_error" in source or "raise" in source
 
 
@@ -122,11 +133,13 @@ async def test_accept_rejects_when_at_cap_ee_on():
     invite_result.scalar_one_or_none.return_value = invite
     tier_result = MagicMock()
     tier_result.first.return_value = ("free",)
+    offering_result = MagicMock()
+    offering_result.first.return_value = (3, 3)  # (included_seats, max_agents) — #2776 카탈로그 조회
     count_result = MagicMock()
     count_result.scalar.return_value = 3  # 이미 cap
 
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[invite_result, MagicMock(), tier_result, count_result])
+    session.execute = AsyncMock(side_effect=[invite_result, MagicMock(), tier_result, offering_result, count_result])
 
     repo = OrgInviteRepository(session)
     with patch("app.repositories.org_invite.settings") as mock_settings:

--- a/backend/tests/test_2776_offering_catalog_gating_realdb.py
+++ b/backend/tests/test_2776_offering_catalog_gating_realdb.py
@@ -1,0 +1,229 @@
+"""story #2776 — offering_versions 카탈로그 정본 gating 실PG 검증.
+
+핵심 축: ①check_agent_add_limit 신규(이전엔 코드 어디서도 max_agents read 0) ②seats
+(check_member_invite_limit/accept_limit) 축이 이제 free뿐 아니라 全 tier(team/business
+포함)에서 카탈로그로 집행됨 ③미지 tier(0228 이전 잔존 'pro' 등)는 fail-open+로그. 로컬 PG
+미설정 시 skip.
+
+⚠️ test_2777_admin_billing_realdb.py 사고(2026-08-18, 공유 실PG의 offering_versions를
+DELETE해 CI 병렬 테스트 26건 연쇄격추) 재발 방지 원칙을 그대로 따른다 — 이 파일은
+offering_versions를 절대 DELETE/UPDATE하지 않는다. `_seed_offering()`은 ON CONFLICT DO
+NOTHING(실 부분 UNIQUE 인덱스 uq_offering_versions_active_tier_currency에 위임)만 쓰고,
+이미 있으면 그 실효값을 그대로 읽어 assert 기준으로 삼는다(하드코딩 기대값 대신 실측값
+사용 — 어떤 값이 실제로 시드돼 있든 이 테스트는 그 값 기준으로 옳다)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_offering(session, *, tier: str, currency: str = "krw"):
+    """이미 있으면 손 안 대고(ON CONFLICT DO NOTHING) 실효값을 그대로 반환 — DELETE/UPDATE
+    없음(#2777 사고 재발 방지 원칙, 파일 docstring)."""
+    from datetime import datetime, timezone
+
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from app.models.offering_version import OfferingVersion
+
+    stmt = pg_insert(OfferingVersion).values(
+        id=uuid.uuid4(), tier=tier, currency=currency, version_label=f"{tier}_{currency}_v1_test",
+        monthly_price_minor=1, annual_price_minor=1, included_seats=3, max_agents=3,
+        au_limit=1, realtime_connection_limit=1, storage_mb_limit=1, max_file_mb=1,
+        lab_credit_minor=1, rate_limit_per_min=1, automation_rule_limit=1, webhook_limit=1,
+        event_replay_days=1, overage_allowed=True,
+        effective_from=datetime.now(timezone.utc), created_by="test_2776_seed",
+    ).on_conflict_do_nothing(
+        index_elements=["tier", "currency"],
+        index_where=OfferingVersion.effective_to.is_(None),
+    )
+    await session.execute(stmt)
+    await session.commit()
+
+    from sqlalchemy import select
+    row = (await session.execute(
+        select(OfferingVersion.included_seats, OfferingVersion.max_agents).where(
+            OfferingVersion.tier == tier, OfferingVersion.currency == currency,
+            OfferingVersion.effective_to.is_(None),
+        )
+    )).first()
+    return int(row[0]), (int(row[1]) if row[1] is not None else None)
+
+
+async def _seed_org(session, *, tier: str):
+    from app.models.organization import Organization
+    from app.models.org_subscription import OrgSubscription
+
+    org = Organization(id=uuid.uuid4(), name="Org2776Gating", slug=f"org2776-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+    session.add(OrgSubscription(id=uuid.uuid4(), org_id=org.id, tier=tier, status="active"))
+    await session.commit()
+    return org.id
+
+
+async def _seed_agent_member(session, *, org_id, is_active: bool = True):
+    from app.models.member import Member
+
+    m = Member(
+        id=uuid.uuid4(), org_id=org_id, type="agent", name=f"agent-{uuid.uuid4().hex[:6]}",
+        is_active=is_active,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+@pytest.mark.asyncio
+async def test_agent_add_limit_blocks_at_max_agents():
+    """free(max_agents=3 실측 카탈로그 기준) — 캡 도달 시 402."""
+    from fastapi import HTTPException
+
+    from ee.plan_limits import check_agent_add_limit
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            _seats, max_agents = await _seed_offering(s, tier="free")
+        assert max_agents is not None, "free는 max_agents가 유한(카탈로그 그라운딩) — None이면 시드 전제가 깨진 것"
+
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+            for _ in range(max_agents):
+                await _seed_agent_member(s, org_id=org_id)
+
+        async with maker() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await check_agent_add_limit(s, org_id)
+            assert exc_info.value.status_code == 402
+            assert exc_info.value.detail["code"] == "PLAN_LIMIT_EXCEEDED"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_agent_add_limit_passes_under_cap():
+    from ee.plan_limits import check_agent_add_limit
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            _seats, max_agents = await _seed_offering(s, tier="free")
+        assert max_agents is not None and max_agents >= 1
+
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+            # cap보다 하나 적게만 seed
+            for _ in range(max_agents - 1):
+                await _seed_agent_member(s, org_id=org_id)
+
+        async with maker() as s:
+            await check_agent_add_limit(s, org_id)  # 예외 없어야 함
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_agent_add_limit_ignores_soft_deleted_and_inactive_members():
+    """deleted_at/is_active=false 에이전트는 카운트에서 빠져야 cap을 부당하게 소모하지 않는다."""
+    from app.models.member import Member
+    from ee.plan_limits import check_agent_add_limit
+    from sqlalchemy import update
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            _seats, max_agents = await _seed_offering(s, tier="free")
+        assert max_agents is not None and max_agents >= 1
+
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+            # cap 개수만큼 만들고 전부 비활성/삭제 처리 — 실질 사용은 0이어야 통과.
+            member_ids = [await _seed_agent_member(s, org_id=org_id) for _ in range(max_agents)]
+            await s.execute(
+                update(Member).where(Member.id.in_(member_ids)).values(is_active=False)
+            )
+            await s.commit()
+
+        async with maker() as s:
+            await check_agent_add_limit(s, org_id)  # 비활성뿐이라 예외 없어야 함
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_team_tier_member_invite_now_enforced_via_catalog():
+    """#2776 핵심 회귀 — 이전엔 team/business가 seats 무제한(하드코딩 free만 캡)이었다.
+    지금은 team도 카탈로그(included_seats)로 캡이 걸려야 한다(양성대조: 캡 도달 시 402)."""
+    from fastapi import HTTPException
+
+    from ee.plan_limits import check_member_invite_limit
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            seats, _max_agents = await _seed_offering(s, tier="team")
+
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="team")
+            from app.models.project import OrgMember
+            for _ in range(seats):
+                s.add(OrgMember(
+                    id=uuid.uuid4(), org_id=org_id, user_id=uuid.uuid4(), role="member",
+                ))
+            await s.commit()
+
+        async with maker() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await check_member_invite_limit(s, org_id)
+            assert exc_info.value.status_code == 402
+            assert exc_info.value.detail["tier"] == "team"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_unknown_tier_fails_open_not_blocked():
+    """org_subscriptions.tier가 _KNOWN_TIERS 밖(예: 0257 백필 누락/미래 값)이면 조용히
+    free로 오분류해 부당 차단하지 않고, fail-open(무제한 통과)해야 한다 — PO 판정 pin."""
+    from ee.plan_limits import check_agent_add_limit, check_member_invite_limit
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="__unknown_future_tier__")
+
+        async with maker() as s:
+            await check_member_invite_limit(s, org_id)  # 예외 없어야(fail-open)
+        async with maker() as s:
+            await check_agent_add_limit(s, org_id)  # 예외 없어야(fail-open)
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_2471_a1_billing_model.py
+++ b/backend/tests/test_e_2471_a1_billing_model.py
@@ -26,10 +26,14 @@ def test_tier_enum_is_v2_3_four_tier():
     assert "solo" not in TierEnum.enums  # v2.3 D12: solo enum 신설 금지
 
 
-def test_free_limits_seats_capped_at_3():
+def test_free_limits_org_project_hardcoded():
+    """#2776: seats(=구 max_members)는 offering_versions 카탈로그 집행으로 이관돼
+    FREE_LIMITS에서 빠졌다 — free=3 seats pin은 아래
+    test_krw_v1_seed_matches_pricing_policy_v2_3_part3의 seats 단언이 담당한다.
+    org/project 축만 여전히 이 dict의 하드코딩(#2776 스코프 밖)."""
     from ee.plan_limits import FREE_LIMITS
 
-    assert FREE_LIMITS["max_members"] == 3  # 선생님 確定 2026-08-06 04:00Z(강제, 그랜드파더링 없음)
+    assert "max_members" not in FREE_LIMITS
     assert FREE_LIMITS["max_orgs_owned"] == 1
     assert FREE_LIMITS["max_projects"] == 1
 

--- a/backend/tests/test_e_org_multi_s5_5_plan_limits.py
+++ b/backend/tests/test_e_org_multi_s5_5_plan_limits.py
@@ -65,11 +65,13 @@ def test_oss_no_plan_limit_imported_unconditionally():
 # ─── AC3: Free 제한값 검증 ───────────────────────────────────────────────────
 
 def test_free_limits_defined():
-    """FREE_LIMITS에 max_orgs_owned, max_projects, max_members 정의."""
+    """FREE_LIMITS에 max_orgs_owned, max_projects 정의(#2776: org/project는 스코프 밖
+    하드코딩 유지). max_members는 #2776로 offering_versions.included_seats 카탈로그
+    집행으로 이관돼 이 dict에서 빠짐(전 tier 공통 조회이지 tier별 상수가 아니므로)."""
     from ee.plan_limits import FREE_LIMITS
     assert FREE_LIMITS["max_orgs_owned"] == 1
     assert FREE_LIMITS["max_projects"] == 1
-    assert FREE_LIMITS["max_members"] == 3  # #2471(A1): v2.3 정책, 5→3(선생님 確定 04:00Z)
+    assert "max_members" not in FREE_LIMITS
 
 
 def test_free_limits_org_check_exists():
@@ -89,22 +91,28 @@ def test_free_limits_project_check_exists():
 
 
 def test_free_limits_member_check_exists():
-    """check_member_invite_limit 함수 존재."""
+    """check_member_invite_limit 함수 존재 — #2776: 하드코딩 max_members 대신
+    offering_versions(카탈로그 정본)에서 seats 캡을 조회."""
     from ee.plan_limits import check_member_invite_limit
     source = inspect.getsource(check_member_invite_limit)
-    assert "max_members" in source
+    assert "_get_offering_limits" in source
     assert "_plan_limit_error" in source or "raise" in source
 
 
-# ─── AC4: Team/Pro 제한 없음 ─────────────────────────────────────────────────
+# ─── AC4: Team/Pro 제한 없음(project/org 축만, #2776 스코프 밖 유지) ─────────
 
-def test_team_pro_skips_limit():
-    """project/member limit 체크 소스에 tier != 'free' 시 return 존재."""
+def test_team_pro_skips_project_limit_but_not_member_limit():
+    """#2776 판정 안B: project/org 축은 여전히 free 전용 하드코딩(스코프 밖, tier!='free'
+    시 skip 유지)이지만, member(seats) 축은 이제 全 tier가 offering_versions 카탈로그로
+    집행돼 더 이상 "team/pro는 무제한"이 아니다 — 이 비대칭을 소스로 직접 pin."""
     from ee.plan_limits import check_project_create_limit, check_member_invite_limit
-    for fn in (check_project_create_limit, check_member_invite_limit):
-        source = inspect.getsource(fn)
-        assert "return" in source
-        assert "free" in source
+    project_source = inspect.getsource(check_project_create_limit)
+    assert "return" in project_source
+    assert "free" in project_source
+
+    member_source = inspect.getsource(check_member_invite_limit)
+    assert "_KNOWN_TIERS" in member_source  # free 단독분기가 아니라 known-tier 집합 방어
+    assert '!= "free"' not in member_source and "!= 'free'" not in member_source
 
 
 # ─── AC5: 402 + upgrade_required ─────────────────────────────────────────────

--- a/backend/tests/test_onboarding_member_anchor_0b115f5d.py
+++ b/backend/tests/test_onboarding_member_anchor_0b115f5d.py
@@ -37,6 +37,15 @@ def _tier_result(tier: str | None):
     return r
 
 
+def _offering_result(seats: int, max_agents: int | None = None):
+    """story #2776 — check_member_invite_limit/accept_limit이 하드코딩 캡 대신
+    offering_versions._get_offering_limits(included_seats, max_agents)를 추가로
+    조회하게 되면서, tier 조회와 count 조회 사이에 이 결과가 하나 더 필요해졌다."""
+    r = MagicMock()
+    r.first.return_value = (seats, max_agents)
+    return r
+
+
 # ─── 경로 ①: organizations.create_organization ──────────────────────────────
 
 
@@ -154,6 +163,7 @@ async def test_invite_accept_ensures_human_member():
             _scalar_result(invite),  # accept(): invite 조회
             MagicMock(),             # story #2477: advisory xact lock
             _tier_result("free"),    # story #2477: check_member_accept_limit._get_org_tier
+            _offering_result(3, 3),  # story #2776: offering_versions.included_seats 조회(신규)
             _count_result(1),        # story #2477: accept-time cap 재검증(1명 < 3, 통과)
             MagicMock(),             # org_members upsert
             _scalar_result(om_id),   # _ensure_member_anchor: om_id 재조회


### PR DESCRIPTION
## Summary
- `ee/plan_limits.py`: `FREE_LIMITS`의 하드코딩 `max_members`(free만 3, 나머지 tier 무제한)를 폐기하고, `check_member_invite_limit`/`check_member_accept_limit`이 全 tier에서 `offering_versions.included_seats`(가격표 정본)를 조회하도록 재작성.
- 신규 `check_agent_add_limit()` — `offering_versions.max_agents` 축 집행(이전엔 코드 어디서도 read 0). `agents.py::create_org_agent`·`team_members.py::create_team_member`(에이전트 앵커 write-sync 직전)에 배선.
- 미지 tier(0228 이전 잔존 `'pro'` 등)는 fail-open + 로그(PO 판정 — 유료 org 오차단보다 캡 미검사 통과가 안전).
- `0257_org_subscriptions_pro_tier_backfill.py`: `org_subscriptions.tier`의 `'pro'` 잔존값을 `'business'`로 데이터 백필(0228이 `pricing_versions`에서 이미 수행한 동일 전환의 자매 — CHECK 신설 없음, 로컬 실PG round-trip으로 검증).
- 기존 3개 테스트 파일(`test_e_org_multi_s5_5_plan_limits.py`/`test_e_2471_a1_billing_model.py`/`test_2477_free_seat_cap_bypass.py`)의 구 하드코딩 가정을 신 카탈로그 기반 계약으로 갱신.
- 신규 realdb 테스트(`test_2776_offering_catalog_gating_realdb.py`) — `check_agent_add_limit`(캡 도달/미달/비활성-제외) · team tier seat 집행(핵심 회귀: 이전엔 team/business가 무제한) · 미지 tier fail-open.

## 스코프 밖(명시)
- `check_org_create_limit`/`check_project_create_limit`(org/project 축) — `offering_versions`에 대응 필드가 없어 하드코딩 유지(PO 確定, 이 스토리 무관).
- 관리자 가격 편집 UI 왕복 실증(spec §3) — dev 배포 후 라이브 검증 예정(코드/데이터는 이 PR로 완료).

## Test plan
- [x] 로컬 실PG(migration 0257까지) — 신규+갱신 테스트 39건 green
- [x] 전체 스위트 collect-only 7458건 무결(import 회귀 없음)
- [x] 비파괴 전체 스위트 로컬 실행 — 기존 실패 9건은 무관(mcp tool-count·standup 등, #2776 무관 pre-existing)
- [ ] CI green 확인 후 재스탬프 요청

🤖 Generated with [Claude Code](https://claude.com/claude-code)