### PR TITLE
[SID:2895] [BUG·2895] ArtifactThumbnail object-cover 크롭이 결재 카드 목업을 흰 배경으로 깨뜨림

### DIFF
--- a/apps/web/src/components/canvas/artifact-thumbnail.test.tsx
+++ b/apps/web/src/components/canvas/artifact-thumbnail.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+//
+// story #2895(BUG·결재 표면, 선생님 실증) — 회귀가드. object-cover가 "imported" 아티팩트
+// (전체 페이지 캡처, 세로로 매우 긴 이미지 — 실측 2480×3560)를 16:9 aspect-video 박스에서
+// 심하게 크롭해 「흰 배경으로 깨진」 것처럼 보이게 한 것이 근본원인 — object-contain(크롭 0)
+// 으로 전환한 것을 잠근다. jsdom엔 IntersectionObserver가 없어(컴포넌트 자체 설계상 그
+// 환경은 lazy 게이트 없이 즉시 inView=true로 시작) 별도 스텁 불요.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ArtifactThumbnail } from './artifact-thumbnail';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+vi.mock('@/services/canvas-export', () => ({
+  listArtifactExports: vi.fn(async () => []),
+}));
+
+const getArtifactVersionDetailMock = vi.fn();
+vi.mock('@/services/canvas', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/canvas')>();
+  return { ...actual, getArtifactVersionDetail: (...args: unknown[]) => getArtifactVersionDetailMock(...args) };
+});
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('ArtifactThumbnail — story #2895 object-fit 회귀가드', () => {
+  it('"imported" 아티팩트(props.src = 전체 페이지 캡처 URL) — <img>가 object-contain(크롭 0)으로 렌더된다', async () => {
+    getArtifactVersionDetailMock.mockResolvedValue({
+      id: 'a-1', title: 'S2b 칩 가독성 목업', story_id: null, epic_id: null, doc_id: null,
+      source: 'imported', latest_version_number: 1, anchor_version: null, created_by: null,
+      created_at: '2026-08-21T08:31:42Z', version_number: 1, version_summary: null,
+      canvas_bounds: null,
+      nodes: [{ id: 'n-1', type: 'html_blob', props: { src: 'https://storage.googleapis.com/example/tall-capture.png' }, parent_id: null, sort_order: 0, description: null }],
+    });
+    await act(async () => {
+      root.render(wrap(<ArtifactThumbnail artifactId="a-1" latestVersionNumber={1} anchorVersion={null} />));
+    });
+    await flush();
+    const img = container.querySelector('img');
+    expect(img).toBeTruthy();
+    expect(img!.className).toContain('object-contain');
+    expect(img!.className).not.toContain('object-cover');
+    expect(img!.src).toContain('tall-capture.png');
+  });
+
+  it('PNG export가 있으면 그 경로도 object-contain으로 렌더된다(export 우선 순위 회귀 0)', async () => {
+    const { listArtifactExports } = await import('@/services/canvas-export');
+    (listArtifactExports as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { format: 'png', download_url: 'https://storage.googleapis.com/example/export.png' },
+    ]);
+    getArtifactVersionDetailMock.mockResolvedValue(null);
+    await act(async () => {
+      root.render(wrap(<ArtifactThumbnail artifactId="a-2" latestVersionNumber={1} anchorVersion={null} />));
+    });
+    await flush();
+    const img = container.querySelector('img');
+    expect(img).toBeTruthy();
+    expect(img!.className).toContain('object-contain');
+    expect(img!.src).toContain('export.png');
+  });
+
+  it('html_blob(자기완결 HTML, props.html) — 여전히 iframe srcDoc으로 렌더된다(회귀 0, img 분기 무영향)', async () => {
+    getArtifactVersionDetailMock.mockResolvedValue({
+      id: 'a-3', title: '자기완결 HTML', story_id: null, epic_id: null, doc_id: null,
+      source: 'created', latest_version_number: 1, anchor_version: null, created_by: null,
+      created_at: '2026-08-21T08:31:42Z', version_number: 1, version_summary: null,
+      canvas_bounds: { w: 1180, h: 1500 },
+      nodes: [{ id: 'n-1', type: 'html_blob', props: { html: '<html><body>hi</body></html>' }, parent_id: null, sort_order: 0, description: null }],
+    });
+    await act(async () => {
+      root.render(wrap(<ArtifactThumbnail artifactId="a-3" latestVersionNumber={1} anchorVersion={null} />));
+    });
+    await flush();
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('iframe[srcdoc]')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/canvas/artifact-thumbnail.tsx
+++ b/apps/web/src/components/canvas/artifact-thumbnail.tsx
@@ -111,8 +111,17 @@ export function ArtifactThumbnail({ artifactId, latestVersionNumber, anchorVersi
       {state.kind === 'loading' ? (
         <div className="size-full animate-pulse bg-muted/60" />
       ) : state.kind === 'image' ? (
+        // story #2895(BUG·결재 표면, 선생님 실증) — object-cover는 PNG export처럼 컨테이너와
+        // 비슷한 종횡비일 때만 무해하다. "imported" 아티팩트(전체 페이지 캡처, 세로로 매우
+        // 긴 이미지 — 실측 2480×3560, 종횡비 ~0.7:1)를 16:9 aspect-video 박스에 object-cover로
+        // 넣으면 세로 내용의 대부분이 크롭돼 사라지고, 잘려 남은 좁은 가로 슬라이스가 우연히
+        // 여백/패딩 구간에 걸리면 "흰 배경으로 깨진" 것처럼 보인다(결재자가 근거 실물을 못
+        // 봄). artifact-stage.tsx(전체 뷰어)는 이미 object-contain을 쓴다 — 썸네일만 이 버그가
+        // 있었다. object-contain(레터박스·크롭 0)으로 통일해 «보여줄 게 있으면 전부 보여준다»
+        // 원칙(이 파일 상단 no-fiction 규율)에 맞춘다. PNG export도 object-contain으로 무해(종횡비
+        // 유사·최악의 경우도 크롭보다 레터박스가 더 정직).
         // eslint-disable-next-line @next/next/no-img-element -- PNG export/artifact content는 외부·동적 URL이라 next/image 도메인 화이트리스트와 안 맞음.
-        <img src={state.url} alt="" className="size-full object-cover" />
+        <img src={state.url} alt="" className="size-full object-contain" />
       ) : state.kind === 'live' ? (
         <div ref={stageRef} className="pointer-events-none size-full" style={{ height: state.bounds.h * scale }}>
           <iframe


### PR DESCRIPTION
[SID:2895]

## 근본원인 (선생님 실증 재현 완료)
`cf8629c6-7058-4d6d-bd37-51ab35840ee1`(S2b 칩 가독성 목업, `source=imported`)를 dev에서 chat sole-link로 강제 렌더해 재현:

- `props.src`가 **전체 페이지 캡처 이미지**를 가리킴(실측 `naturalWidth=2480, naturalHeight=3560`, 종횡비 ~0.7:1 — 세로로 매우 긴 이미지).
- `ArtifactThumbnail`이 이걸 16:9 `aspect-video` 박스에 **`object-cover`**로 렌더 → 세로 내용 대부분이 크롭됨.
- 잘려 남은 좁은 가로 슬라이스가 우연히 여백/패딩 구간에 걸리면 "흰 배경으로 깨진" 것처럼 보임 — **결재자가 근거 실물을 못 보고 승인**하게 되는 구조적 결함.

`artifact-stage.tsx`(전체 캔버스 뷰어)는 이미 `object-contain`을 쓰고 있었습니다 — **썸네일만** 이 버그가 있었습니다(EmbedCard/EntityPreviewModal이 소비하는, 결재 카드에서 여는 바로 그 컴포넌트).

## 판별 축 소거 과정
- ①git 이력 축: 17:44 KST 이후 뷰어 체인 관련 커밋 0건 — "우연히 고쳐짐" 가설 기각.
- ②다크테마 축: 다크에서도 동일 렌더(무관) — 목업 자체 라이트 배경은 의도된 자기완결 특성.
- ③실 재현으로 근본원인 확定(위).

## 변경 사항
`artifact-thumbnail.tsx`: image-format 분기 `object-cover` → `object-contain`(레터박스·크롭 0). PNG export 경로도 동일 분기 재사용이라 함께 적용(종횡비 유사한 경우 무해, 최악의 경우도 크롭보다 레터박스가 더 정직).

## 셀프 게이트
- `pnpm build` — EXIT 0
- `pnpm lint`(대상 파일) — EXIT 0
- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm exec vitest run artifact-thumbnail.test.tsx` — 3/3 pass(신규 — imported 세로 캡처·PNG export·html_blob 회귀 0 셋 다 잠금)

## Test plan
- [x] imported 아티팩트(props.src, canvas_bounds null) — `<img>`가 object-contain
- [x] PNG export 경로도 object-contain(회귀 0)
- [x] html_blob(자기완결 HTML) — iframe 경로 무영향(회귀 0)
- [ ] dev 배포 후 cf8629c6 실 픽셀 재확認 + 다른 imported 아티팩트 1~2개 교차 확認 — 배포 후 보고

🤖 Generated with [Claude Code](https://claude.com/claude-code)