### PR TITLE
[HOTFIX] assetlinks.json Play 서명키 추가 — 실단말 로그인 블록

### DIFF
--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "com.moonklabs.sprintable",
       "sha256_cert_fingerprints": [
-        "F5:D0:7A:92:EA:A1:BB:71:F6:AF:71:9C:EC:E7:34:65:E5:83:FA:CF:C1:90:EE:CA:A0:E1:F0:F1:02:9C:59:99"
+        "F5:D0:7A:92:EA:A1:BB:71:F6:AF:71:9C:EC:E7:34:65:E5:83:FA:CF:C1:90:EE:CA:A0:E1:F0:F1:02:9C:59:99",
+        "C6:8A:29:1D:53:3C:A7:0C:6D:9F:15:5B:CE:D0:6A:E1:C2:52:51:05:AF:82:96:A5:2C:9F:5D:9C:0D:6C:4E:37"
       ]
     }
   },


### PR DESCRIPTION
## 인시던트
선생님 실단말(Android) 로그인이 Digital Asset Links 검증 실패로 블록됨 — Play 서명키의 SHA-256 인증서 지문이 `assetlinks.json`에 등재돼 있지 않았음(#6fa65c1f, 민레 등재).

## 변경 사항
`apps/web/public/.well-known/assetlinks.json`의 `com.moonklabs.sprintable` 항목 `sha256_cert_fingerprints`에 Play 서명키 지문 추가. 기존 업로드키 지문은 유지(둘 다 등재). `com.moonklabs.sprintable.dev` 항목은 무변경.

**Before:**
```json
"sha256_cert_fingerprints": [
  "F5:D0:7A:92:EA:A1:BB:71:F6:AF:71:9C:EC:E7:34:65:E5:83:FA:CF:C1:90:EE:CA:A0:E1:F0:F1:02:9C:59:99"
]
```

**After:**
```json
"sha256_cert_fingerprints": [
  "F5:D0:7A:92:EA:A1:BB:71:F6:AF:71:9C:EC:E7:34:65:E5:83:FA:CF:C1:90:EE:CA:A0:E1:F0:F1:02:9C:59:99",
  "C6:8A:29:1D:53:3C:A7:0C:6D:9F:15:5B:CE:D0:6A:E1:C2:52:51:05:AF:82:96:A5:2C:9F:5D:9C:0D:6C:4E:37"
]
```

## 검증
- JSON 유효성 확인(`python3 -m json.tool`)
- diff 최소 — 지문 1건 추가만, dev 패키지 항목·구조 무변경
- 라이브 확認(curl)은 배포 후 페드루군이 진행

## 배포
main 머지 → Cloud Run prod 자동 배포. **머지는 선생님 승인 후 페드루군이 진행.**

동기 사본 PR(develop): (연결 예정)