### PR TITLE
[SID:2868][FE·BUG] 웹 프록시 경유 PATCH가 낙관적 동시성 필드를 침묵 스트립

### DIFF
--- a/apps/web/src/services/story.ts
+++ b/apps/web/src/services/story.ts
@@ -81,10 +81,14 @@ export class StoryService {
   }
 
   async update(id: string, input: UpdateStoryInput) {
+    // story #2868/#2874 자매(2026-08-21, 페드루 라이브 프로브) — expected_updated_at/
+    // force_overwrite가 이 allowlist에 없어 zod를 통과해도 여기서 다시 조용히 스트립됐다
+    // (같은 «있다≠지금 쓰는 것» 클래스가 요청 파이프라인 두 층에 중복 존재했던 것).
     const ALLOWED_FIELDS: (keyof UpdateStoryInput)[] = [
       'title', 'status', 'priority', 'story_points', 'description', 'acceptance_criteria',
       'attachments', 'epic_id', 'sprint_id', 'assignee_id', 'assignee_ids', 'position',
       'success_hypothesis', 'metric_definition', 'measure_after',
+      'expected_updated_at', 'force_overwrite',
     ];
     const sanitized: Record<string, unknown> = {};
     for (const key of ALLOWED_FIELDS) {

--- a/apps/web/src/services/story.update-allowed-fields.test.ts
+++ b/apps/web/src/services/story.update-allowed-fields.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { StoryService } from './story';
+import type { IStoryRepository, Story } from '@sprintable/core-storage';
+
+// story #2868/#2874 자매(2026-08-21, 페드루 라이브 프로브 실측) — StoryService.update()의
+// ALLOWED_FIELDS allowlist가 expected_updated_at/force_overwrite를 몰라 zod(updateStorySchema,
+// 같은 사고로 이미 수정)를 통과해도 여기서 다시 조용히 스트립됐다(요청 파이프라인 두 층에
+// 중복 존재하던 같은 결함 클래스). repo.update()에 실제로 실리는 값을 값으로 잰다 —
+// "성공했다"만 보면 이 클래스의 결함을 못 잡는다(2863/2868/2874 공통 교훈).
+
+function _story(overrides: Partial<Story> = {}): Story {
+  return {
+    id: 's1', org_id: 'org1', project_id: 'proj1', title: 't', status: 'backlog',
+    priority: 'medium', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Story;
+}
+
+describe('StoryService.update — expected_updated_at/force_overwrite 생존(회귀 — 2868/2874)', () => {
+  it('expected_updated_at이 repo.update()에 실제로 전달된다', async () => {
+    const existing = _story();
+    const repo: Partial<IStoryRepository> = {
+      getById: vi.fn().mockResolvedValue(existing),
+      update: vi.fn().mockResolvedValue(existing),
+    };
+    const service = new StoryService(repo as IStoryRepository);
+
+    await service.update('s1', {
+      description: 'updated', expected_updated_at: '2026-01-01T00:00:00Z',
+    } as any);
+
+    expect(repo.update).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({ expected_updated_at: '2026-01-01T00:00:00Z' }),
+    );
+  });
+
+  it('force_overwrite이 repo.update()에 실제로 전달된다', async () => {
+    const existing = _story();
+    const repo: Partial<IStoryRepository> = {
+      getById: vi.fn().mockResolvedValue(existing),
+      update: vi.fn().mockResolvedValue(existing),
+    };
+    const service = new StoryService(repo as IStoryRepository);
+
+    await service.update('s1', { description: 'updated', force_overwrite: true } as any);
+
+    expect(repo.update).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({ force_overwrite: true }),
+    );
+  });
+});

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -70,6 +70,11 @@ export interface UpdateStoryInput {
   success_hypothesis?: string | null;
   metric_definition?: MetricDefinition | null;
   measure_after?: string | null;
+  // story #2868/#2874 자매(2026-08-21) — BE 낙관적 동시성(409 STORY_CONFLICT) 제어 필드.
+  // updateStorySchema(zod)에 이어 이 타입에도 없으면 ALLOWED_FIELDS(story.ts)/fastapiCall
+  // 본문 어디선가 다시 조용히 새거나 컴파일 자체가 막힌다 — 전 구간 SSOT로 여기서 열어 둔다.
+  expected_updated_at?: string;
+  force_overwrite?: boolean;
 }
 
 export interface BulkUpdateItem {

--- a/packages/shared/src/schemas/__tests__/validation.test.ts
+++ b/packages/shared/src/schemas/__tests__/validation.test.ts
@@ -192,6 +192,18 @@ describe('Sprintable Zod Schemas', () => {
     it('status 없이 다른 필드만 수정 통과', () => {
       expect(updateStorySchema.safeParse({ title: '수정된 제목' }).success).toBe(true);
     });
+    // story #2868/#2874 자매(2026-08-21, 페드루 라이브 프로브 실측) — docs.ts::updateDocSchema
+    // (151e05f1)엔 있었는데 여기 없어 zod가 침묵 strip, 웹 프록시 경유 PATCH가 BE의 409
+    // 낙관적 동시성 가드에 아예 도달 못 했다(#2863과 동일 결함 클래스). docs 쪽 회귀 테스트
+    // (하단 'expected_updated_at/force_overwrite(동시성 제어)도 그대로 유지된다')와 동형.
+    it('expected_updated_at/force_overwrite(동시성 제어)도 파싱 결과에 실제로 살아남는다(회귀 — 2868/2874)', () => {
+      const parsed = updateStorySchema.safeParse({
+        expected_updated_at: '2026-01-01T00:00:00Z', force_overwrite: true,
+      });
+      expect(parsed.success).toBe(true);
+      expect(parsed.success && parsed.data.expected_updated_at).toBe('2026-01-01T00:00:00Z');
+      expect(parsed.success && parsed.data.force_overwrite).toBe(true);
+    });
   });
 
   describe('bulkUpdateStorySchema', () => {

--- a/packages/shared/src/schemas/stories.ts
+++ b/packages/shared/src/schemas/stories.ts
@@ -63,6 +63,12 @@ export const updateStorySchema = z.object({
   success_hypothesis: z.string().optional().nullable(),
   metric_definition: metricDefinitionSchema.optional().nullable(),
   measure_after: z.string().datetime().optional().nullable(),
+  // story #2868/#2874 자매(2026-08-21, 페드루 라이브 프로브 실측) — docs.ts::updateDocSchema
+  // (151e05f1)엔 있는데 여기 없어 zod가 침묵 strip, 웹 프록시 경유 PATCH는 BE의 409 낙관적
+  // 동시성 가드에 아예 도달 못 했다(#2863과 동일 결함 클래스: 있다≠지금 쓰는 것). docs.ts와
+  // 동형 필드로 합집합 유지(어느 쪽도 새로 자르지 않음).
+  expected_updated_at: z.string().optional(),
+  force_overwrite: z.boolean().optional(),
 });
 
 const bulkUpdateItemSchema = z.object({


### PR DESCRIPTION
[SID:2868]

## 요약
dev 배포(e1748058e, #3288 머지분) 후 페드루군 라이브 프로브: 웹 프록시(`/api/stories/[id]`)
경유로 낡은 `expected_updated_at`(2020년) PATCH를 쏘면 409가 아니라 200이 나왔다. BE 직접
호출(REST/MCP — #2752 사고의 실 경로)엔 #3288의 낙관적 동시성 가드가 서지만, 웹 UI 경유는
가드에 도달조차 못 하는 상태였다.

## 원인 — 요청 파이프라인 2개 층에 같은 결함 클래스(#2863과 동형: 있다≠지금 쓰는 것)

1. **`packages/shared/src/schemas/stories.ts::updateStorySchema`(zod)** — `docs.ts`의
   `updateDocSchema`(151e05f1)엔 `expected_updated_at`/`force_overwrite`가 있는데 여기 없어
   zod가 침묵 strip. (페드루군이 지적한 지점)
2. **`apps/web/src/services/story.ts::StoryService.update()`의 `ALLOWED_FIELDS` allowlist** —
   ①만 고쳐도 zod를 통과한 값이 여기서 다시 조용히 스트립됐다. 요청 경로 전수 추적으로
   발견한 두 번째 층 — 같은 PATCH 경로의 일부라 함께 닫았다.

`packages/core-storage/src/interfaces/IStoryRepository.ts::UpdateStoryInput` 타입에도 두
필드가 없어 ②를 고치려면 타입부터 열어야 했다(TS가 `keyof UpdateStoryInput` 배열에 없는
문자열을 거부). `ApiStoryRepository.update()`는 이미 `input`을 통째로 `fastapiCall` body로
전달하는 제네릭 경로라 추가 수정 불요 — 3곳 수정으로 BE까지 값이 실제로 도달함을 확認했다.

## 검증
- `packages/shared`: zod 필드 생존 값-테스트 추가(#2863 재발방지 패턴과 동형) — 값 자체를
  단언(«success:true»만 보는 테스트로는 이 클래스를 못 잡는다).
- `apps/web`: `StoryService.update()`가 `repo.update()`에 두 필드를 실제로 전달하는지
  값-테스트 추가.
- 둘 다 `git apply -R`로 각 fix를 되돌려 즉시 실패 확인(load-bearing 증명).
- `tsc --noEmit`: `core-storage`/`shared`/`storage-api`/`apps/web`(무관한 pre-existing 에러
  2건 제외 — `docx-preview` 모듈 미설치·`.next` 빌드 아티팩트 갭) 전부 clean.
- 기존 story 관련 FE 테스트(API route 6개+shared validation 75건+storage-api 17건) 전부
  무회귀.

머지·배포되면 페드루군이 웹 프록시 경유 409 재프로브로 #2868을 닫을 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)