### PR TITLE
[SID:2728] 결제 게이트 거부 응답 — 평문 문자열 → 구조화 에러코드(BILLING_NOT_LIVE)

### DIFF
--- a/backend/app/routers/billing_packs.py
+++ b/backend/app/routers/billing_packs.py
@@ -15,7 +15,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.billing_order import BillingOrder
 from app.services.billing_pack import PackPurchaseDeclined, PackPurchaseError, purchase_packs
-from app.services.platform_settings import get_platform_settings
+from app.services.platform_settings import get_platform_settings, require_billing_checkout_enabled
 
 router = APIRouter(prefix="/api/v2/org-subscriptions", tags=["billing", "Organization"])
 
@@ -56,10 +56,10 @@ async def purchase_pack(
     카드 거절은 200+status='failed'(비즈니스 결과) — 502는 Toss API 자체 미도달에만.
 
     story #2728(선생님 결정②) — 팩 구매도 실제 결제 처리라 checkout과 동일 스위치로
-    서버측 전면 차단."""
+    서버측 전면 차단. 카디르 QA(PR#3460) — org_subscription_checkout.py의 6개 진입점과
+    같은 헬퍼(require_billing_checkout_enabled)를 공유해 판정이 갈라지지 않게 한다."""
     platform_settings = await get_platform_settings(session)
-    if not platform_settings.billing_checkout_enabled:
-        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+    require_billing_checkout_enabled(platform_settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 

--- a/backend/app/routers/org_subscription_checkout.py
+++ b/backend/app/routers/org_subscription_checkout.py
@@ -15,7 +15,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id_no_project_gate
 from app.dependencies.database import get_db
 from app.models.org_subscription import OrgSubscription
-from app.models.platform_setting import PlatformSetting
 from app.services.org_subscription_checkout import (
     ActivePaidSubscriptionExists,
     CheckoutDeclined,
@@ -29,22 +28,9 @@ from app.services.org_subscription_tier_change import (
     TierChangeInProgress,
     change_tier,
 )
-from app.services.platform_settings import get_platform_settings
+from app.services.platform_settings import get_platform_settings, require_billing_checkout_enabled
 
 router = APIRouter(prefix="/api/v2/org-subscriptions", tags=["billing", "Organization"])
-
-
-def _require_billing_checkout_enabled(settings: PlatformSetting) -> None:
-    """story #2728(PO 확定, 2026-08-24) — 거부는 403+명시 에러코드로 구조화한다(평문
-    문자열이 아니라 `{"code": ..., "message": ...}`) — 클라이언트가 「기능 비활성」을
-    다른 4xx 사유와 구별 처리할 수 있게(admin_billing.py의 AdminBillingError 응답
-    구조와 동형). 6개 진입점(checkout·change-tier·downgrade 왕복·cancel 왕복)이 전부
-    이 헬퍼 하나로 판정한다 — 판정 로직이 갈라지면 그 자체가 결함이다."""
-    if not settings.billing_checkout_enabled:
-        raise HTTPException(
-            status_code=403,
-            detail={"code": "BILLING_NOT_LIVE", "message": "billing checkout is not yet enabled"},
-        )
 
 
 class CheckoutRequest(BaseModel):
@@ -105,7 +91,7 @@ async def checkout(
     켜야만(sprintable-admin/internal-api 경유) 도달 가능해진다. auth 체크보다 먼저 —
     기능 자체가 꺼진 상태에선 호출자의 org 권한과 무관하게 전원 차단이 정답."""
     settings = await get_platform_settings(session)
-    _require_billing_checkout_enabled(settings)
+    require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 
@@ -156,7 +142,7 @@ async def change_tier_endpoint(
     갭 같은 순수 내부 상태 문제뿐이지만, 이쪽은 «잘못된 대상 tier 선택»이 호출자가 고칠
     수 있는 흔한 경로다)."""
     settings = await get_platform_settings(session)
-    _require_billing_checkout_enabled(settings)
+    require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 
@@ -189,7 +175,7 @@ async def reserve_downgrade_endpoint(
     이 엔드포인트의 정상 사용 — 재호출=재예약). 응답의 `pending_tier`/
     `pending_change_apply_at`이 예약 상태를 노출한다."""
     settings = await get_platform_settings(session)
-    _require_billing_checkout_enabled(settings)
+    require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 
@@ -215,7 +201,7 @@ async def cancel_downgrade_endpoint(
     """story #2881 — 예약 철회(재상향 아닌 단순 취소). pending_*만 클리어, 구독 원
     tier는 무변화."""
     settings = await get_platform_settings(session)
-    _require_billing_checkout_enabled(settings)
+    require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 
@@ -243,7 +229,7 @@ async def cancel_subscription_endpoint(
     (v2.1 §12). 좌석 게이트는 타지 않는다(해지 의사는 좌석 초과를 이유로 거부하지
     않는다 — `org_subscription_downgrade.cancel_subscription` docstring 참고)."""
     settings = await get_platform_settings(session)
-    _require_billing_checkout_enabled(settings)
+    require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 
@@ -270,7 +256,7 @@ async def revoke_cancellation_endpoint(
     `cancel_pending_downgrade`를 그대로 재사용(재구현 0) — 예약된 게 하향이든
     취소(free)든 pending_*만 클리어하는 동작은 동일하다."""
     settings = await get_platform_settings(session)
-    _require_billing_checkout_enabled(settings)
+    require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 

--- a/backend/app/routers/org_subscription_checkout.py
+++ b/backend/app/routers/org_subscription_checkout.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id_no_project_gate
 from app.dependencies.database import get_db
 from app.models.org_subscription import OrgSubscription
+from app.models.platform_setting import PlatformSetting
 from app.services.org_subscription_checkout import (
     ActivePaidSubscriptionExists,
     CheckoutDeclined,
@@ -31,6 +32,19 @@ from app.services.org_subscription_tier_change import (
 from app.services.platform_settings import get_platform_settings
 
 router = APIRouter(prefix="/api/v2/org-subscriptions", tags=["billing", "Organization"])
+
+
+def _require_billing_checkout_enabled(settings: PlatformSetting) -> None:
+    """story #2728(PO 확定, 2026-08-24) — 거부는 403+명시 에러코드로 구조화한다(평문
+    문자열이 아니라 `{"code": ..., "message": ...}`) — 클라이언트가 「기능 비활성」을
+    다른 4xx 사유와 구별 처리할 수 있게(admin_billing.py의 AdminBillingError 응답
+    구조와 동형). 6개 진입점(checkout·change-tier·downgrade 왕복·cancel 왕복)이 전부
+    이 헬퍼 하나로 판정한다 — 판정 로직이 갈라지면 그 자체가 결함이다."""
+    if not settings.billing_checkout_enabled:
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "BILLING_NOT_LIVE", "message": "billing checkout is not yet enabled"},
+        )
 
 
 class CheckoutRequest(BaseModel):
@@ -91,8 +105,7 @@ async def checkout(
     켜야만(sprintable-admin/internal-api 경유) 도달 가능해진다. auth 체크보다 먼저 —
     기능 자체가 꺼진 상태에선 호출자의 org 권한과 무관하게 전원 차단이 정답."""
     settings = await get_platform_settings(session)
-    if not settings.billing_checkout_enabled:
-        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+    _require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 
@@ -143,8 +156,7 @@ async def change_tier_endpoint(
     갭 같은 순수 내부 상태 문제뿐이지만, 이쪽은 «잘못된 대상 tier 선택»이 호출자가 고칠
     수 있는 흔한 경로다)."""
     settings = await get_platform_settings(session)
-    if not settings.billing_checkout_enabled:
-        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+    _require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 
@@ -177,8 +189,7 @@ async def reserve_downgrade_endpoint(
     이 엔드포인트의 정상 사용 — 재호출=재예약). 응답의 `pending_tier`/
     `pending_change_apply_at`이 예약 상태를 노출한다."""
     settings = await get_platform_settings(session)
-    if not settings.billing_checkout_enabled:
-        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+    _require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 
@@ -204,8 +215,7 @@ async def cancel_downgrade_endpoint(
     """story #2881 — 예약 철회(재상향 아닌 단순 취소). pending_*만 클리어, 구독 원
     tier는 무변화."""
     settings = await get_platform_settings(session)
-    if not settings.billing_checkout_enabled:
-        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+    _require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 
@@ -233,8 +243,7 @@ async def cancel_subscription_endpoint(
     (v2.1 §12). 좌석 게이트는 타지 않는다(해지 의사는 좌석 초과를 이유로 거부하지
     않는다 — `org_subscription_downgrade.cancel_subscription` docstring 참고)."""
     settings = await get_platform_settings(session)
-    if not settings.billing_checkout_enabled:
-        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+    _require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 
@@ -261,8 +270,7 @@ async def revoke_cancellation_endpoint(
     `cancel_pending_downgrade`를 그대로 재사용(재구현 0) — 예약된 게 하향이든
     취소(free)든 pending_*만 클리어하는 동작은 동일하다."""
     settings = await get_platform_settings(session)
-    if not settings.billing_checkout_enabled:
-        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+    _require_billing_checkout_enabled(settings)
 
     from app.services.project_auth import is_org_owner_or_admin
 

--- a/backend/app/services/platform_settings.py
+++ b/backend/app/services/platform_settings.py
@@ -1,10 +1,11 @@
-"""story #2728(P0·과금) — platform_settings 싱글턴 조회.
+"""story #2728(P0·과금) — platform_settings 싱글턴 조회 + 결제 게이팅 판정.
 
 이 테이블은 정확히 1행(마이그 0255가 고정 id로 시드)만 갖는다는 게 설계 불변식 — 애플리케이션
 코드는 이 헬퍼로만 읽고, 새 행을 만들지 않는다(mutation은 sprintable-admin/internal-api 전용,
 app/models/platform_setting.py 모듈 docstring 참고)."""
 from __future__ import annotations
 
+from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,3 +22,24 @@ async def get_platform_settings(session: AsyncSession) -> PlatformSetting:
             "platform_settings 테이블에 행이 없음 — migration 0255 미적용 또는 삭제됨"
         )
     return row
+
+
+def require_billing_checkout_enabled(settings: PlatformSetting) -> None:
+    """story #2728(PO 확定, 2026-08-24) — 결제 처리형 엔드포인트 전부가 이 함수 하나로
+    판정한다. 거부는 403+명시 에러코드로 구조화(평문 문자열이 아니라
+    `{"code": "BILLING_NOT_LIVE", "message": ...}`) — 클라이언트가 「기능 비활성」을
+    다른 4xx 사유(org 권한 없음 등)와 구별 처리할 수 있게(app/main.py의 전역
+    http_exception_handler가 dict detail의 "code"를 그대로 패스스루 — admin_billing.py의
+    AdminBillingError 응답과 동형).
+
+    카디르 QA(PR#3460) REQUEST_CHANGES — 처음엔 org_subscription_checkout.py 안에만
+    로컬 헬퍼로 뒀는데, 그 파일의 6개 진입점 밖에도 결제 처리형 엔드포인트가 더 있었다
+    (billing_packs.py POST /packs·ee/routers/billing.py POST /checkout(Polar 구세계,
+    EE 환경서 라이브 등록)) — 전부 실측 확認. 「판정이 갈라지면 그 자체가 결함」이라
+    로컬 헬퍼 재복제 대신 이 서비스 모듈로 승격해 3개 라우터 파일이 전부 이 함수
+    하나를 공유한다."""
+    if not settings.billing_checkout_enabled:
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "BILLING_NOT_LIVE", "message": "billing checkout is not yet enabled"},
+        )

--- a/backend/ee/routers/billing.py
+++ b/backend/ee/routers/billing.py
@@ -22,7 +22,7 @@ from app.models.org_subscription import OrgSubscription
 from app.models.pricing_version import PricingVersion
 from app.models.project import OrgMember
 from app.services.payment.factory import get_payment_adapter
-from app.services.platform_settings import get_platform_settings
+from app.services.platform_settings import get_platform_settings, require_billing_checkout_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -152,10 +152,11 @@ async def create_checkout_session(
     """Polar checkout 세션 생성 — owner/admin 전용.
 
     story #2728(선생님 결정②) — 구세계(Polar) checkout도 신세계와 동일하게 서버측 전면
-    차단(org_subscription_checkout.py의 checkout과 동일 근거·동일 스위치)."""
+    차단(org_subscription_checkout.py의 checkout과 동일 근거·동일 스위치). 카디르 QA
+    (PR#3460) — EE 환경서 라이브 등록되는데 이 축 테스트가 0건이었다(실측 적출). 같은
+    헬퍼(require_billing_checkout_enabled)를 공유해 판정이 갈라지지 않게 한다."""
     platform_settings = await get_platform_settings(session)
-    if not platform_settings.billing_checkout_enabled:
-        raise HTTPException(status_code=403, detail="billing checkout is not yet enabled")
+    require_billing_checkout_enabled(platform_settings)
 
     # owner/admin 권한 확인
     role_result = await session.execute(

--- a/backend/tests/test_2728_platform_settings_realdb.py
+++ b/backend/tests/test_2728_platform_settings_realdb.py
@@ -212,6 +212,90 @@ async def test_change_tier_also_rejected_with_same_structured_code():
         await engine.dispose()
 
 
+# ── 카디르 QA(PR#3460) REQUEST_CHANGES — org_subscription_checkout.py의 6개 진입점
+#    밖에도 결제 처리형 엔드포인트가 더 있었다(billing_packs.py·ee/routers/billing.py,
+#    codex ASGI 실측으로 둘 다 error.code=FORBIDDEN 확認済). 같은 헬퍼
+#    (require_billing_checkout_enabled)로 정합하고 각각 응답 shape을 고정한다. ──────
+@pytest.mark.anyio
+async def test_billing_packs_purchase_rejected_with_same_structured_code():
+    """billing_packs.py POST /packs — 상시 등록되는 라이브 라우트(EE 무관). checkout과
+    같은 헬퍼를 공유하는지 응답 shape으로 고정."""
+    from app.main import app
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="2728 Org5", slug=f"s2728e-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            member = Member(id=uuid.uuid4(), org_id=org.id, type="human", name="Owner", is_active=True)
+            s.add(member)
+            await s.commit()
+            s.add(OrgMember(org_id=org.id, user_id=member.id, role="owner"))
+            await s.commit()
+            org_id, member_id = org.id, member.id
+
+        await _setup_app(app, Session, member_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/org-subscriptions/packs",
+                json={"resource": "au", "quantity": 1, "idempotency_key": str(uuid.uuid4())},
+            )
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "BILLING_NOT_LIVE", resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ee_billing_checkout_rejected_with_same_structured_code():
+    """ee/routers/billing.py POST /checkout(Polar 구세계) — EE 환경서 라이브 등록되는
+    라우트인데 이 축 테스트가 0건이었다(카디르 실측 적출). main.py의 EE 라우터 등록이
+    import 시점 `is_ee_enabled` 조건부라(app.main 이미 import된 뒤 몽키패치해도 라우트가
+    소급 등록 안 됨) HTTP 왕복 대신 라우트 함수를 직접 호출한다(_require_ee는 별개
+    관심사라 우회 — 이 테스트는 billing 게이트 하나만 검증)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.dependencies.auth import AuthContext
+    from ee.routers.billing import CheckoutRequest, create_checkout_session
+    from fastapi import HTTPException
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="2728 Org6", slug=f"s2728f-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            member = Member(id=uuid.uuid4(), org_id=org.id, type="human", name="Owner", is_active=True)
+            s.add(member)
+            await s.commit()
+            org_id, member_id = org.id, member.id
+
+            auth = AuthContext(
+                user_id=str(member_id), email="owner@test",
+                claims={"app_metadata": {"org_id": str(org_id)}},
+            )
+            body = CheckoutRequest(plan_id="team", billing_cycle="monthly")
+
+            with pytest.raises(HTTPException) as exc_info:
+                await create_checkout_session(
+                    body=body, org_id=org_id, auth=auth, session=s, _ee=None,
+                )
+            assert exc_info.value.status_code == 403
+            assert exc_info.value.detail == {
+                "code": "BILLING_NOT_LIVE", "message": "billing checkout is not yet enabled",
+            }
+    finally:
+        await engine.dispose()
+
+
 @pytest.mark.anyio
 async def test_toggling_row_directly_takes_effect_next_request_no_cache():
     """③④ 통합 — off→confirmed 403 재현 後, 같은 행을 true로 바꾸고(어드민 PATCH의

--- a/backend/tests/test_2728_platform_settings_realdb.py
+++ b/backend/tests/test_2728_platform_settings_realdb.py
@@ -155,7 +155,56 @@ async def test_checkout_rejected_403_when_disabled_real_db():
                 json={"auth_key": "fake-not-a-real-toss-key", "tier": "team", "billing_cycle": "monthly"},
             )
             assert resp.status_code == 403, resp.text
-            assert "not yet enabled" in resp.text
+            # PO 확定(2026-08-24) — prod 실측(페드루 curl)이 잡은 그대로: 앱 전역
+            # http_exception_handler(app/main.py)가 모든 HTTPException을
+            # {"data":null,"error":{code,message},"meta":null}로 감싼다. detail이
+            # 평문 문자열이면 code가 상태코드 매핑(403→범용 "FORBIDDEN")으로 뭉개져
+            # "기능 비활성"과 "권한 없음"을 클라이언트가 구별 못 했다 — 이게 오늘 fix
+            # 대상. detail을 dict로 주면 그 안의 "code"가 그대로 패스스루된다(핸들러
+            # 로직 확인 완료) — 그래서 BILLING_NOT_LIVE가 최종 응답에 그대로 나와야 한다.
+            body = resp.json()
+            assert body["error"]["code"] == "BILLING_NOT_LIVE", resp.text
+            assert "not yet enabled" in body["error"]["message"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_change_tier_also_rejected_with_same_structured_code():
+    """PO 확定(2026-08-24) — 6개 진입점(checkout·change-tier·downgrade 왕복·cancel 왕복)이
+    전부 같은 헬퍼(_require_billing_checkout_enabled) 하나로 판정해야 한다(「판정 로직이
+    갈라지면 그 자체가 결함」) — checkout이 아닌 다른 진입점(change-tier)도 동일 구조화
+    코드로 거부하는지를 별도로 고정해, 그 주장이 실제로 전 진입점에 적용됐음을 검증한다."""
+    from app.main import app
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="2728 Org4", slug=f"s2728d-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            member = Member(id=uuid.uuid4(), org_id=org.id, type="human", name="Owner", is_active=True)
+            s.add(member)
+            await s.commit()
+            s.add(OrgMember(org_id=org.id, user_id=member.id, role="owner"))
+            await s.commit()
+            org_id, member_id = org.id, member.id
+
+        await _setup_app(app, Session, member_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/org-subscriptions/change-tier",
+                json={"new_tier": "business"},
+            )
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "BILLING_NOT_LIVE", resp.text
         finally:
             await client.aclose()
     finally:


### PR DESCRIPTION
## 요약
그라운딩(2026-08-24) 중 발견 — story #2728(Toss 심사 前 prod 결제표면 차단)은 이미 2026-08-17/18에 대부분 구현·머지 완료된 상태였다(PR#3187 이 repo + PR#31/#34 sprintable-admin repo, 전부 develop/main 머지 확認 — 카디르의 8/18 그라운딩 문서가 그 이전 시점이라 낡아 있었음): `platform_settings` 싱글턴 테이블+공개 read API+FE `IS_PRICE_PUBLIC` 하드코딩 제거+6개 결제 엔드포인트 서버측 게이팅+admin mutation API·UI(별도 repo) 전부 실재.

오늘 PO가 3건 새로 확定(admin 판정=단일함수 `require_operator` 이미 충족·거부코드=403+`BILLING_NOT_LIVE`·설계 1~6 승인)하면서, 페드루가 prod 실측(curl)으로 직접 잡은 정확한 갭 1건만 남았다 — 거부 응답이 `{"error":{"code":"FORBIDDEN","message":"billing checkout is not yet enabled"}}`(범용 코드)라 클라이언트가 "기능 비활성"을 다른 403 사유(org 권한 없음 등)와 구별할 수 없었다.

## fix
`org_subscription_checkout.py`의 6개 진입점(checkout·change-tier·downgrade 왕복·cancel 왕복)에 동일하게 반복되던 `if not settings.billing_checkout_enabled: raise HTTPException(403, detail="...")`(평문 문자열)를 `_require_billing_checkout_enabled()` 헬퍼 하나로 통합 — `detail={"code": "BILLING_NOT_LIVE", "message": "..."}`(dict)로 바꿨다. `app/main.py`의 전역 `http_exception_handler`가 dict detail의 `code`를 그대로 패스스루하는 것을 소스로 확認(`admin_billing.py`의 `AdminBillingError` 응답과 동형 관례) — 판정 로직 자체(게이팅 조건)는 무변경, 응답 구조만 정합.

## 변경 파일 — 정확히 2개(전부 수정)
- `org_subscription_checkout.py`(6곳 → 헬퍼 1개로 통합)
- `test_2728_platform_settings_realdb.py`(기존 테스트 강화 1건 + 신규 1건)

## 검증
- [x] 기존 checkout 거부 테스트 강화 — `resp.json()["error"]["code"] == "BILLING_NOT_LIVE"`로 정확한 최종 응답 shape(전역 핸들러 통과 後)까지 확認(단순 raw detail 아님)
- [x] 신규 1건 — change-tier(checkout이 아닌 다른 진입점)도 동일 구조화 코드로 거부되는지 별도 고정(「6개 진입점이 전부 같은 헬퍼로 판정」 주장을 실측으로 뒷받침)
- [x] `git stash`로 pre-fix 소스에서 신규 2건(강화 포함) 정확히 fail 재현 — 페드루가 잡은 실측(`{"code":"FORBIDDEN",...}`)과 동일 값으로 fail하는 것까지 확인 후 복원
- [x] 로컬 scratch Postgres에 `alembic upgrade head`(0276까지) 적용 후 기존 `test_2728_platform_settings_realdb.py` 4건 + 확장 스위트(`test_e_2506_*`·`test_e_2511_*`·`test_2892_*`·`test_e_2512_*`·`test_e_org_multi_*`·`test_e_2092_*`) **70건 전체 무회귀**
- [x] import/syntax 확認 clean

## AC 대조
1. prod 스위치 off 상태 실측 — 이미 확認됨(오늘 페드루 curl, 기본 false).
2. dev on/off 왕복 — 어드민 UI 경유(별도 repo)로 페드루가 확認 예정(이 PR 스코프 밖).
3. 어드민 관리값 목록화(2개, `billing_price_public`/`billing_checkout_enabled`) — 기존 구현이 이미 정확히 이 2개로 확定(story 본문 재확認).
4. 사람 승인 위조 없음/거부 사유 구별 가능 — 이 fix로 달성.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_017Y8uNHvGThWG8QPBz1nhFz