### PR TITLE
[SID:2933] H1 — Trust Pipeline BE SoT 승격(파생 단일화)

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -170,25 +170,20 @@ describe('StoryDetailPanel — org-switch 잔여 레이스 stale-guard (story #2
   });
 });
 
-// story #2922 W1 — 카디르군 QA(#3336 MEDIUM) 지적 회귀가드: Workcell 헤더 pipelineStage
-// 파생이 needs_input/verified 둘 다 localStatus 무관 단독판정이어야 한다. verified만
-// `localStatus==='in-review'`로 게이팅됐던 결함 때문에 in-progress+webhook발 merge
-// 게이트(ci_result=pass)가 running으로 오표시됐다 — 이 async 왕복이 그 정확한 경로를 판다.
-describe('StoryDetailPanel — Workcell pipelineStage 파생(story #2922, 카디르군 #3336 MEDIUM 회귀가드)', () => {
+// story #2933 H1(P0-H) — 구 FE 재파생(gate 목록+localStatus 조합, #3336 MEDIUM 드리프트
+// 실사례로 이미 1회 버그난 그 로직)을 폐기하고 story.trust_stage(BE derive_trust_stage()
+// 판정값)를 그대로 소비한다는 회귀가드. gate fetch를 몰라도(PO 조건① — 판정은 BE 한 곳)
+// pipelineStage가 정확히 그 prop 값으로 뜨는지만 잰다.
+describe('StoryDetailPanel — Workcell pipelineStage = story.trust_stage 직결(story #2933 H1)', () => {
   const HUMAN_ID = 'human-1';
   const memberMap = { [HUMAN_ID]: { id: HUMAN_ID, name: '책임자', type: 'human' } };
 
-  async function mountWithGates(status: string, gates: Array<{ gate_type: string; status: string; neutral_facts?: Record<string, unknown> }>) {
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (typeof url === 'string' && url.includes('/api/gates?work_item_id=')) {
-        return { ok: true, json: async () => gates };
-      }
-      return { ok: false, json: async () => null };
-    }));
+  async function mountWithTrustStage(trustStage: KanbanStory['trust_stage']) {
+    stubFetch();
     await act(async () => {
       root.render(wrap(
         <StoryDetailPanel
-          story={makeStory({ status, assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID] })}
+          story={makeStory({ status: 'in-progress', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], trust_stage: trustStage })}
           tasks={[]} onClose={() => {}} memberMap={memberMap}
         />,
       ));
@@ -202,14 +197,24 @@ describe('StoryDetailPanel — Workcell pipelineStage 파생(story #2922, 카디
     return container.querySelector('[aria-current="step"]')?.textContent?.trim() ?? null;
   }
 
-  it('in-progress + merge 게이트 pending(ci_result=pass) → Verified (수정 전엔 Running으로 오표시됨)', async () => {
-    await mountWithGates('in-progress', [{ gate_type: 'merge', status: 'pending', neutral_facts: { ci_result: 'pass' } }]);
+  it('trust_stage="verified" → Verified(gate fetch 응답과 무관 — BE 판정값 그대로)', async () => {
+    await mountWithTrustStage('verified');
     expect(currentStageLabel()).toBe('Verified');
   });
 
-  it('in-progress + needs-input류 게이트 pending(doc_approval) → Needs input (기존에도 정상, 대칭 확인)', async () => {
-    await mountWithGates('in-progress', [{ gate_type: 'doc_approval', status: 'pending' }]);
+  it('trust_stage="needs_input" → Needs input', async () => {
+    await mountWithTrustStage('needs_input');
     expect(currentStageLabel()).toBe('Needs input');
+  });
+
+  it('trust_stage=null(done/미지 status 또는 필드 미채움) → 스테퍼 자체가 안 뜬다(no-fiction, 지어낸 단계 0)', async () => {
+    await mountWithTrustStage(null);
+    expect(container.querySelector('[aria-current="step"]')).toBeNull();
+  });
+
+  it('trust_stage=undefined(구 응답 경로) → null과 동일하게 스테퍼 미표시(재파생 폴백 없음)', async () => {
+    await mountWithTrustStage(undefined);
+    expect(container.querySelector('[aria-current="step"]')).toBeNull();
   });
 });
 
@@ -228,8 +233,11 @@ describe('StoryDetailPanel — Workcell Evidence 구획 실배선(story #2922 W2
     }));
     await act(async () => {
       root.render(wrap(
+        // story #2933 H1 — Workcell 자체가 pipelineStage(=story.trust_stage) 없으면 렌더 안
+        // 되므로(no-fiction 게이트), 이 스위트의 실제 대상(Evidence 구획)과 무관하게 값을
+        // 채워 Workcell을 띄운다. storyOverrides가 trust_stage를 명시하면 그게 우선.
         <StoryDetailPanel
-          story={makeStory({ status: 'in-review', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], ...storyOverrides })}
+          story={makeStory({ status: 'in-review', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], trust_stage: 'claimed_done', ...storyOverrides })}
           tasks={[]} onClose={() => {}} memberMap={memberMap}
         />,
       ));
@@ -287,8 +295,11 @@ describe('StoryDetailPanel — Workcell Conversation 구획 대화근거 요약 
     }));
     await act(async () => {
       root.render(wrap(
+        // story #2933 H1 — Workcell 자체가 pipelineStage(=story.trust_stage) 없으면 렌더 안
+        // 되므로(no-fiction 게이트), 이 스위트의 실제 대상(Conversation 구획)과 무관하게
+        // 값을 채워 Workcell을 띄운다.
         <StoryDetailPanel
-          story={makeStory({ status: 'in-review', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID] })}
+          story={makeStory({ status: 'in-review', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], trust_stage: 'claimed_done' })}
           tasks={[]} onClose={() => {}} memberMap={memberMap}
         />,
       ));

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -756,24 +756,16 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   //   buildEvidence와 동일 규율) 렌더 안 함 — trustSeal(human_verified/self_reported)+
   //   evidence.autoVerify(merge 게이트 neutral_facts.ci_result)+gate(그 게이트 자체)만 real signal.
   // - human assignee 없으면 Workcell 렌더 자체를 생략(허구 human 금지, ProofCapsule 배선과 동일 규율).
-  // story #2922 W1 — 구 3색 proofState 배지를 신뢰 파이프라인 6상태로 대체(doc
-  // workcell-redesign-2922 §매핑표). needs_input/verified는 5-status로 표현 불가한 파생값이라
-  // 기존 trustChip(deriveInFlightTrustChip, P0-04)을 그대로 재사용 — merge 게이트 pending+
-  // ci_result=pass가 "Verified"(AC/자동검증 통과·merge gate 前)와 정확히 같은 신호, needs_input
-  // 게이트 pending이 그대로 "Needs input"이다. 신규 BE 필드 0(B1은 doc상 "명시만", 구현 스코프 아님).
-  // 카디르군 QA(#3336 MEDIUM, 2026-08-22) — verified만 `localStatus==='in-review'`로 게이팅해
-  // needs_input과 비대칭이었다: webhook발 merge 게이트가 in-progress 구간에 이미 pending+
-  // ci_result=pass로 도달 가능한 실경로(test_2826 realdb 실증)에서 running으로 오표시되던 결함.
-  // needs_input과 동일하게 trustChip 값만으로 단독판정(status 무관)하도록 정정.
-  const PIPELINE_STAGE_BY_STATUS: Record<string, WorkcellPipelineStage> = {
-    backlog: 'queued', 'ready-for-dev': 'queued', done: 'merge_ready',
-  };
-  const pipelineStage: WorkcellPipelineStage | null = PIPELINE_STAGE_BY_STATUS[localStatus]
-    ?? (trustChip === 'needs_input' ? 'needs_input'
-      : trustChip === 'merge_ready' ? 'verified'
-        : localStatus === 'in-review' ? 'claimed_done'
-          : localStatus === 'in-progress' ? 'running'
-            : null);
+  // story #2933 H1(P0-H) — 구 FE 재파생(PIPELINE_STAGE_BY_STATUS+trustChip 조합, #3336
+  // 드리프트 실사례로 이미 1회 버그난 그 로직)을 폐기하고 BE derive_trust_stage() 판정값을
+  // story.trust_stage로 직접 소비한다(get_story/list_stories 둘 다 배선됨). PO 조건①(2933) —
+  // 판정은 BE 한 곳(trust_pipeline.derive_trust_stage)에만 존재, FE 재계산 0.
+  // PO 조건②(2933) — story prop이 이 필드를 못 채운 응답에서 온 경우(예: handleChangeStatus의
+  // `onStoryUpdate?.({ ...story, status: newStatus })` 낙관적 갱신 — status만 덮어쓰고
+  // trust_stage는 스프레드로 이전 값이 그대로 남는다)도 이 한 줄이 "기존값 유지"를 자동으로
+  // 만족한다 — 별도 로컬 state/재파생 폴백을 얹지 않는다. 뮤테이션 직후의 실시간 갱신은
+  // H2(SSE 구독) 몫.
+  const pipelineStage: WorkcellPipelineStage | null = (story.trust_stage as WorkcellPipelineStage | null) ?? null;
   const assigneeIds = story.assignee_ids?.length ? story.assignee_ids : (story.assignee_id ? [story.assignee_id] : []);
   const proofHumanId = assigneeIds.find((id) => memberMap[id] && memberMap[id]!.type !== 'agent');
   const proofAgentId = assigneeIds.find((id) => memberMap[id]?.type === 'agent');

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -39,6 +39,12 @@ export interface KanbanStory {
   // 지표에서는 뺐으나(#2187 관측) 보드/백로그 화면은 그 플래그를 안 봐 그대로 남아 있었다 —
   // 이 필드로 화면도 존중해 숨긴다(삭제 아닌 숨김, DB엔 남음).
   is_excluded?: boolean;
+  // story #2933 H1(P0-H) — BE trust_pipeline.derive_trust_stage() 판정값(get_story·list_stories
+  // 둘 다 배선). null="done/미지 status(파이프라인 스코프 밖)" 또는 "이 응답 경로가 이 필드를
+  // 아예 안 채움"(bulk_update/update_story 등 H1 스코프 밖) 둘 다일 수 있어 이 필드 하나로는
+  // 구분 못 한다(정직한 한계, story.py trust_stage 필드 주석과 동형) — 소비부는 재파생 폴백을
+  // 두지 않고 "기존값 유지"로 대응한다(story-detail-panel.tsx pipelineStage 참고).
+  trust_stage?: 'queued' | 'running' | 'needs_input' | 'claimed_done' | 'verified' | 'merge_ready' | null;
 }
 
 export interface GateItem {

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -189,6 +189,7 @@ async def list_stories(
         await _attach_has_evidence(repo.session, stories)
         await _attach_has_hypothesis_or_goal(repo.session, stories)
         await _attach_org_project_slugs(repo.session, repo.org_id, stories)
+        await _attach_trust_stage(repo.session, repo.org_id, stories)
         return [StoryResponse.model_validate(s) for s in stories]
 
     # story #2188 ④-b(2026-07-25, 오르테가군 판정 — 의도된 제약, 코드 고칠 이유 없음):
@@ -217,6 +218,7 @@ async def list_stories(
         await _attach_has_evidence(repo.session, stories)
         await _attach_has_hypothesis_or_goal(repo.session, stories)
         await _attach_org_project_slugs(repo.session, repo.org_id, stories)
+        await _attach_trust_stage(repo.session, repo.org_id, stories)
         return [StoryResponse.model_validate(s) for s in stories]
 
     # CB-S4: status + project_id 조합 시 board 쿼리 (order_by + cursor + done 7일 제한)
@@ -244,6 +246,7 @@ async def list_stories(
         await _attach_has_evidence(repo.session, stories)
         await _attach_has_hypothesis_or_goal(repo.session, stories)
         await _attach_org_project_slugs(repo.session, repo.org_id, stories)
+        await _attach_trust_stage(repo.session, repo.org_id, stories)
         return [StoryResponse.model_validate(s) for s in stories]
 
     filters: dict = {}
@@ -283,6 +286,7 @@ async def list_stories(
         )
     await _attach_has_hypothesis_or_goal(repo.session, stories)
     await _attach_org_project_slugs(repo.session, repo.org_id, stories)
+    await _attach_trust_stage(repo.session, repo.org_id, stories)
     return [StoryResponse.model_validate(s) for s in stories]
 
 
@@ -393,6 +397,30 @@ async def _attach_has_hypothesis_or_goal(session: AsyncSession, stories: list[St
     for s in stories:
         if s.epic_id is not None or s.id in ids_with_hypothesis:
             s.has_hypothesis_or_goal = True
+
+
+async def _attach_trust_stage(
+    session: AsyncSession, org_id: uuid.UUID, stories: list[Story]
+) -> None:
+    """story #2933 H1(P0-H) — Trust Pipeline 6단계 판정(transient attr, ORM 컬럼 아님·
+    story-status-primary-axis 전제 유지). PO 조건①: 판정(derive_trust_stage)뿐 아니라 수집
+    (batch_trust_facts) 경로도 단일/배치 어디서 호출하든 이 함수 하나만 거친다 — get_story
+    (단일)·list_stories(보드 주경로) 둘 다 여기로 수렴, FE의 별도 재파생(구
+    deriveInFlightTrustChip+PIPELINE_STAGE_BY_STATUS, #3336 드리프트 실사례)을 없애는 게
+    목적이라 BE 쪽에 그 결함 클래스를 다시 심지 않는다. done/미지 status는 None(파이프라인
+    스코프 밖, §7 확定④) — _attach_has_evidence류의 "positive 단방향" 규율과 달리 이 필드는
+    None 자체가 유효한 판정값이다(has_evidence처럼 "미설정=신호없음"이 아니라
+    derive_trust_stage가 실제로 None을 반환하는 경우가 있음)."""
+    if not stories:
+        return
+    from app.services.trust_pipeline import batch_trust_facts, derive_trust_stage
+
+    story_ids = [s.id for s in stories]
+    facts_map = await batch_trust_facts(session, org_id, story_ids)
+    for s in stories:
+        facts = facts_map.get(s.id)
+        if facts is not None:
+            s.trust_stage = derive_trust_stage(facts)
 
 
 async def _attach_org_project_slugs(
@@ -885,6 +913,7 @@ async def get_story(
     await _attach_has_evidence(repo.session, [story])
     await _attach_has_hypothesis_or_goal(repo.session, [story])
     await _attach_org_project_slugs(repo.session, repo.org_id, [story])
+    await _attach_trust_stage(repo.session, repo.org_id, [story])
     return StoryResponse.model_validate(story)
 
 

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -334,6 +334,21 @@ class StoryResponse(BaseModel):
     def _coerce_human_verified_at(cls, v):
         return v if isinstance(v, datetime) else None
 
+    # story #2933 H1(P0-H) — Trust Pipeline 6단계 판정값(trust_pipeline.derive_trust_stage) 노출.
+    # ORM 컬럼 아님(신규 status 컬럼 0 원칙, doc trust-pipeline-be-design §1 그대로 계승) —
+    # 라우터가 model_validate 前 transient attr로 세팅(has_evidence 패턴 동형). PO 조건②(2933) —
+    # 이 필드가 안 실린 응답(bulk_update/update_story 등 이번 스코프 밖 경로)에서 FE는 재파생
+    # 폴백을 두지 않는다(None="정직한 미상", 기존 표시값 유지가 FE 몫). None이면 done/미지
+    # status(파이프라인 스코프 밖, §7 확定④)이거나 이번 응답 경로가 이 필드를 아예 안 채운
+    # 것 — 두 경우를 이 필드 하나로는 구분 못 한다(정직한 한계, FE는 "기존값 유지"로 대응).
+    trust_stage: str | None = None
+
+    @field_validator("trust_stage", mode="before")
+    @classmethod
+    def _coerce_trust_stage(cls, v):
+        from app.services.trust_pipeline import TRUST_STAGES
+        return v if v in TRUST_STAGES else None
+
     # story #2642(웹·칩 공통, 2026-08-14) — 엔티티 «전체 보기» 착지가 뷰어의 현재 프로젝트로
     # 새는 버그 fix: FE가 뷰어 컨텍스트 대신 이 스토리 자신의 org/project로 직행 URL을 짓게
     # additive로 싣는다(#2168 DocPreviewResponse와 동일 패턴). org_slug는 항상 있음(Organization.

--- a/backend/app/services/trust_pipeline.py
+++ b/backend/app/services/trust_pipeline.py
@@ -169,35 +169,52 @@ async def batch_scope_violation(
     return set(result.scalars().all())
 
 
+async def batch_trust_facts(
+    session: AsyncSession, org_id: uuid.UUID, story_ids: list[uuid.UUID]
+) -> dict[uuid.UUID, TrustFacts]:
+    """N개 story의 현재 trust facts를 실시간 파생(신규 쓰기 0 — 순수 조회, 고정 6쿼리 — story
+    수와 무관). story #2933 H1 — `GET /stories`(보드 주경로, 최대 limit=2000)에 story별 루프로
+    `compute_trust_facts`를 태우면 N×6 쿼리가 되는 것을 막는다. 존재하지 않거나(soft-delete
+    포함) org가 다른 story_id는 반환 dict에서 조용히 빠진다(그 자리는 呼출부가 None 취급)."""
+    if not story_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(Story.id, Story.status, Story.project_id).where(
+                Story.id.in_(story_ids), Story.org_id == org_id, Story.deleted_at.is_(None)
+            )
+        )
+    ).all()
+    if not rows:
+        return {}
+    found_ids = [row[0] for row in rows]
+    verified_map = await batch_human_verified(session, found_ids, "story")
+    pending_gate_ids = await batch_pending_human_gate(session, org_id, found_ids)
+    verify_fail_ids = await batch_verify_fail(session, org_id, found_ids)
+    blocker_ids = await batch_unresolved_blocker(session, org_id, found_ids)
+    scope_violation_ids = await batch_scope_violation(session, org_id, found_ids)
+    return {
+        story_id: TrustFacts(
+            status=status,
+            project_id=project_id,
+            human_verified=story_id in verified_map,
+            has_pending_human_gate=story_id in pending_gate_ids,
+            has_verify_fail=story_id in verify_fail_ids,
+            has_unresolved_blocker=story_id in blocker_ids,
+            has_scope_violation=story_id in scope_violation_ids,
+        )
+        for story_id, status, project_id in rows
+    }
+
+
 async def compute_trust_facts(
     session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID
 ) -> TrustFacts | None:
-    """1개 story의 현재 trust facts를 실시간 파생(신규 쓰기 0 — 순수 조회). story 없으면 None."""
-    row = (
-        await session.execute(
-            select(Story.status, Story.project_id).where(
-                Story.id == story_id, Story.org_id == org_id, Story.deleted_at.is_(None)
-            )
-        )
-    ).first()
-    if row is None:
-        return None
-    status, project_id = row
-    ids = [story_id]
-    verified_map = await batch_human_verified(session, ids, "story")
-    pending_gate_ids = await batch_pending_human_gate(session, org_id, ids)
-    verify_fail_ids = await batch_verify_fail(session, org_id, ids)
-    blocker_ids = await batch_unresolved_blocker(session, org_id, ids)
-    scope_violation_ids = await batch_scope_violation(session, org_id, ids)
-    return TrustFacts(
-        status=status,
-        project_id=project_id,
-        human_verified=story_id in verified_map,
-        has_pending_human_gate=story_id in pending_gate_ids,
-        has_verify_fail=story_id in verify_fail_ids,
-        has_unresolved_blocker=story_id in blocker_ids,
-        has_scope_violation=story_id in scope_violation_ids,
-    )
+    """1개 story의 현재 trust facts. story #2933 H1(PO 조건①) — 판정(derive_trust_stage)뿐 아니라
+    수집(facts) 경로도 단일/배치 갈리지 않게 batch_trust_facts(1건 리스트) 위 얇은 래퍼로 접는다
+    — 두 구현이 갈리면 FE에서 죽인 결함 클래스(#3336 드리프트)를 BE에 다시 심는 꼴이라서."""
+    facts_map = await batch_trust_facts(session, org_id, [story_id])
+    return facts_map.get(story_id)
 
 
 async def _maybe_emit(

--- a/backend/tests/test_2933_h1_trust_stage_api_realdb.py
+++ b/backend/tests/test_2933_h1_trust_stage_api_realdb.py
@@ -1,0 +1,258 @@
+"""story #2933 H1(P0-H, doc ia-... 아님 — trust-pipeline-be-design 후속) 실 PG.
+
+GET /api/v2/stories/{id}(단일) · GET /api/v2/stories?status=&project_id=(보드 주경로) 둘 다
+StoryResponse.trust_stage에 derive_trust_stage() 판정값이 실리는지, 6단계 전부(+done=None
+파이프라인 스코프 밖)를 실측한다. PO 조건①(2933) — 수집(batch_trust_facts)이 단일/배치
+어디로 들어오든 같은 story면 같은 값이 나와야 한다(두 엔드포인트 교차대조로 검증).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _base_org_project_caller(session):
+    """test_e_ui_daegbyeon_p0_04_trust_pipeline_realdb.py의 검증된 anchor 패턴 재현(E-MEMBER-SSOT
+    양쪽 컬럼 다 세팅 — 이 스토리는 project-access 체크가 걸리는 GET 라우트를 두드리므로 필요)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="A")
+    session.add(project)
+    await session.commit()
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(om)
+    await session.commit()
+    m = Member(id=om.id, org_id=org.id, type="human", user_id=caller_id, name=f"Caller-{caller_id.hex[:6]}")
+    session.add(m)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, member_id=m.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+    return org.id, project.id, caller_id
+
+
+def _story(org_id, project_id, title, status="in-progress"):
+    from app.models.pm import Story
+    return Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status=status)
+
+
+async def _seed_six_states(session):
+    from app.models.evidence import Evidence
+    from app.models.gate import Gate
+    from app.models.member import Member
+
+    org_id, project_id, caller_id = await _base_org_project_caller(session)
+
+    s_queued = _story(org_id, project_id, "Backlog", status="backlog")
+    s_queued_ready = _story(org_id, project_id, "Ready", status="ready-for-dev")
+    s_running = _story(org_id, project_id, "Running", status="in-progress")
+    s_needs_input = _story(org_id, project_id, "Needs Input", status="in-progress")
+    s_claimed = _story(org_id, project_id, "Claimed", status="in-review")
+    s_merge_ready = _story(org_id, project_id, "Merge Ready", status="in-review")
+    s_verified_blocked = _story(org_id, project_id, "Verified(blocked)", status="in-review")
+    s_done = _story(org_id, project_id, "Done", status="done")
+    session.add_all([
+        s_queued, s_queued_ready, s_running, s_needs_input,
+        s_claimed, s_merge_ready, s_verified_blocked, s_done,
+    ])
+    await session.commit()
+
+    reviewer = Member(id=uuid.uuid4(), org_id=org_id, type="human", name="Reviewer", org_role="admin")
+    session.add(reviewer)
+    await session.commit()
+
+    session.add(Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=s_needs_input.id, work_item_type="story",
+        gate_type="pr_review", status="pending", requires_human=True,
+    ))
+    # merge_ready: human_verified(gate_approval evidence)+무블로커/무검증실패.
+    session.add(Evidence(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=s_merge_ready.id, work_item_type="story",
+        type="gate_approval", ref="approved", created_by=reviewer.id,
+    ))
+    # verified(blocked): human_verified는 있지만 미해소 블로커가 있어 merge_ready로 못 감.
+    session.add(Evidence(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=s_verified_blocked.id, work_item_type="story",
+        type="gate_approval", ref="approved", created_by=reviewer.id,
+    ))
+    await session.commit()
+
+    from app.models.dependency import ItemDependency
+    blocker_story = _story(org_id, project_id, "Blocker(open)", status="in-progress")
+    session.add(blocker_story)
+    await session.commit()
+    session.add(ItemDependency(
+        id=uuid.uuid4(), org_id=org_id, item_type="story",
+        from_id=blocker_story.id, to_id=s_verified_blocked.id, dep_type="blocks",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org_id, "project_id": project_id, "caller_id": caller_id,
+        "queued": s_queued.id, "queued_ready": s_queued_ready.id,
+        "running": s_running.id, "needs_input": s_needs_input.id,
+        "claimed_done": s_claimed.id, "merge_ready": s_merge_ready.id,
+        "verified": s_verified_blocked.id, "done": s_done.id,
+    }
+
+
+@pytest.mark.anyio
+async def test_get_story_exposes_trust_stage_for_all_six_states():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_six_states(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            expected = {
+                "queued": "queued",
+                "queued_ready": "queued",
+                "running": "running",
+                "needs_input": "needs_input",
+                "claimed_done": "claimed_done",
+                "merge_ready": "merge_ready",
+                "verified": "verified",
+                "done": None,
+            }
+            for key, want in expected.items():
+                resp = await client.get(f"/api/v2/stories/{seeded[key]}")
+                assert resp.status_code == 200, resp.text
+                assert resp.json()["trust_stage"] == want, f"{key}: {resp.json()}"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_stories_board_query_exposes_same_trust_stage_as_get_story():
+    """PO 조건① 교차대조 — 보드 주경로(status+project_id 분기)가 단일 GET과 같은 값을 낸다
+    (batch_trust_facts 하나로 수렴한 증거, 두 엔드포인트가 각자 다른 판정 로직을 안 탄다)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_six_states(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/stories?status=in-review&project_id={seeded['project_id']}"
+            )
+            assert resp.status_code == 200, resp.text
+            by_id = {item["id"]: item["trust_stage"] for item in resp.json()}
+            assert by_id[str(seeded["claimed_done"])] == "claimed_done"
+            assert by_id[str(seeded["merge_ready"])] == "merge_ready"
+            assert by_id[str(seeded["verified"])] == "verified"
+
+            # 단일 GET과 교차대조(같은 story, 같은 값 — 판정 단일화 실증).
+            single = await client.get(f"/api/v2/stories/{seeded['merge_ready']}")
+            assert single.json()["trust_stage"] == by_id[str(seeded["merge_ready"])]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_stories_generic_filter_branch_also_exposes_trust_stage():
+    """4개 list_stories 분기 중 generic filter 분기(project_id만, status_filter 없음)도
+    trust_stage가 실린다 — 4곳 전부 배선했다는 실증(누락 방지)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_six_states(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            by_id = {item["id"]: item["trust_stage"] for item in resp.json()}
+            assert by_id[str(seeded["needs_input"])] == "needs_input"
+            assert by_id[str(seeded["done"])] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## 요약
story #2933(P0-H, \"기본 상태를 신뢰 파이프라인으로\") H1 슬라이스. FE가 별도로 재파생하던 6단계 trust stage 로직(카디르 QA #3336 MEDIUM에서 이미 1회 드리프트 버그 실사례)을 폐기하고, BE `trust_pipeline.derive_trust_stage()`의 판정값을 `StoryResponse.trust_stage`로 직접 노출·소비한다.

PO 조건 2개(2026-08-22 승인 시 명시):
- **①판정 단일화**: facts 수집이 단일/배치 어디로 들어오든 `derive_trust_stage()` 판정은 한 곳만 거친다. `compute_trust_facts`를 신규 `batch_trust_facts` 위 얇은 래퍼로 접어 수집 경로도 하나로 수렴.
- **②재파생 폴백 금지**: `trust_stage`가 안 실린 응답 구간(뮤테이션 직후 등)에서 FE는 조용히 재계산하지 않고 "기존값 유지"로 대응.

## BE 필드 추가(카디르 QA 축 — 명시)
`StoryResponse.trust_stage: str | None` 신규 필드. ORM 컬럼 아님(신규 status 컬럼 0 원칙 계승, doc trust-pipeline-be-design §1), `_attach_has_evidence` 등과 동형 transient-attr 패턴. `GET /api/v2/stories/{id}`(단일)·`GET /api/v2/stories`(4개 분기 전부, 보드 주경로 포함) 응답에 배선. `bulk_update`/`update_story`는 스코프 밖(뮤테이션 직후 갱신은 H2 SSE 몫, PO 승인).

## 변경
- **backend/app/services/trust_pipeline.py**: `batch_trust_facts()` 신설(기존 5개 batch_* 프리미티브 재사용, story 수 무관 고정 6쿼리). `compute_trust_facts`는 이 위 얇은 래퍼로 축소(기존 3개 write-path 호출부 시그니처 무변화).
- **backend/app/schemas/story.py**: `trust_stage` 필드.
- **backend/app/routers/stories.py**: `_attach_trust_stage()` 신설, get_story+list_stories 4분기 배선.
- **apps/web/src/components/kanban/story-detail-panel.tsx**: `pipelineStage`를 `story.trust_stage` 직결로 교체(구 gate 목록 기반 재파생 완전 제거). P0-04 in-flight 칩(`trustChip`)은 별개 기능이라 무변화.
- **apps/web/src/components/kanban/types.ts**: `KanbanStory.trust_stage` 필드.

## 검증
- 신규 `backend/tests/test_2933_h1_trust_stage_api_realdb.py`(3건, 실 PG) — 6단계 전부+list_stories 보드/generic 분기 교차대조(판정 단일화 실증) green.
- 기존 backend: `test_trust_pipeline_unit.py`(19)·`test_e_ui_daegbyeon_p0_04_trust_pipeline_realdb.py`(6)·`test_stories.py` 외 stories 스위트(54) 전부 green.
- FE: tsc/eslint 0·vitest 전체 477 files/4044 tests green·contrast 가드 4종+i18n dup key 가드 신규위반 0·build 0.

## 스크린샷
BE 필드 확장 위주 슬라이스(시각 변화는 스테퍼 정확도 개선뿐, done 상태 오표시 수정 등) — 라이브 dev 배포 후 카디르군 QA 단계에서 실측 스크린샷 첨부 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)