### PR TITLE
[SID:2969] PR-5 채팅 슬라이스 — type-ramp 적용(재분류)

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.test.tsx
@@ -195,3 +195,31 @@ describe('ConversationPage — 헤더 아바타(story #2968)', () => {
     expect(container.querySelector('img')).toBeNull();
   });
 });
+
+// story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — 헤더 상대명/방이름=Claim(600)
+// 로 재분류(구조·크기 불변).
+describe('ConversationPage — 헤더 타이틀 Claim 무게(story #2969 PR-5)', () => {
+  it('DM 헤더 타이틀이 font-semibold(Claim 무게)를 갖는다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/conversations/conv-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            title: null, type: 'dm', muted: false, lastReadAt: null, freeResponse: false,
+            participants: [
+              { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+              { member_id: 'them-1', name: '유나', avatar_url: null, type: 'human' },
+            ],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    await mount();
+
+    const titleEl = [...container.querySelectorAll('span')].find((el) => el.textContent === '유나');
+    expect(titleEl).not.toBeUndefined();
+    expect(titleEl?.className).toContain('font-semibold');
+    expect(titleEl?.className).not.toContain('font-medium');
+  });
+});

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -255,11 +255,13 @@ export default function ConversationPage() {
                 className="group/title flex min-w-0 items-center gap-1"
                 aria-label="방 이름 편집"
               >
-                <span className="min-w-0 truncate text-sm font-medium text-foreground">{headerTitle}</span>
+                {/* story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — 헤더 상대명/
+                    방이름=Claim(600)로 재분류(리스트 대화명과 동일 처방, 구조·크기 불변). */}
+                <span className="min-w-0 truncate text-sm font-semibold text-foreground">{headerTitle}</span>
                 <Pencil className="size-3 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/title:opacity-100" aria-hidden />
               </button>
             ) : (
-              <span className="min-w-0 truncate text-sm font-medium text-foreground">{headerTitle}</span>
+              <span className="min-w-0 truncate text-sm font-semibold text-foreground">{headerTitle}</span>
             )}
           </div>
         }

--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -285,3 +285,23 @@ describe('ChatListView — SSE 재연결·백그라운드 복귀 재fetch (story
     expect(countMyConversationsFetchCalls(fetchMock)).toBe(beforeCount);
   });
 });
+
+// story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — 대화명=Claim(600)로 재분류
+// (구조·크기 불변, preview는 이미 Body-small 부합이라 무편집).
+describe('ChatListView — 대화명 Claim 무게(story #2969 PR-5)', () => {
+  it('대화명이 font-semibold(Claim 무게)를 갖는다', async () => {
+    stubFetchWithConversations([{
+      id: 'conv-dm-1', type: 'dm', title: '유나',
+      latest_message: null, updated_at: '2026-08-23T00:00:00Z', unread_count: 0,
+      participants: [
+        { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+        { member_id: 'them-1', name: '유나', avatar_url: null, type: 'human' },
+      ],
+    }]);
+    await mount();
+    const nameEl = [...container.querySelectorAll('span')].find((el) => el.textContent === '유나');
+    expect(nameEl).not.toBeUndefined();
+    expect(nameEl?.className).toContain('font-semibold');
+    expect(nameEl?.className).not.toContain('font-medium');
+  });
+});

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -190,7 +190,10 @@ function ConversationRow({
       {/* Info */}
       <div className="min-w-0 flex-1">
         <div className="flex items-center justify-between gap-1">
-          <span className="truncate text-sm font-medium text-foreground">{displayName}</span>
+          {/* story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — 대화명=Claim(600)로
+              재분류(구조·크기 불변). preview는 이미 text-xs+muted+기본무게(400)라 Body-small
+              규칙에 이미 부합 — 무편집. */}
+          <span className="truncate text-sm font-semibold text-foreground">{displayName}</span>
           <span className="flex-shrink-0 text-[10px] text-muted-foreground">{formatTime(time)}</span>
         </div>
         {participantLayer}
@@ -233,7 +236,8 @@ function OutsideProjectRow({
         {conv.type === 'dm' ? <MessageSquare className="h-4 w-4" /> : <Users className="h-4 w-4" />}
       </div>
       <div className="min-w-0 flex-1">
-        <span className="truncate text-sm font-medium text-foreground">{displayName}</span>
+        {/* story #2969 §1.3-b(PR-5) — 대화명=Claim(600), ConversationRow와 동일 처방. */}
+        <span className="truncate text-sm font-semibold text-foreground">{displayName}</span>
         {/* ⭐AC③ — 프로젝트명 병기("왜 여기 있지"를 그 자리서 답한다) */}
         <p className="truncate text-xs text-muted-foreground">{conv.project_name}</p>
       </div>


### PR DESCRIPTION
## 요약
doc §1.3-b(유나 확定 2026-08-23) 채팅 매핑. 보드(#3404)에 이어 채팅 화면.

## 변경
| 표면 | 처방 | 구현 |
|---|---|---|
| 대화명(리스트) | Claim(600) | `ConversationRow`/`OutsideProjectRow` — `font-medium`→`font-semibold` |
| 미리보기 | Body-small(muted) | 이미 `text-xs`+muted+기본무게(400) — **무편집** |
| 헤더 상대명/방이름 | Heading/Claim | Claim(600) 채택 — 리스트-헤더 간 동일 콘텐츠 tier 일관성. `font-medium`→`font-semibold`(두 표시 span 모두) |
| 메시지 본문 | Body | 이미 `text-sm`+기본무게(400) — **무편집** |

### 의도적으로 안 한 것
- **편집 인풋(rename 필드)** — 폼 컨트롤이라 텍스트 재분류 범위 밖.
- **메시지 본문 크기** — doc의 Body(17px/1.72)로 올리면 메시지 밀도가 무너진다(카드 제목 크기와 동일한 긴장) — 추측으로 안 건드림.

## 검증
- [x] 뮤테이션 실측 2건 — 대화명·헤더타이틀 각각 되돌려 RED→원복 GREEN
- [x] `tsc --noEmit` — EXIT 0
- [x] `eslint` — 경고 5개(baseline, 신규 0)
- [x] `vitest run` — 490 files / 4220 tests green(신규 2)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0
- ⚠️ 라이브 3화면 실픽셀 — 동일 경계(배포 후 유나 스윕)

🤖 Generated with Claude Code