### PR TITLE
[SSE·근본] 라이브 루프 dedup을 연결-로컬로 교체 — 동시 다중 연결 fan-out 복원

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -264,6 +264,18 @@ async def push_to_org_members(
         _push_to_agent(mid, {"event_type": event_type, **data})
 
 
+def _should_skip_live_event(eid: str | None, sent_event_ids: set[str]) -> bool:
+    """story #3026 — 라이브 루프의 pre-yield dedup 판단을 순수함수로 뽑아 직접 단위테스트
+    가능하게 한다(generate()는 클로저라 직접 호출 불가). `sent_event_ids`는 **연결-로컬**
+    집합이어야 한다 — 이 함수 자체는 그 계약을 강제하지 않으므로(순수함수라 호출자 책임),
+    호출부(generate())가 매 연결마다 새 집합을 만들어 넘기는 것으로 보장한다. 예전엔 이
+    판단을 `Event.status`(DB, org 전체 공유)로 했다 — 같은 member의 다른 연결이 먼저
+    yield하면 이 함수 상당 로직이 전역적으로 "이미 처리됨"을 봐서, 자기 큐에 항목이 와
+    있는 다른 연결까지 전부 skip시켰다(#3026 실사고 근본원인, 968fe78d 실측). 연결-로컬
+    집합으로 바꾸면 그 결함이 구조적으로 성립 안 한다."""
+    return bool(eid) and eid in sent_event_ids
+
+
 def _event_to_payload(event: "Event") -> dict:
     return {
         "event_id": str(event.id),
@@ -396,6 +408,19 @@ async def agent_event_stream(
     _lifespan_deadline = time.monotonic() + _SSE_LIFESPAN_SEC + random.uniform(0, _SSE_LIFESPAN_JITTER_SEC)
 
     async def generate():
+        # story #3026(실사고, PO 확定 2026-08-24) — 이 연결이 실제로 클라에 내보낸(yield
+        # 성공한) A계열(eid 有) event_id 집합. **연결-로컬**이다(다른 연결과 공유 안 함) —
+        # 이게 이 스토리의 핵심 처방. 예전엔 이 dedup을 `Event.status`(DB, org 전체 공유
+        # 상태)로 판별해 "같은 member의 다른 연결(다른 탭·프로브·잔존 연결)이 먼저 yield해
+        # delivered로 찍으면 나머지 연결 전부가 스킵"되는 결함이 있었다(동시 연결 N개 중
+        # 1개만 실제 갱신 — 968fe78d 실사고 실측, delivered_at 편차 +0.1s~+103s). `_push_to_
+        # agent`의 fan-out(멤버의 모든 큐에 push) 자체는 정상이었으므로, 문제는 순전히 "누가
+        # 이미 봤나"를 연결이 아니라 이벤트 자체에 물었던 것 — 연결-로컬 집합으로 바꾸면
+        # 같은 연결 내 중복(백필+라이브 겹침)은 그대로 막히면서, 다른 연결은 서로 완전히
+        # 독립적으로 판단해 진짜 fan-out이 된다. `Event.status`/`delivered_at` DB 마킹
+        # 자체는 그대로 유지(백필 원칙 — "재연결 시 이미 delivered여도 다시 준다"는 이
+        # 값을 재연결 커서 판정에 계속 쓴다, 라이브 dedup의 판단 근거로만 안 쓸 뿐).
+        _sent_event_ids: set[str] = set()
         try:
             # 즉시 heartbeat → HTTP 응답 헤더 즉시 반환 (대량 백필 전 hang 방지)
             yield "event: heartbeat\ndata: {}\n\n"
@@ -514,6 +539,10 @@ async def agent_event_stream(
                     # 남아 영구 누락. 후마킹 + 클라 seen_ids dedup 으로 손실 0(재전송 허용).
                     for data, evt in zip(batch_data, batch):
                         yield f"event: {evt.event_type}\nid: {evt.id}\ndata: {json.dumps({**data, 'is_backfill': True})}\n\n"
+                        # story #3026 — 이 연결이 백필로 이미 내보낸 id. 아래 라이브 루프의
+                        # 큐에 같은 event_id가 겹쳐 들어와도(레이스 윈도우) 이 연결에서 또
+                        # 안 보낸다(연결-로컬 dedup, DB 공유상태 아님).
+                        _sent_event_ids.add(str(evt.id))
                     for evt in batch:
                         evt.status = "delivered"
                         evt.delivered_at = now
@@ -578,24 +607,17 @@ async def agent_event_stream(
                             continue
                         event_data = get_task.result()
                         event_type = event_data.get("event_type", "message")
-                        # 1c22da3e fix: yield 전엔 pending 여부만 확인(skip 판정, 마킹 X),
-                        # delivered 마킹은 yield 성공 후로 미룬다 → yield 실패 시 영구 누락 방지.
+                        # story #3026 — dedup 판단은 이 연결이 이미 보냈는지(연결-로컬
+                        # `_sent_event_ids`)만 본다. ⚠️예전엔 여기서 `Event.status`(DB, org
+                        # 전체 공유)를 조회해 "이미 delivered"면 skip했는데, 그러면 같은
+                        # member의 다른 연결이 먼저 yield한 순간 **이 연결은 자기 큐에 항목이
+                        # 와 있어도 영원히 못 보낸다**(동시 다중 탭 중 1개만 갱신되는 실사고
+                        # 근본원인, 968fe78d 실측). 연결-로컬 판단으로 바꾸면 그 결함이
+                        # 구조적으로 성립 안 한다 — 부수로 매 라이브 이벤트마다의 DB 왕복도
+                        # 없앴다(hot-path DB 0, #2158 B계열과 동일 원칙을 A계열에도 적용).
                         eid = event_data.get("event_id")
-                        if eid:
-                            try:
-                                async with async_session_factory() as db:
-                                    r = await db.execute(
-                                        select(Event.status).where(
-                                            Event.id == uuid.UUID(eid),
-                                            Event.org_id == org_id,
-                                        )
-                                    )
-                                    _status = r.scalar_one_or_none()
-                                    if _status is not None and _status != "pending":
-                                        # 이미 백필/타 연결에서 delivered → 중복 skip
-                                        continue
-                            except Exception:
-                                pass
+                        if _should_skip_live_event(eid, _sent_event_ids):
+                            continue  # 이 연결이 이미 보낸 id(백필 또는 이전 라이브) — 중복 skip.
                         # event_id 없는 경로(chats direct push 등)도 id: 보장 — 재연결 추적 약화 방지
                         # is_backfill: False 명시 + event_id 동기화 — SeenIdsCache dedup 및 relay 필터 정합성
                         # #2158: B계열은 `_push_to_agent`가 발행 시점에 부여한 `_sse_transient_id`를
@@ -610,6 +632,12 @@ async def agent_event_stream(
                         if event_type == "conversation.message_created":
                             yield f"event: conversation:message\nid: {_live_id}\ndata: {_sse_data}\n\n"
                         yield f"event: {event_type}\nid: {_live_id}\ndata: {_sse_data}\n\n"
+                        # story #3026 — 이 연결이 방금 보낸 id를 기록(연결-로컬, 위 pre-yield
+                        # 체크가 읽는 그 집합). yield가 여기까지 왔다는 건 이미 성공했다는
+                        # 뜻이라 실패 시 기록 안 남는 걱정은 없다(아래 DB 마킹과 동일 순서
+                        # 원칙 — "성공 후에만" 기록).
+                        if eid:
+                            _sent_event_ids.add(eid)
                         # yield 성공 후 delivered 마킹 (1c22da3e: 손실 방지, dup은 클라 dedup)
                         if eid:
                             try:

--- a/backend/tests/test_3026_sse_live_loop_connection_local_dedup.py
+++ b/backend/tests/test_3026_sse_live_loop_connection_local_dedup.py
@@ -1,0 +1,100 @@
+"""story #3026(실사고, PO 확定 2026-08-24) — events.py 라이브 루프의 pre-yield dedup을
+`Event.status`(DB, org 전체 공유) 조회에서 연결-로컬 `_sent_event_ids` 집합(+순수함수
+`_should_skip_live_event`)으로 교체한 처방 검증. 실사고 근거: 968fe78d 게이트 해소 이벤트가
+동일 member(sellerking)의 두 연결(페이지 탭+독립 프로브) 중 어느 쪽에도 안 뜨고 +59초 지연
+뒤에야 감(delivered_at 편차 +0.1s~+103s — "안 옴"이 아니라 "어느 연결이 이기느냐"의 복권).
+
+가드레일(PO)에 따라 두 불변식을 짝으로 고정한다. 실 SSE 스트림 종단간(TestClient 두 연결
+동시)은 이 샌드박스에서 anyio/TestClient 하네스 자체가 불안정(30초+ hang, 이 세션의 다른
+정상 동작 테스트(test_eventbus_s2.py)와 동일 패턴으로도 재현) — 그 축은 PO 가드레일③이
+이미 카디르 다중연결 라이브 QA로 배정해 뒀으므로 여기선 로직을 순수함수+직접 구조 조작으로
+격리해 결정적으로 고정한다:
+
+① `_should_skip_live_event`(추출한 순수함수) 자체의 진위표 — 연결-로컬 집합 의미론.
+② `_push_to_agent`의 fan-out이 **같은 member_id의 여러 큐 전부**에 도달하는지(다른
+   member끼리의 격리를 검증하는 기존 test_agent_isolation_multiple_connections의 반대
+   축 — "같은 member, 다른 연결"은 그 테스트가 안 다룸)."""
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+
+from app.routers.events import _agent_connections, _push_to_agent, _should_skip_live_event
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class TestShouldSkipLiveEvent:
+    """① 순수함수 진위표 — generate()가 매 연결마다 새로 만드는 로컬 집합을 그대로 흉내."""
+
+    def test_eid_none_never_skips(self):
+        assert _should_skip_live_event(None, {"a", "b"}) is False
+
+    def test_eid_not_in_local_set_does_not_skip(self):
+        """이 연결이 아직 안 보낸 id — 다른 연결이 몇 번을 먼저 보냈어도(집합에 안 들어있는
+        한) 이 연결은 여전히 내보내야 한다. #3026 핵심 — 예전 DB-status 체크였다면 다른
+        연결이 먼저 delivered로 찍은 순간 이 자리가 True(skip)가 됐을 상황."""
+        assert _should_skip_live_event("evt-1", set()) is False
+        assert _should_skip_live_event("evt-1", {"evt-2", "evt-3"}) is False
+
+    def test_eid_in_local_set_skips(self):
+        """이 연결이 이미 보낸 id(백필 또는 이전 라이브) — 같은 연결 내 중복만 막는다."""
+        assert _should_skip_live_event("evt-1", {"evt-1"}) is True
+
+    def test_empty_string_eid_never_skips(self):
+        """falsy eid(빈 문자열)는 B계열(event_id 없는 transient push) 취급과 동형 — 애초에
+        이 게이트를 안 탄다(빈 문자열도 falsy라 `bool(eid)`에서 걸러짐)."""
+        assert _should_skip_live_event("", {""}) is False
+
+
+@pytest.mark.anyio
+async def test_push_to_agent_fans_out_to_all_queues_of_same_member():
+    """② 같은 member_id의 서로 다른 연결(탭 2개 시뮬레이션) — `_push_to_agent`가 그 member의
+    **모든** 큐에 도달시킨다(연결이 몇 개든). #3026 실사고 재현 시나리오(페이지 탭+프로브
+    둘 다 같은 member)의 push 단계 — 이 단계는 원래도 정상이었음을 재확認(회귀가드), 실제
+    결함은 yield 단계(위 순수함수 테스트가 그 축을 고정)였다는 진단을 구조로도 뒷받침."""
+    member_id = str(uuid.uuid4())
+    queue_1: asyncio.Queue = asyncio.Queue(maxsize=10)
+    queue_2: asyncio.Queue = asyncio.Queue(maxsize=10)
+    queue_3: asyncio.Queue = asyncio.Queue(maxsize=10)
+    _agent_connections[member_id] = {queue_1, queue_2, queue_3}
+
+    try:
+        eid = str(uuid.uuid4())
+        payload = {"event_type": "conversation.gate_resolved", "event_id": eid, "gate_id": "g-1", "status": "approved"}
+        pushed = _push_to_agent(member_id, payload)
+
+        assert pushed is True
+        for q in (queue_1, queue_2, queue_3):
+            received = q.get_nowait()
+            assert received["event_id"] == eid
+            assert q.empty()
+    finally:
+        _agent_connections.pop(member_id, None)
+
+
+@pytest.mark.anyio
+async def test_push_to_agent_survives_one_dead_queue_among_many():
+    """부수 회귀가드 — 동시 연결 중 하나가 죽어있어도(QueueFull) 나머지 연결은 정상 수신
+    (`_push_to_agent`의 기존 dead-queue 청소 로직이 이 처방과 계속 정합하는지)."""
+    member_id = str(uuid.uuid4())
+    dead_queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+    dead_queue.put_nowait({"event_type": "filler"})  # 꽉 채워 QueueFull 유도.
+    alive_queue: asyncio.Queue = asyncio.Queue(maxsize=10)
+    _agent_connections[member_id] = {dead_queue, alive_queue}
+
+    try:
+        eid = str(uuid.uuid4())
+        pushed = _push_to_agent(member_id, {"event_type": "conversation.gate_resolved", "event_id": eid})
+
+        assert pushed is True  # alive_queue 쪽은 성공.
+        assert alive_queue.get_nowait()["event_id"] == eid
+        # dead_queue는 자동 정리(discard)돼 등록에서 빠졌는지.
+        assert dead_queue not in _agent_connections[member_id]
+    finally:
+        _agent_connections.pop(member_id, None)


### PR DESCRIPTION
[SID:3026]

## Summary
story #2985 AC② 라이브 재현(PO 2회) 중 발견한 실사고 근본. `events.py`의 SSE 라이브 루프가 eid(A계열 DB-backed 이벤트)의 pre-yield dedup 판단을 `Event.status`(DB, org 전체 공유 상태) 조회로 했다 — 같은 member의 다른 연결(다른 탭·독립 프로브·잔존 연결)이 먼저 yield+delivered로 찍으면, 자기 큐에 그 항목이 와 있는 나머지 연결 전부가 "이미 처리됨"으로 오판해 skip. 동시 연결 N개 중 실제로는 딱 1개만 갱신됐다.

**실물 증거**(dev DB 직접조회, pgstat-probe-dev job): 968fe78d 게이트 해소 이벤트 `delivered_at`이 `created_at`보다 **+59초** 늦음, 같은 배치 다른 이벤트도 +0.1s~+103s로 편차 극심 — "안 옴"이 아니라 "어느 연결이 이기느냐"의 복권이었다. `_push_to_agent`의 fan-out(멤버의 모든 큐에 push) 자체는 처음부터 정상 — 결함은 순전히 yield 단계의 dedup 판단 축이 이벤트/DB(공유)를 봤지 연결(로컬)을 안 본 데 있었다.

## 처방
- `_should_skip_live_event(eid, sent_event_ids)` 순수함수로 dedup 판단을 추출(`generate()`는 클로저라 직접 단위테스트 불가).
- 각 연결이 `_sent_event_ids: set[str]`(연결-로컬, 매 연결마다 새로 생성)을 들고, 백필 단계에서 이미 보낸 id를 채운 뒤, 라이브 루프는 이 로컬 집합만 본다 — DB 조회 완전 제거(매 라이브 이벤트마다의 hot-path DB 왕복도 없앴다, #2158이 B계열에 이미 적용한 "hot-path DB 0" 원칙을 A계열에도 확장).
- `Event.status`/`delivered_at` DB 마킹 자체는 유지 — 백필(재연결) 경로가 그 값을 커서 판정에 계속 쓴다.

## Test plan
- [x] `_should_skip_live_event` 진위표 4건 — 양방향 mutation 완료("항상 skip"/"항상 non-skip" 각각 정확히 해당 테스트만 FAIL, 복원 후 재green).
- [x] `_push_to_agent`가 같은 member_id의 모든 큐(dead queue 혼재 포함)에 fan-out하는지 2건.
- [x] 기존 SSE 스위트(test_eventbus_s2/s3·2101·2128·2131·2143·2172·2201·2582·2602·c4c72eb1·e_infra_s4/s5·e_ui_daegbyeon·s6_1·sse_conn_leak) 105+ green.
- [x] 유일 실패 1건(test_2128 lifespan_cap)은 원본(스태시) 코드에서도 동일 조합으로 재현되는 기존 타이밍-예민 flake(단독 실행 3/3 green) — 이 변경과 무관 확認.
- [ ] 실 다중-탭 SSE 왕복(TestClient 두 스트림 동시 하네스가 이 샌드박스에서 anyio 이벤트루프 경합으로 30초+ hang, 다른 기존 정상 테스트와 동일 패턴 재현) — 카디르 QA(다중연결 라이브+에이전트 채널 왕복) 배정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)