### PR TITLE
[SID:2902] gate 상세 backlinks 배선 — 「이 게이트를 언급한 대화」(후보 B)

### DIFF
--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -16,6 +16,7 @@ import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-h
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateItem } from '@/components/kanban/types';
 import { fetchWithAuth } from '@/lib/db/client';
+import { EntityBacklinksSection } from '@/components/shared/entity-backlinks-section';
 
 // story #1954(P1a-S4) — Gate 3종(게이트·문서결재·머지게이트) canonical 상세. P1a·P2 공용 유일
 // per-gate 라우트(중복 빌드 봉쇄) — decision(inbox_items)은 별도 표면(오르테가군 PO 판단+
@@ -304,6 +305,11 @@ export default function GateDetailPage() {
                 </Button>
               </div>
             )}
+
+            {/* story #2902(후보 B, S2h①③ list_entity_backlinks 확장 소비처) — 「이 게이트를
+                언급한 대화」 역참조. 기성 EntityBacklinksSection(3곳 소비 중) 그대로 재사용 —
+                신규 뷰어 0. gate는 TARGET_ONLY라 액션 없이 조회만(§8 계약과 정합). */}
+            <EntityBacklinksSection entityType="gate" entityId={gate.id} />
           </>
         )}
       </div>


### PR DESCRIPTION
## 요약
story #2902 — S2h①③(#2889·PR#3302)가 연 `GET /gates/{id}/backlinks`가 화면 소비처 0곳이던 갭. 후보 B(기존 `/gates/[id]` 상세 페이지 + EntityBacklinksSection) 채택 — 실측상 1줄, 가장 저비용.

## 변경
- `gates/[id]/page.tsx`에 `<EntityBacklinksSection entityType="gate" entityId={gate.id} />` 추가. 기성 컴포넌트(doc-view/story-detail-panel/artifact-viewer 3곳 이미 소비 중) 그대로 재사용 — 신규 뷰어 0.

## 스코프 밖
후보 A(S2d side pane의 gate 프리뷰 안 섹션)는 이 PR과 배타 아님 — 별도 검토(스토리 본문에 이미 명시).

## 셀프 게이트
- ✅ `tsc --noEmit` 클린
- ✅ `pnpm lint` 0 errors
- ✅ `vitest run entity-backlinks-section.test.tsx entity-backlinks-section.route-map.test.ts` 12 tests 전부 그린(parity 무회귀)
- ✅ 대비가드 5종 전부 클린(신규 위반 0)
- ✅ `pnpm build` EXIT 0