### PR TITLE
[긴급][SID:2956] /epics 신설 라우트가 2016년 rename 화석에 먹혀 도달 불가

### DIFF
--- a/apps/web/scripts/verify-no-orphan-resource-routes.test.ts
+++ b/apps/web/scripts/verify-no-orphan-resource-routes.test.ts
@@ -5,6 +5,7 @@ import {
   extractComposedTargets,
   extractLiteralTargets,
   extractNavConfigResourceTargets,
+  findAliasedLiveRoutes,
   findEntryWithoutRoute,
   findRouteWithoutEntry,
   GRANDFATHER_BASELINE,
@@ -131,6 +132,25 @@ describe('AC4 — 네 방향 mutation (단위테스트 고정)', () => {
     const routeDirs = new Set(['flow', 'docs']);
     expect(findEntryWithoutRoute(hits, routeDirs, EXEMPT_TARGETS).size).toBe(0);
     expect(findRouteWithoutEntry(['flow', 'docs'], hits)).toEqual([]);
+  });
+});
+
+// AC3(story #2956) — 세 번째 판정: 실 라우트가 legacy rename/retire 표에도 동시에 올라있으면
+// 진입점 유무와 무관하게 실패한다. #3377이 `[ws]/[proj]/epics`를 신설했을 때
+// `RENAMED_RESOURCES.epics='goals'`가 이미 그 이름을 쥐고 있었는데, findEntryWithoutRoute·
+// findRouteWithoutEntry 둘 다 이 조합(라우트 존재+진입점 존재+exempt 존재)을 초록으로 통과시켰다
+// — 그 정확한 사각을 이 함수가 메운다.
+describe('findAliasedLiveRoutes — AC3(story #2956, 신설 판정)', () => {
+  it('실 라우트 이름이 alias 표에도 있으면 잡는다(진입점이 있어도 — #3377/epics 실사례)', () => {
+    expect(findAliasedLiveRoutes(['epics', 'flow'], new Set(['epics', 'board']))).toEqual(['epics']);
+  });
+
+  it('겹치는 이름이 없으면 빈 배열(과잉살상 아님)', () => {
+    expect(findAliasedLiveRoutes(['flow', 'docs'], new Set(['epics', 'board']))).toEqual([]);
+  });
+
+  it('실 저장소 현재 상태 — epics는 더 이상 RENAMED_RESOURCE_ALIASES에 없다(이 스토리의 직접 fix)', () => {
+    expect(RENAMED_RESOURCE_ALIASES.has('epics')).toBe(false);
   });
 });
 

--- a/apps/web/scripts/verify-no-orphan-resource-routes.ts
+++ b/apps/web/scripts/verify-no-orphan-resource-routes.ts
@@ -249,6 +249,22 @@ export function findRouteWithoutEntry(routeDirs: string[], hits: EntryHit[]): st
   return routeDirs.filter((dir) => !referenced.has(dir));
 }
 
+// ── AC3(story #2956, 2026-08-23) — 세 번째 판정: «살아있는 실 라우트가 legacy rename/retire
+// 표에도 동시에 올라있다». #3377이 `[ws]/[proj]/epics/page.tsx`를 신설했는데
+// `RENAMED_RESOURCES.epics='goals'`가 이미 그 이름을 쥐고 있어, proxy.ts(edge 미들웨어, 항상
+// Next 파일 라우팅보다 먼저 실행)가 모든 요청을 /goals로 가로채 그 실 라우트가 영원히 도달
+// 불가였다. 이 클래스는 위 두 판정(findEntryWithoutRoute/findRouteWithoutEntry) 어느 쪽도
+// 못 잡는다 — `EXEMPT_TARGETS`가 RENAMED_RESOURCE_ALIASES를 "이미 아는 별칭"으로 먼저
+// continue시켜(line 240 `if (exempt.has(...) || ...) continue`) entryWithoutRoute 검사
+// 자체를 건너뛰고, routeWithoutEntry는 "그 이름을 가리키는 진입점이 있는가"만 보므로 진입점
+// (WorkspaceFrameTabs 탭·command-palette)이 있으면 통과해 버린다 — 정확히 이 사고의 두 조건
+// (실 라우트 존재 + 진입점 존재)이 이 가드를 초록으로 만드는 바로 그 조합이었다. 별도 축으로
+// 신설: 라우트 존재와 rename/retire 별칭 존재가 **동시에** 참이면 무조건 실패(진입점 유무와
+// 무관 — 있으면 죽은 라우트, 없으면 애초에 존재 이유가 없는 라우트).
+export function findAliasedLiveRoutes(routeDirs: string[], aliases: Set<string>): string[] {
+  return routeDirs.filter((dir) => aliases.has(dir));
+}
+
 // ── main ────────────────────────────────────────────────────────────────
 
 function main(): void {
@@ -280,6 +296,7 @@ function main(): void {
 
   const entryWithoutRoute = findEntryWithoutRoute(hits, routeDirs, EXEMPT_TARGETS);
   const routeWithoutEntry = findRouteWithoutEntry(routeDirsList, hits);
+  const aliasedLiveRoutes = findAliasedLiveRoutes(routeDirsList, RENAMED_RESOURCE_ALIASES);
 
   const uniqueTargets = new Set(hits.map((h) => h.target));
   console.log(
@@ -318,6 +335,14 @@ function main(): void {
       console.log(`\n❌ routeWithoutEntry(신규) — 라우트는 있는데 진입점이 어디에도 없다(도달 불가, 더 조용한 쪽) ${newOnes.length}건:`);
       for (const dir of [...newOnes].sort()) console.log(`  - [ws]/[proj]/${dir}`);
     }
+  }
+
+  // AC3(story #2956) — grandfather 없음(신설 판정이라 현재 0건이 정상): 실 라우트+rename/retire
+  // 별칭 동시 존재는 신규 채무를 절대 허용하면 안 되는 클래스(발견되는 순간 이미 죽은 라우트).
+  if (aliasedLiveRoutes.length > 0) {
+    failed = true;
+    console.log(`\n❌ aliasedLiveRoute(신규) — 실 라우트인데 legacy rename/retire 표에도 올라있다(진입점 유무 무관, proxy.ts가 항상 먼저 가로채 영원히 도달 불가) ${aliasedLiveRoutes.length}건:`);
+    for (const dir of [...aliasedLiveRoutes].sort()) console.log(`  - [ws]/[proj]/${dir} ↔ RENAMED_RESOURCES/RETIRED_RESOURCES['${dir}']`);
   }
 
   const staleBaseline = [...GRANDFATHER_BASELINE].filter((k) => !baselineHit.has(k));

--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -12,7 +12,8 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
 }));
 
-const { NotificationBell } = await import('./notification-bell');
+const { NotificationBell, getEntityHref } = await import('./notification-bell');
+import type { EventNotification } from './notification-bell';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -293,5 +294,30 @@ describe('NotificationBell — conversation.read SSE 즉시 unread-count 재fetc
     await act(async () => { await Promise.resolve(); });
 
     expect(fetchMock.mock.calls.length).toBe(beforeCalls);
+  });
+});
+
+// ⚠️QA changes(PR#3381, 카디르+codex, 2026-08-23) — story #2956이 지운 RENAMED_RESOURCES
+// (epics→goals) 301에 이 딥링크가 얹혀 살고 있었다(테스트 0건이었음). `/epics/{id}`는
+// bare 승격(MIGRATED_RESOURCES) 後 `/{ws}/{proj}/epics/{id}`가 됐다가 옛 rename이 다시
+// `/{ws}/{proj}/goals/{id}`로 옮겨줬는데, 신 `[ws]/[proj]/epics/`엔 목록(`page.tsx`)만
+// 있고 `[id]` 서브라우트가 없어(#3377 스코프에 상세 페이지 없음) rename 제거로 404가
+// 됐다. 회귀가드: 이 딥링크 계약(entity_type='epic' → 유효한 상세 라우트)을 명시로 고정.
+function baseNotification(overrides: Partial<EventNotification>): EventNotification {
+  return {
+    id: 'n1', event_type: 'story.status_changed', source_entity_type: null, source_entity_id: null,
+    payload: null, read_at: null, created_at: '2026-08-23T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('getEntityHref — 딥링크 계약(story #2956 QA changes)', () => {
+  it("entity_type='epic' → /goals/{id}(Goal=Epic, goals/[id]가 에픽 상세 정본 — /epics/{id} 아님)", () => {
+    const href = getEntityHref(baseNotification({ source_entity_type: 'epic', source_entity_id: 'e-123' }));
+    expect(href).toBe('/goals/e-123');
+  });
+
+  it('source_entity_id가 없으면 null(다른 타입도 동형)', () => {
+    expect(getEntityHref(baseNotification({ source_entity_type: 'epic', source_entity_id: null }))).toBeNull();
   });
 });

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -37,7 +37,7 @@ function getNotificationTab(eventType: string): 'story' | 'system' {
   return 'system';
 }
 
-interface EventNotification {
+export interface EventNotification {
   id: string;
   event_type: string;
   source_entity_type: string | null;
@@ -52,7 +52,9 @@ interface EventNotification {
   created_at: string;
 }
 
-function getEntityHref(notification: EventNotification): string | null {
+// export — story #2956 QA changes(카디르+codex, 2026-08-23) 회귀가드(notification-bell.test.tsx)가
+// 전체 컴포넌트 마운트 없이 딥링크 판정만 직접 검증.
+export function getEntityHref(notification: EventNotification): string | null {
   const { source_entity_type, source_entity_id } = notification;
   if (!source_entity_id) return null;
   switch (source_entity_type) {
@@ -61,7 +63,13 @@ function getEntityHref(notification: EventNotification): string | null {
     case 'task':
       return `/board?task_id=${source_entity_id}`;
     case 'epic':
-      return `/epics/${source_entity_id}`;
+      // ⚠️QA changes(PR#3381, 카디르+codex, 2026-08-23) — 이 딥링크는 story #2956이 지운
+      // RENAMED_RESOURCES(epics→goals) 301에 얹혀 살고 있었다: `/epics/{id}`가 bare 승격
+      // (MIGRATED_RESOURCES) 後 `/{ws}/{proj}/epics/{id}`가 됐다가 그 rename이 다시
+      // `/{ws}/{proj}/goals/{id}`로 옮겨줬다 — 신 `[ws]/[proj]/epics/`엔 목록(`page.tsx`)만
+      // 있고 `[id]` 서브라우트가 없어(#3377 스코프에 상세 페이지 없음), rename 제거로
+      // 404가 됐다. Goal=Epic이라 `goals/[id]`가 이미 에픽 상세 정본 — 직접 가리킨다.
+      return `/goals/${source_entity_id}`;
     case 'sprint':
       // sprints-client.tsx에서 id 파라미터 처리 추가됨
       return `/sprints?id=${source_entity_id}`;

--- a/apps/web/src/lib/legacy-resource-tables.ts
+++ b/apps/web/src/lib/legacy-resource-tables.ts
@@ -33,18 +33,18 @@ export const MIGRATED_RESOURCES: Record<string, string[]> = {
   // 안 보였는데, mobile-tab-bar.tsx의 "지금" 탭 href를 bare `/flow`로 바꾸며(옛 `/glance`
   // 대체) 처음으로 실사용 경로가 생겼다 — 등록 없이 나갔으면 즉시 404였을 것.
   flow: [],
-  // story #2016: 8fc51517(B1 리네이밍)이 epics→goals 경로 리터럴을 바꾸면서 RENAMED_RESOURCES에만
-  // 반영되고 여기(MIGRATED_RESOURCES)엔 신 이름 'goals'를 안 넣었다 — bare `/epics`는 이 표를 거쳐
-  // `/{ws}/{proj}/epics`로 301된 뒤 redirectRenamedResourcePath가 2차로 `goals`로 다시 301하지만,
-  // bare `/goals`(신 이름 그대로 오는 딥링크·북마크·검색결과)는 애초에 이 표에 키가 없어 redirectLegacyResourcePath가
-  // 즉시 null 반환 → Next 자체 404. 호스트/쿠키 무관 리소스 등록 누락 실측 확認(direct Cloud Run 호스트에서
-  // /board는 301 정상·/goals만 404, 동일 JWT fallback 경로 재사용).
+  // story #2016: 당시 8fc51517(B1 리네이밍)이 epics→goals 경로 리터럴을 RENAMED_RESOURCES에만
+  // 반영하고 여기(MIGRATED_RESOURCES)엔 신 이름 'goals'를 안 넣어, bare `/goals`(신 이름 그대로
+  // 오는 딥링크·북마크·검색결과)가 이 표에 키가 없어 즉시 404였다(호스트/쿠키 무관 실측 확認).
+  // goals 자체는 여전히 실 리소스라 이 키는 그대로 둔다 — story #2956(2026-08-23)에서 정리된
+  // 것은 RENAMED_RESOURCES 쪽의 `epics: 'goals'` 행(아래 참조, epics가 별개 실 리소스로
+  // 독립하며 그 행 자체가 폐기 대상이 됨)이지 이 goals 항목이 아니다.
   goals: [],
 };
 
 /**
  * story 8fc51517(계층 리네이밍 B1, doc hierarchy-renaming-url-implementation-design §ⓑ) —
- * `/{ws}/{proj}/{resource}` 안의 **경로 리터럴**이 신 용어로 바뀔 때(에픽→목표 등)의 301.
+ * `/{ws}/{proj}/{resource}` 안의 **경로 리터럴**이 신 용어로 바뀔 때(board→flow 등)의 301.
  * proxy.ts의 `redirectLegacyResourcePath`와 다른 관심사 — 저건 ws/proj 세그먼트 자체가 없던
  * 옛 flat URL을 org/project 재조회로 채워 넣는 것이고, 이건 ws/proj가 **이미 URL에 있으므로**
  * 3번째 세그먼트(리소스명)만 신 이름으로 교체하면 된다(org/project 재조회 fetch 불요).
@@ -54,9 +54,18 @@ export const MIGRATED_RESOURCES: Record<string, string[]> = {
  * 스냅샷이었다 — story #2378 리뷰에서 유나양이 발견). story #2393(2026-08-01) — route-resolve.ts의
  * RESERVED_FIRST_SEGMENTS도 여기서 파생시킨다(순환참조 회피를 위해 이 표 자체를 proxy.ts
  * 밖으로 뺀 것이 그 이유).
+ *
+ * ⛔story #2956(2026-08-23, PO 배포 실픽셀 검증 발견) — 여기 있던 `epics: 'goals'` 행(2016년
+ * B1 리네이밍의 화석)이 #3377(story #2931)이 신설한 실 라우트 `[ws]/[proj]/epics/page.tsx`와
+ * 이름이 충돌했다. proxy.ts(edge 미들웨어)는 항상 Next 파일 라우팅보다 먼저 실행되므로, 이
+ * 표에 `epics` 키가 남아있는 한 그 실 라우트는 **영원히 도달 불가**(모든 요청이 301로 /goals에
+ * 가로채임)였다 — 새 리소스가 예전에 rename됐던 이름을 그대로 재사용할 수 있다는 걸 아무도
+ * 미리 대조하지 않은 게이트 사각(verify-no-orphan-resource-routes.ts도 이 이름을 "이미 아는
+ * 별칭"으로 exempt 처리해 놓쳤다 — findAliasedLiveRoutes로 그 가드도 함께 확장했다). epics가
+ * 이제 독립된 실 리소스이므로 이 행 자체를 제거한다 — 2016년 시절 "에픽→목표" 딥링크/북마크가
+ * 새 에픽 뷰로 열리는 것은 수용(진짜 목적지가 goals였던 그 링크들은 이미 8년 전에 죽었다).
  */
 export const RENAMED_RESOURCES: Record<string, string> = {
-  epics: 'goals',
   // story #2224(선생님 정정 2026-07-30) — glance는 이제 /flow 안의 한 조각. 위 MIGRATED_RESOURCES
   // 항목과 짝: bare `/glance` → (redirectLegacyResourcePath) → `/{ws}/{proj}/glance` →
   // (여기) → `/{ws}/{proj}/flow`. `?story=`/`?task_id=` 등 쿼리는 두 함수 다 request.nextUrl을
@@ -70,7 +79,7 @@ export const RENAMED_RESOURCES: Record<string, string> = {
 
 /**
  * story #2378(2026-08-01, 유나양 design:changes) — `RENAMED_RESOURCES`와 «성격이 다른» 은퇴.
- * 위 표(epics/glance/board)는 같은 행이 새 이름을 받은 rename이라 id를 그대로 들고 가도 안전
+ * 위 표(glance/board)는 같은 행이 새 이름을 받은 rename이라 id를 그대로 들고 가도 안전
  * (mockups 3번째 세그먼트 뒤 id가 있으면 「그 id」로 다시 찾을 수 있다). 여기는 반대 —
  * `RETIRED_RESOURCES`에 오르면 옛 리소스가 «폐기»되고 다른 리소스가 그 자리를 대신할 뿐이라
  * id 공간이 다르다(mockup id ≠ artifact id). id를 그대로 옮기면 두 가지 결과가 갈리는데

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -828,7 +828,7 @@ describe('proxy — legacy resource redirect generalized to non-docs resources (
   });
 });
 
-describe('proxy — 경로 리터럴 rename 301(story 8fc51517, 에픽→목표): [ws]/[proj]/epics/* → [ws]/[proj]/goals/*', () => {
+describe('proxy — 경로 리터럴 rename 301(story 8fc51517): [ws]/[proj]/board/* → [ws]/[proj]/flow/*', () => {
   beforeEach(() => {
     process.env['JWT_SECRET'] = JWT_SECRET;
     process.env['NEXT_PUBLIC_FASTAPI_URL'] = 'http://localhost:8000';
@@ -839,24 +839,23 @@ describe('proxy — 경로 리터럴 rename 301(story 8fc51517, 에픽→목표)
     delete process.env['JWT_SECRET'];
   });
 
-  it('/{ws}/{proj}/epics → 301 /{ws}/{proj}/goals(같은 ws/proj 세그먼트 보존, org/project 재조회 없음)', async () => {
+  // ⛔story #2956(2026-08-23, PO 배포 실픽셀 검증) — 여기 있던 epics→goals rename 301 테스트
+  // 2건이 정확히 이 사고의 "그린 테스트가 버그를 고정해버린" 자리였다: #3377이 실 라우트
+  // `[ws]/[proj]/epics`를 신설했는데 RENAMED_RESOURCES.epics='goals'가 여전히 남아있어 그
+  // 실 라우트가 영원히 도달 불가였다 — 이 테스트들은 «그 도달 불가를 정확한 스펙으로»
+  // 계속 지키고 있었다(리네이밍 표에서 epics 행을 지운 지금은 이 옛 기대값 자체가 틀렸다).
+  // epics는 이제 독립 실 리소스이므로 아래에서 "리다이렉트 없음"으로 정반대 방향의 회귀
+  // 가드를 세운다.
+  it('/{ws}/{proj}/epics → 리다이렉트 없이 통과(2016년 rename 화석 제거 확認 — 실 EpicSwimlaneBoard가 렌더될 자리)', async () => {
     const token = await makeAccessToken({ orgId: 'org-1' });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ org_id: 'org-1', org_slug: 'moonklabs', org_role: 'member', project_id: 'proj-1', project_slug: 'sprintable' }),
+    });
     const response = await middleware(makeRequest('/moonklabs/sprintable/epics', {
       sp_at: token, sprintable_current_project_id: 'proj-1',
     }));
-    expect(response.status).toBe(301);
-    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/goals');
-    // 3번째 세그먼트만 교체하는 순수 문자열 치환이라 org/project fetch가 전혀 없어야 한다.
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it('/{ws}/{proj}/epics/{id} — 딥링크(id 서브패스)도 손실 없이 이동', async () => {
-    const token = await makeAccessToken({ orgId: 'org-1' });
-    const response = await middleware(makeRequest('/moonklabs/sprintable/epics/e-123', {
-      sp_at: token, sprintable_current_project_id: 'proj-1',
-    }));
-    expect(response.status).toBe(301);
-    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/goals/e-123');
+    expect(response.status).not.toBe(301);
   });
 
   it('/{ws}/{proj}/board → 301 /{ws}/{proj}/flow(board도 RENAMED_RESOURCES 대상 — #2373 prod 승격 board 은퇴 회귀가드)', async () => {
@@ -866,7 +865,7 @@ describe('proxy — 경로 리터럴 rename 301(story 8fc51517, 에픽→목표)
     }));
     expect(response.status).toBe(301);
     expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/flow');
-    // 3번째 세그먼트만 교체하는 순수 문자열 치환이라 org/project fetch가 전혀 없어야 한다(epics→goals와 동형).
+    // 3번째 세그먼트만 교체하는 순수 문자열 치환이라 org/project fetch가 전혀 없어야 한다.
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -910,7 +909,7 @@ describe('proxy — 폐기된 리소스 301(story #2378, 유나양 design:change
       sp_at: token, sprintable_current_project_id: 'proj-1',
     }));
     expect(response.status).toBe(301);
-    // ⛔/artifacts/abc123 이 아니다 — RENAMED_RESOURCES(epics→goals)와 정확히 다른 지점.
+    // ⛔/artifacts/abc123 이 아니다 — RENAMED_RESOURCES(board→flow 등, id 보존)와 정확히 다른 지점.
     expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/artifacts');
     expect(mockFetch).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## 배경
PO 배포 실픽셀 검증(2026-08-23)에서 발견 — #3377(#2931) 머지·배포 완료 후 `/moonklabs/sprintable/epics` 진입이 **일관되게 /goals로 301**. 신설 `EpicSwimlaneBoard`가 배포는 됐지만 사용자가 도달할 수 없는 상태였습니다.

## 근본 원인
`lib/legacy-resource-tables.ts`의 `RENAMED_RESOURCES = { epics: 'goals', ... }` — 2016년경(story #2016·8fc51517 B1 리네이밍) "epics 리소스가 goals로 개명"됐던 시절의 레거시 301 표가 살아있었습니다. `proxy.ts`의 `redirectRenamedResourcePath`(edge 미들웨어, 항상 Next 파일 라우팅보다 먼저 실행)가 3번째 세그먼트만 보고 무조건 `/goals`로 301시켜, #3377이 같은 세그먼트 이름(`epics`)으로 신설한 실 라우트가 영원히 도달 불가였습니다.

## 변경
1. **`RENAMED_RESOURCES`에서 `epics` 행 제거** — epics는 이제 독립된 실 리소스입니다. `MIGRATED_RESOURCES`의 `epics: []`/`goals: []`는 각자 별개 실 리소스로서 그대로 유지(bare `/epics`·bare `/goals` 승격 경로 둘 다 안전).
2. **`proxy.test.ts`** — "epics→goals 301" 테스트 2건(정확히 이 버그를 스펙으로 고정하고 있던 자리, 그린 테스트가 회귀를 막기는커녕 박제하고 있었습니다)을 "`/{ws}/{proj}/epics`는 리다이렉트 없이 통과" 회귀가드로 교체.
3. **`verify-no-orphan-resource-routes.ts`에 `findAliasedLiveRoutes` 신설(AC3)** — 기존 두 판정(`entryWithoutRoute`/`routeWithoutEntry`) 모두 이 정확한 사고 클래스를 놓쳤습니다: `EXEMPT_TARGETS`가 rename 별칭을 "이미 아는 이름"으로 먼저 `continue`시켜(진입점 존재 여부와 무관하게) 실 라우트 존재 자체를 검사하지 않았기 때문입니다. "실 라우트가 legacy rename/retire 표에도 동시에 올라있다"를 진입점 유무와 무관한 신규 실패 축으로 승격했습니다.

## 뮤테이션 검증
`epics: 'goals'`를 표에 일시 재삽입 → 신설 가드 RED 확認(`aliasedLiveRoute` 1건 정확히 잡음) → 원복 → GREEN 재확認. 로그:
```
❌ aliasedLiveRoute(신규) — 실 라우트인데 legacy rename/retire 표에도 올라있다(진입점 유무 무관,
   proxy.ts가 항상 먼저 가로채 영원히 도달 불가) 1건:
  - [ws]/[proj]/epics ↔ RENAMED_RESOURCES/RETIRED_RESOURCES['epics']
```

## 스코프 경계
AC1(로그인 세션에서 `/[ws]/[proj]/epics` 직접 진입=EpicSwimlaneBoard 렌더)은 컴포넌트 테스트로 대체 불가 — **이 PR 머지·배포 후 실픽셀**로만 닫을 수 있습니다(story #2956 AC 원문). 이 PR의 스코프는 근본 원인 fix + 회귀가드 신설까지입니다. 2931(에픽 스윔레인) done 재선언은 이 실픽셀 확認 이후로 미룹니다.

## 검증
- `pnpm vitest run` — 481 files / 4112 tests PASS(신규 4건: proxy 리다이렉트-없음 1건 + findAliasedLiveRoutes 3건)
- `tsc --noEmit` 0 · `pnpm lint` 0 errors(기존 무관 warning 5건은 develop 베이스라인) · `pnpm build` EXIT 0
- 빌드 산출물에 `ƒ /[ws]/[proj]/epics` 라우트 실존 확認(`grep epics` on build output)
- 실제 가드 스크립트(`tsx scripts/verify-no-orphan-resource-routes.ts`) 직접 실행 — exempt(renamed-alias) 4→3으로 감소, `epics`가 이제 정상 라우트 목록에만 나열됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)