### PR TITLE
[SID:2964] fix: SSE 폴백 훅(chat/notifications) — org 전환 시 재연결 부재 동형 수정

### DIFF
--- a/apps/web/src/hooks/use-chat-sse.test.tsx
+++ b/apps/web/src/hooks/use-chat-sse.test.tsx
@@ -177,3 +177,48 @@ describe('useChatSse — 동시 마운트된 두 인스턴스가 같은 이벤�
     expect(onMessageB).toHaveBeenCalledTimes(1);
   });
 });
+
+// story #2964(sse-multiplexer.ts #2940과 동일 클래스, 폴백 경로 전용) — mux OFF(Provider 밖,
+// 이 파일 전체가 이미 그 조건)일 때만 실제로 발현하던 결함. mux ON(RealtimeProvider 안)이면
+// 이 훅은 애초에 이 effect 자체를 안 타므로(위 mux 분기), 이 회귀가드는 구조적으로 "폴백
+// 경로 전용" 검증이다 — dev가 지금 mux live라 급하진 않되(story 설명 그대로), 같은 클래스
+// 결함을 사전에 닫는다.
+describe('useChatSse — org 전환(memberId 변경) 재연결(story #2964, mux OFF 폴백 경로 전용)', () => {
+  it('currentTeamMemberId가 바뀌면 옛 커넥션을 닫고 새 member_id로 재연결한다', async () => {
+    await act(async () => { root.render(<Harness currentTeamMemberId="member-org-a" />); });
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]!.url).toContain('member_id=member-org-a');
+    expect(FakeEventSource.instances[0]!.closed).toBe(false);
+
+    await act(async () => { root.render(<Harness currentTeamMemberId="member-org-b" />); });
+
+    expect(FakeEventSource.instances[0]!.closed).toBe(true);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(FakeEventSource.instances[1]!.url).toContain('member_id=member-org-b');
+  });
+
+  it('memberId 전환 시 옛 org의 last_event_id를 새 커넥션 URL에 안 싣는다', async () => {
+    await act(async () => { root.render(<Harness currentTeamMemberId="member-org-a" />); });
+    act(() => {
+      FakeEventSource.instances[0]!.emit(
+        'conversation.message_created', { id: 'm1' }, 'org-a-last-event-id',
+      );
+    });
+
+    await act(async () => { root.render(<Harness currentTeamMemberId="member-org-b" />); });
+
+    const url = lastReconnectUrl();
+    expect(url.searchParams.get('member_id')).toBe('member-org-b');
+    expect(url.searchParams.get('last_event_id')).toBeNull(); // ⭐핵심 — 옛 org 커서가 안 샌다.
+  });
+
+  it('memberId가 안 바뀌면(무관한 리렌더) 재연결하지 않는다 — 과잉 재연결 금지', async () => {
+    await act(async () => { root.render(<Harness currentTeamMemberId="member-org-a" />); });
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    await act(async () => { root.render(<Harness currentTeamMemberId="member-org-a" />); });
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]!.closed).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -148,6 +148,9 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
   const onConversationReadRef = useRef(onConversationRead);
   const onReconnectRef = useRef(onReconnect);
   const memberIdRef = useRef(currentTeamMemberId);
+  // story #2964(#2940과 동일 클래스, 폴백 경로 전용) — memberId가 진짜로 바뀐 재실행(마운트·
+  // mux 단독 토글이 아니라)인지 판별용.
+  const prevMemberIdForResetRef = useRef(currentTeamMemberId);
 
   // useLayoutEffect: DOM commit 후 동기 실행 — useEffect(비동기)보다 먼저 실행되어
   // SSE 이벤트 도달 전에 ref가 항상 최신 콜백을 가리킴 (stale closure 방지)
@@ -201,6 +204,16 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
   // 독립 연결 폴백(플래그 OFF 또는 Provider 밖) — story #2078 이전과 완전히 동일한 코드.
   useEffect(() => {
     if (mux || typeof EventSource === 'undefined') return;
+
+    // story #2964(sse-multiplexer.ts #2940과 동일 클래스) — org 전환으로 currentTeamMemberId가
+    // 바뀌어도 이 effect가 재실행되지 않으면(구 deps=[mux, backoff]) 커넥션이 옛 member_id로
+    // 남는다. memberIdRef 쓰기는 effect를 재트리거하지 못한다 — currentTeamMemberId를 deps에
+    // 편입해 값이 실제로 바뀔 때만(문자열 값 비교) 재구독을 강제한다. 동시에 memberId가 진짜
+    // 바뀐 경우에만 옛 org의 lastEventIdRef를 버린다(#3388 카디르 QA와 동일 근거 — 새 org
+    // 커넥션에 옛 org의 last_event_id가 실리면 BE가 org 스코프 없이 그 id의 생성시각만으로
+    // 백필기준을 잡아 조용히 누락된다). mux 단독 토글이나 최초 마운트에선 리셋하지 않는다.
+    if (prevMemberIdForResetRef.current !== currentTeamMemberId) lastEventIdRef.current = null;
+    prevMemberIdForResetRef.current = currentTeamMemberId;
 
     function connect() {
       sourceRef.current?.close();
@@ -271,11 +284,16 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
     connect();
 
     return () => {
-      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+      // #3388 카디르 QA MEDIUM과 동일 근거 — clearTimeout만으론 stale ref가 남아, 재마운트
+      // (memberId 전환) 직후 대기 中이던 백오프 재시도가 stale ref에 걸려 건너뛸 수 있었다.
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
       sourceRef.current?.close();
       sourceRef.current = null;
     };
-  }, [mux, backoff]);
+  }, [mux, backoff, currentTeamMemberId]);
 
   // mux 경로에서는 로컬 connected state를 동기화하지 않고(setState-in-effect 회피) 멀티플렉서
   // 자신의 connected를 그대로 노출한다 — 이미 반응형(context 값 변경 시 이 훅도 리렌더).

--- a/apps/web/src/hooks/use-sse-notifications.test.tsx
+++ b/apps/web/src/hooks/use-sse-notifications.test.tsx
@@ -163,3 +163,44 @@ describe('useSseNotifications — 재개 커서 B계열 오염 방지(#2162)', (
     expect(reconnectUrl.searchParams.get('last_event_id')).toBe('db-event-id-1');
   });
 });
+
+// story #2964(sse-multiplexer.ts #2940과 동일 클래스, 폴백 경로 전용) — 이 파일 전체가 mux
+// OFF(Provider 밖) 조건이라 항상 폴백 분기를 탄다. mux ON이면 이 훅은 이 effect 자체를
+// 안 타므로(위 mux 분기) 이 회귀가드는 구조적으로 "폴백 경로 전용" 검증 — dev는 지금 mux
+// live라 급하진 않되(story 설명 그대로), 같은 클래스 결함을 사전에 닫는다.
+describe('useSseNotifications — org 전환(memberId 변경) 재연결(story #2964, mux OFF 폴백 경로 전용)', () => {
+  it('memberId가 바뀌면 옛 커넥션을 닫고 새 member_id로 재연결한다', async () => {
+    await act(async () => { root.render(<Harness onNotification={vi.fn()} memberId="member-org-a" />); });
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]!.url).toContain('member_id=member-org-a');
+    expect(FakeEventSource.instances[0]!.closed).toBe(false);
+
+    await act(async () => { root.render(<Harness onNotification={vi.fn()} memberId="member-org-b" />); });
+
+    expect(FakeEventSource.instances[0]!.closed).toBe(true);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(FakeEventSource.instances[1]!.url).toContain('member_id=member-org-b');
+  });
+
+  it('memberId 전환 시 옛 org의 last_event_id를 새 커넥션 URL에 안 싣는다', async () => {
+    await act(async () => { root.render(<Harness onNotification={vi.fn()} memberId="member-org-a" />); });
+    const es = FakeEventSource.instances[0]!;
+    act(() => { es.emit('notification', JSON.stringify({}), 'org-a-last-event-id'); });
+
+    await act(async () => { root.render(<Harness onNotification={vi.fn()} memberId="member-org-b" />); });
+
+    const url = new URL(FakeEventSource.instances[FakeEventSource.instances.length - 1]!.url);
+    expect(url.searchParams.get('member_id')).toBe('member-org-b');
+    expect(url.searchParams.get('last_event_id')).toBeNull(); // ⭐핵심 — 옛 org 커서가 안 샌다.
+  });
+
+  it('memberId가 안 바뀌면(무관한 리렌더) 재연결하지 않는다 — 과잉 재연결 금지', async () => {
+    await act(async () => { root.render(<Harness onNotification={vi.fn()} memberId="member-org-a" />); });
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    await act(async () => { root.render(<Harness onNotification={vi.fn()} memberId="member-org-a" />); });
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]!.closed).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/use-sse-notifications.ts
+++ b/apps/web/src/hooks/use-sse-notifications.ts
@@ -178,5 +178,12 @@ export function useSseNotifications({
       if (retryTimer) clearTimeout(retryTimer);
       es?.close();
     };
-  }, [mux, enabled]);
+  // story #2964(sse-multiplexer.ts #2940과 동일 클래스) — org 전환으로 memberId가 바뀌어도
+  // 이 effect가 재실행되지 않으면(구 deps=[mux, enabled]) 커넥션이 옛 member_id로 남는다.
+  // memberIdRef 쓰기는 effect를 재트리거하지 못한다 — memberId를 deps에 편입해 값이 실제로
+  // 바뀔 때만(문자열 값 비교) 재구독을 강제한다. `lastEventId`가 이 effect 본문의 지역
+  // 변수(ref 아님)라 재실행마다 자동으로 새로 초기화되므로 — memberId가 실제로 바뀐 재실행에서
+  // 옛 org의 커서가 자동으로 버려진다(#3388 카디르 QA와 동일 목표를 use-chat-sse.ts의
+  // prevMemberIdForResetRef 같은 별도 판별 없이 이 파일의 기존 설계가 이미 충족).
+  }, [mux, enabled, memberId]);
 }


### PR DESCRIPTION
[SID:2964]

## 요약
`sse-multiplexer.ts`(#2940)와 동일 클래스 결함이 `use-chat-sse.ts`/`use-sse-notifications.ts`의 독립 연결 폴백 경로(mux OFF/Provider 밖)에도 있었다 — org 전환으로 memberId가 바뀌어도 effect deps에 없어 재연결이 안 일으켜지고, 재연결되더라도 옛 org의 `last_event_id`가 새 커넥션에 실려 BE가 org 스코프 없이 그 id의 생성시각만으로 백필기준을 잡아 조용히 누락될 수 있었다(#3388 카디르 QA와 동일 근거).

## 처방(#2940과 동형)
- `use-chat-sse.ts`: deps에 `currentTeamMemberId` 편입 + `prevMemberIdForResetRef`로 진짜 변경 시에만 `lastEventIdRef` 리셋(#2940과 동일 ref 기반 설계, 마운트·mux 단독 토글엔 안 건드림) + `retryTimerRef` stale 방지(MEDIUM, cleanup에서 null 명시 대입 — #3388과 동형).
- `use-sse-notifications.ts`: deps에 `memberId` 편입만으로 충분 — `lastEventId`/`retryTimer`가 이 파일에선 애초에 effect 본문의 지역 변수(ref 아님)라 재실행마다 자동 초기화되므로 별도 리셋 판별 로직이 불필요. 두 파일의 기존 설계 차이를 그대로 인정하고 억지로 통일하지 않았다.

## 조건 명시 — "mux OFF 폴백 경로 전용"
dev는 지금 mux live라 이 폴백 경로가 당장 재현되진 않는다(story 설명 그대로, 급하지 않음). 신규 테스트는 이 조건을 명시적으로 반영 — 두 테스트 파일 전체가 이미 Provider 밖에서 렌더해 `mux=null`을 이용하는 기존 구조를 그대로 재사용(발명 0), 새 describe 블록 docstring에 "구조적으로 폴백 경로 전용 검증"임을 명문화.

## ⚠️AC1 미완 — 블로커
prod의 `_SSE_MULTIPLEX_ENABLED` 실측(AC1)을 시도했으나 이 세션의 gcloud 인증이 만료돼(`gcloud builds list`/`triggers list` 둘 다 재인증 요구) 막혔다. 재인증은 사람만 가능(비대화형 세션에서 프롬프트 불가) — 코드 fix 자체는 이 실측과 무관하게 유효(폴백 경로가 언젠가 라이브가 되는 모든 시나리오에 대비하는 방어적 수정)라 이 AC 하나만 미완인 채로 나머지를 먼저 올린다. 재인증 후 후속 확인 필요.

## 테스트
두 훅에 각 3건 신규(재연결 발생·last_event_id 미유출·과잉재연결 없음) — `use-chat-sse.test.tsx`/`use-sse-notifications.test.tsx`.

## 검증
- 뮤테이션 검증(두 훅의 fix를 각각 되돌리면 정확히 2/3건씩 실패 확認 — 나머지 1건은 "안 바뀌면 재연결 안 함" 음성 케이스라 항상 참) 완료.
- 회귀 스윕: 두 훅의 소비처 전체(kanban-board·chat-list-view·story-detail-panel·verify-rail·use-chat-unread-total·sse-event-dedup·sse-multiplexer) 포함 9파일 148건 전부 통과.
- `tsc --noEmit`/`eslint` 클린.