### PR TITLE
feat(#2975 AC4): 게이트 결재 이력 감사 표면

### DIFF
--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -7,7 +7,7 @@ import { ChevronLeft, CheckCircle, XCircle } from 'lucide-react';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { GateEvidence, gateNeedsAction, gateDecision } from '@/components/cage/gate-evidence';
+import { GateEvidence, GateActivityHistory, gateNeedsAction, gateDecision } from '@/components/cage/gate-evidence';
 import { GateSignatureApproval } from '@/components/cage/gate-signature-approval';
 import { GateUndoButton, isUndoEligible } from '@/components/cage/gate-undo-button';
 import { GateDiscussDialog } from '@/components/cage/gate-discuss-dialog';
@@ -347,6 +347,13 @@ export default function GateDetailPage() {
                     언급한 대화」 역참조. 기성 EntityBacklinksSection(3곳 소비 중) 그대로 재사용 —
                     신규 뷰어 0. gate는 TARGET_ONLY라 액션 없이 조회만(§8 계약과 정합). */}
                 <EntityBacklinksSection entityType="gate" entityId={gate.id} />
+
+                {/* story #2975 AC4(PO 확定 2026-08-24) — 결재 이력(누가·언제·무엇을·어느 SHA에).
+                    needsAction/canAct 분기와 무관하게 항상 렌더 — 감사 표면은 액션 가능 여부와
+                    별개로 "사람이 보는 쪽"에 항상 서 있어야 실사고 때 쓰인다(PO 요구 ㉯). */}
+                <div className="border-t border-proof-line-soft pt-3">
+                  <GateActivityHistory gateId={gate.id} />
+                </div>
               </div>
             }
           />

--- a/apps/web/src/app/api/gates/[id]/activity/route.ts
+++ b/apps/web/src/app/api/gates/[id]/activity/route.ts
@@ -1,0 +1,9 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// story #2975 AC4(PO 확定 2026-08-24) — 사람 결재 행위(approve/reject/undo/void/override) 이력.
+// github-check-events(위 폴더 형제)와 대칭인 gate-scope sub-resource. GateEvidence가 지연
+// 로드하는 소량 read-only 리스트.
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/gates/${id}/activity`);
+}

--- a/apps/web/src/components/cage/gate-evidence-render.test.tsx
+++ b/apps/web/src/components/cage/gate-evidence-render.test.tsx
@@ -10,7 +10,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
-import { GateEvidence } from './gate-evidence';
+import { GateEvidence, GateActivityHistory } from './gate-evidence';
 import { fetchWithAuth } from '@/lib/db/client';
 import type { GateItem } from '@/components/kanban/types';
 import koMessages from '../../../messages/ko.json';
@@ -286,5 +286,80 @@ describe('GateEvidence — 측정 판정 초안 렌더(story #2862)', () => {
     });
 
     expect(container.textContent).not.toContain(koMessages.cage.hypothesisDraftBadge);
+  });
+});
+
+// story #2975 AC4(PO 확定 2026-08-24) — 결재 이력(GET /gates/{id}/activity) 실 응답 shape
+// 마운트. gates.py GateActivityItem과 정합(id/action/actor_id/actor_name/context/created_at).
+describe('GateActivityHistory — 결재 이력 실 응답 shape 마운트(story #2975 AC4)', () => {
+  afterEach(() => {
+    vi.mocked(fetchWithAuth).mockReset();
+  });
+
+  it('승인+취소 두 건이 actor_name·action 라벨·SHA와 함께 그려진다(미스터리①②의 UI판)', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([
+        {
+          id: 'log-2', action: 'gate_resolution_undone', actor_id: 'm-1', actor_name: 'po@test.com',
+          context: { previous_status: 'approved', previous_approved_head_sha: 'sha-a1b2c3d4e5' },
+          created_at: '2026-08-23T19:05:00Z',
+        },
+        {
+          id: 'log-1', action: 'gate_approved', actor_id: 'm-1', actor_name: 'po@test.com',
+          context: { head_sha: 'sha-a1b2c3d4e5' }, created_at: '2026-08-23T18:57:00Z',
+        },
+      ]),
+    } as Response);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateActivityHistory gateId="gate-1" />)); });
+
+    expect(fetchWithAuth).toHaveBeenCalledWith('/api/gates/gate-1/activity');
+    expect(container.textContent).toContain('po@test.com');
+    expect(container.textContent).toContain(koMessages.cage.gateActivityActionApproved);
+    expect(container.textContent).toContain(koMessages.cage.gateActivityActionUndone);
+    expect(container.textContent).toContain('sha-a1b'); // SHA 짧은형(7자) 표시.
+  });
+
+  it('actor_name이 없으면(orphan) 정직한 폴백 문구를 보여준다(actor_id로 지어내지 않음)', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([
+        { id: 'log-1', action: 'gate_voided', actor_id: 'm-gone', actor_name: null, context: { reason: 'x' }, created_at: '2026-08-23T00:00:00Z' },
+      ]),
+    } as Response);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateActivityHistory gateId="gate-1" />)); });
+
+    expect(container.textContent).toContain(koMessages.cage.gateActivityActorFallback);
+    expect(container.textContent).toContain(koMessages.cage.gateActivityActionVoided);
+  });
+
+  it('빈 이력은 "이력 없음"을 정직하게 보여준다(로드 실패와 구분)', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({ ok: true, json: () => Promise.resolve([]) } as Response);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateActivityHistory gateId="gate-1" />)); });
+
+    expect(container.textContent).toContain(koMessages.cage.gateActivityEmpty);
+  });
+
+  it('조회 실패는 조용히(카드 붕괴 없이) 아무것도 안 그린다', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({ ok: false, status: 500 } as Response);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(wrap(<GateActivityHistory gateId="gate-1" />)); });
+
+    expect(container.textContent).not.toContain(koMessages.cage.gateActivityHistoryTitle);
   });
 });

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -284,6 +284,80 @@ function GithubRependingReason({ gateId }: { gateId: string }) {
   );
 }
 
+// story #2975 AC4(PO 확定 2026-08-24) — backend/app/routers/gates.py GateActivityItem과 정합.
+interface GateActivityLogItem {
+  id: string;
+  action: string;
+  actor_id: string | null;
+  actor_name: string | null;
+  context: Record<string, unknown>;
+  created_at: string;
+}
+
+// action(BE ActivityLog.action 원문, gate_service.py) → i18n 키. 매핑에 없는 action은 원문 그대로
+// 폴백 렌더(신규 action 추가 시 이 화면이 죽는 대신 정직하게 raw string을 보여줌 — no-fiction).
+const GATE_ACTIVITY_LABEL_KEY: Record<string, string> = {
+  gate_approved: 'gateActivityActionApproved',
+  gate_rejected: 'gateActivityActionRejected',
+  gate_resolution_undone: 'gateActivityActionUndone',
+  gate_voided: 'gateActivityActionVoided',
+  gate_overridden: 'gateActivityActionOverridden',
+};
+
+/**
+ * story #2975 AC4(PO 확定 2026-08-24) — 「누가·언제·무엇을·어느 SHA에」 결재했는지. 2026-08-23
+ * 두 실사고(PR#3402 취소 반영 여부 판별 불가·PR#3406 approved의 actor 판별 불가)의 근본원인이
+ * 이 표면 부재였다 — `GET /api/gates/{id}/activity`(github-check-events와 대칭)를 최신순 지연
+ * 로드. 실패/빈 응답은 GithubRependingReason과 동형으로 조용히(카드 붕괴 방지) — 단 성공+0건은
+ * "이력 없음"을 정직하게 보여준다(신규 gate에서 당연한 상태와, 로드 실패를 구분).
+ */
+export function GateActivityHistory({ gateId }: { gateId: string }) {
+  const t = useTranslations('cage');
+  const [items, setItems] = useState<GateActivityLogItem[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchWithAuth(`/api/gates/${gateId}/activity`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`status ${res.status}`))))
+      .then((data: unknown) => {
+        // BE는 bare array를 낸다(github-check-events와 대칭, {data} 봉투 아님) — 방어적으로
+        // 배열이 아니면(테스트 mock의 범용 폴백 등) 빈 목록으로 조용히 폴백(카드 붕괴 방지).
+        if (!cancelled) setItems(Array.isArray(data) ? (data as GateActivityLogItem[]) : []);
+      })
+      .catch(() => {
+        if (!cancelled) setItems(null);
+      });
+    return () => { cancelled = true; };
+  }, [gateId]);
+
+  if (items === null) return null;
+
+  return (
+    <div>
+      <p className="mb-1.5 text-[11px] font-semibold text-muted-foreground">{t('gateActivityHistoryTitle')}</p>
+      {items.length === 0 ? (
+        <p className="text-[11px] italic text-muted-foreground">{t('gateActivityEmpty')}</p>
+      ) : (
+        <ul className="space-y-1">
+          {items.map((item) => {
+            const sha = typeof item.context['head_sha'] === 'string' ? (item.context['head_sha'] as string) : null;
+            const labelKey = GATE_ACTIVITY_LABEL_KEY[item.action];
+            return (
+              <li key={item.id} className="text-[11px] text-muted-foreground">
+                <span className="font-medium text-foreground">{item.actor_name ?? t('gateActivityActorFallback')}</span>
+                {' · '}
+                {labelKey ? t(labelKey) : item.action}
+                {sha ? <span className="ml-1 font-mono">{t('githubCheckShaLabel', { sha: sha.slice(0, 7) })}</span> : null}
+                <span className="ml-1">· {new Date(item.created_at).toLocaleString()}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 // read-only PR 칩(gate State C 납품 컬럼). 관리는 story 상세 PrLinkSection — 여기선 표시·새탭 링크만.
 function GatePrChip({ pr }: { pr: PrLinkFact }) {
   return (

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1169,6 +1169,78 @@ async def list_gate_github_check_events_endpoint(
     return [GateGithubCheckEventResponse.model_validate(r) for r in rows]
 
 
+class GateActivityItem(BaseModel):
+    """story #2975 AC4(PO 확定 2026-08-24) — 사람 결재 행위(approve/reject/undo/void/override)
+    이력. `ActivityLog`(story #2631이 이미 append-only로 기록해 두고 있던 것)를 gate 스코프로
+    투영한다 — 신규 테이블 0."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    action: str
+    actor_id: uuid.UUID | None
+    actor_name: str | None = None
+    context: dict
+    created_at: datetime
+
+
+@router.get("/{id}/activity", response_model=list[GateActivityItem])
+async def list_gate_activity_endpoint(
+    id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> list[GateActivityItem]:
+    """story #2975 AC4 — 「누가·언제·무엇을·어느 SHA에」 결재했는지 조회. 2026-08-23 두 실사고
+    (PR#3402 취소 반영 여부 판별 불가·PR#3406 approved의 actor 판별 불가)가 이 표면 부재가
+    원인이었다 — `ActivityLog`엔 이미 기록돼 있었고(transition_gate/undo_gate_resolution)
+    조회 표면만 없었다. `github-check-events`(위)와 대칭인 gate-scope sub-resource로 신설
+    (범용 `/api/v2/activity-logs?entity_type=gate&entity_id=`도 같은 데이터를 반환하지만,
+    이 엔드포인트가 이미 하는 project-access 존재비노출 authz를 그쪽은 안 함 — gate 상세와
+    같은 접근권 경계가 필요해 이 라우터에 둔다)."""
+    from app.models.activity_log import ActivityLog
+    from app.services.member_resolver import lookup_members_by_ids
+
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise HTTPException(status_code=404, detail="Gate not found")
+
+    project_id = await resolve_work_item_project_id(
+        session, org_id, gate.work_item_type, gate.work_item_id,
+    )
+    if project_id is not None:
+        await require_project_access(session, uuid.UUID(auth.user_id), project_id, org_id,
+                                      not_found_detail="Gate not found")
+    elif not is_known_project_agnostic_work_item_type(gate.work_item_type):
+        raise HTTPException(status_code=404, detail="Gate not found")
+
+    rows = (await session.execute(
+        select(ActivityLog)
+        .where(
+            ActivityLog.entity_type == "gate", ActivityLog.entity_id == id,
+            ActivityLog.org_id == org_id,
+        )
+        .order_by(ActivityLog.created_at.desc())
+    )).scalars().all()
+
+    actor_ids = {r.actor_id for r in rows if r.actor_id}
+    actor_name_map: dict[uuid.UUID, str] = {}
+    if actor_ids:
+        resolved = await lookup_members_by_ids(actor_ids, session)
+        actor_name_map = {mid: rm.name for mid, rm in resolved.items() if rm and rm.name}
+
+    return [
+        GateActivityItem(
+            id=r.id, action=r.action, actor_id=r.actor_id,
+            actor_name=actor_name_map.get(r.actor_id) if r.actor_id else None,
+            context=r.context, created_at=r.created_at,
+        )
+        for r in rows
+    ]
+
+
 @router.post("/{id}/transition", response_model=GateResponse)
 async def transition_gate_endpoint(
     id: uuid.UUID,

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -759,6 +759,12 @@ async def transition_gate(
             "work_item_type": gate.work_item_type,
             "work_item_id": str(gate.work_item_id),
             "note": note,
+            # story #2975 AC4(PO 확定 2026-08-24) — 「이 액션이 어느 SHA에 대한 것이었나」를
+            # 이 시점의 gate.github_check_run_sha로 스냅샷. gate.approved_head_sha 컬럼은
+            # 이후 재-pending 시 null로 되돌아가(gate_github_check.py::reopen_gate_if_new_sha)
+            # 그 시점의 역사가 사라지므로, append-only인 이 context가 유일한 영속 기록이 된다.
+            # merge 게이트가 아니면 애초에 None(무관 필드 — 조용히 무해).
+            "head_sha": gate.github_check_run_sha,
         },
     )
 
@@ -892,6 +898,8 @@ async def undo_gate_resolution(
     _prev_resolver_id = gate.resolver_id
     _prev_resolved_at = gate.resolved_at
     _prev_note = gate.resolution_note
+    # story #2975 AC4 — approved_head_sha(무엇이 승인됐었나)도 취소로 곧 사라질 값이라 스냅샷.
+    _prev_approved_head_sha = gate.approved_head_sha
 
     from app.services.doc import DOC_GATE_TYPE, DOC_GATE_WORK_ITEM_TYPE
     if gate.work_item_type == DOC_GATE_WORK_ITEM_TYPE and gate.gate_type == DOC_GATE_TYPE:
@@ -926,6 +934,8 @@ async def undo_gate_resolution(
             "previous_resolver_id": str(_prev_resolver_id) if _prev_resolver_id else None,
             "previous_resolved_at": _prev_resolved_at.isoformat() if _prev_resolved_at else None,
             "previous_note": _prev_note,
+            # story #2975 AC4 — 무엇이 취소됐는지(어느 SHA에 대한 승인이었는지)의 스냅샷.
+            "previous_approved_head_sha": _prev_approved_head_sha,
         },
     )
 
@@ -1045,7 +1055,8 @@ async def void_gate(
     ⚠️void ≠ approval: 묶인 line step_run 을 ``skipped`` 로 해소해 엔티티가 unblock(re-route 가능)되되
     "승인됨"으로 전진하지 않는다(전이 미적용). voider 는 인증 caller(라우터가 강제·body 신뢰 금지·
     S23 RC① 패턴). audit = gate 행(status='voided'·resolver_id·resolution_note)이 distinct 추적
-    (approve/reject 와 **status 로 구분**) + app-log. void=복구 액션이라 strict SoD 불요(PO Q4).
+    (approve/reject 와 **status 로 구분**) + ActivityLog(story #2975 AC4, approve/reject/undo와
+    동형 — 이전엔 logger.info뿐이라 DB 조회 불가였음). void=복구 액션이라 strict SoD 불요(PO Q4).
     """
     gate = (await session.execute(
         select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
@@ -1075,8 +1086,27 @@ async def void_gate(
             sr.routing_reason = f"gate voided by admin: {reason}"[:500]
             sr.resolved_at = datetime.now(timezone.utc)
 
-    # void 는 별개 액션으로 app-log 추적(DB distinct 추적은 gate.status='voided'). ⚠️permission_audit_logs
-    # 는 action CHECK(member_* 만)라 사용 불가·HitlGateAudit 는 enforce-coverage 전용 → gate 행+log 채택.
+    # story #2975 AC4(PO 확定 2026-08-24) — 위 주석이 남긴 이유(permission_audit_logs=member 전용·
+    # HitlGateAudit=enforce-coverage 전용)로 여태 logger.info() 뿐이었다(Cloud Logging 한정,
+    # DB 비영속·조회불가) — 진짜 감사 갭이었다. approve/reject/undo와 동형으로 ActivityLog에
+    # 옮긴다(신규 테이블 불요, 기존 표 재사용).
+    from app.services.activity_log import ActivityLogService
+
+    await ActivityLogService(session).record(
+        org_id=org_id,
+        action="gate_voided",
+        actor_id=voider_id,
+        actor_type="human",
+        entity_type="gate",
+        entity_id=gate.id,
+        context={
+            "gate_type": gate.gate_type,
+            "work_item_type": gate.work_item_type,
+            "work_item_id": str(gate.work_item_id),
+            "reason": reason,
+            "head_sha": gate.github_check_run_sha,
+        },
+    )
     logger.info(
         "gate_voided org=%s gate=%s voider=%s work=%s/%s step_run=%s reason=%s",
         org_id, gate_id, voider_id, gate.work_item_type, gate.work_item_id, sr_id, reason,
@@ -1603,6 +1633,26 @@ async def override_gate(
             },
             correlation_id=sr.correlation_id,
         ))
+    # story #2975 AC4(PO 확定 2026-08-24, ㉮) — 위 WorkflowLineStepRunEvent는 sr(line step_run)이
+    # 있을 때만 쓰인다. line-less override는 지금까지 gate.neutral_facts(위)뿐이었는데 그건
+    # mutable이라 다음 전이가 덮어써 감사 기록이 못 된다 — line 유무 무관하게 ActivityLog에도
+    # 항상 남긴다(transition_gate가 이미 base gate_approved/rejected를 쓰지만, override 고유
+    # 메타(bypassed_sod·override_reason)는 그 안 담기므로 별개 action으로 append).
+    from app.services.activity_log import ActivityLogService
+
+    await ActivityLogService(session).record(
+        org_id=org_id,
+        action="gate_overridden",
+        actor_id=owner_id,
+        actor_type="human",
+        entity_type="gate",
+        entity_id=gate.id,
+        context={
+            "decision": decision, "reason": reason, "bypassed_sod": True,
+            "bypassed_approver_ids": [str(x) for x in bypassed],
+            "head_sha": gate.github_check_run_sha,
+        },
+    )
     logger.warning(
         "gate_overridden org=%s gate=%s decision=%s owner=%s bypassed_approvers=%d reason=%s",
         org_id, gate_id, decision, owner_id, len(bypassed), reason,

--- a/backend/tests/test_2975_gate_activity_audit_trail_realdb.py
+++ b/backend/tests/test_2975_gate_activity_audit_trail_realdb.py
@@ -1,0 +1,282 @@
+"""story #2975 AC4(PO 확定 2026-08-24) — 게이트 결재 이력 감사 표면. 2026-08-23 두 실사고의
+근본 미스터리를 새 `GET /gates/{id}/activity`로 실제 재현+해소하는 양성대조:
+
+미스터리①(PR#3402): PO가 승인 취소(5분 창)를 눌렀는데, 그게 서버에 반영됐는지 판별 불가했다.
+→ approve→undo 시퀀스를 만들고, 새 엔드포인트가 「누가 언제 취소했는지」를 실제로 보여주는지.
+
+미스터리②(PR#3406): 어떤 SHA에 approved 이벤트가 떴는데 그 승인의 actor가 누구였는지 판별
+불가했다. → approve 시퀀스를 만들고, 새 엔드포인트가 actor_name까지 정확히 해석하는지.
+
+부수: void_gate(이전엔 logger.info뿐 — DB 미기록)·override_gate(line-less 시 neutral_facts만,
+mutable이라 감사 불가)도 이제 ActivityLog에 남아 같은 표면에서 조회되는지."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_common(session, *, email_prefix: str = "po", org_role: str = "member"):
+    """org_role — is_org_owner_or_admin(void 엔드포인트 인가)이 org_members.role을 직접 보므로
+    void 테스트는 'owner'|'admin' 필요. approve/undo는 project_access role(owner)로 충분."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    # User 모델엔 name 필드가 없다(member_resolver.py 실측 — OrgMember의 display name은
+    # user.email 배치 조회로 대체된다) — email에 식별 가능한 prefix를 심어 actor_name 대조.
+    user = User(id=uuid.uuid4(), email=f"{email_prefix}-{uuid.uuid4().hex[:8]}@test.com",
+                hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user.id, role=org_role)
+    session.add(om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om.id,
+        permission="granted", role="owner",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "user_id": user.id,
+            "member_id": om.id, "email": user.email}
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_approve_then_undo_answers_mystery1_was_cancel_applied():
+    """미스터리① 양성대조 — approve→undo 시퀀스가 새 엔드포인트에 시간순으로 둘 다 뜨는가.
+    실사고에서 판별 불가했던 「PO 취소가 서버에 반영됐나」를 이제 조회로 답할 수 있어야 한다."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    SHA = "sha-mystery1-2eadc1f44"
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s, email_prefix="po")
+            story = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="#2975 AC4 미스터리① 재현",
+            )
+            s.add(story)
+            await s.commit()
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending",
+                approved_head_sha=None, github_check_run_id=1, github_check_run_sha=SHA,
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "approved", "note": "테스트 승인", "evidence_viewed": True,
+                      "reviewed_head_sha": SHA},
+            )
+            assert resp.status_code == 200, resp.text
+
+            resp = await client.post(f"/api/v2/gates/{gate_id}/undo")
+            assert resp.status_code == 200, resp.text
+
+            resp = await client.get(f"/api/v2/gates/{gate_id}/activity")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()
+            actions = [i["action"] for i in items]
+            # created_at.desc() — 최신(undo)이 먼저.
+            assert actions[:2] == ["gate_resolution_undone", "gate_approved"], actions
+
+            undo_item = items[0]
+            assert undo_item["actor_name"], "취소한 사람 이름이 조회돼야 미스터리①이 실제로 풀림"
+            assert undo_item["context"]["previous_status"] == "approved"
+            assert undo_item["context"]["previous_approved_head_sha"] == SHA, (
+                "무엇이(어느 SHA가) 취소됐는지도 남아야 한다"
+            )
+
+            approve_item = items[1]
+            assert approve_item["actor_name"], "승인한 사람 이름도 조회돼야 함(미스터리② 동형)"
+            assert approve_item["context"]["head_sha"] == SHA
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_approve_actor_resolves_by_name_answers_mystery2():
+    """미스터리② 양성대조 — approved 이벤트의 actor가 실명으로 조회되는가."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s, email_prefix="teacher")
+            story = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="#2975 AC4 미스터리② 재현",
+            )
+            s.add(story)
+            await s.commit()
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+                gate_type=MERGE_GATE_TYPE, status="pending",
+                approved_head_sha=None, github_check_run_id=1, github_check_run_sha="sha-a4ee601e6",
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "approved", "note": "실 승인", "evidence_viewed": True,
+                      "reviewed_head_sha": "sha-a4ee601e6"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            resp = await client.get(f"/api/v2/gates/{gate_id}/activity")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()
+            assert len(items) == 1
+            assert items[0]["action"] == "gate_approved"
+            assert items[0]["actor_id"] == str(seeded["member_id"])
+            # User엔 name 필드가 없어(member_resolver.py 실측) actor_name은 email로 해석된다.
+            assert items[0]["actor_name"] == seeded["email"], items[0]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_void_gate_now_recorded_in_activity_log():
+    """void_gate — 이전엔 logger.info뿐이라 이 엔드포인트에 하나도 안 떴다(진짜 갭). 이제는 뜬다."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            # void 엔드포인트=org owner/admin 전용(is_org_owner_or_admin) — org_role 필요.
+            seeded = await _seed_common(s, email_prefix="admin", org_role="owner")
+            story = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="#2975 AC4 void 회귀",
+            )
+            s.add(story)
+            await s.commit()
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+                gate_type="doc_approval", status="pending",
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/void", json={"reason": "잘못 생성됨"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            resp = await client.get(f"/api/v2/gates/{gate_id}/activity")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()
+            assert len(items) == 1, "void_gate가 ActivityLog에 안 남으면 여기 0건(회귀)"
+            assert items[0]["action"] == "gate_voided"
+            assert items[0]["context"]["reason"] == "잘못 생성됨"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_doc_gate_cascade_scope_realdb.py
+++ b/backend/tests/test_doc_gate_cascade_scope_realdb.py
@@ -32,6 +32,9 @@ async def _session():
     import app.models  # noqa: F401
     import app.models.participation  # noqa: F401
     import app.models.workflow_line  # noqa: F401
+    # story #2975 — void_pending_doc_gate가 void_gate()를 타므로 이제 ActivityLog도 씀
+    # (이전엔 logger.info뿐이라 미등재였음).
+    import app.models.activity_log  # noqa: F401
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql://"):
         if url.startswith(prefix):

--- a/backend/tests/test_edg_s30_void_recovery.py
+++ b/backend/tests/test_edg_s30_void_recovery.py
@@ -40,6 +40,8 @@ async def _session():
     import app.models  # noqa: F401
     import app.models.participation  # noqa: F401  (org_gate_override FK→participation_role)
     import app.models.workflow_line  # noqa: F401
+    # story #2975 — void_gate()가 이제 ActivityLog에도 쓴다(이전엔 logger.info뿐이라 미등재였음).
+    import app.models.activity_log  # noqa: F401
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql://"):
         if url.startswith(prefix):

--- a/backend/tests/test_edg_s33_override.py
+++ b/backend/tests/test_edg_s33_override.py
@@ -130,17 +130,34 @@ async def test_override_rejected():
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
 async def test_override_single_gate_no_approvers():
-    """단일 gate(approver row 없음)도 override 가능(force-resolve)·닫을 approver 0."""
+    """단일 gate(approver row 없음)도 override 가능(force-resolve)·닫을 approver 0.
+
+    story #2975 AC4(PO 확定 2026-08-24, ㉮) — line-less override는 sr(step_run)이 없어
+    WorkflowLineStepRunEvent가 안 쓰인다. 이전엔 gate.neutral_facts(mutable, 다음 전이가
+    덮어씀)뿐이라 감사 기록이 못 됐다 — 이제 ActivityLog(action="gate_overridden")에도
+    남는지 직접 확認(이 파일에서 유일한 실 line-less 케이스)."""
+    from sqlalchemy import select
+    from app.models.activity_log import ActivityLog
     from app.services.gate_service import override_gate
     engine, Session = await _session()
     async with Session() as s:
         org = uuid.uuid4()
+        owner = uuid.uuid4()
         gate, _, _ = await _seed_gate(s, org, n_approvers=0)
         await s.commit()
-        result = await override_gate(s, org, gate.id, uuid.uuid4(), "approved", "단일 gate 강제 통과")
+        result = await override_gate(s, org, gate.id, owner, "approved", "단일 gate 강제 통과")
         await s.commit()
         assert result.status == "approved"
         assert result.neutral_facts["overridden"] is True
+
+        log = (await s.execute(
+            select(ActivityLog).where(
+                ActivityLog.entity_id == gate.id, ActivityLog.action == "gate_overridden",
+            )
+        )).scalar_one()
+        assert log.actor_id == owner
+        assert log.context["bypassed_sod"] is True
+        assert log.context["reason"] == "단일 gate 강제 통과"
     await engine.dispose()
 
 


### PR DESCRIPTION
[SID:2975]

## 요약
2026-08-23 두 실사고(PR#3402 PO 취소 반영 여부 판별 불가·PR#3406 approved actor 판별 불가)의 근본원인 그라운딩 — 이력 기록 부재가 아니라 **조회 표면 부재**였다. `ActivityLog`는 이미 approve/reject/undo를 기록 중(story #2631)이었고, 문제는 조회할 곳이 없었다는 것.

## 층 가르기 (그라운딩 결과)
- **이미 남음**: `gate_approved`/`gate_rejected`(transition_gate)·`gate_resolution_undone`(undo_gate_resolution).
- **진짜 갭 ①**: `void_gate` — `logger.info()`뿐, DB 미기록(`permission_audit_logs`는 member 권한 전용이라 gate_id 개념조차 없음).
- **진짜 갭 ②**: `override_gate` line-less(step_run 없는 override) — `gate.neutral_facts`(mutable, 다음 전이가 덮어씀)뿐이라 감사 기록이 못 됨. line-bound는 `WorkflowLineStepRunEvent`로 이미 남지만 대칭이 안 맞음.
- **공통 갭**: 어느 경로도 "어느 SHA에 대한 것이었나" 스냅샷이 없음 — `gate.approved_head_sha`는 재-pending 시 null화돼 역사가 사라짐.

## 처방 (페드루 PO 설계 확定 2026-08-24)
1. `void_gate`에 `ActivityLogService.record()` 추가(신규 테이블 0 — approve/undo와 완전 동형 재사용).
2. `override_gate` line-less 분기도 ActivityLog에 남김(line-bound `WorkflowLineStepRunEvent`와 대칭 완성).
3. approve/undo/override 각 context에 `head_sha` 스냅샷 필드 추가.
4. `GET /api/v2/gates/{id}/activity` 신설 — `github-check-events`(기존 선례)와 대칭인 gate-scope sub-resource. 범용 `/api/v2/activity-logs?entity_type=gate&entity_id=`도 같은 데이터를 반환하지만, 이 엔드포인트가 이미 하는 project-access 존재비노출 authz가 그쪽엔 없어 gate 상세와 같은 접근권 경계가 필요해 별도로 둠.
5. FE: `GateActivityHistory`(gate-evidence.tsx 신설 컴포넌트, 카디르군이 지적한 미사용 `gateActivity*` i18n 키 7개를 여기서 소비) — 결재함 상세 페이지 하단에 needsAction/canAct 분기와 무관하게 항상 렌더.

## 완료 판별 (PO 요구 — 실사고 실 데이터로 두 미스터리가 실제로 풀리는가)
dev DB `pgstat-probe-dev` job으로 실측(gate `7066ca7b-6f39-4dce-84df-7da062ebfaa6`, PR-4 오버레이, story 2969):

| 시각 | action | actor | 비고 |
|---|---|---|---|
| 09:58:30 | gate_approved | 2fd14616... | note: "head 2eadc1f44 확認" |
| 09:59:22 (52초 後) | gate_resolution_undone | 2fd14616... (동일) | context.previous_resolved_at=09:58:30 스냅샷 |
| 10:06:06 (7분 後) | gate_approved | e75ca548... | |

- **미스터리①**("PO 취소가 서버에 반영됐나 판별 불가") = **YES, 반영됐다** — 같은 actor가 52초 후 명시적으로 되돌렸고, 그 사실이 ActivityLog에 이미 있었다(조회 표면만 없었을 뿐).
- **미스터리②**("두 번째 approved의 actor가 누구인지 판별 불가") = **실명 조회 가능** — team_members 조인 결과 두 actor_id 모두 "송윤재"로 해석됨(같은 사람의 서로 다른 member 행). 조용한 유령 승인이 아니라 추적 가능한 실 인간 행위였음을 실증.

## Test plan
- [x] BE: 신규 realdb 테스트 3종(미스터리①②양성대조+void 회귀) + void/override/undo/doc-cascade 기존 스위트 전부 green
- [x] FE: gate-evidence-render.test.tsx 신규 4종(승인+취소 렌더·actor 폴백·빈 이력·실패 침묵) + 기존 page.test.tsx 16종 green(46 tests)
- [x] tsc --noEmit 0 errors, eslint 0 issues
- [x] dev DB 실측으로 완료 판별 기준 충족(위 표)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AbjN7dJp11Nng4AVZY3Xw