### PR TITLE
[긴급] 칸반 보드 기본 컬럼축 status→trust 플립(P0-04) [SID:1d6001d6-fb36-4d68-a1f1-6856c6161156]

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -59,13 +59,28 @@ function wrap(node: React.ReactNode) {
   );
 }
 
+// PO 긴급 fix(P0-04 기본축 trust 플립, 2026-08-22) — 실 BE는 trust_stage를 매 요청마다
+// derive_trust_stage()로 항상 계산해 내려준다(backend/app/services/trust_pipeline.py, done/미지
+// status 제외 None 없음). 이 축과 무관한 기존 테스트 다수가 trust_stage 없는 고정(fixture)을
+// 써왔는데, 기본 뷰가 trust로 바뀌면 그 고정이 실 BE 응답과 달라 카드가 어느 컬럼에도 안 걸려
+// 사라진다(storyTrustColumn: status!=='done'이면 trust_stage ?? null). 개별 테스트 50여곳을
+// 일일이 고치는 대신 이 stub 자체를 실 BE 파생 규칙과 정합시킨다 — 명시적으로 trust_stage를
+// 지정한 케이스(H4 테스트 등, null 명시 포함)는 그대로 존중하고 아예 안 준 경우만 채운다.
+function deriveDefaultTrustStage(status: string): string | null {
+  if (status === 'backlog' || status === 'ready-for-dev') return 'queued';
+  if (status === 'in-progress') return 'running';
+  if (status === 'in-review') return 'claimed_done';
+  return null; // done/미지 status — derive_trust_stage와 동형.
+}
+
 function stubFetch(stories: Array<Record<string, unknown> & { status: string }>, members: Array<Record<string, unknown>> = []) {
+  const withTrustStage = stories.map((s) => ('trust_stage' in s ? s : { ...s, trust_stage: deriveDefaultTrustStage(s.status) }));
   // CB-S4: 보드는 status별 5회 독립 호출(/api/stories?...&status=<col>) — 각 호출에 해당
   // status만 필터링해 {data:[...]} 형태(meta 포함)로 응답해야 실제 파싱 경로(json.data ?? [])와 맞는다.
   vi.stubGlobal('fetch', vi.fn(async (url: string) => {
     if (typeof url === 'string' && url.startsWith('/api/stories?')) {
       const status = new URL(url, 'http://localhost').searchParams.get('status');
-      const matched = stories.filter((s) => s.status === status);
+      const matched = withTrustStage.filter((s) => s.status === status);
       return { ok: true, json: async () => ({ data: matched, meta: { total: matched.length, nextCursor: null } }) };
     }
     if (typeof url === 'string' && url.startsWith('/api/members')) {
@@ -624,11 +639,36 @@ describe('KanbanBoard — 6단계 신뢰축 뷰(story #2933 H4)', () => {
     await act(async () => { btn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
   }
 
-  it('기본은 5-status 클래식 뷰 — 신뢰축 컬럼 라벨이 안 보인다', async () => {
+  // PO 긴급 fix(선생님 지적, 2026-08-22) — 방향서 P0-04 원문 «기본 상태는 신뢰 파이프라인으로»를
+  // #2933 done 선언 당시 전원(오르테가·QA·design)이 놓쳐 기본값이 거꾸로 'status'였다(실측
+  // 결함). 이 테스트는 원래 그 잘못된 기본값을 그린으로 고정했던 자리 — 스펙대로 뒤집는다.
+  it('기본은 6단계 신뢰축 뷰(P0-04 스펙) — localStorage 미설정 시 5-status 클래식 라벨이 안 보인다', async () => {
     stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', trust_stage: 'queued' }]);
     await mount();
+    expect(container.textContent).toContain('입력 필요');
+    expect(container.textContent).toContain('머지 준비');
+    expect(container.textContent).not.toContain('개발 대기');
+  });
+
+  it('사용자가 명시적으로 5-status 클래식을 선택하면(localStorage) 기본값 뒤집기와 무관하게 존중된다', async () => {
+    stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', trust_stage: 'queued' }]);
+    await mount();
+    const classicBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '5-status 클래식');
+    expect(classicBtn, '클래식 토글 버튼을 못 찾음').toBeDefined();
+    await act(async () => { classicBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(container.textContent).not.toContain('입력 필요');
-    expect(container.textContent).not.toContain('머지 준비');
+
+    await act(async () => { root.unmount(); });
+    container.remove();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.resetModules();
+    stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', trust_stage: 'queued' }]);
+    stubEventSource();
+    await mount();
+    // 재마운트 후에도 명시 선택('status')이 새 기본값('trust')을 덮어쓰지 않고 유지된다.
+    expect(container.textContent).not.toContain('입력 필요');
   });
 
   it('토글 클릭 시 7컬럼(대기/실행 중/입력 필요/주장 완료/검증·잔존/머지 준비/완료) 전부 렌더된다', async () => {

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -173,6 +173,32 @@ describe('KanbanBoard — 보드 first-touch 절제된 배너', () => {
     expect(container.querySelector('input, textarea')).not.toBeNull();
   });
 
+  // ⚠️QA changes(PR#3378, 카디르+codex, 2026-08-22, HIGH) — CTA 브리지가 handleSetAxisMode를
+  // 쓰면 saveAxisMode까지 타 localStorage에 'status'가 영구 저장돼, CTA를 한 번만 눌러도
+  // 그 프로젝트가 조용히 classic으로 고정된다(재마운트해도 trust로 안 돌아옴 — 기본값
+  // 플립의 취지 자체가 무효화). setAxisMode만 쓰는 세션 한정 전환으로 좁혀 이 저장이
+  // 없는지 직접 증명한다.
+  it('배너 CTA 클릭은 축 전환을 localStorage에 저장하지 않는다 — 재마운트하면 다시 신뢰축 기본값', async () => {
+    stubFetch([]);
+    await mount();
+    const ctaButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('첫 스토리 만들기'));
+    await act(async () => { ctaButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.querySelector('input, textarea')).not.toBeNull(); // 임시 전환 자체는 여전히 동작.
+
+    await act(async () => { root.unmount(); });
+    container.remove();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.resetModules();
+    stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', trust_stage: 'queued' }]);
+    stubEventSource();
+    await mount();
+    // CTA 클릭이 명시 선택으로 저장됐다면 여기서도 classic(5-status)일 것 — 저장 안 됐으므로
+    // 기본값(trust)으로 복귀해 신뢰축 라벨이 다시 보인다.
+    expect(container.textContent).toContain('입력 필요');
+  });
+
   it('스토리 데이터가 있으면 배너가 렌더되지 않는다(회귀 0)', async () => {
     stubFetch([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium' }]);
     await mount();

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -116,9 +116,13 @@ function axisModeKey(projectId: string | undefined): string {
   return `board_axis_mode_${projectId ?? 'default'}`;
 }
 
+// PO 긴급 fix(선생님 지적, 2026-08-22) — 방향서 P0-04 원문 «5-status를 보조 뷰로 남기고
+// 기본 상태는 신뢰 파이프라인으로» = 기본값은 'trust'가 스펙. localStorage 미설정 시 'status'로
+// 낙하하던 게 실측 결함(#2933 done 선언 당시 전원이 놓친 사각) — 명시적으로 저장된 'status'
+// 선택만 존중하고, 그 외(미설정 포함)엔 'trust'로 낙하한다.
 function loadAxisMode(projectId: string | undefined): 'status' | 'trust' {
-  if (typeof window === 'undefined') return 'status';
-  return localStorage.getItem(axisModeKey(projectId)) === 'trust' ? 'trust' : 'status';
+  if (typeof window === 'undefined') return 'trust';
+  return localStorage.getItem(axisModeKey(projectId)) === 'status' ? 'status' : 'trust';
 }
 
 function saveAxisMode(projectId: string | undefined, mode: 'status' | 'trust'): void {
@@ -167,7 +171,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
   // story #2933 H4(P0-H) — 5-status/6단계 신뢰축 컬럼 축 토글. viewMode(board/list)와 직교
   // (list 뷰는 이번 슬라이스 스코프 밖 — trust 축은 board 렌더 안에서만). doneCollapsed와
   // 동형 localStorage 패턴(project별) — 재방문해도 마지막 선택 유지.
-  const [axisMode, setAxisMode] = useState<'status' | 'trust'>('status');
+  const [axisMode, setAxisMode] = useState<'status' | 'trust'>('trust');
   useEffect(() => {
     setAxisMode(loadAxisMode(projectId));
   }, [projectId]);
@@ -1516,13 +1520,19 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           // ⚠️컬럼 그리드를 대체하지 않고 그 위 배너로만 — CTA가 여는 백로그 인라인 컴포저
           // (autoComposeSignal)가 KanbanColumn 내부 상태라, 컬럼 자체가 마운트돼 있어야
           // CTA 클릭이 실제로 컴포저를 연다(대체했다면 신호를 받을 컬럼이 없어 무반응했을 것).
+          //
+          // PO 긴급 fix(P0-04 기본축 trust 플립, 2026-08-22) — 인라인 컴포저는 KanbanColumn
+          // (5-status 클래식) 전용이라 KanbanTrustColumn엔 아직 없다(별도 스토리 필요 규모라
+          // 이 소PR 스코프 밖). 기본축이 trust로 바뀌면서 이 CTA가 신호를 받을 컬럼 자체가
+          // 없어 무반응해지는 걸 막기 위해, 클릭 시 클래식 축으로 먼저 전환한다(무한 회귀
+          // onboarding 실종보다 «클래식으로 넘어가서 만든다»가 정직한 임시 처방).
           <div className="shrink-0 border-b border-border/60 px-6 py-4">
             <EmptyState
               icon={<Workflow className="size-8" />}
               title={t('boardEmptyTitle')}
               description={t('boardEmptyDescription')}
               action={
-                <Button size="sm" onClick={() => setAutoComposeNonce((n) => n + 1)}>
+                <Button size="sm" onClick={() => { handleSetAxisMode('status'); setAutoComposeNonce((n) => n + 1); }}>
                   <Plus className="size-3.5" />
                   {t('boardEmptyCta')}
                 </Button>

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1526,13 +1526,19 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           // 이 소PR 스코프 밖). 기본축이 trust로 바뀌면서 이 CTA가 신호를 받을 컬럼 자체가
           // 없어 무반응해지는 걸 막기 위해, 클릭 시 클래식 축으로 먼저 전환한다(무한 회귀
           // onboarding 실종보다 «클래식으로 넘어가서 만든다»가 정직한 임시 처방).
+          //
+          // ⚠️QA changes(PR#3378, 카디르+codex, 2026-08-22, HIGH) — handleSetAxisMode를 쓰면
+          // saveAxisMode까지 타 localStorage에 'status'가 **영구 저장**된다(CTA 클릭이 명시적
+          // 사용자 선택이 아닌데도 명시 선택처럼 기록돼, 이 프로젝트가 재마운트해도 다시는
+          // trust로 안 돌아간다 — 플립의 취지 자체를 무효화). 저장 없는 setAxisMode만 써서
+          // 이번 세션 한정 임시 전환으로 좁힌다.
           <div className="shrink-0 border-b border-border/60 px-6 py-4">
             <EmptyState
               icon={<Workflow className="size-8" />}
               title={t('boardEmptyTitle')}
               description={t('boardEmptyDescription')}
               action={
-                <Button size="sm" onClick={() => { handleSetAxisMode('status'); setAutoComposeNonce((n) => n + 1); }}>
+                <Button size="sm" onClick={() => { setAxisMode('status'); setAutoComposeNonce((n) => n + 1); }}>
                   <Plus className="size-3.5" />
                   {t('boardEmptyCta')}
                 </Button>


### PR DESCRIPTION
## 배경
방향서 P0-04 원문 «5-status를 보조 뷰로 남기고 기본 상태는 신뢰 파이프라인으로»가 스펙인데, `loadAxisMode`가 localStorage 미설정 시 `'status'`로 낙하해 실제로는 기본값이 거꾸로였습니다(#2933 done 선언 당시 전원이 놓친 사각 — 선생님 지적으로 실측 확인).

## 변경
- `loadAxisMode`: 명시적으로 저장된 `'status'` 선택만 존중, 그 외(미설정 포함)엔 `'trust'`로 낙하하도록 반전
- 초기 `useState` 기본값도 `'trust'`로 정정(마운트 직후 잠깐의 클래식 플래시 방지)
- **부수 발견(즉시 처방)**: 인라인 스토리 컴포저(`autoComposeSignal`)는 `KanbanColumn`(클래식 5-status) 전용이라 `KanbanTrustColumn`엔 없습니다. 기본축이 trust로 바뀌면서 빈 보드의 "첫 스토리 만들기" CTA가 신호를 받을 컬럼이 없어 무반응해지는 걸 막기 위해, 클릭 시 클래식 축으로 먼저 전환하도록 처리(온보딩 경로 보존 — 트러스트뷰 인라인 컴포저 자체는 별도 스토리 스코프로 남겨둡니다)
- 테스트: 옛 기본값을 그린으로 고정했던 자리를 스펙대로 뒤집고, 명시 선택이 존중되는지 확인하는 테스트 추가. 축과 무관한 기존 fixture들은 실 BE `derive_trust_stage` 규칙과 정합하도록 stub에 기본 trust_stage 파생 로직 추가(개별 테스트 50여곳 안 건드림)

## 검증
- `pnpm vitest run src/components/kanban/kanban-board.test.tsx` — 35/35 PASS
- `pnpm build` — EXIT 0
- `pnpm lint` — 0 errors(기존 무관 파일 warning 5건은 develop 베이스라인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)