### PR TITLE
[SID:2990] Workcell bento 형태·재질 재편 PR-1

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4194,7 +4194,8 @@
     "pipelineNeedsInput": "Needs input",
     "pipelineClaimedDone": "Claimed done",
     "pipelineVerified": "Verified",
-    "pipelineMergeReady": "Merge-ready"
+    "pipelineMergeReady": "Merge-ready",
+    "confidenceCaption": "Verified {done}/{total} · fill = reached amount"
   },
   "loopQueue": {
     "title": "Unclosed loop queue",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4194,7 +4194,8 @@
     "pipelineNeedsInput": "Needs input",
     "pipelineClaimedDone": "Claimed done",
     "pipelineVerified": "Verified",
-    "pipelineMergeReady": "Merge-ready"
+    "pipelineMergeReady": "Merge-ready",
+    "confidenceCaption": "검증 {done}/{total} · 채움 = 도달 물리량"
   },
   "loopQueue": {
     "title": "닫히지 않은 루프 큐",

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -199,8 +199,15 @@ describe('StoryDetailPanel — Workcell pipelineStage = story.trust_stage 직결
 
   // 스테퍼가 6라벨을 항상 전부 렌더하므로(현재단계=스타일만 다름) textContent.toContain으로는
   // "어느 단계가 current인지" 못 잰다 — aria-current="step"이 붙은 그 원소의 텍스트로만 확인.
+  // story #2984 §3/§6 — bentoLayout 기본값 true는 색 스테퍼(aria-current="step" 리스트)
+  // 대신 물리량 게이지를 렌더한다(현재 단계 라벨은 data-testid="workcell-current-stage"
+  // 한 곳). aria-current를 먼저 시도해 bentoLayout={false} 폴백 경로도 계속 커버한다 —
+  // 이 SSE 라이브 갱신 테스트들의 관심사는 "어느 단계가 뜨는가"이지 스테퍼 시각 표현이
+  // 아니므로 어느 레이아웃이든 같은 헬퍼로 잡는다.
   function currentStageLabel(): string | null {
-    return container.querySelector('[aria-current="step"]')?.textContent?.trim() ?? null;
+    const legacy = container.querySelector('[aria-current="step"]')?.textContent?.trim();
+    if (legacy) return legacy;
+    return container.querySelector('[data-testid="workcell-current-stage"]')?.textContent?.trim() ?? null;
   }
 
   it('trust_stage="verified" → Verified(gate fetch 응답과 무관 — BE 판정값 그대로)', async () => {
@@ -324,8 +331,15 @@ describe('StoryDetailPanel — Workcell pipelineStage SSE 라이브 갱신(story
   const HUMAN_ID = 'human-1';
   const memberMap = { [HUMAN_ID]: { id: HUMAN_ID, name: '책임자', type: 'human' } };
 
+  // story #2984 §3/§6 — bentoLayout 기본값 true는 색 스테퍼(aria-current="step" 리스트)
+  // 대신 물리량 게이지를 렌더한다(현재 단계 라벨은 data-testid="workcell-current-stage"
+  // 한 곳). aria-current를 먼저 시도해 bentoLayout={false} 폴백 경로도 계속 커버한다 —
+  // 이 SSE 라이브 갱신 테스트들의 관심사는 "어느 단계가 뜨는가"이지 스테퍼 시각 표현이
+  // 아니므로 어느 레이아웃이든 같은 헬퍼로 잡는다.
   function currentStageLabel(): string | null {
-    return container.querySelector('[aria-current="step"]')?.textContent?.trim() ?? null;
+    const legacy = container.querySelector('[aria-current="step"]')?.textContent?.trim();
+    if (legacy) return legacy;
+    return container.querySelector('[data-testid="workcell-current-stage"]')?.textContent?.trim() ?? null;
   }
 
   beforeEach(() => { vi.useFakeTimers(); });

--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -117,7 +117,10 @@ describe('Workcell — story #2922 W6 Proofline 레일(단계→색 파생)', ()
 // 트러스트-시맨틱(각 단계 자체의 신뢰상태, 위치 무관)으로 전환. 판별 핵심: "지나온" 단계가
 // 자기 고유 색(예: running=blue)을 유지해야 하며, 그저 지나왔다고 강제로 green이 되면 안 된다
 // — 이게 옛 위치기반 로직과의 진짜 차이(#3345 부수 논의가 지적한 지점).
-describe('Workcell — story #2922 W6 스테퍼 트러스트-시맨틱 컬러(유나양 확定)', () => {
+// story #2984 §6 — 이 축(PipelineStepper 컬러 로직)은 bentoLayout=false 폴백 경로에만
+// 남아있다(기본은 ConfidenceGauge, 물리량이지 색이 아니다) — 복귀 스위치를 켰을 때도 옛
+// 로직이 안 죽었는지 고정하기 위해 bentoLayout={false}로 명시한다.
+describe('Workcell — story #2922 W6 스테퍼 트러스트-시맨틱 컬러(유나양 확定, bentoLayout=false 폴백)', () => {
   // 각 단계의 label-wrapper class는 `role="listitem"`으로 블록을 쪼갠 뒤 그 블록의 첫
   // class="..."(레이블+색을 쥔 중간 span — 바깥 span의 class는 role 앞이라 분할로 이미
   // 소비됨, 점(dot) span의 class는 이보다 뒤에 옴)로 정확히 좁힌다.
@@ -130,29 +133,29 @@ describe('Workcell — story #2922 W6 스테퍼 트러스트-시맨틱 컬러(�
   }
 
   it('merge_ready가 current일 때, 이미 지나온 Running 단계는 강제로 green이 되지 않고 자기 고유색(blue) 유지', () => {
-    const markup = renderKo(<Workcell {...BASE} pipelineStage="merge_ready" />);
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="merge_ready" bentoLayout={false} />);
     const runningClass = stageWrapperClass(markup, 'Running');
     expect(runningClass.split(/\s+/)).toContain('text-proof-blue');
     expect(runningClass.split(/\s+/)).not.toContain('text-proof-green');
   });
 
   it('verified가 current일 때 그 자신은 green(자기 색이 진짜 green이므로)', () => {
-    const markup = renderKo(<Workcell {...BASE} pipelineStage="verified" />);
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="verified" bentoLayout={false} />);
     const verifiedClass = stageWrapperClass(markup, 'Verified');
     expect(verifiedClass.split(/\s+/)).toContain('text-proof-green');
     expect(verifiedClass.split(/\s+/)).toContain('font-bold');
   });
 
   it('claimed_done이 current일 때 그 자신은 blue(주장·미검증 — 아직 green 아님)', () => {
-    const markup = renderKo(<Workcell {...BASE} pipelineStage="claimed_done" />);
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="claimed_done" bentoLayout={false} />);
     const claimedClass = stageWrapperClass(markup, 'Claimed done');
     expect(claimedClass.split(/\s+/)).toContain('text-proof-blue');
   });
 });
 
-describe('Workcell — story #2922 W1 신뢰 파이프라인 헤더 스테퍼(6상태) + 2×2 구획', () => {
+describe('Workcell — story #2922 W1 신뢰 파이프라인 헤더 스테퍼(6상태) + 2×2 구획 (bentoLayout=false 폴백)', () => {
   it('renders all six pipeline stage labels regardless of current stage', () => {
-    const markup = renderKo(<Workcell {...BASE} pipelineStage="queued" />);
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="queued" bentoLayout={false} />);
     expect(markup).toContain('Queued');
     expect(markup).toContain('Running');
     expect(markup).toContain('Needs input');
@@ -162,13 +165,52 @@ describe('Workcell — story #2922 W1 신뢰 파이프라인 헤더 스테퍼(6�
   });
 
   it('marks the current stage with aria-current="step" (색만 금지 — 스크린리더도 현재단계를 안다)', () => {
-    const markup = renderKo(<Workcell {...BASE} pipelineStage="claimed_done" />);
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="claimed_done" bentoLayout={false} />);
     expect(markup).toContain('aria-current="step"');
   });
 
   it('renders a 2×2 quadrant body (Brief|Run / Evidence|Conversation), not a vertical 4-stack', () => {
-    const markup = renderKo(<Workcell {...BASE} />);
+    const markup = renderKo(<Workcell {...BASE} bentoLayout={false} />);
     expect(markup).toContain('grid-cols-2');
+  });
+});
+
+// story #2984 §1~§4/§6(doc workcell-bento-form-material-spec-2984) — bentoLayout 기본값
+// true의 실 착지 회귀가드. §6 복귀 스위치 자체(=bentoLayout prop이 실제로 옛 모습을
+// 복원하는지)는 바로 위 두 describe(bentoLayout={false} 명시)가 고정한다 — "1줄 복귀"의
+// 그 1줄이 정말 옛 마크업을 그대로 살려내는지가 검증 대상이었다.
+describe('Workcell — story #2984 §1~§4 bento 기본 레이아웃(bentoLayout 기본값 true)', () => {
+  it('§1 — Evidence·Run·Brief·Conversation 4셀이 bento grid(1.7fr:4px:1fr 열)로 렌더된다', () => {
+    const markup = renderKo(<Workcell {...BASE} />);
+    expect(markup).toContain('grid-cols-[1.7fr_4px_1fr]');
+    expect(markup).not.toContain('grid-cols-2');
+  });
+
+  it('§2 — Brief/Run과 Evidence를 잇는 계보 연결선(가운데 트랙)이 렌더된다', () => {
+    const markup = renderKo(<Workcell {...BASE} />);
+    expect(markup).toContain('col-start-2 row-start-1 row-span-2');
+    expect(markup).toContain('bg-proof-line-strong');
+  });
+
+  it('§4 — Evidence 셀만 elevation(--elev-overlay) 그림자를 갖고 나머지는 flat', () => {
+    const markup = renderKo(<Workcell {...BASE} />);
+    expect(markup).toContain('shadow-[var(--elev-overlay)]');
+    expect(markup).toContain('shadow-[0_1px_0_var(--proof-line)]');
+  });
+
+  it('§3 — 헤더가 색 스테퍼가 아니라 물리량 게이지(role=progressbar)로 렌더된다', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="needs_input" />);
+    expect(markup).toContain('role="progressbar"');
+    expect(markup).toContain('aria-valuenow="3"');
+    expect(markup).toContain('aria-valuemax="6"');
+    expect(markup).not.toContain('role="list"');
+  });
+
+  it('§6 — bentoLayout={false}로 뒤집으면 §1~§4 마크업이 전부 사라지고 옛 모습으로 복귀한다', () => {
+    const markup = renderKo(<Workcell {...BASE} bentoLayout={false} />);
+    expect(markup).not.toContain('grid-cols-[1.7fr_4px_1fr]');
+    expect(markup).not.toContain('shadow-[var(--elev-overlay)]');
+    expect(markup).not.toContain('role="progressbar"');
   });
 });
 
@@ -178,12 +220,16 @@ describe('Workcell Run layer (진행률바 0 — 현재행위+다음요구만)',
     expect(markup).toContain('지금: 재시도 로직 검증 테스트 작성 중');
     expect(markup).toContain('다음 요구');
     expect(markup).toContain('까심군 QA 리뷰 대기');
-    // clip-path(컷코너)는 CSS 값이라 '%'를 포함하는 게 정상이고, LayerLabel 설명 문구도
-    // "진행률바 아님"이라 그 단어 자체는 등장한다(부재를 명시하는 문구) — 실제로 검사할 건
-    // 진행률 바 "구현"(role/class/width:N% 스타일) 자체가 없다는 것.
-    expect(markup).not.toMatch(/role="progressbar"/);
-    expect(markup).not.toContain('progress-bar');
-    expect(markup).not.toMatch(/width:\s*\d+%/);
+    // story #2984 §3 — 헤더 Confidence 게이지는 물리량 채움 %를 의도적으로 쓴다(전혀 다른
+    // 계약, 위 "§3" 테스트가 고정). 이 안티패턴 검사는 Run 레이어 자신의 마크업(LayerLabel
+    // "Run" 이후·다음 LayerLabel "Evidence" 이전 구간)에만 좁힌다 — Run 자신은 여전히 %
+    // 진행률을 렌더하면 안 된다는 원래 도크트린 그대로.
+    const runStart = markup.indexOf('>Run<');
+    const runEnd = markup.indexOf('>Evidence<');
+    const runMarkup = markup.slice(runStart, runEnd);
+    expect(runMarkup).not.toMatch(/role="progressbar"/);
+    expect(runMarkup).not.toContain('progress-bar');
+    expect(runMarkup).not.toMatch(/width:\s*\d+%/);
   });
 
   it('shows "없음" for blocked when null, and the blocked value when present (never hidden — 도크트린 ③)', () => {

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -73,6 +73,11 @@ export interface WorkcellProps {
   evidence: ProofCapsuleProps | null;
   conversation: WorkcellConversation;
   className?: string;
+  /** story #2984 §6(가역성 1급) — bento 형태·재질 재편(§1~§4) 켜기/끄기 단일 스위치.
+   * 기본값 true(선생님 결재 confirm으로 라이브 기본). 선생님 라이브 감이 반려되면 이
+   * 기본값 한 줄(true→false)만 뒤집으면 균등 2×2 + 색 스테퍼로 전체 복귀(D0 세리프
+   * 토큰 복귀 선례와 동형 — 개별 소비처 산개 금지, 이 prop 하나만 경유). */
+  bentoLayout?: boolean;
 }
 
 const PIPELINE_STAGES: WorkcellPipelineStage[] = ['queued', 'running', 'needs_input', 'claimed_done', 'verified', 'merge_ready'];
@@ -144,6 +149,71 @@ function PipelineStepper({ stage }: { stage: WorkcellPipelineStage }) {
   );
 }
 
+// story #2984 §3(doc workcell-bento-form-material-spec-2984, 유나 설계·선생님 결재 confirm) —
+// 6단계 신뢰를 «채움 눈금 + 도달 노드»(물리량)로 표기. 색 스테퍼(PipelineStepper)의 색맹·
+// 저대비 취약점을 없앤다 — 색은 §7 규율대로 의미 신호로만 남긴다(이 게이지는 무채색).
+// 노드 위치는 트랙 8%~95% 구간에 6개를 균등 배치(끝 여백 확보). fill은 "마지막 도달 노드
+// 위치 + 다음 노드까지 절반"까지 채운다 — "이 단계까지 왔고, 다음으로 가는 중"을 물리적으로
+// 읽히게 하는 의도(유나 시안 db9bdfdf의 66%↔3/6 오버슛 관찰과 동형 원리, 정확한 %는 실 렌더
+// 여백 기준으로 재계산했다 — 시안 픽셀값을 그대로 베끼지 않음, 조정 필요하면 이 상수만).
+const CONFIDENCE_NODE_START_PCT = 8;
+const CONFIDENCE_NODE_END_PCT = 95;
+
+function nodePositions(): number[] {
+  const span = CONFIDENCE_NODE_END_PCT - CONFIDENCE_NODE_START_PCT;
+  const step = span / (PIPELINE_STAGES.length - 1);
+  return PIPELINE_STAGES.map((_, i) => CONFIDENCE_NODE_START_PCT + i * step);
+}
+
+function ConfidenceGauge({ stage }: { stage: WorkcellPipelineStage }) {
+  const t = useTranslations('workcell');
+  const label: Record<WorkcellPipelineStage, string> = {
+    queued: t('pipelineQueued'), running: t('pipelineRunning'), needs_input: t('pipelineNeedsInput'),
+    claimed_done: t('pipelineClaimedDone'), verified: t('pipelineVerified'), merge_ready: t('pipelineMergeReady'),
+  };
+  const curIdx = PIPELINE_STAGES.indexOf(stage);
+  const reachedCount = curIdx + 1; // 현재 단계까지 포함해 "도달"로 센다(mockup 3/6 판독과 동형).
+  const positions = nodePositions();
+  const lastReachedPos = positions[reachedCount - 1] ?? CONFIDENCE_NODE_START_PCT;
+  const nextPos = positions[reachedCount];
+  const fillPct = reachedCount >= PIPELINE_STAGES.length
+    ? 100
+    : lastReachedPos + (nextPos! - lastReachedPos) / 2;
+
+  return (
+    <div className="mb-2.5" role="progressbar" aria-valuemin={0} aria-valuemax={PIPELINE_STAGES.length} aria-valuenow={reachedCount} aria-valuetext={`${reachedCount}/${PIPELINE_STAGES.length} · ${label[stage]}`}>
+      <div className="flex items-center gap-2.5">
+        <div className="relative h-[22px] flex-1 overflow-hidden rounded-[4px] bg-proof-sunk">
+          {/* story #2984 §3 — 물리량 채움. 두 톤 반복 눈금(색 신호 아님, --proof-sunk/--proof-ink-3
+              에서 color-mix로 파생 — 신규 하드코딩 색 0, §7 규율). */}
+          <div
+            className="absolute inset-y-0 left-0"
+            style={{
+              width: `${fillPct}%`,
+              backgroundImage: 'repeating-linear-gradient(90deg, color-mix(in oklch, var(--proof-sunk) 35%, var(--proof-ink-3) 65%) 0 15px, color-mix(in oklch, var(--proof-sunk) 15%, var(--proof-ink-3) 85%) 15px 16px)',
+            }}
+          />
+          {positions.map((pos, i) => (
+            <span
+              key={PIPELINE_STAGES[i]}
+              className={cn(
+                'absolute top-1/2 size-[9px] -translate-x-1/2 -translate-y-1/2 rounded-full border-[1.5px]',
+                i < reachedCount ? 'border-proof-ink bg-proof-ink' : 'border-proof-line-strong bg-proof-panel',
+              )}
+              style={{ left: `${pos}%` }}
+              aria-hidden="true"
+            />
+          ))}
+        </div>
+        <span className="whitespace-nowrap font-mono text-[10px] text-proof-ink-3">
+          {t('confidenceCaption', { done: reachedCount, total: PIPELINE_STAGES.length })}
+        </span>
+      </div>
+      <p className="mt-1 text-[11px] font-semibold text-proof-ink-2" data-testid="workcell-current-stage">{label[stage]}</p>
+    </div>
+  );
+}
+
 /**
  * Workcell — Story 상세 우측 패널의 4구획 재구성(story #2922 P0-D, workcell-fe-spec-handoff
  * 초판 위 재설계). "10초 리트머스": 열고 10초 안에 무엇을(Brief)·누가(Brief)·어디까지
@@ -155,7 +225,7 @@ function PipelineStepper({ stage }: { stage: WorkcellPipelineStage }) {
  * ④자동화 경계(agent 마커 항상 구분) ⑤인간=책임 주체(Evidence의 Human gate가 결정점).
  * 안티패턴 0 — 진행률 바(%) 자체를 렌더하지 않는 게 Run 구획의 핵심 계약.
  */
-export function Workcell({ title, pipelineStage, brief, run, evidence, conversation, className }: WorkcellProps) {
+export function Workcell({ title, pipelineStage, brief, run, evidence, conversation, className, bentoLayout = true }: WorkcellProps) {
   const t = useTranslations('workcell');
   const railState = PIPELINE_STAGE_TRUST_COLOR[pipelineStage];
   return (
@@ -166,7 +236,8 @@ export function Workcell({ title, pipelineStage, brief, run, evidence, conversat
       {railState ? <Proofline state={railState} /> : <div className="w-1 shrink-0 self-stretch bg-proof-line" aria-hidden="true" />}
       <div className="min-w-0 flex-1">
         <div className="border-b border-proof-line px-4.5 py-3.5">
-          <PipelineStepper stage={pipelineStage} />
+          {/* story #2984 §3/§6 — bentoLayout=true(기본)면 색 스테퍼 대신 물리량 게이지. */}
+          {bentoLayout ? <ConfidenceGauge stage={pipelineStage} /> : <PipelineStepper stage={pipelineStage} />}
           <span className="text-[17px] font-bold leading-tight tracking-[-0.012em] text-proof-ink">{title}</span>
           {/* story #2922 W4 — 책임자/실행자를 헤더로 승격("10초 리트머스": 스크롤 없이 «누가»가
               보임). #3339(2921 아바타 단일통합)가 ProofAvatar를 폐기·Avatar로 수렴시켰다 —
@@ -186,15 +257,41 @@ export function Workcell({ title, pipelineStage, brief, run, evidence, conversat
           </div>
         </div>
 
-        {/* story #2922 W1 — 4구획 세로 나열 → 2×2 그리드(Brief|Run / Evidence|Conversation).
-            gap-px+bg-proof-line가 각 구획 사이 헤어라인을 만든다(개별 레이어의 border-b는
-            이제 이 그리드 갭과 중복이라 제거됨). */}
-        <div className="grid grid-cols-2 gap-px bg-proof-line">
-          <div className="bg-proof-panel"><BriefLayer brief={brief} /></div>
-          <div className="bg-proof-panel"><RunLayer run={run} /></div>
-          <div className="bg-proof-panel"><EvidenceLayer evidence={evidence} /></div>
-          <div className="bg-proof-panel"><ConversationLayer conversation={conversation} /></div>
-        </div>
+        {bentoLayout ? (
+          // story #2984 §1/§2/§4 — 균등 2×2 → 크기 차등 bento(Evidence=최우선 큰 셀)+계보
+          // 연결선+Evidence만 elevation. 가운데 4px 열은 연결선 전용 트랙(§2) — 매직 픽셀
+          // 좌표 없이 CSS Grid 라인에 그대로 앵커링해 실 렌더 폰트/패딩에 안 흔들린다.
+          <div className="relative grid grid-cols-[1.7fr_4px_1fr] grid-rows-[auto_auto_auto] gap-3 p-3">
+            <div className="col-start-2 row-start-1 row-span-2 flex justify-center" aria-hidden="true">
+              <div className="relative w-[1.5px] bg-proof-line-strong">
+                <span className="absolute left-1/2 top-0 size-[7px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-proof-ink" />
+                <span className="absolute left-1/2 top-1/2 size-[7px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-proof-ink" />
+              </div>
+            </div>
+            <div className="col-start-1 row-start-1 row-span-2 overflow-hidden rounded-[10px] border border-proof-line-strong bg-proof-panel shadow-[var(--elev-overlay)]">
+              <EvidenceLayer evidence={evidence} />
+            </div>
+            <div className="col-start-3 row-start-1 overflow-hidden rounded-[10px] border border-proof-line bg-proof-panel shadow-[0_1px_0_var(--proof-line)]">
+              <RunLayer run={run} />
+            </div>
+            <div className="col-start-3 row-start-2 overflow-hidden rounded-[10px] border border-proof-line bg-proof-panel shadow-[0_1px_0_var(--proof-line)]">
+              <BriefLayer brief={brief} />
+            </div>
+            <div className="col-span-3 row-start-3 overflow-hidden rounded-[10px] border border-proof-line bg-proof-panel shadow-[0_1px_0_var(--proof-line)]">
+              <ConversationLayer conversation={conversation} />
+            </div>
+          </div>
+        ) : (
+          // story #2922 W1 — 4구획 세로 나열 → 2×2 그리드(Brief|Run / Evidence|Conversation).
+          // gap-px+bg-proof-line가 각 구획 사이 헤어라인을 만든다(개별 레이어의 border-b는
+          // 이제 이 그리드 갭과 중복이라 제거됨).
+          <div className="grid grid-cols-2 gap-px bg-proof-line">
+            <div className="bg-proof-panel"><BriefLayer brief={brief} /></div>
+            <div className="bg-proof-panel"><RunLayer run={run} /></div>
+            <div className="bg-proof-panel"><EvidenceLayer evidence={evidence} /></div>
+            <div className="bg-proof-panel"><ConversationLayer conversation={conversation} /></div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 요약
승인된 스펙 doc `workcell-bento-form-material-spec-2984`(SSOT) 기준, 균등 2×2 그리드 + 6색 컬러 스테퍼를 비대칭 bento 그리드 + 물리량 신뢰 게이지로 재편. §1~§4 구현 + §6 복귀 스위치(`bentoLayout` prop, 기본 `true`).

- **§1/§2** — Evidence 대형 셀(elevated) + Run/Brief 소형 셀 + Conversation 전폭 행. 가운데 4px 거터 컬럼에 Brief→Run→Evidence 계보 연결선(grid 전용 트랙, 매직 픽셀 없음)
- **§3** — `ConfidenceGauge`: 6색 스테퍼 → 물리량 채움 게이지. 노드 위치·채움%는 `PIPELINE_STAGES` 실 배열에서 계산, `role="progressbar"` + `aria-valuenow/max/valuetext`
- **§4** — Evidence 셀만 기존 `--elev-overlay` 토큰으로 elevation, 나머지는 flat 1px 하이라인. 신규 하드코딩 색 없음
- **§6** — `bentoLayout={false}` 1줄로 옛 모습 완전 복귀(`PipelineStepper` 삭제 없이 보존)

## 스크린샷
정적 마크업 + 실 빌드 CSS를 puppeteer로 렌더해 라이브 픽셀 검증(light/dark, §6 복귀 대조 포함) — 별도 코멘트로 첨부.

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4276 tests all green (workcell.test.tsx 31, story-detail-panel.test.tsx 26 포함, 무회귀)
- [x] `pnpm build` green
- [x] 빌드 CSS grep으로 `grid-cols-[1.7fr_4px_1fr]` / `shadow-[var(--elev-overlay)]` 등 실컴파일 확인
- [x] 라이브 픽셀(light/dark, bentoLayout=false 복귀 경로)

## 반응형/접근성
- 게이지 `role=progressbar` 계열 aria 속성으로 스크린리더 커버
- 다크모드는 전량 CSS 커스텀 프로퍼티 기반이라 별도 오버라이드 불필요(라이브 검증 완료)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA