### PR TITLE
[SID:2913] TossAdapter 자체 ERROR 로그 opt-in 강등 — NOT_FOUND_PAYMENT 잔여

### DIFF
--- a/backend/app/services/billing_scheduler.py
+++ b/backend/app/services/billing_scheduler.py
@@ -357,7 +357,9 @@ async def sweep_stale_pending_orders(session: AsyncSession, *, now: datetime | N
     confirmed = failed = skipped = not_found = 0
     for order in stale_orders:
         try:
-            lookup = await TossAdapter().get_payment_by_order_id(order_id=order.order_id)
+            lookup = await TossAdapter().get_payment_by_order_id(
+                order_id=order.order_id, quiet_codes=frozenset({"NOT_FOUND_PAYMENT"}),
+            )
         except TossApiError as exc:
             if exc.code == "NOT_FOUND_PAYMENT":
                 # story #2913(2896 첫 실행 실증) — Toss가 이 주문을 애초에 모른다는

--- a/backend/app/services/payment/toss_adapter.py
+++ b/backend/app/services/payment/toss_adapter.py
@@ -80,8 +80,21 @@ class TossAdapter(PaymentProvider):
 
         return resp.json()
 
-    async def _get(self, path: str, *, timeout: float, op_label: str) -> dict:
-        """공용 GET 왕복 — 결제 조회(get_payment_by_order_id)용. _post와 동일 에러 처리."""
+    async def _get(
+        self, path: str, *, timeout: float, op_label: str, quiet_codes: frozenset[str] = frozenset(),
+    ) -> dict:
+        """공용 GET 왕복 — 결제 조회(get_payment_by_order_id)용. _post와 동일 에러 처리.
+
+        story #2913 후속(2896 라이브 실측, 페드루군 2026-08-22) — sweep_stale_pending_orders는
+        `NOT_FOUND_PAYMENT`를 "확정 미발생"으로 이미 안전 처리하고 자체 INFO 로그를 남기는데
+        (billing_scheduler.py), 이 어댑터 층이 그 위에 매번 별도 ERROR 한 줄을 또 찍어 traceback은
+        없앴어도 "일 단위 ERROR 반복"이라는 원 증상의 절반이 남아 있었다. **어댑터는 호출자
+        문맥(이 404가 정상 흐름인지 이상 신호인지)을 모른다**는 게 근본 원인이라, 코드 하나를
+        무조건 낮추는 대신 호출자가 명시적으로 "이 code는 나한테는 조용해도 된다"고 선언한
+        경우만 로그 레벨을 낮춘다(`quiet_codes` — 기본 빈 집합, 즉 기존 동작 그대로).
+        `billing_reconciliation.py`(confirmed order가 Toss에 없다=원장 무결성 이상 신호)·
+        `billing_charge.py`(DUPLICATED_ORDER_ID 뒤 조회 — 실시간 결제 경로)는 이 파라미터를
+        안 넘겨 ERROR 그대로 유지(전수 호출부 실측 — 두 곳 다 404가 진짜 이상일 수 있음)."""
         try:
             async with httpx.AsyncClient(timeout=timeout) as client:
                 resp = await client.get(f"{_API_BASE}{path}", headers=self._auth_header())
@@ -92,7 +105,10 @@ class TossAdapter(PaymentProvider):
         if resp.status_code != 200:
             body = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
             code = body.get("code", str(resp.status_code))
-            logger.error("Toss %s error: status=%s code=%s", op_label, resp.status_code, code)
+            if code in quiet_codes:
+                logger.info("Toss %s: status=%s code=%s (caller handles this as expected)", op_label, resp.status_code, code)
+            else:
+                logger.error("Toss %s error: status=%s code=%s", op_label, resp.status_code, code)
             raise TossApiError(code, f"Toss {op_label} failed", status_code=resp.status_code)
 
         return resp.json()
@@ -152,14 +168,20 @@ class TossAdapter(PaymentProvider):
             op_label="charge",
         )
 
-    async def get_payment_by_order_id(self, *, order_id: str) -> dict:
+    async def get_payment_by_order_id(self, *, order_id: str, quiet_codes: frozenset[str] = frozenset()) -> dict:
         """GET /v1/payments/orders/{orderId} — PaymentProvider 8메서드 밖의 보조 조회
         (story #2493 C2, PO 리뷰 권장). charge가 `DUPLICATED_ORDER_ID`로 실패했을 때(=
         이 orderId가 이미 처리된 적이 있다는 뜻이지 신규 실패가 아니다) 실제 결제 상태·
         paymentKey를 여기서 확認한다 — Toss 에러 응답 자체엔 그 정보가 없어(공식 문서
-        확認) 조회가 유일한 경로."""
+        확認) 조회가 유일한 경로.
+
+        `quiet_codes`(story #2913 후속) — 호출자가 "이 Toss 에러 code는 나한테는 정상
+        흐름"이라고 명시할 때만 어댑터의 ERROR 로그를 INFO로 낮춘다(기본 빈 집합=기존
+        동작 그대로 ERROR). 어댑터 자신은 어느 호출자가 부르는지 모르므로 기본값을
+        절대 조용하게 두지 않는다 — 호출자별 실제 문맥(_get docstring 참고)에 맞게
+        opt-in으로만 낮춘다."""
         return await self._get(
-            f"/v1/payments/orders/{order_id}", timeout=15, op_label="payment lookup",
+            f"/v1/payments/orders/{order_id}", timeout=15, op_label="payment lookup", quiet_codes=quiet_codes,
         )
 
     def verify_webhook(self, raw_body: bytes, signature: str | None) -> bool:

--- a/backend/tests/test_e_2493_c2_charge_ledger.py
+++ b/backend/tests/test_e_2493_c2_charge_ledger.py
@@ -104,6 +104,72 @@ async def test_toss_get_payment_by_order_id_success():
     assert call_args.args[0].endswith("/v1/payments/orders/ord-dup1")
 
 
+@pytest.mark.anyio
+async def test_toss_get_payment_by_order_id_error_logs_error_by_default(caplog):
+    """story #2913 후속(페드루군 2026-08-22 라이브 실측) — 어댑터는 호출자를 모르므로
+    기본값(quiet_codes 미지정)은 기존 그대로 ERROR. billing_reconciliation.py(confirmed
+    order가 Toss에 없다=원장 무결성 이상)·billing_charge.py(DUPLICATED_ORDER_ID 뒤
+    조회, 실시간 결제 경로) 둘 다 이 기본값을 그대로 쓰므로 이 회귀가 그 두 곳의 ERROR
+    가시성을 보장한다."""
+    import logging
+
+    from app.services.payment.toss_adapter import TossAdapter, TossApiError
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    mock_resp.headers = {"content-type": "application/json"}
+    mock_resp.json.return_value = {"code": "NOT_FOUND_PAYMENT", "message": "not found"}
+
+    with patch("app.services.payment.toss_adapter.settings") as mock_settings:
+        mock_settings.toss_payments_secret_key = "test_sk_dummy"
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value.get = AsyncMock(return_value=mock_resp)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            adapter = TossAdapter()
+            with caplog.at_level(logging.INFO):
+                with pytest.raises(TossApiError):
+                    await adapter.get_payment_by_order_id(order_id="ord-x")
+
+    assert any(
+        r.levelno == logging.ERROR and "NOT_FOUND_PAYMENT" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+@pytest.mark.anyio
+async def test_toss_get_payment_by_order_id_quiet_codes_downgrades_to_info(caplog):
+    """story #2913 후속 — 호출자(sweep_stale_pending_orders)가 명시적으로 quiet_codes에
+    NOT_FOUND_PAYMENT를 넣으면 어댑터 자신의 ERROR 한 줄이 INFO로 낮아진다(2896 라이브
+    실측: billing_scheduler.py가 이미 자체 INFO를 남기는데 그 위에 어댑터가 또 ERROR를
+    찍어 "일 단위 ERROR 반복"이 실제로는 안 없어졌던 잔여를 여기서 닫는다)."""
+    import logging
+
+    from app.services.payment.toss_adapter import TossAdapter, TossApiError
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    mock_resp.headers = {"content-type": "application/json"}
+    mock_resp.json.return_value = {"code": "NOT_FOUND_PAYMENT", "message": "not found"}
+
+    with patch("app.services.payment.toss_adapter.settings") as mock_settings:
+        mock_settings.toss_payments_secret_key = "test_sk_dummy"
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value.get = AsyncMock(return_value=mock_resp)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            adapter = TossAdapter()
+            with caplog.at_level(logging.INFO):
+                with pytest.raises(TossApiError):
+                    await adapter.get_payment_by_order_id(
+                        order_id="ord-x", quiet_codes=frozenset({"NOT_FOUND_PAYMENT"}),
+                    )
+
+    assert not any(r.levelno == logging.ERROR for r in caplog.records), "quiet_codes 지정 시 ERROR가 찍히면 안 됨"
+    assert any(
+        r.levelno == logging.INFO and "NOT_FOUND_PAYMENT" in r.getMessage()
+        for r in caplog.records
+    ), "quiet_codes 지정 시 INFO로 대체 기록돼야 함"
+
+
 # ─── charge_org — 원자적 claim + orderId-먼저-기록 오케스트레이션 ──────────
 
 def _mock_billing_key_row(*, org_id: uuid.UUID):

--- a/backend/tests/test_e_2494_c3_scheduler.py
+++ b/backend/tests/test_e_2494_c3_scheduler.py
@@ -465,10 +465,10 @@ async def test_sweep_stale_pending_not_found_payment_leaves_pending_without_exce
     orders_result.scalars.return_value.all.return_value = [stale_order]
     session.execute = AsyncMock(return_value=orders_result)
 
-    monkeypatch.setattr(
-        sched.TossAdapter, "get_payment_by_order_id",
-        AsyncMock(side_effect=TossApiError("NOT_FOUND_PAYMENT", "결제 정보를 찾을 수 없습니다", status_code=404)),
+    lookup_mock = AsyncMock(
+        side_effect=TossApiError("NOT_FOUND_PAYMENT", "결제 정보를 찾을 수 없습니다", status_code=404)
     )
+    monkeypatch.setattr(sched.TossAdapter, "get_payment_by_order_id", lookup_mock)
     fail_mock = AsyncMock()
     confirm_mock = AsyncMock()
     monkeypatch.setattr(sched, "_mark_failed_if_not_confirmed", fail_mock)
@@ -483,6 +483,13 @@ async def test_sweep_stale_pending_not_found_payment_leaves_pending_without_exce
     }
     fail_mock.assert_not_awaited()
     confirm_mock.assert_not_awaited()
+    # story #2913 후속(페드루군 2896 라이브 실측) — 어댑터 자신의 ERROR 로그도 낮추려면
+    # 호출자가 quiet_codes를 명시해야 한다(TossAdapter._get 참고, opt-in 설계). 그 전달이
+    # 안 되면 이 스윕의 INFO 카운터-로그와 별개로 어댑터가 매번 ERROR를 또 찍어 원 증상
+    # (일 단위 ERROR 반복)이 절반 남는다 — 그 전달 자체를 여기서 고정한다.
+    lookup_mock.assert_awaited_once_with(
+        order_id=stale_order.order_id, quiet_codes=frozenset({"NOT_FOUND_PAYMENT"}),
+    )
     # 풀 traceback(exc_info) 없이 INFO 레벨 한 줄만 — logger.exception이 아니라 logger.info.
     assert any(
         r.levelno == logging.INFO and "NOT_FOUND_PAYMENT" in r.getMessage() and r.exc_info is None


### PR DESCRIPTION
[SID:2913]

## 배경
#2913(#3327) 배포 후 라이브 실측(페드루군, 2026-08-22 00:59 크론 수동 트리거): 풀 traceback은 사라졌지만 `TossAdapter._get()`/`_post()`가 공유하는 자체 로깅이 매번 `"Toss payment lookup error: status=404 code=NOT_FOUND_PAYMENT"` ERROR 한 줄을 어댑터 층에서 또 찍고 있었다 — 원 스토리 취지("예외 로그 영구 반복 제거")의 절반이 남은 상태.

## 전 호출부 실측(get_payment_by_order_id 사용처 3곳)
- `billing_scheduler.py::sweep_stale_pending_orders` — NOT_FOUND_PAYMENT=확정 미발생(#2913 기존 처리), 조용해도 됨.
- `billing_reconciliation.py::daily_reconcile_confirmed_orders` — **confirmed** order가 Toss에 없다는 건 원장 무결성 이상 신호, ERROR 유지 필요.
- `billing_charge.py::_reconcile_duplicated_order` — DUPLICATED_ORDER_ID 뒤 조회(실시간 결제 경로), ERROR 유지 필요.

## 변경
어댑터는 호출자 문맥을 모르므로 코드 하나를 무조건 낮추지 않는다 — 호출자가 명시적으로 opt-in한 code만 조용히 처리하는 `quiet_codes` 파라미터를 `get_payment_by_order_id` → `_get`에 추가(기본값 빈 집합=기존 동작 그대로 ERROR). `sweep_stale_pending_orders`만 `quiet_codes={"NOT_FOUND_PAYMENT"}`를 전달 — 나머지 두 호출부는 무변경(여전히 ERROR).

## 테스트
- 신규 2건(`test_e_2493_c2_charge_ledger.py`): 어댑터 기본 동작(quiet_codes 미지정 시 ERROR 유지) 회귀·`quiet_codes` 지정 시 INFO 강등.
- 기존 #2913 테스트(`test_e_2494_c3_scheduler.py`)에 `quiet_codes` 전달 자체를 고정하는 assert 추가.
- 44/44 pass, 인접 회귀(`test_e_2495_c4_refund_reconciliation*.py`·`test_e_2478_b_payment_adapter.py`) 확認, `import app.main` clean.

## Test plan
- [x] 어댑터 기본(quiet_codes 없음) ERROR 유지 회귀
- [x] quiet_codes 지정 시 INFO 강등 확認
- [x] sweep_stale_pending_orders가 quiet_codes 실제 전달하는지 고정
- [x] 다른 두 호출부(reconciliation·charge) 무변경 확認