### PR TITLE
[SID:2967] 제목 2중 잔존 보강 — 괄호 스토리 접미 관례 교정

### DIFF
--- a/apps/web/src/components/docs/doc-content-renderer.test.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.test.tsx
@@ -168,6 +168,30 @@ describe('DocContentRenderer', () => {
       );
       expect(markup).toContain('결제 스펙 v2</h1>');
     });
+
+    // PO 배포후 실픽셀 재검(2026-08-23) — doc.title이 "…설계안(story #1234)"처럼 괄호
+    // 스토리 접미를 다는 관례라 본문(접미 없음)과 완전일치가 안 나 2중이 잔존했다.
+    it('doc.title에 "(story #NNNN)" 접미가 있고 본문 h1은 접미 없이 같으면 생략한다', () => {
+      const markup = renderToStaticMarkup(
+        <DocContentRenderer content={'# 워크플로 결함 근본 수리 — 설계안\n\n본문'} contentFormat="markdown" suppressLeadingTitle="워크플로 결함 근본 수리 — 설계안(story #1234)" />,
+      );
+      expect(markup).not.toContain('<h1');
+    });
+
+    it('반대 방향(본문 h1에 접미·title은 접미 없음)도 생략한다(대칭)', () => {
+      const markup = renderToStaticMarkup(
+        <DocContentRenderer content={'# 워크플로 결함 근본 수리 — 설계안(story #1234)\n\n본문'} contentFormat="markdown" suppressLeadingTitle="워크플로 결함 근본 수리 — 설계안" />,
+      );
+      expect(markup).not.toContain('<h1');
+    });
+
+    // 음성대조 — 접미를 벗겨도 완전 다른 제목이면 생략하지 않는다(허구 생략 금지 유지).
+    it('접미를 벗겨도 본문 제목이 다르면 여전히 생략하지 않는다(음성대조)', () => {
+      const markup = renderToStaticMarkup(
+        <DocContentRenderer content={'# 전혀 다른 문서 제목\n\n본문'} contentFormat="markdown" suppressLeadingTitle="워크플로 결함 근본 수리 — 설계안(story #1234)" />,
+      );
+      expect(markup).toContain('전혀 다른 문서 제목</h1>');
+    });
   });
 
   // story #2967(선생님 실사용 판정 ③) — 다크 본문 체감 눌림 교정(WCAG는 이미 통과·체감 문제).

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -51,6 +51,30 @@ function normalizeHeadingForTitleCompare(s: string): string {
   return s.trim().replace(/^#+\s*/, '').replace(/\s+/g, ' ').toLowerCase();
 }
 
+// story #2967 후속(PO 배포후 실픽셀 재검, 2026-08-23) — 제목 2중이 일부 문서에 잔존했다.
+// 원인: 우리 doc 제목 관례가 "…설계안(story #1234)" 처럼 괄호 스토리 접미를 붙이는데
+// 본문 첫 heading은 그 접미 없이 순수 제목만 쓴다 — 정규화해도 완전 일치가 안 났다.
+// 처방: 양쪽 다 "말미 괄호(...)" 를 벗겨(반복 적용 — 접미가 여러 겹이어도) 한 번 더
+// 비교한다. 완전 다른 제목은 벗겨도 여전히 다르므로 음성대조 유지(허구 생략 없음).
+function stripTrailingParenthetical(s: string): string {
+  let prev: string;
+  let next = s;
+  do {
+    prev = next;
+    next = prev.replace(/\s*[([][^()[\]]*[)\]]\s*$/, '');
+  } while (next !== prev);
+  return next;
+}
+
+function isLikelyDuplicateTitle(headingText: string, docTitle: string): boolean {
+  const a = normalizeHeadingForTitleCompare(headingText);
+  const b = normalizeHeadingForTitleCompare(docTitle);
+  if (a === b) return true;
+  const aStripped = stripTrailingParenthetical(a).trim();
+  const bStripped = stripTrailingParenthetical(b).trim();
+  return aStripped.length > 0 && aStripped === bStripped;
+}
+
 // 마크다운 경로 sanitize 스키마 — rehype-sanitize 기본 스키마는 img/div 의 data-* 를 제거하므로
 // asset-ref(data-asset-id) + 파일첨부(data-type)가 리졸버까지 도달하지 못한다.
 // img(asset-ref 이미지) + div(fileAttachment·data-type/asset-ref/legacy data-file-data) 양쪽 허용 추가.
@@ -664,7 +688,7 @@ export function DocContentRenderer({
             const idx = headingIndex++;
             const heading = headings[idx];
             // story #2967 — 첫 heading(idx===0)이 doc.title과 정규화 동일하면 생략(2중 렌더 제거).
-            if (idx === 0 && suppressLeadingTitle && heading && normalizeHeadingForTitleCompare(heading.text) === normalizeHeadingForTitleCompare(suppressLeadingTitle)) {
+            if (idx === 0 && suppressLeadingTitle && heading && isLikelyDuplicateTitle(heading.text, suppressLeadingTitle)) {
               return null;
             }
             return <h1 id={heading?.id}>{children}</h1>;


### PR DESCRIPTION
## 요약
#3392(merged) 배포 후 PO 실물 재검에서 잔존 발견 — 메타 sans·본문 밝기·컴팩트 레일은 섰으나 **제목 2중이 일부 문서에 남아있었다**.

## 원인
doc.title이 "…설계안(story #1234)"처럼 **괄호 스토리 접미**를 붙이는 관례인데, 본문 첫 heading은 그 접미 없이 순수 제목만 쓴다 — `suppressLeadingTitle`(#3392)의 정규화 비교(trim·공백·대소문자·선행 `#`)가 완전 일치를 요구해 이 케이스를 못 잡았다.

## 처방
양쪽을 정규화한 뒤 완전 일치가 아니면, **말미 괄호 `(...)`를 벗겨서(반복 적용 — 접미가 여러 겹이어도) 한 번 더 비교**한다. 대칭 처리(title 쪽에 접미가 있든 본문 쪽에 있든 둘 다 잡음). 완전 다른 제목은 벗겨도 여전히 다르므로 **허구 생략 없음(음성대조 유지)**.

## 참고
이 PR은 `fix/2967-docs-reader-readability`(머지된 #3392) 브랜치에 실수로 이어붙였던 커밋을 develop 최신 기준 새 브랜치로 cherry-pick한 것 — 내용은 동일, 검증만 새 base로 재실행.

## 검증
- [x] `pnpm exec tsc --noEmit` — EXIT 0
- [x] `pnpm lint` — 경고 5개(baseline 그대로, 신규 0)
- [x] `pnpm vitest run` — 484 files / 4178 tests green(신규 3 — title 접미 케이스+대칭 케이스+음성대조)
- [x] 뮤테이션 실측 — 정규화-only로 되돌려 신규 2건 RED 확認 → 원복 GREEN 확認
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0

🤖 Generated with Claude Code