### PR TITLE
[SID:3010] 로드맵 P3 통합 — inbox L5·설정 L1·attention-queue L5/L6

### DIFF
--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -595,11 +595,13 @@ export default function InboxPage() {
                             {notification.body ? (
                               <p className="line-clamp-1 text-xs text-muted-foreground">{notification.body}</p>
                             ) : null}
-                            {/* 목업 ⑤: 타입 1급 — agent_joined=Bot 칩(accent-claim)·도달사유 칩 */}
+                            {/* 목업 ⑤: 타입 1급 — agent_joined=Bot 칩·도달사유 칩. story #3010(로드맵
+                                P3, L5) — 정적 정체성 마킹은 citron이 아니라 proof-blue-soft
+                                (P1 PR-B 챗 Bot배지·avatar.tsx 관례와 동형). */}
                             {(notification.type === 'agent_joined' || reasonKey) ? (
                               <div className="flex flex-wrap items-center gap-1.5">
                                 {notification.type === 'agent_joined' ? (
-                                  <Badge className="gap-0.5 bg-accent-claim/15 text-foreground text-[10px]">
+                                  <Badge className="gap-0.5 bg-proof-blue-soft text-foreground text-[10px]">
                                     <Bot className="size-2.5" />Bot
                                   </Badge>
                                 ) : null}

--- a/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
@@ -216,3 +216,36 @@ describe('AttentionQueueView — typeBadge 배선 (story #2923 AQ2)', () => {
     expect(container.textContent).toContain('GATE');
   });
 });
+
+// story #3010(로드맵 P3, L5 대비) — kicker/empty body는 text-proof-faint(라이트 대비 미달)
+// 대신 text-proof-ink-3.
+describe('AttentionQueueView — 로드맵 P3 L5(faint 텍스트 대비 정정)', () => {
+  it('kicker가 text-proof-ink-3를 쓰고 text-proof-faint는 안 쓴다', async () => {
+    await mount(mockGatePendingOnly());
+    const kicker = [...container.querySelectorAll('div')].find((d) => d.className.includes('uppercase') && d.className.includes('tracking-[0.12em]'));
+    expect(kicker?.className).toContain('text-proof-ink-3');
+    expect(container.querySelector('.text-proof-faint')).toBeNull();
+  });
+
+  it('빈 상태 empty body가 text-proof-ink-3를 쓰고 text-proof-faint는 안 쓴다', async () => {
+    await mount(async (url: string) => {
+      if (url.includes('/api/glance/attention')) return { ok: true, json: async () => ({ data: { items: [] } }) };
+      return { ok: true, json: async () => ({ data: [] }) };
+    });
+    const emptyBody = [...container.querySelectorAll('p')].find((p) => p.className.includes('text-[12.5px]'));
+    expect(emptyBody?.className).toContain('text-proof-ink-3');
+    expect(container.querySelector('.text-proof-faint')).toBeNull();
+  });
+});
+
+// story #3010(로드맵 P3, L6, 유나 판정 2026-08-24) — 섹션 주 제목 h2는 font-editorial-heading
+// (820 weight)로, 19px 크기는 유지.
+describe('AttentionQueueView — 로드맵 P3 L6(섹션 제목 editorial weight)', () => {
+  it('h2가 font-editorial-heading을 쓰고 text-[19px]는 유지한다', async () => {
+    await mount(mockGatePendingOnly());
+    const h2 = container.querySelector('h2');
+    expect(h2?.className).toContain('font-editorial-heading');
+    expect(h2?.className).toContain('text-[19px]');
+    expect(h2?.className).not.toContain('font-extrabold');
+  });
+});

--- a/apps/web/src/components/attention-queue/attention-queue-view.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.tsx
@@ -201,9 +201,14 @@ export function AttentionQueueView({ projectId, memberId }: { projectId: string;
     // story #2955 §5 — 인라인 clip-path를 정본 `.proof-cut` 유틸(globals.css)로 이관(24px 기본값 그대로).
     <div className="proof-cut overflow-hidden rounded-2xl border border-proof-line bg-proof-panel">
       <div className="flex items-baseline justify-between gap-3 border-b border-proof-line-soft px-5 py-3.5">
+        {/* story #3010(로드맵 P3, L5 대비) — text-proof-faint 라이트 대비 미달(story #2993
+            유나 처방과 동일 클래스) → text-proof-ink-3(아래 kicker·empty body 2곳). */}
         <div>
-          <div className="text-[11px] font-bold uppercase tracking-[0.12em] text-proof-faint">{t('kicker')}</div>
-          <h2 className="text-[19px] font-extrabold leading-tight tracking-[-0.014em] text-proof-ink">{t('title')}</h2>
+          <div className="text-[11px] font-bold uppercase tracking-[0.12em] text-proof-ink-3">{t('kicker')}</div>
+          {/* story #3010(로드맵 P3, L6, 유나 판정 2026-08-24) — 이 h2는 반복 그룹 라벨이 아니라
+              섹션 주 제목(단일 마운트)이라 L6 대상. weight만 font-editorial-heading(820)로
+              교체, 19px 크기는 유지. */}
+          <h2 className="text-[19px] font-editorial-heading leading-tight tracking-[-0.014em] text-proof-ink">{t('title')}</h2>
         </div>
         {!loading ? (
           <div className="shrink-0 text-[13px] font-medium text-proof-ink-3">
@@ -220,7 +225,7 @@ export function AttentionQueueView({ projectId, memberId }: { projectId: string;
             <ShieldCheck className="size-3.5" aria-hidden="true" />{t('allClear')}
           </div>
           <p className="text-[15px] font-semibold text-proof-ink-2">{t('emptyTitle')}</p>
-          <p className="text-[12.5px] text-proof-faint">{t('emptyBody')}</p>
+          <p className="text-[12.5px] text-proof-ink-3">{t('emptyBody')}</p>
         </div>
       ) : (
         <div>

--- a/apps/web/src/components/settings/workflow-template-gallery-section.test.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.test.tsx
@@ -121,3 +121,22 @@ describe('WorkflowTemplateGallerySection — error.code 분기 (story #2501)', (
     expect(container.textContent).toContain('적용 실패');
   });
 });
+
+// story #3010(로드맵 P3, L1) — 선택 가능한 템플릿 카드는 인라인 카드라 --elev-card.
+describe('WorkflowTemplateGallerySection — 로드맵 P3 L1(템플릿 카드 elevation 토큰)', () => {
+  it('템플릿 카드가 hover:shadow-[var(--elev-card)]를 쓰고 hover:shadow-sm은 안 쓴다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/workflow-templates' && !init) return { ok: true, json: async () => [TEMPLATE] };
+      if (url.includes('/api/team-members')) return { ok: true, json: async () => ({ data: [] }) };
+      if (url.includes('/api/v1/agent-routing-rules')) return { ok: true, json: async () => ({ data: [] }) };
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap(<WorkflowTemplateGallerySection projectId="proj-1" />)); });
+    await flush();
+
+    const tmplBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('테스트 템플릿'));
+    expect(tmplBtn).not.toBeUndefined();
+    expect(tmplBtn?.className).toContain('hover:shadow-[var(--elev-card)]');
+    expect(tmplBtn?.className).not.toMatch(/hover:shadow-sm(\s|$)/);
+  });
+});

--- a/apps/web/src/components/settings/workflow-template-gallery-section.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.tsx
@@ -189,7 +189,8 @@ export function WorkflowTemplateGallerySection({
               key={tmpl.slug}
               onClick={() => void handleSelectTemplate(tmpl)}
               disabled={loadingDetail}
-              className={`rounded-lg border p-4 text-left transition hover:border-primary/60 hover:shadow-sm disabled:opacity-60 ${
+              // story #3010(로드맵 P3, L1) — 선택 가능한 인라인 카드는 --elev-card.
+              className={`rounded-lg border p-4 text-left transition hover:border-primary/60 hover:shadow-[var(--elev-card)] disabled:opacity-60 ${
                 selected?.slug === tmpl.slug ? 'border-primary bg-primary/5' : 'border-border bg-background'
               }`}
             >


### PR DESCRIPTION
## 요약
로드맵 doc `proofline-surface-rollout-roadmap-2984` P3(PR-G inbox·PR-H 설정) 그라운딩 확定분 통합. 스토리 #3010. PO 절충 지시(2026-08-24) — 두 표면 다 스코프 작아 통합 1 PR.

- `inbox/page.tsx`: agent_joined Bot 칩 `bg-accent-claim/15` → `bg-proof-blue-soft`(P1 PR-B 관례 동형).
- `attention-queue-view.tsx`: kicker·empty body `text-proof-faint`(라이트 대비 미달, #2993 유나 처방과 동일 클래스) → `text-proof-ink-3`(2곳).
- `workflow-template-gallery-section.tsx`: 템플릿 선택 카드 `hover:shadow-sm` → `hover:shadow-[var(--elev-card)]`(PR-F 동형 패턴).

## 유나 판정 2건 반영
- **attention-queue-view.tsx h2 섹션 제목**: `font-extrabold` → `font-editorial-heading`(820, 19px 크기 유지) — 반복 그룹 라벨이 아니라 단일 마운트 주 제목이라 L6 대상(코드 확인: 이 컴포넌트 전체에 h2가 이거 하나뿐, inbox/page.tsx에 1회 마운트).
- **`highlighted && bg-proof-citron/15`(신규 항목 도착 플래시)**: 무변경 — 코드 확인 결과 실측 `HIGHLIGHT_MS=900`(요청 700ms와 근사), diff 발생 시에만 `setTimeout`으로 자동 해제되는 진짜 일시 플래시(live 이벤트 신호) → L5 준수.

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest run` — 4340 tests all green
- [x] `pnpm build` green

## 회귀가드 커버리지(투명 고지)
- 기존 컴포넌트-렌더 테스트 인프라가 있던 2개 파일(`attention-queue-view.tsx`·`workflow-template-gallery-section.tsx`)에 신규 회귀가드 4건 추가, 전부 `git stash`로 pre-fix 실패 확인 후 fix 복원해 통과 재확인.
- **`inbox/page.tsx`는 기존 테스트 파일 자체가 없어** 신규 테스트 미작성(PR-E/F와 동일 방침) — tsc/eslint/grep 직접확인+배포 후 라이브 픽셀로 갈음.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Tkpv7P3qyLKcjjvzbnEDyA