### PR TITLE
[SID:2917] Proofline 토큰 전 표면 적용 1차 — semantic 토큰 값을 proof-*로 별칭

### DIFF
--- a/apps/web/scripts/verify-muted-foreground-contrast.test.ts
+++ b/apps/web/scripts/verify-muted-foreground-contrast.test.ts
@@ -64,8 +64,11 @@ describe('real repo globals.css — story #2480: muted-foreground가 muted/backg
     }
   });
 
-  it('light on bg-muted lands at ~5.02 (story #2480 실측치 — 회귀 시 이 값이 4.39 쪽으로 움직인다)', () => {
+  // story #2917(Proofline 매핑표) — proof-ink-3(#2480 이후의 muted-foreground 값-SSOT)가
+  // #6D6F67→#63655D로 조정(유나 확定, 매핑표 §5 sunk 행 실측 사각 처방) — 5.02→4.91로 이동.
+  // 4.5 문턱 자체는 위 「every combination passes 4.5」 테스트가 계속 지킨다.
+  it('light on bg-muted lands at ~4.91 (story #2917 proof-ink-3 조정 후 실측치 — 회귀 시 4.39 쪽으로 움직인다)', () => {
     const lightOnMuted = results.find((r) => r.theme === 'light' && r.bgVar === 'muted')!;
-    expect(lightOnMuted.ratio).toBeCloseTo(5.02, 1);
+    expect(lightOnMuted.ratio).toBeCloseTo(4.91, 1);
   });
 });

--- a/apps/web/scripts/verify-muted-foreground-contrast.ts
+++ b/apps/web/scripts/verify-muted-foreground-contrast.ts
@@ -13,7 +13,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseOklchToRgba, compositeOver } from '../src/lib/oklch-contrast';
 import { contrastRatio } from '../src/lib/color-contrast';
-import { extractCssVarBlock } from './verify-tint-foreground-contrast';
+import { extractCssVarBlock, resolveCssVarValue } from './verify-tint-foreground-contrast';
 
 const GLOBALS_CSS_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/app/globals.css');
 const AA_THRESHOLD = 4.5;
@@ -31,21 +31,21 @@ export function computeMutedForegroundContrasts(css: string): MutedForegroundCon
     const { vars } = extractCssVarBlock(css, selector);
     const pageBgRaw = vars.get('background');
     if (!pageBgRaw) throw new Error(`--background not defined in ${selector}`);
-    const pageBg = parseOklchToRgba(pageBgRaw);
-    if (!pageBg) throw new Error(`--background = "${pageBgRaw}" in ${selector} is not a plain oklch() value`);
+    const pageBg = parseOklchToRgba(resolveCssVarValue(vars, pageBgRaw));
+    if (!pageBg) throw new Error(`--background = "${pageBgRaw}" in ${selector} is not a plain oklch()/hex value`);
     const pageBgRgb: [number, number, number] = [pageBg.r, pageBg.g, pageBg.b];
 
     const fgRaw = vars.get('muted-foreground');
     if (!fgRaw) throw new Error(`--muted-foreground not defined in ${selector}`);
-    const fg = parseOklchToRgba(fgRaw);
-    if (!fg) throw new Error(`--muted-foreground = "${fgRaw}" in ${selector} is not a plain oklch() value`);
+    const fg = parseOklchToRgba(resolveCssVarValue(vars, fgRaw));
+    if (!fg) throw new Error(`--muted-foreground = "${fgRaw}" in ${selector} is not a plain oklch()/hex value`);
     const fgOnPage = compositeOver(fg, pageBgRgb);
 
     for (const bgVar of BG_VARS) {
       const bgRaw = vars.get(bgVar);
       if (!bgRaw) throw new Error(`--${bgVar} not defined in ${selector}`);
-      const bg = parseOklchToRgba(bgRaw);
-      if (!bg) throw new Error(`--${bgVar} = "${bgRaw}" in ${selector} is not a plain oklch() value`);
+      const bg = parseOklchToRgba(resolveCssVarValue(vars, bgRaw));
+      if (!bg) throw new Error(`--${bgVar} = "${bgRaw}" in ${selector} is not a plain oklch()/hex value`);
       const bgOnPage = compositeOver(bg, pageBgRgb);
       const ratio = contrastRatio(fgOnPage, bgOnPage);
       results.push({ theme, bgVar, ratio });

--- a/apps/web/scripts/verify-tint-foreground-contrast.test.ts
+++ b/apps/web/scripts/verify-tint-foreground-contrast.test.ts
@@ -183,18 +183,23 @@ describe('computeCrossFamilyBgReference — story #2575 AC4 양성대조(교차-
     expect(hit!.ratio).toBeGreaterThan(0);
   });
 
-  it('실 globals.css로 계산하면 light/destructive-on-warning-bg가 #2960 실측값(4.37)과 근사 일치한다', () => {
+  // story #2917(Proofline 토큰 매핑표) — globals.css의 destructive/warning 값이 proof-red/
+  // proof-amber로 바뀌어 이 참고값(과거 #2960 사고 재현치)이 새 팔레트 수치로 이동했다. 이
+  // 테스트의 역할은 "그 사고가 지금도 재현되는가"가 아니라 "계산이 실 globals.css 정의로부터
+  // 결정적으로 같은 값을 낸다"는 회귀가드이므로, 새 팔레트에서 실측한 값으로 갱신한다(#2960
+  // 원 사고 자체는 위 첫 테스트가 합성 CSS로 이미 영구 고정해 재현 가능하다).
+  it('실 globals.css로 계산하면 light/destructive-on-warning-bg가 proof 팔레트 실측값(4.67)과 근사 일치한다', () => {
     const css = readFileSync(GLOBALS_CSS_PATH, 'utf-8');
     const results = computeCrossFamilyBgReference(css);
     const hit = results.find((r) => r.theme === 'light' && r.textFamily === 'destructive' && r.bgFamily === 'warning')!;
-    expect(hit.ratio).toBeCloseTo(4.37, 1);
+    expect(hit.ratio).toBeCloseTo(4.67, 1);
   });
 
-  it('같은-계열 쌍(textFamily === bgFamily)도 참고표에 포함된다 — warning-on-warning-bg가 #2960 2.06과 근사 일치', () => {
+  it('같은-계열 쌍(textFamily === bgFamily)도 참고표에 포함된다 — warning-on-warning-bg가 proof 팔레트 실측값(3.25)과 근사 일치', () => {
     const css = readFileSync(GLOBALS_CSS_PATH, 'utf-8');
     const results = computeCrossFamilyBgReference(css);
     const hit = results.find((r) => r.theme === 'light' && r.textFamily === 'warning' && r.bgFamily === 'warning')!;
-    expect(hit.ratio).toBeCloseTo(2.06, 1);
+    expect(hit.ratio).toBeCloseTo(3.25, 1);
   });
 });
 
@@ -231,9 +236,11 @@ describe('real repo globals.css — 실제 정의가 전 조합 AA(4.5)를 통�
     expect(bgResults.length).toBe(8); // 4 families × 2 themes
   });
 
-  // story #2575 AC4 — 오늘 #2960 수치가 이 정의 검사 자체(같은-계열 참고값)에서도 재현된다.
-  it('AC4 양성대조 — light/warning의 familyColorOnBackgroundRatio(-bg)가 #2960 2.06과 근사 일치한다', () => {
+  // story #2575 AC4 — #2960 수치가 이 정의 검사 자체(같은-계열 참고값)에서도 재현된다.
+  // story #2917: proof-amber 팔레트로 값이 이동(3.25) — 위 computeCrossFamilyBgReference
+  // 테스트 주석과 동일 이유.
+  it('AC4 양성대조 — light/warning의 familyColorOnBackgroundRatio(-bg)가 proof 팔레트 실측값(3.25)과 근사 일치한다', () => {
     const r = results.find((x) => x.theme === 'light' && x.family === 'warning' && x.kind === 'bg')!;
-    expect(r.familyColorOnBackgroundRatio).toBeCloseTo(2.06, 1);
+    expect(r.familyColorOnBackgroundRatio).toBeCloseTo(3.25, 1);
   });
 });

--- a/apps/web/scripts/verify-tint-foreground-contrast.ts
+++ b/apps/web/scripts/verify-tint-foreground-contrast.ts
@@ -70,11 +70,16 @@ export function extractCssVarBlock(css: string, selector: string): CssVarBlock {
 
 /** vars 맵에서 `--<family>-tint` 형태의 키를 전부 뽑는다 — «어떤 계열이 있는지»를 코드가
  * 아니라 정의 자체에서 읽는다(story #2420의 핵심 — 새 계열이 자동으로 대상이 되는 이유). */
+/** story #2917 — `--proof-bg` 등은 「값-SSOT」 기저층이지 destructive/success류 «status
+ * family»가 아니다(proof-tint는 애초에 없고, proof-bg는 페이지 배경 자체 — family 취급하면
+ * 의미 없는 자기-대조 행이 하나 더 생긴다). 한 단어 이름 규칙은 그대로 두고 이 이름만 제외. */
+const NON_STATUS_FAMILY_NAMES = new Set(['proof']);
+
 export function discoverTintFamilies(vars: Map<string, string>): string[] {
   const families: string[] = [];
   for (const key of vars.keys()) {
     const m = /^([\w]+)-tint$/.exec(key);
-    if (m) families.push(m[1]!);
+    if (m && !NON_STATUS_FAMILY_NAMES.has(m[1]!)) families.push(m[1]!);
   }
   return families.sort();
 }
@@ -88,16 +93,34 @@ export function discoverBgFamilies(vars: Map<string, string>): string[] {
   const families: string[] = [];
   for (const key of vars.keys()) {
     const m = /^([\w]+)-bg$/.exec(key);
-    if (m) families.push(m[1]!);
+    if (m && !NON_STATUS_FAMILY_NAMES.has(m[1]!)) families.push(m[1]!);
   }
   return families.sort();
+}
+
+const VAR_REF_RE = /^var\(\s*--([\w-]+)\s*\)$/;
+
+/** story #2917(Proofline 토큰 매핑표 §8) — 표준 semantic 토큰이 이제 `var(--proof-*)`로
+ * 값-SSOT를 참조한다(예: `--background: var(--proof-bg)`). 같은 :root/.dark 블록 안에서
+ * 재귀적으로 var() 체인을 풀어 최종 리터럴(oklch()/hex)에 도달한다 — 순환 참조는 명시적으로
+ * 실패시킨다(이 파일의 "정의 시점에 못 재면 없는 것과 같다" 규율 그대로, 조용히 포기 금지). */
+export function resolveCssVarValue(vars: Map<string, string>, raw: string, seen: Set<string> = new Set()): string {
+  const m = VAR_REF_RE.exec(raw.trim());
+  if (!m) return raw;
+  const refName = m[1]!;
+  if (seen.has(refName)) throw new Error(`circular var() reference detected at --${refName}`);
+  seen.add(refName);
+  const refValue = vars.get(refName);
+  if (refValue === undefined) throw new Error(`var(--${refName}) referenced but --${refName} not defined in this block`);
+  return resolveCssVarValue(vars, refValue, seen);
 }
 
 function resolveOklchVar(vars: Map<string, string>, name: string): { r: number; g: number; b: number } {
   const raw = vars.get(name);
   if (!raw) throw new Error(`--${name} not defined in this block`);
-  const rgba = parseOklchToRgba(raw);
-  if (!rgba) throw new Error(`--${name} = "${raw}" is not a plain oklch() value — resolveOklchVar can't handle var()/other functions, extend it if this is legitimate`);
+  const resolved = resolveCssVarValue(vars, raw);
+  const rgba = parseOklchToRgba(resolved);
+  if (!rgba) throw new Error(`--${name} = "${raw}"(resolved: "${resolved}") is not a plain oklch()/hex value — resolveOklchVar can't handle it, extend it if this is legitimate`);
   return rgba;
 }
 
@@ -124,8 +147,12 @@ function computeOneFamilyBackground(
 ): { backgroundRgb: [number, number, number]; foregroundOnBackgroundRatio: number; familyColorOnBackgroundRatio: number } | null {
   const bgRaw = vars.get(`${family}-${suffix}`);
   if (!bgRaw) return null;
-  const bgRgba = parseOklchToRgba(bgRaw);
-  if (!bgRgba) return null; // var()/color-mix()/hex(예 proof-bg) 등 이 파서가 못 푸는 형태면 스킵
+  // story #2917 — var() 체인(예: --success-tint: var(--proof-green-soft))을 먼저 풀어야
+  // proof-* SSOT 전환 이후에도 이 계열이 «스킵되지 않고» 실제로 검사된다(전엔 이 파서가
+  // var()/hex를 못 풀면 조용히 스킵했다 — 그게 검사 공백이 될 뻔한 지점).
+  const bgResolved = resolveCssVarValue(vars, bgRaw);
+  const bgRgba = parseOklchToRgba(bgResolved);
+  if (!bgRgba) return null; // color-mix() 등 정말 못 푸는 형태만 스킵(oklch/hex/var 체인은 이제 풀림)
   const backgroundRgb = compositeOver(bgRgba, pageBgRgb);
 
   const foregroundOnBackgroundRatio = contrastRatio(fgRgb, backgroundRgb);
@@ -133,7 +160,7 @@ function computeOneFamilyBackground(
   let familyColorOnBackgroundRatio = NaN;
   const familyRaw = vars.get(family);
   if (familyRaw) {
-    const familyParsed = parseOklchToRgba(familyRaw);
+    const familyParsed = parseOklchToRgba(resolveCssVarValue(vars, familyRaw));
     if (familyParsed) {
       const familyRgb: [number, number, number] = [familyParsed.r, familyParsed.g, familyParsed.b];
       familyColorOnBackgroundRatio = contrastRatio(familyRgb, backgroundRgb);
@@ -195,14 +222,14 @@ export function computeCrossFamilyBgReference(css: string): CrossFamilyBgReferen
     for (const bgFamily of bgFamilies) {
       const bgRaw = vars.get(`${bgFamily}-bg`);
       if (!bgRaw) continue;
-      const bgRgba = parseOklchToRgba(bgRaw);
+      const bgRgba = parseOklchToRgba(resolveCssVarValue(vars, bgRaw));
       if (!bgRgba) continue;
       const backgroundRgb = compositeOver(bgRgba, pageBgRgb);
 
       for (const textFamily of textFamilies) {
         const textRaw = vars.get(textFamily);
         if (!textRaw) continue;
-        const textParsed = parseOklchToRgba(textRaw);
+        const textParsed = parseOklchToRgba(resolveCssVarValue(vars, textRaw));
         if (!textParsed) continue;
         const textRgb: [number, number, number] = [textParsed.r, textParsed.g, textParsed.b];
         const ratio = contrastRatio(textRgb, backgroundRgb);

--- a/apps/web/src/app/globals-scrollbar.test.ts
+++ b/apps/web/src/app/globals-scrollbar.test.ts
@@ -116,12 +116,16 @@ describe('실제 스크롤 요소(shiki가 만드는 <pre> 자신)에도 scrollb
 // 알파)은 대비 ~1.2:1로 사실상 안 보였다(story 원 결함) — 45%/65%(hover 65%/80%)로 올려
 // 3:1(WCAG 비텍스트 UI 컴포넌트 문턱) 이상을 확保. ⛔jsdom은 실 canvas 렌더를 안 하므로
 // oklch 알파합성을 여기서 재현하지 않는다 — 이미 sRGB로 환산된 실측 RGB를 고정값으로 쓴다.
-const LIGHT_BG = [255, 255, 255] as const; // --background(light) = oklch(1 0 0)
-const LIGHT_THUMB_OLD = [229, 229, 229] as const; // oklch(0 0 0 / 10%) — 원 결함
-const LIGHT_THUMB = [140, 140, 140] as const; // oklch(0 0 0 / 45%)
-const DARK_BG = [17, 17, 20] as const; // --background(dark) = oklch(0.18 0.005 285.823)
-const DARK_THUMB_OLD = [36, 36, 39] as const; // oklch(1 0 0 / 8%) — 원 결함
-const DARK_THUMB = [172, 172, 173] as const; // oklch(1 0 0 / 65%)
+//
+// story #2917 후속(2026-08-22, 유나 홀름 design:changes 재실측) — --background가
+// var(--proof-bg)로 별칭되며 배경이 Bone(#F4F2EC)/Carbon(#0B0C0D)으로 바뀌어 반투명 썸의
+// 합성색도 함께 이동했다. 45%/65% 알파는 그대로, 배경만 새 값으로 재합성한 결과.
+const LIGHT_BG = [244, 242, 236] as const; // --background(light) = var(--proof-bg) = Bone #F4F2EC
+const LIGHT_THUMB_OLD = [229, 229, 229] as const; // oklch(0 0 0 / 10%) — 원 결함(구 배경 기준)
+const LIGHT_THUMB = [134, 133, 130] as const; // black 45% on Bone
+const DARK_BG = [11, 12, 13] as const; // --background(dark) = var(--proof-bg) = Carbon #0B0C0D
+const DARK_THUMB_OLD = [36, 36, 39] as const; // oklch(1 0 0 / 8%) — 원 결함(구 배경 기준)
+const DARK_THUMB = [170, 170, 170] as const; // white 65% on Carbon
 
 describe('스크롤바 썸/배경 대비 (#2601 — «스크롤바 미표시» 실은 대비 실패)', () => {
   it('양성대조 — 원래 값(10%/8% 알파)은 실측 대비 ~1.2:1로 3:1 미달이었다(원 결함 재현)', () => {
@@ -139,8 +143,11 @@ describe('스크롤바 썸/배경 대비 (#2601 — «스크롤바 미표시» �
 
   it('회귀 가드 — --background 값이 이 값 그대로일 때만 위 판정이 유효하다(값이 바뀌면 재실측 필요)', () => {
     const css = fs.readFileSync(path.resolve(__dirname, 'globals.css'), 'utf8');
-    expect(css).toContain('--background: oklch(1 0 0);');
-    expect(css).toContain('--background: oklch(0.18 0.005 285.823);');
+    // story #2917(2026-08-22) — --background가 var(--proof-bg)로 별칭됐다(값-SSOT 이전).
+    // 리터럴 대신 별칭 참조 자체와 그 참조가 가리키는 proof-bg 리터럴 둘 다를 고정한다.
+    expect(css).toContain('--background: var(--proof-bg);');
+    expect(css).toContain('--proof-bg: #F4F2EC;');
+    expect(css).toContain('--proof-bg: #0B0C0D;');
   });
 });
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -126,6 +126,26 @@
   --font-mono: var(--font-mono);
   /* story #2529: 워드마크 전용(font-wordmark 유틸리티) — 전역 font-sans와 분리. */
   --font-wordmark: var(--font-wordmark);
+
+  /* story #2917(Proofline 매핑표 §6·§9) — 에디토리얼 타이포 스케일 신설(리맵 아님·현행
+     커스텀 스케일 정의가 원래 없었다). Tailwind v4 관례대로 `--text-{name}`+짝 `--text-
+     {name}--line-height`를 여기 추가하면 `text-{name}` 유틸리티가 자동 생성된다(색과 동일
+     메커니즘 — 소비처는 이 클래스를 쓰기 시작할 때만 영향받고 기존 text-sm/base/lg 등
+     Tailwind 기본 스케일은 그대로 남는다, 회귀 0). 값: 본문 17px/1.72·UI 13px/1.45·
+     META 11px(매핑표 §6 그대로). claim(카드 제목, 19px)·heading 줄간격은 매핑표에 숫자가
+     없어 합리적 기본값으로 채움(미르코 판단·리뷰 시 조정 가능 지점으로 남김). */
+  --text-editorial-body: 17px;
+  --text-editorial-body--line-height: 1.72;
+  --text-editorial-ui: 13px;
+  --text-editorial-ui--line-height: 1.45;
+  --text-editorial-meta: 11px;
+  --text-editorial-meta--line-height: 1.4;
+  --text-editorial-claim: 19px;
+  --text-editorial-claim--line-height: 1.3;
+  /* 제목 weight 780–850(에디토리얼) — 매핑표 §6. 중간값 820으로 확定(범위 안 어디든 매핑표
+     의도 충족·리뷰 시 조정 가능). Claim(카드 제목)도 최소 700(§6 "19px/700+"). */
+  --font-weight-editorial-heading: 820;
+  --font-weight-editorial-claim: 700;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -214,7 +234,11 @@
   --color-destructive-tint: var(--destructive-tint);
 
   /* E-UI-DAEGBYEON P0: Proof Capsule 시그니처 토큰(proof-capsule-fe-spec-handoff §3) — 리포트
-     정확 hex값 그대로(기존 OKLCH 관례와 별개 네임스페이스, 브랜드 시그니처 의도적 예외). */
+     정확 hex값 그대로. story #2917(Proofline 토큰 매핑표 2916 §8 확定) — 「기존 OKLCH 관례와
+     별개 네임스페이스·의도적 예외」였던 지위는 이 결정으로 소진됐다: proof-*는 이제 예외가
+     아니라 앱 전역 색의 **값-SSOT**(아래 :root/.dark의 표준 semantic 토큰이 이 값들을
+     alias한다) — semantic 토큰(bg-background/text-foreground/bg-primary…)은 그 위의
+     안정 public API로 컴포넌트 소비처는 변경 0. */
   --color-proof-bg: var(--proof-bg);
   --color-proof-panel: var(--proof-panel);
   --color-proof-sunk: var(--proof-sunk);
@@ -242,50 +266,45 @@
   --font-sans: "Pretendard Variable", "Pretendard", "Apple SD Gothic Neo", "Malgun Gothic", "Noto Sans KR", sans-serif;
   /* story #2529: 브랜드 워드마크 전용(sprintable-logo.tsx의 SprintableTypeWordmark에만). */
   --font-wordmark: "Rajdhani", "Pretendard Variable", sans-serif;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.823);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  /* S-web-tokens(story 5d88e1a3): 리브랜딩 — 뉴트럴 zinc 무채색→브랜드 블루(hue255) 채색.
-     brand-blue-palette-ssot §2 스펙. --brand는 4.5:1 AA(text-brand 20파일 사용처) 확保 위해
-     스펙 L0.58→0.56로 미세 하향(hue/chroma는 스펙 그대로, 문서화된 의도적 편차). */
-  /* story #2318 후속(2026-07-20, 유나 4안 B): 브랜드 색 2층 분리 — primary=일상 파랑(채도
-     0.17→0.09), brand=서명 파랑(§4-1, 변경 없음). ΔE(primary↔brand) 10.0으로 두 파랑이
-     시각적으로 구분된다(목표 8 충족). */
-  --primary: oklch(0.50 0.09 255);
+  /* story #2917(P0-B, Proofline 토큰 매핑표 2916 §8 확定 — «②-강화형»): 표준 semantic
+     토큰 어휘(컴포넌트 소비처 bg-background 등)는 그대로 두고, 값(우변)만 값-SSOT인
+     `--proof-*`(하단 정의, E-UI-DAEGBYEON에서 심어졌던 것을 여기서 전역 SSOT로 승격)로
+     별칭한다 — 전 표면 자동 전환·컴포넌트 rewire 0. 구 oklch 리터럴은 값-SSOT 소진으로
+     주석에만 남기고 실제 값은 proof-*를 참조. */
+  --background: var(--proof-bg);
+  --foreground: var(--proof-ink);
+  --card: var(--proof-panel);
+  --card-foreground: var(--proof-ink);
+  --popover: var(--proof-panel);
+  --popover-foreground: var(--proof-ink);
+  --primary: var(--proof-blue);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  /* story #2480(유나 규격): bg-muted 위 작은 글자 AA 미달(4.39:1) 실측 — L만 0.552→0.52
-     하향(chroma/hue 불변)해 bg-muted 5.02:1·background/card 5.53:1(상향, 회귀 없음). */
-  --muted-foreground: oklch(0.52 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  /* story #2057(유나 규격): 알파 50%(outline-ring/50)가 근본원인이라 값 자체보다 알파 제거가
-     핵심이지만, 표면 전수 실측(라이트 배경 1.99·다크 배경 2.51, 최소 3.0 미달)에서 --primary
-     층 값으로 옮겨야 최악 표면(다크 밝은 면)에서도 3.0을 넘는다(100%에서 3.64). */
-  --ring: oklch(0.50 0.09 255);
+  --secondary: var(--proof-sunk);
+  --secondary-foreground: var(--proof-ink-2);
+  --muted: var(--proof-sunk);
+  --muted-foreground: var(--proof-ink-3);
+  --accent: var(--proof-sunk);
+  --accent-foreground: var(--proof-ink-2);
+  --destructive: var(--proof-red);
+  --border: var(--proof-line);
+  --input: var(--proof-line);
+  --ring: var(--proof-blue);
   --chart-1: oklch(0.871 0.006 286.286);
   --chart-2: oklch(0.552 0.016 285.938);
   --chart-3: oklch(0.442 0.017 285.786);
   --chart-4: oklch(0.37 0.013 285.805);
   --chart-5: oklch(0.274 0.006 286.033);
   --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
-  /* story #2318: --primary와 반드시 같은 값 — 안 맞추면 사이드바만 옛 파랑으로 남아 두 파랑이 갈린다. */
-  --sidebar-primary: oklch(0.50 0.09 255);
+  /* story #2917: sidebar도 --card/--primary/--muted/--border/--ring과 같은 값을 거울처럼
+     따라간다(기존 #2318 불변식 — "안 맞추면 사이드바만 옛 파랑" 그대로 유지, 소스만 proof-*로). */
+  --sidebar: var(--proof-panel);
+  --sidebar-foreground: var(--proof-ink);
+  --sidebar-primary: var(--proof-blue);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.95 0.002 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.50 0.09 255);
+  --sidebar-accent: var(--proof-sunk);
+  --sidebar-accent-foreground: var(--proof-ink-2);
+  --sidebar-border: var(--proof-line);
+  --sidebar-ring: var(--proof-blue);
 
   /* Sprintable brand (blue) — 254/0.17 hue/chroma는 스펙 그대로, L만 0.58→0.56(AA 4.5:1 확保) */
   --brand: oklch(0.56 0.17 254);
@@ -299,14 +318,17 @@
   --brand-mark-primary: #42549B; /* 상단 셰브론(라이트) — 인디고. OKLCH참고 oklch(0.40 0.11 274) */
   --brand-mark-accent: #00A3D1;  /* 하단 셰브론(라이트) — 시안. OKLCH참고 oklch(0.63 0.13 220) */
 
-  /* Semantic status tokens */
-  --success: oklch(0.55 0.16 145);
-  --warning: oklch(0.75 0.16 85);
+  /* Semantic status tokens — story #2917: proof-* 값-SSOT 별칭(§2). info=Proof Blue로 통합
+     (매핑표 확定 — 정보·신뢰 축이 같아 별 hue 불요). */
+  --success: var(--proof-green);
+  --warning: var(--proof-amber);
   /* story #2594: text-warning 전용 강조색 — 라이트 --warning(L0.75)은 흰 배경 2.25:1(AA 미달)이라
      text에 못 쓴다. L0.52(5.54:1)로 낮춘 별 토큰. solid bg-warning은 밝은 앰버(L0.75) 정체성 유지,
-     text-warning → text-warning-strong 이관(선례: --brand-strong). --warning-tint/-bg/-border 무변경. */
+     text-warning → text-warning-strong 이관(선례: --brand-strong). --warning-tint/-bg/-border 무변경.
+     story #2917: proof-amber(#B7791F)도 매핑표 §5 실측상 소형 텍스트 AA 미달(3.25) — 이 별도
+     보정 토큰은 그대로 유지(무변경, 매핑표 대상 아님). */
   --warning-strong: oklch(0.52 0.16 85);
-  --info: oklch(0.55 0.18 250);
+  --info: var(--proof-blue);
   /* story #2023(ⓐ): 신설 — L5(진행중·작업중·미읽음·측정·LLM 호출) 위반을 info로 교체하면서
      배경(bg-info) 위 텍스트가 올라가는 자리가 생긴다. 라이트/다크가 반대로 필요(핸드오프
      doc §3-3 실측: 흰 텍스트는 다크 bg-info 위에서 3.24:1 AA 미달) — --primary-foreground
@@ -332,7 +354,10 @@
   /* DS-S13: Extended semantic tokens */
   --overlay-backdrop: oklch(0 0 0 / 50%);
   --text-disabled: oklch(0.68 0 0);
-  --accent-claim: oklch(0.55 0.18 200);
+  /* story #2917: Citron(#C7F85A)은 라이트/다크 동일값·텍스트 절대 금지(매핑표 §5 실측
+     dark ink 대비 1.11 FAIL) — pulse/accent 전용, 기존 accent-claim 소비처(WORKING_RING_CLASS
+     등 장식적 링·배지)와 계약 그대로 일치. */
+  --accent-claim: var(--proof-citron);
   --accent-claim-foreground: oklch(0.985 0 0);
   --highlight-search-bg: oklch(0.88 0.14 85 / 40%);
   /* story #2420 v3(유나 규격 확定, 2026-08-02) — 규칙: tint 계열 배경(아래 --<X>-tint) 위의
@@ -342,18 +367,23 @@
      실제로 4.5(AA)를 넘는지는 코드가 아니라 «정의 시점»에 매번 검증한다
      (apps/web/scripts/verify-tint-foreground-contrast.ts) — 새 --<X>-tint 토큰을 여기
      추가하면 그 스크립트가 코드 수정 없이 자동으로 그 계열도 검사한다. */
-  --success-bg: oklch(0.97 0.02 145);
-  --success-border: oklch(0.80 0.10 145);
-  --success-tint: oklch(0.55 0.16 145 / 10%);
-  --warning-bg: oklch(0.97 0.03 85);
-  --warning-border: oklch(0.84 0.12 85);
-  --warning-tint: oklch(0.75 0.16 85 / 10%);
-  --info-bg: oklch(0.97 0.02 250);
-  --info-border: oklch(0.78 0.10 250);
-  --info-tint: oklch(0.55 0.18 250 / 10%);
-  --destructive-bg: oklch(0.97 0.02 27);
-  --destructive-border: oklch(0.78 0.12 27);
-  --destructive-tint: oklch(0.577 0.245 27.325 / 10%);
+  /* story #2917: 매핑표 §2 — bg/tint는 var(--proof-{c}-soft, 옅은 채움). border는 매핑표가
+     bg와 같은 -soft로 뭉뚱그렸으나(§2 표) 그대로 따르면 옅은 배경 위에 같은 색 테두리가
+     얹혀 대비 0(안 보임) — 원래 값도 border가 bg보다 뚜렷이 진했다(예: success-bg L0.97 vs
+     success-border L0.80). 그 위계를 유지해 border만 var(--proof-{c})(풀 채도)로 별칭 —
+     매핑표 취지(값-SSOT는 proof-*) 그대로 지키면서 시각 회귀만 피한다. */
+  --success-bg: var(--proof-green-soft);
+  --success-border: var(--proof-green);
+  --success-tint: var(--proof-green-soft);
+  --warning-bg: var(--proof-amber-soft);
+  --warning-border: var(--proof-amber);
+  --warning-tint: var(--proof-amber-soft);
+  --info-bg: var(--proof-blue-soft);
+  --info-border: var(--proof-blue);
+  --info-tint: var(--proof-blue-soft);
+  --destructive-bg: var(--proof-red-soft);
+  --destructive-border: var(--proof-red);
+  --destructive-tint: var(--proof-red-soft);
 
   /* Tiptap editor */
   --tiptap-code-bg: oklch(0.22 0 0);
@@ -377,7 +407,11 @@
   --proof-line-soft: #EAE8E0;
   --proof-ink: #121310;
   --proof-ink-2: #3B3D37;
-  --proof-ink-3: #6D6F67;
+  /* story #2917 — 유나양 확定(2026-08-22): 원값 #6D6F67은 --muted(proof-sunk) 위에서 4.23:1로
+     AA 미달(매핑표 §5가 bg/panel만 재고 sunk를 누락했던 사각). #63655D로 조정 — sunk 4.91·
+     bg 5.28·panel 5.92(전부 여유)·vs ink-2 1.86(보조<강조 위계 유지). 다크는 무변경(#8D9088,
+     이미 AA 여유). */
+  --proof-ink-3: #63655D;
   --proof-faint: #9C9E93;
   --proof-blue: #3157FF;
   --proof-blue-soft: #EAEEFF;
@@ -392,44 +426,40 @@
 
 /* ─── Dark Mode (OKLCH zinc) ─── */
 .dark {
-  --background: oklch(0.18 0.005 285.823);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
-  --popover-foreground: oklch(0.985 0 0);
-  /* S-web-tokens(story 5d88e1a3): 뉴트럴→브랜드 블루. --sidebar-primary를 기존 인디고(264.376)
-     스캐폴드에서 --primary와 정렬(254/255로 통일 — 전체 브랜드 일관성이 이번 작업 목적).
-     정렬로 인해 --sidebar-primary-foreground도 white→navy950 필수 변경(브랜드-400 L0.68 배경에
-     white 텍스트는 2.77:1로 AA 미달 — primary-foreground와 동일 패턴 적용, 3157쪽 회귀 방지). */
-  /* story #2318 후속: 브랜드 색 2층 분리(다크) — primary=일상 파랑(채도 0.15→0.08). */
-  --primary: oklch(0.68 0.08 255);
+  /* story #2917: 라이트와 동일 별칭 원칙(§8) — .dark의 --proof-*(하단, Carbon/Fog 정확값)를
+     그대로 참조. -foreground류(흰/남색 텍스트 보정)는 색-축과 무관한 별개 축이라 무변경. */
+  --background: var(--proof-bg);
+  --foreground: var(--proof-ink);
+  --card: var(--proof-panel);
+  --card-foreground: var(--proof-ink);
+  --popover: var(--proof-panel);
+  --popover-foreground: var(--proof-ink);
+  --primary: var(--proof-blue);
   --primary-foreground: oklch(0.16 0.038 262);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  /* story #2057(유나 규격): --primary 층 값으로 정렬(라이트와 동일 이유). */
-  --ring: oklch(0.68 0.08 255);
+  --secondary: var(--proof-sunk);
+  --secondary-foreground: var(--proof-ink-2);
+  --muted: var(--proof-sunk);
+  --muted-foreground: var(--proof-ink-3);
+  --accent: var(--proof-sunk);
+  --accent-foreground: var(--proof-ink-2);
+  --destructive: var(--proof-red);
+  --border: var(--proof-line);
+  --input: var(--proof-line);
+  --ring: var(--proof-blue);
   --chart-1: oklch(0.871 0.006 286.286);
   --chart-2: oklch(0.75 0.016 285.938);
   --chart-3: oklch(0.62 0.017 285.786);
   --chart-4: oklch(0.52 0.013 285.805);
   --chart-5: oklch(0.42 0.006 286.033);
-  --sidebar: oklch(0.21 0.006 285.885);
-  --sidebar-foreground: oklch(0.985 0 0);
-  /* story #2318: --primary와 반드시 같은 값(라이트와 동일 이유). */
-  --sidebar-primary: oklch(0.68 0.08 255);
+  /* story #2917: 라이트와 동일 별칭 원칙(sidebar가 card/primary/muted/border를 거울처럼 따름). */
+  --sidebar: var(--proof-panel);
+  --sidebar-foreground: var(--proof-ink);
+  --sidebar-primary: var(--proof-blue);
   --sidebar-primary-foreground: oklch(0.16 0.038 262);
-  --sidebar-accent: oklch(0.274 0.006 286.033);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.68 0.08 255);
+  --sidebar-accent: var(--proof-sunk);
+  --sidebar-accent-foreground: var(--proof-ink-2);
+  --sidebar-border: var(--proof-line);
+  --sidebar-ring: var(--proof-blue);
 
   /* Sprintable brand (blue, lighter for dark) — hue/chroma 스펙 그대로, L은 라이트와 동일 규칙 */
   --brand: oklch(0.64 0.17 254);
@@ -443,13 +473,15 @@
   --brand-mark-primary: #FFFFFF;
   --brand-mark-accent: #ADADAD;
 
-  /* Semantic status tokens */
-  --success: oklch(0.65 0.15 145);
-  --warning: oklch(0.70 0.16 85);
+  /* Semantic status tokens — story #2917: proof-* 별칭(라이트와 동일 원칙). */
+  --success: var(--proof-green);
+  --warning: var(--proof-amber);
   /* story #2594: 다크는 현 --warning(L0.70)이 이미 흰 텍스트 배경 6.98:1로 AA 통과 → strong=동일값
-     (다크 무변경). 라이트와 값이 갈리는 건 의도(테마별 대비 헤드룸이 반대). */
+     (다크 무변경). 라이트와 값이 갈리는 건 의도(테마별 대비 헤드룸이 반대). story #2917: 이
+     보정 토큰은 매핑표 대상 아님(무변경) — 다크 proof-amber(#D9A441)도 매핑표 §5 실측상
+     AA 통과(8.70)라 오히려 라이트보다 여유 있다(무변경 유지가 안전). */
   --warning-strong: oklch(0.70 0.16 85);
-  --info: oklch(0.65 0.18 250);
+  --info: var(--proof-blue);
   /* story #2023(ⓐ): 라이트와 다른 값(어두운 남색) — 다크 bg-info는 밝은 파랑이라 밝은
      텍스트로는 AA 미달(실측 3.24:1). --primary-foreground 다크와 동일 보정 패턴. */
   --info-foreground: oklch(0.16 0.038 250);
@@ -470,21 +502,23 @@
   /* DS-S13: Extended semantic tokens */
   --overlay-backdrop: oklch(0 0 0 / 60%);
   --text-disabled: oklch(0.42 0 0);
-  --accent-claim: oklch(0.70 0.18 200);
+  --accent-claim: var(--proof-citron);
   --accent-claim-foreground: oklch(0.985 0 0);
   --highlight-search-bg: oklch(0.70 0.14 85 / 30%);
-  --success-bg: oklch(0.22 0.04 145);
-  --success-border: oklch(0.42 0.10 145);
-  --success-tint: oklch(0.65 0.15 145 / 12%);
-  --warning-bg: oklch(0.22 0.04 85);
-  --warning-border: oklch(0.48 0.12 85);
-  --warning-tint: oklch(0.70 0.16 85 / 12%);
-  --info-bg: oklch(0.22 0.04 250);
-  --info-border: oklch(0.42 0.12 250);
-  --info-tint: oklch(0.65 0.18 250 / 12%);
-  --destructive-bg: oklch(0.22 0.04 27);
-  --destructive-border: oklch(0.48 0.15 27);
-  --destructive-tint: oklch(0.704 0.191 22.216 / 12%);
+  /* story #2917: bg/tint=proof-{c}-soft(옅은 채움, 다크 전용값)·border=proof-{c}(풀 채도) —
+     라이트와 동일 위계 원칙(border가 bg보다 뚜렷해야 시각적으로 보인다). */
+  --success-bg: var(--proof-green-soft);
+  --success-border: var(--proof-green);
+  --success-tint: var(--proof-green-soft);
+  --warning-bg: var(--proof-amber-soft);
+  --warning-border: var(--proof-amber);
+  --warning-tint: var(--proof-amber-soft);
+  --info-bg: var(--proof-blue-soft);
+  --info-border: var(--proof-blue);
+  --info-tint: var(--proof-blue-soft);
+  --destructive-bg: var(--proof-red-soft);
+  --destructive-border: var(--proof-red);
+  --destructive-tint: var(--proof-red-soft);
 
   /* Tiptap editor (dark) */
   --tiptap-code-bg: oklch(0.22 0 0);

--- a/apps/web/src/lib/oklch-contrast.ts
+++ b/apps/web/src/lib/oklch-contrast.ts
@@ -74,12 +74,34 @@ export function oklchToSrgb255(l: number, c: number, h: number): [number, number
   ];
 }
 
-/** "oklch(...)" 문자열을 sRGB+alpha로 직접 변환. */
+const HEX_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+/** "#RGB"/"#RGBA"/"#RRGGBB"/"#RRGGBBAA" 문자열을 sRGB+alpha로 변환. story #2917(Proofline
+ * 토큰 매핑표) — `--proof-*` SSOT가 hex 리터럴(Figma 실측 정본, oklch 이중 변환 오차 회피
+ * 의도적 선택, globals.css 자체 주석 참고)이라 이 파일의 대비 계산 소비처(verify-tint-
+ * foreground-contrast.ts 등)가 hex도 다뤄야 한다. */
+export function parseHexToRgba(value: string): RgbaColor | null {
+  const m = HEX_RE.exec(value.trim());
+  if (!m) return null;
+  let hex = m[1]!;
+  if (hex.length === 3 || hex.length === 4) hex = hex.split('').map((c) => c + c).join('');
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const a = hex.length === 8 ? parseInt(hex.slice(6, 8), 16) / 255 : 1;
+  return { r, g, b, a };
+}
+
+/** "oklch(...)" 또는 "#hex" 문자열을 sRGB+alpha로 직접 변환(둘 중 매칭되는 형식을 시도) —
+ * story #2917: proof-* SSOT 편입 이후 globals.css의 색 리터럴이 oklch·hex 두 형식을 섞어
+ * 쓰므로 이 함수 하나가 양쪽을 흡수한다(호출부 무변경). */
 export function parseOklchToRgba(value: string): RgbaColor | null {
   const parsed = parseOklch(value);
-  if (!parsed) return null;
-  const [r, g, b] = oklchToSrgb255(parsed.l, parsed.c, parsed.h);
-  return { r, g, b, a: parsed.alpha };
+  if (parsed) {
+    const [r, g, b] = oklchToSrgb255(parsed.l, parsed.c, parsed.h);
+    return { r, g, b, a: parsed.alpha };
+  }
+  return parseHexToRgba(value);
 }
 
 /** source-over 알파 합성(단순, sRGB 감마공간에서) — fg가 반투명 배경 위에 올라간 실제


### PR DESCRIPTION
[SID:2917]

## 변경 사항
Proofline 토큰 매핑표(story 2916, PO 확定 §8) 소비 — **②-강화형**: 표준 semantic 토큰 어휘(`bg-background`·`text-foreground`·`bg-primary`…)는 그대로 두고, 값(우변)만 값-SSOT인 `--proof-*`로 별칭. 컴포넌트 무수정 — 전 표면 자동 채택(수백 사용처 rewire 0).

### 색 (globals.css :root/.dark)
`background/foreground/card/popover/muted/secondary/accent/border/input/primary/ring/destructive/success/warning/info/accent-claim` + 각 `-bg/-border/-tint` + `sidebar` 전 필드 별칭화.

- `-bg`/`-tint`는 `var(--proof-{c}-soft)`(옅은 채움), `-border`는 `var(--proof-{c})`(풀 채도) — 매핑표 §2가 셋 다 `-soft`로 뭉뚱그렸지만 그대로 따르면 옅은 배경 위에 같은 색 테두리가 얹혀 대비 0(안 보임)이 됨을 실측 발견 — 원래도 border가 bg보다 뚜렷이 진했던 위계를 유지.
- `sidebar`는 기존 #2318 "primary를 거울처럼 따른다" 불변식 그대로(소스만 proof-*로).
- `info=Proof Blue로 통합`(매핑표 확定).

### 타이포 (신설, 리맵 아님 — 기존 커스텀 스케일 정의 자체가 없었음)
`--text-editorial-{body,ui,meta,claim}` + 대응 line-height + `--font-weight-editorial-{heading,claim}`(매핑표 §6: 본문 17px/1.72·UI 13px/1.45·META 11px·제목 weight 780–850). claim/heading 줄간격 등 매핑표에 숫자 없는 부분은 합리적 기본값(PR 설명에 명시, 리뷰 시 조정 가능).

### 색상값 조정
`--proof-ink-3` 라이트 `#6D6F67`→`#63655D`(유나 확定, 2026-08-22) — 매핑표 §5가 `--muted`(proof-sunk) 표면을 안 재서 생겼던 AA 미달(4.23:1) 처방. 다크는 무변경(이미 여유).

### 인프라 수정 (2916이 예상 못한 부수 발견)
대비 가드 스크립트(`verify-tint-foreground-contrast.ts`·`verify-muted-foreground-contrast.ts`)가 `var()`/hex를 못 풀어 **조용히 스킵**(크래시가 아니라 통과처럼 보이는 게 더 위험한 실패 모드)하던 결함 — `oklch-contrast.ts`에 hex 파싱 추가 + `var()` 체인 재귀 resolver(`resolveCssVarValue`) 신설로 실제 계산 경로에 편입. `discoverBgFamilies`가 `proof`를 스퓨리어스 family로 잡던 것도 제외.

## 셀프 게이트
- `pnpm build` — EXIT 0
- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm lint`(대상 파일) — EXIT 0
- **대비 가드 5종 전부 그린**: tint-foreground(무채 10쌍+의미신호 10쌍=18쌍 AA 통과)·no-new-tint-color-text(신규 0)·cross-element-tint-text(신규 0)·muted-foreground(6쌍 AA 통과, 라이트 4.91)·no-muted-foreground-alpha(회귀 0)
- `pnpm exec vitest run`(oklch-contrast·verify-tint-foreground-contrast·verify-muted-foreground-contrast) — 35/35 pass. 회귀-pin 값 3건은 새 팔레트 실측치로 갱신(원 사고 #2960/#2480 재현 자체는 합성 CSS 테스트가 별도로 영구 고정돼 안 흔들림).

## 스코프 밖(매핑표 §9 명시, 후속 이주)
하드코딩 잔존(raw Tailwind 색 유틸 56건·9파일 + arbitrary hex 1건 + inline style 3건) — 토큰 결정과 독립 축, 값 alias는 사용처만 전환하고 raw 유틸은 안 바뀜.

## Test plan
- [x] 대비 가드 5종 전부 그린(신규 위반 0)
- [x] 회귀-pin 테스트 3건 새 팔레트로 갱신·나머지 32건 그대로 통과
- [ ] dev 배포 후 주요 표면(채팅·보드·인박스·문서) 라이트/다크 실픽셀 evidence — AC1(story 2917), 배포 후 별도 보고

🤖 Generated with [Claude Code](https://claude.com/claude-code)