### PR TITLE
[결재선·후속 다듬기] 배타화 무권한 vs 지정 결재선 문구 분리 — gate 상세 페이지

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3873,6 +3873,7 @@
     "gateReadonlyAuto": "Auto-passed · no action needed",
     "gateReadonlyNoVerdict": "No verdict recorded · nothing to review",
     "gateReadonlyNotAuthorized": "You don't have permission to approve this gate",
+    "gateReadonlyDesignatedElsewhere": "This approval is assigned to a designated approver",
     "mergeGateTitle": "Merge gate",
     "outcomeTrustLabel": "Outcome trust",
     "outcomeSummary": "{hit} hit · {resolved} resolved · last {days}d",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3873,6 +3873,7 @@
     "gateReadonlyAuto": "자동 통과 · 액션 불필요",
     "gateReadonlyNoVerdict": "판정 미거침 · 표시할 액션 없음",
     "gateReadonlyNotAuthorized": "본인은 이 게이트를 승인할 권한이 없습니다",
+    "gateReadonlyDesignatedElsewhere": "이 결재는 지정된 결재자에게 배정되어 있습니다",
     "mergeGateTitle": "머지 게이트",
     "outcomeTrustLabel": "가설 적중",
     "outcomeSummary": "적중 {hit} · 판정 {resolved} · 최근 {days}일",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -114,6 +114,35 @@ describe('GateDetailPage — can_approve 게이팅 (story #2091)', () => {
     expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(false);
   });
 
+  // story #3006(유나 design 관찰, 페드루 확定 2026-08-24) — can_approve=false가 "무권한"과
+  // "지정 결재선이 걸려 있음(그저 내가 아님)"을 뭉뚱그리던 것을 갈라 문맥을 회복한다.
+  it('can_approve=false + designated_approver_id가 나(currentTeamMemberId) 아니면 "지정됨" 문구로 분기한다', async () => {
+    useDashboardContextMock.mockReturnValue({
+      orgMemberships: [], projectMemberships: [], currentTeamMemberId: 'member-1',
+    });
+    await mount(gate({ can_approve: false, designated_approver_id: 'member-2' }));
+    expect(container.textContent).toContain(koMessages.cage.gateReadonlyDesignatedElsewhere);
+    expect(container.textContent).not.toContain(koMessages.cage.gateReadonlyNotAuthorized);
+  });
+
+  it('can_approve=false + designated_approver_id가 없으면(일반 게이트) 기존 일반 무권한 문구 그대로(회귀 0)', async () => {
+    useDashboardContextMock.mockReturnValue({
+      orgMemberships: [], projectMemberships: [], currentTeamMemberId: 'member-1',
+    });
+    await mount(gate({ can_approve: false, designated_approver_id: null }));
+    expect(container.textContent).toContain(koMessages.cage.gateReadonlyNotAuthorized);
+    expect(container.textContent).not.toContain(koMessages.cage.gateReadonlyDesignatedElsewhere);
+  });
+
+  it('can_approve=false + designated_approver_id가 나 자신이면(예: 프로젝트 접근을 잃은 지정자) 일반 무권한 문구(지정 사실이 이유가 아님)', async () => {
+    useDashboardContextMock.mockReturnValue({
+      orgMemberships: [], projectMemberships: [], currentTeamMemberId: 'member-1',
+    });
+    await mount(gate({ can_approve: false, designated_approver_id: 'member-1' }));
+    expect(container.textContent).toContain(koMessages.cage.gateReadonlyNotAuthorized);
+    expect(container.textContent).not.toContain(koMessages.cage.gateReadonlyDesignatedElsewhere);
+  });
+
   it('needsAction 자체가 false(예: block 판정)면 can_approve=true여도 버튼이 없다(게이트가 액션을 요구하지 않음)', async () => {
     await mount(gate({ can_approve: true, auto_decision_reason: 'block' }));
     const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -280,9 +280,19 @@ export default function GateDetailPage() {
                   // gate.can_approve=false(이 caller는 승인 권한 없음, BE per-caller 판정). 액션
                   // 버튼을 렌더하지 않고 왜 못 누르는지를 정직하게 알린다 — "이미 처리됨"과는
                   // 다른 사유이므로 별개 문구(gateReadonlyNotAuthorized)를 쓴다.
+                  //
+                  // story #3006(유나 design 관찰, 페드루 확定 2026-08-24) — #3001 카드배타화
+                  // 이후 이 표면(gate 상세, 직접 URL/감사 진입)이 「무권한」과 「지정 결재선이
+                  // 걸려 있음」을 같은 문구로 뭉뚱그리던 유일한 실 표적(챗카드는 비지정자에게
+                  // 애초 안 감 — approval-request-card.tsx 주석 참조). 이름은 안 싣는다(BE도
+                  // 안 주고, 지어내지 않는다는 이 코드베이스 관례 그대로).
                   <div className="space-y-3">
                     <GateEvidence gate={gate} />
-                    <p className="text-[11px] text-muted-foreground">{t('gateReadonlyNotAuthorized')}</p>
+                    <p className="text-[11px] text-muted-foreground">
+                      {gate.designated_approver_id && gate.designated_approver_id !== currentTeamMemberId
+                        ? t('gateReadonlyDesignatedElsewhere')
+                        : t('gateReadonlyNotAuthorized')}
+                    </p>
                   </div>
                 ) : usesSignatureFlow(deriveRiskLevel(gate)) ? (
                   // story #2975(유나양 design 판정 2026-08-24, PO 확定) — 409(gate_head_changed)


### PR DESCRIPTION
[SID:3006]

## Summary
- #3001 카드 배타화 이후 `gates/[id]/page.tsx`에서 owner/admin이 보는 무권한 상태가 「일반 권한 없음」뿐이라 "이 게이트는 지정 결재자에게 배정돼 있다"는 맥락이 사라지던 것을 분리.
- `designated_approver_id`가 설정돼 있고 현재 뷰어와 다를 때만 신규 문구(`gateReadonlyDesignatedElsewhere`), 그 외(미지정·본인 지정인데 다른 사유로 무권한)는 기존 일반 문구 그대로(회귀 0).
- 이름은 싣지 않음(BE도 이름을 안 주고, 지어내지 않는다는 관례 유지) — 확장안(이름 노출)은 페드루 확定으로 비채택.
- BE 신규 배관 0(`GateResponse.designated_approver_id`는 이미 살아있는 필드).
- 다른 컴포넌트(`approval-request-card.tsx`, `doc-gate-section.tsx`, `approvals-queue.tsx`) 그라운딩 결과 안전/무관 확認 — 코드 변경 불요.

## #3004 착지 후 리베이스 정합 확認
- 원 브랜치는 #3435(SID:3004, 결재선 필수화) 머지 전 develop 기준이었음 — origin/develop(7fa12832f, #3435/#3437/#3438/#3439 포함)으로 리베이스, 충돌 0.
- #3004는 `doc_approval`/`agent_decision_request` 2개 게이트 타입만 designated 필수화 — 다른 타입(merge_verdict_gate 등)은 여전히 미지정 가능하므로 이 커밋의 일반 문구 분기는 데드코드가 아니고 계속 유효(스토리 본문이 요구한 정합 확認 항목).

## Test plan
- [x] `vitest run apps/web/.../gates/[id]/page.test.tsx` — 19/19 green(신규 3건 포함)
- [x] `tsc --noEmit` — 0 errors
- [x] `eslint` — 0 errors
- [x] `verify:no-i18n-phrase-collision` — 신규 충돌 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)