### PR TITLE
feat(#2836): 에이전트 API키 401 연속을 관측 신호로 승격

### DIFF
--- a/backend/alembic/versions/0266_agent_auth_failure.py
+++ b/backend/alembic/versions/0266_agent_auth_failure.py
@@ -1,0 +1,45 @@
+"""story #2836([결함·관측], 실사고 — 유나 세션 6시간+ 침묵·미르코 revoke 사례) — agent_auth_failure
+원장 신설.
+
+에이전트 API키 401 인증실패가 어떤 표면에도 안 뜨던 것을 매 401마다 append-only로 기록한다.
+「연속 N회」 판정은 이 원장을 windowed COUNT로 읽는다(별도 카운터/서킷브레이커 테이블 없음).
+
+Revision ID: 0266
+Revises: 0265
+Create Date: 2026-08-20
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0266"
+down_revision = "0265"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_auth_failure",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("api_key_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("member_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("key_prefix", sa.Text(), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.CheckConstraint("reason IN ('expired', 'revoked', 'invalid')", name="ck_agent_auth_failure_reason"),
+    )
+    op.create_index("ix_agent_auth_failure_org_id", "agent_auth_failure", ["org_id"])
+    op.create_index(
+        "ix_agent_auth_failure_org_member_occurred", "agent_auth_failure",
+        ["org_id", "member_id", "occurred_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_auth_failure_org_member_occurred", table_name="agent_auth_failure")
+    op.drop_index("ix_agent_auth_failure_org_id", table_name="agent_auth_failure")
+    op.drop_table("agent_auth_failure")

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -144,6 +144,11 @@ async def _resolve_api_key(
 
     api_key = result.scalar_one_or_none()
     if not api_key:
+        # story #2836 — 이 401이 어떤 표면에도 안 뜨던 것(유나 6시간+ 침묵·미르코 revoke 실사고)의
+        # 근본원인. 원장 기록은 자기 세션(caller는 곧 401 예외로 rollback)+실패해도 401 자체는
+        # 절대 안 막는다(agent_auth_failure.py docstring 참고).
+        from app.services.agent_auth_failure import record_auth_failure
+        await record_auth_failure(raw_key)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
 
     # OB-4b seam(first_auth_seen): 이 키의 최초 인증(last_used_at None)을 갱신 전 캡처 — 1회 dedup.

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -27,6 +27,7 @@ from app.models.usage_meter import UsageMeter
 from app.models.user import RefreshToken, User
 from app.models.workflow_version import WorkflowVersion
 from app.models.api_key import ApiKey
+from app.models.agent_auth_failure import AgentAuthFailure
 from app.models.human_api_key import HumanApiKey
 from app.models.org_subscription import OrgSubscription
 from app.models.pricing_version import PricingVersion

--- a/backend/app/models/agent_auth_failure.py
+++ b/backend/app/models/agent_auth_failure.py
@@ -1,0 +1,44 @@
+"""story #2836([결함·관측], 실사고 — 유나 세션 6시간+ 침묵·미르코 revoke 사례) — 에이전트 API키
+인증실패(401)가 어떤 표면에도 안 뜨던 것을 원장으로 남긴다.
+
+append-only(1행 = 1회 401). 「연속 N회」는 별도 상태 컬럼 없이 이 원장을 windowed COUNT로
+읽어 판정한다(agent_stuck·story_stalled 등 command_center.py의 기존 관측 패턴과 동형 — 발명
+0, 새 서킷브레이커 상태기계 도입 안 함).
+
+reason(AC④, 페드루 확定 — 추측 금지·서버가 아는 사실만): 'expired'(행 있고 expires_at 도과)·
+'revoked'(revoked_at 세팅)·'invalid'(해당 prefix 행 없음 — org 귀속 불가, org_id/member_id
+NULL). key_prefix만 저장(AC⑤ — 값 자체는 어떤 원장/로그/이벤트에도 안 남는다)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, Index, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class AgentAuthFailure(Base):
+    __tablename__ = "agent_auth_failure"
+    __table_args__ = (
+        CheckConstraint(
+            "reason IN ('expired', 'revoked', 'invalid')", name="ck_agent_auth_failure_reason",
+        ),
+        Index("ix_agent_auth_failure_org_member_occurred", "org_id", "member_id", "occurred_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # invalid(prefix 자체가 미상)는 어느 org 소속인지 원리적으로 모른다 — NULL이 정직한 값
+    # (다른 org의 attention에 새는 것보다 「이 org엔 안 뜬다」가 안전한 기본).
+    org_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    api_key_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True,
+    )
+    member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    key_prefix: Mapped[str] = mapped_column(Text, nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -23,12 +23,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db, get_read_db
 from app.models.activity_event import ActivityEvent
+from app.models.agent_auth_failure import AgentAuthFailure
 from app.models.agent_run import AgentRun
 from app.models.dependency import ItemDependency
 from app.models.hypothesis import Hypothesis
 from app.models.member import AgentProjectProfile, Member
 from app.models.pm import Goal, Story, StoryActivity, Task
 from app.models.workflow_line import WorkflowLineStepApproval, WorkflowLineStepRun
+from app.services.agent_auth_failure import AUTH_FAILURE_THRESHOLD, AUTH_FAILURE_WINDOW_MINUTES
 from app.services.member_resolver import resolve_member
 
 router = APIRouter(prefix="/api/v2/command-center", tags=["command-center", "Work"])
@@ -365,6 +367,35 @@ async def my_actions(
             "entity_type": r.entity_type, "entity_id": str(r.entity_id),
             "gate_type": r.effective_gate_type,
             "stuck_since": r.started_at.isoformat() if r.started_at else None,
+        })
+    # 1b) story #2836 — 에이전트 API키 401 연속(유나 6시간+ 침묵·미르코 revoke 실사고 근본원인).
+    # windowed COUNT(agent_stuck·story_stalled와 동형 관측 패턴 — 별도 상태기계 없음). invalid
+    # reason(org_id NULL)은 원리적으로 org 귀속 불가라 이 org의 attention엔 절대 안 뜬다(④ 정직성
+    # — 다른 org에 새는 것보다 안전한 기본, agent_auth_failure.py docstring 참고).
+    auth_failure_rows = (
+        await session.execute(
+            select(
+                AgentAuthFailure.member_id, AgentAuthFailure.reason,
+                func.count().label("cnt"),
+                func.min(AgentAuthFailure.occurred_at).label("first_at"),
+                func.max(AgentAuthFailure.occurred_at).label("last_at"),
+            )
+            .where(
+                AgentAuthFailure.org_id == org_id,
+                AgentAuthFailure.occurred_at >= now - timedelta(minutes=AUTH_FAILURE_WINDOW_MINUTES),
+            )
+            .group_by(AgentAuthFailure.member_id, AgentAuthFailure.reason)
+            .having(func.count() >= AUTH_FAILURE_THRESHOLD)
+        )
+    ).all()
+    for member_id, reason, cnt, first_at, last_at in auth_failure_rows:
+        attention_items.append({
+            "type": "agent_auth_failure", "severity": "danger", "auto_detected": True,
+            "member_id": str(member_id) if member_id else None,
+            "reason": reason,  # expired | revoked | invalid — 서버가 아는 사실만(④).
+            "failure_count": cnt,
+            "first_failed_at": first_at.isoformat() if first_at else None,
+            "last_failed_at": last_at.isoformat() if last_at else None,
         })
     # 2) CC-BE.2 스토리 N일 정체(org-visible 필드만).
     # story #2538(2026-08-09): title 추가 — FE ko.json "가설이 예상과 다르게 진행됩니다"

--- a/backend/app/services/agent_auth_failure.py
+++ b/backend/app/services/agent_auth_failure.py
@@ -1,0 +1,117 @@
+"""story #2836 — 에이전트 API키 401 인증실패를 기록하고, 임계 연속 회수 도달 시 presence
+표면(agent_status)에 반영한다.
+
+⑤(페드루 확定, 시크릿 규율): 원장·로그·이후 모든 신호 payload엔 key_prefix만 — raw_key
+값 자체는 이 모듈 밖으로 절대 안 나간다(에러 경로 포함, 아래 함수 바깥으로 raise하지 않음).
+
+⑥(상수로 시작, 근거는 PR 본문에): 유나·미르코 두 실사고 표본 모두 실측 cadence가 "1분 간격"
+이었다 — «연속 N회»가 그대로 «N분»이 되는 자연 단위. 5회(=약 5분)를 문지방으로 삼는다:
+1~2회는 순간 blip(네트워크 hiccup 등)일 수 있어 매회 신호화하면 소음이고, 5분은 실 사고
+(6시간+)에 비하면 훨씬 빠르면서도 사람이 "잠깐 그런가" 착각할 여유는 준다.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func, select
+
+logger = logging.getLogger(__name__)
+
+AUTH_FAILURE_WINDOW_MINUTES = 5
+AUTH_FAILURE_THRESHOLD = 5
+
+_KEY_PREFIX_LEN = 16  # "sk_live_" (8) + raw[:8] (8) — app/repositories/api_key.py::_generate_key와 동일 규약.
+
+
+def _derive_prefix(raw_key: str) -> str | None:
+    if not raw_key.startswith("sk_live_") or len(raw_key) < _KEY_PREFIX_LEN:
+        return None
+    return raw_key[:_KEY_PREFIX_LEN]
+
+
+async def _classify(session, prefix: str, now: datetime) -> tuple[str, uuid.UUID | None, uuid.UUID | None, uuid.UUID | None]:
+    """AC④ — 추측 금지, 서버가 아는 사실(행 상태)만으로 판별.
+
+    반환: (reason, org_id, api_key_id, member_id). invalid는 뒤 3개가 전부 None(귀속 불가)."""
+    from app.models.api_key import ApiKey
+    from app.models.team import TeamMember
+
+    row = (
+        await session.execute(
+            select(ApiKey.id, ApiKey.member_id, ApiKey.team_member_id, ApiKey.revoked_at, ApiKey.expires_at)
+            .where(ApiKey.key_prefix == prefix)
+            .limit(1)
+        )
+    ).first()
+    if row is None:
+        return "invalid", None, None, None
+
+    api_key_id, member_id, team_member_id, revoked_at, expires_at = row
+    org_id: uuid.UUID | None = None
+    if member_id is not None:
+        from app.models.member import Member
+
+        org_row = (
+            await session.execute(select(Member.org_id).where(Member.id == member_id))
+        ).scalar_one_or_none()
+        org_id = org_row
+    if org_id is None and team_member_id is not None:
+        org_row = (
+            await session.execute(
+                select(TeamMember.org_id).where(TeamMember.id == team_member_id)
+            )
+        ).scalar_one_or_none()
+        org_id = org_row
+
+    if revoked_at is not None:
+        return "revoked", org_id, api_key_id, member_id
+    if expires_at is not None and expires_at <= now:
+        return "expired", org_id, api_key_id, member_id
+    # prefix는 매치했는데 revoked도 expired도 아님 — key_hash 불일치(오타/prefix 우연충돌) 등
+    # 원인을 더 좁힐 근거가 없다. 추측 대신 정직하게 invalid로 떨어뜨린다(④ 정신 그대로).
+    return "invalid", None, None, None
+
+
+async def record_auth_failure(raw_key: str) -> None:
+    """`_resolve_api_key`의 401 직전에서 호출(auth.py) — 자기 세션을 열어 caller 트랜잭션과
+    분리 커밋한다(`_touch_api_key_last_used`와 동일 이유: caller는 401로 곧 예외/rollback,
+    이 기록은 그와 무관하게 반드시 남아야 한다). 실패해도 401 응답 자체는 절대 막지 않는다."""
+    prefix = _derive_prefix(raw_key)
+    if prefix is None:
+        return  # 형식 자체가 우리 키가 아님(외부 스캐너 등) — 원장 대상 밖.
+
+    try:
+        from app.core.database import async_session_factory
+        from app.models.agent_auth_failure import AgentAuthFailure
+
+        now = datetime.now(timezone.utc)
+        async with async_session_factory() as s:
+            reason, org_id, api_key_id, member_id = await _classify(s, prefix, now)
+            s.add(AgentAuthFailure(
+                id=uuid.uuid4(), org_id=org_id, api_key_id=api_key_id, member_id=member_id,
+                key_prefix=prefix, reason=reason,
+            ))
+
+            if member_id is not None:
+                since = now - timedelta(minutes=AUTH_FAILURE_WINDOW_MINUTES)
+                cnt = (
+                    await s.execute(
+                        select(func.count()).select_from(AgentAuthFailure).where(
+                            AgentAuthFailure.member_id == member_id,
+                            AgentAuthFailure.occurred_at >= since,
+                        )
+                    )
+                ).scalar_one()
+                # AsyncSession 기본 autoflush=True — 위 add()가 이 execute() 前에 이미 flush돼
+                # cnt에 방금 이번 행까지 포함돼 있다(별도 +1 불요 — 처음엔 그렇게 짰다가 realdb
+                # 테스트가 임계 1회 조기발화를 잡아냈다).
+                if cnt >= AUTH_FAILURE_THRESHOLD:
+                    from app.services.agent_anchor_sync import sync_agent_profile_presence
+
+                    await sync_agent_profile_presence(s, member_id, agent_status="auth_failed")
+
+            await s.commit()
+    except Exception:
+        logger.warning("record_auth_failure failed(무해 — 401 응답엔 무영향)", exc_info=True)

--- a/backend/tests/test_2836_agent_auth_failure_realdb.py
+++ b/backend/tests/test_2836_agent_auth_failure_realdb.py
@@ -1,0 +1,296 @@
+"""story #2836([결함·관측], 실사고 — 유나 세션 6시간+ 침묵·미르코 revoke 사례) — 에이전트 API키
+401 인증실패 원장 실PG 검증.
+
+AC④(원인 판별, 추측 금지): expired=행 있고 expires_at 도과·revoked=revoked_at 세팅·invalid=
+해당 prefix 행 없음. AC⑤(시크릿 규율): key_prefix만 저장, raw 값은 절대 안 남는다(모델 자체가
+그 컬럼을 안 가짐 — 구조적 보장). AC①/⑥(임계): AUTH_FAILURE_THRESHOLD회 도달 전엔 presence
+무변화, 도달 순간에만 agent_status="auth_failed"로 갱신(매 실패마다 덮어쓰지 않음).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_agent_key(session, *, revoked=False, expired=False):
+    """정확히 app/repositories/api_key.py::_generate_key와 동일 규약으로 raw_key/prefix/hash를
+    만든다(발명 0 — 실 발급 경로와 다른 규약을 테스트가 쓰면 그 자체가 거짓 초록)."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.repositories.api_key import _generate_key
+    from app.models.api_key import ApiKey
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    member = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent", is_active=True)
+    session.add(member)
+    await session.commit()
+    # 0075 1:1 anchor(member.id == team_member.id) — ApiKey.team_member_id FK 충족용.
+    session.add(TeamMember(id=member.id, org_id=org.id, project_id=project.id, type="agent", name="Agent"))
+    await session.commit()
+
+    plaintext, prefix, key_hash = _generate_key()
+    now = datetime.now(timezone.utc)
+    key = ApiKey(
+        id=uuid.uuid4(), team_member_id=member.id, member_id=member.id,
+        key_prefix=prefix, key_hash=key_hash,
+        revoked_at=now if revoked else None,
+        expires_at=(now - timedelta(days=1)) if expired else None,
+    )
+    session.add(key)
+    await session.commit()
+    return {
+        "org_id": org.id, "project_id": project.id, "member_id": member.id,
+        "raw_key": plaintext, "prefix": prefix,
+    }
+
+
+async def _failures_for(session, member_id=None):
+    from sqlalchemy import select
+
+    from app.models.agent_auth_failure import AgentAuthFailure
+
+    q = select(AgentAuthFailure)
+    if member_id is not None:
+        q = q.where(AgentAuthFailure.member_id == member_id)
+    return (await session.execute(q)).scalars().all()
+
+
+@pytest.mark.anyio
+async def test_invalid_key_records_reason_invalid_no_org_attribution():
+    from app.services.agent_auth_failure import record_auth_failure
+
+    engine, Session = await _session_factory()
+    try:
+        import app.core.database as _dbmod
+        _orig = _dbmod.async_session_factory
+        _dbmod.async_session_factory = Session
+        try:
+            await record_auth_failure("sk_live_" + "a" * 64)  # 실존하지 않는 키.
+        finally:
+            _dbmod.async_session_factory = _orig
+
+        async with Session() as s:
+            rows = await _failures_for(s)
+            assert len(rows) == 1
+            assert rows[0].reason == "invalid"
+            assert rows[0].org_id is None
+            assert rows[0].api_key_id is None
+            assert rows[0].member_id is None
+            assert rows[0].key_prefix == "sk_live_" + "a" * 8
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_api_key_401_path_actually_records_failure():
+    """엔드투엔드 배선 확認 — `record_auth_failure`를 직접 부르는 게 아니라 auth.py의 실 401
+    경로(`_resolve_api_key`)가 그걸 호출하는지 증명(단위 테스트만으론 배선 누락을 못 잡는다)."""
+    from app.dependencies.auth import _resolve_api_key
+    from fastapi import HTTPException
+
+    engine, Session = await _session_factory()
+    try:
+        import app.core.database as _dbmod
+        _orig = _dbmod.async_session_factory
+        _dbmod.async_session_factory = Session
+        try:
+            async with Session() as s:
+                with pytest.raises(HTTPException) as exc_info:
+                    await _resolve_api_key("sk_live_" + "b" * 64, s)
+                assert exc_info.value.status_code == 401
+        finally:
+            _dbmod.async_session_factory = _orig
+
+        async with Session() as s:
+            rows = await _failures_for(s)
+            assert len(rows) == 1
+            assert rows[0].reason == "invalid"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_expired_key_records_reason_expired_with_attribution():
+    from app.services.agent_auth_failure import record_auth_failure
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_key(s, expired=True)
+
+        import app.core.database as _dbmod
+        _orig = _dbmod.async_session_factory
+        _dbmod.async_session_factory = Session
+        try:
+            await record_auth_failure(seeded["raw_key"])
+        finally:
+            _dbmod.async_session_factory = _orig
+
+        async with Session() as s:
+            rows = await _failures_for(s, seeded["member_id"])
+            assert len(rows) == 1
+            assert rows[0].reason == "expired"
+            assert rows[0].org_id == seeded["org_id"]
+            assert rows[0].key_prefix == seeded["prefix"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_revoked_key_records_reason_revoked():
+    from app.services.agent_auth_failure import record_auth_failure
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_key(s, revoked=True)
+
+        import app.core.database as _dbmod
+        _orig = _dbmod.async_session_factory
+        _dbmod.async_session_factory = Session
+        try:
+            await record_auth_failure(seeded["raw_key"])
+        finally:
+            _dbmod.async_session_factory = _orig
+
+        async with Session() as s:
+            rows = await _failures_for(s, seeded["member_id"])
+            assert len(rows) == 1
+            assert rows[0].reason == "revoked"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_revoked_and_expired_both_true_revoked_wins():
+    """설계 결정 고정 — 둘 다 참이면 revoked(더 의도적인 상태)가 우선."""
+    from app.services.agent_auth_failure import record_auth_failure
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_key(s, revoked=True, expired=True)
+
+        import app.core.database as _dbmod
+        _orig = _dbmod.async_session_factory
+        _dbmod.async_session_factory = Session
+        try:
+            await record_auth_failure(seeded["raw_key"])
+        finally:
+            _dbmod.async_session_factory = _orig
+
+        async with Session() as s:
+            rows = await _failures_for(s, seeded["member_id"])
+            assert rows[0].reason == "revoked"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_malformed_key_is_skipped_no_row():
+    """⑤ 부속 — 우리 키 형식조차 아니면(prefix 못 뽑음) 원장 대상 밖(외부 스캐너 소음 방지)."""
+    from app.services.agent_auth_failure import record_auth_failure
+
+    engine, Session = await _session_factory()
+    try:
+        import app.core.database as _dbmod
+        _orig = _dbmod.async_session_factory
+        _dbmod.async_session_factory = Session
+        try:
+            await record_auth_failure("not-even-close-to-a-key")
+        finally:
+            _dbmod.async_session_factory = _orig
+
+        async with Session() as s:
+            assert await _failures_for(s) == []
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_threshold_crossing_sets_agent_status_not_before():
+    """AC①/⑥ — 임계(AUTH_FAILURE_THRESHOLD) 미만은 presence 무변화, 도달 순간에만 auth_failed."""
+    from app.models.member import AgentProjectProfile
+    from app.services.agent_auth_failure import AUTH_FAILURE_THRESHOLD, record_auth_failure
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_key(s, revoked=True)
+            s.add(AgentProjectProfile(
+                id=uuid.uuid4(), member_id=seeded["member_id"], project_id=seeded["project_id"],
+                agent_status="online",
+            ))
+            await s.commit()
+
+        import app.core.database as _dbmod
+        _orig = _dbmod.async_session_factory
+        _dbmod.async_session_factory = Session
+        try:
+            for _ in range(AUTH_FAILURE_THRESHOLD - 1):
+                await record_auth_failure(seeded["raw_key"])
+
+            async with Session() as s:
+                from sqlalchemy import select
+                prof = (await s.execute(
+                    select(AgentProjectProfile).where(AgentProjectProfile.member_id == seeded["member_id"])
+                )).scalar_one()
+                assert prof.agent_status == "online", "임계 미달 — presence 그대로여야 함"
+
+            await record_auth_failure(seeded["raw_key"])  # 정확히 임계 도달.
+
+            async with Session() as s:
+                from sqlalchemy import select
+                prof = (await s.execute(
+                    select(AgentProjectProfile).where(AgentProjectProfile.member_id == seeded["member_id"])
+                )).scalar_one()
+                assert prof.agent_status == "auth_failed"
+        finally:
+            _dbmod.async_session_factory = _orig
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -97,7 +97,7 @@ def _ma_seq(
     my_tasks=(), approval_group_counts=(), blocker_weight_counts=(), falsified=(),
     overdue_hyps=(), overdue_goals=(), done_no_outcome_goals=(), measure_plan_missing_goal_count=0,
     loop_overdue_hypothesis_count=None, loop_overdue_goal_count=None, loop_outcome_missing_goal_count=None,
-    unmeasurable_goal_count=0, project_slugs=(),
+    unmeasurable_goal_count=0, project_slugs=(), auth_failures=(),
 ):
     seq = [_r_all(approvals)]
     if approvals:
@@ -109,6 +109,8 @@ def _ma_seq(
         seq.append(_r_all(blocker_weight_counts))
     seq.append(_r_all(waiting))
     seq.append(_r_scalars(stuck))
+    # story #2836 — 에이전트 401 연속 windowed-COUNT(agent_stuck 바로 뒤·stalled 前).
+    seq.append(_r_all(auth_failures))
     seq.append(_r_all(stalled))
     seq.append(_r_all(unanswered))
     seq.append(_r_all(falsified))  # story #2539
@@ -361,6 +363,24 @@ async def test_my_actions_loop_closure_items_and_measure_plan_missing_count():
     assert body["attention"]["loop_overdue_hypothesis_count"] == 1
     assert body["attention"]["loop_overdue_goal_count"] == 1
     assert body["attention"]["unmeasurable_goal_count"] == 7
+
+
+@pytest.mark.anyio
+async def test_my_actions_agent_auth_failure_item_shape():
+    """story #2836 — 임계 도달한 에이전트 401 연속이 attention.items[]에 실린다. reason은
+    서버가 아는 사실(④)만 — raw key 값은 이 응답 어디에도 없다(⑤, key_prefix조차 이 엔드포인트
+    응답엔 안 실림 — command_center.py는 member_id/reason/count/시각만 노출)."""
+    member_id = uuid.uuid4()
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(auth_failures=[(member_id, "revoked", 5, _OLD, _DT)]))
+    assert resp.status_code == 200
+    items = _data(resp)["attention"]["items"]
+    af = next(i for i in items if i["type"] == "agent_auth_failure")
+    assert af["member_id"] == str(member_id)
+    assert af["reason"] == "revoked"
+    assert af["failure_count"] == 5
+    assert af["severity"] == "danger" and af["auto_detected"] is True
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- story #2836([결함·관측], high): 유나 세션 6시간+ 침묵(키 만료)·미르코 세션 revoke 실사고 — 서버가 `/api/v2/agent/stream` 401을 1분 간격으로 계속 관측하면서도 어떤 표면에도 신호를 안 내던 것 처방.
- 락된 AC 7항(①~⑦, 페드루) 전부 반영.

## AC 반영
- **①** `agent_auth_failure` 원장(append-only, 매 401 1행) 신설 — 「연속 N회」는 별도 카운터/서킷브레이커 없이 이 원장을 windowed COUNT로 읽어 판정(`agent_stuck`/`story_stalled`와 동형 command_center.py 관측 패턴 재사용, 발명 0).
- **②** 임계 도달 시 기존 `agent_status` 표면에 `"auth_failed"`로 반영(claim/assignee가 이미 쓰는 `sync_agent_profile_presence` 재사용) + `my_actions` `attention.items[]`에 `agent_auth_failure` 타입 신설(신규 표면 발명 0).
- **③** `heartbeat_freshness`(#2602, 유효 키·죽은 프로세스 축)는 명시 스코프 밖 — 링크만, 재구현 안 함.
- **④** 원인은 추측 금지, 서버가 아는 사실로만 판별: `expired`(행 있고 `expires_at` 도과) · `revoked`(`revoked_at` 세팅) · `invalid`(해당 prefix 행 없음 — org 귀속 불가, `org_id`/`member_id` NULL).
- **⑤** raw key 값은 어떤 원장/로그/신호에도 안 남는다 — `key_prefix`만 저장(모델 자체가 그 컬럼을 안 가짐, 구조적 보장). 에러 경로 포함 raw_key가 함수 밖으로 안 나간다.
- **⑥** 임계값·윈도는 상수로 시작(`AUTH_FAILURE_THRESHOLD=5`, `AUTH_FAILURE_WINDOW_MINUTES=5`) — 근거: 유나·미르코 두 실사고 모두 실측 cadence가 정확히 "1분 간격"이라 「연속 N회」가 그대로 「N분」이 되는 자연 단위. 1~2회는 순간 blip일 수 있어 매회 신호화하면 소음, 5분은 실사고(6시간+)보다 훨씬 빠르면서도 오탐 여유를 준다.
- **⑦** 이 PR은 BE(원장+판별+임계+presence 반영+attention 타입 정의)까지 — attention 클러스터 노출(FE)은 미르코군 몫, 별도 스토리.

## Test plan
- [x] `test_2836_agent_auth_failure_realdb.py`(신규 7건): invalid/expired/revoked/revoked+expired(revoked 우선 고정)/malformed-key skip/임계 미달-도달 presence 전이/`_resolve_api_key` 401 경로 실배선 확認(단순 서비스함수 호출이 아니라 auth.py의 실 401 경로가 record_auth_failure를 실제로 부르는지 end-to-end).
- [x] `test_command_center.py`(신규 1건, 기존 22건 무회귀): `_ma_seq`에 `auth_failures` 시퀀스 슬롯 추가(agent_stuck 직후·stalled 前 — command_center.py 실 쿼리 순서 그대로).
- [x] load-bearing: auth.py 배선/command_center.py 배선 각각 `git apply -R`로 되돌려 신규 wiring 테스트 2건 정확히 기대대로 FAIL(auth 배선 제거 시 401 경로 원장기록 0건, cc 배선 제거 시 mock 시퀀스 밀림 크래시) → 복원 후 재확인 green.
- [x] alembic 0265→0266 신선 로컬 PG 클린 적용.
- [x] 각 realdb 파일 개별 실행(destructive-schema 관례) — `test_2836...`(7)·`test_command_center.py`(23, mock)·`test_2295_readiness_api_key_signal.py`(12)·`test_1940_human_api_keys.py` 전부 fresh migrated DB에서 green(off-by-one 버그 1건을 이 과정에서 실제로 잡아 수정 — AsyncSession autoflush로 COUNT에 방금 add()한 행이 이미 포함되는데 +1을 중복해 임계 1회 조기발화하던 것).

## 못 잡는 것
- `invalid`(prefix 자체가 미상)는 원리적으로 org 귀속이 불가해 이 org의 attention에 안 뜬다 — 다른 org로 새는 것보다 안전한 기본값으로 의도한 것.
- 원장은 append-only라 무기한 성장(정상 동작 시 0행이지만, 방치된 죽은 키는 계속 쌓임) — retention/정리는 이 스토리 스코프 밖, 필요 시 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SID:2836]