### PR TITLE
[SID:2923] AQ4 갭 fix — Audit 행 actor 아바타 shape(human/agent) 배선

### DIFF
--- a/apps/web/src/components/activity/activity-log-view.test.ts
+++ b/apps/web/src/components/activity/activity-log-view.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { auditClaim, auditContextTooltip, type ActivityLogItem } from './activity-log-view';
+import { auditActorProps, auditClaim, auditContextTooltip, type ActivityLogItem } from './activity-log-view';
 
 function item(overrides: Partial<ActivityLogItem> = {}): ActivityLogItem {
   return {
@@ -44,5 +44,34 @@ describe('auditContextTooltip (context 필드는 native title로 보존, 요약�
 
   it('handles an empty context object without leaking "undefined" or extra lines', () => {
     expect(auditContextTooltip(item({ action: 'memo.viewed', context: {} }))).toBe('action: memo.viewed');
+  });
+});
+
+// story #2923(P0-E AQ4, 그라운딩 발견) — 예전엔 actor_type 무관하게 항상 human prop으로만
+// 넘겨(agent 미사용) 시안의 "아바타 shape로 human/agent 구분"이 안 걸렸다. actor_type이
+// 'agent'일 때만 agent 경로, 그 외(human·null=미상)는 human 경로(보수적 기본값).
+describe('auditActorProps (story #2923 AQ4 — actor_type을 human/agent prop으로 정확히 갈라 넘긴다)', () => {
+  it('routes actor_type=agent through the agent prop, not human', () => {
+    const props = auditActorProps(item({ actor_name: '미르코', actor_type: 'agent' }));
+    expect(props.agent).toEqual({ name: '미르코', initial: '미' });
+    expect(props.human).toBeUndefined();
+  });
+
+  it('routes actor_type=human through the human prop, not agent', () => {
+    const props = auditActorProps(item({ actor_name: '송윤재', actor_type: 'human' }));
+    expect(props.human).toEqual({ name: '송윤재', role: 'human' });
+    expect(props.agent).toBeUndefined();
+  });
+
+  it('actor_type=null(미상)은 보수적으로 human 경로로 폴백한다(storage-uploader-avatar.tsx 선례와 동형)', () => {
+    const props = auditActorProps(item({ actor_name: '알수없음', actor_type: null }));
+    expect(props.human).toEqual({ name: '알수없음', role: 'human' });
+    expect(props.agent).toBeUndefined();
+  });
+
+  it('actor_name이 없으면(null) human/agent 둘 다 비운다(지어내지 않음)', () => {
+    const props = auditActorProps(item({ actor_name: null, actor_type: 'agent' }));
+    expect(props.human).toBeUndefined();
+    expect(props.agent).toBeUndefined();
   });
 });

--- a/apps/web/src/components/activity/activity-log-view.tsx
+++ b/apps/web/src/components/activity/activity-log-view.tsx
@@ -316,12 +316,27 @@ export function auditContextTooltip(item: ActivityLogItem): string | undefined {
   return lines.join('\n');
 }
 
+// story #2923(P0-E AQ4, 그라운딩 발견) — actor_type 무관하게 항상 human prop으로만 넘겨(agent
+// prop 미사용) 시안의 "아바타 shape로 human/agent 구분"이 이 표면에서 안 걸렸다. AuditRow가
+// agent prop을 이제 실제로 그려(proof-capsule.tsx 처방) — actor_type==='agent'만 agent로,
+// 그 외(human·null=미상)는 기존처럼 human으로(보수적 기본값, storage-uploader-avatar.tsx
+// 선례와 동형 — 지어내지 않음). auditClaim/auditContextTooltip과 동형 패턴(순수함수 export)으로
+// 렌더 없이 유닛테스트 가능하게 분리.
+export function auditActorProps(item: ActivityLogItem): {
+  human?: { name: string; role: string };
+  agent?: { name: string; initial: string };
+} {
+  if (!item.actor_name) return {};
+  if (item.actor_type === 'agent') return { agent: { name: item.actor_name, initial: item.actor_name.slice(0, 1) } };
+  return { human: { name: item.actor_name, role: item.actor_type ?? 'human' } };
+}
+
 function ActivityRow({ item }: { item: ActivityLogItem }) {
   const locale = typeof document !== 'undefined' ? document.documentElement.lang || 'en' : 'en';
   const time = new Date(item.created_at).toLocaleString(locale, {
     month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
   });
-
+  const { human, agent } = auditActorProps(item);
   return (
     <div title={auditContextTooltip(item)}>
       <ProofCapsule
@@ -330,7 +345,8 @@ function ActivityRow({ item }: { item: ActivityLogItem }) {
         stateLabel={item.action}
         claim={auditClaim(item)}
         now={time}
-        human={item.actor_name ? { name: item.actor_name, role: item.actor_type ?? 'human' } : undefined}
+        human={human}
+        agent={agent}
       />
     </div>
   );

--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -167,6 +167,36 @@ describe('ProofCapsule (human optional — Board card 확산, bf9037cb) — 다�
   });
 });
 
+// story #2923(P0-E AQ4, 카디르 QA 이전 그라운딩 발견) — audit density가 human?.name을 mono
+// 텍스트로만 붙일 뿐 아바타 자체를 안 그려(agent prop도 dispatch에서 안 넘어옴) 시안의
+// "아바타 shape로 human/agent 구분"이 안 걸렸다. 공유 Avatar(shared/avatar.tsx) 재사용 —
+// agent=rounded-full·human=rounded-md+border-proof-line(S4 avatar-unification 정본 그대로).
+describe('ProofCapsule (audit density — actor avatar shape, story #2923 AQ4)', () => {
+  it('renders a rounded-md avatar (human shape) for a human actor', () => {
+    const markup = renderWithIntl(
+      <ProofCapsule {...BASE} density="audit" human={{ name: '윤재', role: 'owner' }} />,
+    );
+    expect(markup).toContain('rounded-md');
+    expect(markup).toContain('border-proof-line');
+    expect(markup).toContain('윤재');
+  });
+
+  it('renders a rounded-full avatar (agent shape) for an agent actor', () => {
+    const { human: _human, ...withoutHuman } = BASE;
+    const markup = renderWithIntl(
+      <ProofCapsule {...withoutHuman} density="audit" agent={{ name: '미르코', initial: '미' }} />,
+    );
+    expect(markup).toContain('rounded-full');
+    expect(markup).toContain('미르코');
+  });
+
+  it('omits the avatar entirely when neither human nor agent is provided (no crash, no undefined leak)', () => {
+    const { human: _human, ...withoutHuman } = BASE;
+    const markup = renderWithIntl(<ProofCapsule {...withoutHuman} density="audit" />);
+    expect(markup).not.toContain('undefined');
+  });
+});
+
 describe('ProofCapsule (footer slot — card·full 밀도, Board card 확산+story #2926 P0-F F2 gates/[id] 실기능 이관)', () => {
   it('renders arbitrary footer content below the claim/evidence in card density', () => {
     const markup = renderWithIntl(

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -91,7 +91,7 @@ export function ProofCapsule({
 }: ProofCapsuleProps) {
   if (density === 'audit') {
     return (
-      <AuditRow proofState={proofState} claim={claim} now={now} human={human} className={className} />
+      <AuditRow proofState={proofState} claim={claim} now={now} human={human} agent={agent} className={className} />
     );
   }
   if (density === 'row') {
@@ -348,15 +348,23 @@ function InlineRow({
   );
 }
 
-function AuditRow({ proofState, claim, now, human, className }: Pick<ProofCapsuleProps, 'proofState' | 'claim' | 'now' | 'human' | 'className'>) {
+// story #2923(P0-E AQ4, 2926-08-22 그라운딩 발견) — 시안(attention-audit-redesign-2923)이
+// audit density에 "아바타 shape로 human/agent 구분"을 명시했는데, 이 행은 그동안 human?.name을
+// mono 텍스트로만 붙일 뿐 아바타 자체를 전혀 안 그렸고(agent prop은 애초에 dispatch에서도
+// 안 넘어옴 — 위 ProofCapsule 본체 참고) human/agent 구분 신호가 텍스트 role 문자열 하나뿐이라
+// 도크트린④(자동화 경계, 항상 구분된 마커)를 audit density만 못 채우고 있었다. 공유 Avatar를
+// size=16(시안 .av 16px 그대로)으로 재사용 — 신규 아바타 컴포넌트 0.
+function AuditRow({ proofState, claim, now, human, agent, className }: Pick<ProofCapsuleProps, 'proofState' | 'claim' | 'now' | 'human' | 'agent' | 'className'>) {
   const dotTone: Record<ProofState, string> = {
     blue: 'bg-proof-blue', amber: 'bg-proof-amber', green: 'bg-proof-green', red: 'bg-proof-red',
   };
+  const actorName = agent?.name ?? human?.name;
   return (
     <div className={cn('flex items-center gap-2 rounded-[6px] border border-proof-line bg-proof-panel px-3 py-2 text-[11px]', className)}>
       <span className={cn('size-1.5 shrink-0 rounded-full', dotTone[proofState])} aria-hidden="true" />
       <span className="min-w-0 flex-1 truncate font-medium text-proof-ink">{claim}</span>
-      <span className="shrink-0 font-mono text-[9.5px] text-proof-faint">{[now, human?.name].filter(Boolean).join(' ')}</span>
+      {actorName ? <Avatar name={actorName} actorType={agent ? 'agent' : 'human'} size={16} /> : null}
+      <span className="shrink-0 font-mono text-[9.5px] text-proof-faint">{[now, actorName].filter(Boolean).join(' ')}</span>
     </div>
   );
 }


### PR DESCRIPTION
## 변경 사항
story #2923(P0-E, Attention Queue × Audit 재설계) 그라운딩 중 발견한 독립 갭 처방. 시안(attention-audit-redesign-2923)이 audit density에 "아바타 shape로 human/agent 구분"을 명시했는데, `ActivityRow`가 `actor_type` 무관하게 항상 `human` prop으로만 넘겨(그리고 `ProofCapsule`→`AuditRow` dispatch 자체가 `agent` prop을 안 넘김) 실제로는 아바타가 전혀 안 그려지고 있었습니다(mono 텍스트로 이름만 붙음).

**처방:**
- `proof-capsule.tsx`: dispatch에 `agent` prop 추가, `AuditRow`가 공유 `Avatar`(size=16, 시안 `.av` 16px 그대로)를 `actorType`으로 렌더.
- `activity-log-view.tsx`: 라우팅 로직을 `auditActorProps()` 순수함수로 분리(`auditClaim`/`auditContextTooltip`과 동형 패턴) — `actor_type==='agent'`만 agent 경로, 그 외(human·null=미상)는 human 경로(보수적 기본값).

## 셀프 게이트
- tsc/lint 0
- vitest 전체 475 files / 3985 tests green(신규 7)
- verify:no-handrolled-modal OK
- build EXIT 0

## Test plan
- [x] tsc/lint/build/vitest 전체 그린
- [x] AuditRow 아바타 shape 3건(human/agent/무렌더)·auditActorProps 4건(agent/human/미상폴백/actor_name없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)