### PR TITLE
[SID:2886] 인라인 엔티티 칩 가독성 — 짧은 라벨+격납 메타

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -149,9 +149,12 @@ describe('ChatBubble — story #2262 AC1(사실성·표면·지점 표기, doc f
         />,
       ));
     });
-    expect(container.textContent).toContain('관찰됨');
-    expect(container.textContent).toContain('멘션');
-    expect(container.textContent).toContain('7/26');
+    // story #2886(S2b) — 격납 메타는 hover/focus tooltip으로 이동(더는 항상 인라인 표기 안 함).
+    // 트리거에 포커스를 줘 tooltip을 열고, base-ui Portal이 document.body에 그리는 내용을 본다.
+    await act(async () => { container.querySelector('button')!.focus(); });
+    expect(document.body.textContent).toContain('관찰됨');
+    expect(document.body.textContent).toContain('멘션');
+    expect(document.body.textContent).toContain('7/26');
   });
 
   it('매칭되는 stored 참조가 있어도 form·referenced_at이 없으면(구서버 폴백) 표기를 지어내지 않는다', async () => {
@@ -179,8 +182,10 @@ describe('ChatBubble — story #2262 AC2 PR② 1단계(2026-08-07 유나양 카�
     await act(async () => {
       root.render(wrap(<ChatBubble message={{ ...baseMessage, references: undefined }} isMine={false} />));
     });
-    expect(container.textContent).toContain('아직 모름');
-    expect(container.textContent).not.toContain('상태 없음');
+    // story #2886(S2b) — 상태 라벨은 격납(hover/focus tooltip)으로 이동. 포커스로 열고 확認.
+    await act(async () => { container.querySelector('button')!.focus(); });
+    expect(document.body.textContent).toContain('아직 모름');
+    expect(document.body.textContent).not.toContain('상태 없음');
   });
 
   it('no-status-concept 타입(hypothesis) 칩은 "상태 없음"을 보인다(로딩이 아니라 구조적 부재)', async () => {
@@ -193,8 +198,9 @@ describe('ChatBubble — story #2262 AC2 PR② 1단계(2026-08-07 유나양 카�
         />,
       ));
     });
-    expect(container.textContent).toContain('상태 없음');
-    expect(container.textContent).not.toContain('아직 모름');
+    await act(async () => { container.querySelector('button')!.focus(); });
+    expect(document.body.textContent).toContain('상태 없음');
+    expect(document.body.textContent).not.toContain('아직 모름');
   });
 
   it('유령 칩에는 상태 라벨을 안 보인다(대상 자체가 없는데 상태를 말할 수 없다)', async () => {
@@ -217,8 +223,10 @@ describe('ChatBubble — story #2262 AC2 PR② 2단계(chat-view.tsx 실 배치�
         />,
       ));
     });
-    expect(container.textContent).toContain('확定');
-    expect(container.textContent).not.toContain('아직 모름');
+    // story #2886(S2b) — 상태 라벨은 격납(hover/focus tooltip)으로 이동. 포커스로 열고 확認.
+    await act(async () => { container.querySelector('button')!.focus(); });
+    expect(document.body.textContent).toContain('확定');
+    expect(document.body.textContent).not.toContain('아직 모름');
   });
 
   it('entityId가 대문자 UUID 토큰이어도 소문자로 정규화해 캐시 키와 매칭한다', async () => {
@@ -244,7 +252,8 @@ describe('ChatBubble — story #2262 AC2 PR② 2단계(chat-view.tsx 실 배치�
         />,
       ));
     });
-    expect(container.textContent).toContain('아직 모름');
+    await act(async () => { container.querySelector('button')!.focus(); });
+    expect(document.body.textContent).toContain('아직 모름');
   });
 
   it('배치조회가 error로 끝나면 loading과 같은 급인 "아직 모름"을 보인다(가짜 "확認 중" 아님)', async () => {
@@ -257,7 +266,8 @@ describe('ChatBubble — story #2262 AC2 PR② 2단계(chat-view.tsx 실 배치�
         />,
       ));
     });
-    expect(container.textContent).toContain('아직 모름');
+    await act(async () => { container.querySelector('button')!.focus(); });
+    expect(document.body.textContent).toContain('아직 모름');
   });
 });
 
@@ -1275,7 +1285,10 @@ describe('ChatBubble — story #2669(B2) doc 칩 결재 CTA', () => {
     expect(transitionCall?.method).toBe('POST');
     expect(JSON.parse(transitionCall!.body!)).toEqual({ status: 'pending' });
     // 재조회 없이 로컬 반영 — 배지가 "검토 중"으로, 버튼은 "결재로 올리기"에서 "결재함에서 보기"로.
-    expect(container.textContent).toContain('검토 중');
+    // story #2886(S2b) — 상태 배지는 격납(hover/focus tooltip)으로 이동 — 칩 트리거(첫 버튼)에
+    // 포커스를 줘 확認(제출 클릭으로 포커스가 그쪽 버튼에 있었으므로 다시 옮겨야 한다).
+    await act(async () => { container.querySelectorAll('button')[0]!.focus(); });
+    expect(document.body.textContent).toContain('검토 중');
     expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '결재로 올리기')).toBe(false);
     expect(container.textContent).toContain('결재함에서 보기');
   });
@@ -1343,7 +1356,9 @@ describe('ChatBubble — story #2669(B2) doc 칩 결재 CTA', () => {
       ));
       await Promise.resolve(); await Promise.resolve();
     });
-    expect(container.textContent).toContain('반려됨');
+    // story #2886(S2b) — 상태 배지는 격납(hover/focus tooltip)으로 이동.
+    await act(async () => { container.querySelectorAll('button')[0]!.focus(); });
+    expect(document.body.textContent).toContain('반려됨');
     expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '결재로 올리기')).toBe(false);
     expect(Array.from(container.querySelectorAll('a')).some((a) => a.textContent === '결재함에서 보기')).toBe(false);
   });
@@ -1359,7 +1374,9 @@ describe('ChatBubble — story #2669(B2) doc 칩 결재 CTA', () => {
       ));
       await Promise.resolve(); await Promise.resolve();
     });
-    expect(container.textContent).toContain('확定');
+    // story #2886(S2b) — 상태 배지는 격납(hover/focus tooltip)으로 이동.
+    await act(async () => { container.querySelectorAll('button')[0]!.focus(); });
+    expect(document.body.textContent).toContain('확定');
     expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '결재로 올리기')).toBe(false);
   });
 

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -152,8 +152,10 @@ describe('ChatBubble — story #2262 AC1(사실성·표면·지점 표기, doc f
     // story #2886(S2b) — 격납 메타는 hover/focus tooltip으로 이동(더는 항상 인라인 표기 안 함).
     // 트리거에 포커스를 줘 tooltip을 열고, base-ui Portal이 document.body에 그리는 내용을 본다.
     await act(async () => { container.querySelector('button')!.focus(); });
-    expect(document.body.textContent).toContain('관찰됨');
+    // story #2886(S2b) — 유나군 하이파이 목업 대조: 툴팁은 라벨:값 행 구조(상태·참조 형태·관찰).
+    expect(document.body.textContent).toContain('참조 형태');
     expect(document.body.textContent).toContain('멘션');
+    expect(document.body.textContent).toContain('관찰');
     expect(document.body.textContent).toContain('7/26');
   });
 

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -6,7 +6,9 @@ import { useRouter } from 'next/navigation';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ExternalLink, X, Eye } from 'lucide-react';
+import { cva, type VariantProps } from 'class-variance-authority';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { docViewUrl } from '@/components/docs/lib/doc-project-url';
 import { resolveScopedEntityHref, storyBoardUrl, goalUrl, sprintUrl, assetStorageUrl } from '@/lib/entity-project-url';
@@ -769,6 +771,22 @@ function formatReferencePoint(iso: string): string {
   return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
 }
 
+/**
+ * story #2886(S2b) — 선생님 실증(2026-08-21): 인라인 칩이 전체 제목+메타 4항을 항상 펼쳐
+ * 산문을 익사시켰다. `inline`(기본) = 아이콘+짧은 라벨만, 메타(관찰됨·form·point·status)는
+ * hover/focus 시 tooltip으로 격납. `inline-meta` = 기존 그대로 전개(독립 표시용 — 예:
+ * 산문 밖에서 칩 하나만 크게 보여줄 때). S1 variant 체계(cva) 준수.
+ */
+const entityChipLabelVariants = cva('', {
+  variants: {
+    variant: {
+      inline: 'max-w-[14ch] truncate',
+      'inline-meta': '',
+    },
+  },
+  defaultVariants: { variant: 'inline' },
+});
+
 export function EntityChip({
   entityType,
   entityId,
@@ -777,6 +795,7 @@ export function EntityChip({
   ghost = false,
   referenceMeta = null,
   entityStatus,
+  variant = 'inline',
 }: {
   entityType: string;
   entityId?: string;
@@ -795,7 +814,7 @@ export function EntityChip({
    * 폴백한다(has-status면 "아직 모름", no-status-concept이면 "상태 없음" — renderEntityStatusLabel이
    * entityType으로 그 둘을 이미 가른다). */
   entityStatus?: EntityStatusFetchState;
-}) {
+} & VariantProps<typeof entityChipLabelVariants>) {
   const [showModal, setShowModal] = useState(false);
   const colorClass = ghost ? GRAY_STATE_COLOR : (ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR);
 
@@ -849,25 +868,49 @@ export function EntityChip({
   };
 
   const statusLabel = ghost ? null : renderEntityStatusLabel(entityType, localDocStatus ? { kind: 'resolved', raw: localDocStatus } : (entityStatus ?? { kind: 'loading' }));
+  // story #2886(S2b) — inline-meta는 기존 그대로 항상 펼침. inline(기본)은 인라인 메타를
+  // 감추고(격납) hover/focus tooltip으로만 낸다 — 산문 속 반복 전개 제거가 이 스토리의 요지.
+  const showInlineMeta = variant === 'inline-meta';
 
   const inner = (
     <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>
       <EntityGlyph Icon={resolveEntityIcon(entityType)} label={label} className="size-3 shrink-0" />
-      <span>{ghost ? '대상이 없습니다' : label}</span>
+      {/* AC3 — truncate된 라벨의 전체 텍스트를 title(native)로도 보장(가장 낮은 공통분모
+          접근성 폴백 — 아래 커스텀 tooltip과 별개, JS 없이도 동작). */}
+      <span className={entityChipLabelVariants({ variant })} title={ghost ? undefined : label}>
+        {ghost ? '대상이 없습니다' : label}
+      </span>
       {/* AC1 — 사실성(상수 "관찰됨": entity_references 자체가 관찰됨 tier) · 표면 · 지점.
-          ⛔색으로만 구분하지 않고 글자로 적는다(가디언 규율 재사용). */}
-      {referenceMeta ? (
+          ⛔색으로만 구분하지 않고 글자로 적는다(가디언 규율 재사용). inline-meta 변형에서만
+          항상 펼친다 — inline(기본)은 아래 tooltip으로 격납. */}
+      {showInlineMeta && referenceMeta ? (
         <span className="opacity-70">
           · 관찰됨 · {FORM_LABELS[referenceMeta.form] ?? referenceMeta.form} · {formatReferencePoint(referenceMeta.referencedAt)}
         </span>
       ) : null}
-      {statusLabel ? <span className="opacity-70">· {statusLabel}</span> : null}
+      {showInlineMeta && statusLabel ? <span className="opacity-70">· {statusLabel}</span> : null}
     </span>
   );
 
   if (ghost) {
     return <span className="inline-flex cursor-default no-underline">{inner}</span>;
   }
+
+  // story #2886(S2b) AC2 — 격납 메타(관찰됨·form·point·status)를 hover/focus tooltip으로.
+  // base-ui Tooltip은 hover+focus 둘 다 기본 지원(키보드 Tab으로 트리거에 도달 가능) — 별도
+  // 배선 불요. inline-meta 변형이거나 표시할 메타가 아예 없으면 tooltip을 안 씌운다(불필요한
+  // 빈 popover 방지).
+  const tooltipContent = !showInlineMeta && (referenceMeta || statusLabel) ? (
+    <div className="space-y-0.5">
+      <p className="font-medium">{label}</p>
+      {referenceMeta ? (
+        <p className="opacity-80">
+          관찰됨 · {FORM_LABELS[referenceMeta.form] ?? referenceMeta.form} · {formatReferencePoint(referenceMeta.referencedAt)}
+        </p>
+      ) : null}
+      {statusLabel ? <p className="opacity-80">{statusLabel}</p> : null}
+    </div>
+  ) : null;
 
   if (entityId) {
     // story #2669(B2) — "쓰던 자리에 이미 있어야 한다": 모달을 열지 않고도 칩 자체에 상태별
@@ -893,15 +936,22 @@ export function EntityChip({
         </Link>
       ) : null
     ) : null;
+    const triggerButtonProps = {
+      type: 'button' as const,
+      onClick: () => setShowModal(true),
+      className: 'inline-flex no-underline transition-opacity hover:opacity-80',
+    };
+    const chipButton = tooltipContent ? (
+      <Tooltip>
+        <TooltipTrigger render={<button {...triggerButtonProps} />}>{inner}</TooltipTrigger>
+        <TooltipContent side="top">{tooltipContent}</TooltipContent>
+      </Tooltip>
+    ) : (
+      <button {...triggerButtonProps}>{inner}</button>
+    );
     return (
       <span className="inline-flex flex-wrap items-center gap-1">
-        <button
-          type="button"
-          onClick={() => setShowModal(true)}
-          className="inline-flex no-underline transition-opacity hover:opacity-80"
-        >
-          {inner}
-        </button>
+        {chipButton}
         {docCta}
         {submitError ? <span className="text-xs text-destructive">상신 실패, 다시 시도해 주세요</span> : null}
         {showModal && (

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -900,15 +900,23 @@ export function EntityChip({
   // base-ui Tooltip은 hover+focus 둘 다 기본 지원(키보드 Tab으로 트리거에 도달 가능) — 별도
   // 배선 불요. inline-meta 변형이거나 표시할 메타가 아예 없으면 tooltip을 안 씌운다(불필요한
   // 빈 popover 방지).
+  // story #2886(S2b) — 유나군 하이파이 목업(S2b 칩 가독성 목업) 대조: 툴팁은 한 줄 문장이
+  // 아니라 라벨:값 행 구조(상태·참조 형태·관찰) — 목업의 「열기(side pane)」 버튼은 S2d(side
+  // pane 정형화) 스코프라 이번엔 제외한다(별도 CTA 배선 없음, 이 스토리 AC 밖).
+  const tooltipRow = (rowLabel: string, value: string) => (
+    <div className="flex items-baseline justify-between gap-4">
+      <span className="text-[10px] text-background/60">{rowLabel}</span>
+      <span className="font-medium">{value}</span>
+    </div>
+  );
   const tooltipContent = !showInlineMeta && (referenceMeta || statusLabel) ? (
-    <div className="space-y-0.5">
-      <p className="font-medium">{label}</p>
-      {referenceMeta ? (
-        <p className="opacity-80">
-          관찰됨 · {FORM_LABELS[referenceMeta.form] ?? referenceMeta.form} · {formatReferencePoint(referenceMeta.referencedAt)}
-        </p>
-      ) : null}
-      {statusLabel ? <p className="opacity-80">{statusLabel}</p> : null}
+    <div className="space-y-1">
+      <p className="font-semibold">{label}</p>
+      <div className="space-y-0.5 border-t border-background/20 pt-1">
+        {statusLabel ? tooltipRow('상태', statusLabel) : null}
+        {referenceMeta ? tooltipRow('참조 형태', FORM_LABELS[referenceMeta.form] ?? referenceMeta.form) : null}
+        {referenceMeta ? tooltipRow('관찰', formatReferencePoint(referenceMeta.referencedAt)) : null}
+      </div>
     </div>
   ) : null;
 

--- a/apps/web/src/components/chat/entity-chip.test.tsx
+++ b/apps/web/src/components/chat/entity-chip.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+//
+// story #2886(S2b) — 선생님 실증(전체 제목+메타 4항이 산문을 익사시킴)에 대한 처방 회귀가드.
+// default(inline) 변형은 짧은 라벨만 상시 표기하고, 격납 메타(관찰됨·form·point·status)는
+// hover/focus tooltip으로만 낸다. inline-meta 변형은 기존 전개 그대로(독립 표시용 escape hatch).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EntityChip } from './embed-card';
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => ({ projectMemberships: [] }),
+}));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: () => {} }) }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({}) })));
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+const LONG_LABEL = '이것은 아주 길고 상세한 스토리 제목으로 산문 속에서 문장을 익사시킬 수 있다';
+const META = { form: 'mention', referencedAt: '2026-07-26T00:00:00.000Z' };
+
+describe('EntityChip variant=inline(기본) — story #2886', () => {
+  it('긴 라벨은 truncate 클래스를 갖고, referenceMeta/status가 컨테이너 텍스트에 상시 노출되지 않는다', async () => {
+    await act(async () => {
+      root.render(<EntityChip entityType="story" entityId="s-1" label={LONG_LABEL} href={null} referenceMeta={META} />);
+    });
+    const labelSpan = Array.from(container.querySelectorAll('span')).filter((s) => s.textContent === LONG_LABEL).at(-1);
+    expect(labelSpan?.className).toContain('truncate');
+    expect(container.textContent).not.toContain('관찰됨');
+  });
+
+  it('트리거에 포커스를 주면 tooltip(portal)에 전체 라벨+관찰됨 메타가 뜬다', async () => {
+    await act(async () => {
+      root.render(<EntityChip entityType="story" entityId="s-1" label={LONG_LABEL} href={null} referenceMeta={META} />);
+    });
+    await act(async () => { container.querySelector('button')!.focus(); });
+    expect(document.body.textContent).toContain(LONG_LABEL);
+    expect(document.body.textContent).toContain('관찰됨');
+    expect(document.body.textContent).toContain('멘션');
+    expect(document.body.textContent).toContain('7/26');
+  });
+
+  it('격납할 메타가 없으면(referenceMeta·status 둘 다 無) tooltip을 안 씌운다', async () => {
+    await act(async () => {
+      root.render(<EntityChip entityType="story" entityId="s-1" label="짧은 제목" href={null} />);
+    });
+    const trigger = container.querySelector('button')!;
+    // base-ui Tooltip.Trigger는 aria-describedby 등 트리거 전용 속성을 부여한다 — 안 씌웠으면
+    // 순수 button 그대로.
+    expect(trigger.tagName).toBe('BUTTON');
+    await act(async () => { trigger.focus(); });
+    expect(document.body.textContent).not.toContain('관찰됨');
+  });
+
+  it('전체 라벨은 native title 속성으로도 보장된다(AC3 접근성 폴백)', async () => {
+    await act(async () => {
+      root.render(<EntityChip entityType="story" entityId="s-1" label={LONG_LABEL} href={null} />);
+    });
+    const labelSpan = Array.from(container.querySelectorAll('span')).filter((s) => s.textContent === LONG_LABEL).at(-1);
+    expect(labelSpan?.getAttribute('title')).toBe(LONG_LABEL);
+  });
+});
+
+describe('EntityChip variant=inline-meta — 기존 전개 그대로(escape hatch)', () => {
+  it('메타가 컨테이너 텍스트에 항상 인라인 표기된다(포커스 불요)', async () => {
+    await act(async () => {
+      root.render(<EntityChip entityType="story" entityId="s-1" label={LONG_LABEL} href={null} referenceMeta={META} variant="inline-meta" />);
+    });
+    expect(container.textContent).toContain('관찰됨');
+    expect(container.textContent).toContain('멘션');
+    expect(container.textContent).toContain('7/26');
+  });
+
+  it('라벨에 truncate 클래스가 없다(전체 제목 그대로)', async () => {
+    await act(async () => {
+      root.render(<EntityChip entityType="story" entityId="s-1" label={LONG_LABEL} href={null} variant="inline-meta" />);
+    });
+    const labelSpan = Array.from(container.querySelectorAll('span')).filter((s) => s.textContent === LONG_LABEL).at(-1);
+    expect(labelSpan?.className).not.toContain('truncate');
+  });
+});
+
+describe('EntityChip ghost — variant 무관 무동작 유지', () => {
+  it('ghost는 inline이든 inline-meta든 항상 "대상이 없습니다"·클릭 없음', async () => {
+    await act(async () => {
+      root.render(<EntityChip entityType="story" entityId="s-1" label={LONG_LABEL} href={null} ghost referenceMeta={META} />);
+    });
+    expect(container.textContent).toContain('대상이 없습니다');
+    expect(container.querySelector('button')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/entity-chip.test.tsx
+++ b/apps/web/src/components/chat/entity-chip.test.tsx
@@ -48,8 +48,10 @@ describe('EntityChip variant=inline(기본) — story #2886', () => {
     });
     await act(async () => { container.querySelector('button')!.focus(); });
     expect(document.body.textContent).toContain(LONG_LABEL);
-    expect(document.body.textContent).toContain('관찰됨');
+    // story #2886(S2b) — 유나군 하이파이 목업 대조: 툴팁은 라벨:값 행 구조(상태·참조 형태·관찰).
+    expect(document.body.textContent).toContain('참조 형태');
     expect(document.body.textContent).toContain('멘션');
+    expect(document.body.textContent).toContain('관찰');
     expect(document.body.textContent).toContain('7/26');
   });
 


### PR DESCRIPTION
## Summary
- 선생님 실증(2026-08-21): 채팅 엔티티 칩이 전체 제목+메타 4항(관찰됨·form·point·status)을 항상 인라인 전개해 산문을 익사시켰다.
- `EntityChip`에 cva `variant` 추가:
  - **`inline`(기본)** — 아이콘+짧은 라벨(`max-w-[14ch] truncate`)만 상시 표기. 격납 메타는 base-ui `Tooltip`(hover+focus 기본 지원, 키보드 도달 가능)으로만 노출. 전체 라벨은 native `title` 속성으로도 이중 보장.
  - **`inline-meta`** — 기존 전개 그대로(독립 표시용 escape hatch, 회귀 없음).
- 기존 결정 트리·doc CTA(결재로 올리기/결재함에서 보기)·ghost 렌더 완전 보존 — 칩 트리거 버튼 하나가 tooltip 트리거와 모달 오픈 버튼을 겸함(base-ui `render` prop 합성).
- `chat-bubble.tsx`의 `a` 핸들러는 별도 배선 없이 새 기본값을 자동 상속(채팅이 이 스토리의 핵심 타깃).

## Test plan
- [x] `pnpm type-check` — 그린
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — 그린
- [x] `pnpm exec vitest run` — 464 files / **3846 tests 전부 green**
  - `chat-bubble.test.tsx` 상태/메타 어서션 9건을 tooltip-aware(트리거 focus 후 `document.body` 확認)로 갱신 — 데이터 계산 로직 무변경, 노출 위치만 이동했음을 값으로 증명
  - `entity-chip.test.tsx` 신규 7건(truncate·tooltip 노출·inline-meta escape hatch·ghost 무동작)
- [x] 대비 CI 가드 4종 — 전부 AA 통과·신규 위반 0
- [ ] 라이브 픽셀(AC5, 선생님 실증 스크린샷 재현 케이스) — 유나군 하이파이 목업 병행 착지 후 대조

Story: [SID:2886] · S2b(UI 갈아엎기 시퀀스, 2888 SSOT 위에 얹힘)

🤖 Generated with [Claude Code](https://claude.com/claude-code)