### PR TITLE
[SID:2887] 아바타 업로드 BE — 서명URL 발급→confirm 검증→반영, 삭제

### DIFF
--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -19,6 +19,7 @@ from app.schemas.team_member import (
     ActiveStorySummary, TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate,
 )
 from app.services.agent_onboarding_config import build_agent_mcp_config_bundle
+from app.services.avatar_upload import AvatarUploadError, confirm_upload, create_upload_url, delete_avatar
 from app.services.member_resolver import assert_caller_is_member, is_caller_member
 from app.services.project_auth import has_project_access
 
@@ -524,6 +525,93 @@ async def update_team_member(
         await _assert_can_manage_human(member, session, org_id, auth, data=data)
     # AC3-4 2-2: team_members 뷰 — 필드를 앵커 테이블로 라우팅(anchor-only). expire 후 뷰 재조회로 갱신값 반영.
     await repo.apply_anchor_update(member, data)
+    session.expire(member)
+    updated = await repo.get(id)
+    _m = updated or member
+    return await _inject_online_single(TeamMemberResponse.model_validate(_m), _m.id)
+
+
+async def _assert_can_edit_avatar(
+    id: uuid.UUID, member: TeamMember, session: AsyncSession, org_id: uuid.UUID, auth: AuthContext,
+) -> None:
+    """story #2887 — avatar_url PATCH와 정확히 동일한 권한 질문("이 caller가 이 member의
+    avatar_url을 바꿀 수 있는가")이라 기존 게이트를 그대로 재사용한다. 에이전트=owner/admin
+    (assert_agent_owner), 휴먼=self(프로필 필드 한정)/admin(_assert_can_manage_human) — 새
+    권한 개념을 만들지 않는다(페드루 AC 확定)."""
+    if member.type == "agent":
+        await assert_agent_owner(id, session, org_id, uuid.UUID(auth.user_id))
+    else:
+        await _assert_can_manage_human(member, session, org_id, auth, data={"avatar_url": None})
+
+
+class AvatarUploadUrlRequest(BaseModel):
+    content_type: str
+
+
+@router.post("/{id}/avatar/upload-url")
+async def create_avatar_upload_url(
+    id: uuid.UUID,
+    body: AvatarUploadUrlRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    repo = TeamMemberRepository(session, org_id)
+    member = await repo.get(id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Team member not found")
+    await _assert_can_edit_avatar(id, member, session, org_id, auth)
+    try:
+        return await create_upload_url(org_id=org_id, member_id=id, content_type=body.content_type)
+    except AvatarUploadError as e:
+        raise HTTPException(status_code=e.status_code, detail={"code": e.code, "message": e.message}) from e
+
+
+class AvatarConfirmRequest(BaseModel):
+    object_path: str
+
+
+@router.post("/{id}/avatar/confirm", response_model=TeamMemberResponse)
+async def confirm_avatar_upload(
+    id: uuid.UUID,
+    body: AvatarConfirmRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> TeamMemberResponse:
+    repo = TeamMemberRepository(session, org_id)
+    member = await repo.get(id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Team member not found")
+    await _assert_can_edit_avatar(id, member, session, org_id, auth)
+    try:
+        new_url = await confirm_upload(
+            org_id=org_id, member_id=id, object_path=body.object_path,
+            previous_avatar_url=member.avatar_url,
+        )
+    except AvatarUploadError as e:
+        raise HTTPException(status_code=e.status_code, detail={"code": e.code, "message": e.message}) from e
+    await repo.apply_anchor_update(member, {"avatar_url": new_url})
+    session.expire(member)
+    updated = await repo.get(id)
+    _m = updated or member
+    return await _inject_online_single(TeamMemberResponse.model_validate(_m), _m.id)
+
+
+@router.delete("/{id}/avatar", response_model=TeamMemberResponse)
+async def delete_avatar_endpoint(
+    id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> TeamMemberResponse:
+    repo = TeamMemberRepository(session, org_id)
+    member = await repo.get(id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Team member not found")
+    await _assert_can_edit_avatar(id, member, session, org_id, auth)
+    await delete_avatar(current_avatar_url=member.avatar_url)
+    await repo.apply_anchor_update(member, {"avatar_url": None})
     session.expire(member)
     updated = await repo.get(id)
     _m = updated or member

--- a/backend/app/services/avatar_upload.py
+++ b/backend/app/services/avatar_upload.py
@@ -16,11 +16,14 @@ prod는 버킷 미프로비저닝(심사 후 일괄, cloudbuild.yaml 참고) —
 전 함수 503(auth_configured류 fail-closed 원칙, admin_auth.py와 동형)."""
 from __future__ import annotations
 
+import logging
 import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
 from app.services.storage import get_storage_provider
+
+logger = logging.getLogger("sprintable.avatar_upload")
 
 AVATARS_BUCKET = os.environ.get("GCS_AVATARS_BUCKET") or None
 _PUBLIC_BASE = f"https://storage.googleapis.com/{AVATARS_BUCKET}/" if AVATARS_BUCKET else None
@@ -104,10 +107,16 @@ async def confirm_upload(
         raise AvatarUploadError(413, "AVATAR_TOO_LARGE", f"{size}bytes가 상한 {MAX_AVATAR_BYTES}bytes 초과")
 
     new_url = _PUBLIC_BASE + object_path
-    # 조건ⓑ: 교체=새 키+구 키 삭제(같은 키 덮어쓰기 금지). best-effort — 실패해도 신규 반영은 진행.
+    # 조건ⓑ: 교체=새 키+구 키 삭제(같은 키 덮어쓰기 금지). best-effort — 실패해도 신규 반영은
+    # 진행해야 하는데(주석 원문 그대로) delete_object 자체가 내부 예외를 삼키지만, 그 계약을
+    # 이 호출부가 코드로도 보장한다(페드루 QA 정정, 2026-08-21) — transient 에러가 confirm
+    # 전체를 넘어뜨리지 않게 명시 방어.
     old_path = canonical_avatar_object_path(previous_avatar_url)
     if old_path and old_path != object_path:
-        await provider.delete_object(bucket, old_path)
+        try:
+            await provider.delete_object(bucket, old_path)
+        except Exception:
+            logger.warning("avatar_upload: 구 blob 삭제 실패(best-effort, 신규 반영은 계속) path=%s", old_path, exc_info=True)
     return new_url
 
 

--- a/backend/app/services/avatar_upload.py
+++ b/backend/app/services/avatar_upload.py
@@ -1,0 +1,119 @@
+"""story #2887(BE) — 아바타(프로필 사진) 업로드: 서명URL 발급→confirm(head_object 실물
+검증)→Member.avatar_url 반영, 삭제. 기존 storage provider(signed_write_url/head_object/
+delete_object)·권한 게이트(assert_agent_owner/_assert_can_manage_human, team_members.py)
+·앵커 write 경로(TeamMemberRepository.apply_anchor_update)를 전부 재사용 — 신규 인프라는
+버킷 하나뿐.
+
+페드루 확定(2026-08-21, 서빙 URL): avatar 전용 신규 격리 버킷을 **public-read**로(memo-
+attachments 등 민감 버킷과 정책 분리 — uniform bucket-level access + allUsers=objectViewer,
+dev=sprintable-avatars-dev). 조건 셋:
+  ⓐ오브젝트 키는 uuid4 세그먼트로 추측 불가(열거 방지)
+  ⓑ교체는 항상 새 키로 쓰고 avatar_url만 갱신 — 같은 키 덮어쓰기 금지(구 키는 confirm 시
+    best-effort 삭제 — CDN/브라우저 캐시 무효화까지 겸함)
+  ⓒ버킷은 avatar 전용 격리(다른 버킷과 IAM/정책 미공유)
+
+prod는 버킷 미프로비저닝(심사 후 일괄, cloudbuild.yaml 참고) — GCS_AVATARS_BUCKET 미설정 시
+전 함수 503(auth_configured류 fail-closed 원칙, admin_auth.py와 동형)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from app.services.storage import get_storage_provider
+
+AVATARS_BUCKET = os.environ.get("GCS_AVATARS_BUCKET") or None
+_PUBLIC_BASE = f"https://storage.googleapis.com/{AVATARS_BUCKET}/" if AVATARS_BUCKET else None
+
+# 페드루 확定값(2026-08-21).
+MAX_AVATAR_BYTES = 5 * 1024 * 1024
+_ALLOWED_CONTENT_TYPES: dict[str, str] = {"image/png": "png", "image/jpeg": "jpg", "image/webp": "webp"}
+UPLOAD_URL_TTL = timedelta(minutes=10)
+
+
+class AvatarUploadError(Exception):
+    def __init__(self, status_code: int, code: str, message: str) -> None:
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+def _require_bucket() -> str:
+    if not AVATARS_BUCKET:
+        raise AvatarUploadError(503, "AVATAR_UPLOAD_NOT_CONFIGURED", "avatar 업로드가 이 환경에 구성되지 않음")
+    return AVATARS_BUCKET
+
+
+def _object_path(org_id: uuid.UUID, member_id: uuid.UUID, ext: str) -> str:
+    # uuid4 hex 세그먼트 — 조건ⓐ(추측 불가). org+member 스코프는 소유권 감사·정리용(접근제어
+    # 자체는 public-read라 경로 비밀성에 기대지 않는다 — confirm 단계의 prefix 검증은 IDOR
+    # 방지가 아니라 "내 것 아닌 경로로 내 avatar_url을 가리키게" 하는 오사용 차단).
+    return f"avatar/{org_id}/{member_id}/{uuid.uuid4().hex}.{ext}"
+
+
+def canonical_avatar_object_path(url: str | None) -> str | None:
+    """avatar_url이 이 avatar 버킷의 객체를 가리키면 그 object_path, 아니면 None(외부 URL·
+    레거시 값 등 — 우리가 관리하지 않는 값은 절대 안 건드린다)."""
+    if not url or not _PUBLIC_BASE or not url.startswith(_PUBLIC_BASE):
+        return None
+    return url[len(_PUBLIC_BASE):] or None
+
+
+async def create_upload_url(*, org_id: uuid.UUID, member_id: uuid.UUID, content_type: str) -> dict:
+    bucket = _require_bucket()
+    ext = _ALLOWED_CONTENT_TYPES.get(content_type)
+    if ext is None:
+        raise AvatarUploadError(
+            422, "UNSUPPORTED_CONTENT_TYPE",
+            f"허용되지 않는 content_type: {content_type!r} (허용: {sorted(_ALLOWED_CONTENT_TYPES)})",
+        )
+    object_path = _object_path(org_id, member_id, ext)
+    upload_url = await get_storage_provider().signed_write_url(
+        bucket, object_path, ttl=UPLOAD_URL_TTL, content_type=content_type,
+    )
+    if upload_url is None:
+        raise AvatarUploadError(502, "SIGN_FAILED", "업로드 URL 서명 실패")
+    return {
+        "upload_url": upload_url,
+        "object_path": object_path,
+        "public_url": _PUBLIC_BASE + object_path,
+        "expires_at": (datetime.now(timezone.utc) + UPLOAD_URL_TTL).isoformat(),
+        "max_bytes": MAX_AVATAR_BYTES,
+    }
+
+
+async def confirm_upload(
+    *, org_id: uuid.UUID, member_id: uuid.UUID, object_path: str, previous_avatar_url: str | None,
+) -> str:
+    bucket = _require_bucket()
+    # 방금 발급한 upload-url이 아닌 임의 object_path(타인 경로 등)를 confirm에 흘려
+    # avatar_url을 오염시키는 것을 차단 — 정확히 이 org/member 스코프 prefix 아래의 단일
+    # 파일(추가 "/" 없음)만 허용.
+    expected_prefix = f"avatar/{org_id}/{member_id}/"
+    if not object_path.startswith(expected_prefix) or "/" in object_path[len(expected_prefix):]:
+        raise AvatarUploadError(403, "PATH_NOT_SCOPED", "이 member 소유 업로드 경로가 아님")
+
+    provider = get_storage_provider()
+    # 까심 ①과 동일 원칙(asset_registry.py) — client가 아니라 실 객체 크기가 authoritative.
+    size = await provider.head_object(bucket, object_path)
+    if size is None:
+        raise AvatarUploadError(404, "OBJECT_NOT_FOUND", "업로드된 객체를 찾을 수 없음(PUT 미완료?)")
+    if size > MAX_AVATAR_BYTES:
+        await provider.delete_object(bucket, object_path)
+        raise AvatarUploadError(413, "AVATAR_TOO_LARGE", f"{size}bytes가 상한 {MAX_AVATAR_BYTES}bytes 초과")
+
+    new_url = _PUBLIC_BASE + object_path
+    # 조건ⓑ: 교체=새 키+구 키 삭제(같은 키 덮어쓰기 금지). best-effort — 실패해도 신규 반영은 진행.
+    old_path = canonical_avatar_object_path(previous_avatar_url)
+    if old_path and old_path != object_path:
+        await provider.delete_object(bucket, old_path)
+    return new_url
+
+
+async def delete_avatar(*, current_avatar_url: str | None) -> None:
+    if not AVATARS_BUCKET:
+        return
+    old_path = canonical_avatar_object_path(current_avatar_url)
+    if old_path:
+        await get_storage_provider().delete_object(AVATARS_BUCKET, old_path)

--- a/backend/tests/test_2887_avatar_upload_router_realdb.py
+++ b/backend/tests/test_2887_avatar_upload_router_realdb.py
@@ -1,0 +1,207 @@
+"""story #2887(BE) — avatar 업로드 라우터 통합(권한 게이트 재사용이 실제로 작동하는지·
+Member.avatar_url이 정말 갱신되는지). 새 권한 개념을 만들지 않고 기존 assert_agent_owner/
+_assert_can_manage_human을 그대로 재사용한다는 AC 확定(페드루, 2026-08-21)의 하중 증명 —
+휴먼 self/stranger/admin 3분기 + 에이전트 owner/non-owner 2분기.
+
+STORAGE_PROVIDER=local(zero-config, 실 로컬 디스크)로 GCS 없이 confirm의 head_object 실물
+검증까지 end-to-end로 태운다."""
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("28870000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("28870000-0000-0000-0000-000000000002")
+USER_A = uuid.UUID("28870000-0000-0000-0000-0000000000a1")   # self — 자기 아바타 편집
+USER_B = uuid.UUID("28870000-0000-0000-0000-0000000000b1")   # stranger — 타인 편집 시도
+USER_ADMIN = uuid.UUID("28870000-0000-0000-0000-0000000000ad")
+MEMBER_A = uuid.UUID("28870000-0000-0000-0000-0000000001a1")  # == org_members.id(휴먼 앵커)
+MEMBER_B = uuid.UUID("28870000-0000-0000-0000-0000000001b1")
+MEMBER_ADMIN = uuid.UUID("28870000-0000-0000-0000-0000000001ad")
+AGENT_MEMBER = uuid.UUID("28870000-0000-0000-0000-000000002a91")  # owner=USER_A
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _local_storage(monkeypatch):
+    tmp_root = tempfile.mkdtemp(prefix="avatar-router-test-")
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", tmp_root)
+    monkeypatch.setenv("GCS_AVATARS_BUCKET", "test-avatars-router-bucket")
+    import importlib
+    import app.services.avatar_upload as avatar_upload_mod
+    importlib.reload(avatar_upload_mod)
+    yield
+    shutil.rmtree(tmp_root, ignore_errors=True)
+    importlib.reload(avatar_upload_mod)
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+def _auth(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s) -> None:
+    for sql in [
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id IN ('{USER_A}','{USER_B}','{USER_ADMIN}')",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S2887','s2887-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{USER_A}','a@s2887.test','x','A',true,true,0,false,0),"
+        f"('{USER_B}','b@s2887.test','x','B',true,true,0,false,0),"
+        f"('{USER_ADMIN}','admin@s2887.test','x','Admin',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"('{MEMBER_A}','{ORG}','{USER_A}','member'),"
+        f"('{MEMBER_B}','{ORG}','{USER_B}','member'),"
+        f"('{MEMBER_ADMIN}','{ORG}','{USER_ADMIN}','admin')",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','P','s2887-proj','warn')",
+        f"INSERT INTO members (id,org_id,type,user_id,name) VALUES "
+        f"('{MEMBER_A}','{ORG}','human','{USER_A}','A'),"
+        f"('{MEMBER_B}','{ORG}','human','{USER_B}','B'),"
+        f"('{MEMBER_ADMIN}','{ORG}','human','{USER_ADMIN}','Admin')",
+        f"INSERT INTO project_access (id,project_id,member_id,permission,role) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{MEMBER_A}','granted','member'),"
+        f"(gen_random_uuid(),'{PROJ}','{MEMBER_B}','granted','member'),"
+        f"(gen_random_uuid(),'{PROJ}','{MEMBER_ADMIN}','granted','admin')",
+        # 에이전트 — owner_member_id=MEMBER_A → team_members뷰 created_by=USER_A(0110 뷰 정의).
+        f"INSERT INTO members (id,org_id,type,owner_member_id,name) VALUES "
+        f"('{AGENT_MEMBER}','{ORG}','agent','{MEMBER_A}','Agent')",
+        f"INSERT INTO project_access (id,project_id,member_id,permission,role) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{AGENT_MEMBER}','granted','member')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _put_and_confirm(session, org_id, caller_member_id, target_id, auth, object_path=None):
+    """caller_member_id는 미사용(과거 시그니처 잔재 방지용 이름) — object_path는 항상
+    target_id(아바타가 바뀌는 대상) 스코프여야 한다(confirm_upload의 실제 검증축과 정합)."""
+    from app.services.avatar_upload import get_storage_provider, AVATARS_BUCKET
+    from app.routers.team_members import confirm_avatar_upload, AvatarConfirmRequest
+
+    if object_path is None:
+        object_path = f"avatar/{org_id}/{target_id}/{uuid.uuid4().hex}.png"
+    provider = get_storage_provider()
+    await provider.put_object(AVATARS_BUCKET, object_path, b"fake-png-bytes", content_type="image/png")
+    return await confirm_avatar_upload(
+        target_id, AvatarConfirmRequest(object_path=object_path),
+        session=session, auth=auth, org_id=org_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_self_can_confirm_own_avatar():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            resp = await _put_and_confirm(s, ORG, MEMBER_A, MEMBER_A, _auth(USER_A))
+            assert resp.avatar_url is not None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.asyncio
+async def test_stranger_cannot_confirm_others_avatar():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await _put_and_confirm(s, ORG, MEMBER_B, MEMBER_A, _auth(USER_B))
+            assert exc_info.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.asyncio
+async def test_org_admin_can_confirm_others_avatar():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            resp = await _put_and_confirm(s, ORG, MEMBER_ADMIN, MEMBER_A, _auth(USER_ADMIN))
+            assert resp.avatar_url is not None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.asyncio
+async def test_agent_owner_can_confirm_agent_avatar():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            resp = await _put_and_confirm(s, ORG, MEMBER_A, AGENT_MEMBER, _auth(USER_A))
+            assert resp.avatar_url is not None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.asyncio
+async def test_non_owner_non_admin_cannot_confirm_agent_avatar():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await _put_and_confirm(s, ORG, MEMBER_B, AGENT_MEMBER, _auth(USER_B))
+            assert exc_info.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.asyncio
+async def test_confirm_persists_avatar_url_to_member_anchor():
+    """라우터가 apply_anchor_update를 실제로 호출해 members.avatar_url이 커밋되는지 —
+    응답 객체 값만이 아니라 별도 세션 재조회로 확인(모델-only 뮤테이션 셀프체크)."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            resp = await _put_and_confirm(s, ORG, MEMBER_A, MEMBER_A, _auth(USER_A))
+            await s.commit()
+            expected_url = resp.avatar_url
+
+        async with Session() as s:
+            persisted = (await s.execute(
+                text(f"SELECT avatar_url FROM members WHERE id='{MEMBER_A}'")
+            )).scalar_one()
+            assert persisted == expected_url
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_2887_avatar_upload_service.py
+++ b/backend/tests/test_2887_avatar_upload_service.py
@@ -168,6 +168,34 @@ async def test_confirm_upload_deletes_old_blob_on_replace():
 
 
 @pytest.mark.asyncio
+async def test_confirm_upload_survives_transient_old_blob_delete_failure(avatar_service, monkeypatch):
+    """페드루 QA 정정(2026-08-21, LOW) — 구 blob 삭제는 주석상 best-effort인데 코드는
+    try 없는 await라 delete_object가 예외를 던지면(transient GCS 에러 등) confirm 전체가
+    죽는다. 실제로 예외를 던지는 delete_object로 재현 — confirm은 그래도 새 avatar_url을
+    반환해야 한다(신규 반영은 계속)."""
+    org_id, member_id = uuid.uuid4(), uuid.uuid4()
+    provider = avatar_service.get_storage_provider()
+
+    old_path = f"avatar/{org_id}/{member_id}/{uuid.uuid4().hex}.png"
+    await provider.put_object(avatar_service.AVATARS_BUCKET, old_path, b"old", content_type="image/png")
+    old_url = f"https://storage.googleapis.com/test-avatars-bucket/{old_path}"
+
+    new_path = f"avatar/{org_id}/{member_id}/{uuid.uuid4().hex}.png"
+    await provider.put_object(avatar_service.AVATARS_BUCKET, new_path, b"new", content_type="image/png")
+
+    async def _raising_delete(container, object_path):
+        raise RuntimeError("transient GCS error(재현용)")
+
+    monkeypatch.setattr(provider, "delete_object", _raising_delete)
+    monkeypatch.setattr(avatar_service, "get_storage_provider", lambda: provider)
+
+    new_url = await avatar_service.confirm_upload(
+        org_id=org_id, member_id=member_id, object_path=new_path, previous_avatar_url=old_url,
+    )
+    assert new_url.endswith(new_path), "구 blob 삭제 실패가 confirm 전체를 넘어뜨림 — best-effort 계약 위반"
+
+
+@pytest.mark.asyncio
 async def test_delete_avatar_removes_blob(avatar_service):
     org_id, member_id = uuid.uuid4(), uuid.uuid4()
     object_path = f"avatar/{org_id}/{member_id}/{uuid.uuid4().hex}.png"

--- a/backend/tests/test_2887_avatar_upload_service.py
+++ b/backend/tests/test_2887_avatar_upload_service.py
@@ -1,0 +1,188 @@
+"""story #2887(BE) — app/services/avatar_upload.py 순수 로직 검증. DB 불요(이 서비스는
+세션을 받지 않는다 — object storage 계약만) — LocalStorageProvider(zero-config, 실 로컬
+디스크)로 GCS 없이 head_object/delete_object/put_object 실물 검증.
+
+핵심 축: ①content_type 화이트리스트 거부 ②confirm이 client-trust 없이 head_object 실물
+크기로 상한(5MB) 판정 + 초과 시 객체 삭제(까심 ① 원칙, asset_registry.py와 동형) ③confirm의
+object_path가 발급 스코프(org/member) 밖이면 거부(PATH_NOT_SCOPED) ④교체 시 구 blob 삭제
+(페드루 조건ⓑ) ⑤미설정(GCS_AVATARS_BUCKET 없음) 시 503 fail-closed."""
+from __future__ import annotations
+
+import importlib
+import os
+import shutil
+import tempfile
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def avatar_service(monkeypatch):
+    """매 테스트 격리된 STORAGE_LOCAL_ROOT + STORAGE_PROVIDER=local + GCS_AVATARS_BUCKET.
+    avatar_upload.py는 모듈 로드 시점에 AVATARS_BUCKET을 read하므로 매 테스트 reload 필요."""
+    tmp_root = tempfile.mkdtemp(prefix="avatar-test-")
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", tmp_root)
+    monkeypatch.setenv("GCS_AVATARS_BUCKET", "test-avatars-bucket")
+    import app.services.avatar_upload as mod
+    importlib.reload(mod)
+    yield mod
+    shutil.rmtree(tmp_root, ignore_errors=True)
+
+
+@pytest.fixture
+def avatar_service_unconfigured(monkeypatch):
+    monkeypatch.delenv("GCS_AVATARS_BUCKET", raising=False)
+    import app.services.avatar_upload as mod
+    importlib.reload(mod)
+    yield mod
+
+
+@pytest.mark.asyncio
+async def test_create_upload_url_rejects_unsupported_content_type(avatar_service):
+    with pytest.raises(avatar_service.AvatarUploadError) as exc_info:
+        await avatar_service.create_upload_url(
+            org_id=uuid.uuid4(), member_id=uuid.uuid4(), content_type="application/pdf",
+        )
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.code == "UNSUPPORTED_CONTENT_TYPE"
+
+
+@pytest.mark.asyncio
+async def test_create_upload_url_unconfigured_bucket_is_503(avatar_service_unconfigured):
+    with pytest.raises(avatar_service_unconfigured.AvatarUploadError) as exc_info:
+        await avatar_service_unconfigured.create_upload_url(
+            org_id=uuid.uuid4(), member_id=uuid.uuid4(), content_type="image/png",
+        )
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.code == "AVATAR_UPLOAD_NOT_CONFIGURED"
+
+
+@pytest.mark.asyncio
+async def test_confirm_upload_rejects_when_object_not_uploaded(avatar_service):
+    org_id, member_id = uuid.uuid4(), uuid.uuid4()
+    object_path = f"avatar/{org_id}/{member_id}/{uuid.uuid4().hex}.png"
+    with pytest.raises(avatar_service.AvatarUploadError) as exc_info:
+        await avatar_service.confirm_upload(
+            org_id=org_id, member_id=member_id, object_path=object_path, previous_avatar_url=None,
+        )
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.code == "OBJECT_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_confirm_upload_rejects_path_not_scoped_to_member(avatar_service):
+    org_id, member_id = uuid.uuid4(), uuid.uuid4()
+    other_member_id = uuid.uuid4()
+    foreign_path = f"avatar/{org_id}/{other_member_id}/{uuid.uuid4().hex}.png"
+    provider = avatar_service.get_storage_provider()
+    await provider.put_object(avatar_service.AVATARS_BUCKET, foreign_path, b"x", content_type="image/png")
+
+    with pytest.raises(avatar_service.AvatarUploadError) as exc_info:
+        await avatar_service.confirm_upload(
+            org_id=org_id, member_id=member_id, object_path=foreign_path, previous_avatar_url=None,
+        )
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.code == "PATH_NOT_SCOPED"
+
+
+@pytest.mark.asyncio
+async def test_confirm_upload_rejects_oversized_and_deletes_object(avatar_service):
+    org_id, member_id = uuid.uuid4(), uuid.uuid4()
+    object_path = f"avatar/{org_id}/{member_id}/{uuid.uuid4().hex}.png"
+    provider = avatar_service.get_storage_provider()
+    oversized = b"x" * (avatar_service.MAX_AVATAR_BYTES + 1)
+    await provider.put_object(avatar_service.AVATARS_BUCKET, object_path, oversized, content_type="image/png")
+
+    with pytest.raises(avatar_service.AvatarUploadError) as exc_info:
+        await avatar_service.confirm_upload(
+            org_id=org_id, member_id=member_id, object_path=object_path, previous_avatar_url=None,
+        )
+    assert exc_info.value.status_code == 413
+    assert exc_info.value.code == "AVATAR_TOO_LARGE"
+
+    # 상한 초과 객체는 client 재시도로 남지 않도록 confirm이 직접 삭제해야 한다.
+    size_after = await provider.head_object(avatar_service.AVATARS_BUCKET, object_path)
+    assert size_after is None, "상한 초과 avatar 객체가 confirm 실패 후에도 버킷에 남아있음"
+
+
+@pytest.mark.asyncio
+async def test_confirm_upload_succeeds_and_returns_public_url(avatar_service):
+    org_id, member_id = uuid.uuid4(), uuid.uuid4()
+    object_path = f"avatar/{org_id}/{member_id}/{uuid.uuid4().hex}.png"
+    provider = avatar_service.get_storage_provider()
+    await provider.put_object(avatar_service.AVATARS_BUCKET, object_path, b"small-image-bytes", content_type="image/png")
+
+    new_url = await avatar_service.confirm_upload(
+        org_id=org_id, member_id=member_id, object_path=object_path, previous_avatar_url=None,
+    )
+    assert new_url == f"https://storage.googleapis.com/test-avatars-bucket/{object_path}"
+
+
+@pytest.mark.asyncio
+async def test_confirm_upload_deletes_old_blob_on_replace():
+    """페드루 조건ⓑ — 교체는 새 키로 쓰고 avatar_url만 갱신, 구 키는 confirm이 삭제한다."""
+    tmp_root = tempfile.mkdtemp(prefix="avatar-test-replace-")
+    old_env = {k: os.environ.get(k) for k in ("STORAGE_PROVIDER", "STORAGE_LOCAL_ROOT", "GCS_AVATARS_BUCKET")}
+    try:
+        os.environ["STORAGE_PROVIDER"] = "local"
+        os.environ["STORAGE_LOCAL_ROOT"] = tmp_root
+        os.environ["GCS_AVATARS_BUCKET"] = "test-avatars-bucket"
+        import app.services.avatar_upload as avatar_service
+        importlib.reload(avatar_service)
+
+        org_id, member_id = uuid.uuid4(), uuid.uuid4()
+        provider = avatar_service.get_storage_provider()
+
+        old_path = f"avatar/{org_id}/{member_id}/{uuid.uuid4().hex}.png"
+        await provider.put_object(avatar_service.AVATARS_BUCKET, old_path, b"old", content_type="image/png")
+        old_url = f"https://storage.googleapis.com/test-avatars-bucket/{old_path}"
+
+        new_path = f"avatar/{org_id}/{member_id}/{uuid.uuid4().hex}.png"
+        await provider.put_object(avatar_service.AVATARS_BUCKET, new_path, b"new", content_type="image/png")
+
+        new_url = await avatar_service.confirm_upload(
+            org_id=org_id, member_id=member_id, object_path=new_path, previous_avatar_url=old_url,
+        )
+        assert new_url.endswith(new_path)
+
+        assert (await provider.head_object(avatar_service.AVATARS_BUCKET, old_path)) is None, (
+            "교체 후 구 avatar blob이 삭제되지 않음 — 페드루 조건ⓑ 위반"
+        )
+        assert (await provider.head_object(avatar_service.AVATARS_BUCKET, new_path)) is not None
+    finally:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+        for k, v in old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        import app.services.avatar_upload as avatar_service
+        importlib.reload(avatar_service)
+
+
+@pytest.mark.asyncio
+async def test_delete_avatar_removes_blob(avatar_service):
+    org_id, member_id = uuid.uuid4(), uuid.uuid4()
+    object_path = f"avatar/{org_id}/{member_id}/{uuid.uuid4().hex}.png"
+    provider = avatar_service.get_storage_provider()
+    await provider.put_object(avatar_service.AVATARS_BUCKET, object_path, b"x", content_type="image/png")
+    url = f"https://storage.googleapis.com/test-avatars-bucket/{object_path}"
+
+    await avatar_service.delete_avatar(current_avatar_url=url)
+
+    assert (await provider.head_object(avatar_service.AVATARS_BUCKET, object_path)) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_avatar_ignores_external_url(avatar_service):
+    """우리 버킷이 아닌 avatar_url(레거시/외부값)은 delete_object 호출 없이 그냥 통과 —
+    canonical_avatar_object_path가 None을 반환하는 값에 대해 예외 없이 조용히 no-op."""
+    await avatar_service.delete_avatar(current_avatar_url="https://example.com/someone-elses-avatar.png")
+    # no exception = pass

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -347,6 +347,14 @@ _ID_MUTATION_FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
     "app.routers.open_api_keys:revoke_project_api_key": "resolves ProjectApiKey→key.project_id!=path project_id 인라인 체크(v1 스캔 miss)",
     "app.routers.project_access:delete_project_access": "_require_owner_or_admin→has_project_role(admin) on path project_id(1-hop miss)",
     "app.routers.workflow_line_config:update_draft_version": "_require_draft_author가 admin-level project_auth 접근권 강제(in-code 문서화)",
+    # story #2887 — path의 {id}는 team_members(member) 행이지 project가 아니다(member는
+    # project 축이 구조적으로 없음, reference_registry.py의 동형 판단 참고). 대상 리소스가
+    # project-소속이 아니라 member 자신이라 has_project_access류가 애초에 무의미한
+    # SELF_DERIVED류 — _assert_can_edit_avatar(team_members.py)가 실 가드(에이전트=
+    # assert_agent_owner, 휴먼=self/admin — avatar_url PATCH와 동일 게이트 재사용, v1
+    # 스캔이 이 커스텀 헬퍼명을 인식 못함). POST 발급/confirm 두 곳도 같은 헬퍼를 쓰지만
+    # 이 스캐너는 DELETE/PATCH/PUT만 대상이라 여기 한 건만 잡힌다.
+    "app.routers.team_members:delete_avatar_endpoint": "_assert_can_edit_avatar(에이전트 owner/admin·휴먼 self/admin — avatar_url PATCH와 동일 게이트 재사용, v1 스캔 미인식 커스텀 헬퍼)",
 }
 
 # ── known-debt: 실 project-scoped IDOR — 후속 라운드 상환(6후보·story 5285888c 감사). ──

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -51,6 +51,8 @@ _DECLARED_SUBSTITUTIONS = {
     "_NEXT_PUBLIC_APP_URL", "_ADMIN_OPERATOR_AUDIENCE", "_ADMIN_OPERATOR_ALLOWLIST",
     # story #2771 — office-converter(Gotenberg) URL, deploy-office-converter 스텝과 짝.
     "_GOTENBERG_SERVICE_URL", "_OFFICE_CONVERTER_MAX_INSTANCES",
+    # story #2887 — avatar 전용 GCS 버킷, deploy-backend dev 분기(ADMIN_OPERATOR_*와 동일 패턴).
+    "_GCS_AVATARS_BUCKET",
     "PROJECT_ID", "PROJECT_NUMBER", "BUILD_ID", "COMMIT_SHA", "SHORT_SHA",
     "REPO_NAME", "BRANCH_NAME", "TAG_NAME", "REVISION_ID", "LOCATION",
 }
@@ -122,6 +124,8 @@ def _run_env_vars_assembly(deploy_env: str, redis_url: str, gotenberg_url: str =
         "_NEXT_PUBLIC_APP_URL": "https://example.run.app",
         "_ADMIN_OPERATOR_AUDIENCE": "https://example-audience.run.app",
         "_ADMIN_OPERATOR_ALLOWLIST": "operator@example.iam.gserviceaccount.com",
+        # story #2887 — set -u라 미설정이면 스크립트가 죽는다(ADMIN_OPERATOR_*와 동일 이유).
+        "_GCS_AVATARS_BUCKET": "sprintable-avatars-dev",
         # story #2771 — 기본 빈 문자열(substitutions 기본값과 정합, set -u라 미설정이면 스크립트가
         # 죽는다 — 여기 없으면 이 테스트 전체가 붕괴).
         "_GOTENBERG_SERVICE_URL": gotenberg_url,
@@ -207,6 +211,19 @@ def test_deploy_backend_prod_excludes_admin_operator_env_vars():
     assert "ADMIN_OPERATOR_ALLOWLIST" not in result
 
 
+def test_deploy_backend_dev_includes_avatars_bucket_env_var():
+    """story #2887 — dev는 GCS_AVATARS_BUCKET을 plain env로 넘긴다(ADMIN_OPERATOR_*와 동일 배선)."""
+    result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379")
+    assert "GCS_AVATARS_BUCKET=sprintable-avatars-dev" in result
+
+
+def test_deploy_backend_prod_excludes_avatars_bucket_env_var():
+    """⭐prod 버킷 미프로비저닝 상태 — 값이 있어도 prod에는 이 키 자체가 없어야 한다(REDIS_URL/
+    ADMIN_OPERATOR_*와 동일 원칙, cloudbuild.yaml의 story #2887 주석 참고)."""
+    result = _run_env_vars_assembly("prod", "")
+    assert "GCS_AVATARS_BUCKET" not in result
+
+
 def test_deploy_backend_includes_gotenberg_service_url_when_set():
     """story #2771 — 부트스트랩 후(_GOTENBERG_SERVICE_URL 채워짐) env var가 실린다."""
     result = _run_env_vars_assembly(
@@ -248,5 +265,6 @@ def test_deploy_backend_dev_env_vars_unchanged_by_prod_branch():
         "NEXT_PUBLIC_APP_URL=https://example.run.app,DEPLOY_ENV=dev,"
         "REDIS_URL=redis://10.164.120.243:6379,"
         "ADMIN_OPERATOR_AUDIENCE=https://example-audience.run.app,"
-        "ADMIN_OPERATOR_ALLOWLIST=operator@example.iam.gserviceaccount.com"
+        "ADMIN_OPERATOR_ALLOWLIST=operator@example.iam.gserviceaccount.com,"
+        "GCS_AVATARS_BUCKET=sprintable-avatars-dev"
     )

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,6 +22,12 @@ substitutions:
   # 자체의 _reject_prod() 가드까지 삼중.
   _ADMIN_OPERATOR_AUDIENCE: https://sprintable-backend-dev-57iommnikq-du.a.run.app
   _ADMIN_OPERATOR_ALLOWLIST: sprintable-admin-web@sprintable-494803.iam.gserviceaccount.com
+  # story #2887(BE 아바타 업로드) — REDIS_URL/ADMIN_OPERATOR_*와 동일 원칙: dev만 싣는다.
+  # 버킷은 avatar 전용 신규 격리 버킷(sprintable-avatars-dev, public-read·uniform bucket-level
+  # access·cloudrun-runtime-dev=objectAdmin — 페드루 확定 2026-08-21)이고 prod 버킷은 아직
+  # 프로비저닝 전(심사 후 일괄)이라 prod에는 이 키 자체가 없어야 한다(설정 부재 시 코드가
+  # 업로드 발급을 503으로 fail-closed — REDIS_URL/GOTENBERG_SERVICE_URL과 동일 이중가드 원칙).
+  _GCS_AVATARS_BUCKET: sprintable-avatars-dev
   # story #2771(pptx 서버 변환, doc 84ef0cb7 §7-4) — office-converter는 아래 deploy-office-
   # converter 스텝이 매 배포마다 재생성/갱신한다. **부트스트랩 완료(페드루군, 2026-08-19)**:
   # 최초 배포가 --port 누락(Gotenberg는 3000, Cloud Run 헬스체크 기본 8080)으로 Ready 실패
@@ -296,6 +302,32 @@ steps:
         echo "OK: dev Cloud Run regional origin confirmed in applied CORS"
     waitFor: ['-']
 
+  # story #2887 — avatar 전용 버킷(sprintable-avatars-dev) CORS. dev 전용 게이트(prod 버킷
+  # 미프로비저닝 — office-converter와 동일 스킵 관례). PUT까지 필요(memo-attachments는
+  # GET/HEAD뿐 — 아바타는 FE가 서명 URL로 직접 PUT하는 업로드 흐름이라 다름).
+  - id: apply-gcs-avatars-cors
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        if [ "${_DEPLOY_ENV}" != "dev" ]; then
+          echo "skip apply-gcs-avatars-cors: prod bucket pending (story #2887, 심사 후 일괄)"
+          exit 0
+        fi
+        gcloud storage buckets update gs://${_GCS_AVATARS_BUCKET} \
+          --cors-file=infra/gcs-avatars-cors.json \
+          --quiet
+        applied=$(gcloud storage buckets describe gs://${_GCS_AVATARS_BUCKET} --format='value(cors_config)')
+        echo "${_GCS_AVATARS_BUCKET} CORS applied = $${applied}"
+        case "$${applied}" in
+          *https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app*) ;;
+          *) echo "FAIL: dev Cloud Run regional origin missing from applied CORS — 배포 검증 실패" >&2; exit 1 ;;
+        esac
+        echo "OK: dev Cloud Run regional origin confirmed in applied CORS"
+    waitFor: ['-']
+
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
   - id: build-frontend
     name: gcr.io/cloud-builders/docker
@@ -540,6 +572,13 @@ steps:
         # 부재를 fail-closed 503으로 처리) ⛔대표 승인 前 prod 결제 개입 전면금지 태세와 정합.
         if [ "${_DEPLOY_ENV}" != "prod" ]; then
           ENV_VARS="$${ENV_VARS},ADMIN_OPERATOR_AUDIENCE=${_ADMIN_OPERATOR_AUDIENCE},ADMIN_OPERATOR_ALLOWLIST=${_ADMIN_OPERATOR_ALLOWLIST}"
+        fi
+        # story #2887 — GCS_AVATARS_BUCKET도 위와 동일 원칙(dev만). prod 버킷 미프로비저닝
+        # 상태에서 이 키가 prod에 실리면 코드 기본값(미설정)이 아니라 존재하지 않는 버킷명이
+        # 박혀 avatar 업로드가 500으로 터질 수 있다 — REDIS_URL/ADMIN_OPERATOR_*와 동일하게
+        # "값의 유무가 아니라 prod에는 이 키 자체가 없어야 안전" 원칙.
+        if [ "${_DEPLOY_ENV}" != "prod" ]; then
+          ENV_VARS="$${ENV_VARS},GCS_AVATARS_BUCKET=${_GCS_AVATARS_BUCKET}"
         fi
         # ⛔QA catch(카디르군, 2026-08-19) — office-converter 자체가 dev 전용 하드게이트인데
         # (deploy-office-converter 스텝) 이 배선엔 REDIS_URL/ADMIN_OPERATOR_*와 같은

--- a/infra/check_env_drift.py
+++ b/infra/check_env_drift.py
@@ -394,6 +394,18 @@ _WEB_CODE_SERVICES = {"sprintable-frontend-dev", "sprintable-frontend-prod"}
 # (subset - master == 공집합) 잰다.
 _SERVICE_NAME_RE = re.compile(r"sprintable-[a-z]+-(?:dev|prod)")
 
+# `_SERVICE_NAME_RE`는 모양(`sprintable-*-{dev,prod}`)만 보는 정규식이라, Cloud Run 서비스가
+# 아닌 다른 리소스(GCS 버킷 등)의 이름이 우연히 같은 모양이면 구분 못한다. 마스터
+# (_SERVICE_SCRIPT_MAP)는 "실 서비스 8개"로 고정된 목록이라 여기 편입시키면 그 불변식이
+# 깨진다 — 그 대신 사유와 함께 여기서 명시 제외한다(주석-스트립과 같은 종류의 오탐 방지,
+# 다만 "주석"이 아니라 "다른 리소스 종류"가 원인).
+_NON_SERVICE_LITERAL_ALLOWLIST: dict[str, str] = {
+    "sprintable-avatars-dev": (
+        "story #2887 — avatar 업로드 전용 GCS 버킷(cloudbuild.yaml _GCS_AVATARS_BUCKET). "
+        "Cloud Run 서비스가 아님."
+    ),
+}
+
 
 def _service_subset_wellformed_violations() -> list[str]:
     """`_SERVICE_SCRIPT_MAP`(마스터) 밖의 이름이 나머지 세 목록에 있으면 그 이름을 낸다.
@@ -440,7 +452,7 @@ def _external_iac_service_literals() -> set[str]:
     for path in targets:
         for line in path.read_text().splitlines():
             names |= set(_SERVICE_NAME_RE.findall(_strip_comment(line)))
-    return names
+    return names - set(_NON_SERVICE_LITERAL_ALLOWLIST)
 
 
 def _external_iac_wellformed_violations() -> list[str]:

--- a/infra/gcs-avatars-cors.json
+++ b/infra/gcs-avatars-cors.json
@@ -1,0 +1,14 @@
+[
+  {
+    "origin": [
+      "https://dev-app.sprintable.ai",
+      "https://app.sprintable.ai",
+      "https://sprintable-frontend-dev-57iommnikq-du.a.run.app",
+      "https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app",
+      "http://localhost:3108"
+    ],
+    "method": ["GET", "HEAD", "PUT"],
+    "responseHeader": ["Content-Type", "Content-Length"],
+    "maxAgeSeconds": 3600
+  }
+]


### PR DESCRIPTION
[SID:2887] (BE 절반 — FE 표면은 유나 설계 뒤)

## AC 확定(페드루, 2026-08-21)
계약 3개(발급→confirm 검증→반영·DELETE) + 5MB 상한·png/jpeg/webp 화이트리스트·head_object
실물 검증·구 blob 삭제 전부 확定. 서빙 URL은 **avatar 전용 신규 격리 버킷 public-read**
(근거: 저민감 자산·소비처 10곳 무변경·매 렌더 서명비용 제거) — 조건 셋: ⓐ오브젝트 키
uuid4(추측 불가) ⓑ교체는 새 키로 쓰고 avatar_url만 갱신(구 키 삭제, 같은 키 덮어쓰기 금지)
ⓒ버킷은 avatar 전용 격리(uniform bucket-level access).

## 그라운딩 — 진짜 갭은 좁았다
저장 필드(`Member.avatar_url`)·권한 게이트(`assert_agent_owner`=에이전트 owner/admin,
`_assert_can_manage_human`=휴먼 self/admin)·앵커 write 경로(`apply_anchor_update`)·서명
URL 인프라(storage provider: `signed_write_url`/`head_object`/`delete_object`)가 전부
이미 있었다 — 신규 인프라는 버킷 하나뿐. 새 권한 개념을 만들지 않고 avatar_url PATCH와
정확히 같은 질문("이 caller가 이 member의 avatar_url을 바꿀 수 있는가")으로 기존 게이트를
재사용한다(`_assert_can_edit_avatar`).

## 엔드포인트
- `POST /api/v2/team-members/{id}/avatar/upload-url` — content_type 화이트리스트 검증 후
  V4 서명 PUT URL 발급(TTL 10분).
- `POST /api/v2/team-members/{id}/avatar/confirm` — `head_object`로 client-trust 없이
  실물 크기 검증(까심①과 동형, asset_registry.py) → 상한 초과 시 거부+삭제 → path가
  발급 스코프(org/member) 밖이면 거부 → `apply_anchor_update`로 avatar_url 반영 → 구
  blob best-effort 삭제(교체=새 키 원칙).
- `DELETE /api/v2/team-members/{id}/avatar` — avatar_url null화 + blob 삭제.

## 인프라(dev 자율 범위 승인 하 완료, prod는 미건드림)
- `sprintable-avatars-dev` 버킷 생성(asia-northeast3, uniform bucket-level access).
- IAM: `allUsers`=`objectViewer`(public-read), `cloudrun-runtime-dev`=`objectAdmin`.
- CORS 적용(GET/HEAD/PUT, `infra/gcs-avatars-cors.json`).
- `cloudbuild.yaml`: `GCS_AVATARS_BUCKET` env var + CORS 적용 스텝 — **dev 전용 게이트**
  (`REDIS_URL`/`ADMIN_OPERATOR_*`와 동일 이중가드 원칙: prod 버킷 미프로비저닝 상태에서
  이 키가 prod에 실리면 존재하지 않는 버킷명으로 500 위험 — prod에는 키 자체가 없어야
  안전). 미설정 시 코드가 503 fail-closed(admin_auth.py와 동형).

## 테스트 (15건)
`test_2887_avatar_upload_service.py`(9) — STORAGE_PROVIDER=local(zero-config 실 로컬
디스크, GCS 불요)로 서비스 레이어 순수 검증: content-type 거부·object 미존재/상한초과
거부+삭제·path-scope 거부·교체 시 구 blob 삭제·미설정 503.

`test_2887_avatar_upload_router_realdb.py`(6) — 라우터 통합: 휴먼 self/stranger/admin
3분기 + 에이전트 owner/non-owner 2분기 + DB persist 확인(members.avatar_url 실제 커밋).

권한 게이트·크기상한·path-scope 셋 다 코드에서 임시 제거 → 정확히 예측된 실패로 재현
확인 → 복원으로 하중 증명. 기존 team_members 테스트 48건 회귀 없음.

## Test plan
- [x] realdb/서비스 신규 테스트 15건 — 3개 방어축 revert→재현→복원으로 하중 증명
- [x] 기존 team_members 테스트 48건 회귀 없음
- [x] dev 버킷/IAM/CORS 실측 적용 완료
- [ ] CI green