### PR TITLE
feat(2925): ConversationItem에 linked_proof(행 승격 신호) 동봉 — 2921-S2 선행

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -20,6 +20,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db, get_read_db
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.event import Event
+from app.models.gate import Gate
 from app.models.project import OrgMember, Project
 from app.models.team import AgentMessageAllowlist, TeamMember
 from app.models.agent_deployment import AgentAuditLog
@@ -412,6 +413,101 @@ async def _fetch_conversation_participants(
             "runtime_type": runtime_type_map.get(r.member_id),
         })
     return conv_participants
+
+
+# story #2925(2921-S2 선행, 유나 확定 스펙) — L1 대화 행을 ProofCapsule card로 승격시킬지
+# 판별하는 신호. 「참조(게이트/작업) 있는 대화만 승격·색은 참조 대상의 실제 상태가 몬다·
+# 참조 없으면 plain(fail-safe·거짓 색 금지)」(2921-S2 서면 확定). 오늘 코드베이스에서 대화가
+# 게이트를 "임베드"하는 유일한 실 메커니즘은 `dispatch_approval_request_cards`(approval_
+# delivery.py)가 심는 `msg_metadata['approval_target']['gate_id']`뿐이다 — entity_references
+# (source_type='chat_message', target_type='gate')는 이 delivery 경로가 안 거쳐(mentions
+# 추출은 insert_chat_mentions·conversations.py의 일반 send_message 경로에서만 발화) 실제로
+# 채워지지 않는다. 「작업(task) 상태」 폴백은 이 그라운딩에서 대화-임베드 메커니즘을 찾지
+# 못해(지어내지 않는다) 이번 판에는 뺐다 — gate 참조가 없으면 null(스토리 fail-safe 원칙
+# 그대로), task 전용 대화-임베드 축은 별도 결정 필요(PO/유나 확認 대상으로 완료 보고에 명시).
+#
+# 상태 매핑(PO 전달 유나 확定): rejected→violation(red) · approved/auto_passed→verified
+# (green) · pending+requires_human→pending_human(blue) · pending(아직 human 단계 아님)·
+# held→waiting(amber). voided는 4상태 어디에도 안 맞는(관리자 회수·실 판정 아님) 상태라
+# 후보에서 제외한다(거짓 색 금지 원칙 — 차라리 null이 낫다).
+def _derive_gate_proof_state(gate: "Gate") -> str | None:
+    if gate.status == "rejected":
+        return "violation"
+    if gate.status in ("approved", "auto_passed"):
+        return "verified"
+    if gate.status == "pending":
+        return "pending_human" if gate.requires_human else "waiting"
+    if gate.status == "held":
+        return "waiting"
+    return None  # voided(또는 알려지지 않은 값) — 지어내지 않는다.
+
+
+_OPEN_GATE_STATUSES = ("pending", "held")
+
+
+async def _batch_resolve_linked_proof(
+    conv_ids: list[uuid.UUID],
+    org_id: uuid.UUID,
+    db: AsyncSession,
+) -> dict[uuid.UUID, dict | None]:
+    """대화(들)의 「행 승격 신호」 배치 조회 — N+1 방지(리스트 크기 무관 쿼리 2개 고정,
+    `_fetch_conversation_participants`/unread_map과 동일 배치 패턴). 대화당 여러 approval
+    카드가 있으면(재상신 등) 열린(pending/held) 게이트를 우선하고, 없으면 가장 최근에
+    해소된 게이트를 반환한다(승인 완료도 "증명"으로서 보여줄 가치가 있다는 2916-B 원칙).
+    voided뿐이거나 참조가 아예 없으면 None(스토리의 fail-safe 원칙)."""
+    if not conv_ids:
+        return {}
+
+    approval_rows = (await db.execute(
+        select(
+            ConversationMessage.conversation_id,
+            ConversationMessage.msg_metadata["approval_target"]["gate_id"].astext.label("gate_id"),
+            ConversationMessage.created_at,
+        ).where(
+            ConversationMessage.conversation_id.in_(conv_ids),
+            ConversationMessage.msg_metadata["approval_target"]["gate_id"].astext.isnot(None),
+        )
+    )).all()
+    if not approval_rows:
+        return {}
+
+    conv_candidates: dict[uuid.UUID, list[tuple[uuid.UUID, object]]] = defaultdict(list)
+    all_gate_ids: set[uuid.UUID] = set()
+    for row in approval_rows:
+        try:
+            gate_id = uuid.UUID(row.gate_id)
+        except (ValueError, TypeError, AttributeError):
+            continue  # 손상된/구형 payload — 지어내지 않고 건너뜀.
+        conv_candidates[row.conversation_id].append((gate_id, row.created_at))
+        all_gate_ids.add(gate_id)
+
+    gates = (await db.execute(
+        select(Gate).where(Gate.id.in_(all_gate_ids), Gate.org_id == org_id)
+    )).scalars().all()
+    gate_map: dict[uuid.UUID, Gate] = {g.id: g for g in gates}
+
+    result: dict[uuid.UUID, dict | None] = {}
+    for conv_id, candidates in conv_candidates.items():
+        # 최신 배달 우선(같은 게이트가 재상신돼도 최신 참조가 "그 대화가 지금 가리키는 것").
+        candidates.sort(key=lambda c: c[1], reverse=True)
+        open_pick: Gate | None = None
+        fallback_pick: Gate | None = None
+        for gate_id, _created_at in candidates:
+            gate = gate_map.get(gate_id)
+            if gate is None or gate.status == "voided":
+                continue
+            if gate.status in _OPEN_GATE_STATUSES and open_pick is None:
+                open_pick = gate
+            elif fallback_pick is None:
+                fallback_pick = gate
+        chosen = open_pick or fallback_pick
+        if chosen is None:
+            continue
+        state = _derive_gate_proof_state(chosen)
+        if state is None:
+            continue
+        result[conv_id] = {"kind": "gate", "state": state, "gate_id": str(chosen.id)}
+    return result
 
 
 _SUMMARY_PREVIEW_MAX = 80
@@ -1313,6 +1409,9 @@ async def list_conversations(
     )).all() if conv_id_list else []
     unread_map: dict[uuid.UUID, int] = {r[0]: r[1] for r in unread_rows}
 
+    # story #2925: 행 승격 신호 배치 조회(N+1 방지 — 쿼리 2개 고정, 리스트 크기 무관).
+    linked_proof_map = await _batch_resolve_linked_proof(conv_id_list, org_id, db)
+
     result = []
     for conv in convs:
         latest_msg = (await db.execute(
@@ -1337,6 +1436,8 @@ async def list_conversations(
                 if caller_last_read_at.get(conv.id) else None
             ),
             "unread_count": unread_map.get(conv.id, 0),
+            # story #2925(2921-S2 선행) — 참조 없으면 null(fail-safe, 거짓 색 금지).
+            "linked_proof": linked_proof_map.get(conv.id),
             "latest_message": {
                 "content": latest_msg.content,
                 "created_at": latest_msg.created_at.isoformat(),

--- a/backend/tests/test_2925_conversation_linked_proof_realdb.py
+++ b/backend/tests/test_2925_conversation_linked_proof_realdb.py
@@ -133,7 +133,7 @@ def _client_for(app):
 
 async def _setup_app_human(app, Session, user_id, org_id):
     from app.dependencies.auth import AuthContext, get_current_user
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     async def _db():
         async with Session() as s:
@@ -150,7 +150,7 @@ async def _setup_app_human(app, Session, user_id, org_id):
             claims={"app_metadata": {"org_id": str(org_id)}},
         )
 
-    app.dependency_overrides[get_db] = _db
+    override_db_and_read(app, _db)
     app.dependency_overrides[get_current_user] = _auth
 
 

--- a/backend/tests/test_2925_conversation_linked_proof_realdb.py
+++ b/backend/tests/test_2925_conversation_linked_proof_realdb.py
@@ -1,0 +1,412 @@
+"""story #2925(2921-S2 선행, 유나 서면 확定) — ConversationItem에 「행 승격 신호」(linked_proof)
+동봉. L1 대화 행은 참조(게이트) 있는 대화만 ProofCapsule card로 승격·색은 참조 대상의 실제
+상태가 몬다·참조 없으면 plain(fail-safe·거짓 색 금지).
+
+그라운딩(코드 실측, 2026-08-23): 대화가 게이트를 "임베드"하는 유일한 실 메커니즘은
+`dispatch_approval_request_cards`(approval_delivery.py)가 심는
+`ConversationMessage.msg_metadata['approval_target']['gate_id']`뿐 — entity_references는
+이 경로를 안 거쳐(mentions 추출은 일반 send_message 경로에서만) 채워지지 않는다. 이 테스트는
+그 실 메커니즘을 직접 재현한다(approval_delivery.py 자체를 호출하지 않고 동형 message row를
+직접 심는다 — 이 스토리의 관심사는 list_conversations의 소비/도출 로직이지 배달 자체가 아님).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_member(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"me-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await session.commit()
+    me = Member(id=uuid.uuid4(), org_id=org.id, type="human", user_id=user_id, name="Me")
+    session.add(me)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=me.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "user_id": user_id, "member_id": me.id}
+
+
+async def _seed_conversation(session, *, org_id, project_id, member_id, title="Convo"):
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv = Conversation(
+        id=uuid.uuid4(), project_id=project_id, org_id=org_id, type="group",
+        title=title, created_by=member_id,
+    )
+    session.add(conv)
+    await session.flush()
+    session.add(ConversationParticipant(conversation_id=conv.id, member_id=member_id))
+    await session.commit()
+    return conv
+
+
+async def _seed_approval_message(session, *, conv_id, sender_id, gate_id, created_at):
+    from app.models.conversation import ConversationMessage
+
+    msg = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conv_id, sender_id=sender_id,
+        content="'X' 결재 요청", created_at=created_at,
+        msg_metadata={
+            "activation": {"audience": [str(sender_id)], "kind": "request", "expects_response": True},
+            "approval_target": {
+                "work_item_type": "story", "work_item_id": str(uuid.uuid4()),
+                "gate_id": str(gate_id), "actions": ["approve", "reject"],
+            },
+        },
+    )
+    session.add(msg)
+    await session.commit()
+    return msg
+
+
+async def _seed_gate(session, *, org_id, status, requires_human=True, work_item_id=None):
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id or uuid.uuid4(),
+        work_item_type="story", gate_type=MERGE_GATE_TYPE, status=status,
+        requires_human=requires_human,
+    )
+    session.add(gate)
+    await session.commit()
+    return gate
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+T0 = datetime(2026, 8, 23, 8, 0, 0, tzinfo=timezone.utc)
+
+
+def _t(minutes: int) -> datetime:
+    return T0 + timedelta(minutes=minutes)
+
+
+async def _list_conversations(client, project_id):
+    resp = await client.get("/api/v2/conversations", params={"project_id": str(project_id)})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["data"]
+
+
+@pytest.mark.parametrize(
+    "gate_status,requires_human,expected_state",
+    [
+        ("pending", True, "pending_human"),
+        ("pending", False, "waiting"),
+        ("held", True, "waiting"),
+        ("approved", False, "verified"),
+        ("auto_passed", False, "verified"),
+        ("rejected", False, "violation"),
+    ],
+)
+async def test_linked_proof_state_mapping(gate_status, requires_human, expected_state):
+    """게이트 status(+requires_human) → linked_proof.state 매핑(PO 전달 유나 확定 매핑)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_member(s)
+            conv = await _seed_conversation(
+                s, org_id=seeded["org_id"], project_id=seeded["project_id"], member_id=seeded["member_id"],
+            )
+            gate = await _seed_gate(
+                s, org_id=seeded["org_id"], status=gate_status, requires_human=requires_human,
+            )
+            await _seed_approval_message(
+                s, conv_id=conv.id, sender_id=seeded["member_id"], gate_id=gate.id, created_at=_t(0),
+            )
+            conv_id, gate_id = conv.id, gate.id
+
+        await _setup_app_human(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            data = await _list_conversations(client, seeded["project_id"])
+        finally:
+            await client.aclose()
+
+        assert len(data) == 1
+        assert data[0]["id"] == str(conv_id)
+        assert data[0]["linked_proof"] == {
+            "kind": "gate", "state": expected_state, "gate_id": str(gate_id),
+        }
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_linked_proof_null_when_no_gate_reference():
+    """참조(게이트) 없는 대화 = null(fail-safe·거짓 색 금지) — 스토리 핵심 불변식."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_member(s)
+            conv = await _seed_conversation(
+                s, org_id=seeded["org_id"], project_id=seeded["project_id"], member_id=seeded["member_id"],
+            )
+            conv_id = conv.id
+
+        await _setup_app_human(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            data = await _list_conversations(client, seeded["project_id"])
+        finally:
+            await client.aclose()
+
+        assert len(data) == 1
+        assert data[0]["id"] == str(conv_id)
+        assert data[0]["linked_proof"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_linked_proof_voided_gate_treated_as_no_reference():
+    """voided는 4상태 어디에도 안 맞는 관리자-회수 상태 — 거짓 색을 칠하느니 null(지어내지 않는다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_member(s)
+            conv = await _seed_conversation(
+                s, org_id=seeded["org_id"], project_id=seeded["project_id"], member_id=seeded["member_id"],
+            )
+            gate = await _seed_gate(s, org_id=seeded["org_id"], status="voided")
+            await _seed_approval_message(
+                s, conv_id=conv.id, sender_id=seeded["member_id"], gate_id=gate.id, created_at=_t(0),
+            )
+            conv_id = conv.id
+
+        await _setup_app_human(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            data = await _list_conversations(client, seeded["project_id"])
+        finally:
+            await client.aclose()
+
+        assert len(data) == 1
+        assert data[0]["id"] == str(conv_id)
+        assert data[0]["linked_proof"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_linked_proof_prefers_open_gate_over_resolved_when_both_referenced():
+    """한 대화에 재상신 등으로 게이트 참조가 둘(하나 closed·하나 open)이면 열린 쪽 우선
+    (스토리 「열린 게이트(우선)」 원칙)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_member(s)
+            conv = await _seed_conversation(
+                s, org_id=seeded["org_id"], project_id=seeded["project_id"], member_id=seeded["member_id"],
+            )
+            closed_gate = await _seed_gate(s, org_id=seeded["org_id"], status="approved")
+            open_gate = await _seed_gate(s, org_id=seeded["org_id"], status="pending", requires_human=True)
+            # closed가 먼저(과거) 배달, open이 나중(최신) — 실제 재상신 흐름과 동형.
+            await _seed_approval_message(
+                s, conv_id=conv.id, sender_id=seeded["member_id"], gate_id=closed_gate.id, created_at=_t(0),
+            )
+            await _seed_approval_message(
+                s, conv_id=conv.id, sender_id=seeded["member_id"], gate_id=open_gate.id, created_at=_t(5),
+            )
+            conv_id, open_gate_id = conv.id, open_gate.id
+
+        await _setup_app_human(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            data = await _list_conversations(client, seeded["project_id"])
+        finally:
+            await client.aclose()
+
+        assert len(data) == 1
+        assert data[0]["id"] == str(conv_id)
+        assert data[0]["linked_proof"] == {
+            "kind": "gate", "state": "pending_human", "gate_id": str(open_gate_id),
+        }
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_linked_proof_falls_back_to_most_recent_resolved_when_no_open_candidate():
+    """열린 후보가 하나도 없으면(전부 해소) 가장 최근 해소된 게이트를 보여준다 — 승인 완료도
+    "증명"으로서 보여줄 가치가 있다는 2916-B 원칙(전부 null로 숨기지 않음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_member(s)
+            conv = await _seed_conversation(
+                s, org_id=seeded["org_id"], project_id=seeded["project_id"], member_id=seeded["member_id"],
+            )
+            older_gate = await _seed_gate(s, org_id=seeded["org_id"], status="rejected")
+            newer_gate = await _seed_gate(s, org_id=seeded["org_id"], status="approved")
+            await _seed_approval_message(
+                s, conv_id=conv.id, sender_id=seeded["member_id"], gate_id=older_gate.id, created_at=_t(0),
+            )
+            await _seed_approval_message(
+                s, conv_id=conv.id, sender_id=seeded["member_id"], gate_id=newer_gate.id, created_at=_t(5),
+            )
+            conv_id, newer_gate_id = conv.id, newer_gate.id
+
+        await _setup_app_human(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            data = await _list_conversations(client, seeded["project_id"])
+        finally:
+            await client.aclose()
+
+        assert len(data) == 1
+        assert data[0]["linked_proof"] == {
+            "kind": "gate", "state": "verified", "gate_id": str(newer_gate_id),
+        }
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_linked_proof_batch_query_not_n_plus_1():
+    """대화 3개 각각 열린 게이트를 참조해도, linked_proof 도출 쿼리는 정확히 2회(approval_target
+    조회 1 + Gate 배치조회 1)여야 한다 — 대화 수와 무관(N+1 방지, 스토리 성능 제약)."""
+    from app.main import app
+    from sqlalchemy import event
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_member(s)
+            conv_ids = []
+            for i in range(3):
+                conv = await _seed_conversation(
+                    s, org_id=seeded["org_id"], project_id=seeded["project_id"],
+                    member_id=seeded["member_id"], title=f"Convo {i}",
+                )
+                gate = await _seed_gate(s, org_id=seeded["org_id"], status="pending", requires_human=True)
+                await _seed_approval_message(
+                    s, conv_id=conv.id, sender_id=seeded["member_id"], gate_id=gate.id, created_at=_t(i),
+                )
+                conv_ids.append(conv.id)
+
+        await _setup_app_human(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+
+        linked_proof_query_count = 0
+        gate_batch_query_count = 0
+
+        def _before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+            nonlocal linked_proof_query_count, gate_batch_query_count
+            low = statement.lower()
+            # asyncpg는 리터럴을 바인드 파라미터($1 등)로 보내 'approval_target'/'gate_id'
+            # 문자열 자체는 컴파일된 SQL에 안 남는다 — 대신 각 쿼리 고유의 구조적 시그니처로 식별.
+            if "conversation_messages.metadata[" in low and "conversation_messages.conversation_id" in low:
+                linked_proof_query_count += 1
+            if low.strip().startswith("select gate.id, gate.org_id"):
+                gate_batch_query_count += 1
+
+        event.listen(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
+        try:
+            data = await _list_conversations(client, seeded["project_id"])
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
+            await client.aclose()
+
+        assert len(data) == 3
+        for item in data:
+            assert item["linked_proof"] is not None and item["linked_proof"]["state"] == "pending_human"
+
+        assert linked_proof_query_count == 1, (
+            f"approval_target 조회가 {linked_proof_query_count}회(N+1 의심, 대화 3개)"
+        )
+        assert gate_batch_query_count == 1, (
+            f"Gate 배치조회가 {gate_batch_query_count}회(N+1 의심, 대화 3개)"
+        )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -379,9 +379,14 @@ async def test_list_conversations():
         latest_msg_result = MagicMock()
         latest_msg_result.scalar_one_or_none.return_value = mock_msg
 
+        # story #2925: linked_proof 배치 조회(approval_target 참조 0건 → gates 배치조회는
+        # 안 불림 — _batch_resolve_linked_proof가 approval_rows 빈 결과에서 조기 return).
+        approval_rows_result = MagicMock()
+        approval_rows_result.all.return_value = []
+
         session.execute = AsyncMock(side_effect=[
             member_result, conv_ids_result, total_result,
-            convs_result, p_rows_result, unread_result, latest_msg_result,
+            convs_result, p_rows_result, unread_result, approval_rows_result, latest_msg_result,
         ])
 
         async with client as c:


### PR DESCRIPTION
[SID:2925]

## 무엇

유나 2921-S2 서면 확定 스펙: L1 대화 리스트 행은 「참조(게이트) 있는 대화만」
ProofCapsule card로 승격하고, 색은 참조 대상의 실제 상태가 몬다. 참조가 없으면
plain(fail-safe — 거짓 색을 칠하느니 안 칠하는 게 낫다). `/api/v2/conversations`의
`ConversationItem`에 `linked_proof` 필드를 신설해 이 판별 신호를 실었다.

## 그라운딩(중요 — 설계 판단의 근거)

`entity_references`(story #2259, 1급 참조 테이블)가 "참조"의 SSOT처럼 보이지만, 실제로
대화가 게이트를 **임베드**하는 유일한 실 프로덕션 경로는
`dispatch_approval_request_cards`(approval_delivery.py)가 심는
`ConversationMessage.msg_metadata['approval_target']['gate_id']`뿐이었다 —
`insert_chat_mentions`(entity_references에 쓰는 경로)는 일반 send_message 흐름에서만
발화하고 approval-request 카드 배달 경로는 그걸 거치지 않는다(직접 grep으로 확인).
그래서 이 필드는 `approval_target`만 소스로 삼는다.

**「작업(task) 상태」 폴백은 뺐다** — 대화가 (게이트 없이) 순수 task를 임베드하는
메커니즘을 코드베이스에서 찾지 못했다(지어내지 않는다 원칙). PO/유나 확認이 필요한
갭으로 명시해 둔다 — task 전용 대화-임베드 축이 실제로 필요하면 별도 스토리로 판단.

## 상태 매핑 (PO 전달 유나 확定)

| gate.status | requires_human | linked_proof.state |
|---|---|---|
| rejected | – | `violation` |
| approved / auto_passed | – | `verified` |
| pending | true | `pending_human` |
| pending | false | `waiting` |
| held | – | `waiting` |
| voided | – | (후보 제외 — null) |

voided는 관리자 회수 상태라 4상태 어디에도 정직하게 안 맞는다 — 거짓 색보다 null.

## 우선순위 규칙

한 대화에 게이트 참조가 여럿이면(재상신 등) **열린(pending/held) 쪽을 우선**한다(스토리
「열린 게이트(우선)」). 열린 후보가 하나도 없으면(전부 해소) 가장 최근 해소된 게이트를
보여준다 — 2916-B 원칙("증명 완료"도 보여줄 가치가 있는 신호). 선택 전 배달 시각
최신순 정렬.

## N+1 방지

리스트 N행 조회에 **쿼리 2개 고정**(approval_target 배치조회 1 + Gate 배치조회 1) —
`_fetch_conversation_participants`/unread_map과 동일한 기존 배치 패턴. 실측 쿼리수
카운트 테스트(`test_linked_proof_batch_query_not_n_plus_1`)로 고정.

## 검증

- 신규 테스트 11건(`tests/test_2925_conversation_linked_proof_realdb.py`): 상태 매핑
  6종(파라미터라이즈)·null fail-safe·voided 제외·open-우선·최근-해소 폴백·N+1 쿼리수.
  전부 뮤테이션 재현(로직을 되돌려 정확히 예측한 실패 확인 후 원복) 포함.
- 기존 `tests/test_conversations.py::test_list_conversations`(모킹 세션) — 신규
  approval_target 배치조회가 `session.execute` 호출 순서에 하나 늘어 side_effect
  리스트 위치 정합 필요, 빈 결과 mock 추가로 수정.
- 관련 62개 테스트(conversations 리스트/상세/unread/admin-bypass/project-scope) 회귀
  스윕 clean.

## 스코프 밖(의도적)

- Task 상태 폴백(위 그라운딩 참조 — 메커니즘 부재로 보류).
- FE 소비(S2, 미르코 후속 — ProofCapsule card 旣완성이라 이 필드 소비만 남음).