### PR TITLE
[SID:2993] 로드맵 PR-A(story-card) 좁은판 — L1/L5

### DIFF
--- a/apps/web/src/components/kanban/story-card.test.tsx
+++ b/apps/web/src/components/kanban/story-card.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import { DndContext } from '@dnd-kit/core';
+import koMessages from '../../../messages/ko.json';
+import { StoryCard } from './story-card';
+import type { KanbanStory, KanbanMember } from './types';
+
+function makeStory(overrides: Partial<KanbanStory> = {}): KanbanStory {
+  return {
+    id: 's1', story_number: 1, title: 'Story', status: 'in-progress', priority: 'medium',
+    story_points: null, assignee_id: null, epic_id: null, sprint_id: null,
+    description: null, acceptance_criteria: null, attachments: null, position: null,
+    success_hypothesis: null, metric_definition: null, measure_after: null,
+    outcome_status: 'n_a', outcome_result: null,
+    ...overrides,
+  };
+}
+
+function render(story: KanbanStory, assignees: KanbanMember[] = []) {
+  return renderToStaticMarkup(
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <DndContext>
+        <StoryCard story={story} assignees={assignees} onClick={() => {}} />
+      </DndContext>
+    </NextIntlClientProvider>,
+  );
+}
+
+// story #2993 로드맵 PR-A(L1) — 컨텍스트/상태 서브메뉴 floating 팝업은 --elev-overlay
+// 토큰이어야 한다(L1: overlay=floating 전용). shadow-md 리터럴 회귀가드.
+describe('StoryCard — 로드맵 PR-A L1(floating 팝업 elev-overlay)', () => {
+  it('상시 마크업에 shadow-md 리터럴이 없다(컨텍스트메뉴는 열렸을 때만 렌더되므로 정적 렌더로는 부재 확인)', () => {
+    const markup = render(makeStory());
+    expect(markup).not.toContain('shadow-md');
+  });
+});
+
+// story #2993 로드맵 PR-A(L5) — agent 정적 아바타 테두리는 citron(live pulse 전용)이 아니라
+// proof-blue(정체성 마킹, avatar.tsx idle 링과 정합)여야 한다.
+describe('StoryCard — 로드맵 PR-A L5(agent 아바타 정적 identity=proof-blue)', () => {
+  it('agent assignee 아바타가 border-proof-blue/bg-proof-blue-soft를 쓰고 citron은 안 쓴다', () => {
+    const markup = render(makeStory(), [{ id: 'a1', name: '에이전트군', type: 'agent' }]);
+    expect(markup).toContain('border-proof-blue/30');
+    expect(markup).toContain('bg-proof-blue-soft');
+    expect(markup).not.toContain('border-accent-claim');
+    expect(markup).not.toContain('bg-accent-claim/10');
+  });
+
+  it('human assignee 아바타는 무변화(border-border/bg-muted 그대로)', () => {
+    const markup = render(makeStory(), [{ id: 'h1', name: '책임자', type: 'human' }]);
+    expect(markup).toContain('border-border');
+    expect(markup).toContain('bg-muted');
+  });
+});

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -356,9 +356,11 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                     {assigneeList.slice(0, 3).map((m) => (
                       <div
                         key={m.id}
+                        // story #2993 로드맵 PR-A(L5) — 정적(비-pulse) agent 정체성 마킹은
+                        // proof-blue(avatar.tsx idle 링과 정합) — citron은 live pulse(실행) 전용.
                         className={`relative flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-medium ring-1 ring-background ${
                           m.type === 'agent'
-                            ? 'border-accent-claim/30 bg-accent-claim/10 text-foreground'
+                            ? 'border-proof-blue/30 bg-proof-blue-soft text-foreground'
                             : 'border-border bg-muted text-muted-foreground'
                         }`}
                         title={m.name}
@@ -448,7 +450,8 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
         <div
           ref={menuRef}
           style={{ position: 'fixed', top: menuPos.top, left: menuPos.left, width: MENU_WIDTH }}
-          className="z-50 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+          // story #2993 로드맵 PR-A(L1) — floating 팝업은 --elev-overlay(오버레이 전용) 토큰으로.
+          className="z-50 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-[var(--elev-overlay)]"
           onClick={(e) => e.stopPropagation()}
         >
           {onEdit && (
@@ -479,7 +482,8 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                 <div
                   ref={statusMenuRef}
                   style={{ position: 'fixed', top: statusMenuPos.top, left: statusMenuPos.left, width: MENU_WIDTH }}
-                  className="z-50 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+                  // story #2993 로드맵 PR-A(L1) — floating 팝업은 --elev-overlay(오버레이 전용) 토큰으로.
+          className="z-50 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-[var(--elev-overlay)]"
                   onClick={(e) => e.stopPropagation()}
                 >
                   {statuses.map((status) => (


### PR DESCRIPTION
## 요약
P0 규칙서(37ac93b6) + 로드맵(983a4cd0) 그라운딩 후 PO 확定. 컷코너(CutCornerShell) 퇴역은 별건([d6bf75bb](entity:story:d6bf75bb-4bd0-446c-9114-d1822df35b51))으로 분리, 이번 판은 좁게 L1/L5만.

1. **L1** — 컨텍스트메뉴/상태서브메뉴 floating 팝업의 `shadow-md`(raw literal) → `shadow-[var(--elev-overlay)]`. floating=overlay 카테고리가 맞는 자리.
2. **L5** — agent assignee 아바타 테두리(정적, live pulse 아님) `border-accent-claim`(citron) → `border-proof-blue`/`bg-proof-blue-soft`. citron은 규칙서상 live pulse(실행) 전용, 정적 정체성 마킹은 proof-blue 몫(`avatar.tsx` idle 링과 정합).

이미 준수 확인된 항목(EPIC_DOT_CLASSES·STATUS_TO_PROOF_STATE·info dot·text-accent-claim→text-foreground)은 무변경.

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4316 tests all green (신규 `story-card.test.tsx` 3건)
- [x] `pnpm build` green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA