### PR TITLE
[SID:2926] P0-F F2 — /gates/[id] 셸을 ProofCapsule density=full로 교체

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3784,6 +3784,7 @@
     "evidenceNonePrompt": "No evidence yet — review by content",
     "gateDetailBackToInbox": "Approvals",
     "gateDetailNotFound": "Gate not found.",
+    "gateDetailStatusPending": "Pending approval",
     "gateDetailResolvedStatus": "Already resolved — status: {status}",
     "gateDetailResolvedByStatus": "Resolved by {name} — status: {status}",
     "queueAgeToday": "Filed today",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3784,6 +3784,7 @@
     "evidenceNonePrompt": "근거 데이터 없음 — 내용으로 직접 판단",
     "gateDetailBackToInbox": "결재함",
     "gateDetailNotFound": "게이트를 찾을 수 없습니다.",
+    "gateDetailStatusPending": "결재 대기",
     "gateDetailResolvedStatus": "이미 처리됨 — 상태: {status}",
     "gateDetailResolvedByStatus": "{name}님이 처리 — 상태: {status}",
     "queueAgeToday": "오늘 접수",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -17,6 +17,7 @@ import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateItem } from '@/components/kanban/types';
 import { fetchWithAuth } from '@/lib/db/client';
 import { EntityBacklinksSection } from '@/components/shared/entity-backlinks-section';
+import { ProofCapsule, type ProofState } from '@/components/proof-capsule/proof-capsule';
 
 // story #1954(P1a-S4) — Gate 3종(게이트·문서결재·머지게이트) canonical 상세. P1a·P2 공용 유일
 // per-gate 라우트(중복 빌드 봉쇄) — decision(inbox_items)은 별도 표면(오르테가군 PO 판단+
@@ -32,6 +33,17 @@ interface GateDetail extends GateItem {
   org_id: string;
   project_id?: string | null;
 }
+
+// story #2926(P0-F F2) — ProofCapsule stateLabel(resolved)용. approval-request-card.tsx(F1)의
+// RESOLVED_STATUS_LABEL_KEYS와 같은 값 계열을 'cage' 네임스페이스 기존 키로 매핑(queue*Badge
+// 류가 이미 있어 신규 키를 최소화 — voided/held는 그대로, approved/rejected만 F1과 문구를
+// 맞춘다). 매핑 안 된 값은 원문 그대로(지어내지 않음, F1과 동형).
+const GATE_DETAIL_STATUS_LABEL_KEYS: Record<string, string> = {
+  approved: 'queueResolvedApproved',
+  rejected: 'queueResolvedRejected',
+  held: 'heldBadge',
+  voided: 'voidedBadge',
+};
 
 export default function GateDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -194,123 +206,137 @@ export default function GateDetailPage() {
         ) : notFound || !gate ? (
           <p className="text-sm text-muted-foreground">{t('gateDetailNotFound')}</p>
         ) : (
-          <>
-            <div className="space-y-2">
-              <div className="flex flex-wrap items-center gap-1.5">
-                <Badge variant="chip">{gate.gate_type}</Badge>
-                {deriveRiskLevel(gate) === 'high' ? (
-                  <Badge variant="warning">{t('riskHigh')}</Badge>
-                ) : deriveRiskLevel(gate) === 'unknown' ? (
-                  <Badge variant="outline" className="text-muted-foreground">{t('riskUnknown')}</Badge>
-                ) : null}
-              </div>
-              <h1 className="text-base font-semibold text-foreground">
-                {gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`}
-              </h1>
-              <p className="text-xs text-muted-foreground">
-                {t('gateDetailOrgContext', {
-                  org: orgMemberships.find((o) => o.orgId === gate.org_id)?.orgName ?? gate.org_id.slice(0, 8),
-                })}
-                {gate.project_id
-                  ? ` · ${projectMemberships.find((p) => p.projectId === gate.project_id)?.projectName ?? gate.project_id.slice(0, 8)}`
-                  : ''}
-              </p>
-            </div>
-
-            {!needsAction ? (
-              <div className="space-y-3">
-                <GateEvidence gate={gate} />
-                {/* story #2043 AC1: status·requires_human·evidence_status 조합별 단일 문장 —
-                    조합표(코드 근거):
-                    - status≠pending → 이미 해소됨(무엇으로 닫혔는지)
-                    - status=pending, decision=block → 자동 차단·읽기전용
-                    - status=pending, decision=auto_merge(requires_human 무관, 실제 BE 판정값) → 자동 통과·액션 불필요
-                    - status=pending, 그 외 전부(decision=null 또는 requires_human=false라 액션 미노출)
-                      → "판정 미거침" — gateDecision()이 이미 requires_human을 반영해 null을
-                      리턴하므로 여기서 "Auto-passed"를 함부로 말하지 않는다(진짜 판정 없이
-                      Auto로 단정하던 게 자기모순의 절반이었다). */}
-                <p className="text-[11px] text-muted-foreground">
-                  {gate.status !== 'pending'
-                    ? (gate.resolver_id
-                        ? t('gateDetailResolvedByStatus', { name: memberNames[gate.resolver_id] ?? gate.resolver_id.slice(0, 8), status: gate.status })
-                        : t('gateDetailResolvedStatus', { status: gate.status }))
-                    : gateDecision(gate) === 'block' ? t('gateReadonlyBlock')
-                    : gateDecision(gate) === 'auto_merge' ? t('gateReadonlyAuto')
-                    : t('gateReadonlyNoVerdict')}
-                </p>
-                {/* story #2631 — 오클릭 정정(방금 본인이 해소한 게이트, 5분 창). */}
-                {isUndoEligible(gate, currentTeamMemberId) ? (
-                  <GateUndoButton gateId={gate.id} onUndone={() => void fetchGate()} />
-                ) : null}
-              </div>
-            ) : !canAct ? (
-              // story #2091(P0) — needsAction=true(게이트 자체는 사람 판단이 필요)이지만
-              // gate.can_approve=false(이 caller는 승인 권한 없음, BE per-caller 판정). 액션
-              // 버튼을 렌더하지 않고 왜 못 누르는지를 정직하게 알린다 — "이미 처리됨"과는
-              // 다른 사유이므로 별개 문구(gateReadonlyNotAuthorized)를 쓴다.
-              <div className="space-y-3">
-                <GateEvidence gate={gate} />
-                <p className="text-[11px] text-muted-foreground">{t('gateReadonlyNotAuthorized')}</p>
-              </div>
-            ) : usesSignatureFlow(deriveRiskLevel(gate)) ? (
-              <GateSignatureApproval
-                gate={gate}
-                resolving={resolving}
-                error={transitionError}
-                onApprove={(reason) => void transition('approved', reason, true)}
-                onReject={(reason) => void transition('rejected', reason)}
-                onDiscuss={(reason) => void discuss(reason)}
-              />
-            ) : (
-              <div className="space-y-3">
-                <GateEvidence gate={gate} />
-                {transitionError ? (
-                  <p
-                    className="rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-xs text-foreground"
-                    role="alert"
-                    aria-live="assertive"
-                    aria-atomic="true"
-                  >
-                    {t('gateTransitionError', { reason: transitionError })}
-                  </p>
-                ) : null}
-                <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    className="min-h-12 flex-1 gap-1.5"
-                    disabled={resolving}
-                    onClick={() => void transition('rejected')}
-                  >
-                    <XCircle className="size-4" />
-                    {t('gateReject')}
-                  </Button>
-                  <Button
-                    className="min-h-12 flex-1 gap-1.5"
-                    disabled={resolving}
-                    onClick={() => void transition('approved')}
-                  >
-                    <CheckCircle className="size-4" />
-                    {resolving ? '...' : t('gateApprove')}
-                  </Button>
+          // story #2926(P0-F F2) — 셸만 ProofCapsule density="full"로 교체, 내부 로직(4갈래
+          // 상태 분기·서명 플로우·GateEvidence·EntityBacklinksSection) 100% 무변경. GateRow
+          // (full 밀도 내장)는 단일 버튼 추상이라 이 페이지의 다상태 액션 분기를 못 담아 —
+          // gate/human 프롭은 안 주고(GateRow 자체를 비활성) 전부 footer로 이관했다. proofState
+          // 매핑은 approval-request-card.tsx(F1)와 동일 관례(attention-queue PROOF_STATE
+          // 재사용) — pending=amber·approved=green·그 외=red.
+          <ProofCapsule
+            density="full"
+            proofState={(gate.status === 'pending' ? 'amber' : gate.status === 'approved' ? 'green' : 'red') as ProofState}
+            stateLabel={
+              gate.status === 'pending'
+                ? t('gateDetailStatusPending')
+                : (GATE_DETAIL_STATUS_LABEL_KEYS[gate.status] ? t(GATE_DETAIL_STATUS_LABEL_KEYS[gate.status]!) : gate.status)
+            }
+            claim={gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`}
+            className="max-w-none"
+            footer={
+              <div className="mt-3.5 space-y-3 border-t border-proof-line-soft pt-3">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <Badge variant="chip">{gate.gate_type}</Badge>
+                  {deriveRiskLevel(gate) === 'high' ? (
+                    <Badge variant="warning">{t('riskHigh')}</Badge>
+                  ) : deriveRiskLevel(gate) === 'unknown' ? (
+                    <Badge variant="outline" className="text-muted-foreground">{t('riskUnknown')}</Badge>
+                  ) : null}
                 </div>
-                {/* story #2631 — 「보류(논의 필요)」. 저위험 경로엔 사유 입력창이 없어 다이얼로그로. */}
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="w-full text-muted-foreground"
-                  disabled={resolving}
-                  onClick={() => setDiscussDialogOpen(true)}
-                >
-                  {t('gateDiscussSubmit')}
-                </Button>
-              </div>
-            )}
+                <p className="text-xs text-muted-foreground">
+                  {t('gateDetailOrgContext', {
+                    org: orgMemberships.find((o) => o.orgId === gate.org_id)?.orgName ?? gate.org_id.slice(0, 8),
+                  })}
+                  {gate.project_id
+                    ? ` · ${projectMemberships.find((p) => p.projectId === gate.project_id)?.projectName ?? gate.project_id.slice(0, 8)}`
+                    : ''}
+                </p>
 
-            {/* story #2902(후보 B, S2h①③ list_entity_backlinks 확장 소비처) — 「이 게이트를
-                언급한 대화」 역참조. 기성 EntityBacklinksSection(3곳 소비 중) 그대로 재사용 —
-                신규 뷰어 0. gate는 TARGET_ONLY라 액션 없이 조회만(§8 계약과 정합). */}
-            <EntityBacklinksSection entityType="gate" entityId={gate.id} />
-          </>
+                {!needsAction ? (
+                  <div className="space-y-3">
+                    <GateEvidence gate={gate} />
+                    {/* story #2043 AC1: status·requires_human·evidence_status 조합별 단일 문장 —
+                        조합표(코드 근거):
+                        - status≠pending → 이미 해소됨(무엇으로 닫혔는지)
+                        - status=pending, decision=block → 자동 차단·읽기전용
+                        - status=pending, decision=auto_merge(requires_human 무관, 실제 BE 판정값) → 자동 통과·액션 불필요
+                        - status=pending, 그 외 전부(decision=null 또는 requires_human=false라 액션 미노출)
+                          → "판정 미거침" — gateDecision()이 이미 requires_human을 반영해 null을
+                          리턴하므로 여기서 "Auto-passed"를 함부로 말하지 않는다(진짜 판정 없이
+                          Auto로 단정하던 게 자기모순의 절반이었다). */}
+                    <p className="text-[11px] text-muted-foreground">
+                      {gate.status !== 'pending'
+                        ? (gate.resolver_id
+                            ? t('gateDetailResolvedByStatus', { name: memberNames[gate.resolver_id] ?? gate.resolver_id.slice(0, 8), status: gate.status })
+                            : t('gateDetailResolvedStatus', { status: gate.status }))
+                        : gateDecision(gate) === 'block' ? t('gateReadonlyBlock')
+                        : gateDecision(gate) === 'auto_merge' ? t('gateReadonlyAuto')
+                        : t('gateReadonlyNoVerdict')}
+                    </p>
+                    {/* story #2631 — 오클릭 정정(방금 본인이 해소한 게이트, 5분 창). */}
+                    {isUndoEligible(gate, currentTeamMemberId) ? (
+                      <GateUndoButton gateId={gate.id} onUndone={() => void fetchGate()} />
+                    ) : null}
+                  </div>
+                ) : !canAct ? (
+                  // story #2091(P0) — needsAction=true(게이트 자체는 사람 판단이 필요)이지만
+                  // gate.can_approve=false(이 caller는 승인 권한 없음, BE per-caller 판정). 액션
+                  // 버튼을 렌더하지 않고 왜 못 누르는지를 정직하게 알린다 — "이미 처리됨"과는
+                  // 다른 사유이므로 별개 문구(gateReadonlyNotAuthorized)를 쓴다.
+                  <div className="space-y-3">
+                    <GateEvidence gate={gate} />
+                    <p className="text-[11px] text-muted-foreground">{t('gateReadonlyNotAuthorized')}</p>
+                  </div>
+                ) : usesSignatureFlow(deriveRiskLevel(gate)) ? (
+                  <GateSignatureApproval
+                    gate={gate}
+                    resolving={resolving}
+                    error={transitionError}
+                    onApprove={(reason) => void transition('approved', reason, true)}
+                    onReject={(reason) => void transition('rejected', reason)}
+                    onDiscuss={(reason) => void discuss(reason)}
+                  />
+                ) : (
+                  <div className="space-y-3">
+                    <GateEvidence gate={gate} />
+                    {transitionError ? (
+                      <p
+                        className="rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-xs text-foreground"
+                        role="alert"
+                        aria-live="assertive"
+                        aria-atomic="true"
+                      >
+                        {t('gateTransitionError', { reason: transitionError })}
+                      </p>
+                    ) : null}
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        className="min-h-12 flex-1 gap-1.5"
+                        disabled={resolving}
+                        onClick={() => void transition('rejected')}
+                      >
+                        <XCircle className="size-4" />
+                        {t('gateReject')}
+                      </Button>
+                      <Button
+                        className="min-h-12 flex-1 gap-1.5"
+                        disabled={resolving}
+                        onClick={() => void transition('approved')}
+                      >
+                        <CheckCircle className="size-4" />
+                        {resolving ? '...' : t('gateApprove')}
+                      </Button>
+                    </div>
+                    {/* story #2631 — 「보류(논의 필요)」. 저위험 경로엔 사유 입력창이 없어 다이얼로그로. */}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="w-full text-muted-foreground"
+                      disabled={resolving}
+                      onClick={() => setDiscussDialogOpen(true)}
+                    >
+                      {t('gateDiscussSubmit')}
+                    </Button>
+                  </div>
+                )}
+
+                {/* story #2902(후보 B, S2h①③ list_entity_backlinks 확장 소비처) — 「이 게이트를
+                    언급한 대화」 역참조. 기성 EntityBacklinksSection(3곳 소비 중) 그대로 재사용 —
+                    신규 뷰어 0. gate는 TARGET_ONLY라 액션 없이 조회만(§8 계약과 정합). */}
+                <EntityBacklinksSection entityType="gate" entityId={gate.id} />
+              </div>
+            }
+          />
         )}
       </div>
       {gate ? (

--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -167,7 +167,7 @@ describe('ProofCapsule (human optional — Board card 확산, bf9037cb) — 다�
   });
 });
 
-describe('ProofCapsule (footer slot — card density, Board card 확산 실기능 이관)', () => {
+describe('ProofCapsule (footer slot — card·full 밀도, Board card 확산+story #2926 P0-F F2 gates/[id] 실기능 이관)', () => {
   it('renders arbitrary footer content below the claim/evidence in card density', () => {
     const markup = renderWithIntl(
       <ProofCapsule
@@ -179,12 +179,26 @@ describe('ProofCapsule (footer slot — card density, Board card 확산 실기�
     expect(markup).toContain('보드 카드 실기능 마커');
   });
 
-  it('ignores the footer prop on non-card densities (no accidental leak)', () => {
-    for (const density of ['full', 'row', 'audit'] as const) {
+  // story #2926(P0-F F2) — full 밀도도 footer를 받는다: GateRow(단일 버튼 추상)로는 gates/[id]
+  // 페이지의 4갈래 상태 분기(읽기전용/무권한/서명플로우/평버튼)를 못 담아, org/project 컨텍스트·
+  // 배지·상태분기·EntityBacklinksSection 전부를 footer로 이관했다(카드 전용이던 전제가 바뀜).
+  it('renders arbitrary footer content below claim/gate in full density too', () => {
+    const markup = renderWithIntl(
+      <ProofCapsule
+        {...BASE}
+        density="full"
+        footer={<span data-testid="gate-detail-footer-marker">gates/[id] 상태분기 마커</span>}
+      />,
+    );
+    expect(markup).toContain('gates/[id] 상태분기 마커');
+  });
+
+  it('ignores the footer prop on row/audit densities (no accidental leak — 이 둘은 여전히 전용 아님)', () => {
+    for (const density of ['row', 'audit'] as const) {
       const markup = renderWithIntl(
-        <ProofCapsule {...BASE} density={density} footer={<span>카드 전용 마커</span>} />,
+        <ProofCapsule {...BASE} density={density} footer={<span>카드·full 전용 마커</span>} />,
       );
-      expect(markup).not.toContain('카드 전용 마커');
+      expect(markup).not.toContain('카드·full 전용 마커');
     }
   });
 });

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -62,8 +62,11 @@ export interface ProofCapsuleProps {
    * 타입·렌더만 준비(호출부 없음 무방 — density="full"와 동일 선례). */
   trustSeal?: TrustSealClaimedProps | TrustSealVerifiedProps;
   density: ProofCapsuleDensity;
-  /** card 밀도 전용 — claim/evidence 아래 호출부 컨텐츠(예: Board card의 담당자 스택·배지·
-   * 컨텍스트 메뉴 앵커) 삽입 슬롯. Proof Capsule 자체 필드로 표현 안 되는 실 기능을 안 잃게. */
+  /** card·full 밀도 — claim/evidence 아래 호출부 컨텐츠(예: Board card의 담당자 스택·배지,
+   * /gates/[id] 상세의 org/project 컨텍스트·상태별 액션 분기·EntityBacklinksSection) 삽입
+   * 슬롯. Proof Capsule 자체 필드로 표현 안 되는 실 기능을 안 잃게(story #2926 P0-F F2 —
+   * full 밀도의 GateRow는 단일 버튼 추상이라 gates/[id]의 다상태 액션 분기를 못 담아
+   * footer로 이관). */
   footer?: ReactNode;
   className?: string;
 }
@@ -102,7 +105,7 @@ export function ProofCapsule({
   return (
     <FullVariant
       proofState={proofState} stateLabel={stateLabel} claim={claim} human={human} agent={agent}
-      now={now} evidence={evidence} gate={gate} trustSeal={trustSeal} className={className}
+      now={now} evidence={evidence} gate={gate} trustSeal={trustSeal} className={className} footer={footer}
     />
   );
 }
@@ -240,7 +243,7 @@ function useEvidenceSweep(evidence: ProofCapsuleEvidence | undefined) {
 }
 
 function FullVariant({
-  proofState, stateLabel, claim, human, agent, now, evidence, gate, trustSeal, className,
+  proofState, stateLabel, claim, human, agent, now, evidence, gate, trustSeal, className, footer,
 }: Omit<ProofCapsuleProps, 'density'>) {
   const t = useTranslations('proofCapsule');
   const sweep = useEvidenceSweep(evidence);
@@ -283,6 +286,7 @@ function FullVariant({
         ) : null}
         {/* Human gate는 도크트린⑤(인간=책임 주체)상 책임자 없이 못 열림 — human 없으면 생략. */}
         {gate && human ? <GateRow gate={gate} human={human} /> : null}
+        {footer}
       </div>
     </CutCornerShell>
   );


### PR DESCRIPTION
## 변경 사항
2916-B 확定 스펙의 «3서피스 수렴» 2/3 슬라이스(F1: [PR#3342](https://github.com/moonklabs/sprintable/pull/3342) 챗 카드, PO PASS). F1과 같은 원칙 — 셸만 교체, 내부 로직 100% 유지. 파일이 안 겹쳐 독립 브랜치(develop 기준)로 냅니다.

**처방:** claim=제목·proofState/stateLabel은 F1과 동일 관례(attention-queue PROOF_STATE 재사용). stateLabel은 'cage' 네임스페이스 기존 키(`queueResolvedApproved`/`Rejected`·`heldBadge`·`voidedBadge`) 재사용 + 신규 `gateDetailStatusPending`("결재 대기", F1과 문구 통일) 1건만 추가.

**GateRow 미사용:** full 밀도 내장 액션 슬롯(GateRow)은 단일 버튼 추상이라 이 페이지의 4갈래 상태 분기(읽기전용 해소됨/무권한/서명플로우/평버튼)를 못 담아 — `gate`/`human` 프롭은 안 주고 org/project 컨텍스트·배지·상태분기 전부를 `footer`로 옮겼습니다.

**무변경 확認:** GateEvidence·GateSignatureApproval·GateUndoButton·GateDiscussDialog·EntityBacklinksSection(#2902 역참조)·evidence_viewed 계약(#2027 AC2)·can_approve 게이팅(#2091)·transition 에러 노출(#2500) — 기존 테스트 13건 무수정 통과가 그 증거.

## ProofCapsule 확장(하위호환)
`footer`를 card 전용에서 card·full 공통으로 확장(row/audit은 여전히 무시) — F1의 CardVariant footer와 동형 이관. 기존 footer 회귀 가드 1건은 새 현실에 맞춰 갱신, 나머지 24건 무수정 통과.

## 셀프 게이트
- tsc/lint 0
- vitest 전체 475 files / 3926 tests green(회귀 1건은 footer 밀도 범위 재정의, gates/[id] 페이지 13건은 무수정 통과)
- 대비 가드 3종 + no-handrolled-modal green
- build EXIT 0

## Test plan
- [x] tsc/lint/build/vitest 전체 그린
- [x] can_approve 게이팅·서명 플로우·evidence_viewed·transition 에러 등 기존 동작 회귀 0
- [ ] dev 배포 후 실 픽셀(컷코너+레일, 라이트/다크)

🤖 Generated with [Claude Code](https://claude.com/claude-code)