### PR TITLE
[SID:2969] PR-2 — card·section-card·alert 크리스프화(shadow 제거+좌측 액센트+시그니처 컷)

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
@@ -199,6 +199,17 @@ describe('GoalsClient — 결과 원장 재조립(§2 이중 신호·§3 마스�
     expect(container.querySelector('.proof-cut-xs')?.className).not.toContain('proof-green');
   });
 
+  // QA독립검증(카디르, PR#3399) — globals.css의 .proof-cut-xs는 --proof-cut 값만 바꾸고
+  // clip-path 자체를 여는 .proof-cut 베이스 클래스가 없으면 컷이 안 그려진다(#2958 원 커밋
+  // 버그, #3399가 수정). 이 회귀를 잡는 전용 테스트가 없었다 — 뮤테이션으로 확인(베이스 클래스
+  // 제거해도 기존 16건 전부 그대로 PASS) 후 신설. PR-2(card 층)에 편입 예정(PO 처분).
+  it('상태 칩이 proof-cut 베이스 클래스를 갖는다(proof-cut-xs만으론 clip-path 안 열림, #3399 회귀가드)', async () => {
+    stubFetch([{ id: 'e1', title: 'H', status: 'done', total_stories: 1, done_stories: 1 }]);
+    await mount();
+    const chip = container.querySelector('.proof-cut-xs');
+    expect(chip?.className.split(' ')).toContain('proof-cut');
+  });
+
   it('green은 결과 필(OutcomeStatusBadge)에서만 뜬다 — outcome=hit일 때 bg-success-tint가 존재', async () => {
     stubFetch([{ id: 'e1', title: 'H', status: 'done', total_stories: 1, done_stories: 1, outcome_status: 'hit' }]);
     await mount();

--- a/apps/web/src/components/ui/alert.test.tsx
+++ b/apps/web/src/components/ui/alert.test.tsx
@@ -125,6 +125,25 @@ describe('Alert variant 라이트 대비 통일 (story #2513)', () => {
     },
   );
 
+  // story #2969 §2 PR-2(doc proofline-system-layer-2969) — 색 variant(success/warning/
+  // destructive/info)는 좌측 2px 상태 액센트를 갖는다. default(중립)는 축이 없어 미적용.
+  it.each(['success', 'warning', 'destructive', 'info'] as const)(
+    'variant=%s — 좌측 2px 상태 액센트(border-l-2)를 갖는다',
+    async (variant) => {
+      await act(async () => {
+        root.render(<Alert variant={variant}><AlertDescription>메시지</AlertDescription></Alert>);
+      });
+      expect(container.firstElementChild?.className).toContain('border-l-2');
+    },
+  );
+
+  it('default(중립)는 좌측 액센트가 없다(축이 없음)', async () => {
+    await act(async () => {
+      root.render(<Alert><AlertDescription>메시지</AlertDescription></Alert>);
+    });
+    expect(container.firstElementChild?.className).not.toContain('border-l-2');
+  });
+
   // 글자만 foreground로 통일됐을 뿐 variant 구분(색 정체성) 자체는 border/tint로 남아야
   // 한다 — 넷이 서로 다른 border-*-border/bg-*-tint를 갖는지 직접 대조.
   it('variant별 색 정체성(border·tint)은 서로 다르게 유지된다(글자 통일이 구분을 지우지 않는다)', async () => {

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -10,14 +10,18 @@ const alertVariants = cva(
         default: 'border-border bg-muted/40 text-foreground',
         // story #2513 — 글자는 text-foreground로 통일(라이트 테마 AA 미달 fix, warning과
         // 동형). variant 정체성은 border-*-border·아이콘·bg-*-tint로만 표현한다.
+        // story #2969 §2 PR-2(doc proofline-system-layer-2969) — 좌측 2px 상태 액센트
+        // 추가(border-l-2, 기존 border-*-border 색 그대로 두껍게만). default(중립)는 축이
+        // 없어 미적용, 색 variant 전부 대칭 적용(doc "정보/경고 색"은 대표 예시로 읽음 —
+        // success/destructive만 빼면 형제간 비일관).
         success:
-          'border-success-border bg-success-tint text-foreground',
+          'border-success-border border-l-2 bg-success-tint text-foreground',
         warning:
-          'border-warning-border bg-warning-tint text-foreground',
+          'border-warning-border border-l-2 bg-warning-tint text-foreground',
         destructive:
-          'border-destructive-border bg-destructive-tint text-foreground',
+          'border-destructive-border border-l-2 bg-destructive-tint text-foreground',
         info:
-          'border-info-border bg-info-tint text-foreground',
+          'border-info-border border-l-2 bg-info-tint text-foreground',
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/card.test.tsx
+++ b/apps/web/src/components/ui/card.test.tsx
@@ -25,9 +25,13 @@ async function mountAndGetRoot(node: React.ReactNode): Promise<{ el: HTMLElement
 }
 
 // 이관 前 손코딩 원본(section-card.tsx/glass-panel.tsx git 이력) — 정본 리터럴로 대조.
-const ORIGINAL_SECTION_CARD_CLASSES = 'rounded-2xl border border-border/80 bg-card text-card-foreground shadow-sm';
+// story #2969 §2 PR-2(doc proofline-system-layer-2969) 갱신 — radius='card' 자체가
+// rounded-2xl→rounded-lg(§1.1, 2xl은 인라인 표면에서 퇴역)로 바뀌어 두 리터럴 다 반영.
+// solid(SectionCard)는 인라인 표면이라 shadow-sm 제거(§1.2). glass는 "정책 검토"로 이
+// PR 범위 밖(§2 C행) — shadow-sm 그대로 유지.
+const ORIGINAL_SECTION_CARD_CLASSES = 'rounded-lg border border-border/80 bg-card text-card-foreground';
 const ORIGINAL_GLASS_PANEL_CLASSES =
-  'rounded-2xl border border-border/80 bg-card/95 text-card-foreground shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/88';
+  'rounded-lg border border-border/80 bg-card/95 text-card-foreground shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/88';
 
 describe('cardVariants (story #2877)', () => {
   it('surface=solid·radius=card가 SectionCard 원본 클래스 집합과 정확히 일치한다', () => {
@@ -76,7 +80,7 @@ describe('SectionCard/GlassPanel — 얇은 alias 회귀가드 (story #2877)', (
   it('추가 className이 병합되고 원본 클래스를 지우지 않는다', async () => {
     const { el } = await mountAndGetRoot(<SectionCard className="mt-4">hi</SectionCard>);
     expect(el.className).toContain('mt-4');
-    expect(el.className).toContain('rounded-2xl');
+    expect(el.className).toContain('rounded-lg');
   });
 });
 
@@ -86,6 +90,17 @@ describe('Card 신규 프리미티브 — variant·서브컴포넌트 (story #28
     expect(cardVariants({ surface: 'subtle', radius: 'compact' })).toContain('rounded-xl');
     expect(cardVariants({ surface: 'plain', radius: 'inline' })).toContain('rounded-lg');
     expect(cardVariants({ surface: 'plain', radius: 'inline' })).not.toContain('shadow-sm');
+  });
+
+  // story #2969 §1.4(doc proofline-system-layer-2969) — 히어로/시그니처 카드 전용 옵트인.
+  it('radius=signature는 rounded-* 대신 proof-cut(컷코너) 클래스를 낸다', () => {
+    const classes = cardVariants({ surface: 'solid', radius: 'signature' });
+    expect(classes).toContain('proof-cut');
+    expect(classes).not.toMatch(/rounded-(lg|xl|2xl)\b/);
+  });
+
+  it('solid surface는 shadow-sm이 없다(§1.2 — 인라인 표면은 그림자 대신 hairline)', () => {
+    expect(cardVariants({ surface: 'solid', radius: 'card' })).not.toContain('shadow-sm');
   });
 
   it('Card/CardHeader/CardBody/CardFooter가 각자 올바른 data-slot으로 렌더된다', async () => {

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -13,15 +13,23 @@ import { cn } from '@/lib/utils';
 export const cardVariants = cva('border text-card-foreground', {
   variants: {
     surface: {
-      solid: 'border-border/80 bg-card shadow-sm',
+      // story #2969 §2 PR-2(doc proofline-system-layer-2969) — solid는 인라인 표면(§1.2)이라
+      // shadow-sm 제거·hairline(기존 border-border/80)만으로 경계. glass는 §2 C행에서
+      // "정책 검토"로 별도 보류된 축(glass-panel.tsx 소비처 2곳·이 PR 범위 밖)이라 무변경.
+      solid: 'border-border/80 bg-card',
       glass: 'border-border/80 bg-card/95 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/88',
       subtle: 'border-border/60 bg-muted/30',
       plain: 'border-border/80 bg-card',
     },
     radius: {
-      card: 'rounded-2xl',
+      // story #2969 §1.1 — rounded-2xl(7.2px, PR-T 이후 값)은 "카드·인라인 표면에서 퇴역"
+      // 대상(§1.1 명시)이라 크리스프 lg(4px)로.
+      card: 'rounded-lg',
       compact: 'rounded-xl',
       inline: 'rounded-lg',
+      // story #2969 §1.4 — 히어로/시그니처 카드(섹션 리드·활성·측정 중 카드 1종, 화면당 소수)
+      // 전용 옵트인. 라운드 대신 컷코너(큰 시그니처 컷, --proof-cut 기본 24px).
+      signature: 'proof-cut',
     },
   },
   defaultVariants: { surface: 'solid', radius: 'card' },


### PR DESCRIPTION
## 요약
doc `proofline-system-layer-2969` §2 A행(card/section-card/alert)·§1.1/§1.4. PR-T(#3398)+PR-1(#3399, merged)이 깔아둔 토큰/패턴 위에서 작업.

## 변경
| 컴포넌트 | 처방 | 구현 |
|---|---|---|
| `card.tsx` | 반경 lg(4px)·shadow 제거→hairline·signature=proof-cut | `radius='card'`: rounded-2xl→**rounded-lg**(§1.1 "2xl은 카드·인라인에서 퇴역")·`surface=solid` shadow-sm 제거·신규 `radius='signature'`(`.proof-cut`, §1.4 히어로카드 옵트인) |
| `section-card.tsx` | card 정책 상속 | alias라 자동 상속, 무편집 |
| `alert.tsx` | 크리스프+좌측 액센트(정보/경고 색) | 색 variant(success/warning/destructive/info) 전부에 `border-l-2` 추가(기존 border 색 그대로 두껍게만) — default는 축 없어 미적용 |

### 의도적으로 안 한 것
- `surface=glass`(card.tsx) — §2 C행 "정책 검토"로 별도 보류(glass-panel.tsx 2 사용처, 이 PR 범위 밖) — shadow-sm 무변경.

## 카디르 회귀테스트 편입 (PO 전달, PR#3399 QA독립검증)
`goals-client.test.tsx`에 "상태 칩이 proof-cut 베이스 클래스를 갖는다" 테스트 추가 — #3399가 고친 #2958 원커밋 버그(`proof-cut-xs`만 쓰고 base `proof-cut` 누락)를 잡는 전용 가드가 없었던 갭을 닫는다.

## 테스트 리터럴 갱신 (의도된 값 변경 — 회귀 아님)
`card.test.tsx`의 하드코딩 리터럴(`ORIGINAL_SECTION_CARD_CLASSES`/`ORIGINAL_GLASS_PANEL_CLASSES`)이 `rounded-2xl`+solid `shadow-sm`을 담고 있어 이번 값 변경에 맞춰 갱신.

## 검증
- [x] 뮤테이션 실측 2건 — signature variant(되돌려 RED→원복 GREEN)·alert border-l-2(제거→4건 RED→원복 GREEN)
- [x] `tsc --noEmit` — EXIT 0
- [x] `eslint` — 경고 5개(baseline, 신규 0)
- [x] `vitest run` — 484 files / 4207 tests green(신규 8)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0
- ⚠️ 라이브 3화면 실픽셀 — PR-T/PR-1과 동일 경계(배포 후 유나 스윕)

🤖 Generated with Claude Code