### PR TITLE
[SID:2969] PR-6 — 유틸 4종 크리스프화+에디토리얼·데드코드 처분·이월 테스트 2건

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.test.tsx
@@ -222,4 +222,30 @@ describe('ConversationPage — 헤더 타이틀 Claim 무게(story #2969 PR-5)',
     expect(titleEl?.className).toContain('font-semibold');
     expect(titleEl?.className).not.toContain('font-medium');
   });
+
+  // 카디르 QA독립검증(PR#3405) — PR-5 신규 테스트가 DM(plain span)만 렌더해 group(editable
+  // 버튼 분기)의 동일 처방이 무테스트였던 갭. PR-6(#3405 이월분)에 편입.
+  it('group 방이름(편집 가능 버튼 분기)도 font-semibold(Claim 무게)를 갖는다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/conversations/conv-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            title: '팀 채널', type: 'group', muted: false, lastReadAt: null, freeResponse: false,
+            participants: [
+              { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+              { member_id: 'them-1', name: '유나', avatar_url: null, type: 'human' },
+            ],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    await mount();
+
+    const titleEl = [...container.querySelectorAll('span')].find((el) => el.textContent === '팀 채널');
+    expect(titleEl).not.toBeUndefined();
+    expect(titleEl?.className).toContain('font-semibold');
+    expect(titleEl?.className).not.toContain('font-medium');
+  });
 });

--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -304,4 +304,15 @@ describe('ChatListView — 대화명 Claim 무게(story #2969 PR-5)', () => {
     expect(nameEl?.className).toContain('font-semibold');
     expect(nameEl?.className).not.toContain('font-medium');
   });
+
+  // 카디르 QA독립검증(PR#3405) — PR-5가 ConversationRow만 커버해 OutsideProjectRow의 동일
+  // 처방(§1.3-b)이 무테스트였던 갭. PR-6(#3405 이월분)에 편입.
+  it('"다른 프로젝트" 항목의 대화명도 font-semibold(Claim 무게)를 갖는다', async () => {
+    stubFetch([OUTSIDE_CONV]);
+    await mount();
+    const nameEl = [...container.querySelectorAll('span')].find((el) => el.textContent === '댄군과의 대화');
+    expect(nameEl).not.toBeUndefined();
+    expect(nameEl?.className).toContain('font-semibold');
+    expect(nameEl?.className).not.toContain('font-medium');
+  });
 });

--- a/apps/web/src/components/kanban/kanban-trust-column.test.tsx
+++ b/apps/web/src/components/kanban/kanban-trust-column.test.tsx
@@ -204,3 +204,26 @@ describe('KanbanTrustColumn — 인라인 컴포저(story #2949)', () => {
     expect(container.querySelector('button[aria-label="스토리 추가"]')).toBeNull();
   });
 });
+
+// story #2969 §1.3-b(doc proofline-system-layer-2969, PR-6) — 유나 실픽셀 갭 fix:
+// kanban-column.tsx(클래식 축)만 하고 이 컴포넌트(6단계 신뢰축=기본 보드 화면)를
+// 놓쳤던 것. 컬럼헤더=소헤딩(Heading 무게), 크기/sans 불변.
+describe('KanbanTrustColumn — 컬럼헤더 소헤딩(story #2969 PR-6)', () => {
+  it('컬럼헤더가 font-extrabold(Heading 무게)를 갖고 크기(text-xs)는 그대로다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <KanbanTrustColumn
+          id="queued" label="대기" locked={false} stories={[]}
+          epicMap={{}} memberMap={{}} onStoryClick={() => {}}
+        />,
+      ));
+    });
+    const header = container.querySelector('h3');
+    expect(header).not.toBeNull();
+    expect(header?.className).toContain('font-extrabold');
+    expect(header?.className).toContain('text-xs');
+    expect(header?.className).not.toContain('font-semibold');
+    expect(header?.className).not.toContain('font-mono');
+    expect(header?.className).not.toContain('uppercase');
+  });
+});

--- a/apps/web/src/components/kanban/kanban-trust-column.tsx
+++ b/apps/web/src/components/kanban/kanban-trust-column.tsx
@@ -137,7 +137,10 @@ export function KanbanTrustColumn({
       }`}
     >
       <div className="mb-3 flex items-center justify-between gap-2">
-        <h3 className="flex items-center gap-2 text-xs font-semibold text-foreground">
+        {/* story #2969 §1.3-b(doc proofline-system-layer-2969, PR-6) — 유나 실픽셀 갭 fix:
+            kanban-column.tsx(클래식 축)만 하고 이 파일(6단계 신뢰축=기본 보드 화면)을
+            놓쳤던 것. 컬럼헤더=소헤딩(Heading 무게), 크기(text-xs)·sans 불변. */}
+        <h3 className="flex items-center gap-2 text-xs font-extrabold text-foreground">
           <span className={`size-1.5 shrink-0 rounded-full ${dotClass}`} aria-hidden="true" />
           {label}
           {locked && <Lock className="size-3 text-muted-foreground" aria-hidden="true" />}

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -14,7 +14,9 @@ export function EmptyState({
   className?: string;
 }) {
   return (
-    <div className={cn('rounded-2xl bg-muted/50 px-6 py-10 text-center', className)}>
+    // story #2969 §2 C행(doc proofline-system-layer-2969, PR-6) — rounded-2xl(§1.1 "카드·
+    // 인라인 표면에서 퇴역")→rounded-lg(4px)로 크리스프화.
+    <div className={cn('rounded-lg bg-muted/50 px-6 py-10 text-center', className)}>
       <div className="mx-auto max-w-md space-y-3">
         {icon ? <div className="mb-3 flex justify-center text-muted-foreground">{icon}</div> : null}
         <h3 className="text-base font-semibold tracking-tight text-foreground">{title}</h3>

--- a/apps/web/src/components/ui/page-header.test.tsx
+++ b/apps/web/src/components/ui/page-header.test.tsx
@@ -17,7 +17,11 @@ async function mount(node: React.ReactNode): Promise<{ el: HTMLElement; root: Ro
   return { el: container.firstElementChild as HTMLElement, root };
 }
 
-const ORIGINAL_TITLE_CLASSES = 'font-heading text-2xl font-bold tracking-tight text-foreground md:text-3xl';
+// story #2969 §1.3/§2 C행(PR-6) 갱신 — Display tier 적용: font-bold(700)→
+// --font-weight-editorial-heading(820, 인라인 style — font-editorial-heading 유틸리티가
+// tailwind-merge와 충돌해 font-heading을 지우는 것 회피, page-header.test.tsx 참고)·
+// tracking-tight→tracking-[-0.02em](§1.3 Display 정의 그대로).
+const ORIGINAL_TITLE_CLASSES = 'font-heading text-2xl tracking-[-0.02em] text-foreground md:text-3xl';
 
 function classSet(s: string): Set<string> {
   return new Set(s.split(/\s+/).filter(Boolean));
@@ -28,6 +32,14 @@ describe('PageHeader size variant (story #2879)', () => {
     const { el } = await mount(<PageHeader title="제목" />);
     const h1 = el.querySelector('h1')!;
     expect(classSet(h1.className)).toEqual(classSet(ORIGINAL_TITLE_CLASSES));
+  });
+
+  // story #2969 §1.3(PR-6) — Display tier 무게(820)가 인라인 style로 걸린다(tailwind-merge
+  // 충돌 회피, 위 주석 참고).
+  it('h1이 --font-weight-editorial-heading을 인라인 font-weight로 갖는다', async () => {
+    const { el } = await mount(<PageHeader title="제목" />);
+    const h1 = el.querySelector('h1')! as HTMLElement;
+    expect(h1.style.fontWeight).toBe('var(--font-weight-editorial-heading)');
   });
 
   it('size=page가 기존과 동일하다', async () => {

--- a/apps/web/src/components/ui/page-header.tsx
+++ b/apps/web/src/components/ui/page-header.tsx
@@ -22,7 +22,17 @@ import { cn } from '@/lib/utils';
  *     쓰거나 아예 안 쓴다.
  * 새 화면을 만들 때 이 표를 참고해 딱 하나만 고른다(dual-header 방지).
  */
-const pageHeaderVariants = cva('font-heading font-bold tracking-tight text-foreground', {
+// story #2969 §1.3/§2 C행(doc proofline-system-layer-2969, PR-6) — Display tier(에디토리얼
+// 디스플레이 타이포) 적용: font-bold(700)→--font-weight-editorial-heading(820)·
+// tracking-tight→-0.02em(§1.3 Display 정의 그대로). ⚠️무게는 `font-editorial-heading`
+// 유틸리티 클래스가 아니라 인라인 style로 건다 — tailwind-merge가 `font-heading`(폰트
+// 패밀리)과 `font-editorial-heading`(무게)을 같은 충돌군으로 오인해 하나를 지운다(직접
+// 실측: twMerge('font-heading font-editorial-heading') === 'font-editorial-heading',
+// font-heading이 조용히 사라짐). §1.4가 이 파일의 "히어로 판"에 proof-cut도 요구하지만,
+// 이 컴포넌트는 현재 배경/패딩이 없는 순수 타이포 블록이라(panel이 아님) cut이 보일
+// 표면 자체가 없다 — bg/padding을 새로 지어 넣는 것은 구조 추가라 추측 구현하지 않음
+// (유나 확認 필요 사항으로 남김).
+const pageHeaderVariants = cva('font-heading tracking-[-0.02em] text-foreground', {
   variants: {
     size: {
       page: 'text-2xl md:text-3xl',
@@ -46,7 +56,12 @@ export function PageHeader({ eyebrow, title, description, actions, className, si
     <section className={cn('flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between', className)}>
       <div className="space-y-1.5">
         {eyebrow ? <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">{eyebrow}</div> : null}
-        <h1 className={cn(pageHeaderVariants({ size }))}>{title}</h1>
+        <h1
+          className={cn(pageHeaderVariants({ size }))}
+          style={{ fontWeight: 'var(--font-weight-editorial-heading)' }}
+        >
+          {title}
+        </h1>
         {description ? <p className="max-w-2xl text-sm text-muted-foreground">{description}</p> : null}
       </div>
       {actions ? <div className="flex flex-wrap items-center gap-3">{actions}</div> : null}

--- a/apps/web/src/components/ui/route-error-state.tsx
+++ b/apps/web/src/components/ui/route-error-state.tsx
@@ -25,7 +25,11 @@ export function RouteErrorState({
 
   return (
     <div className={`flex items-center justify-center ${compact ? 'min-h-[50vh]' : 'min-h-screen bg-background'}`}>
-      <div className={`space-y-4 rounded-2xl bg-card text-center shadow-lg ${compact ? 'w-full max-w-lg border p-6' : 'w-full max-w-sm p-8'}`}>
+      {/* story #2969 §2 C행(doc proofline-system-layer-2969, PR-6) — rounded-2xl→rounded-lg
+          (§1.1 퇴역). 이 표면은 인라인(오버레이 아님·portal/backdrop 없음)이라 shadow-lg
+          제거(§1.2, doc 요약행 "route-error(인라인이면 제거)") — border(compact variant는
+          이미 있음)만으로 경계. */}
+      <div className={`space-y-4 rounded-lg bg-card text-center ${compact ? 'w-full max-w-lg border p-6' : 'w-full max-w-sm border p-8'}`}>
         <div className="space-y-2">
           <p className={`${compact ? 'text-base' : 'text-lg'} font-semibold text-foreground`}>
             {title ?? t('error')}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -709,38 +709,6 @@ function SidebarMenuSubItem({
   )
 }
 
-function SidebarMenuSubButton({
-  render,
-  size = "md",
-  isActive = false,
-  className,
-  ...props
-}: useRender.ComponentProps<"a"> &
-  React.ComponentProps<"a"> & {
-    size?: "sm" | "md"
-    isActive?: boolean
-  }) {
-  return useRender({
-    defaultTagName: "a",
-    props: mergeProps<"a">(
-      {
-        className: cn(
-          "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
-          className
-        ),
-      },
-      props
-    ),
-    render,
-    state: {
-      slot: "sidebar-menu-sub-button",
-      sidebar: "menu-sub-button",
-      size,
-      active: isActive,
-    },
-  })
-}
-
 export {
   Sidebar,
   SidebarContent,
@@ -760,7 +728,6 @@ export {
   SidebarMenuSkeleton,
   SidebarMenuSub,
   sidebarMenuButtonVariants,
-  SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarProvider,
   SidebarRail,


### PR DESCRIPTION
## 요약
doc §2 C행(empty-state/route-error-state/skeleton/page-header)·§1.3. **2969 시스템 층 마지막 조각.**

## 변경
| 대상 | 처방 | 구현 |
|---|---|---|
| `empty-state.tsx` | 크리스프(대반경 퇴역) | `rounded-2xl`→`rounded-lg` |
| `route-error-state.tsx` | 크리스프·인라인이면 shadow 제거 | `rounded-2xl`→`rounded-lg`·`shadow-lg` 제거+양쪽 variant에 `border` 추가(hairline) |
| `skeleton.tsx` | 콘텐츠 반경과 정렬 | 이미 `rounded-md`/`rounded-full` — **무편집** |
| `page-header.tsx` | 에디토리얼 디스플레이 타이포 | Display tier(무게 820·tracking -0.02em) 적용 |

### 발견한 버그(page-header.tsx) — tailwind-merge 충돌
`font-editorial-heading` 유틸리티 클래스를 `font-heading`과 같은 문자열에 쓰면, tailwind-merge가 폰트-패밀리와 폰트-무게 클래스를 같은 충돌군으로 오인해 `font-heading`을 조용히 지운다(직접 실측: `twMerge('font-heading font-editorial-heading') === 'font-editorial-heading'`). 인라인 `style={{ fontWeight: 'var(--font-weight-editorial-heading)' }}`로 회피.

### 의도적으로 안 한 것
- **page-header.tsx의 "히어로 판" proof-cut**(§1.4) — 이 컴포넌트는 배경/패딩 없는 순수 타이포 블록이라(panel 아님) cut이 보일 표면 자체가 없다. bg/padding을 새로 지어 넣는 것은 구조 추가라 추측 구현하지 않음 — 유나 확認 필요.
- **`SidebarMenuSub`/`SidebarMenuSubItem`** — grep 실측상 이 둘도 `sidebar.tsx` 밖 소비처 0이지만, 이번엔 `SidebarMenuSubButton`만 명시 지목됐으므로 스코프 밖으로 남김(추가 발견 사항으로 플래그).

## SidebarMenuSubButton 데드코드 처분
grep 실측 — `sidebar.tsx` 밖 소비처 0(정의+export만). 함수+export 제거.

## 카디르 QA독립검증 이월 테스트 2건 (PR#3405, PO 편입 지시)
- `chat-list-view.test.tsx` — `OutsideProjectRow`의 대화명 Claim(`font-semibold`) 무테스트 갭 → 전용 테스트 추가.
- `[conversation_id]/page.test.tsx` — group(editable 버튼 분기)의 헤더 타이틀 Claim 무테스트 갭 → 전용 테스트 추가.

## 검증
- [x] 뮤테이션 실측 3건 — page-header 무게·chat 대화명·헤더타이틀 각각 되돌려 RED→원복 GREEN
- [x] `tsc --noEmit` — EXIT 0
- [x] `eslint` — 경고 5개(baseline, 신규 0)
- [x] `vitest run` — 490 files / 4229 tests green(신규 5)
- [x] `pnpm build` — EXIT 0
- [x] `verify:*` 18종 전수 — EXIT 0
- ⚠️ 라이브 3화면 실픽셀 — 동일 경계(배포 후 유나 스윕)

🤖 Generated with Claude Code