### PR TITLE
[BUG·긴급] PATCH /api/goals/{id}(assignee_id) 200+무반영 — updateEpicSchema 죽은 코드 근본수정

### DIFF
--- a/packages/shared/src/schemas/__tests__/validation.test.ts
+++ b/packages/shared/src/schemas/__tests__/validation.test.ts
@@ -4,10 +4,10 @@ import {
   createProjectSchema, createInvitationSchema, acceptInvitationSchema,
   createTeamMemberSchema, setCurrentProjectSchema, updateNotificationSchema,
   createEpicSchema, updateEpicSchema,
-  createSprintSchema,
+  createSprintSchema, updateSprintSchema,
   createStorySchema, updateStorySchema, bulkUpdateStorySchema,
   createTaskSchema, updateTaskSchema,
-  createDocSchema, createDocCommentSchema,
+  createDocSchema, updateDocSchema, createDocCommentSchema,
   saveStandupSchema,
   createStandupFeedbackSchema, updateStandupFeedbackSchema,
   createRetroSchema,
@@ -105,15 +105,18 @@ describe('Sprintable Zod Schemas', () => {
 
   // ─── Epic ─────
   describe('createEpicSchema', () => {
+    // story #2863(P0) — project_id/org_id는 route.ts가 항상 세션값으로 백필한 뒤 파싱하므로
+    // (POST /api/goals: `if (!body.project_id) body.project_id = me.project_id` 등) 스키마
+    // 레벨에서 필수(.min(1))로 요구해도 실 호출부와 무회귀 — 이 테스트도 그 전제 그대로 반영.
     it('유효한 epic를 통과', () => {
-      expect(createEpicSchema.safeParse({ title: 'E-015' }).success).toBe(true);
+      expect(createEpicSchema.safeParse({ project_id: 'p1', org_id: 'o1', title: 'E-015' }).success).toBe(true);
     });
     it('title 없으면 실패', () => {
-      expect(createEpicSchema.safeParse({}).success).toBe(false);
+      expect(createEpicSchema.safeParse({ project_id: 'p1', org_id: 'o1' }).success).toBe(false);
     });
     it('optional 필드 포함 시 통과', () => {
       expect(createEpicSchema.safeParse({
-        title: 'E-015', status: 'active', description: null,
+        project_id: 'p1', org_id: 'o1', title: 'E-015', status: 'active', description: null,
       }).success).toBe(true);
     });
   });
@@ -124,6 +127,21 @@ describe('Sprintable Zod Schemas', () => {
     });
     it('빈 객체 통과 (모두 optional)', () => {
       expect(updateEpicSchema.safeParse({}).success).toBe(true);
+    });
+    // story #2863(P0, 긴급 재발방지) — index.ts에 독립 재정의된 구판(assignee_id 등 8필드
+    // 누락)이 이 스키마의 실제 최신판(epics.ts)을 export 체인에서 가려, PATCH
+    // /api/goals/{id}(assignee_id)가 200이면서 값이 조용히 사라졌다(zod 기본 strip 동작).
+    // «success:true」만 보는 이전 테스트로는 이 클래스의 결함을 못 잡는다 — 파싱된 값
+    // 자체를 실측해야 한다.
+    it('assignee_id가 파싱 결과에 실제로 살아남는다(회귀 — 2863)', () => {
+      const parsed = updateEpicSchema.safeParse({ assignee_id: 'member-1' });
+      expect(parsed.success).toBe(true);
+      expect(parsed.success && parsed.data.assignee_id).toBe('member-1');
+    });
+    it('assignee_id=null(원복)도 실제로 반영된다', () => {
+      const parsed = updateEpicSchema.safeParse({ assignee_id: null });
+      expect(parsed.success).toBe(true);
+      expect(parsed.success && parsed.data.assignee_id).toBe(null);
     });
   });
 
@@ -136,6 +154,19 @@ describe('Sprintable Zod Schemas', () => {
     });
     it('필수 필드 누락 시 실패', () => {
       expect(createSprintSchema.safeParse({ title: 'Sprint 1' }).success).toBe(false);
+    });
+  });
+
+  // story #2863(P0) 스윕 — 같은 클래스(index.ts 지역 재정의가 sprints.ts를 가려
+  // success_hypothesis/metric_definition/measure_after가 조용히 drop됐다).
+  describe('updateSprintSchema', () => {
+    it('outcome 필드(success_hypothesis/measure_after)가 파싱 결과에 실제로 살아남는다(회귀 — 2863)', () => {
+      const parsed = updateSprintSchema.safeParse({
+        success_hypothesis: 'DAU 10% 증가', measure_after: '2026-05-01T00:00:00Z',
+      });
+      expect(parsed.success).toBe(true);
+      expect(parsed.success && parsed.data.success_hypothesis).toBe('DAU 10% 증가');
+      expect(parsed.success && parsed.data.measure_after).toBe('2026-05-01T00:00:00Z');
     });
   });
 
@@ -197,6 +228,22 @@ describe('Sprintable Zod Schemas', () => {
   describe('createDocCommentSchema', () => {
     it('유효한 코멘트를 통과', () => {
       expect(createDocCommentSchema.safeParse({ content: '좋은 문서' }).success).toBe(true);
+    });
+  });
+
+  // story #2863(P0) 스윕 — 같은 클래스(index.ts 지역 재정의가 docs.ts를 가려
+  // slug_locked/sort_order가 조용히 drop됐다).
+  describe('updateDocSchema', () => {
+    it('slug_locked/sort_order가 파싱 결과에 실제로 살아남는다(회귀 — 2863)', () => {
+      const parsed = updateDocSchema.safeParse({ slug_locked: true, sort_order: 3 });
+      expect(parsed.success).toBe(true);
+      expect(parsed.success && parsed.data.slug_locked).toBe(true);
+      expect(parsed.success && parsed.data.sort_order).toBe(3);
+    });
+    it('expected_updated_at/force_overwrite(동시성 제어)도 그대로 유지된다(무회귀)', () => {
+      const parsed = updateDocSchema.safeParse({ expected_updated_at: '2026-01-01T00:00:00Z', force_overwrite: true });
+      expect(parsed.success).toBe(true);
+      expect(parsed.success && parsed.data.expected_updated_at).toBe('2026-01-01T00:00:00Z');
     });
   });
 

--- a/packages/shared/src/schemas/docs.ts
+++ b/packages/shared/src/schemas/docs.ts
@@ -1,26 +1,33 @@
 import { z } from 'zod/v4';
 
+// story #2863(P0) 스윕 — index.ts에 독립 재정의돼 있던 구판(slug_locked·sort_order 누락)이
+// export 체인에서 이 파일을 가려 죽은 코드로 만들었다(같은 근본원인의 자매 인스턴스). 여기
+// 하나로 합치되, index.ts live판이 실제로 통과시키던 관용도(slug optional·parent_id
+// nullable)는 그대로 보존하고, 양쪽에 각자만 있던 필드(slug_locked/sort_order ↔
+// expected_updated_at/force_overwrite)는 합집합으로 유지한다(어느 쪽도 새로 자르지 않음).
 export const createDocSchema = z.object({
   title: z.string().min(1),
-  slug: z.string().min(1),
+  slug: z.string().optional(),
   content: z.string().optional(),
   content_format: z.enum(['markdown', 'html']).optional(),
   icon: z.string().optional().nullable(),
   tags: z.array(z.string()).optional(),
-  parent_id: z.string().optional(),
+  parent_id: z.string().optional().nullable(),
   is_folder: z.boolean().optional(),
 });
 
 export const updateDocSchema = z.object({
   title: z.string().min(1).optional(),
-  slug: z.string().min(1).optional(),
+  slug: z.string().optional(),
   slug_locked: z.boolean().optional(),
   content: z.string().optional(),
   content_format: z.enum(['markdown', 'html']).optional(),
   icon: z.string().optional().nullable(),
   tags: z.array(z.string()).optional(),
   sort_order: z.number().optional(),
-  parent_id: z.string().nullable().optional(),
+  parent_id: z.string().optional().nullable(),
+  expected_updated_at: z.string().optional(),
+  force_overwrite: z.boolean().optional(),
 });
 
 export const docCommentSchema = z.object({

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -97,38 +97,18 @@ export const createMemoLinkedDocSchema = z.object({
 });
 
 // ─── Epic ────────────────────────────────────
-export const createEpicSchema = z.object({
-  project_id: z.string().min(1).optional(),
-  org_id: z.string().min(1).optional(),
-  title: z.string().min(1),
-  status: z.string().optional(),
-  priority: z.string().optional(),
-  description: z.string().optional().nullable(),
-});
-
-export const updateEpicSchema = z.object({
-  title: z.string().min(1).optional(),
-  status: z.string().optional(),
-  priority: z.string().optional(),
-  description: z.string().optional().nullable(),
-});
+// story #2863(P0, 긴급) — 이 자리에 독립 정의된 구판(4필드뿐, assignee_id 등 8개 필드
+// 누락)이 epics.ts의 실제 최신판을 export 체인에서 완전히 가렸다(epics.ts는 어디서도
+// re-export 안 됨 — 도달 불가능한 죽은 코드였음). zod가 미인식 키를 조용히 strip해
+// PATCH /api/goals/{id}(assignee_id)가 200+무반영이었던 근본원인. updateHypothesisSchema
+// 처럼 실 정의 파일을 그대로 재노출(정의 중복 0)하는 형태로 통일한다.
+export { createEpicSchema, updateEpicSchema, EPIC_STATUSES } from './epics';
 
 // ─── Sprint ──────────────────────────────────
-export const createSprintSchema = z.object({
-  project_id: z.string().min(1).optional(),
-  org_id: z.string().min(1).optional(),
-  title: z.string().min(1),
-  start_date: z.string().min(1),
-  end_date: z.string().min(1),
-  team_size: z.number().int().positive().optional(),
-});
-
-export const updateSprintSchema = z.object({
-  title: z.string().min(1).optional(),
-  start_date: z.string().optional(),
-  end_date: z.string().optional(),
-  team_size: z.number().int().positive().optional(),
-});
+// story #2863(P0) 스윕 — epics와 동일 클래스(지역 재정의가 sprints.ts를 죽은 코드로 가려
+// success_hypothesis/metric_definition/measure_after가 조용히 drop되고 있었다). sprints.ts로
+// 필드 합집합 병합 후 재노출로 통일.
+export { createSprintSchema, updateSprintSchema } from './sprints';
 
 // ─── Story ───────────────────────────────────
 export { createStorySchema, updateStorySchema, bulkUpdateStoriesSchema as bulkUpdateStorySchema, VALID_STORY_TRANSITIONS, STORY_STATUSES, STORY_PRIORITIES, STORY_SP_VALUES } from './stories';
@@ -164,32 +144,10 @@ export const updateTaskSchema = z.object({
 });
 
 // ─── Doc ─────────────────────────────────────
-export const createDocSchema = z.object({
-  title: z.string().min(1),
-  slug: z.string().optional(),
-  content: z.string().optional(),
-  content_format: z.enum(['markdown', 'html']).optional(),
-  icon: z.string().optional().nullable(),
-  tags: z.array(z.string()).optional(),
-  parent_id: z.string().optional().nullable(),
-  is_folder: z.boolean().optional(),
-});
-
-export const updateDocSchema = z.object({
-  title: z.string().min(1).optional(),
-  slug: z.string().optional(),
-  content: z.string().optional(),
-  content_format: z.enum(['markdown', 'html']).optional(),
-  icon: z.string().optional().nullable(),
-  tags: z.array(z.string()).optional(),
-  parent_id: z.string().optional().nullable(),
-  expected_updated_at: z.string().optional(),
-  force_overwrite: z.boolean().optional(),
-});
-
-export const createDocCommentSchema = z.object({
-  content: z.string().min(1),
-});
+// story #2863(P0) 스윕 — epics와 동일 클래스(지역 재정의가 docs.ts를 죽은 코드로 가림).
+// docs.ts로 필드 합집합 병합 후 재노출로 통일(docCommentSchema는 기존 공개 이름 보존을
+// 위해 createDocCommentSchema로 별칭).
+export { createDocSchema, updateDocSchema, docCommentSchema as createDocCommentSchema } from './docs';
 
 // ─── Standup ─────────────────────────────────
 export const saveStandupSchema = z.object({

--- a/packages/shared/src/schemas/sprints.ts
+++ b/packages/shared/src/schemas/sprints.ts
@@ -1,13 +1,17 @@
 import { z } from 'zod/v4';
 import { metricDefinitionSchema } from './outcome';
 
+// story #2863(P0) 스윕 — epics와 동일 클래스. index.ts live판이 실제로 통과시키던 관용도
+// (project_id/org_id optional·team_size int-positive)는 보존하고, 이 파일에만 있던
+// outcome 3필드(success_hypothesis/metric_definition/measure_after — E-BOARD-SCHEMA 의도
+// 필드, live판에서 누락돼 조용히 drop되고 있었다)를 합친다.
 export const createSprintSchema = z.object({
-  project_id: z.string().min(1),
-  org_id: z.string().min(1),
+  project_id: z.string().min(1).optional(),
+  org_id: z.string().min(1).optional(),
   title: z.string().min(1),
   start_date: z.string().min(1),
   end_date: z.string().min(1),
-  team_size: z.number().optional(),
+  team_size: z.number().int().positive().optional(),
   success_hypothesis: z.string().optional().nullable(),
   metric_definition: metricDefinitionSchema.optional().nullable(),
   measure_after: z.string().datetime().optional().nullable(),
@@ -15,9 +19,9 @@ export const createSprintSchema = z.object({
 
 export const updateSprintSchema = z.object({
   title: z.string().min(1).optional(),
-  start_date: z.string().min(1).optional(),
-  end_date: z.string().min(1).optional(),
-  team_size: z.number().optional(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+  team_size: z.number().int().positive().optional(),
   success_hypothesis: z.string().optional().nullable(),
   metric_definition: metricDefinitionSchema.optional().nullable(),
   measure_after: z.string().datetime().optional().nullable(),


### PR DESCRIPTION
[SID:2863]

## 근본원인
로컬 pnpm dev + 로컬 FastAPI 백엔드 + 실 curl로 재현 확定, route.ts→GoalService→ApiEpicRepository 3압점 로깅으로 정확히 잡음:

`packages/shared/src/schemas/index.ts`에 `updateEpicSchema`/`createEpicSchema`가 **독립 재정의**(4필드뿐, `assignee_id` 등 8필드 누락)돼 있었고, `epics.ts`의 최신판(`assignee_id` 포함)은 index.ts에서 재노출된 적이 없어 **export 체인에서 도달 불가능한 죽은 코드**였습니다. 패키지 루트(`@sprintable/shared` → `src/index.ts` → `export * from './schemas'`)가 실제 내보내는 건 index.ts의 그 구판뿐 — zod가 미인식 키를 조용히 strip해 `PATCH /api/goals/{id}(assignee_id)`가 200+무반영이었습니다. hypothesis 축(`updateHypothesisSchema`)은 진짜 재-export(정의 중복 0)라 멀쩡했습니다.

## 같은 클래스 전수 스윕(페드루 PO 지시)
`index.ts` 지역 재정의 vs 전용 스키마 파일 대조:

| 파일 | 상태 | 처리 |
|---|---|---|
| `epics.ts` | **라이브 결함**(assignee_id 등 8필드 drop) | 본 PR 수정 |
| `docs.ts` | **라이브 결함**(slug_locked·sort_order drop) | 본 PR 수정 |
| `sprints.ts` | **라이브 결함**(success_hypothesis·metric_definition·measure_after drop, E-BOARD-SCHEMA 의도 필드) | 본 PR 수정 |
| `tasks.ts` | 죽은 코드뿐, 라이브 결함 없음(index.ts 쪽이 오히려 더 완전 — story_points 보유) | 후속 정리 대상, 이 PR 스코프 밖(동작 무변경) |
| `standup.ts` | 죽은 코드뿐, byte-identical(무해) | 후속 정리 대상 |

## 처방
①②③을 전용 파일로 필드 **합집합 병합**(어느 쪽 필드도 새로 자르지 않음) 후 `export { ... } from './epics'|'./docs'|'./sprints'`로 재노출 통일(hypothesis 패턴과 동형). `createEpicSchema`의 `project_id`/`org_id`가 이제 필수(`.min(1)`)가 되지만 실 호출부(`POST /api/goals` route.ts)는 항상 세션값으로 사전 백필하므로 무회귀.

## 검증
- `validation.test.ts`에 「success:true만 보면 이 클래스를 못 잡는다」는 교훈 반영한 **필드-값 실측** 회귀 테스트 4건 추가(epic assignee_id set/null 왕복·sprint outcome 필드·doc slug_locked/sort_order) — 전체 95건 green.
- `git apply -R`로 4건이 정확히 실패하는 것 확認(하중 증명).
- apps/web 관련 스위트(goals/docs/sprints route + goal service) 43건 전체 무회귀.
- 전체 `vitest` 3772/3772 테스트 green(무관 4 suite 실패는 로컬 `docx-preview` 미설치 — pre-existing, 무관 확認).
- 로컬 pnpm dev + 로컬 FastAPI로 실 curl 재현 성공 후 fix 적용 후 재현 소멸까지 확認(before/after 둘 다 실측).

## Test plan
- [x] validation.test.ts 신규 4건 green
- [x] 하중 증명(git apply -R)
- [x] apps/web goals/docs/sprints 관련 스위트 무회귀
- [x] 전체 vitest 무회귀(무관 pre-existing 실패 4건 제외)
- [x] 로컬 실 프록시 왕복 재현→수정→재현 소멸 확認
- [ ] CI green (대기)