### PR TITLE
[SID:2938] 소형 count 배지 AA 대비 교정

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -440,8 +440,9 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
               <span className="flex items-center gap-1.5">
                 {tagsCollapsed ? <ChevronRight className="size-3" /> : <ChevronDown className="size-3" />}
                 {t('tagFilter')}
+                {/* story #2938(유나 design 처방) — 소형 count 배지 AA 교정, 전역 badge.tsx 무접촉. */}
                 {tagsCollapsed && selectedTags.length > 0 && (
-                  <span className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground">{selectedTags.length}</span>
+                  <span className="rounded-full bg-proof-blue-soft px-1.5 py-0.5 text-[10px] font-semibold text-foreground">{selectedTags.length}</span>
                 )}
               </span>
             </button>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -449,7 +449,11 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
             {!tagsCollapsed && (
               <div className="flex max-h-[120px] flex-wrap gap-1 overflow-y-auto px-4 py-1">
                 {allTags.map((tag) => (
-                  <button key={tag} type="button" onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((tg) => tg !== tag) : [...prev, tag])} className={`rounded-full px-2 py-0.5 text-[11px] font-medium transition ${selectedTags.includes(tag) ? 'bg-primary text-primary-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted'}`}>
+                  // story #2938(카디르 QA 재검·2026-08-23) — 선택된 태그 pill도 count 배지와
+                  // 동일 색쌍(bg-primary+text-primary-foreground, 11px)이라 같은 다크 AA 미달.
+                  // 같은 처방(bg-proof-blue-soft+text-foreground)으로 교정 — "버튼은 대형만
+                  // 예외"가 이 pill(11px)엔 적용 안 됨(QA 지적 그대로).
+                  <button key={tag} type="button" onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((tg) => tg !== tag) : [...prev, tag])} className={`rounded-full px-2 py-0.5 text-[11px] font-medium transition ${selectedTags.includes(tag) ? 'bg-proof-blue-soft text-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted'}`}>
                     #{tag}
                   </button>
                 ))}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-shell-client.tsx
@@ -456,11 +456,14 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
             {!tagsCollapsed && (
               <div className="flex max-h-[120px] flex-wrap gap-1 overflow-y-auto px-4 py-1">
                 {allTags.map((tag) => (
+                  // story #2938(카디르 QA 재검·2026-08-23) — 선택된 태그 pill도 count 배지와
+                  // 동일 색쌍(11px)이라 같은 다크 AA 미달. "버튼은 대형만 예외"가 이 11px
+                  // pill엔 적용 안 됨(QA 지적) — 같은 처방으로 교정.
                   <button
                     key={tag}
                     type="button"
                     onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag])}
-                    className={`rounded-full px-2 py-0.5 text-[11px] font-medium transition ${selectedTags.includes(tag) ? 'bg-primary text-primary-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted'}`}
+                    className={`rounded-full px-2 py-0.5 text-[11px] font-medium transition ${selectedTags.includes(tag) ? 'bg-proof-blue-soft text-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted'}`}
                   >
                     #{tag}
                   </button>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-shell-client.tsx
@@ -443,8 +443,9 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                 {tagsCollapsed ? <ChevronRight className="size-3" /> : <ChevronDown className="size-3" />}
                 {t('tagFilter')}
                 {/* AC3: 접힌 상태에서 활성 태그 수 뱃지 */}
+                {/* story #2938(유나 design 처방) — 소형 count 배지 AA 교정, 전역 badge.tsx 무접촉. */}
                 {tagsCollapsed && selectedTags.length > 0 && (
-                  <span className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground">
+                  <span className="rounded-full bg-proof-blue-soft px-1.5 py-0.5 text-[10px] font-semibold text-foreground">
                     {selectedTags.length}
                   </span>
                 )}

--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -184,3 +184,37 @@ describe('ChatListView — SSE 재연결·백그라운드 복귀 재fetch (story
     expect(countMyConversationsFetchCalls(fetchMock)).toBe(beforeCount);
   });
 });
+
+// story #2938(유나 design 처방·WCAG 실측 2026-08-23) — unread count 배지가 bg-primary(solid)+
+// text-primary-foreground(white)라 소형 텍스트 AA 미달(다크 3.21). bg-proof-blue-soft+
+// text-foreground로 교정(라이트 16.13/다크 13.94) — 전역 badge.tsx 무접촉, 이 usage만.
+describe('ChatListView — unread count 배지 대비 교정(story #2938)', () => {
+  function stubFetchWithUnread(unreadCount: number) {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/conversations/recent-outside-project')) {
+        return { ok: true, json: async () => ({ data: [] }) };
+      }
+      if (url.includes('/api/conversations?')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{ id: 'conv-1', type: 'dm', title: '읽지 않은 대화', unread_count: unreadCount }],
+            total: 1,
+          }),
+        };
+      }
+      return { ok: false, status: 404, json: async () => null };
+    }));
+  }
+
+  it('unread>0이면 배지가 bg-proof-blue-soft+text-foreground로 뜬다(bg-primary 잔존 0)', async () => {
+    stubFetchWithUnread(3);
+    await mount();
+    const badge = [...container.querySelectorAll('span')].find((s) => s.textContent === '3');
+    expect(badge).toBeTruthy();
+    expect(badge!.className).toContain('bg-proof-blue-soft');
+    expect(badge!.className).toContain('text-foreground');
+    expect(badge!.className).not.toContain('bg-primary');
+    expect(badge!.className).not.toContain('text-primary-foreground');
+  });
+});

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -194,8 +194,12 @@ function ConversationRow({
         {participantLayer}
         <div className="flex items-center justify-between gap-1">
           <p className="truncate text-xs text-muted-foreground">{preview}</p>
+          {/* story #2938(유나 design 처방·WCAG 실측) — 소형 count 배지는 bg-primary(solid)+
+              text-primary-foreground(white)가 AA 미달(다크 3.21). bg-proof-blue-soft+
+              text-foreground로 교체(라이트 16.13/다크 13.94) — 전역 badge.tsx 무접촉, 이
+              usage에만 스코프. */}
           {unread > 0 && (
-            <span className="flex-shrink-0 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground">
+            <span className="flex-shrink-0 rounded-full bg-proof-blue-soft px-1.5 py-0.5 text-[10px] font-semibold text-foreground">
               {unread > 99 ? '99+' : unread}
             </span>
           )}

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -153,10 +153,13 @@ export function MobileTabBar({ chatUnreadTotal }: { chatUnreadTotal: number }) {
           >
             <span className="relative">
               <Icon className="size-[22px]" strokeWidth={1.8} />
+              {/* story #2938(유나 design 처방·WCAG 실측) — bg-primary(solid)+text-primary-
+                  foreground(white) 소형 count가 AA 미달(다크 3.21). bg-proof-blue-soft+
+                  text-foreground로 교체(라이트 16.13/다크 13.94), 전역 badge.tsx 무접촉. */}
               {badge !== null ? (
                 <span
                   aria-hidden
-                  className="absolute -top-1 left-full ml-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold leading-none text-primary-foreground"
+                  className="absolute -top-1 left-full ml-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-proof-blue-soft px-1 text-[10px] font-bold leading-none text-foreground"
                 >
                   {/* story #1977: 채팅 unread 총합은 99+ 상한(시안 768e89b5 v2) — 결재함은 기존 9+ 유지 */}
                   {key === 'chat' ? (badge > 99 ? '99+' : badge) : badge > 9 ? '9+' : badge}


### PR DESCRIPTION
## 요약
유나 design 처방(WCAG 실측, 2026-08-23) — `bg-primary`(solid proof-blue)+`text-primary-foreground`(white)를 얹은 소형 count/숫자 배지가 다크 테마에서 AA 미달(3.21). `bg-proof-blue-soft`+`text-foreground`로 교체.

## 대비 수치(독립 재계산, AC 요구 그대로 기록)
- 라이트: `text-foreground`(`#121310`) on `bg-proof-blue-soft`(`#EAEEFF`) = **16.13**
- 다크: `text-foreground`(`#F2F4ED`) on `bg-proof-blue-soft`(`#1C2438`) = **13.94**
- 유나 실측(16.13/13.94)과 정확히 일치 — 토큰 수학으로 교차검증 완료.

## 스코프(grep 전수 — 진짜 "숫자 count" 배지만)
- `chat-list-view.tsx:198` — 채팅 unread count(스토리 배경에 명시된 자리)
- `nav/mobile-tab-bar.tsx:159` — 모바일 하단탭 unread/count 배지
- `docs/docs-client-layout.tsx:444` — 접힌 태그필터의 활성 태그 수
- `docs/docs-shell-client.tsx:447` — 동일 배지(sibling 파일, 중복 JSX 존재해 함께 정정)

## 경계 준수
- ⛔ 전역 `badge.tsx` default variant는 무접촉 — 4곳 다 raw `<span>`(Badge 컴포넌트 자체를 안 씀)이라 usage별 className만 교체, 신규 variant도 안 만듦(변경 표면 최소).
- 버튼(대형/굵은 라벨, `bg-primary`+white)·체크마크 아이콘(숫자 아님)은 스코프 밖 — grep으로 후보 전수 훑고 "숫자 count"만 추림. `event-definer-form.tsx`의 체크마크, 각종 toggle 버튼(`bg-primary text-primary-foreground` 다수 잔존), `recruiter-client.tsx`의 avatar-initial 배지는 의도적 무변경(커밋 메시지에 근거).

## 검증
- [x] `grep -rn "bg-primary.*text-primary-foreground" --include="*.tsx"` — 소형(9~11px) count 배지 잔존 0(버튼류만 남음, 의도적)
- [x] 신규 회귀테스트(`chat-list-view.test.tsx`) — unread 배지가 `bg-proof-blue-soft`+`text-foreground`로 렌더, 구 클래스 잔존 0
- [x] `pnpm exec tsc --noEmit` — EXIT 0
- [x] `pnpm lint` — 경고 5개(baseline 그대로, 신규 0)
- [x] `pnpm vitest run` — 484 files / 4150 tests green(신규 1)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0
- [x] `verify-tint-foreground-contrast` / `verify-no-new-tint-color-text` — 신규 위반 0
- [ ] 모바일/데스크톱 스크린샷 — dev 배포 후 카디르군 QA 단계에서 동봉 예정

🤖 Generated with Claude Code