### PR TITLE
[SID:2892] P0 — 결제 완료화면 미표시: Decimal 직렬화 500 + pending 구독 tier 침묵노출

### DIFF
--- a/backend/app/services/billing_charge_amount.py
+++ b/backend/app/services/billing_charge_amount.py
@@ -57,7 +57,13 @@ async def compute_pack_charge_minor(
     (current_period_start/end 미세팅 — #2502 갭) 집계 범위를 특정할 수 없으니 0."""
     if period_start is None or period_end is None:
         return 0
-    return (
+    # story #2892(P0, 실사고 2026-08-21) — Postgres SUM(bigint)은 SQL 표준상 numeric을
+    # 반환한다(컬럼 자체는 BigInteger인데도) — asyncpg가 그걸 Python Decimal로 디코드해,
+    # 이 값이 그대로 charge_org→TossAdapter.charge()의 JSON 바디까지 흘러 들어가 httpx의
+    # json.dumps가 "Object of type Decimal is not JSON serializable"로 500을 냈다(Toss
+    # API 호출 前 — 네트워크 왕복 자체가 안 나간 순수 인코딩 실패). 경계(DB→Python)를
+    # 넘는 즉시 명시 int 변환 — 이 함수의 반환 타입 힌트(-> int)가 실제로 참이 되게 한다.
+    result = (
         await session.execute(
             select(func.coalesce(func.sum(BillingLedgerEntry.amount_minor), 0)).where(
                 BillingLedgerEntry.org_id == org_id,
@@ -68,6 +74,7 @@ async def compute_pack_charge_minor(
             )
         )
     ).scalar_one()
+    return int(result)
 
 
 async def compute_charge_amount(session: AsyncSession, *, org_id: uuid.UUID) -> tuple[int, str]:

--- a/backend/app/services/payment/toss_adapter.py
+++ b/backend/app/services/payment/toss_adapter.py
@@ -130,13 +130,22 @@ class TossAdapter(PaymentProvider):
         규율을 강제하지 않는다 — 순수 PG 왕복 레이어).
 
         amount_minor: KRW는 무소수 통화라 minor unit이 곧 원 단위 정수 — Toss의 `amount`
-        필드에 그대로 넘긴다(달러처럼 /100 환산 불요)."""
+        필드에 그대로 넘긴다(달러처럼 /100 환산 불요).
+
+        ⚠️story #2892(P0, 실사고 2026-08-21) — 파이썬 타입힌트(`int`)는 런타임에 강제되지
+        않는다. 실제로 `compute_pack_charge_minor`(SQL `SUM(bigint)`가 Postgres 표준상
+        `numeric`을 반환 → asyncpg가 Decimal로 디코드)가 이 계약을 어기고 Decimal을 흘려
+        보내, httpx의 `json.dumps`가 "Object of type Decimal is not JSON serializable"로
+        Toss 네트워크 호출조차 못 나가고 500을 냈다(charge_org의 pending 청구 기록이
+        confirm 못 받고 영구 pending). 호출부(billing_charge_amount.py)에서도 고쳤지만,
+        이 어댑터가 PG로 나가는 «최종 경계»이므로 여기서도 한 번 더 강제 변환한다 —
+        미래의 다른 호출부가 같은 계약을 또 어겨도 이 함수를 지나는 순간 사고가 죽는다."""
         return await self._post(
             f"/v1/billing/{billing_key}",
             json={
                 "customerKey": customer_key,
                 "orderId": order_id,
-                "amount": amount_minor,
+                "amount": int(amount_minor),
                 "orderName": order_name,
             },
             timeout=65,  # Toss 문서: 최대 60초 소요 가능 — 여유 5초.
@@ -190,7 +199,8 @@ class TossAdapter(PaymentProvider):
         넘겨야 재시도가 중복 취소를 만들지 않는다."""
         body: dict[str, Any] = {"cancelReason": cancel_reason}
         if cancel_amount_minor is not None:
-            body["cancelAmount"] = cancel_amount_minor
+            # story #2892 — charge()와 동일 경계 방어(Decimal이 이 인자에도 흘러들 수 있음).
+            body["cancelAmount"] = int(cancel_amount_minor)
         return await self._post(
             f"/v1/payments/{payment_key}/cancel",
             json=body,

--- a/backend/ee/routers/billing.py
+++ b/backend/ee/routers/billing.py
@@ -82,12 +82,28 @@ async def get_billing_status(
             "can_manage": can_manage,
         }
 
+    # story #2892(P0, 실사고 2026-08-21) — org_subscription_checkout.py의 상태기계는
+    # "청구 성공 時에만 status='active' 전이"를 명시 계약으로 문서화해 뒀는데(그 파일
+    # 모듈 docstring §4), 이 엔드포인트는 그 계약을 안 보고 `tier`를 무조건 내보냈다.
+    # checkout claim UPSERT는 Toss 청구를 부르기 *전에* 이미 커밋된다(TOCTOU 방지를 위한
+    # 의도된 설계, org_subscription_checkout.py 참고) — 그래서 청구가 크래시/거절되면
+    # status='pending'인 채 새 tier 값이 이미 이 행에 앉아 있는 상태가 실존한다. 실사고:
+    # `TypeError: Decimal is not JSON serializable`(billing_charge_amount.py, 별도 fix)로
+    # Toss 호출 자체가 500으로 죽었는데, 이 엔드포인트가 status를 안 보고 tier='starter'를
+    # 그대로 내보내 "돈은 안 냈는데 플랜은 적용된 것처럼" 화면에 잡혔다(재로그인 후에도
+    # 재현 — 이 GET이 그 소스). status가 'active'가 아니면(pending·downgraded 등) 실제로
+    # 확定된 유료 권리가 없다 — tier를 'free'로 낸다(billing_cycle/current_period_end도
+    # 같이 무의미해지므로 None). status 필드 자체는 원값 그대로 실어(FE가 pending 상태를
+    # 구분해 "결제 진행/재시도 필요" 안내를 그릴 여지는 남긴다).
+    effective_tier = sub.tier if sub.status == "active" else "free"
     return {
         "org_id": str(org_id),
-        "tier": sub.tier,
-        "billing_cycle": sub.billing_cycle,
+        "tier": effective_tier,
+        "billing_cycle": sub.billing_cycle if sub.status == "active" else None,
         "status": sub.status,
-        "current_period_end": sub.current_period_end.isoformat() if sub.current_period_end else None,
+        "current_period_end": sub.current_period_end.isoformat() if (
+            sub.status == "active" and sub.current_period_end
+        ) else None,
         "can_manage": can_manage,
     }
 

--- a/backend/tests/test_2892_billing_charge_amount_decimal_realdb.py
+++ b/backend/tests/test_2892_billing_charge_amount_decimal_realdb.py
@@ -1,0 +1,145 @@
+"""story #2892(P0, 실사고 2026-08-21) — `compute_pack_charge_minor`가 Postgres
+`SUM(bigint)`(SQL 표준상 numeric 반환 → asyncpg가 Decimal로 디코드)를 그대로 반환하던
+결함. 반환 타입힌트는 `-> int`인데 실제로는 Decimal이 나와, 그 값이 `charge_org`→
+`TossAdapter.charge()`의 JSON 바디까지 흘러 들어가 httpx `json.dumps`가 "Object of type
+Decimal is not JSON serializable"로 500을 냈다(Toss 네트워크 호출 자체가 안 나간 순수
+인코딩 실패 — dev 실 Cloud Logging 08:18:04Z 확認).
+
+이 테스트는 실제 SUM 집계가 일어나는 경로(billing_ledger_entries에 pack_purchase 2건
+이상 INSERT 후 합산)로 재현한다 — 단건/0건 케이스는 Python 레벨 `+ 0` 등으로 우연히
+int가 나올 수 있어 버그를 못 잡는다(SUM 자체가 진짜로 도는 경로가 필요)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_and_ledger(session) -> tuple[uuid.UUID, uuid.UUID, datetime, datetime]:
+    from app.models.organization import Organization
+    from app.models.org_subscription import OrgSubscription
+    from app.models.billing_ledger_entry import BillingLedgerEntry
+
+    org = Organization(id=uuid.uuid4(), name="Org2892", slug=f"org2892-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+
+    # billing_ledger_entries.subscription_id는 org_subscriptions.id FK — 실제 행 필요.
+    subscription_id = uuid.uuid4()
+    session.add(OrgSubscription(
+        id=subscription_id, org_id=org.id, tier="starter", billing_cycle="monthly",
+        status="active", provider="toss", currency="krw",
+    ))
+    await session.flush()
+
+    period_start = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    period_end = period_start + timedelta(days=30)
+
+    # story #2892 재현 핵심 — 2건 이상(SUM이 진짜로 여러 행을 더하게).
+    for amount in (5000, 3000):
+        session.add(BillingLedgerEntry(
+            id=uuid.uuid4(), org_id=org.id, ts=period_start + timedelta(days=1),
+            entry_type="pack_purchase", amount_minor=amount, currency="krw",
+            direction="credit", subscription_id=subscription_id,
+        ))
+    await session.commit()
+    return org.id, subscription_id, period_start, period_end
+
+
+@pytest.mark.asyncio
+async def test_compute_pack_charge_minor_returns_native_int_not_decimal():
+    from app.services.billing_charge_amount import compute_pack_charge_minor
+    from decimal import Decimal
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, subscription_id, period_start, period_end = await _seed_org_and_ledger(s)
+
+        async with Session() as s:
+            result = await compute_pack_charge_minor(
+                s, org_id=org_id, subscription_id=subscription_id,
+                period_start=period_start, period_end=period_end,
+            )
+            assert result == 8000
+            assert type(result) is int, (
+                f"compute_pack_charge_minor가 {type(result)}를 반환함(Decimal이면 "
+                f"httpx json.dumps가 TossAdapter.charge() 호출 전에 TypeError로 죽는다 — "
+                f"#2892 실사고 재현)"
+            )
+            assert not isinstance(result, Decimal)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_compute_pack_charge_minor_zero_when_no_period():
+    from app.services.billing_charge_amount import compute_pack_charge_minor
+
+    engine, Session = await _session_factory()
+    try:
+        result = await compute_pack_charge_minor(
+            None, org_id=uuid.uuid4(), subscription_id=uuid.uuid4(),
+            period_start=None, period_end=None,
+        )
+        assert result == 0
+        assert type(result) is int
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_toss_adapter_charge_json_body_amount_is_native_int_even_given_decimal():
+    """어댑터 경계 방어(둘째 층) — 호출부가 실수로 Decimal을 넘겨도 charge()가 int로
+    강제 변환해 httpx json 인코딩이 죽지 않는다. 실 Toss 호출은 안 나가게 시크릿
+    미설정으로 그 전 단계(_auth_header)에서 명시 실패시켜 네트워크 접촉 0으로 검증."""
+    from decimal import Decimal
+    from app.services.payment.toss_adapter import TossAdapter
+    from app.core.config import settings
+
+    adapter = TossAdapter()
+    original_secret = settings.toss_payments_secret_key
+    settings.toss_payments_secret_key = ""
+    try:
+        with pytest.raises(RuntimeError, match="TOSS_PAYMENTS_SECRET_KEY"):
+            await adapter.charge(
+                billing_key="bk_test", customer_key="ck_test", order_id="ord_test",
+                amount_minor=Decimal("29000"), order_name="test",
+            )
+    finally:
+        settings.toss_payments_secret_key = original_secret

--- a/backend/tests/test_2892_billing_status_pending_hides_tier_realdb.py
+++ b/backend/tests/test_2892_billing_status_pending_hides_tier_realdb.py
@@ -1,0 +1,156 @@
+"""story #2892(P0, 실사고 2026-08-21) — `ee/routers/billing.py::get_billing_status`(FE
+`/api/billing/status` → `/api/v2/billing/status`, dev 실측: LICENSE_CONSENT=agreed로
+EE 모드 라이브)가 `org_subscriptions.status`를 안 보고 `tier`를 무조건 반환하던 결함.
+
+`org_subscription_checkout.py`의 상태기계는 "청구 성공 時에만 status='active' 전이"를
+이미 명시 계약으로 지키는데(모듈 docstring §4), 이 GET 엔드포인트가 그 계약을 무시해
+status='pending'(charge 실패·진행중)인 subscription도 tier를 그대로 노출했다 — 실사고:
+Decimal TypeError로 charge_org가 Toss 호출 前에 죽어 status='pending'인 채 tier='starter'
+가 org_subscriptions에 남았는데, 이 엔드포인트가 그걸 그대로 "지금 tier=starter"로
+보여줬다(재로그인해도 재현 — 이 GET이 그 소스, "결제 완료 화면 안 보이는데 요금제는
+적용된 것처럼 보인다"는 사용자 관측의 실제 원인)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _enable_ee(monkeypatch):
+    """dev 실측(2026-08-21, gcloud services describe) — LICENSE_CONSENT=agreed라 이
+    엔드포인트가 실제로 라이브다. 이 테스트는 그 상태를 그대로 재현(license_consent
+    문자열을 직접 patch — is_ee_enabled는 property라 이 값에서 파생)."""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "license_consent", "agreed")
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_with_member(session, *, sub_status: str, tier: str = "starter"):
+    from app.models.organization import Organization
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.org_subscription import OrgSubscription
+
+    org = Organization(id=uuid.uuid4(), name="Org2892Status", slug=f"org2892s-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+
+    user = User(id=uuid.uuid4(), email=f"u2892-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user.id, role="owner"))
+
+    now = datetime.now(timezone.utc)
+    session.add(OrgSubscription(
+        id=uuid.uuid4(), org_id=org.id, tier=tier, billing_cycle="monthly",
+        status=sub_status, provider="toss", currency="krw",
+        current_period_start=now, current_period_end=now + timedelta(days=30),
+    ))
+    await session.commit()
+    return org.id, user.id
+
+
+def _auth(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={})
+
+
+@pytest.mark.asyncio
+async def test_pending_subscription_reports_free_tier_not_the_unconfirmed_tier():
+    """#2892 실사고 정확 재현 — status='pending'인 채 tier='starter'가 앉아 있는 행."""
+    from ee.routers.billing import get_billing_status
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, user_id = await _seed_org_with_member(s, sub_status="pending", tier="starter")
+
+        async with Session() as s:
+            resp = await get_billing_status(
+                org_id=org_id, auth=_auth(user_id), session=s, _ee=None,
+            )
+            assert resp["tier"] == "free", (
+                f"status=pending인데 tier={resp['tier']!r}를 노출 — #2892 실사고 재현. "
+                f"청구 미확定 상태를 유료 tier로 보여주면 안 됨."
+            )
+            assert resp["status"] == "pending"
+            assert resp["billing_cycle"] is None
+            assert resp["current_period_end"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_active_subscription_reports_its_real_tier():
+    from ee.routers.billing import get_billing_status
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, user_id = await _seed_org_with_member(s, sub_status="active", tier="team")
+
+        async with Session() as s:
+            resp = await get_billing_status(
+                org_id=org_id, auth=_auth(user_id), session=s, _ee=None,
+            )
+            assert resp["tier"] == "team"
+            assert resp["status"] == "active"
+            assert resp["billing_cycle"] == "monthly"
+            assert resp["current_period_end"] is not None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_downgraded_subscription_also_reports_free_not_stale_tier():
+    """dunning 8일차 강제하향 후(billing_scheduler.py::downgrade_to_free)도 같은 원칙."""
+    from ee.routers.billing import get_billing_status
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, user_id = await _seed_org_with_member(s, sub_status="downgraded", tier="starter")
+
+        async with Session() as s:
+            resp = await get_billing_status(
+                org_id=org_id, auth=_auth(user_id), session=s, _ee=None,
+            )
+            assert resp["tier"] == "free"
+            assert resp["status"] == "downgraded"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2892_checkout_retry_supersedes_stale_pending_realdb.py
+++ b/backend/tests/test_2892_checkout_retry_supersedes_stale_pending_realdb.py
@@ -1,0 +1,131 @@
+"""story #2892(P0) — 페드루 판정(2026-08-21): org_subscriptions의 stale pending 잔재
+(charge 실패가 남긴 상태, 실사고 org에서 실측됨 — tier='starter'·status='pending'·
+checkout_claimed_at=NULL)를 raw SQL DELETE로 지우기 前에, **재시도가 코드 스스로 그
+행을 처리(supersede)하는지**를 먼저 실측하라는 지시. 이 테스트가 그 실측이다.
+
+재현 조건: 실사고 org와 동형인 stale pending 행(claim이 finally에서 이미 release돼
+checkout_claimed_at=NULL인 상태 — org_subscription_checkout.py의 claim UPSERT WHERE
+가드는 정확히 이 조건에서 새 claim을 허용한다)을 세팅해 두고 checkout_subscription()을
+그대로(issue_billing_key/charge_org만 모킹 — Toss 네트워크 미접촉) 재호출한다.
+
+결과가 ⓐ(CheckoutInProgress 없이 성공)면 raw SQL 불요(기존 pending 잔재는 재시도가
+자연히 덮어씀) — ⓑ(막힘)면 그게 진짜 제품 버그(재결제 불가)라 별도 fix 스토리 대상."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_with_stale_pending_subscription(session) -> uuid.UUID:
+    """실사고 org 실측 상태를 그대로 재현. offering_version(krw/starter)은 migration 0228이
+    이미 공유 시드해 뒀다(test_2777_admin_billing_realdb.py 경고와 동일 함정) — 새로
+    INSERT하면 uq_offering_versions_active_tier_currency 위반이라 기존 활성 행을 그대로
+    재사용(checkout_subscription() 자신도 이 SELECT로 offering을 찾으므로 실제 경로와 동일)."""
+    from sqlalchemy import select
+    from app.models.organization import Organization
+    from app.models.offering_version import OfferingVersion
+    from app.models.org_subscription import OrgSubscription
+
+    org = Organization(id=uuid.uuid4(), name="Org2892Retry", slug=f"org2892r-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+
+    offering_id = (await session.execute(
+        select(OfferingVersion.id).where(
+            OfferingVersion.tier == "starter", OfferingVersion.currency == "krw",
+            OfferingVersion.effective_to.is_(None),
+        )
+    )).scalar_one()
+
+    now = datetime.now(timezone.utc)
+    # 실사고 실측 그대로: tier=starter·status=pending·checkout_claimed_at=NULL(release됨).
+    sub = OrgSubscription(
+        id=uuid.uuid4(), org_id=org.id, tier="starter", billing_cycle="monthly",
+        status="pending", provider="toss", currency="krw", offering_version_id=offering_id,
+        current_period_start=now - timedelta(hours=1), current_period_end=now + timedelta(days=29),
+        checkout_claimed_at=None,
+    )
+    session.add(sub)
+    await session.commit()
+    return org.id
+
+
+@pytest.mark.asyncio
+async def test_retry_checkout_supersedes_stale_pending_row_without_blocking():
+    from app.services.org_subscription_checkout import checkout_subscription, CheckoutInProgress
+    from app.models.billing_order import BillingOrder
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org_with_stale_pending_subscription(s)
+
+        fake_order = BillingOrder(
+            id=uuid.uuid4(), org_id=org_id, order_id="fake-retry-order",
+            amount_minor=29000, currency="krw", status="confirmed",
+        )
+
+        async with Session() as s:
+            with patch(
+                "app.services.org_subscription_checkout.issue_billing_key", new=AsyncMock(return_value=None),
+            ), patch(
+                "app.services.org_subscription_checkout.charge_org", new=AsyncMock(return_value=fake_order),
+            ):
+                try:
+                    result = await checkout_subscription(
+                        s, org_id=org_id, auth_key="fake-auth-key-retry",
+                        tier="starter", billing_cycle="monthly",
+                    )
+                except CheckoutInProgress as exc:
+                    pytest.fail(
+                        f"ⓑ 확定 — stale pending 잔재가 재시도를 막았다(진짜 제품 버그, "
+                        f"raw SQL DELETE로 임시조치 후 별도 fix 스토리 필요): {exc}"
+                    )
+
+        # ⓐ 확定 — claim UPSERT가 stale pending 행을 그대로 덮어써 정상 진행됐고,
+        # charge_org가 confirmed를 반환했으니 status가 active로 승격돼야 한다(코드의
+        # 정공 설계 그대로 — 재시도가 스스로 치유).
+        assert result.status == "active", (
+            f"재시도가 claim은 통과했지만 최종 status가 active로 안 감(={result.status}) — "
+            f"claim CAS(checkout_claimed_at==now)가 예상과 다르게 동작했을 가능성"
+        )
+        assert result.tier == "starter"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
[SID:2892] P0(급) — 외부 테스터 실증·선생님 급전달

## 증상
카드결제·요금제 적용은 성공(재로그인 후 확認)인데 완료 화면이 안 보임.

## 근본 원인 2건(dev Cloud Logging 실측, 08:18Z)

### ①Decimal 직렬화 — Toss 호출 자체가 못 나감
Postgres `SUM(bigint)`은 SQL 표준상 `numeric`을 반환(컬럼 자체는 BigInteger인데도) —
asyncpg가 Decimal로 디코드. `compute_pack_charge_minor()`가 그 값을 그대로 반환해(타입힌트
`-> int`는 거짓이었음) `charge_org`→`TossAdapter.charge()`의 JSON 바디까지 흘러 들어가
httpx `json.dumps`가 `TypeError: Object of type Decimal is not JSON serializable`로
500(Toss 네트워크 호출 前 순수 인코딩 실패 — 실 청구 시도조차 없었음).

처방(두 경계 모두 명시 `int` 변환 — json.dumps default 덧대기가 아니라 값의 타입을 경계에서
변환): `compute_pack_charge_minor` 반환 직전 + `TossAdapter.charge`/`refund` 어댑터 경계 둘 다.

### ②pending 구독의 tier가 status 확인 없이 그대로 노출
`org_subscription_checkout.py`의 claim UPSERT는 Toss 청구를 부르기 *전에* 커밋된다(TOCTOU
방지 의도 설계) — 청구가 실패/크래시하면 `status='pending'`인 채 새 tier 값이 이미 행에
앉는다. 그 자체는 정공 설계(모듈 docstring: "청구 성공 時에만 active 전이")인데, **dev 실측:
FE `/api/billing/status`의 실 목적지는 `ee/routers/billing.py::get_billing_status`**(dev는
`LICENSE_CONSENT=agreed`로 EE 모드 라이브 — 관련 메모리 정정 완료)였고, 이 엔드포인트가
`status`를 안 보고 `tier`를 무조건 반환해 "결제 안 됐는데 플랜 적용된 것처럼" 노출됐다.

처방: `status != 'active'`면 `tier='free'`(billing_cycle/current_period_end도 함께 숨김) —
`status` 필드 자체는 그대로 실어 FE가 pending 안내를 그릴 여지는 남김.

## 재시도 자가치유 확認(raw SQL DELETE 대신 실측 — PO 지시)
영향받은 테스트 org(`org_id=adfc74d3-...`) 상태를 그대로 재현한 realdb 테스트로 확認 — claim
UPSERT WHERE 가드(`checkout_claimed_at IS NULL`)가 stale pending 잔재를 자연히 덮어써 재시도가
막히지 않는다(ⓐ 확定). raw SQL 불요 — 이 fix 배포 후 그 org가 재시도하면 코드가 스스로
치유한다. `billing_orders`의 pending 행은 감사흔적으로 유지(PO 동의).

## 테스트 7건(realdb)
- `compute_pack_charge_minor`가 진짜 SUM 경로(2건 합산)에서 native int 반환(Decimal 아님).
- `TossAdapter.charge()`가 Decimal 인자를 받아도 int로 강제 변환(둘째 방어선).
- `get_billing_status`: pending/downgraded→tier=free, active→실 tier(3분기 모두 확認).
- 재시도가 stale pending 잔재를 막힘 없이 supersede.

Decimal 캐스트·상태게이트 둘 다 코드에서 임시 제거→정확히 실사고와 같은 증상으로 재현
확認→복원 — 하중 증명. `billing`/`checkout`/`toss`/`subscription` 키워드 195건 회귀 없음.

## Test plan
- [x] realdb 신규 테스트 7건 — 2개 핵심 방어축 revert→재현→복원으로 하중 증명
- [x] 재시도 자가치유 실측(ⓐ 확定) — raw SQL DELETE 불필요
- [x] billing/checkout/toss/subscription 회귀 스윕 195건 통과
- [ ] CI green
- [ ] FE `checkoutErrorBanner` 실픽셀 렌더 확認(코드 로직상으론 존재 — 라이브 재현 시 눈으로 확認 필요, 별도 후속)