### PR TITLE
[SID:3009] 로드맵 P2·PR-F — shadow-md 전역 분류 실행② 인라인 카드 10곳 → --elev-card

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx
@@ -511,7 +511,8 @@ export default function StandupPage({ projectId }: StandupClientProps) {
                         <div className="space-y-3">
                           <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                             {stories.map((story) => (
-                              <div key={story.id} className="rounded-xl border border-border/70 bg-background p-4 shadow-sm">
+                              // story #3009(로드맵 P2·PR-F, L1) — 인라인 카드는 --elev-card(아래 2곳).
+                              <div key={story.id} className="rounded-xl border border-border/70 bg-background p-4 shadow-[var(--elev-card)]">
                                 <div className="flex flex-wrap items-center justify-between gap-2">
                                   <p className="text-sm font-medium text-foreground">{story.title}</p>
                                   <Badge variant="outline">{story.status}</Badge>
@@ -638,7 +639,7 @@ export default function StandupPage({ projectId }: StandupClientProps) {
 
                       if (isCurrentUser && editingSelf) {
                         return (
-                          <div key={member.id} className="rounded-xl border border-brand/40 bg-card p-4 shadow-sm space-y-4">
+                          <div key={member.id} className="rounded-xl border border-brand/40 bg-card p-4 shadow-[var(--elev-card)] space-y-4">
                             <div className="flex flex-wrap items-center justify-between gap-2">
                               <div className="space-y-0.5">
                                 <h3 className="text-sm font-semibold text-foreground">{t('orgLevelTitle')}</h3>

--- a/apps/web/src/components/canvas/artifact-editor.test.tsx
+++ b/apps/web/src/components/canvas/artifact-editor.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { ArtifactViewer } from './artifact-viewer';
+import { ArtifactEditor } from './artifact-editor';
 import { CommitBar } from './commit-bar';
 import { MOCK_ARTIFACT, MOCK_VERSIONS, MOCK_MEMBERS, MOCK_EDITABLE_ARTIFACT } from '@/services/canvas';
 
@@ -54,5 +55,16 @@ describe('C3 감시-게이트 회귀가드 (§4 — 편집 표면은 CCTV로 가
   it('CommitBar disables the save action when there are no changes (no empty commits)', () => {
     const markup = renderToStaticMarkup(wrap(<CommitBar changeCount={0} onCommit={() => {}} />));
     expect(markup).toContain('disabled=""');
+  });
+});
+
+// story #3009(로드맵 P2·PR-F, L1) — 인라인 카드는 --elev-card.
+describe('ArtifactEditor — 로드맵 P2·PR-F L1(인라인 카드 elevation 토큰)', () => {
+  it('카드 셸이 shadow-[var(--elev-card)]를 쓰고 shadow-sm은 안 쓴다', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<ArtifactEditor title="t" initialNodes={[]} />),
+    );
+    expect(markup).toContain('shadow-[var(--elev-card)]');
+    expect(markup).not.toMatch(/shadow-sm["\s]/);
   });
 });

--- a/apps/web/src/components/canvas/artifact-editor.tsx
+++ b/apps/web/src/components/canvas/artifact-editor.tsx
@@ -54,7 +54,8 @@ export function ArtifactEditor({ title, initialNodes, onCommit, onDone, artifact
 
   return (
     <div className={className}>
-      <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+      {/* story #3009(로드맵 P2·PR-F, L1) — 인라인 카드는 --elev-card. */}
+      <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-[var(--elev-card)]">
         <div className="flex items-center gap-2.5 border-b border-border px-4 py-3">
           <span className="truncate text-sm font-semibold text-foreground">{title}</span>
           <span className="rounded-md border border-border bg-muted px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-muted-foreground">

--- a/apps/web/src/components/canvas/artifact-viewer.test.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.test.tsx
@@ -385,3 +385,14 @@ describe('ArtifactViewer — 새 좌표 코멘트 생성(story #2725, commentsCo
     expect(container.querySelector('textarea')).toBeNull();
   });
 });
+
+// story #3009(로드맵 P2·PR-F, L1) — 인라인 카드는 --elev-card.
+describe('ArtifactViewer — 로드맵 P2·PR-F L1(인라인 카드 elevation 토큰)', () => {
+  it('카드 셸이 shadow-[var(--elev-card)]를 쓰고 shadow-sm은 안 쓴다', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+    );
+    expect(markup).toContain('shadow-[var(--elev-card)]');
+    expect(markup).not.toMatch(/shadow-sm["\s]/);
+  });
+});

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -107,7 +107,8 @@ export function ArtifactViewer({
 
   return (
     <div className={className}>
-      <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+      {/* story #3009(로드맵 P2·PR-F, L1) — 인라인 카드는 --elev-card. */}
+      <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-[var(--elev-card)]">
         <div className="flex items-center gap-2.5 border-b border-border px-4 py-3">
           <span className="truncate text-sm font-semibold text-foreground">{artifact.title}</span>
           <span className="rounded-md border border-border bg-muted px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-muted-foreground">

--- a/apps/web/src/components/canvas/comment-thread-card.test.tsx
+++ b/apps/web/src/components/canvas/comment-thread-card.test.tsx
@@ -55,4 +55,12 @@ describe('CommentThreadCard', () => {
       expect(markup).not.toContain(forbidden);
     }
   });
+
+  // story #3009(로드맵 P2·PR-F, L1) — 인라인 카드는 --elev-card.
+  it('카드 셸이 shadow-[var(--elev-card)]를 쓰고 shadow-sm은 안 쓴다', () => {
+    const open = MOCK_THREADS.find((t) => t.rollup === 'open')!;
+    const markup = renderToStaticMarkup(wrap(<CommentThreadCard thread={open} memberMap={MOCK_MEMBERS} />));
+    expect(markup).toContain('shadow-[var(--elev-card)]');
+    expect(markup).not.toMatch(/shadow-sm["\s]/);
+  });
 });

--- a/apps/web/src/components/canvas/comment-thread-card.tsx
+++ b/apps/web/src/components/canvas/comment-thread-card.tsx
@@ -47,7 +47,8 @@ export function CommentThreadCard({
   };
 
   return (
-    <div className={cn('rounded-xl border border-border bg-card shadow-sm', resolved && 'opacity-70', className)}>
+    // story #3009(로드맵 P2·PR-F, L1) — 인라인 카드는 --elev-card.
+    <div className={cn('rounded-xl border border-border bg-card shadow-[var(--elev-card)]', resolved && 'opacity-70', className)}>
       <div className="flex items-center gap-2 border-b border-border px-3 py-2">
         <AnchorPin
           number={thread.pin_number}

--- a/apps/web/src/components/flow/hypothesis-earth-layer.test.tsx
+++ b/apps/web/src/components/flow/hypothesis-earth-layer.test.tsx
@@ -111,6 +111,15 @@ describe('HypothesisEarthLayer — story #2531 AC(measuring 선명·proposed 흐
     expect(card?.className).toContain('opacity-60');
   });
 
+  // story #3009(로드맵 P2·PR-F, L1) — hover 시 인라인 카드 강조는 --elev-card.
+  it('카드가 hover:shadow-[var(--elev-card)]를 쓰고 hover:shadow-sm은 안 쓴다', async () => {
+    await renderLayer(vi.fn(() => jsonResponse([makeHypothesis({ id: 'h1', status: 'measuring', statement: 'Q1' })])));
+
+    const card = Array.from(container.querySelectorAll('p')).find((p) => p.textContent === 'Q1')?.closest('div');
+    expect(card?.className).toContain('hover:shadow-[var(--elev-card)]');
+    expect(card?.className).not.toMatch(/hover:shadow-sm(\s|$)/);
+  });
+
   it('archived는 그리드·결론난 섹션 어디에도 안 뜬다(더미 미표시)', async () => {
     await renderLayer(vi.fn(() => jsonResponse([
       makeHypothesis({ id: 'h6', status: 'archived', statement: 'DEAD-archived' }),

--- a/apps/web/src/components/flow/hypothesis-earth-layer.tsx
+++ b/apps/web/src/components/flow/hypothesis-earth-layer.tsx
@@ -50,7 +50,8 @@ function HypothesisCard({
         if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(hypothesis.id); }
       }}
       className={cn(
-        'flex cursor-pointer flex-col gap-2.5 rounded-xl border border-border bg-card p-4 text-left transition hover:border-brand/60 hover:shadow-sm',
+        // story #3009(로드맵 P2·PR-F, L1) — hover 시 인라인 카드 강조는 --elev-card.
+        'flex cursor-pointer flex-col gap-2.5 rounded-xl border border-border bg-card p-4 text-left transition hover:border-brand/60 hover:shadow-[var(--elev-card)]',
         dim && 'opacity-60',
         // story #2543 — 방금 심은 가설(guided 생성 직후) 하이라이트. mockup .hcard.new와
         // 같은 결(브랜드 링 + 배지) — 가설 반증에 빨강을 못 쓰는 규율과 무관한 순수 강조색.

--- a/apps/web/src/components/org-briefing/loop-face.test.tsx
+++ b/apps/web/src/components/org-briefing/loop-face.test.tsx
@@ -118,4 +118,13 @@ describe('LoopFace', () => {
     await mount();
     expect(container.innerHTML).toContain('bg-info');
   });
+
+  // story #3009(로드맵 P2·PR-F, L1) — hover 시 인라인 카드 강조는 --elev-card.
+  it('카드 셸이 hover:shadow-[var(--elev-card)]를 쓰고 hover:shadow-sm은 안 쓴다', async () => {
+    stubFetch({ data: [] }, { data: { project_status: { epics: [] } } });
+    await mount();
+    const card = container.firstElementChild;
+    expect(card?.className).toContain('hover:shadow-[var(--elev-card)]');
+    expect(card?.className).not.toMatch(/hover:shadow-sm(\s|$)/);
+  });
 });

--- a/apps/web/src/components/org-briefing/loop-face.tsx
+++ b/apps/web/src/components/org-briefing/loop-face.tsx
@@ -78,7 +78,8 @@ export function LoopFace({ projectId }: { projectId: string }) {
   }, [projectId, t]);
 
   return (
-    <div className="rounded-2xl border border-border bg-card p-4 transition-shadow hover:shadow-sm">
+    // story #3009(로드맵 P2·PR-F, L1) — hover 시 인라인 카드 강조는 --elev-card.
+    <div className="rounded-2xl border border-border bg-card p-4 transition-shadow hover:shadow-[var(--elev-card)]">
       <div className="mb-3 flex items-baseline gap-2.5">
         <span className="size-1.5 shrink-0 rounded-full bg-info" aria-hidden="true" />
         <h2 className="text-sm font-semibold text-foreground">{t('loopTitle')}</h2>

--- a/apps/web/src/components/org-briefing/now-face.test.tsx
+++ b/apps/web/src/components/org-briefing/now-face.test.tsx
@@ -73,6 +73,18 @@ describe('NowFace', () => {
     expect(html).not.toContain('merge'); // gate_type 슬러그 미노출
   });
 
+  // story #3009(로드맵 P2·PR-F, L1) — hover 시 인라인 카드 강조는 --elev-card.
+  it('카드 셸이 hover:shadow-[var(--elev-card)]를 쓰고 hover:shadow-sm은 안 쓴다', async () => {
+    stubFetch(
+      { action_queue: { items: [{ type: 'gate_approval', priority: 'warn', context: { kind: 'canonical' } }] }, attention: { items: [] } },
+      { data: [] },
+    );
+    await mount();
+    const card = container.querySelector('.rounded-2xl.border.border-border.bg-card');
+    expect(card?.className).toContain('hover:shadow-[var(--elev-card)]');
+    expect(card?.className).not.toMatch(/hover:shadow-sm(\s|$)/);
+  });
+
   it('renders the calm empty state ("모두 확인했어요") when both sources are empty — no alarming iconography text', async () => {
     stubFetch(
       { action_queue: { items: [] }, attention: { items: [] } },

--- a/apps/web/src/components/org-briefing/now-face.tsx
+++ b/apps/web/src/components/org-briefing/now-face.tsx
@@ -155,19 +155,20 @@ export function NowFace() {
           memberNames={memberNames}
         />
       ) : null}
+      {/* story #3009(로드맵 P2·PR-F, L1) — hover 시 인라인 카드 강조는 --elev-card(아래 3곳). */}
       {items === null ? (
-        <div className="rounded-2xl border border-border bg-card transition-shadow hover:shadow-sm">
+        <div className="rounded-2xl border border-border bg-card transition-shadow hover:shadow-[var(--elev-card)]">
           {Array.from({ length: 3 }).map((_, i) => <RowSkeleton key={i} />)}
         </div>
       ) : nothingPending ? (
-        <div className="rounded-2xl border border-border bg-card transition-shadow hover:shadow-sm">
+        <div className="rounded-2xl border border-border bg-card transition-shadow hover:shadow-[var(--elev-card)]">
           <div className="flex flex-col items-center gap-1.5 px-5 py-10 text-center">
             <CheckCircle2 className="size-5 text-success/70" aria-hidden="true" />
             <p className="text-sm font-medium text-foreground">{t('nowEmptyTitle')}</p>
           </div>
         </div>
       ) : list.length > 0 ? (
-        <div className="rounded-2xl border border-border bg-card transition-shadow hover:shadow-sm">
+        <div className="rounded-2xl border border-border bg-card transition-shadow hover:shadow-[var(--elev-card)]">
           {shown.map((item) => (
             <NowRow key={item.id} item={item} />
           ))}

--- a/apps/web/src/components/org-briefing/workforce-face.test.tsx
+++ b/apps/web/src/components/org-briefing/workforce-face.test.tsx
@@ -111,4 +111,13 @@ describe('WorkforceFace', () => {
     expect(html).not.toMatch(/\d+\s*(분|시간|일)(?!건)/);
     expect(html).not.toMatch(/순위|랭킹|처리량/);
   });
+
+  // story #3009(로드맵 P2·PR-F, L1) — hover 시 인라인 카드 강조는 --elev-card.
+  it('카드 셸이 hover:shadow-[var(--elev-card)]를 쓰고 hover:shadow-sm은 안 쓴다', async () => {
+    stubFetch(OVERVIEW, {}, MEMBERS);
+    await mount();
+    const card = container.firstElementChild;
+    expect(card?.className).toContain('hover:shadow-[var(--elev-card)]');
+    expect(card?.className).not.toMatch(/hover:shadow-sm(\s|$)/);
+  });
 });

--- a/apps/web/src/components/org-briefing/workforce-face.tsx
+++ b/apps/web/src/components/org-briefing/workforce-face.tsx
@@ -98,7 +98,8 @@ export function WorkforceFace({ projectId }: { projectId: string }) {
   }, [projectId, t]);
 
   return (
-    <div className="rounded-2xl border border-border bg-card p-4 transition-shadow hover:shadow-sm">
+    // story #3009(로드맵 P2·PR-F, L1) — hover 시 인라인 카드 강조는 --elev-card.
+    <div className="rounded-2xl border border-border bg-card p-4 transition-shadow hover:shadow-[var(--elev-card)]">
       <div className="mb-3 flex items-baseline gap-2.5">
         <span className="size-1.5 shrink-0 rounded-full bg-success" aria-hidden="true" />
         <h2 className="text-sm font-semibold text-foreground">{t('workforceTitle')}</h2>

--- a/apps/web/src/components/standup/standup-board-card.tsx
+++ b/apps/web/src/components/standup/standup-board-card.tsx
@@ -33,7 +33,8 @@ export function StandupBoardCard({
   const commentCount = feedback.filter((f) => f.review_type === 'comment').length;
 
   return (
-    <div className={cn('flex flex-col rounded-xl border border-border bg-card shadow-sm', isCurrentUser && 'ring-1 ring-brand/40')}>
+    // story #3009(로드맵 P2·PR-F, L1) — 인라인 카드는 --elev-card.
+    <div className={cn('flex flex-col rounded-xl border border-border bg-card shadow-[var(--elev-card)]', isCurrentUser && 'ring-1 ring-brand/40')}>
       {/* Header */}
       <div className="flex flex-wrap items-start justify-between gap-2 px-4 pt-4">
         <div className="min-w-0 flex-1 space-y-1">


### PR DESCRIPTION
## 요약
로드맵 doc `proofline-surface-rollout-roadmap-2984` P2 PR-F. #2999 그라운딩(2223b1a7) 실행분 ②. 스토리 #3009. PR-E와 파일 겹침 없어 병행 착수(PO 지시).

인라인 카드 `shadow-sm` 리터럴 **12곳**을 `shadow-[var(--elev-card)]`로 치환(P0 규칙서 L1).

> **정정(2026-08-24, 카디르 QA 교차검증·페드루군 지적)** — 최초 본문이 "10곳"으로 오기재됐음. `git diff`로 재확인한 실측은 **12곳**(아래 목록의 실제 합계와 일치, 코드 변경 자체는 무결). 리뷰가 이 수로 범위를 세우는 자리라 서술만 「세고 적는」걸로 정정.

## 대상 (9파일, 12곳)
- `standup-client.tsx`(2곳) · `artifact-editor.tsx`(1곳) · `comment-thread-card.tsx`(1곳) · `artifact-viewer.tsx`(1곳) · `standup-board-card.tsx`(1곳) — 정적 인라인 카드
- `hypothesis-earth-layer.tsx`(1곳) · `org-briefing/loop-face.tsx`(1곳) · `workforce-face.tsx`(1곳) · `now-face.tsx`(3곳) — `hover:shadow-sm` 관례(hover 강조), 4파일 동일 패턴이라 한 판으로 묶어 처리

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4343 tests all green
- [x] `pnpm build` green

## 회귀가드 커버리지(투명 고지)
- 기존 컴포넌트-렌더 테스트 인프라가 있던 7개 파일 전부에 신규 elevation 회귀가드 테스트 추가.
- 신규 테스트 7건 전부 `git stash`로 pre-fix 소스에서 실패 재현 확인 → fix 복원 후 통과 재확인.
- **테스트 파일 자체가 없던 2개**(standup-client.tsx · standup-board-card.tsx)는 신규 테스트를 작성하지 않음 — PR-E와 동일 방침(순수 리터럴 치환, tsc/eslint/grep 직접확인+배포 후 라이브 픽셀로 갈음).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA