### PR TITLE
fix(#2839): 휴먼 개인 API키 침묵 90일 각인 제거 (2838 사람 키 판)

### DIFF
--- a/backend/app/repositories/human_api_key.py
+++ b/backend/app/repositories/human_api_key.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import secrets
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -45,11 +45,13 @@ class HumanApiKeyRepository:
         self,
         member_id: uuid.UUID,
         name: str | None = None,
-        expires_at: datetime | None = None,
+        *,
+        expires_at: datetime | None,
     ) -> tuple[HumanApiKey, str]:
+        """story #2839(#2838 사람 키 판, PO 확定 패턴 그대로 이식) — 침묵 90일 각인 제거.
+        기본값 없는 필수 kwarg: 호출자가 무만료(None)를 명시적으로 골라야만 무만료가 된다 —
+        "호출자가 안 골랐다"와 "명시적으로 무만료를 골랐다"가 둘 다 None으로 뭉개지던 근본원인."""
         plaintext, prefix, key_hash = _generate_key()
-        if expires_at is None:
-            expires_at = datetime.now(timezone.utc) + timedelta(days=90)
         key = HumanApiKey(
             member_id=member_id,
             name=name,

--- a/backend/app/schemas/human_api_key.py
+++ b/backend/app/schemas/human_api_key.py
@@ -25,4 +25,6 @@ class HumanApiKeyCreatedResponse(HumanApiKeyResponse):
 
 class CreateHumanApiKeyRequest(BaseModel):
     name: str | None = None
-    expires_at: datetime | None = None
+    # story #2839(#2838 사람 키 판) — 기본값 없음(필수 필드). null은 여전히 유효(명시적
+    # 무만료), "필드 자체를 안 보냄"만 422 — 침묵 90일 각인 경로를 구조로 차단.
+    expires_at: datetime | None

--- a/backend/tests/test_1940_human_api_keys.py
+++ b/backend/tests/test_1940_human_api_keys.py
@@ -96,7 +96,7 @@ async def test_repo_create_list_revoke_roundtrip():
             member_id = await _seed_human_member(s, org_id, user_id)
 
             repo = HumanApiKeyRepository(s)
-            key, plaintext = await repo.create(member_id=member_id, name="laptop")
+            key, plaintext = await repo.create(member_id=member_id, name="laptop", expires_at=None)
             await s.commit()
             assert plaintext.startswith("hu_live_")
             assert key.key_prefix.startswith("hu_live_")
@@ -108,6 +108,66 @@ async def test_repo_create_list_revoke_roundtrip():
             revoked = await repo.revoke(key.id)
             await s.commit()
             assert revoked.revoked_at is not None
+    finally:
+        await engine.dispose()
+
+
+# ─── story #2839(#2838 사람 키 판) — 침묵 90일 각인 회귀가드 ──────────────────────
+
+
+def test_create_request_schema_requires_expires_at_field():
+    """expires_at 필드 자체가 요청에 없으면 422급(pydantic ValidationError) — null은 여전히
+    유효한 값(명시적 무만료), «필드 생략»만 거절한다."""
+    import pydantic
+    from app.schemas.human_api_key import CreateHumanApiKeyRequest
+
+    with pytest.raises(pydantic.ValidationError):
+        CreateHumanApiKeyRequest(name="laptop")  # expires_at 누락.
+
+    # null은 여전히 valid(명시적 무만료) — 위와 대조.
+    req = CreateHumanApiKeyRequest(name="laptop", expires_at=None)
+    assert req.expires_at is None
+
+
+@pytest.mark.anyio
+async def test_repo_create_requires_expires_at_kwarg():
+    """repo 층도 동형 — expires_at 없이 호출하면 TypeError(호출부가 반드시 의도를 명시)."""
+    from app.repositories.human_api_key import HumanApiKeyRepository
+
+    repo = HumanApiKeyRepository(session=None)  # 호출 자체가 TypeError로 죽어야 하니 세션 불요.
+    with pytest.raises(TypeError):
+        await repo.create(member_id=uuid.uuid4())  # type: ignore[call-arg]
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_repo_create_no_more_silent_90_day_default_realdb():
+    """회귀가드 핵심 — expires_at=None을 명시하면 실제로 NULL(무만료)로 저장된다. 예전엔
+    repo 층이 몰래 now+90일을 각인했다(이 스토리의 근본 결함)."""
+    from app.repositories.human_api_key import HumanApiKeyRepository
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_user(s)
+            member_id = await _seed_human_member(s, org_id, user_id)
+
+            repo = HumanApiKeyRepository(s)
+            key, _plaintext = await repo.create(member_id=member_id, expires_at=None)
+            await s.commit()
+            assert key.expires_at is None
+
+        # DB 재조회로 persist 자체를 확認(세션 캐시값이 아닌 실 저장값).
+        async with Session() as s2:
+            from sqlalchemy import select
+
+            from app.models.human_api_key import HumanApiKey
+
+            reread = (await s2.execute(
+                select(HumanApiKey.expires_at).where(HumanApiKey.id == key.id)
+            )).scalar_one()
+            assert reread is None
     finally:
         await engine.dispose()
 
@@ -129,7 +189,7 @@ async def test_resolve_human_api_key_returns_jwt_shaped_context_no_api_key_id_cl
             user_id = await _seed_user(s)
             member_id = await _seed_human_member(s, org_id, user_id)
             repo = HumanApiKeyRepository(s)
-            _key, plaintext = await repo.create(member_id=member_id)
+            _key, plaintext = await repo.create(member_id=member_id, expires_at=None)
             await s.commit()
 
         async with Session() as s2:
@@ -160,7 +220,7 @@ async def test_resolve_human_api_key_rejects_revoked():
             user_id = await _seed_user(s)
             member_id = await _seed_human_member(s, org_id, user_id)
             repo = HumanApiKeyRepository(s)
-            key, plaintext = await repo.create(member_id=member_id)
+            key, plaintext = await repo.create(member_id=member_id, expires_at=None)
             await repo.revoke(key.id)
             await s.commit()
 
@@ -216,7 +276,7 @@ async def test_resolve_human_api_key_reverifies_member_still_human_fail_closed()
             user_id = await _seed_user(s)
             member_id = await _seed_human_member(s, org_id, user_id)
             repo = HumanApiKeyRepository(s)
-            _key, plaintext = await repo.create(member_id=member_id)
+            _key, plaintext = await repo.create(member_id=member_id, expires_at=None)
             await s.commit()
 
             # 전환 시나리오 대리: 그사이 member.type이 바뀌었다고 가정(직접 UPDATE)
@@ -253,7 +313,7 @@ async def test_human_key_via_agent_header_does_not_authenticate():
             user_id = await _seed_user(s)
             member_id = await _seed_human_member(s, org_id, user_id)
             repo = HumanApiKeyRepository(s)
-            _key, plaintext = await repo.create(member_id=member_id)
+            _key, plaintext = await repo.create(member_id=member_id, expires_at=None)
             await s.commit()
 
         with pytest.raises(HTTPException) as ei:
@@ -321,7 +381,7 @@ async def test_router_create_list_revoke_self_serve():
             auth = _human_auth(user_id, org_id)
 
             created = await create_my_api_key(
-                CreateHumanApiKeyRequest(name="my key"), session=s, auth=auth,
+                CreateHumanApiKeyRequest(name="my key", expires_at=None), session=s, auth=auth,
             )
             assert created.api_key.startswith("hu_live_")
 
@@ -351,7 +411,7 @@ async def test_router_cannot_revoke_other_humans_key():
             await _seed_human_member(s, org_id, owner_user_id, name="Owner")
             owner_auth = _human_auth(owner_user_id, org_id)
             created = await create_my_api_key(
-                CreateHumanApiKeyRequest(), session=s, auth=owner_auth,
+                CreateHumanApiKeyRequest(expires_at=None), session=s, auth=owner_auth,
             )
 
             intruder_user_id = await _seed_user(s, email="intruder1940@example.com")


### PR DESCRIPTION
[SID:2839]

## Summary
- story #2839(#2838의 사람 키 판) — `human_api_key.py::create()`가 agent 키와 동일한 침묵 90일 각인 결함을 갖고 있었다(#2838 그라운딩 중 부수 발견).
- "호출자가 expires_at을 안 보냄"과 "명시적 무만료"가 둘 다 `None`으로 뭉개지던 근본원인 — #2838 확定 패턴 그대로 이식.

## 그라운딩(스코프가 예상보다 작음)
- 숨은 내부 발급 호출부 0개 — 셀프서브 라우터 `POST /api/v2/me/api-keys`(`create_my_api_key`) 단 하나가 `HumanApiKeyRepository.create()`의 유일한 호출부.
- "rotate" 개념이 human 키엔 아예 없다(`/api-keys/rotate`는 별개 테이블인 agent 키 전용 — `ApiKeyRepository`, #2838에서 이미 처방됨). 스토리 초안의 "rotate도 90일 재각인" 서술은 부정확한 추정이었음(정정).
- FE 발급 표면 자체가 없음(이 self-serve 키는 MCP 셀프서브 전용, 브라우저 UI 미구현) — #2838의 만료-선택 UI 확장 대상이 없어 이 PR은 BE 계약만.

## AC
- `HumanApiKeyRepository.create()`: `expires_at: datetime | None`을 기본값 없는 keyword-only 필수 인자로 변경.
- `CreateHumanApiKeyRequest.expires_at`: 기본값 제거(필드 자체 필수, `null` 값은 여전히 유효 — 명시적 무만료).

## Test plan
- [x] `test_1940_human_api_keys.py`(신규 3건, 기존 9건은 `expires_at=None` 명시로 업데이트) — 스키마 필드 필수화(pydantic ValidationError)·repo kwarg 필수화(TypeError)·실PG 재조회로 침묵 90일 각인 소멸 확認(회귀가드 핵심).
- [x] load-bearing: 프로덕션 diff `git apply -R` 후 신규 3건 정확히 기대대로 FAIL(3번째 테스트는 실제 옛 버그 그대로 재현 — expires_at=None인데 now+90일이 찍힘) → 복원 후 재확인 12/12 green.
- [x] `import app.main` 전체 임포트 체크 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 경계 밖 확認(PO 실측, 2026-08-20) — 활성 호출자 0
POST /me/api-keys 계약을 breaking(expires_at 필수화)하기 전에 이 엔드포인트의 실 호출자
(sprintable MCP 클라이언트, 별도 레포/PyPI 패키지)가 새 계약을 준수하는지 확認 필요했다 —
디디는 이 레포/머신 접근권 밖이라 단정 못 함으로 보고, PO가 자기 레인에서 확認:
①dev 백엔드 로그 14일치 — POST /me/api-keys 실호출 1건뿐(08-16 POST 201→DELETE 200 왕복,
검증성 호출 모양) ②prod 0건 ③moonklabs org에 별도 MCP 레포 없음 — vendored 사본(이 레포
sprintable_mcp/)이 곧 소스이고 그쪽 grep도 0건. 즉 이 계약 변경 시점에 활성 호출자가 없어
배포 즉시 422를 맞을 대상이 실측상 없고, 미래 호출자는 처음부터 새(필수 명시) 계약을 본다.
