### PR TITLE
feat(#2829): loop-closure P0 — 닫히지 않은 루프 감지+preset.loop.measure_due [SID:2829]

### DIFF
--- a/backend/alembic/versions/0264_loop_measure_due.py
+++ b/backend/alembic/versions/0264_loop_measure_due.py
@@ -1,0 +1,96 @@
+"""story #2829(loop-closure P0, doc loop-closure-first-class-signal-design §1) — 「닫히지
+않은 루프」 신호: measure_after 도과 hypothesis(active·measuring)/goal(active) 도과 시
+preset.loop.measure_due 발행 대상 컬럼 + 프리셋 정의 시드.
+
+Revision ID: 0264
+Revises: 0263
+Create Date: 2026-08-20
+"""
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0264"
+down_revision = "0263"
+branch_labels = None
+depends_on = None
+
+_KEY = "preset.loop.measure_due"
+
+# routing: kind=payload_field(owner) — 이 이벤트를 발행하는 자리(cron job)가 이미 goal_owner/
+# hypothesis owner_member_id를 알고 있으므로(스캔 쿼리 자체가 그 값을 읽는다) server_derived
+# 신규 해석기(SERVER_DERIVED_TARGETS 확장)를 추가하는 대신 기존 payload_field 부류를 그대로
+# 쓴다 — preset.work.assigned(0245)와 동일 판단(설계 doc의 "새 규칙 발명 금지" 정신).
+_ROUTING = {
+    "escalation": {
+        "kind": "payload_field", "target": "owner", "member_id_field": "owner_member_id",
+    },
+    "broadcast": {"kind": "server_derived", "target": "none"},
+}
+
+_PAYLOAD_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["work_item_type", "work_item_id", "owner_member_id", "reason"],
+    "properties": {
+        # "epic"= 실체 Goal의 work_item_type 리터럴(B1 rename 前 이름이 project 해소 계통
+        # 전체의 SSOT로 그대로 남아 있음 — gate_service.resolve_work_item_project_id 참조,
+        # 새 리터럴 "goal"을 추가하면 그 해소기가 못 풀어 발행이 400으로 죽는다).
+        "work_item_type": {"type": "string", "enum": ["epic", "hypothesis"]},
+        "work_item_id": {"type": "string", "format": "uuid"},
+        "owner_member_id": {"type": "string", "format": "uuid"},
+        # done_without_outcome 케이스(§1 대상 2류)는 measure_after가 애초에 없을 수 있어
+        # nullable — "도과"와 "outcome 없이 done"은 다른 판정 축이라 FE 배지도 갈린다.
+        "measure_after": {"type": ["string", "null"], "format": "date-time"},
+        "overdue_days": {"type": ["number", "null"]},
+        "reason": {"type": "string", "enum": ["measure_after_overdue", "done_without_outcome"]},
+    },
+}
+
+_event_definitions = sa.table(
+    "event_definitions",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("key", sa.Text),
+    sa.column("org_id", postgresql.UUID(as_uuid=True)),
+    sa.column("name", sa.Text),
+    sa.column("payload_schema", postgresql.JSONB),
+    sa.column("routing", postgresql.JSONB),
+    sa.column("enabled", sa.Boolean),
+    sa.column("version", sa.Integer),
+    sa.column("created_by", postgresql.UUID(as_uuid=True)),
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "hypotheses",
+        sa.Column("loop_measure_due_notified_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "goals",
+        sa.Column("loop_measure_due_notified_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.bulk_insert(
+        _event_definitions,
+        [{
+            "id": uuid.uuid4(),
+            "key": _KEY,
+            "org_id": None,
+            "name": "측정 기한 도과",
+            "payload_schema": _PAYLOAD_SCHEMA,
+            "routing": _ROUTING,
+            "enabled": True,
+            "version": 1,
+            "created_by": None,
+        }],
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM event_definitions WHERE key = :key AND org_id IS NULL").bindparams(key=_KEY))
+    op.drop_column("goals", "loop_measure_due_notified_at")
+    op.drop_column("hypotheses", "loop_measure_due_notified_at")

--- a/backend/app/models/hypothesis.py
+++ b/backend/app/models/hypothesis.py
@@ -108,6 +108,14 @@ class Hypothesis(Base, OrgScopedMixin, TimestampMixin):
         UUID(as_uuid=True), ForeignKey("hypotheses.id", ondelete="SET NULL"), nullable=True
     )
 
+    # story #2829(loop-closure P0, migration 0264) — preset.loop.measure_due 중복발행 방지.
+    # measure_after 도과 시 1회만 발행하고 이 컬럼을 찍는다(재발행 없음 — org_subscription.
+    # storage_warn_notified_at과 동형 set-once 패턴). outcome 판정으로 상태가 바뀌면 조회
+    # 조건(status IN active/measuring) 자체를 벗어나 자연히 재발행 대상에서도 빠진다.
+    loop_measure_due_notified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     __table_args__ = (
         # §2.3 제약
         CheckConstraint(

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -82,6 +82,11 @@ class Goal(Base, OrgScopedMixin, TimestampMixin):
     source_loop_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("loop_runs.id", ondelete="SET NULL"), nullable=True
     )
+    # story #2829(loop-closure P0, migration 0264) — preset.loop.measure_due 중복발행 방지
+    # (hypotheses.loop_measure_due_notified_at과 동형 set-once 패턴, 컬럼 주석 참조).
+    loop_measure_due_notified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     project: Mapped["Project"] = relationship("Project", back_populates="epics")
     stories: Mapped[list["Story"]] = relationship("Story", back_populates="epic", lazy="select")

--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -520,6 +520,38 @@ async def my_actions(
             )
         )
     ).scalar_one()
+    # 페드루 PO AC 리뷰 보완①(#3253, 2026-08-20) — items[]는 류별 top-20으로 잘리는데 N은
+    # "0으로 수렴하는가" 판별 기준 그 자체라 참값이어야 한다(실측: outcome 없는 done goal
+    # 51건 vs items 상한 20 — cap이 N을 접어 버리면 그 판별이 거짓말이 된다). items 목록과는
+    # 별도로 류별 total count를 3개 더 얹는다(카운트 쿼리라 20개 fetch보다 오히려 가볍다).
+    loop_overdue_hypothesis_count = (
+        await session.execute(
+            select(func.count()).select_from(Hypothesis).where(
+                Hypothesis.org_id == org_id,
+                Hypothesis.status.in_(("active", "measuring")),
+                Hypothesis.measure_after <= now,
+            )
+        )
+    ).scalar_one()
+    loop_overdue_goal_count = (
+        await session.execute(
+            select(func.count()).select_from(Goal).where(
+                Goal.org_id == org_id,
+                Goal.status == "active",
+                Goal.measure_after.isnot(None),
+                Goal.measure_after <= now,
+            )
+        )
+    ).scalar_one()
+    loop_outcome_missing_goal_count = (
+        await session.execute(
+            select(func.count()).select_from(Goal).where(
+                Goal.org_id == org_id,
+                Goal.status == "done",
+                Goal.outcome_status == "n_a",
+            )
+        )
+    ).scalar_one()
 
     return JSONResponse(content={
         "action_queue": {  # scope: member(caller) — 타 멤버 큐 노출 0.
@@ -533,6 +565,11 @@ async def my_actions(
             # story #2829 — N 비포함·집계만(doc a8e73bdb §2 PO 보완 지시). 카드 하단 보조
             # 텍스트("+{count}건은 측정계획이 아직 없음")용, items[]엔 개별 목록 없음.
             "measure_plan_missing_goal_count": measure_plan_missing_goal_count,
+            # PO 리뷰 보완①(#3253) — items[]의 top-20 cap과 무관한 참값. FE의 N = 이 세 필드
+            # 합(items.length가 아니라). "0으로 수렴하는가" 판별은 반드시 이 값을 써야 한다.
+            "loop_overdue_hypothesis_count": loop_overdue_hypothesis_count,
+            "loop_overdue_goal_count": loop_overdue_goal_count,
+            "loop_outcome_missing_goal_count": loop_outcome_missing_goal_count,
         },
         "is_clear": len(queue) == 0 and len(attention_items) == 0,
     })

--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -447,6 +447,79 @@ async def my_actions(
             "falsified_days": (now - updated_at).days if updated_at else None,
             "superseded_by_hypothesis_id": str(superseded_by) if superseded_by else None,
         })
+    # 5) story #2829(loop-closure P0, doc loop-closure-first-class-signal-design §1·§3
+    # 계약=미르코군 doc a8e73bdb 그대로) — 「닫히지 않은 루프」: N에 포함되는 2류(도과+outcome
+    # 없이 done). loop_measure_due_notified_at(발행 여부)과 무관하게 항상 실물을 그대로
+    # 센다 — 발행 성패가 "닫히지 않았다"는 사실 자체를 안 바꾼다(서비스 모듈독스트링 참조).
+    overdue_hyps = (
+        await session.execute(
+            select(Hypothesis.id, Hypothesis.statement, Hypothesis.measure_after, Hypothesis.owner_member_id)
+            .where(
+                Hypothesis.org_id == org_id,
+                Hypothesis.status.in_(("active", "measuring")),
+                Hypothesis.measure_after <= now,
+            )
+            .order_by(Hypothesis.measure_after.asc())
+            .limit(20)
+        )
+    ).all()
+    for hyp_id, statement, measure_after, owner_id in overdue_hyps:
+        attention_items.append({
+            "type": "loop_overdue_hypothesis", "severity": "warn", "auto_detected": True,
+            "hypothesis_id": str(hyp_id), "statement": statement,
+            "owner_member_id": str(owner_id) if owner_id else None,
+            "overdue_days": (now - measure_after).days if measure_after else None,
+        })
+    overdue_goals = (
+        await session.execute(
+            select(Goal.id, Goal.title, Goal.measure_after, Goal.assignee_id)
+            .where(
+                Goal.org_id == org_id,
+                Goal.status == "active",
+                Goal.measure_after.isnot(None),
+                Goal.measure_after <= now,
+            )
+            .order_by(Goal.measure_after.asc())
+            .limit(20)
+        )
+    ).all()
+    for goal_id, title, measure_after, assignee_id in overdue_goals:
+        attention_items.append({
+            "type": "loop_overdue_goal", "severity": "warn", "auto_detected": True,
+            "goal_id": str(goal_id), "title": title,
+            "owner_member_id": str(assignee_id) if assignee_id else None,
+            "overdue_days": (now - measure_after).days if measure_after else None,
+        })
+    done_no_outcome_goals = (
+        await session.execute(
+            select(Goal.id, Goal.title, Goal.updated_at, Goal.assignee_id)
+            .where(
+                Goal.org_id == org_id,
+                Goal.status == "done",
+                Goal.outcome_status == "n_a",
+            )
+            .order_by(Goal.updated_at.asc())
+            .limit(20)
+        )
+    ).all()
+    for goal_id, title, updated_at, assignee_id in done_no_outcome_goals:
+        attention_items.append({
+            "type": "loop_outcome_missing_goal", "severity": "warn", "auto_detected": True,
+            "goal_id": str(goal_id), "title": title,
+            "owner_member_id": str(assignee_id) if assignee_id else None,
+            "done_days": (now - updated_at).days if updated_at else None,
+        })
+    # N에서 제외하되 집계는 유지(페드루 PO 보완 지시, doc a8e73bdb §2) — measure_after
+    # 자체가 없는 active goal. AC상 클릭 목록 요건이 없어 개별 목록은 안 싣는다(카운트만).
+    measure_plan_missing_goal_count = (
+        await session.execute(
+            select(func.count()).select_from(Goal).where(
+                Goal.org_id == org_id,
+                Goal.status == "active",
+                Goal.measure_after.is_(None),
+            )
+        )
+    ).scalar_one()
 
     return JSONResponse(content={
         "action_queue": {  # scope: member(caller) — 타 멤버 큐 노출 0.
@@ -457,6 +530,9 @@ async def my_actions(
             "scope": "org",
             "items": attention_items,
             "pending": ["time_sensitive"],  # 잔여 미구현(overdue/스프린트 D-N·due 소스 부재).
+            # story #2829 — N 비포함·집계만(doc a8e73bdb §2 PO 보완 지시). 카드 하단 보조
+            # 텍스트("+{count}건은 측정계획이 아직 없음")용, items[]엔 개별 목록 없음.
+            "measure_plan_missing_goal_count": measure_plan_missing_goal_count,
         },
         "is_clear": len(queue) == 0 and len(attention_items) == 0,
     })

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -613,6 +613,29 @@ async def score_hypotheses_cron(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── POST /api/v2/internal/cron/detect-unclosed-loops ──────────────────────────
+
+@router.post("/detect-unclosed-loops")
+async def detect_unclosed_loops_cron(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """story #2829(loop-closure P0) — 「닫히지 않은 루프」 감지 + preset.loop.measure_due
+    발행. 판정 축·set-once 발행 근거는 app.services.loop_measure_due 모듈독스트링 참조.
+    """
+    verify_cron(request)
+
+    from app.services.loop_measure_due import detect_unclosed_loops
+
+    try:
+        summary = await detect_unclosed_loops(session)
+        await session.commit()
+        return _ok(summary)
+    except Exception as exc:
+        logger.exception("detect-unclosed-loops cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 # ─── POST /api/v2/internal/cron/embed-backlog ──────────────────────────────────
 
 @router.post("/embed-backlog")

--- a/backend/app/services/loop_measure_due.py
+++ b/backend/app/services/loop_measure_due.py
@@ -1,0 +1,152 @@
+"""story #2829(loop-closure P0, doc loop-closure-first-class-signal-design §1) — 「닫히지
+않은 루프」 감지 + preset.loop.measure_due 발행.
+
+대상 2류(설계 doc §1 그대로, 새 판정축 발명 0):
+    ①measure_after 도과 hypothesis(status active|measuring) — measuring 도과 = 채점
+      실패/미지원(hypothesis_scorer.py가 measuring 유지)라 이 축이 그 사각을 대신 신호한다.
+    ①measure_after 도과 goal(status active)
+    ②outcome 판정 없이 done된 goal(outcome_status='n_a')
+
+발행은 대상당 **1회**(loop_measure_due_notified_at set-once — 컬럼 주석 참조, 무한
+재발행 방지=AC③). outcome이 실제로 해소되면(hypothesis status 전이·goal outcome_status
+갱신) 조회 조건 자체를 벗어나 자연 소멸 — 별도 "해제" 로직 불요.
+
+owner_member_id가 없으면(goal 미배정) 발행 대상에서 제외(escalation routing이 payload_
+field라 받는 쪽이 없으면 발행 자체가 무의미) — 카운터 API(§3, command_center.py)는 이
+필터와 무관하게 항상 실물 그대로 센다(발행 성패가 "닫히지 않았다"는 사실을 안 바꾼다).
+
+⛔SAVEPOINT로 감싸지 않는다(hypothesis_scorer.py와 달리) — publish_preset_event는 내부
+send_message()가 자체 commit을 이미 수행하는 자기완결 트랜잭션이라, 이걸 session.
+begin_nested()로 한 번 더 감싸면 그 내부 commit이 바깥 SAVEPOINT까지 닫아버려 "closed
+transaction" 오류가 난다(실측 확認). 개별 try/except만으로 격리한다 — 실제 자매 호출부
+(cron.py의 preset.goal.measured 발행)도 동일하게 SAVEPOINT 없이 try/except뿐이다.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.hypothesis import Hypothesis
+from app.models.pm import Goal
+
+logger = logging.getLogger(__name__)
+
+_PRESET_KEY = "preset.loop.measure_due"
+_ACTIVE_HYPOTHESIS_STATUSES = ("active", "measuring")
+
+
+async def _publish_one(
+    session: AsyncSession, *, org_id, payload: dict,
+) -> None:
+    from app.routers.events import publish_preset_event
+
+    await publish_preset_event(session, org_id, _PRESET_KEY, payload)
+
+
+async def detect_unclosed_loops(session: AsyncSession) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    published: list[dict] = []
+    failed: list[dict] = []
+    skipped_no_owner = 0
+
+    # ① 도과 hypothesis(active·measuring)
+    hyp_rows = (
+        await session.execute(
+            select(Hypothesis).where(
+                Hypothesis.status.in_(_ACTIVE_HYPOTHESIS_STATUSES),
+                Hypothesis.measure_after <= now,
+                Hypothesis.loop_measure_due_notified_at.is_(None),
+            )
+        )
+    ).scalars().all()
+    for hyp in hyp_rows:
+        if not hyp.owner_member_id:
+            skipped_no_owner += 1
+            continue
+        payload = {
+            "work_item_type": "hypothesis",
+            "work_item_id": str(hyp.id),
+            "owner_member_id": str(hyp.owner_member_id),
+            "measure_after": hyp.measure_after.isoformat(),
+            "overdue_days": (now - hyp.measure_after).days,
+            "reason": "measure_after_overdue",
+        }
+        try:
+            await _publish_one(session, org_id=hyp.org_id, payload=payload)
+            hyp.loop_measure_due_notified_at = now
+            published.append({"type": "hypothesis", "id": str(hyp.id)})
+        except Exception as exc:  # noqa: BLE001 — best-effort(호출자 계약, publish_preset_event docstring).
+            logger.warning("loop.measure_due 발행 실패 hypothesis=%s: %s", hyp.id, exc, exc_info=True)
+            failed.append({"type": "hypothesis", "id": str(hyp.id), "error": str(exc)})
+
+    # ① 도과 goal(active)
+    overdue_goal_rows = (
+        await session.execute(
+            select(Goal).where(
+                Goal.status == "active",
+                Goal.measure_after.isnot(None),
+                Goal.measure_after <= now,
+                Goal.loop_measure_due_notified_at.is_(None),
+            )
+        )
+    ).scalars().all()
+    for goal in overdue_goal_rows:
+        if not goal.assignee_id:
+            skipped_no_owner += 1
+            continue
+        payload = {
+            "work_item_type": "epic",  # 실체=Goal, project 해소 SSOT 리터럴(payload_schema 주석 참조).
+            "work_item_id": str(goal.id),
+            "owner_member_id": str(goal.assignee_id),
+            "measure_after": goal.measure_after.isoformat(),
+            "overdue_days": (now - goal.measure_after).days,
+            "reason": "measure_after_overdue",
+        }
+        try:
+            await _publish_one(session, org_id=goal.org_id, payload=payload)
+            goal.loop_measure_due_notified_at = now
+            published.append({"type": "goal", "id": str(goal.id), "reason": "measure_after_overdue"})
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("loop.measure_due 발행 실패 goal=%s: %s", goal.id, exc, exc_info=True)
+            failed.append({"type": "goal", "id": str(goal.id), "error": str(exc)})
+
+    # ② outcome 판정 없이 done된 goal
+    done_no_outcome_rows = (
+        await session.execute(
+            select(Goal).where(
+                Goal.status == "done",
+                Goal.outcome_status == "n_a",
+                Goal.loop_measure_due_notified_at.is_(None),
+            )
+        )
+    ).scalars().all()
+    for goal in done_no_outcome_rows:
+        if not goal.assignee_id:
+            skipped_no_owner += 1
+            continue
+        payload = {
+            "work_item_type": "epic",  # 실체=Goal, project 해소 SSOT 리터럴(payload_schema 주석 참조).
+            "work_item_id": str(goal.id),
+            "owner_member_id": str(goal.assignee_id),
+            "measure_after": goal.measure_after.isoformat() if goal.measure_after else None,
+            "overdue_days": None,
+            "reason": "done_without_outcome",
+        }
+        try:
+            await _publish_one(session, org_id=goal.org_id, payload=payload)
+            goal.loop_measure_due_notified_at = now
+            published.append({"type": "goal", "id": str(goal.id), "reason": "done_without_outcome"})
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("loop.measure_due 발행 실패 goal(done)=%s: %s", goal.id, exc, exc_info=True)
+            failed.append({"type": "goal", "id": str(goal.id), "error": str(exc)})
+
+    return {
+        "published": published,
+        "failed": failed,
+        "skipped_no_owner": skipped_no_owner,
+        "total_scanned": len(hyp_rows) + len(overdue_goal_rows) + len(done_no_outcome_rows),
+    }

--- a/backend/app/services/loop_measure_due.py
+++ b/backend/app/services/loop_measure_due.py
@@ -15,6 +15,15 @@ owner_member_id가 없으면(goal 미배정) 발행 대상에서 제외(escalati
 field라 받는 쪽이 없으면 발행 자체가 무의미) — 카운터 API(§3, command_center.py)는 이
 필터와 무관하게 항상 실물 그대로 센다(발행 성패가 "닫히지 않았다"는 사실을 안 바꾼다).
 
+⛔못 잡는 것(AC⑤, 페드루 PO 판정 2026-08-20 — P0 관측 단계에선 fix 대신 선언으로 수용):
+set-once가 「재도과」를 못 잡는다 — 한 번 발행돼 notified_at이 찍힌 뒤, 그 hypothesis/goal의
+outcome이 해소되지 않은 채 owner가 measure_after를 미래로 늘려 잡았다가 그 새 날짜도 다시
+지나면, notified_at이 이미 non-NULL이라 재발행이 안 된다(조회 조건 `IS NULL`을 영원히
+못 만족). 카운터 API(§3)는 measure_after<=now만 보므로 이 케이스도 N에는 여전히 잡히지만
+(관측 축은 안전), preset 이벤트(액션 알림 축)만 조용히 죽는다. P1(outcome 커플링) 이후
+재검토 — 지금은 "발행 1회 보장"이 "매 재도과마다 재알림"보다 단순·안전(무한루프 방지 원칙과
+직접 충돌)하므로 이 gap을 의도적으로 수용한다.
+
 ⛔SAVEPOINT로 감싸지 않는다(hypothesis_scorer.py와 달리) — publish_preset_event는 내부
 send_message()가 자체 commit을 이미 수행하는 자기완결 트랜잭션이라, 이걸 session.
 begin_nested()로 한 번 더 감싸면 그 내부 commit이 바깥 SAVEPOINT까지 닫아버려 "closed

--- a/backend/tests/test_2829_loop_measure_due_realdb.py
+++ b/backend/tests/test_2829_loop_measure_due_realdb.py
@@ -98,12 +98,17 @@ async def test_ac1_detects_overdue_hypothesis_and_goal_and_missing_outcome():
             summary = await _detect(s, Session)
             await s.commit()
 
-            assert summary["total_scanned"] == 3
+            # total_scanned은 전-org 글로벌 카운트라(cron 잡 설계 그대로 — command_center.py
+            # 실서비스 요구에 맞춘 것) CI의 공유 Backend pytest 세션(다른 6000+ 테스트가
+            # 같은 DB에 Goal/Hypothesis를 남길 수 있음)에서 정확한 값으로 단정할 수 없다 —
+            # 이 AC가 증명해야 하는 건 "이 3개가 실물로 잡혔다"이지 "전체가 정확히 3개"가
+            # 아니다(실측 확認: 로컬 격리 실행=3, CI 공유 세션=5도 관측·둘 다 정상).
             published_ids = {p["id"] for p in summary["published"]}
             assert str(hyp.id) in published_ids
             assert str(overdue_goal.id) in published_ids
             assert str(done_goal.id) in published_ids
-            assert summary["failed"] == []
+            my_ids = {str(hyp.id), str(overdue_goal.id), str(done_goal.id)}
+            assert not (my_ids & {f["id"] for f in summary["failed"]})
     finally:
         await engine.dispose()
 
@@ -121,19 +126,23 @@ async def test_ac2_no_infinite_republish_set_once():
 
             first = await _detect(s, Session)
             await s.commit()
-            assert len(first["published"]) == 1
+            first_ids = {p["id"] for p in first["published"]}
+            assert str(hyp.id) in first_ids
 
             second = await _detect(s, Session)
             await s.commit()
-            assert second["published"] == []
-            assert second["total_scanned"] == 0  # notified_at set → 조회 조건 자체를 벗어남.
+            # first/second 둘 다 CI 공유 Backend pytest 세션(다른 테스트가 남긴 미통지
+            # 항목과 같은 DB를 쓸 수 있음)에서 published/total_scanned 절대 수는 이 테스트
+            # 스코프 밖 — id로 직접 증명한다: 이 hyp이 두 번째 스캔에선 대상에서 빠졌다.
+            second_ids = {p["id"] for p in second["published"]}
+            assert str(hyp.id) not in second_ids
 
         async with Session() as s:
             events = await _published_events(s, org.id)
             # 정확한 행 수는 send_message()의 배달 팬아웃 정책(공유 이벤트 발행 계통, 이
             # 스토리 스코프 밖) 몫이라 단정하지 않는다 — 이 AC가 실제로 증명해야 하는 것은
-            # 위 first/second summary(두 번째 스캔=published 0·total_scanned 0)로 이미
-            # 확定됐다: **동일 대상에 두 번째 publish_preset_event 호출 자체가 없었다.**
+            # 위 first/second id 대조로 이미 확定됐다: **동일 대상에 두 번째 publish_
+            # preset_event 호출 자체가 없었다.**
             assert len(events) >= 1, "최초 1회 발행 자체는 실물로 남아야 한다"
     finally:
         await engine.dispose()
@@ -147,14 +156,16 @@ async def test_ac4_no_owner_is_skipped_not_failed():
         async with Session() as s:
             org = await _make_org(s)
             project = await _make_project(s, org.id)
-            await _make_goal(s, org.id, project.id, assignee_id=None, status="active")
+            goal = await _make_goal(s, org.id, project.id, assignee_id=None, status="active")
 
             summary = await _detect(s, Session)
             await s.commit()
 
-            assert summary["published"] == []
-            assert summary["failed"] == []
-            assert summary["skipped_no_owner"] == 1
+            # published/failed/skipped_no_owner 전부 글로벌 카운트(CI 공유 세션 - AC1/AC2와
+            # 동일 근거) — 이 goal의 id로만 직접 증명한다.
+            assert str(goal.id) not in {p["id"] for p in summary["published"]}
+            assert str(goal.id) not in {f["id"] for f in summary["failed"]}
+            assert summary["skipped_no_owner"] >= 1
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_2829_loop_measure_due_realdb.py
+++ b/backend/tests/test_2829_loop_measure_due_realdb.py
@@ -1,0 +1,186 @@
+"""story #2829(loop-closure P0) — detect_unclosed_loops 실PG 검증.
+
+`preset.loop.measure_due`가 migration 0264 시드 데이터(EventDefinition)라 create_all
+스키마가 아니라 **alembic-migrated DB**가 필요하다(publish_preset_event가 이 정의 행을
+읽어야 발행이 성립 — create_all은 모델 테이블만 짓고 데이터 시드는 안 한다).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+
+from app.services.loop_measure_due import detect_unclosed_loops
+from tests.test_1994_backlink_api_realdb import _make_org, _make_project, _session_factory
+from tests.test_2288_command_center_gate_type_waiting_realdb import _make_member
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+_METRIC = {"metric": "signups", "source": "db", "target": 100, "direction": "increase"}
+_PAST = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _make_hypothesis(session, org_id, project_id, owner_id, *, status="measuring", measure_after=_PAST):
+    from app.models.hypothesis import Hypothesis
+    hyp = Hypothesis(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, owner_member_id=owner_id,
+        statement="stmt", metric_definition=_METRIC, measure_after=measure_after, status=status,
+    )
+    session.add(hyp)
+    await session.commit()
+    return hyp
+
+
+async def _make_goal(
+    session, org_id, project_id, assignee_id, *,
+    status="active", measure_after=_PAST, outcome_status="n_a",
+):
+    from app.models.pm import Goal
+    goal = Goal(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, assignee_id=assignee_id,
+        title="G", status=status, measure_after=measure_after, outcome_status=outcome_status,
+    )
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
+async def _detect(session, Session):
+    """detect_unclosed_loops를 직접(HTTP 무경유) 호출하는 테스트 전용 wrapper — publish_
+    preset_event의 배경 배달 경로가 async_session_factory()(모듈 전역)로 **별도 세션**을
+    여는 지점이 있어(test_2813_gate_github_check_realdb.py와 동일 관례), 그걸 이 테스트의
+    Session으로 패치하지 않으면 app.core.database의 기본 설정(포트 54322 기본값 — story
+    #2818에서 이미 파악한 그 축과 동형)으로 새 연결을 시도해 실패한다."""
+    with patch("app.core.database.async_session_factory", Session):
+        return await detect_unclosed_loops(session)
+
+
+async def _published_events(session, org_id):
+    from app.models.event import Event  # story #2632/#2791 발행 이력 테이블(org 격리 — 이 org엔 이것뿐).
+
+    return (await session.execute(select(Event).where(Event.org_id == org_id))).scalars().all()
+
+
+@pytest.mark.anyio
+async def test_ac1_detects_overdue_hypothesis_and_goal_and_missing_outcome():
+    """AC①: 세 축(가설 도과·goal 도과·outcome 없는 done goal) 전부 실물로 잡힌다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, _ = await _make_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, owner_id)
+            overdue_goal = await _make_goal(s, org.id, project.id, owner_id, status="active")
+            done_goal = await _make_goal(
+                s, org.id, project.id, owner_id, status="done", measure_after=None, outcome_status="n_a",
+            )
+
+            summary = await _detect(s, Session)
+            await s.commit()
+
+            assert summary["total_scanned"] == 3
+            published_ids = {p["id"] for p in summary["published"]}
+            assert str(hyp.id) in published_ids
+            assert str(overdue_goal.id) in published_ids
+            assert str(done_goal.id) in published_ids
+            assert summary["failed"] == []
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac2_no_infinite_republish_set_once():
+    """AC③: 같은 대상에 두 번째 스캔에서 재발행되지 않는다(loop_measure_due_notified_at set-once)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, _ = await _make_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, owner_id)
+
+            first = await _detect(s, Session)
+            await s.commit()
+            assert len(first["published"]) == 1
+
+            second = await _detect(s, Session)
+            await s.commit()
+            assert second["published"] == []
+            assert second["total_scanned"] == 0  # notified_at set → 조회 조건 자체를 벗어남.
+
+        async with Session() as s:
+            events = await _published_events(s, org.id)
+            # 정확한 행 수는 send_message()의 배달 팬아웃 정책(공유 이벤트 발행 계통, 이
+            # 스토리 스코프 밖) 몫이라 단정하지 않는다 — 이 AC가 실제로 증명해야 하는 것은
+            # 위 first/second summary(두 번째 스캔=published 0·total_scanned 0)로 이미
+            # 확定됐다: **동일 대상에 두 번째 publish_preset_event 호출 자체가 없었다.**
+            assert len(events) >= 1, "최초 1회 발행 자체는 실물로 남아야 한다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac4_no_owner_is_skipped_not_failed():
+    """못 잡는 것 선언 대상 — assignee 없는 goal은 발행 스킵(라우팅 불가), failed로 세지 않는다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            await _make_goal(s, org.id, project.id, assignee_id=None, status="active")
+
+            summary = await _detect(s, Session)
+            await s.commit()
+
+            assert summary["published"] == []
+            assert summary["failed"] == []
+            assert summary["skipped_no_owner"] == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolved_outcome_naturally_exits_scan():
+    """상태 전이 후 자연 소멸 — hypothesis가 verified로 넘어가면 다음 스캔에서 대상에서 빠진다
+    (별도 '해제' 로직 없이 조회 조건만으로 충분함을 실측)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, _ = await _make_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, owner_id, status="measuring")
+
+            hyp.status = "verified"
+            await s.commit()
+
+            summary = await _detect(s, Session)
+            await s.commit()
+            # total_scanned은 이 잡의 설계상 전-org 글로벌 카운트라(다른 테스트가 남긴
+            # owner-없는 goal 등도 매 스캔 재등장 — #2829 못 잡는 것 선언 대상, 아래 참조)
+            # 공유 DB에서 단정하기 부적합하다. 이 AC가 증명해야 하는 것은 "이 hypothesis가
+            # 대상에서 빠졌다"는 것 하나뿐 — id로 직접 확認한다.
+            published_ids = {p["id"] for p in summary["published"]}
+            assert str(hyp.id) not in published_ids
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -95,6 +95,7 @@ def _data(resp):
 def _ma_seq(
     approvals=(), reviews=(), my_blockers=(), waiting=(), stuck=(), stalled=(), unanswered=(),
     my_tasks=(), approval_group_counts=(), blocker_weight_counts=(), falsified=(),
+    overdue_hyps=(), overdue_goals=(), done_no_outcome_goals=(), measure_plan_missing_goal_count=0,
 ):
     seq = [_r_all(approvals)]
     if approvals:
@@ -109,6 +110,11 @@ def _ma_seq(
     seq.append(_r_all(stalled))
     seq.append(_r_all(unanswered))
     seq.append(_r_all(falsified))  # story #2539
+    # story #2829(loop-closure P0) — 「닫히지 않은 루프」 3쿼리 + 미설정 goal 카운트 1쿼리.
+    seq.append(_r_all(overdue_hyps))
+    seq.append(_r_all(overdue_goals))
+    seq.append(_r_all(done_no_outcome_goals))
+    seq.append(_r_scalar(measure_plan_missing_goal_count))
     return seq
 
 
@@ -281,6 +287,33 @@ async def test_my_actions_hypothesis_falsified_superseded_by_null_when_unconfirm
     hf = next(i for i in items if i["type"] == "hypothesis_falsified")
     assert hf["superseded_by_hypothesis_id"] is None
     assert hf["outcome_result"] is None
+
+
+@pytest.mark.anyio
+async def test_my_actions_loop_closure_items_and_measure_plan_missing_count():
+    """story #2829: 「닫히지 않은 루프」 3타입(가설 도과·goal 도과·outcome 없는 done)이
+    attention.items[]에 실리고, 측정계획 없는 active goal 수는 N에서 제외된 채 별도 스칼라
+    필드로만 실린다(doc a8e73bdb §2 PO 확定 — 페드루 보완 지시)."""
+    hyp_id, goal_id, done_goal_id, owner_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(
+            overdue_hyps=[(hyp_id, "체크아웃 개선 가설", _OLD, owner_id)],
+            overdue_goals=[(goal_id, "Q3 활성화", _OLD, owner_id)],
+            done_no_outcome_goals=[(done_goal_id, "런칭", _OLD, owner_id)],
+            measure_plan_missing_goal_count=40,
+        ))
+    assert resp.status_code == 200
+    body = _data(resp)
+    items_by_type = {i["type"]: i for i in body["attention"]["items"]}
+    oh = items_by_type["loop_overdue_hypothesis"]
+    assert oh["hypothesis_id"] == str(hyp_id) and oh["owner_member_id"] == str(owner_id)
+    og = items_by_type["loop_overdue_goal"]
+    assert og["goal_id"] == str(goal_id) and isinstance(og["overdue_days"], int)
+    om = items_by_type["loop_outcome_missing_goal"]
+    assert om["goal_id"] == str(done_goal_id) and isinstance(om["done_days"], int)
+    # N(=items 카운트)에 measure_plan_missing 3건은 포함 안 됨(위 3개뿐) — 별도 스칼라만.
+    assert body["attention"]["measure_plan_missing_goal_count"] == 40
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -96,6 +96,7 @@ def _ma_seq(
     approvals=(), reviews=(), my_blockers=(), waiting=(), stuck=(), stalled=(), unanswered=(),
     my_tasks=(), approval_group_counts=(), blocker_weight_counts=(), falsified=(),
     overdue_hyps=(), overdue_goals=(), done_no_outcome_goals=(), measure_plan_missing_goal_count=0,
+    loop_overdue_hypothesis_count=None, loop_overdue_goal_count=None, loop_outcome_missing_goal_count=None,
 ):
     seq = [_r_all(approvals)]
     if approvals:
@@ -110,11 +111,21 @@ def _ma_seq(
     seq.append(_r_all(stalled))
     seq.append(_r_all(unanswered))
     seq.append(_r_all(falsified))  # story #2539
-    # story #2829(loop-closure P0) — 「닫히지 않은 루프」 3쿼리 + 미설정 goal 카운트 1쿼리.
+    # story #2829(loop-closure P0) — 「닫히지 않은 루프」 3쿼리 + 미설정 goal 카운트 1쿼리 +
+    # PO 리뷰 보완①(#3253) 류별 total count 3쿼리(items[]와 별개로 항상 참값).
     seq.append(_r_all(overdue_hyps))
     seq.append(_r_all(overdue_goals))
     seq.append(_r_all(done_no_outcome_goals))
     seq.append(_r_scalar(measure_plan_missing_goal_count))
+    seq.append(_r_scalar(
+        loop_overdue_hypothesis_count if loop_overdue_hypothesis_count is not None else len(overdue_hyps)
+    ))
+    seq.append(_r_scalar(
+        loop_overdue_goal_count if loop_overdue_goal_count is not None else len(overdue_goals)
+    ))
+    seq.append(_r_scalar(
+        loop_outcome_missing_goal_count if loop_outcome_missing_goal_count is not None else len(done_no_outcome_goals)
+    ))
     return seq
 
 
@@ -302,6 +313,9 @@ async def test_my_actions_loop_closure_items_and_measure_plan_missing_count():
             overdue_goals=[(goal_id, "Q3 활성화", _OLD, owner_id)],
             done_no_outcome_goals=[(done_goal_id, "런칭", _OLD, owner_id)],
             measure_plan_missing_goal_count=40,
+            # PO 리뷰 보완①(#3253) — items[]는 top-20 cap(위 각 1건뿐)인데 total count는
+            # 참값(51)이어야 한다는 게 이 보완의 핵심 — 일부러 items 길이와 다르게 준다.
+            loop_outcome_missing_goal_count=51,
         ))
     assert resp.status_code == 200
     body = _data(resp)
@@ -314,6 +328,10 @@ async def test_my_actions_loop_closure_items_and_measure_plan_missing_count():
     assert om["goal_id"] == str(done_goal_id) and isinstance(om["done_days"], int)
     # N(=items 카운트)에 measure_plan_missing 3건은 포함 안 됨(위 3개뿐) — 별도 스칼라만.
     assert body["attention"]["measure_plan_missing_goal_count"] == 40
+    # PO 리뷰 보완① 핵심 단정 — items[]는 1건뿐이어도 total count는 51(cap과 무관한 참값).
+    assert body["attention"]["loop_outcome_missing_goal_count"] == 51
+    assert body["attention"]["loop_overdue_hypothesis_count"] == 1
+    assert body["attention"]["loop_overdue_goal_count"] == 1
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- 결재 승인 설계 카드(doc `loop-closure-first-class-signal-design`) P0 BE 축 — measure_after 도과 hypothesis(active/measuring)·goal(active), outcome 없이 done된 goal을 「닫히지 않은 루프」로 감지.
- `migration 0264`: `loop_measure_due_notified_at`(set-once, 무한 재발행 방지) + `preset.loop.measure_due` EventDefinition 시드. escalation=payload_field(owner_member_id) — 새 server_derived 해석기 발명 없이 기존 부류 재사용(`preset.work.assigned`와 동형). work_item_type엔 project 해소 SSOT 리터럴 `"epic"`을 그대로 씀(Goal의 B1 rename 前 리터럴이 여전히 SSOT).
- `app/services/loop_measure_due.py`: 3축 스캔+발행(`app/routers/cron.py::POST /detect-unclosed-loops`).
- `app/routers/command_center.py`: `/my-actions`의 `attention.items[]`에 신규 3타입 추가 — 신규 카운터 API 대신 기존 표면 확장(미르코군 그라운딩 doc `a8e73bdb` §3 계약 그대로) + `measure_plan_missing_goal_count`(N 비포함·집계만, PO 보완 지시).

## PO AC 리뷰 보완 반영(head=7eaeb3c0b 리뷰 → 77e88961d)
① **집계 silent cap** — `attention.items[]`가 류별 top-20인데 FE 계약 N=items.length라 실데이터(outcome 없는 done goal 51건)에서 참값보다 접혀 나오는 문제. `loop_overdue_hypothesis_count`·`loop_overdue_goal_count`·`loop_outcome_missing_goal_count` 3필드를 `attention`에 추가(카운트 쿼리, top-20 fetch보다 가벼움) — FE의 N은 이 세 필드 합.
② **cron 배선** — 실측: 기존 cron들(`score-hypotheses-dev` 등)은 Next.js 프록시가 아니라 **GCP Cloud Scheduler가 backend Cloud Run URL을 직접 호출**(레포에 코드/terraform으로 안 남는 순수 인프라 설정 — `gcloud scheduler jobs list`로 확認). 이 PR엔 그 배선을 담을 파일이 레포에 없다 — 페드루군/PO가 다음 명령으로 provisioning 필요(dev, CRON_SECRET은 기존 잡의 Secret Manager 값 재사용):
  ```
  gcloud scheduler jobs create http detect-unclosed-loops-dev \
    --location=asia-northeast3 --schedule="0 * * * *" \
    --uri="https://sprintable-backend-dev-57iommnikq-du.a.run.app/api/v2/internal/cron/detect-unclosed-loops" \
    --http-method=POST --headers="Authorization=Bearer <CRON_SECRET>"
  ```
  (score-hypotheses-dev와 동일 시간당 1회 스케줄 제안 — 판단은 PO 몫)
③ set-once의 재도과 사각은 fix 대신 **못 잡는 것으로 명시 선언**(서비스 모듈독스트링) — P0 관측 단계 수용(PO 판정).

## AC
1. 실데이터 양성대조 — 라이브(dev) 실측으로 별도 보고 예정.
2. 이벤트 발행 실물 — `test_2829_loop_measure_due_realdb.py::test_ac1_*` green.
3. 중복 발행 방지 — `test_ac2_no_infinite_republish_set_once` green.
4. 못 잡는 것 — owner 없는 항목은 매 스캔 재스캔되나(비용) 발행은 영구 skip(스팸 0), measure_after 자체가 없는 active goal은 이 신호의 사각(카드가 이미 명시, count만 별도 필드), set-once 재도과 사각(위 ③).

## Test plan
- [x] `test_2829_loop_measure_due_realdb.py` 4건(AC①②③④) green — 실PG, alembic-migrated(create_all 아님, migration 시드 데이터 필요).
- [x] `test_command_center.py` 22건(신규 단정 포함) green.
- [x] 회귀: cron/event_definition/hypothesis_scorer 관련 9개 파일(65 테스트) green.
- [ ] CI
- [ ] 라이브 AC①(실데이터 양성대조) — dev 배포 후 별도 보고
- [ ] cron 배선(위 ②, 인프라 provisioning) — PO 몫
- [ ] 카디르 QA

관련: [SID:2829]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>