### PR TITLE
[SID:2893] feat(2893): 게이트 PR단위 슬롯 — 멱등키에 pr_number 편입 (PR①/A1)

### DIFF
--- a/apps/web/src/components/cage/story-merge-gate.tsx
+++ b/apps/web/src/components/cage/story-merge-gate.tsx
@@ -5,13 +5,16 @@ import { useTranslations } from 'next-intl';
 import { GateEvidence } from '@/components/cage/gate-evidence';
 import type { GateItem } from '@/components/kanban/types';
 import { fetchWithAuth } from '@/lib/db/client';
-
-const MERGE_GATE_TYPE = 'merge';
+import { pickRelevantMergeGate } from '@/services/verify';
 
 /**
  * H1-S8 surface②: story-detail-panel 머지 게이트 evidence 섹션(read-only). 그 스토리에 merge
  * 게이트가 있으면 `GateEvidence` 1개 노출(decision 배지 + CI/신뢰도 facts + 사유). 없으면 렌더 0
  * (빈 섹션 미표시). 액션(승인/반려)은 surface①(GateInbox)에만 — 여기는 표시만.
+ *
+ * story #2893(설계안 §2 A1) — 스토리당 merge 게이트가 여러 개(PR마다 1개)일 수 있다. 여러
+ * 개면 `pickRelevantMergeGate`(미종결 우선·동순위는 최근 PR 우선)로 하나를 골라 보인다 —
+ * 옛 "배열의 첫 번째"(사실상 무작위, 실사고1/2의 근본원인과 같은 축) 대신.
  *
  * 데이터: GET /api/gates?work_item_id=<story>&work_item_type=story (raw 배열 패스스루). story↔gate
  * 매핑 단순(BE list_gates work_item_id 필터)이라 v1 포함(기준·추가 BE 0).
@@ -27,7 +30,7 @@ export function StoryMergeGate({ storyId }: { storyId: string }) {
       .then((gates: GateItem[]) => {
         if (cancelled) return;
         const merge = Array.isArray(gates)
-          ? gates.find((g) => g.gate_type === MERGE_GATE_TYPE) ?? null
+          ? pickRelevantMergeGate(gates) ?? null
           : null;
         setGate(merge);
       })

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -24,7 +24,7 @@ import { StoryHypothesesSection } from '@/components/hypotheses/story-hypotheses
 import { StoryMergeGate } from '@/components/cage/story-merge-gate';
 import { EvidenceSection } from '@/components/verify/evidence-section';
 import { ChatProofSection, parseStoryProofReferences } from '@/components/verify/chat-proof-section';
-import { deriveInFlightTrustChip } from '@/services/verify';
+import { deriveInFlightTrustChip, pickRelevantMergeGate } from '@/services/verify';
 import { Workcell, type WorkcellMessage, type WorkcellPipelineStage } from '@/components/workcell/workcell';
 import type { ProofState, ProofCapsuleEvidence, ProofCapsuleGate, ProofCapsuleProps } from '@/components/proof-capsule/proof-capsule';
 import type { TrustSealClaimedProps, TrustSealVerifiedProps } from '@/components/verify/trust-seal';
@@ -790,7 +790,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const evidenceStateLabel = evidenceProofState
     ? { blue: t('proofCapsuleStateRunning'), amber: t('proofCapsuleStateReviewing'), green: t('proofCapsuleStateProven') }[evidenceProofState]
     : null;
-  const mergeGate = chipGates.find((g) => g.gate_type === 'merge') ?? null;
+  // story #2893(설계안 §2 A1) — 스토리당 merge 게이트가 여러 개(PR마다 1개)일 수 있어졌다.
+  // pickRelevantMergeGate(미종결 우선·동순위는 최근 PR 우선)로 하나를 고른다 — 옛
+  // "배열의 첫 번째"는 실사고1/2의 근본원인과 같은 축(어느 PR인지 무작위로 고정)이었다.
+  const mergeGate = pickRelevantMergeGate(chipGates) ?? null;
   const GATE_RISK_MAP: Record<'low' | 'high', '낮음' | '높음'> = { low: '낮음', high: '높음' };
   const ciResult = mergeGate?.neutral_facts?.['ci_result'];
   const evidenceAutoVerify: 'passed' | 'failed' | null = ciResult === 'pass' ? 'passed' : ciResult === 'fail' ? 'failed' : null;

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -71,6 +71,10 @@ export interface GateItem {
   // 가 OrgGatePolicy.posture+gate_type에서 순수 파생해 list/단건 조회 둘 다 동봉(additive). null/undefined는
   // BE가 아직 못 보낸 구버전 응답 대비 방어적 폴백일 뿐 — 정상 응답은 항상 "low"|"high" 둘 중 하나.
   risk_grade?: 'low' | 'high' | null;
+  // story #2893(설계안 §2 A1, 0271) — merge-type만 실제 값을 갖는다(PR 컨텍스트 없는 평가·
+  // PR 개념이 없는 타 gate_type은 null). 한 스토리에 merge 게이트가 여러 개(PR마다 1개)일
+  // 수 있게 된 뒤로, FE가 "이 gates 배열 중 어느 게 지금 관심 있는 PR의 것인지" 고르는 축.
+  pr_number?: number | null;
   // H1-S3 머지 verdict 게이트 evidence(GateResponse·additive·하위호환 default). null≠0(AC③).
   requires_human?: boolean;
   evidence_status?: string | null; // sufficient | blocked | insufficient

--- a/apps/web/src/services/verify.test.ts
+++ b/apps/web/src/services/verify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deriveTrustStage, deriveInFlightTrustChip } from './verify';
+import { deriveTrustStage, deriveInFlightTrustChip, pickRelevantMergeGate } from './verify';
 
 describe('deriveTrustStage (claimed-vs-verified-spec-handoff §3 파생 규칙)', () => {
   it('returns "verified" when human_verified is true (green 무결성 — human_verified가 유일한 green 조건)', () => {
@@ -55,5 +55,34 @@ describe('deriveInFlightTrustChip (trust-pipeline-minimal-decision — in-flight
       { gate_type: 'loop_decision', status: 'pending' },
       { gate_type: 'merge', status: 'pending', neutral_facts: { ci_result: 'pass' } },
     ])).toBe('merge_ready');
+  });
+});
+
+// story #2893(설계안 §2 A1) — 스토리당 merge 게이트가 여러 개(PR마다 1개)일 수 있다.
+describe('pickRelevantMergeGate (story #2893 — PR단위 게이트 중 하나를 고르는 축)', () => {
+  it('non-merge gate_type은 후보에서 제외한다', () => {
+    expect(pickRelevantMergeGate([{ gate_type: 'doc_approval', status: 'pending', pr_number: null }])).toBeUndefined();
+  });
+
+  it('merge 게이트가 없으면 undefined(정직 — 지어내지 않음)', () => {
+    expect(pickRelevantMergeGate([])).toBeUndefined();
+  });
+
+  it('미종결(pending/auto_passed/held)이 종결(approved/rejected/voided)보다 우선', () => {
+    const approved = { gate_type: 'merge', status: 'approved', pr_number: 999 };
+    const pending = { gate_type: 'merge', status: 'pending', pr_number: 1 };
+    expect(pickRelevantMergeGate([approved, pending])).toBe(pending);
+  });
+
+  it('동순위(둘 다 미종결)면 pr_number가 큰 쪽(최근 PR로 근사)이 우선', () => {
+    const older = { gate_type: 'merge', status: 'pending', pr_number: 101 };
+    const newer = { gate_type: 'merge', status: 'pending', pr_number: 102 };
+    expect(pickRelevantMergeGate([older, newer])).toBe(newer);
+  });
+
+  it('pr_number가 null인 게이트는 최하순위(실 PR 정보가 있는 쪽을 우선)', () => {
+    const noPr = { gate_type: 'merge', status: 'pending', pr_number: null };
+    const withPr = { gate_type: 'merge', status: 'pending', pr_number: 5 };
+    expect(pickRelevantMergeGate([noPr, withPr])).toBe(withPr);
   });
 });

--- a/apps/web/src/services/verify.ts
+++ b/apps/web/src/services/verify.ts
@@ -78,3 +78,30 @@ export function deriveInFlightTrustChip(storyStatus: string, gates: ChipGate[]):
   }
   return null;
 }
+
+const _TERMINAL_GATE_STATUSES = new Set(['approved', 'rejected', 'voided']);
+
+/**
+ * story #2893(설계안 §2 A1) — 한 스토리에 merge 게이트가 여러 개(PR마다 1개)일 수 있게 됐다.
+ * "이 스토리의 merge 게이트"를 단건으로 보여주는 화면(StoryMergeGate·Workcell Evidence
+ * 구획)이 이제 «어느 PR 것을 보여줄지» 골라야 한다 — 옛 `.find(g => g.gate_type==='merge')`
+ * (배열의 첫 번째, 삽입순=사실상 무작위)를 대체.
+ *
+ * 우선순위: ①미종결(pending/auto_passed/held — 지금 사람 눈이 필요한 것)이 종결(approved/
+ * rejected/voided)보다 우선 ②동순위 중엔 pr_number가 큰 쪽(가장 최근 열린 PR으로 근사).
+ * pr_number가 없는(레거시/PR 컨텍스트 없음) 게이트는 항상 최하순위(0 취급, 실 PR 정보가
+ * 있는 쪽을 우선 — 지어내지 않되 있으면 쓴다).
+ */
+export function pickRelevantMergeGate<G extends { gate_type: string; status: string; pr_number?: number | null }>(
+  gates: G[],
+): G | undefined {
+  const mergeGates = gates.filter((g) => g.gate_type === 'merge');
+  if (mergeGates.length === 0) return undefined;
+  const sorted = [...mergeGates].sort((a, b) => {
+    const aOpen = _TERMINAL_GATE_STATUSES.has(a.status) ? 0 : 1;
+    const bOpen = _TERMINAL_GATE_STATUSES.has(b.status) ? 0 : 1;
+    if (aOpen !== bOpen) return bOpen - aOpen; // 미종결 먼저.
+    return (b.pr_number ?? 0) - (a.pr_number ?? 0); // 큰 pr_number(최근 PR) 먼저.
+  });
+  return sorted[0];
+}

--- a/backend/alembic/versions/0271_gate_pr_scoped_slot.py
+++ b/backend/alembic/versions/0271_gate_pr_scoped_slot.py
@@ -1,0 +1,77 @@
+"""story #2893(설계안 gate-auto-creation-design-2893 §2 A1) — gate PR단위 슬롯.
+
+같은 스토리에 열린 PR이 복수면 merge-type gate가 «work_item_id+gate_type» 1슬롯을
+공유해 나중 push한 PR의 SHA로 재바인딩됐다(실사고1/2 — story #2893 AC 본문). 멱등 키에
+`pr_number`를 편입해 PR마다 독립 gate row를 갖게 한다 — PR A 서명이 PR B의 SHA를
+물 수 있는 구조 자체를 없앤다(재-pending 로직으로 사후 보정하는 게 아니라 격리가
+설계로 보장됨).
+
+백필: GitHub API 역조회 불요 — `evaluate_merge_gate()`가 매 호출마다
+`neutral_facts.pr_number`를 이미 적어 왔다(merge_verdict_gate.py facts dict, story
+#2156부터). 기존 merge-type row는 거기서 그대로 끌어온다. pr_number<=0(board-preflight
+"no-substance" 경로, PR 컨텍스트 자체가 없던 평가)은 의도적으로 NULL 유지 — 있지도
+않은 PR 번호를 지어내지 않는다. merge 이외 gate_type(doc_approval 등)은 애초에 PR
+개념이 없어 항상 NULL.
+
+제약 재설계: 기존 `uq_gate_work_item_gate_type UNIQUE(org_id, work_item_id,
+work_item_type, gate_type)`을 그대로 두면 PG가 NULL 여러 개를 허용해(NULL≠NULL) PR
+미상 gate들의 "스토리당 1행" 보장이 통째로 사라진다 — 부분 유니크 인덱스 2개로
+쪼갠다: pr_number IS NULL 구간은 옛 계약 그대로(스토리+gate_type당 1행), pr_number IS
+NOT NULL 구간은 새 계약(스토리+gate_type+PR당 1행). 두 구간은 겹치지 않으므로(NULL
+XOR NOT NULL) 합쳐서 "같은 일을 두 번 허용"하는 사각은 없다.
+
+Revision ID: 0271
+Revises: 0270
+Create Date: 2026-08-22
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0271"
+down_revision = "0270"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("gate", sa.Column("pr_number", sa.Integer(), nullable=True))
+
+    op.execute(
+        """
+        UPDATE gate
+        SET pr_number = (neutral_facts->>'pr_number')::integer
+        WHERE gate_type = 'merge'
+          AND neutral_facts ? 'pr_number'
+          AND (neutral_facts->>'pr_number') ~ '^[0-9]+$'
+          AND (neutral_facts->>'pr_number')::integer > 0
+        """
+    )
+
+    op.drop_constraint("uq_gate_work_item_gate_type", "gate", type_="unique")
+    op.create_index(
+        "uq_gate_work_item_gate_type_no_pr",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type"],
+        unique=True,
+        postgresql_where=sa.text("pr_number IS NULL"),
+    )
+    op.create_index(
+        "uq_gate_work_item_gate_type_pr",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type", "pr_number"],
+        unique=True,
+        postgresql_where=sa.text("pr_number IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_gate_work_item_gate_type_pr", table_name="gate")
+    op.drop_index("uq_gate_work_item_gate_type_no_pr", table_name="gate")
+    op.create_unique_constraint(
+        "uq_gate_work_item_gate_type",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type"],
+    )
+    op.drop_column("gate", "pr_number")

--- a/backend/alembic/versions/0271_gate_pr_scoped_slot.py
+++ b/backend/alembic/versions/0271_gate_pr_scoped_slot.py
@@ -67,6 +67,31 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # 카디르 QA(PR#3349, 2026-08-22, codex 소스분석 예측→실 재현 확定) — 같은 4-튜플
+    # (org_id, work_item_id, work_item_type, gate_type)에 pr_number만 다른 행이 2개 이상
+    # 실존하면(=이 마이그 upgrade의 목적 자체가 만드는 정상 상태) 옛 4열 UNIQUE 복원이
+    # UniqueViolation으로 막혀 downgrade 자체가 죽는다. 옛 스키마엔 pr_number 컬럼이
+    # 없으므로 "무손실 복원"은 구조상 불가능 — **lossy 복원**(PO 확定): 그룹당 pr_number가
+    # 가장 큰(=가장 최근 PR) 행만 남기고 나머지를 삭제한 뒤 제약을 되돌린다. NULL은
+    # NULLS LAST(최하순위) — PR 컨텍스트가 있는 행이 없는 행보다 항상 우선한다(FE
+    # pickRelevantMergeGate/verify.ts의 "최근 PR 우선"과 같은 축의 판단). 어느 행이
+    # 살아남는지는 이 규칙 하나뿐 — 애매하게 두지 않는다.
+    op.execute(
+        """
+        DELETE FROM gate
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT id,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY org_id, work_item_id, work_item_type, gate_type
+                           ORDER BY pr_number DESC NULLS LAST, id DESC
+                       ) AS rn
+                FROM gate
+            ) ranked
+            WHERE rn > 1
+        )
+        """
+    )
     op.drop_index("uq_gate_work_item_gate_type_pr", table_name="gate")
     op.drop_index("uq_gate_work_item_gate_type_no_pr", table_name="gate")
     op.create_unique_constraint(

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -19,7 +19,7 @@ neutral_facts: 관찰 사실만 (touches_migration, diff_size 등).
 import uuid
 from datetime import datetime
 
-from sqlalchemy import BigInteger, Boolean, DateTime, String, Text, func, text
+from sqlalchemy import BigInteger, Boolean, DateTime, Integer, String, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -64,6 +64,13 @@ class Gate(Base):
     work_item_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     work_item_type: Mapped[str] = mapped_column(String(20), nullable=False)
     gate_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    # story #2893(0271) — 멱등 키 확장: (org_id, work_item_id, work_item_type, gate_type)
+    # 1슬롯 공유가 「PR A 서명이 PR B의 SHA를 뭄」실사고(설계안 §2 A1)의 근본원인이었다.
+    # NULL=PR 컨텍스트 없음(board-preflight no-substance 경로) 또는 애초에 PR 개념이 없는
+    # gate_type(doc_approval 등) — 지어내지 않는다. DB 제약은 0271에서 부분 유니크 인덱스
+    # 2개로 분리(NULL 구간=옛 계약 그대로, NOT NULL 구간=+pr_number). create_gate() 호출부
+    # 전수는 gate_service.py 참조.
+    pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
     status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="pending")
     resolver_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -145,6 +145,11 @@ class GateResponse(BaseModel):
     # decider 버튼 게이팅 소스(parallel-approver 목록 아님). 비-doc/무자격/비-휴먼은 False(fail-closed·
     # additive 하위호환). ⚠️실 authz 는 BE transition 강제(이 필드는 가시성뿐). [[can_approve_doc_gate_reason]]
     can_approve: bool = False
+    # story #2893(설계안 §2 A1, 0271) — merge-type만 실제 값을 갖는다(PR 컨텍스트 없는
+    # 평가·PR 개념이 없는 타 gate_type은 None). FE가 "이 스토리의 여러 merge 게이트 중
+    # 어느 PR 것인지" 고르는 축. additive·Gate ORM 컬럼과 이름 일치라 from_attributes로
+    # 자동 채워짐(github_check_run_sha와 동일 선례).
+    pr_number: int | None = None
     # story #1972(P1a-S4): 게이트 위험도 UX 등급 — **새 위험도 판정 필드가 아니다**. 기존
     # OrgGatePolicy.posture + Gate.gate_type을 순수 파생(gate_service.derive_risk_grade)한 UX
     # 힌트일 뿐(doc `gate-risk-ux-classification-criteria` §2 SSOT). "risk_level" 이름은 의도적으로

--- a/backend/app/routers/glance.py
+++ b/backend/app/routers/glance.py
@@ -259,9 +259,19 @@ async def glance_attention(
 
     # ⑤ verify_fail = 프로젝트의 오픈 story 중 검증(merge gate) 실패(glance/hero의 기존
     # evidence_status=="blocked" 계약 재사용).
+    #
+    # 카디르 QA(PR#3349, 2026-08-22) — story #2893(§2 A1)부터 merge gate가 스토리당 여러 개일
+    # 수 있다(PR마다 1행). 예전(gate-row 기준 select, dedup 없음)엔 같은 스토리가 blocked인
+    # merge gate 수만큼 중복 노출됐고, LIMIT이 gate-row를 세다 보니 실제로는 서로 다른
+    # 스토리인데 화면에 못 뜨는(밀리는) 사용자 도달 실갭이었다. Story.id/title로 GROUP BY해
+    # ①중복 제거 ②LIMIT을 "스토리 수" 기준으로 되돌린다. entered_at은 MIN(가장 먼저
+    # blocked에 들어간 시각) — 유나 설계(체류시간이 위계를 만든다)와 같은 축: 스토리가
+    # blocked로 «가장 오래» 묶여 있던 시점을 보여줘야 밀린 순서가 거짓으로 짧아지지 않는다.
+    # 나머지 3곳(trust_pipeline/merge_gate_metrics/goal 리포지토리)은 동일 갭이 있을 수 있으나
+    # PR① 스코프 밖 후속으로 유지(PR① 본문 명기).
     verify_fail_rows = (
         await session.execute(
-            select(Story.id, Story.title, Gate.evidence_status_entered_at)
+            select(Story.id, Story.title, func.min(Gate.evidence_status_entered_at))
             .select_from(Gate)
             .join(Story, (Story.id == Gate.work_item_id) & (Gate.work_item_type == "story"))
             .where(
@@ -272,6 +282,7 @@ async def glance_attention(
                 Story.status.not_in(_OPEN_EXCLUDED_STATUSES),
                 Story.deleted_at.is_(None),
             )
+            .group_by(Story.id, Story.title)
             .limit(_LIMIT)
         )
     ).all()

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -450,23 +450,23 @@ async def _process_webhook_event(
         and head_sha
         and gate_check_publish is not None
     ):
-        from app.models.gate import Gate as _Gate
         from app.services.gate_github_check import reopen_gate_if_new_sha
+        from app.services.gate_service import find_gate_slot_with_pr_fallback
         from app.services.merge_verdict_gate import MERGE_GATE_TYPE as _MERGE_GATE_TYPE
 
         # story #2893(설계안 §2 A1) — pr_number 없이 조회하면 같은 스토리의 다른 열린 PR
         # 게이트를 집어 그 게이트를 "이 PR"의 새 SHA로 재-pending 시켜버린다(실사고1/2
         # 그 자체). PR-scoped 게이트가 없으면(None) else 분기가 evaluate_merge_gate로
         # 정확히 이 PR용 게이트를 새로 만든다 — 기존 동작(#2826 auto-create)과 동형.
-        merge_gate = (
-            await session.execute(
-                select(_Gate).where(
-                    _Gate.org_id == org_id, _Gate.work_item_id == story_id,
-                    _Gate.work_item_type == "story", _Gate.gate_type == _MERGE_GATE_TYPE,
-                    _Gate.pr_number == (pr_number if pr_number > 0 else None),
-                )
-            )
-        ).scalar_one_or_none()
+        #
+        # 카디르 QA(PR#3349 CI 실패, 2026-08-22) — 정확매치 only는 line-engine/board-
+        # preflight self-report shell(NULL 슬롯)이 이 PR로 처음 연결되는 순간을 "게이트
+        # 없음"으로 오판해 evaluate_merge_gate가 별도 행을 또 만들 뻔했다(다른 3곳과 동일
+        # 클래스 결함) — find_gate_slot_with_pr_fallback로 나머지 3곳과 동일하게 통일.
+        merge_gate = await find_gate_slot_with_pr_fallback(
+            session, org_id=org_id, work_item_id=story_id, work_item_type="story",
+            gate_type=_MERGE_GATE_TYPE, pr_number=(pr_number if pr_number > 0 else None),
+        )
         if merge_gate is not None:
             await reopen_gate_if_new_sha(
                 session, org_id, merge_gate, head_sha,

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -454,11 +454,16 @@ async def _process_webhook_event(
         from app.services.gate_github_check import reopen_gate_if_new_sha
         from app.services.merge_verdict_gate import MERGE_GATE_TYPE as _MERGE_GATE_TYPE
 
+        # story #2893(설계안 §2 A1) — pr_number 없이 조회하면 같은 스토리의 다른 열린 PR
+        # 게이트를 집어 그 게이트를 "이 PR"의 새 SHA로 재-pending 시켜버린다(실사고1/2
+        # 그 자체). PR-scoped 게이트가 없으면(None) else 분기가 evaluate_merge_gate로
+        # 정확히 이 PR용 게이트를 새로 만든다 — 기존 동작(#2826 auto-create)과 동형.
         merge_gate = (
             await session.execute(
                 select(_Gate).where(
                     _Gate.org_id == org_id, _Gate.work_item_id == story_id,
                     _Gate.work_item_type == "story", _Gate.gate_type == _MERGE_GATE_TYPE,
+                    _Gate.pr_number == (pr_number if pr_number > 0 else None),
                 )
             )
         ).scalar_one_or_none()

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -433,8 +433,15 @@ async def create_gate(
     project_id: uuid.UUID | None = None,
     notify: bool = True,
     gate_id: uuid.UUID | None = None,
+    pr_number: int | None = None,
 ) -> Gate:
     """config 기반 게이트 생성 (멱등: 이미 있으면 기존 반환).
+
+    pr_number: story #2893(설계안 §2 A1) — merge-type만 실제로 쓴다(호출부는
+    evaluate_merge_gate 하나뿐, 그라운딩 확認). 나머지 7개 호출부는 인자를 안 넘겨
+    기본값 None 그대로 — 멱등 키가 `(work_item_id, work_item_type, gate_type)` 옛
+    계약대로 유지된다(무회귀). None이면 "PR 컨텍스트 없음"을 지어내지 않고 그대로 둔다
+    (0 같은 sentinel로 바꾸지 않음 — DB 컬럼 자체가 nullable Integer).
 
     gate_id: story #2709(2026-08-17, PO 판정) — self-referencing standalone anchor(work_item이
     없는 순수 질문류 gate_type)를 위한 파라미터. 호출측(MCP 도구)이 uuid4를 미리 만들어
@@ -457,13 +464,16 @@ async def create_gate(
     全 호출부 무회귀). gate_type/work_item_type별 하드코딩 대신 호출부 판단으로 남겨 이 함수의
     공용 chokepoint 성격을 유지한다.
     """
-    # 멱등: 이미 존재하면 기존 반환
+    # 멱등: 이미 존재하면 기존 반환. story #2893 — pr_number도 키에 편입(0271 부분
+    # 유니크 인덱스와 동형 조건: 둘 다 None이면 NULL=NULL 매치가 아니라 `==` 연산자가
+    # SQLAlchemy에서 자동으로 IS NULL로 번역되므로 그대로 동작한다).
     existing_r = await session.execute(
         select(Gate).where(
             Gate.org_id == org_id,
             Gate.work_item_id == work_item_id,
             Gate.work_item_type == work_item_type,
             Gate.gate_type == gate_type,
+            Gate.pr_number == pr_number,
         ).limit(1)
     )
     existing = existing_r.scalar_one_or_none()
@@ -494,6 +504,7 @@ async def create_gate(
         work_item_id=work_item_id,
         work_item_type=work_item_type,
         gate_type=gate_type,
+        pr_number=pr_number,
         status=status,
         # #2156 AC3(2026-08-07) — merge-type만 evaluate_merge_gate가 이후 이 필드를 정확히
         # 채웠고(decision 기반), 그 외 gate_type(qa·pr_review·deploy 등)은 create_gate가 여태

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -421,6 +421,70 @@ async def _reopen_rejected_gate(
     return gate
 
 
+async def find_gate_slot_with_pr_fallback(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    work_item_id: uuid.UUID,
+    work_item_type: str,
+    gate_type: str,
+    pr_number: int | None,
+) -> Gate | None:
+    """story #2893(§2 A1, 0271) 후속 — 카디르 QA(PR#3349 CI 실 실패 2건, 2026-08-22):
+    pr_number를 멱등 키에 편입한 것(정확매치 only)이 「PR 컨텍스트가 나중에 밝혀지는」
+    정상 케이스까지 «다른 PR»과 똑같이 취급해 새 행을 만들며 옛 행을 고아화시켰다 —
+    ①line-engine/board-preflight self-report shell(pr_number 모름, NULL) 後 실 PR이
+    연결되는 경우 ②legacy/백필 누락 행의 재제출(rejected reopen). A1의 취지는 «서로
+    다른 PR 간 격리»지 「PR 컨텍스트가 나중에 채워지는 같은 게이트의 분열」이 아니다
+    (PO 확定).
+
+    pr_number가 주어지면(실 PR 문맥) 먼저 그 PR 전용 슬롯을 정확매치로 찾는다. 없으면
+    아직 pr_number를 모르던 시절의 NULL-슬롯이 있는지 찾아 **승격**(pr_number를 채워
+    재사용 — flush까지 이 함수 책임, 호출자가 추가로 flush 안 해도 이후 조회에
+    반영됨)한다. 승격 後엔 그 행이 이 PR에 귀속되므로(정확매치 슬롯으로 편입) 다른 PR이
+    같은 NULL-슬롯을 다시 가로챌 길이 없다 — 실사고1/2가 막던 축(서로 다른 PR의 SHA가
+    같은 슬롯을 공유)은 그대로 보존된다(승격은 "미상→특정 PR" 1회성 전이일 뿐, "PR A→PR
+    B" 전이는 이 함수가 만들어내지 않는다).
+
+    pr_number가 None(PR 컨텍스트가 원래 없는 gate_type 또는 board-preflight no-substance)
+    이면 옛 계약 그대로 NULL-슬롯만 찾는다 — 승격 대상 자체가 없다("PR 컨텍스트 있음"으로
+    바꿀 근거가 없다)."""
+    if pr_number is not None:
+        exact = (
+            await session.execute(
+                select(Gate).where(
+                    Gate.org_id == org_id, Gate.work_item_id == work_item_id,
+                    Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
+                    Gate.pr_number == pr_number,
+                )
+            )
+        ).scalar_one_or_none()
+        if exact is not None:
+            return exact
+        null_slot = (
+            await session.execute(
+                select(Gate).where(
+                    Gate.org_id == org_id, Gate.work_item_id == work_item_id,
+                    Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
+                    Gate.pr_number.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+        if null_slot is not None:
+            null_slot.pr_number = pr_number
+            await session.flush()
+        return null_slot
+    return (
+        await session.execute(
+            select(Gate).where(
+                Gate.org_id == org_id, Gate.work_item_id == work_item_id,
+                Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
+                Gate.pr_number.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+
+
 async def create_gate(
     session: AsyncSession,
     org_id: uuid.UUID,
@@ -465,18 +529,13 @@ async def create_gate(
     공용 chokepoint 성격을 유지한다.
     """
     # 멱등: 이미 존재하면 기존 반환. story #2893 — pr_number도 키에 편입(0271 부분
-    # 유니크 인덱스와 동형 조건: 둘 다 None이면 NULL=NULL 매치가 아니라 `==` 연산자가
-    # SQLAlchemy에서 자동으로 IS NULL로 번역되므로 그대로 동작한다).
-    existing_r = await session.execute(
-        select(Gate).where(
-            Gate.org_id == org_id,
-            Gate.work_item_id == work_item_id,
-            Gate.work_item_type == work_item_type,
-            Gate.gate_type == gate_type,
-            Gate.pr_number == pr_number,
-        ).limit(1)
+    # 유니크 인덱스와 동형 조건). find_gate_slot_with_pr_fallback가 정확매치 우선+
+    # NULL-슬롯 승격 폴백까지 처리(카디르 QA, PR#3349 CI 실패 2건 후속 — pr_number가
+    # 나중에 밝혀지는 정상 케이스를 다른 PR과 혼동해 고아 행을 만들던 결함).
+    existing = await find_gate_slot_with_pr_fallback(
+        session, org_id=org_id, work_item_id=work_item_id,
+        work_item_type=work_item_type, gate_type=gate_type, pr_number=pr_number,
     )
-    existing = existing_r.scalar_one_or_none()
     if existing is not None:
         # story #2150 근본수정: rejected는 재제출 시 새 결재 사이클을 연다(그 외 terminal
         # status는 기존 그대로 불변 반환 — 판단 근거는 _reopen_rejected_gate 참조).

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -387,16 +387,23 @@ async def evaluate_merge_gate(
     # story #1968: 이 함수는 story_id(uuid)만 갖고 Story 객체를 로드하지 않으므로(participation/
     # verdict/trust 경로 전부 story_id만 소비) resolve_work_item_project_id()로 신규 조회.
     project_id = await resolve_work_item_project_id(session, org_id, "story", story_id)
+    # story #2893(설계안 §2 A1) — pr_number<=0(no-substance/board-preflight, PR 컨텍스트
+    # 자체가 없음)은 DB에 0을 지어내지 않고 NULL로 정직하게 유지. 0271의 부분 유니크
+    # 인덱스가 NULL 구간=옛 "스토리+gate_type당 1행" 계약을 그대로 지킨다.
+    db_pr_number = pr_number if pr_number > 0 else None
     # story #2118(E-DG-REAL ②): create_gate()가 이미 pending인 기존 gate를 멱등 반환할 때(예:
     # report-done/board-preflight가 이 함수를 반복 호출)마다 승인요청 카드를 중복 배달하지 않으려면
     # "이 호출에서 방금 pending이 됐는지"(신규 생성 또는 rejected/voided→재오픈)를 알아야 한다 —
     # create_gate()는 그 신호를 반환하지 않으므로(반환형 변경은 8개 호출부 전체에 영향, 스코프 밖)
-    # 호출 *전* 상태를 가볍게 먼저 조회해 비교한다(create_gate 내부의 멱등 조회와 동형 SELECT,
-    # 신규 인덱스 불필요 — uq(work_item_id, work_item_type, gate_type) 이미 있음).
+    # 호출 *전* 상태를 가볍게 먼저 조회해 비교한다(create_gate 내부의 멱등 조회와 동형 SELECT).
+    # story #2893 — pr_number를 키에 편입(0271): 안 넣으면 "이 PR의 게이트가 방금
+    # pending이 됐는지"가 아니라 "같은 스토리 다른 PR의 상태"를 잘못 비교해 카드
+    # 배달 판정이 어긋난다(그 PR 실사고류와 동일 클래스).
     _prior_status = (await session.execute(
         select(Gate.status).where(
             Gate.org_id == org_id, Gate.work_item_id == story_id,
             Gate.work_item_type == "story", Gate.gate_type == MERGE_GATE_TYPE,
+            Gate.pr_number == db_pr_number,
         )
     )).scalar_one_or_none()
     gate = await create_gate(
@@ -409,6 +416,7 @@ async def evaluate_merge_gate(
         role_id,
         project_id=project_id,
         neutral_facts=facts,
+        pr_number=db_pr_number,
     )
 
     # 재제출 re-open(doc-gate 48f064e5 선례 이식): uq(work_item,gate_type)=1행 + terminal=immutable
@@ -594,12 +602,17 @@ async def reconcile_merge_gate_with_real_evidence(
     부른다. 이 함수를 `capture_pr_ci_verdict` 본문 안에서 부르면 무한 재귀가 된다 — 반드시
     그 호출부(웹훅 핸들러 등) 쪽에서, `capture_pr_ci_verdict` 리턴 後에 별도로 부를 것.
     """
+    # story #2893(설계안 §2 A1) — pr_number를 키에 편입: 안 넣으면 "이 웹훅이 나른 PR B의
+    # CI/merge 증거"로 story의 아무 pending/auto_passed 게이트(실은 PR A 것일 수 있음)를
+    # 재평가해버린다 — 실사고1/2와 정확히 같은 클래스(엉뚱한 PR의 SHA/증거가 다른 PR의
+    # 게이트에 새는 것).
     existing = await session.execute(
         select(Gate).where(
             Gate.org_id == org_id,
             Gate.work_item_id == story_id,
             Gate.work_item_type == "story",
             Gate.gate_type == MERGE_GATE_TYPE,
+            Gate.pr_number == (pr_number if pr_number > 0 else None),
             Gate.status.in_(("pending", "auto_passed")),
         ).limit(1)
     )

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -29,7 +29,11 @@ from app.services.gate_resolver import (
     SOURCE_ORG_POLICY,
     resolve_disposition,
 )
-from app.services.gate_service import create_gate, resolve_work_item_project_id
+from app.services.gate_service import (
+    create_gate,
+    find_gate_slot_with_pr_fallback,
+    resolve_work_item_project_id,
+)
 from app.services.trust_score import compute_member_trust_scores
 from app.services.verdict_capture import (
     capture_pr_ci_verdict,
@@ -398,14 +402,14 @@ async def evaluate_merge_gate(
     # 호출 *전* 상태를 가볍게 먼저 조회해 비교한다(create_gate 내부의 멱등 조회와 동형 SELECT).
     # story #2893 — pr_number를 키에 편입(0271): 안 넣으면 "이 PR의 게이트가 방금
     # pending이 됐는지"가 아니라 "같은 스토리 다른 PR의 상태"를 잘못 비교해 카드
-    # 배달 판정이 어긋난다(그 PR 실사고류와 동일 클래스).
-    _prior_status = (await session.execute(
-        select(Gate.status).where(
-            Gate.org_id == org_id, Gate.work_item_id == story_id,
-            Gate.work_item_type == "story", Gate.gate_type == MERGE_GATE_TYPE,
-            Gate.pr_number == db_pr_number,
-        )
-    )).scalar_one_or_none()
+    # 배달 판정이 어긋난다(그 PR 실사고류와 동일 클래스). 카디르 QA(PR#3349 CI 실패①,
+    # 2026-08-22) — 정확매치 only는 이 바로 아래 create_gate() 호출이 찾을 행(NULL-슬롯
+    # 승격 포함)과 다른 답을 낼 수 있어 fallback 헬퍼로 통일한다(같은 물음엔 같은 답).
+    _prior_gate = await find_gate_slot_with_pr_fallback(
+        session, org_id=org_id, work_item_id=story_id, work_item_type="story",
+        gate_type=MERGE_GATE_TYPE, pr_number=db_pr_number,
+    )
+    _prior_status = _prior_gate.status if _prior_gate is not None else None
     gate = await create_gate(
         session,
         org_id,
@@ -606,17 +610,14 @@ async def reconcile_merge_gate_with_real_evidence(
     # CI/merge 증거"로 story의 아무 pending/auto_passed 게이트(실은 PR A 것일 수 있음)를
     # 재평가해버린다 — 실사고1/2와 정확히 같은 클래스(엉뚱한 PR의 SHA/증거가 다른 PR의
     # 게이트에 새는 것).
-    existing = await session.execute(
-        select(Gate).where(
-            Gate.org_id == org_id,
-            Gate.work_item_id == story_id,
-            Gate.work_item_type == "story",
-            Gate.gate_type == MERGE_GATE_TYPE,
-            Gate.pr_number == (pr_number if pr_number > 0 else None),
-            Gate.status.in_(("pending", "auto_passed")),
-        ).limit(1)
+    # 카디르 QA(PR#3349 CI 실패②, 2026-08-22) — 정확매치 only 조회는 line-engine/board-
+    # preflight self-report shell(pr_number 모름, NULL로 생성)이 나중에 실 PR로 reconcile
+    # 되는 정상 경로를 놓친다(gate_service.find_gate_slot_with_pr_fallback 참조).
+    existing = await find_gate_slot_with_pr_fallback(
+        session, org_id=org_id, work_item_id=story_id, work_item_type="story",
+        gate_type=MERGE_GATE_TYPE, pr_number=(pr_number if pr_number > 0 else None),
     )
-    if existing.scalar_one_or_none() is None:
+    if existing is None or existing.status not in ("pending", "auto_passed"):
         return None
     return await evaluate_merge_gate(
         session, org_id, story_id,

--- a/backend/tests/test_1968_gate_project_id_threading.py
+++ b/backend/tests/test_1968_gate_project_id_threading.py
@@ -199,7 +199,16 @@ async def test_merge_gate_threads_resolved_project_id():
     from app.services import merge_verdict_gate as mvg
 
     org_id, story_id, project_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    # 카디르 QA(PR#3349 재재verdict, 2026-08-22) — evaluate_merge_gate가 이제 내부에서
+    # find_gate_slot_with_pr_fallback(session.execute 최대 2회)를 거친다. 완전 미설정
+    # AsyncMock()은 `.scalar_one_or_none()`(동기 메서드)까지 AsyncMock 자손이라 호출 시
+    # 「awaited 안 된 coroutine」을 그대로 반환해(is not None) "게이트 찾음"으로 오판,
+    # `.status` 접근에서 AttributeError. session.execute(...)가 항상 "게이트 없음"을
+    # 뜻하는 동기 결과를 반환하도록 미리 배선한다.
     session = AsyncMock()
+    _no_row = MagicMock()
+    _no_row.scalar_one_or_none = MagicMock(return_value=None)
+    session.execute = AsyncMock(return_value=_no_row)
     part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4())
     gate = SimpleNamespace(id=uuid.uuid4(), status="auto_passed", evidence_status=None)
 

--- a/backend/tests/test_2156_merge_gate_evidence_realdb.py
+++ b/backend/tests/test_2156_merge_gate_evidence_realdb.py
@@ -545,7 +545,10 @@ async def test_gate_check_publish_fires_on_base_retarget_edit_when_story_linked(
     installation_result.scalar_one_or_none = lambda: installation
     no_gate_result = AsyncMock()
     no_gate_result.scalar_one_or_none = lambda: None  # 기존 merge Gate row 없음 → evaluate 분기.
-    session.execute = AsyncMock(side_effect=[installation_result, no_gate_result])
+    # story #2893 후속(카디르 QA, PR#3349 CI 실패 2건) — find_gate_slot_with_pr_fallback가
+    # 정확매치(없음) 後 NULL-슬롯 폴백까지 조회한다(2 SELECT). 이 테스트는 둘 다 "없음"인
+    # 시나리오(진짜 신규)라 두 번째 자리도 no_gate_result 재사용으로 충분.
+    session.execute = AsyncMock(side_effect=[installation_result, no_gate_result, no_gate_result])
     evaluate = AsyncMock(return_value=SimpleNamespace(gate_id=gate_id))
     gate_check_publish: list[dict] = []
 

--- a/backend/tests/test_2156_merge_gate_evidence_realdb.py
+++ b/backend/tests/test_2156_merge_gate_evidence_realdb.py
@@ -183,7 +183,14 @@ async def test_reconcile_updates_pending_merge_gate_with_real_evidence_realdb():
     """⭐핵심 — reconcile_merge_gate_with_real_evidence가 실 ci/pr 증거로 pending merge 게이트를
     재평가한다. cold-start(outcome 표본 0<3)라 최종 decision은 여전히 ask_human이지만, 그
     reason이 "CI unknown"에서 "outcome sample insufficient"로 바뀐다 — 실 증거가 게이트에
-    도달했다는 관측 가능한 증거."""
+    도달했다는 관측 가능한 증거.
+
+    story #2893(§2 A1, 0271) 갱신 — 멱등 키가 pr_number를 포함한다. 두 호출을 **같은 PR
+    번호(42)**로 통일 — 이게 실제 프로덕션 체인과도 정합된다(reconcile은 verdict_capture.py
+    웹훅 핸들러에서만 불리고, 그 핸들러는 실 PR 이벤트에서만 pr_number를 뽑아 항상 >0이다
+    — pr_number=0인 reconcile 호출은 애초에 실사용 경로가 아니다). 다른 PR 번호로 만든
+    게이트에 이 증거가 새면 안 된다는 게 정확히 이 스토리의 요지 — 그 회귀가드는
+    test_2893_gate_pr_scoped_isolation_realdb가 전담한다."""
     from app.services.merge_verdict_gate import evaluate_merge_gate, reconcile_merge_gate_with_real_evidence
 
     engine, Session = await _session_factory()
@@ -202,7 +209,7 @@ async def test_reconcile_updates_pending_merge_gate_with_real_evidence_realdb():
             ):
                 await evaluate_merge_gate(
                     s, seeded["org_id"], seeded["story_id"],
-                    pr_number=0, repo="", ci_result=None, pr_result=None,
+                    pr_number=42, repo="", ci_result=None, pr_result=None,
                 )
                 await s.commit()
 

--- a/backend/tests/test_2249_glance_entered_state_at_realdb.py
+++ b/backend/tests/test_2249_glance_entered_state_at_realdb.py
@@ -345,3 +345,56 @@ async def test_entered_state_at_is_optional_and_backward_compatible():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_verify_fail_dedups_by_story_when_multiple_blocked_merge_gates():
+    """카디르 QA(PR#3349, 2026-08-22) — story #2893(§2 A1)부터 merge gate가 스토리당 여러 개
+    (PR마다 1행)일 수 있다. 같은 스토리의 merge gate 2개가 동시에 evidence_status='blocked'
+    여도 verify_fail 항목은 **스토리당 1개**만 나와야 한다(중복 노출 회귀가드) — entered_at은
+    그중 더 이른(=더 오래 blocked인) 시각(MIN)이어야 한다(체류시간 위계 설계와 정합)."""
+    from app.main import app
+    from app.models.gate import Gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story = _story(seeded["org_id"], seeded["project_id"], "Multi-PR Verify Fail Story")
+            s.add(story)
+            await s.commit()
+
+            older_entered = datetime(2026, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+            newer_entered = datetime(2026, 8, 10, 0, 0, 0, tzinfo=timezone.utc)
+            s.add_all([
+                Gate(
+                    id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id,
+                    work_item_type="story", gate_type="merge", status="pending",
+                    pr_number=1, evidence_status="blocked",
+                    evidence_status_entered_at=older_entered,
+                ),
+                Gate(
+                    id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id,
+                    work_item_type="story", gate_type="merge", status="pending",
+                    pr_number=2, evidence_status="blocked",
+                    evidence_status_entered_at=newer_entered,
+                ),
+            ])
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["items"]
+
+            vf_items = [i for i in items if i["kind"] == "verify_fail" and i["story_id"] == str(story.id)]
+            assert len(vf_items) == 1, f"스토리당 1개여야 하는데 {len(vf_items)}개 중복 노출됨"
+            got = datetime.fromisoformat(vf_items[0]["entered_state_at"].replace("Z", "+00:00"))
+            assert got == older_entered, "MIN(evidence_status_entered_at) — 더 오래 blocked인 시각이어야 함"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_2813_gate_github_check_realdb.py
+++ b/backend/tests/test_2813_gate_github_check_realdb.py
@@ -903,7 +903,12 @@ async def test_evaluate_merge_gate_clears_auto_axis_anchor_when_decision_leaves_
 async def test_evaluate_merge_gate_never_clears_human_approved_anchor_realdb():
     """카디르 R4① 안전경계 — `gate.status=="approved"`(사람 승인, gates.py 축)는
     evaluate_merge_gate 재평가가 **절대** 못 건드린다. 시스템 재평가가 사람 결재를 역전시키면
-    사고이므로, 클리어 조건은 반드시 `gate.status=="auto_passed"`로만 스코프돼야 한다."""
+    사고이므로, 클리어 조건은 반드시 `gate.status=="auto_passed"`로만 스코프돼야 한다.
+
+    story #2893(§2 A1, 0271) 갱신 — 멱등 키가 pr_number를 포함한다. 최초 create_gate에도
+    아래 evaluate_merge_gate와 같은 pr_number(99)를 넘겨 «같은 PR이 재평가되는» 실 시나리오와
+    일치시킨다(다른 pr_number면 서로 다른 gate row가 돼 재평가 자체가 이 게이트에 안 닿는다
+    — 그건 이 테스트의 관심사가 아니라 test_2893_gate_pr_scoped_isolation_realdb의 관심사)."""
     from app.services.gate_service import create_gate
     from app.services.merge_verdict_gate import BLOCK, MERGE_GATE_TYPE, evaluate_merge_gate
 
@@ -915,7 +920,7 @@ async def test_evaluate_merge_gate_never_clears_human_approved_anchor_realdb():
             # 사람이 이미 승인한 상태를 직접 시뮬레이션(gates.py 축과 동형 — status=approved+anchor).
             gate = await create_gate(
                 s, seeded["org_id"], seeded["story_id"], "story", MERGE_GATE_TYPE,
-                seeded["member_id"], None, project_id=None, neutral_facts={},
+                seeded["member_id"], None, project_id=None, neutral_facts={}, pr_number=99,
             )
             gate.status = "approved"
             gate.approved_head_sha = "sha-human-approved"

--- a/backend/tests/test_2826_gate_pr_lifecycle_creation_realdb.py
+++ b/backend/tests/test_2826_gate_pr_lifecycle_creation_realdb.py
@@ -248,8 +248,14 @@ async def test_ac1_pr_open_with_link_creates_gate_and_publishes_pending_check():
 
 @pytest.mark.anyio
 async def test_ac2_pr_open_reuses_existing_gate_no_duplicate():
-    """AC②: board-preflight(또는 이전 PR 이벤트)가 이미 gate를 만들어 뒀으면, PR-open 경로가
-    새로 만들지 않고 그 gate 하나만 유지한다(2 경로 교차해도 gate 1개)."""
+    """AC②: 같은 PR에 대해 board-preflight(또는 이전 PR 이벤트)가 이미 gate를 만들어 뒀으면,
+    PR-open 경로가 새로 만들지 않고 그 gate 하나만 유지한다(2 경로 교차해도 gate 1개).
+
+    story #2893(§2 A1) 갱신 — 멱등 키가 이제 pr_number를 포함한다(0271). 기존 gate는 «이
+    PR(12)»용으로 이미 존재해야 재사용 대상이다 — pr_number 없는(PR 컨텍스트 자체가 없던)
+    gate는 더 이상 "아무 PR에나 재사용 가능한 슬롯"이 아니다(그게 실사고1/2의 근본원인이었다
+    — 그 가정 자체를 폐기하는 게 이 스토리의 요지, test_2893_gate_pr_scoped_isolation_realdb
+    참조)."""
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
@@ -262,7 +268,7 @@ async def test_ac2_pr_open_reuses_existing_gate_no_duplicate():
 
             existing_gate = Gate(
                 id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
-                gate_type=MERGE_GATE_TYPE, status="pending",
+                gate_type=MERGE_GATE_TYPE, status="pending", pr_number=12,
             )
             s.add(existing_gate)
             await s.commit()

--- a/backend/tests/test_2853_gate_check_revocation_realdb.py
+++ b/backend/tests/test_2853_gate_check_revocation_realdb.py
@@ -39,10 +39,14 @@ def anyio_backend():
     return "asyncio"
 
 
-async def _seed_anchored_auto_passed_gate(session, seeded, *, head_sha="sha-live"):
+async def _seed_anchored_auto_passed_gate(session, seeded, *, head_sha="sha-live", pr_number=1):
     """이미 AUTO_MERGE를 통과해(anchor+success check 발행이 전제됐던) 상태를 직접 시드 —
     evaluate_merge_gate로 그 상태에 자연 도달하려면 trust cold-start를 전부 채워야 해(무관한
-    복잡도) 회귀가 검증하려는 축(anchor-clear 분기)만 격리해 직접 만든다."""
+    복잡도) 회귀가 검증하려는 축(anchor-clear 분기)만 격리해 직접 만든다.
+
+    story #2893(§2 A1, 0271) — pr_number 기본값(1)이 이 파일의 모든 reconcile 호출부가 쓰는
+    pr_number=1과 일치해야 한다(멱등 키에 편입됐으므로 안 맞으면 reconcile이 이 게이트를
+    못 찾는다 — test_2893_gate_pr_scoped_isolation_realdb가 그 정확한 격리를 별도로 잰다)."""
     from app.models.gate import Gate
     from app.services.merge_verdict_gate import MERGE_GATE_TYPE
 
@@ -50,7 +54,7 @@ async def _seed_anchored_auto_passed_gate(session, seeded, *, head_sha="sha-live
         id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=seeded["story_id"],
         work_item_type="story", gate_type=MERGE_GATE_TYPE, status="auto_passed",
         approved_head_sha=head_sha, github_check_run_id=90001, github_check_run_sha=head_sha,
-        requires_human=False,
+        requires_human=False, pr_number=pr_number,
     )
     session.add(gate)
     await session.commit()

--- a/backend/tests/test_2893_gate_null_slot_promotion_realdb.py
+++ b/backend/tests/test_2893_gate_null_slot_promotion_realdb.py
@@ -1,0 +1,195 @@
+"""story #2893(§2 A1, 0271) 후속 — 카디르 QA(PR#3349 CI 실 실패 2건, 2026-08-22, codex
+소스분석→실 재현 확定).
+
+pr_number를 멱등 키에 편입한 것(정확매치 only)이 「PR 컨텍스트가 나중에 밝혀지는」 정상
+케이스(①line-engine/board-preflight self-report shell 後 실 PR 연결 ②legacy 백필 누락 행의
+재제출)까지 다른 PR과 똑같이 취급해 새 행을 만들며 옛 NULL-슬롯 행을 고아화시켰다.
+`gate_service.find_gate_slot_with_pr_fallback`가 정확매치 우선+NULL-슬롯 승격 폴백으로
+고쳤다 — 이 파일은 그 헬퍼 자체의 계약(승격 성립)과, 승격이 실사고1/2가 막던 축(서로 다른
+PR이 같은 슬롯을 공유)을 다시 열지 않는다는 것 둘 다를 실 PG로 고정한다.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_2893_gate_pr_scoped_isolation_realdb import (
+    _post_app,
+    _pr_payload,
+    _seed_installation,
+    _seed_link,
+    _seed_org_project_story,
+    _session_factory,
+)
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_find_gate_slot_promotes_null_slot_to_real_pr_number():
+    """단위 계약 — NULL-슬롯이 있으면 정확매치가 없을 때 그 행을 찾아 pr_number를 채운다
+    (같은 gate.id 유지, 새 행 생성 아님)."""
+    from app.models.gate import Gate
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="auto_passed", pr_number=None,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        async with Session() as s:
+            found = await find_gate_slot_with_pr_fallback(
+                s, org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", pr_number=8,
+            )
+            assert found is not None
+            assert found.id == gate_id, "새 행이 아니라 기존 NULL-슬롯 행을 재사용해야 함"
+            assert found.pr_number == 8, "승격 — pr_number가 채워져야 함"
+            await s.commit()
+
+        async with Session() as s:
+            row = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert row.pr_number == 8, "승격이 커밋 後에도 영속돼야 함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_find_gate_slot_promotion_does_not_let_second_different_pr_steal_it():
+    """실사고1/2 재발방지 — NULL-슬롯이 PR A로 승격된 後, PR B(다른 pr_number)가 같은
+    (work_item, gate_type)을 조회해도 승격된 행을 못 찾는다(정확매치 불일치+NULL-슬롯
+    자체가 이제 없음) — «미상→특정 PR» 1회성 전이일 뿐 «PR A→PR B» 전이는 이 헬퍼가
+    만들어내지 않는다는 것의 직접 증거."""
+    from app.models.gate import Gate
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="auto_passed", pr_number=None,
+            )
+            s.add(gate)
+            await s.commit()
+
+        async with Session() as s:
+            promoted = await find_gate_slot_with_pr_fallback(
+                s, org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", pr_number=8,
+            )
+            assert promoted is not None and promoted.pr_number == 8
+            await s.commit()
+
+        async with Session() as s:
+            for_pr_b = await find_gate_slot_with_pr_fallback(
+                s, org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", pr_number=9,
+            )
+            assert for_pr_b is None, "PR B는 승격된 PR A의 슬롯을 훔치면 안 됨(실사고1/2 재발방지)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_find_gate_slot_none_pr_number_never_touches_pr_scoped_row():
+    """pr_number=None(PR 컨텍스트 없는 조회)은 NULL-슬롯만 찾는다 — 이미 특정 PR에 귀속된
+    행을 "PR 컨텍스트 없음"이라는 이유로 승격 해제하거나 잘못 반환하면 안 된다."""
+    from app.models.gate import Gate
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="approved", pr_number=8,
+            )
+            s.add(gate)
+            await s.commit()
+
+        async with Session() as s:
+            found = await find_gate_slot_with_pr_fallback(
+                s, org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", pr_number=None,
+            )
+            assert found is None, "PR-scoped 행은 pr_number=None 조회 대상이 아님(NULL-슬롯 전용)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_webhook_self_report_shell_promoted_by_first_pr_then_second_pr_gets_own_row():
+    """통합 — board-preflight/line-engine self-report shell(NULL-슬롯)이 실존하는 상태에서
+    PR A가 열리면 그 행이 승격돼 재사용되고(같은 gate_id), 뒤이어 같은 스토리에 PR B가
+    열리면 승격된 PR A 행과 무관한 **독립** 새 행을 얻는다(실사고1/2 축 그대로 보존)."""
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680401)
+            await _seed_link(s, org, story, pr_number=401)
+            await _seed_link(s, org, story, pr_number=402)
+            story_id = story.id
+            # self-report shell(라인/board-preflight): PR 컨텍스트 모름 — pr_number NULL.
+            shell = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story_id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending", pr_number=None,
+            )
+            s.add(shell)
+            await s.commit()
+            shell_id = shell.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 94001}),
+        ), patch("app.core.database.async_session_factory", Session):
+            await _post_app(
+                _pr_payload(action="opened", pr_number=401, installation_id=680401, head_sha="sha-a1"),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+            await _post_app(
+                _pr_payload(action="opened", pr_number=402, installation_id=680401, head_sha="sha-b1"),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+
+        async with Session() as s:
+            rows = (
+                await s.execute(
+                    select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == MERGE_GATE_TYPE)
+                )
+            ).scalars().all()
+            assert len(rows) == 2, "shell이 PR A로 승격 재사용 + PR B는 별개 새 행 = 총 2행"
+            by_pr = {g.pr_number: g for g in rows}
+            assert set(by_pr) == {401, 402}
+            assert by_pr[401].id == shell_id, "PR A는 승격된 shell 행을 그대로 재사용해야 함"
+            assert by_pr[402].id != shell_id, "PR B는 승격된 shell을 훔치지 않고 독립 행이어야 함"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2893_gate_pr_scoped_isolation_realdb.py
+++ b/backend/tests/test_2893_gate_pr_scoped_isolation_realdb.py
@@ -1,0 +1,280 @@
+"""story #2893(설계안 gate-auto-creation-design-2893 §2 A1, PR①) — gate PR단위 슬롯.
+
+실사고1/2 재발방지 회귀가드: 같은 스토리에 PR A·B가 동시에 열려 있을 때, ①각자 독립된
+gate row를 갖고(rebind 없음) ②PR B의 새 SHA/CI 증거가 이미 approved인 PR A의 gate를
+건드리지 않으며(reconcile_merge_gate_with_real_evidence 격리) ③웹훅의 reopen-vs-auto생성
+분기가 정확히 그 PR의 gate만 골라 재-pending시킨다(verdict_capture.py 격리)는 것을 실 PG
+왕복으로 증명한다.
+
+github_app.py의 실 GitHub API 호출만 mock — DB 왕복은 실 Postgres(test_2826과 동일 관례,
+Base.metadata.create_all이라 0271의 부분 유니크 인덱스 자체는 여기서 검증 안 됨 — 애플리케이션
+레벨 격리 로직만 잰다. 인덱스 자체의 존재는 alembic upgrade head가 별도로 증명).
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+APP_SECRET = "app-secret-2893"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401
+    import app.models.verdict  # noqa: F401 — capture_pr_ci_verdict가 verdict 테이블을 쓴다(#2826 동일 관례).
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _sign(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+async def _post_app(payload, Session, *, delivery_id):
+    from app.main import app as fastapi_app
+    from app.routers import verdict_capture as mod
+    from tests.conftest import override_db_and_read
+
+    async def override_db():
+        async with Session() as s:
+            yield s
+
+    override_db_and_read(fastapi_app, override_db)
+    body = json.dumps(payload).encode()
+    headers = {
+        "X-GitHub-Event": "pull_request", "X-GitHub-Delivery": delivery_id,
+        "X-Hub-Signature-256": _sign(body, APP_SECRET),
+    }
+    try:
+        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            with patch.object(mod.settings, "github_webhook_secret", "legacy-unused"), \
+                 patch.object(mod.settings, "github_app_webhook_secret", APP_SECRET):
+                return await c.post(
+                    "/api/v2/internal/verdict/github-webhook", content=body, headers=headers,
+                )
+    finally:
+        fastapi_app.dependency_overrides.clear()
+
+
+def _pr_payload(*, action, pr_number, installation_id, head_sha, merged=False, title="chore: unrelated"):
+    return {
+        "action": action,
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "installation": {"id": installation_id},
+        "pull_request": {
+            "number": pr_number, "title": title, "body": "", "merged": merged,
+            "head": {"sha": head_sha, "ref": f"feat-branch-{pr_number}"},
+        },
+    }
+
+
+async def _seed_org_project_story(s, *, with_participation: bool):
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    s.add(org)
+    await s.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    s.add(project)
+    await s.commit()
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="in-progress")
+    s.add(story)
+    await s.commit()
+
+    if with_participation:
+        from app.models.participation import Participation, ParticipationRole
+
+        role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="implementation", label="Impl", is_default=True)
+        s.add(role)
+        await s.commit()
+        member_id = uuid.uuid4()
+        s.add(Participation(id=uuid.uuid4(), org_id=org.id, story_id=story.id, member_id=member_id, role_id=role.id))
+        await s.commit()
+
+    return org, project, story
+
+
+async def _seed_installation(s, org, *, installation_id, enforced=False):
+    from app.models.github_installation import GithubInstallation
+
+    inst = GithubInstallation(
+        id=uuid.uuid4(), org_id=org.id, installation_id=installation_id, account_login="moonklabs",
+        enforced_check_repos=["moonklabs/sprintable"] if enforced else None,
+    )
+    s.add(inst)
+    await s.commit()
+    return inst
+
+
+async def _seed_link(s, org, story, *, pr_number):
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    s.add(PullRequestStoryLink(
+        id=uuid.uuid4(), org_id=org.id, story_id=story.id,
+        repo_full_name="moonklabs/sprintable", pr_number=pr_number,
+        link_source="explicit", confidence="high",
+    ))
+    await s.commit()
+
+
+async def _gates_for_story(s, story_id):
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    rows = (
+        await s.execute(
+            select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == MERGE_GATE_TYPE)
+        )
+    ).scalars().all()
+    return sorted(rows, key=lambda g: g.pr_number or 0)
+
+
+@pytest.mark.anyio
+async def test_two_open_prs_get_independent_gate_rows_not_one_shared_slot():
+    """실사고1(story 2889/#3298·#3302) 재현 방지 — PR A·B가 같은 스토리에 동시에 열리면
+    gate가 2개 생겨야 한다(1슬롯 rebind 아님)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680001)
+            await _seed_link(s, org, story, pr_number=101)
+            await _seed_link(s, org, story, pr_number=102)
+            story_id = story.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 91001}),
+        ), patch("app.core.database.async_session_factory", Session):
+            await _post_app(
+                _pr_payload(action="opened", pr_number=101, installation_id=680001, head_sha="sha-a1"),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+            await _post_app(
+                _pr_payload(action="opened", pr_number=102, installation_id=680001, head_sha="sha-b1"),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 2, "PR A·B 각자 독립 gate row(1슬롯 rebind 아님)"
+            assert {g.pr_number for g in gates} == {101, 102}
+            assert gates[0].approved_head_sha != "sha-b1"  # PR A 게이트에 PR B의 SHA가 안 샘
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_pr_b_new_sha_does_not_reopen_prs_a_approved_gate():
+    """실사고2(3302 머지 후 3298 고립) 재현 방지의 역방향 — PR A가 이미 approved인 상태에서
+    PR B가 새 push(synchronize)를 해도, reconcile/reopen 둘 다 PR A의 gate를 건드리면 안
+    된다(같은 스토리 다른 PR의 SHA가 새는 실사고1의 정확한 반대축)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680002)
+            await _seed_link(s, org, story, pr_number=201)
+            await _seed_link(s, org, story, pr_number=202)
+            story_id = story.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 91002}),
+        ), patch("app.core.database.async_session_factory", Session):
+            # PR A 오픈 → gate 생성.
+            await _post_app(
+                _pr_payload(action="opened", pr_number=201, installation_id=680002, head_sha="sha-a-orig"),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+
+        # PR A의 gate를 사람이 이미 승인(approved)한 상태로 직접 세팅 — 실 승인 API(gates.py)를
+        # 타지 않고 이 테스트의 관심사(재조정 격리)만 좁혀 재현한다.
+        async with Session() as s:
+            from datetime import datetime, timezone
+
+            from app.models.gate import Gate as _Gate, set_gate_status
+            from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+            gate_a = (
+                await s.execute(
+                    select(_Gate).where(
+                        _Gate.work_item_id == story_id, _Gate.gate_type == MERGE_GATE_TYPE, _Gate.pr_number == 201,
+                    )
+                )
+            ).scalar_one()
+            set_gate_status(gate_a, "approved", now=datetime.now(timezone.utc))
+            gate_a.approved_head_sha = "sha-a-orig"
+            gate_a_id = gate_a.id
+            await s.commit()
+
+        # PR B 오픈(신규 gate) → PR B synchronize(새 SHA push) — PR A는 절대 안 건드려야 한다.
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 91003}),
+        ), patch("app.core.database.async_session_factory", Session):
+            await _post_app(
+                _pr_payload(action="opened", pr_number=202, installation_id=680002, head_sha="sha-b-orig"),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+            await _post_app(
+                _pr_payload(action="synchronize", pr_number=202, installation_id=680002, head_sha="sha-b-new"),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+
+        async with Session() as s:
+            from app.models.gate import Gate as _Gate
+
+            gate_a_after = (
+                await s.execute(select(_Gate).where(_Gate.id == gate_a_id))
+            ).scalar_one()
+            assert gate_a_after.status == "approved", "PR B의 이벤트가 PR A의 approved를 재-pending시키면 안 됨"
+            assert gate_a_after.approved_head_sha == "sha-a-orig", "PR A의 anchor SHA가 PR B로 안 새야 함(실사고1의 정확한 역방향)"
+
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 2, "PR A·B 여전히 독립 2행"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_h1_s6_github_webhook.py
+++ b/backend/tests/test_h1_s6_github_webhook.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import itertools
 import json
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -105,10 +106,19 @@ async def _post(payload: dict, *, event: str, story=..., sign=True, installation
     if installation is ...:
         session.execute = AsyncMock(return_value=result)  # 모든 query 동일(기존 동작).
     else:
-        # 1st execute=story select, 2nd=installation select(native CI 블록), 이후 installation 반복.
+        # 1st execute=story select, 이후 전부 installation select(native CI 블록 등) 동형 반복.
+        #
+        # 카디르 QA(PR#3349 4라운드, 2026-08-22) — story #2893 후속(find_gate_slot_with_pr_
+        # fallback 위임)이 이 웹훅 경로에 session.execute 호출을 추가로 얹으며, 고정 길이
+        # side_effect 리스트가 소진돼 StopAsyncIteration(merge_link_evidence 등 더 뒤의
+        # 호출부에서 표면화). 이 파일명에 "gate"가 없어 -k gate/merge_gate 스윕 밖이었다 —
+        # 실 CI 「6750 passed 中 1 failed」로 발견. itertools.chain으로 1번째(story) 이후는
+        # inst_result를 **무한 반복**시켜 이후 추가되는 호출 수와 무관하게 안정화한다(13건에
+        # 쓴 `_mock_session()`의 return_value 방식과 동형 의도 — "그 다음부터는 전부 같은
+        # 결과"라는 실제 의미를 유한 리스트 대신 정확히 표현).
         inst_result = MagicMock()
         inst_result.scalar_one_or_none.return_value = installation
-        session.execute = AsyncMock(side_effect=[result, inst_result, inst_result, inst_result])
+        session.execute = AsyncMock(side_effect=itertools.chain([result], itertools.repeat(inst_result)))
 
     async def override_db():
         yield session

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -176,6 +176,22 @@ def test_wilson_lower_bound_sample_aware():
 
 # ── evaluate_merge_gate 오케스트레이션 (Cage 합성·AC⑥) ──────────────────────────
 
+def _mock_session() -> AsyncMock:
+    """카디르 QA(PR#3349 재재verdict, 2026-08-22) — evaluate_merge_gate가 이제 내부에서
+    find_gate_slot_with_pr_fallback(gate_service.py, 최대 2회 session.execute)를 거친다.
+    완전 미설정 `AsyncMock()`은 `.scalar_one_or_none()`(실제론 동기 메서드)까지 AsyncMock
+    자손이라, 호출하면(await 없이) 「awaited 안 된 coroutine」객체를 그대로 반환한다 — 그
+    코루틴이 `is not None`이라 헬퍼가 "게이트 찾음"으로 오판, `.status` 접근에서
+    AttributeError. 이 세션은 session.execute(...)가 항상 "게이트 없음"을 뜻하는 **동기**
+    결과를 반환하도록 미리 배선해 그 함정을 없앤다(pr_number 유무에 따라 1~2회 호출돼도
+    return_value 방식이라 호출 횟수 무관)."""
+    no_row = MagicMock()
+    no_row.scalar_one_or_none = MagicMock(return_value=None)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=no_row)
+    return session
+
+
 def _patch_cage(*, gate_status="auto_passed", trust_scores=None, capture=None, participation=True,
                  project_id=None):
     part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4()) if participation else None
@@ -209,7 +225,7 @@ async def _run(**cage):
             patch.object(mod, "create_gate", AsyncMock(return_value=gate))
         )
         res = await evaluate_merge_gate(
-            AsyncMock(), uuid.uuid4(), uuid.uuid4(),
+            _mock_session(), uuid.uuid4(), uuid.uuid4(),
             pr_number=12, repo="o/r", ci_result="pass", pr_result="pass",
         )
     return res, create_spy
@@ -267,7 +283,7 @@ async def test_evaluate_ci_fail_blocks():
             stack.enter_context(p)
         stack.enter_context(patch.object(mod, "create_gate", AsyncMock(return_value=gate)))
         res = await evaluate_merge_gate(
-            AsyncMock(), uuid.uuid4(), uuid.uuid4(),
+            _mock_session(), uuid.uuid4(), uuid.uuid4(),
             pr_number=1, repo="o/r", ci_result="failure",
         )
     assert res.decision == BLOCK and res.ci_result == "fail"
@@ -299,7 +315,7 @@ async def test_trust_computed_before_capture_records():
          patch.object(mod, "capture_pr_ci_verdict", side_effect=_capture), \
          patch.object(mod, "resolve_work_item_project_id", AsyncMock(return_value=uuid.uuid4())), \
          patch.object(mod, "create_gate", AsyncMock(return_value=SimpleNamespace(id=uuid.uuid4(), status="auto_passed", evidence_status=None, approved_head_sha=None))):
-        await evaluate_merge_gate(AsyncMock(), uuid.uuid4(), uuid.uuid4(), pr_number=1, repo="o/r", ci_result="pass")
+        await evaluate_merge_gate(_mock_session(), uuid.uuid4(), uuid.uuid4(), pr_number=1, repo="o/r", ci_result="pass")
 
     assert order == ["trust", "capture"], f"trust must precede capture, got {order}"
 
@@ -392,7 +408,7 @@ async def test_evaluate_persists_decision_metadata_on_gate():
                AsyncMock(return_value={"scores": []})), \
          patch("app.services.merge_verdict_gate.create_gate", AsyncMock(return_value=gate)):
         res = await evaluate_merge_gate(
-            AsyncMock(), uuid.uuid4(), uuid.uuid4(),
+            _mock_session(), uuid.uuid4(), uuid.uuid4(),
             pr_number=1, repo="o/r", ci_result="pass", pr_result="pass",
         )
     assert res.decision == ASK_HUMAN  # trust None(pending) → ask_human.
@@ -416,7 +432,7 @@ async def test_evaluate_auto_merge_metadata_sufficient():
                AsyncMock(return_value={"scores": [{"role_key": "implementation", "clean_pass_rate": 0.95,
                    "hit": 95, "resolved": 100, "pending": 0, "hit_rate": 0.95}]})), \
          patch("app.services.merge_verdict_gate.create_gate", AsyncMock(return_value=gate)):
-        res = await evaluate_merge_gate(AsyncMock(), uuid.uuid4(), uuid.uuid4(),
+        res = await evaluate_merge_gate(_mock_session(), uuid.uuid4(), uuid.uuid4(),
                                         pr_number=1, repo="o/r", ci_result="pass", pr_result="pass")
     assert res.decision == AUTO_MERGE
     assert gate.requires_human is False and gate.evidence_status == "sufficient"
@@ -530,7 +546,7 @@ async def _run_substance(*, ci_result, pr_number, disposition, source="system_de
                                          AsyncMock(return_value={"scores": []})))
         create_spy = stack.enter_context(patch.object(mod, "create_gate", AsyncMock(return_value=gate)))
         res = await evaluate_merge_gate(
-            AsyncMock(), uuid.uuid4(), uuid.uuid4(),
+            _mock_session(), uuid.uuid4(), uuid.uuid4(),
             pr_number=pr_number, repo=("o/r" if pr_number else ""),
             ci_result=ci_result, pr_result=None,
         )


### PR DESCRIPTION
## Summary
설계안([게이트 자동 생성·사슬 마찰 근본 수리 — 설계안(story #2893)](https://app.sprintable.ai)) §2 A1 그대로. 실사고1/2(같은 스토리에 PR A·B 동시 오픈 시 게이트 SHA가 나중 push한 PR로 rebind, 또는 먼저 머지된 PR의 게이트를 나머지 PR이 받을 수 없던 문제)의 근본원인은 `(work_item_id, work_item_type, gate_type)` 1슬롯 공유. PR마다 독립 게이트 row를 갖도록 멱등 키를 4-튜플로 확장 — 재-pending 로직으로 사후 보정하는 게 아니라 **격리가 설계로 보장됨**.

## BE — 원자 이동 4곳
`create_gate()` 하나만 옮기면 웹훅 재조정 3곳이 계속 옛 4-튜플로 엉뚱한 PR을 집어 G2가 재발하므로 같이 이동(그라운딩에서 발견, 페드루군 승인):
1. `gate_service.py::create_gate()` — `pr_number` 파라미터(기본 `None`, merge 이외 7개 호출부 무회귀) + 멱등 조회/INSERT.
2. `merge_verdict_gate.py::evaluate_merge_gate()` — `_prior_status` 사전체크(승인요청 카드 중복배달 방지 판정)도 pr_number 편입. `pr_number<=0`(board-preflight no-substance)은 0을 지어내지 않고 NULL 유지.
3. `merge_verdict_gate.py::reconcile_merge_gate_with_real_evidence()` — 웹훅이 나른 이 PR의 CI/merge 증거가 다른 PR의 게이트에 새지 않도록.
4. `verdict_capture.py` 웹훅 핸들러 — reopen-vs-auto생성 분기(실사고1/2가 재현되던 정확한 자리).

## 마이그레이션(0271)
`neutral_facts.pr_number`(evaluate_merge_gate가 매 호출마다 이미 적어 옴)에서 백필 — **GitHub API 역조회 불요**. `uq_gate_work_item_gate_type` 단일 유니크 제약 → 부분 유니크 인덱스 2개(NULL 구간=옛 계약·NOT NULL 구간=+pr_number, PG의 NULL≠NULL 시맨틱 때문에 단순 컬럼 추가만으론 옛 보장이 사라짐). upgrade/downgrade 둘 다 baseline+alembic upgrade head로 직접 검증, 3가지 제약 시나리오 raw SQL로 실증.

**downgrade는 lossy다**(카디르 QA, 2026-08-22): 같은 (org, work_item, type, gate_type)에 pr_number만 다른 행이 2개 이상(=이 마이그 목적 자체가 만드는 정상 상태) 실존하면 옛 4열 UNIQUE 복원이 UniqueViolation으로 막힌다 — 옛 스키마는 pr_number를 못 담으므로 무손실 복원은 구조상 불가능. 그룹당 pr_number 최대(최신 PR) 행만 남기고 나머지 삭제 후 제약을 복원한다(NULL은 최하순위). 실 COMMIT된 3-way+singleton 중복 데이터(psql 직접 insert+commit)로 upgrade→downgrade→re-upgrade 왕복 재검증.

## 게이트 조회 — NULL-슬롯 승격 폴백(카디르 QA, CI 실 실패 2건 근본수정)
0271이 pr_number를 멱등 키에 편입하며 4곳 조회를 전부 **정확매치 only**로 바꿨는데, 이것이 「PR 컨텍스트가 나중에 밝혀지는」 정상 케이스(line-engine/board-preflight self-report shell, legacy 백필 갭)까지 다른 PR과 혼동해 새 행을 만들며 옛 NULL-슬롯 행을 고아화시켰다. A1의 취지는 «서로 다른 PR 간 격리»지 「PR 컨텍스트가 나중에 채워지는 같은 게이트의 분열」이 아니다.

- CI(run 32559137389) shard0: `test_merge_gate_reject_resubmit_reopen::test_rejected_gate_reopens_on_resubmit` — rejected gate가 pr_number=NULL로 존재 → 재제출이 pr_number=8로 옴 → 정확매치 실패 → 새 행 생성(고아화).
- CI shard2: `test_2520_line_merge_gate_reconcile::test_reconcile_updates_line_style_gate_regardless_of_h1_flag_realdb` — line-engine self-report shell(pr_number=0→NULL) 실 webhook pr_number=42 reconcile 조회 시 정확매치 실패 → no-op(회귀).

처방: `gate_service.py::find_gate_slot_with_pr_fallback()`(신규 공용 헬퍼) — pr_number 주어지면 정확매치 우선, 없으면 NULL-슬롯을 찾아 **승격**(pr_number 채워 재사용). 승격은 "미상→특정 PR" 1회성 전이일 뿐이라 이미 승격된 슬롯을 다른 PR이 다시 훔칠 길은 없음(실사고1/2가 막던 축은 그대로 보존 — 신규 통합회귀 4건으로 고정, 승격 後 다른 PR이 못 훔치는 것 포함). 4곳(create_gate/evaluate_merge_gate _prior_status peek/reconcile_merge_gate_with_real_evidence/verdict_capture.py 웹훅 lookup) 전부 이 헬퍼로 통일.

**helper 위임의 부수 파급 — mock 13건**: `_prior_status` 조회가 `find_gate_slot_with_pr_fallback`(session.execute 최대 2회) 경유로 바뀌며, 완전 미설정 `AsyncMock()`을 세션으로 쓰던 mock 테스트들이 깨졌다(`.scalar_one_or_none()`이 AsyncMock 자손이라 호출 시 「awaited 안 된 coroutine」을 그대로 반환 → 헬퍼가 "게이트 찾음"으로 오판 → `.status` 접근에서 AttributeError). 실 CI shard(1)(2) FAILURE로 표면화. 13건 전부(`test_merge_verdict_gate.py` 12건 + `test_1968_gate_project_id_threading.py` 1건) `session.execute`가 항상 "게이트 없음"을 뜻하는 **동기** 결과를 반환하도록 `_mock_session()` 헬퍼로 갱신(뮤테이션 검증 포함 — 되돌리면 정확히 그 3건만 재현 확認).

## 무관 기존 결함 — baseline 재현 확認(list, 판정자 검증용)
카디르군이 검증 대상을 못 찾겠다고 한 「baseline 무관」 판정을 명시 목록으로 남긴다:

- **18건, 전부 `relation "organizations" does not exist` 시그니처** — `Base.metadata.create_all`이 아니라 baseline 스키마(`alembic upgrade head`)가 미리 적용된 DB를 요구하는 테스트 파일들을, 스키마 미적용 빈 DB로 돌려 생긴 **테스트-하네스 셋업 갭**(내 코드 변경과 무관). `test_2249_glance_entered_state_at_realdb.py`·`test_e_ui_daegbyeon_174be6bc_scope_violation_realdb.py`에서 동일 시그니처로 재확인 — `ALEMBIC_DATABASE_URL`로 `alembic upgrade head` 선행 시 clean pass.
- **`test_2520_line_merge_gate_reconcile.py::test_reconcile_updates_line_style_gate_regardless_of_h1_flag_realdb`를 그때 "pre-existing, unrelated"로 판정한 것은 철회한다.** 당시 검증은 진짜 baseline이 아니었다 — PR②(#3351) 작업 중 `git stash`로 지운 건 PR②의 *미커밋* diff뿐이고, 이 PR①(`a977d46bd`)은 이미 커밋돼 스택에 남아 있었다. 이번에 `develop`(62105d749, PR① 이전)을 별도 워크트리로 체크아웃해 직접 재확인 — `test_merge_gate_reject_resubmit_reopen.py`+`test_2520_line_merge_gate_reconcile.py` 둘 다 develop에서는 clean 4/4 pass. 즉 이 2건은 위 「NULL-슬롯 승격 폴백」 섹션의 PR①(내 커밋) 원인임을 최종 확定 — 18건 클래스와는 다른 클래스다.

## FE — 소비 3파일
`GateItem.pr_number` 추가. 공용 `pickRelevantMergeGate`(미종결 우선·동순위는 최근 PR 우선)를 `story-merge-gate.tsx`+`story-detail-panel.tsx`의 옛 `.find(g => g.gate_type==='merge')`(사실상 무작위) 대신 사용. `deriveInFlightTrustChip`은 `.some()` 기반이라 원래부터 안전 — 무변경.

## glance verify_fail 스토리 단위 dedup(카디르 QA)
story #2893부터 merge gate가 스토리당 여러 개(PR마다 1행)일 수 있어, gate-row 기준 select+LIMIT이 같은 스토리를 중복 노출하고 다른 스토리를 밀어냈다(사용자 도달 실갭). `Story.id/title` GROUP BY + `MIN(evidence_status_entered_at)`로 스토리 단위 dedup, LIMIT도 스토리 수 기준으로 정정.

## 스코프 밖(페드루군 지시로 PR 본문에 명시)
`glance.py`·`trust_pipeline.py`·`merge_gate_metrics.py`·`goal.py`(repository)의 "스토리 레벨 합산" 4곳은 순수 읽기 집계라 새 버그는 없으나, 스토리당 게이트가 복수가 되면 그 집계가 «전 PR 합산»인지 «최신 PR»인지 의미가 불분명해진다 — **재검토 필요**(후속). (`glance.py`의 verify_fail 1곳은 이번 PR에서 직접 dedup했지만, 나머지 3곳은 여전히 후속 스코프.)

## Test plan
- [x] BE 신규 realdb 2건(PR① 원안) — 실사고1/2 mutation 검증(pr_number 필터 제거→정확히 예측대로 재현 확認→복원→GREEN).
- [x] BE 신규 realdb 4건(NULL-슬롯 승격) — 승격 계약+"승격 後 다른 PR이 못 훔침"(실사고1/2 재발방지) mutation 검증.
- [x] 0271 downgrade lossy-복원 — 실 COMMIT된 3-way+singleton 중복 데이터로 upgrade→downgrade→re-upgrade 왕복.
- [x] glance verify_fail dedup 신규 realdb 1건 — mutation 검증.
- [x] mock 13건(`test_merge_verdict_gate.py`+`test_1968`) `_mock_session()` 갱신 — mutation 검증.
- [x] 기존 4개 realdb 파일의 "PR-agnostic 게이트가 임의 PR과 매치" 가정 정정(멱등 키 확장이 그 가정 자체를 폐기하는 게 이 스토리의 요지).
- [x] 인접 회귀 13개 파일 전부 격리(신선 DB) 재검증 green — 목록: 2156/2520/2826/2853/2893①/2893-신규(null-slot)/reject_resubmit/e_ui_daegbyeon/merge_verdict_gate/1968/2249_glance/2813_github_checks/bot_l1.
- [x] 무관 기존 결함 18건 — 위 섹션 참조, list+원인+재확인 방법 명시.
- [x] FE `pickRelevantMergeGate` 5건 신규(mutation 검증 포함) + 기존 55건 무회귀.
- [x] tsc/eslint 전부 0건.

[SID:2893]
