### PR TITLE
[SID:2911] S2e① FE — 스레드 답글 좌측 rail(R4 위계 시각화)

### DIFF
--- a/apps/web/src/components/chat/thread-panel.test.tsx
+++ b/apps/web/src/components/chat/thread-panel.test.tsx
@@ -128,3 +128,35 @@ describe('ThreadPanel — 스레드 답글 전용 참조가 실제로 배치조�
     expect(container.textContent).not.toContain('아직 모름');
   });
 });
+
+// story #2911(S2e①/R4) — 좌측 rail(원 메시지→답글 잇는 시각선) 회귀가드.
+describe('ThreadPanel — story #2911 좌측 rail(R4 위계 시각화)', () => {
+  it('원본 메시지 블록과 답글 목록 wrapper 둘 다 border-l-2(같은 rail 토큰)를 갖는다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/messages?thread_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [
+              { id: 'reply-1', created_by: 'agent-2', sender: { id: 'agent-2', name: '유나', type: 'agent' }, content: '답글 1', created_at: '2026-08-08T00:01:00.000Z' },
+              { id: 'reply-2', created_by: 'agent-2', sender: { id: 'agent-2', name: '유나', type: 'agent' }, content: '답글 2(같은 발신자 — 그룹핑)', created_at: '2026-08-08T00:02:00.000Z' },
+            ],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+
+    await act(async () => {
+      root.render(wrap(<Harness />));
+    });
+    await flush();
+
+    const railed = container.querySelectorAll('.border-l-2.border-border');
+    // 원본 메시지 블록 1 + 답글 목록 wrapper 1 = 최소 2곳(개별 ChatBubble마다 따로 안 생김 —
+    // AC3: 그룹핑된 답글이 rail을 분절시키지 않는다는 것 자체가 "wrapper 하나"라는 뜻).
+    expect(railed.length).toBeGreaterThanOrEqual(2);
+    expect(container.textContent).toContain('답글 1');
+    expect(container.textContent).toContain('답글 2(같은 발신자 — 그룹핑)');
+  });
+});

--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -149,8 +149,11 @@ export function ThreadPanel({
         </button>
       </div>
 
-      {/* AC9: 원본 메시지 */}
-      <div className="flex-shrink-0 border-b border-border/60 bg-muted/30 px-4 py-3">
+      {/* AC9: 원본 메시지. story #2911(S2e①/R4) — 좌측 rail(border-l-2)이 이 블록에서
+          시작해 아래 답글 목록까지 같은 x-오프셋(pl-3)으로 끊김 없이 이어진다(스펙 §5 "원
+          메시지 pin + 좌측 라인" — 답글이 원 메시지에서 뻗어나온 것처럼). 기존 border-border
+          토큰 재사용(신규 색 0). */}
+      <div className="flex-shrink-0 border-b border-l-2 border-border bg-muted/30 py-3 pl-3 pr-4">
         <p className="mb-1 text-[10px] font-medium text-muted-foreground">원본 메시지</p>
         <ChatBubble
           message={parentMessage}
@@ -163,13 +166,17 @@ export function ThreadPanel({
       </div>
 
       {/* Thread messages */}
-      <div className="flex-1 overflow-y-auto px-4 py-3">
+      <div className="flex-1 overflow-y-auto py-3 pr-4">
         {loading ? (
           <p className="text-center text-sm text-muted-foreground">불러오는 중…</p>
         ) : messages.length === 0 ? (
           <p className="text-center text-sm text-muted-foreground">아직 답글이 없습니다.</p>
         ) : (
-          <div className="flex flex-col gap-2">
+          // story #2911 — rail은 목록 전체를 감싸는 이 wrapper 하나(border-l-2, 원본 메시지
+          // 블록과 동일 x-오프셋 — 둘 다 컨테이너 왼쪽 끝에서 시작)뿐이라 개별 ChatBubble
+          // 그룹핑(isGrouped)과 무관하게 끊기지 않는다(AC3 — 한 줄로 쭉 이어지고, 그 안의
+          // 버블 간격만 gap-2로 나뉜다).
+          <div className="flex flex-col gap-2 border-l-2 border-border pl-3">
             {messages.map((msg, idx) => {
               const prev = messages[idx - 1];
               const isGrouped = Boolean(prev && prev.created_by === msg.created_by);

--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -165,8 +165,11 @@ export function ThreadPanel({
         />
       </div>
 
-      {/* Thread messages */}
-      <div className="flex-1 overflow-y-auto py-3 pr-4">
+      {/* Thread messages — 유나양 design 반려 fix(2026-08-21, 로컬 렌더 실측): 이전
+          `py-3`의 top 12px가 pin 블록 rail-bottom과 답글 rail-top 사이를 세로로 끊었다
+          (「코드 연속≠픽셀 연속」). pt-0으로 상단 패딩 제거해 flush — border-b는 구분자로
+          그대로 유지. */}
+      <div className="flex-1 overflow-y-auto pt-0 pb-3 pr-4">
         {loading ? (
           <p className="text-center text-sm text-muted-foreground">불러오는 중…</p>
         ) : messages.length === 0 ? (


### PR DESCRIPTION
## 요약
story #2911 — S2 스펙 §5(R4) 승계, 시안 불요 갈래①(페드루 착수 신호, 2026-08-21). 스레드 답글이 원 메시지에서 뻗어나온 것처럼 좌측 rail로 시각적으로 이어지게.

## 변경
- `thread-panel.tsx`: "원본 메시지" pin 블록과 답글 목록 wrapper에 각각 `border-l-2 border-border`(같은 x-오프셋, 컨테이너 왼쪽 끝에서 시작) — 끊김 없이 이어지는 rail.
- rail은 답글 목록 전체를 감싸는 단일 wrapper 하나뿐이라 그룹핑(isGrouped)된 연속 답글끼리도 분절되지 않는다(AC3).
- 기존 `border-border` 토큰 재사용 — 신규 색 0.

## 스코프 밖
갈래②(데스크톱 스레드 진입 표시 텍스트 + ReadingPanel과 칩 브레드크럼 문법 통일)는 유나 design 시안 대기 — 이 스토리 범위 아님(페드루가 별도로 유나에게 격차 목록 전달 예정).

## 셀프 게이트
- ✅ `tsc --noEmit` 클린
- ✅ `pnpm lint` 0 errors
- ✅ `vitest run thread-panel.test.tsx` 2 tests 전부 그린(신규 1건)
- ✅ 대비가드 5종 전부 클린(신규 위반 0)
- ✅ `pnpm build` EXIT 0

## 남은 것
AC5(라이브 픽셀, 모바일/데스크톱) — dev 배포 후 확認.