### PR TITLE
[2950] 슬라이스② — diff_size·touches_migration 관찰 사실 배선(판정 없음)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3835,6 +3835,8 @@
     "gateDetailOrgContext": "Org {org}",
     "riskUnknown": "Risk pending",
     "riskHigh": "High risk · review closely",
+    "diffFactsFileCount": "{count} files",
+    "diffFactsMigrationTouch": "touches migration",
     "sigEvidenceLabel": "Evidence",
     "sigEvidenceViewedLabel": "I have reviewed the evidence above",
     "sigReasonLabel": "Decision reason",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3835,6 +3835,8 @@
     "gateDetailOrgContext": "조직 {org}",
     "riskUnknown": "위험도 확인 중",
     "riskHigh": "고위험 · 신중 결재",
+    "diffFactsFileCount": "파일 {count}",
+    "diffFactsMigrationTouch": "마이그레이션 접촉",
     "sigEvidenceLabel": "근거",
     "sigEvidenceViewedLabel": "위 근거를 확인했습니다",
     "sigReasonLabel": "결정 사유",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -217,11 +217,6 @@ export default function GateDetailPage() {
                       text-foreground로 이행 — PR#3367의 이 지점 className 오버라이드는
                       이제 중복. 클래스가 닫혔으니 지점 처방을 걷는다(PO 지시). */}
                   <Badge variant="chip">{gate.gate_type}</Badge>
-                  {deriveRiskLevel(gate) === 'high' ? (
-                    <Badge variant="warning">{t('riskHigh')}</Badge>
-                  ) : deriveRiskLevel(gate) === 'unknown' ? (
-                    <Badge variant="outline" className="text-muted-foreground">{t('riskUnknown')}</Badge>
-                  ) : null}
                 </div>
                 <p className="text-xs text-muted-foreground">
                   {t('gateDetailOrgContext', {

--- a/apps/web/src/components/cage/gate-risk.ts
+++ b/apps/web/src/components/cage/gate-risk.ts
@@ -57,3 +57,19 @@ export function deriveGateProofState(status: string): GateProofStateResult {
   const proofState: ProofState = status === 'pending' ? 'amber' : status === 'approved' ? 'green' : 'red';
   return { proofState, statusKey: GATE_STATUS_I18N_KEYS[status] ?? null };
 }
+
+// story #2950 슬라이스②(PO 설계안 승인, doc gate-risk-real-discriminator-design-2950 §3/§7)
+// — risk_grade 칩(변별 0)을 대체하는 «관찰 사실 그대로 노출». 판정/재분류 없음 — BE
+// neutral_facts.diff_size/touches_migration이 있으면 그대로 보이고, 없으면(관찰 실패·이
+// gate_type엔 파일-diff 개념 자체가 없음 등) 지어내지 않고 null(호출부가 아예 렌더 안 함).
+export interface DiffFacts {
+  fileCount: number;
+  touchesMigration: boolean;
+}
+
+export function deriveDiffFacts(gate: GateItem): DiffFacts | null {
+  const fileCount = gate.neutral_facts?.['diff_size'];
+  if (typeof fileCount !== 'number') return null;
+  const touchesMigration = gate.neutral_facts?.['touches_migration'] === true;
+  return { fileCount, touchesMigration };
+}

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -167,6 +167,54 @@ describe('ApprovalsQueue', () => {
     expect(container.textContent).not.toContain(koMessages.cage.riskUnknown);
   });
 
+  // story #2950 슬라이스②(PO 설계안 승인) — risk_grade 칩을 대체하는 관찰 사실 노출.
+  // can_approve=true인 인라인 카드 경로(density="full")에서만 diffFacts 슬롯이 산다.
+  it('neutral_facts.diff_size/touches_migration이 있으면 「파일 N · 마이그레이션 접촉」을 표시한다', async () => {
+    mockFetches(
+      [gate({
+        id: 'g-diff', can_approve: true, requires_human: true,
+        neutral_facts: { diff_size: 12, touches_migration: true },
+      })],
+      [],
+    );
+    await mount();
+    const text = container.textContent ?? '';
+    expect(text).toContain('파일 12');
+    expect(text).toContain(koMessages.cage.diffFactsMigrationTouch);
+  });
+
+  it('touches_migration=false면 마이그레이션 접촉 문구 없이 파일 수만 표시한다', async () => {
+    mockFetches(
+      [gate({
+        id: 'g-diff-no-migration', can_approve: true, requires_human: true,
+        neutral_facts: { diff_size: 3, touches_migration: false },
+      })],
+      [],
+    );
+    await mount();
+    const text = container.textContent ?? '';
+    expect(text).toContain('파일 3');
+    expect(text).not.toContain(koMessages.cage.diffFactsMigrationTouch);
+  });
+
+  it('neutral_facts가 없으면 diffFacts를 지어내지 않고 아예 표시하지 않는다', async () => {
+    mockFetches([gate({ id: 'g-no-facts', can_approve: true, requires_human: true, neutral_facts: null })], []);
+    await mount();
+    const text = container.textContent ?? '';
+    expect(text).not.toContain('파일');
+  });
+
+  it('risk_grade 칩(고위험/위험도 확인 중)은 어떤 경우에도 더 이상 렌더되지 않는다', async () => {
+    mockFetches(
+      [gate({ id: 'g-no-chip', can_approve: true, requires_human: true, risk_grade: 'high' })],
+      [],
+    );
+    await mount();
+    const text = container.textContent ?? '';
+    expect(text).not.toContain(koMessages.cage.riskHigh);
+    expect(text).not.toContain(koMessages.cage.riskUnknown);
+  });
+
   it('created_at이 오늘이면 "오늘 접수", 과거면 "N일 대기"로 노화를 표시한다', async () => {
     const threeDaysAgo = new Date(Date.now() - 3 * 86_400_000).toISOString();
     mockFetches(

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -293,10 +293,6 @@ export function ApprovalsQueue() {
               <Badge variant="chip">{gate.gate_type}</Badge>
               {held ? (
                 <Badge variant="secondary">{t('heldBadge')}</Badge>
-              ) : deriveRiskLevel(gate) === 'high' ? (
-                <Badge variant="warning">{t('riskHigh')}</Badge>
-              ) : deriveRiskLevel(gate) === 'unknown' ? (
-                <Badge variant="outline" className="text-muted-foreground">{t('riskUnknown')}</Badge>
               ) : null}
               <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">{formatAge(gate.created_at, t)}</span>
             </div>

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -8,7 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { CheckCircle, XCircle } from 'lucide-react';
-import { deriveRiskLevel, usesSignatureFlow } from '@/components/cage/gate-risk';
+import { deriveRiskLevel, usesSignatureFlow, deriveDiffFacts } from '@/components/cage/gate-risk';
 import { gateNeedsAction } from '@/components/cage/gate-evidence';
 import { GateUndoButton, UNDO_WINDOW_MS } from '@/components/cage/gate-undo-button';
 import { GateDiscussDialog } from '@/components/cage/gate-discuss-dialog';
@@ -287,6 +287,7 @@ export function ApprovalsQueue() {
         const orgName = orgMemberships.find((o) => o.orgId === gate.org_id)?.orgName;
         const resolved = resolvedGates[gate.id];
         const inlineResolvable = !resolved && canInlineResolve(gate);
+        const diffFacts = deriveDiffFacts(gate);
         const gateBody = (
           <>
             <div className="flex w-full flex-wrap items-center gap-1.5">
@@ -304,6 +305,12 @@ export function ApprovalsQueue() {
               {gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`}
             </p>
             {orgName ? <p className="text-[11px] text-muted-foreground">{orgName}</p> : null}
+            {diffFacts ? (
+              <p className="text-[11px] text-muted-foreground">
+                {t('diffFactsFileCount', { count: diffFacts.fileCount })}
+                {diffFacts.touchesMigration ? ` · ${t('diffFactsMigrationTouch')}` : ''}
+              </p>
+            ) : null}
           </>
         );
 

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -298,7 +298,12 @@ async def _observe_pr_diff_facts(
             return {}
         return {
             "diff_size": len(changed_files),
-            "touches_migration": any(f.startswith("alembic/versions/") for f in changed_files),
+            # 카디르 QA(PR#3383, 2026-08-23) — GitHub PR-files API는 레포 루트 기준 경로를
+            # 준다(실측: #3376 파일 전부 "backend/..."). 이 모노레포의 실 alembic 위치는
+            # "backend/alembic/versions/"이지 "alembic/versions/"가 아니다 — 원래 버전은
+            # 이 축이 영구 False였다("틀릴 수 없는 표본" 클래스, 신규 테스트가 매치 로직을
+            # 실제로 돌리지 않아 못 잡았다).
+            "touches_migration": any(f.startswith("backend/alembic/versions/") for f in changed_files),
         }
     except Exception:  # noqa: BLE001 — best-effort 관찰, 실패해도 게이트 평가를 막지 않는다.
         logger.warning(

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -262,6 +262,52 @@ async def _role_key(session: AsyncSession, role_id: uuid.UUID) -> str | None:
     return role.key if role is not None else None
 
 
+async def _observe_pr_diff_facts(
+    session: AsyncSession, org_id: uuid.UUID, repo: str, pr_number: int
+) -> dict[str, Any]:
+    """story #2950 슬라이스②(PO 설계안 승인, doc gate-risk-real-discriminator-design-2950 §3) —
+    diff_size(변경 파일 수)·touches_migration(마이그레이션 파일 접촉)을 **관찰 사실로만**
+    neutral_facts에 남긴다. ⚠️판정 아님 — risk_grade 재계산에 이 값을 쓰지 않는다(doc §6 §1972
+    정합 논거 그대로: `Gate` 모델 독스트링이 애초에 이 두 필드를 "관찰 사실"로 예견했다).
+    임계값·low/high 재판정은 v1 스코프 밖(PO 명시, 별도 승인 필요).
+
+    `fetch_pr_changed_files`(verdict_capture.py)가 이미 GitHub PR-files API를 호출하는 능력을
+    scope-violation 체크 전용으로만 썼던 것을 여기로 확장 — 신규 API 통합 0. best-effort:
+    installation 없음/토큰 발급 실패/API 실패 어느 단계든 조용히 `{}` 반환(기존 `_reopen_gate_
+    hook_after_participation` 등과 동일 fail-closed 관례 — 외부 신호를 지어내지 않는다). 이
+    관찰 실패가 머지 게이트 평가 자체를 절대 막지 않는다."""
+    from app.models.github_installation import GithubInstallation
+    from app.services.github_app import get_installation_token
+    from app.services.verdict_capture import fetch_pr_changed_files
+
+    try:
+        installation = (
+            await session.execute(
+                select(GithubInstallation).where(
+                    GithubInstallation.org_id == org_id, GithubInstallation.suspended_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+        if installation is None:
+            return {}
+        token = await get_installation_token(installation.installation_id)
+        if not token:
+            return {}
+        changed_files = await fetch_pr_changed_files(repo, pr_number, token)
+        if changed_files is None:
+            return {}
+        return {
+            "diff_size": len(changed_files),
+            "touches_migration": any(f.startswith("alembic/versions/") for f in changed_files),
+        }
+    except Exception:  # noqa: BLE001 — best-effort 관찰, 실패해도 게이트 평가를 막지 않는다.
+        logger.warning(
+            "merge gate: PR diff facts 관찰 실패(best-effort) org=%s repo=%s pr=%d",
+            org_id, repo, pr_number, exc_info=True,
+        )
+        return {}
+
+
 async def evaluate_merge_gate(
     session: AsyncSession,
     org_id: uuid.UUID,
@@ -398,6 +444,10 @@ async def evaluate_merge_gate(
     # story #2932(HIGH1) — pr_number와 짝으로 repo도 정직하게: 빈 문자열("", no-substance
     # self-report shell의 관례값)은 "모름"이지 실 repo가 아니므로 None으로 정규화.
     db_repo_full_name = repo or None
+    # story #2950 슬라이스② — 관찰 사실(diff_size/touches_migration)만 neutral_facts에 병합.
+    # no-substance shell(db_pr_number/db_repo_full_name 둘 다 None)이면 관찰 대상 자체가 없다.
+    if db_pr_number is not None and db_repo_full_name is not None:
+        facts.update(await _observe_pr_diff_facts(session, org_id, db_repo_full_name, db_pr_number))
     # story #2118(E-DG-REAL ②): create_gate()가 이미 pending인 기존 gate를 멱등 반환할 때(예:
     # report-done/board-preflight가 이 함수를 반복 호출)마다 승인요청 카드를 중복 배달하지 않으려면
     # "이 호출에서 방금 pending이 됐는지"(신규 생성 또는 rejected/voided→재오픈)를 알아야 한다 —

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -668,3 +668,119 @@ async def test_deny_policy_materializes_even_without_evidence():
     res, create_spy = await _run_substance(ci_result=None, pr_number=0, disposition="deny")
     assert res.gate_id is not None
     create_spy.assert_awaited_once()
+
+
+# ── story #2950 슬라이스② — diff_size/touches_migration 관찰 사실(판정 아님) ─────────
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_merges_observed_diff_facts_into_neutral_facts():
+    """PO 설계안 승인(doc gate-risk-real-discriminator-design-2950 §3) — diff_size/
+    touches_migration이 관찰되면 neutral_facts에 그대로 병합돼야 한다(재판정 없음,
+    기존 facts 키와 나란히)."""
+    with patch.object(
+        mod, "_observe_pr_diff_facts",
+        AsyncMock(return_value={"diff_size": 12, "touches_migration": True}),
+    ):
+        res, create_spy = await _run()
+    assert res.gate_id is not None
+    neutral_facts = create_spy.call_args.kwargs["neutral_facts"]
+    assert neutral_facts["diff_size"] == 12
+    assert neutral_facts["touches_migration"] is True
+    assert neutral_facts["ci_result"] == "pass"  # 기존 facts 보존(덮어쓰기 아님).
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_diff_facts_observation_failure_is_silent():
+    """관찰 실패(설치 없음/토큰 없음/API 실패)는 게이트 평가 자체를 막지 않는다 — facts에
+    diff_size/touches_migration 키가 그냥 없을 뿐."""
+    with patch.object(mod, "_observe_pr_diff_facts", AsyncMock(return_value={})):
+        res, create_spy = await _run()
+    assert res.gate_id is not None
+    neutral_facts = create_spy.call_args.kwargs["neutral_facts"]
+    assert "diff_size" not in neutral_facts
+    assert "touches_migration" not in neutral_facts
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_no_substance_shell_skips_diff_observation():
+    """pr_number<=0(no-substance shell)이면 관찰 대상 PR 자체가 없다 — _observe_pr_diff_facts를
+    아예 호출하지 않는다(불필요한 GitHub API 호출 방지)."""
+    observe_spy = AsyncMock(return_value={"diff_size": 1, "touches_migration": False})
+    with patch.object(mod, "_observe_pr_diff_facts", observe_spy):
+        await _run_substance(ci_result="fail", pr_number=0, disposition="ask")
+    observe_spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_observe_pr_diff_facts_no_installation_returns_empty():
+    """GithubInstallation 없음(미연동 org) — 조용히 {} 반환, 예외 없음."""
+    from app.services.merge_verdict_gate import _observe_pr_diff_facts
+
+    no_row = MagicMock()
+    no_row.scalar_one_or_none = MagicMock(return_value=None)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=no_row)
+
+    result = await _observe_pr_diff_facts(session, uuid.uuid4(), "o/r", 12)
+    assert result == {}
+
+
+@pytest.mark.anyio
+async def test_observe_pr_diff_facts_computes_size_and_migration_touch():
+    """설치+토큰+PR 파일 조회 전부 성공 시 diff_size(파일 수)·touches_migration(경로 매치)을
+    정확히 계산한다."""
+    from app.services.merge_verdict_gate import _observe_pr_diff_facts
+
+    installation = SimpleNamespace(installation_id=999)
+    row = MagicMock()
+    row.scalar_one_or_none = MagicMock(return_value=installation)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=row)
+
+    changed_files = [
+        "app/routers/gates.py",
+        "app/services/merge_verdict_gate.py",
+        "alembic/versions/0276_something.py",
+    ]
+    with patch("app.services.github_app.get_installation_token", AsyncMock(return_value="tok")), \
+         patch("app.services.verdict_capture.fetch_pr_changed_files", AsyncMock(return_value=changed_files)):
+        result = await _observe_pr_diff_facts(session, uuid.uuid4(), "o/r", 12)
+
+    assert result == {"diff_size": 3, "touches_migration": True}
+
+
+@pytest.mark.anyio
+async def test_observe_pr_diff_facts_no_migration_file_is_false():
+    from app.services.merge_verdict_gate import _observe_pr_diff_facts
+
+    installation = SimpleNamespace(installation_id=999)
+    row = MagicMock()
+    row.scalar_one_or_none = MagicMock(return_value=installation)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=row)
+
+    changed_files = ["app/routers/gates.py", "tests/test_gates.py"]
+    with patch("app.services.github_app.get_installation_token", AsyncMock(return_value="tok")), \
+         patch("app.services.verdict_capture.fetch_pr_changed_files", AsyncMock(return_value=changed_files)):
+        result = await _observe_pr_diff_facts(session, uuid.uuid4(), "o/r", 12)
+
+    assert result == {"diff_size": 2, "touches_migration": False}
+
+
+@pytest.mark.anyio
+async def test_observe_pr_diff_facts_fetch_failure_returns_empty():
+    """fetch_pr_changed_files가 None(조회 실패/판정불가)이면 관찰 사실 없이 {} — 지어내지 않는다."""
+    from app.services.merge_verdict_gate import _observe_pr_diff_facts
+
+    installation = SimpleNamespace(installation_id=999)
+    row = MagicMock()
+    row.scalar_one_or_none = MagicMock(return_value=installation)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=row)
+
+    with patch("app.services.github_app.get_installation_token", AsyncMock(return_value="tok")), \
+         patch("app.services.verdict_capture.fetch_pr_changed_files", AsyncMock(return_value=None)):
+        result = await _observe_pr_diff_facts(session, uuid.uuid4(), "o/r", 12)
+
+    assert result == {}

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -729,7 +729,10 @@ async def test_observe_pr_diff_facts_no_installation_returns_empty():
 @pytest.mark.anyio
 async def test_observe_pr_diff_facts_computes_size_and_migration_touch():
     """설치+토큰+PR 파일 조회 전부 성공 시 diff_size(파일 수)·touches_migration(경로 매치)을
-    정확히 계산한다."""
+    정확히 계산한다. ⚠️카디르 QA(PR#3383, 2026-08-23) — GitHub PR-files API는 레포 루트
+    기준 경로를 준다(이 모노레포 실측: "backend/..."). 이전 버전은 이 테스트 fixture가
+    "alembic/versions/..."(prefix 없이)라 버그(코드가 정확히 그 잘못된 prefix를 기대)와
+    우연히 맞아떨어져 매치 로직 결함을 못 잡았다 — 실 형상 경로로 교정."""
     from app.services.merge_verdict_gate import _observe_pr_diff_facts
 
     installation = SimpleNamespace(installation_id=999)
@@ -739,9 +742,9 @@ async def test_observe_pr_diff_facts_computes_size_and_migration_touch():
     session.execute = AsyncMock(return_value=row)
 
     changed_files = [
-        "app/routers/gates.py",
-        "app/services/merge_verdict_gate.py",
-        "alembic/versions/0276_something.py",
+        "backend/app/routers/gates.py",
+        "backend/app/services/merge_verdict_gate.py",
+        "backend/alembic/versions/0276_something.py",
     ]
     with patch("app.services.github_app.get_installation_token", AsyncMock(return_value="tok")), \
          patch("app.services.verdict_capture.fetch_pr_changed_files", AsyncMock(return_value=changed_files)):
@@ -752,6 +755,7 @@ async def test_observe_pr_diff_facts_computes_size_and_migration_touch():
 
 @pytest.mark.anyio
 async def test_observe_pr_diff_facts_no_migration_file_is_false():
+    """양성대조 짝 — 실 형상 경로인데 마이그레이션 파일이 없으면 False(실패할 수 있는 대조)."""
     from app.services.merge_verdict_gate import _observe_pr_diff_facts
 
     installation = SimpleNamespace(installation_id=999)
@@ -760,7 +764,7 @@ async def test_observe_pr_diff_facts_no_migration_file_is_false():
     session = AsyncMock()
     session.execute = AsyncMock(return_value=row)
 
-    changed_files = ["app/routers/gates.py", "tests/test_gates.py"]
+    changed_files = ["backend/app/routers/gates.py", "backend/tests/test_gates.py"]
     with patch("app.services.github_app.get_installation_token", AsyncMock(return_value="tok")), \
          patch("app.services.verdict_capture.fetch_pr_changed_files", AsyncMock(return_value=changed_files)):
         result = await _observe_pr_diff_facts(session, uuid.uuid4(), "o/r", 12)


### PR DESCRIPTION
## 요약
PO 설계안 승인(doc `gate-risk-real-discriminator-design-2950` §3/§7) 슬라이스② — 슬라이스①(#3382, risk_grade 칩 제거)에 스택. **v1 경계 명시**: neutral_facts에 diff_size/touches_migration을 관찰 사실로 채우고 결재함에 그대로 노출까지만 — low/high 재판정·임계값·마찰 정책 변경은 이번 슬라이스 스코프 밖(PO 명시, 별도 승인 필요).

## BE
`app/services/merge_verdict_gate.py::_observe_pr_diff_facts` — `verdict_capture.py::fetch_pr_changed_files`(이미 GitHub PR-files API를 호출하지만 scope-violation 체크 전용으로만 쓰이던 것)를 merge 게이트 평가로 확장 재사용. `evaluate_merge_gate`에서 `facts` 딕셔너리 구성 직후, no-substance shell(pr_number<=0)이 아닐 때만 호출:
- `diff_size` = 변경 파일 수
- `touches_migration` = `alembic/versions/` 경로 매치 여부

best-effort — GithubInstallation 없음/토큰 발급 실패/API 실패 어느 단계든 조용히 `{}`(외부 신호를 지어내지 않는다), 게이트 평가 자체는 절대 막지 않는다. 신규 GitHub API 통합 0.

## FE
- `gate-risk.ts::deriveDiffFacts` — `neutral_facts.diff_size`/`touches_migration`을 구조화(없으면 `null`).
- `approvals-queue.tsx` — 결재함 카드에 평문(배지 아님, 판정처럼 안 보이게) 노출: `파일 {count}`(+`· 마이그레이션 접촉`).
- i18n 키 2개(`diffFactsFileCount`/`diffFactsMigrationTouch`) ko/en 추가.

[SID:2950]

## 테스트
- BE `tests/test_merge_verdict_gate.py` 7건 신규: `evaluate_merge_gate`가 관찰 결과를 neutral_facts에 병합/관찰 실패 시 조용히 생략/no-substance shell은 관찰 자체를 스킵 + `_observe_pr_diff_facts` 단위 4건(설치 없음·계산 정확성·마이그레이션 미접촉·fetch 실패). `evaluate_merge_gate`를 소비하는 21개 테스트 파일(214건) 전체 회귀 없음 재확인.
- FE `approvals-queue.test.tsx` 4건 신규(파일수+마이그레이션 표시·마이그레이션 없음·neutral_facts 없음 시 미표시·risk_grade 칩 완전 제거 재확인) — 44건 전체 통과, `gates/[id]/page.test.tsx` 14건 무회귀.
- `tsc --noEmit` 오류 없음.

## Test plan
- [x] BE 신규 7건 + 관련 214건 회귀 없음
- [x] FE 신규 4건 + 관련 58건 회귀 없음
- [x] 타입체크 통과
- [ ] CI green