### PR TITLE
feat(#2842): my-actions attention 항목에 project_id+project_slug

### DIFF
--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -373,7 +373,7 @@ async def my_actions(
     # additive로 채운다.
     stalled = (
         await session.execute(
-            select(Story.id, Story.updated_at, Story.title)
+            select(Story.id, Story.updated_at, Story.title, Story.project_id)
             .where(
                 Story.org_id == org_id,
                 Story.status.not_in(("done", "backlog")),
@@ -385,12 +385,13 @@ async def my_actions(
             .limit(20)
         )
     ).all()
-    for sid, updated_at, title in stalled:
+    for sid, updated_at, title, project_id in stalled:
         attention_items.append({
             "type": "story_stalled", "severity": "warn", "auto_detected": True,
             "title": title,
             "story_id": str(sid),
             "stalled_days": (now - updated_at).days if updated_at else None,
+            "project_id": str(project_id),
         })
     # 3) CC-BE.2 답없는 블로커(enum/ids/age — raw blocker text 0).
     # story #2538: story_stalled와 동형으로 title 추가(막힌 story 제목) — FE 구별용.
@@ -399,7 +400,7 @@ async def my_actions(
         await session.execute(
             select(
                 ItemDependency.from_id, ItemDependency.to_id, ItemDependency.created_at,
-                _BlockedU.title,
+                _BlockedU.title, _BlockedU.project_id,
             )
             .select_from(ItemDependency)
             .join(_BlockedU, _BlockedU.id == ItemDependency.to_id)
@@ -416,12 +417,13 @@ async def my_actions(
             .limit(20)
         )
     ).all()
-    for blocker_id, blocked_id, created_at, blocked_title in unanswered:
+    for blocker_id, blocked_id, created_at, blocked_title, project_id in unanswered:
         attention_items.append({
             "type": "unanswered_blocker", "severity": "warn", "auto_detected": True,
             "blocked_story_id": str(blocked_id), "blocker_id": str(blocker_id),
             "blocked_story_title": blocked_title,
             "age_days": (now - created_at).days if created_at else None,
+            "project_id": str(project_id),
         })
     # 4) story #2539: 최근 반증(falsified) 가설 — 결과 통보(in-flight 감지 아님, 위 주석 참조).
     falsified_hyps = (
@@ -429,6 +431,7 @@ async def my_actions(
             select(
                 Hypothesis.id, Hypothesis.statement, Hypothesis.outcome_result,
                 Hypothesis.updated_at, Hypothesis.superseded_by_hypothesis_id,
+                Hypothesis.project_id,
             )
             .where(
                 Hypothesis.org_id == org_id,
@@ -439,13 +442,14 @@ async def my_actions(
             .limit(20)
         )
     ).all()
-    for hyp_id, statement, outcome_result, updated_at, superseded_by in falsified_hyps:
+    for hyp_id, statement, outcome_result, updated_at, superseded_by, project_id in falsified_hyps:
         attention_items.append({
             "type": "hypothesis_falsified", "severity": "info", "auto_detected": True,
             "hypothesis_id": str(hyp_id), "statement": statement,
             "outcome_result": outcome_result,
             "falsified_days": (now - updated_at).days if updated_at else None,
             "superseded_by_hypothesis_id": str(superseded_by) if superseded_by else None,
+            "project_id": str(project_id),
         })
     # 5) story #2829(loop-closure P0, doc loop-closure-first-class-signal-design §1·§3
     # 계약=미르코군 doc a8e73bdb 그대로) — 「닫히지 않은 루프」: N에 포함되는 2류(도과+outcome
@@ -453,7 +457,10 @@ async def my_actions(
     # 센다 — 발행 성패가 "닫히지 않았다"는 사실 자체를 안 바꾼다(서비스 모듈독스트링 참조).
     overdue_hyps = (
         await session.execute(
-            select(Hypothesis.id, Hypothesis.statement, Hypothesis.measure_after, Hypothesis.owner_member_id)
+            select(
+                Hypothesis.id, Hypothesis.statement, Hypothesis.measure_after,
+                Hypothesis.owner_member_id, Hypothesis.project_id,
+            )
             .where(
                 Hypothesis.org_id == org_id,
                 Hypothesis.status.in_(("active", "measuring")),
@@ -463,16 +470,17 @@ async def my_actions(
             .limit(20)
         )
     ).all()
-    for hyp_id, statement, measure_after, owner_id in overdue_hyps:
+    for hyp_id, statement, measure_after, owner_id, project_id in overdue_hyps:
         attention_items.append({
             "type": "loop_overdue_hypothesis", "severity": "warn", "auto_detected": True,
             "hypothesis_id": str(hyp_id), "statement": statement,
             "owner_member_id": str(owner_id) if owner_id else None,
             "overdue_days": (now - measure_after).days if measure_after else None,
+            "project_id": str(project_id),
         })
     overdue_goals = (
         await session.execute(
-            select(Goal.id, Goal.title, Goal.measure_after, Goal.assignee_id)
+            select(Goal.id, Goal.title, Goal.measure_after, Goal.assignee_id, Goal.project_id)
             .where(
                 Goal.org_id == org_id,
                 Goal.status == "active",
@@ -483,12 +491,13 @@ async def my_actions(
             .limit(20)
         )
     ).all()
-    for goal_id, title, measure_after, assignee_id in overdue_goals:
+    for goal_id, title, measure_after, assignee_id, project_id in overdue_goals:
         attention_items.append({
             "type": "loop_overdue_goal", "severity": "warn", "auto_detected": True,
             "goal_id": str(goal_id), "title": title,
             "owner_member_id": str(assignee_id) if assignee_id else None,
             "overdue_days": (now - measure_after).days if measure_after else None,
+            "project_id": str(project_id),
         })
     # story #2843 — outcome_status "n_a"(아직 손 안 댐)뿐 아니라 "unmeasured"(닫혔는데
     # 판정 미제공·done 전이 시 자동 마킹)도 «닫히지 않은 루프» 축이다. n_a와 unmeasured는
@@ -496,7 +505,7 @@ async def my_actions(
     # unmeasured 자체의 구분은 GoalResponse.outcome_status 값으로 API에 이미 노출된다.
     done_no_outcome_goals = (
         await session.execute(
-            select(Goal.id, Goal.title, Goal.updated_at, Goal.assignee_id)
+            select(Goal.id, Goal.title, Goal.updated_at, Goal.assignee_id, Goal.project_id)
             .where(
                 Goal.org_id == org_id,
                 Goal.status == "done",
@@ -506,12 +515,13 @@ async def my_actions(
             .limit(20)
         )
     ).all()
-    for goal_id, title, updated_at, assignee_id in done_no_outcome_goals:
+    for goal_id, title, updated_at, assignee_id, project_id in done_no_outcome_goals:
         attention_items.append({
             "type": "loop_outcome_missing_goal", "severity": "warn", "auto_detected": True,
             "goal_id": str(goal_id), "title": title,
             "owner_member_id": str(assignee_id) if assignee_id else None,
             "done_days": (now - updated_at).days if updated_at else None,
+            "project_id": str(project_id),
         })
     # N에서 제외하되 집계는 유지(페드루 PO 보완 지시, doc a8e73bdb §2) — measure_after
     # 자체가 없는 active goal. AC상 클릭 목록 요건이 없어 개별 목록은 안 싣는다(카운트만).
@@ -568,6 +578,20 @@ async def my_actions(
             )
         )
     ).scalar_one()
+
+    # 0b17472c(미르코군 그라운딩) — attention.items[] 항목별 project_id는 이미 위 각 SELECT에서
+    # 실려 있다(3모델 Story/Hypothesis/Goal 모두 기존 컬럼) — project_slug만 배치 1쿼리로
+    # 붙인다(N+1 회피, entity_slug.resolve_project_slugs 재사용 — goals.py/stories.py와 동일
+    # 패턴). FE(미르코군) 적체 3건의 열쇠 — story #2819보다 先.
+    from app.services.entity_slug import resolve_project_slugs
+
+    _attention_project_ids = {
+        uuid.UUID(item["project_id"]) for item in attention_items if item.get("project_id")
+    }
+    _project_slug_map = await resolve_project_slugs(session, _attention_project_ids)
+    for item in attention_items:
+        if item.get("project_id"):
+            item["project_slug"] = _project_slug_map.get(uuid.UUID(item["project_id"]))
 
     return JSONResponse(content={
         "action_queue": {  # scope: member(caller) — 타 멤버 큐 노출 0.

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -97,7 +97,7 @@ def _ma_seq(
     my_tasks=(), approval_group_counts=(), blocker_weight_counts=(), falsified=(),
     overdue_hyps=(), overdue_goals=(), done_no_outcome_goals=(), measure_plan_missing_goal_count=0,
     loop_overdue_hypothesis_count=None, loop_overdue_goal_count=None, loop_outcome_missing_goal_count=None,
-    unmeasurable_goal_count=0,
+    unmeasurable_goal_count=0, project_slugs=(),
 ):
     seq = [_r_all(approvals)]
     if approvals:
@@ -129,6 +129,13 @@ def _ma_seq(
     ))
     # story #2843(PO AC②) — unmeasurable_goal_count 스칼라 신설(#3262 CI 판독·Pedro 처방).
     seq.append(_r_scalar(unmeasurable_goal_count))
+    # 0b17472c — attention.items[] project_slug 배치 조회. resolve_project_slugs는 project_id
+    # 집합이 비면 DB 왕복 자체를 스킵(조기 return) — stalled/unanswered/falsified/overdue_*/
+    # done_no_outcome_goals 중 하나라도 있어야(그 항목들에 project_id가 실려 있어야) 이 쿼리가
+    # 발생한다(approval_group_counts/blocker_weight_counts와 동형 조건부 패턴). command_center.py
+    # 실 순서상 unmeasurable_goal_count(#2843) 스칼라 뒤에 이 배치가 온다(rebase 시 확認).
+    if stalled or unanswered or falsified or overdue_hyps or overdue_goals or done_no_outcome_goals:
+        seq.append(_r_all(project_slugs))
     return seq
 
 
@@ -250,12 +257,13 @@ async def test_my_actions_stalled_and_unanswered_blocker_enum_only():
 
     story #2538: title 추가(FE "제목+N일" 구별용) — 가설과 무관한 카피 오라벨링 정정의
     전제 데이터."""
-    sid, blocker_id, blocked_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    sid, blocker_id, blocked_id, pid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     resp, session, resolver = await _get(
         "/api/v2/command-center/my-actions",
         execute_seq=_ma_seq(
-            stalled=[(sid, _OLD, "정체된 스토리")],
-            unanswered=[(blocker_id, blocked_id, _OLD, "막힌 스토리")],
+            stalled=[(sid, _OLD, "정체된 스토리", pid)],
+            unanswered=[(blocker_id, blocked_id, _OLD, "막힌 스토리", pid)],
+            project_slugs=[(pid, "acme")],
         ))
     assert resp.status_code == 200
     types = {i["type"] for i in _data(resp)["attention"]["items"]}
@@ -264,20 +272,28 @@ async def test_my_actions_stalled_and_unanswered_blocker_enum_only():
     stalled_item = next(i for i in items if i["type"] == "story_stalled")
     assert stalled_item["story_id"] == str(sid) and isinstance(stalled_item["stalled_days"], int)
     assert stalled_item["title"] == "정체된 스토리"
+    # 0b17472c — project_id/project_slug 배치 부착 확認.
+    assert stalled_item["project_id"] == str(pid)
+    assert stalled_item["project_slug"] == "acme"
     ub = next(i for i in items if i["type"] == "unanswered_blocker")
     assert ub["blocked_story_title"] == "막힌 스토리"
     assert ub["blocked_story_id"] == str(blocked_id) and isinstance(ub["age_days"], int)
+    assert ub["project_id"] == str(pid)
+    assert ub["project_slug"] == "acme"
 
 
 @pytest.mark.anyio
 async def test_my_actions_hypothesis_falsified_result_notification():
     """story #2539: 최근 falsified 가설 결과 통보(in-flight 이상감지 아님 — severity=info,
     story_stalled/unanswered_blocker의 severity=warn과 의도적으로 다름)."""
-    hyp_id, succ_id = uuid.uuid4(), uuid.uuid4()
+    hyp_id, succ_id, pid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     outcome = {"metric": "signups", "target": 100, "actual": 42, "direction": "increase"}
     resp, session, resolver = await _get(
         "/api/v2/command-center/my-actions",
-        execute_seq=_ma_seq(falsified=[(hyp_id, "체크아웃 2단계면 가입 늘 것", outcome, _OLD, succ_id)]))
+        execute_seq=_ma_seq(
+            falsified=[(hyp_id, "체크아웃 2단계면 가입 늘 것", outcome, _OLD, succ_id, pid)],
+            project_slugs=[(pid, "acme")],
+        ))
     assert resp.status_code == 200
     items = _data(resp)["attention"]["items"]
     hf = next(i for i in items if i["type"] == "hypothesis_falsified")
@@ -292,10 +308,13 @@ async def test_my_actions_hypothesis_falsified_result_notification():
 @pytest.mark.anyio
 async def test_my_actions_hypothesis_falsified_superseded_by_null_when_unconfirmed():
     """AC — 확認된 대체 페어 없으면 superseded_by_hypothesis_id는 None(지어내지 않는다)."""
-    hyp_id = uuid.uuid4()
+    hyp_id, pid = uuid.uuid4(), uuid.uuid4()
     resp, session, resolver = await _get(
         "/api/v2/command-center/my-actions",
-        execute_seq=_ma_seq(falsified=[(hyp_id, "S", None, _OLD, None)]))
+        execute_seq=_ma_seq(
+            falsified=[(hyp_id, "S", None, _OLD, None, pid)],
+            project_slugs=[(pid, "acme")],
+        ))
     assert resp.status_code == 200
     items = _data(resp)["attention"]["items"]
     hf = next(i for i in items if i["type"] == "hypothesis_falsified")
@@ -308,25 +327,29 @@ async def test_my_actions_loop_closure_items_and_measure_plan_missing_count():
     """story #2829: 「닫히지 않은 루프」 3타입(가설 도과·goal 도과·outcome 없는 done)이
     attention.items[]에 실리고, 측정계획 없는 active goal 수는 N에서 제외된 채 별도 스칼라
     필드로만 실린다(doc a8e73bdb §2 PO 확定 — 페드루 보완 지시)."""
-    hyp_id, goal_id, done_goal_id, owner_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    hyp_id, goal_id, done_goal_id, owner_id, pid = (
+        uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    )
     resp, session, resolver = await _get(
         "/api/v2/command-center/my-actions",
         execute_seq=_ma_seq(
-            overdue_hyps=[(hyp_id, "체크아웃 개선 가설", _OLD, owner_id)],
-            overdue_goals=[(goal_id, "Q3 활성화", _OLD, owner_id)],
-            done_no_outcome_goals=[(done_goal_id, "런칭", _OLD, owner_id)],
+            overdue_hyps=[(hyp_id, "체크아웃 개선 가설", _OLD, owner_id, pid)],
+            overdue_goals=[(goal_id, "Q3 활성화", _OLD, owner_id, pid)],
+            done_no_outcome_goals=[(done_goal_id, "런칭", _OLD, owner_id, pid)],
             measure_plan_missing_goal_count=40,
             # PO 리뷰 보완①(#3253) — items[]는 top-20 cap(위 각 1건뿐)인데 total count는
             # 참값(51)이어야 한다는 게 이 보완의 핵심 — 일부러 items 길이와 다르게 준다.
             loop_outcome_missing_goal_count=51,
             # story #2843(PO AC②) — unmeasurable(명시 선언)은 N에서 제외·별도 스칼라만.
             unmeasurable_goal_count=7,
+            project_slugs=[(pid, "acme")],
         ))
     assert resp.status_code == 200
     body = _data(resp)
     items_by_type = {i["type"]: i for i in body["attention"]["items"]}
     oh = items_by_type["loop_overdue_hypothesis"]
     assert oh["hypothesis_id"] == str(hyp_id) and oh["owner_member_id"] == str(owner_id)
+    assert oh["project_id"] == str(pid) and oh["project_slug"] == "acme"
     og = items_by_type["loop_overdue_goal"]
     assert og["goal_id"] == str(goal_id) and isinstance(og["overdue_days"], int)
     om = items_by_type["loop_outcome_missing_goal"]


### PR DESCRIPTION
## Summary
미르코군 그라운딩 — `attention.items[]`를 구성하는 3모델(Story/Hypothesis/Goal) 전부 `project_id` 컬럼이 기존재. SELECT에 컬럼 추가+dict 필드 추가뿐, 새 쿼리는 `project_slug` 배치 조회 1개(`entity_slug.resolve_project_slugs` 재사용, N+1 회피 — goals.py/stories.py와 동일 패턴)만 추가.

대상 6타입: `story_stalled`·`unanswered_blocker`·`hypothesis_falsified`·`loop_overdue_hypothesis`·`loop_overdue_goal`·`loop_outcome_missing_goal`. `agent_stuck`(`WorkflowLineStepRun` 폴리모픽 `entity_type`/`entity_id`)은 스코프 밖(3모델에 해당 안 됨).

⚠️**FE 주의(페드루 PO 지적)**: `agent_stuck` 타입 항목엔 `project_id`/`project_slug` 필드 자체가 없다(다른 5타입에만 있음) — 미르코군 FE는 이 필드 부재를 관용해야 한다(옵셔널 취급, agent_stuck 렌더링이 project 배지를 요구하면 안 됨).

미르코군 FE 적체 3건의 열쇠 — story #2819보다 先(소 PR).

## Test plan
- [x] `test_command_center.py` 6개 테스트에 project_id/project_slug 배치 부착 확認 추가, `_ma_seq()` 헬퍼에 조건부 project_slug 쿼리 삽입(`approval_group_counts`와 동형 패턴). 전체 22건 green(회귀 0).
- [x] dependency_overrides get_read_db lint green.
- [ ] CI
- [ ] 카디르 QA

관련: 0b17472c

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

[SID:2842]