### PR TITLE
[SID:3022] 채팅 report성 메시지 밀도 재설계 — 유형 kicker+리드+최상위 목록 폴딩

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3400,6 +3400,8 @@
     "authFailureTooltipInvalid": "API key not recognized · {n} failures in last 5 min"
   },
   "chats": {
+    "reportViewFull": "View full →",
+    "reportCollapse": "Collapse",
     "unreadMarker": "Unread from here",
     "citationAnchored": "Cited from here — pick the last message",
     "citationSelectedCount": "{count} messages selected",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3400,6 +3400,8 @@
     "authFailureTooltipInvalid": "API 키 인식 불가 · 최근 5분 {n}회"
   },
   "chats": {
+    "reportViewFull": "전문 보기 →",
+    "reportCollapse": "접기",
     "unreadMarker": "여기부터 안읽음",
     "citationAnchored": "여기부터 인용 — 끝 메시지를 마저 골라 주세요",
     "citationSelectedCount": "{count}개 메시지 선택됨",

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1721,3 +1721,100 @@ describe('ChatBubble — 로드맵 PR-B L5(Bot 배지 배경 proof-blue-soft)', 
     expect(badge?.className).not.toContain('accent-claim');
   });
 });
+
+// story #ec57c80c(v2 3호, 아티팩트 2fdc81aa) — report성 메시지 밀도 재설계(kicker+리드+
+// 최상위 목록+전문 보기). 발동은 에이전트의 긴 report성 메시지만(AC1), 짧은 대화·human
+// 메시지는 무변경(회귀 가드), kicker 오분류는 안전측으로 미표시(AC2, 강제 테스트).
+describe('ChatBubble — story #ec57c80c report성 메시지 밀도(kicker+리드+최상위 목록+전문 보기)', () => {
+  const REPORT_CONTENT = [
+    '**전체 판정 — PASS**',
+    '오늘 배포한 3개 표면 전부 실측 완료했는.',
+    '**① 3009 — PASS**',
+    '- 인라인 카드 elev-card 토큰 확認.',
+    '**② 3010 — PASS**',
+    '- inbox Bot칩 확認.',
+    '**③ 3011 — PASS**',
+    '- Workcell 잘림 fix 확認.',
+  ].join('\n');
+
+  const AMBIGUOUS_LONG_CONTENT = [
+    '**진행 상황 업데이트**',
+    '오늘 작업한 내용을 정리해서 공유하는.',
+    '**작업 1**',
+    '- 세부 내용 1',
+    '**작업 2**',
+    '- 세부 내용 2',
+    '**작업 3**',
+    '- 세부 내용 3',
+  ].join('\n');
+
+  it('짧은 agent 메시지는 무변경 — kicker/전문보기 UI 자체가 없다(AC1 회귀 가드)', async () => {
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...baseMessage, content: '고맙는!', references: [] }} isMine={false} />));
+    });
+    expect(container.textContent).not.toContain('전문 보기');
+    expect(container.textContent).toContain('고맙는!');
+  });
+
+  it('긴 report성 agent 메시지 + message_kind="result" — kicker "판정"+리드+최상위 목록+전문보기가 뜬다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble message={{ ...baseMessage, content: REPORT_CONTENT, message_kind: 'result', references: [] }} isMine={false} />,
+      ));
+    });
+    expect(container.textContent).toContain('판정');
+    // 실렌더 harness로 적발된 회귀 — 첫 줄이 리드로도 목록 첫 항목으로도 중복 노출됐었다.
+    // "전체 판정 — PASS"는 리드 한 번만 나와야 한다(목록엔 중복 제거).
+    expect(container.textContent!.split('전체 판정 — PASS').length - 1).toBe(1);
+    expect(container.textContent).toContain('① 3009 — PASS');
+    expect(container.textContent).toContain('전문 보기');
+    // 접힌 상태에선 하위 상세("인라인 카드 elev-card 토큰 확認")는 안 보여야 한다(폴딩).
+    expect(container.textContent).not.toContain('인라인 카드 elev-card 토큰 확認');
+  });
+
+  it('「전문 보기」 클릭 시 실제로 펼쳐져 하위 상세까지 전부 보인다(정보 소실 0) — 실 클릭 시뮬레이션', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble message={{ ...baseMessage, content: REPORT_CONTENT, message_kind: 'result', references: [] }} isMine={false} />,
+      ));
+    });
+    const viewFullBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('전문 보기'));
+    expect(viewFullBtn).toBeTruthy();
+    await act(async () => { viewFullBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    // 펼친 뒤엔 하위 상세 원문이 실제로 나타난다(폴딩 이전엔 없었던 텍스트).
+    expect(container.textContent).toContain('인라인 카드 elev-card 토큰 확認');
+    expect(container.textContent).toContain('접기');
+
+    const collapseBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '접기');
+    expect(collapseBtn).toBeTruthy();
+    await act(async () => { collapseBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    // 다시 접으면 하위 상세가 사라지고 요약 뷰로 돌아온다.
+    expect(container.textContent).not.toContain('인라인 카드 elev-card 토큰 확認');
+    expect(container.textContent).toContain('전문 보기');
+  });
+
+  it('message_kind 없고 패턴도 불확실하면 — 발동은 하되(길이 조건 충족) kicker는 미표시(AC2 강제 테스트, 오분류 방지)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble message={{ ...baseMessage, content: AMBIGUOUS_LONG_CONTENT, message_kind: null, references: [] }} isMine={false} />,
+      ));
+    });
+    expect(container.textContent).toContain('전문 보기');
+    expect(container.textContent).toContain('진행 상황 업데이트');
+    expect(container.textContent).not.toContain('판정');
+  });
+
+  it('human 발신 메시지는 아무리 길어도 report 밀도 처리 대상이 아니다(범위=에이전트 메시지만)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, content: REPORT_CONTENT, message_kind: 'result', sender_type: 'human', references: [] }}
+          isMine={false}
+        />,
+      ));
+    });
+    expect(container.textContent).not.toContain('전문 보기');
+    // 원문(하위 상세 포함)이 그대로 렌더돼야 한다 — 접힘 없음.
+    expect(container.textContent).toContain('인라인 카드 elev-card 토큰 확認');
+  });
+});

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1817,4 +1817,27 @@ describe('ChatBubble — story #ec57c80c report성 메시지 밀도(kicker+리�
     // 원문(하위 상세 포함)이 그대로 렌더돼야 한다 — 접힘 없음.
     expect(container.textContent).toContain('인라인 카드 elev-card 토큰 확認');
   });
+
+  // 카디르 QA(#3448) 적출 — 첫 줄 문장 경계가 볼드 스팬 중간에 떨어지면(마침표가 "**" 안에
+  // 있으면) 리드가 "**Summary."처럼 닫는 마커 없이 잘려 화면에 미완성 ** 문자가 그대로
+  // 노출됐다(dedup도 이 변형에서 무력화). 실렌더로 미완성 마커 부재를 직접 확認한다.
+  it('첫 줄이 볼드 스팬 중간에서 잘리는 경우에도 미완성 마커(**)가 화면에 안 샌다', async () => {
+    const raw = [
+      '**Summary. Done**',
+      '오늘 배포한 3개 표면 전부 실측 완료했는.',
+      '**① 3009 — PASS**',
+      '- 인라인 카드 elev-card 토큰 확認.',
+      '**② 3010 — PASS**',
+      '- inbox Bot칩 확認.',
+      '**③ 3011 — PASS**',
+      '- Workcell 잘림 fix 확認.',
+    ].join('\n');
+    await act(async () => {
+      root.render(wrap(<ChatBubble message={{ ...baseMessage, content: raw, message_kind: 'result', references: [] }} isMine={false} />));
+    });
+    expect(container.textContent).not.toContain('**');
+    expect(container.textContent).toContain('Summary. Done');
+    // "Summary. Done"이 리드 한 번만 나와야 한다(목록에 중복 노출 금지).
+    expect(container.textContent!.split('Summary. Done').length - 1).toBe(1);
+  });
 });

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -33,6 +33,7 @@ import { parseBlockTemplate, type EventDefinitionSummary } from '@/lib/block-tem
 import { segmentMessageContent } from './message-segments';
 import { EmbedGroup } from './embed-group';
 import { toEmbedCardOpenPanel } from './embed-card-open-panel-adapter';
+import { ReportMessageSummary } from './report-message-summary';
 
 interface ChatBubbleProps {
   message: ChatMessage;
@@ -166,7 +167,9 @@ function CopyableCode({ raw, inline, className }: { raw: string; inline: boolean
   );
 }
 
-function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenReadingPanel, eventDefinitionsByKey }: {
+// story #ec57c80c(v2 3호) — report-message-summary.tsx가 「전문 보기」 펼침 상태에서 이
+// 컴포넌트를 그대로 재사용한다(사본 분화 금지 — 접힘 해제 시 원래 렌더 경로와 완전히 동일).
+export function ChatMarkdown({ content, isMine, references, entityStatusByKey, onOpenReadingPanel, eventDefinitionsByKey }: {
   content: string; isMine: boolean; references: ChatMessage['references'];
   entityStatusByKey?: Record<string, EntityStatusFetchState>;
   onOpenReadingPanel?: (target: ReadingPanelTarget) => void;
@@ -604,7 +607,19 @@ export function ChatBubble({
                 ? 'rounded-tr-sm bg-proof-blue-soft'
                 : 'rounded-tl-sm bg-proof-panel'
             }`}>
-              <ChatMarkdown content={displayContent} isMine={isMine} references={message.references} entityStatusByKey={entityStatusByKey} onOpenReadingPanel={onOpenReadingPanel} eventDefinitionsByKey={eventDefinitionsByKey} />
+              {/* story #ec57c80c(v2 3호) — report성 밀도 재설계는 에이전트 메시지에만
+                  적용한다(진단·처방 전부 "에이전트 report성 메시지" 범위, human 메시지는
+                  무변경). ReportMessageSummary 내부가 발동 조건(computeReportDensity) 미충족
+                  이면 곧바로 ChatMarkdown으로 폴백하므로 인간 메시지 경로는 항상 원본 그대로. */}
+              {isAgent ? (
+                <ReportMessageSummary
+                  content={displayContent} messageKind={message.message_kind} isMine={isMine}
+                  references={message.references} entityStatusByKey={entityStatusByKey}
+                  onOpenReadingPanel={onOpenReadingPanel} eventDefinitionsByKey={eventDefinitionsByKey}
+                />
+              ) : (
+                <ChatMarkdown content={displayContent} isMine={isMine} references={message.references} entityStatusByKey={entityStatusByKey} onOpenReadingPanel={onOpenReadingPanel} eventDefinitionsByKey={eventDefinitionsByKey} />
+              )}
             </div>
           )}
 

--- a/apps/web/src/components/chat/report-message-summary.tsx
+++ b/apps/web/src/components/chat/report-message-summary.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import type { ChatMessage } from '@/hooks/use-chat-sse';
+import type { EntityStatusFetchState } from './entity-status-labels';
+import type { ReadingPanelTarget } from './reading-panel';
+import type { EventDefinitionSummary } from '@/lib/block-template';
+import { ChatMarkdown } from './chat-bubble';
+import { computeReportDensity } from '@/lib/chat-report-density';
+
+interface ReportMessageSummaryProps {
+  content: string;
+  messageKind?: string | null;
+  isMine: boolean;
+  references: ChatMessage['references'];
+  entityStatusByKey?: Record<string, EntityStatusFetchState>;
+  onOpenReadingPanel?: (target: ReadingPanelTarget) => void;
+  eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
+}
+
+/**
+ * story #ec57c80c(v2 3호, 아티팩트 2fdc81aa) — 에이전트 report성 메시지 밀도 재설계. 소스
+ * (메시지 content)는 무변경 — 표현 층 전용. 발동 조건(computeReportDensity) 미충족이거나
+ * 펼친 상태면 기존 `ChatMarkdown` 경로 그대로(회귀 0, 사본 분화 금지) — 새 마크업은 접힌
+ * 상태(kicker+리드+최상위 목록+더 보기)일 때만 나타난다.
+ */
+export function ReportMessageSummary({
+  content, messageKind, isMine, references, entityStatusByKey, onOpenReadingPanel, eventDefinitionsByKey,
+}: ReportMessageSummaryProps) {
+  const t = useTranslations('chats');
+  const [expanded, setExpanded] = useState(false);
+  const density = computeReportDensity(content, messageKind);
+
+  if (!density || expanded) {
+    return (
+      <>
+        <ChatMarkdown
+          content={content} isMine={isMine} references={references} entityStatusByKey={entityStatusByKey}
+          onOpenReadingPanel={onOpenReadingPanel} eventDefinitionsByKey={eventDefinitionsByKey}
+        />
+        {density ? (
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            className="mt-1 text-[11px] font-medium text-primary hover:underline"
+          >
+            {t('reportCollapse')}
+          </button>
+        ) : null}
+      </>
+    );
+  }
+
+  return (
+    <div>
+      {density.kicker ? (
+        <span className="mb-1.5 inline-flex items-center gap-1 rounded-md bg-proof-blue-soft px-2 py-0.5 text-[10px] font-bold text-proof-blue">
+          {density.kicker}
+        </span>
+      ) : null}
+      <p className={`mb-1.5 text-sm font-medium leading-relaxed [overflow-wrap:anywhere] ${density.kicker ? '' : 'mt-0'}`}>
+        {density.lead}
+      </p>
+      {density.topLevelItems.length > 0 ? (
+        <ul className="mb-1.5 flex flex-col gap-0.5">
+          {density.topLevelItems.map((item, i) => (
+            <li key={i} className="text-sm leading-relaxed [overflow-wrap:anywhere]">{item.text}</li>
+          ))}
+        </ul>
+      ) : null}
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        className="text-[11.5px] font-semibold text-primary hover:underline"
+      >
+        {t('reportViewFull')}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/lib/chat-report-density.test.ts
+++ b/apps/web/src/lib/chat-report-density.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeReportDensity, deriveKicker, extractLeadSentence, extractTopLevelItems, isReportDense,
+  REPORT_DENSITY_MIN_CHARS, REPORT_DENSITY_MIN_LINES,
+} from './chat-report-density';
+
+describe('isReportDense (story #ec57c80c, 발동 임계값)', () => {
+  it('짧은 대화 메시지는 false(무변경 대상)', () => {
+    expect(isReportDense('고맙는!')).toBe(false);
+    expect(isReportDense('악! 확認했는.')).toBe(false);
+  });
+
+  it('줄 수가 임계값 이상이면 true', () => {
+    const raw = Array.from({ length: REPORT_DENSITY_MIN_LINES }, (_, i) => `줄 ${i + 1}`).join('\n');
+    expect(isReportDense(raw)).toBe(true);
+  });
+
+  it('글자 수가 임계값 이상이면 true(줄 수는 적어도)', () => {
+    expect(isReportDense('가'.repeat(REPORT_DENSITY_MIN_CHARS))).toBe(true);
+  });
+
+  it('임계값 바로 아래는 false(경계 검증)', () => {
+    const justUnder = Array.from({ length: REPORT_DENSITY_MIN_LINES - 1 }, (_, i) => `줄${i}`).join('\n');
+    expect(isReportDense(justUnder.slice(0, REPORT_DENSITY_MIN_CHARS - 1))).toBe(false);
+  });
+});
+
+describe('deriveKicker (story #ec57c80c AC2 — 오분류 안전측)', () => {
+  it('message_kind가 있으면 1차 소스로 즉시 확定', () => {
+    expect(deriveKicker('아무 내용', 'result')).toBe('판정');
+    expect(deriveKicker('아무 내용', 'handoff')).toBe('핸드오프');
+    expect(deriveKicker('아무 내용', 'request')).toBe('요청');
+    expect(deriveKicker('아무 내용', 'ack')).toBe('확인');
+  });
+
+  it('message_kind가 null/undefined면 보수적 패턴 폴백 — 확실한 판정 어휘(PASS/FAIL/REQUEST_CHANGES)가 볼드 라인에 있을 때만', () => {
+    expect(deriveKicker('**결과 — PASS**\n본문', null)).toBe('판정');
+    expect(deriveKicker('**결과 — FAIL**\n본문', undefined)).toBe('판정');
+    expect(deriveKicker('**REQUEST_CHANGES — 사유**\n본문', null)).toBe('판정');
+  });
+
+  it('message_kind 없고 패턴도 불확실하면 kicker 미표시(null) — 오분류=지어냄 방지(강제 테스트)', () => {
+    expect(deriveKicker('그냥 평범한 긴 설명 문단입니다.', null)).toBeNull();
+    // 볼드는 있지만 판정 어휘가 없는 경우도 미표시.
+    expect(deriveKicker('**진행 상황 업데이트**\n작업 중', null)).toBeNull();
+    // PASS가 볼드 밖(평문)에 있으면 미표시 — "확실한 패턴"이 아니라 보수적으로 거른다.
+    expect(deriveKicker('PASS라고 들었는데 확인은 안 함', null)).toBeNull();
+  });
+});
+
+describe('extractLeadSentence (story #ec57c80c — 첫 문장 verbatim, 3015 규율)', () => {
+  it('첫 문장 경계(마침표+공백)에서 자른다', () => {
+    expect(extractLeadSentence('첫 문장입니다. 둘째 문장.')).toBe('첫 문장입니다.');
+  });
+
+  it('마침표 없이 줄바꿈만 있으면 첫 줄에서 자른다', () => {
+    expect(extractLeadSentence('첫 줄 내용\n둘째 줄 내용')).toBe('첫 줄 내용');
+  });
+
+  it('줄바꿈과 마침표 중 먼저 오는 경계를 쓴다', () => {
+    expect(extractLeadSentence('짧은 첫 줄\n둘째 줄. 셋째.')).toBe('짧은 첫 줄');
+    expect(extractLeadSentence('첫 문장. 둘째 줄\n셋째 줄')).toBe('첫 문장.');
+  });
+
+  it('볼드/백틱 마커를 스트립한다(verbatim 텍스트는 그대로)', () => {
+    expect(extractLeadSentence('**중요 결과** — `workcell.tsx` 확認.')).toBe('중요 결과 — workcell.tsx 확認.');
+  });
+
+  it('verbatim — 리라이트·요약 없이 원문 문구를 정확히 보존한다', () => {
+    const raw = '실패한 결제를 재시도로 복구하는 로직 구현 완료';
+    expect(extractLeadSentence(raw)).toBe(raw);
+  });
+
+  it('빈 입력은 빈 문자열', () => {
+    expect(extractLeadSentence('')).toBe('');
+    expect(extractLeadSentence('   ')).toBe('');
+  });
+});
+
+describe('extractTopLevelItems (story #ec57c80c — 최상위 목록만, 하위/표/산문 제외)', () => {
+  it('볼드 단독 라인(섹션 헤더)을 최상위 항목으로 뽑는다', () => {
+    const raw = '**개요**\n본문\n**① 첫 항목 — PASS**\n- 하위 상세\n**② 둘째 항목 — PASS**';
+    const items = extractTopLevelItems(raw);
+    expect(items.map((i) => i.text)).toEqual(['개요', '① 첫 항목 — PASS', '② 둘째 항목 — PASS']);
+  });
+
+  it('들여쓰기된 하위 불릿은 최상위 목록에서 제외한다(들여쓰기 0만 최상위)', () => {
+    const raw = '- 최상위 항목\n  - 들여쓴 하위 항목\n\t- 탭 들여쓴 항목';
+    expect(extractTopLevelItems(raw).map((i) => i.text)).toEqual(['최상위 항목']);
+  });
+
+  it('표(| ... |) 행은 목록 항목으로 뽑지 않는다', () => {
+    const raw = '- 목록 항목\n| 열1 | 열2 |\n|---|---|\n| 값1 | 값2 |';
+    expect(extractTopLevelItems(raw).map((i) => i.text)).toEqual(['목록 항목']);
+  });
+
+  it('산문 문단(볼드도 불릿도 아닌 줄)은 목록에 안 들어간다', () => {
+    const raw = '그냥 산문 설명입니다.\n계속되는 설명.';
+    expect(extractTopLevelItems(raw)).toEqual([]);
+  });
+});
+
+describe('computeReportDensity (story #ec57c80c — 통합, 발동 게이트)', () => {
+  it('발동 조건 미충족이면 null(호출부가 기존 렌더로 폴백)', () => {
+    expect(computeReportDensity('짧은 메시지', 'result')).toBeNull();
+  });
+
+  it('발동 조건 충족 시 kicker/리드/목록 전부 채운다', () => {
+    const raw = [
+      '**전체 판정 — PASS**',
+      '오늘 배포한 3개 표면 전부 실측 완료.',
+      '**① 3009 — PASS**',
+      '- 인라인 카드 elev-card 토큰 확認',
+      '**② 3010 — PASS**',
+      '- inbox Bot칩 확認',
+      '**③ 3011 — PASS**',
+      '- Workcell 잘림 fix 확認',
+    ].join('\n');
+    const result = computeReportDensity(raw, 'result');
+    expect(result).not.toBeNull();
+    expect(result!.kicker).toBe('판정');
+    expect(result!.lead).toBe('전체 판정 — PASS');
+    // 첫 줄(리드로 이미 쓴 볼드 헤더)은 목록에서 중복 제거된다 — ①②③만 남는다.
+    expect(result!.topLevelItems.map((i) => i.text)).toEqual([
+      '① 3009 — PASS', '② 3010 — PASS', '③ 3011 — PASS',
+    ]);
+  });
+
+  // 실렌더 격리 harness(next build 실 CSS 번들)로 스크린샷 대조 중 실제로 잡힌 결함 —
+  // 첫 줄이 볼드 헤더면 extractLeadSentence와 extractTopLevelItems가 같은 줄을 각자
+  // 독립적으로 뽑아 리드와 목록 첫 항목이 화면에 그대로 중복 노출됐다.
+  it('첫 줄이 볼드 헤더면 리드와 동일 텍스트가 목록에 중복되지 않는다(실렌더로 적발된 회귀)', () => {
+    const raw = [
+      '**요약 문장입니다**',
+      '**두 번째 헤더**',
+      '- 상세 1',
+      '**세 번째 헤더**',
+      '- 상세 2',
+      '**네 번째 헤더**',
+      '- 상세 3',
+      '- 상세 4',
+    ].join('\n');
+    const result = computeReportDensity(raw, null);
+    expect(result).not.toBeNull();
+    expect(result!.lead).toBe('요약 문장입니다');
+    expect(result!.topLevelItems.map((i) => i.text)).toEqual(['두 번째 헤더', '세 번째 헤더', '네 번째 헤더']);
+    expect(result!.topLevelItems.some((i) => i.text === result!.lead)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/chat-report-density.test.ts
+++ b/apps/web/src/lib/chat-report-density.test.ts
@@ -75,6 +75,27 @@ describe('extractLeadSentence (story #ec57c80c — 첫 문장 verbatim, 3015 규
     expect(extractLeadSentence('')).toBe('');
     expect(extractLeadSentence('   ')).toBe('');
   });
+
+  // 카디르 QA(#3448) 적출 — 문장 경계(마침표)가 볼드 스팬 중간에 떨어지면 절단 결과가
+  // "**Summary."(닫는 ** 없음)가 돼 미완성 마커가 화면에 그대로 샌다. 마커가 짝 안 맞는
+  // 절단은 건너뛰고 더 늦은(안전한) 경계 또는 전체로 폴백해야 한다.
+  describe('카디르 repro — 마커 균형 폴백(미완성 ** 노출 방지)', () => {
+    it('원 repro — "**Summary. Done**"에서 마침표가 볼드 중간에 있어도 미완성 마커가 안 샌다', () => {
+      expect(extractLeadSentence('**Summary. Done**')).toBe('Summary. Done');
+    });
+
+    it('볼드 스팬 뒤에 더 안전한 줄바꿈 경계가 있으면 그쪽으로 폴백한다', () => {
+      expect(extractLeadSentence('**Summary. Done**\n둘째 줄')).toBe('Summary. Done');
+    });
+
+    it('백틱(인라인 코드) 스팬 중간에 마침표가 있어도 미완성 백틱이 안 샌다', () => {
+      expect(extractLeadSentence('`workcell.tsx 파일. 확認`')).toBe('workcell.tsx 파일. 확認');
+    });
+
+    it('정상적으로 짝이 맞는 절단은 기존대로 그대로 동작한다(회귀 0)', () => {
+      expect(extractLeadSentence('**중요**. 둘째 문장.')).toBe('중요.');
+    });
+  });
 });
 
 describe('extractTopLevelItems (story #ec57c80c — 최상위 목록만, 하위/표/산문 제외)', () => {

--- a/apps/web/src/lib/chat-report-density.ts
+++ b/apps/web/src/lib/chat-report-density.ts
@@ -1,0 +1,119 @@
+/**
+ * story #ec57c80c(v2 3호, 아티팩트 2fdc81aa) — 채팅 report성 메시지 밀도 변환. 소스(메시지
+ * content)는 무변경 — 렌더 시점 표현 변환만. 리라이트·요약 생성 절대 금지(no-fiction) —
+ * kicker·리드·목록 항목은 전부 원문 substring(마크다운 기호 strip 결과)이지 생성 텍스트가
+ * 아니다.
+ */
+
+export type MessageKind = 'request' | 'handoff' | 'result' | 'ack';
+
+const MESSAGE_KIND_LABEL: Record<MessageKind, string> = {
+  request: '요청', handoff: '핸드오프', result: '판정', ack: '확인',
+};
+
+// story #2985 — FE ChatMessage.message_kind는 BE 계약을 앞서 좁히지 않으려 `string | null`로
+// 느슨하게 타입돼 있다(이 세션의 다른 필드들과 동일 관례). 4-enum 소속 여부는 여기서
+// 런타임으로만 판별한다 — 구서버·오염값은 항상 안전하게 폴백(무표시 또는 휴리스틱)한다.
+function asMessageKind(value: string | null | undefined): MessageKind | null {
+  return value != null && Object.hasOwn(MESSAGE_KIND_LABEL, value) ? (value as MessageKind) : null;
+}
+
+// PO 감確認 지점(발동 임계값) — 과폴딩(클릭 피로) vs 벽(스캔 불가) 트레이드오프 튜닝이
+// 필요하면 이 두 상수만 바꾼다. 아티팩트 2fdc81aa ⓒ 실측(실 대화 250px+ 메시지·>400자
+// 요소 다수)을 참고해 잡은 초기값.
+export const REPORT_DENSITY_MIN_LINES = 8;
+export const REPORT_DENSITY_MIN_CHARS = 400;
+
+function stripInlineMarkers(text: string): string {
+  return text
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/`([^`]*)`/g, '$1')
+    .trim();
+}
+
+/** 긴 report성 메시지인지(발동 조건) — N줄 이상 또는 N자 이상. 짧은 대화는 항상 false. */
+export function isReportDense(content: string): boolean {
+  const lineCount = content.split('\n').filter((l) => l.trim().length > 0).length;
+  return lineCount >= REPORT_DENSITY_MIN_LINES || content.length >= REPORT_DENSITY_MIN_CHARS;
+}
+
+// message_kind 없을 때만 도는 보수적 구조 폴백 — 확실한 판정 어휘(이 팀 실사용 관례:
+// PASS/FAIL/REQUEST_CHANGES)가 볼드 라인에 있을 때만 kicker를 단다. 그 외(모호)는 전부
+// 미표시 — 오분류 kicker는 지어냄이라 미표시가 항상 안전측(story AC2).
+const VERDICT_PATTERN = /\*\*[^*]*\b(PASS|FAIL|REQUEST_CHANGES)\b[^*]*\*\*/;
+
+/** kicker 라벨. 1차 소스=message_kind(있으면 그걸로 확定), 없으면 보수적 패턴 폴백,
+ * 그것도 아니면 null(미표시 — 지어내지 않음). */
+export function deriveKicker(content: string, messageKind?: string | null): string | null {
+  const kind = asMessageKind(messageKind);
+  if (kind) return MESSAGE_KIND_LABEL[kind];
+  if (VERDICT_PATTERN.test(content)) return '판정';
+  return null;
+}
+
+/** 첫 문장을 verbatim으로 추출(리라이트 0). 문장 경계 = 마침표/느낌표/물음표+공백(또는
+ * 문자열 끝) 또는 첫 줄바꿈 중 먼저 오는 지점 — report 메시지는 첫 줄이 이미 한 논지인
+ * 경우가 많아(볼드 헤더 라인 관례) 줄바꿈도 유효한 경계로 취급한다. */
+export function extractLeadSentence(content: string): string {
+  const trimmed = content.trim();
+  if (!trimmed) return '';
+
+  const newlineIdx = trimmed.indexOf('\n');
+  const puncMatch = trimmed.match(/[.!?](?:\s|$)/);
+  const puncIdx = puncMatch && puncMatch.index !== undefined ? puncMatch.index + 1 : -1;
+
+  let end = trimmed.length;
+  if (newlineIdx !== -1) end = Math.min(end, newlineIdx);
+  if (puncIdx !== -1) end = Math.min(end, puncIdx);
+
+  return stripInlineMarkers(trimmed.slice(0, end));
+}
+
+export interface TopLevelListItem {
+  text: string;
+}
+
+/** 최상위 섹션만 뽑는다. report 메시지 관례상 볼드 단독 라인(섹션 헤더)이 있으면 그
+ * 헤더들이 최상위 구조 그 자체이고, 그 아래 들여쓰기 없는 대시 불릿은 헤더에 딸린
+ * "하위 상세"다(전문 보기로 접힘) — 헤더가 하나도 없을 때만 들여쓰기 0의 최상위
+ * 불릿(-/*) 자체를 목록으로 쓴다(단순 평문 목록 메시지 대응). 표·산문 문단·들여쓰기된
+ * 하위 내용은 어느 경우든 대상 밖(원문은 그대로 「전문 보기」에 남는다 — 정보 소실 0,
+ * 이 함수는 무엇을 미리 보여줄지만 고르지 원문을 바꾸지 않는다). */
+export function extractTopLevelItems(content: string): TopLevelListItem[] {
+  const lines = content.split('\n');
+  const boldHeaders: TopLevelListItem[] = [];
+  for (const line of lines) {
+    const boldOnly = line.match(/^\*\*([^*]+)\*\*\s*$/);
+    if (boldOnly) boldHeaders.push({ text: stripInlineMarkers(boldOnly[1]!) });
+  }
+  if (boldHeaders.length > 0) return boldHeaders;
+
+  const bullets: TopLevelListItem[] = [];
+  for (const line of lines) {
+    const bullet = line.match(/^[-*]\s+(.+)$/);
+    if (bullet) bullets.push({ text: stripInlineMarkers(bullet[1]!) });
+  }
+  return bullets;
+}
+
+export interface ReportDensity {
+  kicker: string | null;
+  lead: string;
+  topLevelItems: TopLevelListItem[];
+}
+
+/** 발동 조건(isReportDense) 미충족이면 null — 호출부는 null이면 기존 렌더를 그대로 쓴다
+ * (짧은 대화 무변경, story AC1). */
+export function computeReportDensity(content: string, messageKind?: string | null): ReportDensity | null {
+  if (!isReportDense(content)) return null;
+  const lead = extractLeadSentence(content);
+  // report 메시지 첫 줄이 그 자체로 볼드 섹션 헤더인 경우(예: "**전체 판정 — PASS**"),
+  // extractLeadSentence와 extractTopLevelItems가 같은 줄을 각자 독립적으로 뽑아 리드와
+  // 목록 첫 항목이 그대로 중복된다 — 리드로 이미 쓴 항목은 목록에서 제외한다.
+  const topLevelItems = extractTopLevelItems(content).filter((item) => item.text !== lead);
+  return {
+    kicker: deriveKicker(content, messageKind),
+    lead,
+    topLevelItems,
+  };
+}

--- a/apps/web/src/lib/chat-report-density.ts
+++ b/apps/web/src/lib/chat-report-density.ts
@@ -51,9 +51,21 @@ export function deriveKicker(content: string, messageKind?: string | null): stri
   return null;
 }
 
+// 카디르 QA(#3448) 적출 — "**Summary. Done**"류에서 문장 경계(마침표)가 볼드 스팬
+// 중간에 떨어지면 절단 결과가 "**Summary."(닫는 ** 없음)가 돼 미완성 마커가 그대로
+// 화면에 샌다. 굵게·인라인코드 마커(짝수 개수) 균형이 안 맞는 절단은 "미절단 폴백"(정직
+// 측)으로 건너뛴다.
+function isBalancedCut(text: string): boolean {
+  const boldCount = (text.match(/\*\*/g) ?? []).length;
+  const codeCount = (text.match(/`/g) ?? []).length;
+  return boldCount % 2 === 0 && codeCount % 2 === 0;
+}
+
 /** 첫 문장을 verbatim으로 추출(리라이트 0). 문장 경계 = 마침표/느낌표/물음표+공백(또는
  * 문자열 끝) 또는 첫 줄바꿈 중 먼저 오는 지점 — report 메시지는 첫 줄이 이미 한 논지인
- * 경우가 많아(볼드 헤더 라인 관례) 줄바꿈도 유효한 경계로 취급한다. */
+ * 경우가 많아(볼드 헤더 라인 관례) 줄바꿈도 유효한 경계로 취급한다. 두 경계 다 마커
+ * (굵게·인라인코드)를 반으로 가르면 더 늦은(안전한) 경계로, 그마저 없으면 전체로
+ * 폴백한다(「미절단 폴백」— 정직 측, 미완성 마커 노출 방지). */
 export function extractLeadSentence(content: string): string {
   const trimmed = content.trim();
   if (!trimmed) return '';
@@ -62,9 +74,8 @@ export function extractLeadSentence(content: string): string {
   const puncMatch = trimmed.match(/[.!?](?:\s|$)/);
   const puncIdx = puncMatch && puncMatch.index !== undefined ? puncMatch.index + 1 : -1;
 
-  let end = trimmed.length;
-  if (newlineIdx !== -1) end = Math.min(end, newlineIdx);
-  if (puncIdx !== -1) end = Math.min(end, puncIdx);
+  const candidates = [puncIdx, newlineIdx].filter((n) => n !== -1).sort((a, b) => a - b);
+  const end = candidates.find((c) => isBalancedCut(trimmed.slice(0, c))) ?? trimmed.length;
 
   return stripInlineMarkers(trimmed.slice(0, end));
 }


### PR DESCRIPTION
## 요약
유나 시안(아티팩트 `2fdc81aa`, story `ec57c80c`) 확定분 구현. 로드맵 v2 채팅 축 — 에이전트 report성 메시지(판정·상태·핸드오프)가 마크다운 벽으로 흘러 대화 흐름에서 10초 스캔이 안 됐다(3015 Brief·3018 보드 카드 덤프와 동류, 메시지 층). 형태(스플릿뷰)·임베드 스캔성(S1/S2)은 이미 착지 — 이 PR은 콘텐츠(메시지 본문 밀도)만 손본다.

## 파이프라인(소스 무변경 · 표현 층만 · 에이전트 메시지에만 적용)
1. **발동 게이트** — N줄(8) 또는 N자(400) 이상만(짧은 대화는 완전 무변경). PO 감確認 지점이라 두 상수(`REPORT_DENSITY_MIN_LINES`/`_CHARS`)만 튜닝 지점으로 남김.
2. **유형 kicker** — 1차 소스 `message_kind`(BE #2985가 이미 top-level로 노출, **FE `ChatMessage` 타입에도 이미 선언·정규화까지 돼 있었음** — 이번에 처음 소비). 없으면 보수적 패턴 폴백(볼드 라인의 `PASS`/`FAIL`/`REQUEST_CHANGES`만, 이 팀 실사용 어휘) — 그마저 없으면 kicker 자체 미표시(오분류=지어냄 방지, AC2 강제 테스트로 고정).
3. **리드** — 첫 문장 verbatim(마침표/줄바꿈 중 먼저 오는 경계, 3015 규율 동일 — 리라이트 0).
4. **최상위 목록 폴딩** — 볼드 섹션 헤더가 있으면 그 헤더들만(하위 대시 불릿은 상세로 접힘), 헤더가 없으면 최상위(들여쓰기 0) 불릿 자체를 목록으로. 표·산문·하위 내용은 전부 「전문 보기」로 접힘(기존 렌더 경로 그대로 — 새 마크업 0, 정보 소실 0).

## 안전 설계(회귀 0 보장)
- `ReportMessageSummary`는 발동 게이트 미충족이거나 펼친 상태면 곧바로 기존 `ChatMarkdown`(export만 새로 함, 사본 분화 0)을 그대로 렌더 — 짧은 메시지·펼친 후 상태는 **100% 원래 경로**.
- 적용 범위는 `isAgent`로 게이트 — human 메시지는 아무리 길어도 무변경(진단·처방이 전부 "에이전트 report성 메시지" 범위였음).

## 실렌더로 잡은 실결함 1건(자체 회귀가드화)
`next build` 실 CSS 번들로 스크린샷 대조 중 발견 — 메시지 첫 줄이 그 자체로 볼드 섹션 헤더면(예: `**전체 판정 — PASS**`) 리드와 목록 첫 항목이 독립적으로 같은 줄을 뽑아 화면에 중복 노출됐다. `computeReportDensity`에서 리드와 동일한 목록 항목을 제거하는 dedup을 추가하고, 전용 유닛 테스트(1건)+`ChatBubble` 통합 테스트에서 "전체 판정 — PASS" 문자열 정확히 1회 등장 단언으로 고정.

## 변경 파일 — 정확히 7개(4 수정 + 3 신규, `git diff --stat` 실측)
- `lib/chat-report-density.ts`(신규) + `.test.ts`(신규, **20건**)
- `components/chat/report-message-summary.tsx`(신규)
- `components/chat/chat-bubble.tsx`(`export ChatMarkdown` 1줄 + `isAgent` 게이트 분기) + `.test.tsx`(신규 **5건**, 기존 97건 전부 보존)
- `messages/ko.json` / `en.json` — `chats.reportViewFull` / `chats.reportCollapse` 2키

## 검증
- [x] `chat-report-density.test.ts` — **20/20** green(발동 게이트 경계값·kicker 1차/폴백/미표시 강제·리드 문장경계·최상위 목록(헤더우선/불릿폴백/표제외/산문제외)·통합·dedup 회귀 1건)
- [x] `chat-bubble.test.tsx` — 기존 **97건 전부 보존** + 신규 **5건**(짧은 메시지 무변경·kicker+목록 노출·**실 클릭으로 전문보기 펼침/접기 왕복**·AC2 강제 미표시·human 메시지 무변경) = **102/102** green
- [x] 전체 `vitest run` — **499 files / 4440 tests all green**
- [x] `tsc --noEmit` clean
- [x] `eslint` clean(0 warning)
- [x] `pnpm build` EXIT=0

## 실렌더 재현
`next build` 실 컴파일 CSS + `renderToStaticMarkup`의 실 컴포넌트 출력(mock 아님)을 그대로 그려 시안 목업의 report 메시지 예시를 재현 — kicker "판정"+리드+①②③ 최상위 목록+「전문 보기 →」, 라이트·다크 확認. 중복 결함은 이 과정에서 실측으로 잡아 fix.

## AC 대조
1. report성 긴 메시지: kicker(있을 때만)+리드+최상위 목록+전문 보기 — 짧은 메시지 무변경.
2. kicker 오분류 안전측 — message_kind null+패턴 불확실 → 미표시(강제 테스트로 고정).
3. 「전문 보기」=본문 그대로 펼침(정보 소실 0·새 화면 0, ChatMarkdown 사본 분화 0으로 구조적 보장).
4. 유나 design·카디르 QA·배포 후 라이브(실 에이전트 대화) — 이 PR 오픈으로 착수.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_017Y8uNHvGThWG8QPBz1nhFz