### PR TITLE
[BUG·BE] GET /api/v2/gates가 gate_type·limit·offset 침묵 무시 — 근본수정

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -448,12 +448,34 @@ async def list_gates(
     work_item_id: uuid.UUID | None = Query(default=None),
     work_item_type: str | None = Query(default=None),
     status: str | None = Query(default=None),
+    # story #2864(P0, 침묵 스왈로): gate_type·limit·offset이 시그니처에 아예 없어 FastAPI가
+    # 미등재 쿼리 파라미터를 조용히 무시했다(#2863 zod dead-code와 동일 클래스 — 있다≠지금
+    # 쓰는 것). ⚠️`= Query(...)`를 직접 기본값으로 쓰지 않고 Annotated로 뺀 이유 — 이
+    # 라우터 함수는 HTTP 경유(FastAPI가 Query를 실값으로 해소)뿐 아니라 list_gate_inbox()가
+    # **일반 파이썬 함수로 직접 호출**한다(아래) + 테스트 다수가 동일하게 직접 호출한다.
+    # `= Query(default=None)`를 그대로 쓰면 그 호출자들이 이 인자를 안 넘겼을 때 실제
+    # 파이썬 기본값이 `None`이 아니라 Query 객체 그 자체가 돼(직접 호출은 FastAPI 의존성
+    # 해소를 안 거친다) `gate_type is not None`이 항상 참이 되고 `.limit(Query객체)`가
+    # SQLAlchemy에 그대로 들어가 런타임 TypeError로 터진다 — Annotated는 실제 파이썬
+    # 기본값을 리터럴로 유지하면서 Query 메타데이터(ge/le 등)만 얹는다.
+    gate_type: Annotated[str | None, Query()] = None,
     sort: str | None = Query(default=None),
     assigned_to_me: bool = Query(default=False),
+    # limit 기본값은 None(무제한) — list_gate_inbox의 「페이지네이션 없음(기존 GET /gates
+    # 관례 유지)」계약(미르코 합의, conversation eaa1b6cb)을 그대로 보존한다. 명시적으로
+    # 넘긴 경우에만 절단.
+    limit: Annotated[int | None, Query(ge=1, le=500)] = None,
+    offset: Annotated[int, Query(ge=0)] = 0,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
 ) -> list[GateResponse]:
+    # gate_type은 GATE_TYPES(GateCreateRequest.validate_gate_type과 동일 SSOT)로 검증 —
+    # 미지 값은 422(침묵 무시 대신 명시 거부).
+    if gate_type is not None:
+        from app.models.hitl_config import GATE_TYPES
+        if gate_type not in GATE_TYPES:
+            raise HTTPException(status_code=422, detail=f"gate_type must be one of {sorted(GATE_TYPES)}")
     q = select(Gate).where(Gate.org_id == org_id)
     if work_item_id:
         q = q.where(Gate.work_item_id == work_item_id)
@@ -461,11 +483,23 @@ async def list_gates(
         q = q.where(Gate.work_item_type == work_item_type)
     if status:
         q = q.where(Gate.status == status)
+    if gate_type:
+        q = q.where(Gate.gate_type == gate_type)
     # story #1973(P1a-S4): ?sort=urgency = SLA overdue 최상위 → age(created_at) 오래된 순 →
     # held(향후 만료) 최하단(gate_service.apply_gate_urgency_sort). 미지정 시(기본) 기존 동작
     # (무정렬/삽입순) 그대로 — 회귀 없음.
     if sort == "urgency":
         q = apply_gate_urgency_sort(q)
+    elif limit is not None or offset:
+        # story #2864: limit/offset이 결정적이려면 순서가 고정돼야 한다 — 무정렬(삽입순 암묵
+        # 의존)이었던 기존 동작을, 페이지네이션을 실제로 쓰는 호출에서만 created_at desc(최신
+        # 우선, 다른 목록 API들과 동형)로 명시. limit/offset 둘 다 안 쓰면 기존 무정렬 그대로
+        # (list_gate_inbox 등 기존 호출부 회귀 0).
+        q = q.order_by(Gate.created_at.desc())
+    if limit is not None:
+        q = q.limit(limit)
+    if offset:
+        q = q.offset(offset)
     result = await session.execute(q)
     gates = list(result.scalars().all())
     responses = [GateResponse.model_validate(g) for g in gates]

--- a/backend/tests/test_2864_gates_query_params_realdb.py
+++ b/backend/tests/test_2864_gates_query_params_realdb.py
@@ -1,0 +1,208 @@
+"""story #2864(P2, 침묵 스왈로) — GET /api/v2/gates가 gate_type·limit·offset 쿼리 파라미터를
+FastAPI 시그니처에 아예 등재하지 않아 조용히 무시했다(#2863 zod dead-code와 동일 결함
+클래스 — 「있다≠지금 쓰는 것」). 이 파일은 세 파라미터가 실제로 배선됐음을 값으로 실측한다:
+  ① gate_type이 실제로 필터한다(다른 gate_type 섞어 심고 한쪽만 필터링돼 나오는지 값 대조).
+  ② 미지 gate_type은 422(침묵 무시 대신 명시 거부) — GATE_TYPES SSOT 재사용 확認.
+  ③ limit이 실제로 절단한다(N건 심고 limit<N 요청 시 정확히 limit건).
+  ④ offset이 실제로 건너뛴다(limit+offset 조합으로 페이지 2가 페이지 1과 겹치지 않음).
+
+#2853/#2845/#2857과 동일 정신 — 격리 로컬 throwaway realdb만 사용(라이브 배포 시스템 무접촉).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("28640000-0000-0000-0000-000000000001")
+OWNER_USER = uuid.UUID("28640000-0000-0000-0000-0000000000a1")
+OWNER_OM = uuid.UUID("28640000-0000-0000-0000-0000000000b1")
+PROJ = uuid.UUID("28640000-0000-0000-0000-0000000000c1")
+STORY = uuid.UUID("28640000-0000-0000-0000-0000000000d1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth_human(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(ORG))
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed(s, *, n_merge: int = 1, n_qa: int = 1) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+    """ORG · PROJ · STORY(project_id=PROJ) · human owner(project_access). n_merge건의
+    gate_type='merge' + n_qa건의 gate_type='qa' 게이트를 created_at을 벌려 심는다(offset
+    페이지네이션 결정성 확보 — created_at desc 정렬이 새 기본 순서라 나중에 심을수록 앞).
+    (merge_ids, qa_ids) 반환 — created_at 순서(먼저 심은 것부터).
+    """
+    for sql in [
+        f"DELETE FROM gate WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{OWNER_USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S2864','s2864-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{OWNER_USER}','owner@s2864.test','x','Owner',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OWNER_OM}','{ORG}','{OWNER_USER}','member')",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','P','s2864-proj','warn')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{OWNER_OM}','granted','owner')",
+        f"INSERT INTO stories (id,org_id,project_id,title,status,priority) VALUES "
+        f"('{STORY}','{ORG}','{PROJ}','S','backlog','medium')",
+    ]:
+        await s.execute(text(sql))
+    from app.models.gate import Gate
+
+    merge_ids: list[uuid.UUID] = []
+    qa_ids: list[uuid.UUID] = []
+    seq = 0
+    for _ in range(n_merge):
+        gid = uuid.uuid4()
+        seq += 1
+        await s.execute(text(
+            "INSERT INTO gate (id,org_id,work_item_id,work_item_type,gate_type,status,"
+            "neutral_facts,created_at) VALUES "
+            f"('{gid}','{ORG}','{STORY}','story','merge','pending','{{}}',"
+            f"now() + interval '{seq} seconds')"
+        ))
+        merge_ids.append(gid)
+    for _ in range(n_qa):
+        gid = uuid.uuid4()
+        seq += 1
+        await s.execute(text(
+            "INSERT INTO gate (id,org_id,work_item_id,work_item_type,gate_type,status,"
+            "neutral_facts,created_at) VALUES "
+            f"('{gid}','{ORG}','{STORY}','story','qa','pending','{{}}',"
+            f"now() + interval '{seq} seconds')"
+        ))
+        qa_ids.append(gid)
+    await s.commit()
+    return merge_ids, qa_ids
+
+
+# ───────────────────────── ① gate_type 실 필터 ─────────────────────────
+
+@pytest.mark.anyio
+async def test_gate_type_filters_to_matching_type_only():
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            merge_ids, qa_ids = await _seed(s, n_merge=2, n_qa=3)
+
+        async with Session() as s:
+            listed = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, gate_type="merge",
+                sort=None, assigned_to_me=False, limit=100, offset=0,
+                session=s, org_id=ORG, auth=_auth_human(OWNER_USER),
+            )
+        got_ids = {g.id for g in listed}
+        assert got_ids == set(merge_ids), (
+            f"gate_type=merge가 실제로 필터하지 않으면 qa 게이트도 섞여 나온다: {got_ids}"
+        )
+        assert all(g.gate_type == "merge" for g in listed)
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── ② 미지 gate_type = 422 ─────────────────────────
+
+@pytest.mark.anyio
+async def test_unknown_gate_type_rejected_422():
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s, n_merge=1, n_qa=1)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await list_gates(
+                    work_item_id=None, work_item_type=None, status=None, gate_type="bogus_type_xyz",
+                    sort=None, assigned_to_me=False, limit=100, offset=0,
+                    session=s, org_id=ORG, auth=_auth_human(OWNER_USER),
+                )
+        assert exc_info.value.status_code == 422
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── ③ limit 실 절단 ─────────────────────────
+
+@pytest.mark.anyio
+async def test_limit_actually_truncates_result_count():
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            merge_ids, _qa_ids = await _seed(s, n_merge=5, n_qa=0)
+
+        async with Session() as s:
+            listed = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, gate_type=None,
+                sort=None, assigned_to_me=False, limit=2, offset=0,
+                session=s, org_id=ORG, auth=_auth_human(OWNER_USER),
+            )
+        assert len(listed) == 2, (
+            f"limit=2인데 {len(listed)}건 반환 — limit이 배선 안 됐으면 전체 5건이 나온다"
+        )
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── ④ offset 실 페이지네이션 ─────────────────────────
+
+@pytest.mark.anyio
+async def test_offset_paginates_without_overlap():
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            merge_ids, _qa_ids = await _seed(s, n_merge=5, n_qa=0)
+        # created_at desc 기본 정렬 — 나중에 심은(seq 큰) 게이트가 앞에 온다.
+        expected_order = list(reversed(merge_ids))
+
+        async with Session() as s:
+            page1 = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, gate_type=None,
+                sort=None, assigned_to_me=False, limit=2, offset=0,
+                session=s, org_id=ORG, auth=_auth_human(OWNER_USER),
+            )
+        async with Session() as s:
+            page2 = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, gate_type=None,
+                sort=None, assigned_to_me=False, limit=2, offset=2,
+                session=s, org_id=ORG, auth=_auth_human(OWNER_USER),
+            )
+
+        page1_ids = [g.id for g in page1]
+        page2_ids = [g.id for g in page2]
+        assert page1_ids == expected_order[0:2]
+        assert page2_ids == expected_order[2:4]
+        assert set(page1_ids).isdisjoint(page2_ids), "페이지 겹침 — offset이 배선 안 됐다면 두 페이지가 동일해진다"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2864_gates_query_params_realdb.py
+++ b/backend/tests/test_2864_gates_query_params_realdb.py
@@ -29,7 +29,6 @@ ORG = uuid.UUID("28640000-0000-0000-0000-000000000001")
 OWNER_USER = uuid.UUID("28640000-0000-0000-0000-0000000000a1")
 OWNER_OM = uuid.UUID("28640000-0000-0000-0000-0000000000b1")
 PROJ = uuid.UUID("28640000-0000-0000-0000-0000000000c1")
-STORY = uuid.UUID("28640000-0000-0000-0000-0000000000d1")
 
 
 @pytest.fixture
@@ -48,9 +47,12 @@ async def _engine():
 
 
 async def _seed(s, *, n_merge: int = 1, n_qa: int = 1) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
-    """ORG · PROJ · STORY(project_id=PROJ) · human owner(project_access). n_merge건의
-    gate_type='merge' + n_qa건의 gate_type='qa' 게이트를 created_at을 벌려 심는다(offset
-    페이지네이션 결정성 확보 — created_at desc 정렬이 새 기본 순서라 나중에 심을수록 앞).
+    """ORG · PROJ · human owner(project_access). n_merge건의 gate_type='merge' +
+    n_qa건의 gate_type='qa' 게이트를 created_at을 벌려 심는다(offset 페이지네이션
+    결정성 확보 — created_at desc 정렬이 새 기본 순서라 나중에 심을수록 앞).
+    ⚠️`uq_gate_work_item_gate_type`(org_id,work_item_id,work_item_type,gate_type) 유니크
+    제약 — 게이트 1건당 story(work_item) 1건을 새로 만들어 동일 work_item에 동일
+    gate_type을 중복 심지 않는다(CI real-PG에서 IntegrityError로 확인된 결함, #3283 회신).
     (merge_ids, qa_ids) 반환 — created_at 순서(먼저 심은 것부터).
     """
     for sql in [
@@ -71,35 +73,34 @@ async def _seed(s, *, n_merge: int = 1, n_qa: int = 1) -> tuple[list[uuid.UUID],
         f"('{PROJ}','{ORG}','P','s2864-proj','warn')",
         f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) VALUES "
         f"(gen_random_uuid(),'{PROJ}','{OWNER_OM}','granted','owner')",
-        f"INSERT INTO stories (id,org_id,project_id,title,status,priority) VALUES "
-        f"('{STORY}','{ORG}','{PROJ}','S','backlog','medium')",
     ]:
         await s.execute(text(sql))
-    from app.models.gate import Gate
 
     merge_ids: list[uuid.UUID] = []
     qa_ids: list[uuid.UUID] = []
     seq = 0
+
+    async def _insert_gate(gate_type: str) -> uuid.UUID:
+        nonlocal seq
+        seq += 1
+        story_id = uuid.uuid4()
+        gid = uuid.uuid4()
+        await s.execute(text(
+            "INSERT INTO stories (id,org_id,project_id,title,status,priority) VALUES "
+            f"('{story_id}','{ORG}','{PROJ}','S','backlog','medium')"
+        ))
+        await s.execute(text(
+            "INSERT INTO gate (id,org_id,work_item_id,work_item_type,gate_type,status,"
+            "neutral_facts,created_at) VALUES "
+            f"('{gid}','{ORG}','{story_id}','story','{gate_type}','pending','{{}}',"
+            f"now() + interval '{seq} seconds')"
+        ))
+        return gid
+
     for _ in range(n_merge):
-        gid = uuid.uuid4()
-        seq += 1
-        await s.execute(text(
-            "INSERT INTO gate (id,org_id,work_item_id,work_item_type,gate_type,status,"
-            "neutral_facts,created_at) VALUES "
-            f"('{gid}','{ORG}','{STORY}','story','merge','pending','{{}}',"
-            f"now() + interval '{seq} seconds')"
-        ))
-        merge_ids.append(gid)
+        merge_ids.append(await _insert_gate("merge"))
     for _ in range(n_qa):
-        gid = uuid.uuid4()
-        seq += 1
-        await s.execute(text(
-            "INSERT INTO gate (id,org_id,work_item_id,work_item_type,gate_type,status,"
-            "neutral_facts,created_at) VALUES "
-            f"('{gid}','{ORG}','{STORY}','story','qa','pending','{{}}',"
-            f"now() + interval '{seq} seconds')"
-        ))
-        qa_ids.append(gid)
+        qa_ids.append(await _insert_gate("qa"))
     await s.commit()
     return merge_ids, qa_ids
 


### PR DESCRIPTION
[SID:2864]

## 요약
#2863(schema dead-code)와 동일한 「침묵 스왈로」결함 클래스의 BE판. `list_gates()`
시그니처에 `gate_type`·`limit`·`offset`이 아예 없어 FastAPI가 미등재 쿼리 파라미터를
조용히 무시하고 있었다(bogus 값을 줘도 항상 전체 결과 반환 — 페드루 라이브 실측 362=362).

## 근본원인 + 처방
- `gate_type`: 시그니처에 파라미터 자체가 없었다 → 추가 + `GATE_TYPES`
  (`GateCreateRequest.validate_gate_type`과 동일 SSOT)로 검증. 미지 값은 **422**
  (침묵 무시 대신 명시 거부).
- `limit`/`offset`: 마찬가지로 파라미터 자체가 없었다 → 추가, SQL 레벨 실 적용.
- ⚠️`= Query(default=X)`를 그대로 쓰지 않고 `Annotated[T, Query(...)] = literal`로
  뺐다 — `list_gates()`는 HTTP 경유(FastAPI가 Query를 실값으로 해소)뿐 아니라
  `list_gate_inbox()`가 **일반 파이썬 함수로 직접 호출**하고, 기존 테스트 10개
  파일도 동일하게 직접 호출한다. `Query(default=None)`을 그대로 쓰면 그 호출자들이
  신규 인자를 안 넘겼을 때 실제 파이썬 기본값이 Query 객체 그 자체가 돼(직접 호출은
  FastAPI 의존성 해소를 안 거친다) 즉시 오탐 422 또는 `.limit(Query객체)` SQLAlchemy
  런타임 TypeError로 터진다 — 전체 스윕에서 직접 확인(50건 신규 실패, load-bearing
  증명 중 발견·아래 검증 항목 참조). Annotated는 실제 파이썬 기본값을 리터럴로
  유지하며 Query 메타데이터(ge/le)만 얹어 이 결함 클래스를 원천 차단한다.
- `limit` 기본값은 100이 아니라 **None(무제한)** — `list_gate_inbox`의 「페이지네이션
  없음(기존 GET /gates 관례 유지)」계약(미르코 FE 합의, conversation eaa1b6cb)을
  그대로 보존. 명시적으로 넘긴 경우에만 절단.
- 정렬: limit/offset을 실제로 쓰는 호출에서만 `created_at desc`로 명시(페이지네이션
  결정성 확보). 안 쓰는 기존 호출(`list_gate_inbox` 등)은 기존 무정렬 그대로 —
  회귀 0.

## 기존 소비처 스윕(그라운딩 결과)
FE(`apps/web`) 전수 grep — 현재 어떤 소비처도 `gate_type`/`limit`/`offset`을 쓰지
않는다(`work_item_id`/`work_item_type`/`status`/`assigned_to_me`/`sort`만 사용).
즉 지금 당장 FE 동작 변화는 0건 — 이 결함은 "쓰이는 중인 값이 드롭됨"이 아니라
"쓸 수 없는 상태로 방치돼 다음에 누가 붙여도 조용히 무시당할 지뢰"였다(#2863과 대칭
— 같은 결함 클래스, 다른 침투 시점).

## 검증
- 신규 realdb 테스트 4건(격리 로컬 스크래치 Postgres, 라이브 무접촉):
  ① gate_type 실 필터 ② 미지 gate_type=422 ③ limit 실 절단 ④ offset 실 페이지네이션
  (겹침 없음). `git apply -R`로 fix 제거 시 4건 전부 실패 확인(load-bearing 증명).
- `list_gates()` 직접호출 기존 테스트 10파일·140개 케이스 전수 재실행 — 전부
  무회귀(Annotated 전환으로 기존 호출부가 신규 파라미터를 몰라도 안전 기본값 수신
  — 이 회귀는 최초 구현에서 실제로 발생시켰다가 전수 스윕으로 잡아 고친 것).

🤖 Generated with [Claude Code](https://claude.com/claude-code)