### PR TITLE
[SID:2840] prior_sha 착지 시 재-pending 사유 문구 완전화

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3709,6 +3709,7 @@
     "githubCheckFailure": "Failed",
     "githubCheckShaLabel": "SHA {sha}",
     "githubCheckRependingReason": "A new commit (SHA {newSha}) invalidated the prior approval, moving this back to pending.",
+    "githubCheckRependingReasonWithPrior": "SHA {priorSha} was invalidated by SHA {newSha}, moving this back to pending.",
     "trustLabel": "Trust",
     "trustScorePercent": "{score}%",
     "selfReportTag": "Self-reported",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3709,6 +3709,7 @@
     "githubCheckFailure": "실패",
     "githubCheckShaLabel": "SHA {sha}",
     "githubCheckRependingReason": "새 커밋(SHA {newSha})으로 이전 승인이 무효화돼 재-pending 됐습니다.",
+    "githubCheckRependingReasonWithPrior": "SHA {priorSha}에서 SHA {newSha}로 무효화돼 재-pending 됐습니다.",
     "trustLabel": "신뢰도",
     "trustScorePercent": "{score}%",
     "selfReportTag": "자기보고",

--- a/apps/web/src/components/cage/gate-evidence-render.test.tsx
+++ b/apps/web/src/components/cage/gate-evidence-render.test.tsx
@@ -161,6 +161,46 @@ describe('GateEvidence — 재-pending 사유(원장 지연 로드, story #2814 
     expect(container.textContent).not.toContain('재-pending');
   });
 
+  // story #2840(BE PR#3264 §2819 착지) — prior_sha가 채워진 re_pending 행은 "SHA A→B 무효화"
+  // 완전 문구로 조립된다(AC1).
+  it('re_pending 행에 prior_sha가 있으면 두 SHA 모두 담긴 완전 문구가 뜬다', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([
+        { id: 'evt-1', repo_full_name: 'moonklabs/sprintable', pr_number: 3264, head_sha: 'def9876543210abc9876543210def9876543210', prior_sha: 'aaa1111111111111111111111111111111111a', event_type: 're_pending', check_conclusion: null, created_at: '2026-08-20T02:00:00Z' },
+      ]),
+    } as Response);
+
+    const gate = realApiShapedGate({ status: 'pending', github_check_run_id: 987654321 });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateEvidence gate={gate} />)); });
+
+    expect(container.textContent).toContain('aaa1111');
+    expect(container.textContent).toContain('def9876');
+  });
+
+  // story #2840 AC2 — prior_sha가 null(마이그레이션 이전 행·published/resolved 행)이면 두 SHA를
+  // 지어내지 않고 기존 단축 문구("새 SHA만")로 정직하게 폴백한다(no-fiction).
+  it('re_pending 행에 prior_sha가 null이면 prior SHA를 지어내지 않고 단축 문구로 폴백한다', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([
+        { id: 'evt-1', repo_full_name: 'moonklabs/sprintable', pr_number: 3244, head_sha: 'def9876543210abc9876543210def9876543210', prior_sha: null, event_type: 're_pending', check_conclusion: null, created_at: '2026-08-19T02:00:00Z' },
+      ]),
+    } as Response);
+
+    const gate = realApiShapedGate({ status: 'pending', github_check_run_id: 987654321 });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateEvidence gate={gate} />)); });
+
+    expect(container.textContent).toContain('def9876');
+    expect(container.textContent).not.toContain('에서 SHA');
+  });
+
   it('원장 조회가 실패해도(네트워크/404) 카드는 붕괴하지 않고 GithubCheckSignal은 그대로 보인다', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue({ ok: false, status: 500 } as Response);
 

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -191,11 +191,14 @@ function GithubCheckSignal({ state, sha }: { state: GithubCheckState; sha: strin
 }
 
 // story #2814 2단(§5-② 그라운딩) — backend/app/routers/gates.py GateGithubCheckEventResponse와 정합.
+// story #2840(BE PR#3264 §2819) — prior_sha 추가. re_pending 행 전용(무효화된 승인이 귀속됐던
+// SHA) — published/resolved 행이나 마이그레이션 이전 re_pending 행은 null(소급 불가).
 interface GithubCheckLedgerEvent {
   id: string;
   repo_full_name: string;
   pr_number: number;
   head_sha: string;
+  prior_sha: string | null;
   event_type: 'published' | 're_pending' | 'resolved';
   check_conclusion: string | null;
   created_at: string;
@@ -206,12 +209,10 @@ interface GithubCheckLedgerEvent {
  * 로드(최신순). 최신 이벤트가 `re_pending`이면 "새 커밋이 이전 승인을 무효화했다"는 문장을
  * 그 이벤트의 head_sha(무효화를 유발한 새 SHA)로 조립한다.
  *
- * ⚠️알려진 축소 범위 — "이전에 승인됐던 SHA"까지는 못 보여준다. BE
- * `reopen_gate_if_new_sha`(gate_github_check.py:256)가 `prior_sha`를 지역변수로만 로깅하고
- * `GateGithubCheckEvent` 행엔 `head_sha`(새 SHA)만 남긴다 — 원장에 prior_sha 컬럼이 없다.
- * `gate.approved_head_sha`로 메꾸려 해도 같은 함수가 그 필드를 재-pending 즉시 null로 리셋해
- * 버려(§2-2) FE 시점엔 이미 사라지고 없다. 이번 이터레이션은 "새 SHA"만으로 표시하고, prior_sha
- * 컬럼 추가는 후속 BE 조각으로 페드루/디디군에 별도 보고.
+ * story #2840(BE PR#3264 §2819 착지) — 원장에 `prior_sha`(무효화된 승인이 귀속됐던 SHA)가
+ * 추가돼 "SHA {prior}에서 SHA {new}로 무효화" 완전 문구를 조립할 수 있다. `prior_sha`가
+ * null인 행(published/resolved 행·마이그레이션 이전 re_pending 행)은 두 SHA를 지어내지
+ * 않고 기존 단축 문구("새 커밋으로 이전 승인 무효화")로 정직하게 폴백한다(no-fiction).
  *
  * 트리거는 호출부(GateEvidence)가 결정 — ghState==='in_progress'일 때만 마운트한다(success/
  * failure/not_published/null인 게이트는 재-pending 여지 자체가 없어 호출 불요).
@@ -249,7 +250,9 @@ function GithubRependingReason({ gateId }: { gateId: string }) {
 
   return (
     <p className="mt-1 text-[11px] text-muted-foreground">
-      {t('githubCheckRependingReason', { newSha: repending.head_sha.slice(0, 7) })}
+      {repending.prior_sha
+        ? t('githubCheckRependingReasonWithPrior', { priorSha: repending.prior_sha.slice(0, 7), newSha: repending.head_sha.slice(0, 7) })
+        : t('githubCheckRependingReason', { newSha: repending.head_sha.slice(0, 7) })}
     </p>
   );
 }


### PR DESCRIPTION
[SID:2840]

## 요약
BE PR#3264(#2819)가 `GateGithubCheckEvent` 원장에 `prior_sha` 컬럼을
추가해 `GET .../github-check-events` 응답에 노출한다. 이 PR은 그 계약을
소비해 재-pending 사유 문구를 완전화한다.

- `prior_sha` 있음 → "SHA {prior}에서 SHA {new}로 무효화" (신규 i18n 키
  `githubCheckRependingReasonWithPrior`)
- `prior_sha` null(published/resolved 행·마이그레이션 이전 re_pending
  행) → 기존 단축 문구로 폴백(두 SHA를 지어내지 않음, no-fiction)

## AC (스토리 확定)
- [x] prior_sha 있는 경우 완전 문구 노출(render test)
- [x] prior_sha null인 경우 기존 폴백 문구(render test) — 두 SHA를
      지어내지 않음
- [x] vitest green(신규 2건 포함)·eslint/tsc 0·build 성공
- [ ] 라이브 재검: dev에서 신규 재-pending 이벤트가 prior_sha 채운 채
      발생하면 두 SHA 노출 육안 확認 — 배포 후 후속

## 검증
- `pnpm exec tsc --noEmit -p .` 0 errors
- `pnpm exec eslint src/components/cage` 0 warnings
- `pnpm exec vitest run` 3734 passed(신규 2건 포함)
- tint-guard 3종 52 passed
- `pnpm build` exit 0