### PR TITLE
[SID:2905] open-panel 클릭 왕복 회귀가드 — 카디르 QA 채무(#3322) 처방

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1445,6 +1445,37 @@ describe('ChatBubble — story #2671 EmbedCard 단독 참조 문단 카드 렌�
     expect(container.textContent).toContain('스토리 제목');
   });
 
+  // story #2905(#3322 QA 채무, 카디르 지적 2026-08-21) — 「open-panel 클릭 왕복이 레포 전체에서
+  // 테스트 0건(어댑터를 no-op으로 무력화해도 전부 통과)」의 정확한 처방. sole-link EmbedCard를
+  // 실제로 클릭해 onOpenReadingPanel prop이 올바른 ReadingPanelTarget 값으로 호출되는지 잰다
+  // — 이 테스트가 없던 시절엔 toEmbedCardOpenPanel을 no-op으로 바꿔도 위 두 렌더 테스트는
+  // 여전히 그린이었다(클릭 자체를 아무도 안 눌렀으므로).
+  it('sole-link EmbedCard를 클릭하면 onOpenReadingPanel이 올바른 ReadingPanelTarget으로 호출된다(open-panel 왕복 회귀가드)', async () => {
+    const storyId = '55555555-5555-5555-5555-555555555556';
+    const onOpenReadingPanel = vi.fn();
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, content: `[스토리 제목](entity:story:${storyId})`, references: [{ target_type: 'story', target_id: storyId }] }}
+          isMine={false}
+          onOpenReadingPanel={onOpenReadingPanel}
+        />,
+      ));
+    });
+    const cardButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('스토리 제목'));
+    expect(cardButton).toBeTruthy();
+    await act(async () => { cardButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onOpenReadingPanel).toHaveBeenCalledTimes(1);
+    expect(onOpenReadingPanel).toHaveBeenCalledWith({
+      kind: 'entity',
+      entityType: 'story',
+      entityId: storyId,
+      title: '스토리 제목',
+      status: null,
+      href: '/board?story=' + storyId,
+    });
+  });
+
   // story #2905(S2c②) — gate 단건 sole-link 참조는 EmbedCard 대신 approval-request-card.tsx가
   // 그대로 뜬다(§8 "표면은 둘·실체는 하나", 승인 로직 사본 분화 금지 — PO 판정).
   it('참조 링크 하나뿐인 문단(gate)은 EmbedCard가 아니라 ApprovalRequestCard(결재 요청 카드)로 렌더된다', async () => {

--- a/apps/web/src/components/chat/embed-card-open-panel-adapter.test.ts
+++ b/apps/web/src/components/chat/embed-card-open-panel-adapter.test.ts
@@ -1,0 +1,43 @@
+// story #2905(#3322 QA 채무, 카디르 지적) — 「open-panel 클릭 왕복이 레포 전체에서 테스트
+// 0건」: 이 어댑터를 no-op으로 무력화해도 기존 테스트가 전부 통과했다(값으로 잡는 회귀가드
+// 부재). 이 파일이 그 사각을 직접 닫는다 — 어댑터 하나만 단독으로, 5-인자 위치 시그니처가
+// 정확한 필드명으로 ReadingPanelTarget에 매핑되는지 값으로 검증한다.
+import { describe, expect, it, vi } from 'vitest';
+import { toEmbedCardOpenPanel } from './embed-card-open-panel-adapter';
+import type { ReadingPanelTarget } from './reading-panel';
+
+describe('toEmbedCardOpenPanel — story #2905 open-panel 어댑터 회귀가드', () => {
+  it('onOpenReadingPanel이 없으면(undefined) undefined를 반환한다(EmbedCard가 그 자리에서 클릭 핸들러 자체를 안 단다)', () => {
+    expect(toEmbedCardOpenPanel(undefined)).toBeUndefined();
+  });
+
+  it('5-인자(entityType, entityId, title, status, href)를 정확한 필드명의 ReadingPanelTarget으로 매핑해 호출한다', () => {
+    const onOpenReadingPanel = vi.fn<(target: ReadingPanelTarget) => void>();
+    const adapted = toEmbedCardOpenPanel(onOpenReadingPanel);
+    expect(adapted).toBeDefined();
+    adapted!('story', 's-1', '스토리 제목', 'in-progress', '/board?story=s-1');
+    expect(onOpenReadingPanel).toHaveBeenCalledTimes(1);
+    expect(onOpenReadingPanel).toHaveBeenCalledWith({
+      kind: 'entity',
+      entityType: 'story',
+      entityId: 's-1',
+      title: '스토리 제목',
+      status: 'in-progress',
+      href: '/board?story=s-1',
+    });
+  });
+
+  it('title/status/href가 null이어도(EmbedCard가 종종 넘기는 값) 그대로 null로 통과한다(지어내지 않음)', () => {
+    const onOpenReadingPanel = vi.fn<(target: ReadingPanelTarget) => void>();
+    const adapted = toEmbedCardOpenPanel(onOpenReadingPanel)!;
+    adapted('artifact', 'a-1', null, null, null);
+    expect(onOpenReadingPanel).toHaveBeenCalledWith({
+      kind: 'entity',
+      entityType: 'artifact',
+      entityId: 'a-1',
+      title: null,
+      status: null,
+      href: null,
+    });
+  });
+});

--- a/apps/web/src/components/chat/embed-group.test.tsx
+++ b/apps/web/src/components/chat/embed-group.test.tsx
@@ -144,3 +144,46 @@ describe('EmbedGroup — gate 그룹(collapsed/expanded + 헤더 라벨 정직�
     expect(container.textContent).toContain('게이트 둘');
   });
 });
+
+// story #2905(#3322 QA 채무, 카디르 지적) — 「open-panel 클릭 왕복이 레포 전체에서 테스트
+// 0건」 처방. embed-group.tsx도 embed-card-open-panel-adapter.ts를 통해 onOpenReadingPanel을
+// 소비한다 — chat-bubble.tsx의 소비처와 별개로 이 경로도 직접 눌러 값으로 확認한다.
+describe('EmbedGroup — story #2905 open-panel 클릭 왕복(회귀가드)', () => {
+  it('간결 리스트 항목 클릭 시 onOpenReadingPanel이 올바른 ReadingPanelTarget으로 호출된다', async () => {
+    const onOpenReadingPanel = vi.fn();
+    await act(async () => {
+      root.render(<EmbedGroup entityType="story" refs={REFS_3} onOpenReadingPanel={onOpenReadingPanel} />);
+    });
+    const itemButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('스토리 하나'));
+    expect(itemButton).toBeTruthy();
+    await act(async () => { itemButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onOpenReadingPanel).toHaveBeenCalledTimes(1);
+    expect(onOpenReadingPanel).toHaveBeenCalledWith({
+      kind: 'entity',
+      entityType: 'story',
+      entityId: 's-1',
+      title: '스토리 하나',
+      status: null,
+      href: '/board?story=s-1',
+    });
+  });
+
+  it('artifact 캐러셀 항목 클릭도 동일하게 onOpenReadingPanel이 호출된다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({}) })));
+    const onOpenReadingPanel = vi.fn();
+    const refs = [{ entityId: 'a-1', label: '목업 하나' }];
+    await act(async () => {
+      root.render(<EmbedGroup entityType="artifact" refs={refs} onOpenReadingPanel={onOpenReadingPanel} />);
+    });
+    const itemButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('목업 하나'));
+    expect(itemButton).toBeTruthy();
+    await act(async () => { itemButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onOpenReadingPanel).toHaveBeenCalledTimes(1);
+    expect(onOpenReadingPanel).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'entity',
+      entityType: 'artifact',
+      entityId: 'a-1',
+      title: '목업 하나',
+    }));
+  });
+});


### PR DESCRIPTION
[SID:2905]

## 변경 사항
지난 세션 카디르 QA(#3322 qa:pass 비차단 발견) 지적 처방: **「open-panel 클릭 왕복이 레포 전체에서 테스트 0건 — 어댑터를 no-op으로 무력화해도 전부 통과」**. `2904` 계보(스택 동역학 뮤테이션 무감지)의 다음 조각으로 다음 세션 백로그에 등재됐던 항목입니다.

- **`embed-card-open-panel-adapter.test.ts`(신설)** — 어댑터 단독 단위 테스트: 5-인자 위치 시그니처가 정확한 필드명의 `ReadingPanelTarget`으로 매핑되는지 값으로 확認.
- **`chat-bubble.test.tsx`** — sole-link `EmbedCard`를 실제로 **클릭**해 `onOpenReadingPanel` prop이 올바른 target으로 호출되는지 확認(기존 #2671 렌더 테스트만 있던 자리에 클릭 왕복 추가).
- **`embed-group.test.tsx`** — 간결 리스트·artifact 캐러셀 항목 클릭도 동일하게 확認.

## 뮤테이션 확認(수동, PR엔 미포함)
어댑터를 `() => {}`(no-op)로 바꿔 재실행 → **신규 5건만 정확히 실패**·기존 100건은 회귀 없이 그대로 통과 확認 후 원복. 이 테스트들이 카디르가 지적한 그 사각을 정확히 닫는다는 증거입니다.

## 셀프 게이트
- `pnpm build` — EXIT 0
- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm lint`(대상 파일) — EXIT 0
- `pnpm exec vitest run`(대상 3파일) — 105/105 pass

## Test plan
- [x] 어댑터 단독 — undefined 입력·5-인자→target 매핑·null 필드 통과 3건
- [x] chat-bubble sole-link EmbedCard 클릭 → onOpenReadingPanel 값 확認 1건
- [x] embed-group 간결 리스트·캐러셀 클릭 → onOpenReadingPanel 값 확認 2건
- [x] 뮤테이션 스모크(no-op 어댑터) — 신규 5건만 실패, 기존 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)