### PR TITLE
fix(#2806): GCS 첨부 버킷 CORS를 SSOT로(cloudbuild 멱등 적용)

### DIFF
--- a/backend/tests/test_2806_gcs_attachments_cors_ssot.py
+++ b/backend/tests/test_2806_gcs_attachments_cors_ssot.py
@@ -1,0 +1,57 @@
+"""story #2806 — GCS 첨부 버킷 CORS SSOT(infra/gcs-attachments-cors.json + cloudbuild.yaml
+apply-gcs-attachments-cors 스텝) 선언 정합성. 순수 정적 검증(실 gcloud 호출 없음) —
+"동작은 한 곳에서만 선언" 원칙의 pin(feedback_pin_declarations_as_tests류)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CORS_FILE = _REPO_ROOT / "infra" / "gcs-attachments-cors.json"
+_CLOUDBUILD = _REPO_ROOT / "cloudbuild.yaml"
+
+_DEV_ORIGIN = "https://sprintable-frontend-dev-57iommnikq-du.a.run.app"
+_PROD_ORIGIN = "https://app.sprintable.ai"
+
+
+def _load_cors_rules() -> list[dict]:
+    return json.loads(_CORS_FILE.read_text())
+
+
+def test_cors_file_is_valid_json_with_required_origins():
+    rules = _load_cors_rules()
+    assert len(rules) >= 1
+    all_origins = {o for rule in rules for o in rule.get("origin", [])}
+    assert _DEV_ORIGIN in all_origins, "dev FE canonical origin 누락(gcloud run services describe로 실측한 값)"
+    assert _PROD_ORIGIN in all_origins, "prod origin 누락(cloudbuild.yaml _NEXT_PUBLIC_APP_URL과 동일 값이어야 함)"
+
+
+def test_cors_file_allows_get_for_signed_url_fetch():
+    """docx-preview의 client fetch()는 GET — 이게 없으면 CORS를 채워도 여전히 차단된다."""
+    rules = _load_cors_rules()
+    all_methods = {m for rule in rules for m in rule.get("method", [])}
+    assert "GET" in all_methods
+
+
+def test_cloudbuild_apply_step_references_the_cors_file_exactly():
+    """⭐선언 정합성 — cloudbuild.yaml의 apply-gcs-attachments-cors 스텝이 참조하는
+    --cors-file 경로가 실제 이 파일과 정확히 일치하는지(파일명 드리프트 방지)."""
+    doc = yaml.safe_load(_CLOUDBUILD.read_text())
+    step = next((s for s in doc["steps"] if s["id"] == "apply-gcs-attachments-cors"), None)
+    assert step is not None, "cloudbuild.yaml에 apply-gcs-attachments-cors 스텝이 없음"
+    assert step["entrypoint"] == "bash"
+    script = step["args"][1]
+    assert "infra/gcs-attachments-cors.json" in script
+    assert "gcloud storage buckets update" in script
+    assert "sprintable-memo-attachments" in script
+
+
+def test_cloudbuild_step_does_not_require_build_or_push():
+    """이 스텝은 이미지 빌드와 무관 — waitFor가 build/push에 안 걸려 있어야(병행 실행,
+    #2771 office-converter와 동일 원칙) 배포 지연이 안 생긴다."""
+    doc = yaml.safe_load(_CLOUDBUILD.read_text())
+    step = next(s for s in doc["steps"] if s["id"] == "apply-gcs-attachments-cors")
+    wait_for = step.get("waitFor") or []
+    assert not any("build" in w or "push" in w for w in wait_for)

--- a/backend/tests/test_2806_gcs_attachments_cors_ssot.py
+++ b/backend/tests/test_2806_gcs_attachments_cors_ssot.py
@@ -1,6 +1,12 @@
 """story #2806 — GCS 첨부 버킷 CORS SSOT(infra/gcs-attachments-cors.json + cloudbuild.yaml
 apply-gcs-attachments-cors 스텝) 선언 정합성. 순수 정적 검증(실 gcloud 호출 없음) —
-"동작은 한 곳에서만 선언" 원칙의 pin(feedback_pin_declarations_as_tests류)."""
+"동작은 한 곳에서만 선언" 원칙의 pin(feedback_pin_declarations_as_tests류).
+
+PO 재측정(2026-08-19)으로 라이브 CORS가 애초에 완전 비어있던 게 아니라
+(dev-app.sprintable.ai, app.sprintable.ai) 2 origin + 4 responseHeader가 이미 있었음이
+드러남 — 신규 JSON은 이 라이브 상태의 "상위집합"이어야 하며(기존 origin/header 유지),
+누락분(dev Cloud Run 원시 URL 두 형태)만 추가한다. 전체 교체(overwrite) 특성상 상위집합이
+아니면 배포 즉시 회귀다."""
 from __future__ import annotations
 
 import json
@@ -12,20 +18,43 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CORS_FILE = _REPO_ROOT / "infra" / "gcs-attachments-cors.json"
 _CLOUDBUILD = _REPO_ROOT / "cloudbuild.yaml"
 
-_DEV_ORIGIN = "https://sprintable-frontend-dev-57iommnikq-du.a.run.app"
-_PROD_ORIGIN = "https://app.sprintable.ai"
+# PO 실측 라이브 상태(2026-08-19) — 이 셋이 신규 JSON에서 하나라도 빠지면 침묵 회귀.
+_LIVE_ORIGINS = {"https://dev-app.sprintable.ai", "https://app.sprintable.ai"}
+_LIVE_RESPONSE_HEADERS = {"Content-Type", "Content-Length", "Content-Disposition", "Range"}
+
+# 이번 story #2806의 실제 결함 표면 — 유나군 실측(AC③ 양성대조) origin.
+_DEV_CLOUD_RUN_HASH_ORIGIN = "https://sprintable-frontend-dev-57iommnikq-du.a.run.app"
+_DEV_CLOUD_RUN_REGIONAL_ORIGIN = "https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app"
 
 
 def _load_cors_rules() -> list[dict]:
     return json.loads(_CORS_FILE.read_text())
 
 
-def test_cors_file_is_valid_json_with_required_origins():
+def _all_origins(rules: list[dict]) -> set[str]:
+    return {o for rule in rules for o in rule.get("origin", [])}
+
+
+def test_cors_file_is_superset_of_live_origins_and_headers():
+    """전체 교체 특성 — 라이브에 이미 있던 origin/header가 하나라도 빠지면 배포 즉시 회귀(선생님
+    화면이 깨짐). 신규 JSON은 반드시 상위집합이어야 한다."""
     rules = _load_cors_rules()
-    assert len(rules) >= 1
-    all_origins = {o for rule in rules for o in rule.get("origin", [])}
-    assert _DEV_ORIGIN in all_origins, "dev FE canonical origin 누락(gcloud run services describe로 실측한 값)"
-    assert _PROD_ORIGIN in all_origins, "prod origin 누락(cloudbuild.yaml _NEXT_PUBLIC_APP_URL과 동일 값이어야 함)"
+    all_origins = _all_origins(rules)
+    all_headers = {h for rule in rules for h in rule.get("responseHeader", [])}
+
+    missing_origins = _LIVE_ORIGINS - all_origins
+    assert not missing_origins, f"라이브 origin 누락(침묵 회귀 위험): {missing_origins}"
+
+    missing_headers = _LIVE_RESPONSE_HEADERS - all_headers
+    assert not missing_headers, f"라이브 responseHeader 누락(침묵 회귀 위험): {missing_headers}"
+
+
+def test_cors_file_includes_dev_cloud_run_origins():
+    """story #2806의 실제 결함 표면 — dev Cloud Run 원시 URL이 두 형태(hash형/regional형) 다
+    있어야 함. 유나군 실측 origin은 regional형이라 이게 빠지면 AC③ 양성대조가 안 뒤집힌다."""
+    all_origins = _all_origins(_load_cors_rules())
+    assert _DEV_CLOUD_RUN_HASH_ORIGIN in all_origins
+    assert _DEV_CLOUD_RUN_REGIONAL_ORIGIN in all_origins
 
 
 def test_cors_file_allows_get_for_signed_url_fetch():
@@ -46,6 +75,26 @@ def test_cloudbuild_apply_step_references_the_cors_file_exactly():
     assert "infra/gcs-attachments-cors.json" in script
     assert "gcloud storage buckets update" in script
     assert "sprintable-memo-attachments" in script
+
+
+def test_cloudbuild_verify_uses_cors_config_field_not_cors():
+    """`gcloud storage buckets describe --format=value(cors)`는 존재하지 않는 필드라 항상
+    빈 값을 준다(PO가 실측으로 잡은 오측) — 실 필드명은 cors_config."""
+    doc = yaml.safe_load(_CLOUDBUILD.read_text())
+    step = next(s for s in doc["steps"] if s["id"] == "apply-gcs-attachments-cors")
+    script = step["args"][1]
+    assert "cors_config" in script
+    assert "value(cors)" not in script
+
+
+def test_cloudbuild_verify_fails_closed_when_expected_origin_missing():
+    """검증 echo가 항상 통과하면 확認이 아니다 — 기대 origin(dev Cloud Run regional, 유나군
+    실측 표면)이 적용 결과에 없으면 스텝이 exit 1로 죽어야 한다."""
+    doc = yaml.safe_load(_CLOUDBUILD.read_text())
+    step = next(s for s in doc["steps"] if s["id"] == "apply-gcs-attachments-cors")
+    script = step["args"][1]
+    assert _DEV_CLOUD_RUN_REGIONAL_ORIGIN in script
+    assert "exit 1" in script
 
 
 def test_cloudbuild_step_does_not_require_build_or_push():

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -64,7 +64,9 @@ _DECLARED_SUBSTITUTIONS = {
 # 새로 생기면 이 목록에 추가할 것(오르테가 지시 — deploy-realtime도 같은 함정 자리라 포함).
 # story #2771 후속(2026-08-19) — deploy-office-converter도 실 substitution(${_DEPLOY_ENV} 등)을
 # 쓰는 bash entrypoint라 포함.
-_BASH_ENTRYPOINT_STEP_IDS = ("deploy-backend", "deploy-realtime", "deploy-office-converter")
+_BASH_ENTRYPOINT_STEP_IDS = (
+    "deploy-backend", "deploy-realtime", "deploy-office-converter", "apply-gcs-attachments-cors",
+)
 
 
 def _extract_step_script(step_id: str) -> str:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -270,6 +270,27 @@ substitutions:
   _BACKEND_REDIS_DUAL_PUBLISH_ENABLED: 'false'
 
 steps:
+  # story #2806 — GCS 첨부 버킷(sprintable-memo-attachments) CORS를 SSOT로 durable화. 실측
+  # (디디군, 2026-08-19): 이 버킷은 dev/prod 공유(GCS_MEMO_ATTACHMENTS_BUCKET override가
+  # 배포 SSOT 어디에도 없어 코드 기본값 하나를 양쪽이 씀) — 지금까지 CORS가 배포 SSOT에
+  # 선언된 적이 0건(레포 전수 grep)이라 브라우저 signed-URL fetch(docx-preview류, PDF는
+  # iframe이라 무영향)가 origin 불문 전부 차단돼 있었다. `gcloud storage buckets update
+  # --cors-file=`은 **전체 교체**라 매 배포 재실행에도 멱등(파일 내용이 그대로면 결과도
+  # 그대로) — build/push와 무관해 초반부터 병행 실행.
+  - id: apply-gcs-attachments-cors
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        gcloud storage buckets update gs://sprintable-memo-attachments \
+          --cors-file=infra/gcs-attachments-cors.json \
+          --quiet
+        applied=$(gcloud storage buckets describe gs://sprintable-memo-attachments --format='value(cors)')
+        echo "OK: sprintable-memo-attachments CORS applied = $${applied}"
+    waitFor: ['-']
+
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
   - id: build-frontend
     name: gcr.io/cloud-builders/docker

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -287,8 +287,13 @@ steps:
         gcloud storage buckets update gs://sprintable-memo-attachments \
           --cors-file=infra/gcs-attachments-cors.json \
           --quiet
-        applied=$(gcloud storage buckets describe gs://sprintable-memo-attachments --format='value(cors)')
-        echo "OK: sprintable-memo-attachments CORS applied = $${applied}"
+        applied=$(gcloud storage buckets describe gs://sprintable-memo-attachments --format='value(cors_config)')
+        echo "sprintable-memo-attachments CORS applied = $${applied}"
+        case "$${applied}" in
+          *https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app*) ;;
+          *) echo "FAIL: dev Cloud Run regional origin missing from applied CORS — 배포 검증 실패" >&2; exit 1 ;;
+        esac
+        echo "OK: dev Cloud Run regional origin confirmed in applied CORS"
     waitFor: ['-']
 
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────

--- a/infra/gcs-attachments-cors.json
+++ b/infra/gcs-attachments-cors.json
@@ -1,12 +1,14 @@
 [
   {
     "origin": [
-      "https://sprintable-frontend-dev-57iommnikq-du.a.run.app",
+      "https://dev-app.sprintable.ai",
       "https://app.sprintable.ai",
+      "https://sprintable-frontend-dev-57iommnikq-du.a.run.app",
+      "https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app",
       "http://localhost:3108"
     ],
     "method": ["GET", "HEAD"],
-    "responseHeader": ["Content-Type"],
+    "responseHeader": ["Content-Type", "Content-Length", "Content-Disposition", "Range"],
     "maxAgeSeconds": 3600
   }
 ]

--- a/infra/gcs-attachments-cors.json
+++ b/infra/gcs-attachments-cors.json
@@ -1,0 +1,12 @@
+[
+  {
+    "origin": [
+      "https://sprintable-frontend-dev-57iommnikq-du.a.run.app",
+      "https://app.sprintable.ai",
+      "http://localhost:3108"
+    ],
+    "method": ["GET", "HEAD"],
+    "responseHeader": ["Content-Type"],
+    "maxAgeSeconds": 3600
+  }
+]


### PR DESCRIPTION
## Summary
- story #2806 — dev 배포 docx 인앱 렌더가 GCS signed-URL fetch CORS 차단으로 실패하는 결함 수정.
- **CHANGES 반영(2026-08-19, PO 재측정)**: 최초 PR의 「CORS 완전 비어있음」 서술은 오측이었죠 — `gcloud storage buckets describe`의 실 필드명은 `cors`가 아니라 **`cors_config`**라 제 `format='value(cors)'`가 존재하지 않는 필드를 읽어 null을 준 것. 라이브 CORS는 이미 origin 2개(`dev-app.sprintable.ai`, `app.sprintable.ai`) + responseHeader 4종(Content-Type/Content-Length/Content-Disposition/Range)이 있었음.
- ⓒ 모순 해소: 선생님 origin=`dev-app.sprintable.ai`(커스텀 도메인, CORS 이미 OK)라 렌더된 것이고, 유나군은 Cloud Run 원시 URL이라 애초에 allowlist 밖이었던 것. **진짜 결함 = "CORS 완전 부재"가 아니라 "Cloud Run 원시 URL 계열 누락 + SSOT 부재"**로 재정의.
- ⓓ Cloud Audit Log 30일 조회 → `storage.buckets.update` 이력 정확히 1건, actor=이 머신 fleet 공유 로컬 CLI 자격(특정 개인 귀속 금지 — "로컬 CLI 1건(주체 미확定)").

## 변경
- ①CORS 선언을 `infra/gcs-attachments-cors.json`으로 레포 SSOT화. **라이브 상위집합**으로 작성(기존 2 origin + 4 responseHeader 전부 보존 — 전체 교체 특성상 하나라도 빠지면 선생님 화면이 깨지는 침묵 회귀) + dev Cloud Run 원시 URL 두 형태(hash형 `sprintable-frontend-dev-57iommnikq-du.a.run.app` + regional형 `sprintable-frontend-dev-787818285179.asia-northeast3.run.app`, 유나군 실측은 regional형) + `localhost:3108`(로컬 dev fetch용, 제 판단으로 포함).
- ②`cloudbuild.yaml`에 `apply-gcs-attachments-cors` 스텝 신설 — `gcloud storage buckets update --cors-file=`(전체 교체=멱등, build/push 비의존 병행실행). 검증 echo는 `value(cors_config)` 필드로 정정 + 기대 origin(dev Cloud Run regional형) 부재 시 **exit 1**(fail-closed — 항상 통과하는 확認은 확認이 아니라는 PO 지적 반영).
- 이스케이프 가드(`_BASH_ENTRYPOINT_STEP_IDS`)에 신규 스텝 편입, `${applied}` 더블달러 컨벤션 준수.

## Test plan
- [x] `backend/tests/test_2806_gcs_attachments_cors_ssot.py` 5건: 라이브 상위집합 pin(origin/header 양방향)·dev Cloud Run 두 형태 포함·GET 메서드·cors_config 필드 사용·fail-closed exit 1 존재·cloudbuild 스텝 파일경로 정확 일치·build/push 비의존 — 전부 green.
- [x] 기존 이스케이프 가드 스위트 포함 총 83 tests — 전부 green.
- [x] `cloudbuild.yaml` yaml 파싱 확인 + 신규 스텝 스크립트 `bash -n` 구문검증.
- [ ] (배포 후, PO/인프라 lane) 실제 `gcloud storage buckets update` 적용 → 유나군 dev docx 렌더 재측정으로 양성대조 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)