### PR TITLE
[WIP][SID:2791] 프리셋 서버 자동발행 배선 — P0 1단계(core 추출)

### DIFF
--- a/backend/alembic/versions/0258_system_publisher_member.py
+++ b/backend/alembic/versions/0258_system_publisher_member.py
@@ -1,0 +1,38 @@
+"""story #2791(P0, event-workflow-unification-design-2790) — 서버 도메인 전이 자동발행 전용
+시스템 발신자(TeamMember) 프로비저닝을 위한 부분 유니크 인덱스.
+
+레코드 자체는 여기서 시드하지 않는다(org는 마이그레이션 시점 이후에도 계속 생성되므로 시드로는
+전량을 못 덮는다) — `app/routers/events.py::_get_or_create_system_publisher`가 최초 자동발행
+시점에 lazy get-or-create로 프로비저닝한다. 이 인덱스는 그 get-or-create의 `ON CONFLICT`
+타겟이자, org당 정확히 1행만 존재함을 DB 레벨로 보장하는 동시성 가드(레이스로 2행 생성 방지).
+
+runtime_type 컬럼(기존 "에이전트 런타임 종류" 필드, E-CHAT-CMD S1b)을 마커로 재사용 —
+신규 컬럼 발명 없이 기존 필드의 자유텍스트 여유를 쓴다("system-publisher" 고정값).
+
+Revision ID: 0258
+Revises: 0257
+Create Date: 2026-08-19
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0258"
+down_revision = "0257"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "uq_team_members_org_system_publisher",
+        "team_members",
+        ["org_id"],
+        unique=True,
+        postgresql_where=sa.text("runtime_type = 'system-publisher'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_team_members_org_system_publisher", table_name="team_members")

--- a/backend/alembic/versions/0258_system_publisher_member.py
+++ b/backend/alembic/versions/0258_system_publisher_member.py
@@ -1,13 +1,19 @@
 """story #2791(P0, event-workflow-unification-design-2790) — 서버 도메인 전이 자동발행 전용
-시스템 발신자(TeamMember) 프로비저닝을 위한 부분 유니크 인덱스.
+시스템 발신자(Member) 프로비저닝을 위한 부분 유니크 인덱스.
+
+⛔초판 실수(2026-08-19, CI realdb로 즉시 발각) — `team_members`를 대상으로 인덱스를 만들려
+했으나 `team_members`는 0088+에서 `members`/`project_access`/`agent_project_profiles` 위
+3-way UNION ALL **VIEW**로 전환된 지 오래라(0110이 최신 정의) 인덱스는커녕 직접 INSERT도
+안 되는 대상이다("cannot create index on relation ... This operation is not supported for
+views" — CI Alembic 잡이 실측으로 잡아냄). 실제 anchor 테이블 `members`를 대상으로 정정.
 
 레코드 자체는 여기서 시드하지 않는다(org는 마이그레이션 시점 이후에도 계속 생성되므로 시드로는
 전량을 못 덮는다) — `app/routers/events.py::_get_or_create_system_publisher`가 최초 자동발행
-시점에 lazy get-or-create로 프로비저닝한다. 이 인덱스는 그 get-or-create의 `ON CONFLICT`
-타겟이자, org당 정확히 1행만 존재함을 DB 레벨로 보장하는 동시성 가드(레이스로 2행 생성 방지).
+시점에 lazy get-or-create로 프로비저닝한다(`members` 행 + `project_access` grant 1건).
 
-runtime_type 컬럼(기존 "에이전트 런타임 종류" 필드, E-CHAT-CMD S1b)을 마커로 재사용 —
-신규 컬럼 발명 없이 기존 필드의 자유텍스트 여유를 쓴다("system-publisher" 고정값).
+마커는 `members.handle`(구 에이전트 @멘션 핸들 — story #2646이 완전히 은퇴시킨 죽은 필드,
+"이제 아무 코드도 안 쓴다") 재사용 — `runtime_type`(9종 enum, agent_runtime capability
+registry의 실 조회 키)을 마커로 쓰면 그 조회 로직과 충돌할 위험이 있어 피한다.
 
 Revision ID: 0258
 Revises: 0257
@@ -26,13 +32,13 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_index(
-        "uq_team_members_org_system_publisher",
-        "team_members",
+        "uq_members_org_system_publisher",
+        "members",
         ["org_id"],
         unique=True,
-        postgresql_where=sa.text("runtime_type = 'system-publisher'"),
+        postgresql_where=sa.text("handle = 'system-publisher' AND type = 'agent'"),
     )
 
 
 def downgrade() -> None:
-    op.drop_index("uq_team_members_org_system_publisher", table_name="team_members")
+    op.drop_index("uq_members_org_system_publisher", table_name="members")

--- a/backend/alembic/versions/0258_system_publisher_member.py
+++ b/backend/alembic/versions/0258_system_publisher_member.py
@@ -11,9 +11,17 @@ views" — CI Alembic 잡이 실측으로 잡아냄). 실제 anchor 테이블 `m
 전량을 못 덮는다) — `app/routers/events.py::_get_or_create_system_publisher`가 최초 자동발행
 시점에 lazy get-or-create로 프로비저닝한다(`members` 행 + `project_access` grant 1건).
 
-마커는 `members.handle`(구 에이전트 @멘션 핸들 — story #2646이 완전히 은퇴시킨 죽은 필드,
-"이제 아무 코드도 안 쓴다") 재사용 — `runtime_type`(9종 enum, agent_runtime capability
-registry의 실 조회 키)을 마커로 쓰면 그 조회 로직과 충돌할 위험이 있어 피한다.
+마커는 `members.runtime_type`(에이전트 런타임 종류, 9종 enum이지만 `get_runtime_capability`가
+None/빈문자열/미등록 문자열 전부 UNSUPPORTED_CAPABILITY로 안전 처리 — app/services/
+agent_runtime.py 확인) 재사용 — `"system-publisher"`는 그 9종 어디에도 안 걸려 항상
+UNSUPPORTED로 떨어질 뿐 예외를 안 낸다. `team_members` 뷰가 이 컬럼을 그대로 투영해
+`send_message()`(conversations.py) 등 뷰 기반 호출부가 이 값을 직접 읽을 수 있다는 것이
+핵심 — 2026-08-19 재QA(카디르)에서 이 마커가 실제로 필요해짐(system 발신자에게 org-wide
+presence 방출을 스킵시키는 조건 분기의 판별 키).
+
+⚠️초판(2026-08-19 최초 커밋)은 `members.handle`(구 에이전트 @멘션 핸들, 죽은 필드)을 마커로
+썼으나 — `team_members` 뷰가 `handle`을 투영하지 않아 `send_message()` 등 뷰 기반 호출부에서
+읽을 수 없다는 것이 재QA 중 드러나 `runtime_type`으로 정정.
 
 Revision ID: 0258
 Revises: 0257
@@ -36,7 +44,7 @@ def upgrade() -> None:
         "members",
         ["org_id"],
         unique=True,
-        postgresql_where=sa.text("handle = 'system-publisher' AND type = 'agent'"),
+        postgresql_where=sa.text("runtime_type = 'system-publisher' AND type = 'agent'"),
     )
 
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2214,11 +2214,21 @@ async def send_message(
     # 1aeecdde P2: sender 가 이 conversation 에 메시지를 보냄 = 답장 생성 종료 → working clear.
     # fork 분기(아래) 전 **원본 conversation_id** 기준 — working 은 그 conversation 에 set 됐다.
     # 휴먼 sender 면 set 된 적 없어 no-op(무해). agent reply 면 즉시 "...typing" 해제.
-    await chat_presence.clear_working(str(conversation_id), str(sender.id))
-    # R2(da9d1781): working clear → conversation.working + presence SSE 발행(폴링 대체·best-effort).
-    from app.services.presence_events import emit_conversation_working, emit_presence
-    await emit_conversation_working(org_id, conversation_id)
-    await emit_presence(org_id)
+    #
+    # story #2791(P0) 정정(2026-08-19, 페드루 판정) — system publisher(서버 자동발행 전용
+    # 합성 발신자, runtime_type='system-publisher')는 이 블록을 건너뛴다. 우회가 아니라
+    # 의미 정정: presence·working은 "이 구성원이 지금 활동 중"이라는 신호인데, system
+    # 발신자는 애초에 presence 개념이 성립하지 않는 존재라 그걸 org 전체에 쏘는 것 자체가
+    # 원래 틀렸다. 사람이 실제로 타이핑할 때만 타던 이 경로의 암묵 전제가, 도메인 전이마다
+    # 대량으로 트리거되는 자동발행에서 처음 드러났다(재QA 중 story #2791의
+    # test_e_ui_daegbyeon_9ef0f914_sse_bridge_realdb.py cross-project 하드게이트가 이
+    # org-wide presence 방출과 우연히 충돌해 발각).
+    if getattr(sender, "runtime_type", None) != "system-publisher":
+        await chat_presence.clear_working(str(conversation_id), str(sender.id))
+        # R2(da9d1781): working clear → conversation.working + presence SSE 발행(폴링 대체·best-effort).
+        from app.services.presence_events import emit_conversation_working, emit_presence
+        await emit_conversation_working(org_id, conversation_id)
+        await emit_presence(org_id)
 
     # cross-org 차단: mentioned_ids를 현재 org 소속 member로 일괄 필터링 (QA B1).
     # E-MEMBER-SSOT Phase 0: 저장·DM포크·group 멘션 발송 모든 경로에 org 필터를 한 번 적용.

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -550,6 +550,31 @@ async def score_ga4_outcomes(
                 epic.outcome_status = scoring["outcome_status"]
                 epic.outcome_result = scoring["outcome_result"]
                 scored.append({"type": "epic", "id": str(epic.id), "outcome_status": scoring["outcome_status"]})
+
+                # story #2791(P0, event-workflow-unification-design-2790) — preset.goal.measured
+                # 서버 자동발행. "pending"(아직 실측 안 됨)은 발행 대상 아님 — hit/miss처럼
+                # 실제 값이 확정됐을 때만("목표 측정"이라는 사건 자체가 성립한 시점).
+                # best-effort 격리는 호출자(여기) 몫 — cron 잡 자체를 안 깬다.
+                if scoring["outcome_status"] in ("hit", "miss") and scoring.get("outcome_result"):
+                    try:
+                        from app.routers.events import publish_preset_event
+
+                        outcome_result = scoring["outcome_result"]
+                        await publish_preset_event(
+                            session, epic.org_id, "preset.goal.measured",
+                            {
+                                "goal_id": str(epic.id),
+                                "metric_value": outcome_result.get("actual"),
+                                "metric_unit": outcome_result.get("metric"),
+                                "source": source,
+                                "measured_at": outcome_result.get("scored_at"),
+                            },
+                        )
+                    except Exception:
+                        logger.warning(
+                            "preset.goal.measured 자동발행 실패(goal=%s org=%s)",
+                            epic.id, epic.org_id, exc_info=True,
+                        )
             except Exception as exc:
                 logger.warning("epic scoring failed id=%s: %s", epic.id, exc)
                 failed.append({"type": "epic", "id": str(epic.id), "error": str(exc)})

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import random
 import time
 import uuid
@@ -42,6 +43,7 @@ from app.models.event import Event
 from app.services.member_resolver import assert_caller_is_member, resolve_member_identity
 
 router = APIRouter(prefix="/api/v2/events", tags=["events", "Organization"])
+logger = logging.getLogger(__name__)
 
 # ─── Agent connection registry (S2/S3: 에이전트별 SSE) ───────────────────────
 # member_id (str) → set[Queue] — 다중 연결 지원, 해제 시 해당 queue만 제거
@@ -1015,9 +1017,31 @@ async def publish_registry_event(
     이름을 다른 뜻으로 되쓰면 그 가드가 "부활"로 오판하는 게 아니라(가드는 hasattr만 보므로
     실제로 트립됐다), 미래 독자가 두 개념을 착각할 여지도 같이 없앤다.
 
-    definition_key+payload를 검증하고
-    routing(상신선·전파선)을 실 member_id로 풀어 기존 단일 판정 파이프(route_message/
-    DeliveryDecision, AC2)로 전달한다."""
+    실 로직은 `_publish_registry_event_core`(story #2791 P0 추출) — 서버 자동발행
+    (`publish_preset_event`)도 HTTP 요청 컨텍스트 없이 같은 core를 호출해 단일 파이프
+    원칙(#2633 AC2)을 유지한다. 이 엔드포인트는 auth 의존성 해석만 하고 넘긴다."""
+    return await _publish_registry_event_core(
+        db, org_id, auth, body.definition_key, body.payload, background_tasks,
+        request=request, extra_broadcast_member_ids=body.extra_broadcast_member_ids,
+    )
+
+
+async def _publish_registry_event_core(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    auth: AuthContext,
+    definition_key: str,
+    payload: dict,
+    background_tasks: BackgroundTasks,
+    *,
+    request: Request | None = None,
+    extra_broadcast_member_ids: "list[uuid.UUID] | None" = None,
+) -> dict:
+    """`publish_registry_event`(HTTP)·`publish_preset_event`(서버 자동발행, story #2791 P0)의
+    공유 core — definition_key+payload를 검증하고 routing(상신선·전파선)을 실 member_id로
+    풀어 기존 단일 판정 파이프(route_message/DeliveryDecision, AC2)로 전달한다. HTTP 전용
+    폴백(`request`가 있을 때만 쓰는 `resolve_required_project_id`)만 옵션 처리 — 자동발행
+    호출부는 항상 payload에 work_item/goal 참조를 실어 이 폴백에 안 걸린다."""
     from app.services.member_resolver import resolve_member
 
     sender = await resolve_member(auth, org_id, db)
@@ -1027,7 +1051,7 @@ async def publish_registry_event(
     definition = (await db.execute(
         select(EventDefinition)
         .where(
-            EventDefinition.key == body.definition_key,
+            EventDefinition.key == definition_key,
             EventDefinition.enabled.is_(True),
             or_(EventDefinition.org_id == org_id, EventDefinition.org_id.is_(None)),
         )
@@ -1038,7 +1062,7 @@ async def publish_registry_event(
     )).scalars().first()
     if definition is None:
         raise HTTPException(
-            status_code=404, detail=f"event definition not found or disabled: {body.definition_key!r}",
+            status_code=404, detail=f"event definition not found or disabled: {definition_key!r}",
         )
 
     # story #2637 §범위3(미르코 발견 후속, 2026-08-14): action_auth 실 집행 — 정의에 걸려
@@ -1068,7 +1092,7 @@ async def publish_registry_event(
     from app.services.event_definition_registry import InvalidEventPayloadError, validate_event_payload
 
     try:
-        validate_event_payload(definition.payload_schema, body.payload)
+        validate_event_payload(definition.payload_schema, payload)
     except InvalidEventPayloadError as e:
         # story #2634 후속(#2633 정합): api_client.py의 _extract_error_message가 인식하는
         # {"detail":{"code","message"}} shape으로 맞춘다 — 신규 파싱 분기를 MCP 쪽에 안 만들고
@@ -1088,10 +1112,10 @@ async def publish_registry_event(
 
     try:
         escalation_ids = await resolve_routing_leg(
-            definition.routing["escalation"], payload=body.payload, org_id=org_id, db=db,
+            definition.routing["escalation"], payload=payload, org_id=org_id, db=db,
         )
         broadcast_ids = await resolve_routing_leg(
-            definition.routing["broadcast"], payload=body.payload, org_id=org_id, db=db,
+            definition.routing["broadcast"], payload=payload, org_id=org_id, db=db,
         )
     except (MissingRoutingPayloadFieldError, InvalidWorkItemReferenceError, UnknownRoutingMemberError) as e:
         raise HTTPException(
@@ -1099,7 +1123,7 @@ async def publish_registry_event(
             detail={"code": "invalid_payload", "message": str(e), "errors": [str(e)]},
         ) from e
 
-    if body.extra_broadcast_member_ids:
+    if extra_broadcast_member_ids:
         # story #2693(AC2): payload_field routing과 동일 검증 — 예전엔 filter_org_member_ids로
         # 비회원 id를 조용히 걸러내고(silent drop) 발행을 그대로 진행했다. AC1의 원자성
         # 요구(비회원이면 conv/msg 어느 것도 만들지 않는다)와 일관되게, 여기도 걸러내는 대신
@@ -1107,7 +1131,7 @@ async def publish_registry_event(
         # 동일 철학).
         from app.services.member_resolver import filter_org_member_ids
 
-        requested_extra = set(body.extra_broadcast_member_ids)
+        requested_extra = set(extra_broadcast_member_ids)
         valid_extra = await filter_org_member_ids(requested_extra, org_id, db)
         unknown_extra = requested_extra - valid_extra
         if unknown_extra:
@@ -1123,7 +1147,7 @@ async def publish_registry_event(
         broadcast_ids |= valid_extra
 
     try:
-        project_id = await _resolve_event_project_id(db, org_id=org_id, payload=body.payload)
+        project_id = await _resolve_event_project_id(db, org_id=org_id, payload=payload)
     except InvalidWorkItemReferenceError as e:
         raise HTTPException(
             status_code=400,
@@ -1138,8 +1162,8 @@ async def publish_registry_event(
         # 골라주면 더 헷갈린다 — 그대로 명시 거부(test_publish_unresolvable_project_400의
         # 기존 계약, AC2 무회귀).
         attempted_reference = bool(
-            (body.payload.get("work_item_type") and body.payload.get("work_item_id"))
-            or body.payload.get("goal_id")
+            (payload.get("work_item_type") and payload.get("work_item_id"))
+            or payload.get("goal_id")
         )
         if attempted_reference:
             raise HTTPException(
@@ -1175,9 +1199,9 @@ async def publish_registry_event(
     # "이벤트 발행분"으로 인지하고 event_key로 event_definitions를 조회해 block_template
     # 렌더러를 태울 근거. 렌더러 자체는 #2637 FE 레인(이 커밋은 스키마 배선만).
     send_body = SendMessageRequest(
-        content=_render_event_message_content(definition.key, body.payload),
+        content=_render_event_message_content(definition.key, payload),
         mentioned_ids=list(escalation_ids),
-        event_context={"event_key": definition.key, "payload": body.payload},
+        event_context={"event_key": definition.key, "payload": payload},
     )
     msg_response = await send_message(
         conv.id, send_body, background_tasks, db=db, auth=auth, org_id=org_id,
@@ -1200,6 +1224,122 @@ async def publish_registry_event(
         result["warning"] = (
             "발행은 성공했으나 escalation·broadcast 대상이 모두 0명입니다 — "
             "work_item이 미배정이거나 routing이 아무도 가리키지 않습니다."
+        )
+    return result
+
+
+async def _get_or_create_system_publisher(db: AsyncSession, org_id: uuid.UUID) -> "TeamMember":
+    """story #2791(P0) — 서버 도메인 전이 자동발행 전용 시스템 발신자. org당 정확히 1행
+    (0258 부분 유니크 인덱스로 DB 레벨 동시성 가드), get-or-create 멱등.
+
+    소유·수명: 이 org가 존재하는 한 영구 — 별도 TTL·수동 정리 없음(자동발행 자체가 이 org
+    수명과 결합돼 있어 "고아 리소스" 클래스가 아니다).
+
+    `project_id`는 team_members 스키마상 NOT NULL이지만, 이 member로 발행할 때 쓰는
+    `send_message`의 sender 해석(conversations.py::`_resolve_member`, api_key 분기)은
+    `TeamMember.id` 존재만 확인하고 project_id는 안 읽는다(2026-08-19 실측, story #2791 PR
+    참조) — 그래서 org 내 아무 project 하나에 anchor해도 org 전역 전이 이벤트 발행에
+    문제없다. `type='agent'`로 만들어 기존 서킷브레이커(agent 발신자 전용, story #2630)가
+    자동발행 폭주(전이 루프)도 그대로 방어하게 한다 — 의도적으로 끄지 않는다(P0 가드②).
+    이름 "시스템 발행"은 채팅 카드의 sender 표시가 사람 눈에 시스템 발행임을 신규 FE 없이
+    이름만으로 읽히게 하기 위함(P0 가드④) — 팀멤버 목록·리더보드·워크포스 표면에는 이 이름
+    그대로의 agent 1명으로 노출된다(관측 기록, P0 스코프 밖 — 페드루 2026-08-19 확認).
+    """
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    existing = (await db.execute(
+        select(TeamMember).where(
+            TeamMember.org_id == org_id, TeamMember.runtime_type == "system-publisher",
+        ).limit(1)
+    )).scalars().first()
+    if existing is not None:
+        return existing
+
+    anchor_project_id = (await db.execute(
+        select(Project.id)
+        .where(Project.org_id == org_id, Project.deleted_at.is_(None))
+        .order_by(Project.created_at.asc())
+        .limit(1)
+    )).scalar_one_or_none()
+    if anchor_project_id is None:
+        raise ValueError(f"org {org_id}에 anchor할 project가 없음 — 시스템 발신자 프로비저닝 불가")
+
+    ins = pg_insert(TeamMember).values(
+        id=uuid.uuid4(), org_id=org_id, project_id=anchor_project_id,
+        type="agent", name="시스템 발행", role="member",
+        runtime_type="system-publisher", is_active=True,
+    ).on_conflict_do_nothing(
+        index_elements=["org_id"],
+        index_where=(TeamMember.runtime_type == "system-publisher"),
+    ).returning(TeamMember.id)
+    member_id = (await db.execute(ins)).scalar_one_or_none()
+    if member_id is None:
+        # 동시요청 레이스로 다른 트랜잭션이 먼저 생성 — 재조회(asset_registry.py와 동일 TOCTOU 대응).
+        return (await db.execute(
+            select(TeamMember).where(
+                TeamMember.org_id == org_id, TeamMember.runtime_type == "system-publisher",
+            )
+        )).scalars().one()
+    await db.flush()
+    return (await db.execute(select(TeamMember).where(TeamMember.id == member_id))).scalars().one()
+
+
+async def publish_preset_event(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    definition_key: str,
+    payload: dict,
+    background_tasks: BackgroundTasks,
+) -> dict | None:
+    """story #2791(P0, event-workflow-unification-design-2790) — 서버 도메인 전이 지점
+    (상태변경·배정·게이트판정·목표측정)에서 호출하는 자동발행 진입점. HTTP 요청 컨텍스트
+    없이 `_publish_registry_event_core`를 그대로 호출해 #2633 AC2 단일 발행 파이프 원칙을
+    지킨다 — 신규 발행 갈래를 만들지 않는다.
+
+    **구계통(story_status_events.py 등 SSE·웹훅·알림)과의 관계는 병행이다, 대체가 아니다**
+    — 이 함수는 기존 5-effect 옆에 프리셋 발행을 하나 더 추가할 뿐, 기존 effect를 하나도
+    안 건드린다(이중발송처럼 보이지만 서로 다른 채널: 구계통=SSE/webhook/notification,
+    신계통=이벤트 레지스트리 발행 대화 메시지 — 수신자가 같아도 매체가 다르다).
+
+    ⚠️호출자 계약(story_status_events.py::emit_story_status_changed와 동형) — 이 함수는
+    예외를 삼키지 않는다. best-effort 격리(실패가 도메인 전이 자체를 깨면 안 됨)는
+    **호출자**가 개별 try/except로 감싸는 몫이다 — 이 함수 안에서 조용히 삼키면 실패
+    자체를 관측할 수 없다(기존 5-effect와 동일 조직 원칙).
+
+    반환값 `None` = definition이 비활성/미등록이라 정상 no-op(아직 이 org가 프리셋을 안
+    켰거나 #2636 커스텀 오버라이드로 비활성화한 경우 — 발행 실패가 아니다). zero-reach는
+    HTTP 응답 필드 대신 서버 로그(`logger.warning`)로 남긴다 — 이 호출엔 응답을 읽는 사람이
+    없어(핵심 제약②, 침묵 실패 금지) 응답 필드에만 실으면 완전히 유실된다.
+    """
+    from app.models.event_definition import EventDefinition
+
+    definition = (await db.execute(
+        select(EventDefinition)
+        .where(
+            EventDefinition.key == definition_key,
+            EventDefinition.enabled.is_(True),
+            or_(EventDefinition.org_id == org_id, EventDefinition.org_id.is_(None)),
+        )
+        .limit(1)
+    )).scalars().first()
+    if definition is None:
+        return None
+
+    system_member = await _get_or_create_system_publisher(db, org_id)
+    auth = AuthContext(
+        user_id=str(system_member.id), email=None,
+        claims={"app_metadata": {"api_key_id": "system-publisher"}}, org_id=str(org_id),
+    )
+    result = await _publish_registry_event_core(
+        db, org_id, auth, definition_key, payload, background_tasks,
+    )
+    if result.get("zero_reach_warning"):
+        logger.warning(
+            "preset event zero_reach — 도달 0명(org=%s definition=%s payload_keys=%s)",
+            org_id, definition_key, sorted(payload.keys()),
         )
     return result
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1310,12 +1310,13 @@ async def publish_preset_event(
     org_id: uuid.UUID,
     definition_key: str,
     payload: dict,
-    background_tasks: BackgroundTasks,
 ) -> dict | None:
     """story #2791(P0, event-workflow-unification-design-2790) — 서버 도메인 전이 지점
     (상태변경·배정·게이트판정·목표측정)에서 호출하는 자동발행 진입점. HTTP 요청 컨텍스트
-    없이 `_publish_registry_event_core`를 그대로 호출해 #2633 AC2 단일 발행 파이프 원칙을
-    지킨다 — 신규 발행 갈래를 만들지 않는다.
+    없이(4개 호출부 전부 `BackgroundTasks` 미보유 — 시그니처 확장 대신 이 함수가 자체
+    `BackgroundTasks()`를 만들어 `_publish_registry_event_core` 완료 직후 즉시 실행한다,
+    HTTP 응답 이후로 미룰 대상이 없으므로 안전) `_publish_registry_event_core`를 그대로
+    호출해 #2633 AC2 단일 발행 파이프 원칙을 지킨다 — 신규 발행 갈래를 만들지 않는다.
 
     **구계통(story_status_events.py 등 SSE·웹훅·알림)과의 관계는 병행이다, 대체가 아니다**
     — 이 함수는 기존 5-effect 옆에 프리셋 발행을 하나 더 추가할 뿐, 기존 effect를 하나도
@@ -1351,9 +1352,11 @@ async def publish_preset_event(
         user_id=str(system_member.id), email=None,
         claims={"app_metadata": {"api_key_id": "system-publisher"}}, org_id=str(org_id),
     )
+    background_tasks = BackgroundTasks()
     result = await _publish_registry_event_core(
         db, org_id, auth, definition_key, payload, background_tasks,
     )
+    await background_tasks()
     if result.get("zero_reach_warning"):
         logger.warning(
             "preset event zero_reach — 도달 0명(org=%s definition=%s payload_keys=%s)",

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1249,8 +1249,14 @@ async def _get_or_create_system_publisher(db: AsyncSession, org_id: uuid.UUID) -
 
     `type='agent'`로 만들어 기존 서킷브레이커(agent 발신자 전용, story #2630)가 자동발행
     폭주(전이 루프)도 그대로 방어하게 한다 — 의도적으로 끄지 않는다(P0 가드②). 마커는
-    `members.handle`(구 에이전트 @멘션 핸들, story #2646이 완전히 은퇴시킨 죽은 필드) 재사용
-    — `runtime_type`(9종 enum, agent_runtime capability registry 실 조회 키)과 충돌 회피.
+    `members.runtime_type`(9종 enum이지만 `get_runtime_capability`가 미등록 문자열을
+    UNSUPPORTED_CAPABILITY로 안전 처리 — app/services/agent_runtime.py 확인) 재사용 —
+    `team_members` 뷰가 이 컬럼을 그대로 투영해 `send_message()` 등 뷰 기반 호출부가 값을
+    직접 읽을 수 있다(초판은 `handle`을 썼으나 뷰가 그 컬럼을 투영 안 해 재QA 중 정정,
+    0258 참조). 이 마커가 실제로 쓰이는 자리 — `send_message()`가 발신자 `runtime_type`이
+    이 값이면 presence/working 방출을 스킵한다(아래 가드③ 참조: system 발신자는 애초에
+    "지금 활동 중"이라는 presence 개념이 성립하지 않는 존재라 org 전체에 그 신호를 쏘는
+    것 자체가 의미론적으로 틀렸다는 판단, 페드루 2026-08-19).
     이름 "시스템 발행"은 채팅 카드의 sender 표시가 사람 눈에 시스템 발행임을 신규 FE 없이
     이름만으로 읽히게 하기 위함(P0 가드④) — 팀멤버 목록·리더보드·워크포스 표면에는 이 이름
     그대로의 agent 1명으로 노출된다(관측 기록, P0 스코프 밖 — 페드루 2026-08-19 확認).
@@ -1263,7 +1269,7 @@ async def _get_or_create_system_publisher(db: AsyncSession, org_id: uuid.UUID) -
 
     existing = (await db.execute(
         select(Member).where(
-            Member.org_id == org_id, Member.handle == "system-publisher", Member.type == "agent",
+            Member.org_id == org_id, Member.runtime_type == "system-publisher", Member.type == "agent",
         ).limit(1)
     )).scalars().first()
     if existing is not None:
@@ -1280,17 +1286,17 @@ async def _get_or_create_system_publisher(db: AsyncSession, org_id: uuid.UUID) -
 
     ins = pg_insert(Member).values(
         id=uuid.uuid4(), org_id=org_id, type="agent", name="시스템 발행",
-        handle="system-publisher", is_active=True,
+        runtime_type="system-publisher", is_active=True,
     ).on_conflict_do_nothing(
         index_elements=["org_id"],
-        index_where=(and_(Member.handle == "system-publisher", Member.type == "agent")),
+        index_where=(and_(Member.runtime_type == "system-publisher", Member.type == "agent")),
     ).returning(Member.id)
     member_id = (await db.execute(ins)).scalar_one_or_none()
     if member_id is None:
         # 동시요청 레이스로 다른 트랜잭션이 먼저 생성 — 재조회(asset_registry.py와 동일 TOCTOU 대응).
         return (await db.execute(
             select(Member).where(
-                Member.org_id == org_id, Member.handle == "system-publisher", Member.type == "agent",
+                Member.org_id == org_id, Member.runtime_type == "system-publisher", Member.type == "agent",
             )
         )).scalars().one()
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1228,31 +1228,42 @@ async def _publish_registry_event_core(
     return result
 
 
-async def _get_or_create_system_publisher(db: AsyncSession, org_id: uuid.UUID) -> "TeamMember":
+async def _get_or_create_system_publisher(db: AsyncSession, org_id: uuid.UUID) -> "Member":
     """story #2791(P0) — 서버 도메인 전이 자동발행 전용 시스템 발신자. org당 정확히 1행
     (0258 부분 유니크 인덱스로 DB 레벨 동시성 가드), get-or-create 멱등.
+
+    ⚠️`team_members`가 아니라 **`members`**(anchor 테이블)에 직접 쓴다 — `team_members`는
+    0088+에서 `members`/`project_access`/`agent_project_profiles` 위 3-way UNION ALL VIEW로
+    전환됐다(초판 실수 CI가 실측으로 잡아냄, 0258 참조). `send_message`의 sender 해석
+    (conversations.py::`_resolve_member`, api_key 분기)은 `team_members` 뷰를 `TeamMember.id
+    == auth.user_id`로 SELECT하므로, 이 member가 뷰에 최소 1행 투영되려면 `project_access`
+    grant가 최소 1건 있어야 한다(뷰의 3번째 UNION 브랜치 — profile 없는 agent-grant-only).
 
     소유·수명: 이 org가 존재하는 한 영구 — 별도 TTL·수동 정리 없음(자동발행 자체가 이 org
     수명과 결합돼 있어 "고아 리소스" 클래스가 아니다).
 
-    `project_id`는 team_members 스키마상 NOT NULL이지만, 이 member로 발행할 때 쓰는
-    `send_message`의 sender 해석(conversations.py::`_resolve_member`, api_key 분기)은
-    `TeamMember.id` 존재만 확인하고 project_id는 안 읽는다(2026-08-19 실측, story #2791 PR
-    참조) — 그래서 org 내 아무 project 하나에 anchor해도 org 전역 전이 이벤트 발행에
-    문제없다. `type='agent'`로 만들어 기존 서킷브레이커(agent 발신자 전용, story #2630)가
-    자동발행 폭주(전이 루프)도 그대로 방어하게 한다 — 의도적으로 끄지 않는다(P0 가드②).
+    project_access의 `project_id`는 org 내 아무 project 하나에 anchor해도 무방(2026-08-19
+    실측, story #2791 PR 참조) — sender 해석 자체는 project 무관, 그 project를 특정
+    대화방에 결부시키는 것도 아니다(발행 대상 conversation의 project_id는 매 호출마다
+    `_resolve_event_project_id`가 payload의 work_item/goal에서 별도로 뽑는다).
+
+    `type='agent'`로 만들어 기존 서킷브레이커(agent 발신자 전용, story #2630)가 자동발행
+    폭주(전이 루프)도 그대로 방어하게 한다 — 의도적으로 끄지 않는다(P0 가드②). 마커는
+    `members.handle`(구 에이전트 @멘션 핸들, story #2646이 완전히 은퇴시킨 죽은 필드) 재사용
+    — `runtime_type`(9종 enum, agent_runtime capability registry 실 조회 키)과 충돌 회피.
     이름 "시스템 발행"은 채팅 카드의 sender 표시가 사람 눈에 시스템 발행임을 신규 FE 없이
     이름만으로 읽히게 하기 위함(P0 가드④) — 팀멤버 목록·리더보드·워크포스 표면에는 이 이름
     그대로의 agent 1명으로 노출된다(관측 기록, P0 스코프 밖 — 페드루 2026-08-19 확認).
     """
     from sqlalchemy.dialects.postgresql import insert as pg_insert
 
+    from app.models.member import Member
     from app.models.project import Project
-    from app.models.team import TeamMember
+    from app.models.project_access import ProjectAccess
 
     existing = (await db.execute(
-        select(TeamMember).where(
-            TeamMember.org_id == org_id, TeamMember.runtime_type == "system-publisher",
+        select(Member).where(
+            Member.org_id == org_id, Member.handle == "system-publisher", Member.type == "agent",
         ).limit(1)
     )).scalars().first()
     if existing is not None:
@@ -1267,24 +1278,31 @@ async def _get_or_create_system_publisher(db: AsyncSession, org_id: uuid.UUID) -
     if anchor_project_id is None:
         raise ValueError(f"org {org_id}에 anchor할 project가 없음 — 시스템 발신자 프로비저닝 불가")
 
-    ins = pg_insert(TeamMember).values(
-        id=uuid.uuid4(), org_id=org_id, project_id=anchor_project_id,
-        type="agent", name="시스템 발행", role="member",
-        runtime_type="system-publisher", is_active=True,
+    ins = pg_insert(Member).values(
+        id=uuid.uuid4(), org_id=org_id, type="agent", name="시스템 발행",
+        handle="system-publisher", is_active=True,
     ).on_conflict_do_nothing(
         index_elements=["org_id"],
-        index_where=(TeamMember.runtime_type == "system-publisher"),
-    ).returning(TeamMember.id)
+        index_where=(and_(Member.handle == "system-publisher", Member.type == "agent")),
+    ).returning(Member.id)
     member_id = (await db.execute(ins)).scalar_one_or_none()
     if member_id is None:
         # 동시요청 레이스로 다른 트랜잭션이 먼저 생성 — 재조회(asset_registry.py와 동일 TOCTOU 대응).
         return (await db.execute(
-            select(TeamMember).where(
-                TeamMember.org_id == org_id, TeamMember.runtime_type == "system-publisher",
+            select(Member).where(
+                Member.org_id == org_id, Member.handle == "system-publisher", Member.type == "agent",
             )
         )).scalars().one()
+
+    # team_members 뷰(3번째 UNION 브랜치)에 투영되려면 project_access grant가 최소 1건 필요.
+    # 별도 on_conflict 불요 — 위 members insert가 org당 1행을 이미 원자적으로 게이팅해서,
+    # 이 라인엔 그 레이스를 이긴 트랜잭션 단 하나만 도달한다(재조회 분기는 여기 안 옴).
+    db.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=anchor_project_id, org_member_id=None,
+        member_id=member_id, permission="granted", role="member",
+    ))
     await db.flush()
-    return (await db.execute(select(TeamMember).where(TeamMember.id == member_id))).scalars().one()
+    return (await db.execute(select(Member).where(Member.id == member_id))).scalars().one()
 
 
 async def publish_preset_event(

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -1295,6 +1295,27 @@ async def _record_gate_review_verdict(
         facts["rubber_stamp_candidate"] = True
         gate.neutral_facts = facts
 
+    # story #2791(P0, event-workflow-unification-design-2790) — preset.gate.verdict 서버
+    # 자동발행. 위 record_verdict와 동일 게이팅(participation 존재·work_item_type=story)
+    # 스코프 그대로 — best-effort 격리는 호출자(여기) 몫.
+    try:
+        from app.routers.events import publish_preset_event
+
+        await publish_preset_event(
+            session, org_id, "preset.gate.verdict",
+            {
+                "work_item_type": gate.work_item_type,
+                "work_item_id": str(gate.work_item_id),
+                "gate_type": gate.gate_type,
+                "verdict": new_status,
+                "resolver_member_id": str(resolver_id),
+            },
+        )
+    except Exception:
+        logger.warning(
+            "preset.gate.verdict 자동발행 실패(gate=%s org=%s)", gate.id, org_id, exc_info=True,
+        )
+
 
 async def resolve_gate_from_verdict(
     session: AsyncSession,

--- a/backend/app/services/story_assignee_events.py
+++ b/backend/app/services/story_assignee_events.py
@@ -207,3 +207,27 @@ async def emit_story_assignee_changed(
             await db.flush()
         except Exception:
             pass
+
+    # story #2791(P0, event-workflow-unification-design-2790) — preset.work.assigned 서버
+    # 자동발행. payload_schema(0245)가 assignee_member_id를 필수(nullable 아님)로 요구해
+    # 미배정 전이(unassign, story.assignee_id=None)는 발행 대상이 아니다 — 배정 성립 시에만.
+    # 구계통(위 dispatch_notification/webhook 등)과 병행(대체 아님), best-effort 격리는
+    # 호출자(여기) 몫.
+    if story.assignee_id:
+        try:
+            from app.routers.events import publish_preset_event
+
+            await publish_preset_event(
+                db, org_id, "preset.work.assigned",
+                {
+                    "work_item_type": "story",
+                    "work_item_id": str(story.id),
+                    "assignee_member_id": str(story.assignee_id),
+                    "assigned_by_member_id": str(actor_id) if actor_id else None,
+                },
+            )
+        except Exception:
+            logger.warning(
+                "preset.work.assigned 자동발행 실패(story=%s org=%s)",
+                story.id, org_id, exc_info=True,
+            )

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -309,6 +309,29 @@ async def emit_story_status_changed(
     except Exception:
         pass
 
+    # story #2791(P0, event-workflow-unification-design-2790) — preset.work.status_changed
+    # 서버 자동발행. 구계통(위 5-effect)과 **병행**(대체 아님) — 이벤트 레지스트리 발행
+    # 대화 메시지를 하나 더 추가할 뿐 기존 SSE/webhook/notification은 무변경. best-effort
+    # 격리는 여기(호출자)의 몫 — publish_preset_event 자체는 예외를 안 삼킨다.
+    try:
+        from app.routers.events import publish_preset_event
+
+        await publish_preset_event(
+            db, org_id, "preset.work.status_changed",
+            {
+                "work_item_type": "story",
+                "work_item_id": str(story.id),
+                "from_status": old_status,
+                "to_status": story.status,
+                "changed_by_member_id": str(actor_id) if actor_id else None,
+            },
+        )
+    except Exception:
+        logger.warning(
+            "preset.work.status_changed 자동발행 실패(story=%s org=%s)",
+            story.id, org_id, exc_info=True,
+        )
+
 
 async def advance_story_to_done(
     db: AsyncSession,

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -316,16 +316,20 @@ async def emit_story_status_changed(
     try:
         from app.routers.events import publish_preset_event
 
-        await publish_preset_event(
-            db, org_id, "preset.work.status_changed",
-            {
-                "work_item_type": "story",
-                "work_item_id": str(story.id),
-                "from_status": old_status,
-                "to_status": story.status,
-                "changed_by_member_id": str(actor_id) if actor_id else None,
-            },
-        )
+        # ⛔실버그(디디군 교차QA, 2026-08-19) — payload_schema(0245)의 changed_by_member_id는
+        # `{"type":"string","format":"uuid"}`로 non-nullable(assigned_by_member_id와 달리
+        # null 허용 union이 아님). actor_id 없는 전이(시스템/자동 전이 — 바로 이 P0 자동발행
+        # 자체가 그 사례)에서 값을 None으로 실으면 스키마 위반 400 → 발행이 영구 불발됐었다.
+        # 키가 required는 아니므로 값이 없으면 아예 안 싣는다(스키마상 정직한 표현).
+        payload = {
+            "work_item_type": "story",
+            "work_item_id": str(story.id),
+            "from_status": old_status,
+            "to_status": story.status,
+        }
+        if actor_id:
+            payload["changed_by_member_id"] = str(actor_id)
+        await publish_preset_event(db, org_id, "preset.work.status_changed", payload)
     except Exception:
         logger.warning(
             "preset.work.status_changed 자동발행 실패(story=%s org=%s)",

--- a/backend/tests/test_2791_status_changed_actorless_publish.py
+++ b/backend/tests/test_2791_status_changed_actorless_publish.py
@@ -1,0 +1,128 @@
+"""story #2791(P0, event-workflow-unification-design-2790) — 회귀 테스트.
+
+디디군 교차QA 실버그(2026-08-19): `preset.work.status_changed`의 `changed_by_member_id`는
+payload_schema(0245)상 `{"type":"string","format":"uuid"}`로 non-nullable(`preset.work.assigned`
+의 `assigned_by_member_id`와 달리 null union이 아님) — actor_id 없는 전이(시스템/자동 전이,
+정확히 이 P0 자동발행 자체가 그 사례)에서 값을 `None`으로 실으면 스키마 위반 400으로
+`publish_preset_event`가 예외를 던지고, 호출자(`emit_story_status_changed`)의 try/except가
+그 실패를 삼켜 로그만 남긴 채 **그 전이의 발행이 영구 불발**됐다. fix = actor_id 없으면
+`changed_by_member_id` 키 자체를 payload에서 생략.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_story(session):
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="ready-for-dev")
+    session.add(story)
+    await session.commit()
+
+    return org.id, story
+
+
+@pytest.mark.anyio
+async def test_status_changed_without_actor_id_still_publishes():
+    """actor_id 없는 전이(시스템 자동전이)도 preset.work.status_changed 발행이 성립한다 —
+    payload에 changed_by_member_id 키 자체가 없어야 함(None 값 실어 스키마위반 400 유발 금지)."""
+    from app.services.story_status_events import emit_story_status_changed
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, story = await _seed_story(s)
+
+        async with Session() as s:
+            story = await s.get(type(story), story.id)
+            old_status = story.status
+            story.status = "in-progress"
+
+            with patch(
+                "app.routers.events.publish_preset_event", new=AsyncMock(return_value={"zero_reach_warning": False}),
+            ) as publish_mock:
+                await emit_story_status_changed(s, org_id, story, old_status, actor_id=None)
+                await s.commit()
+
+            publish_mock.assert_awaited_once()
+            args, kwargs = publish_mock.await_args
+            # 호출 시그니처: (db, org_id, definition_key, payload)
+            payload = args[3] if len(args) > 3 else kwargs.get("payload")
+            assert payload["work_item_type"] == "story"
+            assert payload["from_status"] == old_status
+            assert payload["to_status"] == "in-progress"
+            assert "changed_by_member_id" not in payload, (
+                "actor_id=None인데 changed_by_member_id 키가 실려있음 — "
+                "non-nullable 필드에 null을 실어 스키마위반을 유발하는 회귀"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_status_changed_with_actor_id_includes_member_id():
+    """대조군 — actor_id가 있으면 changed_by_member_id가 정상적으로 실린다(회귀 없음)."""
+    from app.services.story_status_events import emit_story_status_changed
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, story = await _seed_story(s)
+
+        actor_id = uuid.uuid4()
+        async with Session() as s:
+            story = await s.get(type(story), story.id)
+            old_status = story.status
+            story.status = "in-progress"
+
+            with patch(
+                "app.routers.events.publish_preset_event", new=AsyncMock(return_value={"zero_reach_warning": False}),
+            ) as publish_mock:
+                await emit_story_status_changed(s, org_id, story, old_status, actor_id=actor_id)
+                await s.commit()
+
+            args, kwargs = publish_mock.await_args
+            payload = args[3] if len(args) > 3 else kwargs.get("payload")
+            assert payload["changed_by_member_id"] == str(actor_id)
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2791_system_publisher_no_presence_emission.py
+++ b/backend/tests/test_2791_system_publisher_no_presence_emission.py
@@ -1,0 +1,145 @@
+"""story #2791(P0, event-workflow-unification-design-2790) — 역방향 회귀 테스트.
+
+페드루 판정(2026-08-19, 가드③) — system publisher(서버 자동발행 전용 합성 발신자)로
+`send_message()`를 호출할 때 `chat_presence.clear_working`/`emit_conversation_working`/
+`emit_presence`가 **0회** 호출됨을 직접 assert한다. 이 부수효과(org-wide presence 방출)가
+PO 가드레일 테스트(test_e_ui_daegbyeon_9ef0f914_sse_bridge_realdb.py::
+test_cross_project_member_does_not_receive_push_hard_gate)를 우연히 깨뜨린 것이 이 fix의
+계기 — 그 테스트는 **한 글자도 안 건드리지 않는다**(fix가 옳으면 그 테스트가 저절로 선다).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org + project(preset event definitions는 전역 시드 — 0245) + story(in-review)."""
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="in-review")
+    session.add(story)
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "story_id": story.id}
+
+
+@pytest.mark.anyio
+async def test_system_publisher_send_message_emits_zero_presence():
+    """publish_preset_event(system publisher 경유)가 emit_presence/emit_conversation_working/
+    chat_presence.clear_working을 전혀 호출하지 않는다 — presence는 "지금 활동 중"이라는
+    신호인데 system 발신자에겐 그 개념 자체가 성립하지 않는다(가드③ 근거, 우회 아니라
+    의미 정정)."""
+    from app.routers.events import publish_preset_event
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        async with Session() as s:
+            with patch("app.services.presence_events.emit_presence", new=AsyncMock()) as presence_mock, \
+                 patch("app.services.presence_events.emit_conversation_working", new=AsyncMock()) as working_mock, \
+                 patch("app.services.chat_presence.clear_working", new=AsyncMock()) as clear_mock:
+                result = await publish_preset_event(
+                    s, seeded["org_id"], "preset.work.status_changed",
+                    {
+                        "work_item_type": "story",
+                        "work_item_id": str(seeded["story_id"]),
+                        "from_status": "in-review",
+                        "to_status": "in-progress",
+                    },
+                )
+                await s.commit()
+
+        assert result is not None, "preset.work.status_changed definition이 전역 시드에 없음(0245 확인 필요)"
+        presence_mock.assert_not_awaited()
+        working_mock.assert_not_awaited()
+        clear_mock.assert_not_awaited()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_sender_send_message_still_emits_presence_no_regression():
+    """대조군 — 일반 human 발신자는 이 스킵 분기에 안 걸려 기존 presence 방출이 그대로
+    유지된다(회귀 없음, system publisher만 좁게 스킵됨을 실증)."""
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+    from app.routers.conversations import SendMessageRequest, send_message
+    from app.dependencies.auth import AuthContext
+    from fastapi import BackgroundTasks
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            human = Member(id=uuid.uuid4(), org_id=seeded["org_id"], type="human", name="H")
+            s.add(human)
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=seeded["project_id"], member_id=human.id, permission="granted",
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            from app.models.conversation import Conversation, ConversationParticipant
+
+            conv = Conversation(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"], type="dm")
+            s.add(conv)
+            await s.commit()
+            s.add(ConversationParticipant(conversation_id=conv.id, member_id=human.id))
+            await s.commit()
+
+            auth = AuthContext(
+                user_id=str(human.id), email=None,
+                claims={"app_metadata": {"api_key_id": "human-team-member"}}, org_id=str(seeded["org_id"]),
+            )
+            with patch("app.services.presence_events.emit_presence", new=AsyncMock()) as presence_mock:
+                await send_message(
+                    conv.id, SendMessageRequest(content="hi"), BackgroundTasks(),
+                    db=s, auth=auth, org_id=seeded["org_id"],
+                )
+                await s.commit()
+
+        presence_mock.assert_awaited_once()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## WIP — P0(core 추출+4전이지점 배선), draft

story #2791([2790·P0] 도메인 전이 서버 자동 발행 배선 — 프리셋 4종 «발행자 공백» 폐지). 설계 정본: doc `event-workflow-unification-design-2790`(84ef0cb7... → 1e1acbb0).

**이 PR의 현재 범위**: `publish_registry_event` core 추출 + 서버 자동발행 진입점 + system publisher 프로비저닝 + 4개 전이지점(상태변경·배정·게이트판정·목표측정) 배선. CI realdb 전량 green 확認 후 draft 해제.

## 변경 사항
- `_publish_registry_event_core`(app/routers/events.py): 기존 `publish_registry_event`의 로직을 순수 추출(mechanical move — 로직 변경 0, `body.*` 참조를 파라미터명으로만 치환). HTTP 엔드포인트는 이제 auth 의존성만 해석해 이 core에 위임.
- `publish_preset_event`: HTTP 요청 컨텍스트 없이(cron·gate_service 등) core를 호출하는 서버 자동발행 진입점. 자체 `BackgroundTasks()`를 만들어 완료 직후 즉시 실행(4개 호출부 전부 BackgroundTasks 미보유 — 시그니처 확장 없이 해결).
- `_get_or_create_system_publisher`: org당 1행 시스템 발신자(**`members`+`project_access`**, 아래 「초판 실수」 참조) 멱등 get-or-create.
- migration `0258`: `members(org_id)` 부분 유니크 인덱스(`runtime_type='system-publisher' AND type='agent'`) — 위 get-or-create의 동시성 가드.
- 4개 전이지점 배선(각각 try/except 격리):
  - `story_status_events.py::emit_story_status_changed` → `preset.work.status_changed`
  - `story_assignee_events.py::emit_story_assignee_changed` → `preset.work.assigned`(배정 성립 시만, unassign은 payload_schema 필수필드 부재로 스킵)
  - `gate_service.py::_record_gate_review_verdict` → `preset.gate.verdict`(기존 `record_verdict`와 동일 게이팅)
  - `cron.py::score_ga4_outcomes`(goal 채점) → `preset.goal.measured`(outcome_status가 hit/miss로 확정된 실측만)
- `conversations.py::send_message`: system publisher(`runtime_type='system-publisher'`) 발신자면 `clear_working`/`emit_conversation_working`/`emit_presence` 스킵 — 아래 「presence 방출 스킵」 참조.

## ⛔초판 실수 — team_members는 VIEW (CI realdb가 즉시 발각)
최초 커밋은 `team_members`를 실 테이블로 오판(모델 `__tablename__="team_members"`만 보고 판단)해 그 위에 인덱스·INSERT를 시도 — CI Alembic 잡이 "cannot create index on relation ... not supported for views"로 즉사시킴. `team_members`는 0088+에서 `members`/`project_access`/`agent_project_profiles` 위 3-way UNION ALL VIEW로 전환된 지 오래됨(0110 최신 정의). 실 anchor 테이블 `members`(+투영 조건인 `project_access` grant 1건)로 정정 — CI 재실행 전량 SUCCESS로 확認.

마커도 초판엔 `members.handle`(구 에이전트 @멘션 핸들, 죽은 필드)을 썼으나 — `team_members` 뷰가 `handle`을 투영하지 않아 `send_message()` 등 뷰 기반 호출부에서 못 읽는다는 게 아래 presence 이슈 대응 중 드러나 `runtime_type`(9종 enum이지만 `get_runtime_capability`가 미등록 문자열도 안전 처리, agent_runtime.py 확인)으로 재정정.

## presence 방출 스킵 — 재QA 중 발견한 부수효과 정정(페드루 판정, 2026-08-19)
4개 전이지점 배선 push 후 PO 가드레일 테스트(`test_e_ui_daegbyeon_9ef0f914_sse_bridge_realdb.py::test_cross_project_member_does_not_receive_push_hard_gate`, story 9ef0f914, "project_b 멤버는 project_a 이벤트를 절대 못 받는다")가 깨짐. 근본원인: `preset.gate.verdict` 배선이 타는 `send_message()`(인간 채팅용 풀파이프)가 부수효과로 `emit_presence(org_id)`를 무조건 호출하는데, 이게 **의도적으로 org 전체**(`push_to_org_members`, story #2139 확定설계, project 무관)로 나가 테스트의 project_b 멤버 큐에도 도달(실 이벤트 콘텐츠 누설은 아님 — presence는 빈 payload `{}`. 하지만 테스트는 "큐가 비어있어야 함"만 보므로 콘텐츠 무관하게 실패).

**판정(우회 아니라 의미 정정)**: presence·working은 "이 구성원이 지금 활동 중"이라는 신호인데, system 발행자는 애초에 presence 개념이 성립하지 않는 존재라 그걸 org 전체에 쏘는 것 자체가 원래 틀렸다. 사람이 실제로 타이핑할 때만 타던 이 경로의 암묵 전제가, 도메인 전이마다 대량으로 트리거되는 자동발행에서 처음 드러난 것 — 그라운딩 시점엔 안 보였던 send_message 풀파이프 재사용의 숨은 비용.

**가드 3개(페드루 요구, 전부 반영)**:
ⓐ 스킵 조건은 system publisher 발신자로 좁게(`sender.runtime_type == "system-publisher"`, `getattr` 안전접근 — human 발신자의 `ResolvedMember`엔 이 필드 자체가 없음) — `send_message` 안 1개 조건분기, 의미론 근거를 주석에 명시.
ⓑ PO 가드레일 테스트(9ef0f914)는 **한 글자도 안 건드림** — fix가 옳으면 그 테스트가 저절로 선다(실제로 이 fix 전엔 실패, fix 후 CI에서 재확認 예정).
ⓒ 역방향 회귀 테스트 신설(`test_2791_system_publisher_no_presence_emission.py`): system publisher 경유 `send_message`가 presence류 3함수(`emit_presence`/`emit_conversation_working`/`chat_presence.clear_working`) 호출 0회임을 직접 assert + 대조군(일반 human 발신자는 기존대로 presence 방출 유지, 회귀 없음 실증).

**관측 기록**: 이 정정 결과 — 매 도메인 전이(상태변경/배정/게이트판정/목표측정)가 더 이상 org-wide presence refetch 신호를 유발하지 않는다(정정 前이었다면 자동발행 대량트리거 시 노이즈/성능 부담이 됐을 것). 우연히 QA 하드게이트 충돌로 발견됐지만 독립적으로도 옳은 방향.

## 구계통(story_status_events.py 등)과의 관계 — 이관 계획(핵심 제약①)
**대체가 아니라 병행이다.** `story_status_events.py::emit_story_status_changed` 등 기존 5-effect(SSE outbox·webhook·L2 process_event·notification·StoryActivity)는 하나도 안 건드린다. `publish_preset_event` 호출은 이 5-effect **옆에** 프리셋 발행(이벤트 레지스트리 대화 메시지)을 하나 더 추가하는 것 — 수신 매체가 다르다(구계통=SSE/webhook/notification 채널, 신계통=이벤트 발행 대화). 이중발송처럼 보이지만 실제로는 서로 다른 표면이라 사용자에게 같은 정보가 두 채널로 보이는 것 자체가 설계 의도(2790 설계카드 P0 범위 — "이벤트는 받아 봐야 발견된다"). 대체(구계통 폐기)는 P1(통폐합) 스코프.

## 설계결정 — system member 승격 (페드루 확定, 2026-08-19)
서버 자동발행은 HTTP `AuthContext`가 없어 기존 `send_message`(conversations.py) 파이프를 통과할 신원이 필요. 두 갈래(① system member 합성 AuthContext로 기존 파이프 재사용 vs ② send_message 우회 하위경로 신설) 중 ①로 확定 — ②는 2790 설계철학("죽은 층에 다리 놓지 말고 하나로") 및 #2633 AC2(단일 발행 파이프) 원칙과 정면충돌.

**가드 4개 실측(페드루 요구, 전부 확認)**:
1. **결정적·멱등 프로비저닝**: org당 정확히 1행, `_get_or_create_system_publisher` 한 곳·migration 0258 부분유니크인덱스로 DB레벨 레이스가드. 소유·수명은 함수 docstring에 명시(org 존재기간=영구, 별도 TTL 없음).
2. **서킷브레이커 유지**: system publisher를 `type='agent'`로 생성 — 기존 `send_message`의 `if sender.type=="agent"` 서킷브레이커(story #2630) 분기가 그대로 적용됨(끄지 않음, 자동발행 폭주=전이 루프를 정확히 이 장치가 잡아야 하는 사고).
3. **auto-join/presence 실측**: `_get_or_create_event_conversation`이 참가자집합 **exact-match**로 대화를 찾거나 만들고, 그 집합은 항상 `{sender.id} | escalation_ids | broadcast_ids`(호출부에서 구성) — system publisher가 매치되는 모든 대화엔 이미 그 자신이 참가자로 포함돼 있다. `send_message`의 human-only auto-join 분기(`sender.type=="human"`)는 system(agent)에 애초에 안 걸리고, 참가자 403도 구조상 트리거 조건 자체가 불성립(우회가 아니라 발동 조건 미충족). presence는 위 별도 절 참조(재QA 중 추가 발견).
4. **채팅 표시**: 이름을 "시스템 발행"으로 고정 — FE 신규 발명 없이 sender 이름 표기만으로 사람 눈에 시스템 발행임이 읽힘.

**관측 기록(페드루 지적, P0 스코프 밖)**: system publisher가 `type='agent'`이므로 팀 멤버 목록·리더보드·워크포스 표면에 "시스템 발행"이라는 이름의 agent 1명으로 그대로 노출된다. 막을 필요까진 없다고 판단했으나(P0 스코프 밖), 향후 그 표면들에서 필터링이 필요해지면 이 관측을 근거로 판단할 것.

## zero-reach 침묵실패 금지 (핵심 제약②)
기존 `zero_reach_warning`은 HTTP 응답 필드(MCP가 사람 문장으로 강조)라 서버 자동발행(호출자=없음, 아무도 응답을 안 읽음)에선 그대로 두면 완전히 유실된다. `publish_preset_event`가 `zero_reach_warning=true`를 감지하면 `logger.warning(...)`으로 서버 로그에 남긴다.

## 발행 이력 실측(핵심 제약③)
신규 테이블/엔드포인트 불요 — 기존 `GET /api/v2/events/definitions/publish-history?definition_key=`(story #2665)가 `ConversationMessage.msg_metadata['event']['event_key']`를 SSOT로 조회하는 구조라, 4개 전이지점 배선이 실제로 발행을 시작하면 이 엔드포인트가 자동으로 0→N을 반영한다.

## 최저지능 에이전트 판별 기준(핵심 제약④)
프리셋 4종 전부 `action_auth: NULL`(0245 시드 확인) — 별도 role/human_only 분기 없이 누구나(시스템 포함) 수신 가능한 짧은 정형 이벤트. 4개 전이지점 payload는 각 preset의 `payload_schema`(0245) 필수필드만 채워 "다음 행동을 서버가 알려준다" 원칙을 지킨다.

## 검증
- app import smoke(`python -c "import app.main"`) 통과.
- 비-DB 로직 테스트(routing resolver·UUID validation·presence_events 등 기존 11개) 통과.
- core 추출 단독 커밋: CI realdb 전량 SUCCESS(1차 team_members 오판 fix 후) 확認.
- 4개 배선 커밋: Backend pytest에서 9ef0f914 하드게이트 충돌 발견 → presence 스킵 fix + 역방향 회귀 테스트 추가 → CI 재확認 대기 중.
- ⚠️이 세션 로컬환경은 SysV 공유메모리 고갈로 disposable PG 기동 불가(오늘 반복 재현, story #2798 별도 등재) — 모든 realdb 검증은 CI에 의존.

## Test plan
- [x] app import smoke
- [x] 비DB 로직 테스트(11개) 무회귀
- [x] core 추출 CI realdb 무회귀(1차 team_members 오판 정정 후 확認)
- [ ] 4개 배선 CI realdb 무회귀 + 9ef0f914 하드게이트 재통과 — draft 해제 조건
- [ ] 배선 후 전용 테스트(각 전이지점 실 트리거 → publish-history 0→N 실측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
