### PR TITLE
[SID:2937] Badge chip variant 기본 대비 상향 (text-muted-foreground→text-foreground)

### DIFF
--- a/apps/web/src/components/ui/badge.test.tsx
+++ b/apps/web/src/components/ui/badge.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+//
+// story #2937(유나 P0-02 chip 전수 감사, 2026-08-22) — Badge chip variant가 다른 tint 변형
+// (destructive/success/info/warning, #2420 v3 규칙)과 동일하게 text-foreground를 쓰는지
+// 고정. text-muted-foreground(ink-3)로 되돌아가면 소비처 ~30(loops/retro/standup/gates/
+// trust/recruiter/agents/cage) 전체가 라이트 테마에서 다시 AA 미달로 회귀한다.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Badge } from './badge';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+describe('Badge — chip variant 대비(story #2937)', () => {
+  it('chip variant는 text-foreground를 쓴다(text-muted-foreground 아님)', async () => {
+    await act(async () => {
+      root.render(<Badge variant="chip">member</Badge>);
+    });
+    const el = container.querySelector('[data-slot="badge"]') as HTMLElement;
+    expect(el.className).toContain('text-foreground');
+    expect(el.className).not.toContain('text-muted-foreground');
+  });
+
+  it('다른 tint 변형(success/info/warning/destructive)과 동일한 text-foreground 규칙 — chip만 예외였던 상태로 되돌아가지 않는다', async () => {
+    await act(async () => {
+      root.render(
+        <div>
+          <Badge variant="success">a</Badge>
+          <Badge variant="info">b</Badge>
+          <Badge variant="warning">c</Badge>
+          <Badge variant="destructive">d</Badge>
+          <Badge variant="chip">e</Badge>
+        </div>,
+      );
+    });
+    const badges = [...container.querySelectorAll('[data-slot="badge"]')] as HTMLElement[];
+    expect(badges).toHaveLength(5);
+    for (const el of badges) {
+      expect(el.className).toContain('text-foreground');
+    }
+  });
+});

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -32,7 +32,14 @@ const badgeVariants = cva(
         success: "border-success-border bg-success-tint text-foreground",
         info: "border-info-border bg-info-tint text-foreground",
         warning: "border-warning-border bg-warning-tint text-foreground",
-        chip: "border-border/80 bg-muted/70 text-muted-foreground",
+        // story #2937(유나 P0-02 chip 전수 감사, 2026-08-22) — tint 배경 변형 중 chip만
+        // text-muted-foreground(ink-3) 잔존해 위 success/info/warning/destructive와 같은
+        // #2420 v3 규칙("tint 배경 위 글자는 text-foreground")을 못 지키고 있었다. 실측: ink-3
+        // on bg-muted/70 = 3.55 라이트(AA 4.5 미달)·소비처 ~30(loops/retro/standup/gates/
+        // trust/recruiter/agents/cage) 라이트 체계적 갭. text-foreground로 이행. 위계
+        // de-emphasis는 색이 아니라 tint 배경+작은 크기+pill 형태가 담당(다른 tint 변형이
+        // 이미 증명) — 무회귀.
+        chip: "border-border/80 bg-muted/70 text-foreground",
         counter: "border-transparent bg-destructive text-destructive-foreground",
       },
     },


### PR DESCRIPTION
## 요약
- PO 페드루 상신(2026-08-22) — 유나 P0-02 chip 전수 감사(소비처 ~30) 완료분 소비. `badge.tsx`의 tint 배경 변형 중 chip만 #2420 v3 규칙("tint 배경 위 글자는 text-foreground")을 못 지키고 text-muted-foreground(ink-3) 잔존 — 라이트 테마 체계적 AA 미달(merge 게이트타입 pill 단일측정 3.55).
- destructive/success/info/warning은 이미 전부 이행 완료, chip만 예외였음.

## 변경
- `badge.tsx`: `chip` variant `text-muted-foreground` → `text-foreground`. 소비처 ~30개 지점 오버라이드 대신 클래스 하나로 일괄 해소.
- 신규 `badge.test.tsx` 2건: chip=text-foreground 고정 + 다른 tint 변형과 동일 규칙 회귀가드.

## 검증
- `verify:tint-foreground-contrast`는 family(destructive/info/success/warning) 스캔 대상이라 muted/chip은 범위 밖(AC②의 "있으면"은 비적용 — 확장 불필요).
- FE 전체 478 files/4046 tests green(소비처 ~30 전량 무회귀) · tsc/eslint 0 · contrast 가드 4종 신규위반 0 · build 0.
- **잔여**: PR#3367의 gates/[id]/page.tsx merge-pill 지점 오버라이드는 별도로 #3367 브랜치에서 제거(클래스가 닫히면 지점 처방은 철수).

## 스크린샷
CSS 클래스 변경만 — 색상 자체(text-foreground)는 이미 다른 tint 변형에서 검증된 값 재사용, 신규 시각 언어 없음. 라이브 재확認은 머지 후 유나 담당(P0-02 계열 마감 플로우).