### PR TITLE
[SID:2921] S4 — 챗 버블·아바타 Proofline 재도장

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1664,31 +1664,36 @@ describe('ChatBubble — story #2921 S4(유나 확定, 버블·아바타 Proofli
     expect(container.querySelector('.rounded-tl-sm.bg-proof-blue-soft')).toBeNull();
   });
 
-  it('에이전트 아바타=circle+blue 링(ProofAvatar isAgent 재사용, 사본 분화 금지)', async () => {
+  // story #2921 S4 후속(2026-08-22, 유나 합성 5규칙 확定·avatar-unification-design-memo-2921) —
+  // ProofAvatar가 폐기되고 Avatar(components/shared/avatar.tsx)로 통합됐다 — 형태(circle/
+  // square)·idle blue 링·human 테두리는 이제 Avatar 내부가 결정한다. 아래 2건은 그 통합
+  // 결과를 잰다(옛 ProofAvatar 전용 클래스 대신 Avatar의 실 출력 클래스로 갱신).
+  it('에이전트 아바타=circle+idle blue 링(Avatar 통합, 사본 분화 금지)', async () => {
     await act(async () => {
       root.render(wrap(<ChatBubble message={{ ...plainMessage, references: [], sender_type: 'agent' }} isMine={false} />));
     });
-    const avatar = container.querySelector('.border-proof-blue.bg-proof-blue-soft');
+    const avatar = container.querySelector('.ring-proof-blue');
     expect(avatar).toBeTruthy();
     expect(avatar?.className).toContain('rounded-full');
     expect(avatar?.className).not.toContain('rounded-md');
   });
 
-  it('human 아바타=square+무채(본인·상대 공통) — 에이전트만 circle이다', async () => {
+  it('human 아바타=square+무채 테두리(본인·상대 공통) — 에이전트만 circle+링이다', async () => {
     await act(async () => {
       root.render(wrap(<ChatBubble message={{ ...plainMessage, references: [], sender_type: 'human' }} isMine={false} />));
     });
-    const avatar = container.querySelector('.border-proof-line.bg-proof-sunk');
+    const avatar = container.querySelector('.border-proof-line');
     expect(avatar).toBeTruthy();
     expect(avatar?.className).toContain('rounded-md');
     expect(avatar?.className).not.toContain('rounded-full');
+    expect(avatar?.className).not.toContain('ring-proof-blue');
 
     await act(async () => { root.unmount(); });
     root = createRoot(container);
     await act(async () => {
       root.render(wrap(<ChatBubble message={{ ...plainMessage, references: [], sender_type: 'human' }} isMine />));
     });
-    const mineAvatar = container.querySelector('.border-proof-line.bg-proof-sunk');
+    const mineAvatar = container.querySelector('.border-proof-line');
     expect(mineAvatar).toBeTruthy();
     expect(mineAvatar?.className).toContain('rounded-md');
   });

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1637,3 +1637,59 @@ describe('ChatBubble — story #2905 S2c③④ 다중 sole-link 문단(그룹핑
     expect(container.querySelectorAll('.rounded-md')).toHaveLength(3);
   });
 });
+
+describe('ChatBubble — story #2921 S4(유나 확定, 버블·아바타 Proofline 재도장)', () => {
+  const plainMessage: ChatMessage = {
+    ...baseMessage,
+    content: '안녕한 일반 텍스트 메시지인 — 참조 없음',
+  };
+
+  it('버블=무채 panel(내 메시지=blue-soft) — isMine이면 bg-proof-blue-soft, 아니면 bg-proof-panel', async () => {
+    // ⛔bg-proof-blue-soft는 에이전트 아바타(ProofAvatar isAgent)에도 붙어 셀렉터가 겹친다 —
+    // 버블 고유 모서리 클래스(rounded-tr-sm/rounded-tl-sm)와 함께 잡아 버블 자신만 특정한다.
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...plainMessage, references: [], sender_type: 'human' }} isMine />));
+    });
+    expect(container.querySelector('.rounded-tr-sm.bg-proof-blue-soft')).toBeTruthy();
+    expect(container.querySelector('.rounded-tr-sm.bg-proof-panel')).toBeNull();
+    // 옛 solid 배경+흰 글자 조합이 안 남아있다(눈에 안 보이는 흰 글자 회귀 방지).
+    expect(container.querySelector('.bg-primary.text-primary-foreground')).toBeNull();
+
+    await act(async () => { root.unmount(); });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...plainMessage, references: [], sender_type: 'human' }} isMine={false} />));
+    });
+    expect(container.querySelector('.rounded-tl-sm.bg-proof-panel')).toBeTruthy();
+    expect(container.querySelector('.rounded-tl-sm.bg-proof-blue-soft')).toBeNull();
+  });
+
+  it('에이전트 아바타=circle+blue 링(ProofAvatar isAgent 재사용, 사본 분화 금지)', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...plainMessage, references: [], sender_type: 'agent' }} isMine={false} />));
+    });
+    const avatar = container.querySelector('.border-proof-blue.bg-proof-blue-soft');
+    expect(avatar).toBeTruthy();
+    expect(avatar?.className).toContain('rounded-full');
+    expect(avatar?.className).not.toContain('rounded-md');
+  });
+
+  it('human 아바타=square+무채(본인·상대 공통) — 에이전트만 circle이다', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...plainMessage, references: [], sender_type: 'human' }} isMine={false} />));
+    });
+    const avatar = container.querySelector('.border-proof-line.bg-proof-sunk');
+    expect(avatar).toBeTruthy();
+    expect(avatar?.className).toContain('rounded-md');
+    expect(avatar?.className).not.toContain('rounded-full');
+
+    await act(async () => { root.unmount(); });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...plainMessage, references: [], sender_type: 'human' }} isMine />));
+    });
+    const mineAvatar = container.querySelector('.border-proof-line.bg-proof-sunk');
+    expect(mineAvatar).toBeTruthy();
+    expect(mineAvatar?.className).toContain('rounded-md');
+  });
+});

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -174,10 +174,14 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenRe
    * 사본 분화 금지 재사용)로 뜰 때 그 컴포넌트가 요구하는 카탈로그를 그대로 물려준다. */
   eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
 }) {
-  const text = isMine ? 'text-primary-foreground' : 'text-foreground';
-  const muted = isMine ? 'text-primary-foreground/70' : 'text-muted-foreground';
-  const codeBg = isMine ? 'bg-primary-foreground/10 text-primary-foreground' : 'bg-muted text-foreground';
-  const border = isMine ? 'border-primary-foreground/30' : 'border-border';
+  // story #2921 S4(유나 확定) — 「내 메시지=blue-soft」로 바뀌며 isMine 버블도 밝은 배경이
+  // 됐다(옛 solid bg-primary 위 흰 글자 전제가 깨졌다). 이제 양쪽 다 밝은 무채/blue-soft
+  // 패널 위 어두운 ink라 isMine으로 갈릴 이유가 없다 — Proof Capsule(proof-capsule.tsx)도
+  // 발화자와 무관하게 항상 proof-ink/proof-ink-2를 쓰는 것과 같은 이치.
+  const text = 'text-foreground';
+  const muted = 'text-muted-foreground';
+  const codeBg = 'bg-muted text-foreground';
+  const border = 'border-border';
 
   const hasMention = /@[\w가-힣]+/.test(content);
   const hasMarkdown = /[*_`#\[\]>~]|entity:/.test(content);
@@ -263,8 +267,11 @@ function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenRe
     blockquote: ({ children }: { children?: React.ReactNode }) => <blockquote className={`mb-1.5 border-l-2 pl-3 ${border} ${muted}`}>{children}</blockquote>,
     a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
       if (href?.startsWith('mention:')) {
+        // story #2921 S4 — 옛 isMine 분기(흰 글자 vs text-primary)는 solid bg-primary 버블
+        // 전제였다. blue-soft로 바뀐 지금은 발화자 무관하게 같은 밝은 배경이라 갈릴 이유가
+        // 없다(위 text/muted/codeBg/border와 동일 논리).
         return (
-          <span className={`font-medium ${isMine ? 'text-primary-foreground underline decoration-primary-foreground/40' : 'text-primary'}`}>
+          <span className="font-medium text-primary underline decoration-primary/40">
             {children}
           </span>
         );
@@ -491,8 +498,9 @@ export function ChatBubble({
             className={`flex-shrink-0 ${isMine ? '' : 'cursor-pointer'}`}
           >
             {/* story #2349 — "상대 프로필" 진입점. 자기 자신 아바타는 클릭 불가(role/tabIndex도 안 붙임).
-                story #2901 — Avatar 프리미티브(이미지→이니셜→Bot/User 아이콘 3단 폴백, onError 하드닝
-                포함)로 교체. presence dot·working ring·AI 배지는 컴포넌트 내부가 이미 처리한다. */}
+                story #2901(3335)+#2921 S4(3339) 합성(유나 확定 5규칙, avatar-unification-design-memo-2921) —
+                Avatar가 정본(사본 분화 금지) — shape(에이전트=circle·human=square)·idle blue 링·
+                working citron 펄스·human 테두리는 전부 avatar.tsx 내부가 결정한다. */}
             <Avatar
               name={displayName}
               avatarUrl={message.sender_avatar_url ?? null}
@@ -585,10 +593,14 @@ export function ChatBubble({
               </code>
             </div>
           ) : (
-            <div className={`min-w-0 max-w-full rounded-xl px-3.5 py-2 text-sm leading-relaxed [overflow-wrap:anywhere] ${
+            /* story #2921 S4(유나 확定) — 버블=무채 panel(내 메시지=blue-soft). 옛
+               bg-primary(solid 채색)+text-primary-foreground(흰 글자)를 proof-blue-soft
+               (밝은 틴트)+text-foreground(어두운 ink)로 — Proof Capsule과 같은 어휘(옅은
+               배경 위 ink, 색은 아이콘/배지가 진다는 #2420 규율과 동형). */
+            <div className={`min-w-0 max-w-full rounded-xl px-3.5 py-2 text-sm leading-relaxed text-foreground [overflow-wrap:anywhere] ${
               isMine
-                ? 'rounded-tr-sm bg-primary text-primary-foreground'
-                : 'rounded-tl-sm bg-muted text-foreground'
+                ? 'rounded-tr-sm bg-proof-blue-soft'
+                : 'rounded-tl-sm bg-proof-panel'
             }`}>
               <ChatMarkdown content={displayContent} isMine={isMine} references={message.references} entityStatusByKey={entityStatusByKey} onOpenReadingPanel={onOpenReadingPanel} eventDefinitionsByKey={eventDefinitionsByKey} />
             </div>

--- a/apps/web/src/components/chat/presence-dot.tsx
+++ b/apps/web/src/components/chat/presence-dot.tsx
@@ -24,10 +24,17 @@ const STATUS_LABEL_KEY: Record<PresenceStatus, string> = {
 };
 
 /**
- * 활동 축 — working 시 avatar 래퍼에 덧대는 ring(info pulse — L5 시스템 활동, story #2023
- * ⓑ). dot과 별개(축 합침 금지). prefers-reduced-motion 시 정적 ring(모션 0).
+ * 활동 축 — working 시 avatar 래퍼에 덧대는 ring. dot과 별개(축 합침 금지).
+ * prefers-reduced-motion 시 정적 ring(모션 0).
+ *
+ * story #2921(유나 합성 5규칙③, avatar-unification-design-memo-2921, 2026-08-22 확定) —
+ * 개명+색 스왑. 옛 이름(WORKING_RING_CLASS)·값(ring-info, --info가 proof-blue로 별칭돼
+ * 사실상 이미 blue였다)이 규칙③(idle=blue 정적·working=citron 펄스)과 정반대였다 — idle
+ * 에이전트 링(avatar.tsx)이 blue로 바뀌며 「working만 다른 색」이라는 이 상수의 존재 이유가
+ * citron으로 넘어갔다. 소비처는 avatar.tsx 1곳뿐(챗 아바타 옛 hand-rolled 마크업은 #3335가
+ * Avatar로 흡수하며 이미 소거됨).
  */
-export const WORKING_RING_CLASS = 'ring-2 ring-info ring-offset-1 ring-offset-card motion-safe:animate-pulse';
+export const AGENT_LIVE_RING_CLASS = 'ring-2 ring-proof-citron ring-offset-1 ring-offset-card motion-safe:animate-pulse';
 
 // 2505d27d: 패널은 큰 영역이라 prominent하게(size-3·12px) — 채팅 dot(size-2.5·10px)보다 가시성↑(모바일 교훈).
 const SIZE_CLASS = { sm: 'size-2.5', md: 'size-3' } as const;

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -4,7 +4,7 @@ import { startTransition, useEffect, useRef, useState, type ReactNode } from 're
 import { useTranslations } from 'next-intl';
 import { ArrowRight, Check, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { initials } from '@/lib/storage/format';
+import { Avatar } from '@/components/shared/avatar';
 import { Proofline, type ProofState } from './proofline';
 import { TrustSeal, type TrustSealClaimedProps, type TrustSealVerifiedProps } from '@/components/verify/trust-seal';
 
@@ -134,30 +134,6 @@ function StateHeader({ state, label }: { state: ProofState; label: string }) {
   );
 }
 
-/** Workcell 등 다른 Proof Capsule 계열 컴포넌트가 동일 아바타 스타일을 재사용할 수 있게 export.
- * story #2921 S4 — shape 추가(기본 circle, 기존 호출부 전부 무변화). chat-redesign-2921 §4축
- * 「에이전트=blue 링 아바타·human=무채 사각」이 square 변형을 요구해 추가했다(circle=에이전트,
- * square=human). children이 있으면 label 텍스트 대신 렌더(아이콘 아바타 지원 — 챗은 이름이
- * 없을 수 있는 표시라 이니셜만으론 부족, Bot/User 아이콘을 그대로 쓴다). */
-export function ProofAvatar({
-  label, isAgent, size = 19, shape = 'circle', children,
-}: { label: string; isAgent?: boolean; size?: number; shape?: 'circle' | 'square'; children?: ReactNode }) {
-  return (
-    <span
-      className={cn(
-        'inline-flex shrink-0 items-center justify-center border text-[9px] font-semibold',
-        shape === 'circle' ? 'rounded-full' : 'rounded-md',
-        isAgent
-          ? 'border-proof-blue bg-proof-blue-soft text-proof-blue'
-          : 'border-proof-line bg-proof-sunk text-proof-ink-2',
-      )}
-      style={{ width: size, height: size }}
-    >
-      {children ?? label}
-    </span>
-  );
-}
-
 /** canonical(비-i18n) risk 식별자 → `proofCapsule.risk.*` 번역키. */
 const RISK_KEY: Record<NonNullable<ProofCapsuleGate['risk']>, 'low' | 'medium' | 'high'> = {
   '낮음': 'low', '보통': 'medium', '높음': 'high',
@@ -262,13 +238,13 @@ function FullVariant({
         <div className="mt-2.5 flex flex-wrap items-center gap-3 text-[11px] text-proof-ink-3">
           {human ? (
             <span className="inline-flex items-center gap-1.5">
-              <ProofAvatar label={initials(human.name)} />
+              <Avatar name={human.name} actorType="human" size={19} />
               {t.rich('gate.owner', { name: human.name, b: (chunks) => <>{chunks}</> })}
             </span>
           ) : null}
           {agent ? (
             <span className="inline-flex items-center gap-1.5">
-              <ProofAvatar label={agent.initial} isAgent />
+              <Avatar name={agent.name} actorType="agent" size={19} />
               {t('claim.executor', { name: agent.name })}
             </span>
           ) : null}
@@ -334,8 +310,8 @@ function InlineRow({
         <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-proof-ink">{claim}</span>
         <span className="inline-flex shrink-0 items-center gap-2">
           {duration ? <span className="shrink-0 text-[10.5px] font-medium text-proof-ink-3">{duration}</span> : null}
-          {human ? <ProofAvatar label={initials(human.name)} size={22} /> : null}
-          {agent ? <ProofAvatar label={agent.initial} isAgent size={22} /> : null}
+          {human ? <Avatar name={human.name} actorType="human" size={22} /> : null}
+          {agent ? <Avatar name={agent.name} actorType="agent" size={22} /> : null}
           {gate ? (
             <a
               href={gate.href}

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -134,19 +134,26 @@ function StateHeader({ state, label }: { state: ProofState; label: string }) {
   );
 }
 
-/** Workcell 등 다른 Proof Capsule 계열 컴포넌트가 동일 아바타 스타일을 재사용할 수 있게 export. */
-export function ProofAvatar({ label, isAgent, size = 19 }: { label: string; isAgent?: boolean; size?: number }) {
+/** Workcell 등 다른 Proof Capsule 계열 컴포넌트가 동일 아바타 스타일을 재사용할 수 있게 export.
+ * story #2921 S4 — shape 추가(기본 circle, 기존 호출부 전부 무변화). chat-redesign-2921 §4축
+ * 「에이전트=blue 링 아바타·human=무채 사각」이 square 변형을 요구해 추가했다(circle=에이전트,
+ * square=human). children이 있으면 label 텍스트 대신 렌더(아이콘 아바타 지원 — 챗은 이름이
+ * 없을 수 있는 표시라 이니셜만으론 부족, Bot/User 아이콘을 그대로 쓴다). */
+export function ProofAvatar({
+  label, isAgent, size = 19, shape = 'circle', children,
+}: { label: string; isAgent?: boolean; size?: number; shape?: 'circle' | 'square'; children?: ReactNode }) {
   return (
     <span
       className={cn(
-        'inline-flex shrink-0 items-center justify-center rounded-full border text-[9px] font-semibold',
+        'inline-flex shrink-0 items-center justify-center border text-[9px] font-semibold',
+        shape === 'circle' ? 'rounded-full' : 'rounded-md',
         isAgent
           ? 'border-proof-blue bg-proof-blue-soft text-proof-blue'
           : 'border-proof-line bg-proof-sunk text-proof-ink-2',
       )}
       style={{ width: size, height: size }}
     >
-      {label}
+      {children ?? label}
     </span>
   );
 }

--- a/apps/web/src/components/shared/avatar.test.tsx
+++ b/apps/web/src/components/shared/avatar.test.tsx
@@ -66,18 +66,51 @@ describe('Avatar — story #2887 S2g', () => {
     expect(container.querySelector('[role="img"]')).not.toBeNull(); // PresenceDot
   });
 
-  it('working=true면 pulsing WORKING_RING 클래스, false면 정적 accent-claim 링', async () => {
+  // story #2921(유나 합성 5규칙③, avatar-unification-design-memo-2921, 2026-08-22 확定) —
+  // 옛 값(idle=citron 정적·working=info(=proof-blue 별칭) 펄스)이 규칙③과 정반대였다(3339
+  // 그라운딩에서 실측 발견) — swap: idle=blue 정적·working=citron 펄스가 정본.
+  it('working=true면 citron 펄스(AGENT_LIVE_RING_CLASS), false면 정적 proof-blue 링', async () => {
     await act(async () => {
       root.render(wrap(<Avatar name="유나" avatarUrl={null} actorType="agent" isWorking />));
     });
-    const ringEl = container.querySelector('.ring-info');
-    expect(ringEl).not.toBeNull();
+    expect(container.querySelector('.ring-proof-citron')).not.toBeNull();
+    expect(container.querySelector('.ring-proof-blue')).toBeNull();
 
     await act(async () => {
       root.render(wrap(<Avatar name="유나" avatarUrl={null} actorType="agent" isWorking={false} />));
     });
-    expect(container.querySelector('.ring-accent-claim')).not.toBeNull();
-    expect(container.querySelector('.ring-info')).toBeNull();
+    expect(container.querySelector('.ring-proof-blue')).not.toBeNull();
+    expect(container.querySelector('.ring-proof-citron')).toBeNull();
+  });
+
+  // story #2921(유나 합성 5규칙②) — 형태는 actorType에서 자동 유도(호출부가 shape를 안 넘김).
+  // 이미지가 있어도 같은 클립(overflow-hidden 래퍼의 반경)을 받는다.
+  it('에이전트=circle(rounded-full)·human=square(rounded-md)+무채 테두리(색과 별개의 redundant 경계 신호)', async () => {
+    await act(async () => {
+      root.render(wrap(<Avatar name="유나" avatarUrl={null} actorType="agent" />));
+    });
+    const agentWrapper = container.querySelector('.rounded-full');
+    expect(agentWrapper).toBeTruthy();
+    expect(container.querySelector('.rounded-md')).toBeNull();
+    expect(container.querySelector('.border-proof-line')).toBeNull(); // 에이전트는 링이 그 역할.
+
+    await act(async () => {
+      root.render(wrap(<Avatar name="송윤재" avatarUrl={null} actorType="human" />));
+    });
+    const humanWrapper = container.querySelector('.rounded-md');
+    expect(humanWrapper).toBeTruthy();
+    expect(humanWrapper?.className).toContain('border-proof-line');
+    expect(container.querySelector('.rounded-full')).toBeNull();
+  });
+
+  it('human도 이미지가 있으면 square로 클립된다(이미지 tier도 형태 예외 없음)', async () => {
+    await act(async () => {
+      root.render(wrap(<Avatar name="송윤재" avatarUrl="https://example.com/a.png" actorType="human" />));
+    });
+    expect(container.querySelector('img')).toBeTruthy();
+    const wrapper = container.querySelector('.rounded-md');
+    expect(wrapper).toBeTruthy();
+    expect(wrapper?.querySelector('img')).toBeTruthy();
   });
 
   it('presenceStatus 없으면(휴먼 기본) dot 미표시 — 에이전트라도 null이면 미표시', async () => {

--- a/apps/web/src/components/shared/avatar.tsx
+++ b/apps/web/src/components/shared/avatar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Bot, User } from 'lucide-react';
-import { PresenceDot, WORKING_RING_CLASS, type PresenceStatus } from '@/components/chat/presence-dot';
+import { PresenceDot, AGENT_LIVE_RING_CLASS, type PresenceStatus } from '@/components/chat/presence-dot';
 import { avatarColor, initials } from '@/lib/storage/format';
 import { cn } from '@/lib/utils';
 
@@ -14,8 +14,8 @@ export interface AvatarProps {
   size?: number;
   /** agent 전용 — 연결 축 dot. 휴먼은 항상 미표시. */
   presenceStatus?: PresenceStatus | null;
-  /** agent 전용 — 활동 축(WORKING_RING_CLASS, pulsing). 미작동 시 정적 accent-claim 링(항상
-   * "에이전트임" 식별 — 이미지가 있어도 유지, S2g 목업 규칙). */
+  /** agent 전용 — 활동 축(AGENT_LIVE_RING_CLASS, citron pulse). 미작동 시 정적 proof-blue 링
+   * (항상 "에이전트임" 식별 — 이미지가 있어도 유지, S2g 목업 규칙+#2921 규칙③ 색 스왑). */
   isWorking?: boolean;
   className?: string;
 }
@@ -25,6 +25,16 @@ export interface AvatarProps {
  * Bot/User 아이콘) + 에이전트 식별(정적 링 + presence dot + BOT 배지, 이미지 있어도 유지 —
  * 휴먼과 안 헷갈리게). 목업 `s2g-avatar-mockup` 1:1. storage-uploader-avatar.tsx의 initials/
  * avatarColor 헬퍼를 그대로 재사용(이니셜 폴백 로직 중복 방지).
+ *
+ * story #2921(유나 합성 5규칙, avatar-unification-design-memo-2921, 2026-08-22 확定) — 3339
+ * (챗 Proofline)의 ProofAvatar를 여기로 흡수·폐기(사본 분화 금지, 규칙⑤ 단일 컴포넌트).
+ * 스코프=전 표면 단일 문법(규칙 확定 ⓐ) — 챗 전용 override 없음, 아래 소비처 전부(챗·조직
+ * 인력·아바타 편집·팀 프레즌스 패널) 동일 시각을 받는다:
+ * ②형태 — shape는 actorType에서 자동 유도(agent=circle·human=square, 이미지도 그 형태로
+ * clip — overflow-hidden 래퍼의 반경만 바꾸면 이미지 tier도 자동으로 따라온다). human은
+ * 색과 별개의 테두리(border-proof-line)로 redundant 경계 신호를 더한다.
+ * ③idle 에이전트=Proof Blue 정적 링(ring-proof-blue)·working=citron 펄스(AGENT_LIVE_RING_CLASS,
+ * presence-dot.tsx — 옛 WORKING_RING_CLASS 개명+색 스왑, 그 파일 주석 참고).
  */
 export function Avatar({
   name, avatarUrl, actorType, size = 32, presenceStatus, isWorking = false, className,
@@ -53,8 +63,9 @@ export function Avatar({
     <div className={cn('relative shrink-0', className)} style={{ width: size, height: size }}>
       <div
         className={cn(
-          'h-full w-full overflow-hidden rounded-full',
-          isAgent && (isWorking ? WORKING_RING_CLASS : 'ring-2 ring-accent-claim ring-offset-1 ring-offset-background'),
+          'h-full w-full overflow-hidden',
+          isAgent ? 'rounded-full' : 'rounded-md border border-proof-line',
+          isAgent && (isWorking ? AGENT_LIVE_RING_CLASS : 'ring-2 ring-proof-blue ring-offset-1 ring-offset-background'),
         )}
       >
         {showImage ? (

--- a/apps/web/src/components/shared/avatar.tsx
+++ b/apps/web/src/components/shared/avatar.tsx
@@ -77,7 +77,7 @@ export function Avatar({
           <img src={avatarUrl} alt={name} className="h-full w-full object-cover" onError={() => setImgError(true)} />
         ) : name.trim() ? (
           <span
-            className={cn('flex h-full w-full items-center justify-center font-semibold text-white', avatarColor(name))}
+            className={cn('flex h-full w-full items-center justify-center font-semibold', avatarColor(isAgent))}
             style={{ fontSize: initSize }}
             aria-label={name}
           >

--- a/apps/web/src/components/storage/storage-uploader-avatar.tsx
+++ b/apps/web/src/components/storage/storage-uploader-avatar.tsx
@@ -43,11 +43,15 @@ export function StorageUploaderAvatar({ createdBy, size = 22 }: StorageUploaderA
     );
   }
 
+  // story #2921 S4 후속(유나 design:changes) — avatarColor가 이제 actorType 기반 2값(agent=
+  // blue-soft·human=sunk)이라 AssetCreatedBy엔 없는 정보다. 이 표면은 자산 업로더 표기라
+  // 사람이 대다수(에이전트 업로드도 있으나 구분 신호가 응답에 없다, 지어내지 않음) — human
+  // 처리를 보수적 기본값으로 둔다.
   return (
     <span
       className={cn(
-        'inline-grid shrink-0 place-items-center rounded-full font-semibold text-white',
-        avatarColor(createdBy.id || createdBy.name),
+        'inline-grid shrink-0 place-items-center rounded-full font-semibold',
+        avatarColor(false),
       )}
       style={{ width: size, height: size, fontSize: Math.round(size * 0.4) }}
       aria-label={createdBy.name}

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
-import { ProofAvatar, ProofCapsule, type ProofCapsuleProps } from '@/components/proof-capsule/proof-capsule';
+import { ProofCapsule, type ProofCapsuleProps } from '@/components/proof-capsule/proof-capsule';
+import { Avatar } from '@/components/shared/avatar';
 
 export interface WorkcellOwner {
   name: string;
@@ -165,9 +166,9 @@ function BriefLayer({ brief }: { brief: WorkcellBrief }) {
       </div>
       <div className="mt-1.5 flex flex-wrap items-center gap-2 gap-y-1.5 text-[13px] leading-[1.5] text-proof-ink-2">
         <span className="w-16 shrink-0 pt-px text-[11px] text-proof-faint">{t('briefRoles')}</span>
-        <span className="inline-flex items-center gap-1.5"><ProofAvatar label={brief.owner.name.slice(0, 1)} size={18} />{t('briefOwner')} {brief.owner.name}</span>
+        <span className="inline-flex items-center gap-1.5"><Avatar name={brief.owner.name} actorType="human" size={18} />{t('briefOwner')} {brief.owner.name}</span>
         {brief.agent ? (
-          <span className="inline-flex items-center gap-1.5"><ProofAvatar label={brief.agent.initial} isAgent size={18} />{t('briefAgent')} {brief.agent.name}</span>
+          <span className="inline-flex items-center gap-1.5"><Avatar name={brief.agent.name} actorType="agent" size={18} />{t('briefAgent')} {brief.agent.name}</span>
         ) : null}
         {brief.scopes && brief.scopes.length > 0 ? (
           <span className="font-mono text-[10.5px] text-proof-ink-3">{brief.scopes.join(' · ')}</span>

--- a/apps/web/src/lib/storage/format.ts
+++ b/apps/web/src/lib/storage/format.ts
@@ -46,15 +46,17 @@ export function fileTypeTint(contentType: string): FileTint {
   return 'doc';
 }
 
-/** 결정론적 아바타 배경(고정 토큰 유틸 집합 — Tailwind safelist 안전). */
-const AVATAR_BG = ['bg-info', 'bg-success', 'bg-warning', 'bg-brand', 'bg-destructive'] as const;
-
-export function avatarColor(seed: string): string {
-  let hash = 0;
-  for (let i = 0; i < seed.length; i += 1) {
-    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
-  }
-  return AVATAR_BG[hash % AVATAR_BG.length] ?? AVATAR_BG[0];
+/**
+ * story #2921 S4 후속(유나 design:changes, 2026-08-22) — 이니셜 배경 무채 계승 처방. 옛
+ * AVATAR_BG는 이름 해시로 시맨틱 신호색(info/success/warning/brand/destructive) 5색 중
+ * 하나를 «무작위»로 골랐다 — 해시가 destructive를 뽑은 사람은 아바타가 «빨강=위반»으로
+ * 읽히는 의미 충돌이었고(90% 무채 원칙도 파괴), 옛 ProofAvatar(agent=blue-soft·human=sunk
+ * 무채 2값)에서의 회귀이기도 했다. 그 2값 체계를 그대로 계승 — 사람별 해시 다양성은
+ * 포기하고(신호색 오염 제거가 우선), bg+text를 한 쌍으로 반환해 호출부가 text-white를
+ * 별도로 하드코딩하지 않게 한다(밝은 -soft 배경 위 흰 글자 가독성 문제 원천 차단).
+ */
+export function avatarColor(isAgent: boolean): string {
+  return isAgent ? 'bg-proof-blue-soft text-proof-blue' : 'bg-proof-sunk text-proof-ink-2';
 }
 
 export function initials(name: string): string {


### PR DESCRIPTION
## 변경 사항
챗 리디자인 시안(P0-C·2921) §4축·S4, 유나 확定 그대로: 「버블=무채 panel(내 메시지=blue-soft)·에이전트=blue 링 아바타·human=무채 사각」.

**버블:** 옛 isMine 분기(solid `bg-primary`+흰 `text-primary-foreground` vs `bg-muted`+`text-foreground`)를 `bg-proof-blue-soft`(내 메시지)/`bg-proof-panel`(상대)+공통 `text-foreground`로. 두 배경 다 밝아져 isMine으로 잉크색이 갈릴 이유가 없어져(ChatMarkdown의 text/muted/codeBg/border 4파생값과 멘션 스팬까지) 전부 통일했습니다.

## ⚠️ #3335(2901) 머지 후 rebase — 아바타 부분 재조정(유나 합성 5규칙)
원래 이 PR은 ProofAvatar(신규 컴포넌트)를 챗 아바타로 썼으나, #3335가 같은 자리를 Avatar 프리미티브(avatar_url 이미지→이니셜→아이콘 3단 폴백)로 먼저 머지해 충돌 — 유나가 [avatar-unification-design-memo-2921](entity:doc:04077d58-4081-41a6-b469-2ca18e6cfdd3)로 5규칙 전건 확定, 그대로 재구현했습니다.

**처방(전부 `avatar.tsx` 내부, props 시그니처 무변경):**
- 형태 자동유도(agent=circle·human=square, actorType에서 유도 — 호출부가 shape를 안 넘김). 이미지도 overflow-hidden 래퍼 반경만 바뀌어 자동으로 같은 클립을 받습니다.
- human 테두리 신설(`border-proof-line`, 색과 별개의 redundant 경계 신호).
- idle 에이전트 링: `ring-accent-claim`(citron) → `ring-proof-blue`(정적).
- working 에이전트 링: 개명+색 스왑 — `WORKING_RING_CLASS`(`ring-info`, #2917에서 이미 proof-blue로 별칭됨을 확認)→`AGENT_LIVE_RING_CLASS`(`ring-proof-citron`, presence-dot.tsx). **실측 정정**: 옛 값이 규칙③(idle=blue·working=citron)과 정반대였음을 그라운딩에서 발견, 유나가 swap으로 확定.
- AI 배지·presence dot·onError 폴백 — 무변경.
- **ProofAvatar 완전 폐기**(규칙⑤ 단일 컴포넌트) — `proof-capsule.tsx`(FullVariant·InlineRow 4곳)·`workcell.tsx`(BriefLayer 2곳) 전부 `Avatar`로 교체.
- **스코프=ⓐ 전 표면 단일 문법**(유나 확定, 챗 전용 override 기각) — `organization/workforce/[id]`·`avatar-edit-card`(설정 프로필)·`team-presence-panel` 3표면도 동일 시각을 받습니다.

## 라이브 "before" 3표면 대조(dev, 2026-08-22, Puppeteer 실측)
- **workforce/[id]**(에이전트, 페드루 올리베이라) — 원형+citron 정적 링. → after: 원형 유지(에이전트 형태 무변화)+`ring-proof-blue`.
- **team-presence-panel**(에이전트 다수, 온라인 9명 전부 확認) — 동일 패턴.
- **settings 프로필**(avatar-edit-card, 휴먼 송윤재) — 원형+테두리 없음(배경색만). → after: `rounded-md`+`border-proof-line`.

⚠️**정직 보고 — "after" 라이브 픽셀 미완**: 로컬 풀스택 재현이 이 세션 반복된 기존 한계(`NEXT_PUBLIC_FASTAPI_URL` 미설정)로 안 돼, dev 배포 전 실측은 못 했습니다. "before"는 실측(위), "after"는 로컬 vitest(avatar.test.tsx 신규 2건+갱신 1건)로 형태·클래스만 확認 — dev 배포 후 라이브 픽셀 별도 필요.

## 대비 수동검증(proof-*는 discoverBgFamilies에서 의도적 제외돼 자동가드 대상 밖)
- ink/panel·ink/blue-soft 4조합 13.9~18.6:1(압도)
- 멘션 스팬(text-primary) on blue-soft(mine) — light 4.61/dark 4.81(AA 통과하나 라이트가 근소해서 유나 지시대로 그 폭엔 더 작은 텍스트 금지·현 크기 유지)

## 셀프 게이트
- tsc/lint 0
- vitest 전체 475 files / 3938 tests green(chat-bubble 130건·proof-capsule·avatar·workcell 전부 포함, 회귀 3건 갱신+신규 3건)
- 대비 가드 3종 green
- build EXIT 0

## Test plan
- [x] tsc/lint/build/vitest 전체 그린
- [x] "before" 3표면 라이브 스크린샷(Puppeteer)
- [ ] dev 배포 후 "after" 라이브 픽셀(3표면 + 챗 버블/아바타, 라이트/다크)

🤖 Generated with [Claude Code](https://claude.com/claude-code)