### PR TITLE
[SID:2993] Workcell 항상 렌더 — null 정직 빈 상태

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4184,6 +4184,8 @@
     "briefRoles": "Roles",
     "briefOwner": "Owner",
     "briefAgent": "Agent",
+    "ownerUnassigned": "No owner assigned",
+    "outOfPipeline": "Done — outside trust pipeline scope",
     "runQuestion": "How far · What's needed (current activity, not a progress bar)",
     "runNow": "Now",
     "runStage": "Stage",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4184,6 +4184,8 @@
     "briefRoles": "권한",
     "briefOwner": "책임",
     "briefAgent": "실행",
+    "ownerUnassigned": "책임자 미지정",
+    "outOfPipeline": "완료 — 신뢰 파이프라인 범위 밖",
     "runQuestion": "어디까지 · 무엇이 필요 (현재 행위, 진행률바 아님)",
     "runNow": "지금",
     "runStage": "단계",

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -231,6 +231,72 @@ describe('StoryDetailPanel — Workcell pipelineStage = story.trust_stage 직결
   });
 });
 
+// story #2993(PO 확定①②, 2026-08-24, 선생님 실사고 「주전장이 안 보인다」) — 이전엔
+// pipelineStage(=trust_stage null)와 proofHuman(human assignee 없음) 둘 중 하나만 없어도
+// Workcell 전체가 사라졌다. 합성값(status 매핑 폴백·허구 human)을 만들지 않으면서 각자
+// 정직한 빈 상태로 대체해 Workcell 자체는 항상 뜨는지 고정한다.
+describe('StoryDetailPanel — Workcell 항상 렌더(story #2993)', () => {
+  const HUMAN_ID = 'human-1';
+  const AGENT_ID = 'agent-1';
+  const memberMap = {
+    [HUMAN_ID]: { id: HUMAN_ID, name: '책임자', type: 'human' },
+    [AGENT_ID]: { id: AGENT_ID, name: '에이전트군', type: 'agent' },
+  };
+
+  async function mount(storyOverrides: Partial<KanbanStory>) {
+    stubFetch();
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel
+          story={makeStory({ status: 'in-progress', ...storyOverrides })}
+          tasks={[]} onClose={() => {}} memberMap={memberMap}
+        />,
+      ));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+  }
+
+  it('에이전트만 배정(human 0)이어도 Workcell이 렌더되고 "책임자 미지정"이 정직하게 뜬다', async () => {
+    await mount({ trust_stage: 'running', assignee_id: AGENT_ID, assignee_ids: [AGENT_ID] });
+    expect(container.textContent).toContain('책임자 미지정');
+    expect(container.textContent).toContain('에이전트군');
+  });
+
+  it('status=done(trust_stage=null)이어도 Workcell이 렌더되고 "파이프라인 범위 밖"이 정직하게 뜬다(합성 stage 없음)', async () => {
+    await mount({ status: 'done', trust_stage: null, assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID] });
+    expect(container.textContent).toContain('완료 — 신뢰 파이프라인 범위 밖');
+  });
+
+  it('human_owner_member_id가 있으면 assigneeIds 스캔보다 우선한다(PO 확定③, 실데이터 우선)', async () => {
+    const OWNER_ID = 'owner-1';
+    const map = { ...memberMap, [OWNER_ID]: { id: OWNER_ID, name: '진짜책임자', type: 'human' } };
+    stubFetch();
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel
+          story={makeStory({
+            status: 'in-progress', trust_stage: 'running',
+            assignee_id: AGENT_ID, assignee_ids: [AGENT_ID],
+            human_owner_member_id: OWNER_ID,
+          })}
+          tasks={[]} onClose={() => {}} memberMap={map}
+        />,
+      ));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain('진짜책임자');
+    expect(container.textContent).not.toContain('책임자 미지정');
+  });
+
+  it('human_owner_member_id가 memberMap에 없으면(미해결 참조) 지어내지 않고 다음 우선순위(assigneeIds)로 폴백한다', async () => {
+    await mount({
+      trust_stage: 'running', assignee_id: HUMAN_ID, assignee_ids: [HUMAN_ID],
+      human_owner_member_id: 'unresolvable-ghost-id',
+    });
+    expect(container.textContent).toContain('책임 책임자');
+  });
+});
+
 // story #2933 H3(P0-H 정직성 감사, PO 부수기록ⓐ) — P0-04 in-flight 칩(trustChip, 제목 옆
 // "입력 필요"/"병합 대기" 배지)도 구 gate-목록 재파생(deriveInFlightTrustChip, 폐기됨)이 아니라
 // pipelineStage(=story.trust_stage, H1) 하나로 수렴했는지 고정. gate fetch 응답과 무관해야

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -812,7 +812,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   //   신호 자체가 없어(story.acceptance_criteria는 freeform 텍스트라 카운트=fiction, glance-hero.tsx
   //   buildEvidence와 동일 규율) 렌더 안 함 — trustSeal(human_verified/self_reported)+
   //   evidence.autoVerify(merge 게이트 neutral_facts.ci_result)+gate(그 게이트 자체)만 real signal.
-  // - human assignee 없으면 Workcell 렌더 자체를 생략(허구 human 금지, ProofCapsule 배선과 동일 규율).
+  // - story #2993(PO 확定①) — human assignee 없어도 Workcell은 렌더한다(2993 이전엔 여기서
+  //   전체 생략했으나 "주전장이 안 보인다" 실사고 근본원인 중 하나였다). owner 자리는 정직한
+  //   "책임자 미지정"으로 대체(허구 human 여전히 금지 — ProofCapsule 배선 규율 그대로).
   // story #2933 H1(P0-H) — 구 FE 재파생(PIPELINE_STAGE_BY_STATUS+trustChip 조합, #3336
   // 드리프트 실사례로 이미 1회 버그난 그 로직)을 폐기하고 BE derive_trust_stage() 판정값을
   // story.trust_stage로 직접 소비한다(get_story/list_stories 둘 다 배선됨). PO 조건①(2933) —
@@ -849,7 +851,17 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const trustChipLabel = trustChip === 'needs_input' ? t('trustChipNeedsInput') : trustChip === 'merge_ready' ? t('trustChipMergeReady') : null;
 
   const assigneeIds = story.assignee_ids?.length ? story.assignee_ids : (story.assignee_id ? [story.assignee_id] : []);
-  const proofHumanId = assigneeIds.find((id) => memberMap[id] && memberMap[id]!.type !== 'agent');
+  // story #2993(PO 확定①③) — 「책임자=assignee 중 human」이 유일 소스였던 게 에이전트
+  // 단독배정 스토리(오늘 세션 다수 실사례)에서 Workcell 전체를 지우던 근본원인. 우선순위
+  // 폴백체인(실데이터 있을 때만 — 지어내지 않음): human_owner_member_id(P0-03, BE가 이미
+  // human만 지정 가능하도록 write-time 검증함) → human_verified_by(who 검증했나) →
+  // assigneeIds 중 human. memberMap에 실제로 해당 멤버가 resolve된 경우만 채택(부분
+  // 데이터로 이름을 지어내지 않는다).
+  const proofHumanId =
+    (story.human_owner_member_id && memberMap[story.human_owner_member_id] ? story.human_owner_member_id : null) ??
+    (story.human_verified_by && memberMap[story.human_verified_by] ? story.human_verified_by : null) ??
+    assigneeIds.find((id) => memberMap[id] && memberMap[id]!.type !== 'agent') ??
+    null;
   const proofAgentId = assigneeIds.find((id) => memberMap[id]?.type === 'agent');
   const proofHuman = proofHumanId ? memberMap[proofHumanId] : null;
   const proofAgent = proofAgentId ? memberMap[proofAgentId] : null;
@@ -1408,31 +1420,32 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
           <div className="space-y-5">
             {/* E-UI-DAEGBYEON P0 — Workcell 데뷔(최소 실화면 배선, story `e5310d1b`) + story #2922
                 W1 2×2 재설계. Evidence는 null(정직한 "아직 증거 없음" — EvidenceSection/
-                StoryMergeGate 실데이터 매핑은 후속 스코프, 대체 아님). human assignee 없으면 전체
-                생략. pipelineStage는 5-status 전 구간(backlog 포함) 항상 파생 가능해졌으므로
-                (Queued 신설) 가드에서 제외 — human 부재만 남는다. */}
-            {pipelineStage && proofHuman ? (
-              <Workcell
-                title={story.title}
-                pipelineStage={pipelineStage}
-                brief={{
-                  goal: story.description?.trim() || story.title,
-                  dod: story.acceptance_criteria?.trim() || t('workcellDodMissing'),
-                  owner: { name: proofHuman.name, role: 'human' },
-                  agent: proofAgent ? { name: proofAgent.name, initial: initials(proofAgent.name) } : undefined,
-                }}
-                run={{
-                  now: statusLabel,
-                  stage: statusLabel,
-                  tools: [],
-                  scopes: [],
-                  blocked: story.blocked_by?.length ? t('workcellBlockedReason') : null,
-                  nextNeed: WORKCELL_NEXT_NEED_BY_STATUS[localStatus] ?? statusLabel,
-                }}
-                evidence={workcellEvidence}
-                conversation={{ view: 'run', messages: workcellMessages, chatProof: chatProofSummary }}
-              />
-            ) : null}
+                StoryMergeGate 실데이터 매핑은 후속 스코프, 대체 아님).
+                story #2993(PO 확定①②) — 이전엔 pipelineStage(done=null)·proofHuman(에이전트
+                단독배정=null) 둘 중 하나만 없어도 Workcell 전체가 사라져 "주전장이 안
+                보인다" 실사고로 이어졌다. 이제 무조건 렌더 — 각자 정직한 빈 상태로 대체
+                (owner=null→"책임자 미지정", pipelineStage=null→"파이프라인 범위 밖"). 지어낸
+                값은 여전히 0(no-fiction 원칙 유지). */}
+            <Workcell
+              title={story.title}
+              pipelineStage={pipelineStage}
+              brief={{
+                goal: story.description?.trim() || story.title,
+                dod: story.acceptance_criteria?.trim() || t('workcellDodMissing'),
+                owner: proofHuman ? { name: proofHuman.name, role: 'human' } : null,
+                agent: proofAgent ? { name: proofAgent.name, initial: initials(proofAgent.name) } : undefined,
+              }}
+              run={{
+                now: statusLabel,
+                stage: statusLabel,
+                tools: [],
+                scopes: [],
+                blocked: story.blocked_by?.length ? t('workcellBlockedReason') : null,
+                nextNeed: WORKCELL_NEXT_NEED_BY_STATUS[localStatus] ?? statusLabel,
+              }}
+              evidence={workcellEvidence}
+              conversation={{ view: 'run', messages: workcellMessages, chatProof: chatProofSummary }}
+            />
             <div>
               <div className="flex items-center justify-between">
                 <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('assignee')}</span>

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -34,6 +34,10 @@ export interface KanbanStory {
   human_verified?: boolean | null;
   human_verified_by?: string | null;
   human_verified_at?: string | null;
+  // story #2993 — P0-03(backend/app/schemas/story.py StoryResponse)이 이미 배선해 반환하던
+  // 필드인데 FE가 소비한 적이 없었다(FE 타입 부재). Workcell 책임자 표시 폴백체인(human_owner_
+  // member_id → human_verified_by → assigneeIds 스캔)의 최우선 소스.
+  human_owner_member_id?: string | null;
   // story #2187 — 라이브 QA가 만든 임시 카드([TEMP-QA] 등)는 삭제가 휴먼 전용(에이전트 API키
   // 403)이라 만든 쪽이 못 치운다. PO가 우선 is_excluded=true로 마킹해 analytics/command_center
   // 지표에서는 뺐으나(#2187 관측) 보드/백로그 화면은 그 플래그를 안 봐 그대로 남아 있었다 —

--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -367,3 +367,34 @@ describe('Workcell — story #2922 W5 Conversation 구획 = ChatProofSection 요
     expect(markup).toContain('댓글 2건');
   });
 });
+
+// story #2993(PO 확定①②, 2026-08-24) — pipelineStage/owner 둘 다 이전엔 null이면 Workcell
+// 전체를 지웠다("주전장이 안 보인다" 실사고 근본원인). 이제 무조건 렌더하고 각자 정직한
+// 빈 상태로 대체한다(합성값 금지 — #2933 H1 조건②·no-fiction 유지).
+describe('Workcell — story #2993 pipelineStage/owner null 정직 빈 상태(합성 금지)', () => {
+  it('pipelineStage=null이면 게이지/스테퍼 대신 "파이프라인 범위 밖" 표시, role=progressbar/listitem 렌더 안 함', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage={null} />);
+    expect(markup).toContain('완료 — 신뢰 파이프라인 범위 밖');
+    expect(markup).not.toContain('role="progressbar"');
+    expect(markup).not.toContain('role="listitem"');
+  });
+
+  it('pipelineStage=null이어도 나머지 구획(Brief/Run/Evidence/Conversation)은 그대로 렌더된다', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage={null} />);
+    expect(markup).toContain('Brief');
+    expect(markup).toContain('Run');
+    expect(markup).toContain('Evidence');
+    expect(markup).toContain('Conversation');
+  });
+
+  it('brief.owner=null이면 "책임자 미지정" 정직 표시(허구 human 이름 없음)', () => {
+    const markup = renderKo(<Workcell {...BASE} brief={{ ...BASE.brief, owner: null }} />);
+    expect(markup).toContain('책임자 미지정');
+    expect(markup).not.toContain('책임 윤재');
+  });
+
+  it('agent만 있고 owner=null이어도 agent 표기는 정상 렌더(둘은 독립 축)', () => {
+    const markup = renderKo(<Workcell {...BASE} brief={{ ...BASE.brief, owner: null }} />);
+    expect(markup).toContain('실행 미르코군');
+  });
+});

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -21,7 +21,9 @@ export interface WorkcellAgent {
 export interface WorkcellBrief {
   goal: string;
   dod: string;
-  owner: WorkcellOwner;
+  /** story #2993(PO 확定①) — 에이전트 단독배정 스토리도 Workcell을 렌더한다(허구 human
+   * 금지 원칙은 유지 — 없으면 null로 정직하게 "책임자 미지정" 표시, 지어내지 않음). */
+  owner: WorkcellOwner | null;
   agent?: WorkcellAgent;
   scopes?: string[];
 }
@@ -65,8 +67,11 @@ export type WorkcellPipelineStage = 'queued' | 'running' | 'needs_input' | 'clai
 export interface WorkcellProps {
   title: string;
   /** story #2922 — 구 단일 proofState 배지(3색 점+텍스트)를 헤더 6상태 파이프라인 스테퍼로
-   * 대체(doc workcell-redesign-2922 축②). */
-  pipelineStage: WorkcellPipelineStage;
+   * 대체(doc workcell-redesign-2922 축②). story #2993(PO 확定②) — null=이 스토리가 신뢰
+   * 파이프라인 스코프 밖(현재는 done만 해당, BE trust_pipeline.derive_trust_stage §7 확定④
+   * 그대로)일 때. status 기반 합성 stage로 되돌리지 않고(#2933 H1 조건②가 금지) 정직한
+   * "파이프라인 범위 밖" 표시로 대체한다. */
+  pipelineStage: WorkcellPipelineStage | null;
   brief: WorkcellBrief;
   run: WorkcellRun;
   /** null = 아직 증거 없음(정직한 빈 상태) — Proof Capsule 컴포넌트 그대로 재사용. */
@@ -227,7 +232,7 @@ function ConfidenceGauge({ stage }: { stage: WorkcellPipelineStage }) {
  */
 export function Workcell({ title, pipelineStage, brief, run, evidence, conversation, className, bentoLayout = true }: WorkcellProps) {
   const t = useTranslations('workcell');
-  const railState = PIPELINE_STAGE_TRUST_COLOR[pipelineStage];
+  const railState = pipelineStage ? PIPELINE_STAGE_TRUST_COLOR[pipelineStage] : undefined;
   return (
     // story #2955 §5 — 인라인 clip-path를 정본 `.proof-cut` 유틸(globals.css)로 이관(24px 기본값 그대로).
     <div className={cn('proof-cut flex overflow-hidden rounded-[6px] border border-proof-line bg-proof-panel', className)}>
@@ -236,17 +241,28 @@ export function Workcell({ title, pipelineStage, brief, run, evidence, conversat
       {railState ? <Proofline state={railState} /> : <div className="w-1 shrink-0 self-stretch bg-proof-line" aria-hidden="true" />}
       <div className="min-w-0 flex-1">
         <div className="border-b border-proof-line px-4.5 py-3.5">
-          {/* story #2984 §3/§6 — bentoLayout=true(기본)면 색 스테퍼 대신 물리량 게이지. */}
-          {bentoLayout ? <ConfidenceGauge stage={pipelineStage} /> : <PipelineStepper stage={pipelineStage} />}
+          {/* story #2984 §3/§6 — bentoLayout=true(기본)면 색 스테퍼 대신 물리량 게이지.
+              story #2993(PO 확定②) — pipelineStage=null이면 게이지/스테퍼 대신 정직한
+              "파이프라인 범위 밖" 표시(합성 stage 금지, #2933 H1 조건②). */}
+          {pipelineStage
+            ? (bentoLayout ? <ConfidenceGauge stage={pipelineStage} /> : <PipelineStepper stage={pipelineStage} />)
+            : <p className="text-[11px] font-semibold text-proof-ink-3" data-testid="workcell-out-of-pipeline">{t('outOfPipeline')}</p>}
           <span className="text-[17px] font-bold leading-tight tracking-[-0.012em] text-proof-ink">{title}</span>
           {/* story #2922 W4 — 책임자/실행자를 헤더로 승격("10초 리트머스": 스크롤 없이 «누가»가
               보임). #3339(2921 아바타 단일통합)가 ProofAvatar를 폐기·Avatar로 수렴시켰다 —
               여기도 그 정본을 그대로 소비(신규 변형 0). Brief 구획의 중복 표기는 제거(SSOT=
-              헤더 이 한 자리). */}
+              헤더 이 한 자리). story #2993(PO 확定①) — owner=null(에이전트 단독배정)이면
+              지어내지 않고 "책임자 미지정" 정직 표시(muted). */}
           <div className="mt-2 flex flex-wrap items-center gap-3.5 text-[11px] text-proof-ink-3">
             <span className="inline-flex items-center gap-1.5">
-              <Avatar name={brief.owner.name} actorType="human" size={18} />
-              {t('briefOwner')} {brief.owner.name}
+              {brief.owner ? (
+                <>
+                  <Avatar name={brief.owner.name} actorType="human" size={18} />
+                  {t('briefOwner')} {brief.owner.name}
+                </>
+              ) : (
+                <span className="text-proof-faint">{t('ownerUnassigned')}</span>
+              )}
             </span>
             {brief.agent ? (
               <span className="inline-flex items-center gap-1.5">

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -261,7 +261,10 @@ export function Workcell({ title, pipelineStage, brief, run, evidence, conversat
                   {t('briefOwner')} {brief.owner.name}
                 </>
               ) : (
-                <span className="text-proof-faint">{t('ownerUnassigned')}</span>
+                // story #2993 — 유나 design 판정(2026-08-24): text-proof-faint는 라이트 대비
+                // ~2.72(AA 미달)+"조용히 소실"이라 지정을 촉진 못 함. text-proof-ink-3(4.9)로
+                // 상향 — 읽히되 과하지 않은 muted.
+                <span className="text-proof-ink-3">{t('ownerUnassigned')}</span>
               )}
             </span>
             {brief.agent ? (


### PR DESCRIPTION
## 요약
선생님 실사고 「Workcell이 실사용 동선에서 안 보인다」. PO 지시대로 구현 전 그라운딩(원인 실측·PO 초기 가설 판정)을 먼저 채팅으로 보고·승인받은 뒤 착수.

## 그라운딩 요지 (채팅 기록 참조)
`story-detail-panel.tsx`의 舊 `{pipelineStage && proofHuman ? (...) : null}`가 두 독립 게이트였다:
- `pipelineStage=null`: `status==='done'`일 때 BE `derive_trust_stage()`가 **의도적으로** 반환하는 값(`trust_pipeline.py` §7 확定④ — "파이프라인 스코프 밖", 데이터 누락 아님).
- `proofHuman=null`: `assigneeIds` 중 human 타입이 하나도 없을 때(에이전트 단독배정 스토리 전부).

PO 초기 가설("null이면 2922 매핑표 원안으로 폴백")은 **#2933 H1 PO 조건②(로컬 재파생 폴백 금지, 커밋 315d4a426 명문)**와 **§7 확定④(done=의도적 스코프 밖)** 둘 다와 충돌해 기각.

## PO 확定 처방
1. **proofHuman 게이트 완화** — 에이전트 단독배정에도 Workcell 렌더, 책임자 슬롯은 "책임자 미지정"(muted) 정직 표시. 폴백 우선순위: `human_owner_member_id`(P0-03, BE가 이미 배선했으나 FE가 소비한 적 없었음) → `human_verified_by` → `assigneeIds` 중 human. `memberMap`에 실제 resolve된 경우만 채택.
2. **pipelineStage=null(done)** — 합성 stage 금지, "완료 — 신뢰 파이프라인 범위 밖" 정직 표시.
3. `human_owner_member_id`는 실데이터 있을 때만 우선 채택(추정 금지).
4. "휴먼 책임자 배정 규율"(제품 축)은 이번 PR 범위 밖 — PO가 별도 처리.

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4304 tests all green (workcell.test.tsx 4건 + story-detail-panel.test.tsx 4건 신규)
- [x] `pnpm build` green
- [x] puppeteer 라이브 픽셀 — 두 빈 상태(파이프라인 밖·책임자 미지정) 동시 발생 케이스 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA