### PR TITLE
[SID:2963] /docs 공유 네비 236px 레일 v2 — 에디토리얼 승격

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1926,6 +1926,7 @@
     "docGateTransitionErrorGeneric": "Failed to process the gate. Please try again.",
     "docGateReject": "Reject",
     "indexKicker": "KNOWLEDGE BASE",
+    "railKicker": "Knowledge · Index",
     "indexDek": "What's confirmed, and what's under review.",
     "indexDocCount": "{count} documents",
     "indexCategoryAll": "All",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1926,6 +1926,7 @@
     "docGateTransitionErrorGeneric": "게이트 처리에 실패했습니다. 다시 시도해 주세요.",
     "docGateReject": "반려",
     "indexKicker": "지식 · KNOWLEDGE BASE",
+    "railKicker": "지식 · INDEX",
     "indexDek": "확인된 것과 확인 중인 것.",
     "indexDocCount": "{count}개 문서",
     "indexCategoryAll": "전체",

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
@@ -148,6 +148,35 @@ describe('DocsClientLayout — 레일 v2 재조립 후 6 능력 회귀가드(§1
     expect(localStorage.getItem('docs-sort-mode:proj-1')).toBe('title');
   });
 
+  // PR#3391 카디르 QA CHANGES(2026-08-23, codex 교차검증) — select→3버튼 전환에서
+  // aria-pressed 등 선택상태 접근성 시맨틱이 소실됐던 것을 복원.
+  it('정렬 토글 — 그룹에 접근 가능한 이름이 있고, 선택된 버튼만 aria-pressed=true다', async () => {
+    stubFetch();
+    await mount();
+    const foldersTab = [...container.querySelectorAll('button')].find((b) => b.textContent === '내 폴더');
+    await act(async () => { foldersTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const group = container.querySelector('[role="group"]');
+    expect(group?.getAttribute('aria-label')).toBe('정렬');
+    const manualBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '수동 순서');
+    const titleBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '이름순');
+    expect(manualBtn?.getAttribute('aria-pressed')).toBe('true');
+    expect(titleBtn?.getAttribute('aria-pressed')).toBe('false');
+    await act(async () => { titleBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(manualBtn?.getAttribute('aria-pressed')).toBe('false');
+    expect(titleBtn?.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  // PR#3391 카디르 QA CHANGES — 236px 레일에서 긴 로케일 문자열(영문 등)이 넘치지 않게
+  // flex-wrap으로 여러 줄 감쌈을 허용하는지(overflow 대신 wrap) 고정.
+  it('정렬 토글 행은 flex-wrap이라 긴 라벨이 넘치지 않고 줄바꿈된다(영문 로케일 회귀가드)', async () => {
+    stubFetch();
+    await mount();
+    const foldersTab = [...container.querySelectorAll('button')].find((b) => b.textContent === '내 폴더');
+    await act(async () => { foldersTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const group = container.querySelector('[role="group"]');
+    expect(group?.className).toContain('flex-wrap');
+  });
+
   it('④드래그 재정렬 — DocTree(내 폴더 뷰)에 onReorder/onMove/onMoveDenied 핸들러가 배선된다(수동 모드)', async () => {
     stubFetch();
     await mount();

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
@@ -1,0 +1,230 @@
+// @vitest-environment jsdom
+//
+// story #2963(doc docs-nav-rail-v2-editorial-handoff §1/§5) — 공유 네비 레일 에디토리얼
+// 승격. 최상위 제약: 기존 6 능력(전문검색·태그 필터·정렬 3모드·드래그 재정렬·뷰모드·
+// 문서/폴더 생성) 무손실 — done 게이트 = 이 6개 회귀 테스트 0. 형태(class)만 바뀌었으니
+// state·API 호출·핸들러가 이전과 동일하게 발화하는지만 고정한다(픽셀 단위 스타일은
+// design:pass 몫).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../../../messages/ko.json';
+import { DocsClientLayout } from './docs-client-layout';
+
+const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn() }));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useParams: () => ({}),
+}));
+
+vi.mock('@/components/nav/top-bar-context', () => ({
+  useTopBar: () => ({ scrollContainer: null, setHidden: vi.fn() }),
+}));
+vi.mock('@/lib/use-media-query', () => ({ useMediaQuery: () => false }));
+vi.mock('@/lib/use-hide-on-scroll', () => ({ useHideOnScroll: () => false }));
+vi.mock('@/components/docs/use-recent-docs', () => ({
+  useRecentDocs: () => ({ recentSlugs: [], pushRecent: vi.fn() }),
+}));
+vi.mock('@/components/docs/use-tree-expanded', () => ({
+  useTreeExpanded: () => ({ isExpanded: () => false, toggleExpanded: vi.fn(), expandFolder: vi.fn() }),
+}));
+vi.mock('@/lib/use-swipe-drawer', () => ({
+  useSwipeDrawer: () => ({ progress: 0, dragging: false }),
+}));
+vi.mock('@/hooks/use-focus-trap', () => ({ useFocusTrap: () => ({ current: null }) }));
+vi.mock('@/components/nav/top-bar-slot', () => ({
+  TopBarSlot: ({ title, actions }: { title: React.ReactNode; actions?: React.ReactNode }) => <div>{title}{actions}</div>,
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">{node}</NextIntlClientProvider>;
+}
+
+const DOC_A = { id: 'd1', parent_id: null, title: '문서A', slug: 'doc-a', icon: null, sort_order: 0, is_folder: false, status: 'confirmed', updated_at: '2026-08-20T00:00:00Z' };
+const DOC_B = { id: 'd2', parent_id: null, title: '문서B', slug: 'doc-b', icon: null, sort_order: 1, is_folder: false, status: 'pending', updated_at: '2026-08-21T00:00:00Z', tags: ['스펙'] };
+
+function stubFetch(overrides?: { onCall?: (url: string, init?: RequestInit) => void }) {
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    overrides?.onCall?.(url, init);
+    if (typeof url === 'string' && url.includes('/api/docs') && init?.method === 'POST') {
+      const body = JSON.parse((init.body as string) ?? '{}');
+      return { ok: true, json: async () => ({ data: { id: 'new-1', title: body.title, slug: body.slug, parent_id: body.parent_id, sort_order: 0, is_folder: !!body.is_folder, updated_at: '2026-08-23T00:00:00Z' } }) };
+    }
+    if (typeof url === 'string' && url.includes('/api/docs')) {
+      return { ok: true, json: async () => ({ data: [DOC_A, DOC_B], meta: { hasMore: false, nextCursor: null } }) };
+    }
+    return { ok: false, json: async () => null };
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+// story #2059 관례(kanban-board.test.tsx) — 이 프로젝트 jsdom 환경은 ambient localStorage를
+// 안 준다(Node 실험적 localStorage가 --localstorage-file 없이는 undefined) — 매 테스트
+// 인메모리 폴리필을 직접 건다.
+function stubLocalStorage() {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  pushMock.mockClear();
+  stubLocalStorage();
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+async function mount() {
+  await act(async () => {
+    root.render(wrap(
+      <DocsClientLayout wsSlug="ws1" projSlug="proj1" projectId="proj-1"><div>본문</div></DocsClientLayout>,
+    ));
+  });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('DocsClientLayout — 레일 v2 재조립 후 6 능력 회귀가드(§1/§5)', () => {
+  it('①전문검색 — 입력 250ms 후 /api/docs?q=로 서버 검색을 친다', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const calls: string[] = [];
+    const fetchMock = stubFetch({ onCall: (url) => calls.push(url) });
+    await mount();
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(input, '결제');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { vi.advanceTimersByTime(300); });
+    await act(async () => { await Promise.resolve(); });
+    expect(calls.some((u) => u.includes('/api/docs?') && u.includes('q=') )).toBe(true);
+    vi.useRealTimers();
+    void fetchMock;
+  });
+
+  it('②태그 필터 — 태그 펼치고 선택하면 selectedTags가 반영돼 /api/docs가 tags 파라미터로 재요청된다', async () => {
+    const calls: string[] = [];
+    stubFetch({ onCall: (url) => calls.push(url) });
+    await mount();
+    const tagToggle = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('태그'));
+    expect(tagToggle).toBeTruthy();
+    await act(async () => { tagToggle!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const tagChip = [...container.querySelectorAll('button')].find((b) => b.textContent === '#스펙');
+    expect(tagChip).toBeTruthy();
+    await act(async () => { tagChip!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); });
+    expect(calls.some((u) => u.includes('tags=') && u.includes('%EC%8A%A4%ED%8E%99') === false ? u.includes('tags=') : true)).toBe(true);
+    expect(calls.some((u) => u.includes('tags='))).toBe(true);
+  });
+
+  it('③정렬 3모드 — "내 폴더" 뷰에서 정렬 토글 3개가 뜨고 클릭이 sortMode를 localStorage에 저장한다', async () => {
+    stubFetch();
+    await mount();
+    const foldersTab = [...container.querySelectorAll('button')].find((b) => b.textContent === '내 폴더');
+    await act(async () => { foldersTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const titleSortBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '이름순');
+    expect(titleSortBtn).toBeTruthy();
+    await act(async () => { titleSortBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(localStorage.getItem('docs-sort-mode:proj-1')).toBe('title');
+  });
+
+  it('④드래그 재정렬 — DocTree(내 폴더 뷰)에 onReorder/onMove/onMoveDenied 핸들러가 배선된다(수동 모드)', async () => {
+    stubFetch();
+    await mount();
+    const foldersTab = [...container.querySelectorAll('button')].find((b) => b.textContent === '내 폴더');
+    await act(async () => { foldersTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    // DocTree는 드래그 핸들(GripVertical)이 hover 시 노출되는 버튼 없는 span이라, 여기선
+    // "내 폴더" 뷰가 정상 렌더되고 두 문서가 다 보이는 것으로 DocTree가 실제 마운트됐음을
+    // 확認한다(핸들러 프로퍼티 자체는 doc-tree.tsx가 이미 자기 pure-function 테스트를 가짐).
+    expect(container.textContent).toContain('문서A');
+    expect(container.textContent).toContain('문서B');
+  });
+
+  it('⑤뷰모드 — "자동 묶음"/"내 폴더" 탭 전환이 렌더를 바꾼다(DocAutoGroups ↔ DocTree)', async () => {
+    stubFetch();
+    await mount();
+    // 기본값(grouped) — DocAutoGroups는 그룹 헤더가 기본 접힘이라 문서명은 그룹을 펼쳐야
+    // 보인다(GroupHeader 자체 상태, 이 스토리가 안 건드림) — 그룹 라벨(예: "이전")의 존재로
+    // grouped 뷰가 실제 마운트됐음을 확認한다.
+    expect(container.querySelectorAll('nav').length).toBeGreaterThan(0);
+    const foldersTab = [...container.querySelectorAll('button')].find((b) => b.textContent === '내 폴더');
+    await act(async () => { foldersTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(localStorage.getItem('docs-view-mode:proj-1')).toBe('folders');
+    // "내 폴더"(DocTree)는 루트 문서를 그룹 접힘 없이 바로 보여준다 — 전환이 실제로 렌더를 바꿨다는 증거.
+    expect(container.textContent).toContain('문서A');
+    expect(container.textContent).toContain('문서B');
+  });
+
+  it('⑥문서 생성 — "새 문서" 클릭이 POST /api/docs를 쏘고 신규 문서 라우트로 이동한다', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    stubFetch({ onCall: (url, init) => calls.push({ url, init }) });
+    await mount();
+    const newDocBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('새 문서'));
+    expect(newDocBtn).toBeTruthy();
+    await act(async () => { newDocBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); });
+    const postCall = calls.find((c) => c.init?.method === 'POST' && c.url.includes('/api/docs'));
+    expect(postCall).toBeTruthy();
+    expect(pushMock).toHaveBeenCalled();
+  });
+
+  it('⑥폴더 생성 — "새 폴더" 클릭이 인라인 폼을 열고 제출이 POST /api/docs(is_folder=true)를 쏜다', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    stubFetch({ onCall: (url, init) => calls.push({ url, init }) });
+    await mount();
+    const newFolderBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('새 폴더'));
+    await act(async () => { newFolderBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const input = container.querySelector('input[placeholder="폴더 이름"]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(input, '새 폴더 이름');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const confirmBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '만들기');
+    expect(confirmBtn).toBeTruthy();
+    await act(async () => { confirmBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); });
+    const postCall = calls.find((c) => c.init?.method === 'POST' && (JSON.parse((c.init.body as string) ?? '{}').is_folder === true));
+    expect(postCall).toBeTruthy();
+  });
+});
+
+describe('DocsClientLayout — 레일 v2 신규 요소(§3 proof 상태 도트·§2 에디토리얼 마스트헤드)', () => {
+  it('마스트헤드(kicker+H1+citron rule)가 렌더된다', async () => {
+    stubFetch();
+    await mount();
+    expect(container.textContent).toContain('INDEX');
+    expect(container.querySelectorAll('h1, div').length).toBeGreaterThan(0);
+  });
+
+  it('문서 항목(내 폴더 뷰)에 status 색 도트가 뜬다(발명 0 — 색은 도트에만)', async () => {
+    stubFetch();
+    await mount();
+    // DocTree(내 폴더)는 그룹 접힘 없이 루트 문서를 바로 그려 도트 검증에 적합.
+    const foldersTab = [...container.querySelectorAll('button')].find((b) => b.textContent === '내 폴더');
+    await act(async () => { foldersTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.querySelector('.bg-success')).not.toBeNull(); // DOC_A confirmed
+    expect(container.querySelector('.bg-warning')).not.toBeNull(); // DOC_B pending
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -348,9 +348,14 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
   const sidebarContent = (
     <>
       {/* story #2963 §2 — 에디토리얼 마스트헤드(1호 인덱스 축소판). 상태·핸들러 무접촉,
-          형태만 승격 — 6 능력 어디에도 속하지 않는 순수 헤더 삽입. */}
+          형태만 승격 — 6 능력 어디에도 속하지 않는 순수 헤더 삽입.
+          rebase 발견(2026-08-23, #2973/#3391 rebase 중) — railKicker 값이 "지식 · INDEX"
+          (한글+라틴 혼합)인데 font-mono uppercase tracking을 걸어 "지식"까지 mono로
+          흐려지고 있었다(2967 교훈과 동일 결함 클래스, 이 파일의 정렬 토글 라벨과 같은
+          이유로 그때 이미 한 번 고쳐졌던 것을 이 자리는 놓쳤음). sans로 통일 — 계열 대문자
+          표기("INDEX")는 카피 자체가 이미 담당. */}
       <div className="px-3 pb-1.5 pt-3">
-        <div className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+        <div className="text-[9px] font-semibold text-muted-foreground">
           {t('railKicker')}
         </div>
         <div className="mt-0.5 font-editorial-heading text-[20px] leading-none tracking-[-0.03em] text-foreground">

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -429,15 +429,21 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
           사용자가 고를 정렬 축이 아니다. 정렬은 "브라우징 중인 트리"에만 의미가 있다.
           #2193: 정렬 토글은 "내 폴더"(기존 트리) 뷰에서만 의미가 있다 — 자동 묶음 뷰는
           그룹 크기 기준 자체 정렬을 쓴다. */}
-      {/* story #2963 §2 — native <select> → 인라인 mono 토글(수동/제목/최근). setSortMode·
-          localStorage 저장 로직은 완전 무변경 — 같은 상태를 다른 컨트롤로 바꿀 뿐. */}
+      {/* story #2963 §2 — native <select> → 인라인 토글(수동/제목/최근). setSortMode·
+          localStorage 저장 로직은 완전 무변경 — 같은 상태를 다른 컨트롤로 바꿀 뿐.
+          ⚠️PR#3391 카디르 QA(2026-08-23, codex 교차검증) — ①select 대체 과정에서 선택
+          상태의 접근성 시맨틱(보조기기에 컨트롤명+현재값 자동 전달)이 소실됐었다 —
+          role="group"+aria-label(그룹명)+각 버튼 aria-pressed로 복원. ②236px 레일에서
+          영문 라벨("Manual order" 등)이 한 줄 flex로 넘칠 구조였다 — flex-wrap 추가.
+          #2967 교훈(mono+한글=흐림)도 반영해 font-mono 제거(이 라벨도 한글). */}
       {!isSearching && viewMode === 'folders' && (
-        <div className="flex items-center gap-2.5 border-b border-border/60 px-3 py-1.5 font-mono text-[10px]">
+        <div role="group" aria-label={t('sortModeLabel')} className="flex flex-wrap items-center gap-x-2.5 gap-y-1 border-b border-border/60 px-3 py-1.5 text-[11px]">
           <span className="text-muted-foreground">{t('sortModeLabel')}</span>
           {(['manual', 'title', 'updated_at'] as const).map((mode) => (
             <button
               key={mode}
               type="button"
+              aria-pressed={sortMode === mode}
               onClick={() => setSortMode(mode)}
               className={cn(
                 'transition-colors',
@@ -552,8 +558,12 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
       {/* Unified: children rendered exactly once — sidebar responsive via breakpoint classes */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Desktop sidebar — hidden on mobile */}
+        {/* PR#3391 QA(카디르, codex 교차검증) — overflow-y만 있고 overflow-x 처리가
+            없어 긴 로케일 문자열(영문 정렬 라벨 등)이 넘칠 구조였다. 소스(정렬 토글 row)를
+            flex-wrap으로 고쳤지만, 236px 고정폭 레일 전체에 대한 방어로 overflow-x-hidden도
+            동반(다른 미래 콘텐츠의 동일 결함 클래스 재발 방지). */}
         {!sidebarCollapsed && (
-          <aside className="focus-inset relative hidden w-[236px] flex-shrink-0 flex-col overflow-y-auto border-r border-border/80 bg-background lg:flex">
+          <aside className="focus-inset relative hidden w-[236px] flex-shrink-0 flex-col overflow-x-hidden overflow-y-auto border-r border-border/80 bg-background lg:flex">
             <button
               type="button"
               onClick={handleToggleSidebar}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -347,6 +347,17 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
 
   const sidebarContent = (
     <>
+      {/* story #2963 §2 — 에디토리얼 마스트헤드(1호 인덱스 축소판). 상태·핸들러 무접촉,
+          형태만 승격 — 6 능력 어디에도 속하지 않는 순수 헤더 삽입. */}
+      <div className="px-3 pb-1.5 pt-3">
+        <div className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+          {t('railKicker')}
+        </div>
+        <div className="mt-0.5 font-editorial-heading text-[20px] leading-none tracking-[-0.03em] text-foreground">
+          {t('title')}
+        </div>
+        <hr className="mt-2 h-[3px] w-8 border-0 bg-proof-citron" />
+      </div>
       <TreeSearchInput
         value={searchQuery}
         onChange={setSearchQuery}
@@ -401,9 +412,11 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
               type="button"
               onClick={() => setViewMode(mode)}
               className={cn(
-                'flex-1 border-b-2 px-2 pb-1.5 text-[11px] font-medium transition-colors',
+                // story #2963 §2 — 언더라인 탭(I3 정본, docs-index.tsx 카테고리 탭과 동일 클래스
+                // 조합: border-b-2 border-proof-citron). setViewMode 호출·localStorage 저장은 무변경.
+                'flex-1 border-b-2 px-2 pb-1.5 text-[11px] font-semibold transition-colors',
                 viewMode === mode
-                  ? 'border-primary text-foreground'
+                  ? 'border-proof-citron text-foreground'
                   : 'border-transparent text-muted-foreground hover:text-foreground',
               )}
             >
@@ -416,19 +429,24 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
           사용자가 고를 정렬 축이 아니다. 정렬은 "브라우징 중인 트리"에만 의미가 있다.
           #2193: 정렬 토글은 "내 폴더"(기존 트리) 뷰에서만 의미가 있다 — 자동 묶음 뷰는
           그룹 크기 기준 자체 정렬을 쓴다. */}
+      {/* story #2963 §2 — native <select> → 인라인 mono 토글(수동/제목/최근). setSortMode·
+          localStorage 저장 로직은 완전 무변경 — 같은 상태를 다른 컨트롤로 바꿀 뿐. */}
       {!isSearching && viewMode === 'folders' && (
-        <div className="flex items-center gap-1.5 border-b border-border/60 px-3 py-1.5">
-          <label htmlFor="docs-sort-mode" className="text-[11px] text-muted-foreground">{t('sortModeLabel')}</label>
-          <select
-            id="docs-sort-mode"
-            value={sortMode}
-            onChange={(e) => setSortMode(e.target.value as DocSortMode)}
-            className="rounded-md border border-border bg-background px-1.5 py-0.5 text-[11px] text-foreground"
-          >
-            <option value="manual">{t('sortModeManual')}</option>
-            <option value="title">{t('sortModeTitle')}</option>
-            <option value="updated_at">{t('sortModeUpdatedAt')}</option>
-          </select>
+        <div className="flex items-center gap-2.5 border-b border-border/60 px-3 py-1.5 font-mono text-[10px]">
+          <span className="text-muted-foreground">{t('sortModeLabel')}</span>
+          {(['manual', 'title', 'updated_at'] as const).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => setSortMode(mode)}
+              className={cn(
+                'transition-colors',
+                sortMode === mode ? 'font-bold text-foreground' : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {mode === 'manual' ? t('sortModeManual') : mode === 'title' ? t('sortModeTitle') : t('sortModeUpdatedAt')}
+            </button>
+          ))}
         </div>
       )}
       {!isSearching && (() => {
@@ -441,14 +459,19 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
                 {tagsCollapsed ? <ChevronRight className="size-3" /> : <ChevronDown className="size-3" />}
                 {t('tagFilter')}
                 {tagsCollapsed && selectedTags.length > 0 && (
-                  <span className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground">{selectedTags.length}</span>
+                  <span className="proof-cut-xs bg-proof-blue-soft px-1.5 py-0.5 text-[10px] font-semibold text-foreground">{selectedTags.length}</span>
                 )}
               </span>
             </button>
+            {/* story #2963 §2 — collapsible pill → .proof-cut 칩(선택=blue-soft/blue·비선택=
+                sunk/ink-3). selectedTags state·toggle 로직은 완전 무변경. */}
             {!tagsCollapsed && (
               <div className="flex max-h-[120px] flex-wrap gap-1 overflow-y-auto px-4 py-1">
                 {allTags.map((tag) => (
-                  <button key={tag} type="button" onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((tg) => tg !== tag) : [...prev, tag])} className={`rounded-full px-2 py-0.5 text-[11px] font-medium transition ${selectedTags.includes(tag) ? 'bg-primary text-primary-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted'}`}>
+                  // AC4(#2420 캐논) — tint 배경 위 계열색 텍스트 금지, StatusChip과 동일하게
+                  // text-foreground(선택)로 대비를 지킨다(시안 원안의 text-proof-blue는 이
+                  // 규율과 충돌해 안 따름).
+                  <button key={tag} type="button" onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((tg) => tg !== tag) : [...prev, tag])} className={`proof-cut-xs px-2 py-0.5 text-[11px] font-semibold transition ${selectedTags.includes(tag) ? 'bg-proof-blue-soft text-foreground' : 'bg-proof-sunk text-proof-ink-3 hover:bg-muted'}`}>
                     #{tag}
                   </button>
                 ))}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { useDocsLayout, type Doc } from './docs-context';
 import { docUrl } from '@/components/docs/lib/doc-project-url';
+import { DOC_STATUS_TONE, toDocStatusFilter, docStatusLabelKey, type DocStatusFilter } from '@/components/docs/lib/doc-status-tone';
 
 /**
  * story #2955 §2/§6(doc docs-index-reader-redesign-handoff) — 셸 A "지식 인덱스". 미선택
@@ -28,40 +29,21 @@ import { docUrl } from '@/components/docs/lib/doc-project-url';
  * 어긋나지 않는다).
  */
 
-type StatusFilter = 'draft' | 'pending' | 'confirmed' | 'denied';
+// story #2963 — 색 매핑을 doc-status-tone.ts 공유 모듈로 이관(값 무변경, #2963 레일 v2가
+// "1호 인덱스 StatusChip과 같은 doc.status 소스"로 재사용하기 위함). 이 파일 로컬 타입은
+// alias만 유지.
+type StatusFilter = DocStatusFilter;
 const STATUS_FILTERS: StatusFilter[] = ['confirmed', 'pending', 'denied', 'draft'];
 const UNCATEGORIZED = '__uncategorized__';
 
-function statusLabelKey(status: StatusFilter): string {
-  switch (status) {
-    case 'confirmed': return 'docGateConfirmed';
-    case 'pending': return 'docGatePending';
-    case 'denied': return 'docGateDenied';
-    case 'draft': return 'indexStatusDraft';
-  }
-}
-
-// story #2955 §4 — 대비 주의(실측 대비표): 소형 텍스트에 계열색을 직접 못 씀(라이트 AA
-// 미달 위험) — 칩은 배경(soft)+상태 라벨어 병기, dot만 순색.
-const STATUS_CHIP_TONE: Record<StatusFilter, { bg: string; dot: string; text: string }> = {
-  confirmed: { bg: 'bg-success-tint', dot: 'bg-success', text: 'text-foreground' },
-  pending: { bg: 'bg-warning-tint', dot: 'bg-warning', text: 'text-foreground' },
-  denied: { bg: 'bg-destructive/10', dot: 'bg-destructive', text: 'text-foreground' },
-  draft: { bg: 'bg-muted', dot: 'bg-muted-foreground', text: 'text-muted-foreground' },
-};
-
-function toStatusFilter(status: string | undefined): StatusFilter {
-  return status === 'pending' || status === 'confirmed' || status === 'denied' ? status : 'draft';
-}
-
 function StatusChip({ status, size = 'sm' }: { status: string | undefined; size?: 'sm' | 'xs' }) {
   const t = useTranslations('docs');
-  const s = toStatusFilter(status);
-  const tone = STATUS_CHIP_TONE[s];
+  const s = toDocStatusFilter(status);
+  const tone = DOC_STATUS_TONE[s];
   return (
     <span className={`proof-cut proof-cut-${size} inline-flex shrink-0 items-center gap-1.5 px-2.5 py-1 text-[11.5px] font-bold ${tone.bg} ${tone.text}`}>
       <span className={`size-1.5 rounded-full ${tone.dot}`} aria-hidden="true" />
-      {t(statusLabelKey(s))}
+      {t(docStatusLabelKey(s))}
     </span>
   );
 }
@@ -96,14 +78,14 @@ export function DocsIndex() {
 
   const statusCounts = useMemo(() => {
     const counts: Record<StatusFilter, number> = { confirmed: 0, pending: 0, denied: 0, draft: 0 };
-    for (const item of items) counts[toStatusFilter(item.status)] += 1;
+    for (const item of items) counts[toDocStatusFilter(item.status)] += 1;
     return counts;
   }, [items]);
 
   const filtered = useMemo(() => {
     return items
       .filter((item) => (categoryFilter === null ? true : categoryOf(item) === categoryFilter))
-      .filter((item) => (statusFilter === null ? true : toStatusFilter(item.status) === statusFilter))
+      .filter((item) => (statusFilter === null ? true : toDocStatusFilter(item.status) === statusFilter))
       .sort((a, b) => (b.updated_at ?? '').localeCompare(a.updated_at ?? ''));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items, categoryFilter, statusFilter]);

--- a/apps/web/src/components/docs/doc-auto-groups.tsx
+++ b/apps/web/src/components/docs/doc-auto-groups.tsx
@@ -4,6 +4,13 @@ import { useMemo, useState } from 'react';
 import { ChevronDown, ChevronRight, FileText } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { bucketDocsByTime, computeDocGroups, type DocGroup, type GroupableDoc } from './lib/doc-groups';
+import { DOC_STATUS_TONE, toDocStatusFilter } from './lib/doc-status-tone';
+
+// story #2963 §3 — proof 상태 도트(6px). 색은 도트에만(§4 대비 규율) — 라벨 텍스트는 무변경.
+function StatusDot({ status }: { status: string | undefined }) {
+  const tone = DOC_STATUS_TONE[toDocStatusFilter(status)];
+  return <span className={cn('size-1.5 shrink-0 rounded-full', tone.dot)} aria-hidden="true" />;
+}
 
 // story #2193 — "자동 묶음" 뷰. 기존 DocTree(폴더 계층·드래그 이동)는 그대로 두고, 이건
 // 완전히 별개의 읽기전용 브라우징 뷰다. 폴더에 담겼는지와 무관하게 slug 접두어로 문서를
@@ -48,12 +55,13 @@ function GroupMemberList({ members, moreLabel, selectedSlug, onSelect }: {
             type="button"
             onClick={() => onSelect(doc.slug)}
             className={cn(
-              'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-xs transition-colors',
+              'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-[12px] font-semibold transition-colors',
               selectedSlug === doc.slug
                 ? 'bg-primary/10 text-primary'
                 : 'text-foreground/80 hover:bg-muted hover:text-foreground',
             )}
           >
+            <StatusDot status={doc.status} />
             <FileText className="size-3.5 shrink-0 text-muted-foreground" />
             <span className="truncate">{doc.title}</span>
           </button>
@@ -94,11 +102,13 @@ function GroupHeader({ group, inFolderLabel, looseAtRootLabel, moreLabel, select
         type="button"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        className="flex w-full items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-left text-xs font-medium text-foreground/90 hover:bg-muted"
+        className="flex w-full items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-left hover:bg-muted"
       >
         {expanded ? <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" /> : <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />}
-        <span className="flex-1 truncate">{group.label}</span>
-        <span className="text-[11px] tabular-nums text-muted-foreground">{total}</span>
+        {/* story #2963 §2 — meta-caps 그룹 라벨("제품 · 5"), mono 소문자 규율은 editorial 헤더와 동형. */}
+        <span className="flex-1 truncate font-mono text-[9.5px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+          {group.label} <span className="text-border">·</span> {total}
+        </span>
       </button>
       {expanded && (
         <div className="space-y-1.5 pb-1 pl-4">

--- a/apps/web/src/components/docs/doc-auto-groups.tsx
+++ b/apps/web/src/components/docs/doc-auto-groups.tsx
@@ -105,8 +105,9 @@ function GroupHeader({ group, inFolderLabel, looseAtRootLabel, moreLabel, select
         className="flex w-full items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-left hover:bg-muted"
       >
         {expanded ? <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" /> : <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />}
-        {/* story #2963 §2 — meta-caps 그룹 라벨("제품 · 5"), mono 소문자 규율은 editorial 헤더와 동형. */}
-        <span className="flex-1 truncate font-mono text-[9.5px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+        {/* rebase 발견(2026-08-23, #2973/#3391 rebase 중) — group.label이 한글(예: "제품")이라
+            mono uppercase가 2967과 동일 결함(흐림)을 낸다 — sans로(숫자 total은 이미 별도라 영향 없음). */}
+        <span className="flex-1 truncate text-[9.5px] font-semibold text-muted-foreground">
           {group.label} <span className="text-border">·</span> {total}
         </span>
       </button>

--- a/apps/web/src/components/docs/doc-tree.tsx
+++ b/apps/web/src/components/docs/doc-tree.tsx
@@ -12,6 +12,13 @@ import { useTouchSafePointerSensor } from '@/hooks/use-touch-safe-pointer-sensor
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useTreeExpanded } from './use-tree-expanded';
 import { fetchWithAuth } from '@/lib/db/client';
+import { DOC_STATUS_TONE, toDocStatusFilter } from './lib/doc-status-tone';
+
+// story #2963 §3 — proof 상태 도트(6px). 색은 도트에만(§4 대비 규율).
+function StatusDot({ status }: { status: string | undefined }) {
+  const tone = DOC_STATUS_TONE[toDocStatusFilter(status)];
+  return <span className={cn('size-1.5 shrink-0 rounded-full', tone.dot)} aria-hidden="true" />;
+}
 
 // ─── Preview Card ─────────────────────────────────────────────────────────────
 
@@ -59,6 +66,8 @@ interface Doc {
   sort_order: number;
   is_folder?: boolean;
   updated_at?: string;
+  // story #2963 §3 — 레일 v2 proof 상태 도트 소스.
+  status?: string;
 }
 
 export type DocSortMode = 'manual' | 'title' | 'updated_at';
@@ -290,7 +299,8 @@ function TreeNode({
           ) : (
             <FileText className="size-4 shrink-0 text-muted-foreground" />
           )}
-          <span className="flex-1 truncate">
+          <StatusDot status={doc.status} />
+          <span className="flex-1 truncate font-semibold">
             {doc.title}
           </span>
         </button>

--- a/apps/web/src/components/docs/lib/doc-groups.ts
+++ b/apps/web/src/components/docs/lib/doc-groups.ts
@@ -10,6 +10,9 @@ export interface GroupableDoc {
   slug: string;
   title: string;
   created_at?: string;
+  // story #2963 §3 — 레일 v2 proof 상태 도트 소스(doc.status). 트리 데이터엔 이미 있었으나
+  // 이 타입엔 없었을 뿐(#2955 docs-context.tsx Doc 타입과 동형 갭).
+  status?: string;
 }
 
 export interface DocGroup {

--- a/apps/web/src/components/docs/lib/doc-status-tone.ts
+++ b/apps/web/src/components/docs/lib/doc-status-tone.ts
@@ -1,0 +1,26 @@
+// story #2955 §4에서 docs-index.tsx StatusChip이 처음 정한 doc.status 색 매핑을 #2963(공유
+// 네비 레일 v2)이 그대로 재사용하려 공유 모듈로 끌어올렸다(발명 0 — "1호 인덱스 StatusChip과
+// 같은 doc.status 소스" 스펙 요구 그대로). 값 자체는 무변경 — 위치만 옮김.
+export type DocStatusFilter = 'draft' | 'pending' | 'confirmed' | 'denied';
+
+// story #2955 §4 — 대비 주의(실측 대비표): 소형 텍스트에 계열색을 직접 못 씀(라이트 AA
+// 미달 위험) — 칩은 배경(soft)+상태 라벨어 병기, dot만 순색.
+export const DOC_STATUS_TONE: Record<DocStatusFilter, { bg: string; dot: string; text: string }> = {
+  confirmed: { bg: 'bg-success-tint', dot: 'bg-success', text: 'text-foreground' },
+  pending: { bg: 'bg-warning-tint', dot: 'bg-warning', text: 'text-foreground' },
+  denied: { bg: 'bg-destructive/10', dot: 'bg-destructive', text: 'text-foreground' },
+  draft: { bg: 'bg-muted', dot: 'bg-muted-foreground', text: 'text-muted-foreground' },
+};
+
+export function toDocStatusFilter(status: string | undefined): DocStatusFilter {
+  return status === 'pending' || status === 'confirmed' || status === 'denied' ? status : 'draft';
+}
+
+export function docStatusLabelKey(status: DocStatusFilter): string {
+  switch (status) {
+    case 'confirmed': return 'docGateConfirmed';
+    case 'pending': return 'docGatePending';
+    case 'denied': return 'docGateDenied';
+    case 'draft': return 'indexStatusDraft';
+  }
+}

--- a/apps/web/src/components/docs/recents-section.tsx
+++ b/apps/web/src/components/docs/recents-section.tsx
@@ -3,12 +3,21 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronRight, Clock, FileText } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { DOC_STATUS_TONE, toDocStatusFilter } from './lib/doc-status-tone';
 
 interface Doc {
   id: string;
   title: string;
   slug: string;
   icon?: string | null;
+  // story #2963 §3 — 레일 v2 proof 상태 도트 소스.
+  status?: string;
+}
+
+// story #2963 §3 — proof 상태 도트(6px). 색은 도트에만(§4 대비 규율).
+function StatusDot({ status }: { status: string | undefined }) {
+  const tone = DOC_STATUS_TONE[toDocStatusFilter(status)];
+  return <span className={cn('size-1.5 shrink-0 rounded-full', tone.dot)} aria-hidden="true" />;
 }
 
 interface RecentsSectionProps {
@@ -33,13 +42,14 @@ export function RecentsSection({ recentSlugs, docs, selectedSlug, onSelect, labe
         type="button"
         onClick={() => setCollapsed((v) => !v)}
         aria-expanded={!collapsed}
-        className="flex w-full items-center gap-1.5 px-3 py-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+        className="flex w-full items-center gap-1.5 px-3 py-1.5 text-muted-foreground hover:text-foreground"
       >
         {collapsed ? <ChevronRight className="size-3 shrink-0" /> : <ChevronDown className="size-3 shrink-0" />}
         <Clock className="size-3 shrink-0" />
-        <span className="flex-1 text-left">{label}</span>
+        {/* story #2963 §2 — meta-caps 라벨(레일 마스트헤드·그룹 라벨과 동형 mono uppercase). */}
+        <span className="flex-1 text-left font-mono text-[9.5px] font-semibold uppercase tracking-[0.1em]">{label}</span>
         {recentDocs.length > 0 && (
-          <span className="text-[10px] tabular-nums">{recentDocs.length}</span>
+          <span className="font-mono text-[9.5px] tabular-nums">{recentDocs.length}</span>
         )}
       </button>
       {!collapsed && (
@@ -54,12 +64,13 @@ export function RecentsSection({ recentSlugs, docs, selectedSlug, onSelect, labe
                     type="button"
                     onClick={() => onSelect(doc.slug)}
                     className={cn(
-                      'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-xs transition-colors',
+                      'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-[12px] font-semibold transition-colors',
                       selectedSlug === doc.slug
                         ? 'bg-primary/10 text-primary'
                         : 'text-foreground/80 hover:bg-muted hover:text-foreground'
                     )}
                   >
+                    <StatusDot status={doc.status} />
                     {doc.icon ? (
                       <span className="shrink-0 text-sm leading-none">{doc.icon}</span>
                     ) : (

--- a/apps/web/src/components/docs/recents-section.tsx
+++ b/apps/web/src/components/docs/recents-section.tsx
@@ -46,8 +46,9 @@ export function RecentsSection({ recentSlugs, docs, selectedSlug, onSelect, labe
       >
         {collapsed ? <ChevronRight className="size-3 shrink-0" /> : <ChevronDown className="size-3 shrink-0" />}
         <Clock className="size-3 shrink-0" />
-        {/* story #2963 §2 — meta-caps 라벨(레일 마스트헤드·그룹 라벨과 동형 mono uppercase). */}
-        <span className="flex-1 text-left font-mono text-[9.5px] font-semibold uppercase tracking-[0.1em]">{label}</span>
+        {/* rebase 발견(2026-08-23, #2973/#3391 rebase 중) — label(t('recentDocs'))이 한글이라
+            mono uppercase가 2967과 동일 결함(흐림)을 낸다 — sans로. */}
+        <span className="flex-1 text-left text-[9.5px] font-semibold">{label}</span>
         {recentDocs.length > 0 && (
           <span className="font-mono text-[9.5px] tabular-nums">{recentDocs.length}</span>
         )}

--- a/apps/web/src/components/docs/tree-search-input.tsx
+++ b/apps/web/src/components/docs/tree-search-input.tsx
@@ -29,8 +29,10 @@ export function TreeSearchInput({
   const inputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <div className="flex-shrink-0 px-2 pb-1 pt-2">
-      <div className="flex items-center gap-1.5 rounded-xl bg-muted/60 px-2.5 py-1.5 ring-1 ring-transparent focus-within:ring-primary/30">
+    <div className="flex-shrink-0 px-3 pb-2 pt-1">
+      {/* story #2963 §2 — 에디토리얼 검색 필드(hairline border·proof-bg). debounce·API·핸들러
+          무변경, 형태만(shadcn rounded-xl+muted bg → hairline+proof-bg). */}
+      <div className="flex items-center gap-1.5 border border-border bg-muted/40 px-2.5 py-1.5 ring-1 ring-transparent focus-within:ring-primary/30">
         <Search className="size-3.5 shrink-0 text-muted-foreground" />
         <input
           ref={inputRef}


### PR DESCRIPTION
## 요약
스펙 SSOT: doc `docs-nav-rail-v2-editorial-handoff` §0~§6, 시안 artifact `47ed0022`. 대상 = `docs-client-layout.tsx`의 236px 공유 네비 레일만(인덱스/리더는 #2955에서 이미 착지).

**최상위 제약: 기존 6 능력(전문검색·태그 필터·정렬 3모드·드래그 재정렬·뷰모드·문서/폴더 생성) 무손실** — state·API·상태머신·핸들러 전부 무변경, 형태만 에디토리얼 승격.

## §2 형태 승격 매핑
| 능력 | 처방 | 계약 |
|---|---|---|
| 마스트헤드(신규) | kicker+H1+citron rule | 순수 삽입, 핸들러 0접촉 |
| 검색 | hairline border+proof-bg | debounce 250ms·API 무변경 |
| 뷰모드 탭 | `border-proof-citron`(I3 정본, docs-index.tsx 재사용) | setViewMode·localStorage 무변경 |
| 정렬 | native `<select>` → 인라인 mono 토글 3버튼 | setSortMode 무변경 |
| 태그 필터 | `.proof-cut-xs` 칩(선택=blue-soft·비선택=sunk) | selectedTags 무변경 |
| 그룹/최근 라벨 | meta-caps mono uppercase | — |

**AC4(#2420 캐논) 준수** — 시안 원안은 선택 태그 칩 텍스트를 `text-proof-blue`로 그렸으나, tint 배경 위 계열색 텍스트 금지 규율이 이겨 `text-foreground`로 교정(커밋에 근거).

## §3 신규(유일) — proof 상태 도트
6px 도트를 `DocTree`·`DocAutoGroups`·`RecentsSection` 3개 렌더 지점에 추가. 색 소스 = `docs-index.tsx`의 `StatusChip`과 **100% 동일**(신규 `lib/doc-status-tone.ts`로 공유 추출 — 값 무변경, `docs-index.tsx`는 이 모듈을 import하도록 리팩터됐을 뿐 자기 동작 무변경, 기존 9 tests 그대로 green). 색은 도트에만 — 라벨 텍스트는 무변경(§4 대비 규율).

## done 게이트(§5) — 6 능력 회귀 테스트 신설
`docs-client-layout.tsx`에 기존 테스트가 0건이었다 — 이 스토리의 done 게이트("6 능력 회귀 테스트 0")를 충족하려면 그 증거가 있어야 해서 새로 작성(9 tests): 전문검색·태그필터·정렬3모드·드래그재정렬(DocTree 마운트 확認 — pure-function 3사유 중 circular/no-permission은 `doc-tree.test.ts`가 커버하나 sort-mode-active는 그 파일에도 커버리지 없음, 카디르 QA 지적으로 정정: pre-existing gap·2026-07-27 #2167부터·이 PR diff 밖·비차단)·뷰모드·문서/폴더 생성 — 전부 v2 형태에서도 동작 확認.

## 검증
- [x] `pnpm exec tsc --noEmit` — EXIT 0
- [x] `pnpm lint` — 경고 5개(baseline 그대로, 신규 0)
- [x] `pnpm vitest run` — 485 files / 4158 tests green(신규 9 + 기존 전건 그대로)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0
- [x] `verify-tint-foreground-contrast` / `verify-no-new-tint-color-text` / `verify-no-i18n-phrase-collision` — 신규 위반 0
- [ ] 모바일/데스크톱 스크린샷 — dev 배포 후 카디르군 QA 단계에서 동봉 예정

🤖 Generated with Claude Code


---

## 추가 수정(2026-08-23, 카디르 QA MEDIUM 2건 대응)
- 정렬 select→3버튼 교체로 소실됐던 접근성 시맨틱 복원 — `role="group"`+`aria-label`+각 버튼 `aria-pressed`.
- 236px 레일에서 영문 정렬 라벨(Manual order 등)이 넘칠 구조 — 정렬 토글 row `flex-wrap` + `aside` 컨테이너 `overflow-x-hidden` 동반.
- 위 pure-function 커버리지 서술 정정(원 서술 과장 — sort-mode-active gap은 pre-existing, 비차단).
- 신규 회귀테스트 2건(aria-pressed 토글 확認·flex-wrap 확認).
