### PR TITLE
[SID:2044][BUG·BE] 스토리 첨부 PATCH 500-위장 잔여 축 봉합 + 상한 응답 통일

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -491,15 +491,21 @@ async def _preflight_merge_gate(
 
 def _enforce_mcp_attachment_declared_limit(attachments: list[dict]) -> None:
     """E-MCP-OPT S6: chat(S5 #2)과 동일 갭을 story 에서 처음부터 막는다 — mcp-태그 첨부(dict shape:
-    url/size 키) 부분집합만 선언한도(5개/6MiB) 재검증. FE 업로드 첨부(마커 없음)는 무관."""
+    url/size 키) 부분집합만 선언한도(5개/6MiB) 재검증. FE 업로드 첨부(마커 없음)는 무관.
+
+    story #2044 AC4: 개수/전체 상한 초과가 여기(예전엔 400)와 첨부 개수·개별 크기 상한
+    (StoryAttachment 필드 validator, 422)이 서로 다른 상태코드로 갈려 호출자가 원인을
+    오판하기 쉬웠다 — 422로 통일(Pydantic 검증류와 동일 관례)하고, 실측값(몇 개/몇 바이트)을
+    메시지에 싣는다."""
     mcp_origin = [a for a in attachments if mcp_attachment_upload.is_mcp_upload_object_path(a["url"], kind="story")]
+    total_bytes = sum(a["size"] for a in mcp_origin)
     if len(mcp_origin) > mcp_attachment_upload.MCP_MAX_ATTACHMENTS or (
-        sum(a["size"] for a in mcp_origin) > mcp_attachment_upload.MCP_MAX_TOTAL_ATTACHMENT_BYTES
+        total_bytes > mcp_attachment_upload.MCP_MAX_TOTAL_ATTACHMENT_BYTES
     ):
         raise HTTPException(
-            status_code=400,
+            status_code=422,
             detail=(
-                f"mcp attachments exceed declared limit "
+                f"mcp attachments exceed declared limit: {len(mcp_origin)} files / {total_bytes} bytes "
                 f"(max {mcp_attachment_upload.MCP_MAX_ATTACHMENTS} files / "
                 f"{mcp_attachment_upload.MCP_MAX_TOTAL_ATTACHMENT_BYTES} bytes total)"
             ),
@@ -2125,11 +2131,20 @@ async def update_story(
     if "assignee_id" in data and old_assignee_id != story.assignee_id:
         # story #2172 근본수정(AC1): 이 side-effects를 PATCH /bulk과 공유하는 단일 helper로
         # 추출 — 두 라우트가 발행 지점을 갈라 갖던 #2131류 결함 재발을 막는다.
-        await emit_story_assignee_changed(
-            db, repo.org_id, story, old_assignee_id,
-            background_tasks=background_tasks,
-            actor_id=actor_id, actor_name=actor_name, actor_role=actor_role, actor_type=actor_type,
-        )
+        # story #2044 AC2(2026-08-21): 이 라우트는 위에서 이미 db.commit()으로 write를 확정했다
+        # ("side effects 에러가 rollback시키지 않도록") — 그 설계가 실효되려면 commit 뒤 코드가
+        # 예외를 던져 500으로 새면 안 된다(성공한 쓰기가 실패로 위장). 알림 발행 실패는 write
+        # 자체와 무관한 best-effort라 position-event push(아래)와 동일하게 log+continue.
+        try:
+            await emit_story_assignee_changed(
+                db, repo.org_id, story, old_assignee_id,
+                background_tasks=background_tasks,
+                actor_id=actor_id, actor_name=actor_name, actor_role=actor_role, actor_type=actor_type,
+            )
+        except Exception:
+            logger.warning(
+                "assignee_changed 알림 발행 실패(story=%s, write는 이미 commit됨)", story.id, exc_info=True,
+            )
 
     # story #2172 AC2 판정(오르테가군 지시 — "재정렬 전용 이벤트가 필요한지, 기존 것으로
     # 되는지 판단하고 근거 남길 것"): 신규 전용 event_type(`story.position_changed`)을 쓰되,
@@ -2198,10 +2213,26 @@ async def update_story(
             context=_context,
         )
 
-    await _attach_assignee_ids(db, repo.org_id, [story])
-    await _attach_has_evidence(db, [story])
-    await _attach_has_hypothesis_or_goal(db, [story])
-    await _attach_org_project_slugs(db, repo.org_id, [story])
+    # story #2044 AC2: 아래 4개는 응답에 denorm 필드를 얹는 순수 enrichment다(각 helper
+    # docstring 그대로 — assignee_ids/has_evidence/has_hypothesis_or_goal/org_slug 전부
+    # "positive 단방향, 없으면 미설정"이 기존 계약이라 실패해도 필드가 비는 것 이상의 의미
+    # 손실이 없다). commit()이 이미 위에서 write를 확정했으므로(2112) 이 중 하나가 예외를
+    # 던져 500으로 새면 "저장은 성공, 응답은 실패"라는 원 결함 그대로 재발한다 — 각자
+    # log+continue로 격리해 한 곳이 죽어도 나머지 enrichment와 핵심 응답(title/attachments/
+    # status 등)은 살아남는다.
+    for _attach_fn, _args in (
+        (_attach_assignee_ids, (db, repo.org_id, [story])),
+        (_attach_has_evidence, (db, [story])),
+        (_attach_has_hypothesis_or_goal, (db, [story])),
+        (_attach_org_project_slugs, (db, repo.org_id, [story])),
+    ):
+        try:
+            await _attach_fn(*_args)
+        except Exception:
+            logger.warning(
+                "%s enrichment 실패(story=%s, write는 이미 commit됨)",
+                _attach_fn.__name__, story.id, exc_info=True,
+            )
     # story #2459 prod 회귀(2026-08-05): model_validate는 동기 호출이라 story의 어떤 컬럼이
     # unloaded 상태면(원인 미확定 — repo.update()가 flush+refresh 直後인데도 관측됨)
     # MissingGreenlet 500(await_only 호출 불가 — sync 컨텍스트에서 lazy load 시도)으로

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -88,13 +88,15 @@ class StoryAttachment(BaseModel):
         if v < 0:
             raise ValueError("size must be >= 0")
         if v > _MAX_ATTACHMENT_SIZE:
-            raise ValueError(f"attachment too large (max {_MAX_ATTACHMENT_SIZE} bytes)")
+            # story #2044 AC4: "몇 개/몇 바이트가 넘었는지" 실측값을 메시지에 싣는다 — 상한만
+            # 적으면 호출자가 자기 요청의 어느 첨부가 얼마나 초과했는지 재계산해야 한다.
+            raise ValueError(f"attachment too large: {v} bytes (max {_MAX_ATTACHMENT_SIZE} bytes)")
         return v
 
 
 def _limit_story_attachments(v: list) -> list:
     if v is not None and len(v) > _MAX_STORY_ATTACHMENTS:
-        raise ValueError(f"too many attachments (max {_MAX_STORY_ATTACHMENTS})")
+        raise ValueError(f"too many attachments: {len(v)} (max {_MAX_STORY_ATTACHMENTS})")
     return v
 
 

--- a/backend/tests/test_2044_story_attachment_patch_survives_side_effects_realdb.py
+++ b/backend/tests/test_2044_story_attachment_patch_survives_side_effects_realdb.py
@@ -1,0 +1,179 @@
+"""story #2044(P1, "성공이 실패로 위장" 변종) — PATCH /api/v2/stories/{id}에 attachments를
+실어 보내면 저장(첨부·asset registry reconcile)은 성공하는데, 그 뒤 500이 나 호출자가 재시도해
+GCS 고아 객체가 쌓이는 결함(댄 어윈 실측·2026-07-20, dev).
+
+## AC1 그라운딩(실재현 로그로) — 원 트리거는 이미 닫혔고, 재발 방지 축은 별개로 남아 있었다
+원 사고 시점(2026-07-20) Cloud Logging은 30일 보존 만료로 복구 불가 — 대신 git 이력으로 원인
+계열을 확定했다: `update_story`는 「side-effect 에러가 attachments write를 rollback시키지
+않도록」 `await db.commit()`을 의도적으로 side-effect 코드보다 **먼저** 부른다(주석 원문
+그대로). 이 설계 자체가 "commit 後 model_validate 前 무엇이든 예외를 던지면 저장된 write가
+500으로 위장돼 나간다"는 결함 클래스를 구조적으로 내포한다 — 정확히 이 클래스가 story
+#2459(2026-08-05, commit 3ab2a5c26)에서 독립적으로 재발견·수정됐다: `model_validate` 直前
+`await db.refresh(story)`를 stories.py 3곳(update_story 포함)에 추가하고, 코드베이스 전수
+"commit-then-model_validate" 20곳을 CI lint(`commit-before-validate-lint`)로 막아 뒀다. 즉
+#2044가 보고한 원 트리거(속성 unload→MissingGreenlet)는 #2459가 먼저 닫았다.
+
+그러나 #2459의 수정 범위는 "model_validate 直前 refresh"에 한정됐다 — `emit_story_assignee_
+changed`·4개 `_attach_*` enrichment 호출은 여전히 **commit 뒤·비try/except**였다(AC2가 요구하는
+"성공한 쓰기는 항상 200"이라는 일반 원칙은 MissingGreenlet 하나만으론 안 닫힌다). 이 파일의
+①이 그 잔여 취약점을 실측한다 — 실 attachments PATCH가 최종 응답 직전 임의 enrichment
+단계에서 예외를 만나도 500이 아니라 200을 내는지, 그리고 그 write가 실제로 committed 상태로
+남아 있는지(재조회 값과 응답 값이 일치) 값으로 잰다.
+
+②는 AC4(상한 초과 상태코드 통일)를 실측한다: mcp-선언한도 초과(예전 400)·개수 상한(10, 422)·
+개별 크기 상한(100MB, 422)이 이제 전부 422로 수렴하고, 메시지에 실측값(몇 개/몇 바이트)이
+실리는지 값으로 확인한다.
+
+#2853/#2845/#2857과 동일 정신 — 격리 로컬 throwaway realdb만 사용(라이브 배포 시스템 무접촉).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from starlette.background import BackgroundTasks
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("20440000-0000-0000-0000-000000000101")
+USER = uuid.UUID("20440000-0000-0000-0000-0000000101a1")
+OM = uuid.UUID("20440000-0000-0000-0000-0000000101b1")
+PROJ = uuid.UUID("20440000-0000-0000-0000-0000000101c1")
+STORY = uuid.UUID("20440000-0000-0000-0000-0000000101d1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth_human(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(ORG))
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed(s) -> None:
+    for sql in [
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S2044','s2044-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{USER}','u@s2044.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','owner')",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','P','s2044-proj','warn')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{OM}','granted','owner')",
+        f"INSERT INTO stories (id,org_id,project_id,title,status,priority) VALUES "
+        f"('{STORY}','{ORG}','{PROJ}','S','backlog','medium')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+# ───── ① commit 뒤 enrichment가 죽어도 write는 살고 응답도 200이어야 한다(AC2 핵심) ─────
+
+@pytest.mark.anyio
+async def test_attachment_patch_returns_200_and_persists_even_if_enrichment_raises():
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        body = StoryUpdate(attachments=[{
+            "url": "https://storage.googleapis.com/sprintable-memo-attachments/s2044/f.pdf",
+            "name": "f.pdf", "content_type": "application/pdf", "size": 111,
+        }])
+
+        async def _boom(*_a, **_kw):
+            raise RuntimeError("simulated enrichment failure(#2044 load-bearing probe)")
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            # commit() 뒤 최초로 도는 enrichment 하나를 강제로 죽인다 — 하드닝 前엔 이 예외가
+            # 그대로 update_story 밖으로 전파돼 FastAPI가 500을 냈다(write는 이미 committed).
+            with patch("app.routers.stories._attach_has_evidence", _boom):
+                resp = await update_story(STORY, body, bg, repo, s, _auth_human(USER))
+
+        assert resp.attachments and resp.attachments[0]["name"] == "f.pdf", (
+            "enrichment 실패가 응답 자체를 막으면 안 된다 — 핵심 필드(attachments)는 살아있어야 하는"
+        )
+
+        async with Session() as s:
+            row = (await s.execute(text(
+                f"SELECT attachments FROM stories WHERE id='{STORY}'"
+            ))).first()
+        assert row is not None and row[0] and row[0][0]["name"] == "f.pdf", (
+            "write 자체가 이미 commit돼 있어야 한다 — 이게 비어 있으면 하드닝이 아니라 "
+            "그냥 write까지 날아간 것(AC2가 금지하는 반대 방향의 실패)"
+        )
+    finally:
+        await eng.dispose()
+
+
+
+# ───── ② AC4 — 상한 초과가 전부 422로 수렴 + 실측값이 메시지에 실린다 ─────
+
+def test_mcp_declared_limit_exceeded_is_422_with_measured_counts():
+    from app.routers.stories import _enforce_mcp_attachment_declared_limit
+    from app.services import mcp_attachment_upload
+
+    over_limit = [
+        {
+            "url": f"org/{ORG}/project/{PROJ}/story/{STORY}/mcp/f{i}.bin",
+            "size": mcp_attachment_upload.MCP_MAX_TOTAL_ATTACHMENT_BYTES,
+        }
+        for i in range(mcp_attachment_upload.MCP_MAX_ATTACHMENTS + 1)
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        _enforce_mcp_attachment_declared_limit(over_limit)
+    assert exc_info.value.status_code == 422, "mcp 선언한도 초과는 이제 422(개수/크기 상한과 동일 코드)"
+    assert str(mcp_attachment_upload.MCP_MAX_ATTACHMENTS + 1) in exc_info.value.detail, (
+        "메시지에 실제 개수가 실려야 한다(AC4: 무엇이 몇 개를 넘었는지)"
+    )
+
+
+def test_story_attachment_count_limit_exceeded_is_422_with_measured_count():
+    from app.schemas.story import StoryAttachment, StoryUpdate
+
+    too_many = [
+        StoryAttachment(url=f"https://x.test/{i}.png", name=f"{i}.png", content_type="image/png", size=1)
+        for i in range(11)
+    ]
+    with pytest.raises(Exception) as exc_info:  # pydantic ValidationError → FastAPI가 422로 변환
+        StoryUpdate(attachments=too_many)
+    assert "11" in str(exc_info.value), "메시지에 실제 첨부 개수(11)가 실려야 한다"
+
+
+def test_story_attachment_size_limit_exceeded_is_422_with_measured_bytes():
+    from app.schemas.story import StoryAttachment
+
+    oversized = 100 * 1024 * 1024 + 1
+    with pytest.raises(Exception) as exc_info:
+        StoryAttachment(url="https://x.test/big.png", name="big.png", content_type="image/png", size=oversized)
+    assert str(oversized) in str(exc_info.value), "메시지에 실제 바이트 수가 실려야 한다"

--- a/backend/tests/test_e_mcp_opt_s6_story_doc_upload_realdb.py
+++ b/backend/tests/test_e_mcp_opt_s6_story_doc_upload_realdb.py
@@ -122,7 +122,9 @@ async def test_story_upload_no_project_access_403(monkeypatch, tmp_path):
 
 @pytest.mark.anyio
 async def test_story_update_rejects_mcp_attachments_over_declared_limit(monkeypatch, tmp_path):
-    """S5 #2 와 동일 갭을 story 에서 처음부터 막는지 — 6개(>5) mcp-태그 첨부 참조 update_story 는 400."""
+    """S5 #2 와 동일 갭을 story 에서 처음부터 막는지 — 6개(>5) mcp-태그 첨부 참조 update_story 는
+    422(story #2044 AC4: 예전엔 400·첨부 개수/크기 상한(Pydantic validator)은 422 — 서로 다른
+    상태코드로 갈려 호출자가 오판하기 쉬웠다. 422로 통일)."""
     monkeypatch.setenv("STORAGE_PROVIDER", "local")
     monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
     from app.routers.stories import (
@@ -157,7 +159,7 @@ async def test_story_update_rejects_mcp_attachments_over_declared_limit(monkeypa
                 await update_story(
                     STORY, update_body, BackgroundTasks(), repo=repo, db=s, auth=_auth(AGENT_IN),
                 )
-            assert ei.value.status_code == 400
+            assert ei.value.status_code == 422
     finally:
         await eng.dispose()
 


### PR DESCRIPTION
[SID:2044]

## 요약
`PATCH /api/v2/stories/{id}`에 attachments를 실어 보내면 저장(첨부·asset registry reconcile)은
성공하는데 그 뒤 500이 나 호출자가 재시도 → GCS 고아 객체 누적(댄 어윈 실측, 2026-07-20, dev).

## AC1(근본원인) — 원 로그는 30일 보존 만료로 복구 불가, git 이력으로 원인 계열 확定
원 사고의 Cloud Logging은 이미 만료돼 원본 트레이스백을 볼 수 없었다. 대신 `update_story`
자신의 설계("변경사항 먼저 commit — side effects 에러가 rollback시키지 않도록", 주석 원문)가
"commit 後 model_validate 前 무엇이든 예외를 던지면 저장된 write가 500으로 위장돼 나간다"는
결함 클래스를 구조적으로 내포한다는 것을 코드로 확定했다. 정확히 이 클래스가 story #2459
(2026-08-05, commit 3ab2a5c26, 이 스토리와 **무관한 독립 발견**)에서 "MissingGreenlet 500"
형태로 재발견·수정됐다 — `model_validate` 直前 `await db.refresh(story)` 추가(stories.py 3곳)
+ 코드베이스 전수 20곳 CI lint(`commit-before-validate-lint`) 신설. 즉 #2044가 보고한 원
트리거는 #2459가 이미 닫았다(오늘 로컬 재현도 무예외로 통과 — #2459 적용 後 코드 기준).

## 잔여 취약점(AC2) — #2459가 못 닫은 축
#2459의 범위는 "model_validate 直前 refresh"에 한정됐다. `emit_story_assignee_changed`·4개
`_attach_*`(assignee_ids/has_evidence/has_hypothesis_or_goal/org_project_slugs) enrichment
호출은 여전히 commit 뒤·비try/except였다 — MissingGreenlet이 아닌 다른 이유로 이 중 하나가
예외를 던지면 여전히 같은 결함 클래스가 재현된다. AC2("성공한 쓰기는 항상 200")는
MissingGreenlet 하나만 닫아선 안 닫힌다.

처방: 같은 함수 안에 이미 있던 기존 패턴(position-event push, log+continue)을 나머지
unguarded 지점에 동일하게 적용 — 각자 독립 try/except로 격리해 하나가 죽어도 나머지
enrichment와 핵심 응답(title/attachments/status 등)은 살아남는다. 이 4개는 각자 docstring이
이미 "positive 단방향, 없으면 미설정"이라 명시한 계약이라 실패해도 필드가 비는 것 이상의
의미 손실이 없다.

## AC4(상한 초과 응답 통일)
mcp-선언한도(5개/6MiB) 초과가 400, 첨부 개수(10)·개별 크기(100MB) 초과가 422로 갈려 호출자가
원인을 오판하기 쉬웠다 — mcp 쪽을 422로 통일(Pydantic 검증류와 동일 관례)하고, 3곳 메시지
전부에 실측값(몇 개/몇 바이트 vs 상한)을 싣는다.

## AC5(고아 객체 정리 방침)
**즉시 정리는 하지 않음** — 별도 스토리로 분리 권고(PO 판단 대기). 근거: ①GCS 리스팅 대
asset_links 대조는 이 fix와 무관한 별개 작업(라이브 스토리지 스캔)이고 ②AC1의 근본원인이
이미 닫혀 향후 신규 발생은 줄었다 ③잘못된 대조 로직으로 참조 있는 객체를 지우면 더 위험한
방향(cleanup 스크립트 자체의 정확성 검증이 이 PR 스코프를 크게 넘는다).

## 검증
- 신규 realdb 4건(`test_2044_story_attachment_patch_survives_side_effects_realdb.py`):
  ①enrichment 강제 실패에도 200+DB write 일치 ②mcp 한도 초과 422+실측 개수 ③첨부 개수 상한
  초과 422+실측 개수 ④크기 상한 초과 422+실측 바이트. `git apply -R`로 이 PR diff 제거 시
  3/4 즉시 실패 확인(load-bearing — 나머지 1건은 기존 메시지에도 우연히 값이 포함돼 있었으나
  신규 메시지가 더 명시적이라 유지).
- 기존 `test_e_mcp_opt_s6_story_doc_upload_realdb.py`의 400 단언을 422로 갱신(AC4 의도적 변경).
- pg@16+alembic head 로컬 migrated real-PG에서 stories.py 관련 기존 27파일·183케이스 재실행
  — 전부 무회귀(`test_2346_story_update_length_change_activity_realdb.py` 3건은 이 diff
  적용 前後 동일하게 실패 — 로컬 세션의 `DATABASE_URL`(record_activity_bg 배경 세션 전용
  pool) 미설정 환경 갭이라 무관·별개 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)