### PR TITLE
[SID:2530] wake/push 큐 오버플로 시 연결 discard 제거 — ring-buffer로 정정

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -258,14 +258,49 @@ def wake_agent(agent_id: str, seq: int, _from_listener: bool = False) -> None:
     payload = {"__wake__": True, "seq": seq}
     queues = _agent_connections.get(agent_id)
     if queues:
-        dead = []
+        # story #2530(2026-08-24, PO 판정) — 예전엔 QueueFull을 그 큐(연결)를
+        # `_agent_connections`에서 통째로 제거하는 신호로 썼다: 스트림 자체는 안 끊긴 채
+        # ("연결은 살아 보이는" 상태) 이 agent_id로 오는 모든 이후 wake_agent() 호출이
+        # 이 연결을 dict에서 영원히 못 찾아 조용히 no-op — "연결은 살았는데 신호만 죽는"
+        # 반쪽 상태가 코드로 가능했다(#2530 그라운딩에서 발견, 「선생님→에이전트 왕왕
+        # 미도달」과 정합하는 실 후보로 격상). 처방: 큐를 ring-buffer로 다뤄 **가장
+        # 오래된 항목을 버리고 자리를 만들어 이번 신호를 넣는다** — 연결을 절대 dict에서
+        # 지우지 않는다. wake 신호는 "그 seq 하나"가 아니라 "재조회하라"는 트리거일
+        # 뿐이라(recipient_seq 기반 전체 rescan, 이 함수 상단 docstring 참조) 오래된
+        # 신호를 버려도 살아남은 신호가 여전히 전체 catch-up을 끌어낸다 — 연결이
+        # dict에 남아있는 한 "연결이 살아있으면 신호도 언젠가 닿는다"가 코드로 보증된다.
+        # story #2530(2026-08-24, PO 판정) — 예전엔 QueueFull을 그 큐(연결)를
+        # `_agent_connections`에서 통째로 제거하는 신호로 썼다: 스트림 자체는 안 끊긴 채
+        # ("연결은 살아 보이는" 상태) 이 agent_id로 오는 모든 이후 wake_agent() 호출이
+        # 이 연결을 dict에서 영원히 못 찾아 조용히 no-op — "연결은 살았는데 신호만 죽는"
+        # 반쪽 상태가 코드로 가능했다(#2530 그라운딩에서 발견, 「선생님→에이전트 왕왕
+        # 미도달」과 정합하는 실 후보로 격상). 처방: 큐를 ring-buffer로 다뤄 **가장
+        # 오래된 항목을 버리고 자리를 만들어 이번 신호를 넣는다** — 연결을 절대 dict에서
+        # 지우지 않는다. wake 신호는 "그 seq 하나"가 아니라 "재조회하라"는 트리거일
+        # 뿐이라(recipient_seq 기반 전체 rescan, 이 함수 상단 docstring 참조) 오래된
+        # 신호를 버려도 살아남은 신호가 여전히 전체 catch-up을 끌어낸다 — 연결이
+        # dict에 남아있는 한 "연결이 살아있으면 신호도 언젠가 닿는다"가 코드로 보증된다.
         for q in list(queues):
             try:
                 q.put_nowait(payload)
             except asyncio.QueueFull:
-                dead.append(q)
-        for q in dead:
-            queues.discard(q)
+                logger.warning(
+                    "wake_agent: queue full(maxsize=%d) for agent=%s — dropping oldest "
+                    "pending signal to make room (connection kept registered, not discarded)",
+                    q.maxsize, agent_id,
+                )
+                try:
+                    q.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+                try:
+                    q.put_nowait(payload)
+                except asyncio.QueueFull:
+                    # 극단적 경합(드롭 직후 다른 태스크가 그 자리를 먼저 채움) — 이번
+                    # put만 포기한다(무한 재시도 금지). 연결은 여전히 dict에 남아 다음
+                    # wake_agent() 호출이 다시 시도할 것 — "연결 자체가 사라지지 않는다"는
+                    # 불변식만 지키면 충분하다(개별 신호 1건의 일시 유실은 안전, 위 근거).
+                    pass
     if not _from_listener:
         from app.services.pg_pubsub import fire_and_forget
         from app.core.config import settings as _settings

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -181,7 +181,15 @@ def _push_to_agent(member_id: str, payload: dict, _from_listener: bool = False) 
     queues = _agent_connections.get(member_id)
     pushed = False
     if queues:
-        dead: list[asyncio.Queue] = []
+        # story #2530(2026-08-24, agent_gateway.py::wake_agent과 형제 결함·동일 처방) —
+        # 예전엔 QueueFull이 그 큐(연결)를 `_agent_connections`에서 통째로 제거하는
+        # 신호였다: 스트림 자체는 안 끊긴 채("연결은 살아 보이는" 상태) 이 member로 오는
+        # 모든 이후 push가 이 연결을 dict에서 영원히 못 찾아 조용히 no-op되는 반쪽 상태가
+        # 코드로 가능했다. 처방: 큐를 ring-buffer로 다뤄 가장 오래된 항목을 버리고 자리를
+        # 만들어 이번 payload를 넣는다 — 연결을 절대 dict에서 지우지 않는다. A계열(event_id
+        # 有)은 재연결 시 DB backfill로 회수되니 무해·B계열(transient) 1건 유실은 발생할 수
+        # 있으나, 예전처럼 "연결 자체가 사라져 그 뒤 전부 유실"보다는 항상 개선(strict
+        # improvement) — 연결이 dict에 남아있는 한 다음 push부터는 정상 도달한다.
         for q in list(queues):
             try:
                 # story #3029(카디르+codex 발견, #3447 QA) — 이 member의 모든 큐에 **같은
@@ -196,9 +204,22 @@ def _push_to_agent(member_id: str, payload: dict, _from_listener: bool = False) 
                 q.put_nowait(dict(payload))
                 pushed = True
             except asyncio.QueueFull:
-                dead.append(q)
-        for q in dead:
-            queues.discard(q)
+                logger.warning(
+                    "_push_to_agent: queue full(maxsize=%d) for member=%s — dropping oldest "
+                    "pending payload to make room (connection kept registered, not discarded)",
+                    q.maxsize, member_id,
+                )
+                try:
+                    q.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+                try:
+                    q.put_nowait(dict(payload))
+                    pushed = True
+                except asyncio.QueueFull:
+                    # 극단적 경합 — 이번 push만 포기(무한 재시도 금지). 연결은 dict에 남아
+                    # 다음 push부터 정상 도달(agent_gateway.py wake_agent과 동일 근거).
+                    pass
     if not _from_listener:
         # prod 커넥션 누수 근본fix(2026-07-08) — 참조 미보관 create_task는 GC가 pg_notify()의
         # async with async_session_factory() 도중 태스크를 조기수거할 수 있다(공식 문서 경고) —

--- a/backend/tests/test_2530_agent_wake_queue_overflow_keeps_connection.py
+++ b/backend/tests/test_2530_agent_wake_queue_overflow_keeps_connection.py
@@ -1,0 +1,144 @@
+"""story #2530(2026-08-24, PO 판정) — 「선생님→에이전트 미도달」읽기방향 그라운딩에서 발견:
+`wake_agent()`(agent_gateway.py)와 형제 함수 `_push_to_agent()`(events.py) 둘 다, 대상 큐가
+가득 차면(QueueFull) 그 큐(=그 연결)를 `_agent_connections`에서 **통째로 제거**했다.
+
+스트림 자체는 안 끊긴 채("연결은 살아 보이는" 상태) 그 agent_id/member_id로 오는 모든 이후
+wake/push 호출이 이 연결을 dict에서 영원히 못 찾아 조용히 no-op — "연결은 살았는데 신호만
+죽는" 반쪽 상태가 코드로 가능했다(버스트성 대량 이벤트 직후 「왕왕」 미도달 패턴과 정합하는
+실 후보).
+
+처방: 큐를 ring-buffer로 다뤄 가장 오래된 항목을 버리고 자리를 만든다 — 연결을 절대 dict에서
+지우지 않는다. 이 파일은 순수 in-memory 로직(`_agent_connections`/`asyncio.Queue`)만 다뤄
+DB·HTTP 없이 검증한다(#3026/#3029와 동일 방법론 — 이 클래스 버그는 실 DB가 필요 없다)."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _clean_agent_connections():
+    """`_agent_connections`는 두 모듈이 공유하는 프로세스 전역 defaultdict — 테스트 간
+    오염을 막기 위해 이 테스트가 건드리는 키만 매번 정리한다."""
+    from app.routers.events import _agent_connections
+
+    yield
+    _agent_connections.pop("test-agent-2530", None)
+
+
+@pytest.mark.anyio
+async def test_wake_agent_keeps_connection_registered_on_queue_overflow():
+    """⭐핵심 — 큐가 가득 차도 연결이 `_agent_connections`에서 사라지면 안 된다."""
+    from app.routers.agent_gateway import wake_agent
+    from app.routers.events import _agent_connections
+
+    agent_id = "test-agent-2530"
+    q: asyncio.Queue = asyncio.Queue(maxsize=2)
+    _agent_connections[agent_id].add(q)
+
+    # 큐를 가득 채운다(maxsize=2).
+    q.put_nowait({"__wake__": True, "seq": 1})
+    q.put_nowait({"__wake__": True, "seq": 2})
+    assert q.full()
+
+    # 오버플로를 유발하는 3번째 wake — 예전엔 이 호출이 연결을 dict에서 지웠다.
+    wake_agent(agent_id, seq=3, _from_listener=True)  # _from_listener=True: pg_notify 재발행 skip.
+
+    assert agent_id in _agent_connections, "큐 오버플로 후에도 연결이 dict에 남아있어야 함"
+    assert q in _agent_connections[agent_id], "이 큐 자체가 여전히 등록돼 있어야 함"
+
+
+@pytest.mark.anyio
+async def test_wake_agent_drops_oldest_and_admits_newest_on_overflow():
+    """오래된 신호는 버려지고 새 신호가 대신 자리를 잡는다(ring-buffer)."""
+    from app.routers.agent_gateway import wake_agent
+    from app.routers.events import _agent_connections
+
+    agent_id = "test-agent-2530"
+    q: asyncio.Queue = asyncio.Queue(maxsize=2)
+    _agent_connections[agent_id].add(q)
+
+    q.put_nowait({"__wake__": True, "seq": 1})
+    q.put_nowait({"__wake__": True, "seq": 2})
+
+    wake_agent(agent_id, seq=3, _from_listener=True)
+
+    drained = [q.get_nowait() for _ in range(q.qsize())]
+    seqs = [item["seq"] for item in drained]
+    assert 1 not in seqs, "가장 오래된 신호(seq=1)는 버려져야 함"
+    assert 3 in seqs, "이번 신호(seq=3)는 자리를 만들어 들어가야 함"
+
+
+@pytest.mark.anyio
+async def test_wake_agent_subsequent_call_still_reaches_connection_after_overflow():
+    """⭐AC 판별자 — 오버플로 이후에도 «다음» wake_agent() 호출이 이 연결에 정상 도달해야
+    한다(연결이 dict에서 사라졌다면 이 두 번째 호출도 조용히 no-op됐을 것)."""
+    from app.routers.agent_gateway import wake_agent
+    from app.routers.events import _agent_connections
+
+    agent_id = "test-agent-2530"
+    q: asyncio.Queue = asyncio.Queue(maxsize=2)
+    _agent_connections[agent_id].add(q)
+
+    q.put_nowait({"__wake__": True, "seq": 1})
+    q.put_nowait({"__wake__": True, "seq": 2})
+    wake_agent(agent_id, seq=3, _from_listener=True)  # 오버플로 유발.
+
+    # 큐를 완전히 비운 뒤(컨슈머가 따라잡은 상황을 재현) 새 wake를 보낸다.
+    while not q.empty():
+        q.get_nowait()
+    wake_agent(agent_id, seq=4, _from_listener=True)
+
+    assert q.qsize() == 1
+    assert q.get_nowait()["seq"] == 4, "오버플로 이후에도 다음 wake가 이 연결에 정상 도달해야 함"
+
+
+@pytest.mark.anyio
+async def test_push_to_agent_keeps_connection_registered_on_queue_overflow():
+    """`_push_to_agent`(events.py, 브라우저 SSE) — wake_agent과 동일 형제 결함·동일 처방."""
+    from app.routers.events import _agent_connections, _push_to_agent
+
+    member_id = "test-agent-2530"
+    q: asyncio.Queue = asyncio.Queue(maxsize=2)
+    _agent_connections[member_id].add(q)
+
+    q.put_nowait({"event_type": "conversation.message_created", "data": {"n": 1}})
+    q.put_nowait({"event_type": "conversation.message_created", "data": {"n": 2}})
+    assert q.full()
+
+    pushed = _push_to_agent(
+        member_id, {"event_type": "conversation.message_created", "data": {"n": 3}},
+        _from_listener=True,
+    )
+
+    assert pushed is True, "오버플로 처리(드롭+재시도) 後 이번 push는 성공해야 함"
+    assert member_id in _agent_connections, "큐 오버플로 후에도 연결이 dict에 남아있어야 함"
+    assert q in _agent_connections[member_id]
+
+
+@pytest.mark.anyio
+async def test_push_to_agent_subsequent_call_still_reaches_connection_after_overflow():
+    """⭐AC 판별자(events.py 쪽) — 오버플로 이후에도 다음 push가 이 연결에 정상 도달해야 함."""
+    from app.routers.events import _agent_connections, _push_to_agent
+
+    member_id = "test-agent-2530"
+    q: asyncio.Queue = asyncio.Queue(maxsize=2)
+    _agent_connections[member_id].add(q)
+
+    q.put_nowait({"event_type": "x", "data": {"n": 1}})
+    q.put_nowait({"event_type": "x", "data": {"n": 2}})
+    _push_to_agent(member_id, {"event_type": "x", "data": {"n": 3}}, _from_listener=True)
+
+    while not q.empty():
+        q.get_nowait()
+    pushed = _push_to_agent(member_id, {"event_type": "x", "data": {"n": 4}}, _from_listener=True)
+
+    assert pushed is True
+    assert q.qsize() == 1
+    assert q.get_nowait()["data"]["n"] == 4

--- a/backend/tests/test_3026_sse_live_loop_connection_local_dedup.py
+++ b/backend/tests/test_3026_sse_live_loop_connection_local_dedup.py
@@ -80,21 +80,29 @@ async def test_push_to_agent_fans_out_to_all_queues_of_same_member():
 
 @pytest.mark.anyio
 async def test_push_to_agent_survives_one_dead_queue_among_many():
-    """부수 회귀가드 — 동시 연결 중 하나가 죽어있어도(QueueFull) 나머지 연결은 정상 수신
-    (`_push_to_agent`의 기존 dead-queue 청소 로직이 이 처방과 계속 정합하는지)."""
+    """부수 회귀가드 — 동시 연결 중 하나가 꽉 차 있어도(QueueFull) 나머지 연결은 정상 수신.
+
+    ⚠️story #2530(2026-08-24) 정정 — 이 테스트는 원래 QueueFull 시 그 큐(연결)가
+    `_agent_connections`에서 **제거**되는 걸 기대했다. #2530 그라운딩에서 그 discard
+    자체가 "연결은 살아 보이는데 신호만 영구히 죽는" 실사고 후보로 밝혀져, 처방을
+    "가장 오래된 항목을 버리고 자리를 만들어 연결은 유지"로 바꿨다(agent_gateway.py
+    wake_agent과 동일 원칙 — 상세: test_2530_agent_wake_queue_overflow_keeps_connection.py).
+    이 테스트는 이제 그 새 계약(연결 유지+ring-buffer)을 고정한다."""
     member_id = str(uuid.uuid4())
-    dead_queue: asyncio.Queue = asyncio.Queue(maxsize=1)
-    dead_queue.put_nowait({"event_type": "filler"})  # 꽉 채워 QueueFull 유도.
+    full_queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+    full_queue.put_nowait({"event_type": "filler"})  # 꽉 채워 QueueFull 유도.
     alive_queue: asyncio.Queue = asyncio.Queue(maxsize=10)
-    _agent_connections[member_id] = {dead_queue, alive_queue}
+    _agent_connections[member_id] = {full_queue, alive_queue}
 
     try:
         eid = str(uuid.uuid4())
         pushed = _push_to_agent(member_id, {"event_type": "conversation.gate_resolved", "event_id": eid})
 
-        assert pushed is True  # alive_queue 쪽은 성공.
+        assert pushed is True  # 둘 다 성공(가득 찼던 쪽도 드롭+재시도로 성공).
         assert alive_queue.get_nowait()["event_id"] == eid
-        # dead_queue는 자동 정리(discard)돼 등록에서 빠졌는지.
-        assert dead_queue not in _agent_connections[member_id]
+        # full_queue는 제거되지 않고 남아있어야 함(#2530) — 오래된 "filler"는 버려지고
+        # 이번 이벤트가 대신 들어가 있다.
+        assert full_queue in _agent_connections[member_id]
+        assert full_queue.get_nowait()["event_id"] == eid
     finally:
         _agent_connections.pop(member_id, None)


### PR DESCRIPTION
[SID:2530]

## 그라운딩(선생님→에이전트 읽기방향 미도달, #2926 쓰기방향 후속)
`agent_gateway.py`의 agent stdio 연결(내가 지금 이 순간 실제로 쓰고 있는 그 경로)은 durable `recipient_seq`+`acked_seq` 기반의 "gap-free ordered-at-least-once" 설계 — 오늘 #3026/#3029가 고친 브라우저 `events.py` 라이브루프(in-memory 상태 기반 cross-connection dedup)와는 아키텍처가 다르고, 그쪽 버그 클래스는 여기 적용 안 됨.

대신 `agent_gateway.py::wake_agent` 자체에서 새 결함 발견: 큐 오버플로(`QueueFull`) 시 그 큐(=연결)를 `_agent_connections`에서 **통째로 discard**한다. 스트림 자체는 안 끊긴 채("연결은 살아 보이는" 상태) 그 뒤로 이 agent에 오는 **모든** `wake_agent()` 호출이 이 연결을 dict에서 영원히 못 찾아 조용히 no-op — 「선생님→에이전트 왕왕 미도달」과 정합하는 실 후보로 격상(버스트성 대량 이벤트 직후 재현 가능한 클래스).

`events.py::_push_to_agent`(브라우저 SSE)에도 **동일한 discard 패턴**이 형제 결함으로 존재 — 같은 `_agent_connections`를 공유하므로 동일 처방 동반 적용.

## 처방(PO 판정)
큐를 ring-buffer로 다뤄 가장 오래된 항목을 버리고 자리를 만든다 — **연결을 절대 dict에서 지우지 않는다**. wake 신호는 "그 seq 하나"가 아니라 "재조회하라"는 트리거일 뿐이라(recipient_seq 기반 전체 rescan) 오래된 신호를 버려도 살아남은 신호가 여전히 전체 catch-up을 끌어낸다 — "연결이 살아있으면 신호도 언젠가 닿는다"가 코드 불변식으로 보증된다(AC: 「연결은 살았는데 신호만 죽는」 반쪽 상태가 코드상 불가능해야 함).

`_push_to_agent` 쪽은 B계열(transient, event_id 없음) 1건 유실 가능성이 남지만(드롭된 그 항목 자체는 재전송 안 됨), 예전처럼 "연결 자체가 사라져 그 뒤 전부 유실"보다 항상 개선(strict improvement) — A계열(event_id 有)은 재연결 시 DB backfill로 무관하게 회수됨.

## 부수 발견(스코프 분리 — story #3037로 별도 등재)
`wake_agent`의 plain `pg_notify` 크로스인스턴스 폴백이 `__wake__` 마커를 `event_type` 슬롯에 실어 보내는데 수신측(`_dispatch_received`)이 `data`만 봐 마커가 유실되는 형제 결함 발견. 단 `.github/workflows/cloud-build.yml` 소스 대조 결과 dev/prod 둘 다 `FANOUT_WAKE_REDIS_ENABLED=true`로 배선돼 있어 실제 배포는 항상 Redis 경로(마커 보존 정상)를 탄다 — **현재 도달 불가능한 dormant 코드**(플래그가 나중에 false로 바뀌면 재점화하는 잠복 지뢰). 이번 PR 스코프에서 제외, #3037에 상세 기록.

## 검증
신규 5종 전부 mutation 검증(discard 복원 → 정확 FAIL → 복원 후 재green):
- `wake_agent`: 오버플로 후에도 연결이 dict에 남아있음.
- `wake_agent`: 가장 오래된 신호는 버려지고 새 신호가 대신 들어감.
- `wake_agent`: 오버플로 이후 **다음** 호출도 이 연결에 정상 도달(AC 판별자).
- `_push_to_agent`: 위 3종의 events.py 쌍.

기존 `test_3026_sse_live_loop_connection_local_dedup.py`의 회귀가드 1건이 옛 discard 계약(`assert dead_queue not in ...`)을 고정하고 있어, 새 계약(연결 유지+ring-buffer)으로 갱신.

인접 SSE/agent-gateway 회귀(test_2004/#2082/#2178/#2381×2/#2078/#2158/#2086/#2139_2132/#2143/#3026/#3029/신규) 68/68 green. **DB 불요** — 순수 in-memory 로직(`_agent_connections`/`asyncio.Queue`), #3026/#3029와 동일 방법론.

CI 초록 확인 부탁하는. 머지는 통상 관례대로 위임.