### PR TITLE
[SID:2913] NOT_FOUND_PAYMENT stale pending — 로그 노이즈 제거

### DIFF
--- a/backend/app/services/billing_scheduler.py
+++ b/backend/app/services/billing_scheduler.py
@@ -42,7 +42,7 @@ from app.services.billing_charge_amount import ChargeAmountError, compute_charge
 from app.services.billing_period import compute_period_end
 from app.services.email import send_email
 from app.services.org_subscription_checkout import STALE_CLAIM_WINDOW
-from app.services.payment.toss_adapter import TossAdapter
+from app.services.payment.toss_adapter import TossAdapter, TossApiError
 from app.services.platform_settings import get_platform_settings
 
 logger = logging.getLogger(__name__)
@@ -354,10 +354,28 @@ async def sweep_stale_pending_orders(session: AsyncSession, *, now: datetime | N
         )
     ).scalars().all()
 
-    confirmed = failed = skipped = 0
+    confirmed = failed = skipped = not_found = 0
     for order in stale_orders:
         try:
             lookup = await TossAdapter().get_payment_by_order_id(order_id=order.order_id)
+        except TossApiError as exc:
+            if exc.code == "NOT_FOUND_PAYMENT":
+                # story #2913(2896 첫 실행 실증) — Toss가 이 주문을 애초에 모른다는
+                # *확정* 신호(위젯 진입 前 이탈 등)라, 아래 일반 except의 "조회 자체
+                # 실패(네트워크 등) = 혹시 성공했을 수도 있다"는 전제와 다르다. pending은
+                # 그대로 둔다(#2884 안전측 설계 그대로 — 삭제·failed 전환 없음) — 이
+                # 주문은 cutoff를 넘은 이상 매일 재스윕되고 매번 같은 결과를 받는데, 그걸
+                # logger.exception(풀 traceback)으로 매번 다시 찍으면 운영 로그가 "확정된
+                # 무해 사실"로 영구 오염된다. 별도 카운트+INFO 한 줄로 조용히 넘긴다.
+                logger.info(
+                    "stale pending order_id=%s — Toss NOT_FOUND_PAYMENT(확정 미발생, 위젯 진입 前 이탈 등) — leaving pending",
+                    order.order_id,
+                )
+                not_found += 1
+                continue
+            logger.exception("stale pending reconciliation lookup failed for order_id=%s — leaving pending", order.order_id)
+            skipped += 1
+            continue
         except Exception:
             # PO fix-forward(#2884 리뷰) — 조회 자체가 실패(네트워크 일시 장애 등)한 것과
             # "Toss가 이 주문을 모른다/실패로 안다"는 다른 신호다. 전자를 failed로 찍으면
@@ -382,7 +400,7 @@ async def sweep_stale_pending_orders(session: AsyncSession, *, now: datetime | N
 
     return {
         "stale_pending_seen": len(stale_orders), "confirmed": confirmed,
-        "failed": failed, "skipped_lookup_error": skipped,
+        "failed": failed, "skipped_lookup_error": skipped, "not_found_confirmed_absent": not_found,
     }
 
 

--- a/backend/tests/test_e_2494_c3_scheduler.py
+++ b/backend/tests/test_e_2494_c3_scheduler.py
@@ -368,7 +368,10 @@ async def test_sweep_stale_pending_confirms_when_toss_lookup_done(monkeypatch):
 
     result = await sched.sweep_stale_pending_orders(session, now=now)
 
-    assert result == {"stale_pending_seen": 1, "confirmed": 1, "failed": 0, "skipped_lookup_error": 0}
+    assert result == {
+        "stale_pending_seen": 1, "confirmed": 1, "failed": 0,
+        "skipped_lookup_error": 0, "not_found_confirmed_absent": 0,
+    }
     confirm_mock.assert_awaited_once_with(
         session, org_id=stale_order.org_id, order_id=stale_order.order_id,
         amount_minor=stale_order.amount_minor, currency=stale_order.currency,
@@ -400,7 +403,10 @@ async def test_sweep_stale_pending_marks_failed_when_toss_lookup_not_done(monkey
 
     result = await sched.sweep_stale_pending_orders(session, now=now)
 
-    assert result == {"stale_pending_seen": 1, "confirmed": 0, "failed": 1, "skipped_lookup_error": 0}
+    assert result == {
+        "stale_pending_seen": 1, "confirmed": 0, "failed": 1,
+        "skipped_lookup_error": 0, "not_found_confirmed_absent": 0,
+    }
     confirm_mock.assert_not_awaited()
     fail_mock.assert_awaited_once()
 
@@ -431,9 +437,57 @@ async def test_sweep_stale_pending_leaves_pending_on_transient_lookup_error(monk
 
     result = await sched.sweep_stale_pending_orders(session, now=now)
 
-    assert result == {"stale_pending_seen": 1, "confirmed": 0, "failed": 0, "skipped_lookup_error": 1}
+    assert result == {
+        "stale_pending_seen": 1, "confirmed": 0, "failed": 0,
+        "skipped_lookup_error": 1, "not_found_confirmed_absent": 0,
+    }
     fail_mock.assert_not_awaited()
     confirm_mock.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_sweep_stale_pending_not_found_payment_leaves_pending_without_exception_log(monkeypatch, caplog):
+    """story #2913(2896 첫 실행 실증) — Toss NOT_FOUND_PAYMENT는 "혹시 성공했을 수도"인
+    조회실패(위 테스트)와 달리 확정 미발생 신호. failed로도 skipped_lookup_error로도 안
+    찍히고 별도 카운트(not_found_confirmed_absent)로만 집계, order는 안 건드림(pending
+    유지) + logger.exception(풀 traceback)이 아니라 INFO 한 줄이어야 매일 재스윕에도
+    로그가 오염 안 됨."""
+    import logging
+
+    import app.services.billing_scheduler as sched
+    from app.services.payment.toss_adapter import TossApiError
+
+    now = datetime(2026, 8, 15, tzinfo=timezone.utc)
+    stale_order = _order(status="pending", created_days_ago=1, updated_days_ago=1, now=now)
+
+    session = AsyncMock()
+    orders_result = MagicMock()
+    orders_result.scalars.return_value.all.return_value = [stale_order]
+    session.execute = AsyncMock(return_value=orders_result)
+
+    monkeypatch.setattr(
+        sched.TossAdapter, "get_payment_by_order_id",
+        AsyncMock(side_effect=TossApiError("NOT_FOUND_PAYMENT", "결제 정보를 찾을 수 없습니다", status_code=404)),
+    )
+    fail_mock = AsyncMock()
+    confirm_mock = AsyncMock()
+    monkeypatch.setattr(sched, "_mark_failed_if_not_confirmed", fail_mock)
+    monkeypatch.setattr(sched, "_confirm_with_ledger", confirm_mock)
+
+    with caplog.at_level(logging.INFO, logger=sched.logger.name):
+        result = await sched.sweep_stale_pending_orders(session, now=now)
+
+    assert result == {
+        "stale_pending_seen": 1, "confirmed": 0, "failed": 0,
+        "skipped_lookup_error": 0, "not_found_confirmed_absent": 1,
+    }
+    fail_mock.assert_not_awaited()
+    confirm_mock.assert_not_awaited()
+    # 풀 traceback(exc_info) 없이 INFO 레벨 한 줄만 — logger.exception이 아니라 logger.info.
+    assert any(
+        r.levelno == logging.INFO and "NOT_FOUND_PAYMENT" in r.getMessage() and r.exc_info is None
+        for r in caplog.records
+    )
 
 
 # ─── trigger_due_charges — story #2907이 실제로 채웠다(구 NotImplementedError 폐기) ────


### PR DESCRIPTION
[SID:2913]

## 배경
story #2896 첫 실행(Cloud Scheduler 잡 실증) 즉시 실증: `sweep_stale_pending_orders`가 오늘 #2892 검증 잔여 stale pending을 Toss 실조회 → `NOT_FOUND_PAYMENT`. 코드 확認 결과 이 경로는 "조회 자체 실패(네트워크 등, 혹시 성공했을 수도)"와 같은 `except Exception` 분기로 묶여 `logger.exception`(풀 traceback)을 매번 다시 찍는다 — 이 주문은 `PENDING_STALE_AFTER` cutoff를 넘은 이상 상한 없이 매일(03:15 KST) 재스윕되므로, 시간이 지나도 절대 정리되지 않는 영구 반복 예외 로그가 된다.

## 변경
`TossAdapter.get_payment_by_order_id()`가 던지는 `TossApiError`를 먼저 잡아 `code == "NOT_FOUND_PAYMENT"`만 별도 분기로 구분:
- INFO 레벨 한 줄(풀 traceback 없음)로만 로깅
- 새 카운터 `not_found_confirmed_absent`로 집계(기존 `skipped_lookup_error`와 분리)
- **order 상태는 그대로 pending 유지** — 데이터 처리는 무변경(#2884 안전측 설계 그대로: 삭제·failed 전환 없음). 이 PR은 순수 관측성(로그 노이즈) 수정이다.

그 외 `TossApiError`(다른 code)·일반 `Exception`은 기존 `skipped_lookup_error` 경로 그대로 유지.

## 왜 이 방식인가(대안 배제)
- 새 billing_orders 상태값(예: `abandoned`)을 추가하는 방식도 검토했으나, `status` 컬럼을 건드리면 `status='pending'`을 가정하는 다른 다운스트림(대시보드·집계 등)에 의도치 않은 영향이 갈 수 있어 스코프 밖. 이번 사안의 실제 통증은 "로그 노이즈"뿐이라 그것만 정확히 겨냥.

## 테스트
`tests/test_e_2494_c3_scheduler.py` — 기존 3개(`test_sweep_stale_pending_*`) 반환 dict에 신규 키 반영해 갱신, 신규 1개(`test_sweep_stale_pending_not_found_payment_leaves_pending_without_exception_log`) 추가: NOT_FOUND_PAYMENT 시 order 무변화·INFO 레벨(exc_info 없음)·카운터 분리를 직접 검증. 전체 26/26 pass, 인접 billing 테스트(`test_e_2492_c1_billing_key.py`·`test_e_2495_c4_refund_reconciliation.py`·`test_edg_s8_watchdog.py`) 회귀 확認, `import app.main` clean.

## Test plan
- [x] 신규 테스트로 NOT_FOUND_PAYMENT 분기 직접 검증(로그 레벨·카운터·pending 무변화)
- [x] 기존 3개 스윕 테스트 반환 dict 갱신 후 pass
- [x] 인접 billing 테스트 회귀 확認