### PR TITLE
[SID:2873] 세션 org 정본을 JWT org_id 클레임으로 — 0-프로젝트 org 침묵 오배달 근본수정

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -6,6 +6,7 @@ import {
   TAB_PROJECT_STORAGE_KEY,
   bumpOrgSyncVersion,
   installProjectHeaderInterceptor,
+  resolveEffectiveOrgId,
   resolveEffectiveProjectId,
   setEffectiveProjectId,
   setEffectiveOrgId,
@@ -296,9 +297,26 @@ export function DashboardShell({
   const showTopBar = !pathname.startsWith('/settings');
   const tabletCentered = isTabRootPage(pathname);
 
+  // ⚠️카디르 라이브 재QA(2026-08-10, qa:changes) — 세션의 "현재 org" 정본은 `orgId`(me?.org_id)가
+  // 아니라 `jwtOrgId`다. `orgId`는 실제로는 대개 `app_metadata.project_id` 클레임으로 찾은
+  // TeamMember 행의 org라 `app_metadata.org_id` 클레임(=jwtOrgId)과 다른 신호다 — 부분-stale
+  // JWT(org_id는 reset됐는데 project_id는 옛 org를 여전히 가리키는 경우) 라이브 재현에서
+  // orgId가 pathOrgId와 "우연히" 같아져 아래 org-sync effect가 조기 return했다. jwtOrgId
+  // (getServerSession이 jwtVerify 직후 읽어둔 그 클레임)를 우선하고, 그 클레임이 없는
+  // 인증경로(Firebase 세션 — db/server.ts 참고)에서만 orgId(project-chain 파생)로 폴백한다.
+  const actualTokenOrgId = jwtOrgId ?? orgId;
   // story #2093 — 경로(`[ws]/[proj]`) resolve 결과가 최우선(화면이 실제로 그리는 것의 정본).
-  // 계정 상태(orgId, server prop)는 flat 라우트(경로에 org/project가 없는 화면)에서만 쓰인다.
-  const effectiveOrgId = pathOrgId ?? orgId;
+  // story #2873 — flat 라우트(pathOrgId 없음)의 계정 상태 폴백도 project-chain 파생값
+  // (orgId)이 아니라 jwtOrgId(위 actualTokenOrgId와 동일 우선순위 — resolveEffectiveOrgId
+  // 참고)를 쓴다. 0-프로젝트 org로 전환하면 switch-org가 CURRENT_PROJECT_COOKIE를 지워(그
+  // org엔 앵커할 project가 없어) project-chain 파생값(orgId)이 새 org로 영영 못 넘어가는데도,
+  // 새로 발급된 JWT의 org_id 클레임 자체는 정확히 갱신되어 있었다(BE 실측 확認, 디디군) —
+  // 그런데 flat 라우트는 org-sync effect(아래)가 pathOrgId 부재로 조기 return해 그 정본을 못
+  // 쓰고 orgId로만 폴백하다 보니, X-Org-Id 헤더가 전환 前 org에 갇혀 "새 프로젝트" 같은
+  // 요청이 조용히 옛 org로 갔다(라이브 재현: SK Leak Test로 전환 후 생성한 프로젝트가
+  // 뭉클랩에 떨어짐). resolveEffectiveOrgId를 쓰면 flat 라우트든 아니든 X-Org-Id가 항상
+  // 실제 세션 org를 정확히 반영한다.
+  const effectiveOrgId = resolveEffectiveOrgId(pathOrgId, jwtOrgId, orgId);
   // story #2497 — 인터셉터가 X-Project-Id 옆에 X-Org-Id도 함께 실어야 하는 자리(fire #2486
   // 근본원인: 멀티-org 유저의 stale JWT org가 탭의 실제 org와 달라 has_project_access가
   // 엉뚱한 org로 검증됨). setEffectiveProjectId와 동일하게 렌더 단계에서 동기화 —
@@ -312,17 +330,6 @@ export function DashboardShell({
   // 간헐적으로 403이 난다. 근본: 헤더로 매 요청 우회하는 대신, 불일치를 발견하는 즉시 실제
   // 토큰을 pathOrgId로 재발급해 그 뒤 모든 요청(헤더 有無 무관)이 처음부터 맞게 만든다 —
   // AC2가 명시 허용한 두 방법(헤더 신뢰 / 토큰 재발급) 중 후자.
-  //
-  // ⚠️카디르 라이브 재QA(2026-08-10, qa:changes) — 이 비교엔 `orgId`(me?.org_id)가 아니라
-  // `jwtOrgId`를 쓴다. `orgId`는 실제로는 대개 `app_metadata.project_id` 클레임으로 찾은
-  // TeamMember 행의 org라 `app_metadata.org_id` 클레임(위 jwtOrgId 정의 참고)과 다른
-  // 신호다 — 부분-stale JWT(org_id는 reset됐는데 project_id는 옛 org를 여전히 가리키는
-  // 경우) 라이브 재현에서 orgId가 이미 pathOrgId와 "우연히" 같아져 이 effect가 조기
-  // return하고, 그 순간 실제 서명된 app_metadata.org_id 클레임은 여전히 달라 switch-org가
-  // 0회 발화했다. jwtOrgId(getServerSession이 jwtVerify 직후 읽어둔 그 클레임)를 우선하고,
-  // 그 클레임이 없는 인증경로(Firebase 세션 —
-  // db/server.ts 참고)에서만 orgId로 폴백한다.
-  const actualTokenOrgId = jwtOrgId ?? orgId;
   // story #2587 AC3 — 아래 switch-org effect의 조기 return 조건(`!pathOrgId ||
   // pathOrgId === actualTokenOrgId`)과 정확히 대칭인 부정형. true인 동안은 재발급이
   // 시도됐거나 시도될 예정이라 이 순간의 403은 stale일 수 있다(로딩 유지가 맞음) — false면

--- a/apps/web/src/lib/project-context-client.test.ts
+++ b/apps/web/src/lib/project-context-client.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   TAB_PROJECT_STORAGE_KEY,
+  resolveEffectiveOrgId,
   resolveEffectiveProjectId,
   installProjectHeaderInterceptor,
   setEffectiveProjectId,
@@ -156,5 +157,28 @@ describe('installProjectHeaderInterceptor — X-Project-Id 옆에 X-Org-Id가 �
 
     const [, init] = baseFetch.mock.calls[0] as [string, RequestInit | undefined];
     expect(init?.headers).toBeUndefined();
+  });
+});
+
+describe('resolveEffectiveOrgId (story #2873 — 0-프로젝트 org 전환 후 침묵 오배달 재발방지)', () => {
+  it('pathOrgId(경로 resolve 결과)가 있으면 최우선 — jwtOrgId/orgId 무관', () => {
+    expect(resolveEffectiveOrgId('path-org', 'jwt-org', 'chain-org')).toBe('path-org');
+    expect(resolveEffectiveOrgId('path-org', undefined, 'chain-org')).toBe('path-org');
+  });
+
+  it('flat 라우트(pathOrgId 없음) — jwtOrgId가 project-chain 파생값(orgId)보다 우선한다', () => {
+    // 라이브 재현 그대로: 0-프로젝트 org로 전환하면 switch-org가 새 JWT의 org_id 클레임은
+    // 정확히 새 org로 갱신하지만(jwtOrgId), CURRENT_PROJECT_COOKIE엔 앵커할 project가 없어
+    // project-chain 파생값(orgId)은 여전히 전환 前 org를 가리킨다 — jwtOrgId를 써야 새 org로
+    // 실제 반영된다(전에는 orgId를 써서 여기서 전환 前 org가 나와 조용히 오배달됐다).
+    expect(resolveEffectiveOrgId(undefined, 'sk-leak-test-org', 'mungclab-org')).toBe('sk-leak-test-org');
+  });
+
+  it('flat 라우트에서 jwtOrgId가 없으면(Firebase 세션 등) orgId(project-chain)로 폴백한다', () => {
+    expect(resolveEffectiveOrgId(undefined, undefined, 'chain-org')).toBe('chain-org');
+  });
+
+  it('전부 없으면 undefined', () => {
+    expect(resolveEffectiveOrgId(undefined, undefined, undefined)).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/project-context-client.ts
+++ b/apps/web/src/lib/project-context-client.ts
@@ -164,3 +164,21 @@ export function resolveEffectiveProjectId(
   if (serverProjectId && accessibleIds.has(serverProjectId)) return serverProjectId;
   return undefined;
 }
+
+/**
+ * story #2873 — flat 라우트(경로에 org 세그먼트가 없는 화면)에서 세션의 "현재 org"를 판정한다.
+ * `pathOrgId`(경로 `[ws]/[proj]` resolve 결과)가 최우선(기존 동작 그대로). 그다음은
+ * `jwtOrgId`(JWT `app_metadata.org_id` 클레임 — getServerSession이 jwtVerify 직후 읽어둔 정본)
+ * 를 `orgId`(project_id-체인으로 파생된 값)보다 우선한다: 0-프로젝트 org로 전환하면 그 org엔
+ * 앵커할 project가 없어 project-chain 파생값이 새 org로 영영 못 넘어가지만(switch-org가
+ * CURRENT_PROJECT_COOKIE를 지운다), 새로 발급된 JWT의 org_id 클레임 자체는 switch-org 직후
+ * 정확히 갱신되어 있다(BE 실측 확認, story #2873). jwtOrgId가 없는 인증경로(Firebase 세션 —
+ * db/server.ts 참고)에서만 orgId(project-chain)로 폴백한다.
+ */
+export function resolveEffectiveOrgId(
+  pathOrgId: string | undefined,
+  jwtOrgId: string | undefined,
+  orgId: string | undefined,
+): string | undefined {
+  return pathOrgId ?? jwtOrgId ?? orgId;
+}


### PR DESCRIPTION
## Summary
- **근본원인**: flat 라우트(경로에 `[ws]/[proj]` 세그먼트 없음)에서 `effectiveOrgId`가 `orgId`(project_id-체인으로 파생된 서버 prop)로만 폴백했다. 0-프로젝트 org로 전환하면 `switch-org`가 `CURRENT_PROJECT_COOKIE`를 지워(앵커할 project가 없어) project-chain 파생값이 새 org로 영영 못 넘어가지만, **새로 발급된 JWT의 `org_id` 클레임 자체는 switch-org 직후 정확히 갱신된다**(BE 실측 확認, 디디군). 결과적으로 X-Org-Id 헤더가 전환 前 org에 갇혀 "새 프로젝트" 생성이 조용히 옛 org로 떨어졌다(2468 AC1 재검증서 발견 — SK Leak Test로 전환 후 생성한 프로젝트가 뭉클랩에 생김, 에러 0·성공처럼 보이는 최악급 침묵 실패).
- **수정**: `dashboard-shell.tsx`의 `effectiveOrgId` 계산이 이제 `pathOrgId ?? jwtOrgId ?? orgId` 순서(신규 `resolveEffectiveOrgId`, `project-context-client.ts`에 `resolveEffectiveProjectId`와 동형 패턴으로 추가)를 쓴다. `[ws]/[proj]` 스코프 경로는 `pathOrgId`가 여전히 최우선이라 **동작 무변경**.
- **§2545/§2587 영향범위 검증**: org-sync effect(pathOrgId 기반 토큰 재발급, §2545/§2587)는 이번 변경과 완전히 독립 — flat 라우트는 애초에 재발급 대상 `pathOrgId` 자체가 없어 그 effect가 할 일이 없다(조기 return 그대로 유지, 확장 안 함). 관련 기존 테스트 전량(§2545/§2587 커버 포함) 아래 vitest 전체 통과로 무회귀 증명.

## Test plan
- [x] `pnpm type-check` — 그린
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — 그린
- [x] `pnpm exec vitest run` — 457 files / **3800 tests 전부 green**(신규 4건: `resolveEffectiveOrgId` — pathOrgId 최우선·flat 라우트에서 jwtOrgId가 orgId보다 우선·jwtOrgId 없으면 orgId 폴백·전부 없으면 undefined)
- [x] verify guard 2종(`no-new-raw-fetch-api`·`no-i18n-phrase-collision`) — 신규 위반 0건
- [ ] **dev 라이브 AC1 재검증**(원 재현 그대로: SK Leak Test로 전환→"새 프로젝트" 생성→**그 org에 생기고 뭉클랩엔 안 생김**) — 머지·배포 후 진행(로컬FE→dev BE는 JWT_SECRET 불일치로 pre-merge 라이브 검증 불가, 기존 규율)

Story: [SID:2873] · 승계: 2468 AC1 잔여

🤖 Generated with [Claude Code](https://claude.com/claude-code)