### PR TITLE
docs(#2813 live-AC): scratch test PR for gate approve→success roundtrip [SID:2813]

### DIFF
--- a/docs/scratch-2813-live-ac-roundtrip.md
+++ b/docs/scratch-2813-live-ac-roundtrip.md
@@ -1,0 +1,7 @@
+# story #2813 라이브 AC①②③ 왕복 테스트용 스크래치 PR
+
+이 파일은 `sprintable/gate` required-check 승인→success 전이를 CI 전-초록 조건에서
+실측하기 위한 일회성 테스트 PR 표식입니다. docs-only 변경이라 backend 무거운 잡을
+skip합니다(`.github/workflows/ci.yml` 백엔드-무관 allowlist).
+
+관측 완료 후 이 PR/브랜치/파일은 정리됩니다 — 코드 변경 아님.


### PR DESCRIPTION
## Summary
- 일회성 테스트 PR — story #2813 라이브 AC①②③ 왕복 실측(승인→success 전이)을 CI 전-초록 조건에서 관측하기 위함.
- docs-only 변경(코드 0줄) — backend 무거운 잡 skip 대상.
- 관측 완료 후 정리(close+branch 삭제) 예정.

관련: [SID:2813]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>