### PR TITLE
[SID:2805] 채팅 첨부 accept 제거 — 피커·드래그앤드롭·붙여넣기 동일 범위

### DIFF
--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -662,13 +662,17 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        {/* story #2805 — accept로 확장자를 좁혀도 실제 게이트가 아니다(드래그앤드롭·붙여넣기는
+            원래 accept를 안 타 이미 임의 파일 첨부가 가능했고, 서버도 타입 allowlist가 없다).
+            좁은 accept는 그저 "피커 버튼으로 고를 수 있는 파일"만 실제와 불일치시켰다 — docx/pptx
+            뷰어가 나온 날 정작 피커로는 그 파일을 못 고르던 사고. 세 경로(피커·드롭·붙여넣기)의
+            실제 동작을 일치시키기 위해 accept를 없앤다. */}
         <input
           ref={fileInputRef}
           type="file"
           multiple
           className="hidden"
           onChange={handleFileChange}
-          accept="image/*,.pdf,.txt,.md,.csv"
         />
 
         {/* Textarea */}


### PR DESCRIPTION
## 배경
인시던트(#2788/#2803, 선생님 실클릭 재현) 조사 중 발견: 채팅 첨부 `<input type="file">`의 `accept="image/*,.pdf,.txt,.md,.csv"`가 네이티브 피커에서 .docx/.pptx를 걸러내 — docx/pptx 인앱 뷰어가 배포된 그날, 실사용자는 첨부 버튼으로 그 파일을 고를 수조차 없었다(선생님이 열람 가능했던 건 관리자 API로 직접 넣었기 때문).

## 서버측 확인(착수 전 검토, PO 승인 하 진행)
- Next 업로드 라우트(`apps/web/src/app/api/conversations/[conversation_id]/attachments/route.ts`) — 크기(100MB)만 검증, 타입 allowlist 없음
- FastAPI 첨부 메타 검증(`backend/app/routers/conversations.py`) — 크기(100MB)·개수(10개)만 검증, content_type은 비어있지 않은지만 확인
- `accept`는 원래도 실질 게이트가 아니었음 — 드래그앤드롭·붙여넣기는 accept를 안 타 이미 임의 파일 첨부 가능(`handleFileChange`에 타입 필터 없음)
- FileViewer(`resolveFormat`)는 모든 확장자를 정직 처리 — 지원 포맷 렌더, 그 외 office/unknown 폴백(다운로드 유도, 깨진 화면 없음)

## fix
`accept` 속성 제거 — 피커 버튼·드래그앤드롭·붙여넣기 세 경로의 실제 동작을 일치시킴. 크기(100MB)·개수(10개) 상한은 그대로 유지.

## 검증
- 전체 chat 컴포넌트 스위트(31 files/350 tests) 회귀 없음
- build/lint/tsc 전부 그린

story: entity:story:2a3df2ac-bad9-401a-9594-4189bf07b1ce

🤖 Generated with [Claude Code](https://claude.com/claude-code)