### PR TITLE
[SID:3005] 로드맵 P2·PR-C(goals) — L2 ProgressBar 무채화·L1 드래그카드 elevation 토큰

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
@@ -242,3 +242,75 @@ describe('GoalsClient — 결과 원장 재조립(§2 이중 신호·§3 마스�
     expect(container.textContent).toContain('판정 없이 닫힘');
   });
 });
+
+// story #3005(로드맵 P2·PR-C, L2) — 상세 패널의 스토리진행/SP진행 ProgressBar(위 "작업(Claimed)"
+// 바와는 별개 컴포넌트)도 물리량이라 proof-blue(bg-primary)가 아니라 무채(bg-proof-ink-3)여야
+// 한다.
+describe('GoalsClient — 로드맵 P2·PR-C L2(스토리진행/SP진행 ProgressBar 무채화)', () => {
+  // GoalDetailPanel(스토리진행/SP진행 ProgressBar가 사는 곳)은 행 클릭이 아니라(그건 라우터
+  // 딥링크로 나가버림, AC5) 생성 직후 onCreated 콜백으로만 이 컴포넌트 트리 안에서 열린다 —
+  // 생성 플로우를 실제로 태워서 연다.
+  it('생성 직후 열리는 상세 패널의 스토리진행 바가 bg-proof-ink-3를 쓰고 bg-primary는 안 쓴다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string }) => {
+      if (typeof url === 'string' && url.includes('/api/goals?')) return { ok: true, json: async () => ({ data: [] }) };
+      if (url === '/api/goals' && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              id: 'e1', title: '진행 목표', status: 'active', priority: 'medium', created_at: '2026-08-24',
+              stories: [
+                { id: 's1', title: 'A', status: 'done' },
+                { id: 's2', title: 'B', status: 'done' },
+                { id: 's3', title: 'C', status: 'in-progress' },
+                { id: 's4', title: 'D', status: 'in-progress' },
+              ],
+            },
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    }));
+    const { GoalsClient } = await import('./goals-client');
+    await act(async () => { root.render(wrap(<GoalsClient projectId="proj-1" />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const createBtn = [...document.body.querySelectorAll('button')].find((b) => b.textContent?.includes(koMessages.goals.newGoal));
+    await act(async () => { createBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    const titleInput = document.body.querySelector('input[type="text"]') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(titleInput, '진행 목표');
+      titleInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const form = titleInput.closest('form')!;
+    await act(async () => { form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    // ⚠️같은 화면에 이미 무채인 "작업(Claimed)" 바(§2, GoalRow)가 별도로 존재해 document 전체
+    // .bg-proof-ink-3 grep은 그 바로 오탐한다 — done/total 텍스트("2 / 4")로 이 ProgressBar
+    // 인스턴스 자신의 wrapper만 좁혀서 잰다.
+    const doneTotal = [...document.body.querySelectorAll('span')].find((s) => s.textContent === '2 / 4');
+    expect(doneTotal).toBeTruthy();
+    const wrapper = doneTotal!.closest('.space-y-1')!;
+    expect(wrapper.querySelector('.bg-proof-ink-3')).toBeTruthy();
+    expect(wrapper.querySelector('.bg-primary')).toBeNull();
+  });
+});
+
+// story #3005(로드맵 P2·PR-C, L1) — 에픽 행(카드)은 rest 상태에서 --elev-card를 쓴다. dragging=true
+// 축은 dnd-kit useSortable이 실 포인터 시퀀스에 걸려 jsdom 합성 이벤트로 안정 재현이 안 되는
+// 기지 한계([[feedback-render-test-over-source-grep]]류 synthetic dnd-kit 불안정 교훈, STEER
+// 작업 당시 확인) — rest(비드래그) 축만 유닛으로 고정하고 드래그 중 elev-overlay 전환은 라이브
+// 픽셀로 검증한다.
+describe('GoalsClient — 로드맵 P2·PR-C L1(에픽 카드 elevation 토큰, rest 축)', () => {
+  it('비드래그 상태의 에픽 행이 --elev-card를 쓰고 shadow-lg 리터럴은 안 쓴다', async () => {
+    stubFetch([{ id: 'e1', title: '목표A', status: 'active', total_stories: 2, done_stories: 1 }]);
+    await mount();
+    const row = [...container.querySelectorAll('div')].find((d) => d.className.includes('shadow-[var(--elev-card)]'));
+    expect(row).toBeTruthy();
+    expect(container.querySelector('.shadow-lg')).toBeNull();
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -182,8 +182,11 @@ function ProgressBar({ done, total, label }: ProgressBarProps) {
         </div>
       ) : null}
       <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
+        {/* story #3005(로드맵 P2·PR-C, L2) — done/total은 물리량 게이지라 proof-blue(정체성
+            신호) 대신 무채 명도. 같은 화면의 "작업(Claimed)" 바(§2)가 이미 쓰는
+            bg-proof-ink-3 관례 그대로 재사용(신규 하드코딩 색 0, §7 규율). */}
         <div
-          className="h-full rounded-full bg-primary transition-all duration-300"
+          className="h-full rounded-full bg-proof-ink-3 transition-all duration-300"
           style={{ width: `${pct}%` }}
         />
       </div>
@@ -567,7 +570,11 @@ function GoalRow({ epic, isSelected, onClick, onDeleteRequest, sortable }: GoalR
         isSelected
           ? 'border-primary/40 bg-primary/5'
           : 'border-border bg-card hover:border-primary/30 hover:bg-primary/5'
-      } ${isDragging ? 'shadow-lg' : ''}`}
+      } ${
+        // story #3005(로드맵 P2·PR-C, L1) — 드래그로 «들린» 상태는 일시적 floating이라
+        // --elev-overlay, rest 복귀 시 인라인 카드 기본값 --elev-card(PO 판정 2026-08-24).
+        isDragging ? 'shadow-[var(--elev-overlay)]' : 'shadow-[var(--elev-card)]'
+      }`}
     >
       {sortable ? (
         <button


### PR DESCRIPTION
## 요약
로드맵 doc `proofline-surface-rollout-roadmap-2984` P2 PR-C 구현. 스토리 #3005.

- **L2**: 상세 패널 스토리진행/SP진행 `ProgressBar`(goals-client.tsx:174) fill이 `bg-primary`(proof-blue, 정체성 신호)였던 것을 `bg-proof-ink-3`(무채 명도)로 — 같은 화면의 "작업(Claimed)" 바가 이미 쓰던 관례 재사용, 신규 하드코딩 색 0.
- **L1**: 드래그 중인 에픽 행의 `shadow-lg` 리터럴을 `--elev-overlay`로(일시적 floating), rest 복귀 시 `--elev-card`로(PO 판정 2026-08-24 — 어포던스는 유지하되 raw 리터럴만 죽인다).

결재함(gates) 표면은 그라운딩 결과 이미 준수(`cage/` 14파일+ApprovalsQueue grep 0건) — PR-D 생략, 로드맵 문서에 반영.

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4327 tests all green (신규 2건 포함, git stash로 pre-fix 실패 확인 후 fix 복원해 통과 재확인)
- [x] `pnpm build` green

## 참고
드래그 중(`isDragging=true`) 상태의 `--elev-overlay` 전환은 dnd-kit 실 포인터 시퀀스 의존이라 jsdom 합성 이벤트로 안정 재현이 안 됨(기지 한계, STEER 작업 당시 확인) — rest 축만 유닛 고정, 드래그 축은 배포 후 라이브 픽셀로 확인 예정.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA