### PR TITLE
feat(#2843): goal done 전이 outcome 판정 계약 — P1 BE

### DIFF
--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -490,13 +490,17 @@ async def my_actions(
             "owner_member_id": str(assignee_id) if assignee_id else None,
             "overdue_days": (now - measure_after).days if measure_after else None,
         })
+    # story #2843 — outcome_status "n_a"(아직 손 안 댐)뿐 아니라 "unmeasured"(닫혔는데
+    # 판정 미제공·done 전이 시 자동 마킹)도 «닫히지 않은 루프» 축이다. n_a와 unmeasured는
+    # 서로 다른 사실(조용한 방치 vs 명시적 스킵)이지만 둘 다 이 카운터엔 잔류(AC②) — n_a/
+    # unmeasured 자체의 구분은 GoalResponse.outcome_status 값으로 API에 이미 노출된다.
     done_no_outcome_goals = (
         await session.execute(
             select(Goal.id, Goal.title, Goal.updated_at, Goal.assignee_id)
             .where(
                 Goal.org_id == org_id,
                 Goal.status == "done",
-                Goal.outcome_status == "n_a",
+                Goal.outcome_status.in_(("n_a", "unmeasured")),
             )
             .order_by(Goal.updated_at.asc())
             .limit(20)
@@ -548,7 +552,19 @@ async def my_actions(
             select(func.count()).select_from(Goal).where(
                 Goal.org_id == org_id,
                 Goal.status == "done",
-                Goal.outcome_status == "n_a",
+                Goal.outcome_status.in_(("n_a", "unmeasured")),
+            )
+        )
+    ).scalar_one()
+    # story #2843(PO AC②) — unmeasurable(명시 «측정 불가» 선언)은 루프 N에서 **제외**하되
+    # (조용한 방치가 아니라 사유 있는 명시 선언이라 다른 성격 — §4 위조 채널 감시용 별도 노출.
+    # 전부 이쪽으로 도망치면 여기 숫자가 뛴다 — 관측 축.
+    unmeasurable_goal_count = (
+        await session.execute(
+            select(func.count()).select_from(Goal).where(
+                Goal.org_id == org_id,
+                Goal.status == "done",
+                Goal.outcome_status == "unmeasurable",
             )
         )
     ).scalar_one()
@@ -570,6 +586,10 @@ async def my_actions(
             "loop_overdue_hypothesis_count": loop_overdue_hypothesis_count,
             "loop_overdue_goal_count": loop_overdue_goal_count,
             "loop_outcome_missing_goal_count": loop_outcome_missing_goal_count,
+            # story #2843(PO AC②) — measure_plan_missing_goal_count와 같은 성격(N 비포함·집계만).
+            # unmeasurable은 명시 선언이라 루프 N에선 빠지지만, 위조 채널(전부 여기로 도망)
+            # 감시용으로 별도 노출.
+            "unmeasurable_goal_count": unmeasurable_goal_count,
         },
         "is_clear": len(queue) == 0 and len(attention_items) == 0,
     })

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -521,6 +521,12 @@ async def score_ga4_outcomes(
             )
         )
         for epic in epic_result.scalars().all():
+            # story #2843(PO collision 규칙①) — 사람이 done 전이로 먼저 수동 판정(hit/miss/
+            # unmeasurable)했으면 cron이 덮지 않는다. WHERE의 outcome_status=="pending"이 이미
+            # 대부분 걸러내지만(수동 판정은 status를 pending 밖으로 옮긴다), source=manual
+            # 마커로 명시 스킵을 한 겹 더 둔다(방어심층 — 동시성 경합 등 엣지 대비).
+            if isinstance(epic.outcome_result, dict) and epic.outcome_result.get("source") == "manual":
+                continue
             md = epic.metric_definition
             if not md:
                 continue

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -526,6 +526,9 @@ async def get_goal_reference_candidates(
 
 class GoalTransitionRequest(BaseModel):
     status: str
+    # story #2843 — active→done 전이의 outcome 판정 계약(선택 — 미제공은 unmeasured 자동 마킹).
+    outcome_status: str | None = None
+    outcome_result: dict | None = None
 
 
 @router.post("/{id}/transition", response_model=GoalResponse)
@@ -552,7 +555,10 @@ async def transition_goal_endpoint(
         _old_status = (await session.execute(
             select(Goal.status).where(Goal.id == id, Goal.org_id == org_id)
         )).scalar_one_or_none()
-        goal = await transition_goal(session, org_id, caller, id, body.status)
+        goal = await transition_goal(
+            session, org_id, caller, id, body.status,
+            outcome_status=body.outcome_status, outcome_result=body.outcome_result,
+        )
         await session.commit()
         await emit_goal_status_changed(session, org_id, goal, _old_status, actor_id=caller.id)
         # story #2459 회귀 동형 방어(2026-08-05): commit 後 model_validate 前 명시 refresh.
@@ -563,6 +569,9 @@ async def transition_goal_endpoint(
         _codes = {
             "EPIC_NOT_FOUND": 404, "HUMAN_CONFIRM_REQUIRED": 403,
             "INVALID_STATUS": 422, "INVALID_EPIC_TRANSITION": 422,
+            # story #2843
+            "INVALID_OUTCOME_STATUS": 422, "OUTCOME_RESULT_REQUIRED": 422,
+            "OUTCOME_REASON_REQUIRED": 422,
         }
         raise HTTPException(
             status_code=_codes.get(e.code, 400), detail={"code": e.code, "message": e.message}

--- a/backend/app/services/goal.py
+++ b/backend/app/services/goal.py
@@ -18,9 +18,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.pm import Goal
 from app.schemas.goal import GOAL_STATUSES, is_valid_goal_transition
 from app.services.member_resolver import ResolvedMember
+from app.services.outcome_evidence import has_valid_outcome_evidence, has_valid_unmeasurable_reason
 
 # overlay-gated 전이(나머지는 native 직행). matrix valid_transitions 와 일치.
 _OVERLAY_TRANSITIONS = frozenset({("draft", "active"), ("active", "done")})
+
+# story #2843(PO AC 확定 2026-08-20, doc loop-closure-first-class-signal-design §2 P1) — goal
+# outcome 판정 어휘는 **기존 자동채점(cron·outcome_scorer.py) 어휘 그대로**(hit/miss) — hypothesis의
+# verified/falsified를 goal에 수입하면 같은 `outcome_status` 컬럼에 두 방언이 공존해 모든 소비처가
+# 영원히 둘 다 알아야 한다(기각된 안). FE 라벨만 "맞았다/틀렸다"로 다르게 보여준다.
+_MANUAL_OUTCOME_STATUSES = frozenset({"hit", "miss", "unmeasurable"})
+# 이미 판정된 goal(hit/miss)은 done 재전이 시 판정 재요구 안 함(旣판정 — collision 규칙②).
+_ALREADY_JUDGED = frozenset({"hit", "miss"})
 
 
 class GoalTransitionError(Exception):
@@ -39,10 +48,18 @@ async def transition_goal(
     goal_id: uuid.UUID,
     to_status: str,
     via_gate: bool = False,
+    outcome_status: str | None = None,
+    outcome_result: dict | None = None,
 ) -> Goal:
     """goal status 전이. draft→active·active→done 는 line overlay-gated(enforcing→gate·default-off→
     inline). draft→active 는 human-only(activation=human decision). via_gate=True 면 overlay 재진입 없이
-    native 직행(caller=gate approver)."""
+    native 직행(caller=gate approver).
+
+    story #2843 — active→done 전이가 outcome 판정을 계약으로 받는다(`outcome_status`∈
+    {hit,miss,unmeasurable}+`outcome_result`). **미제공이 전이를 막지 않는다** — outcome_status=
+    unmeasured 자동 마킹으로 성립(AC1·AC5, 하드 거부는 이 스토리 스코프 밖). 旣 hit/miss(collision
+    규칙②)면 판정 요구 자체를 건너뛴다. 전달된 값은 hit/miss=실측 근거(actual+reason)·
+    unmeasurable=사유만 서버가 강제(§4 반증 — `outcome_evidence.py` hypothesis #2038과 공유)."""
     goal = (await session.execute(
         select(Goal).where(Goal.id == goal_id, Goal.org_id == org_id)
     )).scalar_one_or_none()
@@ -78,6 +95,40 @@ async def transition_goal(
     # activation(draft→active)은 휴먼만(PO/owner decision). active→done 은 inline 시 caller 권한(라우터 보강).
     if to_status == "active" and caller.type != "human":
         raise GoalTransitionError("HUMAN_CONFIRM_REQUIRED", "active(activation) 전이는 휴먼만 가능합니다.")
+
+    # story #2843 — done 전이의 outcome 판정. 旣판정(hit/miss)이면 재요구 없이 통과(collision②).
+    if to_status == "done" and goal.outcome_status not in _ALREADY_JUDGED:
+        if outcome_status is not None:
+            if outcome_status not in _MANUAL_OUTCOME_STATUSES:
+                raise GoalTransitionError(
+                    "INVALID_OUTCOME_STATUS",
+                    f"알 수 없는 outcome_status: {outcome_status} (허용: hit/miss/unmeasurable)",
+                )
+            if outcome_status in ("hit", "miss") and not has_valid_outcome_evidence(outcome_result):
+                raise GoalTransitionError(
+                    "OUTCOME_RESULT_REQUIRED",
+                    "hit/miss 판정에는 실제 수치(outcome_result.actual)와 한 줄 근거"
+                    "(outcome_result.reason)가 모두 필요합니다.",
+                )
+            if outcome_status == "unmeasurable" and not has_valid_unmeasurable_reason(outcome_result):
+                raise GoalTransitionError(
+                    "OUTCOME_REASON_REQUIRED",
+                    "unmeasurable 선언에는 사유(outcome_result.reason)가 필요합니다.",
+                )
+            # story #2036과 동형(closed_by 서버 주입 — 클라 자칭 위장 차단) + collision①(cron
+            # scorer skip 가드)이 읽는 source=manual 마커.
+            goal.outcome_status = outcome_status
+            goal.outcome_result = {
+                **(outcome_result or {}),
+                "source": "manual",
+                "closed_by": caller.type,
+                "closed_by_member_id": str(caller.id),
+            }
+        else:
+            # 조용한 n_a 소멸이 목표 — 판정 미제공은 전이를 막지 않고 unmeasured로 명시 마킹
+            # (n_a=아직 손 안 댐 vs unmeasured=닫혔는데 미판정, «닫히지 않은 루프» 카운터 축에서
+            # 구분 — command_center.py/loop_measure_due.py 3곳 정합 필요).
+            goal.outcome_status = "unmeasured"
 
     goal.status = to_status
     await session.flush()

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 import logging
-import math
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -22,6 +21,7 @@ from app.models.evidence import Evidence
 from app.models.gate import Gate
 from app.models.hypothesis import HYPOTHESIS_STATUSES, Hypothesis, HypothesisStoryLink, is_valid_transition
 from app.models.pm import Goal, Sprint, Story
+from app.services.outcome_evidence import has_valid_outcome_evidence
 
 logger = logging.getLogger(__name__)
 from app.repositories.hypothesis import HypothesisRepository
@@ -63,19 +63,9 @@ class HypothesisServiceError(Exception):
         self.message = message
 
 
-def _has_valid_outcome_evidence(outcome_result: dict | None) -> bool:
-    """story #2038 — verified/falsified 서버측 강제 판정. FE(HypothesisResolveDialog)의
-    canSubmit(`actualNum !== null && !Number.isNaN(actualNum) && reason.trim().length > 0`)와
-    동형. bool은 Python에서 int 서브클래스라 명시적으로 배제(isinstance(True, int) is True 함정)."""
-    if not isinstance(outcome_result, dict):
-        return False
-    actual = outcome_result.get("actual")
-    if isinstance(actual, bool) or not isinstance(actual, (int, float)):
-        return False
-    if isinstance(actual, float) and math.isnan(actual):
-        return False
-    reason = outcome_result.get("reason")
-    return isinstance(reason, str) and bool(reason.strip())
+# story #2843 — 근거 판정 헬퍼를 outcome_evidence.py로 추출(goal hit/miss와 공유). 이 이름은
+# 그 재노출(하위호환 — 이 모듈 안 기존 호출부 무변경).
+_has_valid_outcome_evidence = has_valid_outcome_evidence
 
 
 async def batch_stories_with_hypothesis_link(

--- a/backend/app/services/loop_measure_due.py
+++ b/backend/app/services/loop_measure_due.py
@@ -123,12 +123,14 @@ async def detect_unclosed_loops(session: AsyncSession) -> dict[str, Any]:
             logger.warning("loop.measure_due 발행 실패 goal=%s: %s", goal.id, exc, exc_info=True)
             failed.append({"type": "goal", "id": str(goal.id), "error": str(exc)})
 
-    # ② outcome 판정 없이 done된 goal
+    # ② outcome 판정 없이 done된 goal — story #2843: "n_a"(손 안 댐) + "unmeasured"(done 전이 시
+    # 판정 미제공 자동 마킹) 둘 다 대상. command_center.py의 동형 카운터와 정합(unmeasurable은
+    # 명시 선언이라 제외 — AC②).
     done_no_outcome_rows = (
         await session.execute(
             select(Goal).where(
                 Goal.status == "done",
-                Goal.outcome_status == "n_a",
+                Goal.outcome_status.in_(("n_a", "unmeasured")),
                 Goal.loop_measure_due_notified_at.is_(None),
             )
         )

--- a/backend/app/services/outcome_evidence.py
+++ b/backend/app/services/outcome_evidence.py
@@ -1,0 +1,30 @@
+"""근거(evidence) 서버측 강제 판정 — story #2038(hypothesis verified/falsified) 원안을
+story #2843(goal hit/miss·unmeasurable)이 공유하도록 추출. 두 엔티티가 각자 사본을 들면
+그 사본이 갈리는 자리가 다음 사고(#2832류)의 씨앗이라 단일 정의로 공유한다."""
+from __future__ import annotations
+
+import math
+
+
+def has_valid_outcome_evidence(outcome_result: dict | None) -> bool:
+    """실측 판정(hit/miss·verified/falsified)의 근거 요건 — 실제 수치(actual)와 한 줄 근거
+    (reason) 둘 다 필요. FE(HypothesisResolveDialog)의 canSubmit과 동형(story #2038)."""
+    if not isinstance(outcome_result, dict):
+        return False
+    actual = outcome_result.get("actual")
+    # bool은 Python에서 int 서브클래스라 명시적으로 배제(isinstance(True, int) is True 함정).
+    if isinstance(actual, bool) or not isinstance(actual, (int, float)):
+        return False
+    if isinstance(actual, float) and math.isnan(actual):
+        return False
+    reason = outcome_result.get("reason")
+    return isinstance(reason, str) and bool(reason.strip())
+
+
+def has_valid_unmeasurable_reason(outcome_result: dict | None) -> bool:
+    """story #2843 — «측정 불가» 명시 선언의 근거 요건. 실측치가 없다는 게 이 판정의 본질이라
+    actual은 요구하지 않는다(요구하면 unmeasurable 자체가 성립 불가) — 사유(reason)만 필수."""
+    if not isinstance(outcome_result, dict):
+        return False
+    reason = outcome_result.get("reason")
+    return isinstance(reason, str) and bool(reason.strip())

--- a/backend/tests/test_2829_loop_measure_due_realdb.py
+++ b/backend/tests/test_2829_loop_measure_due_realdb.py
@@ -195,3 +195,52 @@ async def test_resolved_outcome_naturally_exits_scan():
             assert str(hyp.id) not in published_ids
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_2843_unmeasured_goal_stays_in_unclosed_loop_scan():
+    """story #2843 AC② — outcome_status="unmeasured"(done 전이 시 판정 미제공 자동 마킹)도
+    "n_a"와 동형으로 ②축(outcome 판정 없이 done된 goal)에 잡혀야 한다(P0 산식 정합)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, _ = await _make_member(s, org.id, project.id)
+            goal = await _make_goal(
+                s, org.id, project.id, owner_id,
+                status="done", measure_after=None, outcome_status="unmeasured",
+            )
+
+            summary = await _detect(s, Session)
+            await s.commit()
+
+            published_ids = {p["id"] for p in summary["published"]}
+            assert str(goal.id) in published_ids
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_2843_unmeasurable_goal_excluded_from_unclosed_loop_scan():
+    """story #2843 AC② — outcome_status="unmeasurable"(명시 «측정 불가» 선언·사유 필수)은
+    조용한 방치가 아니므로 ②축에서 제외돼야 한다(별도 카운트 축, command_center.py
+    unmeasurable_goal_count가 담당 — 이 스캔은 루프 N 쪽만)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, _ = await _make_member(s, org.id, project.id)
+            goal = await _make_goal(
+                s, org.id, project.id, owner_id,
+                status="done", measure_after=None, outcome_status="unmeasurable",
+            )
+
+            summary = await _detect(s, Session)
+            await s.commit()
+
+            published_ids = {p["id"] for p in summary["published"]}
+            assert str(goal.id) not in published_ids
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2843_goal_outcome_verdict_realdb.py
+++ b/backend/tests/test_2843_goal_outcome_verdict_realdb.py
@@ -1,0 +1,279 @@
+"""story #2843(PO AC 확定 2026-08-20, doc loop-closure-first-class-signal-design §2 P1) —
+goal active→done 전이의 outcome 판정 계약. 어휘는 goal의 **기존 자동채점 어휘 그대로**(hit/miss —
+hypothesis의 verified/falsified를 goal에 수입하는 안은 기각·같은 컬럼 두 방언 문제).
+
+신값 둘: `unmeasured`(판정 미제공 시 자동 마킹·루프 N 잔류) / `unmeasurable`(명시 «측정 불가»
+선언·사유 필수·루프 N 제외하되 별도 카운트 노출). collision 규칙: ①manual 판정(source=manual
+마커)은 cron scorer가 안 덮음 ②旣 hit/miss는 done 재전이 시 판정 재요구 안 함.
+
+근거 요구는 hypothesis #2038과 공유(`outcome_evidence.py`) — hit/miss는 actual+reason,
+unmeasurable은 reason만."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    import app.models.event  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_active_goal(session, *, outcome_status="n_a"):
+    from app.models.pm import Goal
+    from app.models.project import Project
+
+    org, proj = uuid.uuid4(), uuid.uuid4()
+    session.add(Project(id=proj, org_id=org, name="p"))
+    await session.flush()
+    goal = Goal(org_id=org, project_id=proj, title="g", status="active", outcome_status=outcome_status)
+    session.add(goal)
+    await session.commit()
+    return org, goal.id
+
+
+def _human():
+    from app.services.member_resolver import ResolvedMember
+    return ResolvedMember(id=uuid.uuid4(), user_id=uuid.uuid4(), name="h", type="human", role="member", org_id=uuid.uuid4())
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_done_without_verdict_auto_marks_unmeasured_and_succeeds_realdb():
+    """AC1·AC5 — 판정 미제공은 전이를 막지 않는다(200 성립) + outcome_status=unmeasured 자동."""
+    from app.services.goal import transition_goal
+    from app.models.pm import Goal
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org, goal_id = await _seed_active_goal(s)
+            caller = _human()
+            goal = await transition_goal(s, org, caller, goal_id, "done")
+            await s.commit()
+
+            assert goal.status == "done"
+            assert goal.outcome_status == "unmeasured"
+
+            refetched = (await s.execute(select(Goal).where(Goal.id == goal_id))).scalar_one()
+            assert refetched.outcome_status == "unmeasured"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_done_with_hit_no_evidence_rejected_realdb():
+    from app.services.goal import transition_goal, GoalTransitionError
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org, goal_id = await _seed_active_goal(s)
+            caller = _human()
+            with pytest.raises(GoalTransitionError) as ei:
+                await transition_goal(s, org, caller, goal_id, "done", outcome_status="hit")
+            assert ei.value.code == "OUTCOME_RESULT_REQUIRED"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_done_with_hit_and_evidence_succeeds_and_injects_source_manual_realdb():
+    from app.services.goal import transition_goal
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org, goal_id = await _seed_active_goal(s)
+            caller = _human()
+            goal = await transition_goal(
+                s, org, caller, goal_id, "done",
+                outcome_status="hit", outcome_result={"actual": 42, "reason": "목표 달성"},
+            )
+            await s.commit()
+
+            assert goal.outcome_status == "hit"
+            assert goal.outcome_result["actual"] == 42
+            assert goal.outcome_result["source"] == "manual"
+            assert goal.outcome_result["closed_by"] == "human"
+            assert goal.outcome_result["closed_by_member_id"] == str(caller.id)
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_done_with_miss_and_evidence_succeeds_realdb():
+    from app.services.goal import transition_goal
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org, goal_id = await _seed_active_goal(s)
+            caller = _human()
+            goal = await transition_goal(
+                s, org, caller, goal_id, "done",
+                outcome_status="miss", outcome_result={"actual": 3, "reason": "목표 미달"},
+            )
+            assert goal.outcome_status == "miss"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_done_with_unmeasurable_no_reason_rejected_realdb():
+    from app.services.goal import transition_goal, GoalTransitionError
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org, goal_id = await _seed_active_goal(s)
+            caller = _human()
+            with pytest.raises(GoalTransitionError) as ei:
+                await transition_goal(s, org, caller, goal_id, "done", outcome_status="unmeasurable")
+            assert ei.value.code == "OUTCOME_REASON_REQUIRED"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_done_with_unmeasurable_and_reason_succeeds_no_actual_required_realdb():
+    """unmeasurable은 actual 없이도(측정 불가가 본질) reason만으로 성립."""
+    from app.services.goal import transition_goal
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org, goal_id = await _seed_active_goal(s)
+            caller = _human()
+            goal = await transition_goal(
+                s, org, caller, goal_id, "done",
+                outcome_status="unmeasurable", outcome_result={"reason": "메트릭 소스 폐지"},
+            )
+            assert goal.outcome_status == "unmeasurable"
+            assert goal.outcome_result["source"] == "manual"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_invalid_outcome_status_rejected_realdb():
+    from app.services.goal import transition_goal, GoalTransitionError
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org, goal_id = await _seed_active_goal(s)
+            caller = _human()
+            with pytest.raises(GoalTransitionError) as ei:
+                await transition_goal(s, org, caller, goal_id, "done", outcome_status="verified")
+            assert ei.value.code == "INVALID_OUTCOME_STATUS"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_already_judged_goal_skips_verdict_requirement_realdb():
+    """collision②: 旣 hit/miss(cron 자동채점 등으로 active 상태에서 이미 판정된 goal)는 done
+    전이 시 판정 재요구 없이 성립·기존 값 보존."""
+    from app.services.goal import transition_goal
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org, goal_id = await _seed_active_goal(s, outcome_status="hit")
+            caller = _human()
+            goal = await transition_goal(s, org, caller, goal_id, "done")  # outcome_status 미제공
+            assert goal.status == "done"
+            assert goal.outcome_status == "hit"  # unmeasured로 안 덮임
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_cron_scorer_skips_manual_verdict_realdb():
+    """collision①: source=manual 마커가 있는 goal은 cron 자동채점 루프가 실제로 건드리지
+    않는다 — cron.py의 명시 스킵 가드(방어심층, 정상 경로에선 outcome_status가 항상 pending
+    밖이라 WHERE가 이미 걸러내지만 그 «정상 경로 전제»가 깨지는 경합 상황을 직접 재현해
+    코드 자체를 실행 검증). 코드가 도달하는 자리를 실제로 태우기 위해 outcome_status를
+    직접 "pending"으로(정상 write 경로로는 절대 안 생기는 상태) seed한다."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import select
+
+    from app.models.pm import Goal
+    from app.models.project import Project
+    from app.routers import cron as cron_mod
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org, proj = uuid.uuid4(), uuid.uuid4()
+            s.add(Project(id=proj, org_id=org, name="p"))
+            await s.flush()
+            # 정상 write 경로로는 절대 안 생기는 조합(pending + source=manual) — 스킵 가드
+            # 코드가 실제로 이 자리에 도달했을 때 올바르게 작동하는지를 직접 태운다.
+            goal = Goal(
+                org_id=org, project_id=proj, title="g", status="active",
+                outcome_status="pending",
+                outcome_result={"actual": 1, "reason": "manual verdict", "source": "manual"},
+                measure_after=datetime.now(timezone.utc) - timedelta(days=1),
+                metric_definition={"source": "ga4", "property_id": "x", "ga4_metric": "y"},
+            )
+            s.add(goal)
+            await s.commit()
+            goal_id = goal.id
+
+        async with Session() as s:
+            with patch.object(cron_mod, "verify_cron", MagicMock()), \
+                 patch("app.services.outcome_scorer.score_ga4_outcome") as mock_score:
+                await cron_mod.score_ga4_outcomes(MagicMock(), s)
+            # 스킵 가드가 continue했다면 score_ga4_outcome은 이 goal에 대해 절대 호출 안 됐어야.
+            mock_score.assert_not_called()
+
+        async with Session() as s:
+            refetched = (await s.execute(select(Goal).where(Goal.id == goal_id))).scalar_one()
+            assert refetched.outcome_status == "pending"  # 안 덮임(스킵 가드 작동 확認)
+            assert refetched.outcome_result["source"] == "manual"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -97,6 +97,7 @@ def _ma_seq(
     my_tasks=(), approval_group_counts=(), blocker_weight_counts=(), falsified=(),
     overdue_hyps=(), overdue_goals=(), done_no_outcome_goals=(), measure_plan_missing_goal_count=0,
     loop_overdue_hypothesis_count=None, loop_overdue_goal_count=None, loop_outcome_missing_goal_count=None,
+    unmeasurable_goal_count=0,
 ):
     seq = [_r_all(approvals)]
     if approvals:
@@ -126,6 +127,8 @@ def _ma_seq(
     seq.append(_r_scalar(
         loop_outcome_missing_goal_count if loop_outcome_missing_goal_count is not None else len(done_no_outcome_goals)
     ))
+    # story #2843(PO AC②) — unmeasurable_goal_count 스칼라 신설(#3262 CI 판독·Pedro 처방).
+    seq.append(_r_scalar(unmeasurable_goal_count))
     return seq
 
 
@@ -316,6 +319,8 @@ async def test_my_actions_loop_closure_items_and_measure_plan_missing_count():
             # PO 리뷰 보완①(#3253) — items[]는 top-20 cap(위 각 1건뿐)인데 total count는
             # 참값(51)이어야 한다는 게 이 보완의 핵심 — 일부러 items 길이와 다르게 준다.
             loop_outcome_missing_goal_count=51,
+            # story #2843(PO AC②) — unmeasurable(명시 선언)은 N에서 제외·별도 스칼라만.
+            unmeasurable_goal_count=7,
         ))
     assert resp.status_code == 200
     body = _data(resp)
@@ -332,6 +337,7 @@ async def test_my_actions_loop_closure_items_and_measure_plan_missing_count():
     assert body["attention"]["loop_outcome_missing_goal_count"] == 51
     assert body["attention"]["loop_overdue_hypothesis_count"] == 1
     assert body["attention"]["loop_overdue_goal_count"] == 1
+    assert body["attention"]["unmeasurable_goal_count"] == 7
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
설계 카드 loop-closure-first-class-signal-design §2 P1 + §4 반증. P0(#2829/#2830)는 관측(신호·카운터·브리핑)까지 — 이제 판정 커플링.

**그라운딩이 잡은 원안 결함**: PO 초안의 verified/falsified(hypothesis 어휘)를 goal에 그대로 수입하면, `Goal.outcome_status`가 이미 쓰는 자동채점 어휘(hit/miss — cron.py GA4/internal_ops 파이프라인, 실사용 중)와 같은 컬럼에서 두 방언이 공존하게 된다. PO 정정: **한 컬럼 한 어휘** — goal은 기존 hit/miss 그대로, hypothesis는 기존 verified/falsified/killed(#2038) 그대로.

## AC(페드루 PO 확定)
1. **신값 둘**: `unmeasured`(판정 미제공 시 done 전이가 자동 마킹 — 전이 자체는 안 막음, AC1/AC5) / `unmeasurable`(명시 «측정 불가» 선언·사유 필수, 루프 N 제외하되 위조 채널 감시용 별도 카운트 노출).
2. **collision 규칙 3**: ①manual 판정(`outcome_result.source=manual` 마커)은 cron scorer가 안 덮음(WHERE 자연 배제 + 명시 스킵 가드 한 겹 더) ②旣 hit/miss는 done 재전이 시 판정 재요구 안 함 ③"나중 쓰기가 이김" 방치 기각.
3. **근거 요구**: hypothesis #2038과 공유(`outcome_evidence.py`로 추출 — hit/miss는 actual+reason, unmeasurable은 reason만). `closed_by`는 #2036과 동형으로 서버가 caller로 주입(클라 위장 차단).
4. **P0 카운터 정합**: `command_center.py`(2곳)·`loop_measure_due.py`(1곳) — `outcome_status=="n_a"` 단일조건을 `.in_(("n_a","unmeasured"))`로. `unmeasurable_goal_count` 신규 노출(N 비포함·집계만).

## Test plan
- [x] `test_2843_goal_outcome_verdict_realdb.py`(신규 9건) — 자동마킹·hit/miss 근거강제·unmeasurable 근거·잘못된 값 거부·旣판정 skip·cron 스킵가드 — 로컬 실PG green.
- [x] `test_2829_loop_measure_due_realdb.py`(신규 2건 추가) — unmeasured 잔류·unmeasurable 제외 — 기존 4건 포함 6건 green.
- [x] hypothesis #2038 회귀 10건 + E-LOOP-LEDGER S19 무회귀 확認(`_has_valid_outcome_evidence` 추출 리팩터 안전성).
- [x] `test_edg_s25_epic_overlay.py` 무회귀.
- [x] `git apply -R` — 9건 중 8건 즉시 FAIL(load-bearing), 1건(旣판정 케이스)은 outcome_status를 애초에 안 건드리던 구코드에서도 우연히 통과(무해 — 로직 자체는 정확히 구현됨).
- [x] dependency_overrides get_read_db lint green.
- [ ] CI
- [ ] 카디르 QA

FE(전이 다이얼로그)는 별도 스토리 — 이 PR 착지 후.

관련: [SID:2843]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>