### PR TITLE
[SID:2926] P0-F F1 — 챗 ApprovalRequestCard 셸을 ProofCapsule density=card로 교체

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3376,6 +3376,7 @@
     "hitlExpired": "Expired",
     "hitlSendFailed": "Failed to send. Please try again.",
     "approvalRequestLabel": "Approval request",
+    "approvalRequestStatusPending": "Pending approval",
     "approvalRequestNotFound": "The approval gate could not be found.",
     "approvalRequestLoadError": "Failed to load approval details.",
     "approvalRequestResolvedStatus": "Resolved — status: {status}",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3376,6 +3376,7 @@
     "hitlExpired": "만료됨",
     "hitlSendFailed": "전송에 실패했습니다. 다시 시도해 주세요.",
     "approvalRequestLabel": "결재 요청",
+    "approvalRequestStatusPending": "결재 대기",
     "approvalRequestNotFound": "결재 게이트를 찾을 수 없습니다.",
     "approvalRequestLoadError": "결재 정보를 불러오지 못했습니다.",
     "approvalRequestResolvedStatus": "처리됨 — 상태: {status}",

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Check, Eye, FileText, X } from 'lucide-react';
+import { Check, FileText, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -9,11 +9,12 @@ import { GateSignatureApproval } from '@/components/cage/gate-signature-approval
 import { GateUndoButton, isUndoEligible } from '@/components/cage/gate-undo-button';
 import { GateDiscussDialog } from '@/components/cage/gate-discuss-dialog';
 import { deriveRiskLevel, usesSignatureFlow } from '@/components/cage/gate-risk';
-import { EntityPreviewModal, canPreviewEntity, getEntityHref, resolveEntityIcon } from '@/components/chat/embed-card';
+import { EntityPreviewModal, canPreviewEntity, getEntityHref } from '@/components/chat/embed-card';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateItem } from '@/components/kanban/types';
 import { parseBlockTemplate, renderBlockTemplate, type EventDefinitionSummary } from '@/lib/block-template';
 import { renderStaticEventBlock } from '@/components/chat/event-block-card';
+import { ProofCapsule, type ProofState } from '@/components/proof-capsule/proof-capsule';
 
 import { fetchWithAuth } from '@/lib/db/client';
 
@@ -91,6 +92,9 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalR
   const [state, setState] = useState<CardState>({ kind: 'loading' });
   const [resolving, setResolving] = useState(false);
   const [transitionError, setTransitionError] = useState<string | null>(null);
+  // story #2926(P0-F F1) — claim 클릭(제목 미리보기)이 이제 ProofCapsule 셸 소관이라 이
+  // state도 그쪽에 맞춰 여기(바깥 컴포넌트)로 끌어올렸다(기존 ApprovalRequestBody 소유였음).
+  const [showPreview, setShowPreview] = useState(false);
 
   const fetchGate = useCallback(async () => {
     try {
@@ -154,49 +158,81 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalR
     }
   };
 
-  // story #2905(S2c②) — gate 단건 sole-link 참조(chat-bubble.tsx) 호출부는 work_item_type을
-  // 모르는 채(빈 문자열 placeholder) 부른다 — fetch 완료 후엔 gate 실물(GateResponse가
-  // work_item_type을 1급 필드로 실어 옴, 페드루 확定 2026-08-21)을 우선한다. 기존 approval_target
-  // 메시지 호출부(BE가 정확한 work_item_type을 이미 실어 보냄)는 무변경(fetch 전 잠깐만 prop 사용).
-  const headerWorkItemType = state.kind === 'ready' ? state.gate.work_item_type : target.work_item_type;
-  const Icon = resolveEntityIcon(toEntityType(headerWorkItemType)) ?? FileText;
+  // story #2926(P0-F F1) — loading/not-found/error는 claim(제목)이 아직 없는 과도 상태라
+  // Proof Capsule 셸을 억지로 씌우지 않는다(claim이 빈 이야기를 지어내는 게 되므로) — 기존
+  // 가벼운 placeholder 그대로 유지. AC1(3서피스 단일 ProofCapsule 소비)의 대상은 실 데이터가
+  // 있는 'ready' 상태다.
+  if (state.kind !== 'ready') {
+    return (
+      <div className="min-w-0 max-w-full rounded-xl rounded-tl-sm border border-border bg-card px-3.5 py-3">
+        <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium text-foreground">
+          <FileText className="h-3 w-3" aria-hidden />
+          {t('approvalRequestLabel')}
+        </div>
+        {state.kind === 'loading' ? (
+          <div className="h-8 animate-pulse rounded-lg bg-muted" />
+        ) : state.kind === 'not-found' ? (
+          <p className="text-xs text-muted-foreground">{t('approvalRequestNotFound')}</p>
+        ) : (
+          <p className="text-xs text-muted-foreground">{t('approvalRequestLoadError')}</p>
+        )}
+      </div>
+    );
+  }
+
+  const gate = state.gate;
+  const title = gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`;
+  const previewEntityType = toEntityType(gate.work_item_type);
+  const canPreview = canPreviewEntity(previewEntityType);
+  // story #2926(P0-F F1) — attention-queue의 기존 PROOF_STATE 관례(gate_pending→amber) 그대로:
+  // pending=amber(인간 검토 대기)·승인=green·그 외(rejected/held/voided)=red — 옛 코드도
+  // approved만 Check/primary고 나머지는 전부 X/destructive였다(line 298 선례), 신규 구분 아님.
+  const proofState: ProofState = gate.status === 'pending' ? 'amber' : gate.status === 'approved' ? 'green' : 'red';
+  const stateLabel = gate.status === 'pending'
+    ? t('approvalRequestStatusPending')
+    : (RESOLVED_STATUS_LABEL_KEYS[gate.status] ? t(RESOLVED_STATUS_LABEL_KEYS[gate.status]!) : gate.status);
 
   return (
-    <div className="min-w-0 max-w-full rounded-xl rounded-tl-sm border border-border bg-card px-3.5 py-3">
-      <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium text-foreground">
-        <Icon className="h-3 w-3" aria-hidden />
-        {t('approvalRequestLabel')}
-      </div>
-
-      {state.kind === 'loading' ? (
-        <div className="h-8 animate-pulse rounded-lg bg-muted" />
-      ) : state.kind === 'not-found' ? (
-        <p className="text-xs text-muted-foreground">{t('approvalRequestNotFound')}</p>
-      ) : state.kind === 'error' ? (
-        <p className="text-xs text-muted-foreground">{t('approvalRequestLoadError')}</p>
-      ) : (
-        <ApprovalRequestBody
-          gate={state.gate}
-          resolving={resolving}
-          transitionError={transitionError}
-          onApprove={(reason, evidenceViewed) => void transition('approved', reason, evidenceViewed)}
-          onReject={(reason) => void transition('rejected', reason)}
-          onDiscuss={(reason) => void discuss(reason)}
-          onDiscussClick={() => setDiscussDialogOpen(true)}
-          onUndone={() => void fetchGate()}
-          eventDefinitionsByKey={eventDefinitionsByKey}
+    <>
+      <ProofCapsule
+        density="card"
+        proofState={proofState}
+        stateLabel={stateLabel}
+        claim={title}
+        onClaimClick={canPreview ? () => setShowPreview(true) : undefined}
+        className="max-w-full"
+        footer={
+          <ApprovalRequestBody
+            gate={gate}
+            resolving={resolving}
+            transitionError={transitionError}
+            onApprove={(reason, evidenceViewed) => void transition('approved', reason, evidenceViewed)}
+            onReject={(reason) => void transition('rejected', reason)}
+            onDiscuss={(reason) => void discuss(reason)}
+            onDiscussClick={() => setDiscussDialogOpen(true)}
+            onUndone={() => void fetchGate()}
+            eventDefinitionsByKey={eventDefinitionsByKey}
+          />
+        }
+      />
+      <GateDiscussDialog
+        open={discussDialogOpen}
+        onOpenChange={setDiscussDialogOpen}
+        onSubmit={(reason) => void discuss(reason)}
+        submitting={discussSubmitting}
+        error={discussError}
+      />
+      {showPreview && (
+        <EntityPreviewModal
+          entityType={previewEntityType}
+          entityId={gate.work_item_id}
+          title={title}
+          status={null}
+          href={getEntityHref(previewEntityType, gate.work_item_id)}
+          onClose={() => setShowPreview(false)}
         />
       )}
-      {state.kind === 'ready' ? (
-        <GateDiscussDialog
-          open={discussDialogOpen}
-          onOpenChange={setDiscussDialogOpen}
-          onSubmit={(reason) => void discuss(reason)}
-          submitting={discussSubmitting}
-          error={discussError}
-        />
-      ) : null}
-    </div>
+    </>
   );
 }
 
@@ -256,30 +292,12 @@ function ApprovalRequestBody({
   const riskLevel = deriveRiskLevel(gate);
   const needsFullFlow = usesSignatureFlow(riskLevel);
   const canAct = gate.status === 'pending' && gate.can_approve === true;
-  const [showPreview, setShowPreview] = useState(false);
-  // story #2118(E-DG-REAL) — doc 전용이던 제목 진입점을 전 work_item_type으로 확장하되,
-  // «클릭에 값이 있는 타입»만(페드루 리뷰). canPreviewEntity가 RICH_PREVIEW/ENTITY_API fetch
-  // 전략/own-href 셋 다 없는 타입(loop·wf_line_version 등)을 걸러 빈 모달 진입점을 안 만든다
-  // — story #2118(P2.2) AC④("미리보기 없는 타입에 억지로 진입점 달아 빈 모달 여는 거짓 안
-  // 만든다")와 동형 판정을 embed-card.tsx 공유 함수로 그대로 재사용.
-  const previewEntityType = toEntityType(gate.work_item_type);
-  const canPreview = canPreviewEntity(previewEntityType);
 
   return (
     <div className="space-y-2">
-      {canPreview ? (
-        <button
-          type="button"
-          onClick={() => setShowPreview(true)}
-          className="group/preview flex w-full min-w-0 items-center gap-1 text-left"
-        >
-          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground group-hover/preview:underline">{title}</span>
-          <Eye className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-        </button>
-      ) : (
-        <p className="truncate text-sm font-medium text-foreground">{title}</p>
-      )}
-
+      {/* story #2926(P0-F F1) — 제목(claim)·미리보기 진입점·EntityPreviewModal은 이제 바깥
+          ApprovalRequestCard의 ProofCapsule 셸이 소유한다(claim=onClaimClick). 이 body는
+          claim 아래의 실 기능(위험 배지·서명 플로우·회신 상태·액션 버튼)만 담당. */}
       {gate.status === 'pending' && (riskLevel === 'high' || riskLevel === 'unknown') ? (
         <Badge variant={riskLevel === 'high' ? 'warning' : 'outline'} className={riskLevel === 'unknown' ? 'text-muted-foreground' : undefined}>
           {riskLevel === 'high' ? tCage('riskHigh') : tCage('riskUnknown')}
@@ -363,17 +381,6 @@ function ApprovalRequestBody({
             {tCage('gateDiscussSubmit')}
           </Button>
         </>
-      )}
-
-      {showPreview && (
-        <EntityPreviewModal
-          entityType={previewEntityType}
-          entityId={gate.work_item_id}
-          title={title}
-          status={null}
-          href={getEntityHref(previewEntityType, gate.work_item_id)}
-          onClose={() => setShowPreview(false)}
-        />
       )}
     </div>
   );

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -702,7 +702,10 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
     await act(async () => {
       root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} />));
     });
-    expect(container.textContent).toContain('결재 요청');
+    // story #2926(P0-F F1) — 「결재 요청」 정적 라벨 행은 ProofCapsule 셸로 전환되며
+    // 빠졌다(카드 정체성은 이제 컷코너+레일 모양이 진다). 대신 stateLabel(pending=
+    // 「결재 대기」)이 그 자리를 잇는다 — 텍스트 내용은 더 구체적으로 유지.
+    expect(container.textContent).toContain('결재 대기');
     expect(container.textContent).toContain('제안서.md');
     expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent?.includes('승인'))).toBe(true);
     expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent?.includes('반려'))).toBe(true);
@@ -958,7 +961,10 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
       await act(async () => {
         root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} eventDefinitionsByKey={withGateVerdictCatalog} />));
       });
-      expect(container.textContent).toContain('결재 요청'); // Q3 — 카드 라벨은 그대로.
+      // story #2926(P0-F F1) — Q3(카드 라벨은 그대로)의 실현 방식이 바뀌었다: 정적 「결재
+      // 요청」 텍스트 행 대신 ProofCapsule stateLabel(resolved="승인됨", 아래서 검증)이
+      // 카드 정체성을 잇는다 — 카드 자체가 사라지거나 라벨 없이 뜨는 게 아니라는 Q3 취지는
+      // 유지, 표현 수단만 shape+stateLabel로 옮겨갔다.
       expect(container.textContent).not.toContain('게이트 판정'); // header는 부분소비 제외.
       expect(container.textContent).not.toContain(DOC_ID); // Q2 — UUID 노출 금지.
       expect(container.textContent).toContain('doc_approval');

--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -285,3 +285,21 @@ describe('ProofCapsule (EN locale — regression: 전면 하드코딩 한국어�
     }
   });
 });
+
+describe('ProofCapsule — story #2926(P0-F F1) onClaimClick (card density only)', () => {
+  it('renders claim as a <button> when onClaimClick is provided(F1 소비처 — approval-request-card.tsx)', () => {
+    const markup = renderWithIntl(
+      <ProofCapsule {...BASE} density="card" onClaimClick={() => {}} />,
+    );
+    expect(markup).toContain('<button');
+    expect(markup).toContain(BASE.claim);
+  });
+
+  it('renders claim as plain text when onClaimClick is omitted(기존 card 호출부 — Board story-card.tsx 등 — 무변화)', () => {
+    const markup = renderWithIntl(
+      <ProofCapsule {...BASE} density="card" />,
+    );
+    expect(markup).not.toContain('<button');
+    expect(markup).toContain(BASE.claim);
+  });
+});

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -65,6 +65,11 @@ export interface ProofCapsuleProps {
   /** card 밀도 전용 — claim/evidence 아래 호출부 컨텐츠(예: Board card의 담당자 스택·배지·
    * 컨텍스트 메뉴 앵커) 삽입 슬롯. Proof Capsule 자체 필드로 표현 안 되는 실 기능을 안 잃게. */
   footer?: ReactNode;
+  /** story #2926(P0-F F1) — card 밀도 전용. claim 자체가 상세/미리보기 진입점인 호출부(예:
+   * 챗 ApprovalRequestCard의 doc/story 제목 클릭→EntityPreviewModal)를 위한 훅. 있으면 claim이
+   * `<button>`(hover underline)으로, 없으면 기존과 동일한 순수 텍스트로 렌더된다 — 기존
+   * card 호출부(Board story-card.tsx 등)는 전부 무변화. */
+  onClaimClick?: () => void;
   className?: string;
 }
 
@@ -79,7 +84,7 @@ export interface ProofCapsuleProps {
  * glow·999px pill·숫자 KPI화·raw CoT·초록만-완료 전부 미사용(색은 항상 stateLabel 텍스트 병기).
  */
 export function ProofCapsule({
-  proofState, stateLabel, claim, human, agent, now, evidence, gate, trustSeal, density, footer, className, duration,
+  proofState, stateLabel, claim, human, agent, now, evidence, gate, trustSeal, density, footer, className, duration, onClaimClick,
 }: ProofCapsuleProps) {
   if (density === 'audit') {
     return (
@@ -96,7 +101,7 @@ export function ProofCapsule({
   }
   if (density === 'card') {
     return (
-      <CardVariant proofState={proofState} stateLabel={stateLabel} claim={claim} evidence={evidence} footer={footer} className={className} />
+      <CardVariant proofState={proofState} stateLabel={stateLabel} claim={claim} evidence={evidence} footer={footer} className={className} onClaimClick={onClaimClick} />
     );
   }
   return (
@@ -288,12 +293,22 @@ function FullVariant({
   );
 }
 
-function CardVariant({ proofState, stateLabel, claim, evidence, footer, className }: Pick<ProofCapsuleProps, 'proofState' | 'stateLabel' | 'claim' | 'evidence' | 'footer' | 'className'>) {
+function CardVariant({ proofState, stateLabel, claim, evidence, footer, className, onClaimClick }: Pick<ProofCapsuleProps, 'proofState' | 'stateLabel' | 'claim' | 'evidence' | 'footer' | 'className' | 'onClaimClick'>) {
   return (
     <CutCornerShell state={proofState} cut={16} className={cn('w-full max-w-[280px]', className)}>
       <div className="min-w-0 flex-1 px-3 py-2.5">
         <StateHeader state={proofState} label={stateLabel} />
-        <div className="mt-1.5 line-clamp-2 text-[12.5px] font-semibold leading-snug text-proof-ink">{claim}</div>
+        {onClaimClick ? (
+          <button
+            type="button"
+            onClick={onClaimClick}
+            className="mt-1.5 line-clamp-2 w-full text-left text-[12.5px] font-semibold leading-snug text-proof-ink hover:underline"
+          >
+            {claim}
+          </button>
+        ) : (
+          <div className="mt-1.5 line-clamp-2 text-[12.5px] font-semibold leading-snug text-proof-ink">{claim}</div>
+        )}
         {evidence ? (
           <div className="mt-1.5 flex items-center gap-2.5 text-[10.5px] text-proof-ink-3">
             {evidence.acMet != null && evidence.acTotal != null ? (


### PR DESCRIPTION
## 변경 사항
2916-B 확定 스펙(proof-capsule-4context-2916b)의 «3서피스 수렴» 1/3 슬라이스(F1: 챗 카드 → F2: /gates/[id] full → F3: /inbox row).

**S3 그라운딩 실측:** 색은 #3329 alias 부수효과로 이미 Proofline(셸이 semantic 토큰뿐)이었고, 빠진 건 모양 시그니처(컷코너 24px+신뢰단계 색 레일)뿐이었습니다.

**셸만 교체, 내부 로직 100% 유지:** 서명 플로우(GateSignatureApproval)·근거확認·discuss/undo·risk_grade 분기·preset.gate.verdict 부분소비·EntityPreviewModal 전부 무변경 — claim/proofState/stateLabel 유도 로직과 preview-click 상태만 바깥 컴포넌트로 끌어올려 ProofCapsule 셸에 먹였습니다. loading/not-found/error는 claim(실 제목)이 아직 없는 과도 상태라 기존 가벼운 placeholder 유지.

**proofState 매핑:** pending=amber·approved=green·그 외=red — attention-queue의 기존 `PROOF_STATE`(gate_pending→amber) 관례 그대로, 신규 판단 아닙니다.

**「결재 요청」 정적 라벨 제거:** Proof Capsule 모양 자체가 카드 정체성을 지므로 중복 — stateLabel("결재 대기" 등)이 더 구체적인 신호로 대체.

## ProofCapsule 확장(하위호환)
`onClaimClick?: () => void`(card 밀도 전용, 있으면 claim이 `<button>`) — 기존 card 호출부(Board story-card.tsx 등)는 전부 무변화.

## 그라운딩 판정 — EventBlockCard 제외
2921 doc이 「Proof Capsule(gate=card)·STEER 이벤트 블록·GATE 인라인」을 서로 다른 세 어휘로 나열 — EventBlockCard(STEER 알림)는 대상이 아닙니다. F1 스코프에서 명시적으로 뺐습니다.

## 셀프 게이트
- tsc/lint 0
- vitest 전체 475 files / 3927 tests green(회귀 2건은 문구 검증 방식만 갱신 — approval-request-card.test.tsx 10건은 무수정 통과)
- 대비 가드 3종 + no-handrolled-modal green
- build EXIT 0

## Test plan
- [x] tsc/lint/build/vitest 전체 그린
- [x] 서명 플로우·risk_grade·discuss/undo 등 기존 동작 회귀 0(테스트로 확認)
- [ ] dev 배포 후 실 픽셀(컷코너+레일, 라이트/다크)

🤖 Generated with [Claude Code](https://claude.com/claude-code)