### PR TITLE
[SID:2980] 스레드 답글 mark-read 배선 — unread 배지 (2) 고착 fix

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -992,6 +992,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
               onClose={closeThread}
               incomingMessage={threadIncoming?.parent_id === activeThread.id ? threadIncoming : null}
               onReplyAdded={handleReplyAdded}
+              onMarkRead={markRead}
               entityStatusByKey={entityStatusByKey}
               eventDefinitionsByKey={eventDefinitionsByKey}
               requestedEntityStatusKeysRef={requestedEntityStatusKeysRef}

--- a/apps/web/src/components/chat/thread-panel.test.tsx
+++ b/apps/web/src/components/chat/thread-panel.test.tsx
@@ -235,3 +235,86 @@ describe('ThreadPanel — story #2911(S2e②③) 헤더 칩 브레드크럼(대�
     expect(header.querySelector('button[type="button"]')).toBeTruthy(); // 대화 칩만 버튼(요약은 span)
   });
 });
+
+// 2026-08-24(선생님 리포트) — 답글을 읽어도 GNB/리스트 unread 배지 (2)가 안 꺼지는 버그 회귀가드.
+// 원인: ThreadPanel이 mark-read(POST .../read)를 한 번도 호출하지 않았다(chat-view.tsx#markRead가
+// top-level 메시지에만 물려있었음). chat-list-view.tsx#applyConversationMessageUpdate는 parent_id
+// 구분 없이 모든 conversation.message_created(스레드 답글 포함)에서 unread_count를 올리므로,
+// 답글을 읽어도 내려갈 방법이 없었다.
+describe('ThreadPanel — 답글 열람 시 mark-read(onMarkRead) 배선(2026-08-24 뱃지 고착 fix)', () => {
+  it('로드 완료 시 최신 답글의 created_at으로 onMarkRead를 호출한다', async () => {
+    const onMarkRead = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/messages?thread_id=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [
+              { id: 'reply-1', created_by: 'agent-2', sender: { id: 'agent-2', name: '유나', type: 'agent' }, content: '답글 1', created_at: '2026-08-08T00:01:00.000Z' },
+              { id: 'reply-2', created_by: 'agent-2', sender: { id: 'agent-2', name: '유나', type: 'agent' }, content: '답글 2', created_at: '2026-08-08T00:02:00.000Z' },
+            ],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+
+    await act(async () => {
+      root.render(wrap(
+        <ThreadPanel parentMessage={parentMessage} conversationId="conv-1" currentTeamMemberId="member-1" projectId="proj-1" onClose={() => {}} onMarkRead={onMarkRead} />,
+      ));
+    });
+    await flush();
+
+    expect(onMarkRead).toHaveBeenCalledWith('2026-08-08T00:02:00.000Z');
+  });
+
+  it('답글이 없으면 parentMessage.created_at으로 onMarkRead를 호출한다(원 메시지만 열람)', async () => {
+    const onMarkRead = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) })));
+
+    await act(async () => {
+      root.render(wrap(
+        <ThreadPanel parentMessage={parentMessage} conversationId="conv-1" currentTeamMemberId="member-1" projectId="proj-1" onClose={() => {}} onMarkRead={onMarkRead} />,
+      ));
+    });
+    await flush();
+
+    expect(onMarkRead).toHaveBeenCalledWith(parentMessage.created_at);
+  });
+
+  it('패널이 열린 채로 신규 답글(incomingMessage)이 도착하면 그 created_at으로 onMarkRead를 재호출한다', async () => {
+    const onMarkRead = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) })));
+
+    await act(async () => {
+      root.render(wrap(
+        <ThreadPanel parentMessage={parentMessage} conversationId="conv-1" currentTeamMemberId="member-1" projectId="proj-1" onClose={() => {}} onMarkRead={onMarkRead} />,
+      ));
+    });
+    await flush();
+    onMarkRead.mockClear();
+
+    const incoming: ChatMessage = {
+      id: 'reply-live',
+      memo_id: 'conv-1',
+      created_by: 'agent-3',
+      sender_name: '카디르',
+      sender_type: 'agent',
+      sender_avatar_url: null,
+      content: '실시간 답글',
+      attachments: [],
+      created_at: '2026-08-08T00:05:00.000Z',
+      parent_id: 'parent-1',
+    };
+
+    await act(async () => {
+      root.render(wrap(
+        <ThreadPanel parentMessage={parentMessage} conversationId="conv-1" currentTeamMemberId="member-1" projectId="proj-1" onClose={() => {}} onMarkRead={onMarkRead} incomingMessage={incoming} />,
+      ));
+    });
+    await flush();
+
+    expect(onMarkRead).toHaveBeenCalledWith('2026-08-08T00:05:00.000Z');
+  });
+});

--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -51,6 +51,13 @@ interface ThreadPanelProps {
   /** story #2637 — chat-view.tsx의 event_definitions 카탈로그 캐시를 그대로 물려받는다
    * (entityStatusByKey와 동일 이유·별도로 안 만든다). */
   eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
+  /** 답글 뱃지 안 꺼지는 버그 fix(2026-08-24, 선생님 리포트) — chat-view.tsx의 markRead(top-level
+   * mark-read와 동일 엔드포인트·멱등 GREATEST 래칫)를 그대로 물려받는다. 이 패널은 열리면 항상
+   * 최신 답글까지 자동 스크롤(위 shouldScrollToBottomRef)이라 "열람=끝까지 봄"이 성립 — 로드
+   * 완료 시·신규 답글 수신 시 마크리드해야 conversation-level unread_count가 내려간다(스레드
+   * 답글도 parent_id 구분 없이 unread_count를 올리는 chat-list-view.tsx#applyConversationMessageUpdate
+   * 와 대칭). */
+  onMarkRead?: (upToIso: string) => void;
 }
 
 export function ThreadPanel({
@@ -65,6 +72,7 @@ export function ThreadPanel({
   requestedEntityStatusKeysRef,
   setEntityStatusByKey,
   eventDefinitionsByKey,
+  onMarkRead,
 }: ThreadPanelProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
@@ -91,11 +99,16 @@ export function ThreadPanel({
       if (!res.ok) return;
       const raw = await res.json() as Record<string, unknown>;
       const rawData = (Array.isArray(raw) ? raw : (raw.data ?? [])) as Record<string, unknown>[];
-      setMessages(rawData.map(normalizeToMessage));
+      const data = rawData.map(normalizeToMessage);
+      setMessages(data);
+      // 패널이 열리면 항상 하단까지 스크롤(아래 effect)이라 "로드=최신까지 열람" — 답글이
+      // 없으면 원 메시지까지만 본 것이므로 parentMessage.created_at으로 마크리드.
+      const latest = data[data.length - 1];
+      onMarkRead?.(latest ? latest.created_at : parentMessage.created_at);
     } finally {
       setLoading(false);
     }
-  }, [conversationId, parentMessage.id]);
+  }, [conversationId, parentMessage.id, parentMessage.created_at, onMarkRead]);
 
   useEffect(() => {
     void fetchThreadMessages();
@@ -114,7 +127,10 @@ export function ThreadPanel({
       return [...prev, incomingMessage];
     });
     shouldScrollToBottomRef.current = true;
-  }, [incomingMessage]);
+    // 패널이 열려있는 동안 도착한 답글도 자동 스크롤로 즉시 열람됨 — top-level chat-view.tsx의
+    // addMessage(nearBottom일 때 markRead)와 동형.
+    onMarkRead?.(incomingMessage.created_at);
+  }, [incomingMessage, onMarkRead]);
 
   // AC6: 매 render 후 플래그 확인 → DOM 업데이트 직후 스크롤 (bare useEffect)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- 선생님 실사용 리포트(2026-08-24): "답글은 확인해도 확인 이벤트가 제대로 안잡히는지 (2) 뱃지가 계속 붙어있는" — [BUG] 스토리 #2980
- 근본원인: `chat-view.tsx`의 top-level 채팅에는 mark-read(POST `.../read`)가 배선돼 있었지만, `ThreadPanel`(스레드 답글 뷰)에는 한 번도 배선되지 않았다. 반면 `chat-list-view.tsx#applyConversationMessageUpdate`는 parent_id 구분 없이 모든 `conversation.message_created`(스레드 답글 포함)에서 `unread_count`를 올린다 — 답글로 배지가 오르는데 답글을 읽어도 내려갈 방법이 없는 비대칭이었다.
- fix: 기존 `markRead`(#1976 계약, 멱등 GREATEST 래칫)를 `ThreadPanel`에 `onMarkRead` prop으로 물려 ①패널 로드 완료 시(최신 답글 또는 답글 없으면 원 메시지 `created_at`) ②패널이 열린 채로 신규 답글 수신 시 마크리드.

## Test plan
- [x] `npx vitest run src/components/chat/thread-panel.test.tsx` — 10 passed(신규 3건: 로드 시 최신 답글 markRead·답글 없을 때 parentMessage.created_at·incomingMessage 수신 시 재호출)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` (thread-panel.tsx/.test.tsx, chat-view.tsx) clean
- [x] `pnpm build` EXIT=0
- [ ] dev 라이브 확인 — 스레드 답글 읽고 배지 0 (유나/카디르 QA 병렬 요청)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>