### PR TITLE
[테스트 인프라] 실DB Gate 빌더 _make_gate 3파일 중복 → 공용 헬퍼로 통합

### DIFF
--- a/backend/tests/gate_mock_factory.py
+++ b/backend/tests/gate_mock_factory.py
@@ -27,6 +27,7 @@ import uuid
 from datetime import datetime, timezone
 
 from app.models.gate import Gate
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 def make_gate(**overrides) -> Gate:
@@ -62,3 +63,33 @@ def make_gate(**overrides) -> Gate:
     )
     defaults.update(overrides)
     return Gate(**defaults)
+
+
+async def make_gate_realdb(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    work_item_id: uuid.UUID,
+    *,
+    work_item_type: str = "story",
+    gate_type: str = "merge",
+    status: str = "pending",
+    requires_human: bool = False,
+    evidence_status: str | None = None,
+    **overrides,
+) -> Gate:
+    """story #2851 — `make_gate()`의 실DB 트윈. insert+commit해 영속 Gate를 반환한다.
+
+    test_2303/test_2298/test_2533 각자 독립 중복이던 `_make_gate(...)`를 여기 하나로
+    합쳤다(2837의 순수 객체 팩토리와 이름·시그니처 결을 맞춤 — `make_gate`↔`make_gate_realdb`).
+    `**overrides`로 나머지 Gate 컬럼(neutral_facts·resolver_id 등)도 열어 둔다 — 지금 세
+    파일 중 이 다섯 개(work_item_type/gate_type/status/requires_human/evidence_status)
+    바깥을 쓰는 호출은 없지만, `make_gate()`와 동일하게 스키마에서 구조적으로 못 벗어나게
+    하기 위함(수동 defaults dict 유지 부담 반복 금지)."""
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, work_item_type=work_item_type,
+        gate_type=gate_type, status=status, requires_human=requires_human,
+        evidence_status=evidence_status, **overrides,
+    )
+    session.add(gate)
+    await session.commit()
+    return gate

--- a/backend/tests/test_2298_goals_glance_include_realdb.py
+++ b/backend/tests/test_2298_goals_glance_include_realdb.py
@@ -14,6 +14,8 @@ import uuid
 
 import pytest
 
+from tests.gate_mock_factory import make_gate_realdb
+
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
 pytestmark = [
@@ -101,17 +103,6 @@ async def _make_story(session, org_id, project_id, epic_id, assignee_id=None, st
     session.add(story)
     await session.commit()
     return story
-
-
-async def _make_gate(session, org_id, story_id, status="pending", gate_type="human_review"):
-    from app.models.gate import Gate
-    gate = Gate(
-        id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
-        gate_type=gate_type, status=status,
-    )
-    session.add(gate)
-    await session.commit()
-    return gate
 
 
 def _client_for(app):
@@ -266,7 +257,7 @@ async def test_focal_story_prefers_gate_pending_over_more_recently_created():
                 s, org.id, project.id, goal.id, assignee_id=caller_id,
                 status="in-progress", title="Older, gate-pending",
             )
-            await _make_gate(s, org.id, older_gated.id, status="pending")
+            await make_gate_realdb(s, org.id, older_gated.id, status="pending", gate_type="human_review")
             # 더 나중에 생성 — created_at DESC tiebreak이면 이게 이겨야 하지만 gate가 없다.
             await _make_story(
                 s, org.id, project.id, goal.id, assignee_id=caller_id,

--- a/backend/tests/test_2303_goals_glance_focal_story_fields_realdb.py
+++ b/backend/tests/test_2303_goals_glance_focal_story_fields_realdb.py
@@ -18,6 +18,8 @@ import uuid
 
 import pytest
 
+from tests.gate_mock_factory import make_gate_realdb
+
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
 pytestmark = [
@@ -105,21 +107,6 @@ async def _make_story(session, org_id, project_id, epic_id, assignee_id=None, st
     session.add(story)
     await session.commit()
     return story
-
-
-async def _make_gate(
-    session, org_id, story_id, status="pending", gate_type="human_review",
-    requires_human=False, evidence_status=None,
-):
-    from app.models.gate import Gate
-    gate = Gate(
-        id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
-        gate_type=gate_type, status=status, requires_human=requires_human,
-        evidence_status=evidence_status,
-    )
-    session.add(gate)
-    await session.commit()
-    return gate
 
 
 async def _make_evidence(session, org_id, story_id, created_by, type="url", ref="https://x"):
@@ -296,7 +283,7 @@ async def test_focal_story_auto_verify_maps_merge_gate_evidence_status(evidence_
             )
             # merge gate 자체는 status="approved"(resolved) — pending 아니어도 auto_verify는
             # evidence_status 원자료 그대로다(gate 필드=pending 전용, auto_verify=merge 전용, 별축).
-            await _make_gate(
+            await make_gate_realdb(
                 s, org.id, story.id, status="approved", gate_type="merge",
                 evidence_status=evidence_status,
             )
@@ -325,7 +312,7 @@ async def test_focal_story_gate_carries_type_and_requires_human_not_status():
                 s, org.id, project.id, goal.id, assignee_id=caller_id,
                 status="in-progress", title="Gated",
             )
-            await _make_gate(
+            await make_gate_realdb(
                 s, org.id, story.id, status="pending", gate_type="merge",
                 requires_human=True,
             )
@@ -388,7 +375,7 @@ async def test_focal_story_excludes_fields_the_screen_does_not_read():
                 s, org.id, project.id, goal.id, assignee_id=caller_id,
                 status="in-progress", title="Lean",
             )
-            await _make_gate(
+            await make_gate_realdb(
                 s, org.id, story.id, status="pending", gate_type="human_review",
                 requires_human=True,
             )
@@ -454,11 +441,11 @@ async def test_focal_story_values_match_glance_hero_for_same_story_rich_case():
             await _make_evidence(
                 s, org.id, story.id, created_by=verifier_id, type="gate_approval", ref="approved",
             )
-            await _make_gate(
+            await make_gate_realdb(
                 s, org.id, story.id, status="pending", gate_type="human_review",
                 requires_human=True,
             )
-            await _make_gate(
+            await make_gate_realdb(
                 s, org.id, story.id, status="approved", gate_type="merge",
                 evidence_status="sufficient",
             )

--- a/backend/tests/test_2533_hypothesis_lifecycle_realdb.py
+++ b/backend/tests/test_2533_hypothesis_lifecycle_realdb.py
@@ -26,6 +26,7 @@ from tests.test_1994_backlink_api_realdb import (
     _session_factory,
     _setup_app_human,
 )
+from tests.gate_mock_factory import make_gate_realdb
 from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL, _make_story
 
 pytestmark = [
@@ -85,17 +86,6 @@ async def _link_hypothesis_epic(session, hypothesis_id, epic_id):
     await session.commit()
 
 
-async def _make_gate(session, org_id, work_item_id, status="pending"):
-    from app.models.gate import Gate
-    gate = Gate(
-        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, work_item_type="story",
-        gate_type="merge", status=status,
-    )
-    session.add(gate)
-    await session.commit()
-    return gate
-
-
 async def _make_evidence(session, org_id, work_item_id, created_by):
     from app.models.evidence import Evidence
     ev = Evidence(
@@ -127,7 +117,7 @@ async def test_lifecycle_assembles_goals_stories_and_evidence_realdb():
             hyp = await _make_hypothesis(s, org.id, project.id, caller_id, statement="가설 A")
             await _link_hypothesis_epic(s, hyp.id, goal.id)
             await _link_hypothesis_story(s, hyp.id, story.id)
-            await _make_gate(s, org.id, story.id, status="pending")
+            await make_gate_realdb(s, org.id, story.id, status="pending")
             await _make_evidence(s, org.id, story.id, caller_id)
             await _make_evidence(s, org.id, story.id, caller_id)
 


### PR DESCRIPTION
[SID:2851]

## 요약
test_2303/test_2298/test_2533 세 파일에 각자 독립 중복이던 `_make_gate(...)` 실DB 빌더를 `tests/gate_mock_factory.py::make_gate_realdb()` 하나로 통합. #2837의 순수 객체 `make_gate()`와 이름·시그니처 결을 맞췄다(`make_gate` ↔ `make_gate_realdb`).

## 함정 하나 고쳐서 넘어감
세 파일의 `gate_type` 기본값이 서로 달랐다 — test_2533은 "merge" 하드코딩, test_2298/test_2303은 "human_review" 기본. 공용 함수는 `make_gate()`와 동일하게 "merge"를 기본으로 뒀고, "human_review" 기본값에 암묵 의존하던 유일한 호출부(test_2298 한 곳)는 `gate_type="human_review"`를 명시하도록 고쳐 동작을 그대로 유지했다(처음 통합했을 때 이 자리에서 assertion 실패로 바로 걸렸음).

## 검증
- 3파일 로컬 실PG 재실행: 리팩터 전/후 동일 pass/fail 집합.
- test_2533의 기존 6건 실패는 `app.core.database` 전역 엔진 관련 기존 인프라 결함(이 변경과 무관 — `git stash`로 리팩터 전 상태에서도 동일하게 재현됨을 대조 확認, 이 PR 스코프 밖이라 손 안 댐).

## Test plan
- [x] 3파일 로컬 실PG green(기존 인프라 실패 6건 제외, 리팩터 전/후 동일)
- [x] gate_type 기본값 회귀 발견+수정
- [ ] CI green (대기)