### PR TITLE
[SID:2933] H3 — 정직성 감사(trustChip BE 수렴)

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -224,6 +224,50 @@ describe('StoryDetailPanel — Workcell pipelineStage = story.trust_stage 직결
   });
 });
 
+// story #2933 H3(P0-H 정직성 감사, PO 부수기록ⓐ) — P0-04 in-flight 칩(trustChip, 제목 옆
+// "입력 필요"/"병합 대기" 배지)도 구 gate-목록 재파생(deriveInFlightTrustChip, 폐기됨)이 아니라
+// pipelineStage(=story.trust_stage, H1) 하나로 수렴했는지 고정. gate fetch 응답과 무관해야
+// 한다(H1의 스테퍼 테스트와 동일 취지) — chipGates는 fetch 실패(stubFetch)로 항상 빈 배열.
+describe('StoryDetailPanel — trustChip도 story.trust_stage로 수렴(story #2933 H3)', () => {
+  const HUMAN_ID = 'human-1';
+  const memberMap = { [HUMAN_ID]: { id: HUMAN_ID, name: '책임자', type: 'human' } };
+
+  async function mountWithTrustStage(trustStage: KanbanStory['trust_stage']) {
+    stubFetch();
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel
+          story={makeStory({ status: 'in-progress', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], trust_stage: trustStage })}
+          tasks={[]} onClose={() => {}} memberMap={memberMap}
+        />,
+      ));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+  }
+
+  it('trust_stage="needs_input" → "입력 필요" 칩(gate fetch는 항상 실패 응답 — 무관하게 뜬다)', async () => {
+    await mountWithTrustStage('needs_input');
+    expect(container.textContent).toContain('입력 필요');
+  });
+
+  it('trust_stage="merge_ready" → "병합 대기" 칩', async () => {
+    await mountWithTrustStage('merge_ready');
+    expect(container.textContent).toContain('병합 대기');
+  });
+
+  it('trust_stage="running"(needs_input/merge_ready 둘 다 아님) → 칩 자체가 안 뜬다', async () => {
+    await mountWithTrustStage('running');
+    expect(container.textContent).not.toContain('입력 필요');
+    expect(container.textContent).not.toContain('병합 대기');
+  });
+
+  it('trust_stage=null(done 등) → 칩 미표시(TrustSeal과 동어반복 금지, 구 deriveInFlightTrustChip의 done 강제와 결과 동일)', async () => {
+    await mountWithTrustStage(null);
+    expect(container.textContent).not.toContain('입력 필요');
+    expect(container.textContent).not.toContain('병합 대기');
+  });
+});
+
 // story #2933 H2(P0-H) — Workcell 스테퍼가 `story.trust_stage_changed` SSE를 라이브 갱신
 // 트리거로 쓰는지(AttentionQueueView, story #2923와 동형 패턴). SSE payload 자체는 신뢰의
 // 소스가 아니다(트리거일 뿐) — REST 재조회(GET /api/stories/{id})의 값만 반영한다(PO 조건②

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -266,6 +266,54 @@ describe('StoryDetailPanel — trustChip도 story.trust_stage로 수렴(story #2
     expect(container.textContent).not.toContain('입력 필요');
     expect(container.textContent).not.toContain('병합 대기');
   });
+
+  // ⚠️QA changes(PR#3364, codex 교차모델, 2026-08-22) — 구 deriveInFlightTrustChip이 갖고
+  // 있던 "status==='done'이면 무조건 null" 하드가드가 trustChip을 story.trust_stage 하나로
+  // 수렴시키는 과정에서 소실됐다. handleChangeStatus의 낙관적 done 전이는 localStatus를 즉시
+  // 'done'으로 바꾸지만(L915), story.trust_stage는 PATCH /status 응답이 돌아와 onStoryUpdate가
+  // 호출될 때까지(그마저도 spread로 옛 값을 보존 — PO 조건②) 그대로 남는다 — 그 창에서
+  // "done인데 in-flight 칩 표시"라는 부당 상태가 뜬다(codex 실물 재현). 이 테스트는 PATCH
+  // 응답을 deferred로 붙잡아 그 창을 직접 관측한다.
+  it('낙관적 done 전이 직후(trust_stage는 아직 옛값) — trustChip이 즉시 사라진다(localStatus 우선)', async () => {
+    let resolveStatusPatch: ((v: unknown) => void) | undefined;
+    const statusPatchPromise = new Promise((resolve) => { resolveStatusPatch = resolve; });
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (typeof url === 'string' && /\/api\/stories\/s1\/status(\?|$)/.test(url)) {
+        return statusPatchPromise as Promise<{ ok: boolean; json: () => Promise<unknown> }>;
+      }
+      return { ok: false, json: async () => null };
+    }));
+
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel
+          story={makeStory({ status: 'in-review', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID], trust_stage: 'needs_input' })}
+          tasks={[]} onClose={() => {}} memberMap={memberMap}
+        />,
+      ));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain('입력 필요'); // 전이 前 — 기존 칩 정상 표시.
+
+    const statusTrigger = document.body.querySelector('button[aria-label="Status"], button[aria-label="상태"]') as HTMLButtonElement | null;
+    expect(statusTrigger).toBeTruthy();
+    await act(async () => { statusTrigger!.click(); });
+    const doneItem = [...document.body.querySelectorAll('[role="menuitem"], button')]
+      .find((el) => el.textContent?.trim() === '완료') as HTMLButtonElement | undefined;
+    expect(doneItem).toBeTruthy();
+    await act(async () => { doneItem!.click(); }); // handleChangeStatus('done') → localStatus 즉시 'done', PATCH는 deferred.
+
+    // 낙관 전이 직후 — story.trust_stage(=pipelineStage)는 여전히 'needs_input'이지만
+    // localStatus는 이미 'done'. 칩이 남아있으면 회귀.
+    expect(container.textContent).not.toContain('입력 필요');
+    expect(container.textContent).not.toContain('병합 대기');
+
+    await act(async () => {
+      resolveStatusPatch!({ ok: true, json: async () => ({ data: { violation: null } }) });
+      await Promise.resolve(); await Promise.resolve();
+    });
+    expect(container.textContent).not.toContain('입력 필요'); // PATCH 완료 後에도 계속 미표시.
+  });
 });
 
 // story #2933 H2(P0-H) — Workcell 스테퍼가 `story.trust_stage_changed` SSE를 라이브 갱신

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -832,9 +832,20 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   // pipelineStage의 needs_input/merge_ready가 정확히 같은 개념(BE 판정 SoT, H1)이라 그대로
   // 재사용 — FE 재파생의 두 번째 온상을 닫는다(H1이 스테퍼 쪽을, 이번엔 이 배지 쪽을).
   // done엔 pipelineStage 자체가 이미 null(derive_trust_stage §7 확定④)이라 구 함수가 하던
-  // "담당·중복 금지" 강제를 별도 코드 없이 그대로 계승한다.
-  const trustChip: 'needs_input' | 'merge_ready' | null =
-    pipelineStage === 'needs_input' ? 'needs_input' : pipelineStage === 'merge_ready' ? 'merge_ready' : null;
+  // "담당·중복 금지" 강제를 별도 코드 없이 그대로 계승한다 — 단, 이건 story.trust_stage가
+  // 실제로 서버에서 새로 온 경우에만 참이다.
+  // ⚠️QA changes(PR#3364, codex 교차모델, 2026-08-22) — handleChangeStatus의 낙관적 갱신은
+  // `onStoryUpdate?.({ ...story, status: newStatus })`로 status만 덮어쓰고 trust_stage는
+  // 스프레드로 «이전 값 그대로» 남긴다(PO 조건②·바로 위 주석). localStatus는 이 낙관 갱신으로
+  // 즉시 'done'이 되지만, pipelineStage(=story.trust_stage)는 실 BE 재조회(SSE 트리거
+  // 재fetch)가 도착하기 전까지 옛 값(예: 'needs_input')에 머무는 창이 생긴다 — 그 창에서
+  // "done인데 in-flight 칩"이 뜨는 부당 표시(구 deriveInFlightTrustChip이 갖고 있던
+  // status==='done' 하드가드가 수렴 과정에서 소실됐던 회귀). localStatus==='done'이면
+  // pipelineStage 값과 무관하게 명시적으로 차단 — 낙관 갱신 창의 신뢰 축을 status(즉시 반영)
+  // 로 고정한다(pipelineStage는 곧 뒤따라 null로 수렴하지만 그 사이 창을 UI에 노출 안 함).
+  const trustChip: 'needs_input' | 'merge_ready' | null = localStatus === 'done'
+    ? null
+    : pipelineStage === 'needs_input' ? 'needs_input' : pipelineStage === 'merge_ready' ? 'merge_ready' : null;
   const trustChipLabel = trustChip === 'needs_input' ? t('trustChipNeedsInput') : trustChip === 'merge_ready' ? t('trustChipMergeReady') : null;
 
   const assigneeIds = story.assignee_ids?.length ? story.assignee_ids : (story.assignee_id ? [story.assignee_id] : []);

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -24,7 +24,7 @@ import { StoryHypothesesSection } from '@/components/hypotheses/story-hypotheses
 import { StoryMergeGate } from '@/components/cage/story-merge-gate';
 import { EvidenceSection } from '@/components/verify/evidence-section';
 import { ChatProofSection, parseStoryProofReferences } from '@/components/verify/chat-proof-section';
-import { deriveInFlightTrustChip, pickRelevantMergeGate } from '@/services/verify';
+import { pickRelevantMergeGate } from '@/services/verify';
 import { Workcell, type WorkcellMessage, type WorkcellPipelineStage } from '@/components/workcell/workcell';
 import { useSseNotifications } from '@/hooks/use-sse-notifications';
 import type { ProofState, ProofCapsuleEvidence, ProofCapsuleGate, ProofCapsuleProps } from '@/components/proof-capsule/proof-capsule';
@@ -803,11 +803,6 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const statusKey = statusKeyMap[localStatus];
   const statusLabel = statusKey ? t(statusKey) : localStatus;
 
-  // P0-04(trust-pipeline-minimal-decision) — in-flight 전용 칩. done엔 항상 무표시(TrustSeal
-  // 담당·중복 금지, deriveInFlightTrustChip 내부에서 강제). 무신호=칩 자체 미렌더(no-fiction).
-  const trustChip = deriveInFlightTrustChip(localStatus, chipGates);
-  const trustChipLabel = trustChip === 'needs_input' ? t('trustChipNeedsInput') : trustChip === 'merge_ready' ? t('trustChipMergeReady') : null;
-
   // E-UI-DAEGBYEON P0 — Workcell 최소 실화면 배선(story `e5310d1b`, dead-path 방지).
   // 정직한 최소 표면: 실 필드(title/status/assignee/description/acceptance_criteria/
   // blocked_by/comments)만으로 채울 수 있는 것만 채운다 — 없는 값은 허구로 안 채움:
@@ -831,6 +826,17 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const pipelineStage: WorkcellPipelineStage | null = ssePipelineStage !== undefined
     ? ssePipelineStage
     : (story.trust_stage as WorkcellPipelineStage | null) ?? null;
+
+  // story #2933 H3(P0-H 정직성 감사, PO 부수기록ⓐ) — P0-04 in-flight 칩(trustChip)도 BE
+  // trust_stage로 수렴한다. 예전엔 deriveInFlightTrustChip(gate 목록 별도 재파생)이 판정했는데
+  // pipelineStage의 needs_input/merge_ready가 정확히 같은 개념(BE 판정 SoT, H1)이라 그대로
+  // 재사용 — FE 재파생의 두 번째 온상을 닫는다(H1이 스테퍼 쪽을, 이번엔 이 배지 쪽을).
+  // done엔 pipelineStage 자체가 이미 null(derive_trust_stage §7 확定④)이라 구 함수가 하던
+  // "담당·중복 금지" 강제를 별도 코드 없이 그대로 계승한다.
+  const trustChip: 'needs_input' | 'merge_ready' | null =
+    pipelineStage === 'needs_input' ? 'needs_input' : pipelineStage === 'merge_ready' ? 'merge_ready' : null;
+  const trustChipLabel = trustChip === 'needs_input' ? t('trustChipNeedsInput') : trustChip === 'merge_ready' ? t('trustChipMergeReady') : null;
+
   const assigneeIds = story.assignee_ids?.length ? story.assignee_ids : (story.assignee_id ? [story.assignee_id] : []);
   const proofHumanId = assigneeIds.find((id) => memberMap[id] && memberMap[id]!.type !== 'agent');
   const proofAgentId = assigneeIds.find((id) => memberMap[id]?.type === 'agent');

--- a/apps/web/src/services/verify.test.ts
+++ b/apps/web/src/services/verify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deriveTrustStage, deriveInFlightTrustChip, pickRelevantMergeGate } from './verify';
+import { deriveTrustStage, pickRelevantMergeGate } from './verify';
 
 describe('deriveTrustStage (claimed-vs-verified-spec-handoff §3 파생 규칙)', () => {
   it('returns "verified" when human_verified is true (green 무결성 — human_verified가 유일한 green 조건)', () => {
@@ -21,42 +21,10 @@ describe('deriveTrustStage (claimed-vs-verified-spec-handoff §3 파생 규칙)'
   });
 });
 
-describe('deriveInFlightTrustChip (trust-pipeline-minimal-decision — in-flight 전용 칩)', () => {
-  it('returns "needs_input" when one of the 3 always-manual gate types is pending', () => {
-    expect(deriveInFlightTrustChip('in-review', [{ gate_type: 'loop_decision', status: 'pending' }])).toBe('needs_input');
-    expect(deriveInFlightTrustChip('in-review', [{ gate_type: 'doc_approval', status: 'pending' }])).toBe('needs_input');
-    expect(deriveInFlightTrustChip('in-review', [{ gate_type: 'artifact_canonicalize', status: 'pending' }])).toBe('needs_input');
-  });
-
-  it('returns "merge_ready" when a pending merge gate has ci_result=pass', () => {
-    expect(deriveInFlightTrustChip('in-review', [
-      { gate_type: 'merge', status: 'pending', neutral_facts: { ci_result: 'pass' } },
-    ])).toBe('merge_ready');
-  });
-
-  it('never returns a chip when story.status is "done" — TrustSeal already owns that surface (no duplication)', () => {
-    expect(deriveInFlightTrustChip('done', [{ gate_type: 'loop_decision', status: 'pending' }])).toBeNull();
-    expect(deriveInFlightTrustChip('done', [
-      { gate_type: 'merge', status: 'pending', neutral_facts: { ci_result: 'pass' } },
-    ])).toBeNull();
-  });
-
-  it('returns null when there is no honest signal (no-fiction — no gates, non-pending gates, or ci_result != pass)', () => {
-    expect(deriveInFlightTrustChip('in-progress', [])).toBeNull();
-    expect(deriveInFlightTrustChip('in-progress', [{ gate_type: 'loop_decision', status: 'approved' }])).toBeNull();
-    expect(deriveInFlightTrustChip('in-progress', [
-      { gate_type: 'merge', status: 'pending', neutral_facts: { ci_result: 'fail' } },
-    ])).toBeNull();
-    expect(deriveInFlightTrustChip('in-progress', [{ gate_type: 'merge', status: 'pending' }])).toBeNull();
-  });
-
-  it('prefers merge_ready over needs_input when both are somehow pending simultaneously', () => {
-    expect(deriveInFlightTrustChip('in-review', [
-      { gate_type: 'loop_decision', status: 'pending' },
-      { gate_type: 'merge', status: 'pending', neutral_facts: { ci_result: 'pass' } },
-    ])).toBe('merge_ready');
-  });
-});
+// story #2933 H3(P0-H 정직성 감사) — deriveInFlightTrustChip(구 in-flight 칩 gate-목록 재파생)
+// 은 story-detail-panel.tsx의 유일한 소비처를 잃고 폐기됐다(story.trust_stage로 수렴, BE
+// derive_trust_stage() SoT 하나만 남김). 이 describe 블록도 함께 제거 — 죽은 함수의 테스트를
+// 남겨두면 "아직 쓰인다"는 착시가 생긴다.
 
 // story #2893(설계안 §2 A1) — 스토리당 merge 게이트가 여러 개(PR마다 1개)일 수 있다.
 describe('pickRelevantMergeGate (story #2893 — PR단위 게이트 중 하나를 고르는 축)', () => {

--- a/apps/web/src/services/verify.ts
+++ b/apps/web/src/services/verify.ts
@@ -47,38 +47,6 @@ export function deriveTrustStage(signal: TrustSignal): TrustStage {
   return null;
 }
 
-/**
- * P0-04 — trust-pipeline-minimal-decision(doc) 결정: 6레인 대시보드 기각·in-flight 전용 칩만
- * 채택. done(주장됨/검증됨)엔 칩 0(TrustSeal이 담당·중복 금지). Queued/Running/범위이탈은
- * BE 신호 자체가 없어(AgentRun story_id 필터 미착지·범위 스키마 무) 렌더 안 함(no-fiction).
- */
-export type InFlightTrustChip = 'needs_input' | 'merge_ready' | null;
-
-interface ChipGate {
-  gate_type: string;
-  status: string;
-  neutral_facts?: Record<string, unknown> | null;
-}
-
-// _ALWAYS_MANUAL_GATE_TYPES(BE gate_service.py) 미러 — 항상 사람 입력 대기.
-const NEEDS_INPUT_GATE_TYPES = new Set(['doc_approval', 'loop_decision', 'artifact_canonicalize']);
-
-/**
- * 결정 doc §스펙: Needs-input(gate 3종 pending)→"입력 필요"(amber)·Merge-ready(merge gate+
- * ci_result=pass+pending)→"병합 대기"(green). story.status==='done'이면 항상 무표시.
- */
-export function deriveInFlightTrustChip(storyStatus: string, gates: ChipGate[]): InFlightTrustChip {
-  if (storyStatus === 'done') return null;
-  const pending = gates.filter((g) => g.status === 'pending');
-  if (pending.some((g) => g.gate_type === 'merge' && g.neutral_facts?.['ci_result'] === 'pass')) {
-    return 'merge_ready';
-  }
-  if (pending.some((g) => NEEDS_INPUT_GATE_TYPES.has(g.gate_type))) {
-    return 'needs_input';
-  }
-  return null;
-}
-
 const _TERMINAL_GATE_STATUSES = new Set(['approved', 'rejected', 'voided']);
 
 /**


### PR DESCRIPTION
## 요약
story #2933(P0-H) H3 슬라이스. **H2(#3363) 위에 쌓은 브랜치 — base가 feat/2933-h2-workcell-sse-live**(H2 머지 후 자동으로 재조정됨).

계승 조각 ⓑ(done에서 TrustSeal과 동어반복 금지)·ⓒ(no-fiction, Queued/Running 정직 표기)는 H1이 `pipelineStage`를 `story.trust_stage` 직결로 바꾸며 이미 구조적으로 만족한 상태였다(done→`derive_trust_stage()`가 `None` 반환→Workcell 자체가 렌더 안 됨, queued/running은 `story.status` 그대로라 애초 fictional AgentRun 신호가 아님) — 별도 코드 수정 없이 감사 결과만 기록.

**PO 부수기록ⓐ(H2 리뷰, 2026-08-22) 판별**: P0-04 in-flight 칩(`trustChip`, 제목 옆 "입력 필요"/"병합 대기" 배지, gate-목록 기반 `deriveInFlightTrustChip`)과 `story.trust_stage`가 개념 겹침 — 수렴 여부 판단 요청.

## 판별 결과
- **trustChip → 수렴.** `pipelineStage`의 needs_input/merge_ready가 정확히 같은 개념(BE `derive_trust_stage()` SoT)이라 gate 목록 재파생을 완전히 폐기하고 `pipelineStage`에서 직접 뽑는다. 소비처가 이 파일 하나뿐이라 전환 비용 0 — `deriveInFlightTrustChip`/`InFlightTrustChip`/`NEEDS_INPUT_GATE_TYPES`를 `verify.ts`에서 완전 제거(죽은 코드 방치 금지), 테스트도 정리.
- **deriveTrustStage(TrustSeal claimed/verified 2값 배지) → 수렴 안 함(별개 축 확定).** `self_reported`/`human_verified` 원시 boolean을 그대로 읽어 라벨만 고르는 함수라 BE 로직을 독립 재계산하지 않는다(BE trust_stage도 같은 `human_verified` 신호를 읽으므로 드리프트 위험 자체가 구조적으로 없음) — "증거 신뢰수준" 배지(TrustSeal)와 "파이프라인 위치" 스테퍼(Workcell)는 이름이 비슷해도 서로 다른 UI 관심사라 그대로 둔다.

## 변경
- `story-detail-panel.tsx`: `pipelineStage` 계산을 `trustChip`보다 앞으로 이동, `trustChip`을 `pipelineStage` 기반으로 재정의(gate fetch 결과와 완전 무관해짐).
- `services/verify.ts`: `deriveInFlightTrustChip` 및 관련 타입/상수 제거.
- `services/verify.test.ts`: 해당 describe 블록 제거.

## 검증
- 신규 테스트 4건(trustChip이 `pipelineStage` 값에서만 파생됨을 gate fetch 무관하게 고정) green.
- 기존 `verify.test.ts`(`deriveTrustStage`·`pickRelevantMergeGate`, 9건)+`story-detail-panel.test.tsx` 전체(H1/H2 포함) 무회귀.
- FE: tsc/eslint 0·vitest 전체 477 files/4046 tests green·contrast 가드 4종 신규위반 0·build 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)