### PR TITLE
[SID:2969] sidebar 활성 항목 carbon fill(유나 확定, PR-3 이연분)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -148,6 +148,8 @@
   --font-weight-editorial-claim: 700;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-active-fill: var(--sidebar-active-fill);
+  --color-sidebar-active-fill-foreground: var(--sidebar-active-fill-foreground);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-accent: var(--sidebar-accent);
   --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
@@ -310,6 +312,14 @@
   --sidebar-accent-foreground: var(--proof-ink-2);
   --sidebar-border: var(--proof-line);
   --sidebar-ring: var(--proof-blue);
+
+  /* story #2969 §2 sidebar 행(유나 확定, PR-3 carbon fill 이연분) — 활성 nav 항목 배경은
+     현재 사이트 테마(라이트/다크)와 무관하게 항상 다크 "Carbon" 톤(신규 브랜드색 아님 —
+     다크 테마의 --proof-panel/--proof-ink 값을 그대로 고정 리터럴로 재사용, 시그니처
+     디자인 결정이라 :root에 1회만 선언·.dark에서 재정의하지 않는다 — 테마 전환에도 항상
+     동일). 시트론 좌측 엣지(PR-3, sidebar.tsx)와 조합해 "활성=carbon+시트론 엣지" 완성. */
+  --sidebar-active-fill: #17191C;
+  --sidebar-active-fill-foreground: #F2F4ED;
 
   /* Sprintable brand (blue) — 254/0.17 hue/chroma는 스펙 그대로, L만 0.58→0.56(AA 4.5:1 확保) */
   --brand: oklch(0.56 0.17 254);

--- a/apps/web/src/components/ui/sidebar-menu-button-variants.test.tsx
+++ b/apps/web/src/components/ui/sidebar-menu-button-variants.test.tsx
@@ -1,14 +1,14 @@
 // @vitest-environment jsdom
 //
-// story #2969 §2 PR-3(doc proofline-system-layer-2969) — 활성 메뉴 항목에 시트론 좌측
-// 엣지(border-l-2 border-l-proof-citron). "carbon" 배경 축은 확定 토큰이 없어 이 PR
-// 범위 밖(유나 확認 필요, PR 본문에 플래그) — 여기서는 확定된 시트론 엣지만 고정한다.
+// story #2969 §2 sidebar 행(doc proofline-system-layer-2969) — 활성 메뉴 항목에 시트론
+// 좌측 엣지(PR-3, border-l-2 border-l-proof-citron) + carbon fill(유나 확定, 이 소PR —
+// sidebar-active-fill/-foreground, 테마 무관 고정 다크 톤·"generic shadcn 결" 갈음).
 // SidebarProvider 없이 순수 cva 함수만 단위 테스트(sidebar.tsx 전체 마운트는 컨텍스트
 // 의존이 커서 다른 사이드바 테스트들과 동형으로 이 파일에서 격리).
 import { describe, expect, it } from 'vitest';
 import { sidebarMenuButtonVariants } from './sidebar';
 
-describe('sidebarMenuButtonVariants — 시트론 엣지(story #2969 PR-3)', () => {
+describe('sidebarMenuButtonVariants — 시트론 엣지 + carbon fill(story #2969)', () => {
   it('기본 상태는 border-l-transparent(레이아웃 시프트 방지 자리 예약)', () => {
     const classes = sidebarMenuButtonVariants({});
     expect(classes).toContain('border-l-2');
@@ -18,5 +18,19 @@ describe('sidebarMenuButtonVariants — 시트론 엣지(story #2969 PR-3)', () 
   it('활성(data-active) 상태는 border-l-proof-citron으로 색이 들어온다', () => {
     const classes = sidebarMenuButtonVariants({});
     expect(classes).toContain('data-active:border-l-proof-citron');
+  });
+
+  it('활성 상태는 carbon fill 배경+light 텍스트를 갖는다(유나 확定, generic shadcn 결 갈음)', () => {
+    const classes = sidebarMenuButtonVariants({});
+    expect(classes).toContain('data-active:bg-sidebar-active-fill');
+    expect(classes).toContain('data-active:text-sidebar-active-fill-foreground');
+    expect(classes).not.toContain('data-active:bg-sidebar-accent');
+    expect(classes).not.toContain('data-active:text-sidebar-accent-foreground');
+  });
+
+  it('hover/열림 상태는 여전히 기존 sidebar-accent를 쓴다(활성 상태만 시그니처, 회귀 0)', () => {
+    const classes = sidebarMenuButtonVariants({});
+    expect(classes).toContain('hover:bg-sidebar-accent');
+    expect(classes).toContain('data-open:hover:bg-sidebar-accent');
   });
 });

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -518,12 +518,11 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  // story #2969 §2 PR-3(doc proofline-system-layer-2969) — 활성 항목에 시트론 좌측 엣지
-  // 추가(border-l-2 border-l-proof-citron, alert.tsx/PR-2와 동일 문법). doc의 "carbon"
-  // (활성 배경을 어두운 톤으로) 축은 확定 토큰·값이 없어(globals.css에 "carbon"이라는
-  // 색 토큰 자체가 없음 — 다크 테마 코드네임일 뿐) 이 PR서 추측 구현하지 않는다 — 유나
-  // 확認 필요 사항으로 남김(PR 본문에 플래그).
-  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md border-l-2 border-l-transparent p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:border-l-proof-citron data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  // story #2969 §2 sidebar 행(유나 확定) — 활성 항목="carbon fill"(sidebar-active-fill,
+  // 테마 무관 고정 다크 톤)+시트론 좌측 엣지(PR-3, border-l-2 border-l-proof-citron)+light
+  // 텍스트(sidebar-active-fill-foreground). "generic shadcn 결"이던 bg-sidebar-accent
+  // 갈음을 대체 — hover/열림 상태는 기존 sidebar-accent 그대로(활성 상태만 시그니처).
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md border-l-2 border-l-transparent p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:border-l-proof-citron data-active:bg-sidebar-active-fill data-active:font-medium data-active:text-sidebar-active-fill-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## 요약
doc §2 sidebar 행(유나 확定 2026-08-23, PR-3에서 확定 토큰 없어 이연했던 것) — 활성 nav 항목="다크 Carbon fill"(팔레트 기존 Carbon 톤 별칭, 신규 브랜드색 아님)+시트론 좌측 엣지(既구현, PR-3)+light 텍스트.

## 변경
- 신규 토큰 `--sidebar-active-fill`/`-foreground`: 다크 테마의 `--proof-panel`(#17191C)/`--proof-ink`(#F2F4ED) 값을 그대로 재사용한 고정 리터럴 — 현재 사이트 테마(라이트/다크)와 무관하게 항상 동일(시그니처 디자인 결정이라 `:root`에 1회만 선언, `.dark` 재정의 없음).
- `sidebarMenuButtonVariants`의 `data-active` 배경/텍스트를 `bg-sidebar-accent`(제네릭 shadcn 결)→`bg-sidebar-active-fill`/`text-sidebar-active-fill-foreground`로 교체. hover/열림 상태는 기존 `sidebar-accent` 그대로(활성 상태만 시그니처, 회귀 0).

## 검증
- [x] 뮤테이션 실측 — 되돌려 RED→원복 GREEN
- [x] `tsc --noEmit` — EXIT 0
- [x] `eslint` — 경고 5개(baseline, 신규 0)
- [x] `vitest run` — 490 files / 4218 tests green(신규 2)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0
- ⚠️ 라이브 3화면 실픽셀 — 동일 경계(배포 후 유나 스윕)

🤖 Generated with Claude Code