### PR TITLE
fix(#2847): 착수 시 participation 자동 등록 + 부재 no-op 관측 신호화

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -2365,6 +2365,18 @@ async def update_story_status(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    # story #2847(AC1) — claim_story/assignee 경로는 이미 3414b6d7의 ensure_implementation_
+    # participation으로 보장되지만, 이 엔드포인트만 거치는 챗-킥오프 흐름(claim/assign 생략)은
+    # 여태 빠져 있었다 — merge gate의 "no implementation participation" 침묵 no-op 근본원인
+    # (#2843/#3262 실사고). caller=착수자를 그대로 implementation participant로 멱등 등록.
+    # 실패해도 전이 비차단(이 함수의 다른 side-effect들과 동일 fail-open 규율).
+    if story_before is not None and old_status != "in-progress" and body.status == "in-progress" and _line_actor_id is not None:
+        try:
+            from app.services.participation_helpers import ensure_implementation_participation
+            await ensure_implementation_participation(db, repo.org_id, id, _line_actor_id)
+        except Exception:  # noqa: BLE001
+            pass
+
     # E-DG S7: agent-handoff relay — status 적용 후 같은 트랜잭션에서 dispatch(commit=False)·step_run
     # delivery 기록(원자). wake/CC delivery 는 commit(아래) 후 recipient_seq 확정 후 발화(P1-2 불변식).
     # relay 실패도 전이 비차단(fail-open).

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -482,6 +482,32 @@ async def _process_webhook_event(
                     "org_id": org_id, "gate_id": decision.gate_id,
                     "head_sha": head_sha, "repo_full_name": repo, "pr_number": pr_number,
                 })
+            elif ungated_check_publish is not None:
+                # story #2847(AC2) — 이 chokepoint(pr_number>0 고정)에서 gate_id=None은 오직
+                # "no implementation participation" 조기반환 하나뿐(evaluate_merge_gate의
+                # no-substance 숏컷은 pr_number<=0 전용이라 여기선 절대 안 탄다 — 그라운딩
+                # 확認). #2826과 동형으로 침묵 대신 action_required check로 안내.
+                from app.models.github_installation import GithubInstallation as _GithubInstallation2
+                from app.services.gate_github_check import (
+                    PARTICIPATION_REQUIRED_SUMMARY,
+                    PARTICIPATION_REQUIRED_TITLE,
+                    is_repo_check_enforced as _is_repo_check_enforced2,
+                )
+
+                _installation_id2 = installation.installation_id if installation is not None else (
+                    await session.execute(
+                        select(_GithubInstallation2.installation_id).where(
+                            _GithubInstallation2.org_id == org_id,
+                            _GithubInstallation2.suspended_at.is_(None),
+                        )
+                    )
+                ).scalar_one_or_none()
+                if _installation_id2 is not None and await _is_repo_check_enforced2(session, org_id, repo):
+                    ungated_check_publish.append({
+                        "installation_id": _installation_id2,
+                        "repo_full_name": repo, "head_sha": head_sha, "pr_number": pr_number,
+                        "title": PARTICIPATION_REQUIRED_TITLE, "summary": PARTICIPATION_REQUIRED_SUMMARY,
+                    })
 
     # P0-05 후속(doc scope-violation-signal-design §2·§3): PR 자체 이벤트(opened/synchronize/reopened)
     # + confident link(should_auto_close 동일 신뢰 등급)일 때만 판정. 3중 침묵 조건은 헬퍼 내부.

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -112,17 +112,34 @@ ACTION_REQUIRED_SUMMARY = (
     "연결 후 새 커밋을 push하면(또는 PR을 재오픈하면) 이 check가 자동으로 갱신됩니다."
 )
 
+# story #2847(AC2) — participation 미등록으로 evaluate_merge_gate가 gate_id=None을 반환하는
+# 경로도 #2826과 동일하게 "말하는 부재"로. gate-less라 원장(AC④) 대상 밖인 것도 동형.
+PARTICIPATION_REQUIRED_TITLE = "Sprintable Gate — participation 미등록"
+PARTICIPATION_REQUIRED_SUMMARY = (
+    "이 PR이 연결된 story에 implementation participation이 등록돼 있지 않아 merge gate를 만들 수 "
+    "없습니다(누가 이 작업을 구현했는지 알 수 없어 신뢰 판정을 할 수 없음).\n\n"
+    "story를 claim하거나 담당자로 지정하면(claim_story/assignee 설정) participation이 자동 "
+    "등록됩니다.\n\n"
+    "등록 후 새 커밋을 push하면(또는 PR을 재오픈하면) 이 check가 자동으로 갱신됩니다."
+)
+
 
 async def publish_action_required_check(
     installation_id: int,
     repo_full_name: str,
     head_sha: str,
     pr_number: int,
+    *,
+    title: str = "Sprintable Gate — story 링크 필요",
+    summary: str = ACTION_REQUIRED_SUMMARY,
 ) -> None:
     """story #2826(부 처방, PO 확定 2026-08-20) — story 링크가 없어 gate 자체가 없는 PR에도
     `sprintable/gate`를 발행하되, 침묵 부재(check 자체가 안 뜸) 대신 **말하는 부재**로:
     conclusion=action_required + 다음 행동 안내. gate가 없으니 DB에 남길 게 없다(원장(AC④)은
     gate 존재를 전제 — 이 경로는 gate-less라 대상 밖, GitHub 쪽 UI 안내만).
+
+    story #2847(AC2)부터 title/summary를 매개변수화 — participation 미등록 사유(별도 상수)도
+    같은 함수를 재사용(새 규칙 발명 0, #2826과 동일 chokepoint).
 
     fail-closed(이 모듈 공통 규율): 예외를 삼켜 호출자(웹훅 트랜잭션 뒤 background task)를
     절대 깨뜨리지 않는다 — 실패해도 GitHub 쪽은 그냥 check가 없는 이전 상태 그대로.
@@ -131,8 +148,8 @@ async def publish_action_required_check(
         result = await create_check_run(
             installation_id, repo_full_name, head_sha,
             name=CHECK_NAME, status="completed", conclusion="action_required",
-            title="Sprintable Gate — story 링크 필요",
-            summary=ACTION_REQUIRED_SUMMARY,
+            title=title,
+            summary=summary,
         )
         if result is None:
             logger.warning(

--- a/backend/tests/test_2826_gate_pr_lifecycle_creation_realdb.py
+++ b/backend/tests/test_2826_gate_pr_lifecycle_creation_realdb.py
@@ -371,3 +371,64 @@ async def test_ac3b_legacy_source_without_installation_still_publishes_action_re
         assert kwargs.get("conclusion") == "action_required"
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_2847_ac2_pr_open_with_link_no_participation_enforced_publishes_action_required():
+    """story #2847(AC2) — 링크는 정확히 풀렸는데 participation이 0건이면 evaluate_merge_gate가
+    gate_id=None으로 조기반환(#2843/#3262 실사고 근본원인). 이 repo가 enforced면 AC③과 동형으로
+    침묵 대신 action_required check(participation 전용 문구)로 안내 — gate row는 여전히 0개."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=False)
+            await _seed_installation(s, org, installation_id=555006, enforced=True)
+            await _seed_link(s, org, story, pr_number=16)
+            story_id = story.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 90006}),
+        ) as create_mock, patch("app.core.database.async_session_factory", Session):
+            payload = _pr_payload(
+                action="opened", pr_number=16, installation_id=555006, head_sha="sha-2847ac2",
+            )
+            resp = await _post_app(payload, Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}")
+            assert resp.status_code == 200, resp.text
+
+        create_mock.assert_called_once()
+        _, kwargs = create_mock.call_args
+        assert kwargs.get("status") == "completed"
+        assert kwargs.get("conclusion") == "action_required"
+        assert "participation" in (kwargs.get("title") or "")
+        assert "claim" in (kwargs.get("summary") or "")
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 0, "participation 없으면 gate가 서면 안 된다(#2843/#3262 재발 방지)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_2847_ac2_pr_open_with_link_no_participation_not_enforced_publishes_nothing():
+    """AC4와 동형 음성대조 — enforced가 아니면 participation 미등록도 침묵(도입 마찰 0 원칙 보존)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=False)
+            await _seed_installation(s, org, installation_id=555007, enforced=False)
+            await _seed_link(s, org, story, pr_number=17)
+
+        with patch(
+            "app.services.gate_github_check.create_check_run", AsyncMock(),
+        ) as create_mock, patch("app.core.database.async_session_factory", Session):
+            payload = _pr_payload(
+                action="opened", pr_number=17, installation_id=555007, head_sha="sha-2847ac2b",
+            )
+            resp = await _post_app(payload, Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}")
+            assert resp.status_code == 200, resp.text
+
+        create_mock.assert_not_called()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2847_participation_gap_realdb.py
+++ b/backend/tests/test_2847_participation_gap_realdb.py
@@ -1,0 +1,175 @@
+"""story #2847(AC1) — story 착수(in-progress 진입) 시 implementation participation 자동 등록.
+
+claim_story/assignee 경로는 이미 3414b6d7의 ensure_implementation_participation으로 보장됐지만,
+PATCH /stories/{id}/status만 거치는 챗-킥오프 흐름(claim/assign 생략)은 여태 빠져 있었다 —
+merge gate의 "no implementation participation" 침묵 no-op 근본원인(#2843/#3262 실사고, 디디
+진단·페드루 확定). 이 파일은 그 새 call site를 실PG로 검증한다(기존 helper 자체 동작은
+test_claim_participation.py가 이미 커버 — 발명 0, 새 chokepoint 배선만 확인).
+
+test_2266_story_backlinks_realdb.py의 harness(session_factory/client_for/human member/
+setup_app_human)를 그대로 재사용.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_2266_story_backlinks_realdb import (
+    _client_for,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _make_story,
+    _session_factory,
+    _setup_app_human,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _seed_default_role(session, org_id):
+    from app.models.participation import ParticipationRole
+
+    role = ParticipationRole(
+        id=uuid.uuid4(), org_id=org_id, key="implementation", label="구현", is_default=True,
+    )
+    session.add(role)
+    await session.commit()
+    return role
+
+
+async def _participation_rows(session, org_id, story_id):
+    from app.models.participation import Participation
+
+    return (
+        await session.execute(
+            select(Participation).where(
+                Participation.org_id == org_id, Participation.story_id == story_id,
+            )
+        )
+    ).scalars().all()
+
+
+@pytest.mark.anyio
+async def test_status_to_in_progress_auto_registers_caller_as_implementation_participant():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            await _seed_default_role(s, org.id)
+            story = await _make_story(s, org.id, project.id)
+            story_id = story.id
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story_id}/status", json={"status": "in-progress"},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rows = await _participation_rows(s, org.id, story_id)
+            assert len(rows) == 1
+            assert rows[0].member_id == member_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_status_to_in_progress_idempotent_no_duplicate_participation():
+    """양성대조 — 두 번 in-progress 전이(예: in-progress→todo→in-progress)해도 participation은
+    1건(ensure_implementation_participation의 멱등성이 이 call site에서도 성립)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            member_id, user_id = await _make_human_member(s, org.id, project.id)
+            await _seed_default_role(s, org.id)
+            story = await _make_story(s, org.id, project.id)
+            story_id = story.id
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            for target in ("in-progress", "ready-for-dev", "in-progress"):
+                resp = await client.patch(
+                    f"/api/v2/stories/{story_id}/status", json={"status": target},
+                )
+                assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rows = await _participation_rows(s, org.id, story_id)
+            assert len(rows) == 1
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_status_transition_not_touching_in_progress_does_not_register_participation():
+    """음성대조 — in-progress를 거치지 않는 전이(backlog→ready-for-dev)는 participation을 만들지 않는다
+    (착수 시점이 아니면 "누가 구현했는지" 서버가 함부로 단정하지 않는다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            _member_id, user_id = await _make_human_member(s, org.id, project.id)
+            await _seed_default_role(s, org.id)
+            story = await _make_story(s, org.id, project.id)
+            story_id = story.id
+
+        await _setup_app_human(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{story_id}/status", json={"status": "ready-for-dev"},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rows = await _participation_rows(s, org.id, story_id)
+            assert len(rows) == 0
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story #2847(high, 결함): #2843/PR#3262 실사고(design/QA/CI 전량 green인데 merge gate 미생성·BLOCKED) 근본원인 처방.
- 근본원인: story에 implementation `participation` 행이 0건이면 `evaluate_merge_gate()`가 `gate_id=None`으로 조기반환하고, PR 웹훅의 gate auto-create fallback은 `gate_id`가 있을 때만 발행하므로 merge gate가 **어떤 표면에도 안 뜨는 채로 침묵 no-op**한다.
- `claim_story`/assignee 경로는 이미 3414b6d7(`ensure_implementation_participation`)로 보장되지만, 챗-킥오프처럼 `PATCH /stories/{id}/status`만 거치는 흐름은 그 경로들을 우회했다.

## AC
- **AC1** — in-progress 진입 시 caller를 implementation participant로 멱등 등록: `stories.py::update_story_status`에 기존 공유 helper(`ensure_implementation_participation`) 호출 추가(이미 resolve된 `_line_actor_id` 재사용, 실패해도 전이 비차단).
- **AC2** — participation 부재로 gate_id=None인 경우 침묵 대신 관측 신호화: `verdict_capture.py`의 gate auto-create fallback에서 `decision.gate_id is None`이면(이 chokepoint에서 pr_number>0 고정이라 이 값은 오직 "no implementation participation" 하나뿐 — no-substance 숏컷은 여기서 절대 안 탐, 그라운딩 확認) `#2826`과 동일 chokepoint(`publish_action_required_check`, 이번에 title/summary 매개변수화)로 action_required check + 안내 문구 발행.

## Test plan
- [x] AC1: `test_2847_participation_gap_realdb.py`(신규 3건) — in-progress 진입 시 등록·멱등(중복 방지)·in-progress를 거치지 않는 전이는 미등록(양성/음성 대조).
- [x] AC2: `test_2826_gate_pr_lifecycle_creation_realdb.py`(신규 2건, 기존 5건 무회귀) — 링크 있음+participation 없음+enforced → action_required(participation 전용 문구)+gate 0행 / not-enforced → 침묵(도입 마찰 0 보존).
- [x] load-bearing: 프로덕션 diff `git apply -R` 후 신규 3건 정확히 기대대로 FAIL(AC1 2건: `resolve_implementation_participation` 미호출로 participation 0건, AC2 1건: `create_check_run` 미호출) → 복원 후 재확인 green.
- [x] 각 realdb 파일 개별 실행(destructive-schema 관례) — `test_2847_participation_gap_realdb.py`(3) / `test_2826...`(7) / 기존 `test_claim_participation.py`(2) / `test_2327_webhook_skipped_reason_realdb.py`(3) 전부 fresh migrated DB에서 green.
- [x] 회귀: `test_stories.py`(42, mock)·`test_s2_4_claim_unclaim.py` 무회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 설계 노트 (PO 리뷰, 2026-08-20)
in-progress를 **건너뛰는** 전이(예: backlog→in-review 직행)는 AC1의 훅(in-progress 진입 전용) 그물 밖이다 — 그 잔여 케이스는 AC1이 아니라 AC2(participation 부재 시 action_required 관측 신호)가 받는다. 층이 그렇게 나뉘어 있는 것이 설계 의도이며 리뷰 사각이 아니다.
