### PR TITLE
test(#2837): 흩어진 SimpleNamespace gate mock을 공용 make_gate() 팩토리로

### DIFF
--- a/backend/tests/gate_mock_factory.py
+++ b/backend/tests/gate_mock_factory.py
@@ -1,0 +1,64 @@
+"""story #2837(설계 락, 페드루 확定) — 흩어진 SimpleNamespace(Gate형) mock을 공용 팩토리로.
+
+오늘 하루 2회 실사고(#3256: github_check_run_sha 누락·#3260: neutral_facts 누락) — 각 테스트가
+그 시점 필요하다 생각한 필드만 SimpleNamespace에 손으로 채워 넣다 보니, Gate에 새 필드가 늘
+때마다 여기저기서 AttributeError가 재발했다.
+
+처방(②, PO 판정 — ①의 defaults-dict 수동유지안보다 근본적): SimpleNamespace 대신 진짜 `Gate`
+ORM 인스턴스를 mock으로 쓴다. 세션에 붙지 않은 순수 Python 객체라 실 DB 왕복은 없다(테스트
+안전) — 그러면서도 같은 클래스이므로 Gate에 필드가 늘어도 이 팩토리가 스키마에서 구조적으로
+못 벗어난다(발산 원천 차단, defaults dict를 손으로 따라가야 하는 ①과의 핵심 차이).
+
+⚠️detached 함정(⑤, 페드루): 컬럼 속성은 세션 밖에서도 안전하게 None으로 읽힌다(SimpleNamespace
+와 달리 AttributeError 없음) — 그러나 **relationship 속성**(현재 Gate엔 없지만 앞으로 생기면)은
+세션이 없으면 접근 시 DetachedInstanceError로 죽는다. 이 팩토리는 컬럼만 커버한다 — relationship
+속성이 필요한 테스트는 각자 명시적으로 세팅할 것(mock/patch로 얹거나 별도 처리).
+
+이관 범위(③, 페드루): 오늘 2회 이상 깨진 3파일(test_gate_can_approve_48f064e5.py·
+test_gate_transition_human_only.py·test_rc1_body_trust_actor.py)만 우선 이관했다. 나머지
+19개 파일의 기존 SimpleNamespace(Gate형) mock은 그대로 둔다 — **"건드릴 때 이관"**이 관례다:
+이미 있는 파일을 굳이 먼저 손대지 않되, 새로 그 파일을 고칠 일이 생기면 그 김에 이 팩토리로
+옮긴다(전수 스윕은 22파일 규모라 priority=low 대비 비용 과대라는 게 PO 판단). 이 규율을 다음
+사람이 다시 고민하지 않도록 여기 명문화해 둔다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from app.models.gate import Gate
+
+
+def make_gate(**overrides) -> Gate:
+    """실 Gate 필드셋(app/models/gate.py) 그대로 기본값 채움 — 필요한 필드만 override.
+
+    `default=`/`server_default=` 컬럼(id/status/requires_human/created_at/updated_at)은
+    세션에 안 붙은 채로는 SQLAlchemy가 자동으로 안 채워주므로(그건 INSERT 시점 동작) 여기서
+    직접 값을 준다 — 안 그러면 예전 SimpleNamespace보다 나을 게 없다(None으로 채워진 id 등)."""
+    now = datetime.now(timezone.utc)
+    defaults: dict = dict(
+        id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        work_item_id=uuid.uuid4(),
+        work_item_type="story",
+        gate_type="merge",
+        status="pending",
+        resolver_id=None,
+        resolved_at=None,
+        resolution_note=None,
+        held_until=None,
+        neutral_facts=None,
+        requires_human=False,
+        evidence_status=None,
+        decision_basis=None,
+        auto_decision_reason=None,
+        status_entered_at=None,
+        evidence_status_entered_at=None,
+        github_check_run_id=None,
+        github_check_run_sha=None,
+        approved_head_sha=None,
+        created_at=now,
+        updated_at=now,
+    )
+    defaults.update(overrides)
+    return Gate(**defaults)

--- a/backend/tests/test_gate_can_approve_48f064e5.py
+++ b/backend/tests/test_gate_can_approve_48f064e5.py
@@ -21,6 +21,7 @@ from app.routers.gates import (
     transition_gate_endpoint,
 )
 from app.services.member_resolver import ResolvedMember
+from tests.gate_mock_factory import make_gate
 
 
 @pytest.fixture
@@ -41,7 +42,7 @@ def _result(obj):
 
 
 def _doc_gate(requester_id: uuid.UUID):
-    return SimpleNamespace(
+    return make_gate(
         gate_type="doc_approval",
         neutral_facts={"requested_by_member_id": str(requester_id)},
         work_item_id=uuid.uuid4(),
@@ -59,7 +60,7 @@ async def _call(resolved, *, execute_results, has_access=None, status="approved"
     # 이 테스트에서 실행 안 됨 — BackgroundTasks().add_task 는 큐잉만). gate_type을 "merge"가 아닌
     # 값으로 둬 anchor 기록 분기(resolve_pr_link 추가 조회)를 건너뛴다 — 이 파일의 관심사(doc-gate
     # authz)와 무관.
-    transition = AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4(), gate_type="merge_approval", neutral_facts=None))
+    transition = AsyncMock(return_value=make_gate(gate_type="merge_approval", neutral_facts=None))
     auth = SimpleNamespace(user_id=str(uuid.uuid4()))
     patches = [
         patch.object(gates_mod, "resolve_member", AsyncMock(return_value=resolved)),
@@ -106,7 +107,7 @@ async def test_doc_gate_self_approval_forbidden():
 # ── ①' fail-closed: 상신자 미기록(None) → 403 (silent self-approval 우회 방지·산티아고/PO 플래그) ──
 @pytest.mark.anyio
 async def test_doc_gate_missing_requester_fail_closed():
-    gate = SimpleNamespace(gate_type="doc_approval", neutral_facts={}, work_item_id=uuid.uuid4())
+    gate = make_gate(gate_type="doc_approval", neutral_facts={}, work_item_id=uuid.uuid4())
     transition = AsyncMock()
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[_result(gate)])
@@ -214,7 +215,7 @@ async def test_non_doc_gate_skips_doc_authz():
     # 명시(누락 시 AttributeError) — 이 테스트의 관심사는 "doc authz 분기를 안 타는가"이지 rule B
     # 자체의 project-role 판정이 아니므로 _non_doc_gate_approvable 을 직접 patch 해 True 로 고정
     # (그 판정 자체는 test_1974_gate_assigned_to_me.py/test_2198_*_realdb.py 가 커버).
-    merge_gate = SimpleNamespace(
+    merge_gate = make_gate(
         gate_type="merge_approval", neutral_facts={}, work_item_id=uuid.uuid4(),
         work_item_type="story",
     )

--- a/backend/tests/test_gate_transition_human_only.py
+++ b/backend/tests/test_gate_transition_human_only.py
@@ -16,6 +16,7 @@ from fastapi import BackgroundTasks, HTTPException
 from app.routers import gates as gates_mod
 from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
 from app.services.member_resolver import ResolvedMember
+from tests.gate_mock_factory import make_gate
 
 
 @pytest.fixture
@@ -44,7 +45,7 @@ async def _call(status: str, member_type: str):
     # (_non_doc_gate_approvable) 은 아래에서 직접 patch 해 True 로 고정(그 판정 자체는 이 파일의
     # 관심사가 아님 — project-role 축은 test_2198_*_realdb.py 가 별도로 커버).
     _gr = MagicMock()
-    _gr.scalar_one_or_none.return_value = SimpleNamespace(
+    _gr.scalar_one_or_none.return_value = make_gate(
         gate_type="merge_approval", work_item_type="story", work_item_id=uuid.uuid4(),
     )
     session.execute = AsyncMock(return_value=_gr)
@@ -53,7 +54,7 @@ async def _call(status: str, member_type: str):
     # 이 테스트에서 실행 안 됨 — BackgroundTasks().add_task 는 큐잉만). gate_type을 "merge"가 아닌
     # 값으로 둬 anchor 기록 분기(resolve_pr_link 추가 조회)를 건너뛴다 — 이 파일의 관심사(human-vs-
     # agent authz)와 무관.
-    transition = AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4(), gate_type="merge_approval", neutral_facts=None))
+    transition = AsyncMock(return_value=make_gate(gate_type="merge_approval", neutral_facts=None))
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved(member_type))), \
          patch.object(gates_mod, "transition_gate", transition), \
          patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)), \

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -14,6 +14,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.gate_mock_factory import make_gate
+
 
 def _non_doc_gate_session():
     """48f064e5: 엔드포인트가 doc-gate authz용 게이트 로드 → 비-doc 게이트 반환으로 그 분기 skip.
@@ -22,6 +24,10 @@ def _non_doc_gate_session():
     _non_doc_gate_approvable 을 별도로 patch 해 그 판정 자체를 우회한다."""
     s = AsyncMock()
     gr = MagicMock()
+    # story #2837 — 여긴 make_gate()로 안 옮긴다: session.execute가 단일 고정 return_value라
+    # 이 한 mock이 Gate SELECT뿐 아니라 뒤이은 PullRequestStoryLink SELECT까지 대신 받는다
+    # (아래 evidence는 Gate 필드가 아니라 그 링크 조회 쪽 attribute) — 순수 Gate mock이 아닌
+    # 다중-쿼리 재사용 hack이라 make_gate 대상 밖(Gate에 없는 필드를 억지로 끼워 넣게 됨).
     gr.scalar_one_or_none.return_value = SimpleNamespace(
         gate_type="merge", work_item_type="story", work_item_id=uuid.uuid4(),
         # story #2813 — session.execute가 단일 고정 return_value라, gates.py의 신규
@@ -70,16 +76,10 @@ async def test_transition_forces_resolver_ignoring_body():
 
     async def _fake_transition(session, org_id, gate_id, status, resolver_id, note, *, pending_deliveries=None):
         captured["resolver_id"] = resolver_id
-        return SimpleNamespace(id=gate_id, org_id=org_id, work_item_id=uuid.uuid4(),
-                               work_item_type="story", gate_type="merge", status=status,
-                               resolver_id=resolver_id, resolved_at=None, resolution_note=None,
-                               held_until=None, neutral_facts=None, requires_human=False,
-                               evidence_status=None, decision_basis=None, auto_decision_reason=None,
-                               # story #2832 — gates.py 승인 anchor 기록이 github_check_run_sha를
-                               # 1순위로 읽는다(gate 자신의 필드, story-스코프 링크 모호성 무관).
-                               github_check_run_sha=None,
-                               created_at=__import__("datetime").datetime.now(),
-                               updated_at=__import__("datetime").datetime.now())
+        # story #2837 — 예전엔 이 자리가 SimpleNamespace 손수 필드나열이라 gates.py가 새 Gate
+        # 필드를 읽을 때마다 AttributeError로 깨졌다(#2832의 github_check_run_sha가 그 사례).
+        # make_gate()는 실 Gate 필드셋을 그대로 기본 채움 — override만 명시.
+        return make_gate(id=gate_id, org_id=org_id, status=status, resolver_id=resolver_id)
 
     from fastapi import BackgroundTasks
     with patch.object(mod, "resolve_member", AsyncMock(return_value=caller)), \


### PR DESCRIPTION
[SID:2837]

## Summary
- story #2837(low, 테스트·구조): 오늘 2회 실사고(#3256 `github_check_run_sha` 누락·#3260 `neutral_facts` 누락) — 손수 필드 나열한 `SimpleNamespace(Gate형)` mock이 Gate에 새 필드가 늘 때마다 AttributeError로 재발.

## AC 반영
- **①** PO 확定: 처방②(실 `Gate` ORM 인스턴스) 채택 — SimpleNamespace 대신 진짜 `Gate(...)`를 mock으로 씀. 세션에 안 붙은 순수 Python 객체라 DB 왕복 없음(테스트 안전) + 같은 클래스라 스키마 변경에서 구조적으로 못 벗어남(defaults-dict 수동유지안보다 근본).
- **②** 공용 헬퍼 한 곳 — `tests/gate_mock_factory.py::make_gate(**overrides)`.
- **③** 마이그레이션 스코프 = 오늘 2회+ 깨진 3파일만(`test_gate_can_approve_48f064e5.py`·`test_gate_transition_human_only.py`·`test_rc1_body_trust_actor.py`). 나머지 19개 파일은 그대로 — **"건드릴 때 이관"** 관례를 팩토리 docstring에 명문화(다음 사람이 전수 스윕을 다시 고민 안 하게).
- **④** C(실DB `_make_gate` 3중복)·D(`_ma_seq`류 positional-list mock, 3곳)는 이 PR에 안 접음 — 페드루가 별도 스토리로 등재 예정.
- **⑤** detached 함정 명시 — 팩토리 docstring에 "컬럼 속성은 세션 밖에서도 안전(None)하나 relationship 속성은 접근 시 위험(현재 Gate엔 없음, 생기면 각 테스트가 명시 세팅)" 한 줄.
- **⑥** "건드릴 때 이관" 관례를 팩토리 모듈 docstring에 명문화.

## 그라운딩 메모
- `test_rc1_body_trust_actor.py`의 `_non_doc_gate_session()`은 의도적으로 미이관 — 단일 mock이 `Gate` SELECT뿐 아니라 뒤이은 `PullRequestStoryLink` SELECT까지 동시에 대신 받는(session.execute 고정 return_value 재사용) 다중-쿼리 hack이라, 그 `.evidence` 필드는 실제로 `Gate` 필드가 아니다 — 순수 Gate mock이 아니므로 `make_gate` 대상 밖(사유를 주석으로 남김).

## Test plan
- [x] 마이그레이션 대상 3파일 전체(17건) green.
- [x] `make_gate()` 단독 sanity(모든 필드 기본값 채움 확認) + `import app.main` 전체 임포트 체크 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)