### PR TITLE
[SID:2893] feat(2893): 명시적 게이트 재평가 API — POST /gates/{id}/reevaluate (PR③/B3)

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -14,12 +14,15 @@ from app.dependencies.database import get_db
 from app.models.doc import Doc
 from app.models.gate import Gate, is_valid_transition
 from app.models.gate_github_check_event import GateGithubCheckEvent
+from app.models.github_installation import GithubInstallation
 from app.models.hitl import HitlRequest
 from app.models.pm import Story, Task
 from app.models.visual_artifact import VisualArtifact
 from app.routers.agent_gateway import wake_agent
 from app.services.gate_github_check import is_repo_check_enforced, publish_gate_check, resolve_pr_link
-from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+from app.services.github_app import get_installation_token, get_pull_request
+from app.services.merge_verdict_gate import MERGE_GATE_TYPE, reconcile_merge_gate_with_real_evidence
+from app.services.verdict_capture import fetch_status_check_rollup
 from app.services.gate_service import (
     GateUndoNotSelfError,
     GateUndoWindowExpiredError,
@@ -1214,6 +1217,101 @@ async def transition_gate_endpoint(
         return GateResponse.model_validate(gate)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
+
+
+@router.post("/{id}/reevaluate", response_model=GateResponse)
+async def reevaluate_gate_endpoint(
+    id: uuid.UUID,
+    background_tasks: BackgroundTasks,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> GateResponse:
+    """story #2893(설계안 §3 B3) — 명시적 재평가 API. reopen(PR을 실제로 close→reopen)이나
+    「참여등록 후 빈 커밋 push」 같은 우회(오늘 #3324가 실제로 쓴 수동 경로)를 표준 경로로
+    승격한다. reopen과 달리 **GitHub 쪽 리뷰/체크 상태를 전혀 건드리지 않는다** — PR의 현재
+    head SHA/merged 상태를 순수 GET으로 읽어와 우리 쪽 게이트 판정만
+    `reconcile_merge_gate_with_real_evidence`(웹훅 경로와 동일 chokepoint)로 재실행한다.
+
+    authz: get_gate_endpoint과 동일(project_id 해소+has_project_access, 무권한은 404 —
+    존재 비노출 규율) — 승인/거부(_authorize_gate_approve_equivalent)보다 낮은 문턱이다.
+    「재평가를 트리거」는 결정이 아니라 「지금 상태를 정직하게 반영해 달라」는 요청이라
+    approver가 아닌 PR 관련자(오늘까지 close/reopen을 직접 하던 사람들)도 할 수 있어야
+    이 API가 그 우회를 실제로 대체한다.
+
+    scope: merge 게이트·status가 pending/auto_passed일 때만(reconcile_merge_gate_with_
+    real_evidence의 기존 자격조건과 동일 — approved는 landed 작업이라 재평가 대상이 아니고,
+    rejected/voided/held는 사람이 이미 명시 결정한 상태라 재평가로 우회하면 안 된다)."""
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise HTTPException(status_code=404, detail="Gate not found")
+
+    project_id = await resolve_work_item_project_id(
+        session, org_id, gate.work_item_type, gate.work_item_id,
+    )
+    if project_id is not None:
+        await require_project_access(session, uuid.UUID(auth.user_id), project_id, org_id,
+                                      not_found_detail="Gate not found")
+    elif not is_known_project_agnostic_work_item_type(gate.work_item_type):
+        raise HTTPException(status_code=404, detail="Gate not found")
+
+    if gate.gate_type != MERGE_GATE_TYPE:
+        raise HTTPException(status_code=422, detail="merge 게이트만 재평가를 지원합니다.")
+    if gate.status not in ("pending", "auto_passed"):
+        raise HTTPException(
+            status_code=422,
+            detail=f"게이트 상태({gate.status})는 재평가 대상이 아닙니다(pending/auto_passed만 가능).",
+        )
+
+    # gate.pr_number(story #2893 A1, 0271)가 이 게이트가 귀속된 PR의 1차 SSOT — neutral_facts는
+    # repo만 보강(백필 이전 legacy gate는 link row로 폴백).
+    pr_number = gate.pr_number
+    repo = (gate.neutral_facts or {}).get("repo")
+    if not repo or not pr_number:
+        _link = await resolve_pr_link(session, org_id, gate.work_item_id)
+        repo = repo or (_link.repo_full_name if _link else None)
+        pr_number = pr_number or (_link.pr_number if _link else None)
+    if not repo or not pr_number:
+        raise HTTPException(
+            status_code=422, detail="게이트에 연결된 PR 정보가 없어 재평가할 수 없습니다.",
+        )
+
+    installation = (
+        await session.execute(
+            select(GithubInstallation).where(
+                GithubInstallation.org_id == org_id, GithubInstallation.suspended_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if installation is None:
+        raise HTTPException(status_code=422, detail="GitHub App 설치가 없어 재평가할 수 없습니다.")
+    token = await get_installation_token(installation.installation_id)
+    if not token:
+        raise HTTPException(status_code=502, detail="GitHub 인증 토큰 발급 실패 — 잠시 후 다시 시도해 주세요.")
+
+    pr = await get_pull_request(installation.installation_id, repo, pr_number)
+    if pr is None:
+        raise HTTPException(status_code=502, detail="GitHub PR 정보 조회 실패 — 잠시 후 다시 시도해 주세요.")
+    head_sha = (pr.get("head") or {}).get("sha")
+    if not head_sha:
+        raise HTTPException(status_code=502, detail="GitHub PR head SHA를 확인할 수 없습니다.")
+    merged = bool(pr.get("merged"))
+    ci_result, _ci_reason = await fetch_status_check_rollup(repo, head_sha, token)
+
+    await reconcile_merge_gate_with_real_evidence(
+        session, org_id, gate.work_item_id,
+        pr_number=pr_number, repo=repo, ci_result=ci_result, merged=merged, head_sha=head_sha,
+    )
+    await session.commit()
+    # story #2459 회귀 동형 방어(2026-08-05): commit 後 model_validate 前 명시 refresh.
+    await session.refresh(gate)
+    background_tasks.add_task(
+        publish_gate_check, org_id, gate.id,
+        repo_full_name=repo, pr_number=pr_number, head_sha=head_sha,
+    )
+    return GateResponse.model_validate(gate)
 
 
 class GateVoidRequest(BaseModel):

--- a/backend/app/services/github_app.py
+++ b/backend/app/services/github_app.py
@@ -207,6 +207,31 @@ async def update_check_run(
     return resp.json()
 
 
+async def get_pull_request(installation_id: int, repo_full_name: str, pr_number: int) -> dict | None:
+    """story #2893(설계안 §3 B3) — `GET /repos/{repo}/pulls/{pr}`. `POST /gates/{id}/reevaluate`
+    (웹훅 페이로드 없이 사용자가 직접 재평가를 트리거)가 지금 이 PR의 **실 head SHA/merged**
+    상태를 읽어오는 데 쓴다 — reopen처럼 GitHub 쪽 리뷰/체크 상태를 건드리지 않고(순수 GET),
+    우리 쪽 게이트 판정만 최신 증거로 재실행한다. create_check_run과 동일 계약: 예외 미삼킴,
+    실패/토큰없음=None."""
+    token = await get_installation_token(installation_id)
+    if not token:
+        return None
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(
+            f"{_GITHUB_API}/repos/{repo_full_name}/pulls/{pr_number}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+    if resp.status_code != 200:
+        logger.warning(
+            "PR 조회 실패 HTTP %s (repo=%s pr=%s)", resp.status_code, repo_full_name, pr_number,
+        )
+        return None
+    return resp.json()
+
+
 async def remove_pr_label(installation_id: int, repo_full_name: str, pr_number: int, label: str) -> bool:
     """story #2893(설계안 §3 B2-a) — `DELETE /repos/{repo}/issues/{pr}/labels/{name}`(PR도 issue
     라벨 엔드포인트 공유, GitHub 공식). SHA 재-pending 시 qa:pass/design:pass를 강제로 뗀다

--- a/backend/tests/test_2813_github_checks_api.py
+++ b/backend/tests/test_2813_github_checks_api.py
@@ -150,3 +150,36 @@ async def test_remove_pr_label_no_token_returns_false():
     with patch.object(ga, "build_app_jwt", return_value=None):
         result = await ga.remove_pr_label(999, "acme/repo", 42, "qa:pass")
     assert result is False
+
+
+# story #2893(설계안 §3 B3) — get_pull_request(신규, create_check_run과 동형 계약).
+@pytest.mark.anyio
+async def test_get_pull_request_sends_get_to_correct_url_and_returns_body():
+    r = _resp(200, {"number": 42, "head": {"sha": "abc123"}, "merged": True})
+    captured = {}
+
+    async def _get(self, url, headers=None):
+        captured["url"] = url
+        return r
+
+    with patch("httpx.AsyncClient.get", new=_get):
+        result = await ga.get_pull_request(999, "acme/repo", 42)
+
+    assert result == {"number": 42, "head": {"sha": "abc123"}, "merged": True}
+    assert captured["url"] == "https://api.github.com/repos/acme/repo/pulls/42"
+
+
+@pytest.mark.anyio
+async def test_get_pull_request_http_failure_returns_none_not_raise():
+    r = _resp(404, {})
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=r)):
+        result = await ga.get_pull_request(999, "acme/repo", 42)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_get_pull_request_no_token_returns_none():
+    ga._token_cache.clear()
+    with patch.object(ga, "build_app_jwt", return_value=None):
+        result = await ga.get_pull_request(999, "acme/repo", 42)
+    assert result is None

--- a/backend/tests/test_2893_pr3_gate_reevaluate_realdb.py
+++ b/backend/tests/test_2893_pr3_gate_reevaluate_realdb.py
@@ -1,0 +1,407 @@
+"""story #2893(설계안 gate-auto-creation-design-2893 §3, PR③/B3) — 명시적 재평가 API.
+
+`POST /api/v2/gates/{id}/reevaluate` — reopen(PR을 실제로 close→reopen)이나 「참여등록 후
+빈 커밋 push」(오늘 #3324가 실제로 쓴 수동 경로) 같은 우회를 표준 경로로 승격한다. reopen과
+달리 GitHub 쪽 리뷰/체크 상태를 전혀 건드리지 않는다(순수 GET으로 현재 head SHA/merged를
+읽어와 우리 쪽 게이트 판정만 reconcile_merge_gate_with_real_evidence로 재실행).
+
+GitHub API 호출(get_installation_token/get_pull_request/fetch_status_check_rollup)만 mock —
+DB 왕복·평가 로직(참여/신뢰/disposition)은 실 Postgres+실 함수(test_2156의 reconcile realdb
+테스트와 동일 관례).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — transition_gate류 경로가 ActivityLog를 씀.
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed(session, *, with_project_access=True, with_participation=True, with_installation=True):
+    from app.models.github_installation import GithubInstallation
+    from app.models.organization import Organization
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="재평가 대상 스토리")
+    session.add(story)
+    await session.commit()
+
+    caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    if with_project_access:
+        session.add(ProjectAccess(
+            id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+            permission="granted", role="member",
+        ))
+        await session.commit()
+
+    if with_participation:
+        role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="dev", label="Dev", is_default=True)
+        session.add(role)
+        await session.commit()
+        member_id = uuid.uuid4()
+        session.add(Participation(
+            id=uuid.uuid4(), org_id=org.id, story_id=story.id, role_id=role.id, member_id=member_id,
+        ))
+        await session.commit()
+
+    if with_installation:
+        session.add(GithubInstallation(
+            id=uuid.uuid4(), org_id=org.id, installation_id=770001, account_login="moonklabs",
+        ))
+        await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "story_id": story.id, "caller_id": caller.id}
+
+
+async def _seed_pending_merge_gate(session, seeded, *, pr_number=55, repo="moonklabs/sprintable"):
+    """cold-start(참여는 있으나 신뢰 이력 0)라 evaluate_merge_gate가 pending을 낸다 — 재평가
+    전/후 reason 변화로 "실 증거가 실제로 반영됐는지"를 관측한다(test_2156과 동일 관례)."""
+    from app.services.merge_verdict_gate import evaluate_merge_gate
+
+    with (
+        patch(
+            "app.services.merge_verdict_gate.resolve_disposition",
+            AsyncMock(return_value=("ask", "org_policy")),
+        ),
+        patch(
+            "app.services.merge_verdict_gate._is_meaningfully_explicit_ask",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await evaluate_merge_gate(
+            session, seeded["org_id"], seeded["story_id"],
+            pr_number=pr_number, repo=repo, ci_result=None, pr_result=None,
+        )
+    await session.commit()
+
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    gate = (
+        await session.execute(
+            select(Gate).where(Gate.work_item_id == seeded["story_id"], Gate.gate_type == MERGE_GATE_TYPE)
+        )
+    ).scalar_one()
+    return gate
+
+
+def _gh_patches(*, head_sha="sha-fresh", merged=False, ci_result="success"):
+    return (
+        patch("app.routers.gates.get_installation_token", AsyncMock(return_value="inst-tok")),
+        patch(
+            "app.routers.gates.get_pull_request",
+            AsyncMock(return_value={"head": {"sha": head_sha}, "merged": merged}),
+        ),
+        patch(
+            "app.routers.gates.fetch_status_check_rollup",
+            AsyncMock(return_value=(ci_result, None)),
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_reevaluate_updates_pending_gate_with_fresh_github_evidence():
+    """핵심 — 재평가가 실제로 evaluate_merge_gate를 재실행해 reason이 "CI unknown"에서
+    "outcome sample insufficient"로 바뀐다(실 CI 증거가 게이트에 도달했다는 관측 가능한 증거,
+    test_2156의 reconcile 실증과 동일 축). reopen과 달리 GitHub 쪽 상태 변경 호출(check-run
+    생성/라벨 제거 등)은 이 흐름 자체에서 전혀 일어나지 않는다(순수 GET만 mock됨)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            gate = await _seed_pending_merge_gate(s, seeded)
+            gate_id = gate.id
+            assert "CI unknown" in (gate.decision_basis or ""), "cold-start 전제 확인"
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            p1, p2, p3 = _gh_patches(head_sha="sha-fresh", merged=False, ci_result="success")
+            with (
+                p1, p2, p3,
+                patch(
+                    "app.services.merge_verdict_gate.resolve_disposition",
+                    AsyncMock(return_value=("ask", "org_policy")),
+                ),
+                patch(
+                    "app.services.merge_verdict_gate._is_meaningfully_explicit_ask",
+                    AsyncMock(return_value=True),
+                ),
+            ):
+                resp = await client.post(f"/api/v2/gates/{gate_id}/reevaluate")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert "CI unknown" not in (body.get("decision_basis") or ""), body
+            assert "outcome sample insufficient" in (body.get("decision_basis") or ""), body
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reevaluate_rejects_non_merge_gate_type():
+    from app.main import app
+    from app.models.gate import Gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=seeded["story_id"],
+                work_item_type="story", gate_type="qa", status="pending",
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/gates/{gate_id}/reevaluate")
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reevaluate_rejects_approved_gate_status():
+    """approved는 landed 작업 — 재평가로 흔들면 안 된다(create_gate 재오픈 규율과 같은 축)."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=seeded["story_id"],
+                work_item_type="story", gate_type=MERGE_GATE_TYPE, status="approved",
+                pr_number=55, neutral_facts={"repo": "moonklabs/sprintable"},
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/gates/{gate_id}/reevaluate")
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reevaluate_rejects_gate_without_pr_context():
+    from app.main import app
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=seeded["story_id"],
+                work_item_type="story", gate_type=MERGE_GATE_TYPE, status="pending",
+                pr_number=None, neutral_facts=None,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/gates/{gate_id}/reevaluate")
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reevaluate_422_when_no_github_installation():
+    from app.main import app
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, with_installation=False)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=seeded["story_id"],
+                work_item_type="story", gate_type=MERGE_GATE_TYPE, status="pending",
+                pr_number=55, neutral_facts={"repo": "moonklabs/sprintable"},
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/gates/{gate_id}/reevaluate")
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reevaluate_no_project_access_returns_404():
+    """authz — get_gate_endpoint과 동일(존재 비노출): project 접근권 없으면 404(403 아님)."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, with_project_access=False)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=seeded["story_id"],
+                work_item_type="story", gate_type=MERGE_GATE_TYPE, status="pending",
+                pr_number=55, neutral_facts={"repo": "moonklabs/sprintable"},
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/gates/{gate_id}/reevaluate")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reevaluate_unknown_gate_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/gates/{uuid.uuid4()}/reevaluate")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## 요약

[SID:2893]

story #2893(gate-auto-creation-design-2893 설계안 §3, PO 승인) 4-PR 절단 중 **PR③** — B3(명시적 재평가 API, reopen 대체).

**base=develop** — PR①(#3349)·PR②(#3351) 둘 다 머지 완료라 스택 불요.

## 문제

지금까지 "게이트를 재평가시키고 싶다"는 요구를 만족시키는 표준 경로가 없었다. 오늘 실제로 관측된 우회 2종:
- PR을 실제로 close→reopen(review-gate 체크가 GitHub 쪽에서 리셋되는 부작용을 감수하면서 재평가만 노림) — 오늘 close/reopen 왕복 8회.
- #3324 — 참여등록 후 재평가를 유발하려고 빈 커밋을 push(SHA 변경으로 synchronize 웹훅을 강제 트리거).

둘 다 "이 게이트를 지금 현재 증거로 다시 판정해 달라"는 단순한 요청을 수동으로 흉내낸 것.

## 처방 — `POST /api/v2/gates/{id}/reevaluate`

- **`app/services/github_app.py::get_pull_request`**(신규) — `GET /repos/{repo}/pulls/{pr}`. `create_check_run`과 동형 계약(예외 미삼킴, 실패/토큰없음=None).
- **`app/routers/gates.py::reevaluate_gate_endpoint`**(신규):
  - **authz**: `get_gate_endpoint`과 동일(project_id 해소+`require_project_access`, 무권한은 404 — 존재 비노출 규율). 승인/거부(`_authorize_gate_approve_equivalent`)보다 **낮은 문턱** — "재평가를 트리거"는 결정이 아니라 정직 반영 요청이라, approver가 아닌 PR 관련자(오늘까지 close/reopen을 직접 하던 사람들)도 할 수 있어야 이 API가 그 우회를 실제로 대체한다.
  - **scope**: merge 게이트·status가 `pending`/`auto_passed`일 때만(`reconcile_merge_gate_with_real_evidence`의 기존 자격조건과 동일 — `approved`는 landed 작업이라 재평가 대상이 아니고, `rejected`/`voided`/`held`는 사람이 이미 명시 결정한 상태라 우회하면 안 된다).
  - **동작**: `gate.pr_number`(story #2893 A1, 0271)를 PR 귀속 1차 SSOT로, `neutral_facts.repo`로 repo 보강(둘 다 없는 legacy gate는 link row 폴백, 그래도 없으면 422). GitHub App 설치+토큰으로 PR을 **순수 GET**해 현재 head SHA/merged를 읽고, `fetch_status_check_rollup`으로 CI 롤업을 읽어 `reconcile_merge_gate_with_real_evidence`(웹훅 경로와 동일 chokepoint)를 재실행한다. **GitHub 쪽에 어떤 쓰기 호출도 하지 않는다** — reopen과 정확히 다른 점(review-gate 체크·라벨·리뷰 상태 전부 무터치).

## 검증

- `tests/test_2893_pr3_gate_reevaluate_realdb.py`(신규, 실 PG) 7건 — happy path(재평가가 실제로 evaluate_merge_gate를 재실행해 reason이 "CI unknown"→"outcome sample insufficient"로 바뀜, test_2156의 reconcile 실증과 동일 축) + non-merge gate_type 422 + approved 상태 422 + PR 컨텍스트 없음 422 + installation 없음 422 + project 접근권 없음 404 + 존재하지 않는 gate 404.
- `tests/test_2813_github_checks_api.py`에 `get_pull_request` 단위 3건 추가.
- **뮤테이션 검증**: status 가드(`gate.status not in (...)`) 제거 시 원래의 422 대신 다음 단계(GitHub 토큰 발급)에서 실패하는 것으로 확인(가드가 실제로 그 앞에서 막고 있었다는 증거) 후 복원. authz 가드는 `elif` 폴백 분기와 우연히 같은 404를 낼 수 있어(work_item_type="story"가 project-agnostic allowlist 밖) 오검증 위험을 인지, `get_gate_endpoint`의 이미 검증된 패턴을 그대로 재사용하는 것으로 갈음(재구현 0).
- `gates.py` 관련 인접 41개 파일(163 non-destructive + 20 destructive, 파일별 격리) 전부 green — 신규 코드가 기존 게이트 엔드포인트 어느 것도 건드리지 않음을 확인.

## 후속

PR④(C1 — 웹훅 기반 게이트 생성-트리거 감지)만 남음 — 별도 착수 신호 대기.