### PR TITLE
[SID:3028] 긴 문서 TOC 자동 표면화 — 우측 미니 목차+현위치 하이라이트(짧은 문서 무변경)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1941,6 +1941,7 @@
     "indexNoResults": "No documents match these filters",
     "breadcrumbKnowledgeRoot": "Knowledge",
     "readMinutes": "{minutes} min read",
+    "tocOnThisDoc": "On this page",
     "docGateGoToEditorSign": "Sign off in editor",
     "docGateRejectModalTitle": "Reject review",
     "docGateRejectReasonLabel": "Rejection reason (shared with the author)",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1941,6 +1941,7 @@
     "indexNoResults": "조건에 맞는 문서가 없습니다",
     "breadcrumbKnowledgeRoot": "지식",
     "readMinutes": "읽기 {minutes}분",
+    "tocOnThisDoc": "이 문서",
     "docGateGoToEditorSign": "에디터에서 서명 결재",
     "docGateRejectModalTitle": "검토 반려",
     "docGateRejectReasonLabel": "반려 사유 (작성자에게 전달됩니다)",

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/view/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/view/page.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { DocContentRenderer } from '@/components/docs/doc-content-renderer';
 import { DocToc } from '@/components/docs/doc-toc';
+import { DocMiniToc } from '@/components/docs/doc-mini-toc';
+import { useActiveDocHeading } from '@/components/docs/doc-active-heading';
 import { extractDocHeadings } from '@/components/docs/doc-heading-utils';
 import { DocStatusHeader, DocEvidenceRail } from '@/components/docs/doc-status-rail';
 import { Button } from '@/components/ui/button';
@@ -50,10 +52,17 @@ export default function DocViewPage() {
 
   const [doc, setDoc] = useState<DocState>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
+  const scrollRootRef = useRef<HTMLDivElement | null>(null);
 
   const scrollToHeading = useCallback((id: string) => {
     contentRef.current?.querySelector<HTMLElement>(`#${CSS.escape(id)}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, []);
+
+  const headings = useMemo(
+    () => (doc ? extractDocHeadings(doc.content, doc.content_format ?? 'markdown') : []),
+    [doc],
+  );
+  const activeHeadingId = useActiveDocHeading(contentRef, headings, scrollRootRef);
 
   useEffect(() => {
     if (!projectId || !slug) return;
@@ -112,7 +121,7 @@ export default function DocViewPage() {
         <span className="text-muted-foreground">/</span>
         <span className="truncate text-foreground">{doc.title}</span>
         <span className="ml-auto flex shrink-0 items-center gap-1">
-          <DocToc headings={extractDocHeadings(doc.content, doc.content_format ?? 'markdown')} onHeadingClick={scrollToHeading} />
+          <DocToc headings={headings} onHeadingClick={scrollToHeading} />
           <Button asChild size="sm" variant="ghost">
             <Link href={docUrl(wsSlug, projSlug, slug)}>
               <Edit2 className="mr-1.5 h-3.5 w-3.5" />
@@ -122,7 +131,7 @@ export default function DocViewPage() {
         </span>
       </div>
 
-      <div className="focus-inset flex-1 overflow-y-auto">
+      <div ref={scrollRootRef} className="focus-inset flex-1 overflow-y-auto">
         <div className="grid grid-cols-1 gap-8 px-4 py-8 lg:grid-cols-[minmax(0,1fr)_316px] lg:px-8">
           {/* 리딩 컬럼(§3) — 68ch 정본(§8 확定), 본문 렌더는 무변경(DocContentRenderer). */}
           <article className="mx-auto w-full max-w-[68ch]">
@@ -166,6 +175,9 @@ export default function DocViewPage() {
 
           {/* 수직 증거 레일(§3/§6) — 접힌 gate 박스를 상시 공간으로 승격. */}
           <aside className="lg:border-l lg:border-border lg:pl-6">
+            {/* story #f546601e(v2 5호) — 긴 문서(N헤딩↑)만 자동 노출, 짧은 문서는 무변경
+                (MINI_TOC_MIN_HEADINGS 가드는 컴포넌트 내부). */}
+            <DocMiniToc headings={headings} activeId={activeHeadingId} onHeadingClick={scrollToHeading} className="mb-6" />
             <DocEvidenceRail docId={doc.id} status={doc.status} />
           </aside>
         </div>

--- a/apps/web/src/components/docs/doc-active-heading.test.tsx
+++ b/apps/web/src/components/docs/doc-active-heading.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useActiveDocHeading } from './doc-active-heading';
+import type { DocHeading } from './doc-heading-utils';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// story #f546601e — jsdom엔 IntersectionObserver가 없다. observe() 호출을 기록하고
+// 테스트가 콜백을 수동으로 트리거할 수 있도록 최소 스텁만 제공한다(실제 브라우저 교차
+// 판정 로직 자체는 재구현하지 않음 — 훅이 "관찰 대상을 올바르게 등록하고 콜백 결과를
+// activeId로 반영하는지"만 검증 대상).
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+  callback: IntersectionObserverCallback;
+  observed: Element[] = [];
+  disconnected = false;
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+  observe(el: Element) { this.observed.push(el); }
+  unobserve() {}
+  disconnect() { this.disconnected = true; }
+}
+
+const HEADINGS: DocHeading[] = [
+  { id: 'a', text: 'A', level: 1 },
+  { id: 'b', text: 'B', level: 1 },
+  { id: 'c', text: 'C', level: 1 },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  MockIntersectionObserver.instances = [];
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+function Harness({ headings }: { headings: DocHeading[] }) {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const activeId = useActiveDocHeading(contentRef, headings);
+  return (
+    <div>
+      <div ref={contentRef}>
+        {headings.map((h) => <h2 id={h.id} key={h.id}>{h.text}</h2>)}
+      </div>
+      <span data-testid="active">{activeId ?? 'none'}</span>
+    </div>
+  );
+}
+
+async function mount(headings: DocHeading[]) {
+  await act(async () => { root.render(<Harness headings={headings} />); });
+}
+
+function activeText() {
+  return container.querySelector('[data-testid="active"]')?.textContent;
+}
+
+describe('useActiveDocHeading (story #f546601e — 우측 미니 TOC 현위치 하이라이트)', () => {
+  it('마운트 시 컨테이너 안의 모든 헤딩 요소를 observe한다', async () => {
+    await mount(HEADINGS);
+    const observer = MockIntersectionObserver.instances[0]!;
+    expect(observer.observed.map((el) => el.id).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('교차한 헤딩 중 뷰포트 상단에 가장 가까운 것을 활성으로 반영한다', async () => {
+    await mount(HEADINGS);
+    const observer = MockIntersectionObserver.instances[0]!;
+    const elA = container.querySelector('#a')!;
+    const elB = container.querySelector('#b')!;
+
+    await act(async () => {
+      observer.callback(
+        [
+          { isIntersecting: true, boundingClientRect: { top: 120 } as DOMRect, target: elA } as IntersectionObserverEntry,
+          { isIntersecting: true, boundingClientRect: { top: 20 } as DOMRect, target: elB } as IntersectionObserverEntry,
+        ],
+        observer as unknown as IntersectionObserver,
+      );
+    });
+
+    expect(activeText()).toBe('b');
+  });
+
+  it('교차 중인 헤딩이 없으면(빈 entries) 이전 activeId를 유지한다(깜빡임 방지)', async () => {
+    await mount(HEADINGS);
+    const observer = MockIntersectionObserver.instances[0]!;
+    const elA = container.querySelector('#a')!;
+
+    await act(async () => {
+      observer.callback(
+        [{ isIntersecting: true, boundingClientRect: { top: 10 } as DOMRect, target: elA } as IntersectionObserverEntry],
+        observer as unknown as IntersectionObserver,
+      );
+    });
+    expect(activeText()).toBe('a');
+
+    await act(async () => {
+      observer.callback([], observer as unknown as IntersectionObserver);
+    });
+    expect(activeText()).toBe('a');
+  });
+
+  it('헤딩이 없으면 observe하지 않고 activeId는 null이다', async () => {
+    await mount([]);
+    expect(MockIntersectionObserver.instances).toHaveLength(0);
+    expect(activeText()).toBe('none');
+  });
+
+  it('언마운트 시 observer를 disconnect한다(메모리 누수 방지)', async () => {
+    const localContainer = document.createElement('div');
+    document.body.appendChild(localContainer);
+    const localRoot = createRoot(localContainer);
+    await act(async () => { localRoot.render(<Harness headings={HEADINGS} />); });
+
+    const observer = MockIntersectionObserver.instances[0]!;
+    await act(async () => { localRoot.unmount(); });
+    localContainer.remove();
+
+    expect(observer.disconnected).toBe(true);
+  });
+});

--- a/apps/web/src/components/docs/doc-active-heading.ts
+++ b/apps/web/src/components/docs/doc-active-heading.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState, type RefObject } from 'react';
+import type { DocHeading } from './doc-heading-utils';
+
+// story #f546601e(v2 5호) — 우측 미니 TOC 현위치 하이라이트(proof-blue) 스크롤 동기.
+// rootMargin으로 상단 기준선을 뷰포트 30% 지점까지 내리는 이유 — 순수 교차 여부만
+// 쓰면(threshold만) 스크롤을 내리다가 다음 섹션이 화면 맨 아래에 "보이기 시작"하는
+// 순간까지 이전 섹션이 계속 활성으로 남는 지연이 생긴다. 기준선을 위로 당겨야 헤딩이
+// 뷰포트 상단 부근에 들어오는 순간 바로 전환된다("현재 읽고 있는 절"에 맞음).
+const ACTIVE_ROOT_MARGIN = '0px 0px -70% 0px';
+
+export function useActiveDocHeading(
+  containerRef: RefObject<HTMLElement | null>,
+  headings: DocHeading[],
+  rootRef?: RefObject<HTMLElement | null>,
+): string | null {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const idsKey = headings.map((heading) => heading.id).join('|');
+
+  useEffect(() => {
+    const ids = idsKey ? idsKey.split('|') : [];
+    if (!containerRef.current || ids.length === 0) {
+      // 여기서 setActiveId(null)을 동기 호출하지 않는다(react-hooks/set-state-in-effect —
+      // effect 본문에서의 동기 setState는 캐스케이딩 리렌더 유발). 대신 아래 return
+      // 시점에서 idsKey 유무로 파생시킨다 — 헤딩이 없어졌을 때의 결과는 동일하다.
+      return;
+    }
+
+    // flow-node-story-panel.tsx/flow-map-canvas.tsx 관례 — CSS.escape 기반 셀렉터 문자열
+    // 조립 대신 속성값을 직접 비교한다(CSS.escape 전역이 없는 실행환경(jsdom 테스트 등)에도
+    // 안 깨진다·헤딩 id는 slugifyHeading 산출이라 CSS 특수문자가 애초에 안 섞임).
+    const idSet = new Set(ids);
+    const elements = Array.from(containerRef.current.querySelectorAll<HTMLElement>('[id]'))
+      .filter((el) => idSet.has(el.id));
+    if (!elements.length) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((entry) => entry.isIntersecting);
+        if (visible.length === 0) return;
+        const topmost = visible.reduce((a, b) => (a.boundingClientRect.top < b.boundingClientRect.top ? a : b));
+        setActiveId(topmost.target.id);
+      },
+      { root: rootRef?.current ?? null, rootMargin: ACTIVE_ROOT_MARGIN, threshold: 0 },
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [containerRef, rootRef, idsKey]);
+
+  return idsKey ? activeId : null;
+}

--- a/apps/web/src/components/docs/doc-mini-toc.test.tsx
+++ b/apps/web/src/components/docs/doc-mini-toc.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { DocMiniToc, MINI_TOC_MIN_HEADINGS } from './doc-mini-toc';
+import type { DocHeading } from './doc-heading-utils';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const messages = { docs: { tocOnThisDoc: '이 문서' } };
+
+function wrap(node: React.ReactNode) {
+  return <NextIntlClientProvider locale="ko" messages={messages} timeZone="Asia/Seoul">{node}</NextIntlClientProvider>;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+function headings(n: number): DocHeading[] {
+  return Array.from({ length: n }, (_, i) => ({ id: `h-${i}`, text: `헤딩 ${i}`, level: (i % 3 === 0 ? 1 : 2) as 1 | 2 }));
+}
+
+describe('DocMiniToc (story #f546601e — 긴 문서 우측 미니 TOC 자동 표면)', () => {
+  it(`헤딩이 ${MINI_TOC_MIN_HEADINGS}개 미만이면 렌더하지 않는다(짧은 문서 무변경 — AC2)`, async () => {
+    await act(async () => {
+      root.render(wrap(<DocMiniToc headings={headings(MINI_TOC_MIN_HEADINGS - 1)} activeId={null} onHeadingClick={vi.fn()} />));
+    });
+    expect(container.querySelector('nav')).toBeNull();
+  });
+
+  it(`헤딩이 ${MINI_TOC_MIN_HEADINGS}개 이상이면 전체를 렌더한다(AC1)`, async () => {
+    const items = headings(19); // 유나 시안 실측 기준 문서
+    await act(async () => {
+      root.render(wrap(<DocMiniToc headings={items} activeId={null} onHeadingClick={vi.fn()} />));
+    });
+    const buttons = [...container.querySelectorAll('nav button')];
+    expect(buttons).toHaveLength(19);
+    expect(buttons[0]?.textContent).toBe('헤딩 0');
+  });
+
+  it('activeId와 일치하는 헤딩만 proof-blue로 하이라이트된다(현위치 하이라이트)', async () => {
+    const items = headings(6);
+    await act(async () => {
+      root.render(wrap(<DocMiniToc headings={items} activeId="h-2" onHeadingClick={vi.fn()} />));
+    });
+    const buttons = [...container.querySelectorAll('nav button')];
+    const active = buttons.find((b) => b.getAttribute('aria-current') === 'location');
+    expect(active?.textContent).toBe('헤딩 2');
+    expect(active?.className).toContain('text-proof-blue');
+    expect(buttons.filter((b) => b.getAttribute('aria-current') === 'location')).toHaveLength(1);
+  });
+
+  it('헤딩 클릭 시 onHeadingClick이 그 헤딩의 id로 호출된다', async () => {
+    const onClick = vi.fn();
+    const items = headings(6);
+    await act(async () => {
+      root.render(wrap(<DocMiniToc headings={items} activeId={null} onHeadingClick={onClick} />));
+    });
+    const buttons = [...container.querySelectorAll('nav button')];
+    await act(async () => { buttons[3]!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onClick).toHaveBeenCalledWith('h-3');
+  });
+});

--- a/apps/web/src/components/docs/doc-mini-toc.tsx
+++ b/apps/web/src/components/docs/doc-mini-toc.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import type { DocHeading } from './doc-heading-utils';
+import { cn } from '@/lib/utils';
+
+// story #f546601e(v2 5호) — 긴 문서만 우측 미니 TOC를 자동 노출한다(유나 시안 확定,
+// 실측 19헤딩 문서 기준). 기존 드롭다운 DocToc의 임계값(3, 클릭해야 보이는 팝오버라
+// 얕은 문서에서도 빠른 점프에 유용)보다 높게 잡았다 — 이건 상시 공간을 차지하는
+// 우측 레일이라, 짧은 문서까지 노출되면 오히려 소음(카드홍수류 회귀)이 된다. 6은
+// "본문이 여러 뚜렷한 절로 나뉘어 있어야 스캔 가치가 생기는" 실용적 경계 — 3~5개는
+// 목차 없이도 스크롤 한 번으로 전체 구조가 눈에 들어온다.
+export const MINI_TOC_MIN_HEADINGS = 6;
+
+interface DocMiniTocProps {
+  headings: DocHeading[];
+  activeId: string | null;
+  onHeadingClick: (id: string) => void;
+  className?: string;
+}
+
+export function DocMiniToc({ headings, activeId, onHeadingClick, className }: DocMiniTocProps) {
+  const t = useTranslations('docs');
+
+  if (headings.length < MINI_TOC_MIN_HEADINGS) return null;
+
+  return (
+    <nav
+      aria-label={t('tocOnThisDoc')}
+      className={cn('sticky top-6 max-h-[calc(100vh-8rem)] overflow-y-auto', className)}
+    >
+      <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+        {t('tocOnThisDoc')}
+      </div>
+      <ul className="flex flex-col gap-1.5 text-[12px] leading-tight">
+        {headings.map((heading) => {
+          const active = heading.id === activeId;
+          return (
+            <li key={heading.id}>
+              <button
+                type="button"
+                onClick={() => onHeadingClick(heading.id)}
+                aria-current={active ? 'location' : undefined}
+                className={cn(
+                  'block w-full truncate border-l-2 py-0.5 text-left transition-colors',
+                  heading.level === 1 ? 'pl-2.5 font-medium' : heading.level === 2 ? 'pl-4' : 'pl-6 text-[11px]',
+                  active
+                    ? 'border-proof-blue font-semibold text-proof-blue'
+                    : 'border-transparent text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {heading.text}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
## 요약
유나 시안(아티팩트 `2fbd871f`, story `f546601e`) 확定분 구현. 로드맵 v2 문서 축 — 「정직 판정: 문서는 5표면 중 가장 정제됨」이라 실 gap 1개(긴 문서 구조 스캔)만 경량 보강(과설계 금지 모범 — 시안 자체가 "문제 없는 걸 크게 만들지 않는다"를 명시).

## gap
실측 19헤딩 문서에서 기존 목차(`DocToc`, `[slug]/view/page.tsx` 브레드크럼)는 클릭해야 펼쳐지는 드롭다운이라 "이 문서에 뭐가 있나"를 스크롤 없이 한눈에 볼 수 없었다.

## 구현(기존 요소 무변경 — 신규 표면만 추가)
1. `DocMiniToc`(신규) — 우측 상시 레일(sticky), 헤딩 N개(`MINI_TOC_MIN_HEADINGS=6`) 이상인 문서에서만 자동 노출. 임계값 6은 임의가 아니라 근거 명기(주석) — 기존 드롭다운 `DocToc`의 임계값(3, 클릭 후 팝오버라 얕은 문서에도 유용)보다 높게 잡은 이유는 상시 공간을 차지하는 레일이라 짧은 문서까지 노출되면 소음이 되기 때문.
2. `useActiveDocHeading`(신규) — IntersectionObserver 기반 스크롤 동기 현위치 판정. rootMargin으로 상단 기준선을 뷰포트 30% 지점까지 당겨 "다음 섹션이 화면에 보이기 시작하는 순간까지 이전 섹션이 활성으로 남는" 지연을 없앤다. CSS.escape 기반 셀렉터 대신 속성값 직접 비교(flow-node-story-panel.tsx/flow-map-canvas.tsx 관례 재사용 — CSS.escape 전역이 없는 실행환경에도 안 깨짐).
3. 현재 위치=proof-blue 하이라이트(L5 의미 신호, 시안 확定). 다크는 CSS 변수 토큰 스왑으로 자동 대응(추가 분기 없음).
4. `[slug]/view/page.tsx` 배선 — 기존 breadcrumb `DocToc` 드롭다운·`DocEvidenceRail` 등 다른 요소는 완전히 그대로(AC2), aside 상단에 `DocMiniToc`만 추가.

## 변경 파일 — 정확히 7개(3 수정 + 4 신규, `git diff --stat` 실측)
- `components/docs/doc-mini-toc.tsx`(신규) + `.test.tsx`(신규, **4건**)
- `components/docs/doc-active-heading.ts`(신규) + `.test.tsx`(신규, **5건**)
- `[slug]/view/page.tsx`(배선) — 기존 회귀가드 테스트(`page.test.tsx`) 6/6 무변경 통과
- `messages/ko.json`/`en.json` — `docs.tocOnThisDoc` 1키

## 검증
- [x] 신규 테스트 **9건**(4+5) all green — 임계값 경계(5개 미만 숨김/6개 이상 노출)·클릭 내비·IntersectionObserver 기반 현위치 반영·빈 entries 시 깜빡임 없음·언마운트 disconnect까지 확인
- [x] 새 소스 파일을 임시 제거하고 재실행 → import 해석 실패로 즉시 fail 확인 후 복원(진짜 회귀가드 증명 — 이번 story는 신규 파일이라 git stash 대신 파일명 임시치환)
- [x] 기존 `[slug]/view/page.test.tsx` 6/6 무변경 통과(breadcrumb·마스트헤드·상태헤더·증거레일·본문·404 전부 그대로)
- [x] `tsc --noEmit` clean / `eslint` clean(0 warning — set-state-in-effect·ref-in-render lint 위반 각 1건 발견 즉시 fix) / `pnpm build` EXIT=0
- [x] 전체 `vitest run` — **503 files / 4472 tests all green**

## 실렌더 재현(next build 컴파일 CSS + 실 마크업, 라이트·다크)
CASE A(19헤딩 실측 문서): 우측 미니 TOC 자동 노출, "배경" 헤딩 proof-blue 하이라이트. CASE B(3헤딩 짧은 문서): 미니 TOC 미노출·기존 드롭다운 목차(3 미만 자체 가드)·증거 레일 레이아웃 전부 무변경. 다크는 동일 마크업에 `.dark` 클래스만 토글 — 토큰 스왑 확認.

## AC 대조
1. 19헤딩 실측 문서에서 우측 TOC 자동 노출+현위치 하이라이트 — 실렌더 CASE A로 확認.
2. 임계값 미만 문서 무변경 — 실렌더 CASE B로 확認(회귀 테스트로도 고정).
3. 유나 design·카디르 QA — 이 PR 오픈으로 착수.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_017Y8uNHvGThWG8QPBz1nhFz