### PR TITLE
[SID:2905] S2c① FE — 임베드 형태 스펙트럼: artifact/mockup 실 렌더 인라인

### DIFF
--- a/apps/web/src/components/chat/embed-card.artifact-form.test.tsx
+++ b/apps/web/src/components/chat/embed-card.artifact-form.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+//
+// story #2905(S2c①) — EmbedCard artifact/mockup 실 렌더 인라인 폼 회귀가드. ArtifactThumbnail
+// 자체(PNG export·canvas 렌더)는 별도 테스트 대상 — 여기는 EmbedCard의 fetch→분기 로직만.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EmbedCard } from './embed-card';
+
+vi.mock('@/components/canvas/artifact-thumbnail', () => ({
+  ArtifactThumbnail: ({ artifactId, latestVersionNumber }: { artifactId: string; latestVersionNumber: number }) => (
+    <div data-testid="artifact-thumbnail" data-artifact-id={artifactId} data-version={latestVersionNumber} />
+  ),
+}));
+
+const pushMock = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: pushMock }) }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('EmbedCard artifact 실 렌더 인라인 — story #2905 S2c①', () => {
+  it('artifact detail fetch 성공(latest_version_number 있음) → ArtifactThumbnail 렌더', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      expect(url).toBe('/api/visual-artifacts/art-1');
+      return { ok: true, json: async () => ({ data: { latest_version_number: 3, anchor_version: 2 } }) };
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="art-1" title="목업 초안" status={null} />);
+    });
+    await flush();
+    const thumb = container.querySelector('[data-testid="artifact-thumbnail"]');
+    expect(thumb).not.toBeNull();
+    expect(thumb?.getAttribute('data-artifact-id')).toBe('art-1');
+    expect(thumb?.getAttribute('data-version')).toBe('3');
+    expect(container.textContent).toContain('목업 초안');
+  });
+
+  it('fetch 실패 시 기존 아이콘+라벨 폼으로 정직하게 폴백(빈 썸네일 거짓 금지)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({}) })));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="art-2" title="깨진 아티팩트" status={null} />);
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="artifact-thumbnail"]')).toBeNull();
+    expect(container.textContent).toContain('깨진 아티팩트');
+  });
+
+  it('story 타입은 이 분기와 무관 — 기존 아이콘+라벨+상태 폼 그대로(회귀 0)', async () => {
+    await act(async () => {
+      root.render(<EmbedCard entity_type="story" entity_id="s-1" title="일반 스토리" status="in-progress" />);
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="artifact-thumbnail"]')).toBeNull();
+    expect(container.textContent).toContain('일반 스토리');
+  });
+});

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -690,6 +690,23 @@ export function EmbedCard({
   // 노출하던 같은 클래스의 gap. translateEntityStatus로 통과시킨다(미매핑=null=뱃지 안 그림).
   const statusLabel = status ? translateEntityStatus(entity_type, status) : null;
 
+  // story #2905(S2c①) — artifact/mockup은 "실 렌더 인라인"(§3 표): 텍스트 칩이 아니라 목업
+  // 자체를 축소 프리뷰로 보여준다. version_number를 몰라 ArtifactThumbnail을 못 그렸던 갭 —
+  // ENTITY_API['artifact'](parity 대상, 이미 등록됨)로 직접 fetch(EntityPreviewModal의 detail
+  // fetch와 별개 경로 — EmbedCard는 원래 fetch를 안 했다, 이 타입 하나만 예외).
+  const [artifactDetail, setArtifactDetail] = useState<{ latest_version_number?: number; anchor_version?: number | null } | null>(null);
+  useEffect(() => {
+    if (entity_type !== 'artifact') return;
+    let cancelled = false;
+    const url = ENTITY_API.artifact?.(entity_id);
+    if (!url) return;
+    void fetchWithAuth(url)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json: { data?: Record<string, unknown> } | null) => { if (!cancelled) setArtifactDetail((json?.data ?? null) as typeof artifactDetail); })
+      .catch(() => { if (!cancelled) setArtifactDetail(null); });
+    return () => { cancelled = true; };
+  }, [entity_type, entity_id]);
+
   const handleDocClick = useCallback(async () => {
     setNavigating(true);
     try {
@@ -716,7 +733,26 @@ export function EmbedCard({
     }
   }, [entity_id, router]);
 
-  const inner = (
+  // story #2905(S2c①) — artifact/mockup 실 렌더 인라인. version_number를 아직 못 받았으면(fetch
+  // 중/실패) 기존 아이콘+라벨 폼으로 정직하게 폴백(renderEntityDetail의 "있으면 열고 없으면
+  // 안 연다" 원칙과 동형 — 빈 썸네일을 거짓으로 그리지 않는다).
+  const isRichArtifact = entity_type === 'artifact' && artifactDetail?.latest_version_number != null;
+
+  const inner = isRichArtifact ? (
+    <div className={`overflow-hidden rounded-md border ${colorClass}`}>
+      <ArtifactThumbnail
+        artifactId={entity_id}
+        latestVersionNumber={artifactDetail!.latest_version_number!}
+        anchorVersion={artifactDetail!.anchor_version ?? null}
+        className="aspect-video w-full"
+      />
+      <div className="flex items-center gap-2 border-t border-current/10 px-3 py-1.5 text-sm">
+        <EntityGlyph Icon={resolveEntityIcon(entity_type)} label={label} />
+        <span className="min-w-0 flex-1 truncate font-medium">{label}</span>
+        {navigating && <span className="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />}
+      </div>
+    </div>
+  ) : (
     <div className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm ${colorClass}`}>
       <EntityGlyph Icon={resolveEntityIcon(entity_type)} label={label} />
       <span className="font-medium">{label}</span>


### PR DESCRIPTION
## 요약
story #2905 — S2c v2(§3 재정의) 4형태 중 **①(실 렌더 인라인)만** 이 PR. 나머지는 명확한 이유로 후속 슬라이스로 분리(아래).

## 변경
- `EmbedCard`에 artifact 전용 detail fetch 추가 — `ENTITY_API['artifact']`(parity 대상, 이미 등록된 경로 재사용) → `latest_version_number` 확보.
- `latest_version_number` 있으면 기존 `ArtifactThumbnail`(신규 뷰어 0)로 축소 프리뷰 + 하단 라벨바 렌더. fetch 전/실패는 기존 아이콘+라벨 폼으로 정직하게 폴백(빈 썸네일 거짓 금지).
- `onOpenReadingPanel` 유무 양쪽 다 자동 적용(단일 `inner` 계산 지점이라 별도 배선 불요).

## 이번 PR에서 뺀 것과 이유(스토리 #2905 잔여로 유지)
- **②Block Kit 리치 블록(gate/story/hypothesis)**: PO 판정(§3+§8 겹쳐 읽기)으로 "리치 블록의 승인 액션은 approval-request-card.tsx를 그대로 재사용"까지는 확定됐으나, `ApprovalRequestCard`가 받는 `ApprovalTarget{work_item_type, work_item_id, gate_id}` 중 `work_item_type/work_item_id`를 EmbedCard 쪽(gate만 아는 상태)에서 어떻게 채울지(중복 fetch 없이)가 아직 설계 확定 전 — 잘못된 prop 계약으로 먼저 만들면 재작업 위험이 커 보류.
- **③가로 캐러셀·④간결 리스트("여럿→격납")**: 한 메시지 안 같은 타입 참조가 몇 개인지는 EmbedCard(개별 참조 단위 컴포넌트)가 알 수 없다 — chat-bubble.tsx의 마크다운 렌더 루프(메시지 단위)에서 같은 타입 sole-link 참조들을 먼저 그룹핑해야 하는 별도 축. 이번 PR 범위 밖.

## 셀프 게이트
- ✅ `tsc --noEmit` 클린
- ✅ `pnpm lint` 0 errors(기존 파일 warning 5건은 미변경 파일)
- ✅ `vitest run src/components/chat/` 39 files·392 tests 전부 그린(신규 3건 포함)
- ✅ 대비가드 5종 전부 클린(신규 위반 0)
- ✅ `pnpm build` EXIT 0

story #2905는 이 PR 머지 후에도 in-review로 유지(②③④ 잔여) — done 전이는 전체 형태 스펙트럼 완주 후.