### PR TITLE
[SID:2880] 결제 트랙 갭① — 유료→유료 상향 엔진

### DIFF
--- a/backend/alembic/versions/0267_billing_orders_refund_status.py
+++ b/backend/alembic/versions/0267_billing_orders_refund_status.py
@@ -1,0 +1,36 @@
+"""story #2880(결제 트랙 갭①, 선생님 확定 2026-08-21) — billing_orders.refund_status.
+
+상향 티어 전환 산식이 확定됐다: 신 offering 전액 charge(confirmed 後) → tier/period
+즉시 전이 → 직전 confirmed 결제 건에 잔여기간 일할 부분취소(Toss cancel). 부분취소가
+실패해도 이미 confirmed된 charge는 되돌리지 않는다(선생님 지시) — 그 실패를 `billing_
+orders`에 명시로 남겨야 향후 재시도/스윕이 찾을 수 있다. NULL=이 order에 환불 시도
+자체가 없었음(기존 행 전부의 기본 상태, 배타적이지 않음 — 한 order가 부분취소를 여러 번
+받을 수도 있으나 이 스토리는 "마지막 시도 결과"만 기록한다).
+
+Revision ID: 0267
+Revises: 0266
+Create Date: 2026-08-21
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0267"
+down_revision = "0266"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("billing_orders", sa.Column("refund_status", sa.Text(), nullable=True))
+    op.create_check_constraint(
+        "ck_billing_orders_refund_status",
+        "billing_orders",
+        "refund_status IS NULL OR refund_status IN ('confirmed', 'failed')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_billing_orders_refund_status", "billing_orders", type_="check")
+    op.drop_column("billing_orders", "refund_status")

--- a/backend/alembic/versions/0268_billing_orders_purpose.py
+++ b/backend/alembic/versions/0268_billing_orders_purpose.py
@@ -1,0 +1,52 @@
+"""story #2880(카디르 CRITICAL, 2026-08-21) — billing_orders.purpose.
+
+`_latest_confirmed_order()`(org_subscription_tier_change.py)가 "이 org의 가장 최근
+confirmed billing_order"를 «직전 구독 결제»로 가정했으나, `billing_orders`엔 주문
+종류(구독 charge vs pack 구매) 구분이 전혀 없었다 — pack 구매도 같은 테이블에
+confirmed row를 남긴다(billing_pack.py::purchase_packs, charge_org(entry_type=
+"pack_purchase")). 그 결과 구독charge 後 pack구매가 있었던 org가 상향하면 pack
+주문을 잘못 부분취소하는 실 재현 결함(카디르 실PG 2시나리오 확定, PR#3306 리뷰).
+
+`purpose`는 `charge_org()`가 받는 `entry_type` 파라미터를 그대로 INSERT 시점에
+같이 찍는다(billing_ledger_entries.entry_type과 같은 값 — 별도 개념 발명 아님,
+billing_orders에도 같은 사실을 갖고 있게 하는 것뿐). 기존 행은 billing_ledger_
+entries(provider_ref=payment_key)와 join해 실 entry_type으로 백필 — 매칭 없는
+행(pending/failed로 끝나 원장 자체가 없는 행)은 'charge'로 기본값(과거
+charge_org() 기본 entry_type과 동일 — 이 스토리 前까지 pack 구매 외엔 전부 charge
+였다는 사실 그대로 반영, 새 가정 발명 아님)."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0268"
+down_revision = "0267"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("billing_orders", sa.Column("purpose", sa.Text(), nullable=True))
+    op.execute(
+        """
+        UPDATE billing_orders bo
+        SET purpose = ble.entry_type
+        FROM billing_ledger_entries ble
+        WHERE bo.payment_key IS NOT NULL AND bo.payment_key = ble.provider_ref
+        """
+    )
+    op.execute("UPDATE billing_orders SET purpose = 'charge' WHERE purpose IS NULL")
+    op.alter_column("billing_orders", "purpose", nullable=False, server_default="charge")
+    # charge_org() 실 호출부 전수 확認(2026-08-21) — entry_type을 명시하는 곳은
+    # billing_pack.py("pack_purchase")뿐, 나머지(checkout·tier_change·admin retry·
+    # dunning retry)는 전부 기본값 "charge"거나 기존 order_id 재사용(claim INSERT가
+    # ON CONFLICT DO NOTHING이라 purpose는 최초 생성 시점 값 그대로 유지). 실제로
+    # 존재하는 두 값만 허용 — 다른 값은 이 CHECK가 스스로 잡는다.
+    op.create_check_constraint(
+        "ck_billing_orders_purpose", "billing_orders", "purpose IN ('charge', 'pack_purchase')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_billing_orders_purpose", "billing_orders", type_="check")
+    op.drop_column("billing_orders", "purpose")

--- a/backend/app/models/billing_order.py
+++ b/backend/app/models/billing_order.py
@@ -24,3 +24,8 @@ class BillingOrder(Base, TimestampMixin, OrgScopedMixin):
     status: Mapped[str] = mapped_column(Text, nullable=False, default="pending")
     payment_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     failure_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #2880(0267) — 이 confirmed order에 대한 부분취소 시도 결과. NULL=시도 없음.
+    # "confirmed"/"failed" — 마지막 시도 결과만(누적 이력 아님). 부분취소 실패가 이 order의
+    # 원 charge(status='confirmed')를 되돌리지 않는다(선생님 지시) — 그래서 실패 표기는
+    # status가 아니라 이 별도 필드다.
+    refund_status: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/models/billing_order.py
+++ b/backend/app/models/billing_order.py
@@ -22,6 +22,13 @@ class BillingOrder(Base, TimestampMixin, OrgScopedMixin):
     amount_minor: Mapped[int] = mapped_column(BigInteger, nullable=False)
     currency: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(Text, nullable=False, default="pending")
+    # 카디르 CRITICAL(2026-08-21, PR#3306 리뷰) — 이 컬럼이 없어 "이 org의 최근 confirmed
+    # order"가 pack 구매와 구독 charge를 구분 못해 상향 부분취소가 무관한 pack 결제를
+    # 잘못 취소한 실 재현 결함(0268). charge_org()가 받는 entry_type과 같은 값을 그대로
+    # 찍는다(billing_ledger_entries.entry_type과 개념 중복이 아니라 — order 자체에도
+    # 같은 사실이 필요해서 복제, "이 order가 왜 만들어졌나"를 join 없이 즉시 알아야 하는
+    # 자리(org_subscription_tier_change.py의 부분취소 대상 선별)가 있다).
+    purpose: Mapped[str] = mapped_column(Text, nullable=False, default="charge")
     payment_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     failure_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     # story #2880(0267) — 이 confirmed order에 대한 부분취소 시도 결과. NULL=시도 없음.

--- a/backend/app/routers/org_subscription_checkout.py
+++ b/backend/app/routers/org_subscription_checkout.py
@@ -21,6 +21,12 @@ from app.services.org_subscription_checkout import (
     CheckoutInProgress,
     checkout_subscription,
 )
+from app.services.org_subscription_tier_change import (
+    TierChangeDeclined,
+    TierChangeError,
+    TierChangeInProgress,
+    change_tier,
+)
 from app.services.platform_settings import get_platform_settings
 
 router = APIRouter(prefix="/api/v2/org-subscriptions", tags=["billing", "Organization"])
@@ -30,6 +36,10 @@ class CheckoutRequest(BaseModel):
     auth_key: str
     tier: Literal["starter", "team", "business"]
     billing_cycle: Literal["monthly", "annual"]
+
+
+class ChangeTierRequest(BaseModel):
+    new_tier: Literal["starter", "team", "business"]
 
 
 class CheckoutResponse(BaseModel):
@@ -93,6 +103,47 @@ async def checkout(
         # 남은 원인은 offering_version 카탈로그 갭 같은 내부 상태 문제(사용자 입력 오류
         # 아님)라 422가 아니라 500.
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return _to_response(sub)
+
+
+@router.post("/change-tier", response_model=CheckoutResponse)
+async def change_tier_endpoint(
+    body: ChangeTierRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
+) -> CheckoutResponse:
+    """story #2880(결제 트랙 갭①, 선생님 최종 확定 2026-08-21) — 월납 유료→유료 상향.
+    신 offering 전액 즉시 청구 → confirmed 後 tier+과금일(period) 즉시 리셋 → 직전
+    결제 건에 잔여기간 일할 부분취소(Toss cancel). checkout과 달리 authKey 불요(기존
+    active billing_key로 즉시 청구) — 신규 결제(checkout)와는 별개 진입점이다.
+
+    청구가 카드 거절로 실패하면 200으로 status=원 tier 그대로인 바디를 반환한다
+    (checkout과 동형 — 재시도 가능한 비즈니스 결과, 502는 Toss API 자체에 도달 못 한
+    시스템 오류에만). 정책 위반(하향·연납·활성 유료 아님 등)은 400 — 캐치가능한
+    호출자 입력 오류로 분류(checkout의 CheckoutError=500과 다른 이유: 그쪽은 카탈로그
+    갭 같은 순수 내부 상태 문제뿐이지만, 이쪽은 «잘못된 대상 tier 선택»이 호출자가 고칠
+    수 있는 흔한 경로다)."""
+    settings = await get_platform_settings(session)
+    if not settings.billing_checkout_enabled:
+        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+
+    from app.services.project_auth import is_org_owner_or_admin
+
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="org admin/owner role required")
+
+    try:
+        sub = await change_tier(session, org_id=org_id, new_tier=body.new_tier)
+    except TierChangeDeclined as exc:
+        return _to_response(exc.subscription, declined_reason=str(exc))
+    except TierChangeInProgress as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except TierChangeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 

--- a/backend/app/services/billing_charge.py
+++ b/backend/app/services/billing_charge.py
@@ -125,6 +125,10 @@ async def charge_org(
     claim_stmt = pg_insert(BillingOrder).values(
         id=uuid.uuid4(), org_id=org_id, order_id=order_id,
         amount_minor=amount_minor, currency=currency, status="pending",
+        # 카디르 CRITICAL(0268) — purpose를 entry_type과 같은 값으로 최초 생성 시점에
+        # 찍는다. ON CONFLICT DO NOTHING이라 재시도(같은 order_id 재호출)는 이 값을
+        # 안 건드림 — 최초 생성이 유일한 진실 시점.
+        purpose=entry_type,
     ).on_conflict_do_nothing(index_elements=["order_id"])
     claim_result = await session.execute(claim_stmt)
     await session.commit()

--- a/backend/app/services/billing_charge_amount.py
+++ b/backend/app/services/billing_charge_amount.py
@@ -15,7 +15,9 @@ story #2505로 별도 추적) 지금은 항상 0을 반환한다. current_period
 없으니 집계 자체를 건너뛴다)."""
 from __future__ import annotations
 
+import math
 import uuid
+from datetime import datetime
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -77,22 +79,13 @@ async def compute_pack_charge_minor(
     return int(result)
 
 
-async def compute_charge_amount(session: AsyncSession, *, org_id: uuid.UUID) -> tuple[int, str]:
-    """(amount_minor, currency) 반환. 기저가(월/연) + 좌석초과분 + 팩분."""
-    sub = (
-        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
-    ).scalar_one_or_none()
-    if sub is None:
-        raise ChargeAmountError(f"no org_subscription row for org_id={org_id}")
-    if sub.offering_version_id is None:
-        raise ChargeAmountError(
-            f"org_subscription(org_id={org_id})에 offering_version_id가 바인딩되지 않음"
-        )
-
-    offering = await session.get(OfferingVersion, sub.offering_version_id)
-    if offering is None:
-        raise ChargeAmountError(f"offering_version {sub.offering_version_id}를 찾을 수 없음")
-
+async def _compute_amount_for_offering(
+    session: AsyncSession, *, org_id: uuid.UUID, sub: OrgSubscription, offering: OfferingVersion,
+) -> tuple[int, str]:
+    """기저가(월/연) + 좌석초과분 + 팩분 — `offering`을 명시로 받는다(story #2880: 티어
+    전환 시점엔 `sub`가 아직 구 tier라 sub.offering_version_id 그대로는 신 tier 금액을
+    못 낸다 — `compute_charge_amount`/`compute_full_charge_for_new_offering` 둘 다
+    이 헬퍼로 수렴, 로직 재구현 0)."""
     # 카디르 결함사냥(#2509, 2026-08-07) — org_subscriptions.billing_cycle에 DB CHECK가
     # 없어(Text nullable) NULL·'Annual'·'yearly'·오타가 조용히 monthly로 폴백해 annual
     # 구독을 10배 저청구할 수 있었다. "annual 아니면 monthly=안전한 기본값"이라는 판단
@@ -137,3 +130,62 @@ async def compute_charge_amount(session: AsyncSession, *, org_id: uuid.UUID) -> 
         )
 
     return base_amount + seat_amount + pack_amount, offering.currency
+
+
+async def _load_sub(session: AsyncSession, org_id: uuid.UUID) -> OrgSubscription:
+    sub = (
+        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+    ).scalar_one_or_none()
+    if sub is None:
+        raise ChargeAmountError(f"no org_subscription row for org_id={org_id}")
+    return sub
+
+
+async def compute_charge_amount(session: AsyncSession, *, org_id: uuid.UUID) -> tuple[int, str]:
+    """(amount_minor, currency) 반환. 기저가(월/연) + 좌석초과분 + 팩분 — sub의 현재
+    offering_version_id 기준."""
+    sub = await _load_sub(session, org_id)
+    if sub.offering_version_id is None:
+        raise ChargeAmountError(
+            f"org_subscription(org_id={org_id})에 offering_version_id가 바인딩되지 않음"
+        )
+    offering = await session.get(OfferingVersion, sub.offering_version_id)
+    if offering is None:
+        raise ChargeAmountError(f"offering_version {sub.offering_version_id}를 찾을 수 없음")
+    return await _compute_amount_for_offering(session, org_id=org_id, sub=sub, offering=offering)
+
+
+async def compute_full_charge_for_new_offering(
+    session: AsyncSession, *, org_id: uuid.UUID, new_offering: OfferingVersion,
+) -> tuple[int, str]:
+    """story #2880 — 유료→유료 상향 시 «신 offering 전액»(좌석초과+팩 포함, 선생님 확定
+    2026-08-21: 일할 차감 없이 신 tier 전액을 즉시 청구한다 — 구 tier 잔여분은 charge
+    쪽이 아니라 별도 부분취소(refund) 경로가 정산한다, org_subscription_tier_change.py
+    참고). sub는 여전히 구 tier인 시점에 호출된다는 전제(호출부가 confirmed 확認 前에
+    부른다)."""
+    sub = await _load_sub(session, org_id)
+    return await _compute_amount_for_offering(session, org_id=org_id, sub=sub, offering=new_offering)
+
+
+def prorate_minor(
+    price_minor: int, *, now: datetime, period_start: datetime, period_end: datetime,
+) -> int:
+    """story #2880 — `price_minor`의 잔여기간 비례 몫(minor unit), 순수 함수(DB 접근
+    없음). (period_end − now) / (period_end − period_start) 비율을 곱한다 — 초 단위
+    정밀도(타임스탬프가 이미 초 단위 저장이므로 일 단위로 먼저 절삭하지 않는다).
+
+    ⛔라운딩 방향은 **floor**로 확定(페드루 지시 ⓒ, 2026-08-21 — 돈은 방향이 계약이라
+    round()의 기본 반올림에 맡기지 않는다, 항상 사용자 유리).
+
+    선생님 재확定(2026-08-21) 후 이 함수는 «청구액»이 아니라 **구 tier 잔여분 부분취소
+    (refund) 금액**을 잰다 — 상향 자체의 청구는 신 offering 전액(`compute_full_charge_
+    for_new_offering`)이고, 이 값은 그 직전 confirmed 결제 건에 Toss cancelAmount로
+    넘긴다(org_subscription_tier_change.py 참고)."""
+    total_seconds = (period_end - period_start).total_seconds()
+    remaining_seconds = (period_end - now).total_seconds()
+    if total_seconds <= 0 or remaining_seconds <= 0:
+        raise ChargeAmountError(
+            f"잔여기간 계산 불가(total_seconds={total_seconds}, remaining_seconds={remaining_seconds})"
+        )
+    remaining_seconds = min(remaining_seconds, total_seconds)
+    return math.floor(price_minor * remaining_seconds / total_seconds)

--- a/backend/app/services/org_subscription_tier_change.py
+++ b/backend/app/services/org_subscription_tier_change.py
@@ -49,7 +49,7 @@ from app.services.billing_charge_amount import (
     prorate_minor,
 )
 from app.services.billing_period import new_subscription_period
-from app.services.billing_refund import RefundError, refund_org
+from app.services.billing_refund import refund_org
 from app.services.org_subscription_checkout import STALE_CLAIM_WINDOW
 from app.services.payment.toss_adapter import TossApiError
 
@@ -81,12 +81,18 @@ async def _refetch_subscription(session: AsyncSession, org_id: uuid.UUID) -> Org
     ).scalar_one()
 
 
-async def _latest_confirmed_order(session: AsyncSession, org_id: uuid.UUID) -> BillingOrder | None:
-    """이 org의 가장 최근 confirmed billing_order — 부분취소 대상(직전 결제 건)."""
+async def _latest_confirmed_subscription_order(session: AsyncSession, org_id: uuid.UUID) -> BillingOrder | None:
+    """⛔카디르 CRITICAL(2026-08-21, PR#3306 리뷰) — 이전 버전은 org_id+status='confirmed'
+    로만 걸러 pack 구매 order를 «직전 구독 결제»로 오인했다(billing_pack.py도 같은
+    billing_orders 테이블에 confirmed row를 남긴다 — 실PG 2시나리오 재현 확定: pack금액<
+    prorate액이면 refund_org 자체 방어로 실패만 남고 진짜 구독 결제는 영원히 미환급,
+    pack금액>prorate액이면 방어선 없이 «조용히 성공»해 무관한 pack 구매가 실제로
+    취소됨). `purpose='charge'`(0268)로 구독 charge만 명시 필터 — pack_purchase는
+    구조적으로 대상에서 빠진다."""
     return (
         await session.execute(
             select(BillingOrder)
-            .where(BillingOrder.org_id == org_id, BillingOrder.status == "confirmed")
+            .where(BillingOrder.org_id == org_id, BillingOrder.status == "confirmed", BillingOrder.purpose == "charge")
             .order_by(BillingOrder.created_at.desc())
             .limit(1)
         )
@@ -162,12 +168,15 @@ async def change_tier(session: AsyncSession, *, org_id: uuid.UUID, new_tier: str
     if claim_result.rowcount == 0:
         raise TierChangeInProgress(f"org_id={org_id}에 다른 결제 작업이 이미 진행 中 — 완료 후 재시도")
 
-    # claim 이후 부분취소 대상(직전 confirmed order)을 미리 스냅샷 — claim이 이 시점부터
-    # 이 org의 결제 작업을 배타적으로 쥐므로, 이 조회와 아래 charge_org 사이에 다른 호출이
-    # 새 order를 confirmed로 만들 여지가 없다(레이스 없음).
-    old_confirmed_order = await _latest_confirmed_order(session, org_id)
-
     try:
+        # ⛔카디르 MEDIUM(2026-08-21, PR#3306 리뷰) — 이전 버전은 이 조회가 try 밖이라
+        # 조회 자체가 실패하면 finally(claim 해제)를 못 타 stale window 동안 org가
+        # 잠겼다. claim commit 직후를 try 시작점으로 당겨 이 조회도 finally 보호 안에
+        # 넣는다. claim이 이 시점부터 이 org의 결제 작업을 배타적으로 쥐므로, 이 조회와
+        # 아래 charge_org 사이에 다른 호출이 새 order를 confirmed로 만들 여지가 없다
+        # (레이스 없음 — 스냅샷 의미는 그대로).
+        old_confirmed_order = await _latest_confirmed_subscription_order(session, org_id)
+
         try:
             amount_minor, currency = await compute_full_charge_for_new_offering(
                 session, org_id=org_id, new_offering=new_offering,
@@ -251,7 +260,12 @@ async def _attempt_partial_refund(
             cancel_amount_minor=refund_amount,
         )
         refund_status = "confirmed"
-    except (RefundError, TossApiError) as exc:
+    except Exception as exc:
+        # 카디르 MEDIUM(2026-08-21, PR#3306 리뷰) — 이전엔 (RefundError, TossApiError)만
+        # 좁게 잡아, 그 외 예외(예: Toss 취소는 성공했는데 record_ledger_entry의 DB write가
+        # 실패)는 refund_status가 NULL로 남아 스윕이 못 찾는 사각지대였다. 이 함수의 계약
+        # 자체가 "실패해도 절대 전파 안 함"이라(④) — 예외 종류를 좁혀 잡을 이유가 없다,
+        # 전부 잡아 반드시 'failed'를 남긴다.
         logger.error(
             "tier change org_id=%s order_id=%s: partial refund FAILED(amount=%d) — %s. "
             "charge already confirmed, NOT rolled back — needs retry/sweep.",

--- a/backend/app/services/org_subscription_tier_change.py
+++ b/backend/app/services/org_subscription_tier_change.py
@@ -1,0 +1,265 @@
+"""story #2880(결제 트랙 갭①) — 월납 유료→유료 상향 엔진. doc
+`billing-policy-scenario-audit-20260821` 1번 갭: `checkout_subscription()`은 신규 결제
+전용이라 활성 유료 org에 다시 부르면 신규 티어 전액을 이중청구한다. 이 모듈이 그 전용
+경로(change-tier)를 연다.
+
+**산식 확定(선생님 최종 결정, 2026-08-21 — 페드루 릴레이)**: 「신 요금 전액 결제 후,
+기존 플랜 남은 기간의 일할 «부분취소»」— 크레딧 차감이 아니다(크레딧 잔액 인프라 자체가
+부재, doc 11번 갭). Toss 부분취소(cancel)로 실 정산한다.
+
+**상태기계**:
+①청구 = 신 offering 월 전액(`compute_full_charge_for_new_offering` — 좌석초과·팩 포함,
+  구 tier와 무관하게 신 tier 정가) — 기존 active billing_key로 `charge_org()` 즉시
+  호출(checkout과 달리 신규 billing key 발급/authKey 재인증 불요, 이미 유료 구독 中인
+  org는 유효한 키가 있다는 전제).
+②환급 = 직전 confirmed 결제 건(billing_orders, 이 org의 가장 최근 confirmed row)의
+  payment_key에 `cancelAmount = floor(구 offering 월요금 × 잔여일/전체일)` 부분취소
+  (`refund_org` 재사용 — TossAdapter.refund 경로, C4/story #2495가 이미 세운 메커니즘
+  그대로 재사용, 재구현 0).
+③period 리셋 — 업그레이드 시점=새 current_period_start, +1개월=새 current_period_end
+  (`billing_period.new_subscription_period` 재사용). 구 period는 끝났다는 뜻(과금일
+  자체가 바뀐다 — 선생님 확定 핵심 전제).
+④**시퀀싱**(#2892 시퀀싱 원칙 연장) — 신 전액 charge가 confirmed **後**에만 tier
+  전이+period 리셋+부분취소를 실행한다. 부분취소가 실패해도 이미 confirmed된 신규
+  charge는 되돌리지 않는다(선생님 지시) — 실패는 `billing_orders.refund_status='failed'`
+  로 명시 기록하고 재시도/스윕 대상으로 남긴다(이 스토리는 스윕 자체는 짓지 않는다 —
+  기록만 남겨 향후 스윕이 찾을 수 있게 한다).
+⑤스코프: billing_cycle='monthly' 3경로만(Starter→Team·Starter→Biz·Team→Biz) — annual·
+  하향은 이 함수가 명시 거부(각각 공식 문서 확定 선행·story #2881).
+ⓐ동시성 — checkout_subscription과 **같은** `org_subscriptions.checkout_claimed_at`
+  필드를 claim으로 재사용한다(같은 org에 checkout과 change-tier가 동시에 들어오면 안
+  되는 것도 이 필드 하나가 막는다 — org당 "진행 中인 결제 작업" 슬롯은 하나뿐).
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.billing_order import BillingOrder
+from app.models.offering_version import OfferingVersion
+from app.models.org_subscription import OrgSubscription
+from app.services.billing_charge import charge_org
+from app.services.billing_charge_amount import (
+    ChargeAmountError,
+    compute_full_charge_for_new_offering,
+    prorate_minor,
+)
+from app.services.billing_period import new_subscription_period
+from app.services.billing_refund import RefundError, refund_org
+from app.services.org_subscription_checkout import STALE_CLAIM_WINDOW
+from app.services.payment.toss_adapter import TossApiError
+
+logger = logging.getLogger(__name__)
+
+PAID_TIERS = frozenset({"starter", "team", "business"})
+_TIER_RANK = {"starter": 1, "team": 2, "business": 3}
+
+
+class TierChangeError(Exception):
+    """상향을 진행할 수 없는 상태(정책 위반·데이터 갭) — 명시 실패, 호출부가 400으로 번역."""
+
+
+class TierChangeDeclined(Exception):
+    """Toss 카드 거절 등 비즈니스 사유 — 시스템 오류 아님. 구독은 원 tier인 채(재시도 가능)."""
+
+    def __init__(self, message: str, *, subscription: OrgSubscription):
+        self.subscription = subscription
+        super().__init__(message)
+
+
+class TierChangeInProgress(Exception):
+    """같은 org에 다른 결제 작업(checkout·change-tier)이 진행 中 — 409, 재시도 가능."""
+
+
+async def _refetch_subscription(session: AsyncSession, org_id: uuid.UUID) -> OrgSubscription:
+    return (
+        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+    ).scalar_one()
+
+
+async def _latest_confirmed_order(session: AsyncSession, org_id: uuid.UUID) -> BillingOrder | None:
+    """이 org의 가장 최근 confirmed billing_order — 부분취소 대상(직전 결제 건)."""
+    return (
+        await session.execute(
+            select(BillingOrder)
+            .where(BillingOrder.org_id == org_id, BillingOrder.status == "confirmed")
+            .order_by(BillingOrder.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+
+async def change_tier(session: AsyncSession, *, org_id: uuid.UUID, new_tier: str) -> OrgSubscription:
+    if new_tier not in PAID_TIERS:
+        raise TierChangeError(f"new_tier={new_tier!r}는 유료 티어만(starter/team/business)")
+
+    sub = (
+        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+    ).scalar_one_or_none()
+    if sub is None or sub.status != "active" or sub.tier not in PAID_TIERS:
+        raise TierChangeError(
+            f"org_id={org_id} 활성 유료 구독이 아님 — 상향 엔진(change-tier)이 아니라 "
+            "신규 결제(checkout)로 진입해야 함"
+        )
+    if sub.billing_cycle != "monthly":
+        raise TierChangeError(
+            f"billing_cycle={sub.billing_cycle!r} — 연납 중 상향은 이 스토리 범위 밖"
+            "(공식 문서 확定 선행, doc billing-policy-scenario-audit-20260821 §3)"
+        )
+    if sub.current_period_start is None or sub.current_period_end is None:
+        raise TierChangeError(f"org_id={org_id} current_period_start/end 없음 — 일할 부분취소 계산 불가")
+    if _TIER_RANK.get(new_tier, 0) <= _TIER_RANK.get(sub.tier, 0):
+        raise TierChangeError(
+            f"{sub.tier!r}→{new_tier!r}는 상향이 아님(하향/동일) — 하향은 story #2881(예약+좌석 게이트)"
+        )
+    if sub.offering_version_id is None:
+        raise TierChangeError(f"org_subscription(org_id={org_id})에 offering_version_id가 바인딩되지 않음")
+
+    old_offering = await session.get(OfferingVersion, sub.offering_version_id)
+    if old_offering is None:
+        raise TierChangeError(f"offering_version {sub.offering_version_id}를 찾을 수 없음")
+
+    new_offering = (
+        await session.execute(
+            select(OfferingVersion).where(
+                OfferingVersion.tier == new_tier,
+                OfferingVersion.currency == "krw",
+                OfferingVersion.effective_to.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if new_offering is None:
+        raise TierChangeError(f"tier={new_tier!r}의 활성 offering_version(krw)을 찾을 수 없음")
+    if new_offering.monthly_price_minor <= old_offering.monthly_price_minor:
+        # ⓓ(페드루 지시) — rank 비교(위)로 대부분 걸리지만, 데이터 이상(같은 rank인데 가격
+        # 역전 등)까지 마지막 방어선으로 한 번 더 잰다. 정가가 실제로 안 오르는데 "상향"으로
+        # 진입하면 부분취소가 charge보다 커지는 회계 모순이 생긴다.
+        raise TierChangeError(
+            f"new_offering.monthly_price_minor({new_offering.monthly_price_minor}) <= "
+            f"old_offering.monthly_price_minor({old_offering.monthly_price_minor}) — 상향 아님"
+        )
+
+    # ⓐ claim — checkout_subscription()과 동형(같은 필드, 같은 WHERE 가드 — org당 진행 中
+    # 결제 작업 슬롯은 하나). rowcount==0이면 이미 다른 checkout/change-tier가 이 org를
+    # 쥐고 있다는 뜻(이중 클릭·동시 호출 모두 여기서 막힌다).
+    now = datetime.now(timezone.utc)
+    claim_result = await session.execute(
+        update(OrgSubscription)
+        .where(
+            OrgSubscription.org_id == org_id,
+            or_(
+                OrgSubscription.checkout_claimed_at.is_(None),
+                OrgSubscription.checkout_claimed_at < now - STALE_CLAIM_WINDOW,
+            ),
+        )
+        .values(checkout_claimed_at=now)
+    )
+    await session.commit()
+    if claim_result.rowcount == 0:
+        raise TierChangeInProgress(f"org_id={org_id}에 다른 결제 작업이 이미 진행 中 — 완료 후 재시도")
+
+    # claim 이후 부분취소 대상(직전 confirmed order)을 미리 스냅샷 — claim이 이 시점부터
+    # 이 org의 결제 작업을 배타적으로 쥐므로, 이 조회와 아래 charge_org 사이에 다른 호출이
+    # 새 order를 confirmed로 만들 여지가 없다(레이스 없음).
+    old_confirmed_order = await _latest_confirmed_order(session, org_id)
+
+    try:
+        try:
+            amount_minor, currency = await compute_full_charge_for_new_offering(
+                session, org_id=org_id, new_offering=new_offering,
+            )
+        except ChargeAmountError as exc:
+            raise TierChangeError(str(exc)) from exc
+
+        order_id = f"tierchange-{org_id}-{new_offering.id}-{uuid.uuid4().hex[:12]}"
+        try:
+            # ① 신 offering 전액 즉시 청구. 감사 기록(billing_orders+billing_ledger_entries,
+            # entry_type="charge" 기본값)은 charge_org 자체가 진다 — 별도 entry_type 신설
+            # 불요(이건 실제로 청구되는 돈이라 "charge" 분류가 맞다).
+            order = await charge_org(
+                session, org_id=org_id, order_id=order_id, amount_minor=amount_minor,
+                currency=currency, order_name=f"Sprintable {sub.tier}→{new_tier} 상향",
+                ledger_metadata={"kind": "tier_change", "from_tier": sub.tier, "to_tier": new_tier},
+            )
+        except TossApiError as exc:
+            refreshed = await _refetch_subscription(session, org_id)
+            raise TierChangeDeclined(str(exc), subscription=refreshed) from exc
+
+        # ④권리는 confirmed 後에만. 실패(pending/failed)면 tier/period 그대로 — 신 전액이
+        # 승인 안 됐는데 구 결제를 부분취소하면 이중 손실이 난다.
+        if order.status != "confirmed":
+            return await _refetch_subscription(session, org_id)
+
+        old_period_start, old_period_end = sub.current_period_start, sub.current_period_end
+        new_period_start, new_period_end = new_subscription_period(now=now, billing_cycle="monthly")
+        await session.execute(
+            update(OrgSubscription)
+            .where(OrgSubscription.org_id == org_id, OrgSubscription.checkout_claimed_at == now)
+            .values(
+                tier=new_tier, offering_version_id=new_offering.id,
+                current_period_start=new_period_start, current_period_end=new_period_end,
+            )
+        )
+        await session.commit()
+
+        # ②③ 구 tier 잔여분 부분취소. old_confirmed_order가 없으면(예: 최초 체크아웃
+        # 직후 잔여 팩분 정산 등 예외 상태) 부분취소할 대상 자체가 없다는 뜻 — charge는
+        # 이미 confirmed로 완결됐으니 여기서 실패로 되돌리지 않고 조용히 skip(로그만).
+        if old_confirmed_order is not None:
+            refund_amount = prorate_minor(
+                old_offering.monthly_price_minor, now=now,
+                period_start=old_period_start, period_end=old_period_end,
+            )
+            if refund_amount > 0:
+                await _attempt_partial_refund(
+                    session, org_id=org_id, order=old_confirmed_order, refund_amount=refund_amount,
+                    from_tier=sub.tier, to_tier=new_tier,
+                )
+        else:
+            logger.warning(
+                "tier change org_id=%s: no prior confirmed billing_order to partially refund "
+                "(charge already confirmed, tier/period already advanced — skipping refund step)",
+                org_id,
+            )
+
+        return await _refetch_subscription(session, org_id)
+    finally:
+        await session.execute(
+            update(OrgSubscription)
+            .where(OrgSubscription.org_id == org_id, OrgSubscription.checkout_claimed_at == now)
+            .values(checkout_claimed_at=None)
+        )
+        await session.commit()
+
+
+async def _attempt_partial_refund(
+    session: AsyncSession, *, org_id: uuid.UUID, order: BillingOrder, refund_amount: int,
+    from_tier: str, to_tier: str,
+) -> None:
+    """구 결제 건에 잔여기간 일할 부분취소 — 실패해도 예외를 전파하지 않는다(④, 선생님
+    지시: 이미 confirmed된 신규 charge를 되돌리지 않는다). 결과는 billing_orders.
+    refund_status에 명시 기록(0267) — 향후 재시도/스윕이 이 필드로 찾는다(이 스토리는
+    스윕 자체는 안 짓는다)."""
+    try:
+        await refund_org(
+            session, org_id=org_id, order_id=order.order_id,
+            cancel_reason=f"tier change {from_tier}->{to_tier} — prorated remainder",
+            cancel_amount_minor=refund_amount,
+        )
+        refund_status = "confirmed"
+    except (RefundError, TossApiError) as exc:
+        logger.error(
+            "tier change org_id=%s order_id=%s: partial refund FAILED(amount=%d) — %s. "
+            "charge already confirmed, NOT rolled back — needs retry/sweep.",
+            org_id, order.order_id, refund_amount, exc,
+        )
+        refund_status = "failed"
+
+    await session.execute(
+        update(BillingOrder).where(BillingOrder.id == order.id).values(refund_status=refund_status)
+    )
+    await session.commit()

--- a/backend/tests/test_2880_prorate_minor_unit.py
+++ b/backend/tests/test_2880_prorate_minor_unit.py
@@ -1,0 +1,64 @@
+"""story #2880 — `prorate_minor` 순수함수 유닛테스트(카디르 비차단 권고, PR#3306 리뷰).
+
+카디르+codex 뮤테이션 테스트가 `math.floor`→`round` 치환을 seed값(29000×2/3=19333.33)
+에서 무감지 확認(19333이 floor·round 둘 다 같음 — 우연히 같은 값이 나오는 케이스였을
+뿐, floor 자체가 틀렸다는 뜻은 아님). floor와 round가 실제로 갈리는 값으로 별도
+검증해 "floor가 명시적으로 필요하다"는 계약을 직접 고정한다."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+def test_prorate_minor_floors_when_round_would_go_up():
+    """price_minor=100·remaining/total=2/3 → 66.666... — floor=66, round()라면 67.
+    round으로 뮤테이션되면 이 테스트가 즉시 잡는다(29000 seed와 달리 여기선 두 값이
+    실제로 다르다)."""
+    from app.services.billing_charge_amount import prorate_minor
+
+    period_start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    period_end = period_start + timedelta(days=30)  # 30일 주기
+    now = period_start + timedelta(days=10)  # 잔여 20일 = 2/3
+
+    result = prorate_minor(100, now=now, period_start=period_start, period_end=period_end)
+
+    assert result == 66
+    assert result != round(100 * 2 / 3)  # round면 67 — floor와 실제로 갈리는 지점
+
+
+def test_prorate_minor_zero_remaining_at_period_start_returns_full_amount():
+    period_start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    period_end = period_start + timedelta(days=30)
+    from app.services.billing_charge_amount import prorate_minor
+
+    result = prorate_minor(9000, now=period_start, period_start=period_start, period_end=period_end)
+    assert result == 9000  # 잔여 100% — 전액
+
+
+def test_prorate_minor_at_period_end_raises_not_zero_silently():
+    """잔여 0(now==period_end)은 "0을 반환"이 아니라 명시 실패 — 호출부가 그 자리를
+    "부분취소 불필요"로 오인하지 않게(계산 불가와 0은 다른 사실)."""
+    from app.services.billing_charge_amount import ChargeAmountError, prorate_minor
+
+    period_start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    period_end = period_start + timedelta(days=30)
+    with pytest.raises(ChargeAmountError):
+        prorate_minor(9000, now=period_end, period_start=period_start, period_end=period_end)
+
+
+def test_prorate_minor_now_past_period_end_clamps_to_zero_remaining_and_raises():
+    from app.services.billing_charge_amount import ChargeAmountError, prorate_minor
+
+    period_start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    period_end = period_start + timedelta(days=30)
+    with pytest.raises(ChargeAmountError):
+        prorate_minor(9000, now=period_end + timedelta(days=1), period_start=period_start, period_end=period_end)
+
+
+def test_prorate_minor_invalid_period_raises():
+    from app.services.billing_charge_amount import ChargeAmountError, prorate_minor
+
+    period_start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    with pytest.raises(ChargeAmountError):
+        prorate_minor(9000, now=period_start, period_start=period_start, period_end=period_start)  # total=0

--- a/backend/tests/test_2880_tier_change_upgrade_proration_realdb.py
+++ b/backend/tests/test_2880_tier_change_upgrade_proration_realdb.py
@@ -1,0 +1,391 @@
+"""story #2880(결제 트랙 갭①) — 월납 유료→유료 상향 엔진 실PG 검증. `test_e_2506_
+subscription_checkout_realdb.py`와 동형(TossAdapter._post만 mock, 나머지는 실 DB) — 이
+파일은 기존 active billing_key + active 유료 구독 + 직전 confirmed billing_order를
+직접 seed해(checkout을 거치지 않고) change_tier() 자체를 검증한다.
+
+**산식**(선생님 최종 확定, 2026-08-21): 신 offering 전액 즉시 청구(charge) → confirmed
+後 tier+period 즉시 전이 → 직전 confirmed 결제 건에 잔여기간 일할 부분취소(refund).
+
+커버:
+  AC①: 신 offering 전액(좌석초과 포함) 청구 — delta 아님.
+  AC②: 부분취소가 직전 confirmed order의 payment_key로 floor(구 월요금×잔여일/전체일)
+       cancelAmount 부분취소를 정확히 태우는지(TossAdapter._post 2회 호출 — charge 1
+       cancel 1, 순서까지 확認).
+  AC③: period 리셋 — current_period_start=업그레이드 시각, current_period_end=+1개월.
+  AC④: 신규 charge confirmed 前 실패 시 tier/period 원본 유지. 부분취소 실패는 신규
+       charge를 되돌리지 않고 billing_orders.refund_status='failed'만 남긴다.
+  AC⑤: annual/하향/동일가/미활성 구독은 TierChangeError(400 매핑 대상).
+  ⓐ: 동시 두 change-tier 호출 중 하나만 성공(claim).
+"""
+from __future__ import annotations
+
+import math
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _crypto_key(monkeypatch):
+    import app.core.config as config_module
+    from app.services import billing_key_crypto
+
+    monkeypatch.setattr(config_module.settings, "org_billing_key_encryption_key", "W3x6lXDky6UQE36FyRU_Snf9m7d73Aev59D4PvS4-N0=")
+    billing_key_crypto._get_multi_fernet.cache_clear()
+    yield
+    billing_key_crypto._get_multi_fernet.cache_clear()
+
+
+async def _seed_org(session):
+    org_id = uuid.uuid4()
+    await session.execute(
+        text("INSERT INTO organizations (id, name, slug, plan) VALUES (:id, :name, :slug, 'free')"),
+        {"id": org_id, "name": f"test-org-{org_id}", "slug": f"slug-{org_id}"},
+    )
+    await session.commit()
+    return org_id
+
+
+async def _offering(session, tier):
+    row = (
+        await session.execute(
+            text("SELECT id, monthly_price_minor FROM offering_versions WHERE tier=:t AND currency='krw' AND effective_to IS NULL"),
+            {"t": tier},
+        )
+    ).first()
+    assert row is not None, f"offering_version(tier={tier!r}, krw) 시드 없음 — 0228 마이그 확認"
+    return row.id, row.monthly_price_minor
+
+
+async def _seed_active_paid_subscription(
+    session, org_id, *, tier="starter", period_start=None, period_end=None,
+):
+    offering_id, _ = await _offering(session, tier)
+    period_start = period_start or datetime.now(timezone.utc) - timedelta(days=10)
+    period_end = period_end or period_start + timedelta(days=30)
+    await session.execute(
+        text(
+            "INSERT INTO org_subscriptions "
+            "(id, org_id, tier, billing_cycle, status, currency, provider, offering_version_id, "
+            " current_period_start, current_period_end) "
+            "VALUES (:id, :org_id, :tier, 'monthly', 'active', 'krw', 'toss', :oid, :ps, :pe)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "tier": tier, "oid": offering_id, "ps": period_start, "pe": period_end},
+    )
+    await session.commit()
+    return offering_id, period_start, period_end
+
+
+async def _seed_active_billing_key(session, org_id):
+    from app.services.billing_key_crypto import encrypt_billing_key
+
+    await session.execute(
+        text(
+            "INSERT INTO org_billing_keys (id, org_id, customer_key, encrypted_billing_key, status, issued_at) "
+            "VALUES (:id, :org_id, :ck, :ebk, 'active', now())"
+        ),
+        {
+            "id": uuid.uuid4(), "org_id": org_id, "ck": f"org-{org_id}",
+            "ebk": encrypt_billing_key("plaintext-billing-key-test"),
+        },
+    )
+    await session.commit()
+
+
+async def _seed_prior_confirmed_order(session, org_id, *, amount_minor):
+    """직전 결제(원 tier 가입 시 charge)를 흉내 — 부분취소 대상."""
+    order_id = f"prior-{uuid.uuid4()}"
+    payment_key = f"pay-prior-{uuid.uuid4()}"
+    await session.execute(
+        text(
+            "INSERT INTO billing_orders (id, org_id, order_id, amount_minor, currency, status, payment_key) "
+            "VALUES (:id, :org_id, :oid, :amt, 'krw', 'confirmed', :pk)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "oid": order_id, "amt": amount_minor, "pk": payment_key},
+    )
+    await session.commit()
+    return order_id, payment_key
+
+
+def _toss_cancel_response(cancel_amount):
+    return {
+        "cancels": [{"transactionKey": f"txn-{uuid.uuid4()}", "cancelAmount": cancel_amount}],
+    }
+
+
+@pytest.mark.anyio
+async def test_upgrade_charges_full_new_price_and_partial_refunds_prior_order_realdb():
+    from app.services.org_subscription_tier_change import change_tier
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            # 30일 주기 중 정확히 10일 경과 → 잔여 20일(2/3).
+            period_start = datetime.now(timezone.utc) - timedelta(days=10)
+            period_end = period_start + timedelta(days=30)
+            _, starter_price = await _offering(session, "starter")
+            _, team_price = await _offering(session, "team")
+            assert team_price > starter_price, "team이 starter보다 비싸야 이 테스트가 의미 있음"
+
+            await _seed_active_paid_subscription(
+                session, org_id, tier="starter", period_start=period_start, period_end=period_end,
+            )
+            await _seed_active_billing_key(session, org_id)
+            prior_order_id, prior_payment_key = await _seed_prior_confirmed_order(session, org_id, amount_minor=starter_price)
+
+            toss_charge_response = {"paymentKey": f"pay-new-{uuid.uuid4()}", "totalAmount": team_price}
+            expected_refund_upper = math.floor(starter_price * (period_end - datetime.now(timezone.utc)).total_seconds() / (period_end - period_start).total_seconds())
+            toss_cancel_response = _toss_cancel_response(expected_refund_upper)
+
+            call_log = []
+
+            async def _fake_post(self, path, **kwargs):
+                call_log.append(path)
+                if "cancel" in path:
+                    return toss_cancel_response
+                return toss_charge_response
+
+            before_call = datetime.now(timezone.utc)
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=_fake_post):
+                sub = await change_tier(session, org_id=org_id, new_tier="team")
+            after_call = datetime.now(timezone.utc)
+
+            # AC① — 신 offering 전액 청구(delta 아님).
+            new_order_row = (
+                await session.execute(
+                    text("SELECT status, amount_minor FROM billing_orders WHERE org_id=:oid AND amount_minor=:amt AND order_id != :prior"),
+                    {"oid": org_id, "amt": team_price, "prior": prior_order_id},
+                )
+            ).first()
+            assert new_order_row is not None, "신 offering 전액(team_price) 청구 row가 없음"
+            assert new_order_row.status == "confirmed"
+
+            # AC③ — period 리셋.
+            assert sub.tier == "team"
+            assert before_call <= sub.current_period_start <= after_call
+            assert sub.current_period_end > sub.current_period_start + timedelta(days=29)
+
+            # AC② — 부분취소가 직전 order를 정확히 태움 + charge가 cancel보다 먼저 호출됨.
+            cancel_calls = [c for c in call_log if "cancel" in c]
+            assert len(cancel_calls) == 1
+            assert prior_payment_key in cancel_calls[0]
+            charge_idx = next(i for i, c in enumerate(call_log) if "billing/" in c and "cancel" not in c)
+            cancel_idx = next(i for i, c in enumerate(call_log) if "cancel" in c)
+            assert charge_idx < cancel_idx, "charge가 cancel보다 먼저 호출돼야 함(④ 시퀀싱)"
+
+            prior_row = (
+                await session.execute(
+                    text("SELECT refund_status FROM billing_orders WHERE order_id=:oid"), {"oid": prior_order_id},
+                )
+            ).first()
+            assert prior_row.refund_status == "confirmed"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_upgrade_charge_declined_keeps_original_tier_and_period_realdb():
+    """AC④ — 신규 전액 charge가 카드 거절되면 tier/period 그대로여야 한다(부분취소는
+    애초에 시도되지 않아야 함 — Toss._post가 charge용 1회만 호출되고 그 뒤로 안 불림)."""
+    from app.services.org_subscription_tier_change import TierChangeDeclined, change_tier
+    from app.services.payment.toss_adapter import TossApiError
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            _, period_start, period_end = await _seed_active_paid_subscription(session, org_id, tier="starter")
+            await _seed_active_billing_key(session, org_id)
+            prior_order_id, _ = await _seed_prior_confirmed_order(session, org_id, amount_minor=1000)
+
+            async def _raise_declined(*args, **kwargs):
+                raise TossApiError("CARD_DECLINED", "카드 거절", status_code=400)
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=_raise_declined):
+                with pytest.raises(TierChangeDeclined) as exc_info:
+                    await change_tier(session, org_id=org_id, new_tier="team")
+                assert exc_info.value.subscription.tier == "starter"
+
+            row = (
+                await session.execute(
+                    text("SELECT tier, current_period_start, current_period_end, checkout_claimed_at FROM org_subscriptions WHERE org_id=:oid"),
+                    {"oid": org_id},
+                )
+            ).first()
+            assert row.tier == "starter"
+            assert row.current_period_start == period_start
+            assert row.current_period_end == period_end
+            assert row.checkout_claimed_at is None  # claim 해제(finally)
+
+            # 부분취소가 시도조차 안 됐어야 함 — refund_status는 seed 시점 NULL 그대로.
+            prior_row = (
+                await session.execute(text("SELECT refund_status FROM billing_orders WHERE order_id=:oid"), {"oid": prior_order_id})
+            ).first()
+            assert prior_row.refund_status is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_partial_refund_failure_does_not_roll_back_confirmed_charge_realdb():
+    """AC④ 핵심 — 신규 charge는 confirmed됐는데 부분취소가 실패하면: tier/period는 그대로
+    반영돼 있고(되돌리지 않음), 직전 order.refund_status='failed'만 남는다."""
+    from app.services.org_subscription_tier_change import change_tier
+    from app.services.payment.toss_adapter import TossApiError
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            _, starter_price = await _offering(session, "starter")
+            await _seed_active_paid_subscription(session, org_id, tier="starter")
+            await _seed_active_billing_key(session, org_id)
+            prior_order_id, _ = await _seed_prior_confirmed_order(session, org_id, amount_minor=starter_price)
+
+            _, team_price = await _offering(session, "team")
+            toss_charge_response = {"paymentKey": f"pay-new-{uuid.uuid4()}", "totalAmount": team_price}
+
+            async def _fake_post(self, path, **kwargs):
+                if "cancel" in path:
+                    raise TossApiError("INTERNAL_SERVER_ERROR", "일시 장애", status_code=500)
+                return toss_charge_response
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=_fake_post):
+                sub = await change_tier(session, org_id=org_id, new_tier="team")
+
+            # 신규 charge는 confirmed로 살아있고 tier도 이미 team — 되돌리지 않음.
+            assert sub.tier == "team"
+            new_order_row = (
+                await session.execute(
+                    text("SELECT status FROM billing_orders WHERE org_id=:oid AND order_id != :prior"),
+                    {"oid": org_id, "prior": prior_order_id},
+                )
+            ).first()
+            assert new_order_row.status == "confirmed"
+
+            prior_row = (
+                await session.execute(text("SELECT refund_status FROM billing_orders WHERE order_id=:oid"), {"oid": prior_order_id})
+            ).first()
+            assert prior_row.refund_status == "failed"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_annual_billing_cycle_rejected_realdb():
+    """AC⑤ — 연납 중 상향은 이 스토리 범위 밖(공식 문서 확定 선행), TierChangeError."""
+    from app.services.org_subscription_tier_change import TierChangeError, change_tier
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            offering_id, _ = await _offering(session, "starter")
+            await session.execute(
+                text(
+                    "INSERT INTO org_subscriptions (id, org_id, tier, billing_cycle, status, currency, provider, offering_version_id) "
+                    "VALUES (:id, :org_id, 'starter', 'annual', 'active', 'krw', 'toss', :oid)"
+                ),
+                {"id": uuid.uuid4(), "org_id": org_id, "oid": offering_id},
+            )
+            await session.commit()
+
+            with pytest.raises(TierChangeError, match="annual|연납"):
+                await change_tier(session, org_id=org_id, new_tier="team")
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_downgrade_direction_rejected_realdb():
+    """AC⑤+ⓓ — team→starter(하향)는 이 엔진이 아니라 story #2881 몫, TierChangeError."""
+    from app.services.org_subscription_tier_change import TierChangeError, change_tier
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            await _seed_active_paid_subscription(session, org_id, tier="team")
+            await _seed_active_billing_key(session, org_id)
+
+            with pytest.raises(TierChangeError, match="상향이 아님"):
+                await change_tier(session, org_id=org_id, new_tier="starter")
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_tier_rejected_realdb():
+    """AC⑤+ⓓ — 동일 tier 재제출도 상향이 아님."""
+    from app.services.org_subscription_tier_change import TierChangeError, change_tier
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            await _seed_active_paid_subscription(session, org_id, tier="team")
+            await _seed_active_billing_key(session, org_id)
+
+            with pytest.raises(TierChangeError, match="상향이 아님"):
+                await change_tier(session, org_id=org_id, new_tier="team")
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_concurrent_change_tier_calls_only_one_succeeds_realdb():
+    """ⓐ — 동시 두 change-tier 호출(이중 클릭 가정) 중 정확히 하나만 claim에 성공,
+    나머지는 TierChangeInProgress(409 매핑 대상)."""
+    import asyncio
+
+    from app.services.org_subscription_tier_change import TierChangeInProgress, change_tier
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as setup_session:
+            org_id = await _seed_org(setup_session)
+            await _seed_active_paid_subscription(setup_session, org_id, tier="starter")
+            await _seed_active_billing_key(setup_session, org_id)
+
+        async def _attempt():
+            async with Session() as s:
+                async def _fake_post(self, path, **kwargs):
+                    if "cancel" in path:
+                        return _toss_cancel_response(0)
+                    return {"paymentKey": f"pay-{uuid.uuid4()}", "totalAmount": 0}
+
+                with patch("app.services.payment.toss_adapter.TossAdapter._post", new=_fake_post):
+                    return await change_tier(s, org_id=org_id, new_tier="team")
+
+        results = await asyncio.gather(_attempt(), _attempt(), return_exceptions=True)
+        succeeded = [r for r in results if not isinstance(r, Exception)]
+        in_progress = [r for r in results if isinstance(r, TierChangeInProgress)]
+        assert len(succeeded) == 1, f"정확히 하나만 성공해야 함: {results}"
+        assert len(in_progress) == 1, f"나머지 하나는 TierChangeInProgress여야 함: {results}"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2880_tier_change_upgrade_proration_realdb.py
+++ b/backend/tests/test_2880_tier_change_upgrade_proration_realdb.py
@@ -109,16 +109,35 @@ async def _seed_active_billing_key(session, org_id):
     await session.commit()
 
 
-async def _seed_prior_confirmed_order(session, org_id, *, amount_minor):
-    """직전 결제(원 tier 가입 시 charge)를 흉내 — 부분취소 대상."""
+async def _seed_prior_confirmed_order(session, org_id, *, amount_minor, created_at=None):
+    """직전 결제(원 tier 가입 시 charge)를 흉내 — 부분취소 대상. purpose는 컬럼
+    server_default('charge')에 맡긴다(0268)."""
     order_id = f"prior-{uuid.uuid4()}"
     payment_key = f"pay-prior-{uuid.uuid4()}"
+    created_at = created_at or datetime.now(timezone.utc)
     await session.execute(
         text(
-            "INSERT INTO billing_orders (id, org_id, order_id, amount_minor, currency, status, payment_key) "
-            "VALUES (:id, :org_id, :oid, :amt, 'krw', 'confirmed', :pk)"
+            "INSERT INTO billing_orders (id, org_id, order_id, amount_minor, currency, status, payment_key, created_at) "
+            "VALUES (:id, :org_id, :oid, :amt, 'krw', 'confirmed', :pk, :ca)"
         ),
-        {"id": uuid.uuid4(), "org_id": org_id, "oid": order_id, "amt": amount_minor, "pk": payment_key},
+        {"id": uuid.uuid4(), "org_id": org_id, "oid": order_id, "amt": amount_minor, "pk": payment_key, "ca": created_at},
+    )
+    await session.commit()
+    return order_id, payment_key
+
+
+async def _seed_pack_purchase_order(session, org_id, *, amount_minor, created_at=None):
+    """카디르 CRITICAL 재현용 — pack 구매도 같은 billing_orders 테이블에 confirmed row를
+    남긴다(billing_pack.py::purchase_packs, charge_org(entry_type="pack_purchase"))."""
+    order_id = f"pack-{uuid.uuid4()}"
+    payment_key = f"pay-pack-{uuid.uuid4()}"
+    created_at = created_at or datetime.now(timezone.utc)
+    await session.execute(
+        text(
+            "INSERT INTO billing_orders (id, org_id, order_id, amount_minor, currency, status, payment_key, purpose, created_at) "
+            "VALUES (:id, :org_id, :oid, :amt, 'krw', 'confirmed', :pk, 'pack_purchase', :ca)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "oid": order_id, "amt": amount_minor, "pk": payment_key, "ca": created_at},
     )
     await session.commit()
     return order_id, payment_key
@@ -387,5 +406,126 @@ async def test_concurrent_change_tier_calls_only_one_succeeds_realdb():
         in_progress = [r for r in results if isinstance(r, TierChangeInProgress)]
         assert len(succeeded) == 1, f"정확히 하나만 성공해야 함: {results}"
         assert len(in_progress) == 1, f"나머지 하나는 TierChangeInProgress여야 함: {results}"
+    finally:
+        await engine.dispose()
+
+
+# ─── 카디르 CRITICAL 재현 회귀(2026-08-21, PR#3306 리뷰) — pack구매 오인 부분취소 ───
+
+@pytest.mark.anyio
+async def test_partial_refund_targets_subscription_charge_not_more_recent_pack_purchase_realdb():
+    """시나리오 A(카디르 재현①) — pack금액이 prorate액보다 작을 때. 정정 前엔
+    `_latest_confirmed_order`가 더 최근인 pack 주문을 골라 refund_org 자체 방어
+    (cancel_amount_minor exceeds original charge amount)로 막혀 refund_status='failed'만
+    남고, 진짜 구독 결제는 영원히 미환급이었다. 정정 後엔 purpose='charge' 필터로
+    구독 order를 정확히 골라 성공해야 한다."""
+    from app.services.org_subscription_tier_change import change_tier
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            period_start = datetime.now(timezone.utc) - timedelta(days=10)
+            period_end = period_start + timedelta(days=30)
+            _, starter_price = await _offering(session, "starter")
+            _, team_price = await _offering(session, "team")
+
+            await _seed_active_paid_subscription(session, org_id, tier="starter", period_start=period_start, period_end=period_end)
+            await _seed_active_billing_key(session, org_id)
+            # 구독 charge(10일 전, starter_price) — 부분취소 진짜 대상.
+            sub_order_id, sub_payment_key = await _seed_prior_confirmed_order(
+                session, org_id, amount_minor=starter_price, created_at=period_start,
+            )
+            # pack 구매(1일 전, 구독 charge보다 최근이지만 소액) — 오인 대상이면 안 됨.
+            pack_amount = 5_000
+            await _seed_pack_purchase_order(
+                session, org_id, amount_minor=pack_amount,
+                created_at=datetime.now(timezone.utc) - timedelta(days=1),
+            )
+
+            call_log = []
+
+            async def _fake_post(self, path, **kwargs):
+                call_log.append((path, kwargs.get("json")))
+                if "cancel" in path:
+                    return _toss_cancel_response(kwargs["json"]["cancelAmount"])
+                return {"paymentKey": f"pay-new-{uuid.uuid4()}", "totalAmount": team_price}
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=_fake_post):
+                await change_tier(session, org_id=org_id, new_tier="team")
+
+            cancel_calls = [c for c in call_log if "cancel" in c[0]]
+            assert len(cancel_calls) == 1
+            assert sub_payment_key in cancel_calls[0][0], "부분취소가 구독 order를 타겟해야 함(pack 아님)"
+
+            sub_row = (
+                await session.execute(text("SELECT refund_status FROM billing_orders WHERE order_id=:oid"), {"oid": sub_order_id})
+            ).first()
+            assert sub_row.refund_status == "confirmed"
+
+            # pack 주문은 손대지 않았어야 함.
+            pack_row = (
+                await session.execute(text("SELECT refund_status FROM billing_orders WHERE purpose='pack_purchase' AND org_id=:oid"), {"oid": org_id})
+            ).first()
+            assert pack_row.refund_status is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_partial_refund_does_not_silently_cancel_unrelated_pack_purchase_when_pack_amount_larger_realdb():
+    """시나리오 B(카디르 재현②, 더 위험) — pack금액이 prorate액보다 클 때. 정정 前엔
+    refund_org의 「초과 금액 방어」가 안 걸려(pack 주문 자체 금액이 충분히 커서)
+    무관한 고객의 정상 pack 구매가 조용히 부분취소됐다(refund_status='confirmed'로
+    기록되지만 targeted_pack=True, targeted_sub=False — 아무 에러도 없이 잘못된 돈이
+    빠져나감). 정정 後엔 애초에 pack 주문이 후보에 들지 않아야 한다."""
+    from app.services.org_subscription_tier_change import change_tier
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            period_start = datetime.now(timezone.utc) - timedelta(days=10)
+            period_end = period_start + timedelta(days=30)
+            _, starter_price = await _offering(session, "starter")
+            _, team_price = await _offering(session, "team")
+
+            await _seed_active_paid_subscription(session, org_id, tier="starter", period_start=period_start, period_end=period_end)
+            await _seed_active_billing_key(session, org_id)
+            sub_order_id, sub_payment_key = await _seed_prior_confirmed_order(
+                session, org_id, amount_minor=starter_price, created_at=period_start,
+            )
+            # pack 구매 — prorate액(대략 starter_price*2/3)보다 확실히 크게, 방어선에
+            # 안 걸리도록.
+            pack_amount = starter_price * 10
+            pack_order_id, pack_payment_key = await _seed_pack_purchase_order(
+                session, org_id, amount_minor=pack_amount,
+                created_at=datetime.now(timezone.utc) - timedelta(days=1),
+            )
+
+            call_log = []
+
+            async def _fake_post(self, path, **kwargs):
+                call_log.append((path, kwargs.get("json")))
+                if "cancel" in path:
+                    return _toss_cancel_response(kwargs["json"]["cancelAmount"])
+                return {"paymentKey": f"pay-new-{uuid.uuid4()}", "totalAmount": team_price}
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=_fake_post):
+                await change_tier(session, org_id=org_id, new_tier="team")
+
+            cancel_calls = [c for c in call_log if "cancel" in c[0]]
+            assert len(cancel_calls) == 1
+            targeted_pack = pack_payment_key in cancel_calls[0][0]
+            targeted_sub = sub_payment_key in cancel_calls[0][0]
+            assert not targeted_pack, "무관한 pack 구매가 취소되면 안 됨(카디르 재현 시나리오B)"
+            assert targeted_sub, "구독 charge가 부분취소 대상이어야 함"
+
+            pack_row = (
+                await session.execute(text("SELECT refund_status FROM billing_orders WHERE order_id=:oid"), {"oid": pack_order_id})
+            ).first()
+            assert pack_row.refund_status is None, "pack 주문은 절대 건드리면 안 됨"
     finally:
         await engine.dispose()

--- a/backend/tests/test_2892_billing_charge_amount_decimal_realdb.py
+++ b/backend/tests/test_2892_billing_charge_amount_decimal_realdb.py
@@ -123,23 +123,64 @@ async def test_compute_pack_charge_minor_zero_when_no_period():
         await engine.dispose()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toss_adapter_charge_json_body_amount_is_native_int_even_given_decimal():
-    """어댑터 경계 방어(둘째 층) — 호출부가 실수로 Decimal을 넘겨도 charge()가 int로
-    강제 변환해 httpx json 인코딩이 죽지 않는다. 실 Toss 호출은 안 나가게 시크릿
-    미설정으로 그 전 단계(_auth_header)에서 명시 실패시켜 네트워크 접촉 0으로 검증."""
+    """⛔story #2897 카디르 발견(2026-08-21, QA secondary on #3301) — 이 테스트의 이전
+    버전은 `toss_payments_secret_key=""`로 만들어 `_auth_header()`가 `int(amount_minor)`
+    캐스트(toss_adapter.py:148)와 json 바디 조립에 도달하기 前에 RuntimeError로
+    먼저 죽었다 — «캐스트가 실제로 동작하는지»를 한 번도 실행하지 않은 채 이름만
+    맞는 tautology였다(시크릿 없어도 통과·있어도 통과·캐스트를 지워도 통과). 이제
+    `_post`를 mock해 실제로 그 지점까지 코드가 도달하게 한 뒤, mock에 넘어간 kwargs의
+    `json["amount"]`가 진짜 `int`(Decimal 아님)인지 타입으로 직접 확認한다."""
     from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
     from app.services.payment.toss_adapter import TossAdapter
     from app.core.config import settings
 
     adapter = TossAdapter()
     original_secret = settings.toss_payments_secret_key
-    settings.toss_payments_secret_key = ""
+    settings.toss_payments_secret_key = "test-secret-key"
     try:
-        with pytest.raises(RuntimeError, match="TOSS_PAYMENTS_SECRET_KEY"):
+        with patch.object(
+            adapter, "_post",
+            new=AsyncMock(return_value={"paymentKey": "pay-1", "totalAmount": 29000}),
+        ) as mock_post:
             await adapter.charge(
                 billing_key="bk_test", customer_key="ck_test", order_id="ord_test",
                 amount_minor=Decimal("29000"), order_name="test",
             )
+        sent_amount = mock_post.await_args.kwargs["json"]["amount"]
+        assert type(sent_amount) is int, f"amount가 여전히 {type(sent_amount)} — 캐스트가 죽었거나 우회됨"
+        assert sent_amount == 29000
+    finally:
+        settings.toss_payments_secret_key = original_secret
+
+
+@pytest.mark.anyio
+async def test_toss_adapter_refund_json_body_cancel_amount_is_native_int_even_given_decimal():
+    """⛔story #2897 — 위 charge 테스트의 짝(부재 축). `TossAdapter.refund()`의
+    `cancelAmount` 캐스트(toss_adapter.py:203)도 같은 클래스의 방어가 필요한데 지금까지
+    이 캐스트를 Decimal 입력으로 실증한 테스트가 0건이었다(기존 refund 테스트들은 전부
+    이미 int인 값만 넘겼다 — test_e_2495_c4_refund_reconciliation.py 확認)."""
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+    from app.services.payment.toss_adapter import TossAdapter
+    from app.core.config import settings
+
+    adapter = TossAdapter()
+    original_secret = settings.toss_payments_secret_key
+    settings.toss_payments_secret_key = "test-secret-key"
+    try:
+        with patch.object(
+            adapter, "_post",
+            new=AsyncMock(return_value={"cancels": [{"transactionKey": "tx-1", "cancelAmount": 10000}]}),
+        ) as mock_post:
+            await adapter.refund(
+                payment_key="pay_test", cancel_reason="test",
+                cancel_amount_minor=Decimal("10000"), idempotency_key="idem-1",
+            )
+        sent_cancel_amount = mock_post.await_args.kwargs["json"]["cancelAmount"]
+        assert type(sent_cancel_amount) is int, f"cancelAmount가 여전히 {type(sent_cancel_amount)} — 캐스트가 죽었거나 우회됨"
+        assert sent_cancel_amount == 10000
     finally:
         settings.toss_payments_secret_key = original_secret


### PR DESCRIPTION
## Summary
- doc `billing-policy-scenario-audit-20260821` 1번 갭 정정: `checkout_subscription()`이 신규 결제 전용이라 활성 유료 org에 재호출 시 신규 티어 전액 이중청구 — 전용 경로(`POST /api/v2/org-subscriptions/change-tier`)를 신설.
- 산식(선생님 최종 확定): 신 offering 전액 즉시 청구(기존 active billing_key, authKey 재인증 불요) → confirmed 後에만 tier 전이+period 리셋(과금일 변경)+직전 confirmed 결제 건에 잔여기간 일할 부분취소(`floor(구 월요금×잔여일/전체일)`, Toss cancel).
- 부분취소 실패는 이미 confirmed된 신규 charge를 되돌리지 않음 — `billing_orders.refund_status`(마이그 0267 신설)='failed'로 명시 기록, 재시도/스윕은 후속.
- 동시성: `checkout_subscription`과 같은 `checkout_claimed_at` claim 필드 재사용(org당 진행 中 결제 작업 슬롯은 하나).
- 스코프: 월납 3경로만(Starter→Team·Starter→Biz·Team→Biz) — annual·하향은 400 거부.
- `billing_charge_amount.py`: base+seat+pack 계산을 `_compute_amount_for_offering`으로 추출(재구현 0) — `compute_full_charge_for_new_offering`이 재사용. `prorate_minor`(순수함수, floor 확定)가 부분취소 금액을 잰다.
- **#2897 부수 정정(페드루 지시로 이 PR에 함께)**: `TossAdapter.charge()`의 Decimal 경계-캐스트 테스트가 secret 미설정으로 `_auth_header()`에서 먼저 죽어 실제로 캐스트 지점에 도달한 적이 없던 tautology였음을 발견·정정(`_post` mock으로 실도달+타입 직검) + `refund()`의 동형 캐스트(cancelAmount)는 테스트가 아예 없어 짝으로 신설. 캐스트 제거 시 둘 다 정확히 fail하는 것으로 load-bearing 실증.

## Test plan
- [x] `pytest tests/test_2880_tier_change_upgrade_proration_realdb.py` — 7 passed(실PG): 전액청구+부분취소 정합·period 리셋·charge confirmed 前 실패 시 원복·부분취소 실패해도 charge 무회귀·annual/하향/동일가 거부·동시성 claim.
- [x] `pytest tests/test_2892_billing_charge_amount_decimal_realdb.py` — 4 passed, 캐스트 제거 시 2건 정확히 fail(load-bearing 실증 후 원복).
- [x] 회귀 스윕(checkout/refund/2892/2474 관련 62+29건) — 무회귀.
- [x] `test_authz_project_scope_coverage.py` — 13 passed.
- [x] `python -c "import app.main"` — 임포트 확認.

[SID:2880]