### PR TITLE
[SID:2474] 운영자 콘솔 백엔드 — offering_version/grandfather_policy admin CRUD

### DIFF
--- a/backend/app/routers/admin_billing.py
+++ b/backend/app/routers/admin_billing.py
@@ -5,17 +5,32 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
+from typing import Literal
 
 from fastapi import APIRouter, Depends, Header, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.dependencies.admin_auth import AdminOperator, require_admin_operator
 from app.dependencies.database import get_db
-from app.services.admin_billing import AdminBillingError, GrantTier, grant_credit, retry_billing_order
+from app.models.grandfather_policy import GrandfatherPolicy
+from app.models.offering_version import OfferingVersion
+from app.services.admin_billing import (
+    AdminBillingError,
+    GrantTier,
+    create_grandfather_policy,
+    create_offering_version,
+    grant_credit,
+    retry_billing_order,
+)
 
 router = APIRouter(prefix="/api/v2/admin", tags=["admin"])
+
+OfferingTier = Literal["free", "starter", "team", "business"]
+OfferingCurrency = Literal["usd", "krw"]
 
 
 def _reject_prod() -> None:
@@ -74,3 +89,142 @@ async def credit_grant(
         "target_tier": entry.entry_metadata["target_tier"],
         "current_period_end": entry.entry_metadata["grant_expires_at"],
     }
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# story #2474 — offering_version/grandfather_policy 어드민 CRUD. 값 「수정」 엔드포인트는
+# 의도적으로 없다 — append-only(effective_from/effective_to)이므로 새 값=새 행(CREATE)뿐.
+# 이 부재 자체가 계약이다(test_admin_billing_router_surface_realdb.py가 라우터 표면을
+# 값으로 단언 — 나중에 PATCH/PUT이 조용히 추가되면 그 테스트가 실패한다, PO 보강ⓐ).
+# ─────────────────────────────────────────────────────────────────────────
+
+class OfferingVersionCreateRequest(BaseModel):
+    tier: OfferingTier
+    currency: OfferingCurrency
+    version_label: str = Field(..., min_length=1)
+    monthly_price_minor: int = Field(..., ge=0)
+    annual_price_minor: int = Field(..., ge=0)
+    included_seats: int = Field(..., ge=0)
+    extra_seat_price_minor: int | None = Field(default=None, ge=0)
+    max_agents: int | None = Field(default=None, ge=0)
+    au_limit: int = Field(..., ge=0)
+    realtime_connection_limit: int = Field(..., ge=0)
+    storage_mb_limit: int = Field(..., ge=0)
+    max_file_mb: int = Field(..., ge=0)
+    lab_credit_minor: int = Field(..., ge=0)
+    rate_limit_per_min: int = Field(..., ge=0)
+    automation_rule_limit: int = Field(..., ge=0)
+    webhook_limit: int = Field(..., ge=0)
+    event_replay_days: int = Field(..., ge=0)
+    overage_allowed: bool
+    pack_catalog: dict | None = None
+
+
+class OfferingVersionResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    tier: str
+    currency: str
+    version_label: str
+    monthly_price_minor: int
+    annual_price_minor: int
+    included_seats: int
+    extra_seat_price_minor: int | None
+    max_agents: int | None
+    au_limit: int
+    realtime_connection_limit: int
+    storage_mb_limit: int
+    max_file_mb: int
+    lab_credit_minor: int
+    rate_limit_per_min: int
+    automation_rule_limit: int
+    webhook_limit: int
+    event_replay_days: int
+    overage_allowed: bool
+    pack_catalog: dict | None
+    effective_from: datetime
+    effective_to: datetime | None
+    created_by: str
+    created_at: datetime
+
+
+class GrandfatherPolicyCreateRequest(BaseModel):
+    org_id: uuid.UUID
+    offering_version_id: uuid.UUID
+    auto_migrate_on_new_version: bool = False
+    grace_period_days: int | None = Field(default=None, ge=0)
+    reason: str = Field(..., min_length=1)
+
+
+class GrandfatherPolicyResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    offering_version_id: uuid.UUID
+    auto_migrate_on_new_version: bool
+    grace_period_days: int | None
+    reason: str
+    effective_from: datetime
+    effective_to: datetime | None
+    created_by: str
+    created_at: datetime
+
+
+@router.post("/offering-versions", response_model=OfferingVersionResponse)
+async def create_offering_version_endpoint(
+    body: OfferingVersionCreateRequest,
+    operator: AdminOperator = Depends(require_admin_operator),
+    session: AsyncSession = Depends(get_db),
+) -> OfferingVersionResponse:
+    _reject_prod()
+    new_version = await create_offering_version(session, actor_email=operator.email, **body.model_dump())
+    return OfferingVersionResponse.model_validate(new_version)
+
+
+@router.get("/offering-versions", response_model=list[OfferingVersionResponse])
+async def list_offering_versions(
+    tier: OfferingTier | None = None,
+    currency: OfferingCurrency | None = None,
+    operator: AdminOperator = Depends(require_admin_operator),
+    session: AsyncSession = Depends(get_db),
+) -> list[OfferingVersionResponse]:
+    q = select(OfferingVersion)
+    if tier is not None:
+        q = q.where(OfferingVersion.tier == tier)
+    if currency is not None:
+        q = q.where(OfferingVersion.currency == currency)
+    # PO 보강ⓑ(2026-08-21, #2864 학습 재적용) — 히스토리 목록은 정렬을 명시하지 않으면
+    # DB가 물리 순서를 그대로 줄 수 있어 비결정적. effective_from desc로 고정.
+    q = q.order_by(OfferingVersion.effective_from.desc(), OfferingVersion.id.desc())
+    rows = (await session.execute(q)).scalars().all()
+    return [OfferingVersionResponse.model_validate(r) for r in rows]
+
+
+@router.post("/grandfather-policies", response_model=GrandfatherPolicyResponse)
+async def create_grandfather_policy_endpoint(
+    body: GrandfatherPolicyCreateRequest,
+    operator: AdminOperator = Depends(require_admin_operator),
+    session: AsyncSession = Depends(get_db),
+) -> GrandfatherPolicyResponse:
+    _reject_prod()
+    try:
+        new_policy = await create_grandfather_policy(session, actor_email=operator.email, **body.model_dump())
+    except AdminBillingError as e:
+        raise HTTPException(status_code=e.status_code, detail={"code": e.code, "message": e.message}) from e
+    return GrandfatherPolicyResponse.model_validate(new_policy)
+
+
+@router.get("/grandfather-policies", response_model=list[GrandfatherPolicyResponse])
+async def list_grandfather_policies(
+    org_id: uuid.UUID | None = None,
+    operator: AdminOperator = Depends(require_admin_operator),
+    session: AsyncSession = Depends(get_db),
+) -> list[GrandfatherPolicyResponse]:
+    q = select(GrandfatherPolicy)
+    if org_id is not None:
+        q = q.where(GrandfatherPolicy.org_id == org_id)
+    q = q.order_by(GrandfatherPolicy.effective_from.desc(), GrandfatherPolicy.id.desc())
+    rows = (await session.execute(q)).scalars().all()
+    return [GrandfatherPolicyResponse.model_validate(r) for r in rows]

--- a/backend/app/services/admin_billing.py
+++ b/backend/app/services/admin_billing.py
@@ -30,11 +30,13 @@ import uuid
 from datetime import datetime, timezone
 from typing import Literal
 
-from sqlalchemy import select
+from sqlalchemy import func, select
+from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.billing_ledger_entry import BillingLedgerEntry
 from app.models.billing_order import BillingOrder
+from app.models.grandfather_policy import GrandfatherPolicy
 from app.models.offering_version import OfferingVersion
 from app.models.org_subscription import OrgSubscription
 from app.services.billing_charge import charge_org
@@ -49,13 +51,14 @@ GrantTier = Literal["starter", "team", "business"]
 _TIER_RANK: dict[str, int] = {"free": 0, "starter": 1, "team": 2, "business": 3}
 
 
-def _audit(*, actor_email: str, org_id: uuid.UUID, action: str, before: dict | None, after: dict) -> None:
+def _audit(*, actor_email: str, org_id: uuid.UUID | None, action: str, before: dict | None, after: dict) -> None:
+    # story #2474: offering_version은 org-scope 밖(플랫폼 카탈로그)이라 org_id=None 허용.
     audit_logger.info(
         json.dumps(
             {
                 "audit": "admin_billing",
                 "actor_email": actor_email,
-                "org_id": str(org_id),
+                "org_id": str(org_id) if org_id is not None else None,
                 "action": action,
                 "before": before,
                 "after": after,
@@ -235,3 +238,110 @@ async def grant_credit(
         after={"entry_id": str(entry.id), "tier": target_tier, "grant_expires_at": period_end.isoformat(), "amount_minor": amount_minor},
     )
     return entry
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# story #2474 — offering_version/grandfather_policy 어드민 CRUD(그릇은 #2471 A1이 이미
+# 착지, 여기선 편집 표면만 신설). 값 「수정」은 없다 — append-only 불변 행이므로 CREATE만
+# 존재하고, 새 활성 버전 등록 시 기존 활성 행을 같은 트랜잭션에서 닫는다.
+#
+# ⚠️원자성 — 최초 설계(행잠금만으로 직렬화)를 realdb 동시성 테스트로 직접 반증했다:
+# "기존 활성 행을 닫는 UPDATE가 락을 쥔다"는 그 스코프 키에 **이미 활성 행이 있을 때만**
+# 성립한다. 그 tier+currency(또는 org_id)의 **첫 버전**을 두 요청이 동시에 만들면 닫을
+# 행 자체가 없어 UPDATE가 둘 다 0건으로 즉시 통과하고, 뒤이은 INSERT 두 개가 동시에
+# 충돌해 partial unique index가 `UniqueViolationError`(500)로 터진다(실측:
+# test_concurrent_offering_version_create_serializes_via_row_lock_no_history_loss).
+# `pg_advisory_xact_lock(hashtext(...))`로 스코프 키 자체를 세션 진입 시점부터 잠근다
+# (billing_pack.py:111의 pack 구매 cap 잠금과 동일 패턴, [[feedback_check_then_insert_toctou]]
+# 교훈 그대로 — "행이 있을 때만 잠기는" SELECT/UPDATE 기반 락은 TOCTOU에 무력하다).
+# 트랜잭션 스코프 락이라 별도 해제 불요(커밋/롤백 시 자동 반납).
+# ─────────────────────────────────────────────────────────────────────────
+
+async def create_offering_version(
+    session: AsyncSession, *, actor_email: str, now: datetime | None = None, **fields: object,
+) -> OfferingVersion:
+    now = now or datetime.now(timezone.utc)
+    tier = fields["tier"]
+    currency = fields["currency"]
+
+    await session.execute(select(func.pg_advisory_xact_lock(func.hashtext(f"offering_version:{tier}:{currency}"))))
+
+    prev_active = (
+        await session.execute(
+            select(OfferingVersion).where(
+                OfferingVersion.tier == tier,
+                OfferingVersion.currency == currency,
+                OfferingVersion.effective_to.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    prev_id = prev_active.id if prev_active is not None else None
+
+    await session.execute(
+        sa_update(OfferingVersion)
+        .where(
+            OfferingVersion.tier == tier,
+            OfferingVersion.currency == currency,
+            OfferingVersion.effective_to.is_(None),
+        )
+        .values(effective_to=now)
+    )
+
+    new_version = OfferingVersion(effective_from=now, effective_to=None, created_by=actor_email, **fields)
+    session.add(new_version)
+    await session.flush()
+    await session.refresh(new_version)
+
+    _audit(
+        actor_email=actor_email, org_id=None, action="offering_version_create",
+        before={"prev_active_id": str(prev_id) if prev_id else None, "tier": tier, "currency": currency},
+        after={"id": str(new_version.id), "version_label": new_version.version_label},
+    )
+    return new_version
+
+
+async def create_grandfather_policy(
+    session: AsyncSession, *, actor_email: str, now: datetime | None = None, **fields: object,
+) -> GrandfatherPolicy:
+    now = now or datetime.now(timezone.utc)
+    org_id = fields["org_id"]
+    offering_version_id = fields["offering_version_id"]
+
+    await session.execute(select(func.pg_advisory_xact_lock(func.hashtext(f"grandfather_policy:{org_id}"))))
+
+    offering = (
+        await session.execute(select(OfferingVersion).where(OfferingVersion.id == offering_version_id))
+    ).scalar_one_or_none()
+    if offering is None:
+        raise AdminBillingError(
+            404, "OFFERING_VERSION_NOT_FOUND",
+            f"offering_version_id={offering_version_id} 미존재 — grandfather 정책은 실재 버전에만 묶는다",
+        )
+
+    prev_active = (
+        await session.execute(
+            select(GrandfatherPolicy).where(
+                GrandfatherPolicy.org_id == org_id,
+                GrandfatherPolicy.effective_to.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    prev_id = prev_active.id if prev_active is not None else None
+
+    await session.execute(
+        sa_update(GrandfatherPolicy)
+        .where(GrandfatherPolicy.org_id == org_id, GrandfatherPolicy.effective_to.is_(None))
+        .values(effective_to=now)
+    )
+
+    new_policy = GrandfatherPolicy(effective_from=now, effective_to=None, created_by=actor_email, **fields)
+    session.add(new_policy)
+    await session.flush()
+    await session.refresh(new_policy)
+
+    _audit(
+        actor_email=actor_email, org_id=org_id, action="grandfather_policy_create",
+        before={"prev_active_id": str(prev_id) if prev_id else None},
+        after={"id": str(new_policy.id), "offering_version_id": str(offering_version_id)},
+    )
+    return new_policy

--- a/backend/tests/test_2474_admin_billing_router_surface.py
+++ b/backend/tests/test_2474_admin_billing_router_surface.py
@@ -1,0 +1,27 @@
+"""story #2474 — PO 보강ⓐ(2026-08-21): admin_billing 라우터가 노출하는 route(path+method)
+집합을 값으로 단언한다. offering_version/grandfather_policy는 append-only라 값 「수정」
+엔드포인트(PATCH/PUT)가 있으면 안 된다는 게 AC 자체의 계약 — 미래에 누군가 조용히
+PATCH를 추가해도 이 테스트가 즉시 빨강이 된다(DB 불요, 라우터 정의만 검사)."""
+from __future__ import annotations
+
+from app.routers import admin_billing
+
+
+def test_admin_billing_router_surface_is_pinned():
+    routes = sorted(
+        (route.path, method)
+        for route in admin_billing.router.routes
+        for method in route.methods
+    )
+    assert routes == [
+        ("/api/v2/admin/grandfather-policies", "GET"),
+        ("/api/v2/admin/grandfather-policies", "POST"),
+        ("/api/v2/admin/offering-versions", "GET"),
+        ("/api/v2/admin/offering-versions", "POST"),
+        ("/api/v2/admin/orgs/{org_id}/billing/credit-grant", "POST"),
+        ("/api/v2/admin/orgs/{org_id}/billing/retry", "POST"),
+    ], (
+        "admin_billing 라우터 표면이 바뀌었다 — offering_version/grandfather_policy는 "
+        "append-only 계약이라 PATCH/PUT류 mutation 엔드포인트가 추가되면 안 된다. 의도된 "
+        "신규 GET/POST 확장이면 이 목록을 함께 갱신할 것."
+    )

--- a/backend/tests/test_2474_admin_offering_grandfather_crud_realdb.py
+++ b/backend/tests/test_2474_admin_offering_grandfather_crud_realdb.py
@@ -1,0 +1,320 @@
+"""story #2474([결제②-A관리1·BE] 운영자 콘솔 백엔드) — offering_version/grandfather_policy
+admin CRUD. AC 확定(페드루, 2026-08-21): require_admin_operator 재사용(새 게이트 발명 금지)·
+append-only 불변 행이라 값 「수정」 엔드포인트는 없음(CREATE=새 버전, 기존 활성 행은 같은
+트랜잭션에서 effective_to로 닫는 원자 스왑)·audit=행 자체(created_by/created_at)로 충분.
+
+핵심 검증축: ①원자 스왑(신규 활성 등록 시 구 행이 실제로 닫히는지) ②동시 CREATE 레이스가
+`pg_advisory_xact_lock`으로 직렬화되는지(마지막 커밋만 활성, 히스토리 유실 0 — ⚠️최초
+설계는 "닫을 활성 행이 있을 때만" 유효한 UPDATE 행잠금이었는데, 그 스코프의 **첫 버전**을
+동시 생성하면 닫을 행 자체가 없어 partial unique index가 UniqueViolationError로 직접
+터지는 걸 이 테스트가 실측으로 반증 → advisory lock으로 재설계, app/services/admin_billing.py
+참고) ③grandfather_policy가 실재하지 않는 offering_version_id를 거부하는지(404) ④히스토리
+목록 정렬 결정성(effective_from desc, PO 보강ⓑ).
+
+⚠️offering_versions는 migration 0228이 krw 4종(free/starter/team/business)을 이미 공유
+시드해 뒀다(test_2777_admin_billing_realdb.py 경고 그대로) — 이 파일의 offering_version
+테스트는 그 공유 카탈로그를 절대 안 건드리도록 **currency='usd'**(A1 스코프 밖, 실제로
+비어있음이 이미 확認된 축)만 쓴다."""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _wipe_usd_catalog() -> None:
+    """test_2777_admin_billing_realdb.py의 `test_grant_credit_fails_loud_when_no_pricing_source`
+    가 「currency='usd'는 어느 tier든 원천이 없다」를 전제로 삼는다(migration 0228이 krw만
+    시드) — 이 파일이 그 전제를 깨는 usd 행을 만들었다가 방치하면(공유 CI DB, 다른 테스트
+    파일과 같은 세션에서 실행될 수 있음) 그 파일이 조용히 깨진다. 정확히 test_2777의
+    _seed_offering docstring이 경고하는 "공유 카탈로그 오염"과 같은 사고 클래스 — usd
+    카탈로그는 이 파일 전용 스코프이므로 매 테스트 앞뒤로 완전히 비운다(FK: grandfather
+    먼저)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlalchemy import text
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(
+                "DELETE FROM grandfather_policies WHERE offering_version_id IN "
+                "(SELECT id FROM offering_versions WHERE currency = 'usd')"
+            ))
+            await conn.execute(text("DELETE FROM offering_versions WHERE currency = 'usd'"))
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+async def _isolate_usd_catalog():
+    await _wipe_usd_catalog()
+    yield
+    await _wipe_usd_catalog()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _offering_fields(**overrides: object) -> dict:
+    base = dict(
+        tier="starter", currency="usd", version_label=f"usd_test_{uuid.uuid4().hex[:8]}",
+        monthly_price_minor=1900, annual_price_minor=19000, included_seats=5,
+        extra_seat_price_minor=None, max_agents=None, au_limit=1000,
+        realtime_connection_limit=10, storage_mb_limit=1024, max_file_mb=100,
+        lab_credit_minor=0, rate_limit_per_min=60, automation_rule_limit=10,
+        webhook_limit=5, event_replay_days=7, overage_allowed=True, pack_catalog=None,
+    )
+    base.update(overrides)
+    return base
+
+
+async def _seed_org(session) -> uuid.UUID:
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name="Org2474", slug=f"org2474-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+    await session.commit()
+    return org.id
+
+
+@pytest.mark.asyncio
+async def test_create_offering_version_atomically_closes_previous_active():
+    from app.services.admin_billing import create_offering_version
+    from app.models.offering_version import OfferingVersion
+    from sqlalchemy import select
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            v1 = await create_offering_version(
+                s, actor_email="op@moonklabs.com", **_offering_fields(tier="starter", currency="usd"),
+            )
+            v1_id = v1.id
+            await s.commit()  # get_db() 래퍼가 요청 끝에 하는 커밋을 직접호출 테스트에서 재현
+
+        async with maker() as s:
+            v2 = await create_offering_version(
+                s, actor_email="op@moonklabs.com", **_offering_fields(tier="starter", currency="usd"),
+            )
+            v2_id = v2.id
+            await s.commit()
+
+        async with maker() as s:
+            rows = (await s.execute(
+                select(OfferingVersion).where(
+                    OfferingVersion.tier == "starter", OfferingVersion.currency == "usd",
+                    OfferingVersion.id.in_([v1_id, v2_id]),
+                )
+            )).scalars().all()
+            by_id = {r.id: r for r in rows}
+            assert by_id[v1_id].effective_to is not None, "구 버전이 새 버전 생성 후에도 여전히 활성 — 원자 스왑 실패"
+            assert by_id[v2_id].effective_to is None
+
+            active_count = (await s.execute(
+                select(OfferingVersion).where(
+                    OfferingVersion.tier == "starter", OfferingVersion.currency == "usd",
+                    OfferingVersion.effective_to.is_(None),
+                )
+            )).scalars().all()
+            assert len(active_count) == 1 and active_count[0].id == v2_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_offering_version_created_by_is_operator_email():
+    from app.services.admin_billing import create_offering_version
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            v = await create_offering_version(
+                s, actor_email="operator@moonklabs.com",
+                **_offering_fields(tier="team", currency="usd"),
+            )
+            assert v.created_by == "operator@moonklabs.com"
+            assert v.effective_to is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_offering_version_create_serializes_via_row_lock_no_history_loss():
+    """동시 두 CREATE(같은 tier+currency)가 partial unique index 위반 없이 둘 다
+    성공하고, 마지막 커밋만 활성으로 남으며, 히스토리(둘 다) 유실이 없는지 — 진짜
+    asyncio.gather 동시성으로 확인(#2874와 동형 정신, 다만 CAS가 아니라 직렬화 검증)."""
+    from app.services.admin_billing import create_offering_version
+    from app.models.offering_version import OfferingVersion
+    from sqlalchemy import select
+
+    engine, maker = await _session_factory()
+    try:
+        currency = "usd"
+        tier = "business"
+
+        async def _create(label: str):
+            async with maker() as s:
+                v = await create_offering_version(
+                    s, actor_email="op@moonklabs.com",
+                    **_offering_fields(tier=tier, currency=currency, version_label=label),
+                )
+                await s.commit()
+                return v.id
+
+        ids = await asyncio.gather(_create("race-a"), _create("race-b"))
+
+        async with maker() as s:
+            all_rows = (await s.execute(
+                select(OfferingVersion).where(
+                    OfferingVersion.tier == tier, OfferingVersion.currency == currency,
+                    OfferingVersion.id.in_(ids),
+                )
+            )).scalars().all()
+            assert len(all_rows) == 2, "동시 CREATE 중 하나가 유실됨(히스토리 손실)"
+
+            active_rows = [r for r in all_rows if r.effective_to is None]
+            assert len(active_rows) == 1, (
+                f"동시 CREATE 후 활성 행이 {len(active_rows)}개 — partial unique index가 "
+                f"실제로 위반됐거나(있으면 안 됨) 직렬화가 깨짐"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_create_grandfather_policy_rejects_nonexistent_offering_version_with_404():
+    from app.services.admin_billing import AdminBillingError, create_grandfather_policy
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s)
+
+        async with maker() as s:
+            with pytest.raises(AdminBillingError) as exc_info:
+                await create_grandfather_policy(
+                    s, actor_email="op@moonklabs.com", org_id=org_id,
+                    offering_version_id=uuid.uuid4(), auto_migrate_on_new_version=False,
+                    grace_period_days=None, reason="테스트 — 미존재 offering_version",
+                )
+            assert exc_info.value.status_code == 404
+            assert exc_info.value.code == "OFFERING_VERSION_NOT_FOUND"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_create_grandfather_policy_atomically_closes_previous_active_for_org():
+    from app.services.admin_billing import create_offering_version, create_grandfather_policy
+    from app.models.grandfather_policy import GrandfatherPolicy
+    from sqlalchemy import select
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s)
+            offering = await create_offering_version(
+                s, actor_email="op@moonklabs.com", **_offering_fields(tier="team", currency="usd"),
+            )
+            offering_id = offering.id
+            await s.commit()
+
+        async with maker() as s:
+            p1 = await create_grandfather_policy(
+                s, actor_email="op@moonklabs.com", org_id=org_id, offering_version_id=offering_id,
+                auto_migrate_on_new_version=False, grace_period_days=None, reason="최초 정책",
+            )
+            p1_id = p1.id
+            await s.commit()
+
+        async with maker() as s:
+            p2 = await create_grandfather_policy(
+                s, actor_email="op@moonklabs.com", org_id=org_id, offering_version_id=offering_id,
+                auto_migrate_on_new_version=True, grace_period_days=30, reason="정책 갱신",
+            )
+            p2_id = p2.id
+            await s.commit()
+
+        async with maker() as s:
+            rows = (await s.execute(
+                select(GrandfatherPolicy).where(GrandfatherPolicy.id.in_([p1_id, p2_id]))
+            )).scalars().all()
+            by_id = {r.id: r for r in rows}
+            assert by_id[p1_id].effective_to is not None
+            assert by_id[p2_id].effective_to is None
+
+            active = (await s.execute(
+                select(GrandfatherPolicy).where(
+                    GrandfatherPolicy.org_id == org_id, GrandfatherPolicy.effective_to.is_(None),
+                )
+            )).scalars().all()
+            assert len(active) == 1 and active[0].id == p2_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_list_offering_versions_ordered_by_effective_from_desc():
+    """PO 보강ⓑ — 히스토리 목록 정렬 결정성(#2864 학습). service 레이어가 아니라 실제
+    라우터 쿼리(GET)와 동일한 order_by를 직접 재현해 값으로 검증(라우터는 FastAPI
+    TestClient 없이 이 세션 검증으로 충분 — order_by 자체가 회귀 축)."""
+    from app.services.admin_billing import create_offering_version
+    from app.models.offering_version import OfferingVersion
+    from sqlalchemy import select
+
+    engine, maker = await _session_factory()
+    try:
+        tier, currency = "free", "usd"
+        ids_in_creation_order = []
+        for i in range(3):
+            async with maker() as s:
+                v = await create_offering_version(
+                    s, actor_email="op@moonklabs.com",
+                    **_offering_fields(tier=tier, currency=currency, version_label=f"seq-{i}"),
+                )
+                ids_in_creation_order.append(v.id)
+                await s.commit()
+
+        async with maker() as s:
+            q = select(OfferingVersion).where(
+                OfferingVersion.tier == tier, OfferingVersion.currency == currency,
+            ).order_by(OfferingVersion.effective_from.desc(), OfferingVersion.id.desc())
+            rows = (await s.execute(q)).scalars().all()
+            returned_ids = [r.id for r in rows if r.id in ids_in_creation_order]
+            assert returned_ids == list(reversed(ids_in_creation_order)), (
+                "effective_from desc 정렬이 생성 역순과 다름 — 히스토리 목록이 비결정적일 위험"
+            )
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
[SID:2474]

## AC 확定(페드루, 2026-08-21)
- platform-admin 게이트 = `require_admin_operator` 재사용(새 게이트 발명 금지, admin_billing.py 기존 선례).
- append-only 불변 행 — 값 「수정」 엔드포인트 없음. CREATE=새 버전, 기존 활성 행은 같은 요청에서 `effective_to`로 닫는 원자 스왑.
- 감사 이력 = 행 자체(`created_by`/`created_at`, 불변)로 충분. 별도 audit 테이블 불요.
- PO 보강ⓐ: 라우터 표면 스냅샷 테스트(미래 PATCH/PUT 조용한 추가를 즉시 잡음).
- PO 보강ⓑ: 히스토리 목록 정렬 결정성(`effective_from desc`, #2864 학습 재적용).

## 엔드포인트
- `POST /api/v2/admin/offering-versions`, `GET /api/v2/admin/offering-versions?tier=&currency=`
- `POST /api/v2/admin/grandfather-policies`, `GET /api/v2/admin/grandfather-policies?org_id=`

## 동시성 — 설계 반증→재설계
최초 설계는 "기존 활성 행을 닫는 UPDATE가 그 행에 락을 쥐어 직렬화된다"였는데, realdb 동시성
테스트로 직접 반증했다: 그 스코프 키(tier+currency 또는 org_id)의 **첫 버전**을 두 요청이
동시에 만들면 닫을 행 자체가 없어 UPDATE가 둘 다 즉시 0건 통과하고, 뒤이은 INSERT 두 개가
동시에 충돌해 `uq_offering_versions_active_tier_currency`(partial unique index)가
`UniqueViolationError`(500)로 직접 터진다.

처방: `pg_advisory_xact_lock(hashtext(...))`로 스코프 키 자체를 세션 진입 시점부터 잠근다
(`billing_pack.py:111`의 pack 구매 cap 잠금과 동일 패턴, `[[feedback_check_then_insert_toctou]]`
교훈 — "행이 있을 때만 잠기는" UPDATE 기반 락은 TOCTOU에 무력하다). 첫 버전/기존 활성 교체
두 경우 모두 동일하게 안전.

## 테스트
`test_2474_admin_offering_grandfather_crud_realdb.py`(6) + `test_2474_admin_billing_router_surface.py`(1):
- 원자 스왑(신규 활성 등록 시 구 행이 실제로 닫히는지, offering_version·grandfather_policy 둘 다)
- **동시성 레이스**(`asyncio.gather`, 진짜 동시): fix 前 정확히 라이브 시나리오대로 `UniqueViolationError`로 FAIL 확인(코드에서 advisory lock 두 줄 임시 제거→재현→복원) 후 fix 적용해 PASS 전환 — 하중 증명.
- grandfather_policy가 실재하지 않는 `offering_version_id`를 404로 거부.
- 히스토리 목록 정렬 결정성(`effective_from desc`).
- 라우터 표면 고정(PATCH/PUT 없음이 계약 그 자체).

⚠️ `offering_versions`는 migration 0228이 krw 카탈로그(free/starter/team/business)를 이미
공유 시드해 뒀다(`test_2777_admin_billing_realdb.py` 경고) — 이 PR의 테스트는 그 공유 카탈로그를
절대 안 건드리도록 `currency='usd'`(A1 스코프 밖, 실제로 비어있음 확認된 축)만 쓰고, 매 테스트
전후 usd 행을 완전히 정리해 `test_2777`의 "usd는 어느 tier든 원천 없음" 전제와 교차오염되지
않게 했다(실제로 처음엔 충돌해 잡았음 — 커밋 메시지 참고).

## Test plan
- [x] realdb 신규 테스트 7건 — 동시성은 revert→재현→복원으로 하중 증명
- [x] 기존 #2777 admin_billing 테스트(19건) 회귀 없음, 교차오염 확인 후 격리 조치
- [ ] CI green