### PR TITLE
[SID:2803] pptx 인앱 미리보기 — 서버 변환 파이프 FE 통합

### DIFF
--- a/apps/web/src/app/api/attachments/convert/route.ts
+++ b/apps/web/src/app/api/attachments/convert/route.ts
@@ -1,0 +1,42 @@
+import { getServerSession } from '@/lib/db/server';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { handleApiError } from '@/lib/api-error';
+
+// story #2803 — pptx 인앱 미리보기: BE 변환 파이프(office_conversion.py, story #2771)로
+// 넘기는 얇은 프록시. 인가·캐시·변환 로직은 전부 BE 권위(그라운딩 doc 84ef0cb7 §7-3) —
+// 이 라우트는 세션 토큰을 얹어 그대로 위임하고 상태코드만 우리 응답 포맷으로 번역한다.
+//
+// POST /api/attachments/convert?asset_id=<uuid> → BE POST /api/v2/attachments/{asset_id}/convert
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+export async function POST(request: Request) {
+  try {
+    const session = await getServerSession().catch(() => null);
+    if (!session) return ApiErrors.unauthorized();
+
+    const { searchParams } = new URL(request.url);
+    const assetId = searchParams.get('asset_id');
+    if (!assetId) return ApiErrors.badRequest('asset_id is required');
+
+    const beUrl = new URL(`/api/v2/attachments/${assetId}/convert`, FASTAPI_URL());
+    const beRes = await fetch(beUrl.toString(), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: 'no-store',
+    });
+
+    if (beRes.status === 403) return ApiErrors.forbidden('첨부 접근 권한이 없습니다');
+    if (beRes.status === 404) return ApiErrors.notFound('asset not found');
+    if (beRes.status === 422) return ApiErrors.badRequest('변환 가능한 오피스 문서가 아닙니다');
+    // BE office_conversion.ConversionUnavailable — 변환 파이프 미배선 env(dev 전용 하드게이트 등).
+    if (beRes.status === 503) return apiError('CONVERSION_UNAVAILABLE', '변환 서비스가 아직 준비되지 않았습니다', 503);
+    // BE office_conversion.ConversionFailed — Gotenberg 왕복 실패.
+    if (beRes.status === 502) return apiError('CONVERSION_FAILED', '문서 변환에 실패했습니다', 502);
+    if (!beRes.ok) return ApiErrors.badRequest('conversion request failed');
+
+    const body = (await beRes.json()) as { asset_id?: string; name?: string; content_type?: string };
+    return apiSuccess(body);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/app/api/attachments/convert/route.ts
+++ b/apps/web/src/app/api/attachments/convert/route.ts
@@ -8,6 +8,9 @@ import { handleApiError } from '@/lib/api-error';
 //
 // POST /api/attachments/convert?asset_id=<uuid> → BE POST /api/v2/attachments/{asset_id}/convert
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+// 까디르군 QA(#2803) — asset_id를 검증 없이 BE 경로 세그먼트에 직접 보간하고 있었다(경로조작
+// 이론 위험). apps/web/src/app/api/assets/[id]/route.ts와 동일 패턴으로 UUID 형식만 통과.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export async function POST(request: Request) {
   try {
@@ -17,6 +20,7 @@ export async function POST(request: Request) {
     const { searchParams } = new URL(request.url);
     const assetId = searchParams.get('asset_id');
     if (!assetId) return ApiErrors.badRequest('asset_id is required');
+    if (!UUID_RE.test(assetId)) return ApiErrors.badRequest('invalid asset id');
 
     const beUrl = new URL(`/api/v2/attachments/${assetId}/convert`, FASTAPI_URL());
     const beRes = await fetch(beUrl.toString(), {

--- a/apps/web/src/components/chat/attachment-file.tsx
+++ b/apps/web/src/components/chat/attachment-file.tsx
@@ -20,18 +20,22 @@ interface AttachmentFileProps {
   /** story #2766(레인 A) — 채팅 호출부가 물려주면 클릭 시 새 탭 대신 ReadingPanel을 연다
    * (서명 URL 자체는 패널이 직접 뜬다 — 여기선 target 정보만 전달). 생략하면(undefined,
    * docs/kanban 등 채팅 밖 기존 호출부) 기존 window.open 다운로드 그대로 — 회귀 없음. */
-  onOpenPanel?: (target: { storedUrl: string; conversationId?: string; storyId?: string; label: string; contentType?: string | null }) => void;
+  onOpenPanel?: (target: { storedUrl: string; conversationId?: string; storyId?: string; label: string; contentType?: string | null; assetId?: string }) => void;
   contentType?: string | null;
+  /** story #2803 — 백엔드가 메시지 전송 시 asset registry에 역기입하는 denorm 필드
+   * (asset_registry.sync_attachment_assets). pptx 변환(POST /convert)은 asset_id 축이라
+   * 이게 있어야 그 뷰어 케이스가 동작한다 — 없으면(구 메시지 등) office 폴백으로 정직 축소. */
+  assetId?: string;
 }
 
-export function AttachmentFile({ storedUrl, conversationId, storyId, label, Icon, onOpenPanel, contentType }: AttachmentFileProps) {
+export function AttachmentFile({ storedUrl, conversationId, storyId, label, Icon, onOpenPanel, contentType, assetId }: AttachmentFileProps) {
   const t = useTranslations('chats');
   const { addToast } = useToast();
   const [loading, setLoading] = useState(false);
 
   const open = useCallback(async () => {
     if (onOpenPanel) {
-      onOpenPanel({ storedUrl, conversationId, storyId, label, contentType });
+      onOpenPanel({ storedUrl, conversationId, storyId, label, contentType, assetId });
       return;
     }
     if (loading) return;
@@ -57,7 +61,7 @@ export function AttachmentFile({ storedUrl, conversationId, storyId, label, Icon
     } finally {
       setLoading(false);
     }
-  }, [storedUrl, conversationId, storyId, label, contentType, loading, addToast, t, onOpenPanel]);
+  }, [storedUrl, conversationId, storyId, label, contentType, assetId, loading, addToast, t, onOpenPanel]);
 
   return (
     <button

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -650,6 +650,7 @@ export function ChatBubble({
                     label={label}
                     Icon={getFileIcon(att.content_type)}
                     contentType={att.content_type}
+                    assetId={att.asset_id}
                     onOpenPanel={
                       onOpenReadingPanel
                         ? (t) => onOpenReadingPanel({ kind: 'attachment', ...t })

--- a/apps/web/src/components/chat/file-viewer.format.test.ts
+++ b/apps/web/src/components/chat/file-viewer.format.test.ts
@@ -1,0 +1,50 @@
+// story #2803 QA(까디르군) 2라운드 — resolveFormat이 docx/pptx를 함수 최상단에서 확장자
+// 단독으로 확정하는지 table-driven으로 못박는다. 1라운드 수정(wordprocessingml/
+// presentationml보다만 앞섬)은 여전히 그 위의 image/pdf/html 등 content-type 판정에
+// 먼저 걸려 .pptx+content-type=application/pdf류가 깨진 pdf iframe으로 오라우팅되는
+// 결함을 남겼다 — 이 테이블이 그 클래스 전체(오명명 조합)를 재발 없이 고정한다.
+import { describe, it, expect } from 'vitest';
+import { resolveFormat } from './file-viewer';
+
+describe('resolveFormat — docx/pptx 확장자 우선순위(story #2803)', () => {
+  const cases: Array<[label: string, contentType: string | null | undefined, expected: string]> = [
+    // 정합 케이스 — 회귀 없음 확인.
+    ['deck.pptx', 'application/vnd.openxmlformats-officedocument.presentationml.presentation', 'pptx'],
+    ['doc.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'docx'],
+    ['photo.png', 'image/png', 'image'],
+    ['report.pdf', 'application/pdf', 'pdf'],
+    ['page.html', 'text/html', 'html'],
+    ['notes.txt', 'text/plain', 'text'],
+    ['legacy.ppt', 'application/vnd.ms-powerpoint', 'office'],
+    ['legacy.doc', 'application/msword', 'office'],
+    ['sheet.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'office'],
+
+    // 오명명(mismatch) — 확장자가 최종 진실이어야 한다. 이 조합들이 1라운드 수정 이후에도
+    // 여전히 깨져 있던 실제 버그(까디르군 2차 지적) — .pptx가 앞선 pdf/image/html/text
+    // content-type 판정에 먼저 걸려 broken iframe으로 렌더되던 경로.
+    ['mismatched.pptx', 'application/pdf', 'pptx'],
+    ['mismatched.docx', 'image/png', 'docx'],
+    ['mismatched.pptx', 'text/html', 'pptx'],
+    ['mismatched.docx', 'application/pdf', 'docx'],
+    ['mismatched.pptx', 'video/mp4', 'pptx'],
+    ['mismatched.docx', 'text/plain', 'docx'],
+    ['mismatched.pptx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'pptx'],
+    ['mismatched.docx', 'application/vnd.openxmlformats-officedocument.presentationml.presentation', 'docx'],
+    // 확장자만 있고 ct가 없거나 알 수 없는 경우.
+    ['no-ct.pptx', null, 'pptx'],
+    ['no-ct.docx', undefined, 'docx'],
+    ['no-ct.pptx', 'application/octet-stream', 'pptx'],
+
+    // 확장자가 없거나 못 알아볼 때만 content-type 폴백 — docx/pptx 확장자 없이 그 ct만
+    // 있는 경우는 여전히 ct로 판정(§7-3 실측 — 이 축은 그대로 유지).
+    ['no-ext', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'docx'],
+    ['no-ext', 'application/vnd.openxmlformats-officedocument.presentationml.presentation', 'pptx'],
+    ['unknown.xyz', 'application/x-unknown', 'unknown'],
+  ];
+
+  for (const [label, contentType, expected] of cases) {
+    it(`${label} × ${contentType ?? '(no content-type)'} → ${expected}`, () => {
+      expect(resolveFormat(contentType, label)).toBe(expected);
+    });
+  }
+});

--- a/apps/web/src/components/chat/file-viewer.pptx.test.tsx
+++ b/apps/web/src/components/chat/file-viewer.pptx.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+//
+// story #2803 — pptx 변환 파이프 FE 통합 실마운트 검증. [[feedback-render-test-over-source-grep]]
+// 동형: PptxBody가 실제로 convert→sign 왕복을 거쳐 PDF iframe을 렌더하는지, 변환 실패/시간
+// 초과 시 정직 폴백(빈 화면/무한 로딩 금지)으로 빠지는지, assetId 없는 첨부는 애초에 네트워크
+// 호출 없이 "준비 중"으로 정직 축소되는지를 실제 마운트로 확인한다.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { FileViewer } from './file-viewer';
+import type { ReadingPanelTarget } from './reading-panel';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('@/lib/db/client', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuthMock(...args),
+}));
+vi.mock('@/lib/native-shell-bridge', () => ({
+  downloadAsset: vi.fn(),
+  openExternal: vi.fn(),
+}));
+
+const ORIGINAL_ASSET_ID = 'orig-asset-2803';
+const CONVERTED_ASSET_ID = 'converted-asset-2803';
+
+const target: Extract<ReadingPanelTarget, { kind: 'attachment' }> = {
+  kind: 'attachment',
+  label: 'deck.pptx',
+  contentType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  assetId: ORIGINAL_ASSET_ID,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mount(node: React.ReactElement) {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => { root.render(node); });
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 5000) {
+  const start = Date.now();
+  while (!check()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out');
+    await act(async () => { await new Promise((r) => setTimeout(r, 20)); });
+  }
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status });
+}
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  fetchWithAuthMock.mockReset();
+});
+
+describe('FileViewer pptx (story #2803)', () => {
+  it('실 convert→sign 왕복을 거쳐 반환된 PDF asset을 iframe으로 렌더한다', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('/api/attachments/sign') && url.includes(`asset_id=${ORIGINAL_ASSET_ID}`)) {
+        return jsonResponse({ data: { url: 'https://signed.example/original.pptx' } });
+      }
+      if (url.includes('/api/attachments/convert') && init?.method === 'POST') {
+        expect(url).toContain(`asset_id=${ORIGINAL_ASSET_ID}`);
+        return jsonResponse({ data: { asset_id: CONVERTED_ASSET_ID, name: 'deck.pdf', content_type: 'application/pdf' } });
+      }
+      if (url.includes('/api/attachments/sign') && url.includes(`asset_id=${CONVERTED_ASSET_ID}`)) {
+        return jsonResponse({ data: { url: 'https://signed.example/deck.pdf' } });
+      }
+      throw new Error(`unexpected fetchWithAuth call: ${url}`);
+    });
+
+    mount(<FileViewer target={target} onClose={() => {}} />);
+    await waitFor(() => container.querySelector('iframe') !== null || container.textContent!.includes('변환에 실패했습니다'));
+
+    const iframe = container.querySelector('iframe');
+    expect(iframe, `iframe 없음. text=${container.textContent}`).not.toBeNull();
+    expect(iframe!.getAttribute('src')).toBe('https://signed.example/deck.pdf');
+    // "변환 중" 스피너는 사라져야 한다.
+    expect(container.textContent).not.toContain('변환 중입니다');
+  });
+
+  it('변환 서비스 미배선(503)이면 정직 폴백으로 빠진다 — 빈 화면/무한 로딩 금지', async () => {
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('/api/attachments/sign') && url.includes(`asset_id=${ORIGINAL_ASSET_ID}`)) {
+        return jsonResponse({ data: { url: 'https://signed.example/original.pptx' } });
+      }
+      if (url.includes('/api/attachments/convert') && init?.method === 'POST') {
+        return jsonResponse({ error: { message: '503' } }, 503);
+      }
+      throw new Error(`unexpected fetchWithAuth call: ${url}`);
+    });
+
+    mount(<FileViewer target={target} onClose={() => {}} />);
+    await waitFor(() => container.textContent!.includes('변환에 실패했습니다'));
+
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(container.querySelector('.animate-spin')).toBeNull();
+    expect(container.textContent).toContain('다운로드해 확인하세요');
+  });
+
+  it('assetId 없는 첨부는 네트워크 호출 없이 "준비 중"으로 정직 축소된다', async () => {
+    const legacyTarget: Extract<ReadingPanelTarget, { kind: 'attachment' }> = {
+      kind: 'attachment',
+      label: 'legacy.pptx',
+      contentType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    };
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url.includes('/api/attachments/sign')) return jsonResponse({ data: { url: 'https://signed.example/legacy.pptx' } });
+      throw new Error(`unexpected fetchWithAuth call for legacy target: ${url}`);
+    });
+
+    mount(<FileViewer target={legacyTarget} onClose={() => {}} />);
+    await waitFor(() => container.textContent!.includes('미리보기 준비 중입니다'));
+
+    expect(fetchWithAuthMock.mock.calls.some((call) => String(call[0]).includes('/convert'))).toBe(false);
+  });
+
+  it('fetch가 응답하지 않고 멈춰도(hang) 상한 타이머로 정직 폴백에 도달한다 — 무한 로딩 금지', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    fetchWithAuthMock.mockImplementation(async (url: string) => {
+      if (url.includes('/api/attachments/sign') && url.includes(`asset_id=${ORIGINAL_ASSET_ID}`)) {
+        return jsonResponse({ data: { url: 'https://signed.example/original.pptx' } });
+      }
+      // convert 요청만 영원히 응답하지 않음(hang 시뮬레이션).
+      return new Promise(() => {});
+    });
+
+    mount(<FileViewer target={target} onClose={() => {}} />);
+    await act(async () => { await Promise.resolve(); });
+    await act(async () => { await Promise.resolve(); });
+    expect(container.textContent).toContain('변환 중입니다');
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(130000); });
+
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(container.textContent).toContain('변환에 실패했습니다');
+    vi.useRealTimers();
+  });
+
+  it('상한 타이머로 failed 확정 후 convert가 뒤늦게 성공해도 상태가 되돌아가지 않는다(cancelled 레이스 가드)', async () => {
+    let resolveConvert: (res: Response) => void = () => {};
+    const pendingConvert = new Promise<Response>((resolve) => { resolveConvert = resolve; });
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('/api/attachments/sign') && url.includes(`asset_id=${ORIGINAL_ASSET_ID}`)) {
+        return jsonResponse({ data: { url: 'https://signed.example/original.pptx' } });
+      }
+      if (url.includes('/api/attachments/convert') && init?.method === 'POST') {
+        return pendingConvert;
+      }
+      if (url.includes('/api/attachments/sign') && url.includes(`asset_id=${CONVERTED_ASSET_ID}`)) {
+        return jsonResponse({ data: { url: 'https://signed.example/deck.pdf' } });
+      }
+      throw new Error(`unexpected fetchWithAuth call: ${url}`);
+    });
+
+    mount(<FileViewer target={target} onClose={() => {}} />);
+    await act(async () => { await Promise.resolve(); });
+    await act(async () => { await Promise.resolve(); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(130000); });
+    expect(container.textContent).toContain('변환에 실패했습니다');
+
+    // failed 확정 후에야 convert가 뒤늦게 성공 응답으로 resolve — 나머지(sign) 왕복이 실제로
+    // 흘러도 이미 확정된 failed를 되돌리면 안 된다.
+    vi.useRealTimers();
+    await act(async () => {
+      resolveConvert(jsonResponse({ data: { asset_id: CONVERTED_ASSET_ID, name: 'deck.pdf', content_type: 'application/pdf' } }));
+      await new Promise((r) => setTimeout(r, 300));
+    });
+
+    expect(container.textContent).toContain('변환에 실패했습니다');
+    expect(container.querySelector('iframe')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/file-viewer.pptx.test.tsx
+++ b/apps/web/src/components/chat/file-viewer.pptx.test.tsx
@@ -87,6 +87,36 @@ describe('FileViewer pptx (story #2803)', () => {
     expect(container.textContent).not.toContain('변환 중입니다');
   });
 
+  it('확장자 .pptx인데 content-type이 wordprocessingml(불일치)이어도 확장자 우선으로 pptx 분기를 탄다(까디르군 QA #2803)', async () => {
+    const mismatchedTarget: Extract<ReadingPanelTarget, { kind: 'attachment' }> = {
+      kind: 'attachment',
+      label: 'mismatched.pptx',
+      contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      assetId: ORIGINAL_ASSET_ID,
+    };
+    fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('/api/attachments/sign') && url.includes(`asset_id=${ORIGINAL_ASSET_ID}`)) {
+        return jsonResponse({ data: { url: 'https://signed.example/mismatched.pptx' } });
+      }
+      if (url.includes('/api/attachments/convert') && init?.method === 'POST') {
+        return jsonResponse({ data: { asset_id: CONVERTED_ASSET_ID, name: 'deck.pdf', content_type: 'application/pdf' } });
+      }
+      if (url.includes('/api/attachments/sign') && url.includes(`asset_id=${CONVERTED_ASSET_ID}`)) {
+        return jsonResponse({ data: { url: 'https://signed.example/deck.pdf' } });
+      }
+      throw new Error(`unexpected fetchWithAuth call: ${url}`);
+    });
+
+    mount(<FileViewer target={mismatchedTarget} onClose={() => {}} />);
+    // pptx로 갔다면 "변환 중" 표시를 거쳐 iframe이 뜬다. docx로 잘못 갔다면 window.fetch(미모킹)
+    // 호출이 던져 실패로 빠진다 — 둘 중 하나로 갈릴 때까지 기다려 실제로 pptx 경로임을 증명.
+    await waitFor(() => container.querySelector('iframe') !== null || container.textContent!.includes('실패'));
+
+    const iframe = container.querySelector('iframe');
+    expect(iframe, `iframe 없음(=docx로 오라우팅됐을 가능성). text=${container.textContent}`).not.toBeNull();
+    expect(iframe!.getAttribute('src')).toBe('https://signed.example/deck.pdf');
+  });
+
   it('변환 서비스 미배선(503)이면 정직 폴백으로 빠진다 — 빈 화면/무한 로딩 금지', async () => {
     fetchWithAuthMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url.includes('/api/attachments/sign') && url.includes(`asset_id=${ORIGINAL_ASSET_ID}`)) {

--- a/apps/web/src/components/chat/file-viewer.tsx
+++ b/apps/web/src/components/chat/file-viewer.tsx
@@ -15,21 +15,24 @@ type AttachmentTarget = Extract<ReadingPanelTarget, { kind: 'attachment' }>;
 // 나머지 office는 여전히 렌더러가 없다(가짜 렌더 금지).
 type Format = 'image' | 'video' | 'audio' | 'text' | 'html' | 'pdf' | 'docx' | 'pptx' | 'office' | 'unknown';
 
-function resolveFormat(contentType: string | null | undefined, label: string): Format {
+// story #2803 QA(까디르군) — 클래스 전체를 table-driven 테스트로 못박기 위해 export.
+export function resolveFormat(contentType: string | null | undefined, label: string): Format {
   const ct = (contentType ?? '').toLowerCase();
   const ext = label.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? '';
+  // 까디르군 QA(#2803) 2라운드 — docx/pptx는 함수 «최상단»에서 확장자 단독으로 확정해야
+  // 한다. wordprocessingml/presentationml보다만 앞서면 여전히 그 위의 image/pdf/html 등
+  // content-type 판정에 먼저 걸려 .pptx+content-type=application/pdf류가 깨진 pdf iframe으로
+  // 오라우팅된다(정직 폴백보다 나쁜 경로). BE office_conversion.is_convertible도 확장자만
+  // 보고 판정하므로 이 두 확장자에선 ext가 최종 진실 — 오명명 파일은 convert 실패→정직
+  // 폴백으로 귀결되니 안전하다.
+  if (ext === 'docx') return 'docx';
+  if (ext === 'pptx') return 'pptx';
   if (ct.startsWith('image/')) return 'image';
   if (ct.startsWith('video/')) return 'video';
   if (ct.startsWith('audio/')) return 'audio';
   if (ct === 'application/pdf' || ext === 'pdf') return 'pdf';
   if (ct === 'text/html' || ext === 'html' || ext === 'htm') return 'html';
   if (ct.startsWith('text/') || ct === 'text/markdown' || ['txt', 'md', 'markdown'].includes(ext)) return 'text';
-  // 까디르군 QA(#2803) — 확장자를 content-type보다 먼저 판정해야 한다. ext/ct 불일치
-  // 입력(예: .pptx인데 ct가 wordprocessingml)이 ct 우선 순서에서는 docx로 잘못 라우팅됐다.
-  // BE office_conversion.is_convertible도 확장자 .pptx만 인정(content-type 무시)하므로 —
-  // 확장자가 결정적일 땐 그걸로 확정, ct는 확장자가 없거나 못 알아볼 때만 폴백으로 쓴다.
-  if (ext === 'docx') return 'docx';
-  if (ext === 'pptx') return 'pptx';
   if (ct.includes('wordprocessingml')) return 'docx';
   if (ct.includes('presentationml')) return 'pptx';
   if (

--- a/apps/web/src/components/chat/file-viewer.tsx
+++ b/apps/web/src/components/chat/file-viewer.tsx
@@ -24,10 +24,14 @@ function resolveFormat(contentType: string | null | undefined, label: string): F
   if (ct === 'application/pdf' || ext === 'pdf') return 'pdf';
   if (ct === 'text/html' || ext === 'html' || ext === 'htm') return 'html';
   if (ct.startsWith('text/') || ct === 'text/markdown' || ['txt', 'md', 'markdown'].includes(ext)) return 'text';
-  if (ext === 'docx' || ct.includes('wordprocessingml')) return 'docx';
-  // BE office_conversion.is_convertible은 확장자 .pptx만 인정(content-type 무시) — FE도 그
-  // 기준에 맞춰 분기해야 convert 호출이 헛되이 422로 떨어지지 않는다(84ef0cb7 §7-3 실측).
-  if (ext === 'pptx' || ct.includes('presentationml')) return 'pptx';
+  // 까디르군 QA(#2803) — 확장자를 content-type보다 먼저 판정해야 한다. ext/ct 불일치
+  // 입력(예: .pptx인데 ct가 wordprocessingml)이 ct 우선 순서에서는 docx로 잘못 라우팅됐다.
+  // BE office_conversion.is_convertible도 확장자 .pptx만 인정(content-type 무시)하므로 —
+  // 확장자가 결정적일 땐 그걸로 확정, ct는 확장자가 없거나 못 알아볼 때만 폴백으로 쓴다.
+  if (ext === 'docx') return 'docx';
+  if (ext === 'pptx') return 'pptx';
+  if (ct.includes('wordprocessingml')) return 'docx';
+  if (ct.includes('presentationml')) return 'pptx';
   if (
     ['ppt', 'doc', 'xlsx', 'xls'].includes(ext) ||
     ct.includes('officedocument') ||

--- a/apps/web/src/components/chat/file-viewer.tsx
+++ b/apps/web/src/components/chat/file-viewer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Download, Expand, File, FileCode, FileText, Film, Image as ImageIcon, Music, X, type LucideIcon } from 'lucide-react';
+import { Download, Expand, File, FileCode, FileText, Film, Image as ImageIcon, Loader2, Music, X, type LucideIcon } from 'lucide-react';
 import { fetchWithAuth } from '@/lib/db/client';
 import { downloadAsset, openExternal } from '@/lib/native-shell-bridge';
 import { MdBody } from '@/components/chat/embed-card';
@@ -10,9 +10,10 @@ import type { ReadingPanelTarget } from '@/components/chat/reading-panel';
 type AttachmentTarget = Extract<ReadingPanelTarget, { kind: 'attachment' }>;
 
 // 인계 doc 0ef7f8ab §A2 — 포맷 라우팅 표 그대로. docx는 story #2788(84ef0cb7 §4-1
-// 판정)에서 docx-preview 클라 렌더로 분리됐다. pptx/xlsx 등 나머지 office는 여전히
-// 렌더러가 없다(가짜 렌더 금지, 2771 서버 변환 트랙 대기).
-type Format = 'image' | 'video' | 'audio' | 'text' | 'html' | 'pdf' | 'docx' | 'office' | 'unknown';
+// 판정)에서 docx-preview 클라 렌더로 분리됐고, pptx는 story #2803(84ef0cb7 §7)에서
+// BE 변환 파이프(POST /api/v2/attachments/{asset_id}/convert)로 분리됐다. xlsx 등
+// 나머지 office는 여전히 렌더러가 없다(가짜 렌더 금지).
+type Format = 'image' | 'video' | 'audio' | 'text' | 'html' | 'pdf' | 'docx' | 'pptx' | 'office' | 'unknown';
 
 function resolveFormat(contentType: string | null | undefined, label: string): Format {
   const ct = (contentType ?? '').toLowerCase();
@@ -24,8 +25,11 @@ function resolveFormat(contentType: string | null | undefined, label: string): F
   if (ct === 'text/html' || ext === 'html' || ext === 'htm') return 'html';
   if (ct.startsWith('text/') || ct === 'text/markdown' || ['txt', 'md', 'markdown'].includes(ext)) return 'text';
   if (ext === 'docx' || ct.includes('wordprocessingml')) return 'docx';
+  // BE office_conversion.is_convertible은 확장자 .pptx만 인정(content-type 무시) — FE도 그
+  // 기준에 맞춰 분기해야 convert 호출이 헛되이 422로 떨어지지 않는다(84ef0cb7 §7-3 실측).
+  if (ext === 'pptx' || ct.includes('presentationml')) return 'pptx';
   if (
-    ['pptx', 'ppt', 'doc', 'xlsx', 'xls'].includes(ext) ||
+    ['ppt', 'doc', 'xlsx', 'xls'].includes(ext) ||
     ct.includes('officedocument') ||
     ct.includes('msword') ||
     ct.includes('ms-excel') ||
@@ -38,7 +42,7 @@ function resolveFormat(contentType: string | null | undefined, label: string): F
 
 const FORMAT_LABEL: Record<Format, string> = {
   image: '이미지', video: '동영상', audio: '오디오', text: '텍스트',
-  html: 'HTML', pdf: 'PDF', docx: 'Word 문서', office: '오피스 문서', unknown: '파일',
+  html: 'HTML', pdf: 'PDF', docx: 'Word 문서', pptx: 'PowerPoint 문서', office: '오피스 문서', unknown: '파일',
 };
 
 function iconFor(format: Format): LucideIcon {
@@ -50,6 +54,7 @@ function iconFor(format: Format): LucideIcon {
     case 'html': return FileCode;
     case 'pdf': return FileText;
     case 'docx': return FileText;
+    case 'pptx': return FileText;
     default: return File;
   }
 }
@@ -195,13 +200,13 @@ export function FileViewer({ target, onClose }: { target: AttachmentTarget; onCl
           </div>
         )}
 
-        {state.kind === 'ready' && <FileViewerBody format={format} url={state.url} label={target.label} />}
+        {state.kind === 'ready' && <FileViewerBody format={format} url={state.url} label={target.label} assetId={target.assetId} />}
       </div>
     </>
   );
 }
 
-function FileViewerBody({ format, url, label }: { format: Format; url: string; label: string }) {
+function FileViewerBody({ format, url, label, assetId }: { format: Format; url: string; label: string; assetId?: string }) {
   switch (format) {
     case 'image':
       // eslint-disable-next-line @next/next/no-img-element -- 서명 URL은 원격 도메인이라 next/image 정적 도메인 화이트리스트 밖(기존 lightbox와 동일 제약)
@@ -231,6 +236,19 @@ function FileViewerBody({ format, url, label }: { format: Format; url: string; l
     case 'docx':
       // key={url} — 다른 첨부로 전환 시 컴포넌트를 통째로 새로 마운트(TextBody와 동형).
       return <DocxBody key={url} url={url} label={label} />;
+    case 'pptx':
+      // assetId 없으면(구 메시지 등 asset registry 역기입 이전) 변환 자체를 트리거할 축이
+      // 없다 — 가짜 렌더 대신 office와 동일 톤의 정직 "준비 중"으로 축소.
+      if (!assetId) {
+        return (
+          <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+            <FileText className="size-8 text-muted-foreground" aria-hidden />
+            <p className="text-sm text-foreground">미리보기 준비 중입니다.</p>
+            <p className="text-xs text-muted-foreground">이 첨부는 인앱 변환 대상 식별자가 없습니다. 다운로드해 확인하세요.</p>
+          </div>
+        );
+      }
+      return <PptxBody key={assetId} assetId={assetId} label={label} />;
     case 'office':
       return (
         <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
@@ -370,4 +388,101 @@ function DocxBody({ url, label }: { url: string; label: string }) {
       />
     </div>
   );
+}
+
+/**
+ * story #2803 — pptx는 BE 변환 파이프(POST /api/attachments/convert → office_conversion.py,
+ * 84ef0cb7 §7-3)로 PDF로 바꾼 뒤 기존 PDF iframe 렌더를 그대로 재사용한다. 콜드스타트가
+ * 수십 초 걸릴 수 있어(LibreOffice 헤드리스, §7-4 timeout=120s) "변환 중" + 경과시간 정직
+ * 표시 — 무한 스피너 금지. 실패 처리는 DocxBody와 동형(AbortController+상한타이머+cancelled
+ * 레이스 가드, story #2788 QA 교훈 그대로 적용 — timeout 확정 뒤 늦은 resolve가 상태를
+ * 되돌리지 못하게 catch에서도 cancelled를 세운다).
+ */
+function PptxBody({ assetId, label }: { assetId: string; label: string }) {
+  const [status, setStatus] = useState<'converting' | 'ready' | 'failed'>('converting');
+  const [failMessage, setFailMessage] = useState<string | null>(null);
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
+  const [elapsedSec, setElapsedSec] = useState(0);
+
+  useEffect(() => {
+    if (status !== 'converting') return;
+    const id = setInterval(() => setElapsedSec((s) => s + 1), 1000);
+    return () => clearInterval(id);
+  }, [status]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout>;
+    // key={assetId}가 다른 첨부 전환 시 이 컴포넌트를 통째로 새로 마운트하므로(DocxBody와
+    // 동형) status/failMessage는 이미 useState 초기값으로 깨끗하다 — 여기서 재설정 불요.
+    const run = (async () => {
+      const convertRes = await fetchWithAuth(`/api/attachments/convert?asset_id=${encodeURIComponent(assetId)}`, {
+        method: 'POST',
+        signal: controller.signal,
+      });
+      const convertJson = (await convertRes.json().catch(() => null)) as
+        | { data?: { asset_id?: string }; error?: { message?: string } }
+        | null;
+      const convertedAssetId = convertJson?.data?.asset_id;
+      if (!convertRes.ok || !convertedAssetId) {
+        throw new Error(convertJson?.error?.message ?? String(convertRes.status));
+      }
+      if (cancelled) return;
+      const signRes = await fetchWithAuth(
+        `/api/attachments/sign?asset_id=${encodeURIComponent(convertedAssetId)}&disposition=inline`,
+        { signal: controller.signal },
+      );
+      const signJson = (await signRes.json().catch(() => null)) as { data?: { url?: string }; error?: { message?: string } } | null;
+      const url = signJson?.data?.url;
+      if (!signRes.ok || !url) {
+        throw new Error(signJson?.error?.message ?? String(signRes.status));
+      }
+      if (!cancelled) {
+        setPdfUrl(url);
+        setStatus('ready');
+      }
+    })();
+    // 백엔드 하드 타임아웃(Gotenberg 왕복 120s, 84ef0cb7 §7-4)보다 여유를 둔 클라이언트 상한 —
+    // fetch든 변환이든 어느 단계가 멈추든 무한 로딩 금지(AC2·AC3).
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error('변환 시간 초과')), 130000);
+    });
+    Promise.race([run, timeout])
+      .catch((e) => {
+        console.error('pptx 변환 실패', e);
+        controller.abort();
+        if (cancelled) return;
+        cancelled = true;
+        setFailMessage(e instanceof Error ? e.message : null);
+        setStatus('failed');
+      })
+      .finally(() => clearTimeout(timeoutId));
+    return () => { cancelled = true; controller.abort(); clearTimeout(timeoutId); };
+  }, [assetId]);
+
+  if (status === 'failed') {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+        <FileText className="size-8 text-muted-foreground" aria-hidden />
+        <p className="text-sm text-foreground">변환에 실패했습니다.</p>
+        <p className="text-xs text-muted-foreground">이 문서를 PDF로 변환하지 못했습니다. 다운로드해 확인하세요.</p>
+        {failMessage && (
+          <p className="w-fit rounded-md bg-destructive-tint px-2 py-1.5 font-mono text-[10.5px] text-foreground">{failMessage}</p>
+        )}
+      </div>
+    );
+  }
+
+  if (status === 'converting') {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" aria-hidden />
+        <p className="text-sm text-foreground">변환 중입니다…</p>
+        <p className="text-xs text-muted-foreground">첫 열람은 최대 1~2분 걸릴 수 있습니다({elapsedSec}초 경과).</p>
+      </div>
+    );
+  }
+
+  return <iframe src={pdfUrl ?? undefined} title={label} className="h-full w-full border-0" />;
 }

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -28,7 +28,9 @@ export interface ChatMessage {
    * 사실 필드, 렌더는 FE 몫). */
   deleted_at?: string | null;
   review_type?: string;
-  attachments: Array<{ url?: string; name?: string; content_type?: string; filename?: string }>;
+  // asset_id — story #2803: BE가 전송 시 asset registry에 역기입하는 denorm 필드
+  // (asset_registry.sync_attachment_assets). 구 메시지(registry 롤아웃 이전)엔 없을 수 있다.
+  attachments: Array<{ url?: string; name?: string; content_type?: string; filename?: string; asset_id?: string }>;
   created_at: string;
   // CB-S9: thread fields
   parent_id?: string | null;    // null = top-level message; set = this is a thread reply


### PR DESCRIPTION
## 배경
2771 그라운딩 doc(84ef0cb7 §7) 완주 — 백엔드 변환 파이프(PR#3226, PO AC PASS, dev 실배포 착지). `POST /api/v2/attachments/{asset_id}/convert`가 200이면 `{asset_id, name, content_type=application/pdf}` 반환, 변환물은 기존 sign→PDF 렌더 경로 재사용 가능.

## 변경 사항
- Next 프록시 라우트 `POST /api/attachments/convert` 신규 — BE convert 엔드포인트로 세션 토큰 얹어 위임, 503(파이프 미배선)/502(변환 실패)/422(비변환대상)/403/404 상태코드를 표준 에러 포맷으로 번역.
- `file-viewer.tsx`: pptx를 `office` 분기에서 분리(확장자 `.pptx` 기준 — BE `office_conversion.is_convertible`이 확장자만 보고 판정하는 것과 일치시켜 헛된 422 호출 방지). `PptxBody` 신규 — convert→sign 왕복 후 기존 PDF iframe 렌더 그대로 재사용.
  - "변환 중" 정직 표시 — 경과시간(초) 노출, 무한 스피너 아님.
  - `AbortController` + 130초 클라이언트 상한 타이머(BE 하드 타임아웃 120s+여유) + `cancelled` 레이스 가드 — story #2788 QA(카디르군)가 잡아낸 "timeout 확정 후 늦은 resolve가 상태를 되돌리는" 레이스를 처음부터 반영.
- `asset_id` 배선: BE가 메시지 전송 시 asset registry에 역기입하는 denorm 필드(`asset_registry.sync_attachment_assets`)를 `ChatMessage` 타입 → `AttachmentFile` → `ReadingPanelTarget`까지 관통. 없는 첨부(asset registry 롤아웃 이전 구 메시지 등)는 네트워크 호출 없이 정직 "준비 중" 폴백(가짜 렌더 금지).

## 검증
- `pnpm build` / `pnpm lint` / `tsc --noEmit` 전부 그린, 전체 모노레포 vitest 스위트(465 files / 3852 tests) 회귀 없음
- **실 마운트 테스트 5종**(`file-viewer.pptx.test.tsx`):
  1. 실 convert→sign 왕복 → PDF iframe 렌더(src 검증)
  2. 변환 서비스 미배선(503) → 정직 폴백, 빈 화면/무한 로딩 없음
  3. assetId 없는 첨부 → 네트워크 호출 없이 즉시 "준비 중"(convert 미호출 검증)
  4. fetch hang → 130초 상한 타이머로 정직 폴백 도달
  5. **레이스 가드**: timeout으로 failed 확정 후 convert가 뒤늦게 성공해도 상태 유지 — `cancelled=true` 픽스를 되돌려 이 테스트가 실제로 빨강이 되는 것을 확인한 뒤 커밋(가짜 그린 아님, story #2788에서 얻은 교훈 그대로 적용)
- CPU 컨텐션 시뮬레이션(20개 busy-loop) 하에서도 반복 green 확인
- **라이브 픽셀**(신규 "변환 중"/"변환 실패" 표면 — PDF iframe 자체는 기존 PDF 렌더 경로 재사용이라 신규 시각 리스크 없음): 라이트/다크 × 데스크톱/모바일(390px) 4종, 실제 컴포넌트 마크업·다크 토큰 그대로 재현해 puppeteer로 확인 — 대비/레이아웃 문제 없음

## AC 대조
1. ✅ convert→sign 왕복으로 실 PDF 렌더 성립(콜드/웜은 §7-5 실측표 — 디디군과 협업해 배포 후 채움)
2. ✅ 변환 중 정직 표시(무한 스피너 아님, 경과시간 노출)
3. ✅ 502/503 정직 폴백(다운로드 유도)
4. ✅ 캐시 hit — BE가 결정적 캐시 경로로 처리(84ef0cb7 §7-2), FE는 매 열람 convert 호출만 하면 됨
5. ✅ 두 테마·모바일 폭 비회귀(라이브 픽셀 확인)
6. ✅ xlsx 등 나머지 office는 범위 밖("준비 중" 유지)

관련: entity:story:d5fc218c-a048-4ba1-9a04-97e74a3a3512, entity:doc:84ef0cb7-e857-49f3-bb96-3899e9e077c5

🤖 Generated with [Claude Code](https://claude.com/claude-code)