### PR TITLE
feat(#2815): gate_github_check_event 원장 조회 엔드포인트 + 관측모드 판별 필드

### DIFF
--- a/backend/alembic/versions/0263_github_installation_enforced_check_repos.py
+++ b/backend/alembic/versions/0263_github_installation_enforced_check_repos.py
@@ -1,0 +1,39 @@
+"""story #2815(§5-④, Gate→GitHub required check 관측모드 판별) —
+`github_installation.enforced_check_repos` 신설.
+
+배경: story #2813로 `sprintable/gate` check 발행 자체는 만들어졌지만, `gate.github_check_run_id`
+가 계속 null인 이유(①check가 아직 발행 안 됨 vs ②이 저장소가 애초에 branch protection에
+required로 등록 안 된 "관측모드"라 영원히 null)를 FE가 구분할 방법이 없었다(미르코군 그라운딩
+doc gate-github-check-fe-grounding-2814 §5-④ 적출).
+
+설계 판단(디디군, 2026-08-20) — GitHub branch-protection API 실측 조회 대신 **수동 플래그**:
+실측 조회는 `administration:read`라는 story #2813 §2-4의 `checks:write`와 별개 신규 권한이
+필요해 승인 마찰을 배로 늘린다. PO가 이미 "check 실발행 시작 後에만 branch protection을 건다"는
+순서를 직접 통제하므로(story #2813 R4) 그 등록 시점을 PO 자신이 정확히 아는 유일한 주체다 —
+라이브 API 실측 전환은 후속(stale 위험 트레이드오프는 문서화).
+
+Revision ID: 0263
+Revises: 0262
+Create Date: 2026-08-20
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0263"
+down_revision = "0262"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "github_installation",
+        sa.Column("enforced_check_repos", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("github_installation", "enforced_check_repos")

--- a/backend/app/models/github_installation.py
+++ b/backend/app/models/github_installation.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import BigInteger, DateTime, ForeignKey, String, UniqueConstraint, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -33,6 +33,16 @@ class GithubInstallation(Base):
     account_login: Mapped[str | None] = mapped_column(String(255), nullable=True)
     account_type: Mapped[str | None] = mapped_column(String(32), nullable=True)  # Organization | User
     repository_selection: Mapped[str | None] = mapped_column(String(16), nullable=True)  # all | selected
+    # story #2815(§5-④, 관측모드 판별) — `sprintable/gate`를 GitHub branch protection에
+    # required로 등록한 repo 목록("owner/repo" 문자열). ⚠️설계 판단(디디군, 2026-08-20): GitHub
+    # branch-protection API 실측 조회 대신 **수동 플래그**를 택했다 — 실측 조회는
+    # `administration:read`라는 checks:write와 별개 신규 권한이 필요해(story #2813 §2-4가 이미
+    # checks:write 하나로도 승인 지연 중) 승인 마찰을 배로 늘린다. 또한 PO가 이미 "check 실발행
+    # 시작 後에만 branch protection을 건다"는 순서를 직접 통제하고 있어(story #2813 R4 PO 코멘트)
+    # 그 등록 시점을 PO 자신이 정확히 아는 유일한 주체다 — 그 사실을 코드가 재조회하는 것보다
+    # PO가 그대로 반영하는 편이 더 정확하고 저비용. 라이브 API 실측으로 전환은 후속(값이 stale해질
+    # 위험을 감수하는 트레이드오프 — PO/운영이 등록 직후 갱신 안 하면 그새 조회는 부정확).
+    enforced_check_repos: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
     suspended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -985,6 +985,10 @@ async def list_gate_github_check_events_endpoint(
     elif not is_known_project_agnostic_work_item_type(gate.work_item_type):
         raise HTTPException(status_code=404, detail="Gate not found")
 
+    # ⛔카디르 QA(PR#3245, 비차단·후속 메모) — created_at 단독 정렬은 같은 밀리초에 여러 행이
+    # 찍히면(이론상 가능 — 같은 트랜잭션 내 다중 이벤트) 동순위 tie 순서가 비결정적이다. 이
+    # 원장은 이벤트가 gate당 소량·거의 항상 시간差가 있어 실무 영향은 낮다고 판단해 이번엔
+    # 그대로 두되, 재발하면 `id`를 2차 정렬키로 추가할 것(UUID는 시간순 아니라 tie-break 용도).
     rows = (await session.execute(
         select(GateGithubCheckEvent)
         .where(GateGithubCheckEvent.gate_id == id, GateGithubCheckEvent.org_id == org_id)

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -13,11 +13,12 @@ from app.dependencies.auth import get_current_user, get_scope_context, get_verif
 from app.dependencies.database import get_db
 from app.models.doc import Doc
 from app.models.gate import Gate, is_valid_transition
+from app.models.gate_github_check_event import GateGithubCheckEvent
 from app.models.hitl import HitlRequest
 from app.models.pm import Story, Task
 from app.models.visual_artifact import VisualArtifact
 from app.routers.agent_gateway import wake_agent
-from app.services.gate_github_check import publish_gate_check, resolve_pr_link
+from app.services.gate_github_check import is_repo_check_enforced, publish_gate_check, resolve_pr_link
 from app.services.merge_verdict_gate import MERGE_GATE_TYPE
 from app.services.gate_service import (
     GateUndoNotSelfError,
@@ -169,6 +170,12 @@ class GateResponse(BaseModel):
     # 이미 있는 컬럼 그대로 — additive·nullable(merge 게이트 아니거나 아직 미발행이면 None).
     github_check_run_id: int | None = None
     approved_head_sha: str | None = None
+    # story #2815(§5-④, 관측모드 판별) — `github_check_run_id`가 계속 null인 이유를 FE가
+    # 구분하게: True면 "이 repo는 required check 등록됨(발행 대기/진행 중)", False/None이면
+    # "이 repo는 애초에 관측모드"로 해석. additive·기본 None(get_gate_endpoint만 채움 — list_gates
+    # 등 타 엔드포인트는 PR 링크 N+1 조회 비용 때문에 스코프 밖, risk_grade/can_approve와 동일
+    # 선례 — Gate ORM에 이 속성이 없어 from_attributes 기본값으로 조용히 통과).
+    github_check_enforced: bool | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -902,6 +909,12 @@ async def get_gate_endpoint(
     # 미경유) + 이 gate의 gate_type을 derive_risk_grade()로 파생(doc §2 SSOT).
     _posture = await get_org_posture(session, org_id)
     resp.risk_grade = derive_risk_grade(_posture, gate.gate_type)
+    # story #2815(§5-④): merge 게이트만 의미 있음(다른 gate_type은 PR/repo 개념 자체가 없음).
+    if gate.gate_type == MERGE_GATE_TYPE:
+        _link = await resolve_pr_link(session, org_id, gate.work_item_id)
+        resp.github_check_enforced = await is_repo_check_enforced(
+            session, org_id, _link.repo_full_name if _link else None,
+        )
     # story #2198(까심 QA 적출·오르테가 확定): can_approve 가 이 엔드포인트에선 **전혀 계산되지
     # 않고** 있었다(docstring 이 enrich 목록에 project_id/work_item_summary/risk_grade 만 적어
     # 뒀던 것 자체가 증거) — doc_approval·non-doc 가릴 것 없이 Pydantic 기본값 False 가 그대로
@@ -926,6 +939,58 @@ async def get_gate_endpoint(
             _approvable = await _non_doc_can_approve(session, gate.gate_type, _uid, org_id, project_id)
             resp.can_approve = _approvable and is_valid_transition(gate.status, "approved")
     return resp
+
+
+class GateGithubCheckEventResponse(BaseModel):
+    """story #2815(§5-②, 미르코군 계약 제안) — `gate_github_check_event`(0262) raw 원장 뷰.
+    org_id/gate_id/story_id는 생략(이미 URL의 `{id}`가 gate 컨텍스트를 특정 — 중복 노출 불요)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    repo_full_name: str
+    pr_number: int
+    head_sha: str
+    event_type: str  # published | re_pending | resolved
+    check_conclusion: str | None
+    created_at: datetime
+
+
+@router.get("/{id}/github-check-events", response_model=list[GateGithubCheckEventResponse])
+async def list_gate_github_check_events_endpoint(
+    id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> list[GateGithubCheckEventResponse]:
+    """story #2815(§5-②) — GitHub check 발행/재-pending/해소 원장(AC④, story #2813) 조회.
+    `GateEvidence`(FE)가 "check 상태·전이 이력" 섹션에서 지연 로드하는 용도 — 소량(gate당
+    보통 수 건)이라 페이지네이션 없이 최신순 전체 반환.
+
+    authz는 `get_gate_endpoint`와 **동일 패턴**(존재 비노출 — project 무권한도 404, 403 아님)을
+    그대로 재사용한다: 이 원장은 gate의 세부 정보이지 별도 리소스가 아니므로 gate 조회와 같은
+    접근권이어야 한다(gate는 보이는데 원장은 막히는 비대칭 방지)."""
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise HTTPException(status_code=404, detail="Gate not found")
+
+    project_id = await resolve_work_item_project_id(
+        session, org_id, gate.work_item_type, gate.work_item_id,
+    )
+    if project_id is not None:
+        await require_project_access(session, uuid.UUID(auth.user_id), project_id, org_id,
+                                      not_found_detail="Gate not found")
+    elif not is_known_project_agnostic_work_item_type(gate.work_item_type):
+        raise HTTPException(status_code=404, detail="Gate not found")
+
+    rows = (await session.execute(
+        select(GateGithubCheckEvent)
+        .where(GateGithubCheckEvent.gate_id == id, GateGithubCheckEvent.org_id == org_id)
+        .order_by(GateGithubCheckEvent.created_at.desc())
+    )).scalars().all()
+    return [GateGithubCheckEventResponse.model_validate(r) for r in rows]
 
 
 @router.post("/{id}/transition", response_model=GateResponse)

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -83,7 +83,11 @@ async def is_repo_check_enforced(
     """story #2815(§5-④, 관측모드 판별) — 이 repo가 `sprintable/gate`를 branch protection에
     required로 등록했는지. `github_installation.enforced_check_repos`(수동 플래그, PO 운영
     — 설계 근거는 0263 마이그·모델 주석) 조회. installation 없음/미설정/repo 없음이면 전부
-    False(관측모드 아님을 확언하는 게 아니라 "모른다≈아직 강제 아님"의 안전한 기본값)."""
+    False(관측모드 아님을 확언하는 게 아니라 "모른다≈아직 강제 아님"의 안전한 기본값).
+
+    카디르 QA(PR#3245) — `enforced_check_repos`는 PO가 손으로 적는 값이라 대소문자 불일치가
+    실전에서 가장 먼저 나는 함정이다("Acme/Repo" vs "acme/repo"). 양쪽을 `.lower()`로
+    정규화 후 비교 — GitHub의 `owner/repo`는 대소문자 무관 동일 저장소를 가리킨다."""
     if not repo_full_name:
         return False
     row = (
@@ -94,7 +98,10 @@ async def is_repo_check_enforced(
             )
         )
     ).scalar_one_or_none()
-    return bool(row) and repo_full_name in row
+    if not row:
+        return False
+    normalized = {r.lower() for r in row if isinstance(r, str)}
+    return repo_full_name.lower() in normalized
 
 
 async def publish_gate_check(

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -77,6 +77,26 @@ async def _resolve_installation_id(session: AsyncSession, org_id: uuid.UUID) -> 
     return row
 
 
+async def is_repo_check_enforced(
+    session: AsyncSession, org_id: uuid.UUID, repo_full_name: str | None,
+) -> bool:
+    """story #2815(§5-④, 관측모드 판별) — 이 repo가 `sprintable/gate`를 branch protection에
+    required로 등록했는지. `github_installation.enforced_check_repos`(수동 플래그, PO 운영
+    — 설계 근거는 0263 마이그·모델 주석) 조회. installation 없음/미설정/repo 없음이면 전부
+    False(관측모드 아님을 확언하는 게 아니라 "모른다≈아직 강제 아님"의 안전한 기본값)."""
+    if not repo_full_name:
+        return False
+    row = (
+        await session.execute(
+            select(GithubInstallation.enforced_check_repos).where(
+                GithubInstallation.org_id == org_id,
+                GithubInstallation.suspended_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    return bool(row) and repo_full_name in row
+
+
 async def publish_gate_check(
     org_id: uuid.UUID,
     gate_id: uuid.UUID,

--- a/backend/tests/test_1970_gate_single_get.py
+++ b/backend/tests/test_1970_gate_single_get.py
@@ -204,7 +204,12 @@ async def test_get_gate_endpoint_200_populates_project_id_and_summary():
                        AsyncMock(return_value=project_id)), \
          patch("app.services.project_auth.has_project_access", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "_resolve_work_item_summary",
-                       AsyncMock(return_value=WorkItemSummary(title="설계 문서", slug="design-doc"))):
+                       AsyncMock(return_value=WorkItemSummary(title="설계 문서", slug="design-doc"))), \
+         patch.object(gates_mod, "resolve_pr_link", AsyncMock(return_value=None)):
+        # story #2815: get_gate_endpoint가 gate_type=="merge"(이 파일 _gate() 헬퍼 고정값)면
+        # github_check_enforced enrich를 위해 resolve_pr_link를 추가 호출한다 — 이 파일 관심사
+        # (project_id/work_item_summary enrich)와 무관하므로 patch로 우회(session.execute 단일
+        # 고정 mock 재사용 충돌 방지, gates.py:916 그 지점).
         result = await get_gate_endpoint(id=gate_id, session=session, org_id=org_id, auth=auth)
 
     assert result.id == gate_id
@@ -231,7 +236,10 @@ async def test_get_gate_endpoint_project_id_none_skips_access_check():
                        AsyncMock(return_value=None)), \
          patch.object(gates_mod, "has_project_access",
                        AsyncMock(side_effect=AssertionError("호출되면 안 됨"))) as access_spy, \
-         patch.object(gates_mod, "_resolve_work_item_summary", AsyncMock(return_value=None)):
+         patch.object(gates_mod, "_resolve_work_item_summary", AsyncMock(return_value=None)), \
+         patch.object(gates_mod, "resolve_pr_link", AsyncMock(return_value=None)):
+        # story #2815: gate_type=="merge"(이 파일 _gate() 헬퍼 고정값)라 github_check_enforced
+        # enrich 경로가 도는 것 — 이 테스트 관심사(project_id=None access-skip)와 무관, 우회.
         result = await get_gate_endpoint(id=gate_id, session=session, org_id=org_id, auth=auth)
 
     assert result.project_id is None

--- a/backend/tests/test_1972_gate_risk_grade.py
+++ b/backend/tests/test_1972_gate_risk_grade.py
@@ -220,7 +220,11 @@ async def test_get_gate_endpoint_populates_risk_grade():
                        AsyncMock(return_value=project_id)), \
          patch("app.services.project_auth.has_project_access", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "_resolve_work_item_summary", AsyncMock(return_value=None)), \
-         patch.object(gates_mod, "get_org_posture", AsyncMock(return_value="balanced")) as posture_spy:
+         patch.object(gates_mod, "get_org_posture", AsyncMock(return_value="balanced")) as posture_spy, \
+         patch.object(gates_mod, "resolve_pr_link", AsyncMock(return_value=None)):
+        # story #2815: gate_type=="merge"라 github_check_enforced enrich(resolve_pr_link 호출)
+        # 도 도는 것 — 이 테스트 관심사(risk_grade)와 무관, session.execute 단일 고정 mock
+        # 재사용 충돌 방지(gates.py:916, test_1970과 동형 원인).
         result = await get_gate_endpoint(id=gate_id, session=session, org_id=org_id, auth=auth)
 
     assert result.risk_grade == "high"  # balanced + merge(2차 축) → high
@@ -243,7 +247,9 @@ async def test_get_gate_endpoint_risk_grade_low_permissive():
                        AsyncMock(return_value=project_id)), \
          patch("app.services.project_auth.has_project_access", AsyncMock(return_value=True)), \
          patch.object(gates_mod, "_resolve_work_item_summary", AsyncMock(return_value=None)), \
-         patch.object(gates_mod, "get_org_posture", AsyncMock(return_value="permissive")):
+         patch.object(gates_mod, "get_org_posture", AsyncMock(return_value="permissive")), \
+         patch.object(gates_mod, "resolve_pr_link", AsyncMock(return_value=None)):
+        # story #2815: 위 테스트와 동일 사유(gate_type="merge" → github_check_enforced enrich).
         result = await get_gate_endpoint(id=gate_id, session=session, org_id=org_id, auth=auth)
 
     assert result.risk_grade == "low"  # 1차 축(posture)이 2차 축(gate_type)을 이김

--- a/backend/tests/test_2815_gate_github_check_events_endpoint_realdb.py
+++ b/backend/tests/test_2815_gate_github_check_events_endpoint_realdb.py
@@ -53,7 +53,8 @@ def _client_for(app):
 
 async def _setup_app(app, Session, org_id, user_id):
     from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
-    from app.dependencies.database import get_db
+
+    from tests.conftest import override_db_and_read
 
     async def _db():
         async with Session() as s:
@@ -70,7 +71,10 @@ async def _setup_app(app, Session, org_id, user_id):
     async def _org():
         return org_id
 
-    app.dependency_overrides[get_db] = _db
+    # 카디르 QA(PR#3245) — get_db만 걸면 get_read_db는 실 커넥션을 그대로 타 read-replica
+    # 라우팅 가드(story 83fc9cbc)에 걸린다. story #2451(§6 Phase3)의 단일 게이트 헬퍼로
+    # 두 dependency key를 항상 함께 오버라이드(구조적으로 못 빠뜨림 — conftest.py 참고).
+    override_db_and_read(app, _db)
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
 
@@ -331,3 +335,29 @@ async def test_is_repo_check_enforced_none_repo_full_name_returns_false():
     result = await is_repo_check_enforced(session, uuid.uuid4(), None)
     assert result is False
     session.execute.assert_not_awaited()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_is_repo_check_enforced_case_insensitive():
+    """카디르 QA(PR#3245) — enforced_check_repos는 PO가 손으로 적는 값이라 대소문자 불일치가
+    실전 최우선 함정. DB엔 대문자 섞어 저장돼도(사람이 실제로 그렇게 칠 법한 값) 소문자
+    질의가 True를 내야 한다."""
+    from app.models.github_installation import GithubInstallation
+    from app.services.gate_github_check import is_repo_check_enforced
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            s.add(GithubInstallation(
+                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=999003,
+                account_login="Acme", enforced_check_repos=["Acme/Repo"],
+            ))
+            await s.commit()
+
+            assert await is_repo_check_enforced(s, seeded["org_id"], "acme/repo") is True
+            assert await is_repo_check_enforced(s, seeded["org_id"], "ACME/REPO") is True
+            assert await is_repo_check_enforced(s, seeded["org_id"], "acme/other") is False
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2815_gate_github_check_events_endpoint_realdb.py
+++ b/backend/tests/test_2815_gate_github_check_events_endpoint_realdb.py
@@ -1,0 +1,333 @@
+"""story #2815(§5-②③④, Gate→GitHub required check FE 계약 후속) — 실PG 검증.
+
+- `GET /api/v2/gates/{id}/github-check-events`(§5-②) — 원장 최신순 조회, 존재 비노출(404).
+- `GithubInstallation.enforced_check_repos` + `is_repo_check_enforced`(§5-④, 관측모드 판별).
+- `get_gate_endpoint`의 `github_check_enforced` 필드 enrich.
+
+test_1970_gate_single_get.py의 realdb harness(session_factory/client_for/setup_app/seed_common)
+패턴을 그대로 재사용(로컬 복제 — 발명 0, 파일 self-contained 유지).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_common(session):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    outsider = User(id=uuid.uuid4(), email=f"outsider-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(outsider)
+    await session.commit()
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=outsider.id, role="member"))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "caller_id": caller.id, "outsider_id": outsider.id}
+
+
+async def _seed_merge_gate(session, seeded):
+    from app.models.gate import Gate
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"], title="s")
+    session.add(story)
+    await session.commit()
+    gate = Gate(
+        id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id,
+        work_item_type="story", gate_type="merge", status="pending",
+    )
+    session.add(gate)
+    await session.commit()
+    return story, gate
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_list_check_events_latest_first_and_shape():
+    from app.main import app
+    from app.models.gate_github_check_event import GateGithubCheckEvent
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            _, gate = await _seed_merge_gate(s, seeded)
+            gate_id = gate.id
+            e1 = GateGithubCheckEvent(
+                id=uuid.uuid4(), org_id=seeded["org_id"], gate_id=gate.id, story_id=gate.work_item_id,
+                repo_full_name="acme/repo", pr_number=7, head_sha="sha-1",
+                event_type="published", check_conclusion=None,
+            )
+            s.add(e1)
+            await s.commit()
+            e2 = GateGithubCheckEvent(
+                id=uuid.uuid4(), org_id=seeded["org_id"], gate_id=gate.id, story_id=gate.work_item_id,
+                repo_full_name="acme/repo", pr_number=7, head_sha="sha-1",
+                event_type="resolved", check_conclusion="success",
+            )
+            s.add(e2)
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/gates/{gate_id}/github-check-events")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body) == 2
+            assert body[0]["event_type"] == "resolved"  # 최신순.
+            assert body[0]["check_conclusion"] == "success"
+            assert body[1]["event_type"] == "published"
+            assert body[0]["repo_full_name"] == "acme/repo"
+            assert body[0]["pr_number"] == 7
+            assert body[0]["head_sha"] == "sha-1"
+            assert "org_id" not in body[0]  # 응답 스키마가 의도적으로 생략(URL이 이미 컨텍스트).
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_list_check_events_empty_list_when_no_events():
+    """양성대조 — 이벤트가 없으면 빈 배열(404 아님, gate 자체는 존재)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            _, gate = await _seed_merge_gate(s, seeded)
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/gates/{gate_id}/github-check-events")
+            assert resp.status_code == 200
+            assert resp.json() == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_list_check_events_404_for_nonexistent_gate():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/gates/{uuid.uuid4()}/github-check-events")
+            assert resp.status_code == 404
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_list_check_events_404_for_outsider_no_project_access():
+    """IDOR — 존재 비노출(403 아니라 404, get_gate_endpoint와 동일 규율)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            _, gate = await _seed_merge_gate(s, seeded)
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["outsider_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/gates/{gate_id}/github-check-events")
+            assert resp.status_code == 404
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_get_gate_github_check_enforced_true_when_repo_listed():
+    from app.main import app
+    from app.models.github_installation import GithubInstallation
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            _, gate = await _seed_merge_gate(s, seeded)
+            gate_id = gate.id
+            s.add(GithubInstallation(
+                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=999001,
+                account_login="acme", enforced_check_repos=["acme/repo"],
+            ))
+            s.add(PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=seeded["org_id"], story_id=gate.work_item_id,
+                repo_full_name="acme/repo", pr_number=7, link_source="sid", confidence="high",
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/gates/{gate_id}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["github_check_enforced"] is True
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_get_gate_github_check_enforced_false_when_repo_not_listed():
+    """양성대조 — repo가 enforced_check_repos에 없으면(관측모드) False."""
+    from app.main import app
+    from app.models.github_installation import GithubInstallation
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            _, gate = await _seed_merge_gate(s, seeded)
+            gate_id = gate.id
+            s.add(GithubInstallation(
+                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=999002,
+                account_login="acme", enforced_check_repos=["acme/other-repo"],
+            ))
+            s.add(PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=seeded["org_id"], story_id=gate.work_item_id,
+                repo_full_name="acme/repo", pr_number=7, link_source="sid", confidence="high",
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/gates/{gate_id}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["github_check_enforced"] is False
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_is_repo_check_enforced_none_repo_full_name_returns_false():
+    """단위 — repo_full_name을 모르면(링크 없음) 무조건 False, DB 조회 자체를 스킵."""
+    from unittest.mock import AsyncMock
+
+    from app.services.gate_github_check import is_repo_check_enforced
+
+    session = AsyncMock()
+    result = await is_repo_check_enforced(session, uuid.uuid4(), None)
+    assert result is False
+    session.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary
story #2813(PR#3243, 머지 완료) FE 계약 그라운딩([[gate-github-check-fe-grounding-2814]] §5) 중 미르코군이 제안한 BE 조각 2건.

## §5-② 원장 조회 엔드포인트
`GET /api/v2/gates/{id}/github-check-events` — `gate_github_check_event`(0262) 최신순 전체 반환(소량이라 페이지네이션 불요). authz는 `get_gate_endpoint`와 동일 패턴 재사용(gate 존재+project 접근권, 무권한도 404 — 존재 비노출). FE `GateEvidence`가 "check 상태·전이 이력" 섹션에서 지연 로드하는 용도.

## §5-④ 관측모드 판별 필드
`gate.github_check_run_id`가 계속 null인 이유(①발행 아직 안 됨 vs ②이 저장소가 애초에 관측모드)를 FE가 구분 못 하던 갭.

**설계 판단** — GitHub branch-protection API 실측 조회 대신 **수동 플래그** 채택(0263 마이그/모델 주석에 근거 명시):
- 실측 조회는 `administration:read`라는 story #2813 §2-4의 `checks:write`와 별개 신규 권한이 필요해 승인 마찰을 배로 늘림.
- PO가 이미 "check 실발행 시작 後에만 branch protection을 건다"는 순서를 직접 통제하므로(story #2813 R4) 그 등록 시점을 PO 자신이 정확히 아는 유일한 주체 — 라이브 API 전환은 후속(stale 위험 트레이드오프는 문서화).

**⚠️운영 절차 결합 필수(PO AC 조건, 2026-08-19)**: `enforced_check_repos`(BE 수동 플래그)와 GitHub 실 branch protection 설정은 **두 곳이 각자 진실을 주장하는 구조**라 드리프트가 가능하다 — required 등록 절차(PO 집행)는 **"branch protection 등록"과 "`enforced_check_repos`에 그 repo 추가"를 반드시 한 절차로 묶어서** 수행해야 한다(둘 중 하나만 하면 즉시 드리프트: 플래그만 켜면 FE가 "enforced"라 표시하는데 실제 머지 차단은 없고, protection만 걸면 FE가 계속 "관측모드"로 오표시). 이 커플링은 story #2815(entity:story:f45c3e1c-dcc9-45c8-9666-112b96bec239)에도 명기했다.

## 변경
- `github_installation.enforced_check_repos`(JSONB, repo_full_name 목록) 신설.
- `gate_github_check.py::is_repo_check_enforced(session, org_id, repo_full_name)`.
- `GateResponse.github_check_enforced: bool | None` — additive, `get_gate_endpoint`에서만 enrich(list_gates 등은 PR 링크 N+1 우려로 스코프 밖, `risk_grade`/`can_approve`와 동일 선례).

## Test plan
- [x] 신규 7 tests: 원장 최신순+shape·빈 배열 양성대조·404(미존재·무권한 IDOR)·`github_check_enforced` true/false 양성대조·단위 1건 — 전부 실PG green.
- [x] alembic `0263`까지 클린 마이그.
- [x] 회귀 스윕: gate 관련 115 tests green — 기존 mock 2곳(`test_1970_gate_single_get.py`, `_gate()` 헬퍼가 `gate_type="merge"` 고정이라 신규 enrich 경로에 물림) `resolve_pr_link` patch로 보강.
- [x] 회귀 스윕 중 **무관한 기존 실패** 발견(미수정, 범위 밖 — develop baseline `9c4c42b40`에서도 동일 재현 확認): `test_e_loop_ledger_s5_decision_gate.py` 9건이 `relation "gate" does not exist`로 실패 — 이 PR의 diff와 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)