### PR TITLE
[SID:2973] design/QA 게이트 라벨 판정 — 웹훅 페이로드 대신 gh api 라이브 재조회

### DIFF
--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -132,7 +132,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          LABELS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --paginate --jq '[.[].name]')"
+          LABELS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --paginate --slurp | jq '[.[][] | .name]')"
           echo "live labels: ${LABELS_JSON}"
           echo "has_design_pass=$(echo "${LABELS_JSON}" | jq 'index("design:pass") != null')" >> "$GITHUB_OUTPUT"
           echo "has_design_changes=$(echo "${LABELS_JSON}" | jq 'index("design:changes") != null')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -115,6 +115,28 @@ jobs:
             echo "No changed file matches the design-review path list — this PR is out of this gate's scope (not a skip: it was evaluated and found empty)."
           fi
 
+      # story #2973(미르코 그라운딩, 2026-08-23) — `github.event.pull_request.labels`는
+      # 이 워크플로를 트리거한 그 웹훅 «페이로드 스냅샷»이다(라이브 조회가 아니다). QA·
+      # Design 두 리뷰어가 근접한 시각에 각자 라벨을 달면, 먼저 도착한 labeled 이벤트의
+      # job이 "그 시점 페이로드"(상대 라벨이 아직 안 실린)만 보고 HAS_*_PASS=false로
+      # 잘못 실패한다(실측: #3399 08:40:39 실패 run 로그 — "형제 run 미완" 판정이 아니라
+      # 이 레이스였다. #3391도 동일 뿌리 — rerun이 같은 스테일 페이로드로 재생돼 "GH가
+      # rerun을 거부"로 보이는 증상까지 설명한다). 처방: 판정 자체를 이벤트 페이로드가
+      # 아니라 `gh api`로 "지금 이 순간의" 라벨을 라이브 재조회해서 낸다 — 대기-폴링(그래도
+      # 타임아웃 전에 실패할 여지가 남는다)이 아니라, 판정 시점의 진짜 상태를 본다.
+      - name: Fetch live PR labels (avoid stale webhook-payload race — story #2973)
+        if: steps.scope.outputs.in_scope == 'true'
+        id: live_labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          LABELS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --paginate --jq '[.[].name]')"
+          echo "live labels: ${LABELS_JSON}"
+          echo "has_design_pass=$(echo "${LABELS_JSON}" | jq 'index("design:pass") != null')" >> "$GITHUB_OUTPUT"
+          echo "has_design_changes=$(echo "${LABELS_JSON}" | jq 'index("design:changes") != null')" >> "$GITHUB_OUTPUT"
+
       # ⭐유나신 지적(2026-07-31) — design:changes 라벨 설명은 "design:pass로 바뀌기 前에는
       # 머지하지 않는다"고 약속하는데, 그 약속을 지키는 코드가 아무것도 없었다(가드는
       # design:pass «존재»만 본다). design:pass와 design:changes가 같이 붙어 있으면(수정
@@ -124,7 +146,7 @@ jobs:
       - name: Enforce design:changes blocks merge (unconditional — regardless of design:pass)
         if: steps.scope.outputs.in_scope == 'true'
         env:
-          HAS_DESIGN_CHANGES: ${{ contains(github.event.pull_request.labels.*.name, 'design:changes') }}
+          HAS_DESIGN_CHANGES: ${{ steps.live_labels.outputs.has_design_changes }}
         run: |
           set -euo pipefail
           if [ "${HAS_DESIGN_CHANGES}" = "true" ]; then
@@ -138,7 +160,7 @@ jobs:
       - name: Enforce design:pass label when in scope
         if: steps.scope.outputs.in_scope == 'true'
         env:
-          HAS_DESIGN_PASS: ${{ contains(github.event.pull_request.labels.*.name, 'design:pass') }}
+          HAS_DESIGN_PASS: ${{ steps.live_labels.outputs.has_design_pass }}
         run: |
           set -euo pipefail
           if [ "${HAS_DESIGN_PASS}" = "true" ]; then

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -110,7 +110,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          LABELS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --paginate --jq '[.[].name]')"
+          LABELS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --paginate --slurp | jq '[.[][] | .name]')"
           echo "live labels: ${LABELS_JSON}"
           echo "has_qa_pass=$(echo "${LABELS_JSON}" | jq 'index("qa:pass") != null')" >> "$GITHUB_OUTPUT"
           echo "has_qa_changes=$(echo "${LABELS_JSON}" | jq 'index("qa:changes") != null')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -94,12 +94,33 @@ jobs:
         with:
           fetch-depth: 0
 
+      # story #2973(미르코 그라운딩, 2026-08-23) — `github.event.pull_request.labels`는
+      # 이 워크플로를 트리거한 그 웹훅 «페이로드 스냅샷»이다(라이브 조회가 아니다). QA·
+      # Design 두 리뷰어가 근접한 시각에 각자 라벨을 달면, 먼저 도착한 labeled 이벤트의
+      # job이 "그 시점 페이로드"(상대 라벨이 아직 안 실린)만 보고 HAS_*_PASS=false로
+      # 잘못 실패한다(실측: #3399 08:40:39 실패 run 로그 — "형제 run 미완" 판정이 아니라
+      # 이 레이스였다. #3391도 동일 뿌리 — rerun이 같은 스테일 페이로드로 재생돼 "GH가
+      # rerun을 거부"로 보이는 증상까지 설명한다). 처방: 판정 자체를 이벤트 페이로드가
+      # 아니라 `gh api`로 "지금 이 순간의" 라벨을 라이브 재조회해서 낸다 — 대기-폴링(그래도
+      # 타임아웃 전에 실패할 여지가 남는다)이 아니라, 판정 시점의 진짜 상태를 본다.
+      - name: Fetch live PR labels (avoid stale webhook-payload race — story #2973)
+        id: live_labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          LABELS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --paginate --jq '[.[].name]')"
+          echo "live labels: ${LABELS_JSON}"
+          echo "has_qa_pass=$(echo "${LABELS_JSON}" | jq 'index("qa:pass") != null')" >> "$GITHUB_OUTPUT"
+          echo "has_qa_changes=$(echo "${LABELS_JSON}" | jq 'index("qa:changes") != null')" >> "$GITHUB_OUTPUT"
+
       # ⭐design-review-gate.yml과 대칭(유나신 지적, 2026-07-31) — qa:changes가 열려 있으면
       # qa:pass 유무와 무관하게 무조건 빨강. 두 changes 라벨이 기계적으로 배타가 되어 changes
       # 라벨도 "하는 일"이 생긴다(전엔 설명뿐이었다).
       - name: Enforce qa:changes blocks merge (unconditional — regardless of qa:pass)
         env:
-          HAS_QA_CHANGES: ${{ contains(github.event.pull_request.labels.*.name, 'qa:changes') }}
+          HAS_QA_CHANGES: ${{ steps.live_labels.outputs.has_qa_changes }}
         run: |
           set -euo pipefail
           if [ "${HAS_QA_CHANGES}" = "true" ]; then
@@ -112,7 +133,7 @@ jobs:
       # 떼면 이 스텝이 다시 돌아 빨강으로 되돌아간다. ⛔경로 필터 없음 — 모든 PR에 적용(AC2).
       - name: Enforce qa:pass label (no path scoping — applies to every PR)
         env:
-          HAS_QA_PASS: ${{ contains(github.event.pull_request.labels.*.name, 'qa:pass') }}
+          HAS_QA_PASS: ${{ steps.live_labels.outputs.has_qa_pass }}
         run: |
           set -euo pipefail
           if [ "${HAS_QA_PASS}" = "true" ]; then


### PR DESCRIPTION
## 요약
그라운딩(실측, #3399 08:40:39 실패 run 로그) — PO 초기 서술("형제 run 미완을 fail-closed로 오판")과 달리, 형제 게이트 제외 필터(candidate①)는 이미 양쪽 yml에 구현돼 있었다. 진짜 기전: `github.event.pull_request.labels`는 이 워크플로를 트리거한 웹훅 **페이로드 스냅샷**이지 라이브 조회가 아니다 — QA·Design 두 리뷰어가 근접한 시각에 각자 라벨을 달면, 먼저 도착한 labeled 이벤트의 job이 "그 시점 페이로드"(상대 라벨 미포함)만 보고 `HAS_DESIGN_PASS=false`로 잘못 실패한다. **#3391의 "rerun도 GH가 거부" 증상도 동일 뿌리** — rerun이 같은 스테일 페이로드를 재생하니 다시 실패한다.

## 처방
`qa:pass`/`qa:changes`/`design:pass`/`design:changes` 판정을 이벤트 페이로드(`contains(github.event.pull_request.labels.*.name, ...)`) 대신 `gh api repos/.../issues/{n}/labels`로 그 순간 라이브 재조회한 값으로 낸다 — 대기-폴링(그래도 타임아웃 전 실패 여지가 남음)이 아니라, 판정 시점의 진짜 상태를 본다. 신선도 가드(라벨 부착 시각 vs 최신 커밋 시각)는 이미 API 조회였으므로 무변경.

## 검증
- [x] YAML 문법 — `python3 yaml.safe_load` 양쪽 파일 OK
- [x] jq 불리언 로직 — 로컬 실행으로 기존 `contains()` 출력 형태(`true`/`false`)와 대조 확認
- [x] `gh api` 엔드포인트 실측 — 실 PR(#3406)에 라이브 호출해 `["design:pass","qa:pass"]` 정확 반환 확認
- [x] 권한 — 새 `gh api` 호출은 `issues/{n}/...` 하위 자원이라, 같은 워크플로의 기존 freshness 스텝(`issues/{n}/events`)이 이미 `pull-requests: read`만으로 동작 검증된 것과 동일 권한 범위 — permissions 블록 변경 불요
- ⚠️ AC1(실 PR 라이브 검증)은 이 PR 자체에 대한 실제 리뷰어 라벨 부착으로 관찰 예정(경합 재현은 근접 타이밍이 필요해 단위 테스트로 인위 재현하지 않음)
- AC3(#3391 rerun 케이스) — 이 fix 이후 판정은 트리거 이벤트가 무엇이었든(rerun 포함) 항상 "지금" 라벨을 다시 읽으므로, 스테일 페이로드 재생 자체가 구조적으로 불가능해진다

🤖 Generated with Claude Code