### PR TITLE
[SID:2972] "다른 프로젝트" DM 행 상대명 미해석 — 반쪽 문자열 fix

### DIFF
--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3521,7 +3521,7 @@
     "selectMembers": "대화 상대 선택",
     "groupTitle": "그룹 이름 (선택)",
     "groupTitlePlaceholder": "그룹 채팅 이름",
-    "dmWith": "님과의 대화",
+    "dmWith": "DM",
     "noMessages": "첫 메시지를 보내보세요",
     "create": "대화 시작",
     "myChatsTab": "내 대화",

--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -137,6 +137,38 @@ describe('ChatListView — 다른 프로젝트 섹션 (story #2168 PR-②)', () 
 
     expect(sessionStorage.getItem('sprintable_pending_toast')).toBe('sprintable-content 프로젝트로 이동');
   });
+
+  // story #2972(선생님 admin 세션 실측) — "다른 프로젝트" DM 행은 title이 항상 NULL(list_
+  // conversations 관례)인데 BE가 participants를 안 줘 FE가 상대 이름을 조립할 재료가 없었다.
+  // 그 결과 "님과의 대화"(이름 앞이 빈 채 조사만 남은 접미 조각)가 그대로 노출됐다 — BE delta로
+  // participants를 실었으니 여기서도 ConversationRow와 동일하게 조립되는지 고정한다.
+  it('title=null인 DM 행은 participants로 상대 이름을 조립한다(#2972 fix)', async () => {
+    stubFetch([{
+      id: 'conv-outside-dm-1', type: 'dm', title: null,
+      project_id: 'proj-content', project_name: 'sprintable-content', project_slug: 'sprintable-content',
+      participants: [
+        { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+        { member_id: 'them-1', name: '댄', avatar_url: null, type: 'human' },
+      ],
+    }]);
+    await mount();
+    expect(container.textContent).toContain('댄');
+    expect(container.textContent).not.toContain('님과의 대화');
+  });
+
+  // 참가자 정보 자체가 없는 진짜 무재료 상황(구 데이터·participants 필드 부재)만 no-fiction
+  // 폴백으로 떨어진다 — "님과의 대화"라는 반쪽 문자열이 아니라 완결된 단어("DM", dmSection과
+  // 동일 관례)여야 한다.
+  it('participants가 없는 DM 행은 완결된 "DM" 폴백을 쓴다 — 조사만 남는 조립 금지(#2972 AC2)', async () => {
+    stubFetch([{
+      id: 'conv-outside-dm-2', type: 'dm', title: null,
+      project_id: 'proj-content', project_name: 'sprintable-content', project_slug: 'sprintable-content',
+    }]);
+    await mount();
+    expect(container.textContent).not.toContain('님과의 대화');
+    const nameEl = [...container.querySelectorAll('span')].find((el) => el.textContent === 'DM');
+    expect(nameEl).not.toBeUndefined();
+  });
 });
 
 // story #2968(선생님 실사용 발견) — 리스트가 avatar.tsx(정본, #2887/#2921)를 안 쓰고 Bot 아이콘/

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -40,6 +40,8 @@ interface ChatListViewProps {
 
 // story #2168 PR-② — 현재 프로젝트 밖에서 caller가 참여 중인 최근 대화(BE
 // GET /conversations/recent-outside-project, caller last_read_at DESC·최대 5개).
+// story #2972 — participants 추가(BE delta). DM 행은 title이 항상 NULL이라 이게 없으면
+// FE가 상대 이름을 조립할 재료가 아예 없었다("님과의 대화" 반쪽 문자열 버그의 원인).
 interface OutsideProjectConversation {
   id: string;
   type: 'dm' | 'group';
@@ -47,6 +49,7 @@ interface OutsideProjectConversation {
   project_id: string;
   project_name: string;
   project_slug: string;
+  participants?: Participant[];
 }
 
 function formatTime(iso: string): string {
@@ -216,13 +219,22 @@ function ConversationRow({
 // 병기)도 이쪽에만 있다. onClick은 부모가 준다(project 전환+토스트는 목록 상태를 알아야 함).
 function OutsideProjectRow({
   conv,
+  currentMemberId,
   onClick,
 }: {
   conv: OutsideProjectConversation;
+  currentMemberId: string;
   onClick: () => void;
 }) {
   const t = useTranslations('chats');
-  const displayName = conv.title ?? (conv.type === 'dm' ? t('dmWith') : t('groupSection'));
+  // story #2972 — DM 행 title은 항상 NULL(list_conversations 관례)이라 participants로
+  // 조립해야만 상대 이름이 뜬다(ConversationRow와 동일 패턴). BE가 이제 participants를
+  // 실어줘(delta) 여기서도 formatParticipantNames를 탈 수 있다 — participants가 비어있는
+  // 진짜 무재료 상황만 no-fiction 폴백(dmWith/groupSection, 완결된 단어로 수정됨)으로 떨어진다.
+  const displayName = conv.title ??
+    (conv.participants && conv.participants.length > 0
+      ? formatParticipantNames(conv.participants, currentMemberId, conv.type, t)
+      : conv.type === 'dm' ? t('dmWith') : t('groupSection'));
 
   return (
     <button
@@ -496,7 +508,7 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
         {t('otherProjectsSection')}
       </p>
       {outsideProjectConvs.map((conv) => (
-        <OutsideProjectRow key={conv.id} conv={conv} onClick={() => handleOutsideProjectClick(conv)} />
+        <OutsideProjectRow key={conv.id} conv={conv} currentMemberId={currentTeamMemberId} onClick={() => handleOutsideProjectClick(conv)} />
       ))}
     </div>
   );

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1507,6 +1507,12 @@ async def list_recent_conversations_outside_project(
     "오래 안 들어간 것부터" 캡의 의미론에 애초에 안 낀다 — list_conversations의
     `include_agent_conversations`처럼 별도 admin 전용 노출 축이 필요하면 그건 이 스토리
     스코프 밖의 별개 결정).
+
+    story #2972 — participants는 unread_count/latest_message와 달리 "미리보기용 부가정보"가
+    아니라 DM 행의 **유일한 이름 소스**다(Conversation.title은 DM에서 항상 NULL — 표시명은
+    참가자 이름으로 클라 조립하는 게 list_conversations 관례). 애초 스펙(#2168)이 이걸
+    "미리보기"로 묶어 함께 뺐던 게 원인 — limit≤5라 배치조회 비용은 무시 가능해 여기만
+    되살린다(unread_count/latest_message는 스펙 그대로 계속 뺀다).
     """
     sender = await _resolve_member(auth, org_id, db, project_id=None)
     uid = uuid.UUID(str(auth.user_id))
@@ -1537,6 +1543,12 @@ async def list_recent_conversations_outside_project(
     )
     rows = (await db.execute(stmt)).all()
 
+    # story #2972 — DM 행은 title이 항상 NULL(대화명은 참가자 이름으로 클라 조립, list_conversations
+    # 관례 그대로)인데 이 엔드포인트가 participants를 안 내려줘 FE가 조립할 재료 자체가 없었다
+    # ("님과의 대화"라는 접미 조각만 그대로 노출되던 원인). limit≤5라 배치조회 비용 무시 가능
+    # — list_conversations/get_conversation과 동일 헬퍼(_fetch_conversation_participants) 재사용.
+    conv_participants = await _fetch_conversation_participants([conv.id for conv, *_ in rows], db)
+
     return {
         "data": [
             {
@@ -1547,6 +1559,7 @@ async def list_recent_conversations_outside_project(
                 "project_name": project_name,
                 "project_slug": project_slug,
                 "last_read_at": last_read_at.isoformat() if last_read_at else None,
+                "participants": conv_participants.get(conv.id, []),
             }
             for conv, project_name, project_slug, last_read_at in rows
         ]

--- a/backend/tests/test_2168_pr2_recent_conversations_outside_project_realdb.py
+++ b/backend/tests/test_2168_pr2_recent_conversations_outside_project_realdb.py
@@ -64,7 +64,7 @@ async def _clean(s):
         f"(SELECT id FROM projects WHERE org_id='{ORG}')",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM org_members WHERE org_id='{ORG}'",
-        f"DELETE FROM users WHERE id='{CALLER_USER}'",
+        f"DELETE FROM users WHERE id IN ('{CALLER_USER}','{OTHER_USER}')",
         f"DELETE FROM organizations WHERE id='{ORG}'",
     ]:
         await s.execute(text(sql))
@@ -120,6 +120,41 @@ async def _add_conv(s, *, conv_id, project_id, caller_om_id, last_read_at):
     await s.execute(text(
         f"INSERT INTO conversation_participants (id,conversation_id,member_id,last_read_at) VALUES "
         f"(gen_random_uuid(),'{conv_id}','{caller_om_id}',{lra})"
+    ))
+    await s.commit()
+
+
+OTHER_USER = uuid.UUID("d2168000-0000-0000-0000-000000000099")
+
+
+async def _seed_other_org_member(s) -> uuid.UUID:
+    """story #2972 — DM 상대역 org_member(별도 user). TeamMember 행은 안 만든다(_seed_base와
+    동일 이유 — team_members는 실 배포 스키마에서 VIEW라 create_all 드리프트를 피한다)."""
+    await s.execute(text(
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{OTHER_USER}','other@d2168.test','x','Other Person',true,true,0,false,0)"
+    ))
+    om_row = (await s.execute(text(
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"(gen_random_uuid(),'{ORG}','{OTHER_USER}','member') RETURNING id"
+    ))).one()
+    await s.commit()
+    return om_row[0]
+
+
+async def _add_dm_conv(s, *, conv_id, project_id, caller_om_id, other_om_id, last_read_at):
+    """story #2972 — DM 대화는 title=NULL(list_conversations 관례 그대로, 표시명은 참가자
+    이름으로 클라 조립)로 심는다. group과 달리 참가자 2인(caller+other)."""
+    await s.execute(text(
+        f"INSERT INTO conversations (id,org_id,project_id,type,title,status) VALUES "
+        f"('{conv_id}','{ORG}','{project_id}','dm',NULL,'open')"
+    ))
+    lra = f"'{last_read_at.isoformat()}'" if last_read_at is not None else "NULL"
+    await s.execute(text(
+        f"INSERT INTO conversation_participants (id,conversation_id,member_id,last_read_at) VALUES "
+        f"(gen_random_uuid(),'{conv_id}','{caller_om_id}',{lra}),"
+        f"(gen_random_uuid(),'{conv_id}','{other_om_id}',NULL)"
     ))
     await s.commit()
 
@@ -185,5 +220,47 @@ async def test_caps_at_limit_dropping_least_recently_read():
         ids = [row["id"] for row in out["data"]]
         assert ids == [str(c) for c in conv_ids[:5]], ids
         assert str(conv_ids[5]) not in ids, "가장 오래 안 들어간(hours=5) 것부터 잘려야 함"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_dm_row_carries_participants_for_client_side_name_assembly():
+    """story #2972 — DM 행(title=NULL)이 participants를 실어 내려줘야 FE가 상대 이름을 조립할
+    재료가 생긴다(이전엔 participants가 아예 없어 "님과의 대화"라는 접미 조각만 노출되던 버그).
+    group 행은 title이 있어 회귀 없음(스펙 그대로 유지) 확인도 같이 잰다."""
+    from app.routers.conversations import list_recent_conversations_outside_project
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            caller_om_id = await _seed_base(s)
+            other_om_id = await _seed_other_org_member(s)
+            conv_dm = uuid.uuid4()
+            conv_group = uuid.uuid4()
+            await _add_dm_conv(
+                s, conv_id=conv_dm, project_id=PROJ_A,
+                caller_om_id=caller_om_id, other_om_id=other_om_id,
+                last_read_at=NOW - timedelta(hours=1),
+            )
+            await _add_conv(
+                s, conv_id=conv_group, project_id=PROJ_B,
+                caller_om_id=caller_om_id, last_read_at=NOW - timedelta(hours=2),
+            )
+        async with Session() as s:
+            out = await list_recent_conversations_outside_project(
+                project_id=PROJ_CURRENT, limit=5, db=s, auth=_auth(), org_id=ORG,
+            )
+        by_id = {row["id"]: row for row in out["data"]}
+
+        dm_row = by_id[str(conv_dm)]
+        assert dm_row["title"] is None, "DM 행 title은 항상 NULL(list_conversations 관례)"
+        dm_member_ids = {p["member_id"] for p in dm_row["participants"]}
+        assert dm_member_ids == {str(caller_om_id), str(other_om_id)}
+        other_p = next(p for p in dm_row["participants"] if p["member_id"] == str(other_om_id))
+        assert other_p["name"], "상대 참가자 이름이 채워져야 FE가 «X님과의 대화»를 조립할 수 있음"
+        assert other_p["name"] != str(other_om_id)[:8], "orphan fallback(8자 UUID)이 아니라 실명이어야 함"
+
+        group_row = by_id[str(conv_group)]
+        assert group_row["title"] == f"T-{conv_group}", "group 행 title 노출은 회귀 없음"
     finally:
         await eng.dispose()


### PR DESCRIPTION
## Summary
- story #2972(선생님 admin 세션 실측, 2968 실픽셀 재검 중 부수 발견): "내 대화" 탭 "다른 프로젝트" 섹션의 DM 행이 "님과의 대화"(이름 앞이 빈 채 조사만 남은 문자열)로 렌더되는 버그.
- 원인 층 2겹:
  1. **BE**: `GET /conversations/recent-outside-project`가 `participants`를 안 내려줌(#2168 스펙이 unread_count/latest_message와 묶어 "미리보기 부가정보"로 함께 뺐던 것) — DM 행 `title`은 `list_conversations` 관례대로 항상 NULL이라, FE가 이름을 조립할 재료 자체가 없었음.
  2. **FE**: `OutsideProjectRow`가 그 무재료 상황에서 접미사 전용 i18n 문자열(`chats.dmWith` = "님과의 대화")을 완결된 라벨인 것처럼 그대로 노출. `en.json`은 이미 "DM"(완결 단어)인데 `ko.json`만 접미조각이었음.

## Fix
- **BE** (`backend/app/routers/conversations.py`): `list_recent_conversations_outside_project`에 기존 `_fetch_conversation_participants` 배치조회를 추가(limit≤5라 비용 무시 가능 — `list_conversations`/`get_conversation`과 동일 헬퍼 재사용, 로직 복제 없음).
- **FE** (`chat-list-view.tsx`): `OutsideProjectRow`가 `ConversationRow`와 동일하게 `participants` → `formatParticipantNames`로 이름을 조립하도록 배선.
- **i18n**: 진짜 무재료 폴백(`chats.dmWith`)을 `en.json`과 나란히 "DM"(`dmSection`과 동일 관례)으로 정정 — "조사만 남는 조립" 재발 방지(AC2).

## Test plan
- [x] FE 회귀테스트 2건 신규(참가자 있음 → 이름 조립 / 참가자 없음 → 완결 폴백 "DM", "님과의 대화" 부재 확인) — `chat-list-view.test.tsx` 15 tests green
- [x] `src/components/chat` 스위트 전체 43 files / 457 tests green
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `pnpm build` EXIT=0
- [x] BE 회귀테스트 신규 1건(realdb — DM 행 participants 왕복, group 행 title 무회귀) — **로컬 docker 데몬 미기동으로 직접 실행은 못 했음(syntax/import는 `pytest --collect` + `py_compile`로 확인)**. CI real-DB 게이트(`Alembic upgrade head (fresh DB)` job)가 실제 실행처.
- [ ] dev 라이브 확인 — admin 세션으로 "다른 프로젝트" DM 행 상대명 노출 (카디르 QA 요청)

## 부수 확인 (AC1 그라운딩 시드)
아바타 generic 아이콘은 이름 미해석과 다른 층 — `OutsideProjectRow`는 애초에 `avatar_url`을 안 그리고 정적 아이콘만 쓴다(#2968 범위, 이 PR에서 안 건드림).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>