### PR TITLE
[SID:2907] 결제 실패 dunning — grace 7일·매일 재시도·owner 메일·free 전이

### DIFF
--- a/backend/alembic/versions/0269_platform_settings_dunning_grace_days.py
+++ b/backend/alembic/versions/0269_platform_settings_dunning_grace_days.py
@@ -1,0 +1,33 @@
+"""story #2907(선생님 확定 2026-08-21) — platform_settings.dunning_grace_days.
+
+grace 기간(재시도 일수)을 하드코딩하지 않는다(AC6 — 문안·금액·기간 등 가변값은 어드민
+관리 원칙). 기본값 7(선생님 확定 cadence)로 시드 — billing_scheduler.py가 이 값으로
+재시도 창(D+1..D+grace_days)과 downgrade 트리거일(D+grace_days+1)을 파생한다."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0269"
+down_revision = "0268"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column("dunning_grace_days", sa.Integer(), nullable=False, server_default="7"),
+    )
+    op.create_check_constraint(
+        "ck_platform_settings_dunning_grace_days_positive",
+        "platform_settings",
+        "dunning_grace_days > 0",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_platform_settings_dunning_grace_days_positive", "platform_settings", type_="check",
+    )
+    op.drop_column("platform_settings", "dunning_grace_days")

--- a/backend/alembic/versions/0270_platform_settings_dunning_grace_days.py
+++ b/backend/alembic/versions/0270_platform_settings_dunning_grace_days.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "0269"
-down_revision = "0268"
+revision = "0270"
+down_revision = "0269"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/models/platform_setting.py
+++ b/backend/app/models/platform_setting.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Text, text
+from sqlalchemy import Boolean, DateTime, Integer, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -38,3 +38,7 @@ class PlatformSetting(Base, TimestampMixin):
         Boolean, nullable=False, server_default=text("false")
     )
     updated_by: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #2907(선생님 확定 2026-08-21) — dunning grace 기간(일). 재시도 창=D+1..
+    # D+dunning_grace_days, downgrade 트리거일=D+dunning_grace_days+1. 하드코딩 금지
+    # 원칙(AC6)에 따라 어드민 관리값으로 — 기본 7일(마이그 0269 시드).
+    dunning_grace_days: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("7"))

--- a/backend/app/models/platform_setting.py
+++ b/backend/app/models/platform_setting.py
@@ -40,5 +40,5 @@ class PlatformSetting(Base, TimestampMixin):
     updated_by: Mapped[str | None] = mapped_column(Text, nullable=True)
     # story #2907(선생님 확定 2026-08-21) — dunning grace 기간(일). 재시도 창=D+1..
     # D+dunning_grace_days, downgrade 트리거일=D+dunning_grace_days+1. 하드코딩 금지
-    # 원칙(AC6)에 따라 어드민 관리값으로 — 기본 7일(마이그 0269 시드).
+    # 원칙(AC6)에 따라 어드민 관리값으로 — 기본 7일(마이그 0270 시드).
     dunning_grace_days: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("7"))

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -955,9 +955,10 @@ async def db_connection_stats(
 
 
 # ─── GET /api/v2/internal/cron/toss-billing-maintenance ───────────────────────
-# 결제②-C3(story #2494): dunning 재시도(pricing-policy-proposal-v1 §12.1) + pending
-# 대사(reconciliation). "신규 결제 주기 도래" 트리거는 스코프 밖(story #2502 대기) —
-# billing_scheduler.trigger_due_charges()가 그 자리를 NotImplementedError로 명시해둔다.
+# 결제②-C3(story #2494): dunning 재시도(story #2907 daily cadence) + pending 대사
+# (reconciliation). "신규 결제 주기 도래" 트리거(trigger_due_charges)는 story #2502
+# (완료, 2026-08-21 이전)가 전제를 채운 뒤 #2907이 실제로 채웠다 — dunning의 진입점
+# (여기서 실패해야 sweep_dunning_retries가 이어받는다)이라 dunning보다 먼저 돈다.
 @router.get("/toss-billing-maintenance")
 async def toss_billing_maintenance(
     request: Request,
@@ -969,9 +970,11 @@ async def toss_billing_maintenance(
             sweep_dunning_retries,
             sweep_expired_grants,
             sweep_stale_pending_orders,
+            trigger_due_charges,
         )
         from app.services.org_subscription_downgrade import sweep_pending_tier_downgrades
 
+        renewal_result = await trigger_due_charges(session)
         dunning_result = await sweep_dunning_retries(session)
         reconciliation_result = await sweep_stale_pending_orders(session)
         # story #2777 PR2 — 어드민 credit_grant의 자가회수. 신규 cron 잡 발명 대신 이
@@ -982,8 +985,9 @@ async def toss_billing_maintenance(
         # 대기) — 코드는 완결이지만 라이브 집행은 그 잡 착지 後(PR 본문 참고).
         downgrade_sweep_result = await sweep_pending_tier_downgrades(session)
         return _ok({
-            "dunning": dunning_result, "reconciliation": reconciliation_result,
-            "grant_sweep": grant_sweep_result, "downgrade_sweep": downgrade_sweep_result,
+            "renewal": renewal_result, "dunning": dunning_result,
+            "reconciliation": reconciliation_result, "grant_sweep": grant_sweep_result,
+            "downgrade_sweep": downgrade_sweep_result,
         })
     except Exception as exc:
         logger.exception("toss-billing-maintenance cron error: %s", exc)

--- a/backend/app/services/billing_scheduler.py
+++ b/backend/app/services/billing_scheduler.py
@@ -30,40 +30,112 @@ from app.models.billing_order import BillingOrder
 from app.models.offering_version import OfferingVersion
 from app.models.org_billing_key import OrgBillingKey
 from app.models.org_subscription import OrgSubscription
+from app.models.project import OrgMember
+from app.models.user import User
 from app.services.billing_charge import (
     _confirm_with_ledger,
     _mark_failed_if_not_confirmed,
     charge_org,
 )
+from app.services.billing_charge_amount import ChargeAmountError, compute_charge_amount
+from app.services.billing_period import compute_period_end
+from app.services.email import send_email
 from app.services.org_subscription_checkout import STALE_CLAIM_WINDOW
 from app.services.payment.toss_adapter import TossAdapter
+from app.services.platform_settings import get_platform_settings
 
 logger = logging.getLogger(__name__)
 
-# pricing-policy-proposal-v1 §12.1(2026-08-07 재확認) — 지어내지 않음, 문서 원문 그대로.
-_DUNNING_RETRY_DAYS = frozenset({1, 3, 5})
-_DUNNING_DOWNGRADE_DAY = 8
+# pricing-policy-proposal-v1 §12.1(2026-08-07 재확認)이 원 근거였으나, story #2907
+# (선생님 확定 2026-08-21)이 cadence를 daily로 대체했다 — 3회(1/3/5일)가 아니라
+# D+1..D+grace_days 매일 1회, downgrade는 D+grace_days+1. grace_days는 이제
+# platform_settings.dunning_grace_days(어드민 관리값, AC6)에서 온다 — 이 상수들은
+# grace_days를 안 넘겨주는 극소수 호출부를 위한 기본값(7)일 뿐, 실 판단은 아래
+# next_dunning_action의 grace_days 파라미터로 한다.
+_DEFAULT_DUNNING_GRACE_DAYS = 7
 
 # Toss charge는 최대 60초(공식 문서) — 그보다 넉넉히 오래 pending이면 크래시/타임아웃으로
 # 간주해 대사 대상.
 PENDING_STALE_AFTER = timedelta(minutes=5)
 
 
-def next_dunning_action(order: BillingOrder, *, now: datetime) -> str:
+def next_dunning_action(
+    order: BillingOrder, *, now: datetime, grace_days: int = _DEFAULT_DUNNING_GRACE_DAYS,
+) -> str:
     """failed order 하나에 대해 지금 뭘 해야 하는지 — 순수 함수(DB/네트워크 접촉 없음).
     "wait" | "retry" | "downgrade_to_free" 중 하나.
+
+    story #2907 cadence(선생님 확定) — 재시도 창은 D+1..D+grace_days **매일** 1회
+    (구 {1,3,5}일 3회 정책을 대체), downgrade는 D+grace_days+1.
 
     같은 날 중복 재시도 방지: `updated_at`이 오늘 이미 갱신됐으면(=오늘 이미 시도함) 또
     재시도하지 않는다 — cron이 하루에 여러 번 돌아도(예: */10분) 하루 1회만 재결제한다."""
     if order.status != "failed":
         return "wait"
     age_days = (now.date() - order.created_at.date()).days
-    if age_days >= _DUNNING_DOWNGRADE_DAY:
+    if age_days >= grace_days + 1:
         return "downgrade_to_free"
     already_attempted_today = order.updated_at.date() >= now.date()
-    if age_days in _DUNNING_RETRY_DAYS and not already_attempted_today:
+    if 1 <= age_days <= grace_days and not already_attempted_today:
         return "retry"
     return "wait"
+
+
+# 갱신 charge order_id 접두사 — 이 접두사로만 "이 실패 order가 갱신(정기결제) 실패인지"를
+# 판별한다. checkout/tier_change의 실패 order도 같은 billing_orders.status='failed' 값을
+# 쓰지만(purpose 컬럼도 둘 다 'charge'라 구분 안 됨 — 확認: entry_type을 명시하는 호출부는
+# billing_pack.py뿐) org_subscriptions.status를 'past_due'로 전이시키는 건 갱신 실패
+# 뿐이어야 한다(checkout 실패=아직 active 아니었던 org, tier_change 실패=원 tier 그대로
+# 유지된 org — 둘 다 "이미 활성 유료였다가 갱신을 놓친" past_due 의미가 아니다).
+_RENEWAL_ORDER_PREFIX = "renewal:"
+
+
+def _renewal_order_id(org_id: uuid.UUID, offering_version_id: uuid.UUID, period_end: datetime) -> str:
+    """org+offering+«원래 결제 도래일»로 결정적 키잉 — 같은 갱신 시도는 재시도 내내
+    (D+1..D+grace_days) 항상 같은 order_id를 가리킨다(charge_org의 failed→pending CAS
+    재청구 경로가 그대로 이 재시도를 태운다, 재구현 0)."""
+    return f"{_RENEWAL_ORDER_PREFIX}{org_id}:{offering_version_id}:{period_end.date()}"
+
+
+def _dunning_email_content(*, tier: str, grace_expires_at) -> tuple[str, str]:
+    """story #2907 AC3 — 매 실패마다 발송할 문안. 「언제(grace 만료일)」·「어떻게(free
+    전이+신규 업로드만 차단·데이터 삭제 없음)」를 명시. tone=nice(선생님 지시) — 고객
+    대면 문구라 개야갤 톤 사용 금지."""
+    grace_date_str = grace_expires_at.strftime("%Y-%m-%d")
+    subject = "[Sprintable] 결제가 처리되지 않았습니다 — 확인해 주세요"
+    html_body = (
+        f"<p>안녕하세요, Sprintable입니다.</p>"
+        f"<p>정기결제 시도가 처리되지 않았습니다. 저희 쪽에서 매일 자동으로 재시도하고 "
+        f"있으니, 등록하신 카드 정보를 확인해 주시면 감사하겠습니다.</p>"
+        f"<p><b>{grace_date_str}</b>까지 결제가 완료되지 않으면 조직의 플랜이 자동으로 "
+        f"Free로 전환됩니다. Free로 전환되어도 <b>기존 데이터는 삭제되지 않으며</b>, "
+        f"신규 업로드만 제한됩니다. 이후 결제를 완료하시면 즉시 원래 플랜({tier})으로 "
+        f"복귀합니다.</p>"
+        f"<p>문의사항이 있으시면 언제든 회신해 주세요.</p>"
+    )
+    return subject, html_body
+
+
+async def _notify_dunning_failure(session: AsyncSession, org_id: uuid.UUID, *, tier: str, grace_expires_at) -> None:
+    """실패 통보 메일 — org owner/admin 전원 수신(storage-usage-warn과 동일 조회 패턴,
+    S8). best-effort(개별 흡수) — 메일 실패가 스윕 자체를 막으면 안 된다."""
+    subject, html_body = _dunning_email_content(tier=tier, grace_expires_at=grace_expires_at)
+    emails = [
+        r[0] for r in (await session.execute(
+            select(User.email)
+            .join(OrgMember, User.id == OrgMember.user_id)
+            .where(
+                OrgMember.org_id == org_id,
+                OrgMember.role.in_(["owner", "admin"]),
+                OrgMember.deleted_at.is_(None),
+            )
+        )).all()
+    ]
+    for em in emails:
+        try:
+            send_email(em, subject, html_body)
+        except Exception:
+            logger.warning("dunning failure email 실패 org=%s", org_id, exc_info=True)
 
 
 async def downgrade_to_free(session: AsyncSession, org_id: uuid.UUID, order_id: str) -> None:
@@ -180,15 +252,22 @@ async def downgrade_to_free(session: AsyncSession, org_id: uuid.UUID, order_id: 
 
 
 async def sweep_dunning_retries(session: AsyncSession, *, now: datetime | None = None) -> dict:
-    """failed billing_orders를 스윕 — §12.1 케이던스대로 재시도하거나 Free로 전환."""
+    """failed billing_orders를 스윕 — cadence대로 재시도하거나 Free로 전환.
+
+    story #2907 — `renewal:` 접두사(=trigger_due_charges가 만든 갱신 실패 order)는 재시도
+    결과에 따라 org_subscriptions.status를 'active'⇄'past_due'로 동기화하고 매 실패마다
+    owner 메일을 보낸다(AC1-3). 그 외(checkout/tier_change 실패 order)는 기존 동작 그대로
+    — past_due 전이 대상이 아니다(둘 다 "이미 활성 유료였다가 갱신을 놓친" 상태가 아님)."""
     now = now or datetime.now(timezone.utc)
+    grace_days = (await get_platform_settings(session)).dunning_grace_days
     failed_orders = (
         await session.execute(select(BillingOrder).where(BillingOrder.status == "failed"))
     ).scalars().all()
 
     retried = downgraded = 0
     for order in failed_orders:
-        action = next_dunning_action(order, now=now)
+        action = next_dunning_action(order, now=now, grace_days=grace_days)
+        is_renewal = order.order_id.startswith(_RENEWAL_ORDER_PREFIX)
         if action == "retry":
             try:
                 # charge_org 자체가 이미 claim/멱등/원장 불변식을 다 지킨다(#2493) — 여기서는
@@ -201,11 +280,50 @@ async def sweep_dunning_retries(session: AsyncSession, *, now: datetime | None =
             except Exception:
                 logger.exception("dunning retry failed for order_id=%s", order.order_id)
             retried += 1
+            if is_renewal:
+                await _sync_renewal_retry_outcome(session, order.org_id, order.order_id, grace_days=grace_days, now=now)
         elif action == "downgrade_to_free":
             await downgrade_to_free(session, order.org_id, order.order_id)
             downgraded += 1
 
     return {"failed_orders_seen": len(failed_orders), "retried": retried, "downgraded": downgraded}
+
+
+async def _sync_renewal_retry_outcome(
+    session: AsyncSession, org_id: uuid.UUID, order_id: str, *, grace_days: int, now: datetime,
+) -> None:
+    """갱신 재시도(retry) 시도 直後 — 그 시도가 confirmed로 끝났으면 원 주기 유지한 채
+    active로 복귀·period 롤오버(AC2 "성공 시 원 주기 유지"), 아직 failed면 past_due
+    유지+이번 실패도 통보(AC3 "매 실패마다")."""
+    order = (
+        await session.execute(select(BillingOrder).where(BillingOrder.order_id == order_id))
+    ).scalar_one()
+    sub = (
+        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+    ).scalar_one_or_none()
+    if sub is None:
+        return
+
+    if order.status == "confirmed":
+        # AC2 — 재결제 성공 시 원 주기 유지: sub.current_period_end는 실패 후에도 «원래
+        # 도래했어야 할 날짜» 그대로다(trigger_due_charges가 실패 시 굴리지 않는다) — 그
+        # 값을 새 period_start로 삼아 다음 주기를 계산한다(추가 유예일을 공짜로 주지 않음).
+        old_due = sub.current_period_end
+        new_end = compute_period_end(old_due, sub.billing_cycle)
+        await session.execute(
+            update(OrgSubscription).where(OrgSubscription.org_id == org_id).values(
+                status="active", current_period_start=old_due, current_period_end=new_end,
+            )
+        )
+        await session.commit()
+    else:
+        await session.execute(
+            update(OrgSubscription).where(OrgSubscription.org_id == org_id, OrgSubscription.status != "past_due")
+            .values(status="past_due")
+        )
+        await session.commit()
+        grace_expires_at = order.created_at.date() + timedelta(days=grace_days)
+        await _notify_dunning_failure(session, org_id, tier=sub.tier, grace_expires_at=grace_expires_at)
 
 
 async def sweep_stale_pending_orders(session: AsyncSession, *, now: datetime | None = None) -> dict:
@@ -395,13 +513,74 @@ async def sweep_expired_grants(session: AsyncSession, *, now: datetime | None = 
     }
 
 
-async def trigger_due_charges(session: AsyncSession) -> dict:
-    """오늘 신규 결제 주기가 도래한 org를 찾아 charge_org를 트리거하는 자리 — 이 스토리
-    스코프 밖(PO 확認, 2026-08-07). `org_subscriptions.current_period_start/end`가 Toss
-    구독에 세팅되는 경로 자체가 아직 없다(story #2502가 그 전제를 채운다). #2502 완료
-    후 이 함수를 채운다."""
-    raise NotImplementedError(
-        "trigger_due_charges — blocked on story #2502(Toss 구독 주기 확定). "
-        "org_subscriptions.current_period_start/end가 Toss 경로에 세팅되지 않아 "
-        "\"누가 오늘 청구 대상인지\" 판단할 데이터 소스가 없다."
-    )
+async def trigger_due_charges(session: AsyncSession, *, now: datetime | None = None) -> dict:
+    """오늘 신규 결제 주기가 도래한 org를 찾아 갱신 청구를 트리거한다 — story #2502가
+    #2907 착수 前 완료돼(current_period_start/end가 Toss 경로에도 세팅됨, checkout §③/
+    tier_change ③) 이 자리를 막던 전제가 사라졌다(2026-08-21 그라운딩 재확認). story
+    #2907(dunning)의 진입점 — 여기서 청구가 실패해야 dunning이 시작된다.
+
+    대상: status='active'·유료 tier·current_period_end 도래(<=now)인 org. 성공 시
+    다음 주기로 롤오버(active 유지). 실패 시 status='past_due' 전이 + 1차 통보 메일
+    (AC1·AC3 — "매 실패마다"는 이 첫 실패도 포함)."""
+    now = now or datetime.now(timezone.utc)
+    grace_days = (await get_platform_settings(session)).dunning_grace_days
+    due_subs = (
+        await session.execute(
+            select(OrgSubscription).where(
+                OrgSubscription.status == "active",
+                OrgSubscription.tier != "free",
+                OrgSubscription.current_period_end.is_not(None),
+                OrgSubscription.current_period_end <= now,
+            )
+        )
+    ).scalars().all()
+
+    charged = failed = skipped_catalog_error = 0
+    for sub in due_subs:
+        if sub.offering_version_id is None:
+            # 카탈로그 바인딩 자체가 없는 org — 고객 결제 실패가 아니라 내부 데이터 갭이라
+            # past_due로 벌하지 않는다(로그만 남기고 다음 스윕이 다시 본다).
+            logger.error("trigger_due_charges: org_id=%s active paid without offering_version_id — skip", sub.org_id)
+            skipped_catalog_error += 1
+            continue
+        order_id = _renewal_order_id(sub.org_id, sub.offering_version_id, sub.current_period_end)
+        try:
+            amount_minor, currency = await compute_charge_amount(session, org_id=sub.org_id)
+        except ChargeAmountError:
+            logger.exception("trigger_due_charges: compute_charge_amount failed for org_id=%s", sub.org_id)
+            skipped_catalog_error += 1
+            continue
+
+        try:
+            order = await charge_org(
+                session, org_id=sub.org_id, order_id=order_id, amount_minor=amount_minor,
+                currency=currency, order_name="Sprintable 정기결제(갱신)",
+            )
+        except Exception:
+            logger.exception("trigger_due_charges: charge_org failed for org_id=%s order_id=%s", sub.org_id, order_id)
+            order = (
+                await session.execute(select(BillingOrder).where(BillingOrder.order_id == order_id))
+            ).scalar_one_or_none()
+
+        if order is not None and order.status == "confirmed":
+            new_end = compute_period_end(sub.current_period_end, sub.billing_cycle)
+            await session.execute(
+                update(OrgSubscription).where(OrgSubscription.org_id == sub.org_id).values(
+                    current_period_start=sub.current_period_end, current_period_end=new_end,
+                )
+            )
+            await session.commit()
+            charged += 1
+        else:
+            await session.execute(
+                update(OrgSubscription).where(OrgSubscription.org_id == sub.org_id).values(status="past_due")
+            )
+            await session.commit()
+            grace_expires_at = now.date() + timedelta(days=grace_days)
+            await _notify_dunning_failure(session, sub.org_id, tier=sub.tier, grace_expires_at=grace_expires_at)
+            failed += 1
+
+    return {
+        "due_subs_seen": len(due_subs), "charged": charged, "failed": failed,
+        "skipped_catalog_error": skipped_catalog_error,
+    }

--- a/backend/app/services/org_subscription_tier_change.py
+++ b/backend/app/services/org_subscription_tier_change.py
@@ -80,7 +80,17 @@ async def _refetch_subscription(session: AsyncSession, org_id: uuid.UUID) -> Org
     참고, 2026-08-21 P0 작업 中 실증) — 이 함수 진입 前에 이미 이 org_id 행을 SELECT한
     적이 있으면(이 함수 자체가 change_tier() 첫 줄의 `sub` 조회 이후에 불린다)
     SQLAlchemy identity map이 캐시된 인스턴스를 돌려줄 위험이 있다.
-    `populate_existing()`으로 항상 강제 재조회한다."""
+    `populate_existing()`으로 항상 강제 재조회한다.
+
+    카디르군 관찰(2907 PR 리뷰, 2026-08-21) — 이 모듈의 write 3곳(claim·tier리셋·claim
+    해제)이 전부 순수 `update(OrgSubscription)` Core구문이라 SQLAlchemy의
+    synchronize_session='auto'가 identity map을 이미 자동 동기화한다 — 실측(populate_existing
+    임시제거+test_2880 9건 재실행) 결과 현재 코드경로 기준으로는 inert(어느 테스트도 못
+    잡음, checkout.py의 `pg_insert().on_conflict_do_update()`와 달리 이쪽은 INSERT
+    구문이 아님). 그래도 걷어내지 않는다 — 이 write 중 하나가 훗날 upsert류로 바뀌면
+    (예: claim을 pg_insert 기반으로 바꾸는 리팩터) 같은 staleness 클래스가 조용히
+    재발할 수 있는 방어선이라, 인위적으로 조작한 테스트로 "증명"하는 대신 이 주석으로
+    위험을 명시해둔다."""
     return (
         await session.execute(
             select(OrgSubscription).where(OrgSubscription.org_id == org_id).execution_options(populate_existing=True)

--- a/backend/tests/test_2907_dunning_past_due_grace_realdb.py
+++ b/backend/tests/test_2907_dunning_past_due_grace_realdb.py
@@ -1,0 +1,341 @@
+"""story #2907(선생님 확定 2026-08-21) — 결제 실패 dunning 실PG 검증.
+
+grace 7일(어드민 관리값, platform_settings.dunning_grace_days) — 갱신 charge 실패 시
+org_subscriptions.status='active'→'past_due', 매일 1회 재시도(D+1..D+grace_days), 매
+실패마다 owner 메일, 성공 시 원 주기 유지+active 복귀, grace 만료(D+grace_days+1) 시
+free 전이(기존 데이터 유지).
+
+커버:
+  AC1: 갱신 charge 실패 → active→past_due.
+  AC2: 재시도 스윕 — 같은 날 중복 재시도 금지(멱등) + 성공 시 원 주기 유지+active 복귀.
+  AC3: 실패 통보 메일 — 매 실패마다, 문안에 grace 만료일+제한 방식 명시.
+  AC4: grace 만료 실패 시 free 전이 — 데이터 삭제 없음(tier=free/status=active).
+  AC6: dunning_grace_days가 하드코딩이 아니라 실제로 판단을 바꾼다(load-bearing).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _crypto_key(monkeypatch):
+    import app.core.config as config_module
+    from app.services import billing_key_crypto
+
+    monkeypatch.setattr(config_module.settings, "org_billing_key_encryption_key", "W3x6lXDky6UQE36FyRU_Snf9m7d73Aev59D4PvS4-N0=")
+    billing_key_crypto._get_multi_fernet.cache_clear()
+    yield
+    billing_key_crypto._get_multi_fernet.cache_clear()
+
+
+async def _seed_org_with_owner(session, *, email):
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    await session.execute(
+        text("INSERT INTO organizations (id, name, slug, plan) VALUES (:id, :name, :slug, 'free')"),
+        {"id": org_id, "name": f"test-org-{org_id}", "slug": f"slug-{org_id}"},
+    )
+    await session.execute(
+        text(
+            "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+            "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+            "(:id,:email,'x','Owner',true,true,0,false,0)"
+        ),
+        {"id": user_id, "email": email},
+    )
+    await session.execute(
+        text("INSERT INTO org_members (id, org_id, user_id, role) VALUES (:id, :org_id, :uid, 'owner')"),
+        {"id": uuid.uuid4(), "org_id": org_id, "uid": user_id},
+    )
+    await session.commit()
+    return org_id
+
+
+async def _offering(session, tier):
+    row = (
+        await session.execute(
+            text("SELECT id, monthly_price_minor FROM offering_versions WHERE tier=:t AND currency='krw' AND effective_to IS NULL"),
+            {"t": tier},
+        )
+    ).first()
+    assert row is not None, f"offering_version(tier={tier!r}, krw) 시드 없음"
+    return row.id, row.monthly_price_minor
+
+
+async def _seed_active_paid_subscription(session, org_id, *, tier, offering_id, period_start, period_end, status="active"):
+    await session.execute(
+        text(
+            "INSERT INTO org_subscriptions "
+            "(id, org_id, tier, billing_cycle, status, currency, provider, offering_version_id, "
+            " current_period_start, current_period_end) "
+            "VALUES (:id, :org_id, :tier, 'monthly', :status, 'krw', 'toss', :oid, :ps, :pe)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "tier": tier, "status": status, "oid": offering_id, "ps": period_start, "pe": period_end},
+    )
+    await session.commit()
+
+
+async def _seed_active_billing_key(session, org_id):
+    from app.services.billing_key_crypto import encrypt_billing_key
+
+    await session.execute(
+        text(
+            "INSERT INTO org_billing_keys (id, org_id, customer_key, encrypted_billing_key, status, issued_at) "
+            "VALUES (:id, :org_id, :ck, :ebk, 'active', now())"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "ck": f"org-{org_id}", "ebk": encrypt_billing_key("plaintext-billing-key-test")},
+    )
+    await session.commit()
+
+
+async def _seed_renewal_failed_order(session, org_id, offering_id, period_end, *, created_at):
+    from app.services.billing_scheduler import _renewal_order_id
+
+    order_id = _renewal_order_id(org_id, offering_id, period_end)
+    await session.execute(
+        text(
+            "INSERT INTO billing_orders (id, org_id, order_id, amount_minor, currency, status, created_at, updated_at) "
+            "VALUES (:id, :org_id, :oid, 100000, 'krw', 'failed', :ca, :ca)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "oid": order_id, "ca": created_at},
+    )
+    await session.commit()
+    return order_id
+
+
+async def _set_grace_days(session, days):
+    await session.execute(text("UPDATE platform_settings SET dunning_grace_days = :d"), {"d": days})
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_trigger_due_charges_success_rolls_period_forward_stays_active_realdb():
+    from app.services.billing_scheduler import trigger_due_charges
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org_with_owner(session, email="owner1@2907.test")
+            offering_id, price = await _offering(session, "starter")
+            period_start = datetime.now(timezone.utc) - timedelta(days=30)
+            period_end = datetime.now(timezone.utc) - timedelta(hours=1)  # 이미 도래
+            await _seed_active_paid_subscription(
+                session, org_id, tier="starter", offering_id=offering_id, period_start=period_start, period_end=period_end,
+            )
+            await _seed_active_billing_key(session, org_id)
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                return_value={"paymentKey": f"pay-{uuid.uuid4()}", "totalAmount": price},
+            )):
+                result = await trigger_due_charges(session)
+
+            assert result["charged"] == 1
+            assert result["failed"] == 0
+            row = (
+                await session.execute(
+                    text("SELECT status, current_period_start, current_period_end FROM org_subscriptions WHERE org_id=:oid"),
+                    {"oid": org_id},
+                )
+            ).first()
+            assert row.status == "active"
+            assert row.current_period_start == period_end  # 원 도래일이 새 시작일
+            assert row.current_period_end > period_end + timedelta(days=29)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_trigger_due_charges_failure_sets_past_due_and_notifies_realdb():
+    from app.services.payment.toss_adapter import TossApiError
+    from app.services.billing_scheduler import trigger_due_charges
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org_with_owner(session, email="owner2@2907.test")
+            offering_id, price = await _offering(session, "starter")
+            period_end = datetime.now(timezone.utc) - timedelta(hours=1)
+            await _seed_active_paid_subscription(
+                session, org_id, tier="starter", offering_id=offering_id,
+                period_start=period_end - timedelta(days=30), period_end=period_end,
+            )
+            await _seed_active_billing_key(session, org_id)
+
+            sent = []
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                side_effect=TossApiError("CARD_DECLINED", "카드 거절", status_code=400),
+            )), patch("app.services.billing_scheduler.send_email", new=lambda to, subj, body: sent.append((to, subj, body))):
+                result = await trigger_due_charges(session)
+
+            assert result["failed"] == 1
+            row = (await session.execute(text("SELECT status FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id})).first()
+            assert row.status == "past_due"
+
+            assert len(sent) == 1
+            to, subject, body = sent[0]
+            assert to == "owner2@2907.test"
+            grace_expires = (datetime.now(timezone.utc).date() + timedelta(days=7)).strftime("%Y-%m-%d")
+            assert grace_expires in body, "메일 문안에 grace 만료일(언제)이 없음"
+            assert "삭제되지 않" in body, "메일 문안에 데이터 미삭제(어떻게) 명시가 없음"
+            assert "Free" in body or "free" in body, "메일 문안에 free 전이(어떻게) 명시가 없음"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweep_dunning_retry_success_restores_active_from_original_due_date_realdb():
+    """AC2 — 재결제 성공 시 «원 주기 유지»: D+3에 성공해도 새 period_start는 원래
+    도래했어야 할 날짜(D+0)를 기준으로 계산돼야 한다(늦게 성공했다고 유예일을 공짜로
+    더 받지 않음)."""
+    from app.services.billing_scheduler import sweep_dunning_retries
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org_with_owner(session, email="owner3@2907.test")
+            offering_id, price = await _offering(session, "starter")
+            original_due = datetime.now(timezone.utc) - timedelta(days=3, hours=1)
+            await _seed_active_paid_subscription(
+                session, org_id, tier="starter", offering_id=offering_id,
+                period_start=original_due - timedelta(days=30), period_end=original_due, status="past_due",
+            )
+            await _seed_active_billing_key(session, org_id)
+            failed_created_at = datetime.now(timezone.utc) - timedelta(days=3)
+            await _seed_renewal_failed_order(session, org_id, offering_id, original_due, created_at=failed_created_at)
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=AsyncMock(
+                return_value={"paymentKey": f"pay-{uuid.uuid4()}", "totalAmount": price},
+            )):
+                result = await sweep_dunning_retries(session)
+
+            assert result["retried"] == 1
+            row = (
+                await session.execute(
+                    text("SELECT status, current_period_start, current_period_end FROM org_subscriptions WHERE org_id=:oid"),
+                    {"oid": org_id},
+                )
+            ).first()
+            assert row.status == "active"
+            assert row.current_period_start == original_due
+            assert row.current_period_end > original_due + timedelta(days=29)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweep_dunning_retry_daily_dedup_no_double_attempt_same_day_realdb():
+    from app.services.billing_scheduler import sweep_dunning_retries
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org_with_owner(session, email="owner4@2907.test")
+            offering_id, price = await _offering(session, "starter")
+            original_due = datetime.now(timezone.utc) - timedelta(days=1, hours=1)
+            await _seed_active_paid_subscription(
+                session, org_id, tier="starter", offering_id=offering_id,
+                period_start=original_due - timedelta(days=30), period_end=original_due, status="past_due",
+            )
+            await _seed_active_billing_key(session, org_id)
+            await _seed_renewal_failed_order(session, org_id, offering_id, original_due, created_at=original_due)
+
+            call_count = 0
+
+            async def _fake_post(self, path, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                from app.services.payment.toss_adapter import TossApiError
+                raise TossApiError("CARD_DECLINED", "카드 거절", status_code=400)
+
+            with patch("app.services.payment.toss_adapter.TossAdapter._post", new=_fake_post):
+                r1 = await sweep_dunning_retries(session)
+                r2 = await sweep_dunning_retries(session)
+
+            assert r1["retried"] == 1
+            assert r2["retried"] == 0, "같은 날 두 번째 스윕은 재시도하면 안 됨(멱등)"
+            assert call_count == 1, "Toss가 하루 두 번 불리면 안 됨"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweep_dunning_downgrade_to_free_after_grace_expires_realdb():
+    """AC4 — grace 만료(D+grace_days+1) 시 free 전이. 데이터 삭제 없음(tier=free만 되돌림,
+    이 스윕은 다른 리소스 테이블을 안 건드린다 — downgrade_to_free 자체가 기존 검증됨)."""
+    from app.services.billing_scheduler import sweep_dunning_retries
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org_with_owner(session, email="owner5@2907.test")
+            offering_id, price = await _offering(session, "starter")
+            original_due = datetime.now(timezone.utc) - timedelta(days=8, hours=1)
+            await _seed_active_paid_subscription(
+                session, org_id, tier="starter", offering_id=offering_id,
+                period_start=original_due - timedelta(days=30), period_end=original_due, status="past_due",
+            )
+            await _seed_renewal_failed_order(session, org_id, offering_id, original_due, created_at=original_due)
+
+            result = await sweep_dunning_retries(session)
+
+            assert result["downgraded"] == 1
+            row = (
+                await session.execute(text("SELECT tier, status FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id})
+            ).first()
+            assert row.tier == "free"
+            assert row.status == "active"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_dunning_grace_days_platform_setting_changes_retry_window_realdb():
+    """AC6 load-bearing — grace_days를 3으로 바꾸면 D+4가 (D+7이 아니라) downgrade
+    트리거일이 돼야 한다. 하드코딩이었다면 이 테스트는 downgraded==0으로 실패한다."""
+    from app.services.billing_scheduler import sweep_dunning_retries
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            await _set_grace_days(session, 3)
+            org_id = await _seed_org_with_owner(session, email="owner6@2907.test")
+            offering_id, price = await _offering(session, "starter")
+            original_due = datetime.now(timezone.utc) - timedelta(days=4, hours=1)
+            await _seed_active_paid_subscription(
+                session, org_id, tier="starter", offering_id=offering_id,
+                period_start=original_due - timedelta(days=30), period_end=original_due, status="past_due",
+            )
+            await _seed_renewal_failed_order(session, org_id, offering_id, original_due, created_at=original_due)
+
+            result = await sweep_dunning_retries(session)
+
+            assert result["downgraded"] == 1, "grace_days=3이면 D+4는 downgrade여야 함(D+8이 아님)"
+            row = (await session.execute(text("SELECT tier FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id})).first()
+            assert row.tier == "free"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2907_dunning_past_due_grace_realdb.py
+++ b/backend/tests/test_2907_dunning_past_due_grace_realdb.py
@@ -149,8 +149,11 @@ async def test_trigger_due_charges_success_rolls_period_forward_stays_active_rea
             )):
                 result = await trigger_due_charges(session)
 
-            assert result["charged"] == 1
-            assert result["failed"] == 0
+            # CI는 전체 pytest 스위트를 한 공유 실PG에서 돌린다 — trigger_due_charges는
+            # org_subscriptions 전체를 스캔하므로 다른(무관한) 테스트가 남긴 active+과거
+            # period_end 행도 함께 집혀 집계 카운트를 오염시킬 수 있다(로컬 파일단위 프레시
+            # DB에서는 안 드러남). 집계는 하한만, 실제 판정은 이 org 자신의 row로.
+            assert result["charged"] >= 1
             row = (
                 await session.execute(
                     text("SELECT status, current_period_start, current_period_end FROM org_subscriptions WHERE org_id=:oid"),
@@ -188,13 +191,14 @@ async def test_trigger_due_charges_failure_sets_past_due_and_notifies_realdb():
             )), patch("app.services.billing_scheduler.send_email", new=lambda to, subj, body: sent.append((to, subj, body))):
                 result = await trigger_due_charges(session)
 
-            assert result["failed"] == 1
+            # 공유 CI DB 오염 가능성 — 하한만(row-level이 실 판정).
+            assert result["failed"] >= 1
             row = (await session.execute(text("SELECT status FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id})).first()
             assert row.status == "past_due"
 
-            assert len(sent) == 1
-            to, subject, body = sent[0]
-            assert to == "owner2@2907.test"
+            own_emails = [s for s in sent if s[0] == "owner2@2907.test"]
+            assert len(own_emails) == 1
+            to, subject, body = own_emails[0]
             grace_expires = (datetime.now(timezone.utc).date() + timedelta(days=7)).strftime("%Y-%m-%d")
             assert grace_expires in body, "메일 문안에 grace 만료일(언제)이 없음"
             assert "삭제되지 않" in body, "메일 문안에 데이터 미삭제(어떻게) 명시가 없음"
@@ -230,7 +234,7 @@ async def test_sweep_dunning_retry_success_restores_active_from_original_due_dat
             )):
                 result = await sweep_dunning_retries(session)
 
-            assert result["retried"] == 1
+            assert result["retried"] >= 1  # 공유 CI DB 오염 가능성 — 하한만.
             row = (
                 await session.execute(
                     text("SELECT status, current_period_start, current_period_end FROM org_subscriptions WHERE org_id=:oid"),
@@ -260,7 +264,7 @@ async def test_sweep_dunning_retry_daily_dedup_no_double_attempt_same_day_realdb
                 period_start=original_due - timedelta(days=30), period_end=original_due, status="past_due",
             )
             await _seed_active_billing_key(session, org_id)
-            await _seed_renewal_failed_order(session, org_id, offering_id, original_due, created_at=original_due)
+            order_id = await _seed_renewal_failed_order(session, org_id, offering_id, original_due, created_at=original_due)
 
             call_count = 0
 
@@ -271,12 +275,21 @@ async def test_sweep_dunning_retry_daily_dedup_no_double_attempt_same_day_realdb
                 raise TossApiError("CARD_DECLINED", "카드 거절", status_code=400)
 
             with patch("app.services.payment.toss_adapter.TossAdapter._post", new=_fake_post):
-                r1 = await sweep_dunning_retries(session)
-                r2 = await sweep_dunning_retries(session)
+                await sweep_dunning_retries(session)
+                updated_at_after_r1 = (
+                    await session.execute(text("SELECT updated_at FROM billing_orders WHERE order_id=:oid"), {"oid": order_id})
+                ).scalar_one()
+                assert updated_at_after_r1.date() == datetime.now(timezone.utc).date(), "1차 스윕에서 이 order가 오늘 날짜로 재시도됐어야 함"
 
-            assert r1["retried"] == 1
-            assert r2["retried"] == 0, "같은 날 두 번째 스윕은 재시도하면 안 됨(멱등)"
-            assert call_count == 1, "Toss가 하루 두 번 불리면 안 됨"
+                await sweep_dunning_retries(session)
+
+            # 공유 CI DB에 다른 org의 재시도가 섞여도, «이 order 자신»은 두 번째 스윕에서
+            # 손대지지 않아야 한다(같은 날 dedup) — 전역 call_count/retried 집계가 아니라
+            # 이 order 고유 updated_at의 불변으로 검증(다른 org의 Toss 콜과 무관).
+            updated_at_after_r2 = (
+                await session.execute(text("SELECT updated_at FROM billing_orders WHERE order_id=:oid"), {"oid": order_id})
+            ).scalar_one()
+            assert updated_at_after_r2 == updated_at_after_r1, "같은 날 두 번째 스윕이 이 order를 다시 건드리면 안 됨(멱등)"
     finally:
         await engine.dispose()
 
@@ -302,7 +315,7 @@ async def test_sweep_dunning_downgrade_to_free_after_grace_expires_realdb():
 
             result = await sweep_dunning_retries(session)
 
-            assert result["downgraded"] == 1
+            assert result["downgraded"] >= 1  # 공유 CI DB 오염 가능성 — 하한만.
             row = (
                 await session.execute(text("SELECT tier, status FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id})
             ).first()
@@ -334,7 +347,7 @@ async def test_dunning_grace_days_platform_setting_changes_retry_window_realdb()
 
             result = await sweep_dunning_retries(session)
 
-            assert result["downgraded"] == 1, "grace_days=3이면 D+4는 downgrade여야 함(D+8이 아님)"
+            assert result["downgraded"] >= 1, "grace_days=3이면 D+4는 downgrade여야 함(D+8이 아님)"
             row = (await session.execute(text("SELECT tier FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id})).first()
             assert row.tier == "free"
     finally:

--- a/backend/tests/test_e_2494_c3_scheduler.py
+++ b/backend/tests/test_e_2494_c3_scheduler.py
@@ -1,5 +1,13 @@
-"""#2494(C3) — dunning 재시도 상태기계(pricing-policy-proposal-v1 §12.1) + pending 대사.
-PO 계약(2026-08-07): (b)-narrowed — "신규 결제 주기 도래" 판정은 스코프 밖(#2502 대기)."""
+"""#2494(C3) — dunning 재시도 상태기계 + pending 대사.
+
+⚠️cadence 갱신(story #2907, 선생님 확定 2026-08-21) — 원 §12.1의 {1,3,5}일 3회 정책은
+매일 1회(D+1..D+grace_days) 정책으로 대체됐다. grace_days 자체는 하드코딩이 아니라
+platform_settings.dunning_grace_days(어드민 관리값, 기본 7)에서 온다 — 이 파일은 그
+기본값(7) 파라미터로 next_dunning_action의 순수 로직만 검증(그라운딩값 자체의
+admin-설정 가능 여부는 test_2907_dunning_past_due_grace_realdb.py가 실PG로 검증).
+
+"신규 결제 주기 도래" 판정(trigger_due_charges)은 #2502(완료, 2026-08-21 이전)가
+전제를 채운 뒤 #2907이 실제로 구현했다 — 더 이상 NotImplementedError가 아니다."""
 from __future__ import annotations
 
 import uuid
@@ -28,13 +36,13 @@ def _order(*, status: str, created_days_ago: int, updated_days_ago: int, now: da
     [
         ("confirmed", 3, 3, "wait"),          # confirmed는 애초에 대상 아님
         ("pending", 3, 3, "wait"),             # pending도 dunning 대상 아님(대사 몫)
-        ("failed", 0, 0, "wait"),              # 최초 실패 당일 — §12.1 "기능 유지"만, 재시도 없음
-        ("failed", 1, 1, "retry"),             # +1일 1차 재결제
-        ("failed", 2, 2, "wait"),              # +2일 — 케이던스에 없는 날
-        ("failed", 3, 3, "retry"),             # +3일 2차
-        ("failed", 5, 5, "retry"),             # +5일 3차
-        ("failed", 7, 7, "wait"),              # +7일 = 유예종료 "알림"이지 재시도 아님
-        ("failed", 8, 7, "downgrade_to_free"), # +8일 Free 전환
+        ("failed", 0, 0, "wait"),              # 최초 실패 당일 — 재시도는 +1일부터
+        ("failed", 1, 1, "retry"),             # +1일
+        ("failed", 2, 2, "retry"),             # +2일 — 매일 1회(구 정책의 "케이던스 없는 날" 폐기)
+        ("failed", 3, 3, "retry"),             # +3일
+        ("failed", 5, 5, "retry"),             # +5일
+        ("failed", 7, 7, "retry"),             # +7일 = grace 마지막 날, 여전히 재시도
+        ("failed", 8, 7, "downgrade_to_free"), # +8일(grace_days+1) Free 전환
         ("failed", 10, 7, "downgrade_to_free"),# 8일 지나면 계속 downgrade(멱등)
     ],
 )
@@ -285,7 +293,9 @@ async def test_sweep_dunning_retries_retries_and_downgrades(monkeypatch):
     now = datetime(2026, 8, 15, tzinfo=timezone.utc)
     retry_order = _order(status="failed", created_days_ago=1, updated_days_ago=1, now=now)
     downgrade_order = _order(status="failed", created_days_ago=9, updated_days_ago=8, now=now)
-    wait_order = _order(status="failed", created_days_ago=2, updated_days_ago=2, now=now)
+    # story #2907(daily cadence) — day 2도 이제 retry 대상이라, "오늘은 대상 아님"을
+    # 보여주려면 대신 "오늘 이미 재시도됨"(updated_days_ago=0) 케이스를 쓴다.
+    wait_order = _order(status="failed", created_days_ago=2, updated_days_ago=0, now=now)
 
     session = AsyncMock()
     orders_result = MagicMock()
@@ -296,6 +306,10 @@ async def test_sweep_dunning_retries_retries_and_downgrades(monkeypatch):
     downgrade_mock = AsyncMock()
     monkeypatch.setattr(sched, "charge_org", charge_mock)
     monkeypatch.setattr(sched, "downgrade_to_free", downgrade_mock)
+    # story #2907 — grace_days는 이제 platform_settings에서 온다. retry_order/downgrade_order의
+    # order_id가 "renewal:" 접두사가 아니라 _sync_renewal_retry_outcome은 안 탄다(기존
+    # checkout/tier_change 실패 order 시나리오 그대로 유지).
+    monkeypatch.setattr(sched, "get_platform_settings", AsyncMock(return_value=MagicMock(dunning_grace_days=7)))
 
     result = await sched.sweep_dunning_retries(session, now=now)
 
@@ -323,6 +337,7 @@ async def test_sweep_dunning_retries_charge_exception_does_not_abort_sweep(monke
 
     monkeypatch.setattr(sched, "charge_org", AsyncMock(side_effect=RuntimeError("toss down")))
     monkeypatch.setattr(sched, "downgrade_to_free", AsyncMock())
+    monkeypatch.setattr(sched, "get_platform_settings", AsyncMock(return_value=MagicMock(dunning_grace_days=7)))
 
     result = await sched.sweep_dunning_retries(session, now=now)
     assert result["retried"] == 1
@@ -421,14 +436,25 @@ async def test_sweep_stale_pending_leaves_pending_on_transient_lookup_error(monk
     confirm_mock.assert_not_awaited()
 
 
-# ─── trigger_due_charges — 명시 스코프 밖 ───────────────────────────────────
+# ─── trigger_due_charges — story #2907이 실제로 채웠다(구 NotImplementedError 폐기) ────
+# 갱신 charge 성공/실패의 실제 산식(period 롤오버·past_due 전이·메일)은 실PG로만 뜻이
+# 있어(charge_org·compute_charge_amount 등 여러 실 write가 얽힘) 여기선 "due 대상이
+# 없으면 아무것도 안 건드리고 0으로 끝난다"는 최소 스모크만 — 나머지는
+# test_2907_dunning_past_due_grace_realdb.py 전담.
 
 @pytest.mark.anyio
-async def test_trigger_due_charges_not_implemented_pending_story_2502():
-    from app.services.billing_scheduler import trigger_due_charges
+async def test_trigger_due_charges_no_due_subs_is_noop(monkeypatch):
+    import app.services.billing_scheduler as sched
 
-    with pytest.raises(NotImplementedError, match="#2502"):
-        await trigger_due_charges(AsyncMock())
+    session = AsyncMock()
+    empty_result = MagicMock()
+    empty_result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=empty_result)
+    monkeypatch.setattr(sched, "get_platform_settings", AsyncMock(return_value=MagicMock(dunning_grace_days=7)))
+
+    result = await sched.trigger_due_charges(session)
+
+    assert result == {"due_subs_seen": 0, "charged": 0, "failed": 0, "skipped_catalog_error": 0}
 
 
 # ─── cron endpoint ───────────────────────────────────────────────────────────


### PR DESCRIPTION
[SID:2907]

## Summary
- `trigger_due_charges`(story #2502가 전제를 채운 뒤 여태 NotImplementedError였던 자리)를 실제로 구현 — 갱신 청구 실패의 진입점.
- 실패 시 `org_subscriptions.status` active→past_due. `sweep_dunning_retries`가 `renewal:` 접두사 order만 골라 daily cadence(D+1..D+grace_days)로 재시도하고 past_due⇄active를 동기화한다 — checkout/tier_change 실패 order는 기존 동작 그대로(회귀 없음).
- 성공 시 **원래 도래했어야 할 날짜**를 기준으로 다음 주기를 롤오버(늦게 성공해도 유예일을 공짜로 더 안 줌).
- 매 실패마다 org owner/admin에게 메일 — grace 만료일(언제)과 free 전이 시 신규 업로드만 차단(데이터 삭제 없음, 어떻게)을 명시.
- grace 일수는 하드코딩이 아니라 `platform_settings.dunning_grace_days`(마이그 0269, 기본 7) — AC6.

## 경계(AC5)
라이브 집행(Cloud Scheduler가 실제로 `toss-billing-maintenance`를 주기 호출)은 story #2896(cron 인프라) 착지 후. 이 PR의 완료선은 코드+실DB 테스트.

## 결제②-D선행(story #2502) — 이 PR로 어디까지 닫히는지
#2502의 원 서술은 두 축이었다: ①신규 유료전환(checkout/change-tier) 시점 period 세팅 — **이미 완료**(#2506/#2880, develop에 merged). ②"C2 charge_org 성공(정기결제 갱신) 시점에 다음 period로 롤오버" — 이건 그동안 `trigger_due_charges`가 NotImplementedError였던 탓에 미착수 상태로 남아 있었다. 이 PR의 `trigger_due_charges`+`_sync_renewal_retry_outcome`이 바로 그 롤오버 로직이다(원 도래일 기준, AC2와 동일 산식) — **①②둘 다 이 시점부로 완결**. Sprintable 트래커상 #2502는 이미 status=done(2026-08-07)이라 별도 상태변경은 불요 — 잔여 없음을 여기 명시.

## AC3(발송 실물 검증) — QA 축 이관
이 PR의 테스트는 `send_email` 호출 자체와 인자(수신자·grace날짜·문안)만 검증한다(mock). **실제 수신함 도달 또는 Resend 발송 로그 확認은 카디르군 QA 몫으로 이관** — dev 환경 email 인프라는 이미 라이브 설정돼 있음(RESEND_API_KEY/EMAIL_FROM 확認됨, storage-usage-warn cron이 실사용 중인 동일 경로 재사용이라 배선 자체의 신뢰도는 높음).

## 비차단 부수 조사
카디르군이 짚은 `org_subscription_tier_change.py`의 `populate_existing` fix 미검증 관찰 — 실측(제거 후 test_2880 9건 재실행) 결과 현재 코드경로 기준 inert함을 확認(그 모듈의 write가 전부 순수 `update()`라 SQLAlchemy `synchronize_session='auto'`가 이미 동기화, checkout.py의 `pg_insert().on_conflict_do_update()`와 다름). 인위적 테스트 대신 주석으로 재발조건 명시. 올리베이라군 승인 완료(대화 스레드 참고).

## Test plan
- [x] `test_2907_dunning_past_due_grace_realdb.py`(신규 6건) — trigger_due_charges 성공/실패, 재시도 성공 시 원주기 유지, 같은날 중복재시도 금지, grace 만료 free 전이, dunning_grace_days load-bearing.
- [x] `test_e_2494_c3_scheduler.py` — 구 cadence 테이블/mock을 신 daily cadence+실 trigger_due_charges로 갱신.
- [x] 회귀: test_e_2509/test_2777/test_2880(9)/test_e_2506(체크아웃 전체)/test_2892 — 96 tests, 프레시 PG 기준 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

