### PR TITLE
[SID:2932] fix(2932): 게이트 PR단위 슬롯 하드닝 3건 — cross-repo identity·NULL승격 동시성·B3 fallback 합성

### DIFF
--- a/backend/alembic/versions/0272_gate_repo_scoped_slot.py
+++ b/backend/alembic/versions/0272_gate_repo_scoped_slot.py
@@ -32,13 +32,17 @@ depends_on = None
 def upgrade() -> None:
     op.add_column("gate", sa.Column("repo_full_name", sa.Text(), nullable=True))
 
+    # 카디르 QA(story #2932 HIGH1, 2026-08-22, 이 PR 자체 재재verdict) — 기존 SSOT
+    # pr_story_link.py::normalize_repo(strip+lower)와 정합하지 않으면 `Acme/Repo`가
+    # 백필된 뒤 애플리케이션이 조회할 땐 소문자로 비교해 못 찾는다 — 백필 자체를
+    # lower(trim(...))로 정규화한다.
     op.execute(
         """
         UPDATE gate
-        SET repo_full_name = (neutral_facts->>'repo')
+        SET repo_full_name = lower(trim(neutral_facts->>'repo'))
         WHERE gate_type = 'merge'
           AND neutral_facts ? 'repo'
-          AND (neutral_facts->>'repo') <> ''
+          AND trim(neutral_facts->>'repo') <> ''
         """
     )
 

--- a/backend/alembic/versions/0272_gate_repo_scoped_slot.py
+++ b/backend/alembic/versions/0272_gate_repo_scoped_slot.py
@@ -1,0 +1,94 @@
+"""story #2932([게이트·후속] PR단위 슬롯 하드닝 3건, HIGH1) — gate 슬롯 identity에 repo 편입.
+
+0271(A1)이 멱등 키를 `(work_item_id, gate_type)` → `(work_item_id, gate_type, pr_number)`로
+확장해 PR간 격리를 구조로 보장했지만, `pr_number`는 repo 경계 없이 전역(스토리 스코프
+안에서)으로만 유니크했다 — 같은 스토리에 **다른 repo의 동일 번호 PR**이 링크되면(예:
+cross-repo 재구성·모노레포 분리 등) 두 PR이 같은 게이트 슬롯을 공유해 SHA/evidence가
+섞인다(story #2932 HIGH1, 카디르 소스 직접확認).
+
+백필: 0271과 동일 패턴 — `neutral_facts.repo`(evaluate_merge_gate가 매 호출마다 이미
+적어 옴, merge_verdict_gate.py facts dict)에서 그대로 끌어온다. GitHub API 역조회 불요.
+
+제약 재설계: pr_number IS NOT NULL 구간을 다시 둘로 쪼갠다 — repo_full_name도 아는
+행(정밀 스코프: pr_number+repo 둘 다로 유니크)과 모르는 행(레거시/미백필, pr_number만으로
+유니크 — 0271 그대로 유지, cross-repo disambiguation을 못 하지만 그 이상 나빠지지도
+않는다). NULL-pr_number 구간(0271의 no_pr 인덱스)은 이 마이그의 스코프 밖 — 그대로 둔다.
+
+Revision ID: 0272
+Revises: 0271
+Create Date: 2026-08-22
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0272"
+down_revision = "0271"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("gate", sa.Column("repo_full_name", sa.Text(), nullable=True))
+
+    op.execute(
+        """
+        UPDATE gate
+        SET repo_full_name = (neutral_facts->>'repo')
+        WHERE gate_type = 'merge'
+          AND neutral_facts ? 'repo'
+          AND (neutral_facts->>'repo') <> ''
+        """
+    )
+
+    op.drop_index("uq_gate_work_item_gate_type_pr", table_name="gate")
+    op.create_index(
+        "uq_gate_work_item_gate_type_pr_repo",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type", "pr_number", "repo_full_name"],
+        unique=True,
+        postgresql_where=sa.text("pr_number IS NOT NULL AND repo_full_name IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_gate_work_item_gate_type_pr_no_repo",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type", "pr_number"],
+        unique=True,
+        postgresql_where=sa.text("pr_number IS NOT NULL AND repo_full_name IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    # 0271 downgrade와 동일 lossy 원칙(PO 선례) — pr_number 스코프 안에서 repo_full_name이
+    # 다른 행이 2개 이상(=이 마이그 목적 자체가 만드는 정상 상태, cross-repo 격리) 실존하면
+    # 옛 pr_number-only 유니크 복원이 UniqueViolation으로 막힌다. repo_full_name을 아는
+    # 행을 모르는 행보다 우선 보존(있는 정보가 없는 정보보다 낫다), 동순위는 id DESC로
+    # 결정론적 타이브레이크.
+    op.execute(
+        """
+        DELETE FROM gate
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT id,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY org_id, work_item_id, work_item_type, gate_type, pr_number
+                           ORDER BY (repo_full_name IS NOT NULL) DESC, id DESC
+                       ) AS rn
+                FROM gate
+                WHERE pr_number IS NOT NULL
+            ) ranked
+            WHERE rn > 1
+        )
+        """
+    )
+    op.drop_index("uq_gate_work_item_gate_type_pr_no_repo", table_name="gate")
+    op.drop_index("uq_gate_work_item_gate_type_pr_repo", table_name="gate")
+    op.create_index(
+        "uq_gate_work_item_gate_type_pr",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type", "pr_number"],
+        unique=True,
+        postgresql_where=sa.text("pr_number IS NOT NULL"),
+    )
+    op.drop_column("gate", "repo_full_name")

--- a/backend/alembic/versions/0273_gate_pr_head_observed_at.py
+++ b/backend/alembic/versions/0273_gate_pr_head_observed_at.py
@@ -1,0 +1,38 @@
+"""story #2932(완주조건 HIGH2, PR#3357 재재verdict — codex+카디르 일치판단) — stale/순서역전
+webhook의 spurious 재-pending 방지.
+
+`reopen_gate_if_new_sha`가 `gate.approved_head_sha != new_head_sha`만으로 재-pending을
+판정했다 — GitHub가 웹훅 배달 순서를 보장하지 않으므로(재시도·네트워크 재정렬), 이미 최신
+SHA로 승인된 게이트에 **뒤늦게 도착한 옛 synchronize 배달**이 그 옛 SHA와의 불일치만 보고
+"최신 검증 SHA에 대한 승인"을 부당하게 재-pending시킬 수 있었다(story #2893의 핵심
+보증 — "승인은 그때의 커밋에" — 을 이 클래스가 직접 깬다는 것이 codex/카디르 일치판단).
+
+처방: `pull_request.updated_at`(GitHub가 실 PR 갱신마다 단조증가시키는 타임스탬프, 웹훅
+페이로드에 항상 동봉)을 게이트에 워터마크로 기록한다. 새로 도착한 이벤트의 `updated_at`이
+이미 관측된 워터마크보다 **오래되면**(<=) 그 배달을 stale로 간주해 SHA 불일치와 무관하게
+재-pending을 skip한다 — GitHub API 재조회 없이(폴링 0, story #2893 §4 C1 원칙과 동형)
+페이로드 자체의 신호만으로 순서를 검증.
+
+Revision ID: 0273
+Revises: 0272
+Create Date: 2026-08-22
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0273"
+down_revision = "0272"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "gate", sa.Column("pr_head_observed_at", sa.DateTime(timezone=True), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("gate", "pr_head_observed_at")

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -71,6 +71,11 @@ class Gate(Base):
     # 2개로 분리(NULL 구간=옛 계약 그대로, NOT NULL 구간=+pr_number). create_gate() 호출부
     # 전수는 gate_service.py 참조.
     pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # story #2932(HIGH1, 0272) — pr_number 단독은 repo 경계가 없어(전역이 아니라 스토리
+    # 스코프 안에서도) 다른 repo의 같은 번호 PR이 슬롯을 공유할 수 있었다(cross-repo
+    # 충돌). pr_number와 짝으로 멱등 키에 편입 — find_gate_slot_with_pr_fallback.py 참조.
+    # NULL=pr_number와 동형 사유(PR 컨텍스트 없음/레거시 미백필).
+    repo_full_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="pending")
     resolver_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -108,6 +108,10 @@ class Gate(Base):
     # 웹훅의 새 head_sha와 다르면 재-pending(approved→pending) 트리거(카디르 QA③-b: reopen 가드를
     # synchronize만이 아니라 네 액션 전부에서 돌림 — 다른 head로 돌아온 재오픈 PR도 잡는다).
     approved_head_sha: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #2932(완주조건 HIGH2, 0273) — GitHub `pull_request.updated_at`(실 PR 갱신마다
+    # 단조증가) 워터마크. reopen_gate_if_new_sha가 이걸로 stale/순서역전 웹훅 배달을
+    # 걸러 이미 최신 SHA로 승인된 게이트를 옛 배달로 부당 재-pending시키지 않는다.
+    pr_head_observed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -19,12 +19,7 @@ from app.models.hitl import HitlRequest
 from app.models.pm import Story, Task
 from app.models.visual_artifact import VisualArtifact
 from app.routers.agent_gateway import wake_agent
-from app.services.gate_github_check import (
-    is_repo_check_enforced,
-    publish_gate_check,
-    resolve_pr_link,
-    seed_pr_head_watermark,
-)
+from app.services.gate_github_check import is_repo_check_enforced, publish_gate_check, resolve_pr_link
 from app.services.github_app import get_installation_token, get_pull_request
 from app.services.merge_verdict_gate import MERGE_GATE_TYPE, reconcile_merge_gate_with_real_evidence
 from app.services.verdict_capture import fetch_status_check_rollup
@@ -1199,11 +1194,14 @@ async def transition_gate_endpoint(
                 _head_sha = (_link.evidence or {}).get("head_sha") if _link else None
             if _head_sha:
                 gate.approved_head_sha = _head_sha
-                # story #2932 완주조건 HIGH2(4라운드 카디르 자기정정) — 사람 UI 승인이 이
-                # 워터마크를 못 얻던 원 결함의 정확한 자리(writer 3곳 중 하나). 여기서 안
-                # 찍으면 승인 직후 도착하는 stale webhook이 워터마크=None이라 staleness guard가
-                # 아예 발동을 못 한다.
-                seed_pr_head_watermark(gate)
+                # story #2932 완주조건 HIGH2(5라운드 재설계) — 이전엔(4라운드) 여기서 서버
+                # now()로 pr_head_observed_at을 씨딩했으나, 서로 다른 시계(서버시각 vs GitHub
+                # 실시각)를 같은 필드에 섞는 결함으로 판명(카디르 5라운드+codex 실물재현) —
+                # 삭제했다. 이 필드는 이제 reopen_gate_if_new_sha(gate_github_check.py) 오직
+                # 한 곳, 오직 실 webhook payload의 pr_updated_at에서만 채워진다(그 함수가
+                # gate.status 무관하게 "관측"은 항상 기록하도록 바뀌어, PR이 opened/
+                # synchronize될 때 거의 항상 먼저 오는 실 웹훅이 승인보다 앞서 워터마크를
+                # 이미 심어 둔다 — 이 승인 지점은 그 값을 그대로 둔다).
         await session.commit()
         # story #2459 회귀 동형 방어(2026-08-05): commit 後 model_validate 前 명시 refresh.
         await session.refresh(gate)

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1265,12 +1265,21 @@ async def reevaluate_gate_endpoint(
             detail=f"게이트 상태({gate.status})는 재평가 대상이 아닙니다(pending/auto_passed만 가능).",
         )
 
-    # gate.pr_number(story #2893 A1, 0271)가 이 게이트가 귀속된 PR의 1차 SSOT — neutral_facts는
-    # repo만 보강(백필 이전 legacy gate는 link row로 폴백).
+    # gate.pr_number(story #2893 A1, 0271)가 이 게이트가 귀속된 PR의 1차 SSOT.
+    # gate.repo_full_name(story #2932 HIGH1, 0272)이 repo의 1차 SSOT — neutral_facts.repo는
+    # 그 컬럼이 아직 없던 legacy gate만을 위한 2차 폴백.
     pr_number = gate.pr_number
-    repo = (gate.neutral_facts or {}).get("repo")
+    repo = gate.repo_full_name or (gate.neutral_facts or {}).get("repo")
     if not repo or not pr_number:
+        # 카디르 QA(story #2932 HIGH3) — pr_number가 이미 알려진 상태에서 repo만 없으면
+        # (구 컬럼 미백필 등) "이 스토리의 가장 최근 링크"를 무조건 빌려오면 안 된다 —
+        # 그 링크가 **다른 PR**의 것이면 (그 repo, 이 pr_number) 조합은 실존한 적 없는
+        # 합성(fictitious) 튜플이 되고, 그 조합으로 GitHub GET을 날리게 된다(실사고). PR
+        # 컨텍스트가 이미 있으면(pr_number 있음) 반드시 그 PR과 일치하는 링크로만 repo를
+        # 보강한다 — pr_number 자체가 없을 때만(둘 다 미상) story 최신 링크를 신뢰한다.
         _link = await resolve_pr_link(session, org_id, gate.work_item_id)
+        if pr_number and _link is not None and _link.pr_number != pr_number:
+            _link = None  # 다른 PR의 링크 — 지어내지 않는다.
         repo = repo or (_link.repo_full_name if _link else None)
         pr_number = pr_number or (_link.pr_number if _link else None)
     if not repo or not pr_number:

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -19,7 +19,12 @@ from app.models.hitl import HitlRequest
 from app.models.pm import Story, Task
 from app.models.visual_artifact import VisualArtifact
 from app.routers.agent_gateway import wake_agent
-from app.services.gate_github_check import is_repo_check_enforced, publish_gate_check, resolve_pr_link
+from app.services.gate_github_check import (
+    is_repo_check_enforced,
+    publish_gate_check,
+    resolve_pr_link,
+    seed_pr_head_watermark,
+)
 from app.services.github_app import get_installation_token, get_pull_request
 from app.services.merge_verdict_gate import MERGE_GATE_TYPE, reconcile_merge_gate_with_real_evidence
 from app.services.verdict_capture import fetch_status_check_rollup
@@ -1194,6 +1199,11 @@ async def transition_gate_endpoint(
                 _head_sha = (_link.evidence or {}).get("head_sha") if _link else None
             if _head_sha:
                 gate.approved_head_sha = _head_sha
+                # story #2932 완주조건 HIGH2(4라운드 카디르 자기정정) — 사람 UI 승인이 이
+                # 워터마크를 못 얻던 원 결함의 정확한 자리(writer 3곳 중 하나). 여기서 안
+                # 찍으면 승인 직후 도착하는 stale webhook이 워터마크=None이라 staleness guard가
+                # 아예 발동을 못 한다.
+                seed_pr_head_watermark(gate)
         await session.commit()
         # story #2459 회귀 동형 방어(2026-08-05): commit 後 model_validate 前 명시 refresh.
         await session.refresh(gate)

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -371,6 +371,18 @@ async def _process_webhook_event(
         }
         is_label_alignment_trigger = all(name in _label_names for name in RECHECK_LABELS)
 
+    # story #2932(완주조건 HIGH2, 0273) — stale/순서역전 웹훅이 최신 승인 SHA를 부당
+    # 재-pending시키는 것을 막는 워터마크. GitHub는 pull_request 이벤트마다 현재
+    # pull_request.updated_at(실 갱신 단조증가)을 동봉한다 — 파싱 실패/부재는 None(그
+    # 이벤트는 이 방지축 없이 기존 SHA-diff-only 동작으로 fail-open, 크래시 아님).
+    _pr_updated_at_raw = (payload.get("pull_request") or {}).get("updated_at")
+    pr_updated_at: datetime | None = None
+    if _pr_updated_at_raw:
+        try:
+            pr_updated_at = datetime.fromisoformat(str(_pr_updated_at_raw).replace("Z", "+00:00"))
+        except ValueError:
+            pr_updated_at = None
+
     installation: GithubInstallation | None = None
     org_id: uuid.UUID | None = None
     if source == "app":
@@ -497,6 +509,7 @@ async def _process_webhook_event(
             _repended = await reopen_gate_if_new_sha(
                 session, org_id, merge_gate, head_sha,
                 repo_full_name=repo, pr_number=pr_number,
+                pr_updated_at=pr_updated_at,
             )
             gate_check_publish.append({
                 "org_id": org_id, "gate_id": merge_gate.id,

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -491,6 +491,7 @@ async def _process_webhook_event(
         merge_gate = await find_gate_slot_with_pr_fallback(
             session, org_id=org_id, work_item_id=story_id, work_item_type="story",
             gate_type=_MERGE_GATE_TYPE, pr_number=(pr_number if pr_number > 0 else None),
+            repo_full_name=(repo or None),
         )
         if merge_gate is not None:
             _repended = await reopen_gate_if_new_sha(

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -19,7 +19,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.gate import Gate, set_gate_status
@@ -401,29 +401,58 @@ async def reopen_gate_if_new_sha(
     경우만 워터마크가 여전히 None — 그 직후 첫 webhook은 SHA-diff-only(#2932 이전
     baseline)로 판정한다. 새로 나빠지는 게 아니라 그 좁은 창에서만 원래 상태로 되돌아가는
     것 — 5라운드가 낸 "진짜 새 커밋을 영영 못 지운다" 사고는 이 설계에서 서버시각이 이
-    필드에 원천적으로 안 쓰이므로 구조적으로 재발 불가."""
+    필드에 원천적으로 안 쓰이므로 구조적으로 재발 불가.
+
+    ⛔카디르 6라운드(codex 발견, 이 PR 자신이 도입한 신규 결함) — 5라운드의 관측 블록은
+    "읽고(Python) 비교하고 쓰는" 3단계라, exact-match SELECT(gate_service.py의
+    `find_gate_slot_with_pr_fallback`)가 `.with_for_update()` 없이 이 gate row를 가져오는
+    한 동시성 레이스에 노출된다: 워터마크=T0인 gate에 Tx A(웹훅 T2, 진짜 최신)와 Tx B(웹훅
+    T1, T0<T1<T2)가 동시 도착 → 둘 다 언락 SELECT로 T0를 읽고 각자 "내 값이 T0보다
+    새롭다"로 독립 판정 → A가 T2로 먼저 commit → 대기하던 B의 UPDATE가 **T1으로 덮어씀**
+    (row-lock은 write만 직렬화할 뿐, Python 비교 결과를 lock 획득 後 재계산하지 않음) →
+    최종 워터마크가 T2가 아니라 T1으로 **역행** → 이후 T1<Tmid<T2인 진짜 stale webhook이
+    가드를 통과해 부당 재-pending. HIGH2(NULL 슬롯 승격)가 이미 같은 클래스 레이스를
+    `.with_for_update()`로 막았는데 관측 로직엔 그 보호가 빠져 있었다.
+
+    **처방(DB 원자적 GREATEST, 페드루 PO 소견 채택)**: FOR UPDATE 잠금 대신 단일 원자적
+    `UPDATE ... SET pr_head_observed_at = GREATEST(pr_head_observed_at, :new)
+    RETURNING pr_head_observed_at`로 관측을 수행한다. PostgreSQL은 각 UPDATE 문을 그
+    실행 시점의 **최신 커밋된** 행 값에 대해 계산한다 — 두 번째 UPDATE는 첫 번째가 커밋해
+    락을 놓은 뒤에야 진행되고, 그때는 이미 첫 번째가 쓴 값을 본 채로 GREATEST를 재계산한다.
+    그 결과 커밋 순서와 무관하게 최종 워터마크는 항상 "지금까지 관측된 모든 값의 최댓값"이
+    된다 — 단조성이 Python 비교(코드 규율)가 아니라 GREATEST라는 **DB 성질 자체**가 되어
+    역행이 구조적으로 불가능해진다(FOR UPDATE처럼 락 대기를 추가로 도입할 필요도 없음).
+    staleness 판정도 같은 원자적 왕복에서 얻는다 — RETURNING된 값이 내 `pr_updated_at`과
+    같으면 내 배달이 GREATEST에서 이겼다(=stale 아님, 4라운드 동일-timestamp tie-break도
+    이 비교가 자연히 흡수 — 같으면 stale 아님, SHA-diff로 넘어감), 다르면(더 큰 값이
+    이미 기록돼 있었다) stale이다."""
     if gate.gate_type != MERGE_GATE_TYPE:
         return False
-    # 관측(상태 무관, 항상) — 판정(승인된 게이트에서만) 보다 먼저 수행. staleness 비교는
-    # "갱신 前" 워터마크(prior_watermark)와 해야 하므로 먼저 old값을 잡아둔다.
-    prior_watermark = gate.pr_head_observed_at
-    if pr_updated_at is not None and (prior_watermark is None or pr_updated_at > prior_watermark):
-        gate.pr_head_observed_at = pr_updated_at
-        await session.flush()
+    # 관측(상태 무관, 항상) — DB 원자적 GREATEST 갱신(위 6라운드 설명 참조). 판정(승인된
+    # 게이트에서만)보다 먼저 수행.
+    is_stale_delivery = False
+    if pr_updated_at is not None:
+        result = await session.execute(
+            text(
+                "UPDATE gate SET pr_head_observed_at = GREATEST(pr_head_observed_at, "
+                "CAST(:new_ts AS timestamptz)) WHERE id = CAST(:gate_id AS uuid) "
+                "RETURNING pr_head_observed_at"
+            ),
+            {"new_ts": pr_updated_at, "gate_id": gate.id},
+        )
+        new_watermark = result.scalar_one()
+        gate.pr_head_observed_at = new_watermark  # ORM 인스턴스를 실제 DB 값과 동기화.
+        is_stale_delivery = new_watermark != pr_updated_at
     if gate.status not in ("approved", "auto_passed"):
         return False  # pending 등 — 관측은 위에서 이미 기록됨(status 무관), 재-pending 판정 대상만 아님.
-    if (
-        pr_updated_at is not None
-        and prior_watermark is not None
-        and pr_updated_at < prior_watermark
-    ):
+    if is_stale_delivery:
         logger.info(
-            "gate=%s: stale/순서역전 웹훅 무시(pr_updated_at=%s < 이미 관측된 %s) — 재-pending skip",
-            gate.id, pr_updated_at, prior_watermark,
+            "gate=%s: stale/순서역전 웹훅 무시(pr_updated_at=%s, 이미 관측된 워터마크=%s) — 재-pending skip",
+            gate.id, pr_updated_at, gate.pr_head_observed_at,
         )
         return False
     if gate.approved_head_sha == new_head_sha:
-        return False  # 워터마크는 위에서 이미 전진 처리됨(newer였다면) — 중복 세팅 불요.
+        return False  # 워터마크는 위에서 이미 원자적으로 전진 처리됨 — 중복 세팅 불요.
     logger.info(
         "gate=%s: SHA 불일치(approved=%s new=%s) — 재-pending", gate.id, gate.approved_head_sha, new_head_sha
     )

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -280,7 +280,6 @@ async def publish_gate_check(
 
             if gh_status == "completed" and gh_conclusion == "success":
                 gate.approved_head_sha = head_sha
-                seed_pr_head_watermark(gate)  # story #2932 완주조건 HIGH2(4라운드) — writer 3곳 중 하나.
 
             event_type = "resolved" if gh_status == "completed" else "published"
             session.add(GateGithubCheckEvent(
@@ -325,27 +324,6 @@ async def publish_label_unlabel(org_id: uuid.UUID, repo_full_name: str, pr_numbe
         logger.exception("repo=%s pr=%s: 라벨 제거 처리 중 예외(fail-closed)", repo_full_name, pr_number)
 
 
-def seed_pr_head_watermark(gate: Gate, *, now: datetime | None = None) -> None:
-    """story #2932(완주조건 HIGH2, 4라운드 카디르 자기정정+codex 반박) — `approved_head_sha`가
-    새로 세워지는 **모든** 자리(사람 UI 승인·AUTO_MERGE 평가·check-run success 발행)는
-    `pr_head_observed_at`도 함께 씨드해야 한다. 원래 처방은 `reopen_gate_if_new_sha` 내부
-    (재-pending·워터마크-전진 두 분기)에서만 워터마크를 썼는데, 그 함수는 gate.status가
-    이미 approved/auto_passed일 때만 도달한다 — 즉 **최초로 그 상태가 되는 순간**(사람이
-    막 승인한 직후 등)엔 아무도 워터마크를 안 찍어 None으로 남았다. 그 직후 도착하는
-    stale webhook은 워터마크=None이라 staleness guard가 아예 발동을 못 해, 이 story가
-    막으려던 spurious 재-pending이 **정상 승인 경로의 기본 상태**로 재발했다(카디르 4라운드
-    발견·정정). 전 3개 writer(gates.py `transition_gate_endpoint`·merge_verdict_gate.py
-    `evaluate_merge_gate` AUTO_MERGE·gate_github_check.py `publish_gate_check` success)가
-    이 헬퍼를 공유 chokepoint로 호출한다(전수 grep으로 확定, approved_head_sha를 새 값으로
-    세우는 자리는 이 3곳+reopen_gate_if_new_sha 자신뿐).
-
-    이 세 경로엔 GitHub의 실 `pull_request.updated_at`이 없다(웹훅 payload가 없는 UI/시스템
-    평가 경로) — 서버 `now()`를 하한 워터마크로 쓴다: "이 시점 이전에 관측된 배달은 이미 아는
-    상태를 설명한다"는 가정이 성립하는 가장 보수적인 근사(신규 GitHub API 재조회 없음, 폴링 0
-    원칙 유지)."""
-    gate.pr_head_observed_at = now or datetime.now(timezone.utc)
-
-
 async def reopen_gate_if_new_sha(
     session: AsyncSession,
     org_id: uuid.UUID,
@@ -376,15 +354,15 @@ async def reopen_gate_if_new_sha(
     증거로 다시 통과시키는 것은 `evaluate_merge_gate`(재평가 시 anchor 재확定)의 몫이지,
     구 anchor를 새 SHA에 그대로 붙여두는 것의 몫이 아니다.
 
-    pr_updated_at: story #2932(완주조건 HIGH2, 0273, codex+카디르 일치판단) — GitHub가 웹훅
-    배달 순서를 보장하지 않아, 이미 최신 SHA로 승인된 게이트에 **뒤늦게 도착한 옛 배달**이
-    그 옛 SHA와의 불일치만 보고 부당 재-pending시킬 수 있었다("승인은 그때의 커밋에" —
-    story #2893 핵심 보증을 이 클래스가 직접 깬다). `pull_request.updated_at`(GitHub가
-    실 갱신마다 단조증가시킴)을 `gate.pr_head_observed_at`에 워터마크로 남겨, 새 이벤트의
-    `updated_at`이 이미 관측된 값보다 **엄격히 과거면**(`<`) SHA 불일치와 무관하게 stale로
-    skip한다. 폴링/GitHub API 재조회 없이(story #2893 §4 C1 원칙과 동형) 페이로드 자체
-    신호만 쓴다. None이면(payload에 없거나 파싱 실패 등) 검증을 건너뛰고 기존
-    SHA-diff-only 동작 그대로(새로 나빠지지 않음, 다만 이 방지축을 못 얻을 뿐).
+    pr_updated_at: story #2932(완주조건 HIGH2, 0273) — GitHub가 웹훅 배달 순서를 보장하지
+    않아, 이미 최신 SHA로 승인된 게이트에 **뒤늦게 도착한 옛 배달**이 그 옛 SHA와의 불일치만
+    보고 부당 재-pending시킬 수 있었다("승인은 그때의 커밋에" — story #2893 핵심 보증을 이
+    클래스가 직접 깬다). `pull_request.updated_at`(GitHub가 실 갱신마다 단조증가시킴)을
+    `gate.pr_head_observed_at`에 워터마크로 남겨, 새 이벤트의 `updated_at`이 이미 관측된
+    값보다 **엄격히 과거면**(`<`) SHA 불일치와 무관하게 stale로 skip한다. 폴링/GitHub API
+    재조회 없이(story #2893 §4 C1 원칙과 동형) 페이로드 자체 신호만 쓴다. None이면(payload에
+    없거나 파싱 실패 등) 검증을 건너뛰고 기존 SHA-diff-only 동작 그대로(새로 나빠지지 않음,
+    다만 이 방지축을 못 얻을 뿐).
 
     ⛔카디르 4라운드(codex 발견) — 원래 `<=`(동일 timestamp도 stale)는 서로 다른 두 진짜
     배달이 같은 초 단위 timestamp를 우연히 공유하면(연속 push 등, GitHub 해상도 제약) 신규
@@ -392,28 +370,60 @@ async def reopen_gate_if_new_sha(
     안 타고 아래 **기존 SHA-diff 비교**(approved_head_sha == new_head_sha)로 자연히
     넘어간다 — "동일 timestamp면 SHA로 갈라라"는 요구를 새 비교 축을 추가하지 않고 이미 있는
     분기가 그대로 흡수한다(SHA가 같으면 no-op, 다르면 정상 재-pending — 타임스탬프 동률은
-    stale 여부 판정에서 아예 빠지고 SHA가 유일한 진실이 된다)."""
+    stale 여부 판정에서 아예 빠지고 SHA가 유일한 진실이 된다).
+
+    ⛔카디르 5라운드(codex+독립교차리뷰 일치, 근본 재설계) — 4라운드 처방(`seed_pr_head_
+    watermark()`가 UI 승인·AUTO_MERGE·publish_gate_check success 3곳에서 서버 `now()`를
+    워터마크로 씀)이 **서로 다른 두 시계를 같은 필드에 혼용**하는 새 결함을 냈다: 커밋A
+    push(GH실시각T1)→커밋B(진짜 새커밋) push(T1.5)→사람이 A를 승인(서버시각T2, T1.5<T2)→
+    B의 웹훅이 지연도착(payload `pr_updated_at=T1.5`)→`T1.5 < T2(서버시각워터마크)`라 진짜
+    새 커밋 B가 stale로 오판돼 **영영 미처리**(2893 핵심보증을 반대방향으로 위반 — 지워야
+    할 걸 안 지움). 처방(삭제 기반 재설계, "더 적은 코드가 더 강한 보증"): `seed_pr_head_
+    watermark()`와 그 3개 호출부를 **완전 삭제**한다 — `pr_head_observed_at`을 쓰는 자리는
+    이제 이 함수 하나, 오직 실 webhook payload의 `pr_updated_at`에서만 온다. 서버시각이
+    이 필드에 섞일 수 있는 경로가 코드상 구조적으로 0개가 된다(관리로 막는 게 아니라 쓰는
+    자리를 없애 원리적으로 불가능하게).
+
+    ⛔페드루 PO 지적(5라운드, 구현 前 명시 요구) — 위 삭제만으로는 **3라운드 구멍이
+    부활한다**: 이 함수는 바로 아래 `gate.status not in ("approved","auto_passed")` 가드
+    때문에 pending 게이트에 대해선 즉시 return해 왔다 — pending 상태에서 도착하는 «진짜»
+    웹훅(PR이 opened/synchronize될 때 거의 항상 먼저 오는 것)의 `pr_updated_at`을 관측할
+    기회 자체가 없었다. 그러면 나중에 사람이 승인해도(서버-now() 씨딩을 없앴으니) 워터마크는
+    여전히 None — 승인 직후 stale webhook 무방비 상태(4라운드가 고치려던 바로 그 구멍)가
+    그대로 되살아난다. **처방**: 워터마크 "관측"(newer면 기록)을 status 가드보다 **먼저,
+    status 무관**으로 수행한다 — pending 상태에서 실 webhook이 오면 이제도 워터마크가
+    쌓인다. 재-pending "판정"만 approved/auto_passed로 계속 스코프한다(이 둘은 다른 축 —
+    관측=항상, 판정=승인된 게이트에서만 의미 있음). 이러면 PR에 연결된 merge gate 대부분
+    (거의 항상 opened/synchronize가 승인보다 먼저 온다)이 승인 시점 이전에 이미 실 GH시각
+    워터마크를 보유하게 돼, 4라운드가 원래 지키려던 "승인 직후 stale webhook 차단"이 서버
+    시계 없이도 자연히 성립한다. **남는(정직하게 문서화하는) 한계**: 이 gate가 «한 번도»
+    실 webhook을 받은 적 없이(순수 self-report/board-preflight 경로) 승인/AUTO_MERGE된
+    경우만 워터마크가 여전히 None — 그 직후 첫 webhook은 SHA-diff-only(#2932 이전
+    baseline)로 판정한다. 새로 나빠지는 게 아니라 그 좁은 창에서만 원래 상태로 되돌아가는
+    것 — 5라운드가 낸 "진짜 새 커밋을 영영 못 지운다" 사고는 이 설계에서 서버시각이 이
+    필드에 원천적으로 안 쓰이므로 구조적으로 재발 불가."""
     if gate.gate_type != MERGE_GATE_TYPE:
         return False
+    # 관측(상태 무관, 항상) — 판정(승인된 게이트에서만) 보다 먼저 수행. staleness 비교는
+    # "갱신 前" 워터마크(prior_watermark)와 해야 하므로 먼저 old값을 잡아둔다.
+    prior_watermark = gate.pr_head_observed_at
+    if pr_updated_at is not None and (prior_watermark is None or pr_updated_at > prior_watermark):
+        gate.pr_head_observed_at = pr_updated_at
+        await session.flush()
     if gate.status not in ("approved", "auto_passed"):
-        return False
+        return False  # pending 등 — 관측은 위에서 이미 기록됨(status 무관), 재-pending 판정 대상만 아님.
     if (
         pr_updated_at is not None
-        and gate.pr_head_observed_at is not None
-        and pr_updated_at < gate.pr_head_observed_at
+        and prior_watermark is not None
+        and pr_updated_at < prior_watermark
     ):
         logger.info(
             "gate=%s: stale/순서역전 웹훅 무시(pr_updated_at=%s < 이미 관측된 %s) — 재-pending skip",
-            gate.id, pr_updated_at, gate.pr_head_observed_at,
+            gate.id, pr_updated_at, prior_watermark,
         )
         return False
     if gate.approved_head_sha == new_head_sha:
-        if pr_updated_at is not None and (
-            gate.pr_head_observed_at is None or pr_updated_at > gate.pr_head_observed_at
-        ):
-            gate.pr_head_observed_at = pr_updated_at  # SHA는 그대로여도 워터마크는 전진.
-            await session.flush()
-        return False
+        return False  # 워터마크는 위에서 이미 전진 처리됨(newer였다면) — 중복 세팅 불요.
     logger.info(
         "gate=%s: SHA 불일치(approved=%s new=%s) — 재-pending", gate.id, gate.approved_head_sha, new_head_sha
     )
@@ -422,8 +432,6 @@ async def reopen_gate_if_new_sha(
     gate.approved_head_sha = None
     gate.github_check_run_id = None  # 새 SHA는 새 check-run(같은 SHA의 pending→success 갱신 축과 분리).
     gate.github_check_run_sha = None
-    if pr_updated_at is not None:
-        gate.pr_head_observed_at = pr_updated_at
     session.add(GateGithubCheckEvent(
         org_id=org_id, gate_id=gate.id, story_id=gate.work_item_id,
         repo_full_name=repo_full_name, pr_number=pr_number, head_sha=new_head_sha,

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -332,6 +332,7 @@ async def reopen_gate_if_new_sha(
     *,
     repo_full_name: str,
     pr_number: int,
+    pr_updated_at: datetime | None = None,
 ) -> bool:
     """SHA 귀속(AC②) — 승인된 게이트가 더 이상 최신 커밋과 안 맞으면 pending으로 되돌린다.
     **호출자의 기존 트랜잭션 안에서 동작**(commit 안 함 — verdict_capture.py가 커밋).
@@ -351,12 +352,37 @@ async def reopen_gate_if_new_sha(
     ⛔카디르 R2 CRITICAL(2026-08-19) — `auto_passed`도 `approved`와 동일하게 다룬다. 정책이
     allow_auto로 내린 통과도 "그 SHA에 대한" 승인이라 새 커밋엔 무효 — 자동통과 정책이 새
     증거로 다시 통과시키는 것은 `evaluate_merge_gate`(재평가 시 anchor 재확定)의 몫이지,
-    구 anchor를 새 SHA에 그대로 붙여두는 것의 몫이 아니다."""
+    구 anchor를 새 SHA에 그대로 붙여두는 것의 몫이 아니다.
+
+    pr_updated_at: story #2932(완주조건 HIGH2, 0273, codex+카디르 일치판단) — GitHub가 웹훅
+    배달 순서를 보장하지 않아, 이미 최신 SHA로 승인된 게이트에 **뒤늦게 도착한 옛 배달**이
+    그 옛 SHA와의 불일치만 보고 부당 재-pending시킬 수 있었다("승인은 그때의 커밋에" —
+    story #2893 핵심 보증을 이 클래스가 직접 깬다). `pull_request.updated_at`(GitHub가
+    실 갱신마다 단조증가시킴)을 `gate.pr_head_observed_at`에 워터마크로 남겨, 새 이벤트의
+    `updated_at`이 이미 관측된 값보다 오래되면(<=) SHA 불일치와 무관하게 stale로 skip한다.
+    폴링/GitHub API 재조회 없이(story #2893 §4 C1 원칙과 동형) 페이로드 자체 신호만 쓴다.
+    None이면(payload에 없거나 파싱 실패 등) 검증을 건너뛰고 기존 SHA-diff-only 동작 그대로
+    (새로 나빠지지 않음, 다만 이 방지축을 못 얻을 뿐)."""
     if gate.gate_type != MERGE_GATE_TYPE:
         return False
     if gate.status not in ("approved", "auto_passed"):
         return False
+    if (
+        pr_updated_at is not None
+        and gate.pr_head_observed_at is not None
+        and pr_updated_at <= gate.pr_head_observed_at
+    ):
+        logger.info(
+            "gate=%s: stale/순서역전 웹훅 무시(pr_updated_at=%s <= 이미 관측된 %s) — 재-pending skip",
+            gate.id, pr_updated_at, gate.pr_head_observed_at,
+        )
+        return False
     if gate.approved_head_sha == new_head_sha:
+        if pr_updated_at is not None and (
+            gate.pr_head_observed_at is None or pr_updated_at > gate.pr_head_observed_at
+        ):
+            gate.pr_head_observed_at = pr_updated_at  # SHA는 그대로여도 워터마크는 전진.
+            await session.flush()
         return False
     logger.info(
         "gate=%s: SHA 불일치(approved=%s new=%s) — 재-pending", gate.id, gate.approved_head_sha, new_head_sha
@@ -366,6 +392,8 @@ async def reopen_gate_if_new_sha(
     gate.approved_head_sha = None
     gate.github_check_run_id = None  # 새 SHA는 새 check-run(같은 SHA의 pending→success 갱신 축과 분리).
     gate.github_check_run_sha = None
+    if pr_updated_at is not None:
+        gate.pr_head_observed_at = pr_updated_at
     session.add(GateGithubCheckEvent(
         org_id=org_id, gate_id=gate.id, story_id=gate.work_item_id,
         repo_full_name=repo_full_name, pr_number=pr_number, head_sha=new_head_sha,

--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -280,6 +280,7 @@ async def publish_gate_check(
 
             if gh_status == "completed" and gh_conclusion == "success":
                 gate.approved_head_sha = head_sha
+                seed_pr_head_watermark(gate)  # story #2932 완주조건 HIGH2(4라운드) — writer 3곳 중 하나.
 
             event_type = "resolved" if gh_status == "completed" else "published"
             session.add(GateGithubCheckEvent(
@@ -324,6 +325,27 @@ async def publish_label_unlabel(org_id: uuid.UUID, repo_full_name: str, pr_numbe
         logger.exception("repo=%s pr=%s: 라벨 제거 처리 중 예외(fail-closed)", repo_full_name, pr_number)
 
 
+def seed_pr_head_watermark(gate: Gate, *, now: datetime | None = None) -> None:
+    """story #2932(완주조건 HIGH2, 4라운드 카디르 자기정정+codex 반박) — `approved_head_sha`가
+    새로 세워지는 **모든** 자리(사람 UI 승인·AUTO_MERGE 평가·check-run success 발행)는
+    `pr_head_observed_at`도 함께 씨드해야 한다. 원래 처방은 `reopen_gate_if_new_sha` 내부
+    (재-pending·워터마크-전진 두 분기)에서만 워터마크를 썼는데, 그 함수는 gate.status가
+    이미 approved/auto_passed일 때만 도달한다 — 즉 **최초로 그 상태가 되는 순간**(사람이
+    막 승인한 직후 등)엔 아무도 워터마크를 안 찍어 None으로 남았다. 그 직후 도착하는
+    stale webhook은 워터마크=None이라 staleness guard가 아예 발동을 못 해, 이 story가
+    막으려던 spurious 재-pending이 **정상 승인 경로의 기본 상태**로 재발했다(카디르 4라운드
+    발견·정정). 전 3개 writer(gates.py `transition_gate_endpoint`·merge_verdict_gate.py
+    `evaluate_merge_gate` AUTO_MERGE·gate_github_check.py `publish_gate_check` success)가
+    이 헬퍼를 공유 chokepoint로 호출한다(전수 grep으로 확定, approved_head_sha를 새 값으로
+    세우는 자리는 이 3곳+reopen_gate_if_new_sha 자신뿐).
+
+    이 세 경로엔 GitHub의 실 `pull_request.updated_at`이 없다(웹훅 payload가 없는 UI/시스템
+    평가 경로) — 서버 `now()`를 하한 워터마크로 쓴다: "이 시점 이전에 관측된 배달은 이미 아는
+    상태를 설명한다"는 가정이 성립하는 가장 보수적인 근사(신규 GitHub API 재조회 없음, 폴링 0
+    원칙 유지)."""
+    gate.pr_head_observed_at = now or datetime.now(timezone.utc)
+
+
 async def reopen_gate_if_new_sha(
     session: AsyncSession,
     org_id: uuid.UUID,
@@ -359,10 +381,18 @@ async def reopen_gate_if_new_sha(
     그 옛 SHA와의 불일치만 보고 부당 재-pending시킬 수 있었다("승인은 그때의 커밋에" —
     story #2893 핵심 보증을 이 클래스가 직접 깬다). `pull_request.updated_at`(GitHub가
     실 갱신마다 단조증가시킴)을 `gate.pr_head_observed_at`에 워터마크로 남겨, 새 이벤트의
-    `updated_at`이 이미 관측된 값보다 오래되면(<=) SHA 불일치와 무관하게 stale로 skip한다.
-    폴링/GitHub API 재조회 없이(story #2893 §4 C1 원칙과 동형) 페이로드 자체 신호만 쓴다.
-    None이면(payload에 없거나 파싱 실패 등) 검증을 건너뛰고 기존 SHA-diff-only 동작 그대로
-    (새로 나빠지지 않음, 다만 이 방지축을 못 얻을 뿐)."""
+    `updated_at`이 이미 관측된 값보다 **엄격히 과거면**(`<`) SHA 불일치와 무관하게 stale로
+    skip한다. 폴링/GitHub API 재조회 없이(story #2893 §4 C1 원칙과 동형) 페이로드 자체
+    신호만 쓴다. None이면(payload에 없거나 파싱 실패 등) 검증을 건너뛰고 기존
+    SHA-diff-only 동작 그대로(새로 나빠지지 않음, 다만 이 방지축을 못 얻을 뿐).
+
+    ⛔카디르 4라운드(codex 발견) — 원래 `<=`(동일 timestamp도 stale)는 서로 다른 두 진짜
+    배달이 같은 초 단위 timestamp를 우연히 공유하면(연속 push 등, GitHub 해상도 제약) 신규
+    SHA를 stale로 오판해 skip할 위험이 있었다. `<`로 완화하면 동일 timestamp는 이 가드를
+    안 타고 아래 **기존 SHA-diff 비교**(approved_head_sha == new_head_sha)로 자연히
+    넘어간다 — "동일 timestamp면 SHA로 갈라라"는 요구를 새 비교 축을 추가하지 않고 이미 있는
+    분기가 그대로 흡수한다(SHA가 같으면 no-op, 다르면 정상 재-pending — 타임스탬프 동률은
+    stale 여부 판정에서 아예 빠지고 SHA가 유일한 진실이 된다)."""
     if gate.gate_type != MERGE_GATE_TYPE:
         return False
     if gate.status not in ("approved", "auto_passed"):
@@ -370,10 +400,10 @@ async def reopen_gate_if_new_sha(
     if (
         pr_updated_at is not None
         and gate.pr_head_observed_at is not None
-        and pr_updated_at <= gate.pr_head_observed_at
+        and pr_updated_at < gate.pr_head_observed_at
     ):
         logger.info(
-            "gate=%s: stale/순서역전 웹훅 무시(pr_updated_at=%s <= 이미 관측된 %s) — 재-pending skip",
+            "gate=%s: stale/순서역전 웹훅 무시(pr_updated_at=%s < 이미 관측된 %s) — 재-pending skip",
             gate.id, pr_updated_at, gate.pr_head_observed_at,
         )
         return False

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -464,7 +464,17 @@ async def find_gate_slot_with_pr_fallback(
 
     pr_number가 None(PR 컨텍스트가 원래 없는 gate_type 또는 board-preflight no-substance)
     이면 옛 계약 그대로 NULL-슬롯만 찾는다 — 승격 대상 자체가 없다("PR 컨텍스트 있음"으로
-    바꿀 근거가 없다)."""
+    바꿀 근거가 없다).
+
+    카디르 QA(story #2932 HIGH1, 2026-08-22, 이 PR 자체 재재verdict) — repo_full_name을
+    대소문자/공백 그대로 비교하면 `Acme/Repo`≠`acme/repo`로 같은 실 repo가 다른 슬롯으로
+    분열한다(DB 유니크 인덱스도 case-sensitive). 기존 SSOT `pr_story_link.py::normalize_repo`
+    (strip+lower)를 여기(읽기·쓰기 둘 다의 단일 관문)서 관통시킨다 — 호출부가 원본 대소문자를
+    그대로 넘겨도 이 함수 안에서 항상 정규화되므로 4개 호출부 전부를 개별 수정할 필요가
+    없다(단일 chokepoint)."""
+    if repo_full_name is not None:
+        from app.services.pr_story_link import normalize_repo
+        repo_full_name = normalize_repo(repo_full_name) or None
     if pr_number is not None:
         exact_conditions = [
             Gate.org_id == org_id, Gate.work_item_id == work_item_id,
@@ -571,6 +581,14 @@ async def create_gate(
     全 호출부 무회귀). gate_type/work_item_type별 하드코딩 대신 호출부 판단으로 남겨 이 함수의
     공용 chokepoint 성격을 유지한다.
     """
+    # 카디르 QA(story #2932 HIGH1, 2026-08-22) — repo_full_name도 find_gate_slot_with_pr_
+    # fallback과 동일하게 여기서 정규화한다: 이 함수의 Gate(...) INSERT는 그 헬퍼를 거치지
+    # 않으므로(조회만 거침) 별도로 정규화해야 저장값 자체가 일관된다(대소문자 다른 두
+    # 호출이 같은 실 repo인데 다른 슬롯으로 분열하는 것 방지).
+    if repo_full_name is not None:
+        from app.services.pr_story_link import normalize_repo
+        repo_full_name = normalize_repo(repo_full_name) or None
+
     # 멱등: 이미 존재하면 기존 반환. story #2893 — pr_number도 키에 편입(0271 부분
     # 유니크 인덱스와 동형 조건). find_gate_slot_with_pr_fallback가 정확매치 우선+
     # NULL-슬롯 승격 폴백까지 처리(카디르 QA, PR#3349 CI 실패 2건 후속 — pr_number가

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -450,9 +450,17 @@ async def find_gate_slot_with_pr_fallback(
     repo_full_name: story #2932(HIGH1, 0272) — pr_number 단독은 repo 경계가 없어(같은
     스토리에 다른 repo의 동일 번호 PR이 링크되면 슬롯을 공유) SHA/evidence가 섞일 수
     있었다(카디르 소스 직접확認). repo_full_name이 주어지면 정확매치가 (pr_number,
-    repo_full_name) 둘 다로 스코프된다 — 다른 repo의 같은 pr_number는 별개 슬롯. 주어지지
-    않으면(호출부가 정말 모르는 극히 드문 경우) pr_number 단독 매치로 물러난다(0271
-    당시 동작과 동형 — 새로 나빠지진 않는다, 다만 disambiguation을 못 할 뿐).
+    repo_full_name) 둘 다로 스코프된다 — 다른 repo의 같은 pr_number는 별개 슬롯.
+
+    ⛔카디르 QA(PR#3359 3라운드, codex 발견) — repo_full_name이 **주어지지 않으면**
+    (호출부가 정말 모름 — report-done류 self-report의 실 경로, workflow_report.py) "repo
+    무관 아무 행이나 매치"로 물러나면 안 된다. 이 PR이 정당하게 허용한 「같은 pr_number·
+    다른 repo 2행 이상」 상태에서 그런 조회가 `MultipleResultsFound`(500)로 죽었다(실사고).
+    `pr_number IS NULL`(PR 컨텍스트 자체 미상)과 대칭으로, repo_full_name=None 조회는
+    **repo도 마찬가지로 모르는 행**(`repo_full_name IS NULL`)만 매치한다 — 그 조건을
+    만족하는 행은 구조적으로 최대 1개뿐이라(`uq_gate_work_item_gate_type_pr_no_repo`)
+    모호성이 원천적으로 없다. repo를 아는 기존 행과는 별개 identity로 남는다(멋대로
+    병합하지 않는다 — 어느 쪽이 "진짜"인지 여기서 판단할 근거가 없다).
 
     **동시성**(story #2932 HIGH2): NULL-슬롯 승격은 read-then-write라 동시 웹훅 2개가
     같은 NULL-슬롯을 서로 다른 PR로 경쟁 승격할 수 있었다(나중 커밋이 조용히 덮어씀).
@@ -481,8 +489,20 @@ async def find_gate_slot_with_pr_fallback(
             Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
             Gate.pr_number == pr_number,
         ]
-        if repo_full_name is not None:
-            exact_conditions.append(Gate.repo_full_name == repo_full_name)
+        # 카디르 QA(story #2932, PR#3359 3라운드, codex 발견) — repo_full_name이 없을 때
+        # (호출부가 정말 모름 — report-done류 self-report의 실 경로) repo 필터를 아예
+        # 안 걸면, 이 PR이 정당하게 허용한 「같은 pr_number·다른 repo 2행 이상」 상태를
+        # 만나 scalar_one_or_none()이 MultipleResultsFound로 500을 낸다(실사고). repo를
+        # 모른다는 것을 "아무 repo나 매치"로 지어내지 않는다 — `Gate.pr_number.is_(None)`
+        # (아래 NULL-슬롯 매치)과 대칭으로, repo_full_name=None 조회는 **repo도 마찬가지로
+        # 모르는 행**(repo_full_name IS NULL, 이 함수 자신이 승격시켜 둔 행 포함)만 매치한다
+        # — 정확히 한 행만 있을 수 있는 조건(uq_gate_work_item_gate_type_pr_no_repo)이라
+        # 구조적으로 모호성이 없다. repo를 아는 기존 행과는 다른 identity로 남는다(멋대로
+        # 병합하지 않는다 — 어느 쪽이 "진짜"인지 여기서 판단할 근거가 없다).
+        exact_conditions.append(
+            Gate.repo_full_name == repo_full_name if repo_full_name is not None
+            else Gate.repo_full_name.is_(None)
+        )
         exact = (
             await session.execute(select(Gate).where(*exact_conditions))
         ).scalar_one_or_none()

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -429,6 +429,7 @@ async def find_gate_slot_with_pr_fallback(
     work_item_type: str,
     gate_type: str,
     pr_number: int | None,
+    repo_full_name: str | None = None,
 ) -> Gate | None:
     """story #2893(§2 A1, 0271) 후속 — 카디르 QA(PR#3349 CI 실 실패 2건, 2026-08-22):
     pr_number를 멱등 키에 편입한 것(정확매치 only)이 「PR 컨텍스트가 나중에 밝혀지는」
@@ -439,39 +440,76 @@ async def find_gate_slot_with_pr_fallback(
     (PO 확定).
 
     pr_number가 주어지면(실 PR 문맥) 먼저 그 PR 전용 슬롯을 정확매치로 찾는다. 없으면
-    아직 pr_number를 모르던 시절의 NULL-슬롯이 있는지 찾아 **승격**(pr_number를 채워
-    재사용 — flush까지 이 함수 책임, 호출자가 추가로 flush 안 해도 이후 조회에
-    반영됨)한다. 승격 後엔 그 행이 이 PR에 귀속되므로(정확매치 슬롯으로 편입) 다른 PR이
-    같은 NULL-슬롯을 다시 가로챌 길이 없다 — 실사고1/2가 막던 축(서로 다른 PR의 SHA가
-    같은 슬롯을 공유)은 그대로 보존된다(승격은 "미상→특정 PR" 1회성 전이일 뿐, "PR A→PR
-    B" 전이는 이 함수가 만들어내지 않는다).
+    아직 pr_number를 모르던 시절의 NULL-슬롯이 있는지 찾아 **승격**(pr_number+
+    repo_full_name을 채워 재사용 — flush까지 이 함수 책임, 호출자가 추가로 flush 안 해도
+    이후 조회에 반영됨)한다. 승격 後엔 그 행이 이 PR(과 이 repo)에 귀속되므로(정확매치
+    슬롯으로 편입) 다른 PR이 같은 NULL-슬롯을 다시 가로챌 길이 없다 — 실사고1/2가 막던
+    축(서로 다른 PR의 SHA가 같은 슬롯을 공유)은 그대로 보존된다(승격은 "미상→특정 PR"
+    1회성 전이일 뿐, "PR A→PR B" 전이는 이 함수가 만들어내지 않는다).
+
+    repo_full_name: story #2932(HIGH1, 0272) — pr_number 단독은 repo 경계가 없어(같은
+    스토리에 다른 repo의 동일 번호 PR이 링크되면 슬롯을 공유) SHA/evidence가 섞일 수
+    있었다(카디르 소스 직접확認). repo_full_name이 주어지면 정확매치가 (pr_number,
+    repo_full_name) 둘 다로 스코프된다 — 다른 repo의 같은 pr_number는 별개 슬롯. 주어지지
+    않으면(호출부가 정말 모르는 극히 드문 경우) pr_number 단독 매치로 물러난다(0271
+    당시 동작과 동형 — 새로 나빠지진 않는다, 다만 disambiguation을 못 할 뿐).
+
+    **동시성**(story #2932 HIGH2): NULL-슬롯 승격은 read-then-write라 동시 웹훅 2개가
+    같은 NULL-슬롯을 서로 다른 PR로 경쟁 승격할 수 있었다(나중 커밋이 조용히 덮어씀).
+    NULL-슬롯 조회에 `SELECT ... FOR UPDATE`를 걸어 두 번째 트랜잭션이 첫 번째의 커밋을
+    기다리게 한다 — 커밋 後 재평가되는 WHERE(`pr_number IS NULL`)가 더는 참이 아니므로
+    두 번째는 자연히 None을 받아(이미 승격된 슬롯을 못 봄) 새 실 INSERT 경로로 빠진다
+    (row가 이미 존재하는 UPDATE류 경합이라 SELECT FOR UPDATE가 유효 — row 자체가 없는
+    check-then-insert TOCTOU와는 다른 축, feedback_check_then_insert_toctou 참고).
 
     pr_number가 None(PR 컨텍스트가 원래 없는 gate_type 또는 board-preflight no-substance)
     이면 옛 계약 그대로 NULL-슬롯만 찾는다 — 승격 대상 자체가 없다("PR 컨텍스트 있음"으로
     바꿀 근거가 없다)."""
     if pr_number is not None:
+        exact_conditions = [
+            Gate.org_id == org_id, Gate.work_item_id == work_item_id,
+            Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
+            Gate.pr_number == pr_number,
+        ]
+        if repo_full_name is not None:
+            exact_conditions.append(Gate.repo_full_name == repo_full_name)
         exact = (
-            await session.execute(
-                select(Gate).where(
-                    Gate.org_id == org_id, Gate.work_item_id == work_item_id,
-                    Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
-                    Gate.pr_number == pr_number,
-                )
-            )
+            await session.execute(select(Gate).where(*exact_conditions))
         ).scalar_one_or_none()
         if exact is not None:
             return exact
+
+        # story #2932(HIGH1 잔여) — pr_number는 이미 정확히 아는데 repo만 몰랐던 legacy/
+        # 미백필 행이 있으면(0272 백필 누락·neutral_facts.repo 부재 등) 「repo가 나중에
+        # 밝혀지는」 같은 클래스의 정상 케이스다 — NULL-슬롯 승격과 대칭: pr_number 대신
+        # repo_full_name 하나만 미상인 슬롯을 찾아 승격한다(고아화 방지, 새 규칙 발명 0).
+        if repo_full_name is not None:
+            repo_unknown_slot = (
+                await session.execute(
+                    select(Gate).where(
+                        Gate.org_id == org_id, Gate.work_item_id == work_item_id,
+                        Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
+                        Gate.pr_number == pr_number, Gate.repo_full_name.is_(None),
+                    ).with_for_update()  # story #2932 HIGH2와 동일 이유 — 동시 승격 경쟁 직렬화.
+                )
+            ).scalar_one_or_none()
+            if repo_unknown_slot is not None:
+                repo_unknown_slot.repo_full_name = repo_full_name
+                await session.flush()
+                return repo_unknown_slot
+
         null_slot = (
             await session.execute(
                 select(Gate).where(
                     Gate.org_id == org_id, Gate.work_item_id == work_item_id,
                     Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
                     Gate.pr_number.is_(None),
-                )
+                ).with_for_update()  # story #2932 HIGH2 — 동시 승격 경쟁 직렬화.
             )
         ).scalar_one_or_none()
         if null_slot is not None:
             null_slot.pr_number = pr_number
+            null_slot.repo_full_name = repo_full_name
             await session.flush()
         return null_slot
     return (
@@ -498,6 +536,7 @@ async def create_gate(
     notify: bool = True,
     gate_id: uuid.UUID | None = None,
     pr_number: int | None = None,
+    repo_full_name: str | None = None,
 ) -> Gate:
     """config 기반 게이트 생성 (멱등: 이미 있으면 기존 반환).
 
@@ -506,6 +545,10 @@ async def create_gate(
     기본값 None 그대로 — 멱등 키가 `(work_item_id, work_item_type, gate_type)` 옛
     계약대로 유지된다(무회귀). None이면 "PR 컨텍스트 없음"을 지어내지 않고 그대로 둔다
     (0 같은 sentinel로 바꾸지 않음 — DB 컬럼 자체가 nullable Integer).
+
+    repo_full_name: story #2932(HIGH1) — pr_number와 짝. pr_number 단독은 repo 경계가
+    없어 다른 repo의 같은 번호 PR이 슬롯을 공유할 수 있었다(cross-repo 충돌). pr_number를
+    넘기는 유일 호출부(evaluate_merge_gate)가 항상 실 repo를 알고 있어 함께 넘긴다.
 
     gate_id: story #2709(2026-08-17, PO 판정) — self-referencing standalone anchor(work_item이
     없는 순수 질문류 gate_type)를 위한 파라미터. 호출측(MCP 도구)이 uuid4를 미리 만들어
@@ -535,6 +578,7 @@ async def create_gate(
     existing = await find_gate_slot_with_pr_fallback(
         session, org_id=org_id, work_item_id=work_item_id,
         work_item_type=work_item_type, gate_type=gate_type, pr_number=pr_number,
+        repo_full_name=repo_full_name,
     )
     if existing is not None:
         # story #2150 근본수정: rejected는 재제출 시 새 결재 사이클을 연다(그 외 terminal
@@ -564,6 +608,7 @@ async def create_gate(
         work_item_type=work_item_type,
         gate_type=gate_type,
         pr_number=pr_number,
+        repo_full_name=repo_full_name,
         status=status,
         # #2156 AC3(2026-08-07) — merge-type만 evaluate_merge_gate가 이후 이 필드를 정확히
         # 채웠고(decision 기반), 그 외 gate_type(qa·pr_review·deploy 등)은 create_gate가 여태

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -519,6 +519,11 @@ async def evaluate_merge_gate(
     if decision == AUTO_MERGE:
         if head_sha:
             gate.approved_head_sha = head_sha
+            # story #2932 완주조건 HIGH2(4라운드) — AUTO_MERGE도 writer 3곳 중 하나(순환
+            # import 회피 위해 함수-로컬 import — gate_github_check.py가 이 모듈의
+            # MERGE_GATE_TYPE을 이미 module-level로 가져다 쓴다).
+            from app.services.gate_github_check import seed_pr_head_watermark
+            seed_pr_head_watermark(gate)
     elif gate.status == "auto_passed" and gate.approved_head_sha:
         logger.info(
             "gate=%s: 재평가로 decision이 AUTO_MERGE 이탈(%s) — auto-axis anchor(%s) 무효화",

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -519,11 +519,11 @@ async def evaluate_merge_gate(
     if decision == AUTO_MERGE:
         if head_sha:
             gate.approved_head_sha = head_sha
-            # story #2932 완주조건 HIGH2(4라운드) — AUTO_MERGE도 writer 3곳 중 하나(순환
-            # import 회피 위해 함수-로컬 import — gate_github_check.py가 이 모듈의
-            # MERGE_GATE_TYPE을 이미 module-level로 가져다 쓴다).
-            from app.services.gate_github_check import seed_pr_head_watermark
-            seed_pr_head_watermark(gate)
+            # story #2932 완주조건 HIGH2(5라운드) — 이전엔 여기서 서버 now()로
+            # pr_head_observed_at을 씨딩했으나(4라운드), 서로 다른 시계(서버시각 vs GitHub
+            # 실시각)를 같은 필드에 섞는 결함으로 판명(카디르 5라운드+codex 실물재현) —
+            # 삭제했다. 이 필드는 이제 reopen_gate_if_new_sha(gate_github_check.py) 오직
+            # 한 곳, 오직 실 webhook payload의 pr_updated_at에서만 채워진다.
     elif gate.status == "auto_passed" and gate.approved_head_sha:
         logger.info(
             "gate=%s: 재평가로 decision이 AUTO_MERGE 이탈(%s) — auto-axis anchor(%s) 무효화",

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -395,6 +395,9 @@ async def evaluate_merge_gate(
     # 자체가 없음)은 DB에 0을 지어내지 않고 NULL로 정직하게 유지. 0271의 부분 유니크
     # 인덱스가 NULL 구간=옛 "스토리+gate_type당 1행" 계약을 그대로 지킨다.
     db_pr_number = pr_number if pr_number > 0 else None
+    # story #2932(HIGH1) — pr_number와 짝으로 repo도 정직하게: 빈 문자열("", no-substance
+    # self-report shell의 관례값)은 "모름"이지 실 repo가 아니므로 None으로 정규화.
+    db_repo_full_name = repo or None
     # story #2118(E-DG-REAL ②): create_gate()가 이미 pending인 기존 gate를 멱등 반환할 때(예:
     # report-done/board-preflight가 이 함수를 반복 호출)마다 승인요청 카드를 중복 배달하지 않으려면
     # "이 호출에서 방금 pending이 됐는지"(신규 생성 또는 rejected/voided→재오픈)를 알아야 한다 —
@@ -407,7 +410,7 @@ async def evaluate_merge_gate(
     # 승격 포함)과 다른 답을 낼 수 있어 fallback 헬퍼로 통일한다(같은 물음엔 같은 답).
     _prior_gate = await find_gate_slot_with_pr_fallback(
         session, org_id=org_id, work_item_id=story_id, work_item_type="story",
-        gate_type=MERGE_GATE_TYPE, pr_number=db_pr_number,
+        gate_type=MERGE_GATE_TYPE, pr_number=db_pr_number, repo_full_name=db_repo_full_name,
     )
     _prior_status = _prior_gate.status if _prior_gate is not None else None
     gate = await create_gate(
@@ -421,6 +424,7 @@ async def evaluate_merge_gate(
         project_id=project_id,
         neutral_facts=facts,
         pr_number=db_pr_number,
+        repo_full_name=db_repo_full_name,
     )
 
     # 재제출 re-open(doc-gate 48f064e5 선례 이식): uq(work_item,gate_type)=1행 + terminal=immutable
@@ -616,6 +620,7 @@ async def reconcile_merge_gate_with_real_evidence(
     existing = await find_gate_slot_with_pr_fallback(
         session, org_id=org_id, work_item_id=story_id, work_item_type="story",
         gate_type=MERGE_GATE_TYPE, pr_number=(pr_number if pr_number > 0 else None),
+        repo_full_name=(repo or None),
     )
     if existing is None or existing.status not in ("pending", "auto_passed"):
         return None
@@ -702,6 +707,7 @@ async def trigger_gate_creation_for_late_participation(
                 existing = await find_gate_slot_with_pr_fallback(
                     session, org_id=org_id, work_item_id=story_id, work_item_type="story",
                     gate_type=MERGE_GATE_TYPE, pr_number=link.pr_number,
+                    repo_full_name=link.repo_full_name,
                 )
                 if existing is not None:
                     continue  # 이미 게이트가 있음 — 이 훅이 고치려는 갭이 아니다.

--- a/backend/tests/test_2156_merge_gate_evidence_realdb.py
+++ b/backend/tests/test_2156_merge_gate_evidence_realdb.py
@@ -207,9 +207,12 @@ async def test_reconcile_updates_pending_merge_gate_with_real_evidence_realdb():
                     AsyncMock(return_value=True),
                 ),
             ):
+                # story #2932(HIGH1) — repo도 이제 멱등 키 일부다. 두 호출을 같은 repo로
+                # 통일(실제 프로덕션 체인과도 정합 — pr_number=42는 항상 실 repo와 짝으로
+                # 옴, repo=""는 pr_number<=0 no-substance 전용 관례값이지 이 케이스가 아님).
                 await evaluate_merge_gate(
                     s, seeded["org_id"], seeded["story_id"],
-                    pr_number=42, repo="", ci_result=None, pr_result=None,
+                    pr_number=42, repo="moonklabs/sprintable", ci_result=None, pr_result=None,
                 )
                 await s.commit()
 
@@ -545,10 +548,12 @@ async def test_gate_check_publish_fires_on_base_retarget_edit_when_story_linked(
     installation_result.scalar_one_or_none = lambda: installation
     no_gate_result = AsyncMock()
     no_gate_result.scalar_one_or_none = lambda: None  # 기존 merge Gate row 없음 → evaluate 분기.
-    # story #2893 후속(카디르 QA, PR#3349 CI 실패 2건) — find_gate_slot_with_pr_fallback가
-    # 정확매치(없음) 後 NULL-슬롯 폴백까지 조회한다(2 SELECT). 이 테스트는 둘 다 "없음"인
-    # 시나리오(진짜 신규)라 두 번째 자리도 no_gate_result 재사용으로 충분.
-    session.execute = AsyncMock(side_effect=[installation_result, no_gate_result, no_gate_result])
+    # story #2893/#2932 후속(카디르 QA) — find_gate_slot_with_pr_fallback가 정확매치(없음)→
+    # repo-unknown 슬롯(없음, story #2932 HIGH1 잔여)→NULL-슬롯 폴백까지 조회한다(3 SELECT).
+    # 이 테스트는 전부 "없음"인 시나리오(진짜 신규)라 매 자리 no_gate_result 재사용으로 충분.
+    session.execute = AsyncMock(
+        side_effect=[installation_result, no_gate_result, no_gate_result, no_gate_result]
+    )
     evaluate = AsyncMock(return_value=SimpleNamespace(gate_id=gate_id))
     gate_check_publish: list[dict] = []
 

--- a/backend/tests/test_2932_gate_slot_hardening_realdb.py
+++ b/backend/tests/test_2932_gate_slot_hardening_realdb.py
@@ -39,6 +39,66 @@ async def _dispose_global_engine_after_test():
 
 
 @pytest.mark.anyio
+async def test_repo_case_and_whitespace_variants_resolve_to_same_slot():
+    """카디르 QA(story #2932 HIGH1, 이 PR 자체 재재verdict) — repo identity 대소문자/공백
+    정규화 누락. `Acme/Repo`와 `acme/repo`(대소문자만 다름)·` acme/repo `(공백)가 전부
+    같은 실 repo인데 정규화 없이 비교하면 슬롯이 분열한다(DB 유니크 인덱스도 case-
+    sensitive라 막지 못함). 기존 SSOT pr_story_link.py::normalize_repo(strip+lower)를
+    find_gate_slot_with_pr_fallback이 관통시켜야 한다."""
+    from app.models.gate import Gate
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            # 정규화된 형태(lower+strip)로 저장된 기존 행 — create_gate/승격 경로가
+            # 실제로 저장하는 형태를 시뮬레이션.
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="pending", pr_number=77, repo_full_name="acme/repo",
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+            story_id, org_id = story.id, org.id
+
+        # 대소문자/공백이 섞인 변형들이 전부 같은 행을 찾아야 한다.
+        for variant in ("Acme/Repo", "ACME/REPO", " acme/repo ", "AcMe/RePo"):
+            async with Session() as s:
+                found = await find_gate_slot_with_pr_fallback(
+                    s, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                    gate_type="merge", pr_number=77, repo_full_name=variant,
+                )
+                assert found is not None and found.id == gate_id, (
+                    f"repo 변형 {variant!r}이 정규화된 기존 슬롯을 찾아야 함"
+                )
+
+        # 승격 경로도 정규화된 값을 저장해야 한다(원본 대소문자를 그대로 쓰면 다음 조회가
+        # 또 못 찾는다).
+        async with Session() as s:
+            null_gate = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="merge", status="pending", pr_number=None,
+            )
+            s.add(null_gate)
+            await s.commit()
+
+        async with Session() as s:
+            promoted = await find_gate_slot_with_pr_fallback(
+                s, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="merge", pr_number=88, repo_full_name="ACME/Other-Repo",
+            )
+            assert promoted is not None
+            assert promoted.repo_full_name == "acme/other-repo", (
+                f"승격 저장값이 정규화(lower+strip)돼야 하는데 {promoted.repo_full_name!r}로 남음"
+            )
+            await s.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_cross_repo_same_pr_number_get_independent_gates():
     """HIGH1 핵심 — 같은 스토리에 다른 repo의 동일 pr_number가 링크되면(예: 모노레포
     분리·조직 재구성 등) 두 게이트가 독립 행이어야 한다(슬롯 공유=SHA/evidence 오염)."""

--- a/backend/tests/test_2932_gate_slot_hardening_realdb.py
+++ b/backend/tests/test_2932_gate_slot_hardening_realdb.py
@@ -1,0 +1,313 @@
+"""story #2932([게이트·후속] PR단위 슬롯 하드닝 3건) — 2893 4-PR 체인 최종 점검(카디르
+#3357 verdict)에서 나온 신규 HIGH 3건. 전부 이미 develop에 머지된 A1(PR①)·B3(PR③)의
+기존 코드 결함(이 story 자체의 신규 코드 결함이 아님).
+
+HIGH1 — cross-repo identity: 게이트 슬롯 identity(work_item_id·gate_type·pr_number)에
+repo가 없어, 다른 repo의 같은 PR번호가 한 스토리에 연결되면 SHA/evidence가 섞일 수 있었다.
+HIGH2 — NULL슬롯 승격 동시성: find_gate_slot_with_pr_fallback의 "미상→특정 PR" 승격에
+락/CAS가 없어 동시 웹훅 2개가 같은 NULL 슬롯을 서로 다른 PR로 경쟁 승격할 수 있었다.
+HIGH3 — B3 fallback 합성: 재평가 API의 legacy 폴백이 존재하지 않는 repo/PR 조합을 합성해
+GitHub GET을 날릴 수 있었다.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_2893_gate_pr_scoped_isolation_realdb import (
+    _seed_org_project_story,
+    _session_factory,
+)
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_repo_same_pr_number_get_independent_gates():
+    """HIGH1 핵심 — 같은 스토리에 다른 repo의 동일 pr_number가 링크되면(예: 모노레포
+    분리·조직 재구성 등) 두 게이트가 독립 행이어야 한다(슬롯 공유=SHA/evidence 오염)."""
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            story_id, org_id = story.id, org.id
+
+        async with Session() as s:
+            gate_a = await find_gate_slot_with_pr_fallback(
+                s, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="merge", pr_number=42, repo_full_name="acme/repo-a",
+            )
+            assert gate_a is None, "아직 아무 게이트도 없어야 함(전제)"
+        # find_gate_slot_with_pr_fallback 자체는 생성하지 않는다(create_gate가 함) — 여기선
+        # 직접 두 repo의 gate row를 만들어 슬롯 독립성만 확認.
+        async with Session() as s:
+            from app.models.gate import Gate
+
+            g1 = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="merge", status="pending", pr_number=42, repo_full_name="acme/repo-a",
+            )
+            s.add(g1)
+            await s.commit()
+
+        async with Session() as s:
+            found_for_b = await find_gate_slot_with_pr_fallback(
+                s, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="merge", pr_number=42, repo_full_name="acme/repo-b",
+            )
+            assert found_for_b is None, "다른 repo의 같은 pr_number는 repo-a의 슬롯을 못 봐야 함"
+
+            from app.models.gate import Gate
+
+            g2 = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="merge", status="pending", pr_number=42, repo_full_name="acme/repo-b",
+            )
+            s.add(g2)
+            await s.commit()
+
+        async with Session() as s:
+            from app.models.gate import Gate
+
+            rows = (
+                await s.execute(select(Gate).where(Gate.work_item_id == story_id))
+            ).scalars().all()
+            assert len(rows) == 2, "cross-repo 동일 pr_number = 독립 2행이어야 함"
+            by_repo = {g.repo_full_name: g for g in rows}
+            assert set(by_repo) == {"acme/repo-a", "acme/repo-b"}
+            assert all(g.pr_number == 42 for g in rows)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_repo_unknown_legacy_slot_is_promoted_not_orphaned():
+    """HIGH1 잔여 — pr_number는 이미 아는데 repo만 몰랐던 legacy/미백필 행이 있으면, repo가
+    나중에 밝혀질 때 그 행을 승격 재사용해야 한다(고아화·중복생성 금지 — NULL-슬롯 승격과
+    대칭인 축)."""
+    from app.models.gate import Gate
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            legacy_gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="pending", pr_number=55, repo_full_name=None,
+            )
+            s.add(legacy_gate)
+            await s.commit()
+            legacy_gate_id = legacy_gate.id
+            story_id, org_id = story.id, org.id
+
+        async with Session() as s:
+            found = await find_gate_slot_with_pr_fallback(
+                s, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="merge", pr_number=55, repo_full_name="acme/repo",
+            )
+            assert found is not None and found.id == legacy_gate_id, "legacy 행을 찾아 승격해야 함(새 행 아님)"
+            assert found.repo_full_name == "acme/repo", "승격 — repo_full_name이 채워져야 함"
+            await s.commit()
+
+        async with Session() as s:
+            rows = (
+                await s.execute(select(Gate).where(Gate.work_item_id == story_id))
+            ).scalars().all()
+            assert len(rows) == 1, "승격이지 신규생성이 아니므로 여전히 1행이어야 함"
+            assert rows[0].repo_full_name == "acme/repo"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_null_slot_promotion_concurrency_serializes_no_double_promotion():
+    """HIGH2 핵심 — 동시(실 Postgres 트랜잭션 2개) 웹훅이 같은 NULL-슬롯을 서로 다른 PR로
+    경쟁 승격하면, SELECT FOR UPDATE가 둘째를 첫째의 커밋까지 블록시켜 직렬화돼야 한다 —
+    둘 다 "성공"해 같은 행을 서로 다른 pr_number로 덮어쓰면 안 된다."""
+    from app.models.gate import Gate
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            null_gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="pending", pr_number=None,
+            )
+            s.add(null_gate)
+            await s.commit()
+            null_gate_id = null_gate.id
+            story_id, org_id = story.id, org.id
+
+        tx1_locked = asyncio.Event()
+        tx1_may_commit = asyncio.Event()
+        result_holder: dict[str, uuid.UUID | None] = {}
+
+        async def _tx1():
+            async with Session() as s1:
+                found = await find_gate_slot_with_pr_fallback(
+                    s1, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                    gate_type="merge", pr_number=801, repo_full_name="acme/repo",
+                )
+                result_holder["tx1"] = found.id if found else None
+                tx1_locked.set()
+                await tx1_may_commit.wait()
+                await s1.commit()
+
+        async def _tx2():
+            await tx1_locked.wait()
+            async with Session() as s2:
+                found = await find_gate_slot_with_pr_fallback(
+                    s2, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                    gate_type="merge", pr_number=802, repo_full_name="acme/repo",
+                )
+                result_holder["tx2"] = found.id if found else None
+                await s2.commit()
+
+        async def _release_tx1_after_delay():
+            await tx1_locked.wait()
+            await asyncio.sleep(0.3)  # tx2가 SELECT FOR UPDATE로 실제 블록할 시간을 준다.
+            tx1_may_commit.set()
+
+        await asyncio.gather(_tx1(), _tx2(), _release_tx1_after_delay())
+
+        assert result_holder["tx1"] == null_gate_id, "tx1이 NULL-슬롯을 승격해야 함"
+        assert result_holder["tx2"] is None, (
+            "tx2는 tx1 커밋 後 재평가에서 이미 승격된 슬롯을 못 보고 None을 받아야 함"
+            "(중복 승격 없음 — FOR UPDATE 직렬화의 직접 증거)"
+        )
+
+        async with Session() as s:
+            rows = (
+                await s.execute(select(Gate).where(Gate.work_item_id == story_id))
+            ).scalars().all()
+            assert len(rows) == 1, "행이 여전히 1개여야 함(승격이지 신규생성 아님)"
+            assert rows[0].pr_number == 801, "먼저 커밋한 tx1의 pr_number로 승격됐어야 함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_b3_reevaluate_does_not_synthesize_fictitious_repo_pr_tuple():
+    """HIGH3 핵심 — 게이트에 pr_number는 이미 있는데 repo가 없고(legacy), 스토리의 «가장
+    최근» PR 링크가 **다른 PR**의 것이면, 그 링크의 repo를 빌려 존재한 적 없는 (repo, 이
+    pr_number) 조합을 합성하면 안 된다 — 조합 실패로 422여야지, 잘못된 조합으로 GitHub GET을
+    날리면 안 된다."""
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.main import app
+    from httpx import ASGITransport, AsyncClient
+    from tests.conftest import override_db_and_read
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project, story = await _seed_org_project_story(s, with_participation=True)
+
+            from app.models.github_installation import GithubInstallation
+            from app.models.project import OrgMember
+            from app.models.project_access import ProjectAccess
+            from app.models.pull_request_story_link import PullRequestStoryLink
+            from app.models.user import User
+
+            s.add(GithubInstallation(
+                id=uuid.uuid4(), org_id=org.id, installation_id=680900, account_login="moonklabs",
+            ))
+            # 스토리의 "가장 최근" 링크는 PR#99(다른 PR) — gate 자신은 PR#42에 귀속.
+            s.add(PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=org.id, story_id=story.id,
+                repo_full_name="acme/repo-of-pr-99", pr_number=99,
+                link_source="explicit", confidence="high",
+            ))
+            await s.commit()
+
+            from app.models.gate import Gate
+            from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending", pr_number=42, repo_full_name=None,
+                neutral_facts=None,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+            caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+            s.add(caller)
+            await s.commit()
+            caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
+            s.add(caller_om)
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+            caller_id = caller.id
+
+        async def _db():
+            async with Session() as s:
+                try:
+                    yield s
+                    await s.commit()
+                except Exception:
+                    await s.rollback()
+                    raise
+
+        async def _auth():
+            return AuthContext(user_id=str(caller_id), email="caller@test", claims={"app_metadata": {}})
+
+        async def _org():
+            return org.id
+
+        override_db_and_read(app, _db)
+        app.dependency_overrides[get_current_user] = _auth
+        app.dependency_overrides[get_verified_org_id] = _org
+
+        client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+        get_pr_calls = []
+
+        async def _spy_get_pull_request(installation_id, repo_full_name, pr_number):
+            get_pr_calls.append((repo_full_name, pr_number))
+            return {"head": {"sha": "sha-x"}, "merged": False}
+
+        try:
+            with (
+                patch("app.routers.gates.get_installation_token", AsyncMock(return_value="inst-tok")),
+                patch("app.routers.gates.get_pull_request", new=_spy_get_pull_request),
+                patch(
+                    "app.routers.gates.fetch_status_check_rollup",
+                    AsyncMock(return_value=("success", None)),
+                ),
+                patch("app.core.database.async_session_factory", Session),
+            ):
+                resp = await client.post(f"/api/v2/gates/{gate_id}/reevaluate")
+            # 합성 튜플로 GET을 날리느니 422로 정직하게 실패해야 한다 — link의 pr_number(99)가
+            # gate의 pr_number(42)와 다르므로 그 링크는 쓰면 안 되고, repo를 못 찾아 422.
+            assert resp.status_code == 422, resp.text
+            assert get_pr_calls == [], f"합성된 (repo, pr_number) 조합으로 GitHub GET이 나가면 안 됨: {get_pr_calls}"
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2932_gate_slot_hardening_realdb.py
+++ b/backend/tests/test_2932_gate_slot_hardening_realdb.py
@@ -544,83 +544,58 @@ async def test_sha_unchanged_but_newer_delivery_advances_watermark_without_statu
 
 
 @pytest.mark.anyio
-async def test_ui_approval_seeds_pr_head_watermark_realdb():
-    """story #2932 완주조건 HIGH2(4라운드, 카디르 자기정정) — 사람 UI 승인 경로
-    (`gates.py::transition_gate_endpoint`)가 approved_head_sha를 세우면서 pr_head_observed_at
-    워터마크도 함께 씨드해야 한다. 원래는 이 자리가 비어 있어(writer 3곳 중 이 경로만
-    누락), 정상 승인 직후에도 워터마크=None으로 남아 다음 stale webhook을 못 걸렀다."""
-    from tests.test_2835_gate_approval_publish_self_sufficient_realdb import (
-        _client_for,
-        _seed_common,
-        _setup_app,
-    )
-    from app.main import app
+async def test_pending_gate_records_watermark_from_real_webhook():
+    """story #2932 완주조건 HIGH2(5라운드 재설계) — 워터마크 "관측"은 gate.status 무관으로
+    항상 기록돼야 한다. `reopen_gate_if_new_sha`가 예전엔 pending 게이트에 대해 status
+    가드에서 즉시 return해 관측 자체를 기록 못 했다(3라운드 구멍의 정확한 근원 — 페드루 PO
+    5라운드 명시 지적). pending 상태에서도(SHA가 그대로든 다르든) 실 webhook의 pr_updated_at
+    이 newer면 워터마크가 기록돼야, 나중에 사람이 승인해도 그 값이 이미 심어져 있다."""
     from app.models.gate import Gate
-    from app.models.github_installation import GithubInstallation
-    from app.models.pm import Story
+    from app.services.gate_github_check import reopen_gate_if_new_sha
     from app.services.merge_verdict_gate import MERGE_GATE_TYPE
 
     engine, Session = await _session_factory()
     try:
+        pr_updated_at = datetime(2026, 8, 23, 9, 0, 0, tzinfo=timezone.utc)
         async with Session() as s:
-            seeded = await _seed_common(s)
-            story = Story(
-                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
-                title="UI 승인 워터마크 씨드",
-            )
-            s.add(story)
-            await s.commit()
-            s.add(GithubInstallation(
-                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=293201, account_login="acme",
-            ))
-            await s.commit()
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
             gate = Gate(
-                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
-                gate_type=MERGE_GATE_TYPE, status="pending",
-                approved_head_sha=None, github_check_run_id=1, github_check_run_sha="sha-ui-approve",
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending", pr_number=2935,
+                repo_full_name="acme/pending-observe-repo", approved_head_sha=None,
                 pr_head_observed_at=None,
-                neutral_facts={"repo": "acme/ui-approve-repo", "pr_number": 2932},
             )
             s.add(gate)
             await s.commit()
-            gate_id = gate.id
+            gate_id, org_id = gate.id, org.id
 
-        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
-        client = _client_for(app)
-        try:
-            # publish_gate_check(background task)는 「승인」과 별개 writer(gate_github_check.py
-            # 자신의 success-발행 경로)라 이 endpoint 자신의 워터마크 로직을 노 no-op으로 만들어도
-            # 그 태스크가 대신 워터마크를 씨드해 뮤테이션을 가릴 수 있다 — 이 테스트는 UI 승인
-            # 코드 자체를 고립시키려 그 태스크를 통째로 no-op 처리한다.
-            with (
-                patch("app.routers.gates.publish_gate_check", AsyncMock()),
-                patch("app.core.database.async_session_factory", Session),
-            ):
-                resp = await client.post(
-                    f"/api/v2/gates/{gate_id}/transition",
-                    json={"status": "approved", "note": "워터마크 씨드 확인", "evidence_viewed": True},
-                )
-                assert resp.status_code == 200, resp.text
-        finally:
-            await client.aclose()
+        async with Session() as s:
+            gate = await s.get(Gate, gate_id)
+            repended = await reopen_gate_if_new_sha(
+                s, org_id, gate, "sha-first-push",
+                repo_full_name="acme/pending-observe-repo", pr_number=2935,
+                pr_updated_at=pr_updated_at,
+            )
+            await s.commit()
+            assert repended is False, "pending 게이트는 재-pending 판정 대상이 아님(이미 pending)"
 
         async with Session() as s:
             refetched = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
-            assert refetched.status == "approved"
-            assert refetched.approved_head_sha == "sha-ui-approve"
-            assert refetched.pr_head_observed_at is not None, (
-                "UI 승인이 approved_head_sha를 세우면서 pr_head_observed_at 워터마크도 함께 씨드해야 함"
+            assert refetched.status == "pending", "상태는 그대로 pending"
+            assert refetched.pr_head_observed_at == pr_updated_at, (
+                "pending 상태에서도 실 webhook의 pr_updated_at이 워터마크로 기록돼야 함"
             )
     finally:
-        app.dependency_overrides.clear()
         await engine.dispose()
 
 
 @pytest.mark.anyio
-async def test_ui_approval_then_stale_webhook_does_not_repend_realdb():
-    """story #2932 완주조건 HIGH2 — 카디르 4라운드가 정확히 지적한 시나리오: 사람이 UI에서
-    막 승인한 직후, 그 승인보다 «과거» pr_updated_at을 가진 지연 webhook(다른 SHA)이
-    도착해도 spurious 재-pending이 일어나면 안 된다. 이게 원래 처방이 실패하던 «주경로»다."""
+async def test_watermark_survives_approval_and_blocks_subsequent_stale_webhook():
+    """story #2932 완주조건 HIGH2(5라운드) — 현실적인 end-to-end 시나리오: PR이
+    opened/synchronize 되면(pending 상태에서) 실 webhook이 먼저 오고(워터마크 기록), 그 뒤
+    사람이 UI에서 승인(서버 now()는 이제 절대 안 씀 — 승인은 그 값을 «건드리지 않는다»),
+    그 뒤 지연 도착한 stale webhook(더 옛 pr_updated_at, 다른 SHA)이 여전히 정확히
+    걸러지는지 — 서버 시계 없이도 원래 4라운드가 지키려던 보증이 성립함을 증명한다."""
     from tests.test_2835_gate_approval_publish_self_sufficient_realdb import (
         _client_for,
         _seed_common,
@@ -635,127 +610,155 @@ async def test_ui_approval_then_stale_webhook_does_not_repend_realdb():
 
     engine, Session = await _session_factory()
     try:
+        real_webhook_time = datetime(2026, 8, 23, 9, 0, 0, tzinfo=timezone.utc)
         async with Session() as s:
             seeded = await _seed_common(s)
             story = Story(
                 id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
-                title="UI 승인 직후 stale webhook",
+                title="워터마크 승인 생존 + stale 차단",
             )
             s.add(story)
             await s.commit()
             s.add(GithubInstallation(
-                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=293202, account_login="acme",
+                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=293203, account_login="acme",
             ))
             await s.commit()
             gate = Gate(
                 id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
                 gate_type=MERGE_GATE_TYPE, status="pending",
-                approved_head_sha=None, github_check_run_id=2, github_check_run_sha="sha-primary-path",
-                pr_head_observed_at=None,
-                neutral_facts={"repo": "acme/primary-path-repo", "pr_number": 2933},
+                approved_head_sha=None, github_check_run_id=None, github_check_run_sha=None,
+                pr_head_observed_at=None, repo_full_name="acme/e2e-repo", pr_number=2936,
             )
             s.add(gate)
             await s.commit()
             gate_id = gate.id
             org_id = seeded["org_id"]
 
+        # 1) PR opened/synchronize — 실 webhook이 승인보다 먼저 도착(거의 항상 일어나는 순서).
+        async with Session() as s:
+            gate = await s.get(Gate, gate_id)
+            await reopen_gate_if_new_sha(
+                s, org_id, gate, "sha-real-head",
+                repo_full_name="acme/e2e-repo", pr_number=2936, pr_updated_at=real_webhook_time,
+            )
+            gate.github_check_run_sha = "sha-real-head"  # transition_gate_endpoint의 anchor 소스.
+            await s.commit()
+
+        async with Session() as s:
+            pre_approval = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert pre_approval.pr_head_observed_at == real_webhook_time, "전제: pending 중 실 webhook이 워터마크를 기록해야 함"
+
+        # 2) 사람이 UI에서 승인 — 워터마크는 «건드리지 않는다»(서버 now() 완전 삭제).
         await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
         client = _client_for(app)
         try:
-            # 위 테스트와 동일 이유 — publish_gate_check 배경 태스크의 독립 워터마크-씨드가
-            # endpoint 자신의 로직을 가리지 않도록 no-op 처리.
             with (
                 patch("app.routers.gates.publish_gate_check", AsyncMock()),
                 patch("app.core.database.async_session_factory", Session),
             ):
                 resp = await client.post(
                     f"/api/v2/gates/{gate_id}/transition",
-                    json={"status": "approved", "note": "주경로 재현", "evidence_viewed": True},
+                    json={"status": "approved", "note": "e2e 승인", "evidence_viewed": True},
                 )
                 assert resp.status_code == 200, resp.text
         finally:
             await client.aclose()
 
-        # 승인 직후 워터마크가 실제로 세팅됐는지 전제 확인.
         async with Session() as s:
             approved_gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
-            assert approved_gate.pr_head_observed_at is not None, "전제: UI 승인이 워터마크를 씨드해야 함"
-            watermark_at_approval = approved_gate.pr_head_observed_at
+            assert approved_gate.status == "approved"
+            assert approved_gate.approved_head_sha == "sha-real-head"
+            assert approved_gate.pr_head_observed_at == real_webhook_time, (
+                "승인이 pending 중 이미 기록된 실 워터마크를 건드리면 안 됨(서버 now() 미사용 확인)"
+            )
 
-        # 승인보다 과거 pr_updated_at을 가진 지연 webhook — 다른(옛) SHA를 실어 도착.
-        stale_delivery = watermark_at_approval - timedelta(minutes=10)
+        # 3) 승인보다 과거 pr_updated_at을 가진 지연 webhook(다른 SHA) 도착 — 여전히 차단돼야.
+        stale_delivery = real_webhook_time - timedelta(minutes=10)
         async with Session() as s:
             gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
             repended = await reopen_gate_if_new_sha(
                 s, org_id, gate, "sha-stale-delayed-delivery",
-                repo_full_name="acme/primary-path-repo", pr_number=2933,
-                pr_updated_at=stale_delivery,
+                repo_full_name="acme/e2e-repo", pr_number=2936, pr_updated_at=stale_delivery,
             )
             await s.commit()
-            assert repended is False, (
-                "UI 승인 직후 도착한 stale webhook이 spurious 재-pending을 일으키면 안 됨"
-                "(카디르 4라운드가 지적한 정확히 이 시나리오)"
-            )
+            assert repended is False, "승인 前 이미 기록된 워터마크가 승인 後에도 stale webhook을 계속 차단해야 함"
 
         async with Session() as s:
             final_gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
-            assert final_gate.status == "approved", "stale webhook 후에도 승인 상태 유지돼야 함"
-            assert final_gate.approved_head_sha == "sha-primary-path", "stale webhook이 anchor를 덮으면 안 됨"
+            assert final_gate.status == "approved"
+            assert final_gate.approved_head_sha == "sha-real-head"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
 
 
 @pytest.mark.anyio
-async def test_publish_gate_check_success_seeds_pr_head_watermark_realdb():
-    """story #2932 완주조건 HIGH2(4라운드) — writer 3곳 중 마지막 하나: `publish_gate_check`
-    (background 발행 태스크)가 conclusion=success를 발행할 때도 워터마크를 함께 씨드해야
-    한다. ⚠️그라운딩(이 테스트 작성 중 실측): approved/auto_passed 게이트는 이 함수 자신의
-    fail-closed 가드(anchor 없으면 발행 자체를 skip — 위쪽 코드)때문에 `approved_head_sha`가
-    **이미** 세팅돼 있어야만 이 지점에 도달한다 — 즉 이 write는 "새 anchor 확立"이 아니라
-    "기존 anchor 재확인"이다. 그래도 워터마크가 비어 있던 legacy 게이트(이 필드가 생기기 前
-    승인된 것 등)가 재발행될 때 씨드 기회를 놓치면 안 되므로, 전제를 "이미 anchor는 있고
-    워터마크만 비어 있음"으로 세팅해 검증한다."""
+async def test_never_webhooked_gate_has_no_watermark_after_approval_documented_gap():
+    """story #2932 완주조건 HIGH2(5라운드) — 정직하게 남기는 한계: 이 gate가 «한 번도» 실
+    webhook을 받은 적 없이(순수 self-report/board-preflight 등) 승인되면, 워터마크는 여전히
+    None이다(서버 now()로 대체 씨딩하지 않으므로) — 그 직후 첫 webhook은 SHA-diff-only
+    (#2932 이전 baseline)로 판정한다. 새로 나빠지는 게 아니라 원래 상태로 돌아가는 것뿐임을
+    회귀 가드로 고정."""
+    from tests.test_2835_gate_approval_publish_self_sufficient_realdb import (
+        _client_for,
+        _seed_common,
+        _setup_app,
+    )
+    from app.main import app
     from app.models.gate import Gate
     from app.models.github_installation import GithubInstallation
-    from app.services.gate_github_check import publish_gate_check
+    from app.models.pm import Story
     from app.services.merge_verdict_gate import MERGE_GATE_TYPE
 
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            seeded = await _seed_common(s)
+            story = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="한 번도 webhook 안 받은 게이트",
+            )
+            s.add(story)
+            await s.commit()
             s.add(GithubInstallation(
-                id=uuid.uuid4(), org_id=org.id, installation_id=293401, account_login="acme",
+                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=293204, account_login="acme",
             ))
             await s.commit()
             gate = Gate(
-                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
-                gate_type=MERGE_GATE_TYPE, status="approved", pr_number=2934,
-                repo_full_name="acme/publish-writer-repo", approved_head_sha="sha-publish-writer",
-                github_check_run_id=None, github_check_run_sha=None,
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending",
+                approved_head_sha=None, github_check_run_id=3, github_check_run_sha="sha-self-report",
                 pr_head_observed_at=None,
+                neutral_facts={"repo": "acme/self-report-repo", "pr_number": 2937},
             )
             s.add(gate)
             await s.commit()
-            gate_id, org_id = gate.id, org.id
+            gate_id = gate.id
 
-        with (
-            patch("app.services.gate_github_check.create_check_run", AsyncMock(return_value={"id": 99})),
-            patch("app.core.database.async_session_factory", Session),
-        ):
-            await publish_gate_check(
-                org_id, gate_id,
-                head_sha="sha-publish-writer", repo_full_name="acme/publish-writer-repo", pr_number=2934,
-            )
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            with (
+                patch("app.routers.gates.publish_gate_check", AsyncMock()),
+                patch("app.core.database.async_session_factory", Session),
+            ):
+                resp = await client.post(
+                    f"/api/v2/gates/{gate_id}/transition",
+                    json={"status": "approved", "note": "webhook 이력 없는 승인", "evidence_viewed": True},
+                )
+                assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
 
         async with Session() as s:
             refetched = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
-            assert refetched.approved_head_sha == "sha-publish-writer"
-            assert refetched.pr_head_observed_at is not None, (
-                "publish_gate_check success 발행이 워터마크를 함께 씨드해야 함(legacy 빈 워터마크 회복)"
+            assert refetched.status == "approved"
+            assert refetched.pr_head_observed_at is None, (
+                "실 webhook을 한 번도 못 받은 게이트는 승인 후에도 워터마크가 None으로 남는 것이 "
+                "이번 재설계의 의도된(정직하게 문서화된) 한계"
             )
     finally:
+        app.dependency_overrides.clear()
         await engine.dispose()
 
 

--- a/backend/tests/test_2932_gate_slot_hardening_realdb.py
+++ b/backend/tests/test_2932_gate_slot_hardening_realdb.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -36,6 +37,46 @@ async def _dispose_global_engine_after_test():
     yield
     from app.core.database import engine as _global_engine
     await _global_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_repo_unknown_query_does_not_crash_on_cross_repo_multiple_matches():
+    """카디르 QA(story #2932, PR#3359 3라운드, codex 발견) — 이 PR 자신이 도입한 신규
+    회귀. repo를 모르는 조회(report-done류 self-report의 실 경로, workflow_report.py:198
+    `evaluate_merge_gate(pr_number=N, repo="")`)가, 이 PR이 정당하게 허용한 "같은
+    pr_number·다른 repo 2행" 상태를 만나면 repo 필터 없는 단독쿼리가 MultipleResultsFound
+    (500)로 죽었다. repo_full_name=None 조회는 repo도 모르는 행(NULL)만 매치해야
+    구조적으로 모호성이 없다 — 크래시 없이 None(확신 있는 매치 없음)을 받아야 한다."""
+    from app.models.gate import Gate
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            s.add_all([
+                Gate(
+                    id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                    gate_type="merge", status="pending", pr_number=99, repo_full_name="acme/repo-a",
+                ),
+                Gate(
+                    id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                    gate_type="merge", status="pending", pr_number=99, repo_full_name="acme/repo-b",
+                ),
+            ])
+            await s.commit()
+            story_id, org_id = story.id, org.id
+
+        async with Session() as s:
+            # 크래시 없이(MultipleResultsFound 0) None을 받아야 한다 — repo를 모르므로
+            # repo-a/repo-b 둘 중 어느 것도 "확신 있는 매치"가 아니다.
+            found = await find_gate_slot_with_pr_fallback(
+                s, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="merge", pr_number=99, repo_full_name=None,
+            )
+            assert found is None, "repo 모름 + cross-repo 다중매치 = 확신 있는 단일 매치 없음(None)이어야 함"
+    finally:
+        await engine.dispose()
 
 
 @pytest.mark.anyio
@@ -369,5 +410,134 @@ async def test_b3_reevaluate_does_not_synthesize_fictitious_repo_pr_tuple():
         finally:
             await client.aclose()
             app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_stale_webhook_does_not_repend_already_approved_gate():
+    """HIGH2 핵심(완주 조건) — 이미 최신 SHA로 승인된 게이트에 뒤늦게 도착한 옛
+    synchronize 배달(pr_updated_at이 이미 관측된 워터마크보다 과거)이 SHA 불일치와
+    무관하게 재-pending을 skip해야 한다. GitHub 웹훅은 순서를 보장하지 않으므로 —
+    story #2893의 핵심 보증("승인은 그때의 커밋에")을 이 클래스가 직접 지킨다."""
+    from app.models.gate import Gate
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        watermark = datetime(2026, 8, 22, 12, 0, 0, tzinfo=timezone.utc)
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="approved", pr_number=42,
+                repo_full_name="acme/repo", approved_head_sha="sha-latest",
+                pr_head_observed_at=watermark,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id, org_id = gate.id, org.id
+
+        stale_delivery = watermark - timedelta(minutes=5)  # 워터마크보다 과거 배달.
+        async with Session() as s:
+            gate = await s.get(Gate, gate_id)
+            repended = await reopen_gate_if_new_sha(
+                s, org_id, gate, "sha-from-stale-delivery",
+                repo_full_name="acme/repo", pr_number=42, pr_updated_at=stale_delivery,
+            )
+            await s.commit()
+            assert repended is False, "stale 배달은 SHA가 달라도 재-pending을 발생시키면 안 됨"
+
+        async with Session() as s:
+            gate = await s.get(Gate, gate_id)
+            assert gate.status == "approved", "stale 배달 후에도 승인 상태가 유지돼야 함"
+            assert gate.approved_head_sha == "sha-latest", "stale 배달이 최신 승인 SHA를 덮어쓰면 안 됨"
+            assert gate.pr_head_observed_at == watermark, "stale 배달은 워터마크를 되돌리면 안 됨"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_genuinely_newer_webhook_still_repends_correctly():
+    """회귀 방지 — 진짜로 더 최신인 배달(pr_updated_at이 워터마크보다 미래)은 HIGH2
+    가드가 생기기 전과 동일하게 SHA 불일치 시 정상적으로 재-pending해야 한다."""
+    from app.models.gate import Gate
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        watermark = datetime(2026, 8, 22, 12, 0, 0, tzinfo=timezone.utc)
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="approved", pr_number=42,
+                repo_full_name="acme/repo", approved_head_sha="sha-old",
+                pr_head_observed_at=watermark,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id, org_id = gate.id, org.id
+
+        newer_delivery = watermark + timedelta(minutes=5)
+        async with Session() as s:
+            gate = await s.get(Gate, gate_id)
+            repended = await reopen_gate_if_new_sha(
+                s, org_id, gate, "sha-new",
+                repo_full_name="acme/repo", pr_number=42, pr_updated_at=newer_delivery,
+            )
+            await s.commit()
+            assert repended is True, "진짜 신규 배달은 SHA 불일치 시 재-pending해야 함(회귀 금지)"
+
+        async with Session() as s:
+            gate = await s.get(Gate, gate_id)
+            assert gate.status == "pending"
+            assert gate.approved_head_sha is None
+            assert gate.pr_head_observed_at == newer_delivery, "재-pending 시 워터마크도 새 배달 시각으로 전진해야 함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sha_unchanged_but_newer_delivery_advances_watermark_without_status_change():
+    """HIGH2 부속 — SHA는 그대로인데(예: 라벨만 바뀐 재전송 등) pr_updated_at만 더
+    최신이면, 상태 변화 없이 워터마크만 전진해야 한다(다음 stale 판정의 기준선을
+    갱신 — 안 그러면 옛 워터마크에 머물러 미래의 진짜 stale 배달을 못 거른다)."""
+    from app.models.gate import Gate
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        watermark = datetime(2026, 8, 22, 12, 0, 0, tzinfo=timezone.utc)
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="approved", pr_number=42,
+                repo_full_name="acme/repo", approved_head_sha="sha-same",
+                pr_head_observed_at=watermark,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id, org_id = gate.id, org.id
+
+        newer_delivery = watermark + timedelta(minutes=1)
+        async with Session() as s:
+            gate = await s.get(Gate, gate_id)
+            repended = await reopen_gate_if_new_sha(
+                s, org_id, gate, "sha-same",
+                repo_full_name="acme/repo", pr_number=42, pr_updated_at=newer_delivery,
+            )
+            await s.commit()
+            assert repended is False, "SHA가 그대로면 재-pending은 아니어야 함"
+
+        async with Session() as s:
+            gate = await s.get(Gate, gate_id)
+            assert gate.status == "approved"
+            assert gate.approved_head_sha == "sha-same"
+            assert gate.pr_head_observed_at == newer_delivery, "워터마크는 상태변화 없이도 전진해야 함"
     finally:
         await engine.dispose()

--- a/backend/tests/test_2932_gate_slot_hardening_realdb.py
+++ b/backend/tests/test_2932_gate_slot_hardening_realdb.py
@@ -541,3 +541,263 @@ async def test_sha_unchanged_but_newer_delivery_advances_watermark_without_statu
             assert gate.pr_head_observed_at == newer_delivery, "워터마크는 상태변화 없이도 전진해야 함"
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ui_approval_seeds_pr_head_watermark_realdb():
+    """story #2932 완주조건 HIGH2(4라운드, 카디르 자기정정) — 사람 UI 승인 경로
+    (`gates.py::transition_gate_endpoint`)가 approved_head_sha를 세우면서 pr_head_observed_at
+    워터마크도 함께 씨드해야 한다. 원래는 이 자리가 비어 있어(writer 3곳 중 이 경로만
+    누락), 정상 승인 직후에도 워터마크=None으로 남아 다음 stale webhook을 못 걸렀다."""
+    from tests.test_2835_gate_approval_publish_self_sufficient_realdb import (
+        _client_for,
+        _seed_common,
+        _setup_app,
+    )
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.github_installation import GithubInstallation
+    from app.models.pm import Story
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            story = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="UI 승인 워터마크 씨드",
+            )
+            s.add(story)
+            await s.commit()
+            s.add(GithubInstallation(
+                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=293201, account_login="acme",
+            ))
+            await s.commit()
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending",
+                approved_head_sha=None, github_check_run_id=1, github_check_run_sha="sha-ui-approve",
+                pr_head_observed_at=None,
+                neutral_facts={"repo": "acme/ui-approve-repo", "pr_number": 2932},
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            # publish_gate_check(background task)는 「승인」과 별개 writer(gate_github_check.py
+            # 자신의 success-발행 경로)라 이 endpoint 자신의 워터마크 로직을 노 no-op으로 만들어도
+            # 그 태스크가 대신 워터마크를 씨드해 뮤테이션을 가릴 수 있다 — 이 테스트는 UI 승인
+            # 코드 자체를 고립시키려 그 태스크를 통째로 no-op 처리한다.
+            with (
+                patch("app.routers.gates.publish_gate_check", AsyncMock()),
+                patch("app.core.database.async_session_factory", Session),
+            ):
+                resp = await client.post(
+                    f"/api/v2/gates/{gate_id}/transition",
+                    json={"status": "approved", "note": "워터마크 씨드 확인", "evidence_viewed": True},
+                )
+                assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            refetched = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert refetched.status == "approved"
+            assert refetched.approved_head_sha == "sha-ui-approve"
+            assert refetched.pr_head_observed_at is not None, (
+                "UI 승인이 approved_head_sha를 세우면서 pr_head_observed_at 워터마크도 함께 씨드해야 함"
+            )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ui_approval_then_stale_webhook_does_not_repend_realdb():
+    """story #2932 완주조건 HIGH2 — 카디르 4라운드가 정확히 지적한 시나리오: 사람이 UI에서
+    막 승인한 직후, 그 승인보다 «과거» pr_updated_at을 가진 지연 webhook(다른 SHA)이
+    도착해도 spurious 재-pending이 일어나면 안 된다. 이게 원래 처방이 실패하던 «주경로»다."""
+    from tests.test_2835_gate_approval_publish_self_sufficient_realdb import (
+        _client_for,
+        _seed_common,
+        _setup_app,
+    )
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.github_installation import GithubInstallation
+    from app.models.pm import Story
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            story = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="UI 승인 직후 stale webhook",
+            )
+            s.add(story)
+            await s.commit()
+            s.add(GithubInstallation(
+                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=293202, account_login="acme",
+            ))
+            await s.commit()
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending",
+                approved_head_sha=None, github_check_run_id=2, github_check_run_sha="sha-primary-path",
+                pr_head_observed_at=None,
+                neutral_facts={"repo": "acme/primary-path-repo", "pr_number": 2933},
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+            org_id = seeded["org_id"]
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            # 위 테스트와 동일 이유 — publish_gate_check 배경 태스크의 독립 워터마크-씨드가
+            # endpoint 자신의 로직을 가리지 않도록 no-op 처리.
+            with (
+                patch("app.routers.gates.publish_gate_check", AsyncMock()),
+                patch("app.core.database.async_session_factory", Session),
+            ):
+                resp = await client.post(
+                    f"/api/v2/gates/{gate_id}/transition",
+                    json={"status": "approved", "note": "주경로 재현", "evidence_viewed": True},
+                )
+                assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+
+        # 승인 직후 워터마크가 실제로 세팅됐는지 전제 확인.
+        async with Session() as s:
+            approved_gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert approved_gate.pr_head_observed_at is not None, "전제: UI 승인이 워터마크를 씨드해야 함"
+            watermark_at_approval = approved_gate.pr_head_observed_at
+
+        # 승인보다 과거 pr_updated_at을 가진 지연 webhook — 다른(옛) SHA를 실어 도착.
+        stale_delivery = watermark_at_approval - timedelta(minutes=10)
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            repended = await reopen_gate_if_new_sha(
+                s, org_id, gate, "sha-stale-delayed-delivery",
+                repo_full_name="acme/primary-path-repo", pr_number=2933,
+                pr_updated_at=stale_delivery,
+            )
+            await s.commit()
+            assert repended is False, (
+                "UI 승인 직후 도착한 stale webhook이 spurious 재-pending을 일으키면 안 됨"
+                "(카디르 4라운드가 지적한 정확히 이 시나리오)"
+            )
+
+        async with Session() as s:
+            final_gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert final_gate.status == "approved", "stale webhook 후에도 승인 상태 유지돼야 함"
+            assert final_gate.approved_head_sha == "sha-primary-path", "stale webhook이 anchor를 덮으면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_success_seeds_pr_head_watermark_realdb():
+    """story #2932 완주조건 HIGH2(4라운드) — writer 3곳 중 마지막 하나: `publish_gate_check`
+    (background 발행 태스크)가 conclusion=success를 발행할 때도 워터마크를 함께 씨드해야
+    한다. ⚠️그라운딩(이 테스트 작성 중 실측): approved/auto_passed 게이트는 이 함수 자신의
+    fail-closed 가드(anchor 없으면 발행 자체를 skip — 위쪽 코드)때문에 `approved_head_sha`가
+    **이미** 세팅돼 있어야만 이 지점에 도달한다 — 즉 이 write는 "새 anchor 확立"이 아니라
+    "기존 anchor 재확인"이다. 그래도 워터마크가 비어 있던 legacy 게이트(이 필드가 생기기 前
+    승인된 것 등)가 재발행될 때 씨드 기회를 놓치면 안 되므로, 전제를 "이미 anchor는 있고
+    워터마크만 비어 있음"으로 세팅해 검증한다."""
+    from app.models.gate import Gate
+    from app.models.github_installation import GithubInstallation
+    from app.services.gate_github_check import publish_gate_check
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            s.add(GithubInstallation(
+                id=uuid.uuid4(), org_id=org.id, installation_id=293401, account_login="acme",
+            ))
+            await s.commit()
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="approved", pr_number=2934,
+                repo_full_name="acme/publish-writer-repo", approved_head_sha="sha-publish-writer",
+                github_check_run_id=None, github_check_run_sha=None,
+                pr_head_observed_at=None,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id, org_id = gate.id, org.id
+
+        with (
+            patch("app.services.gate_github_check.create_check_run", AsyncMock(return_value={"id": 99})),
+            patch("app.core.database.async_session_factory", Session),
+        ):
+            await publish_gate_check(
+                org_id, gate_id,
+                head_sha="sha-publish-writer", repo_full_name="acme/publish-writer-repo", pr_number=2934,
+            )
+
+        async with Session() as s:
+            refetched = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert refetched.approved_head_sha == "sha-publish-writer"
+            assert refetched.pr_head_observed_at is not None, (
+                "publish_gate_check success 발행이 워터마크를 함께 씨드해야 함(legacy 빈 워터마크 회복)"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_equal_timestamp_different_sha_still_repends():
+    """카디르 4라운드(codex 발견) — `<=`(동일 timestamp도 stale)는 서로 다른 두 진짜 배달이
+    같은 초 단위 timestamp를 우연히 공유하면 신규 SHA를 stale로 오판했다. `<`로 완화한 뒤엔
+    동일 timestamp가 staleness guard를 안 타고 기존 SHA-diff 비교로 넘어가 정상 재-pending
+    해야 한다."""
+    from app.models.gate import Gate
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        watermark = datetime(2026, 8, 22, 15, 0, 0, tzinfo=timezone.utc)
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="approved", pr_number=42,
+                repo_full_name="acme/repo", approved_head_sha="sha-old-tie",
+                pr_head_observed_at=watermark,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id, org_id = gate.id, org.id
+
+        async with Session() as s:
+            gate = await s.get(Gate, gate_id)
+            repended = await reopen_gate_if_new_sha(
+                s, org_id, gate, "sha-new-same-timestamp",
+                repo_full_name="acme/repo", pr_number=42, pr_updated_at=watermark,
+            )
+            await s.commit()
+            assert repended is True, (
+                "동일 timestamp라도 SHA가 다르면 stale로 오판하지 않고 정상 재-pending해야 함"
+            )
+
+        async with Session() as s:
+            gate = await s.get(Gate, gate_id)
+            assert gate.status == "pending"
+            assert gate.approved_head_sha is None
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2932_gate_slot_hardening_realdb.py
+++ b/backend/tests/test_2932_gate_slot_hardening_realdb.py
@@ -693,6 +693,89 @@ async def test_watermark_survives_approval_and_blocks_subsequent_stale_webhook()
 
 
 @pytest.mark.anyio
+async def test_concurrent_webhook_deliveries_never_regress_watermark():
+    """story #2932 완주조건 HIGH2(6라운드, 카디르+codex 발견) — 관측 블록이 "읽고(Python)
+    비교하고 쓰는" 3단계였다면, 동시(실 Postgres 트랜잭션 2개) 웹훅 2건 중 나중에 commit된
+    쪽이 «더 과거» 값으로 워터마크를 덮어써 역행시킬 수 있었다(HIGH2가 NULL-슬롯 승격에서
+    이미 FOR UPDATE로 막은 것과 같은 클래스 레이스가 관측 로직엔 없었음). DB 원자적
+    GREATEST 갱신은 commit 순서와 무관하게 최종 워터마크가 항상 두 배달 중 최댓값이어야
+    한다 — SHA는 동일(gate.approved_head_sha와 일치)하게 둬 재-pending 분기를 안 타게
+    하고, 순수하게 워터마크 관측 경쟁만 격리해서 검증한다."""
+    from app.models.gate import Gate
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        t0 = datetime(2026, 8, 22, 10, 0, 0, tzinfo=timezone.utc)
+        t_older = t0 + timedelta(minutes=5)   # 두 배달 중 "더 과거"인 쪽(그래도 t0보단 새로움).
+        t_newest = t0 + timedelta(minutes=10)  # 진짜 최신.
+
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="approved", pr_number=2938,
+                repo_full_name="acme/race-repo", approved_head_sha="sha-race-base",
+                pr_head_observed_at=t0,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id, org_id = gate.id, org.id
+
+        # HIGH2(6라운드) 재현 시나리오 그대로: "진짜 최신(T2)" 배달이 먼저 commit되고,
+        # 그보다 옛(T1) 배달이 그 뒤에 처리되는 순서 — 둘 다 자신의 `s.get()`으로 같은
+        # prior(T0)를 이미 읽어둔 채로 경쟁한다(구 코드의 버그 전제 그대로 재현). 두
+        # 트랜잭션 모두 UPDATE(GREATEST 원자 갱신)까지 마친 뒤 commit 타이밍만 이벤트로
+        # 통제 — "newest"가 먼저 커밋해 락을 놓고, "older"의 blocked UPDATE가 그 뒤에
+        # 재개되도록 강제한다(null-슬롯 승격 동시성 테스트와 동일 기법 — 실 row-lock 대기).
+        newest_ready = asyncio.Event()
+        older_started_wait = asyncio.Event()
+        result_holder: dict[str, bool] = {}
+
+        async def _newest():
+            async with Session() as s:
+                gate = await s.get(Gate, gate_id)
+                repended = await reopen_gate_if_new_sha(
+                    s, org_id, gate, "sha-race-base",
+                    repo_full_name="acme/race-repo", pr_number=2938, pr_updated_at=t_newest,
+                )
+                newest_ready.set()
+                # "older"가 자신의 UPDATE를 발사해(락 대기 진입) 이 시점 이후에야 commit —
+                # older의 UPDATE가 진짜로 blocked 상태에 들어갈 시간을 준다.
+                await asyncio.sleep(0.3)
+                await s.commit()
+                result_holder["newest"] = repended
+
+        async def _older():
+            await newest_ready.wait()
+            async with Session() as s:
+                gate = await s.get(Gate, gate_id)  # newest commit 前이므로 여전히 prior=T0를 봄.
+                older_started_wait.set()
+                repended = await reopen_gate_if_new_sha(
+                    s, org_id, gate, "sha-race-base",
+                    repo_full_name="acme/race-repo", pr_number=2938, pr_updated_at=t_older,
+                )  # newest의 UPDATE가 아직 안 커밋됐으면 여기서 row-lock에 걸려 대기.
+                await s.commit()
+                result_holder["older"] = repended
+
+        await asyncio.gather(_newest(), _older())
+
+        assert result_holder["newest"] is False and result_holder["older"] is False, (
+            "동일 SHA면 둘 다 no-op(재-pending 아님)이어야 함"
+        )
+
+        async with Session() as s:
+            final_gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert final_gate.pr_head_observed_at == t_newest, (
+                f"동시성 레이스 후 워터마크는 항상 최댓값(t_newest)이어야 하는데 "
+                f"{final_gate.pr_head_observed_at}로 나옴 — 역행 발생(GREATEST 원자성 깨짐)"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_never_webhooked_gate_has_no_watermark_after_approval_documented_gap():
     """story #2932 완주조건 HIGH2(5라운드) — 정직하게 남기는 한계: 이 gate가 «한 번도» 실
     webhook을 받은 적 없이(순수 self-report/board-preflight 등) 승인되면, 워터마크는 여전히

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -439,6 +439,32 @@ async def test_evaluate_auto_merge_metadata_sufficient():
     assert gate.auto_decision_reason == AUTO_MERGE
 
 
+@pytest.mark.anyio
+async def test_evaluate_auto_merge_with_head_sha_seeds_pr_head_watermark():
+    """story #2932 완주조건 HIGH2(4라운드, 카디르 자기정정) — approved_head_sha가 새로
+    세워지는 writer 3곳 중 하나(AUTO_MERGE 경로)가 `pr_head_observed_at` 워터마크도 함께
+    씨드해야 한다. 안 그러면 이 결정 직후 도착하는 stale webhook이 워터마크=None이라
+    `reopen_gate_if_new_sha`의 staleness guard를 아예 못 타 spurious 재-pending이 재발한다
+    (사람 UI 승인 경로와 동일 결함 클래스)."""
+    gate = SimpleNamespace(id=uuid.uuid4(), status="auto_passed",
+                           requires_human=True, evidence_status=None, decision_basis=None, auto_decision_reason=None,
+                           approved_head_sha=None, pr_head_observed_at=None)
+    part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4())
+    with patch("app.services.merge_verdict_gate.resolve_implementation_participation", AsyncMock(return_value=part)), \
+         patch("app.services.merge_verdict_gate._role_key", AsyncMock(return_value="implementation")), \
+         patch("app.services.merge_verdict_gate.capture_pr_ci_verdict", AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})), \
+         patch("app.services.merge_verdict_gate.compute_member_trust_scores",
+               AsyncMock(return_value={"scores": [{"role_key": "implementation", "clean_pass_rate": 0.95,
+                   "hit": 95, "resolved": 100, "pending": 0, "hit_rate": 0.95}]})), \
+         patch("app.services.merge_verdict_gate.create_gate", AsyncMock(return_value=gate)):
+        res = await evaluate_merge_gate(_mock_session(), uuid.uuid4(), uuid.uuid4(),
+                                        pr_number=1, repo="o/r", ci_result="pass", pr_result="pass",
+                                        head_sha="sha-auto-merge")
+    assert res.decision == AUTO_MERGE
+    assert gate.approved_head_sha == "sha-auto-merge"
+    assert gate.pr_head_observed_at is not None, "AUTO_MERGE anchor 세팅 시 워터마크도 함께 씨드돼야 함"
+
+
 # ── HO-S6 키스톤 실DB: 가설 적중 이력만으로 auto_merge ──────────────────────────
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -440,12 +440,12 @@ async def test_evaluate_auto_merge_metadata_sufficient():
 
 
 @pytest.mark.anyio
-async def test_evaluate_auto_merge_with_head_sha_seeds_pr_head_watermark():
-    """story #2932 완주조건 HIGH2(4라운드, 카디르 자기정정) — approved_head_sha가 새로
-    세워지는 writer 3곳 중 하나(AUTO_MERGE 경로)가 `pr_head_observed_at` 워터마크도 함께
-    씨드해야 한다. 안 그러면 이 결정 직후 도착하는 stale webhook이 워터마크=None이라
-    `reopen_gate_if_new_sha`의 staleness guard를 아예 못 타 spurious 재-pending이 재발한다
-    (사람 UI 승인 경로와 동일 결함 클래스)."""
+async def test_evaluate_auto_merge_with_head_sha_does_not_touch_pr_head_observed_at():
+    """story #2932 완주조건 HIGH2(5라운드 재설계) — AUTO_MERGE는 approved_head_sha를
+    세우지만 pr_head_observed_at은 **더 이상 건드리지 않는다**(4라운드는 서버 now()로
+    씨딩했으나, 서로 다른 시계를 같은 필드에 섞는 결함으로 판명 — 카디르 5라운드+codex
+    실물재현). 이 필드는 이제 gate_github_check.py::reopen_gate_if_new_sha 오직 한 곳,
+    오직 실 webhook payload에서만 채워진다."""
     gate = SimpleNamespace(id=uuid.uuid4(), status="auto_passed",
                            requires_human=True, evidence_status=None, decision_basis=None, auto_decision_reason=None,
                            approved_head_sha=None, pr_head_observed_at=None)
@@ -462,7 +462,7 @@ async def test_evaluate_auto_merge_with_head_sha_seeds_pr_head_watermark():
                                         head_sha="sha-auto-merge")
     assert res.decision == AUTO_MERGE
     assert gate.approved_head_sha == "sha-auto-merge"
-    assert gate.pr_head_observed_at is not None, "AUTO_MERGE anchor 세팅 시 워터마크도 함께 씨드돼야 함"
+    assert gate.pr_head_observed_at is None, "AUTO_MERGE는 서버시각을 이 필드에 절대 쓰면 안 됨(5라운드 원칙)"
 
 
 # ── HO-S6 키스톤 실DB: 가설 적중 이력만으로 auto_merge ──────────────────────────


### PR DESCRIPTION
## 요약

[SID:2932]

story #2893의 4-PR 체인 최종 점검(카디르 #3357 verdict — codex 발견·카디르 소스 직접확認)에서 나온 신규 HIGH 3건. **전부 이미 develop에 머지된 A1(PR①/#3349)·B3(PR③/#3355)의 기존 코드에 있던 구조적 결함**이며, 이 스토리가 닫혀야 story #2893의 "4-PR 완주" 선언이 정당해진다(카디르 판정 유보 조건).

## HIGH1 — cross-repo PR번호 충돌

게이트 슬롯 identity(`work_item_id`, `gate_type`, `pr_number`)에 repo가 없어, 다른 repo의 같은 PR번호가 한 스토리에 연결되면 SHA/evidence가 오염될 수 있었다.

**방향 판단**: 실 사용 분포(단일 repo 운용 여부) 실측을 시도했으나 dev/prod 둘 다 접근 불가(`gcloud run jobs list` 권한 없음, prod는 애초에 접근 권한 없음)로 측정하지 못했다. 대신 이 마이그레이션 비용이 0271(A1, pr_number 편입)과 동형으로 낮고, "구조적 격리"가 이 story #2893 체인 전체가 일관되게 택해온 원칙(guard가 아니라 identity 확장)이라 **분포와 무관하게 구조적 해법을 채택**했다.

- `alembic/versions/0272_gate_repo_scoped_slot.py`(신규) — `gate.repo_full_name` 컬럼 신설, `neutral_facts.repo`에서 백필(0271과 동형 패턴, GitHub API 역조회 불요). 부분 유니크 인덱스를 (pr_number+repo 둘 다 앎)/(pr_number만 앎, repo 모름 legacy) 2구간으로 재설계 — upgrade/downgrade 둘 다 실 PG로 cross-repo 시나리오 왕복 검증(1건은 동일 pr_number+다른 repo 정상 삽입, 1건은 같은 repo 충돌, 1건은 legacy NULL-repo 충돌 — 3가지 제약 시나리오 raw SQL 실증).
- `app/services/gate_service.py::find_gate_slot_with_pr_fallback` — `repo_full_name` 매개변수 추가. 정확매치가 이제 (pr_number, repo_full_name) 둘 다로 스코프. **HIGH1 잔여**: pr_number는 이미 아는데 repo만 몰랐던 legacy 행이 있으면(NULL-슬롯 승격과 대칭인 3번째 매칭 티어) 고아화 대신 승격 — 새 규칙 발명 0.
- 4개 호출부(`create_gate`/`evaluate_merge_gate`의 `_prior_status` peek+`create_gate` 호출/`reconcile_merge_gate_with_real_evidence`/webhook lookup) 전부 `repo_full_name` 스레딩.

## HIGH2 — NULL슬롯 승격 동시성

`find_gate_slot_with_pr_fallback`의 "미상→특정 PR" 승격이 평범한 SELECT 후 ORM 속성 대입+flush뿐이라 `SELECT FOR UPDATE`도 CAS도 없었다 — 두 PR이 동시에 같은 NULL-슬롯을 승격 시도하면 나중 커밋이 조용히 덮어쓸 수 있었다.

처방: NULL-슬롯 조회에 `.with_for_update()` 적용. 두 번째 트랜잭션이 첫 번째의 커밋까지 블록되고, 커밋 後 재평가되는 `WHERE pr_number IS NULL`이 더는 참이 아니므로 자연히 `None`을 받는다(row가 이미 존재하는 UPDATE류 경합이라 유효 — row 자체가 없는 check-then-insert TOCTOU와는 다른 축).

## HIGH3 — B3 fallback이 존재 안 하는 조합 합성

재평가 API(`gates.py::reevaluate_gate_endpoint`)의 legacy 폴백이 `pr_number = pr_number or (_link.pr_number ...)`에서 `pr_number`가 이미 있으면(legacy gate) `_link`의 repo만 빌려오고 pr_number는 그대로 둬, 실제론 링크된 적 없는 `(그 repo, 이 pr_number)` 조합을 합성해 GitHub GET을 날릴 수 있었다.

처방: pr_number가 이미 알려져 있으면 그 pr_number와 **일치하는** 링크로만 repo를 보강 — 불일치하면 그 링크를 버리고 422(합성 GET 대신 정직한 실패).

## 검증

- 마이그레이션 0272: upgrade/downgrade 실 PG 왕복(3-way 제약 시나리오+cross-repo lossy downgrade 재검증).
- `tests/test_2932_gate_slot_hardening_realdb.py`(신규) 4건: cross-repo 독립 격리, legacy repo 승격, **실 Postgres 트랜잭션 2개**(`asyncio.gather`+`Event` 좌표)로 재현한 진짜 동시성 직렬화, B3 합성방지(GitHub GET 호출 자체가 안 나가는 것까지 spy로 확인). 전부 뮤테이션 검증(가드 제거 시 정확히 그 시나리오만 예상대로 재현 확인 후 복원).
- 인접 회귀 18개 파일(격리, 파일별 신선 DB) 전부 green. 3건(`test_2156`)은 `repo_full_name` 스레딩으로 기존 테스트의 암묵 가정(같은 호출 시퀀스 내 `repo` 값 일관성 — 이전엔 `repo=""`와 `repo="moonklabs/sprintable"`을 섞어 써도 무관했으나 이제는 정합 필요)이 드러나 동일 관례(PR①에서 이미 세운 "실제 프로덕션 체인과 정합" 원칙)로 정정.