### PR TITLE
[SID:2969] PR-1 — button·badge·label-chip 크리스프화(shadow 제거+컷태그+시트론 focus)

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -598,8 +598,11 @@ function GoalRow({ epic, isSelected, onClick, onDeleteRequest, sortable }: GoalR
               전용 — 두 축이 색에서도 안 섞여야 "일 끝≠목표 달성"이 시각으로 선다(작업 축의 첫
               처방 "done&&hit만 green"조차 두 축을 섞는 것이라 유나 판정으로 대체됨). */}
           <div className="flex shrink-0 flex-col items-start gap-1">
+            {/* story #2969 PR-1 발견 버그 — 아래 proof-cut-xs가 --proof-cut 값만 바꾸고
+                clip-path 자체를 여는 proof-cut 베이스 클래스가 빠져 있어(#2958 원 커밋 실수)
+                컷 자체가 안 그려지고 있었다(globals.css 참고). 즉시 수정. */}
             <span
-              className={`proof-cut-xs inline-flex items-center gap-1 px-2 py-0.5 text-[10.5px] font-bold ${
+              className={`proof-cut proof-cut-xs inline-flex items-center gap-1 px-2 py-0.5 text-[10.5px] font-bold ${
                 epic.status === 'active' ? 'bg-proof-blue-soft text-proof-blue' : 'bg-proof-sunk text-proof-ink-3'
               }`}
             >

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -5,7 +5,15 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all shadow-sm focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  // story #2969 §1.4/§2 PR-1(doc proofline-system-layer-2969) — badge.tsx는 §1.4 "proof-cut-xs
+  // 소 컷(태그·마커류)" 목록에 명시 등재. rounded-full→proof-cut+proof-cut-xs 컷태그로,
+  // shadow-sm 제거(§1.2: 인라인 표면은 그림자 대신 라인 — border-transparent(default/success
+  // 등)는 이미 그 자리 없이도 무회귀, 계열 variant는 기존 border-*/70 hairline이 그대로 그
+  // 역할). ⚠️mono 라벨(라틴 전용) 스타일은 이 공유 primitive에 넣지 않는다 — 이 앱 배지
+  // 소비처 대다수가 한글 텍스트라 전역 적용 시 [[feedback-ui-text-agent-tone]] 부류가 아니라
+  // 2967 교훈(mono가 한글서 흐림)을 그대로 재현한다. 라틴 전용 콘텐츠(있다면)는 호출부가
+  // 개별 className으로 옵트인.
+  "group/badge proof-cut proof-cut-xs inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -24,8 +24,11 @@ const badgeVariants = cva(
         // 실패 박스와 동일 조합). story #2420 v3 규칙(계열별 토큰 대신 규칙 하나) — tint 배경
         // 위 글자는 text-foreground(16.72, scripts/verify-tint-foreground-contrast.ts가 정의
         // 시점에 검증). --foreground 자체가 테마마다 값을 가지므로 dark: 짝이 따로 필요 없다.
+        // story #2969 §2 PR-1(유나 판정, 2026-08-23) — 형제 tint variant(success/info/warning)는
+        // 전부 border-{color}-border+tint bg인데 destructive만 border 없이 shadow 의존이라
+        // shadow-sm 제거 후 odd-one-out이었다. --destructive-border(=proof-red, 既존 토큰)로 닫는다.
         destructive:
-          "bg-destructive/10 text-foreground focus-visible:ring-destructive dark:bg-destructive/20 dark:focus-visible:ring-destructive [a]:hover:bg-destructive/20",
+          "border-destructive-border bg-destructive/10 text-foreground focus-visible:ring-destructive dark:bg-destructive/20 dark:focus-visible:ring-destructive [a]:hover:bg-destructive/20",
         outline:
           "border-border/80 bg-background text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost:

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -6,7 +6,10 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 import { Slot } from "@radix-ui/react-slot"
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  // story #2969 §2 PR-1(doc proofline-system-layer-2969) — focus 링을 시트론으로(버튼 시그니처,
+  // 이 컴포넌트 한정 — 전역 --ring/proof-blue는 무변경). radius는 PR-T(#2969 PR-T)의
+  // --radius 토큰 하향(0.625rem→0.25rem)을 그대로 상속(rounded-md=calc 파생, 이 파일 무편집).
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-proof-citron focus-visible:ring-3 focus-visible:ring-proof-citron active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -25,7 +28,10 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive/10 text-foreground hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive",
         link: "text-primary underline-offset-4 hover:underline",
-        hero: "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm",
+        // story #2969 §2 PR-1 — shadow-sm 제거(§1.2: 인라인 표면은 그림자 대신 라인/색).
+        // 이 자리는 "색"으로 대응 — hover:bg-primary/90(기존)이 이미 그 축을 맡고 있어
+        // 별도 hairline 없이 이 변경만으로 §1.2 원칙을 만족한다(신규 색 발명 없음).
+        hero: "bg-primary text-primary-foreground hover:bg-primary/90",
         glass: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
       },
       size: {

--- a/apps/web/src/components/ui/label-chip.tsx
+++ b/apps/web/src/components/ui/label-chip.tsx
@@ -16,8 +16,11 @@ export const LABEL_PRESET_COLORS = [
 ] as const;
 
 export function LabelChip({ label, className }: { label: LabelData; className?: string }) {
+  // story #2969 §1.4(doc proofline-system-layer-2969) — label-chip.tsx는 §1.4 "proof-cut-xs
+  // 소 컷(태그·마커류)" 목록에 badge.tsx/status-badge.tsx와 함께 명시 등재. rounded-full→
+  // proof-cut+proof-cut-xs.
   return (
-    <span className={cn('inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-foreground', className)}>
+    <span className={cn('proof-cut proof-cut-xs inline-flex items-center gap-1.5 bg-muted px-2 py-0.5 text-xs font-medium text-foreground', className)}>
       <span
         className="h-2 w-2 shrink-0 rounded-full"
         style={{ backgroundColor: label.color ?? '#8A8F98' }}


### PR DESCRIPTION
## 요약
doc `proofline-system-layer-2969` §2 A행(button/badge/label-chip/status-badge)·§1.4 컷 시그니처 목록. PR-T(#3398, merged)가 깔아둔 `--radius`/`--elev-overlay` 토큰 위에서 작업.

## 변경
| 컴포넌트 | 처방 | 구현 |
|---|---|---|
| `button.tsx` | hero shadow 제거→라인/색·focus=시트론 | `shadow-sm` 제거(기존 `hover:bg-primary/90`의 "색"으로 대응)·focus-visible 링/보더 시트론(이 컴포넌트 한정) |
| `badge.tsx` | rounded-full→proof-cut-xs·shadow 제거 | `proof-cut proof-cut-xs`로 교체(§1.4 목록 명시 등재)·`shadow-sm` 제거 |
| `label-chip.tsx` | 컷태그 or 소반경("따라") | §1.4가 badge.tsx/status-badge.tsx와 함께 명시 등재해 hedge 해소 → `proof-cut proof-cut-xs` |
| `status-badge.tsx` | badge 정책 상속 | Badge를 감싸는 구조라 무변경(자동 상속) |

### 의도적으로 안 한 것
- **mono 라벨(라틴 전용) 스타일** — 공유 Badge primitive에 안 넣었다. 이 앱 배지 소비처 대다수가 한글 텍스트라 전역 적용 시 story #2967 교훈(mono가 한글서 흐림)을 그대로 재현할 위험이 크다. 라틴 전용 콘텐츠가 실제로 있는 호출부는 개별 className으로 옵트인하는 편이 안전 — doc 자신도 "한글 라벨은 sans" 규칙을 명시.

## 발견 버그 즉시 수정 (#2958 원 커밋)
`goals-client.tsx`의 상태 칩이 `proof-cut-xs`만 쓰고 있었는데, globals.css상 `-xs`는 `--proof-cut` **값만** 바꾸고 clip-path를 여는 베이스 `proof-cut` 클래스가 없으면 컷이 아예 안 그려진다 — 즉 그동안 컷 없이 렌더되고 있었다. `proof-cut proof-cut-xs`로 수정.

## 검증
- [x] `tsc --noEmit` — EXIT 0
- [x] `eslint` — 경고 5개(baseline, 신규 0)
- [x] `vitest run` — 484 files / 4199 tests green(회귀 0)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0
- ⚠️ 라이브 3화면 실픽셀 — PR-T(#3398)와 동일 경계: dev는 develop 머지 후 자동배포라 pre-merge 불가. design gate(코드 재질)까지 이 PR로 닫고 실픽셀은 배포 후 유나 스윕으로 넘어감.

🤖 Generated with Claude Code