### PR TITLE
feat(#2792): 워크플로우 레시피 → 사이클형 event_definitions 컴파일(2790 P1)

### DIFF
--- a/backend/alembic/versions/0259_event_definitions_name_stage_metadata.py
+++ b/backend/alembic/versions/0259_event_definitions_name_stage_metadata.py
@@ -13,6 +13,13 @@ name은 NOT NULL이라 기존 행(0245 프리셋 4종 + 있을 수 있는 org �
 `key`를 폴백으로 채운 뒤 NOT NULL로 잠근다(값이 없는 것보다 key라도 있는 게 안전, 프리셋
 4종은 이 마이그가 곧바로 사람이 읽을 이름으로 덮어쓴다).
 
+⛔실버그(카디르군 QA, 2026-08-19) — 백필 WHERE절을 `name IS NULL`로 짰으나 **0행만 잡힌다**.
+`ADD COLUMN ... server_default=''`는 PG11+ fast-default라 실 UPDATE 없이 기존 행에 즉시
+"missing value"로 `''`를 채운다(디스크 재기록 없음) — 그래서 기존 행은 물리적으로 NULL이
+아니라 **논리적으로 이미 `''`를 읽는다**. `WHERE name IS NULL`은 그 어떤 기존 행도 못 잡고,
+프리셋 4종은 사람이 읽을 이름 대신 `''`로 영구 고정될 뻔했다(PO AC도 이 WHERE절을 못
+잡았던 구멍 — 페드루 확認). 백필 조건을 실제 상태(`name = ''`)로 정정.
+
 Revision ID: 0259
 Revises: 0258
 Create Date: 2026-08-19
@@ -52,11 +59,11 @@ def upgrade() -> None:
     conn = op.get_bind()
     for key, name in _PRESET_NAMES.items():
         conn.execute(
-            sa.text("UPDATE event_definitions SET name = :name WHERE key = :key AND name IS NULL"),
+            sa.text("UPDATE event_definitions SET name = :name WHERE key = :key AND name = ''"),
             {"name": name, "key": key},
         )
     # 그 외(있을 수 있는 org 커스텀 행) — key를 폴백 이름으로.
-    conn.execute(sa.text("UPDATE event_definitions SET name = key WHERE name IS NULL"))
+    conn.execute(sa.text("UPDATE event_definitions SET name = key WHERE name = ''"))
 
     op.alter_column("event_definitions", "name", nullable=False)
 

--- a/backend/alembic/versions/0259_event_definitions_name_stage_metadata.py
+++ b/backend/alembic/versions/0259_event_definitions_name_stage_metadata.py
@@ -1,0 +1,67 @@
+"""story #2792(2790 P1) — event_definitions에 name/description/stage_metadata 신설.
+
+PO 확定(2026-08-19):
+- name(NOT NULL)·description(nullable) — 사람용 표시(드롭다운 등). key는 기계용 식별자로
+  그대로 둔다(role_templates류 i18n 오버레이는 신설 안 함, 이번 스코프 밖).
+- stage_metadata(NOT NULL, 기본 '{}') — 사이클형 정의의 stage별 {role, action} 카탈로그
+  메타. "기대 행동은 정의 레벨 데이터"(발행 payload 아님) 판별의 실물. 키 집합은
+  event_definition_registry.validate_stage_metadata가 등록/수정 시점에 stage.enum의
+  부분집합인지 강제(가드①) — 이 마이그는 컬럼만 추가, 기존 행 검증은 0260(컴파일)이
+  스스로 유효한 값만 넣으므로 여기선 백필 후 재검증 불요.
+
+name은 NOT NULL이라 기존 행(0245 프리셋 4종 + 있을 수 있는 org 커스텀) 백필이 필요 —
+`key`를 폴백으로 채운 뒤 NOT NULL로 잠근다(값이 없는 것보다 key라도 있는 게 안전, 프리셋
+4종은 이 마이그가 곧바로 사람이 읽을 이름으로 덮어쓴다).
+
+Revision ID: 0259
+Revises: 0258
+Create Date: 2026-08-19
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0259"
+down_revision = "0258"
+branch_labels = None
+depends_on = None
+
+# 0245 시드 4종의 사람용 이름 — key로 매칭해 백필(그 외 org 커스텀 행은 key 폴백).
+_PRESET_NAMES: dict[str, str] = {
+    "preset.gate.verdict": "게이트 판정",
+    "preset.work.status_changed": "작업 상태 변경",
+    "preset.work.assigned": "작업 배정",
+    "preset.goal.measured": "목표 측정",
+}
+
+
+def upgrade() -> None:
+    # server_default='' — model.py와 동일 컨벤션(진짜 데이터 경로용이 아니라 create_all+구
+    # 시드 리터럴 직삽입 같은 레거시 경로의 안전망, enabled/version/stage_metadata와 동형).
+    op.add_column(
+        "event_definitions", sa.Column("name", sa.Text(), nullable=True, server_default="")
+    )
+    op.add_column("event_definitions", sa.Column("description", sa.Text(), nullable=True))
+    op.add_column(
+        "event_definitions",
+        sa.Column("stage_metadata", JSONB, nullable=False, server_default=sa.text("'{}'::jsonb")),
+    )
+
+    conn = op.get_bind()
+    for key, name in _PRESET_NAMES.items():
+        conn.execute(
+            sa.text("UPDATE event_definitions SET name = :name WHERE key = :key AND name IS NULL"),
+            {"name": name, "key": key},
+        )
+    # 그 외(있을 수 있는 org 커스텀 행) — key를 폴백 이름으로.
+    conn.execute(sa.text("UPDATE event_definitions SET name = key WHERE name IS NULL"))
+
+    op.alter_column("event_definitions", "name", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("event_definitions", "stage_metadata")
+    op.drop_column("event_definitions", "description")
+    op.drop_column("event_definitions", "name")

--- a/backend/alembic/versions/0260_compile_workflow_recipes_to_cycle_events.py
+++ b/backend/alembic/versions/0260_compile_workflow_recipes_to_cycle_events.py
@@ -1,0 +1,227 @@
+"""story #2792(2790 P1) — builtin 4종 + DB workflow_templates 4행을 사이클형 event_definitions
+로 컴파일("워크플로우 엔티티를 이벤트층으로 흡수", 카드 §2 판정). 발명이 아니라 **기존 실물의
+승격**(PO 확定 2026-08-19) — `workflow_recipes.py::_BUILTIN_RECIPES`(builtin)와
+`workflow_templates`(DB, 0016 시드)의 steps를 그대로 stage enum + stage_metadata로 옮긴다.
+
+⚠️실측 발견(이 마이그 작성 중) — 카드 §1이 "DB 템플릿 3행"이라 적었으나 **실제로는 4행**
+(solo·two-step·three-step·kanban, 0016 확認)이고, 그중 **DB "solo"가 builtin "solo"를
+슬러그 충돌로 그림자 처리**한다(`workflow_recipes.py::list_recipes()`가 db_slugs에 없는
+builtin만 추가 — "solo"는 DB에 있어 builtin 쪽이 영원히 안 나온다). 지금까지 아무도 builtin
+"solo"(Agent 1인 파이프라인)를 recipes 목록에서 본 적이 없다는 뜻 — recipes[0] 임의성보다
+한 겹 더 깊은 은폐. 컴파일은 8건 전부(그림자 포함) 승격하되 키 충돌을 피하려 builtin 쪽을
+`agent_solo`로 개명한다(DB 쪽은 원 슬러그 `solo` 유지 — 지금까지 실제로 도달 가능했던 쪽).
+
+DB steps는 `pattern`(assign/submit/review)만 있고 자유서술 action이 없다(카드 §1 결함ⓑ와
+동일 원인) — **발명 대신 기존 pattern을 최소 사전으로 옮긴다**(assign→담당자 배정 등,
+아래 `_PATTERN_ACTION`). builtin steps는 이미 자유서술 action이 있어 그대로 옮긴다.
+
+stage slug는 DB의 경우 pattern이 같은 recipe 안에서 중복될 수 있어(three-step의 review가
+step_2/step_3 둘 다) `{pattern}_{role_ref}`로 유일화, builtin은 이미 고유한 `pattern`을
+그대로 slug로 쓴다.
+
+routing/block_template은 기존 `preset.work.status_changed`(0245/0249)와 동형 패턴 재사용
+(새 어휘 발명 안 함) — work_item_stakeholders 방송, header+text+fields 3블록.
+
+이번 커밋 범위: 컴파일+정본화까지. `workflow_recipes.py` 라우터·`workflow_templates`/
+`_BUILTIN_RECIPES` 원본은 그대로 둔다(FE `loop-create-dialog.tsx` 등 3곳이 아직 소비 —
+미르코군 FE 전환 확認 후 별도 커밋에서 은퇴, doc workflow-recipes-fe-consumption-map-2792
+§3 순서 그대로).
+
+Revision ID: 0260
+Revises: 0259
+Create Date: 2026-08-19
+"""
+from __future__ import annotations
+
+import json
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0260"
+down_revision = "0259"
+branch_labels = None
+depends_on = None
+
+_PATTERN_ACTION: dict[str, str] = {
+    "assign": "담당자 배정",
+    "submit": "제출",
+    "review": "검토",
+}
+
+# builtin 4종 — workflow_recipes.py::_BUILTIN_RECIPES 그대로 옮김(순서·내용 동일, "solo"만
+# 슬러그 충돌 회피로 agent_solo 개명).
+_BUILTIN_RECIPES = [
+    {
+        "slug": "scrum_3step",
+        "name": "3단계 스크럼",
+        "description": "기획 → 개발 → QA 3단계 워크플로우. 소규모~중규모 스프린트에 적합.",
+        "steps": [
+            {"stage": "kickoff", "role": "PO", "action": "기능 명세 및 AC 작성"},
+            {"stage": "implementation", "role": "Dev", "action": "코드 작성 및 PR 제출"},
+            {"stage": "qa_review", "role": "QA", "action": "AC 체크리스트 검증 후 APPROVE/REJECT"},
+        ],
+    },
+    {
+        "slug": "kanban_simple",
+        "name": "칸반 심플",
+        "description": "할 일 → 진행 중 → 완료 단순 흐름. 지속적 딜리버리 환경에 적합.",
+        "steps": [
+            {"stage": "task_created", "role": "Any", "action": "백로그에서 작업 선택 및 claim"},
+            {"stage": "in_progress", "role": "Dev", "action": "작업 수행 및 진행 상황 업데이트"},
+            {"stage": "done_check", "role": "Lead", "action": "완료 기준 충족 여부 확인"},
+        ],
+    },
+    {
+        "slug": "agent_solo",
+        "name": "솔로 에이전트",
+        "description": "단일 에이전트가 전 단계를 처리. 간단한 자동화 태스크에 적합.",
+        "steps": [
+            {"stage": "received", "role": "Agent", "action": "이벤트 수신 후 컨텍스트 파악"},
+            {"stage": "execute", "role": "Agent", "action": "태스크 수행 및 결과 생성"},
+            {"stage": "report", "role": "Agent", "action": "결과 요약 후 채팅/메모로 보고"},
+        ],
+    },
+    {
+        "slug": "loop_agency",
+        "name": "루프 에이전시",
+        "description": "목표·가설 설정 → 브리프 → 실행안 생성 → 인간 선택 → 실행 → 성과 학습까지 "
+                        "이어지는 복리 조직기억 워크플로우. 반복되는 실험(카피·캠페인 variant 등)에 적합.",
+        "steps": [
+            {"stage": "goal_hypothesis", "role": "Human", "action": "loop의 목표(goal)와 성과 가설(hypothesis)·측정 지표(metric)를 정의"},
+            {"stage": "brief_doc_approval", "role": "PO", "action": "실행 계획을 브리프 문서로 작성하고 doc_approval 게이트를 통과"},
+            {"stage": "generate_variants", "role": "Agent", "action": "brief를 바탕으로 복수의 실행안(variant)을 생성해 loop_artifacts로 등록"},
+            {"stage": "loop_decision", "role": "Human", "action": "실행안 중 하나를 선택(choose)하고 이유를 기록·나머지는 반려(reject) 이유를 기록"},
+            {"stage": "execute", "role": "Any", "action": "선택된 실행안을 외부(캠페인 발행·배포 등)에서 실행"},
+            {"stage": "track_and_learn", "role": "Any", "action": "성과(GA4 등)를 측정해 outcome_snapshot으로 귀속하고, 다음 loop의 Context Pack에 이 loop의 선택·이유·성과가 학습 근거로 반영되게 한다"},
+        ],
+    },
+]
+
+# DB workflow_templates 4행(0016) — steps는 role_ref/default_label/pattern만, action 없음
+# (_PATTERN_ACTION으로 최소 파생). slug는 f"{pattern}_{role_ref}"로 유일화.
+_DB_RECIPES = [
+    {
+        "slug": "solo",
+        "name": "Solo",
+        "description": "1인 작업자. 할당 → 완료.",
+        "steps": [{"pattern": "assign", "role_ref": "step_1", "default_label": "Worker"}],
+    },
+    {
+        "slug": "two_step",
+        "name": "Two-Step Review",
+        "description": "제출 → 검토. 코드 리뷰, 디자인 검토, 원고 편집, 승인 등.",
+        "steps": [
+            {"pattern": "assign", "role_ref": "step_1", "default_label": "Maker"},
+            {"pattern": "submit", "role_ref": "step_1", "default_label": "Maker"},
+            {"pattern": "review", "role_ref": "step_2", "default_label": "Reviewer"},
+        ],
+    },
+    {
+        "slug": "three_step",
+        "name": "Three-Step Pipeline",
+        "description": "제출 → 1차 검토 → 2차 검토. PO-Dev-QA, 작성-편집-발행 등.",
+        "steps": [
+            {"pattern": "assign", "role_ref": "step_1", "default_label": "Executor"},
+            {"pattern": "submit", "role_ref": "step_1", "default_label": "Executor"},
+            {"pattern": "review", "role_ref": "step_2", "default_label": "Reviewer"},
+            {"pattern": "review", "role_ref": "step_3", "default_label": "Approver"},
+        ],
+    },
+    {
+        "slug": "kanban",
+        "name": "Kanban Flow",
+        "description": "상태 전이 기반 알림. 역할 구분 없이 상태 변경 시 팀 알림.",
+        "steps": [{"pattern": "assign", "role_ref": "step_1", "default_label": "Member"}],
+    },
+]
+
+
+def _block_template(name: str) -> dict:
+    return {
+        "blocks": [
+            {"type": "header", "text": name},
+            {"type": "text", "text": "**{{payload.stage}}** 로 넘어갔습니다"},
+            {"type": "fields", "fields": [
+                {"label": "대상", "value": "{{payload.work_item_type}} {{payload.work_item_id}}"},
+            ]},
+        ],
+    }
+
+
+def _payload_schema(stage_slugs: list[str]) -> dict:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["stage", "work_item_id"],
+        "properties": {
+            "stage": {"type": "string", "enum": stage_slugs},
+            "work_item_type": {"type": "string"},
+            "work_item_id": {"type": "string", "format": "uuid"},
+        },
+    }
+
+
+_ROUTING = {
+    "escalation": {"kind": "server_derived", "target": "none"},
+    "broadcast": {
+        "kind": "server_derived", "target": "work_item_stakeholders",
+        "inherit_conversation_scope": True,
+    },
+}
+
+
+def _rows():
+    for r in _BUILTIN_RECIPES:
+        stage_slugs = [s["stage"] for s in r["steps"]]
+        stage_metadata = {s["stage"]: {"role": s["role"], "action": s["action"]} for s in r["steps"]}
+        yield r["slug"], r["name"], r["description"], stage_slugs, stage_metadata
+    for r in _DB_RECIPES:
+        stage_slugs: list[str] = []
+        stage_metadata: dict[str, dict] = {}
+        for s in r["steps"]:
+            slug = f"{s['pattern']}_{s['role_ref']}"
+            if slug not in stage_metadata:  # 같은 pattern+role_ref 중복(assign+submit 동일 role) — 1건만.
+                stage_slugs.append(slug)
+                stage_metadata[slug] = {
+                    "role": s["default_label"],
+                    "action": _PATTERN_ACTION.get(s["pattern"], s["pattern"]),
+                }
+        yield r["slug"], r["name"], r["description"], stage_slugs, stage_metadata
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for slug, name, description, stage_slugs, stage_metadata in _rows():
+        key = f"preset.workflow.{slug}"
+        conn.execute(
+            sa.text(
+                "INSERT INTO event_definitions "
+                "(id, key, org_id, name, description, payload_schema, routing, block_template, "
+                " stage_metadata, enabled, version) "
+                "VALUES (:id, :key, NULL, :name, :description, CAST(:payload_schema AS jsonb), "
+                " CAST(:routing AS jsonb), CAST(:block_template AS jsonb), CAST(:stage_metadata AS jsonb), "
+                " true, 1) "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {
+                "id": str(uuid.uuid4()),
+                "key": key,
+                "name": name,
+                "description": description,
+                "payload_schema": json.dumps(_payload_schema(stage_slugs)),
+                "routing": json.dumps(_ROUTING),
+                "block_template": json.dumps(_block_template(name)),
+                "stage_metadata": json.dumps(stage_metadata),
+            },
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for slug, _name, _description, _stage_slugs, _stage_metadata in _rows():
+        conn.execute(
+            sa.text("DELETE FROM event_definitions WHERE org_id IS NULL AND key = :key"),
+            {"key": f"preset.workflow.{slug}"},
+        )

--- a/backend/alembic/versions/0260_compile_workflow_recipes_to_cycle_events.py
+++ b/backend/alembic/versions/0260_compile_workflow_recipes_to_cycle_events.py
@@ -151,10 +151,15 @@ def _block_template(name: str) -> dict:
 
 
 def _payload_schema(stage_slugs: list[str]) -> dict:
+    # ⛔실버그(카디르군 QA, 2026-08-19) — work_item_type이 properties에만 있고 required엔
+    # 없어, 기존 preset 2종(work.status_changed/assigned)과 비대칭이었다. routing.broadcast
+    # 가 server_derived/work_item_stakeholders(type+id 짝으로 해석)인데 type이 optional이면
+    # "stage+work_item_id만 있는" 스키마상 유효한 payload로 발행이 가능해져, 해석기가
+    # type을 못 받아 zero-reach로 새는 경로가 구조적으로 열려 있었다 — required에 추가.
     return {
         "type": "object",
         "additionalProperties": False,
-        "required": ["stage", "work_item_id"],
+        "required": ["stage", "work_item_type", "work_item_id"],
         "properties": {
             "stage": {"type": "string", "enum": stage_slugs},
             "work_item_type": {"type": "string"},

--- a/backend/app/models/event_definition.py
+++ b/backend/app/models/event_definition.py
@@ -66,11 +66,23 @@ class EventDefinition(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     key: Mapped[str] = mapped_column(Text, nullable=False)
     org_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    # story #2792(2790 P1, PO 확定 2026-08-19 ①) — 사람용 표시(드롭다운 등). key는 기계용
+    # 식별자로 그대로 둔다. i18n 오버레이(role_templates류)는 신설 안 함(이번 스코프 밖).
+    # server_default는 진짜 데이터 경로(마이그 백필·API가 name 필수)를 위한 게 아니라
+    # create_all+구 시드 리터럴 직삽입(0245._SEED, name 없음) 같은 레거시/테스트 경로의
+    # 안전망 — enabled/version/stage_metadata와 동일 컨벤션.
+    name: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
     payload_schema: Mapped[dict] = mapped_column(JSONB, nullable=False)
     routing: Mapped[dict] = mapped_column(JSONB, nullable=False)
     # P2(story #2637)가 소비 — nullable=없으면 제네릭 카드 폴백(블루프린트 §2-1 표).
     block_template: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     action_auth: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # story #2792(2790 P1) — 사이클형(payload_schema.properties.stage.enum 有) 정의의 stage별
+    # 카탈로그 메타(role/action) — "기대 행동은 정의 레벨 데이터"(발행 payload 아님). 키 집합은
+    # stage.enum의 부분집합이어야 한다(event_definition_registry.validate_stage_metadata가 등록/
+    # 수정 시점에 강제 — 오타 slug가 조용히 죽는 클래스 차단, 페드루 판정 2026-08-19).
+    stage_metadata: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
     version: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
     created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1378,9 +1378,17 @@ class EventDefinitionResponse(BaseModel):
     id: str
     key: str
     org_id: str | None
+    # story #2792(2790 P1) — name/description 신설(PO 확定 2026-08-19 ①). key는 여전히
+    # 기계용 식별자, name이 사람용 표시(드롭다운 등) — role_templates류 i18n 오버레이는
+    # 여기 없음(신규 서브시스템 얹지 않는다, 이번 스코프 밖).
+    name: str
+    description: str | None
     payload_schema: dict
     routing: dict
     block_template: dict | None
+    # 사이클형 정의의 stage별 role/action 카탈로그 메타 — {slug: {role, action}}. 신호형/
+    # 측정형 정의는 빈 dict.
+    stage_metadata: dict
     enabled: bool
     version: int
 
@@ -1407,8 +1415,10 @@ async def list_event_definitions(
     return [
         EventDefinitionResponse(
             id=str(r.id), key=r.key, org_id=str(r.org_id) if r.org_id else None,
+            name=r.name, description=r.description,
             payload_schema=r.payload_schema, routing=r.routing,
-            block_template=r.block_template, enabled=r.enabled, version=r.version,
+            block_template=r.block_template, stage_metadata=r.stage_metadata,
+            enabled=r.enabled, version=r.version,
         )
         for r in rows
     ]
@@ -1423,6 +1433,11 @@ async def list_event_definitions(
 
 class CreateEventDefinitionRequest(BaseModel):
     key: str
+    # story #2792(2790 P1, PO 확定 2026-08-19 ①) — 사람용 표시 이름(드롭다운 등). key는
+    # 기계용 식별자로 그대로 둔다. 기본값 ""은 DB server_default와 동일 안전망 컨벤션(#2636
+    # 기존 호출부가 name 없이도 여전히 동작 — 신규 필드가 기존 계약을 안 깬다).
+    name: str = ""
+    description: str | None = None
     payload_schema: dict
     routing: dict
     # story #2637 §범위1/5: optional — 없으면 렌더러가 현행 제네릭 폴백을 쓴다(비회귀).
@@ -1432,24 +1447,34 @@ class CreateEventDefinitionRequest(BaseModel):
     # (버튼/REST/MCP 전부 이 단일 엔드포인트를 탄다 — #2633 AC2 단일 파이프 덕에 별도
     # 집행 지점이 필요 없다).
     action_auth: dict | None = None
+    # story #2792(2790 P1) — 사이클형 정의의 stage별 role/action 카탈로그 메타. 키는
+    # payload_schema.properties.stage.enum의 부분집합이어야 한다(validate_stage_metadata,
+    # 가드①) — 비어 있으면(신호형/측정형) 검증 스킵.
+    stage_metadata: dict = {}
 
 
 class UpdateEventDefinitionRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
     payload_schema: dict | None = None
     routing: dict | None = None
     enabled: bool | None = None
     block_template: dict | None = None
     action_auth: dict | None = None
+    stage_metadata: dict | None = None
 
 
 class EventDefinitionDetailResponse(BaseModel):
     id: str
     key: str
     org_id: str | None
+    name: str
+    description: str | None
     payload_schema: dict
     routing: dict
     block_template: dict | None
     action_auth: dict | None
+    stage_metadata: dict
     enabled: bool
     version: int
     created_by: str | None
@@ -1458,8 +1483,10 @@ class EventDefinitionDetailResponse(BaseModel):
 def _event_definition_detail(d: "EventDefinition") -> EventDefinitionDetailResponse:
     return EventDefinitionDetailResponse(
         id=str(d.id), key=d.key, org_id=str(d.org_id) if d.org_id else None,
+        name=d.name, description=d.description,
         payload_schema=d.payload_schema, routing=d.routing,
         block_template=d.block_template, action_auth=d.action_auth,
+        stage_metadata=d.stage_metadata,
         enabled=d.enabled, version=d.version,
         created_by=str(d.created_by) if d.created_by else None,
     )
@@ -1497,11 +1524,13 @@ async def create_event_definition(
         InvalidEventDefinitionKeyError,
         InvalidEventRoutingError,
         InvalidPayloadSchemaError,
+        InvalidStageMetadataError,
         validate_action_auth,
         validate_block_template,
         validate_event_definition_key,
         validate_event_payload_schema_shape,
         validate_event_routing,
+        validate_stage_metadata,
     )
     from app.services.member_resolver import resolve_member
 
@@ -1517,9 +1546,11 @@ async def create_event_definition(
             validate_block_template(body.block_template)
         if body.action_auth is not None:
             validate_action_auth(body.action_auth)
+        validate_stage_metadata(body.payload_schema, body.stage_metadata)
     except (
         InvalidEventDefinitionKeyError, InvalidPayloadSchemaError,
         InvalidEventRoutingError, InvalidBlockTemplateError, InvalidActionAuthError,
+        InvalidStageMetadataError,
     ) as e:
         raise HTTPException(
             status_code=400, detail={"code": "invalid_definition", "message": str(e)},
@@ -1539,8 +1570,10 @@ async def create_event_definition(
     sender = await resolve_member(auth, org_id, db)
     definition = EventDefinition(
         id=uuid.uuid4(), key=body.key, org_id=org_id,
+        name=body.name, description=body.description,
         payload_schema=body.payload_schema, routing=body.routing,
         block_template=body.block_template, action_auth=body.action_auth,
+        stage_metadata=body.stage_metadata,
         created_by=sender.id,
     )
     db.add(definition)
@@ -1567,18 +1600,21 @@ async def update_event_definition(
         InvalidBlockTemplateError,
         InvalidEventRoutingError,
         InvalidPayloadSchemaError,
+        InvalidStageMetadataError,
         validate_action_auth,
         validate_block_template,
         validate_event_payload_schema_shape,
         validate_event_routing,
+        validate_stage_metadata,
     )
 
     if not await _is_org_admin(db, org_id, uuid.UUID(auth.user_id)):
         raise HTTPException(status_code=403, detail="org admin/owner required")
 
     if (
-        body.payload_schema is None and body.routing is None and body.enabled is None
-        and body.block_template is None and body.action_auth is None
+        body.name is None and body.description is None
+        and body.payload_schema is None and body.routing is None and body.enabled is None
+        and body.block_template is None and body.action_auth is None and body.stage_metadata is None
     ):
         raise HTTPException(status_code=400, detail="at least one field must be provided")
 
@@ -1590,7 +1626,32 @@ async def update_event_definition(
     if definition is None:
         raise HTTPException(status_code=404, detail="event definition not found")
 
+    # story #2792 가드① — stage_metadata는 payload_schema와 짝인 검증이라, 둘 중 하나만
+    # 바뀌어도 **유효 조합**(새 값 있으면 새 값·없으면 기존 값)으로 재검증한다. payload_schema만
+    # 줄어들고 stage_metadata를 안 건드리면 기존 메타가 고아가 될 수 있어(예: enum에서 stage
+    # 하나를 뺐는데 그 slug를 가리키던 메타는 그대로) — 이 경우도 여기서 걸린다.
+    if body.payload_schema is not None or body.stage_metadata is not None:
+        effective_schema = body.payload_schema if body.payload_schema is not None else definition.payload_schema
+        effective_stage_metadata = (
+            body.stage_metadata if body.stage_metadata is not None else definition.stage_metadata
+        )
+        try:
+            validate_stage_metadata(effective_schema, effective_stage_metadata)
+        except InvalidStageMetadataError as e:
+            raise HTTPException(
+                status_code=400, detail={"code": "invalid_definition", "message": str(e)},
+            ) from e
+
     content_changed = False
+    if body.name is not None:
+        definition.name = body.name
+        content_changed = True
+    if body.description is not None:
+        definition.description = body.description
+        content_changed = True
+    if body.stage_metadata is not None:
+        definition.stage_metadata = body.stage_metadata
+        content_changed = True
     if body.payload_schema is not None:
         try:
             validate_event_payload_schema_shape(body.payload_schema)

--- a/backend/app/services/event_definition_registry.py
+++ b/backend/app/services/event_definition_registry.py
@@ -57,6 +57,12 @@ class InvalidBlockTemplateError(ValueError):
     위반 — 등록 시점 구조 게이트(치환 렌더링은 FE 몫, 여기는 구조만)."""
 
 
+class InvalidStageMetadataError(ValueError):
+    """story #2792(2790 P1) — stage_metadata 키가 payload_schema.properties.stage.enum의
+    부분집합이 아님(페드루 판정 2026-08-19, 가드①). 오타 slug가 조용히 죽는 클래스
+    (stage_metadata에는 있는데 실제 stage.enum엔 없어 영원히 안 읽히는 항목) 차단."""
+
+
 class InvalidActionAuthError(ValueError):
     """story #2637 §범위3(미르코 발견 후속, 2026-08-14): action_auth 어휘(human_only·role)
     위반 — block_template.actions[].auth와 EventDefinition.action_auth 둘 다 이 함수 하나로
@@ -261,6 +267,34 @@ def validate_event_payload_schema_shape(payload_schema: dict) -> None:
         raise InvalidPayloadSchemaError(
             "payload_schema는 top-level 'additionalProperties: false'를 명시해야 합니다 — "
             "미선언 스키마는 모르는 필드를 조용히 통과시켜 등록을 거부합니다."
+        )
+
+
+def validate_stage_metadata(payload_schema: dict, stage_metadata: dict) -> None:
+    """story #2792(2790 P1, 페드루 판정 2026-08-19 가드①) — stage_metadata의 키 집합이
+    `payload_schema.properties.stage.enum`의 부분집합인지 강제. 이 검증이 없으면 stage_metadata
+    에 오타 slug(예: enum엔 "in_review"인데 메타는 "inreview")를 넣어도 저장은 되고, 그
+    항목은 정의상 도달 불가능한 채로 영원히 조용히 죽는다(get_workflow_guide 등 소비처가
+    실제 stage 값으로만 조회하므로) — 경계를 넘는 이름이 통과하는 클래스, 등록/수정 시점에
+    막는다.
+
+    stage_metadata가 빈 dict({})면 항상 통과(사이클형이 아닌 정의는 이 슬롯을 안 씀 — 신호형/
+    측정형 정의도 이 함수를 걸어도 안전). payload_schema에 stage enum 자체가 없는데
+    stage_metadata가 비어있지 않으면(가리킬 enum이 없음) 거부."""
+    if not stage_metadata:
+        return
+    stage_prop = (payload_schema.get("properties") or {}).get("stage") or {}
+    enum = stage_prop.get("enum")
+    if not isinstance(enum, list):
+        raise InvalidStageMetadataError(
+            "stage_metadata가 있으려면 payload_schema.properties.stage.enum이 먼저 선언돼야 합니다."
+        )
+    valid = set(enum)
+    unknown = sorted(set(stage_metadata.keys()) - valid)
+    if unknown:
+        raise InvalidStageMetadataError(
+            f"stage_metadata에 payload_schema.properties.stage.enum에 없는 키가 있습니다: {unknown} "
+            f"(허용된 stage: {sorted(valid)})"
         )
 
 

--- a/backend/tests/test_2632_event_definitions.py
+++ b/backend/tests/test_2632_event_definitions.py
@@ -457,3 +457,53 @@ def test_routing_missing_leg_rejected():
 
     with pytest.raises(InvalidEventRoutingError):
         validate_event_routing({"escalation": {"kind": "server_derived", "target": "none"}})
+
+
+# ── story #2792(2790 P1) — stage_metadata 키⊆stage.enum 가드(페드루 판정 2026-08-19 가드①) ──
+
+def test_stage_metadata_accepts_keys_that_are_subset_of_stage_enum():
+    from app.services.event_definition_registry import validate_stage_metadata
+
+    payload_schema = {
+        "type": "object", "additionalProperties": False,
+        "properties": {"stage": {"type": "string", "enum": ["kickoff", "implementation", "qa_review"]}},
+    }
+    validate_stage_metadata(
+        payload_schema,
+        {"kickoff": {"role": "PO", "action": "기능 명세 작성"}, "qa_review": {"role": "QA", "action": "AC 검증"}},
+    )
+
+
+def test_stage_metadata_rejects_typo_key_not_in_enum():
+    """⭐가드①의 핵심 AC — enum에 없는 슬러그가 조용히 저장돼 영원히 안 읽히는 클래스를
+    등록 시점에 막는다. "qa_reviw"는 실제 enum("qa_review")의 오타."""
+    from app.services.event_definition_registry import (
+        InvalidStageMetadataError, validate_stage_metadata,
+    )
+
+    payload_schema = {
+        "type": "object", "additionalProperties": False,
+        "properties": {"stage": {"type": "string", "enum": ["kickoff", "implementation", "qa_review"]}},
+    }
+    with pytest.raises(InvalidStageMetadataError):
+        validate_stage_metadata(payload_schema, {"qa_reviw": {"role": "QA", "action": "AC 검증"}})
+
+
+def test_stage_metadata_empty_dict_always_passes_even_without_stage_enum():
+    """신호형/측정형 정의(stage 개념 자체가 없음)에 걸어도 안전 — 빈 stage_metadata는 무조건 통과."""
+    from app.services.event_definition_registry import validate_stage_metadata
+
+    validate_stage_metadata({"type": "object", "additionalProperties": False, "properties": {}}, {})
+
+
+def test_stage_metadata_nonempty_without_stage_enum_rejected():
+    """가리킬 enum 자체가 없는데 stage_metadata가 채워져 있으면 거부(참조 무결성 없는 고아 메타)."""
+    from app.services.event_definition_registry import (
+        InvalidStageMetadataError, validate_stage_metadata,
+    )
+
+    with pytest.raises(InvalidStageMetadataError):
+        validate_stage_metadata(
+            {"type": "object", "additionalProperties": False, "properties": {}},
+            {"kickoff": {"role": "PO", "action": "x"}},
+        )

--- a/backend/tests/test_2792_workflow_cycle_compile.py
+++ b/backend/tests/test_2792_workflow_cycle_compile.py
@@ -1,0 +1,157 @@
+"""story #2792(2790 P1) — 레시피→사이클형 event_definitions 컴파일(0260) + 슬롯 가드①
+(stage_metadata⊆stage.enum) realdb 검증. DB env 없으면 skip(alembic-fresh CI 잡에서 실행)."""
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+_EXPECTED_KEYS = {
+    "preset.workflow.scrum_3step", "preset.workflow.kanban_simple",
+    "preset.workflow.agent_solo", "preset.workflow.loop_agency",
+    "preset.workflow.solo", "preset.workflow.two_step",
+    "preset.workflow.three_step", "preset.workflow.kanban",
+}
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_all_8_recipes_compiled_with_valid_schema_and_stage_metadata():
+    """builtin 4 + DB 4 = 8건 전부 컴파일됐고, 각 정의의 payload_schema/stage_metadata가
+    실제 레지스트리 검증기(validate_event_payload_schema_shape·validate_stage_metadata)를
+    통과한다 — 컴파일 데이터가 우리가 방금 만든 가드①을 스스로 지키는지 자기증명."""
+    from app.services.event_definition_registry import (
+        validate_event_payload_schema_shape, validate_stage_metadata,
+    )
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            rows = (await s.execute(text(
+                "SELECT key, name, payload_schema, stage_metadata, org_id, enabled "
+                "FROM event_definitions WHERE key LIKE 'preset.workflow.%' ORDER BY key"
+            ))).all()
+
+        found_keys = {r[0] for r in rows}
+        assert found_keys == _EXPECTED_KEYS, f"missing/extra: {_EXPECTED_KEYS ^ found_keys}"
+
+        for key, name, schema, stage_metadata, org_id, enabled in rows:
+            assert org_id is None, f"{key}: preset이면 org_id NULL이어야 함"
+            assert enabled is True
+            assert name  # NOT NULL + 비어있지 않음
+            validate_event_payload_schema_shape(schema)
+            validate_stage_metadata(schema, stage_metadata)
+            # 가드① 자기증명 핵심 — enum과 stage_metadata가 정확히 1:1(고아 슬러그 0, 커버 안 된
+            # stage 0).
+            enum = set(schema["properties"]["stage"]["enum"])
+            assert set(stage_metadata.keys()) == enum, f"{key}: stage_metadata↔enum 불일치"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_solo_and_solo_are_distinct_no_key_collision():
+    """⭐발견(컴파일 중) — builtin "solo"가 DB "solo"에 슬러그 충돌로 그림자 처리돼 지금까지
+    한 번도 recipes[0]로도, 목록 어디로도 노출된 적이 없었다. 컴파일 후엔 별개 키
+    (agent_solo/solo)로 둘 다 도달 가능해야 한다 — 이 회귀가 다시 하나로 합쳐지면 안 됨."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            rows = (await s.execute(text(
+                "SELECT key, stage_metadata FROM event_definitions "
+                "WHERE key IN ('preset.workflow.solo', 'preset.workflow.agent_solo')"
+            ))).all()
+        by_key = dict(rows)
+        assert set(by_key) == {"preset.workflow.solo", "preset.workflow.agent_solo"}
+        # 내용도 실제로 다르다(DB="Worker"/담당자 배정, builtin="Agent"/이벤트 수신 후 컨텍스트 파악).
+        assert by_key["preset.workflow.solo"]["assign_step_1"]["role"] == "Worker"
+        assert by_key["preset.workflow.agent_solo"]["received"]["role"] == "Agent"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_stage_metadata_guard_rejects_corrupted_real_compiled_data():
+    """⭐가드①의 실물 회귀 테스트 — 실제로 컴파일된 scrum_3step 정의를 가져와 stage_metadata에
+    존재하지 않는 slug를 하나 섞으면(오타 재현) validate_stage_metadata가 거부해야 한다."""
+    from app.services.event_definition_registry import (
+        InvalidStageMetadataError, validate_stage_metadata,
+    )
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            row = (await s.execute(text(
+                "SELECT payload_schema, stage_metadata FROM event_definitions "
+                "WHERE key = 'preset.workflow.scrum_3step'"
+            ))).first()
+        schema, stage_metadata = row
+        corrupted = dict(stage_metadata)
+        corrupted["qa_reviw"] = {"role": "QA", "action": "오타 슬러그"}  # 실제 enum엔 "qa_review"
+        with pytest.raises(InvalidStageMetadataError):
+            validate_stage_metadata(schema, corrupted)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_event_definition_api_rejects_stage_metadata_key_not_in_enum():
+    """API 종단 — POST /definitions가 stage_metadata 키 오타를 400으로 거부(가드① 실 엔드포인트
+    집행 확인, registry 단위테스트와 별개 축). org_members 시드는 test_2636_custom_event_
+    registration.py의 검증된 패턴 재사용(user_id FK 없음 — 별도 users 행 불요)."""
+    import uuid as uuid_mod
+
+    from fastapi import HTTPException
+
+    from app.dependencies.auth import AuthContext
+    from app.models.organization import Organization
+    from app.models.project import OrgMember
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        org_id = uuid_mod.uuid4()
+        user_id = uuid_mod.uuid4()
+        slug = f"smorg{org_id.hex[:8]}"
+        async with Session() as s:
+            s.add(Organization(id=org_id, name="StageMetaOrg", slug=slug))
+            s.add(OrgMember(id=uuid_mod.uuid4(), org_id=org_id, user_id=user_id, role="owner"))
+            await s.commit()
+
+        auth = AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(org_id))
+        body = CreateEventDefinitionRequest(
+            key=f"org.{slug}.custom_cycle",
+            name="테스트 사이클",
+            payload_schema={
+                "type": "object", "additionalProperties": False,
+                "required": ["stage"],
+                "properties": {"stage": {"type": "string", "enum": ["a", "b"]}},
+            },
+            routing={
+                "escalation": {"kind": "server_derived", "target": "none"},
+                "broadcast": {"kind": "server_derived", "target": "none"},
+            },
+            stage_metadata={"typo_stage": {"role": "X", "action": "Y"}},  # "a"/"b"에 없음
+        )
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await create_event_definition(body, db=s, auth=auth, org_id=org_id)
+        assert exc.value.status_code == 400
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2792_workflow_cycle_compile.py
+++ b/backend/tests/test_2792_workflow_cycle_compile.py
@@ -155,3 +155,68 @@ async def test_create_event_definition_api_rejects_stage_metadata_key_not_in_enu
         assert exc.value.status_code == 400
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_event_definition_api_rejects_payload_schema_shrink_that_orphans_stage_metadata():
+    """⭐카디르군 QA 커버리지 갭 지적(2026-08-19) — PATCH가 payload_schema만 줄이고
+    stage_metadata는 안 건드리면, 기존 메타의 일부 키가 새 enum 밖으로 밀려나(고아) 조용히
+    저장될 뻔한 케이스. registry 단위테스트(validate_stage_metadata 직접 호출)와 별개로
+    실제 `update_event_definition` 엔드포인트 호출로 400을 실증한다."""
+    import uuid as uuid_mod
+
+    from fastapi import HTTPException
+
+    from app.dependencies.auth import AuthContext
+    from app.models.organization import Organization
+    from app.models.project import OrgMember
+    from app.routers.events import (
+        CreateEventDefinitionRequest, UpdateEventDefinitionRequest,
+        create_event_definition, update_event_definition,
+    )
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        org_id = uuid_mod.uuid4()
+        user_id = uuid_mod.uuid4()
+        slug = f"orphorg{org_id.hex[:8]}"
+        async with Session() as s:
+            s.add(Organization(id=org_id, name="OrphanOrg", slug=slug))
+            s.add(OrgMember(id=uuid_mod.uuid4(), org_id=org_id, user_id=user_id, role="owner"))
+            await s.commit()
+
+        auth = AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(org_id))
+        create_body = CreateEventDefinitionRequest(
+            key=f"org.{slug}.custom_cycle",
+            name="테스트 사이클",
+            payload_schema={
+                "type": "object", "additionalProperties": False,
+                "required": ["stage"],
+                "properties": {"stage": {"type": "string", "enum": ["a", "b"]}},
+            },
+            routing={
+                "escalation": {"kind": "server_derived", "target": "none"},
+                "broadcast": {"kind": "server_derived", "target": "none"},
+            },
+            stage_metadata={"a": {"role": "X", "action": "Y"}, "b": {"role": "Z", "action": "W"}},
+        )
+        async with Session() as s:
+            created = await create_event_definition(create_body, db=s, auth=auth, org_id=org_id)
+
+        # payload_schema만 줄여 "b"를 enum에서 뺀다 — stage_metadata는 건드리지 않음(여전히 a·b 둘 다).
+        shrink_body = UpdateEventDefinitionRequest(
+            payload_schema={
+                "type": "object", "additionalProperties": False,
+                "required": ["stage"],
+                "properties": {"stage": {"type": "string", "enum": ["a"]}},
+            },
+        )
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await update_event_definition(
+                    uuid_mod.UUID(created.id), shrink_body, db=s, auth=auth, org_id=org_id,
+                )
+        assert exc.value.status_code == 400
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
story #2792(2790 카드 P1) — "워크플로우 엔티티를 이벤트층으로 흡수" 판정의 백엔드 축.

- **stage_metadata 슬롯 확定**(PO 승인 2026-08-19): `event_definitions.stage_metadata JSONB` — `{slug: {role, action}}`. "기대 행동은 정의 레벨 데이터"(발행 payload 아님) 판별의 실물. **가드①**(PO 지시): 키 집합이 `payload_schema.properties.stage.enum`의 부분집합인지 `validate_stage_metadata`가 create/update 양쪽에서 강제 — 오타 slug가 조용히 죽는 클래스 차단.
- `name`/`description` 컬럼 신설(PO 확定 3칸 ①) — key는 기계용 식별자, name이 사람용 표시(드롭다운 등).
- **컴파일**: builtin 4종(`_BUILTIN_RECIPES`) + DB `workflow_templates` 4행(0016 시드) → `preset.workflow.<slug>` cycle-type 정의 8건.
  - ⭐**발견**: 설계 카드 §1이 "DB 3행"이라 적었으나 실제 4행이고, builtin "solo"가 DB "solo"에 슬러그 충돌로 그림자 처리돼 **지금까지 한 번도 노출된 적이 없었다**(`workflow_recipes.py::list_recipes()`가 db_slugs에 없는 builtin만 추가). recipes[0] 임의성보다 한 겹 더 깊은 은폐 — `agent_solo`로 개명해 둘 다 승격.
- API(create/update/list/detail)에 `name`/`stage_metadata` 배선 — 기존 호출부 회귀 없이(둘 다 안전한 기본값, `#2636`/`#2634` 기존 스위트 99 tests 전부 green).

## 이번 커밋 범위 (PO 승인 순서)
컴파일+정본화까지. `workflow_recipes.py` 라우터·`workflow_templates`/`_BUILTIN_RECIPES` 원본은 **그대로 둔다** — FE `loop-create-dialog.tsx` 등 3곳이 아직 소비 중(미르코군 지도 doc `workflow-recipes-fe-consumption-map-2792` §1). 라우터 실삭제는 그가 FE 전환 확認 후 별도 커밋.

## 미르코군 계약 확定 3칸 (PO 요청)
① name/description 신설(위) — i18n 오버레이 신설 안 함.
② builtin 판별 = `org_id === null`(CHECK 제약이 구조적으로 강제, 우회 불가).
③ loop 생성 제출 필드 `recipe_slug` 필드명 유지, 값만 신규 `key`(예: `preset.workflow.scrum_3step`)로 — `loop_runs.recipe_slug`는 순수 Text 컬럼(FK/CHECK 없음)이라 스키마 변경 없이 저장 포맷만 전환.

## Test plan
- [x] `test_2792_workflow_cycle_compile.py`(신규, fresh migrated DB): 8건 컴파일 확인·payload_schema/stage_metadata 자기검증·agent_solo/solo 비충돌·가드① 실물 회귀·API 400 종단
- [x] `test_2632_event_definitions.py`에 가드① 단위 테스트 4건 추가(양성 3·음성 1)
- [x] 기존 `test_2632/2636/2634/2665/2633` 스위트 99 tests 전부 green(name Pydantic 기본값 "" 으로 구 호출부 무회귀 확인)
- [x] app import 스모크(543 라우트 정상)
- [ ] FE 전환(미르코군, 후속) → workflow-recipes 라우터 실삭제(별도 커밋)

🤖 Generated with [Claude Code](https://claude.com/claude-code)