### PR TITLE
fix(#2771): office-converter 부트스트랩 실측 SSOT 반영

### DIFF
--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -62,7 +62,9 @@ _DECLARED_SUBSTITUTIONS = {
 # 아니라 이 스텝들로 좁힌다 — 넓히면 순수 YAML 주석(예: 다른 스텝을 설명하는 프로즈 안의
 # `${ENV}` 언급)에 오탐이 나서 안전한 주석을 억지로 고치게 만든다. bash entrypoint 스텝이
 # 새로 생기면 이 목록에 추가할 것(오르테가 지시 — deploy-realtime도 같은 함정 자리라 포함).
-_BASH_ENTRYPOINT_STEP_IDS = ("deploy-backend", "deploy-realtime")
+# story #2771 후속(2026-08-19) — deploy-office-converter도 실 substitution(${_DEPLOY_ENV} 등)을
+# 쓰는 bash entrypoint라 포함.
+_BASH_ENTRYPOINT_STEP_IDS = ("deploy-backend", "deploy-realtime", "deploy-office-converter")
 
 
 def _extract_step_script(step_id: str) -> str:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,15 +23,15 @@ substitutions:
   _ADMIN_OPERATOR_AUDIENCE: https://sprintable-backend-dev-57iommnikq-du.a.run.app
   _ADMIN_OPERATOR_ALLOWLIST: sprintable-admin-web@sprintable-494803.iam.gserviceaccount.com
   # story #2771(pptx 서버 변환, doc 84ef0cb7 §7-4) — office-converter는 아래 deploy-office-
-  # converter 스텝이 매 배포마다 재생성/갱신하지만, 그 서비스의 URL은 Cloud Run이 서비스명+
-  # 리전으로부터 배정하는 canonical 해시(_ADMIN_OPERATOR_AUDIENCE와 동일 함정 — 부트스트랩
-  # 전엔 알 수 없다). **부트스트랩 절차(PO 1회)**: 이 substitutions 그대로 첫 배포(office-
-  # converter만 뜨고 backend는 GOTENBERG_SERVICE_URL 없이 뜬다=503 fail-closed, 무해) →
+  # converter 스텝이 매 배포마다 재생성/갱신한다. **부트스트랩 완료(페드루군, 2026-08-19)**:
+  # 최초 배포가 --port 누락(Gotenberg는 3000, Cloud Run 헬스체크 기본 8080)으로 Ready 실패
+  # 했었다 — 수동 --port=3000 적용으로 리비전 00002 Ready 확認(위 deploy 스텝에 반영됨) 후
   # `gcloud run services describe office-converter-dev --region=asia-northeast3
-  # --format='value(status.url)'`로 실측 → 그 값을 여기 채워 재배포(그 뒤부터 정상 배선).
-  # 빈 문자열 기본값 = 컨벤션대로 이 env var 자체를 backend에 안 싣는다(office_conversion.py
-  # 가 미설정을 ConversionUnavailable=503으로 처리 — 가짜 렌더 금지 유지).
-  _GOTENBERG_SERVICE_URL: ''
+  # --format='value(status.url)'`로 아래 canonical 해시 URL 실측(_ADMIN_OPERATOR_AUDIENCE와
+  # 동일 표기 원칙 — services list의 project번호 표기 아닌 describe의 canonical hash 그대로).
+  # invoker 바인딩(cloudrun-runtime-dev=backend-dev 런타임 SA 실명 일치, 무인증 403 확認)도
+  # 수동 적용 완료 — 위 deploy 스텝의 순서 재구성으로 다음 배포부턴 자동 수렴.
+  _GOTENBERG_SERVICE_URL: 'https://office-converter-dev-57iommnikq-du.a.run.app'
   _OFFICE_CONVERTER_MAX_INSTANCES: '3'
   _BACKEND_MIN_INSTANCES: '1'
   # ⚠️ default '1'(아래) = _DEPLOY_ENV:dev default 와 정합한 **dev-safe fallback**(수동 `gcloud builds submit`
@@ -415,8 +415,13 @@ steps:
           echo "skip deploy-office-converter: prod gate pending (story #2771 dev 검증 후 오픈)"
           exit 0
         fi
+        # ⛔실배포 핫픽스(페드루군, 2026-08-19) — Gotenberg 이미지는 3000 포트에 듣는데 이
+        # --port 플래그가 없어 Cloud Run 기본값(8080)으로 헬스체크해 최초 배포가 Ready 실패
+        # 했다(리비전은 뜨지만 트래픽 라우팅 불가). --port=3000 명시로 근본 수정.
+        set +e
         gcloud run deploy office-converter-${_DEPLOY_ENV} \
           --image=gotenberg/gotenberg:8.36 \
+          --port=3000 \
           --region=${_AR_REGION} \
           --no-allow-unauthenticated \
           --concurrency=1 \
@@ -426,16 +431,29 @@ steps:
           --memory=2Gi \
           --timeout=120 \
           --quiet
-        # backend 런타임 SA(cloudrun-runtime-${_DEPLOY_ENV})에만 invoker 부여 — idempotent라
-        # 재실행 안전(이미 있으면 no-op). 이 배포 파이프라인 밖의 임의 호출자는 전부 403.
+        deploy_status=$?
+        set -e
+        # ⛔구조 수정(페드루군 지적, 2026-08-19) — 이전엔 이 바인딩이 위 deploy 성공(Ready)에
+        # 인질 잡혀 있었다: deploy가 Ready 실패(비-zero exit)하면 set -e가 스텝을 그 자리서
+        # 죽여 바인딩 명령까지 못 갔다(포트 핫픽스 이전 실측 사고 — invoker 미부여 상태로 방치,
+        # 수동 개입 필요). add-iam-policy-binding은 Ready 여부와 무관하게 서비스 리소스만
+        # 있으면 동작하므로(deploy가 Ready 실패해도 서비스 자체는 이미 생성돼 있다), deploy
+        # 성공 여부와 **분리**해 항상 시도한다(idempotent라 안전) — 그래야 향후 다른 이유로
+        # deploy가 일시적으로 non-Ready여도 IAM은 계속 맞는 상태로 수렴하고, deploy 자체의
+        # 실패는(가짜로 감추지 않고) 아래에서 그대로 다시 실패시켜 가시성을 유지한다.
         gcloud run services add-iam-policy-binding office-converter-${_DEPLOY_ENV} \
           --region=${_AR_REGION} \
           --member="serviceAccount:cloudrun-runtime-${_DEPLOY_ENV}@${PROJECT_ID}.iam.gserviceaccount.com" \
           --role="roles/run.invoker" \
           --quiet
+        if [ "$${deploy_status}" -ne 0 ]; then
+          echo "FAIL: office-converter-${_DEPLOY_ENV} deploy did not reach Ready (exit $${deploy_status})."
+          echo "      invoker binding was applied regardless — investigate the deploy failure itself."
+          exit "$${deploy_status}"
+        fi
         served=$(gcloud run services describe office-converter-${_DEPLOY_ENV} \
           --region=${_AR_REGION} --format='value(status.url)')
-        echo "OK: office-converter-${_DEPLOY_ENV} = $served"
+        echo "OK: office-converter-${_DEPLOY_ENV} = $${served}"
         if [ -z "${_GOTENBERG_SERVICE_URL}" ]; then
           echo "NOTE: _GOTENBERG_SERVICE_URL substitution이 비어 있다 — backend는 이 서비스를"
           echo "      아직 모른다(503 fail-closed). 위 URL을 substitutions에 채워 재배포할 것"


### PR DESCRIPTION
## Summary
PR #3226 머지가 트리거한 dev 배포에서 office-converter가 Ready 실패해 전체 파이프라인이 실패했다(backend-dev도 그 여파로 최신 코드 미반영). 페드루군이 수동으로 진단·복구했고, 이 PR은 그 수동 값/구조 수정을 deploy SSOT(cloudbuild.yaml)에 durable화한다("손 값은 다음 배포가 덮는다" 반복 교훈).

- **`--port=3000` 추가**: Gotenberg 이미지는 3000 포트에 듣는데 deploy 스텝에 `--port`가 없어 Cloud Run 기본 8080 헬스체크로 Ready 실패했다.
- **`_GOTENBERG_SERVICE_URL` 실측값 채움**: `https://office-converter-dev-57iommnikq-du.a.run.app`(canonical hash 표기, `_ADMIN_OPERATOR_AUDIENCE`와 동일 원칙) — 이제 backend 변환 엔드포인트가 503 대신 실동한다.
- **invoker 바인딩 순서 구조 수정**: 이전엔 바인딩이 `gcloud run deploy`의 Ready 성공에 인질 잡혀 있었다(Ready 실패=set -e로 스텝 즉시 종료=바인딩 명령까지 미도달, 이번에 실제로 발생해 수동 개입 필요했음). deploy exit status를 `set +e`/`set -e`로 분리 캡처 → invoker 바인딩은 무조건 시도(idempotent, 서비스 리소스만 있으면 Ready 여부 무관 동작) → deploy 자체가 실패했으면 그 실패를 그대로 다시 propagate(가짜로 성공 처리하지 않음).
- deploy-office-converter를 cloudbuild 이스케이프 가드(`_BASH_ENTRYPOINT_STEP_IDS`) 스캔 대상에 추가 — 로컬 검증 중 `$deploy_status`/`$served` 미이스케이프를 이 가드가 직접 잡아 `$${...}`로 고쳤다.

## Test plan
- [x] `python3 -c "import yaml; ..."` — cloudbuild.yaml 파싱 정상
- [x] `bash -n` — de-escape된 deploy-office-converter 스크립트 구문 검증
- [x] `test_deploy_backend_redis_secret_conflict.py` 등 cloudbuild 가드/env-drift 스위트 76 tests pass(신규 이스케이프 위반 자체 발견·수정 포함)
- [ ] 실배포는 이 PR 머지 후 자동(dev Cloud Build) — 페드루군 확認 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)