### PR TITLE
[SID:2792] 워크플로우 레시피 → 사이클형 이벤트 정의 FE 전환(2790 P1)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3708,47 +3708,6 @@
     "sigRequestChanges": "Request changes",
     "sigApproveAndSign": "Approve & sign"
   },
-  "workflowRecipes": {
-    "scrum-3step": {
-      "name": "3-Step Scrum",
-      "description": "Plan → Build → QA three-stage workflow. Fits small to mid-size sprints.",
-      "steps": {
-        "kickoff": { "label": "Define requirements" },
-        "implementation": { "label": "Build" },
-        "qa_review": { "label": "Verify" }
-      }
-    },
-    "kanban-simple": {
-      "name": "Simple Kanban",
-      "description": "To Do → In Progress → Done flow. Fits continuous delivery environments.",
-      "steps": {
-        "task_created": { "label": "Pick up task" },
-        "in_progress": { "label": "In progress" },
-        "done_check": { "label": "Confirm done" }
-      }
-    },
-    "solo": {
-      "name": "Solo Agent",
-      "description": "A single agent handles every stage. Fits simple automated tasks.",
-      "steps": {
-        "received": { "label": "Receive & analyze" },
-        "execute": { "label": "Execute" },
-        "report": { "label": "Report" }
-      }
-    },
-    "loop-agency": {
-      "name": "Loop Agency",
-      "description": "Compounding org-memory workflow — goal & hypothesis → brief → generate variants → human pick → execute → learn from outcomes. Fits recurring experiments (copy tests, campaign variants, etc.).",
-      "steps": {
-        "goal_hypothesis": { "label": "Define goal & hypothesis" },
-        "brief_doc_approval": { "label": "Write brief" },
-        "generate_variants": { "label": "Generate variants" },
-        "loop_decision": { "label": "Human decision" },
-        "execute": { "label": "Execute" },
-        "track_and_learn": { "label": "Track & learn" }
-      }
-    }
-  },
   "recruiter": {
     "title": "Recruiter",
     "noProject": "Please select a project.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3708,47 +3708,6 @@
     "sigRequestChanges": "변경 요청",
     "sigApproveAndSign": "승인하고 서명"
   },
-  "workflowRecipes": {
-    "scrum-3step": {
-      "name": "3단계 스크럼",
-      "description": "기획 → 개발 → QA 3단계 워크플로우. 소규모~중규모 스프린트에 적합.",
-      "steps": {
-        "kickoff": { "label": "요구사항 정의" },
-        "implementation": { "label": "구현" },
-        "qa_review": { "label": "검증" }
-      }
-    },
-    "kanban-simple": {
-      "name": "칸반 심플",
-      "description": "할 일 → 진행 중 → 완료 단순 흐름. 지속적 딜리버리 환경에 적합.",
-      "steps": {
-        "task_created": { "label": "작업 접수" },
-        "in_progress": { "label": "진행" },
-        "done_check": { "label": "완료 확인" }
-      }
-    },
-    "solo": {
-      "name": "솔로 에이전트",
-      "description": "단일 에이전트가 전 단계를 처리. 간단한 자동화 태스크에 적합.",
-      "steps": {
-        "received": { "label": "수신 및 분석" },
-        "execute": { "label": "실행" },
-        "report": { "label": "보고" }
-      }
-    },
-    "loop-agency": {
-      "name": "루프 에이전시",
-      "description": "목표·가설 설정 → 브리프 → 실행안 생성 → 인간 선택 → 실행 → 성과 학습까지 이어지는 복리 조직기억 워크플로우. 반복되는 실험(카피·캠페인 variant 등)에 적합.",
-      "steps": {
-        "goal_hypothesis": { "label": "목표·가설 정의" },
-        "brief_doc_approval": { "label": "브리프 작성" },
-        "generate_variants": { "label": "실행안 생성" },
-        "loop_decision": { "label": "인간 선택" },
-        "execute": { "label": "실행" },
-        "track_and_learn": { "label": "추적 및 학습" }
-      }
-    }
-  },
   "recruiter": {
     "title": "채용관",
     "noProject": "프로젝트를 선택해 주세요.",

--- a/apps/web/src/app/api/workflow-recipes/route.ts
+++ b/apps/web/src/app/api/workflow-recipes/route.ts
@@ -1,7 +1,0 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
-
-// GET /api/workflow-recipes → FastAPI GET /api/v2/workflow-recipes (E-LOOP-LEDGER S18).
-// Raw passthrough (loops.ts convention) — BE returns a raw RecipeResponse[], no {data} envelope.
-export async function GET(request: Request): Promise<Response> {
-  return proxyToFastapi(request, '/api/v2/workflow-recipes');
-}

--- a/apps/web/src/components/loops/loop-create-dialog-error-code.test.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog-error-code.test.tsx
@@ -2,8 +2,8 @@
 //
 // story #2485 — LOOP_HYPOTHESIS_REQUIRED 외 4종 추가 code 분기(backend loops.py
 // create_loop()가 dict{code,message}로 직접 발급 — router _raise()가 그대로 통과,
-// mapApiError 경유 아님). loop-create-dialog.test.tsx(순수함수 localizeRecipe 테스트)와는
-// 별개 파일 — 여기는 풀 마운트 폼 검증.
+// mapApiError 경유 아님). loop-create-dialog.test.tsx(순수함수 cyclicStages/isCyclicDefinition
+// 테스트)와는 별개 파일 — 여기는 풀 마운트 폼 검증.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
@@ -50,7 +50,7 @@ function setNativeValue(el: HTMLInputElement | HTMLTextAreaElement, value: strin
 
 async function mountFilledDialog(errorCode: string) {
   vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
-    if (url === '/api/workflow-recipes') return { ok: false, json: async () => ({}) };
+    if (url === '/api/events/definitions') return { ok: false, json: async () => ({}) };
     if (url === '/api/loops' && init?.method === 'POST') {
       return { ok: false, json: async () => ({ error: { code: errorCode, message: `raw ${errorCode} message` } }) };
     }

--- a/apps/web/src/components/loops/loop-create-dialog-recipe-select.test.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog-recipe-select.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+//
+// story #2792(2790 P1) — LoopCreateDialog가 GET /api/events/definitions 카탈로그에서
+// 사이클형만 골라 select에 렌더하고, 제출 시 recipe_slug 필드(이름 유지)에 선택된 정의의
+// key 값을 담는지 실마운트로 확인한다. [[feedback-render-test-over-source-grep]] 동형 —
+// 소스만 보고 "filter 잘 됐다"고 서술하는 대신 실제 DOM/제출 payload로 확인.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { LoopCreateDialog } from './loop-create-dialog';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const DEFINITIONS = [
+  {
+    id: '1', key: 'preset.workflow.scrum_3step', org_id: null,
+    name: '3단계 스크럼', description: '기획 → 개발 → QA 3단계 워크플로우.',
+    payload_schema: { properties: { stage: { enum: ['kickoff', 'implementation', 'qa_review'] } } },
+    stage_metadata: {
+      kickoff: { role: 'PO', action: '기능 명세 및 AC 작성' },
+      implementation: { role: 'Dev', action: '코드 작성 및 PR 제출' },
+      qa_review: { role: 'QA', action: 'AC 체크리스트 검증 후 APPROVE/REJECT' },
+    },
+  },
+  {
+    id: '2', key: 'org.acme.deploy_started', org_id: 'org-acme',
+    name: '배포 시작(비-사이클형)', description: null,
+    payload_schema: { properties: {} },
+    stage_metadata: {},
+  },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('LoopCreateDialog 레시피 선택 (story #2792 — event_definitions 전환)', () => {
+  it('GET /api/events/definitions 카탈로그에서 사이클형만 select 옵션으로 걸러 렌더한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/events/definitions') return { ok: true, json: async () => DEFINITIONS };
+      throw new Error('unexpected fetch: ' + url);
+    }));
+
+    await act(async () => {
+      root.render(wrap(<LoopCreateDialog projectId="proj-1" open onOpenChange={() => {}} onCreated={() => {}} />));
+    });
+    await flush();
+
+    const options = Array.from(document.body.querySelectorAll('#loop-create-recipe option')).map((o) => o.textContent);
+    expect(options).toContain('3단계 스크럼');
+    expect(options).not.toContain('배포 시작(비-사이클형)');
+  });
+
+  it('레시피 선택 시 stage_metadata의 action(role)을 순서대로 보여준다(짧은 label 없이도 정직 표시)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/events/definitions') return { ok: true, json: async () => DEFINITIONS };
+      throw new Error('unexpected fetch: ' + url);
+    }));
+
+    await act(async () => {
+      root.render(wrap(<LoopCreateDialog projectId="proj-1" open onOpenChange={() => {}} onCreated={() => {}} />));
+    });
+    await flush();
+
+    const select = document.body.querySelector('#loop-create-recipe') as HTMLSelectElement;
+    await act(async () => {
+      select.value = 'preset.workflow.scrum_3step';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+
+    expect(document.body.textContent).toContain('기능 명세 및 AC 작성');
+    expect(document.body.textContent).toContain('PO');
+    expect(document.body.textContent).toContain('AC 체크리스트 검증 후 APPROVE/REJECT');
+  });
+
+  it('제출 시 recipe_slug 필드에 선택된 정의의 key 값을 싣는다(필드명 유지, 값만 신규 key)', async () => {
+    let submittedBody: Record<string, unknown> | null = null;
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/events/definitions') return { ok: true, json: async () => DEFINITIONS };
+      if (url === '/api/loops' && init?.method === 'POST') {
+        submittedBody = JSON.parse(init.body as string);
+        return { ok: true, json: async () => ({ id: 'loop-1' }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+
+    await act(async () => {
+      root.render(wrap(<LoopCreateDialog projectId="proj-1" open onOpenChange={() => {}} onCreated={() => {}} />));
+    });
+    await flush();
+
+    function setNativeValue(el: HTMLInputElement | HTMLTextAreaElement, value: string) {
+      const proto = el instanceof HTMLTextAreaElement ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(proto, 'value')!.set!;
+      setter.call(el, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    const select = document.body.querySelector('#loop-create-recipe') as HTMLSelectElement;
+    await act(async () => {
+      select.value = 'preset.workflow.scrum_3step';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const titleInput = document.body.querySelector('input') as HTMLInputElement;
+    await act(async () => { setNativeValue(titleInput, '테스트 루프'); });
+    const statementTextarea = document.body.querySelector('textarea') as HTMLTextAreaElement;
+    await act(async () => { setNativeValue(statementTextarea, '가설 문장'); });
+    const inputs = Array.from(document.body.querySelectorAll('input'));
+    const metricInput = inputs[1] as HTMLInputElement;
+    await act(async () => { setNativeValue(metricInput, 'conversion_rate'); });
+    const dateInput = document.body.querySelector('input[type="date"]') as HTMLInputElement;
+    await act(async () => { setNativeValue(dateInput, '2026-09-01'); });
+
+    const submitBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent === koMessages.loops.createLoopSubmit);
+    await act(async () => { submitBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(submittedBody).not.toBeNull();
+    expect(submittedBody!['recipe_slug']).toBe('preset.workflow.scrum_3step');
+  });
+});

--- a/apps/web/src/components/loops/loop-create-dialog-recipe-select.test.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog-recipe-select.test.tsx
@@ -24,12 +24,23 @@ const DEFINITIONS = [
       implementation: { role: 'Dev', action: '코드 작성 및 PR 제출' },
       qa_review: { role: 'QA', action: 'AC 체크리스트 검증 후 APPROVE/REJECT' },
     },
+    enabled: true,
   },
   {
     id: '2', key: 'org.acme.deploy_started', org_id: 'org-acme',
     name: '배포 시작(비-사이클형)', description: null,
     payload_schema: { properties: {} },
     stage_metadata: {},
+    enabled: true,
+  },
+  // 까디르군 QA(#3238) — GET /api/events/definitions는 admin 감사 목적으로 disabled도
+  // 의도적으로 내려준다. 구 /api/workflow-recipes는 활성만 반환했으므로 안 거르면 실회귀.
+  {
+    id: '3', key: 'org.acme.custom_flow', org_id: 'org-acme',
+    name: '커스텀 흐름(비활성 — 드롭다운에 안 뜨는 게 정상)', description: null,
+    payload_schema: { properties: { stage: { enum: ['draft', 'review'] } } },
+    stage_metadata: { draft: { role: 'Dev', action: '초안 작성' }, review: { role: 'PO', action: '검토' } },
+    enabled: false,
   },
 ];
 
@@ -75,6 +86,8 @@ describe('LoopCreateDialog 레시피 선택 (story #2792 — event_definitions �
     const options = Array.from(document.body.querySelectorAll('#loop-create-recipe option')).map((o) => o.textContent);
     expect(options).toContain('3단계 스크럼');
     expect(options).not.toContain('배포 시작(비-사이클형)');
+    // 까디르군 QA(#3238) — disabled 사이클형 정의는 stage가 있어도 드롭다운에 뜨면 안 된다.
+    expect(options).not.toContain('커스텀 흐름(비활성 — 드롭다운에 안 뜨는 게 정상)');
   });
 
   it('레시피 선택 시 stage_metadata의 action(role)을 순서대로 보여준다(짧은 label 없이도 정직 표시)', async () => {

--- a/apps/web/src/components/loops/loop-create-dialog.test.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog.test.tsx
@@ -1,68 +1,51 @@
 import { describe, expect, it } from 'vitest';
-import { createTranslator } from 'next-intl';
-import enMessagesRaw from '../../../messages/en.json';
-import koMessagesRaw from '../../../messages/ko.json';
-import { localizeRecipe, type WorkflowRecipe } from './loop-create-dialog';
+import { cyclicStages, isCyclicDefinition, type EventDefinitionResponse } from './loop-create-dialog';
 
-// production `tr` (useTranslations()) resolves against the permissive default `IntlMessages`
-// generic (no global next-intl message-type augmentation in this repo) — cast here so the test
-// translator has the same loose type instead of the JSON import's inferred literal-key type.
-type LooseMessages = { [key: string]: string | LooseMessages };
-const enMessages = enMessagesRaw as unknown as LooseMessages;
-const koMessages = koMessagesRaw as unknown as LooseMessages;
+// story #2792(2790 P1) — workflow-recipes → event_definitions 전환. 서버가 kind 필드를
+// 안 내려주므로 클라 판별(payload_schema.properties.stage.enum 존재)이 유일한 사이클형
+// 필터 축이다 — 이 판별이 틀리면 signal/measurement 정의가 select에 섞이거나, 진짜
+// 사이클형 레시피가 걸러진다.
 
-const BUILTIN_RECIPE: WorkflowRecipe = {
-  id: 'loop-agency',
-  slug: 'loop-agency',
-  name: '루프 에이전시',
-  description: '목표·가설 설정 → 브리프 → 실행안 생성 → 인간 선택 → 실행 → 성과 학습까지 이어지는 복리 조직기억 워크플로우. 반복되는 실험(카피·캠페인 variant 등)에 적합.',
-  steps: [
-    { role: 'Human', label: '목표·가설 정의', pattern: 'goal_hypothesis', action: 'define' },
-    { role: 'PO', label: '브리프 작성', pattern: 'brief_doc_approval', action: 'brief' },
-  ],
-  builtin: true,
+const CYCLIC: EventDefinitionResponse = {
+  id: '1', key: 'preset.workflow.scrum_3step', org_id: null,
+  name: '3단계 스크럼', description: '기획 → 개발 → QA 3단계 워크플로우.',
+  payload_schema: {
+    properties: { stage: { enum: ['kickoff', 'implementation', 'qa_review'] } },
+  },
+  stage_metadata: {
+    kickoff: { role: 'PO', action: '기능 명세 및 AC 작성' },
+    implementation: { role: 'Dev', action: '코드 작성 및 PR 제출' },
+    qa_review: { role: 'QA', action: 'AC 체크리스트 검증 후 APPROVE/REJECT' },
+  },
 };
 
-const CUSTOM_RECIPE: WorkflowRecipe = {
-  id: 'a1b2c3',
-  slug: 'org-authored-flow',
-  name: '조직 자체 워크플로우',
-  description: '조직이 직접 작성한 커스텀 레시피 설명',
-  steps: [{ role: 'Custom', label: '커스텀 단계', pattern: 'unknown_pattern', action: 'do it' }],
-  builtin: false,
+const SIGNAL: EventDefinitionResponse = {
+  id: '2', key: 'org.acme.deploy_started', org_id: 'org-acme',
+  name: '배포 시작', description: null,
+  payload_schema: { properties: {} },
+  stage_metadata: {},
 };
 
-describe('localizeRecipe (E-LOOP-LEDGER S18-fu)', () => {
-  it('translates builtin recipe name/description/step labels for en locale', () => {
-    const tr = createTranslator({ locale: 'en', messages: enMessages, namespace: 'workflowRecipes' });
-    const localized = localizeRecipe(BUILTIN_RECIPE, tr);
-    expect(localized.name).toBe('Loop Agency');
-    expect(localized.description).toContain('Compounding org-memory workflow');
-    expect(localized.steps[0].label).toBe('Define goal & hypothesis');
-    expect(localized.steps[1].label).toBe('Write brief');
+const NO_PROPERTIES: EventDefinitionResponse = {
+  id: '3', key: 'preset.legacy.malformed', org_id: null,
+  name: '스키마 없음', description: null,
+  payload_schema: {},
+  stage_metadata: {},
+};
+
+describe('cyclicStages / isCyclicDefinition (story #2792)', () => {
+  it('사이클형 정의는 payload_schema.properties.stage.enum 순서 그대로 stage 목록을 낸다', () => {
+    expect(cyclicStages(CYCLIC)).toEqual(['kickoff', 'implementation', 'qa_review']);
+    expect(isCyclicDefinition(CYCLIC)).toBe(true);
   });
 
-  it('resolves builtin recipe through the ko table too (identity mapping, no visual change)', () => {
-    const tr = createTranslator({ locale: 'ko', messages: koMessages, namespace: 'workflowRecipes' });
-    const localized = localizeRecipe(BUILTIN_RECIPE, tr);
-    expect(localized.name).toBe(BUILTIN_RECIPE.name);
-    expect(localized.description).toBe(BUILTIN_RECIPE.description);
-    expect(localized.steps[0].label).toBe(BUILTIN_RECIPE.steps[0].label);
+  it('signal/measurement류(stage 없음)는 사이클형이 아니다', () => {
+    expect(cyclicStages(SIGNAL)).toEqual([]);
+    expect(isCyclicDefinition(SIGNAL)).toBe(false);
   });
 
-  it('falls back to BE-original text for a non-builtin (custom/DB) recipe — no crash, no key miss', () => {
-    const tr = createTranslator({ locale: 'en', messages: enMessages, namespace: 'workflowRecipes' });
-    const localized = localizeRecipe(CUSTOM_RECIPE, tr);
-    expect(localized.name).toBe(CUSTOM_RECIPE.name);
-    expect(localized.description).toBe(CUSTOM_RECIPE.description);
-    expect(localized.steps[0].label).toBe(CUSTOM_RECIPE.steps[0].label);
-  });
-
-  it('covers all 4 builtin slugs with complete en translations', () => {
-    const recipes = enMessagesRaw.workflowRecipes as Record<string, { name: string; description: string }>;
-    for (const slug of ['scrum-3step', 'kanban-simple', 'solo', 'loop-agency']) {
-      expect(recipes[slug]?.name).toBeTruthy();
-      expect(recipes[slug]?.description).toBeTruthy();
-    }
+  it('properties 자체가 없는 방어적 케이스도 크래시 없이 빈 배열로 떨어진다', () => {
+    expect(cyclicStages(NO_PROPERTIES)).toEqual([]);
+    expect(isCyclicDefinition(NO_PROPERTIES)).toBe(false);
   });
 });

--- a/apps/web/src/components/loops/loop-create-dialog.test.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog.test.tsx
@@ -17,6 +17,7 @@ const CYCLIC: EventDefinitionResponse = {
     implementation: { role: 'Dev', action: '코드 작성 및 PR 제출' },
     qa_review: { role: 'QA', action: 'AC 체크리스트 검증 후 APPROVE/REJECT' },
   },
+  enabled: true,
 };
 
 const SIGNAL: EventDefinitionResponse = {
@@ -24,6 +25,7 @@ const SIGNAL: EventDefinitionResponse = {
   name: '배포 시작', description: null,
   payload_schema: { properties: {} },
   stage_metadata: {},
+  enabled: true,
 };
 
 const NO_PROPERTIES: EventDefinitionResponse = {
@@ -31,6 +33,17 @@ const NO_PROPERTIES: EventDefinitionResponse = {
   name: '스키마 없음', description: null,
   payload_schema: {},
   stage_metadata: {},
+  enabled: true,
+};
+
+// 까디르군 QA(#3238) — GET /api/events/definitions는 admin 감사 목적으로 disabled 정의도
+// 의도적으로 내려준다(구 /api/workflow-recipes는 활성만 반환했으므로 안 거르면 실회귀).
+const DISABLED_CYCLIC: EventDefinitionResponse = {
+  id: '4', key: 'org.acme.custom_flow', org_id: 'org-acme',
+  name: '커스텀 흐름(비활성)', description: null,
+  payload_schema: { properties: { stage: { enum: ['draft', 'review'] } } },
+  stage_metadata: { draft: { role: 'Dev', action: '초안 작성' }, review: { role: 'PO', action: '검토' } },
+  enabled: false,
 };
 
 describe('cyclicStages / isCyclicDefinition (story #2792)', () => {
@@ -47,5 +60,10 @@ describe('cyclicStages / isCyclicDefinition (story #2792)', () => {
   it('properties 자체가 없는 방어적 케이스도 크래시 없이 빈 배열로 떨어진다', () => {
     expect(cyclicStages(NO_PROPERTIES)).toEqual([]);
     expect(isCyclicDefinition(NO_PROPERTIES)).toBe(false);
+  });
+
+  it('disabled 사이클형 정의는 stage가 있어도 선택 대상이 아니다(까디르군 QA #3238 — 구 라우터는 활성만 반환)', () => {
+    expect(cyclicStages(DISABLED_CYCLIC)).toEqual(['draft', 'review']);
+    expect(isCyclicDefinition(DISABLED_CYCLIC)).toBe(false);
   });
 });

--- a/apps/web/src/components/loops/loop-create-dialog.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog.tsx
@@ -24,42 +24,30 @@ const EMPTY_METRIC: MetricDefinition = { metric: '', source: 'internal_ops', tar
 
 type Mode = 'new' | 'link';
 
-/** E-LOOP-LEDGER S18 — GET /api/workflow-recipes 응답 shape(블루프린트 §5, backend/app/routers/workflow_recipes.py 실측). */
-export interface WorkflowRecipe {
+/**
+ * story #2792(2790 P1) — 워크플로우 레시피가 사이클형 이벤트 정의로 흡수되며 `GET
+ * /api/workflow-recipes`(은퇴)를 `GET /api/events/definitions`(기존 재사용, story #2637
+ * 프록시 그대로)로 교체한다. 신규 엔드포인트 없음 — 계약 확定(페드루군·디디군 2026-08-19).
+ * 사이클형 판별은 서버가 별도 kind 필드를 안 내려주므로 클라에서 `payload_schema.properties.
+ * stage.enum` 존재로 판정한다(signal/measurement 종류는 이 경로가 비어 자동 제외).
+ */
+export interface EventDefinitionResponse {
   id: string;
-  slug: string;
+  key: string;
+  org_id: string | null;
   name: string;
-  description: string;
-  steps: { role: string; label: string; pattern: string; action: string }[];
-  builtin: boolean;
+  description: string | null;
+  payload_schema: { properties?: { stage?: { enum?: string[] } } };
+  stage_metadata: Record<string, { role?: string; action?: string }>;
 }
 
-/** localizeRecipe가 실제로 쓰는 next-intl translator 표면만 뽑은 최소 구조 타입 —
- * next-intl `Translator<Messages, Namespace>`의 깊은 제네릭에 결합하지 않아 테스트에서
- * `createTranslator()`로 만든 translator도 그대로 넘길 수 있다. */
-type RecipeTranslator = {
-  (key: string): string;
-  has(key: string): boolean;
-};
+// story #2792 QA 테스트가 순수 판별 로직을 직접 못박을 수 있게 export.
+export function cyclicStages(def: EventDefinitionResponse): string[] {
+  return def.payload_schema.properties?.stage?.enum ?? [];
+}
 
-/**
- * E-LOOP-LEDGER S18-fu — builtin 레시피는 BE `_BUILTIN_RECIPES`(Python 리터럴, 정적 콘텐츠)라
- * `workflowRecipes` 메시지 네임스페이스로 FE-only 매핑한다(BE locale 필드 불요). `t.has()`로
- * 키 존재를 직접 SSOT 삼아 커스텀(DB WorkflowTemplate) 레시피·미등록 slug는 자동으로 BE 원문
- * fallback(별도 builtin-slug 화이트리스트 불필요, 크래시 0).
- */
-export function localizeRecipe(recipe: WorkflowRecipe, tr: RecipeTranslator): WorkflowRecipe {
-  const nameKey = `${recipe.slug}.name`;
-  const descriptionKey = `${recipe.slug}.description`;
-  return {
-    ...recipe,
-    name: tr.has(nameKey) ? tr(nameKey) : recipe.name,
-    description: tr.has(descriptionKey) ? tr(descriptionKey) : recipe.description,
-    steps: recipe.steps.map((step) => {
-      const labelKey = `${recipe.slug}.steps.${step.pattern}.label`;
-      return tr.has(labelKey) ? { ...step, label: tr(labelKey) } : step;
-    }),
-  };
+export function isCyclicDefinition(def: EventDefinitionResponse): boolean {
+  return cyclicStages(def).length > 0;
 }
 
 /**
@@ -86,7 +74,6 @@ export function LoopCreateDialog({
 }) {
   const t = useTranslations('loops');
   const th = useTranslations('hypotheses');
-  const tr = useTranslations('workflowRecipes');
 
   const [title, setTitle] = useState('');
   const [mode, setMode] = useState<Mode>('new');
@@ -99,7 +86,7 @@ export function LoopCreateDialog({
   const [hypothesisSearch, setHypothesisSearch] = useState('');
   const [linkedId, setLinkedId] = useState<string | null>(null);
 
-  const [recipes, setRecipes] = useState<WorkflowRecipe[] | null>(null);
+  const [definitions, setDefinitions] = useState<EventDefinitionResponse[] | null>(null);
   const [recipesFailed, setRecipesFailed] = useState(false);
   const [recipeSlug, setRecipeSlug] = useState('');
 
@@ -166,21 +153,24 @@ export function LoopCreateDialog({
     })();
   }, [open, mode, hypotheses, projectId]);
 
-  // E-LOOP-LEDGER S18 — recipe 목록은 선택 기능이라 fetch 실패해도 select 옵션만 없어질 뿐
+  // story #2792 — recipe 목록은 선택 기능이라 fetch 실패해도 select 옵션만 없어질 뿐
   // (null-safe, "직접 진행" 기본값으로 폼은 정상 동작). 실패는 recipesFailed로만 표시하고
-  // recipes는 null로 유지 — 닫힘/재오픈(reset)마다 recipesFailed가 풀려 재시도된다(영구 실종 방지).
+  // definitions는 null로 유지 — 닫힘/재오픈(reset)마다 recipesFailed가 풀려 재시도된다(영구
+  // 실종 방지). 카탈로그 전체를 받아 사이클형만 클라에서 골라낸다(신규 엔드포인트 없음 —
+  // GET /api/events/definitions는 signal/measurement 등 비-사이클형도 섞여 온다).
   useEffect(() => {
-    if (!open || recipes !== null || recipesFailed) return;
+    if (!open || definitions !== null || recipesFailed) return;
     void (async () => {
       try {
-        const res = await fetchWithAuth('/api/workflow-recipes');
+        const res = await fetchWithAuth('/api/events/definitions');
         if (!res.ok) { setRecipesFailed(true); return; }
-        setRecipes((await res.json()) as WorkflowRecipe[]);
+        const all = (await res.json()) as EventDefinitionResponse[];
+        setDefinitions(all.filter(isCyclicDefinition));
       } catch {
         setRecipesFailed(true);
       }
     })();
-  }, [open, recipes, recipesFailed]);
+  }, [open, definitions, recipesFailed]);
 
   const setMetricPatch = (patch: Partial<MetricDefinition>) => setMetric((m) => ({ ...m, ...patch }));
 
@@ -255,8 +245,7 @@ export function LoopCreateDialog({
     h.statement.toLowerCase().includes(hypothesisSearch.trim().toLowerCase()),
   );
   const linkedHypothesis = hypotheses?.find((h) => h.id === linkedId) ?? null;
-  const localizedRecipes = recipes?.map((r) => localizeRecipe(r, tr)) ?? null;
-  const selectedRecipe = localizedRecipes?.find((r) => r.slug === recipeSlug) ?? null;
+  const selectedRecipe = definitions?.find((d) => d.key === recipeSlug) ?? null;
 
   return (
     <Dialog
@@ -284,7 +273,7 @@ export function LoopCreateDialog({
             />
           </div>
 
-          {localizedRecipes && localizedRecipes.length > 0 ? (
+          {definitions && definitions.length > 0 ? (
             <div className="space-y-1">
               <label htmlFor="loop-create-recipe" className="text-xs font-medium text-muted-foreground">{t('createLoopRecipeLabel')}</label>
               <select
@@ -294,17 +283,23 @@ export function LoopCreateDialog({
                 className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
               >
                 <option value="">{t('createLoopRecipeNone')}</option>
-                {localizedRecipes.map((r) => (
-                  <option key={r.slug} value={r.slug}>{r.name}</option>
+                {definitions.map((d) => (
+                  <option key={d.key} value={d.key}>{d.name}</option>
                 ))}
               </select>
               {selectedRecipe ? (
                 <div className="space-y-1 rounded-lg border border-dashed border-border bg-muted/30 p-2 text-[10.5px] text-muted-foreground">
-                  <p>{selectedRecipe.description}</p>
+                  {selectedRecipe.description ? <p>{selectedRecipe.description}</p> : null}
                   <ol className="list-decimal space-y-0.5 pl-4">
-                    {selectedRecipe.steps.map((s, i) => (
-                      <li key={i}><span className="font-medium text-foreground">{s.label}</span> ({s.role})</li>
-                    ))}
+                    {cyclicStages(selectedRecipe).map((stage) => {
+                      const meta = selectedRecipe.stage_metadata[stage];
+                      return (
+                        <li key={stage} className="break-words">
+                          <span className="font-medium text-foreground">{meta?.action ?? stage}</span>
+                          {meta?.role ? <> ({meta.role})</> : null}
+                        </li>
+                      );
+                    })}
                   </ol>
                 </div>
               ) : null}

--- a/apps/web/src/components/loops/loop-create-dialog.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog.tsx
@@ -30,6 +30,10 @@ type Mode = 'new' | 'link';
  * 프록시 그대로)로 교체한다. 신규 엔드포인트 없음 — 계약 확定(페드루군·디디군 2026-08-19).
  * 사이클형 판별은 서버가 별도 kind 필드를 안 내려주므로 클라에서 `payload_schema.properties.
  * stage.enum` 존재로 판정한다(signal/measurement 종류는 이 경로가 비어 자동 제외).
+ *
+ * 까디르군 QA(#3238) — `GET /api/events/definitions`는 admin 감사 목적으로 disabled 정의도
+ * 의도적으로 내려준다(P2에서 확定한 비대칭). 구 `/api/workflow-recipes`는 활성만 반환했으므로
+ * 여기서 안 거르면 실회귀 — 사이클형 판정에 `enabled`도 같이 본다.
  */
 export interface EventDefinitionResponse {
   id: string;
@@ -39,6 +43,7 @@ export interface EventDefinitionResponse {
   description: string | null;
   payload_schema: { properties?: { stage?: { enum?: string[] } } };
   stage_metadata: Record<string, { role?: string; action?: string }>;
+  enabled: boolean;
 }
 
 // story #2792 QA 테스트가 순수 판별 로직을 직접 못박을 수 있게 export.
@@ -47,7 +52,7 @@ export function cyclicStages(def: EventDefinitionResponse): string[] {
 }
 
 export function isCyclicDefinition(def: EventDefinitionResponse): boolean {
-  return cyclicStages(def).length > 0;
+  return def.enabled && cyclicStages(def).length > 0;
 }
 
 /**


### PR DESCRIPTION
## 배경
2790 P1(워크플로우 엔티티 은퇴) — 레시피가 사이클형 이벤트 정의의 상위 서식으로 흡수. 디디군 백엔드 컴파일 커밋(#3232, migration 0260)이 착지해 FE 전환 착수.

## 변경
`loop-create-dialog.tsx`의 레시피 선택 UI를 `GET /api/workflow-recipes`(은퇴)에서 `GET /api/events/definitions`(기존 재사용, story #2637 프록시 그대로)로 교체. 확定 계약(페드루군·디디군 2026-08-19):
- 신규 엔드포인트 없음 — 카탈로그 전체를 받아 클라에서 `payload_schema.properties.stage.enum` 존재로 사이클형만 필터
- `name`(not-null)/`description`(nullable) 컬럼을 드롭다운에 직결
- `steps[].label` 자리는 `stage_metadata[slug].action`(문장형)+`role`로 표시 — `<action> (<role>)` (페드루군 승인)
- 제출 필드는 `recipe_slug` 이름 유지, 값만 신규 정의 `key`

## i18n 오버레이 제거 (페드루군 판정)
기존 `workflowRecipes` 메시지 네임스페이스(ko/en dash-slug 키)는 신규 `key` 포맷(`preset.workflow.agent_solo`류, `solo`→`agent_solo` 슬러그 자체 변경)과 안 맞아 `tr.has()` 폴백이 항상 miss. BE `name`/`description`이 이제 admin 편집 가능한 DB 정본이라 FE 오버레이가 남으면 "두 곳이 진실 주장"하는 병이 생겨 걷어냄. **EN 로캘이 BE 한국어 원문을 그대로 보게 되는 회귀는 별도 스토리(#2811, 서버측 다국어 전략 필요)로 등재만.**

## 은퇴
- `/api/workflow-recipes` Next 프록시 라우트 삭제(백엔드 `workflow_recipes.py` 라우터는 디디군이 별도 커밋에서 은퇴 — 이번 FE 전환이 그 선행조건)
- `loop-create-dialog.test.tsx`(localizeRecipe 순수함수 테스트) → `cyclicStages`/`isCyclicDefinition` 판별 테스트로 전면 교체

`loops-client.tsx`/`loop-detail-client.tsx`는 무변경(`recipe_slug` 필드명 유지라 표시 코드 그대로 유효 — grep 재확인). `recruit.ts`의 `default_workflow_recipe_slug`도 무변경(BE `role_templates` 컬럼 미은퇴 — 그라운딩으로 확인).

## 검증
- 신규 `loop-create-dialog-recipe-select.test.tsx`(3케이스: 사이클형 필터·step 표시·제출 payload) + 재작성된 순수함수 테스트 3케이스
- 전체 loops 스위트(4 files/18 tests) 회귀 없음
- **전체 FE 스위트(467 files/3878 tests) 회귀 없음**
- build/lint/tsc 전부 그린
- grep 재확인: `recipe_slug`/`recipeSlug`/`workflowRecipe` 살아있는 참조는 예상된 4곳뿐, 죽은 주소 0

story: entity:story:e7373a73-6d36-49ae-8329-33791aa2fadc

🤖 Generated with [Claude Code](https://claude.com/claude-code)