### PR TITLE
[2939] 방향서 03 슬라이스① — AgentPersona.model을 A2A agent card에 배관

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -443,6 +443,7 @@ async def _build_agent_card(session: AsyncSession, member: TeamMember, base_url:
         default_input_modes=["text/plain"],
         default_output_modes=["text/plain"],
         skills=skills,
+        model=persona.model if persona is not None else None,
         security_schemes={
             _SECURITY_SCHEME_KEY: SecurityScheme(
                 http_auth_security_scheme=HTTPAuthSecurityScheme(

--- a/backend/app/schemas/a2a.py
+++ b/backend/app/schemas/a2a.py
@@ -98,6 +98,10 @@ class AgentCard(BaseModel):
     default_input_modes: list[str] = Field(alias="defaultInputModes")
     default_output_modes: list[str] = Field(alias="defaultOutputModes")
     skills: list[AgentSkill]
+    model: str | None = Field(
+        default=None,
+        description="방향서 03·에이전트 속성 — 사용 모델. AgentPersona.model 실물 값만 표시(no-fiction, 미배정이면 None).",
+    )
     security_schemes: dict[str, SecurityScheme] = Field(
         default_factory=dict, alias="securitySchemes"
     )

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -32,6 +32,9 @@ def _mock_persona(role_template_id: str | None = None) -> MagicMock:
         p.config["role_template_id"] = role_template_id
     p.is_default = True
     p.deleted_at = None
+    # #3369(방향서 03 슬라이스①)의 AgentCard.model 배관 이후: 명시 설정 안 하면 MagicMock
+    # 자동생성 attr이 pydantic str|None 검증을 깨뜨린다(#3366 동형 클래스).
+    p.model = None
     return p
 
 

--- a/backend/tests/test_a2a_sa4_streaming_realdb.py
+++ b/backend/tests/test_a2a_sa4_streaming_realdb.py
@@ -199,3 +199,55 @@ async def test_agent_card_advertises_streaming_true():
         assert card.capabilities.streaming is True
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_card_surfaces_persona_model_when_set():
+    """방향서 03·에이전트 속성 슬라이스① — AgentPersona.model이 카드 API에 실제로 배관됐는지."""
+    from app.routers.a2a import _build_agent_card
+    from app.models.team import TeamMember
+    from app.models.agent_deployment import AgentPersona
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), type="agent",
+                name="Model Card Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.flush()
+            persona = AgentPersona(
+                id=uuid.uuid4(), org_id=member.org_id, project_id=member.project_id,
+                agent_id=member.id, slug="model-card-test",
+                name="Model Card Test Persona", is_default=True, model="claude-sonnet-5",
+            )
+            s.add(persona)
+            await s.commit()
+            card = await _build_agent_card(s, member, "http://test")
+        assert card.model == "claude-sonnet-5"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_card_model_is_honest_none_when_persona_has_none():
+    """no-fiction: 미배정/persona 없음이면 지어내지 않고 None 그대로 노출."""
+    from app.routers.a2a import _build_agent_card
+    from app.models.team import TeamMember
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), type="agent",
+                name="No Persona Card Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.commit()
+            card = await _build_agent_card(s, member, "http://test")
+        assert card.model is None
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약
방향서(ui-upgrade-report.html) 03절 「에이전트에는 권한 범위·사용 모델·예상 비용·중단 조건을 붙인다」의 4속성 중 유일하게 DB에 실물이 있던 **모델(model)**을 A2A agent card API에 배관한다.

- `AgentPersona.model`(`app/models/agent_deployment.py:52`, Text/nullable)은 이미 `POST/PATCH /agent_personas`로 read/write 가능했지만, `_build_agent_card`(`app/routers/a2a.py`)가 이 값을 안 읽어 카드 API(`GET /api/v2/a2a/members`, `sprintable_list_agent_cards` MCP 도구의 소스)엔 노출되지 않았음 — DB엔 있는데 배관만 안 된 갭.
- `AgentCard` 스키마(`app/schemas/a2a.py`)에 `model: str | None = None` 추가, `_build_agent_card`에서 `persona.model if persona is not None else None`으로 채움. 신규 컬럼/마이그 불요.
- no-fiction 원칙: persona 미배정이거나 model 미설정이면 지어내지 않고 정직하게 `None`.

## 배경
story #2939(방향서 03·에이전트 속성 — 위임 에이전트의 4속성 잔여). 슬라이스①(이 PR, 모델 배관)이 완료되면 슬라이스②(권한 범위·예상 비용·중단 조건 3속성 스키마 설계 doc)로 이어짐.

[SID:2939]

## 테스트
- `tests/test_a2a_sa4_streaming_realdb.py`에 2건 추가: persona.model 설정 시 카드에 반영·persona 없을 때 정직한 None. 실 Postgres 대상 통과 확인.
- 기존 `test_a2a_p1_s1_recruit_card_contract_realdb.py`, `test_2599_role_template_skills_backfill.py`의 AgentCard 생성 경로 회귀 없음 확인(model 필드가 optional/default=None이라 기존 호출부 무영향).

## Test plan
- [x] 신규 realdb 테스트 2건 로컬 실 PG 통과
- [x] 기존 agent-card 관련 테스트 회귀 없음
- [ ] CI green