### PR TITLE
[SID:2904] ReadingPanel 스택 동역학 단위 테스트 보강(뮤테이션 무감지 3건 처방)

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -11,6 +11,7 @@ import { ReferenceDropNotice, parseDroppedReferences, type DroppedReference } fr
 import { ChatInput, type CommandTarget } from './chat-input';
 import { ThreadPanel } from './thread-panel';
 import { ReadingPanel, type ReadingPanelTarget } from './reading-panel';
+import { useReadingPanelStack } from './use-reading-panel-stack';
 import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeToMessage, useChatSse, type SseWorkingPayload } from '@/hooks/use-chat-sse';
@@ -132,22 +133,22 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   // story #2766(레인 A) — ReadingPanel도 우측 패널이라 스레드와 동일 슬롯을 공유한다(동시
   // 2패널 레이아웃은 인계 doc에 없는 새 영역이라 짓지 않음 — 열면 서로 배타적으로 닫는다).
   // story #2888/S2 R5 — 단일 target에서 스택(배열)으로. 빈 배열=닫힘(기존 null과 동형).
-  // 최대 깊이 3(유나군 목업 s2d-sidepane-stack-mockup 확定) — push 시 최하단부터 pop.
-  const [readingPanelStack, setReadingPanelStack] = useState<ReadingPanelTarget[]>([]);
-  // activeThreadRef와 동일 이유(popstate stale closure 방지) — 모바일 뒤로가기 제스처가
-  // ThreadPanel과 똑같이 이 패널도 먼저 닫아야 한다(페이지 이탈 아님).
-  const activeReadingPanelRef = useRef(false);
-  const READING_PANEL_MAX_DEPTH = 3;
+  // story #2904 — 스택 오케스트레이션(최대 깊이 truncation·history 1회 정책)은
+  // use-reading-panel-stack.ts로 추출(단위 테스트 가능). 이 컴포넌트는 스레드 패널과의
+  // 상호배타(activeThread 클리어)만 감싸서 얹는다.
+  // 훅이 반환하는 객체 자체는 매 렌더 새 참조라 그대로 deps에 넣으면 콜백 메모이제이션이
+  // 무의미해진다(exhaustive-deps도 "readingPanel 전체"를 요구해 그 무의미함을 강제) — 여기서
+  // 바로 구조분해해 안정 참조(각 함수는 훅 내부 useCallback([])로 고정)만 아래에서 쓴다.
+  const { stack: readingPanelStack, isOpenRef: activeReadingPanelRef, open: openReadingPanelStack, close: closeReadingPanelStack, navigateTo: navigateReadingPanelTo } = useReadingPanelStack();
 
   // 스레드 열기: 현재 URL 유지한 채 history entry 추가
   const openThread = useCallback((message: ChatMessage) => {
-    activeReadingPanelRef.current = false;
-    setReadingPanelStack([]);
+    closeReadingPanelStack();
     setActiveThread(message);
     activeThreadRef.current = true;
     const url = window.location.pathname + window.location.search;
     window.history.pushState({ _sprintableThread: true }, '', url);
-  }, []);
+  }, [closeReadingPanelStack]);
 
   // 스레드 닫기: history.back() 제거 — Next.js router와 충돌 방지 (P0 리그레션 원인)
   const closeThread = useCallback(() => {
@@ -156,29 +157,15 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   }, []);
 
   // story #2888/S2 R5 — 패널이 이미 열려 있으면(스택 비어있지 않음) push(임베드 안에서 또
-  // 임베드), 닫혀 있었으면 새 1단 스택으로 시작. 열릴 때만 history entry를 추가한다(push는
-  // 같은 "패널 열림" 상태 안의 전환이라 뒤로가기 제스처가 매 push마다 쌓이지 않게).
+  // 임베드), 닫혀 있었으면 새 1단 스택으로 시작(정확한 truncation·history 정책은
+  // use-reading-panel-stack.ts#open 참고).
   const openReadingPanel = useCallback((target: ReadingPanelTarget) => {
     activeThreadRef.current = false;
     setActiveThread(null);
-    const wasClosed = !activeReadingPanelRef.current;
-    activeReadingPanelRef.current = true;
-    setReadingPanelStack((prev) => [...prev, target].slice(-READING_PANEL_MAX_DEPTH));
-    if (wasClosed) {
-      const url = window.location.pathname + window.location.search;
-      window.history.pushState({ _sprintableReadingPanel: true }, '', url);
-    }
-  }, []);
+    openReadingPanelStack(target);
+  }, [openReadingPanelStack]);
 
-  // 브레드크럼 세그먼트 클릭 — 그 인덱스까지 pop(그 항목이 새 최상단).
-  const navigateReadingPanelTo = useCallback((index: number) => {
-    setReadingPanelStack((prev) => prev.slice(0, index + 1));
-  }, []);
-
-  const closeReadingPanel = useCallback(() => {
-    activeReadingPanelRef.current = false;
-    setReadingPanelStack([]);
-  }, []);
+  const closeReadingPanel = closeReadingPanelStack;
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
@@ -386,13 +373,12 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
       // 패널 닫기 + 현재 URL 재push → 실제 뒤로가기 취소, 채팅 화면 유지
       activeThreadRef.current = false;
       setActiveThread(null);
-      activeReadingPanelRef.current = false;
-      setReadingPanelStack([]);
+      closeReadingPanelStack();
       window.history.pushState(e.state ?? null, '', window.location.pathname + window.location.search);
     };
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
-  }, []);
+  }, [closeReadingPanelStack, activeReadingPanelRef]);
 
   // CB-S8: 모바일 pull-to-refresh — 스크롤 최상단에서 아래로 당기면 새로고침
   // fix(story #1987): React onTouch* prop은 루트에 passive로 위임돼 있어(React 17+) preventDefault()가

--- a/apps/web/src/components/chat/reading-panel.test.tsx
+++ b/apps/web/src/components/chat/reading-panel.test.tsx
@@ -88,3 +88,34 @@ describe('ReadingPanel 스택 — story #2888 R5', () => {
     expect(container.firstChild).toBeNull();
   });
 });
+
+// story #2904 — 카디르+codex #3303 QA 확定: popOne(최상단 콘텐츠 자기 X)의 "pop-vs-close"
+// 분기가 뮤테이션 무감지였다(정적 렌더 테스트만 있고 이 클릭 자체를 아무 테스트도 안 눌렀음).
+// EntityPreviewModal(embedded) 헤더의 실 닫기 버튼(aria-label="닫기")을 직접 클릭해 왕복 검증.
+describe('ReadingPanel — story #2904 동역학 ③ popOne(최상단 자기 X) pop-vs-close', () => {
+  it('스택 2단 이상 — 콘텐츠 자기 닫기는 onClose가 아니라 onNavigateTo(length-2)를 호출한다', async () => {
+    const onNavigateTo = vi.fn();
+    const onClose = vi.fn();
+    await act(async () => {
+      root.render(<ReadingPanel stack={[A, B, C]} onNavigateTo={onNavigateTo} onClose={onClose} />);
+    });
+    const contentCloseBtn = container.querySelector('[aria-label="닫기"]') as HTMLButtonElement;
+    expect(contentCloseBtn).not.toBeNull();
+    await act(async () => { contentCloseBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onNavigateTo).toHaveBeenCalledWith(1); // stack.length(3) - 2
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('스택 1단뿐 — 콘텐츠 자기 닫기는 onNavigateTo가 아니라 onClose를 호출한다(전체 닫기와 동형)', async () => {
+    const onNavigateTo = vi.fn();
+    const onClose = vi.fn();
+    await act(async () => {
+      root.render(<ReadingPanel stack={[A]} onNavigateTo={onNavigateTo} onClose={onClose} />);
+    });
+    const contentCloseBtn = container.querySelector('[aria-label="닫기"]') as HTMLButtonElement;
+    expect(contentCloseBtn).not.toBeNull();
+    await act(async () => { contentCloseBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onNavigateTo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/chat/use-reading-panel-stack.test.tsx
+++ b/apps/web/src/components/chat/use-reading-panel-stack.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+//
+// story #2904 — ReadingPanel 스택 «동역학» 단위 테스트(카디르+codex #3303 QA 확定: 정적
+// 렌더 테스트뿐이라 뮤테이션 무감지였던 핵심 2건). 무거운 ChatView 전체 마운트 없이,
+// 추출된 훅(use-reading-panel-stack.ts)을 작은 harness로 직접 잰다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useReadingPanelStack, READING_PANEL_MAX_DEPTH } from './use-reading-panel-stack';
+import type { ReadingPanelTarget } from './reading-panel';
+
+let container: HTMLDivElement;
+let root: Root;
+let latestApi: ReturnType<typeof useReadingPanelStack> | null = null;
+
+// react-hooks/globals — 렌더 중 모듈 스코프 변수 재할당은 side-effect라 금지된다. useEffect
+// 안(렌더 뒤)에서 넘겨받는 건 정당한 side-effect 위치 — thread-panel.test.tsx의 Harness류
+// (state 소유 하니스) 패턴과 동형으로, 여기는 훅의 반환 API 자체를 밖으로 노출하는 변형.
+function Harness() {
+  const api = useReadingPanelStack();
+  useEffect(() => { latestApi = api; });
+  return (
+    <ul>
+      {api.stack.map((t) => (
+        <li key={t.kind === 'entity' ? t.entityId : t.label}>{t.kind === 'entity' ? t.title : t.label}</li>
+      ))}
+    </ul>
+  );
+}
+
+function entity(id: string, title: string): ReadingPanelTarget {
+  return { kind: 'entity', entityType: 'story', entityId: id, title, status: null, href: null };
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  latestApi = null;
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe('useReadingPanelStack — story #2904 동역학 ①깊이 truncation', () => {
+  it('4연속 push(A,B,C,D) — 최대 깊이(3) 초과분이 최하단(A)부터 밀려 [B,C,D]만 남는다', async () => {
+    await act(async () => { root.render(<Harness />); });
+    const [A, B, C, D] = [entity('a', 'A'), entity('b', 'B'), entity('c', 'C'), entity('d', 'D')];
+    await act(async () => {
+      latestApi!.open(A);
+      latestApi!.open(B);
+      latestApi!.open(C);
+      latestApi!.open(D);
+    });
+    expect(latestApi!.stack).toHaveLength(READING_PANEL_MAX_DEPTH);
+    expect(latestApi!.stack.map((t) => (t.kind === 'entity' ? t.title : null))).toEqual(['B', 'C', 'D']);
+  });
+});
+
+describe('useReadingPanelStack — story #2904 동역학 ②history entry "닫힘→열림 1회" 정책', () => {
+  it('닫힌 상태에서 첫 open은 pushState를 1회 호출한다', async () => {
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    await act(async () => { root.render(<Harness />); });
+    await act(async () => { latestApi!.open(entity('a', 'A')); });
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+    expect(pushStateSpy).toHaveBeenCalledWith({ _sprintableReadingPanel: true }, '', expect.any(String));
+  });
+
+  it('열려있는 상태에서 연속 push(3회 더)는 pushState를 추가로 호출하지 않는다', async () => {
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    await act(async () => { root.render(<Harness />); });
+    await act(async () => { latestApi!.open(entity('a', 'A')); }); // 1회(닫힘→열림)
+    pushStateSpy.mockClear();
+    await act(async () => {
+      latestApi!.open(entity('b', 'B'));
+      latestApi!.open(entity('c', 'C'));
+      latestApi!.open(entity('d', 'D'));
+    });
+    expect(pushStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('close() 후 다시 open하면(재-닫힘→열림) pushState가 다시 1회 호출된다', async () => {
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    await act(async () => { root.render(<Harness />); });
+    await act(async () => { latestApi!.open(entity('a', 'A')); });
+    await act(async () => { latestApi!.close(); });
+    pushStateSpy.mockClear();
+    await act(async () => { latestApi!.open(entity('b', 'B')); });
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/chat/use-reading-panel-stack.ts
+++ b/apps/web/src/components/chat/use-reading-panel-stack.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import type { ReadingPanelTarget } from './reading-panel';
+
+export const READING_PANEL_MAX_DEPTH = 3;
+
+export interface ReadingPanelStackApi {
+  stack: ReadingPanelTarget[];
+  /** activeThreadRef와 동일 이유(popstate stale closure 방지) — 모바일 뒤로가기 제스처가
+   * 이 패널을 먼저 닫아야 하는지(페이지 이탈 아님) 판정하는 데 쓰인다. */
+  isOpenRef: React.RefObject<boolean>;
+  open: (target: ReadingPanelTarget) => void;
+  close: () => void;
+  navigateTo: (index: number) => void;
+}
+
+/**
+ * story #2888(S2 R5)·#2898(S2d-FE)·#2904(동역학 테스트 보강) — ReadingPanel 스택 상태+전환
+ * 로직을 chat-view.tsx 밖으로 뽑아 무거운 ChatView 전체 마운트 없이 단위 테스트 가능하게 한다.
+ * 카디르+codex가 #3303 QA에서 지목한 뮤테이션 무감지 3지점 중 ①②가 이 훅 안에 있다(③=
+ * popOne의 pop-vs-close 분기는 reading-panel.tsx 자체 로직이라 reading-panel.test.tsx가 잰다):
+ *
+ * ①**최대 깊이 truncation** — push 시 `slice(-READING_PANEL_MAX_DEPTH)`로 초과분을
+ *   최하단부터 민다(유나군 목업 s2d-sidepane-stack-mockup 확定, 최대 3).
+ * ②**history entry "닫힘→열림 1회" 정책** — `isOpenRef`가 이미 열려있으면(스택 비어있지
+ *   않음) push만 하고 history는 안 건드린다. 닫힌 상태에서 열릴 때만 `pushState` 1회
+ *   (뒤로가기 제스처가 매 push마다 쌓이지 않게).
+ *
+ * chat-view.tsx는 이 훅의 `open`/`close`를 그대로 안 쓰고 자기 wrapper(`openReadingPanel`/
+ * `closeReadingPanel`)로 감싼다 — 스레드 패널과의 상호배타(activeThread 클리어)는 이 훅의
+ * 관심사 밖(패널간 조율은 호출부 몫)이라 그대로 chat-view.tsx에 남는다.
+ */
+export function useReadingPanelStack(): ReadingPanelStackApi {
+  const [stack, setStack] = useState<ReadingPanelTarget[]>([]);
+  const isOpenRef = useRef(false);
+
+  const open = useCallback((target: ReadingPanelTarget) => {
+    const wasClosed = !isOpenRef.current;
+    isOpenRef.current = true;
+    setStack((prev) => [...prev, target].slice(-READING_PANEL_MAX_DEPTH));
+    if (wasClosed) {
+      const url = window.location.pathname + window.location.search;
+      window.history.pushState({ _sprintableReadingPanel: true }, '', url);
+    }
+  }, []);
+
+  const close = useCallback(() => {
+    isOpenRef.current = false;
+    setStack([]);
+  }, []);
+
+  const navigateTo = useCallback((index: number) => {
+    setStack((prev) => prev.slice(0, index + 1));
+  }, []);
+
+  return { stack, isOpenRef, open, close, navigateTo };
+}


### PR DESCRIPTION
## 요약
story #2904 — 카디르+codex #3303 QA 확定: 스택 «동역학» 핵심 3건(최대 깊이 truncation·history 1회 정책·pop-vs-close)이 정적 렌더 테스트뿐이라 뮤테이션 무감지였다. 처방 그대로 chat-view 레벨 동적 테스트 3건 추가.

## 변경
- `use-reading-panel-stack.ts`(신규): chat-view.tsx의 스택 오케스트레이션(최대 깊이 truncation·history "닫힘→열림 1회" 정책)을 순수 훅으로 추출 — 무거운 ChatView 전체 마운트 없이 단위 테스트 가능. chat-view.tsx는 구조분해한 안정 참조만 쓰고, 스레드 패널과의 상호배타는 그대로 자기 몫으로 유지(회귀 0 — 외부 인터페이스인 `readingPanelStack`/`openReadingPanel`/`closeReadingPanel`/`navigateReadingPanelTo` 이름·동작 무변경).
- `use-reading-panel-stack.test.tsx`(신규 4건): ①4연속 push→[B,C,D] truncation ②닫힘→열림 1회만 pushState(연속 push·재-열림 케이스 포함).
- `reading-panel.test.tsx`(+2건): ③popOne pop-vs-close — 스택 2단↑은 onNavigateTo, 1단은 onClose(EntityPreviewModal 실 닫기 버튼 클릭으로 왕복 검증).

## 판별(스토리 처방 그대로)
3개 뮤테이션(slice 제거·wasClosed 가드 제거·popOne 로직 반전) 각각이 정확히 대응 테스트만 fail — 수동 확認 완료.

## 셀프 게이트
- ✅ `tsc --noEmit` 클린
- ✅ `pnpm lint` 0 errors, 0 warnings(chat-view.tsx 관련 신규 경고 0 — exhaustive-deps 전부 해소)
- ✅ `vitest run src/components/chat/` 40 files·400 tests 전부 그린(신규 6건)
- ✅ 대비가드 5종 전부 클린
- ✅ `pnpm build` EXIT 0