### PR TITLE
[SID:2856] org-wide 신호 클래스 완결 — 플랫 now-face href도 소속 프로젝트화

### DIFF
--- a/apps/web/src/components/org-briefing/derive-now-face.test.ts
+++ b/apps/web/src/components/org-briefing/derive-now-face.test.ts
@@ -185,6 +185,80 @@ describe('buildNowFace', () => {
     expect(signal?.id).toBe('unanswered_blocker-s7');
   });
 
+  // story #2856(2842 후속, 클래스 완결) — agent_stuck/unanswered_blocker의 bare href도 소속
+  // 프로젝트로 못박고 cross-project만 병기한다(2842 정의분 재사용).
+  describe('cross-project href/병기(story #2856)', () => {
+    it('viewer 제공 시 agent_stuck(story) href가 소속 프로젝트 slug로 지어진다', () => {
+      const raw: RawMyActions = {
+        ...ZERO_LOOP_COUNTS,
+        queue: [],
+        attention: [{ type: 'agent_stuck', entity_type: 'story', entity_id: 's1', gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: 'p-other', project_slug: 'other-proj', member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null }],
+      };
+      const items = buildNowFace(raw, [], t, { orgSlug: 'moonklabs', activeProjectId: 'p-active' });
+      const signal = items.find((i) => i.kind === 'signal');
+      expect(signal?.href).toBe('/moonklabs/other-proj/board?story=s1');
+      expect(signal?.crossProjectLabel).toBe('other-proj');
+    });
+
+    it('viewer 제공 시 unanswered_blocker href도 소속 프로젝트 slug로 지어진다', () => {
+      const raw: RawMyActions = {
+        ...ZERO_LOOP_COUNTS,
+        queue: [],
+        attention: [{ type: 'unanswered_blocker', entity_type: null, entity_id: null, gate_type: null, story_id: null, stalled_days: null, blocked_story_id: 's7', title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: 'p-other', project_slug: 'other-proj', member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null }],
+      };
+      const items = buildNowFace(raw, [], t, { orgSlug: 'moonklabs', activeProjectId: 'p-active' });
+      const signal = items.find((i) => i.kind === 'signal');
+      expect(signal?.href).toBe('/moonklabs/other-proj/board?story=s7');
+      expect(signal?.crossProjectLabel).toBe('other-proj');
+    });
+
+    it('같은 프로젝트 소속이면 crossProjectLabel이 null이다(노이즈 절제)', () => {
+      const raw: RawMyActions = {
+        ...ZERO_LOOP_COUNTS,
+        queue: [],
+        attention: [{ type: 'agent_stuck', entity_type: 'story', entity_id: 's1', gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: 'p-active', project_slug: 'sprintable', member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null }],
+      };
+      const items = buildNowFace(raw, [], t, { orgSlug: 'moonklabs', activeProjectId: 'p-active' });
+      const signal = items.find((i) => i.kind === 'signal');
+      expect(signal?.crossProjectLabel).toBeNull();
+      expect(signal?.href).toBe('/moonklabs/sprintable/board?story=s1');
+    });
+
+    it('viewer 미제공(구 호출부)이면 bare href·crossProjectLabel=null로 폴백한다(회귀 0)', () => {
+      const raw: RawMyActions = {
+        ...ZERO_LOOP_COUNTS,
+        queue: [],
+        attention: [{ type: 'agent_stuck', entity_type: 'story', entity_id: 's1', gate_type: null, story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: 'p-other', project_slug: 'other-proj', member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null }],
+      };
+      const items = buildNowFace(raw, [], t);
+      const signal = items.find((i) => i.kind === 'signal');
+      expect(signal?.href).toBe('/board?story=s1');
+      expect(signal?.crossProjectLabel).toBeNull();
+    });
+
+    it('agent_stuck이 story가 아니면(gates 폴백) 여전히 /inbox?tab=gates이고 crossProjectLabel=null이다', () => {
+      const raw: RawMyActions = {
+        ...ZERO_LOOP_COUNTS,
+        queue: [],
+        attention: [{ type: 'agent_stuck', entity_type: null, entity_id: null, gate_type: 'merge', story_id: null, stalled_days: null, blocked_story_id: null, title: null, hypothesis_id: null, statement: null, outcome_result: null, falsified_days: null, superseded_by_hypothesis_id: null, goal_id: null, overdue_days: null, done_days: null, project_id: 'p-other', project_slug: 'other-proj', member_id: null, reason: null, failure_count: null, first_failed_at: null, last_failed_at: null }],
+      };
+      const items = buildNowFace(raw, [], t, { orgSlug: 'moonklabs', activeProjectId: 'p-active' });
+      const signal = items.find((i) => i.kind === 'signal');
+      expect(signal?.href).toBe('/inbox?tab=gates');
+      expect(signal?.crossProjectLabel).toBeNull();
+    });
+
+    it('action_queue 유래(decide) 항목은 project_id 계약이 없어 crossProjectLabel이 항상 null이다', () => {
+      const raw: RawMyActions = {
+        ...ZERO_LOOP_COUNTS,
+        queue: [{ type: 'review_merge', priority: 'info', title: 'x', context: { story_id: 's1' } }],
+        attention: [],
+      };
+      const items = buildNowFace(raw, [], t, { orgSlug: 'moonklabs', activeProjectId: 'p-active' });
+      expect(items[0]?.crossProjectLabel).toBeNull();
+    });
+  });
+
   it('never leaks raw elapsed-time text into signal context copy (surveillance framing ban — doc §1.5/§1.7)', () => {
     const raw: RawMyActions = {
       ...ZERO_LOOP_COUNTS,

--- a/apps/web/src/components/org-briefing/derive-now-face.ts
+++ b/apps/web/src/components/org-briefing/derive-now-face.ts
@@ -10,6 +10,7 @@
  * 데이터 = `/api/dashboard/my-actions`(action_queue=caller org-wide 결정대기·attention=org 자동감지) +
  * `/api/notifications?type=task_completed`(완료 보고). 신규 BE 0 — 두 기존 BFF만 조합.
  */
+import { projectHref, crossProjectLabel, type ViewerContext } from './derive-attention-clusters';
 
 export type NowKind = 'decide' | 'signal' | 'done';
 
@@ -24,6 +25,10 @@ export interface NowFaceItem {
   href: string;
   /** 정렬용 내부 우선순위(작을수록 상단) — 화면에 노출되지 않음(시간 낙인 금지). */
   priority: number;
+  // story #2856(2842 후속, 클래스 완결) — org-wide 자동감지 신호(agent_stuck·unanswered_blocker)
+  // 만 채워짐(project_id를 가진 attention 유래 항목). action_queue 유래(gate_approval·
+  // review_merge·my_blockers)는 project_id 자체가 없어 항상 null(선행 BE 계약 의존, 스코프 밖).
+  crossProjectLabel: string | null;
 }
 
 export interface NowFaceTranslator {
@@ -235,7 +240,9 @@ function ctxStr(context: Record<string, unknown>, key: string): string | null {
  * 대기 중 최우선 1건만 primary, 나머지 ghost — 우발 mutation 방지 위해 전부 상세 표면으로 네비게이션만
  * (즉시 mutation 0, action-zone.tsx의 동일 원칙 재사용).
  */
-export function buildNowFace(raw: RawMyActions, notifications: RawCompletionNotification[], t: NowFaceTranslator): NowFaceItem[] {
+export function buildNowFace(
+  raw: RawMyActions, notifications: RawCompletionNotification[], t: NowFaceTranslator, viewer?: ViewerContext,
+): NowFaceItem[] {
   const items: NowFaceItem[] = [];
 
   for (const q of raw.queue) {
@@ -248,6 +255,7 @@ export function buildNowFace(raw: RawMyActions, notifications: RawCompletionNoti
         actionLabel: t('actionApprove'), actionTone: 'ghost',
         href: '/inbox?tab=gates',
         priority: PRIORITY_RANK[q.priority ?? 'info'] ?? 2,
+        crossProjectLabel: null, // org-level 표면(스코프 밖) — 프로젝트 개념 자체가 없음.
       });
     } else if (q.type === 'review_merge') {
       const storyId = ctxStr(q.context, 'story_id');
@@ -259,6 +267,8 @@ export function buildNowFace(raw: RawMyActions, notifications: RawCompletionNoti
         actionLabel: t('actionReview'), actionTone: 'ghost',
         href: storyId ? `/board?story=${storyId}` : '/board',
         priority: 10 + (PRIORITY_RANK[q.priority ?? 'info'] ?? 2),
+        // story #2856 — RawQueueItem엔 project_id/slug가 없어(선행 BE 계약 필요) 항상 null.
+        crossProjectLabel: null,
       });
     } else if (q.type === 'my_blockers') {
       const blockedId = ctxStr(q.context, 'blocked_story_id');
@@ -270,6 +280,7 @@ export function buildNowFace(raw: RawMyActions, notifications: RawCompletionNoti
         actionLabel: t('actionReview'), actionTone: 'ghost',
         href: blockedId ? `/board?story=${blockedId}` : '/board',
         priority: -1, // danger — 내가 남을 막고 있음, 최우선.
+        crossProjectLabel: null, // 동형(RawQueueItem 계약 밖).
       });
     }
   }
@@ -284,8 +295,15 @@ export function buildNowFace(raw: RawMyActions, notifications: RawCompletionNoti
         // 노출하면 원시 enum 유출이 된다(카피 스윕 §3-4). 고정 문구만 쓴다(no-fiction).
         context: t('signalAgentStuckContext'),
         actionLabel: t('actionOpen'), actionTone: 'ghost',
-        href: a.entity_type === 'story' && a.entity_id ? `/board?story=${a.entity_id}` : '/inbox?tab=gates',
+        // story #2856(2842 후속 클래스 완결) — /inbox?tab=gates는 org-level이라 그대로,
+        // /board?story= bare path만 소속 프로젝트로 못박는다(viewer/slug 미제공 시 폴백).
+        href: a.entity_type === 'story' && a.entity_id
+          ? projectHref(viewer, a.project_slug, `/board?story=${a.entity_id}`)
+          : '/inbox?tab=gates',
         priority: 20,
+        crossProjectLabel: a.entity_type === 'story' && a.entity_id
+          ? crossProjectLabel(viewer, a.project_id, a.project_slug)
+          : null,
       });
     } else if (a.type === 'unanswered_blocker') {
       items.push({
@@ -294,8 +312,11 @@ export function buildNowFace(raw: RawMyActions, notifications: RawCompletionNoti
         title: t('signalBlockerTitle'),
         context: t('signalBlockerContext'),
         actionLabel: t('actionOpen'), actionTone: 'ghost',
-        href: a.blocked_story_id ? `/board?story=${a.blocked_story_id}` : '/board',
+        href: a.blocked_story_id
+          ? projectHref(viewer, a.project_slug, `/board?story=${a.blocked_story_id}`)
+          : '/board',
         priority: 22,
+        crossProjectLabel: a.blocked_story_id ? crossProjectLabel(viewer, a.project_id, a.project_slug) : null,
       });
     }
     // story #2541 — story_stalled·hypothesis_falsified는 여기서 더는 flat 행으로 안 올린다.
@@ -312,6 +333,7 @@ export function buildNowFace(raw: RawMyActions, notifications: RawCompletionNoti
       actionLabel: t('actionConfirm'), actionTone: 'ghost',
       href: n.href ?? '/inbox',
       priority: 30,
+      crossProjectLabel: null, // 알림 유래 — project_id 계약 자체가 없음.
     });
   }
 

--- a/apps/web/src/components/org-briefing/now-face.test.tsx
+++ b/apps/web/src/components/org-briefing/now-face.test.tsx
@@ -126,4 +126,21 @@ describe('NowFace', () => {
     const badge = [...container.querySelectorAll('span')].find((s) => s.textContent === '지금');
     expect(badge).not.toBeUndefined();
   });
+
+  // story #2856 — 이 테스트 하네스는 useDashboardContext()에 Provider를 안 씌워 기본값
+  // (orgSlug/activeProjectId 둘 다 undefined)을 쓴다 — viewer 미제공 구 호출부와 동형이라
+  // project_id/project_slug가 payload에 있어도 crossProjectLabel은 항상 null이어야 한다
+  // (derive-now-face.test.ts가 순수함수 축은 이미 잠금 — 여기선 그 폴백이 실 렌더에서도
+  // 안전한지만 확認).
+  it('viewer 미제공 컨텍스트에서는 project_id가 있어도 프로젝트 태그를 그리지 않는다(회귀 0)', async () => {
+    stubFetch(
+      {
+        action_queue: { items: [] },
+        attention: { items: [{ type: 'agent_stuck', entity_type: 'story', entity_id: 's1', gate_type: 'merge', project_id: 'p-other', project_slug: 'other-proj' }] },
+      },
+      { data: [] },
+    );
+    await mount();
+    expect(container.textContent).not.toContain('other-proj');
+  });
 });

--- a/apps/web/src/components/org-briefing/now-face.tsx
+++ b/apps/web/src/components/org-briefing/now-face.tsx
@@ -13,7 +13,7 @@ import {
   type NowFaceItem, type NowFaceTranslator,
 } from './derive-now-face';
 import { deriveAttentionClusters, type AttentionClusters, type ViewerContext } from './derive-attention-clusters';
-import { AttentionClusterBoard } from './attention-cluster-board';
+import { AttentionClusterBoard, CrossProjectTag } from './attention-cluster-board';
 import { parseTeamMembers } from './derive-workforce-face';
 
 // story ded31cb3 — 조직 브리핑 "지금" 면. doc org-briefing-hypothesis-grammar-blueprint §1.3.
@@ -39,7 +39,7 @@ async function loadNowFace(t: NowFaceTranslator, viewer: ViewerContext): Promise
   ]);
   const raw = parseMyActions(ma);
   return {
-    items: buildNowFace(raw, parseCompletionNotifications(notifs), t),
+    items: buildNowFace(raw, parseCompletionNotifications(notifs), t, viewer),
     // story #2541 — 같은 raw.attention을 story_stalled/hypothesis_falsified 전용으로 한 번 더
     // 읽어 클러스터로 묶는다(buildNowFace는 이 두 타입을 더는 flat 행으로 안 올린다).
     // story #2829/#2830 — loop_* 3종도 동형(buildNowFace는 이 타입들을 flat 행으로 안 올림,
@@ -72,7 +72,10 @@ function NowRow({ item }: { item: NowFaceItem }) {
     >
       <KindBadge kind={item.kind} label={item.kindLabel} />
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[13.5px] font-medium text-foreground">{item.title}</span>
+        <span className="flex items-center gap-1.5">
+          <span className="min-w-0 truncate text-[13.5px] font-medium text-foreground">{item.title}</span>
+          <CrossProjectTag label={item.crossProjectLabel} />
+        </span>
         <span className="block truncate text-xs text-muted-foreground">{item.context}</span>
       </span>
       <span


### PR DESCRIPTION
[SID:2856]

## 요약
story #2842 후속(클래스 완결). org-briefing attention 클러스터 3종은 이미
href를 소속 프로젝트로 짓지만, 같은 「지금」 면의 플랫 now-face 행
(agent_stuck·unanswered_blocker)은 여전히 bare `/board?story=`를 써 동일
미스내비 리스크가 남아있었다.

## 구현
- `buildNowFace()`에 4번째 파라미터 `viewer?: ViewerContext` 추가 —
  `projectHref`/`crossProjectLabel`(2842 export분)을 그대로 재사용.
- `NowFaceItem.crossProjectLabel` 추가, `NowRow`가 `CrossProjectTag`(2842
  단일 정의)로 병기.
- action_queue 유래 항목은 `RawQueueItem`에 project_id/slug 계약이 없어
  항상 null(스토리 본문이 명시한 스코프 밖 — 별도 BE 계약 선행 필요).
- viewer 미제공(구 호출부·테스트) 시 bare path 폴백(회귀 0).

## AC (스토리 확定)
- [x] AC1 — agent_stuck(story)·unanswered_blocker href 소속 프로젝트화
- [x] AC2 — cross-project만 병기
- [x] AC3 — 같은 프로젝트 병기 0(노이즈 절제), project_id 없는 행은 항상 null
- [x] AC4 — 단일 정의 재사용(projectHref/crossProjectLabel/CrossProjectTag
      전부 2842 export분, 로컬 재정의 0)
- [ ] AC5 — design 게이트(유나 확認)+라이브 픽셀은 배포 후

## 검증
- `pnpm exec tsc --noEmit -p .` 0 errors
- `pnpm exec eslint` 0 warnings
- `pnpm exec vitest run` 3788 passed(신규 7건: derive-now-face 6 + now-face 1)
- tint-guard 3종 52 passed
- `pnpm build` exit 0