### PR TITLE
[SID:2921] S6 — 우측슬롯 넓은폭 3-pane 병렬(xl↑)·lg~xl 구간 rail 자동접힘

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3442,6 +3442,8 @@
     "dmSection": "Direct Messages",
     "groupSection": "Group Chats",
     "newConversation": "New Conversation",
+    "collapseRail": "Hide list",
+    "expandRail": "Show list",
     "noConversations": "No conversations yet",
     "startNewConversation": "Start a new conversation",
     "selectMembers": "Select members",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3442,6 +3442,8 @@
     "dmSection": "DM",
     "groupSection": "그룹 채팅",
     "newConversation": "새 대화",
+    "collapseRail": "목록 닫기",
+    "expandRail": "목록 열기",
     "noConversations": "대화가 없습니다",
     "startNewConversation": "새 대화를 시작해보세요",
     "selectMembers": "대화 상대 선택",

--- a/apps/web/src/app/(authenticated)/chats/chat-rail-context.tsx
+++ b/apps/web/src/app/(authenticated)/chats/chat-rail-context.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+
+/**
+ * story #2921 S6(P0-C, 챗 리디자인 시안 §S6 — 유나 확定 2026-08-22) — 우측 슬롯(ReadingPanel)이
+ * 열렸을 때 좁은 데스크톱(lg~xl 사이, 1024~1279px)에서 rail(270px)+main+reading(480px 최소)이
+ * 동시에 눌려 main이 300px 밑으로 떨어지는 문제의 처방. 리스트 레일(layout.tsx)과 우측 슬롯
+ * (chat-view.tsx)은 서로 다른 컴포넌트라 "지금 reading이 열려 있는지"를 끌어올려야(lift) 한다.
+ *
+ * 규칙(유나 확定, 산수 근거):
+ * ① xl(1280px)↑ — 3-pane 항상 나란히(rail 270+main 530+reading 480). rail은 절대 안 접힘.
+ * ② 1024~1279px, reading 닫힘 — 현행 2-pane(rail+main) 그대로, 무변화.
+ * ③ 1024~1279px, reading 열림 — rail 자동 접힘(main 544 보장), reading은 clamp 아니라 480 고정.
+ * ④ 접힌 rail은 토글로 다시 부를 수 있다 — 그땐 모바일과 동형인 오버레이(main/reading을
+ *    다시 눌러 앉히지 않고 그 위를 덮는다).
+ *
+ * ⛔Thread 패널(w-80=320px 고정)은 이 규칙 대상이 아니다 — reading(480)보다 훨씬 좁아 같은
+ * 폭에서 눌림이 덜하고, 유나 확定 문구도 "Reading 열림"만 명시했다(임의 확장 안 함).
+ */
+export type ChatRailMode = 'normal' | 'collapsed' | 'overlay';
+
+interface ChatRailContextValue {
+  /** normal=평소 flex 흐름 그대로 보임·collapsed=완전히 숨음·overlay=토글로 다시 부른 상태
+   * (main/reading 폭을 안 건드리고 그 위를 덮는다, 모바일 드로어와 동형). */
+  railMode: ChatRailMode;
+  toggleManualExpand: () => void;
+  /** ChatView가 ReadingPanel 열림 여부를 보고한다. */
+  setReadingOpen: (open: boolean) => void;
+}
+
+const ChatRailContext = createContext<ChatRailContextValue | null>(null);
+
+export function ChatRailProvider({ children }: { children: ReactNode }) {
+  const [readingOpen, setReadingOpenState] = useState(false);
+  const [isBelowXl, setIsBelowXl] = useState(false);
+  const [manuallyExpanded, setManuallyExpanded] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 1279px)');
+    const update = () => setIsBelowXl(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  // reading이 닫히는 "전환"에서만 수동 펼침도 같이 리셋한다 — 다음에 reading이 다시 열리면
+  // 자동접힘부터 재시작(닫힌 채로 남아있던 수동 펼침이 다음 무관한 세션까지 새 나가지 않게).
+  // setReadingOpen(이벤트 기반 콜백) 안에서 처리해 렌더 효과(useEffect) 안 setState 연쇄를
+  // 피한다(react-hooks/set-state-in-effect).
+  const setReadingOpen = useCallback((open: boolean) => {
+    setReadingOpenState((prev) => {
+      if (prev && !open) setManuallyExpanded(false);
+      return open;
+    });
+  }, []);
+
+  const railMode: ChatRailMode = !isBelowXl || !readingOpen
+    ? 'normal'
+    : manuallyExpanded ? 'overlay' : 'collapsed';
+
+  const toggleManualExpand = useCallback(() => setManuallyExpanded((v) => !v), []);
+
+  const value = useMemo(
+    () => ({ railMode, toggleManualExpand, setReadingOpen }),
+    [railMode, toggleManualExpand, setReadingOpen],
+  );
+
+  return <ChatRailContext.Provider value={value}>{children}</ChatRailContext.Provider>;
+}
+
+export function useChatRail(): ChatRailContextValue {
+  const ctx = useContext(ChatRailContext);
+  if (!ctx) throw new Error('useChatRail must be used within ChatRailProvider');
+  return ctx;
+}

--- a/apps/web/src/app/(authenticated)/chats/layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.test.tsx
@@ -148,7 +148,9 @@ describe('ChatsLayout — story #2921 S6(xl 미만 + Reading 열림 → rail 자
     });
     const rail = container.querySelector('[data-testid="chat-rail"]');
     expect(rail?.className).not.toMatch(/(^|\s)lg:hidden(\s|$)/);
-    expect(container.querySelector('[aria-label="목록 열기"]')).toBeNull();
+    // 카디르 #3337 QA 처방(포커스 복귀 버그) 후 — 트리거는 이제 항상 마운트되고 CSS로만
+    // 숨는다(DOM 부재가 아니라 !hidden 클래스). 존재 자체가 아니라 숨김 클래스를 잰다.
+    expect(container.querySelector('[aria-label="목록 열기"]')?.className).toContain('!hidden');
   });
 
   it('lg~xl 사이 + Reading 닫힘 — 현행 2-pane 그대로(무변화, ②)', async () => {
@@ -169,7 +171,9 @@ describe('ChatsLayout — story #2921 S6(xl 미만 + Reading 열림 → rail 자
     });
     const rail = container.querySelector('[data-testid="chat-rail"]');
     expect(rail?.className).toMatch(/(^|\s)lg:hidden(\s|$)/);
-    expect(container.querySelector('[aria-label="목록 열기"]')).toBeTruthy();
+    const expandBtn = container.querySelector('[aria-label="목록 열기"]');
+    expect(expandBtn).toBeTruthy();
+    expect(expandBtn?.className).not.toContain('!hidden');
   });
 
   it('접힌 rail을 토글로 다시 부르면 오버레이(fixed)로 뜬다 — main/reading 폭을 다시 누르지 않는다(④)', async () => {
@@ -183,9 +187,10 @@ describe('ChatsLayout — story #2921 S6(xl 미만 + Reading 열림 → rail 자
     const rail = container.querySelector('[data-testid="chat-rail"]');
     expect(rail?.className).toContain('fixed');
     expect(rail?.className).toContain('z-40');
-    // 오버레이 상태에선 collapsed 전용 재호출 토글이 사라지고, backdrop이 대신 뜬다(장식용
-    // click-catcher — 접근성 트리에서는 빠진다, aria-hidden).
-    expect(container.querySelector('[aria-label="목록 열기"]')).toBeNull();
+    // 오버레이 상태에선 collapsed 전용 재호출 토글이 !hidden으로 숨고(DOM 부재 아님 — 카디르
+    // #3337 QA 처방, 포커스 복귀 안정성), backdrop이 대신 뜬다(장식용 click-catcher —
+    // 접근성 트리에서는 빠진다, aria-hidden).
+    expect(container.querySelector('[aria-label="목록 열기"]')?.className).toContain('!hidden');
     const backdrop = Array.from(container.querySelectorAll('button')).find((b) => b.getAttribute('aria-hidden') === 'true');
     expect(backdrop).toBeTruthy();
   });
@@ -233,8 +238,28 @@ describe('ChatsLayout — story #2921 S6(xl 미만 + Reading 열림 → rail 자
     await act(async () => {
       root.render(wrap(<ChatsLayout><ReadingOpenProbe open /></ChatsLayout>));
     });
-    // 리셋됐다면 다시 collapsed(재호출 토글 존재)로 돌아온다 — overlay가 안 남아있다.
-    expect(container.querySelector('[aria-label="목록 열기"]')).toBeTruthy();
+    // 리셋됐다면 다시 collapsed(재호출 토글이 !hidden 없이 보임)로 돌아온다 — overlay가 안 남아있다.
+    expect(container.querySelector('[aria-label="목록 열기"]')?.className).not.toContain('!hidden');
     expect(container.querySelector('[data-testid="chat-rail"]')?.className).not.toContain('fixed');
+  });
+
+  it('카디르 #3337 QA(2026-08-22, HIGH) — Escape로 오버레이를 닫으면 포커스가 트리거로 정확히 돌아온다(숨겨진 rail 안 다른 버튼으로 새지 않는다)', async () => {
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    mqMatches = true;
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><ReadingOpenProbe open /></ChatsLayout>));
+    });
+    const expandBtn = container.querySelector('[aria-label="목록 열기"]') as HTMLButtonElement;
+    expandBtn.focus();
+    await act(async () => { expandBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    // 트리거가 언마운트되지 않고 !hidden으로만 숨는다 — DOM에 여전히 있다(포커스 복귀 대상이
+    // 살아있어야 하는 이 처방의 핵심 전제).
+    expect(expandBtn.isConnected).toBe(true);
+    expect(expandBtn.className).toContain('!hidden');
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(document.activeElement).toBe(expandBtn);
+    expect(expandBtn.className).not.toContain('!hidden');
   });
 });

--- a/apps/web/src/app/(authenticated)/chats/layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.test.tsx
@@ -5,11 +5,12 @@
 // «주장»하는 것(①ChatListView 단일 마운트 ②경로별 반응형 클래스 토글 ③새 대화 버튼 배선)만
 // 좁게 검증한다.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act } from 'react';
+import { act, useEffect } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../../messages/ko.json';
 import ChatsLayout from './layout';
+import { useChatRail } from './chat-rail-context';
 
 const useDashboardContextMock = vi.fn();
 vi.mock('../../dashboard/dashboard-shell', () => ({
@@ -42,12 +43,34 @@ function wrap(node: React.ReactNode) {
   );
 }
 
+// story #2921 S6 — jsdom엔 matchMedia가 없다. `mqMatches`를 테스트별로 바꿔 xl 미만/이상을
+// 흉내낸다(리스너도 실제로 등록·해제해 useEffect cleanup 누락을 놓치지 않게).
+let mqMatches = false;
+const mqListeners = new Set<() => void>();
+
 beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
   useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'member-1', projectId: 'proj-1' });
+  mqMatches = false;
+  mqListeners.clear();
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: mqMatches,
+    media: query,
+    addEventListener: (_: string, cb: () => void) => { mqListeners.add(cb); },
+    removeEventListener: (_: string, cb: () => void) => { mqListeners.delete(cb); },
+  })) as unknown as typeof window.matchMedia;
 });
+
+// story #2921 S6 테스트 전용 — ChatView 대신 심어 chat-rail-context의 setReadingOpen을 직접
+// 호출한다(실 ChatView는 SSE를 물어 이 파일 스코프 밖, chat-view.tsx 자체 책임은 그 파일이 아니라
+// 여기 layout+context 배선만 검증).
+function ReadingOpenProbe({ open }: { open: boolean }) {
+  const { setReadingOpen } = useChatRail();
+  useEffect(() => { setReadingOpen(open); }, [open, setReadingOpen]);
+  return <div data-testid="outlet-content">outlet</div>;
+}
 
 afterEach(async () => {
   await act(async () => { root.unmount(); });
@@ -113,5 +136,77 @@ describe('ChatsLayout — story #2921 S1(영구 스플릿뷰 shell)', () => {
     expect(newConvBtn).toBeTruthy();
     await act(async () => { newConvBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(container.querySelector('[data-testid="chat-list-view"]')!.textContent).toContain('open=true');
+  });
+});
+
+describe('ChatsLayout — story #2921 S6(xl 미만 + Reading 열림 → rail 자동 접힘, 유나 확定)', () => {
+  it('xl↑(넓은 폭)에서는 Reading이 열려도 rail이 절대 안 접힌다(①rail 절대 불변)', async () => {
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    mqMatches = false; // matchMedia('(max-width: 1279px)') 불일치 = xl↑
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><ReadingOpenProbe open /></ChatsLayout>));
+    });
+    const rail = container.querySelector('[data-testid="chat-rail"]');
+    expect(rail?.className).not.toMatch(/(^|\s)lg:hidden(\s|$)/);
+    expect(container.querySelector('[aria-label="목록 열기"]')).toBeNull();
+  });
+
+  it('lg~xl 사이 + Reading 닫힘 — 현행 2-pane 그대로(무변화, ②)', async () => {
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    mqMatches = true; // xl 미만
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><ReadingOpenProbe open={false} /></ChatsLayout>));
+    });
+    const rail = container.querySelector('[data-testid="chat-rail"]');
+    expect(rail?.className).not.toMatch(/(^|\s)lg:hidden(\s|$)/);
+  });
+
+  it('lg~xl 사이 + Reading 열림 — rail이 자동 접히고(③) 재호출 토글이 뜬다', async () => {
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    mqMatches = true;
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><ReadingOpenProbe open /></ChatsLayout>));
+    });
+    const rail = container.querySelector('[data-testid="chat-rail"]');
+    expect(rail?.className).toMatch(/(^|\s)lg:hidden(\s|$)/);
+    expect(container.querySelector('[aria-label="목록 열기"]')).toBeTruthy();
+  });
+
+  it('접힌 rail을 토글로 다시 부르면 오버레이(fixed)로 뜬다 — main/reading 폭을 다시 누르지 않는다(④)', async () => {
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    mqMatches = true;
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><ReadingOpenProbe open /></ChatsLayout>));
+    });
+    const expandBtn = container.querySelector('[aria-label="목록 열기"]') as HTMLButtonElement;
+    await act(async () => { expandBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const rail = container.querySelector('[data-testid="chat-rail"]');
+    expect(rail?.className).toContain('fixed');
+    expect(rail?.className).toContain('z-40');
+    // 오버레이 상태에선 collapsed 전용 재호출 토글이 사라지고, backdrop이 대신 뜬다.
+    expect(container.querySelector('[aria-label="목록 열기"]')).toBeNull();
+    expect(container.querySelector('[aria-label="목록 닫기"]')).toBeTruthy();
+  });
+
+  it('Reading이 닫히면 수동 펼침 상태도 리셋된다(다음에 다시 열릴 때 자동접힘부터 재시작)', async () => {
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    mqMatches = true;
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><ReadingOpenProbe open /></ChatsLayout>));
+    });
+    const expandBtn = container.querySelector('[aria-label="목록 열기"]') as HTMLButtonElement;
+    await act(async () => { expandBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.querySelector('[data-testid="chat-rail"]')?.className).toContain('fixed');
+    // Reading 닫힘 → Provider가 그대로 유지된 채(같은 root) props만 바꿔 재렌더 — 실제 앱에서
+    // ChatView가 readingPanelStack 변화로 setReadingOpen을 다시 부르는 것과 동형.
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><ReadingOpenProbe open={false} /></ChatsLayout>));
+    });
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><ReadingOpenProbe open /></ChatsLayout>));
+    });
+    // 리셋됐다면 다시 collapsed(재호출 토글 존재)로 돌아온다 — overlay가 안 남아있다.
+    expect(container.querySelector('[aria-label="목록 열기"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="chat-rail"]')?.className).not.toContain('fixed');
   });
 });

--- a/apps/web/src/app/(authenticated)/chats/layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.test.tsx
@@ -183,9 +183,37 @@ describe('ChatsLayout — story #2921 S6(xl 미만 + Reading 열림 → rail 자
     const rail = container.querySelector('[data-testid="chat-rail"]');
     expect(rail?.className).toContain('fixed');
     expect(rail?.className).toContain('z-40');
-    // 오버레이 상태에선 collapsed 전용 재호출 토글이 사라지고, backdrop이 대신 뜬다.
+    // 오버레이 상태에선 collapsed 전용 재호출 토글이 사라지고, backdrop이 대신 뜬다(장식용
+    // click-catcher — 접근성 트리에서는 빠진다, aria-hidden).
     expect(container.querySelector('[aria-label="목록 열기"]')).toBeNull();
-    expect(container.querySelector('[aria-label="목록 닫기"]')).toBeTruthy();
+    const backdrop = Array.from(container.querySelectorAll('button')).find((b) => b.getAttribute('aria-hidden') === 'true');
+    expect(backdrop).toBeTruthy();
+  });
+
+  it('오버레이는 접근 가능한 dialog다 — rail 자체가 role="dialog"+aria-modal+aria-labelledby를 지닌다(CI a11y 가드 처방)', async () => {
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    mqMatches = true;
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><ReadingOpenProbe open /></ChatsLayout>));
+    });
+    const expandBtn = container.querySelector('[aria-label="목록 열기"]') as HTMLButtonElement;
+    await act(async () => { expandBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const rail = container.querySelector('[data-testid="chat-rail"]');
+    expect(rail?.getAttribute('role')).toBe('dialog');
+    expect(rail?.getAttribute('aria-modal')).toBe('true');
+    expect(rail?.getAttribute('aria-labelledby')).toBe('chat-rail-heading');
+    expect(container.querySelector('#chat-rail-heading')).toBeTruthy();
+  });
+
+  it('평소(collapsed 아닌 정상 상태)엔 rail이 dialog 시맨틱을 안 지닌다(항상 열려있는 걸 모달이라 우기지 않는다)', async () => {
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    mqMatches = false;
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><ReadingOpenProbe open={false} /></ChatsLayout>));
+    });
+    const rail = container.querySelector('[data-testid="chat-rail"]');
+    expect(rail?.getAttribute('role')).toBeNull();
+    expect(rail?.getAttribute('aria-modal')).toBeNull();
   });
 
   it('Reading이 닫히면 수동 펼침 상태도 리셋된다(다음에 다시 열릴 때 자동접힘부터 재시작)', async () => {

--- a/apps/web/src/app/(authenticated)/chats/layout.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.tsx
@@ -3,11 +3,12 @@
 import { useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Plus } from 'lucide-react';
+import { Plus, PanelLeftOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ChatListView } from '@/components/chat/chat-list-view';
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
 import { EmptyState } from '@/components/ui/empty-state';
+import { ChatRailProvider, useChatRail } from './chat-rail-context';
 
 /**
  * story #2921 S1(P0-C, 챗 리디자인 시안 §S1) — D04 「Chat 분리=맥락 두동강」 처방 골격.
@@ -23,10 +24,19 @@ import { EmptyState } from '@/components/ui/empty-state';
  * 지점 하나로 그 위험 자체를 구조적으로 없앤다.
  */
 export default function ChatsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <ChatRailProvider>
+      <ChatsLayoutBody>{children}</ChatsLayoutBody>
+    </ChatRailProvider>
+  );
+}
+
+function ChatsLayoutBody({ children }: { children: React.ReactNode }) {
   const t = useTranslations('chats');
   const pathname = usePathname();
   const { currentTeamMemberId, projectId } = useDashboardContext();
   const [showModal, setShowModal] = useState(false);
+  const { railMode, toggleManualExpand } = useChatRail();
 
   // `/chats` 정확히 그 경로일 때만 "리스트가 곧 전체화면"인 모바일 상태 — `/chats/[id]`류는
   // 전부 대화 쪽이 전체화면이다(이미 열람 중인 대화 화면에 리스트를 노출하지 않는다, 기존
@@ -41,13 +51,35 @@ export default function ChatsLayout({ children }: { children: React.ReactNode })
     );
   }
 
+  // story #2921 S6(유나 확定) — railMode==='collapsed'일 때만 lg:hidden을 얹어 xl 미만~lg
+  // 구간에서 숨긴다. xl:flex를 항상 정적으로 얹어 두어 xl↑에서는 railMode 계산이 어떻든 항상
+  // 보인다(①rail은 절대 안 접힘의 이중 안전장치 — Tailwind가 브레이크포인트를 sm→2xl 오름차순
+  // 소스 순서로 컴파일하므로 xl:flex가 lg:hidden을 폭 ≥1280에서 CSS 캐스케이드로 자연히 이긴다).
+  // railMode==='overlay'는 고정 오버레이로 뜬다 — main/reading 폭을 다시 누르지 않는다(③④).
+  const railHiddenClass = railMode === 'collapsed' ? 'lg:hidden' : '';
+  const railOverlayClass = railMode === 'overlay'
+    ? 'fixed inset-y-0 left-0 z-40 w-[270px] shadow-xl lg:!flex xl:static xl:z-auto xl:w-[270px] xl:shadow-none'
+    : '';
+
   return (
     <div className="flex min-h-0 flex-1 overflow-hidden">
+      {/* story #2921 S6 — collapsed 상태에서 backdrop 클릭으로 오버레이를 다시 접는다(overlay일
+          때만 존재, 데스크톱 전용이라 모바일 기존 동작과 안 겹침). */}
+      {railMode === 'overlay' && (
+        <button
+          type="button"
+          aria-label={t('collapseRail')}
+          onClick={toggleManualExpand}
+          className="fixed inset-0 z-30 hidden bg-black/20 lg:block xl:hidden"
+        />
+      )}
+
       {/* 리스트 레일 — 모바일은 `/chats`일 때만 전체화면(현행 유지), 데스크톱(lg↑)은 항상
-          270px 고정 폭으로 보인다(§S1 확定 수치). */}
+          270px 고정 폭으로 보인다(§S1 확定 수치). §S6: xl 미만에서 reading이 열리면 자동
+          숨김(collapsed)·토글로 오버레이(overlay) 재호출 가능. */}
       <div
         data-testid="chat-rail"
-        className={`${isListRoute ? 'flex' : 'hidden'} lg:flex min-h-0 w-full flex-col overflow-hidden border-border lg:w-[270px] lg:shrink-0 lg:border-r`}
+        className={`${isListRoute ? 'flex' : 'hidden'} lg:flex min-h-0 w-full flex-col overflow-hidden border-border lg:w-[270px] lg:shrink-0 lg:border-r ${railHiddenClass} xl:flex ${railOverlayClass}`}
       >
         <div className="flex flex-shrink-0 items-center justify-between border-b border-border px-3 py-2.5">
           <h1 className="text-sm font-medium text-foreground">{t('title')}</h1>
@@ -65,6 +97,19 @@ export default function ChatsLayout({ children }: { children: React.ReactNode })
           />
         </div>
       </div>
+
+      {/* story #2921 S6 — railMode==='collapsed'일 때만 보이는 재호출 토글(lg~xl 사이에서만,
+          평소·overlay·모바일에는 안 뜬다). */}
+      {railMode === 'collapsed' && (
+        <button
+          type="button"
+          aria-label={t('expandRail')}
+          onClick={toggleManualExpand}
+          className="fixed left-0 top-1/2 z-30 hidden -translate-y-1/2 rounded-r-md border border-l-0 border-border bg-card p-1.5 text-muted-foreground shadow-sm transition hover:text-foreground lg:block xl:hidden"
+        >
+          <PanelLeftOpen className="h-4 w-4" />
+        </button>
+      )}
 
       {/* 대화 outlet — 모바일은 리스트가 아닌 라우트(`/chats/[id]`)일 때만 전체화면, 데스크톱은
           항상 리스트 옆에 병렬로 보인다. */}

--- a/apps/web/src/app/(authenticated)/chats/layout.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Plus, PanelLeftOpen } from 'lucide-react';
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { ChatListView } from '@/components/chat/chat-list-view';
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
 import { EmptyState } from '@/components/ui/empty-state';
+import { useFocusTrap } from '@/hooks/use-focus-trap';
 import { ChatRailProvider, useChatRail } from './chat-rail-context';
 
 /**
@@ -37,6 +38,12 @@ function ChatsLayoutBody({ children }: { children: React.ReactNode }) {
   const { currentTeamMemberId, projectId } = useDashboardContext();
   const [showModal, setShowModal] = useState(false);
   const { railMode, toggleManualExpand } = useChatRail();
+  // story #2921 S6 후속(유나 design:changes 2026-08-22, CI a11y 가드 지적 처방) — overlay는
+  // 모바일 드로어와 동형인데 접근 가능한 dialog 시맨틱이 없었다(「손수 구현된 모달」로 CI가
+  // 정당하게 잡음). contextual-panel-layout.tsx의 기존 반응형 드로어와 같은 useFocusTrap
+  // 배선을 재사용한다(사본 분화 금지) — Tab 순환+Esc 닫힘+포커스 반환.
+  const closeOverlay = useCallback(() => toggleManualExpand(), [toggleManualExpand]);
+  const trapRef = useFocusTrap(railMode === 'overlay', closeOverlay);
 
   // `/chats` 정확히 그 경로일 때만 "리스트가 곧 전체화면"인 모바일 상태 — `/chats/[id]`류는
   // 전부 대화 쪽이 전체화면이다(이미 열람 중인 대화 화면에 리스트를 노출하지 않는다, 기존
@@ -64,11 +71,13 @@ function ChatsLayoutBody({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-0 flex-1 overflow-hidden">
       {/* story #2921 S6 — collapsed 상태에서 backdrop 클릭으로 오버레이를 다시 접는다(overlay일
-          때만 존재, 데스크톱 전용이라 모바일 기존 동작과 안 겹침). */}
+          때만 존재, 데스크톱 전용이라 모바일 기존 동작과 안 겹침). 장식용 click-catcher일 뿐
+          실제 콘텐츠(rail 자신)가 role="dialog"를 지므로 접근성 트리에서 뺀다(aria-hidden). */}
       {railMode === 'overlay' && (
         <button
           type="button"
-          aria-label={t('collapseRail')}
+          aria-hidden="true"
+          tabIndex={-1}
           onClick={toggleManualExpand}
           className="fixed inset-0 z-30 hidden bg-black/20 lg:block xl:hidden"
         />
@@ -76,13 +85,19 @@ function ChatsLayoutBody({ children }: { children: React.ReactNode }) {
 
       {/* 리스트 레일 — 모바일은 `/chats`일 때만 전체화면(현행 유지), 데스크톱(lg↑)은 항상
           270px 고정 폭으로 보인다(§S1 확定 수치). §S6: xl 미만에서 reading이 열리면 자동
-          숨김(collapsed)·토글로 오버레이(overlay) 재호출 가능. */}
+          숨김(collapsed)·토글로 오버레이(overlay) 재호출 가능 — overlay일 때만 dialog
+          시맨틱(role/aria-modal/aria-labelledby)을 얹는다(평소엔 모달이 아니라 부여 안 함). */}
       <div
+        ref={trapRef}
         data-testid="chat-rail"
-        className={`${isListRoute ? 'flex' : 'hidden'} lg:flex min-h-0 w-full flex-col overflow-hidden border-border lg:w-[270px] lg:shrink-0 lg:border-r ${railHiddenClass} xl:flex ${railOverlayClass}`}
+        tabIndex={-1}
+        role={railMode === 'overlay' ? 'dialog' : undefined}
+        aria-modal={railMode === 'overlay' ? true : undefined}
+        aria-labelledby={railMode === 'overlay' ? 'chat-rail-heading' : undefined}
+        className={`${isListRoute ? 'flex' : 'hidden'} lg:flex min-h-0 w-full flex-col overflow-hidden border-border outline-none lg:w-[270px] lg:shrink-0 lg:border-r ${railHiddenClass} xl:flex ${railOverlayClass}`}
       >
         <div className="flex flex-shrink-0 items-center justify-between border-b border-border px-3 py-2.5">
-          <h1 className="text-sm font-medium text-foreground">{t('title')}</h1>
+          <h1 id="chat-rail-heading" className="text-sm font-medium text-foreground">{t('title')}</h1>
           <Button size="sm" variant="outline" onClick={() => setShowModal(true)}>
             <Plus className="mr-1.5 h-3.5 w-3.5" />
             {t('newConversation')}

--- a/apps/web/src/app/(authenticated)/chats/layout.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.tsx
@@ -113,18 +113,24 @@ function ChatsLayoutBody({ children }: { children: React.ReactNode }) {
         </div>
       </div>
 
-      {/* story #2921 S6 — railMode==='collapsed'일 때만 보이는 재호출 토글(lg~xl 사이에서만,
-          평소·overlay·모바일에는 안 뜬다). */}
-      {railMode === 'collapsed' && (
-        <button
-          type="button"
-          aria-label={t('expandRail')}
-          onClick={toggleManualExpand}
-          className="fixed left-0 top-1/2 z-30 hidden -translate-y-1/2 rounded-r-md border border-l-0 border-border bg-card p-1.5 text-muted-foreground shadow-sm transition hover:text-foreground lg:block xl:hidden"
-        >
-          <PanelLeftOpen className="h-4 w-4" />
-        </button>
-      )}
+      {/* story #2921 S6 후속(카디르 #3337 QA, 2026-08-22 라이브 키보드 재현 HIGH 발견) —
+          railMode==='collapsed'일 때만 보이는 재호출 토글. 예전엔 이 버튼을 조건부로
+          마운트/언마운트했는데(`{railMode==='collapsed' && (...)}`), overlay가 Esc로 닫힐 때
+          useFocusTrap의 "이전 포커스 노드로 복귀" 전제(그 DOM 노드가 안정적으로 존재)가
+          깨졌다 — 트리거가 이미 언마운트된 상태라 focus()가 조용히 no-op되고 포커스가
+          숨겨진 rail 안 「새 대화」 버튼으로 새 나갔다. 처방: 항상 마운트하고 CSS로만
+          숨긴다(`!hidden`, display:none — 네이티브 hidden 속성이 아니라 Tailwind 클래스로
+          강제해야 lg:block과의 특이도 경쟁에서 확実히 이긴다). display:none 요소는 자동으로
+          tab 순서·접근성 트리에서 빠지므로 inert 속성 없이도 동일 효과 — DOM 노드 자체가
+          안 사라지는 것만으로 useFocusTrap의 ref가 계속 유효해진다. */}
+      <button
+        type="button"
+        aria-label={t('expandRail')}
+        onClick={toggleManualExpand}
+        className={`fixed left-0 top-1/2 z-30 hidden -translate-y-1/2 rounded-r-md border border-l-0 border-border bg-card p-1.5 text-muted-foreground shadow-sm transition hover:text-foreground lg:block xl:hidden ${railMode !== 'collapsed' ? '!hidden' : ''}`}
+      >
+        <PanelLeftOpen className="h-4 w-4" />
+      </button>
 
       {/* 대화 outlet — 모바일은 리스트가 아닌 라우트(`/chats/[id]`)일 때만 전체화면, 데스크톱은
           항상 리스트 옆에 병렬로 보인다. */}

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -27,6 +27,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { fetchWithAuth } from '@/lib/db/client';
+import { useChatRail } from '@/app/(authenticated)/chats/chat-rail-context';
 
 interface ChatViewProps {
   threadId: string;
@@ -140,6 +141,15 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   // 무의미해진다(exhaustive-deps도 "readingPanel 전체"를 요구해 그 무의미함을 강제) — 여기서
   // 바로 구조분해해 안정 참조(각 함수는 훅 내부 useCallback([])로 고정)만 아래에서 쓴다.
   const { stack: readingPanelStack, isOpenRef: activeReadingPanelRef, open: openReadingPanelStack, close: closeReadingPanelStack, navigateTo: navigateReadingPanelTo } = useReadingPanelStack();
+
+  // story #2921 S6 — layout.tsx의 리스트 레일에 "지금 ReadingPanel이 열려 있는지"를 끌어올린다
+  // (xl 미만에서 rail 자동 접힘 판단에 필요, 이 컴포넌트만 아는 상태라 layout.tsx가 직접 볼 수
+  // 없다). Thread는 이 신호 대상이 아니다(chat-rail-context.tsx 주석 — w-80이 480보다 훨씬
+  // 좁아 같은 폭에서 눌림이 덜하고 유나 확定 문구가 "Reading 열림"만 명시).
+  const { railMode, setReadingOpen } = useChatRail();
+  useEffect(() => {
+    setReadingOpen(readingPanelStack.length > 0);
+  }, [readingPanelStack.length, setReadingOpen]);
 
   // 스레드 열기: 현재 URL 유지한 채 history entry 추가
   const openThread = useCallback((message: ChatMessage) => {
@@ -993,7 +1003,10 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
           // exit(닫기) 애니는 의도적 무(PO 판정 — 즉시 사라짐=반응성 피드백).
           <div
             className={`motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-right duration-150 flex flex-col overflow-hidden ${isMobileReadingView ? 'flex-1' : 'hidden lg:flex'}`}
-            style={isMobileReadingView ? undefined : { width: 'clamp(480px, 40vw, 720px)', flexShrink: 0 }}
+            // story #2921 S6(유나 확定④) — rail이 접힌/오버레이 상태(xl 미만+reading 열림)에선
+            // clamp 대신 480px 고정(Pedro 산수: main 544 보장은 reading=480 전제). xl↑나
+            // reading 닫힘(=railMode 'normal')은 기존 clamp(480,40vw,720) 그대로.
+            style={isMobileReadingView ? undefined : { width: railMode === 'normal' ? 'clamp(480px, 40vw, 720px)' : '480px', flexShrink: 0 }}
           >
             <ReadingPanel stack={readingPanelStack} onNavigateTo={navigateReadingPanelTo} onClose={closeReadingPanel} />
           </div>


### PR DESCRIPTION
## 변경 사항
챗 리디자인 시안(P0-C·2921) §S6, 유나 확定(2026-08-22) 4규칙 그대로 구현.

**문제:** S1(list rail 270px, lg=1024↑ 상시)이 chat-view.tsx의 기존 우측슬롯(Thread w-80 XOR Reading clamp(480,40vw,720))과 같은 lg 임계값을 공유해, 좁은 데스크톱(1024~1279px)에서 Reading이 열리면 rail+main+reading이 동시에 눌려 main이 300px 밑으로 떨어졌습니다.

**처방:**
1. xl(1280↑) — 3-pane 항상 나란히. rail은 절대 안 접힘.
2. 1024~1279px, Reading 닫힘 — 현행 2-pane 그대로, 무변화.
3. 1024~1279px, Reading 열림 — rail 자동 접힘(main 544 보장), reading은 480 고정.
4. 접힌 rail은 좌측 엣지 토글로 다시 부를 수 있음 — 고정 오버레이(모바일 드로어 동형)로 뜬다.

Thread 패널은 이 규칙 대상 아님(reading보다 훨씬 좁아 눌림이 덜하고, 유나 확定 문구도 "Reading 열림"만 명시).

## 구현
- `chat-rail-context.tsx`(신규) — layout.tsx와 chat-view.tsx가 서로 다른 컴포넌트라 상태를 끌어올림(React Context + matchMedia). `railMode` = normal/collapsed/overlay 상태머신.
- `layout.tsx` — railMode 소비해 rail className 조건부(lg:hidden/xl:flex/fixed 오버레이) + 재호출 토글 + 오버레이 backdrop.
- `chat-view.tsx` — readingPanelStack 열림 여부를 context에 보고, railMode!=='normal'일 때 reading 폭을 480 고정으로 전환.
- ko/en.json — aria-label 문구 추가.

## 셀프 게이트
- tsc/lint 0
- vitest 전체 475 files / 3930 tests green(회귀 0, layout.test.tsx 신규 5건 포함)
- build EXIT 0

## 정직 보고 — 라이브 검증 미완
dev FE sellerking 계정 로그인이 422로 거부됨(Pedro 확認: 요청 형식 문제, 계정 자체는 살아있음). FE 폼 경유 재시도로 확認 예정이나 이 PR 시점엔 미완 — post-deploy 라이브 픽셀(1024/1279/1280 3개 폭 × Reading 열림/닫힘)로 별도 확認 필요.

## Test plan
- [x] tsc/lint/build/vitest 전체 그린
- [ ] dev 배포 후 1024/1279/1280px 3개 폭 × Reading 열림/닫힘 라이브 픽셀

🤖 Generated with [Claude Code](https://claude.com/claude-code)