### PR TITLE
[SID:2893] feat(2893): SHA 재-pending 시 qa:pass/design:pass 라벨 자동 unlabel (PR②/B1+B2-a)

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -318,6 +318,7 @@ async def _process_webhook_event(
     *,
     gate_check_publish: list[dict] | None = None,
     ungated_check_publish: list[dict] | None = None,
+    label_unlabel_publish: list[dict] | None = None,
 ) -> tuple[dict, str]:
     """검증·dedup 통과한 이벤트 처리(legacy/app 라우팅·Bot-L.1 resolver 체인). (result, status) 반환.
 
@@ -335,6 +336,10 @@ async def _process_webhook_event(
     바뀐 경우만**, story #2912)가 발행해야 할 GitHub check-run 정보를 append — 호출자(github_webhook)
     가 **commit 後** 배경 태스크로 발행(fail-closed: GitHub 외부 API 호출을 DB 트랜잭션 성공 확정
     前에 하지 않는다).
+
+    ``label_unlabel_publish``(story #2893 설계안 §3 B2-a, 위와 동형 outparam): `reopen_gate_if_new_sha`
+    가 실제로 SHA 재-pending을 발생시킨 경우에만(단순 재확인·SHA 일치는 대상 아님) qa:pass/
+    design:pass 라벨 제거 요청을 append — 마찬가지로 commit 後 background_tasks로 발행.
     """
     texts = _candidate_texts(payload)
     repo = (payload.get("repository") or {}).get("full_name") or ""
@@ -468,7 +473,7 @@ async def _process_webhook_event(
             gate_type=_MERGE_GATE_TYPE, pr_number=(pr_number if pr_number > 0 else None),
         )
         if merge_gate is not None:
-            await reopen_gate_if_new_sha(
+            _repended = await reopen_gate_if_new_sha(
                 session, org_id, merge_gate, head_sha,
                 repo_full_name=repo, pr_number=pr_number,
             )
@@ -476,6 +481,17 @@ async def _process_webhook_event(
                 "org_id": org_id, "gate_id": merge_gate.id,
                 "head_sha": head_sha, "repo_full_name": repo, "pr_number": pr_number,
             })
+            # story #2893(설계안 §3 B2-a) — 「라벨=검증된 SHA에 대한 약속」. 실제 재-pending이
+            # 일어난 경우(SHA 실불일치)에만 qa:pass/design:pass를 뗀다(재검토 강제) — SHA가
+            # 그대로면(False) 아직 유효한 약속이므로 라벨은 안 건드린다. diff 분류 fast-path
+            # (문서만 변경 등 자동 재라벨)는 PO 명시 스코프 밖 — 여기 조건분기 0.
+            if _repended and label_unlabel_publish is not None:
+                from app.services.gate_github_check import RECHECK_LABELS
+
+                label_unlabel_publish.append({
+                    "org_id": org_id, "repo_full_name": repo, "pr_number": pr_number,
+                    "labels": list(RECHECK_LABELS),
+                })
         else:
             # story #2826(주 처방, PO 확定 2026-08-20) — story 링크는 해소됐는데 gate가 아직
             # 없다(지금까지 유일한 생성 경로였던 board →done preflight를 아직 안 거쳤다는 뜻,
@@ -806,11 +822,13 @@ async def github_webhook(
     # 5) 처리 + status 갱신 + commit 을 **동일 트랜잭션**으로. 실패=rollback(delivery row 도 함께 → retry 보존).
     _gate_check_publish: list[dict] = []
     _ungated_check_publish: list[dict] = []
+    _label_unlabel_publish: list[dict] = []
     try:
         result, status_label = await _process_webhook_event(
             session, source, event, payload, installation_id, delivery,
             gate_check_publish=_gate_check_publish,
             ungated_check_publish=_ungated_check_publish,
+            label_unlabel_publish=_label_unlabel_publish,
         )
         delivery.status = status_label
         # story #2327(재정의): "ignored"의 실제 사유를 delivery 행에도 남긴다 — HTTP 응답
@@ -830,6 +848,13 @@ async def github_webhook(
 
             for _payload in _ungated_check_publish:
                 background_tasks.add_task(publish_action_required_check, **_payload)
+        # story #2893(설계안 §3 B2-a): SHA 재-pending으로 인한 qa:pass/design:pass 라벨 제거도
+        # 동일하게 commit 後 발행(fail-closed).
+        if _label_unlabel_publish:
+            from app.services.gate_github_check import publish_label_unlabel
+
+            for _payload in _label_unlabel_publish:
+                background_tasks.add_task(publish_label_unlabel, **_payload)
         return _ok(result)
     except Exception as exc:
         await session.rollback()  # delivery insert 포함 전부 rollback → GitHub retry 가 재처리(영구 no-op 금지).

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -292,6 +292,38 @@ async def publish_gate_check(
         logger.exception("gate=%s: check 발행 처리 중 예외(fail-closed, GitHub 쪽 무영향)", gate_id)
 
 
+# story #2893(설계안 §3 B2-a) — 재검토를 강제하는 대상 라벨. 「라벨=검증된 SHA에 대한 약속」
+# 시맨틱이라 SHA 재-pending 시 이 둘을 뗀다. diff 분류 fast-path(문서만 변경 등)는 설계상
+# 스코프 밖(PO 명시 제외, 2026-08-21) — 여기 조건 분기 0.
+RECHECK_LABELS = ("qa:pass", "design:pass")
+
+
+async def publish_label_unlabel(org_id: uuid.UUID, repo_full_name: str, pr_number: int, labels: list[str]) -> None:
+    """story #2893(설계안 §3 B2-a) — SHA 재-pending 시 qa:pass/design:pass 라벨을 GitHub에서
+    제거한다. `publish_gate_check`와 동일 background-task 패턴(자기 세션 열어 installation_id만
+    해소 — gate row 조회는 이 함수 관심사 밖, 호출자(verdict_capture.py)가 재-pending 판단을
+    이미 끝내고 넘긴다). 절대 예외를 던지지 않는다 — 실패는 로그만(fail-closed: 라벨이 안
+    떨어져도 GitHub 쪽은 이전 상태 그대로일 뿐, DB 트랜잭션은 이미 커밋 완료된 뒤라 무관)."""
+    from app.core.database import async_session_factory
+    from app.services.github_app import remove_pr_label
+
+    try:
+        async with async_session_factory() as session:
+            installation_id = await _resolve_installation_id(session, org_id)
+        if installation_id is None:
+            logger.info("org=%s: GitHub installation 없음 — 라벨 제거 skip", org_id)
+            return
+        for label in labels:
+            ok = await remove_pr_label(installation_id, repo_full_name, pr_number, label)
+            if not ok:
+                logger.warning(
+                    "repo=%s pr=%s label=%s 제거 실패(fail-closed, GitHub 쪽 무영향)",
+                    repo_full_name, pr_number, label,
+                )
+    except Exception:  # noqa: BLE001 — fail-closed 경계: 백그라운드 태스크는 절대 안 죽는다.
+        logger.exception("repo=%s pr=%s: 라벨 제거 처리 중 예외(fail-closed)", repo_full_name, pr_number)
+
+
 async def reopen_gate_if_new_sha(
     session: AsyncSession,
     org_id: uuid.UUID,

--- a/backend/app/services/github_app.py
+++ b/backend/app/services/github_app.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
+from urllib.parse import quote
 
 import httpx
 from jose import JWTError, jwt
@@ -204,6 +205,34 @@ async def update_check_run(
         )
         return None
     return resp.json()
+
+
+async def remove_pr_label(installation_id: int, repo_full_name: str, pr_number: int, label: str) -> bool:
+    """story #2893(설계안 §3 B2-a) — `DELETE /repos/{repo}/issues/{pr}/labels/{name}`(PR도 issue
+    라벨 엔드포인트 공유, GitHub 공식). SHA 재-pending 시 qa:pass/design:pass를 강제로 뗀다
+    (「라벨=검증된 SHA에 대한 약속」 시맨틱 — 새 커밋이 오면 그 약속은 깨진 것).
+
+    404(그 라벨이 애초에 PR에 없음)는 목표 상태(라벨 없음)와 동일하므로 성공 취급(idempotent —
+    "있으면 떼고 없으면 그대로"). 그 외 실패만 경고 로그+False. create_check_run과 동일 계약:
+    예외 미삼킴(호출자가 fail-closed try/except 담당)."""
+    token = await get_installation_token(installation_id)
+    if not token:
+        return False
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.delete(
+            f"{_GITHUB_API}/repos/{repo_full_name}/issues/{pr_number}/labels/{quote(label, safe='')}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+    if resp.status_code not in (200, 404):
+        logger.warning(
+            "label 제거 실패 HTTP %s (repo=%s pr=%s label=%s)",
+            resp.status_code, repo_full_name, pr_number, label,
+        )
+        return False
+    return True
 
 
 async def fetch_installation_metadata(installation_id: int) -> dict | None:

--- a/backend/tests/test_2813_github_checks_api.py
+++ b/backend/tests/test_2813_github_checks_api.py
@@ -106,3 +106,47 @@ async def test_update_check_run_http_failure_returns_none_not_raise():
     with patch("httpx.AsyncClient.patch", new=AsyncMock(return_value=r)):
         result = await ga.update_check_run(999, "acme/repo", 555, status="completed", conclusion="failure")
     assert result is None
+
+
+# story #2893(설계안 §3 B2-a) — remove_pr_label(신규, create/update_check_run과 동형 계약).
+@pytest.mark.anyio
+async def test_remove_pr_label_sends_delete_to_correct_url():
+    r = _resp(200, {})
+    captured = {}
+
+    async def _delete(self, url, headers=None):
+        captured["url"] = url
+        return r
+
+    with patch("httpx.AsyncClient.delete", new=_delete):
+        result = await ga.remove_pr_label(999, "acme/repo", 42, "design:pass")
+
+    assert result is True
+    # ':' 는 URL 컴포넌트라 인코딩돼야 한다(라벨명이 그대로 path segment에 못 들어감).
+    assert captured["url"] == "https://api.github.com/repos/acme/repo/issues/42/labels/design%3Apass"
+
+
+@pytest.mark.anyio
+async def test_remove_pr_label_404_is_idempotent_success():
+    """라벨이 애초에 없었다 — 목표 상태(제거됨)와 동일하므로 성공 취급(fail-closed 아님,
+    존재-확인 없이 매번 시도하는 설계에서 필수)."""
+    r = _resp(404, {})
+    with patch("httpx.AsyncClient.delete", new=AsyncMock(return_value=r)):
+        result = await ga.remove_pr_label(999, "acme/repo", 42, "qa:pass")
+    assert result is True
+
+
+@pytest.mark.anyio
+async def test_remove_pr_label_other_failure_returns_false_not_raise():
+    r = _resp(500, {})
+    with patch("httpx.AsyncClient.delete", new=AsyncMock(return_value=r)):
+        result = await ga.remove_pr_label(999, "acme/repo", 42, "qa:pass")
+    assert result is False
+
+
+@pytest.mark.anyio
+async def test_remove_pr_label_no_token_returns_false():
+    ga._token_cache.clear()
+    with patch.object(ga, "build_app_jwt", return_value=None):
+        result = await ga.remove_pr_label(999, "acme/repo", 42, "qa:pass")
+    assert result is False

--- a/backend/tests/test_2893_pr2_sha_repending_label_unlabel_realdb.py
+++ b/backend/tests/test_2893_pr2_sha_repending_label_unlabel_realdb.py
@@ -1,0 +1,234 @@
+"""story #2893(설계안 gate-auto-creation-design-2893 §3, PR②/B1+B2-a) — SHA-diff 자동
+재-pending은 이미 #2813에서 완성돼 있었다(reopen_gate_if_new_sha). 이 PR의 신규 축은 B2-a
+(라벨 자동 unlabel) 하나 — 「라벨=검증된 SHA에 대한 약속」 시맨틱을 웹훅 경로에 배선한다:
+synchronize로 head SHA가 anchor(gate.approved_head_sha)와 달라져 실제 재-pending이 발생하면
+qa:pass/design:pass 라벨 제거를 GitHub에 요청해야 한다.
+
+실 GitHub API(remove_pr_label/create_check_run)만 mock — DB 왕복은 실 Postgres
+(test_2893_gate_pr_scoped_isolation_realdb.py와 동일 관례, 헬퍼도 그대로 재사용).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_2893_gate_pr_scoped_isolation_realdb import (
+    _post_app,
+    _pr_payload,
+    _seed_installation,
+    _seed_link,
+    _seed_org_project_story,
+    _session_factory,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _seed_approved_pr_gate(s, org, story, *, pr_number, installation_id, anchor_sha):
+    """이미 승인·라벨(qa:pass/design:pass)이 붙은 상태를 직접 시드 — 실 승인 플로우(gates.py)를
+    타지 않고 이 파일의 관심사(재-pending 발생 시 라벨 제거 배선)만 좁혀 재현한다."""
+    from app.models.gate import Gate, set_gate_status
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+        gate_type=MERGE_GATE_TYPE, status="pending", pr_number=pr_number, requires_human=False,
+    )
+    set_gate_status(gate, "approved", now=datetime.now(timezone.utc))
+    gate.approved_head_sha = anchor_sha
+    gate.github_check_run_id = 92001
+    gate.github_check_run_sha = anchor_sha
+    s.add(gate)
+    await s.commit()
+    return gate
+
+
+async def _reload_gate(Session, gate_id):
+    from app.models.gate import Gate
+
+    async with Session() as s:
+        return (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_sha_mismatch_synchronize_triggers_repending_and_unlabels_both_recheck_labels():
+    """B1(재-pending)+B2-a(unlabel) 결합 — synchronize의 head_sha가 anchor와 다르면 gate가
+    pending으로 돌고, qa:pass/design:pass 둘 다 제거가 시도돼야 한다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680301)
+            await _seed_link(s, org, story, pr_number=301)
+            gate = await _seed_approved_pr_gate(
+                s, org, story, pr_number=301, installation_id=680301, anchor_sha="sha-orig",
+            )
+            gate_id = gate.id
+
+        removed_calls = []
+
+        async def _fake_remove(installation_id, repo_full_name, pr_number, label):
+            removed_calls.append((installation_id, repo_full_name, pr_number, label))
+            return True
+
+        with (
+            patch("app.services.github_app.remove_pr_label", new=_fake_remove),
+            patch("app.services.gate_github_check.create_check_run", AsyncMock(return_value={"id": 92002})),
+            patch("app.services.gate_github_check.update_check_run", AsyncMock(return_value={"id": 92002})),
+            patch("app.core.database.async_session_factory", Session),
+        ):
+            resp = await _post_app(
+                _pr_payload(action="synchronize", pr_number=301, installation_id=680301, head_sha="sha-new"),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+        assert resp.status_code == 200
+
+        gate_after = await _reload_gate(Session, gate_id)
+        assert gate_after.status == "pending", "SHA 불일치 → 재-pending(B1, #2813 기존 동작)"
+        assert gate_after.approved_head_sha is None
+
+        assert {c[3] for c in removed_calls} == {"qa:pass", "design:pass"}, "두 라벨 모두 제거 시도"
+        assert all(c[1] == "moonklabs/sprintable" and c[2] == 301 for c in removed_calls)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sha_match_does_not_repend_or_unlabel():
+    """synchronize라도 head_sha가 anchor와 같으면(GitHub이 보내는 raw 이벤트라 실질 변경 없는
+    호출도 온다) 재-pending도 라벨 제거도 발생하면 안 된다 — reopen_gate_if_new_sha의 기존
+    가드(approved_head_sha == new_head_sha → False)가 그대로 라벨 축의 게이트 역할도 한다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680302)
+            await _seed_link(s, org, story, pr_number=302)
+            gate = await _seed_approved_pr_gate(
+                s, org, story, pr_number=302, installation_id=680302, anchor_sha="sha-same",
+            )
+            gate_id = gate.id
+
+        removed_calls = []
+
+        async def _fake_remove(installation_id, repo_full_name, pr_number, label):
+            removed_calls.append((installation_id, repo_full_name, pr_number, label))
+            return True
+
+        with (
+            patch("app.services.github_app.remove_pr_label", new=_fake_remove),
+            patch("app.services.gate_github_check.create_check_run", AsyncMock(return_value={"id": 92003})),
+            patch("app.services.gate_github_check.update_check_run", AsyncMock(return_value={"id": 92003})),
+            patch("app.core.database.async_session_factory", Session),
+        ):
+            await _post_app(
+                _pr_payload(action="synchronize", pr_number=302, installation_id=680302, head_sha="sha-same"),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+
+        gate_after = await _reload_gate(Session, gate_id)
+        assert gate_after.status == "approved", "SHA 일치 — 재-pending 없음(기존 #2813 계약)"
+        assert gate_after.approved_head_sha == "sha-same"
+        assert removed_calls == [], "재-pending이 안 일어났으면 라벨도 안 건드려야 함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_diff_classification_fast_path_docs_only_title_still_unlabels():
+    """PO 명시 제외(2026-08-21) — 문서만 변경 등 diff 분류 fast-path는 스코프 밖. PR 제목이
+    "docs:"로 시작해도(문서 전용 변경을 시사) 특별취급 없이 다른 케이스와 동일하게
+    재-pending+양쪽 라벨 제거가 그대로 일어나야 한다(코드가 title/diff 내용을 보고 건너뛰는
+    분기를 만들지 않았다는 것의 회귀 가드)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680303)
+            await _seed_link(s, org, story, pr_number=303)
+            gate = await _seed_approved_pr_gate(
+                s, org, story, pr_number=303, installation_id=680303, anchor_sha="sha-docs-orig",
+            )
+            gate_id = gate.id
+
+        removed_calls = []
+
+        async def _fake_remove(installation_id, repo_full_name, pr_number, label):
+            removed_calls.append(label)
+            return True
+
+        with (
+            patch("app.services.github_app.remove_pr_label", new=_fake_remove),
+            patch("app.services.gate_github_check.create_check_run", AsyncMock(return_value={"id": 92004})),
+            patch("app.services.gate_github_check.update_check_run", AsyncMock(return_value={"id": 92004})),
+            patch("app.core.database.async_session_factory", Session),
+        ):
+            await _post_app(
+                _pr_payload(
+                    action="synchronize", pr_number=303, installation_id=680303,
+                    head_sha="sha-docs-new", title="docs: update README only",
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+
+        gate_after = await _reload_gate(Session, gate_id)
+        assert gate_after.status == "pending", "docs 제목이어도 fast-path 없음 — 여전히 재-pending"
+        assert set(removed_calls) == {"qa:pass", "design:pass"}, "docs 제목이어도 fast-path 없음 — 여전히 unlabel"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_label_removal_failure_does_not_block_response_or_gate_state():
+    """fail-closed — GitHub 쪽 라벨 제거가 실패(401/5xx 등)해도 웹훅 응답·gate DB 상태(이미
+    커밋된 재-pending)는 영향 없어야 한다(publish_label_unlabel은 commit 後 background task —
+    실패해도 트랜잭션과 무관)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680304)
+            await _seed_link(s, org, story, pr_number=304)
+            gate = await _seed_approved_pr_gate(
+                s, org, story, pr_number=304, installation_id=680304, anchor_sha="sha-fail-orig",
+            )
+            gate_id = gate.id
+
+        with (
+            patch("app.services.github_app.remove_pr_label", AsyncMock(return_value=False)),
+            patch("app.services.gate_github_check.create_check_run", AsyncMock(return_value={"id": 92005})),
+            patch("app.services.gate_github_check.update_check_run", AsyncMock(return_value={"id": 92005})),
+            patch("app.core.database.async_session_factory", Session),
+        ):
+            resp = await _post_app(
+                _pr_payload(action="synchronize", pr_number=304, installation_id=680304, head_sha="sha-fail-new"),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+        assert resp.status_code == 200, "라벨 제거 실패가 웹훅 응답을 깨면 안 됨(fail-closed)"
+
+        gate_after = await _reload_gate(Session, gate_id)
+        assert gate_after.status == "pending", "라벨 제거 실패와 무관하게 재-pending(DB)은 이미 커밋됨"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약

[SID:2893]

story #2893(gate-auto-creation-design-2893 설계안 §3, PO 승인) 4-PR 절단 중 **PR②** — B1(SHA-diff 자동 재-pending)+B2-a(qa:pass/design:pass 라벨 자동 unlabel).

**base=`feat/2893-pr-scoped-gate-slots`(PR①, #3349)** — pr_number 컬럼(0271 마이그레이션)에 의존하는 스택. PR① 머지 後 develop 재정렬 1회 필요(사전 합의됨).

## B1 — SHA-diff 자동 재-pending

`reopen_gate_if_new_sha()`(story #2813, `gate_github_check.py:295-346`)가 이미 완전히 구현돼 있었다 — 이번 PR에서 새 로직 0, PR①에서 이미 `pr_number` 스코핑을 받았다. synchronize 웹훅의 head SHA가 승인 anchor(`gate.approved_head_sha`)와 다르면 gate를 pending으로 되돌린다.

## B2-a — 라벨 자동 unlabel (신규)

「라벨=검증된 SHA에 대한 약속」 시맨틱 — 새 커밋이 오면 그 약속은 깨진 것이므로 qa:pass/design:pass를 강제로 뗀다(재검토 강제).

- **`app/services/github_app.py::remove_pr_label`**(신규) — `DELETE /repos/{repo}/issues/{pr}/labels/{name}`(PR도 issue 라벨 엔드포인트 공유). `create_check_run`/`update_check_run`과 동형 계약: 예외 미삼킴, 실패는 로그+False. 404(라벨이 애초에 없음)는 목표 상태(제거됨)와 동일 → idempotent 성공 취급.
- **`app/services/gate_github_check.py::publish_label_unlabel`**(신규) + `RECHECK_LABELS = ("qa:pass", "design:pass")` — `publish_gate_check`와 동형 background-task 패턴(자기 세션 열어 installation_id만 해소, 절대 예외를 던지지 않음).
- **`app/routers/verdict_capture.py`** — `_process_webhook_event`에 3번째 outparam `label_unlabel_publish` 추가. `reopen_gate_if_new_sha`가 **실제로 True를 반환한 경우에만**(SHA 실불일치) append — SHA가 그대로면(라벨=여전히 유효한 약속) 안 건드린다. `github_webhook()`에서 기존 `gate_check_publish`/`ungated_check_publish`와 동일하게 **commit 後**에만 `background_tasks.add_task(...)`로 발행(fail-closed).

**PO 명시 스코프 제외 준수**: diff 분류 fast-path(문서만 변경 시 자동 재라벨 등)는 §3 스코프 밖 — 조건분기 0. 회귀 테스트로 부재를 직접 증명(`test_no_diff_classification_fast_path_docs_only_title_still_unlabels`).

## 검증

- `tests/test_2813_github_checks_api.py`에 `remove_pr_label` 단위 5건 추가(URL 인코딩·404 idempotent·기타 실패 False·토큰 없음) — green.
- `tests/test_2893_pr2_sha_repending_label_unlabel_realdb.py`(신규, 실 PG) 4건 — SHA 불일치→재-pending+양쪽 라벨 제거 / SHA 일치→둘 다 무터치 / docs 제목이어도 fast-path 없음 / 라벨 제거 실패가 웹훅 응답·DB 상태를 안 깸(fail-closed) — 전부 green.
- **뮤테이션 검증**: `if _repended and label_unlabel_publish is not None:` → `if True and ...`로 가드 제거 → `test_sha_match_does_not_repend_or_unlabel`이 정확히 그 자리에서 예상대로 깨짐 확인 후 복원, 재검증 green.
- 인접 회귀파일 5개(2156/2520/2826/2853/2893①) 각 격리 신선 DB로 재실행 — `test_2520_line_merge_gate_reconcile.py`의 1건(`test_reconcile_updates_line_style_gate_regardless_of_h1_flag_realdb`)만 실패, `git stash`+동일 격리 재실행으로 이 브랜치 변경과 무관한 pre-existing 실패임을 확인(미손, 스코프 밖).
- `import app.routers.verdict_capture, app.services.gate_github_check, app.services.github_app` — 순환참조/구문 이상 없음. ruff 로컬 미설치(기존 세션과 동일) — CI 린트에 위임.

## 후속

PR③(B3 — 명시적 재평가 API), PR④(C1 — 웹훅 기반 게이트 생성-트리거 감지) 대기 — 각각 별도 착수 신호.