### PR TITLE
feat(#2786): 공유 실PG를 부수는 테스트 SQL 정적 가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,6 +551,22 @@ jobs:
         working-directory: backend
         run: python3 scripts/lint_commit_before_validate.py
 
+  # story #2786(2026-08-19, PR#3088 DROP SCHEMA 906건 연쇄·PR#3217 DELETE FROM 26건 연쇄
+  # — 같은 클래스 3일 내 2회) — 공유 실PG를 부수는 테스트 SQL 리터럴(WHERE 없는 DELETE FROM·
+  # DROP SCHEMA·DROP TABLE·TRUNCATE)을 커밋 시점에 잡는다. 스크립트 docstring(scripts/
+  # lint_destructive_test_sql.py) 참조 — baseline 없음(도입 시점 위반 0건, destructive_schema
+  # 마커 파일은 story #2293 격리 shard에서 돌아 스캔 대상에서 제외).
+  destructive-test-sql-lint:
+    name: destructive test SQL lint (guard, story #2786)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Scan tests/ for shared-DB-destroying SQL literals (bare DELETE/DROP/TRUNCATE)
+        working-directory: backend
+        run: python3 scripts/lint_destructive_test_sql.py
+
   # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라
   # main이 develop과 다른 파일셋(ee_pricing 0146/0147 부재)일 때의 그래프 단절을 원천적으로
   # 못 잡는다(실제로 못 잡아서 prod 승격이 롤백된 그 사고). PR base가 main일 때만 도는 이

--- a/backend/scripts/lint_destructive_test_sql.py
+++ b/backend/scripts/lint_destructive_test_sql.py
@@ -50,6 +50,14 @@
 ⛔baseline 없음 — 이 가드 도입 시점(2026-08-19) 스윕으로 기존 위반 전부 정리(WHERE 없는
    DELETE/무마커 DROP·TRUNCATE 0건 확認 후 켰다). #2459 commit-before-validate와 같은 계약
    ("baseline 없음" = 지금 위반이 있으면 그것도 즉시 FAIL, 봐주는 게 없다).
+
+⛔재QA 1라운드(2026-08-19, PR#3221 — 디디 독립검증→PO 격상): 초판이 `TESTS_DIR.glob("*.py")`
+   (top-level만)를 써서 `tests/mcp/`(8파일) 등 서브디렉토리가 스캔 밖이었는데, pytest 자신은
+   `tests/` 하위를 재귀 실행한다 — 그 하위 파일이 위반을 갖고 있어도 이 가드는 「OK: 0건」이라는
+   **거짓 안전 신호**를 냈다("가드가 자기 재료를 못 찾으면 빨강" 원칙의 변형 — 안 본 걸 본 것처럼
+   찍는 게 이 가드가 잡으려는 바로 그 클래스). fix: `glob`→`rglob`(재귀)+출력에 "스캔 파일 N개"
+   명시(카디르 mobile#61 QA가 요구한 "비교/스킵 계수" 규율과 동형 — 스캔 모수가 줄면 눈에
+   보이게)+서브디렉토리 위반 양성대조 테스트 추가.
 """
 from __future__ import annotations
 
@@ -156,15 +164,26 @@ def find_violations(path: Path) -> list[tuple[str, int, str]]:
     return violations
 
 
-def scan_repo() -> list[tuple[str, int, str]]:
+def scan_dir(root: Path) -> tuple[list[tuple[str, int, str]], int]:
+    """(violations, scanned_file_count). rglob — pytest는 tests/ 하위 서브디렉토리(예: tests/mcp/)
+    까지 재귀 실행하는데(story #2786 재QA, PO 격상 — 디디 3221 fix), 이전 버전이 top-level
+    glob만 써서 그 하위 파일들이 스캔 밖인데 pytest는 도는 «거짓 안전 신호»였다. «가드가 자기
+    재료를 못 찾으면 빨강» 원칙의 변형 — 안 본 걸 본 것처럼 찍는 게 이 가드가 잡으려는 바로
+    그 클래스다."""
     violations = []
-    for path in sorted(TESTS_DIR.glob("*.py")):
+    files = sorted(root.rglob("*.py"))
+    for path in files:
         violations.extend(find_violations(path))
-    return violations
+    return violations, len(files)
+
+
+def scan_repo() -> tuple[list[tuple[str, int, str]], int]:
+    return scan_dir(TESTS_DIR)
 
 
 def main() -> int:
-    violations = scan_repo()
+    violations, scanned = scan_repo()
+    print(f"스캔 파일 {scanned}개(tests/ 재귀)")
     if violations:
         print(f"FAIL: 공유 실PG를 부술 수 있는 테스트 SQL 리터럴 {len(violations)}건 발견")
         print("story #2786 판정: WHERE 없는 DELETE FROM / DROP SCHEMA·DROP TABLE·TRUNCATE는")

--- a/backend/scripts/lint_destructive_test_sql.py
+++ b/backend/scripts/lint_destructive_test_sql.py
@@ -1,0 +1,181 @@
+"""story #2786 — 「공유 실PG를 부수는 테스트 연산」정적 가드. CI가 커밋 시점에 잡는다.
+
+배경(2026-08-18 — 같은 클래스 3일 내 2회):
+- 08-16 PR 3088: pytester가 복사한 conftest의 autouse 스키마리셋이 CI 공유 DB에
+  `DROP SCHEMA` → 906건 연쇄(story #2662).
+- 08-18 PR 3217: 신설 realdb 테스트 autouse가 WHERE 없는
+  `DELETE FROM offering_versions`(migration 0228 공유 seed) → 무관 26건 연쇄(story #2777).
+공통 구조: 로컬(개인 disposable DB)에선 안 잡히고 CI(공유 실PG·알파벳 순서 실행)에서만
+터진다 — 「검사를 어디서 돌렸나」 맹점. 두 사고 모두 실행 **전에** 잡을 방법이 없었다:
+`pytest_collection_modifyitems`(conftest.py, story #2643)의 `_calls_raw_ddl_literal`은
+`DROP/CREATE/TRUNCATE/ALTER TABLE`만 보고 `DELETE`는 안 본다 — PR#3217급 사고를 원천적으로
+못 잡는 사각이었다. 이 가드가 그 사각을 메운다.
+
+⛔`destructive_schema` 마커 파일은 스캔 대상에서 뺀다(오탐 방지 — 최초 스윕에서 32건이
+   여기 걸렸다가 전부 이 이유로 제외됨을 실측): story #2293(2026-07-28)이 이미 이 마커가
+   붙은 파일을 CI `Backend destructive-schema (shard)` job으로 **파일마다 완전히 새로운
+   격리 DB**를 붙여 돌리도록 구조화해놨다(`ci.yml` "isolated fresh DB per file, this
+   shard") — 그 안에서의 DROP/TRUNCATE/무WHERE DELETE는 다른 어떤 테스트도 공유하지
+   않는 자기 전용 DB만 건드리므로 **이 스토리가 막으려는 위험(공유 CI DB 오염) 자체가
+   구조적으로 성립하지 않는다**. 이 가드는 정확히 그 마커가 **없는데** 파괴적 SQL을 쓰는
+   파일 — 즉 공유 메인 pytest job(`-m "not destructive_schema"`)에서 도는데 위험한 SQL을
+   쓰는 파일만 잡는다(PR#3217이 정확히 이 케이스 — 마커 없이 신설 realdb 테스트가 공유
+   DB에서 돌았다).
+
+⛔무엇을 잡는가(conftest.py `_calls_raw_ddl_literal`과 같은 원리 — `text(...)`/`.execute(...)`
+로 **직접 전달된 문자열 리터럴**만 본다, docstring/주석 프로즈 오탐 방지, story #2643 교훈):
+  ① `DROP SCHEMA`/`DROP TABLE`/`TRUNCATE` — 무조건(WHERE라는 개념 자체가 없다).
+  ② `DELETE FROM <table>` — 같은 문자열 리터럴 안에 `WHERE`가 없으면(테이블 전체 삭제).
+     PR#3217 원문(`DELETE FROM offering_versions`, WHERE 없음)이 바로 이 케이스.
+     WHERE가 있으면(예: `DELETE FROM org_members WHERE org_id=:o`) — 테스트가 만든 자기
+     데이터만 지우는 정상 self-cleanup 관례이므로 통과(백엔드 테스트 전역 그라운딩 실측:
+     WHERE절 있는 DELETE FROM 90여 자리 전부 이 패턴).
+
+⛔예외(마커) — 정말 필요한 자리는 같은 줄 또는 바로 윗줄에 `# destructive-sql-allow: <사유>`
+   주석이 있으면 통과. conftest.py의 `_reset_public_schema()`(story #2662, `assert_
+   disposable_test_db()`로 런타임 이중가드된 유일한 정당한 DROP SCHEMA)가 그 예.
+
+⛔이 가드가 **못 잡는 것**(story #2786 요구사항 — 선언):
+  · SQLAlchemy ORM 삭제(`session.execute(delete(Model))`, `Query.delete()`) — 문자열
+    리터럴이 아니라 API 호출이라 이 스캐너의 대상 밖(별도 클래스 — ORM delete는 프레임워크가
+    자동으로 조건절을 강제하지 않는 한 grep 불가능한 형태로 무한히 다양하다).
+  · f-string/`.format()`/`+` 로 **동적 조립**된 SQL 문자열(예: `f"DELETE FROM {t}"`) — AST
+    리터럴이 아니라서 파싱 시점에 값이 없다(conftest.py #2643 교훈과 동일 계층의 사각 —
+    데이터흐름분석 없인 못 본다, 비용 대비 이득 밖).
+  · `text`/`execute`가 아닌 다른 이름으로 wrapping된 실행 경로(`conn.exec_driver_sql` 등,
+    1-hop 이상 간접 경로).
+  다음에 이 사각을 밟는 사람이 있다면 그게 이 판단이 틀렸다는 신호이니 그때 확장한다
+  (conftest.py #2643 docstring과 동일한 원칙).
+
+⛔baseline 없음 — 이 가드 도입 시점(2026-08-19) 스윕으로 기존 위반 전부 정리(WHERE 없는
+   DELETE/무마커 DROP·TRUNCATE 0건 확認 후 켰다). #2459 commit-before-validate와 같은 계약
+   ("baseline 없음" = 지금 위반이 있으면 그것도 즉시 FAIL, 봐주는 게 없다).
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).parent.parent / "tests"
+
+_SQL_EXEC_CALL_NAMES = {"text", "execute"}
+_UNCONDITIONAL_RE = re.compile(r"\b(DROP\s+SCHEMA|DROP\s+TABLE|TRUNCATE)\b", re.IGNORECASE)
+_DELETE_RE = re.compile(r"\bDELETE\s+FROM\s+\S+", re.IGNORECASE)
+_WHERE_RE = re.compile(r"\bWHERE\b", re.IGNORECASE)
+_ALLOW_MARKER_RE = re.compile(r"#\s*destructive-sql-allow\s*:")
+
+
+def _call_func_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _is_destructive_literal(value: str) -> tuple[bool, str] | None:
+    """(위반여부, 사유) — value가 파괴적 SQL 리터럴이면 사유 문자열과 함께 반환, 아니면 None."""
+    if _UNCONDITIONAL_RE.search(value):
+        return True, "DROP SCHEMA/DROP TABLE/TRUNCATE — 무조건 위반"
+    if _DELETE_RE.search(value) and not _WHERE_RE.search(value):
+        return True, "DELETE FROM ... — WHERE절 없음(테이블 전체 삭제)"
+    return None
+
+
+def _has_allow_marker(lines: list[str], lineno: int) -> bool:
+    """1-index lineno의 같은 줄 또는 바로 윗줄에 destructive-sql-allow 마커가 있는지."""
+    for candidate in (lineno - 1, lineno - 2):  # 0-index: 같은 줄, 윗줄
+        if 0 <= candidate < len(lines) and _ALLOW_MARKER_RE.search(lines[candidate]):
+            return True
+    return False
+
+
+def _is_destructive_schema_mark(node: ast.AST) -> bool:
+    """`pytest.mark.destructive_schema` 형태의 Attribute 체인인지(장식자·pytestmark 대입 공용)."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "destructive_schema"
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "mark"
+    )
+
+
+def _has_destructive_schema_marker(tree: ast.AST) -> bool:
+    """파일이 `pytestmark = pytest.mark.destructive_schema`(모듈레벨) 또는
+    `@pytest.mark.destructive_schema`(함수 데코레이터) 중 하나라도 가지면 True.
+
+    story #2293이 이 마커 파일을 CI `Backend destructive-schema (shard)` job으로
+    «파일마다 격리된 fresh DB»에서 돌리도록 이미 구조화해뒀다 — 그 격리 안에서는
+    DROP/TRUNCATE/무WHERE DELETE가 이 스토리가 막으려는 위험(공유 CI DB 오염)을
+    구조적으로 못 만든다. conftest.py의 `pytest_collection_modifyitems`(story #2643)가
+    이 마커 유무로 이미 같은 판별을 하고 있어(파일이 raw DDL 리터럴을 쓰는데 마커가
+    없으면 collection 시점에 즉시 UsageError) — 그 판별축과 동일한 신호를 재사용한다.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and _is_destructive_schema_mark(node.value):
+            return True
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for deco in node.decorator_list:
+                target = deco.func if isinstance(deco, ast.Call) else deco
+                if _is_destructive_schema_mark(target):
+                    return True
+    return False
+
+
+def find_violations(path: Path) -> list[tuple[str, int, str]]:
+    """(file, lineno, reason) — text()/execute()로 실행되는 파괴적 SQL 리터럴(마커 없는 것만).
+
+    destructive_schema 마커 파일은 스캔 자체를 스킵한다(위 docstring 참조 — 격리 shard에서
+    돌아 이 스토리가 막으려는 위험이 구조적으로 성립 안 함)."""
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+    if _has_destructive_schema_marker(tree):
+        return []
+    lines = source.splitlines()
+    violations: list[tuple[str, int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or _call_func_name(node) not in _SQL_EXEC_CALL_NAMES:
+            continue
+        for arg in list(node.args) + [kw.value for kw in node.keywords]:
+            if not (isinstance(arg, ast.Constant) and isinstance(arg.value, str)):
+                continue
+            verdict = _is_destructive_literal(arg.value)
+            if verdict is None:
+                continue
+            _, reason = verdict
+            if _has_allow_marker(lines, arg.lineno):
+                continue
+            violations.append((str(path), arg.lineno, reason))
+    return violations
+
+
+def scan_repo() -> list[tuple[str, int, str]]:
+    violations = []
+    for path in sorted(TESTS_DIR.glob("*.py")):
+        violations.extend(find_violations(path))
+    return violations
+
+
+def main() -> int:
+    violations = scan_repo()
+    if violations:
+        print(f"FAIL: 공유 실PG를 부술 수 있는 테스트 SQL 리터럴 {len(violations)}건 발견")
+        print("story #2786 판정: WHERE 없는 DELETE FROM / DROP SCHEMA·DROP TABLE·TRUNCATE는")
+        print("공유 CI DB에서 무관 테스트를 연쇄로 깨뜨린다(PR#3088·PR#3217 실사고).")
+        print("정말 필요하면 같은 줄/윗줄에 `# destructive-sql-allow: <사유>` 마커를 다세요.")
+        for file, lineno, reason in violations:
+            print(f"  {file}:{lineno} — {reason}")
+        return 1
+    print("OK: 마커 없는 파괴적 테스트 SQL 리터럴 0건")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -129,6 +129,7 @@ def _reset_public_schema(url: str) -> None:
     engine = create_engine(_sync_url(url))
     try:
         with engine.begin() as conn:
+            # destructive-sql-allow: 위 assert_disposable_test_db() 이중가드 통과 후에만 도달(story #2786 정당 예외).
             conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
             conn.execute(text("CREATE SCHEMA public"))
             conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))

--- a/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
+++ b/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
@@ -33,6 +33,7 @@ _CI_OR_LOCAL_ONLY_ALLOWLIST = frozenset({
     "lint_candidate_source_ownership.py",         # story #2363 AC6 — CI lint 게이트
     "lint_commit_before_validate.py",             # story #2459 — CI lint 게이트(AST 정적분석, 운영 DB 무접속)
     "lint_dependency_override_get_read_db.py",    # story #2451 — CI lint 게이트(tests/ override 스캔, 운영 DB 무접속)
+    "lint_destructive_test_sql.py",               # story #2786 — CI lint 게이트(tests/ 재귀 AST 스캔, 운영 DB 무접속)
     "lint_project_access_403.py",                 # story #2342 AC7 — CI lint 게이트
     "lint_query_sentinel_direct_calls.py",        # story #2335 — CI lint 게이트
     "model_db_drift_audit.py",                    # story #2181 — 로컬 1회성 감사(읽기 전용)

--- a/backend/tests/test_2786_destructive_test_sql_lint.py
+++ b/backend/tests/test_2786_destructive_test_sql_lint.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-from lint_destructive_test_sql import find_violations  # noqa: E402
+from lint_destructive_test_sql import find_violations, scan_dir  # noqa: E402
 
 
 def _write(tmp_path: Path, name: str, source: str) -> Path:
@@ -45,6 +45,26 @@ def reset(conn):
     violations = find_violations(path)
     assert len(violations) == 1
     assert "무조건 위반" in violations[0][2]
+
+
+def test_positive_control_subdirectory_violation_is_scanned(tmp_path):
+    """story #2786 재QA(PO 격상, 디디 3221 fix) — pytest는 tests/ 하위 서브디렉토리(예:
+    tests/mcp/)까지 재귀 실행하는데, top-level glob만 쓰면 그 파일들이 스캔 밖인데 pytest는
+    도는 «거짓 안전 신호»가 된다. 이 테스트는 정확히 그 시나리오를 재현 — 하위 폴더의 위반이
+    scan_dir()에 실제로 잡히는지 고정한다."""
+    sub = tmp_path / "mcp"
+    sub.mkdir()
+    (sub / "__init__.py").write_text("")
+    src = '''
+async def cleanup(session):
+    await session.execute(text("DELETE FROM webhook_events"))
+'''
+    _write(sub, "test_nested_bad.py", src)
+    violations, scanned = scan_dir(tmp_path)
+    assert scanned == 2  # __init__.py + test_nested_bad.py
+    assert len(violations) == 1
+    assert "WHERE절 없음" in violations[0][2]
+    assert "mcp" in violations[0][0]  # 서브디렉토리 경로가 보고에 실제로 찍히는지
 
 
 # ── 음성대조: 정상 관례는 통과 ──────────────────────────────────────────────

--- a/backend/tests/test_2786_destructive_test_sql_lint.py
+++ b/backend/tests/test_2786_destructive_test_sql_lint.py
@@ -1,0 +1,155 @@
+"""story #2786 — lint_destructive_test_sql.py의 정탐/오탐 회귀 가드. 실물 파일이 아니라
+합성 fixture로 짓는다(실물이 고쳐져도 이 테스트는 안 사라진다, story #2335/#2342 lint와 동형).
+
+양성대조 2종은 사고 «원문 그대로»(PR#3088 DROP SCHEMA·PR#3217 DELETE FROM)를 fixture화한다."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from lint_destructive_test_sql import find_violations  # noqa: E402
+
+
+def _write(tmp_path: Path, name: str, source: str) -> Path:
+    p = tmp_path / name
+    p.write_text(source)
+    return p
+
+
+# ── 양성대조: 두 사고 원문 그대로 ──────────────────────────────────────────
+
+def test_positive_control_pr3217_delete_without_where(tmp_path):
+    """PR#3217 원문(story #2777) — WHERE 없는 DELETE FROM offering_versions, autouse fixture 안."""
+    src = '''
+import pytest
+
+@pytest.fixture(autouse=True)
+async def _seed(session):
+    await session.execute(text("DELETE FROM offering_versions"))
+    yield
+'''
+    path = _write(tmp_path, "test_bad_3217.py", src)
+    violations = find_violations(path)
+    assert len(violations) == 1
+    assert "WHERE절 없음" in violations[0][2]
+
+
+def test_positive_control_pr3088_drop_schema(tmp_path):
+    """PR#3088 원문(story #2662) — destructive_schema 마커 없는 임의 파일의 DROP SCHEMA."""
+    src = '''
+def reset(conn):
+    conn.execute(text("DROP SCHEMA public CASCADE"))
+'''
+    path = _write(tmp_path, "test_bad_3088.py", src)
+    violations = find_violations(path)
+    assert len(violations) == 1
+    assert "무조건 위반" in violations[0][2]
+
+
+# ── 음성대조: 정상 관례는 통과 ──────────────────────────────────────────────
+
+def test_negative_control_on_conflict_seed_pattern_passes(tmp_path):
+    """ON CONFLICT DO NOTHING seed(예: test_2776 _seed_offering()류) — DELETE/DROP/TRUNCATE
+    자체가 없어 이 가드의 정규식과 애초에 매치하지 않는다(파괴적 연산이 아니므로 당연 통과)."""
+    src = '''
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+async def seed(session, tier):
+    stmt = pg_insert(OfferingVersion).values(tier=tier).on_conflict_do_nothing(
+        index_elements=["tier", "currency"],
+    )
+    await session.execute(stmt)
+'''
+    path = _write(tmp_path, "test_seed_ok.py", src)
+    assert find_violations(path) == []
+
+
+def test_negative_control_where_scoped_delete_passes(tmp_path):
+    """WHERE로 자기 데이터만 지우는 self-cleanup 관례(백엔드 테스트 90여 자리 실측 패턴) — 통과."""
+    src = '''
+async def cleanup(session, org_id):
+    await session.execute(text("DELETE FROM org_members WHERE org_id=:o"), {"o": org_id})
+'''
+    path = _write(tmp_path, "test_cleanup_ok.py", src)
+    assert find_violations(path) == []
+
+
+def test_negative_control_destructive_schema_module_marker_exempts_file(tmp_path):
+    """pytestmark = pytest.mark.destructive_schema — story #2293 격리 shard에서 도니 통과."""
+    src = '''
+import pytest
+
+pytestmark = pytest.mark.destructive_schema
+
+
+def test_rebuild(conn):
+    conn.execute(text("DROP TABLE IF EXISTS scratch"))
+    conn.execute(text("TRUNCATE workflow_line_step_runs CASCADE"))
+'''
+    path = _write(tmp_path, "test_isolated_ok.py", src)
+    assert find_violations(path) == []
+
+
+def test_negative_control_destructive_schema_function_decorator_exempts_file(tmp_path):
+    """함수 데코레이터 형태(@pytest.mark.destructive_schema)도 모듈 대입과 동일하게 통과."""
+    src = '''
+import pytest
+
+@pytest.mark.destructive_schema
+def test_rebuild(conn):
+    conn.execute(text("TRUNCATE gate CASCADE"))
+'''
+    path = _write(tmp_path, "test_isolated_deco_ok.py", src)
+    assert find_violations(path) == []
+
+
+def test_negative_control_explicit_allow_marker_exempts_line(tmp_path):
+    """destructive_schema 마커 없는 파일이라도 명시 사유 마커가 있으면 그 줄만 통과."""
+    src = '''
+def reset(conn):
+    # destructive-sql-allow: 이미 위에서 assert_disposable_test_db()로 검증된 자리
+    conn.execute(text("DROP SCHEMA public CASCADE"))
+'''
+    path = _write(tmp_path, "test_marked_ok.py", src)
+    assert find_violations(path) == []
+
+
+def test_allow_marker_only_covers_its_own_line(tmp_path):
+    """마커가 붙은 줄만 면제 — 같은 파일의 다른 무마커 위반은 여전히 잡힌다."""
+    src = '''
+def reset(conn):
+    # destructive-sql-allow: 이 줄만 봐준다
+    conn.execute(text("DROP SCHEMA public CASCADE"))
+    conn.execute(text("DELETE FROM users"))
+'''
+    path = _write(tmp_path, "test_partial_marked.py", src)
+    violations = find_violations(path)
+    assert len(violations) == 1
+    assert "WHERE절 없음" in violations[0][2]
+
+
+# ── 선언된 사각(못 잡는 것) — 문서화된 한계가 실제로 안 잡힌다는 걸 자기증명 ──
+
+def test_declared_blind_spot_fstring_delete_is_silently_not_caught(tmp_path):
+    """f-string 동적조립 DELETE — AST 리터럴이 아니라 이 가드가 원천적으로 못 본다(문서화된
+    한계, story #2643과 동일 계층). 이 테스트는 «못 잡는다»는 사실 자체를 고정한다 —
+    누군가 이 가드를 고쳐 잡게 만들면 이 테스트가 실패해 그 확장을 표면화한다."""
+    src = '''
+def cleanup(conn, table):
+    conn.execute(text(f"DELETE FROM {table}"))
+'''
+    path = _write(tmp_path, "test_fstring_blindspot.py", src)
+    assert find_violations(path) == []
+
+
+def test_declared_blind_spot_orm_delete_is_silently_not_caught(tmp_path):
+    """ORM delete() 호출 — 문자열 리터럴이 아니라 이 스캐너의 대상 밖(문서화된 한계)."""
+    src = '''
+from sqlalchemy import delete
+
+async def cleanup(session):
+    await session.execute(delete(Model))
+'''
+    path = _write(tmp_path, "test_orm_blindspot.py", src)
+    assert find_violations(path) == []


### PR DESCRIPTION
## Summary
- 배경(같은 클래스 3일 내 2회): PR#3088 DROP SCHEMA 906건 연쇄(#2662)·PR#3217 WHERE없는 DELETE FROM 26건 연쇄(#2777). 둘 다 로컬(disposable DB)에선 안 잡히고 CI(공유 실PG)에서만 터졌다 — 「검사를 어디서 돌렸나」 맹점, 실행 전에 잡을 방법이 없었다.
- `scripts/lint_destructive_test_sql.py`(신설): `text()`/`.execute()` 인자로 전달된 문자열 리터럴에서 `DROP SCHEMA`/`DROP TABLE`/`TRUNCATE`(무조건)·WHERE 없는 `DELETE FROM`을 스캔. `destructive_schema` 마커 파일(story #2293이 CI `Backend destructive-schema (shard)` job에서 파일마다 격리된 fresh DB로 돌리도록 이미 구조화 — 실측 32개 파일)은 스캔 대상에서 제외한다: 그 격리 안에서는 이 스토리가 막으려는 위험(공유 CI DB 오염) 자체가 구조적으로 성립하지 않는다. `# destructive-sql-allow: <사유>` 인라인 마커로 정당한 예외를 허용한다.
- `conftest.py`: 유일한 실제 예외(`_reset_public_schema()`의 `DROP SCHEMA`, 이미 `assert_disposable_test_db()`로 런타임 이중가드됨)에 마커 부착.
- `test_2786_destructive_test_sql_lint.py`(신설): 양성대조 2종(PR#3088·PR#3217 사고 **원문 그대로**)+음성대조(ON CONFLICT seed 패턴·WHERE스코프 DELETE·destructive_schema 마커 파일 2가지 형태·명시 allow 마커·마커가 자기 줄만 면제하는지)+선언된 사각(f-string 동적조립 DELETE·ORM delete() — "못 잡는다"는 사실 자체를 고정) 10개 테스트.
- `ci.yml`: `destructive-test-sql-lint` job 신설(baseline 없음 — 도입 시점 전체 스윕으로 위반 0건 확인 후 켰다, #2459 commit-before-validate와 같은 계약).

## 검증
- [x] 신규 가드를 저장소 전체(`backend/tests/*.py`)에 실행 → 최초 32건 발견(전부 destructive_schema 마커 파일의 정상 격리 연산) → 마커 인식 로직 추가 후 1건(conftest.py의 정당한 예외)만 남음 → 마커 부착 후 0건.
- [x] `pytest tests/test_2786_destructive_test_sql_lint.py` 10/10 PASS.
- [x] 기존 관련 가드(`test_2643_destructive_schema_ddl_guard.py`·`test_schema_reset_safety_guard.py`) 무회귀(36/36 PASS, conftest.py 코멘트 1줄 추가만이라 영향 없음 확인).
- [x] `pytest --collect-only` 전체 스위트(7480건) 무결(신규 파일 추가로 인한 import 회귀 없음).
- [x] `python3 -m py_compile` 클린.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"`로 ci.yml 문법 검증.

## 스코프 밖(명시)
- SQLAlchemy ORM `delete()` 호출, f-string/`.format()` 동적조립 SQL — 문서화된 선언 한계(테스트로 고정, story #2643과 동일 원칙).
- `text`/`execute`가 아닌 이름으로 감싸진 1-hop 이상 간접 실행 경로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)