### PR TITLE
[SID:2967] docs 리더 가독성·사용성 긴급 수리

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx
@@ -353,6 +353,17 @@ export default function DocSlugPage() {
       >
         {mdCopied ? <Check className="h-4 w-4 text-success" /> : <Copy className="h-4 w-4" />}
       </button>
+      {/* story #2967(선생님 실사용 판정 ⑤) — 인덱스 클릭 목적지를 리더→에디터로 되돌리며
+          리더 진입점이 사라지면 안 되니 opt-in 명시 링크를 "..." 드롭다운에서 상단 아이콘
+          버튼으로 승격(발견성). 목적지·라벨(t('preview'))은 기존 그대로 — 위치만 이동. */}
+      <Link
+        href={`${docUrl(wsSlug, projSlug, slug)}/view`}
+        title={t('preview')}
+        aria-label={t('preview')}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+      >
+        <Eye className="h-4 w-4" />
+      </Link>
       <button
         type="button"
         onClick={() => setShareDialogOpen(true)}
@@ -367,10 +378,6 @@ export default function DocSlugPage() {
           <MoreHorizontal className="h-4 w-4" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
-          <DropdownMenuItem render={<Link href={`${docUrl(wsSlug, projSlug, slug)}/view`} />}>
-            <Eye className="mr-2 h-4 w-4" />
-            {t('preview')}
-          </DropdownMenuItem>
           {selectedDoc.doc_type !== 'sprint_report' && (
             <>
               <DropdownMenuItem onClick={() => setUrlDialogOpen(true)}>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/view/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/view/page.tsx
@@ -102,8 +102,11 @@ export default function DocViewPage() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {/* breadcrumb 상단 바(§3) — 옛 인라인 타이틀+TOC+편집 바를 대체. */}
-      <div className="flex shrink-0 items-center gap-2 border-b border-border bg-muted/20 px-4 py-2.5 font-mono text-[11.5px] text-muted-foreground lg:px-8">
+      {/* breadcrumb 상단 바(§3) — 옛 인라인 타이틀+TOC+편집 바를 대체.
+          story #2967(선생님 실사용 판정) — font-mono가 한글에서 가늘고 흐리다(에디토리얼
+          mono 문법은 라틴 고정폭 전제라 한글엔 안 맞음). meta-caps는 라틴 전용으로 한정하고
+          한글 경로는 sans 본문체로 — 위계는 크기/weight/citron rule로만 낸다. */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-border bg-muted/20 px-4 py-2.5 text-[12px] text-muted-foreground lg:px-8">
         <Link href={docsListUrl(wsSlug, projSlug)} className="hover:text-foreground hover:underline">{t('breadcrumbKnowledgeRoot')}</Link>
         {categoryLabel ? (<><span className="text-muted-foreground">/</span><span>{categoryLabel}</span></>) : null}
         <span className="text-muted-foreground">/</span>
@@ -123,11 +126,14 @@ export default function DocViewPage() {
         <div className="grid grid-cols-1 gap-8 px-4 py-8 lg:grid-cols-[minmax(0,1fr)_316px] lg:px-8">
           {/* 리딩 컬럼(§3) — 68ch 정본(§8 확定), 본문 렌더는 무변경(DocContentRenderer). */}
           <article className="mx-auto w-full max-w-[68ch]">
-            <div className="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-proof-blue">
+            {/* story #2967 — kicker/byline은 한글 콘텐츠(카테고리명·작성자명)라 mono+uppercase+
+                wide tracking을 걷는다(«처방도 언어 축을 탄다» — 라틴 전용 문법을 한글에
+                강제하지 않는다). 위계는 색(citron 라인 계열 blue)+굵기로만 유지. */}
+            <div className="text-[13px] font-semibold text-proof-blue">
               {categoryLabel ?? t('indexCategoryUncategorized')}
             </div>
             <h1 className="mt-2 font-editorial-heading text-[38px] leading-[1.1] tracking-[-0.03em] text-foreground">{doc.title}</h1>
-            <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[12.5px] text-muted-foreground">
+            <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] text-muted-foreground">
               {doc.assignee ? (<><span>{doc.assignee.name}</span><span className="text-border">|</span></>) : null}
               <span>{doc.updated_at ? new Date(doc.updated_at).toLocaleDateString() : ''}</span>
               <span className="text-border">|</span>
@@ -147,6 +153,8 @@ export default function DocViewPage() {
                 codeCopyLabel={t('codeCopy')}
                 codeCopiedLabel={t('codeCopied')}
                 assetImageErrorLabel={t('attachImageUnavailable')}
+                suppressLeadingTitle={doc.title}
+                bodyEmphasis="full"
               />
             </div>
             {/* 두 번째 backlinks 자리(첫 자리: story-detail-panel, story #2299) — 컴포넌트

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.test.tsx
@@ -121,12 +121,15 @@ describe('DocsIndex — 문서 있음(§2 마스트헤드+목록)', () => {
     expect(container.textContent).toContain('반려된 문서');
   });
 
-  it('항목을 클릭하면 에디터(docUrl)가 아니라 리더(docViewUrl)로 이동한다', async () => {
+  // story #2967(선생님 실사용 판정 ⑤) — 원래는 리더(docViewUrl)로 갔으나, 트리 사이드바
+  // (에디터 직행)와 목적지가 갈려 편집까지 2스텝이 되는 문제가 실사용에서 적발됐다. 인덱스도
+  // 에디터 직행으로 되돌려 트리와 동선을 통일한다(리더는 에디터의 opt-in "미리보기" 링크로만).
+  it('항목을 클릭하면 트리 사이드바와 동일하게 에디터(docUrl)로 직행한다', async () => {
     useDocsLayoutMock.mockReturnValue({ ...BASE_CTX, tree });
     await mount();
     const item = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('결제 스펙 v2'));
     await act(async () => { item!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
-    expect(pushMock).toHaveBeenCalledWith('/ws1/proj1/docs/payments-v2/view');
+    expect(pushMock).toHaveBeenCalledWith('/ws1/proj1/docs/payments-v2');
   });
 
   it('격자 보기로 전환해도 문서 항목이 그대로 보인다(뷰 전환만, 데이터 손실 없음)', async () => {

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
@@ -7,7 +7,7 @@ import { BookOpen, LayoutGrid, List as ListIcon, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { useDocsLayout, type Doc } from './docs-context';
-import { docViewUrl } from '@/components/docs/lib/doc-project-url';
+import { docUrl } from '@/components/docs/lib/doc-project-url';
 
 /**
  * story #2955 §2/§6(doc docs-index-reader-redesign-handoff) — 셸 A "지식 인덱스". 미선택
@@ -108,7 +108,11 @@ export function DocsIndex() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items, categoryFilter, statusFilter]);
 
-  const goToDoc = (slug: string) => router.push(docViewUrl(wsSlug, projSlug, slug));
+  // story #2967(선생님 실사용 판정) — 인덱스 클릭이 리더(docViewUrl)로 가면 트리 사이드바
+  // (에디터 직행)와 목적지가 갈려 편집까지 2스텝(인덱스→리더→편집)이 됐다. 트리와 동선을
+  // 통일해 에디터 직행 1스텝으로 되돌린다 — 리더는 에디터 상단의 opt-in "읽기 보기" 링크로만
+  // 진입(삭제 아님, default만 이동).
+  const goToDoc = (slug: string) => router.push(docUrl(wsSlug, projSlug, slug));
 
   // story #2955 §6(PO 요건②) — "문서를 선택하세요" 재현 금지. 0건은 에러가 아니라 만들
   // 데이터로서 설계 — 첫 문서 CTA + 왜 0인지 맥락(신규 프로젝트) 병기.

--- a/apps/web/src/components/docs/doc-content-renderer.test.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.test.tsx
@@ -135,4 +135,52 @@ describe('DocContentRenderer', () => {
     expect(markup).toContain('내부참조');
     expect(markup).not.toContain('<button type="button"');
   });
+
+  // story #2967(선생님 실사용 판정 ①) — 마스트헤드 H1(doc.title)과 본문 첫 # 제목이 중복
+  // 렌더되던 것을 정규화 비교로 생략한다. 리더 전용 opt-in prop이라 미지정 시 회귀 0.
+  describe('suppressLeadingTitle(story #2967 §1 — 리더 2중 제목 생략)', () => {
+    it('본문 첫 h1이 doc.title과 정규화 동일하면 생략한다(공백·대소문자·# 무시)', () => {
+      const markup = renderToStaticMarkup(
+        <DocContentRenderer content={'#   결제 스펙 V2   \n\n본문 내용'} contentFormat="markdown" suppressLeadingTitle="결제 스펙 v2" />,
+      );
+      expect(markup).not.toContain('<h1');
+      expect(markup).toContain('<p>본문 내용</p>');
+    });
+
+    it('본문 첫 h1이 doc.title과 다르면 그대로 렌더한다(허구 생략 금지)', () => {
+      const markup = renderToStaticMarkup(
+        <DocContentRenderer content={'# 다른 제목\n\n본문'} contentFormat="markdown" suppressLeadingTitle="결제 스펙 v2" />,
+      );
+      expect(markup).toContain('<h1 id="다른-제목">다른 제목</h1>');
+    });
+
+    it('두 번째 이후 h1(문서 중간)은 doc.title과 같아도 생략하지 않는다(첫 heading만 대상)', () => {
+      const markup = renderToStaticMarkup(
+        <DocContentRenderer content={'# 서론\n\n본문\n\n# 결제 스펙 v2\n\n두 번째 섹션'} contentFormat="markdown" suppressLeadingTitle="결제 스펙 v2" />,
+      );
+      expect(markup).toContain('<h1 id="서론">서론</h1>');
+      expect(markup).toContain('결제 스펙 v2</h1>');
+    });
+
+    it('prop을 안 주면(에디터 프리뷰 등 기존 소비처) 첫 h1도 그대로 렌더한다(회귀 0)', () => {
+      const markup = renderToStaticMarkup(
+        <DocContentRenderer content={'# 결제 스펙 v2\n\n본문'} contentFormat="markdown" />,
+      );
+      expect(markup).toContain('결제 스펙 v2</h1>');
+    });
+  });
+
+  // story #2967(선생님 실사용 판정 ③) — 다크 본문 체감 눌림 교정(WCAG는 이미 통과·체감 문제).
+  describe('bodyEmphasis(story #2967 §3 — 다크 본문 체감 눌림)', () => {
+    it('기본값은 기존 text-foreground/92 그대로(회귀 0)', () => {
+      const markup = renderToStaticMarkup(<DocContentRenderer content="본문" contentFormat="markdown" />);
+      expect(markup).toContain('text-foreground/92');
+    });
+
+    it("bodyEmphasis='full'이면 /92 없는 순수 text-foreground를 쓴다(리더 전용 옵트인)", () => {
+      const markup = renderToStaticMarkup(<DocContentRenderer content="본문" contentFormat="markdown" bodyEmphasis="full" />);
+      expect(markup).not.toContain('text-foreground/92');
+      expect(markup).toContain('text-foreground');
+    });
+  });
 });

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -36,6 +36,19 @@ interface DocContentRendererProps {
   publicImageLabel?: string;
   /** authed-mode label shown when an asset-ref image fails to resolve via the signed route. */
   assetImageErrorLabel?: string;
+  /** story #2967(선생님 실사용 판정) — 리더가 마스트헤드 H1(doc.title)을 그리는데 본문 첫
+   * 줄이 같은 제목을 `#`로 다시 쓴 문서가 대부분이라 2중 렌더로 보였다. 이 값(=doc.title)이
+   * 본문 첫 heading과 정규화 비교(대소문자·공백·선행 # 무시) 동일하면 그 heading만 생략한다
+   * — 리더 전용 opt-in(prop 생략 시 기존 동작 100% 유지, 에디터 프리뷰 등 다른 소비처 무접촉). */
+  suppressLeadingTitle?: string;
+  /** story #2967 — 다크에서 본문 문단이 text-foreground/92라 WCAG는 통과(14.88)하지만 체감
+   * 눌림(full=17.66과 대비). 리더만 'full'로 옵트인 — 기본(미지정)은 기존 /92 그대로라
+   * 공유 렌더러의 다른 소비처(에디터 프리뷰 등) 무접촉. */
+  bodyEmphasis?: 'default' | 'full';
+}
+
+function normalizeHeadingForTitleCompare(s: string): string {
+  return s.trim().replace(/^#+\s*/, '').replace(/\s+/g, ' ').toLowerCase();
 }
 
 // 마크다운 경로 sanitize 스키마 — rehype-sanitize 기본 스키마는 img/div 의 data-* 를 제거하므로
@@ -176,6 +189,8 @@ export function DocContentRenderer({
   publicAttachmentLabel = 'Attachment unavailable in public view',
   publicImageLabel = 'Image unavailable in public view',
   assetImageErrorLabel = 'This image could not be loaded',
+  suppressLeadingTitle,
+  bodyEmphasis = 'default',
 }: DocContentRendererProps) {
   const internalRef = useRef<HTMLDivElement | null>(null);
   const headings = useMemo(() => extractDocHeadings(content, contentFormat), [content, contentFormat]);
@@ -600,7 +615,9 @@ export function DocContentRenderer({
     '[&_h1]:scroll-mt-24 [&_h1]:text-3xl [&_h1]:font-bold [&_h1]:tracking-tight',
     '[&_h2]:scroll-mt-24 [&_h2]:mt-10 [&_h2]:text-2xl [&_h2]:font-semibold',
     '[&_h3]:scroll-mt-24 [&_h3]:mt-8 [&_h3]:text-xl [&_h3]:font-semibold',
-    '[&_p]:leading-7 [&_p]:text-foreground/92',
+    // story #2967 — 다크 체감 눌림(/92=14.88 vs full=17.66, 둘 다 WCAG 통과지만 체감 차).
+    // 리더만 bodyEmphasis='full' 옵트인 — 기본은 기존 /92 그대로(다른 소비처 무접촉).
+    bodyEmphasis === 'full' ? '[&_p]:leading-7 [&_p]:text-foreground' : '[&_p]:leading-7 [&_p]:text-foreground/92',
     // story #2023 ⓒ(§5-2): 유틸 부재로 인한 var() 우회 참조를 정식 토큰으로 되돌림 — 문서 본문
     // 링크색, L1~L5 재분류 아님(콘텐츠 하이퍼링크는 서명·시스템상태 어느 축도 아님).
     '[&_a]:text-brand-soft [&_a]:underline [&_a]:underline-offset-4',
@@ -644,7 +661,12 @@ export function DocContentRenderer({
         urlTransform={(url) => (url.startsWith('entity:') ? url : defaultUrlTransform(url))}
         components={{
           h1: ({ children }) => {
-            const heading = headings[headingIndex++];
+            const idx = headingIndex++;
+            const heading = headings[idx];
+            // story #2967 — 첫 heading(idx===0)이 doc.title과 정규화 동일하면 생략(2중 렌더 제거).
+            if (idx === 0 && suppressLeadingTitle && heading && normalizeHeadingForTitleCompare(heading.text) === normalizeHeadingForTitleCompare(suppressLeadingTitle)) {
+              return null;
+            }
             return <h1 id={heading?.id}>{children}</h1>;
           },
           h2: ({ children }) => {

--- a/apps/web/src/components/docs/doc-status-rail.test.tsx
+++ b/apps/web/src/components/docs/doc-status-rail.test.tsx
@@ -205,7 +205,9 @@ describe('gateTransition 데이터 레이어 안전판(§ 우회 금지, UI 은�
 });
 
 describe('DocEvidenceRail — 증거 레일(§3/§6, 접힌 audit 리스트→상시 타임라인)', () => {
-  it('revision+승인 이력이 있으면 타임라인 노드가 렌더된다', async () => {
+  // story #2967(선생님 실사용 판정 ④) — 이력 1~2건은 316px 세로 레일이 텅 비어 보여 판이
+  // 왼쪽으로 쏠렸다. 노드 2개 이하는 세로선·제목 없이 컴팩트 가로 스트립으로 강등한다.
+  it('이력이 2건 이하면 세로 타임라인(제목·세로선) 없이 컴팩트 스트립으로 뜬다', async () => {
     stubFetch({
       gates: [gate({ status: 'approved', resolver_id: 'm1', resolved_at: '2026-08-21T14:32:00Z' })],
       revisions: [{ id: 'r1', created_by: 'm2', created_at: '2026-08-19T00:00:00Z' }],
@@ -214,11 +216,28 @@ describe('DocEvidenceRail — 증거 레일(§3/§6, 접힌 audit 리스트→�
     const { DocEvidenceRail } = await import('./doc-status-rail');
     await act(async () => { root.render(wrap(<DocEvidenceRail docId="doc-1" status="confirmed" />)); });
     await flush();
-    expect(container.textContent).toContain('결재 이력');
+    expect(container.textContent).not.toContain('결재 이력');
+    expect(container.querySelector('ol')).toBeNull();
     expect(container.textContent).toContain('검토 요청');
     expect(container.textContent).toContain('승인');
     expect(container.textContent).toContain('윤도선');
     expect(container.textContent).toContain('송윤재');
+  });
+
+  it('이력이 3건 이상이면 세로 타임라인(제목·세로선 있는 정규 레일)으로 뜬다', async () => {
+    stubFetch({
+      gates: [gate({ status: 'approved', resolver_id: 'm1', resolved_at: '2026-08-21T14:32:00Z' })],
+      revisions: [
+        { id: 'r1', created_by: 'm2', created_at: '2026-08-18T00:00:00Z' },
+        { id: 'r2', created_by: 'm2', created_at: '2026-08-19T00:00:00Z' },
+      ],
+      members: [{ id: 'm1', name: '윤도선' }, { id: 'm2', name: '송윤재' }],
+    });
+    const { DocEvidenceRail } = await import('./doc-status-rail');
+    await act(async () => { root.render(wrap(<DocEvidenceRail docId="doc-1" status="confirmed" />)); });
+    await flush();
+    expect(container.textContent).toContain('결재 이력');
+    expect(container.querySelector('ol')).not.toBeNull();
   });
 
   it('이력이 전혀 없으면(draft, gate/revision 0건) 아무것도 렌더하지 않는다(노이즈 0)', async () => {

--- a/apps/web/src/components/docs/doc-status-rail.tsx
+++ b/apps/web/src/components/docs/doc-status-rail.tsx
@@ -165,8 +165,9 @@ export function DocStatusHeader({ docId, status, editHref, onTransitioned }: { d
       </span>
       <div className="min-w-0 flex-1">
         <div className="text-[15px] font-bold text-foreground">{t(STATE_LABEL_KEY[state])}</div>
+        {/* story #2967 — resolveName은 한글 사람 이름이라 mono 걷음(동일 결함 클래스). */}
         {state === 'confirmed' && gate ? (
-          <div className="font-mono text-xs text-muted-foreground">{resolveName(gate.resolver_id)} · {fmtDate(gate.resolved_at)}</div>
+          <div className="text-xs text-muted-foreground">{resolveName(gate.resolver_id)} · {fmtDate(gate.resolved_at)}</div>
         ) : state === 'denied' ? (
           <div className="mt-1 text-xs text-foreground">
             <span className="font-medium">{t('docGateDeniedReason')}:</span> {gate?.resolution_note?.trim() || t('docGateNoReason')}
@@ -249,9 +250,31 @@ export function DocEvidenceRail({ docId, status }: { docId: string; status: stri
 
   if (auditEvents.length === 0) return null;
 
+  // story #2967(선생님 실사용 판정 ④) — 이력 1~2건일 때 316px 세로 레일(선+노드 여백)이
+  // 텅 빈 공간을 만들어 판이 왼쪽으로 쏠려 보였다. 노드 2개 이하면 세로 타임라인(선·점) 대신
+  // 컴팩트 가로 스트립으로 강등 — ProofCapsule(density="audit") 자체는 그대로 재사용(발명
+  // 0), 세로선 장식만 걷어 짧은 이력이 "미완성"이 아니라 "원래 이 정도"로 읽히게 한다.
+  if (auditEvents.length <= 2) {
+    return (
+      <div className="flex flex-col gap-2">
+        {auditEvents.map((ev) => (
+          <ProofCapsule
+            key={ev.key}
+            density="audit"
+            proofState={ev.proofState}
+            stateLabel={auditKindLabel[ev.kind]}
+            claim={`${auditKindLabel[ev.kind]}${ev.version ? ` (v${ev.version})` : ''}`}
+            now={fmtDate(ev.at)}
+            human={{ name: ev.name, role: '' }}
+          />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div>
-      <div className="font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+      <div className="text-[12px] font-semibold text-muted-foreground">
         {t('docGateAuditTitle')}
       </div>
       {/* 수직 타임라인 — 기존 접힌 리스트(doc-gate-section.tsx)를 상시 레일로 공간화(§3/§6).


### PR DESCRIPTION
## 요약
선생님 실사용 판정(2026-08-23 14:15) + PO 다크 실픽셀 재검 진단 대응. #2955 구조(인덱스·리더·레일)는 섰으나 타이포 실행이 한국어·실데이터에서 안 섰다는 지적.

## ⑤[우선순위1·핵심] 동선 되돌리기 — 인덱스 클릭=에디터 직행
- `docs-index.tsx`의 `goToDoc`: `docViewUrl`→`docUrl`. 트리 사이드바(에디터 직행)와 인덱스(옛 리더행)의 목적지 불일치로 편집까지 2스텝이던 것을 1스텝으로 복원.
- 리더는 삭제 아님 — 에디터 "..." 드롭다운에 묻혀있던 "미리보기" 링크를 Share 버튼 옆 **상단 아이콘 버튼으로 승격**(발견성). 목적지·라벨은 그대로, 위치만 이동.

## ①제목 2중 렌더 제거
`DocContentRenderer`에 `suppressLeadingTitle?: string` prop 신설(리더만 `doc.title` 전달). 본문 첫 h1이 정규화 비교(trim·공백·대소문자·선행 `#` 무시)로 title과 동일하면 그 h1만 생략 — 불일치·2번째 이후 h1은 그대로(허구 생략 금지). prop 미지정 시 기존 동작 100% 유지.

## ②mono 한글 흐림 → meta-caps 라틴 전용
리더 breadcrumb·kicker·byline의 `font-mono`(+uppercase+wide tracking)를 걷어 sans 본문체로 — 영문 고정폭 mono 문법을 한글에 강제하지 않는다. `doc-status-rail.tsx`의 결재 이력 제목·결재자 이름(한글)도 같은 결함 클래스라 동반 교정.

## ③다크 본문 저대비 체감 → 리더 본문 full foreground
`DocContentRenderer`에 `bodyEmphasis?: 'default'|'full'` prop 신설. 기본(미지정)은 기존 `text-foreground/92` 그대로 — 리더만 `'full'` 옵트인으로 `/92` 제거(WCAG는 이미 통과·체감 눌림만 교정).

## ④빈 레일 → 적응
`DocEvidenceRail` — 이력 노드 2개 이하면 세로 타임라인이 텅 빈 공간을 만들어 판이 왼쪽으로 쏠려 보였다. 2개 이하는 세로선·제목 없는 컴팩트 가로 스트립으로 강등(`ProofCapsule density="audit"` 그대로 재사용, 발명 0) — 3개 이상은 기존 세로 레일 유지.

## 검증
- [x] `pnpm exec tsc --noEmit` — EXIT 0
- [x] `pnpm lint` — 경고 5개(baseline 그대로, 신규 0)
- [x] `pnpm vitest run` — 484 files / 4175 tests green(신규 8 + 기존 2건 의도적 갱신: goToDoc 목적지 변경·컴팩트 레일 전환 각각 새 동작에 맞춤)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0
- [x] tint/i18n 가드 — 신규 위반 0
- [ ] **최종 판정 = 배포 후 실사용 육안**(스토리 자체가 명시한 종결 기준 — 가독성/사용성이라 스크린샷보다 실화면 확認이 정본)

🤖 Generated with Claude Code