### PR TITLE
[SID:2933] H2 — Workcell 스테퍼 SSE 라이브 구독

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -290,6 +290,56 @@ describe('StoryDetailPanel — Workcell pipelineStage SSE 라이브 갱신(story
     expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining('/api/stories/s-live'), expect.anything());
     expect(currentStageLabel()).toBe('Running');
   });
+
+  // PO 리뷰 MEDIUM(PR#3363, 2026-08-22) — story.id 변경 시 「대기 중 타이머」는 지워져도
+  // 「이미 발화해 in-flight인 fetch」는 못 막는다. 늦게 도착한 응답이 새 story 패널에 옛
+  // story의 stage를 override로 붙이는 레이스를 직접 재현한다: story A에서 SSE 발화→디바운스
+  // 만료(fetch 발사)까지 간 다음, fetch가 아직 안 끝난 상태에서 story B로 전환(re-render)하고,
+  // 그 뒤에야 story A의 응답이 도착하게 만든다 — story B 값이 안 덮이는지 확認.
+  it('SSE로 쏜 fetch가 in-flight인 채 다른 story로 전환되면, 늦게 도착한 응답이 새 story를 덮지 않는다', async () => {
+    const { useSseNotifications } = await import('@/hooks/use-sse-notifications');
+    let capturedOnExtraEvent: ((eventName: string, data: unknown) => void) | undefined;
+    (useSseNotifications as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (o: { onExtraEvent?: typeof capturedOnExtraEvent }) => { capturedOnExtraEvent = o.onExtraEvent; },
+    );
+    const storyA = makeStory({ id: 'story-a', status: 'in-progress', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], trust_stage: 'running' });
+    const storyB = makeStory({ id: 'story-b', status: 'in-review', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], trust_stage: 'claimed_done' });
+
+    // story-a의 fetch만 손으로 붙잡아 둔다(deferred) — story-b로 전환된 뒤에야 해소한다.
+    let resolveStoryAFetch: ((v: unknown) => void) | undefined;
+    const storyAFetchPromise = new Promise((resolve) => { resolveStoryAFetch = resolve; });
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (typeof url === 'string' && /\/api\/stories\/story-a(\?|$)/.test(url)) {
+        return storyAFetchPromise as Promise<{ ok: boolean; json: () => Promise<unknown> }>;
+      }
+      return { ok: false, json: async () => null };
+    }));
+
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={storyA} tasks={[]} onClose={() => {}} memberMap={memberMap} />));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(currentStageLabel()).toBe('Running');
+
+    // story-a SSE 발화 → 디바운스 500ms 소진 → fetch 발사(아직 안 끝남, deferred).
+    await act(async () => { capturedOnExtraEvent!('story.trust_stage_changed', { story_id: 'story-a', new_stage: 'merge_ready' }); });
+    await act(async () => { vi.advanceTimersByTime(500); await Promise.resolve(); });
+
+    // story-a의 fetch가 in-flight인 채로 story-b로 전환(부모가 다른 카드를 클릭한 상황).
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={storyB} tasks={[]} onClose={() => {}} memberMap={memberMap} />));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(currentStageLabel()).toBe('Claimed done');
+
+    // 이제야 story-a의 응답이 늦게 도착 — story-b 패널에 새면 안 된다.
+    await act(async () => {
+      resolveStoryAFetch!({ ok: true, json: async () => ({ data: { ...storyA, trust_stage: 'merge_ready' } }) });
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    expect(currentStageLabel()).toBe('Claimed done');
+  });
 });
 
 // story #2922 W2 — Evidence 구획 = ProofCapsule density="full" 실배선. glance-hero.tsx의

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -340,6 +340,70 @@ describe('StoryDetailPanel — Workcell pipelineStage SSE 라이브 갱신(story
 
     expect(currentStageLabel()).toBe('Claimed done');
   });
+
+  // PO 리뷰 확장(PR#3363 codex 교차모델, 2026-08-22) — 위 두 테스트가 덮는 "다른 story로
+  // 전환" 레이스와 달리, 이건 **같은 story**에 연속 발화한 두 SSE 이벤트의 응답이 네트워크에서
+  // 역순 도착하는 경우(E1→fetchA 보류→E2→fetchB→B 먼저 도착→A가 늦게 도착)다. story.id가
+  // 안 바뀌므로 currentStoryIdRef 가드는 둘 다 통과시킨다 — AbortController가 fetchA 자체를
+  // 죽여야(늦게 온 응답이 절대 반영되지 않아야) 막힌다.
+  it('같은 story에 연속 발화한 두 SSE의 fetch가 역순 도착해도, 먼저 쏜(옛) fetch는 abort돼 나중 값(fetchB)이 유지된다', async () => {
+    const { useSseNotifications } = await import('@/hooks/use-sse-notifications');
+    let capturedOnExtraEvent: ((eventName: string, data: unknown) => void) | undefined;
+    (useSseNotifications as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (o: { onExtraEvent?: typeof capturedOnExtraEvent }) => { capturedOnExtraEvent = o.onExtraEvent; },
+    );
+    const story = makeStory({ id: 'story-x', status: 'in-progress', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], trust_stage: 'running' });
+
+    let callCount = 0;
+    let rejectFirstCall: ((e: unknown) => void) | undefined;
+    let resolveSecondCall: ((v: unknown) => void) | undefined;
+    vi.stubGlobal('fetch', vi.fn((url: string, init?: { signal?: AbortSignal }) => {
+      if (typeof url === 'string' && /\/api\/stories\/story-x(\?|$)/.test(url)) {
+        callCount += 1;
+        const thisCall = callCount;
+        return new Promise((resolve, reject) => {
+          if (thisCall === 1) rejectFirstCall = reject;
+          if (thisCall === 2) resolveSecondCall = resolve;
+          // 실 fetch abort 동형 — signal이 abort되면 pending promise가 AbortError로 reject.
+          init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+        });
+      }
+      return Promise.resolve({ ok: false, json: async () => null });
+    }));
+
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={story} tasks={[]} onClose={() => {}} memberMap={memberMap} />));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(currentStageLabel()).toBe('Running');
+
+    // E1 — 디바운스 소진 → fetchA 발사(deferred, 아직 안 끝남).
+    await act(async () => { capturedOnExtraEvent!('story.trust_stage_changed', { story_id: 'story-x', new_stage: 'needs_input' }); });
+    await act(async () => { vi.advanceTimersByTime(500); await Promise.resolve(); });
+    expect(callCount).toBe(1);
+
+    // E2 — fetchA가 아직 in-flight인 채로 새 이벤트 발화 → 디바운스 재소진 시점에 fetchA를
+    // abort하고 fetchB를 발사한다.
+    await act(async () => { capturedOnExtraEvent!('story.trust_stage_changed', { story_id: 'story-x', new_stage: 'verified' }); });
+    await act(async () => { vi.advanceTimersByTime(500); await Promise.resolve(); });
+    expect(callCount).toBe(2);
+    expect(rejectFirstCall).toBeDefined(); // fetchA의 signal이 실제로 abort listener를 받음.
+
+    // fetchB(나중 이벤트) 먼저 도착 — 최신값(Verified) 반영.
+    await act(async () => {
+      resolveSecondCall!({ ok: true, json: async () => ({ data: { ...story, trust_stage: 'verified' } }) });
+      await Promise.resolve(); await Promise.resolve();
+    });
+    expect(currentStageLabel()).toBe('Verified');
+
+    // fetchA(먼저 쏜 옛 fetch)가 이제야 응답 — abort로 이미 reject됐으므로 .then은 아예 실행
+    // 안 되지만, 방어적으로 늦게 resolve를 시도해도(실 abort면 불가능하지만) 무해함을 재확認.
+    await act(async () => {
+      try { rejectFirstCall!(new DOMException('Aborted', 'AbortError')); } catch { /* already settled */ }
+      await Promise.resolve(); await Promise.resolve();
+    });
+    expect(currentStageLabel()).toBe('Verified'); // 역순 도착에도 회귀 없음.
+  });
 });
 
 // story #2922 W2 — Evidence 구획 = ProofCapsule density="full" 실배선. glance-hero.tsx의

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -19,6 +19,12 @@ vi.mock('@/app/dashboard/dashboard-shell', () => ({
   useDashboardContext: () => useDashboardContextMock(),
 }));
 
+// story #2933 H2 — SSE push가 재조회를 "트리거"하는지 직접 잰다(verify-rail.test.tsx #2467
+// respec과 동형 관례) — useSseNotifications를 모킹해 onExtraEvent 콜백을 손으로 쥐고 실행.
+vi.mock('@/hooks/use-sse-notifications', () => ({
+  useSseNotifications: vi.fn(),
+}));
+
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 let container: HTMLDivElement;
@@ -215,6 +221,74 @@ describe('StoryDetailPanel — Workcell pipelineStage = story.trust_stage 직결
   it('trust_stage=undefined(구 응답 경로) → null과 동일하게 스테퍼 미표시(재파생 폴백 없음)', async () => {
     await mountWithTrustStage(undefined);
     expect(container.querySelector('[aria-current="step"]')).toBeNull();
+  });
+});
+
+// story #2933 H2(P0-H) — Workcell 스테퍼가 `story.trust_stage_changed` SSE를 라이브 갱신
+// 트리거로 쓰는지(AttentionQueueView, story #2923와 동형 패턴). SSE payload 자체는 신뢰의
+// 소스가 아니다(트리거일 뿐) — REST 재조회(GET /api/stories/{id})의 값만 반영한다(PO 조건②
+// 재파생 폴백 없음과 정합, verify-rail.test.tsx #2467 respec 관례 재사용).
+describe('StoryDetailPanel — Workcell pipelineStage SSE 라이브 갱신(story #2933 H2)', () => {
+  const HUMAN_ID = 'human-1';
+  const memberMap = { [HUMAN_ID]: { id: HUMAN_ID, name: '책임자', type: 'human' } };
+
+  function currentStageLabel(): string | null {
+    return container.querySelector('[aria-current="step"]')?.textContent?.trim() ?? null;
+  }
+
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('story.trust_stage_changed(이 story_id) 수신 → 디바운스 後 GET /api/stories/{id} 재조회로 스테퍼가 갱신된다', async () => {
+    const { useSseNotifications } = await import('@/hooks/use-sse-notifications');
+    let capturedOnExtraEvent: ((eventName: string, data: unknown) => void) | undefined;
+    (useSseNotifications as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (o: { onExtraEvent?: typeof capturedOnExtraEvent }) => { capturedOnExtraEvent = o.onExtraEvent; },
+    );
+    const story = makeStory({ id: 's-live', status: 'in-progress', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], trust_stage: 'running' });
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      // 정확 일치만 — '/api/stories/s-live/comments' 등 하위 경로가 substring으로 오매칭돼
+      // story payload를 comments state에 흘려보내면 안 된다(comments.map 크래시로 실제로 걸림).
+      if (typeof url === 'string' && /\/api\/stories\/s-live(\?|$)/.test(url)) {
+        return { ok: true, json: async () => ({ data: { ...story, trust_stage: 'needs_input' } }) };
+      }
+      return { ok: false, json: async () => null };
+    }));
+
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={story} tasks={[]} onClose={() => {}} memberMap={memberMap} />));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(currentStageLabel()).toBe('Running');
+
+    expect(capturedOnExtraEvent).toBeDefined();
+    await act(async () => { capturedOnExtraEvent!('story.trust_stage_changed', { story_id: 's-live', new_stage: 'needs_input' }); });
+    await act(async () => { vi.advanceTimersByTime(500); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(currentStageLabel()).toBe('Needs input');
+  });
+
+  it('다른 story_id의 이벤트는 무시한다(이 패널이 보는 story 밖 전이)', async () => {
+    const { useSseNotifications } = await import('@/hooks/use-sse-notifications');
+    let capturedOnExtraEvent: ((eventName: string, data: unknown) => void) | undefined;
+    (useSseNotifications as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (o: { onExtraEvent?: typeof capturedOnExtraEvent }) => { capturedOnExtraEvent = o.onExtraEvent; },
+    );
+    const fetchMock = vi.fn(async () => ({ ok: false, json: async () => null }));
+    vi.stubGlobal('fetch', fetchMock);
+    const story = makeStory({ id: 's-live', status: 'in-progress', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], trust_stage: 'running' });
+
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={story} tasks={[]} onClose={() => {}} memberMap={memberMap} />));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    fetchMock.mockClear();
+
+    await act(async () => { capturedOnExtraEvent!('story.trust_stage_changed', { story_id: 'other-story', new_stage: 'merge_ready' }); });
+    await act(async () => { vi.advanceTimersByTime(500); await Promise.resolve(); });
+
+    expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining('/api/stories/s-live'), expect.anything());
+    expect(currentStageLabel()).toBe('Running');
   });
 });
 

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -346,6 +346,17 @@ describe('StoryDetailPanel — Workcell pipelineStage SSE 라이브 갱신(story
   // 역순 도착하는 경우(E1→fetchA 보류→E2→fetchB→B 먼저 도착→A가 늦게 도착)다. story.id가
   // 안 바뀌므로 currentStoryIdRef 가드는 둘 다 통과시킨다 — AbortController가 fetchA 자체를
   // 죽여야(늦게 온 응답이 절대 반영되지 않아야) 막힌다.
+  // ⚠️QA 2R(PR#3363, 카디르 뮤테이션+codex 교차모델 완전독립재현 일치, 2026-08-22) — 이전
+  // 버전은 fetchB를 resolve한 뒤 fetchA를 **수동으로 rejectFirstCall!()**해 통과시켰는데,
+  // 이 수동 거부가 abort 메커니즘의 실제 작동 여부와 무관하게 항상 같은 결과를 만들어
+  // 동어반복이었다(프로덕션의 `fetchAbortRef.current?.abort()` 호출을 제거해도 21/21 그대로
+  // 통과 — 회귀보호 0). 처방(codex 구체안): ①첫 fetch의 signal을 저장해 E2 후
+  // `signal.aborted===true`를 수동 개입 없이 직접 assert ②수동 reject 완전 삭제 ③fetchA를
+  // **성공 응답**으로 resolve해 진짜 역순 도착을 재현 — signal의 abort 리스너(실 fetch의
+  // 네이티브 동작 시뮬레이션, 수동 개입 아님)가 실제로 먼저 그 promise를 죽였다면 이 resolve는
+  // 이미-settled promise에 대한 무해한 no-op이고, 그게 아니라면(뮤테이션으로 abort()가
+  // 빠지면) 이 resolve가 실제로 적용돼 UI가 부당하게 되돌아간다 — 뮤테이션 시 ①②(아래) 두
+  // 경로 모두에서 확실히 실패한다.
   it('같은 story에 연속 발화한 두 SSE의 fetch가 역순 도착해도, 먼저 쏜(옛) fetch는 abort돼 나중 값(fetchB)이 유지된다', async () => {
     const { useSseNotifications } = await import('@/hooks/use-sse-notifications');
     let capturedOnExtraEvent: ((eventName: string, data: unknown) => void) | undefined;
@@ -355,16 +366,18 @@ describe('StoryDetailPanel — Workcell pipelineStage SSE 라이브 갱신(story
     const story = makeStory({ id: 'story-x', status: 'in-progress', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], trust_stage: 'running' });
 
     let callCount = 0;
-    let rejectFirstCall: ((e: unknown) => void) | undefined;
+    let firstSignal: AbortSignal | undefined;
+    let resolveFirstCall: ((v: unknown) => void) | undefined;
     let resolveSecondCall: ((v: unknown) => void) | undefined;
     vi.stubGlobal('fetch', vi.fn((url: string, init?: { signal?: AbortSignal }) => {
       if (typeof url === 'string' && /\/api\/stories\/story-x(\?|$)/.test(url)) {
         callCount += 1;
         const thisCall = callCount;
         return new Promise((resolve, reject) => {
-          if (thisCall === 1) rejectFirstCall = reject;
+          if (thisCall === 1) { firstSignal = init?.signal; resolveFirstCall = resolve; }
           if (thisCall === 2) resolveSecondCall = resolve;
-          // 실 fetch abort 동형 — signal이 abort되면 pending promise가 AbortError로 reject.
+          // 실 fetch의 네이티브 동작 시뮬레이션(수동 개입 아님) — signal이 abort되면 그 즉시
+          // pending promise가 죽는다. 프로덕션이 실제로 .abort()를 호출했을 때만 발동.
           init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
         });
       }
@@ -381,13 +394,15 @@ describe('StoryDetailPanel — Workcell pipelineStage SSE 라이브 갱신(story
     await act(async () => { capturedOnExtraEvent!('story.trust_stage_changed', { story_id: 'story-x', new_stage: 'needs_input' }); });
     await act(async () => { vi.advanceTimersByTime(500); await Promise.resolve(); });
     expect(callCount).toBe(1);
+    expect(firstSignal?.aborted).toBe(false); // 아직 E2 前 — abort 안 됨.
 
     // E2 — fetchA가 아직 in-flight인 채로 새 이벤트 발화 → 디바운스 재소진 시점에 fetchA를
     // abort하고 fetchB를 발사한다.
     await act(async () => { capturedOnExtraEvent!('story.trust_stage_changed', { story_id: 'story-x', new_stage: 'verified' }); });
     await act(async () => { vi.advanceTimersByTime(500); await Promise.resolve(); });
     expect(callCount).toBe(2);
-    expect(rejectFirstCall).toBeDefined(); // fetchA의 signal이 실제로 abort listener를 받음.
+    // ①수동 개입 없는 직접 assert — 프로덕션이 실제로 이전 컨트롤러를 abort했는지.
+    expect(firstSignal?.aborted).toBe(true);
 
     // fetchB(나중 이벤트) 먼저 도착 — 최신값(Verified) 반영.
     await act(async () => {
@@ -396,13 +411,15 @@ describe('StoryDetailPanel — Workcell pipelineStage SSE 라이브 갱신(story
     });
     expect(currentStageLabel()).toBe('Verified');
 
-    // fetchA(먼저 쏜 옛 fetch)가 이제야 응답 — abort로 이미 reject됐으므로 .then은 아예 실행
-    // 안 되지만, 방어적으로 늦게 resolve를 시도해도(실 abort면 불가능하지만) 무해함을 재확認.
+    // ③fetchA(먼저 쏜 옛 fetch)를 성공 응답으로 resolve — 진짜 역순 «성공» 도착 재현(수동
+    // reject 없음). 진짜 abort됐다면(firstSignal.aborted===true, 위에서 이미 확認) 이
+    // promise는 abort 리스너가 이미 reject해 settled 상태라 이 resolve 시도는 무해한 no-op.
     await act(async () => {
-      try { rejectFirstCall!(new DOMException('Aborted', 'AbortError')); } catch { /* already settled */ }
+      resolveFirstCall!({ ok: true, json: async () => ({ data: { ...story, trust_stage: 'needs_input' } }) });
       await Promise.resolve(); await Promise.resolve();
     });
-    expect(currentStageLabel()).toBe('Verified'); // 역순 도착에도 회귀 없음.
+    // ②늦은 «성공» 응답이 부당 반영되지 않았는지 — Verified 유지.
+    expect(currentStageLabel()).toBe('Verified');
   });
 });
 

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -365,11 +365,16 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   // story #2933 H2(P0-H) — Workcell 스테퍼(pipelineStage, H1이 story.trust_stage 직결로 배선)를
   // `story.trust_stage_changed` SSE로 라이브 갱신한다. AttentionQueueView(story #2923)와 동형
   // 패턴 — SSE payload를 신뢰의 소스로 안 쓰고(트리거로만) 실제 값은 항상 REST 재조회로 얻는다
-  // (진실은 서버). undefined=아직 SSE 오버라이드 없음(story prop의 trust_stage 그대로 씀),
-  // navigate away(story.id 변경)하면 리셋 — 다른 story의 값이 새 story 카드에 새는 것 방지.
+  // (진실은 서버). undefined=아직 SSE 오버라이드 없음(story prop의 trust_stage 그대로 씀).
   const [ssePipelineStage, setSsePipelineStage] = useState<WorkcellPipelineStage | null | undefined>(undefined);
   const sseDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // PO 리뷰 MEDIUM(PR#3363, 2026-08-22) — story.id 변경 시 「대기 중 타이머」는 지워져도
+  // 「이미 발화해 in-flight인 fetch」는 못 막는다. 늦게 도착한 응답이 새 story 패널에 옛
+  // story의 stage를 override로 붙이는 레이스였다 — 해소 시점에 「fetch를 쏜 id == 지금 보고
+  // 있는 id」를 대조해야 진짜로 막힌다(리셋만으론 pre-fetch 케이스만 덮고 in-flight는 못 덮음).
+  const currentStoryIdRef = useRef(story.id);
   useEffect(() => {
+    currentStoryIdRef.current = story.id;
     setSsePipelineStage(undefined);
     return () => {
       if (sseDebounceRef.current) clearTimeout(sseDebounceRef.current);
@@ -379,15 +384,19 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const handleTrustStageChanged = useCallback((_eventName: string, data: unknown) => {
     if (typeof data !== 'object' || data === null) return;
     if ((data as Record<string, unknown>)['story_id'] !== story.id) return;
+    const firedForId = story.id; // 클로저 캡처 — 이 콜백은 story.id별로 useCallback 재생성됨.
     if (sseDebounceRef.current) clearTimeout(sseDebounceRef.current);
     sseDebounceRef.current = setTimeout(() => {
       sseDebounceRef.current = null;
       // story #2933 H2(PO 조건②) — 재파생 폴백 없음: SSE payload의 new_stage를 바로 안 쓰고
       // (그 값은 트리거일 뿐), get_story(H1이 trust_stage 배선한 그 엔드포인트)를 다시 불러
       // BE 판정값을 그대로 반영한다. 실패하면 조용히 무시(기존 표시값 유지 — 재파생 0).
-      fetchWithAuth(`/api/stories/${story.id}`)
+      fetchWithAuth(`/api/stories/${firedForId}`)
         .then((r) => (r.ok ? r.json() : null))
         .then((json) => {
+          // 레이스 가드 — fetch를 쏜 뒤 다른 story로 전환됐으면(currentStoryIdRef가 그새
+          // 바뀜) 늦게 도착한 이 응답은 버린다. 새 story 패널에 옛 값이 새는 것 방지.
+          if (currentStoryIdRef.current !== firedForId) return;
           const fresh = json?.data as { trust_stage?: WorkcellPipelineStage | null } | undefined;
           if (fresh && 'trust_stage' in fresh) setSsePipelineStage(fresh.trust_stage ?? null);
         })

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -26,6 +26,7 @@ import { EvidenceSection } from '@/components/verify/evidence-section';
 import { ChatProofSection, parseStoryProofReferences } from '@/components/verify/chat-proof-section';
 import { deriveInFlightTrustChip, pickRelevantMergeGate } from '@/services/verify';
 import { Workcell, type WorkcellMessage, type WorkcellPipelineStage } from '@/components/workcell/workcell';
+import { useSseNotifications } from '@/hooks/use-sse-notifications';
 import type { ProofState, ProofCapsuleEvidence, ProofCapsuleGate, ProofCapsuleProps } from '@/components/proof-capsule/proof-capsule';
 import type { TrustSealClaimedProps, TrustSealVerifiedProps } from '@/components/verify/trust-seal';
 import { initials, formatDate } from '@/lib/storage/format';
@@ -360,6 +361,44 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [savingTitle, setSavingTitle] = useState(false);
   const [savingStatus, setSavingStatus] = useState(false);
   const [localStatus, setLocalStatus] = useState(story.status);
+
+  // story #2933 H2(P0-H) — Workcell 스테퍼(pipelineStage, H1이 story.trust_stage 직결로 배선)를
+  // `story.trust_stage_changed` SSE로 라이브 갱신한다. AttentionQueueView(story #2923)와 동형
+  // 패턴 — SSE payload를 신뢰의 소스로 안 쓰고(트리거로만) 실제 값은 항상 REST 재조회로 얻는다
+  // (진실은 서버). undefined=아직 SSE 오버라이드 없음(story prop의 trust_stage 그대로 씀),
+  // navigate away(story.id 변경)하면 리셋 — 다른 story의 값이 새 story 카드에 새는 것 방지.
+  const [ssePipelineStage, setSsePipelineStage] = useState<WorkcellPipelineStage | null | undefined>(undefined);
+  const sseDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    setSsePipelineStage(undefined);
+    return () => {
+      if (sseDebounceRef.current) clearTimeout(sseDebounceRef.current);
+    };
+  }, [story.id]);
+
+  const handleTrustStageChanged = useCallback((_eventName: string, data: unknown) => {
+    if (typeof data !== 'object' || data === null) return;
+    if ((data as Record<string, unknown>)['story_id'] !== story.id) return;
+    if (sseDebounceRef.current) clearTimeout(sseDebounceRef.current);
+    sseDebounceRef.current = setTimeout(() => {
+      sseDebounceRef.current = null;
+      // story #2933 H2(PO 조건②) — 재파생 폴백 없음: SSE payload의 new_stage를 바로 안 쓰고
+      // (그 값은 트리거일 뿐), get_story(H1이 trust_stage 배선한 그 엔드포인트)를 다시 불러
+      // BE 판정값을 그대로 반영한다. 실패하면 조용히 무시(기존 표시값 유지 — 재파생 0).
+      fetchWithAuth(`/api/stories/${story.id}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((json) => {
+          const fresh = json?.data as { trust_stage?: WorkcellPipelineStage | null } | undefined;
+          if (fresh && 'trust_stage' in fresh) setSsePipelineStage(fresh.trust_stage ?? null);
+        })
+        .catch(() => { /* 무시 — 기존 표시값 유지, 재파생 안 함 */ });
+    }, 500);
+  }, [story.id]);
+
+  useSseNotifications({
+    extraEventNames: ['story.trust_stage_changed'],
+    onExtraEvent: handleTrustStageChanged,
+  });
 
   const [editingDescription, setEditingDescription] = useState(false);
   const [descriptionDraft, setDescriptionDraft] = useState(story.description ?? '');
@@ -762,10 +801,13 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   // 판정은 BE 한 곳(trust_pipeline.derive_trust_stage)에만 존재, FE 재계산 0.
   // PO 조건②(2933) — story prop이 이 필드를 못 채운 응답에서 온 경우(예: handleChangeStatus의
   // `onStoryUpdate?.({ ...story, status: newStatus })` 낙관적 갱신 — status만 덮어쓰고
-  // trust_stage는 스프레드로 이전 값이 그대로 남는다)도 이 한 줄이 "기존값 유지"를 자동으로
-  // 만족한다 — 별도 로컬 state/재파생 폴백을 얹지 않는다. 뮤테이션 직후의 실시간 갱신은
-  // H2(SSE 구독) 몫.
-  const pipelineStage: WorkcellPipelineStage | null = (story.trust_stage as WorkcellPipelineStage | null) ?? null;
+  // trust_stage는 스프레드로 이전 값이 그대로 남는다)도 "기존값 유지"를 자동으로 만족한다 —
+  // 별도 재파생 폴백은 없다. story #2933 H2 — ssePipelineStage(위, `story.trust_stage_changed`
+  // 구독 결과)가 있으면 그걸 우선(더 최신 BE 조회값), 없으면(SSE 미도달·아직 이 story에서
+  // 이벤트 0건) story prop 그대로.
+  const pipelineStage: WorkcellPipelineStage | null = ssePipelineStage !== undefined
+    ? ssePipelineStage
+    : (story.trust_stage as WorkcellPipelineStage | null) ?? null;
   const assigneeIds = story.assignee_ids?.length ? story.assignee_ids : (story.assignee_id ? [story.assignee_id] : []);
   const proofHumanId = assigneeIds.find((id) => memberMap[id] && memberMap[id]!.type !== 'agent');
   const proofAgentId = assigneeIds.find((id) => memberMap[id]?.type === 'agent');

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -373,11 +373,21 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   // story의 stage를 override로 붙이는 레이스였다 — 해소 시점에 「fetch를 쏜 id == 지금 보고
   // 있는 id」를 대조해야 진짜로 막힌다(리셋만으론 pre-fetch 케이스만 덮고 in-flight는 못 덮음).
   const currentStoryIdRef = useRef(story.id);
+  // PO 리뷰 확장(PR#3363 codex 교차모델, 2026-08-22) — 위 currentStoryIdRef 가드는 "다른
+  // story로 전환"만 막는다. 같은 story에 연속 발화한 두 SSE 이벤트(E1 debounce 만료→fetchA
+  // in-flight 상태에서 E2 도착→fetchB 발사)의 응답이 네트워크에서 역순 도착하면(B 먼저,
+  // A 나중) — 둘 다 firedForId가 같아 위 가드를 통과하고, 나중에 도착한(=먼저 쏜, 더 옛
+  // stage인) A가 이미 반영된 B(더 신선한 stage)를 덮어써 부당 회귀한다(다음 SSE 없으면
+  // 자체 회복 안 됨). 처방: AbortController로 in-flight 자체를 최대 1개로 강제 — 새 fetch를
+  // 쏘기 직전 이전 컨트롤러를 abort하면 오래된 fetch는 AbortError로 죽어 절대 응답을
+  // 반영하지 못한다(순서 문제가 "가장 최근 것만 살아있다"는 불변식으로 구조적 소멸).
+  const fetchAbortRef = useRef<AbortController | null>(null);
   useEffect(() => {
     currentStoryIdRef.current = story.id;
     setSsePipelineStage(undefined);
     return () => {
       if (sseDebounceRef.current) clearTimeout(sseDebounceRef.current);
+      fetchAbortRef.current?.abort();
     };
   }, [story.id]);
 
@@ -388,10 +398,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     if (sseDebounceRef.current) clearTimeout(sseDebounceRef.current);
     sseDebounceRef.current = setTimeout(() => {
       sseDebounceRef.current = null;
+      // 이전 in-flight fetch를 abort — 동시 in-flight 0건 불변식(위 주석). 새 컨트롤러로 교체.
+      fetchAbortRef.current?.abort();
+      const controller = new AbortController();
+      fetchAbortRef.current = controller;
       // story #2933 H2(PO 조건②) — 재파생 폴백 없음: SSE payload의 new_stage를 바로 안 쓰고
       // (그 값은 트리거일 뿐), get_story(H1이 trust_stage 배선한 그 엔드포인트)를 다시 불러
       // BE 판정값을 그대로 반영한다. 실패하면 조용히 무시(기존 표시값 유지 — 재파생 0).
-      fetchWithAuth(`/api/stories/${firedForId}`)
+      fetchWithAuth(`/api/stories/${firedForId}`, { signal: controller.signal })
         .then((r) => (r.ok ? r.json() : null))
         .then((json) => {
           // 레이스 가드 — fetch를 쏜 뒤 다른 story로 전환됐으면(currentStoryIdRef가 그새
@@ -400,7 +414,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
           const fresh = json?.data as { trust_stage?: WorkcellPipelineStage | null } | undefined;
           if (fresh && 'trust_stage' in fresh) setSsePipelineStage(fresh.trust_stage ?? null);
         })
-        .catch(() => { /* 무시 — 기존 표시값 유지, 재파생 안 함 */ });
+        .catch(() => { /* 무시(abort 포함) — 기존 표시값 유지, 재파생 안 함 */ });
     }, 500);
   }, [story.id]);
 


### PR DESCRIPTION
## 요약
story #2933(P0-H) H2 슬라이스. **H1(#3362) 위에 쌓은 브랜치 — base가 develop이 아니라 feat/2933-h1-trust-stage-sot**(H1 머지 후 자동으로 develop 대상으로 재조정됨). H1이 배선한 `pipelineStage`(=`story.trust_stage`)가 story 재진입/org-switch에만 갱신되던 갭(AC "새로고침 없이" 요건)을 `story.trust_stage_changed` SSE 구독으로 메운다.

## 변경
- `story-detail-panel.tsx`: `useSseNotifications({ extraEventNames: ['story.trust_stage_changed'], onExtraEvent })` 구독(AttentionQueueView, story #2923와 동형 패턴). 이 패널이 보는 story_id와 일치하는 이벤트만 반응. SSE payload는 트리거로만 쓰고, 500ms 디바운스 後 `GET /api/stories/{id}`(H1 배선 엔드포인트)를 재조회해 값을 반영(진실은 항상 서버). `story.id`가 바뀌면(다른 story로 네비게이션) 오버라이드 리셋 — 값이 안 샌다. PO 조건②(재파생 폴백 금지) 유지 — fetch 실패는 조용히 무시(기존 표시값 유지).

## 검증
- 신규 테스트 2건(verify-rail.test.tsx #2467 respec과 동형 관례): 일치 story_id 이벤트→재조회로 갱신·불일치 story_id는 무시 둘 다 green.
- 기존 story-detail-panel.test.tsx 전부 무회귀.
- FE: tsc/eslint 0·vitest 전체 477 files/4046 tests green·contrast 가드 4종 신규위반 0·build 0.

## 스크린샷
라이브 dev 배포 후 카디르군 QA 단계에서 실측 예정(SSE 라이브 갱신은 정적 스크린샷으로 증명이 약해 동영상/GIF 검토).

🤖 Generated with [Claude Code](https://claude.com/claude-code)