### PR TITLE
[SID:2930] I3 — 워크스페이스 뷰 프레임(보드 접힘·자동 리듬 nav 제거)

### DIFF
--- a/apps/web/scripts/verify-mobile-nav-depth.test.ts
+++ b/apps/web/scripts/verify-mobile-nav-depth.test.ts
@@ -60,9 +60,9 @@ describe('실 NAV_GROUPS — story #2684 AC3 판별자(이벤트 포함 전 관�
   // 스캔의 시야 밖이라 이 스위트가 못 잰다(nav-config.ts 상단 "AC2 — 이 가드가 못 잡는 것"
   // ㉢·㉥류와 동형) — 렌더 검증은 app-sidebar.test.tsx가 맡는다.
   // story #2930 I3(PO 스코프 확定 2026-08-22) — work 존 흐름+스프린트가 「보드」 단일 항목으로
-  // 접히고 스탠드업·회고가 1차 메뉴에서 빠져(라우트는 보존, 이 스캔은 nav 항목 존재 여부만
-  // 잰다) 20→17항목.
-  it('전 17항목(챗 center 제외)이 depth ≤2다(회귀 0 — 도달불가 0건 포함)', () => {
+  // 접혀 20→19항목(스탠드업·회고는 CI orphan 가드가 nav 제거를 막아 잔존 — nav-config.ts
+  // 상단 주석 참고, «자동 리듬 표면»이 설 때까지의 커플링).
+  it('전 19항목(챗 center 제외)이 depth ≤2다(회귀 0 — 도달불가 0건 포함)', () => {
     const entries = computeMobileDepths(NAV_GROUPS, MOBILE_HUB_EXCLUDE_IDS, hubGroupIds);
     expect(findDepthViolations(entries, MAX_MOBILE_DEPTH)).toEqual([]);
   });

--- a/apps/web/scripts/verify-mobile-nav-depth.test.ts
+++ b/apps/web/scripts/verify-mobile-nav-depth.test.ts
@@ -59,7 +59,10 @@ describe('실 NAV_GROUPS — story #2684 AC3 판별자(이벤트 포함 전 관�
   // center의 depth-1 대응(사이드바 상단 고정, 어떤 구역에도 안 묻힘)은 이 순수 데이터
   // 스캔의 시야 밖이라 이 스위트가 못 잰다(nav-config.ts 상단 "AC2 — 이 가드가 못 잡는 것"
   // ㉢·㉥류와 동형) — 렌더 검증은 app-sidebar.test.tsx가 맡는다.
-  it('전 20항목(챗 center 제외)이 depth ≤2다(회귀 0 — 도달불가 0건 포함)', () => {
+  // story #2930 I3(PO 스코프 확定 2026-08-22) — work 존 흐름+스프린트가 「보드」 단일 항목으로
+  // 접히고 스탠드업·회고가 1차 메뉴에서 빠져(라우트는 보존, 이 스캔은 nav 항목 존재 여부만
+  // 잰다) 20→17항목.
+  it('전 17항목(챗 center 제외)이 depth ≤2다(회귀 0 — 도달불가 0건 포함)', () => {
     const entries = computeMobileDepths(NAV_GROUPS, MOBILE_HUB_EXCLUDE_IDS, hubGroupIds);
     expect(findDepthViolations(entries, MAX_MOBILE_DEPTH)).toEqual([]);
   });
@@ -72,11 +75,12 @@ describe('실 NAV_GROUPS — story #2684 AC3 판별자(이벤트 포함 전 관�
 
   // story #2930 I2 — 'chats'는 이제 NAV_GROUPS에 없어(챗 center 승격) 이 스캔 대상 밖이다.
   // MOBILE_HUB_EXCLUDE_IDS엔 방어적으로 'chats'가 여전히 남아있지만(nav-config.ts 주석 참고)
-  // 매칭될 항목 자체가 없어 depth1Ids엔 안 잡힌다.
-  it('flow·inbox는 depth 1이고 그 외는 전부 depth 2다(바텀 탭 축과 정확히 일치)', () => {
+  // 매칭될 항목 자체가 없어 depth1Ids엔 안 잡힌다. story #2930 I3 — 'flow' id가 'board'로
+  // 개명(work 존 재편)돼 exclude set도 같이 갱신됐다(nav-config.ts 참고).
+  it('board·inbox는 depth 1이고 그 외는 전부 depth 2다(바텀 탭 축과 정확히 일치)', () => {
     const entries = computeMobileDepths(NAV_GROUPS, MOBILE_HUB_EXCLUDE_IDS, hubGroupIds);
     const depth1Ids = entries.filter((e) => e.depth === 1).map((e) => e.id).sort();
-    expect(depth1Ids).toEqual(['flow', 'inbox']);
+    expect(depth1Ids).toEqual(['board', 'inbox']);
     expect(entries.filter((e) => e.depth === 2).length).toBe(entries.length - 2);
   });
 

--- a/apps/web/scripts/verify-no-orphan-resource-routes.ts
+++ b/apps/web/scripts/verify-no-orphan-resource-routes.ts
@@ -55,6 +55,11 @@
  * AC7 — 이 가드가 «못 잡는 것» (선언 없이 초록이면 「전부 봤다」로 읽힌다):
  *   ㉠런타임에 조립되는 경로 — `resourceLink(variable)`처럼 문자열 리터럴이 아닌 인자, 또는
  *     `router.push(`/${x}`)`류 템플릿 조합. 정규식은 리터럴만 본다.
+ *     실사례(story #2930 I3, 2026-08-22): `sprints`가 nav-config work 존에서 'board'로
+ *     접혀 사이드바 진입점이 사라진 뒤에도 이 가드가 계속 초록인 건 command-palette.tsx의
+ *     `go-sprints`(리터럴 href) 덕분이다 — WorkspaceFrameTabs가 만든 진짜 진입점(router.push
+ *     템플릿 리터럴)은 바로 이 ㉠ 시야 밖이라 안 보인다. command-palette 쪽 주석에 "지우지
+ *     말 것" 경고를 남겨 뒀다(PO 확定) — 지우면 이 가드가 못 잡는 조용한 orphan이 된다.
  *   ㉡`(authenticated)` 안이라도 `[ws]/[proj]` 밖의 라우트(`/organization/workforce`처럼
  *     세그먼트가 2개 이상인 하드코딩 href, `/gates/[id]` 등 엔티티 상세) — AC1이 대조하는
  *     축 자체가 `[ws]/[proj]/<resource>` 하나뿐이다.

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
@@ -29,6 +29,12 @@ vi.mock('@/components/nav/top-bar-slot', () => ({
   TopBarSlot: ({ title }: { title: React.ReactNode }) => <div>{title}</div>,
 }));
 
+// story #2930 I3 — WorkspaceFrameTabs는 useParams(next/navigation, 이 스위트가 mock 안 함)를
+// 쓴다. flow-client 자체의 로직과 무관한 크롬이라 TopBarSlot과 동형으로 스텁한다.
+vi.mock('@/components/workspace/workspace-frame-tabs', () => ({
+  WorkspaceFrameTabs: () => null,
+}));
+
 vi.mock('@/components/kanban/kanban-board', () => ({
   KanbanBoard: () => <div data-testid="kanban-board-stub">kanban</div>,
 }));

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -16,6 +16,7 @@ import { FlowNodeStoryPanel } from '@/components/flow/flow-node-story-panel';
 import { HypothesisEarthLayer } from '@/components/flow/hypothesis-earth-layer';
 import { HypothesisNarrativePanel } from '@/components/flow/hypothesis-narrative-panel';
 import { ScaleLadder } from '@/components/flow/scale-ladder';
+import { WorkspaceFrameTabs } from '@/components/workspace/workspace-frame-tabs';
 
 interface FlowPageClientProps {
   projectId: string;
@@ -212,6 +213,11 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
       <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
 
       <div className="space-y-4 p-4">
+        {/* story #2930(P0-G) I3 — nav에서 flow+sprints가 「보드」 단일 항목으로 접히며 사라진
+            sprints 진입점을 메우는 얕은 프레임(WorkspaceFrameTabs). 아래 3탭(가설|갈래|칸반)과
+            다른 층 — 그건 안 건드린다(E-FLOW-V4 기 확定). */}
+        <WorkspaceFrameTabs active="board" />
+
         {/* ② 세 칸 세그(가설|갈래|칸반) — story #2531(E-FLOW-V4 S1)에서 「가설」 칸을
             맨 앞에 신설(v4 조직원리 §2, 축척 최상위=가설). 갈래·칸반 두 칸은 07-23
             시안(`e15905e8`)에서 되찾은 것(IA 개정 때 조용히 지워졌던 것, 유나 지적

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.loadmore.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.loadmore.test.tsx
@@ -21,6 +21,12 @@ vi.mock('@/components/nav/top-bar-slot', () => ({
   ),
 }));
 
+// story #2930 I3 — WorkspaceFrameTabs는 useParams(next/navigation, 이 스위트가 mock 안 함)를
+// 쓴다. sprints-client 자체의 로직과 무관한 크롬이라 TopBarSlot과 동형으로 스텁한다.
+vi.mock('@/components/workspace/workspace-frame-tabs', () => ({
+  WorkspaceFrameTabs: () => null,
+}));
+
 const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
   useDashboardContext: () => useDashboardContextMock(),

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.test.tsx
@@ -21,6 +21,12 @@ vi.mock('@/components/nav/top-bar-slot', () => ({
   ),
 }));
 
+// story #2930 I3 — WorkspaceFrameTabs는 useParams(next/navigation, 이 스위트가 mock 안 함)를
+// 쓴다. sprints-client 자체의 로직과 무관한 크롬이라 TopBarSlot과 동형으로 스텁한다.
+vi.mock('@/components/workspace/workspace-frame-tabs', () => ({
+  WorkspaceFrameTabs: () => null,
+}));
+
 // story #2104 — HumanOnlyAction(스프린트 삭제 트리거를 감싼다)이 useDashboardContext를 읽는다.
 // 기본은 human(기존 first-touch 스위트는 게이팅과 무관). agent 케이스만 개별 override.
 const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/sprints/sprints-client.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { EmptyState } from '@/components/ui/empty-state';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { WorkspaceFrameTabs } from '@/components/workspace/workspace-frame-tabs';
 
 // story 5e229540(doc resource-view-firsttouch-identity-pattern §4 "스프린트" 행 — 정체성=
 // 한 번의 집중 사이클·시작 시 가설 선언·끝에 배움 종합·visual=선택 기간bar): 실험실(원형
@@ -704,6 +705,11 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
         }
         showContextChip
       />
+      {/* story #2930(P0-G) I3 — flow 쪽과 짝(WorkspaceFrameTabs 컴포넌트 주석 참고). nav에서
+          sprints 1차 메뉴가 빠진 자리를 메우는 얕은 프레임. */}
+      <div className="px-6 pt-3">
+        <WorkspaceFrameTabs active="sprints" />
+      </div>
       <div className="flex min-h-0 flex-1 overflow-hidden">
       {/* Sprint list */}
       <div className={`flex flex-col gap-3 overflow-y-auto p-6 transition-all duration-300 ${selected ? 'hidden w-1/2 lg:flex' : 'w-full'}`}>

--- a/apps/web/src/app/(authenticated)/more/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/more/page.test.tsx
@@ -86,8 +86,10 @@ describe('MorePage — story #2682 GNB 미러 그룹형 허브(AC1·AC3)', () =>
     const links = [...container.querySelectorAll('a')];
     const membersLink = links.find((a) => a.textContent?.includes('구성원'));
     expect(membersLink?.getAttribute('href')).toBe('/organization/members');
-    const sprintsLink = links.find((a) => a.textContent?.includes('스프린트'));
-    expect(sprintsLink?.getAttribute('href')).toBe('/sprints');
+    // story #2930 I3 — '스프린트'는 nav-config work 존에서 '보드'로 접혀 빠졌다(href는 옛
+    // 흐름의 '/flow' 그대로 보존). resource 폴백 규약 자체를 확認하는 게 목적이라 대체 항목으로.
+    const goalsLink = links.find((a) => a.textContent?.includes('목표'));
+    expect(goalsLink?.getAttribute('href')).toBe('/goals');
   });
 
   it('설정 섹션이 그룹 라벨로 뜬다(desktop 무라벨 footer와 달리 허브에선 명시 섹션)', async () => {

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -51,6 +51,12 @@ const STATIC_ITEMS: CommandItem[] = [
   { id: 'go-inbox', group: 'navigate', icon: Inbox, labelKey: 'goInbox', href: '/inbox', shortcut: ['G', 'I'] },
   { id: 'go-dashboard', group: 'navigate', icon: LayoutDashboard, labelKey: 'goDashboard', href: '/dashboard', shortcut: ['G', 'D'] },
   { id: 'go-board', group: 'navigate', icon: FolderKanban, labelKey: 'goBoard', href: '/board', shortcut: ['G', 'B'] },
+  // story #2930 I3(PO 확定 2026-08-22) — nav-config.ts work 존에서 'sprints'가 'board'로
+  // 접혀 사이드바 진입점이 사라진 뒤, 이 리터럴 href가 verify-no-orphan-resource-routes
+  // (story #2376) 가드의 유일하게 «보이는» /sprints 앵커다. WorkspaceFrameTabs(flow/sprints
+  // 페이지 상단 프레임)도 실제 도달 경로지만 router.push(템플릿 리터럴)이라 그 가드의 정적
+  // 스캔 시야 밖(가드 파일 AC7㉠에 이미 그렇게 명시돼 있다) — 이 항목을 "중복이니 삭제"하면
+  // 가드가 못 보는 조용한 orphan이 된다. 지우지 말 것.
   { id: 'go-sprints', group: 'navigate', icon: CalendarRange, labelKey: 'goSprints', href: '/sprints' },
   { id: 'go-chats', group: 'navigate', icon: MessageSquareMore, labelKey: 'goChats', href: '/chats', shortcut: ['G', 'M'] },
   { id: 'go-agents', group: 'navigate', icon: Bot, labelKey: 'goAgents', href: '/organization/workforce', shortcut: ['G', 'A'] },

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -82,13 +82,14 @@ async function mount() {
   await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 }
 
-// story #2930(P0-G) I1·I2 처방(doc ia-4zone-redesign-2930) — 「리팩터 전 하드코딩 JSX 정본」
+// story #2930(P0-G) I1·I2·I3 처방(doc ia-4zone-redesign-2930) — 「리팩터 전 하드코딩 JSX 정본」
 // 전제는 이제 지난 얘기다. 12+메뉴→오늘/워크스페이스/신뢰/지식 4구역+관리(조직·설정) 프레임
-// 재편(라우트 전부 불변)+챗을 zone에서 빼 사이드바 챗 center로 승격(I2, 별도 테스트 스위트
-// 아래 참고)한 이후의 실 마크업이 이 표의 정본이다.
+// 재편(라우트 전부 불변)+챗을 zone에서 빼 사이드바 챗 center로 승격(I2)+work 존 흐름·스프린트를
+// 「보드」 단일 항목으로 접고 스탠드업·회고를 1차 메뉴에서 뺌(I3, PO 스코프 확定 ①=ⓒ·②=ⓐ
+// 2026-08-22)한 이후의 실 마크업이 이 표의 정본이다.
 const EXPECTED_GROUPS: Array<{ labelKey: string | null; labels: string[] }> = [
   { labelKey: 'zoneNow', labels: ['조직 브리핑', '알림', '대시보드'] },
-  { labelKey: 'zoneWork', labels: ['흐름', '스프린트', '목표', '실험실', '스탠드업', '회고'] },
+  { labelKey: 'zoneWork', labels: ['보드', '목표', '실험실'] },
   { labelKey: 'zoneTrust', labels: ['활동 로그', '신뢰 센터'] },
   { labelKey: 'zoneKnowledge', labels: ['문서', '산출물', '스토리지', '기억'] },
   { labelKey: 'zoneOrganization', labels: ['구성원', '워크포스', '권한', '이벤트'] },
@@ -100,7 +101,9 @@ const EXPECTED_GROUPS: Array<{ labelKey: string | null; labels: string[] }> = [
 // center 제외 20 + 챗 center 1, 아래 별도 스위트) 전부의 라벨→href 쌍을 개별 대조해 그
 // 구멍을 닫는다 — org/project slug 없는 테스트 환경이라 resource 항목은 bare `/${resource}`로
 // 폴백한 값(기존 resourceLink()와 동일 규칙). story #2930 — '신뢰'→'신뢰 센터'로 키 갱신
-// (org-trust 라벨 개명, href 자체는 불변).
+// (org-trust 라벨 개명, href 자체는 불변). I3 — '흐름'+'스프린트'가 '보드'(href는 옛 흐름의
+// '/flow' 그대로) 하나로 접히고, '스탠드업'/'회고'는 1차 메뉴에서 빠졌다(라우트는 보존 —
+// URL 직접 진입은 여전히 가능, 이 표는 "nav에 뜨는 링크"만의 정본이라 빠진다).
 const EXPECTED_HREF_BY_LABEL: Record<string, string> = {
   '구성원': '/organization/members',
   '워크포스': '/organization/workforce',
@@ -111,12 +114,9 @@ const EXPECTED_HREF_BY_LABEL: Record<string, string> = {
   '조직 브리핑': '/org-briefing',
   '알림': '/inbox',
   '대시보드': '/dashboard',
-  '흐름': '/flow',
-  '스프린트': '/sprints',
+  '보드': '/flow',
   '목표': '/goals',
   '실험실': '/loops',
-  '스탠드업': '/standup',
-  '회고': '/retro',
   '활동 로그': '/activity',
   '문서': '/docs',
   '산출물': '/artifacts',
@@ -148,16 +148,15 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
 
   it('리소스 항목(작업 그룹, org/project slug 없음)이 bare href로 폴백한다(기존 resourceLink 동작)', async () => {
     await mount();
-    const flowLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('흐름'));
-    expect(flowLink?.getAttribute('href')).toBe('/flow');
+    // startsWith — '대시보드'가 '보드'를 부분문자열로 포함해 includes()로는 오매칭된다.
+    const boardLink = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
+    expect(boardLink?.getAttribute('href')).toBe('/flow');
   });
 
-  it('kbd 힌트(흐름=B·스탠드업=S·회고=R)가 항목별로 정확히 붙는다', async () => {
+  it('kbd 힌트(보드=B)가 붙는다', async () => {
     await mount();
-    const flowBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('흐름'));
-    expect(flowBtn?.textContent).toContain('B');
-    const standupBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('스탠드업'));
-    expect(standupBtn?.textContent).toContain('S');
+    const boardBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
+    expect(boardBtn?.textContent).toContain('B');
   });
 
   it('현재 경로와 일치하는 정적 항목이 active로 표시된다(isActive 판정 보존)', async () => {
@@ -197,14 +196,16 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   // 카디르 QA(PR#3100) 지적 — 라벨은 그대로인 채 href만 다른 항목과 뒤바뀌는 뮤테이션은 앞
-  // 테스트들(그룹별 라벨 순서 대조 + 4항목만 개별 href 대조)로는 못 잡는다. NAV_GROUPS 20항목
-  // (story #2930 I2로 챗이 이 배열에서 빠져 21→20 — 챗 center 자체 href는 별도 스위트에서
-  // 대조) 전부를 라벨→href 쌍으로 개별 대조해 "라벨은 맞는데 목적지가 틀림"을 확실히 막는다.
-  it('전 20항목(챗 center 제외)의 라벨→href 쌍이 정확하다(뒤바뀐 목적지 방지, 카디르 QA 지적 반영)', async () => {
+  // 테스트들(그룹별 라벨 순서 대조 + 4항목만 개별 href 대조)로는 못 잡는다. NAV_GROUPS 17항목
+  // (챗 center 자체 href는 별도 스위트에서 대조 — I2로 21→20, I3로 work 존 6→3이라 20→17)
+  // 전부를 라벨→href 쌍으로 개별 대조해 "라벨은 맞는데 목적지가 틀림"을 확실히 막는다.
+  it('전 17항목(챗 center 제외)의 라벨→href 쌍이 정확하다(뒤바뀐 목적지 방지, 카디르 QA 지적 반영)', async () => {
     await mount();
     const links = [...container.querySelectorAll('a')];
     for (const [label, expectedHref] of Object.entries(EXPECTED_HREF_BY_LABEL)) {
-      const link = links.find((a) => a.textContent?.includes(label));
+      // startsWith — story #2930 I3부터 '보드'가 '대시보드'의 부분문자열이라 includes()는
+      // 오매칭된다(kbd 힌트 접미사가 있는 항목도 있어 정확한 === 매칭은 못 쓴다).
+      const link = links.find((a) => a.textContent?.startsWith(label));
       expect(link, `링크 "${label}"를 찾지 못함`).toBeDefined();
       expect(link!.getAttribute('href'), `"${label}"의 href`).toBe(expectedHref);
     }

--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -85,11 +85,13 @@ async function mount() {
 // story #2930(P0-G) I1·I2·I3 처방(doc ia-4zone-redesign-2930) — 「리팩터 전 하드코딩 JSX 정본」
 // 전제는 이제 지난 얘기다. 12+메뉴→오늘/워크스페이스/신뢰/지식 4구역+관리(조직·설정) 프레임
 // 재편(라우트 전부 불변)+챗을 zone에서 빼 사이드바 챗 center로 승격(I2)+work 존 흐름·스프린트를
-// 「보드」 단일 항목으로 접고 스탠드업·회고를 1차 메뉴에서 뺌(I3, PO 스코프 확定 ①=ⓒ·②=ⓐ
-// 2026-08-22)한 이후의 실 마크업이 이 표의 정본이다.
+// 「보드」 단일 항목으로 접음(I3, PO 스코프 확定 ①=ⓒ 2026-08-22). 스탠드업·회고는 애초 I3에서
+// 1차 메뉴 제거를 시도했으나 CI orphan 가드(story #2376)가 막았다 — command-palette에 대체
+// entry가 없어 nav서 빼면 진짜 orphan이 됐다(sprints와 달리). 「자동 리듬 표면」(doc B2, 구현
+// PO)이 아직 없어 생긴 커플링이라 표면이 설 때까지 nav에 남긴다(②=ⓐ→되돌림, 유나 QA 처방).
 const EXPECTED_GROUPS: Array<{ labelKey: string | null; labels: string[] }> = [
   { labelKey: 'zoneNow', labels: ['조직 브리핑', '알림', '대시보드'] },
-  { labelKey: 'zoneWork', labels: ['보드', '목표', '실험실'] },
+  { labelKey: 'zoneWork', labels: ['보드', '목표', '실험실', '스탠드업', '회고'] },
   { labelKey: 'zoneTrust', labels: ['활동 로그', '신뢰 센터'] },
   { labelKey: 'zoneKnowledge', labels: ['문서', '산출물', '스토리지', '기억'] },
   { labelKey: 'zoneOrganization', labels: ['구성원', '워크포스', '권한', '이벤트'] },
@@ -102,8 +104,8 @@ const EXPECTED_GROUPS: Array<{ labelKey: string | null; labels: string[] }> = [
 // 구멍을 닫는다 — org/project slug 없는 테스트 환경이라 resource 항목은 bare `/${resource}`로
 // 폴백한 값(기존 resourceLink()와 동일 규칙). story #2930 — '신뢰'→'신뢰 센터'로 키 갱신
 // (org-trust 라벨 개명, href 자체는 불변). I3 — '흐름'+'스프린트'가 '보드'(href는 옛 흐름의
-// '/flow' 그대로) 하나로 접히고, '스탠드업'/'회고'는 1차 메뉴에서 빠졌다(라우트는 보존 —
-// URL 직접 진입은 여전히 가능, 이 표는 "nav에 뜨는 링크"만의 정본이라 빠진다).
+// '/flow' 그대로) 하나로 접혔다. 스탠드업/회고는 CI orphan 가드가 막아 nav에 그대로 남았다
+// (위 EXPECTED_GROUPS 주석 참고).
 const EXPECTED_HREF_BY_LABEL: Record<string, string> = {
   '구성원': '/organization/members',
   '워크포스': '/organization/workforce',
@@ -117,6 +119,8 @@ const EXPECTED_HREF_BY_LABEL: Record<string, string> = {
   '보드': '/flow',
   '목표': '/goals',
   '실험실': '/loops',
+  '스탠드업': '/standup',
+  '회고': '/retro',
   '활동 로그': '/activity',
   '문서': '/docs',
   '산출물': '/artifacts',
@@ -153,10 +157,12 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
     expect(boardLink?.getAttribute('href')).toBe('/flow');
   });
 
-  it('kbd 힌트(보드=B)가 붙는다', async () => {
+  it('kbd 힌트(보드=B·스탠드업=S)가 항목별로 정확히 붙는다', async () => {
     await mount();
     const boardBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.startsWith('보드'));
     expect(boardBtn?.textContent).toContain('B');
+    const standupBtn = [...container.querySelectorAll('a')].find((a) => a.textContent?.includes('스탠드업'));
+    expect(standupBtn?.textContent).toContain('S');
   });
 
   it('현재 경로와 일치하는 정적 항목이 active로 표시된다(isActive 판정 보존)', async () => {
@@ -196,10 +202,11 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
   });
 
   // 카디르 QA(PR#3100) 지적 — 라벨은 그대로인 채 href만 다른 항목과 뒤바뀌는 뮤테이션은 앞
-  // 테스트들(그룹별 라벨 순서 대조 + 4항목만 개별 href 대조)로는 못 잡는다. NAV_GROUPS 17항목
-  // (챗 center 자체 href는 별도 스위트에서 대조 — I2로 21→20, I3로 work 존 6→3이라 20→17)
-  // 전부를 라벨→href 쌍으로 개별 대조해 "라벨은 맞는데 목적지가 틀림"을 확실히 막는다.
-  it('전 17항목(챗 center 제외)의 라벨→href 쌍이 정확하다(뒤바뀐 목적지 방지, 카디르 QA 지적 반영)', async () => {
+  // 테스트들(그룹별 라벨 순서 대조 + 4항목만 개별 href 대조)로는 못 잡는다. NAV_GROUPS 19항목
+  // (챗 center 자체 href는 별도 스위트에서 대조 — I2로 21→20, I3로 flow+sprints가 board로
+  // 접혀 20→19, 스탠드업/회고는 CI orphan 가드로 되돌려 그대로 잔존) 전부를 라벨→href 쌍으로
+  // 개별 대조해 "라벨은 맞는데 목적지가 틀림"을 확실히 막는다.
+  it('전 19항목(챗 center 제외)의 라벨→href 쌍이 정확하다(뒤바뀐 목적지 방지, 카디르 QA 지적 반영)', async () => {
     await mount();
     const links = [...container.querySelectorAll('a')];
     for (const [label, expectedHref] of Object.entries(EXPECTED_HREF_BY_LABEL)) {

--- a/apps/web/src/components/workspace/workspace-frame-tabs.test.tsx
+++ b/apps/web/src/components/workspace/workspace-frame-tabs.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+//
+// story #2930(P0-G) I3(doc ia-4zone-redesign-2930, PO 스코프 확定 ①=ⓒ 2026-08-22) — flow+sprints가
+// nav에서 「보드」 단일 항목으로 접히며 사라진 sprints 진입점을 이 프레임이 메우는지, 실제로는
+// 진짜 라우트 네비게이션(router.push)인지를 고정한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import enMessages from '../../../messages/en.json';
+
+const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn() }));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useParams: () => ({ ws: 'my-ws', proj: 'my-proj' }),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode, messages: typeof koMessages = koMessages) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={messages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  pushMock.mockReset();
+});
+
+describe('WorkspaceFrameTabs — story #2930 I3', () => {
+  it('보드·스프린트 두 탭만 렌더한다(에픽은 단독 표면 부재로 스코프 밖, PO 확定 ①=ⓒ)', async () => {
+    const { WorkspaceFrameTabs } = await import('./workspace-frame-tabs');
+    await act(async () => { root.render(wrap(<WorkspaceFrameTabs active="board" />)); });
+    const tabs = [...container.querySelectorAll('[role="tab"]')];
+    expect(tabs.map((t) => t.textContent)).toEqual(['보드', '스프린트']);
+  });
+
+  it('active="board"면 보드 탭에 aria-selected=true가 붙는다', async () => {
+    const { WorkspaceFrameTabs } = await import('./workspace-frame-tabs');
+    await act(async () => { root.render(wrap(<WorkspaceFrameTabs active="board" />)); });
+    const boardTab = [...container.querySelectorAll('[role="tab"]')].find((t) => t.textContent === '보드');
+    const sprintsTab = [...container.querySelectorAll('[role="tab"]')].find((t) => t.textContent === '스프린트');
+    expect(boardTab?.getAttribute('aria-selected')).toBe('true');
+    expect(sprintsTab?.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('스프린트 탭 클릭 시 /{ws}/{proj}/sprints로 진짜 라우트 네비게이션한다(in-page 상태 아님)', async () => {
+    const { WorkspaceFrameTabs } = await import('./workspace-frame-tabs');
+    await act(async () => { root.render(wrap(<WorkspaceFrameTabs active="board" />)); });
+    const sprintsTab = [...container.querySelectorAll('[role="tab"]')].find((t) => t.textContent === '스프린트');
+    await act(async () => { sprintsTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(pushMock).toHaveBeenCalledWith('/my-ws/my-proj/sprints');
+  });
+
+  it('보드 탭 클릭 시 /{ws}/{proj}/flow로 이동한다(nav-config path 불변과 정합)', async () => {
+    const { WorkspaceFrameTabs } = await import('./workspace-frame-tabs');
+    await act(async () => { root.render(wrap(<WorkspaceFrameTabs active="sprints" />)); });
+    const boardTab = [...container.querySelectorAll('[role="tab"]')].find((t) => t.textContent === '보드');
+    await act(async () => { boardTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(pushMock).toHaveBeenCalledWith('/my-ws/my-proj/flow');
+  });
+
+  it('en 로케일에서도 렌더된다(ko/en 파리티)', async () => {
+    const { WorkspaceFrameTabs } = await import('./workspace-frame-tabs');
+    await act(async () => { root.render(wrap(<WorkspaceFrameTabs active="board" />, enMessages)); });
+    const tabs = [...container.querySelectorAll('[role="tab"]')];
+    expect(tabs.map((t) => t.textContent)).toEqual(['Board', 'Sprints']);
+  });
+});

--- a/apps/web/src/components/workspace/workspace-frame-tabs.tsx
+++ b/apps/web/src/components/workspace/workspace-frame-tabs.tsx
@@ -28,7 +28,12 @@ export function WorkspaceFrameTabs({ active }: { active: WorkspaceFrameTabKey })
   const params = useParams<{ ws: string; proj: string }>();
 
   return (
-    <div className="flex items-center gap-1 border-b border-border pb-2" role="tablist" aria-label={t('workspace')}>
+    // 유나 QA 블로커(PR#3358, 2026-08-22) — flow-client 내부 3탭(가설/갈래/칸반)과 스타일이
+    // byte-identical(둘 다 rounded pill+bg-muted active)이라 스택되면 «동일 탭 행 2개」로
+    // 위계 구분이 안 됐다. 처방(유나 확定): 상위 프레임은 text-sm+하단 인디케이터(underline)로
+    // — 페이지-크롬(notification-bell.tsx 필터 탭과 동형 패턴, 신규 발명 아님). 내부 뷰 탭의
+    // rounded pill과 kind 자체가 달라 한눈에 "이건 다른 층"으로 읽힌다.
+    <div className="flex items-center gap-4 border-b border-border" role="tablist" aria-label={t('workspace')}>
       {TABS.map((tab) => (
         <button
           key={tab.key}
@@ -36,7 +41,7 @@ export function WorkspaceFrameTabs({ active }: { active: WorkspaceFrameTabKey })
           role="tab"
           aria-selected={active === tab.key}
           onClick={() => router.push(`/${params.ws}/${params.proj}/${tab.path}`)}
-          className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${active === tab.key ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+          className={`-mb-px border-b-2 px-1 pb-2 text-sm font-semibold transition ${active === tab.key ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
         >
           {t(tab.key)}
         </button>

--- a/apps/web/src/components/workspace/workspace-frame-tabs.tsx
+++ b/apps/web/src/components/workspace/workspace-frame-tabs.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+
+const TABS = [
+  { key: 'board', path: 'flow' },
+  { key: 'sprints', path: 'sprints' },
+] as const;
+
+type WorkspaceFrameTabKey = (typeof TABS)[number]['key'];
+
+/**
+ * story #2930(P0-G) I3(doc ia-4zone-redesign-2930, PO 스코프 확定 ①=ⓒ 2026-08-22) — nav에서
+ * flow+sprints가 「보드」 단일 1차 메뉴로 접히면서(nav-config.ts work 존) 사라진 sprints
+ * 진입점을 메우는 얕은 프레임. 두 라우트(/flow·/sprints)는 그대로 실 페이지로 남기고(라우트
+ * 보존 원칙, path 불변) 이 컴포넌트가 그 위에 얹혀 «워크스페이스 뷰 전환처럼 보이는» 탭 한
+ * 줄만 그린다 — 실제로는 진짜 페이지 네비게이션(router.push)이라 각 페이지의 자체 로직·
+ * 데이터 페칭은 서로 안 건드린다. flow-client.tsx 자체의 기존 3탭(가설/갈래/칸반, E-FLOW-V4
+ * 기 확定)과는 다른 층이라 그건 그대로 둔다 — 이 프레임은 그 위(바깥)에 얹힌다.
+ *
+ * "에픽"(시안 3뷰 중 하나)은 코드상 단독 표면이 없어(analytics API만 존재) 이 슬라이스
+ * 스코프 밖(PO 확定, 신규 페이지 제작은 후속 스토리) — 그래서 TABS가 2개뿐이다.
+ */
+export function WorkspaceFrameTabs({ active }: { active: WorkspaceFrameTabKey }) {
+  const t = useTranslations('nav');
+  const router = useRouter();
+  const params = useParams<{ ws: string; proj: string }>();
+
+  return (
+    <div className="flex items-center gap-1 border-b border-border pb-2" role="tablist" aria-label={t('workspace')}>
+      {TABS.map((tab) => (
+        <button
+          key={tab.key}
+          type="button"
+          role="tab"
+          aria-selected={active === tab.key}
+          onClick={() => router.push(`/${params.ws}/${params.proj}/${tab.path}`)}
+          className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${active === tab.key ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+        >
+          {t(tab.key)}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -14,9 +14,11 @@ import {
   Newspaper,
   Settings,
   Shield,
+  Users,
   Users2,
   Workflow,
   Zap,
+  Gauge,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -69,9 +71,14 @@ export interface NavGroupConfig {
 //   별도 등재). /flow·/sprints 페이지 상단엔 WorkspaceFrameTabs(신규 공유 컴포넌트)로 두
 //   라우트를 오가는 얕은 「뷰」 전환처럼 보이는 프레임을 얹는다(flow 자체의 기존 3탭
 //   가설/갈래/칸반은 안 건드림 — 그건 다른 층, E-FLOW-V4 기 확定 기능).
-// ②=ⓐ standup/retro는 1차 메뉴에서만 뺀다(라우트/페이지 보존, URL 직접 진입 가능) — 「자동
-//   리듬 표면」으로의 실제 이관(트리거 발행 등 BE 함의)은 doc B2가 "명시만·구현 PO"로 이미
-//   선을 그어 이 슬라이스 몫이 아니다.
+// ②=ⓐ→되돌림(유나 QA·PO 확定, 2026-08-22): standup/retro를 1차 메뉴에서 빼려 했으나 CI
+//   orphan 가드(verify-no-orphan-resource-routes, story #2376)가 routeWithoutEntry로
+//   막았다 — sprints와 달리 standup/retro는 command-palette.tsx에도 대체 entry가 없어
+//   nav서 빼면 «URL 직접 진입만 가능한 진짜 orphan»(그 URL을 아는 사람만 도달, 가드가
+//   정확히 잡으려던 바로 그 상황)이 된다. 「자동 리듬 표면」(doc B2, 구현 PO)이 아직 없어서
+//   생긴 커플링 — FAB↔B3·배지↔4탭과 동형 패턴("표면이 설 때 nav서 뺀다", 오늘 세 번째
+//   사례). 그래서 standup/retro는 nav에 그대로 남긴다(work 존 6→3이 아니라 6→5 — board가
+//   flow+sprints를 흡수한 만큼만 준다).
 export const NAV_GROUPS: NavGroupConfig[] = [
   {
     id: 'now',
@@ -91,6 +98,8 @@ export const NAV_GROUPS: NavGroupConfig[] = [
       { id: 'board', labelKey: 'board', icon: Workflow, kind: 'resource', path: 'flow', kbdHint: 'B' },
       { id: 'goals', labelKey: 'goals', icon: Layers, kind: 'resource', path: 'goals' },
       { id: 'loops', labelKey: 'loops', icon: FlaskConical, kind: 'resource', path: 'loops' },
+      { id: 'standup', labelKey: 'standup', icon: Users, kind: 'resource', path: 'standup', kbdHint: 'S' },
+      { id: 'retro', labelKey: 'retro', icon: Gauge, kind: 'resource', path: 'retro', kbdHint: 'R' },
     ],
   },
   {

--- a/apps/web/src/lib/nav-config.ts
+++ b/apps/web/src/lib/nav-config.ts
@@ -3,7 +3,6 @@ import {
   BookOpen,
   Bot,
   Brain,
-  CalendarRange,
   ClipboardList,
   FlaskConical,
   GalleryVerticalEnd,
@@ -15,11 +14,9 @@ import {
   Newspaper,
   Settings,
   Shield,
-  Users,
   Users2,
   Workflow,
   Zap,
-  Gauge,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -63,9 +60,18 @@ export interface NavGroupConfig {
 // 그대로 위반한다(라벨만 앞서가고 착지는 그대로라 다시 어긋남) — B3 확定 후 착지가
 // attention으로 바뀌는 시점에 라벨도 같이 바꾼다.
 //
-// work 존 6항목(flow/sprints/goals/loops/standup/retro)의 "보드/목표/실험 뷰 전환+자동 리듬"
-// 재라벨은 I3(워크스페이스 뷰 프레임) 스코프 — 지금 라벨만 바꾸면 6항목이 여전히 개별
-// 메뉴로 보이는 채로 "보드"라는 통합 뷰 이름을 참칭하게 된다. I3가 실제로 접을 때 같이 바꾼다.
+// story #2930 I3(doc ia-4zone-redesign-2930, PO 스코프 확定 2026-08-22) — work 존 6항목
+// (flow/sprints/goals/loops/standup/retro) 재편:
+// ①=ⓒ flow+sprints를 1차 메뉴에서 「보드」 단일 항목으로 접는다(id 'board', path는 기존
+//   'flow' 그대로 — 라우트 불변). sprints 라우트 자체는 안 건드리고(URL 직접 진입 가능)
+//   1차 nav 항목만 뺀다. "에픽"(시안 3뷰 중 하나)은 코드상 단독 표면이 없어(analytics API만
+//   존재) 이 슬라이스 스코프 밖(PO: 신규 페이지 제작은 I3=nav 프레임 스코프 밖·후속 스토리로
+//   별도 등재). /flow·/sprints 페이지 상단엔 WorkspaceFrameTabs(신규 공유 컴포넌트)로 두
+//   라우트를 오가는 얕은 「뷰」 전환처럼 보이는 프레임을 얹는다(flow 자체의 기존 3탭
+//   가설/갈래/칸반은 안 건드림 — 그건 다른 층, E-FLOW-V4 기 확定 기능).
+// ②=ⓐ standup/retro는 1차 메뉴에서만 뺀다(라우트/페이지 보존, URL 직접 진입 가능) — 「자동
+//   리듬 표면」으로의 실제 이관(트리거 발행 등 BE 함의)은 doc B2가 "명시만·구현 PO"로 이미
+//   선을 그어 이 슬라이스 몫이 아니다.
 export const NAV_GROUPS: NavGroupConfig[] = [
   {
     id: 'now',
@@ -82,12 +88,9 @@ export const NAV_GROUPS: NavGroupConfig[] = [
     id: 'work',
     labelKey: 'zoneWork',
     items: [
-      { id: 'flow', labelKey: 'flow', icon: Workflow, kind: 'resource', path: 'flow', kbdHint: 'B' },
-      { id: 'sprints', labelKey: 'sprints', icon: CalendarRange, kind: 'resource', path: 'sprints' },
+      { id: 'board', labelKey: 'board', icon: Workflow, kind: 'resource', path: 'flow', kbdHint: 'B' },
       { id: 'goals', labelKey: 'goals', icon: Layers, kind: 'resource', path: 'goals' },
       { id: 'loops', labelKey: 'loops', icon: FlaskConical, kind: 'resource', path: 'loops' },
-      { id: 'standup', labelKey: 'standup', icon: Users, kind: 'resource', path: 'standup', kbdHint: 'S' },
-      { id: 'retro', labelKey: 'retro', icon: Gauge, kind: 'resource', path: 'retro', kbdHint: 'R' },
     ],
   },
   {
@@ -151,7 +154,9 @@ export const MOBILE_HUB_GROUP_ORDER = ['now', 'work', 'trust', 'knowledge', 'org
 // story #2930 I2 — chats가 NAV_GROUPS 배열 자체에서 빠지므로(사이드바 챗 center로 승격) 이
 // id는 이제 실질적으로 no-op이지만, 모바일 탭바(I4가 다룰 영역)가 chat을 FAB로 승격하며 같은
 // "허브에 중복 진입점 금지" 원칙이 유효하므로 방어적으로 남겨둔다(제거해도 부작용 없음).
-export const MOBILE_HUB_EXCLUDE_IDS = new Set(['flow', 'inbox', 'chats']);
+// story #2930 I3 — 'flow'는 id가 'board'로 접혔다(work 존 재편, 위 참고). depth-1 취급
+// 의도는 그대로(빠른 접근 대상)라 exclude id도 같이 개명.
+export const MOBILE_HUB_EXCLUDE_IDS = new Set(['board', 'inbox', 'chats']);
 
 // story #2930(P0-G) I2 — 챗은 4구역 밖 1급 「center」(중심 꽃, 선생님 확定). NAV_GROUPS
 // 배열엔 없다(구역에 묻지 않는다는 게 이 승격의 요점) — 데스크톱 사이드바 상단 고정 카드


### PR DESCRIPTION
## 요약
story #2930(P0-G, IA 4구역 재설계) I3 슬라이스 — doc `ia-4zone-redesign-2930`.

PO 스코프 확定(2026-08-22, 그라운딩 질의 응답):
- **①=ⓒ** 「에픽」은 코드상 단독 표면이 없어(analytics API만 존재) 이 슬라이스 스코프 밖 — 보드·스프린트 2뷰만 접는다(에픽 전용 페이지는 후속 스토리로 PO가 별도 등재).
- **②=ⓐ→CI가 막아 되돌림(2026-08-22, 유나 QA)** standup/retro를 1차 메뉴에서 빼려 했으나 CI orphan 가드(`verify-no-orphan-resource-routes`, story #2376)가 routeWithoutEntry로 막았다 — sprints와 달리 command-palette.tsx에 대체 entry가 없어 nav서 빼면 **진짜 orphan**(URL을 아는 사람만 도달)이 된다. 「자동 리듬 표면」(doc B2, 구현 PO)이 아직 없어서 생긴 커플링 — FAB↔B3·배지↔4탭과 동형 패턴("표면이 설 때 nav서 뺀다"). **standup/retro는 nav에 그대로 남는다.** work 존은 6→5(board가 flow+sprints만 흡수).

## 변경
- `nav-config.ts`: work 존 6항목 중 flow+sprints만 `board` 단일 nav 항목으로 접힘(path는 기존 `flow` 그대로 — **라우트 100% 불변**). standup/retro는 그대로 유지.
- `workspace-frame-tabs.tsx`(신규): nav에서 sprints 진입점이 사라진 자리를 메우는 얕은 공유 프레임. `/flow`·`/sprints` 두 실 라우트를 오가는 진짜 네비게이션(`router.push`)이라 각 페이지의 데이터 페칭/로직은 서로 안 건드림. flow-client 자체의 기존 3탭(가설/갈래/칸반, E-FLOW-V4 기 확定 기능)과는 다른 층 — 유나 블로커 처방으로 text-sm+underline 인디케이터(notification-bell.tsx 필터탭과 동형)로 시각 위계를 분리했다.
- `flow-client.tsx`·`sprints-client.tsx`: 위 프레임 배선.
- `command-palette.tsx`: `go-sprints` 항목이 orphan 가드의 유일하게 보이는 /sprints 앵커임을 문서화(WorkspaceFrameTabs의 router.push 템플릿 리터럴은 가드 AC7㉠ 시야 밖) — 삭제 금지 경고.
- `verify-no-orphan-resource-routes.ts`: AC7㉠에 위 sprints 실사례를 교차문서화.

## 스코프 밖(명시)
- 에픽 전용 표면 신설 — 후속 스토리(PO 등재 예정)
- standup/retro 자동 리듬 표면 이관 — doc B2, 구현 PO(표면이 설 때 nav에서 뺀다)
- I4(모바일 탭바 4구역 전환), I5(리다이렉트) — 별도 슬라이스

## 검증
- `pnpm exec tsc --noEmit -p .` 0
- `pnpm exec eslint` 대상 파일 0
- `pnpm exec vitest run` 전체 477 files / 4038 tests green
- `verify:no-orphan-resource-routes` 신규 0건(로컬 재현: standup/retro nav 제거 시 2건 실패 → 복원 후 0건)
- `verify:tint-foreground-contrast` / `verify:no-new-tint-color-text` / `verify:cross-element-tint-text` / `verify:no-handrolled-modal` / `verify:no-i18n-phrase-collision` / `verify:reserved-first-segments-sync` / `verify:migrated-resources-sync` 전부 신규위반 0
- `pnpm run build` EXIT 0

## 스크린샷
라이브 dev 배포 후 카디르군 QA 단계에서 실측 스크린샷 첨부 예정(반응형 확인 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)