### PR TITLE
[2950] 슬라이스① — 변별 0인 risk_grade 칩 숨김(결재함·게이트 상세)

### DIFF
--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -217,11 +217,6 @@ export default function GateDetailPage() {
                       text-foreground로 이행 — PR#3367의 이 지점 className 오버라이드는
                       이제 중복. 클래스가 닫혔으니 지점 처방을 걷는다(PO 지시). */}
                   <Badge variant="chip">{gate.gate_type}</Badge>
-                  {deriveRiskLevel(gate) === 'high' ? (
-                    <Badge variant="warning">{t('riskHigh')}</Badge>
-                  ) : deriveRiskLevel(gate) === 'unknown' ? (
-                    <Badge variant="outline" className="text-muted-foreground">{t('riskUnknown')}</Badge>
-                  ) : null}
                 </div>
                 <p className="text-xs text-muted-foreground">
                   {t('gateDetailOrgContext', {

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -293,10 +293,6 @@ export function ApprovalsQueue() {
               <Badge variant="chip">{gate.gate_type}</Badge>
               {held ? (
                 <Badge variant="secondary">{t('heldBadge')}</Badge>
-              ) : deriveRiskLevel(gate) === 'high' ? (
-                <Badge variant="warning">{t('riskHigh')}</Badge>
-              ) : deriveRiskLevel(gate) === 'unknown' ? (
-                <Badge variant="outline" className="text-muted-foreground">{t('riskUnknown')}</Badge>
               ) : null}
               <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">{formatAge(gate.created_at, t)}</span>
             </div>


### PR DESCRIPTION
## 요약
PO 설계안 승인(doc `gate-risk-real-discriminator-design-2950`) 슬라이스① — 선생님 실사용 실증(2026-08-23 아침: "결재함에는 모든 게 고위험 신중결재 칩")에 대한 즉시 조치.

`derive_risk_grade(posture, gate_type)`가 org 내에서 `gate_type` 상수로 붕괴해(merge/doc_approval=항상 high, pr_review/qa/agent_decision_request=항상 low) risk_grade 칩이 타입 내 아무 변별도 못 나른다 — no-fiction 위반. **거짓 변별보다 무표시가 정직**(doc §7)이라는 PO 판단대로 칩을 제거한다.

## 변경
- `apps/web/src/components/inbox/approvals-queue.tsx:296-299` — 결재함 카드의 risk 배지(riskHigh/riskUnknown) 제거.
- `apps/web/src/app/(authenticated)/gates/[id]/page.tsx:220-224` — 게이트 상세 ProofCapsule footer의 risk 배지 제거.

**분리 확認(그라운딩 완료)**: 두 화면 모두 risk 배지와 "고위험 강제 UX"(근거 열람+사유 필수, `usesSignatureFlow(deriveRiskLevel(gate))`)가 서로 다른 독립 호출부다 — 배지만 제거해도 서명 플로우 강제는 그대로 살아있다(PO 판단②, 결재 품질 유지). `held` 배지는 risk_grade와 무관해 유지.

**스코프 밖**: chat 임베드 뷰(`approval-request-card.tsx`, `embed-card.tsx`)는 이번 슬라이스 대상이 아님 — i18n 키(`riskHigh`/`riskUnknown`)는 그쪽이 계속 소비 중이라 그대로 유지.

[SID:2950]

## 테스트
- `approvals-queue.test.tsx`·`gates/[id]/page.test.tsx` 54건 전부 통과 — 두 부정 단언(`not.toContain(riskUnknown)`)은 기존엔 특정 시나리오에서만 검증했는데 이제 항상 참이라 그대로 유효.
- `tsc --noEmit` 두 파일 오류 없음.

## Test plan
- [x] 관련 테스트 54건 통과
- [x] 타입체크 통과
- [ ] CI green