### PR TITLE
fix(#2982): resolved 게이트 죽은 버튼+개발자 에러 문구

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3890,7 +3890,8 @@
     "gateActivityActionUndone": "Undone (correction)",
     "gateActivityActionVoided": "Voided",
     "gateActivityActionOverridden": "Overridden",
-    "gateHeadChangedError": "The commit this gate targets changed after you confirmed. Please review the latest changes before approving."
+    "gateHeadChangedError": "The commit this gate targets changed after you confirmed. Please review the latest changes before approving.",
+    "gateAlreadyResolvedError": "This approval has already been processed. Ask the PO for a re-review if you'd like it reconsidered."
   },
   "recruiter": {
     "title": "Recruiter",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3890,7 +3890,8 @@
     "gateActivityActionUndone": "취소(오클릭 정정)",
     "gateActivityActionVoided": "무효화",
     "gateActivityActionOverridden": "강제 결정",
-    "gateHeadChangedError": "게이트 대상 커밋이 승인 확인 이후 변경되었습니다. 최신 내용을 다시 확인한 뒤 승인해주세요."
+    "gateHeadChangedError": "게이트 대상 커밋이 승인 확인 이후 변경되었습니다. 최신 내용을 다시 확인한 뒤 승인해주세요.",
+    "gateAlreadyResolvedError": "이미 처리된 결재입니다. 되돌리려면 PO에게 재검토를 요청해주세요."
   },
   "recruiter": {
     "title": "채용관",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -147,18 +147,22 @@ export default function GateDetailPage() {
       // 평문 문자열이지만 handler가 error.message로 재포장한다, gates.py:885). 올바른
       // 필드로 교정 — #2027의 "고위험 승인 사유 필수" 문구가 실제로 화면에 뜨게 된다.
       const body = await res.json().catch(() => null) as { error?: { message?: string; code?: string } } | null;
-      // story #2975(페드루 PO 비차단 관찰, 2026-08-24) — BE의 gate_head_changed 메시지는
-      // 한국어 평문(i18n 안 됨). FE가 이미 code를 파싱하므로 code→i18n 매핑으로 렌더(영어
-      // 로케일에서도 정상 표시). 그 외 code는 기존대로 BE message 그대로 통과.
-      const reason = body?.error?.code === 'gate_head_changed'
-        ? t('gateHeadChangedError')
+      // story #2975(페드루 PO 비차단 관찰)·#2982(선생님 실사용 리포트, PO 확定 2026-08-24) —
+      // BE의 code 부착 거부(gate_head_changed·gate_already_resolved)는 한국어 평문이라
+      // i18n 안 됨. FE가 이미 code를 파싱하므로 code→i18n 매핑으로 렌더(영어 로케일에서도
+      // 정상 표시). 그 외 code는 기존대로 BE message 그대로 통과.
+      const code = body?.error?.code;
+      const reason = code === 'gate_head_changed' ? t('gateHeadChangedError')
+        : code === 'gate_already_resolved' ? t('gateAlreadyResolvedError')
         : (body?.error?.message ?? t('gateTransitionErrorGeneric'));
       setTransitionError(reason);
-      // story #2975(PO 요구 ③): 409 gate_head_changed — 승인 확인 사이 대상 커밋이 바뀌어
-      // 서버가 거부했다는 뜻. 화면을 그대로 두면 PO가 옛 SHA를 보며 같은 버튼을 다시 눌러
-      // 똑같이 거부당한다 — 최신 상태(새 github_check_run_sha)로 재조회해 "새 커밋 도착·
-      // 재확認"이 실제로 재렌더되게 한다.
-      if (body?.error?.code === 'gate_head_changed') {
+      // story #2975(PO 요구 ③)·#2982(AC1·AC3, 죽은 버튼 클릭~서버 응답 사이 레이스로 다른
+      // 채널이 먼저 해소한 경우) — 둘 다 "화면이 보여준 상태가 서버와 어긋났다"는 뜻의
+      // 거부다. 화면을 그대로 두면 사람이 옛 상태를 보며 같은 버튼을 다시 눌러 똑같이
+      // 거부당한다 — 최신 상태로 재조회해 실제 현재 상태(resolved 카드 등)로 재렌더되게
+      // 한다(gates/[id]/page.tsx의 needsAction 분기가 이미 status!=='pending'을 올바르게
+      // 읽지 못하는 액션-숨김 표시로 처리하므로, 재조회만 하면 AC1이 자동으로 성립한다).
+      if (code === 'gate_head_changed' || code === 'gate_already_resolved') {
         void fetchGate();
       }
     } finally {

--- a/apps/web/src/components/chat/approval-request-card.test.tsx
+++ b/apps/web/src/components/chat/approval-request-card.test.tsx
@@ -136,3 +136,49 @@ describe('ApprovalRequestCard — 제목 미리보기 진입점, canPreviewEntit
     expect(container.textContent).toContain(title);
   });
 });
+
+// story #2982(선생님 실사용 리포트, PO 확定 2026-08-24) — 죽은 버튼 클릭~서버 응답 사이 레이스로
+// 다른 채널이 먼저 해소한 게이트를 이 챗 카드에서 승인/반려 시도하면 서버가 409로 거부한다.
+// AC1(재조회로 죽은 버튼이 다시 안 뜬다)+AC3(인간 문구)를 검증한다.
+describe('ApprovalRequestCard — 409(gate_already_resolved) 거부 처리(story #2982)', () => {
+  it('AC1·AC3 — 이미 해소된 게이트 승인 시도는 409로 거부되고, 재조회 後 완료 카드+사람 문구로 전환된다', async () => {
+    let getCount = 0;
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string }) => {
+      if (init?.method === 'POST') {
+        return {
+          ok: false, status: 409,
+          json: async () => ({
+            data: null,
+            error: { code: 'gate_already_resolved', message: '이미 처리된 결재입니다. 되돌리려면 PO에게 재검토를 요청해주세요.', current_status: 'approved' },
+            meta: null,
+          }),
+        };
+      }
+      if (url.includes('/api/gates/')) {
+        getCount += 1;
+        const status = getCount === 1 ? 'pending' : 'approved';
+        return { ok: true, json: async () => ({ data: gate({ status, resolver_id: 'member-2', resolved_at: new Date().toISOString() }) }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <ApprovalRequestCard target={{ work_item_type: 'story', work_item_id: 'w-1', gate_id: 'g-1', actions: ['approve', 'reject'] }} />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const approveBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.gateApprove));
+    await act(async () => { approveBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    // 「완료」 카드로 재조회 後 전환됐다 — 그 자체가 AC3의 명시 안내다(진짜 상태를 정직하게
+    // 보여주는 것으로 답이 된다 — 별도 에러 배너를 겹쳐 보이지 않음).
+    expect(container.textContent).toContain(koMessages.chats.approvalRequestResolvedStatus.split('{status}')[0]);
+    expect(getCount).toBe(2); // 최초 로드(1) + 409 이후 재조회(2) — 화면이 옛 status에 안 멈춘다.
+    const buttonsAfter = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttonsAfter.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
+  });
+});

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -124,11 +124,29 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalR
         headers: { 'Content-Type': 'application/json' },
         // story #2027 AC2 — gates/[id]/page.tsx와 동일 계약(evidence_viewed는 고위험 서명
         // 플로우 onApprove에서만 true로 실린다, 아래 ApprovalRequestBody 배선 참조).
-        body: JSON.stringify({ status, note: note?.trim() || null, evidence_viewed: evidenceViewed ?? false }),
+        // story #2975 회귀 자체발견(#2982 작업 중) — reviewed_head_sha 누락(gates/[id]/
+        // page.tsx만 #2975에서 고쳐지고 이 챗 카드는 빠져 있었다). known SHA 있는 merge
+        // 게이트를 이 카드에서 승인하면 #3410 착지 後 항상 409(gate_head_changed)로
+        // 거부되는 라이브 회귀 — state.gate(fetchGate 실측)에서 채운다.
+        body: JSON.stringify({
+          status, note: note?.trim() || null, evidence_viewed: evidenceViewed ?? false,
+          reviewed_head_sha: state.kind === 'ready' ? (state.gate.github_check_run_sha ?? null) : null,
+        }),
       });
       if (res.ok) { await fetchGate(); return; }
-      const body = await res.json().catch(() => null) as { error?: { message?: string } } | null;
-      setTransitionError(body?.error?.message ?? `HTTP ${res.status}`);
+      const body = await res.json().catch(() => null) as { error?: { message?: string; code?: string } } | null;
+      const code = body?.error?.code;
+      // story #2975·#2982(PO 확定) — code 부착 거부는 raw BE 문구(한국어 평문) 대신 사람
+      // 문구로 매핑(gates/[id]/page.tsx와 동형). 둘 다 "화면이 아는 상태가 서버와
+      // 어긋났다"는 뜻이라 재조회로 실제 현재 상태를 반영(AC1 — 죽은 버튼이 다시 안 뜬다).
+      if (code === 'gate_head_changed' || code === 'gate_already_resolved') {
+        await fetchGate();
+      }
+      setTransitionError(
+        code === 'gate_head_changed' ? tCage('gateHeadChangedError')
+          : code === 'gate_already_resolved' ? tCage('gateAlreadyResolvedError')
+          : (body?.error?.message ?? `HTTP ${res.status}`)
+      );
     } catch {
       setTransitionError(t('hitlSendFailed'));
     } finally {
@@ -350,7 +368,12 @@ function ApprovalRequestBody({
         // "액션 불가" 사유는 무권한뿐이다.
         <p className="text-[11px] text-muted-foreground">{tCage('gateReadonlyNotAuthorized')}</p>
       ) : needsFullFlow ? (
+        // story #2975(유나양 design 판정 2026-08-24) 갭 자체발견(#2982 작업 중) — 그 블로커
+        // 처방(key={SHA}로 재조회 後 evidenceViewed/reason 강제 리셋)이 gates/[id]/page.tsx
+        // 에만 적용되고 이 챗 카드는 빠져 있었다. 같은 컴포넌트·같은 취약(SHA 바뀐 뒤에도
+        // 열람체크가 살아있어 재확認 없이 재승인 가능)이라 동형 처방.
         <GateSignatureApproval
+          key={gate.github_check_run_sha}
           gate={gate}
           resolving={resolving}
           error={transitionError}

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -726,7 +726,7 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     const transitionCall = fetchMock.mock.calls.find((call: unknown[]) => (call[0] as string).includes('/transition'));
     expect(transitionCall).toBeDefined();
-    expect(JSON.parse((transitionCall![1] as { body: string }).body)).toEqual({ status: 'approved', note: null, evidence_viewed: false });
+    expect(JSON.parse((transitionCall![1] as { body: string }).body)).toEqual({ status: 'approved', note: null, evidence_viewed: false, reviewed_head_sha: null });
     expect(container.textContent).toContain('처리됨');
     expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent?.includes('승인'))).toBe(false);
   });
@@ -779,7 +779,7 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
 
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     const transitionCall = fetchMock.mock.calls.find((call: unknown[]) => (call[0] as string).includes('/transition'));
-    expect(JSON.parse((transitionCall![1] as { body: string }).body)).toEqual({ status: 'approved', note: '근거 확인함, 승인', evidence_viewed: true });
+    expect(JSON.parse((transitionCall![1] as { body: string }).body)).toEqual({ status: 'approved', note: '근거 확인함, 승인', evidence_viewed: true, reviewed_head_sha: null });
   });
 
   it('이미 처리된 게이트(status=approved)는 버튼 없이 처리됨 상태만 보인다', async () => {

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -424,7 +424,7 @@ describe('ApprovalsQueue', () => {
 
     const postCall = calls.find((c) => c.method === 'POST');
     expect(postCall?.url).toBe('/api/gates/g-low/transition');
-    expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'approved', note: null, evidence_viewed: false });
+    expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'approved', note: null, evidence_viewed: false, reviewed_head_sha: null });
 
     expect(container.textContent).toContain(koMessages.cage.queueResolvedApproved);
     expect(container.textContent).toContain(koMessages.cage.queueViewRecord);
@@ -434,6 +434,47 @@ describe('ApprovalsQueue', () => {
     // 재조회(fetchGates) 없이 이 렌더만으로 반영됐다 — GET 호출 수가 mount 시점(pending+held
     // 각 1회=2)에서 늘지 않았다.
     expect(calls.filter((c) => c.method === undefined || c.method === 'GET')).toHaveLength(2);
+  });
+
+  // story #2982(선생님 실사용 리포트, PO 확定 2026-08-24) — 이 큐의 stale items[] 스냅샷(주석
+  // 위 L125 참고 — resolveGate() 성공 後에도 status=pending 그대로) 때문에, 다른 채널이 먼저
+  // 해소한 게이트를 여기서 다시 승인/반려 시도하면 서버가 409(gate_already_resolved)로 거부한다.
+  // AC1(죽은 버튼이 다시 안 뜬다)+AC3(인간 문구)를 재조회 없이(current_status로 즉시) 만족해야 함.
+  it('AC1·AC3 — 다른 채널이 먼저 해소한 게이트를 클릭하면 서버가 409(gate_already_resolved)로 거부하고, 재조회 없이 즉시 완료 카드+사람 문구로 전환된다', async () => {
+    const calls: { url: string; method?: string; body?: string }[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      calls.push({ url, method: init?.method, body: init?.body });
+      if (init?.method === 'POST') {
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({
+            data: null,
+            error: {
+              code: 'gate_already_resolved',
+              message: '이미 처리된 결재입니다. 되돌리려면 PO에게 재검토를 요청해주세요.',
+              current_status: 'approved',
+            },
+            meta: null,
+          }),
+        };
+      }
+      if (url.includes('status=pending')) return { ok: true, json: async () => [lowRiskActionable()] };
+      return { ok: true, json: async () => [] };
+    }));
+    await mount();
+    const approveButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.gateApprove));
+    await act(async () => { approveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    // 「완료」 카드로 즉시 전환됐다 — 그 자체가 AC3의 명시 안내다(별도 에러 배너를 겹쳐
+    // 보이는 게 아니라, 진짜 상태를 정직하게 보여주는 것으로 "그래서 뭘 해야 하는지"가
+    // 이미 답이 된다: 되돌리려면 undo 창 안이면 취소 버튼, 밖이면 기록 보기뿐).
+    expect(container.textContent).toContain(koMessages.cage.queueResolvedApproved);
+    // 재조회(GET) 없이 body의 current_status만으로 전환됐다 — mount 시점(pending+held=2)에서
+    // POST 1건 추가된 것 외 GET 호출 수가 안 늘어야 한다.
+    expect(calls.filter((c) => c.method === undefined || c.method === 'GET')).toHaveLength(2);
+    const buttonsAfter = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttonsAfter.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
   });
 
   it('AC "중복 탭 중복 실행 0" — 승인 요청이 아직 안 끝난 상태에서 버튼이 비활성화돼 재클릭이 두 번째 요청을 만들지 않는다', async () => {
@@ -470,7 +511,7 @@ describe('ApprovalsQueue', () => {
     const rejectButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.sigRequestChanges));
     await act(async () => { rejectButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     const postCall = calls.find((c) => c.method === 'POST');
-    expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'rejected', note: null, evidence_viewed: false });
+    expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'rejected', note: null, evidence_viewed: false, reviewed_head_sha: null });
     expect(container.textContent).toContain(koMessages.cage.queueResolvedRejected);
   });
 
@@ -684,7 +725,7 @@ describe('ApprovalsQueue', () => {
 
       const postCall = calls.find((c) => c.method === 'POST' && c.url.includes('/transition'));
       expect(postCall?.url).toBe('/api/gates/g-sig-approve/transition');
-      expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'approved', note: '근거 확認·서명 사유', evidence_viewed: true });
+      expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'approved', note: '근거 확認·서명 사유', evidence_viewed: true, reviewed_head_sha: null });
       expect(document.body.querySelector('[data-slot="dialog-content"]')).toBeFalsy();
       expect(container.textContent).toContain(koMessages.cage.queueResolvedApproved);
     });
@@ -703,7 +744,7 @@ describe('ApprovalsQueue', () => {
       await act(async () => { rejectButtons[0]?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
 
       const postCall = calls.find((c) => c.method === 'POST' && c.url.includes('/transition'));
-      expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'rejected', note: '재작업 필요', evidence_viewed: false });
+      expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'rejected', note: '재작업 필요', evidence_viewed: false, reviewed_head_sha: null });
       expect(container.textContent).toContain(koMessages.cage.queueResolvedRejected);
     });
 

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -204,12 +204,21 @@ export function ApprovalsQueue() {
     setResolvingIds((prev) => new Set(prev).add(id));
     setGateErrors((prev) => { const next = { ...prev }; delete next[id]; return next; });
     try {
+      // story #2975 회귀 자체발견(#2982 작업 중) — 이 큐의 인라인 승인(원탭·서명모달 둘 다
+      // 이 함수 하나를 공유)이 reviewed_head_sha를 전혀 안 보냈다. gates/[id]/page.tsx만
+      // #2975에서 고쳐졌고 이 큐는 빠져 있어, #3410 착지 後 known SHA가 있는 merge 게이트를
+      // 이 큐에서 승인하면 항상 409(gate_head_changed)로 거부되는 라이브 회귀였다 — items[]
+      // 에서 찾아 동일 계약으로 채운다.
+      const g = items.find((it) => it.id === id && !isHitl(it)) as GateItem | undefined;
       const res = await fetch(`/api/gates/${id}/transition`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         // story #2027 AC2 — gates/[id]/page.tsx와 동일 계약(evidence_viewed는 고위험 서명
         // 플로우 onApprove에서만 true로 실린다, 아래 GateSignatureApproval 배선 참조).
-        body: JSON.stringify({ status, note: note?.trim() || null, evidence_viewed: evidenceViewed ?? false }),
+        body: JSON.stringify({
+          status, note: note?.trim() || null, evidence_viewed: evidenceViewed ?? false,
+          reviewed_head_sha: g?.github_check_run_sha ?? null,
+        }),
       });
       if (res.ok) {
         setResolvedGates((prev) => ({ ...prev, [id]: status }));
@@ -218,8 +227,26 @@ export function ApprovalsQueue() {
         // 잘못 닫지 않도록 대상 id 일치 확認).
         setSignatureTargetId((cur) => (cur === id ? null : cur));
       } else {
-        const body = await res.json().catch(() => null) as { error?: { message?: string } } | null;
-        setGateErrors((prev) => ({ ...prev, [id]: body?.error?.message ?? t('gateTransitionErrorGeneric') }));
+        const body = await res.json().catch(() => null) as { error?: { message?: string; code?: string; current_status?: string } } | null;
+        const code = body?.error?.code;
+        // story #2975·#2982(PO 확定) — code 부착 거부는 raw BE 문구(한국어 평문·i18n 안 됨)
+        // 대신 사람 문구로. gate_already_resolved는 이 시점부터 서버 진실을 아는 것이므로
+        // (current_status), 재조회 없이도 즉시 「완료」 카드로 전환할 수 있다(AC1 — 죽은
+        // 버튼이 다시 안 뜬다) — approved/rejected만 이 큐의 표시 슬롯이 있고, 그 외
+        // (held/voided 등)는 표시할 슬롯이 없어 목록에서만 제거(클릭-스루로 상세에서 확認).
+        if (code === 'gate_already_resolved') {
+          const cur = body?.error?.current_status;
+          if (cur === 'approved' || cur === 'rejected') {
+            setResolvedGates((prev) => ({ ...prev, [id]: cur }));
+          } else {
+            setItems((prev) => prev.filter((it) => it.id !== id));
+          }
+          setSignatureTargetId((c) => (c === id ? null : c));
+        }
+        const reason = code === 'gate_head_changed' ? t('gateHeadChangedError')
+          : code === 'gate_already_resolved' ? t('gateAlreadyResolvedError')
+          : (body?.error?.message ?? t('gateTransitionErrorGeneric'));
+        setGateErrors((prev) => ({ ...prev, [id]: reason }));
       }
     } finally {
       setResolvingIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
@@ -493,7 +520,10 @@ export function ApprovalsQueue() {
             </DialogTitle>
           </DialogHeader>
           {signatureGate ? (
+            // story #2975(유나양 design 판정) 갭 자체발견(#2982 작업 중) — 동형 처방(SHA
+            // 변경 시 evidenceViewed/reason 강제 리셋). page.tsx만 #2975에서 고쳐졌었다.
             <GateSignatureApproval
+              key={signatureGate.github_check_run_sha}
               gate={signatureGate}
               resolving={resolvingIds.has(signatureGate.id)}
               error={gateErrors[signatureGate.id]}

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1266,6 +1266,24 @@ async def transition_gate_endpoint(
         select(Gate).where(Gate.id == id, Gate.org_id == org_id).with_for_update()
     )).scalar_one_or_none()
     await _authorize_gate_approve_equivalent(session, _gate, resolved, auth, org_id)
+    # story #2982(선생님 실사용 리포트, PO 확定 2026-08-24) — 이미 해소된(pending 아닌) 게이트에
+    # 승인/반려를 시도하면 여기까지 도달해 transition_gate()의 is_valid_transition이 ValueError를
+    # 던졌고, 그게 그대로 "불법 전이: approved → rejected. pending에서만..." 개발자 문구로 화면에
+    # 노출됐다. FE가 상태별 버튼을 숨기게 고쳐도(AC1) 클릭~서버 응답 사이 레이스 창은 원리적으로
+    # 남는다(#2975의 SHA 레이스와 동형 클래스) — 여기서 machine-readable code로 먼저 걸러야 FE가
+    # 사람 문구로 번역할 수 있다(gate_head_changed 선례와 동형). 위 FOR UPDATE로 이미 잠근 행이라
+    # 이 판정도 레이스-프리.
+    if body.status in ("approved", "rejected") and _gate is not None and _gate.status != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "gate_already_resolved",
+                "message": "이미 처리된 결재입니다. 되돌리려면 PO에게 재검토를 요청해주세요.",
+                "current_status": _gate.status,
+                "resolver_id": str(_gate.resolver_id) if _gate.resolver_id else None,
+                "resolved_at": _gate.resolved_at.isoformat() if _gate.resolved_at else None,
+            },
+        )
     # story #2027(까심 QA 적출): 고위험(risk_grade=high) 게이트의 approved 전이는 사유(note) 서버측
     # 강제 — void_gate/override_gate 기존 관례(reason 없으면 ValueError→422, void_gate 참고)에
     # 맞추는 작업이다(신규 규칙 아님). 이전엔 FE 버튼 disable(evidenceViewed && reason.trim())만

--- a/backend/tests/test_2982_gate_already_resolved_realdb.py
+++ b/backend/tests/test_2982_gate_already_resolved_realdb.py
@@ -1,0 +1,198 @@
+"""story #2982(선생님 실사용 리포트, PO 확定 2026-08-24) — 이미 해소된 게이트에 승인/반려를
+시도하면(죽은 버튼 클릭~서버 응답 사이 레이스, #2975 SHA 레이스와 동형 클래스) 서버가
+개발자 문구("불법 전이: approved → rejected. pending에서만...")를 그대로 노출하던 것을
+machine-readable code(gate_already_resolved)로 거부하도록 처방(gate_head_changed 선례와 동형).
+
+FE가 상태별 버튼을 숨기게 고쳐도(AC1) 클릭~서버 응답 사이 레이스 창은 원리적으로 남으므로,
+이 BE 가드가 fail-closed의 실제 경계다 — FE는 이 code를 받으면 사람 문구로 번역+재조회한다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — transition_gate()가 ActivityLog를 씀.
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_common(session):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+        permission="granted", role="owner",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "caller_id": caller.id, "member_id": caller_om.id}
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_reject_after_already_approved_returns_structured_409_not_raw_message():
+    """재현: 승인된 게이트에 반려(변경 요청)를 다시 시도 — 선생님이 실제로 겪은 그 시나리오."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            story = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="#2982 재현 — 이미 승인된 게이트 재전이 시도",
+            )
+            s.add(story)
+            await s.commit()
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="approved",
+                resolver_id=seeded["member_id"],
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "rejected", "note": "변경 요청"},
+            )
+            assert resp.status_code == 409, resp.text
+            error = resp.json()["error"]
+            assert error["code"] == "gate_already_resolved", error
+            assert error["current_status"] == "approved"
+            assert error["resolver_id"] == str(seeded["member_id"])
+            # 개발자 문구("불법 전이"·"pending에서만")가 사람에게 노출되면 안 됨(no-fiction 대신
+            # 명시적으로 인간 문구가 있어야 함 — AC3의 서버측 계약).
+            assert "불법 전이" not in error["message"]
+
+            # gate 상태 자체는 그대로 approved(승인이 파괴/변조되지 않았는지 확認).
+            get_resp = await client.get(f"/api/v2/gates/{gate_id}")
+            assert get_resp.json()["status"] == "approved"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_approve_on_pending_gate_unaffected_by_new_guard():
+    """양성대조 — pending 게이트의 정상 승인은 새 가드에 걸리지 않고 그대로 통과한다."""
+    from app.main import app
+    from app.models.gate import Gate
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            story = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="#2982 양성대조 — 정상 pending 승인",
+            )
+            s.add(story)
+            await s.commit()
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+                gate_type="merge", status="pending",
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "approved", "note": "정상 승인", "evidence_viewed": True},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] == "approved"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -56,6 +56,9 @@ async def test_gate_transition_forces_resolver_id_to_caller(monkeypatch):
     # 테스트는 SHA 앵커링을 다루지 않으므로 명시적으로 None(known SHA 없음)으로 고정해
     # 그 검증 대상 밖임을 분명히 한다.
     _g.github_check_run_sha = None
+    # story #2982 — 이미해소 가드(status!='pending'이면 409)도 MagicMock 오토속성(항상
+    # not-None)을 "이미 해소됨"으로 오독한다. "pending"으로 명시해 그 가드도 대상 밖임을 밝힌다.
+    _g.status = "pending"
     _gr.scalar_one_or_none.return_value = _g
     _sess.execute = AsyncMock(return_value=_gr)
     from fastapi import BackgroundTasks

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -42,6 +42,9 @@ def _non_doc_gate_session():
         # 관심사(resolver_id 강제, RC#1)와 무관하게 명시 필요 — None="known SHA 없음"으로 그
         # 검증 자체가 대상 밖임을 분명히 한다(evidence=None과 동형 처리).
         github_check_run_sha=None,
+        # story #2982 — 이미해소 가드(status!='pending'이면 409)도 이 값을 읽는다. SimpleNamespace는
+        # 미선언 속성이 AttributeError라 명시 필요 — "pending"으로 그 가드가 대상 밖임을 분명히 한다.
+        status="pending", resolver_id=None, resolved_at=None,
     )
     s.execute = AsyncMock(return_value=gr)
     return s


### PR DESCRIPTION
[SID:2982]

## 요약
선생님 실사용 리포트(2026-08-24) — 이미 approved된 게이트 카드에서 「변경 요청」 클릭 → 에러 배너 「처리하지 못했습니다: 불법 전이: approved → rejected. pending에서만 approved|rejected로 전이 가능.」 개발자 문구가 그대로 노출됨.

근본: FE 3서피스(gates/[id]/page.tsx·approvals-queue.tsx·approval-request-card.tsx) 모두 화면이 아는 상태가 서버와 어긋나는(stale) 레이스 창을 안고 있다 — 큐의 `items[]`는 인라인 해소 後에도 재조회 안 함(설계상), 챗카드는 열린 채 다른 채널이 먼저 해소, 상세 페이지도 폴링 없음. #2975(SHA 레이스)와 동형 클래스.

## 처방 (페드루 PO 확定 2026-08-24)
1. **BE**: `transition_gate_endpoint`에 `body.status in (approved,rejected)` + `_gate.status != pending`(FOR UPDATE로 이미 잠근 값, 레이스-프리) 조기 가드 신설 — `gate_already_resolved` code로 409. `transition_gate()`까지 들어가 ValueError 원문이 노출될 기회 자체를 없앤다(gate_head_changed 선례와 동형).
2. **FE**: 세 서피스 모두 `gate_head_changed`·`gate_already_resolved` 둘 다 code→i18n 매핑 + 재조회(큐는 응답의 `current_status`로 재조회 없이 즉시)로 「완료」 카드에 재렌더. 그 카드 자체가 AC3의 명시 안내다 — undo 창 안이면 취소 버튼, 밖이면 기록 보기 링크뿐, 죽은 액션 버튼은 다시 뜨지 않는다(AC1).

## 작업 중 자체발견 — #2975 회귀 2건(동봉 처방)
같은 코드 경로를 손보다 발견, 근본원인이 동일 클래스라 팀 규율(발견 즉시 수정)대로 이 PR에 동봉:
- **reviewed_head_sha 누락**: `approvals-queue.tsx`·`approval-request-card.tsx`의 인라인 승인이 이 필드를 전혀 안 보내고 있었다(#2975에서 `gates/[id]/page.tsx`만 고쳐짐) — #3410 착지 後 known SHA 있는 merge 게이트를 이 두 표면에서 승인하면 **항상** 409(gate_head_changed)로 거부되는 라이브 회귀였다.
- **key={SHA} 리마운트 누락**: 유나양 design 블로커 처방(재조회 後 evidenceViewed/reason 강제 리셋)도 이 두 표면엔 적용 안 돼 있었다 — 동형 처방.

## Test plan
- [x] BE: 신규 realdb 2종(재현+양성대조) + gate-transition 관련 12개 기존 파일 전부 green(mock 2건은 `.status`도 명시 필요해져 #2975와 동형 패턴으로 수정)
- [x] FE: approvals-queue/approval-request-card 신규 2종 + 기존 102 tests green
- [x] tsc --noEmit 0 errors, eslint 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AbjN7dJp11Nng4AVZY3Xw