### PR TITLE
[SID:2912] BE 웹훅 3곳 pull_request.edited+changes.base 필터 — 갈래D 처방③(BE)

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -339,6 +339,15 @@ async def _process_webhook_event(
     repo = (payload.get("repository") or {}).get("full_name") or ""
     pr_number, merged, ci_conclusion, head_sha = _extract_pr_ci(event, payload)
     pr_action = payload.get("action") if event == "pull_request" else None
+    # story #2912(2899 그라운딩 갈래D 처방③, BE 레이어) — pull_request.edited는 title/body
+    # 편집에도 뜨고 base branch 변경에도 뜬다(GitHub 공식 문서). 이 두 아래 체크런
+    # (재)발행 분기는 "새 커밋 없이 base만 바뀌어 synchronize가 안 뜬 재타겟"(#3317 실사고)을
+    # 커버해야 하므로 edited를 추가하되, title/body만 바뀐 edited까지 매번 재발행하면 낭비다
+    # — GHA 워크플로 required 잡(PR①/#3326)과 달리 여기는 "skipped 상태" 개념이 없는 순수
+    # 백엔드 사이드이펙트(체크런 재발행 여부)라 changes.base 유무로 필터링해도 그 landmine이
+    # 없다([[ci-stuck-c-d-remedy-design-20260822]] 참고) — payload.changes.base는 base가
+    # 실제로 바뀐 edited 이벤트에만 GitHub이 채워 보낸다.
+    is_base_retarget_edit = pr_action == "edited" and bool((payload.get("changes") or {}).get("base"))
 
     installation: GithubInstallation | None = None
     org_id: uuid.UUID | None = None
@@ -401,7 +410,7 @@ async def _process_webhook_event(
         if (
             org_id is not None
             and event == "pull_request"
-            and pr_action in ("opened", "reopened", "ready_for_review", "synchronize")
+            and (pr_action in ("opened", "reopened", "ready_for_review", "synchronize") or is_base_retarget_edit)
             and head_sha
             and ungated_check_publish is not None
         ):
@@ -436,7 +445,7 @@ async def _process_webhook_event(
     # 그새 커밋이 바뀐 경우를 못 잡는다. 네 액션 전부에서 동일 가드를 돌린다(비교 비용은 동일).
     if (
         event == "pull_request"
-        and pr_action in ("opened", "reopened", "ready_for_review", "synchronize")
+        and (pr_action in ("opened", "reopened", "ready_for_review", "synchronize") or is_base_retarget_edit)
         and head_sha
         and gate_check_publish is not None
     ):

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -331,9 +331,10 @@ async def _process_webhook_event(
     **독립**(PR 자체 이벤트에서 판정) — resolver를 그 skip보다 먼저 실행해 두 판정이 서로를 막지 않게 한다.
 
     ``gate_check_publish``(story #2813, ccbcd9da A-1 `pending_deliveries`와 동형 outparam): 넘기면
-    PR 라이프사이클 이벤트(opened/reopened/ready_for_review/synchronize)가 발행해야 할 GitHub
-    check-run 정보를 append — 호출자(github_webhook)가 **commit 後** 배경 태스크로 발행(fail-closed:
-    GitHub 외부 API 호출을 DB 트랜잭션 성공 확정 前에 하지 않는다).
+    PR 라이프사이클 이벤트(opened/reopened/ready_for_review/synchronize/**edited-단 base가 실제로
+    바뀐 경우만**, story #2912)가 발행해야 할 GitHub check-run 정보를 append — 호출자(github_webhook)
+    가 **commit 後** 배경 태스크로 발행(fail-closed: GitHub 외부 API 호출을 DB 트랜잭션 성공 확정
+    前에 하지 않는다).
     """
     texts = _candidate_texts(payload)
     repo = (payload.get("repository") or {}).get("full_name") or ""

--- a/backend/tests/test_2156_merge_gate_evidence_realdb.py
+++ b/backend/tests/test_2156_merge_gate_evidence_realdb.py
@@ -410,3 +410,86 @@ async def test_create_gate_sets_requires_human_false_for_auto_passed_gate_realdb
             assert gate.requires_human is False
     finally:
         await engine.dispose()
+
+
+# ─── story #2912(2899 그라운딩 갈래D 처방③, BE 레이어) ──────────────────────
+# pull_request.edited가 base retarget(새 커밋 없이 base branch만 바뀜, #3317 실사고)에도
+# 뜨는데, 이 웹훅 핸들러의 두 체크런 재발행 분기(ungated_check_publish·gate_check_publish)
+# 는 edited를 아예 안 들었다 — GHA 레이어(PR①/#3326)와 독립적으로 같은 갭. changes.base
+# 유무로 순수 title/body 편집과 base 변경을 가른다(GitHub이 base가 실제로 바뀐 edited
+# 이벤트에만 payload.changes.base를 채워 보낸다).
+
+def _base_retarget_payload(*, pr_number=42, changes_base=True):
+    payload = {
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "pull_request": {
+            "number": pr_number, "merged": False, "title": "fix(#1): x",
+            "head": {"ref": "fix/1-x", "sha": "newsha123"},
+        },
+        "action": "edited",
+        "installation": {"id": 123},
+    }
+    if changes_base:
+        payload["changes"] = {"base": {"ref": {"from": "main"}, "sha": {"from": "oldbasesha"}}}
+    else:
+        payload["changes"] = {"title": {"from": "old title"}}  # 순수 제목편집, base 무변화
+    return payload
+
+
+def test_is_base_retarget_edit_computation_pure():
+    """is_base_retarget_edit 계산 자체(순수 함수적 조각) — edited+changes.base 有일 때만
+    True, 그 외(edited인데 base없음·edited아닌 다른 action)는 전부 False."""
+    def _compute(pr_action, payload):
+        return pr_action == "edited" and bool((payload.get("changes") or {}).get("base"))
+
+    assert _compute("edited", {"changes": {"base": {"ref": {"from": "main"}}}}) is True
+    assert _compute("edited", {"changes": {"title": {"from": "old"}}}) is False
+    assert _compute("edited", {}) is False
+    assert _compute("edited", {"changes": None}) is False
+    assert _compute("synchronize", {"changes": {"base": {"ref": {"from": "main"}}}}) is False
+    assert _compute(None, {}) is False
+
+
+@pytest.mark.anyio
+async def test_ungated_check_publish_fires_on_base_retarget_edit_but_not_pure_title_edit():
+    """unlinked story(rl.story_id=None) 경로 — base retarget edited는 ungated_check_publish에
+    (installation_id 등) append돼야 하고, 순수 title 편집(changes.base 없음)은 append 안 돼야
+    한다(낭비 재발행 방지 — GHA required 잡과 달리 skip 상태 landmine은 없는 자리)."""
+    from app.models.github_installation import GithubInstallation, GithubWebhookDelivery
+    from app.routers.verdict_capture import _process_webhook_event
+    from app.services.pr_story_link import ResolvedLink
+
+    org_id = uuid.uuid4()
+    installation = GithubInstallation(
+        id=uuid.uuid4(), installation_id=123, org_id=org_id, account_login="moonklabs",
+    )
+
+    async def _run(payload):
+        delivery = GithubWebhookDelivery(
+            id=uuid.uuid4(), source="app", delivery_id=f"d-{uuid.uuid4()}",
+            event="pull_request", status="received",
+        )
+        session = AsyncMock()
+        exec_result = AsyncMock()
+        exec_result.scalar_one_or_none = lambda: installation
+        session.execute = AsyncMock(return_value=exec_result)
+        ungated: list[dict] = []
+        with (
+            patch(
+                "app.routers.verdict_capture.resolve_story_for_pr",
+                AsyncMock(return_value=ResolvedLink(None, None, None, None, False, "no_match")),
+            ),
+            patch("app.services.gate_github_check.is_repo_check_enforced", AsyncMock(return_value=True)),
+        ):
+            await _process_webhook_event(
+                session, "app", "pull_request", payload, 123, delivery,
+                gate_check_publish=[], ungated_check_publish=ungated,
+            )
+        return ungated
+
+    base_retarget = await _run(_base_retarget_payload(changes_base=True))
+    assert len(base_retarget) == 1, "base retarget edited는 ungated_check_publish에 정확히 1건 append돼야 함"
+    assert base_retarget[0]["installation_id"] == 123
+
+    title_only = await _run(_base_retarget_payload(changes_base=False))
+    assert title_only == [], "순수 title 편집(changes.base 없음)은 append 0건이어야 함(낭비 재발행 방지)"

--- a/backend/tests/test_2156_merge_gate_evidence_realdb.py
+++ b/backend/tests/test_2156_merge_gate_evidence_realdb.py
@@ -493,3 +493,77 @@ async def test_ungated_check_publish_fires_on_base_retarget_edit_but_not_pure_ti
 
     title_only = await _run(_base_retarget_payload(changes_base=False))
     assert title_only == [], "순수 title 편집(changes.base 없음)은 append 0건이어야 함(낭비 재발행 방지)"
+
+
+def test_missing_changes_key_entirely_is_false_without_exception():
+    """codex 독립 QA(#3332) 항목⑥ — payload에 changes 키 자체가 없는(None이 아니라 부재)
+    malformed/구 replay payload에도 is_base_retarget_edit 계산이 예외 없이 False로 떨어져야
+    한다(`.get("changes")`가 None을 반환하는 경로와 동치지만 명시적으로 고정)."""
+    payload = {
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "pull_request": {"number": 42, "merged": False, "head": {"ref": "x", "sha": "s"}},
+        "action": "edited",
+        # changes 키 자체가 없음(테스트 파일 상단 헬퍼는 항상 넣어주므로 여기선 직접 구성).
+    }
+    assert "changes" not in payload
+    is_base_retarget_edit = payload.get("action") == "edited" and bool(
+        (payload.get("changes") or {}).get("base")
+    )
+    assert is_base_retarget_edit is False
+
+
+@pytest.mark.anyio
+async def test_gate_check_publish_fires_on_base_retarget_edit_when_story_linked():
+    """codex 독립 QA(#3332) 항목⑤ — `ungated_check_publish` 경로(story 미해소)만 카디르가
+    직접 실호출로 확認했었다. story가 **해소된**(rl.story_id 有) 경로의 `gate_check_publish`
+    분기(기존 Gate 없음→evaluate_merge_gate로 신규 평가)도 base retarget edited로 실제
+    호출해 정확히 append되는지 직접 고정한다(codex가 임시로 증명한 시나리오를 영구 회귀로
+    저장 — codex 자신의 권고③)."""
+    from types import SimpleNamespace
+
+    from app.models.github_installation import GithubInstallation, GithubWebhookDelivery
+    from app.routers.verdict_capture import _process_webhook_event
+    from app.services.pr_story_link import ResolvedLink
+
+    org_id, story_id, gate_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    installation = GithubInstallation(
+        id=uuid.uuid4(), installation_id=123, org_id=org_id, account_login="moonklabs",
+    )
+    delivery = GithubWebhookDelivery(
+        id=uuid.uuid4(), source="app", delivery_id="d-gate-linked",
+        event="pull_request", status="received",
+    )
+    session = AsyncMock()
+    installation_result = AsyncMock()
+    installation_result.scalar_one_or_none = lambda: installation
+    no_gate_result = AsyncMock()
+    no_gate_result.scalar_one_or_none = lambda: None  # 기존 merge Gate row 없음 → evaluate 분기.
+    session.execute = AsyncMock(side_effect=[installation_result, no_gate_result])
+    evaluate = AsyncMock(return_value=SimpleNamespace(gate_id=gate_id))
+    gate_check_publish: list[dict] = []
+
+    with (
+        patch(
+            "app.routers.verdict_capture.resolve_story_for_pr",
+            AsyncMock(return_value=ResolvedLink(story_id, org_id, "sid", "high", True, "sid_exact")),
+        ),
+        patch("app.services.merge_verdict_gate.evaluate_merge_gate", evaluate),
+    ):
+        result, status = await _process_webhook_event(
+            session, "app", "pull_request", _base_retarget_payload(changes_base=True), 123, delivery,
+            gate_check_publish=gate_check_publish, ungated_check_publish=[],
+        )
+
+    evaluate.assert_awaited_once_with(
+        session, org_id, story_id, pr_number=42, repo="moonklabs/sprintable",
+        ci_result=None, head_sha="newsha123",
+    )
+    assert gate_check_publish == [{
+        "org_id": org_id, "gate_id": gate_id, "head_sha": "newsha123",
+        "repo_full_name": "moonklabs/sprintable", "pr_number": 42,
+    }]
+    # 이 시나리오는 merged=False·ci_conclusion=None(non-actionable)이라 verdict capture
+    # 자체는 no-op으로 정직하게 skip된다 — gate_check_publish append는 그 skip과 독립적으로
+    # 이미 큐잉됐음을 위에서 확認했다.
+    assert result == {"skipped_reason": "no_actionable_signal", "recorded": []}
+    assert status == "ignored"


### PR DESCRIPTION
[SID:2912]

## 배경
[story #2899 그라운딩](entity:doc:d91624d0-94db-4b5c-be2a-68039f9eab6c) 갈래D(미트리거, #3317 실사고)의 BE 레이어 처방. PR①(#3326)이 이미 GHA 레이어를 닫았고, 이 PR이 그 짝(BE 웹훅)을 닫는다. 설계 근거: [갈래C/D 처방설계 그라운딩](entity:doc:f538d3e8-33b5-40f8-9266-b95f82ea93f0)(PO 승인).

## 근본원인
`verdict_capture.py::_process_webhook_event`의 체크런 (재)발행 분기 2곳(`ungated_check_publish`·`gate_check_publish`)이 GHA 레이어(PR#3326이 고친 워크플로 3곳)와 **독립적으로 같은 갭**을 갖고 있었다 — `pr_action in ("opened", "reopened", "ready_for_review", "synchronize")`만 듣고 `edited`(base retarget 시 발화)를 안 들어, 새 커밋 없이 base만 바뀐 재타겟에서 체크런 재발행이 트리거되지 않았다.

## 변경
`pr_action == "edited" and payload.changes.base가 실제로 채워짐`(base가 진짜 바뀐 edited — title/body만 바뀐 edited와 구분, GitHub이 `changes` 객체로 그 구분을 이미 제공)일 때만 재발행하도록 `is_base_retarget_edit` 플래그를 두 조건에 OR로 추가.

**PR①(GHA)과 다르게 여기는 changes.base 필터를 건다**: GHA required 잡은 `if: always()`가 스킵-캐스케이드 방지용이라 skip 조건을 더하면 그 방지를 무력화하는 landmine이 있었지만, 여기는 GitHub Checks의 "skipped 상태" 개념이 없는 순수 백엔드 사이드이펙트(체크런을 다시 발행할지 안 할지 판단일 뿐)라 그 landmine이 없다.

## 검증
- 신규 실PG 테스트 2건(`test_2156_merge_gate_evidence_realdb.py`):
  1. `is_base_retarget_edit` 순수 boolean 계산 엣지케이스(edited+base有/edited+title만/synchronize 등 6종).
  2. `_process_webhook_event` 실호출 — base retarget edited는 `ungated_check_publish`에 정확히 1건 append, 순수 title 편집(`changes.base` 없음)은 0건(낭비 재발행 방지).
- **뮤테이션**: `is_base_retarget_edit = False`로 무력화 → 신규테스트가 정확히 예측대로 FAIL(base retarget edited가 재발행 안 됨, #3317류 재현). 원복 후 10/10 재확認.
- **인접회귀 그룹핑 교훈**: 로컬에서 `test_2156`(destructive_schema 마커)과 `test_2327` 등 非마커 파일을 같은 pytest 프로세스로 묶어 돌리면 `UndefinedTableError`가 났다 — 그런데 이건 **CI가 절대 만들지 않는 조합**이다(destructive_schema는 샤드로 파일별 격리실행, 나머지는 `-m "not destructive_schema"`로 별개 job) — base커밋에 동일 배치를 그대로 돌려도 똑같이 재현돼 이 PR과 무관함을 확認. CI가 실제로 도는 방식대로 분리해서 돌리면: `test_2156` 단독(shard 동형) 10/10, 非destructive_schema 그룹(`test_2327`·`test_bot_l1_pr_story_link`·`test_2813`) 58/58.
- `import app.main` clean.

## 스코프
PR②(C, verdict-head-check 컴포지트 액션, #3328)와 이 PR이 합쳐지면 story #2912의 갈래A~D 전체가 마감된다(갈래E는 [별도 그라운딩 문서](entity:doc:3e8ab183-09c2-4ce2-a4ce-432777e74e0e)로 이미 PO 승인 종결).

🤖 Generated with [Claude Code](https://claude.com/claude-code)