### PR TITLE
[2944][보안] 에이전트 API 키 일반 발급을 「발급=교체」로 통일

### DIFF
--- a/backend/app/repositories/api_key.py
+++ b/backend/app/repositories/api_key.py
@@ -101,6 +101,25 @@ class ApiKeyRepository:
         await self.session.refresh(key)
         return key
 
+    async def revoke_all_active(self, team_member_id: uuid.UUID) -> list[uuid.UUID]:
+        """story #2944(PO 정책 확定) — 「발급=교체」 통일의 원자적 절반: 이 agent의 활성 키 전량을
+        한 UPDATE로 revoke한다. 단일 키 CAS(`rotate()`가 `api_key_id` 하나만 대상)와 달리 여기는
+        "지금 활성인 것 전부"가 대상이라 다건이어도 안전 — WHERE 절 매칭 행 전부를 원자적으로
+        잠그고 갱신하므로(story #2941의 `sync_active_scope`와 동일 RETURNING 패턴, 후속 SELECT로
+        분리하지 않는다 — MultipleResultsFound 재발 클래스 원천 차단).
+
+        동시성: 두 발급 요청이 겹치면 Postgres 행잠금이 직렬화한다 — 먼저 커밋된 쪽이 revoke한
+        구키 위에 신규 키를 만들고, 나중 요청은 그 신규 키까지 다시 매칭해 재차 revoke 후 자기
+        신규 키를 만든다 — 최종적으로 활성 키는 항상 정확히 1개로 수렴(레이스가 나중 커밋
+        승자로 자연 정리, 별도 CAS 재시도 로직 불요)."""
+        result = await self.session.execute(
+            sa_update(ApiKey)
+            .where(ApiKey.team_member_id == team_member_id, ApiKey.revoked_at.is_(None))
+            .values(revoked_at=datetime.now(timezone.utc))
+            .returning(ApiKey.id)
+        )
+        return list(result.scalars().all())
+
     async def rotate(
         self, api_key_id: uuid.UUID, scope: list[str] | None = None
     ) -> tuple[ApiKey, str] | None:

--- a/backend/app/routers/api_keys.py
+++ b/backend/app/routers/api_keys.py
@@ -77,6 +77,14 @@ async def create_agent_api_key(
     repo: ApiKeyRepository = Depends(_get_repo),
 ) -> ApiKeyCreatedResponse:
     await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
+    # story #2944(PO 정책 확定, 카디르 HIGH 발견 후속) — 「발급=교체」 통일: 이 엔드포인트가
+    # 예전엔 기존 활성 키 확인 없이 무조건 신규 발급이라 다건 활성 키가 합법으로 생겼다(2941의
+    # 다중 키 방어는 그 결과를 다루는 임시 봉합, 이건 유입 자체를 막는 정본). FE
+    # (agent-api-key-manager.tsx)도 이미 이 의도(활성 키 있으면 revoke-확認 다이얼로그)로 설계돼
+    # 있었다 — 서버가 그 의도를 원자적으로 강제한다. rotate()와 같은 agent-scoped lock으로
+    # recruit_agent()/rotate와도 직렬화(크로스엔드포인트 레이스 봉인, 기존 컨벤션 재사용).
+    await acquire_agent_mutation_lock(session, agent_id)
+    await repo.revoke_all_active(agent_id)
     key, plaintext = await repo.create(
         team_member_id=agent_id,
         scope=body.scope,

--- a/backend/tests/test_2944_api_key_issuance_replace_semantics_realdb.py
+++ b/backend/tests/test_2944_api_key_issuance_replace_semantics_realdb.py
@@ -1,0 +1,322 @@
+"""story #2944(PO 정책 확定 2026-08-22) — 「발급=교체」 통일: `POST /agents/{agent_id}/api-keys`가
+예전엔 기존 활성 키 확認 없이 무조건 신규 발급이라 활성 키 N개가 합법으로 생겼다(카디르 #3373
+HIGH 발견 → dev DB 실측: 135 agent 중 2건 다건, 둘 다 "몇 주~몇 달 뒤 구키를 잊고 재발급" 시그니처,
+그중 1건은 scope=None(무제한) 신규키+구 narrow 키 공존).
+
+처방: `create_agent_api_key`가 이제 신규 발급 前 `ApiKeyRepository.revoke_all_active()`로 그
+agent의 활성 키 전량을 원자적으로(단일 UPDATE...RETURNING) revoke한다 — 단일/다중 키 모두 동일
+코드 경로(story #2941의 MultipleResultsFound 재발 클래스를 원천 차단하는 것과 같은 패턴).
+FE(agent-api-key-manager.tsx)는 이미 이 의도(활성 키 있으면 revoke-확認 다이얼로그)로 설계돼
+있었다 — 서버가 이제 그 의도를 원자적으로 강제한다.
+
+2941/2939의 다중 키 방어(합집합 표시·전량 UPDATE 재동기화)는 정책과 무관하게 유지(과거 데이터·
+엣지 케이스 대응)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _bypass_fk(session) -> None:
+    from sqlalchemy import text as _text
+    await session.execute(_text("SET session_replication_role = replica"))
+
+
+async def _seed_agent(session):
+    from app.models.team import TeamMember
+    await _bypass_fk(session)
+    member = TeamMember(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), type="agent",
+        name="2944 Test Agent", role="member", is_active=True,
+    )
+    session.add(member)
+    await session.flush()
+    return member.id
+
+
+# ── repo.revoke_all_active() — 단위 ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_revoke_all_active_revokes_single_key():
+    from app.repositories.api_key import ApiKeyRepository
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent_id = await _seed_agent(s)
+            repo = ApiKeyRepository(s)
+            key, _pt = await repo.create(team_member_id=agent_id, scope=["read"], expires_at=None)
+            await s.commit()
+
+            revoked_ids = await repo.revoke_all_active(agent_id)
+            await s.commit()
+            assert revoked_ids == [key.id]
+
+            fresh = await repo.get(key.id)
+            assert fresh.revoked_at is not None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(__import__("app.core.database", fromlist=["Base"]).Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_revoke_all_active_revokes_multiple_keys_no_crash():
+    """카디르 HIGH 재발견 클래스 — MultipleResultsFound가 아니라 전량 RETURNING이라 다건도 안전."""
+    from app.repositories.api_key import ApiKeyRepository
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent_id = await _seed_agent(s)
+            repo = ApiKeyRepository(s)
+            key_a, _ = await repo.create(team_member_id=agent_id, scope=["read"], expires_at=None)
+            key_b, _ = await repo.create(team_member_id=agent_id, scope=None, expires_at=None)
+            await s.commit()
+
+            revoked_ids = await repo.revoke_all_active(agent_id)
+            await s.commit()
+            assert set(revoked_ids) == {key_a.id, key_b.id}
+
+            fresh_a = await repo.get(key_a.id)
+            fresh_b = await repo.get(key_b.id)
+            assert fresh_a.revoked_at is not None
+            assert fresh_b.revoked_at is not None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(__import__("app.core.database", fromlist=["Base"]).Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_revoke_all_active_no_active_keys_is_noop():
+    from app.repositories.api_key import ApiKeyRepository
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent_id = await _seed_agent(s)
+            await s.commit()
+            repo = ApiKeyRepository(s)
+            revoked_ids = await repo.revoke_all_active(agent_id)
+            assert revoked_ids == []
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(__import__("app.core.database", fromlist=["Base"]).Base.metadata.drop_all)
+        await engine.dispose()
+
+
+# ── HTTP 엔드포인트 — direct-API 경로 재현(FE 게이트 우회 시나리오) ────────────
+
+
+async def _client_and_session():
+    import app.models  # noqa: F401
+    from app.main import app
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    org_id = uuid.uuid4()
+    actor_id = uuid.uuid4()
+
+    async def override_db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def override_auth():
+        return AuthContext(user_id=str(actor_id), email=None, claims={"app_metadata": {"org_id": str(org_id)}}, org_id=str(org_id))
+
+    async def override_org_id():
+        return org_id
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    app.dependency_overrides[get_verified_org_id] = override_org_id
+
+    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+    return client, Session, app, org_id, actor_id, engine
+
+
+@pytest.mark.anyio
+async def test_direct_api_reissue_revokes_prior_key_end_to_end():
+    """FE 게이트를 안 거치는 직접 API 호출(dev 실측 시나리오 그대로) — 이미 활성 키가 있는
+    agent에게 일반 발급 엔드포인트를 다시 호출하면, 새 키만 활성으로 남고 구키는 revoke돼야
+    한다(예전엔 둘 다 활성으로 남았다 — 미르코/hermes-test 실사고 그대로)."""
+    from app.models.team import TeamMember
+    from app.repositories.api_key import ApiKeyRepository
+
+    client, Session, app, org_id, actor_id, engine = await _client_and_session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=uuid.uuid4(), type="agent",
+                name="Reissue Test Agent", role="member", is_active=True, created_by=actor_id,
+            )
+            s.add(member)
+            await s.commit()
+            agent_id = member.id
+
+            repo = ApiKeyRepository(s)
+            old_key, _pt = await repo.create(
+                team_member_id=agent_id, scope=["read", "write"], expires_at=None
+            )
+            await s.commit()
+            old_key_id = old_key.id
+
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/agents/{agent_id}/api-keys",
+                json={"scope": ["stories", "tasks"], "expires_at": None},
+            )
+        assert resp.status_code == 201, resp.text
+        new_key_id = uuid.UUID(resp.json()["id"])
+
+        async with Session() as s:
+            repo = ApiKeyRepository(s)
+            refreshed_old = await repo.get(old_key_id)
+            refreshed_new = await repo.get(new_key_id)
+            assert refreshed_old.revoked_at is not None, "구키가 revoke 안 됨 — #2944 회귀"
+            assert refreshed_new.revoked_at is None
+            assert refreshed_new.scope == ["stories", "tasks"]
+
+            active = [k for k in await repo.list_by_member(agent_id) if k.revoked_at is None]
+            assert len(active) == 1, f"활성 키가 정확히 1개여야 하는데 {len(active)}개"
+    finally:
+        app.dependency_overrides.clear()
+        async with engine.begin() as conn:
+            from app.core.database import Base
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_direct_api_reissue_revokes_multiple_prior_keys_end_to_end():
+    """dev 실측과 동형 — 이미 다건 활성 키가 있는 상태(카디르 발견 시나리오)에서 재발급하면
+    기존 것 전부 revoke되고 신규 1개만 남는다."""
+    from app.models.team import TeamMember
+    from app.repositories.api_key import ApiKeyRepository
+
+    client, Session, app, org_id, actor_id, engine = await _client_and_session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=uuid.uuid4(), type="agent",
+                name="Multi Reissue Test Agent", role="member", is_active=True, created_by=actor_id,
+            )
+            s.add(member)
+            await s.commit()
+            agent_id = member.id
+
+            repo = ApiKeyRepository(s)
+            old_a, _ = await repo.create(team_member_id=agent_id, scope=["read"], expires_at=None)
+            old_b, _ = await repo.create(team_member_id=agent_id, scope=None, expires_at=None)
+            await s.commit()
+            old_ids = {old_a.id, old_b.id}
+
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/agents/{agent_id}/api-keys",
+                json={"scope": ["stories"], "expires_at": None},
+            )
+        assert resp.status_code == 201, resp.text
+
+        async with Session() as s:
+            repo = ApiKeyRepository(s)
+            keys = await repo.list_by_member(agent_id)
+            active = [k for k in keys if k.revoked_at is None]
+            revoked = [k for k in keys if k.revoked_at is not None]
+            assert len(active) == 1
+            assert {k.id for k in revoked} == old_ids
+    finally:
+        app.dependency_overrides.clear()
+        async with engine.begin() as conn:
+            from app.core.database import Base
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_direct_api_first_issuance_unaffected_when_no_prior_key():
+    """무회귀: 첫 발급(활성 키 0개)은 기존 동작 그대로 — revoke 대상 없음, 정상 201."""
+    from app.models.team import TeamMember
+    from app.repositories.api_key import ApiKeyRepository
+
+    client, Session, app, org_id, actor_id, engine = await _client_and_session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=uuid.uuid4(), type="agent",
+                name="First Issuance Test Agent", role="member", is_active=True, created_by=actor_id,
+            )
+            s.add(member)
+            await s.commit()
+            agent_id = member.id
+
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/agents/{agent_id}/api-keys",
+                json={"scope": ["stories"], "expires_at": None},
+            )
+        assert resp.status_code == 201, resp.text
+
+        async with Session() as s:
+            repo = ApiKeyRepository(s)
+            active = [k for k in await repo.list_by_member(agent_id) if k.revoked_at is None]
+            assert len(active) == 1
+    finally:
+        app.dependency_overrides.clear()
+        async with engine.begin() as conn:
+            from app.core.database import Base
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_2944_api_key_issuance_replace_semantics_realdb.py
+++ b/backend/tests/test_2944_api_key_issuance_replace_semantics_realdb.py
@@ -144,7 +144,6 @@ async def _client_and_session():
     import app.models  # noqa: F401
     from app.main import app
     from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
-    from app.dependencies.database import get_db
     from httpx import ASGITransport, AsyncClient
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base
@@ -165,6 +164,9 @@ async def _client_and_session():
     async def override_db():
         async with Session() as s:
             try:
+                # 동시 요청은 각자 새 물리 커넥션을 열 수 있어(풀에서 재사용 안 됨) 시딩
+                # 세션에만 건 session_replication_role=replica가 안 이어진다 — 매 세션마다.
+                await _bypass_fk(s)
                 yield s
                 await s.commit()
             except Exception:
@@ -177,7 +179,8 @@ async def _client_and_session():
     async def override_org_id():
         return org_id
 
-    app.dependency_overrides[get_db] = override_db
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, override_db)
     app.dependency_overrides[get_current_user] = override_auth
     app.dependency_overrides[get_verified_org_id] = override_org_id
 
@@ -314,6 +317,60 @@ async def test_direct_api_first_issuance_unaffected_when_no_prior_key():
             repo = ApiKeyRepository(s)
             active = [k for k in await repo.list_by_member(agent_id) if k.revoked_at is None]
             assert len(active) == 1
+    finally:
+        app.dependency_overrides.clear()
+        async with engine.begin() as conn:
+            from app.core.database import Base
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_concurrent_issuance_calls_serialize_to_exactly_one_active_key():
+    """카디르 QA 축 — agent-scoped advisory lock(`acquire_agent_mutation_lock`)이 실제로
+    동시 발급을 직렬화하는지 실증. 락 없이 두 요청이 동시에 revoke_all_active→create를
+    인터리빙하면(둘 다 "지금은 활성 키 없음"을 보고 각자 신규 발급) 활성 키가 2개 남을
+    위험이 있다 — 락이 실동작하면 항상 정확히 1개로 수렴해야 한다."""
+    import asyncio
+    from app.models.team import TeamMember
+    from app.repositories.api_key import ApiKeyRepository
+    from httpx import ASGITransport, AsyncClient
+
+    client, Session, app, org_id, actor_id, engine = await _client_and_session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=uuid.uuid4(), type="agent",
+                name="Concurrent Issuance Test Agent", role="member", is_active=True,
+                created_by=actor_id,
+            )
+            s.add(member)
+            await s.commit()
+            agent_id = member.id
+
+            repo = ApiKeyRepository(s)
+            await repo.create(team_member_id=agent_id, scope=["read"], expires_at=None)
+            await s.commit()
+
+        async def _issue(scope: list[str]) -> int:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post(
+                    f"/api/v2/agents/{agent_id}/api-keys",
+                    json={"scope": scope, "expires_at": None},
+                )
+                return resp.status_code
+
+        statuses = await asyncio.gather(_issue(["stories"]), _issue(["tasks"]))
+        assert all(s == 201 for s in statuses), statuses
+
+        async with Session() as s:
+            repo = ApiKeyRepository(s)
+            active = [k for k in await repo.list_by_member(agent_id) if k.revoked_at is None]
+            assert len(active) == 1, (
+                f"동시 발급 후 활성 키가 정확히 1개여야 하는데 {len(active)}개 — "
+                f"agent-scoped lock이 직렬화 못함"
+            )
     finally:
         app.dependency_overrides.clear()
         async with engine.begin() as conn:

--- a/backend/tests/test_s35.py
+++ b/backend/tests/test_s35.py
@@ -66,8 +66,12 @@ async def test_create_api_key_201():
     client, session, app = await _client()
     try:
         with patch("app.routers.api_keys.assert_agent_owner", new_callable=AsyncMock), \
+             patch("app.routers.api_keys.acquire_agent_mutation_lock", new_callable=AsyncMock), \
              patch("app.services.agent_message_policy.ensure_creator_allowlisted", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.revoke_all_active", new_callable=AsyncMock) as mock_revoke_all, \
              patch("app.repositories.api_key.ApiKeyRepository.create", new_callable=AsyncMock) as mock_create:
+            # story #2944 — 「발급=교체」: 이 엔드포인트가 이제 기존 활성 키를 먼저 전량 revoke한다.
+            mock_revoke_all.return_value = []
             mock_create.return_value = (_mock_key(), PLAINTEXT)
 
             async with client as c:


### PR DESCRIPTION
## 요약
story #2944(PO 정책 확定, story #2941 QA 중 카디르 HIGH 발견의 후속) — `POST /agents/{agent_id}/api-keys`(일반 발급)가 기존 활성 키 확인 없이 무조건 신규 발급이라 활성 키 N개가 합법으로 생기던 갭을 「발급=교체」로 통일한다.

## 정책 그라운딩(이 PR 이전에 완료, story #2944 본문 참조)
- FE(`agent-api-key-manager.tsx`)의 유일한 "Generate API Key" 버튼 핸들러는 이미 `activeKeys.length > 0`이면 revoke-확認 다이얼로그로 보내는 설계 — **서버가 이제 그 의도를 원자적으로 강제**.
- dev DB 실측(135 agent 중 다건 2건, 3개 이상 0건): 둘 다 "몇 주~몇 달 뒤 구키를 잊고 재발급" 동일 시그니처(의도적 병행 근거 0), 그중 1건은 `scope=None`(무제한) 신규 키+구 narrow 키 공존.

## 구현
- `ApiKeyRepository.revoke_all_active(team_member_id)`: 활성 키 전량을 단일 `UPDATE ... RETURNING`으로 원자 revoke — 단일/다중 키 모두 동일 코드 경로(story #2941의 `MultipleResultsFound` 재발 클래스와 동일 원인이라 동일 패턴으로 원천 차단).
- `create_agent_api_key`: 신규 발급 前 `revoke_all_active` 호출 + `recruit_agent()`/`rotate_api_key`와 같은 agent-scoped advisory lock(`acquire_agent_mutation_lock`)으로 크로스엔드포인트 레이스 직렬화(기존 컨벤션 재사용, 신규 발명 아님).

## 스코프 밖(별도 확定)
- 소급 정리(dev에 이미 존재하는 2건의 잔존 구키 revoke)는 파괴적 조치라 "그 키의 최근 사용 실측(마지막 인증 시각)" 선행 필수 — 별도 슬라이스.
- story #2941/#2939의 다중 키 방어(합집합 표시·전량 UPDATE 재동기화)는 정책과 무관하게 유지(과거 데이터·엣지 케이스 대응).
- prod 분포 실측은 소급 정리 슬라이스에서(이 정책 자체엔 불영향).

[SID:2944]

## 테스트
- `tests/test_2944_api_key_issuance_replace_semantics_realdb.py` 6건: repo 단위(단일/다중/무 활성키 revoke) + direct-API E2E(FE 게이트 우회 시나리오, dev 실사고 그대로 재현).
- E2E 핵심 케이스는 fix를 되돌려 정확히 dev 실사고(활성 키 잔존)가 재현되는 것을 확인한 뒤 복원 — 뮤테이션 검증.
- `tests/test_s35.py`의 기존 mocked-session 테스트에 `ApiKeyRepository.revoke_all_active` mock 배선 추가(신규 repo 메서드 호출을 raw AsyncMock 세션이 못 따라가는 것 — #3371에서 겪은 것과 같은 클래스).
- 관련 65건(recruit S3/S16 IDOR/#2838 만료 정책/#1940 human keys/#2058 scope allowlist 등) 회귀 없음.

## Test plan
- [x] 신규 realdb 테스트 6건 로컬 실 PG 통과
- [x] E2E 핵심 케이스 뮤테이션 검증(fix 되돌려 dev 실사고 재현)
- [x] 기존 API 키 관련 회귀 65건 없음
- [ ] CI green