### PR TITLE
[SID:2998] chore: PR-A/PR-B 코드 주석 정정(오귀속 SID·stale 스코프 설명)

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1740,8 +1740,9 @@ describe('ChatBubble — story #2921 S4(유나 확定, 버블·아바타 Proofli
 // proof-blue-soft여야 한다(story-card 아바타·avatar.tsx idle 링과 정합).
 describe('ChatBubble — 로드맵 PR-B L5(Bot 배지 배경 proof-blue-soft)', () => {
   it('agent 발신 메시지의 Bot 배지가 bg-proof-blue-soft를 쓰고 citron은 안 쓴다', async () => {
-    // ⛔avatar.tsx의 "AI" 코너 배지(별개 소비처, 이번 PR-B 스코프 밖)도 accent-claim/15를
-    // 쓰므로 이 원소 자신의 클래스만 좁혀서 잰다(container 전체 grep이 아니라).
+    // ⛔avatar.tsx의 "AI" 코너 배지(별개 소비처 — 같은 PR-B에서 동승 수정됨, avatar.test.tsx
+    // 참고)도 bg-proof-blue-soft를 쓰므로 이 원소 자신의 클래스만 좁혀서 잰다(container 전체
+    // grep이 아니라).
     const plainMessage: ChatMessage = { ...baseMessage, content: '봇 메시지', sender_type: 'agent' };
     await act(async () => {
       root.render(wrap(<ChatBubble message={{ ...plainMessage, references: [] }} isMine={false} />));

--- a/apps/web/src/components/kanban/story-card.test.tsx
+++ b/apps/web/src/components/kanban/story-card.test.tsx
@@ -27,7 +27,7 @@ function render(story: KanbanStory, assignees: KanbanMember[] = []) {
   );
 }
 
-// story #2993 로드맵 PR-A(L1) — 컨텍스트/상태 서브메뉴 floating 팝업은 --elev-overlay
+// story #2998 로드맵 PR-A(L1) — 컨텍스트/상태 서브메뉴 floating 팝업은 --elev-overlay
 // 토큰이어야 한다(L1: overlay=floating 전용). shadow-md 리터럴 회귀가드.
 describe('StoryCard — 로드맵 PR-A L1(floating 팝업 elev-overlay)', () => {
   it('상시 마크업에 shadow-md 리터럴이 없다(컨텍스트메뉴는 열렸을 때만 렌더되므로 정적 렌더로는 부재 확인)', () => {
@@ -36,7 +36,7 @@ describe('StoryCard — 로드맵 PR-A L1(floating 팝업 elev-overlay)', () => 
   });
 });
 
-// story #2993 로드맵 PR-A(L5) — agent 정적 아바타 테두리는 citron(live pulse 전용)이 아니라
+// story #2998 로드맵 PR-A(L5) — agent 정적 아바타 테두리는 citron(live pulse 전용)이 아니라
 // proof-blue(정체성 마킹, avatar.tsx idle 링과 정합)여야 한다.
 describe('StoryCard — 로드맵 PR-A L5(agent 아바타 정적 identity=proof-blue)', () => {
   it('agent assignee 아바타가 border-proof-blue/bg-proof-blue-soft를 쓰고 citron은 안 쓴다', () => {

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -356,7 +356,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                     {assigneeList.slice(0, 3).map((m) => (
                       <div
                         key={m.id}
-                        // story #2993 로드맵 PR-A(L5) — 정적(비-pulse) agent 정체성 마킹은
+                        // story #2998 로드맵 PR-A(L5) — 정적(비-pulse) agent 정체성 마킹은
                         // proof-blue(avatar.tsx idle 링과 정합) — citron은 live pulse(실행) 전용.
                         className={`relative flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-medium ring-1 ring-background ${
                           m.type === 'agent'
@@ -450,7 +450,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
         <div
           ref={menuRef}
           style={{ position: 'fixed', top: menuPos.top, left: menuPos.left, width: MENU_WIDTH }}
-          // story #2993 로드맵 PR-A(L1) — floating 팝업은 --elev-overlay(오버레이 전용) 토큰으로.
+          // story #2998 로드맵 PR-A(L1) — floating 팝업은 --elev-overlay(오버레이 전용) 토큰으로.
           className="z-50 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-[var(--elev-overlay)]"
           onClick={(e) => e.stopPropagation()}
         >
@@ -482,7 +482,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                 <div
                   ref={statusMenuRef}
                   style={{ position: 'fixed', top: statusMenuPos.top, left: statusMenuPos.left, width: MENU_WIDTH }}
-                  // story #2993 로드맵 PR-A(L1) — floating 팝업은 --elev-overlay(오버레이 전용) 토큰으로.
+                  // story #2998 로드맵 PR-A(L1) — floating 팝업은 --elev-overlay(오버레이 전용) 토큰으로.
           className="z-50 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-[var(--elev-overlay)]"
                   onClick={(e) => e.stopPropagation()}
                 >


### PR DESCRIPTION
## 요약
순수 주석 정정, 코드 동작 변화 없음.

1. `story-card.tsx`/`story-card.test.tsx`(PR#3429, 로드맵 PR-A) — 코드 주석이 잘못된 SID `#2993`(Workcell 도달성 결함)을 참조하고 있던 것을 정본 스토리 `#2998`로 정정(페드루군 지적).
2. `chat-bubble.test.tsx`(PR#3431, 로드맵 PR-B) — `avatar.tsx`의 "AI" 코너배지를 "PR-B 스코프 밖"이라 적었던 주석이 같은 PR에서 실제로 동승 수정돼 stale해진 것을 정정.

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4325 tests all green
- [x] `pnpm build` green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA