### PR TITLE
[SID:3023] verify:i18n-keys stripComments — 정규식 리터럴 속 백틱 오탐 근본수정

### DIFF
--- a/scripts/check-i18n-keys.js
+++ b/scripts/check-i18n-keys.js
@@ -76,10 +76,28 @@ function escapeRegExp(s) {
  * 눈에 띄었다 — AC9-c와 같은 교훈: 놀란 수가 나오면 자리부터 볼 게 아니라 자부터 본다).
  * 문자열/템플릿 리터럴 내용은 보존하고 `//`·`/* *\/` 주석만 제거한다.
  */
+// story #3023(카디르 QA #3445 근본추적) — 정규식 리터럴 안의 백틱을 아래 backtick 분기가
+// 문자열 델리미터로 오인하면, 짝이 안 맞는(홀수 개) 백틱을 담은 정규식(예:
+// `INLINE_CODE_SPAN_RE = /`[^`\n]*`/g`처럼 백틱 자체를 매칭하는 패턴 — story-detail-
+// panel.tsx L144 실측)이 그 뒤 남은 파일 전체를 "닫히지 않은 문자열 안"으로 착각시켜,
+// 그 이후의 진짜 `//` 주석이 전부 인식을 놓친다(실제로 지금까지 벌어진 CI 오탐의 원인).
+// '/' 직전의 마지막 유의미 문자가 이 목록에 있을 때만(정규식 리터럴이 실제로 오는 흔한
+// 문맥 — `= /../`, `(/../`, `, /../` 등) 정규식으로 판별해 안쪽을 통째로(백틱·따옴표
+// 델리미터 취급 없이) 건너뛴다. 일부러 좁게(allowlist) 잡았다 — `<`(JSX 닫는 태그
+// `</div>`)처럼 정규식이 아닌데 '/' 앞에 오는 문맥까지 넓히면 JSX가 널린 .tsx 전체에서
+// 새로운 오탐을 만든다. `return /regex/` 류(직전이 식별자 끝 문자라 division 취급되는
+// 소수 케이스)는 이 좁은 스코프 밖(story AC 범위 — 알려진 한계로 남김).
+const REGEX_LITERAL_CONTEXT_CHARS = new Set(['=', '(', ',', ':', ';', '!', '&', '|', '?', '[']);
+
 function stripComments(source) {
   let out = '';
   let i = 0;
   const n = source.length;
+  let lastSig = ''; // 마지막으로 출력한 공백 아닌 문자(정규식 vs 나눗셈 판별용).
+  const emit = (ch) => {
+    out += ch;
+    if (!/\s/.test(ch)) lastSig = ch;
+  };
   while (i < n) {
     const c = source[i];
     const c2 = source[i + 1];
@@ -93,29 +111,48 @@ function stripComments(source) {
       i += 2;
       continue;
     }
+    if (c === '/' && c2 !== '/' && c2 !== '*' && REGEX_LITERAL_CONTEXT_CHARS.has(lastSig)) {
+      let j = i + 1;
+      let inClass = false;
+      let closed = false;
+      while (j < n && source[j] !== '\n') {
+        if (source[j] === '\\') { j += 2; continue; }
+        if (source[j] === '[') { inClass = true; j++; continue; }
+        if (source[j] === ']') { inClass = false; j++; continue; }
+        if (source[j] === '/' && !inClass) { j++; closed = true; break; }
+        j++;
+      }
+      if (closed) {
+        while (j < n && /[a-z]/i.test(source[j])) j++; // 플래그(g/i/m/s/u/y 등) 소비.
+        for (let k = i; k < j; k++) emit(source[k]);
+        i = j;
+        continue;
+      }
+      // 줄 끝까지 닫는 '/'를 못 찾으면 정규식이 아니었다(오판) — 아래 일반 처리로 폴백.
+    }
     if (c === '"' || c === "'") {
       const quote = c;
-      out += c; i++;
+      emit(c); i++;
       while (i < n && source[i] !== quote) {
-        if (source[i] === '\\') { out += source[i]; i++; if (i < n) { out += source[i]; i++; } continue; }
-        out += source[i]; i++;
+        if (source[i] === '\\') { emit(source[i]); i++; if (i < n) { emit(source[i]); i++; } continue; }
+        emit(source[i]); i++;
       }
-      if (i < n) { out += source[i]; i++; }
+      if (i < n) { emit(source[i]); i++; }
       continue;
     }
     if (c === '`') {
-      out += c; i++;
+      emit(c); i++;
       let depth = 0;
       while (i < n) {
-        if (source[i] === '\\') { out += source[i]; i++; if (i < n) { out += source[i]; i++; } continue; }
-        if (source[i] === '`' && depth === 0) { out += source[i]; i++; break; }
-        if (source[i] === '$' && source[i + 1] === '{') { depth++; out += source[i] + source[i + 1]; i += 2; continue; }
-        if (source[i] === '}' && depth > 0) { depth--; out += source[i]; i++; continue; }
-        out += source[i]; i++;
+        if (source[i] === '\\') { emit(source[i]); i++; if (i < n) { emit(source[i]); i++; } continue; }
+        if (source[i] === '`' && depth === 0) { emit(source[i]); i++; break; }
+        if (source[i] === '$' && source[i + 1] === '{') { depth++; emit(source[i]); emit(source[i + 1]); i += 2; continue; }
+        if (source[i] === '}' && depth > 0) { depth--; emit(source[i]); i++; continue; }
+        emit(source[i]); i++;
       }
       continue;
     }
-    out += c; i++;
+    emit(c); i++;
   }
   return out;
 }

--- a/scripts/check-i18n-keys.test.js
+++ b/scripts/check-i18n-keys.test.js
@@ -41,6 +41,49 @@ describe('stripComments — ㉤ 주석 안 예시코드를 실호출로 오인�
     expect(stripped).not.toContain("t('title')");
     expect(stripped).toContain("useTranslations('inbox')");
   });
+
+  // story #3023(카디르 QA #3445 근본추적) — 정규식 리터럴 안의 백틱(짝이 안 맞는 홀수 개)을
+  // backtick 분기가 문자열 델리미터로 오인해, 그 뒤 남은 파일 전체가 "닫히지 않은 문자열
+  // 안"으로 착각되던 결함. story-detail-panel.tsx L144(INLINE_CODE_SPAN_RE) 실제 레포 라인
+  // 그대로 재현.
+  describe('regex 리터럴 안의 백틱 — 정규식 리터럴을 문자열로 오인해 이후 주석 인식이 깨지지 않는다', () => {
+    it('짝이 안 맞는(홀수 개) 백틱을 담은 정규식 리터럴 뒤의 진짜 //주석이 여전히 스트립된다', () => {
+      // 원 repro(story-detail-panel.tsx L143-144 그대로): 이 두 정규식 정의가 있으면
+      // 예전 코드는 이 지점부터 "문자열 안"으로 착각해 뒤이은 실 주석을 못 걷었다.
+      const src = [
+        'const FENCED_CODE_BLOCK_RE = /```[\\s\\S]*?```/g;',
+        'const INLINE_CODE_SPAN_RE = /`[^`\\n]*`/g;',
+        '',
+        "// t('workcellDodMissing') 은 예시일 뿐 실호출 아님",
+        "const t2 = useTranslations('workcell');",
+      ].join('\n');
+      const stripped = stripComments(src);
+      expect(stripped).not.toContain("t('workcellDodMissing')");
+      expect(stripped).toContain("useTranslations('workcell')");
+    });
+
+    it('정규식 리터럴 자체의 내용(백틱 포함)은 그대로 보존한다(verbatim — 정규식 훼손 없음)', () => {
+      const src = 'const RE = /`[^`\\n]*`/g;';
+      expect(stripComments(src)).toBe(src);
+    });
+
+    it('JSX 닫는 태그(</div> 등 "/" 문자)가 정규식으로 오인돼 뒤 내용을 삼키지 않는다(회귀 0)', () => {
+      // 한 줄에 "/" 가 여럿(자체닫힘·닫는태그) 있어도 JSX는 정규식 판별 문맥(직전이
+      // "="/"("/"," 등)에 안 걸려야 한다 — 아니면 JSX가 흔한 .tsx 전체에 새 오탐이 생긴다.
+      const src = '<span>a</span> <b>c</b>\n// real comment after jsx\nconst t = useTranslations("foo");';
+      const stripped = stripComments(src);
+      expect(stripped).toContain('<span>a</span> <b>c</b>');
+      expect(stripped).not.toContain('// real comment after jsx');
+      expect(stripped).toContain('useTranslations("foo")');
+    });
+
+    it('나눗셈(division)은 여전히 정규식으로 오인되지 않는다(회귀 0)', () => {
+      const src = 'const half = total / 2; // 주석';
+      const stripped = stripComments(src);
+      expect(stripped).toContain('total / 2');
+      expect(stripped).not.toContain('주석');
+    });
+  });
 });
 
 describe('isDynamicallyComposed — AC4 화이트리스트, AC5 양성대조', () => {


### PR DESCRIPTION
## 요약
카디르 #3445 QA 근본 추적(2026-08-24) — 이전엔 #3445 자체를 story-detail-panel.tsx 주석 재작성으로 회피했을 뿐(head `6c88b2ef3` 커밋 메시지에 "stripComments() 자체의 결함은 이 PR 스코프 밖 — 별도 부채로 등재됨" 명기), 근본원인인 `stripComments()`는 그대로였다. 이 PR이 그 근본원인을 고친다.

## 근본원인(실측으로 정확히 특정)
`stripComments()`의 backtick 분기는 `` ` ``를 "항상 템플릿 리터럴 문자열의 시작"으로 가정한다 — 정규식 리터럴(`/pattern/flags`) 안의 백틱은 문자열 델리미터가 아니라 그냥 매칭 대상 문자인데, 이 함수는 정규식 리터럴이라는 문법 자체를 모른다. `story-detail-panel.tsx` L144 `INLINE_CODE_SPAN_RE = /`[^`\n]*`/g;` — 이 정규식 소스엔 백틱이 **3개**(홀수)라, 두 개씩 짝지어 "닫히는" 가짜 문자열을 두 번 만들고 세 번째 백틱이 열어놓은 "문자열"이 같은 줄에서 안 닫힌다. 그 결과 이 지점부터 파일 끝까지(또는 다음 우연한 백틱까지) "닫히지 않은 문자열 안"으로 착각돼, 그 사이의 진짜 `//` 주석이 전부 인식을 놓친다 — 실제로 이렇게 새어나간 주석 속 `t('workcellDodMissing')` 문자열이 #3445에서 "실 호출"로 오탐됐다(`node -e`로 직접 재현 확인).

## fix — 좁은 스코프(allowlist), JSX 오탐 신규 유입 없음
`/` 직전 마지막 유의미 문자가 `= ( , : ; ! & | ? [` 중 하나일 때만(정규식 리터럴이 실제로 오는 흔한 문맥) 정규식으로 판별해, 닫는 `/`까지(이스케이프·문자클래스 `[...]` 고려) 백틱·따옴표 델리미터 취급 없이 통째로 건너뛴다. 일부러 좁게 잡은 이유 — `<`(JSX 닫는 태그 `</div>`)까지 정규식 문맥으로 넓히면 JSX가 널린 .tsx 전체에 새 오탐 클래스를 만든다(직접 실측 확인 — 아래 검증 참조).

## 변경 파일 — 정확히 2개(전부 수정, `git diff --stat` 실측)
- `scripts/check-i18n-keys.js`(fix)
- `scripts/check-i18n-keys.test.js`(신규 **4건**)

## 검증
- [x] 신규 4건 all green — ①원 repro(정규식 리터럴 뒤 진짜 주석 스트립)·②정규식 리터럴 내용 자체는 verbatim 보존(백틱 포함 훼손 없음)·③JSX `</div>` 등 "/" 밀집 라인 무회귀·④일반 나눗셈(division) 무회귀
- [x] `git stash`로 pre-fix 소스에서 원 repro(①)만 정확히 fail 재현(나머지 3건은 애초에 pre-fix에서도 안 깨졌던 케이스라 그대로 pass — 진짜 회귀가드임을 구분 확인)
- [x] 기존 `stripComments` 테스트 14건 무변경 통과(전체 18/18)
- [x] **실 코드베이스 end-to-end 실행**(`node scripts/check-i18n-keys.js`) — EXIT=0(현재 전체 `apps/web/src` 무결 재확인, 새 오탐 0)
- [x] **AC2 양성대조 실측** — `story-detail-panel.tsx`에 실제 미존재 키 호출(`t('__..._positive_control__')`)을 임시 삽입해 EXIT=1 정확히 재현(missing key 정상 검출) 확인 후 원복 — "정규식/JSX 무해화 fix가 진짜 누락 탐지력을 죽이지 않았다"를 실측으로 증명
- [x] 루트 `vitest run` 전체 — **526 files / 4704 tests all green**

## AC 대조
1. `stripComments`가 템플릿/정규식 리터럴 속 백틱에 안 깨짐 — #3445 케이스 그대로 재현→GREEN.
2. 「주석 속 키 문자열」은 주석 스트립이 정확해져 자동 해결(신규 4건 중 ①이 직접 고정).
3. 양성대조 — 실제 `t()` 호출 누락은 여전히 RED(임시 삽입 실측으로 증명, 위 검증 참조).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_017Y8uNHvGThWG8QPBz1nhFz