### PR TITLE
[SID:2921] S6 오버레이 rail 투명 배경 — 뒤 GNB 텍스트 겹침

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.test.tsx
@@ -187,6 +187,11 @@ describe('ChatsLayout — story #2921 S6(xl 미만 + Reading 열림 → rail 자
     const rail = container.querySelector('[data-testid="chat-rail"]');
     expect(rail?.className).toContain('fixed');
     expect(rail?.className).toContain('z-40');
+    // story #2921 S6 후속(PO dev 라이브 실측, 2026-08-22) — 오버레이 rail에 배경이 없어
+    // 뒤 GNB 텍스트가 그대로 비쳐 가독을 깼다(docked 상태는 뒤에 아무것도 없어 안 보였다).
+    // 불투명 배경+테두리 회귀가드.
+    expect(rail?.className).toContain('bg-background');
+    expect(rail?.className).toContain('border-border');
     // 오버레이 상태에선 collapsed 전용 재호출 토글이 !hidden으로 숨고(DOM 부재 아님 — 카디르
     // #3337 QA 처방, 포커스 복귀 안정성), backdrop이 대신 뜬다(장식용 click-catcher —
     // 접근성 트리에서는 빠진다, aria-hidden).

--- a/apps/web/src/app/(authenticated)/chats/layout.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.tsx
@@ -64,8 +64,14 @@ function ChatsLayoutBody({ children }: { children: React.ReactNode }) {
   // 소스 순서로 컴파일하므로 xl:flex가 lg:hidden을 폭 ≥1280에서 CSS 캐스케이드로 자연히 이긴다).
   // railMode==='overlay'는 고정 오버레이로 뜬다 — main/reading 폭을 다시 누르지 않는다(③④).
   const railHiddenClass = railMode === 'collapsed' ? 'lg:hidden' : '';
+  // story #2921 S6 후속(PO dev 라이브 실측, 2026-08-22) — 이 fixed 분기 컨테이너에 배경이
+  // 없어(rail 자신의 base className은 border-border만 지정하고 bg-*는 어디에도 없다) docked
+  // 상태(문서 흐름 안, 뒤에 아무것도 없음)에선 안 보이던 투명 배경이 overlay(뒤에 GNB가
+  // 그대로 있는 fixed 오버레이)에서 GNB 텍스트와 겹쳐 가독을 깼다. bg-background(불투명 판)
+  // +border-r border-border(docked의 lg:border-r는 overlay 폭 구간(<1280)에서도 이미
+  // 걸리지만, 이 분기 자체에 명시해 향후 base className 리팩터에도 안전하게 둔다).
   const railOverlayClass = railMode === 'overlay'
-    ? 'fixed inset-y-0 left-0 z-40 w-[270px] shadow-xl lg:!flex xl:static xl:z-auto xl:w-[270px] xl:shadow-none'
+    ? 'fixed inset-y-0 left-0 z-40 w-[270px] bg-background shadow-xl border-r border-border lg:!flex xl:static xl:z-auto xl:w-[270px] xl:shadow-none'
     : '';
 
   return (


### PR DESCRIPTION
## 변경 사항
PO dev 라이브 실측(02555-vhl) 발견 결함 처방. 별도 소PR(F1~F3·2926 fast-follow와 분리, PO 지시).

**결함:** 중간 폭(<1280)에서 Reading 열림→rail 자동접힘 후, 좌측 핸들로 rail을 오버레이로 다시 열면 패널 배경이 `rgba(0,0,0,0)` 투명이라 뒤 GNB 텍스트(조직/구성원/워크포스…)와 rail 콘텐츠가 겹쳐 가독이 깨졌습니다. 딤(z-30 bg-black/20)은 정상 실재 — 패널 자신의 배경만 누락. docked 상태(문서 흐름 안, 뒤에 아무것도 없음)에선 안 보이던 결함이 overlay(fixed, 뒤에 GNB가 그대로 있음)에서만 드러났습니다.

**처방:** overlay 전용 클래스 분기(`railOverlayClass`)에 `bg-background`+`border-r border-border` 추가.

**회귀가드:** 기존 "오버레이(fixed)로 뜬다" 테스트에 클래스 존재 단언 추가.

**완료 판별(PO 지정):** 1279 폭·Reading 열림·rail 핸들 오버레이 상태서 패널 뒤 GNB 글자가 한 글자도 안 비침(실픽셀) — dev 배포 후 확認.

참고로 규칙③ 나머지(열림→접힘 1279/1024·경계 1280 공존·딤 클릭 닫기·X 닫기→rail 복원)는 PO 실측 전부 정상 — 이 한 겹만 남았습니다.

## 셀프 게이트
- tsc/lint 0
- vitest 전체 475 files / 3946 tests green(신규 1건)
- verify:no-handrolled-modal OK
- build EXIT 0

## Test plan
- [x] tsc/lint/build/vitest 전체 그린
- [ ] dev 배포 후 1279px·Reading 열림·오버레이 상태 실픽셀(GNB 텍스트 비침 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)