### PR TITLE
[SID:3000] 로드맵 PR-B(챗) — L1 floating elev-overlay·L5 Bot/AI 배지 blue 틴트

### DIFF
--- a/apps/web/src/components/chat/add-participant-modal.test.tsx
+++ b/apps/web/src/components/chat/add-participant-modal.test.tsx
@@ -101,3 +101,27 @@ describe('AddParticipantModal — 에이전트 정책 거부 구조화 안내(st
     expect(document.body.querySelectorAll('a[href^="/organization/workforce/"]').length).toBe(0);
   });
 });
+
+// story #3000 로드맵 PR-B(L5) — 후보 목록의 Bot 배지 배경은 정적 정체성 마킹이라 citron이
+// 아니라 proof-blue-soft여야 한다.
+describe('AddParticipantModal — 로드맵 PR-B L5(Bot 배지 배경 proof-blue-soft)', () => {
+  it('agent 후보 항목의 Bot 배지가 bg-proof-blue-soft를 쓰고 bg-accent-claim은 안 쓴다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/members')) return { ok: true, json: async () => ({ data: MEMBERS }) };
+      return { ok: true, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(wrap(
+        <AddParticipantModal
+          conversationId={CONV_ID} conversationType="group" projectId={PROJECT_ID}
+          existingParticipantIds={['m-yuna']} onClose={() => {}} onAdded={() => {}}
+        />,
+      ));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const badge = document.body.querySelector('.rounded-sm.bg-proof-blue-soft');
+    expect(badge).toBeTruthy();
+    expect(badge?.textContent).toBe('Bot');
+    expect(document.body.querySelector('.bg-accent-claim\\/15')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/add-participant-modal.tsx
+++ b/apps/web/src/components/chat/add-participant-modal.tsx
@@ -122,8 +122,10 @@ export function AddParticipantModal({
                       {m.name?.slice(0, 2)?.toUpperCase() ?? '?'}
                     </div>
                     <span className="flex-1 truncate">{m.name}</span>
+                    {/* story #3000 로드맵 PR-B(L5) — 정적 Bot 배지 배경은 citron이 아니라
+                        proof-blue-soft(정체성 마킹). */}
                     {m.type === 'agent' && (
-                      <span className="rounded-sm bg-accent-claim/15 px-1 py-0.5 text-[9px] font-medium text-foreground">Bot</span>
+                      <span className="rounded-sm bg-proof-blue-soft px-1 py-0.5 text-[9px] font-medium text-foreground">Bot</span>
                     )}
                     {selected === m.id && <Check className="h-3.5 w-3.5 flex-shrink-0 text-primary" />}
                   </button>

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1735,3 +1735,20 @@ describe('ChatBubble — story #2921 S4(유나 확定, 버블·아바타 Proofli
     expect(mineAvatar?.className).toContain('rounded-md');
   });
 });
+
+// story #3000 로드맵 PR-B(L5) — Bot 배지 배경은 정적(비-pulse) 정체성 마킹이라 citron이 아니라
+// proof-blue-soft여야 한다(story-card 아바타·avatar.tsx idle 링과 정합).
+describe('ChatBubble — 로드맵 PR-B L5(Bot 배지 배경 proof-blue-soft)', () => {
+  it('agent 발신 메시지의 Bot 배지가 bg-proof-blue-soft를 쓰고 citron은 안 쓴다', async () => {
+    // ⛔avatar.tsx의 "AI" 코너 배지(별개 소비처, 이번 PR-B 스코프 밖)도 accent-claim/15를
+    // 쓰므로 이 원소 자신의 클래스만 좁혀서 잰다(container 전체 grep이 아니라).
+    const plainMessage: ChatMessage = { ...baseMessage, content: '봇 메시지', sender_type: 'agent' };
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...plainMessage, references: [] }} isMine={false} />));
+    });
+    const badge = container.querySelector('.rounded-sm.bg-proof-blue-soft');
+    expect(badge).toBeTruthy();
+    expect(badge?.textContent).toBe('Bot');
+    expect(badge?.className).not.toContain('accent-claim');
+  });
+});

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -530,7 +530,9 @@ export function ChatBubble({
                 {displayName}
               </span>
               {isAgent && (
-                <span className="rounded-sm bg-accent-claim/15 px-1 py-0.5 text-[9px] font-medium text-foreground">
+                // story #3000 로드맵 PR-B(L5) — 정적(비-pulse) Bot 배지 배경은 citron이 아니라
+                // proof-blue-soft(정체성 마킹, story-card 아바타·avatar.tsx idle 링과 정합).
+                <span className="rounded-sm bg-proof-blue-soft px-1 py-0.5 text-[9px] font-medium text-foreground">
                   Bot
                 </span>
               )}

--- a/apps/web/src/components/chat/chat-input.test.tsx
+++ b/apps/web/src/components/chat/chat-input.test.tsx
@@ -403,3 +403,28 @@ describe('ChatInput — STEER 모드(story #2942)', () => {
     expect(container.textContent).toContain('방향 전환 지시');
   });
 });
+
+// story #3000 로드맵 PR-B(L1) — floating 드롭다운(멘션 등)은 --elev-overlay 토큰이어야 한다
+// (shadow-md 리터럴 회귀가드).
+describe('ChatInput — 로드맵 PR-B L1(floating elev-overlay)', () => {
+  it('멘션 후보 드롭다운이 shadow-[var(--elev-overlay)]를 쓰고 shadow-md는 안 쓴다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ id: 'm1', name: '오르테가' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } })));
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" onSend={vi.fn()} />));
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '@오');
+      el.selectionStart = 2;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+    expect(listbox?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(listbox?.className).not.toContain('shadow-md');
+  });
+});

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -656,8 +656,10 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
                 aria-label={t('steerPanelWorkItemLabel')}
                 className="w-full rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground placeholder:text-muted-foreground"
               />
+              {/* story #3000 로드맵 PR-B(L1) — 이 파일의 floating 드롭다운 4곳(작업항목·커맨드·
+                  멘션·엔티티 후보) 전부 --elev-overlay(오버레이 전용) 토큰으로 통일. */}
               {workItemPicker.entityResults.length > 0 && (
-                <ul role="listbox" aria-label={t('steerPanelWorkItemLabel')} className="focus-inset absolute top-full left-0 z-50 mt-1 max-h-40 w-full overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+                <ul role="listbox" aria-label={t('steerPanelWorkItemLabel')} className="focus-inset absolute top-full left-0 z-50 mt-1 max-h-40 w-full overflow-y-auto rounded-md border border-border bg-popover shadow-[var(--elev-overlay)]">
                   {workItemPicker.entityResults.map((ent) => (
                     <li key={`${ent.entity_type}:${ent.entity_id}`}>
                       <button
@@ -685,7 +687,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
       <div className="relative flex items-end gap-2">
         {/* Command dropdown (선생님 B·mockup #3) — mention/entity 셸·키보드 nav 동일·command 활성=info 신호 토큰 */}
         {commandCandidates.length > 0 && (
-          <ul role="listbox" aria-label="커맨드 후보" className="focus-inset absolute bottom-full left-8 z-50 mb-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+          <ul role="listbox" aria-label="커맨드 후보" className="focus-inset absolute bottom-full left-8 z-50 mb-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-[var(--elev-overlay)]">
             {commandCandidates.map((cmd, idx) => (
               <li key={cmd.name}>
                 <button
@@ -707,7 +709,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
 
         {/* Mention dropdown */}
         {mentionMembers.length > 0 && (
-          <ul role="listbox" aria-label="멘션 후보" className="focus-inset absolute bottom-full left-8 z-50 mb-1 max-h-48 w-56 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+          <ul role="listbox" aria-label="멘션 후보" className="focus-inset absolute bottom-full left-8 z-50 mb-1 max-h-48 w-56 overflow-y-auto rounded-md border border-border bg-popover shadow-[var(--elev-overlay)]">
             {mentionMembers.map((member, idx) => (
               <li key={member.id}>
                 <button
@@ -729,7 +731,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
         {/* Entity dropdown — story #2263(C-5) ㉡: 종류별 구역(머리글)으로 묶되 열은 안 나눈다
             (entityResults가 이미 groupEntitiesByType로 그룹 순서라 렌더 순서=entityIndex 순서). */}
         {entityPicker.entityResults.length > 0 && (
-          <ul role="listbox" aria-label="엔티티 후보" className="focus-inset absolute bottom-full left-8 z-50 mb-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+          <ul role="listbox" aria-label="엔티티 후보" className="focus-inset absolute bottom-full left-8 z-50 mb-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-[var(--elev-overlay)]">
             {entityPicker.entityResults.map((entity, idx) => {
               const EntityIcon = ENTITY_ICONS[entity.entity_type] ?? Hash;
               const isNewGroup = idx === 0 || entityPicker.entityResults[idx - 1]!.entity_type !== entity.entity_type;

--- a/apps/web/src/components/chat/message-context-menu.test.tsx
+++ b/apps/web/src/components/chat/message-context-menu.test.tsx
@@ -115,3 +115,18 @@ describe('MessageContextMenu — story #2349 사용자 차단', () => {
     expect(container.textContent).not.toContain('사용자 차단');
   });
 });
+
+// story #3000 로드맵 PR-B(L1) — floating 팝업은 --elev-overlay 토큰이어야 한다(shadow-md
+// 리터럴 회귀가드).
+describe('MessageContextMenu — 로드맵 PR-B L1(floating elev-overlay)', () => {
+  it('메뉴 컨테이너가 shadow-[var(--elev-overlay)]를 쓰고 shadow-md는 안 쓴다', async () => {
+    await act(async () => {
+      root.render(
+        <MessageContextMenu x={0} y={0} isMine={false} onReply={NOOP} onCopy={NOOP} onDelete={NOOP} onClose={NOOP} />,
+      );
+    });
+    const menu = container.querySelector('[role="menu"]');
+    expect(menu?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(menu?.className).not.toContain('shadow-md');
+  });
+});

--- a/apps/web/src/components/chat/message-context-menu.tsx
+++ b/apps/web/src/components/chat/message-context-menu.tsx
@@ -56,7 +56,8 @@ export function MessageContextMenu({ x, y, isMine, onReply, onCopy, onDelete, on
     <div
       ref={menuRef}
       role="menu"
-      className="fixed z-50 min-w-[160px] overflow-hidden rounded-lg border border-border bg-popover py-1 shadow-md"
+      // story #3000 로드맵 PR-B(L1) — floating 팝업은 --elev-overlay(오버레이 전용) 토큰으로.
+      className="fixed z-50 min-w-[160px] overflow-hidden rounded-lg border border-border bg-popover py-1 shadow-[var(--elev-overlay)]"
       style={{ left: clampedX, top: clampedY }}
     >
       <button

--- a/apps/web/src/components/chat/new-conversation-modal.test.tsx
+++ b/apps/web/src/components/chat/new-conversation-modal.test.tsx
@@ -134,3 +134,22 @@ describe('NewConversationModal — 에이전트 정책 거부 구조화 안내(s
     expect(document.body.textContent).toContain('대화 생성에 실패했습니다. 다시 시도해보세요.');
   });
 });
+
+// story #3000 로드맵 PR-B(L5) — 후보 목록의 Bot 배지 배경은 정적 정체성 마킹이라 citron이
+// 아니라 proof-blue-soft여야 한다.
+describe('NewConversationModal — 로드맵 PR-B L5(Bot 배지 배경 proof-blue-soft)', () => {
+  it('agent 후보 항목의 Bot 배지가 bg-proof-blue-soft를 쓰고 bg-accent-claim은 안 쓴다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/members')) return { ok: true, json: async () => ({ data: MEMBERS }) };
+      return { ok: true, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(wrap(<NewConversationModal projectId={PROJECT_ID} onClose={() => {}} onCreated={() => {}} />));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const badge = document.body.querySelector('.rounded-sm.bg-proof-blue-soft');
+    expect(badge).toBeTruthy();
+    expect(badge?.textContent).toBe('Bot');
+    expect(document.body.querySelector('.bg-accent-claim\\/15')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/new-conversation-modal.tsx
+++ b/apps/web/src/components/chat/new-conversation-modal.tsx
@@ -118,8 +118,10 @@ export function NewConversationModal({ projectId, onClose, onCreated }: NewConve
                       {m.name?.slice(0, 2)?.toUpperCase() ?? '?'}
                     </div>
                     <span className="flex-1 truncate">{m.name}</span>
+                    {/* story #3000 로드맵 PR-B(L5) — 정적 Bot 배지 배경은 citron이 아니라
+                        proof-blue-soft(정체성 마킹). */}
                     {m.type === 'agent' && (
-                      <span className="rounded-sm bg-accent-claim/15 px-1 py-0.5 text-[9px] font-medium text-foreground">Bot</span>
+                      <span className="rounded-sm bg-proof-blue-soft px-1 py-0.5 text-[9px] font-medium text-foreground">Bot</span>
                     )}
                     {selected.includes(m.id) && <Check className="h-3.5 w-3.5 flex-shrink-0 text-primary" />}
                   </button>

--- a/apps/web/src/components/chat/sender-profile-popover.test.tsx
+++ b/apps/web/src/components/chat/sender-profile-popover.test.tsx
@@ -92,3 +92,16 @@ describe('SenderProfilePopover — story #2349 "상대 프로필" 진입점', ()
     expect(container.querySelector('img')).toBeNull();
   });
 });
+
+// story #3000 로드맵 PR-B(L1) — floating 팝업은 --elev-overlay 토큰이어야 한다(shadow-md
+// 리터럴 회귀가드).
+describe('SenderProfilePopover — 로드맵 PR-B L1(floating elev-overlay)', () => {
+  it('팝오버 컨테이너가 shadow-[var(--elev-overlay)]를 쓰고 shadow-md는 안 쓴다', async () => {
+    await act(async () => {
+      root.render(<SenderProfilePopover x={0} y={0} name="오르테가" isAgent onClose={NOOP} />);
+    });
+    const popover = container.querySelector('[role="dialog"]');
+    expect(popover?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(popover?.className).not.toContain('shadow-md');
+  });
+});

--- a/apps/web/src/components/chat/sender-profile-popover.tsx
+++ b/apps/web/src/components/chat/sender-profile-popover.tsx
@@ -46,7 +46,8 @@ export function SenderProfilePopover({ x, y, name, isAgent, avatarUrl, onClose, 
       ref={ref}
       role="dialog"
       aria-label={name}
-      className="fixed z-50 min-w-[200px] overflow-hidden rounded-lg border border-border bg-popover py-2 shadow-md"
+      // story #3000 로드맵 PR-B(L1) — floating 팝업은 --elev-overlay(오버레이 전용) 토큰으로.
+      className="fixed z-50 min-w-[200px] overflow-hidden rounded-lg border border-border bg-popover py-2 shadow-[var(--elev-overlay)]"
       style={{ left: clampedX, top: clampedY }}
     >
       <div className="flex items-center gap-2.5 px-3 py-1.5">

--- a/apps/web/src/components/shared/avatar.test.tsx
+++ b/apps/web/src/components/shared/avatar.test.tsx
@@ -66,6 +66,19 @@ describe('Avatar — story #2887 S2g', () => {
     expect(container.querySelector('[role="img"]')).not.toBeNull(); // PresenceDot
   });
 
+  // story #3000 로드맵 PR-B(L5, 페드루군 동승 판정) — 정적 "AI" 코너배지는 citron이 아니라
+  // proof-blue 틴트여야 한다(정체성 마킹 — citron은 live pulse 전용).
+  it('AI 코너배지가 border-proof-blue/bg-proof-blue-soft를 쓰고 citron은 안 쓴다', async () => {
+    await act(async () => {
+      root.render(wrap(<Avatar name="유나" avatarUrl={null} actorType="agent" />));
+    });
+    const badge = [...container.querySelectorAll('span')].find((s) => s.textContent === 'AI');
+    expect(badge).toBeTruthy();
+    expect(badge?.className).toContain('border-proof-blue/40');
+    expect(badge?.className).toContain('bg-proof-blue-soft');
+    expect(badge?.className).not.toContain('accent-claim');
+  });
+
   // story #2921(유나 합성 5규칙③, avatar-unification-design-memo-2921, 2026-08-22 확定) —
   // 옛 값(idle=citron 정적·working=info(=proof-blue 별칭) 펄스)이 규칙③과 정반대였다(3339
   // 그라운딩에서 실측 발견) — swap: idle=blue 정적·working=citron 펄스가 정본.

--- a/apps/web/src/components/shared/avatar.tsx
+++ b/apps/web/src/components/shared/avatar.tsx
@@ -97,8 +97,11 @@ export function Avatar({
       </div>
 
       {isAgent && (
+        // story #3000 로드맵 PR-B(L5, 페드루군 동승 판정) — 정적 "AI" 코너배지는 citron이
+        // 아니라 proof-blue 틴트(정체성 마킹 — citron은 live pulse 전용, AGENT_LIVE_RING_CLASS
+        // 참고). 텍스트는 기왕 text-foreground.
         <span
-          className="absolute -right-1.5 -top-1.5 rounded border border-accent-claim/40 bg-accent-claim/15 font-bold text-foreground"
+          className="absolute -right-1.5 -top-1.5 rounded border border-proof-blue/40 bg-proof-blue-soft font-bold text-foreground"
           style={{ fontSize: Math.max(7, Math.round(badgeSize * 0.55)), lineHeight: 1, padding: '2px 3px' }}
         >
           AI


### PR DESCRIPTION
## 요약
P0 규칙서(37ac93b6) + 로드맵(983a4cd0) PR-B 그라운딩 후 PO 확定 좁은 스코프.

### L1 — floating popup shadow-md → --elev-overlay
- `message-context-menu.tsx`(우클릭/롱프레스 메뉴)
- `sender-profile-popover.tsx`(상대 프로필 팝오버)
- `chat-input.tsx` 드롭다운 4종(steer 작업항목·커맨드·멘션·엔티티 후보)

### L5 — 정적(비-pulse) 정체성 마킹 citron → proof-blue 틴트
Bot/AI 배지는 실행 중임을 알리는 live pulse가 아니라 "이 발신자는 에이전트다"라는 정적 정체성 표시라, citron(live pulse 전용) 대신 proof-blue가 규칙서 L5의 맞는 자리(`avatar.tsx` idle 링·story-card 아바타(#3429)와 동일 논리):
- `chat-bubble.tsx` / `add-participant-modal.tsx` / `new-conversation-modal.tsx` — Bot 배지 배경 `bg-accent-claim/15` → `bg-proof-blue-soft`
- `shared/avatar.tsx` — "AI" 코너배지 `border-accent-claim/40`+`bg-accent-claim/15` → `border-proof-blue/40`+`bg-proof-blue-soft`(페드루군 동승 판정 — 신규 테스트 작성 중 이 4번째 소비처를 발견해 스코프에 편입)

이미 준수 확인된 항목(아바타 shape/idle-blue-ring/working-citron-pulse·버블 배경·tombstone·command bubble)은 무변경 — L2/L3/L4/L6은 챗 표면에 해당 요소 부재(N/A). 앱 전역 `shadow-md` 35곳 일괄 전환은 별건([#2999](entity:story:2223b1a7-38f9-4985-8370-7be8e413f931))으로 분리.

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4323 tests all green (신규 회귀가드 7건 — floating 팝업 elev-overlay 3건 + Bot/AI 배지 blue 틴트 4건)
- [x] `pnpm build` green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA