### PR TITLE
feat(2935): EventPublishRequest.conversation_id 오버라이드 + preset.steer.instruct 시드

### DIFF
--- a/backend/alembic/versions/0272_event_definitions_preset_steer_instruct.py
+++ b/backend/alembic/versions/0272_event_definitions_preset_steer_instruct.py
@@ -1,0 +1,110 @@
+"""story #2935(설계 doc steer-event-axis-design-2927 §1 확定분) — preset.steer.instruct
+event_definition 신규 시드.
+
+0245(event_definitions 테이블+프리셋 4종)·0249(block_template 시드) 패턴을 그대로 계승 —
+이건 5번째 preset key 추가일 뿐 새 체계가 아니다(doc §0). payload_schema/routing/
+block_template은 doc §1 초안을 그대로 옮긴다 — action_auth는 이번 판 없음(사람·에이전트
+둘 다 발행 가능해야 하므로 무제한, doc §2).
+
+⚠️용어 충돌(doc addendum, PO 확定 2026-08-22): "steer"라는 key 접두는 2026-07-11 옛
+"로드맵 조타" doc(be-design-roadmap-steer-ortega-events-96b19bc3, 미구현 draft)과 다른
+개념이다 — 이름은 방향서 캐논 어휘(STEER=composer 챗 1급 동작)를 그대로 쓰기로 PO가 확定
+했고, 옛 doc 쪽에 혼동방지 배너를 부착했다. `preset.roadmap.*`류가 실제로 필요해지면 그건
+별도 네임스페이스를 쓸 것 — 이 마이그와 충돌하지 않는다.
+
+Revision ID: 0272
+Revises: 0271
+Create Date: 2026-08-22
+"""
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0272"
+down_revision = "0271"
+branch_labels = None
+depends_on = None
+
+_KEY = "preset.steer.instruct"
+
+_PAYLOAD_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["work_item_type", "work_item_id", "target_member_id", "instruction"],
+    "properties": {
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+        "target_member_id": {"type": "string", "format": "uuid"},
+        "instruction": {"type": "string", "minLength": 1},
+        "issued_by_member_id": {"type": ["string", "null"], "format": "uuid"},
+    },
+}
+
+# preset.work.assigned(0245:94-102)의 payload_field/server_derived 조합을 그대로 복제 —
+# escalation=지시가 실제로 도달해야 하는 대상 1인, broadcast=같은 work item 이해관계자 공람.
+_ROUTING = {
+    "escalation": {
+        "kind": "payload_field", "target": "steer_target",
+        "member_id_field": "target_member_id",
+    },
+    "broadcast": {
+        "kind": "server_derived", "target": "work_item_stakeholders",
+        "inherit_conversation_scope": True,
+    },
+}
+
+# actions 블록 없음 — 0249 선례와 동일 이유("눌러도 뭘 하는지 모르는 버튼보다 없는 게 낫다").
+_BLOCK_TEMPLATE = {
+    "blocks": [
+        {"type": "header", "text": "방향 전환"},
+        {"type": "text", "text": "{{payload.instruction}}"},
+        {"type": "fields", "fields": [
+            {"label": "대상", "value": "{{payload.work_item_id}}"},
+            {"label": "지시 대상자", "value": "{{payload.target_member_id}}"},
+        ]},
+    ],
+}
+
+_event_definitions = sa.table(
+    "event_definitions",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("key", sa.Text),
+    sa.column("org_id", postgresql.UUID(as_uuid=True)),
+    sa.column("payload_schema", postgresql.JSONB),
+    sa.column("routing", postgresql.JSONB),
+    sa.column("block_template", postgresql.JSONB),
+    sa.column("action_auth", postgresql.JSONB),
+    sa.column("enabled", sa.Boolean),
+    sa.column("version", sa.Integer),
+    sa.column("created_by", postgresql.UUID(as_uuid=True)),
+)
+
+
+def upgrade() -> None:
+    op.bulk_insert(
+        _event_definitions,
+        [{
+            "id": uuid.uuid4(),
+            "key": _KEY,
+            "org_id": None,
+            "payload_schema": _PAYLOAD_SCHEMA,
+            "routing": _ROUTING,
+            "block_template": _BLOCK_TEMPLATE,
+            "action_auth": None,
+            "enabled": True,
+            "version": 1,
+            "created_by": None,
+        }],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("DELETE FROM event_definitions WHERE org_id IS NULL AND key = :key"),
+        {"key": _KEY},
+    )

--- a/backend/alembic/versions/0274_event_definitions_preset_steer_instruct.py
+++ b/backend/alembic/versions/0274_event_definitions_preset_steer_instruct.py
@@ -12,9 +12,16 @@ block_template은 doc §1 초안을 그대로 옮긴다 — action_auth는 이�
 했고, 옛 doc 쪽에 혼동방지 배너를 부착했다. `preset.roadmap.*`류가 실제로 필요해지면 그건
 별도 네임스페이스를 쓸 것 — 이 마이그와 충돌하지 않는다.
 
-Revision ID: 0272
-Revises: 0271
+Revision ID: 0274
+Revises: 0273
 Create Date: 2026-08-22
+
+⚠️재넘버링(2026-08-22, PO 지시 #3368 qa:changes): 원래 0272로 작성됐으나 그 사이 develop에
+머지된 #3359(story #2932)의 0272_gate_repo_scoped_slot.py와 리비전 번호가 충돌해(sibling-PR
+가드가 정확히 검출, 로직 무관 순수 넘버링 문제) 0274로 재넘버링·down_revision을 develop 실제
+head(0273)로 rebase. 같은 작성자의 다른 열린 PR(#3371, story #2939)도 0274를 먼저 예약해
+있어 그쪽을 0275로 재넘버링해 체인시켰다(이 마이그가 먼저 머지된다고 가정 — 순서가 바뀌면
+그때 다시 조정).
 """
 from __future__ import annotations
 
@@ -24,8 +31,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision = "0272"
-down_revision = "0271"
+revision = "0274"
+down_revision = "0273"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -919,6 +919,13 @@ class EventPublishRequest(BaseModel):
     # 정의의 routing.broadcast가 선언한 대상 외에 발행 시점에 추가로 공람시킬 대상(옵션 — P1
     # 플랜 §2-2 "추가 전파 대상"). org 소속만 허용(cross-org 필터, send_message와 동형).
     extra_broadcast_member_ids: list[uuid.UUID] = []
+    # story #2935(설계 doc steer-event-axis-design-2927 §2) — 발행 대상 conversation을
+    # 호출자가 직접 지정(예: composer가 "지금 보는 스레드"에 STEER 지시를 남기는 경우).
+    # 지정되면 _get_or_create_event_conversation의 참가자-집합 자동계산을 건너뛰고 그
+    # conversation에 바로 발행한다. None이면(기존 호출부 전부) 현행 동작 그대로 — additive,
+    # 무회귀. escalation 대상이 그 conversation의 실 참가자가 아니면 422로 거부한다(doc
+    # "⚠️§2 보강" — fail-closed, 조용한 미도달 방지).
+    conversation_id: uuid.UUID | None = None
 
 
 async def _resolve_event_project_id(
@@ -1023,6 +1030,7 @@ async def publish_registry_event(
     return await _publish_registry_event_core(
         db, org_id, auth, body.definition_key, body.payload, background_tasks,
         request=request, extra_broadcast_member_ids=body.extra_broadcast_member_ids,
+        conversation_id=body.conversation_id,
     )
 
 
@@ -1036,6 +1044,7 @@ async def _publish_registry_event_core(
     *,
     request: Request | None = None,
     extra_broadcast_member_ids: "list[uuid.UUID] | None" = None,
+    conversation_id: uuid.UUID | None = None,
 ) -> dict:
     """`publish_registry_event`(HTTP)·`publish_preset_event`(서버 자동발행, story #2791 P0)의
     공유 core — definition_key+payload를 검증하고 routing(상신선·전파선)을 실 member_id로
@@ -1188,10 +1197,47 @@ async def _publish_registry_event_core(
             ) from None
 
     participant_ids = {sender.id} | escalation_ids | broadcast_ids
-    conv = await _get_or_create_event_conversation(
-        db, org_id=org_id, project_id=project_id,
-        participant_ids=participant_ids, created_by=sender.id,
-    )
+
+    if conversation_id is not None:
+        # story #2935(설계 doc §2 보강) — 지정 conversation에 바로 발행. sender의 참가자
+        # 여부는 send_message()의 기존 인가가 그대로 검증(및 human+non-dm이면 auto-join)한다
+        # — 여기서 중복 검사하지 않는다. 이 함수가 추가로 지켜야 하는 것은 escalation 대상
+        # ("실제로 도달해야 하는" 대상 — routing이 계산한 것)이 그 conversation의 실 참가자가
+        # 아닌 경우다: 정상 경로(_get_or_create_event_conversation)는 참가자 집합 자체를 그
+        # 대상들로 구성하므로 이 문제가 구조적으로 없는데, 오버라이드는 그 계산을 건너뛰므로
+        # escalation 대상이 실제로 그 스레드에 없으면 메시지가 "성공"해도 대상은 못 보는
+        # 조용한 미도달이 된다 — fail-closed 422로 거부(doc §2 "⚠️§2 보강", 대안: 자동 멘션
+        # 부여는 프라이버시 침범+신규 전달계통 원칙 위반으로 기각됨).
+        from app.models.conversation import Conversation, ConversationParticipant
+
+        conv = (await db.execute(
+            select(Conversation).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
+        )).scalar_one_or_none()
+        if conv is None:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+        conv_participant_ids = set((await db.execute(
+            select(ConversationParticipant.member_id).where(
+                ConversationParticipant.conversation_id == conv.id
+            )
+        )).scalars().all())
+        missing_escalation = escalation_ids - conv_participant_ids
+        if missing_escalation:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "conversation_target_mismatch",
+                    "message": (
+                        "지정된 conversation_id에 escalation 대상이 참가자로 없어 발행을 "
+                        "거부합니다(지시가 조용히 미도달하는 것을 막기 위함)."
+                    ),
+                    "errors": [str(i) for i in missing_escalation],
+                },
+            )
+    else:
+        conv = await _get_or_create_event_conversation(
+            db, org_id=org_id, project_id=project_id,
+            participant_ids=participant_ids, created_by=sender.id,
+        )
 
     from app.routers.conversations import SendMessageRequest, send_message
 

--- a/backend/tests/test_2935_steer_conversation_override.py
+++ b/backend/tests/test_2935_steer_conversation_override.py
@@ -32,16 +32,17 @@ def anyio_backend():
 
 
 def _load_steer_definition():
-    """0272 마이그의 시드 데이터를 실 코드에서 동적 로드 — test_2633의 `_load_seed_definitions`
-    (0245 로드)와 동일 패턴, 신규 헬퍼 발명 금지."""
+    """0274 마이그의 시드 데이터를 실 코드에서 동적 로드 — test_2633의 `_load_seed_definitions`
+    (0245 로드)와 동일 패턴, 신규 헬퍼 발명 금지. (원래 0272로 작성됐으나 develop #3359와
+    번호 충돌해 0274로 재넘버링됨 — PR#3368 코멘트 참조.)"""
     import importlib.util
     import os
 
     spec = importlib.util.spec_from_file_location(
-        "_m0272steer",
+        "_m0274steer",
         os.path.join(
             os.path.dirname(__file__), "..", "alembic", "versions",
-            "0272_event_definitions_preset_steer_instruct.py",
+            "0274_event_definitions_preset_steer_instruct.py",
         ),
     )
     m = importlib.util.module_from_spec(spec)

--- a/backend/tests/test_2935_steer_conversation_override.py
+++ b/backend/tests/test_2935_steer_conversation_override.py
@@ -1,0 +1,318 @@
+"""story #2935(설계 doc steer-event-axis-design-2927 §1/§2 확定분) — EventPublishRequest.
+conversation_id 오버라이드 + preset.steer.instruct 신규 정의.
+
+- §2 보강: conversation_id 지정 시 escalation 대상이 그 conversation의 실 참가자가 아니면
+  422(fail-closed, 조용한 미도달 방지) — doc의 대안 ⓑ(자동 멘션 부여) 기각 근거 그대로.
+- §1: preset.steer.instruct가 실제로 조회/발행 가능한지(escalation=target_member_id,
+  broadcast=work_item_stakeholders).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+from tests.test_2633_event_publish import (
+    _REAL_DB_URL,
+    _auth,
+    _fake_request,
+    _realdb_session,
+    _seed_agent,
+    _seed_org_project,
+    _seed_story,
+)
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _load_steer_definition():
+    """0272 마이그의 시드 데이터를 실 코드에서 동적 로드 — test_2633의 `_load_seed_definitions`
+    (0245 로드)와 동일 패턴, 신규 헬퍼 발명 금지."""
+    import importlib.util
+    import os
+
+    spec = importlib.util.spec_from_file_location(
+        "_m0272steer",
+        os.path.join(
+            os.path.dirname(__file__), "..", "alembic", "versions",
+            "0272_event_definitions_preset_steer_instruct.py",
+        ),
+    )
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m._KEY, m._PAYLOAD_SCHEMA, m._ROUTING, m._BLOCK_TEMPLATE
+
+
+async def _seed_steer_definition(session):
+    from app.models.event_definition import EventDefinition
+
+    key, payload_schema, routing, block_template = _load_steer_definition()
+    session.add(EventDefinition(
+        id=uuid.uuid4(), key=key, org_id=None,
+        payload_schema=payload_schema, routing=routing, block_template=block_template,
+    ))
+    await session.commit()
+
+
+async def _seed_preset_work_assigned(session):
+    """conversation_id 오버라이드 테스트는 기존 preset.work.assigned(단순 payload_field
+    escalation)를 재사용 — 신규 정의 없이도 §2 로직 자체를 검증할 수 있다."""
+    from app.models.event_definition import EventDefinition
+
+    session.add(EventDefinition(
+        id=uuid.uuid4(), key="preset.work.assigned", org_id=None,
+        payload_schema={
+            "type": "object", "additionalProperties": False,
+            "required": ["work_item_type", "work_item_id", "assignee_member_id"],
+            "properties": {
+                "work_item_type": {"type": "string"},
+                "work_item_id": {"type": "string", "format": "uuid"},
+                "assignee_member_id": {"type": "string", "format": "uuid"},
+                "assigned_by_member_id": {"type": ["string", "null"], "format": "uuid"},
+            },
+        },
+        routing={
+            "escalation": {
+                "kind": "payload_field", "target": "assignee", "member_id_field": "assignee_member_id",
+            },
+            "broadcast": {
+                "kind": "server_derived", "target": "work_item_stakeholders",
+                "inherit_conversation_scope": True,
+            },
+        },
+    ))
+    await session.commit()
+
+
+async def _seed_conversation(session, org_id, project_id, *, participant_ids, created_by):
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv = Conversation(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="group",
+        title="Steer target conv", created_by=created_by,
+    )
+    session.add(conv)
+    await session.flush()
+    for member_id in participant_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=member_id))
+    await session.commit()
+    return conv.id
+
+
+# ─── §2 보강: conversation_id 오버라이드 ────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_conversation_id_override_publishes_into_specified_conversation():
+    from app.routers.events import EventPublishRequest, publish_registry_event
+    from app.models.conversation import Conversation
+    from sqlalchemy import func, select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_work_assigned(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            assignee_id = await _seed_agent(s, org_id, project_id, name="assignee")
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=assignee_id)
+            target_conv_id = await _seed_conversation(
+                s, org_id, project_id,
+                participant_ids={publisher_id, assignee_id}, created_by=publisher_id,
+            )
+
+            before_count = (await s.execute(
+                select(func.count()).select_from(Conversation).where(Conversation.org_id == org_id)
+            )).scalar_one()
+
+            body = EventPublishRequest(
+                definition_key="preset.work.assigned",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "assignee_member_id": str(assignee_id),
+                },
+                conversation_id=target_conv_id,
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert resp["conversation_id"] == str(target_conv_id), "지정한 conversation에 발행돼야 함"
+
+            after_count = (await s.execute(
+                select(func.count()).select_from(Conversation).where(Conversation.org_id == org_id)
+            )).scalar_one()
+            assert after_count == before_count, "오버라이드 경로는 새 conversation을 만들면 안 됨"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_conversation_id_override_rejects_when_escalation_target_not_participant():
+    """doc §2 보강 — escalation 대상(target_member_id)이 지정 conversation의 실 참가자가
+    아니면 422(fail-closed) — 조용한 미도달 방지. 대안 ⓑ(자동 멘션 부여)는 기각됨."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_work_assigned(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            assignee_id = await _seed_agent(s, org_id, project_id, name="assignee")
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=assignee_id)
+            # assignee_id를 «넣지 않은» 대화 — escalation 대상이 참가자가 아닌 상태 재현.
+            target_conv_id = await _seed_conversation(
+                s, org_id, project_id, participant_ids={publisher_id}, created_by=publisher_id,
+            )
+
+            body = EventPublishRequest(
+                definition_key="preset.work.assigned",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "assignee_member_id": str(assignee_id),
+                },
+                conversation_id=target_conv_id,
+            )
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 422
+            assert ei.value.detail["code"] == "conversation_target_mismatch"
+            assert str(assignee_id) in ei.value.detail["errors"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_conversation_id_override_none_preserves_get_or_create_behavior():
+    """conversation_id 미지정(기존 호출부 전부) — 무회귀. 기존 _get_or_create_event_
+    conversation 경로가 그대로 새/재사용 conversation을 만든다."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_work_assigned(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            assignee_id = await _seed_agent(s, org_id, project_id, name="assignee")
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=assignee_id)
+
+            body = EventPublishRequest(
+                definition_key="preset.work.assigned",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "assignee_member_id": str(assignee_id),
+                },
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert resp["escalation_member_ids"] == [str(assignee_id)]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_conversation_id_override_404_when_not_found():
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_preset_work_assigned(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            assignee_id = await _seed_agent(s, org_id, project_id, name="assignee")
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=assignee_id)
+
+            body = EventPublishRequest(
+                definition_key="preset.work.assigned",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "assignee_member_id": str(assignee_id),
+                },
+                conversation_id=uuid.uuid4(),  # 존재하지 않음.
+            )
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 404
+    finally:
+        await engine.dispose()
+
+
+# ─── §1: preset.steer.instruct 신규 정의 실왕복 ─────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_steer_instruct_escalates_to_target_broadcasts_to_stakeholders():
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_steer_definition(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            target_id = await _seed_agent(s, org_id, project_id, name="target")
+            stakeholder_id = await _seed_agent(s, org_id, project_id, name="stakeholder")
+            story_id = await _seed_story(s, org_id, project_id, human_owner_member_id=stakeholder_id)
+
+            body = EventPublishRequest(
+                definition_key="preset.steer.instruct",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "target_member_id": str(target_id),
+                    "instruction": "이 스토리 우선순위를 올려주세요",
+                },
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert resp["escalation_member_ids"] == [str(target_id)]
+            assert str(stakeholder_id) in resp["broadcast_member_ids"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_steer_instruct_missing_instruction_400():
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _seed_steer_definition(s)
+            publisher_id = await _seed_agent(s, org_id, project_id, name="publisher")
+            target_id = await _seed_agent(s, org_id, project_id, name="target")
+            story_id = await _seed_story(s, org_id, project_id)
+
+            body = EventPublishRequest(
+                definition_key="preset.steer.instruct",
+                payload={
+                    "work_item_type": "story", "work_item_id": str(story_id),
+                    "target_member_id": str(target_id),
+                    # instruction 누락 — payload_schema required 위반.
+                },
+            )
+            with pytest.raises(HTTPException) as ei:
+                await publish_registry_event(
+                    body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
[SID:2935]

확定 설계: [STEER 이벤트 축 — 데이터모델·발행 경로 설계](entity:doc:f7b92b28-68cf-4d33-8a75-eae2e567ee1d)(§1/§2, PO 서명 완료). 이 스토리는 그 doc이 확定한 BE 코드 변경 2건만 구현한다(composer FE는 미르코 S5 몫, 스코프 밖).

## ① `EventPublishRequest.conversation_id`(additive)

composer가 "지금 보는 스레드"에 바로 발행할 수 있게. 지정되면 `_get_or_create_event_conversation`의 참가자-집합 자동계산을 건너뛰고 그 conversation에 바로 발행한다.

**fail-closed 422**: escalation 대상(routing이 계산한 "실제로 도달해야 하는" 대상)이 그 conversation의 실 참가자가 아니면 거부 — 조용한 미도달 방지(doc §2 보강 절 그대로). 대안(자동 멘션 부여로 참가자 편입)은 (1) 스레드 과거 히스토리 노출이라는 프라이버시 침범 (2) `send_message()`가 오늘 하지 않는 새 부작용이라 "신규 전달 계통 0" 원칙 위반 — 두 이유로 기각됐다.

미지정 시(기존 호출부 전부) 현행 동작 100% 무회귀.

## ② `preset.steer.instruct` 시드 마이그레이션

0245(테이블+프리셋 4종)·0249(block_template 시드) 패턴 계승 — 이건 새 체계가 아니라 신규 preset key 추가일 뿐(그라운딩 실측: 이미 preset.* 14종 존재 — doc의 "5번째" 서술은 다소 과소산정이지만 결론은 더 강화됨, 저비용 확장축이 이미 반복 증명됨).

- payload_schema: `work_item_type`/`work_item_id`/`target_member_id`/`instruction` 필수.
- routing: escalation=`payload_field`(target_member_id) — `preset.work.assigned`과 동형. broadcast=`work_item_stakeholders`.
- block_template: header/text/fields만(actions 없음 — 0249 선례와 동일 이유, "눌러도 뭘 하는지 모르는 버튼보다 없는 게 낫다").

## 검증

- 신규 테스트 8건(`tests/test_2935_steer_conversation_override.py`): conversation_id 오버라이드 발행·422 미참가자 거부(뮤테이션 검증)·미지정 무회귀·404 미존재(뮤테이션 검증)·steer.instruct 실왕복(escalation/broadcast 구분)·payload 스키마 위반 400.
- 마이그레이션 round-trip(업/다운/재업) 실측 검증 — 시드 row 정확한 payload_schema/routing/block_template 확인.
- 관련 기존 이벤트발행 테스트 49건(`test_2633`/`test_2636`/`test_2637`×2/`test_2665`/`test_2675`/`test_2693`) 회귀 없음.

## 스코프 밖(의도적)

- composer FE(2921-S5, 미르코 후속).
- MCP `sprintable_publish_event` 툴에 `conversation_id` 파라미터 노출 — 필요해지면 별도 후속(agent 발행 경로는 이 스토리 스코프 밖).