### PR TITLE
[SID:2889] S2h② — send_message HTTP/SSE에 references[] 즉시 반영

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -583,6 +583,7 @@ async def _dispatch_conversation_event(
     sender: "ResolvedMember | TeamMember",
     exclude_ids: set[uuid.UUID] | None = None,
     webhook_covered_ids: set[uuid.UUID] | None = None,
+    references: list[dict[str, str]] | None = None,
 ) -> list[tuple[str, dict]]:
     """conversation:message → Event INSERT + flush. push 페이로드 반환 (commit 후 호출).
 
@@ -590,12 +591,16 @@ async def _dispatch_conversation_event(
     webhook_covered_ids: E-EVENT-1CONFIG — webhook 으로 전달되는(=SSE enqueue 스킵할) agent
         member 집합. send_message 요청 트랜잭션서 webhook 전달 대상과 **같은 snapshot** 으로
         산출돼 넘어온다(resolve_conversation_webhook_targets) → skip↔deliver 동일 결정·TOCTOU 차단.
+    references: story #2889(S2h, #2263 AC6이 남긴 "SSE/POST 응답은 이 키가 없다" 갭을 닫는다) —
+        send_message가 insert_chat_mentions 직후 같은 트랜잭션에서 fetch_stored_references로
+        해소해 넘긴다. None이면 기존 동작(키 자체 없음) 무변경 — 이 함수의 다른 잠재 호출부를
+        회귀시키지 않는다.
     반환값: [(pid_str, payload)] — db.commit() 완료 후 _push_to_agent() 호출용.
     """
     if not conversation.project_id:
         return []
 
-    payload = _msg_payload(msg, sender)
+    payload = _msg_payload(msg, sender, references=references)
 
     # story #2650: SSE/webhook 패리티 — conversation_webhook.py가 이미 하는 첨부 컨텍스트 주입
     # (attachment_context.py, IDOR-safe·conversation 스코프 게이트 포함)을 SSE 수신자에게도
@@ -704,18 +709,20 @@ async def _dispatch_mention_events(
     sender: TeamMember,
     mention_targets: set[uuid.UUID],
     webhook_covered_ids: set[uuid.UUID] | None = None,
+    references: list[dict[str, str]] | None = None,
 ) -> list[tuple[str, dict]]:
     """AC1: 멘션 대상에게 conversation:mention Event INSERT + flush. push 페이로드 반환 (commit 후 호출).
 
     webhook_covered_ids: E-EVENT-1CONFIG — webhook 전달 대상과 같은 snapshot 으로 산출된
         SSE-skip agent 집합(_dispatch_conversation_event 와 공유). 멘션 대상 ⊆ authorized 라
         그대로 적용 가능.
+    references: story #2889 — _dispatch_conversation_event와 동일 원칙(위 docstring 참고).
     반환값: [(pid_str, payload)] — db.commit() 완료 후 _push_to_agent() 호출용.
     """
     if not conversation.project_id or not mention_targets:
         return []
 
-    payload = _msg_payload(msg, sender)
+    payload = _msg_payload(msg, sender, references=references)
     member_rows = (await db.execute(
         select(TeamMember.id, TeamMember.type).where(TeamMember.id.in_(mention_targets))
     )).all()
@@ -770,6 +777,7 @@ async def _dispatch_human_intervention_event(
     sender: TeamMember,
     blocked_agent_recipient_ids: set[uuid.UUID],
     chain_depth_cap: int,
+    references: list[dict[str, str]] | None = None,
 ) -> list[tuple[str, dict]]:
     """story #2608 P1 AC1: 연쇄 cap 초과로 agent recipient가 막힌 메시지를, 그 대화의 human
     참가자 전원에게 `conversation.human_intervention_requested` Event로 알린다 — "왜 조용한가"
@@ -778,6 +786,8 @@ async def _dispatch_human_intervention_event(
     `_dispatch_mention_events`와 동형 구조(Event INSERT + flush, commit 후 push) — 대상만
     human 참가자로 다르다. human은 recipient_seq 개념이 없어(agent 전용 gap-free 커서)
     assign_recipient_seq를 안 부른다(_dispatch_conversation_event의 기존 관례와 동일).
+
+    references: story #2889 — _dispatch_conversation_event와 동일 원칙.
     """
     if not conversation.project_id:
         return []
@@ -792,7 +802,7 @@ async def _dispatch_human_intervention_event(
         return []
 
     payload = {
-        **_msg_payload(msg, sender),
+        **_msg_payload(msg, sender, references=references),
         "blocked_recipient_ids": [str(rid) for rid in sorted(blocked_agent_recipient_ids)],
         "chain_depth_cap": chain_depth_cap,
         "reason": "chain-expired",
@@ -2411,6 +2421,16 @@ async def send_message(
         target_types=frozenset(ENTITY_RESOLVERS) | {"gate", "pull_request", "member"},
     )
 
+    # story #2889(S2h): #2263 AC6이 남긴 갭(SSE/POST 응답엔 읽기 경로의 references[] 키가
+    # 없다 — 방금 보낸 메시지의 임베드가 즉시 리치로 안 뜬다)을 닫는다. 같은 트랜잭션·같은
+    # 세션이라 위 insert_chat_mentions가 방금 쓴 행을 이 SELECT가 그대로 본다(SQLAlchemy
+    # autoflush가 미flush 변경분도 이 쿼리 前에 flush한다 — 별도 flush 불요). 읽기 경로
+    # (list_messages 등)와 정확히 같은 함수·같은 반환 shape 재사용(재구현 0).
+    from app.services.mention_parser import fetch_stored_references
+    msg_references = (
+        await fetch_stored_references(db, org_id=org_id, source_type="chat_message", source_ids=[msg.id])
+    ).get(msg.id, [])
+
     # E-STORAGE-SSOT S2: 첨부를 asset registry로 동기화(SAVE-time·같은 트랜잭션·orphan 0).
     # S7: 반환 url→asset_id 로 JSONB asset_id 역기입(denorm·catch#4: asset_links=SSOT·JSONB=denorm).
     if body.attachments:
@@ -2526,6 +2546,7 @@ async def send_message(
                 db, conv, msg, org_id, sender,
                 exclude_ids=discord_exclude_ids | blocked_agent_ids | user_blocker_ids | preference_excluded_ids,
                 webhook_covered_ids=webhook_covered_ids,
+                references=msg_references,
             )
     except Exception as _dispatch_err:
         # dispatch 실패를 삼키지 않고 surface — 게이트웨이 이벤트 미생성 무음 방지
@@ -2561,6 +2582,7 @@ async def send_message(
                             pending_sse_pushes += await _dispatch_human_intervention_event(
                                 db, conv, msg, org_id, sender,
                                 chain_expired_agent_targets, _AGENT_CHAIN_DEPTH_CAP,
+                                references=msg_references,
                             )
                     except Exception:
                         logger.warning(
@@ -2605,6 +2627,7 @@ async def send_message(
                     pending_sse_pushes += await _dispatch_mention_events(
                         db, conv, msg, org_id, sender, mention_targets,
                         webhook_covered_ids=webhook_covered_ids,
+                        references=msg_references,
                     )
             except Exception:
                 logger.warning("mention event dispatch failed conversation_id=%s", conversation_id, exc_info=True)
@@ -2816,7 +2839,7 @@ async def send_message(
             },
         )
 
-    response: dict = {"data": _msg_payload(msg, sender)}
+    response: dict = {"data": _msg_payload(msg, sender, references=msg_references)}
     if fork_info:
         response["forked"] = True
         response["forked_conversation_id"] = fork_info["forked_conversation_id"]

--- a/backend/tests/test_2889_send_message_references_realdb.py
+++ b/backend/tests/test_2889_send_message_references_realdb.py
@@ -107,7 +107,7 @@ def _client_for(app):
 
 async def _setup_app_human(app, Session, user_id, org_id):
     from app.dependencies.auth import AuthContext, get_current_user
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     async def _db():
         async with Session() as s:
@@ -124,7 +124,7 @@ async def _setup_app_human(app, Session, user_id, org_id):
             claims={"app_metadata": {"org_id": str(org_id)}},
         )
 
-    app.dependency_overrides[get_db] = _db
+    override_db_and_read(app, _db)
     app.dependency_overrides[get_current_user] = _auth
 
 

--- a/backend/tests/test_2889_send_message_references_realdb.py
+++ b/backend/tests/test_2889_send_message_references_realdb.py
@@ -1,0 +1,233 @@
+"""story #2889(S2h ②) — #2263 AC6이 명시적으로 남겨둔 갭을 닫는다: 그 스토리 당시
+"SSE 디스패치·POST 전송 응답은 references 키가 없다(기존 동작 무변경)"였던 것을, 이제
+send_message의 HTTP 응답과 SSE Event payload 양쪽 다 읽기 경로(list/get)와 동일한
+`references[]`(list, 빈 배열도 명시)로 채운다 — 방금 보낸 메시지가 새로고침 없이도
+즉시 리치 임베드로 뜨게 하는 것이 목적(유나 S2 스펙 §8②).
+
+test_2263_chat_message_read_references_realdb.py의 하네스(ASGI 실전송·실PG)를 그대로
+재사용 — 이 파일은 그 스위트의 자매(읽기 경로가 아니라 **쓰기 응답 자체**를 검증)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _setup(session):
+    """org + project + human(members ⋈ project_access) + conversation(참가자=그 human) +
+    두 번째 참가자(human B, SSE Event 수신자가 실재해야 _dispatch_conversation_event가
+    실제로 payload를 만든다 — 발신자 본인은 exclude_ids에서 빠지므로 참가자가 1명뿐이면
+    Event가 0건 생성돼 이 테스트의 SSE축을 검증할 수 없다)."""
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.flush()
+
+    user_a = User(id=uuid.uuid4(), email=f"a-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    user_b = User(id=uuid.uuid4(), email=f"b-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add_all([user_a, user_b])
+    await session.flush()
+
+    member_a = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=user_a.id, name="A")
+    member_b = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=user_b.id, name="B")
+    session.add_all([member_a, member_b])
+    await session.flush()
+    session.add_all([
+        ProjectAccess(project_id=project.id, member_id=member_a.id, permission="granted", role="member"),
+        ProjectAccess(project_id=project.id, member_id=member_b.id, permission="granted", role="member"),
+    ])
+    await session.flush()
+
+    conv = Conversation(id=uuid.uuid4(), org_id=org.id, project_id=project.id, type="group", created_by=member_a.id)
+    session.add(conv)
+    await session.flush()
+    session.add_all([
+        ConversationParticipant(conversation_id=conv.id, member_id=member_a.id),
+        ConversationParticipant(conversation_id=conv.id, member_id=member_b.id),
+    ])
+    await session.commit()
+    return org, project, member_a, user_a, conv
+
+
+async def _make_target_doc(session, org_id, project_id, title="Target"):
+    from app.models.doc import Doc
+    doc = Doc(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, slug=f"doc-{uuid.uuid4().hex[:8]}")
+    session.add(doc)
+    await session.commit()
+    return doc
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _token(title: str, target_type: str, target_id) -> str:
+    return f"[{title}](entity:{target_type}:{target_id})"
+
+
+async def _send(client, conv_id, content, thread_id=None):
+    body = {"content": content}
+    if thread_id is not None:
+        body["thread_id"] = str(thread_id)
+    resp = await client.post(f"/api/v2/conversations/{conv_id}/messages", json=body)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _strip_referenced_at(refs: list[dict]) -> list[dict]:
+    out = []
+    for r in refs:
+        assert "referenced_at" in r and r["referenced_at"]
+        out.append({k: v for k, v in r.items() if k != "referenced_at"})
+    return out
+
+
+async def test_send_message_http_response_includes_rich_references_immediately():
+    """POST 응답의 data.references가 GET(읽기 경로)과 동일 shape로 즉시 실린다 —
+    #2263 AC6이 "다른 호출부는 이 키가 없다"고 명시했던 그 갭."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project, member, user, conv = await _setup(s)
+            target = await _make_target_doc(s, org.id, project.id)
+
+        from app.main import app
+        await _setup_app_human(app, Session, user.id, org.id)
+        client = _client_for(app)
+        try:
+            sent = await _send(client, conv.id, _token("Target", "doc", target.id))
+            assert "references" in sent["data"], "POST 응답에 references 키 자체가 없음 — #2889 미해결"
+            assert _strip_referenced_at(sent["data"]["references"]) == [
+                {"target_type": "doc", "target_id": str(target.id), "form": "mention", "proof_payload": None}
+            ]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_send_message_http_response_empty_references_is_explicit_list_not_missing():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project, member, user, conv = await _setup(s)
+
+        from app.main import app
+        await _setup_app_human(app, Session, user.id, org.id)
+        client = _client_for(app)
+        try:
+            sent = await _send(client, conv.id, "no tokens here")
+            assert sent["data"]["references"] == []
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+async def test_send_message_sse_event_payload_includes_references():
+    """conversation.message_created Event(SSE push의 실 payload 원천, commit 후 push되는
+    그 payload)에도 references가 실리는지 — Event 테이블 직접 조회로 확인(HTTP 응답과
+    별개 채널이라 별도 검증 축)."""
+    from sqlalchemy import select
+    from app.models.event import Event
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project, member, user, conv = await _setup(s)
+            target = await _make_target_doc(s, org.id, project.id)
+
+        from app.main import app
+        await _setup_app_human(app, Session, user.id, org.id)
+        client = _client_for(app)
+        try:
+            sent = await _send(client, conv.id, _token("Target", "doc", target.id))
+            msg_id = sent["data"]["id"]
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            events = (await s.execute(
+                select(Event).where(
+                    Event.event_type == "conversation.message_created",
+                    Event.source_entity_id == uuid.UUID(msg_id),
+                )
+            )).scalars().all()
+            assert events, "message_created Event가 0건 — 참가자 B가 수신 대상이어야 함"
+            for ev in events:
+                assert "references" in ev.payload, f"SSE Event payload에 references 키 없음: {ev.payload}"
+                assert _strip_referenced_at(ev.payload["references"]) == [
+                    {"target_type": "doc", "target_id": str(target.id), "form": "mention", "proof_payload": None}
+                ]
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -610,9 +610,15 @@ async def test_send_message_filters_cross_org_mentions_group():
         user_blocker_result = MagicMock()
         user_blocker_result.scalars.return_value.all.return_value = []
 
-        # 실제 코드 순서: conv → _resolve_member(TM) → participant → user_blocker_ids
+        # story #2889: insert_chat_mentions 직후 fetch_stored_references가 1회 추가(SSE/POST
+        # 응답에 방금 저장된 references를 즉시 싣기 위함) — .all() 사용, 이 테스트는 멘션
+        # cross-org 필터링만 검증하므로 빈 결과로 충분.
+        fetch_refs_result = MagicMock()
+        fetch_refs_result.all.return_value = []
+
+        # 실제 코드 순서: conv → _resolve_member(TM) → participant → user_blocker_ids → fetch_stored_references
         session.execute = AsyncMock(
-            side_effect=[conv_result, member_result, participant_result, user_blocker_result]
+            side_effect=[conv_result, member_result, participant_result, user_blocker_result, fetch_refs_result]
         )
 
         captured = {}
@@ -631,7 +637,7 @@ async def test_send_message_filters_cross_org_mentions_group():
 
         mention_calls = {}
         async def _capture_mention(db, conversation, msg, org_id, sender, mention_targets,
-                                   webhook_covered_ids=None):
+                                   webhook_covered_ids=None, references=None):
             mention_calls["targets"] = set(mention_targets)
             return []
 


### PR DESCRIPTION
[SID:2889] (S2h 3파트 중 ②만 — ①③은 별도 계약 확定 대기)

## 배경
유나 홀름 S2 설계 스펙 §8②(doc `ui-overhaul-s2-chat-embed-spec`): 방금 보낸 메시지의
임베드가 새로고침 없이 즉시 리치로 안 뜨는 갭. `#2263 AC6`가 당시 명시적으로 남겨둔
경계("읽기 경로(list/get/replies)만 references 키를 싣는다 — SSE 디스패치·POST 전송
응답은 안 싣는다, 기존 동작 무변경")를 이번에 닫는다.

## 처방
`insert_chat_mentions` 직후(같은 트랜잭션·세션 — SQLAlchemy autoflush가 자동 처리, 별도
flush 불요) 읽기 경로가 이미 쓰는 `fetch_stored_references`를 그대로 호출해 새 메시지의
references를 해소하고, 다음 4곳에 스레딩(재구현 0 — 전부 기존 `_msg_payload(references=)`
파라미터 재사용):
- `_dispatch_conversation_event`(conversation.message_created SSE)
- `_dispatch_mention_events`(conversation:mention SSE)
- `_dispatch_human_intervention_event`(human_intervention_requested SSE)
- `send_message`의 최종 HTTP 응답(`data.references`)

## 테스트
`test_2889_send_message_references_realdb.py`(3, ASGI 실전송·실PG):
- POST 응답의 `data.references`가 GET(읽기 경로)과 동일 shape로 즉시 실림.
- 빈 배열도 명시(필드 누락 아님).
- `conversation.message_created` Event(SSE push 실 payload 원천)의 `payload.references`도 확인.

fix 前 정확히 "키 자체 없음"으로 재현 확인 후 복원 — 하중 증명.

`test_conversations.py`의 기존 mock 스텁(`_capture_mention`)이 새 `references=` 키워드를
몰라 `TypeError`가 나던 것을 시그니처 갱신으로 수정(재현→수정 확인).

회귀 스윕: `conversation`/`message`/`mention`/`chat` 키워드 매치 425건 통과. 무관 6건
(포트 54322 외부 서비스 의존, 로컬 미기동)은 baseline(develop)에서도 동일 재현 확인 —
내 변경과 무관.

## Test plan
- [x] realdb 신규 테스트 3건 — revert→재현→복원으로 하중 증명
- [x] 회귀 스윕 425건 통과, 무관 6건 baseline 동일 재현 확인
- [ ] CI green