### PR TITLE
[SID:2814] 재-pending 사유 문구 미노출 수정 — events[0]→최근 re_pending 이벤트

### DIFF
--- a/apps/web/src/components/cage/gate-evidence-render.test.tsx
+++ b/apps/web/src/components/cage/gate-evidence-render.test.tsx
@@ -122,6 +122,28 @@ describe('GateEvidence — 재-pending 사유(원장 지연 로드, story #2814 
     expect(container.textContent).toContain('def9876');
   });
 
+  // 2026-08-20 dev 라이브 AC2 재검 중 실측(gate bad5ad2c, PR#3249) — 새 커밋 감지 시 BE가
+  // re_pending 기록 직후 그 SHA로 published까지 같은 처리 안에서 남겨, 원장 최신순 정렬 시
+  // events[0]이 published·re_pending이 events[1]이 되는 순서가 실운영 기본값이었다. 이 케이스에서
+  // events[0]만 보던 구버전은 사유 문구가 항상 죽어있었다(AC2 미충족) — 회귀 가드.
+  it('원장 최신 이벤트가 published여도 그 직전이 re_pending이면 사유 문구가 나타난다(실측 순서)', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([
+        { id: 'evt-2', repo_full_name: 'moonklabs/sprintable', pr_number: 3249, head_sha: 'b01c8c3d7fdf291090e3c3e4b69a0c8d3ab03981', event_type: 'published', check_conclusion: null, created_at: '2026-08-20T02:56:36.175894Z' },
+        { id: 'evt-1', repo_full_name: 'moonklabs/sprintable', pr_number: 3249, head_sha: 'b01c8c3d7fdf291090e3c3e4b69a0c8d3ab03981', event_type: 're_pending', check_conclusion: null, created_at: '2026-08-20T02:56:36.114101Z' },
+      ]),
+    } as Response);
+
+    const gate = realApiShapedGate({ status: 'pending', github_check_run_id: 987654321 });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateEvidence gate={gate} />)); });
+
+    expect(container.textContent).toContain('b01c8c3');
+  });
+
   it('최신 원장 이벤트가 re_pending이 아니면(published 등) 사유 문구를 그리지 않는다', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue({
       ok: true,

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -216,32 +216,40 @@ interface GithubCheckLedgerEvent {
  * 트리거는 호출부(GateEvidence)가 결정 — ghState==='in_progress'일 때만 마운트한다(success/
  * failure/not_published/null인 게이트는 재-pending 여지 자체가 없어 호출 불요).
  *
+ * ⚠️2026-08-20 라이브 AC2 재검 중 발견·즉시수정 — `events[0]`(최신 이벤트 그 자체)이 아니라
+ * "가장 최근 re_pending 이벤트"를 찾아야 한다. 실왕복 확인 결과 새 커밋 감지 시 BE가 re_pending
+ * 기록 직후(같은 웹훅 처리 안에서) 그 새 SHA로 새 check-run을 published — 즉 정상 케이스에서
+ * `events[0]`은 거의 항상 `published`이고 `re_pending`은 events[1]. 이전 코드(`events[0]?.event_type
+ * !== 're_pending'`)는 이 실측 순서에서 사실상 절대 참이 안 돼 사유 문구가 죽어있었다(AC2 미충족).
+ * ghState==='in_progress' 마운트 가드가 이미 "아직 미해결"을 보장하므로, 원장에서 가장 최근
+ * re_pending을 찾아 그 SHA로 표시하면 된다(뒤이은 published가 있어도 그 사유는 여전히 유효).
+ *
  * 실패/빈 응답은 침묵(옵션 정보라 카드 붕괴 X) — 이 신호가 evidence 판정(gateHasEvidence)에
  * 관여하지 않는 이유이기도 하다(로드 전/실패 시에도 카드가 이미 유효한 GithubCheckSignal로
  * State B/C에 들어가 있어야 함).
  */
 function GithubRependingReason({ gateId }: { gateId: string }) {
   const t = useTranslations('cage');
-  const [latest, setLatest] = useState<GithubCheckLedgerEvent | null | undefined>(undefined);
+  const [repending, setRepending] = useState<GithubCheckLedgerEvent | null | undefined>(undefined);
 
   useEffect(() => {
     let cancelled = false;
     fetchWithAuth(`/api/gates/${gateId}/github-check-events`)
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`status ${res.status}`))))
       .then((events: GithubCheckLedgerEvent[]) => {
-        if (!cancelled) setLatest(events[0] ?? null);
+        if (!cancelled) setRepending(events.find((e) => e.event_type === 're_pending') ?? null);
       })
       .catch(() => {
-        if (!cancelled) setLatest(null);
+        if (!cancelled) setRepending(null);
       });
     return () => { cancelled = true; };
   }, [gateId]);
 
-  if (!latest || latest.event_type !== 're_pending') return null;
+  if (!repending) return null;
 
   return (
     <p className="mt-1 text-[11px] text-muted-foreground">
-      {t('githubCheckRependingReason', { newSha: latest.head_sha.slice(0, 7) })}
+      {t('githubCheckRependingReason', { newSha: repending.head_sha.slice(0, 7) })}
     </p>
   );
 }


### PR DESCRIPTION
## 배경
#2814 AC2("재-pending 발생 시 화면에 사유 문구 노출") 라이브 재검 중 실측 결함 발견.

## 원인
`GithubRependingReason`(gate-evidence.tsx)이 `github-check-events` 원장의 `events[0]`(최신 이벤트 그 자체)이 `re_pending`일 때만 사유 문구를 그림. 실제 dev 라이브(gate `bad5ad2c`, PR#3249, 새 커밋 SHA `b01c8c3d`)로 확인해 보니, BE는 re_pending 기록 직후 같은 웹훅 처리 안에서 그 새 SHA로 check-run을 즉시 `published` — 원장 최신순 정렬에서 `events[0]`이 거의 항상 `published`이고 `re_pending`은 `events[1]`로 밀린다. 이 실운영 순서에서 구 로직은 사유 문구를 항상 숨겨 AC2 미충족.

## 변경
- `events[0]`이 아니라 원장에서 **가장 최근 `re_pending` 이벤트**를 찾아 그 SHA로 사유 문구를 그리도록 수정 (`ghState==='in_progress'` 마운트 가드가 이미 "아직 미해결"을 보장하므로, 뒤이은 published가 있어도 그 re_pending 사유는 여전히 유효).
- 회귀 가드 테스트 추가(`gate-evidence-render.test.tsx`) — 실측과 동일한 이벤트 순서([published, re_pending])로 사유 문구가 나타나는지 검증.

## 검증
- `pnpm vitest run src/components/cage/gate-evidence-render.test.tsx` — 7 passed
- `pnpm exec eslint` 대상 파일 — 경고 0개
- `pnpm build` — 성공
- dev 라이브 재검(gate `bad5ad2c`) — 스크린샷 미첨부(코드 변경 전 캡처한 "미노출" 상태만 evidence로 스토리에 등재됨). 이 PR 머지 후 재-재검 예정.

## 스크린샷
변경은 텍스트 한 줄 추가/조건 변경이라 별도 시각 diff 없음. before(미노출) 상태는 스토리 evidence(gate-bad5ad2c-repending-missing-reason-light) 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)