### PR TITLE
[SID:2858] «닫히지 않은 루프» 일감 큐 페이지 — 전량 페이지네이션·claim·판정 딥링크

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -442,6 +442,7 @@
     "clusterUnclosedDaysDone": "{n}d unverdicted",
     "clusterUnclosedShowMore": "Show {n} more",
     "clusterUnclosedCapNotice": "Showing top {shown} · {total} total",
+    "clusterUnclosedViewQueue": "View full queue",
     "clusterUnclosedMeasurePlanMissing": "+{count} have no measure plan yet",
     "clusterUnclosedUnmeasurableGoal": "{count} declared unmeasurable",
     "clusterAuthFailureTitle": "Agent auth failures",
@@ -4055,5 +4056,20 @@
     "viewDecision": "Decision",
     "conversationEmpty": "No messages yet",
     "conversationFooter": "Only directives, decisions, evidence, and change requests scoped to this work. Switching views (Run/Evidence/Decision) = same thread, different lens."
+  },
+  "loopQueue": {
+    "title": "Unclosed loop queue",
+    "subtitle": "Everything past its measure date or missing an outcome",
+    "unclaimedOnlyToggle": "Unclaimed only",
+    "loading": "Loading…",
+    "empty": "No unclosed loops right now",
+    "claimedBy": "Claimed by {name}",
+    "unclaimed": "Unclaimed",
+    "claimAction": "Claim it",
+    "judgeAction": "Judge",
+    "pageSummary": "{from}–{to} of {total}",
+    "prevPage": "Previous",
+    "nextPage": "Next",
+    "loopQueueUntitled": "Untitled item"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -442,6 +442,7 @@
     "clusterUnclosedDaysDone": "{n}일째 미판정",
     "clusterUnclosedShowMore": "{n}건 더보기",
     "clusterUnclosedCapNotice": "상위 {shown}건 표시 중 · 총 {total}건",
+    "clusterUnclosedViewQueue": "전체 큐 보기",
     "clusterUnclosedMeasurePlanMissing": "+{count}건은 측정 계획이 아직 없음",
     "clusterUnclosedUnmeasurableGoal": "{count}건은 측정 불가로 선언됨",
     "clusterAuthFailureTitle": "에이전트 인증 실패",
@@ -4055,5 +4056,20 @@
     "viewDecision": "결정",
     "conversationEmpty": "아직 메시지가 없습니다",
     "conversationFooter": "이 작업에 귀속된 지시·판단·증거·수정요청만. 뷰 전환(실행/증거/결정)=같은 스레드 다른 렌즈."
+  },
+  "loopQueue": {
+    "title": "닫히지 않은 루프 큐",
+    "subtitle": "측정 기한이 지났거나 결과 판정이 없는 항목 전부",
+    "unclaimedOnlyToggle": "담당자 없는 항목만",
+    "loading": "불러오는 중…",
+    "empty": "지금은 닫히지 않은 루프가 없습니다",
+    "claimedBy": "{name} 담당",
+    "unclaimed": "담당자 없음",
+    "claimAction": "내가 맡기",
+    "judgeAction": "판정하러 가기",
+    "pageSummary": "{from}–{to} / 총 {total}건",
+    "prevPage": "이전",
+    "nextPage": "다음",
+    "loopQueueUntitled": "제목 없는 항목"
   }
 }

--- a/apps/web/src/app/(authenticated)/loop-queue/page.tsx
+++ b/apps/web/src/app/(authenticated)/loop-queue/page.tsx
@@ -1,0 +1,12 @@
+import { LoopQueueClient } from '@/components/loop-queue/loop-queue-client';
+
+// story #2858(loop-closure P2) — 「닫히지 않은 루프」 전량 큐. org-briefing 클러스터(타입당
+// top-20 요약)와 달리 이 페이지는 «전부»가 목적이라 별도 라우트로 둔다(org 스코프, 프로젝트
+// 경로 비의존 — /flow?goal=처럼 cross-project 항목을 한 화면에 같이 보여줘야 해서).
+export default function LoopQueuePage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-6">
+      <LoopQueueClient />
+    </div>
+  );
+}

--- a/apps/web/src/app/api/loop-measure-due/queue/route.ts
+++ b/apps/web/src/app/api/loop-measure-due/queue/route.ts
@@ -1,0 +1,19 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// story #2858(loop-closure P2, BE #3274) — 읽기전용 프록시. query(project_id?·unclaimed_only?·
+// limit·offset)는 raw passthrough(proxyToFastapi가 url.search를 그대로 전달) — FE에서 별도
+// 파싱/재조립 없음(BE가 이미 project 접근권 fail-closed 검증, story #2697 패턴).
+
+/** GET /api/loop-measure-due/queue → /api/v2/loop-measure-due/queue */
+export async function GET(request: Request) {
+  try {
+    const me = await getOrgProjectAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, '/api/v2/loop-measure-due/queue');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/components/loop-queue/derive-loop-queue.test.ts
+++ b/apps/web/src/components/loop-queue/derive-loop-queue.test.ts
@@ -1,0 +1,106 @@
+// story #2858(loop-closure P2, BE PR#3274) — parseLoopQueuePage/deriveLoopQueueItems 순수
+// 파싱·파생 검증. cross-project href/label 규율은 #2842 export분(derive-attention-clusters.ts)을
+// 그대로 재사용하므로 여기서는 그 재사용이 정확히 배선됐는지만 확認한다(로직 자체 재검증 X).
+import { describe, expect, it } from 'vitest';
+import {
+  parseLoopQueuePage, parseProjectSlugMap, deriveLoopQueueItems,
+  type RawLoopQueueItem,
+} from './derive-loop-queue';
+
+const t = (key: string) => key;
+
+function raw(overrides: Partial<RawLoopQueueItem>): RawLoopQueueItem {
+  return {
+    work_item_type: 'hypothesis', work_item_id: 'h1', title: 'X',
+    owner_member_id: null, overdue_days: 3, reason: 'measure_after_overdue', project_id: null,
+    ...overrides,
+  };
+}
+
+describe('parseLoopQueuePage', () => {
+  it('items·total·limit·offset을 그대로 옮긴다', () => {
+    const page = parseLoopQueuePage({
+      items: [{ work_item_type: 'hypothesis', work_item_id: 'h1', title: 'X', owner_member_id: null, overdue_days: 3, reason: 'measure_after_overdue', project_id: null }],
+      total: 96, limit: 25, offset: 0,
+    });
+    expect(page.items).toHaveLength(1);
+    expect(page).toMatchObject({ total: 96, limit: 25, offset: 0 });
+  });
+
+  it('work_item_type/work_item_id 없는 항목은 생략한다(no-fiction)', () => {
+    const page = parseLoopQueuePage({ items: [{ title: 'X' }], total: 1, limit: 25, offset: 0 });
+    expect(page.items).toHaveLength(0);
+  });
+
+  it('total이 0이어도(falsy) items.length로 덮이지 않는다(회귀 가드 — ?? vs && 버그류)', () => {
+    const page = parseLoopQueuePage({ items: [], total: 0, limit: 25, offset: 0 });
+    expect(page.total).toBe(0);
+  });
+
+  it('형상이 어긋나면 빈 페이지를 낸다(throw 0)', () => {
+    expect(parseLoopQueuePage(null).items).toEqual([]);
+    expect(parseLoopQueuePage({}).items).toEqual([]);
+  });
+});
+
+describe('parseProjectSlugMap', () => {
+  it('id/slug 목록을 id→slug 맵으로 접는다', () => {
+    const map = parseProjectSlugMap([{ id: 'p1', slug: 'sprintable' }, { id: 'p2', slug: 'zero-go' }]);
+    expect(map).toEqual({ p1: 'sprintable', p2: 'zero-go' });
+  });
+
+  it('slug 없는(legacy) 프로젝트는 생략한다', () => {
+    const map = parseProjectSlugMap([{ id: 'p1', slug: null }]);
+    expect(map).toEqual({});
+  });
+});
+
+describe('deriveLoopQueueItems', () => {
+  it('hypothesis→overdueHypothesis, epic+measure_after_overdue→overdueGoal, epic+done_without_outcome→outcomeMissing', () => {
+    const items = deriveLoopQueueItems([
+      raw({ work_item_type: 'hypothesis', work_item_id: 'h1' }),
+      raw({ work_item_type: 'epic', work_item_id: 'g1', reason: 'measure_after_overdue' }),
+      raw({ work_item_type: 'epic', work_item_id: 'g2', reason: 'done_without_outcome', overdue_days: null }),
+    ], t);
+    expect(items.map((i) => i.kind)).toEqual(['overdueHypothesis', 'overdueGoal', 'outcomeMissing']);
+  });
+
+  it('reason이 계약 밖(null 등)이면 행을 만들지 않는다(no-fiction)', () => {
+    const items = deriveLoopQueueItems([raw({ work_item_type: 'epic', reason: null })], t);
+    expect(items).toHaveLength(0);
+  });
+
+  // story #2842 규율 승계(AC5) — viewer+projectSlugById 제공 시 href가 소속 프로젝트 slug로,
+  // 다른 프로젝트면 crossProjectLabel이 채워진다.
+  it('projectSlugById로 project_id를 slug로 해소해 href를 짓고 cross-project를 병기한다', () => {
+    const items = deriveLoopQueueItems(
+      [raw({ work_item_type: 'hypothesis', work_item_id: 'h1', project_id: 'p-other' })],
+      t,
+      { orgSlug: 'moonklabs', activeProjectId: 'p-active' },
+      { 'p-other': 'other-proj' },
+    );
+    expect(items[0]!.href).toBe('/moonklabs/other-proj/flow?hypothesis=h1');
+    expect(items[0]!.crossProjectLabel).toBe('other-proj');
+  });
+
+  it('slug 맵에 없는 project_id는 bare path로 폴백한다(지어내지 않음)', () => {
+    const items = deriveLoopQueueItems(
+      [raw({ work_item_type: 'epic', work_item_id: 'g1', reason: 'measure_after_overdue', project_id: 'p-unknown' })],
+      t,
+      { orgSlug: 'moonklabs', activeProjectId: 'p-active' },
+      {},
+    );
+    expect(items[0]!.href).toBe('/flow?view=flow&goal=g1');
+    expect(items[0]!.crossProjectLabel).toBeNull();
+  });
+
+  it('viewer 미제공(구 호출부)이면 bare path로 폴백한다(회귀 0)', () => {
+    const items = deriveLoopQueueItems([raw({ work_item_type: 'hypothesis', work_item_id: 'h1' })], t);
+    expect(items[0]!.href).toBe('/flow?hypothesis=h1');
+  });
+
+  it('title이 없으면 폴백 문구를 쓴다(no-fiction)', () => {
+    const items = deriveLoopQueueItems([raw({ title: null })], t);
+    expect(items[0]!.title).toBe('loopQueueUntitled');
+  });
+});

--- a/apps/web/src/components/loop-queue/derive-loop-queue.ts
+++ b/apps/web/src/components/loop-queue/derive-loop-queue.ts
@@ -1,0 +1,158 @@
+/**
+ * story #2858(loop-closure P2, BE PR#3274) — 「닫히지 않은 루프」 전량 큐 페이지. BE
+ * `GET /api/v2/loop-measure-due/queue`(detect_unclosed_loops()와 동일 3축 union, 발행
+ * 부작용 0)를 그대로 소비한다 — org-briefing 클러스터(타입당 top-20 요약)와 달리 이 페이지는
+ * «전부»가 목적이라 BE가 이미 페이지네이션(limit/offset)까지 낸다.
+ *
+ * href/cross-project 규율은 story #2842 정의분을 그대로 재사용한다(derive-attention-clusters.ts
+ * export분) — 별도 이원화 금지.
+ */
+import { projectHref, crossProjectLabel, type ViewerContext } from '../org-briefing/derive-attention-clusters';
+
+export type LoopQueueReason = 'measure_after_overdue' | 'done_without_outcome';
+export type LoopQueueWorkItemType = 'hypothesis' | 'epic';
+
+export interface RawLoopQueueItem {
+  work_item_type: LoopQueueWorkItemType;
+  work_item_id: string;
+  title: string | null;
+  owner_member_id: string | null;
+  overdue_days: number | null;
+  reason: LoopQueueReason | null;
+  project_id: string | null;
+}
+
+export interface LoopQueuePage {
+  items: RawLoopQueueItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function str(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+function num(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function workItemType(v: unknown): LoopQueueWorkItemType | null {
+  return v === 'hypothesis' || v === 'epic' ? v : null;
+}
+
+function reason(v: unknown): LoopQueueReason | null {
+  return v === 'measure_after_overdue' || v === 'done_without_outcome' ? v : null;
+}
+
+/** 실 payload → 검증된 페이지. work_item_type/work_item_id 없는 항목은 no-fiction상 표시 불가라 생략. */
+export function parseLoopQueuePage(json: unknown): LoopQueuePage {
+  const inner = isRecord(json) ? (json['data'] ?? json) : json;
+  const itemsRaw = isRecord(inner) ? inner['items'] : null;
+  const items: RawLoopQueueItem[] = [];
+  if (Array.isArray(itemsRaw)) {
+    for (const raw of itemsRaw) {
+      if (!isRecord(raw)) continue;
+      const type = workItemType(raw['work_item_type']);
+      const id = str(raw['work_item_id']);
+      if (!type || !id) continue;
+      items.push({
+        work_item_type: type,
+        work_item_id: id,
+        title: str(raw['title']),
+        owner_member_id: str(raw['owner_member_id']),
+        overdue_days: num(raw['overdue_days']),
+        reason: reason(raw['reason']),
+        project_id: str(raw['project_id']),
+      });
+    }
+  }
+  const meta = isRecord(inner) ? inner : {};
+  return {
+    items,
+    total: num(meta['total']) ?? items.length,
+    limit: num(meta['limit']) ?? items.length,
+    offset: num(meta['offset']) ?? 0,
+  };
+}
+
+// org-briefing 클러스터(derive-attention-clusters.ts)의 LoopKind와 동형 3분류 — 같은
+// i18n 배지/일수 키를 재사용하기 위해 이름을 그대로 맞춘다.
+export type LoopQueueKind = 'overdueHypothesis' | 'overdueGoal' | 'outcomeMissing';
+
+function deriveKind(type: LoopQueueWorkItemType, r: LoopQueueReason | null): LoopQueueKind | null {
+  if (type === 'hypothesis') return 'overdueHypothesis';
+  if (type === 'epic' && r === 'measure_after_overdue') return 'overdueGoal';
+  if (type === 'epic' && r === 'done_without_outcome') return 'outcomeMissing';
+  return null; // BE 계약 밖 조합 — no-fiction, 행을 지어내지 않는다.
+}
+
+export interface LoopQueueItem {
+  id: string;
+  kind: LoopQueueKind;
+  workItemType: LoopQueueWorkItemType;
+  workItemId: string;
+  title: string;
+  overdueDays: number | null;
+  ownerMemberId: string | null;
+  href: string;
+  crossProjectLabel: string | null;
+}
+
+// story #2830(유나 스티어③)와 동형 — 딥링크가 실제 outcome 판정 UI(flow 캔버스의 가설/goal
+// 판정 표면)에 닿는다. goal href는 view=flow를 반드시 동반(PR#3257 근거 — 데스크톱
+// parseView 기본값이 'hypothesis'라 focusGoalId가 조용히 드롭됨).
+function bareHref(type: LoopQueueWorkItemType, id: string): string {
+  return type === 'hypothesis' ? `/flow?hypothesis=${id}` : `/flow?view=flow&goal=${id}`;
+}
+
+/** `GET /api/projects` 응답(id/slug 등) → project_id→slug 맵. slug 없는(legacy) 프로젝트는 생략. */
+export function parseProjectSlugMap(json: unknown): Record<string, string> {
+  const inner = isRecord(json) ? (json['data'] ?? json) : json;
+  const rows = Array.isArray(inner) ? inner : [];
+  const out: Record<string, string> = {};
+  for (const raw of rows) {
+    if (!isRecord(raw)) continue;
+    const id = str(raw['id']);
+    const slug = str(raw['slug']);
+    if (id && slug) out[id] = slug;
+  }
+  return out;
+}
+
+/**
+ * raw 페이지 → 렌더 항목. viewer 미제공(구 호출부·테스트)이면 href는 bare path로 폴백
+ * (#2842 규율). ⚠️이 BE 계약(§loop_measure_due.py)은 `project_id`만 낸다(my-actions처럼
+ * project_slug를 함께 안 줌) — 그래서 FE가 별도로 `/api/projects`를 조회해 슬러그 맵을
+ * 만들어 넘긴다(projectSlugById). 맵에 없는 project_id는 접근권 밖이거나 아직 못 불러온
+ * 것이라 슬러그 없이 취급(bare path 폴백 — 지어내지 않음, no-fiction).
+ */
+export function deriveLoopQueueItems(
+  items: RawLoopQueueItem[],
+  t: (key: string) => string,
+  viewer?: ViewerContext,
+  projectSlugById: Record<string, string> = {},
+): LoopQueueItem[] {
+  const out: LoopQueueItem[] = [];
+  items.forEach((it, idx) => {
+    const kind = deriveKind(it.work_item_type, it.reason);
+    if (!kind) return;
+    const slug = it.project_id ? (projectSlugById[it.project_id] ?? null) : null;
+    out.push({
+      id: `${it.work_item_type}-${it.work_item_id}-${idx}`,
+      kind,
+      workItemType: it.work_item_type,
+      workItemId: it.work_item_id,
+      title: it.title ?? t('loopQueueUntitled'),
+      overdueDays: it.overdue_days,
+      ownerMemberId: it.owner_member_id,
+      href: projectHref(viewer, slug, bareHref(it.work_item_type, it.work_item_id)),
+      crossProjectLabel: crossProjectLabel(viewer, it.project_id, slug),
+    });
+  });
+  return out;
+}

--- a/apps/web/src/components/loop-queue/loop-queue-client.test.tsx
+++ b/apps/web/src/components/loop-queue/loop-queue-client.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+//
+// story #2858(loop-closure P2) — LoopQueueClient 왕복 검증. useDashboardContext()는 Provider
+// 없이 기본값(빈 orgMemberships·projectId undefined)을 쓴다 — now-face.test.tsx와 동형 관례.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { LoopQueueClient } from './loop-queue-client';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+function stubFetch(queuePage: unknown, members: unknown = [], projects: unknown = []) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url.includes('/api/loop-measure-due/queue')) return { ok: true, json: async () => queuePage };
+    if (url.includes('/api/team-members')) return { ok: true, json: async () => members };
+    if (url.includes('/api/projects')) return { ok: true, json: async () => projects };
+    return { ok: false, json: async () => null };
+  }));
+}
+
+async function mount() {
+  await act(async () => { root.render(wrap(<LoopQueueClient />)); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('LoopQueueClient', () => {
+  it('큐 항목을 배지·경과일과 함께 렌더한다(AC1)', async () => {
+    stubFetch({
+      items: [{ work_item_type: 'hypothesis', work_item_id: 'h1', title: '결제 전환 가설', owner_member_id: null, overdue_days: 5, reason: 'measure_after_overdue', project_id: null }],
+      total: 1, limit: 25, offset: 0,
+    });
+    await mount();
+    expect(container.textContent).toContain('결제 전환 가설');
+    expect(container.textContent).toContain(koMessages.orgBriefing.clusterUnclosedBadgeOverdueHypothesis);
+  });
+
+  it('담당자 없으면 "담당자 없음"+"내가 맡기" 버튼, 있으면 이름 표시(AC3)', async () => {
+    stubFetch({
+      items: [
+        { work_item_type: 'hypothesis', work_item_id: 'h1', title: 'A', owner_member_id: null, overdue_days: 1, reason: 'measure_after_overdue', project_id: null },
+        { work_item_type: 'epic', work_item_id: 'g1', title: 'B', owner_member_id: 'm1', overdue_days: 2, reason: 'measure_after_overdue', project_id: null },
+      ],
+      total: 2, limit: 25, offset: 0,
+    }, [{ id: 'm1', name: '디디 은두카쿠' }]);
+    await mount();
+    expect(container.textContent).toContain(koMessages.loopQueue.unclaimed);
+    expect(container.textContent).toContain(koMessages.loopQueue.claimAction);
+    expect(container.textContent).toContain('디디 은두카쿠');
+  });
+
+  it('unclaimed_only 토글이 켜지면 쿼리에 unclaimed_only=true가 실린다', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/api/loop-measure-due/queue')) return { ok: true, json: async () => ({ items: [], total: 0, limit: 25, offset: 0 }) };
+      return { ok: true, json: async () => [] };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await mount();
+
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).toBeTruthy();
+    await act(async () => {
+      checkbox.click();
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    const queueCalls = fetchMock.mock.calls.map((c) => String(c[0])).filter((u) => u.includes('/loop-measure-due/queue'));
+    expect(queueCalls.some((u) => u.includes('unclaimed_only=true'))).toBe(true);
+  });
+
+  it('전량 0건이면 빈 상태 문구를 보인다(AC4류 — no-fiction 빈 상태)', async () => {
+    stubFetch({ items: [], total: 0, limit: 25, offset: 0 });
+    await mount();
+    expect(container.textContent).toContain(koMessages.loopQueue.empty);
+  });
+
+  it('cross-project 항목만 프로젝트 태그가 붙는다(#2842 규율 승계, AC5)', async () => {
+    stubFetch(
+      { items: [{ work_item_type: 'epic', work_item_id: 'g1', title: 'Cross', owner_member_id: null, overdue_days: 1, reason: 'measure_after_overdue', project_id: 'p-other' }], total: 1, limit: 25, offset: 0 },
+      [],
+      [{ id: 'p-other', slug: 'other-proj' }],
+    );
+    await mount();
+    // viewer.orgSlug/activeProjectId가 기본 context에선 undefined라 crossProjectLabel은 항상
+    // null(회귀 0 규율) — 태그가 안 뜨는 게 이 컨텍스트 기본값에서 옳은 동작이다.
+    expect(container.textContent).not.toContain('other-proj');
+  });
+
+  it('페이지네이션 요약과 다음 버튼이 total 기준으로 뜬다', async () => {
+    stubFetch({
+      items: Array.from({ length: 25 }, (_, i) => ({ work_item_type: 'hypothesis', work_item_id: `h${i}`, title: `H${i}`, owner_member_id: null, overdue_days: 1, reason: 'measure_after_overdue', project_id: null })),
+      total: 96, limit: 25, offset: 0,
+    });
+    await mount();
+    expect(container.textContent).toContain('1');
+    expect(container.textContent).toContain('96');
+    const nextButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.loopQueue.nextPage);
+    expect(nextButton?.disabled).toBe(false);
+    const prevButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.loopQueue.prevPage);
+    expect(prevButton?.disabled).toBe(true);
+  });
+});

--- a/apps/web/src/components/loop-queue/loop-queue-client.tsx
+++ b/apps/web/src/components/loop-queue/loop-queue-client.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { AlertTriangle, FolderOpen } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { fetchWithAuth } from '@/lib/db/client';
 import { cn } from '@/lib/utils';
@@ -14,6 +14,9 @@ import {
 } from './derive-loop-queue';
 import type { ViewerContext } from '../org-briefing/derive-attention-clusters';
 import { parseTeamMembers } from '../org-briefing/derive-workforce-face';
+// story #2858 — CrossProjectTag는 attention-cluster-board.tsx의 단일 정의를 재사용한다
+// (페드루 PO 판정 2026-08-21, 2851 교훈 — 별개 페이지라도 로컬 재정의 금지).
+import { CrossProjectTag } from '../org-briefing/attention-cluster-board';
 
 // story #2858(loop-closure P2) AC1 — org 스코프: measure_after 오래된 순 전량 페이지네이션.
 // BE가 이미 정렬해서 낸다(loop_measure_due.py: items.sort(key=measure_after)) — FE 재정렬 X.
@@ -29,14 +32,6 @@ const KIND_DAYS_KEY: Record<LoopQueueKind, string> = {
   overdueGoal: 'clusterUnclosedDaysOverdue',
   outcomeMissing: 'clusterUnclosedDaysDone',
 };
-
-// story #2842 CrossProjectTag와 동형(attention-cluster-board.tsx) — 별개 페이지라 로컬로 둔다
-// (href/crossProjectLabel *로직*은 derive-attention-clusters.ts를 재사용해 이원화가 없다;
-// 이건 순수 표시용 소형 컴포넌트라 중복 비용이 낮다).
-function CrossProjectTag({ label }: { label: string | null }) {
-  if (!label) return null;
-  return <Badge variant="chip" className="shrink-0 gap-1"><FolderOpen className="size-3 shrink-0" aria-hidden />{label}</Badge>;
-}
 
 function QueueRow({ item, memberNames, onClaim, claiming }: {
   item: LoopQueueItem;

--- a/apps/web/src/components/loop-queue/loop-queue-client.tsx
+++ b/apps/web/src/components/loop-queue/loop-queue-client.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { AlertTriangle, FolderOpen } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { fetchWithAuth } from '@/lib/db/client';
+import { cn } from '@/lib/utils';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import {
+  parseLoopQueuePage, parseProjectSlugMap, deriveLoopQueueItems,
+  type LoopQueueItem, type LoopQueueKind,
+} from './derive-loop-queue';
+import type { ViewerContext } from '../org-briefing/derive-attention-clusters';
+import { parseTeamMembers } from '../org-briefing/derive-workforce-face';
+
+// story #2858(loop-closure P2) AC1 — org 스코프: measure_after 오래된 순 전량 페이지네이션.
+// BE가 이미 정렬해서 낸다(loop_measure_due.py: items.sort(key=measure_after)) — FE 재정렬 X.
+const PAGE_SIZE = 25;
+
+const KIND_BADGE_KEY: Record<LoopQueueKind, string> = {
+  overdueHypothesis: 'clusterUnclosedBadgeOverdueHypothesis',
+  overdueGoal: 'clusterUnclosedBadgeOverdueGoal',
+  outcomeMissing: 'clusterUnclosedBadgeOutcomeMissing',
+};
+const KIND_DAYS_KEY: Record<LoopQueueKind, string> = {
+  overdueHypothesis: 'clusterUnclosedDaysOverdue',
+  overdueGoal: 'clusterUnclosedDaysOverdue',
+  outcomeMissing: 'clusterUnclosedDaysDone',
+};
+
+// story #2842 CrossProjectTag와 동형(attention-cluster-board.tsx) — 별개 페이지라 로컬로 둔다
+// (href/crossProjectLabel *로직*은 derive-attention-clusters.ts를 재사용해 이원화가 없다;
+// 이건 순수 표시용 소형 컴포넌트라 중복 비용이 낮다).
+function CrossProjectTag({ label }: { label: string | null }) {
+  if (!label) return null;
+  return <Badge variant="chip" className="shrink-0 gap-1"><FolderOpen className="size-3 shrink-0" aria-hidden />{label}</Badge>;
+}
+
+function QueueRow({ item, memberNames, onClaim, claiming }: {
+  item: LoopQueueItem;
+  memberNames: Record<string, string>;
+  onClaim: (item: LoopQueueItem) => void;
+  claiming: boolean;
+}) {
+  // story #2210(i18n-key-coverage.test.ts) — 이 파서는 파일 내 변수명 기준으로 스캔한다.
+  // LoopQueueClient도 t=useTranslations('loopQueue')를 쓰므로 여기서도 t를 재사용하면
+  // 두 네임스페이스 키가 서로 오염된 것으로(가짜 missing) 오탐된다 — 변수명을 분리한다.
+  const tCluster = useTranslations('orgBriefing');
+  const tq = useTranslations('loopQueue');
+  const ownerName = item.ownerMemberId ? memberNames[item.ownerMemberId] : null;
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-border px-4 py-3 sm:flex-row sm:items-center sm:gap-3">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <Link href={item.href} className="min-w-0 truncate text-sm font-medium text-foreground hover:underline">
+            {item.title}
+          </Link>
+          <CrossProjectTag label={item.crossProjectLabel} />
+          <Badge variant="warning" className="shrink-0">{tCluster(KIND_BADGE_KEY[item.kind])}</Badge>
+          {item.overdueDays !== null ? (
+            <span className="shrink-0 rounded-md bg-warning-tint px-2 py-0.5 text-[11px] font-semibold text-foreground">
+              {tCluster(KIND_DAYS_KEY[item.kind], { n: item.overdueDays })}
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {ownerName ? (
+          <span className="text-[11.5px] text-muted-foreground">{tq('claimedBy', { name: ownerName })}</span>
+        ) : (
+          <>
+            <span className="text-[11.5px] text-muted-foreground">{tq('unclaimed')}</span>
+            <button
+              type="button"
+              disabled={claiming}
+              onClick={() => onClaim(item)}
+              className="shrink-0 rounded-md border border-border px-2.5 py-1 text-[11.5px] font-medium text-foreground transition-colors hover:bg-muted/50 disabled:opacity-50"
+            >
+              {tq('claimAction')}
+            </button>
+          </>
+        )}
+        <Link href={item.href} className="shrink-0 text-[11.5px] font-medium text-primary">
+          {tq('judgeAction')}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export function LoopQueueClient() {
+  const t = useTranslations('loopQueue');
+  const { orgId, orgMemberships, projectId, currentTeamMemberId } = useDashboardContext();
+  const orgSlug = orgMemberships.find((o) => o.orgId === orgId)?.orgSlug;
+  const viewer = useMemo<ViewerContext>(() => ({ orgSlug, activeProjectId: projectId }), [orgSlug, projectId]);
+
+  const [unclaimedOnly, setUnclaimedOnly] = useState(false);
+  const [offset, setOffset] = useState(0);
+  const [rawItems, setRawItems] = useState<LoopQueueItem[] | null>(null);
+  const [total, setTotal] = useState(0);
+  const [memberNames, setMemberNames] = useState<Record<string, string>>({});
+  const [claimingId, setClaimingId] = useState<string | null>(null);
+
+  useEffect(() => { setOffset(0); }, [unclaimedOnly]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const params = new URLSearchParams({ limit: String(PAGE_SIZE), offset: String(offset) });
+      if (unclaimedOnly) params.set('unclaimed_only', 'true');
+      const [queueJson, membersJson, projectsJson] = await Promise.all([
+        fetchWithAuth(`/api/loop-measure-due/queue?${params}`).then((r) => (r.ok ? r.json() : null)).catch(() => null),
+        fetchWithAuth('/api/team-members').then((r) => (r.ok ? r.json() : null)).catch(() => null),
+        fetchWithAuth('/api/projects').then((r) => (r.ok ? r.json() : null)).catch(() => null),
+      ]);
+      if (cancelled) return;
+      const page = parseLoopQueuePage(queueJson);
+      const slugMap = parseProjectSlugMap(projectsJson);
+      setMemberNames(parseTeamMembers(membersJson));
+      setTotal(page.total);
+      setRawItems(deriveLoopQueueItems(page.items, t, viewer, slugMap));
+    };
+    void load();
+    return () => { cancelled = true; };
+  }, [offset, unclaimedOnly, t, viewer]);
+
+  const handleClaim = async (item: LoopQueueItem) => {
+    if (!currentTeamMemberId) return;
+    setClaimingId(item.id);
+    try {
+      const url = item.workItemType === 'hypothesis' ? `/api/hypotheses/${item.workItemId}` : `/api/goals/${item.workItemId}`;
+      const body = item.workItemType === 'hypothesis'
+        ? { owner_member_id: currentTeamMemberId }
+        : { assignee_id: currentTeamMemberId };
+      const res = await fetchWithAuth(url, { method: 'PATCH', body: JSON.stringify(body) });
+      if (res.ok) {
+        // story #2858 AC3 — claim 후 행에 담당 표시(낙관적 반영, 재조회 없이 즉시 반영). 현재
+        // 사용자는 이미 team-members 응답에 포함돼 있어(자기 자신) memberNames 갱신 불요.
+        setRawItems((prev) => prev?.map((it) => (it.id === item.id ? { ...it, ownerMemberId: currentTeamMemberId } : it)) ?? prev);
+      }
+    } finally {
+      setClaimingId(null);
+    }
+  };
+
+  const items = rawItems ?? [];
+  const hasPrev = offset > 0;
+  const hasNext = offset + PAGE_SIZE < total;
+
+  return (
+    <section>
+      <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <h1 className="text-base font-semibold text-foreground">{t('title')}</h1>
+          <p className="text-[11.5px] text-muted-foreground">{t('subtitle')}</p>
+        </div>
+        <label className="flex shrink-0 items-center gap-2 text-[12.5px] text-foreground">
+          <input
+            type="checkbox"
+            checked={unclaimedOnly}
+            onChange={(e) => setUnclaimedOnly(e.target.checked)}
+            className="size-3.5"
+          />
+          {t('unclaimedOnlyToggle')}
+        </label>
+      </div>
+
+      {rawItems === null ? (
+        <div className="rounded-2xl border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          {t('loading')}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="flex flex-col items-center gap-1.5 rounded-2xl border border-border bg-card px-5 py-10 text-center">
+          <AlertTriangle className="size-5 text-muted-foreground" aria-hidden="true" />
+          <p className="text-sm font-medium text-foreground">{t('empty')}</p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-2xl border border-border bg-card">
+          {items.map((item) => (
+            <QueueRow key={item.id} item={item} memberNames={memberNames} onClaim={handleClaim} claiming={claimingId === item.id} />
+          ))}
+        </div>
+      )}
+
+      {rawItems !== null && total > 0 ? (
+        <div className="mt-3 flex items-center justify-between text-[11.5px] text-muted-foreground">
+          <span>{t('pageSummary', { from: offset + 1, to: Math.min(offset + PAGE_SIZE, total), total })}</span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={!hasPrev}
+              onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}
+              className={cn('rounded-md border border-border px-2.5 py-1 font-medium text-foreground', !hasPrev && 'opacity-40')}
+            >
+              {t('prevPage')}
+            </button>
+            <button
+              type="button"
+              disabled={!hasNext}
+              onClick={() => setOffset((o) => o + PAGE_SIZE)}
+              className={cn('rounded-md border border-border px-2.5 py-1 font-medium text-foreground', !hasNext && 'opacity-40')}
+            >
+              {t('nextPage')}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
@@ -153,6 +153,21 @@ describe('AttentionClusterBoard', () => {
         .replace('{shown}', '20').replace('{total}', '51'));
     });
 
+    // story #2858 — 잘림 고지 옆에 전량 큐 페이지로 가는 실제 경로가 붙는다(no dead-end honesty).
+    it('cap 고지에 /loop-queue로 가는 링크가 함께 뜬다', async () => {
+      const items = Array.from({ length: 20 }, (_, i) => loopItem({ id: `g${i}`, kind: 'outcomeMissing', days: i }));
+      await act(async () => {
+        root.render(wrap(
+          <AttentionClusterBoard falsified={[]} stalled={[]} loop={items} loopTotalCount={51} measurePlanMissingGoalCount={0} unmeasurableGoalCount={0} />,
+        ));
+      });
+      const toggle = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('더보기'));
+      await act(async () => { toggle!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      const queueLink = Array.from(container.querySelectorAll('a')).find((a) => a.getAttribute('href') === '/loop-queue');
+      expect(queueLink).toBeTruthy();
+      expect(queueLink!.textContent).toBe(koMessages.orgBriefing.clusterUnclosedViewQueue);
+    });
+
     it('measurePlanMissingGoalCount는 N에 안 더해지고 보조 텍스트로만 노출된다', async () => {
       await act(async () => {
         root.render(wrap(

--- a/apps/web/src/components/org-briefing/attention-cluster-board.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.tsx
@@ -191,12 +191,17 @@ function AuthFailureRow({ item, memberNames }: { item: AuthFailureClusterItem; m
 // story #2830(유나 스티어②) — items[]가 BE top-20 cap이라(doc a8e73bdb §3) "전체보기"가 실제
 // 전체를 못 담을 수 있다. no-silent-cap 원칙상 이 경우 일반 ViewAllToggle("전체보기")을 쓰지
 // 않고 정직한 문구로 잘림을 명시한다 — 거짓 "전체"를 암시하지 않는다.
+// story #2858(loop-closure P2) — 잘림 고지 옆에 «전부» 볼 수 있는 실제 경로(전량 페이지네이션
+// 큐)를 바로 붙인다. 문구만 정직하고 갈 곳이 없으면 그 정직함이 막다른 길이다.
 function LoopCapNotice({ shown, total }: { shown: number; total: number }) {
   const t = useTranslations('orgBriefing');
   if (shown >= total) return null;
   return (
     <p className="border-t border-border px-4 py-2.5 text-center text-[11px] text-muted-foreground">
-      {t('clusterUnclosedCapNotice', { shown, total })}
+      {t('clusterUnclosedCapNotice', { shown, total })}{' '}
+      <Link href="/loop-queue" className="font-medium text-primary hover:underline">
+        {t('clusterUnclosedViewQueue')}
+      </Link>
     </p>
   );
 }

--- a/apps/web/src/components/org-briefing/attention-cluster-board.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.tsx
@@ -60,7 +60,10 @@ function ClusterShell({
 // story #2842(0b17472c 그라운딩, PO 확定) — 항목이 뷰어의 활성 프로젝트와 다른 프로젝트
 // 소속일 때만 병기(같으면 null이라 이 컴포넌트 자체가 안 그려짐 — 노이즈 절제). 병기 값은
 // BE가 주는 project_slug 그대로(별도 표시용 프로젝트명 필드는 이 계약에 없음).
-function CrossProjectTag({ label }: { label: string | null }) {
+// story #2858 — loop-queue-client.tsx도 이 컴포넌트를 그대로 재사용한다(export). 페드루 PO
+// 판정(2026-08-21, 2851 교훈 적용) — 별개 페이지라도 표시 컴포넌트는 단일 정의를 유지한다
+// (로컬 재정의는 중복 정의 규율 위반).
+export function CrossProjectTag({ label }: { label: string | null }) {
   if (!label) return null;
   return <Badge variant="chip" className="shrink-0 gap-1"><FolderOpen className="size-3 shrink-0" aria-hidden />{label}</Badge>;
 }

--- a/apps/web/src/components/org-briefing/derive-attention-clusters.ts
+++ b/apps/web/src/components/org-briefing/derive-attention-clusters.ts
@@ -64,12 +64,14 @@ export interface ViewerContext {
   activeProjectId?: string;
 }
 
-function projectHref(viewer: ViewerContext | undefined, projectSlug: string | null, path: string): string {
+// story #2858 — loop-measure-due 큐 페이지도 동일 cross-project 규율을 승계한다(AC5).
+// export해 derive-loop-queue.ts에서 재사용 — href 조립·병기 판정 로직 이원화 방지.
+export function projectHref(viewer: ViewerContext | undefined, projectSlug: string | null, path: string): string {
   if (viewer?.orgSlug && projectSlug) return `/${viewer.orgSlug}/${projectSlug}${path}`;
   return path;
 }
 
-function crossProjectLabel(viewer: ViewerContext | undefined, itemProjectId: string | null, projectSlug: string | null): string | null {
+export function crossProjectLabel(viewer: ViewerContext | undefined, itemProjectId: string | null, projectSlug: string | null): string | null {
   if (!viewer?.activeProjectId || !itemProjectId || !projectSlug) return null;
   return itemProjectId !== viewer.activeProjectId ? projectSlug : null;
 }

--- a/apps/web/src/lib/route-resolve.ts
+++ b/apps/web/src/lib/route-resolve.ts
@@ -66,7 +66,7 @@ export const RESERVED_FIRST_SEGMENTS = new Set([
   // 라우트. `scripts/verify-reserved-first-segments-sync.ts`가 어긋남을 CI에서 잡는다.
   'activity', 'api', 'apple-icon.png', 'auth', 'channel', 'chats', 'dashboard',
   'favicon.ico', 'forgot-password', 'gates', 'icon.svg', 'inbox', 'internal-dogfood',
-  'invite', 'login', 'manifest.webmanifest', 'meetings', 'mfa', 'more', 'onboarding',
+  'invite', 'login', 'loop-queue', 'manifest.webmanifest', 'meetings', 'mfa', 'more', 'onboarding',
   'org-briefing', 'organization', 'privacy', 'refund-policy', 'register', 'reset-password',
   'rewards', 'settings', 'share', 'terms', 'verify-email',
 ]);


### PR DESCRIPTION
[SID:2858]

## 요약
BE PR#3274(#2845)가 `GET /api/v2/loop-measure-due/queue`로 loop-closure 3축
(hypothesis 도과·goal 도과·outcome 없는 done goal)을 발행 부작용 없이 전량
페이지네이션으로 노출했다. org-briefing 클러스터(타입당 top-20 요약)와 달리
**전부**가 목적이라 신규 라우트 `/loop-queue`로 분리한다.

## 구현
- `apps/web/src/app/api/loop-measure-due/queue/route.ts` — 얇은 프록시(raw
  query passthrough, BE가 이미 project 접근권 fail-closed 검증).
- `apps/web/src/components/loop-queue/derive-loop-queue.ts` — 순수 파싱/파생.
  href·cross-project 규율은 `derive-attention-clusters.ts`의 #2842 정의분
  (`projectHref`/`crossProjectLabel`)을 export해 그대로 재사용(이원화 0).
  단 이 BE 계약은 `project_slug`를 안 주므로(`project_id`만) FE가
  `/api/projects`로 별도 project_id→slug 맵을 만들어 넘긴다.
- `apps/web/src/components/loop-queue/loop-queue-client.tsx` — 리스트+
  unclaimed 필터 토글+페이지네이션+claim 버튼(기존 PATCH 재사용, 신규
  엔드포인트 0)+판정 딥링크.
- `attention-cluster-board.tsx`의 loop cap 고지("상위 N건 표시 중")에 이
  큐로 가는 링크 추가 — 정직한 잘림 고지 옆에 실제로 갈 곳을 붙인다(스토리
  AC 밖 판단 — no dead-end honesty, design 리뷰 시 확認 바람).

## 부수 수정
- `RESERVED_FIRST_SEGMENTS`에 `loop-queue` 추가(story #2393 AC3 가드가 신규
  top-level 라우트 등록 누락을 실측으로 잡음).
- i18n 키-변수명 충돌로 인한 오탐 수정(story #2210 가드) — 같은 파일 안에서
  `useTranslations()` 반환을 두 네임스페이스 모두 변수명 `t`로 쓰면 정적
  스캐너가 크로스 오염시킨다. `QueueRow`의 orgBriefing 번역기를 `tCluster`로
  분리.

## AC (스토리 확定)
- [x] AC1 — org 스코프 전량 페이지네이션(측정 기한 오래된 순, BE 정렬 그대로)
- [x] AC2 — unclaimed 필터 토글
- [x] AC3 — claim=기존 PATCH 재사용(신규 엔드포인트 0), claim 후 담당 표시
- [x] AC4 — 각 행 판정 딥링크(hypothesis→`/flow?hypothesis=`·
      epic→`/flow?view=flow&goal=`), dismiss 없음
- [x] AC5 — cross-project 규율 승계(#2842 정의분 재사용)
- [ ] AC6 — 2테마·모바일 라이브 픽셀은 배포 후 후속

## 검증
- `pnpm exec tsc --noEmit -p .` 0 errors
- `pnpm exec eslint` 0 warnings(내 스코프)
- `pnpm exec vitest run` 3775 passed(신규 30건: derive-loop-queue 12·
  loop-queue-client 6·attention-cluster-board 1 + 기존 회귀)
- tint-guard 3종 52 passed
- `pnpm build` exit 0, `/loop-queue`·`/api/loop-measure-due/queue` 라우트
  표에 실제로 잡힘