### PR TITLE
feat(#2813): Gate→GitHub sprintable/gate required check 발행 — 1단계(BE 본체)

### DIFF
--- a/backend/alembic/versions/0262_gate_github_check.py
+++ b/backend/alembic/versions/0262_gate_github_check.py
@@ -9,8 +9,13 @@ head_sha가 없고, verdict_capture.py가 웹훅에서 뽑는 head_sha가 게이
 - `gates.github_check_run_id`(BigInteger, nullable) — 이 게이트가 추적 중인 현재 GitHub
   check-run id. 같은 SHA에 대한 pending→success/failure 갱신은 이 id로 PATCH, 새 SHA(재-pending)
   는 새 check-run을 만들고 이 값을 교체한다.
-- `gates.approved_head_sha`(Text, nullable) — "이 승인이 귀속된 SHA"(AC②). synchronize 웹훅
-  수신 시 이 값과 새 head_sha가 다르면 게이트를 pending으로 되돌린다(재-pending).
+- `gates.github_check_run_sha`(Text, nullable) — 카디르 QA(PR#3243)③-c: check-run은 **SHA당
+  1개**가 정본이라, github_check_run_id가 "어느 SHA"에 대한 것인지 알아야 발행 대상 SHA가
+  다를 때 PATCH 대신 새 run을 만들 수 있다(안 그러면 새 head로는 영원히 check가 안 생겨
+  required가 영구 미충족되는 데드엔드가 생긴다).
+- `gates.approved_head_sha`(Text, nullable) — "이 승인이 귀속된 SHA"(AC②). PR 라이프사이클
+  웹훅(synchronize뿐 아니라 opened/reopened/ready_for_review도, 카디르 QA③-b) 수신 시 이 값과
+  새 head_sha가 다르면 게이트를 pending으로 되돌린다(재-pending).
 - 신규 테이블 `gate_github_check_event` — check 발행/재-pending/해소 원장(AC④). 기존 audit
   테이블 3종(permission_audit_logs/login_audit_log/deletion_audit)은 전부 목적이 달라(권한변경·
   로그인·삭제 전용 스키마) 재사용 부적합 판정(그라운딩 §1) — 신규가 정본.
@@ -33,6 +38,7 @@ depends_on = None
 
 def upgrade() -> None:
     op.add_column("gate", sa.Column("github_check_run_id", sa.BigInteger(), nullable=True))
+    op.add_column("gate", sa.Column("github_check_run_sha", sa.Text(), nullable=True))
     op.add_column("gate", sa.Column("approved_head_sha", sa.Text(), nullable=True))
 
     op.create_table(
@@ -66,4 +72,5 @@ def downgrade() -> None:
     op.drop_index("ix_gate_github_check_event_gate_created", table_name="gate_github_check_event")
     op.drop_table("gate_github_check_event")
     op.drop_column("gate", "approved_head_sha")
+    op.drop_column("gate", "github_check_run_sha")
     op.drop_column("gate", "github_check_run_id")

--- a/backend/alembic/versions/0262_gate_github_check.py
+++ b/backend/alembic/versions/0262_gate_github_check.py
@@ -1,0 +1,69 @@
+"""story #2813([Gate 강제·BE], 설계 카드 doc c1855e0d) — Gate→GitHub required check 발행에
+필요한 SHA 귀속 축 신설.
+
+그라운딩 발견(설계 doc gate-github-required-check-grounding-design-2813 §1): `gates` 테이블에
+SHA 개념이 전혀 없었다 — `evaluate_merge_gate`/`reconcile_merge_gate_with_real_evidence` 인자에도
+head_sha가 없고, verdict_capture.py가 웹훅에서 뽑는 head_sha가 게이트까지 전파되지 않는다. 이
+마이그는 그 갭을 메운다:
+
+- `gates.github_check_run_id`(BigInteger, nullable) — 이 게이트가 추적 중인 현재 GitHub
+  check-run id. 같은 SHA에 대한 pending→success/failure 갱신은 이 id로 PATCH, 새 SHA(재-pending)
+  는 새 check-run을 만들고 이 값을 교체한다.
+- `gates.approved_head_sha`(Text, nullable) — "이 승인이 귀속된 SHA"(AC②). synchronize 웹훅
+  수신 시 이 값과 새 head_sha가 다르면 게이트를 pending으로 되돌린다(재-pending).
+- 신규 테이블 `gate_github_check_event` — check 발행/재-pending/해소 원장(AC④). 기존 audit
+  테이블 3종(permission_audit_logs/login_audit_log/deletion_audit)은 전부 목적이 달라(권한변경·
+  로그인·삭제 전용 스키마) 재사용 부적합 판정(그라운딩 §1) — 신규가 정본.
+
+Revision ID: 0262
+Revises: 0261
+Create Date: 2026-08-19
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0262"
+down_revision = "0261"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("gate", sa.Column("github_check_run_id", sa.BigInteger(), nullable=True))
+    op.add_column("gate", sa.Column("approved_head_sha", sa.Text(), nullable=True))
+
+    op.create_table(
+        "gate_github_check_event",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "org_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True,
+        ),
+        sa.Column(
+            "gate_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("gate.id", ondelete="CASCADE"), nullable=False, index=True,
+        ),
+        sa.Column("story_id", postgresql.UUID(as_uuid=True), nullable=False, index=True),
+        sa.Column("repo_full_name", sa.Text(), nullable=False),
+        sa.Column("pr_number", sa.Integer(), nullable=False),
+        sa.Column("head_sha", sa.Text(), nullable=False),
+        # published(최초/재-pending 발행) | re_pending(SHA 불일치로 되돌림) | resolved(success/failure).
+        sa.Column("event_type", sa.Text(), nullable=False),
+        # GitHub check-run conclusion 그대로: pending 발행이면 NULL(status=in_progress).
+        sa.Column("check_conclusion", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "ix_gate_github_check_event_gate_created",
+        "gate_github_check_event", ["gate_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_gate_github_check_event_gate_created", table_name="gate_github_check_event")
+    op.drop_table("gate_github_check_event")
+    op.drop_column("gate", "approved_head_sha")
+    op.drop_column("gate", "github_check_run_id")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -19,6 +19,7 @@ from app.models.event import Event
 from app.models.event_outbox import EventOutbox
 from app.models.delivery_job import DeliveryJob
 from app.models.gate import Gate
+from app.models.gate_github_check_event import GateGithubCheckEvent
 from app.models.github_installation import GithubInstallation, GithubInstallNonce, GithubWebhookDelivery
 from app.models.hitl import HitlPolicy, HitlRequest
 from app.models.judgment import Judgment
@@ -133,6 +134,7 @@ __all__ = [
     "EventOutbox",
     "DeliveryJob",
     "Gate",
+    "GateGithubCheckEvent",
     "GithubInstallation",
     "GithubInstallNonce",
     "GithubWebhookDelivery",

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -19,7 +19,7 @@ neutral_facts: 관찰 사실만 (touches_migration, diff_size 등).
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, String, Text, func, text
+from sqlalchemy import BigInteger, Boolean, DateTime, String, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -37,6 +37,11 @@ _VALID_TRANSITIONS: set[tuple[str, str]] = {
     ("pending", "held"),       # S31 hold(일시정지·SLA pause)
     ("held", "pending"),       # S31 unhold(재개·SLA resume)
 }
+# story #2813(Gate→GitHub required check) — SHA 재-pending(승인 後 PR에 새 커밋 push 시 그 승인을
+# 무효화)은 `_VALID_TRANSITIONS`/`transition_gate`(사람 결재 전용 FSM — ActivityLog·line resolution·
+# doc-gate 등 사람 승인에만 맞는 부작용 체인이 딸림, RC#1)를 안 거친다. `resolve_gate_from_verdict`
+# (시스템 자동판정)가 이미 쓰는 것과 동일한 경량 경로 — `set_gate_status()` 직접 호출(gate_github_
+# check.py::reopen_gate_if_new_sha) — 을 재사용한다. 그래서 이 전이는 위 set에 없다(의도).
 
 
 def is_valid_transition(from_status: str, to_status: str) -> bool:
@@ -80,6 +85,13 @@ class Gate(Base):
     # 지점에서 값 비교 후 조건부로만 갱신한다(gate.py 직접 대입 금지, SSOT 헬퍼 경유).
     status_entered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     evidence_status_entered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # story #2813(Gate→GitHub required check, 0262) — 이 게이트가 추적 중인 현재 GitHub
+    # check-run id. 같은 SHA의 pending→success/failure는 이 id로 PATCH, 새 SHA(재-pending)는
+    # 새 check-run 생성 후 이 값 교체.
+    github_check_run_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # story #2813 — "이 승인이 귀속된 SHA"(AC②). synchronize 웹훅의 새 head_sha와 다르면
+    # 재-pending(approved→pending) 트리거.
+    approved_head_sha: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -86,11 +86,15 @@ class Gate(Base):
     status_entered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     evidence_status_entered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # story #2813(Gate→GitHub required check, 0262) — 이 게이트가 추적 중인 현재 GitHub
-    # check-run id. 같은 SHA의 pending→success/failure는 이 id로 PATCH, 새 SHA(재-pending)는
-    # 새 check-run 생성 후 이 값 교체.
+    # check-run id. **check-run은 SHA당 1개가 정본**(카디르 QA③-c, 2026-08-19) — 발행 대상
+    # SHA가 github_check_run_sha와 다르면 PATCH가 아니라 새 run을 만든다(안 그러면 새 head로는
+    # 영원히 check가 안 생겨 required가 영구 미충족되는 데드엔드).
     github_check_run_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
-    # story #2813 — "이 승인이 귀속된 SHA"(AC②). synchronize 웹훅의 새 head_sha와 다르면
-    # 재-pending(approved→pending) 트리거.
+    # story #2813 — 위 github_check_run_id가 "어느 SHA에 대해" 만들어졌는지(카디르 QA③-c).
+    github_check_run_sha: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #2813 — "이 승인이 귀속된 SHA"(AC②). synchronize/opened/reopened/ready_for_review
+    # 웹훅의 새 head_sha와 다르면 재-pending(approved→pending) 트리거(카디르 QA③-b: reopen 가드를
+    # synchronize만이 아니라 네 액션 전부에서 돌림 — 다른 head로 돌아온 재오픈 PR도 잡는다).
     approved_head_sha: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/gate_github_check_event.py
+++ b/backend/app/models/gate_github_check_event.py
@@ -1,0 +1,40 @@
+"""story #2813(Gate→GitHub required check) — check 발행/재-pending/해소 원장(AC④).
+
+기존 audit 테이블 3종(permission_audit_logs/login_audit_log/deletion_audit)은 전부 목적이 달라
+(권한변경·로그인·삭제 전용 스키마) 이번 목적(check 발행+SHA)에 재사용 부적합(그라운딩 doc
+gate-github-required-check-grounding-design-2813 §1) — 이 테이블이 정본.
+
+append-only(update/delete 없음) — 매 이벤트가 1행. `gates.github_check_run_id`/
+`gates.approved_head_sha`는 "현재값"만 담고, 이 테이블이 그 값들이 어떻게 여기까지 왔는지의 이력이다.
+"""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class GateGithubCheckEvent(Base):
+    __tablename__ = "gate_github_check_event"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    gate_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("gate.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    story_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    repo_full_name: Mapped[str] = mapped_column(Text, nullable=False)
+    pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    head_sha: Mapped[str] = mapped_column(Text, nullable=False)
+    # published(최초/재-pending 발행) | re_pending(SHA 불일치로 게이트를 되돌림) | resolved(success/failure).
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    # GitHub check-run conclusion — pending 발행이면 NULL(status=in_progress).
+    check_conclusion: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -164,6 +164,11 @@ class GateResponse(BaseModel):
     evidence_status: str | None = None
     decision_basis: str | None = None
     auto_decision_reason: str | None = None
+    # story #2813/#2814 계약 ①(미르코군 그라운딩 doc gate-github-check-fe-grounding-2814 §5) —
+    # GitHub check-run 상태를 FE가 읽을 수 있게 raw passthrough(신규 엔드포인트 불요). Gate ORM에
+    # 이미 있는 컬럼 그대로 — additive·nullable(merge 게이트 아니거나 아직 미발행이면 None).
+    github_check_run_id: int | None = None
+    approved_head_sha: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -17,6 +17,7 @@ from app.models.hitl import HitlRequest
 from app.models.pm import Story, Task
 from app.models.visual_artifact import VisualArtifact
 from app.routers.agent_gateway import wake_agent
+from app.services.gate_github_check import publish_gate_check
 from app.services.gate_service import (
     GateUndoNotSelfError,
     GateUndoWindowExpiredError,
@@ -975,6 +976,10 @@ async def transition_gate_endpoint(
         await session.refresh(gate)
         # ccbcd9da(A-1): doc/epic 자동재개 wake — commit(recipient_seq 확정) 후 발화(이중전달 방지).
         _schedule_pending_deliveries(background_tasks, _pending_deliveries)
+        # story #2813 — 사람 승인/반려를 GitHub check-run(success/failure)으로 반영. commit 後
+        # 배경 태스크(fail-closed: 실패해도 이미 commit된 gate 상태엔 영향 없음, GitHub 쪽만 stale).
+        # merge 게이트 아니면 publish_gate_check 내부에서 조용히 no-op.
+        background_tasks.add_task(publish_gate_check, org_id, gate.id)
         return GateResponse.model_validate(gate)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -17,7 +17,8 @@ from app.models.hitl import HitlRequest
 from app.models.pm import Story, Task
 from app.models.visual_artifact import VisualArtifact
 from app.routers.agent_gateway import wake_agent
-from app.services.gate_github_check import publish_gate_check
+from app.services.gate_github_check import publish_gate_check, resolve_pr_link
+from app.services.merge_verdict_gate import MERGE_GATE_TYPE
 from app.services.gate_service import (
     GateUndoNotSelfError,
     GateUndoWindowExpiredError,
@@ -971,6 +972,17 @@ async def transition_gate_endpoint(
             session, org_id, id, body.status, _resolver_id, body.note,
             pending_deliveries=_pending_deliveries,
         )
+        # ⛔카디르 QA(PR#3243, 2026-08-19) 레이스 fix — anchor(gate.approved_head_sha)를 배경
+        # publish 태스크가 뒤늦게 적으면, 승인(SHA A) 직후·태스크 실행 前에 새 커밋(B)의
+        # synchronize가 먼저 도착해 link.evidence를 B로 갱신 → 뒤늦은 태스크가 B를 읽어 "A 승인이
+        # B를 축복"하는 경로가 열린다. **"승인은 그때의 커밋에" 문자 그대로 — anchor는 이 승인
+        # 트랜잭션(commit 前)에서 확정 기록**한다. 배경 태스크(publish_gate_check)는 이 값을
+        # 그대로 반영만 한다(gate_github_check.py 참고).
+        if body.status == "approved" and gate.gate_type == MERGE_GATE_TYPE:
+            _link = await resolve_pr_link(session, org_id, gate.work_item_id)
+            _head_sha = (_link.evidence or {}).get("head_sha") if _link else None
+            if _head_sha:
+                gate.approved_head_sha = _head_sha
         await session.commit()
         # story #2459 회귀 동형 방어(2026-08-05): commit 後 model_validate 前 명시 refresh.
         await session.refresh(gate)

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -393,6 +393,10 @@ async def _process_webhook_event(
     # 증거와 무관하게 merge 게이트를 GitHub check-run으로 반영한다. 설계 doc §2-1(PO 승인): 카드
     # 원안 "push 이벤트" 대신 `pull_request.synchronize`를 쓴다 — PR번호+head_sha가 payload에
     # 이미 있어 브랜치→PR 매칭 추가조회가 불요. synchronize는 SHA 재-pending(§2-2)도 겸한다.
+    #
+    # ⛔카디르 QA(PR#3243)③-b — 재-pending 가드를 synchronize 하나에만 걸면, PR이 **다른
+    # head로 재오픈**(close→reopen 사이 강제 push 등)되거나 draft→ready_for_review로 전환되며
+    # 그새 커밋이 바뀐 경우를 못 잡는다. 네 액션 전부에서 동일 가드를 돌린다(비교 비용은 동일).
     if (
         event == "pull_request"
         and pr_action in ("opened", "reopened", "ready_for_review", "synchronize")
@@ -412,8 +416,10 @@ async def _process_webhook_event(
             )
         ).scalar_one_or_none()
         if merge_gate is not None:
-            if pr_action == "synchronize":
-                await reopen_gate_if_new_sha(session, org_id, merge_gate, head_sha)
+            await reopen_gate_if_new_sha(
+                session, org_id, merge_gate, head_sha,
+                repo_full_name=repo, pr_number=pr_number,
+            )
             gate_check_publish.append({
                 "org_id": org_id, "gate_id": merge_gate.id,
                 "head_sha": head_sha, "repo_full_name": repo, "pr_number": pr_number,

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -512,9 +512,12 @@ async def _process_webhook_event(
     # 배달은 영구 no-op(processed로 커밋)"이 돼 GitHub 재시도를 못 받는다(delivery 모델
     # 자체 계약 — "실패=rollback→retry 보존"). 이 함수 밖(github_webhook)이 이미 예외를
     # 전체 rollback+500으로 처리해 GitHub가 재시도하므로, 여기서 삼키지 않고 그대로 올린다.
+    # story #2813(카디르 R2) — head_sha를 넘겨 auto_passed 판정 시 anchor(gate.approved_head_sha)
+    # 즉시 확定(merge_verdict_gate.evaluate_merge_gate 참고).
     await reconcile_merge_gate_with_real_evidence(
         session, org_id, story_id,
         pr_number=pr_number, repo=repo, ci_result=ci_conclusion, merged=merged,
+        head_sha=head_sha,
     )
 
     # ⭐story #2327 후속(PO 판정, 2026-07-30, PR#2685 실 웹훅 시험대가 드러낸 갭) — merge 시

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -13,7 +13,7 @@ import re
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Header, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import func, select
@@ -315,6 +315,8 @@ async def _resolve_legacy_org_by_repo_owner(
 async def _process_webhook_event(
     session: AsyncSession, source: str, event: str, payload: dict, installation_id: int | None,
     delivery: GithubWebhookDelivery,
+    *,
+    gate_check_publish: list[dict] | None = None,
 ) -> tuple[dict, str]:
     """검증·dedup 통과한 이벤트 처리(legacy/app 라우팅·Bot-L.1 resolver 체인). (result, status) 반환.
 
@@ -326,6 +328,11 @@ async def _process_webhook_event(
 
     P0-05 후속(doc scope-violation-signal-design §2): scope-violation 판정은 머지/CI 액션가능신호와
     **독립**(PR 자체 이벤트에서 판정) — resolver를 그 skip보다 먼저 실행해 두 판정이 서로를 막지 않게 한다.
+
+    ``gate_check_publish``(story #2813, ccbcd9da A-1 `pending_deliveries`와 동형 outparam): 넘기면
+    PR 라이프사이클 이벤트(opened/reopened/ready_for_review/synchronize)가 발행해야 할 GitHub
+    check-run 정보를 append — 호출자(github_webhook)가 **commit 後** 배경 태스크로 발행(fail-closed:
+    GitHub 외부 API 호출을 DB 트랜잭션 성공 확정 前에 하지 않는다).
     """
     texts = _candidate_texts(payload)
     repo = (payload.get("repository") or {}).get("full_name") or ""
@@ -381,6 +388,36 @@ async def _process_webhook_event(
     story_id = rl.story_id
     org_id = rl.org_id  # app=입력 org·legacy=story.org_id(resolver 검증). 단일 진실원.
     delivery.org_id = org_id
+
+    # story #2813 — PR 라이프사이클 자체(opened/reopened/ready_for_review/synchronize)는 CI/merge
+    # 증거와 무관하게 merge 게이트를 GitHub check-run으로 반영한다. 설계 doc §2-1(PO 승인): 카드
+    # 원안 "push 이벤트" 대신 `pull_request.synchronize`를 쓴다 — PR번호+head_sha가 payload에
+    # 이미 있어 브랜치→PR 매칭 추가조회가 불요. synchronize는 SHA 재-pending(§2-2)도 겸한다.
+    if (
+        event == "pull_request"
+        and pr_action in ("opened", "reopened", "ready_for_review", "synchronize")
+        and head_sha
+        and gate_check_publish is not None
+    ):
+        from app.models.gate import Gate as _Gate
+        from app.services.gate_github_check import reopen_gate_if_new_sha
+        from app.services.merge_verdict_gate import MERGE_GATE_TYPE as _MERGE_GATE_TYPE
+
+        merge_gate = (
+            await session.execute(
+                select(_Gate).where(
+                    _Gate.org_id == org_id, _Gate.work_item_id == story_id,
+                    _Gate.work_item_type == "story", _Gate.gate_type == _MERGE_GATE_TYPE,
+                )
+            )
+        ).scalar_one_or_none()
+        if merge_gate is not None:
+            if pr_action == "synchronize":
+                await reopen_gate_if_new_sha(session, org_id, merge_gate, head_sha)
+            gate_check_publish.append({
+                "org_id": org_id, "gate_id": merge_gate.id,
+                "head_sha": head_sha, "repo_full_name": repo, "pr_number": pr_number,
+            })
 
     # P0-05 후속(doc scope-violation-signal-design §2·§3): PR 자체 이벤트(opened/synchronize/reopened)
     # + confident link(should_auto_close 동일 신뢰 등급)일 때만 판정. 3중 침묵 조건은 헬퍼 내부.
@@ -596,6 +633,7 @@ async def _maybe_check_scope_violation(
 @router.post("/github-webhook")
 async def github_webhook(
     request: Request,
+    background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_db),
     x_github_event: str | None = Header(default=None),
     x_hub_signature_256: str | None = Header(default=None),
@@ -606,6 +644,9 @@ async def github_webhook(
     보안(산티아고 lock): ⭐**HMAC-before-parse**(검증 前 parse/DB/dedup/capture 0)·source 는 **검증된
     secret 으로만**(payload 금지)·dedup `(source, delivery_id)` insert+side-effect+status **동일 트랜잭션**
     (실패=rollback→GitHub retry 보존·중복=2xx no-op)·app=installation resolve 後 org-scope(anti-IDOR).
+
+    story #2813: PR 라이프사이클 이벤트가 만든 GitHub check-run 발행은 **commit 後**(fail-closed —
+    외부 API 호출을 DB 트랜잭션 확정 前에 하지 않는다) `background_tasks`로.
     """
     raw = await request.body()
 
@@ -643,9 +684,11 @@ async def github_webhook(
         return _ok({"skipped_reason": "duplicate_delivery", "recorded": []})
 
     # 5) 처리 + status 갱신 + commit 을 **동일 트랜잭션**으로. 실패=rollback(delivery row 도 함께 → retry 보존).
+    _gate_check_publish: list[dict] = []
     try:
         result, status_label = await _process_webhook_event(
-            session, source, event, payload, installation_id, delivery
+            session, source, event, payload, installation_id, delivery,
+            gate_check_publish=_gate_check_publish,
         )
         delivery.status = status_label
         # story #2327(재정의): "ignored"의 실제 사유를 delivery 행에도 남긴다 — HTTP 응답
@@ -653,6 +696,12 @@ async def github_webhook(
         delivery.skipped_reason = result.get("skipped_reason") if status_label == "ignored" else None
         delivery.processed_at = datetime.now(timezone.utc)
         await session.commit()
+        # story #2813: commit 확정 後에만 GitHub check-run 발행(fail-closed).
+        if _gate_check_publish:
+            from app.services.gate_github_check import publish_gate_check
+
+            for _payload in _gate_check_publish:
+                background_tasks.add_task(publish_gate_check, **_payload)
         return _ok(result)
     except Exception as exc:
         await session.rollback()  # delivery insert 포함 전부 rollback → GitHub retry 가 재처리(영구 no-op 금지).

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -108,28 +108,34 @@ async def publish_gate_check(
             repo_full_name = repo_full_name or link.repo_full_name
             pr_number = pr_number if pr_number is not None else link.pr_number
 
-            # ⛔카디르 QA(PR#3243, 2026-08-19) 레이스 fix — 여기서 link.evidence.head_sha를
-            # "지금 추적 중인 SHA"로 재해소하면, 승인(SHA A) 커밋 後·이 배경 태스크 실행 前에
-            # 새 커밋(B)의 synchronize가 먼저 link.evidence를 B로 갱신해버렸을 때 "A 승인이 B를
-            # 축복"하는 사고가 난다. approved/auto_passed는 **anchor(gate.approved_head_sha,
-            # 승인 트랜잭션에서 이미 확정 기록됨 — gates.py 참고)를 그대로 쓴다** — link.evidence는
-            # pending 상태(아직 anchor 없음)에서만 참고한다.
+            # ⛔카디르 R2 CRITICAL(2026-08-19, 코드 추적 재확認) — 이전 fix는 anchor 우선을
+            # "head_sha 인자가 None일 때만" 적용했다. 그런데 verdict_capture.py 웹훅 경로는
+            # **항상 head_sha를 명시 전달**하므로(gate_check_publish outparam) 그 경로에서
+            # anchor 검증이 통째로 우회됐다 — 웹훅이 다른 SHA를 넘기면 그대로 그 SHA에
+            # success가 발행될 수 있었다(레이스 fix가 막으려던 것과 같은 계열의 구멍).
             #
-            # ⛔카디르 QA③-a — approved/auto_passed인데 anchor가 없으면(정상 경로라면 gates.py
-            # 승인 트랜잭션이 항상 채우므로 legacy/이상 상태뿐) link.evidence로 **폴백하지 않고
-            # success 발행 자체를 skip**한다. 폴백을 허용하면 "확인 안 된 SHA에 success"라는
-            # anchor bypass 구멍이 그대로 남는다(레이스 fix의 취지와 정면 충돌).
-            if head_sha is None:
-                if gate.status in ("approved", "auto_passed"):
-                    if not gate.approved_head_sha:
-                        logger.warning(
-                            "gate=%s: %s인데 anchor(approved_head_sha) 없음 — success 발행 skip"
-                            "(fail-closed, anchor bypass 방지)", gate_id, gate.status,
-                        )
-                        return
-                    head_sha = gate.approved_head_sha
-                else:
-                    head_sha = (link.evidence or {}).get("head_sha")
+            # 불변식으로 재정의: **approved/auto_passed 게이트에서 success를 받을 수 있는
+            # SHA는 anchor(gate.approved_head_sha) 단 하나** — 인자로 뭐가 왔든 무관하다.
+            # ①anchor가 없으면(legacy/이상 상태) skip(QA③-a 그대로) ②인자 head_sha가 anchor와
+            # 다르면(=최신 SHA가 승인된 것과 다름) 그 상황은 **재-pending 영역이지 발행 영역이
+            # 아니다** — reopen_gate_if_new_sha가 처리할 몫이므로 여기서도 skip. 통과하면
+            # head_sha를 anchor로 **강제 고정**(인자 무시).
+            if gate.status in ("approved", "auto_passed"):
+                if not gate.approved_head_sha:
+                    logger.warning(
+                        "gate=%s: %s인데 anchor(approved_head_sha) 없음 — success 발행 skip"
+                        "(fail-closed, anchor bypass 방지)", gate_id, gate.status,
+                    )
+                    return
+                if head_sha is not None and head_sha != gate.approved_head_sha:
+                    logger.warning(
+                        "gate=%s: 요청 head_sha(%s)가 anchor(%s)와 불일치 — success 발행 skip"
+                        "(재-pending 영역, 발행 영역 아님)", gate_id, head_sha, gate.approved_head_sha,
+                    )
+                    return
+                head_sha = gate.approved_head_sha  # anchor가 절대 기준 — 인자 유무 무관.
+            elif head_sha is None:
+                head_sha = (link.evidence or {}).get("head_sha")
             if not head_sha:
                 logger.info("gate=%s: head_sha 미상 — check 발행 skip", gate_id)
                 return
@@ -205,10 +211,15 @@ async def reopen_gate_if_new_sha(
     하고 `GateGithubCheckEvent` 원장에 `re_pending` 행을 전혀 안 남기고 있었다(AC④의 가운데
     조각이 비어 FE가 "재-pending 사유"를 원장만으로 못 만듦). `repo_full_name`/`pr_number`를
     받아 이 트랜잭션 안에서 원장 행도 함께 기록한다(`publish_gate_check`의 별도 background
-    발행과 무관 — 재-pending "발생 사실"은 그 즉시, 같은 트랜잭션에 남아야 한다)."""
+    발행과 무관 — 재-pending "발생 사실"은 그 즉시, 같은 트랜잭션에 남아야 한다).
+
+    ⛔카디르 R2 CRITICAL(2026-08-19) — `auto_passed`도 `approved`와 동일하게 다룬다. 정책이
+    allow_auto로 내린 통과도 "그 SHA에 대한" 승인이라 새 커밋엔 무효 — 자동통과 정책이 새
+    증거로 다시 통과시키는 것은 `evaluate_merge_gate`(재평가 시 anchor 재확定)의 몫이지,
+    구 anchor를 새 SHA에 그대로 붙여두는 것의 몫이 아니다."""
     if gate.gate_type != MERGE_GATE_TYPE:
         return False
-    if gate.status != "approved":
+    if gate.status not in ("approved", "auto_passed"):
         return False
     if gate.approved_head_sha == new_head_sha:
         return False

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -114,8 +114,19 @@ async def publish_gate_check(
             # 축복"하는 사고가 난다. approved/auto_passed는 **anchor(gate.approved_head_sha,
             # 승인 트랜잭션에서 이미 확정 기록됨 — gates.py 참고)를 그대로 쓴다** — link.evidence는
             # pending 상태(아직 anchor 없음)에서만 참고한다.
+            #
+            # ⛔카디르 QA③-a — approved/auto_passed인데 anchor가 없으면(정상 경로라면 gates.py
+            # 승인 트랜잭션이 항상 채우므로 legacy/이상 상태뿐) link.evidence로 **폴백하지 않고
+            # success 발행 자체를 skip**한다. 폴백을 허용하면 "확인 안 된 SHA에 success"라는
+            # anchor bypass 구멍이 그대로 남는다(레이스 fix의 취지와 정면 충돌).
             if head_sha is None:
-                if gate.status in ("approved", "auto_passed") and gate.approved_head_sha:
+                if gate.status in ("approved", "auto_passed"):
+                    if not gate.approved_head_sha:
+                        logger.warning(
+                            "gate=%s: %s인데 anchor(approved_head_sha) 없음 — success 발행 skip"
+                            "(fail-closed, anchor bypass 방지)", gate_id, gate.status,
+                        )
+                        return
                     head_sha = gate.approved_head_sha
                 else:
                     head_sha = (link.evidence or {}).get("head_sha")
@@ -132,7 +143,10 @@ async def publish_gate_check(
 
             gh_status, gh_conclusion = _github_state_for_gate_status(gate.status)
 
-            if gate.github_check_run_id is None:
+            # 카디르 QA③-c — check-run은 **SHA당 1개**가 정본. 기존 run이 다른 SHA에 대한
+            # 것이면(github_check_run_sha 불일치) PATCH가 아니라 새 run을 만든다 — 안 그러면 새
+            # head로는 영원히 check가 안 생겨 required가 영구 미충족되는 데드엔드가 생긴다.
+            if gate.github_check_run_id is None or gate.github_check_run_sha != head_sha:
                 result = await create_check_run(
                     installation_id, repo_full_name, head_sha,
                     name=CHECK_NAME, status=gh_status, conclusion=gh_conclusion,
@@ -143,6 +157,7 @@ async def publish_gate_check(
                     logger.warning("gate=%s: check-run 생성 실패(fail-closed, GitHub 쪽 무영향)", gate_id)
                     return
                 gate.github_check_run_id = result.get("id")
+                gate.github_check_run_sha = head_sha
             else:
                 result = await update_check_run(
                     installation_id, repo_full_name, gate.github_check_run_id,
@@ -169,7 +184,13 @@ async def publish_gate_check(
 
 
 async def reopen_gate_if_new_sha(
-    session: AsyncSession, org_id: uuid.UUID, gate: Gate, new_head_sha: str,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    gate: Gate,
+    new_head_sha: str,
+    *,
+    repo_full_name: str,
+    pr_number: int,
 ) -> bool:
     """SHA 귀속(AC②) — 승인된 게이트가 더 이상 최신 커밋과 안 맞으면 pending으로 되돌린다.
     **호출자의 기존 트랜잭션 안에서 동작**(commit 안 함 — verdict_capture.py가 커밋).
@@ -178,7 +199,13 @@ async def reopen_gate_if_new_sha(
 
     ⛔카디르 QA(PR#3243) fail-closed 보강 — approved인데 `approved_head_sha`가 비어있는 경우
     (정상 경로라면 gates.py 승인 트랜잭션이 항상 채워두므로 legacy/이상 상태뿐)도 **재-pending
-    쪽으로** 판정한다. "SHA를 모르는 승인"을 그대로 success로 방치하는 것이 fail-open이다."""
+    쪽으로** 판정한다. "SHA를 모르는 승인"을 그대로 success로 방치하는 것이 fail-open이다.
+
+    ⛔미르코군 그라운딩(doc gate-github-check-fe-grounding-2814) 적출 — 이 함수가 상태만 리셋
+    하고 `GateGithubCheckEvent` 원장에 `re_pending` 행을 전혀 안 남기고 있었다(AC④의 가운데
+    조각이 비어 FE가 "재-pending 사유"를 원장만으로 못 만듦). `repo_full_name`/`pr_number`를
+    받아 이 트랜잭션 안에서 원장 행도 함께 기록한다(`publish_gate_check`의 별도 background
+    발행과 무관 — 재-pending "발생 사실"은 그 즉시, 같은 트랜잭션에 남아야 한다)."""
     if gate.gate_type != MERGE_GATE_TYPE:
         return False
     if gate.status != "approved":
@@ -188,8 +215,16 @@ async def reopen_gate_if_new_sha(
     logger.info(
         "gate=%s: SHA 불일치(approved=%s new=%s) — 재-pending", gate.id, gate.approved_head_sha, new_head_sha
     )
+    prior_sha = gate.approved_head_sha
     set_gate_status(gate, "pending", now=datetime.now(timezone.utc))
     gate.approved_head_sha = None
     gate.github_check_run_id = None  # 새 SHA는 새 check-run(같은 SHA의 pending→success 갱신 축과 분리).
+    gate.github_check_run_sha = None
+    session.add(GateGithubCheckEvent(
+        org_id=org_id, gate_id=gate.id, story_id=gate.work_item_id,
+        repo_full_name=repo_full_name, pr_number=pr_number, head_sha=new_head_sha,
+        event_type="re_pending", check_conclusion=None,
+    ))
+    logger.info("gate=%s: re_pending 원장 기록(prior_sha=%s)", gate.id, prior_sha)
     await session.flush()
     return True

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -45,7 +45,7 @@ def _github_state_for_gate_status(status: str) -> tuple[str, str | None]:
     return "in_progress", None
 
 
-async def _resolve_pr_link(
+async def resolve_pr_link(
     session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID
 ) -> PullRequestStoryLink | None:
     """story에 연결된 PR 링크 — 가장 최근 갱신 1건(⚠️단순화: 한 story에 PR 링크가 여럿이면
@@ -101,16 +101,24 @@ async def publish_gate_check(
             if gate is None or gate.gate_type != MERGE_GATE_TYPE:
                 return  # merge 게이트 아니면 이 1단계 스코프 밖(설계 doc §0).
 
-            # 링크는 항상 조회한다(head_sha가 이미 인자로 왔어도) — 웹훅 경로가 알아낸 head_sha를
-            # link.evidence에 되먹여야, 나중에 사람 승인(gates.py, head_sha를 모르는 호출자)이 같은
-            # 링크에서 "이 게이트가 지금 추적 중인 SHA"를 찾을 수 있다(단일 소스, 이중진실 방지).
-            link = await _resolve_pr_link(session, org_id, gate.work_item_id)
+            link = await resolve_pr_link(session, org_id, gate.work_item_id)
             if link is None:
                 logger.info("gate=%s: PR 링크 없음 — check 발행 skip", gate_id)
                 return
             repo_full_name = repo_full_name or link.repo_full_name
             pr_number = pr_number if pr_number is not None else link.pr_number
-            head_sha = head_sha or (link.evidence or {}).get("head_sha")
+
+            # ⛔카디르 QA(PR#3243, 2026-08-19) 레이스 fix — 여기서 link.evidence.head_sha를
+            # "지금 추적 중인 SHA"로 재해소하면, 승인(SHA A) 커밋 後·이 배경 태스크 실행 前에
+            # 새 커밋(B)의 synchronize가 먼저 link.evidence를 B로 갱신해버렸을 때 "A 승인이 B를
+            # 축복"하는 사고가 난다. approved/auto_passed는 **anchor(gate.approved_head_sha,
+            # 승인 트랜잭션에서 이미 확정 기록됨 — gates.py 참고)를 그대로 쓴다** — link.evidence는
+            # pending 상태(아직 anchor 없음)에서만 참고한다.
+            if head_sha is None:
+                if gate.status in ("approved", "auto_passed") and gate.approved_head_sha:
+                    head_sha = gate.approved_head_sha
+                else:
+                    head_sha = (link.evidence or {}).get("head_sha")
             if not head_sha:
                 logger.info("gate=%s: head_sha 미상 — check 발행 skip", gate_id)
                 return
@@ -166,12 +174,16 @@ async def reopen_gate_if_new_sha(
     """SHA 귀속(AC②) — 승인된 게이트가 더 이상 최신 커밋과 안 맞으면 pending으로 되돌린다.
     **호출자의 기존 트랜잭션 안에서 동작**(commit 안 함 — verdict_capture.py가 커밋).
     `resolve_gate_from_verdict`(시스템 자동판정)와 동일한 경량 경로(`set_gate_status` 직접 —
-    `transition_gate`의 사람-결재 부작용 체인 우회, gate.py 주석 참고). True=재-pending 발생."""
+    `transition_gate`의 사람-결재 부작용 체인 우회, gate.py 주석 참고). True=재-pending 발생.
+
+    ⛔카디르 QA(PR#3243) fail-closed 보강 — approved인데 `approved_head_sha`가 비어있는 경우
+    (정상 경로라면 gates.py 승인 트랜잭션이 항상 채워두므로 legacy/이상 상태뿐)도 **재-pending
+    쪽으로** 판정한다. "SHA를 모르는 승인"을 그대로 success로 방치하는 것이 fail-open이다."""
     if gate.gate_type != MERGE_GATE_TYPE:
         return False
     if gate.status != "approved":
         return False
-    if not gate.approved_head_sha or gate.approved_head_sha == new_head_sha:
+    if gate.approved_head_sha == new_head_sha:
         return False
     logger.info(
         "gate=%s: SHA 불일치(approved=%s new=%s) — 재-pending", gate.id, gate.approved_head_sha, new_head_sha

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -1,0 +1,183 @@
+"""story #2813([Gate 강제·BE], 설계 카드 doc c1855e0d) — Gate(gate_type="merge") 상태를
+GitHub `sprintable/gate` required check로 반영한다.
+
+설계 doc `gate-github-required-check-grounding-design-2813` §2 그대로:
+- fail-closed(§2-3): check 최초 발행은 항상 `status=in_progress`(미완료 — required면 머지 차단).
+  `conclusion=success`로 넘어가는 유일한 경로는 `publish_gate_check()`가 **Gate DB 상태를 이미
+  읽은 후**의 GitHub API 호출뿐 — 이 함수가 예외를 던지면(네트워크/5xx/권한) GitHub 쪽 check는
+  그냥 마지막 상태(pending)에 머문다. 이 모듈의 모든 공개 함수는 예외를 삼켜 호출자(웹훅
+  트랜잭션·백그라운드 태스크)를 절대 깨뜨리지 않는다 — 이게 fail-closed의 실제 경계다.
+- SHA 귀속(§2-2): `gates.approved_head_sha`에 "이 승인이 귀속된 SHA"를 기록. `reopen_gate_if_new_sha`
+  가 `resolve_gate_from_verdict`(시스템 자동판정)와 동일한 경량 경로(`set_gate_status` 직접 호출 —
+  `transition_gate`의 사람-결재 전용 부작용 체인은 안 탐, gate.py 주석 참고)로 approved→pending을
+  되돌린다.
+- 원장(AC④): 모든 발행/재-pending/해소를 `GateGithubCheckEvent`에 append-only로 남긴다.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate, set_gate_status
+from app.models.gate_github_check_event import GateGithubCheckEvent
+from app.models.github_installation import GithubInstallation
+from app.models.pull_request_story_link import PullRequestStoryLink
+from app.services.github_app import create_check_run, update_check_run
+from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+logger = logging.getLogger(__name__)
+
+CHECK_NAME = "sprintable/gate"
+
+
+def _github_state_for_gate_status(status: str) -> tuple[str, str | None]:
+    """Gate.status → GitHub Checks API (status, conclusion). completed 상태만 conclusion을 가진다
+    (GitHub API 제약) — pending/held는 in_progress(미완료=required check가 머지를 막는 상태)."""
+    if status == "approved" or status == "auto_passed":
+        return "completed", "success"
+    if status in ("rejected", "voided"):
+        return "completed", "failure"
+    # pending | held — 미완료. voided를 성공으로 착각하면 fail-closed 위반이라 명시 분기.
+    return "in_progress", None
+
+
+async def _resolve_pr_link(
+    session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID
+) -> PullRequestStoryLink | None:
+    """story에 연결된 PR 링크 — 가장 최근 갱신 1건(⚠️단순화: 한 story에 PR 링크가 여럿이면
+    최신 것만 check 발행 대상. 다중-PR 동시추적은 이번 1단계 스코프 밖 — 설계 doc §3 후속 검토)."""
+    row = (
+        await session.execute(
+            select(PullRequestStoryLink)
+            .where(
+                PullRequestStoryLink.org_id == org_id,
+                PullRequestStoryLink.story_id == story_id,
+                PullRequestStoryLink.deleted_at.is_(None),
+            )
+            .order_by(PullRequestStoryLink.updated_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return row
+
+
+async def _resolve_installation_id(session: AsyncSession, org_id: uuid.UUID) -> int | None:
+    row = (
+        await session.execute(
+            select(GithubInstallation.installation_id).where(
+                GithubInstallation.org_id == org_id,
+                GithubInstallation.suspended_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    return row
+
+
+async def publish_gate_check(
+    org_id: uuid.UUID,
+    gate_id: uuid.UUID,
+    *,
+    head_sha: str | None = None,
+    repo_full_name: str | None = None,
+    pr_number: int | None = None,
+) -> None:
+    """gate 현재 상태를 GitHub check-run으로 반영 — **자기 세션**을 연다(background task 표준
+    패턴, `conversation_webhook.py::deliver_injected_event_webhook` 선례). ``head_sha``/
+    ``repo_full_name``/``pr_number``를 인자로 주면(웹훅 직후처럼 이미 알고 있을 때) 재조회를
+    생략, 없으면 `PullRequestStoryLink`에서 해소한다. 이 함수는 절대 예외를 던지지 않는다 —
+    실패는 로그만(fail-closed: 실패해도 GitHub 쪽 check는 마지막 상태 그대로).
+    """
+    from app.core.database import async_session_factory
+
+    try:
+        async with async_session_factory() as session:
+            gate = (
+                await session.execute(select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id))
+            ).scalar_one_or_none()
+            if gate is None or gate.gate_type != MERGE_GATE_TYPE:
+                return  # merge 게이트 아니면 이 1단계 스코프 밖(설계 doc §0).
+
+            # 링크는 항상 조회한다(head_sha가 이미 인자로 왔어도) — 웹훅 경로가 알아낸 head_sha를
+            # link.evidence에 되먹여야, 나중에 사람 승인(gates.py, head_sha를 모르는 호출자)이 같은
+            # 링크에서 "이 게이트가 지금 추적 중인 SHA"를 찾을 수 있다(단일 소스, 이중진실 방지).
+            link = await _resolve_pr_link(session, org_id, gate.work_item_id)
+            if link is None:
+                logger.info("gate=%s: PR 링크 없음 — check 발행 skip", gate_id)
+                return
+            repo_full_name = repo_full_name or link.repo_full_name
+            pr_number = pr_number if pr_number is not None else link.pr_number
+            head_sha = head_sha or (link.evidence or {}).get("head_sha")
+            if not head_sha:
+                logger.info("gate=%s: head_sha 미상 — check 발행 skip", gate_id)
+                return
+            if (link.evidence or {}).get("head_sha") != head_sha:
+                link.evidence = {**(link.evidence or {}), "head_sha": head_sha}
+
+            installation_id = await _resolve_installation_id(session, org_id)
+            if installation_id is None:
+                logger.info("org=%s: GitHub installation 없음 — check 발행 skip", org_id)
+                return
+
+            gh_status, gh_conclusion = _github_state_for_gate_status(gate.status)
+
+            if gate.github_check_run_id is None:
+                result = await create_check_run(
+                    installation_id, repo_full_name, head_sha,
+                    name=CHECK_NAME, status=gh_status, conclusion=gh_conclusion,
+                    title="Sprintable Gate",
+                    summary=f"게이트 상태: {gate.status}",
+                )
+                if result is None:
+                    logger.warning("gate=%s: check-run 생성 실패(fail-closed, GitHub 쪽 무영향)", gate_id)
+                    return
+                gate.github_check_run_id = result.get("id")
+            else:
+                result = await update_check_run(
+                    installation_id, repo_full_name, gate.github_check_run_id,
+                    status=gh_status, conclusion=gh_conclusion,
+                    title="Sprintable Gate",
+                    summary=f"게이트 상태: {gate.status}",
+                )
+                if result is None:
+                    logger.warning("gate=%s: check-run 갱신 실패(fail-closed, GitHub 쪽 무영향)", gate_id)
+                    return
+
+            if gh_status == "completed" and gh_conclusion == "success":
+                gate.approved_head_sha = head_sha
+
+            event_type = "resolved" if gh_status == "completed" else "published"
+            session.add(GateGithubCheckEvent(
+                org_id=org_id, gate_id=gate.id, story_id=gate.work_item_id,
+                repo_full_name=repo_full_name, pr_number=pr_number, head_sha=head_sha,
+                event_type=event_type, check_conclusion=gh_conclusion,
+            ))
+            await session.commit()
+    except Exception:  # noqa: BLE001 — fail-closed 경계: 백그라운드 태스크는 절대 안 죽는다.
+        logger.exception("gate=%s: check 발행 처리 중 예외(fail-closed, GitHub 쪽 무영향)", gate_id)
+
+
+async def reopen_gate_if_new_sha(
+    session: AsyncSession, org_id: uuid.UUID, gate: Gate, new_head_sha: str,
+) -> bool:
+    """SHA 귀속(AC②) — 승인된 게이트가 더 이상 최신 커밋과 안 맞으면 pending으로 되돌린다.
+    **호출자의 기존 트랜잭션 안에서 동작**(commit 안 함 — verdict_capture.py가 커밋).
+    `resolve_gate_from_verdict`(시스템 자동판정)와 동일한 경량 경로(`set_gate_status` 직접 —
+    `transition_gate`의 사람-결재 부작용 체인 우회, gate.py 주석 참고). True=재-pending 발생."""
+    if gate.gate_type != MERGE_GATE_TYPE:
+        return False
+    if gate.status != "approved":
+        return False
+    if not gate.approved_head_sha or gate.approved_head_sha == new_head_sha:
+        return False
+    logger.info(
+        "gate=%s: SHA 불일치(approved=%s new=%s) — 재-pending", gate.id, gate.approved_head_sha, new_head_sha
+    )
+    set_gate_status(gate, "pending", now=datetime.now(timezone.utc))
+    gate.approved_head_sha = None
+    gate.github_check_run_id = None  # 새 SHA는 새 check-run(같은 SHA의 pending→success 갱신 축과 분리).
+    await session.flush()
+    return True

--- a/backend/app/services/github_app.py
+++ b/backend/app/services/github_app.py
@@ -126,6 +126,86 @@ async def get_installation_token(installation_id: int) -> str | None:
         return None
 
 
+async def create_check_run(
+    installation_id: int,
+    repo_full_name: str,
+    head_sha: str,
+    *,
+    name: str = "sprintable/gate",
+    status: str = "in_progress",
+    conclusion: str | None = None,
+    title: str | None = None,
+    summary: str | None = None,
+) -> dict | None:
+    """story #2813 — `POST /repos/{repo}/check-runs`(installation token). 실패/토큰없음=None
+    (fail-closed 상위 호출자 책임 — 이 함수는 예외를 삼키지 않는다, 호출자가 try/except로
+    "실패해도 GitHub 쪽 상태는 안 바뀐다"를 보장). `status='completed'`일 때만 `conclusion` 필수
+    (GitHub API 제약 — queued/in_progress엔 conclusion 없음)."""
+    token = await get_installation_token(installation_id)
+    if not token:
+        return None
+    body: dict = {"name": name, "head_sha": head_sha, "status": status}
+    if status == "completed" and conclusion:
+        body["conclusion"] = conclusion
+    if title or summary:
+        body["output"] = {"title": title or name, "summary": summary or ""}
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(
+            f"{_GITHUB_API}/repos/{repo_full_name}/check-runs",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            json=body,
+        )
+    if resp.status_code not in (200, 201):
+        logger.warning(
+            "check-run create 실패 HTTP %s (repo=%s sha=%s)", resp.status_code, repo_full_name, head_sha
+        )
+        return None
+    return resp.json()
+
+
+async def update_check_run(
+    installation_id: int,
+    repo_full_name: str,
+    check_run_id: int,
+    *,
+    status: str | None = None,
+    conclusion: str | None = None,
+    title: str | None = None,
+    summary: str | None = None,
+) -> dict | None:
+    """story #2813 — `PATCH /repos/{repo}/check-runs/{id}`. create_check_run과 동일 계약(예외
+    미삼킴·실패=None)."""
+    token = await get_installation_token(installation_id)
+    if not token:
+        return None
+    body: dict = {}
+    if status:
+        body["status"] = status
+    if status == "completed" and conclusion:
+        body["conclusion"] = conclusion
+    if title or summary:
+        body["output"] = {"title": title or "sprintable/gate", "summary": summary or ""}
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.patch(
+            f"{_GITHUB_API}/repos/{repo_full_name}/check-runs/{check_run_id}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            json=body,
+        )
+    if resp.status_code != 200:
+        logger.warning(
+            "check-run update 실패 HTTP %s (repo=%s check_run_id=%s)",
+            resp.status_code, repo_full_name, check_run_id,
+        )
+        return None
+    return resp.json()
+
+
 async def fetch_installation_metadata(installation_id: int) -> dict | None:
     """`GET /app/installations/{id}`(App JWT) — account login/type·repo selection. best-effort(None=graceful)."""
     app_jwt = build_app_jwt()

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -275,11 +275,14 @@ async def evaluate_merge_gate(
     Cage 재사용: capture_pr_ci_verdict(독립 verdict 기록) + compute_member_trust_scores(trust) +
     create_gate(정책 disposition 아티팩트·AC⑥). 모든 평가는 gate row를 남긴다.
 
-    ``head_sha``(story #2813, 카디르 R2 CRITICAL) — 이 평가로 gate.status가 "auto_passed"가
-    되면(정책이 allow_auto) `gate.approved_head_sha`를 이 값으로 즉시 확定한다. 사람 승인
-    (gates.py transition_gate_endpoint)이 승인 트랜잭션에서 anchor를 즉시 박는 것과 동일한
-    불변식 — "success를 받을 수 있는 SHA는 anchor 단 하나"가 approved/auto_passed 둘 다에서
-    성립해야 publish_gate_check의 anchor 검증이 의미가 있다. 호출자가 head_sha를 모르면(board
+    ``head_sha``(story #2813, 카디르 R2 CRITICAL·R3 HIGH) — 이 평가의 **실 판정이
+    `_decide()`==AUTO_MERGE**일 때만(아래 §4) `gate.approved_head_sha`를 이 값으로 즉시
+    확定한다. ⛔`gate.status=="auto_passed"`(정책 disposition 축) 시점에 찍으면 안 된다 —
+    status="auto_passed"이면서 CI 미완/trust 표본 부족으로 실판정은 ASK_HUMAN인 게이트가
+    실재한다(카디르 QA PR#2902②·#2156이 이미 고정한 두 축 구분). 사람 승인(gates.py
+    transition_gate_endpoint)이 승인 트랜잭션에서 anchor를 즉시 박는 것과 동일한 불변식 —
+    "success를 받을 수 있는 SHA는 anchor 단 하나"가 approved/AUTO_MERGE 둘 다에서 성립해야
+    publish_gate_check의 anchor 검증이 의미가 있다. 호출자가 head_sha를 모르면(board
     preflight/report-done처럼 웹훅 컨텍스트가 없는 경로) None — anchor 없음(fail-closed, publish
     가 success 발행을 skip)."""
     ci = _normalize_result(ci_result)
@@ -408,12 +411,6 @@ async def evaluate_merge_gate(
         neutral_facts=facts,
     )
 
-    # story #2813(카디르 R2 CRITICAL) — auto_passed는 정책이 내리는 "그 순간의" 승인이다.
-    # 사람 승인(gates.py)과 동일하게 **결정 트랜잭션에서 즉시** anchor를 박는다 — 재평가로 다시
-    # auto_passed가 되면(새 증거·같은 정책) anchor도 그 시점 head_sha로 갱신(idempotent).
-    if gate.status == "auto_passed" and head_sha:
-        gate.approved_head_sha = head_sha
-
     # 재제출 re-open(doc-gate 48f064e5 선례 이식): uq(work_item,gate_type)=1행 + terminal=immutable
     # → create_gate 멱등이 rejected/voided gate 를 그대로 반환하면 아래 _decide 가 deny BLOCK 을
     # 영구 반환한다(void/override 는 pending 전용이라 API 복구 경로 0 — reject→수정→재제출 불가).
@@ -488,6 +485,17 @@ async def evaluate_merge_gate(
     set_gate_evidence_status(gate, _evidence_status(decision), now=datetime.now(timezone.utc))
     gate.decision_basis = reason
     gate.auto_decision_reason = decision
+
+    # story #2813(카디르 R3 HIGH) — anchor는 **실 판정이 AUTO_MERGE일 때만** 확定한다.
+    # ⛔최초 fix는 `gate.status == "auto_passed"`(정책 disposition 축) 시점에 찍었는데, 그건
+    # `_decide()`의 실 증거 기반 verdict(이 axis)와 다른 필드다(카디르 QA PR#2902②·#2156이
+    # 이미 고정한 구분 — status="auto_passed"이면서 CI 미완/trust 표본 부족으로 실판정은
+    # ASK_HUMAN인 게이트가 실재한다). 그 상태에서 anchor를 찍으면 "사람이 봐야 하는" SHA에도
+    # success가 나갈 수 있었다 — AUTO_MERGE로 옮기면 그런 상태는 anchor가 안 생겨
+    # publish_gate_check의 불변식이 자연히 success를 막는다(fail-closed 정합).
+    if decision == AUTO_MERGE and head_sha:
+        gate.approved_head_sha = head_sha
+
     await session.flush()
 
     logger.info(

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -268,12 +268,20 @@ async def evaluate_merge_gate(
     ci_result: str | None,
     pr_result: str | None = "pass",
     trust_threshold: float = DEFAULT_TRUST_THRESHOLD,
+    head_sha: str | None = None,
 ) -> MergeGateDecision:
     """story 머지 게이트를 평가해 decision(auto_merge|ask_human|block)을 산출한다.
 
     Cage 재사용: capture_pr_ci_verdict(독립 verdict 기록) + compute_member_trust_scores(trust) +
     create_gate(정책 disposition 아티팩트·AC⑥). 모든 평가는 gate row를 남긴다.
-    """
+
+    ``head_sha``(story #2813, 카디르 R2 CRITICAL) — 이 평가로 gate.status가 "auto_passed"가
+    되면(정책이 allow_auto) `gate.approved_head_sha`를 이 값으로 즉시 확定한다. 사람 승인
+    (gates.py transition_gate_endpoint)이 승인 트랜잭션에서 anchor를 즉시 박는 것과 동일한
+    불변식 — "success를 받을 수 있는 SHA는 anchor 단 하나"가 approved/auto_passed 둘 다에서
+    성립해야 publish_gate_check의 anchor 검증이 의미가 있다. 호출자가 head_sha를 모르면(board
+    preflight/report-done처럼 웹훅 컨텍스트가 없는 경로) None — anchor 없음(fail-closed, publish
+    가 success 발행을 skip)."""
     ci = _normalize_result(ci_result)
     pr = _normalize_result(pr_result)
 
@@ -400,6 +408,12 @@ async def evaluate_merge_gate(
         neutral_facts=facts,
     )
 
+    # story #2813(카디르 R2 CRITICAL) — auto_passed는 정책이 내리는 "그 순간의" 승인이다.
+    # 사람 승인(gates.py)과 동일하게 **결정 트랜잭션에서 즉시** anchor를 박는다 — 재평가로 다시
+    # auto_passed가 되면(새 증거·같은 정책) anchor도 그 시점 head_sha로 갱신(idempotent).
+    if gate.status == "auto_passed" and head_sha:
+        gate.approved_head_sha = head_sha
+
     # 재제출 re-open(doc-gate 48f064e5 선례 이식): uq(work_item,gate_type)=1행 + terminal=immutable
     # → create_gate 멱등이 rejected/voided gate 를 그대로 반환하면 아래 _decide 가 deny BLOCK 을
     # 영구 반환한다(void/override 는 pending 전용이라 API 복구 경로 0 — reject→수정→재제출 불가).
@@ -507,6 +521,7 @@ async def reconcile_merge_gate_with_real_evidence(
     repo: str,
     ci_result: str | None,
     merged: bool,
+    head_sha: str | None = None,
 ) -> MergeGateDecision | None:
     """story #2156 AC2(2026-08-07) — GitHub 웹훅이 잡은 실 CI/PR verdict를 merge-type
     게이트에 반영한다.
@@ -552,4 +567,5 @@ async def reconcile_merge_gate_with_real_evidence(
         session, org_id, story_id,
         pr_number=pr_number, repo=repo, ci_result=ci_result,
         pr_result=("pass" if merged else None),
+        head_sha=head_sha,
     )

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -493,8 +493,22 @@ async def evaluate_merge_gate(
     # ASK_HUMAN인 게이트가 실재한다). 그 상태에서 anchor를 찍으면 "사람이 봐야 하는" SHA에도
     # success가 나갈 수 있었다 — AUTO_MERGE로 옮기면 그런 상태는 anchor가 안 생겨
     # publish_gate_check의 불변식이 자연히 success를 막는다(fail-closed 정합).
-    if decision == AUTO_MERGE and head_sha:
-        gate.approved_head_sha = head_sha
+    # story #2813(카디르 R4①) — 같은 SHA 재평가로 decision이 AUTO_MERGE에서 이탈하면(CI
+    # 재실패·trust 하락 등) 이전 auto-pass anchor는 더 이상 유효하지 않다 — 지운다.
+    # ⚠️스코프: `gate.status=="auto_passed"`(정책이 여전히 allow_auto인 "자동 축")일 때만 —
+    # 사람이 승인한 anchor(`gate.status=="approved"`, gates.py `transition_gate_endpoint`가
+    # 세팅)는 이 시스템 재평가가 **절대 못 건드린다**(건드리면 사람 결재를 시스템이 역전시키는
+    # 사고). head_sha를 모르는 호출자의 AUTO_MERGE 재확認은 기존 anchor를 그대로 둔다(새로
+    # 세우지도 지우지도 않음 — "모른다"는 "무효"가 아니다).
+    if decision == AUTO_MERGE:
+        if head_sha:
+            gate.approved_head_sha = head_sha
+    elif gate.status == "auto_passed" and gate.approved_head_sha:
+        logger.info(
+            "gate=%s: 재평가로 decision이 AUTO_MERGE 이탈(%s) — auto-axis anchor(%s) 무효화",
+            gate.id, decision, gate.approved_head_sha,
+        )
+        gate.approved_head_sha = None
 
     await session.flush()
 

--- a/backend/tests/test_2813_gate_github_check_realdb.py
+++ b/backend/tests/test_2813_gate_github_check_realdb.py
@@ -149,8 +149,11 @@ async def test_publish_gate_check_approved_sets_conclusion_success_and_sha_attri
             # github_check_run_sha를 발행 대상 head_sha와 동일하게 시드해야(카디르 QA③-c 이후)
             # PATCH(update_check_run) 경로를 탄다 — 다르면 새 run 생성 경로로 바뀐다(정상 동작,
             # test_publish_gate_check_creates_new_run_for_different_sha_realdb가 그 축을 커버).
+            # approved_head_sha도 같은 값으로 시드해야(카디르 R2 CRITICAL 이후) anchor 검증을
+            # 통과한다 — 인자 head_sha만으론 더 이상 안 통과.
             seeded = await _seed(
-                s, gate_status="approved", github_check_run_id=9001, github_check_run_sha="sha-approved-1",
+                s, gate_status="approved", approved_head_sha="sha-approved-1",
+                github_check_run_id=9001, github_check_run_sha="sha-approved-1",
             )
 
         with patch(
@@ -170,6 +173,21 @@ async def test_publish_gate_check_approved_sets_conclusion_success_and_sha_attri
         async with Session() as s:
             gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
             assert gate.approved_head_sha == "sha-approved-1"  # SHA 귀속(AC②) 실제 저장 확認.
+
+            # PO 지시(2026-08-19) — 원장 3축(published/re_pending/resolved) 완충족의 마지막
+            # 조각. resolved는 gh_status=="completed"일 때만 찍힌다(_process_webhook_event와
+            # 무관 — publish_gate_check 자체 로직).
+            from app.models.gate_github_check_event import GateGithubCheckEvent
+
+            events = (
+                await s.execute(
+                    select(GateGithubCheckEvent).where(GateGithubCheckEvent.gate_id == gate.id)
+                )
+            ).scalars().all()
+            assert len(events) == 1
+            assert events[0].event_type == "resolved"
+            assert events[0].check_conclusion == "success"
+            assert events[0].head_sha == "sha-approved-1"
     finally:
         await engine.dispose()
 
@@ -187,7 +205,9 @@ async def test_publish_gate_check_fail_closed_on_github_error_does_not_set_succe
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            seeded = await _seed(s, gate_status="approved")
+            # anchor를 head_sha와 동일하게 시드(카디르 R2 이후) — anchor-missing-skip이 아니라
+            # "GitHub 호출 자체가 실패"하는 이 테스트 본연의 시나리오를 타야 한다.
+            seeded = await _seed(s, gate_status="approved", approved_head_sha="sha-fail-1")
 
         with patch(
             "app.services.gate_github_check.create_check_run", AsyncMock(return_value=None),
@@ -199,7 +219,7 @@ async def test_publish_gate_check_fail_closed_on_github_error_does_not_set_succe
 
         async with Session() as s:
             gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
-            assert gate.approved_head_sha is None
+            assert gate.approved_head_sha == "sha-fail-1"  # 시드값 그대로 — 새로 오염 안 됨.
             assert gate.github_check_run_id is None
             events = (
                 await s.execute(select(GateGithubCheckEvent).where(GateGithubCheckEvent.gate_id == gate.id))
@@ -217,7 +237,9 @@ async def test_publish_gate_check_never_raises_on_unexpected_exception_realdb():
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            seeded = await _seed(s, gate_status="approved")
+            # anchor를 head_sha와 동일하게 시드(카디르 R2 이후) — 예외를 실제로 일으키는
+            # create_check_run 호출까지 도달해야 이 테스트가 뭘 검증하는지 의미가 있다.
+            seeded = await _seed(s, gate_status="approved", approved_head_sha="sha-x")
 
         with patch(
             "app.services.gate_github_check.create_check_run",
@@ -518,5 +540,186 @@ async def test_race_reopen_fail_closed_when_anchor_missing_despite_approved_real
         async with Session() as s:
             gate = await s.get(Gate, seeded["gate_id"])
             assert gate.status == "pending"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_r2_critical_webhook_explicit_head_sha_mismatch_never_bypasses_anchor_realdb():
+    """카디르 R2 CRITICAL(2026-08-19, 코드 추적 재확認) — 이전 fix는 anchor 우선을
+    "head_sha 인자가 None일 때만" 적용해서, **항상 head_sha를 명시 전달하는 웹훅 경로**
+    (verdict_capture.py의 gate_check_publish outparam)가 그 검증을 통째로 우회했다. 이 테스트가
+    바로 그 경로를 재현한다 — 웹훅이 anchor(A)와 다른 head_sha(B)를 명시로 넘겨도 success가
+    발행되면 안 된다(그 상황은 재-pending 영역)."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.models.gate_github_check_event import GateGithubCheckEvent
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="approved", approved_head_sha="sha-A")
+
+        with patch(
+            "app.services.gate_github_check.create_check_run", AsyncMock(return_value={"id": 1}),
+        ) as create_mock, patch(
+            "app.services.gate_github_check.update_check_run", AsyncMock(),
+        ) as update_mock, patch("app.core.database.async_session_factory", Session):
+            # 웹훅 경로와 동일한 호출 형태 — head_sha를 **명시로** 넘긴다(다른 SHA).
+            await publish_gate_check(
+                seeded["org_id"], seeded["gate_id"],
+                head_sha="sha-B", repo_full_name="acme/repo", pr_number=7,
+            )
+
+        # ⭐핵심 단언 — 구 코드였다면 head_sha="sha-B"가 인자로 왔으므로 anchor 검증 자체가
+        # 안 돌아 create_check_run(status=completed, conclusion=success)이 그대로 호출됐을 것.
+        create_mock.assert_not_awaited()
+        update_mock.assert_not_awaited()
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
+            assert gate.approved_head_sha == "sha-A"  # B로 오염 안 됨.
+            events = (
+                await s.execute(select(GateGithubCheckEvent).where(GateGithubCheckEvent.gate_id == gate.id))
+            ).scalars().all()
+            assert events == []  # 발행 자체가 안 일어났으므로 원장도 0건.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reopen_gate_if_new_sha_treats_auto_passed_same_as_approved_realdb():
+    """카디르 R2 fix② — auto_passed도 approved와 동일하게 재-pending 대상이어야 한다(구 코드는
+    `gate.status != "approved"`로 auto_passed를 완전히 건너뛰었다)."""
+    from app.models.gate import Gate
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="auto_passed", approved_head_sha="sha-old")
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            flipped = await reopen_gate_if_new_sha(
+                s, seeded["org_id"], gate, "sha-new", repo_full_name="acme/repo", pr_number=7,
+            )
+            await s.commit()
+
+        assert flipped is True  # 구 코드라면 gate_type만 보고 status 체크에서 False였을 것.
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            assert gate.status == "pending"
+            assert gate.approved_head_sha is None
+    finally:
+        await engine.dispose()
+
+
+# ── 카디르 R2 fix②-a — auto_passed 판정 시점 anchor 즉시 확定(merge_verdict_gate.evaluate_
+# merge_gate) — test_2156_merge_gate_evidence_realdb.py의 _seed_story_with_participation/
+# _gate_row 패턴을 그대로 재사용(발명 0, 이 파일 self-contained 유지 위해 로컬 복제). ──────────
+
+
+async def _seed_story_with_participation(session):
+    from app.models.organization import Organization
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="anchor stamp target")
+    session.add(story)
+    await session.commit()
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="dev", label="Dev", is_default=True)
+    session.add(role)
+    await session.commit()
+
+    member_id = uuid.uuid4()
+    participation = Participation(
+        id=uuid.uuid4(), org_id=org.id, story_id=story.id, role_id=role.id, member_id=member_id,
+    )
+    session.add(participation)
+    await session.commit()
+
+    return {"org_id": org.id, "story_id": story.id, "member_id": member_id}
+
+
+async def _gate_row_by_story(session, story_id):
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    result = await session.execute(
+        select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == MERGE_GATE_TYPE)
+    )
+    return result.scalar_one_or_none()
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_stamps_anchor_when_auto_passed_realdb():
+    """카디르 R2 fix②-a — 정책이 allow_auto로 판정하면(status=auto_passed) 그 결정 트랜잭션
+    에서 즉시 `approved_head_sha`가 head_sha로 확定돼야 한다(사람 승인과 동일 불변식)."""
+    from app.services.merge_verdict_gate import evaluate_merge_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+
+            with patch(
+                "app.services.gate_service.resolve_disposition",
+                AsyncMock(return_value=("allow_auto", "org_policy")),
+            ):
+                await evaluate_merge_gate(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=99, repo="acme/repo", ci_result="pass", pr_result="pass",
+                    head_sha="sha-auto-1",
+                )
+                await s.commit()
+
+            gate = await _gate_row_by_story(s, seeded["story_id"])
+            assert gate.status == "auto_passed"
+            assert gate.approved_head_sha == "sha-auto-1"  # ⭐핵심 단언.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_no_anchor_when_head_sha_unknown_realdb():
+    """양성대조 — head_sha를 모르는 호출자(board preflight류)는 anchor를 못 남긴다(발명 금지,
+    None 그대로) — publish_gate_check가 그 경우 success 발행을 skip하는 것과 짝을 이룬다."""
+    from app.services.merge_verdict_gate import evaluate_merge_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+
+            with patch(
+                "app.services.gate_service.resolve_disposition",
+                AsyncMock(return_value=("allow_auto", "org_policy")),
+            ):
+                await evaluate_merge_gate(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=99, repo="acme/repo", ci_result="pass", pr_result="pass",
+                    # head_sha 인자 생략 — None 기본값.
+                )
+                await s.commit()
+
+            gate = await _gate_row_by_story(s, seeded["story_id"])
+            assert gate.status == "auto_passed"
+            assert gate.approved_head_sha is None
     finally:
         await engine.dispose()

--- a/backend/tests/test_2813_gate_github_check_realdb.py
+++ b/backend/tests/test_2813_gate_github_check_realdb.py
@@ -776,3 +776,89 @@ async def test_evaluate_merge_gate_no_anchor_when_status_auto_passed_but_decisio
             assert gate.approved_head_sha is None  # ⭐핵심 단언 — 구 fix라면 여기 SHA가 찍혔을 것.
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_clears_auto_axis_anchor_when_decision_leaves_auto_merge_realdb():
+    """카디르 R4① — 같은 SHA를 두 번 평가: ①CI pass+강한 trust → AUTO_MERGE, anchor 확定
+    ②(같은 SHA) CI가 나중에 fail로 뒤집힘 → `_decide()`가 하드 BLOCK(trust 무관) → 이전
+    auto-pass anchor는 더 이상 유효하지 않으므로 지워져야 한다."""
+    from app.services.merge_verdict_gate import AUTO_MERGE, BLOCK, evaluate_merge_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+
+            with patch(
+                "app.services.gate_service.resolve_disposition",
+                AsyncMock(return_value=("allow_auto", "org_policy")),
+            ), patch(
+                "app.services.merge_verdict_gate.compute_member_trust_scores",
+                AsyncMock(return_value=_STRONG_TRUST),
+            ):
+                d1 = await evaluate_merge_gate(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=99, repo="acme/repo", ci_result="pass", pr_result="pass",
+                    head_sha="sha-same",
+                )
+                await s.commit()
+                assert d1.decision == AUTO_MERGE, f"1차 전제 실패: {d1.reason}"
+                gate = await _gate_row_by_story(s, seeded["story_id"])
+                assert gate.approved_head_sha == "sha-same"  # anchor 확定 확認.
+
+                # 같은 SHA — CI가 나중에 fail로 뒤집힘(재평가).
+                d2 = await evaluate_merge_gate(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=99, repo="acme/repo", ci_result="fail", pr_result="pass",
+                    head_sha="sha-same",
+                )
+                await s.commit()
+
+            assert d2.decision == BLOCK, f"2차 전제 실패: {d2.reason}"
+            gate = await _gate_row_by_story(s, seeded["story_id"])
+            assert gate.approved_head_sha is None  # ⭐핵심 단언 — 무효화된 anchor.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_never_clears_human_approved_anchor_realdb():
+    """카디르 R4① 안전경계 — `gate.status=="approved"`(사람 승인, gates.py 축)는
+    evaluate_merge_gate 재평가가 **절대** 못 건드린다. 시스템 재평가가 사람 결재를 역전시키면
+    사고이므로, 클리어 조건은 반드시 `gate.status=="auto_passed"`로만 스코프돼야 한다."""
+    from app.services.gate_service import create_gate
+    from app.services.merge_verdict_gate import BLOCK, MERGE_GATE_TYPE, evaluate_merge_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+
+            # 사람이 이미 승인한 상태를 직접 시뮬레이션(gates.py 축과 동형 — status=approved+anchor).
+            gate = await create_gate(
+                s, seeded["org_id"], seeded["story_id"], "story", MERGE_GATE_TYPE,
+                seeded["member_id"], None, project_id=None, neutral_facts={},
+            )
+            gate.status = "approved"
+            gate.approved_head_sha = "sha-human-approved"
+            await s.commit()
+
+            with patch(
+                "app.services.gate_service.resolve_disposition",
+                AsyncMock(return_value=("allow_auto", "org_policy")),
+            ):
+                # CI fail 재평가가 들어와도(시스템 축 관점) — 사람 승인 anchor는 안 건드려야 함.
+                decision = await evaluate_merge_gate(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=99, repo="acme/repo", ci_result="fail", pr_result="pass",
+                    head_sha="sha-human-approved",
+                )
+                await s.commit()
+
+            gate = await _gate_row_by_story(s, seeded["story_id"])
+            # create_gate가 approved 게이트를 멱등 반환하므로 status는 그대로 approved 유지.
+            assert gate.status == "approved"
+            assert gate.approved_head_sha == "sha-human-approved"  # ⭐핵심 단언 — 안 지워짐.
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2813_gate_github_check_realdb.py
+++ b/backend/tests/test_2813_gate_github_check_realdb.py
@@ -291,3 +291,85 @@ async def test_reopen_gate_if_new_sha_noop_when_not_approved_realdb():
         assert flipped is False
     finally:
         await engine.dispose()
+
+
+# ── 카디르 QA(PR#3243, 2026-08-19) 레이스 회귀 — 실 재현 시나리오 ──────────────────────
+#
+# ①사람 승인(SHA A) 커밋 ②publish 태스크 실행 前 새 커밋(B)의 synchronize 도착
+# ③(구 코드) anchor가 아직 None이라 reopen 스킵 ④웹훅이 link.evidence.head_sha를 B로 갱신
+# ⑤뒤늦은 승인-publish가 B를 읽어 success 발행 — "A 승인이 B를 축복"하는 사고.
+# fix①(gates.py, 승인 트랜잭션에서 anchor 즉시 기록)+fix②(reopen이 anchor 없어도 재-pending)로
+# 막힌다 — 아래 두 테스트가 그 닫힘을 실측한다.
+
+
+@pytest.mark.anyio
+async def test_race_approval_background_task_uses_anchor_not_stale_link_evidence_realdb():
+    """fix① 실측 — gates.py가 승인 트랜잭션에서 이미 `approved_head_sha=A`를 박아둔 상태를
+    시뮬레이션(라우터 레벨 재현은 무거워 서비스 레벨에서 그 결과 상태로 시작). 그 사이 synchronize
+    가 link.evidence.head_sha를 B로 먼저 덮어써도(레이스 그대로 재현), 뒤늦게 도는 승인-publish
+    (head_sha 인자 없음 — gates.py 배경 태스크 호출 시그니처와 동일)는 **anchor(A)를 그대로 써야
+    한다** — B를 읽어 success를 발행하면(구 버그) 이 테스트가 실패한다."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.models.pull_request_story_link import PullRequestStoryLink
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            # fix①이 승인 트랜잭션에서 이미 확정했다고 가정하는 상태 그대로 시드.
+            seeded = await _seed(s, gate_status="approved", approved_head_sha="sha-A")
+
+        # 레이스 재현: synchronize 웹훅이 승인-publish보다 먼저 link.evidence를 B로 덮어씀.
+        async with Session() as s:
+            link = (
+                await s.execute(
+                    select(PullRequestStoryLink).where(PullRequestStoryLink.story_id == seeded["story_id"])
+                )
+            ).scalar_one()
+            link.evidence = {"head_sha": "sha-B"}
+            await s.commit()
+
+        # 뒤늦게 도는 승인-publish(gates.py 배경 태스크 — head_sha 인자 없이 호출).
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 7001}),
+        ) as create_mock, patch("app.core.database.async_session_factory", Session):
+            await publish_gate_check(seeded["org_id"], seeded["gate_id"])
+
+        # ⭐핵심 단언 — B가 아니라 A에 success가 발행돼야 한다.
+        assert create_mock.call_args.args[1:3] == ("acme/repo", "sha-A")
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            assert gate.approved_head_sha == "sha-A"  # B로 오염 안 됨.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_race_reopen_fail_closed_when_anchor_missing_despite_approved_realdb():
+    """fix② 실측 — anchor(approved_head_sha)가 비어있는데 status=approved인 legacy/이상 상태에서
+    synchronize가 오면, 구 코드(`if not gate.approved_head_sha: return False`)는 침묵 스킵했지만
+    fix 後엔 **재-pending 쪽으로**(fail-closed) 판정해야 한다."""
+    from app.models.gate import Gate
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="approved", approved_head_sha=None)
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "sha-new")
+            await s.commit()
+
+        assert flipped is True  # 구 코드라면 False(침묵 스킵)였을 것.
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            assert gate.status == "pending"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2813_gate_github_check_realdb.py
+++ b/backend/tests/test_2813_gate_github_check_realdb.py
@@ -45,7 +45,10 @@ async def _session_factory():
     return engine, async_sessionmaker(engine, expire_on_commit=False)
 
 
-async def _seed(session, *, gate_status="pending", approved_head_sha=None, github_check_run_id=None):
+async def _seed(
+    session, *, gate_status="pending", approved_head_sha=None,
+    github_check_run_id=None, github_check_run_sha=None,
+):
     from app.models.gate import Gate
     from app.models.github_installation import GithubInstallation
     from app.models.organization import Organization
@@ -68,6 +71,7 @@ async def _seed(session, *, gate_status="pending", approved_head_sha=None, githu
         id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
         gate_type=MERGE_GATE_TYPE, status=gate_status,
         approved_head_sha=approved_head_sha, github_check_run_id=github_check_run_id,
+        github_check_run_sha=github_check_run_sha,
     )
     session.add(gate)
 
@@ -142,7 +146,12 @@ async def test_publish_gate_check_approved_sets_conclusion_success_and_sha_attri
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            seeded = await _seed(s, gate_status="approved", github_check_run_id=9001)
+            # github_check_run_sha를 발행 대상 head_sha와 동일하게 시드해야(카디르 QA③-c 이후)
+            # PATCH(update_check_run) 경로를 탄다 — 다르면 새 run 생성 경로로 바뀐다(정상 동작,
+            # test_publish_gate_check_creates_new_run_for_different_sha_realdb가 그 축을 커버).
+            seeded = await _seed(
+                s, gate_status="approved", github_check_run_id=9001, github_check_run_sha="sha-approved-1",
+            )
 
         with patch(
             "app.services.gate_github_check.update_check_run",
@@ -223,6 +232,126 @@ async def test_publish_gate_check_never_raises_on_unexpected_exception_realdb():
 
 
 @pytest.mark.anyio
+async def test_publish_gate_check_skips_success_when_approved_but_anchor_missing_realdb():
+    """카디르 QA③-a — approved인데 anchor(approved_head_sha)가 없으면 link.evidence로
+    폴백해서 success를 발행하면 안 된다(anchor bypass). create_check_run이 아예 안 불려야 함."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.models.gate_github_check_event import GateGithubCheckEvent
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="approved", approved_head_sha=None)
+            # link.evidence에 다른 SHA가 있어도(레이스로 오염된 상황 재현) 이걸 못 쓰게 막는 것이 핵심.
+            from app.models.pull_request_story_link import PullRequestStoryLink
+
+            link = (
+                await s.execute(
+                    select(PullRequestStoryLink).where(PullRequestStoryLink.story_id == seeded["story_id"])
+                )
+            ).scalar_one()
+            link.evidence = {"head_sha": "sha-from-link-should-not-be-used"}
+            await s.commit()
+
+        with patch(
+            "app.services.gate_github_check.create_check_run", AsyncMock(return_value={"id": 1}),
+        ) as create_mock, patch("app.core.database.async_session_factory", Session):
+            await publish_gate_check(seeded["org_id"], seeded["gate_id"])  # head_sha 인자 없음.
+
+        create_mock.assert_not_awaited()
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
+            assert gate.github_check_run_id is None
+            events = (
+                await s.execute(select(GateGithubCheckEvent).where(GateGithubCheckEvent.gate_id == gate.id))
+            ).scalars().all()
+            assert events == []
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_creates_new_run_for_different_sha_realdb():
+    """카디르 QA③-c — 기존 check-run이 다른 SHA(github_check_run_sha)에 대한 것이면 PATCH가
+    아니라 새 run을 만든다(같은 run을 다른 SHA로 옮기면 required check가 그 SHA에서 영영 안 생김)."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(
+                s, gate_status="pending",
+                github_check_run_id=9001, github_check_run_sha="sha-old",
+            )
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 9002}),
+        ) as create_mock, patch(
+            "app.services.gate_github_check.update_check_run", AsyncMock(),
+        ) as update_mock, patch("app.core.database.async_session_factory", Session):
+            await publish_gate_check(
+                seeded["org_id"], seeded["gate_id"],
+                head_sha="sha-new", repo_full_name="acme/repo", pr_number=7,
+            )
+
+        create_mock.assert_awaited_once()  # 새 run 생성 — PATCH 아님.
+        update_mock.assert_not_awaited()
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
+            assert gate.github_check_run_id == 9002
+            assert gate.github_check_run_sha == "sha-new"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_updates_existing_run_for_same_sha_realdb():
+    """양성대조 — 같은 SHA면 여전히 PATCH(새 run 남발 안 함)."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(
+                s, gate_status="pending",
+                github_check_run_id=9001, github_check_run_sha="sha-same",
+            )
+
+        with patch(
+            "app.services.gate_github_check.create_check_run", AsyncMock(),
+        ) as create_mock, patch(
+            "app.services.gate_github_check.update_check_run",
+            AsyncMock(return_value={"id": 9001}),
+        ) as update_mock, patch("app.core.database.async_session_factory", Session):
+            await publish_gate_check(
+                seeded["org_id"], seeded["gate_id"],
+                head_sha="sha-same", repo_full_name="acme/repo", pr_number=7,
+            )
+
+        update_mock.assert_awaited_once()
+        create_mock.assert_not_awaited()
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
+            assert gate.github_check_run_id == 9001
+            assert gate.github_check_run_sha == "sha-same"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_reopen_gate_if_new_sha_flips_approved_to_pending_realdb():
     from app.models.gate import Gate
     from app.services.gate_github_check import reopen_gate_if_new_sha
@@ -236,7 +365,7 @@ async def test_reopen_gate_if_new_sha_flips_approved_to_pending_realdb():
 
         async with Session() as s:
             gate = await s.get(Gate, seeded["gate_id"])
-            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "new-sha")
+            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "new-sha", repo_full_name="acme/repo", pr_number=7)
             await s.commit()
 
         assert flipped is True
@@ -246,6 +375,24 @@ async def test_reopen_gate_if_new_sha_flips_approved_to_pending_realdb():
             assert gate.status == "pending"
             assert gate.approved_head_sha is None
             assert gate.github_check_run_id is None  # 새 SHA는 새 check-run(§2-2).
+            assert gate.github_check_run_sha is None
+
+        # 미르코군 그라운딩(doc gate-github-check-fe-grounding-2814 §3) 적출 — re_pending 원장
+        # 행이 실제로 남는지(구 코드는 상태만 리셋하고 원장은 전혀 안 씀).
+        async with Session() as s:
+            from sqlalchemy import select
+
+            from app.models.gate_github_check_event import GateGithubCheckEvent
+
+            events = (
+                await s.execute(
+                    select(GateGithubCheckEvent).where(GateGithubCheckEvent.gate_id == seeded["gate_id"])
+                )
+            ).scalars().all()
+            assert len(events) == 1
+            assert events[0].event_type == "re_pending"
+            assert events[0].head_sha == "new-sha"
+            assert events[0].check_conclusion is None
     finally:
         await engine.dispose()
 
@@ -263,7 +410,7 @@ async def test_reopen_gate_if_new_sha_noop_when_sha_matches_realdb():
 
         async with Session() as s:
             gate = await s.get(Gate, seeded["gate_id"])
-            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "same-sha")
+            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "same-sha", repo_full_name="acme/repo", pr_number=7)
 
         assert flipped is False
 
@@ -286,7 +433,7 @@ async def test_reopen_gate_if_new_sha_noop_when_not_approved_realdb():
 
         async with Session() as s:
             gate = await s.get(Gate, seeded["gate_id"])
-            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "any-sha")
+            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "any-sha", repo_full_name="acme/repo", pr_number=7)
 
         assert flipped is False
     finally:
@@ -363,7 +510,7 @@ async def test_race_reopen_fail_closed_when_anchor_missing_despite_approved_real
 
         async with Session() as s:
             gate = await s.get(Gate, seeded["gate_id"])
-            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "sha-new")
+            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "sha-new", repo_full_name="acme/repo", pr_number=7)
             await s.commit()
 
         assert flipped is True  # 구 코드라면 False(침묵 스킵)였을 것.

--- a/backend/tests/test_2813_gate_github_check_realdb.py
+++ b/backend/tests/test_2813_gate_github_check_realdb.py
@@ -667,11 +667,20 @@ async def _gate_row_by_story(session, story_id):
     return result.scalar_one_or_none()
 
 
+_STRONG_TRUST = {
+    # Wilson 하한(n=25,전부 hit)≈0.867 > DEFAULT_TRUST_THRESHOLD(0.8) — 실측 확認(_wilson_lower_bound).
+    "scores": [{"role_key": "dev", "hit": 25, "resolved": 25, "pending": 0, "hit_rate": 1.0}],
+}
+
+
 @pytest.mark.anyio
-async def test_evaluate_merge_gate_stamps_anchor_when_auto_passed_realdb():
-    """카디르 R2 fix②-a — 정책이 allow_auto로 판정하면(status=auto_passed) 그 결정 트랜잭션
-    에서 즉시 `approved_head_sha`가 head_sha로 확定돼야 한다(사람 승인과 동일 불변식)."""
-    from app.services.merge_verdict_gate import evaluate_merge_gate
+async def test_evaluate_merge_gate_stamps_anchor_only_when_decision_is_auto_merge_realdb():
+    """카디르 R3 HIGH — anchor는 `gate.status=="auto_passed"`(정책 disposition 축)가 아니라
+    **`_decide()`의 실 판정이 AUTO_MERGE일 때만** 확定돼야 한다(#2156이 이미 고정한 두 축
+    구분과 동일 원칙). trust_score를 mock해(25건 실seed 대신 — 이 테스트의 관심사는 trust
+    계산 자체가 아니라 anchor 배선 지점) 표본 충분+Wilson 하한 높음을 강제, decision=AUTO_MERGE
+    를 실제로 만든 뒤 anchor가 그 시점에 찍히는지 확認한다."""
+    from app.services.merge_verdict_gate import AUTO_MERGE, evaluate_merge_gate
 
     engine, Session = await _session_factory()
     try:
@@ -681,14 +690,18 @@ async def test_evaluate_merge_gate_stamps_anchor_when_auto_passed_realdb():
             with patch(
                 "app.services.gate_service.resolve_disposition",
                 AsyncMock(return_value=("allow_auto", "org_policy")),
+            ), patch(
+                "app.services.merge_verdict_gate.compute_member_trust_scores",
+                AsyncMock(return_value=_STRONG_TRUST),
             ):
-                await evaluate_merge_gate(
+                decision = await evaluate_merge_gate(
                     s, seeded["org_id"], seeded["story_id"],
                     pr_number=99, repo="acme/repo", ci_result="pass", pr_result="pass",
                     head_sha="sha-auto-1",
                 )
                 await s.commit()
 
+            assert decision.decision == AUTO_MERGE, f"테스트 전제 실패 — 실판정이 AUTO_MERGE가 아님: {decision.reason}"
             gate = await _gate_row_by_story(s, seeded["story_id"])
             assert gate.status == "auto_passed"
             assert gate.approved_head_sha == "sha-auto-1"  # ⭐핵심 단언.
@@ -697,10 +710,47 @@ async def test_evaluate_merge_gate_stamps_anchor_when_auto_passed_realdb():
 
 
 @pytest.mark.anyio
-async def test_evaluate_merge_gate_no_anchor_when_head_sha_unknown_realdb():
-    """양성대조 — head_sha를 모르는 호출자(board preflight류)는 anchor를 못 남긴다(발명 금지,
-    None 그대로) — publish_gate_check가 그 경우 success 발행을 skip하는 것과 짝을 이룬다."""
-    from app.services.merge_verdict_gate import evaluate_merge_gate
+async def test_evaluate_merge_gate_no_anchor_when_decision_is_auto_merge_but_head_sha_unknown_realdb():
+    """양성대조 — decision=AUTO_MERGE가 나더라도 head_sha를 모르는 호출자(board preflight류)는
+    anchor를 못 남긴다(발명 금지, None 그대로) — publish_gate_check가 그 경우 success 발행을
+    skip하는 것과 짝을 이룬다."""
+    from app.services.merge_verdict_gate import AUTO_MERGE, evaluate_merge_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+
+            with patch(
+                "app.services.gate_service.resolve_disposition",
+                AsyncMock(return_value=("allow_auto", "org_policy")),
+            ), patch(
+                "app.services.merge_verdict_gate.compute_member_trust_scores",
+                AsyncMock(return_value=_STRONG_TRUST),
+            ):
+                decision = await evaluate_merge_gate(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=99, repo="acme/repo", ci_result="pass", pr_result="pass",
+                    # head_sha 인자 생략 — None 기본값.
+                )
+                await s.commit()
+
+            assert decision.decision == AUTO_MERGE, f"테스트 전제 실패: {decision.reason}"
+            gate = await _gate_row_by_story(s, seeded["story_id"])
+            assert gate.status == "auto_passed"
+            assert gate.approved_head_sha is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_no_anchor_when_status_auto_passed_but_decision_ask_human_realdb():
+    """⭐카디르 R3 HIGH 핵심 재현 — `gate.status=="auto_passed"`(정책은 allow_auto)인데
+    outcome 표본 부족(cold-start, #2156 동형)으로 **실판정은 ASK_HUMAN**인 상태. 구 fix(R2
+    시점)는 `gate.status`만 보고 여기서 anchor를 찍어 "사람이 봐야 하는 SHA"에도 success가
+    나갈 수 있었다 — R3 fix 後엔 anchor가 안 남아야 한다(publish_gate_check가 자연히 success
+    발행을 skip)."""
+    from app.services.merge_verdict_gate import ASK_HUMAN, evaluate_merge_gate
 
     engine, Session = await _session_factory()
     try:
@@ -711,15 +761,18 @@ async def test_evaluate_merge_gate_no_anchor_when_head_sha_unknown_realdb():
                 "app.services.gate_service.resolve_disposition",
                 AsyncMock(return_value=("allow_auto", "org_policy")),
             ):
-                await evaluate_merge_gate(
+                # trust_score mock 없음 — 신규 participation은 outcome.resolved=0 <
+                # MIN_OUTCOME_SAMPLE(3) → cold-start ASK_HUMAN(_decide() AC④).
+                decision = await evaluate_merge_gate(
                     s, seeded["org_id"], seeded["story_id"],
                     pr_number=99, repo="acme/repo", ci_result="pass", pr_result="pass",
-                    # head_sha 인자 생략 — None 기본값.
+                    head_sha="sha-should-not-be-anchored",
                 )
                 await s.commit()
 
+            assert decision.decision == ASK_HUMAN, f"테스트 전제 실패: {decision.reason}"
             gate = await _gate_row_by_story(s, seeded["story_id"])
-            assert gate.status == "auto_passed"
-            assert gate.approved_head_sha is None
+            assert gate.status == "auto_passed"  # 정책 축 — allow_auto 그대로.
+            assert gate.approved_head_sha is None  # ⭐핵심 단언 — 구 fix라면 여기 SHA가 찍혔을 것.
     finally:
         await engine.dispose()

--- a/backend/tests/test_2813_gate_github_check_realdb.py
+++ b/backend/tests/test_2813_gate_github_check_realdb.py
@@ -1,0 +1,293 @@
+"""story #2813(Gate→GitHub required check) — gate_github_check.py 실 PG 영속 검증.
+
+github_app.py의 실 GitHub API 호출만 mock(checks:write 권한 미착지 — 설계 doc §2-4, PO 4/19
+확認: "라이브 AC는 권한 착지 후"), DB 왕복(migration 0262 컬럼/테이블·SHA 귀속·재-pending·원장)은
+전부 실 Postgres로 검증한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드(GateGithubCheckEvent 포함).
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session, *, gate_status="pending", approved_head_sha=None, github_check_run_id=None):
+    from app.models.gate import Gate
+    from app.models.github_installation import GithubInstallation
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+    from app.models.pull_request_story_link import PullRequestStoryLink
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="gate check target")
+    session.add(story)
+    await session.commit()
+
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+        gate_type=MERGE_GATE_TYPE, status=gate_status,
+        approved_head_sha=approved_head_sha, github_check_run_id=github_check_run_id,
+    )
+    session.add(gate)
+
+    installation = GithubInstallation(
+        id=uuid.uuid4(), org_id=org.id, installation_id=424242, account_login="acme",
+    )
+    session.add(installation)
+
+    link = PullRequestStoryLink(
+        id=uuid.uuid4(), org_id=org.id, story_id=story.id,
+        repo_full_name="acme/repo", pr_number=7, link_source="sid", confidence="high",
+    )
+    session.add(link)
+    await session.commit()
+    await session.refresh(gate)
+
+    return {"org_id": org.id, "story_id": story.id, "gate_id": gate.id}
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_creates_pending_check_and_ledger_row_realdb():
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.models.gate_github_check_event import GateGithubCheckEvent
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="pending")
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 9001}),
+        ) as create_mock, patch(
+            "app.core.database.async_session_factory", Session,
+        ):
+            await publish_gate_check(
+                seeded["org_id"], seeded["gate_id"],
+                head_sha="sha-pending-1", repo_full_name="acme/repo", pr_number=7,
+            )
+
+        create_mock.assert_awaited_once()
+        _, kwargs = create_mock.call_args
+        assert create_mock.call_args.args[1:3] == ("acme/repo", "sha-pending-1")
+        assert create_mock.call_args.kwargs["status"] == "in_progress"
+        assert create_mock.call_args.kwargs["conclusion"] is None
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
+            assert gate.github_check_run_id == 9001
+            assert gate.approved_head_sha is None  # pending이라 SHA 귀속 아직
+
+            events = (
+                await s.execute(select(GateGithubCheckEvent).where(GateGithubCheckEvent.gate_id == gate.id))
+            ).scalars().all()
+            assert len(events) == 1
+            assert events[0].event_type == "published"
+            assert events[0].head_sha == "sha-pending-1"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_approved_sets_conclusion_success_and_sha_attribution_realdb():
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="approved", github_check_run_id=9001)
+
+        with patch(
+            "app.services.gate_github_check.update_check_run",
+            AsyncMock(return_value={"id": 9001, "conclusion": "success"}),
+        ) as update_mock, patch(
+            "app.core.database.async_session_factory", Session,
+        ):
+            await publish_gate_check(
+                seeded["org_id"], seeded["gate_id"],
+                head_sha="sha-approved-1", repo_full_name="acme/repo", pr_number=7,
+            )
+
+        assert update_mock.call_args.kwargs["status"] == "completed"
+        assert update_mock.call_args.kwargs["conclusion"] == "success"
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
+            assert gate.approved_head_sha == "sha-approved-1"  # SHA 귀속(AC②) 실제 저장 확認.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_fail_closed_on_github_error_does_not_set_success_realdb():
+    """fail-closed(설계 doc §2-3) — create/update_check_run이 실패(None)하면 approved_head_sha도
+    ledger row도 안 남는다(요청 자체가 GitHub에 성공적으로 안 갔으므로)."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.models.gate_github_check_event import GateGithubCheckEvent
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="approved")
+
+        with patch(
+            "app.services.gate_github_check.create_check_run", AsyncMock(return_value=None),
+        ), patch("app.core.database.async_session_factory", Session):
+            await publish_gate_check(
+                seeded["org_id"], seeded["gate_id"],
+                head_sha="sha-fail-1", repo_full_name="acme/repo", pr_number=7,
+            )
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
+            assert gate.approved_head_sha is None
+            assert gate.github_check_run_id is None
+            events = (
+                await s.execute(select(GateGithubCheckEvent).where(GateGithubCheckEvent.gate_id == gate.id))
+            ).scalars().all()
+            assert events == []
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_never_raises_on_unexpected_exception_realdb():
+    """fail-closed 최종 경계 — 예측 못 한 예외도 삼킨다(백그라운드 태스크는 절대 안 죽는다)."""
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="approved")
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(side_effect=RuntimeError("boom")),
+        ), patch("app.core.database.async_session_factory", Session):
+            await publish_gate_check(  # 예외 없이 반환돼야 함(raise 안 함).
+                seeded["org_id"], seeded["gate_id"],
+                head_sha="sha-x", repo_full_name="acme/repo", pr_number=7,
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reopen_gate_if_new_sha_flips_approved_to_pending_realdb():
+    from app.models.gate import Gate
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(
+                s, gate_status="approved", approved_head_sha="old-sha", github_check_run_id=9001,
+            )
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "new-sha")
+            await s.commit()
+
+        assert flipped is True
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            assert gate.status == "pending"
+            assert gate.approved_head_sha is None
+            assert gate.github_check_run_id is None  # 새 SHA는 새 check-run(§2-2).
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reopen_gate_if_new_sha_noop_when_sha_matches_realdb():
+    """양성대조 — SHA가 같으면 재-pending 안 한다(vacuous하게 항상 flip하는 버그 방지)."""
+    from app.models.gate import Gate
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="approved", approved_head_sha="same-sha")
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "same-sha")
+
+        assert flipped is False
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            assert gate.status == "approved"  # 무회귀.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reopen_gate_if_new_sha_noop_when_not_approved_realdb():
+    from app.models.gate import Gate
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="pending")
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            flipped = await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "any-sha")
+
+        assert flipped is False
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2813_github_checks_api.py
+++ b/backend/tests/test_2813_github_checks_api.py
@@ -1,0 +1,108 @@
+"""story #2813(Gate→GitHub required check) — Checks API 클라이언트 단위(mock, 실서버 0).
+
+github_app.py의 App JWT/installation token은 test_github_app_bot_s.py가 이미 커버 — 여기는
+create_check_run/update_check_run만(신규 함수, 그라운딩 doc §1에서 확認한 "repo 전수 0건").
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import github_app as ga
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _seed_token_cache():
+    ga._token_cache[999] = ("cached-tok", time.time() + 3600)
+    yield
+    ga._token_cache.clear()
+
+
+def _resp(status_code: int, body: dict):
+    return type("R", (), {"status_code": status_code, "json": lambda self: body})()
+
+
+@pytest.mark.anyio
+async def test_create_check_run_sends_correct_payload_and_returns_result():
+    r = _resp(201, {"id": 555, "status": "in_progress"})
+    captured = {}
+
+    async def _post(self, url, headers=None, json=None):
+        captured["url"] = url
+        captured["json"] = json
+        return r
+
+    with patch("httpx.AsyncClient.post", new=_post):
+        result = await ga.create_check_run(999, "acme/repo", "abc123", status="in_progress")
+
+    assert result == {"id": 555, "status": "in_progress"}
+    assert captured["url"] == "https://api.github.com/repos/acme/repo/check-runs"
+    assert captured["json"]["name"] == "sprintable/gate"
+    assert captured["json"]["head_sha"] == "abc123"
+    assert captured["json"]["status"] == "in_progress"
+    assert "conclusion" not in captured["json"]  # in_progress엔 conclusion 없음(GitHub API 제약).
+
+
+@pytest.mark.anyio
+async def test_create_check_run_completed_includes_conclusion():
+    r = _resp(201, {"id": 556})
+    captured = {}
+
+    async def _post(self, url, headers=None, json=None):
+        captured["json"] = json
+        return r
+
+    with patch("httpx.AsyncClient.post", new=_post):
+        await ga.create_check_run(999, "acme/repo", "sha1", status="completed", conclusion="success")
+
+    assert captured["json"]["status"] == "completed"
+    assert captured["json"]["conclusion"] == "success"
+
+
+@pytest.mark.anyio
+async def test_create_check_run_http_failure_returns_none_not_raise():
+    r = _resp(500, {})
+    with patch("httpx.AsyncClient.post", new=AsyncMock(return_value=r)):
+        result = await ga.create_check_run(999, "acme/repo", "sha1")
+    assert result is None  # fail-closed: 예외 없이 None — 호출자가 "GitHub 쪽 무영향"으로 처리.
+
+
+@pytest.mark.anyio
+async def test_create_check_run_no_token_returns_none():
+    ga._token_cache.clear()
+    with patch.object(ga, "build_app_jwt", return_value=None):
+        result = await ga.create_check_run(999, "acme/repo", "sha1")
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_update_check_run_patches_correct_url():
+    r = _resp(200, {"id": 555, "status": "completed", "conclusion": "success"})
+    captured = {}
+
+    async def _patch(self, url, headers=None, json=None):
+        captured["url"] = url
+        captured["json"] = json
+        return r
+
+    with patch("httpx.AsyncClient.patch", new=_patch):
+        result = await ga.update_check_run(999, "acme/repo", 555, status="completed", conclusion="success")
+
+    assert result["id"] == 555
+    assert captured["url"] == "https://api.github.com/repos/acme/repo/check-runs/555"
+    assert captured["json"]["conclusion"] == "success"
+
+
+@pytest.mark.anyio
+async def test_update_check_run_http_failure_returns_none_not_raise():
+    r = _resp(404, {})
+    with patch("httpx.AsyncClient.patch", new=AsyncMock(return_value=r)):
+        result = await ga.update_check_run(999, "acme/repo", 555, status="completed", conclusion="failure")
+    assert result is None

--- a/backend/tests/test_gate_can_approve_48f064e5.py
+++ b/backend/tests/test_gate_can_approve_48f064e5.py
@@ -54,7 +54,9 @@ async def _call(resolved, *, execute_results, has_access=None, status="approved"
     # 를 1회 더 호출한다(risk_grade 사유-강제 가드) — side_effect 리스트 끝에 그 몫을 추가. 이 파일의
     # 관심사(project-access/self-approval authz)와 무관하므로 결과값은 무의미(None으로 충분).
     session.execute = AsyncMock(side_effect=[*execute_results, _result(None)])
-    transition = AsyncMock(return_value=SimpleNamespace())
+    # story #2813: 엔드포인트가 commit 後 publish_gate_check 배경 태스크 예약에 gate.id 를 읽는다
+    # (백그라운드 태스크 자체는 이 테스트에서 실행되지 않음 — BackgroundTasks().add_task 는 큐잉만).
+    transition = AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4()))
     auth = SimpleNamespace(user_id=str(uuid.uuid4()))
     patches = [
         patch.object(gates_mod, "resolve_member", AsyncMock(return_value=resolved)),

--- a/backend/tests/test_gate_can_approve_48f064e5.py
+++ b/backend/tests/test_gate_can_approve_48f064e5.py
@@ -54,9 +54,12 @@ async def _call(resolved, *, execute_results, has_access=None, status="approved"
     # 를 1회 더 호출한다(risk_grade 사유-강제 가드) — side_effect 리스트 끝에 그 몫을 추가. 이 파일의
     # 관심사(project-access/self-approval authz)와 무관하므로 결과값은 무의미(None으로 충분).
     session.execute = AsyncMock(side_effect=[*execute_results, _result(None)])
-    # story #2813: 엔드포인트가 commit 後 publish_gate_check 배경 태스크 예약에 gate.id 를 읽는다
-    # (백그라운드 태스크 자체는 이 테스트에서 실행되지 않음 — BackgroundTasks().add_task 는 큐잉만).
-    transition = AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4()))
+    # story #2813: 엔드포인트가 commit 前 gate.gate_type 을 읽어 merge 게이트인지 판정하고(anchor
+    # 기록 여부), commit 後 publish_gate_check 배경 태스크 예약에 gate.id 를 읽는다(태스크 자체는
+    # 이 테스트에서 실행 안 됨 — BackgroundTasks().add_task 는 큐잉만). gate_type을 "merge"가 아닌
+    # 값으로 둬 anchor 기록 분기(resolve_pr_link 추가 조회)를 건너뛴다 — 이 파일의 관심사(doc-gate
+    # authz)와 무관.
+    transition = AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4(), gate_type="merge_approval"))
     auth = SimpleNamespace(user_id=str(uuid.uuid4()))
     patches = [
         patch.object(gates_mod, "resolve_member", AsyncMock(return_value=resolved)),

--- a/backend/tests/test_gate_transition_human_only.py
+++ b/backend/tests/test_gate_transition_human_only.py
@@ -48,9 +48,12 @@ async def _call(status: str, member_type: str):
         gate_type="merge_approval", work_item_type="story", work_item_id=uuid.uuid4(),
     )
     session.execute = AsyncMock(return_value=_gr)
-    # story #2813: 엔드포인트가 commit 後 publish_gate_check 배경 태스크 예약에 gate.id 를 읽는다
-    # (백그라운드 태스크 자체는 이 테스트에서 실행되지 않음 — BackgroundTasks().add_task 는 큐잉만).
-    transition = AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4()))
+    # story #2813: 엔드포인트가 commit 前 gate.gate_type 을 읽어 merge 게이트인지 판정하고(anchor
+    # 기록 여부), commit 後 publish_gate_check 배경 태스크 예약에 gate.id 를 읽는다(태스크 자체는
+    # 이 테스트에서 실행 안 됨 — BackgroundTasks().add_task 는 큐잉만). gate_type을 "merge"가 아닌
+    # 값으로 둬 anchor 기록 분기(resolve_pr_link 추가 조회)를 건너뛴다 — 이 파일의 관심사(human-vs-
+    # agent authz)와 무관.
+    transition = AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4(), gate_type="merge_approval"))
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved(member_type))), \
          patch.object(gates_mod, "transition_gate", transition), \
          patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)), \

--- a/backend/tests/test_gate_transition_human_only.py
+++ b/backend/tests/test_gate_transition_human_only.py
@@ -48,7 +48,9 @@ async def _call(status: str, member_type: str):
         gate_type="merge_approval", work_item_type="story", work_item_id=uuid.uuid4(),
     )
     session.execute = AsyncMock(return_value=_gr)
-    transition = AsyncMock(return_value=SimpleNamespace())
+    # story #2813: 엔드포인트가 commit 後 publish_gate_check 배경 태스크 예약에 gate.id 를 읽는다
+    # (백그라운드 태스크 자체는 이 테스트에서 실행되지 않음 — BackgroundTasks().add_task 는 큐잉만).
+    transition = AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4()))
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved(member_type))), \
          patch.object(gates_mod, "transition_gate", transition), \
          patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)), \

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -179,7 +179,7 @@ def test_wilson_lower_bound_sample_aware():
 def _patch_cage(*, gate_status="auto_passed", trust_scores=None, capture=None, participation=True,
                  project_id=None):
     part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4()) if participation else None
-    gate = SimpleNamespace(id=uuid.uuid4(), status=gate_status, evidence_status=None)
+    gate = SimpleNamespace(id=uuid.uuid4(), status=gate_status, evidence_status=None, approved_head_sha=None)
     ctx = [
         patch.object(mod, "resolve_implementation_participation", AsyncMock(return_value=part)),
         patch.object(mod, "_role_key", AsyncMock(return_value="implementation")),
@@ -298,7 +298,7 @@ async def test_trust_computed_before_capture_records():
          patch.object(mod, "compute_member_trust_scores", side_effect=_trust), \
          patch.object(mod, "capture_pr_ci_verdict", side_effect=_capture), \
          patch.object(mod, "resolve_work_item_project_id", AsyncMock(return_value=uuid.uuid4())), \
-         patch.object(mod, "create_gate", AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4(), status="auto_passed", evidence_status=None))):
+         patch.object(mod, "create_gate", AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4(), status="auto_passed", evidence_status=None, approved_head_sha=None))):
         await evaluate_merge_gate(AsyncMock(), uuid.uuid4(), uuid.uuid4(), pr_number=1, repo="o/r", ci_result="pass")
 
     assert order == ["trust", "capture"], f"trust must precede capture, got {order}"
@@ -380,6 +380,7 @@ async def test_evaluate_persists_decision_metadata_on_gate():
     gate = SimpleNamespace(
         id=uuid.uuid4(), status="pending",
         requires_human=False, evidence_status=None, decision_basis=None, auto_decision_reason=None,
+        approved_head_sha=None,
     )
     part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4())
     with patch("app.services.merge_verdict_gate.resolve_implementation_participation",
@@ -405,7 +406,8 @@ async def test_evaluate_persists_decision_metadata_on_gate():
 @pytest.mark.anyio
 async def test_evaluate_auto_merge_metadata_sufficient():
     gate = SimpleNamespace(id=uuid.uuid4(), status="auto_passed",
-                           requires_human=True, evidence_status=None, decision_basis=None, auto_decision_reason=None)
+                           requires_human=True, evidence_status=None, decision_basis=None, auto_decision_reason=None,
+                           approved_head_sha=None)
     part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4())
     with patch("app.services.merge_verdict_gate.resolve_implementation_participation", AsyncMock(return_value=part)), \
          patch("app.services.merge_verdict_gate._role_key", AsyncMock(return_value="implementation")), \
@@ -513,7 +515,7 @@ async def _run_substance(*, ci_result, pr_number, disposition, source="system_de
     if explicit is None:
         explicit = source != "system_default"  # 기존 테스트들의 암묵 기대(하위호환 기본값)
     part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4())
-    gate = SimpleNamespace(id=uuid.uuid4(), status="pending", evidence_status=None)
+    gate = SimpleNamespace(id=uuid.uuid4(), status="pending", evidence_status=None, approved_head_sha=None)
     with contextlib.ExitStack() as stack:
         stack.enter_context(patch.object(mod, "resolve_implementation_participation",
                                          AsyncMock(return_value=part)))

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -24,6 +24,13 @@ def _non_doc_gate_session():
     gr = MagicMock()
     gr.scalar_one_or_none.return_value = SimpleNamespace(
         gate_type="merge", work_item_type="story", work_item_id=uuid.uuid4(),
+        # story #2813 — session.execute가 단일 고정 return_value라, gates.py의 신규
+        # resolve_pr_link(SELECT PullRequestStoryLink) 호출도 이 같은 목을 되돌려 받는다
+        # (이 파일의 관심사는 resolver_id 강제이지 PR 링크 조회가 아님). `.evidence`가 없으면
+        # gates.py의 anchor 기록 분기(status=="approved" and gate_type=="merge"에서 항상 발동
+        # — 이 목의 gate_type이 정확히 "merge")가 AttributeError로 죽는다 — None으로 명시해
+        # "링크 없음/head_sha 미상"과 동형 무해 경로를 타게 한다.
+        evidence=None,
     )
     s.execute = AsyncMock(return_value=gr)
     return s


### PR DESCRIPTION
## Summary
설계 카드([설계 카드] Gate → GitHub required check 서버측 강제 계층, doc c1855e0d) 승인(선생님 2026-08-19 "승인하는. 완주 바라는.") 1단 범위 ①②③의 BE 본체. 그라운딩·설계 doc(`gate-github-required-check-grounding-design-2813`) PO 승인 4건(①push 대신 pull_request.synchronize ②Gate 컬럼+신규 원장 ③fail-closed 정의 ④권한/branch protection은 PO 인수) 그대로 구현.

## 신설
- `0262` 마이그: `gate.github_check_run_id`(BigInteger)·`gate.github_check_run_sha`(Text, "SHA당 run 1개" 강제)·`gate.approved_head_sha`(Text, SHA 귀속 AC②) + 신규 원장 `gate_github_check_event`(AC④, append-only — 기존 audit 3종은 전부 목적 안 맞아 재사용 부적합, 그라운딩 §1에서 확認).
- `github_app.py::create_check_run`/`update_check_run` — installation token 재사용(신규 API 표면, 그라운딩에서 repo 전수 0건 확認).
- `gate_github_check.py`(신규 서비스):
  - `publish_gate_check` — gate.status→GitHub Checks(status,conclusion) 매핑, fail-closed. approved/auto_passed에서 success를 받을 수 있는 SHA는 **anchor(gate.approved_head_sha) 단 하나**(인자 head_sha 유무 무관 불변식 — QA R2). anchor 없으면 skip, 인자가 anchor와 다르면 skip(그 상황은 재-pending 영역).
  - `reopen_gate_if_new_sha` — SHA 재-pending(§2-2). `resolve_gate_from_verdict`(시스템 자동판정)와 동일한 경량 경로(`set_gate_status` 직접)를 재사용. approved/auto_passed 둘 다 대상(QA R4).
  - `resolve_pr_link` — gates.py(사람 승인)와 verdict_capture.py(웹훅) 공유 헬퍼.

## 배선(chokepoint 2곳)
1. `gates.py::transition_gate_endpoint`(사람 승인/반려) — **승인 트랜잭션에서 즉시** anchor 확定(commit 前, QA R2 레이스 fix) + commit 後 background_tasks로 `publish_gate_check` 예약.
2. `verdict_capture.py::_process_webhook_event` — `pull_request` action `opened`/`reopened`/`ready_for_review`/`synchronize` 신설 분기(4액션 전부 재-pending 가드, QA R2③-b). synchronize는 SHA 재-pending도 겸함. GitHub 발행은 `gate_check_publish` outparam으로 모아 commit 後에만 발화.
3. `merge_verdict_gate.py::evaluate_merge_gate` — auto-pass anchor는 `gate.status=="auto_passed"`(정책 축)가 아니라 **`_decide()` 실 판정이 AUTO_MERGE일 때만** 확定(QA R3, #2156이 이미 고정한 두 축 구분 재적용). 재평가로 decision이 AUTO_MERGE를 이탈하면 anchor 무효화 — 단 사람 승인(status=="approved") anchor는 시스템 재평가가 절대 못 건드림(QA R4①, 안전경계 양성대조 테스트 포함).

## QA 라운드 요약(카디르군, R2~R4 전부 반영·재검증 대기)
- R2 CRITICAL: anchor 검증이 "head_sha 인자 None일 때만" 걸려 웹훅 경로(항상 명시 전달)가 전부 우회 — 불변식으로 재정의해 닫음.
- R3 HIGH: anchor 확定 지점이 정책 축(`auto_passed`)이 아니라 실 판정 축(`AUTO_MERGE`)이어야 함 — 이동.
- R4①(HIGH, 반영): 재평가로 decision이 AUTO_MERGE 이탈 시 auto-axis anchor 무효화, 사람 승인 axis는 절대 불가침.
- **R4②(범위 밖 처분 — 여기 명기, 카디르군 확認 요청)**: `reconcile_merge_gate_with_real_evidence`의 `pr_result=("pass" if merged else None)`가 "required check 모드에서 pre-merge 시점엔 auto-pass 정책이 구조적으로 AUTO_MERGE를 낼 수 없다"(순환 의존)는 지적 — **git log -S로 계보 확認: story #2156(PR#2902, commit 6af6111f4)에서 이미 존재하던 기존 설계, 이 PR 신설 아님**. PO 판정: 코드 결함이 아니라 "pr_result를 pre-merge 축으로 재정의해야 하는" 설계 질문 — 현재 fail-closed(auto 게이트가 pending 유지→사람 승인 요구)라 안전 방향, 1단 출하를 막지 않음. **story #2817로 별도 등재**(설계 카드 §3 "이중 클릭 제거" 축과 인접한 후속).
- CI 실패 1건(무관 목 충돌, `test_rc1_body_trust_actor.py`) — resolve_pr_link 신규 호출과 목 공유 충돌, `.evidence=None` 보강으로 해소.

## 스코프 밖(§2-4 PO 인수 + 이번 PR 명시적 미포함)
- `checks:write` 권한 추가(GitHub App 설정 UI, App=sprintable-dev ID 4120278) + customer-zero branch protection 등록 — PO가 실측 후 인수.
- `void_gate` 훅 미배선 — 이번 PR은 사람 승인/반려 + PR 라이프사이클 + auto-pass 세 축(AC①③의 핵심 경로). 후속 커밋 대상.
- 한 story에 PR 링크가 여럿이면 최신 1건만 발행(다중-PR 동시추적은 후속).
- story #2815(원장 조회 엔드포인트·관측모드 판별 필드, 미르코군 FE 계약)·story #2816(gate.status="auto_passed" 오인 소비처 전수)·story #2817(pr_result 순환) — 전부 별도 등재, 이 PR 범위 밖.

## Test plan(mock 기반 — checks:write 미착지라 라이브 AC①~③은 권한 착지 後 별도 실측, PO 확認됨)
- [x] 신규/보강 테스트(gate_github_check 실PG 20+건 — 최초 발행·원장 3축(published/re_pending/resolved)·fail-closed 2종·SHA당 run 1개(신규/PATCH 양성대조)·R2 레이스 재현 2건·R3 auto_merge 판정 축 3건·R4① 소거+안전경계 2건) + Checks API 클라이언트 6건.
- [x] alembic `0262`까지 실 PG 클린 마이그 — 컬럼/테이블 실측 확認.
- [x] 회귀 스윕 최종: gate/webhook/merge-verdict/checks-api 169 tests + 넓은 mock 스윕 444 tests 전부 green. 영향받은 기존 mock(gate.id·gate.gate_type·gate.approved_head_sha·link.evidence 신규 접근) 총 9개 파일 보강.
- [x] 회귀 스윕 중 **무관한 기존 버그** 발견(미수정, 범위 밖 — 에러 시그니처로 확認): `test_2198_non_doc_gate_authz_realdb.py`/`test_2237_gate_create_project_scope_realdb.py`의 raw SQL `INSERT INTO projects`가 `violation_level` NOT NULL 컬럼 누락(스키마 드리프트, 이 PR의 diff와 무관).
- [ ] AC①②③(dev 저장소 실왕복·재-pending 라이브·fail-closed 실측)·AC⑤(customer-zero) — checks:write 권한 착지 後 별도 실측(PO 인수).

🤖 Generated with [Claude Code](https://claude.com/claude-code)