### PR TITLE
[SID:2988] 채팅방 헤더 아바타 ring 상하 클리핑 fix

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.test.tsx
@@ -194,6 +194,34 @@ describe('ConversationPage — 헤더 아바타(story #2968)', () => {
 
     expect(container.querySelector('img')).toBeNull();
   });
+
+  // story #2988(선생님 실사용 지적, 스크린샷) — top-bar.tsx의 `[&>*]:truncate`가 title 루트
+  // div 자신에 overflow:hidden을 건다(빌드 CSS 실측). agent Avatar의 ring-2 ring-offset-1은
+  // box-shadow라 레이아웃 박스 밖 3px까지 번지는데, 그 div가 overflow:hidden이면서 자기
+  // 자식(24px Avatar)에 딱 맞는 높이라 링이 상하로 잘렸다. py-1(4px, 3px보다 여유)로 클립
+  // 경계를 밀어내는 fix의 회귀가드 — 실제 DOM에서 padding 클래스가 걸려있는지 고정한다.
+  it('agent 상대 헤더의 title 루트가 py-1을 가져 ring(box-shadow)이 overflow:hidden에 안 잘린다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/conversations/conv-1')) {
+        return {
+          ok: true,
+          json: async () => ({
+            title: null, type: 'dm', muted: false, lastReadAt: null, freeResponse: false,
+            participants: [
+              { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+              { member_id: 'them-1', name: '페드루', avatar_url: null, type: 'agent' },
+            ],
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    await mount();
+
+    const backBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('채팅'));
+    const titleRoot = backBtn?.parentElement;
+    expect(titleRoot?.className).toContain('py-1');
+  });
 });
 
 // story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — 헤더 상대명/방이름=Claim(600)

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -210,7 +210,15 @@ export default function ConversationPage() {
     <>
       <TopBarSlot
         title={
-          <div className="flex min-w-0 items-center gap-1">
+          // story #2988(선생님 실사용 지적) — top-bar.tsx의 `[&>*]:min-w-0 [&>*]:truncate`가
+          // 이 title 루트 div 자신에 `overflow:hidden`을 건다(빌드 CSS 실측:
+          // `.truncate{overflow:hidden;...}`). 텍스트 말줄임(6df91dce)이 원 의도였는데, 이
+          // div의 자연 높이는 가장 큰 자식(Avatar 24px)에 맞춰지고, agent Avatar의
+          // `ring-2 ring-offset-1`은 box-shadow라 레이아웃 박스 밖으로 3px 번진다(빌드 CSS
+          // 실측: `calc(2px + 1px)` 링 반경) — overflow:hidden이 그 3px를 상하로 그대로
+          // 잘라 "위아래가 잘려 렌더"됐다. py-1(4px)로 클립 경계를 링 밖까지 밀어낸다(회귀
+          // 0 — 텍스트 말줄임 동작은 overflow:hidden이 여전히 걸려있어 그대로 유지).
+          <div className="flex min-w-0 items-center gap-1 py-1">
             <button
               type="button"
               // story #1990: replace(), not push() — 콜드-진입 합성 스택에 세번째 엔트리를


### PR DESCRIPTION
## Summary
선생님 실사용 지적(2026-08-24, 스크린샷): 채팅방 상단 헤더에서 상대(agent) 아바타 원형이 위아래로 잘려 렌더됨(「< 🧑 페드루 올리베이라」 헤더).

## 그라운딩 (빌드 CSS 실측, 추측 안 함)
- `top-bar.tsx:70`의 `[&>*]:min-w-0 [&>*]:truncate`가 title 루트 div 자신에 `overflow:hidden`을 건다 — 빌드 CSS 확인: `.truncate{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}`. story 6df91dce가 도입한 텍스트 말줄임 처방을 이 div의 **모든 직계 자식**에 무차별 적용한다.
- `chats/[conversation_id]/page.tsx`의 title div는 자연 높이가 가장 큰 자식(Avatar 24px)에 맞춰지는데, agent Avatar의 `ring-2 ring-offset-1`(`avatar.tsx`)은 `box-shadow`라 레이아웃 박스 밖으로 번진다 — 빌드 CSS 확인: `ring-offset-shadow`(1px) + `ring-shadow` `calc(2px + 1px)`=3px 반경. `overflow:hidden`이 그 3px를 상하로 그대로 잘랐다.

## Fix
title 루트 div에 `py-1`(4px, 3px 링 반경보다 여유) 추가 — `overflow:hidden`의 클립 경계를 링 밖까지 밀어낸다. 텍스트 말줄임(`overflow:hidden` 자체)은 그대로 유지되어 원 기능 회귀 없음.

## grep 전수 (AC2)
`TopBarSlot` `title`에 `Avatar`를 넣는 자리는 이 페이지가 유일(다른 조합 `team-activity-view.tsx`는 title이 순수 텍스트 `h1`). `sidebar.tsx`의 유사 패턴(`[&>span:last-child]:truncate`)은 마지막 `span`만 겨눠 비-span 형제(Avatar div)엔 애초에 안 걸려 같은 결함 클래스가 아니다.

## Test plan
- [x] 회귀테스트 신규 1건 — agent DM 헤더에서 title 루트가 `py-1`을 갖는지 고정(기존 9건 포함 10 tests green)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `pnpm build` EXIT=0, 빌드 CSS로 `py-1` 실제 발행 재확認
- [ ] dev 배포 후 실픽셀 — 선생님 스크린샷 그 화면(카디르 QA)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>