### PR TITLE
[2941][보안] PATCH /agent_personas의 tool_allowlist를 ApiKey.scope에 원자 재동기화

### DIFF
--- a/backend/app/repositories/agent_persona.py
+++ b/backend/app/repositories/agent_persona.py
@@ -257,6 +257,10 @@ class AgentPersonaRepository:
                 config.pop(key, None)
             if tl is not None:
                 config["tool_allowlist"] = tl
+                # story #2941 — 표시용(tool_allowlist)과 집행용(ApiKey.scope) 권한이 갈라지지
+                # 않도록 같은 세션·같은 트랜잭션에서 원자 재동기화(같은 커밋에 함께 들어간다).
+                from app.repositories.api_key import ApiKeyRepository
+                await ApiKeyRepository(self.session).sync_active_scope(persona.agent_id, tl)
             if rtid:
                 config["role_template_id"] = str(rtid)
 

--- a/backend/app/repositories/api_key.py
+++ b/backend/app/repositories/api_key.py
@@ -38,22 +38,32 @@ class ApiKeyRepository:
         )
         return result.scalar_one_or_none()
 
-    async def sync_active_scope(self, team_member_id: uuid.UUID, scope: list[str]) -> ApiKey | None:
+    async def sync_active_scope(self, team_member_id: uuid.UUID, scope: list[str]) -> list[uuid.UUID]:
         """story #2941 — `PATCH /agent_personas`가 표시용 tool_allowlist만 바꾸고 실제 집행값
         `ApiKey.scope`(매 요청 `_check_api_key_scope`로 검증)를 재동기화 안 하던 갭 봉합.
         `rotate()`와 달리 새 키를 발급하지 않는다 — 스코프 축소가 기존에 발급된 키에 **즉시**
         반영되는 게 보안 취지(호출자가 새 plaintext를 다시 받아야 하는 건 이 작업의 목적이
         아니다). 활성(revoked_at IS NULL) 키가 없으면(persona만 만들고 아직 recruit/키 발급이
-        없는 경우) no-op — None 반환, 에러 아님."""
-        await self.session.execute(
+        없는 경우) no-op — 빈 리스트 반환, 에러 아님.
+
+        ⚠️카디르 HIGH 재발견(2026-08-22): "활성 키는 항상 최대 1개"는 recruit
+        (`_rotate_or_create_key`) 경로에서만 참인 불변식이다 — 일반 발급 엔드포인트
+        `POST /agents/{agent_id}/api-keys`(`api_keys.py::create_agent_api_key`)는 기존 활성
+        키 존재 여부를 확인하지 않고 무조건 `repo.create()`로 신규 발급하므로, 한 agent가
+        합법적으로 활성 키를 2개 이상 가질 수 있다. UPDATE 문 자체는 WHERE 절에 매칭되는
+        모든 행을 원자적으로 갱신하므로 다중 키에도 원래 안전했지만, 예전 구현은 결과 확인용
+        후속 SELECT에 `scalar_one_or_none()`을 써 다중 키 케이스에서 `MultipleResultsFound`로
+        크래시했다 — 트랜잭션 전체 롤백으로 이어져 **권한 축소가 가장 필요한 다중 키 상황에서
+        정확히 실패**하는 최악의 결과였다. 처방: 후속 SELECT 자체를 없애고 UPDATE의
+        `RETURNING`으로 갱신된 모든 행의 id를 그대로 받는다 — 단일/다중 키 모두 동일 코드
+        경로로 안전."""
+        result = await self.session.execute(
             sa_update(ApiKey)
             .where(ApiKey.team_member_id == team_member_id, ApiKey.revoked_at.is_(None))
             .values(scope=scope)
+            .returning(ApiKey.id)
         )
-        result = await self.session.execute(
-            select(ApiKey).where(ApiKey.team_member_id == team_member_id, ApiKey.revoked_at.is_(None))
-        )
-        return result.scalar_one_or_none()
+        return list(result.scalars().all())
 
     async def create(
         self,

--- a/backend/app/repositories/api_key.py
+++ b/backend/app/repositories/api_key.py
@@ -38,6 +38,23 @@ class ApiKeyRepository:
         )
         return result.scalar_one_or_none()
 
+    async def sync_active_scope(self, team_member_id: uuid.UUID, scope: list[str]) -> ApiKey | None:
+        """story #2941 — `PATCH /agent_personas`가 표시용 tool_allowlist만 바꾸고 실제 집행값
+        `ApiKey.scope`(매 요청 `_check_api_key_scope`로 검증)를 재동기화 안 하던 갭 봉합.
+        `rotate()`와 달리 새 키를 발급하지 않는다 — 스코프 축소가 기존에 발급된 키에 **즉시**
+        반영되는 게 보안 취지(호출자가 새 plaintext를 다시 받아야 하는 건 이 작업의 목적이
+        아니다). 활성(revoked_at IS NULL) 키가 없으면(persona만 만들고 아직 recruit/키 발급이
+        없는 경우) no-op — None 반환, 에러 아님."""
+        await self.session.execute(
+            sa_update(ApiKey)
+            .where(ApiKey.team_member_id == team_member_id, ApiKey.revoked_at.is_(None))
+            .values(scope=scope)
+        )
+        result = await self.session.execute(
+            select(ApiKey).where(ApiKey.team_member_id == team_member_id, ApiKey.revoked_at.is_(None))
+        )
+        return result.scalar_one_or_none()
+
     async def create(
         self,
         team_member_id: uuid.UUID,

--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -417,14 +417,25 @@ async def _build_agent_card(session: AsyncSession, member: TeamMember, base_url:
         ]
 
     # 방향서 03·에이전트 속성(#2939 슬라이스②) — 권한 범위 표시 SSOT는 ApiKey.scope(실제
-    # 매 요청 집행되는 값). recruit 불변식상 활성(revoked_at IS NULL) 키는 최대 1개
-    # (`recruit_service._rotate_or_create_key` — 있으면 회전, 없으면 신규, 절대 2건 동시 생성
-    # 안 함). 방어적으로 created_at desc 1순위를 취한다(설계 doc §1 미확定 항목의 구현 판정).
+    # 매 요청 집행되는 값). ⚠️카디르 HIGH 재발견(story #2941, 2026-08-22): "활성 키 최대 1개"는
+    # recruit(`_rotate_or_create_key`) 경로에서만 참인 불변식 — 일반 발급 엔드포인트
+    # (`POST /agents/{agent_id}/api-keys`)는 기존 활성 키 확인 없이 무조건 신규 발급이라
+    # 합법적으로 활성 키가 2개 이상일 수 있다. 표시=집행값 원칙을 지키려면 "어느 한 키"를
+    # 임의로 골라 보여주면 안 된다(그 키로는 안 되고 다른 활성 키로는 되는 액션이 있을 수
+    # 있어 과소평가 위험) — 전 활성 키 scope의 **합집합**을 보인다("이 에이전트가 가진 어떤
+    # 자격증명으로도 할 수 있는 것" = 실제 노출 표면의 상한, no-fiction 원칙상 절대 과소평가
+    # 하지 않는 쪽). 활성 키 중 하나라도 scope=None(무제한)이면 전체를 무제한으로 표시
+    # (좁은 목록을 보여줘 실제보다 안전해 보이게 하는 것 자체가 과소평가).
     from app.repositories.api_key import ApiKeyRepository
 
     api_keys = await ApiKeyRepository(session).list_by_member(member.id)
-    active_key = next((k for k in api_keys if k.revoked_at is None), None)
-    permission_scope = list(active_key.scope) if active_key is not None and active_key.scope else None
+    active_keys = [k for k in api_keys if k.revoked_at is None]
+    if not active_keys:
+        permission_scope = None
+    elif any(k.scope is None for k in active_keys):
+        permission_scope = None
+    else:
+        permission_scope = sorted({s for k in active_keys for s in k.scope})
 
     interface_url = f"{base_url}/api/v2/a2a/members/{member.id}/rpc"
     return AgentCard(

--- a/backend/tests/test_2941_apikey_scope_resync_realdb.py
+++ b/backend/tests/test_2941_apikey_scope_resync_realdb.py
@@ -197,3 +197,64 @@ async def test_patch_tool_allowlist_no_active_key_is_noop_not_error():
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_patch_tool_allowlist_resyncs_all_active_keys_when_agent_has_multiple():
+    """카디르 HIGH 재발견(2026-08-22): "활성 키 최대 1개"는 recruit 경로에서만 참인
+    불변식 — 일반 발급 엔드포인트(POST /agents/{agent_id}/api-keys)는 기존 활성 키를
+    확인 안 하고 무조건 신규 발급이라 활성 키가 합법적으로 2개 이상일 수 있다. 이 상태서
+    PATCH로 권한을 축소하면 (a) 크래시 없이 (b) 두 키 전부 새 scope로 갱신돼야 한다."""
+    from app.core.database import Base
+    from app.models.team import TeamMember
+    from app.models.api_key import ApiKey
+    from app.repositories.agent_persona import AgentPersonaRepository
+
+    engine, Session = await _session()
+    try:
+        org_id, project_id = uuid.uuid4(), uuid.uuid4()
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent",
+                name="Multi Active Key Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.flush()
+
+            repo = AgentPersonaRepository(s)
+            persona = await repo.create(
+                org_id=org_id, project_id=project_id, agent_id=member.id, actor_id=uuid.uuid4(),
+                name="Multi Active Key Persona", tool_allowlist=["read", "write", "admin"],
+            )
+            key_a = ApiKey(
+                id=uuid.uuid4(), team_member_id=member.id, key_prefix="sk_live_multia",
+                key_hash="fake-hash-multi-a", scope=["read", "write", "admin"],
+            )
+            key_b = ApiKey(
+                id=uuid.uuid4(), team_member_id=member.id, key_prefix="sk_live_multib",
+                key_hash="fake-hash-multi-b", scope=["read", "write", "admin"],
+            )
+            s.add_all([key_a, key_b])
+            await s.commit()
+            persona_id, key_a_id, key_b_id = persona.id, key_a.id, key_b.id
+
+        async with Session() as s:
+            repo = AgentPersonaRepository(s)
+            # 크래시(MultipleResultsFound → 트랜잭션 롤백) 없이 완료돼야 한다.
+            await repo.update(
+                persona_id, org_id, project_id, uuid.uuid4(),
+                tool_allowlist=["read"],
+            )
+            await s.commit()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            refreshed_a = (await s.execute(select(ApiKey).where(ApiKey.id == key_a_id))).scalar_one()
+            refreshed_b = (await s.execute(select(ApiKey).where(ApiKey.id == key_b_id))).scalar_one()
+            assert refreshed_a.scope == ["read"], f"key A 미갱신: {refreshed_a.scope}"
+            assert refreshed_b.scope == ["read"], f"key B 미갱신: {refreshed_b.scope}"
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_2941_apikey_scope_resync_realdb.py
+++ b/backend/tests/test_2941_apikey_scope_resync_realdb.py
@@ -1,0 +1,199 @@
+"""story #2941(2939-② 설계 재조사 중 발견): PATCH /agent_personas의 tool_allowlist 갱신이
+ApiKey.scope(실제 매 요청 `_check_api_key_scope`로 집행되는 값)를 재동기화 안 해 표시용/
+집행용 권한이 드리프트하던 갭 — `AgentPersonaRepository.update()`가 tool_allowlist를 건드릴
+때 같은 세션·같은 트랜잭션에서 `ApiKeyRepository.sync_active_scope()`를 호출해 봉합.
+
+`rotate()`(신규 키 발급)가 아니라 활성 키의 scope만 원자 갱신 — 스코프 축소가 기존 발급 키에
+즉시 반영되는 게 보안 취지(호출자가 새 plaintext를 다시 받아야 하면 그 자체가 별도 마찰이라
+목적에 안 맞는다, PO 방향 확定)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3 컨벤션: create_all/drop_all 자체 스키마 관리 — 공유 alembic-migrated DB 오염 방지.
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _bypass_fk(session) -> None:
+    from sqlalchemy import text as _text
+    await session.execute(_text("SET session_replication_role = replica"))
+
+
+@pytest.mark.anyio
+async def test_patch_tool_allowlist_resyncs_active_api_key_scope():
+    """핵심 회귀: PATCH(=repo.update)로 tool_allowlist를 좁히면, 발급된 활성 키의 ApiKey.scope도
+    같은 값으로 즉시 바뀐다(드리프트가 실제로 봉합됐는지 직접 검증)."""
+    from app.core.database import Base
+    from app.models.team import TeamMember
+    from app.models.api_key import ApiKey
+    from app.repositories.agent_persona import AgentPersonaRepository
+
+    engine, Session = await _session()
+    try:
+        org_id, project_id = uuid.uuid4(), uuid.uuid4()
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent",
+                name="Scope Resync Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.flush()
+
+            repo = AgentPersonaRepository(s)
+            persona = await repo.create(
+                org_id=org_id, project_id=project_id, agent_id=member.id, actor_id=uuid.uuid4(),
+                name="Scope Resync Persona", tool_allowlist=["read", "write", "admin"],
+            )
+            key = ApiKey(
+                id=uuid.uuid4(), team_member_id=member.id, key_prefix="sk_live_resync",
+                key_hash="fake-hash-resync", scope=["read", "write", "admin"],
+            )
+            s.add(key)
+            await s.commit()
+            persona_id, key_id = persona.id, key.id
+
+        async with Session() as s:
+            repo = AgentPersonaRepository(s)
+            await repo.update(
+                persona_id, org_id, project_id, uuid.uuid4(),
+                tool_allowlist=["read"],  # 권한 축소
+            )
+            await s.commit()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            refreshed = (await s.execute(select(ApiKey).where(ApiKey.id == key_id))).scalar_one()
+            assert refreshed.scope == ["read"], (
+                f"PATCH로 tool_allowlist를 좁혔는데 실제 집행값 ApiKey.scope가 안 바뀜(드리프트 "
+                f"재발) — 얻은 값: {refreshed.scope}"
+            )
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_patch_tool_allowlist_does_not_touch_revoked_key():
+    """revoke된(옛) 키는 재동기화 대상이 아니다 — 활성 키만."""
+    from app.core.database import Base
+    from app.models.team import TeamMember
+    from app.models.api_key import ApiKey
+    from app.repositories.agent_persona import AgentPersonaRepository
+    from datetime import datetime, timezone
+
+    engine, Session = await _session()
+    try:
+        org_id, project_id = uuid.uuid4(), uuid.uuid4()
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent",
+                name="Revoked Untouched Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.flush()
+
+            repo = AgentPersonaRepository(s)
+            persona = await repo.create(
+                org_id=org_id, project_id=project_id, agent_id=member.id, actor_id=uuid.uuid4(),
+                name="Revoked Untouched Persona", tool_allowlist=["read"],
+            )
+            revoked_key = ApiKey(
+                id=uuid.uuid4(), team_member_id=member.id, key_prefix="sk_live_revoked",
+                key_hash="fake-hash-revoked", scope=["old_scope_should_stay"],
+                revoked_at=datetime.now(timezone.utc),
+            )
+            s.add(revoked_key)
+            await s.commit()
+            persona_id, revoked_key_id = persona.id, revoked_key.id
+
+        async with Session() as s:
+            repo = AgentPersonaRepository(s)
+            await repo.update(
+                persona_id, org_id, project_id, uuid.uuid4(),
+                tool_allowlist=["read", "write"],
+            )
+            await s.commit()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            refreshed = (await s.execute(
+                select(ApiKey).where(ApiKey.id == revoked_key_id)
+            )).scalar_one()
+            assert refreshed.scope == ["old_scope_should_stay"]
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_patch_tool_allowlist_no_active_key_is_noop_not_error():
+    """수기 생성 persona(recruit 이전, 키 발급 없음)에 PATCH해도 크래시하지 않는다."""
+    from app.core.database import Base
+    from app.models.team import TeamMember
+    from app.repositories.agent_persona import AgentPersonaRepository
+
+    engine, Session = await _session()
+    try:
+        org_id, project_id = uuid.uuid4(), uuid.uuid4()
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent",
+                name="No Key Yet Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.flush()
+
+            repo = AgentPersonaRepository(s)
+            persona = await repo.create(
+                org_id=org_id, project_id=project_id, agent_id=member.id, actor_id=uuid.uuid4(),
+                name="No Key Yet Persona",
+            )
+            await s.commit()
+            persona_id = persona.id
+
+        async with Session() as s:
+            repo = AgentPersonaRepository(s)
+            updated = await repo.update(
+                persona_id, org_id, project_id, uuid.uuid4(),
+                tool_allowlist=["read"],
+            )
+            await s.commit()
+        assert updated.config["tool_allowlist"] == ["read"]
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_a2a_sa4_streaming_realdb.py
+++ b/backend/tests/test_a2a_sa4_streaming_realdb.py
@@ -352,3 +352,72 @@ async def test_agent_card_permission_scope_ignores_revoked_key():
         assert card.permission_scope is None
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_card_permission_scope_unions_multiple_active_keys():
+    """카디르 HIGH 재발견(story #2941): 활성 키가 2개 이상일 수 있다(POST /agents/{id}/
+    api-keys는 recruit과 달리 기존 활성 키 확인 없이 무조건 신규 발급). "표시=집행값"
+    원칙상 어느 한 키만 임의로 보여주면 과소평가 위험 — 전 활성 키 scope의 합집합을 보인다."""
+    from app.routers.a2a import _build_agent_card
+    from app.models.team import TeamMember
+    from app.models.api_key import ApiKey
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), type="agent",
+                name="Multi Key Union Card Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.flush()
+            key_a = ApiKey(
+                id=uuid.uuid4(), team_member_id=member.id, key_prefix="sk_live_uniona",
+                key_hash="fake-hash-union-a", scope=["read", "write"],
+            )
+            key_b = ApiKey(
+                id=uuid.uuid4(), team_member_id=member.id, key_prefix="sk_live_unionb",
+                key_hash="fake-hash-union-b", scope=["deploy"],
+            )
+            s.add_all([key_a, key_b])
+            await s.commit()
+            card = await _build_agent_card(s, member, "http://test")
+        assert card.permission_scope == ["deploy", "read", "write"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_card_permission_scope_none_when_any_active_key_unrestricted():
+    """무제한(scope=None) 활성 키가 하나라도 있으면 좁은 목록으로 과소평가하지 않고
+    전체를 None(무제한)으로 표시한다."""
+    from app.routers.a2a import _build_agent_card
+    from app.models.team import TeamMember
+    from app.models.api_key import ApiKey
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), type="agent",
+                name="Unrestricted Key Card Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.flush()
+            narrow_key = ApiKey(
+                id=uuid.uuid4(), team_member_id=member.id, key_prefix="sk_live_narrow",
+                key_hash="fake-hash-narrow", scope=["read"],
+            )
+            unrestricted_key = ApiKey(
+                id=uuid.uuid4(), team_member_id=member.id, key_prefix="sk_live_unres",
+                key_hash="fake-hash-unrestricted", scope=None,
+            )
+            s.add_all([narrow_key, unrestricted_key])
+            await s.commit()
+            card = await _build_agent_card(s, member, "http://test")
+        assert card.permission_scope is None
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약
2939 슬라이스② 설계 재조사 중 발견한 권한 드리프트(story #2941, high)를 봉합한다: recruit 시점엔 `tool_allowlist`가 `ApiKey.scope`(매 요청 `_check_api_key_scope`로 실제 집행되는 값)에 기록되지만, 이후 `PATCH /agent_personas/{id}`는 `persona.config.tool_allowlist`(표시용 사본)만 갱신하고 `ApiKey.scope`를 재동기화하는 경로가 어디에도 없었다 — 권한 축소 의도가 실제 집행에 반영되지 않는 보안 갭.

## 설계 판단 (PO 질문 2건 응답)
① **재동기화 방식**: `ApiKeyRepository.rotate()`(새 키 발급, 이전 키 revoke)가 아니라 **활성 키의 `scope` 컬럼만 원자 UPDATE**하는 신설 메서드 `sync_active_scope()`를 썼다. "스코프 축소가 기존 발급 키에 즉시 반영되는 게 보안 취지"인데, rotate는 키 자격 자체를 바꿔(새 plaintext 발급) 호출자가 새 키를 다시 받아야 하는 부작용이 있어 목적에 안 맞는다. `AgentPersonaRepository.update()`가 `tool_allowlist`를 건드릴 때 같은 `self.session`에서 호출 — 별도 트랜잭션/커밋 없이 persona 갱신과 원자적으로 함께 들어간다.
② **판정 함수 한 곳**: scope 쓰기 경로는 recruit(`_rotate_or_create_key`, 기존 그대로 — 신규 발급/회전 시 scope 지정)과 PATCH(`sync_active_scope`, 이 PR 신설 — 기존 활성 키의 scope만 갱신)로 성격이 달라 통합하지 않고, 대신 PATCH 쪽 로직을 **하나의 리포지토리 메서드**로 캡슐화해 향후 다른 write 경로가 생겨도 그 메서드 하나만 재사용하면 되게 했다.

[SID:2941]

## 테스트
- `tests/test_2941_apikey_scope_resync_realdb.py` 3건: PATCH로 tool_allowlist 축소 시 활성 키 scope 즉시 반영·revoked 키는 비대상·키 미발급 persona에 PATCH해도 크래시 없음(no-op).
- 핵심 케이스(재동기화 확인)는 fix를 되돌려 원래 버그(`['read','write','admin']` 잔존)가 정확히 재현되는 것을 확인한 뒤 fix 복원 — 뮤테이션 검증.
- 기존 `test_e_recruit_s3_recruit_service_realdb.py`·`test_e_recruit_s5_connection_artifact_realdb.py`·`test_e_security_sec_s6/s7_*_realdb.py` 전부 통과(마이그레이션 격리 재실행으로 재확인).

## Test plan
- [x] 신규 realdb 테스트 3건 로컬 실 PG 통과
- [x] 핵심 케이스 뮤테이션 검증(fix 되돌려 실패 재현)
- [x] 기존 recruit/persona/보안 스코프 회귀 없음
- [ ] CI green