### PR TITLE
[관찰·게이트] merge gate requested_reviewers 관찰 사실 배선 (판정 무영향)

### DIFF
--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -313,6 +313,49 @@ async def _observe_pr_diff_facts(
         return {}
 
 
+async def _observe_pr_reviewer_facts(
+    session: AsyncSession, org_id: uuid.UUID, repo: str, pr_number: int
+) -> dict[str, Any]:
+    """story #3014(2995 보류 결정의 관찰 슬라이스, PO 2026-08-24) — PR의 requested_reviewers를
+    **관찰 사실로만** neutral_facts에 남긴다. ⚠️판정 아님 — designated_approver_id 배선도, 어떤
+    임계값 분기도 하지 않는다(_observe_pr_diff_facts와 동형 관례). GitHub reviewer login을
+    Sprintable member_id로 바꿀 조인키가 시스템에 없음이 2995 재그라운딩에서 확定됐으므로(지어내지
+    않는다), 이 슬라이스는 raw login 문자열과 개수만 세어 "«정확히 1명» 게이트가 실제로 얼마나
+    되는지"를 실측하는 게 유일한 목적 — 그 숫자가 선행(identity linking, story de7a115b의
+    보류 사유)의 착수 우선순위를 정한다.
+
+    _observe_pr_diff_facts와 동일한 fail-open 관례: installation 없음/토큰 발급 실패/API 실패
+    어느 단계든 조용히 `{}` 반환 — 이 관찰 실패가 게이트 생성 자체를 절대 막지 않는다."""
+    from app.models.github_installation import GithubInstallation
+    from app.services.github_app import get_installation_token, get_pull_request
+
+    try:
+        installation = (
+            await session.execute(
+                select(GithubInstallation).where(
+                    GithubInstallation.org_id == org_id, GithubInstallation.suspended_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+        if installation is None:
+            return {}
+        token = await get_installation_token(installation.installation_id)
+        if not token:
+            return {}
+        pr = await get_pull_request(installation.installation_id, repo, pr_number)
+        if pr is None:
+            return {}
+        reviewers = pr.get("requested_reviewers") or []
+        logins = sorted({r.get("login") for r in reviewers if isinstance(r, dict) and r.get("login")})
+        return {"reviewer_count": len(logins), "reviewer_logins": logins}
+    except Exception:  # noqa: BLE001 — best-effort 관찰, 실패해도 게이트 평가를 막지 않는다.
+        logger.warning(
+            "merge gate: PR reviewer facts 관찰 실패(best-effort) org=%s repo=%s pr=%d",
+            org_id, repo, pr_number, exc_info=True,
+        )
+        return {}
+
+
 async def evaluate_merge_gate(
     session: AsyncSession,
     org_id: uuid.UUID,
@@ -459,6 +502,8 @@ async def evaluate_merge_gate(
     # no-substance shell(db_pr_number/db_repo_full_name 둘 다 None)이면 관찰 대상 자체가 없다.
     if db_pr_number is not None and db_repo_full_name is not None:
         facts.update(await _observe_pr_diff_facts(session, org_id, db_repo_full_name, db_pr_number))
+        # story #3014 — reviewer 관찰 사실(판정 무영향). _observe_pr_reviewer_facts docstring 참고.
+        facts.update(await _observe_pr_reviewer_facts(session, org_id, db_repo_full_name, db_pr_number))
     # story #2118(E-DG-REAL ②): create_gate()가 이미 pending인 기존 gate를 멱등 반환할 때(예:
     # report-done/board-preflight가 이 함수를 반복 호출)마다 승인요청 카드를 중복 배달하지 않으려면
     # "이 호출에서 방금 pending이 됐는지"(신규 생성 또는 rejected/voided→재오픈)를 알아야 한다 —

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -788,3 +788,113 @@ async def test_observe_pr_diff_facts_fetch_failure_returns_empty():
         result = await _observe_pr_diff_facts(session, uuid.uuid4(), "o/r", 12)
 
     assert result == {}
+
+
+# ── story #3014(2995 보류 결정의 관찰 슬라이스) — reviewer_count/reviewer_logins 관찰 사실(판정 아님) ──
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_merges_observed_reviewer_facts_into_neutral_facts():
+    """관찰되면 neutral_facts에 그대로 병합돼야 한다(재판정 없음, 기존 facts 키와 나란히) —
+    _observe_pr_diff_facts 병합 테스트와 동형."""
+    with patch.object(mod, "_observe_pr_reviewer_facts",
+                       AsyncMock(return_value={"reviewer_count": 1, "reviewer_logins": ["alice"]})):
+        res, create_spy = await _run()
+    assert res.gate_id is not None
+    neutral_facts = create_spy.call_args.kwargs["neutral_facts"]
+    assert neutral_facts["reviewer_count"] == 1
+    assert neutral_facts["reviewer_logins"] == ["alice"]
+    assert neutral_facts["ci_result"] == "pass"  # 기존 facts 보존(덮어쓰기 아님).
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_reviewer_facts_observation_failure_is_silent():
+    """관찰 실패(설치 없음/토큰 없음/API 실패)는 게이트 평가 자체를 막지 않는다 — facts에
+    reviewer_count/reviewer_logins 키가 그냥 없을 뿐."""
+    with patch.object(mod, "_observe_pr_reviewer_facts", AsyncMock(return_value={})):
+        res, create_spy = await _run()
+    assert res.gate_id is not None
+    neutral_facts = create_spy.call_args.kwargs["neutral_facts"]
+    assert "reviewer_count" not in neutral_facts
+    assert "reviewer_logins" not in neutral_facts
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_no_substance_shell_skips_reviewer_observation():
+    """pr_number<=0(no-substance shell)이면 관찰 대상 PR 자체가 없다 — _observe_pr_reviewer_facts를
+    아예 호출하지 않는다(불필요한 GitHub API 호출 방지)."""
+    observe_spy = AsyncMock(return_value={"reviewer_count": 1, "reviewer_logins": ["alice"]})
+    with patch.object(mod, "_observe_pr_reviewer_facts", observe_spy):
+        await _run_substance(ci_result="fail", pr_number=0, disposition="ask")
+    observe_spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_observe_pr_reviewer_facts_no_installation_returns_empty():
+    """GithubInstallation 없음(미연동 org) — 조용히 {} 반환, 예외 없음."""
+    from app.services.merge_verdict_gate import _observe_pr_reviewer_facts
+
+    no_row = MagicMock()
+    no_row.scalar_one_or_none = MagicMock(return_value=None)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=no_row)
+
+    result = await _observe_pr_reviewer_facts(session, uuid.uuid4(), "o/r", 12)
+    assert result == {}
+
+
+@pytest.mark.anyio
+async def test_observe_pr_reviewer_facts_counts_and_lists_logins():
+    """설치+토큰+PR 조회 전부 성공 시 reviewer_count·reviewer_logins(정렬된 dedup 목록)을
+    정확히 계산한다 — GitHub PR 응답의 requested_reviewers는 [{"login": ...}, ...] 형태."""
+    from app.services.merge_verdict_gate import _observe_pr_reviewer_facts
+
+    installation = SimpleNamespace(installation_id=999)
+    row = MagicMock()
+    row.scalar_one_or_none = MagicMock(return_value=installation)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=row)
+
+    pr = {"requested_reviewers": [{"login": "bob"}, {"login": "alice"}]}
+    with patch("app.services.github_app.get_installation_token", AsyncMock(return_value="tok")), \
+         patch("app.services.github_app.get_pull_request", AsyncMock(return_value=pr)):
+        result = await _observe_pr_reviewer_facts(session, uuid.uuid4(), "o/r", 12)
+
+    assert result == {"reviewer_count": 2, "reviewer_logins": ["alice", "bob"]}
+
+
+@pytest.mark.anyio
+async def test_observe_pr_reviewer_facts_zero_reviewers_returns_count_zero():
+    """양성대조 짝 — 대부분의 실경로일 zero-reviewer 케이스가 예외 없이 count 0을 낸다(AC②)."""
+    from app.services.merge_verdict_gate import _observe_pr_reviewer_facts
+
+    installation = SimpleNamespace(installation_id=999)
+    row = MagicMock()
+    row.scalar_one_or_none = MagicMock(return_value=installation)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=row)
+
+    pr = {"requested_reviewers": []}
+    with patch("app.services.github_app.get_installation_token", AsyncMock(return_value="tok")), \
+         patch("app.services.github_app.get_pull_request", AsyncMock(return_value=pr)):
+        result = await _observe_pr_reviewer_facts(session, uuid.uuid4(), "o/r", 12)
+
+    assert result == {"reviewer_count": 0, "reviewer_logins": []}
+
+
+@pytest.mark.anyio
+async def test_observe_pr_reviewer_facts_fetch_failure_returns_empty():
+    """get_pull_request가 None(조회 실패/판정불가)이면 관찰 사실 없이 {} — 지어내지 않는다(AC③)."""
+    from app.services.merge_verdict_gate import _observe_pr_reviewer_facts
+
+    installation = SimpleNamespace(installation_id=999)
+    row = MagicMock()
+    row.scalar_one_or_none = MagicMock(return_value=installation)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=row)
+
+    with patch("app.services.github_app.get_installation_token", AsyncMock(return_value="tok")), \
+         patch("app.services.github_app.get_pull_request", AsyncMock(return_value=None)):
+        result = await _observe_pr_reviewer_facts(session, uuid.uuid4(), "o/r", 12)
+
+    assert result == {}


### PR DESCRIPTION
[SID:3014]

## Summary
- #2995(reviewer→designated_approver_id 매핑) 착수 재그라운딩에서 GitHub 리뷰어 login을 Sprintable member_id로 바꿀 조인키가 시스템에 없음이 드러나 2995 자체는 보류(story de7a115b). 이 PR은 그 후속으로 실행 가능한 잔여 부분만 떼어낸 관찰 슬라이스.
- `evaluate_merge_gate`의 merge gate 최초 생성 시점(`merge_verdict_gate.py:477` 직전)에 `get_pull_request()`로 `requested_reviewers`를 읽어 `reviewer_count`/`reviewer_logins`를 `neutral_facts`에 **관찰 사실로만** 남긴다.
- `designated_approver_id` 배선 없음·판정 로직 무변경 — `_observe_pr_diff_facts`(#2950 슬라이스②)와 완전히 동형인 fail-open 관례(installation 없음/토큰 없음/API 실패 어느 단계든 조용히 `{}` 반환, 게이트 생성 자체는 절대 막지 않음).
- 목적: «정확히 1명 reviewer» 게이트의 실 비율을 실측해 선행(identity linking, story de7a115b) 스토리의 착수 우선순위를 숫자로 정한다.

## Test plan
- [x] 신규 7테스트(병합 배선 2건+실패 무영향 1건+no-substance 스킵 1건+관찰함수 자체 3건: installation없음/count+login/0명/API실패) 전부 green.
- [x] 기존 `test_merge_verdict_gate.py` 스위트 47/2skip(불변, diff_size/touches_migration 동일 패턴 유지).
- [x] 인접 gate 단위 테스트(1968/2047/edg_s5/h1_s4/h1_s5/h1_s10/reject_resubmit_reopen/bot_l1/workflow_report) 73/15skip 전부 green.
- [x] 로드베어링 mutation 검증 — `facts.update(...)` 배선 라인 제거 시 정확히 병합 테스트 1건만 `KeyError`로 FAIL, 복원 후 재green.
- [x] `import app.main` 정상.
- [ ] AC④(실 PR로 생성된 게이트 실물 대조) — dev 배포 후 라이브 확認 필요(QA/카디르).

🤖 Generated with [Claude Code](https://claude.com/claude-code)