### PR TITLE
[SID:2912] verdict-head-check 컴포지트 액션 추출 — 갈래C 처방②

### DIFF
--- a/.github/actions/verdict-head-check/action.yml
+++ b/.github/actions/verdict-head-check/action.yml
@@ -51,7 +51,7 @@ runs:
       run: |
         set -euo pipefail
         LATEST_VERDICT_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-          --jq --arg re "${HEADER_REGEX}" '.[] | select(.body | test($re)) | [.created_at, .body] | @tsv' \
+          | jq -r --arg re "${HEADER_REGEX}" '.[] | select(.body | test($re)) | [.created_at, .body] | @tsv' \
           | sort | tail -1 | cut -f2-)"
         if [ -z "${LATEST_VERDICT_BODY}" ]; then
           echo "::error title=${LABEL_NAME} verdict comment not found::${LABEL_NAME} 라벨은 있는데 그 근거 판정 코멘트를 못 찾았다(패턴: ${HEADER_REGEX}) — head 대조 불가. fail-closed."

--- a/.github/actions/verdict-head-check/action.yml
+++ b/.github/actions/verdict-head-check/action.yml
@@ -1,0 +1,75 @@
+name: Verdict head check
+description: >
+  qa/design review gate 공용 — 최신 판정 코멘트가 명시한 head SHA가 현재 PR head와
+  일치하는지 확認(fail-closed). story #2676(신설)·#2912(2899 그라운딩 갈래C, 컴포지트
+  액션 추출) 참고.
+
+# story #2912 — qa-review-gate.yml과 design-review-gate.yml이 이 로직(코멘트 fetch·
+# 최신순 정렬·빈값 fail-closed·head추출·비교·에러메시지)을 그대로 복붙하고 있었다
+# (story #2676·#2827 fix가 양쪽에 각각 따로 적용된 이력이 그 증거). 그 중복만 여기로
+# 수렴한다.
+#
+# ⛔header-regex·head-extract-regex는 «파라미터로 유지한다» — 하나로 통일하지 않는다.
+# 이유: qa-review-gate.yml은 "**Head:** `sha`" 고정포맷(카디르 자신의 규율)을 엄격 매치
+# 하지만, design-review-gate.yml은 유나의 실제 리뷰 코멘트 포맷이 그만큼 고정적이지
+# 않음을 실측(design-review-gate.yml 자체 주석: "리뷰 head: `9c8867e9`"·"PASS (head
+# `dd37eecb`)" 둘 다 관찰)해 의도적으로 느슨하게 잡은 것 — 드리프트가 아니라 리뷰어별
+# 실제 관행 차이를 반영한 정책 차이다(2026-08-22, 카디르 재대조+페드루 PO 판정 확定).
+# 여기를 하나의 정규식으로 «통일»하면 design 쪽 실제 리뷰 포맷 다수가 "verdict comment
+# not found"로 새로 fail-closed된다(진짜 회귀) — 다음 사람이 "왜 하나로 안 합쳤냐"고
+# 물으면 이 문단이 답이다.
+
+inputs:
+  label-name:
+    description: 판정 라벨 이름(예 qa:pass·design:pass) — 에러 메시지 표기용.
+    required: true
+  header-regex:
+    description: >
+      최신 판정 코멘트를 찾는 jq test() 패턴(POSIX ERE, comment.body 전체에 매치).
+      소비자마다 다르게 유지 — 위 ⛔주석 참고.
+    required: true
+  head-extract-regex:
+    description: >
+      판정 코멘트 본문에서 head SHA를 뽑는 grep -ioE 패턴(마지막 hex 그룹이 head).
+      소비자마다 다르게 유지 — 위 ⛔주석 참고.
+    required: true
+  gh-token:
+    description: gh api 호출용 토큰.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        LABEL_NAME: ${{ inputs.label-name }}
+        HEADER_REGEX: ${{ inputs.header-regex }}
+        HEAD_EXTRACT_REGEX: ${{ inputs.head-extract-regex }}
+      run: |
+        set -euo pipefail
+        LATEST_VERDICT_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+          --jq --arg re "${HEADER_REGEX}" '.[] | select(.body | test($re)) | [.created_at, .body] | @tsv' \
+          | sort | tail -1 | cut -f2-)"
+        if [ -z "${LATEST_VERDICT_BODY}" ]; then
+          echo "::error title=${LABEL_NAME} verdict comment not found::${LABEL_NAME} 라벨은 있는데 그 근거 판정 코멘트를 못 찾았다(패턴: ${HEADER_REGEX}) — head 대조 불가. fail-closed."
+          exit 1
+        fi
+        VERDICT_HEAD="$(printf '%s' "${LATEST_VERDICT_BODY}" | grep -ioE "${HEAD_EXTRACT_REGEX}" | head -1 | grep -oE '[0-9a-f]{7,40}$')"
+        if [ -z "${VERDICT_HEAD}" ]; then
+          echo "::error title=${LABEL_NAME} verdict head unparsable::가장 최근 ${LABEL_NAME} 판정 코멘트에서 head sha를 못 찾았다(패턴: ${HEAD_EXTRACT_REGEX}) — head 대조 불가. fail-closed."
+          exit 1
+        fi
+        echo "latest ${LABEL_NAME} verdict comment states head: ${VERDICT_HEAD}"
+        echo "current PR head: ${HEAD_SHA}"
+        case "${HEAD_SHA}" in
+          "${VERDICT_HEAD}"*)
+            echo "일치 — 가장 최근 ${LABEL_NAME} verdict가 현재 head를 보고 판정했다."
+            ;;
+          *)
+            echo "::error title=${LABEL_NAME} verdict is for a stale head::가장 최근 ${LABEL_NAME} 판정 코멘트가 명시한 head(${VERDICT_HEAD})가 현재 PR head(${HEAD_SHA})와 다르다 — 그 사이 새 커밋이 끼어들었다(story #2676). 재리뷰 후 ${LABEL_NAME}를 다시 붙일 것."
+            exit 1
+            ;;
+        esac

--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -203,37 +203,21 @@ jobs:
       # 적으면 fail-closed(모르면 실패)로 막지만, 위 두 관찰 포맷과 «다른» 새 포맷이 등장하면
       # 오탐(엉뚱한 코멘트를 판정 근거로 오인)이 생길 여지가 QA gate보다 크다 — 포맷이
       # 고정적이지 않다는 것 자체가 이 스텝의 한계다(디자인 게이트는 QA gate보다 약한 보증).
+      #
+      # story #2912(2899 그라운딩 갈래C) — qa-review-gate.yml이 이 로직을 그대로 복붙해
+      # 갖고 있었다(story #2676·#2827 fix가 양쪽에 각각 적용된 이력이 그 증거) — 공유
+      # 컴포지트 액션(.github/actions/verdict-head-check)으로 수렴. 정규식은 이 게이트의
+      # 기존 느슨한 패턴 그대로 전달(QA 쪽과 다른 이유는 그 액션 자체의 주석 참고 — 통일
+      # 대상 아님, 이 파일이 위에서 이미 밝힌 "포맷이 고정적이지 않다"는 사실을 그대로
+      # 반영한 의도적 차이).
       - name: Enforce design:pass verdict comment's stated head matches current PR head
         if: steps.scope.outputs.in_scope == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          LATEST_VERDICT_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq '.[] | select(.body | test("^## .*PASS")) | [.created_at, .body] | @tsv' \
-            | sort | tail -1 | cut -f2-)"
-          if [ -z "${LATEST_VERDICT_BODY}" ]; then
-            echo "::error title=design:pass verdict comment not found::design:pass 라벨은 있는데 그 근거로 보이는 'PASS' 판정 코멘트를 못 찾았다 — head 대조 불가. fail-closed."
-            exit 1
-          fi
-          VERDICT_HEAD="$(printf '%s' "${LATEST_VERDICT_BODY}" | grep -ioE 'head[^0-9a-f]*[0-9a-f]{7,40}' | head -1 | grep -oE '[0-9a-f]{7,40}$')"
-          if [ -z "${VERDICT_HEAD}" ]; then
-            echo "::error title=design:pass verdict head unparsable::가장 최근 design 판정 코멘트에서 head sha를 못 찾았다 — head 대조 불가. fail-closed."
-            exit 1
-          fi
-          echo "latest design verdict comment states head: ${VERDICT_HEAD}"
-          echo "current PR head: ${HEAD_SHA}"
-          case "${HEAD_SHA}" in
-            "${VERDICT_HEAD}"*)
-              echo "일치 — 가장 최근 design:pass verdict가 현재 head를 보고 판정했다."
-              ;;
-            *)
-              echo "::error title=design:pass verdict is for a stale head::가장 최근 design 판정 코멘트가 명시한 head(${VERDICT_HEAD})가 현재 PR head(${HEAD_SHA})와 다르다 — 그 사이 새 커밋이 끼어들었다(story #2676). 재리뷰 후 design:pass를 다시 붙일 것."
-              exit 1
-              ;;
-          esac
+        uses: ./.github/actions/verdict-head-check
+        with:
+          label-name: design:pass
+          header-regex: '^## .*PASS'
+          head-extract-regex: 'head[^0-9a-f]*[0-9a-f]{7,40}'
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       # story #2676 AC2 — qa-review-gate.yml과 동형(로직 복제). 잡 이름이 "— advisory"로
       # 끝나면 비차단 관례(실측 확認)라 그것만 빼고, design:pass 붙인 시점에 나머지 체크런

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -162,36 +162,19 @@ jobs:
       # ⛔이 스텝이 못 잡는 것 — QA verdict 코멘트가 "**Head:** \`sha\`" 포맷을 안 지키면(예:
       # 코멘트 형식을 사람이 바꾸면) fail-closed(모르면 통과가 아니라 실패)로 막긴 하지만,
       # «다른 포맷을 다른 포맷으로 오인식»해 틀린 head를 뽑을 가능성까지는 없앨 수 없다.
+      #
+      # story #2912(2899 그라운딩 갈래C) — design-review-gate.yml이 이 로직을 그대로
+      # 복붙해 갖고 있었다(story #2676·#2827 fix가 양쪽에 각각 적용된 이력이 그 증거) —
+      # 공유 컴포지트 액션(.github/actions/verdict-head-check)으로 수렴. 정규식은 이
+      # 게이트의 기존 엄격 패턴 그대로 전달(디자인 쪽과 다른 이유는 그 액션 자체의 주석
+      # 참고 — 통일 대상 아님, 리뷰어별 실제 코멘트 관행 차이를 반영한 의도적 차이).
       - name: Enforce qa:pass verdict comment's stated head matches current PR head
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          LATEST_VERDICT_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq '.[] | select(.body | test("^## QA verdict: approved \\(qa:pass\\)")) | [.created_at, .body] | @tsv' \
-            | sort | tail -1 | cut -f2-)"
-          if [ -z "${LATEST_VERDICT_BODY}" ]; then
-            echo "::error title=qa:pass verdict comment not found::qa:pass 라벨은 있는데 그 근거인 '## QA verdict: approved (qa:pass)' 코멘트를 못 찾았다 — head 대조 불가. fail-closed."
-            exit 1
-          fi
-          VERDICT_HEAD="$(printf '%s' "${LATEST_VERDICT_BODY}" | grep -oE '\*\*Head:\*\*[^0-9a-f]*[0-9a-f]{7,40}' | head -1 | grep -oE '[0-9a-f]{7,40}$')"
-          if [ -z "${VERDICT_HEAD}" ]; then
-            echo "::error title=qa:pass verdict head unparsable::가장 최근 QA verdict 코멘트에서 '**Head:** \`<sha>\`' 패턴을 못 찾았다 — head 대조 불가. fail-closed."
-            exit 1
-          fi
-          echo "latest QA verdict comment states head: ${VERDICT_HEAD}"
-          echo "current PR head: ${HEAD_SHA}"
-          case "${HEAD_SHA}" in
-            "${VERDICT_HEAD}"*)
-              echo "일치 — 가장 최근 qa:pass verdict가 현재 head를 보고 판정했다."
-              ;;
-            *)
-              echo "::error title=qa:pass verdict is for a stale head::가장 최근 QA verdict 코멘트가 명시한 head(${VERDICT_HEAD})가 현재 PR head(${HEAD_SHA})와 다르다 — 그 사이 새 커밋이 끼어들었다(story #2676, PR#3088 실사고와 동형). 재리뷰 후 qa:pass를 다시 붙일 것."
-              exit 1
-              ;;
-          esac
+        uses: ./.github/actions/verdict-head-check
+        with:
+          label-name: qa:pass
+          header-regex: '^## QA verdict: approved \(qa:pass\)'
+          head-extract-regex: '\*\*Head:\*\*[^0-9a-f]*[0-9a-f]{7,40}'
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       # story #2676 AC2 — PR#3088 실사고 ③: 최초 qa:pass 승인이 Backend pytest가 아직
       # in_progress이던 도중(job 95074664724, 21:49~21:59) 21:54에 나갔다 — 리뷰 코멘트가


### PR DESCRIPTION
[SID:2912]

## 배경
[story #2899 그라운딩](entity:doc:d91624d0-94db-4b5c-be2a-68039f9eab6c) 갈래C(stale 완주)의 처방. 설계 근거: [갈래C/D 처방설계 그라운딩](entity:doc:f538d3e8-33b5-40f8-9266-b95f82ea93f0)(PO 승인, 착수 中 2차 정정 포함).

## 근본원인
`qa-review-gate.yml`과 `design-review-gate.yml`이 "verdict 코멘트의 stated head가 현재 PR head와 일치하는지" 확認하는 로직(코멘트 fetch·최신순 정렬·빈값 fail-closed·head추출·비교·에러메시지)을 그대로 복붙해 갖고 있었다 — story #2676(신설)·#2827(순환대기 방지) fix가 양쪽에 각각 따로 적용된 이력이 그 증거(각 파일 주석에 "동형 사본" 명시).

## 변경
`.github/actions/verdict-head-check`(composite action) 신설로 보일러플레이트를 수렴하고, 두 게이트가 파라미터(`label-name`·`header-regex`·`head-extract-regex`)로 호출하도록 전환.

## ⛔정규식은 통일하지 않는다 — 착수 中 2차 정정(설계문서 반영)
1차 설계는 두 게이트의 정규식 차이를 "손으로 두 번 복사되며 생긴 드리프트"로 보고 통일을 검토했으나, 실제 파일을 전문 재대조한 결과 **design-review-gate.yml 자신의 주석이 그 느슨함을 명시적으로 정당화**하고 있었다:

> (원문) "디자인 리뷰 코멘트는 head를 명시하는 문구가 QA만큼 고정 포맷이 아니다(실측: '리뷰 head: `9c8867e9`'·'PASS (head `dd37eecb`)' 둘 다 관찰됨)"

QA(카디르)는 "**Head:** `sha`" 고정포맷을 스스로 지키지만, 유나의 실제 design 리뷰 코멘트는 그만큼 고정적이지 않다 — **리뷰어별 실제 관행 차이를 반영한 의도적 관용도 조정**이지 실수로 갈라진 사본이 아니다. 정규식을 통일했으면 design의 실제 리뷰 포맷 다수가 새로 "verdict comment not found"로 fail-closed됐을 것(진짜 회귀). 그래서 컴포지트 액션은 **구조(fetch/정렬/에러처리)만 수렴하고 정규식은 소비자별 파라미터로 그대로 유지** — action.yml 자체에 "왜 파라미터인가(정책 차이·통일 금지)" 주석을 박아 다음 사람이 재시도하는 것을 막았다(페드루군 지시).

## 셀프 게이트
- 3개 파일(action.yml·qa-review-gate.yml·design-review-gate.yml) 전부 valid YAML(`python3 -c "import yaml; yaml.safe_load(...)"`).
- `act` 로컬 실행기 미설치 — 대신 컴포지트 액션의 jq/grep 추출 로직을 GHA 밖에서 bash로 직접 시뮬레이션(정규식 문자열 그대로 이식): QA 표준 포맷("**Head:** `sha`")·design 관찰 포맷 2종("리뷰 head: `sha`"·"## PASS (head `sha`)") 전부 정확한 head 추출 확認, QA패턴이 design 코멘트를 오인하지 않는 스코프 격리도 확認(4/4 케이스 PASS).
- 두 게이트에 전달하는 정규식 문자열은 원본과 byte-identical(escape 처리 수동 재검증) — 동작 변화 없는 순수 구조 리팩터.
- 이 PR 자신이 `qa-review-gate.yml`을 건드리므로, 이 PR에 대한 향후 qa:pass verdict 판정 자체가 신규 컴포지트 액션(QA경로)을 라이브로 태운다 — 자기시연.

## 스코프
D-BE(`verdict_capture.py` 웹훅 3곳)는 별도 PR③으로 이어간다(BE 변경은 실PG 뮤테이션 테스트 필요, GHA YAML-only PR과 셀프게이트 방식이 달라 스코프 분리).

🤖 Generated with [Claude Code](https://claude.com/claude-code)