### PR TITLE
[SID:2870] GNB 사업자 정보 7종 접이식 노출 — ? 도움말을 사업자정보 펼치기로 대체

### DIFF
--- a/apps/web/src/components/legal/legal-footer.tsx
+++ b/apps/web/src/components/legal/legal-footer.tsx
@@ -66,6 +66,29 @@ export function BusinessInfoBlock({ className = '' }: { className?: string }) {
   );
 }
 
+/** 사업자정보 6종 — 세로 스택(라벨+값), 좁은 폭(GNB 등)용. justify는 호출부에서 지정. */
+export function BusinessInfoList({ className = '' }: { className?: string }) {
+  const t = useTranslations('legal');
+  const rows = [
+    { label: null, value: BUSINESS_INFO.companyName },
+    { label: t('ceoLabel'), value: BUSINESS_INFO.ceo },
+    { label: t('registrationLabel'), value: BUSINESS_INFO.registrationNumber },
+    { label: t('mailOrderLabel'), value: BUSINESS_INFO.mailOrderNumber },
+    { label: null, value: BUSINESS_INFO.address },
+    { label: null, value: BUSINESS_INFO.phone },
+  ];
+  return (
+    <div className={`space-y-0.5 ${className}`}>
+      {rows.map((row, i) => (
+        <div key={i} className="text-xs leading-relaxed">
+          {row.label && <span className="text-sidebar-foreground/60">{row.label} </span>}
+          <span className="text-sidebar-foreground">{row.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 /**
  * 비로그인 클러스터(로그인·가입·legal 페이지) 하단 푸터.
  * 사업자정보 + 법적 문서 링크를 가운데 정렬로 묶는다.

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -205,4 +205,14 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1)', () =>
       expect(link!.getAttribute('href'), `"${label}"의 href`).toBe(expectedHref);
     }
   });
+
+  // story #2870 — footer `?` docs 도움말 링크(docsLink)가 「사업자 정보」 토글로 대체됐다.
+  // /docs는 이미 knowledge 그룹의 1차 내비 항목이라 footer 단축 제거로 도달성 손실은 없다.
+  it('footer에 docs 도움말 링크(?)가 없고, 「사업자 정보」 토글이 대신 존재한다', async () => {
+    await mount();
+    const docsHelpLink = [...container.querySelectorAll('a[href="/docs"][aria-label]')];
+    expect(docsHelpLink).toHaveLength(0);
+    const businessInfoToggle = [...container.querySelectorAll('button')].find((b) => b.getAttribute('aria-expanded') !== null);
+    expect(businessInfoToggle).toBeDefined();
+  });
 });

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -4,11 +4,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { CircleHelp, Search } from 'lucide-react';
+import { Search } from 'lucide-react';
 import { LocaleSwitcher } from '@/components/locale-switcher';
 import { ThemeToggle } from '@/components/nav/theme-toggle';
 import { CommandPalette } from '@/components/command-palette/command-palette';
 import { ProfileMenu } from '@/components/nav/profile-menu';
+import { BusinessInfoDisclosure } from '@/components/nav/business-info-disclosure';
 import { UnifiedSwitcher, type OrgSwitcherItem } from '@/components/nav/unified-switcher';
 import { fetchWithAuth } from '@/lib/db/client';
 import { NAV_GROUPS } from '@/lib/nav-config';
@@ -70,9 +71,6 @@ export function AppSidebar({
       || Boolean(orgSlug && currentProjectSlug && pathname.startsWith(`/${orgSlug}/${currentProjectSlug}/${resource}`));
     return { href, isActive };
   }
-  // story #2681 — docsLink는 footer 도움말 링크가 루프 밖에서 따로 참조해 개별 바인딩을
-  // 유지한다(그 외 리소스 항목은 전부 NAV_GROUPS 순회 중 resourceLink()를 그 자리에서 호출).
-  const docsLink = resourceLink('docs');
   // story #2224(IA v2.2 §7-3, AC12) — 기본 진입은 /flow, 사이드바가 통합뷰를 가리킨다.
   // 칸반은 /flow?view=list로 흡수됐다(PR#2698, `/board` 라우트 자체는 삭제) — 사이드바에
   // board를 flow와 나란히 1Depth로 세우지 않는다("나란히 두면 「내렸다」가 무효가 된다" —
@@ -224,20 +222,11 @@ export function AppSidebar({
 
       <SidebarFooter className="space-y-2 p-2">
         {userName && <ProfileMenu name={userName} />}
-        <div className="flex items-center justify-between gap-1">
-          <div className="flex items-center gap-1">
-            <LocaleSwitcher />
-            <ThemeToggle />
-          </div>
-          <Link
-            href={docsLink.href}
-            aria-label={t('help')}
-            title={t('help')}
-            className="flex size-8 items-center justify-center rounded-md text-sidebar-foreground/60 transition hover:bg-sidebar-accent hover:text-sidebar-foreground"
-          >
-            <CircleHelp className="size-4" />
-          </Link>
+        <div className="flex items-center gap-1">
+          <LocaleSwitcher />
+          <ThemeToggle />
         </div>
+        <BusinessInfoDisclosure />
       </SidebarFooter>
 
       <SidebarRail />

--- a/apps/web/src/components/nav/business-info-disclosure.test.tsx
+++ b/apps/web/src/components/nav/business-info-disclosure.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+//
+// story #2870 — GNB footer 「사업자 정보」 접이식 토글. 「표시를 테스트」한다: default 접힘
+// 상태에서 패널이 렌더되지 않고, 클릭하면 사업자정보 6종+법적 문서 3링크가 실제로
+// 나타나는지 화면 결과로 확인한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { BUSINESS_INFO } from '@/lib/legal/business-info';
+import { BusinessInfoDisclosure } from './business-info-disclosure';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.resetModules();
+});
+
+async function mount(node: React.ReactNode) {
+  await act(async () => { root.render(wrap(node)); });
+}
+
+describe('BusinessInfoDisclosure (story #2870)', () => {
+  it('default 접힘 — 패널이 렌더되지 않고 토글은 aria-expanded=false다', async () => {
+    await mount(<BusinessInfoDisclosure />);
+    const toggle = container.querySelector('button') as HTMLButtonElement;
+    expect(toggle).toBeTruthy();
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(container.textContent).not.toContain(BUSINESS_INFO.registrationNumber);
+  });
+
+  it('클릭하면 사업자정보 6종과 법적 문서 3링크가 렌더된다', async () => {
+    await mount(<BusinessInfoDisclosure />);
+    const toggle = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => { toggle.click(); });
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    const text = container.textContent ?? '';
+    expect(text).toContain(BUSINESS_INFO.companyName);
+    expect(text).toContain(BUSINESS_INFO.ceo);
+    expect(text).toContain(BUSINESS_INFO.registrationNumber);
+    expect(text).toContain(BUSINESS_INFO.mailOrderNumber);
+    expect(text).toContain(BUSINESS_INFO.address);
+    expect(text).toContain(BUSINESS_INFO.phone);
+
+    const hrefs = Array.from(container.querySelectorAll('a')).map((a) => a.getAttribute('href'));
+    expect(hrefs).toContain('/terms');
+    expect(hrefs).toContain('/privacy');
+    expect(hrefs).toContain('/refund-policy');
+  });
+
+  it('다시 클릭하면 접힌다', async () => {
+    await mount(<BusinessInfoDisclosure />);
+    const toggle = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => { toggle.click(); });
+    await act(async () => { toggle.click(); });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(container.textContent).not.toContain(BUSINESS_INFO.registrationNumber);
+  });
+});

--- a/apps/web/src/components/nav/business-info-disclosure.tsx
+++ b/apps/web/src/components/nav/business-info-disclosure.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+/**
+ * GNB 사이드바 footer 「사업자 정보」 접이식 노출 (story #2870).
+ *
+ * 로컬 useState 토글 — collapsible 프리미티브 신규 의존성 0. default 접힘, 클릭 시 토글
+ * 바로 아래로 인라인 펼침(오버레이 아님) — footer 흐름 안에서 SidebarContent(nav)가
+ * 세로 공간을 흡수한다. 값은 전부 SSOT(lib/legal/business-info.ts)에서만 가져온다.
+ */
+
+import { useId, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Building2, ChevronDown } from 'lucide-react';
+import { BusinessInfoList, LegalLinks } from '@/components/legal/legal-footer';
+
+export function BusinessInfoDisclosure() {
+  const t = useTranslations('legal');
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={panelId}
+        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sidebar-foreground/60 transition hover:bg-sidebar-accent hover:text-sidebar-foreground"
+      >
+        <Building2 className="size-4 shrink-0" />
+        <span className="flex-1 truncate text-xs">{t('businessInfoHeading')}</span>
+        <ChevronDown className={`size-3.5 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+      {open && (
+        <div id={panelId} className="max-h-[45vh] overflow-y-auto px-2 py-2">
+          <BusinessInfoList />
+          <div className="mt-2 border-t border-sidebar-border/60 pt-2">
+            <p className="mb-1 text-[10px] font-medium text-sidebar-foreground/60">{t('policiesHeading')}</p>
+            <LegalLinks className="text-xs text-sidebar-foreground/60" />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/nav/profile-menu.test.tsx
+++ b/apps/web/src/components/nav/profile-menu.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 //
-// story #2865 — ProfileMenu 드롭다운에 「약관 및 정책」 그룹(3링크)이 상시 접근 경로로
-// 추가됐다. 배선이 아니라 «표시를 테스트»한다: 드롭다운을 열었을 때 3개 링크가 실제로
-// 렌더되고 기존 legal 라우트로 걸리는지 화면 결과로 확인한다.
+// story #2870 — GNB의 법적 고지 접점이 단일화됐다(사이드바 footer 「사업자 정보」 토글로
+// 수렴). ProfileMenu의 「약관 및 정책」 그룹(story #2865에서 추가)은 중복이라 제거됐다 —
+// 이 스위트는 그 회귀를 막는다: 배선이 아니라 «표시 부재»를 테스트한다.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
@@ -58,25 +58,19 @@ async function openMenu() {
   await act(async () => { trigger.click(); });
 }
 
-describe('ProfileMenu — 약관 및 정책 드롭다운 그룹 (story #2865)', () => {
-  it('드롭다운을 열면 약관 및 정책 3링크가 렌더되고 기존 legal 라우트로 걸린다', async () => {
+describe('ProfileMenu — 약관 및 정책 그룹 제거 회귀가드 (story #2870)', () => {
+  it('드롭다운에 법적 문서 링크가 0건이다(GNB footer 토글로 수렴)', async () => {
     await mount(<ProfileMenu name="송윤재" />);
     await openMenu();
 
-    // base-ui Menu.Portal은 document.body에 렌더된다(컨테이너 내부가 아님).
     const anchors = Array.from(document.querySelectorAll('[data-slot="dropdown-menu-content"] a'));
     const hrefs = anchors.map((a) => a.getAttribute('href'));
-    expect(hrefs).toContain('/terms');
-    expect(hrefs).toContain('/privacy');
-    expect(hrefs).toContain('/refund-policy');
-
-    const labels = anchors.map((a) => a.textContent);
-    expect(labels).toContain('이용약관');
-    expect(labels).toContain('개인정보처리방침');
-    expect(labels).toContain('환불정책');
+    expect(hrefs).not.toContain('/terms');
+    expect(hrefs).not.toContain('/privacy');
+    expect(hrefs).not.toContain('/refund-policy');
   });
 
-  it('약관 및 정책 그룹이 설정↔로그아웃 사이에 위치한다', async () => {
+  it('설정 항목 바로 다음이 로그아웃이다(약관 그룹 자리가 완전히 비었다)', async () => {
     await mount(<ProfileMenu name="송윤재" />);
     await openMenu();
 
@@ -86,17 +80,8 @@ describe('ProfileMenu — 약관 및 정책 드롭다운 그룹 (story #2865)', 
       (el) => el.textContent ?? '',
     );
     const settingsIdx = items.findIndex((t) => t.includes('설정'));
-    const termsIdx = items.findIndex((t) => t.includes('이용약관'));
     const signOutIdx = items.findIndex((t) => t.includes('로그아웃'));
     expect(settingsIdx).toBeGreaterThanOrEqual(0);
-    expect(termsIdx).toBeGreaterThan(settingsIdx);
-    expect(signOutIdx).toBeGreaterThan(termsIdx);
-  });
-
-  it('raw i18n 키가 노출되지 않는다', async () => {
-    await mount(<ProfileMenu name="송윤재" />);
-    await openMenu();
-    const text = document.querySelector('[data-slot="dropdown-menu-content"]')?.textContent ?? '';
-    expect(text).not.toMatch(/policiesHeading|termsOfService|privacyPolicy|refundPolicy/);
+    expect(signOutIdx).toBe(settingsIdx + 1);
   });
 });

--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -17,7 +17,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 import { ACCOUNT_CAP } from '@/lib/auth/account-limits';
-import { LEGAL_DOC_ROUTES } from '@/lib/legal/business-info';
 
 interface Account {
   account_id: string;
@@ -69,7 +68,6 @@ export function ProfileMenu({ name, avatarUrl }: ProfileMenuProps) {
   const t = useTranslations('accountSwitcher');
   const tc = useTranslations('common');
   const tn = useTranslations('nav');
-  const tLegal = useTranslations('legal');
 
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [busy, setBusy] = useState<string | null>(null); // account_id | 'add' | 'signout'
@@ -216,20 +214,6 @@ export function ProfileMenu({ name, avatarUrl }: ProfileMenuProps) {
           <Settings className="size-4" />
           {tn('settings')}
         </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuGroup>
-          {/* GroupLabel(base-ui)은 반드시 Group 내부 — Popup 직속이면 error #31 크래시(story #2865). */}
-          <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">{tLegal('policiesHeading')}</DropdownMenuLabel>
-          <DropdownMenuItem render={<Link href={LEGAL_DOC_ROUTES.terms} />}>
-            {tLegal('termsOfService')}
-          </DropdownMenuItem>
-          <DropdownMenuItem render={<Link href={LEGAL_DOC_ROUTES.privacy} />}>
-            {tLegal('privacyPolicy')}
-          </DropdownMenuItem>
-          <DropdownMenuItem render={<Link href={LEGAL_DOC_ROUTES.refundPolicy} />}>
-            {tLegal('refundPolicy')}
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           disabled={busy !== null}


### PR DESCRIPTION
## Summary
- 사이드바 footer의 `?` docs 도움말 링크(CircleHelp+docsLink)를 「사업자 정보」 전폭 토글(`BusinessInfoDisclosure`, 로컬 useState·default 접힘)로 대체.
- 펼치면 사업자정보 6종(신설 `BusinessInfoList` — SSOT 세로 변형)+법적 문서 3링크(`LegalLinks` 재사용)가 토글 바로 아래 인라인으로 나타남(오버레이 아님).
- ProfileMenu의 「약관 및 정책」 그룹(#2865에서 추가)을 제거 — GNB 법적 접점을 신규 토글 하나로 단일화. `profile-menu.test.tsx`도 부재를 확인하는 회귀가드로 갱신.
- `/docs`는 이미 knowledge 그룹 1차 내비 항목이라 `?` 제거로 도달성 손실 없음.
- 유나 홀름 디자인 핸드오프(`legal-gnb-disclosure-handoff-2870`) 그대로 — 신규 컴포넌트 1개(`business-info-disclosure.tsx`) 외 신규 문자열/라우트 0, SSOT(`lib/legal/business-info.ts`) 무변경.

## Test plan
- [x] `pnpm type-check` — 그린
- [x] `pnpm lint` — 0 errors (기존 무관 파일 warning 5건은 pre-existing)
- [x] `pnpm build` — 그린, `/settings`·`/loop-queue` 등 라우트 정상 착지
- [x] `pnpm exec vitest run` — 457 files / 3796 tests 전부 그린
  - `business-info-disclosure.test.tsx`(신규 3건): default 접힘(패널 미렌더)·클릭 시 6종+3링크 렌더·재클릭 시 재접힘
  - `profile-menu.test.tsx`(회귀가드로 갱신): 약관 링크 0건·설정 바로 다음이 로그아웃
  - `app-sidebar.test.tsx`(1건 추가): footer docs 도움말 링크 0건·사업자정보 토글 존재
- [x] verify guard 3종(`no-new-tint-color-text`·`no-i18n-phrase-collision`·`no-new-raw-fetch-api`) — 신규 위반 0건
- [ ] dev 실픽셀(접힘 default · 펼침 × 라이트/다크 × ko/en) — 머지 후 진행

Story: [SID:2870]

🤖 Generated with [Claude Code](https://claude.com/claude-code)