### PR TITLE
[SID:3035] evaluate_merge_gate 기본값 pr_result="pass" — 근거없는 낙관 확定 제거

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -538,9 +538,19 @@ async def _process_webhook_event(
             # 나중 쪽은 기존 gate를 그대로 반환) — 별도 dedup 로직 불필요.
             from app.services.merge_verdict_gate import evaluate_merge_gate as _evaluate_merge_gate
 
+            # story #3035(2026-08-24, 카디르+codex QA #3456 부수발견, PO 판정) — 이 분기
+            # 자체가 pull_request 라이프사이클 이벤트(opened/reopened/ready_for_review/
+            # synchronize) 전용이다(위 바깥 if의 pr_action 조건) — merge closed 이벤트는
+            # 함수 앞부분에서 이미 별도로 처리된다. 즉 이 시점에 PR은 **구조적으로 아직
+            # 안 머지된 상태**인데, `pr_result`를 생략하면 `evaluate_merge_gate`의 기본값
+            # "pass"가 그대로 게이트 생성 시점(neutral_facts)에 낙관적으로 확定돼 버렸다
+            # — #3033(SHA 폴백)이 세운 규율과 동일: 모름/아직-아님을 "pass"로 위조하지
+            # 않는다. 여기선 실제로 "미머지"를 안다(이벤트 종류 자체가 증거)면서도 기본값이
+            # "머지됨"을 지어내던 landmine이라 #3033보다 더 명백한 오류 — 명시로 None을
+            # 넘겨 `_decide()`가 AUTO_MERGE(pr=="pass" 요건)를 잘못 통과시키지 않게 한다.
             decision = await _evaluate_merge_gate(
                 session, org_id, story_id,
-                pr_number=pr_number, repo=repo, ci_result=None, head_sha=head_sha,
+                pr_number=pr_number, repo=repo, ci_result=None, pr_result=None, head_sha=head_sha,
             )
             if decision.gate_id is not None:
                 gate_check_publish.append({

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -902,10 +902,20 @@ async def trigger_gate_creation_for_late_participation(
                 if not head_sha:
                     continue
                 ci_result, _reason = await fetch_status_check_rollup(link.repo_full_name, head_sha, token)
+                # story #3035(2026-08-24, #3033 QA 부수발견 — verdict_capture.py:541과 형제
+                # 결함) — 바로 위에서 GitHub REST로 이 PR의 실 `merged` 상태를 이미 받아왔는데
+                # (head_sha 추출에만 쓰고) 여기 안 넘겼다 — `evaluate_merge_gate`가 그래서
+                # 기본값 "pass"로 낙관적 확定(아직 안 머지된 PR도 "머지됨"으로 게이트 생성
+                # 시점에 고정)했다. 이미 아는 사실을 던져버리고 근거없는 기본값으로 대체하던
+                # landmine — #3033과 동일 원칙(모름/아직-아님을 pass로 위조 안 함) 그대로
+                # 명시 배선. merged=False(아직 열려 있거나 머지 없이 닫힘)는 "실패"가 아니라
+                # 중립(None)으로 — 다른 웹훅 경로(`reconcile_merge_gate_with_real_evidence`
+                # 등)와 동일 관례.
+                merged = bool(pr.get("merged"))
                 await evaluate_merge_gate(
                     session, org_id, story_id,
                     pr_number=link.pr_number, repo=link.repo_full_name,
-                    ci_result=ci_result, head_sha=head_sha,
+                    ci_result=ci_result, pr_result=("pass" if merged else None), head_sha=head_sha,
                 )
         except Exception:  # noqa: BLE001 — 이 링크만 실패 처리(SAVEPOINT 롤백), 다른 링크·호출자 세션엔 무영향.
             logger.warning(

--- a/backend/tests/test_2156_merge_gate_evidence_realdb.py
+++ b/backend/tests/test_2156_merge_gate_evidence_realdb.py
@@ -569,9 +569,11 @@ async def test_gate_check_publish_fires_on_base_retarget_edit_when_story_linked(
             gate_check_publish=gate_check_publish, ungated_check_publish=[],
         )
 
+    # story #3035(2026-08-24) — 이 late-gate-creation 분기가 pr_result를 명시로 None
+    # 넘기도록 정정됐다(과거엔 생략→evaluate_merge_gate 기본값 "pass"가 낙관적으로 확定).
     evaluate.assert_awaited_once_with(
         session, org_id, story_id, pr_number=42, repo="moonklabs/sprintable",
-        ci_result=None, head_sha="newsha123",
+        ci_result=None, pr_result=None, head_sha="newsha123",
     )
     assert gate_check_publish == [{
         "org_id": org_id, "gate_id": gate_id, "head_sha": "newsha123",

--- a/backend/tests/test_3035_late_participation_pr_result_explicit_realdb.py
+++ b/backend/tests/test_3035_late_participation_pr_result_explicit_realdb.py
@@ -1,0 +1,204 @@
+"""story #3035(2026-08-24, 카디르+codex QA #3456 부수발견, PO 판정) — `evaluate_merge_gate`
+호출부 2곳이 `pr_result`를 생략해 함수 기본값 `"pass"`가 그대로 게이트 생성 시점(neutral_facts
+스냅샷)에 낙관적으로 확定됐다. #3033(SHA 폴백)이 세운 규율과 동일: 모름/아직-아님을 "pass"로
+위조하지 않는다.
+
+①`merge_verdict_gate.py::trigger_gate_creation_for_late_participation` — GitHub REST로 PR의
+실 `merged` 상태를 이미 받아왔는데(head_sha 추출에만 쓰고) `evaluate_merge_gate` 호출엔 안
+넘겨 이미 아는 사실을 던져버리던 landmine(#3033 QA가 원 지목한 verdict_capture.py:541과
+형제 결함, 이 파일 작업 중 발견 즉시 동반수정 — feedback_fix_on_sight 팀 관례).
+②`verdict_capture.py::_process_webhook_event`의 late-gate-creation else 분기(#2826 처방) —
+이 분기 자체가 `pull_request` 라이프사이클 이벤트(opened/reopened/ready_for_review/
+synchronize) 전용이라 PR은 **구조적으로 아직 안 머지된 상태**인데 기본값이 "머지됨"을
+지어냈다(가장 명백한 인스턴스 — #3033보다 원인이 더 뚜렷하다).
+
+둘 다 `evaluate_merge_gate`를 모킹해 **호출 인자**를 직접 대조한다(#3033과 동일 방법론 —
+`neutral_facts`가 생성 시점 1회만 채워지는 실측 함정을 재확認할 필요 없이, "무엇을 넘기는지"가
+이 fix의 전부)."""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.test_2893_gate_pr_scoped_isolation_realdb import (
+    _post_app,
+    _seed_installation,
+    _seed_link,
+    _session_factory,
+)
+from tests.test_2893_pr4_late_participation_gate_creation_realdb import (
+    _seed_org_project_story_no_role,
+)
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_late_participation_hook_passes_pass_when_github_confirms_merged_realdb():
+    """실 merged=True를 GitHub REST가 확認하면 그대로 "pass"를 넘긴다(모름이 아니라 진짜
+    아는 경우 — 이 fix가 "항상 None"이 아니라 "아는 값을 정직하게" 전달함을 증명하는 양성대조)."""
+    from app.services.participation_helpers import ensure_implementation_participation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story_no_role(s)
+            await _seed_installation(s, org, installation_id=690801)
+            await _seed_link(s, org, story, pr_number=801)
+            story_id = story.id
+
+        captured: list[dict] = []
+
+        async def _spy_evaluate(session_arg, org_id_arg, work_item_id_arg, **kwargs):
+            captured.append(kwargs)
+            return SimpleNamespace(gate_id=uuid.uuid4())
+
+        async with Session() as s:
+            with (
+                patch("app.services.github_app.get_installation_token", AsyncMock(return_value="inst-tok")),
+                patch(
+                    "app.services.github_app.get_pull_request",
+                    AsyncMock(return_value={"head": {"sha": "sha-801"}, "merged": True}),
+                ),
+                patch(
+                    "app.services.verdict_capture.fetch_status_check_rollup",
+                    AsyncMock(return_value=("success", None)),
+                ),
+                patch("app.services.merge_verdict_gate.evaluate_merge_gate", _spy_evaluate),
+            ):
+                ok = await ensure_implementation_participation(s, org.id, story_id, uuid.uuid4())
+                await s.commit()
+        assert ok is True
+
+        assert len(captured) == 1
+        assert captured[0]["pr_result"] == "pass", "GitHub이 merged=True로 확認했으면 그대로 pass를 넘겨야 함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_late_participation_hook_never_claims_pass_when_not_merged_realdb():
+    """⭐핵심 — GitHub REST가 merged=False(아직 열려 있음)를 확認했는데도, 최초 버전은 그
+    사실을 던져버리고 `evaluate_merge_gate` 기본값 "pass"를 그대로 썼다. 명시로 None을
+    넘겨야 한다(merged=False는 "실패"도 아니다 — 중립)."""
+    from app.services.participation_helpers import ensure_implementation_participation
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story_no_role(s)
+            await _seed_installation(s, org, installation_id=690802)
+            await _seed_link(s, org, story, pr_number=802)
+            story_id = story.id
+
+        captured: list[dict] = []
+
+        async def _spy_evaluate(session_arg, org_id_arg, work_item_id_arg, **kwargs):
+            captured.append(kwargs)
+            return SimpleNamespace(gate_id=uuid.uuid4())
+
+        async with Session() as s:
+            with (
+                patch("app.services.github_app.get_installation_token", AsyncMock(return_value="inst-tok")),
+                patch(
+                    "app.services.github_app.get_pull_request",
+                    AsyncMock(return_value={"head": {"sha": "sha-802"}, "merged": False}),
+                ),
+                patch(
+                    "app.services.verdict_capture.fetch_status_check_rollup",
+                    AsyncMock(return_value=("success", None)),
+                ),
+                patch("app.services.merge_verdict_gate.evaluate_merge_gate", _spy_evaluate),
+            ):
+                ok = await ensure_implementation_participation(s, org.id, story_id, uuid.uuid4())
+                await s.commit()
+        assert ok is True
+
+        assert len(captured) == 1
+        assert captured[0]["pr_result"] is None, (
+            "merged=False(아직 안 머지됨)를 pass로 위조하면 안 됨 — 근거없는 낙관 확定 landmine"
+        )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_webhook_lifecycle_late_gate_creation_never_claims_pass_realdb():
+    """⭐verdict_capture.py:541 원 지목 지점 — `pull_request.opened`(구조적으로 아직 안
+    머지된 라이프사이클 이벤트)가 late-gate-creation(#2826 처방, else 분기)을 태울 때
+    `evaluate_merge_gate`에 pr_result를 명시로 None 전달해야 한다(과거엔 생략→기본값
+    "pass")."""
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story_no_role(s)
+            await _seed_installation(s, org, installation_id=690803)
+            story_id = story.id
+
+            # 이 분기(#2826 처방)는 "story 링크는 해소됐는데 게이트가 아직 없다"가 전제 —
+            # PullRequestStoryLink를 먼저 심어 opened 웹훅의 resolver가 story를 찾게 한다.
+            await _seed_link(s, org, story, pr_number=803)
+
+            # implementation participation도 필요(없으면 evaluate_merge_gate가 그 전에
+            # "no implementation participation"으로 조기반환 — pr_result를 볼 일도 없음).
+            from app.models.participation import Participation, ParticipationRole
+            from sqlalchemy import select
+
+            role = (
+                await s.execute(
+                    select(ParticipationRole).where(
+                        ParticipationRole.org_id == org.id, ParticipationRole.is_default.is_(True),
+                    )
+                )
+            ).scalar_one()
+            s.add(Participation(
+                id=uuid.uuid4(), org_id=org.id, story_id=story_id, role_id=role.id, member_id=uuid.uuid4(),
+            ))
+            await s.commit()
+
+        captured: list[dict] = []
+
+        async def _spy_evaluate(session_arg, org_id_arg, work_item_id_arg, **kwargs):
+            captured.append(kwargs)
+            return SimpleNamespace(gate_id=uuid.uuid4())
+
+        payload = {
+            "action": "opened",
+            "repository": {"full_name": "moonklabs/sprintable"},
+            "installation": {"id": 690803},
+            "pull_request": {
+                "number": 803, "title": "chore: unrelated", "body": "", "merged": False,
+                "head": {"sha": "sha-803", "ref": "feat-branch-803"},
+                "labels": [],
+            },
+        }
+        async with Session() as s:
+            with (
+                patch("app.services.merge_verdict_gate.evaluate_merge_gate", _spy_evaluate),
+                patch("app.core.database.async_session_factory", Session),
+            ):
+                await _post_app(payload, Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}")
+
+        assert len(captured) == 1, f"late-gate-creation 분기의 evaluate_merge_gate가 정확히 1회 불려야 함(실제: {captured})"
+        assert captured[0]["pr_result"] is None, (
+            "opened(구조적으로 미머지) 이벤트가 pr_result를 생략해 기본값 pass를 쓰면 안 됨"
+        )
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
[SID:3035]

## 배경
#3033(SHA 폴백) 카디르+codex QA(PR#3456)에서 소스 확認으로 부수 발견: `evaluate_merge_gate(pr_result: str | None = "pass")`의 기본값을 생략한 호출부가 그대로 이 값을 써, 미확定 PR을 "머지됨"으로 게이트 **생성 시점**(neutral_facts 스냅샷)에 낙관적으로 확定하고 있었다. #3033이 세운 규율과 동일: 모름/아직-아님을 "pass"로 위조하지 않는다.

## 처방 — 두 호출부
①**`verdict_capture.py:541`**(late-gate-creation, #2826 처방, 카디르 원 지목 지점) — 이 분기 자체가 `pull_request` 라이프사이클 이벤트(opened/reopened/ready_for_review/synchronize) 전용이라 PR은 **구조적으로 아직 안 머지된 상태**(merge closed 이벤트는 함수 앞부분에서 이미 별도 처리) — 명시로 `pr_result=None`.

②**`merge_verdict_gate.py:905`**(`trigger_gate_creation_for_late_participation`, 작업 중 발견 즉시 동반수정 — 팀 관례) — 이 함수는 GitHub REST(`get_pull_request`)로 PR의 실 `merged` 상태를 이미 받아왔는데(`head_sha` 추출에만 쓰고) `evaluate_merge_gate` 호출엔 안 넘겨 아는 사실을 던져버리던 형제 결함(①보다 더 명백 — 이미 아는 답을 버리고 기본값으로 대체). `merged = bool(pr.get("merged"))`를 명시 배선(`"pass" if merged else None` — 다른 웹훅 경로와 동일 관례, merged=False는 "실패"가 아니라 중립).

## 부수 수정
기존 pre-existing 테스트 1건(`test_2156_merge_gate_evidence_realdb.py::test_gate_check_publish_fires_on_base_retarget_edit_when_story_linked`)이 옛 call 시그니처(`pr_result` 생략)를 `assert_awaited_with`로 고정하고 있어 새 시그니처(`pr_result=None` 명시)로 갱신.

## 검증
신규 3종 전부 mutation 검증:
- late-participation 훅, `merged=True` → `pr_result="pass"`(양성대조 — "항상 None"이 아니라 "아는 값을 정직하게" 전달함을 증명).
- late-participation 훅, `merged=False` → `pr_result=None`(핵심 — 기존엔 여기서 기본값 "pass"로 샜음).
- webhook lifecycle `opened` 이벤트 → `pr_result=None`(카디르 원 지목 지점).

각각 배선 제거 mutation → 정확히 FAIL(`KeyError: 'pr_result'`, 생략으로 되돌아감) → 복원 후 재green.

인접 gate/verdict 회귀(test_2156/#2520/#2853/#2893×3/bot_l1_pr_story_link/신규) 70/70 green.

CI 초록 확인 부탁하는. 머지는 통상 관례대로 위임.