### PR TITLE
[SID:3025] BE 상태 자가회수 — done 스토리의 pending merge 게이트 영구 잔존 fix

### DIFF
--- a/backend/app/services/gate_self_reclamation.py
+++ b/backend/app/services/gate_self_reclamation.py
@@ -1,0 +1,96 @@
+"""story #f2b66f32(3025, BE·상태 자가회수) — 해소·머지 완료된 대상의 pending merge-type 게이트가
+영구 잔존하던 결함의 자가회수.
+
+그라운딩(2026-08-24, 실측 `/api/v2/gates?status=pending` 56건 GROUP BY, 페드루 PO 확認 후 착수):
+gate_type=merge(work_item_type=story) 33건 전건이 이미 target story.status=='done'인데 게이트만
+pending 잔존했다 — 31건은 라인엔진 self-report merge-gate(workflow_line_engine._merge_gate_wrapper,
+pr_number=0/repo="")라 애초에 웹훅 연결점이 구조적으로 없어 영구 미해소, 나머지 2건은 실 PR 연결인데
+(PR#3350 MERGED·PR#3307 CLOSED, gh 실측) reconcile_merge_gate_with_real_evidence 웹훅 경로가 놓친
+별도 회귀 — 둘 다 이 모듈로 동일하게 회수된다(원인 분리는 회귀 재발방지 별도 트랙).
+
+doc_approval(8건)은 target doc.status가 여전히 pending이라(실측) 자가회수 대상이 아니다 — 이
+모듈은 gate_type=merge만 다룬다. agent_decision_request(15건)는 work_item_id가 gate.id 자체라
+"대상 상태" 개념이 구조적으로 없어 이 스토리 스코프 밖(별도 story #3032로 분리, PO 판정
+2026-08-24) — 이 모듈이 절대 건드리지 않는다.
+
+⚠️AC3(사람 승인 위조 금지): 이 모듈은 gate.status를 **절대 approved로 만들지 않는다** — 기존
+`Gate._VALID_TRANSITIONS`에 이미 있는 pending→voided(S30 admin recovery용 전이, 신규 상태 발명
+0)를 재사용한다. resolver_id는 항상 None(사람이 안 눌렀다는 사실 그대로 — void_gate()·
+gates.py POST /{id}/void의 admin 수동 void와 달리, 이건 사람 caller가 없는 시스템 트리거라
+그 함수를 그대로 재사용하지 않는다: void_gate()는 voider_id를 강제하고 ActivityLog
+actor_type="human"을 하드코딩해 재사용하면 거짓 귀속이 된다).
+
+재오픈 안전성(PO 요청 그라운딩, 2026-08-24 확認 완료 — 추가 코드 불요): merge_verdict_gate.
+evaluate_merge_gate()가 이미 `gate.status in ("rejected", "voided")` 케이스를 "재제출 시 새 결재
+사이클로 재오픈"(pending 복귀 + decision_history 보존)으로 처리한다. 즉 story가 재오픈되어
+in-review→done을 다시 타면 이 모듈이 voided로 만든 게이트는 새 row 없이 같은 row가 그 기존
+경로에서 자동으로 pending 재오픈된다.
+"""
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate, is_valid_transition, set_gate_status
+
+logger = logging.getLogger(__name__)
+
+RECLAIM_RESOLUTION_NOTE = (
+    "system_auto_reclaim: target story already done, merge gate never resolved (story #f2b66f32)"
+)
+
+
+async def reclaim_stale_merge_gates_for_story(
+    session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID,
+) -> list[Gate]:
+    """story가 방금 done으로 전이된 직후 호출 — 그 story에 걸린 pending merge-type 게이트를
+    전부 voided로 회수한다(승인 위조 아님, AC3). 호출자(emit_story_status_changed)가 이미 개별
+    try/except로 이 호출 전체를 감싸므로(fail-open 계약), 여기선 방어적 개별 게이트 단위
+    try/except를 두지 않는다 — 한 게이트 처리 중 예외가 나면 그 story의 남은 게이트도 이번
+    호출에서는 회수되지 않지만(다음 done 재전이 또는 별도 백필에서 재시도 가능), 예외가 story
+    상태 전이 자체를 막지는 않는다."""
+    gates = (await session.execute(
+        select(Gate).where(
+            Gate.org_id == org_id,
+            Gate.work_item_id == story_id,
+            Gate.work_item_type == "story",
+            Gate.gate_type == "merge",
+            Gate.status == "pending",
+        )
+    )).scalars().all()
+
+    reclaimed: list[Gate] = []
+    now = datetime.now(timezone.utc)
+    for gate in gates:
+        if not is_valid_transition(gate.status, "voided"):
+            continue  # 방어적 — 위 쿼리가 이미 status=='pending'만 걸러 정상 경로에선 항상 참.
+
+        set_gate_status(gate, "voided", now=now)
+        gate.resolver_id = None  # 사람이 안 눌렀다는 사실 그대로 — 위조 금지(AC3).
+        gate.resolution_note = RECLAIM_RESOLUTION_NOTE
+        gate.resolved_at = now
+
+        from app.services.workflow_line_resolution import find_active_step_run_for_gate
+        from app.models.workflow_line import WorkflowLineStepRun
+
+        sr_id = await find_active_step_run_for_gate(session, org_id, gate.id)
+        if sr_id is not None:
+            sr = (await session.execute(
+                select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr_id)
+            )).scalar_one_or_none()
+            if sr is not None:
+                sr.status = "skipped"
+                sr.routing_reason = f"gate auto-voided: {RECLAIM_RESOLUTION_NOTE}"[:500]
+                sr.resolved_at = now
+
+        logger.info(
+            "gate_auto_reclaimed org=%s gate=%s story=%s step_run=%s",
+            org_id, gate.id, story_id, sr_id,
+        )
+        reclaimed.append(gate)
+
+    if reclaimed:
+        await session.flush()
+    return reclaimed

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -336,6 +336,20 @@ async def emit_story_status_changed(
             story.id, org_id, exc_info=True,
         )
 
+    # story #f2b66f32(3025, BE·상태 자가회수) — done 전이 시 이 story에 걸린 pending merge-type
+    # 게이트를 voided로 자가회수(승인 위조 아님, AC3 — gate_self_reclamation.py 모듈 docstring
+    # 참조). best-effort 격리(다른 side-effect들과 동일 — 실패해도 status 전이 무영향).
+    if story.status == "done":
+        try:
+            from app.services.gate_self_reclamation import reclaim_stale_merge_gates_for_story
+
+            await reclaim_stale_merge_gates_for_story(db, org_id, story.id)
+        except Exception:
+            logger.warning(
+                "merge gate 자가회수 실패(story=%s org=%s)",
+                story.id, org_id, exc_info=True,
+            )
+
 
 async def advance_story_to_done(
     db: AsyncSession,

--- a/backend/scripts/jobs/backfill_void_stale_done_merge_gates.py
+++ b/backend/scripts/jobs/backfill_void_stale_done_merge_gates.py
@@ -1,0 +1,93 @@
+"""story #f2b66f32(3025, BE·상태 자가회수) — 기존 잔존분 1회 백필(idempotent).
+
+그라운딩(2026-08-24, 실측 `/api/v2/gates?status=pending` 56건 GROUP BY): gate_type=merge
+(work_item_type=story) 33건 전건이 target story.status=='done'인데 게이트만 pending으로 영구
+잔존했다. 이 job은 그 잔존분을 `gate_self_reclamation.reclaim_stale_merge_gates_for_story()`
+(story #f2b66f32 신규, 정확히 같은 로직 — story.status→done 전이 시 forward hook과 동일 함수
+재사용, 중복 구현 0)로 회수한다.
+
+⚠️`backfill_void_empty_merge_gates.py`(E-DG-REAL P0, 선례)와 다른 기준 — 그 job은 "실 PR
+컨텍스트 없는 shell"(decision_basis 텍스트 매칭)만 대상으로 하고 실 PR 연결 게이트는 명시적으로
+skip한다. 이 job은 "target story가 이미 done인가"만 본다 — 그래서 self-report shell(31건)뿐
+아니라 실 PR이 있는데도 reconcile 웹훅이 놓친 2건(PR#3350 MERGED·PR#3307 CLOSED, gh 실측)까지
+동일하게 잡는다. 두 job은 서로 다른 기준이라 중복 대상이 있어도 안전(재실행 멱등 — 이미
+voided면 status가 pending이 아니라 재대상 아님).
+
+env: DATABASE_URL이 있으면 그것을 쓴다. 없으면 ALEMBIC_URL로 폴백(scripts/jobs/_db_env.py).
+실행:
+  cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_void_stale_done_merge_gates            # dry-run
+  cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_void_stale_done_merge_gates --apply     # 실제 void
+옵션: --org <uuid> 로 특정 org만.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import uuid
+
+from sqlalchemy import select
+
+from scripts.jobs._db_env import resolve_database_url
+
+_db_url_summary = resolve_database_url()
+
+from app.core.database import async_session_factory  # noqa: E402 — 위 폴백이 먼저 돌아야 한다
+from app.models.gate import Gate  # noqa: E402
+from app.models.pm import Story  # noqa: E402
+
+MERGE_GATE_TYPE = "merge"
+
+
+async def main() -> int:
+    if _db_url_summary is None:
+        print("DATABASE_URL·ALEMBIC_URL 둘 다 미설정", file=sys.stderr)
+        return 2
+    print(f"[db] {_db_url_summary}", file=sys.stderr)
+
+    parser = argparse.ArgumentParser(
+        description="target story가 이미 done인데 pending으로 잔존한 merge gate를 voided로 회수(idempotent)"
+    )
+    parser.add_argument("--apply", action="store_true", help="실제 회수 커밋 (미지정 시 dry-run)")
+    parser.add_argument("--org", type=str, default=None, help="특정 org_id만 (기본 전체)")
+    args = parser.parse_args()
+
+    q = (
+        select(Gate.org_id, Gate.work_item_id)
+        .join(Story, Story.id == Gate.work_item_id)
+        .where(
+            Gate.gate_type == MERGE_GATE_TYPE,
+            Gate.work_item_type == "story",
+            Gate.status == "pending",
+            Story.status == "done",
+        )
+        .distinct()
+    )
+    if args.org:
+        q = q.where(Gate.org_id == uuid.UUID(args.org))
+
+    async with async_session_factory() as db:
+        pairs = (await db.execute(q)).all()
+        print(f"target stories(이미 done인데 pending merge gate 있음): {len(pairs)}")
+
+        if not args.apply:
+            for org_id, story_id in pairs[:20]:
+                print(f"  [dry-run] org={org_id} story={story_id}")
+            if len(pairs) > 20:
+                print(f"  … +{len(pairs) - 20} more")
+            print("dry-run — no changes. 실제 적용은 --apply.")
+            return 0
+
+        from app.services.gate_self_reclamation import reclaim_stale_merge_gates_for_story
+
+        total_reclaimed = 0
+        for org_id, story_id in pairs:
+            reclaimed = await reclaim_stale_merge_gates_for_story(db, org_id, story_id)
+            total_reclaimed += len(reclaimed)
+        await db.commit()
+        print(f"voided {total_reclaimed} stale merge gates across {len(pairs)} stories.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/tests/test_3025_gate_self_reclamation_realdb.py
+++ b/backend/tests/test_3025_gate_self_reclamation_realdb.py
@@ -1,0 +1,203 @@
+"""story #f2b66f32(3025, BE·상태 자가회수) — merge-type pending 게이트 자가회수.
+
+핵심: ①target story.status=='done'인데 pending인 merge gate만 voided로 회수 ②resolver_id는
+항상 None(사람 승인 위조 금지, AC3) ③묶인 step_run이 있으면 skipped로 해소(void_gate와 동형 —
+entity unblock) ④doc_approval·다른 story의 게이트·이미 non-pending인 게이트는 절대 안 건드림
+(음성대조, 페드루 PO 요청 2026-08-24) ⑤emit_story_status_changed 배선 — done 전이에서만 호출,
+실패해도 격리(status 전이 비차단).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3 관례 — create_all(+drop_all)로 자체 스키마를 직접 다뤄 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용.
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    import app.models.activity_log  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_gate(s, org, work_item_id, *, gate_type="merge", work_item_type="story",
+                      status="pending", with_step_run=True):
+    from app.models.gate import Gate
+    from app.models.workflow_line import WorkflowLineStepRun
+    proj = uuid.uuid4()
+    gate = Gate(id=uuid.uuid4(), org_id=org, work_item_id=work_item_id,
+                work_item_type=work_item_type, gate_type=gate_type, status=status)
+    s.add(gate)
+    await s.flush()
+    sr = None
+    if with_step_run:
+        sr = WorkflowLineStepRun(
+            org_id=org, project_id=proj, entity_type="story", entity_id=work_item_id,
+            from_status="in-review", to_status="done", status="gate_pending", mode="gate_pending",
+            gate_id=gate.id, h1_gate_id=gate.id, correlation_id=uuid.uuid4(),
+            transition_id=uuid.uuid4().hex)
+        s.add(sr)
+        await s.flush()
+    return gate, sr
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_reclaims_pending_merge_gate_and_resolves_step_run():
+    """핵심 케이스: pending merge gate → voided, resolver_id=None, step_run=skipped."""
+    from app.services.gate_self_reclamation import reclaim_stale_merge_gates_for_story
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        story_id = uuid.uuid4()
+        gate, sr = await _seed_gate(s, org, story_id)
+        await s.commit()
+
+        reclaimed = await reclaim_stale_merge_gates_for_story(s, org, story_id)
+        await s.commit()
+
+        assert len(reclaimed) == 1
+        assert reclaimed[0].status == "voided"
+        assert reclaimed[0].resolver_id is None  # AC3: 사람 승인 위조 금지 — 아무도 안 눌렀다.
+        assert "system_auto_reclaim" in (reclaimed[0].resolution_note or "")
+        assert reclaimed[0].resolved_at is not None
+
+        sr2 = (await s.execute(
+            select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id)
+        )).scalar_one()
+        assert sr2.status == "skipped"
+        assert "gate auto-voided" in (sr2.routing_reason or "")
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_negative_control_doc_approval_untouched():
+    """음성대조(페드루 PO 요청) — doc_approval 게이트는 gate_type이 merge가 아니므로 절대 안 건드림."""
+    from app.services.gate_self_reclamation import reclaim_stale_merge_gates_for_story
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        doc_id = uuid.uuid4()
+        gate, _ = await _seed_gate(
+            s, org, doc_id, gate_type="doc_approval", work_item_type="doc", with_step_run=False,
+        )
+        await s.commit()
+
+        reclaimed = await reclaim_stale_merge_gates_for_story(s, org, doc_id)
+        await s.commit()
+
+        assert reclaimed == []
+        await s.refresh(gate)
+        assert gate.status == "pending"  # 완전 무변경.
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_negative_control_other_story_untouched():
+    """음성대조 — 다른 story_id의 게이트는 안 건드림(work_item_id 정확 매치만)."""
+    from app.services.gate_self_reclamation import reclaim_stale_merge_gates_for_story
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        target_story = uuid.uuid4()
+        other_story = uuid.uuid4()
+        gate_other, _ = await _seed_gate(s, org, other_story, with_step_run=False)
+        await s.commit()
+
+        reclaimed = await reclaim_stale_merge_gates_for_story(s, org, target_story)
+        await s.commit()
+
+        assert reclaimed == []
+        await s.refresh(gate_other)
+        assert gate_other.status == "pending"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_negative_control_non_pending_untouched():
+    """음성대조 — 이미 approved/rejected/voided/held인 게이트는 idempotent 재실행에도 건드리지 않음."""
+    from app.services.gate_self_reclamation import reclaim_stale_merge_gates_for_story
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        story_id = uuid.uuid4()
+        approved, _ = await _seed_gate(s, org, story_id, status="approved", with_step_run=False)
+        await s.commit()
+
+        reclaimed = await reclaim_stale_merge_gates_for_story(s, org, story_id)
+        await s.commit()
+
+        assert reclaimed == []
+        await s.refresh(approved)
+        assert approved.status == "approved"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_idempotent_rerun_no_double_processing():
+    """재실행 멱등 — 이미 voided인 게이트를 다시 돌려도 재처리 0건(백필 재실행 안전)."""
+    from app.services.gate_self_reclamation import reclaim_stale_merge_gates_for_story
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        story_id = uuid.uuid4()
+        gate, _ = await _seed_gate(s, org, story_id, with_step_run=False)
+        await s.commit()
+
+        first = await reclaim_stale_merge_gates_for_story(s, org, story_id)
+        await s.commit()
+        second = await reclaim_stale_merge_gates_for_story(s, org, story_id)
+        await s.commit()
+
+        assert len(first) == 1
+        assert second == []
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_no_step_run_ok():
+    """step_run 없는 게이트(legacy/비-라인)도 정상 회수(void_gate와 동형 no-op recovery)."""
+    from app.services.gate_self_reclamation import reclaim_stale_merge_gates_for_story
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        story_id = uuid.uuid4()
+        gate, _ = await _seed_gate(s, org, story_id, with_step_run=False)
+        await s.commit()
+
+        reclaimed = await reclaim_stale_merge_gates_for_story(s, org, story_id)
+        await s.commit()
+
+        assert len(reclaimed) == 1
+        assert reclaimed[0].status == "voided"
+    await engine.dispose()

--- a/backend/tests/test_emit_story_status_changed_isolation.py
+++ b/backend/tests/test_emit_story_status_changed_isolation.py
@@ -111,6 +111,61 @@ async def test_trust_pipeline_raise_does_not_propagate():
         )  # 예외 없이 반환.
 
 
+# ── story #f2b66f32(3025, BE·상태 자가회수) — merge gate 자가회수도 다른 5종과 동일하게
+#    격리돼야 한다(실패해도 done 전이 자체는 무영향). _story()는 status="done" 고정이라 이
+#    side-effect가 실제로 시도되는 경로를 그대로 탄다. ───────────────────────────────────
+@pytest.mark.anyio
+async def test_gate_self_reclamation_raise_does_not_propagate():
+    with ExitStack() as stack:
+        _base_patches(stack)
+        stack.enter_context(patch(
+            "app.services.gate_self_reclamation.reclaim_stale_merge_gates_for_story",
+            AsyncMock(side_effect=RuntimeError("reclaim down")),
+        ))
+        await emit_story_status_changed(
+            AsyncMock(), uuid.uuid4(), _story(), "in-review",
+            actor_id=uuid.uuid4(), actor_type="human",
+        )  # 예외 없이 반환.
+
+
+@pytest.mark.anyio
+async def test_gate_self_reclamation_called_only_when_status_is_done():
+    """음성대조(페드루 PO 요청) — done이 아닌 전이(예: in-progress)에서는 아예 호출 안 됨."""
+    reclaim = AsyncMock()
+    story = SimpleNamespace(
+        id=uuid.uuid4(), epic_id=None, title="S", priority="low",
+        project_id=uuid.uuid4(), status="in-progress", assignee_id=uuid.uuid4(),
+    )
+    with ExitStack() as stack:
+        _base_patches(stack)
+        stack.enter_context(patch(
+            "app.services.gate_self_reclamation.reclaim_stale_merge_gates_for_story", reclaim,
+        ))
+        await emit_story_status_changed(
+            AsyncMock(), uuid.uuid4(), story, "backlog",
+            actor_id=uuid.uuid4(), actor_type="human",
+        )
+    reclaim.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_gate_self_reclamation_called_when_status_is_done():
+    """양성대조 — done 전이에서는 실제로 호출됨(자기 자신의 story_id로)."""
+    reclaim = AsyncMock()
+    story = _story()  # status="done"
+    with ExitStack() as stack:
+        _base_patches(stack)
+        stack.enter_context(patch(
+            "app.services.gate_self_reclamation.reclaim_stale_merge_gates_for_story", reclaim,
+        ))
+        await emit_story_status_changed(
+            AsyncMock(), uuid.uuid4(), story, "in-review",
+            actor_id=uuid.uuid4(), actor_type="human",
+        )
+    reclaim.assert_awaited_once()
+    assert reclaim.call_args.args[2] == story.id
+
+
 def test_single_item_callsite_intentionally_unwrapped_source_pin():
     """단건 콜사이트(update_story_status)가 emit_story_status_changed를 try/except 없이
     부르는 것이 실수로 안 감싸진 게 아니라 #2173 판정에 근거한 의도적 상태임을 소스에 고정


### PR DESCRIPTION
## 요약
유나 인박스 진단(2026-08-24) 뿌리 — [SID:3024](#3450)(인박스 그룹핑)는 증상 완화, 이게 뿌리 fix. 페드루 PO 그라운딩 승인(2026-08-24, 회수규칙 1~5 + 덧붙임 3건) 후 착수.

## 그라운딩 실측(추정 아닌 API 실조회 — `/api/v2/gates?status=pending`, 56건 GROUP BY)
- `gate_type=merge`(work_item=story) 33건 — **전건(33/33) target story.status=='done'**. 31건은 `pr_number` NULL(워크플로우 라인엔진 self-report merge-gate, `workflow_line_engine._merge_gate_wrapper` — `pr_number=0/repo=""`라 애초에 웹훅 연결점이 구조적으로 없음). 나머지 2건은 실 PR 연결인데(PR#3350 MERGED·PR#3307 CLOSED, `gh` 실측) `reconcile_merge_gate_with_real_evidence` 웹훅 경로가 놓친 별도 회귀 — 이 fix는 원인 불문 둘 다 동일하게 회수한다.
- `gate_type=doc_approval` 8건 — 전건 target `doc.status`가 여전히 `pending`(진짜 미결) — **손대지 않음**(자가회수 대상 아님, 스코프 확定).
- `gate_type=agent_decision_request` 15건 — `work_item_id==gate.id`(self-referencing anchor, 설계 #2709)라 "대상 상태" 개념 자체가 구조적으로 없음 — 별도 story #3032로 분리(페드루 PO 판정, "답변 존재 여부"가 판별자여야 함·age-based 아님 — merge/doc과 다른 설계 필요).

## fix — 신규 상태 발명 0, 승인 위조 0(AC3)
`gate_self_reclamation.reclaim_stale_merge_gates_for_story()`(신규) — story가 `done`으로 전이될 때(`emit_story_status_changed` 훅, 다른 5개 side-effect와 동일하게 fail-open 격리) 그 story에 걸린 pending merge-type 게이트를 기존 `Gate._VALID_TRANSITIONS`에 이미 있던 `pending→voided`(S30 admin recovery 전이) 로 회수한다. `resolver_id`는 항상 `None` — 사람이 안 눌렀다는 사실 그대로(`void_gate()`는 admin caller를 강제해 그대로 재사용하면 거짓 귀속이 됨, 별도 함수로 분리). 묶인 step_run은 `void_gate()`와 동형으로 `skipped` 해소(entity unblock).

## 재오픈 안전성 확認(페드루 PO 요청 그라운딩) — 추가 코드 불요, 확인만
`merge_verdict_gate.evaluate_merge_gate()`가 이미 `gate.status in ("rejected", "voided")`를 "재제출 시 새 결재 사이클로 재오픈"(pending 복귀 + decision_history 보존)으로 처리하고 있음을 소스로 확인(line ~491). story 재오픈→in-review→done을 다시 타면 이 fix가 voided로 만든 게이트는 새 row 없이 같은 row가 그 기존 경로에서 자동으로 pending 재오픈된다.

## 백필(기존 잔존 33건 1회)
`scripts/jobs/backfill_void_stale_done_merge_gates.py`(신규, `backfill_void_empty_merge_gates.py` 선례와 동일 관례 — argparse `--apply`/dry-run·`--org`, `_db_env.resolve_database_url()` 폴백). forward hook과 정확히 같은 함수(`reclaim_stale_merge_gates_for_story`) 재사용 — 중복 구현 0. 다른 기준(target 종결 vs. 선례의 evidence-shell 텍스트매칭)이라 두 job이 중복 대상 있어도 안전.

## 변경 파일 — 정확히 5개(2 수정 + 3 신규, `git diff --stat` 실측)
- `services/gate_self_reclamation.py`(신규)
- `services/story_status_events.py`(`emit_story_status_changed`에 배선, +14줄)
- `scripts/jobs/backfill_void_stale_done_merge_gates.py`(신규)
- `tests/test_3025_gate_self_reclamation_realdb.py`(신규, **6건**)
- `tests/test_emit_story_status_changed_isolation.py`(**+3건** — raise 격리·done에서만 호출 음성/양성대조)

## 검증
- [x] 신규 realdb 테스트 6건 all green — 핵심 회수(voided+resolver_id=None+step_run skipped)·음성대조 3종(doc_approval 무변경·다른 story 무변경·이미 non-pending 무변경)·재실행 멱등·step_run 없는 legacy 케이스
- [x] 소스 파일 임시 제거 후 재실행 → import 실패로 즉시 fail 확인 후 복원(신규 파일이라 git stash 대신 파일명 임시치환, 진짜 회귀가드 증명)
- [x] `emit_story_status_changed` 격리 테스트 신규 3건(raise 전파 안 함·done 아닌 전이엔 미호출 음성대조·done 전이엔 실호출 양성대조) all green, 기존 6건 무변경 통과
- [x] scripts/jobs lint 가드(test_2386/test_2384) 통과
- [x] `merge_verdict_gate.py` 전체 회귀 **49/49 green**(무변경 확인)
- [x] 백필 스크립트 실 시나리오 검증 — 로컬 scratch Postgres에 done story+pending merge gate·open story+pending merge gate·무관 doc_approval gate 시딩 → dry-run 정확히 1건 식별 → `--apply` 정확히 1건만 voided(다른 둘은 pending 그대로) → 재실행 0건(멱등) 실측 확인

## AC 대조
1. 실측 표(대상 상태별 pending 게이트 분포) — PO 확認 게이트 통과(페드루 승인, 이 PR 前).
2. 종결 대상 게이트 자동 무효화 + 기존 잔존분 1회 백필 — forward hook+backfill 둘 다 구현·검증.
3. 사람 승인 위조 금지 — approved 아닌 기존 voided 상태 재사용, `resolver_id` 항상 `None`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_017Y8uNHvGThWG8QPBz1nhFz