### PR TITLE
[SID:2987] 앱 백그라운드 복귀 SSE 좀비 커넥션 강제 재연결+연결끊김 배너

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3523,6 +3523,8 @@
     "groupTitlePlaceholder": "Group chat name",
     "dmWith": "DM",
     "noMessages": "Send the first message",
+    "connectionLost": "Connection lost",
+    "refreshNow": "Refresh",
     "create": "Start chat",
     "myChatsTab": "My Chats",
     "agentChatsTab": "Agent Chats",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3523,6 +3523,8 @@
     "groupTitlePlaceholder": "그룹 채팅 이름",
     "dmWith": "DM",
     "noMessages": "첫 메시지를 보내보세요",
+    "connectionLost": "연결이 끊겼어요",
+    "refreshNow": "새로고침",
     "create": "대화 시작",
     "myChatsTab": "내 대화",
     "agentChatsTab": "에이전트 대화",

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronLeft, RefreshCw } from 'lucide-react';
+import { ChevronLeft, RefreshCw, WifiOff } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { ChatBubble } from './chat-bubble';
@@ -372,12 +372,25 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
 
   useEffect(() => { void fetchWorking(); }, [fetchWorking]);
 
-  useChatSse({
+  // story #2987 — AC2 후반(연결 끊김 표시+수동 갱신). `connected`는 훅이 이미 반환하던 값
+  // (mux 경로는 getter로 최신값을 항상 읽되 참조 안정적 — story #2144)인데 이 컴포넌트가
+  // 그동안 아무도 안 읽고 있었다.
+  const { connected } = useChatSse({
     currentTeamMemberId,
     onConversationMessage: handleConversationMessage,
     onWorking: handleWorking,
     onReconnect: handleReconnect,
   });
+  // 짧은 순단(정상 60초 재연결 사이클, sse-reconnect-backoff.ts 주석 참고)까지 매번 배너를
+  // 띄우면 소음이라, 끊김이 일정 시간(2s) 이상 지속될 때만 보인다 — 자동 재연결(#2987 §1)이
+  // 대부분 그 안에 복구하므로 실사용자는 배너를 거의 못 본다. 안 붙으면(주소창 없는 앱에서
+  // 자동 재연결도 실패) 수동 갱신 affordance가 유일한 탈출구가 된다.
+  const [showDisconnectedBanner, setShowDisconnectedBanner] = useState(false);
+  useEffect(() => {
+    if (connected) { setShowDisconnectedBanner(false); return; }
+    const timer = setTimeout(() => setShowDisconnectedBanner(true), 2000);
+    return () => clearTimeout(timer);
+  }, [connected]);
 
   // fix: popstate — 스레드/리딩패널 열린 상태에서만 가로채기 (Next.js 네비게이션 비간섭)
   useEffect(() => {
@@ -781,6 +794,24 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
 
         {/* Main chat — AC8: 모바일에서 스레드/리딩패널 뷰 활성 시 hidden */}
         <div className={`flex min-w-0 flex-1 flex-col overflow-hidden ${isMobileRightPanelView ? 'hidden lg:flex' : 'flex'}`}>
+          {/* story #2987 AC2 후반 — 자동 재연결(§1)이 대부분 소리 없이 복구하지만, 실패하면
+              (예: 서버가 실제로 죽음) 주소창 없는 앱에선 새로고침 우회조차 없다 — 수동 갱신
+              affordance가 유일한 탈출구. 빨강(destructive) 아님 — "네가 실패했다"가 아니라
+              "연결이 끊긴 상태"(reference-drop-notice.tsx와 동일 warning-tint 관례). */}
+          {showDisconnectedBanner && (
+            <div className="flex flex-shrink-0 items-center gap-2 border-b border-warning-border bg-warning-tint px-3 py-2 text-xs text-foreground">
+              <WifiOff className="h-3.5 w-3.5 flex-shrink-0" />
+              <span className="flex-1">{t('connectionLost')}</span>
+              <button
+                type="button"
+                onClick={() => void fetchMessages()}
+                className="flex items-center gap-1 rounded px-1.5 py-1 font-medium hover:bg-warning-border/40"
+              >
+                <RefreshCw className="h-3 w-3" />
+                {t('refreshNow')}
+              </button>
+            </div>
+          )}
           {/* Messages */}
           <div
             ref={scrollRef}

--- a/apps/web/src/hooks/use-chat-sse.test.tsx
+++ b/apps/web/src/hooks/use-chat-sse.test.tsx
@@ -222,3 +222,52 @@ describe('useChatSse — org 전환(memberId 변경) 재연결(story #2964, mux 
     expect(FakeEventSource.instances[0]!.closed).toBe(false);
   });
 });
+
+// story #2987(선생님 실사용 지적, standalone-fallback 경로) — sse-multiplexer.test.tsx의
+// "가시성 복귀 강제 재연결" 회귀가드와 동형(mux OFF일 때 이 훅이 직접 여는 EventSource도
+// 같은 처방을 받아야 한다).
+describe('useChatSse — 가시성 복귀 강제 재연결(#2987, standalone-fallback)', () => {
+  function setVisibility(state: DocumentVisibilityState) {
+    Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  }
+
+  afterEach(() => {
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+  });
+
+  it('임계값(3s) 이상 숨겨졌다 돌아오면 기존 커넥션을 닫고 새로 연다', async () => {
+    await act(async () => { root.render(<Harness currentTeamMemberId="m1" />); });
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    act(() => { setVisibility('hidden'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(5_000); });
+    act(() => { setVisibility('visible'); });
+
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(FakeEventSource.instances[0]!.closed).toBe(true);
+  });
+
+  it('임계값(3s) 미만의 짧은 전환은 재연결하지 않는다 — 처칭 방지', async () => {
+    await act(async () => { root.render(<Harness currentTeamMemberId="m1" />); });
+
+    act(() => { setVisibility('hidden'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(1_000); });
+    act(() => { setVisibility('visible'); });
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it('강제 재연결이 열리면 onReconnect가 불린다(backfill 트리거, backoff 이력 무관)', async () => {
+    const onReconnect = vi.fn();
+    await act(async () => { root.render(<Harness currentTeamMemberId="m1" onReconnect={onReconnect} />); });
+    expect(onReconnect).not.toHaveBeenCalled();
+
+    act(() => { setVisibility('hidden'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(5_000); });
+    act(() => { setVisibility('visible'); });
+    act(() => { FakeEventSource.instances[1]!.onopen?.(); });
+
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -6,6 +6,7 @@ import { shouldSuppressDuplicateSseEvent, createSeenIdTracker } from '@/lib/real
 import { createReconnectBackoffState, type ReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
 import { isSessionAlive } from '@/lib/realtime/sse-session-guard';
 import { isCursorEligibleEventName } from '@/lib/realtime/sse-cursor-eligibility';
+import { createVisibilityReconnectState } from '@/lib/realtime/sse-visibility-reconnect';
 
 // chat-attach: 메시지 전송 시 첨부 메타 (BE MessageAttachment 계약과 동일).
 export interface SendAttachment {
@@ -215,6 +216,11 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
     if (prevMemberIdForResetRef.current !== currentTeamMemberId) lastEventIdRef.current = null;
     prevMemberIdForResetRef.current = currentTeamMemberId;
 
+    // story #2987 — sse-multiplexer.ts와 동일 처방(그쪽 주석 참고). 가시성 복귀 강제 재연결은
+    // backoff.isReconnect()를 안 거치므로(onError 미경유) 이 플래그로 onReconnect(=backfill)를
+    // 확실히 태운다.
+    let pendingForcedReconnect = false;
+
     function connect() {
       sourceRef.current?.close();
       sourceRef.current = null;
@@ -227,7 +233,8 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
       sourceRef.current = source;
 
       source.onopen = () => {
-        const isReconnect = backoff.isReconnect();
+        const isReconnect = backoff.isReconnect() || pendingForcedReconnect;
+        pendingForcedReconnect = false;
         setConnected(true);
         backoff.onOpen();
         // AC4: 재연결 시 backfill 트리거
@@ -283,7 +290,23 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
 
     connect();
 
+    // story #2987 — sse-multiplexer.ts와 동일 처방(그쪽 주석 참고, sse-visibility-reconnect.ts
+    // 공용 모듈). readyState는 좀비 커넥션을 못 잡으므로 가시성 복귀 시 무조건 강제 재연결한다.
+    const visibilityState = createVisibilityReconnectState();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        visibilityState.onHidden();
+        return;
+      }
+      if (visibilityState.onVisible()) {
+        pendingForcedReconnect = true;
+        connect();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
     return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
       // #3388 카디르 QA MEDIUM과 동일 근거 — clearTimeout만으론 stale ref가 남아, 재마운트
       // (memberId 전환) 직후 대기 中이던 백오프 재시도가 stale ref에 걸려 건너뛸 수 있었다.
       if (reconnectTimerRef.current) {

--- a/apps/web/src/hooks/use-sse-notifications.test.tsx
+++ b/apps/web/src/hooks/use-sse-notifications.test.tsx
@@ -204,3 +204,41 @@ describe('useSseNotifications — org 전환(memberId 변경) 재연결(story #2
     expect(FakeEventSource.instances[0]!.closed).toBe(false);
   });
 });
+
+// story #2987(PO beyond-diff 지적) — chat과 동일 좀비 커넥션 클래스가 알림 SSE의 mux OFF
+// 폴백 경로에도 있었다(mux ON이면 sse-multiplexer.ts 처방이 이미 커버 — 이 회귀가드는
+// fallback 전용). sse-multiplexer.test.tsx·use-chat-sse.test.tsx와 동형 시나리오.
+describe('useSseNotifications — 가시성 복귀 강제 재연결(#2987, mux OFF 폴백 경로 전용)', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => {
+    vi.useRealTimers();
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+  });
+
+  function setVisibility(state: DocumentVisibilityState) {
+    Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  }
+
+  it('임계값(3s) 이상 숨겨졌다 돌아오면 기존 커넥션을 닫고 새로 연다', async () => {
+    await act(async () => { root.render(<Harness onNotification={vi.fn()} memberId="m1" />); });
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    act(() => { setVisibility('hidden'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(5_000); });
+    act(() => { setVisibility('visible'); });
+
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(FakeEventSource.instances[0]!.closed).toBe(true);
+  });
+
+  it('임계값(3s) 미만의 짧은 전환은 재연결하지 않는다 — 처칭 방지', async () => {
+    await act(async () => { root.render(<Harness onNotification={vi.fn()} memberId="m1" />); });
+
+    act(() => { setVisibility('hidden'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(1_000); });
+    act(() => { setVisibility('visible'); });
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+});

--- a/apps/web/src/hooks/use-sse-notifications.ts
+++ b/apps/web/src/hooks/use-sse-notifications.ts
@@ -6,6 +6,7 @@ import { shouldSuppressDuplicateSseEvent, createSeenIdTracker } from '@/lib/real
 import { createReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
 import { isSessionAlive } from '@/lib/realtime/sse-session-guard';
 import { isCursorEligibleEventName } from '@/lib/realtime/sse-cursor-eligibility';
+import { createVisibilityReconnectState } from '@/lib/realtime/sse-visibility-reconnect';
 
 export interface SseEventNotification {
   id?: string;
@@ -173,8 +174,23 @@ export function useSseNotifications({
 
     connect();
 
+    // story #2987(PO 지적, chat과 동일 좀비 커넥션 클래스 — sse-multiplexer.ts·use-chat-sse.ts
+    // 주석 참고) — 이 fallback은 mux ON(dev/prod 라이브)이면 애초에 안 탄다(위 106행 가드).
+    // mux가 이미 그 경로를 고쳤으니 이건 mux OFF/Provider 밖 경로 전용 동형 처방(방어 계층).
+    // last_event_id는 이 effect 본문의 지역 변수라 강제 재연결에도 자동 보존된다.
+    const visibilityState = createVisibilityReconnectState();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        visibilityState.onHidden();
+        return;
+      }
+      if (visibilityState.onVisible()) connect();
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
     return () => {
       closed = true;
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
       if (retryTimer) clearTimeout(retryTimer);
       es?.close();
     };

--- a/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
+++ b/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
@@ -394,4 +394,63 @@ describe('useSseMultiplexer — story #2078', () => {
       vi.useRealTimers();
     });
   });
+
+  // story #2987(선생님 실사용 지적) — "앱을 나갔다 들어와야 채팅이 갱신된다"의 근본원인
+  // 회귀가드. readyState는 좀비 커넥션(브라우저가 아직 못 알아챈 죽은 소켓)을 못 잡으므로,
+  // 가시성 복귀 시 그걸 안 보고 무조건 강제 재연결해야 한다.
+  describe('가시성 복귀 강제 재연결(#2987)', () => {
+    function setVisibility(state: DocumentVisibilityState) {
+      Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    }
+
+    afterEach(() => {
+      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    });
+
+    it('임계값(3s) 이상 숨겨졌다 돌아오면 기존 커넥션을 닫고 새로 연다', async () => {
+      vi.useFakeTimers();
+      await act(async () => { root.render(<Harness memberId="me-1" enabled />); });
+      act(() => { instances[0]!.onopen?.(); });
+      expect(instances).toHaveLength(1);
+
+      act(() => { setVisibility('hidden'); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(5_000); });
+      act(() => { setVisibility('visible'); });
+
+      expect(instances).toHaveLength(2);
+      expect(instances[0]!.closed).toBe(true);
+      vi.useRealTimers();
+    });
+
+    it('임계값(3s) 미만의 짧은 전환은 재연결하지 않는다 — 처칭 방지', async () => {
+      vi.useFakeTimers();
+      await act(async () => { root.render(<Harness memberId="me-1" enabled />); });
+      act(() => { instances[0]!.onopen?.(); });
+
+      act(() => { setVisibility('hidden'); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(1_000); });
+      act(() => { setVisibility('visible'); });
+
+      expect(instances).toHaveLength(1);
+      vi.useRealTimers();
+    });
+
+    it('강제 재연결이 열리면 backoff 이력과 무관하게 subscribeReconnect 핸들러가 불린다(backfill 트리거)', async () => {
+      vi.useFakeTimers();
+      await act(async () => { root.render(<Harness memberId="me-1" enabled />); });
+      const onReconnect = vi.fn();
+      await act(async () => { handle!.subscribeReconnect(onReconnect); });
+      act(() => { instances[0]!.onopen?.(); }); // 최초 open(onError 이력 없음)
+      expect(onReconnect).not.toHaveBeenCalled();
+
+      act(() => { setVisibility('hidden'); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(5_000); });
+      act(() => { setVisibility('visible'); });
+      act(() => { instances[1]!.onopen?.(); }); // 강제 재연결의 새 커넥션이 open
+
+      expect(onReconnect).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+  });
 });

--- a/apps/web/src/lib/realtime/sse-multiplexer.ts
+++ b/apps/web/src/lib/realtime/sse-multiplexer.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createReconnectBackoffState } from './sse-reconnect-backoff';
 import { isSessionAlive } from './sse-session-guard';
 import { isCursorEligibleEventName } from './sse-cursor-eligibility';
+import { createVisibilityReconnectState } from './sse-visibility-reconnect';
 
 /**
  * story #2078(E-ARCH 0단계) — presence·notification·chat이 각자 EventSource를 열어 탭당 장수
@@ -114,6 +115,11 @@ export function useSseMultiplexer(memberId: string | undefined, enabled: boolean
 
     let closed = false;
     const backoff = createReconnectBackoffState();
+    // story #2987 — 가시성 복귀로 강제 재연결할 때는 backoff.isReconnect()(과거 onError
+    // 이력 여부)가 아니라 이 플래그로 reconnectSubscribers(=chat-view의 backfill fetch 등)를
+    // 확실히 태운다. onError를 거치지 않은 강제 재연결이라 backoff 내부 상태는 그대로 두고
+    // (실패 카운트·healthy-cycle 판정 오염 방지) 이 자리에서만 별도로 신호한다.
+    let pendingForcedReconnect = false;
 
     const connect = () => {
       if (closed) return;
@@ -130,7 +136,8 @@ export function useSseMultiplexer(memberId: string | undefined, enabled: boolean
       for (const eventName of namedSubscribersRef.current.keys()) attachIfNeeded(eventName);
 
       es.onopen = () => {
-        const isReconnect = backoff.isReconnect();
+        const isReconnect = backoff.isReconnect() || pendingForcedReconnect;
+        pendingForcedReconnect = false;
         backoff.onOpen();
         setConnected(true);
         if (isReconnect) for (const handler of reconnectSubscribersRef.current) handler();
@@ -168,9 +175,27 @@ export function useSseMultiplexer(memberId: string | undefined, enabled: boolean
 
     connect();
 
+    // story #2987 — 앱이 백그라운드로 갔다 돌아와도 커넥션이 실제로 살아있는지 아무도 확認
+    // 안 하던 것(선생님 실사용 지적 "나갔다 들어와야 갱신됨"의 근본원인). readyState는 좀비
+    // 커넥션(브라우저가 아직 끊김을 감지 못한 상태)을 못 잡으므로, 숨겨진 시간이 임계값
+    // 이상이면 readyState를 안 보고 무조건 강제 재연결한다(sse-visibility-reconnect.ts).
+    const visibilityState = createVisibilityReconnectState();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        visibilityState.onHidden();
+        return;
+      }
+      if (visibilityState.onVisible()) {
+        pendingForcedReconnect = true;
+        connect();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
     return () => {
       closed = true;
       setConnected(false);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
       // 카디르 QA(PR#3388) MEDIUM — clearTimeout만으론 stale ref가 남아, 재마운트(예: memberId
       // 전환) 직후 대기 중이던 백오프 재시도의 scheduleRetry()가 `if (retryTimerRef.current)
       // return` 가드에 stale 값으로 걸려 재시도를 건너뛸 수 있었다. null로 명시 리셋.

--- a/apps/web/src/lib/realtime/sse-visibility-reconnect.test.ts
+++ b/apps/web/src/lib/realtime/sse-visibility-reconnect.test.ts
@@ -1,0 +1,49 @@
+// story #2987(선생님 실사용 지적) — "앱을 나갔다 들어와야 채팅이 갱신된다"의 근본원인은
+// visibilitychange 복귀 시 SSE 커넥션 건강을 아무도 확認 안 하던 것. 이 모듈의 계약:
+// ① 숨겨진 시간이 임계값(3s) 미만이면 재연결 불필요(false) — 데스크톱 짧은 탭 전환에서
+//    매번 재연결하는 처칭 방지.
+// ② 임계값 이상 숨겨졌다 돌아오면 강제 재연결 필요(true) — readyState를 안 믿는다(좀비
+//    커넥션은 OPEN을 self-report할 수 있어 그 체크로는 못 잡는다는 게 이 fix의 핵심 근거).
+// ③ hidden 없이(mount 직후 등) onVisible이 불려도 안전하게 false.
+import { describe, expect, it } from 'vitest';
+import { createVisibilityReconnectState } from './sse-visibility-reconnect';
+
+describe('createVisibilityReconnectState — story #2987', () => {
+  it('숨겨진 시간이 임계값(3s) 미만이면 재연결이 필요 없다(false) — 짧은 탭 전환', () => {
+    let t = 0;
+    const state = createVisibilityReconnectState(() => t);
+    state.onHidden();
+    t += 2_999;
+    expect(state.onVisible()).toBe(false);
+  });
+
+  it('숨겨진 시간이 임계값(3s) 이상이면 강제 재연결이 필요하다(true) — 백그라운드 복귀', () => {
+    let t = 0;
+    const state = createVisibilityReconnectState(() => t);
+    state.onHidden();
+    t += 3_000;
+    expect(state.onVisible()).toBe(true);
+  });
+
+  it('오래(수 분) 백그라운드에 있었어도 true(좀비 커넥션 의심 — readyState를 안 믿고 무조건 재연결)', () => {
+    let t = 0;
+    const state = createVisibilityReconnectState(() => t);
+    state.onHidden();
+    t += 5 * 60_000;
+    expect(state.onVisible()).toBe(true);
+  });
+
+  it('onHidden 없이 onVisible이 불려도(마운트 직후 등) 안전하게 false를 반환한다', () => {
+    const state = createVisibilityReconnectState(() => 0);
+    expect(state.onVisible()).toBe(false);
+  });
+
+  it('한 번 판정 후 hiddenAt이 리셋돼 연속 onVisible 호출은 항상 false다(재진입 안전)', () => {
+    let t = 0;
+    const state = createVisibilityReconnectState(() => t);
+    state.onHidden();
+    t += 5_000;
+    expect(state.onVisible()).toBe(true);
+    expect(state.onVisible()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/realtime/sse-visibility-reconnect.ts
+++ b/apps/web/src/lib/realtime/sse-visibility-reconnect.ts
@@ -1,0 +1,44 @@
+'use client';
+
+/**
+ * story #2987(선생님 실사용 지적, 2026-08-24) — "앱 안에서 채팅방을 나갔다 들어와야 새
+ * 내용이 반영된다". 그라운딩(코드 실측): `use-chat-sse.ts`·`sse-multiplexer.ts` 어느
+ * 경로에도 `visibilitychange` 리스너가 없다 — RealtimeProvider가 세션 전체에서 SSE
+ * 커넥션 하나를 계속 유지하는데(대화방 이동은 REST `fetchMessages()`만 새로 태울 뿐, SSE
+ * 재구독이 아니다), 앱이 백그라운드로 갔다 돌아와도 그 커넥션이 살아있는지 아무도 확認
+ * 안 한다. standalone PWA(주소창 없음, manifest.ts display:'standalone')는 백그라운드
+ * 전환 시 OS가 JS 실행 자체를 정지시키는 경우가 흔해(iOS Safari 홈스크린 앱 등), 복귀
+ * 시점엔 이미 "좀비 커넥션"(EventSource.readyState는 OPEN을 self-report하지만 실제
+ * 소켓은 죽음)일 수 있다 — `readyState` 체크는 이 케이스를 못 잡는다(브라우저 자신도
+ * 아직 모른다). 유일한 안전한 처방은 가시성 복귀 시 **무조건 강제 재연결**(close+reopen)
+ * — 기존 backfill(last_event_id)·dedup 인프라가 있어 비용은 가볍고 유실도 없다.
+ *
+ * 다만 데스크톱에서 짧은 탭 전환(alt-tab)까지 매번 재연결하면 불필요한 처칭이라, "숨겨진
+ * 시간이 임계값 이상"일 때만 재연결한다 — 순간 blur/focus는 건너뛴다.
+ */
+const HIDDEN_RECONNECT_THRESHOLD_MS = 3_000;
+
+export interface VisibilityReconnectState {
+  /** 페이지가 hidden이 될 때 호출(visibilitychange, document.visibilityState==='hidden'). */
+  onHidden: () => void;
+  /** 페이지가 다시 visible이 될 때 호출 — true면 강제 재연결해야 한다(숨겨진 시간이 임계값
+   * 이상). false면 순간 전환이었으니 기존 커넥션을 그대로 둔다. */
+  onVisible: () => boolean;
+}
+
+/** 테스트에서 결정적 값을 주입할 수 있도록 시계 소스를 분리(기본 Date.now). */
+export function createVisibilityReconnectState(now: () => number = Date.now): VisibilityReconnectState {
+  let hiddenAt: number | null = null;
+
+  return {
+    onHidden() {
+      hiddenAt = now();
+    },
+    onVisible() {
+      if (hiddenAt === null) return false;
+      const hiddenDuration = now() - hiddenAt;
+      hiddenAt = null;
+      return hiddenDuration >= HIDDEN_RECONNECT_THRESHOLD_MS;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
선생님 실사용 지적(2026-08-24): "앱 안에서 채팅방을 나갔다 들어와야 새 내용이 반영된다". standalone 앱(주소창 없음)에선 새로고침 우회조차 불가.

## 그라운딩 (AC1 — stale 층 확定, 코드 실측)
`RealtimeProvider`가 세션 전체에서 SSE 커넥션 하나를 계속 유지한다(대화방 이동은 REST `fetchMessages()`만 새로 태울 뿐 SSE 재구독이 아니다). 두 연결경로(`sse-multiplexer.ts` · `use-chat-sse.ts` 폴백) 어디에도 `visibilitychange` 리스너가 없었다 — 앱이 백그라운드로 갔다 돌아와도 커넥션이 실제로 살아있는지 아무도 확認 안 했다.

standalone PWA는 백그라운드 전환 시 OS가 JS 실행을 정지시키는 경우가 흔해(iOS Safari 홈스크린 앱 등), 복귀 시점엔 이미 **"좀비 커넥션"**(`EventSource.readyState`가 OPEN을 self-report하지만 실제 소켓은 죽음)일 수 있다 — `readyState` 체크로는 이 케이스를 못 잡는다(브라우저 자신도 아직 모른다).

## Fix
**AC1/AC2 전반**: 신규 공용 모듈 `sse-visibility-reconnect.ts` — 가시성 복귀 시 숨겨진 시간이 임계값(3s) 이상이면 `readyState`를 안 보고 무조건 강제 재연결(close+reopen), 짧은 탭 전환(<3s)은 건너뛴다(처칭 방지). 두 연결경로 모두에 배선. 강제 재연결은 backoff의 onError 이력과 무관하게 `reconnectSubscribers`(=chat-view의 backfill fetch)를 확실히 태우도록 별도 플래그로 신호(backoff 내부 실패카운트·healthy-cycle 판정은 안 건드림). `last_event_id`는 보존되므로 서버가 커서 기준으로 놓친 이벤트도 재생한다.

**AC2 후반**: `chat-view.tsx`에 연결끊김 배너+수동 갱신 버튼 추가. 짧은 순단(정상 60초 재연결 사이클)까지 매번 안 뜨게 2s 이상 지속될 때만 표시 — `reference-drop-notice.tsx`와 동일 warning-tint 관례(빨강 아님, "네가 실패했다"가 아니라 "연결이 끊긴 상태").

## Test plan
- [x] 신규 회귀테스트 — `sse-visibility-reconnect.test.ts`(순수 로직 5건) + `sse-multiplexer.test.tsx`/`use-chat-sse.test.tsx`에 통합 시나리오 각 3건(임계값 이상 재연결·미만 스킵·backfill 트리거) — 실제 EventSource 페이크 하니스로 "백그라운드 후 복귀"를 직접 재현
- [x] 전체 `vitest` 493 files / 4273 tests green(회귀 0)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `pnpm build` EXIT=0
- [ ] **AC3(라이브 확認·앱 환경 포함)** — 코드 레벨로 재현 불가(실 디바이스 백그라운딩 필요), dev 배포 후 QA 몫. 방을 열어 둔 채 상대 발신 → 즉시 반영(나갔다 들어오기 불요) + 실제 앱(standalone) 백그라운드/복귀 시나리오 확認 필요.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>