### PR TITLE
[SID:2879] PageHeader 단일화 — size variant + top-bar-slot 역할 정리

### DIFF
--- a/apps/web/src/components/nav/top-bar-slot.tsx
+++ b/apps/web/src/components/nav/top-bar-slot.tsx
@@ -3,6 +3,11 @@
 import { useEffect, type ReactNode } from 'react';
 import { useTopBar } from './top-bar-context';
 
+/**
+ * story #2879(S1b) — top-bar ↔ PageHeader(`components/ui/page-header.tsx`) 역할 규칙
+ * 전문은 그쪽 파일 주석 참고. 요지: 이 `title`과 PageHeader의 `title`을 같은 화면에서
+ * 동시에 쓰지 않는다 — 화면 타입별로 title을 갖는 표면을 하나만 고른다.
+ */
 interface TopBarSlotProps {
   title: ReactNode;
   actions?: ReactNode;

--- a/apps/web/src/components/ui/page-header.test.tsx
+++ b/apps/web/src/components/ui/page-header.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+//
+// story #2879(S1b) — PageHeader size variant(cva). 기존 API(eyebrow/title/description/
+// actions·size 미지정)는 원본 클래스와 값으로 동일해야 한다(회귀 0).
+import { describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { PageHeader } from './page-header';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function mount(node: React.ReactNode): Promise<{ el: HTMLElement; root: Root }> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => { root.render(node); });
+  return { el: container.firstElementChild as HTMLElement, root };
+}
+
+const ORIGINAL_TITLE_CLASSES = 'font-heading text-2xl font-bold tracking-tight text-foreground md:text-3xl';
+
+function classSet(s: string): Set<string> {
+  return new Set(s.split(/\s+/).filter(Boolean));
+}
+
+describe('PageHeader size variant (story #2879)', () => {
+  it('size 미지정(기존 API 그대로)이면 원본 h1 클래스 집합과 정확히 일치한다(회귀 0)', async () => {
+    const { el } = await mount(<PageHeader title="제목" />);
+    const h1 = el.querySelector('h1')!;
+    expect(classSet(h1.className)).toEqual(classSet(ORIGINAL_TITLE_CLASSES));
+  });
+
+  it('size=page가 기존과 동일하다', async () => {
+    const { el } = await mount(<PageHeader title="제목" size="page" />);
+    const h1 = el.querySelector('h1')!;
+    expect(classSet(h1.className)).toEqual(classSet(ORIGINAL_TITLE_CLASSES));
+  });
+
+  it('size=section이 text-xl을 렌더한다', async () => {
+    const { el } = await mount(<PageHeader title="제목" size="section" />);
+    const h1 = el.querySelector('h1')!;
+    expect(h1.className).toContain('text-xl');
+    expect(h1.className).not.toContain('text-2xl');
+    expect(h1.className).not.toContain('md:text-3xl');
+  });
+
+  it('size=compact가 text-lg를 렌더한다', async () => {
+    const { el } = await mount(<PageHeader title="제목" size="compact" />);
+    const h1 = el.querySelector('h1')!;
+    expect(h1.className).toContain('text-lg');
+  });
+
+  it('eyebrow·description·actions가 기존과 동일하게 렌더된다', async () => {
+    const { el } = await mount(
+      <PageHeader eyebrow="여정" title="제목" description="설명" actions={<button>액션</button>} />,
+    );
+    expect(el.textContent).toContain('여정');
+    expect(el.textContent).toContain('설명');
+    expect(el.textContent).toContain('액션');
+  });
+});

--- a/apps/web/src/components/ui/page-header.tsx
+++ b/apps/web/src/components/ui/page-header.tsx
@@ -1,24 +1,52 @@
 import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
-export function PageHeader({
-  eyebrow,
-  title,
-  description,
-  actions,
-  className,
-}: {
+/**
+ * story #2879(S1b) — PageHeader ↔ top-bar(+slot) 역할 정리(스펙 §2, doc
+ * ui-overhaul-s1-primitives-spec 기준).
+ *
+ * - **top-bar**(`components/nav/top-bar.tsx` + `TopBarSlot`) = 글로벌 chrome 상단 —
+ *   브레드크럼/현재 화면명·컨텍스트 칩(조직·프로젝트 전환)·전역 액션(알림·presence 등).
+ *   `<1024`에서 특히 "지금 어디에 있는지"를 화면 제목보다 먼저 보여주는 상시 표면이다.
+ * - **PageHeader**(이 파일) = 페이지 **본문** 최상단 제목 블록 — 그 화면의 콘텐츠 위계에서
+ *   h1을 소유한다. eyebrow(여정/컨텍스트 라벨, 예: 소속 에픽·목표명 — Task→Trust 서사
+ *   훅으로 활용 가능)+title+description+actions.
+ *
+ * **규칙(한 화면에 title을 그리는 표면은 하나만):** top-bar 슬롯의 `title`과 PageHeader의
+ * `title`을 같은 화면에서 동시에 쓰지 않는다 — 어느 쪽이 title을 갖는지는 화면 타입으로 정한다.
+ *   - **루트/목록형 화면**(보드·목표목록 등 컨텍스트를 "훑는" 화면): top-bar 슬롯이 title을
+ *     가진다(현재 관례 — TopBarSlot 소비처 다수). PageHeader는 안 쓰거나 title 없이 actions만.
+ *   - **콘텐츠 본문이 두꺼운 상세/도구 화면**(내부 대시보드·상세 패널 등 PageHeader 기존
+ *     소비처 2곳): PageHeader가 title을 가진다 — 이런 화면은 보통 top-bar 슬롯을 title 없이
+ *     쓰거나 아예 안 쓴다.
+ * 새 화면을 만들 때 이 표를 참고해 딱 하나만 고른다(dual-header 방지).
+ */
+const pageHeaderVariants = cva('font-heading font-bold tracking-tight text-foreground', {
+  variants: {
+    size: {
+      page: 'text-2xl md:text-3xl',
+      section: 'text-xl',
+      compact: 'text-lg',
+    },
+  },
+  defaultVariants: { size: 'page' },
+});
+
+export interface PageHeaderProps extends VariantProps<typeof pageHeaderVariants> {
   eyebrow?: React.ReactNode;
   title: React.ReactNode;
   description?: React.ReactNode;
   actions?: React.ReactNode;
   className?: string;
-}) {
+}
+
+export function PageHeader({ eyebrow, title, description, actions, className, size }: PageHeaderProps) {
   return (
     <section className={cn('flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between', className)}>
       <div className="space-y-1.5">
         {eyebrow ? <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">{eyebrow}</div> : null}
-        <h1 className="font-heading text-2xl font-bold tracking-tight text-foreground md:text-3xl">{title}</h1>
+        <h1 className={cn(pageHeaderVariants({ size }))}>{title}</h1>
         {description ? <p className="max-w-2xl text-sm text-muted-foreground">{description}</p> : null}
       </div>
       {actions ? <div className="flex flex-wrap items-center gap-3">{actions}</div> : null}


### PR DESCRIPTION
## Summary
- `PageHeader`에 cva 기반 `size` variant 추가: `page`(text-2xl md:text-3xl·기본, 기존과 동일)·`section`(text-xl)·`compact`(text-lg). API는 그대로 유지(재설계 없음).
- **역할 규칙 문서화**(page-header.tsx 코드 주석): top-bar(+`TopBarSlot`)=글로벌 chrome 상단(브레드크럼·컨텍스트 칩·전역 액션), PageHeader=페이지 본문 최상단 제목 블록 — 한 화면에 title을 그리는 표면은 하나만. `top-bar-slot.tsx`에 교차참조 코멘트 추가.
- eyebrow=여정/컨텍스트 라벨 활용 방향 설계 노트로 명기(Task→Trust 서사 훅).
- 표면 무접촉: 기존 소비처 2곳(`agent-run-detail.tsx`·`internal-dogfood/page.tsx`) 무변경 — `size` 미지정 시 원본 h1 클래스 집합과 값으로 동일함을 `page-header.test.tsx`로 회귀가드.
- ad-hoc h1 58곳 이관은 표면 교체(S2~) 몫 — 이번 스코프 밖.

## Test plan
- [x] `pnpm type-check` — 그린
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — 그린
- [x] `pnpm exec vitest run` — 459 files / **3807 tests 전부 green**(신규 5건 — size variant 매핑·기존 API 회귀가드)
- [x] 대비 CI 가드 4종 — 전부 AA 통과·신규 위반 0

Story: [SID:2879] · S1b(UI 갈아엎기 시퀀스 뼈대 단계, 2877 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)