### PR TITLE
[SID:2908] fix: 스택 PR 게이트 체크런 고아 — SHA당 실물 1개 강제

### DIFF
--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -26,7 +26,7 @@ from app.models.gate import Gate, set_gate_status
 from app.models.gate_github_check_event import GateGithubCheckEvent
 from app.models.github_installation import GithubInstallation
 from app.models.pull_request_story_link import PullRequestStoryLink
-from app.services.github_app import create_check_run, update_check_run
+from app.services.github_app import create_check_run, list_check_runs_for_ref, update_check_run
 from app.services.merge_verdict_gate import MERGE_GATE_TYPE
 
 logger = logging.getLogger(__name__)
@@ -255,18 +255,50 @@ async def publish_gate_check(
             # 카디르 QA③-c — check-run은 **SHA당 1개**가 정본. 기존 run이 다른 SHA에 대한
             # 것이면(github_check_run_sha 불일치) PATCH가 아니라 새 run을 만든다 — 안 그러면 새
             # head로는 영원히 check가 안 생겨 required가 영구 미충족되는 데드엔드가 생긴다.
+            #
+            # story #2908(실사고 그라운딩) — 위 전제("이 Gate 행이 모르면 없다")가 이 Gate 행
+            # 스코프에서만 참이다. 서로 다른 Gate 행(다른 PR 번호)이 같은 SHA에 바인딩되는 경우
+            # (스택 PR을 통합 PR로 재타겟하는 워크플로 등) 각자 "나는 모른다"고 독립적으로
+            # create해 한 SHA에 동명 check-run이 중복 생성됐다 — 승인된 쪽만 완결되고 먼저
+            # 만들어진 쪽은 영원히 in_progress 고아로 남았다(실측: story 2905, PR #3307/#3331).
+            # 처방(PO 확定, 후보 C): create 前 GitHub 쪽 실 상태를 직접 물어(list_check_runs_
+            # for_ref) 이미 있으면 그걸 PATCH — "SHA당 실물 1개"를 캐시가 아니라 GitHub 자신에게
+            # 확인해 강제한다. 조회 실패(None)는 fail-closed 폴백(PO 확定) — skip은 신규 SHA의
+            # 정상 첫 check-run 생성까지 막는 과잉살상이라, 최악에도 기존 동작(create-new)으로.
             if gate.github_check_run_id is None or gate.github_check_run_sha != head_sha:
-                result = await create_check_run(
-                    installation_id, repo_full_name, head_sha,
-                    name=CHECK_NAME, status=gh_status, conclusion=gh_conclusion,
-                    title="Sprintable Gate",
-                    summary=f"게이트 상태: {gate.status}",
+                existing_runs = await list_check_runs_for_ref(
+                    installation_id, repo_full_name, head_sha, name=CHECK_NAME,
                 )
-                if result is None:
-                    logger.warning("gate=%s: check-run 생성 실패(fail-closed, GitHub 쪽 무영향)", gate_id)
-                    return
-                gate.github_check_run_id = result.get("id")
-                gate.github_check_run_sha = head_sha
+                if existing_runs is None:
+                    logger.warning(
+                        "gate=%s: check-run 조회 실패 — 기존 create-new 폴백(PO 확定, fail-closed)",
+                        gate_id,
+                    )
+                reused_id = existing_runs[0].get("id") if existing_runs else None
+                if reused_id is not None:
+                    result = await update_check_run(
+                        installation_id, repo_full_name, reused_id,
+                        status=gh_status, conclusion=gh_conclusion,
+                        title="Sprintable Gate",
+                        summary=f"게이트 상태: {gate.status}",
+                    )
+                    if result is None:
+                        logger.warning("gate=%s: check-run 갱신 실패(fail-closed, GitHub 쪽 무영향)", gate_id)
+                        return
+                    gate.github_check_run_id = reused_id
+                    gate.github_check_run_sha = head_sha
+                else:
+                    result = await create_check_run(
+                        installation_id, repo_full_name, head_sha,
+                        name=CHECK_NAME, status=gh_status, conclusion=gh_conclusion,
+                        title="Sprintable Gate",
+                        summary=f"게이트 상태: {gate.status}",
+                    )
+                    if result is None:
+                        logger.warning("gate=%s: check-run 생성 실패(fail-closed, GitHub 쪽 무영향)", gate_id)
+                        return
+                    gate.github_check_run_id = result.get("id")
+                    gate.github_check_run_sha = head_sha
             else:
                 result = await update_check_run(
                     installation_id, repo_full_name, gate.github_check_run_id,

--- a/backend/app/services/github_app.py
+++ b/backend/app/services/github_app.py
@@ -207,6 +207,37 @@ async def update_check_run(
     return resp.json()
 
 
+async def list_check_runs_for_ref(
+    installation_id: int, repo_full_name: str, ref: str, *, name: str = "sprintable/gate",
+) -> list[dict] | None:
+    """story #2908 — `GET /repos/{repo}/commits/{ref}/check-runs?check_name=...`. `publish_gate_check`가
+    새 check-run을 만들기 전에 그 SHA에 이미 이 이름의 check-run이 있는지 GitHub 쪽 실 상태를
+    직접 물어본다 — `gate.github_check_run_id`는 그 Gate 행 하나의 캐시일 뿐이라, 서로 다른 Gate
+    행(다른 PR 번호)이 같은 SHA에 바인딩되는 경우(스택 PR을 통합 PR로 재타겟하는 워크플로 등)
+    캐시만 보면 "나는 모른다"고 오판해 같은 SHA에 동명 check-run을 중복 생성한다(실사고 그라운딩
+    doc `2908-stacked-pr-gate-checkrun-orphan-design`). 실패/토큰없음=None(create_check_run/
+    update_check_run과 동일 계약 — fail-closed 상위 호출자 책임). 조회 성공+매치 0건은 빈 리스트
+    (None과 구분 — "몰라서 못 찾음"과 "찾아봤는데 없음"은 다른 신호)."""
+    token = await get_installation_token(installation_id)
+    if not token:
+        return None
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(
+            f"{_GITHUB_API}/repos/{repo_full_name}/commits/{ref}/check-runs",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            params={"check_name": name},
+        )
+    if resp.status_code != 200:
+        logger.warning(
+            "check-run 조회 실패 HTTP %s (repo=%s ref=%s)", resp.status_code, repo_full_name, ref
+        )
+        return None
+    return resp.json().get("check_runs", [])
+
+
 async def get_pull_request(installation_id: int, repo_full_name: str, pr_number: int) -> dict | None:
     """story #2893(설계안 §3 B3) — `GET /repos/{repo}/pulls/{pr}`. `POST /gates/{id}/reevaluate`
     (웹훅 페이로드 없이 사용자가 직접 재평가를 트리거)가 지금 이 PR의 **실 head SHA/merged**

--- a/backend/tests/test_2813_gate_github_check_realdb.py
+++ b/backend/tests/test_2813_gate_github_check_realdb.py
@@ -944,3 +944,159 @@ async def test_evaluate_merge_gate_never_clears_human_approved_anchor_realdb():
             assert gate.approved_head_sha == "sha-human-approved"  # ⭐핵심 단언 — 안 지워짐.
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_reuses_existing_run_when_another_gate_shares_sha_realdb():
+    """story #2908(실사고 재현, story 2905 PR #3307/#3331) — 서로 다른 두 Gate 행(다른 PR 번호)이
+    같은 SHA에 바인딩되면, 나중에 publish되는 쪽은 자기 캐시(github_check_run_id=None)만 보고
+    새 check-run을 만들면 안 된다 — GitHub 쪽에 이미 있는지(list_check_runs_for_ref) 먼저 물어
+    있으면 그 run을 PATCH해야 한다(중복 생성 0). 두 Gate 행을 실제로 seed해 재현한다."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.models.github_installation import GithubInstallation
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+    from app.services.gate_github_check import publish_gate_check
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        shared_sha = "sha-stack-shared"
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+            s.add(project)
+            await s.commit()
+            story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="stack story")
+            s.add(story)
+            installation = GithubInstallation(
+                id=uuid.uuid4(), org_id=org.id, installation_id=424243, account_login="acme",
+            )
+            s.add(installation)
+            # gate_a = base PR(#3307류) — 이미 그 SHA에 check-run을 만들어둔 상태(먼저 publish됨).
+            gate_a = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending", pr_number=3307,
+                github_check_run_id=90001, github_check_run_sha=shared_sha,
+            )
+            s.add(gate_a)
+            # gate_b = 재타겟된 통합 PR(#3331류) — 자기 캐시는 비어있음(같은 SHA를 처음 본다).
+            gate_b = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="approved", approved_head_sha=shared_sha,
+                pr_number=3331,
+            )
+            s.add(gate_b)
+            await s.commit()
+            org_id, gate_b_id = org.id, gate_b.id
+
+        with patch(
+            "app.services.gate_github_check.list_check_runs_for_ref",
+            AsyncMock(return_value=[{"id": 90001}]),
+        ) as list_mock, patch(
+            "app.services.gate_github_check.create_check_run", AsyncMock(),
+        ) as create_mock, patch(
+            "app.services.gate_github_check.update_check_run",
+            AsyncMock(return_value={"id": 90001}),
+        ) as update_mock, patch("app.core.database.async_session_factory", Session):
+            await publish_gate_check(
+                org_id, gate_b_id,
+                head_sha=shared_sha, repo_full_name="acme/repo", pr_number=3331,
+            )
+
+        list_mock.assert_awaited_once()
+        create_mock.assert_not_awaited()  # ⭐핵심 — 중복 생성 0.
+        update_mock.assert_awaited_once()
+        _, update_kwargs = update_mock.call_args
+        assert update_kwargs.get("conclusion") == "success"  # gate_b는 approved.
+
+        async with Session() as s:
+            gate_b_row = (await s.execute(select(Gate).where(Gate.id == gate_b_id))).scalar_one()
+            assert gate_b_row.github_check_run_id == 90001  # gate_a의 run을 재사용.
+            assert gate_b_row.github_check_run_sha == shared_sha
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_falls_back_to_create_when_list_check_runs_fails_realdb():
+    """PO 확定(2026-08-23) fail-closed 폴백 — GitHub 조회(list_check_runs_for_ref) 자체가
+    실패(None)하면 skip이 아니라 기존 create-new 동작 그대로(최악에도 현행 동작 유지, 신규 SHA의
+    정상 첫 check-run 생성까지 막는 과잉살상 금지)."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="pending")
+
+        with patch(
+            "app.services.gate_github_check.list_check_runs_for_ref",
+            AsyncMock(return_value=None),  # 조회 실패.
+        ) as list_mock, patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 9099}),
+        ) as create_mock, patch(
+            "app.services.gate_github_check.update_check_run", AsyncMock(),
+        ) as update_mock, patch("app.core.database.async_session_factory", Session):
+            await publish_gate_check(
+                seeded["org_id"], seeded["gate_id"],
+                head_sha="sha-fallback", repo_full_name="acme/repo", pr_number=7,
+            )
+
+        list_mock.assert_awaited_once()
+        create_mock.assert_awaited_once()  # 폴백 — 기존 create-new 그대로.
+        update_mock.assert_not_awaited()
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
+            assert gate.github_check_run_id == 9099
+            assert gate.github_check_run_sha == "sha-fallback"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_gate_check_creates_when_list_check_runs_returns_empty_realdb():
+    """양성대조 — 조회가 성공했지만 매치 0건(진짜 새 SHA)이면 정상 생성 경로(폴백이 아님)."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.services.gate_github_check import publish_gate_check
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, gate_status="pending")
+
+        with patch(
+            "app.services.gate_github_check.list_check_runs_for_ref",
+            AsyncMock(return_value=[]),  # 조회 성공, 매치 0건.
+        ) as list_mock, patch(
+            "app.services.gate_github_check.create_check_run",
+            AsyncMock(return_value={"id": 9100}),
+        ) as create_mock, patch(
+            "app.services.gate_github_check.update_check_run", AsyncMock(),
+        ) as update_mock, patch("app.core.database.async_session_factory", Session):
+            await publish_gate_check(
+                seeded["org_id"], seeded["gate_id"],
+                head_sha="sha-genuinely-new", repo_full_name="acme/repo", pr_number=7,
+            )
+
+        list_mock.assert_awaited_once()
+        create_mock.assert_awaited_once()
+        update_mock.assert_not_awaited()
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
+            assert gate.github_check_run_id == 9100
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
[SID:2908]

## 요약
`publish_gate_check`가 새 check-run 생성 여부를 Gate 행 자신의 캐시(`github_check_run_id`)만 보고 판단해, 서로 다른 Gate 행(다른 PR 번호)이 같은 커밋 SHA에 바인딩되는 경우(스택 PR을 통합 PR로 재타겟하는 워크플로 등) 한 SHA에 동명 check-run이 중복 생성됐다. 승인된 쪽 check-run만 완결되고 먼저 만들어진 쪽은 영원히 `in_progress` 고아로 남아 base PR 머지가 BLOCKED.

## 그라운딩 — 원 가설 정정
스토리 원 설명("스토리+gate_type 멱등 1슬롯")은 코드 실측 결과 부정확했다. `find_gate_slot_with_pr_fallback`/`create_gate`는 story #2893(0271) 이후 이미 `pr_number`까지 멱등키에 포함해 PR별로 정확히 분리돼 있다(코드 확인). 실 DB 그라운딩(story 2905, PR #3307/#3331)으로 실물 확인: 서로 다른 두 Gate 행이 동일 SHA에 각자 독립 check-run(96951577906 vs 97053989468)을 가진 상태 그대로 재현됐다. 진짜 갭은 "check-run 유일성을 Gate 행 스코프로 보느냐 vs GitHub SHA 스코프로 보느냐"였다.

설계 doc: `2908-stacked-pr-gate-checkrun-orphan-design`(승인 완료, 후보 C 채택).

## 변경
- `app/services/github_app.py`: `list_check_runs_for_ref(installation_id, repo_full_name, ref, name=...)` 신설 — `GET /repos/{repo}/commits/{ref}/check-runs?check_name=...`. 실패=None, 성공+0건=`[]`(구분).
- `app/services/gate_github_check.py`: `publish_gate_check`가 새 check-run이 필요한 분기에서 create 前 `list_check_runs_for_ref`로 GitHub 실 상태를 먼저 조회 — 이미 있으면(다른 Gate 행이 만든 것 포함) 그 id로 PATCH, 없으면만 POST. 조회 실패(None)는 PO 확定 폴백 — 기존 create-new 그대로 + warning 로그(skip은 신규 SHA의 정상 첫 check-run 생성까지 막는 과잉살상이라 기각).
- `tests/test_2813_gate_github_check_realdb.py`: 신규 3건 — ①두 Gate 행·같은 SHA 재현(중복 생성 0·기존 run PATCH 확인) ②조회 실패 시 fail-closed 폴백(create-new) ③조회 성공+0건 시 정상 생성(양성대조).

## 부수 발견 → 별건 분리
`gate.resolved_at` 有 + `status=pending` 불일치(story 2905 gate 실측 中 발견) — [SID:2961]로 분리, 이 PR 스코프 밖(PO 판정).

## 검증
- 신규 3건 + 기존 21건 = 24건 전부 통과.
- 뮤테이션 검증(fix 되돌려 신규 3건 정확히 실패 확인 → 복원 → 재통과 확認) 완료.
- 회귀 스윕: gate/merge-verdict 관련 12개 테스트 파일(120건) 전부 통과. 무관 실패 1건(`test_2829_loop_measure_due_realdb.py::test_ac2_no_infinite_republish_set_once`)은 미수정 baseline(develop)에서도 동일하게 실패 — 이 PR과 무관 확認, 별도 조치 안 함.