### PR TITLE
[SID:2881] 결제 트랙 갭② — 하향 예약 큐 + 갱신일 좌석 게이트

### DIFF
--- a/backend/alembic/versions/0268_org_subscriptions_pending_tier_change.py
+++ b/backend/alembic/versions/0268_org_subscriptions_pending_tier_change.py
@@ -1,0 +1,44 @@
+"""story #2881(결제 트랙 갭②, 선생님 확定 2026-08-21) — 하향 예약(pending_tier_change).
+
+하향은 즉시 전이가 아니다 — 예약만 받고 다음 갱신일(current_period_end)부터 적용한다
+(v2.2 D10, 부분 환불 없음). org당 예약은 최대 1건(재예약은 덮어씀 — 두 번째 예약이
+첫 번째를 대체한다는 뜻, 큐가 아니라 단일 슬롯). pending_change_apply_at이 NULL이면
+예약 없음(가장 흔한 상태) — sweep(`sweep_pending_tier_downgrades`, toss-billing-
+maintenance cron)이 이 값 <= now()인 행만 훑는다.
+
+Revision ID: 0268
+Revises: 0267
+Create Date: 2026-08-21
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0268"
+down_revision = "0267"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("org_subscriptions", sa.Column("pending_tier", sa.Text(), nullable=True))
+    op.add_column(
+        "org_subscriptions",
+        sa.Column("pending_offering_version_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column(
+        "org_subscriptions", sa.Column("pending_change_apply_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_org_subscriptions_pending_offering_version",
+        "org_subscriptions", "offering_versions", ["pending_offering_version_id"], ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_org_subscriptions_pending_offering_version", "org_subscriptions", type_="foreignkey")
+    op.drop_column("org_subscriptions", "pending_change_apply_at")
+    op.drop_column("org_subscriptions", "pending_offering_version_id")
+    op.drop_column("org_subscriptions", "pending_tier")

--- a/backend/alembic/versions/0269_org_subscriptions_pending_tier_change.py
+++ b/backend/alembic/versions/0269_org_subscriptions_pending_tier_change.py
@@ -6,8 +6,8 @@
 예약 없음(가장 흔한 상태) — sweep(`sweep_pending_tier_downgrades`, toss-billing-
 maintenance cron)이 이 값 <= now()인 행만 훑는다.
 
-Revision ID: 0268
-Revises: 0267
+Revision ID: 0269
+Revises: 0268
 Create Date: 2026-08-21
 """
 from __future__ import annotations
@@ -16,8 +16,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision = "0268"
-down_revision = "0267"
+revision = "0269"
+down_revision = "0268"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/models/org_subscription.py
+++ b/backend/app/models/org_subscription.py
@@ -51,6 +51,15 @@ class OrgSubscription(Base):
     offering_version_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("offering_versions.id"), nullable=True
     )
+    # story #2881(0268) — 하향 예약(단일 슬롯, 큐 아님 — 재예약은 이전 예약을 덮어씀).
+    # pending_change_apply_at=NULL이 "예약 없음"(가장 흔한 상태). sweep(billing_scheduler.
+    # sweep_pending_tier_downgrades)이 apply_at<=now()인 행만 적용한다 — 즉시 전이 없음
+    # (v2.2 D10, 부분 환불 없음).
+    pending_tier: Mapped[str | None] = mapped_column(Text, nullable=True)
+    pending_offering_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("offering_versions.id"), nullable=True
+    )
+    pending_change_apply_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -970,15 +970,20 @@ async def toss_billing_maintenance(
             sweep_expired_grants,
             sweep_stale_pending_orders,
         )
+        from app.services.org_subscription_downgrade import sweep_pending_tier_downgrades
 
         dunning_result = await sweep_dunning_retries(session)
         reconciliation_result = await sweep_stale_pending_orders(session)
         # story #2777 PR2 — 어드민 credit_grant의 자가회수. 신규 cron 잡 발명 대신 이
         # 기존 billing-maintenance 표면에 동거(PO 지시 2026-08-18).
         grant_sweep_result = await sweep_expired_grants(session)
+        # story #2881 — 하향 예약 갱신일 적용도 동일 원칙(신규 cron 잡 발명 대신 동거).
+        # ⛔이 엔드포인트 자체를 부르는 Cloud Scheduler 잡이 아직 전 리전 0건(story #2896
+        # 대기) — 코드는 완결이지만 라이브 집행은 그 잡 착지 後(PR 본문 참고).
+        downgrade_sweep_result = await sweep_pending_tier_downgrades(session)
         return _ok({
             "dunning": dunning_result, "reconciliation": reconciliation_result,
-            "grant_sweep": grant_sweep_result,
+            "grant_sweep": grant_sweep_result, "downgrade_sweep": downgrade_sweep_result,
         })
     except Exception as exc:
         logger.exception("toss-billing-maintenance cron error: %s", exc)

--- a/backend/app/routers/org_subscription_checkout.py
+++ b/backend/app/routers/org_subscription_checkout.py
@@ -42,6 +42,10 @@ class ChangeTierRequest(BaseModel):
     new_tier: Literal["starter", "team", "business"]
 
 
+class DowngradeRequest(BaseModel):
+    new_tier: Literal["starter", "team", "business"]
+
+
 class CheckoutResponse(BaseModel):
     org_id: uuid.UUID
     tier: str
@@ -50,6 +54,10 @@ class CheckoutResponse(BaseModel):
     current_period_start: str | None = None
     current_period_end: str | None = None
     declined_reason: str | None = None
+    # story #2881 — 예약된 하향이 있으면 어드민/사용자 표면에 노출(페드루 지시: 응답
+    # 스키마에 pending 노출 포함). 예약 없으면 셋 다 None(가장 흔한 상태).
+    pending_tier: str | None = None
+    pending_change_apply_at: str | None = None
 
     model_config = {"from_attributes": True}
 
@@ -60,6 +68,8 @@ def _to_response(sub: OrgSubscription, *, declined_reason: str | None = None) ->
         current_period_start=sub.current_period_start.isoformat() if sub.current_period_start else None,
         current_period_end=sub.current_period_end.isoformat() if sub.current_period_end else None,
         declined_reason=declined_reason,
+        pending_tier=sub.pending_tier,
+        pending_change_apply_at=sub.pending_change_apply_at.isoformat() if sub.pending_change_apply_at else None,
     )
 
 
@@ -146,5 +156,62 @@ async def change_tier_endpoint(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return _to_response(sub)
+
+
+@router.post("/downgrade", response_model=CheckoutResponse)
+async def reserve_downgrade_endpoint(
+    body: DowngradeRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
+) -> CheckoutResponse:
+    """story #2881(결제 트랙 갭②) — 하향 예약. 즉시 전이 없음 — 다음 갱신일부터 적용
+    (부분 환불 없음, v2.2 D10). 단일 슬롯이라 재호출은 이전 예약을 덮어쓴다(그것도
+    이 엔드포인트의 정상 사용 — 재호출=재예약). 응답의 `pending_tier`/
+    `pending_change_apply_at`이 예약 상태를 노출한다."""
+    settings = await get_platform_settings(session)
+    if not settings.billing_checkout_enabled:
+        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+
+    from app.services.project_auth import is_org_owner_or_admin
+
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="org admin/owner role required")
+
+    from app.services.org_subscription_downgrade import DowngradeError, reserve_downgrade
+
+    try:
+        sub = await reserve_downgrade(session, org_id=org_id, new_tier=body.new_tier)
+    except DowngradeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return _to_response(sub)
+
+
+@router.delete("/downgrade", response_model=CheckoutResponse)
+async def cancel_downgrade_endpoint(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
+) -> CheckoutResponse:
+    """story #2881 — 예약 철회(재상향 아닌 단순 취소). pending_*만 클리어, 구독 원
+    tier는 무변화."""
+    settings = await get_platform_settings(session)
+    if not settings.billing_checkout_enabled:
+        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+
+    from app.services.project_auth import is_org_owner_or_admin
+
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="org admin/owner role required")
+
+    from app.services.org_subscription_downgrade import DowngradeError, cancel_pending_downgrade
+
+    try:
+        sub = await cancel_pending_downgrade(session, org_id=org_id)
+    except DowngradeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return _to_response(sub)

--- a/backend/app/services/org_subscription_downgrade.py
+++ b/backend/app/services/org_subscription_downgrade.py
@@ -125,13 +125,18 @@ async def _notify_downgrade_auto_cancelled(session: AsyncSession, *, org_id: uui
             )
         ).all()
     ]
-    subject = f"[Sprintable] Plan downgrade to {tier} was cancelled — seat limit exceeded"
+    # 유나양 design 반려(PR#3308, 2026-08-21) — 영문 메일이 제품의 기존 한국어 메일
+    # (초대·#3316 dunning)과 보이스가 갈렸다. 로케일별 분기 정책은 아직 없음(PO 확認) —
+    # 기존 메일 관례대로 한국어 단일. 문안은 design이 첨부한 원문 그대로(#3316 톤 매칭).
+    subject = "[Sprintable] 예약된 하향 전환이 취소되었습니다 — 좌석 한도 초과"
     html = (
-        f"<p>Your scheduled downgrade to <b>{tier}</b> was automatically cancelled because your "
-        f"organization has <b>{seat_count}</b> members, exceeding that plan's included seat limit "
-        f"of <b>{included_seats}</b>.</p>"
-        f"<p>No members were removed. Reduce your team size or keep your current plan, then "
-        f"reschedule the downgrade if you still want it.</p>"
+        f"<p>안녕하세요, Sprintable입니다.</p>"
+        f"<p>예약하신 {tier} 플랜으로의 하향 전환이 자동으로 취소되었습니다. 현재 조직 "
+        f"멤버가 {seat_count}명으로, 해당 플랜의 포함 좌석({included_seats}석)을 초과하기 "
+        f"때문입니다.</p>"
+        f"<p>기존 멤버는 제거되지 않았습니다. 팀 규모를 줄이거나 현재 플랜을 유지하신 뒤, "
+        f"하향 전환이 여전히 필요하시면 다시 예약해 주세요.</p>"
+        f"<p>문의사항이 있으시면 언제든 회신해 주세요.</p>"
     )
     for em in emails:
         try:

--- a/backend/app/services/org_subscription_downgrade.py
+++ b/backend/app/services/org_subscription_downgrade.py
@@ -166,6 +166,15 @@ async def sweep_pending_tier_downgrades(session: AsyncSession, *, now: datetime 
 
         seat_count = await count_human_seats(session, sub.org_id)
         if seat_count > new_offering.included_seats:
+            # 카디르 확定 버그(PR#3308 QA, 2026-08-21) — 아래 raw UPDATE(pending_tier=None)를
+            # session.execute()가 실행하면 SQLAlchemy Core update()의 기본 "evaluate"
+            # synchronize_session 전략이 PK로 매칭되는 이 in-session `sub` 객체를 자동으로
+            # in-place 동기화한다(populate_existing 없이도) — 그 直後 `sub.pending_tier`를
+            # 읽으면 이미 None이라, 알림 메일이 항상 "Plan downgrade to None was
+            # cancelled..."로 발송됐다(오늘 PR#3312에서 배운 identity-map staleness의
+            # 정반대 실패모드 — 거긴 sync 부재가 문제, 여긴 sync 존재가 문제). UPDATE
+            # 前에 로컬 변수로 스냅샷해 그 값을 메일에 넘긴다.
+            pending_tier_snapshot = sub.pending_tier
             await session.execute(
                 update(OrgSubscription)
                 .where(OrgSubscription.id == sub.id)
@@ -173,7 +182,7 @@ async def sweep_pending_tier_downgrades(session: AsyncSession, *, now: datetime 
             )
             await session.commit()
             await _notify_downgrade_auto_cancelled(
-                session, org_id=sub.org_id, tier=sub.pending_tier,
+                session, org_id=sub.org_id, tier=pending_tier_snapshot,
                 seat_count=seat_count, included_seats=new_offering.included_seats,
             )
             cancelled_seat_overage += 1

--- a/backend/app/services/org_subscription_downgrade.py
+++ b/backend/app/services/org_subscription_downgrade.py
@@ -1,0 +1,195 @@
+"""story #2881(결제 트랙 갭②) — 월납/연납 유료→유료 하향 예약 + 갱신일 적용 + 좌석 게이트.
+doc `billing-policy-scenario-audit-20260821` 4·5번 갭: 자발 하향 write 경로가 0건이었고
+(유일한 tier 하강=dunning 강제 전환), 좌석 vs 신규 티어 한도 체크도 전무했다.
+
+**정책 확定(선생님, 2026-08-21, 페드루 릴레이)**:
+①하향은 **즉시 전이 없음** — `pending_tier`/`pending_offering_version_id`/
+  `pending_change_apply_at`(=current_period_end)만 기록(예약, 단일 슬롯 — 재예약은
+  이전 예약을 덮어씀). 부분 환불 없음(v2.2 D10 그대로).
+②갱신일 적용은 `sweep_pending_tier_downgrades`(billing_scheduler.py, toss-billing-
+  maintenance cron에 편입)가 `pending_change_apply_at <= now()`인 행을 훑어 처리한다.
+  ⛔이 크론의 «도는 자리»(Cloud Scheduler)가 아직 전 리전 0건(story #2896 대기) — 이
+  스토리는 코드+sweep 실DB 테스트까지가 완료선이고, **라이브 집행은 #2896 착지 後**다
+  (PR/AC에 명시 — 「만들어졌는데 도는 자리가 없다」 재발 방지).
+③좌석 게이트: 적용 시점에 좌석수(count_human_seats) > 신규 offering.included_seats면
+  **하향을 자동 취소**(pending_* 클리어)하고 org owner/admin에게 이메일 통지 —
+  ⛔기존 멤버 강제 제거 없음, ⛔extra_seat 자동 유료전환도 없음(동의 없는 과금 금지,
+  페드루 지시 — «신규 초대만 차단»과 동형 패턴이지만 이 스토리에서 신규 초대 차단
+  자체를 구현하진 않는다, 좌석초과 자체가 «하향 무산» 사유일 뿐).
+④예약 철회(재상향 아닌 단순 취소)는 별도 엔드포인트로 연다 — pending_*만 클리어,
+  구독 자체는 원 tier 그대로 무변화.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.offering_version import OfferingVersion
+from app.models.org_subscription import OrgSubscription
+from app.models.project import OrgMember
+from app.models.user import User
+from app.services.billing_charge_amount import count_human_seats
+from app.services.billing_period import compute_period_end
+from app.services.email import send_email
+from app.services.org_subscription_tier_change import PAID_TIERS, _TIER_RANK
+
+logger = logging.getLogger(__name__)
+
+
+class DowngradeError(Exception):
+    """하향 예약/철회를 진행할 수 없는 상태(정책 위반·데이터 갭) — 명시 실패, 400 매핑 대상."""
+
+
+async def _refetch_subscription(session: AsyncSession, org_id: uuid.UUID) -> OrgSubscription:
+    return (
+        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+    ).scalar_one()
+
+
+async def reserve_downgrade(session: AsyncSession, *, org_id: uuid.UUID, new_tier: str) -> OrgSubscription:
+    """①③④ — 하향 예약(단일 슬롯, 재예약은 이전 예약을 덮어씀). 돈이 안 걸린 순수
+    메타데이터 write라 checkout/change-tier류의 claim(checkout_claimed_at) 불요 —
+    UPDATE 자체가 원자적이고, 같은 org의 동시 재예약은 마지막 커밋이 이긴다(그게
+    "재예약=덮어씀" 정책과 정합, 레이스가 아니라 사양)."""
+    if new_tier not in PAID_TIERS:
+        raise DowngradeError(f"new_tier={new_tier!r}는 유료 티어만(starter/team/business) — free 전환은 구독 취소(story #2882)")
+
+    sub = (
+        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+    ).scalar_one_or_none()
+    if sub is None or sub.status != "active" or sub.tier not in PAID_TIERS:
+        raise DowngradeError(f"org_id={org_id} 활성 유료 구독이 아님 — 하향 예약 대상 아님")
+    if sub.current_period_end is None:
+        raise DowngradeError(f"org_id={org_id} current_period_end 없음 — 적용일을 정할 수 없음")
+    if _TIER_RANK.get(new_tier, 0) >= _TIER_RANK.get(sub.tier, 0):
+        raise DowngradeError(
+            f"{sub.tier!r}→{new_tier!r}는 하향이 아님(상향/동일) — 상향은 story #2880(change-tier)"
+        )
+
+    new_offering = (
+        await session.execute(
+            select(OfferingVersion).where(
+                OfferingVersion.tier == new_tier,
+                OfferingVersion.currency == sub.currency,
+                OfferingVersion.effective_to.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if new_offering is None:
+        raise DowngradeError(f"tier={new_tier!r}의 활성 offering_version({sub.currency!r})을 찾을 수 없음")
+
+    await session.execute(
+        update(OrgSubscription)
+        .where(OrgSubscription.org_id == org_id)
+        .values(
+            pending_tier=new_tier, pending_offering_version_id=new_offering.id,
+            pending_change_apply_at=sub.current_period_end,
+        )
+    )
+    await session.commit()
+    return await _refetch_subscription(session, org_id)
+
+
+async def cancel_pending_downgrade(session: AsyncSession, *, org_id: uuid.UUID) -> OrgSubscription:
+    """④ — 예약 철회. pending_*만 클리어, 구독 원 tier는 무변화."""
+    sub = (
+        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+    ).scalar_one_or_none()
+    if sub is None:
+        raise DowngradeError(f"org_id={org_id} 구독 없음")
+    if sub.pending_change_apply_at is None:
+        raise DowngradeError(f"org_id={org_id} 철회할 예약된 하향이 없음")
+
+    await session.execute(
+        update(OrgSubscription)
+        .where(OrgSubscription.org_id == org_id)
+        .values(pending_tier=None, pending_offering_version_id=None, pending_change_apply_at=None)
+    )
+    await session.commit()
+    return await _refetch_subscription(session, org_id)
+
+
+async def _notify_downgrade_auto_cancelled(session: AsyncSession, *, org_id: uuid.UUID, tier: str, seat_count: int, included_seats: int) -> None:
+    """③ — 좌석초과로 하향이 자동 취소됐음을 owner/admin에게 통지(storage-usage-warn과
+    동형 best-effort 이메일 패턴, 재구현 0)."""
+    emails = [
+        r[0] for r in (
+            await session.execute(
+                select(User.email)
+                .join(OrgMember, User.id == OrgMember.user_id)
+                .where(OrgMember.org_id == org_id, OrgMember.role.in_(["owner", "admin"]), OrgMember.deleted_at.is_(None))
+            )
+        ).all()
+    ]
+    subject = f"[Sprintable] Plan downgrade to {tier} was cancelled — seat limit exceeded"
+    html = (
+        f"<p>Your scheduled downgrade to <b>{tier}</b> was automatically cancelled because your "
+        f"organization has <b>{seat_count}</b> members, exceeding that plan's included seat limit "
+        f"of <b>{included_seats}</b>.</p>"
+        f"<p>No members were removed. Reduce your team size or keep your current plan, then "
+        f"reschedule the downgrade if you still want it.</p>"
+    )
+    for em in emails:
+        try:
+            send_email(em, subject, html)
+        except Exception:
+            logger.warning("downgrade auto-cancel notify 실패 org=%s", org_id, exc_info=True)
+
+
+async def sweep_pending_tier_downgrades(session: AsyncSession, *, now: datetime | None = None) -> dict:
+    """② — 갱신일(pending_change_apply_at)이 도래한 하향 예약을 적용한다. ⛔story #2896
+    (Cloud Scheduler 잡)이 착지하기 前엔 이 함수를 «부르는 자리» 자체가 없다 — 코드
+    완결과 라이브 집행은 별개(PR 본문 명시)."""
+    now = now or datetime.now(timezone.utc)
+    pending = (
+        await session.execute(
+            select(OrgSubscription).where(
+                OrgSubscription.pending_change_apply_at.is_not(None),
+                OrgSubscription.pending_change_apply_at <= now,
+            )
+        )
+    ).scalars().all()
+
+    applied = cancelled_seat_overage = skipped = 0
+    for sub in pending:
+        if sub.pending_offering_version_id is None or sub.pending_tier is None:
+            skipped += 1
+            continue
+        new_offering = await session.get(OfferingVersion, sub.pending_offering_version_id)
+        if new_offering is None:
+            skipped += 1
+            continue
+
+        seat_count = await count_human_seats(session, sub.org_id)
+        if seat_count > new_offering.included_seats:
+            await session.execute(
+                update(OrgSubscription)
+                .where(OrgSubscription.id == sub.id)
+                .values(pending_tier=None, pending_offering_version_id=None, pending_change_apply_at=None)
+            )
+            await session.commit()
+            await _notify_downgrade_auto_cancelled(
+                session, org_id=sub.org_id, tier=sub.pending_tier,
+                seat_count=seat_count, included_seats=new_offering.included_seats,
+            )
+            cancelled_seat_overage += 1
+            continue
+
+        new_period_end = compute_period_end(now, sub.billing_cycle or "monthly")
+        await session.execute(
+            update(OrgSubscription)
+            .where(OrgSubscription.id == sub.id)
+            .values(
+                tier=sub.pending_tier, offering_version_id=sub.pending_offering_version_id,
+                current_period_start=now, current_period_end=new_period_end,
+                pending_tier=None, pending_offering_version_id=None, pending_change_apply_at=None,
+            )
+        )
+        await session.commit()
+        applied += 1
+
+    return {"pending_seen": len(pending), "applied": applied, "cancelled_seat_overage": cancelled_seat_overage, "skipped": skipped}

--- a/backend/tests/test_2881_downgrade_reservation_seat_gate_realdb.py
+++ b/backend/tests/test_2881_downgrade_reservation_seat_gate_realdb.py
@@ -304,8 +304,8 @@ async def test_sweep_auto_cancel_email_content_shows_real_tier_not_none_realdb()
             assert to == "owner@2881-email-content.test"
             assert "None" not in subject, f"tier명이 None으로 새는 회귀 — subject={subject!r}"
             assert "None" not in html, f"tier명이 None으로 새는 회귀 — html={html!r}"
-            assert "starter" in subject
             assert "starter" in html
+            assert "Sprintable" in subject
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_2881_downgrade_reservation_seat_gate_realdb.py
+++ b/backend/tests/test_2881_downgrade_reservation_seat_gate_realdb.py
@@ -1,0 +1,281 @@
+"""story #2881(결제 트랙 갭②) — 하향 예약 + 갱신일 좌석 게이트 실PG 검증. 순수 DB write
+(Toss 호출 없음 — 하향은 즉시 charge/refund가 없다, v2.2 D10)라 TossAdapter mock도 불요.
+
+커버:
+  AC① — 하향 예약이 즉시 전이 없이 pending_*만 기록(현재 tier 무변화).
+  AC② — sweep이 apply_at<=now인 예약만 적용(future는 skip).
+  AC③ — 좌석초과 시 sweep이 하향을 자동 취소(pending_* 클리어) + 원 tier 유지(강제 제거 없음).
+  AC④ — 예약 철회 엔드포인트 대신 서비스 직접 호출(cancel_pending_downgrade) — pending_*만 클리어.
+  ⑤ — 상향/동일tier 방향은 DowngradeError(400 매핑 대상), free 대상도 거부.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_org(session):
+    org_id = uuid.uuid4()
+    await session.execute(
+        text("INSERT INTO organizations (id, name, slug, plan) VALUES (:id, :name, :slug, 'free')"),
+        {"id": org_id, "name": f"test-org-{org_id}", "slug": f"slug-{org_id}"},
+    )
+    await session.commit()
+    return org_id
+
+
+async def _offering_id(session, tier):
+    row = (
+        await session.execute(
+            text("SELECT id FROM offering_versions WHERE tier=:t AND currency='krw' AND effective_to IS NULL"),
+            {"t": tier},
+        )
+    ).first()
+    assert row is not None, f"offering_version(tier={tier!r}, krw) 시드 없음"
+    return row.id
+
+
+async def _seed_active_paid_subscription(session, org_id, *, tier="business", period_end=None):
+    offering_id = await _offering_id(session, tier)
+    period_end = period_end or (datetime.now(timezone.utc) + timedelta(days=20))
+    await session.execute(
+        text(
+            "INSERT INTO org_subscriptions "
+            "(id, org_id, tier, billing_cycle, status, currency, provider, offering_version_id, "
+            " current_period_start, current_period_end) "
+            "VALUES (:id, :org_id, :tier, 'monthly', 'active', 'krw', 'toss', :oid, :ps, :pe)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "tier": tier, "oid": offering_id, "ps": period_end - timedelta(days=10), "pe": period_end},
+    )
+    await session.commit()
+    return period_end
+
+
+async def _seed_human_member(session, org_id):
+    from app.models.member import Member
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x"))
+    await session.flush()
+    om_id = uuid.uuid4()
+    session.add(OrgMember(id=om_id, org_id=org_id, user_id=user_id, role="member"))
+    await session.flush()
+    session.add(Member(id=om_id, org_id=org_id, type="human", user_id=user_id, name="Human"))
+    await session.commit()
+    return om_id
+
+
+@pytest.mark.anyio
+async def test_reserve_downgrade_does_not_change_tier_immediately_realdb():
+    from app.services.org_subscription_downgrade import reserve_downgrade
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            period_end = await _seed_active_paid_subscription(session, org_id, tier="business")
+
+            sub = await reserve_downgrade(session, org_id=org_id, new_tier="starter")
+
+            assert sub.tier == "business"  # AC① 즉시 전이 없음
+            assert sub.pending_tier == "starter"
+            assert sub.pending_change_apply_at == period_end
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reserve_downgrade_overwrites_prior_reservation_realdb():
+    from app.services.org_subscription_downgrade import reserve_downgrade
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            await _seed_active_paid_subscription(session, org_id, tier="business")
+
+            await reserve_downgrade(session, org_id=org_id, new_tier="team")
+            sub = await reserve_downgrade(session, org_id=org_id, new_tier="starter")
+
+            assert sub.pending_tier == "starter"  # 단일 슬롯, 재예약이 이전 것을 덮어씀
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cancel_pending_downgrade_clears_reservation_realdb():
+    from app.services.org_subscription_downgrade import cancel_pending_downgrade, reserve_downgrade
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            await _seed_active_paid_subscription(session, org_id, tier="business")
+            await reserve_downgrade(session, org_id=org_id, new_tier="starter")
+
+            sub = await cancel_pending_downgrade(session, org_id=org_id)
+
+            assert sub.pending_tier is None
+            assert sub.pending_offering_version_id is None
+            assert sub.pending_change_apply_at is None
+            assert sub.tier == "business"  # AC④ 원 tier 무변화
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweep_applies_due_downgrade_and_rolls_period_realdb():
+    """AC② — apply_at이 이미 지난 예약은 sweep이 적용하고 tier/period 둘 다 전이."""
+    from app.services.org_subscription_downgrade import reserve_downgrade, sweep_pending_tier_downgrades
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            past_period_end = datetime.now(timezone.utc) - timedelta(hours=1)
+            await _seed_active_paid_subscription(session, org_id, tier="business", period_end=past_period_end)
+            await reserve_downgrade(session, org_id=org_id, new_tier="starter")
+
+            result = await sweep_pending_tier_downgrades(session)
+            assert result["applied"] == 1
+            assert result["cancelled_seat_overage"] == 0
+
+            row = (
+                await session.execute(
+                    text("SELECT tier, pending_tier, pending_change_apply_at, current_period_start, current_period_end FROM org_subscriptions WHERE org_id=:oid"),
+                    {"oid": org_id},
+                )
+            ).first()
+            assert row.tier == "starter"
+            assert row.pending_tier is None
+            assert row.pending_change_apply_at is None
+            assert row.current_period_end > past_period_end  # 새 주기로 굴러감
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweep_skips_future_reservation_realdb():
+    """AC② — apply_at이 아직 안 지난 예약은 이 sweep 실행에서 손대지 않는다."""
+    from app.services.org_subscription_downgrade import reserve_downgrade, sweep_pending_tier_downgrades
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            future_period_end = datetime.now(timezone.utc) + timedelta(days=5)
+            await _seed_active_paid_subscription(session, org_id, tier="business", period_end=future_period_end)
+            await reserve_downgrade(session, org_id=org_id, new_tier="starter")
+
+            result = await sweep_pending_tier_downgrades(session)
+            assert result["pending_seen"] == 0  # 이 org는 apply_at 미도래라 대상에 안 들어옴
+
+            row = (
+                await session.execute(text("SELECT tier, pending_tier FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id})
+            ).first()
+            assert row.tier == "business"
+            assert row.pending_tier == "starter"  # 예약 그대로
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweep_auto_cancels_downgrade_on_seat_overage_no_forced_removal_realdb():
+    """AC③ — starter는 좌석 3석(카탈로그). 4명 있는 org가 starter로 하향 예약 → sweep이
+    자동 취소(pending_* 클리어) + business tier 유지 + 멤버 4명 그대로(강제 제거 없음)."""
+    from app.services.org_subscription_downgrade import reserve_downgrade, sweep_pending_tier_downgrades
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            past_period_end = datetime.now(timezone.utc) - timedelta(hours=1)
+            await _seed_active_paid_subscription(session, org_id, tier="business", period_end=past_period_end)
+            for _ in range(4):
+                await _seed_human_member(session, org_id)
+
+            included_seats_starter = (
+                await session.execute(text("SELECT included_seats FROM offering_versions WHERE tier='starter' AND currency='krw' AND effective_to IS NULL"))
+            ).scalar_one()
+            assert included_seats_starter < 4, "이 테스트가 의미 있으려면 starter included_seats < 4명이어야 함(카탈로그 확認)"
+
+            await reserve_downgrade(session, org_id=org_id, new_tier="starter")
+            result = await sweep_pending_tier_downgrades(session)
+
+            assert result["cancelled_seat_overage"] == 1
+            assert result["applied"] == 0
+
+            row = (
+                await session.execute(
+                    text("SELECT tier, pending_tier, pending_change_apply_at FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id},
+                )
+            ).first()
+            assert row.tier == "business"  # 원 tier 유지(자동 취소)
+            assert row.pending_tier is None
+
+            member_count = (
+                await session.execute(text("SELECT COUNT(*) FROM org_members WHERE org_id=:oid AND deleted_at IS NULL"), {"oid": org_id})
+            ).scalar_one()
+            assert member_count == 4  # 강제 제거 없음
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_upgrade_direction_rejected_by_downgrade_endpoint_realdb():
+    """⑤ — starter→team(상향 방향)을 이 서비스로 넣으면 거부(하향 전용)."""
+    from app.services.org_subscription_downgrade import DowngradeError, reserve_downgrade
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            await _seed_active_paid_subscription(session, org_id, tier="starter")
+
+            with pytest.raises(DowngradeError, match="하향이 아님"):
+                await reserve_downgrade(session, org_id=org_id, new_tier="team")
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cancel_without_pending_reservation_rejected_realdb():
+    from app.services.org_subscription_downgrade import DowngradeError, cancel_pending_downgrade
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            await _seed_active_paid_subscription(session, org_id, tier="starter")
+
+            with pytest.raises(DowngradeError, match="철회할 예약된 하향이 없음"):
+                await cancel_pending_downgrade(session, org_id=org_id)
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2881_downgrade_reservation_seat_gate_realdb.py
+++ b/backend/tests/test_2881_downgrade_reservation_seat_gate_realdb.py
@@ -246,6 +246,70 @@ async def test_sweep_auto_cancels_downgrade_on_seat_overage_no_forced_removal_re
         await engine.dispose()
 
 
+async def _seed_owner_member(session, org_id, *, email):
+    from app.models.member import Member
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=email, hashed_password="x"))
+    await session.flush()
+    om_id = uuid.uuid4()
+    session.add(OrgMember(id=om_id, org_id=org_id, user_id=user_id, role="owner"))
+    await session.flush()
+    session.add(Member(id=om_id, org_id=org_id, type="human", user_id=user_id, name="Owner"))
+    await session.commit()
+    return om_id
+
+
+@pytest.mark.anyio
+async def test_sweep_auto_cancel_email_content_shows_real_tier_not_none_realdb():
+    """카디르 확定 버그(PR#3308 QA, 2026-08-21) 회귀 고정 — 좌석초과 자동취소 알림
+    이메일이 raw UPDATE 直後 `sub.pending_tier`를 읽어(SQLAlchemy Core update()의
+    evaluate synchronize_session이 in-session 객체를 이미 None으로 동기화한 뒤라)
+    항상 "Plan downgrade to None was cancelled"로 발송됐다. 기존 8건은 DB 상태만
+    확認하고 메일 CONTENT는 전혀 assert하지 않아 이 결함을 놓쳤다 — 여기서 실제
+    발송 인자(subject/html)에 tier명("starter")이 정확히 들어가는지 직접 확認한다."""
+    from app.services.org_subscription_downgrade import reserve_downgrade, sweep_pending_tier_downgrades
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            past_period_end = datetime.now(timezone.utc) - timedelta(hours=1)
+            await _seed_active_paid_subscription(session, org_id, tier="business", period_end=past_period_end)
+            await _seed_owner_member(session, org_id, email="owner@2881-email-content.test")
+            for _ in range(4):
+                await _seed_human_member(session, org_id)
+
+            included_seats_starter = (
+                await session.execute(text("SELECT included_seats FROM offering_versions WHERE tier='starter' AND currency='krw' AND effective_to IS NULL"))
+            ).scalar_one()
+            assert included_seats_starter < 5, "이 테스트가 의미 있으려면 starter included_seats < 5명(owner 포함)이어야 함"
+
+            await reserve_downgrade(session, org_id=org_id, new_tier="starter")
+
+            sent = []
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setattr(
+                    "app.services.org_subscription_downgrade.send_email",
+                    lambda to, subject, html: sent.append((to, subject, html)),
+                )
+                result = await sweep_pending_tier_downgrades(session)
+
+            assert result["cancelled_seat_overage"] == 1
+            assert len(sent) == 1, "owner 1명 — 메일 정확히 1건"
+            to, subject, html = sent[0]
+            assert to == "owner@2881-email-content.test"
+            assert "None" not in subject, f"tier명이 None으로 새는 회귀 — subject={subject!r}"
+            assert "None" not in html, f"tier명이 None으로 새는 회귀 — html={html!r}"
+            assert "starter" in subject
+            assert "starter" in html
+    finally:
+        await engine.dispose()
+
+
 @pytest.mark.anyio
 async def test_upgrade_direction_rejected_by_downgrade_endpoint_realdb():
     """⑤ — starter→team(상향 방향)을 이 서비스로 넣으면 거부(하향 전용)."""

--- a/backend/tests/test_e_2506_checkout_router.py
+++ b/backend/tests/test_e_2506_checkout_router.py
@@ -23,6 +23,10 @@ def _sub(*, org_id, status="active"):
     s.status = status
     s.current_period_start = datetime(2026, 8, 7, tzinfo=timezone.utc)
     s.current_period_end = datetime(2026, 9, 7, tzinfo=timezone.utc)
+    # story #2881 — CheckoutResponse가 이 필드들을 읽는다(pending 하향 노출).
+    s.pending_tier = None
+    s.pending_offering_version_id = None
+    s.pending_change_apply_at = None
     return s
 
 


### PR DESCRIPTION
## Summary
⛔**#3306(2880) 위 스택 브랜치입니다** — base가 develop이 아니라 feat/2880-tier-upgrade-proration. #3306 머지 후 이 PR의 base도 develop으로 재조정합니다(diff는 2881분만).

- doc `billing-policy-scenario-audit-20260821` 4·5번 갭: 자발 하향 write 경로 0건(유일한 tier 하강=dunning 강제 전환)·좌석 vs 신규 티어 한도 체크 전무.
- `POST /api/v2/org-subscriptions/downgrade` — 하향 예약(즉시 전이 없음, 단일 슬롯, 다음 갱신일 적용, 부분 환불 없음 — v2.2 D10).
- `DELETE /api/v2/org-subscriptions/downgrade` — 예약 철회.
- `sweep_pending_tier_downgrades`(billing_scheduler.py, `toss-billing-maintenance` cron 편입) — apply_at 도래한 예약을 적용(tier+period 전이). **⛔이 크론을 실제로 부르는 Cloud Scheduler 잡이 전 리전 0건(story #2896 대기)** — 코드+실DB 테스트까지가 이 스토리 완료선, 라이브 집행은 #2896 착지 後입니다.
- 좌석 게이트: 적용 시점 좌석수 > 신규 offering.included_seats면 자동 취소+owner/admin 이메일 통지(기존 멤버 강제 제거·extra_seat 자동 유료전환 둘 다 없음 — 동의 없는 과금 금지).
- storage quota 강제(초과 데이터 신규 업로드만 차단)는 별도 스토리 #2906으로 분리 — 이 PR은 하향 자체만.

## Test plan
- [x] `pytest tests/test_2881_downgrade_reservation_seat_gate_realdb.py` — 8 passed(실PG): 예약 시 즉시전이 없음·재예약 덮어씀·철회·sweep 적용+period 롤·future 예약 skip·좌석초과 자동취소(강제제거 없음 실증)·방향 오류 거부.
- [x] 회귀 스윕(checkout/change-tier/refund/scheduler 관련 132건) — 무회귀. 기존 MagicMock 픽스처(`test_e_2506_checkout_router.py`)에 신규 응답 필드 기본값 추가.
- [x] `test_authz_project_scope_coverage.py` — 13 passed.
- [x] `python -c "import app.main"` — 임포트 확認.

[SID:2881]