### PR TITLE
[SID:2885] 0-프로젝트 org sentinel 멤버십 합성 가드

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 import { headers } from 'next/headers';
 import { getServerSession } from '@/lib/db/server';
 import { buildLoginRedirect } from '@/lib/auth/session-redirect';
+import { resolveProjectMemberships } from '@/lib/resolve-project-memberships';
 import { DashboardShell } from '../dashboard/dashboard-shell';
 import { StorageCapacityToastProvider } from '@/components/storage/storage-capacity-toast-provider';
 import { CrossProjectToastProvider } from '@/components/chat/cross-project-toast-provider';
@@ -74,9 +75,8 @@ export default async function AuthenticatedLayout({
   if (!me?.org_id) redirect('/onboarding');
   const memberships: { projectId: string; projectName: string }[] =
     membershipsRes?.ok ? ((await membershipsRes.json()) as { projectId: string; projectName: string }[]) : [];
-  let projectMemberships = memberships.length > 0
-    ? memberships
-    : me ? [{ projectId: me.project_id, projectName: me.project_name }] : [];
+  // story #2885 — sentinel(0-프로젝트 org) 오염 가드, 근거는 resolve-project-memberships.ts 참고.
+  let projectMemberships = resolveProjectMemberships(memberships, me);
 
   const rawOrgs: OrgMembership[] = orgsRes?.ok ? ((await orgsRes.json()) as OrgMembership[]) : [];
   const orgMemberships = rawOrgs.map((o) => ({

--- a/apps/web/src/lib/resolve-project-memberships.test.ts
+++ b/apps/web/src/lib/resolve-project-memberships.test.ts
@@ -1,0 +1,37 @@
+// story #2885 — sentinel(0-프로젝트 org) 오염 재발방지. 원 재현: SK Leak Test(0-프로젝트
+// org)로 전환 후 /me/memberships가 빈 배열인데, 폴백이 me.project_id(=org_id sentinel,
+// project_name:null과 짝지어 옴)를 실 멤버십인 양 합성해 accessibleIds→X-Project-Id로
+// 전파되고 BE has_project_access가 403 — 「새 프로젝트」 생성이 막혔다.
+import { describe, expect, it } from 'vitest';
+import { resolveProjectMemberships } from './resolve-project-memberships';
+
+describe('resolveProjectMemberships (story #2885)', () => {
+  it('memberships가 비어있지 않으면 그대로 반환한다', () => {
+    const memberships = [{ projectId: 'p1', projectName: '프로젝트1' }];
+    expect(resolveProjectMemberships(memberships, { project_id: 'other', project_name: '다른' })).toBe(memberships);
+  });
+
+  it('0-프로젝트 org sentinel(project_name:null)은 합성하지 않는다 — 회귀가드', () => {
+    const result = resolveProjectMemberships([], { project_id: 'org-id-as-sentinel', project_name: null });
+    expect(result).toEqual([]);
+  });
+
+  it('memberships fetch 실패했지만 실 현재 프로젝트가 있으면(project_name 존재) 합성한다', () => {
+    const result = resolveProjectMemberships([], { project_id: 'real-project-id', project_name: '진짜 프로젝트' });
+    expect(result).toEqual([{ projectId: 'real-project-id', projectName: '진짜 프로젝트' }]);
+  });
+
+  it('me가 null이면 빈 배열', () => {
+    expect(resolveProjectMemberships([], null)).toEqual([]);
+  });
+
+  it('project_id는 있는데 project_name이 빈 문자열이어도 합성하지 않는다(falsy 가드)', () => {
+    const result = resolveProjectMemberships([], { project_id: 'x', project_name: '' });
+    expect(result).toEqual([]);
+  });
+
+  it('project_name은 있는데 project_id가 없으면 합성하지 않는다', () => {
+    const result = resolveProjectMemberships([], { project_id: null, project_name: '이름만 있음' });
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/resolve-project-memberships.ts
+++ b/apps/web/src/lib/resolve-project-memberships.ts
@@ -1,0 +1,26 @@
+export interface ProjectMembership {
+  projectId: string;
+  projectName: string;
+}
+
+/**
+ * story #2885 — `(authenticated)/layout.tsx`가 `/me/memberships` 빈 배열을 받았을 때 쓰는
+ * 폴백. 원 용도는 "fetch는 실패했지만 실제 현재 프로젝트는 있는" 케이스지만, 0-프로젝트
+ * org(진짜로 멤버십이 0)에서도 무가드로 발동해 BE의 sentinel placeholder(`me.project_id` =
+ * org_id 자체, `me.project_name` = null — `get_me.py` 참고)를 실 멤버십인 양 합성했다.
+ * 그 합성값이 dashboard-shell의 accessibleIds에 들어가 X-Project-Id로 실려 나가면
+ * has_project_access가 (정당하게) 403 — 「새 프로젝트」 생성이 막힌다.
+ *
+ * sentinel은 항상 project_name:null과 짝지어 온다(실 프로젝트라면 이름이 있다) — 그 신호로
+ * 가드한다.
+ */
+export function resolveProjectMemberships(
+  memberships: ProjectMembership[],
+  me: { project_id?: string | null; project_name?: string | null } | null,
+): ProjectMembership[] {
+  if (memberships.length > 0) return memberships;
+  if (me?.project_id && me?.project_name) {
+    return [{ projectId: me.project_id, projectName: me.project_name }];
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary
- `(authenticated)/layout.tsx`의 `/me/memberships` 빈 배열 폴백이 `me.project_id`(0-프로젝트 org에선 BE가 반환하는 sentinel placeholder = org_id 자체, `project_name:null`과 짝)를 실 멤버십인 양 합성하던 갭 수정.
- 이 합성값이 `dashboard-shell`의 `accessibleIds`에 편입 → `X-Project-Id` 헤더로 전파 → BE `has_project_access`가 (정당하게) 403 — 0-프로젝트 org에서 「새 프로젝트」 생성 자체가 막혔다.
- story #2873 라이브 재검증 중 발견: get_me fix(#3293)로 org 컨텍스트가 바로잡힌 뒤에야 드러난 후속 갭(이전엔 org 자체가 틀려 X-Project-Id가 다른 org의 실 프로젝트였고, 그래서 403 없이 조용히 오배달됐다).
- `resolveProjectMemberships(memberships, me)`로 로직 추출 — `project_name` 존재 여부를 sentinel 가드로 사용(project_name:null이면 합성하지 않음). fetch 실패했지만 실 현재 프로젝트가 있는(project_name 존재) 기존 케이스는 그대로 동작.

## Test plan
- [x] `pnpm type-check` — 그린
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — 그린
- [x] `pnpm exec vitest run` — 459 files / **3808 tests 전부 green**(신규 6건 — sentinel 가드·기존 fetch-실패 폴백 케이스·null 가드류)
- [x] 대비 CI 가드 4종 — 전부 AA 통과·신규 위반 0

Story: [SID:2885] · 2873 후속(라이브 재검증 중 발견)

🤖 Generated with [Claude Code](https://claude.com/claude-code)