### PR TITLE
[SID:2969] PR-5 — 보드 type-ramp 적용(재분류) + PR-4 이월 테스트 2건

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
@@ -530,3 +530,17 @@ describe('FlowPageClient — story #2535 지구→대륙→도시 드릴다운',
     expect(container.textContent).toContain(koMessages.flow.ladderName_building);
   });
 });
+
+// story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — TopBar 타이틀=Heading
+// 무게로 재분류(크기는 TopBar 유지·구조 불변).
+describe('FlowPageClient — TopBar 타이틀 Heading 무게(story #2969 PR-5)', () => {
+  it('TopBar 타이틀 h1이 font-extrabold를 갖고 크기(text-sm)는 그대로다', async () => {
+    await renderFlowClient();
+
+    const h1 = container.querySelector('h1');
+    expect(h1).not.toBeNull();
+    expect(h1?.className).toContain('font-extrabold');
+    expect(h1?.className).toContain('text-sm');
+    expect(h1?.className).not.toContain('font-medium');
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -210,7 +210,9 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
 
   return (
     <>
-      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} showContextChip />
+      {/* story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — 재분류(구조·크기 불변):
+          TopBar 타이틀=Heading(무게↑만·크기는 TopBar 유지). */}
+      <TopBarSlot title={<h1 className="text-sm font-extrabold">{t('title')}</h1>} showContextChip />
 
       <div className="space-y-4 p-4">
         {/* story #2930(P0-G) I3 — nav에서 flow+sprints가 「보드」 단일 항목으로 접히며 사라진

--- a/apps/web/src/components/kanban/kanban-column.test.tsx
+++ b/apps/web/src/components/kanban/kanban-column.test.tsx
@@ -75,3 +75,33 @@ describe('KanbanColumn — story #2062 포커스 링 클리핑', () => {
     expect(scrollContainer?.className).toContain('p-1.5');
   });
 });
+
+// story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — 컬럼헤더=소헤딩(Heading
+// 무게로 재분류·크기/sans 불변, 한글이라 caps/mono 금지).
+describe('KanbanColumn — 컬럼헤더 소헤딩(story #2969 PR-5)', () => {
+  it('컬럼헤더가 font-extrabold(Heading 무게)를 갖고 크기(text-xs)는 그대로다', async () => {
+    await act(async () => {
+      root.render(
+        wrap(
+          <KanbanColumn
+            id="backlog"
+            label="백로그"
+            stories={[]}
+            epicMap={{}}
+            memberMap={{}}
+            onStoryClick={vi.fn()}
+          />,
+        ),
+      );
+    });
+
+    const header = container.querySelector('h3');
+    expect(header).not.toBeNull();
+    expect(header?.className).toContain('font-extrabold');
+    expect(header?.className).toContain('text-xs');
+    expect(header?.className).not.toContain('font-semibold');
+    // 한글 라벨 — mono/uppercase/caps 금지(2967 교훈, [[feedback_copy_from_korean_convention]]).
+    expect(header?.className).not.toContain('font-mono');
+    expect(header?.className).not.toContain('uppercase');
+  });
+});

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -162,7 +162,9 @@ export function KanbanColumn({
             </>
           ) : (
             <>
-              <h3 className="flex items-center gap-2 text-xs font-semibold text-foreground">
+              {/* story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — 컬럼헤더=소헤딩
+                  (Heading 무게, sans 유지 — 한글이라 caps/mono 금지). 크기(text-xs)는 불변. */}
+              <h3 className="flex items-center gap-2 text-xs font-extrabold text-foreground">
                 <span className={`size-1.5 shrink-0 rounded-full ${statusColor.dot}`} aria-hidden="true" />
                 {label}
               </h3>

--- a/apps/web/src/components/ui/dropdown-menu.test.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.test.tsx
@@ -5,7 +5,7 @@
 import { describe, expect, it, afterEach } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './dropdown-menu';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSubContent } from './dropdown-menu';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -38,5 +38,29 @@ describe('DropdownMenuContent — --elev-overlay + proof-line-strong(story #2969
     expect(popup?.className).toContain('ring-proof-line-strong');
     expect(popup?.className).not.toContain('ring-foreground/10');
     expect(popup?.className).not.toContain('shadow-md');
+  });
+
+  // 카디르 QA독립검증(PR#3402) — DropdownMenuSubContent가 무테스트였던 커버리지 갭.
+  // PR-5(#3402 이월분)에 편입.
+  it('열린 서브메뉴 팝업도 elev-overlay 그림자와 proof-line-strong 링을 갖는다', async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <DropdownMenu open>
+          <DropdownMenuTrigger>열기</DropdownMenuTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuItem>서브 항목</DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenu>,
+      );
+    });
+    const popup = document.querySelector('[data-slot="dropdown-menu-sub-content"]');
+    expect(popup).not.toBeNull();
+    expect(popup?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(popup?.className).toContain('ring-proof-line-strong');
+    expect(popup?.className).not.toContain('ring-foreground/10');
+    expect(popup?.className).not.toContain('shadow-lg');
   });
 });

--- a/apps/web/src/components/ui/sheet.test.tsx
+++ b/apps/web/src/components/ui/sheet.test.tsx
@@ -37,4 +37,33 @@ describe('SheetContent — --elev-overlay + proof-line-strong(story #2969 PR-4)'
     expect(popup?.className).toContain('border-l-proof-line-strong');
     expect(popup?.className).not.toContain('shadow-lg');
   });
+
+  // 카디르 QA독립검증(PR#3402) — right만 커버해 나머지 3방향(top/bottom/left) 뮤테이션에
+  // 무영향이던 커버리지 갭. PR-5(#3402 이월분)에 편입.
+  it.each(['top', 'bottom', 'left'] as const)(
+    'side=%s도 그 방향의 proof-line-strong 보더를 갖는다(3방 커버리지 보강)',
+    async (side) => {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+      root = createRoot(container);
+      await act(async () => {
+        root.render(
+          <Sheet open>
+            <SheetContent side={side}>
+              <SheetTitle>제목</SheetTitle>
+            </SheetContent>
+          </Sheet>,
+        );
+      });
+      const popup = document.querySelector('[data-slot="sheet-content"]');
+      expect(popup).not.toBeNull();
+      // 시트가 슬라이드해 들어오는 방향의 "반대편"(콘텐츠와 맞닿는 안쪽 모서리)에 hairline이
+      // 선다 — top 시트는 아래쪽(border-b)·bottom 시트는 위쪽(border-t)·left 시트는
+      // 오른쪽(border-r)이 콘텐츠 접면(sheet.tsx의 data-[side=X]:border-* 매핑과 동일).
+      const borderSideClass = side === 'top' ? 'border-b-proof-line-strong'
+        : side === 'bottom' ? 'border-t-proof-line-strong'
+        : 'border-r-proof-line-strong';
+      expect(popup?.className).toContain(borderSideClass);
+    },
+  );
 });


### PR DESCRIPTION
## 요약
doc §1.3-b(유나 확定 2026-08-23) — "헤딩을 얹지 않고 재분류"(구조·레이아웃·크기 불변, 텍스트 표면만 램프 역할에 매핑). 보드(flow) 화면부터 착수(헤딩 슬롯이 명확한 화면).

## 변경
| 표면 | 처방 | 구현 |
|---|---|---|
| TopBar 타이틀 | Heading(무게↑·크기 유지) | `font-medium`→`font-extrabold`, `text-sm` 그대로 |
| 칸반 컬럼헤더 | 소헤딩(sans·weight, 한글 caps 금지) | `font-semibold`→`font-extrabold`, `text-xs` 그대로 |
| 카드 제목(claim) | Claim(600·editorial-claim) | 이미 `font-semibold`(600) — **무편집**(아래 설명) |
| 카드 메타 | Meta(한글=small-sans·color) | 이미 sans+`proof-ink-3` 위계 — **무편집** |

### 의도적으로 안 한 것
- **카드 제목 크기** — doc의 Claim 범위(16~19px)보다 작은 12.5px(`proof-capsule.tsx` CardVariant)를 그대로 유지. 280px폭 다열 칸반의 기존 의도적 축소 설계라, 19px로 올리면 카드가 커져 정보밀도가 무너진다 — 추측으로 깨지 않음.
- **채팅 슬라이스** — 이번 PR은 보드만. §1.3-b는 채팅 매핑도 확定했지만 별도 후속 PR-5 소PR로 분리.

## PR-4(#3402) 이월 테스트 2건 (카디르 QA독립검증, PO 편입 지시)
- `sheet.test.tsx` — `side="right"`만 커버해 나머지 3방향의 `proof-line-strong` 뮤테이션에 무영향이던 갭 → 3방향 전부 테스트 추가.
- `dropdown-menu.test.tsx` — `DropdownMenuSubContent` 무테스트 갭 → elev-overlay/proof-line-strong 검증 테스트 추가.

## 검증
- [x] 뮤테이션 실측 2건 — TopBar 타이틀·컬럼헤더 각각 되돌려 RED→원복 GREEN
- [x] `tsc --noEmit` — EXIT 0
- [x] `eslint` — 경고 5개(baseline, 신규 0)
- [x] `vitest run` — 490 files / 4222 tests green(신규 6)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0
- ⚠️ 라이브 3화면 실픽셀 — 동일 경계(배포 후 유나 스윕)

🤖 Generated with Claude Code