### PR TITLE
[SID:2874][하드닝·BE] 낙관적 동시성 진짜 CAS 승격 — UPDATE...WHERE updated_at= 원자 비교

### DIFF
--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,11 +1,22 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, func
+from sqlalchemy import DateTime, func, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
+
+# story #2874/#3291(카디르 QA rework, 2026-08-21): 낙관적 동시성 CAS가 ms-절삭 updated_at을
+# 토큰으로 쓰는데(false-409 방지, 카디르 probe), 같은 밀리초 버킷 안에서 write가 두 번 겹치면
+# 그 절삭값이 «퇴화»해 낡은 expected가 통과하는 SQL 레벨 결정적 재현이 나왔다(타이밍 운 아님).
+# 처방: 매 write가 직전 값보다 최소 1ms는 반드시 전진하게 onupdate 자체를 이 식으로 강제 —
+# `updated_at`을 CAS 토큰으로 쓰는 모델(Story·Doc, app/models/pm.py·doc.py)이 이 상수를
+# import해 컬럼을 override한다. 한 곳(이 상수)만 선언하면 그 모델의 일반 update()(setattr+
+# flush, onupdate 자동 적용)와 BaseRepository.update_with_cas() 둘 다 같은 불변식을 타므로
+# "CAS 경로만 고치면 반쪽" 클래스를 원천 차단(update_with_cas는 updated_at을 explicit으로
+# SET하지 않는다 — 이 onupdate가 유일한 경로).
+MONOTONIC_UPDATED_AT_ONUPDATE = text("GREATEST(clock_timestamp(), updated_at + interval '1 millisecond')")
 
 
 class TimestampMixin:

--- a/backend/app/models/doc.py
+++ b/backend/app/models/doc.py
@@ -7,7 +7,7 @@ from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
-from app.models.base import OrgScopedMixin, SoftDeleteMixin, TimestampMixin
+from app.models.base import MONOTONIC_UPDATED_AT_ONUPDATE, OrgScopedMixin, SoftDeleteMixin, TimestampMixin
 
 # E-DG S22: doc decision lifecycle(doc-specific·work status 아님). hypothesis _VALID_TRANSITIONS 패턴 미러.
 # E-DG doc-gate(48f064e5): draft→pending(상신·Gate inbox 노출)→confirmed/denied(gate 해소). pending=
@@ -33,6 +33,14 @@ def is_valid_doc_transition(from_status: str, to_status: str) -> bool:
 
 class Doc(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "docs"
+
+    # story #2874/#3291(카디르 QA rework): update_with_cas()가 이 컬럼을 CAS 토큰으로 쓴다 —
+    # TimestampMixin의 기본 onupdate=func.now()를 override(MONOTONIC_UPDATED_AT_ONUPDATE,
+    # app/models/base.py 상수 참조 — 근거 그 파일에 있음, stories.py와 동일 처방).
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=MONOTONIC_UPDATED_AT_ONUPDATE,
+        nullable=False,
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     project_id: Mapped[uuid.UUID] = mapped_column(

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
-from app.models.base import OrgScopedMixin, SoftDeleteMixin, TimestampMixin
+from app.models.base import MONOTONIC_UPDATED_AT_ONUPDATE, OrgScopedMixin, SoftDeleteMixin, TimestampMixin
 
 
 class Sprint(Base, OrgScopedMixin, TimestampMixin):
@@ -99,6 +99,14 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
         # app.repositories.story.allocate_story_number(advisory xact lock)이 보장, 이 제약은
         # 그 보장이 깨졌을 때(버그·우회 write) 조용히 중복 채번되는 걸 막는 최후 방어선.
         UniqueConstraint("project_id", "story_number", name="uq_stories_project_id_story_number"),
+    )
+
+    # story #2874/#3291(카디르 QA rework): update_with_cas()가 이 컬럼을 CAS 토큰으로 쓴다 —
+    # TimestampMixin의 기본 onupdate=func.now()를 override(MONOTONIC_UPDATED_AT_ONUPDATE,
+    # app/models/base.py 상수 참조 — 근거 그 파일에 있음).
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=MONOTONIC_UPDATED_AT_ONUPDATE,
+        nullable=False,
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -5,12 +5,22 @@ from datetime import datetime
 from typing import Any, Generic, TypeVar
 
 from sqlalchemy import func, select
+from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import Base
 from app.models.base import SoftDeleteMixin
 
 T = TypeVar("T", bound=Base)
+
+
+class CasConflict(Exception):
+    """story #2874: update_with_cas() 낙관적 동시성 충돌 — 호출자가 .current(최신 row)로
+    409 detail(current_updated_at 등)을 구성한다."""
+
+    def __init__(self, current: Any) -> None:
+        self.current = current
+        super().__init__("optimistic concurrency conflict")
 
 # cursor 페이지네이션이 안전한 단조 정렬 컬럼 화이트리스트.
 # title/priority 등 비단조 컬럼은 cursor 중복으로 누락/중복을 유발하므로 제외한다.
@@ -122,6 +132,50 @@ class BaseRepository(Generic[T]):
         await self.session.flush()
         await self.session.refresh(obj)
         return obj
+
+    async def update_with_cas(
+        self, id: uuid.UUID, *, expected_updated_at: datetime | None = None, **data: Any
+    ) -> T | None:
+        """story #2874(하드닝): ``update()``는 재조회→setattr→flush로 check-then-write라
+        원자적이지 않다 — 같은 밀리초대 진짜 동시 PATCH 두 건이 겹치면(둘 다 "충돌 前" 값을
+        읽고 통과) 나중 flush가 먼저 것을 조용히 덮어쓸 수 있다(#3288 QA·codex 지적, 카디르
+        사실 확認). ``expected_updated_at``이 주어지면 단일 SQL 문
+        ``UPDATE ... WHERE id= AND updated_at=`` 로 승격 — DB가 원자적으로 비교+쓰기를
+        한 스텝에 한다(진짜 CAS, TOCTOU 창 없음).
+
+        ms-절삭 비교(docs.py 151e05f1 근거 그대로, 카디르 probe로 실증된 축 — DB μs=654321·
+        클라 ms절삭 654000 전송해도 false-409 없이 통과해야 함): ``date_trunc('milliseconds',
+        ...)``로 컬럼·파라미터 양쪽을 SQL 레벨에서 동일하게 절삭 후 비교한다.
+
+        rowcount=0이면 대상이 없거나(404, 호출자가 반환값 None으로 판별) 그 사이 다른 write가
+        있었다(409, ``CasConflict`` — 최신 row를 실어 올린다). ``expected_updated_at``이
+        None이면 기존 ``update()``와 완전히 동일(무CAS·하위호환)."""
+        if expected_updated_at is None:
+            return await self.update(id, **data)
+
+        values = {**data, "updated_at": func.now()}
+        result = await self.session.execute(
+            sa_update(self.model)
+            .where(
+                self._org_filter(),
+                self.model.id == id,  # type: ignore[attr-defined]
+                func.date_trunc("milliseconds", self.model.updated_at)  # type: ignore[attr-defined]
+                == func.date_trunc("milliseconds", expected_updated_at),
+            )
+            .values(**values)
+        )
+        # Core-style UPDATE는 세션 identity map을 자동 동기화하지 않는다 — 호출부가 이미
+        # 같은 id를 로드해 둔 인스턴스(예: 라우터의 사전조회 story_before)가 있으면 재조회
+        # (get)만으로는 그 캐시된 파이썬 객체를 그대로 돌려줄 뿐 새 컬럼값을 안 반영한다.
+        # expire_all()로 강제 무효화 후 재조회해야 rowcount 판정과 무관하게 항상 신선하다.
+        self.session.expire_all()
+        if result.rowcount == 1:
+            return await self.get(id)
+
+        current = await self.get(id)
+        if current is None:
+            return None
+        raise CasConflict(current)
 
     async def delete(self, id: uuid.UUID) -> bool:
         obj = await self.get(id)

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -147,13 +147,22 @@ class BaseRepository(Generic[T]):
         클라 ms절삭 654000 전송해도 false-409 없이 통과해야 함): ``date_trunc('milliseconds',
         ...)``로 컬럼·파라미터 양쪽을 SQL 레벨에서 동일하게 절삭 후 비교한다.
 
+        ⚠️#3291 카디르 QA rework(2026-08-21, SQL 레벨 결정적 재현): ms-절삭 토큰을 CAS 비교에
+        쓰면 「T1의 write가 만든 새 updated_at이 원래 값과 같은 ms 버킷에 떨어지는」 경우
+        T2가 낡은 expected를 들고 와도 date_trunc 비교가 통과해 rowcount=1로 조용히
+        덮어쓴다(같은 버킷=같은 절삭값). 이 메서드는 절대 ``updated_at``을 explicit으로
+        SET하지 않는다 — 대상 모델(Story/Doc)이 컬럼 자체의 ``onupdate``를 「매 write마다
+        직전 값보다 최소 1ms 전진」(``GREATEST(clock_timestamp(), updated_at + 1ms)``,
+        app/models/pm.py·doc.py)로 override해 뒀으므로, 이 CAS 경로뿐 아니라 일반
+        ``update()``(setattr+flush, onupdate가 그대로 적용)까지 **같은 한 곳의 선언**으로
+        모노토닉이 강제된다(둘 중 하나만 고치면 반쪽이 되는 걸 원천 차단).
+
         rowcount=0이면 대상이 없거나(404, 호출자가 반환값 None으로 판별) 그 사이 다른 write가
         있었다(409, ``CasConflict`` — 최신 row를 실어 올린다). ``expected_updated_at``이
         None이면 기존 ``update()``와 완전히 동일(무CAS·하위호환)."""
         if expected_updated_at is None:
             return await self.update(id, **data)
 
-        values = {**data, "updated_at": func.now()}
         result = await self.session.execute(
             sa_update(self.model)
             .where(
@@ -162,7 +171,7 @@ class BaseRepository(Generic[T]):
                 func.date_trunc("milliseconds", self.model.updated_at)  # type: ignore[attr-defined]
                 == func.date_trunc("milliseconds", expected_updated_at),
             )
-            .values(**values)
+            .values(**data)
         )
         # Core-style UPDATE는 세션 identity map을 자동 동기화하지 않는다 — 호출부가 이미
         # 같은 id를 로드해 둔 인스턴스(예: 라우터의 사전조회 story_before)가 있으면 재조회

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -506,9 +506,9 @@ async def update_doc(
     if "parent_id" in data:
         await _assert_doc_parent_in_project(session, doc.project_id, data["parent_id"])
 
-    # 일반 필드 적용 (slug 제외)
-    for attr, val in data.items():
-        setattr(doc, attr, val)
+    # story #2874(하드닝): slug/slug_locked도 아래서 setattr 직접 대신 data에 모아 뒀다가
+    # update_with_cas() 한 SQL 문으로 함께 반영한다 — 필드 적용을 두 단계(setattr 여기 +
+    # slug setattr 저기)로 나누면 그 사이에도 TOCTOU 창이 생겨 원자성이 반쪽이 된다.
 
     # slug 변경 처리 (4dd399c6)
     if slug_in is not None:
@@ -544,7 +544,7 @@ async def update_doc(
                     session, repo.org_id, doc.project_id, new_slug, exclude_doc_id=doc.id
                 )
             old_slug = doc.slug
-            doc.slug = new_slug
+            data["slug"] = new_slug
             # AC3: 구 slug → alias 보존 (이미 있으면 skip). 신 slug 가 과거 alias였다면 정리(live 우선).
             await session.execute(
                 sa_delete(DocSlugAlias).where(
@@ -569,10 +569,28 @@ async def update_doc(
                 existing_alias.doc_id = doc.id
 
     if slug_locked_in is not None:
-        doc.slug_locked = slug_locked_in
+        data["slug_locked"] = slug_locked_in
 
-    await session.flush()
-    await session.refresh(doc)
+    # story #2874: check-then-write(위 expected_updated_at 사전 체크, side-effect 前 빠른
+    # 실패용)는 non-atomic이라 진짜 동시 PATCH TOCTOU 창이 남는다 — 실제 write는 여기
+    # update_with_cas()의 원자 SQL(UPDATE...WHERE updated_at=)로 다시 한번 강제한다
+    # (force_overwrite면 CAS 생략). stories.py::update_story와 동일 공용 판정 함수(중복 구현 0).
+    from app.repositories.base import CasConflict
+    try:
+        doc = await repo.update_with_cas(
+            id, expected_updated_at=None if force_overwrite else expected_updated_at, **data
+        )
+    except CasConflict as e:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "DOC_CONFLICT",
+                "message": "문서가 다른 곳에서 수정됨 — 최신본을 다시 불러오세요",
+                "current_updated_at": e.current.updated_at.isoformat(),
+            },
+        )
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
 
     if "content" in data:
         cutoff_sq = (

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -2071,7 +2071,24 @@ async def update_story(
     # status를 그대로 씀, #2131은 status_changed **emit** 갭만 닫았지 게이트 자체는 다른 축).
     # 단건은 게이트를 거치는데 bulk는 안 거쳐 사람 승인을 우회할 수 있는 별건 갭 — #2521로
     # 후속 분리(#2156 advisory→enforcing flip 前에 닫아야 flip이 실효).
-    story = await repo.update(id, **data)
+    # story #2874: 위의 expected_updated_at 사전 체크(commit 전, 다른 side-effect 前 빠른
+    # 실패)는 non-atomic 시야라 진짜 동시 PATCH TOCTOU 창이 남는다 — 실제 write는 여기
+    # update_with_cas()의 원자 SQL(UPDATE...WHERE updated_at=)로 다시 한번, 이번엔 진짜로
+    # 강제한다(force_overwrite면 CAS 자체를 생략 — docs.py와 동일 계약).
+    from app.repositories.base import CasConflict
+    try:
+        story = await repo.update_with_cas(
+            id, expected_updated_at=None if force_overwrite else expected_updated_at, **data
+        )
+    except CasConflict as e:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "STORY_CONFLICT",
+                "message": "스토리가 다른 곳에서 수정됨 — 최신본을 다시 불러오세요",
+                "current_updated_at": e.current.updated_at.isoformat(),
+            },
+        )
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
 

--- a/backend/tests/test_2874_story_doc_cas_atomic_concurrency_realdb.py
+++ b/backend/tests/test_2874_story_doc_cas_atomic_concurrency_realdb.py
@@ -274,3 +274,101 @@ async def test_story_genuinely_different_ms_is_rejected_409():
         assert exc_info.value.status_code == 409
     finally:
         await eng.dispose()
+
+
+# ───────────── ③ #3291 카디르 QA rework — ms-절삭 CAS 토큰의 same-bucket 퇴화 ─────────────
+#
+# 카디르 SQL 레벨 결정적 재현(2026-08-21): T1의 write가 만든 새 updated_at이 원래 값과 같은
+# ms 버킷에 떨어지면(양쪽 다 date_trunc('milliseconds', ...)로 같은 값), T2가 T0(원래) 시점의
+# 낡은 expected_updated_at을 들고 와도 CAS 비교가 통과해 rowcount=1로 조용히 덮어쓴다 —
+# 타이밍 운이 아니라 같은 ms 안에서는 항상 재현되는 결정적 결함. 처방: onupdate 자체를
+# GREATEST(clock_timestamp(), updated_at + 1ms)로 바꿔 매 write가 최소 1ms(=최소 1 버킷)는
+# 반드시 전진하게 강제(app/models/base.py::MONOTONIC_UPDATED_AT_ONUPDATE, Story/Doc가 override).
+# 이 아래 테스트는 실 타이밍(비결정적)에 기대지 않고 저장값을 직접 조작해 **결정적으로** 잰다.
+
+@pytest.mark.anyio
+async def test_story_onupdate_strictly_advances_ms_bucket_even_when_stored_value_is_far_future():
+    """수학적 불변식 직접 검증 — updated_at을 실제 시각보다 훨씬 미래로 박아 두면
+    clock_timestamp() 단독으로는 절대 못 앞서므로, GREATEST의 «updated_at+1ms» 분기가
+    반드시 이겨야 한다(그렇지 않으면 뒤로 가거나 제자리 — 둘 다 same-bucket 퇴화의 원인).
+    ms 경계에 딱 붙은 microsecond(999000)로 앞서 최악 케이스까지 잡는다."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import get_story, update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            # 실 시각보다 100년 미래 + ms 경계에 딱 붙은 microsecond — clock_timestamp()가
+            # 이 값을 절대 못 앞지르는 조건을 만든다(GREATEST의 +1ms 분기 강제 발동 검증).
+            await s.execute(text(
+                f"UPDATE stories SET updated_at = '2126-01-01 00:00:00.999000+00' WHERE id='{STORY}'"
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            before = await get_story(STORY, repo, _auth_human(USER))
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            after = await update_story(
+                STORY, StoryUpdate(description="ADVANCED"), BackgroundTasks(), repo, s, _auth_human(USER),
+            )
+
+        before_ms_bucket = before.updated_at.replace(microsecond=(before.updated_at.microsecond // 1000) * 1000)
+        after_ms_bucket = after.updated_at.replace(microsecond=(after.updated_at.microsecond // 1000) * 1000)
+        assert after_ms_bucket > before_ms_bucket, (
+            f"onupdate가 ms 버킷을 전진 못 시키면 same-bucket 퇴화가 재현된다 — "
+            f"before={before.updated_at} after={after.updated_at}"
+        )
+        assert after.updated_at >= before.updated_at + timedelta(milliseconds=1)
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_cas_rejects_stale_token_after_write_forced_into_far_future_bucket():
+    """통합 레벨 — T0 스냅숏(미래로 박아 둔 값)을 들고 온 T2가, T1이 이미 다른 값을 쓴
+    뒤에도 여전히 409로 거부되는지(설령 T1의 새 값이 T0와 «가까운» ms대라도 onupdate가
+    최소 1버킷은 반드시 벌려 둬서 date_trunc 비교가 다시는 우연히 일치하지 않는다)."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import get_story, update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text(
+                f"UPDATE stories SET updated_at = '2126-01-01 00:00:00.999000+00' WHERE id='{STORY}'"
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            t0_snapshot = await get_story(STORY, repo, _auth_human(USER))
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            await update_story(
+                STORY, StoryUpdate(description="T1_WRITE"), BackgroundTasks(), repo, s, _auth_human(USER),
+            )
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            with pytest.raises(HTTPException) as exc_info:
+                await update_story(
+                    STORY,
+                    StoryUpdate(description="T2_STALE", expected_updated_at=t0_snapshot.updated_at),
+                    BackgroundTasks(), repo, s, _auth_human(USER),
+                )
+        assert exc_info.value.status_code == 409
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            final = await get_story(STORY, repo, _auth_human(USER))
+        assert final.description == "T1_WRITE", "T2가 거부돼야 T1의 write가 안 덮인다"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2874_story_doc_cas_atomic_concurrency_realdb.py
+++ b/backend/tests/test_2874_story_doc_cas_atomic_concurrency_realdb.py
@@ -1,0 +1,276 @@
+"""story #2874(하드닝) — #3288 QA서 codex가 지적(카디르 사실 확認): `BaseRepository.update()`
+는 재조회→setattr→flush의 check-then-write라 원자적 CAS가 아니다. `expected_updated_at`
+방어(#2868)가 같은 밀리초대 «진짜 동시» PATCH 두 건 앞에서 뚫릴 수 있다 — 두 요청이 모두
+"충돌 前" updated_at을 읽고 통과한 뒤, 나중 flush가 먼저 것을 조용히 덮어쓰는 TOCTOU 창.
+
+이 파일은 `BaseRepository.update_with_cas()`(단일 SQL `UPDATE ... WHERE id= AND
+date_trunc('milliseconds', updated_at)=`)가:
+  ① 진짜 동시(asyncio.gather, 별도 세션) PATCH 두 건 중 정확히 1건만 통과시키는지(원자성
+     실측 — 순차 staleness가 아니라 진짜 레이스로 하중 증명)
+  ② ms-절삭 경계에서 false-409를 안 내는지(DB μs=654321·클라 ms절삭 654000 전송 → 200,
+     카디르 probe로 실증된 축 — #3288 5건엔 직접 커버가 없던 갭)
+값으로 잰다. stories·docs 양쪽 다(공용 판정 함수 재사용 확認).
+
+#2853/#2845/#2857과 동일 정신 — 격리 로컬 throwaway realdb만 사용(라이브 배포 시스템 무접촉).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import timedelta
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from starlette.background import BackgroundTasks
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("28740000-0000-0000-0000-000000000101")
+USER = uuid.UUID("28740000-0000-0000-0000-0000000101a1")
+OM = uuid.UUID("28740000-0000-0000-0000-0000000101b1")
+PROJ = uuid.UUID("28740000-0000-0000-0000-0000000101c1")
+STORY = uuid.UUID("28740000-0000-0000-0000-0000000101d1")
+DOC = uuid.UUID("28740000-0000-0000-0000-0000000101e1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth_human(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(ORG))
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC, pool_size=5, max_overflow=5)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed(s) -> None:
+    for sql in [
+        f"DELETE FROM docs WHERE org_id='{ORG}'",
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S2874','s2874-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{USER}','u@s2874.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','owner')",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','P','s2874-proj','warn')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{OM}','granted','owner')",
+        "INSERT INTO stories (id,org_id,project_id,title,status,priority,description) VALUES "
+        f"('{STORY}','{ORG}','{PROJ}','S','backlog','medium','ORIGINAL')",
+        "INSERT INTO docs (id,org_id,project_id,title,slug,content) VALUES "
+        f"('{DOC}','{ORG}','{PROJ}','D','s2874-doc','ORIGINAL')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+# ───────────── ① 진짜 동시 PATCH 두 건 — 정확히 1건만 통과(원자성) ─────────────
+
+@pytest.mark.anyio
+async def test_story_concurrent_patch_only_one_wins_atomically():
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import get_story, update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            snapshot = await get_story(STORY, repo, _auth_human(USER))
+
+        async def _patch(suffix: str):
+            async with Session() as s:
+                repo = StoryRepository(s, ORG)
+                try:
+                    resp = await update_story(
+                        STORY,
+                        StoryUpdate(description=f"ORIGINAL+{suffix}", expected_updated_at=snapshot.updated_at),
+                        BackgroundTasks(), repo, s, _auth_human(USER),
+                    )
+                    return ("ok", resp.description)
+                except HTTPException as e:
+                    return ("conflict", e.status_code)
+
+        results = await asyncio.gather(_patch("A"), _patch("B"))
+        outcomes = [r[0] for r in results]
+        assert outcomes.count("ok") == 1, (
+            f"진짜 동시 PATCH 두 건 중 정확히 1건만 통과해야 한다(원자적 CAS) — {results}"
+        )
+        assert outcomes.count("conflict") == 1
+        conflict = next(r for r in results if r[0] == "conflict")
+        assert conflict[1] == 409
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            final = await get_story(STORY, repo, _auth_human(USER))
+        winner_desc = next(r[1] for r in results if r[0] == "ok")
+        assert final.description == winner_desc, "DB 최종 상태가 승자의 write와 일치해야 한다"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_doc_concurrent_patch_only_one_wins_atomically():
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import get_doc, update_doc
+    from app.schemas.doc import DocUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            repo = DocRepository(s, ORG)
+            snapshot = await get_doc(DOC, session=s, repo=repo, auth=_auth_human(USER))
+
+        async def _patch(suffix: str):
+            async with Session() as s:
+                repo = DocRepository(s, ORG)
+                try:
+                    resp = await update_doc(
+                        DOC,
+                        DocUpdate(content=f"ORIGINAL+{suffix}", expected_updated_at=snapshot.updated_at),
+                        BackgroundTasks(), repo, s, _auth_human(USER),
+                    )
+                    # update_doc은 (stories.py와 달리) 자체 commit이 없다 — 실 FastAPI 경로는
+                    # get_db() 디펜던시 래퍼가 요청 종료 시 commit한다. 직접호출 테스트는 그
+                    # 래퍼 역할을 여기서 명시로 재현해야 락 보유 구간(원자성의 핵심)이 실제
+                    # 요청과 동형이 된다 — 생략하면 두 트랜잭션 다 커밋 전 롤백돼 "둘 다 성공"
+                    # 이라는 가짜 결과가 나온다(직접 확인한 실패 모드).
+                    await s.commit()
+                    return ("ok", resp.content)
+                except HTTPException as e:
+                    return ("conflict", e.status_code)
+
+        results = await asyncio.gather(_patch("A"), _patch("B"))
+        outcomes = [r[0] for r in results]
+        assert outcomes.count("ok") == 1, f"doc도 동일 — {results}"
+        assert outcomes.count("conflict") == 1
+        conflict = next(r for r in results if r[0] == "conflict")
+        assert conflict[1] == 409
+    finally:
+        await eng.dispose()
+
+
+# ───────────── ② ms-절삭 경계 — DB μs 대비 클라 ms절삭 전송해도 false-409 없음 ─────────────
+
+@pytest.mark.anyio
+async def test_story_ms_truncated_expected_updated_at_no_false_409():
+    """카디르 probe 축(#3288) — DB가 μs=654321을 들고 있는데 클라(JS Date)가 ms절삭한
+    654000을 expected_updated_at으로 보내도 CAS가 «다른 값»으로 오판해 409를 내면 안 된다."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            # μs=654321로 정밀 세팅(INSERT 기본 now()는 임의 μs라 명시로 고정해 대조를 값으로 잰다).
+            await s.execute(text(
+                f"UPDATE stories SET updated_at = '2026-08-21 05:00:00.654321+00' WHERE id='{STORY}'"
+            ))
+            await s.commit()
+
+        client_ms_truncated = __import__("datetime").datetime(
+            2026, 8, 21, 5, 0, 0, 654000, tzinfo=__import__("datetime").timezone.utc
+        )
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            resp = await update_story(
+                STORY,
+                StoryUpdate(description="APPENDED", expected_updated_at=client_ms_truncated),
+                BackgroundTasks(), repo, s, _auth_human(USER),
+            )
+        assert resp.description == "APPENDED", "ms-절삭값 == DB μs값(ms 단위까지)이면 통과해야 한다(false-409 금지)"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_doc_ms_truncated_expected_updated_at_no_false_409():
+    """story 쪽과 대칭 — doc도 같은 공용 판정 함수(update_with_cas)를 타므로 동일하게
+    ms-절삭 경계에서 false-409가 없어야 한다."""
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import update_doc
+    from app.schemas.doc import DocUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text(
+                f"UPDATE docs SET updated_at = '2026-08-21 05:00:00.654321+00' WHERE id='{DOC}'"
+            ))
+            await s.commit()
+
+        client_ms_truncated = __import__("datetime").datetime(
+            2026, 8, 21, 5, 0, 0, 654000, tzinfo=__import__("datetime").timezone.utc
+        )
+
+        async with Session() as s:
+            repo = DocRepository(s, ORG)
+            resp = await update_doc(
+                DOC, DocUpdate(content="APPENDED", expected_updated_at=client_ms_truncated),
+                BackgroundTasks(), repo, s, _auth_human(USER),
+            )
+        assert resp.content == "APPENDED"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_genuinely_different_ms_is_rejected_409():
+    """대조군 — ms 단위 자체가 다르면(진짜 stale) 여전히 409여야 한다(ms-절삭 관용이
+    "아무 값이나 통과"로 새지 않았는지 확認)."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text(
+                f"UPDATE stories SET updated_at = '2026-08-21 05:00:00.654321+00' WHERE id='{STORY}'"
+            ))
+            await s.commit()
+
+        stale = __import__("datetime").datetime(
+            2026, 8, 21, 5, 0, 0, 653000, tzinfo=__import__("datetime").timezone.utc
+        )  # ms 단위가 654→653으로 실제로 다름(1ms 오차, 진짜 stale 시나리오)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            with pytest.raises(HTTPException) as exc_info:
+                await update_story(
+                    STORY, StoryUpdate(description="X", expected_updated_at=stale),
+                    BackgroundTasks(), repo, s, _auth_human(USER),
+                )
+        assert exc_info.value.status_code == 409
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_doc_concurrency_151e05f1.py
+++ b/backend/tests/test_doc_concurrency_151e05f1.py
@@ -37,10 +37,27 @@ def _doc(updated_at=T1):
 
 
 async def _call(body_kwargs, doc_updated_at=T1):
+    from app.repositories.base import CasConflict
+
     repo = MagicMock()
     repo.org_id = uuid.uuid4()
     d = _doc(doc_updated_at)
     repo.get = AsyncMock(return_value=d)
+
+    # story #2874: 실 write는 이제 repo.update_with_cas()로 위임된다(check-then-write에서
+    # 원자 CAS로 승격) — 이 목(mock) repo도 그 계약(ms-절삭 비교·불일치 시 CasConflict)을
+    # 재현해야 이 파일이 검증하려는 동시성 의미(409/통과 분기)가 그대로 유효하다.
+    async def _fake_update_with_cas(_id, *, expected_updated_at=None, **data):
+        if expected_updated_at is not None:
+            cur_ms = d.updated_at.replace(microsecond=(d.updated_at.microsecond // 1000) * 1000)
+            exp_ms = expected_updated_at.replace(microsecond=(expected_updated_at.microsecond // 1000) * 1000)
+            if cur_ms != exp_ms:
+                raise CasConflict(d)
+        for k, v in data.items():
+            setattr(d, k, v)
+        return d
+
+    repo.update_with_cas = AsyncMock(side_effect=_fake_update_with_cas)
     session = AsyncMock()
     session.execute = AsyncMock()
     session.flush = AsyncMock()


### PR DESCRIPTION
[SID:2874]

## 배경
#3288 QA서 codex가 HIGH 지적·카디르 사실 확認: `BaseRepository.update()`는 재조회→setattr→
flush의 check-then-write라 원자적이지 않다 — 같은 밀리초대 「진짜 동시」 PATCH 두 건이 겹치면
`expected_updated_at` 방어(#2868)가 뚫릴 수 있다(둘 다 "충돌 前" 값을 읽고 통과한 뒤, 나중
flush가 먼저 것을 조용히 덮어씀). `docs.py`(151e05f1)도 같은 `BaseRepository`라 동일 특성을
공유한다 — #3288은 쌍둥이 동형 이식이 목표였고 실사고 클래스(순차 staleness)는 100% 차단
증명이라 비차단 재분류(PO 승認 2026-08-21).

## 처방
`BaseRepository.update_with_cas()`(신규, stories/docs 공용 — 중복 구현 0): `expected_updated_at`
제공 시 단일 SQL `UPDATE ... WHERE id= AND date_trunc('milliseconds', updated_at) =
date_trunc('milliseconds', :expected)`로 원자 CAS로 승격. `rowcount=0`이면 대상 없음(404)
또는 그 사이 다른 write(409, `CasConflict` 예외로 최신 row를 실어 올림) — 재조회 1회로
갈라 판정. ms-절삭을 **SQL 레벨**에서(파이썬이 아니라) 컬럼·파라미터 양쪽에 동일 적용해
false-409가 없다(카디르 probe 축 그대로 보존 — DB μs=654321·클라 ms절삭 654000 전송해도 통과).

- `stories.py::update_story`/`docs.py::update_doc` 둘 다 실제 write 지점을 `repo.update(...)`
  (docs는 기존 setattr 직접)에서 `repo.update_with_cas(...)`로 교체. 기존 commit-前 manual
  체크(비원자·side-effect 前 빠른 실패용, GCS/attachments sync 등을 아끼는 fast-path)는
  그대로 두고 defense-in-depth로 유지 — 실제 write 지점의 CAS가 최종 진실.
- `docs.py`: slug/slug_locked도 별도 setattr 대신 같은 CAS 호출 한 문에 실어 반영한다(두
  단계로 나누면 그 사이도 TOCTOU 창이 생긴다).
- Core-style UPDATE는 세션 identity map을 자동 동기화하지 않는다 — `expire_all()` 후
  재조회로 rowcount 판정과 무관하게 항상 신선한 값을 보장한다.

## 검증
- 신규 realdb 5건(`test_2874_story_doc_cas_atomic_concurrency_realdb.py`):
  ①story/②doc 각각 **진짜 동시**(`asyncio.gather`, 별도 세션+명시 커밋) PATCH 두 건 중
  정확히 1건만 통과(원자성 실측 — 순차 staleness가 아니라 진짜 레이스로 하중 증명)
  ③story/④doc 각각 ms-절삭 경계(DB μs=654321·클라 ms절삭 654000)에서 false-409 없음
  ⑤진짜 다른 ms는 여전히 409(ms-절삭 관용이 "아무 값이나 통과"로 안 샜는지 대조군).
  `git apply -R`로 fix 제거 시 ①이 **정확히 예측한 실패 모드**로 재현됨을 확인(두 PATCH가
  다 "성공"하고 나중 것이 조용히 먼저 것을 덮어씀 — load-bearing).
- 기존 `test_doc_concurrency_151e05f1.py`(mock 기반)는 `repo.update_with_cas`를 모킹하도록
  갱신(아키텍처 변경에 따른 정합 조정 — 검증하는 동시성 *의미*는 무변경, 6건 전부 무회귀).
- pg@16+alembic head 로컬 migrated real-PG, 깨끗한 신규 DB에서 stories/docs 관련 기존
  41파일·269케이스 재실행 — 전부 무회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)