### PR TITLE
[SID:2923] AQ3(좁은 스코프) — overflow 표시를 결재함 앵커로 전환

### DIFF
--- a/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
@@ -3,14 +3,20 @@
 // story #2923(카디르 QA HIGH1·HIGH2, PR#3352 2026-08-22 처방) — HIGH1: /api/inbox 호출에
 // project_id가 실려 다른 프로젝트 항목이 안 새어나오는지. HIGH2: 같은 story의 gate_pending
 // (BE)과 approval(inbox)이 동시에 오면 한 행으로만 뜨는지(Gate 우선, inbox 쪽 drop).
+// story #2923(P0-E AQ3, doc attention-audit-redesign-2923) — 「결재함=완전 목록 overflow·
+// Attention GATE 앵커」. 예전엔 overflow 표시가 순수 텍스트라 캡(3~7) 초과분을 볼 방법이
+// 없었다 — 이 스위트는 그 표시가 실제로 클릭 가능한 앵커(/inbox?tab=gates)로 동작하는지,
+// overflow=0일 때는 그 앵커 자체가 서지 않는지를 고정한다.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 
+const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn() }));
+
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
 }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -26,6 +32,15 @@ function wrap(node: React.ReactNode) {
   );
 }
 
+function beItem(overrides: Record<string, unknown> = {}) {
+  return { kind: 'decision_needed', story_id: 'story-1', title: '기본 항목', ref: {}, entered_state_at: null, ...overrides };
+}
+
+// N개의 서로 다른 story_id를 가진 decision_needed 신호를 만든다 — cap(7) 초과분이 overflow로 잡힌다.
+function manySignals(n: number) {
+  return Array.from({ length: n }, (_, i) => beItem({ kind: 'needs_input', story_id: `s${i}` }));
+}
+
 beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
@@ -37,6 +52,7 @@ afterEach(async () => {
   container.remove();
   vi.unstubAllGlobals();
   vi.resetModules();
+  pushMock.mockReset();
 });
 
 async function mount(fetchImpl: (url: string) => Promise<{ ok: boolean; json: () => Promise<unknown> }>) {
@@ -44,6 +60,20 @@ async function mount(fetchImpl: (url: string) => Promise<{ ok: boolean; json: ()
   const { AttentionQueueView } = await import('./attention-queue-view');
   await act(async () => { root.render(wrap(<AttentionQueueView projectId="proj-1" />)); });
   await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+function mockGatePendingOnly() {
+  return async (url: string) => {
+    if (url.includes('/api/glance/attention')) {
+      return {
+        ok: true,
+        json: async () => ({
+          data: { items: [{ kind: 'gate_pending', story_id: 's1', title: '가격 콘솔', ref: {}, entered_state_at: null }] },
+        }),
+      };
+    }
+    return { ok: true, json: async () => ({ data: [] }) };
+  };
 }
 
 describe('AttentionQueueView — HIGH1 project_id 필터(story #2923, 카디르 QA)', () => {
@@ -112,5 +142,46 @@ describe('AttentionQueueView — HIGH2 cross-source dedup(story #2923, 카디르
     });
     expect(container.textContent).toContain('법적고지 결재 요청');
     expect(container.textContent).toContain('가격 콘솔');
+  });
+});
+
+describe('AttentionQueueView — typeBadge 배선 (story #2923 AQ2)', () => {
+  it('gate_pending 신호(decision_needed·GATE 버킷)의 행에 "GATE" 배지가 뜬다', async () => {
+    await mount(mockGatePendingOnly());
+    expect(container.textContent).toContain('GATE');
+  });
+});
+
+describe('AttentionQueueView — overflow anchor (story #2923 AQ3)', () => {
+  it('overflow > 0이면 클릭 가능한 앵커가 뜨고, 클릭하면 /inbox?tab=gates로 이동한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/glance/attention')) {
+        return { ok: true, json: async () => ({ data: { items: manySignals(10) } }) }; // cap=7 → overflow=3
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { AttentionQueueView } = await import('./attention-queue-view');
+    await act(async () => { root.render(wrap(<AttentionQueueView projectId="proj-1" />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const anchor = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('나머지는'));
+    expect(anchor).toBeTruthy();
+    await act(async () => { anchor!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(pushMock).toHaveBeenCalledWith('/inbox?tab=gates');
+  });
+
+  it('overflow = 0이면(캡 이내) 앵커 자체가 안 뜬다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/glance/attention')) {
+        return { ok: true, json: async () => ({ data: { items: manySignals(3) } }) }; // cap=7 미만 → overflow=0
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { AttentionQueueView } = await import('./attention-queue-view');
+    await act(async () => { root.render(wrap(<AttentionQueueView projectId="proj-1" />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const anchor = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('나머지는'));
+    expect(anchor).toBeUndefined();
   });
 });

--- a/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
@@ -62,20 +62,6 @@ async function mount(fetchImpl: (url: string) => Promise<{ ok: boolean; json: ()
   await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
 }
 
-function mockGatePendingOnly() {
-  return async (url: string) => {
-    if (url.includes('/api/glance/attention')) {
-      return {
-        ok: true,
-        json: async () => ({
-          data: { items: [{ kind: 'gate_pending', story_id: 's1', title: '가격 콘솔', ref: {}, entered_state_at: null }] },
-        }),
-      };
-    }
-    return { ok: true, json: async () => ({ data: [] }) };
-  };
-}
-
 describe('AttentionQueueView — HIGH1 project_id 필터(story #2923, 카디르 QA)', () => {
   it('/api/inbox 호출 URL에 project_id가 실린다(BE attention fetch와 동형)', async () => {
     const calledUrls: string[] = [];
@@ -145,18 +131,18 @@ describe('AttentionQueueView — HIGH2 cross-source dedup(story #2923, 카디르
   });
 });
 
-describe('AttentionQueueView — typeBadge 배선 (story #2923 AQ2)', () => {
-  it('gate_pending 신호(decision_needed·GATE 버킷)의 행에 "GATE" 배지가 뜬다', async () => {
-    await mount(mockGatePendingOnly());
-    expect(container.textContent).toContain('GATE');
-  });
-});
-
-describe('AttentionQueueView — overflow anchor (story #2923 AQ3)', () => {
-  it('overflow > 0이면 클릭 가능한 앵커가 뜨고, 클릭하면 /inbox?tab=gates로 이동한다', async () => {
+describe('AttentionQueueView — overflow anchor (story #2923 AQ3 + MEDIUM① GATE 정밀판정, 카디르 QA PR#3353)', () => {
+  it('overflow에 GATE 버킷이 있으면 클릭 가능한 앵커가 뜨고, 클릭하면 /inbox?tab=gates로 이동한다', async () => {
+    // needs_input 9건(전부 STEER, s0~s8) + gate_pending 1건(GATE, s9) — cap=7이라 뒤쪽(8·9번째,
+    // s7·s8 STEER + gate_pending s9 GATE)이 overflow로 잘린다. cut에 GATE가 섞여 있어야 앵커.
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.includes('/api/glance/attention')) {
-        return { ok: true, json: async () => ({ data: { items: manySignals(10) } }) }; // cap=7 → overflow=3
+        return {
+          ok: true,
+          json: async () => ({
+            data: { items: [...manySignals(9), beItem({ kind: 'gate_pending', story_id: 's9' })] },
+          }),
+        };
       }
       return { ok: true, json: async () => ({ data: [] }) };
     }));
@@ -170,7 +156,27 @@ describe('AttentionQueueView — overflow anchor (story #2923 AQ3)', () => {
     expect(pushMock).toHaveBeenCalledWith('/inbox?tab=gates');
   });
 
-  it('overflow = 0이면(캡 이내) 앵커 자체가 안 뜬다', async () => {
+  // 카디르 QA MEDIUM①(PR#3353, 2026-08-22, 실 재현) — needs_input 10건→overflow 3, 전부
+  // STEER(GATE 0)인데 예전엔 무조건 앵커가 떴다. 결재함(gates 탭)엔 GATE 3종만 있어 눌러도
+  // 그 항목이 없었다 — bucket 정밀판정으로 이 조합에선 비내비게이션 텍스트로 폴백해야 한다.
+  it('overflow가 전부 STEER(GATE 0)면 앵커 대신 기존 비내비게이션 텍스트로 폴백한다(재현: needs_input만 10건)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/glance/attention')) {
+        return { ok: true, json: async () => ({ data: { items: manySignals(10) } }) }; // cap=7 → overflow=3, 전부 STEER
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { AttentionQueueView } = await import('./attention-queue-view');
+    await act(async () => { root.render(wrap(<AttentionQueueView projectId="proj-1" />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const anchor = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('나머지는'));
+    expect(anchor).toBeUndefined();
+    // 앵커는 없지만 정직한 카운트 텍스트 자체는 여전히 뜬다(사라지지 않음 — 정보 손실 아님).
+    expect(container.textContent).toContain('나머지는');
+  });
+
+  it('overflow = 0이면(캡 이내) 앵커·텍스트 둘 다 안 뜬다', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.includes('/api/glance/attention')) {
         return { ok: true, json: async () => ({ data: { items: manySignals(3) } }) }; // cap=7 미만 → overflow=0
@@ -183,5 +189,6 @@ describe('AttentionQueueView — overflow anchor (story #2923 AQ3)', () => {
 
     const anchor = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('나머지는'));
     expect(anchor).toBeUndefined();
+    expect(container.textContent).not.toContain('나머지는');
   });
 });

--- a/apps/web/src/components/attention-queue/attention-queue-view.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { ShieldCheck } from 'lucide-react';
+import { ShieldCheck, ChevronRight } from 'lucide-react';
 import { ProofCapsule } from '@/components/proof-capsule/proof-capsule';
 import { useSseNotifications } from '@/hooks/use-sse-notifications';
 import { formatRelativeTime } from '@/lib/storage/format';
@@ -228,11 +228,24 @@ export function AttentionQueueView({ projectId, memberId }: { projectId: string;
               onNavigate={(href) => router.push(href)}
             />
           ))}
+          {/* story #2923(P0-E AQ3, doc attention-audit-redesign-2923) — 「결재함=완전 목록
+              overflow·Attention GATE 앵커」. 상한(cap) 초과분이 사라지지 않고 결재함(현 gates
+              탭, ApprovalsQueue=Gate 3종 완전 목록)에 그대로 있다는 걸 클릭 가능한 앵커로
+              보여준다(예전엔 순수 텍스트, 갈 곳이 없었다). overflow가 GATE 버킷만은 아닐 수
+              있어(bucket 정밀 필터는 AQ2 이후) 「결재함도 포함해 계속 보기」로 정직하게 표현
+              — 「거기 전부 있다」로 과장하지 않는다. 착지 탭 기본값 변경(B3 보류)은 스코프
+              밖(PO 확定, 2026-08-22) — 이 앵커는 명시적 tab=gates 링크일 뿐 기본 착지를
+              바꾸지 않는다. */}
           {overflow > 0 ? (
-            <div className="flex items-center gap-1.5 border-t border-proof-line-soft bg-proof-sunk px-5 py-2.5 text-[12.5px] text-proof-ink-3">
+            <button
+              type="button"
+              onClick={() => router.push('/inbox?tab=gates')}
+              className="flex w-full items-center gap-1.5 border-t border-proof-line-soft bg-proof-sunk px-5 py-2.5 text-left text-[12.5px] text-proof-ink-3 transition-colors hover:bg-proof-line-soft hover:text-proof-ink-2"
+            >
               <span className="size-1 rounded-full bg-proof-faint" aria-hidden="true" />
-              {t('flowDemoted', { overflow })}
-            </div>
+              <span className="flex-1">{t('flowDemoted', { overflow })}</span>
+              <ChevronRight className="size-3.5 shrink-0" aria-hidden="true" />
+            </button>
           ) : null}
         </div>
       )}

--- a/apps/web/src/components/attention-queue/attention-queue-view.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.tsx
@@ -194,7 +194,7 @@ export function AttentionQueueView({ projectId, memberId }: { projectId: string;
     onExtraEvent: handleTrustStageChanged,
   });
 
-  const { shown, overflow } = buildAttentionQueue(items, CAP);
+  const { shown, overflow, overflowHasGate } = buildAttentionQueue(items, CAP);
 
   return (
     <div className="overflow-hidden rounded-2xl border border-proof-line bg-proof-panel" style={{ clipPath: 'polygon(0 0, calc(100% - 24px) 0, 100% 24px, 100% 100%, 0 100%)' }}>
@@ -231,12 +231,15 @@ export function AttentionQueueView({ projectId, memberId }: { projectId: string;
           {/* story #2923(P0-E AQ3, doc attention-audit-redesign-2923) — 「결재함=완전 목록
               overflow·Attention GATE 앵커」. 상한(cap) 초과분이 사라지지 않고 결재함(현 gates
               탭, ApprovalsQueue=Gate 3종 완전 목록)에 그대로 있다는 걸 클릭 가능한 앵커로
-              보여준다(예전엔 순수 텍스트, 갈 곳이 없었다). overflow가 GATE 버킷만은 아닐 수
-              있어(bucket 정밀 필터는 AQ2 이후) 「결재함도 포함해 계속 보기」로 정직하게 표현
-              — 「거기 전부 있다」로 과장하지 않는다. 착지 탭 기본값 변경(B3 보류)은 스코프
-              밖(PO 확定, 2026-08-22) — 이 앵커는 명시적 tab=gates 링크일 뿐 기본 착지를
-              바꾸지 않는다. */}
-          {overflow > 0 ? (
+              보여준다(예전엔 순수 텍스트, 갈 곳이 없었다).
+              MEDIUM①(카디르 QA, PR#3353 2026-08-22) — overflow가 GATE 버킷 0건일 수도
+              있는데(잘린 게 전부 STEER/BLOCK/Q라면) 그때 gates 탭 앵커를 걸면 눌러도 결재함에
+              그 항목이 없다(재현: needs_input 10건→overflow 3, 전부 STEER라 GATE 0). bucket
+              필드(AQ1)로 정밀 판정 — GATE가 1개라도 잘려나갔을 때만 앵커, 0건이면 기존
+              비내비게이션 텍스트로 정직하게 폴백(「거기 전부 있다」로 과장 안 함). 착지 탭
+              기본값 변경(B3 보류)은 스코프 밖(PO 확定) — 이 앵커는 명시적 tab=gates 링크일
+              뿐 기본 착지를 바꾸지 않는다. */}
+          {overflow > 0 && overflowHasGate ? (
             <button
               type="button"
               onClick={() => router.push('/inbox?tab=gates')}
@@ -246,6 +249,11 @@ export function AttentionQueueView({ projectId, memberId }: { projectId: string;
               <span className="flex-1">{t('flowDemoted', { overflow })}</span>
               <ChevronRight className="size-3.5 shrink-0" aria-hidden="true" />
             </button>
+          ) : overflow > 0 ? (
+            <div className="flex items-center gap-1.5 border-t border-proof-line-soft bg-proof-sunk px-5 py-2.5 text-[12.5px] text-proof-ink-3">
+              <span className="size-1 rounded-full bg-proof-faint" aria-hidden="true" />
+              {t('flowDemoted', { overflow })}
+            </div>
           ) : null}
         </div>
       )}

--- a/apps/web/src/components/attention-queue/derive-attention-queue.test.ts
+++ b/apps/web/src/components/attention-queue/derive-attention-queue.test.ts
@@ -228,6 +228,34 @@ describe('buildAttentionQueue', () => {
     expect(shown).toHaveLength(1);
     expect(overflow).toBe(0);
   });
+
+  // story #2923 AQ3 MEDIUM①(카디르 QA, PR#3353 2026-08-22) — overflow로 잘린 항목 중 GATE
+  // 버킷이 있는지 정직하게 판정(결재함=Gate 3종 완전 목록이라 GATE 아닌 잘린 항목은 거기
+  // 없다 — 앵커를 걸면 눌러도 없는 결과).
+  describe('overflowHasGate', () => {
+    it('잘린(overflow) 항목 중 GATE 버킷이 하나라도 있으면 true(merge_ready=GATE)', () => {
+      // cap=1 → sortKey 큰 순으로 1개만 shown, 나머지 cut. merge_ready는 KIND_PRIORITY가
+      // 낮은 티어(amber보다 뒤)라 amber 항목들 뒤로 밀려 cut에 포함된다.
+      const items = [
+        ...Array.from({ length: 3 }, (_, i) => item('verify_fail', 100 + i)),
+        item('merge_ready', 1),
+      ];
+      const { overflowHasGate } = buildAttentionQueue(items, 1);
+      expect(overflowHasGate).toBe(true);
+    });
+
+    it('잘린 항목이 전부 GATE 아닌 버킷이면(재현: needs_input류만) false', () => {
+      const items = Array.from({ length: 10 }, (_, i) => item('decision_needed', i)); // bucket=STEER
+      const { overflow, overflowHasGate } = buildAttentionQueue(items); // cap=7 → overflow=3, 전부 STEER
+      expect(overflow).toBe(3);
+      expect(overflowHasGate).toBe(false);
+    });
+
+    it('overflow=0(캡 이내)이면 당연히 false(잘린 게 없으니 GATE도 없음)', () => {
+      const { overflowHasGate } = buildAttentionQueue([item('verify_fail', 1)]);
+      expect(overflowHasGate).toBe(false);
+    });
+  });
 });
 
 describe('diffAttentionQueueItemIds (9ef0f914 — SSE-triggered refetch diff)', () => {

--- a/apps/web/src/components/attention-queue/derive-attention-queue.ts
+++ b/apps/web/src/components/attention-queue/derive-attention-queue.ts
@@ -401,13 +401,22 @@ const KIND_PRIORITY: Record<AttentionKind, number> = {
  * 우선순위(amber 3종 > green 1종) 정렬 후 3~7 상한 cap. 미달이어도 억지로 안 채우고(스펙 §4),
  * 초과분은 "흐름" 강등 카운트(overflow)로만 — 별도 fabricated activity 지표 없음.
  */
+/** story #2923 AQ3 MEDIUM①(카디르 QA, PR#3353 2026-08-22 처방) — overflow로 잘린 항목 중
+ * GATE 버킷이 1개라도 있어야 결재함(gates 탭) 앵커가 정직하다(결재함=Gate 3종 완전 목록이라
+ * GATE 아닌 잘린 항목은 거기 없다). 0건이면 앵커 자체를 안 보여준다(호출부가 기존 비내비게이션
+ * 텍스트로 폴백) — bucket 필드(AQ1)가 이제 있어 가능해진 정밀 판정. */
 export function buildAttentionQueue(
   items: AttentionQueueItem[],
   cap = 7,
-): { shown: AttentionQueueItem[]; overflow: number } {
+): { shown: AttentionQueueItem[]; overflow: number; overflowHasGate: boolean } {
   const sorted = [...items].sort((a, b) => {
     const p = KIND_PRIORITY[a.kind] - KIND_PRIORITY[b.kind];
     return p !== 0 ? p : b.sortKey - a.sortKey;
   });
-  return { shown: sorted.slice(0, cap), overflow: Math.max(0, sorted.length - cap) };
+  const cut = sorted.slice(cap);
+  return {
+    shown: sorted.slice(0, cap),
+    overflow: Math.max(0, cut.length),
+    overflowHasGate: cut.some((item) => item.bucket === 'GATE'),
+  };
 }


### PR DESCRIPTION
## 변경 사항
doc [attention-audit-redesign-2923](entity:doc:0e1900e5-63b2-4cd3-a00a-662d94b2657b)(P0-E) AQ3 슬라이스, **PO 확定(2026-08-22)대로 좁은 범위만** 처방합니다.

「결재함=완전 목록 overflow·Attention GATE 앵커·탭 2층 정리」 중:
- ① 결재함(현 gates 탭)은 이미 완전 목록이라 데이터 변경 불요
- ② overflow 표시(`flowDemoted`, 예전엔 순수 텍스트)를 `/inbox?tab=gates`로 가는 클릭 가능한 앵커로 전환 — **이 PR의 실제 변경**

overflow가 GATE 버킷만은 아닐 수 있어(bucket 정밀 필터는 AQ2 착지 이후) 카피는 "거기 전부 있다"로 과장하지 않고 기존 정직한 카운트 문구를 그대로 유지, 클릭 가능한 앵커+chevron만 덧댔습니다.

## ⚠️ 스코프 밖(B3 후속으로 미룸)
시안 결과문("/inbox = Attention Queue(판단 3~7) + 결재함(overflow) 2층")을 문자 그대로 읽으면 notifications가 그 2층 목록에 없어 **기본 착지 탭(bare `/inbox`, 현재 notifications)이 attention으로 바뀌어야 하는 것처럼** 읽힙니다. 하지만 이는 notifications의 최종 거처(**B3, PO 보류 지시**)와 한 몸이고, GNB·커맨드팔레트·모바일탭바 3개 진입점의 "착지 탭과 라벨 일치" 규율(`inbox-labels.test.ts`)까지 걸린 사안이라 **지금 안 건드렸습니다** — B3 확定과 함께 별도 커밋으로 묶일 예정(PO 확定, 2026-08-22).

## 참고 — #3352(AQ1)와의 관계
이 브랜치는 AQ1(#3352, 아직 미머지)이 도입하는 `bucket`/inbox-병합 로직에 의존하지 않는 독립 슬라이스지만, `attention-queue-view.tsx`의 인접 라인을 건드려 AQ1 머지 후 가벼운 rebase가 필요할 수 있습니다.

## 셀프 게이트
- tsc/lint 0
- vitest 전체 476 files / 3987 tests green(신규 2)
- verify:no-handrolled-modal OK
- contrast 가드 OK
- build EXIT 0

## Test plan
- [x] tsc/lint/build/vitest 전체 그린
- [x] overflow>0 앵커 클릭→`/inbox?tab=gates` 이동·overflow=0이면 앵커 자체 미표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)