### PR TITLE
[SID:2888] 임베드 파이프라인 SSOT — parseEntityRef·EmbedRenderer·entity-registry 통합

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -9,6 +9,8 @@ import { useTranslations } from 'next-intl';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { commandName, dequoteLiteral, isCommand } from '@/lib/command-classifier';
 import { EmbedCard, EntityChip, getEntityHref } from '@/components/chat/embed-card';
+import { parseEntityRef } from '@/components/chat/entity-ref';
+import { resolveEmbedDecision } from '@/components/chat/embed-renderer';
 import type { EntityStatusFetchState } from '@/components/chat/entity-status-labels';
 import { AssetEmbedCard } from '@/components/chat/asset-embed-card';
 import { getFileIcon } from '@/lib/file-icon';
@@ -75,39 +77,6 @@ interface ChatBubbleProps {
 interface ContextMenuState {
   x: number;
   y: number;
-}
-
-// story #2263 AC6 — 본문 토큰(target_type+target_id)이 메시지의 stored 참조 목록에 있는지
-// 대조한다. `references === undefined`(옛 서버·SSE 디스패치 등 이 필드를 안 주는 경로)는
-// 판단 재료가 없다는 뜻이라 유령 처리를 보류한다(폴백 — 기존처럼 그대로 그린다). 대소문자
-// 차이(사용자가 UUID를 대문자로 쳐 넣는 경우)를 흡수하려 양쪽 다 lower-case로 비교한다.
-function isGhostReference(
-  references: ChatMessage['references'],
-  targetType: string,
-  targetId: string,
-): boolean {
-  if (references === undefined) return false;
-  const type = targetType.toLowerCase();
-  const id = targetId.toLowerCase();
-  return !references.some((r) => r.target_type.toLowerCase() === type && r.target_id.toLowerCase() === id);
-}
-
-// story #2262 AC1(2026-08-08) — doc `flow-map-blueprint-v1` §2-3 「사실성 · 표면 · 지점」의
-// «표면·지점» 재료. isGhostReference와 같은 대조를 한 번 더 해 form·referenced_at까지
-// 끌어온다(스토리 자신의 AC1 정의: 표면=form('mention'|'embed'|'proof'), 지점=referenced_at —
-// "이 참조가 «언제 생겼나»"이지 대상이 「언제 만들어졌나」가 아니다). 매칭 없으면(유령이거나
-// references 자체가 없으면) null — 그때는 칩에 표기하지 않는다(모르는 것을 지어내지 않는다).
-function findReferenceMeta(
-  references: ChatMessage['references'],
-  targetType: string,
-  targetId: string,
-): { form: string; referencedAt: string } | null {
-  if (!references) return null;
-  const type = targetType.toLowerCase();
-  const id = targetId.toLowerCase();
-  const match = references.find((r) => r.target_type.toLowerCase() === type && r.target_id.toLowerCase() === id);
-  if (!match || !match.form || !match.referenced_at) return null;
-  return { form: match.form, referencedAt: match.referenced_at };
 }
 
 // story #2671 — EmbedCard(ME-S5 원조 카드 렌더)가 실 렌더 경로에 미배선이던 것을 여기서
@@ -216,21 +185,25 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenRe
   const components = useMemo(() => ({
     p: ({ children, node }: { children?: React.ReactNode; node?: HastElementLike }) => {
       // story #2671 — 참조 링크 하나가 문단의 전부면(다른 텍스트 0) 카드 임베드로.
+      // story #2888(S2a) — 파싱은 parseEntityRef SSOT·결정은 resolveEmbedDecision(EmbedRenderer)
+      // 공유. 이 슬롯은 'card' kind일 때만 반응하고(allowCard:true), asset/chip은 원래도
+      // 여기선 무동작이라(기존 동작 그대로) 그대로 아래 <p> 폴백으로 떨어진다.
       const link = soleLinkChild(node);
       const href = link?.properties?.href;
-      const m = typeof href === 'string' ? href.match(/^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i) : null;
-      if (m && m[1]!.toLowerCase() !== 'asset' && !isGhostReference(references, m[1]!, m[2]!)) {
-        const statusFetch = entityStatusByKey?.[`${m[1]!.toLowerCase()}:${m[2]!.toLowerCase()}`];
+      const ref = typeof href === 'string' ? parseEntityRef(href) : null;
+      const decision = ref ? resolveEmbedDecision(ref.entityType, ref.entityId, references, { allowCard: true }) : null;
+      if (ref && decision?.kind === 'card') {
+        const statusFetch = entityStatusByKey?.[`${ref.entityType.toLowerCase()}:${ref.entityId.toLowerCase()}`];
         const status = statusFetch?.kind === 'resolved' ? statusFetch.raw : null;
         // PO 리뷰 지적 — 링크 라벨이 여러 자식(예: **강조** 섞인 텍스트)으로 쪼개질 수
         // 있어 첫 자식만 읽으면 라벨이 잘린다. 전 자식을 이어붙인다(hastNodeText가
         // 재귀로 하듯 여기도 동일 패턴).
-        const label = (link!.children ?? []).map(hastNodeText).join('') || m[2]!;
+        const label = (link!.children ?? []).map(hastNodeText).join('') || ref.entityId;
         const openReadingPanel = onOpenReadingPanel
           ? (entityType: string, entityId: string, t: string | null, s: string | null, h: string | null) =>
               onOpenReadingPanel({ kind: 'entity', entityType, entityId, title: t, status: s, href: h })
           : undefined;
-        return <EmbedCard entity_type={m[1]!} entity_id={m[2]!} title={label} status={status} onOpenReadingPanel={openReadingPanel} />;
+        return <EmbedCard entity_type={ref.entityType} entity_id={ref.entityId} title={label} status={status} onOpenReadingPanel={openReadingPanel} />;
       }
       return <p className={`mb-1.5 [overflow-wrap:anywhere] text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>;
     },
@@ -275,28 +248,32 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenRe
         );
       }
       // id 는 UUID 만 허용 — `dead`·`----` 등 비-UUID는 매칭 실패→평문 링크로 폴백(엔티티 칩/카드 미렌더).
-      const m = href?.match(/^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
-      if (m) {
+      // story #2888(S2a) — 파싱·결정은 parseEntityRef+resolveEmbedDecision(EmbedRenderer) 공유.
+      const ref = parseEntityRef(href);
+      if (ref) {
+        const decision = resolveEmbedDecision(ref.entityType, ref.entityId, references, { allowCard: false });
         // S6: 자산 토큰은 컴팩트 칩 대신 리치 임베드 카드(썸네일+메타+화살표).
         // ⛔asset은 reference_registry.ENTITY_RESOLVERS 밖의 FE 전용 타입이라(embed-card.tsx
         // 주석 참조) mention_parser가 애초에 entity_references에 안 쓴다 — stored 참조와
         // 대조하면 asset 임베드가 전부 유령으로 오판된다. 유령 판정 자체를 안 태운다.
-        if (m[1]!.toLowerCase() === 'asset') {
-          return <AssetEmbedCard entityId={m[2]!} label={String(children)} ownMessage={isMine} onOpenReadingPanel={onOpenReadingPanel} />;
+        if (decision.kind === 'asset') {
+          return <AssetEmbedCard entityId={ref.entityId} label={String(children)} ownMessage={isMine} onOpenReadingPanel={onOpenReadingPanel} />;
         }
-        const ghost = isGhostReference(references, m[1]!, m[2]!);
-        const referenceMeta = ghost ? null : findReferenceMeta(references, m[1]!, m[2]!);
-        return (
-          <EntityChip
-            entityType={m[1]!}
-            entityId={m[2]!}
-            label={String(children)}
-            href={getEntityHref(m[1]!, m[2]!)}
-            ghost={ghost}
-            referenceMeta={referenceMeta}
-            entityStatus={entityStatusByKey?.[`${m[1]!.toLowerCase()}:${m[2]!.toLowerCase()}`]}
-          />
-        );
+        // allowCard:false라 decision.kind는 여기서 항상 'chip'('card'는 불가능 — resolveEmbedDecision
+        // 계약: opts.allowCard가 false면 'card'를 반환하지 않는다).
+        if (decision.kind === 'chip') {
+          return (
+            <EntityChip
+              entityType={ref.entityType}
+              entityId={ref.entityId}
+              label={String(children)}
+              href={getEntityHref(ref.entityType, ref.entityId)}
+              ghost={decision.ghost}
+              referenceMeta={decision.referenceMeta}
+              entityStatus={entityStatusByKey?.[`${ref.entityType.toLowerCase()}:${ref.entityId.toLowerCase()}`]}
+            />
+          );
+        }
       }
       return <a href={href} target="_blank" rel="noopener noreferrer" className={`underline underline-offset-2 ${text}`}>{children}</a>;
     },

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -5,78 +5,20 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import {
-  ExternalLink, X, FileText, File, Layers, CheckSquare, Eye,
-  Calendar, Image, FlaskConical, Paperclip, type LucideIcon,
-} from 'lucide-react';
+import { ExternalLink, X, Eye } from 'lucide-react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { docViewUrl } from '@/components/docs/lib/doc-project-url';
 import { resolveScopedEntityHref, storyBoardUrl, goalUrl, sprintUrl, assetStorageUrl } from '@/lib/entity-project-url';
-import { initials } from '@/lib/storage/format';
 import { renderEntityStatusLabel, translateEntityStatus, type EntityStatusFetchState } from './entity-status-labels';
 import { ArtifactThumbnail } from '@/components/canvas/artifact-thumbnail';
 import { fetchWithAuth } from '@/lib/db/client';
+import { parseEntityRef } from './entity-ref';
+// story #2888(S2a) — 이관 후 재수출(기존 소비처 4곳 import 경로 무변경, 회귀 0). 정본은
+// entity-registry.tsx 참고.
+import { ENTITY_ICONS, ENTITY_COLORS, GRAY_STATE_COLOR, resolveEntityIcon, EntityGlyph } from './entity-registry';
 
-// story #2302 — 이 8종은 BE reference_registry.py ENTITY_RESOLVERS 와 키 집합이 같아야 한다
-// (AC2·AC5, entity-icons.registry-parity.test.ts 가 코드스캔으로 대조). `asset`은 registry
-// 밖 FE 전용 타입(AC5 명시 예외) — 아이콘을 **일부러** 안 준다: asset은 이미지/PDF/영상 등
-// content-type이 제각각이라 타입 레벨 단일 아이콘이 의미가 없고(개별 파일 아이콘은
-// getFileIcon이 파일별로 처리), "아이콘 없으면 이름 글자로"가 AC4가 못박은 **기본값**이지
-// asset만의 예외 처리가 아니다 — 그래서 이 fallback은 `resolveEntityIcon()`이 모든 타입에
-// 공통 적용한다(Hash 캐치올을 버림 — 있지도 않은 아이콘을 그리는 거짓보다 글자가 정직하다).
-//
-// ⛔story #2263(C-7, 2026-07-29) — 한 번 여기 chat_message를 추가했다가 되돌렸다: BE
-// ENTITY_RESOLVERS에 등록하면 «완전지원 엔티티»(검색·MCP mention·project축 parity까지)를
-// 전부 갖춰야 한다는 게 CI 13건 실패로 드러났다(PO 판정). chat_message는 참조 TARGET은
-// 되지만 그 다섯 계약을 구조적으로 다 못 갖춰(검색대상 아님·project축 아님·단독조회
-// 라우트 없음) `reference_registry.TARGET_ONLY_TYPES`라는 별도 집합으로 옮겨졌다 —
-// ENTITY_RESOLVERS 밖이라 이 FE parity 대조에도 안 걸린다(의도적으로 안 나타난다).
-export const ENTITY_ICONS: Record<string, LucideIcon> = {
-  story: FileText,
-  doc: File,
-  epic: Layers,
-  task: CheckSquare,
-  sprint: Calendar,
-  artifact: Image,
-  hypothesis: FlaskConical,
-  evidence: Paperclip,
-};
-
-/** ENTITY_ICONS에 없는 타입(지금은 asset뿐) → 아이콘 대신 이름 첫 글자(들). 예외 처리 아님(위 주석). */
-export function resolveEntityIcon(entityType: string): LucideIcon | null {
-  return ENTITY_ICONS[entityType] ?? null;
-}
-
-/** 아이콘이 없는 타입(asset)의 렌더 지점 3곳(모달 헤더·EmbedCard·EntityChip)이 각자 Hash로
- * 캐치올하지 않고 한 곳에서 초성/이니셜 폴백을 공유하게 — 새 타입이 추가돼도 렌더 지점마다
- * 따로 안 고쳐도 된다. Icon은 호출부에서 미리 resolve해 prop으로 받는다(레포 관례 —
- * storage-file-glyph.tsx 동일 주석: 컴포넌트 스코프 안에서 lookup한 컴포넌트를 바로 JSX로 쓰면
- * `react-hooks/static-components`에 걸린다). */
-function EntityGlyph({ Icon, label, className }: { Icon: LucideIcon | null; label: string; className?: string }) {
-  if (Icon) return <Icon className={className ?? 'size-4 shrink-0'} />;
-  return <span className={`flex items-center justify-center text-[10px] font-bold ${className ?? 'size-4 shrink-0'}`}>{initials(label)}</span>;
-}
-
-// 엔티티 신호 토큰(하드코딩 blue/purple/emerald/slate 제거·다크 자동 정합). 타입별 절제 틴트.
-// ⛔AC4: ②/③(담긴 곳으로 보내거나 갈 곳이 없는) 상태에서는 이 틴트를 쓰지 않고 GRAY_STATE_COLOR로
-// 덮어쓴다(회색 하나로 통일 — 노랑 금지 근거는 그 상수 주석 참고). 여기 있는 색은 **①일 때만** 보인다.
-const ENTITY_COLORS: Record<string, string> = {
-  story: 'border-info/30 bg-info/8 text-foreground',
-  doc: 'border-border bg-muted/40 text-foreground',
-  epic: 'border-secondary bg-secondary/40 text-foreground',
-  task: 'border-success/30 bg-success/8 text-foreground',
-  sprint: 'border-warning/30 bg-warning/8 text-foreground',
-  artifact: 'border-info/30 bg-info/8 text-foreground',
-  hypothesis: 'border-border bg-muted/40 text-foreground',
-  evidence: 'border-border bg-muted/40 text-foreground',
-  // S6: 스토리지 자산 토큰 — info 틴트(파일 아이콘은 content-type 의존이라 AssetEmbedCard 에서 getFileIcon 처리).
-  asset: 'border-info/30 bg-info/8 text-foreground',
-};
-
-// ⛔AC4 색 규율: 노랑 금지 — 노랑은 "기다리면 풀리는 것"인데 ②/③은 사용자가 기다려서 풀 수
-// 있는 상태가 아니다(담긴 곳으로 보내거나, 애초에 갈 곳이 없는 것). 구별은 색이 아니라 말로.
-export const GRAY_STATE_COLOR = 'border-border bg-muted/40 text-muted-foreground';
+export { ENTITY_ICONS, ENTITY_COLORS, GRAY_STATE_COLOR, resolveEntityIcon };
 
 /** story #2302 — task·evidence는 항상 담긴 곳(②) 판정에 own-href가 없다(모델 FK 그대로:
  * Task.story_id/Evidence.work_item_id 항상 NOT NULL — 항상 유일한 부모, 모호함 0).
@@ -176,18 +118,17 @@ const MdBadge = ({ label }: { label: string }) => (
 // 새 함수 참조가 되어 react-markdown이 서브트리를 리마운트한다(chat-bubble 근본원인과 동형).
 // 이 객체는 props/상태에 의존하지 않는 순수 상수이고 자식도 전부 stateless라 useMemo조차
 // 불필요 — 모듈 스코프로 끌어올려 참조를 영구 고정한다.
-// story #2639 — 본문 엔티티 참조 토큰 `[제목](entity:타입:id)`의 href 매칭(id는 UUID만).
-// doc-content-renderer.tsx·chat-bubble.tsx의 파싱 규칙과 문자 그대로 동일(드리프트 방지).
-const MDBODY_ENTITY_REF_RE = /^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
-
 const mdBodyComponents = {
   // story #2639(미르코 리뷰 ⑤) — 결재 카드 문서 미리보기(EntityPreviewModal→EntityDetail doc
   // 분기)가 이 경량 렌더러를 쓴다. doc-content-renderer와 동일하게 entity: 참조를 EntityChip으로
   // 잇는다(같은 파일의 EntityChip 재사용·사본 0). 비-UUID/asset은 평문 링크 폴백(무동작 0).
+  // story #2888(S2a) — 파싱은 parseEntityRef SSOT. 이 렌더러엔 `references` 사이드밴드가
+  // 없어(중첩 엔티티 본문) doc-content-renderer.tsx와 동일한 단순 2갈래(asset 제외 칩 or
+  // 평문 링크)를 그대로 유지한다 — asset은 원래도 AssetEmbedCard가 아니라 평문 링크 폴백.
   a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
-    const m = href?.match(MDBODY_ENTITY_REF_RE);
-    if (m && m[1]!.toLowerCase() !== 'asset') {
-      return <EntityChip entityType={m[1]!} entityId={m[2]!} label={String(children)} href={getEntityHref(m[1]!, m[2]!)} />;
+    const ref = parseEntityRef(href);
+    if (ref && ref.entityType.toLowerCase() !== 'asset') {
+      return <EntityChip entityType={ref.entityType} entityId={ref.entityId} label={String(children)} href={getEntityHref(ref.entityType, ref.entityId)} />;
     }
     return <a href={href} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">{children}</a>;
   },

--- a/apps/web/src/components/chat/embed-renderer.test.ts
+++ b/apps/web/src/components/chat/embed-renderer.test.ts
@@ -1,0 +1,58 @@
+// story #2888(S2a) — EmbedRenderer 결정 트리 SSOT. chat-bubble.tsx의 `p`(sole-link)·`a`(inline)
+// 두 슬롯이 각자 인라인으로 짜던 asset/유령/referenceMeta 판정이 이 함수 하나로 수렴했다는
+// 회귀가드 — 결정 트리 케이스별(AC2 "케이스별 회귀 테스트").
+import { describe, expect, it } from 'vitest';
+import { isGhostReference, findReferenceMeta, resolveEmbedDecision } from './embed-renderer';
+
+const STORY_ID = '12345678-90ab-cdef-1234-567890abcdef';
+const refs = [{ target_type: 'story', target_id: STORY_ID, form: 'mention', referenced_at: '2026-08-01T00:00:00Z' }];
+
+describe('isGhostReference (story #2888)', () => {
+  it('references가 undefined면 유령 아님(판단 재료 없음 — 폴백)', () => {
+    expect(isGhostReference(undefined, 'story', STORY_ID)).toBe(false);
+  });
+  it('references가 []이고 매칭 없으면 유령', () => {
+    expect(isGhostReference([], 'story', STORY_ID)).toBe(true);
+  });
+  it('references에 매칭 있으면 유령 아님(대소문자 무관)', () => {
+    expect(isGhostReference(refs, 'STORY', STORY_ID.toUpperCase())).toBe(false);
+  });
+});
+
+describe('findReferenceMeta (story #2888)', () => {
+  it('매칭되면 form·referencedAt을 반환한다', () => {
+    expect(findReferenceMeta(refs, 'story', STORY_ID)).toEqual({ form: 'mention', referencedAt: '2026-08-01T00:00:00Z' });
+  });
+  it('매칭 없으면 null', () => {
+    expect(findReferenceMeta(refs, 'doc', STORY_ID)).toBeNull();
+  });
+  it('references가 undefined면 null', () => {
+    expect(findReferenceMeta(undefined, 'story', STORY_ID)).toBeNull();
+  });
+});
+
+describe('resolveEmbedDecision (story #2888) — 결정 트리', () => {
+  it('asset은 allowCard 무관 항상 kind=asset', () => {
+    expect(resolveEmbedDecision('asset', STORY_ID, refs, { allowCard: true })).toEqual({ kind: 'asset' });
+    expect(resolveEmbedDecision('asset', STORY_ID, undefined, { allowCard: false })).toEqual({ kind: 'asset' });
+  });
+
+  it('sole-link(allowCard:true) + 비유령 → kind=card', () => {
+    expect(resolveEmbedDecision('story', STORY_ID, refs, { allowCard: true })).toEqual({ kind: 'card' });
+  });
+
+  it('sole-link(allowCard:true)이어도 유령이면 card 아님 — chip(ghost:true)로 떨어진다', () => {
+    const decision = resolveEmbedDecision('story', STORY_ID, [], { allowCard: true });
+    expect(decision).toEqual({ kind: 'chip', ghost: true, referenceMeta: null });
+  });
+
+  it('allowCard:false면 비유령이어도 chip(ghost:false)', () => {
+    const decision = resolveEmbedDecision('story', STORY_ID, refs, { allowCard: false });
+    expect(decision).toEqual({ kind: 'chip', ghost: false, referenceMeta: { form: 'mention', referencedAt: '2026-08-01T00:00:00Z' } });
+  });
+
+  it('references undefined + allowCard:false → chip(ghost:false, referenceMeta:null) — mdBody/doc-content-renderer의 무-사이드밴드 케이스', () => {
+    const decision = resolveEmbedDecision('story', STORY_ID, undefined, { allowCard: false });
+    expect(decision).toEqual({ kind: 'chip', ghost: false, referenceMeta: null });
+  });
+});

--- a/apps/web/src/components/chat/embed-renderer.ts
+++ b/apps/web/src/components/chat/embed-renderer.ts
@@ -1,0 +1,76 @@
+import type { ChatMessage } from '@/hooks/use-chat-sse';
+
+/**
+ * story #2888(S2a) — 임베드 렌더 결정 트리 SSOT("EmbedRenderer"). 이전엔 chat-bubble.tsx의
+ * `p`(sole-link)·`a`(inline) 두 react-markdown 컴포넌트가 각자 asset 체크·유령 체크·
+ * referenceMeta 조회를 따로 인라인으로 짜고 있었다 — 이 파일 하나로 수렴한다.
+ *
+ * 두 호출부는 데이터 형태(`node`+`children` vs `href`+`children`)가 달라 단일 컴포넌트로
+ * 합칠 수 없지만(react-markdown 슬롯 시그니처가 다름), **결정 로직**(무엇을 렌더할지)은
+ * 이 순수 함수 하나로 합쳐 두 곳이 똑같이 호출한다.
+ *
+ * embed-card.tsx(mdBody)·doc-content-renderer.tsx는 `references` 사이드밴드가 아예 없는
+ * 컨텍스트(엔티티 본문 안에 중첩된 참조·doc 페이지 본문)라 `allowCard: false`·
+ * `references: undefined`로 호출한다 — `isGhostReference(undefined,...)`가 `false`를
+ * 반환하는 기존 계약(references 부재 = "모른다", "유령"이 아니다) 그대로 asset|chip 2갈래로
+ * 자연히 좁혀진다(기존 동작과 값으로 동일 — 두 파일 다 ghost/referenceMeta를 원래도 안 썼다).
+ */
+
+// story #2263 AC6 — 본문 토큰(target_type+target_id)이 메시지의 stored 참조 목록에 있는지
+// 대조한다. `references === undefined`(옛 서버·SSE 디스패치 등 이 필드를 안 주는 경로)는
+// 판단 재료가 없다는 뜻이라 유령 처리를 보류한다(폴백 — 기존처럼 그대로 그린다). 대소문자
+// 차이(사용자가 UUID를 대문자로 쳐 넣는 경우)를 흡수하려 양쪽 다 lower-case로 비교한다.
+export function isGhostReference(
+  references: ChatMessage['references'],
+  targetType: string,
+  targetId: string,
+): boolean {
+  if (references === undefined) return false;
+  const type = targetType.toLowerCase();
+  const id = targetId.toLowerCase();
+  return !references.some((r) => r.target_type.toLowerCase() === type && r.target_id.toLowerCase() === id);
+}
+
+// story #2262 AC1(2026-08-08) — doc `flow-map-blueprint-v1` §2-3 「사실성 · 표면 · 지점」의
+// «표면·지점» 재료. isGhostReference와 같은 대조를 한 번 더 해 form·referenced_at까지
+// 끌어온다(스토리 자신의 AC1 정의: 표면=form('mention'|'embed'|'proof'), 지점=referenced_at —
+// "이 참조가 «언제 생겼나»"이지 대상이 「언제 만들어졌나」가 아니다). 매칭 없으면(유령이거나
+// references 자체가 없으면) null — 그때는 칩에 표기하지 않는다(모르는 것을 지어내지 않는다).
+export function findReferenceMeta(
+  references: ChatMessage['references'],
+  targetType: string,
+  targetId: string,
+): { form: string; referencedAt: string } | null {
+  if (!references) return null;
+  const type = targetType.toLowerCase();
+  const id = targetId.toLowerCase();
+  const match = references.find((r) => r.target_type.toLowerCase() === type && r.target_id.toLowerCase() === id);
+  if (!match || !match.form || !match.referenced_at) return null;
+  return { form: match.form, referencedAt: match.referenced_at };
+}
+
+export type EmbedDecision =
+  | { kind: 'asset' }
+  | { kind: 'card' }
+  | { kind: 'chip'; ghost: boolean; referenceMeta: { form: string; referencedAt: string } | null };
+
+/**
+ * 결정 트리(AC2): asset→'asset'(AssetEmbedCard) / sole-link(& allowCard·비유령)→'card'
+ * (EmbedCard) / 그 외 인라인→'chip'(EntityChip, ghost·referenceMeta 동봉).
+ *
+ * `allowCard`는 호출부(그 슬롯이 "문단 전체가 링크 하나뿐"인지)가 이미 판정해 넘긴다 —
+ * 이 함수 자신은 그 판정을 하지 않는다(soleLinkChild는 hast AST가 필요해 chat-bubble의
+ * `p` 컴포넌트 스코프에만 있다).
+ */
+export function resolveEmbedDecision(
+  entityType: string,
+  entityId: string,
+  references: ChatMessage['references'],
+  opts: { allowCard: boolean },
+): EmbedDecision {
+  if (entityType.toLowerCase() === 'asset') return { kind: 'asset' };
+  const ghost = isGhostReference(references, entityType, entityId);
+  if (opts.allowCard && !ghost) return { kind: 'card' };
+  const referenceMeta = ghost ? null : findReferenceMeta(references, entityType, entityId);
+  return { kind: 'chip', ghost, referenceMeta };
+}

--- a/apps/web/src/components/chat/entity-ref.test.ts
+++ b/apps/web/src/components/chat/entity-ref.test.ts
@@ -1,0 +1,35 @@
+// story #2888(S2a) — parseEntityRef SSOT. 3중 복제(chat-bubble ×2·embed-card·
+// doc-content-renderer)가 이 함수 하나로 수렴했다는 회귀가드.
+import { describe, expect, it } from 'vitest';
+import { parseEntityRef } from './entity-ref';
+
+const UUID = '12345678-90ab-cdef-1234-567890abcdef';
+
+describe('parseEntityRef (story #2888)', () => {
+  it('entity:타입:UUID 형태를 파싱한다', () => {
+    expect(parseEntityRef(`entity:story:${UUID}`)).toEqual({ entityType: 'story', entityId: UUID });
+  });
+
+  it('대문자 UUID도 매칭한다(대소문자 무관)', () => {
+    expect(parseEntityRef(`entity:doc:${UUID.toUpperCase()}`)).toEqual({ entityType: 'doc', entityId: UUID.toUpperCase() });
+  });
+
+  it('asset 타입도 동일하게 파싱한다(asset 배제는 호출부 몫)', () => {
+    expect(parseEntityRef(`entity:asset:${UUID}`)).toEqual({ entityType: 'asset', entityId: UUID });
+  });
+
+  it('비-UUID id는 매칭 실패(null)한다', () => {
+    expect(parseEntityRef('entity:story:dead')).toBeNull();
+    expect(parseEntityRef('entity:story:----')).toBeNull();
+  });
+
+  it('entity: 스킴이 아니면 null', () => {
+    expect(parseEntityRef(`mention:story:${UUID}`)).toBeNull();
+    expect(parseEntityRef('https://example.com')).toBeNull();
+  });
+
+  it('href가 undefined/null이면 null', () => {
+    expect(parseEntityRef(undefined)).toBeNull();
+    expect(parseEntityRef(null)).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/entity-ref.ts
+++ b/apps/web/src/components/chat/entity-ref.ts
@@ -1,0 +1,20 @@
+/**
+ * story #2888(S2a) — entity ref 파싱 SSOT. 이전엔 이 정규식이 chat-bubble.tsx(×2 — `p`·`a`
+ * 컴포넌트 각자)·embed-card.tsx(`MDBODY_ENTITY_REF_RE`)·doc-content-renderer.tsx
+ * (`ENTITY_REF_RE`)에 문자 그대로 3중 복제돼 있었다(드리프트 위험) — 이 파일 하나로 수렴한다.
+ *
+ * 본문 entity 참조 토큰 `[제목](entity:타입:id)`의 href 매칭 — id는 UUID만(비-UUID는
+ * 매칭 실패 → 호출부가 평문 링크로 폴백, 엔티티 칩/카드 미렌더).
+ */
+const ENTITY_REF_RE = /^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+
+export interface ParsedEntityRef {
+  entityType: string;
+  entityId: string;
+}
+
+export function parseEntityRef(href: string | null | undefined): ParsedEntityRef | null {
+  const m = href?.match(ENTITY_REF_RE);
+  if (!m) return null;
+  return { entityType: m[1]!, entityId: m[2]! };
+}

--- a/apps/web/src/components/chat/entity-registry.parity.test.ts
+++ b/apps/web/src/components/chat/entity-registry.parity.test.ts
@@ -1,5 +1,6 @@
 /**
- * story #2302 AC2·AC5 — ENTITY_ICONS/ENTITY_COLORS/getEntityHref가 BE
+ * story #2302 AC2·AC5(story #2888 S2a — entity-registry.tsx로 이관 후 파일명·소스경로만 갱신,
+ * 대조 로직·단언은 그대로) — ENTITY_ICONS/ENTITY_COLORS/getEntityHref가 BE
  * `reference_registry.py::ENTITY_RESOLVERS`와 어긋나면(등록된 종류를 FE가 모르는 채로 남으면)
  * CI가 코드스캔으로 잡는다. 완전 동일은 요구하지 않는다 — `asset`은 registry 밖 FE 전용 타입
  * (명시 예외, 이 파일에 그대로 선언). 가드가 자기 재료(backend 파일)를 못 찾으면 skip이 아니라
@@ -8,7 +9,7 @@
 import { describe, expect, it } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { ENTITY_ICONS } from './embed-card';
+import { ENTITY_ICONS } from './entity-registry';
 
 function findRepoRoot(startDir: string): string {
   let dir = startDir;
@@ -37,23 +38,23 @@ function parseFeSwitchKeys(source: string, functionSignature: RegExp): Set<strin
   return new Set([...m[1]!.matchAll(/case '([^']+)':/g)].map((mm) => mm[1]!));
 }
 
-// asset은 BE reference_registry.py 밖의 FE 전용 타입(embed-card.tsx 주석 — 채팅 첨부는
+// asset은 BE reference_registry.py 밖의 FE 전용 타입(entity-registry.tsx 주석 — 채팅 첨부는
 // mention_parser.py write-path가 하드코딩 source_type으로 직접 다뤄 target-resolver가 없다).
 const FE_ONLY_TYPES = new Set(['asset']);
 
-describe('embed-card.tsx 엔티티 키 집합 ↔ BE ENTITY_RESOLVERS 코드스캔 동기화', () => {
+describe('entity-registry.tsx 엔티티 키 집합 ↔ BE ENTITY_RESOLVERS 코드스캔 동기화', () => {
   it('BE에 등록된 종류를 ENTITY_ICONS가 전부 안다(asset은 의도적 예외 — 아이콘 없이 글자로)', () => {
     const backendTypes = parseBackendEntityResolvers();
     const feIconTypes = new Set(Object.keys(ENTITY_ICONS));
-    // ENTITY_ICONS는 asset을 일부러 안 갖는다(embed-card.tsx 상단 주석) — 그래서 정확히 BE와 같아야 한다.
+    // ENTITY_ICONS는 asset을 일부러 안 갖는다(entity-registry.tsx 상단 주석) — 그래서 정확히 BE와 같아야 한다.
     expect(feIconTypes).toEqual(backendTypes);
   });
 
   it('BE에 등록된 종류를 ENTITY_COLORS가 전부 안다(+ asset 예외 포함)', () => {
     const backendTypes = parseBackendEntityResolvers();
-    const source = readFileSync(resolve(__dirname, 'embed-card.tsx'), 'utf-8');
-    const m = source.match(/const ENTITY_COLORS: Record<string, string> = \{([\s\S]*?)\n\};/);
-    if (!m) throw new Error('ENTITY_COLORS 정의를 embed-card.tsx에서 못 찾았다 — 리팩터로 형태가 바뀌었으면 이 정규식도 갱신');
+    const source = readFileSync(resolve(__dirname, 'entity-registry.tsx'), 'utf-8');
+    const m = source.match(/export const ENTITY_COLORS: Record<string, string> = \{([\s\S]*?)\n\};/);
+    if (!m) throw new Error('ENTITY_COLORS 정의를 entity-registry.tsx에서 못 찾았다 — 리팩터로 형태가 바뀌었으면 이 정규식도 갱신');
     const feColorTypes = new Set([...m[1]!.matchAll(/^\s*(\w+):/gm)].map((mm) => mm[1]!));
     for (const t of backendTypes) expect(feColorTypes.has(t)).toBe(true);
     expect(feColorTypes).toEqual(new Set([...backendTypes, ...FE_ONLY_TYPES]));

--- a/apps/web/src/components/chat/entity-registry.tsx
+++ b/apps/web/src/components/chat/entity-registry.tsx
@@ -1,0 +1,73 @@
+import type { LucideIcon } from 'lucide-react';
+import { FileText, File, Layers, CheckSquare, Calendar, Image, FlaskConical, Paperclip } from 'lucide-react';
+import { initials } from '@/lib/storage/format';
+
+/**
+ * story #2888(S2a) — 엔티티 타입 레지스트리 SSOT(원래 embed-card.tsx에 있던 것을 이관·
+ * embed-card.tsx는 재수출만 한다 — 기존 소비처 4곳(chat-input·entity-aware-textarea·
+ * approval-request-card·notification-display)은 import 경로 무변경, 회귀 0).
+ *
+ * story #2302: 이 8종은 BE reference_registry.py ENTITY_RESOLVERS 와 키 집합이 같아야 한다
+ * (AC2·AC5, entity-registry.parity.test.ts 가 코드스캔으로 대조). `asset`은 registry 밖
+ * FE 전용 타입(AC5 명시 예외) — 아이콘을 **일부러** 안 준다: asset은 이미지/PDF/영상 등
+ * content-type이 제각각이라 타입 레벨 단일 아이콘이 의미가 없고(개별 파일 아이콘은
+ * getFileIcon이 파일별로 처리), "아이콘 없으면 이름 글자로"가 AC4가 못박은 **기본값**이지
+ * asset만의 예외 처리가 아니다 — 그래서 이 fallback은 `resolveEntityIcon()`이 모든 타입에
+ * 공통 적용한다(Hash 캐치올을 버림 — 있지도 않은 아이콘을 그리는 거짓보다 글자가 정직하다).
+ *
+ * ⛔story #2263(C-7, 2026-07-29) — 한 번 여기 chat_message를 추가했다가 되돌렸다: BE
+ * ENTITY_RESOLVERS에 등록하면 «완전지원 엔티티»(검색·MCP mention·project축 parity까지)를
+ * 전부 갖춰야 한다는 게 CI 13건 실패로 드러났다(PO 판정). chat_message는 참조 TARGET은
+ * 되지만 그 다섯 계약을 구조적으로 다 못 갖춰(검색대상 아님·project축 아님·단독조회
+ * 라우트 없음) `reference_registry.TARGET_ONLY_TYPES`라는 별도 집합으로 옮겨졌다 —
+ * ENTITY_RESOLVERS 밖이라 이 FE parity 대조에도 안 걸린다(의도적으로 안 나타난다).
+ *
+ * **신규 타입 추가 지점**(S2h — gate/PR/member): BE reference_registry.py ENTITY_RESOLVERS에
+ * 새 타입을 등록하면 이 두 레지스트리(ENTITY_ICONS·ENTITY_COLORS)와 embed-card.tsx의
+ * getEntityHref·ENTITY_API도 같이 넓혀야 parity 테스트가 통과한다.
+ */
+export const ENTITY_ICONS: Record<string, LucideIcon> = {
+  story: FileText,
+  doc: File,
+  epic: Layers,
+  task: CheckSquare,
+  sprint: Calendar,
+  artifact: Image,
+  hypothesis: FlaskConical,
+  evidence: Paperclip,
+};
+
+/** ENTITY_ICONS에 없는 타입(지금은 asset뿐) → 아이콘 대신 이름 첫 글자(들). 예외 처리 아님(위 주석). */
+export function resolveEntityIcon(entityType: string): LucideIcon | null {
+  return ENTITY_ICONS[entityType] ?? null;
+}
+
+/** 아이콘이 없는 타입(asset)의 렌더 지점 3곳(모달 헤더·EmbedCard·EntityChip)이 각자 Hash로
+ * 캐치올하지 않고 한 곳에서 초성/이니셜 폴백을 공유하게 — 새 타입이 추가돼도 렌더 지점마다
+ * 따로 안 고쳐도 된다. Icon은 호출부에서 미리 resolve해 prop으로 받는다(레포 관례 —
+ * storage-file-glyph.tsx 동일 주석: 컴포넌트 스코프 안에서 lookup한 컴포넌트를 바로 JSX로 쓰면
+ * `react-hooks/static-components`에 걸린다). */
+export function EntityGlyph({ Icon, label, className }: { Icon: LucideIcon | null; label: string; className?: string }) {
+  if (Icon) return <Icon className={className ?? 'size-4 shrink-0'} />;
+  return <span className={`flex items-center justify-center text-[10px] font-bold ${className ?? 'size-4 shrink-0'}`}>{initials(label)}</span>;
+}
+
+// 엔티티 신호 토큰(하드코딩 blue/purple/emerald/slate 제거·다크 자동 정합). 타입별 절제 틴트.
+// ⛔AC4: ②/③(담긴 곳으로 보내거나 갈 곳이 없는) 상태에서는 이 틴트를 쓰지 않고 GRAY_STATE_COLOR로
+// 덮어쓴다(회색 하나로 통일 — 노랑 금지 근거는 그 상수 주석 참고). 여기 있는 색은 **①일 때만** 보인다.
+export const ENTITY_COLORS: Record<string, string> = {
+  story: 'border-info/30 bg-info/8 text-foreground',
+  doc: 'border-border bg-muted/40 text-foreground',
+  epic: 'border-secondary bg-secondary/40 text-foreground',
+  task: 'border-success/30 bg-success/8 text-foreground',
+  sprint: 'border-warning/30 bg-warning/8 text-foreground',
+  artifact: 'border-info/30 bg-info/8 text-foreground',
+  hypothesis: 'border-border bg-muted/40 text-foreground',
+  evidence: 'border-border bg-muted/40 text-foreground',
+  // S6: 스토리지 자산 토큰 — info 틴트(파일 아이콘은 content-type 의존이라 AssetEmbedCard 에서 getFileIcon 처리).
+  asset: 'border-info/30 bg-info/8 text-foreground',
+};
+
+// ⛔AC4 색 규율: 노랑 금지 — 노랑은 "기다리면 풀리는 것"인데 ②/③은 사용자가 기다려서 풀 수
+// 있는 상태가 아니다(담긴 곳으로 보내거나, 애초에 갈 곳이 없는 것). 구별은 색이 아니라 말로.
+export const GRAY_STATE_COLOR = 'border-border bg-muted/40 text-muted-foreground';

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils';
 import { extractDocHeadings, slugifyHeading } from './doc-heading-utils';
 // story #2639 — 본문 entity: 참조 링크를 앱 내 엔티티로 잇는다(chat/story-panel과 동일 자산 재사용).
 import { EntityChip, getEntityHref } from '@/components/chat/embed-card';
+import { parseEntityRef } from '@/components/chat/entity-ref';
 import { fetchWithAuth } from '@/lib/db/client';
 
 interface DocContentRendererProps {
@@ -80,11 +81,6 @@ const docMarkdownSanitizeSchema = {
     href: [...(defaultSchema.protocols?.href ?? []), 'entity'],
   },
 };
-
-// story #2639 — 본문 엔티티 참조 토큰 `[제목](entity:타입:id)`의 href 매칭(id는 UUID만 —
-// 비-UUID는 매칭 실패→평문 링크 폴백). chat-bubble.tsx·story-detail-panel.tsx의 파싱 규칙과
-// 문자 그대로 동일하게 둔다(정의가 세 곳에 흩어지면 그 자체가 드리프트 위험).
-const ENTITY_REF_RE = /^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
 
 // asset-ref 식별 — react-markdown 은 hast node(properties.dataAssetId) + data-* prop 양쪽을 줄 수 있어
 // 둘 다 확인한다(스키마 통과분만 도달).
@@ -540,17 +536,18 @@ export function DocContentRenderer({
     // epic→/goals/·doc→/docs?id= 동일오리진 라우트를 준다(웹뷰서 SPA 착지·셸 무변경).
     // 매핑 없는 타입은 getEntityHref=null→모달만 뜨고(무동작 0), 비-UUID/asset은 평문 링크 폴백.
     a: ({ href, children }: { href?: string; children?: ReactNode }) => {
-      const m = href?.match(ENTITY_REF_RE);
+      // story #2888(S2a) — 파싱은 parseEntityRef SSOT(chat-bubble.tsx·embed-card.tsx와 공유).
+      const ref = parseEntityRef(href);
       // asset은 story-detail-panel과 동일하게 칩 경로에서 제외한다(자산 임베드는 별 경로).
-      if (m && m[1]!.toLowerCase() !== 'asset') {
+      if (ref && ref.entityType.toLowerCase() !== 'asset') {
         // public share 뷰어: 내부 참조는 비활성 평문(메타 유출 경계 — wikiLink publicMode와 동일).
         if (publicMode) return <span className="text-sm text-muted-foreground">{children}</span>;
         return (
           <EntityChip
-            entityType={m[1]!}
-            entityId={m[2]!}
+            entityType={ref.entityType}
+            entityId={ref.entityId}
             label={String(children)}
-            href={getEntityHref(m[1]!, m[2]!)}
+            href={getEntityHref(ref.entityType, ref.entityId)}
           />
         );
       }

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -15,6 +15,7 @@ import { parseCursorMeta } from '@/lib/pagination';
 import { AttachmentImage } from '@/components/chat/attachment-image';
 import { AttachmentFile } from '@/components/chat/attachment-file';
 import { EntityChip, getEntityHref } from '@/components/chat/embed-card';
+import { parseEntityRef } from '@/components/chat/entity-ref';
 import { ReferenceDropNotice, parseDroppedReferences, type DroppedReference } from '@/components/chat/reference-drop-notice';
 import { LabelChip, LABEL_PRESET_COLORS, type LabelData } from '@/components/ui/label-chip';
 import { DependencyGraph } from './dependency-graph';
@@ -293,16 +294,18 @@ export function DescriptionViewer({
           </span>
         );
       }
-      // id는 UUID만 허용 — chat-bubble.tsx의 entity: 파싱 규칙과 동일.
-      const m = href?.match(/^entity:(\w+):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
+      // story #2888(S2a) — 파싱은 parseEntityRef SSOT(chat-bubble.tsx·embed-card.tsx와 공유,
+      // 정규식 정의 1곳). ghost 판정(isGhostOutgoingReference)은 이 화면 고유 축(story 서술의
+      // «나가는» 참조)이라 EmbedRenderer 결정 트리와는 별개 — 그대로 둔다.
+      const ref = parseEntityRef(href);
       // ⛔asset은 reference_registry.ENTITY_RESOLVERS 밖의 FE 전용 타입(mention_parser.py
       // 주석 참조) — chat-bubble.tsx와 동일하게 일반 EntityChip 경로를 안 태운다.
-      if (m && m[1]!.toLowerCase() !== 'asset') {
-        const ghost = isGhostOutgoingReference(references, m[1]!, m[2]!);
+      if (ref && ref.entityType.toLowerCase() !== 'asset') {
+        const ghost = isGhostOutgoingReference(references, ref.entityType, ref.entityId);
         return (
           // 긴급 정정(2026-07-28) 재발 방지 — 부모 div의 편집모드 진입 onClick으로 버블링 금지.
           <span onClick={(e) => e.stopPropagation()}>
-            <EntityChip entityType={m[1]!} entityId={m[2]!} label={String(children)} href={getEntityHref(m[1]!, m[2]!)} ghost={ghost} />
+            <EntityChip entityType={ref.entityType} entityId={ref.entityId} label={String(children)} href={getEntityHref(ref.entityType, ref.entityId)} ghost={ghost} />
           </span>
         );
       }


### PR DESCRIPTION
## Summary
- **AC1**: entity ref 정규식 3중 복제(chat-bubble.tsx `p`·`a` 각자·embed-card.tsx mdBody·doc-content-renderer.tsx) → `entity-ref.ts::parseEntityRef` 단일 SSOT. 덤으로 동일 정규식이 있던 `kanban/story-detail-panel.tsx`도 함께 정리(AC 명시 3곳 밖이지만 저위험 순수 교체 — PR 리뷰 참고용으로 별도 표기).
- **AC2**: chat-bubble의 렌더 결정 트리(sole-link→EmbedCard / asset→AssetEmbedCard / 인라인→EntityChip+ghost/referenceMeta)를 `embed-renderer.ts::resolveEmbedDecision` 한 곳으로 — `p`·`a` 두 슬롯이 공유. embed-card.tsx(mdBody)·doc-content-renderer.tsx는 `references` 사이드밴드가 없는 컨텍스트라 parseEntityRef만 공유(원래도 asset/ghost 미처리 — 단순 2갈래 그대로 보존).
- **AC3**: `ENTITY_ICONS`/`ENTITY_COLORS`/`resolveEntityIcon`/`EntityGlyph`/`GRAY_STATE_COLOR` → `entity-registry.tsx`. `embed-card.tsx`는 재수출만(기존 소비처 4곳 — chat-input·entity-aware-textarea·approval-request-card·notification-display — import 경로 무변경, 회귀 0). BE reference_registry parity 테스트는 `entity-registry.parity.test.ts`로 이동(대조 로직 무변경, 소스 경로만 갱신).
- **AC4**: 표면 무접촉 — 대비 CI 가드 4종 신규 위반 0.
- **AC5**: `references[]` undefined(미지) vs [](확定0) 구분 시맨틱은 `isGhostReference`/`resolveEmbedDecision` 계약 그대로 보존(값으로 테스트).

## Test plan
- [x] `pnpm type-check` — 그린
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — 그린
- [x] `pnpm exec vitest run` — 463 files / **3839 tests 전부 green**(신규 14건: parseEntityRef 6·resolveEmbedDecision 8) — 기존 chat-bubble(1479줄)·embed-card·doc-content-renderer·story-detail-panel 테스트 전량 무변경 통과(값으로 회귀 0 증명)
- [x] `grep -rn "0-9a-f.{8}-.*0-9a-f.{12}"` repo-wide — entity ref 정규식이 `entity-ref.ts` 한 곳에만 존재(AC1 grep 검산)
- [x] 대비 CI 가드 4종 — 전부 AA 통과·신규 위반 0

Story: [SID:2888] · S2a(UI 갈아엎기 시퀀스 뼈대 2호 첫 슬라이스)

🤖 Generated with [Claude Code](https://claude.com/claude-code)