### PR TITLE
[SID:2898] S2d FE — ReadingPanel 스택화(push/pop·브레드크럼, 최대 깊이 3)

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -131,15 +131,18 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
 
   // story #2766(레인 A) — ReadingPanel도 우측 패널이라 스레드와 동일 슬롯을 공유한다(동시
   // 2패널 레이아웃은 인계 doc에 없는 새 영역이라 짓지 않음 — 열면 서로 배타적으로 닫는다).
-  const [activeReadingPanel, setActiveReadingPanel] = useState<ReadingPanelTarget | null>(null);
+  // story #2888/S2 R5 — 단일 target에서 스택(배열)으로. 빈 배열=닫힘(기존 null과 동형).
+  // 최대 깊이 3(유나군 목업 s2d-sidepane-stack-mockup 확定) — push 시 최하단부터 pop.
+  const [readingPanelStack, setReadingPanelStack] = useState<ReadingPanelTarget[]>([]);
   // activeThreadRef와 동일 이유(popstate stale closure 방지) — 모바일 뒤로가기 제스처가
   // ThreadPanel과 똑같이 이 패널도 먼저 닫아야 한다(페이지 이탈 아님).
   const activeReadingPanelRef = useRef(false);
+  const READING_PANEL_MAX_DEPTH = 3;
 
   // 스레드 열기: 현재 URL 유지한 채 history entry 추가
   const openThread = useCallback((message: ChatMessage) => {
     activeReadingPanelRef.current = false;
-    setActiveReadingPanel(null);
+    setReadingPanelStack([]);
     setActiveThread(message);
     activeThreadRef.current = true;
     const url = window.location.pathname + window.location.search;
@@ -152,18 +155,29 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     setActiveThread(null);
   }, []);
 
+  // story #2888/S2 R5 — 패널이 이미 열려 있으면(스택 비어있지 않음) push(임베드 안에서 또
+  // 임베드), 닫혀 있었으면 새 1단 스택으로 시작. 열릴 때만 history entry를 추가한다(push는
+  // 같은 "패널 열림" 상태 안의 전환이라 뒤로가기 제스처가 매 push마다 쌓이지 않게).
   const openReadingPanel = useCallback((target: ReadingPanelTarget) => {
     activeThreadRef.current = false;
     setActiveThread(null);
+    const wasClosed = !activeReadingPanelRef.current;
     activeReadingPanelRef.current = true;
-    setActiveReadingPanel(target);
-    const url = window.location.pathname + window.location.search;
-    window.history.pushState({ _sprintableReadingPanel: true }, '', url);
+    setReadingPanelStack((prev) => [...prev, target].slice(-READING_PANEL_MAX_DEPTH));
+    if (wasClosed) {
+      const url = window.location.pathname + window.location.search;
+      window.history.pushState({ _sprintableReadingPanel: true }, '', url);
+    }
+  }, []);
+
+  // 브레드크럼 세그먼트 클릭 — 그 인덱스까지 pop(그 항목이 새 최상단).
+  const navigateReadingPanelTo = useCallback((index: number) => {
+    setReadingPanelStack((prev) => prev.slice(0, index + 1));
   }, []);
 
   const closeReadingPanel = useCallback(() => {
     activeReadingPanelRef.current = false;
-    setActiveReadingPanel(null);
+    setReadingPanelStack([]);
   }, []);
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -373,7 +387,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
       activeThreadRef.current = false;
       setActiveThread(null);
       activeReadingPanelRef.current = false;
-      setActiveReadingPanel(null);
+      setReadingPanelStack([]);
       window.history.pushState(e.state ?? null, '', window.location.pathname + window.location.search);
     };
     window.addEventListener('popstate', handlePopState);
@@ -740,7 +754,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   // story #2766(레인 A) — ReadingPanel도 같은 "메인 채팅 숨김" 규칙을 탄다(모바일 전체화면
   // 드로어). ReadingPanel 자신이 이미 자체 닫기(X) 버튼을 갖고 있어(FileViewer/EntityPreviewModal
   // 헤더) ThreadPanel처럼 별도 상단 "뒤로" 바를 새로 만들지 않는다.
-  const isMobileReadingView = activeReadingPanel !== null;
+  const isMobileReadingView = readingPanelStack.length > 0;
   const isMobileRightPanelView = isMobileThreadView || isMobileReadingView;
 
   return (
@@ -983,12 +997,12 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
         {/* story #2766(레인 A) §A1 — ReadingPanel: 데스크톱 clamp(480px,40vw,720px) 사이드 /
             모바일 전체 뷰. ThreadPanel과 같은 슬롯이지만 폭 규격이 다르다(320px 고정이 아님
             — 문서 가독 기준 폭). */}
-        {activeReadingPanel && (
+        {readingPanelStack.length > 0 && (
           <div
             className={`flex flex-col overflow-hidden ${isMobileReadingView ? 'flex-1' : 'hidden lg:flex'}`}
             style={isMobileReadingView ? undefined : { width: 'clamp(480px, 40vw, 720px)', flexShrink: 0 }}
           >
-            <ReadingPanel target={activeReadingPanel} onClose={closeReadingPanel} />
+            <ReadingPanel stack={readingPanelStack} onNavigateTo={navigateReadingPanelTo} onClose={closeReadingPanel} />
           </div>
         )}
       </div>

--- a/apps/web/src/components/chat/reading-panel.test.tsx
+++ b/apps/web/src/components/chat/reading-panel.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+//
+// story #2888(S2·R5) — ReadingPanel 스택(push/pop·브레드크럼) 회귀가드. EntityPreviewModal/
+// FileViewer 자체 로직은 각자 테스트가 있다 — 여기는 스택 렌더·네비게이션만 잰다(fetch는
+// 실패 스텁 — 어차피 graceful fallback으로 떨어지고, 이 테스트의 관심사가 아니다).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ReadingPanel, type ReadingPanelTarget } from './reading-panel';
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => ({ projectMemberships: [] }),
+}));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: () => {} }) }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({}) })));
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+const A: ReadingPanelTarget = { kind: 'entity', entityType: 'story', entityId: 's-1', title: '스토리 A', status: null, href: null };
+const B: ReadingPanelTarget = { kind: 'entity', entityType: 'doc', entityId: 'd-1', title: '문서 B', status: null, href: null };
+const C: ReadingPanelTarget = { kind: 'entity', entityType: 'epic', entityId: 'e-1', title: '목표 C', status: null, href: null };
+
+describe('ReadingPanel 스택 — story #2888 R5', () => {
+  it('스택 1개면 브레드크럼을 안 그린다', async () => {
+    await act(async () => {
+      root.render(<ReadingPanel stack={[A]} onNavigateTo={() => {}} onClose={() => {}} />);
+    });
+    expect(container.querySelector('[title="전체 닫기"]')).toBeNull();
+    expect(container.textContent).toContain('스토리 A');
+  });
+
+  it('스택 2개 이상이면 브레드크럼에 전 항목이 순서대로 뜬다(최상단은 굵게·비활성)', async () => {
+    await act(async () => {
+      root.render(<ReadingPanel stack={[A, B]} onNavigateTo={() => {}} onClose={() => {}} />);
+    });
+    const buttons = Array.from(container.querySelectorAll('button')).filter((b) => b.textContent?.trim());
+    expect(buttons.map((b) => b.textContent)).toEqual(['스토리 A', '문서 B']);
+    expect(buttons[1]!.disabled).toBe(true);
+    expect(buttons[0]!.disabled).toBe(false);
+  });
+
+  it('브레드크럼 세그먼트를 클릭하면 그 인덱스로 onNavigateTo가 호출된다', async () => {
+    const onNavigateTo = vi.fn();
+    await act(async () => {
+      root.render(<ReadingPanel stack={[A, B, C]} onNavigateTo={onNavigateTo} onClose={() => {}} />);
+    });
+    const firstSegment = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '스토리 A')!;
+    await act(async () => { firstSegment.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onNavigateTo).toHaveBeenCalledWith(0);
+  });
+
+  it('전체 닫기(X) 클릭 시 onClose가 호출된다', async () => {
+    const onClose = vi.fn();
+    await act(async () => {
+      root.render(<ReadingPanel stack={[A, B]} onNavigateTo={() => {}} onClose={onClose} />);
+    });
+    const closeBtn = container.querySelector('[title="전체 닫기"]') as HTMLButtonElement;
+    await act(async () => { closeBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('최상단 항상 렌더 — 3단 스택에서도 C(최신)의 내용이 본문에 보인다', async () => {
+    await act(async () => {
+      root.render(<ReadingPanel stack={[A, B, C]} onNavigateTo={() => {}} onClose={() => {}} />);
+    });
+    // EntityPreviewModal embedded 헤더가 최상단 라벨을 그린다(본문 영역 — 브레드크럼과 별개).
+    const headerLabel = Array.from(container.querySelectorAll('span')).find((s) => s.textContent === '목표 C');
+    expect(headerLabel).toBeTruthy();
+  });
+
+  it('빈 스택이면 아무것도 렌더하지 않는다', async () => {
+    await act(async () => {
+      root.render(<ReadingPanel stack={[]} onNavigateTo={() => {}} onClose={() => {}} />);
+    });
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/reading-panel.tsx
+++ b/apps/web/src/components/chat/reading-panel.tsx
@@ -88,7 +88,7 @@ export function ReadingPanel({
             const isLast = i === stack.length - 1;
             return (
               <div key={i} className="flex shrink-0 items-center gap-1">
-                {i > 0 && <span className="text-xs text-muted-foreground/60">›</span>}
+                {i > 0 && <span className="text-xs text-border">›</span>}
                 <button
                   type="button"
                   onClick={() => onNavigateTo(i)}

--- a/apps/web/src/components/chat/reading-panel.tsx
+++ b/apps/web/src/components/chat/reading-panel.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { EntityPreviewModal } from '@/components/chat/embed-card';
+import { EntityGlyph, resolveEntityIcon } from '@/components/chat/entity-registry';
 import { FileViewer } from '@/components/chat/file-viewer';
+import { getFileIcon } from '@/lib/file-icon';
+import { X } from 'lucide-react';
 
 /**
  * story #2766(레인 A)·#2780(엔티티 확장)·#2781(asset 편입) — 채팅을 벗어나지 않는 우측 리딩
@@ -23,33 +26,104 @@ export type ReadingPanelTarget =
       assetId?: string;
     };
 
-/**
- * 인계 doc 0ef7f8ab §A1 — thread-panel.tsx 선례(데스크톱 나란히·모바일 전체화면 드로어)를
- * 그대로 따르되, 폭은 부모(chat-view.tsx)가 clamp(480px,40vw,720px)로 강제한다(⛔base
- * DialogContent의 sm:max-w-sm 상속 금지 — 애초에 Dialog를 안 쓰므로 상속될 여지가 없다).
- * 채팅 입력은 이 패널이 열려도 그대로 활성 — ThreadPanel과 달리 이 컴포넌트는 자기 폭 밖의
- * 레이아웃(모달 아님·오버레이 아님)에 개입하지 않는다.
- */
-export function ReadingPanel({ target, onClose }: { target: ReadingPanelTarget; onClose: () => void }) {
+function targetLabel(target: ReadingPanelTarget): string {
+  return target.kind === 'entity' ? (target.title ?? target.entityId) : target.label;
+}
+
+function TargetGlyph({ target, className }: { target: ReadingPanelTarget; className?: string }) {
+  const label = targetLabel(target);
+  const Icon = target.kind === 'entity' ? resolveEntityIcon(target.entityType) : getFileIcon(target.contentType);
+  return <EntityGlyph Icon={Icon} label={label} className={className} />;
+}
+
+function ReadingPanelContent({ target, onClose }: { target: ReadingPanelTarget; onClose: () => void }) {
   if (target.kind === 'entity') {
     return (
-      <div className="flex h-full flex-col overflow-hidden border-l border-border bg-background">
-        <EntityPreviewModal
-          entityType={target.entityType}
-          entityId={target.entityId}
-          title={target.title}
-          status={target.status}
-          href={target.href}
-          onClose={onClose}
-          embedded
-        />
-      </div>
+      <EntityPreviewModal
+        entityType={target.entityType}
+        entityId={target.entityId}
+        title={target.title}
+        status={target.status}
+        href={target.href}
+        onClose={onClose}
+        embedded
+      />
     );
   }
+  return <FileViewer target={target} onClose={onClose} />;
+}
+
+/**
+ * story #2888/S2(임베드 뼈대) R5 — 인계 doc 0ef7f8ab §A1(thread-panel.tsx 선례: 데스크톱
+ * 나란히·모바일 전체화면 드로어)에 스택(push/pop·브레드크럼)을 얹는다. 폭은 부모
+ * (chat-view.tsx)가 clamp(480px,40vw,720px)로 강제(⛔Dialog 미사용이라 sm:max-w-sm 상속 여지
+ * 자체가 없음). 채팅 입력은 이 패널이 열려도 그대로 활성.
+ *
+ * **스택 규칙**(S2 스펙 §4·유나군 목업 s2d-sidepane-stack-mockup): 최대 깊이 3 — 부모
+ * (chat-view.tsx openReadingPanel)가 초과분을 최하단부터 pop해 이 컴포넌트에 넘긴다(이
+ * 컴포넌트는 스택 길이를 강제하지 않고 받은 그대로 그린다). 콘텐츠 자체의 자기 X(닫기)는
+ * "한 단계 뒤로"(pop) — 스택에 1개뿐이면 그게 곧 전체 닫기와 같다. 브레드크럼 우측의 별도
+ * X는 "전체 닫기"(스택 전부 버리기, onClose).
+ */
+export function ReadingPanel({
+  stack, onNavigateTo, onClose,
+}: {
+  stack: ReadingPanelTarget[];
+  /** 브레드크럼 세그먼트 클릭 — 그 인덱스까지 pop(그 항목이 새 최상단이 된다). */
+  onNavigateTo: (index: number) => void;
+  /** 전체 닫기(스택 전부 버림) — 브레드크럼 X, 최상단 콘텐츠 자기 X 둘 다(콘텐츠 쪽은 "한 단계
+   * 뒤로"가 되도록 호출부가 stack.length에 따라 onNavigateTo/onClose 중 골라 넘긴다). */
+  onClose: () => void;
+}) {
+  const top = stack[stack.length - 1];
+  if (!top) return null;
+
+  const popOne = stack.length > 1 ? () => onNavigateTo(stack.length - 2) : onClose;
 
   return (
     <div className="flex h-full flex-col overflow-hidden border-l border-border bg-background">
-      <FileViewer target={target} onClose={onClose} />
+      {stack.length > 1 && (
+        <div className="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border px-2 py-1.5">
+          {stack.map((item, i) => {
+            const isLast = i === stack.length - 1;
+            return (
+              <div key={i} className="flex shrink-0 items-center gap-1">
+                {i > 0 && <span className="text-xs text-muted-foreground/60">›</span>}
+                <button
+                  type="button"
+                  onClick={() => onNavigateTo(i)}
+                  disabled={isLast}
+                  className={`flex max-w-32 items-center gap-1 rounded px-1.5 py-1 text-xs ${
+                    isLast ? 'font-medium text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                  }`}
+                  title={targetLabel(item)}
+                >
+                  <TargetGlyph target={item} className="size-3 shrink-0" />
+                  <span className="truncate">{targetLabel(item)}</span>
+                </button>
+              </div>
+            );
+          })}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="전체 닫기"
+            title="전체 닫기"
+            className="ml-auto shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+      )}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {/* 스택 top이 바뀔 때마다(어느 방향이든) 확실히 리마운트 — 대상 정체성 자체를 key로
+            (stack.length만으론 pop→다른 대상 push가 같은 길이일 때 리마운트가 안 됨). */}
+        <ReadingPanelContent
+          key={top.kind === 'entity' ? `entity:${top.entityType}:${top.entityId}` : `attachment:${top.assetId ?? top.storedUrl ?? top.label}`}
+          target={top}
+          onClose={popOne}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 요약
story #2898 — S2d 목업(s2d-sidepane-stack-mockup, PO 승인) R2/R5 중 순수 FE 축. gate 프리뷰·2891 원탭 결재 카드는 #2889(S2h③ reference_registry TARGET_ONLY) 착지 후 후속 슬라이스로 분리(디디군 확認 완료 — 계약은 확定, 구현 착지 대기 중).

## 변경
- `reading-panel.tsx`: 단일 `target` prop → `stack: ReadingPanelTarget[]`. 2단 이상이면 브레드크럼(세그먼트 클릭=그 인덱스까지 pop, 최상단은 굵게·비활성) + 전체닫기 X. 최상단 콘텐츠 자기 닫기(X)는 "한 단계 뒤로"(pop) — 1단뿐이면 전체 닫기와 동형.
- `chat-view.tsx`: `openReadingPanel`이 이미 열린 상태면 push(최대 깊이 3, 초과 시 최하단부터 밀림), 닫혀 있었으면 새 1단 스택 시작. history push는 "닫힘→열림" 전환 시점 1회만(매 push마다 안 쌓여 모바일 뒤로가기 제스처 1회로 전체 닫힘 — 기존 규약 유지). popstate/`closeReadingPanel`은 스택 전체를 닫는다.
- `reading-panel.test.tsx`(신규 6건): 단일 스택 브레드크럼 미표시·다단 브레드크럼 순서/비활성·세그먼트 클릭 네비게이션·전체닫기·최상단 콘텐츠 렌더·빈 스택 no-render.

## 셀프 게이트
- ✅ `tsc --noEmit` 클린
- ✅ `pnpm lint` 0 errors(기존 파일 warning 5건은 미변경 파일)
- ✅ `vitest run src/components/chat/` 36 files·379 tests 전부 그린(신규 6건 포함)
- ✅ 대비가드 4종(tint-fg·no-new-tint·cross-element·muted-fg) 전부 클린(신규 위반 0)
- ✅ `pnpm build` EXIT 0

## 남은 것(라이브 픽셀)
AC5(라이브 실측·3단 스택 왕복)는 dev 배포 후 별도 확認 — 이 PR은 구조 변경 자체의 self-gate만 다룬다.