### PR TITLE
[SID:2912] 워크플로 concurrency 그룹 4곳 추가 — CI stuck 갈래B 처방①

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -11,6 +11,13 @@ on:
       - ee/**
       - .github/workflows/docker-smoke-test.yml
 
+# story #2912(2899 그라운딩 갈래B 처방) — 같은 PR에 새 커밋이 들어오면 구head 런이 여전히
+# 러너를 붙든 채(오늘 실사례 #3302: 구head shard 20분+ in_progress) 신head 런과 캐파를
+# 다툰다. cancel-in-progress로 구head 런을 즉시 접어 캐파를 신head에 양보한다.
+concurrency:
+  group: docker-smoke-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   smoke-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ee-pricing-fork-guard.yml
+++ b/.github/workflows/ee-pricing-fork-guard.yml
@@ -15,6 +15,12 @@ on:
   pull_request:
     branches: [develop]
 
+# story #2912(2899 그라운딩 갈래B 처방) — 구head 런이 캐파를 계속 붙들지 않게 신 커밋이
+# 오면 즉시 취소(다른 gate들과 동형 패턴).
+concurrency:
+  group: ee-pricing-fork-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   ee-pricing-fork-guard:
     name: ee_pricing fork stability — advisory

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main]
 
+# story #2912(2899 그라운딩 갈래B 처방) — pull_request+push 혼합 트리거라 PR번호가 없는
+# push 이벤트도 커버해야 해서 ci.yml과 동형으로 github.ref 기반 그룹을 쓴다(pull_request
+# 이벤트의 github.ref는 refs/pull/N/merge로 안정적이라 PR별로도 정확히 갈린다).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/sid-link-check.yml
+++ b/.github/workflows/sid-link-check.yml
@@ -9,6 +9,12 @@ on:
   pull_request:
     branches: [main, develop]
 
+# story #2912(2899 그라운딩 갈래B 처방) — 구head 런이 캐파를 계속 붙들지 않게 신 커밋이
+# 오면 즉시 취소(다른 gate들과 동형 패턴).
+concurrency:
+  group: sid-link-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   sid-link-check:
     name: Story link (SID) — advisory


### PR DESCRIPTION
[SID:2912]

## 배경
[story #2899 그라운딩](entity:doc:d91624d0-94db-4b5c-be2a-68039f9eab6c)(카디르, PO 승인 2026-08-22)이 오늘 실사례 6건을 5갈래로 분류. 이 PR은 갈래B(러너 캐파 점유, #3302 실사례)의 1차 처방 — 워크플로 concurrency 그룹.

## 그라운딩 정정
착수 중 발견 — `ci.yml`·`qa-review-gate.yml`·`design-review-gate.yml`은 이미 concurrency 그룹이 있었다(구head 런 자동취소, `qa-review-gate.yml`은 April OSS 커밋부터). **진짜 갭은 pull_request로 트리거되는 나머지 4개 워크플로**가 전혀 안 걸려 있던 것:
- `Docker Smoke Test` (docker-smoke-test.yml)
- `ee_pricing Fork Guard` (ee-pricing-fork-guard.yml)
- `Story link (SID)` (sid-link-check.yml)
- `Lighthouse CI` (lighthouse-ci.yml)

이 4곳은 PR에 새 커밋이 들어와도 구head 런이 캐파를 계속 붙든 채 남아있는다 — #3302류 재발 표면.

## 변경
`qa-review-gate.yml`/`design-review-gate.yml`의 기존 패턴(`<workflow명>-${{ github.event.pull_request.number }}`)을 순수 pull_request 트리거 3곳(docker-smoke-test·ee-pricing-fork-guard·sid-link-check)에 동형 적용.

`Lighthouse CI`는 pull_request+push(main) 혼합 트리거라 PR번호가 없는 push 이벤트도 커버해야 해서 `ci.yml`과 동형인 `github.ref` 기반 그룹(`pull_request` 이벤트의 `github.ref`는 `refs/pull/N/merge`로 안정적이라 PR별로도 정확히 갈림)을 대신 적용.

## 스코프
갈래A·B만. C(stale 완주 재평가 일반화)·D(체크런 0개 자동감지)·E(재트리거-잠금 회피)는 설계가 더 커 후속 PR로 순차(story #2912 본문 그대로).

## 셀프 게이트
- `python3 -c "import yaml; yaml.safe_load(...)"` 4개 파일 전부 valid YAML 확認.
- `act` 로컬 실행기 미설치 — 대신 이미 수십 건의 실PR에서 검증된 기존 패턴(qa-review-gate·design-review-gate·ci.yml)을 문자 그대로 재사용해 동작 신뢰도 확보.
- 실제 concurrency 취소 동작은 이 PR 자체가 develop에 머지된 뒤 다음 PR들의 실제 rebase/재푸시에서 자연 검증(워크플로 파일 자체의 동작을 PR 안에서 직접 재현하기는 구조적으로 어려움 — 같은 PR에 재푸시해 그 취소가 자기 자신에게 적용되는지 관찰하는 방법은 있음, 리뷰 中 시연 가능).

🤖 Generated with [Claude Code](https://claude.com/claude-code)