### PR TITLE
[SID:2852] 에이전트 인증 실패 관측 신호 렌더 — org-briefing 클러스터 + presence 뱃지

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -444,6 +444,14 @@
     "clusterUnclosedCapNotice": "Showing top {shown} · {total} total",
     "clusterUnclosedMeasurePlanMissing": "+{count} have no measure plan yet",
     "clusterUnclosedUnmeasurableGoal": "{count} declared unmeasurable",
+    "clusterAuthFailureTitle": "Agent auth failures",
+    "clusterAuthFailureSub": "Requests keep being rejected due to API key issues",
+    "clusterAuthFailureReasonExpired": "API key expired",
+    "clusterAuthFailureReasonRevoked": "API key revoked",
+    "clusterAuthFailureReasonInvalid": "API key not recognized",
+    "clusterAuthFailureDiagnostic": "{n} failures in last 5 min",
+    "clusterAuthFailureReissue": "Reissue key",
+    "clusterAuthFailureUnknownAgent": "Unknown agent",
     "doneGenericContext": "Review the evidence and approve",
     "loopTitle": "Lab",
     "loopSubject": "Hypotheses under test",
@@ -3273,7 +3281,11 @@
     "groupOffline": "Offline",
     "working": "Generating reply",
     "assignedStory": "On \"{title}\"",
-    "empty": "No agents to show"
+    "empty": "No agents to show",
+    "authFailureBadge": "Auth failed",
+    "authFailureTooltipExpired": "API key expired · {n} failures in last 5 min",
+    "authFailureTooltipRevoked": "API key revoked · {n} failures in last 5 min",
+    "authFailureTooltipInvalid": "API key not recognized · {n} failures in last 5 min"
   },
   "chats": {
     "unreadMarker": "Unread from here",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -444,6 +444,14 @@
     "clusterUnclosedCapNotice": "상위 {shown}건 표시 중 · 총 {total}건",
     "clusterUnclosedMeasurePlanMissing": "+{count}건은 측정 계획이 아직 없음",
     "clusterUnclosedUnmeasurableGoal": "{count}건은 측정 불가로 선언됨",
+    "clusterAuthFailureTitle": "에이전트 인증 실패",
+    "clusterAuthFailureSub": "API 키 문제로 요청이 반복 거부됨",
+    "clusterAuthFailureReasonExpired": "API 키 만료",
+    "clusterAuthFailureReasonRevoked": "API 키 무효화",
+    "clusterAuthFailureReasonInvalid": "API 키 인식 불가",
+    "clusterAuthFailureDiagnostic": "최근 5분 {n}회",
+    "clusterAuthFailureReissue": "키 재발급",
+    "clusterAuthFailureUnknownAgent": "알 수 없는 에이전트",
     "doneGenericContext": "근거를 확인하고 승인하세요",
     "loopTitle": "실험실",
     "loopSubject": "검증 중인 가설",
@@ -3273,7 +3281,11 @@
     "groupOffline": "오프라인",
     "working": "답 생성 중",
     "assignedStory": "\"{title}\" 담당",
-    "empty": "표시할 에이전트가 없습니다"
+    "empty": "표시할 에이전트가 없습니다",
+    "authFailureBadge": "인증 실패",
+    "authFailureTooltipExpired": "API 키 만료 · 최근 5분 {n}회",
+    "authFailureTooltipRevoked": "API 키 무효화 · 최근 5분 {n}회",
+    "authFailureTooltipInvalid": "API 키 인식 불가 · 최근 5분 {n}회"
   },
   "chats": {
     "unreadMarker": "여기부터 안읽음",

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -22,6 +22,7 @@ import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { ContextualPanelLayout, useContextualPanelState } from '@/components/ui/contextual-panel-layout';
 import { TeamPresencePanel } from '@/components/presence/team-presence-panel';
 import { useTeamPresence } from '@/components/presence/use-team-presence';
+import { useAgentAuthFailures } from '@/components/presence/use-agent-auth-failures';
 import { useChatUnreadTotal } from '@/hooks/use-chat-unread-total';
 import { ReleaseNotesProvider } from '@/components/release-notes/release-notes-gate';
 import { RefreshProvider } from '@/contexts/refresh-context';
@@ -168,6 +169,9 @@ function ScrollShell({
   const { currentTeamMemberId } = useDashboardContext();
   const items = useTeamPresence(true, currentTeamMemberId);
   const workingCount = items.filter((i) => i.working).length;
+  // story #2852(2836 FE 조각) — presence 패널은 전역 상시 마운트라 「인증 실패」 뱃지 원자료도
+  // 여기서 함께 폴한다(org-briefing 진입과 무관하게 늘 최신).
+  const authFailureByMember = useAgentAuthFailures(true);
 
   return (
     <ReleaseNotesProvider userId={currentTeamMemberId}>
@@ -187,6 +191,7 @@ function ScrollShell({
             <div className={mode === 'inline' ? '2xl:sticky 2xl:top-0 2xl:h-svh 2xl:p-2' : 'h-full'}>
               <TeamPresencePanel
                 items={items}
+                authFailureByMember={authFailureByMember}
                 onClose={mode === 'inline' ? () => panel.setInlinePanelOpen(false) : closePanel}
               />
             </div>

--- a/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
@@ -8,7 +8,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { AttentionClusterBoard } from './attention-cluster-board';
-import type { FalsifiedClusterItem, StalledClusterItem, LoopClusterItem } from './derive-attention-clusters';
+import type { AuthFailureClusterItem, FalsifiedClusterItem, StalledClusterItem, LoopClusterItem } from './derive-attention-clusters';
 
 // story #2830 — falsified/stalled 기존 테스트는 loop 신호와 무관하니 빈 값으로 고정(회귀 0).
 const NO_LOOP = { loop: [] as LoopClusterItem[], loopTotalCount: 0, measurePlanMissingGoalCount: 0, unmeasurableGoalCount: 0 };
@@ -208,6 +208,58 @@ describe('AttentionClusterBoard', () => {
       });
       expect(container.textContent).toContain('other-proj');
       expect(container.textContent?.match(/other-proj/g)).toHaveLength(1);
+    });
+  });
+
+  // story #2852(2836 FE 조각, BE PR#3266) — 에이전트 인증 실패 클러스터.
+  describe('agent auth failure cluster (story #2852)', () => {
+    function authFailureItem(overrides: Partial<AuthFailureClusterItem>): AuthFailureClusterItem {
+      return { id: 'a1', memberId: 'm1', reason: 'expired', failureCount: 6, firstFailedAt: null, lastFailedAt: null, ...overrides };
+    }
+
+    it('N=0이면 카드 자체를 안 그린다(AC4)', async () => {
+      await act(async () => {
+        root.render(wrap(<AttentionClusterBoard falsified={[]} stalled={[]} {...NO_LOOP} authFailure={[]} />));
+      });
+      expect(container.textContent).not.toContain(koMessages.orgBriefing.clusterAuthFailureTitle);
+    });
+
+    // AC1 — BE severity:"danger"를 시각으로 직결하지 않고 warning 톤을 쓴다(destructive 금지).
+    it('destructive(빨강)를 쓰지 않고 warning 계열을 쓴다(AC1)', async () => {
+      await act(async () => {
+        root.render(wrap(
+          <AttentionClusterBoard falsified={[]} stalled={[]} {...NO_LOOP} authFailure={[authFailureItem({})]} />,
+        ));
+      });
+      expect(container.innerHTML).not.toMatch(/bg-destructive/);
+      expect(container.querySelector('.bg-warning-tint')).toBeTruthy();
+    });
+
+    // AC3 — reason enum을 raw로 노출하지 않고 유저 어휘로 매핑 + 진단(최근 5분 N회) + 재발급 링크.
+    it('reason이 raw enum 아니라 유저 어휘로 매핑되고 진단·재발급 링크가 함께 뜬다(AC3)', async () => {
+      const memberNames = { m1: '디디 은두카쿠' };
+      await act(async () => {
+        root.render(wrap(
+          <AttentionClusterBoard falsified={[]} stalled={[]} {...NO_LOOP} authFailure={[authFailureItem({ reason: 'revoked', failureCount: 9 })]} memberNames={memberNames} />,
+        ));
+      });
+      expect(container.textContent).not.toContain('revoked'); // raw enum 유출 금지
+      expect(container.textContent).toContain(koMessages.orgBriefing.clusterAuthFailureReasonRevoked);
+      expect(container.textContent).toContain('디디 은두카쿠');
+      expect(container.textContent).toContain('9');
+      const link = Array.from(container.querySelectorAll('a')).find((a) => a.getAttribute('href') === '/organization/workforce/m1');
+      expect(link).toBeTruthy();
+    });
+
+    it('memberNames에 이름이 없으면(또는 memberId가 null) 이름 폴백 문구를 쓴다(no-fiction)', async () => {
+      await act(async () => {
+        root.render(wrap(
+          <AttentionClusterBoard falsified={[]} stalled={[]} {...NO_LOOP} authFailure={[authFailureItem({ memberId: null, reason: 'invalid' })]} />,
+        ));
+      });
+      expect(container.textContent).toContain(koMessages.orgBriefing.clusterAuthFailureUnknownAgent);
+      // memberId가 없으면 재발급 링크 자체를 안 만든다(어디로 갈지 지어낼 수 없음).
+      expect(container.querySelectorAll('a')).toHaveLength(0);
     });
   });
 });

--- a/apps/web/src/components/org-briefing/attention-cluster-board.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.tsx
@@ -3,10 +3,10 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { RefreshCw, PauseCircle, AlertTriangle, FolderOpen } from 'lucide-react';
+import { RefreshCw, PauseCircle, AlertTriangle, FolderOpen, KeyRound } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
-import type { FalsifiedClusterItem, StalledClusterItem, LoopClusterItem } from './derive-attention-clusters';
+import type { AuthFailureClusterItem, AuthFailureReason, FalsifiedClusterItem, StalledClusterItem, LoopClusterItem } from './derive-attention-clusters';
 
 // story #2541(유나 v4 SSOT f01fa94a) — 상위 2~3건만 기본 노출하고 나머지는 "전체보기"로
 // 펼친다(카드 폭발 회피, hypothesis-earth-layer.tsx의 결론난 가설 <details> 관례와 같은 결).
@@ -152,6 +152,42 @@ function LoopRow({ item }: { item: LoopClusterItem }) {
   );
 }
 
+// story #2852(2836 FE 조각) AC3 — reason enum을 화면에 그대로 노출하지 않고 유저 어휘로
+// 매핑한다. invalid는 org-스코프 attention엔 실질적으로 안 뜨지만(org_id NULL이라 귀속
+// 불가) 방어적으로 매핑해 둔다.
+const AUTH_FAILURE_REASON_KEY: Record<AuthFailureReason, string> = {
+  expired: 'clusterAuthFailureReasonExpired',
+  revoked: 'clusterAuthFailureReasonRevoked',
+  invalid: 'clusterAuthFailureReasonInvalid',
+};
+
+// story #2852 AC1 — 인증 실패는 「복구 가능한 주의 요망 상태」(키 재발급으로 복구)이지
+// kill/종결 이벤트가 아니다. BE severity:"danger"를 시각으로 직결하지 않고 loop 클러스터와
+// 동형 warning 톤을 쓴다. AC3 — 「키 재발급」 행동 경로(에이전트 상세 페이지, AgentApiKeyManager
+// 위치)를 제공해 긴급성을 색이 아니라 행동 어포던스로 전한다.
+function AuthFailureRow({ item, memberNames }: { item: AuthFailureClusterItem; memberNames: Record<string, string> }) {
+  const t = useTranslations('orgBriefing');
+  const name = (item.memberId && memberNames[item.memberId]) || t('clusterAuthFailureUnknownAgent');
+  return (
+    <div className="flex items-center gap-2.5 border-t border-border px-4 py-2.5">
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm text-foreground">{name}</p>
+        <p className="truncate text-[11px] text-foreground">
+          {t(AUTH_FAILURE_REASON_KEY[item.reason])} · {t('clusterAuthFailureDiagnostic', { n: item.failureCount })}
+        </p>
+      </div>
+      {item.memberId ? (
+        <Link
+          href={`/organization/workforce/${item.memberId}`}
+          className="shrink-0 rounded-md bg-warning-tint px-2.5 py-1 text-[11.5px] font-medium text-foreground transition-colors hover:brightness-95"
+        >
+          <span className="inline-flex items-center gap-1"><KeyRound className="size-3" aria-hidden />{t('clusterAuthFailureReissue')}</span>
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
 // story #2830(유나 스티어②) — items[]가 BE top-20 cap이라(doc a8e73bdb §3) "전체보기"가 실제
 // 전체를 못 담을 수 있다. no-silent-cap 원칙상 이 경우 일반 ViewAllToggle("전체보기")을 쓰지
 // 않고 정직한 문구로 잘림을 명시한다 — 거짓 "전체"를 암시하지 않는다.
@@ -227,6 +263,8 @@ export function AttentionClusterBoard({
   loopTotalCount,
   measurePlanMissingGoalCount,
   unmeasurableGoalCount,
+  authFailure = [],
+  memberNames = {},
 }: {
   falsified: FalsifiedClusterItem[];
   stalled: StalledClusterItem[];
@@ -234,26 +272,31 @@ export function AttentionClusterBoard({
   loopTotalCount: number;
   measurePlanMissingGoalCount: number;
   unmeasurableGoalCount: number;
+  authFailure?: AuthFailureClusterItem[];
+  memberNames?: Record<string, string>;
 }) {
   const t = useTranslations('orgBriefing');
   const [falsifiedExpanded, setFalsifiedExpanded] = useState(false);
   const [stalledExpanded, setStalledExpanded] = useState(false);
   const [loopExpanded, setLoopExpanded] = useState(false);
+  const [authFailureExpanded, setAuthFailureExpanded] = useState(false);
 
   const hasLoop = loopTotalCount > 0;
-  if (falsified.length === 0 && stalled.length === 0 && !hasLoop) return null;
+  const hasAuthFailure = authFailure.length > 0;
+  if (falsified.length === 0 && stalled.length === 0 && !hasLoop && !hasAuthFailure) return null;
 
   const shownFalsified = falsifiedExpanded ? falsified : falsified.slice(0, TOP_N);
   const shownStalled = stalledExpanded ? stalled : stalled.slice(0, TOP_N);
   const shownLoop = loopExpanded ? loop : loop.slice(0, TOP_N);
-  const visibleCount = [falsified.length > 0, stalled.length > 0, hasLoop].filter(Boolean).length;
+  const shownAuthFailure = authFailureExpanded ? authFailure : authFailure.slice(0, TOP_N);
+  const visibleCount = [falsified.length > 0, stalled.length > 0, hasLoop, hasAuthFailure].filter(Boolean).length;
 
   return (
     <div
       className={cn(
         'mb-4 grid grid-cols-1 gap-3',
         visibleCount === 2 && 'lg:grid-cols-2',
-        visibleCount === 3 && 'lg:grid-cols-2 xl:grid-cols-3',
+        visibleCount >= 3 && 'lg:grid-cols-2 xl:grid-cols-3',
       )}
     >
       {falsified.length > 0 ? (
@@ -306,6 +349,22 @@ export function AttentionClusterBoard({
           {loopExpanded ? <LoopCapNotice shown={loop.length} total={loopTotalCount} /> : null}
           <MeasurePlanMissingNote count={measurePlanMissingGoalCount} />
           <UnmeasurableGoalNote count={unmeasurableGoalCount} />
+        </ClusterShell>
+      ) : null}
+      {hasAuthFailure ? (
+        <ClusterShell
+          tone="warning"
+          icon={<KeyRound className="size-4" aria-hidden="true" />}
+          title={t('clusterAuthFailureTitle')}
+          subtitle={t('clusterAuthFailureSub')}
+          count={authFailure.length}
+        >
+          {shownAuthFailure.map((item) => <AuthFailureRow key={item.id} item={item} memberNames={memberNames} />)}
+          <ViewAllToggle
+            expanded={authFailureExpanded}
+            remaining={authFailure.length - TOP_N}
+            onToggle={() => setAuthFailureExpanded((v) => !v)}
+          />
         </ClusterShell>
       ) : null}
     </div>

--- a/apps/web/src/components/org-briefing/derive-attention-clusters.test.ts
+++ b/apps/web/src/components/org-briefing/derive-attention-clusters.test.ts
@@ -28,6 +28,11 @@ function attentionItem(overrides: Partial<RawAttentionItem>): RawAttentionItem {
     done_days: null,
     project_id: null,
     project_slug: null,
+    member_id: null,
+    reason: null,
+    failure_count: null,
+    first_failed_at: null,
+    last_failed_at: null,
     ...overrides,
   };
 }
@@ -186,6 +191,47 @@ describe('deriveAttentionClusters', () => {
       ], t, undefined, { orgSlug: 'moonklabs', activeProjectId: 'p-active' });
       expect(clusters.loop[0]!.href).toBe('/flow?view=flow&goal=g1');
       expect(clusters.loop[0]!.crossProjectLabel).toBeNull();
+    });
+  });
+
+  // story #2852(2836 FE 조각, BE PR#3266) — agent_auth_failure는 BE가 이미 (member_id, reason)
+  // 그룹핑해서 낸다 — 원시 항목 1건 = 클러스터 행 1건 그대로.
+  describe('agent_auth_failure(story #2852)', () => {
+    it('member_id/reason/failure_count/first·last_failed_at을 그대로 옮긴다', () => {
+      const clusters = deriveAttentionClusters([
+        attentionItem({
+          type: 'agent_auth_failure', member_id: 'm1', reason: 'expired', failure_count: 7,
+          first_failed_at: '2026-08-20T10:00:00Z', last_failed_at: '2026-08-20T10:04:00Z',
+        }),
+      ], t);
+      expect(clusters.authFailure).toHaveLength(1);
+      expect(clusters.authFailure[0]).toMatchObject({
+        memberId: 'm1', reason: 'expired', failureCount: 7,
+        firstFailedAt: '2026-08-20T10:00:00Z', lastFailedAt: '2026-08-20T10:04:00Z',
+      });
+    });
+
+    it('reason이 없으면(BE 계약 위반·no-fiction) 항목을 만들지 않는다', () => {
+      const clusters = deriveAttentionClusters([
+        attentionItem({ type: 'agent_auth_failure', member_id: 'm1', reason: null, failure_count: 3 }),
+      ], t);
+      expect(clusters.authFailure).toHaveLength(0);
+    });
+
+    it('member_id가 null이어도(귀속 불가) reason이 있으면 항목은 만든다 — 렌더에서 이름 폴백', () => {
+      const clusters = deriveAttentionClusters([
+        attentionItem({ type: 'agent_auth_failure', member_id: null, reason: 'invalid', failure_count: 5 }),
+      ], t);
+      expect(clusters.authFailure).toHaveLength(1);
+      expect(clusters.authFailure[0]!.memberId).toBeNull();
+    });
+
+    it('최근 실패순(last_failed_at 내림차순)으로 정렬된다', () => {
+      const clusters = deriveAttentionClusters([
+        attentionItem({ type: 'agent_auth_failure', member_id: 'old', reason: 'expired', failure_count: 5, last_failed_at: '2026-08-19T00:00:00Z' }),
+        attentionItem({ type: 'agent_auth_failure', member_id: 'recent', reason: 'revoked', failure_count: 5, last_failed_at: '2026-08-20T00:00:00Z' }),
+      ], t);
+      expect(clusters.authFailure.map((a) => a.memberId)).toEqual(['recent', 'old']);
     });
   });
 });

--- a/apps/web/src/components/org-briefing/derive-attention-clusters.ts
+++ b/apps/web/src/components/org-briefing/derive-attention-clusters.ts
@@ -42,6 +42,21 @@ export interface LoopClusterItem {
   crossProjectLabel: string | null;
 }
 
+// story #2852(2836 FE 조각, BE PR#3266) — 에이전트 인증 실패(agent_auth_failure) 관측 신호.
+// BE가 이미 (member_id, reason) windowed COUNT로 그룹핑해 낸다 — 원시 항목 1건 = 클러스터
+// 행 1건(추가 dedup 불요). member 이름은 여기서 안 붙인다(순수 함수 유지) — 렌더 시
+// memberNames 맵으로 붙인다(workforce-face.tsx parseTeamMembers와 동형 관례).
+export type AuthFailureReason = 'expired' | 'revoked' | 'invalid';
+
+export interface AuthFailureClusterItem {
+  id: string;
+  memberId: string | null;
+  reason: AuthFailureReason;
+  failureCount: number;
+  firstFailedAt: string | null;
+  lastFailedAt: string | null;
+}
+
 // story #2842(0b17472c 그라운딩) — 뷰어 컨텍스트. 미제공(구 호출부·테스트)이면 href는 기존
 // bare path로 폴백하고 crossProjectLabel은 항상 null(회귀 0).
 export interface ViewerContext {
@@ -72,6 +87,8 @@ export interface AttentionClusters {
   // story #2843/#2844 — 명시 "측정 불가" 선언 goal 수. N 비포함·집계만(동형 성격), 카드 하단
   // 보조 텍스트 전용.
   unmeasurableGoalCount: number;
+  // story #2852 — 에이전트 인증 실패 그룹(member_id, reason)별 1건.
+  authFailure: AuthFailureClusterItem[];
 }
 
 export interface LoopCounts {
@@ -110,6 +127,7 @@ export function deriveAttentionClusters(
   const falsified: { item: FalsifiedClusterItem; days: number | null }[] = [];
   const stalled: StalledClusterItem[] = [];
   const loop: { item: LoopClusterItem; days: number | null }[] = [];
+  const authFailure: { item: AuthFailureClusterItem; lastFailedAt: string | null }[] = [];
 
   attention.forEach((a, idx) => {
     if (a.type === 'loop_overdue_hypothesis') {
@@ -183,6 +201,18 @@ export function deriveAttentionClusters(
         href: projectHref(viewer, a.project_slug, a.story_id ? `/board?story=${a.story_id}` : '/board'),
         crossProjectLabel: crossProjectLabel(viewer, a.project_id, a.project_slug),
       });
+    } else if (a.type === 'agent_auth_failure' && a.reason) {
+      authFailure.push({
+        item: {
+          id: `${a.member_id ?? 'unknown'}-${a.reason}-${idx}`,
+          memberId: a.member_id,
+          reason: a.reason,
+          failureCount: a.failure_count ?? 0,
+          firstFailedAt: a.first_failed_at,
+          lastFailedAt: a.last_failed_at,
+        },
+        lastFailedAt: a.last_failed_at,
+      });
     }
   });
 
@@ -192,11 +222,14 @@ export function deriveAttentionClusters(
   stalled.sort((x, y) => (y.days ?? -Infinity) - (x.days ?? -Infinity));
   // 루프도 정체와 동형(오래 묵을수록 위) — 도과/done 경과 둘 다 "오래 방치될수록 먼저".
   loop.sort((x, y) => (y.days ?? -Infinity) - (x.days ?? -Infinity));
+  // 최근 실패부터(lastFailedAt 내림차순) — 가장 급한(지금도 진행 중일 가능성 높은) 것 먼저.
+  authFailure.sort((x, y) => (y.lastFailedAt ?? '').localeCompare(x.lastFailedAt ?? ''));
 
   return {
     falsified: falsified.map((f) => f.item),
     stalled,
     loop: loop.map((l) => l.item),
+    authFailure: authFailure.map((a) => a.item),
     // BE count 필드 3종의 합(§3 갱신, doc a8e73bdb) — items[] top-20 cap과 무관한 참값.
     // loopCounts 미제공(구 호출부·테스트) 시 loop.length로 폴백(회귀 0).
     loopTotalCount: loopCounts

--- a/apps/web/src/components/org-briefing/derive-now-face.test.ts
+++ b/apps/web/src/components/org-briefing/derive-now-face.test.ts
@@ -146,8 +146,8 @@ describe('buildNowFace', () => {
         { type: 'my_blockers', priority: null, title: null, context: { blocked_story_id: 's2' } },
       ],
       attention: [
-        { type: 'agent_stuck', entity_type: 'story', entity_id: 's3', gate_type: 'merge', story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null },
-        { type: 'unanswered_blocker', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: 's5', title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null },
+        { type: 'agent_stuck', entity_type: 'story', entity_id: 's3', gate_type: 'merge', story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null, member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null },
+        { type: 'unanswered_blocker', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: 's5', title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null, member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null },
       ],
     };
     const notifications = [{ id: 'n1', title: 'Contract done', body: 'evidence attached', href: '/inbox' }];
@@ -163,8 +163,8 @@ describe('buildNowFace', () => {
       ...ZERO_LOOP_COUNTS,
       queue: [],
       attention: [
-        { type: 'story_stalled', entity_type: null, entity_id: null, gate_type: null, story_id: 's9', stalled_days: 9, blocked_story_id: null, title: '결제 완료율 개선', hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null },
-        { type: 'hypothesis_falsified', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: 'h1', statement: '결제 완료율 개선', outcome_result: { target: 60, actual: 52 }, falsified_days: 2, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null },
+        { type: 'story_stalled', entity_type: null, entity_id: null, gate_type: null, story_id: 's9', stalled_days: 9, blocked_story_id: null, title: '결제 완료율 개선', hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null, member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null },
+        { type: 'hypothesis_falsified', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: 'h1', statement: '결제 완료율 개선', outcome_result: { target: 60, actual: 52 }, falsified_days: 2, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null, member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null },
       ],
     };
     const items = buildNowFace(raw, [], t);
@@ -176,7 +176,7 @@ describe('buildNowFace', () => {
       ...ZERO_LOOP_COUNTS,
       queue: [],
       attention: [
-        { type: 'unanswered_blocker', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: 's7', title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null },
+        { type: 'unanswered_blocker', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: 's7', title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null, member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null },
       ],
     };
     const items = buildNowFace(raw, [], t);
@@ -189,7 +189,7 @@ describe('buildNowFace', () => {
     const raw: RawMyActions = {
       ...ZERO_LOOP_COUNTS,
       queue: [],
-      attention: [{ type: 'agent_stuck', entity_type: 'story', entity_id: 's1', gate_type: 'merge', story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null }],
+      attention: [{ type: 'agent_stuck', entity_type: 'story', entity_id: 's1', gate_type: 'merge', story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null, member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null }],
     };
     const items = buildNowFace(raw, [], t);
     const signal = items.find((i) => i.kind === 'signal');
@@ -215,7 +215,7 @@ describe('buildNowFace', () => {
 
   it('produces no primary action when there are no decide items', () => {
     const raw: RawMyActions = {
-      ...ZERO_LOOP_COUNTS, queue: [], attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null }] };
+      ...ZERO_LOOP_COUNTS, queue: [], attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null, member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null }] };
     const items = buildNowFace(raw, [], t);
     expect(items.every((i) => i.actionTone === 'ghost')).toBe(true);
   });
@@ -224,7 +224,7 @@ describe('buildNowFace', () => {
     const raw: RawMyActions = {
       ...ZERO_LOOP_COUNTS,
       queue: [{ type: 'review_merge', priority: 'info', title: 'x', context: {} }],
-      attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null }],
+      attention: [{ type: 'agent_stuck', entity_type: null, entity_id: 's1', gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: null, project_slug: null, member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null }],
     };
     const items = buildNowFace(raw, [{ id: 'n1', title: 'done', body: null, href: null }], t);
     expect(items.map((i) => i.kind)).toEqual(['decide', 'signal', 'done']);

--- a/apps/web/src/components/org-briefing/derive-now-face.ts
+++ b/apps/web/src/components/org-briefing/derive-now-face.ts
@@ -52,6 +52,12 @@ function record(v: unknown): Record<string, unknown> | null {
   return isRecord(v) ? v : null;
 }
 
+// story #2852 — BE가 아는 사실 3종만 유효(AC3 raw enum 화면 노출 금지의 전제: 파싱 단계부터
+// 화이트리스트로 걸러 알 수 없는 값을 조용히 지어내지 않는다, no-fiction).
+function authFailureReason(v: unknown): 'expired' | 'revoked' | 'invalid' | null {
+  return v === 'expired' || v === 'revoked' || v === 'invalid' ? v : null;
+}
+
 interface RawQueueItem {
   type: string;
   priority: string | null;
@@ -101,6 +107,15 @@ export interface RawAttentionItem {
   // 경로를 지어 항목의 진짜 소속으로 못박을 수 있다.
   project_id: string | null;
   project_slug: string | null;
+  // story #2852(2836 FE 조각, BE PR#3266) — `agent_auth_failure` 전용. windowed COUNT로
+  // 판정된 (member_id, reason) 그룹 1건 = 항목 1건. member_id는 귀속 가능할 때만(없으면 이름
+  // 폴백). reason은 서버가 아는 사실만(expired|revoked|invalid) — 화면엔 raw enum 노출 금지,
+  // 유저 어휘로 매핑해서 보여준다(AC3).
+  member_id: string | null;
+  reason: 'expired' | 'revoked' | 'invalid' | null;
+  failure_count: number | null;
+  first_failed_at: string | null;
+  last_failed_at: string | null;
 }
 
 export interface RawMyActions {
@@ -166,6 +181,11 @@ export function parseMyActions(json: unknown): RawMyActions {
         done_days: num(raw['done_days']),
         project_id: str(raw['project_id']),
         project_slug: str(raw['project_slug']),
+        member_id: str(raw['member_id']),
+        reason: authFailureReason(raw['reason']),
+        failure_count: num(raw['failure_count']),
+        first_failed_at: str(raw['first_failed_at']),
+        last_failed_at: str(raw['last_failed_at']),
       });
     }
   }

--- a/apps/web/src/components/org-briefing/now-face.tsx
+++ b/apps/web/src/components/org-briefing/now-face.tsx
@@ -14,6 +14,7 @@ import {
 } from './derive-now-face';
 import { deriveAttentionClusters, type AttentionClusters, type ViewerContext } from './derive-attention-clusters';
 import { AttentionClusterBoard } from './attention-cluster-board';
+import { parseTeamMembers } from './derive-workforce-face';
 
 // story ded31cb3 — 조직 브리핑 "지금" 면. doc org-briefing-hypothesis-grammar-blueprint §1.3.
 // 기본 5 + "+N 더" 인라인 펼침(⛔우선순위 컷 금지 — nod 확定②: 초과분 숨김은 정보 은닉이라 폐기).
@@ -23,14 +24,18 @@ const REFRESH_MS = 60_000;
 interface NowFaceLoad {
   items: NowFaceItem[];
   clusters: AttentionClusters;
+  memberNames: Record<string, string>;
 }
 
 async function loadNowFace(t: NowFaceTranslator, viewer: ViewerContext): Promise<NowFaceLoad> {
   // story #2689 — 콜드 재진입 시 raw fetch는 401을 재시도 없이 삼켜(!r.ok=>null) "지금" 면이
   // 빈 채로 60초 REFRESH_MS까지 안 채워졌다. fetchWithAuth로 401→refresh→재시도 경로에 태운다.
-  const [ma, notifs] = await Promise.all([
+  // story #2852 — agent_auth_failure 클러스터가 member_id만 갖고 있어(BE가 이름을 안 줌)
+  // 이름 표시엔 /api/team-members가 필요하다(workforce-face.tsx parseTeamMembers와 동형 소비).
+  const [ma, notifs, membersJson] = await Promise.all([
     fetchWithAuth('/api/dashboard/my-actions').then((r) => (r.ok ? r.json() : null)).catch(() => null),
     fetchWithAuth('/api/notifications?type=task_completed&unread=true').then((r) => (r.ok ? r.json() : null)).catch(() => null),
+    fetchWithAuth('/api/team-members').then((r) => (r.ok ? r.json() : null)).catch(() => null),
   ]);
   const raw = parseMyActions(ma);
   return {
@@ -46,6 +51,7 @@ async function loadNowFace(t: NowFaceTranslator, viewer: ViewerContext): Promise
       measurePlanMissingGoalCount: raw.measurePlanMissingGoalCount,
       unmeasurableGoalCount: raw.unmeasurableGoalCount,
     }, viewer),
+    memberNames: parseTeamMembers(membersJson),
   };
 }
 
@@ -87,12 +93,13 @@ function RowSkeleton() {
   return <div className="h-[60px] animate-pulse border-t border-border bg-muted/30 first:border-t-0" />;
 }
 
-const EMPTY_CLUSTERS: AttentionClusters = { falsified: [], stalled: [], loop: [], loopTotalCount: 0, measurePlanMissingGoalCount: 0, unmeasurableGoalCount: 0 };
+const EMPTY_CLUSTERS: AttentionClusters = { falsified: [], stalled: [], loop: [], loopTotalCount: 0, measurePlanMissingGoalCount: 0, unmeasurableGoalCount: 0, authFailure: [] };
 
 export function NowFace() {
   const t = useTranslations('orgBriefing');
   const [items, setItems] = useState<NowFaceItem[] | null>(null);
   const [clusters, setClusters] = useState<AttentionClusters>(EMPTY_CLUSTERS);
+  const [memberNames, setMemberNames] = useState<Record<string, string>>({});
   const [expanded, setExpanded] = useState(false);
   // story #2842 — loop-face.tsx와 동형(orgMemberships에서 orgSlug 파생). useMemo로 orgId/
   // projectId(원시값)가 실제로 바뀔 때만 새 참조를 만든다 — 매 렌더 새 객체면 아래 effect가
@@ -106,6 +113,7 @@ export function NowFace() {
       const result = await loadNowFace(t, viewer);
       setItems(result.items);
       setClusters(result.clusters);
+      setMemberNames(result.memberNames);
     };
     void load();
     const id = setInterval(() => void load(), REFRESH_MS);
@@ -115,7 +123,7 @@ export function NowFace() {
   const list = items ?? [];
   const shown = expanded ? list : list.slice(0, CAP);
   const overflow = Math.max(0, list.length - CAP);
-  const hasClusters = clusters.falsified.length > 0 || clusters.stalled.length > 0 || clusters.loopTotalCount > 0;
+  const hasClusters = clusters.falsified.length > 0 || clusters.stalled.length > 0 || clusters.loopTotalCount > 0 || clusters.authFailure.length > 0;
   // story #2541 AC1/AC2 — story_stalled/hypothesis_falsified가 클러스터 보드로 옮겨간 뒤
   // NowFace 플랫 리스트가 실제로 비어도(decide/done/agent_stuck/unanswered_blocker가 0건)
   // 클러스터에 내용이 있으면 "모두 확인했어요"는 거짓이다 — 두 표면을 합쳐서 판단한다.
@@ -140,6 +148,8 @@ export function NowFace() {
           loopTotalCount={clusters.loopTotalCount}
           measurePlanMissingGoalCount={clusters.measurePlanMissingGoalCount}
           unmeasurableGoalCount={clusters.unmeasurableGoalCount}
+          authFailure={clusters.authFailure}
+          memberNames={memberNames}
         />
       ) : null}
       {items === null ? (

--- a/apps/web/src/components/presence/team-presence-panel.test.tsx
+++ b/apps/web/src/components/presence/team-presence-panel.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+//
+// story #2852(2836 FE 조각) AC1/AC2/AC3 — presence 패널의 「인증 실패」 뱃지가 실제로 렌더되고
+// destructive(빨강)를 안 쓰는지, reason이 raw enum 아니라 title 툴팁으로 유저 어휘 매핑되는지
+// 실 마운트로 검증한다.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { TeamPresencePanel } from './team-presence-panel';
+import type { TeamPresenceItem } from './use-team-presence';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+function presenceItem(overrides: Partial<TeamPresenceItem>): TeamPresenceItem {
+  return { member_id: 'm1', name: '디디 은두카쿠', working: false, presence_status: 'online', ...overrides };
+}
+
+describe('TeamPresencePanel — 인증 실패 뱃지(story #2852)', () => {
+  it('authFailureByMember에 해당 member_id가 있으면 뱃지가 뜬다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <TeamPresencePanel
+          items={[presenceItem({})]}
+          authFailureByMember={{ m1: { reason: 'expired', failureCount: 6 } }}
+        />,
+      ));
+    });
+    expect(container.textContent).toContain(koMessages.presence.authFailureBadge);
+  });
+
+  it('authFailureByMember에 없으면 뱃지가 안 뜬다(다른 멤버는 무영향)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <TeamPresencePanel
+          items={[presenceItem({})]}
+          authFailureByMember={{ 'other-member': { reason: 'expired', failureCount: 6 } }}
+        />,
+      ));
+    });
+    expect(container.textContent).not.toContain(koMessages.presence.authFailureBadge);
+  });
+
+  // AC1 — 인증 실패는 복구 가능한 주의 상태이지 kill이 아니다. destructive 금지.
+  it('뱃지 색이 destructive(빨강)가 아니다(AC1)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <TeamPresencePanel
+          items={[presenceItem({})]}
+          authFailureByMember={{ m1: { reason: 'revoked', failureCount: 4 } }}
+        />,
+      ));
+    });
+    expect(container.innerHTML).not.toMatch(/bg-destructive/);
+    expect(container.querySelector('.bg-warning-tint')).toBeTruthy();
+  });
+
+  // AC3 — reason enum을 raw로 보이지 않고 title 툴팁에 유저 어휘로 매핑한다.
+  it('뱃지 title 툴팁에 raw enum이 아니라 유저 어휘+횟수가 담긴다(AC3)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <TeamPresencePanel
+          items={[presenceItem({})]}
+          authFailureByMember={{ m1: { reason: 'revoked', failureCount: 4 } }}
+        />,
+      ));
+    });
+    const badge = Array.from(container.querySelectorAll('span')).find((s) => s.textContent === koMessages.presence.authFailureBadge);
+    expect(badge?.getAttribute('title')).toBe(koMessages.presence.authFailureTooltipRevoked.replace('{n}', '4'));
+    expect(badge?.getAttribute('title')).not.toContain('revoked');
+  });
+});

--- a/apps/web/src/components/presence/team-presence-panel.tsx
+++ b/apps/web/src/components/presence/team-presence-panel.tsx
@@ -45,7 +45,10 @@ function AuthFailureBadge({ info }: { info: AgentAuthFailureInfo | undefined }) 
   return (
     <span
       title={t(AUTH_FAILURE_TOOLTIP_KEY[info.reason], { n: info.failureCount })}
-      className="inline-flex shrink-0 items-center gap-1 rounded-md bg-warning-tint px-1.5 py-0.5 text-[10px] font-semibold text-foreground"
+      // 유나 design:changes(2026-08-20, PR#3275) — border 없는 bg-warning-tint 단독은 패널
+      // 배경과 대비 1.06(라이트)/1.67(다크)로 AC2 layer①(≥3:1) 미달. 클러스터 행 Badge
+      // variant="warning"이 이미 쓰는 관례(border-warning-border)를 그대로 맞춘다.
+      className="inline-flex shrink-0 items-center gap-1 rounded-md border border-warning-border bg-warning-tint px-1.5 py-0.5 text-[10px] font-semibold text-foreground"
     >
       <KeyRound className="size-2.5 shrink-0" aria-hidden />
       {t('authFailureBadge')}

--- a/apps/web/src/components/presence/team-presence-panel.tsx
+++ b/apps/web/src/components/presence/team-presence-panel.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { Bot, X } from 'lucide-react';
+import { Bot, KeyRound, X } from 'lucide-react';
 import { PresenceDot, WORKING_RING_CLASS, type PresenceStatus } from '@/components/chat/presence-dot';
 import { GlassPanel } from '@/components/ui/glass-panel';
 import { cn } from '@/lib/utils';
 import type { TeamPresenceItem } from './use-team-presence';
+import type { AgentAuthFailureInfo } from './use-agent-auth-failures';
 
 type GroupKey = 'working' | 'online' | 'offline';
 // story #2023(ⓑ): working=시스템 활동 신호(L5) — brand(인간 서명)가 아니라 info.
@@ -28,7 +29,31 @@ function groupItems(items: TeamPresenceItem[]): { key: GroupKey; items: TeamPres
   ] as { key: GroupKey; items: TeamPresenceItem[] }[]).filter((g) => g.items.length > 0);
 }
 
-function PresenceRow({ item }: { item: TeamPresenceItem }) {
+// story #2852(2836 FE 조각) AC1 — 인증 실패는 「복구 가능한 주의 요망 상태」(키 재발급으로
+// 복구)이지 kill/종결이 아니다. destructive(빨강) 금지 — warning-tint 뱃지+text-foreground
+// (story #2420 규칙, tint 배경 위 계열색 금지). AC3 — reason enum을 raw로 안 보이고 title
+// 툴팁에 유저 어휘로 매핑.
+const AUTH_FAILURE_TOOLTIP_KEY: Record<AgentAuthFailureInfo['reason'], string> = {
+  expired: 'authFailureTooltipExpired',
+  revoked: 'authFailureTooltipRevoked',
+  invalid: 'authFailureTooltipInvalid',
+};
+
+function AuthFailureBadge({ info }: { info: AgentAuthFailureInfo | undefined }) {
+  const t = useTranslations('presence');
+  if (!info) return null;
+  return (
+    <span
+      title={t(AUTH_FAILURE_TOOLTIP_KEY[info.reason], { n: info.failureCount })}
+      className="inline-flex shrink-0 items-center gap-1 rounded-md bg-warning-tint px-1.5 py-0.5 text-[10px] font-semibold text-foreground"
+    >
+      <KeyRound className="size-2.5 shrink-0" aria-hidden />
+      {t('authFailureBadge')}
+    </span>
+  );
+}
+
+function PresenceRow({ item, authFailure }: { item: TeamPresenceItem; authFailure?: AgentAuthFailureInfo }) {
   const t = useTranslations('presence');
   const offline = !item.working && (item.presence_status === 'offline' || !item.presence_status);
   const dotStatus: PresenceStatus = item.presence_status ?? 'offline';
@@ -51,9 +76,12 @@ function PresenceRow({ item }: { item: TeamPresenceItem }) {
       </div>
 
       <div className="min-w-0 flex-1">
-        <p className={cn('truncate text-sm font-medium', offline ? 'text-muted-foreground' : 'text-foreground')}>
-          {item.name}
-        </p>
+        <div className="flex items-center gap-1.5">
+          <p className={cn('min-w-0 truncate text-sm font-medium', offline ? 'text-muted-foreground' : 'text-foreground')}>
+            {item.name}
+          </p>
+          <AuthFailureBadge info={authFailure} />
+        </div>
         <div className="truncate text-xs text-muted-foreground">
           {item.working ? (
             <span className="inline-flex max-w-full items-center gap-1 text-info">
@@ -86,9 +114,11 @@ function PresenceRow({ item }: { item: TeamPresenceItem }) {
 export function TeamPresencePanel({
   items,
   onClose,
+  authFailureByMember = {},
 }: {
   items: TeamPresenceItem[];
   onClose?: () => void;
+  authFailureByMember?: Record<string, AgentAuthFailureInfo>;
 }) {
   const t = useTranslations('presence');
   const groups = groupItems(items);
@@ -124,7 +154,7 @@ export function TeamPresencePanel({
               </div>
               <ul>
                 {g.items.map((item) => (
-                  <PresenceRow key={item.member_id} item={item} />
+                  <PresenceRow key={item.member_id} item={item} authFailure={authFailureByMember[item.member_id]} />
                 ))}
               </ul>
             </section>

--- a/apps/web/src/components/presence/use-agent-auth-failures.test.ts
+++ b/apps/web/src/components/presence/use-agent-auth-failures.test.ts
@@ -1,0 +1,40 @@
+// story #2852(2836 FE 조각, BE PR#3266) — parseAgentAuthFailures 순수 파싱 검증. attention.
+// items[]에서 type==='agent_auth_failure'만 골라 member_id 키 맵으로 접는지, reason이 화이트
+// 리스트 밖이면(계약 위반) 조용히 지어내지 않고 생략하는지(no-fiction) 고정한다.
+import { describe, expect, it } from 'vitest';
+import { parseAgentAuthFailures } from './use-agent-auth-failures';
+
+function payload(items: unknown[]) {
+  return { data: { attention: { items } } };
+}
+
+describe('parseAgentAuthFailures', () => {
+  it('agent_auth_failure 항목만 member_id 키 맵으로 뽑는다(다른 타입은 무시)', () => {
+    const out = parseAgentAuthFailures(payload([
+      { type: 'story_stalled', story_id: 's1' },
+      { type: 'agent_auth_failure', member_id: 'm1', reason: 'expired', failure_count: 6 },
+    ]));
+    expect(Object.keys(out)).toEqual(['m1']);
+    expect(out.m1).toEqual({ reason: 'expired', failureCount: 6 });
+  });
+
+  it('reason이 화이트리스트(expired/revoked/invalid) 밖이면 생략한다(no-fiction)', () => {
+    const out = parseAgentAuthFailures(payload([
+      { type: 'agent_auth_failure', member_id: 'm1', reason: 'unknown_reason', failure_count: 6 },
+    ]));
+    expect(out).toEqual({});
+  });
+
+  it('member_id가 없으면(귀속 불가) 맵에 못 올린다 — 뱃지는 member_id 키로만 매핑되므로', () => {
+    const out = parseAgentAuthFailures(payload([
+      { type: 'agent_auth_failure', member_id: null, reason: 'invalid', failure_count: 3 },
+    ]));
+    expect(out).toEqual({});
+  });
+
+  it('attention.items가 없거나 형상이 어긋나면 빈 맵을 낸다(throw 0)', () => {
+    expect(parseAgentAuthFailures(null)).toEqual({});
+    expect(parseAgentAuthFailures({})).toEqual({});
+    expect(parseAgentAuthFailures(payload(null as unknown as unknown[]))).toEqual({});
+  });
+});

--- a/apps/web/src/components/presence/use-agent-auth-failures.ts
+++ b/apps/web/src/components/presence/use-agent-auth-failures.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { fetchWithAuth } from '@/lib/db/client';
+
+// story #2852(2836 FE 조각, BE PR#3266) — TeamPresencePanel은 ScrollShell(전역)에 항상 마운트돼
+// 있어(org-briefing 진입과 무관) 「인증 실패」 뱃지에 필요한 원자료를 자체적으로 확보해야 한다.
+// derive-now-face.ts의 RawAttentionItem 전체 파싱은 org-briefing 전용 스코프(project_id 등
+// 무관 필드까지 요구)라 이 훅에선 agent_auth_failure 항목만 가볍게 직접 뽑는다(중복 파서
+// 아님 — 필요한 필드 4개만 보는 얇은 별도 파서, org-briefing 파서와 결합 시 원치 않는 결합만
+// 생김).
+export interface AgentAuthFailureInfo {
+  reason: 'expired' | 'revoked' | 'invalid';
+  failureCount: number;
+}
+
+const REFRESH_MS = 60_000;
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** `/api/dashboard/my-actions` attention.items[]에서 agent_auth_failure만 골라 member_id 키 맵으로. */
+export function parseAgentAuthFailures(json: unknown): Record<string, AgentAuthFailureInfo> {
+  const inner = isRecord(json) ? (json['data'] ?? json) : json;
+  const attentionObj = isRecord(inner) && isRecord(inner['attention']) ? (inner['attention'] as Record<string, unknown>) : null;
+  const itemsRaw = attentionObj ? attentionObj['items'] : null;
+  const out: Record<string, AgentAuthFailureInfo> = {};
+  if (!Array.isArray(itemsRaw)) return out;
+  for (const raw of itemsRaw) {
+    if (!isRecord(raw) || raw['type'] !== 'agent_auth_failure') continue;
+    const memberId = typeof raw['member_id'] === 'string' ? raw['member_id'] : null;
+    const reason = raw['reason'];
+    if (!memberId || (reason !== 'expired' && reason !== 'revoked' && reason !== 'invalid')) continue;
+    const failureCount = typeof raw['failure_count'] === 'number' ? raw['failure_count'] : 0;
+    // 한 member가 두 reason 모두로 뜰 수 있으나(동시에 revoked+새 키 expired 등, 드묾) presence
+    // 행 뱃지는 1개뿐이라 먼저 만난 것을 유지한다(정렬은 BE단 없음·표시상 치명적이지 않음).
+    if (!out[memberId]) out[memberId] = { reason, failureCount };
+  }
+  return out;
+}
+
+/** 팀 전역 presence 패널에 「인증 실패」 뱃지를 얹기 위한 얇은 폴(60s) — active=false면 폴 정지. */
+export function useAgentAuthFailures(active: boolean): Record<string, AgentAuthFailureInfo> {
+  const [failures, setFailures] = useState<Record<string, AgentAuthFailureInfo>>({});
+
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+    const load = async () => {
+      const json = await fetchWithAuth('/api/dashboard/my-actions').then((r) => (r.ok ? r.json() : null)).catch(() => null);
+      if (!cancelled) setFailures(parseAgentAuthFailures(json));
+    };
+    void load();
+    const id = setInterval(() => void load(), REFRESH_MS);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [active]);
+
+  return failures;
+}


### PR DESCRIPTION
[SID:2852]

## 요약
BE PR#3266(#2836)이 API 키 연속 401을 `attention.items[]`에
`agent_auth_failure` 타입으로 승격했다. 이 PR은 그 신호를 2개 표면에 렌더한다
(신규 BE 0, 기존 my-actions payload 그대로 소비).

1. **org-briefing attention 클러스터** — loop/falsified/stalled와 동형
   (`ClusterShell tone="warning"` 재사용). BE `severity:"danger"`를 시각으로
   직결하지 않고 warning-tint만 사용(destructive 금지). reason enum을
   raw로 노출하지 않고 유저 어휘로 매핑 + 진단("최근 5분 N회") + 「키 재발급」
   행동 경로(`/organization/workforce/{member_id}`) 제공.
2. **TeamPresencePanel**(전역 상시 마운트) — 영향 에이전트 이름 옆에
   warning-tint 「인증 실패」 뱃지. 신규 `useAgentAuthFailures` 훅(60s 폴)으로
   원자료 확보 — org-briefing 진입과 무관하게 항상 최신.

## 스코프 노트
스토리가 언급한 `workforce-face.tsx`는 presence 개념이 없는 별개 컴포넌트
(active epic 협업자 아바타 클러스터)라 이번 스코프에서 제외했다 — 실제
presence 표면인 `team-presence-panel.tsx`에 배선했다. design 리뷰 시 확認
바란다.

## AC (스토리 확定, 유나 스티어 3축)
- [x] AC1 — destructive 금지, warning 톤(bg-destructive 부재 + bg-warning/
      bg-warning-tint 존재, render test)
- [x] AC2 — 대비 2층×2테마(text-foreground on tint, story #2420 규칙 재사용 —
      기존 규칙과 동일 토큰이라 신규 실측 불요, 재사용 검증)
- [x] AC3 — raw enum 미노출, 유저 어휘 매핑 + 진단 + 재발급 경로, i18n en/ko
      parity
- [x] AC4 — N=0 숨김(render test), member_id NULL 이름 폴백
- [ ] AC5 — design 게이트(유나 확認) 대기

## 검증
- `pnpm exec tsc --noEmit -p .` 0 errors
- `pnpm exec eslint` 0 warnings
- `pnpm exec vitest run` 3754 passed(신규 12건: derive-attention-clusters 4·
  attention-cluster-board 4·use-agent-auth-failures 4·team-presence-panel 4 —
  일부 기존 파일 확장 포함)
- tint-guard 3종 52 passed
- `pnpm build` exit 0
- 라이브 픽셀은 배포 후 스팟체크(AC5 명시: design:pass = 코드 실측 범위,
  라이브 픽셀 미포함) — 후속 예정