### PR TITLE
[SID:3031] P0 hotfix — deploy-realtime 스텝 UTF-8 바이트 한도 초과로 dev 배포 2연속 실패

### DIFF
--- a/backend/tests/test_3031_realtime_cloudrun_deploy_path_filter.py
+++ b/backend/tests/test_3031_realtime_cloudrun_deploy_path_filter.py
@@ -1,11 +1,35 @@
 """story #3031(2026-08-24) — deploy-realtime-gce(GCE, story #2089)엔 이미 realtime-relevant
 path-filter가 있었는데 **실제로 브라우저 SSE를 서빙하는** deploy-realtime(Cloud Run) 스텝엔
 그게 없어, 관련 없는 코드만 섞인 develop merge에서도 매번 무조건 재배포됐다 — 오늘(08-24)
-sprintable-realtime-dev 리비전 12개(PO 실측), 롤아웃마다 라이브 SSE 전 연결 절단.
+sprintable-realtime-dev 리비전 12개(PO 실측), 롤아웃마다 라이브 SSE 전 연결 절단(재연결/
+백필 사이클 반복). #3026/#3029로 고친 건 코드층 dedup 버그이고, 이건 별개의 인프라층
+원인 — 둘 다 있어야 #2985 AC② 라이브 재검이 안정된다.
 
 이 테스트는 그 비대칭이 해소됐음을 cloudbuild.yaml 내용으로 고정한다(test_2178_realtime_
 flag_parity.py와 동일 관례 — 실제 gcloud/git 호출은 CI 밖이라 실행 자체를 테스트할 수
-없고, "무조건 재배포하던 이전 상태로 되돌아가지 않는다"를 구조 검사로 pin한다)."""
+없고, "무조건 재배포하던 이전 상태로 되돌아가지 않는다"를 구조 검사로 pin한다).
+
+## 설계 상세(원래 cloudbuild.yaml 스텝 주석에 있었으나, deploy-realtime 스텝이 UTF-8
+바이트 한도(10,000, Cloud Build args 제약)를 넘겨 2연속 배포 실패를 낸 핫픽스로 여기
+이관됨 — 한글 주석 1자=UTF-8 3바이트라 문자수로는 안 걸리던 게 함정의 본체였다):
+
+- GCE MIG는 인스턴스 템플릿 이름에서 직전 SHA를 grep으로 뽑아야 했지만(임의 이름이라),
+  Cloud Run은 서빙 리비전의 이미지 태그 자체가 정확히 그 SHA다(`--image=...:${COMMIT_SHA}`
+  컨벤션 그대로) — grep 휴리스틱 불요, 태그를 그대로 쓴다.
+- "서빙"(트래픽 100%) 리비전이어야 한다 — `describe`의 `spec.template`은 다음 배포
+  대상이지 실제 트래픽이 아니다(배포 실효=서빙 리비전 digest 교훈, #2985 조사에서
+  재확인). `status.traffic[]`에서 100%를 받는 리비전 이름을 먼저 뽑고, 그 리비전 자체를
+  describe해 이미지 태그를 읽는다.
+- fail-safe는 GCE 선례와 동일: 판별 불가(첫 배포·트래픽 스플릿 중·describe 실패)면
+  스킵하지 않고 배포로 진행(`check_realtime_relevant_diff.sh` 자체의 fail-safe도 동일
+  방향 — "필터가 실수로 좁아도 조용히 안 새게").
+- story #2421 교훈(deploy-backend 핫픽스, `test_deploy_backend_redis_secret_conflict.py`
+  가드) — Cloud Build 자신의 substitution 파서가 bash 실행 前에 args 문자열 전체를 먼저
+  훑어, `${선언안된이름}`을 substitution 오류로 build submit 자체를 거부한다. 그래서 이
+  스텝 안에서 새로 짓는 로컬 셸 변수(`serving_revision`·`last_image`·`last_sha`)는
+  참조할 때마다 `$$`로 이스케이프해야 한다(Cloud Build가 `$$`→`$`로 한 번 접어 bash에
+  넘긴다) — GCE 선례(`current_template`·`last_sha`, `deploy-realtime-gce` 스텝)는 이
+  가드 대상 스텝 목록 밖이라 안 걸렸을 뿐, 실제로는 같은 함정 자리다."""
 from __future__ import annotations
 
 from pathlib import Path

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -189,15 +189,28 @@ def test_bash_entrypoint_steps_under_cloudbuild_arg_byte_limit():
     바이트 한도를 넘기는 이 클래스는 다시 재발할 수 있다 — 그래서 문자 수가 아니라
     **`.encode('utf-8')` 길이**로 정적 고정한다(에디터 표시 글자수를 믿지 않는다).
 
+    ⛔PO 리뷰 지적(2026-08-24, PR#3455 1라운드) — 최초 버전은 `_BASH_ENTRYPOINT_STEP_IDS`
+    (substitution-escape 가드용 4개 목록, 위)만 순회해 apply-gcs-avatars-cors·
+    update-migrate-job·deploy-mcp·deploy-realtime-gce 4개 스텝이 가드 밖이었다 — 이
+    함정은 "한글 주석이 자라는 어느 bash 스텝에서든" 재발하는 클래스라 목록 상수(용도가
+    다른 가드와 공유하는 고정 집합)로는 원천적으로 사각을 만든다. 그래서 이 가드만큼은
+    `entrypoint == "bash"`인 스텝 **전부**를 cloudbuild.yaml에서 동적으로 순회한다(신규
+    bash 스텝이 나중에 추가돼도 목록 갱신 없이 자동 커버 — `_BASH_ENTRYPOINT_STEP_IDS`는
+    $$ substitution 가드 용도로만 그대로 둔다, 그쪽은 실 substitution 참조가 있는
+    스텝만 의도적으로 좁힌 것이라 별개 스코프).
+
     ⛔이 값(10,000)은 story #3031 사고 당시 GitHub 에러 메시지("max: 10000")를 그대로
     반영한 것 — Cloud Build 쪽 실제 한도가 바뀌면(추정: 인프라 변경 없이는 안 바뀜) 이
     상수도 같이 갱신할 것.
     """
-    for step_id in _BASH_ENTRYPOINT_STEP_IDS:
-        script = _extract_step_script(step_id)
+    doc = yaml.safe_load(_CLOUDBUILD_YAML.read_text())
+    bash_steps = [s for s in doc["steps"] if s.get("entrypoint") == "bash"]
+    assert bash_steps, "cloudbuild.yaml에 bash entrypoint 스텝이 0개 — 이 가드 자체가 무의미해짐(파일 구조 변경 의심)"
+    for step in bash_steps:
+        script = step["args"][1]
         byte_len = len(script.encode("utf-8"))
         assert byte_len < _CLOUDBUILD_STEP_ARG_BYTE_LIMIT, (
-            f"cloudbuild.yaml {step_id} 스텝 args가 UTF-8 {byte_len}바이트로 Cloud Build "
+            f"cloudbuild.yaml {step['id']} 스텝 args가 UTF-8 {byte_len}바이트로 Cloud Build "
             f"한도({_CLOUDBUILD_STEP_ARG_BYTE_LIMIT})를 넘김(문자 수={len(script)} — 문자 "
             "수만으로는 안 걸리는 게 story #3031 사고의 정확한 함정). 긴 한글 주석은 "
             "관련 테스트 파일 docstring 등 외부로 옮기고 스텝엔 짧은 포인터만 남길 것."

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -174,6 +174,36 @@ def test_deploy_backend_no_unescaped_shell_vars_in_cloudbuild_substitution_synta
         )
 
 
+_CLOUDBUILD_STEP_ARG_BYTE_LIMIT = 10_000
+
+
+def test_bash_entrypoint_steps_under_cloudbuild_arg_byte_limit():
+    """⭐story #3031 핫픽스(2026-08-24) — Cloud Build 실사고: `deploy-realtime` 스텝이
+    "invalid .steps field: build step 11 arg 1 too long (max: 10000)"로 dev develop
+    배포를 2연속 실패시켰다(4d8014ab3·2406e6f89).
+
+    함정의 본체: 그 스텝은 **문자 수로는 7,590자**(다른 스텝들과 비슷한 규모)였는데
+    **UTF-8 바이트로는 11,459바이트**였다 — 한글 완성형 1글자가 UTF-8에서 3바이트라,
+    한글 주석이 많은 스텝은 "문자 수 감각"으로 안전해 보여도 실제 한도(Cloud Build는
+    **바이트** 기준)를 조용히 넘길 수 있다. 리뷰에서 육안으로 "길다"는 못 느끼면서
+    바이트 한도를 넘기는 이 클래스는 다시 재발할 수 있다 — 그래서 문자 수가 아니라
+    **`.encode('utf-8')` 길이**로 정적 고정한다(에디터 표시 글자수를 믿지 않는다).
+
+    ⛔이 값(10,000)은 story #3031 사고 당시 GitHub 에러 메시지("max: 10000")를 그대로
+    반영한 것 — Cloud Build 쪽 실제 한도가 바뀌면(추정: 인프라 변경 없이는 안 바뀜) 이
+    상수도 같이 갱신할 것.
+    """
+    for step_id in _BASH_ENTRYPOINT_STEP_IDS:
+        script = _extract_step_script(step_id)
+        byte_len = len(script.encode("utf-8"))
+        assert byte_len < _CLOUDBUILD_STEP_ARG_BYTE_LIMIT, (
+            f"cloudbuild.yaml {step_id} 스텝 args가 UTF-8 {byte_len}바이트로 Cloud Build "
+            f"한도({_CLOUDBUILD_STEP_ARG_BYTE_LIMIT})를 넘김(문자 수={len(script)} — 문자 "
+            "수만으로는 안 걸리는 게 story #3031 사고의 정확한 함정). 긴 한글 주석은 "
+            "관련 테스트 파일 docstring 등 외부로 옮기고 스텝엔 짧은 포인터만 남길 것."
+        )
+
+
 def test_deploy_backend_is_bash_entrypoint():
     """story #2141 정정 — env 조건분기를 위해 gcloud 단순 args에서 bash로 전환됐다."""
     doc = yaml.safe_load(_CLOUDBUILD_YAML.read_text())

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -652,30 +652,10 @@ steps:
           echo "      --substitutions 에 _REALTIME_URL=<realtime 서비스 URL> 을 명시할 것."
           exit 1
         fi
-        # story #3031(2026-08-24) — realtime path-filter, Cloud Run 버전. deploy-realtime-gce
-        # (아래, story #2089)엔 이미 이 필터가 있는데 **실제로 브라우저 SSE를 서빙하는 건
-        # 이 Cloud Run 서비스**라 그 비대칭이 뿌리였다 — 매 develop 머지가 무조건 이 스텝을
-        # 재실행시켜, 관련 없는 코드가 섞인 커밋에서도 재배포·롤아웃마다 라이브 SSE 전 연결이
-        # 절단(재연결/백필 사이클 반복)됐다(오늘 08-24 리비전 12개, PO 실측). #3026/#3029로
-        # 고친 건 코드층 dedup 버그이고, 이건 별개의 인프라층 원인 — 둘 다 있어야 #2985 AC②
-        # 라이브 재검이 안정된다.
-        # GCE MIG는 인스턴스 템플릿 이름에서 직전 SHA를 grep으로 뽑아야 했지만(임의 이름이라),
-        # Cloud Run은 서빙 리비전의 이미지 태그 자체가 정확히 그 SHA다(아래 --image=...:
-        # ${COMMIT_SHA} 컨벤션 그대로) — grep 휴리스틱 불요, 태그를 그대로 쓴다.
-        # ⛔"서빙"(트래픽 100%) 리비전이어야 한다 — describe의 spec.template은 다음 배포
-        # 대상이지 실제 트래픽이 아니다(배포 실효=서빙 리비전 digest 교훈, 이 세션 #2985
-        # 조사에서 재확인). status.traffic[]에서 100%를 받는 리비전 이름을 먼저 뽑고, 그
-        # 리비전 자체를 describe해 이미지 태그를 읽는다.
-        # fail-safe는 GCE 선례와 동일: 판별 불가(첫 배포·트래픽 스플릿 중·describe 실패)면
-        # 스킵하지 않고 배포로 진행(check_realtime_relevant_diff.sh 자체의 fail-safe도 동일
-        # 방향 — "필터가 실수로 좁아도 조용히 안 새게").
-        # ⛔story #2421 교훈(deploy-backend 핫픽스, 위 test_deploy_backend_redis_secret_conflict.py
-        # 가드) — Cloud Build 자신의 substitution 파서가 bash 실행 前에 args 문자열 전체를
-        # 먼저 훑어, `${선언안된이름}`을 substitution 오류로 build submit 자체를 거부한다.
-        # 그래서 이 스텝 안에서 새로 짓는 로컬 셸 변수(serving_revision·last_image·last_sha)는
-        # 참조할 때마다 `$$`로 이스케이프해야 한다(Cloud Build가 `$$`→`$`로 한 번 접어 bash에
-        # 넘긴다) — GCE 선례(current_template·last_sha, 아래 deploy-realtime-gce)는 이
-        # 가드 대상 스텝 목록 밖이라 안 걸렸을 뿐, 실제로는 같은 함정 자리다.
+        # story #3031 — realtime path-filter(Cloud Run). 근거·설계 전문은
+        # backend/tests/test_3031_realtime_cloudrun_deploy_path_filter.py 참조(이 스텝의
+        # UTF-8 바이트 한도 초과 핫픽스로 이관). 로컬 변수는 $$ 이스케이프 필수(Cloud
+        # Build 자신의 substitution 파서가 bash 실행 前에 미선언 substitution 참조를 거부).
         serving_revision="$(gcloud run services describe sprintable-realtime-${_DEPLOY_ENV} \
           --region="${_AR_REGION}" --project="${PROJECT_ID}" \
           --format='value(status.traffic.filter(percent=100).revisionName)' 2>/dev/null || echo '')"


### PR DESCRIPTION
[SID:3031]

**P0 — dev develop 배포가 현재 막혀 있음 (2연속 실패: 4d8014ab3, 2406e6f89)**

## 근본원인
#3453(story #3031) 머지로 추가된 `deploy-realtime` 스텝의 신규 주석이 Cloud Build의 args 바이트 한도(10,000)를 넘김 — `invalid .steps field: build step 11 arg 1 too long (max: 10000)`.

함정의 정확한 성격: 그 스텝은 **문자 수로는 7,590자**(다른 스텝과 비슷한 규모)였지만 **UTF-8 바이트로는 11,459바이트**였다. 한글 완성형 1글자가 UTF-8에서 3바이트라, 리뷰 시 "문자 수 감각"으로는 안전해 보이는 스텝이 실제 한도(Cloud Build는 바이트 기준)를 조용히 넘길 수 있다.

## 처방
1. `deploy-realtime` 스텝의 긴 내러티브 한글 주석을 `test_3031_realtime_cloudrun_deploy_path_filter.py` 모듈 docstring으로 이관 — 스텝엔 짧은 포인터 + 로직만 남김(9,457바이트로 축소, deploy-backend의 8,592바이트와 비슷한 여유). 런타임 echo 문자열은 무변경이라 기존 pin 테스트 4종(#3031) 그대로 green.
2. **재발 가드**(PO 지시): `test_bash_entrypoint_steps_under_cloudbuild_arg_byte_limit` 신규 — `_BASH_ENTRYPOINT_STEP_IDS`(deploy-backend/deploy-realtime/deploy-office-converter/apply-gcs-attachments-cors) 전 스텝을 `.encode('utf-8')` 바이트 길이로 10,000 미만 assert(**문자 수 아님** — 이번에 문자 수로는 안 걸렸던 게 함정의 본체).
3. test_3031의 pin 테스트는 주석 이동에 영향받지 않음(런타임 echo 문자열만 대조하므로) — 확認만, 변경 불요.

## 검증
- `cloudbuild.yaml` 파싱 OK, 전 bash entrypoint 스텝 바이트 한도 내(deploy-realtime 최대 9,457).
- 신규 가드 mutation 검증: 가짜 한글 300자 패딩 → 정확히 실패(10,358바이트로 보고) → 복원 후 재green 확認.
- cloudbuild/deploy 인접 회귀 149/149 green.

CI 초록 확인되는 대로 최속 머지 부탁하는 — dev 배포가 이 PR로 막혀 있는.