### PR TITLE
[SID:2986] 이니셜 폴백 욕설 조립 실사고 fix — 「시스템 발행」→「시발」

### DIFF
--- a/apps/web/src/components/docs/doc-assignee-control.tsx
+++ b/apps/web/src/components/docs/doc-assignee-control.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { User, UserPlus } from 'lucide-react';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
+import { initials as toInitials } from '@/lib/storage/format';
 
 /**
  * 박스1: 담당자 아바타 + popover. 슬림 헤더 액션 클러스터에 glanceable owner 신호(누가 owner인지 보여야 함).
@@ -42,7 +43,9 @@ export function DocAssigneeControl({
 
   const assigned = !!currentAssigneeId;
   // currentAssigneeId 가드: 담당자 해제/변경 시 stale memberName 무시(render 파생).
-  const initials = assigned && memberName ? memberName.slice(0, 2).toUpperCase() : null;
+  // story #2986(PO beyond-diff 지적) — 정본(lib/storage/format.ts#initials) 우회하던 인라인
+  // slice(0,2)를 정본 경유로 접음(산개 구현 금지, avatar.tsx 등 다른 5개 소비처와 동일 규칙).
+  const initials = assigned && memberName ? toInitials(memberName) : null;
   const label = assigned ? `${t('assignee')}: ${memberName ?? ''}`.trim() : t('assigneeUnassigned');
 
   return (

--- a/apps/web/src/lib/storage/format.test.ts
+++ b/apps/web/src/lib/storage/format.test.ts
@@ -1,0 +1,36 @@
+// story #2986(선생님 실사용 발견, 2026-08-24) — 이니셜 폴백 아바타가 어절별 첫 글자를
+// 조합하면(라틴 이니셜 관례) 한글에서 우연히 비속어가 조립되는 실사고. 「시스템 발행」→
+// 「시」+「발」=「시발」이 정확히 그 사례. 한글(비라틴) 다어절 이름은 첫 어절 첫 글자
+// 1자만 쓰도록 고정 — 라틴 다어절(John Smith→JS)은 국제 관례대로 유지.
+import { describe, expect, it } from 'vitest';
+import { initials } from './format';
+
+describe('initials() — 한글 다어절 이름은 어절 조합 없이 첫 어절 첫 글자만(#2986)', () => {
+  it('「시스템 발행」이 「시발」이 아니라 「시」를 반환한다(실사고 재현 고정)', () => {
+    expect(initials('시스템 발행')).toBe('시');
+    expect(initials('시스템 발행')).not.toBe('시발');
+  });
+
+  it('한글 다어절 이름(성+이름 표기) 전반이 첫 어절 첫 글자만 반환한다', () => {
+    expect(initials('미르코 페트로비치')).toBe('미');
+    expect(initials('페드루 올리베이라')).toBe('페');
+    expect(initials('디캄포 은두카쿠')).toBe('디');
+  });
+
+  it('한글 단일 어절 이름은 기존과 동일하게 첫 글자 1자를 반환한다(회귀 0)', () => {
+    expect(initials('미르코')).toBe('미');
+  });
+
+  it('라틴 다어절 이름은 국제 관례대로 각 단어 첫 글자를 조합한다(회귀 0)', () => {
+    expect(initials('John Smith')).toBe('JS');
+  });
+
+  it('라틴 단일 단어 이름은 기존과 동일하게 앞 2글자를 대문자로 반환한다(회귀 0)', () => {
+    expect(initials('claude')).toBe('CL');
+  });
+
+  it('빈 이름은 물음표를 반환한다(회귀 0)', () => {
+    expect(initials('')).toBe('?');
+    expect(initials('   ')).toBe('?');
+  });
+});

--- a/apps/web/src/lib/storage/format.ts
+++ b/apps/web/src/lib/storage/format.ts
@@ -62,11 +62,20 @@ export function avatarColor(isAgent: boolean): string {
 export function initials(name: string): string {
   const parts = name.trim().split(/\s+/).filter(Boolean);
   if (parts.length === 0) return '?';
+  const first = parts[0] ?? '';
+  const isLatin = /[a-zA-Z]/.test(first);
   if (parts.length === 1) {
-    const p = parts[0] ?? '';
-    return /[a-zA-Z]/.test(p) ? p.slice(0, 2).toUpperCase() : p.slice(0, 1);
+    return isLatin ? first.slice(0, 2).toUpperCase() : first.slice(0, 1);
   }
-  return ((parts[0]?.[0] ?? '') + (parts[1]?.[0] ?? '')).toUpperCase();
+  // story #2986(선생님 실사용 발견) — 어절별 첫 글자를 조합하면(라틴 이니셜 관례) 한글에서
+  // 우연히 실제 단어(간혹 비속어)가 조립될 구조적 위험이 있다 — 「시스템 발행」→「시」+「발」
+  // =「시발」실사고. 한글(및 그 외 비라틴) 다어절 이름은 조합하지 않고 첫 어절 첫 글자
+  // 1자만 쓴다(단일 어절일 때와 동일 규칙). 라틴 다어절(예: John Smith)은 국제 관례대로
+  // 각 단어 첫 글자 조합(JS)을 유지 — 위험은 한글류 음절 문자에 한정된다.
+  if (isLatin) {
+    return ((parts[0]?.[0] ?? '') + (parts[1]?.[0] ?? '')).toUpperCase();
+  }
+  return first.slice(0, 1);
 }
 
 /** 파일 확장자 라벨 — 파일명 우선, 없으면 content-type subtype. (예: PNG·PDF·DOCX·JSON) */


### PR DESCRIPTION
## Summary
선생님 실사용 발견(2026-08-24, 스크린샷): DM 목록의 「시스템 발행」 멤버 아바타 폴백이 이름 어절별 첫 글자를 조합(라틴 이니셜 관례 "John Smith"→"JS"의 오이식)해 **「시」+「발」="시발"**을 렌더 — 욕설로 읽히는 실사고. 다른 멤버는 사진 아바타라 폴백이 안 보였을 뿐, 같은 규칙이면 두 어절 한글 이름의 첫 글자 조합이 우연히 비속어가 되는 재발 가능한 클래스.

## Fix (AC②)
`initials()`(`lib/storage/format.ts` — `avatar.tsx` 등 6개 소비처의 단일 정본, 산개 구현 없음)에서 다어절 이름의 "각 단어 첫 글자 조합" 분기를 **라틴 문자에만 한정**. 비라틴(한글 등) 다어절 이름은 단일 어절일 때와 동일 규칙(첫 어절 첫 글자 1자)으로 통일 — 어절 간 조합 자체를 구조적으로 없앤다. 라틴 다어절(`John Smith`→`JS`)은 국제 관례 그대로 유지.

## Test plan
- [x] 신규 회귀테스트(`format.test.ts`) — 실사고 재현 고정(`"시스템 발행"` → `"시"`, `"시발"` 아님) · 한글 다어절 3종 · 한글/라틴 단일 어절 회귀 0 · 빈 이름 회귀 0
- [x] 전체 `vitest` 492 files / 4265 tests green(회귀 0)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `pnpm build` EXIT=0
- [ ] dev 배포 후 실픽셀 — 「시스템 발행」 DM 행 확인(선생님 스크린샷 화면, 카디르 QA)

## 범위 밖 (스토리 자체 명시, 추측 안 함)
- **AC①** "시스템 발행" 전용 아이콘 지정 — 유나군 시각 판정 영역
- **AC③** 시스템 이벤트 발행자가 DM 목록에 사람처럼 노출되는 것의 적정성 — 관찰만 기록(별도 판단 대상)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>