### PR TITLE
[SID:2924] scrollbar 가드 라이트/다크 독립 대조(#3329 QA fast-follow)

### DIFF
--- a/apps/web/src/app/globals-scrollbar.test.ts
+++ b/apps/web/src/app/globals-scrollbar.test.ts
@@ -12,6 +12,24 @@ const css = fs.readFileSync(
   'utf8',
 );
 
+// story #2924 — 「css.toContain(x)」는 x가 :root/.dark 어느 블록에서 왔는지 구분 못 한다. 한
+// 테마만 리터럴로 되돌려도(다른 테마는 별칭 유지) 문자열이 어딘가엔 남아 통과해버린 것(카디르
+// #3329 QA 뮤테이션 실증). 블록 경계(중괄호 균형)로 잘라 테마별로 독립 대조한다.
+function extractTopLevelBlock(source: string, selectorLine: string): string {
+  const start = source.indexOf(selectorLine);
+  if (start === -1) throw new Error(`selector not found: ${selectorLine}`);
+  const braceStart = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = braceStart; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(braceStart, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces for selector: ${selectorLine}`);
+}
+
 describe('전역 스크롤바 숨김 CSS 불변식 (#2165)', () => {
   it('전역 * 규칙이 scrollbar-width:none + webkit scrollbar display:none 이다', () => {
     expect(css).toMatch(/\*\s*\{\s*scrollbar-width:\s*none;\s*\}/);
@@ -145,9 +163,19 @@ describe('스크롤바 썸/배경 대비 (#2601 — «스크롤바 미표시» �
     const css = fs.readFileSync(path.resolve(__dirname, 'globals.css'), 'utf8');
     // story #2917(2026-08-22) — --background가 var(--proof-bg)로 별칭됐다(값-SSOT 이전).
     // 리터럴 대신 별칭 참조 자체와 그 참조가 가리키는 proof-bg 리터럴 둘 다를 고정한다.
-    expect(css).toContain('--background: var(--proof-bg);');
-    expect(css).toContain('--proof-bg: #F4F2EC;');
-    expect(css).toContain('--proof-bg: #0B0C0D;');
+    //
+    // story #2924 후속(2026-08-22, 카디르 #3329 QA 발견) — 라이트/다크 둘 다 같은
+    // `var(--proof-bg)` 문자열로 합쳐지며 파일 전체 toContain만으론 "한 테마만 리터럴로
+    // 되돌아가도 다른 테마가 살아있으면 통과"하는 구분력 상실이 생겼다(뮤테이션 실증). :root/
+    // .dark 블록을 중괄호 경계로 잘라 각 테마의 --background 우변을 독립적으로 대조한다.
+    const rootBlock = extractTopLevelBlock(css, ':root {');
+    const darkBlock = extractTopLevelBlock(css, '.dark {');
+    expect(rootBlock).toContain('--background: var(--proof-bg);');
+    expect(darkBlock).toContain('--background: var(--proof-bg);');
+    // --proof-bg 리터럴도 같은 방식으로 테마별 독립 대조(라이트=Bone·다크=Carbon, 값 자체가
+    // 다르므로 이쪽은 문자열이 애초에 안 겹친다 — 대칭성을 위해 블록 스코프로 통일).
+    expect(rootBlock).toContain('--proof-bg: #F4F2EC;');
+    expect(darkBlock).toContain('--proof-bg: #0B0C0D;');
   });
 });
 


### PR DESCRIPTION
## 변경 사항
카디르 #3329 QA 발견(MEDIUM 비블로킹, codex 교차확認) 처방 — #3329의 회귀 가드 이중 고정이 라이트/다크 둘 다 같은 `var(--proof-bg)` 문자열로 합쳐지며, 구 가드가 갖던 "두 테마가 서로 다른 리터럴이라 생기던 구분력"을 잃었습니다. 파일 전체 `toContain`은 한 테마만 리터럴로 되돌아가도(다른 테마는 별칭 유지) 문자열이 어딘가엔 남아 통과해버립니다.

**처방:** `:root`/`.dark` 블록을 중괄호 경계(`extractTopLevelBlock`, 기존 `@layer base` 스캔과 동형 기법)로 분리해 각 테마의 `--background` 우변을 독립 대조합니다.

## 뮤테이션 실증
라이트 `--background`만 `oklch(1 0 0)` 리터럴로 되돌리고(다크는 별칭 유지) 재실행 — 기존 가드라면 PASS(구분력 상실), 이 처방으로는 정확히 FAIL로 잡힙니다(원상복구 후 24/24 재확認).

develop(#3329 머지 후, f7e8ceca8) 위에서 rebase 완료.

## 셀프 게이트
- vitest 24/24 green
- tsc/lint 0
- build EXIT 0
- 뮤테이션 실증(위)

## Test plan
- [x] 회귀 가드 24/24 green
- [x] 뮤테이션 실증 — 단일 테마 리터럴 회귀를 정확히 잡음

🤖 Generated with [Claude Code](https://claude.com/claude-code)