### PR TITLE
[SID:2923] AQ2 — 개입유형(GATE/STEER/BLOCK/Q) 무채 compact 배지

### DIFF
--- a/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
@@ -7,6 +7,9 @@
 // Attention GATE 앵커」. 예전엔 overflow 표시가 순수 텍스트라 캡(3~7) 초과분을 볼 방법이
 // 없었다 — 이 스위트는 그 표시가 실제로 클릭 가능한 앵커(/inbox?tab=gates)로 동작하는지,
 // overflow=0일 때는 그 앵커 자체가 서지 않는지를 고정한다.
+// story #2923(P0-E AQ2, doc attention-audit-redesign-2923) — 개입유형(GATE/STEER/BLOCK/Q)
+// compact 배지 배선. bucket 값이 실제로 ProofCapsule의 typeBadge prop까지 전달되는지 고정
+// (배지 자체의 무채 스타일링은 proof-capsule.test.tsx에서 컴포넌트 단위로 이미 검증됨).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
@@ -60,6 +63,20 @@ async function mount(fetchImpl: (url: string) => Promise<{ ok: boolean; json: ()
   const { AttentionQueueView } = await import('./attention-queue-view');
   await act(async () => { root.render(wrap(<AttentionQueueView projectId="proj-1" />)); });
   await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+function mockGatePendingOnly() {
+  return async (url: string) => {
+    if (url.includes('/api/glance/attention')) {
+      return {
+        ok: true,
+        json: async () => ({
+          data: { items: [{ kind: 'gate_pending', story_id: 's1', title: '가격 콘솔', ref: {}, entered_state_at: null }] },
+        }),
+      };
+    }
+    return { ok: true, json: async () => ({ data: [] }) };
+  };
 }
 
 describe('AttentionQueueView — HIGH1 project_id 필터(story #2923, 카디르 QA)', () => {
@@ -190,5 +207,12 @@ describe('AttentionQueueView — overflow anchor (story #2923 AQ3 + MEDIUM① GA
     const anchor = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('나머지는'));
     expect(anchor).toBeUndefined();
     expect(container.textContent).not.toContain('나머지는');
+  });
+});
+
+describe('AttentionQueueView — typeBadge 배선 (story #2923 AQ2)', () => {
+  it('gate_pending 신호(decision_needed·GATE 버킷)의 행에 "GATE" 배지가 뜬다', async () => {
+    await mount(mockGatePendingOnly());
+    expect(container.textContent).toContain('GATE');
   });
 });

--- a/apps/web/src/components/attention-queue/attention-queue-view.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.tsx
@@ -102,6 +102,7 @@ function AttentionRow({ item, highlighted, onNavigate }: {
         density="row"
         proofState={item.proofState}
         stateLabel={item.kindLabel}
+        typeBadge={item.bucket}
         claim={item.claim}
         human={item.actor && !item.actor.isAgent ? { name: item.actor.name, role: '' } : undefined}
         agent={item.actor?.isAgent ? { name: item.actor.name, initial: item.actor.name.slice(0, 1) } : undefined}

--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -145,6 +145,34 @@ describe('ProofCapsule (안티패턴 자체 체크 — 도크트린 준수 회�
     expect(markup).not.toContain('일 전');
     expect(markup).not.toContain('시간 전');
   });
+
+  // story #2923(P0-E AQ2, Yuna 확定 2026-08-22) — 개입유형(GATE/STEER/BLOCK/Q) compact 배지.
+  // 「색은 신뢰상태 축 하나(레일/점)뿐」 — 이 배지는 무채(색 클래스 0)로만 렌더돼야 한다.
+  it('row density renders the typeBadge text with monochrome classes (bg-proof-sunk/text-proof-ink-2 — no proofState color)', () => {
+    const markup = renderWithIntl(
+      <ProofCapsule {...BASE} density="row" gate={{ action: '결재' }} typeBadge="GATE" />,
+    );
+    // 배지 자체의 스타일 클래스가 무채(proof-sunk/ink-2)인지 — 이 두 클래스는 이 컴포넌트
+    // 어디에도 상태색(blue/green/amber/red) 용도로 안 쓰인다(proof-capsule.tsx 실측).
+    expect(markup).toContain('GATE');
+    expect(markup).toContain('bg-proof-sunk');
+    expect(markup).toContain('text-proof-ink-2');
+  });
+
+  it('row density renders no typeBadge element when omitted (다른 밀도 호출부·전 F1~F3는 이 prop 자체를 안 준다, 무변화)', () => {
+    const markup = renderWithIntl(
+      <ProofCapsule {...BASE} density="row" gate={{ action: '결재' }} />,
+    );
+    expect(markup).not.toContain('GATE');
+    expect(markup).not.toContain('STEER');
+  });
+
+  it('typeBadge는 row 밀도 전용 — full/card/audit에는 안 새어나간다(스코프 밖 밀도 무누출)', () => {
+    for (const density of ['full', 'card', 'audit'] as const) {
+      const markup = renderWithIntl(<ProofCapsule {...BASE} density={density} typeBadge="GATE" />);
+      expect(markup).not.toContain('>GATE<');
+    }
+  });
 });
 
 describe('ProofCapsule (human optional — Board card 확산, bf9037cb) — 다중 담당자 등 human 필드로 표현 안 되는 실 기능을 위한 완화', () => {

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -338,7 +338,10 @@ function InlineRow({
               둔다(proofState의 문자 신호 유지 — 도크트린 "색만으로 의미 전달 금지"가 요구하는
               stateLabel 텍스트 병기를 이 배지 추가로 잃지 않는다). */}
           {typeBadge ? (
-            <span className="rounded-[4px] border border-proof-line bg-proof-sunk px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-[0.04em] text-proof-ink-2">
+            // 유나 비차단 refinement(2026-08-22, PR#3356) — GATE/STEER/BLOCK/Q 글자수 편차
+            // (1~5자)로 auto-width면 claim 좌측 정렬이 들쭉날쭉했다. min-w로 폭 통일(최장
+            // 라벨 STEER 기준)+text-center로 짧은 라벨(Q)도 같은 자리에 정렬.
+            <span className="min-w-[30px] rounded-[4px] border border-proof-line bg-proof-sunk px-1.5 py-0.5 text-center text-[8px] font-bold uppercase tracking-[0.04em] text-proof-ink-2">
               {typeBadge}
             </span>
           ) : null}

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -50,6 +50,12 @@ export interface ProofCapsuleProps {
    * 미리 포맷해 넘긴다(예: "3일 전"). 모르면 아예 넘기지 않는다(빈 문자열/"모름" 라벨로 지어내지
    * 않음 — glance.py의 entered_state_at이 null인 신호는 값 자체가 없다). */
   duration?: string;
+  /** row 밀도 전용(story #2923 AQ2, doc attention-audit-redesign-2923) — 「지금 개입할 것」의
+   * 개입 유형(예: GATE/STEER/BLOCK/Q) compact 배지. Yuna AQ2 확定(2026-08-22): 「색은 신뢰상태
+   * 축 하나(레일/점)뿐」 — 이 배지는 무채(monochrome)로만 렌더한다(색 이중 인코딩 금지). 값은
+   * 호출부가 이미 계산해 넘긴다(feature-agnostic 컴포넌트가 특정 도메인의 버킷 열거형을 몰라도
+   * 되게 plain string으로 받는다 — AttentionQueueItem.bucket 등). */
+  typeBadge?: string;
   /** full/audit만 사용 — card/row는 다중 담당자(예: Board card의 assignee 스택)를 자체
    * 렌더하는 경우가 많아 요구하지 않는다(optional, 2026-07-11 Board 확산 시 완화). */
   human?: ProofCapsuleHuman;
@@ -87,7 +93,7 @@ export interface ProofCapsuleProps {
  * glow·999px pill·숫자 KPI화·raw CoT·초록만-완료 전부 미사용(색은 항상 stateLabel 텍스트 병기).
  */
 export function ProofCapsule({
-  proofState, stateLabel, claim, human, agent, now, evidence, gate, trustSeal, density, footer, className, duration, onClaimClick,
+  proofState, stateLabel, claim, human, agent, now, evidence, gate, trustSeal, density, footer, className, duration, onClaimClick, typeBadge,
 }: ProofCapsuleProps) {
   if (density === 'audit') {
     return (
@@ -98,7 +104,7 @@ export function ProofCapsule({
     return (
       <InlineRow
         proofState={proofState} stateLabel={stateLabel} claim={claim} human={human} agent={agent}
-        gate={gate} duration={duration} className={className}
+        gate={gate} duration={duration} className={className} typeBadge={typeBadge}
       />
     );
   }
@@ -320,12 +326,24 @@ const GATE_BUTTON_TONE: Record<NonNullable<ProofCapsuleGate['tone']>, string> = 
 };
 
 function InlineRow({
-  proofState, stateLabel, claim, human, agent, gate, duration, className,
-}: Pick<ProofCapsuleProps, 'proofState' | 'stateLabel' | 'claim' | 'human' | 'agent' | 'gate' | 'duration' | 'className'>) {
+  proofState, stateLabel, claim, human, agent, gate, duration, className, typeBadge,
+}: Pick<ProofCapsuleProps, 'proofState' | 'stateLabel' | 'claim' | 'human' | 'agent' | 'gate' | 'duration' | 'className' | 'typeBadge'>) {
   return (
     <CutCornerShell state={proofState} cut={16} className={cn('w-full', className)}>
       <div className="flex min-h-[52px] min-w-0 flex-1 items-center gap-2.5 px-3 py-2">
-        <span className="w-24 shrink-0"><StateHeader state={proofState} label={stateLabel} /></span>
+        <span className="flex shrink-0 items-center gap-1.5">
+          {/* story #2923 AQ2(Yuna 확定 2026-08-22) — 개입유형(GATE/STEER/BLOCK/Q) compact
+              배지. 「색은 신뢰상태 축 하나(레일/점+아래 StateHeader)뿐」 — 이 배지는 무채
+              (bg-proof-sunk·text-proof-ink-2, 색 없음)로만 렌더한다. StateHeader는 그대로
+              둔다(proofState의 문자 신호 유지 — 도크트린 "색만으로 의미 전달 금지"가 요구하는
+              stateLabel 텍스트 병기를 이 배지 추가로 잃지 않는다). */}
+          {typeBadge ? (
+            <span className="rounded-[4px] border border-proof-line bg-proof-sunk px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-[0.04em] text-proof-ink-2">
+              {typeBadge}
+            </span>
+          ) : null}
+          <StateHeader state={proofState} label={stateLabel} />
+        </span>
         <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-proof-ink">{claim}</span>
         <span className="inline-flex shrink-0 items-center gap-2">
           {duration ? <span className="shrink-0 text-[10.5px] font-medium text-proof-ink-3">{duration}</span> : null}


### PR DESCRIPTION
## 요약
story #2923(P0-E, Attention Queue × Audit 재설계) AQ2 슬라이스 — Attention Queue 행에 개입유형(GATE/STEER/BLOCK/Q) 무채 compact 배지를 추가한다.

유나 홀름 디자인 확定(2026-08-22):
- ① 유형 배지 = 무채(monochrome) — 4색 solid 배지안 기각
- ② 행 액션 버튼 = 기존 3톤(primary/neutral/ready) 유지, 변경 없음

## 변경
- `proof-capsule.tsx`: `ProofCapsuleProps.typeBadge?: string` 추가, row density(`InlineRow`)에서만 렌더(다른 density는 영향 없음) — 기존 `StateHeader`를 대체하지 않고 병기.
- `attention-queue-view.tsx`: `AttentionRow`의 `ProofCapsule` 호출에 `typeBadge={item.bucket}` 배선(AQ1에서 이미 데이터 계층에 있던 bucket 필드를 시각화하는 첫 소비처).

## 스코프
AQ1(#3352)·AQ3(#3353) 머지 후 develop 위로 rebase — bucket 필드가 이제 develop에 있어 가능해진 슬라이스. 다른 두 PR과 파일 축이 겹치되(attention-queue-view.tsx) 실 diff는 이 PR만의 typeBadge 배선분만.

## 검증
- `pnpm exec tsc --noEmit -p .` 0
- `pnpm exec eslint` 대상 파일 0
- `pnpm exec vitest run` 전체 476 files / 4037 tests green
- `verify:tint-foreground-contrast` / `verify:no-new-tint-color-text` / `verify:cross-element-tint-text` / `verify:no-handrolled-modal` 전부 OK(신규 위반 0)
- `pnpm run build` EXIT 0

## 스크린샷
무채 배지는 텍스트 전용(색상 대비 이슈 없음) — 라이브 dev 배포 후 카디르군 QA 단계에서 실측 스크린샷 첨부 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)