### PR TITLE
[게이트·결재선] AC2 — 게이트 상세·결재함 큐에 실시간 해소/위임 반영

### DIFF
--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -14,9 +14,10 @@ import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../../../messages/ko.json';
 import type { GateItem } from '@/components/kanban/types';
 
-const { useDashboardContextMock, replaceMock } = vi.hoisted(() => ({
+const { useDashboardContextMock, replaceMock, muxSubscribeMock } = vi.hoisted(() => ({
   useDashboardContextMock: vi.fn(),
   replaceMock: vi.fn(),
+  muxSubscribeMock: vi.fn((_eventName: string, _handler: (raw: string, eventId?: string) => void) => () => {}),
 }));
 
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
@@ -26,6 +27,12 @@ vi.mock('@/app/dashboard/dashboard-shell', () => ({
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
   useParams: () => ({ id: 'gate-1' }),
+}));
+
+// story #2985 AC2 — approval-request-card.test.tsx와 동일 전략: useSseMultiplexerContext()
+// 훅을 모킹해 subscribe 핸들러를 테스트가 직접 잡아 fire한다.
+vi.mock('@/components/realtime-provider', () => ({
+  useSseMultiplexerContext: () => ({ subscribe: muxSubscribeMock }),
 }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -69,6 +76,7 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   useDashboardContextMock.mockReturnValue({ orgMemberships: [], projectMemberships: [] });
+  muxSubscribeMock.mockClear();
 });
 
 afterEach(async () => {
@@ -442,5 +450,93 @@ describe('GateDetailPage — gate_type 배지 대비(P0-02, chip variant 기본�
     expect(chipEl, 'gate_type 배지를 못 찾음').toBeDefined();
     expect(chipEl!.className).toContain('text-foreground');
     expect(chipEl!.className).not.toContain('text-muted-foreground');
+  });
+});
+
+describe('GateDetailPage — 실시간 해소 반영(story #2985 AC2)', () => {
+  it('mux가 conversation.gate_resolved(같은 gate_id)를 쏘면 재조회된다', async () => {
+    let getCount = 0;
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/gates/gate-1') {
+        getCount += 1;
+        return { ok: true, status: 200, json: async () => ({ data: gate({ status: 'pending' }) }) };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { default: GateDetailPage } = await import('./page');
+    const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+    await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    expect(getCount).toBe(1);
+
+    const call = muxSubscribeMock.mock.calls.find(([eventName]) => eventName === 'conversation.gate_resolved');
+    expect(call).toBeTruthy();
+    const handler = call![1] as (raw: string, eventId?: string) => void;
+    await act(async () => { handler(JSON.stringify({ gate_id: 'gate-1', status: 'approved' })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(getCount).toBe(2); // 새로고침 없이 재조회.
+  });
+
+  it('다른 gate_id의 이벤트는 무시한다', async () => {
+    let getCount = 0;
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/gates/gate-1') {
+        getCount += 1;
+        return { ok: true, status: 200, json: async () => ({ data: gate({ status: 'pending' }) }) };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { default: GateDetailPage } = await import('./page');
+    const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+    await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    expect(getCount).toBe(1);
+
+    const call = muxSubscribeMock.mock.calls.find(([eventName]) => eventName === 'conversation.gate_resolved');
+    const handler = call![1] as (raw: string, eventId?: string) => void;
+    await act(async () => { handler(JSON.stringify({ gate_id: 'other-gate', status: 'approved' })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(getCount).toBe(1);
+  });
+
+  it('mux가 conversation.gate_delegated(같은 gate_id)를 쏘면 재조회된다', async () => {
+    let getCount = 0;
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/gates/gate-1') {
+        getCount += 1;
+        return { ok: true, status: 200, json: async () => ({ data: gate({ status: 'pending' }) }) };
+      }
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { default: GateDetailPage } = await import('./page');
+    const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+    await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    expect(getCount).toBe(1);
+
+    const call = muxSubscribeMock.mock.calls.find(([eventName]) => eventName === 'conversation.gate_delegated');
+    expect(call).toBeTruthy();
+    const handler = call![1] as (raw: string, eventId?: string) => void;
+    await act(async () => { handler(JSON.stringify({ gate_id: 'gate-1', new_approver_id: 'member-3' })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(getCount).toBe(2);
+  });
+
+  it('malformed payload는 크래시 없이 무시한다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/gates/gate-1') return { ok: true, status: 200, json: async () => ({ data: gate({ status: 'pending' }) }) };
+      return { ok: true, json: async () => ({ data: [] }) };
+    }));
+    const { default: GateDetailPage } = await import('./page');
+    const { TopBarProvider } = await import('@/components/nav/top-bar-context');
+    await act(async () => { root.render(wrap(<GateDetailPage />, TopBarProvider)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    const call = muxSubscribeMock.mock.calls.find(([eventName]) => eventName === 'conversation.gate_resolved');
+    const handler = call![1] as (raw: string, eventId?: string) => void;
+    expect(() => handler('not-json{')).not.toThrow();
   });
 });

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -18,6 +18,7 @@ import type { GateItem } from '@/components/kanban/types';
 import { fetchWithAuth } from '@/lib/db/client';
 import { EntityBacklinksSection } from '@/components/shared/entity-backlinks-section';
 import { ProofCapsule } from '@/components/proof-capsule/proof-capsule';
+import { useSseMultiplexerContext } from '@/components/realtime-provider';
 
 // story #1954(P1a-S4) — Gate 3종(게이트·문서결재·머지게이트) canonical 상세. P1a·P2 공용 유일
 // per-gate 라우트(중복 빌드 봉쇄) — decision(inbox_items)은 별도 표면(오르테가군 PO 판단+
@@ -71,6 +72,35 @@ export default function GateDetailPage() {
   }, [id]);
 
   useEffect(() => { void fetchGate(); }, [fetchGate]);
+
+  // story #2985 AC2(PO 계약 확定 2026-08-24) — 다른 승인자가 이 게이트를 먼저 해소하거나
+  // 위임하면, 이 상세 페이지를 보고 있는 화면도 새로고침 없이 갱신된다. approval-request-
+  // card.tsx(챗 카드)와 완전히 동형 구독 — BE 계약(notify_gate_card_recipients_resolved/
+  // notify_gate_delegated_to_old_approver)은 이미 존재(신규 배관 0), 여기가 빠져 있던 두
+  // FE 표면 중 하나. mux가 없으면(RealtimeProvider 밖) 조용히 스킵 — 기존처럼 마운트 1회
+  // fetchGate만 유효(회귀 아님, 저하일 뿐).
+  const mux = useSseMultiplexerContext();
+  useEffect(() => {
+    if (!mux) return;
+    const unsub = mux.subscribe('conversation.gate_resolved', (raw) => {
+      try {
+        const payload = JSON.parse(raw) as { gate_id?: string };
+        if (payload.gate_id === id) void fetchGate();
+      } catch { /* malformed — 무시(다음 정상 이벤트나 fetchGate 재시도로 자연 회복) */ }
+    });
+    return unsub;
+  }, [mux, id, fetchGate]);
+
+  useEffect(() => {
+    if (!mux) return;
+    const unsub = mux.subscribe('conversation.gate_delegated', (raw) => {
+      try {
+        const payload = JSON.parse(raw) as { gate_id?: string };
+        if (payload.gate_id === id) void fetchGate();
+      } catch { /* malformed — 무시 */ }
+    });
+    return unsub;
+  }, [mux, id, fetchGate]);
 
   // story #2631 QA중 발견 — memberNames를 deps에 넣으면 setMemberNames가 매번 새 객체
   // 레퍼런스를 만들어(resolver가 응답 목록에 없는 한) 이 effect가 무한 재실행됐다(fetch

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -12,9 +12,10 @@ import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import type { GateItem, HitlInboxItem } from '../kanban/types';
 
-const { useDashboardContextMock, pushMock } = vi.hoisted(() => ({
+const { useDashboardContextMock, pushMock, muxSubscribeMock } = vi.hoisted(() => ({
   useDashboardContextMock: vi.fn(),
   pushMock: vi.fn(),
+  muxSubscribeMock: vi.fn((_eventName: string, _handler: (raw: string, eventId?: string) => void) => () => {}),
 }));
 
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
@@ -23,6 +24,11 @@ vi.mock('@/app/dashboard/dashboard-shell', () => ({
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+}));
+
+// story #2985 AC2 — approval-request-card.test.tsx와 동일 전략.
+vi.mock('@/components/realtime-provider', () => ({
+  useSseMultiplexerContext: () => ({ subscribe: muxSubscribeMock }),
 }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -86,6 +92,7 @@ beforeEach(() => {
     projectMemberships: [],
     currentMemberType: 'human',
   });
+  muxSubscribeMock.mockClear();
 });
 
 afterEach(async () => {
@@ -803,5 +810,69 @@ describe('ApprovalsQueue', () => {
       expect(wrapper.parentElement).toBe(actionRow);
       expect(mobileOrderOf(primary!)).toBeLessThan(mobileOrderOf(wrapper));
     }
+  });
+});
+
+describe('ApprovalsQueue — 실시간 해소/위임 반영(story #2985 AC2)', () => {
+  function actionableGate(overrides: Partial<GateItem> = {}): GateItem {
+    return gate({
+      id: 'g-live', gate_type: 'merge_gate', status: 'pending', requires_human: true,
+      can_approve: true, risk_grade: 'low', work_item_summary: { title: '실시간 대상 항목', slug: null },
+      ...overrides,
+    });
+  }
+
+  it('mux가 conversation.gate_resolved(큐에 있는 gate_id)를 쏘면 그 항목이 완료 상태로 바뀐다(undo 버튼 없이)', async () => {
+    mockFetches([actionableGate()], []);
+    await mount();
+    expect(container.textContent).toContain('실시간 대상 항목');
+    expect(container.textContent).not.toContain(koMessages.cage.queueResolvedApproved);
+
+    const call = muxSubscribeMock.mock.calls.find(([eventName]) => eventName === 'conversation.gate_resolved');
+    expect(call).toBeTruthy();
+    const handler = call![1] as (raw: string, eventId?: string) => void;
+    await act(async () => { handler(JSON.stringify({ gate_id: 'g-live', status: 'approved' })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain(koMessages.cage.queueResolvedApproved);
+    // 남이 해소한 건 — 이 세션에서 내가 한 게 아니므로 undo(정정) 버튼은 안 뜬다.
+    const buttons = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateUndo))).toBe(false);
+  });
+
+  it('큐에 없는 gate_id의 이벤트는 무시한다', async () => {
+    mockFetches([actionableGate()], []);
+    await mount();
+
+    const call = muxSubscribeMock.mock.calls.find(([eventName]) => eventName === 'conversation.gate_resolved');
+    const handler = call![1] as (raw: string, eventId?: string) => void;
+    await act(async () => { handler(JSON.stringify({ gate_id: 'not-in-queue', status: 'approved' })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).not.toContain(koMessages.cage.queueResolvedApproved);
+  });
+
+  it('mux가 conversation.gate_delegated를 쏘면 그 항목이 큐에서 사라진다(assigned_to_me 스코프 이탈)', async () => {
+    mockFetches([actionableGate()], []);
+    await mount();
+    expect(container.textContent).toContain('실시간 대상 항목');
+
+    const call = muxSubscribeMock.mock.calls.find(([eventName]) => eventName === 'conversation.gate_delegated');
+    expect(call).toBeTruthy();
+    const handler = call![1] as (raw: string, eventId?: string) => void;
+    await act(async () => { handler(JSON.stringify({ gate_id: 'g-live', new_approver_id: 'member-3' })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).not.toContain('실시간 대상 항목');
+  });
+
+  it('malformed payload는 크래시 없이 무시한다', async () => {
+    mockFetches([actionableGate()], []);
+    await mount();
+
+    const resolvedHandler = muxSubscribeMock.mock.calls.find(([e]) => e === 'conversation.gate_resolved')![1] as (raw: string) => void;
+    const delegatedHandler = muxSubscribeMock.mock.calls.find(([e]) => e === 'conversation.gate_delegated')![1] as (raw: string) => void;
+    expect(() => resolvedHandler('not-json{')).not.toThrow();
+    expect(() => delegatedHandler('not-json{')).not.toThrow();
   });
 });

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -16,6 +16,7 @@ import { GateSignatureApproval } from '@/components/cage/gate-signature-approval
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateInboxItem, GateItem, HitlInboxItem } from '@/components/kanban/types';
 import { ProofCapsule, type ProofState } from '@/components/proof-capsule/proof-capsule';
+import { useSseMultiplexerContext } from '@/components/realtime-provider';
 
 import { fetchWithAuth } from '@/lib/db/client';
 
@@ -179,6 +180,46 @@ export function ApprovalsQueue() {
     });
     return () => { cancelled = true; };
   }, []);
+
+  // story #2985 AC2(PO 계약 확定 2026-08-24) — 다른 승인자가 큐에 있는 게이트를 먼저
+  // 해소하면, 이 화면도 새로고침 없이 갱신된다. resolveGate()가 본인 해소 시 이미 쓰는
+  // resolvedGates 오버레이를 그대로 재사용(신규 렌더 분기 0) — resolvedAtMs는 일부러
+  // 안 채운다(그건 "이 세션에서 내가 방금 해소했다"는 undo 자격 신호라 남이 해소한 건에는
+  // undo 버튼이 뜨면 안 된다, 위 resolvedAtMs 주석 참조). BE 계약은 approval-request-
+  // card.tsx/gates/[id]/page.tsx와 동일(notify_gate_card_recipients_resolved, 신규 배관 0).
+  // ⚠️items를 deps에 넣지 않는다(items.some(...) 멤버십 가드는 fetchGates 완료 前 빈
+  // 배열을 캡처한 stale effect가 재구독으로 안 씻겨나가는 함정이 있다 — mux.subscribe가
+  // 리스너 목록에 append만 하고 이전 것을 안 지우는 구현이면 첫 구독(빈 items)이 계속 살아
+  // 있어 항상 no-op이 된다). 대신 무조건 기록 — items에 없는 gate_id가 들어와도 그 키는
+  // 그냥 안 쓰일 뿐(렌더는 items.map()이 도는 항목만 resolvedGates[gate.id]를 읽는다).
+  const mux = useSseMultiplexerContext();
+  useEffect(() => {
+    if (!mux) return;
+    const unsub = mux.subscribe('conversation.gate_resolved', (raw) => {
+      try {
+        const payload = JSON.parse(raw) as { gate_id?: string; status?: 'approved' | 'rejected' };
+        if (!payload.gate_id || !payload.status) return;
+        setResolvedGates((prev) => ({ ...prev, [payload.gate_id!]: payload.status! }));
+      } catch { /* malformed — 무시 */ }
+    });
+    return unsub;
+  }, [mux]);
+
+  // story #3001(위임) — 이 큐는 assigned_to_me=true로 이미 스코프돼 있다. 지정자가
+  // 위임으로 밀려나면 그 게이트는 더 이상 "내 할 일"이 아니므로(재조회하면 안 옴), 목록에서
+  // 바로 제거한다 — gate_resolved(완료 오버레이 유지)와 다르게 여긴 실제 삭제가 재조회
+  // 결과와 정확히 일치한다.
+  useEffect(() => {
+    if (!mux) return;
+    const unsub = mux.subscribe('conversation.gate_delegated', (raw) => {
+      try {
+        const payload = JSON.parse(raw) as { gate_id?: string };
+        if (!payload.gate_id) return;
+        setItems((prev) => prev.filter((it) => it.id !== payload.gate_id));
+      } catch { /* malformed — 무시 */ }
+    });
+    return unsub;
+  }, [mux]);
 
   // story #2054 AC3: HitlRequest는 상세 페이지가 없어 이 큐 안에서 바로 승인/반려한다 —
   // 승인 후 원래 작업(report-done)이 통과하는지는 사용자 왕복(재시도)으로 확認된다.


### PR DESCRIPTION
[SID:2985]

## Summary
- story #2985 AC②: "다른 사람이 해소하면 열린 화면의 카드가 새로고침 없이 완료 상태로 갱신".
- 그라운딩 결과 챗 카드(`approval-request-card.tsx`)는 **이미** 이 계약(BE `notify_gate_card_recipients_resolved`/`notify_gate_delegated_to_old_approver` → `conversation.gate_resolved`/`conversation.gate_delegated` SSE 이벤트, `mux.subscribe`)을 구현·배포하고 있었다 — 신규 전송계층/BE 작업 0. 이 PR은 같은 패턴이 빠져 있던 나머지 두 FE 표면에 동형 구독만 추가한다.
- `gates/[id]/page.tsx` — `approval-request-card.tsx`와 완전히 동일한 구독+`fetchGate()` 재호출.
- `approvals-queue.tsx` — 본인 해소 시 이미 쓰는 `resolvedGates` 오버레이(완료 상태+기록 링크로 그 자리서 전환)를 재사용. `resolvedAtMs`는 채우지 않아 undo 버튼이 안 뜨게 유지(그건 "이 세션에서 내가 방금 해소했다"는 자격 신호). `gate_delegated`는 `assigned_to_me=true` 스코프 이탈이라 목록에서 제거.
- `story-merge-gate.tsx`(workcell 임베드 evidence 패널)는 스코프 제외 — 문서화된 read-only 표시 전용("액션은 surface①에만"), AC②가 다루는 "액션 카드의 잔존" 결함이 애초에 성립하지 않는다.

## 구현 중 발견한 실버그
`approvals-queue.tsx` 최초 구현이 `gate_resolved` 구독 effect의 deps에 `items`를 넣어 items 변화마다 재구독했는데, `mux.subscribe`가 구 리스너를 안 지우는 구현이라 최초(items=[]) 구독의 stale closure가 계속 살아있어 항상 no-op이었다(신규 테스트가 실제로 이걸 잡아냈다). items 멤버십 가드 자체를 제거(무조건 기록 — 렌더 시점에 `items.map()`이 도는 항목만 `resolvedGates`를 읽으므로 안전)해 `deps=[mux]`로 단순화.

## Test plan
- [x] 신규 11테스트(gate 상세 4+결재함 큐 4+approval-request-card 기존 유지 3) green.
- [x] FE 전체 스위트 519 files / 4582 tests green(회귀 0).
- [x] `tsc --noEmit` 0 errors, `eslint` 0 errors.
- [x] 로드베어링 mutation 검증 — 배선 3곳(gate 상세 resolved/delegated, 결재함 큐 resolved) 각각 제거 시 해당 테스트만 정확히 FAIL, 복원 후 재green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)