### PR TITLE
fix(#2826): PR 수명주기에서 merge gate가 저절로 서게 [SID:2826]

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -317,6 +317,7 @@ async def _process_webhook_event(
     delivery: GithubWebhookDelivery,
     *,
     gate_check_publish: list[dict] | None = None,
+    ungated_check_publish: list[dict] | None = None,
 ) -> tuple[dict, str]:
     """검증·dedup 통과한 이벤트 처리(legacy/app 라우팅·Bot-L.1 resolver 체인). (result, status) 반환.
 
@@ -384,6 +385,25 @@ async def _process_webhook_event(
             and rl.reason == "story_number_requires_org_scope"
         ):
             skipped_reason = repo_owner_reason
+        # story #2826(부 처방, PO 확定 2026-08-20) — 링크가 아예 안 풀린 PR 라이프사이클 이벤트라도
+        # (app installation이 있어 org 컨텍스트가 확실하고) 이 repo가 sprintable/gate를 required로
+        # 걸어 뒀으면, 침묵 부재 대신 action_required check로 "왜 막혔는지+다음 행동"을 안내한다.
+        # legacy(org 미상)는 대상 밖 — installation 컨텍스트 자체가 없어 어느 org 설정을 볼지 모른다.
+        if (
+            source == "app"
+            and installation is not None
+            and event == "pull_request"
+            and pr_action in ("opened", "reopened", "ready_for_review", "synchronize")
+            and head_sha
+            and ungated_check_publish is not None
+        ):
+            from app.services.gate_github_check import is_repo_check_enforced
+
+            if await is_repo_check_enforced(session, installation.org_id, repo):
+                ungated_check_publish.append({
+                    "installation_id": installation.installation_id,
+                    "repo_full_name": repo, "head_sha": head_sha, "pr_number": pr_number,
+                })
         return {"skipped_reason": skipped_reason, "recorded": []}, "ignored"  # no_match/auto suggestion 등.
     story_id = rl.story_id
     org_id = rl.org_id  # app=입력 org·legacy=story.org_id(resolver 검증). 단일 진실원.
@@ -424,6 +444,27 @@ async def _process_webhook_event(
                 "org_id": org_id, "gate_id": merge_gate.id,
                 "head_sha": head_sha, "repo_full_name": repo, "pr_number": pr_number,
             })
+        else:
+            # story #2826(주 처방, PO 확定 2026-08-20) — story 링크는 해소됐는데 gate가 아직
+            # 없다(지금까지 유일한 생성 경로였던 board →done preflight를 아직 안 거쳤다는 뜻,
+            # 그라운딩 참고: create_gate(merge) 실 호출부는 evaluate_merge_gate 하나뿐). PR
+            # 자체가 연결된 실 신호이므로 이 자리에서 즉시 평가·생성한다 — **판정 로직은
+            # evaluate_merge_gate 재사용**(board preflight와 동일 chokepoint, 새 규칙 발명 0).
+            # pr_number>0을 넘겨 "no-substance"(§P0 no-gate) 숏컷을 건너뛴다 — 연결된 PR
+            # 자체가 그 숏컷이 요구하는 "실 신호"다. create_gate의 uq(work_item,gate_type) 멱등이
+            # 이 경로와 board-preflight 경로 사이 중복 생성을 이미 막는다(어느 쪽이 먼저 오든
+            # 나중 쪽은 기존 gate를 그대로 반환) — 별도 dedup 로직 불필요.
+            from app.services.merge_verdict_gate import evaluate_merge_gate as _evaluate_merge_gate
+
+            decision = await _evaluate_merge_gate(
+                session, org_id, story_id,
+                pr_number=pr_number, repo=repo, ci_result=None, head_sha=head_sha,
+            )
+            if decision.gate_id is not None:
+                gate_check_publish.append({
+                    "org_id": org_id, "gate_id": decision.gate_id,
+                    "head_sha": head_sha, "repo_full_name": repo, "pr_number": pr_number,
+                })
 
     # P0-05 후속(doc scope-violation-signal-design §2·§3): PR 자체 이벤트(opened/synchronize/reopened)
     # + confident link(should_auto_close 동일 신뢰 등급)일 때만 판정. 3중 침묵 조건은 헬퍼 내부.
@@ -694,10 +735,12 @@ async def github_webhook(
 
     # 5) 처리 + status 갱신 + commit 을 **동일 트랜잭션**으로. 실패=rollback(delivery row 도 함께 → retry 보존).
     _gate_check_publish: list[dict] = []
+    _ungated_check_publish: list[dict] = []
     try:
         result, status_label = await _process_webhook_event(
             session, source, event, payload, installation_id, delivery,
             gate_check_publish=_gate_check_publish,
+            ungated_check_publish=_ungated_check_publish,
         )
         delivery.status = status_label
         # story #2327(재정의): "ignored"의 실제 사유를 delivery 행에도 남긴다 — HTTP 응답
@@ -711,6 +754,12 @@ async def github_webhook(
 
             for _payload in _gate_check_publish:
                 background_tasks.add_task(publish_gate_check, **_payload)
+        # story #2826(부 처방): gate-less action_required 안내도 동일하게 commit 後 발행.
+        if _ungated_check_publish:
+            from app.services.gate_github_check import publish_action_required_check
+
+            for _payload in _ungated_check_publish:
+                background_tasks.add_task(publish_action_required_check, **_payload)
         return _ok(result)
     except Exception as exc:
         await session.rollback()  # delivery insert 포함 전부 rollback → GitHub retry 가 재처리(영구 no-op 금지).

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -104,6 +104,48 @@ async def is_repo_check_enforced(
     return repo_full_name.lower() in normalized
 
 
+ACTION_REQUIRED_SUMMARY = (
+    "이 PR엔 연결된 Sprintable story가 없어 merge gate를 만들 수 없습니다.\n\n"
+    "다음 중 하나로 연결하면 gate가 자동 생성됩니다:\n"
+    "- PR 제목에 `[SID:<story-id>]` 태그 포함\n"
+    "- Sprintable의 explicit PR-story link API로 연결\n\n"
+    "연결 후 새 커밋을 push하면(또는 PR을 재오픈하면) 이 check가 자동으로 갱신됩니다."
+)
+
+
+async def publish_action_required_check(
+    installation_id: int,
+    repo_full_name: str,
+    head_sha: str,
+    pr_number: int,
+) -> None:
+    """story #2826(부 처방, PO 확定 2026-08-20) — story 링크가 없어 gate 자체가 없는 PR에도
+    `sprintable/gate`를 발행하되, 침묵 부재(check 자체가 안 뜸) 대신 **말하는 부재**로:
+    conclusion=action_required + 다음 행동 안내. gate가 없으니 DB에 남길 게 없다(원장(AC④)은
+    gate 존재를 전제 — 이 경로는 gate-less라 대상 밖, GitHub 쪽 UI 안내만).
+
+    fail-closed(이 모듈 공통 규율): 예외를 삼켜 호출자(웹훅 트랜잭션 뒤 background task)를
+    절대 깨뜨리지 않는다 — 실패해도 GitHub 쪽은 그냥 check가 없는 이전 상태 그대로.
+    """
+    try:
+        result = await create_check_run(
+            installation_id, repo_full_name, head_sha,
+            name=CHECK_NAME, status="completed", conclusion="action_required",
+            title="Sprintable Gate — story 링크 필요",
+            summary=ACTION_REQUIRED_SUMMARY,
+        )
+        if result is None:
+            logger.warning(
+                "action_required check 발행 실패(fail-closed, GitHub 쪽 무영향) repo=%s pr=%s",
+                repo_full_name, pr_number,
+            )
+    except Exception:  # noqa: BLE001 — fail-closed 경계: 백그라운드 태스크는 절대 안 죽는다.
+        logger.exception(
+            "action_required check 발행 중 예외(fail-closed, GitHub 쪽 무영향) repo=%s pr=%s",
+            repo_full_name, pr_number,
+        )
+
+
 async def publish_gate_check(
     org_id: uuid.UUID,
     gate_id: uuid.UUID,

--- a/backend/tests/test_2826_gate_pr_lifecycle_creation_realdb.py
+++ b/backend/tests/test_2826_gate_pr_lifecycle_creation_realdb.py
@@ -72,15 +72,15 @@ def _sign(body: bytes, secret: str) -> str:
 
 
 async def _post_app(payload, Session, *, delivery_id):
-    from app.dependencies.database import get_db
     from app.main import app as fastapi_app
     from app.routers import verdict_capture as mod
+    from tests.conftest import override_db_and_read
 
     async def override_db():
         async with Session() as s:
             yield s
 
-    fastapi_app.dependency_overrides[get_db] = override_db
+    override_db_and_read(fastapi_app, override_db)
     body = json.dumps(payload).encode()
     headers = {
         "X-GitHub-Event": "pull_request", "X-GitHub-Delivery": delivery_id,

--- a/backend/tests/test_2826_gate_pr_lifecycle_creation_realdb.py
+++ b/backend/tests/test_2826_gate_pr_lifecycle_creation_realdb.py
@@ -1,0 +1,299 @@
+"""story #2826(PO 확定 2026-08-20) — merge gate가 story→done 전이(evaluate_merge_gate 유일
+호출부였던 board preflight)에만 묶여 있어, PR 머지 시점엔 gate가 아직 없는 게 기본 케이스였다.
+
+주 처방: PR open/synchronize 웹훅에서 story 링크가 해소되고 gate가 없으면 evaluate_merge_gate를
+그 자리에서 재사용해 즉시 생성 + check pending 발행(AC①, AC②=board-preflight와 중복 0).
+부 처방: 링크가 아예 안 풀렸는데 이 repo가 required로 걸려 있으면(enforced) action_required
+check로 다음 행동을 안내(AC③, 링크 없으면 강제 없음=AC④와 짝인 "관측 없인 침묵" 유지).
+
+github_app.py의 실 GitHub API 호출만 mock — DB 왕복은 실 Postgres(test_2813과 동일 관례).
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+APP_SECRET = "app-secret-2826"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드.
+    import app.models.verdict  # noqa: F401 — app.models.__init__ 미등재 10건 중 하나(의도적,
+    # #2201 후속 코멘트 참고) — evaluate_merge_gate가 capture_pr_ci_verdict로 verdict 테이블을
+    # 쓰므로 이 파일에서만 로컬로 등재한다.
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _sign(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+async def _post_app(payload, Session, *, delivery_id):
+    from app.dependencies.database import get_db
+    from app.main import app as fastapi_app
+    from app.routers import verdict_capture as mod
+
+    async def override_db():
+        async with Session() as s:
+            yield s
+
+    fastapi_app.dependency_overrides[get_db] = override_db
+    body = json.dumps(payload).encode()
+    headers = {
+        "X-GitHub-Event": "pull_request", "X-GitHub-Delivery": delivery_id,
+        "X-Hub-Signature-256": _sign(body, APP_SECRET),
+    }
+    try:
+        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            with patch.object(mod.settings, "github_webhook_secret", "legacy-unused"), \
+                 patch.object(mod.settings, "github_app_webhook_secret", APP_SECRET):
+                return await c.post(
+                    "/api/v2/internal/verdict/github-webhook", content=body, headers=headers,
+                )
+    finally:
+        fastapi_app.dependency_overrides.clear()
+
+
+def _pr_payload(*, action, pr_number, installation_id, head_sha, title="chore: unrelated"):
+    return {
+        "action": action,
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "installation": {"id": installation_id},
+        "pull_request": {
+            "number": pr_number, "title": title, "body": "", "merged": False,
+            "head": {"sha": head_sha, "ref": "feat-branch"},
+        },
+    }
+
+
+async def _seed_org_project_story(s, *, with_participation: bool):
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    s.add(org)
+    await s.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    s.add(project)
+    await s.commit()
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="in-progress")
+    s.add(story)
+    await s.commit()
+
+    if with_participation:
+        from app.models.participation import Participation, ParticipationRole
+
+        role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="implementation", label="Impl", is_default=True)
+        s.add(role)
+        await s.commit()
+        member_id = uuid.uuid4()
+        s.add(Participation(id=uuid.uuid4(), org_id=org.id, story_id=story.id, member_id=member_id, role_id=role.id))
+        await s.commit()
+
+    return org, project, story
+
+
+async def _seed_installation(s, org, *, installation_id, enforced=False):
+    from app.models.github_installation import GithubInstallation
+
+    inst = GithubInstallation(
+        id=uuid.uuid4(), org_id=org.id, installation_id=installation_id, account_login="moonklabs",
+        enforced_check_repos=["moonklabs/sprintable"] if enforced else None,
+    )
+    s.add(inst)
+    await s.commit()
+    return inst
+
+
+async def _seed_link(s, org, story, *, pr_number):
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    link = PullRequestStoryLink(
+        id=uuid.uuid4(), org_id=org.id, story_id=story.id,
+        repo_full_name="moonklabs/sprintable", pr_number=pr_number,
+        link_source="explicit", confidence="high",
+    )
+    s.add(link)
+    await s.commit()
+
+
+async def _gates_for_story(s, story_id):
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    return (
+        await s.execute(
+            select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == MERGE_GATE_TYPE)
+        )
+    ).scalars().all()
+
+
+@pytest.mark.anyio
+async def test_ac1_pr_open_with_link_creates_gate_and_publishes_pending_check():
+    """AC①: 링크 있는 신규 PR — gate가 없으면 즉시 생성되고 check가 pending(in_progress)으로 뜬다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=555001)
+            await _seed_link(s, org, story, pr_number=11)
+            story_id = story.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 90001}),
+        ) as create_mock, patch("app.core.database.async_session_factory", Session):
+            payload = _pr_payload(action="opened", pr_number=11, installation_id=555001, head_sha="sha-ac1")
+            resp = await _post_app(payload, Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}")
+            assert resp.status_code == 200, resp.text
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 1, "PR-open 경로가 gate를 정확히 1개 만들어야 한다"
+            assert gates[0].status == "pending"
+
+        create_mock.assert_called_once()
+        _, kwargs = create_mock.call_args
+        assert kwargs.get("status") == "in_progress"
+        assert kwargs.get("conclusion") is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac2_pr_open_reuses_existing_gate_no_duplicate():
+    """AC②: board-preflight(또는 이전 PR 이벤트)가 이미 gate를 만들어 뒀으면, PR-open 경로가
+    새로 만들지 않고 그 gate 하나만 유지한다(2 경로 교차해도 gate 1개)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=555002)
+            await _seed_link(s, org, story, pr_number=12)
+
+            from app.models.gate import Gate
+            from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+            existing_gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending",
+            )
+            s.add(existing_gate)
+            await s.commit()
+            story_id = story.id
+            existing_gate_id = existing_gate.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 90002}),
+        ), patch("app.core.database.async_session_factory", Session):
+            payload = _pr_payload(action="synchronize", pr_number=12, installation_id=555002, head_sha="sha-ac2")
+            resp = await _post_app(payload, Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}")
+            assert resp.status_code == 200, resp.text
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 1
+            assert gates[0].id == existing_gate_id, "기존 gate가 그대로 재사용돼야(중복 생성 0)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac3_pr_open_without_link_enforced_publishes_action_required():
+    """AC③: story 링크가 아예 안 풀렸는데 이 repo가 required로 걸려 있으면(enforced) — 침묵 대신
+    action_required check로 다음 행동을 안내한다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, _story = await _seed_org_project_story(s, with_participation=False)
+            await _seed_installation(s, org, installation_id=555003, enforced=True)
+            # 링크·story 매치 자체를 안 만든다 — resolver가 no_match로 떨어지게.
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 90003}),
+        ) as create_mock, patch("app.core.database.async_session_factory", Session):
+            payload = _pr_payload(
+                action="opened", pr_number=13, installation_id=555003, head_sha="sha-ac3",
+                title="chore: no story link at all",
+            )
+            resp = await _post_app(payload, Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}")
+            assert resp.status_code == 200, resp.text
+
+        create_mock.assert_called_once()
+        _, kwargs = create_mock.call_args
+        assert kwargs.get("status") == "completed"
+        assert kwargs.get("conclusion") == "action_required"
+        assert "연결" in (kwargs.get("summary") or "")
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac4_pr_open_without_link_not_enforced_publishes_nothing():
+    """AC④(관측모드 미해): enforced_check_repos에 없는(=required 미등록) repo면 링크 없는 PR에도
+    아무 check도 안 뜬다 — 도입 마찰 0 원칙(#2813) 그대로 보존."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, _story = await _seed_org_project_story(s, with_participation=False)
+            await _seed_installation(s, org, installation_id=555004, enforced=False)
+
+        with patch(
+            "app.services.gate_github_check.create_check_run", AsyncMock(),
+        ) as create_mock, patch("app.core.database.async_session_factory", Session):
+            payload = _pr_payload(
+                action="opened", pr_number=14, installation_id=555004, head_sha="sha-ac4",
+                title="chore: no story link, not enforced",
+            )
+            resp = await _post_app(payload, Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}")
+            assert resp.status_code == 200, resp.text
+
+        create_mock.assert_not_called()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- 그라운딩 결과: `create_gate(gate_type="merge")`의 유일한 프로덕션 경로는 `evaluate_merge_gate`였고, 그 호출부는 board PATCH →done preflight 하나뿐이었다. PR open/synchronize 웹훅은 기존 gate만 재-pending할 뿐 새로 만들지 않아, `sprintable/gate` required check이 필요한 시점(머지 시도)엔 gate가 아직 없는 게 기본 케이스 — "story 링크 없음"은 그 큰 갭의 한 아종일 뿐이었다.
- **주 처방**: `verdict_capture.py`의 PR 라이프사이클 분기(opened/reopened/ready_for_review/synchronize)에서 story 링크가 해소되고 gate가 없으면 `evaluate_merge_gate`를 그 자리에서 재사용해 즉시 생성 + check pending 발행. 새 판정 로직 0개 — `create_gate`의 uq(work_item,gate_type) 멱등이 board-preflight 경로와의 중복 생성을 이미 막는다.
- **부 처방**: story 링크가 아예 안 풀렸는데 그 repo가 required로 걸려 있으면(`enforced_check_repos`) `sprintable/gate`를 `action_required`로 발행해 "story 링크가 필요하다 + 방법"을 안내(gate_github_check.py 신규 `publish_action_required_check`). 미등록 repo는 기존처럼 조용함(도입 마찰 0 보존).

## Test plan
- [x] 기존 관련 6개 파일(73 테스트) 회귀 green — test_2156/2327/2520/2813/bot_l1_pr_story_link/e_ui_daegbyeon_174be6bc
- [x] 신규 `test_2826_gate_pr_lifecycle_creation_realdb.py` 4건(AC①~④) green
- [ ] CI
- [ ] 라이브 AC(dev 배포 후, 신규 PR로 실왕복) — 카디르 QA

관련: [SID:2826]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>