### PR TITLE
[SID:2901] fix(2901): chat sender avatar_url — BE payload + FE Avatar 소비

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -64,6 +64,7 @@ const baseMessage: ChatMessage = {
   created_by: 'agent-1',
   sender_name: '오르테가',
   sender_type: 'agent',
+  sender_avatar_url: null,
   // story #2671 — 링크 하나뿐인 문단은 이제 EmbedCard(카드)로 렌더된다(신규 기능, 아래
   // 전용 describe에서 검증). 이 파일의 나머지 스위트는 전부 EntityChip 특화 동작(사실성
   // 표기·상태 배지·결재 CTA·모달 재렌더 생존 등)을 재는 게 목적이라 앞에 문맥어를 붙여

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
-import { Bot, Check, Copy, MessageSquare, Terminal, User } from 'lucide-react';
+import { Check, Copy, MessageSquare, Terminal } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { commandName, dequoteLiteral, isCommand } from '@/lib/command-classifier';
@@ -21,7 +21,8 @@ import { ImageLightbox, type LightboxItem } from './image-lightbox';
 import type { ReadingPanelTarget } from './reading-panel';
 import { MessageContextMenu, type CiteAction } from './message-context-menu';
 import { SenderProfilePopover } from './sender-profile-popover';
-import { PresenceDot, WORKING_RING_CLASS, type PresenceStatus } from './presence-dot';
+import { type PresenceStatus } from './presence-dot';
+import { Avatar } from '@/components/shared/avatar';
 import { ReferenceSuggestionRow } from './reference-suggestion-row';
 import { IntentSuggestionCard } from './intent-suggestion-card';
 import { parseHitlRequest } from '@/lib/hitl-classifier';
@@ -482,26 +483,24 @@ export function ChatBubble({
         {isGrouped ? (
           <div className="w-7 flex-shrink-0" />
         ) : (
-          <div className="relative h-7 w-7 flex-shrink-0">
-            {/* story #2349 — "상대 프로필" 진입점. 자기 자신 아바타는 클릭 불가(role/tabIndex도 안 붙임). */}
-            <div
-              role={isMine ? undefined : 'button'}
-              tabIndex={isMine ? undefined : 0}
-              onClick={isMine ? undefined : handleOpenProfilePopover}
-              onKeyDown={isMine ? undefined : (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleOpenProfilePopover(e); } }}
-              className={`flex h-full w-full items-center justify-center rounded-full text-xs font-medium ${
-                isAgent
-                  ? 'bg-accent-claim/15 text-accent-claim'
-                  : isMine
-                    ? 'bg-primary/20 text-primary'
-                    : 'bg-muted text-muted-foreground'
-              } ${isAgent && isWorking ? WORKING_RING_CLASS : ''} ${isMine ? '' : 'cursor-pointer'}`}
-            >
-              {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
-            </div>
-            {isAgent && presenceStatus ? (
-              <PresenceDot status={presenceStatus} className="absolute -bottom-0.5 -right-0.5" />
-            ) : null}
+          <div
+            role={isMine ? undefined : 'button'}
+            tabIndex={isMine ? undefined : 0}
+            onClick={isMine ? undefined : handleOpenProfilePopover}
+            onKeyDown={isMine ? undefined : (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleOpenProfilePopover(e); } }}
+            className={`flex-shrink-0 ${isMine ? '' : 'cursor-pointer'}`}
+          >
+            {/* story #2349 — "상대 프로필" 진입점. 자기 자신 아바타는 클릭 불가(role/tabIndex도 안 붙임).
+                story #2901 — Avatar 프리미티브(이미지→이니셜→Bot/User 아이콘 3단 폴백, onError 하드닝
+                포함)로 교체. presence dot·working ring·AI 배지는 컴포넌트 내부가 이미 처리한다. */}
+            <Avatar
+              name={displayName}
+              avatarUrl={message.sender_avatar_url ?? null}
+              actorType={isAgent ? 'agent' : 'human'}
+              size={28}
+              presenceStatus={isAgent ? presenceStatus : null}
+              isWorking={isWorking}
+            />
           </div>
         )}
 

--- a/apps/web/src/components/chat/thread-panel.test.tsx
+++ b/apps/web/src/components/chat/thread-panel.test.tsx
@@ -49,6 +49,7 @@ const parentMessage: ChatMessage = {
   created_by: 'agent-1',
   sender_name: '오르테가',
   sender_type: 'agent',
+  sender_avatar_url: null,
   content: '원본 메시지',
   attachments: [],
   created_at: '2026-08-08T00:00:00.000Z',

--- a/apps/web/src/hooks/use-chat-sse.test.tsx
+++ b/apps/web/src/hooks/use-chat-sse.test.tsx
@@ -28,6 +28,22 @@ describe('normalizeToMessage — story #2604 P2 approval_target 노출', () => {
   });
 });
 
+describe('normalizeToMessage — story #2901 sender.avatar_url 노출', () => {
+  it('sender.avatar_url이 있으면 sender_avatar_url로 실린다', () => {
+    const raw = { id: 'm1', content: 'hi', sender: { id: 'u1', name: '오르테가', type: 'agent', avatar_url: 'https://cdn.test/a.png' } };
+    expect(normalizeToMessage(raw).sender_avatar_url).toBe('https://cdn.test/a.png');
+  });
+
+  it('sender.avatar_url이 없으면(레거시 OrgMember 소싱 등) null로 통일된다', () => {
+    const raw = { id: 'm2', content: 'hi', sender: { id: 'u2', name: '송윤재', type: 'human' } };
+    expect(normalizeToMessage(raw).sender_avatar_url).toBeNull();
+  });
+
+  it('sender 자체가 없으면 null로 통일된다', () => {
+    expect(normalizeToMessage({ id: 'm3', content: 'hi' }).sender_avatar_url).toBeNull();
+  });
+});
+
 class FakeEventSource {
   static readonly CONNECTING = 0;
   static readonly OPEN = 1;

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -22,6 +22,9 @@ export interface ChatMessage {
   created_by: string;     // backend: sender.id
   sender_name: string;    // backend: sender.name
   sender_type: string;    // backend: sender.type ('human' | 'agent')
+  // story #2901 — backend: sender.avatar_url. TeamMember/Member 소싱만 값이 있고
+  // OrgMember 소싱(레거시 JWT-휴먼 일부 경로)은 컬럼 자체가 없어 항상 null.
+  sender_avatar_url: string | null;
   content: string;
   /** story #2319 — set이면 tombstone됨(행은 남고 content는 서버가 이미 ""로 스크럽했다).
    * ChatBubble이 이 필드로 placeholder를 렌더한다(#2299 still_exists와 같은 축 — 「끊어짐」은
@@ -73,7 +76,7 @@ export interface ChatMessage {
 
 // Normalize backend _to_chat_message format → ChatMessage
 export function normalizeToMessage(raw: Record<string, unknown>): ChatMessage {
-  const sender = raw.sender as { id?: string; name?: string; type?: string } | undefined;
+  const sender = raw.sender as { id?: string; name?: string; type?: string; avatar_url?: string | null } | undefined;
   return {
     id: (raw.id ?? '') as string,
     // conversation:message uses conversation_id; chat:message uses thread_id or memo_id
@@ -81,6 +84,7 @@ export function normalizeToMessage(raw: Record<string, unknown>): ChatMessage {
     created_by: (raw.created_by ?? sender?.id ?? '') as string,
     sender_name: (sender?.name ?? '') as string,
     sender_type: (sender?.type ?? 'human') as string,
+    sender_avatar_url: (sender?.avatar_url ?? null) as string | null,
     content: (raw.content ?? '') as string,
     deleted_at: (raw.deleted_at ?? null) as string | null,
     attachments: (raw.attachments ?? []) as ChatMessage['attachments'],

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -459,6 +459,7 @@ def _msg_payload(
             "id": str(sender.id),
             "name": sender.name,
             "type": sender.type,
+            "avatar_url": sender.avatar_url,
         } if sender else None,
         # e2608901: 알림 카피 — raw event_type 대신 사람-친화 summary를 payload에 동봉.
         "summary": _build_message_summary(msg.content, sender.name if sender else None, bool(attachments)),

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -84,6 +84,7 @@ async def _resolve_member_legacy(
             role=tm.role,
             org_id=tm.org_id,
             project_id=tm.project_id,
+            avatar_url=tm.avatar_url,
         )
 
     # JWT 휴먼
@@ -108,6 +109,9 @@ async def _resolve_member_legacy(
     )).scalar_one_or_none()
     name = user.email if user else str(user_id)
 
+    # story #2901 — OrgMember·User 둘 다 avatar_url 컬럼이 없다(TeamMember/Member만 보유) —
+    # 지어낼 수 없어 dataclass 기본값(None) 그대로 둔다. JWT-휴먼이 TeamMember 행도 없는
+    # 레거시 org-member-only 케이스에 한정된 사각(앵커 모드 전환 시 Member 통합으로 해소).
     return ResolvedMember(
         id=om.id,
         user_id=user_id,
@@ -164,6 +168,7 @@ async def _resolve_member_anchor(
             role=role or "member",
             org_id=m.org_id,
             project_id=proj,
+            avatar_url=m.avatar_url,
         )
 
     # JWT 휴먼
@@ -203,6 +208,8 @@ async def _resolve_member_anchor(
         )).scalar_one_or_none()
         if om is None:
             raise HTTPException(status_code=400, detail="Organization member not found")
+        # story #2901 — 이 폴백은 om(OrgMember) 소싱이라 위 L111 레거시 분기와 동일하게
+        # avatar_url 컬럼이 없다(지어낼 수 없어 dataclass 기본값 None 유지).
         return ResolvedMember(
             id=om.id,
             user_id=user_id,
@@ -221,6 +228,7 @@ async def _resolve_member_anchor(
         role=m.org_role or "member",
         org_id=m.org_id,
         project_id=project_id,
+        avatar_url=m.avatar_url,
     )
 
 
@@ -251,6 +259,7 @@ async def _lookup_members_by_ids_legacy(
         m.id: ResolvedMember(
             id=m.id, user_id=m.user_id, name=m.name,
             type=m.type, role=m.role, org_id=m.org_id, project_id=m.project_id,
+            avatar_url=m.avatar_url,
         )
         for m in tms
     }
@@ -270,6 +279,7 @@ async def _lookup_members_by_ids_legacy(
             users_map = {u.id: u.email for u in users}
 
         for om in oms:
+            # story #2901 — om(OrgMember) 소싱, avatar_url 컬럼 없음(위 단일 resolve와 동일 사각).
             result[om.id] = ResolvedMember(
                 id=om.id,
                 user_id=om.user_id,
@@ -368,12 +378,14 @@ async def _lookup_members_by_ids_anchor(
                 id=m.id, user_id=None, name=m.name, type="agent",
                 role=role_by_member.get(m.id, "member"), org_id=m.org_id,
                 project_id=proj_by_member.get(m.id),
+                avatar_url=m.avatar_url,
             )
         else:
             result[orig_id] = ResolvedMember(
                 id=m.id, user_id=m.user_id,
                 name=email_by_user.get(m.user_id) if m.user_id else str(m.id),
                 type="human", role=m.org_role or "member", org_id=m.org_id, project_id=None,
+                avatar_url=m.avatar_url,
             )
 
     # 3. 진짜 orphan(member/alias 모두 없음) — telemetry-only + 크래시 방지 placeholder

--- a/backend/tests/test_2608_human_intervention_dispatch.py
+++ b/backend/tests/test_2608_human_intervention_dispatch.py
@@ -41,7 +41,9 @@ def _msg(mentioned=None):
 
 
 def _sender():
-    return SimpleNamespace(id=uuid.uuid4(), name="에이전트A", type="agent")
+    # story #2901 — _msg_payload가 sender.avatar_url을 읽는다(ResolvedMember/TeamMember
+    # 실 타입 둘 다 이 속성을 갖는다).
+    return SimpleNamespace(id=uuid.uuid4(), name="에이전트A", type="agent", avatar_url=None)
 
 
 class _DB:

--- a/backend/tests/test_2650_sse_attachment_context_parity.py
+++ b/backend/tests/test_2650_sse_attachment_context_parity.py
@@ -45,7 +45,9 @@ def _msg(*, content="hi", attachments=None):
 
 
 def _sender():
-    return SimpleNamespace(id=uuid.uuid4(), name="송신자", type="human")
+    # story #2901 — _msg_payload가 sender.avatar_url을 읽는다(ResolvedMember/TeamMember
+    # 실 타입 둘 다 이 속성을 갖는다).
+    return SimpleNamespace(id=uuid.uuid4(), name="송신자", type="human", avatar_url=None)
 
 
 async def _assign_seq(_db, event):

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -20,13 +20,16 @@ def anyio_backend():
     return "asyncio"
 
 
-def _make_member(member_id: uuid.UUID = MEMBER_ID, member_type: str = "human") -> MagicMock:
+def _make_member(
+    member_id: uuid.UUID = MEMBER_ID, member_type: str = "human", avatar_url: str | None = None,
+) -> MagicMock:
     m = MagicMock()
     m.id = member_id
     m.name = "테스트 멤버"
     m.type = member_type
     m.org_id = ORG_ID
     m.user_id = uuid.uuid4()
+    m.avatar_url = avatar_url
     return m
 
 
@@ -126,6 +129,35 @@ def test_msg_payload_includes_summary():
     payload = _msg_payload(msg, sender)
     assert "summary" in payload
     assert payload["summary"].startswith(f"{sender.name}: ")
+
+
+def test_msg_payload_sender_includes_avatar_url():
+    """story #2901 — sender dict에 avatar_url 동봉(read+SSE+POST 응답 전부의 SSOT인
+    _msg_payload 한 지점만 고치면 되는 이유 — 호출부 7곳이 전부 이 함수를 거친다)."""
+    from app.routers.conversations import _msg_payload
+    msg = _make_msg()
+    sender = _make_member(avatar_url="https://cdn.test/member.png")
+    payload = _msg_payload(msg, sender)
+    assert payload["sender"]["avatar_url"] == "https://cdn.test/member.png"
+
+
+def test_msg_payload_sender_avatar_url_none_when_sender_has_none():
+    """avatar_url 미보유 sender(예: 레거시 org_member 전용 휴먼)는 None으로 정직하게 떨어짐
+    (없는 값을 지어내지 않음)."""
+    from app.routers.conversations import _msg_payload
+    msg = _make_msg()
+    sender = _make_member()  # avatar_url 기본값 None
+    payload = _msg_payload(msg, sender)
+    assert payload["sender"]["avatar_url"] is None
+
+
+def test_msg_payload_sender_none_when_no_sender():
+    """sender 자체가 없으면(orphan 등) payload["sender"]는 None 그대로 — avatar_url 키를
+    억지로 만들지 않음(기존 계약 무변경 확認)."""
+    from app.routers.conversations import _msg_payload
+    msg = _make_msg()
+    payload = _msg_payload(msg, None)
+    assert payload["sender"] is None
 
 
 def test_msg_payload_exposes_approval_target_when_present():

--- a/backend/tests/test_event1config_message_gating.py
+++ b/backend/tests/test_event1config_message_gating.py
@@ -46,7 +46,9 @@ def _msg(mentioned=None):
 
 
 def _sender():
-    return SimpleNamespace(id=uuid.uuid4(), name="송신자", type="human")
+    # story #2901 — _msg_payload가 sender.avatar_url을 읽는다(ResolvedMember/TeamMember
+    # 실 타입 둘 다 이 속성을 갖는다).
+    return SimpleNamespace(id=uuid.uuid4(), name="송신자", type="human", avatar_url=None)
 
 
 async def _assign_seq(_db, event):

--- a/backend/tests/test_member_ssot_phase0.py
+++ b/backend/tests/test_member_ssot_phase0.py
@@ -38,7 +38,7 @@ def _make_auth(user_id: uuid.UUID = USER_ID, is_api_key: bool = False) -> MagicM
     return ctx
 
 
-def _make_team_member(tid=AGENT_TM_ID, ttype="agent", org_id=ORG_ID):
+def _make_team_member(tid=AGENT_TM_ID, ttype="agent", org_id=ORG_ID, avatar_url=None):
     tm = MagicMock()
     tm.id = tid
     tm.user_id = None
@@ -47,11 +47,12 @@ def _make_team_member(tid=AGENT_TM_ID, ttype="agent", org_id=ORG_ID):
     tm.role = "agent"
     tm.org_id = org_id
     tm.project_id = PROJECT_ID
+    tm.avatar_url = avatar_url
     return tm
 
 
 def _make_org_member(oid=ORG_MEMBER_ID, user_id=USER_ID, org_id=ORG_ID):
-    om = MagicMock()
+    om = MagicMock(spec=["id", "user_id", "org_id", "role", "deleted_at"])
     om.id = oid
     om.user_id = user_id
     om.org_id = org_id
@@ -77,6 +78,22 @@ async def test_resolve_member_api_key_returns_team_member_id():
     assert resolved.id == AGENT_TM_ID
     assert resolved.type == "agent"
     assert resolved.user_id is None
+
+
+@pytest.mark.anyio
+async def test_resolve_member_api_key_includes_avatar_url():
+    """story #2901 — TeamMember 소싱 분기는 avatar_url을 그대로 전달해야 함(ChatMessage
+    sender 페이로드의 선행 조건)."""
+    auth = _make_auth(is_api_key=True)
+    tm = _make_team_member(avatar_url="https://cdn.test/agent.png")
+
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = tm
+    session.execute = AsyncMock(return_value=result)
+
+    resolved = await resolve_member(auth, ORG_ID, session)
+    assert resolved.avatar_url == "https://cdn.test/agent.png"
 
 
 @pytest.mark.anyio
@@ -117,6 +134,27 @@ async def test_resolve_member_jwt_returns_org_member_id():
     assert resolved.type == "human"
     assert resolved.user_id == USER_ID
     assert resolved.name == "user@test.com"
+
+
+@pytest.mark.anyio
+async def test_resolve_member_jwt_avatar_url_none_no_column():
+    """story #2901 — OrgMember(+User) 소싱 분기는 avatar_url 컬럼 자체가 없어 None이
+    정직한 값(_make_org_member가 spec=[...]로 제한돼 있어 프로덕션 코드가 om.avatar_url을
+    건드리면 이 테스트가 AttributeError로 즉시 잡는다)."""
+    auth = _make_auth()
+    om = _make_org_member()
+
+    session = AsyncMock()
+    user_mock = MagicMock()
+    user_mock.email = "user@test.com"
+    om_result = MagicMock(); om_result.scalar_one_or_none.return_value = om
+    user_result = MagicMock(); user_result.scalar_one_or_none.return_value = user_mock
+
+    with patch("app.services.member_resolver.has_project_access", return_value=True):
+        session.execute = AsyncMock(side_effect=[om_result, user_result])
+        resolved = await resolve_member(auth, ORG_ID, session, project_id=PROJECT_ID)
+
+    assert resolved.avatar_url is None
 
 
 @pytest.mark.anyio
@@ -165,6 +203,19 @@ async def test_lookup_members_team_member_first():
 
 
 @pytest.mark.anyio
+async def test_lookup_members_team_member_includes_avatar_url():
+    """story #2901 — 배치 조회(list_messages 읽기 경로가 실제로 소비)도 TeamMember 소싱
+    시 avatar_url을 전달해야 함."""
+    tm = _make_team_member(avatar_url="https://cdn.test/agent.png")
+    session = AsyncMock()
+    tm_result = MagicMock(); tm_result.scalars.return_value.all.return_value = [tm]
+    session.execute = AsyncMock(return_value=tm_result)
+
+    result = await lookup_members_by_ids({AGENT_TM_ID}, session)
+    assert result[AGENT_TM_ID].avatar_url == "https://cdn.test/agent.png"
+
+
+@pytest.mark.anyio
 async def test_lookup_members_falls_back_to_org_member():
     """TeamMember에 없으면 OrgMember에서 fallback."""
     om = _make_org_member()
@@ -177,6 +228,7 @@ async def test_lookup_members_falls_back_to_org_member():
     result = await lookup_members_by_ids({ORG_MEMBER_ID}, session)
     assert ORG_MEMBER_ID in result
     assert result[ORG_MEMBER_ID].type == "human"
+    assert result[ORG_MEMBER_ID].avatar_url is None  # story #2901 — OrgMember 소싱, 컬럼 없음
 
 
 # ── _enforce_agent_creator_policy 유닛 테스트 ────────────────────────────────

--- a/backend/tests/test_member_ssot_resolver_shadow.py
+++ b/backend/tests/test_member_ssot_resolver_shadow.py
@@ -48,6 +48,7 @@ async def test_anchor_resolve_member_agent(monkeypatch):
     member.name = "Agent Bot"
     member.type = "agent"
     member.org_id = org_id
+    member.avatar_url = "https://cdn.test/agent.png"
 
     session = AsyncMock()
     # Member(agent) → ProjectAccess.role → AgentProjectProfile.project_id
@@ -59,6 +60,7 @@ async def test_anchor_resolve_member_agent(monkeypatch):
     assert resolved.role == "member"
     assert resolved.project_id == proj_id
     assert resolved.user_id is None
+    assert resolved.avatar_url == "https://cdn.test/agent.png"  # story #2901
 
 
 @pytest.mark.anyio
@@ -74,6 +76,7 @@ async def test_anchor_resolve_member_human(monkeypatch):
     member.user_id = user_id
     member.org_id = org_id
     member.org_role = "admin"
+    member.avatar_url = "https://cdn.test/human.png"
     user = MagicMock()
     user.email = "human@test.com"
 
@@ -86,6 +89,7 @@ async def test_anchor_resolve_member_human(monkeypatch):
     assert resolved.user_id == user_id
     assert resolved.role == "admin"   # org_role
     assert resolved.name == "human@test.com"
+    assert resolved.avatar_url == "https://cdn.test/human.png"  # story #2901 — Member 소싱
 
 
 @pytest.mark.anyio
@@ -119,6 +123,7 @@ async def test_anchor_lookup_direct_member(monkeypatch):
     mid = uuid.uuid4()
     m = MagicMock()
     m.id = mid; m.user_id = uuid.uuid4(); m.name = "H"; m.type = "human"; m.org_role = "member"; m.org_id = uuid.uuid4()
+    m.avatar_url = "https://cdn.test/h.png"
 
     session = AsyncMock()
     # Member.in_(ids) → [m]
@@ -130,6 +135,7 @@ async def test_anchor_lookup_direct_member(monkeypatch):
     assert out[mid].type == "human"
     assert out[mid].role == "member"
     assert out[mid].name == "h@test.com"  # M1: 휴먼 name=email
+    assert out[mid].avatar_url == "https://cdn.test/h.png"  # story #2901
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- `_msg_payload` sender dict에 `avatar_url` 추가 — read/SSE/POST 3면 공통(8 call site 단일 SSOT).
- `ResolvedMember` 생성자 12곳 중 6곳(TeamMember/Member 소싱)에 `avatar_url` 채움, 나머지 6곳(OrgMember 소싱, 컬럼 자체 없음)은 명시 주석과 함께 `None` 유지.
- FE: `ChatMessage.sender_avatar_url` 필드 추가(`use-chat-sse.ts`), `chat-bubble.tsx` non-grouped 아바타 블록을 `shared/avatar.tsx`의 `Avatar` 프리미티브(이미지→이니셜→아이콘 3단 폴백, onError 하드닝·presence dot·working ring·AI 배지 내장)로 교체.

## 스펙 대비 정정 2건 (미르코 그라운딩 재검증)
1. anchor 모드 org_members-fallback 분기(member_resolver.py `_resolve_member_anchor`)는 스펙이 tm/m 소싱이라 주장했으나 실제로는 `om`(OrgMember) 소싱 — avatar_url 컬럼이 없어 `None` 유지가 맞음(레거시 분기와 동형).
2. `lookup_members_by_ids`/`_lookup_members_by_ids_anchor`(배치 조회)를 스펙은 "우선순위 낮음"으로 뒀으나, `conversations.py::list_messages`(읽기 경로)가 `resolve_member` 아닌 이쪽을 직접 쓰므로 스토리 목표(read+SSE+POST 3면) 달성에 필수 — 함께 구현.

## Test plan
- [x] BE: `test_conversations.py`(50/50), `test_member_ssot_phase0.py`+`test_member_ssot_resolver_shadow.py`(30/30), `test_event1config_message_gating.py`(4/4, 회귀 발견·수정) — 전부 격리 fresh DB로 개별 검증.
- [x] FE: `chat-bubble.test.tsx`+`thread-panel.test.tsx`+`use-chat-sse.test.tsx` 111/111 통과, `tsc --noEmit` 0건, eslint 0건.
- [x] 대형 combined pytest sweep에서 관측된 110건은 CI 미재현 조합(파일 간 공유 DB 오염, #3332 카디르 선례와 동형)으로 판정 — 직접 관련 파일 전부 개별 격리 재확인 완료.

[SID:2901]