### PR TITLE
[SID:2978] 결재 상세 스크롤 불가 — CutCornerShell shrink-0 (flex overflow-hidden 자동최소크기=0)

### DIFF
--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -53,6 +53,21 @@ describe('ProofCapsule (density variants)', () => {
       expect(markup).toContain('proof-cut');
     }
   });
+
+  it('regression #2978 — CutCornerShell never compresses below content height in a vertical flex chain (shrink-0 alongside overflow-hidden)', () => {
+    // 선생님 실사용 발견 — /gates/[id] 상세가 overflow-y-auto 조상 안에서 뷰포트가 좁으면
+    // 스크롤이 원천 봉쇄됐다. 원인: overflow-hidden인 flex item의 CSS 스펙상 automatic
+    // minimum size가 0이라, shrink-0 없이는 셸이 내용 실제 높이보다 찌그러들며 잘림을
+    // overflow-hidden이 감춰 조상 스크롤러가 넘침을 못 본다.
+    // ⚠️row/audit 밀도는 셸 내부 아이콘 span 등에 무관한 shrink-0가 이미 있어 단순
+    // `.toContain('shrink-0')`는 이 fix와 무관하게도 통과하는 약한 assert가 된다 — 반드시
+    // CutCornerShell 자신의 리터럴 클래스 조합("proof-cut flex shrink-0")으로 특정한다
+    // (mutation-검증: shrink-0 제거 시 이 assert만 RED, 위 span들은 무관).
+    for (const density of ['full', 'card', 'row'] as const) {
+      const markup = renderWithIntl(<ProofCapsule {...BASE} density={density} />);
+      expect(markup).toContain('proof-cut flex shrink-0');
+    }
+  });
 });
 
 describe('ProofCapsule (4 proof states — 색만으로 의미 전달 금지, stateLabel 텍스트 항상 병기)', () => {

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -125,9 +125,16 @@ function CutCornerShell({ state, cut, className, children }: { state: ProofState
   // story #2955 §5 — 지오메트리 계산은 globals.css의 `.proof-cut`(단일 정본)에 위임하고,
   // 이 컴포넌트는 `--proof-cut`만 오버라이드한다(24/16 두 호출부 그대로 — 값-SSOT는 여기가
   // 아니라 CSS에 있다).
+  // story #2978(선생님 실사용 발견) — 이 셸의 `overflow-hidden`은 CSS flexbox 스펙상 자신의
+  // "automatic minimum size"를 0으로 만든다(overflow!=visible인 flex item의 스펙 규칙). 즉
+  // 세로 flex 체인(예: /gates/[id] 상세 뷰의 dashboard-shell overflow-y-auto 스크롤러 하위)
+  // 안에서 뷰포트가 좁으면 이 셸이 컨텐츠 실제 높이보다 더 작게 "찌그러들며" 잘림을
+  // overflow-hidden이 감춰버려 — 조상 스크롤러가 scrollHeight>clientHeight를 못 보고
+  // 스크롤이 원천 봉쇄된다. shrink-0으로 자기 내용 실제 높이를 지키면 초과분이 정상적으로
+  // 조상 체인을 타고 올라가 진짜 스크롤러에서 스크롤 가능해진다(컷코너·헤어라인 결 무변경).
   return (
     <div
-      className={cn('proof-cut flex overflow-hidden rounded-[6px] border border-proof-line bg-proof-panel', className)}
+      className={cn('proof-cut flex shrink-0 overflow-hidden rounded-[6px] border border-proof-line bg-proof-panel', className)}
       style={{ '--proof-cut': `${cut}px` } as React.CSSProperties}
     >
       <Proofline state={state} />


### PR DESCRIPTION
## 요약
선생님 실사용 발견(2026-08-23 21:18)·PO 재현 확定(뷰포트 500px, `scrollHeight=clientHeight=484` 고정). DOM 체인: `dashboard-shell.tsx`의 진짜 스크롤러(`overflow-y-auto`) > `ContextualPanelLayout` grid > `gates/[id]/page.tsx` 루트(flex-col) > `ProofCapsule density="full"` > `CutCornerShell`.

## 원인
`CutCornerShell`(`proof-cut flex overflow-hidden rounded-[6px] border ...`)이 세로 flex 체인의 flex item인데, CSS Flexbox 스펙상 `overflow`가 `visible`이 아닌 flex item의 automatic minimum size는 0이다 — `shrink-0` 없이는 뷰포트가 좁을 때 이 셸이 내용의 실제 높이보다 작게 찌그러들고, 그 잘림을 자신의 `overflow-hidden`이 감춰버린다. 조상 어디에서도 `scrollHeight > clientHeight`가 성립하지 않아 스크롤이 원천 봉쇄된다.

## AC2(오늘 회귀 여부) — git blame으로 확定
- `CutCornerShell` 자체: `a02b841da4`(2026-07-11, 최초 ProofCapsule 도입, story #2058)
- `gates/[id]/page.tsx` 루트 wrapper: `f614b97101`(2026-07-17)
- 진짜 스크롤러(`dashboard-shell.tsx`): `b1a1a4d348`(2026-05-26)

**오늘(#2969 PR-6) 회귀 아님 — #2058 이래 잠복해 있던 기존 결함.** 긴 결정 사유+좁은 뷰포트 조합이 오늘 처음 실사용에서 걸린 것으로 보인다.

## 처방
`CutCornerShell` 클래스에 `shrink-0` 추가 — 컷코너 clip-path·hairline 결·`overflow-hidden` 자체는 무변경(clip-path 표면 유지 목적은 그대로, 높이 전파만 살림). full/card/row 3개 밀도(FullVariant/CardVariant/InlineRow) 전부 `CutCornerShell`을 경유하므로 한 곳 수정으로 전부 해소.

## 검증
- [x] mutation-테스트 — `shrink-0` 제거 시 신규 assert만 RED(35 passed/1 failed) 확認 후 복원 → 36 passed
- [x] tsc EXIT 0
- [x] vitest 490 files/4231 tests green(회귀 0, 신규 1)
- [x] build EXIT 0 · lint EXIT 0
- [x] verify:* 18종 전수 EXIT 0
- [x] AC3(시그니처 결 유지) — `overflow-hidden`·`rounded-[6px]`·`proof-cut`·`border` 등 기존 클래스 전부 무변경, `shrink-0`만 추가
- ⚠️ AC1(실픽셀·작은 뷰포트 재현)은 dev 배포 후 라이브로 이어서 검증 예정

🤖 Generated with Claude Code