### PR TITLE
[SID:2916] P0-02 대비 위반 처방 — proof-capsule eyebrow/audit 타임스탬프

### DIFF
--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -307,3 +307,18 @@ describe('GateDetailPage — evidence_viewed 서버 계약 (story #2027 AC2)', (
     expect(JSON.parse(transitionCall?.body ?? '{}')).toMatchObject({ status: 'approved', evidence_viewed: false });
   });
 });
+
+// story P0-02(유나 full 검산, PR#3367 2026-08-22) — gate_type "chip" 배지가 Badge 기본
+// variant(text-muted-foreground on bg-muted/70)를 그대로 쓰면 AA 미달(실측 3.55). 전역
+// variant는 다른 소비처 파급이라 이 지점만 className 오버라이드(text-foreground — #2420 v3
+// "tint 배경 위 글자=text-foreground" 규칙과 동형, badge.tsx의 destructive/success/info/
+// warning variant가 이미 같은 규칙을 쓰고 chip만 예외였다).
+describe('GateDetailPage — gate_type 배지 대비(P0-02, PR#3367)', () => {
+  it('gate_type 배지가 text-foreground를 쓴다(chip variant 기본 text-muted-foreground 오버라이드)', async () => {
+    await mount(gate({ gate_type: 'merge_gate' }));
+    const chipEl = [...container.querySelectorAll('span')].find((el) => el.textContent === 'merge_gate');
+    expect(chipEl, 'gate_type 배지를 못 찾음').toBeDefined();
+    expect(chipEl!.className).toContain('text-foreground');
+    expect(chipEl!.className).not.toContain('text-muted-foreground');
+  });
+});

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -213,7 +213,13 @@ export default function GateDetailPage() {
             footer={
               <div className="mt-3.5 space-y-3 border-t border-proof-line-soft pt-3">
                 <div className="flex flex-wrap items-center gap-1.5">
-                  <Badge variant="chip">{gate.gate_type}</Badge>
+                  {/* 유나 P0-02 full 검산(2026-08-22, PR#3367) — Badge "chip" variant 기본
+                      (text-muted-foreground on bg-muted/70)이 이 자리에서 AA 미달 실측(3.55).
+                      전역 variant를 고치면 다른 소비처 전부 파급이라 이 지점만 className
+                      오버라이드(text-foreground — #2420 "tint 위 계열색 글자=text-foreground"
+                      규칙과 동형). 전역 chip variant 자체의 대비 상향 여부는 유나 별도 판단
+                      (발견만 기록, 이 PR 스코프 아님). */}
+                  <Badge variant="chip" className="text-foreground">{gate.gate_type}</Badge>
                   {deriveRiskLevel(gate) === 'high' ? (
                     <Badge variant="warning">{t('riskHigh')}</Badge>
                   ) : deriveRiskLevel(gate) === 'unknown' ? (

--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -173,6 +173,34 @@ describe('ProofCapsule (안티패턴 자체 체크 — 도크트린 준수 회�
       expect(markup).not.toContain('>GATE<');
     }
   });
+
+  // story P0-02(유나 full 검산, PR#3368 2026-08-22) — full 밀도 eyebrow 라벨(evidence/gate/claim
+  // 3곳)+audit 밀도 mono 타임스탬프가 전부 --proof-panel 배경 위 text-proof-faint였다. 수동
+  // WCAG 계산(python, 이 PR): light 2.72·dark 2.84(둘 다 AA 4.5 미달) → text-proof-ink-3(light
+  // 5.92·dark 5.43, 둘 다 통과). proof-* 페어링은 자동 tint-contrast 가드 대상 밖(NON_STATUS_
+  // FAMILY_NAMES 제외)이라 이 회귀가드가 유일한 고정점.
+  it('full 밀도 eyebrow 라벨(evidence/gate/claim)이 text-proof-faint 대신 text-proof-ink-3를 쓴다(AA 대비)', () => {
+    const markup = renderWithIntl(
+      <ProofCapsule
+        {...BASE}
+        density="full"
+        evidence={{ acMet: 1, acTotal: 1 }}
+        gate={{ risk: '낮음', action: '결재' }}
+        human={{ name: '유나', role: '' }}
+      />,
+    );
+    expect(markup).not.toContain('text-proof-faint');
+    // eyebrow 3곳(evidence.label/gate.label/claim.label) 전부 ink-3 — 최소 3회 등장 확인.
+    expect((markup.match(/text-proof-ink-3/g) ?? []).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('audit 밀도 타임스탬프(now+actorName)도 text-proof-faint 대신 text-proof-ink-3를 쓴다(같은 AA 처방)', () => {
+    const markup = renderWithIntl(
+      <ProofCapsule {...BASE} density="audit" now="3일 전" human={{ name: '유나', role: '' }} />,
+    );
+    expect(markup).not.toContain('text-proof-faint');
+    expect(markup).toContain('text-proof-ink-3');
+  });
 });
 
 describe('ProofCapsule (human optional — Board card 확산, bf9037cb) — 다중 담당자 등 human 필드로 표현 안 되는 실 기능을 위한 완화', () => {

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -163,7 +163,7 @@ function EvidenceRow({ evidence, sweep }: { evidence: ProofCapsuleEvidence; swee
           aria-hidden="true"
         />
       ) : null}
-      <div className="mb-2 text-[8.5px] font-bold uppercase tracking-[0.12em] text-proof-faint">
+      <div className="mb-2 text-[8.5px] font-bold uppercase tracking-[0.12em] text-proof-ink-3">
         {t('evidence.label')}
       </div>
       <div className="flex flex-wrap items-center gap-3.5 text-[13px] leading-[1.45] text-proof-ink-2">
@@ -200,7 +200,7 @@ function GateRow({ gate, human }: { gate: ProofCapsuleGate; human: ProofCapsuleH
   const t = useTranslations('proofCapsule');
   return (
     <div className="mt-3.5 border-t border-proof-line-soft pt-3">
-      <div className="mb-2 text-[8.5px] font-bold uppercase tracking-[0.12em] text-proof-faint">
+      <div className="mb-2 text-[8.5px] font-bold uppercase tracking-[0.12em] text-proof-ink-3">
         {t('gate.label')}
       </div>
       <div className="flex flex-wrap items-center gap-3.5 text-[13px] text-proof-ink-2">
@@ -245,7 +245,7 @@ function FullVariant({
     <CutCornerShell state={proofState} cut={24} className={className}>
       <div className="min-w-0 flex-1 px-4.5 py-4">
         <StateHeader state={proofState} label={stateLabel} />
-        <div className="mb-1 mt-3 text-[8.5px] font-bold uppercase tracking-[0.12em] text-proof-faint">
+        <div className="mb-1 mt-3 text-[8.5px] font-bold uppercase tracking-[0.12em] text-proof-ink-3">
           {t('claim.label')}
         </div>
         <div className="text-[19px] font-bold leading-[1.25] tracking-[-0.012em] text-proof-ink">{claim}</div>
@@ -385,7 +385,7 @@ function AuditRow({ proofState, claim, now, human, agent, className }: Pick<Proo
       <span className={cn('size-1.5 shrink-0 rounded-full', dotTone[proofState])} aria-hidden="true" />
       <span className="min-w-0 flex-1 truncate font-medium text-proof-ink">{claim}</span>
       {actorName ? <Avatar name={actorName} actorType={agent ? 'agent' : 'human'} size={16} /> : null}
-      <span className="shrink-0 font-mono text-[9.5px] text-proof-faint">{[now, actorName].filter(Boolean).join(' ')}</span>
+      <span className="shrink-0 font-mono text-[9.5px] text-proof-ink-3">{[now, actorName].filter(Boolean).join(' ')}</span>
     </div>
   );
 }


### PR DESCRIPTION
## 요약
doc P0-02(#3347 선례와 동형·develop 직행, 스택 아님) — 유나군 full 검산에서 발견한 대비 위반 처방.

지목된 2건(evidence.label·gate.label eyebrow, text-proof-faint→text-proof-ink-3)에 더해, **동일 클래스 조합을 쓰는 나머지 2곳(claim.label eyebrow·audit 밀도 mono 타임스탬프)도 grep으로 확인해 같이 처방**(수동 WCAG 계산으로 실측 — light 2.72, dark 2.84, 둘 다 AA 4.5 미달 확인 후 픽스).

**②(merge 게이트타입 pill)는 정확한 파일/라인을 못 찾았습니다** — proof-capsule.tsx·cage/story-merge-gate.tsx 양쪽 grep에 해당 패턴이 없어, 별도로 여쭤 확認 후 후속 처리하겠습니다.

## 처방
`text-proof-faint` → `text-proof-ink-3` (4곳): light 2.72→5.92·dark 2.84→5.43, 전부 AA(4.5) 통과.

## 검증
- 신규 회귀가드 2건 — full 밀도 eyebrow 3곳+audit 밀도 타임스탬프가 `text-proof-ink-3`를 쓰는지 고정.
- 기존 `proof-capsule.test.tsx` 35건 전부 무회귀.
- FE: tsc/eslint 0·vitest 전체 477 files/4044 tests green·contrast 가드 4종 신규위반 0·build 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)