### PR TITLE
fix(#2822): GOTENBERG_SERVICE_URL을 Settings SSOT 경유로

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -384,6 +384,12 @@ class Settings(BaseSettings):
     # §7.3: 사용자당 bounded N개 active installation — 초과 등록은 fresh re-auth(이미 강제,
     # 5분 auth_time freshness)+MFA(user.totp_enabled 전제) 요구.
     device_installation_max_active_per_user: int = 5
+    # story #2822 — office_conversion.py(pptx→pdf, #2771)가 소비하는 배포 설정값. 예전엔
+    # 이 필드를 안 거치고 os.environ 을 모듈 레벨에서 직접 읽어(둘 다 프로세스 시작 시 1회
+    # 스냅샷이라 타이밍은 동일) infra/check_env_drift.py ④축(Settings 커버리지)이 매번
+    # report했다. 미설정 시 변환은 ConversionUnavailable(가짜 렌더 금지, 인프라 배치 전엔
+    # 그냥 비활성) — 이 필드로 옮겨도 그 fail-closed 시맨틱은 그대로.
+    gotenberg_service_url: str = ""
 
     @property
     def is_ee_enabled(self) -> bool:

--- a/backend/app/services/office_conversion.py
+++ b/backend/app/services/office_conversion.py
@@ -14,7 +14,6 @@ story #2771 §7 구현 그라운딩(doc 84ef0cb7) 결정 반영:
 """
 from __future__ import annotations
 
-import os
 import uuid
 
 import httpx
@@ -22,9 +21,13 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.models.asset import Asset
 
-_GOTENBERG_URL = os.environ.get("GOTENBERG_SERVICE_URL", "").rstrip("/")
+# story #2822 — Settings SSOT 경유(예전엔 os.environ 직접읽기라 infra/check_env_drift.py
+# ④축 report 대상이었다). settings도 프로세스 시작 시 1회 인스턴스화라 타이밍 동일 —
+# fail-closed 시맨틱(미설정 시 ConversionUnavailable) 그대로 보존.
+_GOTENBERG_URL = settings.gotenberg_service_url.rstrip("/")
 _CONVERTIBLE_EXTS = frozenset({"pptx"})
 _TIMEOUT = httpx.Timeout(120.0)  # §7-4: 대형 pptx 변환 지연 흡수
 # ⛔QA catch(카디르군, 2026-08-19) — %PDF- 매직만으론 부족, 응답 크기도 상한 필요(무제한

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -187,4 +187,7 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # 필드를 설계대로 잡은 것.
     assert "ADMIN_OPERATOR_AUDIENCE" in keys and "ADMIN_OPERATOR_ALLOWLIST" in keys
     assert "DEPLOY_ENV" in keys
-    assert len(keys) == 97
+    # story #2822(2026-08-20): gotenberg_service_url 필드 신설(office_conversion.py의
+    # os.environ 직접읽기를 Settings SSOT 경유로 교체)로 97→98. 가드가 신규 필드를 설계대로 잡은 것.
+    assert "GOTENBERG_SERVICE_URL" in keys
+    assert len(keys) == 98


### PR DESCRIPTION
[SID:2822]

## Summary
- story #2822(low, 결함·인프라): `office_conversion.py`(#2771)가 `os.environ`을 모듈 레벨에서 직접 읽어(`app.core.config.Settings` 82필드 SSOT 밖) `infra/check_env_drift.py` ④축(Settings 커버리지, report-only)이 `sprintable-backend-dev`의 `GOTENBERG_SERVICE_URL`을 매 실행 미커버로 report.

## 그라운딩(PO 확定)
- **모듈-로드-시점 fail-closed 우려 해소**: `settings = Settings()`(app.core.config.py)도 프로세스 시작 시 1회 인스턴스화 — `os.environ.get(...)` 직접읽기와 타이밍이 동일. Settings 경유로 바꿔도 "인프라 배치 전엔 그냥 비활성"(`ConversionUnavailable`) fail-closed 시맨틱은 그대로 보존.
- **테스트 영향 0**: 5개 call site(`test_office_conversion_2771.py` 4곳·`test_office_conversion_realdb_2771.py` 1곳) 전부 `monkeypatch.setattr(office_conversion, "_GOTENBERG_URL", ...)`로 모듈 속성 자체를 직접 패치 — `_GOTENBERG_URL`이라는 이름/위치를 그대로 유지한 채 초기화 소스만 교체해 기존 테스트 무수정으로 통과.

## AC
- `Settings`에 `gotenberg_service_url: str = ""` 필드 추가(pydantic-settings 기본 대문자 매핑으로 env `GOTENBERG_SERVICE_URL` 자동 바인딩).
- `office_conversion.py`의 `_GOTENBERG_URL = os.environ.get("GOTENBERG_SERVICE_URL", "").rstrip("/")` → `_GOTENBERG_URL = settings.gotenberg_service_url.rstrip("/")`로 교체(그 외 변경 0, 미사용 `os` import 제거).

## Test plan
- [x] `test_office_conversion_2771.py`(4)·`test_office_conversion_realdb_2771.py`(6) 전부 무수정 green(10/10).
- [x] `import app.main` 전체 임포트 체크 green.
- [x] env var 실제 바인딩 확認(`GOTENBERG_SERVICE_URL=... Settings()` → `gotenberg_service_url`에 정확히 반영).

🤖 Generated with [Claude Code](https://claude.com/claude-code)