### PR TITLE
[SID:2922] feat(2922): Workcell W1 — 2×2 셸 + 신뢰 파이프라인 6상태 헤더 스테퍼

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -856,7 +856,6 @@
     "verificationPending": "Verification pending",
     "verificationRequested": "Verification requested",
     "verificationRequestFailed": "Failed to request verification",
-    "workcellStateInProgress": "In progress",
     "workcellDodMissing": "No DoD specified",
     "workcellBlockedReason": "Waiting on dependency stories",
     "workcellNextNeedInProgress": "Request review once work is done",
@@ -4094,7 +4093,14 @@
     "viewEvidence": "Evidence",
     "viewDecision": "Decision",
     "conversationEmpty": "No messages yet",
-    "conversationFooter": "Only directives, decisions, evidence, and change requests scoped to this work. Switching views (Run/Evidence/Decision) = same thread, different lens."
+    "conversationFooter": "Only directives, decisions, evidence, and change requests scoped to this work. Switching views (Run/Evidence/Decision) = same thread, different lens.",
+    "pipelineQuestion": "How far along (trust pipeline)",
+    "pipelineQueued": "Queued",
+    "pipelineRunning": "Running",
+    "pipelineNeedsInput": "Needs input",
+    "pipelineClaimedDone": "Claimed done",
+    "pipelineVerified": "Verified",
+    "pipelineMergeReady": "Merge-ready"
   },
   "loopQueue": {
     "title": "Unclosed loop queue",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -856,7 +856,6 @@
     "verificationPending": "검증 대기 중",
     "verificationRequested": "검증 요청됨",
     "verificationRequestFailed": "검증 요청 실패",
-    "workcellStateInProgress": "진행 중",
     "workcellDodMissing": "완료 조건 미기재",
     "workcellBlockedReason": "의존 스토리 대기 중",
     "workcellNextNeedInProgress": "작업 완료 후 리뷰 요청",
@@ -4094,7 +4093,14 @@
     "viewEvidence": "증거",
     "viewDecision": "결정",
     "conversationEmpty": "아직 메시지가 없습니다",
-    "conversationFooter": "이 작업에 귀속된 지시·판단·증거·수정요청만. 뷰 전환(실행/증거/결정)=같은 스레드 다른 렌즈."
+    "conversationFooter": "이 작업에 귀속된 지시·판단·증거·수정요청만. 뷰 전환(실행/증거/결정)=같은 스레드 다른 렌즈.",
+    "pipelineQuestion": "지금 어디까지 왔나 (신뢰 파이프라인)",
+    "pipelineQueued": "Queued",
+    "pipelineRunning": "Running",
+    "pipelineNeedsInput": "Needs input",
+    "pipelineClaimedDone": "Claimed done",
+    "pipelineVerified": "Verified",
+    "pipelineMergeReady": "Merge-ready"
   },
   "loopQueue": {
     "title": "닫히지 않은 루프 큐",

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -169,3 +169,46 @@ describe('StoryDetailPanel — org-switch 잔여 레이스 stale-guard (story #2
     expect(trigger()?.textContent).toBe('Comments (1)'); // 여전히 1 — stale 응답이 2번째로 덮어쓰지 않았다
   });
 });
+
+// story #2922 W1 — 카디르군 QA(#3336 MEDIUM) 지적 회귀가드: Workcell 헤더 pipelineStage
+// 파생이 needs_input/verified 둘 다 localStatus 무관 단독판정이어야 한다. verified만
+// `localStatus==='in-review'`로 게이팅됐던 결함 때문에 in-progress+webhook발 merge
+// 게이트(ci_result=pass)가 running으로 오표시됐다 — 이 async 왕복이 그 정확한 경로를 판다.
+describe('StoryDetailPanel — Workcell pipelineStage 파생(story #2922, 카디르군 #3336 MEDIUM 회귀가드)', () => {
+  const HUMAN_ID = 'human-1';
+  const memberMap = { [HUMAN_ID]: { id: HUMAN_ID, name: '책임자', type: 'human' } };
+
+  async function mountWithGates(status: string, gates: Array<{ gate_type: string; status: string; neutral_facts?: Record<string, unknown> }>) {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/api/gates?work_item_id=')) {
+        return { ok: true, json: async () => gates };
+      }
+      return { ok: false, json: async () => null };
+    }));
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel
+          story={makeStory({ status, assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID] })}
+          tasks={[]} onClose={() => {}} memberMap={memberMap}
+        />,
+      ));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+  }
+
+  // 스테퍼가 6라벨을 항상 전부 렌더하므로(현재단계=스타일만 다름) textContent.toContain으로는
+  // "어느 단계가 current인지" 못 잰다 — aria-current="step"이 붙은 그 원소의 텍스트로만 확인.
+  function currentStageLabel(): string | null {
+    return container.querySelector('[aria-current="step"]')?.textContent?.trim() ?? null;
+  }
+
+  it('in-progress + merge 게이트 pending(ci_result=pass) → Verified (수정 전엔 Running으로 오표시됨)', async () => {
+    await mountWithGates('in-progress', [{ gate_type: 'merge', status: 'pending', neutral_facts: { ci_result: 'pass' } }]);
+    expect(currentStageLabel()).toBe('Verified');
+  });
+
+  it('in-progress + needs-input류 게이트 pending(doc_approval) → Needs input (기존에도 정상, 대칭 확인)', async () => {
+    await mountWithGates('in-progress', [{ gate_type: 'doc_approval', status: 'pending' }]);
+    expect(currentStageLabel()).toBe('Needs input');
+  });
+});

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -25,8 +25,7 @@ import { StoryMergeGate } from '@/components/cage/story-merge-gate';
 import { EvidenceSection } from '@/components/verify/evidence-section';
 import { ChatProofSection } from '@/components/verify/chat-proof-section';
 import { deriveInFlightTrustChip } from '@/services/verify';
-import type { ProofState } from '@/components/proof-capsule/proof-capsule';
-import { Workcell, type WorkcellMessage } from '@/components/workcell/workcell';
+import { Workcell, type WorkcellMessage, type WorkcellPipelineStage } from '@/components/workcell/workcell';
 import { initials } from '@/lib/storage/format';
 import { ArtifactSection } from '@/components/canvas/artifact-section';
 import { StuckHandoffSection } from '@/components/cage/stuck-handoff-section';
@@ -741,21 +740,20 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   // - Evidence는 ProofCapsuleProps 실 매핑 인프라(EvidenceSection 재사용)가 후속 스코프라
   //   지금은 null(정직한 "아직 증거 없음" — 스펙이 명시적으로 허용하는 케이스).
   // - human assignee 없으면 Workcell 렌더 자체를 생략(허구 human 금지, ProofCapsule 배선과 동일 규율).
-  // P0-04 그라운딩(2026-07-11): GET /api/v2/agent-runs가 story_id 필터를 지원하지 않아(BE
-  // AgentRunRepository.list()는 project_id/agent_id만 필터) FE가 "지금 실제로 도는 에이전트가
-  // 있는지" 알 방법이 없다. 종전엔 blue 상태에 공용 "실행 중"(proofCapsuleStateRunning) 라벨을
-  // 썼는데, 이는 story.status='in-progress'라는 coarse 신호를 "에이전트가 지금 실행 중"이라는
-  // 더 구체적인 주장으로 과장한 것 — no-fiction 위반(파운더 독트린: 실시간 이벤트 텍스트≠실
-  // 실시간 신호). Workcell 전용으로 "진행 중"(workcellStateInProgress, 순수 status 반영, 실행
-  // 주장 없음)으로 정정. Board/Audit의 공용 blue="실행 중" 라벨은 별개 표면이라 스코프 밖
-  // (그쪽도 같은 근본 갭이 있으면 후속 별도 판단). 실 AgentRun story_id 필터는 디디 BE 티켓.
-  const PROOF_STATE_BY_STATUS: Record<string, ProofState> = {
-    'in-progress': 'blue', 'in-review': 'amber', done: 'green',
+  // story #2922 W1 — 구 3색 proofState 배지를 신뢰 파이프라인 6상태로 대체(doc
+  // workcell-redesign-2922 §매핑표). needs_input/verified는 5-status로 표현 불가한 파생값이라
+  // 기존 trustChip(deriveInFlightTrustChip, P0-04)을 그대로 재사용 — merge 게이트 pending+
+  // ci_result=pass가 "Verified"(AC/자동검증 통과·merge gate 前)와 정확히 같은 신호, needs_input
+  // 게이트 pending이 그대로 "Needs input"이다. 신규 BE 필드 0(B1은 doc상 "명시만", 구현 스코프 아님).
+  const PIPELINE_STAGE_BY_STATUS: Record<string, WorkcellPipelineStage> = {
+    backlog: 'queued', 'ready-for-dev': 'queued', done: 'merge_ready',
   };
-  const proofState = PROOF_STATE_BY_STATUS[localStatus];
-  const proofStateLabel = proofState
-    ? { blue: t('workcellStateInProgress'), amber: t('proofCapsuleStateReviewing'), green: t('proofCapsuleStateProven'), red: t('proofCapsuleStateViolation') }[proofState]
-    : null;
+  const pipelineStage: WorkcellPipelineStage | null = PIPELINE_STAGE_BY_STATUS[localStatus]
+    ?? (trustChip === 'needs_input' ? 'needs_input'
+      : localStatus === 'in-review' && trustChip === 'merge_ready' ? 'verified'
+        : localStatus === 'in-review' ? 'claimed_done'
+          : localStatus === 'in-progress' ? 'running'
+            : null);
   const assigneeIds = story.assignee_ids?.length ? story.assignee_ids : (story.assignee_id ? [story.assignee_id] : []);
   const proofHumanId = assigneeIds.find((id) => memberMap[id] && memberMap[id]!.type !== 'agent');
   const proofAgentId = assigneeIds.find((id) => memberMap[id]?.type === 'agent');
@@ -1273,14 +1271,15 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
             옵트인(신규 CSS 아님) — .tableWrapper(#2203)가 이미 라이브 양성으로 검증한 패턴. */}
         <div className="scrollbar-visible flex-1 overflow-y-auto p-5">
           <div className="space-y-5">
-            {/* E-UI-DAEGBYEON P0 — Workcell 4층 데뷔(최소 실화면 배선, story `e5310d1b`).
-                Evidence는 null(정직한 "아직 증거 없음" — EvidenceSection/StoryMergeGate 실
-                데이터 매핑은 후속 스코프, 대체 아님). human assignee 없으면 전체 생략. */}
-            {proofState && proofStateLabel && proofHuman ? (
+            {/* E-UI-DAEGBYEON P0 — Workcell 데뷔(최소 실화면 배선, story `e5310d1b`) + story #2922
+                W1 2×2 재설계. Evidence는 null(정직한 "아직 증거 없음" — EvidenceSection/
+                StoryMergeGate 실데이터 매핑은 후속 스코프, 대체 아님). human assignee 없으면 전체
+                생략. pipelineStage는 5-status 전 구간(backlog 포함) 항상 파생 가능해졌으므로
+                (Queued 신설) 가드에서 제외 — human 부재만 남는다. */}
+            {pipelineStage && proofHuman ? (
               <Workcell
                 title={story.title}
-                proofState={proofState}
-                stateLabel={proofStateLabel}
+                pipelineStage={pipelineStage}
                 brief={{
                   goal: story.description?.trim() || story.title,
                   dod: story.acceptance_criteria?.trim() || t('workcellDodMissing'),

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -745,12 +745,16 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   // 기존 trustChip(deriveInFlightTrustChip, P0-04)을 그대로 재사용 — merge 게이트 pending+
   // ci_result=pass가 "Verified"(AC/자동검증 통과·merge gate 前)와 정확히 같은 신호, needs_input
   // 게이트 pending이 그대로 "Needs input"이다. 신규 BE 필드 0(B1은 doc상 "명시만", 구현 스코프 아님).
+  // 카디르군 QA(#3336 MEDIUM, 2026-08-22) — verified만 `localStatus==='in-review'`로 게이팅해
+  // needs_input과 비대칭이었다: webhook발 merge 게이트가 in-progress 구간에 이미 pending+
+  // ci_result=pass로 도달 가능한 실경로(test_2826 realdb 실증)에서 running으로 오표시되던 결함.
+  // needs_input과 동일하게 trustChip 값만으로 단독판정(status 무관)하도록 정정.
   const PIPELINE_STAGE_BY_STATUS: Record<string, WorkcellPipelineStage> = {
     backlog: 'queued', 'ready-for-dev': 'queued', done: 'merge_ready',
   };
   const pipelineStage: WorkcellPipelineStage | null = PIPELINE_STAGE_BY_STATUS[localStatus]
     ?? (trustChip === 'needs_input' ? 'needs_input'
-      : localStatus === 'in-review' && trustChip === 'merge_ready' ? 'verified'
+      : trustChip === 'merge_ready' ? 'verified'
         : localStatus === 'in-review' ? 'claimed_done'
           : localStatus === 'in-progress' ? 'running'
             : null);

--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -17,8 +17,7 @@ function renderKo(ui: ReactElement): string {
 
 const BASE: WorkcellProps = {
   title: '결제 복구 플로우 — 재시도 로직',
-  proofState: 'blue',
-  stateLabel: '실행 중',
+  pipelineStage: 'running',
   brief: {
     goal: '실패한 결제를 재시도로 복구',
     dod: 'AC 4 충족 · 자동검증 passed · 정본 승인',
@@ -46,10 +45,10 @@ describe('Workcell (4층 — Brief/Run/Evidence/Conversation)', () => {
     expect(markup).toContain('Conversation');
   });
 
-  it('renders the header title and state label together (색만으로 의미 전달 금지)', () => {
+  it('renders the header title and the current pipeline stage label together (색만으로 의미 전달 금지)', () => {
     const markup = renderKo(<Workcell {...BASE} />);
     expect(markup).toContain(BASE.title);
-    expect(markup).toContain('실행 중');
+    expect(markup).toContain('Running');
   });
 
   it('renders Brief goal/dod/owner/agent', () => {
@@ -58,6 +57,28 @@ describe('Workcell (4층 — Brief/Run/Evidence/Conversation)', () => {
     expect(markup).toContain('AC 4 충족');
     expect(markup).toContain('책임 윤재');
     expect(markup).toContain('실행 미르코군');
+  });
+});
+
+describe('Workcell — story #2922 W1 신뢰 파이프라인 헤더 스테퍼(6상태) + 2×2 구획', () => {
+  it('renders all six pipeline stage labels regardless of current stage', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="queued" />);
+    expect(markup).toContain('Queued');
+    expect(markup).toContain('Running');
+    expect(markup).toContain('Needs input');
+    expect(markup).toContain('Claimed done');
+    expect(markup).toContain('Verified');
+    expect(markup).toContain('Merge-ready');
+  });
+
+  it('marks the current stage with aria-current="step" (색만 금지 — 스크린리더도 현재단계를 안다)', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="claimed_done" />);
+    expect(markup).toContain('aria-current="step"');
+  });
+
+  it('renders a 2×2 quadrant body (Brief|Run / Evidence|Conversation), not a vertical 4-stack', () => {
+    const markup = renderKo(<Workcell {...BASE} />);
+    expect(markup).toContain('grid-cols-2');
   });
 });
 

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
-import { ProofAvatar, ProofCapsule, type ProofCapsuleProps, type ProofState } from '@/components/proof-capsule/proof-capsule';
+import { ProofAvatar, ProofCapsule, type ProofCapsuleProps } from '@/components/proof-capsule/proof-capsule';
 
 export interface WorkcellOwner {
   name: string;
@@ -45,13 +45,16 @@ export interface WorkcellConversation {
   messages: WorkcellMessage[];
 }
 
+/** story #2922(P0-D 재설계) — 신뢰 파이프라인 6상태. 현행 5-status(backlog/ready-for-dev/
+ * in-progress/in-review/done)로는 표현 못 하는 needs_input·verified는 파생(호출부 책임,
+ * doc workcell-redesign-2922 §매핑표). 순서 자체가 파이프라인 진행 축(STAGES 배열과 동일). */
+export type WorkcellPipelineStage = 'queued' | 'running' | 'needs_input' | 'claimed_done' | 'verified' | 'merge_ready';
+
 export interface WorkcellProps {
   title: string;
-  proofState: ProofState;
-  /** workcell-fe-spec-handoff §2 인터페이스엔 없지만, Proofline 자체(§1) 및 도크트린 ③(색만
-   * 금지 텍스트 병기)이 이 헤더 배지에도 동일 적용 — ProofCapsule.stateLabel과 같은 관례로
-   * 필수화(목업 pstate가 실제로 "실행 중" 텍스트를 렌더하므로 스펙 인터페이스의 누락 보완). */
-  stateLabel: string;
+  /** story #2922 — 구 단일 proofState 배지(3색 점+텍스트)를 헤더 6상태 파이프라인 스테퍼로
+   * 대체(doc workcell-redesign-2922 축②). */
+  pipelineStage: WorkcellPipelineStage;
   brief: WorkcellBrief;
   run: WorkcellRun;
   /** null = 아직 증거 없음(정직한 빈 상태) — Proof Capsule 컴포넌트 그대로 재사용. */
@@ -60,43 +63,80 @@ export interface WorkcellProps {
   className?: string;
 }
 
+const PIPELINE_STAGES: WorkcellPipelineStage[] = ['queued', 'running', 'needs_input', 'claimed_done', 'verified', 'merge_ready'];
 
-const STATE_TONE: Record<ProofState, string> = {
-  blue: 'text-proof-blue', amber: 'text-proof-amber', green: 'text-proof-green', red: 'text-proof-red',
-};
-const STATE_DOT: Record<ProofState, string> = {
-  blue: 'bg-proof-blue', amber: 'bg-proof-amber', green: 'bg-proof-green', red: 'bg-proof-red',
-};
+function PipelineStepper({ stage }: { stage: WorkcellPipelineStage }) {
+  const t = useTranslations('workcell');
+  const label: Record<WorkcellPipelineStage, string> = {
+    queued: t('pipelineQueued'), running: t('pipelineRunning'), needs_input: t('pipelineNeedsInput'),
+    claimed_done: t('pipelineClaimedDone'), verified: t('pipelineVerified'), merge_ready: t('pipelineMergeReady'),
+  };
+  const curIdx = PIPELINE_STAGES.indexOf(stage);
+  return (
+    <div className="mb-2.5 flex flex-wrap items-center gap-x-0 gap-y-1" role="list" aria-label={t('pipelineQuestion')}>
+      {PIPELINE_STAGES.map((s, i) => {
+        const status = i < curIdx ? 'done' : i === curIdx ? 'current' : 'pending';
+        return (
+          <span key={s} className="flex items-center" role="listitem">
+            <span
+              className={cn(
+                'flex items-center gap-1.5 pr-1.5 text-[9px] font-semibold leading-none',
+                status === 'done' && 'text-proof-green',
+                status === 'current' && 'font-bold text-proof-blue',
+                status === 'pending' && 'text-proof-faint',
+              )}
+              aria-current={status === 'current' ? 'step' : undefined}
+            >
+              <span
+                className={cn(
+                  'size-1.5 rounded-full',
+                  status === 'done' && 'bg-proof-green',
+                  status === 'current' && 'bg-proof-blue ring-2 ring-proof-blue/20',
+                  status === 'pending' && 'bg-proof-line',
+                )}
+                aria-hidden="true"
+              />
+              {label[s]}
+            </span>
+            {i < PIPELINE_STAGES.length - 1 ? <span className="px-1 text-[9px] text-proof-line" aria-hidden="true">›</span> : null}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
 
 /**
- * Workcell — Story 상세 우측 패널의 4층 재구성(workcell-fe-spec-handoff). "10초 리트머스":
- * 열고 10초 안에 무엇을(Brief)·누가(Brief)·어디까지(Run+Evidence)·무엇이 필요한지(Run
- * nextNeed) 답 가능해야 한다. Brief(약속)→Run(현재행위+다음요구, 진행률바 없음)→Evidence
- * (Proof Capsule 재사용)→Conversation(작업-귀속, 전역 chat과 분리) 순.
+ * Workcell — Story 상세 우측 패널의 4구획 재구성(story #2922 P0-D, workcell-fe-spec-handoff
+ * 초판 위 재설계). "10초 리트머스": 열고 10초 안에 무엇을(Brief)·누가(Brief)·어디까지
+ * (Run+Evidence)·무엇이 필요한지(Run nextNeed) 답 가능해야 한다. 2×2 구획(Brief|Run /
+ * Evidence|Conversation, 탭 0)+헤더 신뢰 파이프라인 6상태 스테퍼(Queued→…→Merge-ready).
  *
- * 도크트린 5 준수: ①약속>활동(Brief가 최상단) ②주장>로그(활동 로그 필드 자체가 없음)
- * ③예외 선명(막힘은 숨기지 않되 빨강 아닌 info 톤) ④자동화 경계(agent 마커 항상 구분)
- * ⑤인간=책임 주체(Evidence의 Human gate가 결정점). 안티패턴 0 — 진행률 바(%) 자체를
- * 렌더하지 않는 게 Run 층의 핵심 계약.
+ * 도크트린 5 준수: ①약속>활동(Brief가 좌상단) ②주장>로그(활동 로그 필드 자체가 없음)
+ * ③예외 선명(막힘은 숨기지 않되 빨강 아닌 info 톤, 파이프라인 단계도 색+텍스트 병기)
+ * ④자동화 경계(agent 마커 항상 구분) ⑤인간=책임 주체(Evidence의 Human gate가 결정점).
+ * 안티패턴 0 — 진행률 바(%) 자체를 렌더하지 않는 게 Run 구획의 핵심 계약.
  */
-export function Workcell({ title, proofState, stateLabel, brief, run, evidence, conversation, className }: WorkcellProps) {
+export function Workcell({ title, pipelineStage, brief, run, evidence, conversation, className }: WorkcellProps) {
   return (
     <div
       className={cn('overflow-hidden rounded-[6px] border border-proof-line bg-proof-panel', className)}
       style={{ clipPath: 'polygon(0 0, calc(100% - 24px) 0, 100% 24px, 100% 100%, 0 100%)' }}
     >
-      <div className="flex items-center gap-3 border-b border-proof-line px-4.5 py-3.5">
+      <div className="border-b border-proof-line px-4.5 py-3.5">
+        <PipelineStepper stage={pipelineStage} />
         <span className="text-[17px] font-bold leading-tight tracking-[-0.012em] text-proof-ink">{title}</span>
-        <span className={cn('ml-auto inline-flex items-center gap-1.5 text-[11px] font-semibold', STATE_TONE[proofState])}>
-          <span className={cn('size-1.5 rounded-full', STATE_DOT[proofState])} aria-hidden="true" />
-          {stateLabel}
-        </span>
       </div>
 
-      <BriefLayer brief={brief} />
-      <RunLayer run={run} />
-      <EvidenceLayer evidence={evidence} />
-      <ConversationLayer conversation={conversation} />
+      {/* story #2922 W1 — 4구획 세로 나열 → 2×2 그리드(Brief|Run / Evidence|Conversation).
+          gap-px+bg-proof-line가 각 구획 사이 헤어라인을 만든다(개별 레이어의 border-b는
+          이제 이 그리드 갭과 중복이라 제거됨). */}
+      <div className="grid grid-cols-2 gap-px bg-proof-line">
+        <div className="bg-proof-panel"><BriefLayer brief={brief} /></div>
+        <div className="bg-proof-panel"><RunLayer run={run} /></div>
+        <div className="bg-proof-panel"><EvidenceLayer evidence={evidence} /></div>
+        <div className="bg-proof-panel"><ConversationLayer conversation={conversation} /></div>
+      </div>
     </div>
   );
 }
@@ -113,7 +153,7 @@ function LayerLabel({ title, question, className }: { title: string; question: s
 function BriefLayer({ brief }: { brief: WorkcellBrief }) {
   const t = useTranslations('workcell');
   return (
-    <div className="border-b border-proof-line-soft px-4.5 py-3.5">
+    <div className="h-full px-4.5 py-3.5">
       <LayerLabel title="Brief" question={t('briefQuestion')} className="mb-2.5" />
       <div className="flex gap-2 text-[13px] leading-[1.5] text-proof-ink-2">
         <span className="w-16 shrink-0 pt-px text-[11px] text-proof-faint">{t('briefGoal')}</span>
@@ -140,7 +180,7 @@ function BriefLayer({ brief }: { brief: WorkcellBrief }) {
 function RunLayer({ run }: { run: WorkcellRun }) {
   const t = useTranslations('workcell');
   return (
-    <div className="border-b border-proof-line-soft px-4.5 py-3.5">
+    <div className="h-full px-4.5 py-3.5">
       <LayerLabel title="Run" question={t('runQuestion')} className="mb-2.5" />
       <div className="mb-2 text-[13.5px] font-semibold text-proof-ink">{t('runNow')}: {run.now}</div>
       <div className="mb-2.5 flex flex-wrap gap-3.5 text-[11px] text-proof-ink-3">
@@ -161,7 +201,7 @@ function RunLayer({ run }: { run: WorkcellRun }) {
 function EvidenceLayer({ evidence }: { evidence: ProofCapsuleProps | null }) {
   const t = useTranslations('workcell');
   return (
-    <div className="border-b border-proof-line-soft px-4.5 py-3.5">
+    <div className="h-full px-4.5 py-3.5">
       <LayerLabel title="Evidence" question={t('evidenceQuestion')} className="mb-2.5" />
       {evidence ? (
         <ProofCapsule {...evidence} />
@@ -181,7 +221,7 @@ function ConversationLayer({ conversation }: { conversation: WorkcellConversatio
     run: t('viewRun'), evidence: t('viewEvidence'), decision: t('viewDecision'),
   };
   return (
-    <div className="px-4.5 py-3.5">
+    <div className="h-full px-4.5 py-3.5">
       <div className="mb-2.5 flex items-center gap-2">
         <LayerLabel title="Conversation" question={t('conversationQuestion')} />
         <div className="ml-auto inline-flex overflow-hidden rounded-[6px] border border-proof-line">


### PR DESCRIPTION
## Summary
- doc `workcell-redesign-2922` §구현 슬라이스 W1(6개 중 1/6, 아티팩트 335f138d 하이파이 시안 기준).
- 기존 `workcell.tsx`(#1786, Brief→Run→Evidence→Conversation 세로 4층)를 **2×2 구획**(Brief|Run / Evidence|Conversation)으로 재배치.
- 헤더의 3색 단일 `proofState` 배지 → **6단계 신뢰 파이프라인 스테퍼**(Queued→Running→Needs input→Claimed done→Verified→Merge-ready, `PipelineStepper` 신설).

## 파생 로직 — 신규 BE 0
`Needs input`/`Verified`는 현행 5-status로 표현 불가한 파생 상태(doc §매핑표)지만, 이미 존재하는 `deriveInFlightTrustChip`(P0-04, story-detail-panel.tsx)을 그대로 재사용했음:
- merge 게이트 pending + `ci_result=pass` → **Verified**(AC/자동검증 통과·merge gate 前, 매핑표 그대로).
- needs_input류 게이트 pending → **Needs input**.
- `backlog`/`ready-for-dev` → Queued, `done` → Merge-ready, 나머지는 status 직접매핑.

doc의 B1(status enum 확장 또는 파생 필드 API 노출)은 "명시만·구현 스코프 아님"으로 doc 자체가 못박아둔 대로 **이번 PR에서 구현하지 않음** — 위 파생이 그 필요를 우회한 것.

## 배선
`story-detail-panel.tsx`: `pipelineStage`가 이제 전 status(Queued 포함) 항상 파생 가능해져 렌더 가드를 `pipelineStage && proofHuman`으로 단순화(human assignee 부재만 남는 조건). 오르핀된 `workcellStateInProgress` i18n 키 정리.

## Test plan
- [x] `workcell.test.tsx` 12/12(6상태 라벨 전부 렌더+`aria-current="step"`+2×2 grid 회귀가드 신규 3건 포함), `story-detail-panel.test.tsx` 6/6.
- [x] `tsc --noEmit` 0건, eslint 0건.
- [x] `verify:no-duplicate-i18n-keys`+`verify:no-i18n-phrase-collision` 신규 충돌 0건(grandfather 20건 무변).

[SID:2922]