### PR TITLE
[SID:3019] 에픽 스윔레인 뷰 로드 37초+ stuck — 스코프 축소(epic_ids/done_within_days)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -861,6 +861,8 @@
     "epicSwimlaneUnassigned": "Unassigned",
     "epicSwimlaneOverflowToggle": "{count} more epics",
     "epicSwimlaneLoadError": "Couldn't load. Please try again in a moment.",
+    "epicSwimlaneLoadTimeout": "Loading took too long, so we stopped. Please try again.",
+    "epicSwimlaneLoadingElapsed": "Loading… ({seconds}s)",
     "epicSwimlaneRetry": "Retry",
     "proofCapsuleStateRunning": "Running",
     "proofCapsuleStateReviewing": "Awaiting verification",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -861,6 +861,8 @@
     "epicSwimlaneUnassigned": "미할당",
     "epicSwimlaneOverflowToggle": "에픽 {count}개 더 보기",
     "epicSwimlaneLoadError": "불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    "epicSwimlaneLoadTimeout": "불러오는 데 시간이 너무 오래 걸려 중단했습니다. 다시 시도해 주세요.",
+    "epicSwimlaneLoadingElapsed": "불러오는 중… ({seconds}초)",
     "epicSwimlaneRetry": "다시 시도",
     "proofCapsuleStateRunning": "실행 중",
     "proofCapsuleStateReviewing": "검증 대기",

--- a/apps/web/src/app/api/stories/route.ts
+++ b/apps/web/src/app/api/stories/route.ts
@@ -94,6 +94,12 @@ export async function GET(request: Request) {
       // story #2328(C-11 ㉡층) — 083176e8/story_number와 같은 클래스(있는 필드가 프록시에서
       // 빠지는 것) 재발 방지로 처음부터 포함.
       boost_candidates_from: searchParams.get('boost_candidates_from') ?? undefined,
+      // story #3019(실사고 처방) — epic_ids(comma-separated)+epic_unassigned+done_within_days.
+      // 이 셋이 함께 오면 buildCursorPageMeta의 limit+1 오버페치 계약을 그대로 타 hasMore가
+      // 정확히 서는 좁혀진(스코프 축소) 결과에 대해서도 성립한다 — 별도 분기 불요.
+      epic_ids: searchParams.get('epic_ids')?.split(',').map((id) => id.trim()).filter(Boolean),
+      epic_unassigned: searchParams.get('epic_unassigned') === 'true' ? true : undefined,
+      done_within_days: searchParams.get('done_within_days') ? Number(searchParams.get('done_within_days')) : undefined,
       limit: pageInput.limit + 1,  // RC3: 오버페치 → buildCursorPageMeta hasMore 판단
       cursor: pageInput.cursor,
     });

--- a/apps/web/src/components/epics/epic-swimlane-board.test.tsx
+++ b/apps/web/src/components/epics/epic-swimlane-board.test.tsx
@@ -831,3 +831,74 @@ describe('EpicSwimlaneBoard — StoryDetailPanel 배선(story #2931, QA changes 
     expect(container.textContent).not.toContain('삭제될카드');
   });
 });
+
+// story #3019(실사고, PO 확定 2026-08-24) — 매 로드마다 project 전체 역사(이 프로젝트 실측
+// 3018 스토리)를 페이지네이션하던 것을 서버측 스코프(활성 에픽+미배정, done은 최근 7일)로
+// 좁혔다. 31회 순차 왕복=37초+ 멈춤의 근본 처방 — 이 축의 실물 계약(요청 URL이 실제로
+// 좁혀진 파라미터를 싣는지)을 고정한다.
+describe('EpicSwimlaneBoard — 스코프 축소(story #3019)', () => {
+  it('stories 요청이 활성 에픽 id만 epic_ids로, epic_unassigned=true·done_within_days=7을 싣는다(비활성 에픽 제외)', async () => {
+    await mount({
+      epics: [
+        { id: 'e-active-1', title: '활성1', status: 'active', position: 1 },
+        { id: 'e-active-2', title: '활성2', status: 'active', position: 2 },
+        { id: 'e-inactive', title: '완료된 에픽', status: 'completed', position: 3 },
+      ],
+      stories: [],
+    });
+
+    const storiesCall = callLog.find((l) => l.startsWith('GET /api/stories?'));
+    expect(storiesCall, 'stories GET 호출을 못 찾음').toBeDefined();
+    const url = new URL(storiesCall!.replace('GET ', ''), 'http://localhost');
+    const epicIds = (url.searchParams.get('epic_ids') ?? '').split(',').filter(Boolean);
+    expect(new Set(epicIds)).toEqual(new Set(['e-active-1', 'e-active-2']));
+    expect(epicIds).not.toContain('e-inactive');
+    expect(url.searchParams.get('epic_unassigned')).toBe('true');
+    expect(url.searchParams.get('done_within_days')).toBe('7');
+  });
+
+  it('활성 에픽이 0개여도 epic_unassigned=true는 그대로 실려 미배정 레인은 여전히 조회된다', async () => {
+    await mount({
+      epics: [{ id: 'e-inactive', title: '완료된 에픽', status: 'completed', position: 1 }],
+      stories: [],
+    });
+
+    const storiesCall = callLog.find((l) => l.startsWith('GET /api/stories?'));
+    const url = new URL(storiesCall!.replace('GET ', ''), 'http://localhost');
+    expect(url.searchParams.has('epic_ids')).toBe(false); // 빈 목록은 아예 안 보낸다(서버 elif 분기).
+    expect(url.searchParams.get('epic_unassigned')).toBe('true');
+  });
+
+  it('타임아웃(LOAD_TIMEOUT_MS) 경과 시 정직한 타임아웃 문구로 떨어진다(일반 에러와 구분)', async () => {
+    vi.useFakeTimers();
+    try {
+      // goals는 정상 응답하되 stories fetch가 영원히 안 끝나는 것을 시뮬레이션(AbortSignal
+      // 자체는 이 스텁이 못 흉내내므로, 타임아웃 도달 시 실제 abort된 fetch가 reject하는
+      // 대신 "응답이 안 옴"을 직접 재현 — 컴포넌트의 setTimeout(abort) 발동 자체를 검증).
+      vi.stubGlobal('fetch', vi.fn((url: string, init?: { signal?: AbortSignal }) => {
+        if (typeof url === 'string' && url.startsWith('/api/goals')) {
+          return Promise.resolve({ ok: true, json: async () => ({ data: [], meta: { hasMore: false, nextCursor: null } }) });
+        }
+        if (typeof url === 'string' && url.startsWith('/api/stories?')) {
+          // 영원히 응답 안 옴 — 컴포넌트의 AbortController(setTimeout 발동)만이 유일한
+          // 탈출. 실 fetch/AbortSignal 계약을 흉내: signal이 abort되면 reject.
+          return new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(new DOMException('The operation was aborted.', 'AbortError'));
+            });
+          });
+        }
+        return Promise.resolve({ ok: true, json: async () => ({ data: [] }) });
+      }));
+
+      await act(async () => {
+        root.render(withIntl(<EpicSwimlaneBoard projectId="p1" />));
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(20_000); });
+
+      expect(container.textContent).toContain('불러오는 데 시간이 너무 오래 걸려 중단했습니다');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/components/epics/epic-swimlane-board.tsx
+++ b/apps/web/src/components/epics/epic-swimlane-board.tsx
@@ -335,7 +335,7 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
       setEpics(epics);
       if (membersRes.ok) { const json = await membersRes.json(); setMembers(json.data ?? []); }
       setLoadError(null);
-    } catch (err) {
+    } catch (_err) {
       // QA changes 8R HIGH②(카디르+codex, 2026-08-22) — fetchAllPages가 이제 중간 실패를
       // throw로 승격하니 여기서 정직한 에러 상태로 받는다. stories/epics를 손대지 않고
       // (부분 데이터로 덮어써 "이 프로젝트엔 원래 이만큼만 있다"처럼 보이는 재발 방지)

--- a/apps/web/src/components/epics/epic-swimlane-board.tsx
+++ b/apps/web/src/components/epics/epic-swimlane-board.tsx
@@ -34,21 +34,38 @@ const UNASSIGNED_LANE_ID = '__unassigned__';
 // 하게 서버에서 maxLimit=100으로 clamp한다(apps/web/src/app/api/stories/route.ts). 기존
 // limit=1000 단발 요청은 100건 초과 프로젝트에서 hasMore/nextCursor를 소비하지 않은 채
 // 조용히 잘려 레인 카운트·상위3 큐레이션이 틀어졌다. 이 뷰는 kanban-board(컬럼별 "더보기"
-// UX)와 달리 레인×컬럼 버킷팅 자체가 «전체 집합»을 요구해 부분 로드로는 정직할 수 없다 —
-// hasMore가 꺼질 때까지 커서를 소진한다("정직한 더-있음 표시"보다 전량 소진이 이 뷰엔 맞음).
+// UX)와 달리 레인×컬럼 버킷팅 자체가 «필요한 전체 집합»을 요구해 부분 로드로는 정직할 수
+// 없다 — hasMore가 꺼질 때까지 커서를 소진한다("정직한 더-있음 표시"보다 전량 소진이 이
+// 뷰엔 맞음).
 // QA changes 7R(카디르+codex, 2026-08-22) — 원 발견의 «에픽» 절반: /api/goals도 동일
 // maxLimit=100 clamp라 활성 에픽 100+ 프로젝트에서 레인 자체가 조용히 누락된다. stories
 // 전용이던 헬퍼를 basePath 파라미터화해 goals에도 동형 적용(중복 루프 제거).
+// ⚠️story #3019(실사고, PO 확定 2026-08-24) — 위 "«전체 집합»을 요구"는 «org 역사 전체»가
+// 아니라 «화면이 실제로 그리는 것(활성 에픽+미배정)의 전체»로 재정의됐다. 예전엔 이 구분이
+// 없어 project_id만 걸고 페이지네이션했고, 이 프로젝트 실측(3018 스토리)에서 31회 순차
+// 왕복=37초+ 멈춤을 냈다 — 이제 fetchAll()이 epic_ids(활성 에픽)+epic_unassigned+
+// done_within_days=7로 BE 쿼리 자체를 좁힌 뒤 그 좁혀진 결과에 한해 전량 소진한다(보통
+// 1~2페이지, 안전판은 그대로 살아있다 — 활성 에픽 하나가 실제로 5000건을 넘는 극단만 throw).
 const PAGE_LIMIT = 100;
 const PAGE_HARD_CAP = 50; // 안전판(최대 5000건) — 정상 프로젝트 규모를 크게 상회.
+// story #3019 가드레일② — 스코프 축소 後 정상 케이스는 수 초 내 완료가 기대치. 20초는
+// 그 기대치의 넉넉한 배수(정상 편차 흡수)이면서 "멈춤"을 사용자가 무한정 기다리게
+// 두지는 않는 상한.
+const LOAD_TIMEOUT_MS = 20_000;
 
-async function fetchAllPages<T>(basePath: string, projectId: string, source: string): Promise<T[]> {
+async function fetchAllPages<T>(
+  basePath: string, projectId: string, source: string,
+  extraParams?: Record<string, string>, signal?: AbortSignal,
+): Promise<T[]> {
+  const extra = extraParams
+    ? Object.entries(extraParams).map(([k, v]) => `&${k}=${encodeURIComponent(v)}`).join('')
+    : '';
   const all: T[] = [];
   let cursor: string | null = null;
   let exhaustedNaturally = false;
   for (let page = 0; page < PAGE_HARD_CAP; page += 1) {
-    const url = `${basePath}?project_id=${projectId}&limit=${PAGE_LIMIT}${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`;
-    const res = await fetchWithAuth(url);
+    const url = `${basePath}?project_id=${projectId}&limit=${PAGE_LIMIT}${extra}${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`;
+    const res = await fetchWithAuth(url, signal ? { signal } : undefined);
     // ⚠️QA changes 8R HIGH②(카디르+codex, 2026-08-22) — 중간 페이지 실패를 `break`로 삼키면
     // 그때까지 모은 부분 집합을 완전 집합처럼 반환한다(6R/7R이 막으려던 "조용한 누락"과
     // 같은 클래스, 실패 경로에서 재발). 부분-성공을 허용하지 않는다 — throw해 호출부
@@ -227,7 +244,11 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
   const [epics, setEpics] = useState<KanbanEpic[]>([]);
   const [members, setMembers] = useState<KanbanMember[]>([]);
   const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState(false);
+  // story #3019(실사고 처방) — "느림"과 "멈춤"이 구분 안 되던 축(타임아웃 부재+진행표시 0)도
+  // 결함의 절반이었다. loadError를 원인별로 갈라 문구를 정직하게(지어내지 않고 실제
+  // 사유대로) 낸다.
+  const [loadError, setLoadError] = useState<'timeout' | 'generic' | null>(null);
+  const [loadingElapsedSec, setLoadingElapsedSec] = useState(0);
   const [axisMode, setAxisMode] = useState<AxisMode>('trust');
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [selectedStoryId, setSelectedStoryId] = useState<string | null>(null);
@@ -277,11 +298,35 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
 
   const fetchAll = useCallback(async () => {
     setLoading(true);
+    setLoadingElapsedSec(0);
+    // story #3019 가드레일② — 타임아웃은 "선택"이 아니라 스코프 축소와 동승. 백엔드가
+    // 정말로 응답을 안 주는 극단(스코프 축소가 못 막는 유일한 남은 축)에서도 화면이
+    // 무한정 "불러오는 중"으로 얼어붙지 않고 LOAD_TIMEOUT_MS 뒤 정직한 타임아웃 에러로
+    // 떨어진다.
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), LOAD_TIMEOUT_MS);
     try {
-      const [stories, epics, membersRes] = await Promise.all([
-        fetchAllPages<KanbanStory>('/api/stories', projectId, 'EpicSwimlaneBoard fetchAll(stories)'),
-        fetchAllPages<KanbanEpic>('/api/goals', projectId, 'EpicSwimlaneBoard fetchAll(goals)'),
-        fetchWithAuth(`/api/members?project_id=${projectId}`),
+      // story #3019 근본 처방 — epics를 먼저 확定해야 "활성 에픽 집합"을 알 수 있다
+      // (stories 쿼리의 epic_ids가 그 집합에 의존) — Promise.all로 병렬화할 수 없는 진짜
+      // 순차 의존(이전엔 이 의존이 아예 없었다 — 매번 project 전체를 불렀으니까).
+      const epics = await fetchAllPages<KanbanEpic>(
+        '/api/goals', projectId, 'EpicSwimlaneBoard fetchAll(goals)', undefined, controller.signal,
+      );
+      const activeEpicIds = epics
+        .filter((e) => (e.status ?? 'active') === 'active')
+        .map((e) => e.id);
+      // story #3019 — 화면이 실제로 그리는 것(활성 에픽 소속+미배정)만, done은 최근 7일만
+      // (list_board의 done-7일 관례를 일반화). 스토리에 명기한 범위 선언 그대로: 비활성
+      // 에픽 소속 스토리는 애초에 어느 레인에도 안 그려지므로 제외해도 화면상 무변화이고,
+      // 미배정+done 7일 초과분만 유일하게 눈에 보이는 축소(kanban-board.tsx의 done 컬럼과
+      // 동일 관례로의 정합 — 새 제약 발명이 아니다).
+      const storyParams: Record<string, string> = { done_within_days: '7', epic_unassigned: 'true' };
+      if (activeEpicIds.length > 0) storyParams.epic_ids = activeEpicIds.join(',');
+      const [stories, membersRes] = await Promise.all([
+        fetchAllPages<KanbanStory>(
+          '/api/stories', projectId, 'EpicSwimlaneBoard fetchAll(stories)', storyParams, controller.signal,
+        ),
+        fetchWithAuth(`/api/members?project_id=${projectId}`, { signal: controller.signal }),
       ]);
       // story #2187/b8157376(kanban-board와 동형 불변식, QA changes 6R HIGH①) — is_excluded=true
       // (라이브 QA 임시 카드 등)는 삭제 권한이 없는 화면에서라도 무조건 숨긴다. 토글 없음 —
@@ -289,19 +334,29 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
       setStories(stories.filter((s) => !s.is_excluded));
       setEpics(epics);
       if (membersRes.ok) { const json = await membersRes.json(); setMembers(json.data ?? []); }
-      setLoadError(false);
-    } catch {
+      setLoadError(null);
+    } catch (err) {
       // QA changes 8R HIGH②(카디르+codex, 2026-08-22) — fetchAllPages가 이제 중간 실패를
       // throw로 승격하니 여기서 정직한 에러 상태로 받는다. stories/epics를 손대지 않고
       // (부분 데이터로 덮어써 "이 프로젝트엔 원래 이만큼만 있다"처럼 보이는 재발 방지)
       // 전용 에러 화면으로 대체한다.
-      setLoadError(true);
+      setLoadError(controller.signal.aborted ? 'timeout' : 'generic');
     } finally {
+      clearTimeout(timeoutId);
       setLoading(false);
     }
   }, [projectId]);
 
   useEffect(() => { void fetchAll(); }, [fetchAll]);
+
+  // story #3019 가드레일② — 진행 표시 0이 "느림"과 "멈춤"을 구분 못 하게 했다. 초 단위
+  // 하트비트만으로도 "화면이 살아있다"는 신호는 충분(페이지 수 기반 진행률은 스코프 축소
+  // 後엔 보통 1~2회라 의미 있는 분모가 없다 — 지어내지 않는다).
+  useEffect(() => {
+    if (!loading) return;
+    const intervalId = setInterval(() => setLoadingElapsedSec((s) => s + 1), 1000);
+    return () => clearInterval(intervalId);
+  }, [loading]);
 
   const memberMap = useMemo(() => {
     const map: Record<string, KanbanMember> = {};
@@ -452,10 +507,14 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
         <WorkspaceFrameTabs active="epic" />
 
         {loading ? (
-          <div className="p-4 text-sm text-muted-foreground">{t('loading')}</div>
+          <div className="p-4 text-sm text-muted-foreground">
+            {t('epicSwimlaneLoadingElapsed', { seconds: loadingElapsedSec })}
+          </div>
         ) : loadError ? (
           <div className="flex flex-col items-start gap-2 p-4">
-            <p role="alert" className="text-sm text-destructive">{t('epicSwimlaneLoadError')}</p>
+            <p role="alert" className="text-sm text-destructive">
+              {t(loadError === 'timeout' ? 'epicSwimlaneLoadTimeout' : 'epicSwimlaneLoadError')}
+            </p>
             <button
               type="button"
               onClick={() => { void fetchAll(); }}

--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -103,7 +103,8 @@ class StoryRepository(BaseRepository[Story]):
 
     async def list(
         self, limit: int = 1000, *, q: str | None = None, cursor: datetime | None = None,
-        unattached: bool = False, **filters,
+        unattached: bool = False, epic_ids: list[uuid.UUID] | None = None,
+        include_unassigned: bool = False, done_within_days: int | None = None, **filters,
     ) -> tuple[list[Story], int]:
         """story #2537(카디르 QA #2932 실측, 2026-08-09) — `list_board()`와 동형으로
         `(stories, total)` 튜플을 반환한다. 이전엔 `list[Story]`만 반환해 이 분기(status
@@ -141,7 +142,22 @@ class StoryRepository(BaseRepository[Story]):
         걸친 행은 이론상 다음 페이지에서 스킵될 수 있다(중복 전달보다는 덜 나쁜 실패 모드로
         의도적으로 선택). board 분기도 동일한 구조적 한계를 이미 갖고 있다 — 실제로 skip이
         관측되면 그때 복합 커서(`created_at`+`id`)로 승격한다.
-        """
+
+        story #3019(실사고, PO 확定 2026-08-24) — 에픽 스윔레인 뷰가 매 로드마다 프로젝트
+        전체 역사(이 프로젝트 실측 3018건)를 31회 순차 페이지네이션으로 끌어와 37초+ 멈춤을
+        냈다. 근본은 «화면이 실제로 그리는 건 활성 에픽 소속+미배정뿐인데 org 전체를 부른다»
+        — epic_ids(IN)+include_unassigned(OR)로 그 스코프를 서버측에서 정확히 좁힌다.
+
+        `epic_ids`/`include_unassigned`는 **OR** 결합(활성 에픽 소속 «또는» 미배정) —
+        AND라면 "이 에픽들에 속하면서 동시에 미배정"이 돼 공집합이 된다. `unattached`
+        (기존 파라미터, #2532)와 다른 개념이다 — `_unattached_clause()`는 "에픽도 가설도
+        둘 다 안 매달림"이고, 여기 `include_unassigned`는 스윔레인의 "미배정 레인"과 순수
+        1:1 대응하는 "에픽만 없음"(가설 링크 유무 무관) — 기존 `unattached`를 재사용하면
+        가설이 매달린 미배정 스토리가 스윔레인에서 조용히 누락되는 별개 결함을 만든다.
+
+        `done_within_days`는 list_board()의 "done: 최근 7일" 관례(CB-S4)를 이 제네릭 경로에
+        일반화한 것 — done 아닌 상태는 무관(그 상태들은 자연히 유한하다, 완료 이력만 무한
+        누적), done만 `created_at >= now - N일`로 좁힌다. None(기본)이면 기존 동작 그대로."""
         query = select(Story).where(self._org_filter(), Story.deleted_at.is_(None))
         for attr, val in filters.items():
             query = query.where(getattr(Story, attr) == val)
@@ -151,6 +167,14 @@ class StoryRepository(BaseRepository[Story]):
             query = query.where(Story.created_at < cursor)
         if unattached:
             query = query.where(_unattached_clause())
+        if epic_ids is not None:
+            epic_clause = Story.epic_id.in_(epic_ids)
+            query = query.where(or_(epic_clause, Story.epic_id.is_(None)) if include_unassigned else epic_clause)
+        elif include_unassigned:
+            query = query.where(Story.epic_id.is_(None))
+        if done_within_days is not None:
+            cutoff = datetime.now(timezone.utc) - timedelta(days=done_within_days)
+            query = query.where(or_(Story.status != "done", Story.created_at >= cutoff))
 
         count_q = select(func.count()).select_from(query.subquery())
         total = (await self.session.execute(count_q)).scalar_one()

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -146,6 +146,28 @@ async def list_stories(
     ids: str | None = Query(default=None, description="comma-separated story ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관)"),
     story_number: int | None = Query(default=None, description="프로젝트 내 사람-읽는 #N(project_id와 함께 사용 — N은 project 내에서만 유일)"),
     q: str | None = Query(default=None, description="title 부분검색(ILIKE) — 기존 필터와 AND 결합"),
+    epic_ids: str | None = Query(
+        default=None,
+        description=(
+            "story #3019 — comma-separated epic ids(IN 필터). epic_id(단일)와 별개 파라미터 "
+            "— include_unassigned=true와 함께 쓰면 OR(이 에픽들 소속 «또는» 미배정) 결합."
+        ),
+    ),
+    include_unassigned: bool = Query(
+        default=False,
+        description=(
+            "story #3019 — epic_id IS NULL(가설 링크 유무 무관, 기존 unattached와 다른 개념) "
+            "인 story도 결과에 포함. epic_ids와 단독으로도 쓸 수 있다(그 경우 미배정만)."
+        ),
+    ),
+    done_within_days: int | None = Query(
+        default=None,
+        ge=1,
+        description=(
+            "story #3019 — status=done row만 created_at이 최근 N일 이내인 것으로 제한(list_board "
+            "의 done-7일 관례를 제네릭 경로에 일반화). done 아닌 상태는 무관."
+        ),
+    ),
     boost_candidates_from: uuid.UUID | None = Query(
         default=None,
         description=(
@@ -167,6 +189,19 @@ async def list_stories(
     # 오는데, 센티널은 항상 truthy라 `if unattached:`가 무조건 참이 돼 기존 테스트 전부가
     # 조용히 필터링당한다 — `isinstance` 가드로 실제 bool일 때만 필터를 켠다.
     unattached = unattached if isinstance(unattached, bool) else False
+    # story #3019 — 동일 함정(위 boost_candidates_from 주석 참조), 신규 파라미터 3종에도 그대로 적용.
+    include_unassigned = include_unassigned if isinstance(include_unassigned, bool) else False
+    epic_ids = epic_ids if isinstance(epic_ids, str) else None
+    done_within_days = done_within_days if isinstance(done_within_days, int) else None
+
+    parsed_epic_ids: list[uuid.UUID] | None = None
+    if epic_ids is not None:
+        try:
+            parsed_epic_ids = [uuid.UUID(x) for x in epic_ids.split(",") if x.strip()]
+        except ValueError:
+            raise HTTPException(status_code=422, detail="invalid epic id in epic_ids")
+        if len(parsed_epic_ids) > 200:  # ids 파라미터와 동형 방어(과대 IN 금지).
+            raise HTTPException(status_code=422, detail="too many epic ids (max 200)")
 
     if ids is not None:
         # story ca37b2b0 ②: 갤러리 등 정확한 story 집합이 필요한 소비자용 — base.list()의
@@ -266,7 +301,11 @@ async def list_stories(
     # FE(buildCursorPageMeta)가 계산한 nextCursor가 다음 요청에서 조용히 무시돼 같은 페이지가
     # 반복된다(sprints/standup "더 보기" 중복 누적의 원인).
     cursor_dt = _parse_stories_cursor(cursor)
-    stories, total = await repo.list(limit=limit, q=q, cursor=cursor_dt, unattached=unattached, **filters)
+    stories, total = await repo.list(
+        limit=limit, q=q, cursor=cursor_dt, unattached=unattached,
+        epic_ids=parsed_epic_ids, include_unassigned=include_unassigned,
+        done_within_days=done_within_days, **filters,
+    )
     if response is not None:
         response.headers["X-Total-Count"] = str(total)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)

--- a/backend/tests/test_2188_no_sprint_alone_contract_pin.py
+++ b/backend/tests/test_2188_no_sprint_alone_contract_pin.py
@@ -86,6 +86,9 @@ async def test_actual_behavior_no_sprint_without_project_id_falls_through_to_gen
             # story #2532: 신규 Query 파라미터 — sentinel lint(scripts/lint_query_sentinel_
             # direct_calls.py) baseline과 missing-set을 맞추기 위해 명시.
             unattached=False,
+            # story #3019: epic_ids/include_unassigned/done_within_days 신규 Query
+            # 파라미터 — 위와 동일 이유로 명시(boost_candidates_from만 baseline 그대로 유지).
+            epic_ids=None, include_unassigned=False, done_within_days=None,
         )
         assert result == []
         repo.list.assert_awaited_once()

--- a/backend/tests/test_2642_entity_slug_exposure.py
+++ b/backend/tests/test_2642_entity_slug_exposure.py
@@ -146,6 +146,10 @@ async def test_story_list_and_get_carry_org_project_slug():
                 status_filter=None, no_sprint=False, unattached=False, ids=None,
                 story_number=None, q=None, boost_candidates_from=None, limit=1000,
                 cursor=None, response=None, repo=repo, auth=_auth(agent_id, org.id),
+                # story #3019: epic_ids/include_unassigned/done_within_days 신규 Query
+                # 파라미터 — sentinel lint(scripts/lint_query_sentinel_direct_calls.py)
+                # baseline과 missing-set을 맞추기 위해 명시.
+                epic_ids=None, include_unassigned=False, done_within_days=None,
             )
             assert len(listed) == 1
             assert listed[0].org_slug == org.slug
@@ -229,6 +233,9 @@ async def test_story_list_slug_resolution_is_not_n_plus_1():
                     status_filter=None, no_sprint=False, unattached=False, ids=None,
                     story_number=None, q=None, boost_candidates_from=None, limit=1000,
                     cursor=None, response=None, repo=repo, auth=_auth(agent_id, org.id),
+                    # story #3019: epic_ids/include_unassigned/done_within_days 신규
+                    # Query 파라미터 — sentinel lint baseline과 missing-set을 맞추기 위해 명시.
+                    epic_ids=None, include_unassigned=False, done_within_days=None,
                 )
             finally:
                 event.remove(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)

--- a/backend/tests/test_3019_epic_swimlane_scope_reduction_realdb.py
+++ b/backend/tests/test_3019_epic_swimlane_scope_reduction_realdb.py
@@ -1,0 +1,296 @@
+"""story #3019(실사고, PO 확定 2026-08-24) — 에픽 스윔레인 뷰가 매 로드마다 프로젝트 전체
+역사(그라운딩 시점 실측 3018건)를 페이지네이션으로 소진해 37초+ 멈춤을 냈다. 근본 처방은
+StoryRepository.list()에 epic_ids(IN)+include_unassigned(OR)+done_within_days 필터를 얹어
+"화면이 실제로 그리는 것"만 서버측에서 좁히는 것 — 이 파일은 그 세 파라미터의 실PG 검증.
+
+핵심 회귀 축(신규 파라미터라 실측 0이던 것들):
+① epic_ids+include_unassigned는 AND가 아니라 OR(합집합) — 잘못 짜면 공집합.
+② include_unassigned는 기존 `unattached`(#2532, 가설 링크까지 검사)와 다른 개념 —
+   가설이 매달린 미배정 스토리도 include_unassigned=True엔 포함돼야 한다.
+③ done_within_days는 status=done row만 좁히고 그 외 상태는 나이 무관 전부 포함."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _auth(agent_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(agent_id), email=None, claims={"app_metadata": {}})
+
+
+async def _call_list_stories(session, org_id, agent_id, **kwargs):
+    """test_083176e8와 동형 관례 — Query() 센티널 함정 회피(신규 3종 포함 전부 명시)."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import list_stories
+
+    repo = StoryRepository(session, org_id)
+    params = dict(
+        project_id=None, epic_id=None, sprint_id=None, assignee_id=None,
+        status_filter=None, no_sprint=False, unattached=False, ids=None, story_number=None,
+        q=None, boost_candidates_from=None, epic_ids=None, include_unassigned=False,
+        done_within_days=None, limit=1000, cursor=None, response=None,
+    )
+    params.update(kwargs)
+    return await list_stories(repo=repo, auth=_auth(agent_id), **params)
+
+
+async def _seed(session):
+    from app.models.hypothesis import Hypothesis, HypothesisStoryLink
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Goal, Story
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org3019", slug=f"org3019-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted"))
+    await session.commit()
+
+    epic_active = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Active epic", status="active")
+    epic_other = Goal(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Other epic", status="active")
+    session.add_all([epic_active, epic_other])
+    await session.commit()
+
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(days=30)
+    recent = now - timedelta(days=1)
+
+    s_epic_active = Story(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Story under active epic",
+        status="in-progress", epic_id=epic_active.id,
+    )
+    s_epic_other = Story(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Story under other epic",
+        status="in-progress", epic_id=epic_other.id,
+    )
+    s_unassigned_open = Story(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Unassigned open story",
+        status="backlog", epic_id=None,
+    )
+    s_unassigned_done_recent = Story(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Unassigned done recent",
+        status="done", epic_id=None,
+    )
+    s_unassigned_done_old = Story(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Unassigned done old",
+        status="done", epic_id=None,
+    )
+    s_epic_active_done_old = Story(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Active epic done old",
+        status="done", epic_id=epic_active.id,
+    )
+    # story #2532 unattached와 include_unassigned의 개념 분리 검증용 — epic_id는 없지만
+    # 가설이 매달려 있어 기존 _unattached_clause()는 이걸 걸러낸다(unattached=True 시 제외).
+    s_unassigned_with_hypothesis = Story(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Unassigned but has hypothesis",
+        status="backlog", epic_id=None,
+    )
+    session.add_all([
+        s_epic_active, s_epic_other, s_unassigned_open, s_unassigned_done_recent,
+        s_unassigned_done_old, s_epic_active_done_old, s_unassigned_with_hypothesis,
+    ])
+    await session.commit()
+
+    # created_at은 서버 default(now)라 커밋 後 직접 UPDATE로 시점을 조작한다(seed 전용, 실제
+    # 쓰기경로가 아니므로 raw update 허용 — 기존 realdb 시딩 관례와 동형).
+    from sqlalchemy import update
+    await session.execute(update(Story).where(Story.id == s_unassigned_done_recent.id).values(created_at=recent))
+    await session.execute(update(Story).where(Story.id == s_unassigned_done_old.id).values(created_at=old))
+    await session.execute(update(Story).where(Story.id == s_epic_active_done_old.id).values(created_at=old))
+    await session.commit()
+
+    hyp = Hypothesis(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, owner_member_id=agent.id,
+        statement="H", metric_definition={"metric": "x", "target": 1, "direction": "up"},
+        measure_after=now + timedelta(days=7),
+    )
+    session.add(hyp)
+    await session.commit()
+    session.add(HypothesisStoryLink(
+        id=uuid.uuid4(), hypothesis_id=hyp.id, story_id=s_unassigned_with_hypothesis.id,
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "agent_id": agent.id,
+        "epic_active": epic_active.id, "epic_other": epic_other.id,
+        "s_epic_active": s_epic_active.id, "s_epic_other": s_epic_other.id,
+        "s_unassigned_open": s_unassigned_open.id,
+        "s_unassigned_done_recent": s_unassigned_done_recent.id,
+        "s_unassigned_done_old": s_unassigned_done_old.id,
+        "s_epic_active_done_old": s_epic_active_done_old.id,
+        "s_unassigned_with_hypothesis": s_unassigned_with_hypothesis.id,
+    }
+
+
+async def test_epic_ids_filters_to_that_set_only():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], epic_ids=str(seeded["epic_active"]),
+            )
+            ids = {r.id for r in result}
+            assert seeded["s_epic_active"] in ids
+            assert seeded["s_epic_active_done_old"] in ids  # done_within_days 미지정 — 나이 무관 포함.
+            assert seeded["s_epic_other"] not in ids
+            assert seeded["s_unassigned_open"] not in ids
+    finally:
+        await engine.dispose()
+
+
+async def test_epic_ids_and_include_unassigned_is_or_not_and():
+    """① 회귀축 — epic_ids(활성 에픽 집합)+include_unassigned=True는 합집합이어야 한다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], epic_ids=str(seeded["epic_active"]),
+                include_unassigned=True,
+            )
+            ids = {r.id for r in result}
+            assert seeded["s_epic_active"] in ids
+            assert seeded["s_unassigned_open"] in ids
+            assert seeded["s_unassigned_with_hypothesis"] in ids
+            assert seeded["s_epic_other"] not in ids  # 다른(요청 안 한) 에픽은 여전히 제외.
+    finally:
+        await engine.dispose()
+
+
+async def test_include_unassigned_differs_from_legacy_unattached():
+    """② 회귀축 — include_unassigned은 가설 링크 유무를 안 본다(#2532 unattached와 다른 축).
+    unattached=True로 같은 질의를 하면 가설 매달린 미배정 스토리가 빠진다(대조군)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], include_unassigned=True,
+            )
+            ids = {r.id for r in result}
+            assert seeded["s_unassigned_with_hypothesis"] in ids
+
+            legacy = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], unattached=True,
+            )
+            legacy_ids = {r.id for r in legacy}
+            assert seeded["s_unassigned_with_hypothesis"] not in legacy_ids  # 대조군 — 기존 동작 무변화.
+            assert seeded["s_unassigned_open"] in legacy_ids
+    finally:
+        await engine.dispose()
+
+
+async def test_done_within_days_bounds_only_done_status():
+    """③ 회귀축 — done_within_days는 done row만 나이 제한. non-done은 나이 무관 전부 포함."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], include_unassigned=True, done_within_days=7,
+            )
+            ids = {r.id for r in result}
+            assert seeded["s_unassigned_done_recent"] in ids  # 1일 전 done — 포함.
+            assert seeded["s_unassigned_done_old"] not in ids  # 30일 전 done — 제외.
+            assert seeded["s_unassigned_open"] in ids  # backlog(non-done) — 나이 무관 포함.
+
+            with_epic = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], epic_ids=str(seeded["epic_active"]), done_within_days=7,
+            )
+            epic_ids = {r.id for r in with_epic}
+            assert seeded["s_epic_active"] in epic_ids  # in-progress — 나이 무관.
+            assert seeded["s_epic_active_done_old"] not in epic_ids  # 30일 전 done — 에픽 소속이어도 제외.
+    finally:
+        await engine.dispose()
+
+
+async def test_no_new_params_no_regression():
+    """무회귀 — 신규 파라미터 셋 다 미지정 시 기존 동작(project 전체) 그대로."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(s, seeded["org_id"], seeded["agent_id"], project_id=seeded["project_id"])
+            ids = {r.id for r in result}
+            assert ids == {
+                seeded["s_epic_active"], seeded["s_epic_other"], seeded["s_unassigned_open"],
+                seeded["s_unassigned_done_recent"], seeded["s_unassigned_done_old"],
+                seeded["s_epic_active_done_old"], seeded["s_unassigned_with_hypothesis"],
+            }
+    finally:
+        await engine.dispose()
+
+
+async def test_epic_ids_too_many_rejected_422():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            too_many = ",".join(str(uuid.uuid4()) for _ in range(201))
+            from fastapi import HTTPException
+            with pytest.raises(HTTPException) as exc_info:
+                await _call_list_stories(s, seeded["org_id"], seeded["agent_id"], epic_ids=too_many)
+            assert exc_info.value.status_code == 422
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_ca37b2b0_stories_ids_batch_realdb.py
+++ b/backend/tests/test_ca37b2b0_stories_ids_batch_realdb.py
@@ -102,6 +102,8 @@ async def _call_list_stories(session, org_id, agent_id, ids_param):
         # direct_calls.py) baseline과 missing-set을 맞추기 위해 명시(이 호출부는 ids
         # 분기라 다른 미기재 Query 파라미터들은 기존 baseline grandfather 그대로 둔다).
         unattached=False,
+        # story #3019: epic_ids/include_unassigned/done_within_days 신규 Query 파라미터 — 동일 이유로 명시.
+        epic_ids=None, include_unassigned=False, done_within_days=None,
     )
 
 

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -112,6 +112,16 @@ export interface StoryListFilters extends PaginationOptions {
   /** story #2328(C-11 ㉡층) — 이 story_id의 의미 후보를 결과 맨 앞으로 재정렬(필터 아님,
    * q 비어도 동작). 해당 항목엔 is_reference_candidate=true·matched_snippet이 실린다. */
   boost_candidates_from?: string;
+  /** story #3019(실사고 처방) — epic_id IN(...) 필터. `epic_id`(단일)와 별개 — 여러 에픽을
+   * 한 번에(스윔레인 뷰의 "활성 에픽 전체") 좁힌다. `epic_unassigned`와 함께 쓰면 OR 결합. */
+  epic_ids?: string[];
+  /** story #3019 — epic_id IS NULL인 story도 포함(가설 링크 유무 무관). `unattached`(#2532,
+   * 가설까지 검사)나 `unassigned`(담당자 미배정, 완전 별개 축)와 다른 개념 — 이름 충돌
+   * 방지로 "unassigned" 단독이 아닌 "epic_unassigned"로 명명. */
+  epic_unassigned?: boolean;
+  /** story #3019 — status=done row만 created_at이 최근 N일 이내인 것으로 제한(list_board의
+   * done-7일 관례를 제네릭 경로에 일반화). done 아닌 상태는 나이 무관 전부 포함. */
+  done_within_days?: number;
 }
 
 export interface IStoryRepository {

--- a/packages/storage-api/src/ApiStoryRepository.ts
+++ b/packages/storage-api/src/ApiStoryRepository.ts
@@ -29,6 +29,11 @@ export class ApiStoryRepository implements IStoryRepository {
         story_number: filters.story_number,
         // story #2328(C-11 ㉡층, PR#2659) — 같은 클래스 재발 방지로 처음부터 여기 포함.
         boost_candidates_from: filters.boost_candidates_from,
+        // story #3019(실사고 처방) — BE(stories.py) epic_ids/include_unassigned/
+        // done_within_days 3종. epic_ids는 comma-separated로(ids와 동형 관례).
+        epic_ids: filters.epic_ids?.join(','),
+        include_unassigned: filters.epic_unassigned,
+        done_within_days: filters.done_within_days,
       },
     });
   }


### PR DESCRIPTION
[SID:3019]

## 근본원인
에픽 스윔레인 뷰가 매 로드마다 프로젝트 역사 전체(그라운딩 시점 실측 3018건 스토리, 31페이지 순차 fetch)를 가져온 뒤 클라이언트에서 필터링 — 실제 렌더되는 카드는 ~70개 수준인데 서버 왕복이 31회, 37초+ 걸려 sellerking 계정에서 「불러오는 중」 무한 stuck으로 관측됨.

## 처방 (Oliveira 승인, 가드레일 2종 포함)
- BE: `StoryRepository.list()`에 `epic_ids`(IN), `include_unassigned`(OR 결합), `done_within_days` 3개 파라미터 추가 — 화면이 실제로 그리는 범위(활성 에픽 + 미배정 레인 + 최근 7일 이내 done)만 서버측에서 좁힘.
- FE: `epic-swimlane-board.tsx`의 `fetchAll()`을 위 3개 파라미터로 재작성. 활성 에픽이 0개면 `epic_ids`는 아예 생략(빈 배열로 보내면 서버가 공집합으로 오독할 위험 회피).
- 가드레일①: 미배정 레인은 `epic_unassigned=true`로 명시 스코프 선언 — 스코프 축소가 "미배정 스토리 누락"으로 새지 않게.
- 가드레일②: `LOAD_TIMEOUT_MS=20_000` + `AbortController` — 타임아웃 시 전용 에러 문구, 로딩 중엔 경과 초 표시(`loadingElapsedSec`).

## 실측 (before/after)
- before: 31회 순차 페이지 왕복, 37초+, 최종 무한 stuck 재현.
- after: 왕복 1~2회(활성 에픽 수에 무관, 서버측 IN 필터 1콜) 수준으로 축소.

## 검증
- BE realdb(디스포저블 PG, `Base.metadata.create_all`): `test_3019_epic_swimlane_scope_reduction_realdb.py` 6/6 통과 — epic_ids IN, OR 결합(공집합 회귀 방지), include_unassigned≠unattached 구분, done_within_days가 done만 좁히고 타 상태는 나이 무관 포함, 무회귀, 422 oversize(200건 cap).
- FE(vitest): `epic-swimlane-board.test.tsx` 31/31 통과. 신규 3종(story #3019 스코프축소 describe 블록) 포함: 활성 에픽만 epic_ids로 전송/0건이면 생략/20s 타임아웃 전용 에러문구.
- 뮤테이션 테스트: `epic_ids` 할당 라인 제거 → 정확히 해당 1개 테스트만 실패, 나머지 2개는 그대로 통과(검증이 그 라인에 실제로 물려 있음 확인).
- 회귀 재확인: `test_083176e8_story_search_q_realdb.py` + `test_2189_generic_branch_cursor_pagination_realdb.py` 11/11 통과 — `StoryRepository.list()` 시그니처 확장이 기존 q검색/커서페이징 경로에 영향 없음.
- `tsc --noEmit` clean, `eslint`(변경 파일) clean, i18n 가드(`verify:no-duplicate-i18n-keys`/`verify:no-i18n-phrase-collision`) 신규 키 0건 충돌.

CI 초록 확인 부탁하는. 머지는 통상 관례대로 위임.