### PR TITLE
[SID:2969] PR-3 — input·tabs·sidebar·operator-control 크리스프화(shadow 제거+시트론 액센트)

### DIFF
--- a/apps/web/src/components/ui/input.test.tsx
+++ b/apps/web/src/components/ui/input.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+//
+// story #2969 §2 PR-3(doc proofline-system-layer-2969) — Input focus를 시트론으로(이
+// 컴포넌트 한정, 전역 --ring/proof-blue 무변경).
+import { describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Input } from './input';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function mount(node: React.ReactNode): Promise<{ el: HTMLElement; root: Root }> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => { root.render(node); });
+  return { el: container.firstElementChild as HTMLElement, root };
+}
+
+describe('Input — focus 시트론(story #2969 PR-3)', () => {
+  it('focus-visible 보더/링이 proof-citron이다', async () => {
+    const { el } = await mount(<Input placeholder="x" />);
+    expect(el.className).toContain('focus-visible:border-proof-citron');
+    expect(el.className).toContain('focus-visible:ring-proof-citron');
+    expect(el.className).not.toContain('focus-visible:ring-ring');
+  });
+});

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -9,7 +9,9 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-xl border border-input bg-transparent px-3 py-2 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        // story #2969 §2 PR-3(doc proofline-system-layer-2969) — focus를 시트론으로(이
+        // 컴포넌트 한정, button.tsx와 동일 문법 — 전역 --ring/proof-blue 무변경).
+        "h-9 w-full min-w-0 rounded-xl border border-input bg-transparent px-3 py-2 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-proof-citron focus-visible:ring-3 focus-visible:ring-proof-citron disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -11,7 +11,10 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       className={cn(
         // story #2969 §2 PR-3(doc proofline-system-layer-2969) — focus를 시트론으로(이
         // 컴포넌트 한정, button.tsx와 동일 문법 — 전역 --ring/proof-blue 무변경).
-        "h-9 w-full min-w-0 rounded-xl border border-input bg-transparent px-3 py-2 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-proof-citron focus-visible:ring-3 focus-visible:ring-proof-citron disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        // PO AC 리뷰 지적(2026-08-23) — rounded-xl(5.6px)이 남아 있었다. §1.1의 "2xl/3xl만
+        // 퇴역"은 일반 규칙이고, §2 input 행의 "크리스프(sm~md)"가 더 구체적인 정본이라
+        // 그쪽을 따라 rounded-md(4px)로.
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-2 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-proof-citron focus-visible:ring-3 focus-visible:ring-proof-citron disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/operator-control.tsx
+++ b/apps/web/src/components/ui/operator-control.tsx
@@ -22,7 +22,9 @@ export function OperatorSelect({ className, ...props }: React.ComponentProps<'se
     <select
       className={cn(
         operatorControlClassName,
-        "h-10 cursor-pointer appearance-none rounded-xl border-border/80 bg-[image:linear-gradient(45deg,transparent_50%,currentColor_50%),linear-gradient(135deg,currentColor_50%,transparent_50%)] bg-[position:calc(100%-18px)_calc(50%-2px),calc(100%-12px)_calc(50%-2px)] bg-[size:6px_6px,6px_6px] bg-no-repeat pr-10 text-foreground shadow-sm hover:border-primary/40 hover:bg-muted/30",
+        // story #2969 §2 PR-3(doc proofline-system-layer-2969) — shadow-sm 제거(§1.2, 이미
+        // border-border/80 hairline이 경계 역할을 겸함).
+        "h-10 cursor-pointer appearance-none rounded-xl border-border/80 bg-[image:linear-gradient(45deg,transparent_50%,currentColor_50%),linear-gradient(135deg,currentColor_50%,transparent_50%)] bg-[position:calc(100%-18px)_calc(50%-2px),calc(100%-12px)_calc(50%-2px)] bg-[size:6px_6px,6px_6px] bg-no-repeat pr-10 text-foreground hover:border-primary/40 hover:bg-muted/30",
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/operator-control.tsx
+++ b/apps/web/src/components/ui/operator-control.tsx
@@ -23,8 +23,10 @@ export function OperatorSelect({ className, ...props }: React.ComponentProps<'se
       className={cn(
         operatorControlClassName,
         // story #2969 §2 PR-3(doc proofline-system-layer-2969) — shadow-sm 제거(§1.2, 이미
-        // border-border/80 hairline이 경계 역할을 겸함).
-        "h-10 cursor-pointer appearance-none rounded-xl border-border/80 bg-[image:linear-gradient(45deg,transparent_50%,currentColor_50%),linear-gradient(135deg,currentColor_50%,transparent_50%)] bg-[position:calc(100%-18px)_calc(50%-2px),calc(100%-12px)_calc(50%-2px)] bg-[size:6px_6px,6px_6px] bg-no-repeat pr-10 text-foreground hover:border-primary/40 hover:bg-muted/30",
+        // border-border/80 hairline이 경계 역할을 겸함). PO AC 리뷰 지적(2026-08-23) —
+        // rounded-xl(5.6px)이 남아 있었다. §2 input 행 "크리스프(sm~md)"가 정본이라
+        // rounded-md(4px)로.
+        "h-10 cursor-pointer appearance-none rounded-md border-border/80 bg-[image:linear-gradient(45deg,transparent_50%,currentColor_50%),linear-gradient(135deg,currentColor_50%,transparent_50%)] bg-[position:calc(100%-18px)_calc(50%-2px),calc(100%-12px)_calc(50%-2px)] bg-[size:6px_6px,6px_6px] bg-no-repeat pr-10 text-foreground hover:border-primary/40 hover:bg-muted/30",
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/sidebar-menu-button-variants.test.tsx
+++ b/apps/web/src/components/ui/sidebar-menu-button-variants.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+//
+// story #2969 §2 PR-3(doc proofline-system-layer-2969) — 활성 메뉴 항목에 시트론 좌측
+// 엣지(border-l-2 border-l-proof-citron). "carbon" 배경 축은 확定 토큰이 없어 이 PR
+// 범위 밖(유나 확認 필요, PR 본문에 플래그) — 여기서는 확定된 시트론 엣지만 고정한다.
+// SidebarProvider 없이 순수 cva 함수만 단위 테스트(sidebar.tsx 전체 마운트는 컨텍스트
+// 의존이 커서 다른 사이드바 테스트들과 동형으로 이 파일에서 격리).
+import { describe, expect, it } from 'vitest';
+import { sidebarMenuButtonVariants } from './sidebar';
+
+describe('sidebarMenuButtonVariants — 시트론 엣지(story #2969 PR-3)', () => {
+  it('기본 상태는 border-l-transparent(레이아웃 시프트 방지 자리 예약)', () => {
+    const classes = sidebarMenuButtonVariants({});
+    expect(classes).toContain('border-l-2');
+    expect(classes).toContain('border-l-transparent');
+  });
+
+  it('활성(data-active) 상태는 border-l-proof-citron으로 색이 들어온다', () => {
+    const classes = sidebarMenuButtonVariants({});
+    expect(classes).toContain('data-active:border-l-proof-citron');
+  });
+});

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -242,7 +242,10 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border"
+          // story #2969 §2 PR-3(doc proofline-system-layer-2969) — floating variant shadow-sm
+          // 제거(§1.2: 인라인 표면은 그림자 대신 라인 — 기존 ring-1 ring-sidebar-border가 이미
+          // 그 hairline 역할을 겸하고 있어 대체 없이 제거만으로 충분).
+          className="flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border"
         >
           {children}
         </div>
@@ -515,7 +518,12 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  // story #2969 §2 PR-3(doc proofline-system-layer-2969) — 활성 항목에 시트론 좌측 엣지
+  // 추가(border-l-2 border-l-proof-citron, alert.tsx/PR-2와 동일 문법). doc의 "carbon"
+  // (활성 배경을 어두운 톤으로) 축은 확定 토큰·값이 없어(globals.css에 "carbon"이라는
+  // 색 토큰 자체가 없음 — 다크 테마 코드네임일 뿐) 이 PR서 추측 구현하지 않는다 — 유나
+  // 확認 필요 사항으로 남김(PR 본문에 플래그).
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md border-l-2 border-l-transparent p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:border-l-proof-citron data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
   {
     variants: {
       variant: {
@@ -752,6 +760,7 @@ export {
   SidebarMenuItem,
   SidebarMenuSkeleton,
   SidebarMenuSub,
+  sidebarMenuButtonVariants,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarProvider,

--- a/apps/web/src/components/ui/tabs.test.tsx
+++ b/apps/web/src/components/ui/tabs.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+//
+// story #2969 §2 PR-3(doc proofline-system-layer-2969) — line variant 활성 언더라인을
+// 시트론으로, default variant 활성 shadow-sm 제거.
+import { describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Tabs, TabsList, TabsTrigger } from './tabs';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function mount(node: React.ReactNode): Promise<{ el: HTMLElement; root: Root }> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => { root.render(node); });
+  return { el: container.firstElementChild as HTMLElement, root };
+}
+
+describe('TabsTrigger — 시트론 언더라인 + shadow 제거(story #2969 PR-3)', () => {
+  it('언더라인 의사요소(after)가 proof-citron이다', async () => {
+    const { el } = await mount(
+      <Tabs defaultValue="a">
+        <TabsList variant="line">
+          <TabsTrigger value="a">A</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+    const trigger = el.querySelector('[data-slot="tabs-trigger"]');
+    expect(trigger?.className).toContain('after:bg-proof-citron');
+    expect(trigger?.className).not.toContain('after:bg-foreground');
+  });
+
+  it('default variant 활성 shadow-sm 클래스가 없다', async () => {
+    const { el } = await mount(
+      <Tabs defaultValue="a">
+        <TabsList variant="default">
+          <TabsTrigger value="a">A</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+    const trigger = el.querySelector('[data-slot="tabs-trigger"]');
+    expect(trigger?.className).not.toContain('data-active:shadow-sm');
+  });
+});

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -58,10 +58,15 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
     <TabsPrimitive.Tab
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        // story #2969 §2 PR-3(doc proofline-system-layer-2969) — default variant 활성
+        // shadow-sm 제거(§1.2, 인라인 표면은 그림자 대신 라인/색 — data-active:bg-background
+        // 대비 자체가 이미 그 축을 맡는다).
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
-        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        // story #2969 §2 PR-3 — "활성=시트론 언더라인"(doc). line variant의 기존 언더라인
+        // 인디케이터(after 의사요소) 색을 foreground→시트론으로.
+        "after:absolute after:bg-proof-citron after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
         className
       )}
       {...props}


### PR DESCRIPTION
## 요약
doc `proofline-system-layer-2969` §2 A행(input/tabs/sidebar/operator-control/member-row). PR-T/PR-1/PR-2(merged)가 깔아둔 토큰/패턴 위에서 작업.

## 변경
| 컴포넌트 | 처방 | 구현 |
|---|---|---|
| `input.tsx` | 크리스프+focus=시트론 | focus-visible 보더/링 시트론(이 컴포넌트 한정). radius는 PR-T 상속, 무편집 |
| `tabs.tsx` | 활성=시트론 언더라인·shadow 제거 | default variant 활성 shadow-sm 제거·line variant 언더라인(after) 색 foreground→시트론 |
| `sidebar.tsx` | 활성=carbon+시트론 엣지·shadow 제거 | floating variant shadow-sm 제거·활성 메뉴 항목 시트론 좌측 엣지(border-l-2) 추가 |
| `operator-control.tsx` | 크리스프·shadow 제거·hairline | OperatorSelect shadow-sm 제거(기존 hairline이 경계 역할 겸함) |
| `member-row.tsx` | 크리스프·행 hairline | 이미 `rounded-md`+`border border-border`로 doc 처방 충족 — **무편집** |

### 의도적으로 안 한 것
- **sidebar 활성 "carbon" 배경** — doc이 "활성=**carbon**+시트론 엣지"라 명시하지만, globals.css에 "carbon"이라는 실제 색 토큰이 없다(다크 테마 코드네임 "Carbon/Fog"일 뿐, §1.2 주석 참고). 시트론 엣지는 확定 구현했으나 carbon 배경은 추측 신설하지 않았다 — 유나 확認 필요 사항으로 남김.

## 부수 변경
- `sidebarMenuButtonVariants`를 export(다른 컴포넌트의 cva들과 동일 관례 — 직접 단위 테스트 가능하게).

## 검증
- [x] 뮤테이션 실측 3건 — input focus·tabs 언더라인·sidebar 엣지 각각 되돌려 RED→원복 GREEN
- [x] `tsc --noEmit` — EXIT 0
- [x] `eslint` — 경고 5개(baseline, 신규 0)
- [x] `vitest run` — 487 files / 4212 tests green(신규 5)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0
- ⚠️ 라이브 3화면 실픽셀 — PR-T/PR-1/PR-2와 동일 경계(배포 후 유나 스윕)

🤖 Generated with Claude Code