### PR TITLE
[SID:2961] fix: reopen_gate_if_new_sha가 재-pending 시 resolver 필드를 안 지우던 것 수정

### DIFF
--- a/backend/app/services/gate_github_check.py
+++ b/backend/app/services/gate_github_check.py
@@ -490,6 +490,16 @@ async def reopen_gate_if_new_sha(
     )
     prior_sha = gate.approved_head_sha
     set_gate_status(gate, "pending", now=datetime.now(timezone.utc))
+    # story #2961(실 DB 관측, story 2905 gate 재현) — 이 함수만 재-pending 3종 중 유일하게
+    # resolver_id/resolved_at/resolution_note를 안 지웠다. gate_service.py의 다른 두 재-pending
+    # 경로(_reopen_rejected_gate·undo_gate_resolution)는 이 셋을 항상 함께 지운다 — status가
+    # pending으로 돌아가면 "누가 언제 무슨 사유로 해소했나"는 더 이상 참이 아니므로(그 해소는
+    # 이제 무효화된 옛 SHA에 대한 것), 셋을 같이 null로 되돌려 그 불변식(해소 3종 필드는
+    # status!=pending일 때만 값을 가진다)을 여기서도 지킨다. 감사 이력은 유실 안 됨 — 아래
+    # GateGithubCheckEvent(re_pending, prior_sha)가 별도로 원장에 남긴다.
+    gate.resolver_id = None
+    gate.resolved_at = None
+    gate.resolution_note = None
     gate.approved_head_sha = None
     gate.github_check_run_id = None  # 새 SHA는 새 check-run(같은 SHA의 pending→success 갱신 축과 분리).
     gate.github_check_run_sha = None

--- a/backend/tests/test_2813_gate_github_check_realdb.py
+++ b/backend/tests/test_2813_gate_github_check_realdb.py
@@ -497,6 +497,49 @@ async def test_reopen_gate_if_new_sha_flips_approved_to_pending_realdb():
 
 
 @pytest.mark.anyio
+async def test_reopen_gate_if_new_sha_clears_resolver_fields_realdb():
+    """story #2961(실 DB 관측, story 2905 pr_number=3307 gate 재현) — 재-pending 시
+    resolver_id/resolved_at/resolution_note가 status와 함께 지워지는지. 다른 두 재-pending
+    경로(gate_service.py의 _reopen_rejected_gate·undo_gate_resolution)는 이미 이 셋을
+    같이 지우는데 이 함수만 빠뜨려, "해소됐다"는 흔적(resolved_at 有)이 status=pending인
+    게이트에 그대로 남아있었다(불변식 위반: 이 셋은 status!=pending일 때만 값을 가져야 함)."""
+    from datetime import datetime, timezone
+    import uuid
+
+    from app.models.gate import Gate
+    from app.services.gate_github_check import reopen_gate_if_new_sha
+
+    engine, Session = await _session_factory()
+    try:
+        resolver_id = uuid.uuid4()
+        stale_resolved_at = datetime(2026, 8, 21, 16, 33, 20, tzinfo=timezone.utc)
+        async with Session() as s:
+            seeded = await _seed(
+                s, gate_status="approved", approved_head_sha="old-sha", github_check_run_id=9001,
+            )
+            gate = await s.get(Gate, seeded["gate_id"])
+            gate.resolver_id = resolver_id
+            gate.resolved_at = stale_resolved_at
+            gate.resolution_note = "approved via PR review"
+            await s.commit()
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            await reopen_gate_if_new_sha(s, seeded["org_id"], gate, "new-sha", repo_full_name="acme/repo", pr_number=7)
+            await s.commit()
+
+        async with Session() as s:
+            gate = await s.get(Gate, seeded["gate_id"])
+            assert gate.status == "pending"
+            # ⭐핵심 — 셋 다 status와 함께 지워져야(다른 두 재-pending 경로와 동형).
+            assert gate.resolver_id is None
+            assert gate.resolved_at is None
+            assert gate.resolution_note is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_reopen_gate_if_new_sha_noop_when_sha_matches_realdb():
     """양성대조 — SHA가 같으면 재-pending 안 한다(vacuous하게 항상 flip하는 버그 방지)."""
     from app.models.gate import Gate


### PR DESCRIPTION
[SID:2961]

## 요약
실 DB 관측(story 2905, pr_number=3307 gate — #2908 그라운딩 중 발견)으로 확認: `status=pending`인데 `resolved_at`(과거 승인 시각)이 그대로 남아있는 게이트 행. `gate_service.py`의 다른 두 재-pending 경로(`_reopen_rejected_gate`·`undo_gate_resolution`)는 이미 `resolver_id`/`resolved_at`/`resolution_note` 셋을 status와 함께 지우는데, `reopen_gate_if_new_sha`(gate_github_check.py, SHA 재-pending 축)만 이 셋을 빠뜨렸다.

## AC1 — 코드 확認
`set_gate_status`(app/models/gate.py) 자체는 `status`/`status_entered_at`만 다룬다 — resolver 3필드는 호출부 책임. `reopen_gate_if_new_sha`만 이 셋을 클리어하지 않는 유일한 재-pending 경로임을 grep으로 전수 확認.

## AC2 — FE 영향 확認(현재 잘못된 신호 0건)
- `gate-undo-button.tsx`: `status`를 먼저 체크(approved/rejected만 통과) — pending 게이트는 애초에 안전.
- `approvals-queue.tsx`: 이미 "pending이면 resolver_id/resolved_at을 못 믿는다"고 코드 주석에 명시하는 방어적 설계 — 안전.
- `doc-gate-section.tsx`/`doc-status-rail.tsx`: `DOC_GATE_TYPE` 전용 — 이 함수는 `MERGE_GATE_TYPE` 전용이라 스코프 밖.
- kanban 컴포넌트: `resolved_at`을 아예 안 씀.

그래도 SSOT 데이터 정합(불변식: 이 세 필드는 `status != pending`일 때만 값을 가진다) 자체는 지켜야 할 결함이라 처방한다.

## 처방
`set_gate_status(gate, "pending", ...)` 직후 `resolver_id`/`resolved_at`/`resolution_note`를 명시적으로 `None` — 다른 두 재-pending 경로와 동형. 감사 이력 유실 없음(`GateGithubCheckEvent`의 `re_pending` 행이 `prior_sha`로 이미 별도 원장에 남긴다).

## AC3 — 테스트
신규 1건(`test_reopen_gate_if_new_sha_clears_resolver_fields_realdb`) — story 2905 재현(resolver_id/resolved_at/resolution_note를 미리 세팅한 approved 게이트에 새 SHA를 흘려 재-pending시키고, 세 필드 모두 None인지 확認).

## 검증
- 뮤테이션 검증(fix 되돌리면 정확히 `resolver_id` 단언에서 `UUID(...) is None` 실패 확認 → 복원 → 재통과) 완료.
- 회귀 스윕: `reopen_gate_if_new_sha` 소비 테스트 4개 파일 48건 통과. 무관 실패 1건(`test_2829_loop_measure_due_realdb.py::test_ac2_no_infinite_republish_set_once`)은 이 세션에서 이미 baseline(develop, 미수정 상태)에서도 동일하게 실패함을 확定한 사전 known-flaky — 이 PR과 무관.