### PR TITLE
fix(#2975): merge 게이트 승인 anchor SHA 레이스 근본 처방

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3880,7 +3880,16 @@
     "sigReasonPlaceholder": "Enter a reason to record with this decision",
     "sigConsequenceNote": "Approving records your signature",
     "sigRequestChanges": "Request changes",
-    "sigApproveAndSign": "Approve & sign"
+    "sigApproveAndSign": "Approve & sign",
+    "gateActivityHistoryTitle": "Approval history",
+    "gateActivityActorFallback": "Unknown",
+    "gateActivityEmpty": "No approval history yet",
+    "gateActivityActionApproved": "Approved",
+    "gateActivityActionRejected": "Rejected",
+    "gateActivityActionUndone": "Undone (correction)",
+    "gateActivityActionVoided": "Voided",
+    "gateActivityActionOverridden": "Overridden",
+    "gateHeadChangedError": "The commit this gate targets changed after you confirmed. Please review the latest changes before approving."
   },
   "recruiter": {
     "title": "Recruiter",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3880,7 +3880,16 @@
     "sigReasonPlaceholder": "기록에 남을 결정 사유를 입력하세요",
     "sigConsequenceNote": "승인은 당신의 서명으로 기록됩니다",
     "sigRequestChanges": "변경 요청",
-    "sigApproveAndSign": "승인하고 서명"
+    "sigApproveAndSign": "승인하고 서명",
+    "gateActivityHistoryTitle": "결재 이력",
+    "gateActivityActorFallback": "알 수 없음",
+    "gateActivityEmpty": "결재 이력 없음",
+    "gateActivityActionApproved": "승인",
+    "gateActivityActionRejected": "반려",
+    "gateActivityActionUndone": "취소(오클릭 정정)",
+    "gateActivityActionVoided": "무효화",
+    "gateActivityActionOverridden": "강제 결정",
+    "gateHeadChangedError": "게이트 대상 커밋이 승인 확인 이후 변경되었습니다. 최신 내용을 다시 확인한 뒤 승인해주세요."
   },
   "recruiter": {
     "title": "채용관",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -172,6 +172,43 @@ describe('GateDetailPage — transition 실패 사유 노출 (story #2500)', () 
     expect(container.textContent).not.toContain('HTTP 500');
     expect(container.textContent).toContain(koMessages.cage.gateTransitionErrorGeneric);
   });
+
+  // story #2975(PO 요구 ①②③, 2026-08-24) — merge 게이트 승인 anchor SHA 레이스 근본처방.
+  // BE가 409(code=gate_head_changed)로 거부하면 화면은 옛 SHA를 보여준 채 멈추지 않고
+  // gate를 재조회(fetchGate)해 최신 상태로 재렌더해야 「새 커밋 도착·재확認」이 실제로 된다.
+  it('409 gate_head_changed 거부 시 사유를 보여주고 gate를 재조회한다', async () => {
+    let gateFetchCount = 0;
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/gates/gate-1' && !init) {
+        gateFetchCount += 1;
+        const sha = gateFetchCount === 1 ? 'sha-old-reviewed' : 'sha-new-race-landed';
+        return { ok: true, status: 200, json: async () => ({ data: gate({ can_approve: true, risk_grade: 'low', github_check_run_sha: sha }) }) };
+      }
+      if (url === '/api/gates/gate-1/transition') {
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({
+            data: null,
+            error: { code: 'gate_head_changed', message: '게이트 대상 커밋이 승인 확인 이후 변경되었습니다. 최신 내용을 다시 확인한 뒤 승인해주세요.', current_head_sha: 'sha-new-race-landed' },
+            meta: null,
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { default: GateDetailPage } = await import('./page');
+    const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+    await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const approveBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes(koMessages.cage.gateApprove));
+    await act(async () => { approveBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('게이트 대상 커밋이 승인 확인 이후 변경되었습니다');
+    expect(gateFetchCount).toBe(2); // 최초 로드(1) + 409 이후 재조회(2) — 화면이 옛 SHA에 안 멈춘다.
+  });
 });
 
 // story #2631(FE 계약 doc bb733f26) — 「보류(논의 필요)」+ 오클릭 정정(취소). 저위험 경로

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -209,6 +209,60 @@ describe('GateDetailPage — transition 실패 사유 노출 (story #2500)', () 
     expect(container.textContent).toContain('게이트 대상 커밋이 승인 확인 이후 변경되었습니다');
     expect(gateFetchCount).toBe(2); // 최초 로드(1) + 409 이후 재조회(2) — 화면이 옛 SHA에 안 멈춘다.
   });
+
+  // story #2975(유나양 design 판정 2026-08-24, PO 확定) — 409→fetchGate() 재조회 後
+  // GateSignatureApproval의 evidenceViewed/reason state가 안 리셋되면 canSign이 그대로 true라
+  // PO가 새 SHA(B)를 실제로 안 보고도 재승인 버튼을 바로 누를 수 있었다(서버가 막은 "리뷰
+  // 안 한 SHA 승인"이 UX 층에서 뚫림). key={github_check_run_sha}로 SHA 변경 시 강제 remount
+  // 해 열람 체크·사유가 초기화되는지 — 「새 SHA 열람 前 canSign=false」를 직접 증명한다.
+  it('409 재조회로 SHA가 바뀌면 근거열람 체크·사유가 리셋돼 재승인 버튼이 다시 비활성화된다', async () => {
+    let gateFetchCount = 0;
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/gates/gate-1' && !init) {
+        gateFetchCount += 1;
+        const sha = gateFetchCount === 1 ? 'sha-A-reviewed' : 'sha-B-race-landed';
+        return { ok: true, status: 200, json: async () => ({ data: gate({ can_approve: true, risk_grade: 'high', github_check_run_sha: sha }) }) };
+      }
+      if (url === '/api/gates/gate-1/transition') {
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({
+            data: null,
+            error: { code: 'gate_head_changed', message: 'SHA changed', current_head_sha: 'sha-B-race-landed' },
+            meta: null,
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { default: GateDetailPage } = await import('./page');
+    const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+    await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    // SHA A 열람: 체크+사유 입력 → 서명 버튼이 활성화됨을 먼저 확인(사전조건).
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await act(async () => { checkbox.click(); });
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+      setter.call(textarea, 'SHA A 검토 완료');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    let signBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes(koMessages.cage.sigApproveAndSign));
+    expect(signBtn?.disabled).toBe(false);
+
+    // 승인 클릭 → 409(SHA B로 바뀜) → fetchGate() 재조회 → key 변경으로 강제 remount.
+    await act(async () => { signBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(gateFetchCount).toBe(2);
+    const checkboxAfter = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkboxAfter.checked).toBe(false); // remount로 evidenceViewed 리셋 확認.
+    signBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes(koMessages.cage.sigApproveAndSign));
+    expect(signBtn?.disabled).toBe(true); // canSign=false — 새 SHA B를 실제로 다시 봐야만 재활성화.
+  });
 });
 
 // story #2631(FE 계약 doc bb733f26) — 「보류(논의 필요)」+ 오클릭 정정(취소). 저위험 경로

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -147,7 +147,12 @@ export default function GateDetailPage() {
       // 평문 문자열이지만 handler가 error.message로 재포장한다, gates.py:885). 올바른
       // 필드로 교정 — #2027의 "고위험 승인 사유 필수" 문구가 실제로 화면에 뜨게 된다.
       const body = await res.json().catch(() => null) as { error?: { message?: string; code?: string } } | null;
-      const reason = body?.error?.message ?? t('gateTransitionErrorGeneric');
+      // story #2975(페드루 PO 비차단 관찰, 2026-08-24) — BE의 gate_head_changed 메시지는
+      // 한국어 평문(i18n 안 됨). FE가 이미 code를 파싱하므로 code→i18n 매핑으로 렌더(영어
+      // 로케일에서도 정상 표시). 그 외 code는 기존대로 BE message 그대로 통과.
+      const reason = body?.error?.code === 'gate_head_changed'
+        ? t('gateHeadChangedError')
+        : (body?.error?.message ?? t('gateTransitionErrorGeneric'));
       setTransitionError(reason);
       // story #2975(PO 요구 ③): 409 gate_head_changed — 승인 확인 사이 대상 커밋이 바뀌어
       // 서버가 거부했다는 뜻. 화면을 그대로 두면 PO가 옛 SHA를 보며 같은 버튼을 다시 눌러
@@ -276,7 +281,16 @@ export default function GateDetailPage() {
                     <p className="text-[11px] text-muted-foreground">{t('gateReadonlyNotAuthorized')}</p>
                   </div>
                 ) : usesSignatureFlow(deriveRiskLevel(gate)) ? (
+                  // story #2975(유나양 design 판정 2026-08-24, PO 확定) — 409(gate_head_changed)
+                  // 후 fetchGate() 재조회로 gate.github_check_run_sha가 바뀌어도, key 없이는 이
+                  // 컴포넌트가 그대로 살아있어 evidenceViewed/reason state가 안 리셋된다 —
+                  // canSign이 true로 유지된 채 새 SHA(B)로 자동 재승인 가능(PO가 B를 실제로
+                  // 다시 안 봄) = 서버가 막은 "리뷰 안 한 SHA 승인"이 UX 층에서 그대로 뚫림.
+                  // key={SHA}로 SHA가 바뀔 때마다 강제 remount — 세밀한 useEffect 리셋 목록은
+                  // 미래 state 추가마다 리셋 누락 사각을 만드는 구조(이번 사고와 동형 클래스)라
+                  // PO가 명시 기각, remount가 미래 state까지 구조적으로 안전(최소안 채택).
                   <GateSignatureApproval
+                    key={gate.github_check_run_sha}
                     gate={gate}
                     resolving={resolving}
                     error={transitionError}

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -122,7 +122,13 @@ export default function GateDetailPage() {
         // 실려온다(그 컴포넌트 자체가 canSign=evidenceViewed&&reason로 버튼을 막아 이 콜백에
         // 도달했다는 사실 자체가 열람 확인 — 아래 저위험 경로는 안 보내 undefined→백엔드가
         // risk_grade=='high'가 아니면 아예 안 봄).
-        body: JSON.stringify({ status, note: note?.trim() || null, evidence_viewed: evidenceViewed ?? false }),
+        // story #2975(PO 설계 확定 2026-08-24): reviewed_head_sha — 지금 이 화면이 보여주는
+        // gate.github_check_run_sha를 「내가 review한 SHA」로 실어 보낸다. merge 게이트가 아니면
+        // BE가 무시(SHA 개념 자체가 없는 gate_type)하므로 gate_type 분기 없이 항상 보낸다.
+        body: JSON.stringify({
+          status, note: note?.trim() || null, evidence_viewed: evidenceViewed ?? false,
+          reviewed_head_sha: gate.github_check_run_sha ?? null,
+        }),
       });
       // story #1990: push()는 콜드-진입 합성 스택([parentTab, target])에 세번째 엔트리를
       // 쌓아 브라우저 BACK 1회가 이 상세를 재진입시키는 트랩을 만든다(§3.2 재진입 트랩).
@@ -140,13 +146,20 @@ export default function GateDetailPage() {
       // 없는 필드라 이 분기는 항상 죽어있었다(그라운딩 확認 — BE HTTPException(detail=...)은
       // 평문 문자열이지만 handler가 error.message로 재포장한다, gates.py:885). 올바른
       // 필드로 교정 — #2027의 "고위험 승인 사유 필수" 문구가 실제로 화면에 뜨게 된다.
-      const body = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+      const body = await res.json().catch(() => null) as { error?: { message?: string; code?: string } } | null;
       const reason = body?.error?.message ?? t('gateTransitionErrorGeneric');
       setTransitionError(reason);
+      // story #2975(PO 요구 ③): 409 gate_head_changed — 승인 확인 사이 대상 커밋이 바뀌어
+      // 서버가 거부했다는 뜻. 화면을 그대로 두면 PO가 옛 SHA를 보며 같은 버튼을 다시 눌러
+      // 똑같이 거부당한다 — 최신 상태(새 github_check_run_sha)로 재조회해 "새 커밋 도착·
+      // 재확認"이 실제로 재렌더되게 한다.
+      if (body?.error?.code === 'gate_head_changed') {
+        void fetchGate();
+      }
     } finally {
       setResolving(false);
     }
-  }, [gate, router, t]);
+  }, [gate, router, t, fetchGate]);
 
   // story #2631 — «보류(논의 필요)». transition()과 형제: 상태 전이가 없어(pending 유지)
   // 페이지 이동 없이 그 자리서 fetchGate()로 discussion_requested만 갱신한다.

--- a/apps/web/src/lib/fastapi-proxy.test.ts
+++ b/apps/web/src/lib/fastapi-proxy.test.ts
@@ -182,3 +182,41 @@ describe('fastapi-proxy — null-body status(204 등) 재구성이 안 던진다
     expect(await res.json()).toEqual({ ok: true });
   });
 });
+
+// story #2975(페드루 PO QA 필수 축 지정, 2026-08-24) — gates.py transition_gate_endpoint가 이
+// 엔드포인트 처음으로 409에 dict detail({code, message, current_head_sha})을 내보낸다. FE
+// (gates/[id]/page.tsx)는 body.error.code로 재조회 여부를 가른다 — 이 프록시가 res.text()로
+// 읽어 새 Response로 재구성하는 자리(res.json()이 아니라 텍스트 그대로)라 필드가 안 사라지는
+// 것은 코드상 자명해 보이지만, 실제로 실물 경계(mock fetch 응답 → proxyToFastapi 재구성 →
+// 최종 Response.json())를 왕복시켜 증명한다 — "코드를 읽고 될 것 같다"와 "실제로 됨"은 다르다.
+describe('fastapi-proxy — dict-detail 409(error.code) passthrough(story #2975)', () => {
+  beforeEach(() => {
+    getServerSessionMock.mockReset();
+    getServerSessionMock.mockResolvedValue({ access_token: 'token-1', org_id: 'org-1', project_id: 'proj-1' });
+  });
+
+  it('BE의 409 error.code/current_head_sha가 프록시 재구성을 거쳐도 그대로 살아남는다', async () => {
+    global.fetch = vi.fn(async () => new Response(
+      JSON.stringify({
+        data: null,
+        error: {
+          code: 'gate_head_changed',
+          message: '게이트 대상 커밋이 승인 확인 이후 변경되었습니다. 최신 내용을 다시 확인한 뒤 승인해주세요.',
+          current_head_sha: 'sha-race-landed',
+        },
+        meta: null,
+      }),
+      { status: 409, headers: { 'content-type': 'application/json' } },
+    ));
+    const request = new Request('http://localhost/api/gates/gate-1/transition', {
+      method: 'POST', body: JSON.stringify({ status: 'approved', reviewed_head_sha: 'sha-reviewed' }),
+    });
+
+    const res = await proxyToFastapi(request, '/api/v2/gates/gate-1/transition');
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { code: string; message: string; current_head_sha: string } };
+    expect(body.error.code).toBe('gate_head_changed');
+    expect(body.error.current_head_sha).toBe('sha-race-landed');
+  });
+});

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -101,6 +101,14 @@ class GateTransitionRequest(BaseModel):
     # 몰라 기본값 False로 막힌다 — AC1의 note 강제와 같은 방어선). 기본값 False = 안 보내면
     # 고위험에서 막힘(저위험은 아래 강제 블록이 risk_grade=="high"일 때만 돌아 무관).
     evidence_viewed: bool = False
+    # story #2975(HIGH, 게이트 신선도 구멍) — merge 게이트 승인의 anchor SHA 레이스 근본 처방.
+    # PO가 화면에서 review한 SHA를 여기 실어 보내야, 서버가 「지금 이 순간의 github_check_run_sha」
+    # (승인 클릭~서버 커밋 사이 웹훅 레이스로 이미 딴 SHA일 수 있음)를 review-time SHA와 대조할
+    # 수 있다. Optional 유지 이유: 이 엔드포인트는 merge 게이트 전용이 아니라 doc_approval·
+    # artifact_canonicalize 등 SHA 개념이 없는 gate_type도 함께 처리(공유 계약) — 그쪽엔 강제 불가.
+    # merge 게이트 승인 시의 fail-closed 강제는 transition_gate_endpoint 본문에서(None도 「안 보냄」
+    # 취급돼 known SHA와 불일치로 거부됨 — "안 보내면 조용히 통과"라는 구멍 자체가 생기지 않는다).
+    reviewed_head_sha: str | None = None
 
     @field_validator("status")
     @classmethod
@@ -1177,8 +1185,13 @@ async def transition_gate_endpoint(
     # E-DG 48f064e5 / #2198(까심 QA·오르테가 PO): doc/non-doc 인가 규칙 —
     # story #2631 로 _authorize_gate_approve_equivalent 로 추출(discuss 액션과 공유, 위 정의부 주석 참고).
     resolved = await resolve_member(auth, org_id, session)
+    # story #2975 — FOR UPDATE: 이 트랜잭션이 커밋할 때까지 이 gate 행에 대한 concurrent
+    # UPDATE(웹훅 구동 publish_gate_check의 github_check_run_sha 갱신 포함, gate_github_check.py)를
+    # Postgres 행 잠금으로 블록한다. 아래 reviewed_head_sha 대조가 "읽고 나중에 커밋" 창에서
+    # 딴 값으로 덮이지 않고, 대조에 쓴 값 그대로 approved_head_sha에 확정 기록됨을 보장(PO 요구 ②
+    # — 대조와 anchor 쓰기가 같은 락 스코프 안에서 원자적).
     _gate = (await session.execute(
-        select(Gate).where(Gate.id == id, Gate.org_id == org_id)
+        select(Gate).where(Gate.id == id, Gate.org_id == org_id).with_for_update()
     )).scalar_one_or_none()
     await _authorize_gate_approve_equivalent(session, _gate, resolved, auth, org_id)
     # story #2027(까심 QA 적출): 고위험(risk_grade=high) 게이트의 approved 전이는 사유(note) 서버측
@@ -1201,6 +1214,27 @@ async def transition_gate_endpoint(
                     status_code=422,
                     detail="고위험(risk_grade=high) 게이트 승인은 근거 열람 확인(evidence_viewed=true)이 필수입니다.",
                 )
+    # story #2975(HIGH, 게이트 신선도 구멍 근본처방·페드루 PO 설계 확定 2026-08-24) — merge 게이트
+    # 승인의 anchor SHA 레이스. 위 FOR UPDATE로 이 gate 행을 이미 잠근 상태이므로 여기서 읽는
+    # _gate.github_check_run_sha는 이 트랜잭션이 커밋할 때까지 그 누구도 못 바꾸는 값이다(레이스
+    # 윈도가 줄어든 게 아니라 없음). PO가 화면에서 review한 SHA(body.reviewed_head_sha)가 이 값과
+    # 다르면 — body가 그 필드를 아예 안 보낸 경우(None)도 포함 — 승인을 진행하지 않고 즉시 409로
+    # 거부한다. known SHA가 없는 legacy 게이트(github_check_run_sha=None)는 애초에 대조할 review
+    # 시점 값이 없으므로 기존 동작(아래 anchor 블록의 PR-link 폴백) 그대로 통과.
+    if body.status == "approved" and _gate is not None and _gate.gate_type == MERGE_GATE_TYPE:
+        _known_head_sha = _gate.github_check_run_sha
+        if _known_head_sha is not None and body.reviewed_head_sha != _known_head_sha:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "gate_head_changed",
+                    "message": (
+                        "게이트 대상 커밋이 승인 확인 이후 변경되었습니다. "
+                        "최신 내용을 다시 확인한 뒤 승인해주세요."
+                    ),
+                    "current_head_sha": _known_head_sha,
+                },
+            )
     # ⭐S23 RC① + RC#1(방어심층): resolver_id 를 **전 status 무조건 인증 caller 로 강제**(body 무시).
     # body 조작(타인 UUID)으로 SoD(approver≠owner) 우회·confirmed_by_member_id 위조 차단.
     _resolver_id = resolved.id

--- a/backend/tests/test_2832_gate_reapproval_anchor_realdb.py
+++ b/backend/tests/test_2832_gate_reapproval_anchor_realdb.py
@@ -172,7 +172,10 @@ async def test_realdb_reapproval_anchors_to_gate_tracked_sha_not_stale_link_evid
         try:
             resp = await client.post(
                 f"/api/v2/gates/{gate_id}/transition",
-                json={"status": "approved", "note": "재승인 anchor 회귀 확인", "evidence_viewed": True},
+                json={
+                    "status": "approved", "note": "재승인 anchor 회귀 확인", "evidence_viewed": True,
+                    "reviewed_head_sha": SHA_CURRENT_PR,  # story #2975 — PO가 review한 SHA 필수 대조.
+                },
             )
             assert resp.status_code == 200, resp.text
             body = resp.json()

--- a/backend/tests/test_2835_gate_approval_publish_self_sufficient_realdb.py
+++ b/backend/tests/test_2835_gate_approval_publish_self_sufficient_realdb.py
@@ -171,7 +171,10 @@ async def test_realdb_rowless_autocreated_gate_approve_publishes_success_via_neu
                  patch("app.core.database.async_session_factory", Session):
                 resp = await client.post(
                     f"/api/v2/gates/{gate_id}/transition",
-                    json={"status": "approved", "note": "row-less 발행 자립 확인", "evidence_viewed": True},
+                    json={
+                        "status": "approved", "note": "row-less 발행 자립 확인", "evidence_viewed": True,
+                        "reviewed_head_sha": "sha-rowless",  # story #2975 — review-time SHA 대조.
+                    },
                 )
                 assert resp.status_code == 200, resp.text
         finally:

--- a/backend/tests/test_2932_gate_slot_hardening_realdb.py
+++ b/backend/tests/test_2932_gate_slot_hardening_realdb.py
@@ -658,7 +658,10 @@ async def test_watermark_survives_approval_and_blocks_subsequent_stale_webhook()
             ):
                 resp = await client.post(
                     f"/api/v2/gates/{gate_id}/transition",
-                    json={"status": "approved", "note": "e2e 승인", "evidence_viewed": True},
+                    json={
+                        "status": "approved", "note": "e2e 승인", "evidence_viewed": True,
+                        "reviewed_head_sha": "sha-real-head",  # story #2975 — review-time SHA 대조.
+                    },
                 )
                 assert resp.status_code == 200, resp.text
         finally:
@@ -827,7 +830,10 @@ async def test_never_webhooked_gate_has_no_watermark_after_approval_documented_g
             ):
                 resp = await client.post(
                     f"/api/v2/gates/{gate_id}/transition",
-                    json={"status": "approved", "note": "webhook 이력 없는 승인", "evidence_viewed": True},
+                    json={
+                        "status": "approved", "note": "webhook 이력 없는 승인", "evidence_viewed": True,
+                        "reviewed_head_sha": "sha-self-report",  # story #2975 — review-time SHA 대조.
+                    },
                 )
                 assert resp.status_code == 200, resp.text
         finally:

--- a/backend/tests/test_2975_gate_approval_sha_race_realdb.py
+++ b/backend/tests/test_2975_gate_approval_sha_race_realdb.py
@@ -1,0 +1,265 @@
+"""story #2975(HIGH, 게이트 신선도 구멍) — 근본원인 확定+GREEN 전환.
+
+원래 RED 재현(2026-08-24 초판): 승인 트랜잭션이 «PO가 화면에서 review한 SHA»가 아니라
+«지금 이 순간 gate.github_check_run_sha가 가리키는 SHA»를 anchor로 찍었다(gates.py
+transition_gate_endpoint, story #2832가 도입한 1순위 로직). 승인 요청 body가 review 시점
+SHA를 전혀 실어 보내지 않아, 승인 클릭과 서버 커밋 사이에 웹훅 구동 publish_gate_check가
+github_check_run_sha를 새 SHA로 먼저 갱신해 두면 서버는 그 차이를 구별할 수단이 없었다 —
+승인이 «리뷰한 적 없는 새 커밋»에 그대로 anchor됐다(실사고: 2026-08-23 18:57~58, PR#3402,
+gate #f07fae4e/story 2969 — PO가 head 2eadc1f44 기준으로 서명했는데 새 SHA a4f57604f
+check-run이 즉시 "게이트 상태: approved"로 뜸). reopen_gate_if_new_sha 미발화가 아니라
+(#2961 패턴이 다루는 문제가 아님) 애초에 anchor가 새 SHA로 찍혀 «불일치» 자체가 안 생긴
+것이었다.
+
+처방(페드루 PO 설계 확定 2026-08-24, gates.py transition_gate_endpoint): body에
+`reviewed_head_sha` 신설 — merge 게이트 승인 시 known SHA(gate.github_check_run_sha, not
+None)와 불일치하면(필드 누락=None 포함, fail-closed) 409로 거부하고 승인을 진행하지 않는다.
+대조는 FOR UPDATE로 이 gate 행을 잠근 뒤 수행(같은 트랜잭션/락 스코프 — 대조~anchor 쓰기
+사이에 레이스 윈도가 남지 않는다).
+
+이 파일은 이제 GREEN: 레이스가 나면(사례1 그대로) 승인이 조용히 성공하는 게 아니라 명시
+거부돼야 한다. 필드 자체를 안 보내는 옛 클라이언트도 fail-closed로 막힌다. 매칭되는
+정상 경로(레이스 없음)는 여전히 200으로 통과한다(양성대조 — 회귀가드가 과잉차단하지 않음
+확인)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — transition_gate()가 ActivityLog를 씀.
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_common(session):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+        permission="granted", role="owner",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "caller_id": caller.id}
+
+
+async def _seed_race_gate(session, *, github_check_run_sha):
+    from app.models.gate import Gate
+    from app.models.pm import Story
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    seeded = await _seed_common(session)
+    story = Story(
+        id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+        title="#2975 사례1 — 승인 anchor SHA 레이스",
+    )
+    session.add(story)
+    await session.commit()
+
+    gate = Gate(
+        id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+        gate_type=MERGE_GATE_TYPE, status="pending",
+        approved_head_sha=None, github_check_run_id=90199, github_check_run_sha=github_check_run_sha,
+    )
+    session.add(gate)
+    await session.commit()
+    return seeded, gate.id
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_race_landed_sha_rejected_not_silently_anchored():
+    """GREEN(사례1 그대로): PO가 SHA_REVIEWED를 보고 승인 클릭(body에 reviewed_head_sha=
+    SHA_REVIEWED로 실어 보냄) 직전, 웹훅 구동 publish_gate_check가 github_check_run_sha를
+    SHA_RACE_PUSH로 먼저 갱신(동시성 시뮬레이션 — DB 직접 갱신). 처방 前엔 이게 200+조용한
+    오-anchor였다 — 처방 後엔 409로 명시 거부되고 gate는 pending에 그대로 머물러야 한다."""
+    from app.models.gate import Gate
+    from app.main import app
+
+    SHA_REVIEWED = "sha-2eadc1f44-po-reviewed-this"
+    SHA_RACE_PUSH = "sha-a4f57604f-comment-only-push-landed-during-approve"
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded, gate_id = await _seed_race_gate(s, github_check_run_sha=SHA_REVIEWED)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            # 레이스 시뮬레이션: PO가 승인 버튼을 누르기 직전, Mirko의 comment-only push에 대한
+            # synchronize 웹훅이 이미 처리돼(gate_github_check.py::publish_gate_check 백그라운드
+            # 태스크) gate.github_check_run_sha가 새 SHA로 먼저 갱신됐다 — PO의 화면은 아직 옛
+            # SHA를 보여주고 있지만(리로드 안 함) DB는 이미 새 SHA를 가리킨다.
+            async with Session() as race_session:
+                race_gate = (await race_session.execute(
+                    __import__("sqlalchemy").select(Gate).where(Gate.id == gate_id)
+                )).scalar_one()
+                race_gate.github_check_run_sha = SHA_RACE_PUSH
+                await race_session.commit()
+
+            # PO의 승인 클릭 — body는 review-time SHA(SHA_REVIEWED)를 실어 보낸다(신규 계약).
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={
+                    "status": "approved", "note": "SHA_REVIEWED 기준 서명", "evidence_viewed": True,
+                    "reviewed_head_sha": SHA_REVIEWED,
+                },
+            )
+            assert resp.status_code == 409, resp.text
+            error = resp.json()["error"]
+            assert error["code"] == "gate_head_changed", error
+            assert error["current_head_sha"] == SHA_RACE_PUSH, error
+
+            # 승인이 진행되지 않았어야 한다 — status=pending 유지, anchor 미기록.
+            async with Session() as verify_session:
+                gate_after = (await verify_session.execute(
+                    __import__("sqlalchemy").select(Gate).where(Gate.id == gate_id)
+                )).scalar_one()
+                assert gate_after.status == "pending", "409 거부에도 승인이 진행됐다 — fail-closed 위반"
+                assert gate_after.approved_head_sha is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_missing_reviewed_head_sha_rejected_fail_closed():
+    """옛 클라이언트(reviewed_head_sha 필드 자체를 모르는 호출자) 시뮬레이션 — 필드를 아예 안
+    보내면 Optional 필드 기본값(None)이 known SHA와 자동 불일치해 fail-closed로 막혀야 한다
+    (PO 요구 ① — "안 보내는 호출자에게 구멍이 그대로 남으면 안 된다")."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded, gate_id = await _seed_race_gate(s, github_check_run_sha="sha-known-head")
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "approved", "note": "필드 누락", "evidence_viewed": True},
+            )
+            assert resp.status_code == 409, resp.text
+            assert resp.json()["error"]["code"] == "gate_head_changed", resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_matching_reviewed_head_sha_approves_normally():
+    """양성대조 — 레이스가 전혀 없는 정상 경로(reviewed_head_sha가 현재 known SHA와 정확히
+    일치)는 이 회귀가드가 과잉차단하지 않고 그대로 200+정확한 anchor로 통과해야 한다."""
+    from app.main import app
+
+    SHA_CURRENT = "sha-no-race-here"
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded, gate_id = await _seed_race_gate(s, github_check_run_sha=SHA_CURRENT)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={
+                    "status": "approved", "note": "정상 승인", "evidence_viewed": True,
+                    "reviewed_head_sha": SHA_CURRENT,
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["status"] == "approved", body
+            assert body["approved_head_sha"] == SHA_CURRENT, body
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -50,6 +50,12 @@ async def test_gate_transition_forces_resolver_id_to_caller(monkeypatch):
     _gr = MagicMock()
     _g = MagicMock()
     _g.gate_type = "merge"
+    # story #2975 — bare MagicMock의 auto-attribute는 None이 아니라 또 다른 MagicMock이라,
+    # transition_gate_endpoint의 reviewed_head_sha 대조(known SHA가 None이 아니면 body와
+    # 불일치 시 409)가 이 테스트의 관심사(resolver_id 강제)와 무관하게 발동해버린다. 이
+    # 테스트는 SHA 앵커링을 다루지 않으므로 명시적으로 None(known SHA 없음)으로 고정해
+    # 그 검증 대상 밖임을 분명히 한다.
+    _g.github_check_run_sha = None
     _gr.scalar_one_or_none.return_value = _g
     _sess.execute = AsyncMock(return_value=_gr)
     from fastapi import BackgroundTasks

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -37,6 +37,11 @@ def _non_doc_gate_session():
         # — 이 목의 gate_type이 정확히 "merge")가 AttributeError로 죽는다 — None으로 명시해
         # "링크 없음/head_sha 미상"과 동형 무해 경로를 타게 한다.
         evidence=None,
+        # story #2975 — SimpleNamespace는 MagicMock과 달리 미선언 속성 접근 시 AttributeError를
+        # 던진다. reviewed_head_sha 대조 분기가 이 값을 읽으므로(known SHA 유무 판정), 이 파일의
+        # 관심사(resolver_id 강제, RC#1)와 무관하게 명시 필요 — None="known SHA 없음"으로 그
+        # 검증 자체가 대상 밖임을 분명히 한다(evidence=None과 동형 처리).
+        github_check_run_sha=None,
     )
     s.execute = AsyncMock(return_value=gr)
     return s


### PR DESCRIPTION
[SID:2975]

## 요약
승인 트랜잭션이 「PO가 review한 SHA」가 아니라 「승인 커밋 시점에 gate.github_check_run_sha가 가리키는 값」을 anchor로 찍고 있었다. 승인 클릭~서버 커밋 사이 웹훅 레이스(publish_gate_check가 github_check_run_sha를 먼저 갱신)로 이 값이 바뀌면, 리뷰한 적 없는 커밋에 승인이 조용히 승계됐다 — 실사고(2026-08-23, PR#3402, gate #f07fae4e/story 2969).

`reopen_gate_if_new_sha`는 결백함을 실측 확인 — 애초에 SHA 불일치 자체가 안 생겨 발화 대상이 아니었다(그라운딩 시드의 "왜 안 탔나" 질문 자체가 뒤집힘).

## 처방 (페드루 PO 설계 확定 2026-08-24)
1. **필수 대조**: body에 `reviewed_head_sha` 신설. merge 게이트 승인 시 known SHA(gate.github_check_run_sha)와 불일치하면(필드 누락=None도 포함, fail-closed) 409(`gate_head_changed`)로 거부.
2. **원자적 락 스코프**: 대조는 `SELECT ... FOR UPDATE`로 gate 행을 잠근 뒤 수행 — 대조~anchor 쓰기 사이 레이스 윈도가 구조적으로 없다(웹훅의 concurrent UPDATE는 이 트랜잭션 커밋까지 블록됨).
3. **FE 재렌더**: 409 응답에 `current_head_sha`를 실어 보내고, FE(gates/[id])는 이 코드를 받으면 gate를 재조회해 최신 SHA로 재렌더 — PO가 옛 화면에 멈춰 같은 실패를 반복하지 않는다.

## 호출부 전수 확인
`transition_gate_endpoint`(gates.py)가 merge 게이트 human 승인의 유일한 HTTP 엔드포인트임을 확인 — MCP 도구·타 REST 경로 없음(다른 `transition_gate()` 서비스 호출부는 전부 workflow-line/SLA/quorum/loop 등 SHA 개념이 없는 다른 gate_type 전용).

## AC 재정렬 (PO 확定)
- AC1(양성대조, 기존 커버): `test_2932_gate_slot_hardening_realdb.py::test_genuinely_newer_webhook_still_repends_correctly` — 진짜 승인 완료 後 push는 reopen이 정상 발화함을 이미 검증(무회귀).
- AC-신설(GREEN 전환): `test_2975_gate_approval_sha_race_realdb.py` 3종 — 레이스 거부, 필드누락 fail-closed, 정상경로 양성대조.
- AC4(감사 표면): 별개 축, 이 PR 스코프 밖.

## Test plan
- [x] BE: 위 4개 realdb 테스트 파일(26 tests) 격리 fresh PG로 green
- [x] FE: gates/[id]/page.test.tsx 15 tests green(신규 409 재조회 테스트 포함)
- [x] FE: tsc --noEmit 0 errors
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AbjN7dJp11Nng4AVZY3Xw