### PR TITLE
[SID:2807] PDF/pptx 인앱 미리보기 백지 — CSP frame-src를 blob:로 좁게 전환

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -22,7 +22,12 @@ const _CSP = [
   // 이미 같은 호스트가 허용돼 있다(story #2050, 서명 URL·노출 축 동일) — 새 origin을
   // 여는 것이 아니라 media-src를 img-src와 같은 경계로 맞추는 것이다.
   "media-src 'self' blob: https://storage.googleapis.com",
-  "frame-src 'none'",
+  // story #2807 — PDF/pptx 인앱 미리보기가 GCS 서명 URL을 곧바로 iframe src에 넣어
+  // frame-src 'none'에 원천 차단됐다(선생님 실측 ERR_BLOCKED_BY_CSP). storage.googleapis.com
+  // 같은 외부 호스트를 통째로 열면 임의 GCS 콘텐츠를 끼우는 피싱 표면이 생긴다(toss-checkout
+  // 선례와 동일 판단) — 대신 FE가 fetch→Blob→객체 URL로 직접 받아 그 blob: URL만 iframe에
+  // 넣는다. blob:은 그 탭이 방금 만든 콘텐츠만 가리키므로 외부 호스트 개방보다 훨씬 좁다.
+  "frame-src blob:",
   "object-src 'none'",
   "base-uri 'self'",
   // OAuth 리다이렉트 대상

--- a/apps/web/src/components/chat/file-viewer.pdf.test.tsx
+++ b/apps/web/src/components/chat/file-viewer.pdf.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+//
+// story #2807 — PdfBody가 서명 GCS URL을 곧장 iframe src에 넣지 않고(CSP frame-src 'none'에
+// 막힘, 선생님 실측 ERR_BLOCKED_BY_CSP) fetch→Blob→객체 URL로 바꿔 iframe에 거는지 실마운트로
+// 확인한다. [[feedback-render-test-over-source-grep]] 동형 — 소스만 보고 "blob URL 쓴다"고
+// 서술하는 대신 실제로 iframe의 src가 blob:인지, 실패 시 정직 폴백에 도달하는지를 확인한다.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { FileViewer } from './file-viewer';
+import type { ReadingPanelTarget } from './reading-panel';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/lib/db/client', () => ({
+  fetchWithAuth: vi.fn(async () =>
+    new Response(JSON.stringify({ data: { url: 'https://signed.example/fixture.pdf' } }), { status: 200 })
+  ),
+}));
+vi.mock('@/lib/native-shell-bridge', () => ({
+  downloadAsset: vi.fn(),
+  openExternal: vi.fn(),
+}));
+
+const target: Extract<ReadingPanelTarget, { kind: 'attachment' }> = {
+  kind: 'attachment',
+  label: 'fixture.pdf',
+  contentType: 'application/pdf',
+  assetId: 'asset-pdf',
+};
+
+let container: HTMLDivElement;
+let root: Root;
+let objectUrlCounter = 0;
+
+function mount(node: React.ReactElement) {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => { root.render(node); });
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 5000) {
+  const start = Date.now();
+  while (!check()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out');
+    await act(async () => { await new Promise((r) => setTimeout(r, 20)); });
+  }
+}
+
+function stubObjectUrl() {
+  vi.stubGlobal('URL', Object.assign(URL, {
+    createObjectURL: vi.fn(() => `blob:mock-${objectUrlCounter++}`),
+    revokeObjectURL: vi.fn(),
+  }));
+}
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  objectUrlCounter = 0;
+});
+
+describe('FileViewer pdf (story #2807 — CSP frame-src blob 전환)', () => {
+  it('서명 URL을 fetch→Blob→객체 URL로 바꿔 iframe src에 건다(외부 호스트 URL을 곧장 안 씀)', async () => {
+    stubObjectUrl();
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === 'https://signed.example/fixture.pdf') return new Response(new Blob(['%PDF-fake']), { status: 200 });
+      throw new Error(`unexpected fetch: ${url}`);
+    }));
+
+    mount(<FileViewer target={target} onClose={() => {}} />);
+    await waitFor(() => container.querySelector('iframe') !== null || container.textContent!.includes('표시하지 못했습니다'));
+
+    const iframe = container.querySelector('iframe');
+    expect(iframe, `iframe 없음. text=${container.textContent}`).not.toBeNull();
+    expect(iframe!.getAttribute('src')).toBe('blob:mock-0');
+    // 서명 URL(외부 호스트)을 그대로 src에 넣지 않는다 — CSP frame-src가 blob:만 허용.
+    expect(iframe!.getAttribute('src')).not.toContain('signed.example');
+    expect(container.querySelector('.animate-spin')).toBeNull();
+  });
+
+  it('fetch가 실패(404)하면 정직 폴백으로 빠진다 — 빈 화면/무한 로딩 금지', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 404 })));
+
+    mount(<FileViewer target={target} onClose={() => {}} />);
+    await waitFor(() => container.textContent!.includes('표시하지 못했습니다'));
+
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(container.textContent).toContain('다운로드해 확인하세요');
+  });
+
+  it('fetch가 응답하지 않고 멈춰도(hang) 상한 타이머로 정직 폴백에 도달한다 — 무한 로딩 금지', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})));
+
+    mount(<FileViewer target={target} onClose={() => {}} />);
+    await act(async () => { await Promise.resolve(); });
+    expect(container.querySelector('.animate-spin')).not.toBeNull();
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(20000); });
+
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(container.textContent).toContain('표시하지 못했습니다');
+    errorSpy.mockRestore();
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/src/components/chat/file-viewer.pdf.test.tsx
+++ b/apps/web/src/components/chat/file-viewer.pdf.test.tsx
@@ -67,7 +67,10 @@ describe('FileViewer pdf (story #2807 — CSP frame-src blob 전환)', () => {
   it('서명 URL을 fetch→Blob→객체 URL로 바꿔 iframe src에 건다(외부 호스트 URL을 곧장 안 씀)', async () => {
     stubObjectUrl();
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (url === 'https://signed.example/fixture.pdf') return new Response(new Blob(['%PDF-fake']), { status: 200 });
+      // story #2807 CI 재발견 — new Response(new Blob([...]))는 Node 22(CI)에서
+      // "object.stream is not a function"으로 깨진다(undici Response 생성자가 cross-realm
+      // Blob의 .stream()을 못 찾는 버전차, 로컬 Node 26에선 안 재현됨). 문자열 body로 우회.
+      if (url === 'https://signed.example/fixture.pdf') return new Response('%PDF-fake', { status: 200 });
       throw new Error(`unexpected fetch: ${url}`);
     }));
 

--- a/apps/web/src/components/chat/file-viewer.pptx.test.tsx
+++ b/apps/web/src/components/chat/file-viewer.pptx.test.tsx
@@ -53,12 +53,20 @@ function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status });
 }
 
+// story #2807 — 변환된 PDF는 이제 서명 URL을 곧장 iframe src에 넣지 않고(CSP frame-src
+// 'none'에 막힘) fetch→Blob→객체 URL로 바꿔서 건다. jsdom엔 URL.createObjectURL이 없어
+// 스텁하고, plain fetch(fetchWithAuth 아님)도 별도로 모킹해야 이 단계를 테스트로 통과시킬 수 있다.
+let objectUrlCounter = 0;
+const fetchMock = vi.fn();
+
 afterEach(() => {
   act(() => { root.unmount(); });
   container.remove();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
   fetchWithAuthMock.mockReset();
+  fetchMock.mockReset();
+  objectUrlCounter = 0;
 });
 
 describe('FileViewer pptx (story #2803)', () => {
@@ -76,13 +84,22 @@ describe('FileViewer pptx (story #2803)', () => {
       }
       throw new Error(`unexpected fetchWithAuth call: ${url}`);
     });
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === 'https://signed.example/deck.pdf') return new Response(new Blob(['%PDF-fake']), { status: 200 });
+      throw new Error(`unexpected plain fetch call: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('URL', Object.assign(URL, {
+      createObjectURL: vi.fn(() => `blob:mock-${objectUrlCounter++}`),
+      revokeObjectURL: vi.fn(),
+    }));
 
     mount(<FileViewer target={target} onClose={() => {}} />);
     await waitFor(() => container.querySelector('iframe') !== null || container.textContent!.includes('변환에 실패했습니다'));
 
     const iframe = container.querySelector('iframe');
     expect(iframe, `iframe 없음. text=${container.textContent}`).not.toBeNull();
-    expect(iframe!.getAttribute('src')).toBe('https://signed.example/deck.pdf');
+    expect(iframe!.getAttribute('src')).toBe('blob:mock-0');
     // "변환 중" 스피너는 사라져야 한다.
     expect(container.textContent).not.toContain('변환 중입니다');
   });
@@ -106,6 +123,15 @@ describe('FileViewer pptx (story #2803)', () => {
       }
       throw new Error(`unexpected fetchWithAuth call: ${url}`);
     });
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === 'https://signed.example/deck.pdf') return new Response(new Blob(['%PDF-fake']), { status: 200 });
+      throw new Error(`unexpected plain fetch call: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('URL', Object.assign(URL, {
+      createObjectURL: vi.fn(() => `blob:mock-${objectUrlCounter++}`),
+      revokeObjectURL: vi.fn(),
+    }));
 
     mount(<FileViewer target={mismatchedTarget} onClose={() => {}} />);
     // pptx로 갔다면 "변환 중" 표시를 거쳐 iframe이 뜬다. docx로 잘못 갔다면 window.fetch(미모킹)
@@ -114,7 +140,7 @@ describe('FileViewer pptx (story #2803)', () => {
 
     const iframe = container.querySelector('iframe');
     expect(iframe, `iframe 없음(=docx로 오라우팅됐을 가능성). text=${container.textContent}`).not.toBeNull();
-    expect(iframe!.getAttribute('src')).toBe('https://signed.example/deck.pdf');
+    expect(iframe!.getAttribute('src')).toBe('blob:mock-0');
   });
 
   it('변환 서비스 미배선(503)이면 정직 폴백으로 빠진다 — 빈 화면/무한 로딩 금지', async () => {

--- a/apps/web/src/components/chat/file-viewer.pptx.test.tsx
+++ b/apps/web/src/components/chat/file-viewer.pptx.test.tsx
@@ -84,8 +84,11 @@ describe('FileViewer pptx (story #2803)', () => {
       }
       throw new Error(`unexpected fetchWithAuth call: ${url}`);
     });
+    // story #2807 CI 재발견 — new Response(new Blob([...]))는 Node 22(CI)에서 "object.stream
+    // is not a function"으로 깨진다(undici Response 생성자가 cross-realm Blob의 .stream()을
+    // 못 찾는 버전차, 로컬 Node 26에선 안 재현됨). 문자열 body로 우회.
     fetchMock.mockImplementation(async (url: string) => {
-      if (url === 'https://signed.example/deck.pdf') return new Response(new Blob(['%PDF-fake']), { status: 200 });
+      if (url === 'https://signed.example/deck.pdf') return new Response('%PDF-fake', { status: 200 });
       throw new Error(`unexpected plain fetch call: ${url}`);
     });
     vi.stubGlobal('fetch', fetchMock);
@@ -124,7 +127,7 @@ describe('FileViewer pptx (story #2803)', () => {
       throw new Error(`unexpected fetchWithAuth call: ${url}`);
     });
     fetchMock.mockImplementation(async (url: string) => {
-      if (url === 'https://signed.example/deck.pdf') return new Response(new Blob(['%PDF-fake']), { status: 200 });
+      if (url === 'https://signed.example/deck.pdf') return new Response('%PDF-fake', { status: 200 });
       throw new Error(`unexpected plain fetch call: ${url}`);
     });
     vi.stubGlobal('fetch', fetchMock);

--- a/apps/web/src/components/chat/file-viewer.tsx
+++ b/apps/web/src/components/chat/file-viewer.tsx
@@ -231,7 +231,8 @@ function FileViewerBody({ format, url, label, assetId }: { format: Format; url: 
         </div>
       );
     case 'pdf':
-      return <iframe src={url} title={label} className="h-full w-full border-0" />;
+      // key={url} — 다른 첨부로 전환 시 컴포넌트를 통째로 새로 마운트(DocxBody와 동형).
+      return <PdfBody key={url} url={url} label={label} />;
     case 'html':
       // 미신뢰 업로드 컨텐츠 미리보기 — allow-scripts 없음(격리, CSP 준하는 최소 권한).
       return <iframe src={url} title={label} sandbox="allow-popups" className="h-full w-full border-0 bg-white" />;
@@ -415,6 +416,83 @@ function DocxBody({ url, label }: { url: string; label: string }) {
 }
 
 /**
+ * story #2807 — 예전엔 서명 GCS URL을 곧장 iframe src에 넣었는데, CSP frame-src 'none'
+ * (SEC-08)에 원천 차단됐다(선생님 실측 ERR_BLOCKED_BY_CSP — 백지의 진짜 원인). frame-src에
+ * blob:만 열려 있으므로(next.config.ts, storage.googleapis.com 같은 외부 호스트 전체
+ * 개방은 피싱 표면이라 금지 — toss-checkout 선례) fetch로 직접 받아 Blob→객체 URL로 바꿔
+ * 그것만 iframe에 건다. DocxBody와 동형 패턴(단일 try/catch+독립 타이머).
+ */
+function PdfBody({ url, label }: { url: string; label: string }) {
+  const [status, setStatus] = useState<'loading' | 'ready' | 'failed'>('loading');
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let settled = false;
+    const controller = new AbortController();
+    let objectUrl: string | null = null;
+
+    const markFailed = (err: unknown) => {
+      if (settled) return;
+      settled = true;
+      console.error('pdf 인앱 렌더 실패', err);
+      controller.abort();
+      setStatus('failed');
+    };
+    const markReady = (u: string) => {
+      if (settled) return;
+      settled = true;
+      setBlobUrl(u);
+      setStatus('ready');
+    };
+
+    // AC(무한 로딩 금지) — fetch가 멈추든 어느 단계가 멈추든 20초 뒤 강제로 정직 실패로
+    // 떨어뜨린다. run과 독립적으로 도는 타이머라 run 쪽 로직과 무관하게 항상 발화한다.
+    const timeoutId = setTimeout(() => markFailed(new Error('pdf fetch timeout')), 20000);
+
+    (async () => {
+      try {
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) throw new Error(String(res.status));
+        const blob = await res.blob();
+        objectUrl = URL.createObjectURL(blob);
+        clearTimeout(timeoutId);
+        markReady(objectUrl);
+      } catch (err) {
+        clearTimeout(timeoutId);
+        markFailed(err);
+      }
+    })();
+
+    return () => {
+      settled = true;
+      controller.abort();
+      clearTimeout(timeoutId);
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [url]);
+
+  if (status === 'failed') {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+        <FileText className="size-8 text-muted-foreground" aria-hidden />
+        <p className="text-sm text-foreground">미리보기를 표시하지 못했습니다.</p>
+        <p className="text-xs text-muted-foreground">이 문서는 인앱 렌더에 실패했습니다. 다운로드해 확인하세요.</p>
+      </div>
+    );
+  }
+
+  if (status === 'loading') {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" aria-hidden />
+      </div>
+    );
+  }
+
+  return <iframe src={blobUrl ?? undefined} title={label} className="h-full w-full border-0" />;
+}
+
+/**
  * story #2803 — pptx는 BE 변환 파이프(POST /api/attachments/convert → office_conversion.py,
  * 84ef0cb7 §7-3)로 PDF로 바꾼 뒤 기존 PDF iframe 렌더를 그대로 재사용한다. 콜드스타트가
  * 수십 초 걸릴 수 있어(LibreOffice 헤드리스, §7-4 timeout=120s) "변환 중" + 경과시간 정직
@@ -444,6 +522,7 @@ function PptxBody({ assetId, label }: { assetId: string; label: string }) {
     // 동형) status/failMessage는 이미 useState 초기값으로 깨끗하다 — 여기서 재설정 불요.
     let settled = false;
     const controller = new AbortController();
+    let objectUrl: string | null = null;
 
     const markFailed = (msg: string | null) => {
       if (settled) return;
@@ -486,12 +565,19 @@ function PptxBody({ assetId, label }: { assetId: string; label: string }) {
           { signal: controller.signal },
         );
         const signJson = (await signRes.json().catch(() => null)) as { data?: { url?: string }; error?: { message?: string } } | null;
-        const url = signJson?.data?.url;
-        if (!signRes.ok || !url) {
+        const signedUrl = signJson?.data?.url;
+        if (!signRes.ok || !signedUrl) {
           throw new Error(signJson?.error?.message ?? String(signRes.status));
         }
+        // story #2807 — 서명 URL을 곧장 iframe src에 넣으면 CSP frame-src 'none'에
+        // 원천 차단된다(선생님 실측 ERR_BLOCKED_BY_CSP — 백지의 진짜 원인). frame-src에
+        // blob:만 열려 있으므로(PdfBody와 동형) fetch로 직접 받아 Blob→객체 URL로 바꾼다.
+        const pdfRes = await fetch(signedUrl, { signal: controller.signal });
+        if (!pdfRes.ok) throw new Error(String(pdfRes.status));
+        const blob = await pdfRes.blob();
+        objectUrl = URL.createObjectURL(blob);
         clearTimeout(timeoutId);
-        markReady(url);
+        markReady(objectUrl);
       } catch (e) {
         clearTimeout(timeoutId);
         // 에러를 삼키지 않는다 — 폴백 UI로 사용자에겐 정직 실패를 보여주되, 원인은 콘솔에 남긴다.
@@ -500,7 +586,12 @@ function PptxBody({ assetId, label }: { assetId: string; label: string }) {
       }
     })();
 
-    return () => { settled = true; controller.abort(); clearTimeout(timeoutId); };
+    return () => {
+      settled = true;
+      controller.abort();
+      clearTimeout(timeoutId);
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
   }, [assetId]);
 
   if (status === 'failed') {


### PR DESCRIPTION
## 배경
선생님이 pptx 미리보기를 웹·데스크톱 앱 양쪽에서 백지로 겪었고, devtools로 **`ERR_BLOCKED_BY_CSP`**를 직접 잡음. 조사 경위(재현·반증 포함)는 스토리 #2807 본문 참조.

**근본 원인**: `PdfBody`/`PptxBody`가 서명 GCS URL을 곧장 `<iframe src=...>`에 넣는데, `next.config.ts`의 CSP가 `frame-src 'none'`(SEC-08, #599부터)이라 모든 외부 iframe이 원천 차단됨. #2788/#2803 인시던트 fix(PR#3234, 상태전이 버그)는 유효하지만 최종 시각 렌더 단계에서 이 CSP에 별개로 막혀 있었음.

## CSP에서 무엇이 어떻게 바뀌는지
- `frame-src 'none'` → **`frame-src blob:`** (딱 그만큼만)
- **`storage.googleapis.com` 같은 외부 호스트는 열지 않음** — toss-checkout 선례(2026-08-07, PR#2895)와 동일 판단: 임의 iframe이 외부 GCS 콘텐츠를 끼우는 피싱 표면을 만들지 않기 위해서. `blob:`은 그 탭이 방금 fetch로 받아 만든 콘텐츠만 가리키므로 훨씬 좁음.
- 다른 iframe 사용처(docs YouTube/Figma embed, canvas artifact srcdoc)는 **전혀 영향받지 않음**(blob:만 추가, 다른 origin/scheme 무변경 — 확인 완료).

## 코드 변경
- `PdfBody`(신규 컴포넌트, `case 'pdf'`) — 서명 URL을 `fetch()`→`Blob`→`URL.createObjectURL()`로 바꿔 그 `blob:` URL만 iframe에 건다. `DocxBody`와 동형 패턴(단일 try/catch+독립 20초 타이머+cancel 가드).
- `PptxBody` — convert→sign 이후 서명 URL을 동일하게 fetch→Blob→객체 URL로 바꾼 뒤 markReady. 언마운트/재마운트 시 `URL.revokeObjectURL`로 정리.

## 의존성
story #2806(GCS 버킷 CORS allowlist, PR#3236)이 **선행 배포**되어야 blob fetch가 실제로 성공한다(fetch도 CORS를 탄다) — #3236 머지 전까지는 코드 준비만, **라이브 최종 검증은 배포 후**.

## 검증
- 신규 `file-viewer.pdf.test.tsx`(3케이스: 성공/404실패/hang타임아웃)
- `file-viewer.pptx.test.tsx` blob 경로 반영(6케이스 그린)
- 전체 chat 스위트(32 files/353 tests) 회귀 없음, CPU 컨텐션 반복 green
- build/lint/tsc 전부 그린
- **라이브 최종 검증은 #2806/PR#3236 배포 후 진행**(dev 실클릭, 양 테마)

story: entity:story:77998b9c-10f3-4d10-85f7-dfc1c9a9ab75

🤖 Generated with [Claude Code](https://claude.com/claude-code)