### PR TITLE
[SID:2968] 채팅 리스트·헤더 아바타 avatar.tsx 정본 배선 — stale avatar 근본 수리

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.test.tsx
@@ -147,3 +147,51 @@ describe('ConversationPage — 실패 자리 (story #2168 PR-②, 능동 클릭 
     expect(container.textContent).toContain('해당 프로젝트에 접근 권한이 없습니다');
   });
 });
+
+// story #2968(선생님 실사용 발견) — 채팅 헤더는 이전까지 avatar_url을 애초에 안 그렸다(제목
+// 텍스트만). avatar.tsx 정본(#2887/#2921) 배선으로 DM 상대의 실사진을 헤더에도 노출한다.
+describe('ConversationPage — 헤더 아바타(story #2968)', () => {
+  it('DM 상대의 avatar_url이 있으면 헤더에 실사진(<img>)을 렌더한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/conversations/conv-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            title: null, type: 'dm', muted: false, lastReadAt: null, freeResponse: false,
+            participants: [
+              { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+              { member_id: 'them-1', name: '유나', avatar_url: 'https://storage.googleapis.com/bucket/avatar/a.png', type: 'human' },
+            ],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    await mount();
+
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute('src')).toBe('https://storage.googleapis.com/bucket/avatar/a.png');
+  });
+
+  it('group 대화는 헤더에 단일 실사진을 그리지 않는다(다인원, 회귀 0)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/conversations/conv-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            title: '팀 채널', type: 'group', muted: false, lastReadAt: null, freeResponse: false,
+            participants: [
+              { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+              { member_id: 'them-1', name: '유나', avatar_url: 'https://storage.googleapis.com/bucket/avatar/a.png', type: 'human' },
+            ],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    await mount();
+
+    expect(container.querySelector('img')).toBeNull();
+  });
+});

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -10,6 +10,7 @@ import type { PresenceStatus } from '@/components/chat/presence-dot';
 import { AddParticipantModal } from '@/components/chat/add-participant-modal';
 import { DeliveryContractModal } from '@/components/chat/delivery-contract-modal';
 import { EmptyState } from '@/components/ui/empty-state';
+import { Avatar } from '@/components/shared/avatar';
 import { useDashboardContext } from '../../../dashboard/dashboard-shell';
 import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
 
@@ -193,6 +194,12 @@ export default function ConversationPage() {
     ? formatHeaderTitle(meta, currentTeamMemberId)
     : (meta === null ? '채팅' : '로딩 중…');
 
+  // story #2968 — 리스트(chat-list-view.tsx)와 동일 원칙: 1:1(DM)만 상대가 특정되므로
+  // avatar.tsx 정본으로 실사진을 보여준다. group은 다인원이라 대표 사진이 없어 미표시 유지.
+  const headerAvatarParticipant = meta?.type === 'dm'
+    ? meta.participants.find((p) => p.member_id !== currentTeamMemberId)
+    : null;
+
   // S8 #2: pre-send capability 경고 대상 = 에이전트 participant(본인 제외)·runtime_type 필드 존재시만.
   // (S8b 미머지 → runtime_type undefined → commandTargets 빈 배열 → 경고 미표시 graceful.)
   const commandTargets = (meta?.participants ?? [])
@@ -219,6 +226,15 @@ export default function ConversationPage() {
               <ChevronLeft className="h-4 w-4" />
               <span className="lg:hidden">채팅</span>
             </button>
+            {headerAvatarParticipant && (
+              <Avatar
+                name={headerAvatarParticipant.name ?? '?'}
+                avatarUrl={headerAvatarParticipant.avatar_url ?? null}
+                actorType={headerAvatarParticipant.type === 'agent' ? 'agent' : 'human'}
+                size={24}
+                className="flex-shrink-0"
+              />
+            )}
             {editingTitle && meta?.type === 'group' ? (
               <input
                 autoFocus

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -735,6 +735,7 @@ export function ChatBubble({
           y={profilePopover.y}
           name={displayName}
           isAgent={isAgent}
+          avatarUrl={message.sender_avatar_url ?? null}
           onClose={() => setProfilePopover(null)}
           onBlock={onBlockUser}
         />

--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -139,6 +139,67 @@ describe('ChatListView — 다른 프로젝트 섹션 (story #2168 PR-②)', () 
   });
 });
 
+// story #2968(선생님 실사용 발견) — 리스트가 avatar.tsx(정본, #2887/#2921)를 안 쓰고 Bot 아이콘/
+// 이니셜만 그려 avatar_url이 애초에 죽은 데이터였다(캐시·BE 스냅샷 문제 아님 — 3층 그라운딩
+// 실측으로 확認: BE는 write/read 전부 members.avatar_url 라이브, 업로드도 매번 새 uuid4 키).
+function stubFetchWithConversations(items: unknown[]) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url.includes('/api/conversations/recent-outside-project')) {
+      return { ok: true, json: async () => ({ data: [] }) };
+    }
+    if (url.includes('/api/conversations?')) {
+      return { ok: true, json: async () => ({ data: items, total: items.length }) };
+    }
+    return { ok: false, status: 404, json: async () => null };
+  }));
+}
+
+describe('ChatListView — 리스트 아바타 실사진(story #2968)', () => {
+  it('DM 상대의 avatar_url이 있으면 이니셜/아이콘 대신 실사진(<img>)을 렌더한다', async () => {
+    stubFetchWithConversations([{
+      id: 'conv-dm-1', type: 'dm', title: null,
+      latest_message: null, updated_at: '2026-08-23T00:00:00Z', unread_count: 0,
+      participants: [
+        { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+        { member_id: 'them-1', name: '유나', avatar_url: 'https://storage.googleapis.com/bucket/avatar/a.png', type: 'human' },
+      ],
+    }]);
+    await mount();
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute('src')).toBe('https://storage.googleapis.com/bucket/avatar/a.png');
+  });
+
+  it('avatar_url이 없으면(레거시·미업로드) Avatar 정본 자체의 이니셜 폴백으로 떨어진다(img 없음)', async () => {
+    stubFetchWithConversations([{
+      id: 'conv-dm-2', type: 'dm', title: null,
+      latest_message: null, updated_at: '2026-08-23T00:00:00Z', unread_count: 0,
+      participants: [
+        { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+        { member_id: 'them-2', name: '유나', avatar_url: null, type: 'human' },
+      ],
+    }]);
+    await mount();
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain('유나');
+  });
+
+  // 음성대조 — group은 특정 1인 사진이 의미 없어(다인원) 기존 Users 아이콘 자리를 그대로 유지한다.
+  it('group 대화는 여전히 단일 실사진을 그리지 않는다(다인원, 회귀 0)', async () => {
+    stubFetchWithConversations([{
+      id: 'conv-group-1', type: 'group', title: '팀 채널',
+      latest_message: null, updated_at: '2026-08-23T00:00:00Z', unread_count: 0,
+      participants: [
+        { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+        { member_id: 'them-1', name: '유나', avatar_url: 'https://storage.googleapis.com/bucket/avatar/a.png', type: 'human' },
+        { member_id: 'them-2', name: '카디르', avatar_url: 'https://storage.googleapis.com/bucket/avatar/b.png', type: 'human' },
+      ],
+    }]);
+    await mount();
+    expect(container.querySelector('img')).toBeNull();
+  });
+});
+
 // story #1978(트랙C) — SSE 드롭 후 놓친 conversation.message_created가 목록에 미백필되던
 // 두 구멍(재연결·백그라운드 복귀)을 고정한다. useChatSse는 위에서 옵션 캡처용으로만 목했으므로
 // 실제 SSE 백오프/타이머는 재현하지 않는다 — onReconnect 콜백이 넘어왔는지, 그리고 그 콜백을

--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -198,6 +198,46 @@ describe('ChatListView — 리스트 아바타 실사진(story #2968)', () => {
     await mount();
     expect(container.querySelector('img')).toBeNull();
   });
+
+  // 카디르 QA(#3397, HIGH 재발) — agentOnlyConvs 필터(`!myConvIds.has(c.id)`)는 conv.type을
+  // 안 가려 group 대화도 isAgentConv=true로 렌더된다. 그 경로에서까지 "임의 참가자 1인 사진을
+  // 대표사진처럼" 보여주면 안 된다(PR 자신의 group 원칙 위반) — 기존 group 테스트는 일반탭만
+  // 커버해 이 회귀를 놓쳤다. agent 탭을 실제로 열어(role="tab" 클릭) 검증한다.
+  it('agent 탭의 group 대화도 임의 참가자 사진을 대표사진처럼 노출하지 않는다(회귀 재발 방지)', async () => {
+    useDashboardContextMock.mockReturnValue({ role: 'admin' });
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/conversations/recent-outside-project')) {
+        return { ok: true, json: async () => ({ data: [] }) };
+      }
+      if (url.includes('include_agent_conversations=true')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{
+              id: 'conv-agent-group-1', type: 'group', title: '에이전트 그룹',
+              latest_message: null, updated_at: '2026-08-23T00:00:00Z', unread_count: 0,
+              participants: [
+                { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+                { member_id: 'agent-1', name: '올리베이라', avatar_url: 'https://storage.googleapis.com/bucket/avatar/agent.png', type: 'agent' },
+                { member_id: 'human-1', name: '유나', avatar_url: 'https://storage.googleapis.com/bucket/avatar/yuna.png', type: 'human' },
+              ],
+            }],
+            total: 1,
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [], total: 0 }) };
+    }));
+    await mount();
+
+    const agentTab = [...container.querySelectorAll('[role="tab"]')].find((el) => el.textContent?.includes('에이전트'));
+    expect(agentTab).not.toBeUndefined();
+    await act(async () => { agentTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('에이전트 그룹');
+    expect(container.querySelector('img')).toBeNull();
+  });
 });
 
 // story #1978(트랙C) — SSE 드롭 후 놓친 conversation.message_created가 목록에 미백필되던

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -108,10 +108,16 @@ function ConversationRow({
   const others = conv.participants ? getOtherParticipants(conv.participants, currentMemberId) : [];
   const isAgentInConv = conv.participants ? hasAgentParticipant(conv.participants) : false;
   const agentCount = others.filter((p) => p.type === 'agent').length;
-  // story #2968 — 1:1(DM·agent 탭)은 상대 1인이 특정되므로 avatar_url 실사진을 그대로 쓴다
+  // story #2968 — 1:1(conv.type==='dm')만 상대가 특정되므로 avatar_url 실사진을 그대로 쓴다
   // (avatar.tsx=정본, story #2887/#2921 — 3단 폴백[이미지→이니셜→아이콘]도 그쪽이 갖고 있다).
   // group은 "그 방을 대표하는 단일 인물"이 없어(다인원) 기존 Users 아이콘을 유지한다.
-  const oneOnOneParticipant = (conv.type === 'dm' || isAgentConv) ? others[0] : null;
+  //
+  // 카디르 QA(#3397, HIGH) — isAgentConv를 조건에 넣으면 agent탭의 group 대화까지 걸려
+  // others[0](임의 참가자 1인)을 대표사진처럼 노출했다(agentOnlyConvs 필터가 conv.type을
+  // 안 가려 group에도 isAgentConv=true가 붙는다, ChatListView 참고). 순수 conv.type만 본다
+  // — isAgentConv는 이름/actorType 폴백에서만 쓴다(agent탭 DM의 상대가 실제 에이전트임을
+  // 보강하는 용도, group 판정에는 관여하지 않는다).
+  const oneOnOneParticipant = conv.type === 'dm' ? others[0] : null;
 
   const participantLayer = conv.participants && conv.participants.length > 0 ? (
     conv.type === 'dm' ? (

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Bot, MessageSquare, Users } from 'lucide-react';
+import { MessageSquare, Users } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
@@ -10,6 +10,7 @@ import { NewConversationModal } from './new-conversation-modal';
 import { useChatSse, type SseConversationReadPayload } from '@/hooks/use-chat-sse';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { queuePendingToast } from './cross-project-toast-provider';
+import { Avatar } from '@/components/shared/avatar';
 
 import { fetchWithAuth } from '@/lib/db/client';
 
@@ -104,13 +105,13 @@ function ConversationRow({
   const time = conv.latest_message?.created_at ?? conv.updated_at;
   const unread = conv.unread_count ?? 0;
 
-  const avatarInitial = !isAgentConv && conv.type === 'dm' && conv.participants
-    ? (conv.participants.find((p) => p.member_id !== currentMemberId)?.name?.slice(0, 2) ?? 'DM')
-    : null;
-
   const others = conv.participants ? getOtherParticipants(conv.participants, currentMemberId) : [];
   const isAgentInConv = conv.participants ? hasAgentParticipant(conv.participants) : false;
   const agentCount = others.filter((p) => p.type === 'agent').length;
+  // story #2968 — 1:1(DM·agent 탭)은 상대 1인이 특정되므로 avatar_url 실사진을 그대로 쓴다
+  // (avatar.tsx=정본, story #2887/#2921 — 3단 폴백[이미지→이니셜→아이콘]도 그쪽이 갖고 있다).
+  // group은 "그 방을 대표하는 단일 인물"이 없어(다인원) 기존 Users 아이콘을 유지한다.
+  const oneOnOneParticipant = (conv.type === 'dm' || isAgentConv) ? others[0] : null;
 
   const participantLayer = conv.participants && conv.participants.length > 0 ? (
     conv.type === 'dm' ? (
@@ -165,25 +166,20 @@ function ConversationRow({
       onClick={onClick}
       className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-muted/60 active:bg-muted"
     >
-      {/* Avatar — story #2590(TIER1 아이콘): 계열 글자는 tint 유무와 무관하게(카드/배경/muted
-          전부) 3.0 미달이라(--warning L=0.75 자체가 옅음) tint 제거+ring으로도 안 풀린다(직접
-          재실측: warning on card 2.25·warning-border on card 1.65 — 둘 다 실패). 진한 warning
-          토큰 신설은 이 스토리 범위 밖(#2420 doc "별건") — foreground로 잠정 통일. */}
-      <div className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full text-sm font-medium ${
-        isAgentConv
-          ? 'bg-warning-tint text-foreground'
-          : conv.type === 'dm'
-            ? 'bg-primary/15 text-primary'
-            : 'bg-info/15 text-info'
-      }`}>
-        {isAgentConv
-          ? <Bot className="h-4 w-4" />
-          : conv.type === 'dm' && avatarInitial
-            ? avatarInitial
-            : conv.type === 'dm'
-              ? <MessageSquare className="h-4 w-4" />
-              : <Users className="h-4 w-4" />}
-      </div>
+      {/* story #2968 — 1:1(DM·agent 탭)은 avatar.tsx 정본으로 실사진(3단 폴백은 그 컴포넌트
+          책임). group은 특정 1인 사진이 의미가 없어(다인원) 기존 아이콘 자리를 유지한다. */}
+      {oneOnOneParticipant ? (
+        <Avatar
+          name={oneOnOneParticipant.name ?? (isAgentConv ? t('agent') : 'DM')}
+          avatarUrl={oneOnOneParticipant.avatar_url ?? null}
+          actorType={isAgentConv || oneOnOneParticipant.type === 'agent' ? 'agent' : 'human'}
+          size={36}
+        />
+      ) : (
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-info/15 text-foreground">
+          {conv.type === 'dm' ? <MessageSquare className="h-4 w-4" /> : <Users className="h-4 w-4" />}
+        </div>
+      )}
 
       {/* Info */}
       <div className="min-w-0 flex-1">

--- a/apps/web/src/components/chat/sender-profile-popover.test.tsx
+++ b/apps/web/src/components/chat/sender-profile-popover.test.tsx
@@ -71,4 +71,24 @@ describe('SenderProfilePopover — story #2349 "상대 프로필" 진입점', ()
     });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  // story #2968(카디르 QA #3397 MEDIUM) — chat-bubble.tsx가 이미 들고 있던 sender_avatar_url을
+  // 이 팝업에 안 넘겨 Bot/User 하드코딩 아이콘에 머물러 있었다. avatar.tsx 정본 배선.
+  it('avatarUrl을 주면 Bot/User 아이콘 대신 avatar.tsx 정본이 실사진(<img>)을 렌더한다', async () => {
+    await act(async () => {
+      root.render(
+        <SenderProfilePopover x={0} y={0} name="유나" isAgent={false} avatarUrl="https://storage.googleapis.com/bucket/avatar/a.png" onClose={NOOP} />,
+      );
+    });
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute('src')).toBe('https://storage.googleapis.com/bucket/avatar/a.png');
+  });
+
+  it('avatarUrl을 안 주면(레거시) avatar.tsx 정본의 이니셜 폴백으로 떨어진다(img 없음)', async () => {
+    await act(async () => {
+      root.render(<SenderProfilePopover x={0} y={0} name="유나" isAgent={false} onClose={NOOP} />);
+    });
+    expect(container.querySelector('img')).toBeNull();
+  });
 });

--- a/apps/web/src/components/chat/sender-profile-popover.tsx
+++ b/apps/web/src/components/chat/sender-profile-popover.tsx
@@ -1,13 +1,17 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { Bot, ShieldOff, User } from 'lucide-react';
+import { ShieldOff } from 'lucide-react';
+import { Avatar } from '@/components/shared/avatar';
 
 interface SenderProfilePopoverProps {
   x: number;
   y: number;
   name: string;
   isAgent: boolean;
+  /** story #2968(카디르 QA #3397 MEDIUM) — chat-bubble.tsx가 이미 들고 있던 sender_avatar_url을
+   * 안 넘겨 이 팝업만 Bot/User 하드코딩 아이콘에 머물러 있었다. avatar.tsx 정본 배선. */
+  avatarUrl?: string | null;
   onClose: () => void;
   /** 생략하면(undefined) 「사용자 차단」 버튼 자체를 안 그린다(자기 자신 클릭 시 호출부가 안 넘김). */
   onBlock?: () => void;
@@ -16,7 +20,7 @@ interface SenderProfilePopoverProps {
 // story #2349 — "상대 프로필" 진입점. 이 제품에 다른 멤버를 보는 화면이 없었다(net-new 표면,
 // 그라운딩 확認됨) — message-context-menu.tsx와 같은 위치-고정 팝업 패턴을 그대로 재사용해
 // 새 상호작용 패턴을 발명하지 않는다.
-export function SenderProfilePopover({ x, y, name, isAgent, onClose, onBlock }: SenderProfilePopoverProps) {
+export function SenderProfilePopover({ x, y, name, isAgent, avatarUrl, onClose, onBlock }: SenderProfilePopoverProps) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -46,9 +50,7 @@ export function SenderProfilePopover({ x, y, name, isAgent, onClose, onBlock }: 
       style={{ left: clampedX, top: clampedY }}
     >
       <div className="flex items-center gap-2.5 px-3 py-1.5">
-        <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-          {isAgent ? <Bot className="h-4 w-4" /> : <User className="h-4 w-4" />}
-        </div>
+        <Avatar name={name} avatarUrl={avatarUrl ?? null} actorType={isAgent ? 'agent' : 'human'} size={32} />
         <span className="truncate text-sm font-medium text-foreground">{name}</span>
       </div>
       {onBlock && (


### PR DESCRIPTION
## 요약
선생님 실사용 발견: 프로필 사진을 바꿔도 채팅 리스트 아바타는 옛 사진 그대로.

## 그라운딩(3층 실측 — 지시받은 대로 어느 층에서 끊기는지 실물 대조)
| 후보 | 판정 | 근거 |
|---|---|---|
| ① BE가 avatar_url을 스냅샷 저장 | 기각 | write(`apply_anchor_update`→`Member.avatar_url`)·read(`_lookup_members_by_ids_legacy`→`team_members` VIEW) 모두 `members.avatar_url` 동일 컬럼 라이브(0110 마이그레이션 뷰 정의: `m.avatar_url`) |
| ② 재업로드 동일 URL·캐시버스터 부재 | 기각 | 매 업로드마다 `uuid4().hex` 신규 오브젝트 키(`avatar_upload.py`, "같은 키 덮어쓰기 금지") — URL 자체가 항상 새것 |
| ③ 렌더가 avatar_url을 애초에 안 그림 | **확定(진짜 원인)** | `chat-list-view.tsx`가 avatar.tsx 정본(#2887/#2921)을 안 쓰고 Bot 아이콘/이니셜만 렌더 — `avatar_url` 필드는 타입에만 있고 소비처가 없는 죽은 데이터. `chats/[conversation_id]/page.tsx` 헤더도 동형(아바타 자체가 없음). `chat-bubble.tsx`(메시지)는 이미 정본 사용 — 대조군. |

## 처방
1:1(DM·agent 탭)만 상대 1인이 특정되므로 `<Avatar avatarUrl actorType size/>`(정본, 3단 폴백은 그쪽 책임)로 실사진 배선. group은 다인원이라 "방을 대표하는 1인 사진"이 의미 없어 기존 Users 아이콘 유지(의도적 스코프 — 허구 없음).

## AC3 — 아바타 소비처 전수 grep
- `chat-bubble.tsx`(메시지) — 이미 정본, 무변경(대조군)
- `chat-list-view.tsx`(리스트) — **이번 fix**
- `chats/[conversation_id]/page.tsx`(헤더) — **이번 fix**
- `organization/workforce/[id]/page.tsx` — 이미 정본, 무변경
- `docs/[slug]/page.tsx`(assignee) — avatar_url 필드만 있고 렌더 미사용(이름만) — AC1(리스트·헤더·메시지) 범위 밖, 참고로만 기록

## 검증
- [x] 뮤테이션 실측 2건 — 리스트 avatarUrl 배선 되돌려 RED 확認→원복 GREEN, 헤더 동일
- [x] `tsc --noEmit` — EXIT 0
- [x] `eslint` — 경고 5개(baseline, 신규 0)
- [x] `vitest run` — 484 files / 4196 tests green(신규 5)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0(`no-new-tint-color-text`: 신규 fallback div의 `text-info`를 `text-foreground`로 선제 교정, #2420 AC7)

🤖 Generated with Claude Code