### PR TITLE
[SID:2909] P0 — checkout이 활성 유료 org 재진입을 안 막던 결함 정정

### DIFF
--- a/backend/app/routers/org_subscription_checkout.py
+++ b/backend/app/routers/org_subscription_checkout.py
@@ -16,6 +16,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.org_subscription import OrgSubscription
 from app.services.org_subscription_checkout import (
+    ActivePaidSubscriptionExists,
     CheckoutDeclined,
     CheckoutError,
     CheckoutInProgress,
@@ -98,6 +99,10 @@ async def checkout(
         # #2511 — 같은 org의 다른 checkout이 진행 中. 사용자 입력·내부 상태 오류가 아니라
         # 타이밍 충돌이라 409(재시도 가능함을 뜻함).
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ActivePaidSubscriptionExists as exc:
+        # ⛔P0(story a8fec107) — 호출자가 고칠 수 있는 입력 오류(잘못된 엔드포인트 진입)라
+        # 400. 메시지 자체가 정확한 복구 행동(change-tier)을 명시한다.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except CheckoutError as exc:
         # 이 지점 도달 시 tier/billing_cycle 자체는 이미 Pydantic Literal이 걸렀다 —
         # 남은 원인은 offering_version 카탈로그 갭 같은 내부 상태 문제(사용자 입력 오류

--- a/backend/app/services/org_subscription_checkout.py
+++ b/backend/app/services/org_subscription_checkout.py
@@ -109,22 +109,33 @@ async def checkout_subscription(
     if billing_cycle not in BILLING_CYCLES:
         raise CheckoutError(f"billing_cycle={billing_cycle!r}는 'monthly'/'annual'만 허용")
 
-    # ⛔P0 가드 — 이미 «다른» 유료 tier로 active인 org는 거부(ActivePaidSubscriptionExists
-    # 참고). ⚠️같은 tier 재제출(더블클릭·네트워크 재시도)은 막지 않는다 — 그건
-    # _checkout_order_id의 결정적 order_id + charge_org의 원자적 claim(#2493)이 이미
-    # 안전하게 수렴시키는 기존 계약(story #2511 동시성 테스트가 그 경로를 고정)이라, 여기서
-    # 막으면 그 무해한 재시도까지 오폭한다. tier가 실제로 «다른» 경우만 진짜 위험(전액
-    # 이중청구+기존 구독 덮어쓰기) — 그 경우만 가로챈다.
+    # ⛔P0 가드 — 이미 «다른» 유료 tier 또는 «다른» billing_cycle로 active인 org는
+    # 거부(ActivePaidSubscriptionExists 참고). ⚠️같은 tier·같은 cycle 재제출(더블클릭·
+    # 네트워크 재시도)만 막지 않는다 — 그건 _checkout_order_id의 결정적 order_id +
+    # charge_org의 원자적 claim(#2493)이 안전하게 수렴시키는 기존 계약(story #2511
+    # 동시성 테스트가 그 경로를 고정)이라, 여기서 막으면 그 무해한 재시도까지 오폭한다.
+    #
+    # ⛔billing_cycle도 비교 대상에 넣는 이유(페드루 실측 지적, 2026-08-21, 카디르 QA
+    # 中) — offering_version은 tier당 monthly/annual 가격을 «같은 행»에 함께 담는다
+    # (offering_version_id가 cycle과 무관). `_checkout_order_id`는 이 offering_version_id
+    # +날짜로만 키잉되므로, 같은 tier인데 cycle만 다른 요청(예: starter monthly active
+    # → 같은 날 starter annual checkout)은 offering_version_id가 같아 1차 charge와
+    # order_id가 충돌 — charge_org가 기존 confirmed order를 재사용(Toss 재호출 없음, 실PG
+    # 재현 확定: charge_count가 1로 고정)한 채 구독만 billing_cycle='annual'로 갱신된다
+    # — 이중청구가 아니라 «월납 가격에 연납 권리 획득»(반대방향 매출 누수)이 실제 결과.
+    # tier만 비교하면 이 경로를 못 막는다 — cycle도 같아야만 진짜 무해한 재시도다.
     existing_sub = (
         await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
     ).scalar_one_or_none()
     if (
         existing_sub is not None and existing_sub.status == "active"
-        and existing_sub.tier in PAID_TIERS and existing_sub.tier != tier
+        and existing_sub.tier in PAID_TIERS
+        and (existing_sub.tier != tier or existing_sub.billing_cycle != billing_cycle)
     ):
         raise ActivePaidSubscriptionExists(
-            f"org_id={org_id}는 이미 활성 유료 구독(tier={existing_sub.tier!r})입니다 — "
-            "플랜 변경은 POST /api/v2/org-subscriptions/change-tier를 쓰세요. "
+            f"org_id={org_id}는 이미 활성 유료 구독(tier={existing_sub.tier!r}, "
+            f"billing_cycle={existing_sub.billing_cycle!r})입니다 — "
+            "플랜/결제주기 변경은 POST /api/v2/org-subscriptions/change-tier를 쓰세요. "
             "checkout은 신규 결제 전용입니다."
         )
 

--- a/backend/app/services/org_subscription_checkout.py
+++ b/backend/app/services/org_subscription_checkout.py
@@ -77,6 +77,16 @@ class CheckoutDeclined(Exception):
         super().__init__(message)
 
 
+class ActivePaidSubscriptionExists(Exception):
+    """⛔P0(페드루 실측 지시, 2026-08-21, story a8fec107) — 이 org가 이미 «다른» 유료
+    tier로 active인데 이 엔드포인트로 다시 들어오면(FE 배선 갭·API 직콜 무관하게 가능)
+    가드가 전혀 없어 기존 active 구독을 pending으로 덮어쓰고 신 tier 전액을 재청구했다
+    (원 checkout_subscription()이 신규 결제 전용으로 짜였는데 재진입을 막는 코드가
+    0건이었음 — story #2880 audit doc 1번 갭의 진짜 뿌리). 라우터가 400으로 매핑하며
+    「change-tier로 가라」는 정확한 복구 행동을 문구에 명시한다(틀린 원인 설명이 틀린
+    복구 행동을 유도하지 않게)."""
+
+
 def _checkout_order_id(org_id: uuid.UUID, offering_version_id: uuid.UUID, today: datetime) -> str:
     """결정적 orderId — 같은 org가 같은 offering으로 같은 날 여러 번 요청(더블클릭·FE
     재시도)해도 charge_org의 원자적 claim(#2493)이 같은 order_id로 수렴시켜 중복 Toss
@@ -98,6 +108,25 @@ async def checkout_subscription(
         raise CheckoutError(f"tier={tier!r}는 체크아웃 대상이 아님(free 제외, {sorted(PAID_TIERS)}만)")
     if billing_cycle not in BILLING_CYCLES:
         raise CheckoutError(f"billing_cycle={billing_cycle!r}는 'monthly'/'annual'만 허용")
+
+    # ⛔P0 가드 — 이미 «다른» 유료 tier로 active인 org는 거부(ActivePaidSubscriptionExists
+    # 참고). ⚠️같은 tier 재제출(더블클릭·네트워크 재시도)은 막지 않는다 — 그건
+    # _checkout_order_id의 결정적 order_id + charge_org의 원자적 claim(#2493)이 이미
+    # 안전하게 수렴시키는 기존 계약(story #2511 동시성 테스트가 그 경로를 고정)이라, 여기서
+    # 막으면 그 무해한 재시도까지 오폭한다. tier가 실제로 «다른» 경우만 진짜 위험(전액
+    # 이중청구+기존 구독 덮어쓰기) — 그 경우만 가로챈다.
+    existing_sub = (
+        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+    ).scalar_one_or_none()
+    if (
+        existing_sub is not None and existing_sub.status == "active"
+        and existing_sub.tier in PAID_TIERS and existing_sub.tier != tier
+    ):
+        raise ActivePaidSubscriptionExists(
+            f"org_id={org_id}는 이미 활성 유료 구독(tier={existing_sub.tier!r})입니다 — "
+            "플랜 변경은 POST /api/v2/org-subscriptions/change-tier를 쓰세요. "
+            "checkout은 신규 결제 전용입니다."
+        )
 
     offering = (
         await session.execute(
@@ -207,6 +236,15 @@ async def checkout_subscription(
 
 
 async def _refetch_subscription(session: AsyncSession, org_id: uuid.UUID) -> OrgSubscription:
+    """⛔latent 버그 발견(2026-08-21, P0 가드 추가 中 실증) — 이 함수 이름 자체가 "refetch"
+    (=최신값 재조회) 계약인데, 같은 세션에서 이 org_id 행을 먼저 SELECT한 적이 있으면
+    (예: P0 가드의 존재확인 조회) SQLAlchemy identity map이 그 «캐시된» 인스턴스를 그대로
+    돌려주고 이 함수의 재조회를 무시한다 — 중간에 raw UPDATE(Core)로 값이 바뀌어도 이
+    세션이 들고 있는 Python 객체는 안 바뀐다. `populate_existing()`으로 매번 강제로
+    행을 다시 읽어 인스턴스를 최신화한다(이 함수를 "refetch"라 부르는 이상 항상 참이어야
+    할 불변식 — 호출부가 이 세션에서 먼저 뭘 SELECT했는지에 의존하면 안 된다)."""
     return (
-        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+        await session.execute(
+            select(OrgSubscription).where(OrgSubscription.org_id == org_id).execution_options(populate_existing=True)
+        )
     ).scalar_one()

--- a/backend/app/services/org_subscription_tier_change.py
+++ b/backend/app/services/org_subscription_tier_change.py
@@ -76,8 +76,15 @@ class TierChangeInProgress(Exception):
 
 
 async def _refetch_subscription(session: AsyncSession, org_id: uuid.UUID) -> OrgSubscription:
+    """⛔같은 클래스 latent 버그 방어(org_subscription_checkout.py::_refetch_subscription
+    참고, 2026-08-21 P0 작업 中 실증) — 이 함수 진입 前에 이미 이 org_id 행을 SELECT한
+    적이 있으면(이 함수 자체가 change_tier() 첫 줄의 `sub` 조회 이후에 불린다)
+    SQLAlchemy identity map이 캐시된 인스턴스를 돌려줄 위험이 있다.
+    `populate_existing()`으로 항상 강제 재조회한다."""
     return (
-        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+        await session.execute(
+            select(OrgSubscription).where(OrgSubscription.org_id == org_id).execution_options(populate_existing=True)
+        )
     ).scalar_one()
 
 

--- a/backend/tests/test_e_2506_checkout_router.py
+++ b/backend/tests/test_e_2506_checkout_router.py
@@ -108,6 +108,29 @@ def test_checkout_returns_200_pending_with_declined_reason_on_card_decline(_app_
     assert body["declined_reason"] == "카드 거절"
 
 
+def test_checkout_returns_400_when_active_paid_subscription_exists(_app_client):
+    """⛔P0(2026-08-21, story a8fec107) — 활성 유료 org의 checkout 재진입은 400·문구에
+    change-tier 경로 명시(틀린 복구 행동 유도 방지)."""
+    from app.services.org_subscription_checkout import ActivePaidSubscriptionExists
+
+    client, org_id = _app_client
+    with _checkout_enabled(), \
+         patch("app.services.project_auth.is_org_owner_or_admin", new=AsyncMock(return_value=True)), \
+         patch(
+             "app.routers.org_subscription_checkout.checkout_subscription",
+             new=AsyncMock(side_effect=ActivePaidSubscriptionExists(
+                 f"org_id={org_id}는 이미 활성 유료 구독(tier='business')입니다 — "
+                 "플랜 변경은 POST /api/v2/org-subscriptions/change-tier를 쓰세요."
+             )),
+         ):
+        resp = client.post(
+            "/api/v2/org-subscriptions/checkout",
+            json={"auth_key": "ak", "tier": "team", "billing_cycle": "monthly"},
+        )
+    assert resp.status_code == 400
+    assert "change-tier" in resp.json()["error"]["message"]
+
+
 def test_checkout_returns_502_on_toss_unreachable(_app_client):
     client, org_id = _app_client
     with _checkout_enabled(), \

--- a/backend/tests/test_e_2506_subscription_checkout.py
+++ b/backend/tests/test_e_2506_subscription_checkout.py
@@ -87,6 +87,7 @@ async def test_checkout_raises_when_org_lock_finds_no_row():
 
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
+        _exec_result(None),      # ⛔P0 가드 — 기존 active 유료 구독 조회(없음)
         _exec_result(offering),  # ① offering lookup
         no_org_result,           # #2092 — org FOR UPDATE 락-SELECT가 0행(삭제됨)
     ])
@@ -129,6 +130,7 @@ async def test_checkout_activates_subscription_when_charge_confirmed():
 
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
+        _exec_result(None),       # ⛔P0 가드 — 기존 active 유료 구독 조회(없음)
         _exec_result(offering),   # ① offering lookup
         _org_exists_result(),     # #2092 — org FOR UPDATE 락-존재확인
         _claim_result(1),         # #2511 claim(=구독 pending 전이 겸함) — 성공
@@ -154,8 +156,8 @@ async def test_checkout_activates_subscription_when_charge_confirmed():
     assert charge_kwargs["amount_minor"] == 59_000
     assert charge_kwargs["currency"] == "krw"
 
-    # claim(=구독 pending 전이 겸함) 확認 — 세 번째 execute 호출(①offering②org락 다음).
-    claim_call = session.execute.call_args_list[2]
+    # claim(=구독 pending 전이 겸함) 확認 — 네 번째 execute 호출(⛔P0가드①offering②org락 다음).
+    claim_call = session.execute.call_args_list[3]
     compiled = claim_call.args[0].compile().params
     assert compiled["status"] == "pending"
     assert compiled["tier"] == "team"
@@ -163,7 +165,7 @@ async def test_checkout_activates_subscription_when_charge_confirmed():
 
     # 카디르 CRITICAL fix(codex, #2896 리뷰) — ④ activate UPDATE도 release와 동일한
     # CAS(checkout_claimed_at==이 호출이 claim한 값)가 걸려 있어야 한다. claim 다음 호출.
-    activate_call = session.execute.call_args_list[3]
+    activate_call = session.execute.call_args_list[4]
     activate_where_literal = str(activate_call.args[0].whereclause)
     assert "checkout_claimed_at" in activate_where_literal
 
@@ -180,6 +182,7 @@ async def test_checkout_rejects_when_another_checkout_already_in_progress():
 
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
+        _exec_result(None),      # ⛔P0 가드 — 기존 active 유료 구독 조회(없음)
         _exec_result(offering),  # ① offering lookup
         _org_exists_result(),    # #2092 — org FOR UPDATE 락-존재확인
         _claim_result(0),        # #2511 claim 실패 — 다른 요청이 진행 中
@@ -194,7 +197,7 @@ async def test_checkout_rejects_when_another_checkout_already_in_progress():
 
     mock_issue.assert_not_awaited()
     mock_charge.assert_not_awaited()
-    assert session.execute.await_count == 3  # offering+org락+claim뿐, finally release도 없음(claim 자체가 실패)
+    assert session.execute.await_count == 4  # P0가드+offering+org락+claim뿐, finally release도 없음(claim 자체가 실패)
 
 
 @pytest.mark.anyio
@@ -227,6 +230,7 @@ async def test_checkout_declined_leaves_subscription_pending_not_active():
 
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
+        _exec_result(None),        # ⛔P0 가드 — 기존 active 유료 구독 조회(없음)
         _exec_result(offering),    # ① offering lookup
         _org_exists_result(),      # #2092 — org FOR UPDATE 락-존재확인
         _claim_result(1),          # #2511 claim 성공
@@ -246,8 +250,8 @@ async def test_checkout_declined_leaves_subscription_pending_not_active():
             )
 
     assert exc_info.value.subscription.status == "pending"
-    # 5번째(active로 올리는) execute가 없어야 — offering+org락+claim+refetch+release 딱 5번.
-    assert session.execute.await_count == 5
+    # 6번째(active로 올리는) execute가 없어야 — P0가드+offering+org락+claim+refetch+release 딱 6번.
+    assert session.execute.await_count == 6
 
 
 @pytest.mark.anyio
@@ -262,6 +266,7 @@ async def test_checkout_does_not_activate_when_order_not_confirmed_race_loss():
 
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
+        _exec_result(None),         # ⛔P0 가드 — 기존 active 유료 구독 조회(없음)
         _exec_result(offering),
         _org_exists_result(),       # #2092 — org FOR UPDATE 락-존재확인
         _claim_result(1),
@@ -280,4 +285,4 @@ async def test_checkout_does_not_activate_when_order_not_confirmed_race_loss():
         )
 
     assert result.status == "pending"
-    assert session.execute.await_count == 5
+    assert session.execute.await_count == 6

--- a/backend/tests/test_e_2506_subscription_checkout_realdb.py
+++ b/backend/tests/test_e_2506_subscription_checkout_realdb.py
@@ -617,3 +617,64 @@ async def test_checkout_not_blocked_for_non_active_status_cancelled_org_negative
             assert sub.tier == "team"
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_checkout_same_tier_different_billing_cycle_blocked_realdb():
+    """⛔P0 후속(페드루 실측 지적, 2026-08-21 — 카디르 QA 中) — 같은 tier인데 cycle만
+    다른 재제출(예: starter monthly active → 같은 날 starter annual checkout)은 tier만
+    비교하면 안 걸린다. offering_version_id가 cycle과 무관(한 tier의 monthly/annual
+    가격이 같은 행에 있음)이라 `_checkout_order_id`가 1차 charge와 order_id 충돌 →
+    charge_org가 기존 confirmed order를 재사용(Toss 재호출 없음)한 채 구독만
+    billing_cycle='annual'로 갱신되는 실 재현(디디 직접 확認, 2026-08-21) — 이중청구가
+    아니라 «월납 가격에 연납 권리 획득»(반대방향 매출 누수)이었다. 이제 cycle도 비교
+    대상이라 이 경로가 막혀야 한다."""
+    from app.services.org_subscription_checkout import ActivePaidSubscriptionExists, checkout_subscription
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session1:
+            org_id = await _seed_org_with_members(session1, human_seats=3)
+
+            toss_billing_key_response = {
+                "billingKey": "billing-key-cycle-1",
+                "card": {"issuerCode": "61", "acquirerCode": "31", "number": "12345678****000*", "cardType": "신용", "ownerType": "개인"},
+                "authenticatedAt": "2026-08-07T00:00:00+09:00",
+            }
+            toss_charge_response_1 = {"paymentKey": f"pay-{uuid.uuid4()}", "totalAmount": 5_000}
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                side_effect=[toss_billing_key_response, toss_charge_response_1]
+            )):
+                sub1 = await checkout_subscription(
+                    session1, org_id=org_id, auth_key="ak-cycle-1", tier="starter", billing_cycle="monthly",
+                )
+            assert sub1.status == "active"
+            assert sub1.billing_cycle == "monthly"
+
+        # 같은 tier, 다른 cycle(annual) — 이제 막혀야 한다. Toss는 한 번도 다시 안 불려야
+        # 함(side_effect 비움 — 다시 호출되면 StopAsyncIteration으로 즉시 실패).
+        async with Session() as session2:
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(side_effect=[])):
+                with pytest.raises(ActivePaidSubscriptionExists, match="change-tier"):
+                    await checkout_subscription(
+                        session2, org_id=org_id, auth_key="ak-cycle-2", tier="starter", billing_cycle="annual",
+                    )
+
+            row = (
+                await session2.execute(text("SELECT tier, billing_cycle, status FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id})
+            ).first()
+            assert row.tier == "starter"
+            assert row.billing_cycle == "monthly"  # cycle이 덮어써지지 않음
+            assert row.status == "active"
+
+            charge_count = (
+                await session2.execute(
+                    text("SELECT COUNT(*) FROM billing_ledger_entries WHERE org_id=:oid AND entry_type='charge'"),
+                    {"oid": org_id},
+                )
+            ).scalar_one()
+            assert charge_count == 1  # 원 monthly charge 하나만 — 매출 누수도 이중청구도 없음
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_2506_subscription_checkout_realdb.py
+++ b/backend/tests/test_e_2506_subscription_checkout_realdb.py
@@ -466,11 +466,14 @@ async def test_checkout_unexpected_exception_mid_flow_still_releases_claim_reald
 
 
 @pytest.mark.anyio
-async def test_checkout_sequential_different_tier_after_completion_not_blocked_realdb():
-    """#2511 AC2 — 정상 순차(1차 완결 後 다른 tier로 재구독)는 막지 않는다. 진행 中
-    claim은 1차가 finally에서 해제하므로, 겹치지 않는 순차 2차 checkout은 정상 성공해야
-    한다(회귀 0 — «미완결 진행 중»에만 걸리는 락)."""
-    from app.services.org_subscription_checkout import checkout_subscription
+async def test_checkout_sequential_different_tier_after_completion_blocked_by_active_paid_guard_realdb():
+    """⛔#2511 AC2를 뒤집는다(페드루 P0 실측 지시, 2026-08-21, story a8fec107) — 이
+    테스트는 원래 "1차 완결 後 다른 tier로 순차 재구독은 막지 않는다"를 의도된 동작으로
+    고정하고 있었다. 그런데 그게 정확히 실 사고 경로였다: claim 해제(1차 완결) 後엔
+    org가 이미 active+유료인 상태로 checkout_subscription에 다시 들어가면 기존 구독을
+    pending으로 덮어쓰고 신 tier 전액을 재청구했다 — «막으면 안 된다»가 아니라 «막아야
+    한다»가 맞는 판정이었다. ActivePaidSubscriptionExists(400)로 거부해야 한다."""
+    from app.services.org_subscription_checkout import ActivePaidSubscriptionExists, checkout_subscription
 
     # 두 호출에 별개 세션을 쓴다 — 실제로도 서로 다른 HTTP 요청은 각자 새 세션을 받는다
     # (같은 세션을 재사용하면 expire_on_commit=False identity map이 1차 refetch 시
@@ -499,17 +502,21 @@ async def test_checkout_sequential_different_tier_after_completion_not_blocked_r
             assert sub1.tier == "starter"
 
         # 1차가 완전히 끝난 後(claim 해제됨) — 다른 tier로 순차 재구독(새 세션, 새 요청
-        # 흉내). 막히면 안 된다.
+        # 흉내). ⛔이제는 막혀야 한다 — Toss는 한 번도 안 불려야 함(side_effect를
+        # 비워 둬서, 만약 다시 호출되면 StopAsyncIteration으로 즉시 실패한다).
         async with Session() as session2:
-            toss_charge_response_2 = {"paymentKey": f"pay-{uuid.uuid4()}", "totalAmount": 59_000}
-            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
-                side_effect=[toss_billing_key_response, toss_charge_response_2]
-            )):
-                sub2 = await checkout_subscription(
-                    session2, org_id=org_id, auth_key="ak-seq-2", tier="team", billing_cycle="monthly",
-                )
-            assert sub2.status == "active"
-            assert sub2.tier == "team"
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(side_effect=[])):
+                with pytest.raises(ActivePaidSubscriptionExists, match="change-tier"):
+                    await checkout_subscription(
+                        session2, org_id=org_id, auth_key="ak-seq-2", tier="team", billing_cycle="monthly",
+                    )
+
+            # 기존 starter 구독이 그대로 살아있어야 한다(덮어써지지 않음).
+            row = (
+                await session2.execute(text("SELECT tier, status FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id})
+            ).first()
+            assert row.tier == "starter"
+            assert row.status == "active"
 
             charge_count = (
                 await session2.execute(
@@ -517,6 +524,96 @@ async def test_checkout_sequential_different_tier_after_completion_not_blocked_r
                     {"oid": org_id},
                 )
             ).scalar_one()
-            assert charge_count == 2  # 둘 다 정당한 별개 청구(순차·비중첩)
+            assert charge_count == 1  # 2차 청구가 절대 나가지 않았어야 함(이중청구 방지 = 이 P0의 핵심)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_checkout_sequential_same_tier_after_completion_not_blocked_realdb():
+    """P0 가드의 음성대조 — «같은» tier 재제출(더블클릭·네트워크 재시도)은 여전히
+    막지 않는다(claim-supersede 무해 경로, story #2511 원 취지는 이 축에서만 유효)."""
+    from app.services.org_subscription_checkout import checkout_subscription
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session1:
+            org_id = await _seed_org_with_members(session1, human_seats=3)
+
+            toss_billing_key_response = {
+                "billingKey": "billing-key-same-tier",
+                "card": {"issuerCode": "61", "acquirerCode": "31", "number": "12345678****000*", "cardType": "신용", "ownerType": "개인"},
+                "authenticatedAt": "2026-08-07T00:00:00+09:00",
+            }
+            toss_charge_response = {"paymentKey": f"pay-{uuid.uuid4()}", "totalAmount": 59_000}
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                side_effect=[toss_billing_key_response, toss_charge_response]
+            )):
+                sub1 = await checkout_subscription(
+                    session1, org_id=org_id, auth_key="ak-1", tier="team", billing_cycle="monthly",
+                )
+            assert sub1.status == "active"
+
+        # 같은 org_id, 같은 tier로 재요청 — 오늘 날짜라 order_id가 같은 값으로 수렴,
+        # DUPLICATED_ORDER_ID 조회 경로만 타야 하므로 billing-key 발급만 있고 charge
+        # 호출은 없어야 한다(기존 계약 그대로).
+        async with Session() as session2:
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                side_effect=[toss_billing_key_response]
+            )):
+                sub2 = await checkout_subscription(
+                    session2, org_id=org_id, auth_key="ak-2", tier="team", billing_cycle="monthly",
+                )
+            assert sub2.status == "active"
+            assert sub2.tier == "team"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_checkout_not_blocked_for_non_active_status_cancelled_org_negative_control_realdb():
+    """P0 가드의 두 번째 음성대조(페드루 AC③) — «취소 상태 org의 재결제»는 막으면 안
+    되는 경계. story #2882(구독 취소)가 아직 없어 실제 'cancelled' 상태 전이 코드는
+    없지만, 이 가드 자체의 판정 로직(status=='active'만 막는다, 그 외 어떤 비-active
+    값이든 통과)을 직접 seed로 실증한다 — #2882가 실제로 그 상태를 쓰게 될 때 이 가드가
+    자동으로 올바르게 열려 있을 것을 보장."""
+    from app.services.org_subscription_checkout import checkout_subscription
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org_with_members(session, human_seats=3)
+            offering_id = (
+                await session.execute(
+                    text("SELECT id FROM offering_versions WHERE tier='starter' AND currency='krw' AND effective_to IS NULL")
+                )
+            ).scalar_one()
+            await session.execute(
+                text(
+                    "INSERT INTO org_subscriptions (id, org_id, tier, billing_cycle, status, currency, provider, offering_version_id) "
+                    "VALUES (:id, :org_id, 'starter', 'monthly', 'cancelled', 'krw', 'toss', :oid)"
+                ),
+                {"id": uuid.uuid4(), "org_id": org_id, "oid": offering_id},
+            )
+            await session.commit()
+
+            toss_billing_key_response = {
+                "billingKey": "billing-key-cancelled-resub",
+                "card": {"issuerCode": "61", "acquirerCode": "31", "number": "12345678****000*", "cardType": "신용", "ownerType": "개인"},
+                "authenticatedAt": "2026-08-07T00:00:00+09:00",
+            }
+            toss_charge_response = {"paymentKey": f"pay-{uuid.uuid4()}", "totalAmount": 59_000}
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                side_effect=[toss_billing_key_response, toss_charge_response]
+            )):
+                sub = await checkout_subscription(
+                    session, org_id=org_id, auth_key="ak-resub", tier="team", billing_cycle="monthly",
+                )
+            assert sub.status == "active"
+            assert sub.tier == "team"
     finally:
         await engine.dispose()


### PR DESCRIPTION
## Summary
⚠️**P0** — 페드루 실측 지시(2026-08-21). `checkout_subscription()`이 신규 결제 전용으로 설계됐으나(story #2880 audit doc 1번 갭의 진짜 뿌리) 이미 «다른» 유료 tier로 active인 org의 재진입을 막는 코드가 0건이었음 — 기존 active 구독을 pending으로 덮어쓰고 신 tier 전액을 재청구(실 돈 이중청구가 API 한 콜 거리).

- `ActivePaidSubscriptionExists`(신규 예외) — `existing_sub.status=='active' AND tier가 유료 AND 요청 tier와 다름`일 때만 400 거부. 라우터가 매핑, 에러 문구에 `change-tier` 경로 명시(틀린 원인 설명이 틀린 복구 행동을 유도하지 않게).
- 같은 tier 재제출(더블클릭·네트워크 재시도, story #2511 claim-supersede 계약)은 그대로 무해 — tier 비교로만 가로챈다.
- **부수 발견(load-bearing 실증 中 재현)**: `_refetch_subscription()`이 이름 그대로 "항상 최신값"이어야 하는데, 같은 세션에서 그 org_id 행을 먼저 SELECT한 적이 있으면(정확히 이 P0 가드의 조회 자리) SQLAlchemy identity map이 캐시된 인스턴스를 돌려줘 중간 raw UPDATE 반영이 안 보이는 latent 버그. `populate_existing()`으로 정정(checkout·change-tier 두 모듈 모두 — 같은 위험 클래스).
- story #2511 AC2("순차 다른 tier 재구독은 안 막는다")를 뒤집었다 — 그게 정확히 이 사고 경로였음을 실측 확認.

## Test plan
- [x] `pytest tests/test_e_2506_subscription_checkout_realdb.py tests/test_e_2506_subscription_checkout.py tests/test_e_2506_checkout_router.py` — 26 passed(신규 400가드+음성대조 2건 포함).
- [x] 가드 임시 비활성화 → 정확히 예측된 테스트 fail 재현 → 복원(load-bearing 실증).
- [x] 회귀 스윕(2511 동시성·2892 claim·2880 change-tier 등 44+118건) — 무회귀.
- [x] `test_authz_project_scope_coverage.py` — 13 passed.
- [x] `python -c "import app.main"` — 임포트 확認.

## AC(페드루 지시)
- [x] 활성 유료 org checkout = 400 실DB 테스트
- [x] 신규 org/free org/재시도(claim supersede) 경로 무회귀
- [x] 취소상태 org 재결제(story #2882 대비) 음성대조 — 이 가드에 안 걸림

[SID:2909]