### PR TITLE
[SID:2921] S1 — 챗 영구 스플릿뷰 shell(D04 처방 골격)

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+//
+// story #2921 S1(D04 처방 골격) — 영구 스플릿뷰 shell 회귀가드. ChatListView 내부(SSE·fetch
+// 등)는 자기 테스트(chat-list-view.test.tsx)가 이미 잰다 — 여기는 이 layout이 실제로 잰다고
+// «주장»하는 것(①ChatListView 단일 마운트 ②경로별 반응형 클래스 토글 ③새 대화 버튼 배선)만
+// 좁게 검증한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../messages/ko.json';
+import ChatsLayout from './layout';
+
+const useDashboardContextMock = vi.fn();
+vi.mock('../../dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+const usePathnameMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  usePathname: () => usePathnameMock(),
+}));
+
+// story #2921 — ChatListView 자체 로직(SSE·fetch·모달 내부)은 스코프 밖. open/onOpenChange를
+// 그대로 받는지만 확認하는 얕은 스텁.
+vi.mock('@/components/chat/chat-list-view', () => ({
+  ChatListView: ({ open }: { open?: boolean }) => (
+    <div data-testid="chat-list-view">chat-list-view(open={String(open)})</div>
+  ),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'member-1', projectId: 'proj-1' });
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe('ChatsLayout — story #2921 S1(영구 스플릿뷰 shell)', () => {
+  it('ChatListView는 정확히 1곳만 마운트된다(리스트 경로·대화 경로 둘 다 — 이중 구독 방지가 이 story의 핵심 근거)', async () => {
+    usePathnameMock.mockReturnValue('/chats');
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><div>children</div></ChatsLayout>));
+    });
+    expect(container.querySelectorAll('[data-testid="chat-list-view"]')).toHaveLength(1);
+  });
+
+  it('/chats(리스트 경로) — 레일은 모바일에서도 보이고(lg 무관 flex), outlet은 모바일에서 숨는다(hidden)', async () => {
+    usePathnameMock.mockReturnValue('/chats');
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><div data-testid="outlet-content">outlet</div></ChatsLayout>));
+    });
+    const rail = container.querySelector('[data-testid="chat-rail"]');
+    const outlet = container.querySelector('[data-testid="chat-outlet"]');
+    expect(rail?.className).toContain('flex');
+    expect(rail?.className).not.toMatch(/(^|\s)hidden(\s|$)/);
+    expect(outlet?.className).toMatch(/(^|\s)hidden(\s|$)/);
+  });
+
+  it('/chats/[id](대화 경로) — outlet은 모바일에서도 보이고, 레일은 모바일에서 숨는다(현행 라우트 전환 유지)', async () => {
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><div data-testid="outlet-content">outlet</div></ChatsLayout>));
+    });
+    const rail = container.querySelector('[data-testid="chat-rail"]');
+    const outlet = container.querySelector('[data-testid="chat-outlet"]');
+    expect(rail?.className).toMatch(/(^|\s)hidden(\s|$)/);
+    expect(outlet?.className).toContain('flex');
+    expect(outlet?.className).not.toMatch(/(^|\s)hidden(\s|$)/);
+  });
+
+  it('두 경로 다 lg:flex(데스크톱 항상 병렬)를 갖는다 — 반응형 토글은 모바일 전용', async () => {
+    for (const pathname of ['/chats', '/chats/conv-123']) {
+      usePathnameMock.mockReturnValue(pathname);
+      await act(async () => { root.unmount(); });
+      root = createRoot(container);
+      await act(async () => {
+        root.render(wrap(<ChatsLayout><div data-testid="outlet-content">outlet</div></ChatsLayout>));
+      });
+      const rail = container.querySelector('[data-testid="chat-rail"]');
+      const outlet = container.querySelector('[data-testid="chat-outlet"]');
+      expect(rail?.className).toContain('lg:flex');
+      expect(outlet?.className).toContain('lg:flex');
+    }
+  });
+
+  it('「새 대화」버튼 클릭 시 ChatListView에 open=true가 전달된다(모달 배선 회귀 0)', async () => {
+    usePathnameMock.mockReturnValue('/chats');
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><div>children</div></ChatsLayout>));
+    });
+    expect(container.querySelector('[data-testid="chat-list-view"]')!.textContent).toContain('open=false');
+    const newConvBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('새 대화') || b.textContent?.includes('New'));
+    expect(newConvBtn).toBeTruthy();
+    await act(async () => { newConvBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.querySelector('[data-testid="chat-list-view"]')!.textContent).toContain('open=true');
+  });
+});

--- a/apps/web/src/app/(authenticated)/chats/layout.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ChatListView } from '@/components/chat/chat-list-view';
+import { useDashboardContext } from '../../dashboard/dashboard-shell';
+import { EmptyState } from '@/components/ui/empty-state';
+
+/**
+ * story #2921 S1(P0-C, 챗 리디자인 시안 §S1) — D04 「Chat 분리=맥락 두동강」 처방 골격.
+ * 현행 `/chats`(L1 리스트)↔`/chats/[id]`(L2/L3)는 완전히 분리된 라우트라 대화 하나를 열면
+ * 리스트가 화면에서 통째로 사라졌다(전체 페이지 전환, 회귀 0 근거는 story 그라운딩 참고).
+ * 이 layout이 두 라우트를 감싸 **데스크톱(lg↑)은 영구 스플릿뷰**(리스트 270px 고정 좌 레일 +
+ * 대화 우 outlet, 동시에 보임)로 봉합한다 — **모바일은 시안 §S1 명시대로 현행 그대로**
+ * (좁은 폭에서는 라우트별로 한쪽만 전체화면, 기존 UX 무변경).
+ *
+ * `ChatListView`(리스트 본체)를 이 layout이 유일하게 마운트한다 — `/chats/page.tsx`는 더는
+ * 리스트를 안 그린다(데스크톱 빈 상태만). 두 라우트가 각자 리스트를 따로 마운트하면 SSE
+ * 구독·fetch가 이중으로 뜬다(이 세션 초반부터 반복된 "구독 중복" 사고 클래스) — 단일 마운트
+ * 지점 하나로 그 위험 자체를 구조적으로 없앤다.
+ */
+export default function ChatsLayout({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('chats');
+  const pathname = usePathname();
+  const { currentTeamMemberId, projectId } = useDashboardContext();
+  const [showModal, setShowModal] = useState(false);
+
+  // `/chats` 정확히 그 경로일 때만 "리스트가 곧 전체화면"인 모바일 상태 — `/chats/[id]`류는
+  // 전부 대화 쪽이 전체화면이다(이미 열람 중인 대화 화면에 리스트를 노출하지 않는다, 기존
+  // 라우트 전환 UX 그대로 계승).
+  const isListRoute = pathname === '/chats';
+
+  if (!currentTeamMemberId || !projectId) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <EmptyState title="로딩 중…" description="" className="w-full max-w-xs" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 overflow-hidden">
+      {/* 리스트 레일 — 모바일은 `/chats`일 때만 전체화면(현행 유지), 데스크톱(lg↑)은 항상
+          270px 고정 폭으로 보인다(§S1 확定 수치). */}
+      <div
+        data-testid="chat-rail"
+        className={`${isListRoute ? 'flex' : 'hidden'} lg:flex min-h-0 w-full flex-col overflow-hidden border-border lg:w-[270px] lg:shrink-0 lg:border-r`}
+      >
+        <div className="flex flex-shrink-0 items-center justify-between border-b border-border px-3 py-2.5">
+          <h1 className="text-sm font-medium text-foreground">{t('title')}</h1>
+          <Button size="sm" variant="outline" onClick={() => setShowModal(true)}>
+            <Plus className="mr-1.5 h-3.5 w-3.5" />
+            {t('newConversation')}
+          </Button>
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <ChatListView
+            projectId={projectId}
+            currentTeamMemberId={currentTeamMemberId}
+            open={showModal}
+            onOpenChange={setShowModal}
+          />
+        </div>
+      </div>
+
+      {/* 대화 outlet — 모바일은 리스트가 아닌 라우트(`/chats/[id]`)일 때만 전체화면, 데스크톱은
+          항상 리스트 옆에 병렬로 보인다. */}
+      <div data-testid="chat-outlet" className={`${isListRoute ? 'hidden' : 'flex'} lg:flex min-h-0 flex-1 flex-col overflow-hidden`}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/chats/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/page.tsx
@@ -1,45 +1,27 @@
 'use client';
 
-import { useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Plus } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { MessageSquare } from 'lucide-react';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
-import { ChatListView } from '@/components/chat/chat-list-view';
-import { useDashboardContext } from '../../dashboard/dashboard-shell';
 import { EmptyState } from '@/components/ui/empty-state';
 
+/**
+ * story #2921 S1 — 리스트 본체는 `chats/layout.tsx`(영구 좌측 레일)로 이관됐다. 이 페이지는
+ * 이제 데스크톱 스플릿뷰의 **우측 outlet 빈 상태**만 그린다(모바일은 layout이 이 outlet
+ * 자체를 숨겨 아예 안 보인다 — `/chats` 경로에서 모바일은 레일이 전체화면을 차지, 현행 유지).
+ */
 export default function ChatsPage() {
   const t = useTranslations('chats');
-  const { currentTeamMemberId, projectId } = useDashboardContext();
-  const [showModal, setShowModal] = useState(false);
-
-  if (!currentTeamMemberId || !projectId) {
-    return (
-      <div className="flex h-64 items-center justify-center">
-        <EmptyState title="로딩 중…" description="" className="w-full max-w-xs" />
-      </div>
-    );
-  }
 
   return (
     <>
-      <TopBarSlot
-        title={<h1 className="text-sm font-medium">{t('title')}</h1>}
-        actions={
-          <Button size="sm" variant="outline" onClick={() => setShowModal(true)}>
-            <Plus className="mr-1.5 h-3.5 w-3.5" />
-            {t('newConversation')}
-          </Button>
-        }
-        showContextChip
-      />
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <ChatListView
-          projectId={projectId}
-          currentTeamMemberId={currentTeamMemberId}
-          open={showModal}
-          onOpenChange={setShowModal}
+      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
+      <div className="flex h-full items-center justify-center">
+        <EmptyState
+          icon={<MessageSquare className="size-8 text-muted-foreground" />}
+          title={t('title')}
+          description="왼쪽에서 대화를 선택하세요"
+          className="w-full max-w-xs"
         />
       </div>
     </>


### PR DESCRIPTION
[SID:2921]

## 변경 사항
챗 리디자인 시안(story 2921, PO 확定) §S1 소비 — **D04 「Chat 분리=맥락 두동강」 처방 골격**. 현행 `/chats`(L1 리스트)↔`/chats/[id]`(L2/L3)는 완전히 분리된 라우트라 대화를 클릭하면 리스트가 화면에서 통째로 사라진다(전체 페이지 전환).

- **`chats/layout.tsx`(신설)** — 두 라우트를 감싸는 공유 layout. `ChatListView`를 이 layout이 유일하게 마운트(리스트 본체가 `chats/page.tsx`에서 이관) — 두 라우트가 각자 리스트를 따로 그리면 SSE 구독·fetch가 이중으로 뜨는 위험을 구조적으로 없앱니다.
  - **데스크톱(lg↑)**: 좌 270px 고정 레일 + 우 outlet, 항상 병렬(영구 스플릿뷰).
  - **모바일**: 현재 경로가 정확히 `/chats`인지로 레일/outlet 중 하나만 전체화면 — 기존 라우트 전환 UX 그대로 계승(회귀 0).
  - 「새 대화」 트리거(기존 `chats/page.tsx`의 `TopBarSlot actions`에 있던 버튼)를 레일 자체의 로컬 헤더로 이관 — 전역 `TopBarSlot`은 이제 대화 상세(참여자명·설정)가 데스크톱에서도 그 화면이 열려 있는 동안 온전히 쓸 수 있습니다.
- **`chats/page.tsx`** — `ChatListView` 렌더 제거, 데스크톱 우측 outlet의 "대화를 선택하세요" 빈 상태만 남김(모바일에선 layout이 이 outlet 자체를 숨겨 안 보임). `TopBarSlot` title+`showContextChip`은 회귀 없이 유지.

## 셀프 게이트
- `pnpm build` — EXIT 0
- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm lint`(대상 파일) — EXIT 0
- `pnpm exec vitest run`(신규 layout.test.tsx + 기존 `[conversation_id]/page.test.tsx`) — 10/10 pass(신규 5건+기존 5건 회귀 0)

## 라이브 검증 — 미완(정직 보고)
이 worktree에 로컬 BE가 없어(`NEXT_PUBLIC_FASTAPI_URL` 미설정, 기본값 `localhost:8000` 무응답) 로컬 풀스택 pre-merge 검증을 시도했으나 로그인 자체가 안 돼 불가했습니다. **dev 배포 후 실 픽셀(데스크톱 스플릿뷰·모바일 라우트 전환 둘 다)로 별도 확認·보고 예정**입니다.

## 머지 순서
[PR#3329(2917 토큰)](https://github.com/moonklabs/sprintable/pull/3329)와 독립 구조 축(순수 레이아웃, 색 변경 0) — 3329 먼저 머지되면 이 브랜치를 그 위에 rebase합니다.

## Test plan
- [x] `ChatListView` 정확히 1곳만 마운트(이중 구독 방지)
- [x] `/chats` 리스트 경로 — 모바일 레일 전체화면·outlet 숨김
- [x] `/chats/[id]` 대화 경로 — 모바일 outlet 전체화면·레일 숨김(현행 유지)
- [x] 두 경로 다 `lg:flex`(데스크톱 항상 병렬)
- [x] 「새 대화」 버튼 → `ChatListView`에 `open=true` 배선
- [x] 기존 대화 페이지 뒤로가기/실패 처리 테스트 회귀 0
- [ ] dev 배포 후 실 픽셀(데스크톱 스플릿뷰·모바일 전환) — 배포 후 별도 보고

🤖 Generated with [Claude Code](https://claude.com/claude-code)