### PR TITLE
[loop-closure·P2-B] 측정 판정 초안=에이전트·확定=휴먼 — hypothesis_outcome_confirm 게이트

### DIFF
--- a/backend/app/routers/hypotheses.py
+++ b/backend/app/routers/hypotheses.py
@@ -30,6 +30,7 @@ from app.schemas.hypothesis import (
     HypothesisGuidedCreate,
     HypothesisLifecycleResponse,
     HypothesisLinkRequest,
+    HypothesisOutcomeDraftRequest,
     HypothesisResponse,
     HypothesisTransition,
     HypothesisUnlinkRequest,
@@ -80,14 +81,19 @@ def _raise(err: svc.HypothesisServiceError) -> None:
     )
 
 
-def _assert_active_authorized(caller: ResolvedMember, owner_member_id: uuid.UUID) -> None:
-    """§3.1.7 — 'active' 전이는 owner 휴먼 또는 org owner/admin만."""
+def _assert_active_authorized(caller: ResolvedMember, owner_member_id: uuid.UUID, target: str = "active") -> None:
+    """§3.1.7 — 'active' 전이는 owner 휴먼 또는 org owner/admin만.
+
+    story #2857: verified/falsified도 같은 규칙 재사용(함수명은 이력 보존을 위해 유지 —
+    첫 도입 대상이 active라 붙은 이름, 내부는 target 무관 owner/admin 판정 하나뿐). 기존
+    "ACTIVE_TRANSITION_FORBIDDEN" 에러 코드는 target=="active"에 한해 그대로 보존
+    (test_hypotheses_router.py가 이미 이 정확한 문자열을 고정 — 무회귀)."""
     if caller.id == owner_member_id or caller.role in _ADMIN_ROLES:
         return
+    code = "ACTIVE_TRANSITION_FORBIDDEN" if target == "active" else "TRANSITION_FORBIDDEN"
     raise HTTPException(
         status_code=403,
-        detail={"code": "ACTIVE_TRANSITION_FORBIDDEN",
-                "message": "active 전이는 owner 또는 org owner/admin만 가능합니다."},
+        detail={"code": code, "message": f"{target} 전이는 owner 또는 org owner/admin만 가능합니다."},
     )
 
 
@@ -249,7 +255,12 @@ async def transition_hypothesis(
     await _assert_hypothesis_project_access(session, uuid.UUID(auth.user_id), org_id, hypothesis_id)
     caller = await resolve_member(auth, org_id, session)
     # §3.1.7 active 전이 권한은 라우터에서 보강(owner 휴먼 또는 org admin/owner).
-    if body.status == "active":
+    # story #2857 AC(부수 발견 처방, 페드루 PO 판정 2026-08-20) — verified/falsified 직통로가
+    # 지금까지 human-only 가드 없이 열려 있었다(2038 시대 「근거 강제된 누구나 종결」 의도적
+    # 설계였으나, 2845-B의 «확定=휴먼» 게이트 계약과 함께 도입하지 않으면 게이트를 거치지 않고
+    # 우회할 수 있었다). 게이트 신설과 이 차단을 한 PR에서 원자적으로 — 에이전트의 유일한 길은
+    # 초안 게이트(hypothesis_outcome_confirm), 사람의 길은 이 직접 transition 그대로 유지.
+    if body.status in ("active", "verified", "falsified"):
         repo = HypothesisRepository(session, org_id)
         hyp = await repo.get(hypothesis_id)
         if hyp is None:
@@ -257,11 +268,44 @@ async def transition_hypothesis(
                 status_code=404,
                 detail={"code": "HYPOTHESIS_NOT_FOUND", "message": "가설을 찾을 수 없습니다."},
             )
-        _assert_active_authorized(caller, hyp.owner_member_id)
+        _assert_active_authorized(caller, hyp.owner_member_id, target=body.status)
     try:
         return await svc.transition_hypothesis(session, org_id, caller, hypothesis_id, body)
     except svc.HypothesisServiceError as err:
         _raise(err)
+
+
+@router.post("/{hypothesis_id}/outcome-draft")
+async def draft_hypothesis_outcome_endpoint(
+    hypothesis_id: uuid.UUID,
+    body: HypothesisOutcomeDraftRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """story #2857 — 측정 판정 초안 제출(agent/human 둘 다 호출 가능·확定은 게이트 승인만).
+
+    새 authz 0 — 게이트가 항상 human-only pending(_ALWAYS_MANUAL_GATE_TYPES)이라 이
+    엔드포인트 자체는 project 접근권만 요구한다(제출≠확定, 확定 축은 transition_gate가 막는다).
+    """
+    await _assert_hypothesis_project_access(session, uuid.UUID(auth.user_id), org_id, hypothesis_id)
+    caller = await resolve_member(auth, org_id, session)
+    from app.services.hypothesis_outcome_confirm import (
+        HypothesisOutcomeConfirmError,
+        draft_hypothesis_outcome,
+    )
+
+    try:
+        gate = await draft_hypothesis_outcome(
+            session, org_id, caller.id, hypothesis_id,
+            draft_target=body.draft_target, draft_actual=body.draft_actual,
+            draft_reason=body.draft_reason,
+        )
+        await session.commit()
+    except HypothesisOutcomeConfirmError as err:
+        _status = {"HYPOTHESIS_NOT_FOUND": 404}.get(err.code, 422)
+        raise HTTPException(status_code=_status, detail={"code": err.code, "message": err.message})
+    return {"gate_id": str(gate.id), "gate_status": gate.status}
 
 
 @router.post("/{hypothesis_id}/links", response_model=HypothesisResponse)

--- a/backend/app/schemas/hypothesis.py
+++ b/backend/app/schemas/hypothesis.py
@@ -91,6 +91,13 @@ class HypothesisTransition(BaseModel):
     outcome_result: dict[str, Any] | None = None
 
 
+class HypothesisOutcomeDraftRequest(BaseModel):
+    """story #2857 — 측정 판정 초안(에이전트 제출). 확定은 게이트 승인(휴먼)만 반영한다."""
+    draft_target: str
+    draft_actual: Any
+    draft_reason: str
+
+
 class HypothesisLinkRequest(BaseModel):
     epic_ids: list[uuid.UUID] = []
     story_ids: list[uuid.UUID] = []

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -310,8 +310,13 @@ async def resolve_work_item_project_id(
 # 'loop_decision'(E-LOOP-LEDGER S5): variant 선택도 동일 이유로 항상 human pending — GATE_TYPES에도
 # 미등록(doc_approval과 동일 선례. org gate override 설정 대상에서 제외=애초에 자동화 불가 명시).
 # 'artifact_canonicalize'(E-CANVAS C4-S8): 정본화=계약(§1) — org auto posture 무관 항상 HITL.
+# 'hypothesis_outcome_confirm'(story #2857): 측정 판정 초안=에이전트·확定=휴먼 계약 그 자체가
+# 존재 이유라 org posture 무관 항상 HITL(agent_decision_request와 동형 근거).
 _ALWAYS_MANUAL_GATE_TYPES: frozenset[str] = frozenset(
-    {"doc_approval", "loop_decision", "artifact_canonicalize", "agent_decision_request"}
+    {
+        "doc_approval", "loop_decision", "artifact_canonicalize", "agent_decision_request",
+        "hypothesis_outcome_confirm",
+    }
 )
 # ⚠️story #2709 — agent_decision_request가 항상 manual(=posture 무관 항상 pending)인 이유:
 # 이 게이트는 "사람의 판단"이 존재 이유인데, org posture가 permissive라고 자동 allow_auto가
@@ -641,6 +646,11 @@ async def transition_gate(
         await _resolve_artifact_canonicalize_gate(session, gate, new_status)
         # HITL crux(story 7726a003) — A2A task INPUT_REQUIRED 복귀. writer 미배선이라 오늘은 no-op.
         await _resume_a2a_task_on_gate_resolve(session, gate, new_status)
+        # story #2857(loop-closure P2-B): 측정 판정 초안=에이전트·확定=휴먼 — approve 시만
+        # hypothesis 실 전이(via_gate=True). 새 gate_type 외 no-op(기존 함수들과 동형 자리).
+        from app.services.hypothesis_outcome_confirm import resolve_hypothesis_outcome_confirm_gate
+
+        await resolve_hypothesis_outcome_confirm_gate(session, gate, new_status, resolver_id)
 
     # E-VERIFY V0-S2(story 3fbd048d): 휴먼 gate 승인 → gate_approval evidence 자동 편입(순수
     # additive — approved+story/task work_item_type 아니면 no-op).

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -490,10 +490,13 @@ async def transition_hypothesis(
             await session.refresh(hyp)
             return await _to_response(repo, hyp)
 
-    # 'active' 확정은 휴먼만(§2.5.2). org admin/owner 검증은 라우터(S3)에서 보강.
-    if target == "active" and caller.type != "human":
+    # 'active'·'verified'·'falsified' 확定은 휴먼만(§2.5.2 + story #2857 AC — 게이트 경유
+    # via_gate=True는 이 서비스를 직호출하는 라우터 authz를 이미 통과한 human resolver라
+    # caller.type이 항상 "human"이므로 이 체크와 자연 정합). org admin/owner 검증은
+    # 라우터(S3/#2857)에서 보강.
+    if target in ("active", "verified", "falsified") and caller.type != "human":
         raise HypothesisServiceError(
-            "HUMAN_CONFIRM_REQUIRED", "active 전이는 휴먼만 가능합니다."
+            "HUMAN_CONFIRM_REQUIRED", f"{target} 전이는 휴먼만 가능합니다."
         )
 
     # story #2038(까심 QA 적출, #2027과 동일 패턴): verified/falsified는 FE(HypothesisResolveDialog)

--- a/backend/app/services/hypothesis_outcome_confirm.py
+++ b/backend/app/services/hypothesis_outcome_confirm.py
@@ -1,0 +1,133 @@
+"""story #2857(loop-closure P2-B) — 측정 판정 초안=에이전트·확定=휴먼.
+
+metric_definition의 source가 자동채점 대상(ga4/internal_ops)이 아닌 hypothesis(§2845
+큐가 표면화하는 measuring 축)를 위한 흐름: 에이전트가 측정을 실행해 판정 초안을 만들고,
+사람이 기존 게이트 판에서 승인해야 실제로 hypothesis가 verified/falsified/killed로
+전이한다("판정 기계+휴먼 승인" — merge/doc gate와 동형 구조, 새 authz 발명 0).
+
+초안 보관소는 Hypothesis에 새 컬럼을 얹지 않고 ``Gate.neutral_facts``를 재사용한다 —
+그 필드가 이미 "에이전트가 계산한 사실, 사람 판정 대기"라는 정확히 이 목적으로 설계돼
+있다(create_gate() 전역 chokepoint 그대로). ``Hypothesis.draft_metadata``는 다른 개념
+(가설 «문장» 저작 시 LLM 초안 추적, hypothesis.py:708)이라 재사용하면 confound된다 —
+페드루 PO 판정(2026-08-20)으로 배제 확定.
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate
+from app.models.hypothesis import Hypothesis, is_valid_transition
+
+HYPOTHESIS_OUTCOME_CONFIRM_GATE_TYPE = "hypothesis_outcome_confirm"
+
+# measuring에서 도달 가능한 해소 상태만 초안 대상(§2.5 상태기계 그대로 — 새 전이 발명 0).
+_DRAFTABLE_TARGETS = frozenset({"verified", "falsified", "killed"})
+
+
+class HypothesisOutcomeConfirmError(Exception):
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+async def draft_hypothesis_outcome(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    member_id: uuid.UUID,
+    hypothesis_id: uuid.UUID,
+    *,
+    draft_target: str,
+    draft_actual: Any,
+    draft_reason: str,
+) -> Gate:
+    """에이전트가 측정 판정 초안을 제출 — Gate row(항상 pending·human-only 승인)로 대기.
+
+    create_gate()의 멱등 chokepoint를 그대로 쓴다(같은 hypothesis에 재제출해도 새 gate
+    난립 없음 — 기존 pending/approved/rejected 게이트가 있으면 그 규칙 그대로 따른다).
+    role_id — merge 게이트처럼 자연 참여-역할이 없어 doc.py의 기본 결재 role 폴백 패턴을
+    그대로 재사용(_default_role_id, 없으면 hypothesis_id를 placeholder로 — FK 비강제라 무해,
+    doc.py:121과 동형).
+    """
+    if draft_target not in _DRAFTABLE_TARGETS:
+        raise HypothesisOutcomeConfirmError(
+            "INVALID_DRAFT_TARGET", f"draft_target은 {sorted(_DRAFTABLE_TARGETS)} 중 하나여야 합니다.",
+        )
+    hyp = (await session.execute(
+        select(Hypothesis).where(Hypothesis.id == hypothesis_id, Hypothesis.org_id == org_id)
+    )).scalar_one_or_none()
+    if hyp is None:
+        raise HypothesisOutcomeConfirmError("HYPOTHESIS_NOT_FOUND", "가설을 찾을 수 없습니다.")
+    if hyp.status != "measuring":
+        raise HypothesisOutcomeConfirmError(
+            "NOT_MEASURING", f"measuring 상태만 판정 초안 대상입니다(현재={hyp.status}).",
+        )
+    if not is_valid_transition(hyp.status, draft_target):
+        raise HypothesisOutcomeConfirmError(
+            "INVALID_HYPOTHESIS_TRANSITION", f"불법 전이: {hyp.status} → {draft_target}",
+        )
+
+    from app.services.gate_service import create_gate
+    from app.services.workflow_line_config import _default_role_id
+
+    role_id = await _default_role_id(session, org_id) or hypothesis_id
+
+    gate = await create_gate(
+        session, org_id, hypothesis_id, "hypothesis", HYPOTHESIS_OUTCOME_CONFIRM_GATE_TYPE,
+        member_id, role_id,
+        neutral_facts={
+            "draft_target": draft_target,
+            "draft_actual": draft_actual,
+            "draft_reason": draft_reason,
+        },
+        project_id=hyp.project_id,
+    )
+    return gate
+
+
+async def resolve_hypothesis_outcome_confirm_gate(
+    session: AsyncSession, gate: Gate, new_status: str, resolver_id: uuid.UUID | None,
+) -> None:
+    """게이트 해소 → hypothesis 실 전이(승인 시만). transition_gate()의 기존 gate_type
+    dispatch 대열(_resolve_doc_gate 등과 동형 자리)에 얹는다 — pending 아니면/타 gate_type
+    이면 no-op.
+
+    caller는 이 게이트 승인 라우터(transition_gate_endpoint)가 이미 human-only로 강제한
+    resolver 그대로(93fc7aeb) — 여기서 재검증하지 않는다(via_gate=True가 그 전제를 명시).
+    """
+    if gate.work_item_type != "hypothesis" or gate.gate_type != HYPOTHESIS_OUTCOME_CONFIRM_GATE_TYPE:
+        return
+    if new_status != "approved":
+        return  # rejected/voided는 그냥 소거 — hypothesis는 measuring 그대로(다시 초안 가능).
+
+    hyp = (await session.execute(
+        select(Hypothesis).where(Hypothesis.id == gate.work_item_id, Hypothesis.org_id == gate.org_id)
+    )).scalar_one_or_none()
+    if hyp is None or hyp.status != "measuring":
+        return  # 멱등 — 이미 다른 경로로 해소됐거나 삭제됨.
+
+    facts = gate.neutral_facts or {}
+    target = facts.get("draft_target")
+    if target not in _DRAFTABLE_TARGETS:
+        return  # 방어(있을 수 없는 상태 — 조용히 no-op, 새 판정 로직 0).
+
+    from app.schemas.hypothesis import HypothesisTransition
+    from app.services.hypothesis import transition_hypothesis
+
+    payload = HypothesisTransition(
+        status=target,
+        outcome_result=(
+            {"actual": facts.get("draft_actual"), "reason": facts.get("draft_reason")}
+            if target in ("verified", "falsified") else None
+        ),
+        note=facts.get("draft_reason") if target == "killed" else None,
+    )
+    # caller — transition_gate_endpoint가 이미 human-only 강제(93fc7aeb) 후 넘어온 resolver.
+    # transition_hypothesis는 caller.id/caller.type만 읽는다(via_gate 경로 전용 최소 duck-type).
+    caller = SimpleNamespace(id=resolver_id, type="human")
+    await transition_hypothesis(session, gate.org_id, caller, hyp.id, payload, via_gate=True)

--- a/backend/tests/test_2857_hypothesis_outcome_confirm_realdb.py
+++ b/backend/tests/test_2857_hypothesis_outcome_confirm_realdb.py
@@ -1,0 +1,224 @@
+"""story #2857(loop-closure P2-B) — 측정 판정 초안=에이전트·확定=휴먼 실PG 검증.
+
+AC 확定(페드루 PO, 2026-08-20):
+  ①Gate.neutral_facts 재사용 + 새 gate_type hypothesis_outcome_confirm(_ALWAYS_MANUAL)
+  ②scorer 경계=source 축(2845-B는 ga4/internal_ops «아닌» 축만)
+  ③기존 게이트 판 재사용 — transition_gate_endpoint가 이미 human-only.
+  ⚠️부수 발견 처방(같은 PR 원자 전환): verified/falsified 직통로 human-only화 +
+    「차단 회귀: 에이전트 키로 verified 직접 호출=403+게이트 경유는 성립」 짝.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_1994_backlink_api_realdb import (
+    _client_for,
+    _make_agent_member,
+    _make_human_member,
+    _make_org,
+    _make_project,
+    _session_factory,
+    _setup_app_agent,
+    _setup_app_human,
+)
+from tests.test_2301_story_body_mentions_realdb import _REAL_DB_URL
+from tests.test_2829_loop_measure_due_realdb import _make_hypothesis
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_direct_verified_call_now_403():
+    """차단 회귀 — 에이전트 키로 verified 직접 호출은 403(부수 발견 처방)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, _ = await _make_human_member(s, org.id, project.id)
+            agent_id = await _make_agent_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, owner_id, status="measuring")
+
+        await _setup_app_agent(app, Session, agent_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/hypotheses/{hyp.id}/transition",
+                json={"status": "verified", "outcome_result": {"actual": 100, "reason": "달성"}},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_owner_direct_verified_call_still_works():
+    """무회귀 — owner 휴먼의 직접 verified 호출은 그대로 성립(사람의 길 유지)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, owner_user_id = await _make_human_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, owner_id, status="measuring")
+
+        await _setup_app_human(app, Session, owner_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/hypotheses/{hyp.id}/transition",
+                json={"status": "verified", "outcome_result": {"actual": 100, "reason": "달성"}},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] == "verified"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_outcome_draft_creates_always_pending_gate():
+    """①③ — 에이전트 초안 제출은 항상 pending gate(org posture 무관, _ALWAYS_MANUAL)."""
+    from app.main import app
+    from app.models.gate import Gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, _ = await _make_human_member(s, org.id, project.id)
+            agent_id = await _make_agent_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, owner_id, status="measuring")
+
+        await _setup_app_agent(app, Session, agent_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/hypotheses/{hyp.id}/outcome-draft",
+                json={"draft_target": "verified", "draft_actual": 42, "draft_reason": "지표 달성 관측"},
+            )
+            assert resp.status_code == 200, resp.text
+            gate_id = uuid.UUID(resp.json()["gate_id"])
+            assert resp.json()["gate_status"] == "pending"
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert gate.gate_type == "hypothesis_outcome_confirm"
+            assert gate.work_item_type == "hypothesis"
+            assert gate.work_item_id == hyp.id
+            assert gate.status == "pending"
+            assert gate.requires_human is True
+            assert gate.neutral_facts == {
+                "draft_target": "verified", "draft_actual": 42, "draft_reason": "지표 달성 관측",
+            }
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_approval_transitions_hypothesis_and_records_human_closer():
+    """②의 반대편 실증 — 초안 gate 승인(휴먼)이 실제로 hypothesis를 verified로 옮기고,
+    closed_by=human(승인자)로 서버가 채운다(클라이언트 위조 불가 계약 그대로 유지)."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.hypothesis import Hypothesis
+    from app.services.gate_service import transition_gate
+    from app.services.hypothesis_outcome_confirm import draft_hypothesis_outcome
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, _ = await _make_human_member(s, org.id, project.id)
+            approver_id, _ = await _make_human_member(s, org.id, project.id)
+            agent_id = await _make_agent_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, owner_id, status="measuring")
+
+            gate = await draft_hypothesis_outcome(
+                s, org.id, agent_id, hyp.id,
+                draft_target="falsified", draft_actual=3, draft_reason="목표 미달 관측",
+            )
+            await s.commit()
+            assert gate.status == "pending"
+
+            approved = await transition_gate(s, org.id, gate.id, "approved", approver_id, None)
+            await s.commit()
+            assert approved.status == "approved"
+
+            refreshed = (await s.execute(
+                select(Hypothesis).where(Hypothesis.id == hyp.id)
+            )).scalar_one()
+            assert refreshed.status == "falsified"
+            assert refreshed.outcome_result == {
+                "actual": 3, "reason": "목표 미달 관측",
+                "closed_by": "human", "closed_by_member_id": str(approver_id),
+            }
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_rejection_leaves_hypothesis_measuring():
+    """②거절 경로 no-op — hypothesis는 measuring 그대로(재초안 가능)."""
+    from app.models.hypothesis import Hypothesis
+    from app.services.gate_service import transition_gate
+    from app.services.hypothesis_outcome_confirm import draft_hypothesis_outcome
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            owner_id, _ = await _make_human_member(s, org.id, project.id)
+            approver_id, _ = await _make_human_member(s, org.id, project.id)
+            agent_id = await _make_agent_member(s, org.id, project.id)
+            hyp = await _make_hypothesis(s, org.id, project.id, owner_id, status="measuring")
+
+            gate = await draft_hypothesis_outcome(
+                s, org.id, agent_id, hyp.id,
+                draft_target="verified", draft_actual=1, draft_reason="근거 약함",
+            )
+            await s.commit()
+
+            await transition_gate(s, org.id, gate.id, "rejected", approver_id, "근거 부족")
+            await s.commit()
+
+            refreshed = (await s.execute(
+                select(Hypothesis).where(Hypothesis.id == hyp.id)
+            )).scalar_one()
+            assert refreshed.status == "measuring"
+            assert refreshed.outcome_result is None
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_hypothesis_service.py
+++ b/backend/tests/test_hypothesis_service.py
@@ -340,14 +340,22 @@ async def test_transition_verified_server_stamps_closed_by_from_human_caller():
 
 
 async def test_transition_verified_ignores_client_declared_closed_by():
-    """⛔ gate 1(오르테가군): agent 자격증명으로 직접 호출해 outcome_result에 closed_by="human"을
-    실어 보내도 저장된 값은 human이 아니어야 한다 — 클라이언트 자칭 위장 차단."""
+    """⛔ gate 1(오르테가군): 클라이언트가 outcome_result에 임의 closed_by_member_id를
+    실어 보내도 저장된 값은 실 caller의 것이어야 한다 — 클라이언트 자칭 위장 차단.
+
+    카디르 QA(story #2857, 2026-08-20) — 원래 caller="agent"로 이 불변식을 증명했으나,
+    #2857이 verified/falsified 직통로를 human-only로 막으면서(caller.type!="human"이면
+    HUMAN_CONFIRM_REQUIRED로 이 지점 도달 前에 raise) 그 caller가 이제 이 경로에 못
+    들어온다. 하지만 「서버가 closed_by를 결정한다」는 human 전용이 아니라 이 경로(직접
+    transition)가 살아 있는 한 human 클라이언트에도 그대로 지켜야 하는 불변식 — 죽은
+    경로(agent)의 주장을 삭제하는 대신 산 경로(human)로 이전한다(게이트 경로는
+    test_2857_hypothesis_outcome_confirm_realdb.py가 별도로 잡는다)."""
     repo = _repo_mock(_hyp_stub(status="measuring"))
     p_repo, p_lookup = _patch(repo, "human")
     p_verdict, p_loop = _patch_verified_downstream()
     with p_repo, p_lookup, p_verdict, p_loop:
         await svc.transition_hypothesis(
-            MagicMock(), ORG_ID, _caller("agent"), HYP_ID,
+            MagicMock(), ORG_ID, _caller("human"), HYP_ID,
             HypothesisTransition(
                 status="verified",
                 outcome_result={
@@ -357,8 +365,9 @@ async def test_transition_verified_ignores_client_declared_closed_by():
             ),
         )
     outcome = repo.update.call_args.kwargs["outcome_result"]
-    assert outcome["closed_by"] == "agent"  # 실 caller.type — 클라이언트 자칭("human") 무시
-    assert outcome["closed_by_member_id"] == str(CALLER_AGENT_ID)
+    assert outcome["closed_by"] == "human"  # 실 caller.type
+    # 클라이언트가 보낸 임의 UUID가 아니라 실 caller.id — 자칭 위장 무시.
+    assert outcome["closed_by_member_id"] == str(CALLER_HUMAN_ID)
 
 
 # ── update: allowlist / NO_VALID_FIELDS / owner=human ─────────────────────────


### PR DESCRIPTION
[SID:2857]

## 요약
#2845-B(측정 판정 초안=에이전트·확定=휴먼) hypothesis 축 구현. metric_definition의 source가 자동채점 대상(ga4/internal_ops)이 아닌 hypothesis(measuring에 갇히는 축)를 위한 흐름 — 에이전트가 측정 초안을 제출하면 새 gate_type(`hypothesis_outcome_confirm`, 항상 human-only pending)이 생기고, 사람이 기존 게이트 판에서 승인해야 실제 hypothesis 전이가 일어난다.

## AC 확定(페드루 PO, 2026-08-20)
- ①초안 보관소=`Gate.neutral_facts` 재사용(Hypothesis에 새 컬럼 0, `draft_metadata`는 다른 개념이라 재사용 안 함)
- ②scorer 경계=source 축(metric_definition 有無 아님 — 항상 NOT NULL)
- ③확定 표면=기존 게이트 판(`transition_gate_endpoint`가 이미 human-only 403)
- ⚠️부수 발견 — `transition_hypothesis`(verified/falsified)에 human-only 가드가 없던 기존 갭을 이 PR에서 원자적으로 닫음(에이전트 직접 호출=403, 게이트 경유만 성립)

## 검증
- `test_2857_hypothesis_outcome_confirm_realdb.py`(5건, 실PG): 에이전트 직접 verified 403 / 휴먼 직접 verified 무회귀 / 초안 게이트 항상 pending(org posture 무관) / 승인 시 hypothesis 실 전이+closed_by 서버 귀속 / 거절 시 measuring 유지
- 기존 hypotheses/gate 관련 스위트(test_hypotheses_router·test_e_sec_hypotheses_project_scope·test_gate_can_approve_48f064e5·test_gate_transition_human_only) 49건 전체 green
- `git apply -R`로 핵심 배선(gate_service/hypothesis 서비스+라우터) 되돌려 5건 중 3건이 정확히 실패하는 것 확認(하중 증명)

## Test plan
- [x] 신규 realdb 테스트 5건 green
- [x] 기존 hypothesis/gate 스위트 49건 무회귀
- [x] 하중 증명(git apply -R)
- [ ] CI green (대기)