### PR TITLE
[SID:2905] EmbedCard open-panel 어댑터 중복 제거 — 주석-실물 드리프트 해소

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -31,6 +31,7 @@ import { EventBlockCard } from './event-block-card';
 import { parseBlockTemplate, type EventDefinitionSummary } from '@/lib/block-template';
 import { segmentMessageContent } from './message-segments';
 import { EmbedGroup } from './embed-group';
+import { toEmbedCardOpenPanel } from './embed-card-open-panel-adapter';
 
 interface ChatBubbleProps {
   message: ChatMessage;
@@ -219,10 +220,10 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenRe
         // 있어 첫 자식만 읽으면 라벨이 잘린다. 전 자식을 이어붙인다(hastNodeText가
         // 재귀로 하듯 여기도 동일 패턴).
         const label = (link!.children ?? []).map(hastNodeText).join('') || ref.entityId;
-        const openReadingPanel = onOpenReadingPanel
-          ? (entityType: string, entityId: string, t: string | null, s: string | null, h: string | null) =>
-              onOpenReadingPanel({ kind: 'entity', entityType, entityId, title: t, status: s, href: h })
-          : undefined;
+        // object(ReadingPanelTarget)→5-인자 어댑터는 embed-card-open-panel-adapter.ts SSOT
+        // (embed-group.tsx의 캐러셀/간결 리스트와 진짜 같은 참조 — 카디르 QA #3319 지적으로
+        // 각자 로컬 구현하던 드리프트를 제거했다).
+        const openReadingPanel = toEmbedCardOpenPanel(onOpenReadingPanel);
         return <EmbedCard entity_type={ref.entityType} entity_id={ref.entityId} title={label} status={status} onOpenReadingPanel={openReadingPanel} />;
       }
       return <p className={`mb-1.5 [overflow-wrap:anywhere] text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>;

--- a/apps/web/src/components/chat/embed-card-open-panel-adapter.ts
+++ b/apps/web/src/components/chat/embed-card-open-panel-adapter.ts
@@ -1,0 +1,27 @@
+import type { ReadingPanelTarget } from './reading-panel';
+
+/**
+ * story #2905(S2c①/③④) — `EmbedCard.onOpenReadingPanel`은 (entityType, entityId, title,
+ * status, href) 5-인자 위치 시그니처를 받는다(기존 EmbedCard 계약, 변경 없음). 소비부
+ * (chat-bubble.tsx의 `p` 핸들러·embed-group.tsx의 캐러셀/간결 리스트)는 전부 object 기반
+ * `(target: ReadingPanelTarget) => void` 시그니처를 물고 있어 그 사이를 잇는 어댑터가 필요
+ * — 카디르 QA(#3319) 지적: 이전엔 이 변환을 두 파일이 각자 인라인/로컬 함수로 따로
+ * 구현하고 있었다(결과 동일·기능 위험 0였지만 "재사용"이라 적은 주석과 실물이 어긋났고,
+ * 한쪽만 고치면 드리프트할 위험이 있었다). 이 파일 하나로 수렴해 두 소비부가 **진짜 같은
+ * 참조**를 쓴다.
+ */
+export type EmbedCardOpenPanel = (
+  entityType: string,
+  entityId: string,
+  title: string | null,
+  status: string | null,
+  href: string | null,
+) => void;
+
+export function toEmbedCardOpenPanel(
+  onOpenReadingPanel?: (target: ReadingPanelTarget) => void,
+): EmbedCardOpenPanel | undefined {
+  if (!onOpenReadingPanel) return undefined;
+  return (entityType, entityId, title, status, href) =>
+    onOpenReadingPanel({ kind: 'entity', entityType, entityId, title, status, href });
+}

--- a/apps/web/src/components/chat/embed-group.tsx
+++ b/apps/web/src/components/chat/embed-group.tsx
@@ -8,6 +8,7 @@ import type { GateItem } from '@/components/kanban/types';
 import { fetchWithAuth } from '@/lib/db/client';
 import type { ReadingPanelTarget } from './reading-panel';
 import type { EventDefinitionSummary } from '@/lib/block-template';
+import { toEmbedCardOpenPanel } from './embed-card-open-panel-adapter';
 
 // story #2905(S2c③④) — delta 시안(`s2c-delta-grouping-states`) §② collapsed/expanded 상태.
 // «풍부하되 격납» 불변식 재확認: 여럿=격납이 default, 헤더가 개수/성격 요약, 펼침은 사용자 액션.
@@ -92,17 +93,9 @@ function GateGroup({ refs, eventDefinitionsByKey }: { refs: EmbedGroupProps['ref
 
 /** artifact 그룹 — «가로 슬라이드 캐러셀»(§3 표: 썸네일/미리보기가 값을 갖는 여럿). 각 항목은
  * EmbedCard(artifact)를 그대로 재사용(S2c① 실 렌더 인라인 로직·사본 0) — 고정폭 열로 늘어놓고
- * overflow-x-auto로 스크롤(1스크린 자연 노출 + 나머지는 옆으로). */
-// EmbedCard는 (entityType, entityId, title, status, href) 5-인자 위치 시그니처를 받는다
-// (기존 EmbedCard 계약, 변경 없음) — chat-bubble.tsx의 `p` 핸들러가 이미 쓰는 것과 동일한
-// object(ReadingPanelTarget)→5-인자 어댑터를 여기서도 그대로 재사용(사본 아님, 같은 변환 로직).
-type EmbedCardOpenPanel = (entityType: string, entityId: string, title: string | null, status: string | null, href: string | null) => void;
-function toEmbedCardOpenPanel(onOpenReadingPanel?: EmbedGroupProps['onOpenReadingPanel']): EmbedCardOpenPanel | undefined {
-  if (!onOpenReadingPanel) return undefined;
-  return (entityType, entityId, title, status, href) =>
-    onOpenReadingPanel({ kind: 'entity', entityType, entityId, title, status, href });
-}
-
+ * overflow-x-auto로 스크롤(1스크린 자연 노출 + 나머지는 옆으로). object→5-인자 어댑터는
+ * embed-card-open-panel-adapter.ts SSOT(chat-bubble.tsx `p` 핸들러와 진짜 같은 참조 — 카디르
+ * QA #3319 지적 반영, 각자 로컬 구현 드리프트 제거). */
 function ArtifactCarousel({ refs, onOpenReadingPanel }: { refs: EmbedGroupProps['refs']; onOpenReadingPanel?: EmbedGroupProps['onOpenReadingPanel'] }) {
   const openPanel = toEmbedCardOpenPanel(onOpenReadingPanel);
   return (


### PR DESCRIPTION
## 변경 사항
카디르 QA(#3319) 비차단 지적 정리 — `embed-group.tsx`의 주석이 "chat-bubble.tsx의 `p` 핸들러가 쓰는 것과 동일한 어댑터를 재사용"이라 적었지만, 실물은 두 파일이 각자 로컬로 구현한 별도 함수였습니다(결과 동일·기능 위험 0, 다만 한쪽만 고치면 드리프트할 위험).

`embed-card-open-panel-adapter.ts`(신규, `toEmbedCardOpenPanel`)로 단일화해 `chat-bubble.tsx`의 `p` 핸들러와 `embed-group.tsx`(캐러셀·간결 리스트)가 진짜 같은 참조를 쓰도록 정리했습니다.

**순수 리팩터 — 동작 변경 없음.**

## 셀프 게이트
- `pnpm build` — EXIT 0
- `pnpm lint`(대상 파일) — EXIT 0
- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm exec vitest run`(chat-bubble·embed-group·message-segments) — 112/112 pass, 회귀 0

## Test plan
- [x] 기존 sole-link 카드 클릭→ReadingPanel 오픈 동작(chat-bubble.test.tsx) 회귀 0
- [x] 그룹(캐러셀/간결 리스트) 클릭→ReadingPanel 오픈 동작(embed-group.test.tsx) 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)