### PR TITLE
[2939] 방향서 03 슬라이스② — 권한 범위·예상 비용·중단 조건 배관

### DIFF
--- a/backend/alembic/versions/0274_agent_persona_expected_cost_stop_condition.py
+++ b/backend/alembic/versions/0274_agent_persona_expected_cost_stop_condition.py
@@ -1,0 +1,36 @@
+"""방향서 03·에이전트 속성(story #2939 슬라이스②) — 예상 비용·중단 조건 선언 필드.
+
+PO 방향 확定: 방향서 03절 4속성 중 「예상 비용」·「중단 조건」은 1차 층=선언·가시성이지
+실측 계측/자동 집행이 아니다. `system_prompt`/`style_prompt`와 동형으로 자유 텍스트
+nullable 컬럼 2개만 추가 — 구조화(amount/currency/period 등)는 실제 계측 파이프라인이
+붙기 전엔 선반영 낭비라 하지 않는다(설계 doc
+`agent-attributes-permission-cost-stop-2939` §2/§3). 백필 불요 — NULL이 곧 정직한
+"미선언" 상태.
+
+Revision ID: 0274
+Revises: 0273
+Create Date: 2026-08-22
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0274"
+down_revision = "0273"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_personas", sa.Column("expected_cost_note", sa.Text(), nullable=True)
+    )
+    op.add_column(
+        "agent_personas", sa.Column("stop_condition_note", sa.Text(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_personas", "stop_condition_note")
+    op.drop_column("agent_personas", "expected_cost_note")

--- a/backend/alembic/versions/0275_agent_persona_expected_cost_stop_condition.py
+++ b/backend/alembic/versions/0275_agent_persona_expected_cost_stop_condition.py
@@ -7,17 +7,21 @@ nullable 컬럼 2개만 추가 — 구조화(amount/currency/period 등)는 실�
 `agent-attributes-permission-cost-stop-2939` §2/§3). 백필 불요 — NULL이 곧 정직한
 "미선언" 상태.
 
-Revision ID: 0274
-Revises: 0273
+Revision ID: 0275
+Revises: 0274
 Create Date: 2026-08-22
+
+⚠️재넘버링(2026-08-22, PO 지시): 원래 0274로 작성됐으나 같은 작성자의 다른 열린 PR(#3368,
+story #2935 STEER)이 develop 충돌 회피로 먼저 0274를 점유해(PR#3368 코멘트 참조) 0275로
+재넘버링·down_revision을 0274로 rebase(#3368이 먼저 머지된다고 가정).
 """
 from __future__ import annotations
 
 import sqlalchemy as sa
 from alembic import op
 
-revision = "0274"
-down_revision = "0273"
+revision = "0275"
+down_revision = "0274"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/models/agent_deployment.py
+++ b/backend/app/models/agent_deployment.py
@@ -50,6 +50,9 @@ class AgentPersona(Base):
     system_prompt: Mapped[str] = mapped_column(Text, nullable=False, default="")
     style_prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
     model: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # 방향서 03·에이전트 속성(story #2939 슬라이스②) — 1차=선언(자유 텍스트), 실측 계측/집행 불요.
+    expected_cost_note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    stop_condition_note: Mapped[str | None] = mapped_column(Text, nullable=True)
     config: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     is_builtin: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/backend/app/repositories/agent_persona.py
+++ b/backend/app/repositories/agent_persona.py
@@ -58,6 +58,8 @@ def _build_summary(persona: AgentPersona, is_in_use: bool, base: AgentPersona | 
         resolved_system_prompt=resolved_system,
         resolved_style_prompt=resolved_style,
         model=persona.model,
+        expected_cost_note=persona.expected_cost_note,
+        stop_condition_note=persona.stop_condition_note,
         config=persona.config,
         is_builtin=persona.is_builtin,
         is_default=persona.is_default,
@@ -172,6 +174,8 @@ class AgentPersonaRepository:
         system_prompt: str | None = None,
         style_prompt: str | None = None,
         model: str | None = None,
+        expected_cost_note: str | None = None,
+        stop_condition_note: str | None = None,
         base_persona_id: uuid.UUID | None = None,
         tool_allowlist: list[str] | None = None,
         is_default: bool = False,
@@ -200,6 +204,8 @@ class AgentPersonaRepository:
             system_prompt=(system_prompt or "").strip(),
             style_prompt=style_prompt.strip() if style_prompt else None,
             model=model.strip() if model else None,
+            expected_cost_note=expected_cost_note.strip() if expected_cost_note else None,
+            stop_condition_note=stop_condition_note.strip() if stop_condition_note else None,
             config=config,
             is_builtin=False,
             is_default=is_default,
@@ -258,7 +264,10 @@ class AgentPersonaRepository:
             await self._clear_default(org_id, project_id, persona.agent_id, exclude_id=persona_id)
 
         patch: dict[str, Any] = {"config": config, "updated_at": datetime.now(timezone.utc)}
-        for key in ("name", "slug", "description", "system_prompt", "style_prompt", "model", "is_default"):
+        for key in (
+            "name", "slug", "description", "system_prompt", "style_prompt", "model",
+            "expected_cost_note", "stop_condition_note", "is_default",
+        ):
             if key in fields and (fields[key] is not None or key in force_none_fields):
                 val = fields[key]
                 if key == "name":
@@ -267,7 +276,7 @@ class AgentPersonaRepository:
                     val = _slugify(val)
                 elif key in ("description", "system_prompt", "style_prompt"):
                     val = val.strip() if val else None
-                elif key == "model":
+                elif key in ("model", "expected_cost_note", "stop_condition_note"):
                     val = val.strip() if val else None
                 patch[key] = val
 

--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -416,6 +416,16 @@ async def _build_agent_card(session: AsyncSession, member: TeamMember, base_url:
             )
         ]
 
+    # 방향서 03·에이전트 속성(#2939 슬라이스②) — 권한 범위 표시 SSOT는 ApiKey.scope(실제
+    # 매 요청 집행되는 값). recruit 불변식상 활성(revoked_at IS NULL) 키는 최대 1개
+    # (`recruit_service._rotate_or_create_key` — 있으면 회전, 없으면 신규, 절대 2건 동시 생성
+    # 안 함). 방어적으로 created_at desc 1순위를 취한다(설계 doc §1 미확定 항목의 구현 판정).
+    from app.repositories.api_key import ApiKeyRepository
+
+    api_keys = await ApiKeyRepository(session).list_by_member(member.id)
+    active_key = next((k for k in api_keys if k.revoked_at is None), None)
+    permission_scope = list(active_key.scope) if active_key is not None and active_key.scope else None
+
     interface_url = f"{base_url}/api/v2/a2a/members/{member.id}/rpc"
     return AgentCard(
         name=member.name,
@@ -444,6 +454,9 @@ async def _build_agent_card(session: AsyncSession, member: TeamMember, base_url:
         default_output_modes=["text/plain"],
         skills=skills,
         model=persona.model if persona is not None else None,
+        permission_scope=permission_scope,
+        expected_cost=persona.expected_cost_note if persona is not None else None,
+        stop_condition=persona.stop_condition_note if persona is not None else None,
         security_schemes={
             _SECURITY_SCHEME_KEY: SecurityScheme(
                 http_auth_security_scheme=HTTPAuthSecurityScheme(

--- a/backend/app/routers/agent_personas.py
+++ b/backend/app/routers/agent_personas.py
@@ -83,6 +83,8 @@ async def create_persona(
             system_prompt=body.system_prompt,
             style_prompt=body.style_prompt,
             model=body.model,
+            expected_cost_note=body.expected_cost_note,
+            stop_condition_note=body.stop_condition_note,
             base_persona_id=body.base_persona_id,
             tool_allowlist=body.tool_allowlist,
             is_default=body.is_default or False,

--- a/backend/app/schemas/a2a.py
+++ b/backend/app/schemas/a2a.py
@@ -102,6 +102,25 @@ class AgentCard(BaseModel):
         default=None,
         description="방향서 03·에이전트 속성 — 사용 모델. AgentPersona.model 실물 값만 표시(no-fiction, 미배정이면 None).",
     )
+    permission_scope: list[str] | None = Field(
+        default=None,
+        alias="permissionScope",
+        description=(
+            "방향서 03·에이전트 속성 — 권한 범위. 표시 SSOT=ApiKey.scope(실제 매 요청 집행되는 "
+            "값, persona.config.tool_allowlist 아님 — 설계 doc agent-attributes-permission-cost-"
+            "stop-2939 §1 드리프트 경고 참조). 발급된 활성 키가 없으면 None."
+        ),
+    )
+    expected_cost: str | None = Field(
+        default=None,
+        alias="expectedCost",
+        description="방향서 03·에이전트 속성 — 예상 비용(선언, 자유 텍스트). 미선언이면 None.",
+    )
+    stop_condition: str | None = Field(
+        default=None,
+        alias="stopCondition",
+        description="방향서 03·에이전트 속성 — 중단 조건(선언, 자유 텍스트). 미선언이면 None.",
+    )
     security_schemes: dict[str, SecurityScheme] = Field(
         default_factory=dict, alias="securitySchemes"
     )

--- a/backend/app/schemas/agent_persona.py
+++ b/backend/app/schemas/agent_persona.py
@@ -20,6 +20,8 @@ class PersonaBaseResponse(BaseModel):
     system_prompt: str
     style_prompt: str | None
     model: str | None
+    expected_cost_note: str | None
+    stop_condition_note: str | None
     config: dict[str, Any]
     is_builtin: bool
     is_default: bool
@@ -48,6 +50,8 @@ class CreatePersonaRequest(BaseModel):
     system_prompt: str | None = None
     style_prompt: str | None = None
     model: str | None = None
+    expected_cost_note: str | None = None
+    stop_condition_note: str | None = None
     base_persona_id: uuid.UUID | None = None
     tool_allowlist: list[str] | None = None
     is_default: bool | None = None
@@ -60,6 +64,8 @@ class UpdatePersonaRequest(BaseModel):
     system_prompt: str | None = None
     style_prompt: str | None = None
     model: str | None = None
+    expected_cost_note: str | None = None
+    stop_condition_note: str | None = None
     base_persona_id: uuid.UUID | None = None
     tool_allowlist: list[str] | None = None
     is_default: bool | None = None

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -33,8 +33,11 @@ def _mock_persona(role_template_id: str | None = None) -> MagicMock:
     p.is_default = True
     p.deleted_at = None
     # #3369(방향서 03 슬라이스①)의 AgentCard.model 배관 이후: 명시 설정 안 하면 MagicMock
-    # 자동생성 attr이 pydantic str|None 검증을 깨뜨린다(#3366 동형 클래스).
+    # 자동생성 attr이 pydantic str|None 검증을 깨뜨린다(#3366 동형 클래스). #3371(슬라이스②)의
+    # expected_cost/stop_condition도 동일 클래스라 같이 명시.
     p.model = None
+    p.expected_cost_note = None
+    p.stop_condition_note = None
     return p
 
 

--- a/backend/tests/test_a2a_sa4_streaming_realdb.py
+++ b/backend/tests/test_a2a_sa4_streaming_realdb.py
@@ -249,5 +249,106 @@ async def test_agent_card_model_is_honest_none_when_persona_has_none():
             await s.commit()
             card = await _build_agent_card(s, member, "http://test")
         assert card.model is None
+        assert card.permission_scope is None
+        assert card.expected_cost is None
+        assert card.stop_condition is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_card_surfaces_expected_cost_and_stop_condition_when_declared():
+    """방향서 03·에이전트 속성 슬라이스② — 선언 필드(예상 비용·중단 조건) 배관."""
+    from app.routers.a2a import _build_agent_card
+    from app.models.team import TeamMember
+    from app.models.agent_deployment import AgentPersona
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), type="agent",
+                name="Declared Attrs Card Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.flush()
+            persona = AgentPersona(
+                id=uuid.uuid4(), org_id=member.org_id, project_id=member.project_id,
+                agent_id=member.id, slug="declared-attrs-test",
+                name="Declared Attrs Test Persona", is_default=True,
+                expected_cost_note="월 5만원 내외(추정)", stop_condition_note="예산 초과 시 정지",
+            )
+            s.add(persona)
+            await s.commit()
+            card = await _build_agent_card(s, member, "http://test")
+        assert card.expected_cost == "월 5만원 내외(추정)"
+        assert card.stop_condition == "예산 초과 시 정지"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_card_permission_scope_reflects_active_api_key_not_persona_config():
+    """표시 SSOT=ApiKey.scope(실제 집행값) — persona.config.tool_allowlist가 달라도 카드는
+    실제 발급된 활성 키의 scope를 보인다(설계 doc §1의 드리프트 경고를 직접 검증)."""
+    from app.routers.a2a import _build_agent_card
+    from app.models.team import TeamMember
+    from app.models.agent_deployment import AgentPersona
+    from app.models.api_key import ApiKey
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), type="agent",
+                name="Scope Card Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.flush()
+            persona = AgentPersona(
+                id=uuid.uuid4(), org_id=member.org_id, project_id=member.project_id,
+                agent_id=member.id, slug="scope-drift-test", name="Scope Drift Test Persona",
+                is_default=True, config={"tool_allowlist": ["stale_persona_only_tool"]},
+            )
+            s.add(persona)
+            key = ApiKey(
+                id=uuid.uuid4(), team_member_id=member.id, key_prefix="sk_live_testpfx",
+                key_hash="fake-hash-for-test", scope=["real_enforced_tool"],
+            )
+            s.add(key)
+            await s.commit()
+            card = await _build_agent_card(s, member, "http://test")
+        assert card.permission_scope == ["real_enforced_tool"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_card_permission_scope_ignores_revoked_key():
+    from app.routers.a2a import _build_agent_card
+    from app.models.team import TeamMember
+    from app.models.api_key import ApiKey
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), type="agent",
+                name="Revoked Key Card Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.flush()
+            revoked = ApiKey(
+                id=uuid.uuid4(), team_member_id=member.id, key_prefix="sk_live_revoked",
+                key_hash="fake-hash-revoked", scope=["should_not_appear"],
+                revoked_at=datetime.now(timezone.utc),
+            )
+            s.add(revoked)
+            await s.commit()
+            card = await _build_agent_card(s, member, "http://test")
+        assert card.permission_scope is None
     finally:
         await engine.dispose()

--- a/backend/tests/test_s42.py
+++ b/backend/tests/test_s42.py
@@ -53,6 +53,8 @@ def _make_persona_summary():
         resolved_system_prompt="You are a helpful assistant.",
         resolved_style_prompt=None,
         model=None,
+        expected_cost_note=None,
+        stop_condition_note=None,
         config={},
         is_builtin=False,
         is_default=True,


### PR DESCRIPTION
## 요약
설계 doc [권한 범위·예상 비용·중단 조건 — 스키마·표시 표면 설계](https://sprintable.ai — agent-attributes-permission-cost-stop-2939)의 PO 확定안을 구현한다. 슬라이스①(#3369, `model` 배관)에 스택 — 같은 story #2939, 같은 파일(`AgentCard` 스키마/`_build_agent_card`)을 이어서 확장하므로 슬라이스① 브랜치 위에 쌓았다.

### 권한 범위(permission_scope)
- 표시 SSOT = **`ApiKey.scope`**(실제 매 요청 `_check_api_key_scope`로 집행되는 값) — `persona.config.tool_allowlist`가 아니다. 슬라이스② 착수 중 재조사로 최초 P0-03 그라운딩의 "권한=없음" 서술을 스스로 정정했다: `PATCH /agent_personas`가 tool_allowlist는 바꿔도 ApiKey.scope는 재동기화하지 않아 두 값이 드리프트할 수 있음을 발견 — no-fiction 원칙상 카드는 실제 집행값을 보여야 한다.
- 신규 컬럼/마이그 **불요** — `_build_agent_card`에서 활성(`revoked_at IS NULL`) `ApiKey`를 조회해 `.scope` 그대로 노출.
- 설계 doc §1의 미확定 항목("member가 다건 키를 가질 수 있는가")은 `recruit_service._rotate_or_create_key`의 불변식(활성 키가 있으면 회전, 없으면 신규 생성 — 절대 2건 동시 생성 안 함 → 활성 키는 항상 최대 1개)으로 해소됨을 확인. 별도 다건-키 선택 규칙 불요.
- 드리프트 자체(ApiKey.scope↔tool_allowlist 재동기화)는 이 PR 스코프 밖 — PO가 별도 보안 성격 스토리 **#2941**로 분리 등재.

### 예상 비용 / 중단 조건
- `AgentPersona`에 `expected_cost_note`·`stop_condition_note` 신규 nullable Text 컬럼(마이그 `0274`, 백필 불요 — NULL=정직한 미선언). `system_prompt`/`style_prompt`와 동형 패턴, 자유 텍스트(1차=선언, 구조화/실측 계측은 후속 질문).
- `CreatePersonaRequest`/`UpdatePersonaRequest`에 두 필드 추가 — `POST/PATCH /agent_personas`로 read/write.

### AgentCard
- `permission_scope: list[str] | None`·`expected_cost: str | None`·`stop_condition: str | None` 3필드 추가(전부 optional, `default=None` — 기존 호출부 무회귀).

[SID:2939]

## 테스트
- `tests/test_a2a_sa4_streaming_realdb.py`에 6건 추가: 권한범위=실 활성키 scope 반영(persona.config.tool_allowlist와 다르게 설정해 드리프트 시나리오 직접 검증)·revoked 키 제외·예상비용/중단조건 배관·전부 미선언 시 정직한 None.
- 마이그레이션 0274 upgrade/downgrade/re-upgrade 라운드트립 실 Postgres 검증.
- 기존 persona/recruit/카드 관련 realdb 회귀(`test_e_recruit_s3`, `test_e_recruit_s5`, `test_e_security_sec_s6/s7`, `test_a2a_p1_s1_recruit_card_contract`) 전부 통과 — migration-managed DB에서 격리 실행으로 재확인(같은 세션에서 `create_all`/`drop_all` 자체관리 파일과 섞어 돌리면 스키마가 서로 wipe되는 로컬 실행 아티팩트를 발견해 분리 재확인함, 실 CI 파이프라인 영향 없음).

## Test plan
- [x] 신규 realdb 테스트 6건 로컬 실 PG 통과
- [x] 마이그레이션 0274 라운드트립 통과
- [x] 기존 persona/recruit/카드 회귀 없음(격리 재확인)
- [ ] CI green