### PR TITLE
fix(#2821): env 드리프트 가드 dev FAIL — 드리프트 아니라 None-크래시

### DIFF
--- a/backend/tests/test_check_env_drift_null_env_guard.py
+++ b/backend/tests/test_check_env_drift_null_env_guard.py
@@ -1,0 +1,143 @@
+"""story #2821 — infra/check_env_drift.py 스케줄 가드 dev FAIL 회귀가드.
+
+실사고(2026-08-19): 드리프트가 아니라 스크립트 크래시였다. `office-converter-dev`
+(story #2771, gotenberg 공개 이미지)는 컨테이너 스펙에 `env` 필드 자체가 없어
+`gcloud run services describe --format=json(...containers[0].env)`가 literal JSON
+`null`을 낸다 — 빈 문자열이 아니라 텍스트 "null"이라 기존 `if not out` 가드를 통과하고,
+`json.loads("null")`이 `None`이 되어 `data.get(...)`이 AttributeError로 죽었다.
+
+축① — 어느 서비스가 왜(`_live_env_entries`의 None 가드 + 진단 출력).
+축② — office-converter-dev가 `_SERVICE_SCRIPT_MAP`(마스터)에 아예 미등재였던 부수 발견
+(None-크래시가 그 자리를 가리고 있었을 뿐).
+축③ — Discord "상세 없음(호출 경로 오류 의심)" 알림도 같은 근본원인이었다: 크래시가
+`_write_state_file` 호출 전에 스크립트를 죽여 그날 state 파일이 아예 안 남고,
+`compare_env_drift_state.py`가 "파일 없음"을 fail_lines=[]로 읽어 그 방어 문구를 냈다
+— 별도 결함이 아니다. 재발 방지로 `_run_cli`가 미처리 예외를 state 파일에 진단명으로
+남기고 다시 던진다(다음에 «다른» 예외가 나도 같은 침묵이 재발하지 않게).
+
+gcloud 라이브 접근 없이(`_run` 몽키패치) 실행 가능.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFRA_DIR = _REPO_ROOT / "infra"
+
+
+def _load_check_env_drift():
+    spec = importlib.util.spec_from_file_location(
+        "check_env_drift", _INFRA_DIR / "check_env_drift.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── 축① _live_env_entries — None/빈 문자열/정상 3갈래 ────────────────────────
+
+def test_live_env_entries_returns_empty_on_json_null(monkeypatch, capsys):
+    """실사고 재현 — describe가 literal 'null'을 내면 크래시 대신 env 0건으로 처리한다."""
+    mod = _load_check_env_drift()
+    monkeypatch.setattr(mod, "_run", lambda cmd: "null")
+
+    result = mod._live_env_entries("office-converter-dev")
+
+    assert result == []
+    assert "office-converter-dev" in capsys.readouterr().out
+
+
+def test_live_env_entries_returns_empty_on_blank_output(monkeypatch):
+    """기존 가드(빈 문자열) 회귀 없음 — 이번 변경이 이 갈래를 깨지 않는다."""
+    mod = _load_check_env_drift()
+    monkeypatch.setattr(mod, "_run", lambda cmd: "")
+
+    assert mod._live_env_entries("some-service") == []
+
+
+def test_live_env_entries_parses_normal_json_unaffected(monkeypatch):
+    """양성대조 — 정상 describe 응답(진짜 env 있음)은 그대로 파싱된다(None 가드가 happy
+    path를 건드리지 않는다는 증명)."""
+    mod = _load_check_env_drift()
+    payload = json.dumps({
+        "spec": {"template": {"spec": {"containers": [
+            {"env": [{"name": "APP_URL", "value": "https://dev-app.sprintable.ai"}]}
+        ]}}}
+    })
+    monkeypatch.setattr(mod, "_run", lambda cmd: payload)
+
+    result = mod._live_env_entries("sprintable-backend-dev")
+
+    assert result == [{"name": "APP_URL", "value": "https://dev-app.sprintable.ai"}]
+
+
+# ── 축② office-converter-dev 마스터 등재 ─────────────────────────────────────
+
+def test_office_converter_dev_registered_in_master():
+    mod = _load_check_env_drift()
+    assert "office-converter-dev" in mod._SERVICE_SCRIPT_MAP
+    assert mod._env_for_service("office-converter-dev") == "dev"
+
+
+def test_office_converter_dev_no_longer_falls_into_unmapped(monkeypatch):
+    """등재 전엔 None-크래시가 이 서비스를 "매핑 안 된 신규 서비스" 판정 자체에 도달하지도
+    못하게 가렸다 — 이제 정상적으로 checked 대상에 들어가고 unmapped엔 안 잡힘을 증명."""
+    mod = _load_check_env_drift()
+
+    def _fake_live_env_entries(service):
+        return []
+
+    monkeypatch.setattr(mod, "_list_live_services", lambda: ["office-converter-dev"])
+    monkeypatch.setattr(mod, "_live_env_entries", _fake_live_env_entries)
+    monkeypatch.setattr(mod, "_load_allowlist", lambda: ({}, {}))
+    monkeypatch.setattr(mod, "_iac_covered_keys", lambda: set())
+    monkeypatch.setattr(mod, "_settings_field_env_keys", lambda: set())
+    monkeypatch.setattr(mod, "_load_settings_exempt", lambda: {})
+    monkeypatch.setattr(mod, "_web_env_reads", lambda: {})
+    monkeypatch.setattr(mod, "_load_code_read_exempt", lambda: set())
+    monkeypatch.setattr(mod, "_load_code_read_high_baseline", lambda: {})
+    monkeypatch.setattr(mod, "_service_subset_wellformed_violations", lambda: [])
+    monkeypatch.setattr(mod, "_external_iac_wellformed_violations", lambda: [])
+
+    exit_code = mod.main(only_env="dev")
+
+    assert exit_code == 0
+
+
+# ── 축③ 미처리 예외도 state 파일에 진단명을 남긴다 ────────────────────────────
+
+def test_unhandled_exception_writes_diagnostic_state_file_before_reraising(
+    tmp_path, monkeypatch
+):
+    """실사고의 축③ 재발 방지 — main() 밖 예외라도 state 파일이 비어있는 채로 남지 않는다.
+    이게 없으면 compare_env_drift_state.py가 "파일 없음"을 fail_lines=[]로 읽어 Discord가
+    "상세 없음(호출 경로 오류 의심)"을 낸다(실사고 그 문구)."""
+    mod = _load_check_env_drift()
+    state_path = tmp_path / "state.json"
+    monkeypatch.setenv("ENV_DRIFT_STATE_FILE", str(state_path))
+
+    def _boom(only_env=None):
+        raise RuntimeError("simulated future crash — unrelated to the None case")
+
+    monkeypatch.setattr(mod, "main", _boom)
+
+    with pytest.raises(RuntimeError, match="simulated future crash"):
+        mod._run_cli(["--only-env", "dev"])
+
+    data = json.loads(state_path.read_text(encoding="utf-8"))
+    assert data["env"] == "dev"
+    assert len(data["fail_lines"]) == 1
+    assert "RuntimeError" in data["fail_lines"][0]
+    assert "simulated future crash" in data["fail_lines"][0]
+
+
+def test_run_cli_returns_main_exit_code_on_clean_run(monkeypatch):
+    mod = _load_check_env_drift()
+    monkeypatch.setattr(mod, "main", lambda only_env=None: 0)
+    monkeypatch.delenv("ENV_DRIFT_STATE_FILE", raising=False)
+
+    assert mod._run_cli([]) == 0

--- a/backend/tests/test_check_env_drift_service_subset_axis.py
+++ b/backend/tests/test_check_env_drift_service_subset_axis.py
@@ -27,15 +27,17 @@ def _load_check_env_drift():
 
 # ── AC1: 마스터 확定 ────────────────────────────────────────────────────────────
 
-def test_service_script_map_is_declared_master_of_seven():
-    """`_SERVICE_SCRIPT_MAP`이 7개 실서비스를 담은 마스터다 — 이 카운트가 바뀌면(신규 서비스
-    추가/삭제) 알아야 하므로 명시 고정."""
+def test_service_script_map_is_declared_master_of_eight():
+    """`_SERVICE_SCRIPT_MAP`이 8개 실서비스를 담은 마스터다 — 이 카운트가 바뀌면(신규 서비스
+    추가/삭제) 알아야 하므로 명시 고정. story #2821(2026-08-19) — office-converter-dev
+    (story #2771, gotenberg 공개 이미지) 편입으로 7→8."""
     mod = _load_check_env_drift()
     assert set(mod._SERVICE_SCRIPT_MAP) == {
         "sprintable-backend-dev", "sprintable-backend-prod",
         "sprintable-frontend-dev", "sprintable-frontend-prod",
         "sprintable-mcp-dev", "sprintable-mcp-prod",
         "sprintable-realtime-dev",
+        "office-converter-dev",
     }
 
 
@@ -101,13 +103,25 @@ def test_positive_control_ghost_in_web_code_services_is_caught(monkeypatch):
 
 # ── AC3+AC4: 외부 IaC 대조 + 주석-오탐 방지 ──────────────────────────────────────
 
-def test_external_iac_literals_match_master_exactly_today():
-    """cloudbuild.yaml·.github/workflows/*.yml·deploy_*.sh에 실선언된 서비스명 전량이 오늘
-    정확히 마스터 7개와 같다(realtime-prod는 주석에만 있으므로 여기 안 잡혀야 한다)."""
+def test_external_iac_literals_are_a_subset_of_master_today():
+    """cloudbuild.yaml·.github/workflows/*.yml·deploy_*.sh에 실선언된 서비스명 전량이 마스터의
+    부분집합이다(realtime-prod는 주석에만 있으므로 여기 안 잡혀야 한다).
+
+    ⛔story #2821(2026-08-19) — 이전엔 등식(external == master)이었으나 office-converter-dev
+    편입으로 깨졌다: `_SERVICE_NAME_RE`가 `sprintable-`로 시작하는 이름만 잡는데,
+    office-converter-dev는 cloudbuild.yaml에서 `office-converter-${_DEPLOY_ENV}`로 bash
+    변수 보간되어 있어 어느 줄에도 "office-converter-dev"라는 리터럴 문자열로 «선언»되지
+    않는다(같은 문자열이 주석·URL 값 안에 등장하긴 하지만 그건 이 정규식의 대상인 "선언"이
+    아니다). 파일 docstring이 명시하는 진짜 불변식은 애초에 한 방향(subset)이었다 —
+    이 테스트를 그 불변식에 맞춘다."""
     mod = _load_check_env_drift()
     external = mod._external_iac_service_literals()
-    assert external == set(mod._SERVICE_SCRIPT_MAP)
+    assert external <= set(mod._SERVICE_SCRIPT_MAP)
     assert "sprintable-realtime-prod" not in external
+    # office-converter-dev는 마스터엔 있지만 bash 변수 보간 때문에 이 정적 리터럴 스캔으로는
+    # 원천적으로 안 보인다 — 위 subset 관계가 이미 안전(다른 방향만 위험한 방향).
+    assert "office-converter-dev" not in external
+    assert "office-converter-dev" in mod._SERVICE_SCRIPT_MAP
 
 
 def test_comment_only_service_name_is_not_a_real_declaration():

--- a/infra/check_env_drift.py
+++ b/infra/check_env_drift.py
@@ -163,6 +163,12 @@ _SERVICE_SCRIPT_MAP: dict[str, list[str]] = {
     "sprintable-frontend-prod": ["backend/scripts/deploy_frontend.sh"],
     "sprintable-mcp-dev": ["backend/scripts/deploy_mcp_dev.sh"],
     "sprintable-mcp-prod": ["backend/scripts/deploy_mcp_prod.sh"],
+    # story #2821 부수 발견(2026-08-19) — office-converter-dev(story #2771, gotenberg 공개
+    # 이미지)가 어제 편입됐으나 여기 미등재라 "매핑 안 된 신규 서비스"로도 안 잡히고 있었다
+    # (None-크래시가 그 자리를 가리고 있었을 뿐). cloudbuild.yaml deploy-office-converter
+    # 스텝이 env 플래그 자체를 안 실어(공통 파싱에 이미 포함) 전용 스크립트가 없다 —
+    # sprintable-realtime-dev([])와 동일 패턴.
+    "office-converter-dev": [],
 }
 
 # ② 값 대조 대상 — DRY_RUN=1로 ENV_VARS_SPEC을 stdout에 뽑아낼 수 있는 스크립트만.
@@ -214,15 +220,31 @@ def _list_live_services() -> list[str]:
 
 
 def _live_env_entries(service: str) -> list[dict]:
-    """서비스의 raw env 리스트(name + value 또는 valueFrom) — ②③이 공유."""
+    """서비스의 raw env 리스트(name + value 또는 valueFrom) — ②③이 공유.
+
+    ⛔story #2821 실사고 — `env` 필드가 컨테이너 스펙에 아예 없으면(빈 배열이 아니라 키
+    자체 부재) `--format=json(...)` 필드 프로젝션이 literal JSON `null`을 낸다(빈 문자열이
+    아니라 텍스트 "null" — `if not out`을 통과해버린다). `json.loads("null")`은 `None`이라
+    다음 줄 `data.get(...)`이 AttributeError로 죽는다. 실측(2026-08-19): office-converter-dev
+    (gotenberg 공개 이미지, cloudbuild.yaml deploy-office-converter 스텝이 env 플래그
+    자체를 안 실음)가 정확히 이 형태 — env 0건은 정상 상태이지 결함이 아니다. 조용히
+    삼키지 않고 어느 서비스가 왜 0건으로 처리됐는지 stdout에 남긴다(크래시는 빨강이되
+    진단 불가라 반쪽이라는 지적, PO 2026-08-19)."""
     out = _run([
         "gcloud", "run", "services", "describe", service,
         f"--region={_REGION}",
         "--format=json(spec.template.spec.containers[0].env)",
     ])
     if not out:
+        print(f"  ℹ️ {service}: describe 결과가 빈 문자열 — env 0건으로 처리")
         return []
     data = json.loads(out)
+    if data is None:
+        print(
+            f"  ℹ️ {service}: describe의 env 필드가 null(컨테이너 스펙에 env 키 자체가 "
+            "없음) — env 0건으로 처리"
+        )
+        return []
     return (
         data.get("spec", {}).get("template", {}).get("spec", {})
         .get("containers", [{}])[0].get("env", [])
@@ -852,5 +874,26 @@ def _parse_only_env(argv: list[str]) -> str | None:
     return value
 
 
+def _run_cli(argv: list[str]) -> int:
+    """CLI 진입점 — story #2821 축③. `_write_state_file`은 `main()`이 정상 완주해야만
+    불린다 — 이번 None-크래시처럼 루프 중간에 죽으면 그날의 state 파일이 아예 안 남고,
+    `compare_env_drift_state.py`가 "파일 없음"을 fail_lines=[]로 읽어 Discord 알림이
+    "상세 없음(호출 경로 오류 의심)"으로 나간다(실측 확認 — 이번 사고가 정확히 이 경로로
+    그 문구를 냈다. 별도 결함이 아니라 위 None-크래시와 같은 근본원인).
+
+    한 번 이 구멍을 실측했으니, 다음에 «다른» 미처리 예외가 나도 같은 증상(진단 불가한
+    침묵)이 재발하지 않게 최상위에서 잡아 예외 자체를 state 파일에 진단명으로 남기고
+    다시 던진다 — exit code·CI FAIL 판정(GHA가 트레이스백을 그대로 보므로)은 그대로다."""
+    only_env = _parse_only_env(argv)
+    try:
+        return main(only_env=only_env)
+    except Exception as exc:
+        _write_state_file(
+            [f"⚠️ check_env_drift.py 크래시(스크립트 결함 — 즉시 조사 필요): {type(exc).__name__}: {exc}"],
+            only_env=only_env,
+        )
+        raise
+
+
 if __name__ == "__main__":
-    sys.exit(main(only_env=_parse_only_env(sys.argv[1:])))
+    sys.exit(_run_cli(sys.argv[1:]))


### PR DESCRIPTION
## Summary
스케줄 env 드리프트 가드 dev FAIL(run 32316683382) 실측 — 드리프트가 아니라 스크립트 크래시였다. PO 배정 3축 모두 완료.

## 축① 원인 서비스 실측
`office-converter-dev`(story #2771, gotenberg 공개 이미지 — 어제 편입)가 컨테이너 스펙에 `env` 필드 자체가 없다(빈 배열이 아니라 키 부재). `gcloud run services describe --format=json(spec.template.spec.containers[0].env)`가 이 경우 literal JSON `null`을 낸다 — 빈 문자열이 아니라 텍스트 `"null"`이라 기존 `if not out` 가드를 통과하고, `json.loads("null")`이 `None`을 반환해 `data.get(...)`이 `AttributeError`로 죽었다. 실측 확認: 전체 dev 서비스 12개 개별 describe → office-converter-dev 하나만 이 형태.

## 축② 스크립트 fix
- `_live_env_entries`: `data is None` 가드 추가 — env 0건으로 처리 + 어느 서비스가 왜인지 stdout 진단 출력(크래시는 빨강이되 진단 불가라 반쪽이라는 지적 반영).
- 부수 발견: `office-converter-dev`가 `_SERVICE_SCRIPT_MAP`(마스터, ①축 대조 기준)에 아예 미등재였다 — None-크래시가 "매핑 안 된 신규 서비스" 판정 자체를 가리고 있었을 뿐. `sprintable-realtime-dev`와 동일 패턴(`[]`, cloudbuild.yaml 공통 파싱만)으로 등재.

## 축③ Discord "상세 없음" 알림
같은 근본원인으로 확認(별도 결함 아님) — `_write_state_file`은 `main()`이 정상 완주해야만 불리는데, 크래시가 그 호출 전에 스크립트를 죽여 그날 dev state 파일이 아예 안 남았다. `compare_env_drift_state.py::load_fail_lines`가 "파일 없음"을 `fail_lines=[]`로 읽고, `format_discord_message`의 방어 분기(`if not result["current_fail"]`)가 정확히 그 "상세 없음(호출 경로 오류 의심)" 문구를 냈다.

재발 방지: `_run_cli` wrapper 신설 — `main()` 밖 미처리 예외라도 잡아 진단명을 state 파일에 남기고 나서 다시 던진다(exit code·CI FAIL 판정은 무변경). 이번 None 케이스뿐 아니라 앞으로 «다른» 예외가 나도 같은 침묵 재발을 막는다.

## 부수 관측(범위 밖, 수정 안 함 — report-only라 FAIL 아님)
실 gcloud dev 대조 중 ④Settings 커버리지가 `GOTENBERG_SERVICE_URL`(sprintable-backend-dev)을 미커버로 report — office-converter 관련 신규 env로 보이나 report-only 축이라 exit code에 영향 없음. 필요시 별도 판단.

## Test plan
- [x] 신규 회귀 7 tests(`test_check_env_drift_null_env_guard.py`): None/빈문자열/정상 3갈래, office-converter-dev 마스터 등재+unmapped 이탈, 미처리 예외 state 파일 진단 기록.
- [x] 기존 subset-axis 테스트 2건 갱신(마스터 7→8; external-IaC-literal 등식→subset 관계로 — office-converter-dev는 cloudbuild.yaml에서 `office-converter-${_DEPLOY_ENV}` bash 변수 보간이라 정적 리터럴 스캔으로 원천적으로 안 보임, 안전한 방향).
- [x] env-drift 관련 파일 전체(6개) 회귀 스윕 73 tests green.
- [x] 실 gcloud 상대 `--only-env dev`/`--only-env prod` 양쪽 end-to-end 실행 — 크래시 없음, 둘 다 exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)