### PR TITLE
[SID:2905] S2c③④ 임베드 그룹핑 — 캐러셀·간결 리스트·gate 접힘

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1536,8 +1536,16 @@ describe('ChatBubble — story #2671 EmbedCard 단독 참조 문단 카드 렌�
 // 렌더 경로) 회귀 반경이 넓다. 시안(유나양) 착지 전까지 지금 "그룹핑 미착수" 상태의 실제
 // 동작을 characterization test로 고정해 둔다 — ③④ 구현 시 이 스위트가 "의도한 대로 바뀐
 // 지점"과 "실수로 깨진 지점"을 가른다.
-describe('ChatBubble — story #2905 S2c③④ 착수 전 다중 sole-link 문단 베이스라인(그룹핑 미착수 상태 고정)', () => {
-  it('연속된 같은 타입(story) sole-link 문단 2개 — 오늘은 그룹핑 없이 EmbedCard 2장이 각자 독립 렌더된다', async () => {
+// story #2905 S2c③④(#3310 베이스라인 → 그룹핑 착지 후 rebase, 2026-08-22) — 이 스위트가
+// «오늘은 그룹핑 없음»으로 고정해 둔 4건 중 2건(같은 타입 연속)의 기대값이 실제로 뒤집혔다.
+// 페드루 지시: 그 뒤집힘이 diff에 명시적으로 드러나야 이 그물의 원 설계 취지(#3310의
+// "③④ 구현 시 이 스위트가 의도한 변경과 실수를 가른다")가 선다 — .rounded-md 카운트만
+// 보는 낡은 단언은 EmbedGroup(ConciseList/ArtifactCarousel)이 내부적으로도 EmbedCard를
+// 재사용하는 바람에 숫자가 우연히 그대로 맞아 "말없이 통과"할 뻔했다(실측으로 확認) — 그룹
+// wrapper(.space-y-1.5·overflow-x-auto) 존재 여부로 뮤테이션 감지력을 되살린다. 그대로 남는
+// 2건(다른 타입 섞임·산문 단절)은 §3 delta의 두 불변식을 재확認하는 자리로 성격이 바뀐다.
+describe('ChatBubble — story #2905 S2c③④ 다중 sole-link 문단(그룹핑 착지 후, #3310 베이스라인 뒤집힘 명시)', () => {
+  it('연속된 같은 타입(story) sole-link 문단 2개 — 이제 EmbedGroup(간결 리스트)으로 묶여 렌더된다(베이스라인 뒤집힘)', async () => {
     const idA = '55555555-5555-5555-5555-555555555551';
     const idB = '55555555-5555-5555-5555-555555555552';
     await act(async () => {
@@ -1552,15 +1560,18 @@ describe('ChatBubble — story #2905 S2c③④ 착수 전 다중 sole-link 문�
         />,
       ));
     });
+    // 간결 리스트 그룹 wrapper(embed-group.tsx ConciseList)가 정확히 1개 — 개별 <p> 2개로
+    // 흩어지지 않고 하나의 그룹으로 묶였다는 것 자체가 이 테스트의 요지.
+    expect(container.querySelectorAll('.space-y-1\\.5')).toHaveLength(1);
     const cards = container.querySelectorAll('.rounded-md');
     expect(cards).toHaveLength(2);
     expect(container.textContent).toContain('스토리 A');
     expect(container.textContent).toContain('스토리 B');
-    // 렌더 순서=본문 순서(캐러셀/리스트로 바뀌면 이 DOM 순서 단언부터 깨질 것 — 의도된 변경).
+    // 그룹 안에서도 렌더 순서=본문 순서는 유지된다.
     expect(container.textContent!.indexOf('스토리 A')).toBeLessThan(container.textContent!.indexOf('스토리 B'));
   });
 
-  it('연속된 서로 다른 타입(doc·story) sole-link 문단 2개도 오늘은 각자 독립 렌더된다', async () => {
+  it('연속된 서로 다른 타입(doc·story) sole-link 문단 2개 — §3 delta 「타입별 서브그룹」 불변식대로 여전히 각자 독립 렌더된다(그룹 대상 아님)', async () => {
     const docId = DOC_ID;
     const storyId = '55555555-5555-5555-5555-555555555553';
     await act(async () => {
@@ -1578,9 +1589,11 @@ describe('ChatBubble — story #2905 S2c③④ 착수 전 다중 sole-link 문�
     expect(container.querySelectorAll('.rounded-md')).toHaveLength(2);
     // doc 전용 마커(미리보기 버튼)가 정확히 doc 카드에만 붙는다 — 타입별 폼이 안 섞였는지.
     expect(container.querySelectorAll('button[aria-label="미리보기"]')).toHaveLength(1);
+    // 그룹 조건(같은 타입+2개↑)을 각자 1개씩만 채워 미달 — EmbedGroup wrapper가 안 생긴다.
+    expect(container.querySelectorAll('.space-y-1\\.5')).toHaveLength(0);
   });
 
-  it('산문으로 떨어진(연속 아닌) 같은 타입 sole-link 문단 2개 — 오늘도 앞으로도 그룹핑 대상 아님(각자 독립)', async () => {
+  it('산문으로 떨어진(연속 아닌) 같은 타입 sole-link 문단 2개 — §3 delta 「산문 문단만 run을 끊는다」 불변식대로 오늘도 앞으로도 그룹핑 영구 비대상(각자 독립)', async () => {
     const idA = '55555555-5555-5555-5555-555555555554';
     const idB = '55555555-5555-5555-5555-555555555555';
     await act(async () => {
@@ -1597,9 +1610,11 @@ describe('ChatBubble — story #2905 S2c③④ 착수 전 다중 sole-link 문�
     });
     expect(container.querySelectorAll('.rounded-md')).toHaveLength(2);
     expect(container.textContent).toContain('중간에 낀 산문 한 줄.');
+    // 산문이 run을 끊어 그룹 wrapper 자체가 안 생긴다(공백줄과 달리 산문은 진짜 단절).
+    expect(container.querySelectorAll('.space-y-1\\.5')).toHaveLength(0);
   });
 
-  it('sole-link 문단 3개 연속(artifact) — 오늘은 캐러셀/격납 없이 3장 전부 개별 렌더(카드 홍수 베이스라인)', async () => {
+  it('sole-link 문단 3개 연속(artifact) — 이제 가로 캐러셀(overflow-x-auto)로 격납돼 렌더된다(카드 홍수 베이스라인 뒤집힘)', async () => {
     const ids = ['66666666-6666-6666-6666-666666666661', '66666666-6666-6666-6666-666666666662', '66666666-6666-6666-6666-666666666663'];
     await act(async () => {
       root.render(wrap(
@@ -1614,6 +1629,10 @@ describe('ChatBubble — story #2905 S2c③④ 착수 전 다중 sole-link 문�
       ));
       await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
     });
+    // 캐러셀 wrapper(embed-group.tsx ArtifactCarousel)가 정확히 1개 — 3장이 세로로 벽처럼
+    // 흩어지지 않고 가로 스크롤 한 자리로 격납됐다는 것 자체가 이 테스트의 요지(§3 「풍부
+    // 하되 격납」 불변식).
+    expect(container.querySelectorAll('.overflow-x-auto')).toHaveLength(1);
     expect(container.querySelectorAll('.rounded-md')).toHaveLength(3);
   });
 });

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -29,6 +29,8 @@ import { HitlApprovalCard, type HitlAnswer } from './hitl-approval-card';
 import { ApprovalRequestCard } from './approval-request-card';
 import { EventBlockCard } from './event-block-card';
 import { parseBlockTemplate, type EventDefinitionSummary } from '@/lib/block-template';
+import { segmentMessageContent } from './message-segments';
+import { EmbedGroup } from './embed-group';
 
 interface ChatBubbleProps {
   message: ChatMessage;
@@ -307,16 +309,38 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenRe
 
   const prepared = hasMention ? prepareMentions(content) : content;
 
+  // story #2905(S2c③④) — 렌더 전에 메시지를 세그먼트로 미리 쪼갠다(§3 delta 「연속 판별」).
+  // 산문/단건 sole-link 세그먼트는 원문 그대로 기존 단일 ReactMarkdown 경로(components 재사용,
+  // 회귀 0)로 흘러가고, 2개↑ 연속 sole-link 세그먼트만 EmbedGroup(캐러셀/간결 리스트/gate
+  // 접힘)으로 대체된다. references(유령·asset 판정)는 그룹 판별에도 같은 SSOT를 쓴다
+  // (message-segments.ts가 resolveEmbedDecision을 직접 호출).
+  const segments = segmentMessageContent(prepared, references);
+
   return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkBreaks]}
-      urlTransform={(url) =>
-        url.startsWith('entity:') || url.startsWith('mention:') ? url : defaultUrlTransform(url)
-      }
-      components={components}
-    >
-      {prepared}
-    </ReactMarkdown>
+    <>
+      {segments.map((seg, idx) =>
+        seg.kind === 'group' ? (
+          <EmbedGroup
+            key={idx}
+            entityType={seg.entityType}
+            refs={seg.refs}
+            onOpenReadingPanel={onOpenReadingPanel}
+            eventDefinitionsByKey={eventDefinitionsByKey}
+          />
+        ) : (
+          <ReactMarkdown
+            key={idx}
+            remarkPlugins={[remarkGfm, remarkBreaks]}
+            urlTransform={(url) =>
+              url.startsWith('entity:') || url.startsWith('mention:') ? url : defaultUrlTransform(url)
+            }
+            components={components}
+          >
+            {seg.text}
+          </ReactMarkdown>
+        ),
+      )}
+    </>
   );
 }
 

--- a/apps/web/src/components/chat/embed-group.test.tsx
+++ b/apps/web/src/components/chat/embed-group.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+//
+// story #2905(S2c③④) — EmbedGroup 렌더 회귀가드. delta 시안 §② collapsed/expanded 픽셀
+// 대신(HTML 아티팩트 대조는 별건) 구조/문구/카운트 정확성만 잰다: 간결 리스트 3행+더보기·
+// gate 헤더 정직 라벨(pending만 vs 「N·대기 M」)·caroulsel(artifact) 항목 수.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { EmbedGroup } from './embed-group';
+import type { GateItem } from '@/components/kanban/types';
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => ({ projectMemberships: [] }),
+}));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: () => {} }) }));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function gate(overrides: Partial<GateItem> = {}): GateItem {
+  return {
+    id: 'g-1', org_id: 'org-1', work_item_id: 'w-1', work_item_type: 'story',
+    gate_type: 'merge_gate', status: 'pending', resolver_id: null, resolved_at: null,
+    resolution_note: null, neutral_facts: null, created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(), can_approve: true, risk_grade: 'low',
+    work_item_summary: { title: '스토리 제목', slug: null },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+const REFS_3 = [
+  { entityId: 's-1', label: '스토리 하나' },
+  { entityId: 's-2', label: '스토리 둘' },
+  { entityId: 's-3', label: '스토리 셋' },
+];
+const REFS_5 = [...REFS_3, { entityId: 's-4', label: '스토리 넷' }, { entityId: 's-5', label: '스토리 다섯' }];
+
+describe('EmbedGroup — 간결 리스트(story 등 텍스트류)', () => {
+  it('3개 이하면 더보기 버튼 없이 전부 보인다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({}) })));
+    await act(async () => {
+      root.render(<EmbedGroup entityType="story" refs={REFS_3} />);
+    });
+    expect(container.textContent).toContain('스토리 하나');
+    expect(container.textContent).toContain('스토리 셋');
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent?.includes('더보기'))).toBe(false);
+  });
+
+  it('5개면 기본 3행만 보이고 「+2 더보기」가 뜬다 — 클릭하면 전체+「접기」로 바뀐다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({}) })));
+    await act(async () => {
+      root.render(<EmbedGroup entityType="story" refs={REFS_5} />);
+    });
+    expect(container.textContent).toContain('스토리 하나');
+    expect(container.textContent).toContain('스토리 셋');
+    expect(container.textContent).not.toContain('스토리 넷');
+    const moreBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '+2 더보기');
+    expect(moreBtn).toBeTruthy();
+    await act(async () => { moreBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.textContent).toContain('스토리 넷');
+    expect(container.textContent).toContain('스토리 다섯');
+    expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === '접기')).toBe(true);
+  });
+});
+
+describe('EmbedGroup — artifact 캐러셀', () => {
+  it('artifact 타입은 가로 스크롤 컨테이너(overflow-x-auto)로 항목 수만큼 렌더된다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({}) })));
+    const refs = [{ entityId: 'a-1', label: '목업 하나' }, { entityId: 'a-2', label: '목업 둘' }];
+    await act(async () => {
+      root.render(<EmbedGroup entityType="artifact" refs={refs} />);
+    });
+    const scroller = container.querySelector('.overflow-x-auto');
+    expect(scroller).toBeTruthy();
+    expect(container.textContent).toContain('목업 하나');
+    expect(container.textContent).toContain('목업 둘');
+  });
+});
+
+describe('EmbedGroup — gate 그룹(collapsed/expanded + 헤더 라벨 정직성)', () => {
+  it('전부 pending — 「결재 대기 N건」으로 접힌 채 시작한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/gates/')) return { ok: true, json: async () => ({ data: gate({ status: 'pending' }) }) };
+      return { ok: true, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(<EmbedGroup entityType="gate" refs={[{ entityId: 'g-1', label: 'G1' }, { entityId: 'g-2', label: 'G2' }]} />);
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain('결재 대기 2건');
+    // 접힌 상태 — ApprovalRequestCard(개별 gate fetch로 제목 등을 그리는 카드)의 몸통이 아직 안 보인다.
+    expect(container.querySelector('[data-slot="dialog-content"]')).toBeNull();
+  });
+
+  it('pending/resolved 섞이면 「결재 N건 · 대기 M건」으로 정직하게 요약한다(pending만 세지 않는다)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/gates/g-1')) return { ok: true, json: async () => ({ data: gate({ id: 'g-1', status: 'pending' }) }) };
+      if (url.includes('/api/gates/g-2')) return { ok: true, json: async () => ({ data: gate({ id: 'g-2', status: 'approved' }) }) };
+      return { ok: true, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(<EmbedGroup entityType="gate" refs={[{ entityId: 'g-1', label: 'G1' }, { entityId: 'g-2', label: 'G2' }]} />);
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain('결재 2건 · 대기 1건');
+    expect(container.textContent).not.toContain('결재 대기 2건');
+  });
+
+  it('헤더 클릭 시 펼쳐져 각 gate가 ApprovalRequestCard(제목 텍스트)로 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/gates/g-1')) return { ok: true, json: async () => ({ data: gate({ id: 'g-1', status: 'pending', work_item_summary: { title: '게이트 하나', slug: null } }) }) };
+      if (url.includes('/api/gates/g-2')) return { ok: true, json: async () => ({ data: gate({ id: 'g-2', status: 'pending', work_item_summary: { title: '게이트 둘', slug: null } }) }) };
+      return { ok: true, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <EmbedGroup entityType="gate" refs={[{ entityId: 'g-1', label: 'G1' }, { entityId: 'g-2', label: 'G2' }]} />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const headerBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('결재 대기 2건'));
+    expect(headerBtn).toBeTruthy();
+    await act(async () => { headerBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain('게이트 하나');
+    expect(container.textContent).toContain('게이트 둘');
+  });
+});

--- a/apps/web/src/components/chat/embed-group.tsx
+++ b/apps/web/src/components/chat/embed-group.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ChevronDown, ChevronUp, ShieldCheck } from 'lucide-react';
+import { EmbedCard } from './embed-card';
+import { ApprovalRequestCard } from './approval-request-card';
+import type { GateItem } from '@/components/kanban/types';
+import { fetchWithAuth } from '@/lib/db/client';
+import type { ReadingPanelTarget } from './reading-panel';
+import type { EventDefinitionSummary } from '@/lib/block-template';
+
+// story #2905(S2c③④) — delta 시안(`s2c-delta-grouping-states`) §② collapsed/expanded 상태.
+// «풍부하되 격납» 불변식 재확認: 여럿=격납이 default, 헤더가 개수/성격 요약, 펼침은 사용자 액션.
+const LIST_DEFAULT_VISIBLE = 3;
+
+export interface EmbedGroupProps {
+  entityType: string;
+  refs: Array<{ entityId: string; label: string }>;
+  onOpenReadingPanel?: (target: ReadingPanelTarget) => void;
+  eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
+}
+
+/**
+ * gate 그룹 — 접힘 기본 「결재 대기 N건」(세로 벽 방지) → 펼치면 각 gate =
+ * ApprovalRequestCard(§②·원탭+마찰, 사본 분화 금지 재사용). **헤더 라벨 정직성**(delta §②
+ * ⚠️): pending/resolved 섞이면 N은 pending만 세지 않고 「결재 N건 · 대기 M건」으로 전체와
+ * 대기를 함께 밝힌다 — 거짓 라벨(오래된 대기 수 방치) 금지.
+ */
+function GateGroup({ refs, eventDefinitionsByKey }: { refs: EmbedGroupProps['refs']; eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null }) {
+  const [expanded, setExpanded] = useState(false);
+  const [statuses, setStatuses] = useState<Record<string, string> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const entries = await Promise.all(
+        refs.map(async (r) => {
+          try {
+            const res = await fetchWithAuth(`/api/gates/${r.entityId}`);
+            if (!res.ok) return [r.entityId, null] as const;
+            const json = (await res.json().catch(() => null)) as { data?: GateItem } | GateItem | null;
+            const gate = (json && 'data' in json ? json.data : json) as GateItem | undefined;
+            return [r.entityId, gate?.status ?? null] as const;
+          } catch {
+            return [r.entityId, null] as const;
+          }
+        }),
+      );
+      if (!cancelled) {
+        setStatuses(Object.fromEntries(entries.filter(([, s]) => s !== null)) as Record<string, string>);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [refs]);
+
+  const total = refs.length;
+  const known = statuses ? Object.values(statuses) : [];
+  const pendingCount = known.filter((s) => s === 'pending').length;
+  // fetch 완료 전(statuses===null)이거나 일부만 확認됐으면 "결재 대기"로 단정하지 않는다 —
+  // 아직 모르는 걸 안다고 말하지 않는다(정직 라벨 원칙, [[feedback-verify-claim-needs-exact-command]]와 같은 결).
+  const headerLabel = statuses === null
+    ? `게이트 ${total}건`
+    : pendingCount === total
+      ? `결재 대기 ${pendingCount}건`
+      : `결재 ${total}건 · 대기 ${pendingCount}건`;
+
+  return (
+    <div className="rounded-lg border border-border bg-muted/20">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm font-medium text-foreground transition hover:bg-muted/40"
+      >
+        <ShieldCheck className="size-4 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate">{headerLabel}</span>
+        {expanded ? <ChevronUp className="size-4 shrink-0 text-muted-foreground" /> : <ChevronDown className="size-4 shrink-0 text-muted-foreground" />}
+      </button>
+      {expanded && (
+        <div className="space-y-2 border-t border-border p-2">
+          {refs.map((r) => (
+            <ApprovalRequestCard
+              key={r.entityId}
+              target={{ work_item_type: '', work_item_id: '', gate_id: r.entityId }}
+              eventDefinitionsByKey={eventDefinitionsByKey}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** artifact 그룹 — «가로 슬라이드 캐러셀»(§3 표: 썸네일/미리보기가 값을 갖는 여럿). 각 항목은
+ * EmbedCard(artifact)를 그대로 재사용(S2c① 실 렌더 인라인 로직·사본 0) — 고정폭 열로 늘어놓고
+ * overflow-x-auto로 스크롤(1스크린 자연 노출 + 나머지는 옆으로). */
+// EmbedCard는 (entityType, entityId, title, status, href) 5-인자 위치 시그니처를 받는다
+// (기존 EmbedCard 계약, 변경 없음) — chat-bubble.tsx의 `p` 핸들러가 이미 쓰는 것과 동일한
+// object(ReadingPanelTarget)→5-인자 어댑터를 여기서도 그대로 재사용(사본 아님, 같은 변환 로직).
+type EmbedCardOpenPanel = (entityType: string, entityId: string, title: string | null, status: string | null, href: string | null) => void;
+function toEmbedCardOpenPanel(onOpenReadingPanel?: EmbedGroupProps['onOpenReadingPanel']): EmbedCardOpenPanel | undefined {
+  if (!onOpenReadingPanel) return undefined;
+  return (entityType, entityId, title, status, href) =>
+    onOpenReadingPanel({ kind: 'entity', entityType, entityId, title, status, href });
+}
+
+function ArtifactCarousel({ refs, onOpenReadingPanel }: { refs: EmbedGroupProps['refs']; onOpenReadingPanel?: EmbedGroupProps['onOpenReadingPanel'] }) {
+  const openPanel = toEmbedCardOpenPanel(onOpenReadingPanel);
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-1">
+      {refs.map((r) => (
+        <div key={r.entityId} className="w-40 shrink-0">
+          <EmbedCard entity_type="artifact" entity_id={r.entityId} title={r.label} status={null} onOpenReadingPanel={openPanel} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** 텍스트류(story/task/doc/epic/sprint/hypothesis/evidence) — «간결 리스트»(§3 표: 상태·시각
+ * 약한 텍스트 레코드 여럿). default 3행 + 「+N 더보기」 → 펼치면 전체 + 「접기」. 각 행은
+ * EmbedCard(비-artifact 폼 = 아이콘+라벨+상태 압축 pill)를 그대로 재사용. */
+function ConciseList({ entityType, refs, onOpenReadingPanel }: { entityType: string; refs: EmbedGroupProps['refs']; onOpenReadingPanel?: EmbedGroupProps['onOpenReadingPanel'] }) {
+  const [expanded, setExpanded] = useState(false);
+  const visible = expanded ? refs : refs.slice(0, LIST_DEFAULT_VISIBLE);
+  const hiddenCount = refs.length - LIST_DEFAULT_VISIBLE;
+  const openPanel = toEmbedCardOpenPanel(onOpenReadingPanel);
+
+  return (
+    <div className="space-y-1.5">
+      {visible.map((r) => (
+        <EmbedCard key={r.entityId} entity_type={entityType} entity_id={r.entityId} title={r.label} status={null} onOpenReadingPanel={openPanel} />
+      ))}
+      {hiddenCount > 0 && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="text-xs font-medium text-primary hover:underline"
+        >
+          {expanded ? '접기' : `+${hiddenCount} 더보기`}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function EmbedGroup({ entityType, refs, onOpenReadingPanel, eventDefinitionsByKey }: EmbedGroupProps) {
+  if (entityType === 'gate') return <GateGroup refs={refs} eventDefinitionsByKey={eventDefinitionsByKey} />;
+  if (entityType === 'artifact') return <ArtifactCarousel refs={refs} onOpenReadingPanel={onOpenReadingPanel} />;
+  return <ConciseList entityType={entityType} refs={refs} onOpenReadingPanel={onOpenReadingPanel} />;
+}

--- a/apps/web/src/components/chat/message-segments.test.ts
+++ b/apps/web/src/components/chat/message-segments.test.ts
@@ -1,0 +1,123 @@
+// story #2905(S2c③④) — 세그먼트 판별 순수 로직 단위 테스트. delta 시안(`s2c-delta-grouping-
+// states`) §① 규칙 전수 — 그룹 조건(같은 타입+sole-link+2개↑+사이 산문 없음)·공백줄 예외·
+// 산문 단절·타입별 서브그룹. entity ref 파싱(entity-ref.ts)이 id를 UUID로만 받아들이므로
+// (비-UUID는 매칭 실패→평문 폴백) 픽스처 id는 전부 유효한 UUID로 둔다.
+import { describe, expect, it } from 'vitest';
+import { segmentMessageContent } from './message-segments';
+
+const S1 = '11111111-1111-1111-1111-111111111111';
+const S2 = '22222222-2222-2222-2222-222222222222';
+const S3 = '33333333-3333-3333-3333-333333333333';
+const D1 = '44444444-4444-4444-4444-444444444444';
+const D2 = '55555555-5555-5555-5555-555555555555';
+const G1 = '66666666-6666-6666-6666-666666666666';
+const G2 = '77777777-7777-7777-7777-777777777777';
+const A1 = '88888888-8888-8888-8888-888888888888';
+const A2 = '99999999-9999-9999-9999-999999999999';
+const GHOST1 = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const GHOST2 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const AS1 = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const AS2 = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+
+const REFS_ALL_OBSERVED = [
+  { target_type: 'story', target_id: S1 },
+  { target_type: 'story', target_id: S2 },
+  { target_type: 'story', target_id: S3 },
+  { target_type: 'doc', target_id: D1 },
+  { target_type: 'doc', target_id: D2 },
+  { target_type: 'gate', target_id: G1 },
+  { target_type: 'gate', target_id: G2 },
+  { target_type: 'artifact', target_id: A1 },
+  { target_type: 'artifact', target_id: A2 },
+];
+
+function link(type: string, id: string, label = id) {
+  return `[${label}](entity:${type}:${id})`;
+}
+
+describe('segmentMessageContent — 그룹 조건', () => {
+  it('같은 타입 sole-link 2개(공백줄 하나로만 분리) — 그룹 세그먼트 1개', () => {
+    const content = `${link('story', S1)}\n\n${link('story', S2)}`;
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([{ kind: 'group', entityType: 'story', refs: [{ entityId: S1, label: S1 }, { entityId: S2, label: S2 }] }]);
+  });
+
+  it('같은 타입 sole-link 1개뿐 — 그룹 아님(텍스트 세그먼트로 남는다)', () => {
+    const content = link('story', S1);
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([{ kind: 'text', text: content }]);
+  });
+
+  it('여분의 공백줄(3줄 이상)도 여전히 연속 — run이 안 끊긴다', () => {
+    const content = `${link('story', S1)}\n\n\n\n${link('story', S2)}`;
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([{ kind: 'group', entityType: 'story', refs: [{ entityId: S1, label: S1 }, { entityId: S2, label: S2 }] }]);
+  });
+
+  it('사이에 산문 문단이 끼면 run이 끊긴다 — 각자 단건(비그룹) 텍스트 세그먼트', () => {
+    const content = `${link('story', S1)}\n\n이건 산문이다\n\n${link('story', S2)}`;
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([{ kind: 'text', text: content }]);
+  });
+
+  it('다른 타입 섞인 연속 sole-link — 타입별 서브그룹 2개로 갈린다', () => {
+    const content = `${link('story', S1)}\n\n${link('story', S2)}\n\n${link('doc', D1)}\n\n${link('doc', D2)}`;
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([
+      { kind: 'group', entityType: 'story', refs: [{ entityId: S1, label: S1 }, { entityId: S2, label: S2 }] },
+      { kind: 'group', entityType: 'doc', refs: [{ entityId: D1, label: D1 }, { entityId: D2, label: D2 }] },
+    ]);
+  });
+
+  it('산문 속 인라인 참조(문단에 다른 텍스트 있음) — sole-link 아니라 그룹 대상 아님', () => {
+    const content = `앞에 ${link('story', S1)} 뒤에도 텍스트\n\n${link('story', S2)}`;
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([{ kind: 'text', text: content }]);
+  });
+
+  it('gate 2개 연속 — gate 그룹 세그먼트', () => {
+    const content = `${link('gate', G1)}\n\n${link('gate', G2)}`;
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([{ kind: 'group', entityType: 'gate', refs: [{ entityId: G1, label: G1 }, { entityId: G2, label: G2 }] }]);
+  });
+
+  it('artifact 2개 연속 — artifact 그룹 세그먼트', () => {
+    const content = `${link('artifact', A1)}\n\n${link('artifact', A2)}`;
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([{ kind: 'group', entityType: 'artifact', refs: [{ entityId: A1, label: A1 }, { entityId: A2, label: A2 }] }]);
+  });
+
+  it('유령 참조(stored references에 없음) sole-link 2개 — 카드 판정 자체가 아니므로 그룹 대상 아님', () => {
+    const content = `${link('story', GHOST1)}\n\n${link('story', GHOST2)}`;
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([{ kind: 'text', text: content }]);
+  });
+
+  it('references === undefined(판단 재료 없음) — 유령 판정 보류라 sole-link 카드로 정상 그룹', () => {
+    const content = `${link('story', S1)}\n\n${link('story', S2)}`;
+    const segs = segmentMessageContent(content, undefined);
+    expect(segs).toEqual([{ kind: 'group', entityType: 'story', refs: [{ entityId: S1, label: S1 }, { entityId: S2, label: S2 }] }]);
+  });
+
+  it('asset 타입 sole-link 2개 — asset은 카드가 아니라(§EmbedRenderer) 그룹 대상 아님', () => {
+    const content = `${link('asset', AS1)}\n\n${link('asset', AS2)}`;
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([{ kind: 'text', text: content }]);
+  });
+
+  it('3개 연속 + 앞뒤 산문 — 산문은 별도 텍스트 세그먼트, 중간만 그룹', () => {
+    const content = `머리말\n\n${link('story', S1)}\n\n${link('story', S2)}\n\n${link('story', S3)}\n\n꼬리말`;
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([
+      { kind: 'text', text: '머리말' },
+      { kind: 'group', entityType: 'story', refs: [{ entityId: S1, label: S1 }, { entityId: S2, label: S2 }, { entityId: S3, label: S3 }] },
+      { kind: 'text', text: '꼬리말' },
+    ]);
+  });
+
+  it('라벨이 링크 텍스트와 다른 경우(제목 붙은 참조) — refs.label에 그 라벨이 실린다', () => {
+    const content = `${link('story', S1, '스토리 하나')}\n\n${link('story', S2, '스토리 둘')}`;
+    const segs = segmentMessageContent(content, REFS_ALL_OBSERVED);
+    expect(segs).toEqual([{ kind: 'group', entityType: 'story', refs: [{ entityId: S1, label: '스토리 하나' }, { entityId: S2, label: '스토리 둘' }] }]);
+  });
+});

--- a/apps/web/src/components/chat/message-segments.ts
+++ b/apps/web/src/components/chat/message-segments.ts
@@ -1,0 +1,93 @@
+import type { ChatMessage } from '@/hooks/use-chat-sse';
+import { parseEntityRef } from './entity-ref';
+import { resolveEmbedDecision } from './embed-renderer';
+
+export interface TextSegment {
+  kind: 'text';
+  text: string;
+}
+
+export interface GroupSegment {
+  kind: 'group';
+  entityType: string;
+  refs: Array<{ entityId: string; label: string }>;
+}
+
+export type MessageSegment = TextSegment | GroupSegment;
+
+const SOLE_LINK_BLOCK_RE = /^\[([^\]]*)\]\(([^)]+)\)$/;
+
+/**
+ * story #2905(S2c③④) — 메시지 content를 ChatMarkdown이 그리기 전에 미리 세그먼트로 쪼갠다.
+ * delta 시안(`s2c-delta-grouping-states`, PO 확定 2026-08-21) 규칙 그대로:
+ *
+ * 그룹 조건 = «같은 entity_type» + «sole-link(문단이 참조 하나뿐)» + «2개 이상» + «사이에
+ * 산문 없음». **공백줄(빈 문단)은 안 끊는다** — `\n{2,}`로 나눈 블록 중 빈 블록은 애초에
+ * 걸러지므로(filter) 공백줄만 사이에 낀 두 sole-link는 이 스캔에서 곧바로 이웃으로 보인다.
+ * 산문 문단만 run을 끊는다. 다른 타입이 섞인 연속 sole-link는 entityType 일치 조건 때문에
+ * 자연히 타입별 서브그룹으로 갈린다(별도 분기 불요).
+ *
+ * sole-link 판정 자체는 resolveEmbedDecision(allowCard:true)과 같은 SSOT — asset이나 유령
+ * 참조(§EmbedRenderer 계약상 'card'가 아닌 것)는 원래도 카드가 아니던 문단이라 그룹 대상도
+ * 아니다(그 문단은 그대로 일반 텍스트 세그먼트에 남아 기존 chip/asset 렌더로 떨어진다).
+ */
+export function segmentMessageContent(
+  content: string,
+  references: ChatMessage['references'],
+): MessageSegment[] {
+  const blocks = content.split(/\n{2,}/).filter((b) => b.trim().length > 0);
+
+  type Classified =
+    | { kind: 'prose'; raw: string }
+    | { kind: 'sole-link'; raw: string; entityType: string; entityId: string; label: string };
+
+  const classified: Classified[] = blocks.map((raw) => {
+    const trimmed = raw.trim();
+    const m = trimmed.match(SOLE_LINK_BLOCK_RE);
+    if (!m) return { kind: 'prose', raw };
+    const ref = parseEntityRef(m[2]);
+    if (!ref) return { kind: 'prose', raw };
+    const decision = resolveEmbedDecision(ref.entityType, ref.entityId, references, { allowCard: true });
+    if (decision.kind !== 'card') return { kind: 'prose', raw };
+    return { kind: 'sole-link', raw, entityType: ref.entityType, entityId: ref.entityId, label: m[1] || ref.entityId };
+  });
+
+  const segments: MessageSegment[] = [];
+  let textBuffer: string[] = [];
+  const flushText = () => {
+    if (textBuffer.length) {
+      segments.push({ kind: 'text', text: textBuffer.join('\n\n') });
+      textBuffer = [];
+    }
+  };
+
+  let i = 0;
+  while (i < classified.length) {
+    const c = classified[i]!;
+    if (c.kind === 'prose') {
+      textBuffer.push(c.raw);
+      i += 1;
+      continue;
+    }
+    let j = i + 1;
+    while (j < classified.length) {
+      const next = classified[j]!;
+      if (next.kind !== 'sole-link' || next.entityType !== c.entityType) break;
+      j += 1;
+    }
+    const run = classified.slice(i, j) as Extract<Classified, { kind: 'sole-link' }>[];
+    if (run.length >= 2) {
+      flushText();
+      segments.push({
+        kind: 'group',
+        entityType: c.entityType,
+        refs: run.map((r) => ({ entityId: r.entityId, label: r.label })),
+      });
+    } else {
+      textBuffer.push(c.raw);
+    }
+    i = j;
+  }
+  flushText();
+  return segments;
+}


### PR DESCRIPTION
## 변경 사항
delta 시안(`s2c-delta-grouping-states`, PO 확定 2026-08-21) §① 연속 판별 + §② collapsed/expanded 상태 구현.

- `message-segments.ts`: 메시지 content를 렌더 전 세그먼트로 분리 — 그룹 조건 = **같은 entity_type + sole-link(문단이 참조 하나뿐) + 2개 이상 + 사이에 산문 없음**. 공백줄만 사이는 연속(끊지 않음), 산문 문단만 run을 끊는다. 다른 타입 섞인 연속 sole-link는 entityType 서브그룹으로 자연히 갈린다. sole-link 카드 판정은 `resolveEmbedDecision`(allowCard:true)과 동일 SSOT — asset·유령 참조는 원래도 그룹 대상이 아니었다.
- `embed-group.tsx`:
  - **gate** → 접힘 헤더(default) — pending만이면 「결재 대기 N건」, pending/resolved 섞이면 「결재 N건 · 대기 M건」(거짓 라벨 금지, §② ⚠️ 규칙 그대로). 펼치면 각 gate = `ApprovalRequestCard`(S2c②·사본 분화 금지 재사용).
  - **artifact** → 가로 슬라이드 캐러셀(overflow-x-auto), 각 항목은 `EmbedCard`(S2c① 실 렌더 인라인 재사용).
  - **그 외(story/doc/epic/task/sprint/hypothesis/evidence)** → 간결 리스트, default 3행 + 「+N 더보기」 → 펼치면 전체 + 「접기」. 각 행은 `EmbedCard` 재사용.
- `chat-bubble.tsx`: `ChatMarkdown`이 세그먼트 배열을 순회 렌더 — 단건/산문 세그먼트는 원문 그대로 기존 단일 `ReactMarkdown` 경로(components 100% 재사용)로 흘러가고, 2개↑ 그룹 세그먼트만 `EmbedGroup`으로 대체된다.

## 셀프 게이트
- `pnpm build` — EXIT 0
- `pnpm lint` — EXIT 0, 신규 경고 0건(기존 5건은 미터치 파일)
- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm exec vitest run`(대상 3파일) — 108/108 pass, 기존 chat-bubble.test.tsx 회귀 0
- 대비 가드 6종(tint-foreground·no-new-tint-color-text·cross-element-tint-text·muted-foreground·no-muted-foreground-alpha·no-new-raw-fetch-api) — 전부 OK, 신규 위반 0건(신규 색 0·전부 fetchWithAuth)

## 반응형/스크린샷
텍스트/구조 위주 변경(그룹핑 로직+접힘/펼침 상태)이라 로컬 유닛 테스트로 구조·카운트·정직 라벨을 검증했습니다. 실 픽셀 검증은 dev 배포 후 라이브로 진행 예정(이번 세션 확립 규율).

## Test plan
- [x] 그룹 조건 전수(2개+·공백줄 연속·산문 단절·타입 섞임·유령·asset·라벨) — message-segments.test.ts
- [x] 간결 리스트 3행+더보기/접기 — embed-group.test.tsx
- [x] artifact 캐러셀 렌더 — embed-group.test.tsx
- [x] gate 헤더 라벨 정직성(전부 pending vs 섞임) + 펼침 시 ApprovalRequestCard 렌더 — embed-group.test.tsx
- [ ] dev 배포 후 실 픽셀(캐러셀 스크롤·gate 접힘/펼침 애니 없음 확認) — 배포 후 별도 보고

🤖 Generated with [Claude Code](https://claude.com/claude-code)