### PR TITLE
[SID:2926] P0-F F3 — /inbox 클릭-스루 게이트 행을 ProofCapsule density=row로 교체

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3783,6 +3783,7 @@
     "evidenceNonePrompt": "No evidence yet — review by content",
     "gateDetailBackToInbox": "Approvals",
     "gateDetailNotFound": "Gate not found.",
+    "gateDetailStatusPending": "Pending approval",
     "gateDetailResolvedStatus": "Already resolved — status: {status}",
     "gateDetailResolvedByStatus": "Resolved by {name} — status: {status}",
     "queueAgeToday": "Filed today",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3783,6 +3783,7 @@
     "evidenceNonePrompt": "근거 데이터 없음 — 내용으로 직접 판단",
     "gateDetailBackToInbox": "결재함",
     "gateDetailNotFound": "게이트를 찾을 수 없습니다.",
+    "gateDetailStatusPending": "결재 대기",
     "gateDetailResolvedStatus": "이미 처리됨 — 상태: {status}",
     "gateDetailResolvedByStatus": "{name}님이 처리 — 상태: {status}",
     "queueAgeToday": "오늘 접수",

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -152,10 +152,15 @@ describe('ApprovalsQueue', () => {
     expect(container.textContent).not.toContain(koMessages.cage.riskUnknown);
   });
 
-  it('held 아닌 pending gate는 위험도(unknown) 배지를 표시한다', async () => {
+  // story #2926(P0-F F3, 유나 확定①) — 이 항목(클릭-스루만 가능·인라인 액션 없음)이
+  // ProofCapsule density="row"로 바뀌며 위험도 배지 슬롯이 없어졌다(row 밀도 자체의 기존
+  // 한계 — Attention Queue 원안에도 이미 있던 제약, F3이 새로 만든 게 아니다). 대신
+  // stateLabel("결재 대기")이 그 자리의 상태 신호를 잇는다.
+  it('held 아닌 pending gate는 stateLabel(결재 대기)을 표시한다(row 밀도라 위험도 배지는 생략)', async () => {
     mockFetches([gate({ id: 'g-pending' })], []);
     await mount();
-    expect(container.textContent).toContain(koMessages.cage.riskUnknown);
+    expect(container.textContent).toContain(koMessages.cage.gateDetailStatusPending);
+    expect(container.textContent).not.toContain(koMessages.cage.riskUnknown);
   });
 
   it('created_at이 오늘이면 "오늘 접수", 과거면 "N일 대기"로 노화를 표시한다', async () => {
@@ -178,6 +183,27 @@ describe('ApprovalsQueue', () => {
     const button = container.querySelector('button');
     await act(async () => { button?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(pushMock).toHaveBeenCalledWith('/gates/g-tap');
+  });
+
+  // story #2926(P0-F F3) — 클릭-스루 전용 항목은 ProofCapsule density="row"(컷코너+신뢰단계
+  // 레일)로 셸이 바뀐다. 3버튼 인라인 결재 카드·resolved 카드는 F3 스코프 밖(현행 rounded-xl
+  // border 카드 그대로 — 2923이 다룰 표면)이라 이 항목만 겨냥해 확認한다.
+  it('클릭-스루 항목(inlineResolvable=false·미해소)은 ProofCapsule row 셸(컷코너)로 렌더된다', async () => {
+    mockFetches([gate({ id: 'g-row' })], []);
+    await mount();
+    // ProofCapsule의 CutCornerShell 자체 시그니처 — clip-path 컷코너.
+    const capsule = container.querySelector('[style*="clip-path"]');
+    expect(capsule).toBeTruthy();
+    expect(capsule?.className).toContain('bg-proof-panel');
+  });
+
+  it('3버튼 인라인 결재 카드는 F3 스코프 밖 — 현행 rounded-xl border 카드 셸 그대로다(2923 선점 안 함)', async () => {
+    mockFetches([lowRiskActionable()], []);
+    await mount();
+    // 인라인 액션 카드는 여전히 기존 셸(ProofCapsule 컷코너 아님) — 승인/변경요청 버튼이
+    // 그 증거(row 밀도엔 그런 버튼 슬롯이 없다).
+    expect(container.textContent).toContain(koMessages.cage.gateApprove);
+    expect(container.querySelector('[style*="clip-path"]')).toBeNull();
   });
 
   it('pending·held 둘 다 비어 있으면 빈 상태 문구를 렌더한다', async () => {

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -15,6 +15,7 @@ import { GateDiscussDialog } from '@/components/cage/gate-discuss-dialog';
 import { GateSignatureApproval } from '@/components/cage/gate-signature-approval';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateInboxItem, GateItem, HitlInboxItem } from '@/components/kanban/types';
+import { ProofCapsule, type ProofState } from '@/components/proof-capsule/proof-capsule';
 
 import { fetchWithAuth } from '@/lib/db/client';
 
@@ -355,14 +356,30 @@ export function ApprovalsQueue() {
               </div>
             );
           }
+          // story #2926(P0-F F3, 유나 확定①) — 「밀도는 항목의 액션 무게를 따른다」. 이
+          // 항목(inlineResolvable=false·미해소 — held/무권한/unknown 등 클릭-스루만 가능)은
+          // 경량이라 ProofCapsule density="row"로 셸만 교체한다. 3버튼 인라인 결재 카드·
+          // resolved 카드는 2923(결재함 완전목록 overflow=card로 정식화될 표면)이 다룰
+          // 영역이라 F3 스코프에서 명시적으로 뺐다(선점 금지).
+          //
+          // ⛔정보 축소 고지 — InlineRow는 risk/gate_type 배지·org 컨텍스트를 담을 슬롯이
+          // 없다(row 밀도 자체의 기존 한계, Attention Queue 원안 문서에 이미 "위험도 표시는
+          // row에서 생략 가능"으로 명시돼 있던 것 그대로 — F3이 새로 만든 제약이 아니다).
+          // claim(제목)+state(pending=결재 대기·held=보류중)+age(duration)만 남는다.
           return (
             <button
               key={gate.id}
               type="button"
               onClick={() => router.push(`/gates/${gate.id}`)}
-              className="flex min-h-12 w-full flex-col items-start gap-1 rounded-xl border border-border bg-card px-4 py-3 text-left transition-colors hover:bg-muted/40"
+              className="block w-full text-left"
             >
-              {gateBody}
+              <ProofCapsule
+                density="row"
+                proofState={'amber' as ProofState}
+                stateLabel={held ? t('heldBadge') : t('gateDetailStatusPending')}
+                claim={gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`}
+                duration={formatAge(gate.created_at, t)}
+              />
             </button>
           );
         }


### PR DESCRIPTION
## 변경 사항
2916-B 확定 스펙의 «3서피스 수렴» 3/3 슬라이스(F1 [PR#3342](https://github.com/moonklabs/sprintable/pull/3342)·F2 [PR#3343](https://github.com/moonklabs/sprintable/pull/3343)). F1·F2와 독립 브랜치(develop 기준).

**유나 확定① — 「밀도는 항목의 액션 무게를 따른다」:** 경량 클릭-스루 항목(inlineResolvable=false·미해소)만 row로, 3버튼 인라인 결재 카드·resolved 카드는 F3 스코프 밖(2923 「결재함 완전목록 overflow=card」가 다룰 표면 — 선점 금지, 유나가 ②안 명시 기각).

**처방:** `approvals-queue.tsx`의 `!inlineResolvable && !resolved` 분기(현행 단순 `<button onClick={router.push}>` 카드)만 `<ProofCapsule density="row">`로 셸 교체. claim=제목·duration=formatAge(그대로 재사용)·stateLabel=pending이면 「결재 대기」(F1/F2와 통일된 신규 키)·held면 기존 heldBadge 키 재사용.

**정보 축소 고지(카디르 QA 정정, 2026-08-22):** ~~F3이 새로 만든 제약 아님~~ — **부정확했습니다.** git show로 실측하니 직전 셸(gateBody)이 이 호출부에서도 실제로 gate_type 배지+risk 배지+org명을 표시하고 있었습니다. 정확히는: 이 호출부는 기존에 배지·org명을 표시했고, F3이 클릭-스루 버킷(inlineResolvable=false·미해소) 한정으로 **의도적으로 축소**했습니다(유나 확定① — 「밀도는 액션 무게를 따른다」, 낮은 액션 무게=낮은 정보 밀도). 복원이 필요하면 2923(AQ 재설계)이 다룰 몫입니다. InlineRow 자체가 애초에 그 슬롯을 안 가진 것(row 밀도의 구조적 한계)은 여전히 사실이나, "이 호출부가 원래도 안 보여줬다"는 주장은 틀렸었습니다. 기존 테스트 1건을 이 현실에 맞춰 갱신, 나머지 37건 무수정 통과.

**3버튼 카드·resolved 카드는 무변경 확認:** gateBody·GateSignatureApproval·GateUndoButton·GateDiscussDialog·서명 모달·중복실행 방지·오클릭 정정 전부 그대로 — 관련 기존 테스트 다수 무수정 통과가 그 증거.

## 셀프 게이트
- tsc/lint 0
- vitest 전체 475 files / 3932 tests green(회귀 1건 갱신+신규 2건 — approvals-queue.test.tsx 40/40)
- 대비 가드 3종 + no-handrolled-modal green
- build EXIT 0

## Test plan
- [x] tsc/lint/build/vitest 전체 그린
- [x] 3버튼 인라인 결재 카드·resolved 카드 무변경 확認(전용 테스트로)
- [ ] dev 배포 후 실 픽셀(컷코너+레일, 라이트/다크)

⚠️ `gateDetailStatusPending` 키를 F2와 동일하게 독립 추가했습니다 — F2/F3 어느 쪽이 먼저 머지되든 messages/*.json에 사소한(양쪽 다 동일 내용 추가) 머지 충돌이 날 수 있어 미리 알려둡니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)