### PR TITLE
[SID:2905] S2c② FE — 임베드 형태 스펙트럼: gate Block Kit 리치 블록(승인 로직 재사용)

### DIFF
--- a/apps/web/src/components/chat/approval-request-card.test.tsx
+++ b/apps/web/src/components/chat/approval-request-card.test.tsx
@@ -103,6 +103,29 @@ describe('ApprovalRequestCard — 제목 미리보기 진입점, canPreviewEntit
     expect(document.body.querySelector('[data-slot="dialog-content"]')).toBeTruthy();
   });
 
+  // story #2905(S2c②) — gate 단건 sole-link 참조(chat-bubble.tsx)는 work_item_type/
+  // work_item_id를 모르는 채(빈 문자열 placeholder) target을 넘긴다. fetch된 gate 실물이
+  // 그 자리를 대신해 카드가 정상 완결되는지(제목 버튼·크래시 없음) 확인.
+  it('target.work_item_type/work_item_id가 빈 문자열(placeholder)이어도 fetch된 gate 실물로 정상 완결된다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/gates/')) {
+        return { ok: true, json: async () => ({ data: gate({ work_item_type: 'doc', work_item_id: 'wi-9', work_item_summary: { title: '플레이스홀더 대조', slug: null } }) }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <ApprovalRequestCard target={{ work_item_type: '', work_item_id: '', gate_id: 'g-1' }} />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain('플레이스홀더 대조');
+    const titleButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('플레이스홀더 대조'));
+    expect(titleButton).toBeTruthy(); // doc은 canPreviewEntity 통과 — gate 실물 기준으로 진입점이 뜬다.
+  });
+
   it.each([
     ['loop', '루프 제목'],
     ['wf_line_version', '워크플로 버전'],

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -154,7 +154,12 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalR
     }
   };
 
-  const Icon = resolveEntityIcon(toEntityType(target.work_item_type)) ?? FileText;
+  // story #2905(S2c②) — gate 단건 sole-link 참조(chat-bubble.tsx) 호출부는 work_item_type을
+  // 모르는 채(빈 문자열 placeholder) 부른다 — fetch 완료 후엔 gate 실물(GateResponse가
+  // work_item_type을 1급 필드로 실어 옴, 페드루 확定 2026-08-21)을 우선한다. 기존 approval_target
+  // 메시지 호출부(BE가 정확한 work_item_type을 이미 실어 보냄)는 무변경(fetch 전 잠깐만 prop 사용).
+  const headerWorkItemType = state.kind === 'ready' ? state.gate.work_item_type : target.work_item_type;
+  const Icon = resolveEntityIcon(toEntityType(headerWorkItemType)) ?? FileText;
 
   return (
     <div className="min-w-0 max-w-full rounded-xl rounded-tl-sm border border-border bg-card px-3.5 py-3">

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1445,6 +1445,40 @@ describe('ChatBubble — story #2671 EmbedCard 단독 참조 문단 카드 렌�
     expect(container.textContent).toContain('스토리 제목');
   });
 
+  // story #2905(S2c②) — gate 단건 sole-link 참조는 EmbedCard 대신 approval-request-card.tsx가
+  // 그대로 뜬다(§8 "표면은 둘·실체는 하나", 승인 로직 사본 분화 금지 — PO 판정).
+  it('참조 링크 하나뿐인 문단(gate)은 EmbedCard가 아니라 ApprovalRequestCard(결재 요청 카드)로 렌더된다', async () => {
+    const gateId = '44444444-4444-4444-4444-444444444444';
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === `/api/gates/${gateId}`) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              id: gateId, status: 'pending', gate_type: 'doc_approval', risk_grade: 'low',
+              work_item_type: 'doc', work_item_id: 'wi-1', can_approve: true,
+              work_item_summary: { title: '기획안 v2', slug: null },
+              resolver_id: null, resolved_at: null, resolution_note: null, neutral_facts: null,
+            },
+          }),
+        };
+      }
+      return { ok: false, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, content: `[결재 요청](entity:gate:${gateId})`, references: [{ target_type: 'gate', target_id: gateId }] }}
+          isMine={false}
+        />,
+      ));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    // ApprovalRequestCard 전용 마커 — "결재 요청" 라벨은 EmbedCard엔 없다.
+    expect(container.textContent).toContain('기획안 v2');
+    expect(container.querySelector('button[aria-label="미리보기"]')).toBeNull(); // EmbedCard doc 전용 마커 아님
+  });
+
   it('참조가 유령(stored 참조에 없음)이면 단독 문단이어도 카드가 아니라 유령 칩(행동 0)이다', async () => {
     await act(async () => {
       root.render(wrap(

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -162,10 +162,13 @@ function CopyableCode({ raw, inline, className }: { raw: string; inline: boolean
   );
 }
 
-function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenReadingPanel }: {
+function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenReadingPanel, eventDefinitionsByKey }: {
   content: string; isMine: boolean; references: ChatMessage['references'];
   entityStatusByKey?: Record<string, EntityStatusFetchState>;
   onOpenReadingPanel?: (target: ReadingPanelTarget) => void;
+  /** story #2905(S2c②) — gate 단건 sole-link 참조가 ApprovalRequestCard(Block Kit 리치 블록,
+   * 사본 분화 금지 재사용)로 뜰 때 그 컴포넌트가 요구하는 카탈로그를 그대로 물려준다. */
+  eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
 }) {
   const text = isMine ? 'text-primary-foreground' : 'text-foreground';
   const muted = isMine ? 'text-primary-foreground/70' : 'text-muted-foreground';
@@ -193,6 +196,21 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenRe
       const ref = typeof href === 'string' ? parseEntityRef(href) : null;
       const decision = ref ? resolveEmbedDecision(ref.entityType, ref.entityId, references, { allowCard: true }) : null;
       if (ref && decision?.kind === 'card') {
+        // story #2905(S2c②) — gate 단건 sole-link 참조 = §3 Block Kit 리치 블록. approval-
+        // request-card.tsx를 그대로 재사용(PO 판정 — 사본 분화 금지). ApprovalRequestCard가
+        // 자체 fetch(GET /api/gates/{id}, GateResponse에 work_item_type/work_item_id 1급
+        // 필드로 실림)로 완결되므로 여기선 placeholder만 넘긴다(실사용은 fetch 후 컴포넌트
+        // 내부에서 gate 실물로 대체 — approval-request-card.tsx 자체 수정분 참고). 자체
+        // 인터랙션(승인/반려/서명)을 가진 컴포넌트라 onOpenReadingPanel 클릭-전체-래핑
+        // 대상이 아니다(버튼-안-버튼 방지, §8 "표면은 둘·실체는 하나").
+        if (ref.entityType === 'gate') {
+          return (
+            <ApprovalRequestCard
+              target={{ work_item_type: '', work_item_id: '', gate_id: ref.entityId }}
+              eventDefinitionsByKey={eventDefinitionsByKey}
+            />
+          );
+        }
         const statusFetch = entityStatusByKey?.[`${ref.entityType.toLowerCase()}:${ref.entityId.toLowerCase()}`];
         const status = statusFetch?.kind === 'resolved' ? statusFetch.raw : null;
         // PO 리뷰 지적 — 링크 라벨이 여러 자식(예: **강조** 섞인 텍스트)으로 쪼개질 수
@@ -277,7 +295,7 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenRe
       }
       return <a href={href} target="_blank" rel="noopener noreferrer" className={`underline underline-offset-2 ${text}`}>{children}</a>;
     },
-  }), [text, muted, codeBg, border, isMine, references, entityStatusByKey, onOpenReadingPanel]);
+  }), [text, muted, codeBg, border, isMine, references, entityStatusByKey, onOpenReadingPanel, eventDefinitionsByKey]);
 
   if (!hasMarkdown && !hasMention) {
     return (
@@ -548,7 +566,7 @@ export function ChatBubble({
                 ? 'rounded-tr-sm bg-primary text-primary-foreground'
                 : 'rounded-tl-sm bg-muted text-foreground'
             }`}>
-              <ChatMarkdown content={displayContent} isMine={isMine} references={message.references} entityStatusByKey={entityStatusByKey} onOpenReadingPanel={onOpenReadingPanel} />
+              <ChatMarkdown content={displayContent} isMine={isMine} references={message.references} entityStatusByKey={entityStatusByKey} onOpenReadingPanel={onOpenReadingPanel} eventDefinitionsByKey={eventDefinitionsByKey} />
             </div>
           )}
 

--- a/apps/web/src/components/chat/embed-card.artifact-form.test.tsx
+++ b/apps/web/src/components/chat/embed-card.artifact-form.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+//
+// story #2905(S2c①) — EmbedCard artifact/mockup 실 렌더 인라인 폼 회귀가드. ArtifactThumbnail
+// 자체(PNG export·canvas 렌더)는 별도 테스트 대상 — 여기는 EmbedCard의 fetch→분기 로직만.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EmbedCard } from './embed-card';
+
+vi.mock('@/components/canvas/artifact-thumbnail', () => ({
+  ArtifactThumbnail: ({ artifactId, latestVersionNumber }: { artifactId: string; latestVersionNumber: number }) => (
+    <div data-testid="artifact-thumbnail" data-artifact-id={artifactId} data-version={latestVersionNumber} />
+  ),
+}));
+
+const pushMock = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: pushMock }) }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('EmbedCard artifact 실 렌더 인라인 — story #2905 S2c①', () => {
+  it('artifact detail fetch 성공(latest_version_number 있음) → ArtifactThumbnail 렌더', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      expect(url).toBe('/api/visual-artifacts/art-1');
+      return { ok: true, json: async () => ({ data: { latest_version_number: 3, anchor_version: 2 } }) };
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="art-1" title="목업 초안" status={null} />);
+    });
+    await flush();
+    const thumb = container.querySelector('[data-testid="artifact-thumbnail"]');
+    expect(thumb).not.toBeNull();
+    expect(thumb?.getAttribute('data-artifact-id')).toBe('art-1');
+    expect(thumb?.getAttribute('data-version')).toBe('3');
+    expect(container.textContent).toContain('목업 초안');
+  });
+
+  it('fetch 실패 시 기존 아이콘+라벨 폼으로 정직하게 폴백(빈 썸네일 거짓 금지)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({}) })));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="art-2" title="깨진 아티팩트" status={null} />);
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="artifact-thumbnail"]')).toBeNull();
+    expect(container.textContent).toContain('깨진 아티팩트');
+  });
+
+  it('story 타입은 이 분기와 무관 — 기존 아이콘+라벨+상태 폼 그대로(회귀 0)', async () => {
+    await act(async () => {
+      root.render(<EmbedCard entity_type="story" entity_id="s-1" title="일반 스토리" status="in-progress" />);
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="artifact-thumbnail"]')).toBeNull();
+    expect(container.textContent).toContain('일반 스토리');
+  });
+});

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -690,6 +690,23 @@ export function EmbedCard({
   // 노출하던 같은 클래스의 gap. translateEntityStatus로 통과시킨다(미매핑=null=뱃지 안 그림).
   const statusLabel = status ? translateEntityStatus(entity_type, status) : null;
 
+  // story #2905(S2c①) — artifact/mockup은 "실 렌더 인라인"(§3 표): 텍스트 칩이 아니라 목업
+  // 자체를 축소 프리뷰로 보여준다. version_number를 몰라 ArtifactThumbnail을 못 그렸던 갭 —
+  // ENTITY_API['artifact'](parity 대상, 이미 등록됨)로 직접 fetch(EntityPreviewModal의 detail
+  // fetch와 별개 경로 — EmbedCard는 원래 fetch를 안 했다, 이 타입 하나만 예외).
+  const [artifactDetail, setArtifactDetail] = useState<{ latest_version_number?: number; anchor_version?: number | null } | null>(null);
+  useEffect(() => {
+    if (entity_type !== 'artifact') return;
+    let cancelled = false;
+    const url = ENTITY_API.artifact?.(entity_id);
+    if (!url) return;
+    void fetchWithAuth(url)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json: { data?: Record<string, unknown> } | null) => { if (!cancelled) setArtifactDetail((json?.data ?? null) as typeof artifactDetail); })
+      .catch(() => { if (!cancelled) setArtifactDetail(null); });
+    return () => { cancelled = true; };
+  }, [entity_type, entity_id]);
+
   const handleDocClick = useCallback(async () => {
     setNavigating(true);
     try {
@@ -716,7 +733,26 @@ export function EmbedCard({
     }
   }, [entity_id, router]);
 
-  const inner = (
+  // story #2905(S2c①) — artifact/mockup 실 렌더 인라인. version_number를 아직 못 받았으면(fetch
+  // 중/실패) 기존 아이콘+라벨 폼으로 정직하게 폴백(renderEntityDetail의 "있으면 열고 없으면
+  // 안 연다" 원칙과 동형 — 빈 썸네일을 거짓으로 그리지 않는다).
+  const isRichArtifact = entity_type === 'artifact' && artifactDetail?.latest_version_number != null;
+
+  const inner = isRichArtifact ? (
+    <div className={`overflow-hidden rounded-md border ${colorClass}`}>
+      <ArtifactThumbnail
+        artifactId={entity_id}
+        latestVersionNumber={artifactDetail!.latest_version_number!}
+        anchorVersion={artifactDetail!.anchor_version ?? null}
+        className="aspect-video w-full"
+      />
+      <div className="flex items-center gap-2 border-t border-current/10 px-3 py-1.5 text-sm">
+        <EntityGlyph Icon={resolveEntityIcon(entity_type)} label={label} />
+        <span className="min-w-0 flex-1 truncate font-medium">{label}</span>
+        {navigating && <span className="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />}
+      </div>
+    </div>
+  ) : (
     <div className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm ${colorClass}`}>
       <EntityGlyph Icon={resolveEntityIcon(entity_type)} label={label} />
       <span className="font-medium">{label}</span>


### PR DESCRIPTION
## 요약
story #2905 — S2c v2(§3+§8) ②(gate Block Kit 리치 블록). **PR#3307(①) 위에 쌓은 스택 PR** — #3307이 develop에 착지하면 base를 develop으로 재타겟하고 diff를 이 커밋 하나로 정리하겠는(2886-on-2888 선례와 동형).

## 변경
- `chat-bubble.tsx`: `ChatMarkdown`에 `eventDefinitionsByKey` prop 신설(ApprovalRequestCard가 요구하는 카탈로그 물림). `p` 핸들러 sole-link 분기에서 `entityType==='gate'`면 `EmbedCard` 대신 `ApprovalRequestCard`를 렌더 — `onOpenReadingPanel` 클릭-전체-래핑 대상에서 제외(자체 인터랙션 보유 컴포넌트라 버튼-안-버튼 방지).
- `approval-request-card.tsx`: 헤더 아이콘이 fetch 완료 후 gate 실물의 `work_item_type`을 우선하도록(placeholder target 호출부 대응, GateResponse가 1급 필드로 실어 옴 — 페드루 확定 2026-08-21).

## PO 판정 반영(스토리 본문에 이미 명문화)
「표면은 둘·실체는 하나」— gate=결재함과 같은 실체의 두 표면(§8). Block Kit 리치 블록에 승인 액션이 실리되, 그 액션 로직은 `approval-request-card.tsx`를 그대로 재사용(사본 분화 금지). 프리뷰 표면(ReadingPanel·모달, #2903 `renderGateSummary`)은 요약 전용 그대로 유지.

## 셀프 게이트
- ✅ `tsc --noEmit` 클린
- ✅ `pnpm lint` 0 errors
- ✅ `vitest run src/components/chat/` 39 files·394 tests 전부 그린(신규 2건 포함)
- ✅ 대비가드 5종 전부 클린(신규 위반 0)
- ✅ `pnpm build` EXIT 0