### PR TITLE
[SID:3033] merge gate 웹훅 오배선 근본수정 — CI verdict를 SHA 기준 폴백으로

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -663,10 +663,14 @@ async def _process_webhook_event(
     # 전체 rollback+500으로 처리해 GitHub가 재시도하므로, 여기서 삼키지 않고 그대로 올린다.
     # story #2813(카디르 R2) — head_sha를 넘겨 auto_passed 판정 시 anchor(gate.approved_head_sha)
     # 즉시 확定(merge_verdict_gate.evaluate_merge_gate 참고).
+    # story #3033(2026-08-24) — SHA 폴백(형제 PR 게이트 여럿 갱신 가능)의 publish 큐잉은
+    # 이 함수 자신이 담당(각 형제가 자기 pr_number/repo로 append — 웹훅 자신의 pr_number/
+    # repo는 그 형제 중 하나만 가리켜 잘못된 PR에 check-run을 publish할 위험이 있다).
+    # 반환값은 그대로 원래 pr_number 경로가 찾은 "이 story의" 단일 decision(하위 호환).
     _reconcile_decision = await reconcile_merge_gate_with_real_evidence(
         session, org_id, story_id,
         pr_number=pr_number, repo=repo, ci_result=ci_conclusion, merged=merged,
-        head_sha=head_sha,
+        head_sha=head_sha, gate_check_publish=gate_check_publish,
     )
     # story #2853(AC①) — 예전엔 이 반환값을 그냥 버려, 재평가로 decision이 AUTO_MERGE에서
     # 이탈해도(CI 재실패·trust 재계산 등) 이미 GitHub에 선 success check-run이 안 고쳐졌다.

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -557,6 +557,46 @@ async def find_gate_slot_with_pr_fallback(
     ).scalar_one_or_none()
 
 
+async def find_pending_merge_gates_by_head_sha(
+    session: AsyncSession, *, org_id: uuid.UUID, head_sha: str,
+) -> list[Gate]:
+    """story #3033(2026-08-24, PO 판정) — CI verdict는 PR의 속성이 아니라 SHA의 속성이다.
+
+    실사고 그라운딩(#3350 MERGED·#3307 CLOSED, 2/2 실물): 스택형 형제 PR이 같은 head SHA를
+    공유하면(브랜치를 다른 PR에 이어 붙이는 관례), 원 PR이 머지된 뒤 도착하는 CI-완료 웹훅
+    (check_suite/workflow_run/status)의 `pull_requests[]`에서 GitHub이 그 PR을 빼버린다
+    (머지된 PR은 더는 그 SHA의 "현재 head"가 아니므로) — 남는 건 그 SHA를 여전히 물고 있는
+    형제 PR뿐이다. `_extract_pr_ci`가 그 페이로드에서 뽑는 pr_number는 그래서 **원 PR이
+    아니라 형제 PR**을 가리키고, `find_gate_slot_with_pr_fallback`(work_item_id=story_id
+    스코프)는 애초에 "다른 story일 수도 있는" 그 형제 게이트를 찾을 근거가 없다(순환 —
+    story 자체를 pr_number 경유로 아는데, 그 pr_number가 이미 틀렸다).
+
+    그래서 이 폴백은 **story 스코프를 걷어내고 org+SHA로만** 찾는다 — `gate.github_check_run_sha`
+    는 그 게이트가 생성될 때 찍힌 실 head SHA(anchor)라 「이 SHA의 CI가 완료됐다」는 사실을
+    story 경계 없이 그대로 반영할 수 있다(SHA는 조직 전역에서 유일). 일치가 여럿(형제 PR
+    각자의 게이트, 같은 story든 다른 story든)이면 **전부** 후보 — 같은 SHA의 CI 결과는
+    사실 그 자체로 공유되는 것이지 임의 선택이 아니다.
+
+    ⛔pending/auto_passed만: `find_gate_slot_with_pr_fallback`과 동일 이유(rejected/voided/
+    held는 사람이 이미 명시 결정했거나 일시정지한 것 — CI 이벤트로 조용히 재오픈/간섭 금지).
+    ⛔pr_result는 이 함수의 관심사가 아니다 — 호출자(`reconcile_merge_gate_with_real_evidence`)
+    가 ci_result만 갱신하고 pr_result는 각 게이트의 기존 값을 보존한다(머지/클로즈 여부는
+    PR별 사실이라 SHA로 공유될 근거가 없다 — PO 명시 구분)."""
+    # 순환 import 회피(merge_verdict_gate.py가 이 모듈을 모듈 레벨에서 import) — 이 파일의
+    # 1444행 기존 관례와 동일하게 함수 안에서 지역 import.
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    return list((
+        await session.execute(
+            select(Gate).where(
+                Gate.org_id == org_id, Gate.gate_type == MERGE_GATE_TYPE,
+                Gate.github_check_run_sha == head_sha,
+                Gate.status.in_(("pending", "auto_passed")),
+            )
+        )
+    ).scalars().all())
+
+
 async def create_gate(
     session: AsyncSession,
     org_id: uuid.UUID,

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -784,12 +784,25 @@ async def reconcile_merge_gate_with_real_evidence(
     for gate in sibling_gates:
         gate_pr_number = gate.pr_number or 0
         gate_repo = (gate.neutral_facts or {}).get("repo") or gate.repo_full_name or repo
-        # 각 게이트의 기존 pr_result를 그대로 되돌려 넣는다 — SHA 폴백은 ci_result만 갱신.
-        preserved_pr_result = (gate.neutral_facts or {}).get("pr_result")
         decision = await evaluate_merge_gate(
             session, org_id, gate.work_item_id,
             pr_number=gate_pr_number, repo=gate_repo, ci_result=ci_result,
-            pr_result=preserved_pr_result,
+            # story #3033(PO 정정, 2026-08-24, 1라운드 QA REQUEST_CHANGES) — 최초 버전은
+            # gate.neutral_facts["pr_result"]를 읽어 "보존"했는데, 그건 게이트 **생성 시점
+            # 스냅샷**이라(neutral_facts는 이후 재평가마다 안 갱신됨, 위 docstring 참조)
+            # 실제로는 stale일 수 있다. CI-완료 이벤트(check_suite/workflow_run/status)엔
+            # PR 머지/클로즈 여부가 구조적으로 안 실린다 — 그 「모름」을 stale snapshot으로
+            # 위조하면(카디르+codex 실PG 재현) neutral_facts가 우연히 옛 "pass"를 들고 있는
+            # gate_status=="auto_passed" 게이트에서 «상향 오판»(auto_merge 잘못 승인)이
+            # 난다. 그래서 명시로 None(모름)을 넘긴다 — `_decide()`의 AUTO_MERGE 분기는
+            # pr=="pass" 정확 일치만 통과시켜 None은 항상 막고(상향 전이 없음, PO 요건②),
+            # `capture_pr_ci_verdict`는 merged=False일 때 pr verdict 자체를 기록 안 해(그
+            # 함수 참조 — merged=True일 때만 기록) "미머지"를 이력에 지어내지도 않는다(PO
+            # 요건①). status=="pending"(실사고 #3350/#3307 둘 다 이 케이스)인 게이트는
+            # `_decide()`가 pr 값과 무관하게 "policy disposition=ask"로 조기 반환하므로
+            # 실사고 재현 시나리오엔 아예 영향이 없다 — 이 정정은 auto_passed 게이트에서만
+            # 실제로 갈린다.
+            pr_result=None,
             head_sha=head_sha,
         )
         if gate_check_publish is not None and decision.gate_id is not None:

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -32,6 +32,7 @@ from app.services.gate_resolver import (
 from app.services.gate_service import (
     create_gate,
     find_gate_slot_with_pr_fallback,
+    find_pending_merge_gates_by_head_sha,
     resolve_work_item_project_id,
 )
 from app.services.trust_score import compute_member_trust_scores
@@ -691,6 +692,7 @@ async def reconcile_merge_gate_with_real_evidence(
     ci_result: str | None,
     merged: bool,
     head_sha: str | None = None,
+    gate_check_publish: list[dict] | None = None,
 ) -> MergeGateDecision | None:
     """story #2156 AC2(2026-08-07) — GitHub 웹훅이 잡은 실 CI/PR verdict를 merge-type
     게이트에 반영한다.
@@ -720,7 +722,31 @@ async def reconcile_merge_gate_with_real_evidence(
     ⚠️호출 위치 주의 — `evaluate_merge_gate` 자신이 내부에서 `capture_pr_ci_verdict`를 이미
     부른다. 이 함수를 `capture_pr_ci_verdict` 본문 안에서 부르면 무한 재귀가 된다 — 반드시
     그 호출부(웹훅 핸들러 등) 쪽에서, `capture_pr_ci_verdict` 리턴 後에 별도로 부를 것.
-    """
+
+    ⭐story #3033(2026-08-24, PO 판정) — pr_number 경로가 아무 게이트도 못 찾으면(아래),
+    SHA 폴백으로 한 번 더 시도한다. 그라운딩(디디, #3350/#3307 2/2 실물): 스택형 형제 PR이
+    같은 head SHA를 공유하면, 원 PR이 머지된 뒤 도착하는 CI-완료 웹훅(check_suite/
+    workflow_run/status)의 pull_requests[]에서 GitHub이 그 PR을 빼버려 pr_number 자체가
+    틀린 PR(형제)을 가리킨다 — «같은 story의 게이트» 스코프로는 못 잡는다(story 자체를
+    그 틀린 pr_number 경유로 아는 순환이라). CI verdict는 PR이 아니라 SHA의 속성이라는
+    PO 판정에 따라, org+github_check_run_sha로만(story 무관) 찾는다
+    (`find_pending_merge_gates_by_head_sha`). 일치가 여럿이면 전부 갱신 — **ci_result만**.
+    pr_result(머지/클로즈)는 PR별 사실이라 SHA로 공유될 근거가 없으므로 각 게이트의 기존
+    값을 그대로 보존한다(evaluate_merge_gate의 pr_result 파라미터는 무조건부 덮어쓰기라
+    None을 넘기면 기존 값을 지운다 — 그래서 명시로 읽어 되돌려 넣는다).
+
+    ⚠️반환 계약은 그대로 유지(하위 호환 — 이 함수를 직접 호출하는 기존 realdb 테스트
+    다수(#2156/#2520/#2853/#2893)가 단일 `MergeGateDecision | None`을 전제로 한다): SHA
+    폴백이 갱신한 형제 게이트들은 이 반환값에 실리지 않는다(원래 pr_number 경로가 찾은
+    "그 story의" 결정만 반환). 대신 `gate_check_publish`(옵션, `_process_webhook_event`의
+    동형 outparam 관례 그대로 — 넘기면 형제 게이트마다 자신의 pr_number/repo로 항목을
+    append) 로 그 결과에 접근한다. 안 넘기면(기존 모든 호출부) DB 쓰기(ci_result 갱신)는
+    그대로 일어나되 GitHub check-run publish 신호만 안 나간다 — 그 쓰기 자체가 이 fix의
+    본체(게이트가 영원히 pending에 갇히는 것 해소)이므로 publish는 부가.
+
+    관측(AC2, PO 지시) — 폴백이 발동하면 info 로그(매치 건수 포함), pr_number 경로도
+    SHA 폴백도 둘 다 못 찾으면 warning(«이 CI 신호가 어떤 게이트에도 안 닿았다»가 조용히
+    묻히지 않게)."""
     # story #2893(설계안 §2 A1) — pr_number를 키에 편입: 안 넣으면 "이 웹훅이 나른 PR B의
     # CI/merge 증거"로 story의 아무 pending/auto_passed 게이트(실은 PR A 것일 수 있음)를
     # 재평가해버린다 — 실사고1/2와 정확히 같은 클래스(엉뚱한 PR의 SHA/증거가 다른 PR의
@@ -733,14 +759,45 @@ async def reconcile_merge_gate_with_real_evidence(
         gate_type=MERGE_GATE_TYPE, pr_number=(pr_number if pr_number > 0 else None),
         repo_full_name=(repo or None),
     )
-    if existing is None or existing.status not in ("pending", "auto_passed"):
+    if existing is not None and existing.status in ("pending", "auto_passed"):
+        return await evaluate_merge_gate(
+            session, org_id, story_id,
+            pr_number=pr_number, repo=repo, ci_result=ci_result,
+            pr_result=("pass" if merged else None),
+            head_sha=head_sha,
+        )
+
+    if not head_sha:
         return None
-    return await evaluate_merge_gate(
-        session, org_id, story_id,
-        pr_number=pr_number, repo=repo, ci_result=ci_result,
-        pr_result=("pass" if merged else None),
-        head_sha=head_sha,
+    sibling_gates = await find_pending_merge_gates_by_head_sha(session, org_id=org_id, head_sha=head_sha)
+    if not sibling_gates:
+        logger.warning(
+            "merge gate reconcile: no pending/auto_passed gate matched by pr_number(=%s) or "
+            "sha=%s (org=%s repo=%s) — this CI/merge signal reached no gate",
+            pr_number, head_sha, org_id, repo,
+        )
+        return None
+    logger.info(
+        "merge gate SHA fallback triggered: sha=%s matched %d sibling gate(s) (pr_number=%s path found none)",
+        head_sha, len(sibling_gates), pr_number,
     )
+    for gate in sibling_gates:
+        gate_pr_number = gate.pr_number or 0
+        gate_repo = (gate.neutral_facts or {}).get("repo") or gate.repo_full_name or repo
+        # 각 게이트의 기존 pr_result를 그대로 되돌려 넣는다 — SHA 폴백은 ci_result만 갱신.
+        preserved_pr_result = (gate.neutral_facts or {}).get("pr_result")
+        decision = await evaluate_merge_gate(
+            session, org_id, gate.work_item_id,
+            pr_number=gate_pr_number, repo=gate_repo, ci_result=ci_result,
+            pr_result=preserved_pr_result,
+            head_sha=head_sha,
+        )
+        if gate_check_publish is not None and decision.gate_id is not None:
+            gate_check_publish.append({
+                "org_id": org_id, "gate_id": decision.gate_id,
+                "head_sha": head_sha, "repo_full_name": gate_repo, "pr_number": gate_pr_number,
+            })
+    return None
 
 
 async def trigger_gate_creation_for_late_participation(

--- a/backend/tests/test_3033_merge_gate_sha_fallback_realdb.py
+++ b/backend/tests/test_3033_merge_gate_sha_fallback_realdb.py
@@ -1,0 +1,371 @@
+"""story #3033(2026-08-24, PO 판정) — reconcile_merge_gate_with_real_evidence 웹훅이 실 PR
+종결을 놓친 회귀(PR#3350 MERGED·PR#3307 CLOSED 2/2 실물)의 근본 처방.
+
+그라운딩(디디, GitHub webhook delivery + REST API 실물 대조): 웹훅 자체는 정상 발송·수신
+됐고 매칭 로직(find_gate_slot_with_pr_fallback)도 «주어진 pr_number»로는 정확했다 — 문제는
+스택형 형제 PR이 같은 head SHA를 공유할 때, 원 PR이 머지된 뒤 도착하는 CI-완료 웹훅
+(check_suite/workflow_run/status)의 GitHub `pull_requests[]`에서 그 PR이 빠져(머지된 PR은
+"현재 head" 목록에서 제외됨), pr_number 추출 단계가 애초에 틀린(형제) PR을 가리켰다는 것.
+
+처방(PO 판정): CI verdict는 PR이 아니라 SHA의 속성이다 — pr_number 경로가 못 찾으면
+org+github_check_run_sha로만(story 무관) 찾는 SHA 폴백을 추가한다. ci_result만 갱신하고
+pr_result(머지/클로즈, PR별 사실)는 각 게이트의 기존 값을 보존한다.
+
+이 파일은 그 폴백(`find_pending_merge_gates_by_head_sha` 직접 + `reconcile_merge_gate_
+with_real_evidence` 통합) 자체를 검증한다."""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    import app.models.verdict  # noqa: F401 — story #2662류 미등재 갭(evaluate_merge_gate가
+    # capture_pr_ci_verdict 경유로 Verdict 테이블을 직접 쓰는데, 이 파일을 단독 실행하면
+    # app.models 벌크 임포트만으로는 이 모듈이 로드 안 될 때가 있어(다른 테스트 파일이
+    # 먼저 임포트해 둔 프로세스 전역 부수효과에 의존하던 것) create_all() 직전에 명시.
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_story_with_participation(session, org_id=None, org_slug_prefix="org"):
+    """⚠️`resolve_implementation_participation`(verdict_capture.py)은 org 안의 "default"
+    role을 `ParticipationRole.org_id==org_id, is_default.is_(True)` + `.limit(1)`(role_id로
+    좁히지 않음, ORDER BY 없음)로 조회한다 — 같은 org_id를 재사용하면서 매번 새
+    `is_default=True` role을 또 만들면, 그 조회가 «어느 역할이 default인지» 모호해져
+    엉뚱한(먼저 만들어진) role_id를 집고, 그 role_id로는 이 story의 Participation을 못 찾아
+    "no implementation participation"으로 조용히 새 버린다(evaluate_merge_gate가 gate_id=
+    None을 돌려주는데 예외가 없어 원인 추적이 느리다 — 실측으로 적발). 그래서 org_id를
+    재사용할 때는 role도 재사용한다(같은 org 안 여러 story가 같은 default role을 공유하는
+    게 실제 프로덕션 모양과도 일치 — role은 story가 아니라 org 단위 개념)."""
+    from app.models.organization import Organization
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.project import Project
+    from sqlalchemy import select
+
+    if org_id is None:
+        org = Organization(id=uuid.uuid4(), name="Org", slug=f"{org_slug_prefix}-{uuid.uuid4().hex[:8]}")
+        session.add(org)
+        await session.commit()
+        org_id = org.id
+
+    role = (
+        await session.execute(
+            select(ParticipationRole).where(
+                ParticipationRole.org_id == org_id, ParticipationRole.is_default.is_(True),
+            ).limit(1)
+        )
+    ).scalar_one_or_none()
+    if role is None:
+        role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="dev", label="Dev", is_default=True)
+        session.add(role)
+        await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org_id, name="P")
+    session.add(project)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project.id, title="Merge gate SHA fallback target")
+    session.add(story)
+    await session.commit()
+
+    member_id = uuid.uuid4()
+    participation = Participation(
+        id=uuid.uuid4(), org_id=org_id, story_id=story.id, role_id=role.id, member_id=member_id,
+    )
+    session.add(participation)
+    await session.commit()
+
+    return {"org_id": org_id, "story_id": story.id, "member_id": member_id}
+
+
+async def _gate_row(session, story_id):
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+
+    result = await session.execute(
+        select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "merge")
+    )
+    return result.scalar_one_or_none()
+
+
+async def _seed_pending_merge_gate_with_sha(
+    session, seeded, *, pr_number, repo, head_sha, pr_result="pass", ci_result=None,
+):
+    """실제로 publish_gate_check가 나중에 github_check_run_sha를 찍는 것을 시뮬레이션
+    (그 발행 로직 자체는 이 테스트 스코프 밖 — 게이트에 이미 anchor SHA가 있는 상태만 재현)."""
+    from app.services.merge_verdict_gate import evaluate_merge_gate
+
+    await evaluate_merge_gate(
+        session, seeded["org_id"], seeded["story_id"],
+        pr_number=pr_number, repo=repo, ci_result=ci_result, pr_result=pr_result,
+    )
+    await session.commit()
+    gate = await _gate_row(session, seeded["story_id"])
+    gate.github_check_run_sha = head_sha
+    await session.commit()
+    return gate
+
+
+@pytest.mark.anyio
+async def test_find_pending_merge_gates_by_head_sha_is_org_scoped_and_status_filtered_realdb():
+    """직접 단위 검증 — org 경계는 지키고(다른 org의 같은 SHA는 안 섞임), terminal 상태
+    (approved/rejected)는 제외한다(사람이 이미 결정한 것을 CI 이벤트로 조용히 재오픈 금지)."""
+    from app.services.gate_service import find_pending_merge_gates_by_head_sha
+
+    engine, Session = await _session_factory()
+    try:
+        sha = f"sha{uuid.uuid4().hex}"
+        async with Session() as s:
+            seeded_a = await _seed_story_with_participation(s, org_slug_prefix="org-a")
+            gate_a = await _seed_pending_merge_gate_with_sha(
+                s, seeded_a, pr_number=101, repo="acme/repo", head_sha=sha,
+            )
+            assert gate_a.status == "pending"
+
+            # 같은 SHA·다른 org — 절대 섞이면 안 됨.
+            seeded_b = await _seed_story_with_participation(s, org_slug_prefix="org-b")
+            await _seed_pending_merge_gate_with_sha(
+                s, seeded_b, pr_number=202, repo="acme/repo", head_sha=sha,
+            )
+
+            # 같은 org·같은 SHA·terminal(approved) — 제외 대상.
+            seeded_c = await _seed_story_with_participation(s, seeded_a["org_id"])
+            gate_c = await _seed_pending_merge_gate_with_sha(
+                s, seeded_c, pr_number=303, repo="acme/repo", head_sha=sha,
+            )
+            from app.models.gate import set_gate_status
+            from datetime import datetime, timezone
+            set_gate_status(gate_c, "approved", now=datetime.now(timezone.utc))
+            await s.commit()
+
+            matches = await find_pending_merge_gates_by_head_sha(s, org_id=seeded_a["org_id"], head_sha=sha)
+            match_ids = {g.id for g in matches}
+            assert gate_a.id in match_ids, "같은 org·pending·같은 SHA는 매치돼야 함"
+            assert gate_c.id not in match_ids, "approved(terminal)는 CI 이벤트로 재오픈되면 안 됨"
+            assert len(matches) == 1, f"org 경계 밖(org-b) 게이트가 섞임: {match_ids}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reconcile_sha_fallback_updates_ci_only_preserves_pr_result_cross_story_realdb():
+    """⭐핵심 — pr_number 경로가 못 찾으면(웹훅이 형제 PR로 오배선), SHA로 **다른 story의**
+    게이트까지 찾아 ci_result만 갱신하고 pr_result(이미 "pass")는 그대로 보존한다.
+
+    ⚠️`gate.neutral_facts`(JSONB)는 게이트 **생성 시점 1회**만 채워진다(`create_gate`의
+    멱등 반환 분기 — 이미 존재하는 pending/auto_passed 게이트는 neutral_facts를 다시
+    쓰지 않는다, gate_service.py 실측 확認). 그래서 "ci_result만 갱신·pr_result 보존"을
+    DB에 쌓인 neutral_facts로는 검증할 수 없다(애초에 둘 다 재기록 안 됨) — 실제로
+    매 호출마다 갱신되는 건 `gate.decision_basis`/`requires_human`(별도 컬럼, `_decide()`
+    직후 무조건 write-back) 쪽이고, 그 `_decide()`에 **어떤 pr 값이 실제로 들어갔는지**가
+    이 fix의 핵심(참고: outcome 표본 0인 fresh seed에서는 `_decide()`가 outcome-insufficient
+    로 조기 리턴해 pr 값이 reason 문자열에 아예 안 드러나 — 그래서 `evaluate_merge_gate`를
+    직접 모킹해 **호출 인자**를 대조한다. 이게 "pr_result가 None으로 새는지"를 검증하는
+    가장 직접적이고 seeding 부담이 없는 방법이다).
+
+    story 경계를 넘어 매치되는 걸 일부러 검증한다 — PO 판정의 핵심("SHA는 PR이 아니라
+    커밋의 속성, story 스코프가 아니다")이 실제 실사고(#3350/#3307, 같은 story 안 형제
+    PR)보다 더 넓은 일반화라는 것을 이 테스트가 고정한다."""
+    from app.services.merge_verdict_gate import (
+        MergeGateDecision,
+        reconcile_merge_gate_with_real_evidence,
+    )
+
+    engine, Session = await _session_factory()
+    try:
+        sha = f"sha{uuid.uuid4().hex}"
+        async with Session() as s:
+            # story A = 웹훅이 실제로 의도한 원 PR(이미 머지됨, pr_result=pass로 생성됨).
+            seeded_a = await _seed_story_with_participation(s, org_slug_prefix="org")
+            gate_a = await _seed_pending_merge_gate_with_sha(
+                s, seeded_a, pr_number=100, repo="acme/repo", head_sha=sha, pr_result="pass", ci_result=None,
+            )
+            assert gate_a.neutral_facts["pr_result"] == "pass"
+
+            # story B = 무관한 다른 story(같은 org — story 경계만 다르다는 걸 보이기 위해).
+            seeded_b = await _seed_story_with_participation(s, seeded_a["org_id"])
+
+            captured_calls: list[dict] = []
+            real_evaluate = None
+
+            async def _spy(session_arg, org_id_arg, work_item_id_arg, **kwargs):
+                captured_calls.append({"work_item_id": work_item_id_arg, **kwargs})
+                return MergeGateDecision(
+                    decision="ask_human", reason="stub", gate_id=gate_a.id, gate_status="pending",
+                    disposition="ask", trust=None, ci_result=kwargs.get("ci_result"),
+                )
+
+            # 웹훅이 자원(story_id)은 A로 정확히 resolve했지만(SID 매치 등), pr_number 자체가
+            # GitHub의 pull_requests[]가 원 PR을 빼버려 엉뚱한(존재하지 않는 A의) 번호를 문다
+            # — pr_number 경로(find_gate_slot_with_pr_fallback)는 story A에서 999를 못 찾음.
+            with patch("app.services.merge_verdict_gate.evaluate_merge_gate", _spy):
+                decision = await reconcile_merge_gate_with_real_evidence(
+                    s, seeded_a["org_id"], seeded_a["story_id"],
+                    pr_number=999, repo="acme/repo", ci_result="pass", merged=False, head_sha=sha,
+                )
+            await s.commit()
+
+            # 반환값은 하위 호환 계약대로 None(SHA 폴백 결과는 반환값에 안 실림).
+            assert decision is None
+
+            assert len(captured_calls) == 1, f"SHA 폴백이 정확히 gate_a 1건만 재평가해야 함(실제: {captured_calls})"
+            call = captured_calls[0]
+            assert call["work_item_id"] == seeded_a["story_id"]
+            assert call["ci_result"] == "pass", "SHA 폴백이 새 ci_result를 그대로 넘겨야 함"
+            assert call["pr_result"] == "pass", (
+                "pr_result는 이 폴백의 관심사가 아니다 — gate_a의 기존 값(pass)을 읽어 그대로 "
+                "되돌려 넣어야 함(None을 넘기면 evaluate_merge_gate 내부에서 무조건부 덮어쓰기로 "
+                "지워지는 landmine — evaluate_merge_gate 자체는 이미 확認됐으므로 여기선 "
+                "reconcile이 «무엇을 넘기는지»만 정확히 대조한다)"
+            )
+            assert call["head_sha"] == sha
+
+            # story B는 무관 — 애초에 이 SHA와 아무 관계도 없으므로 게이트 자체가 없어야 함.
+            gate_b = await _gate_row(s, seeded_b["story_id"])
+            assert gate_b is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reconcile_sha_fallback_zero_match_returns_none_no_gate_created_realdb():
+    """pr_number 경로도 SHA 폴백도 둘 다 못 찾으면(이 CI 신호가 어떤 게이트와도 무관) 새
+    게이트를 만들지 않고(reconcile은 «반영»이지 「생성」이 아니다) None을 반환한다."""
+    from app.services.merge_verdict_gate import reconcile_merge_gate_with_real_evidence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+
+            decision = await reconcile_merge_gate_with_real_evidence(
+                s, seeded["org_id"], seeded["story_id"],
+                pr_number=999, repo="acme/repo", ci_result="pass", merged=False,
+                head_sha=f"sha{uuid.uuid4().hex}",  # 아무 게이트도 물고 있지 않은 SHA.
+            )
+            await s.commit()
+
+            assert decision is None
+            assert await _gate_row(s, seeded["story_id"]) is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reconcile_pr_number_path_takes_priority_skips_sha_fallback_realdb():
+    """pr_number 경로가 이미 정확한 게이트를 찾으면(정상 케이스 — 웹훅이 원 PR을 제대로
+    가리킴) SHA 폴백은 아예 발동하지 않는다 — 같은 SHA를 공유하는 형제 게이트가 있어도
+    그건 안 건드린다(이 웹훅이 말하는 건 정확히 그 pr_number PR 하나뿐이라는 사실).
+
+    ⚠️`neutral_facts`가 생성 시점 1회만 채워진다는 사실(위 테스트 참조) 때문에, "형제가
+    안 건드려졌다"를 neutral_facts로는 증명할 수 없다(애초에 정상 케이스에서도 안 바뀜 —
+    거짓 양성). `find_pending_merge_gates_by_head_sha`를 스파이로 감싸 **호출 자체가
+    없었음**을 직접 증명한다 — 그게 "폴백이 발동 안 함"의 유일한 정직한 신호다."""
+    from app.services import merge_verdict_gate as mvg
+    from app.services.merge_verdict_gate import reconcile_merge_gate_with_real_evidence
+
+    engine, Session = await _session_factory()
+    try:
+        sha = f"sha{uuid.uuid4().hex}"
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+            gate_primary = await _seed_pending_merge_gate_with_sha(
+                s, seeded, pr_number=100, repo="acme/repo", head_sha=sha, pr_result=None, ci_result=None,
+            )
+
+            # 같은 story·같은 SHA를 공유하는 "형제" 게이트(다른 pr_number) — 건드리면 안 됨.
+            seeded2 = await _seed_story_with_participation(s, seeded["org_id"])
+            await _seed_pending_merge_gate_with_sha(
+                s, seeded2, pr_number=101, repo="acme/repo", head_sha=sha, pr_result=None, ci_result=None,
+            )
+
+            sha_fallback_calls: list = []
+            real_find = mvg.find_pending_merge_gates_by_head_sha
+
+            async def _spy(*args, **kwargs):
+                sha_fallback_calls.append((args, kwargs))
+                return await real_find(*args, **kwargs)
+
+            with patch("app.services.merge_verdict_gate.find_pending_merge_gates_by_head_sha", _spy):
+                decision = await reconcile_merge_gate_with_real_evidence(
+                    s, seeded["org_id"], seeded["story_id"],
+                    pr_number=100, repo="acme/repo", ci_result="pass", merged=True, head_sha=sha,
+                )
+            await s.commit()
+
+            assert decision is not None
+            assert decision.gate_id == gate_primary.id
+            assert not sha_fallback_calls, (
+                "pr_number 경로가 이미 성공했으면 SHA 폴백 조회 자체를 호출하면 안 됨 — "
+                f"호출됨: {sha_fallback_calls}"
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reconcile_sha_fallback_queues_gate_check_publish_with_matched_gates_own_pr_number_realdb():
+    """SHA 폴백이 갱신한 게이트를 GitHub check-run publish 큐에 넣을 때, 웹훅 자신의
+    pr_number(형제를 가리킬 수 있음)가 아니라 **매치된 게이트 자신의** pr_number/repo로
+    넣어야 한다 — 안 그러면 엉뚱한 PR에 check-run이 발행된다."""
+    from app.services.merge_verdict_gate import reconcile_merge_gate_with_real_evidence
+
+    engine, Session = await _session_factory()
+    try:
+        sha = f"sha{uuid.uuid4().hex}"
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+            gate = await _seed_pending_merge_gate_with_sha(
+                s, seeded, pr_number=100, repo="acme/repo", head_sha=sha, pr_result="pass", ci_result=None,
+            )
+
+            publish_queue: list[dict] = []
+            decision = await reconcile_merge_gate_with_real_evidence(
+                s, seeded["org_id"], seeded["story_id"],
+                # 웹훅 자신은 999(형제 PR)를 가리킨다 — 실제로 갱신되는 건 gate(pr_number=100).
+                pr_number=999, repo="acme/repo", ci_result="pass", merged=False, head_sha=sha,
+                gate_check_publish=publish_queue,
+            )
+            await s.commit()
+
+            assert decision is None
+            assert len(publish_queue) == 1
+            queued = publish_queue[0]
+            assert queued["gate_id"] == gate.id
+            assert queued["pr_number"] == 100, "웹훅의 999가 아니라 매치된 게이트 자신의 pr_number여야 함"
+            assert queued["repo_full_name"] == "acme/repo"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3033_merge_gate_sha_fallback_realdb.py
+++ b/backend/tests/test_3033_merge_gate_sha_fallback_realdb.py
@@ -181,20 +181,25 @@ async def test_find_pending_merge_gates_by_head_sha_is_org_scoped_and_status_fil
 
 
 @pytest.mark.anyio
-async def test_reconcile_sha_fallback_updates_ci_only_preserves_pr_result_cross_story_realdb():
+async def test_reconcile_sha_fallback_updates_ci_only_never_claims_pr_result_cross_story_realdb():
     """⭐핵심 — pr_number 경로가 못 찾으면(웹훅이 형제 PR로 오배선), SHA로 **다른 story의**
-    게이트까지 찾아 ci_result만 갱신하고 pr_result(이미 "pass")는 그대로 보존한다.
+    게이트까지 찾아 ci_result만 갱신한다.
 
-    ⚠️`gate.neutral_facts`(JSONB)는 게이트 **생성 시점 1회**만 채워진다(`create_gate`의
-    멱등 반환 분기 — 이미 존재하는 pending/auto_passed 게이트는 neutral_facts를 다시
-    쓰지 않는다, gate_service.py 실측 확認). 그래서 "ci_result만 갱신·pr_result 보존"을
-    DB에 쌓인 neutral_facts로는 검증할 수 없다(애초에 둘 다 재기록 안 됨) — 실제로
-    매 호출마다 갱신되는 건 `gate.decision_basis`/`requires_human`(별도 컬럼, `_decide()`
-    직후 무조건 write-back) 쪽이고, 그 `_decide()`에 **어떤 pr 값이 실제로 들어갔는지**가
-    이 fix의 핵심(참고: outcome 표본 0인 fresh seed에서는 `_decide()`가 outcome-insufficient
-    로 조기 리턴해 pr 값이 reason 문자열에 아예 안 드러나 — 그래서 `evaluate_merge_gate`를
-    직접 모킹해 **호출 인자**를 대조한다. 이게 "pr_result가 None으로 새는지"를 검증하는
-    가장 직접적이고 seeding 부담이 없는 방법이다).
+    ⛔카디르+codex QA 1라운드(PR#3456, 2026-08-24) — 최초 버전은 `gate.neutral_facts
+    ["pr_result"]`(게이트 **생성 시점 스냅샷** — `create_gate`의 멱등 반환 분기가 기존
+    게이트는 재기록 안 함, gate_service.py 실측)를 읽어 "보존"했는데, 그건 stale일 수
+    있다. CI-완료 이벤트(check_suite/workflow_run/status)엔 PR 머지/클로즈 여부가
+    구조적으로 안 실린다 — 그 「모름」을 stale snapshot으로 위조하면, 우연히 옛
+    "pass"를 들고 있는 `gate_status=="auto_passed"` 게이트에서 **상향 오판**(auto_merge
+    잘못 승인)이 실PG로 재현됐다. PO 정정(2026-08-24): SHA 폴백은 pr_result를
+    **항상 명시로 None**(모름)을 넘긴다 — `_decide()`의 AUTO_MERGE 분기는 `pr=="pass"`
+    정확 일치만 통과시켜 None은 항상 막고(상향 전이 원천 차단), `capture_pr_ci_verdict`는
+    merged=False일 때 pr verdict 자체를 기록 안 해(아래 별도 테스트로 고정) "미머지"를
+    이력에 지어내지도 않는다.
+
+    ⚠️`gate.neutral_facts`가 재평가마다 안 갱신된다는 사실 때문에 "pr_result에 실제로
+    무엇이 넘어갔는지"를 DB로는 검증할 수 없다 — `evaluate_merge_gate`를 직접 모킹해
+    **호출 인자**를 대조한다(seeding 부담 없는 가장 직접적인 방법).
 
     story 경계를 넘어 매치되는 걸 일부러 검증한다 — PO 판정의 핵심("SHA는 PR이 아니라
     커밋의 속성, story 스코프가 아니다")이 실제 실사고(#3350/#3307, 같은 story 안 형제
@@ -208,18 +213,17 @@ async def test_reconcile_sha_fallback_updates_ci_only_preserves_pr_result_cross_
     try:
         sha = f"sha{uuid.uuid4().hex}"
         async with Session() as s:
-            # story A = 웹훅이 실제로 의도한 원 PR(이미 머지됨, pr_result=pass로 생성됨).
+            # story A = 웹훅이 실제로 의도한 원 PR(이미 머지됨, neutral_facts엔 stale하게 pass가 남음).
             seeded_a = await _seed_story_with_participation(s, org_slug_prefix="org")
             gate_a = await _seed_pending_merge_gate_with_sha(
                 s, seeded_a, pr_number=100, repo="acme/repo", head_sha=sha, pr_result="pass", ci_result=None,
             )
-            assert gate_a.neutral_facts["pr_result"] == "pass"
+            assert gate_a.neutral_facts["pr_result"] == "pass"  # stale snapshot — 이걸 믿으면 안 됨.
 
             # story B = 무관한 다른 story(같은 org — story 경계만 다르다는 걸 보이기 위해).
             seeded_b = await _seed_story_with_participation(s, seeded_a["org_id"])
 
             captured_calls: list[dict] = []
-            real_evaluate = None
 
             async def _spy(session_arg, org_id_arg, work_item_id_arg, **kwargs):
                 captured_calls.append({"work_item_id": work_item_id_arg, **kwargs})
@@ -245,17 +249,78 @@ async def test_reconcile_sha_fallback_updates_ci_only_preserves_pr_result_cross_
             call = captured_calls[0]
             assert call["work_item_id"] == seeded_a["story_id"]
             assert call["ci_result"] == "pass", "SHA 폴백이 새 ci_result를 그대로 넘겨야 함"
-            assert call["pr_result"] == "pass", (
-                "pr_result는 이 폴백의 관심사가 아니다 — gate_a의 기존 값(pass)을 읽어 그대로 "
-                "되돌려 넣어야 함(None을 넘기면 evaluate_merge_gate 내부에서 무조건부 덮어쓰기로 "
-                "지워지는 landmine — evaluate_merge_gate 자체는 이미 확認됐으므로 여기선 "
-                "reconcile이 «무엇을 넘기는지»만 정확히 대조한다)"
+            assert call["pr_result"] is None, (
+                "SHA 폴백은 pr_result를 절대 '알고 있는 척' 하면 안 된다 — gate_a.neutral_facts에 "
+                "stale 'pass'가 남아 있어도(위에서 확認) 그걸 읽어 되돌려 넣지 않고 명시로 None을 "
+                "넘겨야 함(카디르+codex가 실PG로 재현한 auto_merge 상향 오판의 정확한 원인)"
             )
             assert call["head_sha"] == sha
 
             # story B는 무관 — 애초에 이 SHA와 아무 관계도 없으므로 게이트 자체가 없어야 함.
             gate_b = await _gate_row(s, seeded_b["story_id"])
             assert gate_b is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reconcile_sha_fallback_never_fabricates_pr_verdict_history_realdb():
+    """⭐PO 지시(2026-08-24, REQUEST_CHANGES 재검 판별 축) — SHA 폴백 경로에서 pr_result=
+    None을 넘겨도 «미머지 사실»이 Verdict 이력 어디에도 기록되면 안 된다(그것도 위조 —
+    "모른다"를 "머지 안 됐다"로 지어내는 것과 같은 클래스).
+
+    실 `evaluate_merge_gate`(모킹 없음)로 SHA 폴백을 실행해 그 story의 participation에
+    걸린 `Verdict` 행을 전수 조회 — `source='pr'`인 행이 하나도 없어야 한다(capture_pr_
+    ci_verdict가 merged=True일 때만 그 소스를 기록하므로, merged=False로 정규화되는
+    pr_result=None은 애초에 그 기록 자체를 건너뛴다 — 참조: verdict_capture.py
+    capture_pr_ci_verdict `if merged:` 가드)."""
+    from sqlalchemy import select
+
+    from app.models.verdict import Verdict
+    from app.services.merge_verdict_gate import reconcile_merge_gate_with_real_evidence
+
+    engine, Session = await _session_factory()
+    try:
+        sha = f"sha{uuid.uuid4().hex}"
+        async with Session() as s:
+            seeded = await _seed_story_with_participation(s)
+            # ⚠️seed 자체가 evaluate_merge_gate(pr_result="pass")를 한 번 부르므로(원 PR이
+            # 실제로 merged=True였던 순간을 재현) 그 시점에 정당한 ("pr","pass") verdict가
+            # 이미 남는다 — 그건 진짜 사실 기록이라 있어도 된다. 폴백 호출 «이후에 새로
+            # 추가된» 것이 있는지(델타)만 본다, 절대 개수 0이 아니라.
+            gate = await _seed_pending_merge_gate_with_sha(
+                s, seeded, pr_number=100, repo="acme/repo", head_sha=sha, pr_result="pass", ci_result=None,
+            )
+
+            from app.models.participation import Participation
+
+            participation = (
+                await s.execute(
+                    select(Participation).where(Participation.story_id == seeded["story_id"])
+                )
+            ).scalar_one()
+            before_ids = {
+                v.id for v in (
+                    await s.execute(select(Verdict).where(Verdict.participation_id == participation.id))
+                ).scalars().all()
+            }
+
+            # pr_number 경로가 못 찾도록(999) — SHA 폴백을 실제로 태운다.
+            await reconcile_merge_gate_with_real_evidence(
+                s, seeded["org_id"], seeded["story_id"],
+                pr_number=999, repo="acme/repo", ci_result="pass", merged=False, head_sha=sha,
+            )
+            await s.commit()
+
+            after = (
+                await s.execute(select(Verdict).where(Verdict.participation_id == participation.id))
+            ).scalars().all()
+            new_verdicts = [v for v in after if v.id not in before_ids]
+            new_pr_verdicts = [v for v in new_verdicts if v.source == "pr"]
+            assert not new_pr_verdicts, (
+                f"SHA 폴백(pr_result=None) 호출 자체가 새 pr-source verdict를 추가하면 안 됨 "
+                f"('미머지' 위조 방지) — 신규 발견: {[(v.source, v.result) for v in new_pr_verdicts]}"
+            )
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
[SID:3033]

## 그라운딩(실물 근거, 3갈래 가설 전부 반증)
GitHub webhook delivery 로그(gh api hooks/deliveries)+백엔드 게이트 REST API로 PR#3350(story #2923)·PR#3307(story #2905) 2건 각각의 유실 지점을 직접 대조:
- **발송 안 됨** — 반증. 두 PR의 close 웹훅 모두 200 OK로 배달됨.
- **수신 실패** — 반증. `capture_pr_ci_verdict`+`reconcile_merge_gate_with_real_evidence` 둘 다 실행돼 `pr_result=pass`까지 게이트에 정확히 기록됨.
- **매칭 실패(단순)** — 부분 반증. `find_gate_slot_with_pr_fallback`은 «주어진 pr_number»로는 정확했다.

**진짜 원인**: 스택형 형제 PR이 같은 head SHA를 공유할 때, 원 PR이 머지된 뒤 도착하는 CI-완료 웹훅(check_suite/workflow_run/status)의 GitHub `pull_requests[]`에서 머지된 PR이 빠진다(GitHub 자체 동작 — 머지된 PR은 "그 SHA의 현재 head"가 아니므로). 그래서 `_extract_pr_ci`가 그 페이로드에서 뽑는 pr_number는 원 PR이 아니라 **형제 PR**을 가리킨다. 2/2 실물 확認:
- #3350(github_check_run_sha=`988537d6...`) → 지금 그 SHA는 형제 PR **#3352**가 물고 있음.
- #3307(github_check_run_sha=`c5939bead9...`) → 지금 그 SHA는 형제 PR **#3331**이 물고 있음.

## 처방(PO 판정)
CI verdict는 PR이 아니라 **SHA의 속성**이다 — pr_number 경로가 못 찾으면 `org+github_check_run_sha`로만(story 무관) 찾는 SHA 폴백을 추가한다.
- 일치가 여럿(형제 PR 각자의 게이트)이면 **전부** 갱신 — 같은 SHA의 CI 결과는 사실 그 자체로 공유되는 것.
- **ci_result만** 갱신 — `pr_result`(머지/클로즈 여부, PR별 사실)는 각 게이트의 기존 값을 그대로 보존(`evaluate_merge_gate`의 `pr_result`는 무조건부 덮어쓰기라 `None`을 넘기면 지워지는 landmine — 명시로 읽어 되돌려 넣음).
- 관측(AC2): 폴백 발동 시 info 로그(매치 건수), pr_number 경로도 SHA 폴백도 둘 다 못 찾으면 warning("이 CI 신호가 어떤 게이트에도 안 닿았다"가 조용히 묻히지 않게).
- 반환 계약은 하위 호환 유지(`MergeGateDecision | None`, 기존 realdb 테스트 7개 파일 무변경) — 폴백이 갱신한 형제 게이트는 옵션 `gate_check_publish` outparam으로만 노출(각 형제 자신의 pr_number/repo로 큐잉 — 웹훅 자신의 pr_number는 그 형제 중 하나만 가리켜 잘못된 PR에 check-run을 발행할 위험이 있었음).

## 변경
- `gate_service.py`: `find_pending_merge_gates_by_head_sha` 신규(org+SHA+status IN(pending,auto_passed)만, rejected/voided/held 제외 — 사람이 이미 결정한 걸 CI 이벤트로 재오픈 금지).
- `merge_verdict_gate.py`: `reconcile_merge_gate_with_real_evidence`에 폴백 배선.
- `verdict_capture.py`: `gate_check_publish`를 reconcile 호출에 그대로 관통.

## 검증
신규 5종 전부 mutation 검증:
- pr_result 보존 로직 제거 → 정확히 FAIL(evaluate_merge_gate 호출 인자를 스파이로 대조).
- pr_number-우선/SHA-스킵 조건 제거 → 정확히 FAIL(폴백 조회 자체가 호출 안 됨을 스파이로 대조).
- status 필터(pending/auto_passed만) 완화 → 정확히 FAIL(approved 게이트가 새 매치에 섞임).
- 각각 복원 후 재green 확認.

⚠️검증 방법론 부기: `gate.neutral_facts`(JSONB)는 게이트 **생성 시점 1회**만 채워지고(`create_gate`의 멱등 반환 분기가 기존 게이트를 재기록 안 함) 이후 재평가는 별도 컬럼(`decision_basis`/`requires_human` 등)만 갱신한다는 걸 테스트 작성 중 실측으로 발견 — 처음 짠 "neutral_facts로 ci_result 갱신 확認" 테스트가 정상 코드에서도 실패해 이 사실을 적발했고, `evaluate_merge_gate` 호출 인자를 직접 대조하는 방식으로 재설계했다.

인접 gate/verdict realdb 회귀(test_2156/#2520/#2853/#2893×2/bot_l1_pr_story_link) 65/65 green.

CI 초록 확인 부탁하는. 머지는 통상 관례대로 위임.