### PR TITLE
[SID:2983] citron 라이트테마 저대비 재처방

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -361,7 +361,9 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
         <div className="mt-0.5 font-editorial-heading text-[20px] leading-none tracking-[-0.03em] text-foreground">
           {t('title')}
         </div>
-        <hr className="mt-2 h-[3px] w-8 border-0 bg-proof-citron" />
+        {/* story #2983(유나 확定) — 정적 장식 citron 퇴출(citron=live pulse 신호 전용).
+            시그니처는 무채 두께(3px)·길이로 유지. */}
+        <hr className="mt-2 h-[3px] w-8 border-0 bg-proof-line-strong" />
       </div>
       <TreeSearchInput
         value={searchQuery}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
@@ -134,7 +134,9 @@ export function DocsIndex() {
         <h1 className="mt-2 font-display font-editorial-heading text-[46px] leading-none tracking-[-0.035em] text-foreground">
           {t('title')}
         </h1>
-        <hr className="my-4 h-[3px] w-[88px] border-0 bg-proof-citron" />
+        {/* story #2983(유나 확定) — 정적 장식 citron 퇴출(citron=live pulse 신호 전용).
+            시그니처는 무채 두께(3px)·길이로 유지. */}
+        <hr className="my-4 h-[3px] w-[88px] border-0 bg-proof-line-strong" />
         <p className="text-editorial-ui text-muted-foreground">
           {t('indexDek')} <span className="text-muted-foreground">{t('indexDocCount', { count: items.length })}</span>
         </p>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -1065,7 +1065,9 @@ export function GoalsClient({ projectId, orgId }: GoalsClientProps) {
         {/* story #2974(PR-D0) delta — font-display(페이스)+font-editorial-heading(무게 유틸,
             --font-weight-editorial-heading:820) 병기. docs-index.tsx 마스트헤드 주석 참고. */}
         <h1 className="mt-1.5 font-display font-editorial-heading text-[28px] leading-none tracking-[-0.03em] text-foreground sm:text-[34px]">{t('title')}</h1>
-        <hr className="my-3 h-[3px] w-16 border-0 bg-proof-citron" />
+        {/* story #2983(유나 확定) — 정적 장식 citron 퇴출(citron=live pulse 신호 전용).
+            시그니처는 무채 두께(3px)·길이로 유지. */}
+        <hr className="my-3 h-[3px] w-16 border-0 bg-proof-line-strong" />
         <p className="text-editorial-ui text-muted-foreground">
           {t('indexDek')} <span className="text-muted-foreground">{t('indexCountActive', { count: activeCount })} · {t('indexCountDone', { count: doneCount })}</span>
         </p>

--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -599,7 +599,7 @@ export default function InboxPage() {
                             {(notification.type === 'agent_joined' || reasonKey) ? (
                               <div className="flex flex-wrap items-center gap-1.5">
                                 {notification.type === 'agent_joined' ? (
-                                  <Badge className="gap-0.5 bg-accent-claim/15 text-accent-claim text-[10px]">
+                                  <Badge className="gap-0.5 bg-accent-claim/15 text-foreground text-[10px]">
                                     <Bot className="size-2.5" />Bot
                                   </Badge>
                                 ) : null}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -376,9 +376,13 @@
   /* DS-S13: Extended semantic tokens */
   --overlay-backdrop: oklch(0 0 0 / 50%);
   --text-disabled: oklch(0.68 0 0);
-  /* story #2917: Citron(#C7F85A)은 라이트/다크 동일값·텍스트 절대 금지(매핑표 §5 실측
-     dark ink 대비 1.11 FAIL) — pulse/accent 전용, 기존 accent-claim 소비처(WORKING_RING_CLASS
-     등 장식적 링·배지)와 계약 그대로 일치. */
+  /* story #2917: 텍스트 절대 금지(매핑표 §5 실측 dark ink 대비 1.11 FAIL) — pulse/accent
+     전용, 기존 accent-claim 소비처(WORKING_RING_CLASS 등 장식적 링·배지)와 계약 그대로 일치.
+     story #2983(선생님 실사고 2026-08-24): #2917 당시 "라이트/다크 동일값"은 텍스트-대비축만
+     실측했고, 실사용(포커스링·active탭 등 비텍스트 border/ring) 축의 라이트 대비는 미실측이었다
+     — 실측하니 라이트 전 배경 1.03~1.24:1(비텍스트 최소 3:1 대폭 미달, 다크는 11~16:1로
+     정상). --proof-citron을 라이트 전용으로 분리(동일 hue/sat, L만 하향 — 다크는 무변경).
+     텍스트 금지 원칙은 그대로 유지. */
   --accent-claim: var(--proof-citron);
   --accent-claim-foreground: oklch(0.985 0 0);
   --highlight-search-bg: oklch(0.88 0.14 85 / 40%);
@@ -443,7 +447,12 @@
   --proof-faint: #9C9E93;
   --proof-blue: #3157FF;
   --proof-blue-soft: #EAEEFF;
-  --proof-citron: #C7F85A;
+  /* story #2983 — 라이트 전용 재조정값(다크 #C7F85A와 hue/sat 동일, L만 하향, 유나 확定
+     2026-08-24). vs proof-panel(white) 4.22:1 · vs proof-sunk(#ECEAE2) 3.50:1 — 비텍스트
+     3:1 최소 위 여유 margin. 텍스트(작은 배지 라벨 등)로는 4.5:1 미달이라 그 축은 값을
+     더 내리지 않고 text-accent-claim 소비처를 text-foreground로 전환해 해소(색값을 텍스트급
+     까지 내리면 링/dot이 과채도가 되는 트레이드오프 회피 — 유나 판단). */
+  --proof-citron: #5F8706;
   --proof-green: #1F9D57;
   --proof-green-soft: #E7F6EE;
   --proof-amber: #B7791F;

--- a/apps/web/src/components/chat/add-participant-modal.tsx
+++ b/apps/web/src/components/chat/add-participant-modal.tsx
@@ -123,7 +123,7 @@ export function AddParticipantModal({
                     </div>
                     <span className="flex-1 truncate">{m.name}</span>
                     {m.type === 'agent' && (
-                      <span className="rounded-sm bg-accent-claim/15 px-1 py-0.5 text-[9px] font-medium text-accent-claim">Bot</span>
+                      <span className="rounded-sm bg-accent-claim/15 px-1 py-0.5 text-[9px] font-medium text-foreground">Bot</span>
                     )}
                     {selected === m.id && <Check className="h-3.5 w-3.5 flex-shrink-0 text-primary" />}
                   </button>

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -530,7 +530,7 @@ export function ChatBubble({
                 {displayName}
               </span>
               {isAgent && (
-                <span className="rounded-sm bg-accent-claim/15 px-1 py-0.5 text-[9px] font-medium text-accent-claim">
+                <span className="rounded-sm bg-accent-claim/15 px-1 py-0.5 text-[9px] font-medium text-foreground">
                   Bot
                 </span>
               )}

--- a/apps/web/src/components/chat/new-conversation-modal.tsx
+++ b/apps/web/src/components/chat/new-conversation-modal.tsx
@@ -119,7 +119,7 @@ export function NewConversationModal({ projectId, onClose, onCreated }: NewConve
                     </div>
                     <span className="flex-1 truncate">{m.name}</span>
                     {m.type === 'agent' && (
-                      <span className="rounded-sm bg-accent-claim/15 px-1 py-0.5 text-[9px] font-medium text-accent-claim">Bot</span>
+                      <span className="rounded-sm bg-accent-claim/15 px-1 py-0.5 text-[9px] font-medium text-foreground">Bot</span>
                     )}
                     {selected.includes(m.id) && <Check className="h-3.5 w-3.5 flex-shrink-0 text-primary" />}
                   </button>

--- a/apps/web/src/components/kanban/kanban-list-view.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.tsx
@@ -77,7 +77,7 @@ function ListStoryRow({ story, epicMap, memberMap, onStoryClick, onChangeStatus 
           <div className="mt-1 flex items-center gap-2 relative z-10">
             <p className="text-xs text-muted-foreground">{memberMap[story.assignee_id].name}</p>
             {memberMap[story.assignee_id].type === 'agent' && (
-              <div className="flex items-center gap-1.5 text-[10px] font-mono text-accent-claim">
+              <div className="flex items-center gap-1.5 text-[10px] font-mono text-foreground">
                 <span className="relative flex h-1.5 w-1.5">
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-claim opacity-75"></span>
                   <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-accent-claim"></span>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -358,7 +358,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                         key={m.id}
                         className={`relative flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-medium ring-1 ring-background ${
                           m.type === 'agent'
-                            ? 'border-accent-claim/30 bg-accent-claim/10 text-accent-claim'
+                            ? 'border-accent-claim/30 bg-accent-claim/10 text-foreground'
                             : 'border-border bg-muted text-muted-foreground'
                         }`}
                         title={m.name}
@@ -380,7 +380,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                   <div />
                 )}
                 {hasAgent && (
-                  <span className="inline-flex items-center gap-1 text-[10px] text-accent-claim">
+                  <span className="inline-flex items-center gap-1 text-[10px] text-foreground">
                     <span className="size-1.5 shrink-0 rounded-full bg-accent-claim" aria-hidden="true" />
                     {t('filterAgents')}
                   </span>

--- a/apps/web/src/components/shared/avatar.tsx
+++ b/apps/web/src/components/shared/avatar.tsx
@@ -98,7 +98,7 @@ export function Avatar({
 
       {isAgent && (
         <span
-          className="absolute -right-1.5 -top-1.5 rounded border border-accent-claim/40 bg-accent-claim/15 font-bold text-accent-claim"
+          className="absolute -right-1.5 -top-1.5 rounded border border-accent-claim/40 bg-accent-claim/15 font-bold text-foreground"
           style={{ fontSize: Math.max(7, Math.round(badgeSize * 0.55)), lineHeight: 1, padding: '2px 3px' }}
         >
           AI


### PR DESCRIPTION
## 요약
선생님 실사용 발견 — 라이트 테마 밝은 회색 배경에서 citron 강조색이 안 보임.

**원인**: proof-blue/green/amber/red는 테마별로 값이 갈리는데 proof-citron만 유일하게 라이트/다크 hex가 완전 동일(#C7F85A). 다크 배경 대비 11~16:1로 우수하나, 같은 값이 라이트 배경(bg/panel/sunk/line 전부)에서 1.03~1.24:1(비텍스트 최소 3:1에도 대폭 미달).

story #2917 당시 텍스트-대비축만 실측(dark ink on citron 1.11 FAIL)했고, 실사용(border/ring/dot) 축의 라이트 대비는 미실측이었던 사각.

## 처방 (유나 홀름 확定, story #2983 Sprintable 채팅 판정 2026-08-24 — 페드루 올리베이라 중계)
사용처 14곳 grep 전수 분류 + `accent-claim` 별칭 경유 텍스트 소비처 추가 발견 후 3갈래 처방:

1. **비텍스트 11곳**(포커스링·active탭·agent working pulse·진행중 dot 등 실 상태신호) → `--proof-citron` 라이트 전용 `#5F8706` 신설(다크는 원값 `#C7F85A` 무변경). vs proof-panel(white) 4.22:1 · vs proof-sunk 3.50:1.
2. **텍스트인 자리**(lead/Bot 배지·kanban agent 라벨·initials 등, 소형텍스트 4.5:1 기준) → 값 fix 아니라 `text-accent-claim` → `text-foreground` 전환(7곳). `#5F8706`도 실제 `/15` 틴트 배경 위 텍스트로는 4.5 미달이라, 값을 텍스트급까지 내리면 링/dot이 과채도가 되는 트레이드오프를 피해 색 텍스트 자체를 없앰. `avatar.tsx`의 Bot 아이콘 color(텍스트 아님)는 비텍스트 축이라 유지.
3. **장식 hr 3곳**(마스트헤드 구분선, 상태 무관 정적 요소) → 무채(`bg-proof-line-strong`)로 전환. citron은 live pulse 신호 전용 규율 — 시그니처는 두께(3px)·길이로 유지.

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4284 tests all green(무회귀)
- [x] `pnpm build` green
- [x] 빌드 CSS grep으로 `--proof-citron:#5f8706`(라이트)/`#c7f85a`(다크) 실컴파일 확인

## 후속 논의(비차단, 이 PR 범위 밖)
`kanban-list-view.tsx`/`story-card.tsx`의 `border-accent-claim/30`·`/50`(기본상태, 오파시티로 재희석) 실측상 3:1 미달(1.56·2.19) 확인 — 앰비언트 힌트 보더라 badge/텍스트로 이미 라벨된 카드의 보조신호이지 유일 식별 수단은 아니라 이번 PR 스코프에서 뺐음. 필요하면 opacity 상향(예: /50→/70, /80→그대로) 후속 스토리로.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA