### PR TITLE
[SID:2922] feat(2922): Workcell W6 선행 조각 — Proofline 좌측 레일

### DIFF
--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -104,6 +104,50 @@ describe('Workcell — story #2922 W6 Proofline 레일(단계→색 파생)', ()
     expect(railMatch![0]).toContain('bg-proof-line');
     expect(railMatch![0]).not.toMatch(/bg-proof-(blue|amber|green|red)/);
   });
+
+  it('verified → bg-proof-green 레일(유나양 확定 델타 — 이전엔 blue였다)', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="verified" />);
+    const railMatch = markup.match(/^<div\b[^>]*><div class="([^"]*)" aria-hidden="true"><\/div>/);
+    expect(railMatch).toBeTruthy();
+    expect(railMatch![1].split(/\s+/)).toContain('bg-proof-green');
+  });
+});
+
+// story #2922 W6 델타(유나양 확定, 2026-08-22) — 스테퍼 색을 위치기반(done=항상 green)에서
+// 트러스트-시맨틱(각 단계 자체의 신뢰상태, 위치 무관)으로 전환. 판별 핵심: "지나온" 단계가
+// 자기 고유 색(예: running=blue)을 유지해야 하며, 그저 지나왔다고 강제로 green이 되면 안 된다
+// — 이게 옛 위치기반 로직과의 진짜 차이(#3345 부수 논의가 지적한 지점).
+describe('Workcell — story #2922 W6 스테퍼 트러스트-시맨틱 컬러(유나양 확定)', () => {
+  // 각 단계의 label-wrapper class는 `role="listitem"`으로 블록을 쪼갠 뒤 그 블록의 첫
+  // class="..."(레이블+색을 쥔 중간 span — 바깥 span의 class는 role 앞이라 분할로 이미
+  // 소비됨, 점(dot) span의 class는 이보다 뒤에 옴)로 정확히 좁힌다.
+  function stageWrapperClass(markup: string, label: string): string {
+    const block = markup.split('role="listitem"').slice(1).find((b) => b.includes(`>${label}</span>`));
+    if (!block) throw new Error(`stage block not found for label: ${label}`);
+    const m = block.match(/class="([^"]*)"/);
+    if (!m) throw new Error(`class attr not found for label: ${label}`);
+    return m[1];
+  }
+
+  it('merge_ready가 current일 때, 이미 지나온 Running 단계는 강제로 green이 되지 않고 자기 고유색(blue) 유지', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="merge_ready" />);
+    const runningClass = stageWrapperClass(markup, 'Running');
+    expect(runningClass.split(/\s+/)).toContain('text-proof-blue');
+    expect(runningClass.split(/\s+/)).not.toContain('text-proof-green');
+  });
+
+  it('verified가 current일 때 그 자신은 green(자기 색이 진짜 green이므로)', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="verified" />);
+    const verifiedClass = stageWrapperClass(markup, 'Verified');
+    expect(verifiedClass.split(/\s+/)).toContain('text-proof-green');
+    expect(verifiedClass.split(/\s+/)).toContain('font-bold');
+  });
+
+  it('claimed_done이 current일 때 그 자신은 blue(주장·미검증 — 아직 green 아님)', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="claimed_done" />);
+    const claimedClass = stageWrapperClass(markup, 'Claimed done');
+    expect(claimedClass.split(/\s+/)).toContain('text-proof-blue');
+  });
 });
 
 describe('Workcell — story #2922 W1 신뢰 파이프라인 헤더 스테퍼(6상태) + 2×2 구획', () => {

--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -82,8 +82,14 @@ describe('Workcell — story #2922 W4 책임자/실행자 헤더 승격(중복 �
 // 어느 것도 아니라(신호 없음) 회색 폴백이어야 한다(no-fiction — 색을 지어내지 않음).
 describe('Workcell — story #2922 W6 Proofline 레일(단계→색 파생)', () => {
   it('merge_ready → bg-proof-green 레일', () => {
+    // 카디르군 QA(#3345 HIGH) — 이전 정규식(전역 class+aria-hidden 매치)이 레일이 아니라
+    // merge_ready일 때 PipelineStepper의 «선행완료 점»(동일하게 bg-proof-green+
+    // aria-hidden="true")에 우연매치해 로드베어링이 아니었다(뮤테이션해도 안 깨짐, 실증
+    // — codex+카디르 완전독립 이중재현). 최상위 첫 자식(레일 그 자체)에만 앵커링한다.
     const markup = renderKo(<Workcell {...BASE} pipelineStage="merge_ready" />);
-    expect(markup).toMatch(/class="[^"]*bg-proof-green[^"]*"[^>]*aria-hidden="true"/);
+    const railMatch = markup.match(/^<div\b[^>]*><div class="([^"]*)" aria-hidden="true"><\/div>/);
+    expect(railMatch).toBeTruthy();
+    expect(railMatch![1].split(/\s+/)).toContain('bg-proof-green');
   });
 
   it('needs_input → bg-proof-amber 레일', () => {

--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -78,6 +78,28 @@ describe('Workcell — story #2922 W4 책임자/실행자 헤더 승격(중복 �
   });
 });
 
+// story #2922 W6(선행 조각) — Proofline 좌측 레일. queued는 4색(blue/amber/green/red) 중
+// 어느 것도 아니라(신호 없음) 회색 폴백이어야 한다(no-fiction — 색을 지어내지 않음).
+describe('Workcell — story #2922 W6 Proofline 레일(단계→색 파생)', () => {
+  it('merge_ready → bg-proof-green 레일', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="merge_ready" />);
+    expect(markup).toMatch(/class="[^"]*bg-proof-green[^"]*"[^>]*aria-hidden="true"/);
+  });
+
+  it('needs_input → bg-proof-amber 레일', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="needs_input" />);
+    expect(markup).toMatch(/class="[^"]*bg-proof-amber[^"]*"[^>]*aria-hidden="true"/);
+  });
+
+  it('queued(신호 없음) → 4색 어느 것도 안 쓰고 중립 회색(bg-proof-line)만', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="queued" />);
+    const railMatch = markup.match(/<div class="w-1 shrink-0 self-stretch[^"]*" aria-hidden="true"><\/div>/);
+    expect(railMatch).toBeTruthy();
+    expect(railMatch![0]).toContain('bg-proof-line');
+    expect(railMatch![0]).not.toMatch(/bg-proof-(blue|amber|green|red)/);
+  });
+});
+
 describe('Workcell — story #2922 W1 신뢰 파이프라인 헤더 스테퍼(6상태) + 2×2 구획', () => {
   it('renders all six pipeline stage labels regardless of current stage', () => {
     const markup = renderKo(<Workcell {...BASE} pipelineStage="queued" />);

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -67,12 +67,26 @@ export interface WorkcellProps {
 
 const PIPELINE_STAGES: WorkcellPipelineStage[] = ['queued', 'running', 'needs_input', 'claimed_done', 'verified', 'merge_ready'];
 
-// story #2922 W6(선행 조각) — Proofline 좌측 레일 색(ProofCapsule CutCornerShell과 동형 부품
-// 재사용). queued는 "아직 신호 없음"이라 4색(blue/amber/green/red) 중 어느 것도 지어내지
-// 않는다 — ProofState에 없는 매핑은 아래에서 회색(bg-proof-line, 스테퍼 pending 점과 동일
-// 토큰) 레일로 정직하게 대체한다(색만으로 의미 전달 금지 — 헤더 stepper 텍스트가 항상 병기).
-const PIPELINE_TO_RAIL_STATE: Partial<Record<WorkcellPipelineStage, ProofState>> = {
-  running: 'blue', needs_input: 'amber', claimed_done: 'blue', verified: 'blue', merge_ready: 'green',
+// story #2922 W6 — 유나양 확定 트러스트-시맨틱 컬러 매핑(2026-08-22, 시안 335f138d 갱신).
+// 색=그 단계 자체의 신뢰상태(위치 무관 고정) — Running/Claimed done=blue(실행·주장,
+// 미검증)·Needs input=amber(대기)·Verified/Merge-ready=green(증명). Queued는 매핑에 없음
+// (아직 신호 자체가 없다 — 4색 중 어느 것도 지어내지 않고 중립 faint/line 토큰으로 대체).
+// 레일(Proofline)과 헤더 스테퍼 둘 다 이 SSOT 하나를 공유(동작 이중선언 금지).
+const PIPELINE_STAGE_TRUST_COLOR: Partial<Record<WorkcellPipelineStage, ProofState>> = {
+  running: 'blue', needs_input: 'amber', claimed_done: 'blue', verified: 'green', merge_ready: 'green',
+};
+
+const TRUST_TEXT_CLASS: Record<ProofState, string> = {
+  blue: 'text-proof-blue', amber: 'text-proof-amber', green: 'text-proof-green', red: 'text-proof-red',
+};
+const TRUST_BG_CLASS: Record<ProofState, string> = {
+  blue: 'bg-proof-blue', amber: 'bg-proof-amber', green: 'bg-proof-green', red: 'bg-proof-red',
+};
+const TRUST_BORDER_CLASS: Record<ProofState, string> = {
+  blue: 'border-proof-blue', amber: 'border-proof-amber', green: 'border-proof-green', red: 'border-proof-red',
+};
+const TRUST_RING_CLASS: Record<ProofState, string> = {
+  blue: 'ring-proof-blue/20', amber: 'ring-proof-amber/20', green: 'ring-proof-green/20', red: 'ring-proof-red/20',
 };
 
 function PipelineStepper({ stage }: { stage: WorkcellPipelineStage }) {
@@ -85,24 +99,28 @@ function PipelineStepper({ stage }: { stage: WorkcellPipelineStage }) {
   return (
     <div className="mb-2.5 flex flex-wrap items-center gap-x-0 gap-y-1" role="list" aria-label={t('pipelineQuestion')}>
       {PIPELINE_STAGES.map((s, i) => {
-        const status = i < curIdx ? 'done' : i === curIdx ? 'current' : 'pending';
+        const isCurrent = i === curIdx;
+        const color = PIPELINE_STAGE_TRUST_COLOR[s];
+        // story #2922 W6 델타(유나양 확定) — 색=신뢰상태(위치 무관, 위 표) · 강조=위치
+        // (ring/weight/dot-fill로만, current만 채워진 점+ring+굵기). "지나온" 단계라고
+        // 강제로 초록 처리하지 않는다 — 그 자체가 이미 초록(예: verified)이 아닌 한.
         return (
           <span key={s} className="flex items-center" role="listitem">
             <span
               className={cn(
-                'flex items-center gap-1.5 pr-1.5 text-[9px] font-semibold leading-none',
-                status === 'done' && 'text-proof-green',
-                status === 'current' && 'font-bold text-proof-blue',
-                status === 'pending' && 'text-proof-faint',
+                'flex items-center gap-1.5 pr-1.5 text-[9px] leading-none',
+                color ? TRUST_TEXT_CLASS[color] : 'text-proof-faint',
+                isCurrent && 'font-bold',
+                !isCurrent && 'font-semibold',
               )}
-              aria-current={status === 'current' ? 'step' : undefined}
+              aria-current={isCurrent ? 'step' : undefined}
             >
               <span
                 className={cn(
                   'size-1.5 rounded-full',
-                  status === 'done' && 'bg-proof-green',
-                  status === 'current' && 'bg-proof-blue ring-2 ring-proof-blue/20',
-                  status === 'pending' && 'bg-proof-line',
+                  isCurrent
+                    ? cn(color ? TRUST_BG_CLASS[color] : 'bg-proof-line', 'ring-2', color ? TRUST_RING_CLASS[color] : 'ring-proof-line/40')
+                    : cn('border bg-transparent', color ? TRUST_BORDER_CLASS[color] : 'border-proof-line'),
                 )}
                 aria-hidden="true"
               />
@@ -129,7 +147,7 @@ function PipelineStepper({ stage }: { stage: WorkcellPipelineStage }) {
  */
 export function Workcell({ title, pipelineStage, brief, run, evidence, conversation, className }: WorkcellProps) {
   const t = useTranslations('workcell');
-  const railState = PIPELINE_TO_RAIL_STATE[pipelineStage];
+  const railState = PIPELINE_STAGE_TRUST_COLOR[pipelineStage];
   return (
     <div
       className={cn('flex overflow-hidden rounded-[6px] border border-proof-line bg-proof-panel', className)}

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { ProofCapsule, type ProofCapsuleProps } from '@/components/proof-capsule/proof-capsule';
+import { Proofline, type ProofState } from '@/components/proof-capsule/proofline';
 import { Avatar } from '@/components/shared/avatar';
 
 export interface WorkcellOwner {
@@ -66,6 +67,14 @@ export interface WorkcellProps {
 
 const PIPELINE_STAGES: WorkcellPipelineStage[] = ['queued', 'running', 'needs_input', 'claimed_done', 'verified', 'merge_ready'];
 
+// story #2922 W6(선행 조각) — Proofline 좌측 레일 색(ProofCapsule CutCornerShell과 동형 부품
+// 재사용). queued는 "아직 신호 없음"이라 4색(blue/amber/green/red) 중 어느 것도 지어내지
+// 않는다 — ProofState에 없는 매핑은 아래에서 회색(bg-proof-line, 스테퍼 pending 점과 동일
+// 토큰) 레일로 정직하게 대체한다(색만으로 의미 전달 금지 — 헤더 stepper 텍스트가 항상 병기).
+const PIPELINE_TO_RAIL_STATE: Partial<Record<WorkcellPipelineStage, ProofState>> = {
+  running: 'blue', needs_input: 'amber', claimed_done: 'blue', verified: 'blue', merge_ready: 'green',
+};
+
 function PipelineStepper({ stage }: { stage: WorkcellPipelineStage }) {
   const t = useTranslations('workcell');
   const label: Record<WorkcellPipelineStage, string> = {
@@ -120,40 +129,46 @@ function PipelineStepper({ stage }: { stage: WorkcellPipelineStage }) {
  */
 export function Workcell({ title, pipelineStage, brief, run, evidence, conversation, className }: WorkcellProps) {
   const t = useTranslations('workcell');
+  const railState = PIPELINE_TO_RAIL_STATE[pipelineStage];
   return (
     <div
-      className={cn('overflow-hidden rounded-[6px] border border-proof-line bg-proof-panel', className)}
+      className={cn('flex overflow-hidden rounded-[6px] border border-proof-line bg-proof-panel', className)}
       style={{ clipPath: 'polygon(0 0, calc(100% - 24px) 0, 100% 24px, 100% 100%, 0 100%)' }}
     >
-      <div className="border-b border-proof-line px-4.5 py-3.5">
-        <PipelineStepper stage={pipelineStage} />
-        <span className="text-[17px] font-bold leading-tight tracking-[-0.012em] text-proof-ink">{title}</span>
-        {/* story #2922 W4 — 책임자/실행자를 헤더로 승격("10초 리트머스": 스크롤 없이 «누가»가
-            보임). #3339(2921 아바타 단일통합)가 ProofAvatar를 폐기·Avatar로 수렴시켰다 —
-            여기도 그 정본을 그대로 소비(신규 변형 0). Brief 구획의 중복 표기는 제거(SSOT=
-            헤더 이 한 자리). */}
-        <div className="mt-2 flex flex-wrap items-center gap-3.5 text-[11px] text-proof-ink-3">
-          <span className="inline-flex items-center gap-1.5">
-            <Avatar name={brief.owner.name} actorType="human" size={18} />
-            {t('briefOwner')} {brief.owner.name}
-          </span>
-          {brief.agent ? (
+      {/* story #2922 W6(선행 조각) — Proofline 좌측 레일(ProofCapsule CutCornerShell과 동형
+          부품 재사용, 신규 컴포넌트 0). */}
+      {railState ? <Proofline state={railState} /> : <div className="w-1 shrink-0 self-stretch bg-proof-line" aria-hidden="true" />}
+      <div className="min-w-0 flex-1">
+        <div className="border-b border-proof-line px-4.5 py-3.5">
+          <PipelineStepper stage={pipelineStage} />
+          <span className="text-[17px] font-bold leading-tight tracking-[-0.012em] text-proof-ink">{title}</span>
+          {/* story #2922 W4 — 책임자/실행자를 헤더로 승격("10초 리트머스": 스크롤 없이 «누가»가
+              보임). #3339(2921 아바타 단일통합)가 ProofAvatar를 폐기·Avatar로 수렴시켰다 —
+              여기도 그 정본을 그대로 소비(신규 변형 0). Brief 구획의 중복 표기는 제거(SSOT=
+              헤더 이 한 자리). */}
+          <div className="mt-2 flex flex-wrap items-center gap-3.5 text-[11px] text-proof-ink-3">
             <span className="inline-flex items-center gap-1.5">
-              <Avatar name={brief.agent.name} actorType="agent" size={18} />
-              {t('briefAgent')} {brief.agent.name}
+              <Avatar name={brief.owner.name} actorType="human" size={18} />
+              {t('briefOwner')} {brief.owner.name}
             </span>
-          ) : null}
+            {brief.agent ? (
+              <span className="inline-flex items-center gap-1.5">
+                <Avatar name={brief.agent.name} actorType="agent" size={18} />
+                {t('briefAgent')} {brief.agent.name}
+              </span>
+            ) : null}
+          </div>
         </div>
-      </div>
 
-      {/* story #2922 W1 — 4구획 세로 나열 → 2×2 그리드(Brief|Run / Evidence|Conversation).
-          gap-px+bg-proof-line가 각 구획 사이 헤어라인을 만든다(개별 레이어의 border-b는
-          이제 이 그리드 갭과 중복이라 제거됨). */}
-      <div className="grid grid-cols-2 gap-px bg-proof-line">
-        <div className="bg-proof-panel"><BriefLayer brief={brief} /></div>
-        <div className="bg-proof-panel"><RunLayer run={run} /></div>
-        <div className="bg-proof-panel"><EvidenceLayer evidence={evidence} /></div>
-        <div className="bg-proof-panel"><ConversationLayer conversation={conversation} /></div>
+        {/* story #2922 W1 — 4구획 세로 나열 → 2×2 그리드(Brief|Run / Evidence|Conversation).
+            gap-px+bg-proof-line가 각 구획 사이 헤어라인을 만든다(개별 레이어의 border-b는
+            이제 이 그리드 갭과 중복이라 제거됨). */}
+        <div className="grid grid-cols-2 gap-px bg-proof-line">
+          <div className="bg-proof-panel"><BriefLayer brief={brief} /></div>
+          <div className="bg-proof-panel"><RunLayer run={run} /></div>
+          <div className="bg-proof-panel"><EvidenceLayer evidence={evidence} /></div>
+          <div className="bg-proof-panel"><ConversationLayer conversation={conversation} /></div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- doc `workcell-redesign-2922` §W6 일부(페드루군 스코프: 색·컷코너·레일만 — 기존 섹션 하위접힘은 별도 후속). **W4(#3341) 위 독립 스택 PR** — base=`feat/2922-w4-owner-agent-header`(W5와 형제, 서로 독립).
- `ProofCapsule`의 `CutCornerShell`이 이미 쓰는 `Proofline` 부품을 그대로 재사용(신규 컴포넌트 0) — `pipelineStage` 6상태를 4색(blue/amber/green/red)으로 파생해 Workcell 좌측 레일에 반영.

## no-fiction
`queued`는 4색 중 어느 것도 지어내지 않는다(아직 신호 없음) — 헤더 stepper의 pending 점과 같은 토큰(`bg-proof-line`)으로 정직하게 중립 표시. 컷코너(clipPath)는 W1부터 이미 있었음(기존 유지, 변경 없음).

## Test plan
- [x] 3건 신규(merge_ready=green·needs_input=amber·queued=중립, 4색 미사용 확인).
- [x] tsc 0·eslint 0.

[SID:2922]