### PR TITLE
[SID:3031] realtime-dev 무변경 배포 skip 게이팅 — 매 머지 재배포로 라이브 SSE 절단

### DIFF
--- a/backend/tests/test_3031_realtime_cloudrun_deploy_path_filter.py
+++ b/backend/tests/test_3031_realtime_cloudrun_deploy_path_filter.py
@@ -1,0 +1,81 @@
+"""story #3031(2026-08-24) — deploy-realtime-gce(GCE, story #2089)엔 이미 realtime-relevant
+path-filter가 있었는데 **실제로 브라우저 SSE를 서빙하는** deploy-realtime(Cloud Run) 스텝엔
+그게 없어, 관련 없는 코드만 섞인 develop merge에서도 매번 무조건 재배포됐다 — 오늘(08-24)
+sprintable-realtime-dev 리비전 12개(PO 실측), 롤아웃마다 라이브 SSE 전 연결 절단.
+
+이 테스트는 그 비대칭이 해소됐음을 cloudbuild.yaml 내용으로 고정한다(test_2178_realtime_
+flag_parity.py와 동일 관례 — 실제 gcloud/git 호출은 CI 밖이라 실행 자체를 테스트할 수
+없고, "무조건 재배포하던 이전 상태로 되돌아가지 않는다"를 구조 검사로 pin한다)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CLOUDBUILD_YAML = _REPO_ROOT / "cloudbuild.yaml"
+
+
+def _deploy_realtime_step_script() -> str:
+    import yaml
+
+    doc = yaml.safe_load(_CLOUDBUILD_YAML.read_text())
+    step = next(s for s in doc["steps"] if s["id"] == "deploy-realtime")
+    assert step["entrypoint"] == "bash"
+    return step["args"][1]
+
+
+def test_deploy_realtime_reuses_shared_path_filter_script():
+    """GCE 선례와 같은 스크립트 재사용(SSOT — 판별 로직 이중선언 금지)."""
+    script = _deploy_realtime_step_script()
+    assert "backend/scripts/check_realtime_relevant_diff.sh" in script
+
+
+def test_deploy_realtime_skip_branch_exits_before_actual_deploy():
+    """스킵 결정이 실제 `gcloud run deploy`보다 앞서야 한다 — 순서가 뒤바뀌면 스킵이 무의미.
+
+    ⚠️두 함정을 각각 피한다:
+    ①"skip deploy-realtime:" 앵커는 이 스텝 맨 앞(prod-gate skip, story #2078 이전부터
+    존재)에도 나온다 — story #3031 전용 스킵 메시지를 별도로 찾아야 한다.
+    ②"exit 0"를 skip 메시지~배포커맨드 «전체 구간»에서 substring 검색하면 그 사이에
+    껴 있는 무관한 산문 주석(story #2442, "함수 진입 전에 exit 0)")에 우연히 매치돼
+    거짓양성이 난다(실제 겪음 — mutation으로 exit 0를 지워도 4/4 그대로 통과했었다).
+    «스킵 echo 바로 다음 줄»이 정확히 exit 0인지, 줄 단위 인접성으로 좁혀야 한다."""
+    script = _deploy_realtime_step_script()
+    lines = script.splitlines()
+    skip_line_idx = next(
+        i for i, l in enumerate(lines)
+        if "skip deploy-realtime:" in l and "story #3031 path-filter" in l
+    )
+    deploy_line_idx = next(
+        i for i, l in enumerate(lines)
+        if "gcloud run deploy sprintable-realtime-${_DEPLOY_ENV}" in l
+    )
+    assert skip_line_idx < deploy_line_idx, "path-filter 스킵 판단이 실제 배포 커맨드보다 뒤에 있음"
+
+    next_nonblank = next(l.strip() for l in lines[skip_line_idx + 1 :] if l.strip())
+    assert next_nonblank == "exit 0", (
+        f"스킵 echo 바로 다음 줄이 'exit 0'가 아님(실제: {next_nonblank!r}) — "
+        "로그만 찍고 실제로 안 빠져나가면 그 아래 배포가 그대로 실행됨"
+    )
+
+
+def test_deploy_realtime_reads_serving_revision_not_template_spec():
+    """describe의 spec.template은 다음 배포 대상이지 실제 트래픽이 아니다(배포 실효=서빙
+    리비전 digest 교훈) — 100% 트래픽 리비전을 명시로 골라야 한다."""
+    script = _deploy_realtime_step_script()
+    assert "status.traffic.filter(percent=100).revisionName" in script
+
+
+def test_deploy_realtime_fails_safe_when_serving_revision_unknown():
+    """최초 배포·트래픽 스플릿 중처럼 직전 SHA를 못 구하면 스킵하지 않고 배포로 진행해야
+    한다(GCE 선례·check_realtime_relevant_diff.sh 자체의 fail-safe와 동일 방향 — "필터가
+    실수로 좁아도 조용히 안 새게")."""
+    script = _deploy_realtime_step_script()
+    # ⚠️`$$`로 이스케이프돼 있다 — Cloud Build 자신의 substitution 파서가 bash 실행 前에
+    # 이 args 문자열을 먼저 훑어(test_deploy_backend_redis_secret_conflict.py 가드), 미선언
+    # `${serving_revision}` 참조를 build submit 자체 거부로 처리한다. 원문 그대로 대조한다.
+    assert 'if [ -z "$$serving_revision" ]; then' in script
+    # 그 분기 본문에 exit이 없어야(=스킵하지 않고 이어서 배포 진행) fail-safe가 성립.
+    branch_start = script.index('if [ -z "$$serving_revision" ]; then')
+    branch_end = script.index("else", branch_start)
+    branch_body = script[branch_start:branch_end]
+    assert "exit" not in branch_body, "serving_revision 판별 불가 분기에서 exit 하면 fail-safe(배포 진행)가 아니라 fail-closed가 됨"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -652,6 +652,50 @@ steps:
           echo "      --substitutions 에 _REALTIME_URL=<realtime 서비스 URL> 을 명시할 것."
           exit 1
         fi
+        # story #3031(2026-08-24) — realtime path-filter, Cloud Run 버전. deploy-realtime-gce
+        # (아래, story #2089)엔 이미 이 필터가 있는데 **실제로 브라우저 SSE를 서빙하는 건
+        # 이 Cloud Run 서비스**라 그 비대칭이 뿌리였다 — 매 develop 머지가 무조건 이 스텝을
+        # 재실행시켜, 관련 없는 코드가 섞인 커밋에서도 재배포·롤아웃마다 라이브 SSE 전 연결이
+        # 절단(재연결/백필 사이클 반복)됐다(오늘 08-24 리비전 12개, PO 실측). #3026/#3029로
+        # 고친 건 코드층 dedup 버그이고, 이건 별개의 인프라층 원인 — 둘 다 있어야 #2985 AC②
+        # 라이브 재검이 안정된다.
+        # GCE MIG는 인스턴스 템플릿 이름에서 직전 SHA를 grep으로 뽑아야 했지만(임의 이름이라),
+        # Cloud Run은 서빙 리비전의 이미지 태그 자체가 정확히 그 SHA다(아래 --image=...:
+        # ${COMMIT_SHA} 컨벤션 그대로) — grep 휴리스틱 불요, 태그를 그대로 쓴다.
+        # ⛔"서빙"(트래픽 100%) 리비전이어야 한다 — describe의 spec.template은 다음 배포
+        # 대상이지 실제 트래픽이 아니다(배포 실효=서빙 리비전 digest 교훈, 이 세션 #2985
+        # 조사에서 재확인). status.traffic[]에서 100%를 받는 리비전 이름을 먼저 뽑고, 그
+        # 리비전 자체를 describe해 이미지 태그를 읽는다.
+        # fail-safe는 GCE 선례와 동일: 판별 불가(첫 배포·트래픽 스플릿 중·describe 실패)면
+        # 스킵하지 않고 배포로 진행(check_realtime_relevant_diff.sh 자체의 fail-safe도 동일
+        # 방향 — "필터가 실수로 좁아도 조용히 안 새게").
+        # ⛔story #2421 교훈(deploy-backend 핫픽스, 위 test_deploy_backend_redis_secret_conflict.py
+        # 가드) — Cloud Build 자신의 substitution 파서가 bash 실행 前에 args 문자열 전체를
+        # 먼저 훑어, `${선언안된이름}`을 substitution 오류로 build submit 자체를 거부한다.
+        # 그래서 이 스텝 안에서 새로 짓는 로컬 셸 변수(serving_revision·last_image·last_sha)는
+        # 참조할 때마다 `$$`로 이스케이프해야 한다(Cloud Build가 `$$`→`$`로 한 번 접어 bash에
+        # 넘긴다) — GCE 선례(current_template·last_sha, 아래 deploy-realtime-gce)는 이
+        # 가드 대상 스텝 목록 밖이라 안 걸렸을 뿐, 실제로는 같은 함정 자리다.
+        serving_revision="$(gcloud run services describe sprintable-realtime-${_DEPLOY_ENV} \
+          --region="${_AR_REGION}" --project="${PROJECT_ID}" \
+          --format='value(status.traffic.filter(percent=100).revisionName)' 2>/dev/null || echo '')"
+        if [ -z "$$serving_revision" ]; then
+          echo "deploy-realtime: 100% 트래픽 서빙 리비전을 못 읽음(최초 배포이거나 트래픽 스플릿 중) — path-filter 건너뛰고 배포 진행"
+        else
+          last_image="$(gcloud run revisions describe "$$serving_revision" \
+            --region="${_AR_REGION}" --project="${PROJECT_ID}" \
+            --format='value(spec.containers[0].image)' 2>/dev/null || echo '')"
+          last_sha="$${last_image##*:}"
+          if [ -z "$$last_sha" ] || [ "$$last_sha" = "$$last_image" ]; then
+            echo "deploy-realtime: 서빙 리비전 이미지 태그를 못 읽음 — path-filter 건너뛰고 배포 진행"
+          else
+            git fetch --unshallow >/dev/null 2>&1 || true
+            if ! bash backend/scripts/check_realtime_relevant_diff.sh "$$last_sha" "${COMMIT_SHA}"; then
+              echo "skip deploy-realtime: $$last_sha..${COMMIT_SHA} 사이 realtime-관련 경로 변경 없음(story #3031 path-filter, 스킵 사유는 위 로그 참고)"
+              exit 0
+            fi
+          fi
+        fi
         # ⚠️story #2078 긴급수정(2026-07-21): PG_LISTEN_ENABLED가 여기 true로 하드코딩돼
         # 있었다 — PO가 라이브에서 손으로 false로 전환(LISTEN 제거·Redis 단독 dispatch 확認
         # 완료)했는데, 이 스텝이 명시적으로 true를 다시 밀어넣어 **다음 배포마다 LISTEN이


### PR DESCRIPTION
[SID:3031]

## 근본원인
`/api/event-stream` 업스트림=별도 Cloud Run 서비스 `sprintable-realtime-dev`(브라우저 SSE 실제 서빙처). `deploy-realtime-gce`(GCE MIG, story #2089)엔 이미 realtime-relevant path-filter가 있는데, 이 Cloud Run 서비스를 배포하는 `deploy-realtime` 스텝엔 그게 없어 **매 develop 머지마다 무조건 재배포** — 오늘(08-24) 리비전 12개(PO 실측), 롤아웃마다 라이브 SSE 전 연결 절단(재연결/백필 사이클 반복). #3026/#3029로 고친 코드층 dedup 버그와는 별개의 인프라층 원인이며, #2985 AC② 잔여 라이브 실패의 최종 배경.

## 처방
`check_realtime_relevant_diff.sh`(기존, #2089 선례와 SSOT 재사용, 로직 이중선언 없음)로 realtime-관련 경로 변경 여부를 판별해 무변경이면 스킵.
- GCE는 인스턴스 템플릿 이름에서 직전 SHA를 grep으로 뽑지만, Cloud Run은 서빙 리비전의 이미지 태그 자체가 정확히 그 SHA라(`--image=...:${COMMIT_SHA}` 컨벤션) 태그를 직접 쓴다 — grep 휴리스틱 불요.
- "서빙"(트래픽 100%) 리비전을 명시로 골라 읽는다 — `describe`의 `spec.template`은 다음 배포 대상이지 실제 트래픽이 아니라는 교훈(이 세션 #2985 조사에서 재확인)을 그대로 반영.
- 판별 불가(최초 배포·트래픽 스플릿 중·describe 실패)면 fail-safe로 배포 진행(스킵하지 않음) — GCE 선례·`check_realtime_relevant_diff.sh` 자체의 fail-safe와 동일 방향.

## 부수 발견
새 로컬 셸 변수(`serving_revision` 등)가 기존 가드(`test_deploy_backend_redis_secret_conflict.py`, story #2421)에 즉시 걸렸다 — Cloud Build 자신의 substitution 파서가 bash 실행 前에 args 문자열을 훑어 미선언 `${var}` 참조를 build submit 자체 거부로 처리하는 함정이 정확히 재현됨. `$$` 이스케이프로 해소. (참고: GCE 선례의 로컬 변수는 이 가드의 스텝 목록 밖이라 안 걸렸을 뿐 같은 함정 자리 — 코드 코멘트로 명시만, 이 PR 스코프 밖으로 남김.)

## 스코프 밖(스토리 관찰 항목으로 남김, 올리베이라군 확認)
- **16:03 롤아웃-외 킬 조사**: gcloud ADC reauth가 사람 전용이라(내 계정·PO 계정 둘 다 오늘 만료) 이번 PR에서 로그 실측 불가. PO 재인증 후 별도 진행.
- **SSE graceful drain**: Cloud Run 자체 특성 조사는 후속.
- **"SSE 라이브 검증은 배포 조용한 창에서" QA 규율 명기**: 이 PR의 실효(재배포 빈도 감소)가 확인된 후 문서화.

## 검증
신규 4종 전부 mutation 검증:
- 스킵 분기의 `exit 0` 제거 → 정확히 해당 테스트 FAIL(줄 단위 인접성 검사라 무관한 산문 주석의 "exit 0" 언급에 우연매치되던 1차 버전의 vacuous-pass 버그도 자체 발견·수정 — PR 본문에 그 경위도 남김).
- fail-safe 분기에 `exit` 주입 → 정확히 해당 테스트 FAIL.
- 각각 복원 후 재확認.

인접 cloudbuild/deploy 테스트 148/148 green(YAML 파싱 포함, `test_deploy_backend_redis_secret_conflict.py`의 substitution 이스케이프 가드 포함).

CI 초록 확인 부탁하는. 머지는 통상 관례대로 위임.