### PR TITLE
fix(#2832 CRITICAL): 재-pending 후 재승인이 approved_head_sha를 못 찍는 결함

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1057,8 +1057,22 @@ async def transition_gate_endpoint(
         # 트랜잭션(commit 前)에서 확정 기록**한다. 배경 태스크(publish_gate_check)는 이 값을
         # 그대로 반영만 한다(gate_github_check.py 참고).
         if body.status == "approved" and gate.gate_type == MERGE_GATE_TYPE:
-            _link = await resolve_pr_link(session, org_id, gate.work_item_id)
-            _head_sha = (_link.evidence or {}).get("head_sha") if _link else None
+            # story #2832(CRITICAL, PO 페드루 배정 2026-08-20) — 재-pending 후 재승인이
+            # approved_head_sha를 못 찍는 결함의 근본원인: story 하나에 PR 링크 행이 둘 이상이면
+            # (예: 이전 PR 머지 후 같은 story에 새 PR — 잔류 흔한 케이스) resolve_pr_link가
+            # story_id만으로 "가장 최근 updated_at" 행 하나를 고르는데, explicit-link API가
+            # evidence를 **전체 교체**(pr_story_link.py upsert_link)해 head_sha 없는 얕은 evidence로
+            # 갱신하면 그 행이 "가장 최근"이 돼 실제 anchor 없는 링크가 뽑힌다(실 사고 재현: gate
+            # 38430aa8, PR#3255 — 07:13:59 웹훅이 정상 anchor를 썼는데 07:14:09 explicit-link
+            # 호출이 evidence를 {"by":"explicit_api"}로 교체해 head_sha가 사라짐). gate 자신의
+            # github_check_run_sha는 이 story-스코프 다중-PR 모호성과 무관하게(publish_gate_check가
+            # 이 gate row 자체에 마지막으로 발행한 check-run의 SHA를 직접 기록) 항상 "지금 이
+            # gate가 추적 중인 SHA"를 정확히 담고 있으므로 **1순위**로 쓴다 — story 링크 조회는
+            # 그 필드가 아예 빈 legacy/이상 상태(#2813 이전 gate 등)에만 폴백으로 남긴다.
+            _head_sha = gate.github_check_run_sha
+            if not _head_sha:
+                _link = await resolve_pr_link(session, org_id, gate.work_item_id)
+                _head_sha = (_link.evidence or {}).get("head_sha") if _link else None
             if _head_sha:
                 gate.approved_head_sha = _head_sha
         await session.commit()

--- a/backend/scripts/dependency_override_get_read_db_baseline.txt
+++ b/backend/scripts/dependency_override_get_read_db_baseline.txt
@@ -27,7 +27,6 @@ tests/test_2003_a2a_rpc_error_contract_realdb.py::test_rpc_invalid_params_still_
 tests/test_2003_a2a_rpc_error_contract_realdb.py::test_rpc_unhandled_exception_returns_standard_internal_error	1
 tests/test_2005_a2a_rpc_timeout.py::_authed_client	1
 tests/test_2009_conversation_detail_participants_realdb.py::_setup_app_human	1
-tests/test_2027_gate_approval_reason_enforce.py::_setup_app	1
 tests/test_2038_hypothesis_outcome_result_enforce.py::_setup_app	1
 tests/test_2043_ac3_hitl_reason_enforce.py::_setup_app	1
 tests/test_2054_gate_inbox.py::_setup_app	1

--- a/backend/tests/test_2027_gate_approval_reason_enforce.py
+++ b/backend/tests/test_2027_gate_approval_reason_enforce.py
@@ -67,7 +67,7 @@ def _client_for(app):
 
 async def _setup_app(app, Session, org_id, user_id):
     from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     async def _db():
         async with Session() as s:
@@ -84,7 +84,7 @@ async def _setup_app(app, Session, org_id, user_id):
     async def _org():
         return org_id
 
-    app.dependency_overrides[get_db] = _db
+    override_db_and_read(app, _db)
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
 

--- a/backend/tests/test_2832_gate_reapproval_anchor_realdb.py
+++ b/backend/tests/test_2832_gate_reapproval_anchor_realdb.py
@@ -1,0 +1,250 @@
+"""story #2832(CRITICAL, PO 페드루 배정 2026-08-20) — «재-pending 후 재승인»이 approved_head_sha를
+못 찍어 success 발행이 영구 skip되는 결함의 회귀 테스트.
+
+실 사고(gate 38430aa8, PR#3255, 2026-08-20 07:36:06): story #2826에 PR#3252(머지 완료)·
+PR#3255(잔류 fix, 진행 중) 두 PR 링크 행이 공존 — `resolve_pr_link`가 story_id만으로 "가장 최근
+updated_at" 행 하나를 뽑는데, 07:14:09 explicit-link 호출(`upsert_link`, evidence **전체 교체**)이
+head_sha 없는 얕은 evidence로 PR#3255 링크 행을 갱신해 그 행이 "가장 최근"이 됐다. 그 결과 07:36:06
+재승인이 anchor를 못 찍고(`approved_head_sha=None` 그대로), 배경 발행이 "approved인데 anchor
+없음"으로 fail-closed skip — check success가 영원히 안 뜬다.
+
+fix(gates.py transition_gate_endpoint): anchor 1순위를 `gate.github_check_run_sha`로 바꿨다 — 이
+필드는 story-스코프 다중-PR 모호성과 무관하게 **이 gate 자신**이 마지막으로 발행한 check-run의
+SHA만 담으므로(publish_gate_check가 매 발행 시 갱신) 항상 정확하다. story 링크 조회(옛 로직)는
+그 필드가 아예 빈 legacy 상태에만 폴백."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드.
+    import app.models.activity_log  # noqa: F401 — transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_common(session):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+        permission="granted", role="owner",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "caller_id": caller.id}
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_reapproval_anchors_to_gate_tracked_sha_not_stale_link_evidence():
+    """실 사고 재현: story에 PR 링크 행이 둘(머지된 옛 PR + 진행 중 새 PR), 새 PR 쪽 evidence는
+    explicit-link 전체교체로 head_sha가 비어있다 — gate.github_check_run_sha(새 PR의 실제 SHA)가
+    이 모호성과 무관하게 anchor로 쓰여야 한다."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+    from app.models.pull_request_story_link import PullRequestStoryLink
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    SHA_OLD_MERGED_PR = "sha-old-merged-pr"
+    SHA_CURRENT_PR = "sha-current-pr-tracked-by-gate"
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            story = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="재-pending 후 재승인 anchor 회귀",
+            )
+            s.add(story)
+            await s.commit()
+
+            # 옛 PR(이미 머지) 링크 — head_sha 보존돼 있음(정상 케이스라면 이게 정본이 아니어야 함).
+            link_old = PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=seeded["org_id"], story_id=story.id,
+                repo_full_name="acme/repo", pr_number=1, link_source="sid", confidence="high",
+                evidence={"head_sha": SHA_OLD_MERGED_PR, "webhook_merge": {"recorded_at": "2026-08-20T05:22:49Z"}},
+            )
+            s.add(link_old)
+            await s.commit()
+
+            # 새 PR(진행 중) 링크 — explicit-link 전체교체로 head_sha 없는 얕은 evidence, 옛 PR
+            # 행보다 나중에 갱신돼 "가장 최근"이 된다(resolve_pr_link가 이걸 고르면 옛 로직은 실패).
+            link_new = PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=seeded["org_id"], story_id=story.id,
+                repo_full_name="acme/repo", pr_number=2, link_source="explicit", confidence="high",
+                evidence={"by": "explicit_api"},
+            )
+            s.add(link_new)
+            await s.commit()
+
+            # gate: 재-pending 직후 상태 — approved_head_sha는 reopen에서 이미 None으로 클리어됐고,
+            # github_check_run_sha는 새 PR의 웹훅 발행이 이미 정확히 찍어 둔 값(publish_gate_check
+            # 자체 로직, 이 테스트의 관심사 밖이라 직접 seed).
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending",
+                approved_head_sha=None, github_check_run_id=90099, github_check_run_sha=SHA_CURRENT_PR,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "approved", "note": "재승인 anchor 회귀 확인", "evidence_viewed": True},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["status"] == "approved", body
+            assert body["approved_head_sha"] == SHA_CURRENT_PR, (
+                f"anchor가 gate.github_check_run_sha({SHA_CURRENT_PR})가 아니라 "
+                f"story-스코프 링크 모호성에 휘둘렸다: {body.get('approved_head_sha')!r}"
+            )
+            assert body["approved_head_sha"] != SHA_OLD_MERGED_PR
+
+            recheck = await client.get(f"/api/v2/gates/{gate_id}")
+            assert recheck.status_code == 200, recheck.text
+            assert recheck.json()["approved_head_sha"] == SHA_CURRENT_PR
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_approve_falls_back_to_link_evidence_when_no_check_run_yet():
+    """폴백 보존 확인: gate가 아직 어떤 check-run도 추적한 적 없으면(github_check_run_sha=None —
+    #2813 이전 legacy 상태 등) 옛 경로(링크 evidence)로 여전히 anchor를 찍는다(회귀 없음)."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+    from app.models.pull_request_story_link import PullRequestStoryLink
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    SHA_FROM_LINK = "sha-from-link-evidence"
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            story = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="legacy 폴백 회귀",
+            )
+            s.add(story)
+            await s.commit()
+
+            link = PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=seeded["org_id"], story_id=story.id,
+                repo_full_name="acme/repo", pr_number=9, link_source="sid", confidence="high",
+                evidence={"head_sha": SHA_FROM_LINK},
+            )
+            s.add(link)
+            await s.commit()
+
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending",
+                approved_head_sha=None, github_check_run_id=None, github_check_run_sha=None,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "approved", "note": "legacy 폴백 확인", "evidence_viewed": True},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["approved_head_sha"] == SHA_FROM_LINK, resp.json()
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2832_gate_reapproval_anchor_realdb.py
+++ b/backend/tests/test_2832_gate_reapproval_anchor_realdb.py
@@ -59,7 +59,7 @@ def _client_for(app):
 
 async def _setup_app(app, Session, org_id, user_id):
     from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     async def _db():
         async with Session() as s:
@@ -76,7 +76,7 @@ async def _setup_app(app, Session, org_id, user_id):
     async def _org():
         return org_id
 
-    app.dependency_overrides[get_db] = _db
+    override_db_and_read(app, _db)
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
 

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -75,6 +75,9 @@ async def test_transition_forces_resolver_ignoring_body():
                                resolver_id=resolver_id, resolved_at=None, resolution_note=None,
                                held_until=None, neutral_facts=None, requires_human=False,
                                evidence_status=None, decision_basis=None, auto_decision_reason=None,
+                               # story #2832 — gates.py 승인 anchor 기록이 github_check_run_sha를
+                               # 1순위로 읽는다(gate 자신의 필드, story-스코프 링크 모호성 무관).
+                               github_check_run_sha=None,
                                created_at=__import__("datetime").datetime.now(),
                                updated_at=__import__("datetime").datetime.now())
 


### PR DESCRIPTION
## Summary
- 결함(페드루 PO 배정 2026-08-20, CRITICAL): merge gate가 재-pending(SHA 불일치로 approved→pending) 후 다시 승인돼도 `approved_head_sha`가 안 찍혀, `sprintable/gate` check success 발행이 fail-closed로 영구 skip — 재승인 사이클 자체가 죽는 구조.
- 근본원인(실측): `transition_gate_endpoint`의 anchor 기록이 `resolve_pr_link(story_id)`(story-스코프, "가장 최근 updated_at" 링크 행 1건)에 의존하는데, story 하나에 PR 링크 행이 둘 이상이면(이전 PR 머지 후 같은 story에 새 PR — 드물지 않은 케이스) explicit-link API(`upsert_link`)가 evidence를 **전체 교체**해 head_sha 없는 얕은 evidence로 갱신 → 그 행이 "가장 최근"이 돼 실제 anchor 없는 링크가 뽑힌다.
- 실 사고 재현: gate `38430aa8`(story #2826, PR#3255) — 07:13:59 웹훅이 정상 anchor(`0c3c08823...`)를 찍었는데, 07:14:09 explicit-link 호출이 evidence를 `{"by":"explicit_api"}`로 전체교체해 head_sha가 사라짐 → 07:36:06 재승인이 anchor 미기록.
- fix: anchor 1순위를 `gate.github_check_run_sha`로 변경 — 이 필드는 story-스코프 다중-PR 모호성과 무관하게 **이 gate 자신**이 마지막으로 발행한 check-run의 SHA만 담아(publish_gate_check가 매 발행 시 갱신) 항상 정확하다. 링크 evidence 조회는 그 필드가 아예 빈 legacy 상태(#2813 이전 gate 등)에만 폴백 — 새 규칙 발명 0.

## 복구 경로 실측(④, 잔류 gate 38430aa8)
- 이 gate는 이미 `status=approved`라 `is_valid_transition`(pending→approved|rejected만 허용)상 재승인 API를 다시 못 태운다(직접 patch는 승인/감사 축을 우회해 지양).
- 자연 치유 경로 둘 확인:
  1. PR#3255에 새 커밋(재-pending 트리거) → 사람이 재승인 → 이 fix로 정상 anchor.
  2. PR#3255가 실제로 머지되면, merge 웹훅의 `reconcile_merge_gate_with_real_evidence`→`evaluate_merge_gate`가 `decision==AUTO_MERGE`일 때 `gate.status` 무관하게 `approved_head_sha=head_sha`를 다시 쓴다(merge_verdict_gate.py:503-505) — merge event 자체가 자연 치유한다(단, merge 웹훅의 head_sha가 현재 anchor 대상 SHA와 같아야 함 — PR#3255는 동일할 것으로 판단).
- 결정은 PO 판단 사항이라 실행은 안 함(관리자 required-check bypass merge 여부 등).

## Test plan
- [x] `test_2832_gate_reapproval_anchor_realdb.py` 2건(anchor 우선순위 fix + legacy 폴백 보존) — 로컬 실PG green.
- [x] `git apply -R` 뮤테이션 검증 — fix 되돌리면 재현 테스트가 실제로 FAIL하는 것 확인(load-bearing).
- [ ] CI
- [ ] 카디르 QA

관련: [SID:2832]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>