### PR TITLE
[SID:2842] org-wide attention 신호 href를 소속 프로젝트로 짓고 cross-project 항목만 병기

### DIFF
--- a/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
@@ -36,7 +36,7 @@ afterEach(async () => {
 });
 
 function stalledItem(i: number): StalledClusterItem {
-  return { id: `s${i}`, title: `스토리 ${i}`, days: 10 - i, href: `/board?story=s${i}` };
+  return { id: `s${i}`, title: `스토리 ${i}`, days: 10 - i, href: `/board?story=s${i}`, crossProjectLabel: null };
 }
 
 describe('AttentionClusterBoard', () => {
@@ -76,6 +76,7 @@ describe('AttentionClusterBoard', () => {
     const item: FalsifiedClusterItem = {
       id: 'h1', title: '온보딩 연결 완료율이 오르면 채택이 는다',
       target: 70, actual: 41, hasOutcome: true, supersededId: 'h2', href: '/flow?hypothesis=h1',
+      crossProjectLabel: null,
     };
     await act(async () => {
       root.render(wrap(<AttentionClusterBoard falsified={[item]} stalled={[]} {...NO_LOOP} />));
@@ -88,6 +89,7 @@ describe('AttentionClusterBoard', () => {
   it('대체 가설이 없으면 미연결 정직 문구를 보인다(대체 가설 제목을 지어내지 않는다)', async () => {
     const item: FalsifiedClusterItem = {
       id: 'h1', title: 'X', target: null, actual: null, hasOutcome: false, supersededId: null, href: '/flow?hypothesis=h1',
+      crossProjectLabel: null,
     };
     await act(async () => {
       root.render(wrap(<AttentionClusterBoard falsified={[item]} stalled={[]} {...NO_LOOP} />));
@@ -99,7 +101,7 @@ describe('AttentionClusterBoard', () => {
   // story #2830 — 「닫힌 적 없는 루프」 클러스터.
   describe('loop cluster (story #2830)', () => {
     function loopItem(overrides: Partial<LoopClusterItem>): LoopClusterItem {
-      return { id: 'l1', kind: 'overdueHypothesis', title: '결제 전환 가설', days: 5, href: '/flow?hypothesis=l1', ...overrides };
+      return { id: 'l1', kind: 'overdueHypothesis', title: '결제 전환 가설', days: 5, href: '/flow?hypothesis=l1', crossProjectLabel: null, ...overrides };
     }
 
     it('N=0이면 카드 자체를 안 그린다(배경음 방지)', async () => {
@@ -191,6 +193,21 @@ describe('AttentionClusterBoard', () => {
       const hrefs = Array.from(container.querySelectorAll('a')).map((a) => a.getAttribute('href'));
       expect(hrefs).toContain('/flow?hypothesis=h1');
       expect(hrefs).toContain('/flow?view=flow&goal=g1');
+    });
+
+    // story #2842(0b17472c) — cross-project 항목만 프로젝트 slug 배지가 붙는다(노이즈 절제).
+    it('crossProjectLabel이 있는 항목만 프로젝트 태그가 보인다', async () => {
+      const items = [
+        loopItem({ id: 'same', title: '같은 프로젝트', crossProjectLabel: null }),
+        loopItem({ id: 'other', title: '다른 프로젝트', crossProjectLabel: 'other-proj' }),
+      ];
+      await act(async () => {
+        root.render(wrap(
+          <AttentionClusterBoard falsified={[]} stalled={[]} loop={items} loopTotalCount={2} measurePlanMissingGoalCount={0} unmeasurableGoalCount={0} />,
+        ));
+      });
+      expect(container.textContent).toContain('other-proj');
+      expect(container.textContent?.match(/other-proj/g)).toHaveLength(1);
     });
   });
 });

--- a/apps/web/src/components/org-briefing/attention-cluster-board.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { RefreshCw, PauseCircle, AlertTriangle } from 'lucide-react';
+import { RefreshCw, PauseCircle, AlertTriangle, FolderOpen } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import type { FalsifiedClusterItem, StalledClusterItem, LoopClusterItem } from './derive-attention-clusters';
@@ -57,6 +57,14 @@ function ClusterShell({
   );
 }
 
+// story #2842(0b17472c 그라운딩, PO 확定) — 항목이 뷰어의 활성 프로젝트와 다른 프로젝트
+// 소속일 때만 병기(같으면 null이라 이 컴포넌트 자체가 안 그려짐 — 노이즈 절제). 병기 값은
+// BE가 주는 project_slug 그대로(별도 표시용 프로젝트명 필드는 이 계약에 없음).
+function CrossProjectTag({ label }: { label: string | null }) {
+  if (!label) return null;
+  return <Badge variant="chip" className="shrink-0 gap-1"><FolderOpen className="size-3 shrink-0" aria-hidden />{label}</Badge>;
+}
+
 function FalsifiedRow({ item }: { item: FalsifiedClusterItem }) {
   const t = useTranslations('orgBriefing');
   return (
@@ -66,6 +74,7 @@ function FalsifiedRow({ item }: { item: FalsifiedClusterItem }) {
     >
       <div className="flex items-center gap-2">
         <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">{item.title}</p>
+        <CrossProjectTag label={item.crossProjectLabel} />
         <Badge variant="info" className="shrink-0">{t('clusterFalsifiedBadge')}</Badge>
       </div>
       <p className="mt-1.5 text-xs text-muted-foreground">
@@ -99,6 +108,7 @@ function StalledRow({ item }: { item: StalledClusterItem }) {
       className="flex items-center gap-2.5 border-t border-border px-4 py-2.5 transition-colors hover:bg-muted/50"
     >
       <p className="min-w-0 flex-1 truncate text-sm text-foreground">{item.title}</p>
+      <CrossProjectTag label={item.crossProjectLabel} />
       {/* story #2420 규칙 — tint 배경 위 글자는 계열색이 아니라 text-foreground. */}
       {item.days !== null ? (
         <span className="shrink-0 rounded-md bg-info/10 px-2 py-0.5 text-[11px] font-semibold text-foreground">
@@ -131,6 +141,7 @@ function LoopRow({ item }: { item: LoopClusterItem }) {
       className="flex items-center gap-2.5 border-t border-border px-4 py-2.5 transition-colors hover:bg-muted/50"
     >
       <p className="min-w-0 flex-1 truncate text-sm text-foreground">{item.title}</p>
+      <CrossProjectTag label={item.crossProjectLabel} />
       <Badge variant="warning" className="shrink-0">{t(LOOP_KIND_BADGE_KEY[item.kind])}</Badge>
       {item.days !== null ? (
         <span className="shrink-0 rounded-md bg-warning-tint px-2 py-0.5 text-[11px] font-semibold text-foreground">

--- a/apps/web/src/components/org-briefing/derive-attention-clusters.test.ts
+++ b/apps/web/src/components/org-briefing/derive-attention-clusters.test.ts
@@ -26,6 +26,8 @@ function attentionItem(overrides: Partial<RawAttentionItem>): RawAttentionItem {
     goal_id: null,
     overdue_days: null,
     done_days: null,
+    project_id: null,
+    project_slug: null,
     ...overrides,
   };
 }
@@ -140,6 +142,50 @@ describe('deriveAttentionClusters', () => {
       expect(clusters.loopTotalCount).toBe(1);
       expect(clusters.measurePlanMissingGoalCount).toBe(0);
       expect(clusters.unmeasurableGoalCount).toBe(0);
+    });
+  });
+
+  // story #2842(0b17472c 그라운딩) — href를 항목의 실제 소속 프로젝트로 짓고, 뷰어의 활성
+  // 프로젝트와 다를 때만 crossProjectLabel을 채운다.
+  describe('project-scoped href · cross-project 병기(story #2842)', () => {
+    it('viewer(orgSlug+activeProjectId) 제공 시 href가 항목 소속 프로젝트 slug로 지어진다', () => {
+      const clusters = deriveAttentionClusters([
+        attentionItem({ type: 'loop_overdue_goal', goal_id: 'g1', overdue_days: 1, project_id: 'p-other', project_slug: 'other-proj' }),
+        attentionItem({ type: 'story_stalled', story_id: 's1', stalled_days: 1, project_id: 'p-other', project_slug: 'other-proj' }),
+      ], t, undefined, { orgSlug: 'moonklabs', activeProjectId: 'p-active' });
+      expect(clusters.loop[0]!.href).toBe('/moonklabs/other-proj/flow?view=flow&goal=g1');
+      expect(clusters.stalled[0]!.href).toBe('/moonklabs/other-proj/board?story=s1');
+    });
+
+    it('같은 프로젝트 소속이면 crossProjectLabel이 null(노이즈 절제) — href는 여전히 완전 경로', () => {
+      const clusters = deriveAttentionClusters([
+        attentionItem({ type: 'loop_overdue_goal', goal_id: 'g1', overdue_days: 1, project_id: 'p-active', project_slug: 'sprintable' }),
+      ], t, undefined, { orgSlug: 'moonklabs', activeProjectId: 'p-active' });
+      expect(clusters.loop[0]!.crossProjectLabel).toBeNull();
+      expect(clusters.loop[0]!.href).toBe('/moonklabs/sprintable/flow?view=flow&goal=g1');
+    });
+
+    it('다른 프로젝트 소속이면 crossProjectLabel에 project_slug가 채워진다', () => {
+      const clusters = deriveAttentionClusters([
+        attentionItem({ type: 'loop_overdue_goal', goal_id: 'g1', overdue_days: 1, project_id: 'p-other', project_slug: 'other-proj' }),
+      ], t, undefined, { orgSlug: 'moonklabs', activeProjectId: 'p-active' });
+      expect(clusters.loop[0]!.crossProjectLabel).toBe('other-proj');
+    });
+
+    it('viewer 미제공(구 호출부)이면 crossProjectLabel은 항상 null·href는 기존 bare path로 폴백(오탐 방지·회귀 0)', () => {
+      const clusters = deriveAttentionClusters([
+        attentionItem({ type: 'loop_overdue_goal', goal_id: 'g1', overdue_days: 1, project_id: 'p-other', project_slug: 'other-proj' }),
+      ], t);
+      expect(clusters.loop[0]!.crossProjectLabel).toBeNull();
+      expect(clusters.loop[0]!.href).toBe('/flow?view=flow&goal=g1');
+    });
+
+    it('project_slug가 없으면(BE 미해소) orgSlug가 있어도 bare path로 폴백한다', () => {
+      const clusters = deriveAttentionClusters([
+        attentionItem({ type: 'loop_overdue_goal', goal_id: 'g1', overdue_days: 1, project_id: 'p-other', project_slug: null }),
+      ], t, undefined, { orgSlug: 'moonklabs', activeProjectId: 'p-active' });
+      expect(clusters.loop[0]!.href).toBe('/flow?view=flow&goal=g1');
+      expect(clusters.loop[0]!.crossProjectLabel).toBeNull();
     });
   });
 });

--- a/apps/web/src/components/org-briefing/derive-attention-clusters.ts
+++ b/apps/web/src/components/org-briefing/derive-attention-clusters.ts
@@ -16,6 +16,9 @@ export interface FalsifiedClusterItem {
   hasOutcome: boolean;
   supersededId: string | null;
   href: string;
+  // story #2842 — 항목 소속 프로젝트가 뷰어의 활성 프로젝트와 다를 때만 채워짐(같으면
+  // null·노이즈 절제). 값은 그 프로젝트의 slug.
+  crossProjectLabel: string | null;
 }
 
 export interface StalledClusterItem {
@@ -23,6 +26,7 @@ export interface StalledClusterItem {
   title: string;
   days: number | null;
   href: string;
+  crossProjectLabel: string | null;
 }
 
 // story #2829/#2830(loop-closure P0) — 「닫힌 적 없는 루프」 3분류 중 N에 포함되는 2류
@@ -35,6 +39,24 @@ export interface LoopClusterItem {
   title: string;
   days: number | null;
   href: string;
+  crossProjectLabel: string | null;
+}
+
+// story #2842(0b17472c 그라운딩) — 뷰어 컨텍스트. 미제공(구 호출부·테스트)이면 href는 기존
+// bare path로 폴백하고 crossProjectLabel은 항상 null(회귀 0).
+export interface ViewerContext {
+  orgSlug?: string;
+  activeProjectId?: string;
+}
+
+function projectHref(viewer: ViewerContext | undefined, projectSlug: string | null, path: string): string {
+  if (viewer?.orgSlug && projectSlug) return `/${viewer.orgSlug}/${projectSlug}${path}`;
+  return path;
+}
+
+function crossProjectLabel(viewer: ViewerContext | undefined, itemProjectId: string | null, projectSlug: string | null): string | null {
+  if (!viewer?.activeProjectId || !itemProjectId || !projectSlug) return null;
+  return itemProjectId !== viewer.activeProjectId ? projectSlug : null;
 }
 
 export interface AttentionClusters {
@@ -83,6 +105,7 @@ export function deriveAttentionClusters(
   attention: RawAttentionItem[],
   t: ClusterTranslator,
   loopCounts?: LoopCounts,
+  viewer?: ViewerContext,
 ): AttentionClusters {
   const falsified: { item: FalsifiedClusterItem; days: number | null }[] = [];
   const stalled: StalledClusterItem[] = [];
@@ -96,7 +119,8 @@ export function deriveAttentionClusters(
           kind: 'overdueHypothesis',
           title: a.statement ?? t('clusterUnclosedOverdueHypothesisTitle'),
           days: a.overdue_days,
-          href: a.hypothesis_id ? `/flow?hypothesis=${a.hypothesis_id}` : '/flow',
+          href: projectHref(viewer, a.project_slug, a.hypothesis_id ? `/flow?hypothesis=${a.hypothesis_id}` : '/flow'),
+          crossProjectLabel: crossProjectLabel(viewer, a.project_id, a.project_slug),
         },
         days: a.overdue_days,
       });
@@ -112,7 +136,8 @@ export function deriveAttentionClusters(
           // 조용히 드롭된다(NextMakerScreen이 view==='flow'일 때만 소비). 정본 경로
           // handleNavigateToGoal(flow-client.tsx)이 이미 view=flow를 명시 세팅하는 것과 동형으로
           // 딥링크도 명시한다.
-          href: a.goal_id ? `/flow?view=flow&goal=${a.goal_id}` : '/flow',
+          href: projectHref(viewer, a.project_slug, a.goal_id ? `/flow?view=flow&goal=${a.goal_id}` : '/flow'),
+          crossProjectLabel: crossProjectLabel(viewer, a.project_id, a.project_slug),
         },
         days: a.overdue_days,
       });
@@ -128,7 +153,8 @@ export function deriveAttentionClusters(
           // 조용히 드롭된다(NextMakerScreen이 view==='flow'일 때만 소비). 정본 경로
           // handleNavigateToGoal(flow-client.tsx)이 이미 view=flow를 명시 세팅하는 것과 동형으로
           // 딥링크도 명시한다.
-          href: a.goal_id ? `/flow?view=flow&goal=${a.goal_id}` : '/flow',
+          href: projectHref(viewer, a.project_slug, a.goal_id ? `/flow?view=flow&goal=${a.goal_id}` : '/flow'),
+          crossProjectLabel: crossProjectLabel(viewer, a.project_id, a.project_slug),
         },
         days: a.done_days,
       });
@@ -144,7 +170,8 @@ export function deriveAttentionClusters(
           actual,
           hasOutcome: actual !== null && target !== null,
           supersededId: a.superseded_by_hypothesis_id,
-          href: a.hypothesis_id ? `/flow?hypothesis=${a.hypothesis_id}` : '/flow',
+          href: projectHref(viewer, a.project_slug, a.hypothesis_id ? `/flow?hypothesis=${a.hypothesis_id}` : '/flow'),
+          crossProjectLabel: crossProjectLabel(viewer, a.project_id, a.project_slug),
         },
         days: a.falsified_days,
       });
@@ -153,7 +180,8 @@ export function deriveAttentionClusters(
         id: a.story_id ?? `story_stalled-${idx}`,
         title: a.title ?? t('signalStalledTitle'),
         days: a.stalled_days,
-        href: a.story_id ? `/board?story=${a.story_id}` : '/board',
+        href: projectHref(viewer, a.project_slug, a.story_id ? `/board?story=${a.story_id}` : '/board'),
+        crossProjectLabel: crossProjectLabel(viewer, a.project_id, a.project_slug),
       });
     }
   });

--- a/apps/web/src/components/org-briefing/derive-now-face.test.ts
+++ b/apps/web/src/components/org-briefing/derive-now-face.test.ts
@@ -146,8 +146,8 @@ describe('buildNowFace', () => {
         { type: 'my_blockers', priority: null, title: null, context: { blocked_story_id: 's2' } },
       ],
       attention: [
-        { type: 'agent_stuck', entity_type: 'story', entity_id: 's3', gate_type: 'merge', story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null },
-        { type: 'unanswered_blocker', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: 's5', title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null },
+        { type: 'agent_stuck', entity_type: 'story', entity_id: 's3', gate_type: 'merge', story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null },
+        { type: 'unanswered_blocker', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: 's5', title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null },
       ],
     };
     const notifications = [{ id: 'n1', title: 'Contract done', body: 'evidence attached', href: '/inbox' }];
@@ -163,8 +163,8 @@ describe('buildNowFace', () => {
       ...ZERO_LOOP_COUNTS,
       queue: [],
       attention: [
-        { type: 'story_stalled', entity_type: null, entity_id: null, gate_type: null, story_id: 's9', stalled_days: 9, blocked_story_id: null, title: '결제 완료율 개선', hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null },
-        { type: 'hypothesis_falsified', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: 'h1', statement: '결제 완료율 개선', outcome_result: { target: 60, actual: 52 }, falsified_days: 2, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null },
+        { type: 'story_stalled', entity_type: null, entity_id: null, gate_type: null, story_id: 's9', stalled_days: 9, blocked_story_id: null, title: '결제 완료율 개선', hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null },
+        { type: 'hypothesis_falsified', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: 'h1', statement: '결제 완료율 개선', outcome_result: { target: 60, actual: 52 }, falsified_days: 2, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null },
       ],
     };
     const items = buildNowFace(raw, [], t);
@@ -176,7 +176,7 @@ describe('buildNowFace', () => {
       ...ZERO_LOOP_COUNTS,
       queue: [],
       attention: [
-        { type: 'unanswered_blocker', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: 's7', title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null },
+        { type: 'unanswered_blocker', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: 's7', title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null },
       ],
     };
     const items = buildNowFace(raw, [], t);
@@ -189,7 +189,7 @@ describe('buildNowFace', () => {
     const raw: RawMyActions = {
       ...ZERO_LOOP_COUNTS,
       queue: [],
-      attention: [{ type: 'agent_stuck', entity_type: 'story', entity_id: 's1', gate_type: 'merge', story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null }],
+      attention: [{ type: 'agent_stuck', entity_type: 'story', entity_id: 's1', gate_type: 'merge', story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null }],
     };
     const items = buildNowFace(raw, [], t);
     const signal = items.find((i) => i.kind === 'signal');
@@ -215,7 +215,7 @@ describe('buildNowFace', () => {
 
   it('produces no primary action when there are no decide items', () => {
     const raw: RawMyActions = {
-      ...ZERO_LOOP_COUNTS, queue: [], attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null }] };
+      ...ZERO_LOOP_COUNTS, queue: [], attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null }] };
     const items = buildNowFace(raw, [], t);
     expect(items.every((i) => i.actionTone === 'ghost')).toBe(true);
   });
@@ -224,7 +224,7 @@ describe('buildNowFace', () => {
     const raw: RawMyActions = {
       ...ZERO_LOOP_COUNTS,
       queue: [{ type: 'review_merge', priority: 'info', title: 'x', context: {} }],
-      attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null }],
+      attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null }],
     };
     const items = buildNowFace(raw, [{ id: 'n1', title: 'done', body: null, href: null }], t);
     expect(items.map((i) => i.kind)).toEqual(['decide', 'signal', 'done']);

--- a/apps/web/src/components/org-briefing/derive-now-face.ts
+++ b/apps/web/src/components/org-briefing/derive-now-face.ts
@@ -95,6 +95,12 @@ export interface RawAttentionItem {
   goal_id: string | null;
   overdue_days: number | null;
   done_days: number | null;
+  // story #2842(0b17472c, BE PR#3263) — 항목의 실제 소속 프로젝트. bare href(예: `/flow?...`)는
+  // 미들웨어가 뷰어의 "활성" 프로젝트 쿠키로 해석해버려, 다른 프로젝트 소속 항목을 클릭하면
+  // 엉뚱한 프로젝트 캔버스로 떨어진다 — slug가 있어야 `/{orgSlug}/{projectSlug}/...` 완전
+  // 경로를 지어 항목의 진짜 소속으로 못박을 수 있다.
+  project_id: string | null;
+  project_slug: string | null;
 }
 
 export interface RawMyActions {
@@ -158,6 +164,8 @@ export function parseMyActions(json: unknown): RawMyActions {
         goal_id: str(raw['goal_id']),
         overdue_days: num(raw['overdue_days']),
         done_days: num(raw['done_days']),
+        project_id: str(raw['project_id']),
+        project_slug: str(raw['project_slug']),
       });
     }
   }

--- a/apps/web/src/components/org-briefing/now-face.tsx
+++ b/apps/web/src/components/org-briefing/now-face.tsx
@@ -1,17 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { CheckCircle2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { fetchWithAuth } from '@/lib/db/client';
 import { cn } from '@/lib/utils';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import {
   buildNowFace, parseCompletionNotifications, parseMyActions,
   type NowFaceItem, type NowFaceTranslator,
 } from './derive-now-face';
-import { deriveAttentionClusters, type AttentionClusters } from './derive-attention-clusters';
+import { deriveAttentionClusters, type AttentionClusters, type ViewerContext } from './derive-attention-clusters';
 import { AttentionClusterBoard } from './attention-cluster-board';
 
 // story ded31cb3 — 조직 브리핑 "지금" 면. doc org-briefing-hypothesis-grammar-blueprint §1.3.
@@ -24,7 +25,7 @@ interface NowFaceLoad {
   clusters: AttentionClusters;
 }
 
-async function loadNowFace(t: NowFaceTranslator): Promise<NowFaceLoad> {
+async function loadNowFace(t: NowFaceTranslator, viewer: ViewerContext): Promise<NowFaceLoad> {
   // story #2689 — 콜드 재진입 시 raw fetch는 401을 재시도 없이 삼켜(!r.ok=>null) "지금" 면이
   // 빈 채로 60초 REFRESH_MS까지 안 채워졌다. fetchWithAuth로 401→refresh→재시도 경로에 태운다.
   const [ma, notifs] = await Promise.all([
@@ -44,7 +45,7 @@ async function loadNowFace(t: NowFaceTranslator): Promise<NowFaceLoad> {
       loopOutcomeMissingGoalCount: raw.loopOutcomeMissingGoalCount,
       measurePlanMissingGoalCount: raw.measurePlanMissingGoalCount,
       unmeasurableGoalCount: raw.unmeasurableGoalCount,
-    }),
+    }, viewer),
   };
 }
 
@@ -93,17 +94,23 @@ export function NowFace() {
   const [items, setItems] = useState<NowFaceItem[] | null>(null);
   const [clusters, setClusters] = useState<AttentionClusters>(EMPTY_CLUSTERS);
   const [expanded, setExpanded] = useState(false);
+  // story #2842 — loop-face.tsx와 동형(orgMemberships에서 orgSlug 파생). useMemo로 orgId/
+  // projectId(원시값)가 실제로 바뀔 때만 새 참조를 만든다 — 매 렌더 새 객체면 아래 effect가
+  // 무한 재구독된다.
+  const { orgId, orgMemberships, projectId } = useDashboardContext();
+  const orgSlug = orgMemberships.find((o) => o.orgId === orgId)?.orgSlug;
+  const viewer = useMemo<ViewerContext>(() => ({ orgSlug, activeProjectId: projectId }), [orgSlug, projectId]);
 
   useEffect(() => {
     const load = async () => {
-      const result = await loadNowFace(t);
+      const result = await loadNowFace(t, viewer);
       setItems(result.items);
       setClusters(result.clusters);
     };
     void load();
     const id = setInterval(() => void load(), REFRESH_MS);
     return () => clearInterval(id);
-  }, [t]);
+  }, [t, viewer]);
 
   const list = items ?? [];
   const shown = expanded ? list : list.slice(0, CAP);


### PR DESCRIPTION
[SID:2842]

## 요약
org-wide attention 신호(닫힌 적 없는 루프·반증 가설·정체 스토리) 클릭 href가 항목의
실제 소속 프로젝트가 아니라 뷰어의 "활성" 프로젝트로 해석돼 엉뚱한 캔버스로 떨어지던
갭을 봉합한다.

- BE PR#3263이 attention 항목 6종 전부에 `project_id`/`project_slug`를 실어줌(라이브 확인,
  `resolve_project_slugs()` 배치 호출로 N+1 없음).
- `deriveAttentionClusters()`에 `viewer?: ViewerContext`(orgSlug/activeProjectId) 4번째
  파라미터 추가 — 제공 시 href를 `/{orgSlug}/{projectSlug}/...` 완전 경로로 짓는다.
- 미제공(구 호출부·테스트)이면 기존 bare path로 폴백(회귀 0).
- 뷰어의 활성 프로젝트와 다른 소속일 때만 `crossProjectLabel`(프로젝트 slug)을 채워
  `AttentionClusterBoard`의 각 행에 병기한다(같으면 null — 노이즈 절제, AC 확定).

## AC (PO 확定)
- [x] href가 항목의 실제 소속 프로젝트 slug로 지어진다
- [x] cross-project 항목에만 프로젝트명이 병기된다
- [x] 같은 프로젝트 항목은 병기 없음(노이즈 0)

## 검증
- `pnpm exec tsc --noEmit -p .` 0 errors
- `pnpm exec eslint src/components/org-briefing` 0 warnings
- `pnpm exec vitest run` 3725 passed (신규 10건: derive-attention-clusters.test.ts 5건 +
  attention-cluster-board.test.tsx 1건 + 기존 회귀 갱신)
- tint-guard 3종(verify-no-new-tint-color-text·verify-cross-element-tint-text·
  verify-tint-foreground-contrast) 52 passed
- `pnpm build` exit 0