### PR TITLE
[SID:2949] feat: 트러스트 뷰 자체 인라인 스토리 컴포저 — 축 전환 브리지 제거

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -2,8 +2,11 @@
 //
 // story bb78f14b(doc resource-view-firsttouch-identity-pattern §4 "보드" 행 — ⚠️과함 주의): 진짜
 // 빈 보드(stories.length===0, unfiltered)에 절제된 3요소 배너(아이콘+headline+CTA)가 컬럼 그리드
-// "위"에 뜨는지(대체 아님 — 백로그 컬럼이 계속 마운트돼 있어야 CTA의 autoComposeSignal이
+// "위"에 뜨는지(대체 아님 — settable 첫 컬럼이 계속 마운트돼 있어야 CTA의 autoComposeSignal이
 // 실제로 컴포저를 연다), 데이터 있으면 배너가 안 뜨는지 왕복 검증한다.
+//
+// story #2949 — 기본축이 trust인 이상 CTA는 이제 축 전환 없이 트러스트 뷰의 queued 컬럼(현재
+// 보이는 축의 settable 첫 컬럼)에서 바로 컴포저를 연다(#3378의 임시 클래식 전환 브리지 제거).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
@@ -163,7 +166,7 @@ describe('KanbanBoard — 보드 first-touch 절제된 배너', () => {
     expect(html).toContain('스토리가 없습니다');
   });
 
-  it('배너 CTA 클릭 시 백로그 컬럼의 인라인 컴포저(제목 입력 필드)가 열린다', async () => {
+  it('배너 CTA 클릭 시 트러스트 뷰 queued 컬럼의 인라인 컴포저(제목 입력 필드)가 열린다 — 축 전환 없음', async () => {
     stubFetch([]);
     await mount();
     const ctaButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('첫 스토리 만들기'));
@@ -171,14 +174,42 @@ describe('KanbanBoard — 보드 first-touch 절제된 배너', () => {
     await act(async () => { ctaButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     // 컴포저가 열리면 입력 필드(placeholder 또는 textbox role)가 나타난다.
     expect(container.querySelector('input, textarea')).not.toBeNull();
+    // ⭐핵심(story #2949) — 축 전환 브리지가 사라졌으니 트러스트 축 라벨(예: "입력 필요")이
+    // 여전히 보여야 한다(클래식 5-status로 튕기지 않음).
+    expect(container.textContent).toContain('입력 필요');
   });
 
-  // ⚠️QA changes(PR#3378, 카디르+codex, 2026-08-22, HIGH) — CTA 브리지가 handleSetAxisMode를
-  // 쓰면 saveAxisMode까지 타 localStorage에 'status'가 영구 저장돼, CTA를 한 번만 눌러도
-  // 그 프로젝트가 조용히 classic으로 고정된다(재마운트해도 trust로 안 돌아옴 — 기본값
-  // 플립의 취지 자체가 무효화). setAxisMode만 쓰는 세션 한정 전환으로 좁혀 이 저장이
-  // 없는지 직접 증명한다.
-  it('배너 CTA 클릭은 축 전환을 localStorage에 저장하지 않는다 — 재마운트하면 다시 신뢰축 기본값', async () => {
+  it('컴포저에서 제출하면 H4 매핑(queued→ready-for-dev)대로 status가 실린 POST가 나간다', async () => {
+    const posted: Array<Record<string, unknown>> = [];
+    stubFetch([]);
+    const baseFetch = vi.mocked(fetch);
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url === '/api/stories' && init?.method === 'POST') {
+        const body = JSON.parse(init.body as string) as Record<string, unknown>;
+        posted.push(body);
+        return { ok: true, json: async () => ({ data: { id: 'new-1', ...body } }) };
+      }
+      return baseFetch(url, init);
+    }));
+    await mount();
+    const ctaButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('첫 스토리 만들기'));
+    await act(async () => { ctaButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const input = container.querySelector('input') as HTMLInputElement;
+    expect(input).not.toBeNull();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(input, '새 스토리');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const submitButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('추가'));
+    expect(submitButton).not.toBeUndefined();
+    await act(async () => { submitButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(posted).toHaveLength(1);
+    expect(posted[0]?.['status']).toBe('ready-for-dev'); // TRUST_COLUMN_TO_STATUS.queued
+    expect(posted[0]?.['title']).toBe('새 스토리');
+  });
+
+  it('배너 CTA 클릭은 축 전환을 localStorage에 저장하지 않는다(회귀 0 — 애초에 전환 자체가 없음)', async () => {
     stubFetch([]);
     await mount();
     const ctaButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('첫 스토리 만들기'));

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1066,6 +1066,15 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
     }
   }, [projectId, selectedSprintId, selectedEpicId, t, adjustColumnTotal, bumpTransitionErrorNonce]);
 
+  // story #2949 — 트러스트 뷰의 인라인 컴포저는 TrustColumnId(예: 'queued')를 넘긴다.
+  // handleCreateStory는 그 값을 그대로 story.status로 POST하므로(classic 뷰는 컬럼id=status라
+  // 문제 없음), TRUST_COLUMN_TO_STATUS(H4 확定 매핑, 드롭과 동일 규칙)로 실 status를 먼저
+  // 해소한 뒤 위임한다 — 생성 로직 자체는 발명 0(같은 handleCreateStory 재사용).
+  const handleCreateStoryTrust = useCallback((columnId: string, title: string) => {
+    const status = TRUST_COLUMN_TO_STATUS[columnId as TrustColumnId] ?? columnId;
+    return handleCreateStory(status, title);
+  }, [handleCreateStory]);
+
   // AC1/AC5: WIP limit 핸들러
   const handleWipLimitEdit = useCallback((columnId: string) => {
     setWipLimits((prev) => ({
@@ -1517,28 +1526,23 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           // 1문장) — 보드 자체가 이미 레인 시각이라 별도 visual/AI hint는 중복·클러터.
           // stories(unfiltered 원본)로 진짜 빈 프로젝트만 판정 — 필터/검색 결과 0건은 여기 안 타고
           // 기존 per-column "스토리가 없습니다" 그대로(에픽 PR#2209에서 배운 필터빈 vs 진짜빈 구분).
-          // ⚠️컬럼 그리드를 대체하지 않고 그 위 배너로만 — CTA가 여는 백로그 인라인 컴포저
-          // (autoComposeSignal)가 KanbanColumn 내부 상태라, 컬럼 자체가 마운트돼 있어야
-          // CTA 클릭이 실제로 컴포저를 연다(대체했다면 신호를 받을 컬럼이 없어 무반응했을 것).
+          // ⚠️컬럼 그리드를 대체하지 않고 그 위 배너로만 — CTA가 여는 인라인 컴포저
+          // (autoComposeSignal)가 컬럼 내부 상태라, 컬럼 자체가 마운트돼 있어야 CTA 클릭이
+          // 실제로 컴포저를 연다(대체했다면 신호를 받을 컬럼이 없어 무반응했을 것).
           //
-          // PO 긴급 fix(P0-04 기본축 trust 플립, 2026-08-22) — 인라인 컴포저는 KanbanColumn
-          // (5-status 클래식) 전용이라 KanbanTrustColumn엔 아직 없다(별도 스토리 필요 규모라
-          // 이 소PR 스코프 밖). 기본축이 trust로 바뀌면서 이 CTA가 신호를 받을 컬럼 자체가
-          // 없어 무반응해지는 걸 막기 위해, 클릭 시 클래식 축으로 먼저 전환한다(무한 회귀
-          // onboarding 실종보다 «클래식으로 넘어가서 만든다»가 정직한 임시 처방).
-          //
-          // ⚠️QA changes(PR#3378, 카디르+codex, 2026-08-22, HIGH) — handleSetAxisMode를 쓰면
-          // saveAxisMode까지 타 localStorage에 'status'가 **영구 저장**된다(CTA 클릭이 명시적
-          // 사용자 선택이 아닌데도 명시 선택처럼 기록돼, 이 프로젝트가 재마운트해도 다시는
-          // trust로 안 돌아간다 — 플립의 취지 자체를 무효화). 저장 없는 setAxisMode만 써서
-          // 이번 세션 한정 임시 전환으로 좁힌다.
+          // story #2949(본편, PR#3378의 축 전환 브리지 대체) — 인라인 컴포저가 이제
+          // KanbanTrustColumn(settable 4컬럼)에도 있어, 축 전환 없이 **현재 보이는 축의
+          // settable 첫 컬럼**(trust=queued/status=backlog)이 바로 컴포저를 연다. #3378의
+          // 임시 브리지(클릭 시 클래식으로 강제 전환)는 신호를 받을 컬럼이 없을 때만 필요했던
+          // 처방이라 여기서 제거 — 축 전환 자체가 없으니 유나 #3378 design 판정이 지적한
+          // "전환 시각 큐 부재"도 함께 소멸(전환이 안 일어나므로 큐가 지킬 대상이 없음).
           <div className="shrink-0 border-b border-border/60 px-6 py-4">
             <EmptyState
               icon={<Workflow className="size-8" />}
               title={t('boardEmptyTitle')}
               description={t('boardEmptyDescription')}
               action={
-                <Button size="sm" onClick={() => { setAxisMode('status'); setAutoComposeNonce((n) => n + 1); }}>
+                <Button size="sm" onClick={() => setAutoComposeNonce((n) => n + 1)}>
                   <Plus className="size-3.5" />
                   {t('boardEmptyCta')}
                 </Button>
@@ -1593,6 +1597,8 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                     storyGatesMap={storyGatesMap}
                     storyLineMap={storyLineMap}
                     isDragging={activeId != null}
+                    onCreateStory={handleCreateStoryTrust}
+                    autoComposeSignal={col.id === 'queued' ? autoComposeNonce : 0}
                   />
                 );
               })}

--- a/apps/web/src/components/kanban/kanban-trust-column.test.tsx
+++ b/apps/web/src/components/kanban/kanban-trust-column.test.tsx
@@ -92,3 +92,115 @@ describe('KanbanTrustColumn — 파생 컬럼 드래그 중 "닫힘" 시각(stor
     expect(container.textContent).not.toContain('드롭 불가');
   });
 });
+
+// story #2949 — settable 컬럼(locked=false)에 이식된 인라인 컴포저. KanbanColumn과 동형 계약
+// (autoComposeSignal로 open·onCreateStory(id, title)로 제출) — 이 컴포넌트는 TrustColumnId→
+// 실 status 매핑을 모른다(호출자 몫), 그래서 onCreateStory에 그대로 id를 넘기는지만 잰다.
+describe('KanbanTrustColumn — 인라인 컴포저(story #2949)', () => {
+  it('locked=false + onCreateStory 있으면 "+" 버튼이 뜨고, 클릭하면 컴포저가 열린다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <KanbanTrustColumn
+          id="queued" label="대기" locked={false} stories={[]}
+          epicMap={{}} memberMap={{}} onStoryClick={() => {}} onCreateStory={() => {}}
+        />,
+      ));
+    });
+    const addButton = container.querySelector('button[aria-label="스토리 추가"]');
+    expect(addButton).not.toBeNull();
+    expect(container.querySelector('input')).toBeNull(); // 클릭 전엔 닫혀있음.
+    await act(async () => { addButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.querySelector('input')).not.toBeNull();
+  });
+
+  it('locked=true(파생 컬럼)는 onCreateStory가 있어도 "+" 버튼을 안 그린다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <KanbanTrustColumn
+          id="needs_input" label="입력 필요" locked stories={[]}
+          epicMap={{}} memberMap={{}} onStoryClick={() => {}} onCreateStory={() => {}}
+        />,
+      ));
+    });
+    expect(container.querySelector('button[aria-label="스토리 추가"]')).toBeNull();
+  });
+
+  it('autoComposeSignal이 0보다 커지면(부모의 CTA 트리거) "+" 클릭 없이도 컴포저가 열린다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <KanbanTrustColumn
+          id="queued" label="대기" locked={false} stories={[]}
+          epicMap={{}} memberMap={{}} onStoryClick={() => {}} onCreateStory={() => {}}
+          autoComposeSignal={0}
+        />,
+      ));
+    });
+    expect(container.querySelector('input')).toBeNull();
+    await act(async () => {
+      root.render(wrap(
+        <KanbanTrustColumn
+          id="queued" label="대기" locked={false} stories={[]}
+          epicMap={{}} memberMap={{}} onStoryClick={() => {}} onCreateStory={() => {}}
+          autoComposeSignal={1}
+        />,
+      ));
+    });
+    expect(container.querySelector('input')).not.toBeNull();
+  });
+
+  it('제출하면 onCreateStory(id, title)가 TrustColumnId 그대로(매핑 안 함) 호출된다', async () => {
+    const created: Array<[string, string]> = [];
+    await act(async () => {
+      root.render(wrap(
+        <KanbanTrustColumn
+          id="queued" label="대기" locked={false} stories={[]}
+          epicMap={{}} memberMap={{}} onStoryClick={() => {}}
+          onCreateStory={(colId, title) => { created.push([colId, title]); }}
+        />,
+      ));
+    });
+    const addButton = container.querySelector('button[aria-label="스토리 추가"]')!;
+    await act(async () => { addButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const input = container.querySelector('input') as HTMLInputElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(input, '새 스토리');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+    });
+    expect(created).toEqual([['queued', '새 스토리']]); // ⭐매핑은 호출자 몫 — 여기선 id 그대로.
+  });
+
+  it('Escape를 누르면 컴포저가 닫힌다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <KanbanTrustColumn
+          id="queued" label="대기" locked={false} stories={[]}
+          epicMap={{}} memberMap={{}} onStoryClick={() => {}} onCreateStory={() => {}}
+        />,
+      ));
+    });
+    const addButton = container.querySelector('button[aria-label="스토리 추가"]')!;
+    await act(async () => { addButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.querySelector('input')).not.toBeNull();
+    const input = container.querySelector('input') as HTMLInputElement;
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    });
+    expect(container.querySelector('input')).toBeNull();
+  });
+
+  it('onCreateStory가 없으면(호출자가 이 컬럼에서 생성을 안 허용) "+" 버튼 자체가 없다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <KanbanTrustColumn
+          id="queued" label="대기" locked={false} stories={[]}
+          epicMap={{}} memberMap={{}} onStoryClick={() => {}}
+        />,
+      ));
+    });
+    expect(container.querySelector('button[aria-label="스토리 추가"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/kanban/kanban-trust-column.tsx
+++ b/apps/web/src/components/kanban/kanban-trust-column.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import type { ComponentType } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useTranslations } from 'next-intl';
-import { Lock } from 'lucide-react';
+import { Lock, Plus } from 'lucide-react';
 import { StoryCard } from './story-card';
 import type { KanbanStory, KanbanMember, LineStatusSummary, TrustColumnId } from './types';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 type SortableContextCompatProps = {
   children?: React.ReactNode;
@@ -51,6 +54,15 @@ interface KanbanTrustColumnProps {
   storyLabelsMap?: Record<string, { id: string; name: string; color: string | null }[]>;
   storyGatesMap?: Record<string, { id: string; gate_type: string; status: string }[]>;
   storyLineMap?: Record<string, LineStatusSummary>;
+  // story #2949 — settable 컬럼(locked=false: queued/running/claimed_done/done) 전용 인라인
+  // 컴포저. KanbanColumn(kanban-column.tsx)의 동일 기능을 그대로 이식(발명 0) — 다만 이 컬럼은
+  // "story status"가 아니라 TrustColumnId를 다루므로, id(TrustColumnId)→실제 status 매핑은
+  // 호출자(kanban-board.tsx, TRUST_COLUMN_TO_STATUS)가 onCreateStory 넘기기 前에 해소한다 —
+  // 이 컴포넌트는 그 매핑을 몰라도 된다(과결합 회피, 이 파일 상단 설계 원칙 그대로).
+  onCreateStory?: (columnId: string, title: string) => Promise<void> | void;
+  // f1910a31과 동형 — nonce가 바뀔 때마다(0→1, 1→2…) 컴포저 재오픈. CTA가 트러스트 뷰에서도
+  // 바로 열리게(축 전환 브리지 제거, story #2949).
+  autoComposeSignal?: number;
   // story #2933 H4(PO 리뷰 질문, PR#3366 2026-08-22) — 드래그가 진행 중인지(어떤 카드든).
   // v4 아티팩트 §B("파생 3개가 «닫힌다»") — 파생 컬럼은 «항상» 무효 타깃이라 5-status의
   // dragStatus별 valid/invalid 판정과 달리 뭘 끌든 똑같이 닫힌다. 정적 상태(잠금배지+힌트
@@ -62,11 +74,13 @@ interface KanbanTrustColumnProps {
 
 /**
  * story #2933 H4(P0-H) — 6단계 신뢰축+완료 7컬럼 중 1개. KanbanColumn(5-status)과 별도
- * 컴포넌트로 새로 만든 이유: WIP limit·done-collapse·backlog 인라인 컴포저 등 KanbanColumn의
- * 부가 기능 대부분이 «status 컬럼» 전용 개념이라(WIP는 status별 한도, 컴포저는 backlog
- * 전용) 트러스트 컬럼엔 안 맞는다 — 억지로 끼워맞추느니 이 뷰가 실제로 필요한 최소(헤더+
- * 카드 목록+잠금 표시)만 담은 별도 컴포넌트가 더 정직하다(과결합 회피, 새 KanbanColumn prop
- * 10여개를 트러스트뷰용으로 옵셔널/무의미하게 늘리지 않음).
+ * 컴포넌트로 새로 만든 이유: WIP limit·done-collapse 등 KanbanColumn의 부가 기능 대부분이
+ * «status 컬럼» 전용 개념이라(WIP는 status별 한도) 트러스트 컬럼엔 안 맞는다 — 억지로
+ * 끼워맞추느니 이 뷰가 실제로 필요한 최소만 담은 별도 컴포넌트가 더 정직하다(과결합 회피).
+ * 단 인라인 컴포저는 예외(story #2949) — 트러스트 축이 기본이 된 이상 "기본 화면에서 바로
+ * 스토리 생성"은 1급 경로라 settable 컬럼(locked=false)에 KanbanColumn과 동형으로 이식했다
+ * (발명 0). id(TrustColumnId)→실제 story status 매핑은 이 컴포넌트가 모른다 — 호출자
+ * (kanban-board.tsx)가 TRUST_COLUMN_TO_STATUS로 해소한 뒤 onCreateStory를 넘긴다.
  *
  * locked=true(파생 컬럼: needs_input/verified/merge_ready) — useDroppable disabled로 이
  * 컬럼 자체가 드롭 타깃이 되지 않는다(kanban-board.tsx resolveTrustColumnId가 이미 한 번
@@ -78,12 +92,42 @@ interface KanbanTrustColumnProps {
 export function KanbanTrustColumn({
   id, label, locked, stories, epicMap, memberMap, onStoryClick, onEditStory, onChangeStatus, onDeleteStory,
   projectId, onKickoffStory, executionMap, blockedByMap, storyLabelsMap, storyGatesMap, storyLineMap,
-  isDragging = false,
+  onCreateStory, autoComposeSignal, isDragging = false,
 }: KanbanTrustColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id, disabled: locked });
   const t = useTranslations('board');
   const dotClass = TRUST_COLUMN_DOT[id];
   const closedDuringDrag = locked && isDragging;
+
+  const [composing, setComposing] = useState(false);
+  const [draftTitle, setDraftTitle] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (autoComposeSignal && autoComposeSignal > 0) setComposing(true);
+  }, [autoComposeSignal]);
+
+  const startCompose = () => {
+    setDraftTitle('');
+    setComposing(true);
+  };
+  const cancelCompose = () => {
+    setComposing(false);
+    setDraftTitle('');
+  };
+  const submitCompose = async () => {
+    const title = draftTitle.trim();
+    if (!title || !onCreateStory || submitting) return;
+    setSubmitting(true);
+    try {
+      await onCreateStory(id, title);
+      setDraftTitle('');
+      setComposing(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
     <div
@@ -98,7 +142,20 @@ export function KanbanTrustColumn({
           {label}
           {locked && <Lock className="size-3 text-muted-foreground" aria-hidden="true" />}
         </h3>
-        <span className="text-xs tabular-nums text-muted-foreground">{stories.length}</span>
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs tabular-nums text-muted-foreground">{stories.length}</span>
+          {!locked && onCreateStory ? (
+            <button
+              type="button"
+              aria-label={t('addStory')}
+              title={t('addStory')}
+              onClick={startCompose}
+              className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition hover:bg-muted hover:text-foreground"
+            >
+              <Plus className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+        </div>
       </div>
       {locked && (
         <p className={`mb-2 text-[10px] leading-snug ${closedDuringDrag ? 'font-semibold text-foreground' : 'text-muted-foreground'}`}>
@@ -106,9 +163,49 @@ export function KanbanTrustColumn({
         </p>
       )}
 
+      {!locked && composing ? (
+        <div className="mb-2 rounded-xl border border-primary/30 bg-background/50 p-2">
+          <Input
+            ref={inputRef}
+            autoFocus
+            value={draftTitle}
+            onChange={(e) => setDraftTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                void submitCompose();
+              } else if (e.key === 'Escape') {
+                cancelCompose();
+              }
+            }}
+            placeholder={t('addStoryPlaceholder')}
+            className="h-8 text-sm"
+          />
+          <div className="mt-2 flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="default"
+              className="h-7 px-2 text-xs"
+              onClick={() => void submitCompose()}
+              disabled={submitting || !draftTitle.trim()}
+            >
+              {t('addStorySubmit')}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 px-2 text-xs text-muted-foreground"
+              onClick={cancelCompose}
+            >
+              {t('addStoryCancel')}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
       <SortableContextCompat items={stories.map((s) => s.id)} strategy={verticalListSortingStrategy} disabled={locked}>
         <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-y-auto p-1.5 [&>*]:shrink-0">
-          {stories.length === 0 ? (
+          {stories.length === 0 && !composing ? (
             <div className="flex min-h-[100px] items-center justify-center px-4 text-center">
               <p className="text-xs text-muted-foreground">{t('noStories')}</p>
             </div>


### PR DESCRIPTION
[SID:2949]

## 요약
기본 축이 trust로 승격(#3378)됐는데 인라인 스토리 컴포저(`autoComposeSignal`)는 `KanbanColumn`(5-status 클래식) 전용이라 트러스트 뷰엔 없었다 — #3378은 빈 보드 CTA 클릭 시 클래식 축으로 강제 전환하는 브리지로 온보딩 경로를 임시 보존했다(정직한 임시 처방, 본편 아님).

이 PR=본편: `KanbanTrustColumn`의 settable 4컬럼(queued/running/claimed_done/done)에 인라인 컴포저를 이식하고, 더 이상 필요 없어진 축 전환 브리지를 제거했다.

## 그라운딩 — kanban-board.tsx의 autoComposeSignal
- `KanbanColumn`(kanban-column.tsx)의 composer 구현(open/submit/cancel state + `autoComposeSignal` effect)을 그대로 이식(발명 0).
- 드롭 컬럼→status 매핑은 H4 확定(`TRUST_COLUMN_TO_STATUS`, types.ts) 그대로 재사용 — queued→ready-for-dev/running→in-progress/claimed_done→in-review/done→done.
- 파생 3컬럼(needs_input/verified/merge_ready)은 `locked=true`라 "+" 버튼과 컴포저 자체가 안 뜬다(게이트가 계산하는 자리, 생성 대상 아님) — `TRUST_COLUMNS`의 기존 `locked` 플래그와 settable 여부가 그대로 일치해 별도 판단 불필요.

## 설계 원칙 — 매핑 책임 분리
`KanbanTrustColumn`은 `TrustColumnId`→실 story status 매핑을 모른다. `onCreateStory(id, title)`에 컬럼 id를 그대로 넘기고, 호출자(`kanban-board.tsx`의 `handleCreateStoryTrust`)가 `TRUST_COLUMN_TO_STATUS`로 해소한 뒤 기존 `handleCreateStory`에 위임한다(과결합 회피 — 이 컴포넌트 자신이 상단 docstring에서 이미 선언한 설계 원칙 그대로 준수).

## 축 전환 브리지 제거
CTA(`boardEmptyCta`)는 이제 `setAutoComposeNonce`만 호출 — 어느 축이 보이고 있든(기본값 trust) 그 축의 settable 첫 컬럼에서 바로 컴포저가 열린다. 유나 #3378 design 판정이 비차단 권고한 "축 전환 시각 큐"(전환 시 사용자가 왜 화면이 바뀌었는지 모름)도 함께 소멸 — 전환 자체가 없으니 지킬 대상이 없다.

## 테스트
- `kanban-trust-column.test.tsx`: 컴포저 신규 6건 — "+" 버튼 노출(locked=false + onCreateStory)/클릭 시 오픈/`autoComposeSignal` 트리거/제출 시 `onCreateStory(id, title)` 호출(id 그대로, 매핑 안 함)/Escape 취소/`onCreateStory` 없으면 버튼 자체 없음.
- `kanban-board.test.tsx`: CTA 관련 기존 2건 갱신(축 전환 브리지 전제가 사라졌으므로 — 열리는 곳이 트러스트 queued임을 명시 확認, "localStorage 미저장" 테스트는 이제 애초에 전환이 없다는 취지로 재작성) + 신규 1건(컴포저 제출 시 H4 매핑대로 `status: 'ready-for-dev'`가 실린 POST가 실제로 나가는지 종단 확認).

## 검증
- 뮤테이션 검증(컴포저 구현 되돌리면 6건 중 4건 정확히 실패 — 나머지 2건은 locked/no-onCreateStory 음성 케이스라 항상 참인 것 확認) 완료.
- 회귀 스윕: kanban 디렉터리 전체(8파일) + `epic-swimlane-board`(주석에 `KanbanTrustColumn` 언급하나 실제 import/사용 없음 확認) = 139건 전부 통과.
- `tsc --noEmit`/`eslint` 클린.
- ⚠️브라우저 실측 미실행(헤드리스 에이전트, 시각 렌더 도구 부재) — 컴포넌트/통합 테스트로 동작 검증. 시각 판정은 design 리뷰 체인(카드 자체 지정)에 위임.