### PR TITLE
[SID:2893] feat(2893): qa:pass+design:pass 라벨정렬 웹훅 트리거로 게이트 자동생성 — 폴링 배제 (PR④/C1)

### DIFF
--- a/backend/app/routers/participation.py
+++ b/backend/app/routers/participation.py
@@ -68,6 +68,11 @@ async def add_participation(
         member_id=body.member_id,
         role_id=body.role_id,
     )
+    # story #2893 후속(PR#3357 qa:changes) — 직접 참여 등록도 assignee 자동참여와 동일하게
+    # 게이트 생성 갭을 메울 계기다(app/services/participation_helpers.py의 동형 훅 참고).
+    from app.services.merge_verdict_gate import trigger_gate_creation_for_late_participation
+
+    await trigger_gate_creation_for_late_participation(repo.session, repo.org_id, body.story_id)
     return ParticipationResponse.model_validate(p)
 
 

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -333,7 +333,8 @@ async def _process_webhook_event(
 
     ``gate_check_publish``(story #2813, ccbcd9da A-1 `pending_deliveries`와 동형 outparam): 넘기면
     PR 라이프사이클 이벤트(opened/reopened/ready_for_review/synchronize/**edited-단 base가 실제로
-    바뀐 경우만**, story #2912)가 발행해야 할 GitHub check-run 정보를 append — 호출자(github_webhook)
+    바뀐 경우만**, story #2912/**qa:pass+design:pass 라벨이 둘 다 갖춰진 labeled 이벤트**, story
+    #2893 설계안 §4 C1)가 발행해야 할 GitHub check-run 정보를 append — 호출자(github_webhook)
     가 **commit 後** 배경 태스크로 발행(fail-closed: GitHub 외부 API 호출을 DB 트랜잭션 성공 확정
     前에 하지 않는다).
 
@@ -354,6 +355,21 @@ async def _process_webhook_event(
     # 없다([[ci-stuck-c-d-remedy-design-20260822]] 참고) — payload.changes.base는 base가
     # 실제로 바뀐 edited 이벤트에만 GitHub이 채워 보낸다.
     is_base_retarget_edit = pr_action == "edited" and bool((payload.get("changes") or {}).get("base"))
+    # story #2893(설계안 §4 C1) — 원 스토리(#2893) 증상 자체("QA·design·CI 전부 서고도 merge
+    # 게이트 레코드가 없어 PR 작성자가 close→reopen으로 수동 생성") 최종 처방: qa:pass+
+    # design:pass 라벨이 **둘 다** 갖춰지는 순간(pull_request.labeled, GitHub raw 웹훅 —
+    # 폴링 0)을 게이트 생성 트리거로 더한다. `pull_request` 페이로드는 어떤 action이든 현재
+    # 라벨 전체 집합(labels)을 동봉하므로 추가 조회 불요. RECHECK_LABELS(B2-a와 동일 SSOT) —
+    # "이 두 라벨이 갖춰지면 게이트가 있어야 한다"는 명제가 "SHA 불일치 시 이 두 라벨을 뗀다"는
+    # B2-a 명제와 정확히 대칭이라 같은 상수를 공유한다.
+    is_label_alignment_trigger = False
+    if pr_action == "labeled":
+        from app.services.gate_github_check import RECHECK_LABELS
+
+        _label_names = {
+            (label.get("name") or "") for label in (payload.get("pull_request") or {}).get("labels") or []
+        }
+        is_label_alignment_trigger = all(name in _label_names for name in RECHECK_LABELS)
 
     installation: GithubInstallation | None = None
     org_id: uuid.UUID | None = None
@@ -451,7 +467,11 @@ async def _process_webhook_event(
     # 그새 커밋이 바뀐 경우를 못 잡는다. 네 액션 전부에서 동일 가드를 돌린다(비교 비용은 동일).
     if (
         event == "pull_request"
-        and (pr_action in ("opened", "reopened", "ready_for_review", "synchronize") or is_base_retarget_edit)
+        and (
+            pr_action in ("opened", "reopened", "ready_for_review", "synchronize")
+            or is_base_retarget_edit
+            or is_label_alignment_trigger
+        )
         and head_sha
         and gate_check_publish is not None
     ):

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -642,9 +642,26 @@ async def trigger_gate_creation_for_late_participation(
     조합을 그대로 재사용 — get_pull_request로 현재 head SHA/merged를, fetch_status_check_
     rollup으로 CI를 읽어 evaluate_merge_gate 재호출. 새 규칙 발명 0).
 
-    best-effort — 실패해도 호출자의 주 액션(참여 등록 자체)을 막으면 안 된다. 링크된 PR이
-    없거나(story #2893 스코프 밖 board-preflight 전용 story 등) GitHub installation이
-    없으면 조용히 no-op(fail-closed: 외부 신호를 지어내지 않는다)."""
+    ⚠️호출자의 세션을 그대로 받는다(별도 세션 아님) — 방금 `flush`된(아직 커밋 前) participation
+    행을 evaluate_merge_gate가 같은 트랜잭션 안에서 즉시 봐야 하기 때문(실측: 별도 세션으로
+    분리했더니 그 세션엔 아직 안 보이는 미커밋 행 탓에 "no implementation participation"으로
+    재실패 — read-your-own-write가 세션 경계를 못 넘는다). 대신 **세션 오염은 SAVEPOINT로
+    막는다**(카디르 QA②) — 링크마다 `session.begin_nested()`로 감싸, 그 PR의 DB 예외가
+    SAVEPOINT까지만 롤백되고 호출자의 participation flush·다른 링크의 처리·최종 commit에는
+    전혀 새지 않는다.
+
+    카디르 QA(PR#3357 재재verdict, 2026-08-22) 3건 하드닝:
+    ①**link별 예외 격리** — 하나의 PR 처리 실패가 나머지 PR을 막으면 안 된다(전체를 감싸던
+    단일 try를 per-link try로 분리).
+    ②**세션 오염 차단** — 위 SAVEPOINT 격리(개별 세션이 아니라 개별 SAVEPOINT — 이유는
+    docstring 서두 참조).
+    ③**soft-delete 필터** — `resolve_pr_link`(canonical reader)와 동일하게
+    `deleted_at IS NULL`만 조회한다 — 없으면 사용자가 명시로 끊은 연결(explicit unlink)이
+    이 훅으로 되살아나는 의미 결함이었다.
+
+    best-effort — 어느 PR이 실패해도 다른 PR·호출자의 참여 등록 자체를 절대 막지 않는다.
+    링크된 PR이 없거나(board-preflight 전용 story 등) GitHub installation이 없으면 조용히
+    no-op(fail-closed: 외부 신호를 지어내지 않는다)."""
     from app.models.github_installation import GithubInstallation
     from app.models.pull_request_story_link import PullRequestStoryLink
     from app.services.github_app import get_installation_token, get_pull_request
@@ -656,6 +673,7 @@ async def trigger_gate_creation_for_late_participation(
                 select(PullRequestStoryLink).where(
                     PullRequestStoryLink.org_id == org_id,
                     PullRequestStoryLink.story_id == story_id,
+                    PullRequestStoryLink.deleted_at.is_(None),
                 )
             )
         ).scalars().all()
@@ -670,30 +688,40 @@ async def trigger_gate_creation_for_late_participation(
         ).scalar_one_or_none()
         if installation is None:
             return
-        for link in links:
-            existing = await find_gate_slot_with_pr_fallback(
-                session, org_id=org_id, work_item_id=story_id, work_item_type="story",
-                gate_type=MERGE_GATE_TYPE, pr_number=link.pr_number,
-            )
-            if existing is not None:
-                continue  # 이미 게이트가 있음 — 이 훅이 고치려는 갭이 아니다.
-            token = await get_installation_token(installation.installation_id)
-            if not token:
-                continue
-            pr = await get_pull_request(installation.installation_id, link.repo_full_name, link.pr_number)
-            if pr is None:
-                continue
-            head_sha = (pr.get("head") or {}).get("sha")
-            if not head_sha:
-                continue
-            ci_result, _reason = await fetch_status_check_rollup(link.repo_full_name, head_sha, token)
-            await evaluate_merge_gate(
-                session, org_id, story_id,
-                pr_number=link.pr_number, repo=link.repo_full_name,
-                ci_result=ci_result, head_sha=head_sha,
-            )
-    except Exception:  # noqa: BLE001 — best-effort: 참여 등록 자체를 절대 깨뜨리지 않는다.
+        installation_id = installation.installation_id
+    except Exception:  # noqa: BLE001 — best-effort: 준비 단계 실패도 참여 등록을 안 막는다.
         logger.warning(
-            "story=%s: 참여등록 후 게이트 생성 재시도 실패(best-effort, 참여 등록 자체엔 무영향)",
+            "story=%s: 참여등록 후 게이트 생성 재시도 준비 단계 실패(best-effort)",
             story_id, exc_info=True,
         )
+        return
+
+    for link in links:
+        try:
+            async with session.begin_nested():  # SAVEPOINT — 이 링크만 롤백, 호출자 트랜잭션은 무영향.
+                existing = await find_gate_slot_with_pr_fallback(
+                    session, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                    gate_type=MERGE_GATE_TYPE, pr_number=link.pr_number,
+                )
+                if existing is not None:
+                    continue  # 이미 게이트가 있음 — 이 훅이 고치려는 갭이 아니다.
+                token = await get_installation_token(installation_id)
+                if not token:
+                    continue
+                pr = await get_pull_request(installation_id, link.repo_full_name, link.pr_number)
+                if pr is None:
+                    continue
+                head_sha = (pr.get("head") or {}).get("sha")
+                if not head_sha:
+                    continue
+                ci_result, _reason = await fetch_status_check_rollup(link.repo_full_name, head_sha, token)
+                await evaluate_merge_gate(
+                    session, org_id, story_id,
+                    pr_number=link.pr_number, repo=link.repo_full_name,
+                    ci_result=ci_result, head_sha=head_sha,
+                )
+        except Exception:  # noqa: BLE001 — 이 링크만 실패 처리(SAVEPOINT 롤백), 다른 링크·호출자 세션엔 무영향.
+            logger.warning(
+                "story=%s pr=%s: 참여등록 후 게이트 생성 재시도 실패(best-effort, 다른 PR·참여 등록 자체엔 무영향)",
+                story_id, link.pr_number, exc_info=True,
+            )

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -625,3 +625,75 @@ async def reconcile_merge_gate_with_real_evidence(
         pr_result=("pass" if merged else None),
         head_sha=head_sha,
     )
+
+
+async def trigger_gate_creation_for_late_participation(
+    session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID,
+) -> None:
+    """story #2893 후속(카디르 4라운드 verdict, PR#3357 qa:changes) — 순서 조합 갭: PR
+    opened(참여 無)→라벨정렬(웹훅 트리거는 실행되나 evaluate_merge_gate가 "no implementation
+    participation"으로 gate_id=None 즉시반환)→참여등록(재평가 훅 0)→이후 웹훅 이벤트 없음
+    → **게이트 row가 영구 미생성**된다(2893 원 증상 — close/reopen 강제 그대로 재현. B3
+    재평가 API도 gate id가 없어 호출 불가하므로 이 순서에선 탈출구가 없었다).
+
+    참여 생성 공유 chokepoint(`ensure_implementation_participation`— assignee 자동참여·
+    story claim 양쪽이 공유·`add_participation` 라우터의 직접 생성) 양쪽에서 이 훅을 불러,
+    지금 story에 연결된 PR마다 게이트가 아직 없으면 즉시 만든다(B3의 원격 GitHub 조회
+    조합을 그대로 재사용 — get_pull_request로 현재 head SHA/merged를, fetch_status_check_
+    rollup으로 CI를 읽어 evaluate_merge_gate 재호출. 새 규칙 발명 0).
+
+    best-effort — 실패해도 호출자의 주 액션(참여 등록 자체)을 막으면 안 된다. 링크된 PR이
+    없거나(story #2893 스코프 밖 board-preflight 전용 story 등) GitHub installation이
+    없으면 조용히 no-op(fail-closed: 외부 신호를 지어내지 않는다)."""
+    from app.models.github_installation import GithubInstallation
+    from app.models.pull_request_story_link import PullRequestStoryLink
+    from app.services.github_app import get_installation_token, get_pull_request
+    from app.services.verdict_capture import fetch_status_check_rollup
+
+    try:
+        links = (
+            await session.execute(
+                select(PullRequestStoryLink).where(
+                    PullRequestStoryLink.org_id == org_id,
+                    PullRequestStoryLink.story_id == story_id,
+                )
+            )
+        ).scalars().all()
+        if not links:
+            return
+        installation = (
+            await session.execute(
+                select(GithubInstallation).where(
+                    GithubInstallation.org_id == org_id, GithubInstallation.suspended_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+        if installation is None:
+            return
+        for link in links:
+            existing = await find_gate_slot_with_pr_fallback(
+                session, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, pr_number=link.pr_number,
+            )
+            if existing is not None:
+                continue  # 이미 게이트가 있음 — 이 훅이 고치려는 갭이 아니다.
+            token = await get_installation_token(installation.installation_id)
+            if not token:
+                continue
+            pr = await get_pull_request(installation.installation_id, link.repo_full_name, link.pr_number)
+            if pr is None:
+                continue
+            head_sha = (pr.get("head") or {}).get("sha")
+            if not head_sha:
+                continue
+            ci_result, _reason = await fetch_status_check_rollup(link.repo_full_name, head_sha, token)
+            await evaluate_merge_gate(
+                session, org_id, story_id,
+                pr_number=link.pr_number, repo=link.repo_full_name,
+                ci_result=ci_result, head_sha=head_sha,
+            )
+    except Exception:  # noqa: BLE001 — best-effort: 참여 등록 자체를 절대 깨뜨리지 않는다.
+        logger.warning(
+            "story=%s: 참여등록 후 게이트 생성 재시도 실패(best-effort, 참여 등록 자체엔 무영향)",
+            story_id, exc_info=True,
+        )

--- a/backend/app/services/participation_helpers.py
+++ b/backend/app/services/participation_helpers.py
@@ -71,4 +71,11 @@ async def ensure_implementation_participation(
     p_repo = ParticipationRepository(session, org_id)
     if not await p_repo.exists(story_id, member_id, default_role.id):
         await p_repo.create(story_id=story_id, member_id=member_id, role_id=default_role.id)
+        # story #2893 후속(PR#3357 qa:changes) — PR opened가 참여 등록보다 먼저면
+        # evaluate_merge_gate가 그때 "no implementation participation"으로 gate row를
+        # 영구 미생성했을 수 있다. 지금 막 생긴 participation이 그 갭을 메울 유일한 계기라
+        # 여기서 재시도한다(assignee 자동참여·story claim 양쪽이 이 helper를 공유).
+        from app.services.merge_verdict_gate import trigger_gate_creation_for_late_participation
+
+        await trigger_gate_creation_for_late_participation(session, org_id, story_id)
     return True

--- a/backend/tests/test_2893_pr4_label_alignment_gate_creation_realdb.py
+++ b/backend/tests/test_2893_pr4_label_alignment_gate_creation_realdb.py
@@ -1,0 +1,240 @@
+"""story #2893(설계안 gate-auto-creation-design-2893 §4, PR④/C1) — 라벨정렬 기반 게이트
+생성 트리거(웹훅, 폴링 배제).
+
+원 스토리(#2893) 증상 그 자체: "QA·design·CI가 전부 서고도 merge 게이트 레코드가 없어
+PR 작성자가 close→reopen으로 수동 생성". qa:pass+design:pass 라벨이 **둘 다** 갖춰지는
+순간(`pull_request.labeled` raw 웹훅)을 게이트 생성의 2차 트리거로 추가한다 — PR
+opened/synchronize 등 1차 트리거가 어떤 이유로든(참여 미등록 당시 open됐다가 나중에
+등록 등) 게이트를 못 만들었어도, 라벨정렬이 마지막 안전망이 된다.
+
+github_app.py의 실 GitHub API 호출만 mock — DB 왕복은 실 Postgres
+(test_2893_gate_pr_scoped_isolation_realdb.py와 동일 관례, 헬퍼 재사용).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_2893_gate_pr_scoped_isolation_realdb import (
+    _post_app,
+    _seed_installation,
+    _seed_link,
+    _seed_org_project_story,
+    _session_factory,
+)
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _labeled_payload(*, pr_number, installation_id, head_sha, labels, title="chore: unrelated"):
+    return {
+        "action": "labeled",
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "installation": {"id": installation_id},
+        "pull_request": {
+            "number": pr_number, "title": title, "body": "", "merged": False,
+            "head": {"sha": head_sha, "ref": f"feat-branch-{pr_number}"},
+            "labels": [{"name": name} for name in labels],
+        },
+    }
+
+
+async def _gates_for_story(s, story_id):
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    rows = (
+        await s.execute(
+            select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == MERGE_GATE_TYPE)
+        )
+    ).scalars().all()
+    return rows
+
+
+@pytest.mark.anyio
+async def test_labeled_event_with_both_labels_creates_missing_gate():
+    """핵심 — opened/synchronize 없이 labeled(둘 다 갖춤) 단독으로도 게이트가 생겨야 한다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680501)
+            await _seed_link(s, org, story, pr_number=501)
+            story_id = story.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 95001}),
+        ), patch("app.core.database.async_session_factory", Session):
+            resp = await _post_app(
+                _labeled_payload(
+                    pr_number=501, installation_id=680501, head_sha="sha-label-1",
+                    labels=["qa:pass", "design:pass"],
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+        assert resp.status_code == 200, resp.text
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 1, "labeled(둘 다 갖춤) 단독 트리거로 게이트가 생겨야 함"
+            assert gates[0].pr_number == 501
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_labeled_event_with_only_one_label_does_not_create_gate():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680502)
+            await _seed_link(s, org, story, pr_number=502)
+            story_id = story.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 95002}),
+        ), patch("app.core.database.async_session_factory", Session):
+            resp = await _post_app(
+                _labeled_payload(
+                    pr_number=502, installation_id=680502, head_sha="sha-label-2",
+                    labels=["qa:pass"],
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+        assert resp.status_code == 200, resp.text
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 0, "한 라벨만으로는 생성 트리거가 안 돼야 함(둘 다 정렬 필요)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_labeled_event_with_unrelated_label_does_not_create_gate():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680503)
+            await _seed_link(s, org, story, pr_number=503)
+            story_id = story.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 95003}),
+        ), patch("app.core.database.async_session_factory", Session):
+            resp = await _post_app(
+                _labeled_payload(
+                    pr_number=503, installation_id=680503, head_sha="sha-label-3",
+                    labels=["bug"],
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+        assert resp.status_code == 200, resp.text
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_labeled_event_does_not_duplicate_existing_gate():
+    """이미 게이트가 있으면(1차 트리거로 생성됐던 경우) labeled 이벤트가 중복 행을 만들면 안
+    된다 — find_gate_slot_with_pr_fallback가 기존 행을 찾아 reopen_gate_if_new_sha 분기로
+    가고(SHA 동일이라 no-op), 새 create는 안 탄다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680504)
+            await _seed_link(s, org, story, pr_number=504)
+            story_id = story.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 95004}),
+        ), patch("app.core.database.async_session_factory", Session):
+            await _post_app(
+                _labeled_payload(
+                    pr_number=504, installation_id=680504, head_sha="sha-label-4",
+                    labels=["qa:pass", "design:pass"],
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+
+        async with Session() as s:
+            gates_first = await _gates_for_story(s, story_id)
+            assert len(gates_first) == 1
+            first_gate_id = gates_first[0].id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 95005}),
+        ), patch("app.core.database.async_session_factory", Session):
+            await _post_app(
+                _labeled_payload(
+                    pr_number=504, installation_id=680504, head_sha="sha-label-4",
+                    labels=["qa:pass", "design:pass", "extra"],
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+
+        async with Session() as s:
+            gates_second = await _gates_for_story(s, story_id)
+            assert len(gates_second) == 1, "두 번째 labeled 이벤트가 중복 행을 만들면 안 됨"
+            assert gates_second[0].id == first_gate_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unlabeled_action_with_both_labels_present_does_not_trigger_creation():
+    """action이 "labeled"가 아니면(예: unlabeled) 라벨 집합이 같아도 트리거 대상이 아니다 —
+    "정렬되는 그 순간"만 게이트 생성 신호이지, 다른 액션에 얹혀 오면 안 된다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=680505)
+            await _seed_link(s, org, story, pr_number=505)
+            story_id = story.id
+
+        payload = _labeled_payload(
+            pr_number=505, installation_id=680505, head_sha="sha-label-5",
+            labels=["qa:pass", "design:pass"],
+        )
+        payload["action"] = "unlabeled"
+
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 95006}),
+        ), patch("app.core.database.async_session_factory", Session):
+            resp = await _post_app(payload, Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}")
+        assert resp.status_code == 200, resp.text
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 0
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2893_pr4_late_participation_gate_creation_realdb.py
+++ b/backend/tests/test_2893_pr4_late_participation_gate_creation_realdb.py
@@ -162,7 +162,8 @@ async def test_late_participation_after_opened_and_labeled_creates_missing_gate(
         async with Session() as s:
             assert len(await _gates_for_story(s, story_id)) == 0, "라벨정렬로도 참여 無면 여전히 없어야 함(전제)"
 
-        # 3) 참여 등록(늦게) — 이 훅이 갭을 메워야 한다.
+        # 3) 참여 등록(늦게) — 이 훅이 갭을 메워야 한다. 훅은 호출자 세션(s)을 그대로 쓴다
+        #    (카디르 QA② — SAVEPOINT 격리, 별도 세션 아님. read-your-own-write 유지).
         p1, p2, p3 = _live_pr_patches(head_sha="sha-late-1", ci_result="success")
         async with Session() as s:
             with p1, p2, p3:
@@ -313,5 +314,135 @@ async def test_participation_hook_noop_when_gate_already_exists():
         async with Session() as s:
             gates = await _gates_for_story(s, story_id)
             assert len(gates) == 1, "이미 있던 게이트를 중복 생성하면 안 됨"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_one_pr_failure_does_not_block_other_pr_gate_creation():
+    """카디르 QA②-①(PR#3357 재재verdict) — link별 예외 격리. 같은 스토리에 링크된 PR 2개
+    중 하나(701) 처리가 실패해도, 다른 하나(702)는 정상적으로 게이트를 받아야 한다(예전엔
+    전체를 감싼 단일 try가 첫 실패에서 나머지 링크 처리를 통째로 건너뛰었다)."""
+    from app.services.participation_helpers import ensure_implementation_participation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story_no_role(s)
+            await _seed_installation(s, org, installation_id=680701)
+            await _seed_link(s, org, story, pr_number=701)
+            await _seed_link(s, org, story, pr_number=702)
+            story_id = story.id
+
+        async def _get_pr_fails_for_701(installation_id, repo_full_name, pr_number):
+            if pr_number == 701:
+                raise RuntimeError("simulated GitHub fetch failure for PR 701")
+            return {"head": {"sha": "sha-702"}, "merged": False}
+
+        async with Session() as s:
+            with (
+                patch("app.services.github_app.get_installation_token", AsyncMock(return_value="inst-tok")),
+                patch("app.services.github_app.get_pull_request", new=_get_pr_fails_for_701),
+                patch(
+                    "app.services.verdict_capture.fetch_status_check_rollup",
+                    AsyncMock(return_value=("success", None)),
+                ),
+            ):
+                ok = await ensure_implementation_participation(s, org.id, story_id, uuid.uuid4())
+                await s.commit()
+        assert ok is True
+
+        async with Session() as s:
+            gates = {g.pr_number: g for g in await _gates_for_story(s, story_id)}
+            assert 702 in gates, "701 처리가 실패해도 702는 정상적으로 게이트를 받아야 함(link별 격리)"
+            assert 701 not in gates, "701 자체는 실패했으니 게이트가 없어야 함(지어내지 않음)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_link_failure_does_not_poison_session_participation_still_commits():
+    """카디르 QA②-②(PR#3357 재재verdict) — 세션 오염 차단. 훅 내부에서 **실 DB 레벨 에러**
+    (Postgres division_by_zero — mock이 아니라 진짜 DBAPI 에러라야 세션이 실제로 오염된다)가
+    나도 호출자 세션이 오염되면 안 된다 — SAVEPOINT 격리 덕에 참여 등록 자체(호출자의
+    flush·commit)는 여전히 성공해야 한다는 것을 직접 증명한다."""
+    from app.services.participation_helpers import ensure_implementation_participation
+
+    async def _evaluate_merge_gate_with_real_db_error(session, org_id, story_id, **kwargs):
+        from sqlalchemy import text
+        await session.execute(text("SELECT 1/0"))  # 실 Postgres division_by_zero — 진짜 세션 오염.
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story_no_role(s)
+            await _seed_installation(s, org, installation_id=680703)
+            await _seed_link(s, org, story, pr_number=703)
+            story_id = story.id
+
+        member_id = uuid.uuid4()
+        p1, p2 = _live_pr_patches(head_sha="sha-703", ci_result="success")[:2]
+        async with Session() as s:
+            with (
+                p1, p2,
+                patch(
+                    "app.services.merge_verdict_gate.evaluate_merge_gate",
+                    new=_evaluate_merge_gate_with_real_db_error,
+                ),
+            ):
+                ok = await ensure_implementation_participation(s, org.id, story_id, member_id)
+                # 핵심 단언: 훅이 실 DB 에러를 만났어도, 이 commit 자체가 안 죽어야 한다
+                # (PendingRollbackError 등으로 여기서 raise되면 세션이 오염됐다는 뜻).
+                await s.commit()
+            assert ok is True
+
+        async with Session() as s:
+            from app.models.participation import Participation
+
+            rows = (
+                await s.execute(select(Participation).where(Participation.story_id == story_id))
+            ).scalars().all()
+            assert len(rows) == 1 and rows[0].member_id == member_id, (
+                "참여 행이 실제로 커밋돼 있어야 함(세션 오염이 없었다는 최종 증거)"
+            )
+            assert len(await _gates_for_story(s, story_id)) == 0, "실패한 evaluate_merge_gate가 게이트를 만들면 안 됨"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_soft_deleted_link_is_not_revived_by_late_participation():
+    """카디르 QA②-③(PR#3357 재재verdict) — soft-delete 필터. 사용자가 명시로 끊은 연결
+    (deleted_at 有)은 참여등록이 늦게 와도 되살아나면 안 된다."""
+    from app.services.participation_helpers import ensure_implementation_participation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story_no_role(s)
+            await _seed_installation(s, org, installation_id=680704)
+            story_id = story.id
+
+            from datetime import datetime, timezone
+
+            from app.models.pull_request_story_link import PullRequestStoryLink
+
+            s.add(PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=org.id, story_id=story_id,
+                repo_full_name="moonklabs/sprintable", pr_number=704,
+                link_source="explicit", confidence="high",
+                deleted_at=datetime.now(timezone.utc),
+            ))
+            await s.commit()
+
+        p1, p2, p3 = _live_pr_patches(head_sha="sha-704", ci_result="success")
+        async with Session() as s:
+            with p1, p2, p3:
+                ok = await ensure_implementation_participation(s, org.id, story_id, uuid.uuid4())
+                await s.commit()
+        assert ok is True
+
+        async with Session() as s:
+            assert len(await _gates_for_story(s, story_id)) == 0, "soft-delete된 링크는 부활하면 안 됨"
     finally:
         await engine.dispose()

--- a/backend/tests/test_2893_pr4_late_participation_gate_creation_realdb.py
+++ b/backend/tests/test_2893_pr4_late_participation_gate_creation_realdb.py
@@ -1,0 +1,317 @@
+"""story #2893 후속(카디르 4라운드 verdict, PR#3357 qa:changes) — 순서 조합 갭.
+
+참여등록이 라벨정렬보다 **늦으면**: opened(참여 無)→라벨정렬(PR④ 트리거는 실행되나
+evaluate_merge_gate가 "no implementation participation"으로 gate_id=None 즉시반환)→
+참여등록(재평가 훅 0)→이후 이벤트 없음 → 게이트 row가 영구 미생성된다(2893 원 증상이
+이 순서에선 그대로 재현 — B3 재평가 API도 gate id가 없어 호출 불가).
+
+처방: 참여 생성 공유 chokepoint(`ensure_implementation_participation` — assignee 자동참여·
+story claim 양쪽 공유·`add_participation` 라우터 직접 생성)에 게이트 재평가 훅을 추가.
+PR④의 기존 5건은 전부 참여 선시딩이라 이 "참여 後시딩" 순서를 커버하지 못했다 — 이 파일이
+그 정확한 순서로 재현한다.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_2893_gate_pr_scoped_isolation_realdb import (
+    _post_app,
+    _seed_installation,
+    _seed_link,
+    _session_factory,
+)
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _labeled_payload(*, pr_number, installation_id, head_sha, labels):
+    return {
+        "action": "labeled",
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "installation": {"id": installation_id},
+        "pull_request": {
+            "number": pr_number, "title": "chore: unrelated", "body": "", "merged": False,
+            "head": {"sha": head_sha, "ref": f"feat-branch-{pr_number}"},
+            "labels": [{"name": name} for name in labels],
+        },
+    }
+
+
+def _opened_payload(*, pr_number, installation_id, head_sha):
+    return {
+        "action": "opened",
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "installation": {"id": installation_id},
+        "pull_request": {
+            "number": pr_number, "title": "chore: unrelated", "body": "", "merged": False,
+            "head": {"sha": head_sha, "ref": f"feat-branch-{pr_number}"},
+            "labels": [],
+        },
+    }
+
+
+async def _seed_org_project_story_no_role(s):
+    """with_participation=False(test_2893_gate_pr_scoped_isolation_realdb)는 role조차 안
+    만든다 — 이 파일은 "role은 있는데 participation만 나중에 생기는" 정확한 순서가 필요해
+    role만 먼저 시드하는 별도 헬퍼를 쓴다."""
+    from app.models.organization import Organization
+    from app.models.participation import ParticipationRole
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    s.add(org)
+    await s.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    s.add(project)
+    await s.commit()
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="in-progress")
+    s.add(story)
+    await s.commit()
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="implementation", label="Impl", is_default=True)
+    s.add(role)
+    await s.commit()
+    return org, project, story
+
+
+async def _gates_for_story(s, story_id):
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    rows = (
+        await s.execute(
+            select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == MERGE_GATE_TYPE)
+        )
+    ).scalars().all()
+    return rows
+
+
+def _live_pr_patches(*, head_sha="sha-late-1", ci_result="success"):
+    # trigger_gate_creation_for_late_participation은 함수 내부(local import)에서
+    # app.services.github_app/verdict_capture를 직접 불러온다 — patch 대상은 그 원본
+    # 모듈(merge_verdict_gate의 재노출 이름이 아님, local import는 attribute lookup을
+    # merge_verdict_gate 네임스페이스에 만들지 않는다).
+    return (
+        patch("app.services.github_app.get_installation_token", AsyncMock(return_value="inst-tok")),
+        patch(
+            "app.services.github_app.get_pull_request",
+            AsyncMock(return_value={"head": {"sha": head_sha}, "merged": False}),
+        ),
+        patch(
+            "app.services.verdict_capture.fetch_status_check_rollup",
+            AsyncMock(return_value=(ci_result, None)),
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_late_participation_after_opened_and_labeled_creates_missing_gate():
+    """핵심 재현 — opened→labeled(둘 다) 순서에서 참여가 없어 게이트가 안 생기고, 나중에
+    참여가 생기면 그 계기로 게이트가 생겨야 한다."""
+    from app.services.participation_helpers import ensure_implementation_participation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story_no_role(s)
+            await _seed_installation(s, org, installation_id=680601)
+            await _seed_link(s, org, story, pr_number=601)
+            story_id = story.id
+
+        # 1) opened — 참여 無 → 게이트 미생성.
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 96001}),
+        ), patch("app.core.database.async_session_factory", Session):
+            await _post_app(
+                _opened_payload(pr_number=601, installation_id=680601, head_sha="sha-late-1"),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+        async with Session() as s:
+            assert len(await _gates_for_story(s, story_id)) == 0, "참여 無 — 아직 게이트 없어야 함(전제)"
+
+        # 2) labeled(둘 다) — 여전히 참여 無 → 여전히 게이트 미생성(PR④ 트리거는 타지만
+        #    evaluate_merge_gate가 no-participation으로 조기반환).
+        with patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 96002}),
+        ), patch("app.core.database.async_session_factory", Session):
+            await _post_app(
+                _labeled_payload(
+                    pr_number=601, installation_id=680601, head_sha="sha-late-1",
+                    labels=["qa:pass", "design:pass"],
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+        async with Session() as s:
+            assert len(await _gates_for_story(s, story_id)) == 0, "라벨정렬로도 참여 無면 여전히 없어야 함(전제)"
+
+        # 3) 참여 등록(늦게) — 이 훅이 갭을 메워야 한다.
+        p1, p2, p3 = _live_pr_patches(head_sha="sha-late-1", ci_result="success")
+        async with Session() as s:
+            with p1, p2, p3:
+                ok = await ensure_implementation_participation(s, org.id, story_id, uuid.uuid4())
+                await s.commit()
+            assert ok is True
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 1, "참여등록이 늦어도 그 계기로 게이트가 생겨야 함(2893 원 증상 재발방지)"
+            assert gates[0].pr_number == 601
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_add_participation_endpoint_also_triggers_gate_creation():
+    """라우터 배선 확인 — POST /api/v2/participation(직접 생성 경로)도 동일 훅을 태운다."""
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.main import app
+    from httpx import ASGITransport, AsyncClient
+    from tests.conftest import override_db_and_read
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project, story = await _seed_org_project_story_no_role(s)
+            await _seed_installation(s, org, installation_id=680602)
+            await _seed_link(s, org, story, pr_number=602)
+            story_id = story.id
+
+            from app.models.project import OrgMember
+            from app.models.project_access import ProjectAccess
+            from app.models.user import User
+
+            caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+            s.add(caller)
+            await s.commit()
+            caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
+            s.add(caller_om)
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+
+            from app.models.participation import ParticipationRole
+            role = (
+                await s.execute(
+                    select(ParticipationRole).where(ParticipationRole.org_id == org.id, ParticipationRole.is_default.is_(True))
+                )
+            ).scalar_one()
+            role_id = role.id
+            caller_id = caller.id
+
+        async def _db():
+            async with Session() as s:
+                try:
+                    yield s
+                    await s.commit()
+                except Exception:
+                    await s.rollback()
+                    raise
+
+        async def _auth():
+            return AuthContext(user_id=str(caller_id), email="caller@test", claims={"app_metadata": {}})
+
+        async def _org():
+            return org.id
+
+        override_db_and_read(app, _db)
+        app.dependency_overrides[get_current_user] = _auth
+        app.dependency_overrides[get_verified_org_id] = _org
+
+        client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+        try:
+            p1, p2, p3 = _live_pr_patches(head_sha="sha-late-2", ci_result="success")
+            with p1, p2, p3:
+                resp = await client.post(
+                    "/api/v2/participation",
+                    json={"story_id": str(story_id), "member_id": str(uuid.uuid4()), "role_id": str(role_id)},
+                )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 1, "add_participation 라우터도 게이트 생성 훅을 태워야 함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_participation_hook_noop_when_no_pr_linked():
+    """링크된 PR이 없으면(board-preflight 전용 story 등) 조용히 no-op — 크래시도, 지어낸
+    게이트도 없어야 한다."""
+    from app.services.participation_helpers import ensure_implementation_participation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story_no_role(s)
+            story_id = story.id
+
+        async with Session() as s:
+            ok = await ensure_implementation_participation(s, org.id, story_id, uuid.uuid4())
+            await s.commit()
+        assert ok is True
+
+        async with Session() as s:
+            assert len(await _gates_for_story(s, story_id)) == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_participation_hook_noop_when_gate_already_exists():
+    """게이트가 이미 있으면(1차 트리거가 이미 만들어 둔 정상 케이스) 참여가 나중에 추가돼도
+    중복 행을 만들면 안 된다."""
+    from app.services.participation_helpers import ensure_implementation_participation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story_no_role(s)
+            await _seed_installation(s, org, installation_id=680603)
+            await _seed_link(s, org, story, pr_number=603)
+            story_id = story.id
+
+            # 1차 트리거가 이미 만들어 둔 상태를 직접 시드(참여가 처음부터 있었던 정상 경로 모사).
+            from app.models.gate import Gate
+            from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+            s.add(Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story_id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending", pr_number=603,
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            ok = await ensure_implementation_participation(s, org.id, story_id, uuid.uuid4())
+            await s.commit()
+        assert ok is True
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 1, "이미 있던 게이트를 중복 생성하면 안 됨"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약

[SID:2893]

story #2893(gate-auto-creation-design-2893 설계안 §4, PO 승인) 4-PR 절단 중 **마지막 PR④** — C1(라벨정렬 웹훅 기반 게이트 자동생성 트리거, 폴링 배제).

**base=develop** — PR①②③ 전부 머지 완료, 스택 불요.

## 원 스토리 증상을 직접 닫는 조각

story #2893의 원 제목 그대로: "merge 게이트가 «PR 작성자 수동 생성»에 걸려 매번 잊힌다". 실사고(#3296/#3297/#3299, customer-zero 실측): QA·design·CI가 전부 서고도 merge 게이트 레코드가 없어 매번 ①PO가 결재함 API 전수 조회로 부재 발견 ②PR 작성자 호출 ③close→reopen으로 생성 ④reopen이 review-gate 체크를 리셋 ⑤CI 재완주 대기 ⑥실패 런 rerun ⑦서명·머지 — 슬라이스당 15~30분 손실.

PR①(#3349)로 PR단위 게이트 슬롯이, PR②(#3351)로 SHA-diff 자동 재-pending+라벨 unlabel이, PR③(#3355)로 명시적 재평가 API가 각각 자리 잡았지만, "애초에 게이트가 생성 안 되는" 그 자체는 이번 PR이 처음 닫는다.

## 처방

qa:pass+design:pass 라벨이 **둘 다** 갖춰지는 순간(`pull_request.labeled` raw 웹훅)을 게이트 생성의 2차 안전망으로 추가한다 — PR opened/synchronize 등 1차 트리거가 어떤 이유로든(참여 미등록 당시 open됐다가 나중에 등록 등, #3324 실사고 그 자체) 게이트를 못 만들었어도, 라벨정렬이 마지막 기회가 된다.

**폴링 0**: GitHub `pull_request` 페이로드는 어떤 action이든 현재 라벨 전체 집합(`labels`)을 동봉하므로 추가 조회가 불요하다.

**새 코드경로 0**: 기존 PR-라이프사이클 chokepoint(`opened`/`reopened`/`ready_for_review`/`synchronize`/base-retarget-`edited`)의 트리거 조건에 "`labeled` 이벤트 + qa:pass·design:pass 둘 다 존재"를 더했을 뿐 — `find_gate_slot_with_pr_fallback`(있으면 `reopen_gate_if_new_sha` no-op·없으면 `evaluate_merge_gate`로 생성) 로직을 그대로 재사용한다. `RECHECK_LABELS`(B2-a와 동일 상수 — "이 두 라벨이 갖춰지면 게이트가 있어야 한다"는 명제가 "SHA 불일치 시 이 두 라벨을 뗀다"는 B2-a 명제와 정확히 대칭)를 공유해 라벨 이름 리터럴 중복도 0.

## 검증

- `tests/test_2893_pr4_label_alignment_gate_creation_realdb.py`(신규, 실 PG) 5건:
  - 둘 다 갖춤 → 없던 게이트가 생성됨(핵심).
  - 한쪽만 → 미생성.
  - 무관 라벨만 → 미생성.
  - 이미 게이트가 있는 상태에서 labeled(둘 다 갖춤) 재발 → 중복 행 없음(기존 행 재사용).
  - action이 `labeled`가 아니면(예: `unlabeled`) 라벨 집합이 같아도 미트리거.
- **뮤테이션 검증**: `all(...)` → `any(...)`(한쪽 라벨만으로도 트리거되게)로 되돌리면 "한쪽만" 테스트가 정확히 예상대로 재현 확인 후 복원. `if pr_action == "labeled":` 가드 제거 시 "action≠labeled" 테스트가 정확히 예상대로 재현 확인 후 복원.
- 카디르 PR① 후속 권고③(codex 예방 발견) — `test_bot_m2_webhook_integration.py`가 같은 고정-길이 `side_effect` 패턴을 쓰고 있어 향후 호출수 증가 시 재발 후보라는 지적을 이 PR 범위에서 직접 확인: 이 파일엔 `action="labeled"` 테스트 케이스 자체가 없어(grep 0건) 이번 변경의 영향권 밖 — 별도 정비는 여전히 후속 과제로 남김(이 PR 스코프 아님, PR 본문에 남겨 다음 사람이 다시 팔 필요 없게).
- 인접 회귀 24개 파일(195 non-destructive + 13 destructive, 파일별 격리) 전부 green.

## 완료

story #2893의 4-PR 절단(A1/B1+B2-a/B3/C1)이 전부 착지 — G1~G9 수리 목표 목록 전체가 이 4개 PR로 흡수됨(G8/G9는 설계안 §5에서 명시적으로 스코프 밖·별도 트래킹).