### PR TITLE
[SID:3007] 로드맵 P2·PR-E — shadow-md 전역 분류 실행① floating 18곳 → --elev-overlay

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
@@ -257,3 +257,18 @@ describe('DocsClientLayout — 레일 v2 신규 요소(§3 proof 상태 도트·
     expect(container.querySelector('.bg-warning')).not.toBeNull(); // DOC_B pending
   });
 });
+
+// story #3007(로드맵 P2·PR-E, L1) — 모바일 스와이프 드로어는 floating이라 --elev-overlay.
+describe('DocsClientLayout — 로드맵 P2·PR-E L1(모바일 드로어 elevation 토큰)', () => {
+  it('트리 열기 버튼으로 연 드로어 패널이 shadow-[var(--elev-overlay)]를 쓰고 shadow-lg는 안 쓴다', async () => {
+    stubFetch();
+    await mount();
+    const openBtn = container.querySelector('button[aria-label="문서 트리 열기"]') as HTMLButtonElement;
+    await act(async () => { openBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const panel = document.querySelector('[role="dialog"][aria-label="문서 트리"]')
+      ?? [...document.querySelectorAll('[role="dialog"]')][0];
+    expect(panel).toBeTruthy();
+    expect(panel?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(panel?.className).not.toMatch(/(^|\s)shadow-lg(\s|$)/);
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -633,7 +633,8 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
           role="dialog"
           aria-modal="true"
           aria-label={t('title')}
-          className="fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-hidden border-r border-border bg-background shadow-lg outline-none lg:hidden"
+          // story #3007(로드맵 P2·PR-E, L1) — 모바일 드로어는 floating이라 --elev-overlay.
+          className="fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-hidden border-r border-border bg-background shadow-[var(--elev-overlay)] outline-none lg:hidden"
           style={{
             transform: `translateX(${(drawerProgress - 1) * 100}%)`,
             transition: drawerDragging ? 'none' : 'transform 280ms cubic-bezier(0.4,0,0.2,1)',

--- a/apps/web/src/app/(authenticated)/chats/layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.test.tsx
@@ -267,4 +267,18 @@ describe('ChatsLayout — story #2921 S6(xl 미만 + Reading 열림 → rail 자
     expect(document.activeElement).toBe(expandBtn);
     expect(expandBtn.className).not.toContain('!hidden');
   });
+
+  // story #3007(로드맵 P2·PR-E, L1) — 오버레이 rail은 floating이라 --elev-overlay.
+  it('오버레이 rail이 shadow-[var(--elev-overlay)]를 쓰고 shadow-xl은 안 쓴다', async () => {
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    mqMatches = true;
+    await act(async () => {
+      root.render(wrap(<ChatsLayout><ReadingOpenProbe open /></ChatsLayout>));
+    });
+    const expandBtn = container.querySelector('[aria-label="목록 열기"]') as HTMLButtonElement;
+    await act(async () => { expandBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const rail = container.querySelector('[data-testid="chat-rail"]');
+    expect(rail?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(rail?.className).not.toMatch(/(^|\s)shadow-xl(\s|$)/);
+  });
 });

--- a/apps/web/src/app/(authenticated)/chats/layout.tsx
+++ b/apps/web/src/app/(authenticated)/chats/layout.tsx
@@ -70,8 +70,10 @@ function ChatsLayoutBody({ children }: { children: React.ReactNode }) {
   // 그대로 있는 fixed 오버레이)에서 GNB 텍스트와 겹쳐 가독을 깼다. bg-background(불투명 판)
   // +border-r border-border(docked의 lg:border-r는 overlay 폭 구간(<1280)에서도 이미
   // 걸리지만, 이 분기 자체에 명시해 향후 base className 리팩터에도 안전하게 둔다).
+  // story #3007(로드맵 P2·PR-E, L1) — 모바일 드로어는 floating이라 shadow-xl 리터럴 대신
+  // --elev-overlay.
   const railOverlayClass = railMode === 'overlay'
-    ? 'fixed inset-y-0 left-0 z-40 w-[270px] bg-background shadow-xl border-r border-border lg:!flex xl:static xl:z-auto xl:w-[270px] xl:shadow-none'
+    ? 'fixed inset-y-0 left-0 z-40 w-[270px] bg-background shadow-[var(--elev-overlay)] border-r border-border lg:!flex xl:static xl:z-auto xl:w-[270px] xl:shadow-none'
     : '';
 
   return (

--- a/apps/web/src/components/canvas/artifact-expand-dialog.test.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.test.tsx
@@ -93,3 +93,13 @@ describe('ArtifactExpandDialog — 반응형 미리보기 브레이크포인트 
     expect(iframe().style.width).toBe('1280px');
   });
 });
+
+// story #3007(로드맵 P2·PR-E, L1) — 다이얼로그는 floating이라 --elev-overlay.
+describe('ArtifactExpandDialog — 로드맵 P2·PR-E L1(다이얼로그 elevation 토큰)', () => {
+  it('팝업이 shadow-[var(--elev-overlay)]를 쓰고 shadow-lg는 안 쓴다', async () => {
+    await mount();
+    const popup = document.body.querySelector('.rounded-xl.bg-card');
+    expect(popup?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(popup?.className).not.toMatch(/(^|\s)shadow-lg(\s|$)/);
+  });
+});

--- a/apps/web/src/components/canvas/artifact-expand-dialog.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.tsx
@@ -59,7 +59,8 @@ export function ArtifactExpandDialog({
         <DialogPrimitive.Popup
           className={cn(
             'fixed top-1/2 left-1/2 z-50 flex h-[85vh] w-[90vw] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden',
-            'rounded-xl bg-card shadow-lg ring-1 ring-foreground/10 outline-none',
+            // story #3007(로드맵 P2·PR-E, L1) — 다이얼로그는 floating이라 --elev-overlay.
+            'rounded-xl bg-card shadow-[var(--elev-overlay)] ring-1 ring-foreground/10 outline-none',
             'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
             'data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
           )}

--- a/apps/web/src/components/canvas/comment-compose-popover.tsx
+++ b/apps/web/src/components/canvas/comment-compose-popover.tsx
@@ -46,7 +46,8 @@ export function CommentComposePopover({ onSubmit, onCancel, style, className }: 
     <div
       ref={containerRef}
       style={style}
-      className={`absolute z-20 w-56 rounded-lg border border-border bg-card p-2 shadow-md ${className ?? ''}`}
+      // story #3007(로드맵 P2·PR-E, L1) — 팝오버는 floating이라 --elev-overlay.
+      className={`absolute z-20 w-56 rounded-lg border border-border bg-card p-2 shadow-[var(--elev-overlay)] ${className ?? ''}`}
       onKeyDown={(e) => { if (e.key === 'Escape') onCancel(); }}
     >
       <textarea

--- a/apps/web/src/components/command-palette/command-palette.test.tsx
+++ b/apps/web/src/components/command-palette/command-palette.test.tsx
@@ -119,3 +119,13 @@ describe('CommandPalette — action commands (story 4f991165)', () => {
     expect(document.body.textContent).not.toMatch(/\d+\s*(회|번|분 전|초 전)/);
   });
 });
+
+// story #3007(로드맵 P2·PR-E, L1) — cmd palette 다이얼로그는 floating이라 --elev-overlay.
+describe('CommandPalette — 로드맵 P2·PR-E L1(다이얼로그 elevation 토큰)', () => {
+  it('팝업이 shadow-[var(--elev-overlay)]를 쓰고 shadow-lg는 안 쓴다', async () => {
+    await mount();
+    const popup = document.body.querySelector('.rounded-xl.bg-popover');
+    expect(popup?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(popup?.className).not.toMatch(/(^|\s)shadow-lg(\s|$)/);
+  });
+});

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -251,7 +251,8 @@ export function CommandPalette({ open, onOpenChange, projectId, contextStoryId }
         <DialogPrimitive.Popup
           className={cn(
             'fixed top-[20%] left-1/2 z-50 w-full max-w-[calc(100%-2rem)] -translate-x-1/2',
-            'overflow-hidden rounded-xl bg-popover text-popover-foreground shadow-lg ring-1 ring-foreground/10',
+            // story #3007(로드맵 P2·PR-E, L1) — cmd palette 다이얼로그는 floating이라 --elev-overlay.
+            'overflow-hidden rounded-xl bg-popover text-popover-foreground shadow-[var(--elev-overlay)] ring-1 ring-foreground/10',
             'sm:max-w-xl outline-none',
             'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
             'data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',

--- a/apps/web/src/components/dispatch/entity-dispatch-panel.test.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.test.tsx
@@ -96,3 +96,27 @@ describe('EntityDispatchPanel — 까심군 QA 회귀 (envelope unwrap)', () => 
     expect(document.body.textContent).toContain('담당자가 지정되지 않았습니다');
   });
 });
+
+// story #3007(로드맵 P2·PR-E, L1) — "더보기" 드롭다운은 floating이라 --elev-overlay.
+describe('EntityDispatchPanel — 로드맵 P2·PR-E L1(더보기 드롭다운 elevation 토큰)', () => {
+  it('더보기 드롭다운이 shadow-[var(--elev-overlay)]를 쓰고 shadow-md는 안 쓴다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/members')) return { ok: true, json: async () => ({ data: MEMBERS }) };
+      if (url === '/api/stories/s1') return { ok: true, json: async () => ({ data: {} }) };
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => {
+      root.render(wrap(
+        <EntityDispatchPanel entityType="story" entityId="s1" projectId="p1" currentAssigneeId="m1" mobileMode="assignee-only" />,
+      ));
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    const moreBtn = container.querySelector('button[aria-label="더보기"]') as HTMLButtonElement;
+    await act(async () => { moreBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    const dropdown = container.querySelector('.shadow-\\[var\\(--elev-overlay\\)\\]');
+    expect(dropdown).not.toBeNull();
+    expect(container.querySelector('.shadow-md')).toBeNull();
+  });
+});

--- a/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
@@ -168,8 +168,9 @@ export function EntityDispatchPanel({
           >
             <MoreHorizontal className="size-4" />
           </button>
+          {/* story #3007(로드맵 P2·PR-E, L1) — 드롭다운은 floating이라 --elev-overlay. */}
           {moreOpen && (
-            <div className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded-md border border-border bg-background py-1 shadow-md">
+            <div className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded-md border border-border bg-background py-1 shadow-[var(--elev-overlay)]">
               <button
                 type="button"
                 disabled={!assigneeId || dispatching}

--- a/apps/web/src/components/docs/doc-assignee-control.tsx
+++ b/apps/web/src/components/docs/doc-assignee-control.tsx
@@ -64,7 +64,8 @@ export function DocAssigneeControl({
         {assigned ? (initials ?? <User className="size-3.5" />) : <UserPlus className="size-3.5" />}
       </button>
       {open ? (
-        <div className="absolute right-0 top-full z-50 mt-1 w-72 rounded-lg border border-border bg-popover p-2 shadow-md">
+        // story #3007(로드맵 P2·PR-E, L1) — 드롭다운은 floating이라 --elev-overlay.
+        <div className="absolute right-0 top-full z-50 mt-1 w-72 rounded-lg border border-border bg-popover p-2 shadow-[var(--elev-overlay)]">
           <EntityDispatchPanel
             entityType="doc"
             entityId={docId}

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -634,7 +634,8 @@ export function DocEditor({
                   <div
                     role="menu"
                     onClick={(e) => e.stopPropagation()}
-                    className="absolute left-7 top-0 w-36 overflow-hidden rounded-lg border border-border bg-card p-1 shadow-lg"
+                    // story #3007(로드맵 P2·PR-E, L1) — 드롭다운은 floating이라 --elev-overlay.
+                    className="absolute left-7 top-0 w-36 overflow-hidden rounded-lg border border-border bg-card p-1 shadow-[var(--elev-overlay)]"
                   >
                     <button
                       type="button"

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -633,7 +633,8 @@ const SlashMenu = forwardRef<
   return (
     <div
       ref={containerRef}
-      className="max-h-72 w-64 overflow-y-auto rounded-xl border border-white/10 bg-card p-1 shadow-lg"
+      // story #3007(로드맵 P2·PR-E, L1) — 슬래시메뉴는 floating이라 --elev-overlay.
+      className="max-h-72 w-64 overflow-y-auto rounded-xl border border-white/10 bg-card p-1 shadow-[var(--elev-overlay)]"
     >
       {grouped ? (
         grouped.map((group) => (

--- a/apps/web/src/components/docs/extensions/wiki-link.tsx
+++ b/apps/web/src/components/docs/extensions/wiki-link.tsx
@@ -153,16 +153,17 @@ function WikiLinkMenu({
     return () => document.removeEventListener('keydown', handleKey);
   }, [items, selectedIndex, command]);
 
+  // story #3007(로드맵 P2·PR-E, L1) — 프리뷰/메뉴 둘 다 floating이라 --elev-overlay(아래 2곳).
   if (items.length === 0) {
     return (
-      <div className="w-56 rounded-xl border border-white/10 bg-card p-3 text-xs text-muted-foreground shadow-lg">
+      <div className="w-56 rounded-xl border border-white/10 bg-card p-3 text-xs text-muted-foreground shadow-[var(--elev-overlay)]">
         문서를 찾을 수 없습니다
       </div>
     );
   }
 
   return (
-    <div ref={menuRef} className="max-h-64 w-56 overflow-y-auto rounded-xl border border-white/10 bg-card p-1 shadow-lg">
+    <div ref={menuRef} className="max-h-64 w-56 overflow-y-auto rounded-xl border border-white/10 bg-card p-1 shadow-[var(--elev-overlay)]">
       {items.map((item, i) => (
         <button
           key={item.id}

--- a/apps/web/src/components/docs/mobile-selection-menu.tsx
+++ b/apps/web/src/components/docs/mobile-selection-menu.tsx
@@ -92,7 +92,8 @@ export function MobileSelectionMenu({ editor }: { editor: Editor | null }) {
       role="toolbar"
       aria-label="텍스트 서식"
       style={{ position: 'fixed', top: pos.top, left: pos.left, zIndex: 9999 }}
-      className="flex items-center gap-0.5 rounded-xl border border-border bg-background p-1 shadow-lg"
+      // story #3007(로드맵 P2·PR-E, L1) — 툴바는 floating이라 --elev-overlay.
+      className="flex items-center gap-0.5 rounded-xl border border-border bg-background p-1 shadow-[var(--elev-overlay)]"
     >
       {buttons.map(({ icon: Icon, label, action, active }) => (
         <button

--- a/apps/web/src/components/flow/flow-node-story-panel.test.tsx
+++ b/apps/web/src/components/flow/flow-node-story-panel.test.tsx
@@ -212,6 +212,20 @@ describe('FlowNodeStoryPanel — 로딩 표시(유나 가디언 리뷰 2026-07-3
     // 아직 마운트되지 않아야 정상이다(fetch가 안 끝났으므로).
     expect(container.querySelector('[data-testid="story-detail-panel-stub"]')).toBeNull();
   });
+
+  // story #3007(로드맵 P2·PR-E, L1) — 로딩 플로팅 패널은 floating이라 --elev-overlay.
+  it('로딩 패널이 shadow-[var(--elev-overlay)]를 쓰고 shadow-xl은 안 쓴다', () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
+    placeAnchor('story-abc', { top: 100, bottom: 130 });
+
+    act(() => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} />));
+    });
+
+    const panel = [...container.querySelectorAll('div')].find((d) => d.textContent?.includes('노드를 불러오는 중'));
+    expect(panel?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(panel?.className).not.toMatch(/(^|\s)shadow-xl(\s|$)/);
+  });
 });
 
 describe('FlowNodeStoryPanel — 모바일 게이트(유나 가디언 리뷰 2026-07-31, issuecomment-5139371576)', () => {

--- a/apps/web/src/components/flow/flow-node-story-panel.tsx
+++ b/apps/web/src/components/flow/flow-node-story-panel.tsx
@@ -145,7 +145,8 @@ export function FlowNodeStoryPanel({ storyId, onClose }: FlowNodeStoryPanelProps
   if (state.kind === 'loading' || (!isMobile && !overlayPosition)) {
     return (
       <div
-        className="fixed inset-x-4 top-4 z-50 mx-auto max-w-xl rounded-lg border border-border bg-background p-3 text-xs text-muted-foreground shadow-xl sm:inset-x-auto sm:right-4 sm:w-full"
+        // story #3007(로드맵 P2·PR-E, L1) — 플로팅 패널은 floating이라 --elev-overlay(아래 3곳).
+        className="fixed inset-x-4 top-4 z-50 mx-auto max-w-xl rounded-lg border border-border bg-background p-3 text-xs text-muted-foreground shadow-[var(--elev-overlay)] sm:inset-x-auto sm:right-4 sm:w-full"
         style={!isMobile && overlayPosition ? { top: overlayPosition.top } : undefined}
       >
         {t('nodesLoading')}
@@ -155,7 +156,7 @@ export function FlowNodeStoryPanel({ storyId, onClose }: FlowNodeStoryPanelProps
   if (state.kind === 'error') {
     return (
       <div
-        className="fixed inset-x-4 top-4 z-50 mx-auto max-w-xl rounded-lg border border-border bg-background p-3 text-xs text-muted-foreground shadow-xl sm:inset-x-auto sm:right-4 sm:w-full"
+        className="fixed inset-x-4 top-4 z-50 mx-auto max-w-xl rounded-lg border border-border bg-background p-3 text-xs text-muted-foreground shadow-[var(--elev-overlay)] sm:inset-x-auto sm:right-4 sm:w-full"
         style={!isMobile && overlayPosition ? { top: overlayPosition.top } : undefined}
       >
         {t('nodesError')}
@@ -171,7 +172,7 @@ export function FlowNodeStoryPanel({ storyId, onClose }: FlowNodeStoryPanelProps
       type="button"
       size="sm"
       variant="secondary"
-      className="fixed right-4 top-4 z-[60] shadow-md"
+      className="fixed right-4 top-4 z-[60] shadow-[var(--elev-overlay)]"
       onClick={() => setReviewQueueOpen(true)}
     >
       {t('relationReviewEntryButton', { count: unconfirmedCount })}

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -327,6 +327,26 @@ describe('KanbanBoard — 스토리 생성 실패 접근성(story #2105 2차)', 
     expect(second).not.toBeNull();
     expect(second).not.toBe(first);
   });
+
+  // story #3007(로드맵 P2·PR-E, L1) — 토스트성 에러배너는 floating이라 --elev-overlay.
+  it('생성 실패 배너가 shadow-[var(--elev-overlay)]를 쓰고 shadow-md는 안 쓴다', async () => {
+    stubFetch([]);
+    await mount();
+    const ctaButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('첫 스토리 만들기'));
+    await act(async () => { ctaButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const titleInput = container.querySelector('input') as HTMLInputElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(titleInput, '새 스토리');
+      titleInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      titleInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+    });
+    const alertEl = await waitForAlert();
+    expect(alertEl?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(alertEl?.className).not.toMatch(/(^|\s)shadow-md(\s|$)/);
+  });
 });
 
 // story #2059 — 보드 실시간 반영. 새 EventSource를 여는 대신 기존 useSseNotifications의

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1127,7 +1127,8 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
         // story #2154 — handleDragEnd/handleChangeStatus/handleCreateStory가 실패 시점마다
         // bumpTransitionErrorNonce()를 함께 호출해, 4초 내 동일 사유가 재발해도 key가 바뀌어
         // 항상 새 DOM 노드로 재낭독된다(#2400이 남긴 latent gap 해소).
-        <div key={transitionErrorNonce} role="alert" aria-live="assertive" aria-atomic="true" className="fixed bottom-4 right-4 z-50 rounded-md border border-destructive bg-destructive px-4 py-3 text-sm text-destructive-foreground shadow-md">
+        // story #3007(로드맵 P2·PR-E, L1) — 토스트성 배너는 floating이라 --elev-overlay.
+        <div key={transitionErrorNonce} role="alert" aria-live="assertive" aria-atomic="true" className="fixed bottom-4 right-4 z-50 rounded-md border border-destructive bg-destructive px-4 py-3 text-sm text-destructive-foreground shadow-[var(--elev-overlay)]">
           ⚠️ {transitionError}
         </div>
       )}

--- a/apps/web/src/components/kanban/kanban-list-view.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.tsx
@@ -102,7 +102,8 @@ function ListStoryRow({ story, epicMap, memberMap, onStoryClick, onChangeStatus 
         </button>
 
         {statusOpen && validNext.length > 0 && (
-          <div className="absolute right-0 top-full z-50 mt-1 min-w-[140px] rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md">
+          // story #3007(로드맵 P2·PR-E, L1) — 드롭다운은 floating이라 --elev-overlay.
+          <div className="absolute right-0 top-full z-50 mt-1 min-w-[140px] rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-[var(--elev-overlay)]">
             {validNext.map((nextStatus) => {
               const col = COLUMNS.find((c) => c.id === nextStatus);
               if (!col) return null;

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -98,6 +98,27 @@ describe('StoryDetailPanel — overlayPosition (story #2354, 지도 위에 겹�
     expect(panel.style.height).toBe('300px');
   });
 
+  // story #3007(로드맵 P2·PR-E, L1) — 모바일 시트/오버레이 패널 둘 다 floating이라 --elev-overlay.
+  it('두 분기(전체화면 드로어·overlayPosition 팝오버) 모두 panel이 shadow-[var(--elev-overlay)]를 쓰고 shadow-xl은 안 쓴다(story #3007)', async () => {
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={makeStory()} tasks={[]} onClose={() => {}} />));
+    });
+    const drawerPanel = container.querySelector('[role="dialog"]');
+    expect(drawerPanel?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(drawerPanel?.className).not.toMatch(/(^|\s)shadow-xl(\s|$)/);
+
+    await act(async () => { root.unmount(); });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel story={makeStory()} tasks={[]} onClose={() => {}} overlayPosition={{ top: 120, heightPx: 300 }} />,
+      ));
+    });
+    const overlayPanel = container.querySelector('[role="dialog"]');
+    expect(overlayPanel?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(overlayPanel?.className).not.toMatch(/(^|\s)shadow-xl(\s|$)/);
+  });
+
   it('overlay panel content is the SAME component internals — story title still renders (재사용 확認, AC7)', async () => {
     await act(async () => {
       root.render(wrap(

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1279,9 +1279,11 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
         role="dialog"
         aria-modal="true"
         aria-label={story.title}
+        // story #3007(로드맵 P2·PR-E, L1) — 모바일 시트/데스크톱 사이드시트 둘 다 floating이라
+        // --elev-overlay.
         className={overlayPosition
-          ? 'fixed inset-x-4 z-50 mx-auto max-w-xl overflow-hidden rounded-lg border border-border bg-background shadow-xl outline-none backdrop-blur-xl sm:inset-x-auto sm:right-4 sm:w-full'
-          : 'fixed inset-0 z-50 bg-background shadow-xl outline-none backdrop-blur-xl lg:inset-y-0 lg:left-auto lg:right-0 lg:w-full lg:max-w-3xl lg:border-l lg:border-border'}
+          ? 'fixed inset-x-4 z-50 mx-auto max-w-xl overflow-hidden rounded-lg border border-border bg-background shadow-[var(--elev-overlay)] outline-none backdrop-blur-xl sm:inset-x-auto sm:right-4 sm:w-full'
+          : 'fixed inset-0 z-50 bg-background shadow-[var(--elev-overlay)] outline-none backdrop-blur-xl lg:inset-y-0 lg:left-auto lg:right-0 lg:w-full lg:max-w-3xl lg:border-l lg:border-border'}
         style={overlayPosition ? { top: overlayPosition.top, height: overlayPosition.heightPx } : undefined}
       >
       <div className="flex h-full flex-col">

--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -321,3 +321,14 @@ describe('getEntityHref — 딥링크 계약(story #2956 QA changes)', () => {
     expect(getEntityHref(baseNotification({ source_entity_type: 'epic', source_entity_id: null }))).toBeNull();
   });
 });
+
+// story #3007(로드맵 P2·PR-E, L1) — 데스크톱 드롭다운 패널은 floating이라 --elev-overlay.
+describe('NotificationBell — 로드맵 P2·PR-E L1(드롭다운 패널 elevation 토큰)', () => {
+  it('데스크톱 드롭다운(.w-80)이 shadow-[var(--elev-overlay)]를 쓰고 shadow-lg는 안 쓴다', async () => {
+    stubFetchSequenceByOffset({ 0: { items: [], hasMore: false } });
+    await openBell();
+    const desktopPanel = container.querySelector('.w-80');
+    expect(desktopPanel?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(desktopPanel?.className).not.toMatch(/(^|\s)shadow-lg(\s|$)/);
+  });
+});

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -568,7 +568,8 @@ export function NotificationBell() {
 
       {/* 데스크톱 드롭다운 (lg+) */}
       {open && (
-        <div className="absolute right-0 top-full z-50 mt-1 hidden w-80 overflow-hidden rounded-lg border bg-background shadow-lg lg:flex lg:flex-col" style={{ maxHeight: '480px' }}>
+        // story #3007(로드맵 P2·PR-E, L1) — 드롭다운 패널은 floating이라 --elev-overlay.
+        <div className="absolute right-0 top-full z-50 mt-1 hidden w-80 overflow-hidden rounded-lg border bg-background shadow-[var(--elev-overlay)] lg:flex lg:flex-col" style={{ maxHeight: '480px' }}>
           <NotificationPanel
             notifications={notifications}
             onMarkAllRead={handleMarkAllRead}

--- a/apps/web/src/components/settings/byom-key-management.tsx
+++ b/apps/web/src/components/settings/byom-key-management.tsx
@@ -348,7 +348,10 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
       {/* Delete confirmation dialog */}
       {showDeleteConfirm ? (
         <Dialog open={showDeleteConfirm} onOpenChange={(open) => { if (!open && !deleting) setShowDeleteConfirm(false); }}>
-          <DialogContent className="max-w-sm rounded-2xl border-white/10 bg-muted shadow-xl backdrop-blur-xl" showCloseButton={false}>
+          {/* story #3007(로드맵 P2·PR-E, L1) — 이 consumer가 얹는 className이 DialogContent
+              기본 --elev-overlay를 덮어써 shadow-xl 리터럴로 갈라져 있었다. 원시(Dialog) 교체는
+              동작 리스크 판단상 보류(PO 확定) — 토큰만 치환. */}
+          <DialogContent className="max-w-sm rounded-2xl border-white/10 bg-muted shadow-[var(--elev-overlay)] backdrop-blur-xl" showCloseButton={false}>
             <DialogTitle className="text-lg font-semibold text-destructive">{t('deleteConfirmTitle')}</DialogTitle>
             <p className="mt-2 text-sm text-muted-foreground">{t('deleteConfirmDesc')}</p>
             <div className="mt-6 flex gap-3">

--- a/apps/web/src/components/shared/entity-aware-textarea.test.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.test.tsx
@@ -136,3 +136,27 @@ describe('EntityAwareTextarea — story #2264', () => {
     expect(container.textContent).not.toContain('in-review');
   });
 });
+
+// story #3007(로드맵 P2·PR-E, L1) — 자동완성 리스트박스는 floating이라 --elev-overlay.
+describe('EntityAwareTextarea — 로드맵 P2·PR-E L1(리스트박스 elevation 토큰)', () => {
+  it('# 후보 리스트박스가 shadow-[var(--elev-overlay)]를 쓰고 shadow-md는 안 쓴다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ entity_type: 'story', entity_id: '11111111-1111-1111-1111-111111111111', title: '제목', status: null }],
+    }))));
+    await act(async () => {
+      root.render(<ControlledHarness initial="" projectId="p1" onValueChange={() => {}} />);
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '#');
+      el.selectionStart = 1;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox?.className).toContain('shadow-[var(--elev-overlay)]');
+    expect(listbox?.className).not.toMatch(/(^|\s)shadow-md(\s|$)/);
+  });
+});

--- a/apps/web/src/components/shared/entity-aware-textarea.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.tsx
@@ -76,7 +76,8 @@ export function EntityAwareTextarea({ value, onChange, projectId, placeholder, c
       />
       {/* story #2263(C-5) ㉠㉡㉢ 그대로 재사용 — chat-input.tsx 엔티티 dropdown과 동형 렌더. */}
       {entityPicker.entityResults.length > 0 && (
-        <ul role="listbox" aria-label="엔티티 후보" className="focus-inset absolute left-0 z-50 mt-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+        // story #3007(로드맵 P2·PR-E, L1) — 자동완성 리스트박스는 floating이라 --elev-overlay.
+        <ul role="listbox" aria-label="엔티티 후보" className="focus-inset absolute left-0 z-50 mt-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-[var(--elev-overlay)]">
           {entityPicker.entityResults.map((entity, idx) => {
             const EntityIcon = ENTITY_ICONS[entity.entity_type] ?? Hash;
             const isNewGroup = idx === 0 || entityPicker.entityResults[idx - 1]!.entity_type !== entity.entity_type;


### PR DESCRIPTION
## 요약
로드맵 doc `proofline-surface-rollout-roadmap-2984` P2 PR-E. #2999 그라운딩(2223b1a7) 실행분 ①. 스토리 #3007.

18개 파일의 floating 팝업/드롭다운/드로어/토스트/다이얼로그 `shadow-md`·`lg`·`xl`·`sm` 리터럴을 `shadow-[var(--elev-overlay)]`로 치환(P0 규칙서 L1).

## 대상 (18파일)
chats/layout.tsx · docs-client-layout.tsx(모바일 드로어) · entity-dispatch-panel.tsx · doc-assignee-control.tsx · entity-aware-textarea.tsx · kanban-board.tsx(에러배너) · kanban-list-view.tsx · doc-editor.tsx · slash-command.tsx · artifact-expand-dialog.tsx · mobile-selection-menu.tsx · wiki-link.tsx(2곳) · story-detail-panel.tsx(2곳, 모바일 시트) · comment-compose-popover.tsx · command-palette.tsx · notification-bell.tsx · flow-node-story-panel.tsx(3곳) · byom-key-management.tsx(토큰만, 아래 참고)

## 스코프 밖 판단(임의 확대 안 함)
- **card.tsx glass variant**: #2969(PR-2)에서 이미 「정책 검토로 별도 보류·범위 밖」이라 명시적으로 스킵됐던 축(주석에 박제, doc `proofline-system-layer-2969`는 아직 draft) — 이번 PR이 임의로 뒤집지 않고 그대로 보류. PO 확定.
- **byom-key-management.tsx**: 공유 `Dialog`/`DialogContent` 원시가 consumer의 className에 `shadow-xl`로 덮어써지던 인콘시스턴시를 발견. 원시 교체(Dialog 자체 재사용)가 정공이나 동작 리스크 판단상 이번엔 보류 — 토큰만 치환(리팩터에 동작 변화 0 원칙, PO 확定).

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4336 tests all green
- [x] `pnpm build` green

## 회귀가드 커버리지(투명 고지)
- 기존 컴포넌트-렌더 테스트 인프라가 있던 11개 파일 중 10개에 신규 elevation 회귀가드 테스트 추가(`slash-command.tsx`는 기존 테스트가 `calculatePopupPosition` 순수함수만 커버 — 컴포넌트 렌더 하네스 자체가 없어 스킵).
- 신규 테스트 10건 전부 `git stash`로 pre-fix 소스에서 실패 재현 확인 → fix 복원 후 통과 재확인(진짜 회귀가드 증명).
- **테스트 파일 자체가 없던 7개**(doc-assignee-control · kanban-list-view · doc-editor · mobile-selection-menu · wiki-link · comment-compose-popover · byom-key-management)는 신규 테스트를 작성하지 않음 — 순수 리터럴 문자열 치환(로직 변경 0)이라 tsc/eslint 통과 + 직접 grep 재확인으로 정확성을 확보했고, 배포 후 라이브 픽셀 검증으로 최종 확인 예정.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA