### PR TITLE
[SID:2990] Workcell bento 모바일 단일컬럼 스택(critical) + elev-card

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -469,6 +469,12 @@
      그림자만으론 엣지가 흐리다는 게 doc §1.2의 명시 규칙. */
   --elev-overlay: 0 1px 2px rgba(20, 21, 15, .05), 0 10px 30px -8px rgba(20, 21, 15, .22);
 
+  /* story #2990 §4 fast-follow(유나 확定 2026-08-24) — 인라인 카드(문서 흐름 안, 예:
+     Workcell Evidence 셀) 전용 elevation. --elev-overlay(오버레이 전용, 위 §1.2 규칙)를
+     재사용하면 "셀이 팝오버처럼 분리"되는 의미 혼용이라 신설. overlay보다 약한 단일 강도 —
+     오프셋/블러/스프레드 40~50%·불투명도 ~59%로 축소(같은 carbon-tint, 2레이어 구조 유지). */
+  --elev-card: 0 1px 2px rgba(20, 21, 15, .04), 0 4px 14px -4px rgba(20, 21, 15, .13);
+
   /* story #2955 §5(doc docs-index-reader-redesign-handoff) — 컷코너 3단 토큰 정식화.
      기존 산발 clip-path 4곳(proof-capsule.tsx CutCornerShell·attention-queue-view.tsx·
      artifact-gallery-view.tsx·workcell.tsx)이 정본 없이 각자 인라인으로 같은 지오메트리를
@@ -630,6 +636,11 @@
 
   /* story #2969 §1.2(PR-T) — 다크 오버레이 그림자(라이트 대응값의 doc §1.2 지정 다크값). */
   --elev-overlay: 0 1px 2px rgba(0, 0, 0, .5), 0 12px 34px -8px rgba(0, 0, 0, .62);
+
+  /* story #2990 §4 fast-follow — 라이트 --elev-card와 동일 축소비(오프셋/블러/스프레드
+     40~50%·불투명도 ~59%)를 다크 --elev-overlay에 적용해 유도(값-SSOT 재사용, 임의 신규
+     불투명도 없음). */
+  --elev-card: 0 1px 2px rgba(0, 0, 0, .4), 0 4px 16px -4px rgba(0, 0, 0, .36);
 }
 
 /* Sidebar: open triggers get active background */

--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -188,13 +188,26 @@ describe('Workcell — story #2984 §1~§4 bento 기본 레이아웃(bentoLayout
 
   it('§2 — Brief/Run과 Evidence를 잇는 계보 연결선(가운데 트랙)이 렌더된다', () => {
     const markup = renderKo(<Workcell {...BASE} />);
-    expect(markup).toContain('col-start-2 row-start-1 row-span-2');
+    expect(markup).toContain('lg:col-start-2 lg:row-start-1 lg:row-span-2');
     expect(markup).toContain('bg-proof-line-strong');
   });
 
-  it('§4 — Evidence 셀만 elevation(--elev-overlay) 그림자를 갖고 나머지는 flat', () => {
+  // story bc9ee586(critical, 선생님 실사고 2026-08-24) — 3열 그리드가 모바일(390px)에서
+  // 그대로 유지돼 Evidence 제목 어절 세로 낙하·Run CTA 글자 꺾임. base=단일 컬럼 스택,
+  // lg: 이상만 3열(GNB lg:hidden과 일치하는 breakpoint — CLAUDE.md md 사용 금지 규율).
+  it('bc9ee586 — base는 단일 컬럼 스택(grid-cols-1), 3열/연결선은 lg: 이상에서만 적용된다', () => {
     const markup = renderKo(<Workcell {...BASE} />);
-    expect(markup).toContain('shadow-[var(--elev-overlay)]');
+    expect(markup).toContain('grid-cols-1');
+    // 연결선 wrapper는 모바일에서 숨김(hidden), lg:flex로만 드러난다.
+    expect(markup).toContain('class="hidden lg:col-start-2 lg:row-start-1 lg:row-span-2 lg:flex lg:justify-center"');
+  });
+
+  it('§4 — Evidence 셀만 elevation(--elev-card, 인라인 카드 전용) 그림자를 갖고 나머지는 flat', () => {
+    // story #2990 §4 fast-follow(유나 확定) — elev-overlay(오버레이 전용)는 "팝오버처럼
+    // 분리"되는 의미 혼용이라 elev-card(인라인 카드 전용, 약한 강도)로 교체.
+    const markup = renderKo(<Workcell {...BASE} />);
+    expect(markup).toContain('shadow-[var(--elev-card)]');
+    expect(markup).not.toContain('shadow-[var(--elev-overlay)]');
     expect(markup).toContain('shadow-[0_1px_0_var(--proof-line)]');
   });
 
@@ -209,7 +222,7 @@ describe('Workcell — story #2984 §1~§4 bento 기본 레이아웃(bentoLayout
   it('§6 — bentoLayout={false}로 뒤집으면 §1~§4 마크업이 전부 사라지고 옛 모습으로 복귀한다', () => {
     const markup = renderKo(<Workcell {...BASE} bentoLayout={false} />);
     expect(markup).not.toContain('grid-cols-[1.7fr_4px_1fr]');
-    expect(markup).not.toContain('shadow-[var(--elev-overlay)]');
+    expect(markup).not.toContain('shadow-[var(--elev-card)]');
     expect(markup).not.toContain('role="progressbar"');
   });
 });

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -261,23 +261,31 @@ export function Workcell({ title, pipelineStage, brief, run, evidence, conversat
           // story #2984 §1/§2/§4 — 균등 2×2 → 크기 차등 bento(Evidence=최우선 큰 셀)+계보
           // 연결선+Evidence만 elevation. 가운데 4px 열은 연결선 전용 트랙(§2) — 매직 픽셀
           // 좌표 없이 CSS Grid 라인에 그대로 앵커링해 실 렌더 폰트/패딩에 안 흔들린다.
-          <div className="relative grid grid-cols-[1.7fr_4px_1fr] grid-rows-[auto_auto_auto] gap-3 p-3">
-            <div className="col-start-2 row-start-1 row-span-2 flex justify-center" aria-hidden="true">
+          // story bc9ee586(critical, 선생님 실사고 2026-08-24) — 3열 그리드가 모바일에서
+          // 그대로 유지돼 Evidence 제목 어절 세로 낙하·Run CTA 글자 꺾임. base=단일 컬럼
+          // 스택(DOM 순서 그대로 Evidence→Run→Brief→Conversation), lg: 이상만 3열 그리드로
+          // 전환(GNB lg:hidden과 일치하는 breakpoint — CLAUDE.md md 사용 금지 규율이라
+          // 페드루군 구두 지시의 "md:"를 lg:로 치환). 계보 연결선은 모바일에서 숨김.
+          <div className="relative grid grid-cols-1 gap-3 p-3 lg:grid-cols-[1.7fr_4px_1fr] lg:grid-rows-[auto_auto_auto]">
+            <div className="hidden lg:col-start-2 lg:row-start-1 lg:row-span-2 lg:flex lg:justify-center" aria-hidden="true">
               <div className="relative w-[1.5px] bg-proof-line-strong">
                 <span className="absolute left-1/2 top-0 size-[7px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-proof-ink" />
                 <span className="absolute left-1/2 top-1/2 size-[7px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-proof-ink" />
               </div>
             </div>
-            <div className="col-start-1 row-start-1 row-span-2 overflow-hidden rounded-[10px] border border-proof-line-strong bg-proof-panel shadow-[var(--elev-overlay)]">
+            {/* story #2990 §4 fast-follow(유나 확定) — elev-overlay(오버레이 전용)는 인라인
+                카드에 과한 "팝오버처럼 분리" 신호라 elev-card(인라인 카드 전용, 약한 강도)로
+                교체. */}
+            <div className="lg:col-start-1 lg:row-start-1 lg:row-span-2 overflow-hidden rounded-[10px] border border-proof-line-strong bg-proof-panel shadow-[var(--elev-card)]">
               <EvidenceLayer evidence={evidence} />
             </div>
-            <div className="col-start-3 row-start-1 overflow-hidden rounded-[10px] border border-proof-line bg-proof-panel shadow-[0_1px_0_var(--proof-line)]">
+            <div className="lg:col-start-3 lg:row-start-1 overflow-hidden rounded-[10px] border border-proof-line bg-proof-panel shadow-[0_1px_0_var(--proof-line)]">
               <RunLayer run={run} />
             </div>
-            <div className="col-start-3 row-start-2 overflow-hidden rounded-[10px] border border-proof-line bg-proof-panel shadow-[0_1px_0_var(--proof-line)]">
+            <div className="lg:col-start-3 lg:row-start-2 overflow-hidden rounded-[10px] border border-proof-line bg-proof-panel shadow-[0_1px_0_var(--proof-line)]">
               <BriefLayer brief={brief} />
             </div>
-            <div className="col-span-3 row-start-3 overflow-hidden rounded-[10px] border border-proof-line bg-proof-panel shadow-[0_1px_0_var(--proof-line)]">
+            <div className="lg:col-span-3 lg:row-start-3 overflow-hidden rounded-[10px] border border-proof-line bg-proof-panel shadow-[0_1px_0_var(--proof-line)]">
               <ConversationLayer conversation={conversation} />
             </div>
           </div>


### PR DESCRIPTION
## 요약
**critical**: 선생님 실사고 — Workcell bento가 모바일에서 3열 그리드 그대로 유지되어 Evidence 제목 어절 세로 낙하·Run CTA 글자 꺾임. PO가 390×844에서 재현.

## bc9ee586 — 모바일 단일 컬럼 스택
- base = 단일 컬럼(`grid-cols-1`, DOM 순서 그대로 Evidence→Run→Brief→Conversation)
- `lg:` 이상만 3열(`[1.7fr_4px_1fr]`) 그리드로 전환
- breakpoint는 GNB `lg:hidden`과 일치시킴 — **CLAUDE.md "md 사용 금지" 규율에 따라 페드루군 구두 지시의 "md:"를 `lg:`로 치환**했습니다(변경 있으면 알려달라 요청드림)
- 계보 연결선(§2)은 모바일에서 `hidden`, `lg:flex`로만 노출
- 구 2×2 폴백(`bentoLayout={false}`)은 무변경

## story #2990 §4 — elev-card fast-follow (동일 PR 동승, 페드루군 재량)
유나 확定: Evidence 셀의 `shadow-[var(--elev-overlay)]`는 dialog/toast "floating overlay" 강도 재사용이라 "셀이 팝오버처럼 분리"되는 의미 혼용. `--elev-card`(인라인 카드 전용, 중간 강도) 신설해 교체 — `--elev-overlay`는 오버레이 전용으로 유지. 값은 `--elev-overlay` 대비 오프셋/블러/스프레드 40~50%·불투명도 ~59%로 축소(라이트/다크 동일 축소비, 임의 신규값 아님).

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4290 tests all green (workcell.test.tsx 32개, bc9ee586 신규 2종 포함)
- [x] `pnpm build` green
- [x] puppeteer 라이브 픽셀: 390px 단일컬럼(낙하/꺾임 없음) · 1024px 3열(회귀 없음)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA