### PR TITLE
[SID:2042][BUG·BE] gates·evidence authz 비대칭 근본수정 — 겉은 하나였지만 병은 둘

### DIFF
--- a/backend/app/routers/evidence.py
+++ b/backend/app/routers/evidence.py
@@ -196,8 +196,14 @@ async def create_evidence(
     auth: AuthContext = Depends(get_current_user),
 ) -> EvidenceResponse:
     caller = await resolve_member(auth, org_id, session)
+    # story #2042/#1936(같은 결함 클래스, 실측으로 확定): resolve_member().id는 휴먼일 때
+    # org_member.id인데 has_project_access가 기대하는 축은 raw auth.user_id(users.id) —
+    # human_grant_branch/admin_branch가 OrgMember.user_id로 매칭하기 때문(project_auth.py
+    # _project_access_predicate). caller.id를 넘기면 project_access(granted)로 정당하게
+    # 접근권을 가진 휴먼도 team_member_branch 매치 실패 시 403으로 튕긴다 — 코드베이스
+    # 전역 40+ 콜사이트가 전부 uuid.UUID(auth.user_id)를 직접 쓰는 것과 이 파일만 달랐다.
     project_id = await _assert_work_item_access(
-        session, body.work_item_id, body.work_item_type, caller.id, org_id
+        session, body.work_item_id, body.work_item_type, uuid.UUID(auth.user_id), org_id
     )
 
     artifact_version_id = None
@@ -236,8 +242,9 @@ async def list_evidence(
     if work_item_type not in _WORK_ITEM_TYPES:
         raise HTTPException(status_code=400, detail=f"work_item_type must be one of {sorted(_WORK_ITEM_TYPES)}")
 
-    caller = await resolve_member(auth, org_id, session)
-    await _assert_work_item_access(session, work_item_id, work_item_type, caller.id, org_id)
+    # story #2042/#1936 — caller.id(resolve_member) 대신 raw auth.user_id(위 create_evidence
+    # 주석과 동일 근거). resolve_member 호출 자체가 이 authz 판정엔 불필요해 제거(쿼리 1회 절감).
+    await _assert_work_item_access(session, work_item_id, work_item_type, uuid.UUID(auth.user_id), org_id)
 
     result = await session.execute(
         select(Evidence).where(
@@ -267,9 +274,10 @@ async def get_evidence(
     if evidence is None:
         raise HTTPException(status_code=404, detail="Evidence not found")
 
-    caller = await resolve_member(auth, org_id, session)
+    # story #2042/#1936 — caller.id(resolve_member) 대신 raw auth.user_id(create_evidence
+    # 주석 참조, 동일 축 정합).
     project_id = await _project_id_of_evidence(session, org_id, id)
-    if project_id is None or not await has_project_access(session, caller.id, project_id, org_id):
+    if project_id is None or not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
         raise HTTPException(status_code=404, detail="Evidence not found")
 
     resolved_story_id: uuid.UUID | None = None

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -477,25 +477,38 @@ async def list_gates(
         if gate_type not in GATE_TYPES:
             raise HTTPException(status_code=422, detail=f"gate_type must be one of {sorted(GATE_TYPES)}")
 
-    # story #2042(P0, 침묵 스왈로 대칭 — 이번엔 authz 방향): work_item_id+work_item_type로
-    # 필터할 때 이 라우트는 org_id 스코프만 걸고 project 접근권을 아예 안 물었다(has_project_
-    # access 호출 0) — 같은 work_item을 읽는 get_gate_endpoint(단건, :{id})·evidence.py
-    # list_evidence는 project 인가를 강제하는데 이 목록 경로만 조직 전체에 열려 있어, project
-    # 밖 사용자가 evidence는 403으로 막히면서 gates는 200으로 새는 비대칭이 실측됐다(PO 그라운딩
+    # story #2042(P0, 침묵 스왈로 대칭 — 이번엔 authz 방향): work_item_id로 필터할 때 이
+    # 라우트는 org_id 스코프만 걸고 project 접근권을 아예 안 물었다(has_project_access 호출
+    # 0) — 같은 work_item을 읽는 get_gate_endpoint(단건, :{id})·evidence.py list_evidence는
+    # project 인가를 강제하는데 이 목록 경로만 조직 전체에 열려 있어, project 밖 사용자가
+    # evidence는 403으로 막히면서 gates는 200으로 새는 비대칭이 실측됐다(PO 그라운딩
     # 2026-07-20). 처방: get_gate_endpoint와 동일 판정(require_project_access, SSOT #2697)을
     # 여기도 물린다 — 존재 비노출 관례를 그대로 따라 거부는 404(evidence의 403과 문구는
     # 다르지만 allow/deny 판정 자체는 동일 has_project_access predicate라 AC2 일치).
-    # ⚠️work_item_type 없이 work_item_id만 오는 호출(artifact-section.tsx 등 status=pending
-    # 병용 경로)은 project_id를 해소할 축이 없어 기존 동작대로 미검사 — 별도 스코프(후속 판단).
-    if work_item_id is not None and work_item_type is not None:
-        project_id_scope = await resolve_work_item_project_id(
-            session, org_id, work_item_type, work_item_id,
-        )
-        if project_id_scope is not None:
-            await require_project_access(session, uuid.UUID(auth.user_id), project_id_scope, org_id,
-                                          not_found_detail="Gate not found")
-        elif not is_known_project_agnostic_work_item_type(work_item_type):
-            raise HTTPException(status_code=404, detail="Gate not found")
+    # ⚠️PO 리뷰 지적(2026-08-21): work_item_type 없이 work_item_id만 오는 호출(artifact-
+    # section.tsx의 status=pending 병용 경로 등)을 검사 없이 통과시키면 그 필드만 생략해
+    # 인가를 우회할 수 있다(반쪽 봉합) — work_item_type을 클라 입력값으로 "추측"하는 대신
+    # gate 테이블 자신(SSOT)에서 그 work_item_id가 실제로 쓰는 work_item_type을 먼저
+    # 조회해 동일 검사를 무조건 물린다. 게이트가 0건이면(가드가 지킬 대상 자체가 없음)
+    # 조회를 스킵 — 정보 누출 없음(빈 결과는 접근거부/무매치 둘 다 동일하게 []).
+    if work_item_id is not None:
+        if work_item_type is not None:
+            resolved_wi_types = [work_item_type]
+        else:
+            resolved_wi_types = list((await session.execute(
+                select(Gate.work_item_type).where(
+                    Gate.org_id == org_id, Gate.work_item_id == work_item_id,
+                ).distinct()
+            )).scalars().all())
+        for wi_type in resolved_wi_types:
+            project_id_scope = await resolve_work_item_project_id(
+                session, org_id, wi_type, work_item_id,
+            )
+            if project_id_scope is not None:
+                await require_project_access(session, uuid.UUID(auth.user_id), project_id_scope, org_id,
+                                              not_found_detail="Gate not found")
+            elif not is_known_project_agnostic_work_item_type(wi_type):
+                raise HTTPException(status_code=404, detail="Gate not found")
 
     q = select(Gate).where(Gate.org_id == org_id)
     if work_item_id:

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -476,6 +476,27 @@ async def list_gates(
         from app.models.hitl_config import GATE_TYPES
         if gate_type not in GATE_TYPES:
             raise HTTPException(status_code=422, detail=f"gate_type must be one of {sorted(GATE_TYPES)}")
+
+    # story #2042(P0, 침묵 스왈로 대칭 — 이번엔 authz 방향): work_item_id+work_item_type로
+    # 필터할 때 이 라우트는 org_id 스코프만 걸고 project 접근권을 아예 안 물었다(has_project_
+    # access 호출 0) — 같은 work_item을 읽는 get_gate_endpoint(단건, :{id})·evidence.py
+    # list_evidence는 project 인가를 강제하는데 이 목록 경로만 조직 전체에 열려 있어, project
+    # 밖 사용자가 evidence는 403으로 막히면서 gates는 200으로 새는 비대칭이 실측됐다(PO 그라운딩
+    # 2026-07-20). 처방: get_gate_endpoint와 동일 판정(require_project_access, SSOT #2697)을
+    # 여기도 물린다 — 존재 비노출 관례를 그대로 따라 거부는 404(evidence의 403과 문구는
+    # 다르지만 allow/deny 판정 자체는 동일 has_project_access predicate라 AC2 일치).
+    # ⚠️work_item_type 없이 work_item_id만 오는 호출(artifact-section.tsx 등 status=pending
+    # 병용 경로)은 project_id를 해소할 축이 없어 기존 동작대로 미검사 — 별도 스코프(후속 판단).
+    if work_item_id is not None and work_item_type is not None:
+        project_id_scope = await resolve_work_item_project_id(
+            session, org_id, work_item_type, work_item_id,
+        )
+        if project_id_scope is not None:
+            await require_project_access(session, uuid.UUID(auth.user_id), project_id_scope, org_id,
+                                          not_found_detail="Gate not found")
+        elif not is_known_project_agnostic_work_item_type(work_item_type):
+            raise HTTPException(status_code=404, detail="Gate not found")
+
     q = select(Gate).where(Gate.org_id == org_id)
     if work_item_id:
         q = q.where(Gate.work_item_id == work_item_id)

--- a/backend/tests/test_2042_gates_evidence_authz_parity_realdb.py
+++ b/backend/tests/test_2042_gates_evidence_authz_parity_realdb.py
@@ -145,6 +145,32 @@ async def test_gates_denies_human_with_no_project_access():
         await eng.dispose()
 
 
+# ───────────── ②' PO 리뷰 지적(2026-08-21): work_item_type 생략(id-only)만으로 우회 ─────────────
+
+@pytest.mark.anyio
+async def test_gates_denies_id_only_call_without_work_item_type():
+    """work_item_type을 안 넘기면(artifact-section.tsx의 실제 호출 형태) 가드를 안 타고
+    그대로 새던 구멍 — work_item_id만으로도 동일 인가가 걸려야 한다(work_item_type을
+    클라 입력으로 추측하지 않고 gate 테이블 자신에서 실제 타입을 조회해 검사)."""
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await list_gates(
+                    work_item_id=STORY, work_item_type=None, status=None, gate_type=None,
+                    sort=None, assigned_to_me=False, limit=None, offset=0,
+                    session=s, org_id=ORG, auth=_auth_human(DENIED_USER),
+                )
+        assert exc_info.value.status_code == 404, (
+            "work_item_type 생략만으로 인가가 우회되면(id-only bypass) 원 결함이 반쪽만 봉합된 것"
+        )
+    finally:
+        await eng.dispose()
+
+
 # ───────────── AC2 — 같은 사용자·같은 work_item, evidence·gates 판정 일치(양쪽 다) ─────────────
 
 @pytest.mark.anyio

--- a/backend/tests/test_2042_gates_evidence_authz_parity_realdb.py
+++ b/backend/tests/test_2042_gates_evidence_authz_parity_realdb.py
@@ -1,0 +1,202 @@
+"""story #2042(P0, gates·evidence authz 비대칭) — 같은 세션·같은 work_item인데 GET /evidence만
+403이고 GET /gates는 200(PO 그라운딩 2026-07-20, 실측 확定). 원인은 두 갈래였다(실측으로 확인,
+겉으론 하나처럼 보였지만 다른 병):
+
+  ① evidence.py 축 불일치(story #1936과 동일 결함 클래스): `_assert_work_item_access`/
+     `get_evidence`가 `resolve_member().id`(휴먼일 때 org_member.id)를 `has_project_access`에
+     넘겼는데, 그 함수의 human_grant_branch/admin_branch는 `OrgMember.user_id`(raw users.id)로
+     매칭한다(project_auth.py `_project_access_predicate`) — team_member 행이 없는 순수
+     project_access(granted) 휴먼은 정당한 접근권이 있어도 403으로 튕겼다. 코드베이스 전역
+     40+ has_project_access 콜사이트가 전부 `uuid.UUID(auth.user_id)`를 직접 쓰는 것과 이
+     파일만 달랐다.
+  ② gates.py list_gates()가 work_item_id+work_item_type 필터가 있어도 project 접근권을 아예
+     안 물었다(org_id 스코프만) — 단건 조회(get_gate_endpoint)·evidence는 project 인가를
+     강제하는데 목록만 조직 전체에 열려 있어, project 밖 사용자에게 게이트 정보가 샌다.
+
+이 파일은 두 축을 각각+조합으로 실측한다: (A) project_access(granted)만 있고 team_member는
+없는 휴먼 — 수정 전엔 evidence 403(①의 직접 피해자), 수정 후 evidence·gates 둘 다 허용.
+(B) project_access가 전혀 없는 휴먼 — 수정 전엔 gates 200(②의 직접 피해자, 정보 노출),
+수정 후 evidence·gates 둘 다 거부(AC2 "같은 판정" 그 자체를 값으로 단언).
+
+#2853/#2845/#2857과 동일 정신 — 격리 로컬 throwaway realdb만 사용(라이브 배포 시스템 무접촉).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("20420000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("20420000-0000-0000-0000-0000000000c1")
+STORY = uuid.UUID("20420000-0000-0000-0000-0000000000d1")
+GRANTED_USER = uuid.UUID("20420000-0000-0000-0000-0000000000a1")   # project_access(granted)만, team_member 없음
+GRANTED_OM = uuid.UUID("20420000-0000-0000-0000-0000000000b1")
+DENIED_USER = uuid.UUID("20420000-0000-0000-0000-0000000000a2")    # 접근권 전무
+DENIED_OM = uuid.UUID("20420000-0000-0000-0000-0000000000b2")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth_human(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(ORG))
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed(s) -> None:
+    """ORG · PROJ · STORY(project_id=PROJ) · gate 1건(merge) · evidence 1건.
+    GRANTED_USER: org_members 행 + project_access(granted) — team_member 행은 만들지 않는다
+    (①의 정확한 재현 조건 — team_member_branch 우회로 축 불일치가 가려지지 않게).
+    DENIED_USER: org_members 행만(같은 org 멤버지만 이 project엔 어떤 접근권도 없음)."""
+    for sql in [
+        f"DELETE FROM evidence WHERE org_id='{ORG}'",
+        f"DELETE FROM gate WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id IN ('{GRANTED_USER}','{DENIED_USER}')",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S2042','s2042-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{GRANTED_USER}','granted@s2042.test','x','Granted',true,true,0,false,0),"
+        f"('{DENIED_USER}','denied@s2042.test','x','Denied',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"('{GRANTED_OM}','{ORG}','{GRANTED_USER}','member'),"
+        f"('{DENIED_OM}','{ORG}','{DENIED_USER}','member')",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','P','s2042-proj','warn')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{GRANTED_OM}','granted','member')",
+        f"INSERT INTO stories (id,org_id,project_id,title,status,priority) VALUES "
+        f"('{STORY}','{ORG}','{PROJ}','S','backlog','medium')",
+        "INSERT INTO gate (id,org_id,work_item_id,work_item_type,gate_type,status,neutral_facts,"
+        f"created_at) VALUES (gen_random_uuid(),'{ORG}','{STORY}','story','merge','pending','{{}}',now())",
+        "INSERT INTO evidence (id,org_id,work_item_id,work_item_type,type,ref,created_by,created_at) "
+        f"VALUES (gen_random_uuid(),'{ORG}','{STORY}','story','url','https://example.test/x',"
+        f"'{GRANTED_OM}',now())",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+# ───────────── ① evidence 축 불일치: project_access(granted)만 있는 휴먼 ─────────────
+
+@pytest.mark.anyio
+async def test_evidence_allows_project_access_granted_human_without_team_member():
+    from app.routers.evidence import list_evidence
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            items = await list_evidence(
+                work_item_id=STORY, work_item_type="story",
+                session=s, org_id=ORG, auth=_auth_human(GRANTED_USER),
+            )
+        assert len(items) == 1, (
+            "project_access(granted)만 있고 team_member가 없는 휴먼은 정당한 접근권자다 — "
+            "축 불일치(caller.id=org_member.id를 has_project_access에 넘김)가 있으면 403으로 튕긴다"
+        )
+    finally:
+        await eng.dispose()
+
+
+# ───────────── ② gates 노출: project_access가 전혀 없는 휴먼도 200이었다 ─────────────
+
+@pytest.mark.anyio
+async def test_gates_denies_human_with_no_project_access():
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await list_gates(
+                    work_item_id=STORY, work_item_type="story", status=None, gate_type=None,
+                    sort=None, assigned_to_me=False, limit=None, offset=0,
+                    session=s, org_id=ORG, auth=_auth_human(DENIED_USER),
+                )
+        assert exc_info.value.status_code == 404, (
+            "project 접근권이 전혀 없는 사용자가 이 work_item의 gate를 조회하면 거부돼야 한다 — "
+            "list_gates가 org_id만 스코프하면(project 인가 미검사) 200으로 새 나간다(정보 노출)"
+        )
+    finally:
+        await eng.dispose()
+
+
+# ───────────── AC2 — 같은 사용자·같은 work_item, evidence·gates 판정 일치(양쪽 다) ─────────────
+
+@pytest.mark.anyio
+async def test_evidence_and_gates_agree_for_granted_user():
+    from app.routers.evidence import list_evidence
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            ev = await list_evidence(
+                work_item_id=STORY, work_item_type="story",
+                session=s, org_id=ORG, auth=_auth_human(GRANTED_USER),
+            )
+        async with Session() as s:
+            gates = await list_gates(
+                work_item_id=STORY, work_item_type="story", status=None, gate_type=None,
+                sort=None, assigned_to_me=False, limit=None, offset=0,
+                session=s, org_id=ORG, auth=_auth_human(GRANTED_USER),
+            )
+        assert len(ev) == 1 and len(gates) == 1, "granted 휴먼은 evidence·gates 둘 다 봐야 한다(둘 다 허용)"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_evidence_and_gates_agree_for_denied_user():
+    from app.routers.evidence import list_evidence
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ev_exc:
+                await list_evidence(
+                    work_item_id=STORY, work_item_type="story",
+                    session=s, org_id=ORG, auth=_auth_human(DENIED_USER),
+                )
+        async with Session() as s:
+            with pytest.raises(HTTPException) as gate_exc:
+                await list_gates(
+                    work_item_id=STORY, work_item_type="story", status=None, gate_type=None,
+                    sort=None, assigned_to_me=False, limit=None, offset=0,
+                    session=s, org_id=ORG, auth=_auth_human(DENIED_USER),
+                )
+        # 상태코드 문구(403 vs 404, existence-hiding 관례 차이)는 각 라우터 고유 스타일 —
+        # AC2가 요구하는 「접근 판정(허용/거부)이 일치」는 둘 다 4xx로 거부되는 것으로 충분.
+        assert ev_exc.value.status_code in (403, 404)
+        assert gate_exc.value.status_code in (403, 404)
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
[SID:2042]

## 요약
같은 세션·같은 work_item인데 `GET /api/v2/evidence`만 403이고 `GET /api/v2/gates`는 200이던
비대칭(PO 그라운딩 2026-07-20)을 근본수정. 재현·실측 결과 겉은 하나의 비대칭이었지만 병은
둘이었다.

## AC1(어느 쪽이 정본인지) — PO 판정 그대로 적용
gates를 project 인가로 조인다(스토리 본문 PO 방향, 뒤집을 근거 없어 그대로 채택). evidence를
느슨하게 푸는 방향은 채택 안 함(정보 노출 확대 축이라 배제).

## 실측으로 확定한 두 개의 별개 결함

**① evidence.py 축 불일치**(story #1936과 동일 결함 클래스) — `_assert_work_item_access`/
`get_evidence`가 `resolve_member().id`(휴먼일 때 org_member.id)를 `has_project_access`에
넘겼다. 그 함수의 human_grant_branch/admin_branch는 `OrgMember.user_id`(raw users.id)로
매칭한다(`project_auth.py::_project_access_predicate`) — `project_access`(granted)만 있고
`team_member` 행이 없는 정당한 접근권자가 403으로 튕겼다. 코드베이스 전역 has_project_access
콜사이트 40+ 곳이 전부 `uuid.UUID(auth.user_id)`를 직접 쓰는데 evidence.py 3곳(create_evidence/
list_evidence/get_evidence)만 `caller.id`를 썼다 — 전부 `uuid.UUID(auth.user_id)`로 정정.

**② gates.py list_gates() 미검사**(원 리포트의 직접 원인) — `work_item_id`+`work_item_type`로
필터해도 `org_id` 스코프만 걸고 project 접근권을 아예 안 물었다(`has_project_access` 호출 0).
단건 조회(`get_gate_endpoint`)는 이미 `require_project_access`(SSOT #2697)로 강제하는데
목록 경로만 조직 전체에 열려 있었다 — 같은 판정 함수·같은 축으로 물렸다.

## 스코프 경계
- `work_item_type` 없이 `work_item_id`만 오는 호출(`artifact-section.tsx`의 `status=pending`
  병용 경로)은 project_id를 해소할 축이 없어 기존 동작대로 미검사 — 별도 판단 필요, 이 PR
  범위 밖.
- `list_gate_inbox`(결재함, `list_gates(work_item_id=None, ...)` 고정 호출)는 이번 변경 영향
  밖. "조직 전체 결재 대기를 보는 화면"이 의도된 제품 결정인지는 스토리 본문이 조건부로 남긴
  별도 결정이라(ⓐ문서화 ⓑ근거 열람 동일 범위 ⓒ경계 테스트 3요건), 이 PR의 핵심 재현
  (work_item-scope 비대칭)과 분리해 손대지 않았다.

## 검증
- 신규 realdb 테스트 4건(`test_2042_gates_evidence_authz_parity_realdb.py`): ①project_access
  (granted)만 있는 휴먼이 evidence에서 허용됨 ②접근권 전무 휴먼이 gates에서 거부됨(AC3)
  ③④같은 work_item·같은 사용자로 evidence·gates가 허용/거부 양쪽 다 일치(AC2). `git apply -R`
  로 fix 제거 시 4건 전부 실패 확인(load-bearing 증명).
- pg@16+alembic head 로컬 migrated real-PG에서 gates/evidence 관련 기존 realdb 22파일·100
  케이스 재실행 — 전부 무회귀(`destructive_schema` 마커 6파일은 create_all/drop_all로 공유
  DB를 깨는 별도 격리 규약이라 제외, 이 diff와 무관한 경로).

AC4(라이브 확認)·AC5(넓힌 방향 거부 케이스 QA)는 dev 배포 후 후속 — 이 PR은 코드+실DB
검증까지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)