### PR TITLE
feat(#1715): merge gate 해소 시 상신자 알림 — 승인돼도 requester가 모르는 갭

### DIFF
--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -462,6 +462,22 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
         DeepLinkManifestEntry(
+            # story #1715(카디르 QA, PR#3428) — merge gate(work_item_type="story") 해소
+            # 결과가 상신자(participation.member_id)에게 회신되는 벨 알림. doc_approval_
+            # resolved/agent_decision_resolved와 완전 동형(dispatch_approval_result_reply
+            # 파라미터화 재사용, gate 경유·reference_id=gate_id·읽기전용 FYI) — 착지 화면도
+            # 그 둘과 같은 gate_detail(스토리 상세가 아니라 게이트 문맥 그대로, 기존 관례).
+            app=DeepLinkAppFields(
+                type="merge_gate_resolved", target="gate_detail", parent_tab=ParentTab.approvals,
+                target_promotion_pending=True,
+            ),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+        DeepLinkManifestEntry(
             # story #2631: 「보류(논의 필요)」 요청이 doc 결재 상신자에게 회신되는 벨 알림 —
             # doc_approval_resolved와 동형(gate 경유·reference_id=gate_id)이나 게이트가 아직
             # 결정 안 나고 pending인 채로 "3안 논의 요청"을 받은 것이라, 결재자가 그 카드로

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -809,6 +809,15 @@ async def transition_gate(
         except Exception:  # noqa: BLE001 — best-effort, 실시간 반영 실패가 게이트 해소를 막지 않음.
             logger.warning("gate_resolved 카드 실시간 반영 배선 실패 gate=%s", gate.id, exc_info=True)
 
+    # story #1715(PO 판정 2026-08-24) — 상신자(requested_by_member_id) 회신은 gate_type/
+    # line-bound 분기와 무관하게 **이 한 자리에서만** 부른다(아래 if/else 갈리기 전) — 두
+    # 경로 양쪽에 각자 호출을 심으면 "구조적으로 배타적"이라는 주장이 코드 두 곳의 일치에
+    # 의존하게 된다(다음 사람이 한쪽만 고치면 조용히 깨지는 자리). 단일 호출점이면 이중발송
+    # 자체가 원리적으로 불가능 — _notify_doc_gate_requester 내부가 gate_type 스위치가 아니라
+    # neutral_facts.requested_by_member_id **유무**로 자기 자신을 게이트한다(PO 지적 — 판별축
+    # 정정: gate_type이 아니라 "상신자가 실제로 있는가"가 맞는 축).
+    await _notify_doc_gate_requester(session, gate, new_status)
+
     # E-DG S6: gate 전이를 범용 line resolution 에 배선. gate 에 묶인 active line step_run 이 있으면
     # apply_workflow_line_resolution(H1/line approve 동일 status side-effect 경로)·없으면 legacy
     # _advance_story_on_merge_approve 유지(무회귀). 신규 승인경로 0.
@@ -840,10 +849,9 @@ async def transition_gate(
         # 조건부로 재배선할 단일 idempotent 헬퍼로 의도적으로 남겨둔다.
         # E-DG doc-gate(48f064e5): doc 결재 게이트 approve→confirmed·reject→denied.
         await _resolve_doc_gate(session, gate, new_status)
-        # story #2624: 해소 결과를 상신자에게 회신(approval_delivery.py 반대 방향) — 선생님
-        # 직접 지적(폴링해야만 반려를 알던 실사례). doc.status 변경 후 호출돼도 무방(회신
-        # 내용은 gate 필드에서만 유도).
-        await _notify_doc_gate_requester(session, gate, new_status)
+        # story #2624 — 상신자 회신은 이제 이 if/else 진입 前 단일 호출점(위 story #1715 주석
+        # 참조)에서 이미 처리됨. doc.status 변경 순서와 무관(회신 내용은 gate 필드에서만
+        # 유도 — _notify_doc_gate_requester가 아래서 다시 안 불림, 여기 있던 호출 제거).
         # E-CANVAS C4-S8(story a5118cb0): 정본화 게이트 approve→anchor_version set·reject→재논의 코멘트.
         await _resolve_artifact_canonicalize_gate(session, gate, new_status)
         # HITL crux(story 7726a003) — A2A task INPUT_REQUIRED 복귀. writer 미배선이라 오늘은 no-op.
@@ -1322,6 +1330,7 @@ async def _notify_doc_gate_requester(session: AsyncSession, gate: Gate, new_stat
     격리하지만, requester_id 파싱 등 그 앞 단계도 안전해야 한다)."""
     try:
         from app.services.doc import DOC_GATE_TYPE, DOC_GATE_WORK_ITEM_TYPE
+        from app.services.merge_verdict_gate import MERGE_GATE_TYPE
         if new_status not in ("approved", "rejected") or gate.resolver_id is None:
             return
 
@@ -1362,6 +1371,25 @@ async def _notify_doc_gate_requester(session: AsyncSession, gate: Gate, new_stat
                 requester_id=requester_id, resolver_id=gate.resolver_id,
                 decision=new_status, resolution_note=gate.resolution_note,
                 event_type="agent_decision_resolved",
+            )
+        elif gate.gate_type == MERGE_GATE_TYPE:
+            # story #1715(PO 판정 2026-08-24) — merge gate(work_item_type="story")도 상신자
+            # 회신 대상에 편입. requested_by_member_id는 evaluate_merge_gate()가 이미 계산해
+            # 두던 participation.member_id(누가 실작업했는지)를 neutral_facts에 stash만 추가한
+            # 것(merge_verdict_gate.py) — 새 식별 로직 0.
+            from app.models.pm import Story
+            story_title = (await session.execute(
+                select(Story.title).where(Story.id == gate.work_item_id, Story.org_id == gate.org_id)
+            )).scalar_one_or_none() or f"#{str(gate.work_item_id)[:8]}"
+            project_id = await resolve_work_item_project_id(session, gate.org_id, "story", gate.work_item_id)
+            if not project_id:
+                return
+            await dispatch_approval_result_reply(
+                session, org_id=gate.org_id, work_item_type="story", work_item_id=gate.work_item_id,
+                project_id=project_id, title=story_title, gate_id=gate.id,
+                requester_id=requester_id, resolver_id=gate.resolver_id,
+                decision=new_status, resolution_note=gate.resolution_note,
+                event_type="merge_gate_resolved",
             )
     except Exception:  # noqa: BLE001 — best-effort, 회신 실패가 게이트 해소를 막지 않는다.
         logger.warning(

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -422,6 +422,12 @@ async def evaluate_merge_gate(
 
     # 3. 정책 disposition 아티팩트 gate row(Cage·AC⑥). create_gate가 disposition→status 설정·멱등.
     facts = {
+        # story #1715(PO 판정 2026-08-24) — 상신자 해소 회신(gate_service.py::
+        # _notify_doc_gate_requester)용 stash. 새 식별 로직 0 — member_id는 이 함수가 이미
+        # participation.member_id(누가 실작업했는지)로 계산해 create_gate()의 정책판정에
+        # 쓰던 그 값 그대로, doc.py의 동명 필드와 같은 계약(neutral_facts에 저장해두면 해소
+        # 시점에 그 값으로 회신 대상을 찾는다).
+        "requested_by_member_id": str(member_id),
         "ci_result": ci,
         "pr_result": pr,
         # HO-S6(AC⑥): 신뢰 근거 = 가설 적중 이력(CI clean-pass 아님). 명시 노출.

--- a/backend/tests/test_1715_merge_gate_requester_notify_realdb.py
+++ b/backend/tests/test_1715_merge_gate_requester_notify_realdb.py
@@ -1,0 +1,169 @@
+"""story #1715(PO 판정 2026-08-24) — merge gate 해소(승인/반려) 시 상신자(requested_by_
+member_id=participation.member_id, evaluate_merge_gate가 이미 계산해두던 값 stash) 회신.
+기존 doc/agent_decision_request 전용이던 _notify_doc_gate_requester를 gate_type 스위치가
+아니라 requested_by_member_id **유무**로 게이팅하도록 정정 + 호출점을 transition_gate의
+if/else(line-bound·else) 분기 이전 단일 자리로 옮겨(이중발송 구조적 불가) merge gate까지
+편입한다.
+
+핵심 검증축: ①merge gate 해소가 dispatch_approval_result_reply를 실제로 태워 상신자 DM에
+회신 메시지가 실제로 남는지(end-to-end) ②self-resolve(해소자==상신자) 억제(PO ⓑ)
+③_notify_doc_gate_requester가 transition_gate 안에서 정확히 1곳에서만 불려 line-bound·
+else 두 경로가 구조적으로 이중발송 불가능함(PO ⓐ). 로컬 PG 미설정 시 skip(CI 관례 동일)."""
+from __future__ import annotations
+
+import inspect
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — #2662: app.models 벌크 import 밖(create_all 전 명시 필요).
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org1715", slug=f"org1715-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_human(session, org_id, project_id, *, name="member"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="human",
+        name=name, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="머지 대상 스토리"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="in-review")
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _seed_merge_gate(session, org_id, story_id, *, requested_by_member_id):
+    from app.models.gate import Gate
+
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+        gate_type="merge", status="pending",
+        neutral_facts={"requested_by_member_id": str(requested_by_member_id)},
+    )
+    session.add(gate)
+    await session.commit()
+    return gate
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_merge_gate_resolve_notifies_requester_end_to_end():
+    from app.services.gate_service import transition_gate
+    from app.models.conversation import ConversationMessage
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_human(s, org_id, project_id, name="implementer")
+            resolver_id = await _seed_human(s, org_id, project_id, name="reviewer")
+            story = await _seed_story(s, org_id, project_id)
+            gate = await _seed_merge_gate(s, org_id, story.id, requested_by_member_id=requester_id)
+
+        async with Session() as s:
+            await transition_gate(s, org_id, gate.id, "approved", resolver_id, "LGTM")
+            await s.commit()
+
+        async with Session() as s:
+            msgs = (await s.execute(
+                select(ConversationMessage).where(
+                    ConversationMessage.msg_metadata["approval_target"]["gate_id"].astext == str(gate.id),
+                )
+            )).scalars().all()
+            result_msgs = [m for m in msgs if m.msg_metadata.get("activation", {}).get("kind") == "result"]
+            assert len(result_msgs) == 1
+            assert requester_id in [uuid.UUID(str(x)) for x in (result_msgs[0].mentioned_ids or [])]
+            assert result_msgs[0].msg_metadata["approval_target"]["decision"] == "approved"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_merge_gate_self_resolve_skips_notification():
+    """PO ⓑ — 해소자==상신자면 자기 알림은 무의미하다(dispatch_approval_result_reply
+    기존 가드 재사용, merge 경로도 우회 없이 동일하게 억제되는지 end-to-end 확認)."""
+    from app.services.gate_service import transition_gate
+    from app.models.conversation import ConversationMessage
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            same_person_id = await _seed_human(s, org_id, project_id, name="solo-implementer-reviewer")
+            story = await _seed_story(s, org_id, project_id)
+            gate = await _seed_merge_gate(s, org_id, story.id, requested_by_member_id=same_person_id)
+
+        async with Session() as s:
+            await transition_gate(s, org_id, gate.id, "approved", same_person_id, None)
+            await s.commit()
+
+        async with Session() as s:
+            msgs = (await s.execute(
+                select(ConversationMessage).where(
+                    ConversationMessage.msg_metadata["approval_target"]["gate_id"].astext == str(gate.id),
+                )
+            )).scalars().all()
+            result_msgs = [m for m in msgs if m.msg_metadata.get("activation", {}).get("kind") == "result"]
+            assert result_msgs == []
+    finally:
+        await engine.dispose()
+
+
+def test_notify_doc_gate_requester_has_exactly_one_call_site_in_transition_gate():
+    """PO ⓐ — 두 해소 경로(line-bound·else)가 각자 알림을 심으면 "구조적으로 배타적"이라는
+    주장이 두 코드 위치의 일치에 의존하게 된다(누가 한쪽만 고치면 조용히 깨지는 자리). 이
+    소스 검사가 그 구조를 직접 고정한다 — if/else 분기가 갈리기 前 단일 호출점이어야
+    이중발송이 원리적으로 불가능."""
+    from app.services.gate_service import transition_gate
+
+    source = inspect.getsource(transition_gate)
+    assert source.count("_notify_doc_gate_requester(") == 1

--- a/backend/tests/test_2624_gate_requester_reply_gating.py
+++ b/backend/tests/test_2624_gate_requester_reply_gating.py
@@ -35,9 +35,12 @@ def _gate(**overrides):
 
 
 @pytest.mark.anyio
-async def test_non_doc_gate_is_noop_zero_db_calls():
+async def test_unhandled_gate_type_is_noop_zero_db_calls():
+    """story #1715 — merge(gate_type="merge")는 이제 처리 대상이라(아래
+    test_merge_gate_calls_delivery_with_correct_args) 이 no-op 표본을 pr_review로 교체한다
+    (아직 미처리인 다른 gate_type — doc_approval/agent_decision_request/merge 3종 밖)."""
     session = AsyncMock()
-    gate = _gate(work_item_type="story", gate_type="merge")
+    gate = _gate(work_item_type="story", gate_type="pr_review")
     await _notify_doc_gate_requester(session, gate, "approved")
     session.execute.assert_not_called()
 
@@ -112,6 +115,54 @@ async def test_valid_gate_calls_delivery_with_correct_args():
     assert kw["resolver_id"] == gate.resolver_id
     assert kw["decision"] == "rejected"
     assert kw["resolution_note"] == "사유"
+
+
+@pytest.mark.anyio
+async def test_merge_gate_calls_delivery_with_correct_args():
+    """story #1715 — merge gate(work_item_type="story")도 상신자 회신 대상. requested_by_
+    member_id는 evaluate_merge_gate()가 stash한 participation.member_id(신규 로직 0)."""
+    session = AsyncMock()
+    story_title_result = AsyncMock()
+    story_title_result.scalar_one_or_none = lambda: "머지 대상 스토리"
+    session.execute = AsyncMock(return_value=story_title_result)
+
+    requester_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    gate = _gate(
+        work_item_type="story", gate_type="merge",
+        neutral_facts={"requested_by_member_id": str(requester_id)},
+    )
+
+    with patch("app.services.approval_delivery.dispatch_approval_result_reply", new=AsyncMock()) as mock_dispatch, \
+         patch("app.services.gate_service.resolve_work_item_project_id", new=AsyncMock(return_value=project_id)):
+        await _notify_doc_gate_requester(session, gate, "approved")
+
+    mock_dispatch.assert_awaited_once()
+    kw = mock_dispatch.await_args.kwargs
+    assert kw["org_id"] == gate.org_id
+    assert kw["work_item_type"] == "story"
+    assert kw["work_item_id"] == gate.work_item_id
+    assert kw["project_id"] == project_id
+    assert kw["title"] == "머지 대상 스토리"
+    assert kw["gate_id"] == gate.id
+    assert kw["requester_id"] == requester_id
+    assert kw["resolver_id"] == gate.resolver_id
+    assert kw["decision"] == "approved"
+    assert kw["event_type"] == "merge_gate_resolved"
+
+
+@pytest.mark.anyio
+async def test_merge_gate_no_project_id_is_noop_no_delivery_call():
+    session = AsyncMock()
+    story_title_result = AsyncMock()
+    story_title_result.scalar_one_or_none = lambda: "제목"
+    session.execute = AsyncMock(return_value=story_title_result)
+    gate = _gate(work_item_type="story", gate_type="merge")
+
+    with patch("app.services.approval_delivery.dispatch_approval_result_reply", new=AsyncMock()) as mock_dispatch, \
+         patch("app.services.gate_service.resolve_work_item_project_id", new=AsyncMock(return_value=None)):
+        await _notify_doc_gate_requester(session, gate, "approved")
+    mock_dispatch.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_deeplink_manifest_contract.py
+++ b/backend/tests/test_deeplink_manifest_contract.py
@@ -88,7 +88,7 @@ def test_conversation_mention_lands_in_chat_tab():
     assert entry.app.parent_tab == ParentTab.chat
 
 
-def test_manifest_covers_all_29_dispatch_notification_event_types():
+def test_manifest_covers_all_30_dispatch_notification_event_types():
     """AC1 회귀 고정: story #1951 GATE1 전수 조사에서 확인한 dispatch_notification()
     event_type 리터럴이 전부 등재돼 있어야 한다. 새 알림 타입이 코드에 추가되고
     이 집합이 갱신 안 되면 이 테스트가 알려준다(양방향 대조 — 매니페스트 초과분도 잡음).
@@ -96,7 +96,8 @@ def test_manifest_covers_all_29_dispatch_notification_event_types():
     story #2624: doc_approval_resolved 신설로 25→26.
     story #2630: conversation.circuit_breaker_opened 신설로 26→27.
     story #2631: doc_approval_discussion_requested 신설로 27→28.
-    story #2709: agent_decision_resolved 신설로 28→29."""
+    story #2709: agent_decision_resolved 신설로 28→29.
+    story #1715: merge_gate_resolved 신설로 29→30."""
     expected = {
         "sprint_closed", "task_completed", "story_assigned", "comment.created",
         "artifact.created", "artifact.exported", "artifact.updated", "artifact.canonicalized",
@@ -106,7 +107,7 @@ def test_manifest_covers_all_29_dispatch_notification_event_types():
         "doc_approval_requested", "handoff_fallback", "story_status_changed",
         "conversation.unsupervised_chain_expired", "doc_approval_resolved",
         "conversation.circuit_breaker_opened", "doc_approval_discussion_requested",
-        "agent_decision_resolved",
+        "agent_decision_resolved", "merge_gate_resolved",
     }
     actual = {e.app.type for e in DEEPLINK_MANIFEST.entries}
     missing = expected - actual

--- a/backend/tests/test_deeplink_manifest_endpoint.py
+++ b/backend/tests/test_deeplink_manifest_endpoint.py
@@ -50,7 +50,8 @@ async def test_deeplink_manifest_endpoint_returns_200_with_schema_version_and_lo
     # story #2630: conversation.circuit_breaker_opened 신설로 35→36.
     # story #2631: doc_approval_discussion_requested 신설로 36→37.
     # story #2709: agent_decision_resolved 신설로 37→38.
-    assert isinstance(body["entries"], list) and len(body["entries"]) == 38
+    # story #1715: merge_gate_resolved 신설로 38→39.
+    assert isinstance(body["entries"], list) and len(body["entries"]) == 39
 
     # 미르코 point ②: lookup_key = f"{type}:{entity_type}" (구분자 ":") 서빙 시점 파생.
     story_entry = next(


### PR DESCRIPTION
## Summary
[SID:1715]

선생님 지적(2026-07-08) — 상신 시 결재자 알림은 있는데 해소→상신자 회신이 없어 승인해도 상신자가 모름. 그라운딩(2026-08-24)으로 확認: `doc_approval`/`agent_decision_request`는 #2624/#2709로 이미 해소됨 — 실 남은 갭은 line-bound 게이트(merge gate 포함)가 `apply_workflow_line_resolution` 경로를 타면서 상신자 회신 코드가 아예 0인 것.

### 변경
- `merge_verdict_gate.py` — `facts`에 `requested_by_member_id` 추가. `evaluate_merge_gate()`가 이미 계산해두던 `participation.member_id`(누가 실작업했는지)를 stash만 함(신규 식별 로직 0, doc.py와 동일 계약)
- `_notify_doc_gate_requester` 판별축 정정 — gate_type 스위치가 아니라 `neutral_facts.requested_by_member_id` **유무**로 자기 자신을 게이팅(PO 지적: 잘못된 축이 gate_type이었다). merge gate_type 분기 신설(Story title+`resolve_work_item_project_id` 조회)
- **ⓐ 하드닝** — 호출점을 `transition_gate`의 if/else(line-bound·else) 분기 **이전 단일 자리**로 이동. 두 경로가 각자 알림을 심으면 "구조적 배타성"이 코드 두 곳의 일치에 의존하게 되는 자리라, 단일 호출점으로 이중발송을 원리적으로 불가능하게 만듦 — 소스 검사 테스트(`inspect.getsource` 호출 횟수==1)로 고정
- **ⓑ 하드닝** — self-resolve(해소자==상신자) 억제. `dispatch_approval_result_reply`의 기존 가드(`resolver_id==requester_id` 시 no-op)를 그대로 재사용(신규 로직 0) — merge 경로에서도 end-to-end로 억제되는지 확認

## Test plan
- [x] 신규 realdb 테스트 3건(`test_1715_merge_gate_requester_notify_realdb.py`) — 해소→상신자 실회신 end-to-end(ⓐ 검증) · self-resolve 억제(ⓑ 검증) · 단일 호출점 소스검사
- [x] 기존 gating 테스트(`test_2624_gate_requester_reply_gating.py`) 갱신 — merge no-op 표본을 여전히 미처리인 `pr_review`로 교체 + merge 양성/음성(project_id 없음) 2건 추가
- [x] 기존 gate/doc/decision 관련 backend 테스트(2624·2709·2891·373cfaa1·edg_doc_gate_inbox·h1_s7·e_cage_referee_p3·gate_transition_human_only·rc1_body_trust_actor·merge_gate_reject_resubmit_reopen·merge_verdict_gate·h1_fix2·h1_s10_e2e·edg_s31/32/33) 개별 재실행, 회귀 없음 확認(cross-file 오염 아티팩트는 격리 재확認)
- [ ] CI green 확인 대기
- [ ] 라이브 실증(AC2) — doc 상신→승인→상신자 실수신은 기존 #2624 경로로 이미 실증됨. merge gate 경로는 결제 재테스트 인터럽트 이후 여유 생기면 라이브 왕복 예정(PO 지시로 #2985 라이브 도장과 겸할 수 있으면 겸함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AbjN7dJp11Nng4AVZY3Xw