### PR TITLE
fix(#2827): QA review gate 순환 데드락 정정 — sprintable/gate 제외 [SID:2827]

### DIFF
--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -243,6 +243,13 @@ jobs:
       # 이름만 빼면 "QA review gate"는 여전히 비-advisory로 잡혀, 두 라벨이 다 걸린 PR에서
       # 두 게이트가 동시에 재실행되면 서로가 서로를 "아직 안 끝남"으로 보고 상호 RED로 고착된다
       # (자동 재트리거 없어 새 pull_request 이벤트 전까지 안 풀림). 상대 게이트 이름도 같이 뺀다.
+      #
+      # ⛔story #2827(2026-08-20, qa-review-gate.yml과 동형 사본 fix·페드루 PO 판정) —
+      # "sprintable/gate"(story #2813)도 같은 범주: 사람 승인이 QA/Design 리뷰 완료를 전제하는
+      # **뒤 순서** 액션이라, 이 게이트가 그 완결을 기다리면 승인이 하염없이 안 나오고(승인이
+      # 안 나오니 gate가 안 끝나고, gate가 안 끝나니 이 게이트가 안 풀리는 결정론적 순환 —
+      # dev moonklabs/sprintable#3249 실측). qa-review-gate.yml 쪽만 고치면 사본 하나가
+      # 남아 design:pass 라벨 경로에서 동일 데드락이 재발하므로 여기도 제외.
       - name: Enforce no incomplete non-advisory checks when design:pass is claimed
         if: steps.scope.outputs.in_scope == 'true'
         env:
@@ -251,7 +258,7 @@ jobs:
         run: |
           set -euo pipefail
           INCOMPLETE="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs" --paginate \
-            --jq '.check_runs[] | select(.name != "Design review gate" and .name != "QA review gate") | select(.name | endswith("— advisory") | not) | select(.status != "completed") | .name' \
+            --jq '.check_runs[] | select(.name != "Design review gate" and .name != "QA review gate" and .name != "sprintable/gate") | select(.name | endswith("— advisory") | not) | select(.status != "completed") | .name' \
             | sort -u)"
           if [ -n "${INCOMPLETE}" ]; then
             echo "::error title=required-ish checks still incomplete::design:pass가 붙어 있지만 아직 안 끝난(비-advisory) 체크가 있다:"

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -206,9 +206,19 @@ jobs:
       # "Design review gate"는 여전히 비-advisory로 잡혀, 두 라벨이 다 걸린 PR에서 두 게이트가
       # 동시에 재실행되면(오늘 3086/3088류 실물 — 한 PR에 qa:pass+design:pass 둘 다 필요하면
       # 흔한 정상 상황) 서로가 서로를 "아직 안 끝남"으로 보고 상호 RED로 고착된다(둘 다 완료된
-      # 뒤에도 자동 재트리거가 없어 새 pull_request 이벤트 전까지 안 풀림). 상대 게이트 이름도
+      # 뒤에도 자동 재트리거가 없어 새 pull_request 이벤트 전까지 안 풀린다). 상대 게이트 이름도
       # 같이 뺀다 — 순환 대기를 구조적으로 없앤다(광범위 제외라 "advisory 아닌 다른 게이트류"가
       # 미래에 더 생기면 그때 또 추가해야 하는 갭은 남는다, 지금은 이 리포에 게이트가 이 둘뿐).
+      #
+      # ⛔story #2827(2026-08-20, 페드루 PO 판정·라이브 실사고 실측) — "sprintable/gate"(story
+      # #2813, Gate→GitHub required check)도 같은 범주다: 이 check는 사람이 gate를 승인해야
+      # success로 넘어가는데, 그 승인이 "QA/Design 리뷰가 이미 끝났다"를 전제로 하는 **뒤 순서**
+      # 액션이다 — QA review gate가 sprintable/gate의 완결을 기다리면 승인이 안 나온 채로는 QA
+      # gate가 영원히 안 풀리고, QA gate가 안 풀리면(비-advisory 미완료 판정에 걸려) gate의
+      # ci_result가 fail이 돼 승인 자체가 막힌다(결정론적 순환, rerun으로 안 풀림 — dev
+      # moonklabs/sprintable#3249 실측으로 확定). 위 QA/Design 상호제외와 동일한 근본 원인(둘 다
+      # "review-gate류"가 자기보다 늦게 끝나는 다른 review-gate류를 기다리는 카테고리 착오)이라
+      # 같은 처방을 적용 — sprintable/gate도 제외 목록에 추가한다.
       - name: Enforce no incomplete non-advisory checks when qa:pass is claimed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -216,7 +226,7 @@ jobs:
         run: |
           set -euo pipefail
           INCOMPLETE="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs" --paginate \
-            --jq '.check_runs[] | select(.name != "QA review gate" and .name != "Design review gate") | select(.name | endswith("— advisory") | not) | select(.status != "completed") | .name' \
+            --jq '.check_runs[] | select(.name != "QA review gate" and .name != "Design review gate" and .name != "sprintable/gate") | select(.name | endswith("— advisory") | not) | select(.status != "completed") | .name' \
             | sort -u)"
           if [ -n "${INCOMPLETE}" ]; then
             echo "::error title=required-ish checks still incomplete::qa:pass가 붙어 있지만 아직 안 끝난(비-advisory) 체크가 있다 — 「CI green」은 이것들이 전부 completed일 때만 참이다:"


### PR DESCRIPTION
## Summary
- QA/Design review gate 둘 다 incomplete-check 강제가 `sprintable/gate`(story #2813)를 카운트해 결정론적 순환 데드락이 생기고 있었다 — 매 develop PR 머지마다 우회(초록 워크플로 재실행)가 필요한 상태(dev moonklabs/sprintable#3249 라이브 실측으로 확定).
- **동형 2곳** 동일 판별 근거로 fix — 이미 QA/Design review gate가 서로를 제외하는 선례(PR#3092)와 완전히 같은 범주: `sprintable/gate`도 사람 승인이 QA/Design 리뷰 완료를 전제하는 **뒤 순서** 액션이라 카운트 대상이 아니다.
  - `.github/workflows/qa-review-gate.yml` — `sprintable/gate`를 제외 목록에 추가.
  - `.github/workflows/design-review-gate.yml` — 동일 사본, 동일 fix(design:pass 라벨 경로에서 재발 방지).
- 처방 2(백엔드 `ci_result` last-writer-wins 폐기)는 3334bc91 트랙에 남김, 이 PR은 워크플로 yml만.

## Test plan
- [x] 두 파일 YAML 파싱 검증
- [ ] 이 PR 자체가 sprintable/gate required check에 걸림 — 승인 우회(초록 워크플로 재실행→휴먼 승인)로 머지, **이게 마지막 우회**가 되는지 실측
- [ ] 카디르 QA

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>