### PR TITLE
fix(#2819): gate_github_check_event 원장에 prior_sha 컬럼 신설

### DIFF
--- a/backend/alembic/versions/0265_gate_github_check_event_prior_sha.py
+++ b/backend/alembic/versions/0265_gate_github_check_event_prior_sha.py
@@ -1,0 +1,33 @@
+"""story #2819([Gate 강제·BE], PR#3246 미르코 발견) — gate_github_check_event 원장에
+prior_sha 컬럼 신설, 재-pending 사유 완전화.
+
+`reopen_gate_if_new_sha`(gate_github_check.py)가 무효화된 승인이 귀속됐던 SHA를 지역변수
+`prior_sha`로만 로깅하고 원장(`re_pending` 행)엔 `head_sha`(새 SHA)만 저장했다 — `gate.
+approved_head_sha`로 메꾸려 해도 같은 함수가 재-pending 즉시 그 필드를 null로 리셋해버려
+FE 조회 시점엔 이미 사라지고 없었다(FE는 "새 커밋(SHA {new})으로 이전 승인이 무효화됨"까지만
+표시, "어느 SHA에서"는 못 보여줌).
+
+`re_pending` 행 전용(published/resolved 행이나 마이그레이션 이전 re_pending 행은 NULL —
+소급 불가라 정직하게 표시, FE는 이미 null 폴백 설계·PR#3246).
+
+Revision ID: 0265
+Revises: 0264
+Create Date: 2026-08-20
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0265"
+down_revision = "0264"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("gate_github_check_event", sa.Column("prior_sha", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("gate_github_check_event", "prior_sha")

--- a/backend/app/models/gate_github_check_event.py
+++ b/backend/app/models/gate_github_check_event.py
@@ -31,6 +31,11 @@ class GateGithubCheckEvent(Base):
     repo_full_name: Mapped[str] = mapped_column(Text, nullable=False)
     pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
     head_sha: Mapped[str] = mapped_column(Text, nullable=False)
+    # story #2819 — re_pending 행 전용: 무효화된 승인이 귀속됐던 SHA(reopen_gate_if_new_sha가
+    # 이미 계산해 둔 prior_sha 지역변수를 여기 같이 남긴다 — 이전엔 로그로만 나가고 원장엔
+    # head_sha(새 SHA)만 남아 "어느 SHA에서" 무효화됐는지가 조회 시점엔 이미 사라져 있었다).
+    # published/resolved 행이나 마이그레이션 이전 행은 NULL(소급 불가 — no-fiction).
+    prior_sha: Mapped[str | None] = mapped_column(Text, nullable=True)
     # published(최초/재-pending 발행) | re_pending(SHA 불일치로 게이트를 되돌림) | resolved(success/failure).
     event_type: Mapped[str] = mapped_column(Text, nullable=False)
     # GitHub check-run conclusion — pending 발행이면 NULL(status=in_progress).

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -955,6 +955,9 @@ class GateGithubCheckEventResponse(BaseModel):
     repo_full_name: str
     pr_number: int
     head_sha: str
+    # story #2819 — re_pending 행 전용(무효화된 승인이 귀속됐던 SHA). published/resolved 행이나
+    # 마이그레이션 이전 re_pending 행은 null(소급 불가 — FE는 이미 null 폴백 설계, PR#3246).
+    prior_sha: str | None = None
     event_type: str  # published | re_pending | resolved
     check_conclusion: str | None
     created_at: datetime

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -320,7 +320,9 @@ async def reopen_gate_if_new_sha(
     session.add(GateGithubCheckEvent(
         org_id=org_id, gate_id=gate.id, story_id=gate.work_item_id,
         repo_full_name=repo_full_name, pr_number=pr_number, head_sha=new_head_sha,
-        event_type="re_pending", check_conclusion=None,
+        # story #2819 — 이미 계산해 둔 prior_sha를 로그뿐 아니라 원장에도 남긴다(FE가
+        # "SHA {prior}에서 SHA {new}로 무효화"를 조회 시점에 만들 수 있게).
+        event_type="re_pending", check_conclusion=None, prior_sha=prior_sha,
     ))
     logger.info("gate=%s: re_pending 원장 기록(prior_sha=%s)", gate.id, prior_sha)
     await session.flush()

--- a/backend/tests/test_2813_gate_github_check_realdb.py
+++ b/backend/tests/test_2813_gate_github_check_realdb.py
@@ -489,6 +489,9 @@ async def test_reopen_gate_if_new_sha_flips_approved_to_pending_realdb():
             assert events[0].event_type == "re_pending"
             assert events[0].head_sha == "new-sha"
             assert events[0].check_conclusion is None
+            # story #2819(AC1) — 무효화된 승인이 귀속됐던 SHA(gate.approved_head_sha가
+            # 리셋되기 전 값)가 원장 행에 남아야 FE가 "SHA old-sha→new-sha 무효화"를 표시.
+            assert events[0].prior_sha == "old-sha"
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_2815_gate_github_check_events_endpoint_realdb.py
+++ b/backend/tests/test_2815_gate_github_check_events_endpoint_realdb.py
@@ -171,6 +171,47 @@ async def test_realdb_list_check_events_latest_first_and_shape():
             assert body[0]["pr_number"] == 7
             assert body[0]["head_sha"] == "sha-1"
             assert "org_id" not in body[0]  # 응답 스키마가 의도적으로 생략(URL이 이미 컨텍스트).
+            # story #2819(AC2/AC3) — published/resolved 행은 prior_sha 개념이 없어 null.
+            assert body[0]["prior_sha"] is None
+            assert body[1]["prior_sha"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_list_check_events_exposes_prior_sha_on_re_pending():
+    """story #2819(AC2) — re_pending 행에 실제로 기록된 prior_sha가 GET 응답에 그대로
+    노출되는지(모델 컬럼 신설만으로는 직렬화 경로가 자동 보장되지 않으므로 별도 확認)."""
+    from app.main import app
+    from app.models.gate_github_check_event import GateGithubCheckEvent
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            _, gate = await _seed_merge_gate(s, seeded)
+            gate_id = gate.id
+            s.add(GateGithubCheckEvent(
+                id=uuid.uuid4(), org_id=seeded["org_id"], gate_id=gate.id, story_id=gate.work_item_id,
+                repo_full_name="acme/repo", pr_number=7, head_sha="sha-2",
+                event_type="re_pending", check_conclusion=None, prior_sha="sha-1",
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/gates/{gate_id}/github-check-events")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body) == 1
+            assert body[0]["event_type"] == "re_pending"
+            assert body[0]["head_sha"] == "sha-2"
+            assert body[0]["prior_sha"] == "sha-1"
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## Summary
- story #2819([Gate 강제·BE], PR#3246 미르코 발견) — `reopen_gate_if_new_sha`가 무효화된 승인이 귀속됐던 SHA를 로그로만 남기고 원장(`gate_github_check_event`)에는 저장하지 않던 것을 `prior_sha` 컬럼 신설로 고침.
- 근본원인: `gate.approved_head_sha`로 메꾸려 해도 같은 함수가 재-pending 즉시 그 필드를 null로 리셋해버려 FE 조회 시점엔 이미 사라지고 없었다.
- `re_pending` 행 전용(published/resolved 행 및 마이그 이전 re_pending 행은 소급 불가라 정직하게 null — FE는 이미 null 폴백 설계, PR#3246).
- 마이그레이션 0265 신설(`gate_github_check_event.prior_sha`), 서비스 persist, 응답 스키마(`GateGithubCheckEventResponse.prior_sha`) 노출까지 배선.

## AC
- AC1: 재-pending 발생 시 원장 행에 prior_sha가 실제로 기록된다 — `test_2813_gate_github_check_realdb.py::test_reopen_gate_if_new_sha_flips_approved_to_pending_realdb`에 어서션 추가로 확인.
- AC2/AC3: `GET /api/v2/gates/{id}/github-check-events` 응답에 prior_sha가 노출(re_pending은 값, published/resolved는 null) — `test_2815_gate_github_check_events_endpoint_realdb.py::test_realdb_list_check_events_exposes_prior_sha_on_re_pending`(신규) + 기존 shape 테스트에 null 어서션 추가.

## Test plan
- [x] `alembic upgrade heads` 신선 로컬 PG에 0264→0265 클린 적용 확인
- [x] `test_2813_gate_github_check_realdb.py`(21) + `test_2815_gate_github_check_events_endpoint_realdb.py`(9, 신규 1건 포함) + `test_2826_gate_pr_lifecycle_creation_realdb.py`(5) = 35건 전량 green
- [x] load-bearing 확인: 프로덕션 diff `git apply -R` 후 신규/확장 어서션 2건 정확히 기대대로 FAIL(`TypeError: 'prior_sha' is an invalid keyword argument`) → 복원 후 재확인 green

story #2840(FE, prior_sha 착지 시 재-pending 사유 문구 완전화)이 이 PR 머지로 언블록됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)