### PR TITLE
[SID:2917] 하드코딩 색 잔존 이주 — raw 유틸 56건 + arbitrary hex 1건 전량 토큰화

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/workforce/[id]/page.tsx
@@ -394,7 +394,7 @@ export default function AgentDetailPage() {
                   placeholder="role"
                   className="max-w-32"
                 />
-                <button type="button" onClick={() => void handleSaveEdit()} disabled={savingEdit} className="text-emerald-500 hover:text-emerald-400 disabled:opacity-50">
+                <button type="button" onClick={() => void handleSaveEdit()} disabled={savingEdit} className="text-success transition hover:opacity-80 disabled:opacity-50">
                   <Check className="h-4 w-4" />
                 </button>
                 <button type="button" onClick={() => setEditingName(false)} className="text-muted-foreground hover:text-foreground">

--- a/apps/web/src/app/(authenticated)/rewards/page.tsx
+++ b/apps/web/src/app/(authenticated)/rewards/page.tsx
@@ -145,7 +145,7 @@ export default function RewardsPage() {
                         <Badge variant="outline">#{i + 1}</Badge>
                         <span className="text-sm font-medium text-foreground">{memberMap[e.member_id] ?? t('unknown')}</span>
                       </div>
-                      <span className={`text-sm font-bold ${e.balance >= 0 ? 'text-emerald-600' : 'text-destructive'}`}>
+                      <span className={`text-sm font-bold ${e.balance >= 0 ? 'text-success' : 'text-destructive'}`}>
                         {e.balance >= 0 ? '+' : ''}{e.balance.toLocaleString()} TJSB
                       </span>
                     </div>
@@ -216,7 +216,7 @@ export default function RewardsPage() {
                         <p className="text-xs text-muted-foreground">{e.reason}</p>
                       </div>
                       <div className="text-right">
-                        <p className={`text-sm font-bold ${e.amount >= 0 ? 'text-emerald-600' : 'text-destructive'}`}>
+                        <p className={`text-sm font-bold ${e.amount >= 0 ? 'text-success' : 'text-destructive'}`}>
                           {e.amount >= 0 ? '+' : ''}{e.amount.toLocaleString()} TJSB
                         </p>
                         <p className="text-xs text-muted-foreground">{new Date(e.created_at).toLocaleDateString()}</p>

--- a/apps/web/src/app/internal-dogfood/page.tsx
+++ b/apps/web/src/app/internal-dogfood/page.tsx
@@ -28,7 +28,7 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
   const actor = session ? resolveInternalDogfoodActor(session.teamMemberId) : null;
 
   return (
-    <div className="min-h-screen bg-gray-50 px-4 py-10">
+    <div className="min-h-screen bg-muted px-4 py-10">
       <div className="mx-auto max-w-5xl space-y-6">
         <PageHeader
           eyebrow="Internal dogfood"
@@ -44,7 +44,7 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
         {signedOut ? (
           <SectionCard>
             <SectionCardBody>
-              <p className="text-sm text-emerald-700">내부 dogfood 세션 종료 완료한.</p>
+              <p className="text-sm text-success">내부 dogfood 세션 종료 완료한.</p>
             </SectionCardBody>
           </SectionCard>
         ) : null}
@@ -52,7 +52,7 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
         {error ? (
           <SectionCard>
             <SectionCardBody>
-              <p className="text-sm text-rose-700" role="alert" aria-live="assertive" aria-atomic="true">오류: {error}</p>
+              <p className="text-sm text-destructive" role="alert" aria-live="assertive" aria-atomic="true">오류: {error}</p>
             </SectionCardBody>
           </SectionCard>
         ) : null}
@@ -78,16 +78,16 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
               {actors.length ? (
                 <form action="/api/internal-dogfood/session" method="post" className="space-y-4">
                   <div className="space-y-2">
-                    <label htmlFor="team_member_id" className="block text-sm font-medium text-gray-700">내부 계정</label>
-                    <select id="team_member_id" name="team_member_id" className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm" defaultValue={actors[0]?.id}>
+                    <label htmlFor="team_member_id" className="block text-sm font-medium text-foreground">내부 계정</label>
+                    <select id="team_member_id" name="team_member_id" className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm" defaultValue={actors[0]?.id}>
                       {actors.map((item) => (
                         <option key={item.id} value={item.id}>{item.name} · {item.project_name}</option>
                       ))}
                     </select>
                   </div>
                   <div className="space-y-2">
-                    <label htmlFor="secret" className="block text-sm font-medium text-gray-700">공유 시크릿</label>
-                    <input id="secret" name="secret" type="password" className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm" placeholder="internal access secret" required />
+                    <label htmlFor="secret" className="block text-sm font-medium text-foreground">공유 시크릿</label>
+                    <input id="secret" name="secret" type="password" className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm" placeholder="internal access secret" required />
                   </div>
                   <Button type="submit">내부 세션 시작</Button>
                 </form>
@@ -118,20 +118,20 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
                 <SectionCardBody>
                   <form action="/api/internal-dogfood/memos" method="post" className="space-y-4">
                     <div className="space-y-2">
-                      <label htmlFor="memo-title" className="block text-sm font-medium text-gray-700">제목</label>
-                      <input id="memo-title" name="title" className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm" placeholder="예: [PO][BE] blocker 확인" />
+                      <label htmlFor="memo-title" className="block text-sm font-medium text-foreground">제목</label>
+                      <input id="memo-title" name="title" className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm" placeholder="예: [PO][BE] blocker 확인" />
                     </div>
                     <div className="space-y-2">
-                      <label htmlFor="memo-type" className="block text-sm font-medium text-gray-700">memo_type</label>
-                      <input id="memo-type" name="memo_type" defaultValue="memo" className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm" />
+                      <label htmlFor="memo-type" className="block text-sm font-medium text-foreground">memo_type</label>
+                      <input id="memo-type" name="memo_type" defaultValue="memo" className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm" />
                     </div>
                     <div className="space-y-2">
-                      <label htmlFor="memo-assigned" className="block text-sm font-medium text-gray-700">담당자 team member id</label>
-                      <input id="memo-assigned" name="assigned_to" className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm" placeholder="예: 9cac9d96-5474-45f7-941e-787407597b52" />
+                      <label htmlFor="memo-assigned" className="block text-sm font-medium text-foreground">담당자 team member id</label>
+                      <input id="memo-assigned" name="assigned_to" className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm" placeholder="예: 9cac9d96-5474-45f7-941e-787407597b52" />
                     </div>
                     <div className="space-y-2">
-                      <label htmlFor="memo-content" className="block text-sm font-medium text-gray-700">내용</label>
-                      <textarea id="memo-content" name="content" required rows={8} className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm" placeholder="메모 내용" />
+                      <label htmlFor="memo-content" className="block text-sm font-medium text-foreground">내용</label>
+                      <textarea id="memo-content" name="content" required rows={8} className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm" placeholder="메모 내용" />
                     </div>
                     <Button type="submit">메모 생성</Button>
                   </form>
@@ -145,21 +145,21 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
                 <SectionCardBody>
                   <form action="/api/internal-dogfood/stories" method="post" className="space-y-4">
                     <div className="space-y-2">
-                      <label htmlFor="story-title" className="block text-sm font-medium text-gray-700">제목</label>
-                      <input id="story-title" name="title" required className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm" placeholder="예: Sprintable communication migration blocker" />
+                      <label htmlFor="story-title" className="block text-sm font-medium text-foreground">제목</label>
+                      <input id="story-title" name="title" required className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm" placeholder="예: Sprintable communication migration blocker" />
                     </div>
                     <div className="grid gap-4 md:grid-cols-2">
                       <div className="space-y-2">
-                        <label htmlFor="story-status" className="block text-sm font-medium text-gray-700">상태</label>
-                        <select id="story-status" name="status" defaultValue="backlog" className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm">
+                        <label htmlFor="story-status" className="block text-sm font-medium text-foreground">상태</label>
+                        <select id="story-status" name="status" defaultValue="backlog" className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm">
                           <option value="backlog">backlog</option>
                           <option value="ready-for-dev">ready-for-dev</option>
                           <option value="in-progress">in-progress</option>
                         </select>
                       </div>
                       <div className="space-y-2">
-                        <label htmlFor="story-priority" className="block text-sm font-medium text-gray-700">우선순위</label>
-                        <select id="story-priority" name="priority" defaultValue="medium" className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm">
+                        <label htmlFor="story-priority" className="block text-sm font-medium text-foreground">우선순위</label>
+                        <select id="story-priority" name="priority" defaultValue="medium" className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm">
                           <option value="low">low</option>
                           <option value="medium">medium</option>
                           <option value="high">high</option>
@@ -168,12 +168,12 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
                       </div>
                     </div>
                     <div className="space-y-2">
-                      <label htmlFor="story-assignee" className="block text-sm font-medium text-gray-700">담당자 team member id</label>
-                      <input id="story-assignee" name="assignee_id" className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm" placeholder="예: cff9055b-c671-4401-8436-a17f804a0406" />
+                      <label htmlFor="story-assignee" className="block text-sm font-medium text-foreground">담당자 team member id</label>
+                      <input id="story-assignee" name="assignee_id" className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm" placeholder="예: cff9055b-c671-4401-8436-a17f804a0406" />
                     </div>
                     <div className="space-y-2">
-                      <label htmlFor="story-description" className="block text-sm font-medium text-gray-700">설명</label>
-                      <textarea id="story-description" name="description" rows={8} className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm" placeholder="스토리 설명" />
+                      <label htmlFor="story-description" className="block text-sm font-medium text-foreground">설명</label>
+                      <textarea id="story-description" name="description" rows={8} className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm" placeholder="스토리 설명" />
                     </div>
                     <Button type="submit">스토리 생성</Button>
                   </form>

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -4,6 +4,10 @@ import type { MetadataRoute } from 'next';
 // 산출물 그대로 재사용.
 // story #2529: 마크 v1(3단 모노 #1274D4)→v2(2단 듀오톤) 갱신 — theme_color를 마크 상단
 // 색(인디고, 핸드오프 §6-2) #42549B로. 아이콘 파일은 경로 그대로 in-place 교체(§5).
+// story #2917 후속(2026-08-22, 유나 홀름 결정) — background_color를 Proofline 배경
+// Bone(#F4F2EC)으로. Web App Manifest 스펙상 정적 hex만 허용돼 CSS 토큰 참조는 불가하나,
+// 콜드런치 splash가 앱 실제 배경과 다른 흰 섬광으로 뜨는 걸 막기 위해 값 자체를 동기화한다.
+// theme_color(#42549B)는 브랜드 마크 색 축(별개 결정 축)이라 유지.
 export default function manifest(): MetadataRoute.Manifest {
   return {
     // story #2745 — layout.tsx SITE_TITLE/SITE_DESCRIPTION과 동일 정본(같은 이유로 동시 갱신).
@@ -12,7 +16,7 @@ export default function manifest(): MetadataRoute.Manifest {
     description: 'The organization OS that closes open loops. Kanban, memos, standups, retros, MCP server — with AI agents as first-class team members.',
     start_url: '/',
     display: 'standalone',
-    background_color: '#FFFFFF',
+    background_color: '#F4F2EC',
     theme_color: '#42549B',
     icons: [
       { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png', purpose: 'any' },

--- a/apps/web/src/app/onboarding/connect-step.tsx
+++ b/apps/web/src/app/onboarding/connect-step.tsx
@@ -252,11 +252,11 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
   if (!apiKey) {
     return (
       <div className="space-y-4">
-        <div className="space-y-2 rounded-md border border-amber-500/20 bg-amber-500/10 p-3">
-          <p className="text-sm text-amber-600 dark:text-amber-400">{t('apiKeyFailedMembers')}</p>
+        <div className="space-y-2 rounded-md border border-warning-border bg-warning-tint p-3">
+          <p className="text-sm text-warning-strong">{t('apiKeyFailedMembers')}</p>
           <Link
             href="/settings?tab=members"
-            className="inline-block rounded border border-amber-500/30 bg-background px-3 py-1 text-xs font-medium text-amber-600 transition-colors hover:bg-amber-500/10 dark:text-amber-400"
+            className="inline-block rounded border border-warning-border bg-background px-3 py-1 text-xs font-medium text-warning-strong transition-colors hover:bg-warning-tint"
           >
             {t('goToMembersAgents')} →
           </Link>

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -298,7 +298,7 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
                     <span
                       key={s}
                       title={s}
-                      className={`max-w-full truncate rounded px-1.5 py-0.5 text-xs font-medium ${s === 'admin' ? 'bg-orange-100 text-orange-700' : 'bg-muted text-muted-foreground'}`}
+                      className={`max-w-full truncate rounded px-1.5 py-0.5 text-xs font-medium ${s === 'admin' ? 'bg-warning-tint text-warning-strong' : 'bg-muted text-muted-foreground'}`}
                     >
                       {s}
                     </span>
@@ -316,7 +316,7 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
                   const isExpired = daysLeft <= 0;
                   const isWarning = daysLeft > 0 && daysLeft <= 7;
                   return (
-                    <p className={`text-xs mt-0.5 ${isExpired ? 'text-destructive font-medium' : isWarning ? 'text-orange-500 font-medium' : 'text-muted-foreground'}`}>
+                    <p className={`text-xs mt-0.5 ${isExpired ? 'text-destructive font-medium' : isWarning ? 'text-warning-strong font-medium' : 'text-muted-foreground'}`}>
                       {isExpired
                         ? `Expired ${expiresDate.toLocaleDateString()}`
                         : isWarning

--- a/apps/web/src/components/docs/extensions/page-embed-node.tsx
+++ b/apps/web/src/components/docs/extensions/page-embed-node.tsx
@@ -139,8 +139,8 @@ function PageEmbedView({ node, updateAttributes, extension }: ReactNodeViewProps
   if (circular) {
     return (
       <NodeViewWrapper data-testid="page-embed-circular">
-        <div className="flex items-center gap-2 rounded-xl border border-rose-500/30 bg-rose-500/8 px-4 py-3 text-sm text-rose-400">
-          <AlertCircle className="size-4 shrink-0" />
+        <div className="flex items-center gap-2 rounded-xl border border-destructive-border bg-destructive-tint px-4 py-3 text-sm text-foreground">
+          <AlertCircle className="size-4 shrink-0 text-destructive" />
           <span>Circular embed detected — a document cannot embed itself.</span>
         </div>
       </NodeViewWrapper>

--- a/apps/web/src/components/flow/next-maker-header.tsx
+++ b/apps/web/src/components/flow/next-maker-header.tsx
@@ -55,7 +55,7 @@ export function NextMakerHeader({ headline, zeroStage }: NextMakerHeaderProps) {
         {headline.aboutToStallCount > 0 && (
           <>
             {' — '}
-            <b className="font-mono text-amber-600 dark:text-amber-400">
+            <b className="font-mono text-warning-strong">
               {t('nextMakerHeadlineStall', { n: headline.aboutToStallCount })}
             </b>
           </>
@@ -87,7 +87,7 @@ function ZeroStageCell({
   const valueClass = {
     brand: 'text-primary',
     info: 'text-info',
-    warn: 'text-amber-600 dark:text-amber-400',
+    warn: 'text-warning-strong',
     neutral: 'text-foreground',
   }[tone];
 

--- a/apps/web/src/components/flow/stem-row.tsx
+++ b/apps/web/src/components/flow/stem-row.tsx
@@ -55,7 +55,7 @@ function Flag({ tone, label }: { tone: 'info' | 'neutral' | 'brand' | 'warn'; la
     info: 'border-info/50 text-info',
     neutral: 'border-border text-muted-foreground',
     brand: 'border-primary/50 text-primary font-semibold',
-    warn: 'border-amber-500/50 text-amber-600 dark:text-amber-400 font-semibold',
+    warn: 'border-warning/50 text-warning-strong font-semibold',
   }[tone];
   return <span className={`rounded border px-1 py-0.5 font-mono text-[9.5px] ${cls}`}>{label}</span>;
 }

--- a/apps/web/src/components/nav/create-organization-dialog.tsx
+++ b/apps/web/src/components/nav/create-organization-dialog.tsx
@@ -139,13 +139,13 @@ export function CreateOrganizationDialog({
         </DialogHeader>
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
           {planLimitHit && (
-            <div key={planLimitNonce} role="alert" aria-live="assertive" aria-atomic="true" className="rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm space-y-1">
-              <p className="font-medium text-amber-800">{t('orgLimitBannerTitle')}</p>
-              <p className="text-amber-700">{tOnboarding('orgLimitExceededError', { limit: 1 })}</p>
+            <div key={planLimitNonce} role="alert" aria-live="assertive" aria-atomic="true" className="rounded-md border border-warning-border bg-warning-tint px-3 py-3 text-sm space-y-1">
+              <p className="font-medium text-warning-strong">{t('orgLimitBannerTitle')}</p>
+              <p className="text-warning-strong">{tOnboarding('orgLimitExceededError', { limit: 1 })}</p>
               {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- story a539c649 S2 오탐, invite-accept-client.tsx 주석 참고 */}
               <a
                 href="/settings?tab=billing"
-                className="inline-block mt-1 text-xs font-medium text-amber-800 underline underline-offset-2 hover:text-amber-900"
+                className="inline-block mt-1 text-xs font-medium text-warning-strong underline underline-offset-2 transition hover:opacity-80"
               >
                 {t('orgLimitUpgradeLink')}
               </a>

--- a/apps/web/src/components/verify/trust-seal.tsx
+++ b/apps/web/src/components/verify/trust-seal.tsx
@@ -60,7 +60,7 @@ export function TrustSeal(props: TrustSealProps) {
   if (props.variant === 'verified') {
     return (
       <div className={cn('flex items-center gap-2 rounded-[10px] bg-proof-green-soft px-2.5 py-2 text-[11.5px]', props.className)}>
-        <span className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-proof-green text-[9px] font-bold text-white dark:text-[#0B0C0D]">
+        <span className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-proof-green text-[9px] font-bold text-white dark:text-proof-bg">
           {initials(props.humanName)}
         </span>
         <span className="min-w-0 flex-1 text-proof-ink-3">


### PR DESCRIPTION
[SID:2917]

## 변경 사항
Proofline 토큰 매핑표(story 2916) §9 잔존 목록 소비 — 2917 본문에 실었던 grep 재현 결과(raw Tailwind 색 유틸 56건·9파일 + arbitrary hex 1건)를 전부 기존 semantic 토큰으로 이주했습니다.

- **`internal-dogfood/page.tsx`**: `bg-gray-50`→`bg-muted`·`text-emerald-700`→`text-success`·`text-rose-700`→`text-destructive`·라벨 14곳 `text-gray-700`→`text-foreground`·입력 14곳 `border-gray-300`→`border-border`(+ 발견한 김에 `bg-white`→`bg-card`도 함께).
- **`organization/workforce/[id]/page.tsx`**: 저장 확認 아이콘 → `text-success` + `hover:opacity-80`.
- **`rewards/page.tsx`**: 잔고 양수 표시 → `text-success`.
- **`onboarding/connect-step.tsx`**·**`agent-api-key-manager.tsx`**·**`create-organization-dialog.tsx`**: amber/orange 계열 경고 박스·배지 → `warning`/`warning-border`/`warning-tint`/`warning-strong` 패밀리.
- **`page-embed-node.tsx`**: 순환 임베드 에러 박스 rose 계열 → `destructive-border`/`destructive-tint`(+아이콘만 `text-destructive`, 본문은 `text-foreground`).
- **`stem-row.tsx`**·**`next-maker-header.tsx`**: `warn` 톤을 형제 톤(info/brand/neutral)과 동일 관례로 통일.
- **`trust-seal.tsx`**: `dark:text-[#0B0C0D]`(`--proof-bg` dark 값 그대로 박제돼 있던 것) → `dark:text-proof-bg`.

## 게이트가 실제로 잡은 것
`page-embed-node.tsx` 첫 시도에서 `bg-destructive-tint` 배경 위에 `text-destructive`(같은 계열 글자)를 그대로 옮겼다가 `verify:no-new-tint-color-text`가 신규 위반으로 정확히 잡았습니다 — story #2420 규칙(tint 배경 위 글자는 계열색이 아니라 `text-foreground`, 색은 아이콘/배지가 짐) 그대로 즉시 처방했습니다.

## 스코프 밖(구조적 예외, 의도적으로 손 안 댐 — 인라인 style hex 3건)
- **`manifest.ts`**(PWA `background_color`/`theme_color`): Web App Manifest 스펙상 정적 hex만 허용(CSS 커스텀 프로퍼티 소비 불가). `background_color`가 구 `--background`(#FFFFFF) 값과 어긋난 채로 남습니다(Proofline #F4F2EC 미반영) — splash 배경을 새 팔레트에 맞출지는 디자인 판단이라 임의로 안 바꿨습니다.
- **`mermaid-renderer.ts`**: mermaid.js 라이브러리 자체 theme 설정(SVG 렌더 시점에 라이브러리가 직접 소비하는 JS 객체, 앱 CSS 캐스케이드 밖) — `theme:'dark'` 고정이라 애초에 앱 라이트/다크와 무관하게 항상 다크(의도적 독립 축).

## 셀프 게이트
- `pnpm build` — EXIT 0
- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm lint`(대상 파일) — EXIT 0
- **대비 가드 4종 전부 그린**(신규 위반 0 — 위 1건 발견→즉시 처방 과정 포함)
- `pnpm exec vitest run`(관련 5개 테스트 파일) — 35/35 pass, 회귀 0

## Test plan
- [x] grep 재현: raw 유틸 56건→0건, arbitrary hex 1건→0건
- [x] 대비 가드 4종 그린(신규 위반 0)
- [x] 기존 테스트 5파일 회귀 0
- [ ] dev 배포 후 실 픽셀(#2917 라이트/다크 전 표면 evidence에 포함해 보고 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)