### PR TITLE
fix(#2834): upsert_link이 evidence 전체 교체 — 2832의 뿌리 반쪽

### DIFF
--- a/backend/app/services/pr_story_link.py
+++ b/backend/app/services/pr_story_link.py
@@ -268,6 +268,20 @@ async def resolve_story_for_pr(
     return ResolvedLink(None, org_id, None, None, False, reason)
 
 
+def _merge_evidence(existing: dict | None, patch: dict | None) -> dict:
+    """story #2834 — evidence 병합의 단일 정의. **항상 dict-merge**(기존 키 보존·명시된 키만
+    갱신), 전체 교체 금지. `upsert_link`/`merge_link_evidence` 둘이 각자 이 의미론을 복제하고
+    있었던 게 #2832(재승인 anchor 소실)의 방아쇠였다 — `upsert_link`가 evidence를 통째로
+    갈아 끼워, 웹훅이 이미 채워 둔 head_sha가 explicit-link 호출 한 번에 사라졌다. 이제 한 곳만
+    고치면 두 호출부가 같이 옳아지게 이 함수를 공유한다(사본이 갈리는 자리를 구조적으로 없앰).
+
+    ⛔못 잡는 것(#2834 AC④, 명시 수용) — merge는 "같은 키를 서로 다른 쓰기가 쓰면 최신이 이긴다"의
+    한계를 그대로 갖는다. 지금 실측(#2834 그라운딩)으론 쓰기별 top-level 키가 겹치지 않는다
+    (head_sha/scope_check/webhook_merge/by) — 그 전제가 깨지고 같은 키를 다투는 쓰기가 새로
+    생기면 이 함수만으론 부족해 재판단이 필요하다."""
+    return {**(existing or {}), **(patch or {})}
+
+
 async def upsert_link(
     session: AsyncSession,
     org_id: uuid.UUID,
@@ -280,7 +294,10 @@ async def upsert_link(
     created_by: uuid.UUID | None = None,
     evidence: dict | None = None,
 ) -> PullRequestStoryLink:
-    """canonical 단일 링크 upsert(uq org,repo,pr). 재링크=우선순위/소스 갱신. 호출자는 org-scope 검증 후 호출."""
+    """canonical 단일 링크 upsert(uq org,repo,pr). 재링크=우선순위/소스 갱신. 호출자는 org-scope 검증 후 호출.
+
+    story #2834 — evidence는 이제 `_merge_evidence`로 병합(예전엔 전체 교체 — #2832의 방아쇠,
+    웹훅이 채운 head_sha/scope_check가 explicit-link 호출 한 번에 사라졌다)."""
     repo = normalize_repo(repo_full_name)
     existing = (
         await session.execute(
@@ -296,13 +313,14 @@ async def upsert_link(
         existing.link_source = link_source
         existing.confidence = confidence
         existing.created_by = created_by
-        existing.evidence = evidence
+        existing.evidence = _merge_evidence(existing.evidence, evidence)
         existing.deleted_at = None
         await session.flush()
         return existing
     link = PullRequestStoryLink(
         org_id=org_id, story_id=story_id, repo_full_name=repo, pr_number=pr_number,
-        link_source=link_source, confidence=confidence, created_by=created_by, evidence=evidence,
+        link_source=link_source, confidence=confidence, created_by=created_by,
+        evidence=_merge_evidence(None, evidence),
     )
     session.add(link)
     await session.flush()
@@ -321,9 +339,9 @@ async def merge_link_evidence(
     patch: dict,
 ) -> PullRequestStoryLink:
     """E-UI-DAEGBYEON P0-05 후속(doc scope-violation-signal-design §3·§4) — evidence **dict-merge**
-    upsert(덮어쓰기 금지). `upsert_link`는 explicit-link API 전용(evidence 전체 교체가 맞는 의미론)이라
-    별도 — 여기는 auto_match/sid로 **아직 행이 없을 수 있는** confident link에 scope_check 같은 신규
-    키를 안전하게 얹기 위함(기존 evidence의 다른 키 보존). 행 없으면 patch만으로 신규 생성."""
+    upsert(덮어쓰기 금지, `_merge_evidence` 공유 — story #2834). auto_match/sid로 **아직 행이
+    없을 수 있는** confident link에 scope_check 같은 신규 키를 안전하게 얹기 위함(기존 evidence의
+    다른 키 보존). 행 없으면 patch만으로 신규 생성."""
     repo = normalize_repo(repo_full_name)
     existing = (
         await session.execute(
@@ -335,13 +353,13 @@ async def merge_link_evidence(
         )
     ).scalar_one_or_none()
     if existing is not None:
-        existing.evidence = {**(existing.evidence or {}), **patch}
+        existing.evidence = _merge_evidence(existing.evidence, patch)
         existing.deleted_at = None
         await session.flush()
         return existing
     link = PullRequestStoryLink(
         org_id=org_id, story_id=story_id, repo_full_name=repo, pr_number=pr_number,
-        link_source=link_source, confidence=confidence, evidence=dict(patch),
+        link_source=link_source, confidence=confidence, evidence=_merge_evidence(None, patch),
     )
     session.add(link)
     await session.flush()

--- a/backend/tests/test_2834_link_evidence_merge_semantics_realdb.py
+++ b/backend/tests/test_2834_link_evidence_merge_semantics_realdb.py
@@ -1,0 +1,137 @@
+"""story #2834(PO AC 확定 2026-08-20, #2832 그라운딩에서 파생 — 디디 실측) — `upsert_link`
+(explicit-link API 전용)가 evidence를 **전체 교체**해 웹훅이 이미 채워 둔 필드를 지우던 결함의
+회귀. 실 사고(#2832 방아쇠): 07:13:59 웹훅이 head_sha를 채움 → 07:14:09 explicit-link 호출이
+`{"by":"explicit_api"}`로 evidence를 통째로 갈아 끼워 head_sha 소실.
+
+fix: `upsert_link`/`merge_link_evidence` 공유 `_merge_evidence`(dict-merge, 전체 교체 금지).
+
+그라운딩(소비처 전수 grep)이 확인한 top-level 키 비겹침(head_sha/scope_check/webhook_merge/by)
+전제 — 이 파일의 두 테스트가 그 실측을 그대로 고정한다. AC②의 "진짜 양성대조"는 scope_check쪽
+— trust_pipeline.batch_scope_violation이 실제로 그 값을 읽는 소비처라서(head_sha쪽은 #2832가
+gate 자체 필드로 이미 우회해 둔 터라 링크 레벨만으론 소비처 실증이 약하다)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드.
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_story(session):
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="link evidence merge")
+    session.add(story)
+    await session.commit()
+    return org, project, story
+
+
+@pytest.mark.anyio
+async def test_explicit_link_preserves_webhook_head_sha_realdb():
+    """①: 웹훅이 head_sha를 이미 채운 링크에 explicit-link(upsert_link)를 걸어도 head_sha가
+    살아있어야 한다 — #2832 실사고(07:13:59 웹훅 → 07:14:09 explicit-link가 지웠던 것) 재현."""
+    from app.services.pr_story_link import merge_link_evidence, upsert_link
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s)
+
+            await merge_link_evidence(
+                s, org.id, story.id, "acme/repo", 42,
+                link_source="sid", confidence="high",
+                patch={"head_sha": "sha-from-webhook"},
+            )
+            await s.commit()
+
+            link = await upsert_link(
+                s, org.id, story.id, "acme/repo", 42,
+                link_source="explicit", confidence="high",
+                evidence={"by": "explicit_api"},
+            )
+            await s.commit()
+
+            assert link.evidence.get("head_sha") == "sha-from-webhook", link.evidence
+            assert link.evidence.get("by") == "explicit_api", link.evidence
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_explicit_link_preserves_scope_violation_signal_realdb():
+    """②(양성대조, AC②): scope_check.violated=true가 이미 찍힌 링크에 explicit-link를 걸어도
+    trust_pipeline.batch_scope_violation이 그 story를 여전히 위반으로 잡아야 한다 — 실 소비처를
+    통해 값이 진짜 안 지워졌는지 실증(단순 dict 재조회보다 강한 증거)."""
+    from app.services.pr_story_link import merge_link_evidence, upsert_link
+    from app.services.trust_pipeline import batch_scope_violation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s)
+
+            await merge_link_evidence(
+                s, org.id, story.id, "acme/repo", 43,
+                link_source="sid", confidence="high",
+                patch={"scope_check": {"violated": True, "out_of_scope_files": ["x.py"]}},
+            )
+            await s.commit()
+
+            await upsert_link(
+                s, org.id, story.id, "acme/repo", 43,
+                link_source="explicit", confidence="high",
+                evidence={"by": "explicit_api"},
+            )
+            await s.commit()
+
+            violated_ids = await batch_scope_violation(s, org.id, [story.id])
+            assert story.id in violated_ids, "explicit-link 후에도 scope_check.violated 소비처가 여전히 잡아야 한다"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- #2832(재승인 anchor 소실·critical)의 방아쇠 뿌리 — `pr_story_link.py::upsert_link`가 explicit-link 호출 시 evidence를 **전체 교체**해, 웹훅이 이미 채운 `head_sha`가 조용히 사라졌다(실사고 타임라인: 07:13:59 웹훅 anchor → 07:14:09 explicit-link 소거). #3256은 anchor **소비처**를 gate 자체 필드(`github_check_run_sha`)로 옮겨 우회했을 뿐, 전체 교체 동작 자체는 그대로 남아 있었다.
- 그라운딩(link.evidence 소비처 전수 grep) — top-level 키가 서로 안 겹침(`head_sha`/`scope_check`/`webhook_merge`/`by`) 확인. 네임스페이스 재설계는 과함 → `upsert_link`를 `merge_link_evidence`와 같은 dict-merge 의미론으로 통일, 둘이 공유 헬퍼(`_merge_evidence`) 하나만 쓰도록(의미론 복제 = 오늘 사고의 재발 축이라 제거).
- 그라운딩 중 발견한 두 번째 라이브 소비처: `trust_pipeline.py::batch_scope_violation`이 `evidence["scope_check"]["violated"]`를 읽는데, #2832는 이 축을 안 건드렸다 — explicit-link를 이미 scope-위반 찍힌 PR에 걸면 위반 신호가 조용히 사라지는 게 아직 라이브 결함이었다(이번 fix로 같이 해소).

## AC(페드루 PO 확定)
1. upsert_link ↔ merge_link_evidence 의미론 통일(공유 헬퍼).
2. 회귀 2건: 웹훅 head_sha → explicit-link → 보존 / scope_check.violated → explicit-link → 보존(trust_pipeline 소비 축 양성대조).
3. git apply -R 뮤테이션 검증.
4. 못 잡는 것 선언: 같은 top-level 키를 다투는 쓰기가 새로 생기면 merge도 최신-승 한계.
5. 관측 기록(정리는 범위 밖): `webhook_merge.recorded_at` 프로그램적 소비처 0(감사용) · GET /links의 evidence passthrough를 FE 어디도 안 읽음(죽은 자리).

## Test plan
- [x] `test_2834_link_evidence_merge_semantics_realdb.py` 2건(웹훅 head_sha 보존 / scope_check.violated 보존·trust_pipeline 양성대조) — 로컬 실PG green.
- [x] `test_bot_l1_pr_story_link.py`(36건, upsert_link/merge_link_evidence 기존 커버리지) + `test_e_ui_daegbyeon_174be6bc_scope_violation_realdb.py` 회귀 0 — 로컬 실PG green.
- [x] `git apply -R` — 되돌리면 신규 2건 모두 FAIL(load-bearing).
- [x] dependency_overrides get_read_db lint green.
- [ ] CI
- [ ] 카디르 QA

관련: [SID:2834]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>