### PR TITLE
[SID:2889] S2h①③ — gate/pull_request/member TARGET_ONLY 등록 + backlinks 확장

### DIFF
--- a/apps/web/src/app/api/gates/[id]/backlinks/route.ts
+++ b/apps/web/src/app/api/gates/[id]/backlinks/route.ts
@@ -1,0 +1,25 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors, type ApiMeta } from '@/lib/api-response';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** GET /api/gates/{id}/backlinks — story #2889(S2h①): stories/docs/visual-artifacts
+ * 형제(list_entity_backlinks 공용 함수·convention-A {data,meta} shape)와 동형으로 짓는다
+ * (raw json.data ?? json 언랩, #2247/#2564 이중포장 재발 방지). */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getOrgProjectAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/gates/[id]/backlinks', { id });
+    if (!_r.ok) return _r;
+    const beJson = await _r.json() as { data?: unknown; meta?: ApiMeta };
+    return apiSuccess(beJson.data ?? beJson, beJson.meta);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/app/api/pull-requests/[id]/backlinks/route.ts
+++ b/apps/web/src/app/api/pull-requests/[id]/backlinks/route.ts
@@ -1,0 +1,30 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors, type ApiMeta } from '@/lib/api-response';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** GET /api/pull-requests/{id}/backlinks — story #2889(S2h①). `id`는 GitHub PR 자체가
+ * 아니라 canonical 링크 행(PullRequestStoryLink.id) — BE 실경로는
+ * `/api/v2/integrations/github/links/{id}/backlinks`(github_integration.py, PR-story
+ * 링크 도메인에 이미 있는 라우터 재사용, 신규 top-level 리소스 발명 아님). 세그먼트 이름은
+ * FE `ENTITY_ROUTE_SEGMENT` 맵의 편의상 별칭일 뿐 — stories/docs 형제와 동일 convention-A
+ * {data,meta} shape로 언랩한다(#2247/#2564 이중포장 재발 방지). */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getOrgProjectAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const _r = await proxyToFastapiWithParams(
+      request, '/api/v2/integrations/github/links/[id]/backlinks', { id },
+    );
+    if (!_r.ok) return _r;
+    const beJson = await _r.json() as { data?: unknown; meta?: ApiMeta };
+    return apiSuccess(beJson.data ?? beJson, beJson.meta);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/shared/entity-backlinks-section.tsx
+++ b/apps/web/src/components/shared/entity-backlinks-section.tsx
@@ -85,6 +85,13 @@ const ENTITY_ROUTE_SEGMENT = {
   story: 'stories',
   doc: 'docs',
   artifact: 'visual-artifacts',
+  // story #2889(S2h①, 페드루 확定 2026-08-21) — BE BACKLINKS_ALLOWED_TARGET_TYPES와 집합
+  // 파리티(entity-backlinks-section.route-map.test.ts가 코드스캔으로 고정). gate/
+  // pull_request는 아직 상세 라우트 소비처가 없다(미르코 S2d gate 프리뷰 side-pane 축과
+  // 어긋나지 않게 좁게: 이 맵은 fetch 세그먼트일 뿐 화면 링크 목적지가 아니다) — 프록시
+  // route.ts만 신설(app/api/gates/[id]/backlinks, app/api/pull-requests/[id]/backlinks).
+  gate: 'gates',
+  pull_request: 'pull-requests',
 } as const satisfies Record<string, string>;
 
 export type BacklinksEntityType = keyof typeof ENTITY_ROUTE_SEGMENT;

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2399,9 +2399,16 @@ async def send_message(
     # 예외가 그대로 propagate 되어 메시지 전송 전체가 롤백된다(AC4 원자성 — 아래 best-effort 블록들과
     # 의도적으로 다른 격리 수준).
     from app.services.mention_parser import insert_chat_mentions
+    # story #2889(S2h③, 페드루 확定 2026-08-21): gate/pull_request/member는 TARGET_ONLY_TYPES
+    # (완전지원 ENTITY_RESOLVERS 아님)라 insert_chat_mentions의 기본 target_types(=ENTITY_
+    # RESOLVERS만)엔 안 잡힌다 — "존재판정+멘션 자동감지"까지가 이 세 타입의 계약(reference_
+    # registry.py 참고)이라 여기서 명시로 넓힌다. chat_message는 안 넣는다(자기 자신을
+    # @멘션하는 토큰은 의미가 없음 — proof form의 별도 경로로만 채팅 메시지를 인용한다).
+    from app.services.reference_registry import ENTITY_RESOLVERS
     mention_result = await insert_chat_mentions(
         db, org_id=org_id, message_id=msg.id, content=msg.content, created_by=sender.id,
         auto_story_ids=frozenset(_auto_story_ids),
+        target_types=frozenset(ENTITY_RESOLVERS) | {"gate", "pull_request", "member"},
     )
 
     # E-STORAGE-SSOT S2: 첨부를 asset registry로 동기화(SAVE-time·같은 트랜잭션·orphan 0).

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1013,6 +1013,46 @@ async def get_gate_endpoint(
     return resp
 
 
+@router.get("/{id}/backlinks")
+async def get_gate_backlinks(
+    id: uuid.UUID,
+    limit: int = Query(default=30, ge=1, le=200),
+    before: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> dict:
+    """GET /api/v2/gates/{id}/backlinks — story #2889(S2h①) — 이 gate를 언급한 chat_message
+    목록(stories.py::get_story_backlinks와 동일 convention — cursor pagination, 응답
+    `{"data": [...], "meta": {"next_cursor", "has_more"}}`). 실 쿼리는
+    `list_entity_backlinks`(target_type만 다름, 재구현 0).
+
+    TARGET 게이트는 get_gate_endpoint와 동일(resolve_work_item_project_id — story #1968
+    SSOT 재사용 — + is_known_project_agnostic_work_item_type fail-closed 분기, 새 인증
+    미발명). gate 자체가 org에 없거나(취소·타org) work_item project 접근권이 없으면 404
+    (존재 비노출 — get_gate_endpoint와 동형)."""
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise HTTPException(status_code=404, detail="Gate not found")
+
+    project_id = await resolve_work_item_project_id(
+        session, org_id, gate.work_item_type, gate.work_item_id,
+    )
+    if project_id is not None:
+        await require_project_access(session, uuid.UUID(auth.user_id), project_id, org_id,
+                                      not_found_detail="Gate not found")
+    elif not is_known_project_agnostic_work_item_type(gate.work_item_type):
+        raise HTTPException(status_code=404, detail="Gate not found")
+
+    from app.services.backlinks import list_entity_backlinks
+    return await list_entity_backlinks(
+        session, org_id=org_id, target_type="gate", target_id=id,
+        auth=auth, limit=limit, cursor=before,
+    )
+
+
 class GateGithubCheckEventResponse(BaseModel):
     """story #2815(§5-②, 미르코군 계약 제안) — `gate_github_check_event`(0262) raw 원장 뷰.
     org_id/gate_id/story_id는 생략(이미 URL의 `{id}`가 gate 컨텍스트를 특정 — 중복 노출 불요)."""

--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse, RedirectResponse
 from jose import jwt
 from pydantic import BaseModel
@@ -314,3 +314,44 @@ async def delete_link(
     link.deleted_at = datetime.now(timezone.utc)
     await session.commit()
     return JSONResponse(content={"deleted": True, "id": str(link_id)})
+
+
+@router.get("/links/{link_id}/backlinks")
+async def get_pr_link_backlinks(
+    link_id: uuid.UUID,
+    limit: int = Query(default=30, ge=1, le=200),
+    before: str | None = Query(default=None),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> dict:
+    """GET /api/v2/integrations/github/links/{link_id}/backlinks — story #2889(S2h①) — 이
+    PR을 언급한 chat_message 목록(stories.py::get_story_backlinks와 동일 convention). TARGET
+    게이트는 delete_link와 동일(link.id+org_id+미삭제 선조회 → story_id 경유 project 접근권
+    — SEC-S8 Z와 동형 패턴, 새 게이트 미발명). 무권한/미존재는 generic 404(존재 비노출)."""
+    from app.services.backlinks import list_entity_backlinks
+    from app.services.project_auth import has_project_access
+
+    link = (
+        await session.execute(
+            select(PullRequestStoryLink).where(
+                PullRequestStoryLink.id == link_id,
+                PullRequestStoryLink.org_id == org_id,
+                PullRequestStoryLink.deleted_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if link is None:
+        raise HTTPException(status_code=404, detail="PR link not found")
+    story_project_id = (
+        await session.execute(select(Story.project_id).where(Story.id == link.story_id))
+    ).scalar_one_or_none()
+    if story_project_id is None or not await has_project_access(
+        session, uuid.UUID(auth.user_id), story_project_id, org_id
+    ):
+        raise HTTPException(status_code=404, detail="PR link not found")
+
+    return await list_entity_backlinks(
+        session, org_id=org_id, target_type="pull_request", target_id=link_id,
+        auth=auth, limit=limit, cursor=before,
+    )

--- a/backend/app/services/backlinks.py
+++ b/backend/app/services/backlinks.py
@@ -267,7 +267,7 @@ async def _chat_predicate_inputs(
 # 구멍»이 생긴다 — 이 함수는 TARGET 접근 검증을 스스로 하지 않고(§8①) 호출부(라우터)가
 # 이미 검증했다는 전제로 짜여 있기 때문(위 docstring 참조). 그래서 "이 타입은 호출부가 실제로
 # 게이트를 세웠다"를 이 allowlist가 보증한다 — 코드 레벨 계약이지 편의 목록이 아니다.
-BACKLINKS_ALLOWED_TARGET_TYPES = frozenset({"doc", "story", "artifact"})
+BACKLINKS_ALLOWED_TARGET_TYPES = frozenset({"doc", "story", "artifact", "gate", "pull_request"})
 # ⛔registry(reference_registry.ENTITY_RESOLVERS)의 나머지 타입(epic 등)이 여기 없는 이유는
 # "의도적 제외"가 아니라 **게이트 미비**다 — 그 타입들의 라우터에 아직 이 함수와 동형인
 # TARGET project-access 선-게이트(docs.py._require_doc_project_access ·
@@ -277,6 +277,13 @@ BACKLINKS_ALLOWED_TARGET_TYPES = frozenset({"doc", "story", "artifact"})
 # 새 게이트 발명 0. WRITE(entity_references에 target_type=artifact 저장)는 reference_registry.
 # ENTITY_RESOLVERS에 이미 등재돼 실측 확認됨(그라운딩) — 이 스토리는 READ(backlinks 조회)
 # 축만 연다.
+# story #2889(S2h①, 페드루 확定 2026-08-21) — gate·pull_request 추가. WRITE 측 등록은
+# reference_registry.ENTITY_RESOLVERS(완전지원)가 아니라 TARGET_ONLY_TYPES다(검색 handler 등
+# 나머지 계약이 안 서는 이유는 reference_registry.py의 _resolve_gates/_resolve_pull_requests
+# docstring 참고) — 이 함수는 완전지원과 무관하게 TARGET 접근이 «호출 라우터가 이미 검증»
+# 했다는 계약만 요구하므로(위 §8① 불변식) TARGET_ONLY 타입도 문제없이 연다. TARGET 게이트는
+# gates.py::get_gate_backlinks(resolve_work_item_project_id 재사용)·github_integration.py::
+# get_pr_link_backlinks(delete_link과 동일 게이트) 신규.
 
 
 class UnsupportedBacklinkTargetTypeError(ValueError):
@@ -293,10 +300,16 @@ class UnsupportedBacklinkTargetTypeError(ValueError):
 
 
 # ⛔story #2277(E-CONNECT) target_type → model — count_zero_referenced_entities 전용.
-# BACKLINKS_ALLOWED_TARGET_TYPES와 반드시 같은 키 집합이어야 한다(AC1: "#2266이 세운 허용
-# 목록과 같은 목록을 쓴다, 별도 목록을 만들지 않는다") — 이 dict의 키를 늘릴 땐 반드시
-# BACKLINKS_ALLOWED_TARGET_TYPES도 같이 늘어 있어야 한다(파생이 아니라 하드코딩인 이유: model
-# 클래스 자체는 registry가 담을 수 없는 타입정보라 여기 한 곳에만 둔다).
+# 이 dict의 키를 늘릴 땐 반드시 BACKLINKS_ALLOWED_TARGET_TYPES도 같이 늘어 있어야 한다
+# (파생이 아니라 하드코딩인 이유: model 클래스 자체는 registry가 담을 수 없는 타입정보라
+# 여기 한 곳에만 둔다) — 이 방향의 부분집합 관계만 요구된다(하위 ⊆ 상위), **역방향은 아니다**.
+# story #2889(S2h①, 2026-08-21): gate·pull_request는 BACKLINKS_ALLOWED_TARGET_TYPES엔
+# 있지만 여기 의도적으로 없다 — ①Gate엔 soft-delete 컬럼 자체가 없어(gate.py, 상태기계
+# row는 절대 안 지워짐) 아래 루프의 `model.deleted_at.is_(None)` 필터가 AttributeError로
+# 죽는다 ②"고아 참조" 감사(story #2277 원 취지)는 자유텍스트 제목이 있는 doc/story류에
+# 의미 있는 지표이지, gate/PR(제목 없는 상태 레코드)엔 적용 대상이 아니다(감사할 "미언급"
+# 개념 자체가 어색). BACKLINKS_ALLOWED_TARGET_TYPES 확장의 실 목적(chat 임베드 역참조 조회)은
+# _ZERO_REF_MODELS와 무관하게 이미 충족된다.
 _ZERO_REF_MODELS: dict[str, type] = {"doc": Doc, "story": Story, "artifact": VisualArtifact}
 
 

--- a/backend/app/services/backlinks.py
+++ b/backend/app/services/backlinks.py
@@ -317,8 +317,12 @@ async def count_zero_referenced_entities(
     session: AsyncSession, org_id: uuid.UUID | None = None,
 ) -> dict[str, int]:
     """story #2277 AC1/AC2 — target_type별로 "가리키는 참조가 0건"인 엔티티 수를 센다.
-    대상 타입은 #2266이 세운 `BACKLINKS_ALLOWED_TARGET_TYPES`(doc·story)와 동일 허용목록만
-    쓴다(AC1 — 별도 목록을 새로 만들지 않는다). org_id=None(기본)이면 전체 org 스코프.
+    대상 타입은 `_ZERO_REF_MODELS`의 키만 순회한다(`BACKLINKS_ALLOWED_TARGET_TYPES`의
+    부분집합 — 위 클래스 주석 참조). ⛔story #2889 카디르 CRITICAL(2026-08-21): 이전엔
+    `BACKLINKS_ALLOWED_TARGET_TYPES`를 직접 순회해 gate/pull_request 추가 시
+    `_ZERO_REF_MODELS[target_type]`가 KeyError로 죽었다(cron이 부르는 실경로, 3중 재현) —
+    부분집합 쪽을 순회 기준으로 삼아 구조적으로 재발을 막는다. org_id=None(기본)이면
+    전체 org 스코프.
 
     ⛔AC2 후속(PO 정정, 2026-07-29): 이 함수가 세는 수는 「고아」가 아니라 「이 항목을 가리키는
     mention/embed/proof 참조가 entity_references에 0건」이라는 사실뿐이다 — `entity_references`
@@ -327,7 +331,7 @@ async def count_zero_referenced_entities(
     `count_entity_references_total`(아래)도 같이 불러 분모를 나란히 실어야 한다(cron endpoint
     참조) — 절대값만 단독으로 보고하지 않는다."""
     counts: dict[str, int] = {}
-    for target_type in sorted(BACKLINKS_ALLOWED_TARGET_TYPES):
+    for target_type in sorted(_ZERO_REF_MODELS):
         model = _ZERO_REF_MODELS[target_type]
         stmt = (
             select(func.count())

--- a/backend/app/services/mention_parser.py
+++ b/backend/app/services/mention_parser.py
@@ -94,8 +94,14 @@ _UUID_RE = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-f
 # 안 된) `]`에서만 멈춘다. `build_reference_token`(reference_token.py)이 title을
 # backslash-escape하는 것과 **짝**이다 — 한쪽만 고치면(escape만 하고 파서는 그대로) 여전히
 # 안 열린다는 것을 실측으로 확인했다.
+# story #2889(S2h①③) — `[a-z]+`는 언더스코어를 모른다. TARGET_ONLY_TYPES에 새로 편입된
+# `pull_request`(reference_registry.py)가 정확히 이 모양이라, 이 클래스를 안 넓히면 그
+# 타입의 채팅 멘션은 토큰이 «모양은 맞는데» 정규식이 애초에 매치를 못해 항상 0건으로
+# 조용히 죽는다(chat_message도 언더스코어가 있지만 그 타입은 채팅 본문 토큰 경로로
+# 쓰이지 않아 — proof form 별도 경로 — 지금까지 이 구멍이 안 드러났을 뿐). `[a-z_]+`로
+# 넓혀 두 정규식(아래 SHAPE_RE도 동일 근거) 다 대비한다.
 _CHAT_TOKEN_RE = re.compile(
-    r"\[(?:[^\]\\]|\\.)*\]\(entity:(?P<type>[a-z]+):(?P<id>" + _UUID_RE + r")\)"
+    r"\[(?:[^\]\\]|\\.)*\]\(entity:(?P<type>[a-z_]+):(?P<id>" + _UUID_RE + r")\)"
 )
 
 
@@ -161,7 +167,7 @@ def extract_chat_entity_mentions(content: str) -> list[tuple[str, uuid.UUID]]:
 # 이유: 코어는 이미 파싱된 `extracted_refs`만 받는 계약이라(#2301) 애초에 추출조차 안 된
 # 토큰은 코어의 시야 밖 — #2301의 "얇은 변환" 원칙 위반이 아니라 코어가 볼 수 없는 축이다.
 _CHAT_TOKEN_SHAPE_RE = re.compile(
-    r"\[(?:[^\]\\]|\\.)*\]\(entity:(?P<type>[a-z]+):(?P<id>[^)]*)\)"
+    r"\[(?:[^\]\\]|\\.)*\]\(entity:(?P<type>[a-z_]+):(?P<id>[^)]*)\)"
 )
 
 

--- a/backend/app/services/reference_registry.py
+++ b/backend/app/services/reference_registry.py
@@ -158,6 +158,56 @@ async def _resolve_chat_messages(session: AsyncSession, org_id: uuid.UUID, ids: 
     return set(rows)
 
 
+async def _resolve_gates(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    """story #2889(S2h③, 페드루 확定 2026-08-21) — gate는 자유텍스트 제목이 없는(상태기계
+    레코드) 엔티티라 검색 picker UX 자체가 자연스럽지 않고, project 스코프도 work_item_type별
+    8갈래 분기(resolve_work_item_project_id)라 «완전지원» 다섯 계약(특히 검색 핸들러)을 여는
+    비용이 실효 없다 — chat_message와 동형으로 TARGET_ONLY(존재판정+backlinks+멘션 자동감지만).
+    Gate엔 soft-delete 컬럼이 없다(상태기계 row는 절대 안 지워짐, gate.py 참조) — row 존재
+    자체가 존재판정."""
+    from app.models.gate import Gate
+
+    rows = (
+        await session.execute(select(Gate.id).where(Gate.org_id == org_id, Gate.id.in_(ids)))
+    ).scalars().all()
+    return set(rows)
+
+
+async def _resolve_pull_requests(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    """story #2889(S2h③) — "PR" target_id는 GitHub PR 자체(uuid 없음)가 아니라 그 canonical
+    링크 행(`PullRequestStoryLink.id`, repo_full_name+pr_number+story_id를 담는 이 시스템의
+    PR 표현) — gate와 동일 이유(제목 없음·검색 UX 부자연)로 TARGET_ONLY."""
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    rows = (
+        await session.execute(
+            select(PullRequestStoryLink.id).where(
+                PullRequestStoryLink.org_id == org_id, PullRequestStoryLink.id.in_(ids),
+                PullRequestStoryLink.deleted_at.is_(None),
+            )
+        )
+    ).scalars().all()
+    return set(rows)
+
+
+async def _resolve_members(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
+    """story #2889(S2h③) — member는 org-scoped 신원 참조라 project 축이 구조적으로 없다
+    (한 member가 여러 project에 동시 소속 가능) — PROJECT_ID_RESOLVERS가 요구하는 "정확히
+    하나의 project_id"를 낼 수 없어 완전지원(ENTITY_RESOLVERS) 등록이 아예 성립하지 않는다
+    (등록하면 POST /references가 target_project_id=None을 항상 404로 거부해 명시 생성이
+    구조적으로 막힘). chat_message·meeting과 동형 TARGET_ONLY — 존재판정+멘션 자동감지만."""
+    from app.models.member import Member
+
+    rows = (
+        await session.execute(
+            select(Member.id).where(
+                Member.org_id == org_id, Member.id.in_(ids), Member.deleted_at.is_(None),
+            )
+        )
+    ).scalars().all()
+    return set(rows)
+
+
 async def _resolve_evidence(session: AsyncSession, org_id: uuid.UUID, ids: list[uuid.UUID]) -> set[uuid.UUID]:
     from app.models.evidence import Evidence
 
@@ -209,7 +259,11 @@ SOURCE_ONLY_TYPES: frozenset[str] = frozenset({"chat_message", "meeting"})
 # 없다(conversations.py의 메시지 라우트 4개 전부 conversation_id를 path에 요구). 위
 # SOURCE_ONLY_TYPES와 겹치는 멤버(chat_message)가 있는 것은 정상이다 — source 자격과
 # target 자격은 독립된 두 질문이다.
-TARGET_ONLY_TYPES: frozenset[str] = frozenset({"chat_message"})
+# ⛔story #2889(S2h③, 페드루 확定 2026-08-21): gate·pull_request·member 3종 추가 —
+# chat_message/meeting과 동일 판정 사유("자유텍스트 제목 없음" 또는 "project 축 구조적 부재"
+# → 검색 handler·PROJECT_ID_RESOLVERS 계약이 성립 불가). 채팅 임베드 용도(존재판정+backlinks
+# 역참조+멘션 자동감지)엔 TARGET_ONLY로 충분 — 검색 picker가 실증되면 그때 별도 스토리로 승격.
+TARGET_ONLY_TYPES: frozenset[str] = frozenset({"chat_message", "gate", "pull_request", "member"})
 
 # TARGET_ONLY_TYPES 멤버의 존재판정 resolver. ENTITY_RESOLVERS와 분리된 이유는 위와 동일 —
 # 이 dict에 들어간다고 검색/MCP/project축 계약까지 진 것으로 오인되면 안 된다.
@@ -220,6 +274,9 @@ TARGET_ONLY_TYPES: frozenset[str] = frozenset({"chat_message"})
 #     13건이 깨진다(2026-07-29 실측). 「왜 여기만 따로지?」로 되돌리지 말 것.
 TARGET_ONLY_RESOLVERS: dict[str, EntityExistsResolver] = {
     "chat_message": _resolve_chat_messages,
+    "gate": _resolve_gates,
+    "pull_request": _resolve_pull_requests,
+    "member": _resolve_members,
 }
 
 

--- a/backend/tests/test_2266_story_backlinks_realdb.py
+++ b/backend/tests/test_2266_story_backlinks_realdb.py
@@ -191,22 +191,48 @@ async def test_list_entity_backlinks_rejects_unsupported_target_type():
 
 @pytest.mark.anyio
 async def test_backlinks_allowlist_contains_exactly_doc_and_story():
-    """story #2721(2026-08-17)이 artifact를 추가 — 허용목록은 정확히 {doc, story, artifact}뿐
-    (다음 판이 늘리기 전까지 고정, 함수명은 이력 보존을 위해 유지)."""
+    """story #2889(2026-08-21)가 gate·pull_request를 추가 — 허용목록은 정확히
+    {doc, story, artifact, gate, pull_request}뿐(다음 판이 늘리기 전까지 고정, 함수명은
+    이력 보존을 위해 유지)."""
     from app.services.backlinks import BACKLINKS_ALLOWED_TARGET_TYPES
-    assert BACKLINKS_ALLOWED_TARGET_TYPES == frozenset({"doc", "story", "artifact"})
+    assert BACKLINKS_ALLOWED_TARGET_TYPES == frozenset(
+        {"doc", "story", "artifact", "gate", "pull_request"}
+    )
 
 
-def test_zero_ref_models_key_set_matches_allowlist():
-    """story #2721 — backlinks.py 자기 주석("_ZERO_REF_MODELS의 키를 늘릴 땐 반드시
-    BACKLINKS_ALLOWED_TARGET_TYPES도 같이 늘어야 한다")이 지금까지 코드로 강제된 적이 없었다
-    (grep 확認 — 이 테스트가 최초). count_zero_referenced_entities()가 `_ZERO_REF_MODELS
-    [target_type]`을 BACKLINKS_ALLOWED_TARGET_TYPES 전체에 대해 순회하므로, 두 집합이 어긋나면
-    한쪽만 늘어도 조용히 넘어가는 게 아니라 **KeyError로 즉시 죽는다**(런타임 크래시 —
-    다음 사람이 한쪽만 고치면 이 함수가 다음 cron 실행에서 바로 터진다) — 그 자리를 이 테스트가
-    push 前에 잡는다."""
+def test_zero_ref_models_key_set_is_subset_of_allowlist():
+    """⛔story #2889 카디르 CRITICAL(2026-08-21, cron 3중 재현) — 이 테스트는 원래 «동일
+    집합»을 요구했으나 그 전제 자체가 count_zero_referenced_entities()의 순회 버그였다:
+    함수가 `BACKLINKS_ALLOWED_TARGET_TYPES` 전체를 돌며 `_ZERO_REF_MODELS[target_type]`를
+    찾아, gate/pull_request처럼 허용목록에만 있고 `_ZERO_REF_MODELS`엔 없는(의도적 제외 —
+    backlinks.py 클래스 주석 참고) 타입에서 KeyError로 죽었다. 정정: 함수는 이제
+    `_ZERO_REF_MODELS`(부분집합) 쪽을 순회 기준으로 삼는다 — 두 집합은 «동일»이 아니라
+    **`_ZERO_REF_MODELS` ⊆ `BACKLINKS_ALLOWED_TARGET_TYPES`**만 요구된다(역방향은 아님,
+    backlinks.py 자신의 주석과 정합). 이 부등식이 깨지면(즉 `_ZERO_REF_MODELS`에 허용목록
+    밖 유령 타입이 들어가면) 그건 여전히 실제 결함이라 여기서 잡는다."""
     from app.services.backlinks import _ZERO_REF_MODELS, BACKLINKS_ALLOWED_TARGET_TYPES
-    assert set(_ZERO_REF_MODELS) == BACKLINKS_ALLOWED_TARGET_TYPES
+    assert set(_ZERO_REF_MODELS) <= BACKLINKS_ALLOWED_TARGET_TYPES
+
+
+@pytest.mark.anyio
+async def test_count_zero_referenced_entities_does_not_crash_with_gate_and_pull_request_in_allowlist():
+    """⛔story #2889 카디르 CRITICAL 회귀 가드 — 위 pin 테스트는 집합 «관계»만 재는 정적
+    테스트라, 실제로 `count_zero_referenced_entities()`를 호출하는 런타임 경로(cron이
+    부르는 그 경로, app/routers/cron.py의 zero-referenced 엔드포인트)는 아무도 실행해
+    본 적이 없었다 — 그래서 KeyError가 3번 재현될 때까지 안 잡혔다. 이 테스트는 실PG로
+    직접 호출해 그 경로 자체가 죽지 않는지 증명한다(gate/pull_request가 결과 dict에
+    없어야 한다는 것도 같이 확認 — _ZERO_REF_MODELS 기준 순회이므로)."""
+    from app.services.backlinks import count_zero_referenced_entities
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            result = await count_zero_referenced_entities(s)
+            assert set(result) == {"doc", "story", "artifact"}
+            assert "gate" not in result
+            assert "pull_request" not in result
+    finally:
+        await engine.dispose()
 
 
 # ─── ②story TARGET 게이트 — AC2 money test(권한 대조: 있음 vs 없음) ────────────

--- a/backend/tests/test_2889_target_only_types_backlinks_realdb.py
+++ b/backend/tests/test_2889_target_only_types_backlinks_realdb.py
@@ -1,0 +1,517 @@
+"""story #2889(S2h①③, 페드루 확定 2026-08-21) — gate/pull_request/member를 reference_registry의
+TARGET_ONLY_TYPES로 등록 + gate/pull_request의 backlinks READ 엔드포인트 신설, 실PG 검증.
+
+WRITE(entity_references target_type=gate/pull_request/member 저장)는 이미 배선된
+`insert_chat_mentions`를 target_types 파라미터만 넓혀 재사용한다(재구현 0 — conversations.py의
+send_message가 이미 이렇게 호출). 이 스토리의 신규 로직은 ③(존재판정 resolver 3종:
+_resolve_gates/_resolve_pull_requests/_resolve_members) + ①(BACKLINKS_ALLOWED_TARGET_TYPES
+확장 + GET /{id}/backlinks 엔드포인트 2개, gate·pull_request 대상, member는 backlinks 대상
+아님 — 원 계약이 존재판정+멘션감지까지만).
+
+커버:
+  AC-③: 존재판정 resolver 3종(gate/pull_request/member) 실PG 왕복 — insert_chat_mentions가
+        각 타입 토큰을 entity_references에 저장하는지(=resolver가 "존재함"을 올바로 판정).
+  AC-①-gate: GET /api/v2/gates/{id}/backlinks — mention→backlinks 왕복, 404(비존재/타project).
+  AC-①-pr: GET /api/v2/integrations/github/links/{id}/backlinks — 동형.
+  AC-parity: 레지스트리 집합 고정(TARGET_ONLY_TYPES/TARGET_ONLY_RESOLVERS/
+        BACKLINKS_ALLOWED_TARGET_TYPES) — 조용한 드리프트 방지 핀(#2889 확定 계약 그대로).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+# ─── seeding ────────────────────────────────────────────────────────────────
+
+async def _seed_org_project(session, name_suffix=""):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name=f"Org2889{name_suffix}", slug=f"org2889-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id):
+    from app.models.member import AgentProjectProfile, Member
+    from app.models.project_access import ProjectAccess
+
+    member_id = uuid.uuid4()
+    session.add(Member(id=member_id, org_id=org_id, type="agent", name="agent"))
+    await session.commit()
+    session.add(AgentProjectProfile(id=uuid.uuid4(), member_id=member_id, project_id=project_id))
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, member_id=member_id, permission="granted",
+    ))
+    await session.commit()
+    return member_id
+
+
+async def _seed_story(session, org_id, project_id, title="스토리"):
+    from app.models.pm import Story
+
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        status="backlog", priority="medium",
+    )
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _seed_gate(session, org_id, story_id, gate_type="qa"):
+    from app.models.gate import Gate
+
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+        gate_type=gate_type, status="pending",
+    )
+    session.add(gate)
+    await session.commit()
+    return gate
+
+
+async def _seed_pr_link(session, org_id, story_id, pr_number=1):
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    link = PullRequestStoryLink(
+        id=uuid.uuid4(), org_id=org_id, story_id=story_id, repo_full_name="moonklabs/sprintable",
+        pr_number=pr_number, link_source="explicit", confidence="high",
+    )
+    session.add(link)
+    await session.commit()
+    return link
+
+
+async def _seed_conversation(session, org_id, project_id, member_ids, created_by):
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type="group",
+        title="T", created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv.id
+
+
+async def _seed_message(session, conversation_id, sender_id, content="본문"):
+    from app.models.conversation import ConversationMessage
+    msg = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conversation_id, sender_id=sender_id, content=content,
+        created_at=datetime.now(UTC),
+    )
+    session.add(msg)
+    await session.commit()
+    return msg
+
+
+def _agent_auth(agent_id, org_id, project_id):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {
+            "org_id": str(org_id), "project_id": str(project_id), "api_key_id": str(uuid.uuid4()),
+        }},
+    )
+
+
+async def _setup_app(app, Session, agent_id, org_id, project_id):
+    from app.dependencies.auth import get_current_user
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return _agent_auth(agent_id, org_id, project_id)
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _target_only_token(entity_type: str, entity_id, title: str) -> str:
+    """gate/pull_request/member는 TARGET_ONLY(완전지원 아님)라 `reference_token.
+    build_reference_token()`이 `is_registered_entity_type`(=ENTITY_RESOLVERS 멤버십)로 걸러
+    None을 준다(그 함수의 명시 계약, AC5) — 여기선 `_CHAT_TOKEN_RE`가 실제로 매치하는
+    `[title](entity:type:id)` 원문을 직접 짓는다(파서 문법만 재사용, 신규 문법 0)."""
+    return f"[{title}](entity:{entity_type}:{entity_id})"
+
+
+async def _insert_mention(session, *, org_id, message_id, content, created_by):
+    """conversations.py::send_message와 동일 배선 — target_types를 명시로 넓힌다(라우터가
+    이미 이렇게 함, WIP diff 참고)."""
+    from app.services.mention_parser import insert_chat_mentions
+    from app.services.reference_registry import ENTITY_RESOLVERS
+
+    return await insert_chat_mentions(
+        session, org_id=org_id, message_id=message_id, content=content, created_by=created_by,
+        target_types=frozenset(ENTITY_RESOLVERS) | {"gate", "pull_request", "member"},
+    )
+
+
+# ─── AC-③: 존재판정 resolver 실PG 왕복 ──────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_gate_mention_is_resolved_and_stored():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, "G")
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story = await _seed_story(s, org_id, project_id)
+            gate = await _seed_gate(s, org_id, story.id)
+            conv_id = await _seed_conversation(s, org_id, project_id, [agent_id], created_by=agent_id)
+
+            token = _target_only_token("gate", gate.id, "게이트")
+            msg = await _seed_message(s, conv_id, agent_id, content=f"확認 필요: {token}")
+            result = await _insert_mention(s, org_id=org_id, message_id=msg.id, content=msg.content, created_by=agent_id)
+            await s.commit()
+            assert result.stored == 1, "_resolve_gates가 실존 gate를 못 찾으면 여기서 0으로 잡힌다"
+
+            from sqlalchemy import select
+            from app.models.reference import Reference
+            row = (await s.execute(
+                select(Reference).where(Reference.target_type == "gate", Reference.target_id == gate.id)
+            )).scalar_one()
+            assert row.source_id == msg.id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_mention_of_nonexistent_gate_is_not_stored():
+    """존재판정 resolver가 실존하지 않는 id는 걸러야 한다(허위 참조 저장 방지)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, "GX")
+            agent_id = await _seed_agent(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id, [agent_id], created_by=agent_id)
+
+            ghost_id = uuid.uuid4()
+            token = _target_only_token("gate", ghost_id, "유령게이트")
+            msg = await _seed_message(s, conv_id, agent_id, content=f"확認: {token}")
+            result = await _insert_mention(s, org_id=org_id, message_id=msg.id, content=msg.content, created_by=agent_id)
+            await s.commit()
+            assert result.stored == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_pull_request_mention_is_resolved_and_stored():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, "PR")
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story = await _seed_story(s, org_id, project_id)
+            link = await _seed_pr_link(s, org_id, story.id)
+            conv_id = await _seed_conversation(s, org_id, project_id, [agent_id], created_by=agent_id)
+
+            token = _target_only_token("pull_request", link.id, "PR#1")
+            msg = await _seed_message(s, conv_id, agent_id, content=f"리뷰: {token}")
+            result = await _insert_mention(s, org_id=org_id, message_id=msg.id, content=msg.content, created_by=agent_id)
+            await s.commit()
+            assert result.stored == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_pull_request_mention_excludes_soft_deleted_link():
+    """_resolve_pull_requests가 deleted_at 필터를 지키는지 — story #2889 diff의 명시 요구."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, "PRD")
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story = await _seed_story(s, org_id, project_id)
+            link = await _seed_pr_link(s, org_id, story.id)
+            link.deleted_at = datetime.now(UTC)
+            await s.commit()
+            conv_id = await _seed_conversation(s, org_id, project_id, [agent_id], created_by=agent_id)
+
+            token = _target_only_token("pull_request", link.id, "PR#1")
+            msg = await _seed_message(s, conv_id, agent_id, content=f"리뷰: {token}")
+            result = await _insert_mention(s, org_id=org_id, message_id=msg.id, content=msg.content, created_by=agent_id)
+            await s.commit()
+            assert result.stored == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_member_mention_is_resolved_and_stored():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, "M")
+            agent_id = await _seed_agent(s, org_id, project_id)
+            other_id = await _seed_agent(s, org_id, project_id)
+            conv_id = await _seed_conversation(s, org_id, project_id, [agent_id, other_id], created_by=agent_id)
+
+            token = _target_only_token("member", other_id, "동료")
+            msg = await _seed_message(s, conv_id, agent_id, content=f"담당: {token}")
+            result = await _insert_mention(s, org_id=org_id, message_id=msg.id, content=msg.content, created_by=agent_id)
+            await s.commit()
+            assert result.stored == 1
+    finally:
+        await engine.dispose()
+
+
+# ─── AC-①-gate: GET /api/v2/gates/{id}/backlinks ────────────────────────────
+
+@pytest.mark.anyio
+async def test_gate_backlinks_returns_mentioning_message():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, "GB")
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story = await _seed_story(s, org_id, project_id)
+            gate = await _seed_gate(s, org_id, story.id)
+            conv_id = await _seed_conversation(s, org_id, project_id, [agent_id], created_by=agent_id)
+
+            token = _target_only_token("gate", gate.id, "게이트")
+            msg = await _seed_message(s, conv_id, agent_id, content=f"확認: {token}")
+            result = await _insert_mention(s, org_id=org_id, message_id=msg.id, content=msg.content, created_by=agent_id)
+            await s.commit()
+            assert result.stored == 1
+            msg_id, gate_id = msg.id, gate.id
+
+        await _setup_app(app, Session, agent_id, org_id, project_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/gates/{gate_id}/backlinks")
+            assert resp.status_code == 200, resp.text
+            source_ids = {item["source_id"] for item in resp.json()["data"]}
+            assert str(msg_id) in source_ids
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_backlinks_nonexistent_gate_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, "GB404")
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        await _setup_app(app, Session, agent_id, org_id, project_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/gates/{uuid.uuid4()}/backlinks")
+            assert resp.status_code == 404
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_backlinks_cross_project_returns_404():
+    """SEC-S8류 선례 — 같은 org·다른 project의 gate는 존재 비노출 404(resolve_work_item_project_id
+    → require_project_access 경유, get_gate_endpoint와 동형 상속)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_a = await _seed_org_project(s, "GBX")
+            from app.models.project import Project
+            project_b = Project(id=uuid.uuid4(), org_id=org_id, name="ProjectB")
+            s.add(project_b)
+            await s.commit()
+
+            agent_in_a = await _seed_agent(s, org_id, project_a)
+            story_in_b = await _seed_story(s, org_id, project_b.id)
+            gate_in_b = await _seed_gate(s, org_id, story_in_b.id)
+
+        await _setup_app(app, Session, agent_in_a, org_id, project_a)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/gates/{gate_in_b.id}/backlinks")
+            assert resp.status_code == 404
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── AC-①-pr: GET /api/v2/integrations/github/links/{id}/backlinks ─────────
+
+@pytest.mark.anyio
+async def test_pr_link_backlinks_returns_mentioning_message():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, "PRB")
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story = await _seed_story(s, org_id, project_id)
+            link = await _seed_pr_link(s, org_id, story.id)
+            conv_id = await _seed_conversation(s, org_id, project_id, [agent_id], created_by=agent_id)
+
+            token = _target_only_token("pull_request", link.id, "PR#1")
+            msg = await _seed_message(s, conv_id, agent_id, content=f"리뷰: {token}")
+            result = await _insert_mention(s, org_id=org_id, message_id=msg.id, content=msg.content, created_by=agent_id)
+            await s.commit()
+            assert result.stored == 1
+            msg_id, link_id = msg.id, link.id
+
+        await _setup_app(app, Session, agent_id, org_id, project_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/integrations/github/links/{link_id}/backlinks")
+            assert resp.status_code == 200, resp.text
+            source_ids = {item["source_id"] for item in resp.json()["data"]}
+            assert str(msg_id) in source_ids
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_pr_link_backlinks_nonexistent_link_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, "PRB404")
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        await _setup_app(app, Session, agent_id, org_id, project_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/integrations/github/links/{uuid.uuid4()}/backlinks")
+            assert resp.status_code == 404
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_pr_link_backlinks_cross_project_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_a = await _seed_org_project(s, "PRBX")
+            from app.models.project import Project
+            project_b = Project(id=uuid.uuid4(), org_id=org_id, name="ProjectB")
+            s.add(project_b)
+            await s.commit()
+
+            agent_in_a = await _seed_agent(s, org_id, project_a)
+            story_in_b = await _seed_story(s, org_id, project_b.id)
+            link_in_b = await _seed_pr_link(s, org_id, story_in_b.id)
+
+        await _setup_app(app, Session, agent_in_a, org_id, project_a)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/integrations/github/links/{link_in_b.id}/backlinks")
+            assert resp.status_code == 404
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+# ─── AC-parity: 레지스트리 집합 고정(조용한 드리프트 방지 핀) ───────────────────
+
+def test_registry_target_only_types_pinned():
+    """story #2889 확定 계약 — gate/pull_request/member가 TARGET_ONLY(완전지원 아님)로
+    고정됐다는 판정을 테스트로 pin한다(판정 근거+무너지는 조건, feedback_pin_declarations_
+    as_tests 관례). 이 세트가 조용히 늘거나 줄면(오타·재구현) 여기서 즉시 빨개진다 — FE
+    (미르코군) 쪽 gate 프리뷰·원탭 카드가 기대하는 백엔드 표면의 앵커이기도 하다."""
+    from app.services.reference_registry import ENTITY_RESOLVERS, TARGET_ONLY_RESOLVERS, TARGET_ONLY_TYPES
+
+    assert TARGET_ONLY_TYPES == frozenset({"chat_message", "gate", "pull_request", "member"})
+    assert set(TARGET_ONLY_RESOLVERS) == set(TARGET_ONLY_TYPES)
+    # 완전지원(검색/MCP/project축/명시생성) 목록엔 이 3종이 없어야 한다 — 있으면 그 4계약도
+    # 진 것으로 오인돼 POST /references 명시생성·검색 picker가 열려버린다(§reference_registry.py
+    # docstring 불변식).
+    for t in ("gate", "pull_request", "member"):
+        assert t not in ENTITY_RESOLVERS, f"{t}는 TARGET_ONLY여야 하는데 ENTITY_RESOLVERS(완전지원)에 있음"
+
+
+def test_backlinks_allowed_target_types_pinned():
+    from app.services.backlinks import BACKLINKS_ALLOWED_TARGET_TYPES
+
+    assert BACKLINKS_ALLOWED_TARGET_TYPES == frozenset({"doc", "story", "artifact", "gate", "pull_request"})
+    # member는 의도적으로 backlinks 대상이 아니다(원 계약=존재판정+멘션감지까지, #2889 확定).
+    assert "member" not in BACKLINKS_ALLOWED_TARGET_TYPES


### PR DESCRIPTION
## Summary
- ③ reference_registry.py: gate/pull_request/member를 TARGET_ONLY_TYPES로 등록(존재판정 resolver 3종 신설). 완전지원(ENTITY_RESOLVERS) 아님 — 검색 handler·project축·명시생성 계약은 각 resolver docstring에 근거와 함께 의도적으로 안 엶.
- ① backlinks.py: BACKLINKS_ALLOWED_TARGET_TYPES에 gate/pull_request 추가(member는 제외 — 원 계약 범위 밖). gates.py::get_gate_backlinks, github_integration.py::get_pr_link_backlinks 신규 GET 엔드포인트(기존 target-access 게이트 재사용, 재구현 0).
- conversations.py: insert_chat_mentions의 target_types를 gate/pull_request/member까지 넓혀 채팅 멘션 자동감지가 되게 함.
- **버그 fix(테스트 중 발견)**: mention_parser.py의 `_CHAT_TOKEN_RE`/`_CHAT_TOKEN_SHAPE_RE`가 `[a-z]+`라 언더스코어를 못 먹어 `pull_request` 채팅 멘션이 모양은 맞는데 항상 0건으로 죽던 실결함 — `[a-z_]+`로 수정.
- 실PG 테스트 13건(test_2889_target_only_types_backlinks_realdb.py) — 존재판정 3종·backlinks 2엔드포인트(404/cross-project 포함)·레지스트리 집합 고정(parity pin).

## Test plan
- [x] `pytest tests/test_2889_target_only_types_backlinks_realdb.py` — 13 passed (실PG, alembic head)
- [x] 회귀 스윕(mention/reference/backlink/gate/github_integration 키워드, 179개 무관련) — 무회귀
- [x] `test_authz_project_scope_coverage.py` — 13 passed(신규 GET 라우트는 읽기전용이라 mutation 스캐너 무관)
- [x] `python -c "import app.main"` — 임포트 확認

[SID:2889]