### PR TITLE
[SID:2977] SidebarMenuSub/SidebarMenuSubItem 데드코드 제거

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -681,34 +681,6 @@ function SidebarMenuSkeleton({
   )
 }
 
-function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
-  return (
-    <ul
-      data-slot="sidebar-menu-sub"
-      data-sidebar="menu-sub"
-      className={cn(
-        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden",
-        className
-      )}
-      {...props}
-    />
-  )
-}
-
-function SidebarMenuSubItem({
-  className,
-  ...props
-}: React.ComponentProps<"li">) {
-  return (
-    <li
-      data-slot="sidebar-menu-sub-item"
-      data-sidebar="menu-sub-item"
-      className={cn("group/menu-sub-item relative", className)}
-      {...props}
-    />
-  )
-}
-
 export {
   Sidebar,
   SidebarContent,
@@ -726,9 +698,7 @@ export {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarMenuSkeleton,
-  SidebarMenuSub,
   sidebarMenuButtonVariants,
-  SidebarMenuSubItem,
   SidebarProvider,
   SidebarRail,
   SidebarSeparator,


### PR DESCRIPTION
## Summary
- story #2977(PR#3406 부수 발견): `SidebarMenuSubButton`은 소비처 0 확認 후 PR-6에서 제거했으나, 같은 가족 `SidebarMenuSub`·`SidebarMenuSubItem`도 동일하게 무소비인데 지목 목록에 없어 스코프 밖 플래그만 남겨뒀던 것.
- grep 전수 재확認 — 두 심볼 모두 정의+export 외 소비처 0(코드·테스트 공통). `'@/components/ui/sidebar'`를 import하는 4개 파일(`app-sidebar.tsx`·`dashboard-shell.tsx`·`top-bar.tsx`·`unified-switcher.tsx`) 전부 확認, 해당 없음.

## Fix
컴포넌트 정의 2개 + export 표면 2곳 함께 제거(반쪽 제거 금지, AC2).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `nav`+`sidebar` 관련 `vitest` 12 files / 76 tests green
- [x] `pnpm build` EXIT=0

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>