### PR TITLE
feat(#2989): 결제수단 셀프서브 삭제/교체 + admin 초기화

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2548,7 +2548,8 @@
     "paymentMethodDeleteConfirm": "Remove",
     "paymentMethodDeleteCancel": "Cancel",
     "paymentMethodDeleteSuccess": "Payment method removed.",
-    "paymentMethodDeleteBlocked": "You have an active paid subscription ({tier}) — cancel it before removing your payment method.",
+    "paymentMethodDeleteBlocked": "You have an active paid subscription ({tier}) — you can't remove your payment method yet.",
+    "paymentMethodDeleteBlockedUntil": "Your active paid subscription ({tier}) runs until {date}. You can remove your payment method after that.",
     "paymentMethodDeleteError": "Couldn't remove the payment method. Please try again."
   },
   "usage": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2538,7 +2538,18 @@
     "packDialogConfirm": "Confirm purchase",
     "packDialogNote": "Charges apply only after you confirm. You can cancel starting next cycle at any time.",
     "loadError": "Couldn't load pricing information.",
-    "memberNotice": "Only owners or admins can manage billing. Contact an admin if you need to change plans."
+    "memberNotice": "Only owners or admins can manage billing. Contact an admin if you need to change plans.",
+    "paymentMethodTitle": "Payment method",
+    "paymentMethodNone": "No payment method on file.",
+    "paymentMethodMasked": "{issuer} {number}",
+    "paymentMethodDeleteButton": "Remove payment method",
+    "paymentMethodDeleteConfirmTitle": "Remove this payment method?",
+    "paymentMethodDeleteConfirmBody": "The card will be permanently revoked with the payment provider and this cannot be undone. You can register a new card afterward.",
+    "paymentMethodDeleteConfirm": "Remove",
+    "paymentMethodDeleteCancel": "Cancel",
+    "paymentMethodDeleteSuccess": "Payment method removed.",
+    "paymentMethodDeleteBlocked": "You have an active paid subscription ({tier}) — cancel it before removing your payment method.",
+    "paymentMethodDeleteError": "Couldn't remove the payment method. Please try again."
   },
   "usage": {
     "eyebrow": "OPERATOR USAGE",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2548,7 +2548,8 @@
     "paymentMethodDeleteConfirm": "삭제",
     "paymentMethodDeleteCancel": "취소",
     "paymentMethodDeleteSuccess": "결제수단이 삭제되었습니다.",
-    "paymentMethodDeleteBlocked": "활성 유료 구독({tier})이 있어 결제수단을 삭제할 수 없습니다. 구독 해지 후 다시 시도해주세요.",
+    "paymentMethodDeleteBlocked": "활성 유료 구독({tier})이 있어 결제수단을 삭제할 수 없습니다.",
+    "paymentMethodDeleteBlockedUntil": "활성 유료 구독({tier})은 {date}까지 유효합니다. 그 이후에 결제수단을 삭제할 수 있어요.",
     "paymentMethodDeleteError": "결제수단 삭제에 실패했습니다. 잠시 후 다시 시도해주세요."
   },
   "usage": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2538,7 +2538,18 @@
     "packDialogConfirm": "구매 확인",
     "packDialogNote": "확인을 눌러야만 청구됩니다. 언제든 다음 결제 주기부터 해지할 수 있습니다.",
     "loadError": "요금제 정보를 불러올 수 없습니다.",
-    "memberNotice": "결제 관리는 owner 또는 admin만 가능합니다. 플랜 변경이 필요하면 관리자에게 문의해 주세요."
+    "memberNotice": "결제 관리는 owner 또는 admin만 가능합니다. 플랜 변경이 필요하면 관리자에게 문의해 주세요.",
+    "paymentMethodTitle": "결제수단",
+    "paymentMethodNone": "등록된 결제수단이 없습니다.",
+    "paymentMethodMasked": "{issuer} {number}",
+    "paymentMethodDeleteButton": "결제수단 삭제",
+    "paymentMethodDeleteConfirmTitle": "결제수단을 삭제할까요?",
+    "paymentMethodDeleteConfirmBody": "등록된 카드가 결제사에서 실제로 폐기되며, 되돌릴 수 없습니다. 새 카드는 다시 등록할 수 있습니다.",
+    "paymentMethodDeleteConfirm": "삭제",
+    "paymentMethodDeleteCancel": "취소",
+    "paymentMethodDeleteSuccess": "결제수단이 삭제되었습니다.",
+    "paymentMethodDeleteBlocked": "활성 유료 구독({tier})이 있어 결제수단을 삭제할 수 없습니다. 구독 해지 후 다시 시도해주세요.",
+    "paymentMethodDeleteError": "결제수단 삭제에 실패했습니다. 잠시 후 다시 시도해주세요."
   },
   "usage": {
     "eyebrow": "OPERATOR USAGE",

--- a/apps/web/scripts/verify-no-i18n-phrase-collision.ts
+++ b/apps/web/scripts/verify-no-i18n-phrase-collision.ts
@@ -156,6 +156,11 @@ export function flattenMessages(obj: Record<string, unknown>, prefix = ''): Map<
 //                문자열로 겹쳤다(카디르군 실측 4건, 전부 이 이름 하나가 원인). "실제로 채우는
 //                값을 먼저 읽는다"(위 규율) — checkoutDialogTitle의 기존 {tier}도 동일 축이며
 //                지금까지 우연히 이 스캔에 안 걸렸을 뿐 이름·경로류가 맞다.
+//   date       — YYYY-MM-DD 형식 캘린더 날짜(story #2989, PR#3423 리뷰 — 구독 종료일
+//                표시). payment-method-section.tsx가 채우는 값은
+//                `outcome.currentPeriodEnd?.slice(0, 10)`(예: "2026-09-24") — teamId·slug와
+//                같은 축의 «불투명 포맷 값»이지 «N개/N건류 카운트»가 아니다(자릿수가 늘거나
+//                줄어도 문법이 안 바뀜 — 이 가드가 지키려는 «수와 함께 서는 문구» 축과 무관).
 // ⛔새 이름을 여기 더하기 前에(PO 지적, 2026-08-02): 그 이름이 실제로 채우는 ko.json 값을
 // 먼저 읽는다. 정말 이름·경로류(수가 아님)면 더한다. 그런데 만약 «숫자인» 값인데 여기 걸려
 // EXEMPT_PAIRS에 다시 나타난다면, 그건 denylist 후보가 아니라 «진짜 충돌»이다 — 그 경우
@@ -165,7 +170,7 @@ export function flattenMessages(obj: Record<string, unknown>, prefix = ''): Map<
 // 재는지 모르게 되는 것)이 재발한다.
 const NON_NUMBER_PLACEHOLDER_NAMES = new Set([
   'name', 'runtime', 'filename', 'promptFile', 'gate', 'role', 'project', 'teamId', 'dir',
-  'sources', 'excludes', 'slug', 'tier',
+  'sources', 'excludes', 'slug', 'tier', 'date',
 ]);
 const PLACEHOLDER_NAME_RE = /\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g;
 

--- a/apps/web/src/app/api/billing/billing-key/route.ts
+++ b/apps/web/src/app/api/billing/billing-key/route.ts
@@ -1,0 +1,15 @@
+import { proxyToFastapiWrapped } from '@/lib/fastapi-proxy';
+
+/**
+ * story #2989 — 결제수단(빌링키) 조회+셀프서브 삭제.
+ * GET → `GET /api/v2/org-billing-keys`(등록된 카드가 있으면 마스킹 정보, 없으면 data:null).
+ * DELETE → `DELETE /api/v2/org-billing-keys`(Toss 실 폐기+DB 정리 — revoke_billing_key).
+ * 활성 유료 구독이 있으면 BE가 409(active_subscription_blocks_revoke)로 거부한다.
+ */
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapiWrapped(request, '/api/v2/org-billing-keys');
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  return proxyToFastapiWrapped(request, '/api/v2/org-billing-keys');
+}

--- a/apps/web/src/ee/components/billing/billing-actions.ts
+++ b/apps/web/src/ee/components/billing/billing-actions.ts
@@ -87,17 +87,26 @@ export async function fetchBillingKey(): Promise<BillingKeyInfo | null> {
 
 export type DeleteBillingKeyOutcome =
   | { kind: 'deleted' }
-  | { kind: 'blocked'; tier: string }
+  | { kind: 'blocked'; tier: string; currentPeriodEnd: string | null }
   | { kind: 'error'; status: number };
 
 /** 셀프서브 결제수단 삭제 — Toss 실 폐기 포함(BE revoke_billing_key). 활성 유료 구독이
  * 있으면 서버가 409(active_subscription_blocks_revoke)로 거부한다(P3, 선생님 정책
- * 확定 2026-08-24 — 판별자는 「현재 유효 여부」뿐, 예약된 해지/다운그레이드는 안 봄). */
+ * 확定 2026-08-24 — 판별자는 「현재 유효 여부」뿐, 예약된 해지/다운그레이드는 안 봄).
+ * PO 재지적(2026-08-24, PR#3423 리뷰) — 해지는 예약형(종료일까지 유효)이라 「해지 후
+ * 다시 시도」는 해지 직후에도 또 막히는 거짓 안내다. current_period_end를 그대로 전달해
+ * 화면이 실 날짜를 찍게 한다. */
 export async function deleteBillingKey(): Promise<DeleteBillingKeyOutcome> {
   const res = await fetchWithAuth('/api/billing/billing-key', { method: 'DELETE', credentials: 'include' });
   if (res.status === 409) {
-    const body = (await res.json().catch(() => null)) as { error?: { tier?: string } } | null;
-    return { kind: 'blocked', tier: body?.error?.tier ?? '' };
+    const body = (await res.json().catch(() => null)) as {
+      error?: { tier?: string; current_period_end?: string | null };
+    } | null;
+    return {
+      kind: 'blocked',
+      tier: body?.error?.tier ?? '',
+      currentPeriodEnd: body?.error?.current_period_end ?? null,
+    };
   }
   if (!res.ok) return { kind: 'error', status: res.status };
   return { kind: 'deleted' };

--- a/apps/web/src/ee/components/billing/billing-actions.ts
+++ b/apps/web/src/ee/components/billing/billing-actions.ts
@@ -67,3 +67,38 @@ export async function revokePendingChange(): Promise<ChangeTierOutcome> {
   const json = (await res.json()) as { data: ChangeTierResult };
   return { kind: 'active', result: json.data };
 }
+
+// story #2989 — 결제수단 조회+셀프서브 삭제. FE가 등록만 하고 지금 뭐가 등록돼 있는지
+// 보여줄 표면이 아예 없던 갭(그라운딩 실측) — 이 둘이 그 표면.
+export interface BillingKeyInfo {
+  org_id: string;
+  status: string;
+  card_issuer_code: string | null;
+  card_number_masked: string | null;
+  card_type: string | null;
+}
+
+export async function fetchBillingKey(): Promise<BillingKeyInfo | null> {
+  const res = await fetchWithAuth('/api/billing/billing-key', { credentials: 'include' });
+  if (!res.ok) return null;
+  const json = (await res.json()) as { data: BillingKeyInfo | null };
+  return json.data;
+}
+
+export type DeleteBillingKeyOutcome =
+  | { kind: 'deleted' }
+  | { kind: 'blocked'; tier: string }
+  | { kind: 'error'; status: number };
+
+/** 셀프서브 결제수단 삭제 — Toss 실 폐기 포함(BE revoke_billing_key). 활성 유료 구독이
+ * 있으면 서버가 409(active_subscription_blocks_revoke)로 거부한다(P3, 선생님 정책
+ * 확定 2026-08-24 — 판별자는 「현재 유효 여부」뿐, 예약된 해지/다운그레이드는 안 봄). */
+export async function deleteBillingKey(): Promise<DeleteBillingKeyOutcome> {
+  const res = await fetchWithAuth('/api/billing/billing-key', { method: 'DELETE', credentials: 'include' });
+  if (res.status === 409) {
+    const body = (await res.json().catch(() => null)) as { error?: { tier?: string } } | null;
+    return { kind: 'blocked', tier: body?.error?.tier ?? '' };
+  }
+  if (!res.ok) return { kind: 'error', status: res.status };
+  return { kind: 'deleted' };
+}

--- a/apps/web/src/ee/components/billing/billing-tab.tsx
+++ b/apps/web/src/ee/components/billing/billing-tab.tsx
@@ -31,6 +31,7 @@ import { PricingPlanCard } from './pricing-plan-card';
 import { PricingLimitsTable } from './pricing-limits-table';
 import { PricingPacks, type PackKind } from './pricing-packs';
 import { completeCheckout, startBillingAuth, type CheckoutOutcome } from './toss-checkout';
+import { PaymentMethodSection } from './payment-method-section';
 import {
   cancelSubscription,
   changeTier,
@@ -232,6 +233,8 @@ export function BillingTab({ orgId }: { orgId: string }) {
           <AlertDescription>{t('checkoutWidgetFailedBanner')}</AlertDescription>
         </Alert>
       )}
+
+      <PaymentMethodSection canManage={canManage} />
 
       {isPricePublic && (
         <Tabs value={cycle} onValueChange={(v) => setCycle(v as 'monthly' | 'yearly')}>

--- a/apps/web/src/ee/components/billing/payment-method-section.test.tsx
+++ b/apps/web/src/ee/components/billing/payment-method-section.test.tsx
@@ -91,12 +91,17 @@ describe('PaymentMethodSection(story #2989)', () => {
     expect(container.textContent).toContain(koMessages.pricingPlans.paymentMethodNone);
   });
 
-  it('409(active_subscription_blocks_revoke)면 tier를 포함한 차단 배너를 보여준다(P3 서버강제)', async () => {
+  it('409(active_subscription_blocks_revoke)면 tier+실 종료일을 포함한 차단 배너를 보여준다(P3 서버강제)', async () => {
+    // PO 재지적(2026-08-24, PR#3423 리뷰, 유나 관찰) — 해지는 예약형이라 "해지 후 다시
+    // 시도" 안내는 거짓. 배너가 실 종료일(current_period_end)을 찍어야 한다.
     vi.mocked(fetchWithAuth).mockImplementation(async (_url: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === 'DELETE') {
         return {
           ok: false, status: 409,
-          json: async () => ({ data: null, error: { code: 'active_subscription_blocks_revoke', message: 'x', tier: 'starter' } }),
+          json: async () => ({
+            data: null,
+            error: { code: 'active_subscription_blocks_revoke', message: 'x', tier: 'starter', current_period_end: '2026-09-24T00:00:00+00:00' },
+          }),
         } as unknown as Response;
       }
       return { ok: true, json: async () => ({ data: { org_id: 'org-1', status: 'active', card_issuer_code: '91', card_number_masked: '54258677****176*', card_type: 'CREDIT' } }) } as Response;
@@ -110,7 +115,33 @@ describe('PaymentMethodSection(story #2989)', () => {
     await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 
     expect(container.textContent).toContain('starter');
+    expect(container.textContent).toContain('2026-09-24');
+    expect(container.textContent).not.toContain('해지 후 다시 시도');
     // 카드는 여전히 남아있다(BE가 삭제 자체를 거부했으므로 목록에서 안 사라져야 함).
     expect(container.textContent).toContain('54258677****176*');
+  });
+
+  it('409 응답에 current_period_end가 없으면 날짜 없는 폴백 문구를 보여준다', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return {
+          ok: false, status: 409,
+          json: async () => ({
+            data: null,
+            error: { code: 'active_subscription_blocks_revoke', message: 'x', tier: 'team', current_period_end: null },
+          }),
+        } as unknown as Response;
+      }
+      return { ok: true, json: async () => ({ data: { org_id: 'org-1', status: 'active', card_issuer_code: '91', card_number_masked: '54258677****176*', card_type: 'CREDIT' } }) } as Response;
+    });
+
+    await mount(<PaymentMethodSection canManage={true} />);
+    const openBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.pricingPlans.paymentMethodDeleteButton));
+    await act(async () => { openBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const confirmBtn = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.trim() === koMessages.pricingPlans.paymentMethodDeleteConfirm);
+    await act(async () => { confirmBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain(koMessages.pricingPlans.paymentMethodDeleteBlocked.replace('{tier}', 'team'));
   });
 });

--- a/apps/web/src/ee/components/billing/payment-method-section.test.tsx
+++ b/apps/web/src/ee/components/billing/payment-method-section.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+//
+// story #2989 — PaymentMethodSection 실 렌더 검증. 이전엔 등록된 결제수단을 보여줄
+// 표면 자체가 없었다(그라운딩 실측) — 이 파일이 그 신규 표면의 회귀가드.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../messages/ko.json';
+import { PaymentMethodSection } from './payment-method-section';
+import { fetchWithAuth } from '@/lib/db/client';
+
+vi.mock('@/lib/db/client', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+async function mount(node: React.ReactNode) {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => { root.render(wrap(node)); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+  vi.mocked(fetchWithAuth).mockReset();
+});
+
+describe('PaymentMethodSection(story #2989)', () => {
+  it('canManage=false면 아무것도 안 그린다(등록 진입점과 동형 게이팅)', async () => {
+    await mount(<PaymentMethodSection canManage={false} />);
+    expect(fetchWithAuth).not.toHaveBeenCalled();
+    expect(container.textContent).toBe('');
+  });
+
+  it('등록된 카드가 없으면 "등록된 결제수단이 없습니다"를 보여준다(지어내지 않음)', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({ ok: true, json: async () => ({ data: null }) } as Response);
+    await mount(<PaymentMethodSection canManage={true} />);
+    expect(container.textContent).toContain(koMessages.pricingPlans.paymentMethodNone);
+  });
+
+  it('등록된 카드가 있으면 마스킹 정보+삭제 버튼을 보여준다', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { org_id: 'org-1', status: 'active', card_issuer_code: '91', card_number_masked: '54258677****176*', card_type: 'CREDIT' } }),
+    } as Response);
+    await mount(<PaymentMethodSection canManage={true} />);
+    expect(container.textContent).toContain('54258677****176*');
+    const deleteBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.pricingPlans.paymentMethodDeleteButton));
+    expect(deleteBtn).toBeTruthy();
+  });
+
+  it('삭제 확認 다이얼로그에서 삭제 클릭 → DELETE 호출 → 성공 시 완료 배너+목록 갱신', async () => {
+    // 첫 GET(마운트)만 카드 있음, DELETE 성공, 그 後 재조회 GET은 없음(재조회로 목록 갱신 확認).
+    let getCount = 0;
+    vi.mocked(fetchWithAuth).mockImplementation(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return { ok: true, json: async () => ({ data: { deleted: true } }) } as Response;
+      }
+      getCount += 1;
+      if (getCount === 1) {
+        return { ok: true, json: async () => ({ data: { org_id: 'org-1', status: 'active', card_issuer_code: '91', card_number_masked: '54258677****176*', card_type: 'CREDIT' } }) } as Response;
+      }
+      return { ok: true, json: async () => ({ data: null }) } as Response;
+    });
+
+    await mount(<PaymentMethodSection canManage={true} />);
+    const openBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.pricingPlans.paymentMethodDeleteButton));
+    await act(async () => { openBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    const confirmBtn = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.trim() === koMessages.pricingPlans.paymentMethodDeleteConfirm);
+    await act(async () => { confirmBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain(koMessages.pricingPlans.paymentMethodDeleteSuccess);
+    expect(container.textContent).toContain(koMessages.pricingPlans.paymentMethodNone);
+  });
+
+  it('409(active_subscription_blocks_revoke)면 tier를 포함한 차단 배너를 보여준다(P3 서버강제)', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return {
+          ok: false, status: 409,
+          json: async () => ({ data: null, error: { code: 'active_subscription_blocks_revoke', message: 'x', tier: 'starter' } }),
+        } as unknown as Response;
+      }
+      return { ok: true, json: async () => ({ data: { org_id: 'org-1', status: 'active', card_issuer_code: '91', card_number_masked: '54258677****176*', card_type: 'CREDIT' } }) } as Response;
+    });
+
+    await mount(<PaymentMethodSection canManage={true} />);
+    const openBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.pricingPlans.paymentMethodDeleteButton));
+    await act(async () => { openBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const confirmBtn = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.trim() === koMessages.pricingPlans.paymentMethodDeleteConfirm);
+    await act(async () => { confirmBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('starter');
+    // 카드는 여전히 남아있다(BE가 삭제 자체를 거부했으므로 목록에서 안 사라져야 함).
+    expect(container.textContent).toContain('54258677****176*');
+  });
+});

--- a/apps/web/src/ee/components/billing/payment-method-section.tsx
+++ b/apps/web/src/ee/components/billing/payment-method-section.tsx
@@ -29,7 +29,9 @@ export function PaymentMethodSection({ canManage }: { canManage: boolean }) {
   const [key, setKey] = useState<BillingKeyInfo | null | undefined>(undefined);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const [banner, setBanner] = useState<{ kind: 'success' | 'blocked' | 'error'; tier?: string } | null>(null);
+  const [banner, setBanner] = useState<
+    { kind: 'success' | 'blocked' | 'error'; tier?: string; periodEndDate?: string } | null
+  >(null);
 
   const refetch = () => {
     void fetchBillingKey().then(setKey);
@@ -57,7 +59,13 @@ export function PaymentMethodSection({ canManage }: { canManage: boolean }) {
       setBanner({ kind: 'success' });
       refetch();
     } else if (outcome.kind === 'blocked') {
-      setBanner({ kind: 'blocked', tier: outcome.tier });
+      // PO 재지적(2026-08-24, PR#3423 리뷰) — 해지가 예약형이라 "해지 후 다시 시도"는
+      // 거짓 안내. current_period_end를 YYYY-MM-DD로 잘라 실 날짜를 보여준다(라이브러리
+      // 없이 결정적 — 타임존/로케일 분기로 테스트가 흔들리지 않게).
+      setBanner({
+        kind: 'blocked', tier: outcome.tier,
+        periodEndDate: outcome.currentPeriodEnd?.slice(0, 10),
+      });
     } else {
       setBanner({ kind: 'error' });
     }
@@ -74,7 +82,11 @@ export function PaymentMethodSection({ canManage }: { canManage: boolean }) {
       )}
       {banner?.kind === 'blocked' && (
         <Alert variant="warning" className="mb-2">
-          <AlertDescription>{t('paymentMethodDeleteBlocked', { tier: banner.tier ?? '' })}</AlertDescription>
+          <AlertDescription>
+            {banner.periodEndDate
+              ? t('paymentMethodDeleteBlockedUntil', { tier: banner.tier ?? '', date: banner.periodEndDate })
+              : t('paymentMethodDeleteBlocked', { tier: banner.tier ?? '' })}
+          </AlertDescription>
         </Alert>
       )}
       {banner?.kind === 'error' && (

--- a/apps/web/src/ee/components/billing/payment-method-section.tsx
+++ b/apps/web/src/ee/components/billing/payment-method-section.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+/**
+ * story #2989 — 결제수단(빌링키) 표시+셀프서브 삭제. 이전엔 등록(POST)만 있고 「지금
+ * 뭐가 등록돼 있는지」를 보여줄 표면 자체가 FE에 없었다(그라운딩 실측, `billing-tab.tsx`
+ * 다른 섹션들과 독립된 파일로 분리 — 이 관심사만 자기완결적으로 fetch/상태를 갖는다).
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { CreditCard, Trash2, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  fetchBillingKey,
+  deleteBillingKey,
+  type BillingKeyInfo,
+} from './billing-actions';
+
+export function PaymentMethodSection({ canManage }: { canManage: boolean }) {
+  const t = useTranslations('pricingPlans');
+  const [key, setKey] = useState<BillingKeyInfo | null | undefined>(undefined);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [banner, setBanner] = useState<{ kind: 'success' | 'blocked' | 'error'; tier?: string } | null>(null);
+
+  const refetch = () => {
+    void fetchBillingKey().then(setKey);
+  };
+
+  useEffect(() => {
+    // 무권한(canManage=false)이면 조회조차 안 한다 — 신규 자체발견 회귀(테스트 작성 중):
+    // 이 가드가 없으면 아래 렌더 게이트와 무관하게 mount마다 GET이 매번 나간다(무권한
+    // 뷰어에게도 낭비 왕복 + 이 화면이 「등록됐는지 여부」를 조용히 아는 부작용).
+    if (!canManage) return;
+    refetch();
+  }, [canManage]);
+
+  // 로딩 중(undefined)이거나 무권한(canManage=false)이면 이 섹션 자체를 안 그린다 — 등록
+  // 진입점(카드 등록하고 결제 버튼)도 canManage 게이팅을 이미 상위에서 하고 있어 동형.
+  if (key === undefined || !canManage) return null;
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setBanner(null);
+    const outcome = await deleteBillingKey();
+    setDeleting(false);
+    setConfirmOpen(false);
+    if (outcome.kind === 'deleted') {
+      setBanner({ kind: 'success' });
+      refetch();
+    } else if (outcome.kind === 'blocked') {
+      setBanner({ kind: 'blocked', tier: outcome.tier });
+    } else {
+      setBanner({ kind: 'error' });
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <p className="mb-2 text-sm font-semibold text-foreground">{t('paymentMethodTitle')}</p>
+
+      {banner?.kind === 'success' && (
+        <Alert variant="success" className="mb-2">
+          <AlertDescription>{t('paymentMethodDeleteSuccess')}</AlertDescription>
+        </Alert>
+      )}
+      {banner?.kind === 'blocked' && (
+        <Alert variant="warning" className="mb-2">
+          <AlertDescription>{t('paymentMethodDeleteBlocked', { tier: banner.tier ?? '' })}</AlertDescription>
+        </Alert>
+      )}
+      {banner?.kind === 'error' && (
+        <Alert variant="destructive" className="mb-2">
+          <AlertDescription>{t('paymentMethodDeleteError')}</AlertDescription>
+        </Alert>
+      )}
+
+      {key === null ? (
+        <p className="text-sm text-muted-foreground">{t('paymentMethodNone')}</p>
+      ) : (
+        <div className="flex items-center justify-between gap-3">
+          <span className="flex items-center gap-2 text-sm text-foreground">
+            <CreditCard className="h-4 w-4 text-muted-foreground" aria-hidden />
+            {t('paymentMethodMasked', {
+              issuer: key.card_issuer_code ?? '',
+              number: key.card_number_masked ?? '',
+            })}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 text-muted-foreground hover:text-destructive"
+            onClick={() => setConfirmOpen(true)}
+          >
+            <Trash2 className="h-3.5 w-3.5" aria-hidden />
+            {t('paymentMethodDeleteButton')}
+          </Button>
+        </div>
+      )}
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('paymentMethodDeleteConfirmTitle')}</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">{t('paymentMethodDeleteConfirmBody')}</p>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setConfirmOpen(false)} disabled={deleting}>
+              {t('paymentMethodDeleteCancel')}
+            </Button>
+            <Button type="button" variant="destructive" onClick={() => void handleDelete()} disabled={deleting}>
+              {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : t('paymentMethodDeleteConfirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/backend/app/routers/admin_billing.py
+++ b/backend/app/routers/admin_billing.py
@@ -24,6 +24,7 @@ from app.services.admin_billing import (
     create_grandfather_policy,
     create_offering_version,
     grant_credit,
+    reset_billing_key,
     retry_billing_order,
 )
 
@@ -65,6 +66,24 @@ async def retry_billing(
     except AdminBillingError as e:
         raise HTTPException(status_code=e.status_code, detail={"code": e.code, "message": e.message}) from e
     return {"order_id": order.order_id, "status": order.status}
+
+
+@router.post("/orgs/{org_id}/billing/reset-billing-key")
+async def reset_billing_key_endpoint(
+    org_id: uuid.UUID,
+    operator: AdminOperator = Depends(require_admin_operator),
+    session: AsyncSession = Depends(get_db),
+) -> dict:
+    """story #2989 AC3 — 테스트/운영 개입용 결제수단 초기화. retry_billing과 동형(admin
+    인가+prod 차단+구조화 audit). 셀프서브(billing_keys.py DELETE)와 같은 레일
+    (revoke_billing_key)을 타되 활성 구독 차단을 우회한다(force=True, reset_billing_key
+    docstring 참고)."""
+    _reject_prod()
+    try:
+        result = await reset_billing_key(session, org_id=org_id, actor_email=operator.email)
+    except AdminBillingError as e:
+        raise HTTPException(status_code=e.status_code, detail={"code": e.code, "message": e.message}) from e
+    return result
 
 
 @router.post("/orgs/{org_id}/billing/credit-grant")

--- a/backend/app/routers/billing_keys.py
+++ b/backend/app/routers/billing_keys.py
@@ -133,12 +133,22 @@ async def delete_billing_key(
             session, org_id=org_id, actor_id=resolved_actor_id, actor_type="human",
         )
     except ActiveSubscriptionBlocksRevoke as exc:
+        # PO 재지적(2026-08-24, PR#3423 리뷰, 유나 관찰) — 해지는 예약형(종료일까지 tier가
+        # 여전히 active)이라 "해지 후 다시 시도"는 해지 직후에도 또 409가 나는 거짓 안내.
+        # current_period_end를 실어 FE가 실 날짜를 찍게 한다(파싱 없이 그대로 전달할 수
+        # 있게 ISO 문자열).
+        current_period_end_iso = exc.current_period_end.isoformat() if exc.current_period_end else None
         raise HTTPException(
             status_code=409,
             detail={
                 "code": "active_subscription_blocks_revoke",
-                "message": "활성 유료 구독이 있어 결제수단을 지울 수 없습니다. 구독 해지 후 다시 시도해주세요.",
+                "message": (
+                    f"구독 종료일({current_period_end_iso}) 후 삭제 가능합니다."
+                    if current_period_end_iso
+                    else "활성 유료 구독이 종료된 후 결제수단을 삭제할 수 있습니다."
+                ),
                 "tier": exc.tier,
+                "current_period_end": current_period_end_iso,
             },
         ) from exc
     return result

--- a/backend/app/routers/billing_keys.py
+++ b/backend/app/routers/billing_keys.py
@@ -12,11 +12,13 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id_no_project_gate
 from app.dependencies.database import get_db
-from app.services.org_billing_key import ensure_customer_key, issue_billing_key
+from app.models.org_billing_key import OrgBillingKey
+from app.services.org_billing_key import ActiveSubscriptionBlocksRevoke, ensure_customer_key, issue_billing_key, revoke_billing_key
 
 router = APIRouter(prefix="/api/v2/org-billing-keys", tags=["billing", "Organization"])
 
@@ -86,3 +88,57 @@ async def create_billing_key(
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     return BillingKeyResponse.model_validate(key)
+
+
+@router.get("", response_model=BillingKeyResponse | None)
+async def get_billing_key(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
+) -> BillingKeyResponse | None:
+    """story #2989(AC1 선행) — 저장된 결제수단을 화면에 보여줄 표면이 없던 갭(FE가 등록만
+    하고 «지금 뭐가 등록돼 있는지»를 조회할 GET이 아예 없었다, 그라운딩 실측). status=
+    'deleted'는 「지금은 없다」와 동형이라 None으로 응답(카드 흔적을 지어내지 않음)."""
+    from app.services.project_auth import is_org_owner_or_admin
+
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="org admin/owner role required")
+
+    key = (
+        await session.execute(select(OrgBillingKey).where(OrgBillingKey.org_id == org_id))
+    ).scalar_one_or_none()
+    if key is None or key.status == "deleted":
+        return None
+    return BillingKeyResponse.model_validate(key)
+
+
+@router.delete("", response_model=dict)
+async def delete_billing_key(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id_no_project_gate),
+) -> dict:
+    """story #2989 AC1·AC2 — 셀프서브 결제수단 삭제. Toss 실 폐기 포함(revoke_billing_key
+    참고). 활성 유료 구독이 있으면(P3 — 판별자는 «현재 유효 여부»뿐, 예약된 해지/다운
+    그레이드 여부는 안 봄, 선생님 정책 확定 2026-08-24) 서버가 명시 거부한다(force 인자를
+    이 라우터는 절대 안 노출 — 우회는 admin 전용 경로(admin_billing.py)뿐)."""
+    from app.services.project_auth import is_org_owner_or_admin
+
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="org admin/owner role required")
+
+    resolved_actor_id = uuid.UUID(auth.user_id)
+    try:
+        result = await revoke_billing_key(
+            session, org_id=org_id, actor_id=resolved_actor_id, actor_type="human",
+        )
+    except ActiveSubscriptionBlocksRevoke as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "active_subscription_blocks_revoke",
+                "message": "활성 유료 구독이 있어 결제수단을 지울 수 없습니다. 구독 해지 후 다시 시도해주세요.",
+                "tier": exc.tier,
+            },
+        ) from exc
+    return result

--- a/backend/app/services/admin_billing.py
+++ b/backend/app/services/admin_billing.py
@@ -113,6 +113,30 @@ async def retry_billing_order(
     return refreshed
 
 
+async def reset_billing_key(session: AsyncSession, *, org_id: uuid.UUID, actor_email: str) -> dict:
+    """story #2989 AC3 — admin 개입용 결제수단 초기화(테스트/운영 개입, 예: 심사·테스트
+    계정 재등록). `revoke_billing_key(force=True)`로 셀프서브와 동일한 단일 레일을 타되
+    (Toss 실 폐기 먼저·DB는 그 다음 — 신규 규칙 발명 0), 활성 유료 구독 차단을 우회한다
+    (이 경로 자체가 "정상 사용자 플로우 밖의 명시적 개입"이라는 뜻이므로 그 가드가
+    여기선 장애물일 뿐 — retry_billing_order와 동형으로 이 라우터의 admin 인가
+    (require_admin_operator)가 이미 그 신뢰를 감당)."""
+    from app.services.org_billing_key import ActiveSubscriptionBlocksRevoke, revoke_billing_key
+
+    try:
+        result = await revoke_billing_key(session, org_id=org_id, actor_id=None, actor_type="agent", force=True)
+    except ActiveSubscriptionBlocksRevoke:
+        # force=True라 이 분기는 원리적으로 안 탄다 — 방어적 재-raise(향후 force 인자
+        # 제거/리팩터가 이 불변식을 실수로 깨도 조용히 안 통과하게).
+        raise AdminBillingError(409, "ACTIVE_SUBSCRIPTION_BLOCKS_REVOKE", "예상치 못한 차단(force=True인데 발생)")
+
+    _audit(
+        actor_email=actor_email, org_id=org_id, action="billing_key_reset",
+        before={"had_billing_key": result.get("deleted", False)},
+        after=result,
+    )
+    return result
+
+
 async def _derive_grant_amount_minor(session: AsyncSession, *, target_tier: GrantTier, currency: str, months: int) -> int:
     """checkout과 동일 가격 원천(offering_versions)에서 파생 — 어드민 손입력 금지(PO
     지적③: 지어낸 수를 장부에 남기지 않는다). 원천 없으면 조용한 0/추정 대신 fail loud."""

--- a/backend/app/services/org_billing_key.py
+++ b/backend/app/services/org_billing_key.py
@@ -5,6 +5,7 @@ ON CONFLICT DO UPDATE를 쓴다 — org_billing_keys는 append-only가 아니다
 """
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import datetime, timezone
 
@@ -15,6 +16,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.org_billing_key import OrgBillingKey
 from app.services.billing_key_crypto import decrypt_billing_key, encrypt_billing_key, ensure_configured
 from app.services.payment.toss_adapter import TossAdapter
+
+logger = logging.getLogger("sprintable.billing_key")
 
 
 class ActiveSubscriptionBlocksRevoke(Exception):
@@ -77,8 +80,9 @@ async def issue_billing_key(
     """FE 위젯 인증 완료 후 authKey로 실 빌링키를 발급받아 저장한다.
 
     기존 행이 있으면(재발급 = 카드 교체) 그 customer_key를 재사용 — Toss 쪽 고객 식별을
-    유지한다. 새 billingKey로 UPDATE(이전 빌링키의 Toss측 폐기는 story C4 대상, 여기서는
-    저장 갱신만).
+    유지한다. 새 billingKey로 UPDATE — story #2989(PO 동승 권고, PR#3423 리뷰) 이전엔
+    이전 빌링키의 Toss측 폐기가 C4 유예 항목이었으나, 이제 delete_billing_key가 생겨
+    같은 함수 안에서 닫는다(신 키 저장 성공 → 구 키 Toss 폐기, 순서 고정 — 아래 참고).
 
     카디르 결함사냥 fix(#2892 리뷰, 2026-08-07) — 크로스-커넥션 레이스: 예전엔 이 함수가
     raw SELECT로 스스로 customer_key를 결정했다. ensure_customer_key()의 원자적 INSERT..
@@ -93,6 +97,16 @@ async def issue_billing_key(
     ensure_configured()
 
     customer_key = await ensure_customer_key(session, org_id=org_id)
+
+    # story #2989(PO 동승 권고, PR#3423 리뷰) — 재발급이 아래 ON CONFLICT DO UPDATE로 구
+    # 행을 덮어쓰기 前에 구 encrypted_billing_key를 미리 읽어둔다(덮어쓴 뒤엔 사라짐).
+    # placeholder(awaiting_auth, encrypted_billing_key=None)면 폐기할 실 키가 없어 자연히
+    # None — revoke_billing_key의 placeholder-skip과 동형 판단.
+    old_encrypted_billing_key = (
+        await session.execute(
+            select(OrgBillingKey.encrypted_billing_key).where(OrgBillingKey.org_id == org_id)
+        )
+    ).scalar_one_or_none()
 
     result = await TossAdapter().create_billing_key(auth_key=auth_key, customer_key=customer_key)
 
@@ -130,6 +144,19 @@ async def issue_billing_key(
     )
     await session.execute(stmt)
     await session.commit()
+
+    if old_encrypted_billing_key:
+        # 신 키 저장은 이미 커밋됐다(PO 지시 순서: 성공 후 구 키 폐기, 폐기가 실패해도
+        # 신 키 저장은 유지 — 롤백하지 않는다). Toss 실패는 org_id를 남겨 수동 정리가
+        # 가능하게만 로깅한다.
+        try:
+            old_plaintext = decrypt_billing_key(old_encrypted_billing_key)
+            await TossAdapter().delete_billing_key(billing_key=old_plaintext)
+        except Exception:
+            logger.warning(
+                "재발급 후 구 빌링키 Toss 폐기 실패(org_id=%s) — 신 키 저장은 유지, 수동 정리 필요",
+                org_id, exc_info=True,
+            )
 
     return (
         await session.execute(select(OrgBillingKey).where(OrgBillingKey.org_id == org_id))

--- a/backend/app/services/org_billing_key.py
+++ b/backend/app/services/org_billing_key.py
@@ -25,15 +25,26 @@ class ActiveSubscriptionBlocksRevoke(Exception):
     수단을 지우면 다음 청구가 "no active billing key"로 조용히 실패한다(billing_charge.py
     charge_org의 기존 active-필터 가드 재사용, 신규 분기 불요 — mark_billing_key_deleted
     docstring과 동형 근거). 차단이 기본값: 구독 해지가 먼저(org_subscription_checkout.py의
-    change-tier/cancel 레일), 결제수단 삭제는 그 다음이라는 순서를 서버가 강제한다."""
+    change-tier/cancel 레일), 결제수단 삭제는 그 다음이라는 순서를 서버가 강제한다.
 
-    def __init__(self, *, org_id: uuid.UUID, tier: str, billing_cycle: str | None):
+    PO 재지적(2026-08-24, PR#3423 리뷰, 유나 관찰) — 해지는 예약형(다음 갱신까지 tier가
+    여전히 active로 남는다, org_subscription_checkout.py의 cancel 레일)이라 "해지 후 다시
+    시도"는 해지 직후에도 또 409가 나는 거짓 안내다. 판별자(P3 원문)는 "현재 유효한 기간이
+    지났는가"뿐 — 그 실 시점(current_period_end)을 예외가 실어 라우터/FE가 정확한 날짜를
+    보여주게 한다."""
+
+    def __init__(
+        self, *, org_id: uuid.UUID, tier: str, billing_cycle: str | None,
+        current_period_end: datetime | None,
+    ):
         self.org_id = org_id
         self.tier = tier
         self.billing_cycle = billing_cycle
+        self.current_period_end = current_period_end
         super().__init__(
             f"org_id={org_id}는 활성 유료 구독(tier={tier!r})이 있어 결제수단을 지울 수 "
-            "없습니다 — 구독 해지/변경을 먼저 진행하세요."
+            f"없습니다 — 구독 종료일({current_period_end.isoformat() if current_period_end else '미정'}) "
+            "이후 삭제할 수 있습니다."
         )
 
 
@@ -196,7 +207,10 @@ async def revoke_billing_key(
             await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
         ).scalar_one_or_none()
         if sub is not None and sub.status == "active" and sub.tier in PAID_TIERS:
-            raise ActiveSubscriptionBlocksRevoke(org_id=org_id, tier=sub.tier, billing_cycle=sub.billing_cycle)
+            raise ActiveSubscriptionBlocksRevoke(
+                org_id=org_id, tier=sub.tier, billing_cycle=sub.billing_cycle,
+                current_period_end=sub.current_period_end,
+            )
 
     masked_card = key.card_number_masked
     toss_revoked = False

--- a/backend/app/services/org_billing_key.py
+++ b/backend/app/services/org_billing_key.py
@@ -13,8 +13,25 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.org_billing_key import OrgBillingKey
-from app.services.billing_key_crypto import encrypt_billing_key, ensure_configured
+from app.services.billing_key_crypto import decrypt_billing_key, encrypt_billing_key, ensure_configured
 from app.services.payment.toss_adapter import TossAdapter
+
+
+class ActiveSubscriptionBlocksRevoke(Exception):
+    """story #2989 AC2(PO 확定 2026-08-24, block 정책) — 활성 유료 구독이 있는 채로 결제
+    수단을 지우면 다음 청구가 "no active billing key"로 조용히 실패한다(billing_charge.py
+    charge_org의 기존 active-필터 가드 재사용, 신규 분기 불요 — mark_billing_key_deleted
+    docstring과 동형 근거). 차단이 기본값: 구독 해지가 먼저(org_subscription_checkout.py의
+    change-tier/cancel 레일), 결제수단 삭제는 그 다음이라는 순서를 서버가 강제한다."""
+
+    def __init__(self, *, org_id: uuid.UUID, tier: str, billing_cycle: str | None):
+        self.org_id = org_id
+        self.tier = tier
+        self.billing_cycle = billing_cycle
+        super().__init__(
+            f"org_id={org_id}는 활성 유료 구독(tier={tier!r})이 있어 결제수단을 지울 수 "
+            "없습니다 — 구독 해지/변경을 먼저 진행하세요."
+        )
 
 
 def generate_customer_key(org_id: uuid.UUID) -> str:
@@ -117,6 +134,81 @@ async def issue_billing_key(
     return (
         await session.execute(select(OrgBillingKey).where(OrgBillingKey.org_id == org_id))
     ).scalar_one()
+
+
+async def revoke_billing_key(
+    session: AsyncSession, *, org_id: uuid.UUID, actor_id: uuid.UUID | None, actor_type: str,
+    force: bool = False,
+) -> dict:
+    """story #2989(AC1·AC3) — 사용자 셀프서브 삭제 + admin 초기화가 공유하는 단일 레일
+    (신규 규칙 발명 0, [[feedback_behavior_declared_one_place]] 동형 — 어디서 부르든
+    같은 불변식). 순서 고정: ①활성 유료 구독 차단(force가 아니면) ②**Toss 실 폐기가
+    먼저**(성공해야 DB를 건드림 — 반대 순서면 Toss엔 남고 DB만 지워진 유령 상태) ③DB
+    행을 status='deleted'로 마킹(mark_billing_key_deleted와 동형 — customer_key는
+    유지해 재등록 시 ensure_customer_key()가 그대로 재사용, 신규 customer_key 발급 불요)
+    ④ActivityLog에 감사 기록(actor·masked card·revoke 시각 — admin 초기화의 AC3 요건이나
+    셀프서브도 동일하게 남겨 감사 표면 일관).
+
+    `force=True`(admin 전용 경로가 넘김) — 활성 구독 차단을 우회한다(테스트/운영 개입,
+    story #2989 AC3 "admin 개입용 초기화"가 명시한 그 예외 — 셀프서브 라우터는 이 인자를
+    노출하지 않는다).
+
+    반환: 삭제 여부(deleted)·이미 카드가 없던 경우(no-op)·마스킹 카드 정보 — 호출자
+    (라우터·admin 스크립트)가 "무엇을 지웠는지"를 사람이 읽을 형태로 보고할 수 있게."""
+    from app.models.org_subscription import OrgSubscription
+    from app.services.org_subscription_checkout import PAID_TIERS
+
+    key = (
+        await session.execute(select(OrgBillingKey).where(OrgBillingKey.org_id == org_id))
+    ).scalar_one_or_none()
+    if key is None or key.status == "deleted":
+        return {"deleted": False, "reason": "no_active_billing_key"}
+
+    if not force:
+        sub = (
+            await session.execute(select(OrgSubscription).where(OrgSubscription.org_id == org_id))
+        ).scalar_one_or_none()
+        if sub is not None and sub.status == "active" and sub.tier in PAID_TIERS:
+            raise ActiveSubscriptionBlocksRevoke(org_id=org_id, tier=sub.tier, billing_cycle=sub.billing_cycle)
+
+    masked_card = key.card_number_masked
+    toss_revoked = False
+    if key.encrypted_billing_key:
+        plaintext = decrypt_billing_key(key.encrypted_billing_key)
+        # ⛔平문은 이 스코프를 벗어나지 않는다(issue_billing_key의 동형 guard 재사용) —
+        # Toss 호출 인자로만 쓰고 로깅·반환값에 절대 안 실음.
+        await TossAdapter().delete_billing_key(billing_key=plaintext)
+        toss_revoked = True
+    # placeholder(status='awaiting_auth', encrypted_billing_key=None)는 Toss에 애초에
+    # 발급된 적이 없어 폐기할 대상이 없다 — DB 정리만으로 충분(no-fiction: 안 한 걸 했다고
+    # 안 함).
+
+    key.status = "deleted"
+    key.encrypted_billing_key = None
+    key.card_issuer_code = None
+    key.card_acquirer_code = None
+    key.card_number_masked = None
+    key.card_type = None
+    key.card_owner_type = None
+
+    from app.services.activity_log import ActivityLogService
+
+    await ActivityLogService(session).record(
+        org_id=org_id,
+        action="billing_key_revoked",
+        actor_id=actor_id,
+        actor_type=actor_type,
+        entity_type="org_billing_key",
+        entity_id=key.id,
+        context={
+            "toss_revoked": toss_revoked,
+            "card_number_masked": masked_card,
+            "force": force,
+        },
+    )
+    await session.commit()
+
+    return {"deleted": True, "toss_revoked": toss_revoked, "card_number_masked": masked_card}
 
 
 async def mark_billing_key_deleted(session: AsyncSession, *, customer_key: str) -> None:

--- a/backend/app/services/payment/toss_adapter.py
+++ b/backend/app/services/payment/toss_adapter.py
@@ -113,6 +113,35 @@ class TossAdapter(PaymentProvider):
 
         return resp.json()
 
+    async def _delete(self, path: str, *, timeout: float, op_label: str) -> None:
+        """공용 DELETE 왕복(story #2989) — 빌링키 삭제 전용. 공식 문서 직접 대조
+        (2026-08-24, 훈련데이터 안 믿음 원칙 — 이 파일 상단 주석과 동형): `DELETE
+        /v1/billing/{billingKey}`는 성공 시 200+빈 바디를 낸다(_post/_get과 달리
+        resp.json()을 성공 경로에서 아예 호출하지 않는다 — 빈 바디에 json()을 부르면
+        JSONDecodeError)."""
+        headers = self._auth_header()
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.delete(f"{_API_BASE}{path}", headers=headers)
+        except httpx.RequestError as exc:
+            logger.exception("Toss %s request failed", op_label)
+            raise RuntimeError("Cannot reach Toss API") from exc
+
+        if resp.status_code != 200:
+            body = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
+            code = body.get("code", str(resp.status_code))
+            logger.error("Toss %s error: status=%s code=%s", op_label, resp.status_code, code)
+            raise TossApiError(code, f"Toss {op_label} failed", status_code=resp.status_code)
+
+    async def delete_billing_key(self, *, billing_key: str) -> None:
+        """DELETE /v1/billing/{billingKey}(story #2989) — 빌링키를 Toss 측에서 실 폐기.
+        DB 행 정리만으로는 반쪽(카드가 PG 쪽에 계속 살아있어 재청구/재조회가 가능한 채로
+        남음, 페드루 PO 실측 지적 2026-08-24) — 호출자는 이 호출이 성공한 *後에* DB
+        상태를 정리해야 한다(반대 순서면 DB엔 없는데 Toss엔 남는 유령 빌링키가 생긴다)."""
+        await self._delete(
+            f"/v1/billing/{billing_key}", timeout=15, op_label="billing key deletion",
+        )
+
     async def create_billing_key(self, *, auth_key: str, customer_key: str) -> dict:
         """POST /v1/billing/authorizations/issue — FE 위젯이 넘긴 authKey + customerKey로
         재사용 가능한 billingKey를 발급받는다. 응답 그대로 반환(billingKey 평문 포함 —

--- a/backend/tests/test_2474_admin_billing_router_surface.py
+++ b/backend/tests/test_2474_admin_billing_router_surface.py
@@ -19,6 +19,10 @@ def test_admin_billing_router_surface_is_pinned():
         ("/api/v2/admin/offering-versions", "GET"),
         ("/api/v2/admin/offering-versions", "POST"),
         ("/api/v2/admin/orgs/{org_id}/billing/credit-grant", "POST"),
+        # story #2989 — admin 결제수단 초기화(테스트/운영 개입). GET/POST만(mutation은
+        # POST로 명시 액션화 — PATCH/PUT류로 슬쩍 상태를 바꾸지 않는다는 이 파일의 원 취지와
+        # 정합).
+        ("/api/v2/admin/orgs/{org_id}/billing/reset-billing-key", "POST"),
         ("/api/v2/admin/orgs/{org_id}/billing/retry", "POST"),
     ], (
         "admin_billing 라우터 표면이 바뀌었다 — offering_version/grandfather_policy는 "

--- a/backend/tests/test_2989_billing_key_endpoints.py
+++ b/backend/tests/test_2989_billing_key_endpoints.py
@@ -1,0 +1,140 @@
+"""story #2989(AC1·AC2·AC3) — 라우터 층 단위 테스트(mock_session, DB 불요). 서비스 레일
+(revoke_billing_key)의 실제 동작은 test_2989_billing_key_revoke_realdb.py가 실PG로 검증;
+여기서는 그 서비스가 던지는 예외가 라우터에서 올바른 HTTP 응답으로 매핑되는지만 본다
+(create_billing_key_endpoint 계보의 기존 테스트 관례 그대로 — service는 monkeypatch)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ─── GET /api/v2/org-billing-keys ───────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_billing_key_endpoint_returns_none_when_no_active_card(
+    test_client, mock_session, monkeypatch, org_id
+):
+    import app.services.project_auth as project_auth
+
+    monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=True))
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/org-billing-keys")
+    assert resp.status_code == 200
+    assert resp.json() is None
+
+
+@pytest.mark.anyio
+async def test_get_billing_key_endpoint_returns_card_when_active(
+    test_client, mock_session, monkeypatch, org_id
+):
+    import app.services.project_auth as project_auth
+
+    monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=True))
+    fake_key = MagicMock()
+    fake_key.org_id = org_id
+    fake_key.status = "active"
+    fake_key.card_issuer_code = "61"
+    fake_key.card_number_masked = "1234********5678"
+    fake_key.card_type = "신용"
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = fake_key
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/org-billing-keys")
+    assert resp.status_code == 200
+    assert resp.json()["card_number_masked"] == "1234********5678"
+
+
+# ─── DELETE /api/v2/org-billing-keys ────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_delete_billing_key_endpoint_success(test_client, mock_session, monkeypatch, org_id):
+    import app.routers.billing_keys as router_module
+    import app.services.project_auth as project_auth
+
+    monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        router_module, "revoke_billing_key",
+        AsyncMock(return_value={"deleted": True, "toss_revoked": True, "card_number_masked": "1234********5678"}),
+    )
+
+    resp = await test_client.delete("/api/v2/org-billing-keys")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+
+
+@pytest.mark.anyio
+async def test_delete_billing_key_endpoint_409_when_active_subscription_blocks(
+    test_client, mock_session, monkeypatch, org_id
+):
+    """P3 — revoke_billing_key가 ActiveSubscriptionBlocksRevoke를 던지면 라우터가 409로
+    매핑하고 FE가 분기할 code+tier를 싣는다(gate_head_changed 계보 관례 재사용)."""
+    import app.routers.billing_keys as router_module
+    import app.services.project_auth as project_auth
+    from app.services.org_billing_key import ActiveSubscriptionBlocksRevoke
+
+    monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        router_module, "revoke_billing_key",
+        AsyncMock(side_effect=ActiveSubscriptionBlocksRevoke(org_id=org_id, tier="starter", billing_cycle="monthly")),
+    )
+
+    resp = await test_client.delete("/api/v2/org-billing-keys")
+    assert resp.status_code == 409
+    body = resp.json()["error"]
+    assert body["code"] == "active_subscription_blocks_revoke"
+    assert body["tier"] == "starter"
+
+
+@pytest.mark.anyio
+async def test_delete_billing_key_endpoint_403_for_non_admin(test_client, mock_session, monkeypatch):
+    import app.services.project_auth as project_auth
+
+    monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=False))
+
+    resp = await test_client.delete("/api/v2/org-billing-keys")
+    assert resp.status_code == 403
+
+
+# ─── POST /api/v2/admin/orgs/{org_id}/billing/reset-billing-key ────────────
+
+@pytest.mark.anyio
+async def test_admin_reset_billing_key_endpoint_success(test_client, mock_session, monkeypatch, org_id):
+    import app.routers.admin_billing as router_module
+    from app.dependencies.admin_auth import AdminOperator, require_admin_operator
+    from app.main import app
+
+    monkeypatch.setattr(
+        router_module, "reset_billing_key",
+        AsyncMock(return_value={"deleted": True, "toss_revoked": True, "card_number_masked": "1234********5678"}),
+    )
+    app.dependency_overrides[require_admin_operator] = lambda: AdminOperator(email="operator@moonklabs.com", subject="sub-123")
+    try:
+        resp = await test_client.post(f"/api/v2/admin/orgs/{org_id}/billing/reset-billing-key")
+    finally:
+        app.dependency_overrides.pop(require_admin_operator, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+
+
+@pytest.mark.anyio
+async def test_admin_reset_billing_key_endpoint_rejects_in_prod(test_client, mock_session, org_id):
+    from app.core.config import settings
+    from app.dependencies.admin_auth import AdminOperator, require_admin_operator
+    from app.main import app
+
+    orig = settings.deploy_env
+    settings.deploy_env = "prod"
+    app.dependency_overrides[require_admin_operator] = lambda: AdminOperator(email="operator@moonklabs.com", subject="sub-123")
+    try:
+        resp = await test_client.post(f"/api/v2/admin/orgs/{org_id}/billing/reset-billing-key")
+        assert resp.status_code == 403
+    finally:
+        settings.deploy_env = orig
+        app.dependency_overrides.pop(require_admin_operator, None)

--- a/backend/tests/test_2989_billing_key_endpoints.py
+++ b/backend/tests/test_2989_billing_key_endpoints.py
@@ -73,15 +73,21 @@ async def test_delete_billing_key_endpoint_409_when_active_subscription_blocks(
     test_client, mock_session, monkeypatch, org_id
 ):
     """P3 — revoke_billing_key가 ActiveSubscriptionBlocksRevoke를 던지면 라우터가 409로
-    매핑하고 FE가 분기할 code+tier를 싣는다(gate_head_changed 계보 관례 재사용)."""
+    매핑하고 FE가 분기할 code+tier+current_period_end를 싣는다(gate_head_changed 계보
+    관례 재사용). PO 재지적(2026-08-24, PR#3423 리뷰) — "해지 후 다시 시도"는 해지가
+    예약형이라 거짓 안내다, 대신 실 종료일을 실어야 한다."""
     import app.routers.billing_keys as router_module
     import app.services.project_auth as project_auth
+    from datetime import datetime, timezone
     from app.services.org_billing_key import ActiveSubscriptionBlocksRevoke
 
     monkeypatch.setattr(project_auth, "is_org_owner_or_admin", AsyncMock(return_value=True))
+    period_end = datetime(2026, 9, 24, tzinfo=timezone.utc)
     monkeypatch.setattr(
         router_module, "revoke_billing_key",
-        AsyncMock(side_effect=ActiveSubscriptionBlocksRevoke(org_id=org_id, tier="starter", billing_cycle="monthly")),
+        AsyncMock(side_effect=ActiveSubscriptionBlocksRevoke(
+            org_id=org_id, tier="starter", billing_cycle="monthly", current_period_end=period_end,
+        )),
     )
 
     resp = await test_client.delete("/api/v2/org-billing-keys")
@@ -89,6 +95,8 @@ async def test_delete_billing_key_endpoint_409_when_active_subscription_blocks(
     body = resp.json()["error"]
     assert body["code"] == "active_subscription_blocks_revoke"
     assert body["tier"] == "starter"
+    assert body["current_period_end"] == period_end.isoformat()
+    assert "해지 후 다시 시도" not in body["message"]
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_2989_billing_key_revoke_realdb.py
+++ b/backend/tests/test_2989_billing_key_revoke_realdb.py
@@ -1,0 +1,334 @@
+"""story #2989(AC1·AC2·AC3) realdb 검증 — 결제수단(빌링키) 셀프서브 삭제 + admin 초기화가
+공유하는 단일 레일 `revoke_billing_key()`. 핵심 검증축: ①활성 유료 구독이면 차단(P3,
+force 아닐 때) ②force=True(admin)면 그 차단을 우회 ③Toss 실 폐기 호출 확認(전면 mock —
+실 Toss 왕복은 이 스위트 스코프 밖) ④DB 행이 status='deleted'+카드정보 전부 NULL로
+정리되지만 customer_key는 보존(재등록 시 재사용) ⑤이미 삭제됐거나 카드가 아예 없으면
+no-op(idempotent) ⑥placeholder(awaiting_auth, encrypted_billing_key=None)는 Toss 호출 없이
+DB 정리만 ⑦ActivityLog에 billing_key_revoked 기록. 로컬 PG 미설정 시 skip(CI 관례 동일)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_billing_key_crypto(monkeypatch):
+    """revoke_billing_key가 실제로 decrypt_billing_key()를 거친다 — 다른 realdb 스위트처럼
+    가짜 문자열("enc-token")을 넣으면 Fernet 파싱에서 터진다. 실 키를 구성해 seed에도
+    encrypt_billing_key()로 진짜 토큰을 만든다([[feedback_no_secret_shaped_literals]]와
+    별개 축 — 이건 Fernet 대칭키지 Toss/Stripe 형태의 secret 리터럴이 아니다)."""
+    import importlib
+    from cryptography.fernet import Fernet
+    import app.core.config as config_module
+
+    key = Fernet.generate_key().decode()
+    monkeypatch.setattr(config_module.settings, "org_billing_key_encryption_key", key)
+    import app.services.billing_key_crypto as crypto_module
+    importlib.reload(crypto_module)
+    import app.services.org_billing_key as org_billing_key_module
+    monkeypatch.setattr(org_billing_key_module, "encrypt_billing_key", crypto_module.encrypt_billing_key)
+    monkeypatch.setattr(org_billing_key_module, "decrypt_billing_key", crypto_module.decrypt_billing_key)
+    return crypto_module
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, tier: str | None = None, sub_status: str = "active"):
+    from app.models.organization import Organization
+    from app.models.org_subscription import OrgSubscription
+
+    org = Organization(id=uuid.uuid4(), name="Org2989", slug=f"org2989-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.flush()
+    if tier is not None:
+        session.add(OrgSubscription(id=uuid.uuid4(), org_id=org.id, tier=tier, status=sub_status))
+        await session.flush()
+    await session.commit()
+    return org.id
+
+
+async def _seed_billing_key(
+    session, *, org_id, status: str = "active", plaintext: str | None = "billing_plaintext_token",
+    customer_key: str | None = None,
+):
+    from app.models.org_billing_key import OrgBillingKey
+    from app.services.billing_key_crypto import encrypt_billing_key
+
+    key = OrgBillingKey(
+        id=uuid.uuid4(), org_id=org_id, customer_key=customer_key or f"cust-{uuid.uuid4().hex[:10]}",
+        encrypted_billing_key=encrypt_billing_key(plaintext) if plaintext else None,
+        card_issuer_code="61" if plaintext else None,
+        card_number_masked="1234********5678" if plaintext else None,
+        card_type="신용" if plaintext else None,
+        card_owner_type="개인" if plaintext else None,
+        status=status,
+        issued_at=datetime(2026, 1, 1, tzinfo=timezone.utc) if plaintext else None,
+    )
+    session.add(key)
+    await session.commit()
+    return key.id, key.customer_key
+
+
+@pytest.mark.asyncio
+async def test_revoke_billing_key_blocks_when_active_paid_subscription():
+    """P3 — 활성 유료 구독이 있으면(force 아닐 때) 결제수단 삭제를 서버가 명시 거부한다."""
+    from app.services.org_billing_key import ActiveSubscriptionBlocksRevoke, revoke_billing_key
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="starter", sub_status="active")
+            await _seed_billing_key(s, org_id=org_id)
+
+        async with maker() as s:
+            with pytest.raises(ActiveSubscriptionBlocksRevoke) as exc_info:
+                await revoke_billing_key(s, org_id=org_id, actor_id=uuid.uuid4(), actor_type="human")
+            assert exc_info.value.tier == "starter"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_revoke_billing_key_allows_when_no_paid_subscription():
+    """free tier(또는 구독 자체 없음)면 차단되지 않는다 — P1/P2 하한은 이 함수 스코프
+    밖(라우터/FE가 이미 카드 1건뿐인 UI라 자연히 만족, org_billing_keys가 org당 1행)."""
+    from app.services.org_billing_key import revoke_billing_key
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free", sub_status="active")
+            await _seed_billing_key(s, org_id=org_id)
+
+        with patch("app.services.org_billing_key.TossAdapter.delete_billing_key", new=AsyncMock()) as mock_delete:
+            async with maker() as s:
+                result = await revoke_billing_key(s, org_id=org_id, actor_id=uuid.uuid4(), actor_type="human")
+
+        assert result["deleted"] is True
+        assert result["toss_revoked"] is True
+        mock_delete.assert_awaited_once()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_revoke_billing_key_force_bypasses_active_subscription_block():
+    """AC3 — admin 경로(force=True)는 활성 유료 구독이 있어도 차단을 우회한다."""
+    from app.services.org_billing_key import revoke_billing_key
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="team", sub_status="active")
+            await _seed_billing_key(s, org_id=org_id)
+
+        with patch("app.services.org_billing_key.TossAdapter.delete_billing_key", new=AsyncMock()):
+            async with maker() as s:
+                result = await revoke_billing_key(s, org_id=org_id, actor_id=None, actor_type="agent", force=True)
+
+        assert result["deleted"] is True
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_revoke_billing_key_calls_toss_delete_before_db_mutation_and_clears_card_fields():
+    """순서 고정 — Toss 실 폐기가 먼저(성공해야 DB를 건드림). 성공 후 DB 행은 status=
+    'deleted'+카드정보 전부 NULL이지만 customer_key는 보존(재등록 시 재사용)."""
+    from app.services.org_billing_key import revoke_billing_key
+    from app.models.org_billing_key import OrgBillingKey
+    from sqlalchemy import select
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+            key_id, customer_key = await _seed_billing_key(s, org_id=org_id)
+
+        with patch("app.services.org_billing_key.TossAdapter.delete_billing_key", new=AsyncMock()) as mock_delete:
+            async with maker() as s:
+                result = await revoke_billing_key(s, org_id=org_id, actor_id=uuid.uuid4(), actor_type="human")
+
+        # billing_key_crypto로 복호화된 평문이 Toss 호출 인자로 정확히 실렸는지(암호화
+        # 토큰 그대로가 아니라 seed에 쓴 원문과 동일해야 한다).
+        mock_delete.assert_awaited_once_with(billing_key="billing_plaintext_token")
+        assert result["card_number_masked"] == "1234********5678"
+
+        async with maker() as s:
+            row = (await s.execute(select(OrgBillingKey).where(OrgBillingKey.id == key_id))).scalar_one()
+            assert row.status == "deleted"
+            assert row.encrypted_billing_key is None
+            assert row.card_issuer_code is None
+            assert row.card_number_masked is None
+            assert row.card_type is None
+            assert row.card_owner_type is None
+            assert row.customer_key == customer_key  # 보존 — 재등록 시 ensure_customer_key 재사용
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_revoke_billing_key_placeholder_skips_toss_call():
+    """awaiting_auth placeholder(encrypted_billing_key=None)는 Toss에 애초에 발급된 적이
+    없어 폐기 대상이 없다 — Toss 호출 없이 DB 정리만(no-fiction)."""
+    from app.services.org_billing_key import revoke_billing_key
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+            await _seed_billing_key(s, org_id=org_id, status="awaiting_auth", plaintext=None)
+
+        with patch("app.services.org_billing_key.TossAdapter.delete_billing_key", new=AsyncMock()) as mock_delete:
+            async with maker() as s:
+                result = await revoke_billing_key(s, org_id=org_id, actor_id=uuid.uuid4(), actor_type="human")
+
+        mock_delete.assert_not_awaited()
+        assert result["deleted"] is True
+        assert result["toss_revoked"] is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_revoke_billing_key_noop_when_already_deleted():
+    """멱등 — 이미 status='deleted'면 재호출해도 no-op(reason=no_active_billing_key)."""
+    from app.services.org_billing_key import revoke_billing_key
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+            await _seed_billing_key(s, org_id=org_id, status="deleted", plaintext=None)
+
+        with patch("app.services.org_billing_key.TossAdapter.delete_billing_key", new=AsyncMock()) as mock_delete:
+            async with maker() as s:
+                result = await revoke_billing_key(s, org_id=org_id, actor_id=uuid.uuid4(), actor_type="human")
+
+        mock_delete.assert_not_awaited()
+        assert result == {"deleted": False, "reason": "no_active_billing_key"}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_revoke_billing_key_noop_when_no_row_at_all():
+    from app.services.org_billing_key import revoke_billing_key
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+            # org_billing_keys 행 자체를 세팅하지 않음.
+
+        async with maker() as s:
+            result = await revoke_billing_key(s, org_id=org_id, actor_id=uuid.uuid4(), actor_type="human")
+        assert result == {"deleted": False, "reason": "no_active_billing_key"}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_revoke_billing_key_records_activity_log():
+    """AC3 요건(admin 초기화 감사) — 셀프서브도 동일하게 남긴다(감사 표면 일관)."""
+    from app.services.org_billing_key import revoke_billing_key
+    from app.models.activity_log import ActivityLog
+    from sqlalchemy import select
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+            await _seed_billing_key(s, org_id=org_id)
+        actor_id = uuid.uuid4()
+
+        with patch("app.services.org_billing_key.TossAdapter.delete_billing_key", new=AsyncMock()):
+            async with maker() as s:
+                await revoke_billing_key(s, org_id=org_id, actor_id=actor_id, actor_type="human")
+
+        async with maker() as s:
+            log = (await s.execute(
+                select(ActivityLog).where(
+                    ActivityLog.org_id == org_id, ActivityLog.action == "billing_key_revoked",
+                )
+            )).scalar_one()
+            assert log.actor_id == actor_id
+            assert log.actor_type == "human"
+            assert log.context["toss_revoked"] is True
+            assert log.context["card_number_masked"] == "1234********5678"
+            assert log.context["force"] is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_reset_billing_key_admin_wrapper_bypasses_block_and_audits():
+    """admin_billing.reset_billing_key — revoke_billing_key(force=True)를 타는지 +
+    _audit() 구조화 로깅이 도는지(예외 없이 완주하면 성공, 로그 포맷 자체는 다른 admin_billing
+    액션들과 동형이라 별도 캡처 불요)."""
+    from app.services.admin_billing import reset_billing_key
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="business", sub_status="active")
+            await _seed_billing_key(s, org_id=org_id)
+
+        with patch("app.services.org_billing_key.TossAdapter.delete_billing_key", new=AsyncMock()):
+            async with maker() as s:
+                result = await reset_billing_key(s, org_id=org_id, actor_email="operator@moonklabs.com")
+
+        assert result["deleted"] is True
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_reset_billing_key_admin_wrapper_noop_when_no_billing_key():
+    from app.services.admin_billing import reset_billing_key
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+
+        async with maker() as s:
+            result = await reset_billing_key(s, org_id=org_id, actor_email="operator@moonklabs.com")
+        assert result == {"deleted": False, "reason": "no_active_billing_key"}
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2989_billing_key_revoke_realdb.py
+++ b/backend/tests/test_2989_billing_key_revoke_realdb.py
@@ -4,7 +4,9 @@ force 아닐 때) ②force=True(admin)면 그 차단을 우회 ③Toss 실 폐�
 실 Toss 왕복은 이 스위트 스코프 밖) ④DB 행이 status='deleted'+카드정보 전부 NULL로
 정리되지만 customer_key는 보존(재등록 시 재사용) ⑤이미 삭제됐거나 카드가 아예 없으면
 no-op(idempotent) ⑥placeholder(awaiting_auth, encrypted_billing_key=None)는 Toss 호출 없이
-DB 정리만 ⑦ActivityLog에 billing_key_revoked 기록. 로컬 PG 미설정 시 skip(CI 관례 동일)."""
+DB 정리만 ⑦ActivityLog에 billing_key_revoked 기록 ⑧issue_billing_key 재발급(카드 교체)이
+신 키 저장 성공 後 구 키를 Toss에서도 폐기(PO 동승 권고, PR#3423 리뷰 — C4 유예 갭을 이
+스토리가 닫음), 폐기 실패해도 신 키 저장은 유지. 로컬 PG 미설정 시 skip(CI 관례 동일)."""
 from __future__ import annotations
 
 import os
@@ -292,6 +294,106 @@ async def test_revoke_billing_key_records_activity_log():
             assert log.context["toss_revoked"] is True
             assert log.context["card_number_masked"] == "1234********5678"
             assert log.context["force"] is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_issue_billing_key_reissue_revokes_old_toss_key_after_new_key_saved():
+    """story #2989(PO 동승 권고, PR#3423 리뷰) — 카드 교체(재발급) 성공 後 구 빌링키를
+    Toss에서도 실 폐기한다(신 키 저장 커밋이 먼저, 그 다음 구 키 폐기). 이전엔 구 키가
+    Toss에 고아로 남는 C4 유예 갭이었다(issue_billing_key 옛 docstring)."""
+    from app.services.org_billing_key import issue_billing_key
+    from app.models.org_billing_key import OrgBillingKey
+    from sqlalchemy import select
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+            _, customer_key = await _seed_billing_key(
+                s, org_id=org_id, plaintext="old_billing_key_plaintext", customer_key="cust-fixed-2989",
+            )
+
+        mock_create = AsyncMock(return_value={
+            "billingKey": "new_billing_key_plaintext",
+            "authenticatedAt": "2026-08-24T00:00:00+09:00",
+            "card": {"issuerCode": "61", "number": "9999********0000", "cardType": "신용", "ownerType": "개인"},
+        })
+        mock_delete = AsyncMock()
+        with patch("app.services.org_billing_key.TossAdapter.create_billing_key", new=mock_create), \
+                patch("app.services.org_billing_key.TossAdapter.delete_billing_key", new=mock_delete):
+            async with maker() as s:
+                await issue_billing_key(s, org_id=org_id, auth_key="auth_reissue")
+
+        # 구 키가 정확히 그 평문으로 폐기 호출됐는지(암호화 토큰이 아니라 복호된 원문).
+        mock_delete.assert_awaited_once_with(billing_key="old_billing_key_plaintext")
+
+        async with maker() as s:
+            row = (await s.execute(select(OrgBillingKey).where(OrgBillingKey.org_id == org_id))).scalar_one()
+            assert row.customer_key == customer_key  # 재발급이라 customer_key는 유지
+            assert row.card_number_masked == "9999********0000"  # 새 카드로 갱신됨
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_issue_billing_key_new_org_no_old_key_skips_toss_delete():
+    """신규 org(구 행 없음)면 old-key preread가 None → Toss delete 호출 자체가 없다."""
+    from app.services.org_billing_key import issue_billing_key
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+            # org_billing_keys 행 자체를 세팅하지 않음(최초 발급 시나리오).
+
+        mock_create = AsyncMock(return_value={
+            "billingKey": "first_billing_key_plaintext",
+            "authenticatedAt": "2026-08-24T00:00:00+09:00",
+            "card": {"issuerCode": "61", "number": "1111********2222", "cardType": "신용", "ownerType": "개인"},
+        })
+        mock_delete = AsyncMock()
+        with patch("app.services.org_billing_key.TossAdapter.create_billing_key", new=mock_create), \
+                patch("app.services.org_billing_key.TossAdapter.delete_billing_key", new=mock_delete):
+            async with maker() as s:
+                await issue_billing_key(s, org_id=org_id, auth_key="auth_first")
+
+        mock_delete.assert_not_awaited()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_issue_billing_key_reissue_keeps_new_key_saved_even_if_old_key_toss_delete_fails():
+    """PO 지시 순서 — 구 키 Toss 폐기 실패는 신 키 저장을 롤백하지 않는다(신 키는 이미
+    커밋됨, 폐기 실패는 로깅만)."""
+    from app.services.org_billing_key import issue_billing_key
+    from app.models.org_billing_key import OrgBillingKey
+    from sqlalchemy import select
+
+    engine, maker = await _session_factory()
+    try:
+        async with maker() as s:
+            org_id = await _seed_org(s, tier="free")
+            await _seed_billing_key(s, org_id=org_id, plaintext="old_billing_key_plaintext")
+
+        mock_create = AsyncMock(return_value={
+            "billingKey": "new_billing_key_plaintext",
+            "authenticatedAt": "2026-08-24T00:00:00+09:00",
+            "card": {"issuerCode": "61", "number": "9999********0000", "cardType": "신용", "ownerType": "개인"},
+        })
+        mock_delete = AsyncMock(side_effect=RuntimeError("Toss 5xx"))
+        with patch("app.services.org_billing_key.TossAdapter.create_billing_key", new=mock_create), \
+                patch("app.services.org_billing_key.TossAdapter.delete_billing_key", new=mock_delete):
+            async with maker() as s:
+                result = await issue_billing_key(s, org_id=org_id, auth_key="auth_reissue")
+
+        assert result is not None
+        async with maker() as s:
+            row = (await s.execute(select(OrgBillingKey).where(OrgBillingKey.org_id == org_id))).scalar_one()
+            assert row.status == "active"
+            assert row.card_number_masked == "9999********0000"  # 신 키 저장은 유지
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_2989_billing_key_revoke_realdb.py
+++ b/backend/tests/test_2989_billing_key_revoke_realdb.py
@@ -70,7 +70,10 @@ async def _session_factory():
     return engine, async_sessionmaker(engine, expire_on_commit=False)
 
 
-async def _seed_org(session, *, tier: str | None = None, sub_status: str = "active"):
+async def _seed_org(
+    session, *, tier: str | None = None, sub_status: str = "active",
+    current_period_end: datetime | None = None,
+):
     from app.models.organization import Organization
     from app.models.org_subscription import OrgSubscription
 
@@ -78,7 +81,10 @@ async def _seed_org(session, *, tier: str | None = None, sub_status: str = "acti
     session.add(org)
     await session.flush()
     if tier is not None:
-        session.add(OrgSubscription(id=uuid.uuid4(), org_id=org.id, tier=tier, status=sub_status))
+        session.add(OrgSubscription(
+            id=uuid.uuid4(), org_id=org.id, tier=tier, status=sub_status,
+            current_period_end=current_period_end,
+        ))
         await session.flush()
     await session.commit()
     return org.id
@@ -108,19 +114,24 @@ async def _seed_billing_key(
 
 @pytest.mark.asyncio
 async def test_revoke_billing_key_blocks_when_active_paid_subscription():
-    """P3 — 활성 유료 구독이 있으면(force 아닐 때) 결제수단 삭제를 서버가 명시 거부한다."""
+    """P3 — 활성 유료 구독이 있으면(force 아닐 때) 결제수단 삭제를 서버가 명시 거부한다.
+    PO 재지적(2026-08-24, PR#3423 리뷰, 유나 관찰) — 해지는 예약형이라 "해지 후 다시
+    시도" 안내는 거짓이다. 예외가 current_period_end를 정확히 실어야 라우터/FE가 실
+    날짜를 보여줄 수 있다."""
     from app.services.org_billing_key import ActiveSubscriptionBlocksRevoke, revoke_billing_key
 
+    period_end = datetime(2026, 9, 24, tzinfo=timezone.utc)
     engine, maker = await _session_factory()
     try:
         async with maker() as s:
-            org_id = await _seed_org(s, tier="starter", sub_status="active")
+            org_id = await _seed_org(s, tier="starter", sub_status="active", current_period_end=period_end)
             await _seed_billing_key(s, org_id=org_id)
 
         async with maker() as s:
             with pytest.raises(ActiveSubscriptionBlocksRevoke) as exc_info:
                 await revoke_billing_key(s, org_id=org_id, actor_id=uuid.uuid4(), actor_type="human")
             assert exc_info.value.tier == "starter"
+            assert exc_info.value.current_period_end == period_end
     finally:
         await engine.dispose()
 
@@ -311,8 +322,11 @@ async def test_issue_billing_key_reissue_revokes_old_toss_key_after_new_key_save
     try:
         async with maker() as s:
             org_id = await _seed_org(s, tier="free")
+            # customer_key는 unique 제약 대상 — _seed_billing_key 기본 생성(uuid 접미)에
+            # 맡긴다(고정 리터럴을 썼다가 재실행 시 잔존행과 충돌해 UniqueViolationError를
+            # 자초한 적이 있다, 이 파일의 다른 헬퍼들과 동일 관례로 정정).
             _, customer_key = await _seed_billing_key(
-                s, org_id=org_id, plaintext="old_billing_key_plaintext", customer_key="cust-fixed-2989",
+                s, org_id=org_id, plaintext="old_billing_key_plaintext",
             )
 
         mock_create = AsyncMock(return_value={

--- a/backend/tests/test_e_2492_c1_billing_key.py
+++ b/backend/tests/test_e_2492_c1_billing_key.py
@@ -168,9 +168,13 @@ async def test_issue_billing_key_new_org_generates_customer_key_and_persists(mon
 
     org_id = uuid.uuid4()
     session = AsyncMock()
+    # story #2989 — issue_billing_key가 덮어쓰기 前에 구 빌링키 존재여부를 먼저 읽는다
+    # (재발급 시 구 키 Toss 폐기용, PR#3423 리뷰). 신규 org라 구 행이 없으므로 None.
+    old_key_result = MagicMock()
+    old_key_result.scalar_one_or_none.return_value = None
     persisted = MagicMock()
     persisted.scalar_one.return_value = MagicMock(spec=OrgBillingKey)
-    session.execute = AsyncMock(side_effect=[MagicMock(), persisted])
+    session.execute = AsyncMock(side_effect=[old_key_result, MagicMock(), persisted])
     session.commit = AsyncMock()
 
     monkeypatch.setattr(svc, "ensure_configured", MagicMock())
@@ -189,7 +193,7 @@ async def test_issue_billing_key_new_org_generates_customer_key_and_persists(mon
     result = await svc.issue_billing_key(session, org_id=org_id, auth_key="auth_x")
 
     assert result is not None
-    insert_call = session.execute.call_args_list[0]
+    insert_call = session.execute.call_args_list[1]
     compiled_params = insert_call.args[0].compile().params
     assert compiled_params["org_id"] == org_id
     assert compiled_params["customer_key"] == "org-generated-key"
@@ -206,8 +210,10 @@ async def test_issue_billing_key_reuses_existing_customer_key(monkeypatch):
 
     org_id = uuid.uuid4()
     session = AsyncMock()
+    old_key_result = MagicMock()
+    old_key_result.scalar_one_or_none.return_value = None
     persisted = MagicMock()
-    session.execute = AsyncMock(side_effect=[MagicMock(), persisted])
+    session.execute = AsyncMock(side_effect=[old_key_result, MagicMock(), persisted])
     session.commit = AsyncMock()
 
     monkeypatch.setattr(svc, "ensure_configured", MagicMock())
@@ -256,8 +262,12 @@ async def test_issue_billing_key_reissue_bumps_updated_at(monkeypatch):
     session = AsyncMock()
     existing_result = MagicMock()
     existing_result.scalar_one_or_none.return_value = existing_row
+    # story #2989 — 구 빌링키 preread(PR#3423 리뷰 반영). None으로 두어 이 테스트의 관심사
+    # (updated_at 명시 갱신) 밖인 구 키 Toss 폐기 분기가 끼어들지 않게 한다.
+    old_key_result = MagicMock()
+    old_key_result.scalar_one_or_none.return_value = None
     persisted = MagicMock()
-    session.execute = AsyncMock(side_effect=[existing_result, MagicMock(), persisted])
+    session.execute = AsyncMock(side_effect=[existing_result, old_key_result, MagicMock(), persisted])
     session.commit = AsyncMock()
 
     monkeypatch.setattr(svc, "ensure_configured", MagicMock())
@@ -269,7 +279,7 @@ async def test_issue_billing_key_reissue_bumps_updated_at(monkeypatch):
 
     await svc.issue_billing_key(session, org_id=org_id, auth_key="auth_z")
 
-    insert_call = session.execute.call_args_list[1]
+    insert_call = session.execute.call_args_list[2]
     stmt = insert_call.args[0]
     on_conflict_set = stmt._post_values_clause.update_values_to_set
     set_columns = {c if isinstance(c, str) else c.name for c, _ in on_conflict_set}

--- a/backend/tests/test_e_2512_customer_key_pre_widget.py
+++ b/backend/tests/test_e_2512_customer_key_pre_widget.py
@@ -102,7 +102,11 @@ async def test_issue_billing_key_delegates_customer_key_to_ensure_customer_key()
 
     org_id = uuid.uuid4()
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[MagicMock(), _exec_result(MagicMock())])
+    # story #2989(PO 재지적, PR#3423 리뷰) — issue_billing_key가 덮어쓰기 前에 구
+    # encrypted_billing_key를 preread하는 session.execute 호출이 하나 더 생겼다(재발급 시
+    # 구 키 Toss 폐기용). 신규 org라 구 행이 없으므로 None — 이 값 축은 이 테스트의 관심사
+    # (ensure_customer_key 위임 확認) 밖이라 그냥 통과만 시킨다.
+    session.execute = AsyncMock(side_effect=[_exec_result(None), MagicMock(), _exec_result(MagicMock())])
     session.commit = AsyncMock()
 
     toss_response = {
@@ -125,7 +129,7 @@ async def test_issue_billing_key_delegates_customer_key_to_ensure_customer_key()
     create_call_kwargs = MockAdapter.return_value.create_billing_key.await_args.kwargs
     assert create_call_kwargs["customer_key"] == "org-converged-key"  # ensure_customer_key 값 그대로
 
-    upsert_call = session.execute.call_args_list[0]
+    upsert_call = session.execute.call_args_list[1]
     compiled = upsert_call.args[0].compile().params
     assert compiled["status"] == "active"
     assert compiled["encrypted_billing_key"] == "encrypted-value"


### PR DESCRIPTION
## Summary
[SID:2989]

- Toss billing-key 실 폐기(`DELETE /v1/billing/{billingKey}`) 어댑터 추가
- `revoke_billing_key()` — 셀프서브 삭제(AC1)와 admin 초기화(AC3)가 공유하는 단일 레일. 순서 고정: Toss 실 폐기 먼저(성공해야 DB 건드림) → `status='deleted'`+카드정보 클리어(customer_key는 보존, 재등록 시 재사용) → ActivityLog 기록. 활성 유료 구독이면 차단(AC2/P3, `force=True`로 admin만 우회)
- `GET`/`DELETE /api/v2/org-billing-keys` — 등록된 카드 조회+셀프서브 삭제. GET은 이 PR 이전엔 아예 없던 신규 표면(그라운딩 실측 — 등록만 있고 "지금 뭐가 등록돼 있는지" 조회할 길이 없었음)
- `POST /api/v2/admin/orgs/{org_id}/billing/reset-billing-key` — 테스트/운영 개입용 결제수단 초기화(`retry_billing`과 동형: admin 인가+prod 차단+구조화 audit)
- FE `PaymentMethodSection` — 마스킹 카드 표시+삭제 확인 다이얼로그+409 차단 배너, `billing-tab.tsx`에 편입
- **(리뷰 반영①)** 카드 교체(재발급) 시 구 빌링키를 Toss에서도 실 폐기 — `issue_billing_key()`가 덮어쓰기 前 구 키를 preread해두고, 신 키 저장 커밋 後 그 구 키를 폐기(폐기 실패해도 신 키 저장은 유지). 이전엔 story C4로 유예돼 있던 갭
- **(리뷰 반영②)** 409 차단 문구를 "구독 해지 후 다시 시도"(예약형 해지라 거짓 안내)에서 실 종료일(`current_period_end`) 표시로 수정 — 예외/응답 payload에 날짜를 실어 FE가 정확한 날짜를 보여줌
- story #2991(예약된 구독 해지/다운그레이드 취소 기능)은 존재 확인 결과 이미 #2881/#2882/#2909②로 구현 완료 — 이 PR 배포 후 라이브 라운드트립 검증만 남음(별도 보고)

## Test plan
- [x] 신규 realdb 테스트 16건(`test_2989_billing_key_revoke_realdb.py`) — 활성구독 차단(종료일 전파 포함)/force 우회/Toss 호출 순서+카드필드 클리어/placeholder no-op/이미삭제 no-op/ActivityLog 기록/admin wrapper/재발급 시 구 키 폐기(호출확認·신규org스킵·폐기실패해도 신키유지)
- [x] 신규 라우터 단위 테스트 8건(`test_2989_billing_key_endpoints.py`) — GET/DELETE 200·409(current_period_end 포함)·403·admin prod 차단
- [x] 기존 billing 관련 18개 테스트 파일 개별 재실행, 회귀 없음 확認
- [x] FE: `tsc --noEmit` 0 errors, eslint 0 issues, 전체 vitest 스위트(4276/4276) 통과(i18n phrase-collision 가드에 `date` non-count 등재 포함)
- [ ] CI green 확인 대기

## Cleanup note
urgent 초기화 요청 대응으로 임시 생성한 Cloud Run Job `billing-key-admin-dev`는 이 엔드포인트가 dev에 배포 확인된 후 삭제 예정(PO 조건부 존치 재가 사항).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AbjN7dJp11Nng4AVZY3Xw