### PR TITLE
[SID:3012] Workcell Conversation 메시지 값 span break-words 추가 — 3011 동일 클래스 잔존 fix

### DIFF
--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -397,6 +397,28 @@ describe('Workcell — story #2922 W5 Conversation 구획 = ChatProofSection 요
     expect(chatProofIdx).toBeLessThan(disclosureIdx);
   });
 
+  // story 8df36496(high, 3011 동일 클래스 잔존) — 카디르 QA(#3440) 발견: 메시지 본문 값 span이
+  // min-w-0만 갖고 break-words가 없었다. m.body는 자유텍스트라 URL·해시 등 무단절 토큰 실
+  // 위험군(#3440 하네스가 증명한 대로 min-w-0 단독으론 클리핑이 재현된다).
+  it('story 8df36496 — 메시지 본문 값 span이 min-w-0과 break-words를 동시에 갖는다(무단절 토큰 클리핑 회귀가드)', () => {
+    const longToken = 'https://example.com/xtremelylongunbrokenidentifiertoken1234567890abcdefghijklmnop';
+    const markup = renderKo(
+      <Workcell
+        {...BASE}
+        conversation={{ view: 'run', messages: [{ author: 'A', body: longToken }] }}
+      />,
+    );
+    // 정규식 이스케이프 없이 순수 문자열 탐색으로 토큰 직전의 span class를 역추적한다
+    // (동적 토큰을 정규식에 끼워넣는 이스케이프 버그를 원천 차단).
+    const bodyIdx = markup.indexOf(`>${longToken}`);
+    expect(bodyIdx).toBeGreaterThan(-1);
+    const spanOpenIdx = markup.lastIndexOf('<span class="', bodyIdx);
+    const classStart = spanOpenIdx + '<span class="'.length;
+    const classEnd = markup.indexOf('"', classStart);
+    const spanClass = markup.slice(classStart, classEnd);
+    expect(spanClass.split(/\s+/)).toEqual(expect.arrayContaining(['min-w-0', 'break-words']));
+  });
+
   it('댓글 N건 disclosure 라벨에 정확한 건수가 들어간다', () => {
     const markup = renderKo(
       <Workcell

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -465,7 +465,9 @@ function ConversationLayer({ conversation }: { conversation: WorkcellConversatio
               {conversation.messages.map((m, i) => (
                 <div key={i} className="flex gap-2 py-0.5 text-[12.5px] leading-[1.5] text-proof-ink-2">
                   <span className="shrink-0 whitespace-nowrap font-semibold text-proof-ink">{m.author}</span>
-                  <span className="min-w-0">
+                  {/* story 8df36496(high, 3011 동일 클래스 잔존) — min-w-0만 있고 break-words가
+                      없었다. m.body는 자유텍스트라 URL·해시 등 무단절 토큰 실 위험군. */}
+                  <span className="min-w-0 break-words">
                     {m.body}
                     {m.resultLink ? <span className="ml-1.5 font-mono text-[10.5px] text-proof-blue">{m.resultLink}</span> : null}
                   </span>


### PR DESCRIPTION
## 요약
카디르 QA(#3440) 중 codex 교차검증 발견(HIGH·비차단 보고), PO 소스 실측 확認(2026-08-24) — story 8df36496(high, 3011 동일 클래스 잔존). Conversation 메시지 행(`workcell.tsx` L468) 값 span이 `min-w-0`만 갖고 `break-words`가 없었다.

#3440(3011) 자신의 실번들 하네스가 증명한 대로 `min-w-0` 단독으로는 긴 무단절 토큰의 클리핑이 재현된다. `m.body`는 자유텍스트라 URL·해시·코드 토큰이 실제로 들어오는 위험군.

## 변경 — 정확히 1개 span, 1줄
`git diff` 실측(과대·과소 계수 방지, 페드루군 지적 반영해 실제 hunk로 확인 후 기재):
```diff
-                  <span className="min-w-0">
+                  <span className="min-w-0 break-words">
```
nested `m.resultLink` span은 `overflow-wrap`이 상속 속성이라 별도 처방 없이 부모의 `break-words`를 동반 커버(CSS 상속 확인, 추가 클래스 불필요).

## 검증
- [x] `tsc --noEmit` clean
- [x] `eslint workcell.tsx workcell.test.tsx` clean(0 warning)
- [x] `vitest run workcell.test.tsx` — **39/39** green(신규 회귀가드 1건 포함, 정확한 총계)
- [x] 신규 테스트를 `git stash`로 pre-fix 소스에 되돌려 실패 재현 확인(`min-w-0` 단독 결과로 `AssertionError` 재현) → fix 복원 후 재통과(진짜 회귀가드 증명, 서술 아님)
- [x] `pnpm build` EXIT=0

## 실렌더 메커니즘 검증(#3440과 동일 방식 재사용)
`next build` 실 컴파일 Tailwind CSS 번들을 그대로 로드한 격리 harness로 Conversation 행 구조(246px 셀 + `overflow-hidden` 조상) 재현, 순수 무단절 토큰(하이픈·공백 0개)으로 측정:

| 조합 | cell.scrollWidth vs clientWidth | 결과 |
|---|---|---|
| `min-w-0`만(수정 전 상태) | 547 vs 244 | 오버플로 — 클리핑 재현 |
| `min-w-0` + `break-words`(적용한 fix) | 244 vs 244 | 오버플로 0 |

## AC 대조
1. min-w-0+break-words 동시 보유 + 회귀가드 — 충족(위 diff·테스트).
2. 긴 무단절 토큰 메시지 클리핑 0 — 충족(하네스 실측).
3. 유나 design·카디르 QA 사슬 — 이 PR 오픈으로 착수, 3011과 동형 순서로 진행.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_017Y8uNHvGThWG8QPBz1nhFz