### PR TITLE
[SID:2910] S2f FE — 전환 애니메이션(R3): 패널 slide-in·스택 push/pop·칩 press, exit 무애니

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -976,7 +976,10 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
 
         {/* AC7/AC8: 스레드 패널 — 데스크톱 사이드 패널 / 모바일 전체 뷰 */}
         {activeThread && (
-          <div className={`flex flex-col overflow-hidden ${isMobileThreadView ? 'flex-1' : 'hidden w-80 flex-shrink-0 lg:flex'}`}>
+          // story #2910(S2f/R3) — ReadingPanel과 동형 slide-in(1회, activeThread가 null→값
+          // 전환될 때만 — 다른 스레드로 전환은 ThreadPanel 자체 key가 담당, 이 wrapper는 안
+          // 리마운트돼 재발화 없음). exit 애니 의도적 무(ReadingPanel과 동일 판정).
+          <div className={`motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-right duration-150 flex flex-col overflow-hidden ${isMobileThreadView ? 'flex-1' : 'hidden w-80 flex-shrink-0 lg:flex'}`}>
             <ThreadPanel
               key={activeThread.id}
               parentMessage={activeThread}
@@ -998,8 +1001,12 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
             모바일 전체 뷰. ThreadPanel과 같은 슬롯이지만 폭 규격이 다르다(320px 고정이 아님
             — 문서 가독 기준 폭). */}
         {readingPanelStack.length > 0 && (
+          // story #2910(S2f/R3) — 패널이 처음 열릴 때 1회만 slide-in(이 div는 push/pop마다
+          // readingPanelStack 참조만 바뀔 뿐 리마운트되지 않아 재발화 안 함 — 스택 전환은
+          // reading-panel.tsx 안쪽 콘텐츠 wrapper가 자기 key로 별도 담당, 자연 분리).
+          // exit(닫기) 애니는 의도적 무(PO 판정 — 즉시 사라짐=반응성 피드백).
           <div
-            className={`flex flex-col overflow-hidden ${isMobileReadingView ? 'flex-1' : 'hidden lg:flex'}`}
+            className={`motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-right duration-150 flex flex-col overflow-hidden ${isMobileReadingView ? 'flex-1' : 'hidden lg:flex'}`}
             style={isMobileReadingView ? undefined : { width: 'clamp(480px, 40vw, 720px)', flexShrink: 0 }}
           >
             <ReadingPanel stack={readingPanelStack} onNavigateTo={navigateReadingPanelTo} onClose={closeReadingPanel} />

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -769,12 +769,16 @@ export function EmbedCard({
   // 자신의 명시 액션으로 이동, EntityPreviewModal 풋터 링크가 이미 그 역할). 채팅 밖 호출부
   // (onOpenReadingPanel 미제공 — chat-input.tsx 작성 중 미리보기 등)는 아래 타입별 기존
   // 분기를 그대로 유지(회귀 0).
+  // story #2910(S2f/R3) — 「칩→카드→패널 연속」을 shared-element 모핑(비용 대비 장식, §6 위반
+  // 소지) 대신 press 즉각 스케일 피드백 + 뒤이은 패널 slide-in 순차 배치로 전달(PO 판정
+  // 2026-08-21). 이 파일의 클릭 가능 지점 4곳(이 버튼·doc 버튼·EntityChip 트리거·plain
+  // Link) 전부 동일 패턴.
   if (onOpenReadingPanel) {
     return (
       <button
         type="button"
         onClick={() => onOpenReadingPanel(entity_type, entity_id, title, status, href)}
-        className="block w-full text-left transition-opacity hover:opacity-80"
+        className="block w-full text-left transition hover:opacity-80 motion-safe:active:scale-[0.98]"
       >
         {inner}
       </button>
@@ -833,7 +837,7 @@ export function EmbedCard({
       <button
         type="button"
         onClick={() => setShowModal(true)}
-        className="block w-full text-left transition-opacity hover:opacity-80"
+        className="block w-full text-left transition hover:opacity-80 motion-safe:active:scale-[0.98]"
       >
         {inner}
       </button>
@@ -1044,7 +1048,7 @@ export function EntityChip({
     const triggerButtonProps = {
       type: 'button' as const,
       onClick: () => setShowModal(true),
-      className: 'inline-flex no-underline transition-opacity hover:opacity-80',
+      className: 'inline-flex no-underline transition hover:opacity-80 motion-safe:active:scale-[0.98]',
     };
     const chipButton = tooltipContent ? (
       <Tooltip>
@@ -1075,7 +1079,7 @@ export function EntityChip({
 
   if (href) {
     return (
-      <Link href={href} className="inline-flex no-underline transition-opacity hover:opacity-80">
+      <Link href={href} className="inline-flex no-underline transition hover:opacity-80 motion-safe:active:scale-[0.98]">
         {inner}
       </Link>
     );

--- a/apps/web/src/components/chat/reading-panel.test.tsx
+++ b/apps/web/src/components/chat/reading-panel.test.tsx
@@ -87,4 +87,16 @@ describe('ReadingPanel 스택 — story #2888 R5', () => {
     });
     expect(container.firstChild).toBeNull();
   });
+
+  // story #2910(S2f/R3) — 스택 top 전환(push/pop) 시 slide-up+fade가 자연 발화하는 자리
+  // (key로 리마운트되는 그 wrapper)에 motion-safe: 게이팅 클래스가 실려 있는지.
+  it('스택 top 콘텐츠 wrapper에 motion-safe 전환 클래스가 실려 있다(reduce-motion 자동 제거)', async () => {
+    await act(async () => {
+      root.render(<ReadingPanel stack={[A]} onNavigateTo={() => {}} onClose={() => {}} />);
+    });
+    const wrapper = container.querySelector('.motion-safe\\:animate-in');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).toContain('motion-safe:slide-in-from-bottom-2');
+    expect(wrapper?.className).toContain('motion-safe:fade-in');
+  });
 });

--- a/apps/web/src/components/chat/reading-panel.tsx
+++ b/apps/web/src/components/chat/reading-panel.tsx
@@ -115,14 +115,16 @@ export function ReadingPanel({
           </button>
         </div>
       )}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {/* 스택 top이 바뀔 때마다(어느 방향이든) 확실히 리마운트 — 대상 정체성 자체를 key로
-            (stack.length만으론 pop→다른 대상 push가 같은 길이일 때 리마운트가 안 됨). */}
-        <ReadingPanelContent
-          key={top.kind === 'entity' ? `entity:${top.entityType}:${top.entityId}` : `attachment:${top.assetId ?? top.storedUrl ?? top.label}`}
-          target={top}
-          onClose={popOne}
-        />
+      <div
+        // story #2910(S2f/R3) — 스택 top이 바뀔 때마다(어느 방향이든) 확실히 리마운트 — 대상
+        // 정체성 자체를 key로(stack.length만으론 pop→다른 대상 push가 같은 길이일 때 리마운트가
+        // 안 됨). 리마운트가 slide-up+fade를 push/pop 매번 자연 재발화시킨다(exit 애니는 의도적
+        // 무 — PO 판정 2026-08-21: 즉시 사라짐=반응성 피드백, isClosing 지연-unmount는 스택
+        // 동역학 테스트 부채(#2904) 자리에 회귀 반경만 키움).
+        key={top.kind === 'entity' ? `entity:${top.entityType}:${top.entityId}` : `attachment:${top.assetId ?? top.storedUrl ?? top.label}`}
+        className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 flex min-h-0 flex-1 flex-col overflow-hidden duration-150"
+      >
+        <ReadingPanelContent target={top} onClose={popOne} />
       </div>
     </div>
   );


### PR DESCRIPTION
## 요약
story #2910 — S2 스펙 §6(R3) 승계. 신 dep 0(tw-animate-css 기존 설치·motion-safe: 게이팅 관례 재사용).

## 변경
- `chat-view.tsx`: ReadingPanel·ThreadPanel wrapper에 각각 `motion-safe:slide-in-from-right`(1회만 — wrapper 자체는 push/pop·스레드 전환마다 리마운트 안 됨, 자연 분리).
- `reading-panel.tsx`: 스택 top 콘텐츠 wrapper(기존 key로 push/pop마다 리마운트)에 `motion-safe:slide-in-from-bottom-2` — 매 전환 자연 재발화.
- `embed-card.tsx`: 클릭 가능 지점 4곳(EmbedCard 버튼 2·EntityChip 트리거·Link)에 `motion-safe:active:scale-[0.98]`.

## PO 판정 2건(스토리 본문에 명문화, 착수 전 확定)
- **모핑 vs 순차 = 순차.** shared-element 모핑은 §6 "장식 금지·의미만" 위반 소지 — press 즉각 반응→패널 slide-in 순차 배치로 최소 비용 전달.
- **exit(패널 닫기) = 의도적 무애니.** 즉시 사라짐이 곧 반응성 피드백(진입=주의 유도라 애니 가치·퇴장=의도 완료라 즉시가 정당). `isClosing` 지연-unmount는 스택 동역학 테스트 부채(#2904) 자리에 회귀 반경만 키워 채택 안 함 — 나중에 유나 design이 exit 가치를 재판정하면 별도 커밋으로 열어둠.

## 셀프 게이트
- ✅ `tsc --noEmit` 클린
- ✅ `pnpm lint` 0 errors
- ✅ `vitest run src/components/chat/` 39 files·394 tests 전부 그린(+ reading-panel.test.tsx 신규 1건)
- ✅ 대비가드 5종 전부 클린(신규 위반 0)
- ✅ `pnpm build` EXIT 0

## 남은 것
AC6(prefers-reduced-motion 브라우저 emulation 실측)은 dev 배포 후 라이브 확認.