### PR TITLE
[SID:3011] Workcell Brief 셀 값 컬럼 min-w-0+break-words — 우측 글자 잘림 fix

### DIFF
--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -60,6 +60,49 @@ describe('Workcell (4층 — Brief/Run/Evidence/Conversation)', () => {
   });
 });
 
+// story 38f524e1(critical, 선생님 실사고 2026-08-24) — Brief 셀 label+값 flex 행의 값
+// 컬럼에 min-w-0이 없어 긴 무단절 토큰(코드·경로)이 min-content 폭을 강제, lg 3열 좁은
+// 우열(246px)에서 셀 밖까지 뻗어 조상 overflow-hidden에 글자 중간 클리핑됐다. jsdom은 실제
+// 레이아웃을 측정 못 하므로(라이브 픽셀 검증은 별도, feedback-render-test-over-source-grep)
+// 이 테스트는 클리핑을 막는 CSS 메커니즘(min-w-0 + break-words)이 값 컬럼에 실제로 배선돼
+// 있는지에 대한 회귀가드다.
+describe('Workcell — story 38f524e1 Brief 값 컬럼 min-w-0/break-words 회귀가드', () => {
+  it('goal/dod/scopes 값 span 모두 min-w-0 break-words를 갖는다(긴 코드·경로 토큰도 셀 폭 안에 수납)', () => {
+    const longToken = 'workcell-bento-form-material-spec-2984-extremely-long-inline-code-path-token';
+    const markup = renderKo(
+      <Workcell
+        {...BASE}
+        brief={{ ...BASE.brief, goal: longToken, dod: longToken, scopes: [longToken] }}
+      />,
+    );
+    // goal·dod·scopes(단일 원소라 join 결과도 동일 문자열) 셋 다 같은 긴 토큰이라 span이
+    // 3개 생긴다 — 셋 다 min-w-0 break-words를 갖는지 개별 확인해 하나만 고치고 방치하는
+    // 회귀를 잡는다.
+    const valueMatches = [...markup.matchAll(/<span class="([^"]*)">workcell-bento-form-material-spec-2984-extremely-long-inline-code-path-token<\/span>/g)];
+    expect(valueMatches).toHaveLength(3);
+    for (const m of valueMatches) {
+      expect(m[1].split(/\s+/)).toEqual(expect.arrayContaining(['min-w-0', 'break-words']));
+    }
+
+    expect(markup).toMatch(/class="[^"]*\bmin-w-0\b[^"]*\bbreak-words\b[^"]*font-mono[^"]*"/);
+  });
+
+  it('Run 요약(tools/scopes)도 실 파일경로 토큰 리스크가 있어 동형 처방(min-w-0 break-words)이 붙는다', () => {
+    const markup = renderKo(
+      <Workcell {...BASE} run={{ ...BASE.run, tools: ['apps/web/src/components/workcell/workcell.tsx'], scopes: ['apps/web/src/components/workcell/'] }} />,
+    );
+    // ko.json workcell.runTools = "도구" — 그 라벨을 안은 span의 class에 min-w-0/break-words가
+    // 실제로 붙었는지 확인(라벨 텍스트로 정확히 좁혀 다른 span과 오탐 방지).
+    const runToolsMatch = markup.match(/<span class="([^"]*)">도구 apps\/web\/src\/components\/workcell\/workcell\.tsx<\/span>/);
+    expect(runToolsMatch).toBeTruthy();
+    expect(runToolsMatch![1].split(/\s+/)).toEqual(expect.arrayContaining(['min-w-0', 'break-words']));
+
+    const runScopesMatch = markup.match(/<span class="([^"]*)">권한 apps\/web\/src\/components\/workcell\/<\/span>/);
+    expect(runScopesMatch).toBeTruthy();
+    expect(runScopesMatch![1].split(/\s+/)).toEqual(expect.arrayContaining(['min-w-0', 'break-words']));
+  });
+});
+
 // story #2922 W4 — 책임자/실행자가 헤더 한 곳으로 승격됐다(Brief 구획 중복 제거).
 describe('Workcell — story #2922 W4 책임자/실행자 헤더 승격(중복 제거 회귀가드)', () => {
   it('owner/agent "라벨+이름" 텍스트가 정확히 한 번씩만 렌더된다(헤더 SSOT, Brief에 중복 없음)', () => {

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -340,18 +340,22 @@ function BriefLayer({ brief }: { brief: WorkcellBrief }) {
       <LayerLabel title="Brief" question={t('briefQuestion')} className="mb-2.5" />
       <div className="flex gap-2 text-[13px] leading-[1.5] text-proof-ink-2">
         <span className="w-16 shrink-0 pt-px text-[11px] text-proof-faint">{t('briefGoal')}</span>
-        <span className="text-proof-ink">{brief.goal}</span>
+        {/* story 38f524e1(critical, 선생님 실사고 2026-08-24) — flex 자식 기본 min-width:auto가
+            긴 무단절 토큰(인라인 코드·경로)의 min-content 폭을 그대로 요구해 축소를 거부하고
+            셀(246px) 밖까지 뻗어 조상 overflow-hidden에 글자 중간이 잘렸다. min-w-0으로 축소
+            허용 + break-words로 그 폭에서 토큰 내부 줄바꿈. */}
+        <span className="min-w-0 break-words text-proof-ink">{brief.goal}</span>
       </div>
       <div className="mt-1.5 flex gap-2 text-[13px] leading-[1.5] text-proof-ink-2">
         <span className="w-16 shrink-0 pt-px text-[11px] text-proof-faint">{t('briefDod')}</span>
-        <span className="text-proof-ink">{brief.dod}</span>
+        <span className="min-w-0 break-words text-proof-ink">{brief.dod}</span>
       </div>
       {/* story #2922 W4 — owner/agent는 헤더로 승격됐다(위 Workcell 헤더 참조, SSOT 이동).
           scopes만 남아 briefRoles 라벨을 계승. */}
       {brief.scopes && brief.scopes.length > 0 ? (
         <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[13px] leading-[1.5] text-proof-ink-2">
           <span className="w-16 shrink-0 pt-px text-[11px] text-proof-faint">{t('briefRoles')}</span>
-          <span className="font-mono text-[10.5px] text-proof-ink-3">{brief.scopes.join(' · ')}</span>
+          <span className="min-w-0 break-words font-mono text-[10.5px] text-proof-ink-3">{brief.scopes.join(' · ')}</span>
         </div>
       ) : null}
     </div>
@@ -366,8 +370,10 @@ function RunLayer({ run }: { run: WorkcellRun }) {
       <div className="mb-2 text-[13.5px] font-semibold text-proof-ink">{t('runNow')}: {run.now}</div>
       <div className="mb-2.5 flex flex-wrap gap-3.5 text-[11px] text-proof-ink-3">
         <span>{t('runStage')} <b className="font-semibold text-proof-ink-2">{run.stage}</b></span>
-        {run.tools.length > 0 ? <span className="font-mono text-[10.5px]">{t('runTools')} {run.tools.join(', ')}</span> : null}
-        {run.scopes.length > 0 ? <span className="font-mono text-[10.5px]">{t('runScopes')} {run.scopes.join(', ')}</span> : null}
+        {/* 38f524e1 동형 처방 — runScopes는 실제 파일경로 토큰(예: apps/web/src/…)이라
+            동일 클리핑 소지, min-w-0 + break-words 선제 적용. */}
+        {run.tools.length > 0 ? <span className="min-w-0 break-words font-mono text-[10.5px]">{t('runTools')} {run.tools.join(', ')}</span> : null}
+        {run.scopes.length > 0 ? <span className="min-w-0 break-words font-mono text-[10.5px]">{t('runScopes')} {run.scopes.join(', ')}</span> : null}
       </div>
       <div className="mb-2 text-[11.5px] text-proof-ink-3">
         {t('runBlocked')}: <b className={cn('font-semibold', run.blocked ? 'text-proof-amber' : 'text-proof-ink-2')}>{run.blocked ?? t('none')}</b>


### PR DESCRIPTION
## 요약
선생님 실사고(2026-08-24, #2990 bento 라이브 확認 중) — Brief 셀 본문이 우측 경계에서 글자 중간까지 잘림. story 38f524e1(critical).

**원인** — lg 3열 우열(clientWidth 246px)의 label+값 flex 행에서 값 컬럼에 `min-w-0`이 없어, flex 아이템 기본 `min-width:auto`가 긴 무단절 토큰(인라인 코드·경로)의 min-content 폭을 그대로 요구 → 축소 거부 → 값 span이 셀 밖까지 뻗음 → 조상 `overflow-hidden`이 글자 중간을 클리핑. PO 실측(scrollWidth 321 > clientWidth 210, 값 span width 249·x=1500)과 일치.

**처방** — 값 span에 `min-w-0` + `break-words` 동시 적용(PO 처방 방향 그대로).

## 변경
- `workcell.tsx` `BriefLayer`: goal/dod/scopes 값 span 3곳에 `min-w-0 break-words` 적용
- `workcell.tsx` `RunLayer`: tools/scopes 값 span — 실제 파일경로 토큰(예: `apps/web/src/components/workcell/workcell.tsx`)이 들어가는 동일 위험군이라 동형 처방 선제 적용
- `workcell.test.tsx`: 무단절 토큰 주입 시 값 span class에 `min-w-0`/`break-words`가 실제로 배선됐는지 확인하는 회귀가드 2건 추가

## AC2 — 컴포넌트 내 동일 label+값 flex 패턴 전수 grep 결과
`grep -n "flex gap-\|flex flex-wrap items-center gap-\|flex items-center gap-1.5 rounded" workcell.tsx` 7곳 전수 판정:

| 위치 | 판정 | 근거 |
|---|---|---|
| BriefLayer goal (L341) | **fix** | 고정폭 라벨 + 자유폭 값, no-wrap 행 — 정확히 재현된 결함 패턴 |
| BriefLayer dod (L345) | **fix** | 위와 동일 구조 |
| BriefLayer scopes (L351) | **fix** | `flex-wrap` 행이지만 값이 파일경로 join 결과라 단일 아이템 자체가 여전히 클리핑 위험 |
| RunLayer tools/scopes (L367) | **fix(선제)** | `flex-wrap`이지만 scopes는 실제 파일경로 토큰(코드형) — 동일 위험군으로 판단해 사전 처방 |
| Conversation 메시지 행 (L460) | **해당 없음** | 값 span에 `min-w-0`이 **이미 적용돼 있었음**(정본 패턴) — 이번 변경 없음 |
| 헤더 owner/agent 행 (L256) | **해당 없음** | Avatar+짧은 사람 이름(i18n 라벨), 코드형 무단절 토큰 없음 |
| PipelineStepper (L120) | **해당 없음** | 정적 짧은 i18n 라벨(Queued/Running 등), 사용자 데이터 아님 |

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint workcell.tsx workcell.test.tsx` clean (0 warning)
- [x] `vitest run workcell.test.tsx` — 38/38 green (신규 회귀가드 2건 포함)
- [x] `pnpm build` EXIT=0

## 실렌더 메커니즘 검증(jsdom 한계 보완 — feedback-render-test-over-source-grep)
`next build`가 만든 실제 컴파일 Tailwind CSS 번들을 그대로 로드한 격리 HTML로 PO 실측 조건(246px 셀 + `overflow-hidden` 조상)을 재현, 진짜 무단절 토큰(하이픈·공백 0개)으로 4가지 조합을 측정:

| 조합 | cell.scrollWidth vs clientWidth | 결과 |
|---|---|---|
| 처방 없음 | 598 vs 244 | 오버플로(재현) — 글자 중간 클리핑 |
| `min-w-0`만 | 598 vs 244 | **여전히 오버플로** — 박스는 안 크지만 글자 자체가 박스 밖으로 삐져나가 클리핑 지속(스크린샷으로 확인) |
| `break-words`만 | 598 vs 244 | 오버플로(재현) — min-w-0 없인 애초에 박스가 안 줄어 break 기회 자체가 없음 |
| `min-w-0` + `break-words`(적용한 fix) | 244 vs 244 | **오버플로 0** — 값이 셀 폭 안에서 줄바꿈, 클리핑 소멸 |

라이트·다크 양 테마 동일 결과 확인(스크린샷 4-way 비교, PO/유나께 별도 첨부).

## 반응형 회귀
- 단일 컬럼(<lg)·2994 모바일 스택 축은 이번 변경(값 span 내부 wrap 속성)과 무관 — 그리드 자체를 건드리지 않음.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_017Y8uNHvGThWG8QPBz1nhFz