### PR TITLE
[SID:2865] 법적 고지 인앱 도달 경로 — GNB 상시 접근 + 설정 전역 하단 노출

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+//
+// story #2865 — 설정 페이지 하단 법적 고지 푸터가 프로필 탭 전용 카드에서 «전 탭 공통
+// 하단 푸터»로 승격됐다. 배선이 아니라 «표시를 테스트»한다: profile이 아닌 다른 탭이
+// 활성일 때도 이용약관/개인정보처리방침/환불정책+사업자정보가 실제로 렌더되는지, 그리고
+// 프로필 탭 안에는 더 이상 중복 렌더가 없는지 화면 결과로 확인한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../messages/ko.json';
+
+const { useDashboardContextMock } = vi.hoisted(() => ({
+  useDashboardContextMock: vi.fn(),
+}));
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), refresh: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams('tab=appearance'),
+  usePathname: () => '/settings',
+}));
+
+vi.mock('@/lib/db/client', () => ({
+  fetchWithAuth: vi.fn(async () => ({ ok: false, json: async () => ({ data: null }) })),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({ orgId: 'org-1', orgMemberships: [] });
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({ data: null }) })));
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+async function mount(node: React.ReactNode) {
+  await act(async () => { root.render(wrap(node)); });
+}
+
+describe('SettingsPage — 전역 법적 고지 푸터 (story #2865)', () => {
+  it('profile이 아닌 탭(appearance)이 활성이어도 정책·사업자정보가 렌더된다', async () => {
+    const { default: SettingsPage } = await import('./page');
+    await mount(<SettingsPage />);
+
+    const text = container.textContent ?? '';
+    expect(text).toContain('이용약관');
+    expect(text).toContain('개인정보처리방침');
+    expect(text).toContain('환불정책');
+    expect(text).toContain('주식회사 뭉클랩');
+
+    const anchors = Array.from(container.querySelectorAll('a'));
+    const hrefs = anchors.map((a) => a.getAttribute('href'));
+    expect(hrefs).toContain('/terms');
+    expect(hrefs).toContain('/privacy');
+    expect(hrefs).toContain('/refund-policy');
+  });
+
+  it('전역 푸터는 정확히 1벌만 렌더된다 (프로필 탭 중복 제거 확인)', async () => {
+    const { default: SettingsPage } = await import('./page');
+    await mount(<SettingsPage />);
+
+    const termsLinks = Array.from(container.querySelectorAll('a[href="/terms"]'));
+    expect(termsLinks).toHaveLength(1);
+  });
+});

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -802,21 +802,6 @@ export default function SettingsPage() {
                   />
                 )}
                 <BlockedUsersSection />
-
-                <SectionCard>
-                  <SectionCardHeader>
-                    <div className="space-y-1">
-                      <h2 className="text-base font-semibold text-foreground">{tLegal('policiesHeading')}</h2>
-                    </div>
-                  </SectionCardHeader>
-                  <SectionCardBody className="space-y-4">
-                    <LegalLinks className="justify-start text-sm text-muted-foreground" />
-                    <div className="border-t border-border pt-4">
-                      <p className="mb-1.5 text-xs font-medium text-muted-foreground">{tLegal('businessInfoHeading')}</p>
-                      <BusinessInfoBlock className="justify-start text-xs text-muted-foreground" />
-                    </div>
-                  </SectionCardBody>
-                </SectionCard>
               </div>
             </TabsContent>
 
@@ -1371,6 +1356,15 @@ export default function SettingsPage() {
               </SectionCard>
             </TabsContent>
 
+            {/* 설정 전역 법적 고지 푸터 — 활성 탭 무관 상시 노출 (story #2865) */}
+            <div className="mt-8 border-t border-border pt-6">
+              <h2 className="mb-3 text-sm font-medium text-foreground">{tLegal('policiesHeading')}</h2>
+              <LegalLinks className="justify-start text-sm text-muted-foreground" />
+              <div className="mt-4 border-t border-border pt-4">
+                <p className="mb-1.5 text-xs font-medium text-muted-foreground">{tLegal('businessInfoHeading')}</p>
+                <BusinessInfoBlock className="justify-start text-xs text-muted-foreground" />
+              </div>
+            </div>
           </div>
         </div>
       </Tabs>

--- a/apps/web/src/components/nav/profile-menu.test.tsx
+++ b/apps/web/src/components/nav/profile-menu.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// story #2865 — ProfileMenu 드롭다운에 「약관 및 정책」 그룹(3링크)이 상시 접근 경로로
+// 추가됐다. 배선이 아니라 «표시를 테스트»한다: 드롭다운을 열었을 때 3개 링크가 실제로
+// 렌더되고 기존 legal 라우트로 걸리는지 화면 결과로 확인한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ProfileMenu } from './profile-menu';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), refresh: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/',
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, json: async () => ({ data: { accounts: [] } }) })),
+  );
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  document.querySelectorAll('[data-slot="dropdown-menu-content"]').forEach((el) => el.remove());
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+async function mount(node: React.ReactNode) {
+  await act(async () => { root.render(wrap(node)); });
+}
+
+async function openMenu() {
+  const trigger = container.querySelector('[data-slot="dropdown-menu-trigger"]') as HTMLElement;
+  expect(trigger).toBeTruthy();
+  await act(async () => { trigger.click(); });
+}
+
+describe('ProfileMenu — 약관 및 정책 드롭다운 그룹 (story #2865)', () => {
+  it('드롭다운을 열면 약관 및 정책 3링크가 렌더되고 기존 legal 라우트로 걸린다', async () => {
+    await mount(<ProfileMenu name="송윤재" />);
+    await openMenu();
+
+    // base-ui Menu.Portal은 document.body에 렌더된다(컨테이너 내부가 아님).
+    const anchors = Array.from(document.querySelectorAll('[data-slot="dropdown-menu-content"] a'));
+    const hrefs = anchors.map((a) => a.getAttribute('href'));
+    expect(hrefs).toContain('/terms');
+    expect(hrefs).toContain('/privacy');
+    expect(hrefs).toContain('/refund-policy');
+
+    const labels = anchors.map((a) => a.textContent);
+    expect(labels).toContain('이용약관');
+    expect(labels).toContain('개인정보처리방침');
+    expect(labels).toContain('환불정책');
+  });
+
+  it('약관 및 정책 그룹이 설정↔로그아웃 사이에 위치한다', async () => {
+    await mount(<ProfileMenu name="송윤재" />);
+    await openMenu();
+
+    const content = document.querySelector('[data-slot="dropdown-menu-content"]');
+    expect(content).toBeTruthy();
+    const items = Array.from(content!.querySelectorAll('[role="menuitem"]')).map(
+      (el) => el.textContent ?? '',
+    );
+    const settingsIdx = items.findIndex((t) => t.includes('설정'));
+    const termsIdx = items.findIndex((t) => t.includes('이용약관'));
+    const signOutIdx = items.findIndex((t) => t.includes('로그아웃'));
+    expect(settingsIdx).toBeGreaterThanOrEqual(0);
+    expect(termsIdx).toBeGreaterThan(settingsIdx);
+    expect(signOutIdx).toBeGreaterThan(termsIdx);
+  });
+
+  it('raw i18n 키가 노출되지 않는다', async () => {
+    await mount(<ProfileMenu name="송윤재" />);
+    await openMenu();
+    const text = document.querySelector('[data-slot="dropdown-menu-content"]')?.textContent ?? '';
+    expect(text).not.toMatch(/policiesHeading|termsOfService|privacyPolicy|refundPolicy/);
+  });
+});

--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 import { ACCOUNT_CAP } from '@/lib/auth/account-limits';
+import { LEGAL_DOC_ROUTES } from '@/lib/legal/business-info';
 
 interface Account {
   account_id: string;
@@ -68,6 +69,7 @@ export function ProfileMenu({ name, avatarUrl }: ProfileMenuProps) {
   const t = useTranslations('accountSwitcher');
   const tc = useTranslations('common');
   const tn = useTranslations('nav');
+  const tLegal = useTranslations('legal');
 
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [busy, setBusy] = useState<string | null>(null); // account_id | 'add' | 'signout'
@@ -214,6 +216,20 @@ export function ProfileMenu({ name, avatarUrl }: ProfileMenuProps) {
           <Settings className="size-4" />
           {tn('settings')}
         </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          {/* GroupLabel(base-ui)은 반드시 Group 내부 — Popup 직속이면 error #31 크래시(story #2865). */}
+          <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">{tLegal('policiesHeading')}</DropdownMenuLabel>
+          <DropdownMenuItem render={<Link href={LEGAL_DOC_ROUTES.terms} />}>
+            {tLegal('termsOfService')}
+          </DropdownMenuItem>
+          <DropdownMenuItem render={<Link href={LEGAL_DOC_ROUTES.privacy} />}>
+            {tLegal('privacyPolicy')}
+          </DropdownMenuItem>
+          <DropdownMenuItem render={<Link href={LEGAL_DOC_ROUTES.refundPolicy} />}>
+            {tLegal('refundPolicy')}
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           disabled={busy !== null}


### PR DESCRIPTION
## Summary
- ProfileMenu 드롭다운(설정↔로그아웃 사이)에 「약관 및 정책」 DropdownMenuGroup(이용약관·개인정보처리방침·환불정책 3링크) 추가 — 어느 화면에서든 GNB 사이드바 하단 프로필 메뉴로 1클릭 상시 접근.
- 설정 페이지 약관 SectionCard를 profile 탭 전용(구 L807-820)에서 **전 탭 공통 하단 푸터**로 승격, profile 탭 내 중복 렌더 제거.
- 신규 컴포넌트/라우트/i18n 문자열 0 — `legal-footer.tsx`의 `LegalLinks`/`BusinessInfoBlock` 기존 자산만 재사용, SSOT(`lib/legal/business-info.ts`) 무변경.
- 유나 홀름 디자인 핸드오프 doc(`legal-notice-inapp-handoff-2865`) 스펙 그대로 구현.

## Test plan
- [x] `pnpm type-check` — 그린
- [x] `pnpm lint` — 0 errors (기존 무관 파일 warning 5건은 pre-existing, 이 PR 변경분 아님)
- [x] `pnpm build` — 그린, `/settings`·`/loop-queue` 등 라우트 정상 착지
- [x] `pnpm exec vitest run` — 456 files / 3793 tests 전부 그린 (신규 5건: profile-menu.test.tsx 3 + settings/page.test.tsx 2)
- [x] `verify:no-new-tint-color-text` / `verify:no-i18n-phrase-collision` / `verify:no-new-raw-fetch-api` — 신규 위반 0건
- [ ] dev 라이브 픽셀(라이트/다크 × ko/en) — 머지 후 진행

Story: [SID:2865]

🤖 Generated with [Claude Code](https://claude.com/claude-code)