### PR TITLE
[SID:3038] 결재함 merge 카드 work_item_summary(제목) 배치 enrich

### DIFF
--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -211,6 +211,39 @@ describe('ApprovalsQueue', () => {
     expect(text).not.toContain('파일');
   });
 
+  it('story #3038 AC4(PO #3188 오서명 실사고) — 같은 work_item의 merge 게이트 2장이 pr_number로 서로 구분된다', async () => {
+    mockFetches(
+      [
+        gate({
+          id: 'g-pr-a', can_approve: true, requires_human: true,
+          work_item_id: 'w-2728', work_item_summary: { title: '2728 결제 게이팅', slug: null },
+          pr_number: 3187, github_check_run_sha: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+        }),
+        gate({
+          id: 'g-pr-b', can_approve: true, requires_human: true,
+          work_item_id: 'w-2728', work_item_summary: { title: '2728 결제 게이팅', slug: null },
+          pr_number: 3460, github_check_run_sha: 'f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5',
+        }),
+      ],
+      [],
+    );
+    await mount();
+    const text = container.textContent ?? '';
+    expect(text).toContain('PR #3187');
+    expect(text).toContain('a1b2c3d');
+    expect(text).toContain('PR #3460');
+    expect(text).toContain('f6e5d4c');
+  });
+
+  it('story #3038 AC4 — pr_number가 없는 게이트(doc_approval 등)는 PR 배지를 지어내지 않는다', async () => {
+    mockFetches(
+      [gate({ id: 'g-no-pr', can_approve: true, requires_human: true, pr_number: null })],
+      [],
+    );
+    await mount();
+    expect(container.textContent ?? '').not.toContain('PR #');
+  });
+
   it('risk_grade 칩(고위험/위험도 확인 중)은 어떤 경우에도 더 이상 렌더되지 않는다', async () => {
     mockFetches(
       [gate({ id: 'g-no-chip', can_approve: true, requires_human: true, risk_grade: 'high' })],

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -369,7 +369,10 @@ export function ApprovalsQueue() {
                 content 폭까지 shrink-to-fit돼 ellipsis가 걸릴 폭 기준 자체가 없다(카드
                 우변에서 그냥 잘림). w-full로 폭을 부모 카드 전체로 고정해야 truncate가 실제로
                 동작한다. */}
-            <p className="w-full truncate text-sm text-foreground">
+            <p
+              className="w-full truncate text-sm text-foreground"
+              title={gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`}
+            >
               {gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`}
             </p>
             {orgName ? <p className="text-[11px] text-muted-foreground">{orgName}</p> : null}

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -59,6 +59,15 @@ function isHeld(gate: GateItem): boolean {
   return gate.status === 'held' || !!gate.held_until;
 }
 
+// story #3038 AC4(페드루 전언, PO #3188 오서명 실사고) — row 밀도(ProofCapsule)는 claim
+// 텍스트 1줄뿐이라 gateBody 카드처럼 별도 행을 못 얹는다. 같은 work_item(스토리)의 merge
+// 게이트가 여러 개(PR마다 1개, story #2893)면 제목만으론 동명 2장이 되므로, 있으면
+// 그 1줄 안에 PR 번호를 이어붙여 게이트 자신을 구분 가능하게 한다.
+function gateRowClaimLabel(gate: GateItem): string {
+  const identity = gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`;
+  return gate.pr_number ? `${identity} · PR #${gate.pr_number}` : identity;
+}
+
 // story #1961(P2-S5) — gates/[id]/page.tsx의 canAct 판정과 동일 규칙(중복 빌드 봉쇄 취지상
 // 판정 로직을 새로 짓지 않고 그대로 재사용 — gateNeedsAction만 import, doc/canonicalize
 // 특례·can_approve 게이팅까지 canonical 상세와 1:1).
@@ -375,6 +384,16 @@ export function ApprovalsQueue() {
             >
               {gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`}
             </p>
+            {/* story #3038 AC4(페드루 전언, PO #3188 오서명 실사고) — 같은 work_item(스토리)의
+                merge 게이트가 여러 개(PR마다 1개, story #2893)면 제목만으론 동명 2장이 된다.
+                pr_number·head SHA는 이미 GateResponse에 있었지만(from_attributes 자동 채움)
+                카드가 안 그려 판별자가 못 됐다 — 이 게이트 자신의 고유 식별을 1행에 표기. */}
+            {gate.pr_number ? (
+              <p className="text-[11px] font-medium text-muted-foreground">
+                PR #{gate.pr_number}
+                {gate.github_check_run_sha ? ` · ${gate.github_check_run_sha.slice(0, 7)}` : ''}
+              </p>
+            ) : null}
             {orgName ? <p className="text-[11px] text-muted-foreground">{orgName}</p> : null}
             {diffFacts ? (
               <p className="text-[11px] text-muted-foreground">
@@ -459,7 +478,7 @@ export function ApprovalsQueue() {
                 density="row"
                 proofState={'amber' as ProofState}
                 stateLabel={held ? t('gateStatusHeld') : t('gateStatusPending')}
-                claim={gate.work_item_summary?.title ?? `#${gate.work_item_id.slice(0, 8)}`}
+                claim={gateRowClaimLabel(gate)}
                 duration={formatAge(gate.created_at, t)}
               />
             </button>
@@ -562,6 +581,14 @@ export function ApprovalsQueue() {
             <DialogTitle>
               {signatureGate ? (signatureGate.work_item_summary?.title ?? `#${signatureGate.work_item_id.slice(0, 8)}`) : ''}
             </DialogTitle>
+            {/* story #3038 AC4 — 서명 모달도 방어적으로 동형 표기(카드 단계에서 이미 구분
+                가능해졌지만, 모달 단독으로도 "이게 그 PR 맞나" 재확認 가능하게). */}
+            {signatureGate?.pr_number ? (
+              <p className="text-[11px] text-muted-foreground">
+                PR #{signatureGate.pr_number}
+                {signatureGate.github_check_run_sha ? ` · ${signatureGate.github_check_run_sha.slice(0, 7)}` : ''}
+              </p>
+            ) : null}
           </DialogHeader>
           {signatureGate ? (
             // story #2975(유나양 design 판정) 갭 자체발견(#2982 작업 중) — 동형 처방(SHA

--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -44,6 +44,17 @@ describe('ProofCapsule (density variants)', () => {
     }
   });
 
+  it('story #3038(선생님 실사고, 결재함 merge 카드 «#해시») — row/audit(단일행 truncate)의 claim에 title 툴팁으로 전문 노출', () => {
+    // AC1: "긴 제목은 truncate(툴팁 전문)" — truncate는 시각적으로만 잘릴 뿐, 마우스오버 시
+    // native title 속성으로 전문을 볼 수 있어야 한다(별도 팝오버 컴포넌트 신설 없이 최소 구현).
+    // full/card는 truncate가 아니라 line-clamp-2/줄바꿈이라 이 요구 범위 밖(생략 텍스트가 아님).
+    const longClaim = '[SID:9999] 아주 긴 스토리 제목이라 한 줄에 다 안 들어가고 잘려야 하는 케이스';
+    for (const density of ['row', 'audit'] as const) {
+      const markup = renderWithIntl(<ProofCapsule {...BASE} claim={longClaim} density={density} />);
+      expect(markup).toContain(`title="${longClaim}"`);
+    }
+  });
+
   it('applies a clip-path cut-corner on full/card/row (not a plain rounded-full pill anywhere)', () => {
     // story #2955 §5 — clip-path 지오메트리 계산이 인라인 style에서 globals.css의 `.proof-cut`
     // 단일 정본으로 이관됐다(CutCornerShell). 렌더 마크업엔 이제 'polygon(' 리터럴이 없다

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -383,7 +383,7 @@ function InlineRow({
           ) : null}
           <StateHeader state={proofState} label={stateLabel} />
         </span>
-        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-proof-ink">{claim}</span>
+        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-proof-ink" title={claim}>{claim}</span>
         <span className="inline-flex shrink-0 items-center gap-2">
           {duration ? <span className="shrink-0 text-[10.5px] font-medium text-proof-ink-3">{duration}</span> : null}
           {human ? <Avatar name={human.name} actorType="human" size={22} /> : null}
@@ -419,7 +419,7 @@ function AuditRow({ proofState, claim, now, human, agent, className }: Pick<Proo
   return (
     <div className={cn('flex items-center gap-2 rounded-[6px] border border-proof-line bg-proof-panel px-3 py-2 text-[11px]', className)}>
       <span className={cn('size-1.5 shrink-0 rounded-full', dotTone[proofState])} aria-hidden="true" />
-      <span className="min-w-0 flex-1 truncate font-medium text-proof-ink">{claim}</span>
+      <span className="min-w-0 flex-1 truncate font-medium text-proof-ink" title={claim}>{claim}</span>
       {actorName ? <Avatar name={actorName} actorType={agent ? 'agent' : 'human'} size={16} /> : null}
       <span className="shrink-0 font-mono text-[9.5px] text-proof-ink-3">{[now, actorName].filter(Boolean).join(' ')}</span>
     </div>

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -741,20 +741,29 @@ async def list_gates(
         # owner/admin(정본 담당자)에겐 assigned_to_me=true 인박스에서 사라졌다(회귀). VisualArtifact.
         # project_id는 NOT NULL이라 story/task와 동형으로 항상 배치 해소 가능.
         artifact_ids = {g.work_item_id for _, g in non_doc_gates if g.work_item_type == "visual_artifact"}
+        # story #3784a8d0(3038, 실사고 — 선생님 제보 2026-08-25) — work_item_summary가 doc만
+        # 배치 enrich됐다. merge 게이트(work_item_type=='story', 결재함 대다수)는 항상 None이라
+        # FE가 "#해시" 폴백만 그렸다 — `_resolve_work_item_summary`(단건 GET /{id} 경로, story
+        # #1970)는 story/task를 이미 커버하는데 이 목록/배치 경로만 doc-only로 남아 있던
+        # 드리프트. 새 쿼리를 추가하지 않고 이미 도는 이 project_id 배치 쿼리에 title을
+        # 얹는다(N+1 0 유지 — 이 파일이 이미 지켜온 관례 그대로).
+        summary_by_work_item: dict[uuid.UUID, WorkItemSummary] = {}
         if story_ids:
             rows = (await session.execute(
-                select(Story.id, Story.project_id).where(
+                select(Story.id, Story.project_id, Story.title).where(
                     Story.id.in_(story_ids), Story.org_id == org_id,
                 )
             )).all()
-            project_id_by_work_item.update({sid: pid for sid, pid in rows})
+            project_id_by_work_item.update({sid: pid for sid, pid, _ in rows})
+            summary_by_work_item.update({sid: WorkItemSummary(title=title) for sid, _, title in rows})
         if task_ids:
             rows = (await session.execute(
-                select(Task.id, Story.project_id)
+                select(Task.id, Story.project_id, Task.title)
                 .join(Story, Task.story_id == Story.id)
                 .where(Task.id.in_(task_ids), Task.org_id == org_id)
             )).all()
-            project_id_by_work_item.update({tid: pid for tid, pid in rows})
+            project_id_by_work_item.update({tid: pid for tid, pid, _ in rows})
+            summary_by_work_item.update({tid: WorkItemSummary(title=title) for tid, _, title in rows})
         if artifact_ids:
             rows = (await session.execute(
                 select(VisualArtifact.id, VisualArtifact.project_id).where(
@@ -762,6 +771,9 @@ async def list_gates(
                 )
             )).all()
             project_id_by_work_item.update({aid: pid for aid, pid in rows})
+        for resp in responses:
+            if resp.work_item_type in ("story", "task"):
+                resp.work_item_summary = summary_by_work_item.get(resp.work_item_id)
 
     # ⭐신규 enrich(원인 수정 본체): 위에서 이미 계산해 둔 project_id_by_work_item 을
     # can_approve 판정뿐 아니라 응답 필드 자체에도 대입한다 — 지금까지 이 값이 어디에도 안

--- a/backend/tests/test_1974_gate_assigned_to_me.py
+++ b/backend/tests/test_1974_gate_assigned_to_me.py
@@ -236,7 +236,7 @@ async def test_assigned_to_me_doc_approval_self_author_excluded():
 async def test_assigned_to_me_project_role_owner_included():
     g = _story_gate(gate_type="merge")
     out = await _call_list_gates(
-        [g], project_role="owner", story_rows=[(g.work_item_id, uuid.uuid4())],
+        [g], project_role="owner", story_rows=[(g.work_item_id, uuid.uuid4(), "T")],
     )
     assert len(out) == 1
     assert out[0].id == g.id
@@ -246,7 +246,7 @@ async def test_assigned_to_me_project_role_owner_included():
 async def test_assigned_to_me_project_role_member_excluded():
     g = _story_gate(gate_type="qa")
     out = await _call_list_gates(
-        [g], project_role="member", story_rows=[(g.work_item_id, uuid.uuid4())],
+        [g], project_role="member", story_rows=[(g.work_item_id, uuid.uuid4(), "T")],
     )
     assert out == []
 
@@ -275,7 +275,7 @@ async def test_assigned_to_me_held_status_included():
     시뮬레이션하듯 held 게이트를 직접 넘겨 eligibility 판정만 검증)."""
     g = _story_gate(gate_type="merge", status="held")
     out = await _call_list_gates(
-        [g], project_role="owner", story_rows=[(g.work_item_id, uuid.uuid4())],
+        [g], project_role="owner", story_rows=[(g.work_item_id, uuid.uuid4(), "T")],
     )
     assert len(out) == 1
     assert out[0].id == g.id
@@ -287,7 +287,7 @@ async def test_assigned_to_me_approved_status_included_when_role_eligible():
     필터링 책임은 전적으로 바깥 `status` 쿼리 파라미터(list_gates 최상단 select)에 있다."""
     g = _story_gate(gate_type="merge", status="approved")
     out = await _call_list_gates(
-        [g], project_role="owner", story_rows=[(g.work_item_id, uuid.uuid4())],
+        [g], project_role="owner", story_rows=[(g.work_item_id, uuid.uuid4(), "T")],
     )
     assert len(out) == 1
     assert out[0].id == g.id
@@ -300,7 +300,7 @@ async def test_assigned_to_me_agent_caller_returns_empty():
     g = _story_gate(gate_type="merge")
     out = await _call_list_gates(
         [g], resolved=_agent(uuid.uuid4()), project_role="owner",
-        story_rows=[(g.work_item_id, uuid.uuid4())],
+        story_rows=[(g.work_item_id, uuid.uuid4(), "T")],
     )
     assert out == []
 
@@ -320,7 +320,7 @@ async def test_assigned_to_me_mixed_gates_only_eligible_returned():
     org_g = _org_level_gate()
     out = await _call_list_gates(
         [doc_g, story_g, org_g], has_access=True, project_role="member", org_admin=True,
-        story_rows=[(story_g.work_item_id, uuid.uuid4())],
+        story_rows=[(story_g.work_item_id, uuid.uuid4(), "T")],
     )
     ids = {r.id for r in out}
     assert ids == {doc_g.id, org_g.id}  # story_g(member=불가)만 배제
@@ -342,7 +342,7 @@ async def test_default_assigned_to_me_false_returns_all_unfiltered_but_can_appro
     g = _story_gate(gate_type="merge")
     out = await _call_list_gates(
         [g], project_role="owner", assigned_to_me=False,
-        story_rows=[(g.work_item_id, uuid.uuid4())],
+        story_rows=[(g.work_item_id, uuid.uuid4(), "T")],
     )
     assert len(out) == 1
     assert out[0].id == g.id

--- a/backend/tests/test_gate_decider_can_approve_89484c8c.py
+++ b/backend/tests/test_gate_decider_can_approve_89484c8c.py
@@ -208,7 +208,7 @@ async def _run_non_doc_can_approve(project_role):
     gates_result = MagicMock()
     gates_result.scalars.return_value.all.return_value = [merge]
     story_batch = MagicMock()
-    story_batch.all.return_value = [(merge.work_item_id, uuid.uuid4())]
+    story_batch.all.return_value = [(merge.work_item_id, uuid.uuid4(), "T")]
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[gates_result, story_batch])
     auth = SimpleNamespace(user_id=str(uuid.uuid4()))

--- a/backend/tests/test_gate_inbox_doc_enrich.py
+++ b/backend/tests/test_gate_inbox_doc_enrich.py
@@ -56,26 +56,36 @@ async def test_doc_gate_enriched_with_title_slug():
 
 
 @pytest.mark.anyio
-async def test_non_doc_gate_no_enrich_no_extra_query():
-    """비-doc gate 는 work_item_summary enrich 0·doc 쿼리 미발생(N+1 0)·can_approve enrich skip(비휴먼/
+async def test_story_gate_summary_enriched_via_project_id_batch_no_extra_query():
+    """doc 전용 쿼리·can_approve 판정 쿼리는 여전히 안 나감(N+1 0)·can_approve enrich skip(비휴먼/
     resolve 실패 caller).
 
     ⚠️2026-07-31 수정(오르테가 라이브 실측 — GET /api/v2/gates pending 37/37 project_id=None):
     story/task/artifact project_id 배치 조회는 이제 caller 타입과 무관하게 항상 돈다(project_id는
     authz 판정이 아니라 데이터 정합성이라 caller 의존이면 결함). 그래서 이 케이스도 session.execute
-    호출이 1(gates)→2(gates+story 배치)로 늘었다 —
-    "쿼리가 아예 안 남"이 아니라 "doc 전용 쿼리·can_approve 판정 쿼리가 안 남"으로 좁혀 재확認한다."""
+    호출이 1(gates)→2(gates+story 배치)로 늘었다.
+
+    ⚠️story #3784a8d0(3038, 2026-08-25) 갱신 — 이 테스트는 원래 "비-doc gate는 work_item_summary
+    enrich 0"을 단언했었는데, 그게 바로 #3038의 버그 그 자체였다(merge 카드가 "#해시"만 보이던
+    실사고). story project_id 배치 쿼리에 title도 얹어 같은 쿼리 1건으로 enrich한다(새 쿼리 추가
+    없음 — N+1 0 유지) — 테스트명·단언 전부 새 계약으로 갱신."""
     org, story_id, pid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     gates_res = MagicMock()
     gates_res.scalars.return_value.all.return_value = [_gate(org, story_id, "story")]
     story_batch_res = MagicMock()
-    story_batch_res.all.return_value = [(story_id, pid)]
+    # story #3784a8d0(3038) — 이 배치 쿼리가 이제 project_id뿐 아니라 title도 같이 실어
+    # 3-tuple이 됐다(work_item_summary enrich를 별도 쿼리로 안 늘리고 이 쿼리에 얹음).
+    story_batch_res.all.return_value = [(story_id, pid, "스토리 제목")]
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[gates_res, story_batch_res])
     with patch.object(gates_mod, "get_org_posture", AsyncMock(return_value=None)):
         out = await list_gates(work_item_id=None, work_item_type=None, status=None,
                                assigned_to_me=False, session=session, org_id=org, auth=None)
-    assert out[0].work_item_summary is None
+    # story #3784a8d0(3038, 실사고 fix) — merge 게이트(work_item_type=='story')도 이제
+    # work_item_summary가 채워진다(예전엔 이 테스트명대로 "no enrich"였으나, 그게 바로
+    # #3038의 버그 그 자체였다 — 테스트명은 유지하되 단언은 새 계약으로 갱신).
+    assert out[0].work_item_summary is not None
+    assert out[0].work_item_summary.title == "스토리 제목"
     assert out[0].can_approve is False  # 비휴먼/resolve 실패 caller — authz enrich 는 여전히 skip
     assert out[0].project_id == pid  # ⭐데이터 enrich 는 caller 무관 — 근본수정 본체
-    assert session.execute.await_count == 2  # gates + story project_id 배치(doc 쿼리·posture 는 mocked)
+    assert session.execute.await_count == 2  # gates + story project_id/title 배치(doc 쿼리·posture 는 mocked, N+1 0 유지)


### PR DESCRIPTION
## 요약
- **증상**(선생님 실사고 제보): 결재함(inbox) merge 게이트 카드가 제목 없이 `#e6500272` 같은 해시만 보여 무엇에 대한 결재인지 카드만으로 알 수 없었음.
- **원인**: `gates.py`의 `list_gates()`가 `work_item_summary`를 `work_item_type == "doc"`에만 배치 enrich했음. merge 게이트(대부분 `work_item_type == "story"`)는 항상 `work_item_summary = None`이라 FE가 `#해시` 폴백만 그림.
- **실사고 표본 #2**(페드루 전언): PO가 같은 스토리(#2728)의 게이트 카드 2장을 구별 못 해 엉뚱한 게이트(#3188 고아)에 서명. 제목만으론 동일 work_item의 복수 merge 게이트(PR마다 1개)가 여전히 동명 2장.

## 수정 (커밋 1 — BE, AC1~3)
- 새 쿼리를 추가하지 않고, 이미 caller-무관으로 항상 도는 기존 `project_id_by_work_item` 배치 쿼리(story #1968)에 `Story.title`/`Task.title`을 얹어 같은 쿼리 1건으로 `work_item_summary`도 함께 채움(N+1 0 유지).

## 수정 (커밋 2 — FE, AC1 완결: 툴팁)
- `proof-capsule.tsx`의 단일행 truncate claim(row/audit 밀도)과 `approvals-queue.tsx` 카드 제목 문단에 native `title` 속성 추가.

## 수정 (커밋 3 — FE, AC4: 게이트 고유 식별)
- BE는 이미 `pr_number`(Gate ORM 컬럼, story #2893)·`github_check_run_sha`(story #3244)를 `GateResponse`에 노출 중이었음(`from_attributes` 자동 채움) — `kanban/types.ts:88-90` 주석에 "FE가 이 gates 배열 중 어느 게 지금 관심 있는 PR의 것인지 고르는 축"이라고 설계 의도까지 이미 적혀 있었는데 카드가 안 그려주던 순수 FE 렌더 갭.
- `gateBody` 카드·서명 모달에 `PR #<pr_number> · <head_sha 앞 7자>` 행 추가.
- `ProofCapsule` row 밀도는 claim 1줄뿐이라 `gateRowClaimLabel()` 헬퍼로 claim 문자열에 `· PR #<n>` 접미(1행 유지).

## 검증
- **회귀가드(BE)**: git stash로 pre-fix 코드에 새 mock(3-tuple)을 대면 `ValueError`로 즉시 크래시 확認.
- gate 관련 테스트 12개 파일을 `alembic upgrade head`한 realdb로 재검증: **139 pass**. 무관 사전 결함 5개(`test_2198_non_doc_gate_authz_realdb.py`, `projects.violation_level NOT NULL` 위반)는 develop HEAD 기준으로도 동일 재현되는 기존 결함 — 본 PR 범위 밖.
- **회귀가드(FE, AC1 툴팁)**: title 속성 제거 시 RED 확認(stash 실증).
- **회귀가드(FE, AC4)**: PO 실사고 문구를 그대로 재현하는 2-게이트 시나리오 테스트 신설 — git stash로 pre-fix에선 두 카드 텍스트가 완전 동일함을 실증(진짜 재현), fix 후 PR 번호·SHA로 구분됨을 확認. pr_number 없는 게이트는 배지를 지어내지 않는 음성대조 포함.
- `proof-capsule.test.tsx`(43)+`approvals-queue.test.tsx`(51) 전체 pass, eslint 0 warning, `pnpm build` EXIT=0.
- **실픽셀(before/after)**: Puppeteer + `next build` 컴파일 Tailwind CSS로 실 마크업 재현. AC1(해시→제목)·AC4(동명 2장→PR#/SHA 구분) 양쪽 라이트/다크 확認(단, 3번째 커밋 이후 puppeteer 세션 종료로 최종 스크린샷 재확認은 vitest DOM 텍스트 회귀가드로 대체 — 마크업 자체는 1·2커밋에서 이미 실렌더 확認된 동일 클래스 조합).

## AC 체크
- [x] merge 카드에 사람이 읽는 제목 1행 표시(해시는 폴백으로 강등)
- [x] 대기 일수·유형 등 기존 필드 유지(무변경)
- [x] 긴 제목 truncate + 툴팁 전문
- [x] 같은 work_item의 복수 게이트 카드가 PR 번호·head SHA로 구분됨(PO #3188 오서명 재발 방지)
- [x] before/after 실픽셀 확認

## 리뷰 요청
- 유나군 design
- 카디르군 QA