### PR TITLE
[SID:2877] Card 단일 프리미티브 — cardVariants(cva)·SectionCard/GlassPanel alias·회귀 0

### DIFF
--- a/apps/web/src/components/ui/card.test.tsx
+++ b/apps/web/src/components/ui/card.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// story #2877(S1a) — Card 단일 프리미티브. SectionCard/GlassPanel이 cardVariants로 이관된 뒤
+// 원래 손코딩 클래스 세트와 «값으로» 동일한지 잠근다(회귀 0 AC의 실측 근거) — 순서가 아니라
+// 클래스 집합 동치를 잰다(Tailwind는 순서 무관).
+import { describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { cardVariants, Card, CardHeader, CardBody, CardFooter } from './card';
+import { SectionCard, SectionCardHeader, SectionCardBody } from './section-card';
+import { GlassPanel } from './glass-panel';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function classSet(el: Element | null): Set<string> {
+  return new Set((el?.className ?? '').split(/\s+/).filter(Boolean));
+}
+
+async function mountAndGetRoot(node: React.ReactNode): Promise<{ el: HTMLElement; root: Root }> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => { root.render(node); });
+  return { el: container.firstElementChild as HTMLElement, root };
+}
+
+// 이관 前 손코딩 원본(section-card.tsx/glass-panel.tsx git 이력) — 정본 리터럴로 대조.
+const ORIGINAL_SECTION_CARD_CLASSES = 'rounded-2xl border border-border/80 bg-card text-card-foreground shadow-sm';
+const ORIGINAL_GLASS_PANEL_CLASSES =
+  'rounded-2xl border border-border/80 bg-card/95 text-card-foreground shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/88';
+
+describe('cardVariants (story #2877)', () => {
+  it('surface=solid·radius=card가 SectionCard 원본 클래스 집합과 정확히 일치한다', () => {
+    expect(classSet({ className: cardVariants({ surface: 'solid', radius: 'card' }) } as Element)).toEqual(
+      classSet({ className: ORIGINAL_SECTION_CARD_CLASSES } as Element),
+    );
+  });
+
+  it('surface=glass·radius=card가 GlassPanel 원본 클래스 집합과 정확히 일치한다', () => {
+    expect(classSet({ className: cardVariants({ surface: 'glass', radius: 'card' }) } as Element)).toEqual(
+      classSet({ className: ORIGINAL_GLASS_PANEL_CLASSES } as Element),
+    );
+  });
+
+  it('defaultVariants가 solid·card다', () => {
+    expect(classSet({ className: cardVariants({}) } as Element)).toEqual(
+      classSet({ className: ORIGINAL_SECTION_CARD_CLASSES } as Element),
+    );
+  });
+});
+
+describe('SectionCard/GlassPanel — 얇은 alias 회귀가드 (story #2877)', () => {
+  it('SectionCard가 <section> 태그와 원본 클래스 그대로 렌더된다(태그·클래스 무회귀)', async () => {
+    const { el } = await mountAndGetRoot(<SectionCard>hi</SectionCard>);
+    expect(el.tagName).toBe('SECTION');
+    expect(el.getAttribute('data-slot')).toBe('section-card');
+    expect(classSet(el)).toEqual(classSet({ className: ORIGINAL_SECTION_CARD_CLASSES } as Element));
+  });
+
+  it('GlassPanel이 <div> 태그와 원본 클래스 그대로 렌더된다(태그·클래스 무회귀)', async () => {
+    const { el } = await mountAndGetRoot(<GlassPanel>hi</GlassPanel>);
+    expect(el.tagName).toBe('DIV');
+    expect(el.getAttribute('data-slot')).toBe('glass-panel');
+    expect(classSet(el)).toEqual(classSet({ className: ORIGINAL_GLASS_PANEL_CLASSES } as Element));
+  });
+
+  it('SectionCardHeader/Body가 여전히 border-b/px-5 py-4 시맨틱을 렌더한다', async () => {
+    const { el } = await mountAndGetRoot(<SectionCardHeader>h</SectionCardHeader>);
+    expect(el.className).toContain('border-b');
+    expect(el.className).toContain('px-5');
+    const { el: bodyEl } = await mountAndGetRoot(<SectionCardBody>b</SectionCardBody>);
+    expect(bodyEl.className).toContain('px-5');
+    expect(bodyEl.className).not.toContain('border-b');
+  });
+
+  it('추가 className이 병합되고 원본 클래스를 지우지 않는다', async () => {
+    const { el } = await mountAndGetRoot(<SectionCard className="mt-4">hi</SectionCard>);
+    expect(el.className).toContain('mt-4');
+    expect(el.className).toContain('rounded-2xl');
+  });
+});
+
+describe('Card 신규 프리미티브 — variant·서브컴포넌트 (story #2877)', () => {
+  it('subtle/plain surface와 compact/inline radius가 정확히 매핑된다', () => {
+    expect(cardVariants({ surface: 'subtle', radius: 'compact' })).toContain('bg-muted/30');
+    expect(cardVariants({ surface: 'subtle', radius: 'compact' })).toContain('rounded-xl');
+    expect(cardVariants({ surface: 'plain', radius: 'inline' })).toContain('rounded-lg');
+    expect(cardVariants({ surface: 'plain', radius: 'inline' })).not.toContain('shadow-sm');
+  });
+
+  it('Card/CardHeader/CardBody/CardFooter가 각자 올바른 data-slot으로 렌더된다', async () => {
+    const { el: card } = await mountAndGetRoot(<Card>c</Card>);
+    expect(card.getAttribute('data-slot')).toBe('card');
+    const { el: header } = await mountAndGetRoot(<CardHeader>h</CardHeader>);
+    expect(header.getAttribute('data-slot')).toBe('card-header');
+    const { el: body } = await mountAndGetRoot(<CardBody>b</CardBody>);
+    expect(body.getAttribute('data-slot')).toBe('card-body');
+    const { el: footer } = await mountAndGetRoot(<CardFooter>f</CardFooter>);
+    expect(footer.getAttribute('data-slot')).toBe('card-footer');
+    expect(footer.className).toContain('border-t');
+  });
+});

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+/**
+ * Card 단일 프리미티브 — story #2877(S1a, UI/UX 갈아엎기 시퀀스 S1). button.tsx의 cva 패턴을
+ * 그대로 따른다. SectionCard(surface=solid, 32 사용)·GlassPanel(surface=glass, 2 사용)은
+ * 이 variant 체계의 얇은 alias로 재정의된다(하위호환·회귀 0) — 새 화면은 Card를 직접 쓴다.
+ */
+
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+export const cardVariants = cva('border text-card-foreground', {
+  variants: {
+    surface: {
+      solid: 'border-border/80 bg-card shadow-sm',
+      glass: 'border-border/80 bg-card/95 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/88',
+      subtle: 'border-border/60 bg-muted/30',
+      plain: 'border-border/80 bg-card',
+    },
+    radius: {
+      card: 'rounded-2xl',
+      compact: 'rounded-xl',
+      inline: 'rounded-lg',
+    },
+  },
+  defaultVariants: { surface: 'solid', radius: 'card' },
+});
+
+export interface CardProps extends React.ComponentProps<'div'>, VariantProps<typeof cardVariants> {}
+
+export function Card({ className, surface, radius, ...props }: CardProps) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(cardVariants({ surface, radius, className }))}
+      {...props}
+    />
+  );
+}
+
+export function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn('border-b border-border/80 px-5 py-4 sm:px-6', className)}
+      {...props}
+    />
+  );
+}
+
+export function CardBody({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-body"
+      className={cn('px-5 py-4 sm:px-6', className)}
+      {...props}
+    />
+  );
+}
+
+export function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn('border-t border-border/80 px-5 py-4 sm:px-6', className)}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/components/ui/glass-panel.tsx
+++ b/apps/web/src/components/ui/glass-panel.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
+import { cardVariants } from '@/components/ui/card';
 
+/**
+ * story #2877 — Card 프리미티브(surface=glass)의 얇은 alias(하위호환·회귀 0). 기존
+ * 2개 소비처는 이 컴포넌트를 그대로 계속 쓴다 — 스타일 SSOT는 cardVariants로 이관됐다.
+ */
 export function GlassPanel({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="glass-panel"
-      className={cn(
-        'rounded-2xl border border-border/80 bg-card/95 text-card-foreground shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/88',
-        className,
-      )}
+      className={cn(cardVariants({ surface: 'glass', radius: 'card' }), className)}
       {...props}
     />
   );

--- a/apps/web/src/components/ui/section-card.tsx
+++ b/apps/web/src/components/ui/section-card.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
+import { cardVariants, CardHeader, CardBody } from '@/components/ui/card';
 
+/**
+ * story #2877 — Card 프리미티브(surface=solid)의 얇은 alias(하위호환·회귀 0). 기존
+ * 32개 소비처는 이 컴포넌트를 그대로 계속 쓴다 — 스타일 SSOT는 cardVariants로 이관됐다.
+ */
 export function SectionCard({ className, ...props }: React.ComponentProps<'section'>) {
   return (
     <section
       data-slot="section-card"
-      className={cn('rounded-2xl border border-border/80 bg-card text-card-foreground shadow-sm', className)}
+      className={cn(cardVariants({ surface: 'solid', radius: 'card' }), className)}
       {...props}
     />
   );
 }
 
-export function SectionCardHeader({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div className={cn('border-b border-border/80 px-5 py-4 sm:px-6', className)} {...props} />;
-}
-
-export function SectionCardBody({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div className={cn('px-5 py-4 sm:px-6', className)} {...props} />;
-}
+export const SectionCardHeader = CardHeader;
+export const SectionCardBody = CardBody;


### PR DESCRIPTION
## Summary
- **신설** `components/ui/card.tsx`: `cardVariants`(cva, button.tsx 패턴) — `surface: solid/glass/subtle/plain` × `radius: card/compact/inline`, `defaultVariants: {solid, card}`. 서브컴포넌트 `Card`·`CardHeader`·`CardBody`·`CardFooter`(신설).
- **SectionCard/GlassPanel = 얇은 alias**: 둘 다 `cardVariants(...)`로 클래스를 생성하도록 재정의. 원본 태그(`<section>`/`<div>`)·`data-slot` 값·클래스 세트 전부 무변경 — `card.test.tsx`가 원본 손코딩 클래스 리터럴과 값 동치를 회귀가드로 잠금.
- `SectionCardHeader`/`SectionCardBody`는 신규 `CardHeader`/`CardBody` re-export(px-5 py-4·border-b 시맨틱 승계).
- `ContextualPanelLayout`은 스펙 교정대로 통합 대상에서 제외(레이아웃 프리미티브, 카드 아님) — 무접촉.
- ad-hoc 카드 452곳은 이번 스코프 밖(표면 교체 단계 S2~에서 점진 치환).

## Test plan
- [x] `pnpm type-check` — 그린
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — 그린
- [x] `pnpm exec vitest run` — 459 files / **3811 tests 전부 green**(신규 9건 — cardVariants 클래스 동치·SectionCard/GlassPanel 태그+data-slot+클래스 무회귀·서브컴포넌트 data-slot·variant 매핑)
- [x] 대비 CI 가드 4종(`tint-foreground-contrast`·`no-new-tint-color-text`·`cross-element-tint-text`·`muted-foreground-contrast`) — 전부 AA 통과·신규 위반 0

Story: [SID:2877] · S1a(UI 갈아엎기 시퀀스 뼈대 단계)

🤖 Generated with [Claude Code](https://claude.com/claude-code)