### PR TITLE
fix(#2826 잔여): publish_gate_check가 link row 없어도 인자만으로 발행

### DIFF
--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -170,12 +170,24 @@ async def publish_gate_check(
             if gate is None or gate.gate_type != MERGE_GATE_TYPE:
                 return  # merge 게이트 아니면 이 1단계 스코프 밖(설계 doc §0).
 
-            link = await resolve_pr_link(session, org_id, gate.work_item_id)
-            if link is None:
-                logger.info("gate=%s: PR 링크 없음 — check 발행 skip", gate_id)
-                return
-            repo_full_name = repo_full_name or link.repo_full_name
-            pr_number = pr_number if pr_number is not None else link.pr_number
+            # story #2826 잔여(카디르 판독·페드루 PO 승인 2026-08-20, #3257 실사고) — link row는
+            # "필수 전제"가 아니라 "인자로 못 받은 값의 폴백"이다. docstring은 원래 "인자로 주면
+            # 재조회를 생략"이라 약속했는데, 구현은 인자 유무와 무관하게 무조건 link를 조회해
+            # 없으면 즉시 return했다 — SID-only로 해소된 PR(merge_link_evidence/upsert_link
+            # 둘 다 row를 안 만드는 조건, #3257이 그 표본)은 story_id는 정확히 풀려 gate까지는
+            # 서는데 check 발행만 이 자리서 조용히 죽었다. 이제 docstring 그대로: repo_full_name+
+            # pr_number가 이미 인자로 왔으면 link 조회 자체를 스킵한다.
+            link: PullRequestStoryLink | None = None
+            if repo_full_name is None or pr_number is None:
+                link = await resolve_pr_link(session, org_id, gate.work_item_id)
+                if link is None:
+                    logger.info(
+                        "gate=%s: repo_full_name/pr_number 인자 없음 + PR 링크도 없음 — "
+                        "check 발행 skip(사유: 발행 대상 repo/PR 식별 불가)", gate_id,
+                    )
+                    return
+                repo_full_name = repo_full_name or link.repo_full_name
+                pr_number = pr_number if pr_number is not None else link.pr_number
 
             # ⛔카디르 R2 CRITICAL(2026-08-19, 코드 추적 재확認) — 이전 fix는 anchor 우선을
             # "head_sha 인자가 None일 때만" 적용했다. 그런데 verdict_capture.py 웹훅 경로는
@@ -204,11 +216,16 @@ async def publish_gate_check(
                     return
                 head_sha = gate.approved_head_sha  # anchor가 절대 기준 — 인자 유무 무관.
             elif head_sha is None:
-                head_sha = (link.evidence or {}).get("head_sha")
+                # link가 위에서 스킵됐으면(repo_full_name+pr_number 인자로 이미 옴) 여기서만
+                # 폴백 조회 — head_sha 인자까지 없는 건 이 함수를 approved/auto_passed 밖에서
+                # link 정보 전혀 없이 부르는 드문 경로뿐(주 호출부는 항상 head_sha를 명시 전달).
+                if link is None:
+                    link = await resolve_pr_link(session, org_id, gate.work_item_id)
+                head_sha = (link.evidence or {}).get("head_sha") if link else None
             if not head_sha:
                 logger.info("gate=%s: head_sha 미상 — check 발행 skip", gate_id)
                 return
-            if (link.evidence or {}).get("head_sha") != head_sha:
+            if link is not None and (link.evidence or {}).get("head_sha") != head_sha:
                 link.evidence = {**(link.evidence or {}), "head_sha": head_sha}
 
             installation_id = await _resolve_installation_id(session, org_id)

--- a/backend/tests/test_2813_gate_github_check_realdb.py
+++ b/backend/tests/test_2813_gate_github_check_realdb.py
@@ -47,7 +47,7 @@ async def _session_factory():
 
 async def _seed(
     session, *, gate_status="pending", approved_head_sha=None,
-    github_check_run_id=None, github_check_run_sha=None,
+    github_check_run_id=None, github_check_run_sha=None, with_link=True,
 ):
     from app.models.gate import Gate
     from app.models.github_installation import GithubInstallation
@@ -80,11 +80,12 @@ async def _seed(
     )
     session.add(installation)
 
-    link = PullRequestStoryLink(
-        id=uuid.uuid4(), org_id=org.id, story_id=story.id,
-        repo_full_name="acme/repo", pr_number=7, link_source="sid", confidence="high",
-    )
-    session.add(link)
+    if with_link:
+        link = PullRequestStoryLink(
+            id=uuid.uuid4(), org_id=org.id, story_id=story.id,
+            repo_full_name="acme/repo", pr_number=7, link_source="sid", confidence="high",
+        )
+        session.add(link)
     await session.commit()
     await session.refresh(gate)
 
@@ -132,6 +133,79 @@ async def test_publish_gate_check_creates_pending_check_and_ledger_row_realdb():
             assert len(events) == 1
             assert events[0].event_type == "published"
             assert events[0].head_sha == "sha-pending-1"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_no_link_row_publishes_from_args_alone_realdb():
+    """story #2826 잔여(카디르 판독·페드루 PO 승인 2026-08-20, #3257 실사고 재현) — link row가
+    0개(SID-only 해소, merge_link_evidence/upsert_link 둘 다 이 조건에선 row를 안 만든다)여도
+    repo_full_name+pr_number+head_sha가 인자로 이미 왔으면 link 조회 자체를 스킵하고 그 인자만으로
+    check를 발행해야 한다 — 이전엔 link가 없다는 이유만으로 조용히 skip됐다(gate row는 서 있는데
+    check-run만 영원히 안 뜨는 상태)."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.models.gate_github_check_event import GateGithubCheckEvent
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="pending", with_link=False)
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 9099}),
+        ) as create_mock, patch(
+            "app.core.database.async_session_factory", Session,
+        ):
+            await publish_gate_check(
+                seeded["org_id"], seeded["gate_id"],
+                head_sha="sha-sid-only", repo_full_name="acme/repo", pr_number=3257,
+            )
+
+        create_mock.assert_awaited_once()
+        assert create_mock.call_args.args[1:3] == ("acme/repo", "sha-sid-only")
+        assert create_mock.call_args.kwargs["status"] == "in_progress"
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
+            assert gate.github_check_run_id == 9099
+            assert gate.github_check_run_sha == "sha-sid-only"
+
+            events = (
+                await s.execute(select(GateGithubCheckEvent).where(GateGithubCheckEvent.gate_id == gate.id))
+            ).scalars().all()
+            assert len(events) == 1
+            assert events[0].event_type == "published"
+            assert events[0].pr_number == 3257
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_no_link_and_no_repo_args_skips_with_reason_logged_realdb():
+    """②(사유 로그, 침묵 부재 금지): link도 없고 repo_full_name/pr_number 인자도 없으면 발행
+    대상 자체를 특정 못 하므로 여전히 skip — 이번엔 그 사유가 로그에 명시적으로 남는지 확인한다."""
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="pending", with_link=False)
+
+        with patch(
+            "app.services.gate_github_check.create_check_run", AsyncMock(),
+        ) as create_mock, patch(
+            "app.core.database.async_session_factory", Session,
+        ), patch("app.services.gate_github_check.logger") as mock_logger:
+            await publish_gate_check(seeded["org_id"], seeded["gate_id"], head_sha="sha-x")
+
+        create_mock.assert_not_called()
+        logged = " ".join(str(c.args) for c in mock_logger.info.call_args_list)
+        assert "식별 불가" in logged, logged
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
## Summary
- 카디르 판독·페드루 PO 승인(2026-08-20, #3257 실사고) — `gate_github_check.py::publish_gate_check` docstring은 "head_sha/repo_full_name/pr_number를 인자로 주면 재조회를 생략"이라 약속했는데, 실제 구현은 인자 유무와 무관하게 무조건 `resolve_pr_link`를 호출해 `link is None`이면 즉시 return — 인자로 이미 다 받은 값을 버렸다.
- 실 사고(story #2830, PR#3257): SID 매칭만으로 story_id가 해소된 PR — `merge_link_evidence`(merged 이벤트 전용)/`upsert_link`(explicit-link 전용) 둘 다 이 조건에선 `PullRequestStoryLink` row를 안 만든다. story #2826 주처방(gate 생성)은 story_id만 있으면 되니 정상 작동했지만, check-run 발행은 link row가 없다는 이유로 조용히 죽어 gate row는 있는데 GitHub check가 한 번도 안 뜨는 상태가 됐다.
- fix: `repo_full_name`+`pr_number`가 이미 인자로 왔으면 link 조회 자체를 스킵. head_sha 인자도 없는 극단(approved/auto_passed 밖에서 link 정보 전혀 없이 호출)에만 폴백 조회. 남는 반환 자리(repo/PR 둘 다 미상)엔 사유를 명시한 로그 한 줄 추가 — 침묵 부재 금지(페드루 지시 ②).

## Test plan
- [x] `test_2813_gate_github_check_realdb.py` 21건(신규 2건: link 0행+인자만으로 발행 / link 0행+인자도 없어 사유 로그 확인) — 로컬 실PG green.
- [x] `git apply -R` 뮤테이션 검증 — 되돌리면 신규 테스트가 실제로 FAIL(load-bearing).
- [ ] CI
- [ ] 라이브 검증 — 배포 후 #3257에 synchronize 한 번(빈 커밋 push)으로 check-run이 실제로 뜨는지 확인 예정(#2826 라이브 AC 반례 해소 실증).
- [ ] 카디르 QA

관련: [SID:2826]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>