### PR TITLE
[SID:2781] asset 임베드 카드 — 우측 ReadingPanel(FileViewer)로 인앱 열람

### DIFF
--- a/apps/web/src/components/chat/asset-embed-card.tsx
+++ b/apps/web/src/components/chat/asset-embed-card.tsx
@@ -10,6 +10,7 @@ import { FILE_TINT_CLASS, fileExtLabel, fileTypeTint } from '@/lib/storage/forma
 import type { Asset } from '@/lib/storage/types';
 import { Skeleton } from '@/components/ui/skeleton';
 import { fetchWithAuth } from '@/lib/db/client';
+import type { ReadingPanelTarget } from '@/components/chat/reading-panel';
 
 /** 파일 타입 글리프 — getFileIcon 결과를 createElement 로 직접 렌더(render 중 컴포넌트 생성 lint 회피). */
 function fileGlyph(contentType: string | null, className: string) {
@@ -22,6 +23,12 @@ interface AssetEmbedCardProps {
   label: string;
   /** 내 메시지(brand 버블) 위면 카드 배경을 반투명 화이트로(목업 ②). */
   ownMessage: boolean;
+  /**
+   * story #2781 — 채팅 컨텍스트(제공됨)에서는 클릭이 `/storage` 이탈 대신 우측 ReadingPanel의
+   * FileViewer를 연다(#2766·#2780과 같은 패턴 — «채팅을 벗어나지 않는다»의 마지막 사각).
+   * 미제공(채팅 밖 호출부)이면 기존 `<Link>` 이동 그대로(회귀 0).
+   */
+  onOpenReadingPanel?: (target: ReadingPanelTarget) => void;
 }
 
 /**
@@ -30,7 +37,7 @@ interface AssetEmbedCardProps {
  * 썸네일(타입 틴트 글리프) + 이름 + 메타 + 외부링크 화살표. 링크 `/storage?asset={id}`.
  * 로딩=스켈레톤·미존재(fetch 실패/404)=graceful(평문 라벨, 링크/화살표 제거).
  */
-export function AssetEmbedCard({ entityId, label, ownMessage }: AssetEmbedCardProps) {
+export function AssetEmbedCard({ entityId, label, ownMessage, onOpenReadingPanel }: AssetEmbedCardProps) {
   const t = useTranslations('chats');
   const [asset, setAsset] = useState<Asset | null>(null);
   const [loading, setLoading] = useState(true);
@@ -100,11 +107,8 @@ export function AssetEmbedCard({ entityId, label, ownMessage }: AssetEmbedCardPr
   const ext = fileExtLabel(asset.content_type, asset.name);
   const meta = `${ext} · ${formatFileSize(asset.size_bytes)}`;
 
-  return (
-    <Link
-      href={`/storage?asset=${asset.id}`}
-      className={`mt-2 flex max-w-[300px] items-center gap-2.5 rounded-md border px-2.5 py-2 no-underline transition-colors ${cardSurface}`}
-    >
+  const inner = (
+    <>
       {/* 썸네일 38×38 — 타입 틴트 글리프(서명 썸네일 필드 부재 → 글리프, 추후 affordance). */}
       <span className={`grid size-[38px] shrink-0 place-items-center overflow-hidden rounded-sm ${ownMessage ? 'bg-white/15 text-white' : tint}`}>
         {fileGlyph(asset.content_type, 'size-[17px]')}
@@ -114,6 +118,29 @@ export function AssetEmbedCard({ entityId, label, ownMessage }: AssetEmbedCardPr
         <p className={`mt-px text-[11px] ${metaTone}`}>{meta}</p>
       </div>
       <ExternalLink className={`size-[15px] shrink-0 ${arrowTone}`} aria-hidden />
+    </>
+  );
+
+  if (onOpenReadingPanel) {
+    return (
+      <button
+        type="button"
+        onClick={() =>
+          onOpenReadingPanel({ kind: 'attachment', assetId: asset.id, label: asset.name, contentType: asset.content_type })
+        }
+        className={`mt-2 flex w-full max-w-[300px] items-center gap-2.5 rounded-md border px-2.5 py-2 text-left transition-colors ${cardSurface}`}
+      >
+        {inner}
+      </button>
+    );
+  }
+
+  return (
+    <Link
+      href={`/storage?asset=${asset.id}`}
+      className={`mt-2 flex max-w-[300px] items-center gap-2.5 rounded-md border px-2.5 py-2 no-underline transition-colors ${cardSurface}`}
+    >
+      {inner}
     </Link>
   );
 }

--- a/apps/web/src/components/chat/asset-embed-card.tsx
+++ b/apps/web/src/components/chat/asset-embed-card.tsx
@@ -128,7 +128,7 @@ export function AssetEmbedCard({ entityId, label, ownMessage, onOpenReadingPanel
         onClick={() =>
           onOpenReadingPanel({ kind: 'attachment', assetId: asset.id, label: asset.name, contentType: asset.content_type })
         }
-        className={`mt-2 flex w-full max-w-[300px] items-center gap-2.5 rounded-md border px-2.5 py-2 text-left transition-colors ${cardSurface}`}
+        className={`mt-2 flex max-w-[300px] items-center gap-2.5 rounded-md border px-2.5 py-2 text-left transition-colors ${cardSurface}`}
       >
         {inner}
       </button>

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -282,7 +282,7 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenRe
         // 주석 참조) mention_parser가 애초에 entity_references에 안 쓴다 — stored 참조와
         // 대조하면 asset 임베드가 전부 유령으로 오판된다. 유령 판정 자체를 안 태운다.
         if (m[1]!.toLowerCase() === 'asset') {
-          return <AssetEmbedCard entityId={m[2]!} label={String(children)} ownMessage={isMine} />;
+          return <AssetEmbedCard entityId={m[2]!} label={String(children)} ownMessage={isMine} onOpenReadingPanel={onOpenReadingPanel} />;
         }
         const ghost = isGhostReference(references, m[1]!, m[2]!);
         const referenceMeta = ghost ? null : findReferenceMeta(references, m[1]!, m[2]!);

--- a/apps/web/src/components/chat/file-viewer.tsx
+++ b/apps/web/src/components/chat/file-viewer.tsx
@@ -56,11 +56,20 @@ type SignState =
   | { kind: 'error'; status: number; message: string }
   | { kind: 'ready'; url: string };
 
+// story #2781 — /api/attachments/sign은 BE 계약상 정확히 하나의 리소스 식별자(conversation_id|
+// story_id|asset_id)만 받는다(route.ts 실측). 채팅 첨부는 storedUrl+conversationId/storyId,
+// 스토리지 asset은 assetId 하나로 충분(path 불요 — BE가 asset registry에서 {container,
+// object_path}를 권위 derive한다).
 async function signAttachment(target: AttachmentTarget, disposition: 'inline' | 'attachment'): Promise<SignState> {
   try {
-    const params = new URLSearchParams({ path: target.storedUrl, disposition });
-    if (target.conversationId) params.set('conversation_id', target.conversationId);
-    else if (target.storyId) params.set('story_id', target.storyId);
+    const params = new URLSearchParams({ disposition });
+    if (target.assetId) {
+      params.set('asset_id', target.assetId);
+    } else if (target.storedUrl) {
+      params.set('path', target.storedUrl);
+      if (target.conversationId) params.set('conversation_id', target.conversationId);
+      else if (target.storyId) params.set('story_id', target.storyId);
+    }
     const res = await fetchWithAuth(`/api/attachments/sign?${params.toString()}`);
     if (res.status === 403) return { kind: 'denied' };
     const json = (await res.json().catch(() => null)) as { data?: { url?: string }; error?: { message?: string } } | null;

--- a/apps/web/src/components/chat/reading-panel.tsx
+++ b/apps/web/src/components/chat/reading-panel.tsx
@@ -4,19 +4,23 @@ import { EntityPreviewModal } from '@/components/chat/embed-card';
 import { FileViewer } from '@/components/chat/file-viewer';
 
 /**
- * story #2766(레인 A)·#2780(엔티티 확장) — 채팅을 벗어나지 않는 우측 리딩 패널의 대상 2형태.
- * ①엔티티 읽기 뷰(story/epic/doc/hypothesis/artifact/task/sprint — EntityPreviewModal embedded
- * 재사용, 타입별 분기는 그 내부(EntityDetail)에만 있다) ②채팅 첨부(FileViewer).
+ * story #2766(레인 A)·#2780(엔티티 확장)·#2781(asset 편입) — 채팅을 벗어나지 않는 우측 리딩
+ * 패널의 대상 2형태. ①엔티티 읽기 뷰(story/epic/doc/hypothesis/artifact/task/sprint —
+ * EntityPreviewModal embedded 재사용, 타입별 분기는 그 내부(EntityDetail)에만 있다) ②파일류
+ * (FileViewer) — 채팅 첨부(storedUrl+conversationId/storyId)와 스토리지 asset(assetId) 둘 다
+ * 이 kind 하나로 들어온다. sign 방식만 다르다(파일 signer가 정확히 하나만 요구·file-viewer.tsx
+ * signAttachment 참고) — 소비부(FileViewer 본체)는 동일.
  */
 export type ReadingPanelTarget =
   | { kind: 'entity'; entityType: string; entityId: string; title: string | null; status: string | null; href: string | null }
   | {
       kind: 'attachment';
-      storedUrl: string;
-      conversationId?: string;
-      storyId?: string;
       label: string;
       contentType?: string | null;
+      storedUrl?: string;
+      conversationId?: string;
+      storyId?: string;
+      assetId?: string;
     };
 
 /**


### PR DESCRIPTION
## 요약
- #2766(첨부 리딩 패널)·#2780(엔티티 임베드 패널 통합)이 확立한 "채팅을 벗어나지 않는다" 원칙의 마지막 사각(#2780 AC 리뷰 중 발견) 처리
- asset 임베드는 `EmbedCard`가 아니라 별도 컴포넌트(`asset-embed-card.tsx`)로 렌더되어 이전엔 클릭 시 `/storage?asset=` 이탈이었음 — 이제 우측 ReadingPanel의 FileViewer로 인앱 열람

## 구현
- `reading-panel.tsx`: `ReadingPanelTarget`의 `attachment` kind에 `assetId?` 추가(`storedUrl`은 optional로 완화) — 채팅 첨부와 스토리지 asset이 같은 kind로 FileViewer에 들어옴
- `file-viewer.tsx`: `signAttachment`가 BE 계약(`conversation_id`|`story_id`|`asset_id` 중 정확히 하나)을 따라 `assetId` 우선 분기
- `asset-embed-card.tsx`: `onOpenReadingPanel` prop 추가 — 제공 시(채팅) 클릭이 패널을 열고, 미제공(채팅 밖 호출부)이면 기존 `<Link>` 그대로(회귀 0)
- `chat-bubble.tsx`: 호출부에 콜백 전달(이미 의존성 배열에 있어 추가 배선 불요)

## 검증
- `pnpm type-check` / vitest 전체(3629개 PASS) / `pnpm lint` / `pnpm build` 전부 clean
- 라이브 픽셀 검증 진행 예정(실 asset — qa-android-2765-test.txt로 클릭→패널 오픈 확認)

## 게이트
PO AC 리뷰 → 유나 design → 카디르 QA → 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)