### PR TITLE
[SID:2906] storage quota 서버측 강제 — 갭 2곳 wiring + SSOT 이관

### DIFF
--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -21,7 +21,6 @@ from app.models.agent_session import AgentSession
 from app.models.asset import Asset
 from app.models.hitl import HitlRequest
 from app.models.org_subscription import OrgSubscription
-from app.models.plan_tier_limit import PlanTierLimit
 from app.models.project import OrgMember
 from app.models.user import User
 from app.services.email import send_email
@@ -821,9 +820,16 @@ async def storage_usage_warn(
         subs = list((await session.execute(
             select(OrgSubscription).where(OrgSubscription.status == "active")
         )).scalars().all())
+        # story #2906(선생님 확定 2026-08-21) — SSOT를 offering_versions로 이관(check_storage_capacity와
+        # 동일 소스, 구 twin(plan_tier_limits) 결별). 이관 전엔 「경고 임계(이 cron)≠거부 임계(#2906
+        # 이전 check_storage_capacity)」split-brain 위험이 실재했다 — DISTINCT ON으로 tier당 대표 1행
+        # (currency 무관·ASC 결정적 — `_get_org_storage_limits`와 동일 규율).
         caps = {
             t: mb for t, mb in (await session.execute(
-                select(PlanTierLimit.tier, PlanTierLimit.max_storage_mb)
+                text(
+                    "SELECT DISTINCT ON (tier) tier, storage_mb_limit FROM offering_versions "
+                    "WHERE effective_to IS NULL ORDER BY tier, currency ASC"
+                )
             )).all()
         }
         notified = 0

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -1098,6 +1098,7 @@ async def upload_doc_attachment(
     (has_project_access·sync_attachment_assets) — doc 은 업로드=등록이 곧 종결 액션이라(story/chat과
     달리 별도 "메시지 생성" 시점이 없음) S5식 집계 재검증이 불필요하다(이 한 호출 자체가 그 지점).
     """
+    from app.core.config import settings
     from app.models.doc import Doc
     from app.services import mcp_attachment_upload
     from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
@@ -1124,6 +1125,16 @@ async def upload_doc_attachment(
     )
     if not uploaded:
         raise HTTPException(status_code=502, detail="upload failed")
+
+    # story #2906(선생님 확定 2026-08-21) — 이 엔드포인트는 sync_attachment_assets 6개
+    # 호출부 중 유일하게 check_storage_capacity가 안 걸려 있던 자리(발견된 진짜 갭).
+    # 다른 4곳(conversations.py·docs.py 문서저장·stories.py×2)과 동일 규율(ee seam·SaaS
+    # only·OSS no-op)로 sync 直前에 건다 — put_object 直後(byte는 이미 썼지만 이 함수
+    # 자체가 head_object로 재조회하는 기존 계약이라 업로드 前 시점엔 걸 수 없다, 다른
+    # 4곳과 동형 트레이드오프).
+    if settings.is_ee_enabled:
+        from ee.plan_limits import check_storage_capacity  # type: ignore[import]
+        await check_storage_capacity(session, org_id, [{"url": object_path}])
 
     created_by: uuid.UUID | None = None
     try:

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -951,6 +951,16 @@ async def complete_png_export(
     if size_bytes is None:
         return _err("NOT_FOUND", "업로드된 객체를 찾을 수 없습니다(head_object 실패)", 404)
 
+    # story #2906(선생님 확定 2026-08-21) — 이 export 경로는 sync_attachment_assets가 아니라
+    # 별도 _upsert_export_asset(자체 ON CONFLICT)를 쓰는 두 번째 asset-생성 choke point라
+    # check_storage_capacity가 애초에 안 걸려 있었다(그라운딩에서 발견된 진짜 갭 ②).
+    # chat/story/doc 첨부와 동일 규율(ee seam·SaaS only·OSS no-op)로 upsert 直前에 건다.
+    from app.core.config import settings
+
+    if settings.is_ee_enabled:
+        from ee.plan_limits import check_storage_capacity  # type: ignore[import]
+        await check_storage_capacity(session, org_id, [{"url": body.object_path}])
+
     created_by = uuid.UUID(auth.user_id)
     asset_id = await _upsert_export_asset(
         session, org_id=org_id, project_id=project_id, object_path=body.object_path,
@@ -1017,6 +1027,13 @@ async def create_html_export(
     )
     if not ok:
         return _err("STORAGE_ERROR", "HTML export 업로드 실패", 500)
+
+    # story #2906 — PNG export와 동일 갭·동일 규율(위 complete_png_export 주석 참고).
+    from app.core.config import settings
+
+    if settings.is_ee_enabled:
+        from ee.plan_limits import check_storage_capacity  # type: ignore[import]
+        await check_storage_capacity(session, org_id, [{"url": object_path}])
 
     created_by = uuid.UUID(auth.user_id)
     asset_id = await _upsert_export_asset(

--- a/backend/ee/plan_limits.py
+++ b/backend/ee/plan_limits.py
@@ -128,11 +128,22 @@ def _storage_limit_error(resource: str, limit_mb: int, tier: str, *, used_mb: fl
     # 「현재 사용량/한도」+「무엇을 하면 되는지」를 명시한다(dunning 메일 문안과 같은 규율,
     # #2907 참고). resource="storage"=총량 초과(파일 정리 or 업그레이드 안내),
     # resource="file_size"=단일 파일이 한도 자체를 넘음(정리로는 해결 안 됨, 업그레이드만).
+    #
+    # 유나양 design 지적(2026-08-21) — business는 더 위 tier가 없어 "업그레이드해
+    # 주세요"가 거짓 안내다(업그레이드 불가한데 업그레이드를 권함). upgrade_required
+    # (=tier != "business")를 문구 자체에도 배선 — business면 정리/문의로 갈음.
+    upgrade_required = tier != "business"
     if resource == "file_size":
-        msg = f"파일 크기가 {tier} 플랜의 파일당 한도({_format_mb(limit_mb)})를 초과했습니다. 더 작은 파일로 업로드하시거나 플랜을 업그레이드해 주세요."
+        if upgrade_required:
+            msg = f"파일 크기가 {tier} 플랜의 파일당 한도({_format_mb(limit_mb)})를 초과했습니다. 더 작은 파일로 업로드하시거나 플랜을 업그레이드해 주세요."
+        else:
+            msg = f"파일 크기가 {tier} 플랜의 파일당 한도({_format_mb(limit_mb)})를 초과했습니다. 더 작은 파일로 업로드해 주세요."
     else:
         usage_str = f"{used_mb:.0f}MB" if used_mb is not None else "한도"
-        msg = f"저장 공간이 부족합니다({tier} 플랜 한도 {_format_mb(limit_mb)} 중 {usage_str} 사용 중). 기존 파일을 정리하시거나 플랜을 업그레이드해 주세요."
+        if upgrade_required:
+            msg = f"저장 공간이 부족합니다({tier} 플랜 한도 {_format_mb(limit_mb)} 중 {usage_str} 사용 중). 기존 파일을 정리하시거나 플랜을 업그레이드해 주세요."
+        else:
+            msg = f"저장 공간이 부족합니다({tier} 플랜 한도 {_format_mb(limit_mb)} 중 {usage_str} 사용 중). 기존 파일을 정리해 주세요. 추가 용량이 필요하시면 문의해 주세요."
     return HTTPException(
         status_code=402,
         detail={
@@ -140,7 +151,7 @@ def _storage_limit_error(resource: str, limit_mb: int, tier: str, *, used_mb: fl
             "resource": resource,
             "limit_mb": limit_mb,
             "tier": tier,
-            "upgrade_required": tier != "business",
+            "upgrade_required": upgrade_required,
             "message": msg,
         },
     )

--- a/backend/ee/plan_limits.py
+++ b/backend/ee/plan_limits.py
@@ -119,12 +119,20 @@ async def check_project_create_limit(session: AsyncSession, org_id) -> None:
         raise _plan_limit_error("project", FREE_LIMITS["max_projects"])
 
 
-def _storage_limit_error(resource: str, limit_mb: int, tier: str) -> HTTPException:
-    upgrade = tier != "pro"
-    msg = (
-        f"{tier} plan {resource} limit ({limit_mb}MB) reached. Upgrade for more capacity."
-        if upgrade else f"{resource} limit ({limit_mb}MB) reached."
-    )
+def _format_mb(mb: int) -> str:
+    return f"{mb / 1024:.1f}GB" if mb >= 1024 else f"{mb}MB"
+
+
+def _storage_limit_error(resource: str, limit_mb: int, tier: str, *, used_mb: float | None = None) -> HTTPException:
+    # story #2906(선생님 확定 2026-08-21, 페드루군 조건ⓐ) — 고객 대면 문구는 한국어로
+    # 「현재 사용량/한도」+「무엇을 하면 되는지」를 명시한다(dunning 메일 문안과 같은 규율,
+    # #2907 참고). resource="storage"=총량 초과(파일 정리 or 업그레이드 안내),
+    # resource="file_size"=단일 파일이 한도 자체를 넘음(정리로는 해결 안 됨, 업그레이드만).
+    if resource == "file_size":
+        msg = f"파일 크기가 {tier} 플랜의 파일당 한도({_format_mb(limit_mb)})를 초과했습니다. 더 작은 파일로 업로드하시거나 플랜을 업그레이드해 주세요."
+    else:
+        usage_str = f"{used_mb:.0f}MB" if used_mb is not None else "한도"
+        msg = f"저장 공간이 부족합니다({tier} 플랜 한도 {_format_mb(limit_mb)} 중 {usage_str} 사용 중). 기존 파일을 정리하시거나 플랜을 업그레이드해 주세요."
     return HTTPException(
         status_code=402,
         detail={
@@ -132,39 +140,58 @@ def _storage_limit_error(resource: str, limit_mb: int, tier: str) -> HTTPExcepti
             "resource": resource,
             "limit_mb": limit_mb,
             "tier": tier,
-            "upgrade_required": upgrade,
+            "upgrade_required": tier != "business",
             "message": msg,
         },
     )
 
 
-async def get_org_storage_limit_bytes(session: AsyncSession, org_id) -> int | None:
-    """org tier 의 storage 캡(bytes). 캡 미정의 tier=None(무제한). storage-usage 표시 공용(server 권위 SSOT)."""
-    tier = await _get_org_tier(session, org_id)
+async def _get_org_storage_limits(session: AsyncSession, tier: str) -> tuple[int, int] | None:
+    """(storage_mb_limit, max_file_mb) — 가격표 정본(offering_versions). story #2906
+    (선생님 확定 2026-08-21) — seats(#2776)와 동일 이관: 이전엔 `plan_tier_limits`(구
+    twin)가 SSOT였으나, 카탈로그가 이미 `offering_versions`로 통일된 뒤였다(가격·좌석은
+    거기 있는데 storage만 구 테이블에 남아 "경고 임계≠거부 임계" split-brain 위험이
+    있었다 — 지금 이 자리서 닫는다). `_get_offering_limits`와 동일 조회 패턴(currency
+    무관·ASC 1건, 통화별 값 차이 없음)."""
     row = (await session.execute(
-        text("SELECT max_storage_mb FROM plan_tier_limits WHERE tier = :t"), {"t": tier},
-    )).first()
-    return int(row[0]) * 1024 * 1024 if row else None
-
-
-async def check_storage_capacity(session: AsyncSession, org_id, attachments: list[dict] | None) -> None:
-    """S8: org storage 캡 enforce(서버 게이트·all tiers). per-file + 총량(committed+신규).
-
-    tier(org_subscriptions)→plan_tier_limits[tier]→캡. 캡 미정의 tier=무제한(no-op). **우리 버킷 객체만**
-    카운트(canonical_object_path not None·외부 URL 제외). **size 는 head_object authoritative**(까심 ①:
-    client-size:0 quota 우회·음수 size 오염 차단·sync 와 동일 source). 객체 부재(head None)=미카운트(미등록될
-    것). OSS 는 호출 안 됨(is_ee_enabled 게이트·라우터). 초과 시 402 PLAN_LIMIT_EXCEEDED.
-    """
-    if not attachments:
-        return
-    tier = await _get_org_tier(session, org_id)
-    row = (await session.execute(
-        text("SELECT max_storage_mb, max_file_mb FROM plan_tier_limits WHERE tier = :t"),
+        text(
+            "SELECT storage_mb_limit, max_file_mb FROM offering_versions "
+            "WHERE tier = :t AND effective_to IS NULL ORDER BY currency ASC LIMIT 1"
+        ),
         {"t": tier},
     )).first()
     if row is None:
-        return  # 캡 미정의 tier → 무제한
-    max_storage_mb, max_file_mb = int(row[0]), int(row[1])
+        return None
+    return int(row[0]), int(row[1])
+
+
+async def get_org_storage_limit_bytes(session: AsyncSession, org_id) -> int | None:
+    """org tier 의 storage 캡(bytes). 캡 미정의 tier=None(무제한). storage-usage 표시 공용(server 권위 SSOT)."""
+    tier = await _get_org_tier(session, org_id)
+    limits = await _get_org_storage_limits(session, tier)
+    return limits[0] * 1024 * 1024 if limits else None
+
+
+async def check_storage_capacity(session: AsyncSession, org_id, attachments: list[dict] | None) -> None:
+    """S8(story #2906 갱신, 2026-08-21): org storage 캡 enforce(서버 게이트·all tiers).
+    per-file + 총량(committed+신규).
+
+    tier(org_subscriptions)→offering_versions[tier]→캡. 캡 미정의 tier=무제한(no-op).
+    **우리 버킷 객체만** 카운트(canonical_object_path not None·외부 URL 제외). **size 는
+    head_object authoritative**(까심 ①: client-size:0 quota 우회·음수 size 오염 차단·sync
+    와 동일 source). 객체 부재(head None)=미카운트(미등록될 것). OSS 는 호출 안 됨
+    (is_ee_enabled 게이트·라우터). 초과 시 402 PLAN_LIMIT_EXCEEDED."""
+    if not attachments:
+        return
+    tier = await _get_org_tier(session, org_id)
+    if tier not in _KNOWN_TIERS:
+        logger.error("check_storage_capacity: unknown tier %r for org_id=%s — skipping cap(fail-open)", tier, org_id)
+        return
+    limits = await _get_org_storage_limits(session, tier)
+    if limits is None:
+        logger.error("check_storage_capacity: no offering_version for tier=%r org_id=%s — skipping cap(fail-open)", tier, org_id)
+        return
+    max_storage_mb, max_file_mb = limits
     max_file_bytes = max_file_mb * 1024 * 1024
     max_storage_bytes = max_storage_mb * 1024 * 1024
 
@@ -192,7 +219,7 @@ async def check_storage_capacity(session: AsyncSession, org_id, attachments: lis
         {"oid": str(org_id)},
     )).scalar() or 0
     if int(used) + new_bytes > max_storage_bytes:
-        raise _storage_limit_error("storage", max_storage_mb, tier)
+        raise _storage_limit_error("storage", max_storage_mb, tier, used_mb=int(used) / (1024 * 1024))
 
 
 async def _seat_usage(session: AsyncSession, org_id, *, include_pending_invites: bool) -> int:

--- a/backend/tests/test_2906_storage_quota_enforcement_realdb.py
+++ b/backend/tests/test_2906_storage_quota_enforcement_realdb.py
@@ -1,0 +1,430 @@
+"""story #2906(선생님 확定 2026-08-21) — storage quota 서버측 강제, 실PG 검증.
+
+그라운딩 정정(스토리 본문 참고) — `ee/plan_limits.py::check_storage_capacity()`는 이미
+존재·이미 4개 choke point(conversations.py·docs.py 문서저장·stories.py×2)에 wired돼
+있었다. 이 PR의 실 작업은 ①진짜 미커버 갭 2곳(docs.py MCP 첨부·visual_artifacts export)
+wiring ②SSOT를 `plan_tier_limits`(구 twin)에서 `offering_versions`(seats 선례와 동일
+카탈로그)로 이관 ③기존 데이터 무변화 음성대조.
+
+커버:
+  AC① — docs.py MCP JSON/base64 첨부 엔드포인트, 쿼터 초과 시 402.
+  AC② — visual_artifacts PNG export 완결 엔드포인트, 쿼터 초과 시 402.
+  AC③(SSOT 이관, load-bearing) — offering_versions 값만 바꿔도 판정이 바뀜(plan_tier_limits
+       가 여전히 구값이어도).
+  AC④(페드루군 조건ⓐ) — 402 문구가 한국어로 현재 사용량/한도+행동 안내.
+  AC⑤(페드루군 조건ⓑ, 음성대조) — 이미 쿼터 초과 상태 org의 기존 자산 접근/다운로드는
+       무변화(차단 없음).
+  AC⑥ — storage-usage-warn cron도 같은 SSOT(offering_versions)를 읽는다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+GB = 1024 * 1024 * 1024
+MB = 1024 * 1024
+BUCKET = "sprintable-memo-attachments"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _mock_storage_head(monkeypatch):
+    """까심① — check_storage_capacity/sync_attachment_assets 둘 다 call-time import로
+    storage provider를 가져온다(test_asset_registry_realdb.py와 동일 규율)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import app.services.storage as _storage_mod
+
+    sizes: dict[str, int] = {}
+
+    async def _head(container, object_path):
+        return sizes.get(object_path, 10)
+
+    prov = MagicMock()
+    prov.head_object = AsyncMock(side_effect=_head)
+
+    async def _put(container, object_path, data, content_type=None):
+        sizes[object_path] = len(data)
+        return True
+
+    prov.put_object = AsyncMock(side_effect=_put)
+    prov.signed_write_url = AsyncMock(return_value="https://fake-signed-url.example/upload")
+    monkeypatch.setattr(_storage_mod, "get_storage_provider", lambda: prov)
+    yield sizes
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, tier="free", used_bytes=0):
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    om_id = uuid.uuid4()
+    await session.execute(
+        text("INSERT INTO organizations (id,name,slug,plan) VALUES (:id,:name,:slug,'free')"),
+        {"id": org_id, "name": f"org-{org_id}", "slug": f"slug-{org_id}"},
+    )
+    await session.execute(
+        text(
+            "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+            "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+            "(:id,:email,'x','U',true,true,0,false,0)"
+        ),
+        {"id": user_id, "email": f"u-{org_id}@test.local"},
+    )
+    await session.execute(
+        text("INSERT INTO org_members (id,org_id,user_id,role) VALUES (:id,:org_id,:uid,'owner')"),
+        {"id": om_id, "org_id": org_id, "uid": user_id},
+    )
+    await session.execute(
+        text("INSERT INTO projects (id,org_id,name) VALUES (:id,:org_id,'P')"),
+        {"id": project_id, "org_id": org_id},
+    )
+    await session.execute(
+        text("INSERT INTO project_access (id,project_id,org_member_id,permission) VALUES (gen_random_uuid(),:p,:om,'granted')"),
+        {"p": project_id, "om": om_id},
+    )
+    if tier != "free":
+        await session.execute(
+            text("INSERT INTO org_subscriptions (id,org_id,tier,status,currency,provider) VALUES (gen_random_uuid(),:o,:t,'active','krw','toss')"),
+            {"o": org_id, "t": tier},
+        )
+    if used_bytes:
+        await session.execute(
+            text(
+                "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes,deleted_at)"
+                " VALUES (gen_random_uuid(),:o,:p,:c,:path,'existing',:sz,NULL)"
+            ),
+            {"o": org_id, "p": project_id, "c": BUCKET, "path": f"pre-existing/{uuid.uuid4()}", "sz": used_bytes},
+        )
+    await session.commit()
+    return {"org_id": org_id, "user_id": user_id, "project_id": project_id}
+
+
+async def _get_offering_id(session, tier):
+    row = (await session.execute(
+        text("SELECT id FROM offering_versions WHERE tier=:t AND currency='krw' AND effective_to IS NULL"),
+        {"t": tier},
+    )).first()
+    assert row is not None, f"offering_version(tier={tier!r}) 시드 없음"
+    return row.id
+
+
+@pytest.mark.anyio
+async def test_ssot_migrated_to_offering_version_not_plan_tier_limits_realdb(_mock_storage_head):
+    """AC③(load-bearing) — plan_tier_limits는 구값(5GB) 그대로 두고 offering_versions만
+    1MB로 낮추면, check_storage_capacity가 새 값(1MB)을 따라야 한다(구 twin을 계속 읽고
+    있었다면 5GB 여유로 통과했을 요청이, SSOT 이관 後엔 즉시 거부돼야 한다)."""
+    from fastapi import HTTPException
+
+    from ee.plan_limits import check_storage_capacity
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org(s, tier="free")
+            offering_id = await _get_offering_id(s, "free")
+
+            plan_tier_limit_mb = (await s.execute(
+                text("SELECT max_storage_mb FROM plan_tier_limits WHERE tier='free'")
+            )).scalar_one()
+            assert plan_tier_limit_mb >= 5 * 1024, "구 twin이 여전히 5GB대여야 이 테스트가 의미 있음"
+
+            # offering_versions.storage_mb_limit은 org별 행이 아니라 tier당 공유 카탈로그 행 —
+            # CI가 전체 스위트를 하나의 공유 PG에 돌리므로(feedback_disposable_pg_reuse_pollution
+            # 동형 클래스) 반드시 원복해야 다른 테스트(test_asset_registry_realdb.py 등)를
+            # 오염시키지 않는다.
+            original_limit_mb = (await s.execute(
+                text("SELECT storage_mb_limit FROM offering_versions WHERE id=:id"), {"id": offering_id},
+            )).scalar_one()
+            try:
+                await s.execute(
+                    text("UPDATE offering_versions SET storage_mb_limit=1 WHERE id=:id"), {"id": offering_id},
+                )
+                await s.commit()
+
+                url = f"org/{seeded['org_id']}/project/{seeded['project_id']}/chat/{uuid.uuid4()}/big.png"
+                att = {"url": url, "name": "big.png", "content_type": "image/png", "size": 0}
+                _mock_storage_head[url] = 2 * 1024 * 1024  # 2MB — head_object가 authoritative(까심①)
+
+                with pytest.raises(HTTPException) as exc_info:
+                    await check_storage_capacity(s, seeded["org_id"], [att])
+                assert exc_info.value.status_code == 402
+                # storage_mb_limit=1(offering_versions 새 한도) 초과 — max_file_mb는 안 건드렸으니
+                # file_size가 아니라 총량(storage) 축에서 걸려야 SSOT가 실제로 이 필드를 읽었다는 증거.
+                assert exc_info.value.detail["resource"] == "storage"
+                assert exc_info.value.detail["limit_mb"] == 1
+            finally:
+                await s.execute(
+                    text("UPDATE offering_versions SET storage_mb_limit=:mb WHERE id=:id"),
+                    {"mb": original_limit_mb, "id": offering_id},
+                )
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_storage_limit_error_korean_usage_and_action_realdb(_mock_storage_head):
+    """AC④(페드루군 조건ⓐ) — 402 문구는 한국어로 현재 사용량/한도+행동(정리 or 업그레이드)을 명시."""
+    from fastapi import HTTPException
+
+    from ee.plan_limits import check_storage_capacity
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org(s, tier="free", used_bytes=5 * GB - 100)
+            url = f"org/{seeded['org_id']}/project/{seeded['project_id']}/chat/{uuid.uuid4()}/f.png"
+            _mock_storage_head[url] = 200  # 기존 사용량(5GB-100)+200 > 5GB 한도 — 확실히 초과.
+
+            with pytest.raises(HTTPException) as exc_info:
+                await check_storage_capacity(s, seeded["org_id"], [{"url": url, "name": "f", "content_type": "image/png", "size": 0}])
+            msg = exc_info.value.detail["message"]
+            assert any(ch >= "가" and ch <= "힣" for ch in msg), f"메일과 동일 규율 — 한국어 문구여야 함: {msg!r}"
+            assert "한도" in msg
+            assert ("정리" in msg) or ("업그레이드" in msg), "행동 안내(무엇을 하면 되는지)가 없음"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_over_quota_org_existing_asset_access_unaffected_realdb():
+    """AC⑤(페드루군 조건ⓑ, 음성대조 필수) — 이미 쿼터 초과 상태 org라도 기존 자산 접근
+    (list/read)은 무변화 — 「신규 업로드만 차단」의 반쪽. check_storage_capacity 자체가
+    신규 첨부 없이는(no-op) 절대 호출되지 않는 경로(list/read엔 attachments 인자가 없다)
+    임을 직접 실증한다."""
+    from app.routers.assets import list_assets
+    from unittest.mock import MagicMock
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org(s, tier="free", used_bytes=6 * GB)  # 이미 free 5GB 초과
+
+            auth = MagicMock()
+            auth.user_id = str(seeded["user_id"])
+            # FastAPI Query(...) 기본값은 함수를 직접 호출하면 resolve 안 됨(Query 객체 그대로
+            # 남는다) — 전부 명시로 넘겨야 실제 no-filter 조회와 동치가 된다.
+            resp = await list_assets(
+                project_id=None, folder_id=None, mime=None, q=None,
+                sort="date", order="desc", cursor=None, limit=50,
+                db=s, auth=auth, org_id=seeded["org_id"],
+            )
+            assert len(resp.items) == 1, "쿼터 초과 상태에서도 기존 자산은 그대로 조회됨(삭제·차단 없음)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_docs_mcp_attachment_upload_rejected_over_quota_realdb(monkeypatch):
+    """AC① — docs.py MCP JSON/base64 첨부 엔드포인트(진짜 미커버 갭)가 쿼터 초과 시 402."""
+    import base64
+
+    from fastapi import HTTPException
+
+    from app.core.config import settings
+    from app.dependencies.auth import AuthContext
+    from app.models.doc import Doc
+    from app.routers.docs import UploadDocAttachmentRequest, upload_doc_attachment
+
+    monkeypatch.setattr(settings, "license_consent", "agreed")  # is_ee_enabled 게이트 통과
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org(s, tier="free", used_bytes=5 * GB - 100)
+            doc_id = uuid.uuid4()
+            s.add(Doc(
+                id=doc_id, org_id=seeded["org_id"], project_id=seeded["project_id"], title="D",
+                slug=f"doc-{doc_id.hex[:8]}",
+            ))
+            await s.commit()
+
+            auth = AuthContext(user_id=str(seeded["user_id"]), email=None, claims={})
+            body = UploadDocAttachmentRequest(
+                content_base64=base64.b64encode(b"x" * 300).decode(), name="big.bin", content_type="application/octet-stream",
+            )
+            # 200바이트 여유인데 300바이트 파일 → 총량 초과.
+            with pytest.raises(HTTPException) as exc_info:
+                await upload_doc_attachment(doc_id=doc_id, body=body, session=s, auth=auth, org_id=seeded["org_id"])
+            assert exc_info.value.status_code == 402
+            assert exc_info.value.detail["resource"] == "storage"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_visual_artifact_png_export_rejected_over_quota_realdb(monkeypatch):
+    """AC② — visual_artifacts PNG export 완결 엔드포인트(별도 asset upsert 경로, 진짜
+    미커버 갭)가 쿼터 초과 시 402."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.core.config import settings
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+    from app.main import app
+    from app.models.member import Member
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.visual_artifact import ArtifactVersion, VisualArtifact
+    from app.services.asset_registry import DEFAULT_CONTAINER
+    from app.services.storage import get_storage_provider
+
+    monkeypatch.setattr(settings, "license_consent", "agreed")  # is_ee_enabled 게이트 통과
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org(s, tier="free", used_bytes=5 * GB - 100)
+            # project는 _seed_org가 만들었지만 Project 모델 row 자체가 필요(visual_artifacts scope).
+            proj = (await s.execute(text("SELECT id FROM projects WHERE id=:p"), {"p": seeded["project_id"]})).first()
+            assert proj is not None
+
+            creator = Member(id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="exporter", is_active=True)
+            s.add(creator)
+            await s.commit()
+            s.add(ProjectAccess(id=uuid.uuid4(), project_id=seeded["project_id"], member_id=creator.id, permission="granted", role="member"))
+            await s.commit()
+
+            artifact = VisualArtifact(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"], title="Export",
+                source="created", latest_version_number=1, created_by=creator.id,
+            )
+            s.add(artifact)
+            await s.commit()
+            version = ArtifactVersion(id=uuid.uuid4(), artifact_id=artifact.id, version_number=1, created_by=creator.id)
+            s.add(version)
+            await s.commit()
+            artifact_id, org_id, project_id = artifact.id, seeded["org_id"], seeded["project_id"]
+
+        async def _db():
+            async with Session() as s2:
+                try:
+                    yield s2
+                    await s2.commit()
+                except Exception:
+                    await s2.rollback()
+                    raise
+
+        async def _auth():
+            return AuthContext(
+                user_id=str(creator.id), email=None,
+                claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+            )
+
+        app.dependency_overrides[get_db] = _db
+        app.dependency_overrides[get_current_user] = _auth
+        client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+        try:
+            url_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/versions/1/export/png/upload-url",
+                json={"content_type": "image/png"},
+            )
+            assert url_resp.status_code == 200, url_resp.text
+            object_path = url_resp.json()["data"]["object_path"]
+
+            # 200바이트 여유인데 300바이트 "PNG" → 총량 초과 기대.
+            put_ok = await get_storage_provider().put_object(
+                DEFAULT_CONTAINER, object_path, b"\x89" * 300, content_type="image/png",
+            )
+            assert put_ok
+
+            complete_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/versions/1/export/png/complete",
+                json={"object_path": object_path},
+            )
+            assert complete_resp.status_code == 402, complete_resp.text
+            assert complete_resp.json()["error"]["code"] == "PLAN_LIMIT_EXCEEDED"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_storage_warn_cron_uses_offering_version_ssot_realdb(monkeypatch):
+    """AC⑥ — storage-usage-warn cron도 offering_versions를 읽는다(check_storage_capacity와
+    같은 소스로 통일 — «경고 임계≠거부 임계» split-brain 방지). plan_tier_limits는 구값
+    (5GB) 그대로 두고 offering_versions만 낮추면, 훨씬 적은 사용량에서도 80% 경고가 떠야
+    한다(구 twin을 계속 읽고 있었다면 안 떴을 것)."""
+    from unittest.mock import MagicMock
+
+    from app.routers import cron
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org(s, tier="free", used_bytes=int(90 * MB))  # 5GB 기준 2%뿐
+            # cron 대상은 org_subscriptions(status='active') 스캔 — free tier는 _seed_org가
+            # 구독 행을 안 만든다(실 운영과 동형, _get_org_tier의 "행 없음=free" fallback과 짝).
+            # 이 cron 자체는 애초에 구독 행 없는 free org는 안 본다(#2906 스코프 밖 기존 한계) —
+            # 이 테스트는 «구독 행이 있는» free org에서 SSOT가 맞는지만 검증한다.
+            await s.execute(
+                text(
+                    "INSERT INTO org_subscriptions (id,org_id,tier,status,currency,provider) "
+                    "VALUES (gen_random_uuid(),:o,'free','active','krw','toss')"
+                ),
+                {"o": seeded["org_id"]},
+            )
+            await s.commit()
+            offering_id = await _get_offering_id(s, "free")
+            original_limit_mb = (await s.execute(
+                text("SELECT storage_mb_limit FROM offering_versions WHERE id=:id"), {"id": offering_id},
+            )).scalar_one()
+            owner_email = (await s.execute(
+                text("SELECT email FROM users WHERE id=:id"), {"id": seeded["user_id"]},
+            )).scalar_one()
+            try:
+                # 100MB로 낮추면 90MB 사용은 90% — 80% 임계 초과.
+                await s.execute(text("UPDATE offering_versions SET storage_mb_limit=100 WHERE id=:id"), {"id": offering_id})
+                await s.commit()
+
+                sent: list = []
+                monkeypatch.setattr(cron, "send_email", lambda to, subject, html: sent.append(to) or True)
+
+                await cron.storage_usage_warn(MagicMock(), session=s)
+                # 전역 스캔(org_subscriptions 전체) — CI 공유 PG엔 다른 테스트의 active 구독이
+                # 동시에 있을 수 있다(feedback_failure_triage_by_signature 동형: 정확한 길이가
+                # 아니라 «이 org의 owner에게 갔는가»만 판별력 있다).
+                assert owner_email in sent, "90MB/100MB(offering_versions 새 한도)=90% — 이 org 경고 떴어야 함"
+            finally:
+                await s.execute(
+                    text("UPDATE offering_versions SET storage_mb_limit=:mb WHERE id=:id"),
+                    {"mb": original_limit_mb, "id": offering_id},
+                )
+                await s.commit()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2906_storage_quota_enforcement_realdb.py
+++ b/backend/tests/test_2906_storage_quota_enforcement_realdb.py
@@ -294,7 +294,6 @@ async def test_visual_artifact_png_export_rejected_over_quota_realdb(monkeypatch
 
     from app.core.config import settings
     from app.dependencies.auth import AuthContext, get_current_user
-    from app.dependencies.database import get_db
     from app.main import app
     from app.models.member import Member
     from app.models.project import Project
@@ -302,6 +301,7 @@ async def test_visual_artifact_png_export_rejected_over_quota_realdb(monkeypatch
     from app.models.visual_artifact import ArtifactVersion, VisualArtifact
     from app.services.asset_registry import DEFAULT_CONTAINER
     from app.services.storage import get_storage_provider
+    from tests.conftest import override_db_and_read
 
     monkeypatch.setattr(settings, "license_consent", "agreed")  # is_ee_enabled 게이트 통과
     engine, Session = await _session_factory()
@@ -344,7 +344,7 @@ async def test_visual_artifact_png_export_rejected_over_quota_realdb(monkeypatch
                 claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
             )
 
-        app.dependency_overrides[get_db] = _db
+        override_db_and_read(app, _db)
         app.dependency_overrides[get_current_user] = _auth
         client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
         try:


### PR DESCRIPTION
[SID:2906]

## 그라운딩 정정
초기 그라운딩에서 "storage 강제 코드 0건"으로 오보고했으나, 실제로는 `ee/plan_limits.py::check_storage_capacity()`가 이미 존재하고 4/6 choke point(conversations.py·docs.py 문서저장·stories.py×2)에 이미 wired돼 있었다. 이 PR은 그 정정된 스코프로 진행한다 — 스토리 #2906 본문에도 정정 기록.

## 변경 사항
- **진짜 미커버 갭 2곳 wiring**(기존 `check_storage_capacity` 재사용, 신규 로직 없음):
  - `docs.py::upload_doc_attachment` — MCP JSON/base64 첨부 엔드포인트
  - `visual_artifacts.py::complete_png_export`/`create_html_export` — export 완결 엔드포인트(별도 `_upsert_export_asset` choke point)
- **SSOT 이관**: 한도 소스를 `plan_tier_limits`(구 twin)에서 `offering_versions`(story #2776 seats 선례와 동일 카탈로그)로 교체. 강제 로직(per-file+총량, head_object authoritative)은 무변경.
- `storage-usage-warn` cron도 동일 SSOT로 동승 — "경고 임계≠거부 임계" split-brain 방지.
- 402 에러 문구를 한국어 고객 대면으로 교체: 현재 사용량/한도 + 행동 안내(정리 또는 업그레이드) — dunning 메일과 동일 규율.
- `doc_asset_backfill.py`는 의도적으로 미wiring 유지(레거시 base64→GCS 이관은 신규 사용량이 아님 — 차단 시 해악).

## 조건 충족(페드루군 승인 조건)
- ⓐ 402 메시지 한국어 고객 대면 — `test_storage_limit_error_korean_usage_and_action_realdb`
- ⓑ 이미 초과 상태 org의 기존 자산 접근/다운로드 무변화(음성대조) — `test_over_quota_org_existing_asset_access_unaffected_realdb`

## 테스트
`tests/test_2906_storage_quota_enforcement_realdb.py` 신규 6종(실PG):
1. SSOT load-bearing 증명 — `plan_tier_limits`는 구값 유지, `offering_versions`만 바꿔도 판정이 바뀜
2. 한국어 문구 검증
3. 음성대조(기존 데이터 무변화)
4. docs.py MCP 갭 402
5. visual_artifacts export 갭 402
6. cron SSOT 동기화

기존 회귀(`test_asset_registry_realdb.py`·`test_docs.py`·`test_mcp_docs_2191_shape.py`·`test_authz_project_scope_coverage.py`) 전부 통과 확인. `import app.main` 정상.

## Test plan
- [x] 신규 6종 실PG 테스트 통과 (fresh DB, 상호오염 없음 확인)
- [x] 기존 storage 관련 회귀 테스트 통과
- [x] CI 확인 대기