### PR TITLE
[SID:2882] 구독 취소 — #2881 하향 예약 슬롯 재사용, 좌석 게이트 미적용

### DIFF
--- a/backend/app/routers/org_subscription_checkout.py
+++ b/backend/app/routers/org_subscription_checkout.py
@@ -220,3 +220,60 @@ async def cancel_downgrade_endpoint(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return _to_response(sub)
+
+
+@router.post("/cancel", response_model=CheckoutResponse)
+async def cancel_subscription_endpoint(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
+) -> CheckoutResponse:
+    """story #2882(구독 취소) — 「tier=free로의 하향」으로 예약(같은 pending_* 슬롯·같은
+    sweep). 즉시 전이 없음 — 현재 기간 말까지 사용, 다음 갱신 중지, 부분 환불 없음
+    (v2.1 §12). 좌석 게이트는 타지 않는다(해지 의사는 좌석 초과를 이유로 거부하지
+    않는다 — `org_subscription_downgrade.cancel_subscription` docstring 참고)."""
+    settings = await get_platform_settings(session)
+    if not settings.billing_checkout_enabled:
+        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+
+    from app.services.project_auth import is_org_owner_or_admin
+
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="org admin/owner role required")
+
+    from app.services.org_subscription_downgrade import DowngradeError, cancel_subscription
+
+    try:
+        sub = await cancel_subscription(session, org_id=org_id)
+    except DowngradeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return _to_response(sub)
+
+
+@router.delete("/cancel", response_model=CheckoutResponse)
+async def revoke_cancellation_endpoint(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
+) -> CheckoutResponse:
+    """story #2882 — 취소 철회(재구독 의사). 같은 pending_* 슬롯이라
+    `cancel_pending_downgrade`를 그대로 재사용(재구현 0) — 예약된 게 하향이든
+    취소(free)든 pending_*만 클리어하는 동작은 동일하다."""
+    settings = await get_platform_settings(session)
+    if not settings.billing_checkout_enabled:
+        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+
+    from app.services.project_auth import is_org_owner_or_admin
+
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="org admin/owner role required")
+
+    from app.services.org_subscription_downgrade import DowngradeError, cancel_pending_downgrade
+
+    try:
+        sub = await cancel_pending_downgrade(session, org_id=org_id)
+    except DowngradeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return _to_response(sub)

--- a/backend/app/services/org_subscription_downgrade.py
+++ b/backend/app/services/org_subscription_downgrade.py
@@ -50,6 +50,47 @@ async def _refetch_subscription(session: AsyncSession, org_id: uuid.UUID) -> Org
     ).scalar_one()
 
 
+async def _active_paid_sub_or_raise(session: AsyncSession, org_id: uuid.UUID) -> OrgSubscription:
+    """reserve_downgrade·cancel_subscription 공통 전제 — 활성 유료 구독+적용일을 정할
+    current_period_end가 있어야 한다(재구현 0)."""
+    sub = (
+        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+    ).scalar_one_or_none()
+    if sub is None or sub.status != "active" or sub.tier not in PAID_TIERS:
+        raise DowngradeError(f"org_id={org_id} 활성 유료 구독이 아님 — 하향/취소 예약 대상 아님")
+    if sub.current_period_end is None:
+        raise DowngradeError(f"org_id={org_id} current_period_end 없음 — 적용일을 정할 수 없음")
+    return sub
+
+
+async def _offering_or_raise(session: AsyncSession, *, tier: str, currency: str) -> OfferingVersion:
+    offering = (
+        await session.execute(
+            select(OfferingVersion).where(
+                OfferingVersion.tier == tier,
+                OfferingVersion.currency == currency,
+                OfferingVersion.effective_to.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if offering is None:
+        raise DowngradeError(f"tier={tier!r}의 활성 offering_version({currency!r})을 찾을 수 없음")
+    return offering
+
+
+async def _reserve_pending_change(session: AsyncSession, *, sub: OrgSubscription, new_tier: str, offering_id: uuid.UUID) -> OrgSubscription:
+    await session.execute(
+        update(OrgSubscription)
+        .where(OrgSubscription.org_id == sub.org_id)
+        .values(
+            pending_tier=new_tier, pending_offering_version_id=offering_id,
+            pending_change_apply_at=sub.current_period_end,
+        )
+    )
+    await session.commit()
+    return await _refetch_subscription(session, sub.org_id)
+
+
 async def reserve_downgrade(session: AsyncSession, *, org_id: uuid.UUID, new_tier: str) -> OrgSubscription:
     """①③④ — 하향 예약(단일 슬롯, 재예약은 이전 예약을 덮어씀). 돈이 안 걸린 순수
     메타데이터 write라 checkout/change-tier류의 claim(checkout_claimed_at) 불요 —
@@ -58,40 +99,36 @@ async def reserve_downgrade(session: AsyncSession, *, org_id: uuid.UUID, new_tie
     if new_tier not in PAID_TIERS:
         raise DowngradeError(f"new_tier={new_tier!r}는 유료 티어만(starter/team/business) — free 전환은 구독 취소(story #2882)")
 
-    sub = (
-        await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
-    ).scalar_one_or_none()
-    if sub is None or sub.status != "active" or sub.tier not in PAID_TIERS:
-        raise DowngradeError(f"org_id={org_id} 활성 유료 구독이 아님 — 하향 예약 대상 아님")
-    if sub.current_period_end is None:
-        raise DowngradeError(f"org_id={org_id} current_period_end 없음 — 적용일을 정할 수 없음")
+    sub = await _active_paid_sub_or_raise(session, org_id)
     if _TIER_RANK.get(new_tier, 0) >= _TIER_RANK.get(sub.tier, 0):
         raise DowngradeError(
             f"{sub.tier!r}→{new_tier!r}는 하향이 아님(상향/동일) — 상향은 story #2880(change-tier)"
         )
 
-    new_offering = (
-        await session.execute(
-            select(OfferingVersion).where(
-                OfferingVersion.tier == new_tier,
-                OfferingVersion.currency == sub.currency,
-                OfferingVersion.effective_to.is_(None),
-            )
-        )
-    ).scalar_one_or_none()
-    if new_offering is None:
-        raise DowngradeError(f"tier={new_tier!r}의 활성 offering_version({sub.currency!r})을 찾을 수 없음")
+    new_offering = await _offering_or_raise(session, tier=new_tier, currency=sub.currency)
+    return await _reserve_pending_change(session, sub=sub, new_tier=new_tier, offering_id=new_offering.id)
 
-    await session.execute(
-        update(OrgSubscription)
-        .where(OrgSubscription.org_id == org_id)
-        .values(
-            pending_tier=new_tier, pending_offering_version_id=new_offering.id,
-            pending_change_apply_at=sub.current_period_end,
-        )
-    )
-    await session.commit()
-    return await _refetch_subscription(session, org_id)
+
+async def cancel_subscription(session: AsyncSession, *, org_id: uuid.UUID) -> OrgSubscription:
+    """story #2882(구독 취소, 선생님 확定 2026-08-21) — v2.1 §12 「월간 구독 취소: 현재
+    기간 말까지 사용, 다음 갱신 중지, 부분 환불 없음」. 메커니즘은 reserve_downgrade와
+    동일(즉시 전이 없음·단일 슬롯 재예약·`sweep_pending_tier_downgrades`가 갱신일에
+    적용)이라 «tier=free로의 하향»으로 취급 — 같은 pending_* 슬롯·같은 sweep 재사용
+    (새 컬럼·새 스윕 발명 0).
+
+    ⛔단, 좌석 게이트는 **타지 않는다**(페드루 확定 판정, #2881의 유료↔유료 하향과
+    결정적으로 다른 지점) — 하향은 «선택»이라 조건 미충족 시 안 해줘도 되지만, 취소는
+    «해지 의사»라 좌석 초과를 이유로 거부하면 사용자가 결제를 끊을 수 없는 상태가
+    된다(해지 방해). `sweep_pending_tier_downgrades`가 `pending_tier == "free"`일 때
+    이 스킵을 구현한다(이 함수 자체는 예약만 걸 뿐, 게이트 스킵은 sweep 쪽 책임).
+    초과 좌석 기존 멤버는 제거하지 않고, free 전이 後 **신규 좌석 추가만** 기존
+    `ee/plan_limits.check_member_invite_limit`(무수정 재사용)가 자연히 막는다 — 스토리
+    #2906(storage 초과=신규 업로드만 차단)과 같은 판별.
+
+    월납만(연납은 §12의 별도 환불식이 필요해 미착수 — story #2880/#2881과 동일 선례)."""
+    sub = await _active_paid_sub_or_raise(session, org_id)
+    free_offering = await _offering_or_raise(session, tier="free", currency=sub.currency)
+    return await _reserve_pending_change(session, sub=sub, new_tier="free", offering_id=free_offering.id)
 
 
 async def cancel_pending_downgrade(session: AsyncSession, *, org_id: uuid.UUID) -> OrgSubscription:
@@ -169,8 +206,15 @@ async def sweep_pending_tier_downgrades(session: AsyncSession, *, now: datetime 
             skipped += 1
             continue
 
-        seat_count = await count_human_seats(session, sub.org_id)
-        if seat_count > new_offering.included_seats:
+        # story #2882(선생님 확定 2026-08-21) — 취소(pending_tier="free")는 좌석 게이트를
+        # 타지 않는다. 하향은 «선택»이라 조건 미충족 시 거부해도 되지만, 취소는 «해지
+        # 의사»라 좌석 초과를 이유로 거부하면 사용자가 결제를 끊을 수 없는 상태가 된다
+        # (해지 방해 — 소비자 보호·심사 관점 둘 다 위험). free 전이는 무조건 실행하고,
+        # 초과 멤버는 제거하지 않는다 — 이후 신규 좌석 추가만 기존
+        # ee/plan_limits.check_member_invite_limit이 자연히 막는다(재구현 0).
+        is_cancellation = sub.pending_tier == "free"
+        seat_count = 0 if is_cancellation else await count_human_seats(session, sub.org_id)
+        if not is_cancellation and seat_count > new_offering.included_seats:
             # 카디르 확定 버그(PR#3308 QA, 2026-08-21) — 아래 raw UPDATE(pending_tier=None)를
             # session.execute()가 실행하면 SQLAlchemy Core update()의 기본 "evaluate"
             # synchronize_session 전략이 PK로 매칭되는 이 in-session `sub` 객체를 자동으로
@@ -193,15 +237,23 @@ async def sweep_pending_tier_downgrades(session: AsyncSession, *, now: datetime 
             cancelled_seat_overage += 1
             continue
 
-        new_period_end = compute_period_end(now, sub.billing_cycle or "monthly")
+        if is_cancellation:
+            # free는 Toss 결제 주기가 없다 — downgrade_to_free(dunning 강제전환)의 free
+            # upsert 관례와 동형으로 billing_cycle/period를 비운다(재구현 0).
+            update_values = {
+                "tier": "free", "offering_version_id": sub.pending_offering_version_id,
+                "billing_cycle": None, "current_period_start": None, "current_period_end": None,
+                "pending_tier": None, "pending_offering_version_id": None, "pending_change_apply_at": None,
+            }
+        else:
+            new_period_end = compute_period_end(now, sub.billing_cycle or "monthly")
+            update_values = {
+                "tier": sub.pending_tier, "offering_version_id": sub.pending_offering_version_id,
+                "current_period_start": now, "current_period_end": new_period_end,
+                "pending_tier": None, "pending_offering_version_id": None, "pending_change_apply_at": None,
+            }
         await session.execute(
-            update(OrgSubscription)
-            .where(OrgSubscription.id == sub.id)
-            .values(
-                tier=sub.pending_tier, offering_version_id=sub.pending_offering_version_id,
-                current_period_start=now, current_period_end=new_period_end,
-                pending_tier=None, pending_offering_version_id=None, pending_change_apply_at=None,
-            )
+            update(OrgSubscription).where(OrgSubscription.id == sub.id).values(**update_values)
         )
         await session.commit()
         applied += 1

--- a/backend/tests/test_2882_subscription_cancellation_realdb.py
+++ b/backend/tests/test_2882_subscription_cancellation_realdb.py
@@ -1,0 +1,252 @@
+"""story #2882(구독 취소, 선생님 확定 2026-08-21) — 실PG 검증. v2.1 §12 「월간 구독
+취소: 현재 기간 말까지 사용, 다음 갱신 중지, 부분 환불 없음」 — «tier=free로의 하향»으로
+취급, #2881의 pending_* 슬롯·`sweep_pending_tier_downgrades`를 그대로 재사용한다.
+
+커버:
+  AC① — 취소 예약이 즉시 전이 없이 pending_tier='free'만 기록(현재 tier 무변화).
+  AC② — 활성 유료 구독이 아니면 취소 예약 거부(DowngradeError).
+  AC③ — 철회(POST 취소 후 DELETE)는 pending_*만 클리어, 구독 원 tier 무변화.
+  AC④ — sweep이 갱신일에 free로 실제 전이(billing_cycle/period 클리어).
+  ⛔AC⑤(선생님 확定 핵심) — 좌석 초과 상태에서도 취소는 **거부되지 않는다**(하향과
+  달리 seat gate를 안 탐) — 기존 멤버는 제거되지 않고, free 전이 後 신규 좌석 추가만
+  기존 `ee/plan_limits.check_member_invite_limit`이 자연히 막는다.
+  ⑥ — 하향 예약과 취소 예약은 같은 슬롯 — 서로 재예약(덮어씀) 가능.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_org(session):
+    org_id = uuid.uuid4()
+    await session.execute(
+        text("INSERT INTO organizations (id, name, slug, plan) VALUES (:id, :name, :slug, 'free')"),
+        {"id": org_id, "name": f"test-org-{org_id}", "slug": f"slug-{org_id}"},
+    )
+    await session.commit()
+    return org_id
+
+
+async def _offering_id(session, tier):
+    row = (
+        await session.execute(
+            text("SELECT id, included_seats FROM offering_versions WHERE tier=:t AND currency='krw' AND effective_to IS NULL"),
+            {"t": tier},
+        )
+    ).first()
+    assert row is not None, f"offering_version(tier={tier!r}, krw) 시드 없음"
+    return row.id, row.included_seats
+
+
+async def _seed_active_paid_subscription(session, org_id, *, tier="business", period_end=None):
+    offering_id, _ = await _offering_id(session, tier)
+    period_end = period_end or (datetime.now(timezone.utc) + timedelta(days=20))
+    await session.execute(
+        text(
+            "INSERT INTO org_subscriptions "
+            "(id, org_id, tier, billing_cycle, status, currency, provider, offering_version_id, "
+            " current_period_start, current_period_end) "
+            "VALUES (:id, :org_id, :tier, 'monthly', 'active', 'krw', 'toss', :oid, :ps, :pe)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "tier": tier, "oid": offering_id, "ps": period_end - timedelta(days=10), "pe": period_end},
+    )
+    await session.commit()
+    return period_end
+
+
+async def _seed_human_member(session, org_id):
+    from app.models.member import Member
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x"))
+    await session.flush()
+    om_id = uuid.uuid4()
+    session.add(OrgMember(id=om_id, org_id=org_id, user_id=user_id, role="member"))
+    await session.flush()
+    session.add(Member(id=om_id, org_id=org_id, type="human", user_id=user_id, name="Human"))
+    await session.commit()
+    return om_id
+
+
+@pytest.mark.anyio
+async def test_cancel_subscription_does_not_change_tier_immediately_realdb():
+    from app.services.org_subscription_downgrade import cancel_subscription
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            period_end = await _seed_active_paid_subscription(session, org_id, tier="business")
+
+            sub = await cancel_subscription(session, org_id=org_id)
+
+            assert sub.tier == "business", "즉시 전이 없음 — 현재 tier 유지"
+            assert sub.pending_tier == "free"
+            assert sub.pending_change_apply_at == period_end
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cancel_subscription_rejects_non_active_paid_org_realdb():
+    from app.services.org_subscription_downgrade import DowngradeError, cancel_subscription
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)  # 구독 행 자체가 없음(free, 시드 안 함)
+
+            with pytest.raises(DowngradeError, match="활성 유료 구독이 아님"):
+                await cancel_subscription(session, org_id=org_id)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_revoke_cancellation_clears_reservation_realdb():
+    from app.services.org_subscription_downgrade import cancel_pending_downgrade, cancel_subscription
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            await _seed_active_paid_subscription(session, org_id, tier="business")
+            await cancel_subscription(session, org_id=org_id)
+
+            sub = await cancel_pending_downgrade(session, org_id=org_id)
+
+            assert sub.tier == "business"
+            assert sub.pending_tier is None
+            assert sub.pending_change_apply_at is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweep_applies_cancellation_to_free_at_period_end_realdb():
+    from app.services.org_subscription_downgrade import cancel_subscription, sweep_pending_tier_downgrades
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            past_period_end = datetime.now(timezone.utc) - timedelta(hours=1)
+            await _seed_active_paid_subscription(session, org_id, tier="starter", period_end=past_period_end)
+            await _seed_human_member(session, org_id)  # 1명(free 3석 이내)
+
+            await cancel_subscription(session, org_id=org_id)
+            result = await sweep_pending_tier_downgrades(session)
+
+            assert result["applied"] == 1
+            assert result["cancelled_seat_overage"] == 0
+            row = (
+                await session.execute(
+                    text("SELECT tier, status, billing_cycle, current_period_start, current_period_end, pending_tier FROM org_subscriptions WHERE org_id=:oid"),
+                    {"oid": org_id},
+                )
+            ).first()
+            assert row.tier == "free"
+            assert row.status == "active"
+            assert row.billing_cycle is None
+            assert row.current_period_start is None
+            assert row.current_period_end is None
+            assert row.pending_tier is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweep_cancellation_bypasses_seat_gate_and_blocks_new_seats_after_realdb():
+    """⛔AC⑤ 핵심 — 선생님 확定: 취소는 좌석 초과를 이유로 거부되면 안 된다(해지 방해
+    금지). free 포함좌석(3석)을 초과하는 6명 org가 취소하면 sweep이 그대로 free 전이를
+    실행(자동 취소 아님)하고, 기존 멤버는 그대로 유지되며, 전이 後 신규 초대만
+    check_member_invite_limit이 거부한다."""
+    from app.services.org_subscription_downgrade import cancel_subscription, sweep_pending_tier_downgrades
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            past_period_end = datetime.now(timezone.utc) - timedelta(hours=1)
+            await _seed_active_paid_subscription(session, org_id, tier="business", period_end=past_period_end)
+            for _ in range(6):
+                await _seed_human_member(session, org_id)
+
+            _free_id, free_included_seats = await _offering_id(session, "free")
+            assert 6 > free_included_seats, "이 테스트가 의미 있으려면 6명이 free 포함좌석을 초과해야 함"
+
+            await cancel_subscription(session, org_id=org_id)
+            result = await sweep_pending_tier_downgrades(session)
+
+            # 좌석 게이트 미적용 — 자동 취소 0건, 실제 free 전이 실행.
+            assert result["cancelled_seat_overage"] == 0
+            assert result["applied"] == 1
+            row = (
+                await session.execute(text("SELECT tier FROM org_subscriptions WHERE org_id=:oid"), {"oid": org_id})
+            ).first()
+            assert row.tier == "free"
+
+            # 기존 멤버는 그대로.
+            member_count = (
+                await session.execute(text("SELECT COUNT(*) FROM org_members WHERE org_id=:oid AND deleted_at IS NULL"), {"oid": org_id})
+            ).scalar_one()
+            assert member_count == 6, "기존 멤버 강제 제거 없음"
+
+            # 신규 좌석 추가만 차단 — check_member_invite_limit이 자연히 막는다(재구현 0).
+            from fastapi import HTTPException
+
+            from ee.plan_limits import check_member_invite_limit
+
+            with pytest.raises(HTTPException) as exc_info:
+                await check_member_invite_limit(session, org_id)
+            assert exc_info.value.status_code == 402
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_downgrade_and_cancel_share_single_slot_last_wins_realdb():
+    """⑥ — 하향 예약 후 취소하면(또는 그 반대) 같은 pending_* 슬롯을 덮어쓴다 — 새
+    개념 발명 없이 #2881의 «재예약=덮어씀» 정책 그대로."""
+    from app.services.org_subscription_downgrade import cancel_subscription, reserve_downgrade
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            await _seed_active_paid_subscription(session, org_id, tier="business")
+
+            await reserve_downgrade(session, org_id=org_id, new_tier="starter")
+            sub = await cancel_subscription(session, org_id=org_id)
+            assert sub.pending_tier == "free", "취소가 이전 하향 예약을 덮어써야 함"
+
+            sub2 = await reserve_downgrade(session, org_id=org_id, new_tier="team")
+            assert sub2.pending_tier == "team", "재하향이 이전 취소 예약을 덮어써야 함"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
[SID:2882]

## Summary
v2.1 §12(pricing-policy-proposal-v1) 「월간 구독 취소: 현재 기간 말까지 사용, 다음 갱신 중지, 부분 환불 없음」 구현. base=`feat/2881-downgrade-reservation-seat-gate`(pending_tier/pending_offering_version_id/pending_change_apply_at 슬롯·`sweep_pending_tier_downgrades` 재사용이 전제라 스택).

- `cancel_subscription()` — 「tier=free로의 하향」으로 취급, 같은 pending_* 슬롯에 예약. 새 컬럼·새 sweep 없음.
- `reserve_downgrade`/`cancel_pending_downgrade`는 무수정 — 같은 슬롯을 공유(재예약=덮어씀, 하향↔취소 양방향).
- **⛔올리베이라군 판정으로 #2881과 결정적으로 다른 지점**: 취소는 좌석 게이트를 타지 않음. 하향은 「선택」이라 조건 미충족 시 거부 가능하지만, 취소는 「해지 의사」라 좌석 초과를 이유로 거부하면 사용자가 결제를 못 끊는 상태가 됨(해지 방해 — 소비자 보호·심사 리스크). free 전이는 좌석 초과 상태여도 그대로 실행, 기존 멤버는 제거 안 함, 신규 좌석 추가만 기존 `ee/plan_limits.check_member_invite_limit`(무수정)이 자연히 막음(#2906 storage=신규 업로드만 차단과 같은 판별).
- 라우터: `POST/DELETE /api/v2/org-subscriptions/cancel` — DELETE는 `cancel_pending_downgrade` 직접 재사용(pending_* 클리어는 하향이든 취소든 동일).
- 월납만(연납은 §12 별도 환불식 필요 — #2880/#2881과 동일 선례로 미착수).

## Test plan
- [x] 신규 6건(`test_2882_subscription_cancellation_realdb.py`): 즉시전이없음·비유료구독거부·철회·sweep 실전이(billing_cycle/period 클리어)·**좌석초과에도 취소 실행+신규초대만 차단(핵심, load-bearing 증명 포함)**·하향↔취소 슬롯 공유.
- [x] 회귀: test_2881(9)·test_2880·test_e_2506(체크아웃 전체)·test_authz_project_scope_coverage — 60 tests, 프레시 PG green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
