### PR TITLE
[SID:2912] required 워크플로 3곳 pull_request.edited 추가 — 갈래D 처방①(GHA)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,15 @@ name: CI
 
 on:
   pull_request:
+    # story #2912(2899 그라운딩 갈래D 처방) — 기본값([opened, synchronize, reopened])엔
+    # edited가 없어, base branch만 바뀌고 새 커밋이 없는 재타겟(synchronize 미발화)에서
+    # 이 required 워크플로 자체가 재트리거되지 않았다(#3317 실사고). edited를 명시 추가해
+    # base 재타겟도 새 런을 튼다 — required 3잡(alembic-fresh-db·backend-test·ci)엔
+    # changes.base skip-필터를 걸지 않는다(그 잡들의 기존 `if: always()`가 스킵-캐스케이드
+    # 방지용이라, skip 조건을 더하면 그 방지를 무력화한다 — [[ci-stuck-c-d-remedy-design-20260822]]
+    # landmine 참고). title/body 편집에도 전체 재실행되지만 PR#3324의 concurrency그룹이
+    # 연속 편집 시 구run을 자동취소해 낭비를 완화한다.
+    types: [opened, synchronize, reopened, edited]
     branches: [main, develop]
   push:
     branches: [main, develop]

--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -40,12 +40,14 @@ name: Design Review Gate
 # ⚠️등록 «이전»에 이미 열려 있던 PR은 이 체크를 자동으로 못 받을 수 있다 — GitHub이 그
 # PR에 대해선 이 체크를 아예 "기대하지 않는" 상태로 남아 required인데도 «영원한 pending»이
 # 된다(실측 2026-07-31: #2737·#2294). 이것도 "안 잰 것"인데 앞서 잡은 스킵=통과 병의
-# 반대편(안 재면서 빨강)이다 — 고치는 법이 코드가 아니라 사람 손(새 커밋 push로 synchronize
-# 이벤트를 유발하거나, PR을 close 후 재오픈)이라는 게 다르다.
+# 반대편(안 재면서 빨강)이다 — base branch만 바뀌고 새 커밋이 없는 재타겟(synchronize
+# 미발화)의 경우 story #2912(2899 그라운딩 갈래D) 이전엔 고치는 법이 코드가 아니라 사람 손
+# (새 커밋 push로 synchronize 이벤트를 유발하거나, PR을 close 후 재오픈)뿐이었다 — 아래
+# edited 추가로 이 케이스는 이제 자동 재트리거된다(#3317 실사고 재발 방지).
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
     branches: [main, develop]
 
 concurrency:

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -64,12 +64,14 @@ name: QA Review Gate
 # ⚠️등록 «이전»에 이미 열려 있던 PR은 이 체크를 자동으로 못 받을 수 있다 — GitHub이 그
 # PR에 대해선 이 체크를 아예 "기대하지 않는" 상태로 남아 required인데도 «영원한 pending»이
 # 된다(실측 2026-07-31: #2737·#2294). 이것도 "안 잰 것"인데 앞서 잡은 스킵=통과 병의
-# 반대편(안 재면서 빨강)이다 — 고치는 법이 코드가 아니라 사람 손(새 커밋 push로 synchronize
-# 이벤트를 유발하거나, PR을 close 후 재오픈)이라는 게 다르다.
+# 반대편(안 재면서 빨강)이다 — base branch만 바뀌고 새 커밋이 없는 재타겟(synchronize
+# 미발화)의 경우 story #2912(2899 그라운딩 갈래D) 이전엔 고치는 법이 코드가 아니라 사람 손
+# (새 커밋 push로 synchronize 이벤트를 유발하거나, PR을 close 후 재오픈)뿐이었다 — 아래
+# edited 추가로 이 케이스는 이제 자동 재트리거된다(#3317 실사고 재발 방지).
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
     branches: [main, develop]
 
 concurrency:


### PR DESCRIPTION
[SID:2912]

## 배경
[story #2899 그라운딩](entity:doc:d91624d0-94db-4b5c-be2a-68039f9eab6c) 갈래D(미트리거, #3317 실사고: 재타겟 후 CI 미트리거)의 GHA 레이어 처방. 설계 근거: [갈래C/D 처방설계 그라운딩](entity:doc:f538d3e8-33b5-40f8-9266-b95f82ea93f0)(PO 승인).

## 근본원인
`gh api repos/moonklabs/sprintable/branches/develop/protection --jq '.required_status_checks.contexts'`로 실측한 required 6개 중 GHA 소속 5개(`Backend pytest`·`Lint, Type Check, Test, Build`·`Alembic upgrade head (fresh DB)`=ci.yml, `Design review gate`·`QA review gate`)가 걸린 3개 워크플로 파일 전부 `pull_request.edited`(base branch 변경 시 발화)를 안 듣고 있었다:
- `ci.yml` — `types:` 자체 생략 → GitHub 기본값 `[opened, synchronize, reopened]`.
- `qa-review-gate.yml`/`design-review-gate.yml` — `types:` 명시했지만 `[opened, synchronize, reopened, labeled, unlabeled]`로 `edited` 부재.

새 커밋 없이 base branch만 바뀌면(재타겟) `synchronize`는 안 뜨고 `edited`가 유일하게 반응 가능한데, 아무도 안 들어서 이 3곳(required 체크가 걸린 워크플로 전부) 재트리거 자체가 없었다.

## 변경
3개 파일 모두 `types:`에 `edited` 추가.

## 스코프 판단 — `changes.base` skip-필터는 안 건다(landmine)
설계문서 초안은 "edited는 title/body 편집에도 뜨니 changes.base 유무로 필터링해 낭비 방지"였으나, 착수 중 발견: `alembic-fresh-db`·`backend-test` 잡엔 이미 `if: always()`가 붙어 있고 그 자리에 "없으면 detect-changed-scope가 실패했을 때 required 체크 자체가 스킵된다"는 ⛔주석이 있다. 여기에 `changes.base` skip 조건을 더하면 이 repo가 이미 막아둔 "required 체크가 skipped로 뜨는" 구멍을 재개방한다(카디르 QA #3297 지적 — feedback_ci_stuck_run_absent_check_not_green과 동형 위험). 그래서 이 PR은 `edited` 커버리지 확장만 하고 필터는 걸지 않는다 — title/body 순수편집에도 전체 재실행되지만, PR#3324의 concurrency그룹이 연속 편집 시 구run을 자동취소해 낭비를 완화한다.

## 스코프 — BE 레이어는 별도 PR
`verdict_capture.py`의 웹훅 처리 3곳(같은 `edited` 부재 갭)은 이 PR에 안 담았다 — BE 변경은 실PG 뮤테이션 테스트가 필요해 GHA YAML-only PR과 셀프게이트 방식이 달라 스코프 분리(카디르 사슬로 이어감, 이 PR이 develop에 머지된 뒤 착수).

## 셀프 게이트
- 3개 파일 전부 `python3 -c "import yaml; yaml.safe_load(...)"` valid YAML 확認.
- 순수 트리거 조건 추가(`types:` 배열에 원소 1개 추가)라 기존 스텝 로직 무변경 — 회귀 위험 최소.
- 실제 재트리거 동작은 이 PR이 develop에 머지된 뒤, 어떤 PR의 base가 재타겟될 때 자연 검증(워크플로 트리거 자체의 동작이라 이 PR 자신 안에서 재현하기 어려움).

🤖 Generated with [Claude Code](https://claude.com/claude-code)