### PR TITLE
feat(#2771): pptx 서버 변환 백엔드 파이프 — Gotenberg 자체호스팅

### DIFF
--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -227,7 +227,10 @@ async def convert_attachment(
     if asset.project_id is not None and not await has_project_access(
         db, uuid.UUID(auth.user_id), asset.project_id, org_id
     ):
-        raise HTTPException(status_code=403, detail="No access to this project")
+        # story #2342(존재 비노출) — has_project_access 거부는 항상 404(CI lint_project_access_403.py
+        # 가 403을 신규 위반으로 잡는다). authorize_attachment의 asset_id 분기(위)는 이 파일이
+        # 통째로 grandfather 베이스라인에 있어 403이지만, 이건 신규 코드라 정공법(404)으로 낸다.
+        raise HTTPException(status_code=404, detail="Asset not found")
 
     if not office_conversion.is_convertible(asset.name, asset.content_type):
         raise HTTPException(status_code=422, detail="Asset is not a convertible office document")

--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -23,6 +23,7 @@ from app.dependencies.database import get_db
 from app.models.asset import Asset, AssetLink
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.pm import Story
+from app.services import office_conversion
 from app.services.asset_registry import canonical_object_path as _canonical_object_path
 from app.services.asset_registry import path_in_source_scope
 from app.services.member_resolver import resolve_member
@@ -196,3 +197,50 @@ async def authorize_attachment(
             raise HTTPException(status_code=403, detail="Attachment does not belong to this story")
 
     return {"authorized": True}
+
+
+@router.post("/{asset_id}/convert")
+async def convert_attachment(
+    asset_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """POST /api/v2/attachments/{asset_id}/convert — office(pptx) 첨부 → pdf 변환(story #2771).
+
+    열람 시(lazy) 트리거 — FE가 뷰어를 열 때 호출, 최초 1회만 실 변환하고 이후는 캐시(§7-2,
+    doc 84ef0cb7). authz는 `/authorize`의 asset_id 분기와 **동일**(org 매치 + has_project_access,
+    project_id NULL이면 org-level) — 변환 산출물도 원본과 동일한 org/project 경계에 생성되므로
+    이 게이트 하나로 원본·변환물 둘 다 커버한다(타 org 토큰은 애초에 org_id 필터에서 404).
+
+    변환 asset은 AssetLink 를 만들지 않는다(orphan) — FE는 반환된 `asset_id`로 기존
+    `/api/attachments/sign?asset_id=` → 이 라우터의 `/authorize` asset_id 분기를 그대로 타면
+    된다(link 0건이면 tombstone 체크를 스킵하고 통과하는 기존 로직 재사용, 신규 게이트 불요).
+    """
+    asset = (await db.execute(
+        select(Asset).where(
+            Asset.id == asset_id, Asset.org_id == org_id, Asset.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    if asset.project_id is not None and not await has_project_access(
+        db, uuid.UUID(auth.user_id), asset.project_id, org_id
+    ):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    if not office_conversion.is_convertible(asset.name, asset.content_type):
+        raise HTTPException(status_code=422, detail="Asset is not a convertible office document")
+
+    try:
+        converted = await office_conversion.get_or_convert_pdf(db, source_asset=asset)
+    except office_conversion.ConversionUnavailable as exc:
+        raise HTTPException(status_code=503, detail="conversion service not configured") from exc
+    except office_conversion.ConversionFailed as exc:
+        raise HTTPException(status_code=502, detail="conversion failed") from exc
+
+    return {
+        "asset_id": str(converted.id),
+        "name": converted.name,
+        "content_type": converted.content_type,
+    }

--- a/backend/app/services/office_conversion.py
+++ b/backend/app/services/office_conversion.py
@@ -84,6 +84,12 @@ async def _call_gotenberg(filename: str, data: bytes) -> bytes:
             raise ConversionFailed(f"gotenberg request error: {exc}") from exc
     if resp.status_code != 200:
         raise ConversionFailed(f"gotenberg returned {resp.status_code}")
+    # ⛔QA catch(카디르군, 2026-08-19) — 200이어도 body가 PDF가 아닌 응답(에러 페이지류 등
+    # 프록시/게이트웨이 오탐)이 오면 검증 없이 캐시하는 순간 영구 오염된다(§7-2 캐시는
+    # 결정적 path라 재변환 트리거 자체가 없어 다음 열람마다 그 오염을 계속 서빙). 저장 前
+    # 최소 가드: 비어있지 않음 + `%PDF-` 매직 프리픽스.
+    if not resp.content.startswith(b"%PDF-"):
+        raise ConversionFailed("gotenberg response is not a valid PDF (missing %PDF- magic)")
     return resp.content
 
 

--- a/backend/app/services/office_conversion.py
+++ b/backend/app/services/office_conversion.py
@@ -1,0 +1,158 @@
+"""pptx 서버 변환 — Gotenberg 자체호스팅 파이프 (#2771).
+
+story #2771 §7 구현 그라운딩(doc 84ef0cb7) 결정 반영:
+- 트리거 = 열람 시(lazy) + 결정적 object_path 캐시. `assets` 테이블 기존 멱등 upsert
+  유니크 인덱스(org+project+container+object_path)가 캐시 키 역할을 그대로 한다 —
+  신규 스키마 불요.
+- 입력 = raw bytes multipart POST. Gotenberg에 URL을 주지 않는다(스스로 fetch 안 함) —
+  §3-A가 반복 지적한 SSRF CVE 클래스가 발동할 표면 자체가 없다.
+- 변환 결과 asset은 AssetLink 0건(orphan) — `/authorize`의 asset_id 분기가 link 0건이면
+  그대로 통과하는 기존 로직을 그대로 탄다(신규 인가 게이트 불요).
+
+⚠️ 배포 전제(인프라 lane): `GOTENBERG_SERVICE_URL` 미설정 시 변환은 `ConversionUnavailable`
+(호출부가 503으로 매핑) — 가짜 렌더 금지 원칙 유지, 인프라 배치 전엔 그냥 비활성.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.asset import Asset
+
+_GOTENBERG_URL = os.environ.get("GOTENBERG_SERVICE_URL", "").rstrip("/")
+_CONVERTIBLE_EXTS = frozenset({"pptx"})
+_TIMEOUT = httpx.Timeout(120.0)  # §7-4: 대형 pptx 변환 지연 흡수
+
+
+class ConversionUnavailable(Exception):
+    """GOTENBERG_SERVICE_URL 미배선."""
+
+
+class ConversionFailed(Exception):
+    """Gotenberg 변환 실패(비-2xx 응답/네트워크 오류)."""
+
+
+def _ext(name: str) -> str:
+    return name.rsplit(".", 1)[-1].lower() if "." in name else ""
+
+
+def is_convertible(name: str, content_type: str | None) -> bool:
+    """이 파이프가 다루는 형식인지 — 이 스토리 범위는 pptx만(docx는 클라이언트 렌더 별도 트랙)."""
+    return _ext(name) in _CONVERTIBLE_EXTS
+
+
+def converted_object_path(
+    org_id: uuid.UUID, project_id: uuid.UUID | None, source_asset_id: uuid.UUID
+) -> str:
+    """원본 asset id로부터 결정적 변환물 경로 — 캐시 키(§7-2)."""
+    proj_seg = str(project_id) if project_id is not None else "org"
+    return f"converted/{org_id}/{proj_seg}/{source_asset_id}.pdf"
+
+
+def _id_token_header() -> dict[str, str]:
+    """office-converter Cloud Run 서비스는 `--no-allow-unauthenticated`(§7-4) — 호출부가 자신의
+    런타임 SA로 audience=office-converter URL인 Google-서명 ID 토큰을 떠서 Authorization에
+    실어야 IAM 게이트를 통과한다. 로컬(ADC 미가용) 등에서 발급 실패 시 헤더 없이 진행(gotenberg가
+    403을 주면 ConversionFailed로 귀결 — best-effort가 아니라 정직한 실패)."""
+    try:
+        import google.auth.transport.requests
+        from google.oauth2 import id_token as _id_token
+
+        req = google.auth.transport.requests.Request()
+        token = _id_token.fetch_id_token(req, _GOTENBERG_URL)
+        return {"Authorization": f"Bearer {token}"}
+    except Exception:
+        return {}
+
+
+async def _call_gotenberg(filename: str, data: bytes) -> bytes:
+    if not _GOTENBERG_URL:
+        raise ConversionUnavailable("GOTENBERG_SERVICE_URL not configured")
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        try:
+            resp = await client.post(
+                f"{_GOTENBERG_URL}/forms/libreoffice/convert",
+                files={"files": (filename, data, "application/octet-stream")},
+                headers=_id_token_header(),
+            )
+        except httpx.HTTPError as exc:
+            raise ConversionFailed(f"gotenberg request error: {exc}") from exc
+    if resp.status_code != 200:
+        raise ConversionFailed(f"gotenberg returned {resp.status_code}")
+    return resp.content
+
+
+def _pdf_name(source_name: str) -> str:
+    stem = source_name.rsplit(".", 1)[0] if "." in source_name else source_name
+    return f"{stem}.pdf"
+
+
+async def get_or_convert_pdf(db: AsyncSession, *, source_asset: Asset) -> Asset:
+    """source_asset(pptx) → 변환된 pdf Asset(캐시 hit 또는 변환).
+
+    호출부가 authz(org 매치 + has_project_access)를 이미 통과시킨 asset만 넘길 것 — 이 함수는
+    authz를 하지 않는다(라우터 책임, asset_registry.py 패턴과 동일 관심사 분리).
+    """
+    container = source_asset.container
+    obj_path = converted_object_path(source_asset.org_id, source_asset.project_id, source_asset.id)
+
+    def _select_cached():
+        sel = select(Asset).where(
+            Asset.org_id == source_asset.org_id,
+            Asset.container == container,
+            Asset.object_path == obj_path,
+            Asset.deleted_at.is_(None),
+        )
+        return sel.where(
+            Asset.project_id == source_asset.project_id
+            if source_asset.project_id is not None
+            else Asset.project_id.is_(None)
+        )
+
+    cached = (await db.execute(_select_cached())).scalar_one_or_none()
+    if cached is not None:
+        return cached
+
+    # call-time import(asset_registry.py와 동일 관례) — 테스트가 `app.services.storage.
+    # get_storage_provider`를 monkeypatch 하면 이 호출이 그대로 mock 을 픽업한다.
+    from app.services.storage import get_storage_provider
+
+    provider = get_storage_provider()
+    source_bytes = await provider.download_object(container, source_asset.object_path)
+    pdf_bytes = await _call_gotenberg(source_asset.name, source_bytes)
+
+    if not await provider.put_object(container, obj_path, pdf_bytes, content_type="application/pdf"):
+        raise ConversionFailed("failed to store converted pdf")
+
+    ins = pg_insert(Asset).values(
+        org_id=source_asset.org_id,
+        project_id=source_asset.project_id,
+        container=container,
+        object_path=obj_path,
+        name=_pdf_name(source_asset.name),
+        content_type="application/pdf",
+        size_bytes=len(pdf_bytes),
+        created_by=None,
+    )
+    if source_asset.project_id is not None:
+        ins = ins.on_conflict_do_nothing(
+            index_elements=[Asset.org_id, Asset.project_id, Asset.container, Asset.object_path],
+            index_where=Asset.project_id.isnot(None),
+        ).returning(Asset.id)
+    else:
+        ins = ins.on_conflict_do_nothing(
+            index_elements=[Asset.org_id, Asset.container, Asset.object_path],
+            index_where=Asset.project_id.is_(None),
+        ).returning(Asset.id)
+    asset_id = (await db.execute(ins)).scalar_one_or_none()
+    if asset_id is None:
+        # 동시 요청 레이스로 다른 트랜잭션이 먼저 upsert — 재조회(asset_registry.py와 동일 TOCTOU 대응).
+        asset_id = (await db.execute(_select_cached())).scalar_one().id
+    await db.commit()
+
+    return (await db.execute(select(Asset).where(Asset.id == asset_id))).scalar_one()

--- a/backend/app/services/office_conversion.py
+++ b/backend/app/services/office_conversion.py
@@ -77,31 +77,55 @@ def _id_token_header() -> dict[str, str]:
         return {}
 
 
+_PDF_MAGIC = b"%PDF-"
+
+
 async def _call_gotenberg(filename: str, data: bytes) -> bytes:
+    """Gotenberg 호출 — 응답을 **스트리밍**으로 읽는다(카디르군 재QA, 2026-08-19).
+
+    이전 버전은 `client.post()`로 전체 바디를 먼저 버퍼링한 뒤 매직/크기를 검사했다 —
+    캐시 오염은 막았지만, 주석이 약속한 "무제한 메모리 적재 방지" 자체는 못 지켰다(거대
+    payload가 크기 상한에 걸려 결국 거부되더라도 그 순간까진 이미 전량 메모리에 있었다).
+    `client.stream()` + `aiter_bytes()`로 청크 단위 누적하며 ①매직이 판정 가능한 즉시(5바이트
+    확보 시) 검사해 아닌 것으로 판명되면 나머지 바디를 읽지 않고 바로 중단 ②누적 바이트가
+    상한을 넘는 순간 즉시 중단 — 두 실패 경로 모두 전체 바디를 메모리에 올리기 전에 끊는다.
+    """
     if not _GOTENBERG_URL:
         raise ConversionUnavailable("GOTENBERG_SERVICE_URL not configured")
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        try:
-            resp = await client.post(
+    chunks: list[bytes] = []
+    total = 0
+    magic_checked = False
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            async with client.stream(
+                "POST",
                 f"{_GOTENBERG_URL}/forms/libreoffice/convert",
                 files={"files": (filename, data, "application/octet-stream")},
                 headers=_id_token_header(),
-            )
-        except httpx.HTTPError as exc:
-            raise ConversionFailed(f"gotenberg request error: {exc}") from exc
-    if resp.status_code != 200:
-        raise ConversionFailed(f"gotenberg returned {resp.status_code}")
-    # ⛔QA catch(카디르군, 2026-08-19) — 200이어도 body가 PDF가 아닌 응답(에러 페이지류 등
-    # 프록시/게이트웨이 오탐)이 오면 검증 없이 캐시하는 순간 영구 오염된다(§7-2 캐시는
-    # 결정적 path라 재변환 트리거 자체가 없어 다음 열람마다 그 오염을 계속 서빙). 저장 前
-    # 최소 가드: 비어있지 않음 + `%PDF-` 매직 프리픽스.
-    if not resp.content.startswith(b"%PDF-"):
+            ) as resp:
+                if resp.status_code != 200:
+                    raise ConversionFailed(f"gotenberg returned {resp.status_code}")
+                async for chunk in resp.aiter_bytes():
+                    chunks.append(chunk)
+                    total += len(chunk)
+                    if not magic_checked and total >= len(_PDF_MAGIC):
+                        if not b"".join(chunks)[: len(_PDF_MAGIC)].startswith(_PDF_MAGIC):
+                            raise ConversionFailed(
+                                "gotenberg response is not a valid PDF (missing %PDF- magic)"
+                            )
+                        magic_checked = True
+                    if total > _MAX_CONVERTED_PDF_BYTES:
+                        raise ConversionFailed(
+                            f"gotenberg response exceeds size cap (>{_MAX_CONVERTED_PDF_BYTES} bytes)"
+                        )
+    except httpx.HTTPError as exc:
+        raise ConversionFailed(f"gotenberg request error: {exc}") from exc
+
+    body = b"".join(chunks)
+    if not magic_checked and not body.startswith(_PDF_MAGIC):
+        # 5바이트 미만으로 스트림이 끝난 초단문/빈 응답 — 위 루프 중엔 판정 못 했으니 여기서.
         raise ConversionFailed("gotenberg response is not a valid PDF (missing %PDF- magic)")
-    if len(resp.content) > _MAX_CONVERTED_PDF_BYTES:
-        raise ConversionFailed(
-            f"gotenberg response exceeds size cap ({len(resp.content)} > {_MAX_CONVERTED_PDF_BYTES} bytes)"
-        )
-    return resp.content
+    return body
 
 
 def _pdf_name(source_name: str) -> str:

--- a/backend/app/services/office_conversion.py
+++ b/backend/app/services/office_conversion.py
@@ -27,6 +27,13 @@ from app.models.asset import Asset
 _GOTENBERG_URL = os.environ.get("GOTENBERG_SERVICE_URL", "").rstrip("/")
 _CONVERTIBLE_EXTS = frozenset({"pptx"})
 _TIMEOUT = httpx.Timeout(120.0)  # §7-4: 대형 pptx 변환 지연 흡수
+# ⛔QA catch(카디르군, 2026-08-19) — %PDF- 매직만으론 부족, 응답 크기도 상한 필요(무제한
+# 메모리 적재+캐시 방지). 근거: 원본 pptx 업로드 상한 = 100MB(conversations.py
+# `_MAX_ATTACHMENT_SIZE`, conversation 첨부 경로). pptx→pdf는 보통 원본과 비슷하거나 작지만
+# (임베디드 미디어는 재인코딩 안 됨), 폰트 서브셋 임베딩·벡터 도형 래스터화 워스트케이스를
+# 감안해 2배 여유(=200MB)를 상한으로 잡는다 — 정밀 측정치가 아니라 방어적 상한(§7-4 concurrency=1
+# 이라 동시 1건 기준 300MB 피크 메모리(원본+응답)는 backend 컨테이너에 안전한 범위).
+_MAX_CONVERTED_PDF_BYTES = 200 * 1024 * 1024
 
 
 class ConversionUnavailable(Exception):
@@ -90,6 +97,10 @@ async def _call_gotenberg(filename: str, data: bytes) -> bytes:
     # 최소 가드: 비어있지 않음 + `%PDF-` 매직 프리픽스.
     if not resp.content.startswith(b"%PDF-"):
         raise ConversionFailed("gotenberg response is not a valid PDF (missing %PDF- magic)")
+    if len(resp.content) > _MAX_CONVERTED_PDF_BYTES:
+        raise ConversionFailed(
+            f"gotenberg response exceeds size cap ({len(resp.content)} > {_MAX_CONVERTED_PDF_BYTES} bytes)"
+        )
     return resp.content
 
 

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -49,6 +49,8 @@ _DECLARED_SUBSTITUTIONS = {
     "_BACKEND_SSE_LEASE_REDIS_ENABLED", "_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED",
     "_FRONTEND_MIN_INSTANCES", "_FRONTEND_MAX_INSTANCES", "_LICENSE_CONSENT",
     "_NEXT_PUBLIC_APP_URL", "_ADMIN_OPERATOR_AUDIENCE", "_ADMIN_OPERATOR_ALLOWLIST",
+    # story #2771 — office-converter(Gotenberg) URL, deploy-office-converter 스텝과 짝.
+    "_GOTENBERG_SERVICE_URL", "_OFFICE_CONVERTER_MAX_INSTANCES",
     "PROJECT_ID", "PROJECT_NUMBER", "BUILD_ID", "COMMIT_SHA", "SHORT_SHA",
     "REPO_NAME", "BRANCH_NAME", "TAG_NAME", "REVISION_ID", "LOCATION",
 }
@@ -85,7 +87,7 @@ def _apply_cloudbuild_escaping(script: str) -> str:
     return script.replace("$$", "$")
 
 
-def _run_env_vars_assembly(deploy_env: str, redis_url: str) -> str:
+def _run_env_vars_assembly(deploy_env: str, redis_url: str, gotenberg_url: str = "") -> str:
     """실제 gcloud 호출부만 잘라내고 ENV_VARS 조립 로직까지만 실행 — 실제 배포 없이 결과 문자열만 얻는다."""
     script = _apply_cloudbuild_escaping(_extract_deploy_backend_script())
     # 실제 gcloud run deploy 호출 라인 이후는 잘라내고 ENV_VARS를 echo하도록 붙인다.
@@ -116,6 +118,9 @@ def _run_env_vars_assembly(deploy_env: str, redis_url: str) -> str:
         "_NEXT_PUBLIC_APP_URL": "https://example.run.app",
         "_ADMIN_OPERATOR_AUDIENCE": "https://example-audience.run.app",
         "_ADMIN_OPERATOR_ALLOWLIST": "operator@example.iam.gserviceaccount.com",
+        # story #2771 — 기본 빈 문자열(substitutions 기본값과 정합, set -u라 미설정이면 스크립트가
+        # 죽는다 — 여기 없으면 이 테스트 전체가 붕괴).
+        "_GOTENBERG_SERVICE_URL": gotenberg_url,
     }
     proc = subprocess.run(
         ["bash", "-c", assembly_only],
@@ -196,6 +201,21 @@ def test_deploy_backend_prod_excludes_admin_operator_env_vars():
     result = _run_env_vars_assembly("prod", "")
     assert "ADMIN_OPERATOR_AUDIENCE" not in result
     assert "ADMIN_OPERATOR_ALLOWLIST" not in result
+
+
+def test_deploy_backend_includes_gotenberg_service_url_when_set():
+    """story #2771 — 부트스트랩 후(_GOTENBERG_SERVICE_URL 채워짐) env var가 실린다."""
+    result = _run_env_vars_assembly(
+        "dev", "redis://10.164.120.243:6379", gotenberg_url="https://office-converter-dev.example.run.app"
+    )
+    assert "GOTENBERG_SERVICE_URL=https://office-converter-dev.example.run.app" in result
+
+
+def test_deploy_backend_excludes_gotenberg_service_url_when_unset():
+    """⭐story #2771 부트스트랩 전 상태 — 빈 값이면 키 자체를 안 싣는다(office_conversion.py가
+    미설정을 503 fail-closed로 처리하므로 이게 안전한 기본 상태)."""
+    result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379", gotenberg_url="")
+    assert "GOTENBERG_SERVICE_URL" not in result
 
 
 def test_deploy_backend_dev_env_vars_unchanged_by_prod_branch():

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -218,6 +218,18 @@ def test_deploy_backend_excludes_gotenberg_service_url_when_unset():
     assert "GOTENBERG_SERVICE_URL" not in result
 
 
+def test_deploy_backend_prod_excludes_gotenberg_service_url_even_when_set():
+    """⭐QA catch(카디르군, 2026-08-19) 회귀 방지 — office-converter는 dev 전용 하드게이트
+    (deploy-office-converter 스텝)인데 이 배선에 REDIS_URL/ADMIN_OPERATOR_*와 같은 prod
+    게이트가 없었다. **값이 채워져 있어도** prod에서는 이 키 자체가 없어야 한다(#2141 원칙과
+    동일 — 값 유무가 아니라 키 존재 자체가 신호). substitution에 실수로 값이 남아 있는
+    상태를 흉내내 검증(빈 값 fallback에 기대지 않음)."""
+    result = _run_env_vars_assembly(
+        "prod", "", gotenberg_url="https://office-converter-dev.example.run.app"
+    )
+    assert "GOTENBERG_SERVICE_URL" not in result
+
+
 def test_deploy_backend_dev_env_vars_unchanged_by_prod_branch():
     """dev 경로 무회귀 — prod 분기 추가가 dev의 다른 필드에 영향을 주지 않는다."""
     result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379")

--- a/backend/tests/test_office_conversion_2771.py
+++ b/backend/tests/test_office_conversion_2771.py
@@ -51,57 +51,81 @@ async def test_call_gotenberg_unavailable_when_url_unset(monkeypatch):
         raise AssertionError("expected ConversionUnavailable")
 
 
-def _mock_gotenberg_response(status_code: int, content: bytes):
+def _mock_gotenberg_stream(status_code: int, chunks: list[bytes]):
+    """client.stream()+aiter_bytes() 청크 스트림 mock(카디르군 재QA, 2026-08-19 — 버퍼링
+    client.post() 대신 실제 스트리밍 경로를 그대로 연습). 소비된 청크 수를 센다 — 상한/매직
+    위반 시 **나머지 청크를 안 읽고 조기 중단**하는지 테스트가 직접 확인할 수 있게."""
+    consumed = {"n": 0}
+
+    async def _aiter_bytes():
+        for c in chunks:
+            consumed["n"] += 1
+            yield c
+
     mock_resp = MagicMock()
     mock_resp.status_code = status_code
-    mock_resp.content = content
+    mock_resp.aiter_bytes = _aiter_bytes
+
+    mock_stream_cm = AsyncMock()
+    mock_stream_cm.__aenter__.return_value = mock_resp
+
     mock_client = AsyncMock()
-    mock_client.__aenter__.return_value.post = AsyncMock(return_value=mock_resp)
-    return mock_client
+    mock_client.__aenter__.return_value.stream = MagicMock(return_value=mock_stream_cm)
+    return mock_client, consumed
 
 
 async def test_call_gotenberg_accepts_valid_pdf_magic(monkeypatch):
-    """정상 케이스 — %PDF- 매직으로 시작하는 200 응답은 그대로 통과."""
+    """정상 케이스 — %PDF- 매직으로 시작하는 200 응답(여러 청크로 분할)은 그대로 통과."""
     monkeypatch.setattr(office_conversion, "_GOTENBERG_URL", "https://example.internal")
     monkeypatch.setattr(office_conversion, "_id_token_header", lambda: {})
-    mock_client = _mock_gotenberg_response(200, b"%PDF-1.4 real pdf bytes")
+    mock_client, consumed = _mock_gotenberg_stream(200, [b"%PDF-1.4 ", b"real ", b"pdf bytes"])
     with patch("httpx.AsyncClient", return_value=mock_client):
         result = await office_conversion._call_gotenberg("x.pptx", b"data")
     assert result == b"%PDF-1.4 real pdf bytes"
+    assert consumed["n"] == 3  # 정상 케이스는 끝까지 읽는다
 
 
 async def test_call_gotenberg_rejects_non_pdf_body_even_on_200(monkeypatch):
-    """⭐QA catch(카디르군, 2026-08-19) 회귀 방지 — 200이어도 %PDF- 매직이 없으면(에러 페이지류
-    오탐) ConversionFailed로 거부해 캐시 오염을 막는다."""
+    """⭐QA catch(카디르군) 회귀 방지 — 200이어도 %PDF- 매직이 없으면(에러 페이지류 오탐)
+    ConversionFailed로 거부해 캐시 오염을 막는다. 스트리밍 조기중단(2026-08-19 라운드 2) —
+    매직이 판정 가능한 첫 청크에서 바로 거부, 나머지 청크는 안 읽는다."""
     monkeypatch.setattr(office_conversion, "_GOTENBERG_URL", "https://example.internal")
     monkeypatch.setattr(office_conversion, "_id_token_header", lambda: {})
 
-    mock_client = _mock_gotenberg_response(200, b"<html>error page</html>")
+    mock_client, consumed = _mock_gotenberg_stream(
+        200, [b"<html>err", b"or page - should never be consumed"]
+    )
     with patch("httpx.AsyncClient", return_value=mock_client):
         with pytest.raises(office_conversion.ConversionFailed):
             await office_conversion._call_gotenberg("x.pptx", b"data")
+    assert consumed["n"] == 1  # 조기 중단 — 2번째 청크는 안 읽음
 
-    # 빈 body도 마찬가지로 거부.
-    mock_client_empty = _mock_gotenberg_response(200, b"")
+    # 완전히 빈 스트림(청크 0개)도 마찬가지로 거부.
+    mock_client_empty, _ = _mock_gotenberg_stream(200, [])
     with patch("httpx.AsyncClient", return_value=mock_client_empty):
         with pytest.raises(office_conversion.ConversionFailed):
             await office_conversion._call_gotenberg("x.pptx", b"data")
 
 
 async def test_call_gotenberg_rejects_oversized_response(monkeypatch):
-    """⭐QA catch(카디르군, 2026-08-19) 회귀 방지 — %PDF- 매직은 통과해도 상한(200MB) 초과 응답은
-    거부한다(무제한 메모리 적재+캐시 방지). 실제로 200MB를 만들지 않고 cap을 낮춰 검증."""
+    """⭐QA catch(카디르군) 회귀 방지 — %PDF- 매직은 통과해도 상한 초과 응답은 거부한다.
+    스트리밍 조기중단(2026-08-19 라운드 2) — 상한을 넘기는 청크에서 바로 거부, 그 뒤 청크는
+    안 읽는다(무제한 메모리 적재를 실제로 막는지 소비 청크 수로 직접 검증)."""
     monkeypatch.setattr(office_conversion, "_GOTENBERG_URL", "https://example.internal")
     monkeypatch.setattr(office_conversion, "_id_token_header", lambda: {})
     monkeypatch.setattr(office_conversion, "_MAX_CONVERTED_PDF_BYTES", 10)
 
-    mock_client = _mock_gotenberg_response(200, b"%PDF-1.4 " + b"x" * 20)  # 매직은 유효, 크기만 초과
+    mock_client, consumed = _mock_gotenberg_stream(
+        200,
+        [b"%PDF-", b"1234567890ABCDEF", b"SHOULD_NOT_BE_CONSUMED"],  # 누적 5→22(cap=10 초과)→미소비
+    )
     with patch("httpx.AsyncClient", return_value=mock_client):
         with pytest.raises(office_conversion.ConversionFailed):
             await office_conversion._call_gotenberg("x.pptx", b"data")
+    assert consumed["n"] == 2  # 3번째 청크는 상한 초과 판정 前에 도달 안 함
 
     # cap 이내면 통과(경계값 아래 정상 케이스도 회귀로 고정).
-    mock_client_ok = _mock_gotenberg_response(200, b"%PDF-")
+    mock_client_ok, _ = _mock_gotenberg_stream(200, [b"%PDF-"])
     with patch("httpx.AsyncClient", return_value=mock_client_ok):
         result = await office_conversion._call_gotenberg("x.pptx", b"data")
     assert result == b"%PDF-"

--- a/backend/tests/test_office_conversion_2771.py
+++ b/backend/tests/test_office_conversion_2771.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from app.services import office_conversion
 
@@ -46,3 +49,40 @@ async def test_call_gotenberg_unavailable_when_url_unset(monkeypatch):
         pass
     else:
         raise AssertionError("expected ConversionUnavailable")
+
+
+def _mock_gotenberg_response(status_code: int, content: bytes):
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.content = content
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.post = AsyncMock(return_value=mock_resp)
+    return mock_client
+
+
+async def test_call_gotenberg_accepts_valid_pdf_magic(monkeypatch):
+    """정상 케이스 — %PDF- 매직으로 시작하는 200 응답은 그대로 통과."""
+    monkeypatch.setattr(office_conversion, "_GOTENBERG_URL", "https://example.internal")
+    monkeypatch.setattr(office_conversion, "_id_token_header", lambda: {})
+    mock_client = _mock_gotenberg_response(200, b"%PDF-1.4 real pdf bytes")
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await office_conversion._call_gotenberg("x.pptx", b"data")
+    assert result == b"%PDF-1.4 real pdf bytes"
+
+
+async def test_call_gotenberg_rejects_non_pdf_body_even_on_200(monkeypatch):
+    """⭐QA catch(카디르군, 2026-08-19) 회귀 방지 — 200이어도 %PDF- 매직이 없으면(에러 페이지류
+    오탐) ConversionFailed로 거부해 캐시 오염을 막는다."""
+    monkeypatch.setattr(office_conversion, "_GOTENBERG_URL", "https://example.internal")
+    monkeypatch.setattr(office_conversion, "_id_token_header", lambda: {})
+
+    mock_client = _mock_gotenberg_response(200, b"<html>error page</html>")
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(office_conversion.ConversionFailed):
+            await office_conversion._call_gotenberg("x.pptx", b"data")
+
+    # 빈 body도 마찬가지로 거부.
+    mock_client_empty = _mock_gotenberg_response(200, b"")
+    with patch("httpx.AsyncClient", return_value=mock_client_empty):
+        with pytest.raises(office_conversion.ConversionFailed):
+            await office_conversion._call_gotenberg("x.pptx", b"data")

--- a/backend/tests/test_office_conversion_2771.py
+++ b/backend/tests/test_office_conversion_2771.py
@@ -86,3 +86,22 @@ async def test_call_gotenberg_rejects_non_pdf_body_even_on_200(monkeypatch):
     with patch("httpx.AsyncClient", return_value=mock_client_empty):
         with pytest.raises(office_conversion.ConversionFailed):
             await office_conversion._call_gotenberg("x.pptx", b"data")
+
+
+async def test_call_gotenberg_rejects_oversized_response(monkeypatch):
+    """⭐QA catch(카디르군, 2026-08-19) 회귀 방지 — %PDF- 매직은 통과해도 상한(200MB) 초과 응답은
+    거부한다(무제한 메모리 적재+캐시 방지). 실제로 200MB를 만들지 않고 cap을 낮춰 검증."""
+    monkeypatch.setattr(office_conversion, "_GOTENBERG_URL", "https://example.internal")
+    monkeypatch.setattr(office_conversion, "_id_token_header", lambda: {})
+    monkeypatch.setattr(office_conversion, "_MAX_CONVERTED_PDF_BYTES", 10)
+
+    mock_client = _mock_gotenberg_response(200, b"%PDF-1.4 " + b"x" * 20)  # 매직은 유효, 크기만 초과
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(office_conversion.ConversionFailed):
+            await office_conversion._call_gotenberg("x.pptx", b"data")
+
+    # cap 이내면 통과(경계값 아래 정상 케이스도 회귀로 고정).
+    mock_client_ok = _mock_gotenberg_response(200, b"%PDF-")
+    with patch("httpx.AsyncClient", return_value=mock_client_ok):
+        result = await office_conversion._call_gotenberg("x.pptx", b"data")
+    assert result == b"%PDF-"

--- a/backend/tests/test_office_conversion_2771.py
+++ b/backend/tests/test_office_conversion_2771.py
@@ -1,0 +1,48 @@
+"""office_conversion 순수 로직 단위 테스트 (#2771 §7). DB/네트워크 불요."""
+from __future__ import annotations
+
+import uuid
+
+from app.services import office_conversion
+
+
+def test_is_convertible_pptx_only():
+    assert office_conversion.is_convertible("deck.pptx", None) is True
+    assert office_conversion.is_convertible("DECK.PPTX", None) is True  # 대소문자 무관
+    # docx는 별도 트랙(클라이언트 렌더) — 이 파이프 범위 밖.
+    assert office_conversion.is_convertible("doc.docx", None) is False
+    assert office_conversion.is_convertible("image.png", "image/png") is False
+    assert office_conversion.is_convertible("noext", None) is False
+
+
+def test_converted_object_path_deterministic():
+    org = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    proj = uuid.UUID("22222222-2222-2222-2222-222222222222")
+    source = uuid.UUID("33333333-3333-3333-3333-333333333333")
+
+    p1 = office_conversion.converted_object_path(org, proj, source)
+    p2 = office_conversion.converted_object_path(org, proj, source)
+    assert p1 == p2  # 결정적 — 캐시 키로 쓰려면 재호출해도 동일해야 함
+    assert p1 == f"converted/{org}/{proj}/{source}.pdf"
+
+
+def test_converted_object_path_org_level_no_project():
+    org = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    source = uuid.UUID("33333333-3333-3333-3333-333333333333")
+    p = office_conversion.converted_object_path(org, None, source)
+    assert p == f"converted/{org}/org/{source}.pdf"
+
+
+def test_pdf_name_replaces_extension():
+    assert office_conversion._pdf_name("quarterly deck.pptx") == "quarterly deck.pdf"
+    assert office_conversion._pdf_name("noext") == "noext.pdf"
+
+
+async def test_call_gotenberg_unavailable_when_url_unset(monkeypatch):
+    monkeypatch.setattr(office_conversion, "_GOTENBERG_URL", "")
+    try:
+        await office_conversion._call_gotenberg("x.pptx", b"data")
+    except office_conversion.ConversionUnavailable:
+        pass
+    else:
+        raise AssertionError("expected ConversionUnavailable")

--- a/backend/tests/test_office_conversion_realdb_2771.py
+++ b/backend/tests/test_office_conversion_realdb_2771.py
@@ -1,0 +1,183 @@
+"""office_conversion + /attachments/{asset_id}/convert real-DB 통합 (#2771 §7).
+
+커버: 원본 pptx→pdf 변환(mock Gotenberg/storage)·2회째 캐시 hit(변환 재호출 0회)·
+비-office 자산 422·**교차 테넌트 음성대조**(PO 판정 2026-08-19 ① — 타 org 토큰으로 변환물
+asset_id sign/authorize 시도 시 org 필터로 404, 변환물도 원본과 동일한 org_id로 생성되므로
+`/authorize` asset_id 분기 하나가 원본·변환물 둘 다 커버함을 실증).
+
+DB env 없으면 skip(CI alembic-fresh 잡서 실행) — test_asset_registry_realdb.py/
+test_attachment_authorize_asset_s3.py와 동일 관례.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("a4000000-0000-0000-0000-000000000001")
+ORG2 = uuid.UUID("a4000000-0000-0000-0000-000000000002")
+USER = uuid.UUID("a4000000-0000-0000-0000-0000000000a1")
+USER2 = uuid.UUID("a4000000-0000-0000-0000-0000000000a2")
+OM = uuid.UUID("a4000000-0000-0000-0000-0000000000b1")
+OM2 = uuid.UUID("a4000000-0000-0000-0000-0000000000b2")
+PROJ = uuid.UUID("a4000000-0000-0000-0000-0000000000c1")
+PROJ_OTHER = uuid.UUID("a4000000-0000-0000-0000-0000000000d1")  # ORG2 소속
+BUCKET = "sprintable-memo-attachments"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM assets WHERE org_id IN ('{ORG}','{ORG2}')",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM org_members WHERE org_id IN ('{ORG}','{ORG2}')",
+        f"DELETE FROM projects WHERE org_id IN ('{ORG}','{ORG2}')",
+        f"DELETE FROM users WHERE id IN ('{USER}','{USER2}')",
+        f"DELETE FROM organizations WHERE id IN ('{ORG}','{ORG2}')",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','A4','a4','free')",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG2}','A4b','a4b','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@a4.test','x','U',true,true,0,false,0)",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER2}','u2@a4b.test','x','U2',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM2}','{ORG2}','{USER2}','member')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','warn')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ_OTHER}','{ORG2}','OtherP','warn')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ}','{OM}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _mk_pptx_asset(s) -> uuid.UUID:
+    aid = uuid.uuid4()
+    await s.execute(
+        text(
+            "INSERT INTO assets (id,org_id,project_id,container,object_path,name,content_type,size_bytes) "
+            "VALUES (:id,:org,:proj,:bucket,:path,'deck.pptx',"
+            "'application/vnd.openxmlformats-officedocument.presentationml.presentation',1000)"
+        ),
+        {"id": str(aid), "org": str(ORG), "proj": str(PROJ), "bucket": BUCKET, "path": f"chat/{PROJ}/x/{aid}.pptx"},
+    )
+    await s.commit()
+    return aid
+
+
+def _auth(user):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user), email="u@a4.test", claims={}, org_id=str(ORG))
+
+
+@pytest.fixture(autouse=True)
+def _mock_storage_and_gotenberg(monkeypatch):
+    import app.services.storage as _storage_mod
+    from app.services import office_conversion
+
+    store: dict[str, bytes] = {}
+
+    async def _download(container, object_path):
+        return store.get(object_path, b"fake-pptx-bytes")
+
+    async def _put(container, object_path, data, *, content_type=None):
+        store[object_path] = data
+        return True
+
+    prov = MagicMock()
+    prov.download_object = AsyncMock(side_effect=_download)
+    prov.put_object = AsyncMock(side_effect=_put)
+    monkeypatch.setattr(_storage_mod, "get_storage_provider", lambda: prov)
+
+    calls = {"n": 0}
+
+    async def _fake_gotenberg(filename, data):
+        calls["n"] += 1
+        return b"%PDF-1.4 fake converted bytes"
+
+    monkeypatch.setattr(office_conversion, "_call_gotenberg", _fake_gotenberg)
+    monkeypatch.setattr(office_conversion, "_GOTENBERG_URL", "https://office-converter.example.internal")
+    yield calls
+
+
+@pytest.mark.anyio
+async def test_convert_then_cache_hit_then_cross_org_authorize_denied(_mock_storage_and_gotenberg):
+    from app.routers.attachments import authorize_attachment, convert_attachment
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            source_id = await _mk_pptx_asset(s)
+            auth = _auth(USER)
+
+            # 최초 변환 — Gotenberg 1회 호출.
+            res1 = await convert_attachment(asset_id=source_id, db=s, auth=auth, org_id=ORG)
+            assert res1["content_type"] == "application/pdf"
+            converted_id = uuid.UUID(res1["asset_id"])
+            assert converted_id != source_id
+            assert _mock_storage_and_gotenberg["n"] == 1
+
+            # 2회째 — 캐시 hit, Gotenberg 재호출 없음, 같은 asset_id.
+            res2 = await convert_attachment(asset_id=source_id, db=s, auth=auth, org_id=ORG)
+            assert uuid.UUID(res2["asset_id"]) == converted_id
+            assert _mock_storage_and_gotenberg["n"] == 1
+
+            # 변환물도 원본과 같은 org_id로 생성됨 — 원본 org 사용자는 authorize 통과(orphan asset, link 0건).
+            authz_ok = await authorize_attachment(
+                path=None, conversation_id=None, story_id=None,
+                asset_id=converted_id, db=s, auth=auth, org_id=ORG,
+            )
+            assert authz_ok["authorized"] is True
+
+            # PO AC①: 교차 테넌트 음성대조 — ORG2 토큰으로 변환물 authorize 시도 → org 필터 0행 → 404.
+            with pytest.raises(HTTPException) as exc:
+                await authorize_attachment(
+                    path=None, conversation_id=None, story_id=None,
+                    asset_id=converted_id, db=s, auth=_auth(USER2), org_id=ORG2,
+                )
+            assert exc.value.status_code == 404
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_convert_rejects_non_office_asset():
+    from app.routers.attachments import convert_attachment
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            aid = uuid.uuid4()
+            await s.execute(
+                text(
+                    "INSERT INTO assets (id,org_id,project_id,container,object_path,name,content_type,size_bytes) "
+                    "VALUES (:id,:org,:proj,:bucket,:path,'photo.png','image/png',10)"
+                ),
+                {"id": str(aid), "org": str(ORG), "proj": str(PROJ), "bucket": BUCKET, "path": f"chat/{PROJ}/x/{aid}.png"},
+            )
+            await s.commit()
+
+            with pytest.raises(HTTPException) as exc:
+                await convert_attachment(asset_id=aid, db=s, auth=_auth(USER), org_id=ORG)
+            assert exc.value.status_code == 422
+    finally:
+        await engine.dispose()

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -497,10 +497,14 @@ steps:
         if [ "${_DEPLOY_ENV}" != "prod" ]; then
           ENV_VARS="$${ENV_VARS},ADMIN_OPERATOR_AUDIENCE=${_ADMIN_OPERATOR_AUDIENCE},ADMIN_OPERATOR_ALLOWLIST=${_ADMIN_OPERATOR_ALLOWLIST}"
         fi
-        # story #2771 — _MCP_ALLOWED_HOSTS와 동일 컨벤션: 빈 문자열이면 키 자체를 안 싣는다
-        # (office_conversion.py는 os.environ.get 기본값 ""로 "미설정"과 "빈 문자열"을 이미
-        # 같은 뜻으로 다뤄 이 조건이 없어도 안전하지만, 다른 substitution들과 표기를 통일한다).
-        if [ -n "${_GOTENBERG_SERVICE_URL}" ]; then
+        # ⛔QA catch(카디르군, 2026-08-19) — office-converter 자체가 dev 전용 하드게이트인데
+        # (deploy-office-converter 스텝) 이 배선엔 REDIS_URL/ADMIN_OPERATOR_*와 같은
+        # `_DEPLOY_ENV != prod` 게이트가 빠져 있었다. 지금은 `_GOTENBERG_SERVICE_URL` 기본값이
+        # 빈 문자열이라 무해하지만, prod substitution에 값이 실수로 채워지는 단 한 번의 수동
+        # bootstrap 오조작만으로 prod backend가 dev office-converter로 테넌트 pptx를 흘리는
+        # 구조가 된다 — 값의 유무가 아니라 **prod에서는 이 키 자체가 없어야** 안전(story #2141
+        # REDIS_URL과 동일 원칙). dev만 싣는다.
+        if [ "${_DEPLOY_ENV}" != "prod" ] && [ -n "${_GOTENBERG_SERVICE_URL}" ]; then
           ENV_VARS="$${ENV_VARS},GOTENBERG_SERVICE_URL=${_GOTENBERG_SERVICE_URL}"
         fi
         # story #2445 Phase1(2026-08-03) — dev만 DATABASE_URL/DATABASE_URL_DIRECT를 PgBouncer

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,6 +22,17 @@ substitutions:
   # 자체의 _reject_prod() 가드까지 삼중.
   _ADMIN_OPERATOR_AUDIENCE: https://sprintable-backend-dev-57iommnikq-du.a.run.app
   _ADMIN_OPERATOR_ALLOWLIST: sprintable-admin-web@sprintable-494803.iam.gserviceaccount.com
+  # story #2771(pptx 서버 변환, doc 84ef0cb7 §7-4) — office-converter는 아래 deploy-office-
+  # converter 스텝이 매 배포마다 재생성/갱신하지만, 그 서비스의 URL은 Cloud Run이 서비스명+
+  # 리전으로부터 배정하는 canonical 해시(_ADMIN_OPERATOR_AUDIENCE와 동일 함정 — 부트스트랩
+  # 전엔 알 수 없다). **부트스트랩 절차(PO 1회)**: 이 substitutions 그대로 첫 배포(office-
+  # converter만 뜨고 backend는 GOTENBERG_SERVICE_URL 없이 뜬다=503 fail-closed, 무해) →
+  # `gcloud run services describe office-converter-dev --region=asia-northeast3
+  # --format='value(status.url)'`로 실측 → 그 값을 여기 채워 재배포(그 뒤부터 정상 배선).
+  # 빈 문자열 기본값 = 컨벤션대로 이 env var 자체를 backend에 안 싣는다(office_conversion.py
+  # 가 미설정을 ConversionUnavailable=503으로 처리 — 가짜 렌더 금지 유지).
+  _GOTENBERG_SERVICE_URL: ''
+  _OFFICE_CONVERTER_MAX_INSTANCES: '3'
   _BACKEND_MIN_INSTANCES: '1'
   # ⚠️ default '1'(아래) = _DEPLOY_ENV:dev default 와 정합한 **dev-safe fallback**(수동 `gcloud builds submit`
   #    override 없을 때 무리한 maxScale 재현 차단). GHA cloud-build.yml 이 per-env override(prod=5·dev=8, #2074 응급).
@@ -382,6 +393,56 @@ steps:
       - --quiet
     waitFor: [push-frontend]
 
+  # story #2771(pptx 서버 변환, doc 84ef0cb7 §7-4) — office-converter: Gotenberg(LibreOffice+
+  # Chromium 번들) 격리 배치. 자체 빌드 없음(공개 이미지 그대로) — build/push 스텝 불요,
+  # push-backend/push-frontend를 기다릴 필요도 없어 초반부터 병행 실행. ⛔dev 전용 하드게이트
+  # (deploy-realtime과 동일 컨벤션) — prod 승격은 별도 PO 판단.
+  # 보안(§7-3): --no-allow-unauthenticated — IAM 게이트(ingress 제한 아님, VPC 커넥터 불요).
+  # 호출부(backend)가 자신의 런타임 SA로 audience=이 서비스 URL인 ID 토큰을 떠 Authorization에
+  # 실어야 통과(office_conversion.py `_id_token_header()`) — admin_auth.require_admin_operator()
+  # 의 반대 방향(거긴 backend가 검증자, 여긴 backend가 호출자)과 같은 Cloud Run IAM 패턴.
+  # concurrency=1(§3-A: LibreOffice headless 사실상 단일스레드, 다중요청 동거=메모리 누수/좀비
+  # 프로세스 실보고) · min=0(열람 트리거라 상시 트래픽 없음, scale-to-zero) · timeout=120s(대형
+  # pptx 변환 지연 흡수).
+  - id: deploy-office-converter
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        if [ "${_DEPLOY_ENV}" != "dev" ]; then
+          echo "skip deploy-office-converter: prod gate pending (story #2771 dev 검증 후 오픈)"
+          exit 0
+        fi
+        gcloud run deploy office-converter-${_DEPLOY_ENV} \
+          --image=gotenberg/gotenberg:8.36 \
+          --region=${_AR_REGION} \
+          --no-allow-unauthenticated \
+          --concurrency=1 \
+          --min-instances=0 \
+          --max-instances=${_OFFICE_CONVERTER_MAX_INSTANCES} \
+          --cpu=1 \
+          --memory=2Gi \
+          --timeout=120 \
+          --quiet
+        # backend 런타임 SA(cloudrun-runtime-${_DEPLOY_ENV})에만 invoker 부여 — idempotent라
+        # 재실행 안전(이미 있으면 no-op). 이 배포 파이프라인 밖의 임의 호출자는 전부 403.
+        gcloud run services add-iam-policy-binding office-converter-${_DEPLOY_ENV} \
+          --region=${_AR_REGION} \
+          --member="serviceAccount:cloudrun-runtime-${_DEPLOY_ENV}@${PROJECT_ID}.iam.gserviceaccount.com" \
+          --role="roles/run.invoker" \
+          --quiet
+        served=$(gcloud run services describe office-converter-${_DEPLOY_ENV} \
+          --region=${_AR_REGION} --format='value(status.url)')
+        echo "OK: office-converter-${_DEPLOY_ENV} = $served"
+        if [ -z "${_GOTENBERG_SERVICE_URL}" ]; then
+          echo "NOTE: _GOTENBERG_SERVICE_URL substitution이 비어 있다 — backend는 이 서비스를"
+          echo "      아직 모른다(503 fail-closed). 위 URL을 substitutions에 채워 재배포할 것"
+          echo "      (부트스트랩 절차, 위 substitutions 섹션 주석 참고)."
+        fi
+    waitFor: ['-']
+
   - id: deploy-backend
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
     entrypoint: bash
@@ -435,6 +496,12 @@ steps:
         # 부재를 fail-closed 503으로 처리) ⛔대표 승인 前 prod 결제 개입 전면금지 태세와 정합.
         if [ "${_DEPLOY_ENV}" != "prod" ]; then
           ENV_VARS="$${ENV_VARS},ADMIN_OPERATOR_AUDIENCE=${_ADMIN_OPERATOR_AUDIENCE},ADMIN_OPERATOR_ALLOWLIST=${_ADMIN_OPERATOR_ALLOWLIST}"
+        fi
+        # story #2771 — _MCP_ALLOWED_HOSTS와 동일 컨벤션: 빈 문자열이면 키 자체를 안 싣는다
+        # (office_conversion.py는 os.environ.get 기본값 ""로 "미설정"과 "빈 문자열"을 이미
+        # 같은 뜻으로 다뤄 이 조건이 없어도 안전하지만, 다른 substitution들과 표기를 통일한다).
+        if [ -n "${_GOTENBERG_SERVICE_URL}" ]; then
+          ENV_VARS="$${ENV_VARS},GOTENBERG_SERVICE_URL=${_GOTENBERG_SERVICE_URL}"
         fi
         # story #2445 Phase1(2026-08-03) — dev만 DATABASE_URL/DATABASE_URL_DIRECT를 PgBouncer
         # 경유 시크릿으로 재바인딩(--update-secrets=additive, 기존 다른 시크릿 preserve — REDIS_URL_


### PR DESCRIPTION
## Summary
- story #2771(선생님 확定: 자체호스팅 Gotenberg + 격리 배치) 구현 그라운딩 §7 반영, 백엔드 변환 파이프 구현.
- `POST /api/v2/attachments/{asset_id}/convert` 신규 — 열람 시(lazy) 트리거 + 결정적 object_path 캐시(assets 테이블 기존 멱등 upsert가 캐시 키, 신규 스키마 불요).
- `office_conversion.py` — Gotenberg에 raw bytes multipart POST(URL fetch 아님 — SSRF 표면 구조적 제거) + office-converter Cloud Run 서비스용 ID 토큰 인증.
- 변환 asset은 AssetLink 0건 orphan — 신규 인가 게이트 없이 기존 `/authorize` asset_id 분기(org 필터 + has_project_access)를 그대로 재사용. 원본과 동일 org_id/project_id로 생성되므로 이 필터 하나가 원본·변환물 둘 다 커버(PO AC①).
- `cloudbuild.yaml` — `deploy-office-converter` 스텝(dev 전용, `gotenberg/gotenberg:8.36` 공개 이미지, IAM invoker binding) + backend `GOTENBERG_SERVICE_URL` 배선. 실행(gcloud apply·부트스트랩)은 PO 인프라 lane.

그라운딩 doc: [pptx/docx 인앱 미리보기 — 변환 경로 그라운딩](https://app.sprintable.ai) §7 (84ef0cb7) 참고.

## Test plan
- [x] `test_office_conversion_2771.py` — 순수 로직(is_convertible/캐시 경로 결정성/파일명 변환) 7 tests pass
- [x] `test_office_conversion_realdb_2771.py` — 실PG(create_all): 최초 변환→2회째 캐시 hit(재변환 0회)→**교차 테넌트 authorize 거부(404, PO AC①)**·비-office 자산 422
- [x] `test_deploy_backend_redis_secret_conflict.py` — `_GOTENBERG_SERVICE_URL` 가드 세트 갱신(미등재 시 로컬에서 실제로 #2421/#2423류 배포거부를 재현·수정함)
- [x] `python -c "import app.main"` 전체 앱 임포트 스모크 — 543 라우트 정상 등록
- [ ] office-converter 실배포·부트스트랩(PO 인프라 lane) — §7-4 절차 참고
- [ ] FE 뷰어 통합 + 콜드스타트 실측(§7-5, 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)