### PR TITLE
[SID:2969] PR-T — Proofline 시스템 토큰 층(radius 하향+elev-overlay 신설)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -294,7 +294,11 @@
   --chart-3: oklch(0.442 0.017 285.786);
   --chart-4: oklch(0.37 0.013 285.805);
   --chart-5: oklch(0.274 0.006 286.033);
-  --radius: 0.625rem;
+  /* story #2969 §1.1(PR-T, 유나 확定 2026-08-23) — 0.625rem(10px, shadcn 기본값)→0.25rem(4px).
+     전 표면 균일 soft round(default 결)를 크리스프로. 파생 스케일(sm~4xl)은 이 값의 calc()라
+     자동 추종 — 별도 편집 불요. 시그니처면(히어로 카드·활성 상태 등)은 이 반경 대신 `.proof-cut`
+     컷코너를 쓴다(적용 표면 목록=doc proofline-system-layer-2969 §1.4가 정본, 이 PR은 토큰만). */
+  --radius: 0.25rem;
   /* story #2917: sidebar도 --card/--primary/--muted/--border/--ring과 같은 값을 거울처럼
      따라간다(기존 #2318 불변식 — "안 맞추면 사이드바만 옛 파랑" 그대로 유지, 소스만 proof-*로). */
   --sidebar: var(--proof-panel);
@@ -422,6 +426,15 @@
   --proof-amber-soft: #FBF1DE;
   --proof-red: #C33B3B;
   --proof-red-soft: #FBEAEA;
+
+  /* story #2969 §1.2(PR-T, 유나 확定 2026-08-23) — 오버레이(dialog/dropdown-menu/sheet/toast/
+     tooltip/popover 등 «떠 있는» 표면) 전용 그림자. 인라인 표면(card/badge/button 등, 문서
+     흐름 안)은 이 토큰을 쓰지 않는다 — 그쪽은 §1.2 처방대로 drop-shadow 대신 hairline border로
+     간다(이 PR은 토큰만·컴포넌트 적용은 PR-4). Carbon-tinted(cold black 아님·북유럽 warm)·
+     2레이어(crisp 근접+soft 확산)·현행 shadow-lg보다 tighter·softer. 오버레이 소비 시 항상
+     1px hairline(`--proof-line-strong`, PR-4에서 오버레이 컴포넌트와 함께 신설 예정) 동반 —
+     그림자만으론 엣지가 흐리다는 게 doc §1.2의 명시 규칙. */
+  --elev-overlay: 0 1px 2px rgba(20, 21, 15, .05), 0 10px 30px -8px rgba(20, 21, 15, .22);
 
   /* story #2955 §5(doc docs-index-reader-redesign-handoff) — 컷코너 3단 토큰 정식화.
      기존 산발 clip-path 4곳(proof-capsule.tsx CutCornerShell·attention-queue-view.tsx·
@@ -577,6 +590,9 @@
   --proof-amber-soft: #2A2214;
   --proof-red: #E06767;
   --proof-red-soft: #2A1717;
+
+  /* story #2969 §1.2(PR-T) — 다크 오버레이 그림자(라이트 대응값의 doc §1.2 지정 다크값). */
+  --elev-overlay: 0 1px 2px rgba(0, 0, 0, .5), 0 12px 34px -8px rgba(0, 0, 0, .62);
 }
 
 /* Sidebar: open triggers get active background */


### PR DESCRIPTION
## 요약
**토큰만·컴포넌트 불변.** spec SSOT = doc `proofline-system-layer-2969` §1(유나 확定 2026-08-23). §3 절단 순서의 1단계(PR-T) — 시스템 토큰 층만, 컴포넌트 파일은 이 PR서 전혀 안 건드린다.

## 변경
| 항목 | 내용 |
|---|---|
| §1.1 Radius | `--radius: 0.625rem`(10px)→**`0.25rem`**(4px). 파생 스케일(sm~4xl)은 `calc()`라 자동 추종 |
| §1.2 Elevation | 신규 `--elev-overlay`(오버레이 전용, 라이트/다크 값 doc 그대로) — 인라인 표면은 미사용(hairline은 PR-2/3 몫) |
| §1.4 컷 시그니처 | 코드 변경 없음 — doc §1.4 목록 자체가 사용규칙 정본 |
| §1.3 Type-ramp | 코드 변경 없음 — 에디토리얼 토큰은 #2917에서 이미 `@theme inline` 승격 완료 |

### 의도적으로 안 한 것 (플래그)
- `--proof-line-strong`(오버레이 hairline 동반용, doc §1.2 프로즈에 언급) — 아직 미존재. PR-4에서 오버레이 컴포넌트와 함께 신설 예정, 이 PR 범위 밖.
- §1.3 표의 "Heading 800"(Display 820~850과 별개 행) — doc에 ✅확定 마크 없음(radius·elev-overlay와 대비). 추측으로 새 토큰 신설 안 함 — PO/유나 확認 필요 사항으로 남김.

## 검증 범위의 경계(투명하게)
- ✅ 로컬 기계적 검증(아래) 전부 통과.
- ⚠️ doc §3 "대표 3화면(보드·채팅·docs) 실픽셀+axe" — dev는 develop 머지 후 자동배포라 **pre-merge 라이브 검증이 파이프라인 구조상 불가**. #2968(PR#3397) 유나 검수와 동일 패턴 — design gate(코드 재질)까지는 이 PR로 닫고, 실픽셀 스윕은 배포 후 확認(PO/유나 사슬)으로 넘어감.

## 검증
- [x] `tsc --noEmit` — EXIT 0
- [x] `eslint` — 경고 5개(baseline, 신규 0)
- [x] `vitest run` — 484 files / 4191 tests green(회귀 0 — 값만 바뀐 CSS 커스텀 프로퍼티라 단정 걸리는 테스트 없음, 예상대로)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0

🤖 Generated with Claude Code