### PR TITLE
[SID:2937] gates/[id] chip 지점 오버라이드 제거(클래스가 닫힘)

### DIFF
--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -308,13 +308,12 @@ describe('GateDetailPage — evidence_viewed 서버 계약 (story #2027 AC2)', (
   });
 });
 
-// story P0-02(유나 full 검산, PR#3367 2026-08-22) — gate_type "chip" 배지가 Badge 기본
-// variant(text-muted-foreground on bg-muted/70)를 그대로 쓰면 AA 미달(실측 3.55). 전역
-// variant는 다른 소비처 파급이라 이 지점만 className 오버라이드(text-foreground — #2420 v3
-// "tint 배경 위 글자=text-foreground" 규칙과 동형, badge.tsx의 destructive/success/info/
-// warning variant가 이미 같은 규칙을 쓰고 chip만 예외였다).
-describe('GateDetailPage — gate_type 배지 대비(P0-02, PR#3367)', () => {
-  it('gate_type 배지가 text-foreground를 쓴다(chip variant 기본 text-muted-foreground 오버라이드)', async () => {
+// story P0-02(유나 full 검산, PR#3367 2026-08-22) — gate_type "chip" 배지가 AA 미달(실측
+// 3.55)이라 처음엔 이 지점만 className 오버라이드(text-foreground)로 처방했다. story #2937
+// (PR#3372)로 chip variant 기본 자체가 text-foreground로 이행 — 지점 오버라이드는 걷었고
+// (badge.tsx가 이제 이 값을 자동으로 준다), 이 가드는 그대로 유지(회귀 시 잡아냄).
+describe('GateDetailPage — gate_type 배지 대비(P0-02, chip variant 기본으로 승계·#2937)', () => {
+  it('gate_type 배지가 text-foreground를 쓴다(chip variant 기본값 — #2937 이후 지점 오버라이드 불요)', async () => {
     await mount(gate({ gate_type: 'merge_gate' }));
     const chipEl = [...container.querySelectorAll('span')].find((el) => el.textContent === 'merge_gate');
     expect(chipEl, 'gate_type 배지를 못 찾음').toBeDefined();

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -308,10 +308,13 @@ describe('GateDetailPage — evidence_viewed 서버 계약 (story #2027 AC2)', (
   });
 });
 
-// story P0-02(유나 full 검산, PR#3367 2026-08-22) — gate_type "chip" 배지가 AA 미달(실측
-// 3.55)이라 처음엔 이 지점만 className 오버라이드(text-foreground)로 처방했다. story #2937
-// (PR#3372)로 chip variant 기본 자체가 text-foreground로 이행 — 지점 오버라이드는 걷었고
-// (badge.tsx가 이제 이 값을 자동으로 준다), 이 가드는 그대로 유지(회귀 시 잡아냄).
+// story P0-02(PR#3367 2026-08-22) — gate_type "chip" 배지에 처음엔 이 지점만 className
+// 오버라이드(text-foreground)로 처방했다. ⚠️정정(2026-08-22, 유나 재검산·codex 교차확인) —
+// 당시 인용된 "3.55(AA 미달)"는 측정 아티팩트(bg-blend 버그)로 판명, 실측은 5.20/5.65로
+// 이미 AA 통과였다 — #3367은 「위반 수정」이 아니라 「#2420 캐논 규칙(tint 배경 위 글자=
+// text-foreground) 정합」이었다. story #2937(PR#3372)로 chip variant 기본 자체가
+// text-foreground로 이행 — 지점 오버라이드는 걷었고(badge.tsx가 이제 이 값을 자동으로
+// 준다), 이 가드는 그대로 유지(회귀 시 잡아냄).
 describe('GateDetailPage — gate_type 배지 대비(P0-02, chip variant 기본으로 승계·#2937)', () => {
   it('gate_type 배지가 text-foreground를 쓴다(chip variant 기본값 — #2937 이후 지점 오버라이드 불요)', async () => {
     await mount(gate({ gate_type: 'merge_gate' }));

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -213,13 +213,10 @@ export default function GateDetailPage() {
             footer={
               <div className="mt-3.5 space-y-3 border-t border-proof-line-soft pt-3">
                 <div className="flex flex-wrap items-center gap-1.5">
-                  {/* 유나 P0-02 full 검산(2026-08-22, PR#3367) — Badge "chip" variant 기본
-                      (text-muted-foreground on bg-muted/70)이 이 자리에서 AA 미달 실측(3.55).
-                      전역 variant를 고치면 다른 소비처 전부 파급이라 이 지점만 className
-                      오버라이드(text-foreground — #2420 "tint 위 계열색 글자=text-foreground"
-                      규칙과 동형). 전역 chip variant 자체의 대비 상향 여부는 유나 별도 판단
-                      (발견만 기록, 이 PR 스코프 아님). */}
-                  <Badge variant="chip" className="text-foreground">{gate.gate_type}</Badge>
+                  {/* story #2937(PR#3372, 2026-08-22)로 chip variant 기본 자체가
+                      text-foreground로 이행 — PR#3367의 이 지점 className 오버라이드는
+                      이제 중복. 클래스가 닫혔으니 지점 처방을 걷는다(PO 지시). */}
+                  <Badge variant="chip">{gate.gate_type}</Badge>
                   {deriveRiskLevel(gate) === 'high' ? (
                     <Badge variant="warning">{t('riskHigh')}</Badge>
                   ) : deriveRiskLevel(gate) === 'unknown' ? (


### PR DESCRIPTION
## 요약
PO 지시 — #3367의 임시 지점 오버라이드(`className="text-foreground"`)가 #2937(PR#3372)로 chip variant 기본값 자체가 text-foreground로 이행되며 중복이 됨. 둘 다 develop 착지 완료 — 지점 처방 철수.

## 변경
`<Badge variant="chip" className="text-foreground">` → `<Badge variant="chip">` (1줄). 회귀가드 테스트는 유지, 주석만 현재 사실로 갱신.

## 검증
tsc/eslint 0 · 해당 파일 14/14 + FE 전체 479 files/4059 tests green · contrast 가드 4종 신규위반 0 · build 0.