### PR TITLE
[SID:2997] SSE 연결끊김 배너 고착 fix — connected 반응형 컨텍스트

### DIFF
--- a/apps/web/src/components/realtime-provider.tsx
+++ b/apps/web/src/components/realtime-provider.tsx
@@ -17,6 +17,23 @@ export function useSseMultiplexerContext(): SseMultiplexerHandle | null {
   return useContext(SseMultiplexerContext);
 }
 
+// story 6ddaa086(선생님 실사고, critical) — SseMultiplexerHandle은 의도적으로 참조가
+// 안정적이다(connected가 토글돼도 핸들 자체는 그대로 — sse-multiplexer.ts 주석 참고,
+// 소비처의 재구독 churn 방지). 그런데 그 안정성이 바로 배너 버그의 원인이었다: Context.
+// Provider는 value의 "참조"가 안 바뀌면 소비자를 리렌더시키지 않는다 — multiplexer 핸들이
+// 안정 참조인 이상 connected가 실제로 토글돼도(getter 뒤 값은 바뀜) chat-view의
+// useChatSse가 그 변화를 리렌더로 못 받아, 다음 «무관한» 리렌더(새 메시지 등)가 우연히
+// 올 때까지 배너가 옛 값에 고정됐다(readyState=1인데 배너만 남는 그 증상). connected
+// 전용의 별도 원시값 컨텍스트를 둬 — 이건 매 토글마다 값(boolean) 자체가 달라지므로
+// Provider가 정상적으로 소비자를 리렌더시킨다.
+const SseConnectedContext = createContext<boolean>(false);
+
+/** connected 전용 반응형 컨텍스트 — SseMultiplexerHandle과 달리 매 토글마다 실제로
+ * 리렌더를 유발한다. 연결 상태에 반응해야 하는 소비처(예: 끊김 배너)는 이걸 쓴다. */
+export function useSseConnectedContext(): boolean {
+  return useContext(SseConnectedContext);
+}
+
 interface RealtimeProviderProps {
   currentTeamMemberId?: string;
   children: React.ReactNode;
@@ -29,8 +46,10 @@ export function RealtimeProvider({ currentTeamMemberId, children }: RealtimeProv
 
   return (
     <SseMultiplexerContext.Provider value={SSE_MULTIPLEX_ENABLED ? multiplexer : null}>
-      {children}
-      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+      <SseConnectedContext.Provider value={SSE_MULTIPLEX_ENABLED ? multiplexer.connected : false}>
+        {children}
+        <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+      </SseConnectedContext.Provider>
     </SseMultiplexerContext.Provider>
   );
 }

--- a/apps/web/src/hooks/use-chat-sse.test.tsx
+++ b/apps/web/src/hooks/use-chat-sse.test.tsx
@@ -4,7 +4,7 @@
 // 오염 방지 회귀가드. Provider 없이 렌더하면 useSseMultiplexerContext()가 null을 반환해
 // 독립 EventSource 폴백 분기를 타는 것을 이용한다(SseMultiplexerContext 기본값 null).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act } from 'react';
+import { act, useEffect } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { useChatSse, normalizeToMessage } from './use-chat-sse';
 
@@ -269,5 +269,88 @@ describe('useChatSse — 가시성 복귀 강제 재연결(#2987, standalone-fal
     act(() => { FakeEventSource.instances[1]!.onopen?.(); });
 
     expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+});
+
+// story 6ddaa086(critical, 선생님 실사고) — 「연결이 끊겼어요」 배너가 실 연결(readyState=1
+// OPEN) 정상 도달 뒤에도 안 풀리던 결함. 근본원인: mux 핸들(sse-multiplexer.ts)이 #2144
+// 처방으로 참조안정적인데, chat-view의 배너는 mux.connected를 getter로 직접 읽어 그 값이
+// 바뀌어도 리렌더를 못 받았다(핸들 참조=Context 값이 안 바뀌므로 Provider가 소비자를
+// 스킵). realtime-provider.tsx에 connected 전용 반응형 컨텍스트(SseConnectedContext)를
+// 신설해 분리 — mux 핸들 자체의 참조안정성(#2144 보존)과 connected 리렌더 반응성을 둘 다
+// 만족시킨다. use-team-presence.test.tsx #2144 스위트와 동일한 vi.stubEnv+resetModules+
+// 동적 import 패턴(mux 공유 커넥션 경로 재현에 필수).
+describe('useChatSse — mux 공유 커넥션 경로에서 connected 리렌더 반응성(story 6ddaa086)', () => {
+  afterEach(() => { vi.resetModules(); });
+
+  it('mux 최초 open(false→true)이 이 훅을 리렌더시켜 connected=true를 즉시 반영한다', async () => {
+    vi.resetModules();
+    vi.stubEnv('NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED', 'true');
+    const { RealtimeProvider } = await import('@/components/realtime-provider');
+    const { useChatSse: useChatSseFresh } = await import('./use-chat-sse');
+
+    const connectedCapture = { current: false };
+    function Consumer() {
+      const { connected } = useChatSseFresh({ currentTeamMemberId: 'm1' });
+      useEffect(() => { connectedCapture.current = connected; }, [connected]);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <RealtimeProvider currentTeamMemberId="m1">
+          <Consumer />
+        </RealtimeProvider>,
+      );
+      await Promise.resolve();
+    });
+    expect(connectedCapture.current).toBe(false);
+
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => { es.onopen?.(); await Promise.resolve(); });
+
+    // 옛 버그: mux 핸들 참조가 안 바뀌어 Consumer가 리렌더 안 되고 connectedCapture가 false에
+    // 고착됐다(PO 실측 — readyState=1인데 배너만 남는 그 증상). 고친 뒤엔 이 open 자체가
+    // 곧바로 리렌더를 유발해 true로 반영된다 — 다른 무관한 트리거(새 메시지 등) 불필요.
+    expect(connectedCapture.current).toBe(true);
+  });
+
+  it('재연결(error→새 인스턴스 open)에서도 다른 무관한 리렌더 없이 connected가 다시 true로 풀린다(PO 재현 시나리오)', async () => {
+    vi.resetModules();
+    vi.stubEnv('NEXT_PUBLIC_SSE_MULTIPLEX_ENABLED', 'true');
+    const { RealtimeProvider } = await import('@/components/realtime-provider');
+    const { useChatSse: useChatSseFresh } = await import('./use-chat-sse');
+
+    const connectedCapture = { current: false };
+    function Consumer() {
+      const { connected } = useChatSseFresh({ currentTeamMemberId: 'm1' });
+      useEffect(() => { connectedCapture.current = connected; }, [connected]);
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <RealtimeProvider currentTeamMemberId="m1">
+          <Consumer />
+        </RealtimeProvider>,
+      );
+      await Promise.resolve();
+    });
+    const first = FakeEventSource.instances[0]!;
+    await act(async () => { first.onopen?.(); await Promise.resolve(); });
+    expect(connectedCapture.current).toBe(true);
+
+    // 끊김 — PO 실측대로 배너가 뜨는 쪽(정상 동작).
+    await act(async () => { first.readyState = FakeEventSource.CONNECTING; first.onerror?.(); await Promise.resolve(); });
+    expect(connectedCapture.current).toBe(false);
+
+    // 재연결 — 새 EventSource 인스턴스가 open(신규 인스턴스라는 게 PO 가설①의 핵심 축).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000); // backoff 재시도 대기
+      const second = FakeEventSource.instances[FakeEventSource.instances.length - 1]!;
+      second.onopen?.();
+      await Promise.resolve();
+    });
+    expect(connectedCapture.current).toBe(true);
   });
 });

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { useSseMultiplexerContext } from '@/components/realtime-provider';
+import { useSseMultiplexerContext, useSseConnectedContext } from '@/components/realtime-provider';
 import { shouldSuppressDuplicateSseEvent, createSeenIdTracker } from '@/lib/realtime/sse-event-dedup';
 import { createReconnectBackoffState, type ReconnectBackoffState } from '@/lib/realtime/sse-reconnect-backoff';
 import { isSessionAlive } from '@/lib/realtime/sse-session-guard';
@@ -205,6 +205,11 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
   // 이미 살아있는 canonical 경로 `conversation.message_created`(S-COMM-12, 아래
   // handleConversationMessage)가 전부 커버한다 — 별도 기능 손실 없이 제거.
   const mux = useSseMultiplexerContext();
+  // story 6ddaa086(critical, 선생님 실사고) — mux.connected(getter)는 mux 핸들 자체가
+  // 참조안정적(realtime-provider.tsx 주석 참고)이라 값이 바뀌어도 리렌더를 못 유발했다
+  // ("연결 끊겼어요" 배너가 정상 재연결 후에도 안 풀리는 근본원인). 반응형 전용 컨텍스트로
+  // 교체.
+  const muxConnected = useSseConnectedContext();
 
   useEffect(() => {
     if (!mux) return;
@@ -333,7 +338,8 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
     };
   }, [mux, backoff, currentTeamMemberId]);
 
-  // mux 경로에서는 로컬 connected state를 동기화하지 않고(setState-in-effect 회피) 멀티플렉서
-  // 자신의 connected를 그대로 노출한다 — 이미 반응형(context 값 변경 시 이 훅도 리렌더).
-  return { connected: mux ? mux.connected : connected };
+  // story 6ddaa086 — 이전 주석은 "mux.connected가 이미 반응형"이라 적었으나 틀렸다: mux
+  // 핸들 자체는 참조안정적이라(realtime-provider.tsx) getter 뒤 값이 바뀌어도 이 컴포넌트가
+  // 리렌더되지 않았다. muxConnected(위, 전용 컨텍스트)만 실제로 반응형이다.
+  return { connected: mux ? muxConnected : connected };
 }


### PR DESCRIPTION
## 요약
**critical**: 선생님 실사고 — 「연결이 끊겼어요」 배너가 실 연결(readyState=1 OPEN) 정상 도달 뒤에도 상시 노출. PO 실측: fresh 로드 3초부터 노출·30초 연속·재연결해도 안 풀림.

## 원인 확定
`sse-multiplexer.ts`의 mux 핸들은 story #2144 처방으로 참조가 **의도적으로** 안정적입니다(connected가 토글돼도 핸들 자체 참조 불변 — 소비처의 재구독 churn 방지, `useTeamPresence`가 이 안정성에 의존). 그런데 `realtime-provider.tsx`가 이 안정된 핸들을 그대로 Context value로 넘기고, `use-chat-sse.ts`는 `mux.connected`를 getter로 직접 읽었습니다 — React Context.Provider는 value의 "참조"가 안 바뀌면 소비자를 리렌더시키지 않으므로, connected가 실제로 토글돼도(getter 뒤 값은 바뀜) chat-view가 그 변화를 리렌더로 못 받았습니다. 다음 "무관한" 리렌더(새 메시지 등)가 우연히 올 때까지 배너가 옛 값에 고정 — PO가 관측한 정확한 증상과 일치합니다.

## 처방
`realtime-provider.tsx`에 `SseConnectedContext`(boolean 전용) 신설 — `RealtimeProvider`가 매 렌더 `multiplexer.connected`의 현재값을 이 컨텍스트 value로 넘깁니다(원시값이라 매 토글마다 실제로 달라짐 → Provider가 정상 리렌더 유발). `use-chat-sse.ts`는 `mux.connected` 대신 이 반응형 컨텍스트를 쓰도록 교체. mux 핸들 자체의 참조안정성(#2144)은 무변경 — 두 요구(구독 안정성 vs connected 반응성)를 별도 채널로 분리해 둘 다 만족시킵니다.

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4315 tests all green — 신규 회귀가드 2건(PO 재현 시나리오 포함: open→error→새 인스턴스 open, 무관한 트리거 없이 connected 복구)
- [x] **원본(수정 전) 소스로 두 신규 테스트가 실제로 실패함을 직접 확인**(readyState=1인데 connected가 false로 고착 — PO 증상 그대로 재현) — 진짜 회귀가드임을 검증
- [x] `pnpm build` green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA