### PR TITLE
fix(#2826 잔여): action_required 부처방이 legacy 웹훅에서 죽어 있던 것 정정 [SID:2826]

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -386,22 +386,39 @@ async def _process_webhook_event(
         ):
             skipped_reason = repo_owner_reason
         # story #2826(부 처방, PO 확定 2026-08-20) — 링크가 아예 안 풀린 PR 라이프사이클 이벤트라도
-        # (app installation이 있어 org 컨텍스트가 확실하고) 이 repo가 sprintable/gate를 required로
-        # 걸어 뒀으면, 침묵 부재 대신 action_required check로 "왜 막혔는지+다음 행동"을 안내한다.
-        # legacy(org 미상)는 대상 밖 — installation 컨텍스트 자체가 없어 어느 org 설정을 볼지 모른다.
+        # org 컨텍스트가 확실하고 이 repo가 sprintable/gate를 required로 걸어 뒀으면, 침묵 부재
+        # 대신 action_required check로 "왜 막혔는지+다음 행동"을 안내한다. org_id가 여전히 None
+        # (legacy에서 repo owner 해소도 실패)이면 대상 밖 — 어느 org 설정을 볼지 모른다.
+        #
+        # ⛔실사고 정정(2026-08-20, 라이브 시험 #3254) — 최초 버전은 `source=="app" and
+        # installation is not None`만 받았는데, 페드루군이 그라운딩에서 이미 실측해 둔 사실
+        # ("App 자체 웹훅은 이벤트 구독 0 — PR 이벤트는 repo-level 웹훅이 나른다")을 놓쳐, repo-level
+        # 웹훅이 실제로 타는 secret(legacy)에서는 `installation`이 항상 None이라 이 분기가
+        # **한 번도 발화하지 않았다**(라이브 실측으로 발견 — action_required check-run 부재
+        # 확認). 위 legacy 분기가 이미 repo owner exactly-1-match로 org_id를 풀어 두므로, app/
+        # legacy 둘 다 org_id 하나만 있으면 installation_id를 다시 조회하면 된다(installation
+        # 객체 자체를 요구하지 않는다 — app 전용 가정 제거).
         if (
-            source == "app"
-            and installation is not None
+            org_id is not None
             and event == "pull_request"
             and pr_action in ("opened", "reopened", "ready_for_review", "synchronize")
             and head_sha
             and ungated_check_publish is not None
         ):
+            from app.models.github_installation import GithubInstallation as _GithubInstallation
             from app.services.gate_github_check import is_repo_check_enforced
 
-            if await is_repo_check_enforced(session, installation.org_id, repo):
+            _installation_id = installation.installation_id if installation is not None else (
+                await session.execute(
+                    select(_GithubInstallation.installation_id).where(
+                        _GithubInstallation.org_id == org_id,
+                        _GithubInstallation.suspended_at.is_(None),
+                    )
+                )
+            ).scalar_one_or_none()
+            if _installation_id is not None and await is_repo_check_enforced(session, org_id, repo):
                 ungated_check_publish.append({
-                    "installation_id": installation.installation_id,
+                    "installation_id": _installation_id,
                     "repo_full_name": repo, "head_sha": head_sha, "pr_number": pr_number,
                 })
         return {"skipped_reason": skipped_reason, "recorded": []}, "ignored"  # no_match/auto suggestion 등.

--- a/backend/tests/test_2826_gate_pr_lifecycle_creation_realdb.py
+++ b/backend/tests/test_2826_gate_pr_lifecycle_creation_realdb.py
@@ -29,6 +29,7 @@ pytestmark = [
 ]
 
 APP_SECRET = "app-secret-2826"
+LEGACY_SECRET = "legacy-secret-2826"
 
 
 @pytest.fixture
@@ -95,6 +96,47 @@ async def _post_app(payload, Session, *, delivery_id):
                 )
     finally:
         fastapi_app.dependency_overrides.clear()
+
+
+async def _post_legacy(payload, Session, *, delivery_id):
+    """story #2827 라이브 실사고 정정 회귀 — repo-level 웹훅(installation payload 없음)은 실제로
+    legacy secret으로 서명돼 온다(App 자체 웹훅 구독 0건, 페드루 그라운딩 실측). _post_app과
+    유일한 차이는 서명 secret과 payload에 installation 키가 없다는 것뿐."""
+    from app.main import app as fastapi_app
+    from app.routers import verdict_capture as mod
+    from tests.conftest import override_db_and_read
+
+    async def override_db():
+        async with Session() as s:
+            yield s
+
+    override_db_and_read(fastapi_app, override_db)
+    body = json.dumps(payload).encode()
+    headers = {
+        "X-GitHub-Event": "pull_request", "X-GitHub-Delivery": delivery_id,
+        "X-Hub-Signature-256": _sign(body, LEGACY_SECRET),
+    }
+    try:
+        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            with patch.object(mod.settings, "github_webhook_secret", LEGACY_SECRET), \
+                 patch.object(mod.settings, "github_app_webhook_secret", "app-secret-unused-2826"):
+                return await c.post(
+                    "/api/v2/internal/verdict/github-webhook", content=body, headers=headers,
+                )
+    finally:
+        fastapi_app.dependency_overrides.clear()
+
+
+def _pr_payload_legacy(*, action, pr_number, head_sha, title="chore: unrelated"):
+    """installation 키 없음(legacy 웹훅 실물 형태) — repo만으로 owner 매치."""
+    return {
+        "action": action,
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "pull_request": {
+            "number": pr_number, "title": title, "body": "", "merged": False,
+            "head": {"sha": head_sha, "ref": "feat-branch"},
+        },
+    }
 
 
 def _pr_payload(*, action, pr_number, installation_id, head_sha, title="chore: unrelated"):
@@ -295,5 +337,37 @@ async def test_ac4_pr_open_without_link_not_enforced_publishes_nothing():
             assert resp.status_code == 200, resp.text
 
         create_mock.assert_not_called()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac3b_legacy_source_without_installation_still_publishes_action_required():
+    """실사고 회귀(2026-08-20, 라이브 시험 #3254 발견) — repo-level 웹훅은 실제로 legacy secret
+    으로 온다(installation payload 없음, App 자체 웹훅 구독 0건). 최초 부처방 구현이
+    `source=="app"`만 받아 이 경로에서 **한 번도 발화하지 않았다** — org_id(legacy도 repo owner
+    exactly-1-match로 이미 해소됨) 기준으로 installation_id를 재조회하는 fix를 고정."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, _story = await _seed_org_project_story(s, with_participation=False)
+            await _seed_installation(s, org, installation_id=555005, enforced=True)
+            # 링크·story 매치 자체를 안 만든다 — resolver가 no_match로 떨어지게(AC③과 동일 조건),
+            # 이번엔 app installation 대신 legacy 서명으로 보낸다.
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 90005}),
+        ) as create_mock, patch("app.core.database.async_session_factory", Session):
+            payload = _pr_payload_legacy(
+                action="opened", pr_number=15, head_sha="sha-ac3b",
+                title="chore: legacy webhook, no story link",
+            )
+            resp = await _post_legacy(payload, Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}")
+            assert resp.status_code == 200, resp.text
+
+        create_mock.assert_called_once()
+        _, kwargs = create_mock.call_args
+        assert kwargs.get("conclusion") == "action_required"
     finally:
         await engine.dispose()


### PR DESCRIPTION
## Summary
- 라이브 AC 시험(#3254, 링크 없는 PR)에서 발견: `sprintable/gate` action_required check-run이 한 번도 안 뜸.
- 원인: 부처방(링크 없는 PR 안내) 최초 구현이 `source=="app" and installation is not None`을 요구했는데, 실 repo-level 웹훅은 App 자체 웹훅 구독이 0건이라 **항상 legacy secret으로 온다**(installation payload 자체가 없음).
- **주처방(evaluate_merge_gate 재사용 gate 자동생성)은 org_id만 필요해 legacy 경로에서도 이미 실증됐다** — #3253 자체가 [SID:2829] 제목의 legacy 웹훅으로 gate를 자동 생성한 게 그 증거. 부처방만 "app installation이 있어야 org를 안다"는 잘못된 전제를 깔고 있었던 차이.
- fix: org_id(legacy도 repo owner exactly-1-match로 이미 위에서 해소됨) 하나만 있으면 `GithubInstallation` 재조회로 installation_id를 얻는다.

## Test plan
- [x] `test_2826_gate_pr_lifecycle_creation_realdb.py` 5건(신규 `test_ac3b_legacy_source_*` 포함) green.
- [ ] CI
- [ ] 라이브 재시험(신규 unlinked PR) — action_required check-run 실물 확認
- [ ] 카디르 QA

관련: [SID:2826]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>