### PR TITLE
fix(#2789): 요청자 자기 결정 카드 철회 API — POST /gates/{id}/withdraw

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1548,6 +1548,79 @@ class GateVoidRequest(BaseModel):
     reason: str  # 사유 필수(audit·파괴적 액션). 빈 사유는 서비스서 422.
 
 
+@router.post("/{id}/withdraw", response_model=GateResponse)
+async def withdraw_gate_endpoint(
+    id: uuid.UUID,
+    body: GateVoidRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> GateResponse:
+    """story #2789(2026-08-24, PO 판정) — 갭③: 요청자(에이전트 포함) 자기 결정 카드 철회.
+
+    `/void`(위)는 admin-only 복구 액션(잘못 생성된 게이트를 관리자가 무효화) — 그와는
+    **다른 인가 축**이다: 여기는 "이 게이트를 만든 사람 본인이 자기 질문을 철회"하는
+    것이라, admin 자격이 아니라 **본인이 원 요청자인가**만 검사한다(neutral_facts.
+    requested_by_member_id — /decisions 생성 시점에 caller_id로 stamp됨, gates.py:418).
+    admin이 아닌 에이전트가 자기 질문을 낸 뒤 스스로 취소할 방법이 지금까지 전무했다
+    (2026-08-19 실증: DELETE 405·withdraw/resolve/agent-decisions/* 전부 404) — 무효화된
+    질문 카드가 결재함에 영구 잔존하던 그 갭.
+
+    상태 전이·audit는 `void_gate()`(SSOT, admin `/void`와 동일 로직) 그대로 재사용 — 새
+    상태기계 발명 0. actor_type만 실 caller 신원(agent_gateway.py 등과 동형 api_key_id
+    판별)으로 정직하게 넘긴다(#2789 이전엔 이 함수의 유일한 호출자가 항상 사람이라
+    "human" 하드코딩이 참이었다 — 더는 아니다).
+
+    철회는 결재함(gate.status≠pending이 되는 순간 그 목록에서 자연히 빠짐, 별도 배선
+    불요)과 채팅(designated_approver에게 "철회" 결과 회신 — dispatch_approval_result_reply
+    재사용, approved/rejected와 동형의 반대방향 알림) 양쪽에 반영된다."""
+    resolved = await resolve_member(auth, org_id, session)
+
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise HTTPException(status_code=404, detail="Gate not found")
+
+    requester_raw = (gate.neutral_facts or {}).get("requested_by_member_id")
+    if not requester_raw or uuid.UUID(str(requester_raw)) != resolved.id:
+        # 존재 비노출 관례(다른 gate 라우트와 동형) — 남의 게이트 존재 여부를 403으로
+        # 흘리지 않는다. 본인 요청이 아니면 404(admin은 /void를 쓸 것).
+        raise HTTPException(status_code=404, detail="Gate not found")
+
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    actor_type = "agent" if is_api_key else "human"
+
+    try:
+        gate = await void_gate(session, org_id, id, resolved.id, body.reason, actor_type=actor_type)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    designated_approver_id = gate.designated_approver_id
+    if designated_approver_id is not None:
+        try:
+            from app.services.approval_delivery import dispatch_approval_result_reply
+            project_id_raw = (gate.neutral_facts or {}).get("project_id")
+            # dispatch_approval_result_reply 자체가 project_id falsy면 no-op(그 함수 첫 줄
+            # 가드) — 없으면 지어내지 않고 None 그대로 넘긴다.
+            await dispatch_approval_result_reply(
+                session, org_id=org_id, work_item_type=gate.work_item_type,
+                work_item_id=gate.work_item_id,
+                project_id=uuid.UUID(str(project_id_raw)) if project_id_raw else None,
+                title=(gate.neutral_facts or {}).get("question", "결정 요청"),
+                gate_id=gate.id, requester_id=designated_approver_id, resolver_id=resolved.id,
+                decision="withdrawn", resolution_note=body.reason,
+                event_type="agent_decision_withdrawn",
+            )
+        except Exception:  # noqa: BLE001 — 회신 실패가 철회 자체를 막지 않는다(결재함 반영은 이미 완료).
+            logger.warning("decision-request 철회 회신 실패 gate=%s", gate.id, exc_info=True)
+
+    await session.commit()
+    # story #2459 회귀 동형 방어(2026-08-05): commit 後 model_validate 前 명시 refresh.
+    await session.refresh(gate)
+    return GateResponse.model_validate(gate)
+
+
 @router.post("/{id}/void", response_model=GateResponse)
 async def void_gate_endpoint(
     id: uuid.UUID,

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1582,8 +1582,13 @@ async def withdraw_gate_endpoint(
     if gate is None:
         raise HTTPException(status_code=404, detail="Gate not found")
 
+    # 카디르 QA(#3462, 2026-08-25 probe 실측): neutral_facts는 외부 JSONB라 requested_by_
+    # member_id가 손상된/비-UUID 문자열일 수 있다 — uuid.UUID(...) 파싱은 그 경우 uncaught
+    # ValueError로 500을 낸다(다른 gate 라우트가 쓰는 문자열비교 패턴을 그대로 재사용해
+    # 파싱 자체를 없앤다 — 손상값은 어차피 어떤 유효 uuid 문자열과도 안 같으므로 결과는
+    # 동일하게 404, 크래시만 사라진다).
     requester_raw = (gate.neutral_facts or {}).get("requested_by_member_id")
-    if not requester_raw or uuid.UUID(str(requester_raw)) != resolved.id:
+    if not requester_raw or str(requester_raw) != str(resolved.id):
         # 존재 비노출 관례(다른 gate 라우트와 동형) — 남의 게이트 존재 여부를 403으로
         # 흘리지 않는다. 본인 요청이 아니면 404(admin은 /void를 쓸 것).
         raise HTTPException(status_code=404, detail="Gate not found")
@@ -1592,7 +1597,10 @@ async def withdraw_gate_endpoint(
     actor_type = "agent" if is_api_key else "human"
 
     try:
-        gate = await void_gate(session, org_id, id, resolved.id, body.reason, actor_type=actor_type)
+        gate = await void_gate(
+            session, org_id, id, resolved.id, body.reason,
+            actor_type=actor_type, void_reason_label="requester",
+        )
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
 

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -462,6 +462,21 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
         DeepLinkManifestEntry(
+            # story #2789: 요청자 자기-철회(withdraw) 결과가 designated_approver에게 회신되는
+            # 벨 알림 — agent_decision_resolved와 완전 동형(dispatch_approval_result_reply
+            # 파라미터화 재사용, gate 경유·reference_id=gate_id·읽기전용 FYI). 차이는 결과값이
+            # "승인/반려"가 아니라 "철회"라는 것뿐 — 착지 화면·조치 가능 여부는 동일.
+            app=DeepLinkAppFields(
+                type="agent_decision_withdrawn", target="gate_detail", parent_tab=ParentTab.approvals,
+                target_promotion_pending=True,
+            ),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+        DeepLinkManifestEntry(
             # story #1715(카디르 QA, PR#3428) — merge gate(work_item_type="story") 해소
             # 결과가 상신자(participation.member_id)에게 회신되는 벨 알림. doc_approval_
             # resolved/agent_decision_resolved와 완전 동형(dispatch_approval_result_reply

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -256,7 +256,11 @@ async def dispatch_approval_result_reply(
         logger.warning("approval-result 회신 스킵 — resolver 미확인 work_item=%s", work_item_id)
         return
 
-    decision_label = "승인" if decision == "approved" else "반려"
+    # story #2789(2026-08-24) — 이 이진 매핑(approved 아니면 전부 "반려")은 "withdrawn"
+    # (요청자 자기-철회, 이 함수의 새 호출자)이 들어오면 승인 거부인 것처럼 잘못 라벨링한다
+    # — decision 값마다 명시로 라벨을 정한다(미지 값은 문자열 그대로, 지어내지 않는다).
+    _DECISION_LABELS = {"approved": "승인", "rejected": "반려", "withdrawn": "철회"}
+    decision_label = _DECISION_LABELS.get(decision, decision)
     content = f"'{title}' 결재 결과: {decision_label}"
     if resolution_note:
         content += f"\n사유: {resolution_note}"

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -1131,6 +1131,7 @@ async def void_gate(
     reason: str,
     *,
     actor_type: str = "human",
+    void_reason_label: str = "admin",
 ) -> Gate:
     """⭐S30 admin recovery: 잘못 생성된 **pending** gate 를 무효화(voided).
 
@@ -1146,6 +1147,15 @@ async def void_gate(
     그 전제가 깨진다 — 호출부가 실제 caller 타입(agent_gateway.py 등에서 이미 쓰는
     `app_metadata.api_key_id` 신호와 동형 판별)을 명시로 넘긴다. 기본값 "human"은 기존
     admin `/void` 경로의 무회귀만 보존한다.
+
+    void_reason_label: 카디르 QA(#3462, 2026-08-25) — 최초 구현이 이 값을 `actor_type`과
+    같은 변수로 합쳐 썼다가, 그 결과 step_run.routing_reason 리터럴이 기존 admin `/void`
+    경로에서도 "gate voided by admin: ..."(항상 이 고정 문구였음, git blame 확認)에서
+    "gate voided by human: ..."로 바뀌어버려 `test_edg_s30_void_recovery`가 실 PG에서
+    깨졌다(disposable PG 재현). `actor_type`(ActivityLog 감사축)과 `void_reason_label`
+    (routing_reason 표시축)은 서로 다른 축이라 분리한다 — 전자는 "누가"(agent/human),
+    후자는 "어떤 경로로"(admin 복구 vs 요청자 철회)를 나타낸다. 기본값 "admin"은 기존
+    admin `/void` 호출자의 출력을 byte-동일 보존한다.
     """
     gate = (await session.execute(
         select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
@@ -1173,7 +1183,8 @@ async def void_gate(
         if sr is not None:
             sr.status = "skipped"
             # story #2789 — "by admin"이 더는 항상 참이 아니다(요청자 자기-철회 경로 추가).
-            sr.routing_reason = f"gate voided by {actor_type}: {reason}"[:500]
+            # 카디르 QA(#3462): actor_type과 혼용하면 기존 admin 경로 출력이 바뀐다 — 별도 축.
+            sr.routing_reason = f"gate voided by {void_reason_label}: {reason}"[:500]
             sr.resolved_at = datetime.now(timezone.utc)
 
     # story #2975 AC4(PO 확定 2026-08-24) — 위 주석이 남긴 이유(permission_audit_logs=member 전용·

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -1129,6 +1129,8 @@ async def void_gate(
     gate_id: uuid.UUID,
     voider_id: uuid.UUID,
     reason: str,
+    *,
+    actor_type: str = "human",
 ) -> Gate:
     """⭐S30 admin recovery: 잘못 생성된 **pending** gate 를 무효화(voided).
 
@@ -1137,6 +1139,13 @@ async def void_gate(
     S23 RC① 패턴). audit = gate 행(status='voided'·resolver_id·resolution_note)이 distinct 추적
     (approve/reject 와 **status 로 구분**) + ActivityLog(story #2975 AC4, approve/reject/undo와
     동형 — 이전엔 logger.info뿐이라 DB 조회 불가였음). void=복구 액션이라 strict SoD 불요(PO Q4).
+
+    actor_type: story #2789(2026-08-24) — 이전엔 이 함수의 유일한 호출자(admin-only `/void`
+    엔드포인트)가 항상 사람이라 ActivityLog에 `actor_type="human"`을 하드코딩해도 참이었다.
+    이 스토리가 새 호출자(요청자 자기-철회 `/withdraw`, 에이전트도 호출 가능)를 추가하며
+    그 전제가 깨진다 — 호출부가 실제 caller 타입(agent_gateway.py 등에서 이미 쓰는
+    `app_metadata.api_key_id` 신호와 동형 판별)을 명시로 넘긴다. 기본값 "human"은 기존
+    admin `/void` 경로의 무회귀만 보존한다.
     """
     gate = (await session.execute(
         select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
@@ -1163,7 +1172,8 @@ async def void_gate(
         )).scalar_one_or_none()
         if sr is not None:
             sr.status = "skipped"
-            sr.routing_reason = f"gate voided by admin: {reason}"[:500]
+            # story #2789 — "by admin"이 더는 항상 참이 아니다(요청자 자기-철회 경로 추가).
+            sr.routing_reason = f"gate voided by {actor_type}: {reason}"[:500]
             sr.resolved_at = datetime.now(timezone.utc)
 
     # story #2975 AC4(PO 확定 2026-08-24) — 위 주석이 남긴 이유(permission_audit_logs=member 전용·
@@ -1176,7 +1186,7 @@ async def void_gate(
         org_id=org_id,
         action="gate_voided",
         actor_id=voider_id,
-        actor_type="human",
+        actor_type=actor_type,
         entity_type="gate",
         entity_id=gate.id,
         context={

--- a/backend/tests/test_2789_gate_withdraw_endpoint.py
+++ b/backend/tests/test_2789_gate_withdraw_endpoint.py
@@ -1,0 +1,319 @@
+"""story #2789 — 갭③: 요청자(에이전트 포함) 자기 결정 카드 철회 API.
+
+`/void`(admin-only)와 다른 인가 축(본인이 원 요청자인가만 검사, neutral_facts.
+requested_by_member_id 매치) — test_edg_s30_void_recovery.py의 엔드포인트 직접호출
+unit 패턴(session/resolve_member/void_gate 전부 mock)을 그대로 재사용한다. void_gate
+자체의 상태전이/audit 로직은 test_edg_s30이 이미 커버(SSOT 재사용·새 상태기계 0).
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _resolved(member_id):
+    from app.services.member_resolver import ResolvedMember
+    return ResolvedMember(id=member_id, user_id=uuid.uuid4(), name="caller",
+                          type="human", role="member", org_id=uuid.uuid4())
+
+
+def _fake_gate(*, requester_id, designated_approver_id=None, status="pending"):
+    return SimpleNamespace(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), status=status,
+        work_item_type="agent_decision", work_item_id=uuid.uuid4(),
+        designated_approver_id=designated_approver_id,
+        neutral_facts={
+            "requested_by_member_id": str(requester_id),
+            "question": "A or B?",
+            "project_id": str(uuid.uuid4()),
+        },
+    )
+
+
+def _session_returning(gate):
+    """session.execute(select(Gate)...) → .scalar_one_or_none() == gate 로 고정한 AsyncMock."""
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: gate))
+    return session
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_withdraw_endpoint_requester_can_withdraw_own_gate():
+    """본인이 낸 gate → void_gate 호출·응답 반환(200 상당, 예외 없음)."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateVoidRequest, withdraw_gate_endpoint
+
+    caller = _resolved(uuid.uuid4())
+    gate = _fake_gate(requester_id=caller.id)
+    voided_gate = SimpleNamespace(**{**gate.__dict__, "status": "voided"})
+    voidfn = AsyncMock(return_value=voided_gate)
+    session = _session_returning(gate)
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "void_gate", voidfn), \
+         patch.object(gates_mod.GateResponse, "model_validate", lambda g: g):
+        result = await withdraw_gate_endpoint(
+            id=gate.id, body=GateVoidRequest(reason="더 이상 필요 없음"),
+            session=session, org_id=uuid.uuid4(),
+            auth=SimpleNamespace(user_id=str(caller.user_id), claims={}),
+        )
+
+    voidfn.assert_awaited_once()
+    assert result.status == "voided"
+    session.commit.assert_awaited()
+
+
+@pytest.mark.anyio
+async def test_withdraw_endpoint_non_requester_404():
+    """요청자가 아닌 caller(admin 포함) → 404·void_gate 미호출(존재 비노출)."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateVoidRequest, withdraw_gate_endpoint
+
+    caller = _resolved(uuid.uuid4())
+    other_requester = uuid.uuid4()
+    gate = _fake_gate(requester_id=other_requester)
+    voidfn = AsyncMock()
+    session = _session_returning(gate)
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "void_gate", voidfn):
+        with pytest.raises(HTTPException) as ei:
+            await withdraw_gate_endpoint(
+                id=gate.id, body=GateVoidRequest(reason="x"),
+                session=session, org_id=uuid.uuid4(),
+                auth=SimpleNamespace(user_id=str(caller.user_id), claims={}),
+            )
+
+    assert ei.value.status_code == 404
+    voidfn.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_withdraw_endpoint_missing_requester_field_404():
+    """neutral_facts 에 requested_by_member_id 자체가 없는(비정상/구형) gate → fail-closed 404."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateVoidRequest, withdraw_gate_endpoint
+
+    caller = _resolved(uuid.uuid4())
+    gate = _fake_gate(requester_id=caller.id)
+    gate.neutral_facts = {"question": "no requester field"}
+    voidfn = AsyncMock()
+    session = _session_returning(gate)
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "void_gate", voidfn):
+        with pytest.raises(HTTPException) as ei:
+            await withdraw_gate_endpoint(
+                id=gate.id, body=GateVoidRequest(reason="x"),
+                session=session, org_id=uuid.uuid4(),
+                auth=SimpleNamespace(user_id=str(caller.user_id), claims={}),
+            )
+
+    assert ei.value.status_code == 404
+    voidfn.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_withdraw_endpoint_gate_not_found_404():
+    """org_id/id 로 gate 자체가 안 잡히면(다른 org 또는 오탈자 id) 404."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateVoidRequest, withdraw_gate_endpoint
+
+    caller = _resolved(uuid.uuid4())
+    voidfn = AsyncMock()
+    session = _session_returning(None)
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "void_gate", voidfn):
+        with pytest.raises(HTTPException) as ei:
+            await withdraw_gate_endpoint(
+                id=uuid.uuid4(), body=GateVoidRequest(reason="x"),
+                session=session, org_id=uuid.uuid4(),
+                auth=SimpleNamespace(user_id=str(caller.user_id), claims={}),
+            )
+
+    assert ei.value.status_code == 404
+    voidfn.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_withdraw_endpoint_already_resolved_gate_422():
+    """void_gate 가 불법 전이(ValueError)를 내면 422로 변환(이미 approved/rejected/voided)."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateVoidRequest, withdraw_gate_endpoint
+
+    caller = _resolved(uuid.uuid4())
+    gate = _fake_gate(requester_id=caller.id, status="approved")
+    voidfn = AsyncMock(side_effect=ValueError("불법 전이: approved → voided. pending 게이트만 무효화 가능."))
+    session = _session_returning(gate)
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "void_gate", voidfn):
+        with pytest.raises(HTTPException) as ei:
+            await withdraw_gate_endpoint(
+                id=gate.id, body=GateVoidRequest(reason="x"),
+                session=session, org_id=uuid.uuid4(),
+                auth=SimpleNamespace(user_id=str(caller.user_id), claims={}),
+            )
+
+    assert ei.value.status_code == 422
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("is_api_key,expected_actor_type", [(True, "agent"), (False, "human")])
+async def test_withdraw_endpoint_actor_type_reflects_real_caller(is_api_key, expected_actor_type):
+    """⭐actor_type 하드코딩 landmine 회귀가드 — api_key_id 유무로 agent/human 정직 전달(#2789)."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateVoidRequest, withdraw_gate_endpoint
+
+    caller = _resolved(uuid.uuid4())
+    gate = _fake_gate(requester_id=caller.id)
+    voidfn = AsyncMock(return_value=gate)
+    session = _session_returning(gate)
+    claims = {"app_metadata": {"api_key_id": "k1"}} if is_api_key else {}
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "void_gate", voidfn), \
+         patch.object(gates_mod.GateResponse, "model_validate", lambda g: g):
+        await withdraw_gate_endpoint(
+            id=gate.id, body=GateVoidRequest(reason="x"),
+            session=session, org_id=uuid.uuid4(),
+            auth=SimpleNamespace(user_id=str(caller.user_id), claims=claims),
+        )
+
+    assert voidfn.call_args.kwargs["actor_type"] == expected_actor_type
+
+
+@pytest.mark.anyio
+async def test_withdraw_endpoint_notifies_designated_approver_as_withdrawn():
+    """designated_approver 있으면 dispatch_approval_result_reply(decision='withdrawn') 호출."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateVoidRequest, withdraw_gate_endpoint
+
+    caller = _resolved(uuid.uuid4())
+    approver_id = uuid.uuid4()
+    gate = _fake_gate(requester_id=caller.id, designated_approver_id=approver_id)
+    voided_gate = SimpleNamespace(**{**gate.__dict__, "status": "voided"})
+    voidfn = AsyncMock(return_value=voided_gate)
+    session = _session_returning(gate)
+    dispatch = AsyncMock()
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "void_gate", voidfn), \
+         patch.object(gates_mod.GateResponse, "model_validate", lambda g: g), \
+         patch("app.services.approval_delivery.dispatch_approval_result_reply", dispatch):
+        await withdraw_gate_endpoint(
+            id=gate.id, body=GateVoidRequest(reason="더 이상 필요 없음"),
+            session=session, org_id=uuid.uuid4(),
+            auth=SimpleNamespace(user_id=str(caller.user_id), claims={}),
+        )
+
+    dispatch.assert_awaited_once()
+    assert dispatch.call_args.kwargs["decision"] == "withdrawn"
+    assert dispatch.call_args.kwargs["requester_id"] == approver_id
+    assert dispatch.call_args.kwargs["resolver_id"] == caller.id
+
+
+@pytest.mark.anyio
+async def test_withdraw_endpoint_no_approver_skips_notification():
+    """designated_approver_id 없는 gate(구형/anchor 없음) → 알림 호출 자체가 없다(에러 아님)."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateVoidRequest, withdraw_gate_endpoint
+
+    caller = _resolved(uuid.uuid4())
+    gate = _fake_gate(requester_id=caller.id, designated_approver_id=None)
+    voidfn = AsyncMock(return_value=gate)
+    session = _session_returning(gate)
+    dispatch = AsyncMock()
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "void_gate", voidfn), \
+         patch.object(gates_mod.GateResponse, "model_validate", lambda g: g), \
+         patch("app.services.approval_delivery.dispatch_approval_result_reply", dispatch):
+        await withdraw_gate_endpoint(
+            id=gate.id, body=GateVoidRequest(reason="x"),
+            session=session, org_id=uuid.uuid4(),
+            auth=SimpleNamespace(user_id=str(caller.user_id), claims={}),
+        )
+
+    dispatch.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_withdraw_endpoint_notification_failure_does_not_block_commit():
+    """회신 배달 실패(best-effort) → 철회 자체(commit)는 그대로 완료된다."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateVoidRequest, withdraw_gate_endpoint
+
+    caller = _resolved(uuid.uuid4())
+    gate = _fake_gate(requester_id=caller.id, designated_approver_id=uuid.uuid4())
+    voidfn = AsyncMock(return_value=gate)
+    session = _session_returning(gate)
+    dispatch = AsyncMock(side_effect=RuntimeError("dm 라우팅 실패"))
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "void_gate", voidfn), \
+         patch.object(gates_mod.GateResponse, "model_validate", lambda g: g), \
+         patch("app.services.approval_delivery.dispatch_approval_result_reply", dispatch):
+        await withdraw_gate_endpoint(
+            id=gate.id, body=GateVoidRequest(reason="x"),
+            session=session, org_id=uuid.uuid4(),
+            auth=SimpleNamespace(user_id=str(caller.user_id), claims={}),
+        )
+
+    session.commit.assert_awaited()
+
+
+@pytest.mark.anyio
+async def test_decision_label_withdrawn_is_not_mislabeled_as_rejected():
+    """⭐approval_delivery._DECISION_LABELS landmine 회귀가드 — decision='withdrawn'이 이진
+    fail-open 매핑(approved 아니면 전부 '반려')으로 되돌아가면 철회를 반려로 오라벨링한다."""
+    from unittest.mock import AsyncMock as _AM
+    from app.services import approval_delivery as ad_mod
+
+    captured = {}
+
+    class _FakeConv(SimpleNamespace):
+        pass
+
+    async def _fake_get_or_create(db, *, org_id, project_id, requester_id, approver_id):
+        return _FakeConv(id=uuid.uuid4())
+
+    async def _fake_dispatch_event(db, conv, msg, org_id, resolver):
+        captured["content"] = msg.content
+
+    resolver_member = SimpleNamespace(id=uuid.uuid4())
+
+    session = AsyncMock()
+    session.begin_nested = lambda: _NestedCtx()
+
+    class _NestedCtx:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch.object(ad_mod, "_get_or_create_approval_dm", _fake_get_or_create), \
+         patch("app.routers.conversations._dispatch_conversation_event", _fake_dispatch_event), \
+         patch("app.services.member_resolver.lookup_members_by_ids",
+               _AM(return_value={resolver_member.id: resolver_member})):
+        await ad_mod.dispatch_approval_result_reply(
+            session, org_id=uuid.uuid4(), work_item_type="agent_decision",
+            work_item_id=uuid.uuid4(), project_id=uuid.uuid4(), title="A or B?",
+            gate_id=uuid.uuid4(), requester_id=uuid.uuid4(), resolver_id=resolver_member.id,
+            decision="withdrawn", resolution_note=None,
+            event_type="agent_decision_withdrawn",
+        )
+
+    assert "철회" in captured["content"]
+    assert "반려" not in captured["content"]

--- a/backend/tests/test_2789_gate_withdraw_endpoint.py
+++ b/backend/tests/test_2789_gate_withdraw_endpoint.py
@@ -317,3 +317,101 @@ async def test_decision_label_withdrawn_is_not_mislabeled_as_rejected():
 
     assert "철회" in captured["content"]
     assert "반려" not in captured["content"]
+
+
+# ── 카디르 QA(#3462, 2026-08-25) 회귀가드 2건 ────────────────────────────────────
+def _void_gate_fixture():
+    """void_gate() 내부 3개 side-effect(Gate select·step_run select·find_active_step_run_
+    for_gate·ActivityLogService.record)를 전부 mock해 실PG 없이 직접호출 검증한다."""
+    org_id = uuid.uuid4()
+    gate_id = uuid.uuid4()
+    voider_id = uuid.uuid4()
+    fake_gate = SimpleNamespace(
+        id=gate_id, org_id=org_id, status="pending",
+        resolver_id=None, resolution_note=None, resolved_at=None,
+        status_entered_at=None, gate_type="agent_decision_request",
+        work_item_type="agent_decision", work_item_id=uuid.uuid4(),
+        github_check_run_sha=None,
+    )
+    fake_sr = SimpleNamespace(
+        id=uuid.uuid4(), status="gate_pending", routing_reason=None, resolved_at=None,
+    )
+
+    gate_result = SimpleNamespace(scalar_one_or_none=lambda: fake_gate)
+    sr_result = SimpleNamespace(scalar_one_or_none=lambda: fake_sr)
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[gate_result, sr_result])
+    return org_id, gate_id, voider_id, fake_gate, fake_sr, session
+
+
+@pytest.mark.anyio
+async def test_void_gate_default_preserves_original_admin_routing_reason_and_actor_type():
+    """⭐회귀가드① — actor_type/void_reason_label을 분리하기 前엔 이 둘을 한 변수로 합쳐
+    썼다가 기존 admin `/void` 경로의 routing_reason 리터럴이 "voided by admin"(git blame상
+    항상 이 고정문구)에서 "voided by human"으로 바뀌어 test_edg_s30_void_recovery가 실PG서
+    깨졌다(카디르 disposable PG 재현). 기본값(둘 다 인자 미지정)이면 byte-동일해야 한다."""
+    from app.services import gate_service as gs_mod
+
+    org_id, gate_id, voider_id, fake_gate, fake_sr, session = _void_gate_fixture()
+    activity_record = AsyncMock()
+
+    with patch(
+        "app.services.workflow_line_resolution.find_active_step_run_for_gate",
+        AsyncMock(return_value=fake_sr.id),
+    ), patch("app.services.activity_log.ActivityLogService") as ActivityLogServiceMock:
+        ActivityLogServiceMock.return_value.record = activity_record
+        result = await gs_mod.void_gate(session, org_id, gate_id, voider_id, "오발행")
+
+    assert result.status == "voided"
+    assert fake_sr.routing_reason == "gate voided by admin: 오발행"
+    assert activity_record.call_args.kwargs["actor_type"] == "human"
+
+
+@pytest.mark.anyio
+async def test_void_gate_withdraw_path_labels_requester_not_admin():
+    """withdraw 호출부가 명시로 void_reason_label="requester"를 넘기면 그 표시만 바뀌고
+    admin 기본값과 섞이지 않는다(두 축 분리 확인 — 라벨 축 vs actor_type 축)."""
+    from app.services import gate_service as gs_mod
+
+    org_id, gate_id, voider_id, fake_gate, fake_sr, session = _void_gate_fixture()
+    activity_record = AsyncMock()
+
+    with patch(
+        "app.services.workflow_line_resolution.find_active_step_run_for_gate",
+        AsyncMock(return_value=fake_sr.id),
+    ), patch("app.services.activity_log.ActivityLogService") as ActivityLogServiceMock:
+        ActivityLogServiceMock.return_value.record = activity_record
+        await gs_mod.void_gate(
+            session, org_id, gate_id, voider_id, "더 이상 필요 없음",
+            actor_type="agent", void_reason_label="requester",
+        )
+
+    assert fake_sr.routing_reason == "gate voided by requester: 더 이상 필요 없음"
+    assert activity_record.call_args.kwargs["actor_type"] == "agent"
+
+
+@pytest.mark.anyio
+async def test_withdraw_endpoint_malformed_requester_field_404_not_500():
+    """⭐회귀가드② — 카디르 probe 실측: requested_by_member_id가 손상된 비-UUID 문자열이면
+    uuid.UUID(...) 파싱이 uncaught ValueError→500을 낸다. 문자열비교로 바꿔 크래시 없이
+    똑같이 404(모든 유효 uuid 문자열과도 매치될 리 없으므로 결과는 이미 fail-closed)."""
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateVoidRequest, withdraw_gate_endpoint
+
+    caller = _resolved(uuid.uuid4())
+    gate = _fake_gate(requester_id=caller.id)
+    gate.neutral_facts = {"requested_by_member_id": "not-a-valid-uuid-at-all"}
+    voidfn = AsyncMock()
+    session = _session_returning(gate)
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "void_gate", voidfn):
+        with pytest.raises(HTTPException) as ei:
+            await withdraw_gate_endpoint(
+                id=gate.id, body=GateVoidRequest(reason="x"),
+                session=session, org_id=uuid.uuid4(),
+                auth=SimpleNamespace(user_id=str(caller.user_id), claims={}),
+            )
+
+    assert ei.value.status_code == 404
+    voidfn.assert_not_awaited()

--- a/backend/tests/test_deeplink_manifest_contract.py
+++ b/backend/tests/test_deeplink_manifest_contract.py
@@ -97,7 +97,8 @@ def test_manifest_covers_all_30_dispatch_notification_event_types():
     story #2630: conversation.circuit_breaker_opened 신설로 26→27.
     story #2631: doc_approval_discussion_requested 신설로 27→28.
     story #2709: agent_decision_resolved 신설로 28→29.
-    story #1715: merge_gate_resolved 신설로 29→30."""
+    story #1715: merge_gate_resolved 신설로 29→30.
+    story #2789: agent_decision_withdrawn 신설로 30→31."""
     expected = {
         "sprint_closed", "task_completed", "story_assigned", "comment.created",
         "artifact.created", "artifact.exported", "artifact.updated", "artifact.canonicalized",
@@ -107,7 +108,7 @@ def test_manifest_covers_all_30_dispatch_notification_event_types():
         "doc_approval_requested", "handoff_fallback", "story_status_changed",
         "conversation.unsupervised_chain_expired", "doc_approval_resolved",
         "conversation.circuit_breaker_opened", "doc_approval_discussion_requested",
-        "agent_decision_resolved", "merge_gate_resolved",
+        "agent_decision_resolved", "merge_gate_resolved", "agent_decision_withdrawn",
     }
     actual = {e.app.type for e in DEEPLINK_MANIFEST.entries}
     missing = expected - actual

--- a/backend/tests/test_deeplink_manifest_endpoint.py
+++ b/backend/tests/test_deeplink_manifest_endpoint.py
@@ -51,7 +51,8 @@ async def test_deeplink_manifest_endpoint_returns_200_with_schema_version_and_lo
     # story #2631: doc_approval_discussion_requested 신설로 36→37.
     # story #2709: agent_decision_resolved 신설로 37→38.
     # story #1715: merge_gate_resolved 신설로 38→39.
-    assert isinstance(body["entries"], list) and len(body["entries"]) == 39
+    # story #2789: agent_decision_withdrawn 신설로 39→40.
+    assert isinstance(body["entries"], list) and len(body["entries"]) == 40
 
     # 미르코 point ②: lookup_key = f"{type}:{entity_type}" (구분자 ":") 서빙 시점 파생.
     story_entry = next(


### PR DESCRIPTION
## Summary
[SID:2789]

결정 요청(agent_decision_request) 게이트가 결재함에만 쌓이고 요청자(에이전트 포함) 본인이 철회할 방법이 없던 갭③(스토리 원문 2026-08-22 재그라운딩 기준 유일 잔존 갭)을 해소한다.

- `POST /api/v2/gates/{id}/withdraw` 신설 — `/void`(admin-only)와 다른 인가 축: `neutral_facts.requested_by_member_id`로 본인 요청 여부만 검사(불일치 시 404, 존재 비노출 관례). 상태전이/audit는 `void_gate()` SSOT 그대로 재사용(새 상태기계 발명 0), 승인자에게는 `dispatch_approval_result_reply(decision="withdrawn")`로 결과 회신(결재함+채팅 양쪽 반영).
- 재사용 과정에서 발견한 landmine 2건도 같이 수정:
  - `void_gate()`의 `actor_type="human"` 하드코딩 — 새 호출자(에이전트 자기-철회)가 생기며 더는 항상 참이 아니라 keyword-only 파라미터화(기존 admin `/void` 호출자 회귀 0, 기본값 유지).
  - `dispatch_approval_result_reply()`의 이진 라벨 매핑(`approved` 아니면 전부 "반려")이 `decision="withdrawn"`을 반려로 오라벨링 — 명시 딕셔너리(`{"approved": "승인", "rejected": "반려", "withdrawn": "철회"}`)로 교체.

## Test plan
- [x] 신규 11개 테스트(`backend/tests/test_2789_gate_withdraw_endpoint.py`) — 엔드포인트 직접호출 unit(`test_edg_s30_void_recovery.py` 패턴 재사용): 요청자 본인 철회 성공·비요청자/필드누락/gate미발견 404·이미해소 422·actor_type agent/human 정직 반영(parametrize)·승인자 "철회" 알림 발송/미지정 시 스킵/알림실패해도 commit 유지·`_DECISION_LABELS` 오라벨링 회귀가드.
- [x] mutation-검증 3종 모두 RED 확인 후 복원: actor_type 하드코딩 되돌리기 → agent 케이스 실패, 404 가드 제거 → 두 테스트 다른 에러로 실패, 라벨 딕셔너리 되돌리기 → "철회"가 "반려"로 잘못 뜨는 것 확인.
- [x] `uv run pytest tests/test_2789_gate_withdraw_endpoint.py tests/test_edg_s30_void_recovery.py tests/test_2709_agent_decision_request.py tests/test_2891_decision_request_chat_card_realdb.py` — 14 passed, 14 skipped(실PG 없는 로컬 환경, 정상), 회귀 0.
- [x] `pytest --collect-only` 전수(8007개) 수집 성공 — import 깨짐 없음.
- [x] `python -m py_compile` 3개 변경 파일 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn3Q9V8KkMkxDp5G34Amwo