### PR TITLE
[SID:6fa65c1f] assetlinks.json Play 서명키 동기 — main 핫픽스 develop 사본

### DIFF
--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "com.moonklabs.sprintable",
       "sha256_cert_fingerprints": [
-        "F5:D0:7A:92:EA:A1:BB:71:F6:AF:71:9C:EC:E7:34:65:E5:83:FA:CF:C1:90:EE:CA:A0:E1:F0:F1:02:9C:59:99"
+        "F5:D0:7A:92:EA:A1:BB:71:F6:AF:71:9C:EC:E7:34:65:E5:83:FA:CF:C1:90:EE:CA:A0:E1:F0:F1:02:9C:59:99",
+        "C6:8A:29:1D:53:3C:A7:0C:6D:9F:15:5B:CE:D0:6A:E1:C2:52:51:05:AF:82:96:A5:2C:9F:5D:9C:0D:6C:4E:37"
       ]
     }
   },


### PR DESCRIPTION
## 배경
main 직행 핫픽스 PR#3227(assetlinks.json Play 서명키 추가, 실단말 로그인 블록 인시던트)의 develop 동기 사본. 다음 develop→main 승격이 이 fix를 되돌리지 않도록 두 브랜치를 미리 맞춘다.

## 변경 사항
PR#3227과 동일 — `apps/web/public/.well-known/assetlinks.json`의 `com.moonklabs.sprintable` 항목 `sha256_cert_fingerprints`에 Play 서명키 지문 추가, 업로드키 지문 유지, dev 패키지 항목 무변경.

**Before:**
```json
"sha256_cert_fingerprints": [
  "F5:D0:7A:92:EA:A1:BB:71:F6:AF:71:9C:EC:E7:34:65:E5:83:FA:CF:C1:90:EE:CA:A0:E1:F0:F1:02:9C:59:99"
]
```

**After:**
```json
"sha256_cert_fingerprints": [
  "F5:D0:7A:92:EA:A1:BB:71:F6:AF:71:9C:EC:E7:34:65:E5:83:FA:CF:C1:90:EE:CA:A0:E1:F0:F1:02:9C:59:99",
  "C6:8A:29:1D:53:3C:A7:0C:6D:9F:15:5B:CE:D0:6A:E1:C2:52:51:05:AF:82:96:A5:2C:9F:5D:9C:0D:6C:4E:37"
]
```

## 검증
- JSON 유효성 확인, main PR#3227과 diff 동일함(byte-identical) 확인
- 두 프로젝트 카피(main/develop)가 어긋나지 않도록 이 스토리 범위 안에서 동시 처리

관련: main PR #3227