### PR TITLE
[SID:2976] tailwind-merge 커스텀 테마 충돌군 근본처방 — font-weight+text-size 축

### DIFF
--- a/apps/web/src/components/ui/page-header.test.tsx
+++ b/apps/web/src/components/ui/page-header.test.tsx
@@ -18,12 +18,16 @@ async function mount(node: React.ReactNode): Promise<{ el: HTMLElement; root: Ro
 }
 
 // story #2969 §1.3/§2 C행(PR-6) 갱신 — Display tier 적용: font-bold(700)→
-// --font-weight-editorial-heading(820, 인라인 style — 과거 font-editorial-heading
-// 유틸리티가 tailwind-merge와 충돌해 font-heading을 지우던 것을 회피)·
-// tracking-tight→tracking-[-0.02em](§1.3 Display 정의 그대로).
+// --font-weight-editorial-heading(820)·tracking-tight→tracking-[-0.02em]
+// (§1.3 Display 정의 그대로).
 // story #2974 §1(PR-D0) 갱신 — 페이스(family)가 font-heading(Pretendard 고정)에서
 // font-display(§1 신규 토큰, D0 값=var(--font-sans)라 시각 변화 0)로 전환.
-const ORIGINAL_TITLE_CLASSES = 'font-display text-2xl tracking-[-0.02em] text-foreground md:text-3xl';
+// story #2976(근본처방) 갱신 — 무게가 인라인 style에서 유틸리티 클래스(font-editorial-heading)
+// 로 복귀. cn()이 extendTailwindMerge로 이 이름을 font-weight 충돌군에 등록해 font-display와
+// 안전하게 병기된다(lib/utils.ts 참고) — 더 이상 인라인 style 우회가 필요 없다.
+// story #2974 D1 revert(PO 판정 2026-08-24, PR#3416) — D1이 반려돼 페이스는 다시 D0 값
+// (font-display=var(--font-sans), 시각 무변화)이다.
+const ORIGINAL_TITLE_CLASSES = 'font-display font-editorial-heading text-2xl tracking-[-0.02em] text-foreground md:text-3xl';
 
 function classSet(s: string): Set<string> {
   return new Set(s.split(/\s+/).filter(Boolean));
@@ -36,12 +40,14 @@ describe('PageHeader size variant (story #2879)', () => {
     expect(classSet(h1.className)).toEqual(classSet(ORIGINAL_TITLE_CLASSES));
   });
 
-  // story #2969 §1.3(PR-6) — Display tier 무게(820)가 인라인 style로 걸린다(tailwind-merge
-  // 충돌 회피, 위 주석 참고).
-  it('h1이 --font-weight-editorial-heading을 인라인 font-weight로 갖는다', async () => {
+  // story #2976(근본처방) — 무게가 인라인 style이 아니라 font-editorial-heading 유틸리티
+  // 클래스로 걸린다(twMerge가 이제 font-display와의 병기를 정확한 충돌군으로 구분해 안전).
+  it('h1이 인라인 style 없이 font-editorial-heading 클래스로 무게를 받는다', async () => {
     const { el } = await mount(<PageHeader title="제목" />);
     const h1 = el.querySelector('h1')! as HTMLElement;
-    expect(h1.style.fontWeight).toBe('var(--font-weight-editorial-heading)');
+    expect(h1.className).toContain('font-editorial-heading');
+    expect(h1.className).toContain('font-display');
+    expect(h1.style.fontWeight).toBe('');
   });
 
   it('size=page가 기존과 동일하다', async () => {

--- a/apps/web/src/components/ui/page-header.tsx
+++ b/apps/web/src/components/ui/page-header.tsx
@@ -24,9 +24,7 @@ import { cn } from '@/lib/utils';
  */
 // story #2969 §1.3/§2 C행(doc proofline-system-layer-2969, PR-6) — Display tier(에디토리얼
 // 디스플레이 타이포) 적용: font-bold(700)→--font-weight-editorial-heading(820)·
-// tracking-tight→-0.02em(§1.3 Display 정의 그대로). ⚠️무게는 유틸리티 클래스가 아니라
-// 인라인 style로 건다 — tailwind-merge가 페이스 클래스와 (구)무게 클래스를 같은 충돌군으로
-// 오인해 하나를 지우던 전례가 있었다(직접 실측 완료, page-header.test.tsx에 회귀가드).
+// tracking-tight→-0.02em(§1.3 Display 정의 그대로).
 // §1.4가 이 파일의 "히어로 판"에 proof-cut도 요구하지만, 이 컴포넌트는 현재 배경/패딩이
 // 없는 순수 타이포 블록이라(panel이 아님) cut이 보일 표면 자체가 없다 — 유나가 이 요건을
 // 철회함(2026-08-23, «page-header는 Display 타이포까지가 끝»).
@@ -36,7 +34,19 @@ import { cn } from '@/lib/utils';
 // 파일이 doc §3의 "가장 대표" Display 소비처로 명시된 자리 — 세리프 켜기(D1~)가 실제로
 // 이 h1부터 반영되게 하려면 반드시 이 토큰을 경유해야 한다(font-heading으로 남으면 세리프
 // 전환에서 이 화면만 빠짐).
-const pageHeaderVariants = cva('font-display tracking-[-0.02em] text-foreground', {
+//
+// story #2976(근본처방) — 무게는 이제 유틸리티 클래스(`font-editorial-heading`)로 건다.
+// 과거 인라인 style 우회는 반창고였다: tailwind-merge가 자체 Tailwind 설정을 안 읽어
+// `font-editorial-heading`(무게)을 `font-family` 충돌군으로 오인, `font-display`/
+// `font-heading`과 병기 시 하나를 조용히 지우던 게 원인 — `lib/utils.ts`의 `cn()`을
+// `extendTailwindMerge`로 교체해 이 이름을 정확한 `font-weight` 충돌군에 등록했다(실측
+// 확認 완료). 이 파일이 그 반창고의 발원지였으니 여기서 먼저 되돌린다.
+//
+// story #2974 D1 revert(PO 판정 2026-08-24, PR#3416) — D1(세리프 점등)이 반려돼 페이스는
+// 다시 D0 값(font-display=var(--font-sans), 시각 무변화)이다. D1 한정 제외 주석은 D1 자체가
+// 없어져 더 이상 유효하지 않아 걷어냄 — 무게(font-editorial-heading)는 D1 존재 여부와
+// 무관하게 항상 유틸리티 클래스로 건다.
+const pageHeaderVariants = cva('font-display font-editorial-heading tracking-[-0.02em] text-foreground', {
   variants: {
     size: {
       page: 'text-2xl md:text-3xl',
@@ -60,10 +70,7 @@ export function PageHeader({ eyebrow, title, description, actions, className, si
     <section className={cn('flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between', className)}>
       <div className="space-y-1.5">
         {eyebrow ? <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">{eyebrow}</div> : null}
-        <h1
-          className={cn(pageHeaderVariants({ size }))}
-          style={{ fontWeight: 'var(--font-weight-editorial-heading)' }}
-        >
+        <h1 className={cn(pageHeaderVariants({ size }))}>
           {title}
         </h1>
         {description ? <p className="max-w-2xl text-sm text-muted-foreground">{description}</p> : null}

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,0 +1,35 @@
+// story #2976 — tailwind-merge 커스텀 테마 충돌군 회귀가드.
+//
+// twMerge는 프로젝트의 실제 Tailwind 설정을 읽지 않고 표준 테마 값(굵기는 thin~black,
+// 크기는 xs~9xl 등) 이름만 기본 내장한다. globals.css `@theme inline`이 정의한 커스텀
+// 테마 키(`--font-weight-editorial-*`·`--text-editorial-*`)는 그 목록에 없어, 같은
+// `font-`/`text-` 접두를 공유하는 다른 충돌군(font-family·text-color)의 더 관대한
+// arbitrary-name 매처가 먼저 먹혀 뒤 클래스가 앞을 조용히 지운다(PR#3406 페이지헤더
+// 인라인 style 우회의 원인 — text-color 축도 동일 패턴, 이 그라운딩에서 신규 확인).
+// `cn()`(lib/utils.ts)을 `extendTailwindMerge`로 교체해 정확한 충돌군에 등록했다 —
+// 이 파일은 그 처방이 실제로 두 축(family+weight·color+size) 모두에서 동작하고, 같은
+// 축끼리(weight+weight·size+size)는 여전히 올바르게 충돌하는지 고정한다.
+import { describe, expect, it } from 'vitest';
+import { cn } from './utils';
+
+describe('cn() — 커스텀 font-weight/text 테마 값이 다른 축과 병기될 때 안 지워진다(#2976)', () => {
+  it('font-weight(font-editorial-heading)가 font-family(font-display/font-heading)와 공존한다', () => {
+    expect(cn('font-heading', 'font-editorial-heading')).toBe('font-heading font-editorial-heading');
+    expect(cn('font-display', 'font-editorial-heading')).toBe('font-display font-editorial-heading');
+    // 순서를 뒤집어도(가장 취약했던 방향) 동일 — 과거엔 순서에 따라 둘 중 하나가 사라졌다.
+    expect(cn('font-editorial-heading', 'font-display')).toBe('font-editorial-heading font-display');
+  });
+
+  it('font-size(text-editorial-*)가 text-color와 공존한다', () => {
+    expect(cn('text-red-500', 'text-editorial-body')).toBe('text-red-500 text-editorial-body');
+    expect(cn('text-muted-foreground', 'text-editorial-ui')).toBe('text-muted-foreground text-editorial-ui');
+    expect(cn('text-editorial-claim', 'text-foreground')).toBe('text-editorial-claim text-foreground');
+  });
+
+  it('같은 축끼리는 여전히 충돌한다(뒤가 이김 — 회귀 방지 처방이 충돌 판정 자체를 무력화하지 않았는지)', () => {
+    expect(cn('font-editorial-heading', 'font-bold')).toBe('font-bold');
+    expect(cn('font-sans', 'font-serif')).toBe('font-serif');
+    expect(cn('text-lg', 'text-editorial-body')).toBe('text-editorial-body');
+    expect(cn('text-editorial-body', 'text-editorial-ui')).toBe('text-editorial-ui');
+  });
+});

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,5 +1,25 @@
 import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { extendTailwindMerge } from "tailwind-merge"
+
+// story #2976 — twMerge는 프로젝트의 실제 Tailwind 설정을 읽지 않고 표준 테마 값(굵기는
+// thin~black, 크기는 xs~9xl 등) 이름만 기본 내장한다. 우리 `@theme inline`(globals.css)이
+// 정의한 커스텀 테마 키(`--font-weight-editorial-*`·`--text-editorial-*`)는 그 목록에 없어,
+// 같은 `font-`/`text-` 접두를 공유하는 다른 충돌군(예: font-family·text-color)의 더 관대한
+// arbitrary-name 매처가 먼저 먹혀버린다 — `cn('font-heading', 'font-editorial-heading')`이나
+// `cn('text-muted-foreground', 'text-editorial-ui')`에서 뒤 클래스가 앞을 조용히 지운다
+// (실측: PR#3406 페이지헤더 인라인 style 우회 + 이 그라운딩에서 text-color 축도 동일 패턴
+// 확인·2026-08-24). 처방 — `extendTailwindMerge`로 실제 커스텀 테마 값을 알려준다: 이러면
+// twMerge가 이 이름들을 정확한 충돌군(font-weight·font-size)으로 분류해 서로 다른 축의
+// 클래스(family+weight, color+size)는 공존하고, 같은 축끼리(weight+weight, size+size)는
+// 여전히 올바르게 충돌(뒤가 이김)한다 — 실측 확認 완료.
+const twMerge = extendTailwindMerge({
+  extend: {
+    theme: {
+      'font-weight': ['editorial-heading', 'editorial-claim'],
+      'text': ['editorial-body', 'editorial-ui', 'editorial-meta', 'editorial-claim'],
+    },
+  },
+})
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))


### PR DESCRIPTION
## Summary
- story #2976(PR#3406 실측 발견): `font-editorial-heading`(커스텀 무게 유틸)을 `font-heading`류와 함께 `cn()`으로 병기하면 tailwind-merge가 같은 충돌군(font-family)으로 오인해 뒤 클래스가 앞을 조용히 지운다. PR-6은 인라인 style로 회피했으나 반창고 — 유틸을 쓰는 다음 사람이 같은 함정에 빠짐.
- **그라운딩 중 추가 발견**: `text-editorial-*`(커스텀 font-size 유틸)도 동일 패턴으로 `text-color` 충돌군과 오인 병합됨(`text-muted-foreground`+`text-editorial-ui` 등 — 실측 확인). 지금까지는 `cn()` 실사용 조합이 없어 잠복만 해 있었음(grep 확인, page-header.tsx가 유일한 실 충돌 지점).

## Root cause
tailwind-merge는 프로젝트의 실제 Tailwind 설정을 읽지 않고 표준 테마 값 이름(굵기 thin~black, 크기 xs~9xl 등)만 기본 내장한다. `globals.css`의 `@theme inline`이 정의한 커스텀 키(`--font-weight-editorial-*`·`--text-editorial-*`)는 그 목록에 없어, 같은 `font-`/`text-` 접두를 공유하는 다른 충돌군(font-family·text-color)의 더 관대한 arbitrary-name 매처가 먼저 매칭된다.

## Fix
- `lib/utils.ts`: `cn()`을 plain `twMerge`에서 `extendTailwindMerge({ extend: { theme: { 'font-weight': [...], 'text': [...] } } })`로 교체 — 커스텀 테마 값을 정확한 충돌군에 등록.
- `page-header.tsx`: PR-6의 인라인 style 우회를 근본 처방으로 되돌림 — 무게가 다시 `font-editorial-heading` 유틸리티 클래스로 걸린다(D1이 이 파일을 `font-heading`으로 되돌린 상태와도 정상 병기).

검증 방법(node 스크립트로 실측, PR 본문 수치는 실제 출력 그대로):
```
cn('font-heading', 'font-editorial-heading')  // before: 'font-editorial-heading' (family 소실) → after: 'font-heading font-editorial-heading'
cn('text-muted-foreground', 'text-editorial-ui')  // before: 'text-editorial-ui' (color 소실) → after: 둘 다 유지
cn('font-editorial-heading', 'font-bold')  // 동일 축 충돌은 여전히 정상: 'font-bold'(뒤가 이김)
cn('text-editorial-body', 'text-editorial-ui')  // 동일 축 충돌 여전히 정상: 'text-editorial-ui'
```

## Test plan
- [x] 신규 회귀테스트(`lib/utils.test.ts`) — family+weight·color+size 공존 3건, 동축 충돌 유지 4건
- [x] `page-header.test.tsx` 갱신 — 인라인 style 대신 클래스 검증
- [x] 전체 `vitest` 492 files / 4262 tests green(회귀 0)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `pnpm build` EXIT=0, 빌드 CSS 실측 — `.font-editorial-heading{font-weight:820}` 정상 발행

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>