### PR TITLE
[SID:2911] S2e②③ FE — ThreadPanel 헤더 칩 브레드크럼 통일(R4 깊이 문법)

### DIFF
--- a/apps/web/src/components/chat/thread-panel.test.tsx
+++ b/apps/web/src/components/chat/thread-panel.test.tsx
@@ -160,3 +160,77 @@ describe('ThreadPanel — story #2911 좌측 rail(R4 위계 시각화)', () => {
     expect(container.textContent).toContain('답글 2(같은 발신자 — 그룹핑)');
   });
 });
+
+// story #2911(S2e②③/R4) — 「s2e-thread-depth-grammar」 확定 회귀가드. ThreadPanel 헤더가
+// ReadingPanel과 같은 칩 브레드크럼 문법(칩 버튼 + `›` 구분자)으로 통일됐는지, 세그먼트가
+// 정확히 2개(대화 › 원 메시지 요약)인지, 원 메시지 칩은 비클릭(span, 버튼 아님)인지 잰다.
+describe('ThreadPanel — story #2911(S2e②③) 헤더 칩 브레드크럼(대화 › 원 메시지 요약)', () => {
+  async function mountWithNoReplies() {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) })));
+    await act(async () => { root.render(wrap(<Harness />)); });
+    await flush();
+  }
+
+  it('「스레드」 평문 폐기 — 헤더에 그 문구가 없다', async () => {
+    await mountWithNoReplies();
+    const header = container.querySelector('.border-b.border-border\\/80');
+    expect(header?.textContent).not.toContain('스레드');
+  });
+
+  it('세그먼트 정확히 2개(대화·원 메시지 요약) — 구분자 `›`가 정확히 1개', async () => {
+    await mountWithNoReplies();
+    const header = container.querySelector('.border-b.border-border\\/80')!;
+    const seps = Array.from(header.querySelectorAll('span')).filter((s) => s.textContent === '›');
+    expect(seps).toHaveLength(1);
+    expect(header.textContent).toContain('대화');
+    expect(header.textContent).toContain('원본 메시지'); // parentMessage.content 그대로(마크다운 없음)
+  });
+
+  it('「대화」 칩은 버튼(클릭 시 onClose) — 원 메시지 요약 칩은 span(비클릭, 현재 위치)', async () => {
+    const onClose = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) })));
+    await act(async () => {
+      root.render(wrap(
+        <ThreadPanel parentMessage={parentMessage} conversationId="conv-1" currentTeamMemberId="member-1" projectId="proj-1" onClose={onClose} />,
+      ));
+    });
+    await flush();
+    const header = container.querySelector('.border-b.border-border\\/80')!;
+    const convChip = Array.from(header.querySelectorAll('button')).find((b) => b.textContent?.includes('대화'));
+    expect(convChip).toBeTruthy();
+    await act(async () => { convChip!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onClose).toHaveBeenCalled();
+    // 원 메시지 요약은 버튼이 아니라 span이어야(비클릭) 한다.
+    const summarySpan = Array.from(header.querySelectorAll('span')).find((s) => s.textContent?.includes('원본 메시지'));
+    expect(summarySpan?.tagName).toBe('SPAN');
+  });
+
+  it('원 메시지 요약 칩은 native title로 전문을 갖는다(truncate 대비 접근성 폴백)', async () => {
+    const longMessage: ChatMessage = { ...parentMessage, content: '이것은 아주 길어서 truncate가 실제로 적용될 만한 원본 메시지 본문입니다' };
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) })));
+    await act(async () => {
+      root.render(wrap(
+        <ThreadPanel parentMessage={longMessage} conversationId="conv-1" currentTeamMemberId="member-1" projectId="proj-1" onClose={() => {}} />,
+      ));
+    });
+    await flush();
+    const header = container.querySelector('.border-b.border-border\\/80')!;
+    const summarySpan = Array.from(header.querySelectorAll('span')).find((s) => s.getAttribute('title')?.includes('아주 길어서'));
+    expect(summarySpan).toBeTruthy();
+  });
+
+  it('원 메시지가 마크다운 링크(sole-link 등)면 요약 칩에는 라벨만 남는다(카드/칩 중첩 방지)', async () => {
+    const linkMessage: ChatMessage = { ...parentMessage, content: '[작업 A](entity:task:33333333-3333-3333-3333-333333333333)' };
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) })));
+    await act(async () => {
+      root.render(wrap(
+        <ThreadPanel parentMessage={linkMessage} conversationId="conv-1" currentTeamMemberId="member-1" projectId="proj-1" onClose={() => {}} />,
+      ));
+    });
+    await flush();
+    const header = container.querySelector('.border-b.border-border\\/80')!;
+    expect(header.textContent).toContain('작업 A');
+    expect(header.textContent).not.toContain('entity:task:');
+    expect(header.querySelector('button[type="button"]')).toBeTruthy(); // 대화 칩만 버튼(요약은 span)
+  });
+});

--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
-import { X } from 'lucide-react';
+import { ArrowLeft, MessageSquare, X } from 'lucide-react';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { normalizeToMessage } from '@/hooks/use-chat-sse';
 import { ChatBubble } from './chat-bubble';
@@ -16,6 +16,18 @@ import { fetchWithAuth } from '@/lib/db/client';
 // 렌더 새 배열을 만들면 useEntityStatusBatchFetch의 effect가 messages 변경으로 오인해
 // 매번 재실행된다 — 어차피 빈 배열이라 fetch는 안 나가지만 불필요한 재실행 자체를 막는다).
 const EMPTY_THREAD_MESSAGES: ChatMessage[] = [];
+
+// story #2911(S2e②③) — 헤더 칩의 "원 메시지 요약"은 순수 텍스트라야 한다(ChatBubble의 마크다운
+// 렌더 전체를 여기 또 태우면 칩 안에 카드/칩이 중첩되는 사고). 마크다운 링크 `[라벨](...)`는
+// 라벨만 남기고, 기본 강조 마커는 지운 뒤 공백을 접는다 — 시안이 요구하는 "≤15ch truncate"는
+// CSS(max-w+truncate, ReadingPanel과 동일 패턴)가 처리하므로 여기선 자르지 않는다.
+function plainPreview(content: string): string {
+  return content
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[*_`#]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 interface ThreadPanelProps {
   parentMessage: ChatMessage;
@@ -136,14 +148,41 @@ export function ThreadPanel({
 
   return (
     <div className="flex h-full flex-col overflow-hidden border-l border-border bg-background">
-      {/* Header */}
-      <div className="flex flex-shrink-0 items-center justify-between border-b border-border/80 px-4 py-2.5">
-        <span className="text-sm font-medium text-foreground">스레드</span>
+      {/* Header — story #2911(S2e②③/R4) 「s2e-thread-depth-grammar」 확定: ReadingPanel과
+          «같은 칩 브레드크럼» 문법(칩 버튼 + `›` text-border 구분자, 동일 토큰/스타일).
+          「스레드」 평문 폐기. 스레드는 단일 레벨이라 세그먼트는 정확히 2개 — [대화](뒤로
+          어포던스, 모바일 「← 대화」 텍스트 바를 이 칩이 대체) › [원 메시지 요약](스크롤로
+          pin이 밀려도 헤더에 «어느 스레드인지» 상시 유지, 현 위치라 비클릭·ReadingPanel의
+          최상단 세그먼트와 같은 문법). tint는 유나양 확定(2026-08-21) — chat_message는
+          의도적 무색(§2263 C-7)이고 메시지는 5계열 어느 의미도 아니라 둘 다 중립 muted bg
+          하나로 통일, 구분은 색이 아니라 아이콘+텍스트 weight로만(아래). */}
+      <div className="flex flex-shrink-0 items-center gap-1 overflow-x-auto border-b border-border/80 px-2 py-1.5">
+        {/* story #2911 — 유나양 확定(2026-08-21, C-7 논거: chat_message는 의도적 무색이고
+            메시지는 5계열 어느 «의미」도 아니라 없는 뜻을 억지로 안 붙인다): 둘 다 muted bg
+            하나로 통일, 구분은 색이 아니라 **아이콘+텍스트 weight**로만 — 「대화」=뒤로
+            어포던스(ArrowLeft)+text-muted-foreground, 원 메시지=현재 위치(MessageSquare)+
+            text-foreground font-medium. 신규 색 0. */}
         <button
           type="button"
           onClick={onClose}
-          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          className="flex shrink-0 items-center gap-1 rounded bg-muted px-1.5 py-1 text-xs text-muted-foreground transition hover:text-foreground"
+        >
+          <ArrowLeft className="size-3 shrink-0" />
+          <span>대화</span>
+        </button>
+        <span className="text-xs text-border">›</span>
+        <span
+          title={plainPreview(parentMessage.content)}
+          className="flex max-w-32 shrink items-center gap-1 rounded bg-muted px-1.5 py-1 text-xs font-medium text-foreground"
+        >
+          <MessageSquare className="size-3 shrink-0" />
+          <span className="truncate">{plainPreview(parentMessage.content)}</span>
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
           aria-label="스레드 닫기"
+          className="ml-auto shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
         >
           <X className="h-4 w-4" />
         </button>


### PR DESCRIPTION
## 변경 사항
delta 시안(`s2e-thread-depth-grammar`, 선생님 승인+PO PASS 2026-08-21) §5 부기 구현.

- ThreadPanel 헤더 「스레드」 평문 폐기 → **ReadingPanel과 같은 칩 브레드크럼 문법**(칩 버튼 + `›` text-border 구분자, 동일 토큰/스타일)으로 통일.
- 스레드는 단일 레벨이라 **세그먼트 정확히 2개**: `[대화]`(뒤로 어포던스, ArrowLeft 아이콘) › `[원 메시지 요약]`(현재 위치, MessageSquare 아이콘, ≤15ch truncate + native title, 비클릭).
- `대화` 칩 클릭 = 스레드 닫고 대화로 — 모바일 「← 대화」 텍스트 바를 이 칩이 대체(데스크톱·모바일 문법 통일).
- **tint**: 그라운딩 중 시안의 violet 데모 헥스와 「신규 색 0」 텍스트가 충돌해 PO 판정 요청 → 유나양 확定 — chat_message는 §2263(C-7)로 의도적 무색이고 메시지는 destructive/success/warning/info/accent-claim 5계열 어느 의미도 아니므로 **없는 뜻을 억지로 안 붙인다**: 두 칩 모두 muted bg 하나로 통일, 구분은 색이 아니라 **아이콘+텍스트 weight**로만(신규 색 0).
- 원 메시지가 마크다운 링크(sole-link 등)여도 요약 칩엔 `plainPreview()`로 라벨만 남는다(카드/칩 헤더 안 중첩).

## 셀프 게이트
- `pnpm build` — EXIT 0
- `pnpm lint`(대상 파일) — EXIT 0, 신규 경고 0건
- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm exec vitest run thread-panel.test.tsx` — 7/7 pass(기존 2건 회귀 0 + 신규 5건: 평문 폐기·세그먼트 2개·클릭성 구분·native title·마크다운 링크 라벨화)
- 대비 가드 5종(tint-foreground·no-new-tint-color-text·cross-element-tint-text·muted-foreground·no-muted-foreground-alpha) — 전부 OK, 신규 위반 0건(신규 색 0)

## 반응형/스크린샷
로컬 유닛 테스트로 구조·문구·클릭성을 검증했습니다. 실 픽셀(칩 truncate·좁은폭 줄바꿈)은 dev 배포 후 라이브로 진행 예정(이번 세션 확립 규율).

## Test plan
- [x] 「스레드」 평문 폐기
- [x] 세그먼트 정확히 2개(구분자 `›` 1개)
- [x] 대화=버튼(클릭→onClose) / 원 메시지=span(비클릭)
- [x] 원 메시지 칩 native title(truncate 대비)
- [x] 마크다운 링크 원 메시지 → 요약 칩엔 라벨만(카드/칩 중첩 방지)
- [x] 기존 rail(#3314)·배치조회(#2262) 회귀 0
- [ ] dev 배포 후 실 픽셀 확認 — 배포 후 별도 보고

🤖 Generated with [Claude Code](https://claude.com/claude-code)