### PR TITLE
fix(#3039): CI-완료 웹훅이 merge 게이트 재평가를 다시 못 태우던 근본원인 2건

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -27,7 +27,7 @@ from app.models.pm import Story
 from app.routers.cron import CRON_SECRET, _err, _ok, verify_cron
 from app.services.github_app import get_installation_token
 from app.services.merge_verdict_gate import reconcile_merge_gate_with_real_evidence
-from app.services.pr_story_link import merge_link_evidence, resolve_story_for_pr
+from app.services.pr_story_link import merge_link_evidence, resolve_story_for_pr, upsert_link
 from app.services.verdict_capture import (
     capture_pr_ci_verdict,
     capture_review_verdict,
@@ -468,6 +468,33 @@ async def _process_webhook_event(
     story_id = rl.story_id
     org_id = rl.org_id  # app=입력 org·legacy=story.org_id(resolver 검증). 단일 진실원.
     delivery.org_id = org_id
+
+    # story #3039(2026-08-25, PO 판정) — resolve_story_for_pr()의 SID/auto_match/text 해소는
+    # 매 호출 휘발성(반환만·미영속)이다. pull_request류 이벤트는 payload에 title/body가
+    # 있어(_candidate_texts) 매번 SID 텍스트로 재해소되지만, check_suite/workflow_run/status
+    # 이벤트는 그 텍스트 자체가 payload에 없어 이 경로로는 다시는 못 찾는다 — 최초
+    # pull_request.opened 웹훅에서 SID로 딱 한 번 풀리고, 그 뒤 도착하는 CI-완료 웹훅은 전부
+    # "story 못 찾음"으로 조용히 ignored 처리돼(위 skipped_reason 분기) 게이트 재평가
+    # (reconcile_merge_gate_with_real_evidence)가 원천적으로 다시 안 태워지는 근본원인이었다
+    # (실 사례: PR#3460 — 5개 워크플로 전부 green·check_suite completed 웹훅 200 배달 확認됐으나
+    # 게이트 neutral_facts.ci_result 영구 null, evaluate_merge_gate 재호출 로그 0건). 비-stored
+    # 경로(explicit/stored_link 가 아닌, 즉 이번에 텍스트/auto_match 로 새로 풀린 것)로 해소되면
+    # 그 자리서 canonical link 로 영속화 — 다음부턴 이 함수의 1)단계(explicit/stored link, 텍스트
+    # 불요)가 바로 찾는다. #2832 교훈대로 upsert_link 는 evidence 병합(전체교체 아님)이라 이후
+    # 웹훅이 채우는 head_sha/scope_check 와 충돌 없다. 저장 실패는 이 요청의 처리 자체를 막지
+    # 않는다(비차단 — 최악의 경우 이번에도 못 찾은 것과 동일하게 남을 뿐).
+    if org_id is not None and repo and pr_number > 0 and rl.reason not in ("stored_explicit", "stored_link"):
+        try:
+            await upsert_link(
+                session, org_id, story_id, repo, pr_number,
+                link_source=rl.source or "auto_match", confidence=rl.confidence or "medium",
+                evidence=rl.evidence,
+            )
+        except Exception:  # noqa: BLE001 — 링크 캐싱 실패가 이번 웹훅 처리 자체를 막으면 안 된다.
+            logger.warning(
+                "PR-story link 영속화 실패(비차단) repo=%s pr=%s story=%s",
+                repo, pr_number, story_id, exc_info=True,
+            )
 
     # story #2813 — PR 라이프사이클 자체(opened/reopened/ready_for_review/synchronize)는 CI/merge
     # 증거와 무관하게 merge 게이트를 GitHub check-run으로 반영한다. 설계 doc §2-1(PO 승인): 카드

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -562,6 +562,19 @@ async def evaluate_merge_gate(
             "merge gate re-opened on resubmit story=%s gate=%s prior=%s",
             story_id, gate.id, prior["status"],
         )
+    elif gate.status in ("pending", "auto_passed") and _prior_gate is not None:
+        # story #3039(2026-08-25, 근본원인 fix②) — create_gate()의 멱등 반환은 이미 존재하는
+        # gate에 새 neutral_facts를 전혀 반영하지 않는다(신규 생성 시점에만 씀). 그래서 CI/PR
+        # 증거가 나중에(웹훅으로) 갱신돼도 이 함수가 매번 새로 계산한 ci_result/pr_result 등이
+        # DB에 영구 반영 안 되고 증발했다 — decision_basis/auto_decision_reason(아래 H1-FIX-1,
+        # gate row 컬럼)은 이미 재평가마다 write-back되는데 neutral_facts(JSONB, FE가 실제
+        # "CI 통과/사유"를 읽는 자리)만 최초 생성 시점 값에 영구히 갇혀 있었다(실사고: PR#3460 —
+        # 5개 워크플로 전부 green check_suite completed 웹훅을 200으로 수신했으나
+        # gate.neutral_facts.ci_result가 계속 null). 기존 키(과거 reopen이 남긴
+        # decision_history 등)는 보존하고 이번에 새로 계산된 관찰사실/증거만 병합 갱신한다
+        # (전체교체 아님 — #2832 교훈과 동형).
+        gate.neutral_facts = {**(gate.neutral_facts or {}), **facts}
+        await session.flush()
 
     # story #2118(E-DG-REAL ②) — doc.py의 dispatch_approval_request_cards(#2604) 패턴을 merge
     # gate까지 확장: 이 호출에서 gate가 «방금» pending이 된 경우만(_prior_status와 비교, 위 주석

--- a/backend/tests/test_2156_merge_gate_evidence_realdb.py
+++ b/backend/tests/test_2156_merge_gate_evidence_realdb.py
@@ -551,8 +551,10 @@ async def test_gate_check_publish_fires_on_base_retarget_edit_when_story_linked(
     # story #2893/#2932 후속(카디르 QA) — find_gate_slot_with_pr_fallback가 정확매치(없음)→
     # repo-unknown 슬롯(없음, story #2932 HIGH1 잔여)→NULL-슬롯 폴백까지 조회한다(3 SELECT).
     # 이 테스트는 전부 "없음"인 시나리오(진짜 신규)라 매 자리 no_gate_result 재사용으로 충분.
+    # story #3039 — resolve_story_for_pr가 sid(비-stored) 경로로 해소되면 upsert_link()가
+    # 그 자리서 링크를 영속화한다(기존 PullRequestStoryLink 존재여부 확인 SELECT 1건 추가).
     session.execute = AsyncMock(
-        side_effect=[installation_result, no_gate_result, no_gate_result, no_gate_result]
+        side_effect=[installation_result, no_gate_result, no_gate_result, no_gate_result, no_gate_result]
     )
     evaluate = AsyncMock(return_value=SimpleNamespace(gate_id=gate_id))
     gate_check_publish: list[dict] = []

--- a/backend/tests/test_3039_merge_gate_ci_reeval_webhook_realdb.py
+++ b/backend/tests/test_3039_merge_gate_ci_reeval_webhook_realdb.py
@@ -1,0 +1,333 @@
+"""story #3039(2026-08-25, PO 판정) — CI-완료 웹훅이 merge 게이트 재평가를 다시 못 태우던
+근본원인 2건의 회귀가드(실 사례: PR#3460 — 5개 워크플로 전부 green check_suite completed
+웹훅을 200으로 수신했으나 gate.neutral_facts.ci_result가 영구 null이었다).
+
+fix① — resolve_story_for_pr()의 SID/auto_match 해소는 매 호출 휘발성(반환만·미영속)이었다.
+check_suite/workflow_run/status 이벤트는 payload에 PR title/body가 없어(_candidate_texts)
+SID 텍스트로 다시 못 찾는다 — 최초 pull_request.opened 웹훅에서 SID로 한 번 풀린 뒤로는
+텍스트 신호가 사라져 그 뒤 도착하는 CI-완료 웹훅은 전부 "story 못 찾음"으로 조용히
+ignored 처리됐다. verdict_capture.py가 이제 텍스트 기반 해소 성공 시 그 자리서
+PullRequestStoryLink로 영속화한다 — 다음부턴 explicit/stored 1)단계(텍스트 불요)가 바로 찾는다.
+
+fix② — evaluate_merge_gate()가 재평가 때마다 ci/pr/decision을 정확히 재계산하고
+decision_basis/auto_decision_reason(gate row 컬럼)은 write-back 하지만, create_gate()의
+멱등 반환 특성상 neutral_facts(JSONB, FE가 실제로 읽는 "CI 통과/사유" 자리)는 최초 생성
+시점 값에 영구히 갇혀 있었다 — 재평가 시 병합 갱신하도록 고쳤다.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+APP_SECRET = "app-secret-3039"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401
+    import app.models.verdict  # noqa: F401 — capture_pr_ci_verdict가 verdict 테이블을 쓴다.
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _sign(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+async def _post_app(payload, Session, *, delivery_id, event="pull_request"):
+    from app.main import app as fastapi_app
+    from app.routers import verdict_capture as mod
+    from tests.conftest import override_db_and_read
+
+    async def override_db():
+        async with Session() as s:
+            yield s
+
+    override_db_and_read(fastapi_app, override_db)
+    body = json.dumps(payload).encode()
+    headers = {
+        "X-GitHub-Event": event, "X-GitHub-Delivery": delivery_id,
+        "X-Hub-Signature-256": _sign(body, APP_SECRET),
+    }
+    try:
+        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            with patch.object(mod.settings, "github_webhook_secret", "legacy-unused"), \
+                 patch.object(mod.settings, "github_app_webhook_secret", APP_SECRET):
+                return await c.post(
+                    "/api/v2/internal/verdict/github-webhook", content=body, headers=headers,
+                )
+    finally:
+        fastapi_app.dependency_overrides.clear()
+
+
+def _pr_opened_payload(*, pr_number, installation_id, head_sha, title):
+    """SID 태그만이 유일한 해소 신호(explicit link 사전등재 없음) — check_suite류는 이 텍스트가
+    payload에 없다는 것이 fix①의 정확한 실측 지점."""
+    return {
+        "action": "opened",
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "installation": {"id": installation_id},
+        "pull_request": {
+            "number": pr_number, "title": title, "body": "", "merged": False,
+            "head": {"sha": head_sha, "ref": f"feat-branch-{pr_number}"},
+        },
+    }
+
+
+def _check_suite_completed_payload(*, pr_number, installation_id, head_sha, conclusion):
+    """check_suite payload — title/body 자체가 없다(_candidate_texts가 head_branch/ref만
+    본다, SID 텍스트 원천 부재)."""
+    return {
+        "action": "completed",
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "installation": {"id": installation_id},
+        "check_suite": {
+            "head_sha": head_sha, "head_branch": f"feat-branch-{pr_number}",
+            "conclusion": conclusion,
+            "pull_requests": [{"number": pr_number, "head": {"ref": f"feat-branch-{pr_number}"}}],
+            "app": {"slug": "github-actions"},
+        },
+    }
+
+
+async def _seed_org_project_story(s, *, with_participation: bool):
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org3039", slug=f"org3039-{uuid.uuid4().hex[:8]}")
+    s.add(org)
+    await s.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    s.add(project)
+    await s.commit()
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="in-progress")
+    s.add(story)
+    await s.commit()
+
+    if with_participation:
+        from app.models.participation import Participation, ParticipationRole
+
+        role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="implementation", label="Impl", is_default=True)
+        s.add(role)
+        await s.commit()
+        member_id = uuid.uuid4()
+        s.add(Participation(id=uuid.uuid4(), org_id=org.id, story_id=story.id, member_id=member_id, role_id=role.id))
+        await s.commit()
+
+    return org, project, story
+
+
+async def _seed_installation(s, org, *, installation_id):
+    from app.models.github_installation import GithubInstallation
+
+    inst = GithubInstallation(
+        id=uuid.uuid4(), org_id=org.id, installation_id=installation_id, account_login="moonklabs",
+    )
+    s.add(inst)
+    await s.commit()
+    return inst
+
+
+async def _get_gate(s, story_id, pr_number):
+    from app.models.gate import Gate
+    from app.services.merge_verdict_gate import MERGE_GATE_TYPE
+
+    return (
+        await s.execute(
+            select(Gate).where(
+                Gate.work_item_id == story_id, Gate.gate_type == MERGE_GATE_TYPE, Gate.pr_number == pr_number,
+            )
+        )
+    ).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_sid_only_resolution_persists_pr_story_link():
+    """⭐fix① 핵심 — explicit link 사전등재 0, SID 텍스트만으로 해소된 pull_request.opened
+    처리 後 PullRequestStoryLink가 실제로 DB에 남는다(다음부터 텍스트 불요 조회 가능)."""
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=690001)
+            story_id, org_id = story.id, org.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run", AsyncMock(return_value={"id": 92001}),
+        ), patch("app.core.database.async_session_factory", Session):
+            resp = await _post_app(
+                _pr_opened_payload(
+                    pr_number=3460, installation_id=690001, head_sha="sha-3460-orig",
+                    title=f"[SID:{story_id}] fix billing gate",
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+            assert resp.status_code == 200, resp.text
+
+        async with Session() as s:
+            link = (await s.execute(
+                select(PullRequestStoryLink).where(
+                    PullRequestStoryLink.org_id == org_id,
+                    PullRequestStoryLink.repo_full_name == "moonklabs/sprintable",
+                    PullRequestStoryLink.pr_number == 3460,
+                )
+            )).scalar_one_or_none()
+            assert link is not None, "SID 텍스트로만 풀린 해소가 링크로 영속화되지 않음(fix① 회귀)"
+            assert link.story_id == story_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_check_suite_after_sid_open_updates_pending_gate_ci_result():
+    """⭐#3460 실사고 정확 재현+회귀가드(fix①+②) — SID로만 해소된 PR 오픈 後, title/body가
+    아예 없는 check_suite completed(success) 이벤트가 그 게이트를 찾아 ci_result를 실제로
+    갱신한다. fix① 없으면 이 이벤트는 조용히 ignored(story 못 찾음)로 죽고, fix② 없으면
+    설령 찾아도 neutral_facts가 create_gate 멱등경로에 막혀 갱신 안 된다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=690002)
+            story_id = story.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run", AsyncMock(return_value={"id": 92002}),
+        ), patch("app.core.database.async_session_factory", Session):
+            await _post_app(
+                _pr_opened_payload(
+                    pr_number=3461, installation_id=690002, head_sha="sha-3461-orig",
+                    title=f"[SID:{story_id}] fix billing gate2",
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+
+        async with Session() as s:
+            gate = await _get_gate(s, story_id, 3461)
+            assert (gate.neutral_facts or {}).get("ci_result") is None, "생성 시점엔 CI 미지가 정상"
+
+        with patch(
+            "app.services.gate_github_check.publish_gate_check", AsyncMock(return_value=None),
+        ), patch("app.core.database.async_session_factory", Session):
+            resp = await _post_app(
+                _check_suite_completed_payload(
+                    pr_number=3461, installation_id=690002, head_sha="sha-3461-orig", conclusion="success",
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}", event="check_suite",
+            )
+            assert resp.status_code == 200, resp.text
+
+        async with Session() as s:
+            gate = await _get_gate(s, story_id, 3461)
+            assert gate.neutral_facts.get("ci_result") == "pass", (
+                f"check_suite completed(success)가 도달했는데도 neutral_facts.ci_result가 "
+                f"갱신 안 됨: {gate.neutral_facts}"
+            )
+            assert gate.status == "pending", "사람 승인 전이라 여전히 pending(자동 승격 아님)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reevaluation_updates_neutral_facts_with_link_already_stored():
+    """⭐fix② 단독 격리 — explicit link를 미리 심어(fix①과 무관하게 해소 자체는 항상 성공)도,
+    같은 게이트에 대한 두 번째 재평가(check_suite completed, 첫 실패→두번째 성공)가 최신
+    ci_result로 neutral_facts를 갱신하는지만 좁혀 검증한다."""
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, _project, story = await _seed_org_project_story(s, with_participation=True)
+            await _seed_installation(s, org, installation_id=690003)
+            s.add(PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=org.id, story_id=story.id,
+                repo_full_name="moonklabs/sprintable", pr_number=3462,
+                link_source="explicit", confidence="high",
+            ))
+            await s.commit()
+            story_id = story.id
+
+        with patch(
+            "app.services.gate_github_check.create_check_run", AsyncMock(return_value={"id": 92003}),
+        ), patch("app.core.database.async_session_factory", Session):
+            await _post_app(
+                _pr_opened_payload(
+                    pr_number=3462, installation_id=690003, head_sha="sha-3462-orig",
+                    title="chore: no sid tag here",
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+            )
+
+        with patch(
+            "app.services.gate_github_check.publish_gate_check", AsyncMock(return_value=None),
+        ), patch("app.core.database.async_session_factory", Session):
+            # 1차: CI 실패.
+            await _post_app(
+                _check_suite_completed_payload(
+                    pr_number=3462, installation_id=690003, head_sha="sha-3462-orig", conclusion="failure",
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}", event="check_suite",
+            )
+            async with Session() as s:
+                gate = await _get_gate(s, story_id, 3462)
+                assert gate.neutral_facts.get("ci_result") == "fail"
+
+            # 2차: 같은 SHA 재실행 성공(예: 재-run) — 최신 값으로 갱신돼야 한다(첫 값에 안 갇힘).
+            await _post_app(
+                _check_suite_completed_payload(
+                    pr_number=3462, installation_id=690003, head_sha="sha-3462-orig", conclusion="success",
+                ),
+                Session, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}", event="check_suite",
+            )
+            async with Session() as s:
+                gate = await _get_gate(s, story_id, 3462)
+                assert gate.neutral_facts.get("ci_result") == "pass", (
+                    f"두번째 재평가가 첫 값(fail)에 갇힘: {gate.neutral_facts}"
+                )
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_ui_daegbyeon_174be6bc_scope_violation_realdb.py
+++ b/backend/tests/test_e_ui_daegbyeon_174be6bc_scope_violation_realdb.py
@@ -188,7 +188,12 @@ async def test_silence_no_declaration_skips_fetch_entirely():
 
         async with Session() as s:
             link = await _link_evidence(s, seeded["org_id"], seeded["story_id"])
-            assert link is None  # 행 자체가 생성 안 됨.
+            # story #3039 — SID로 해소된 PR은 이제 그 사실 자체가 링크 행으로 캐싱된다(스코프
+            # 체크와 무관한 별개 목적 — check_suite류 텍스트-없는 후속 웹훅이 재해소할 수 있게).
+            # 이 테스트의 진짜 불변식은 "scope_check 증거를 지어내지 않는다"이지 "행 자체가
+            # 안 생긴다"가 아니다 — evidence에 그 키가 없는지로 좁혀 확인한다.
+            assert link is not None
+            assert "scope_check" not in (link.evidence or {})
     finally:
         await engine.dispose()
 
@@ -204,7 +209,10 @@ async def test_silence_fetch_failure_writes_nothing():
         assert "scope_check" not in result
         async with Session() as s:
             link = await _link_evidence(s, seeded["org_id"], seeded["story_id"])
-            assert link is None  # 판정불가는 추측 금지 — 행도 안 남김.
+            # story #3039 — 위와 동형: SID 해소 캐싱 행은 생기되(별개 목적), scope_check 증거는
+            # 판정불가라 여전히 지어내지 않는다(진짜 불변식).
+            assert link is not None
+            assert "scope_check" not in (link.evidence or {})
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
## Summary
[SID:3039]

실사고(PO 라이브 실측): PR#3460의 required `sprintable/gate` 체크런이 30분+ pending 지속. 스토리 원문 가설 2건(旣머지 PR 잔존 게이트의 스토리-스코프 오염 / 서명 API 조용한 거부)은 dev DB probe + GitHub webhook delivery 로그 + Cloud Logging 교차실측으로 **반증**됨 — `publish_gate_check`는 이미 PR/gate 단위(#2893), `POST /transition` 성공 로그도 명확.

**진짜 근본원인** — CI-완료 웹훅이 도착·200 응답은 하지만 게이트 재평가(`reconcile_merge_gate_with_real_evidence`)에 도달하지 못함:

1. `resolve_story_for_pr()`의 SID/auto_match 해소가 매 호출 휘발성(반환만·미영속)이었다. `check_suite`/`workflow_run`/`status` 이벤트는 payload에 PR title/body가 없어(`_candidate_texts`) SID 텍스트로 다시 못 찾는다 — 최초 `pull_request.opened`에서 SID로 한 번 풀린 뒤, 그 뒤 도착하는 CI-완료 웹훅은 전부 "story 못 찾음"으로 조용히 ignored 처리됨. → 텍스트 기반(비-stored) 해소 성공 시 그 자리서 `PullRequestStoryLink`로 영속화.
2. `evaluate_merge_gate()`가 재평가 때마다 `decision_basis`/`auto_decision_reason`(gate row 컬럼)은 write-back 하지만, `create_gate()`의 멱등 반환 특성상 `neutral_facts`(JSONB, FE가 실제로 읽는 "CI 통과/사유" 자리)는 최초 생성 시점 값에 영구히 갇혀 있었다. → pending/auto_passed 게이트 재평가 시 관찰사실을 병합 갱신하도록 수정(기존 `decision_history` 등은 보존).

## Test plan
- [x] 신규 3테스트(`backend/tests/test_3039_merge_gate_ci_reeval_webhook_realdb.py`, 실 PG 왕복 — 로컬 pg16 인스턴스로 검증): SID만으로 해소된 PR 오픈 후 `PullRequestStoryLink` 영속화 확인, title/body 없는 `check_suite completed(success)` 웹훅이 그 게이트를 찾아 `ci_result`를 실제로 갱신(#3460 실사고 정확 재현), 링크 사전등재 상태에서도 재평가가 최신 값으로 갱신(첫 값에 안 갇힘).
- [x] mutation-검증 2종 모두 RED 확인 후 복원: fix① 되돌리기 → 두 테스트 모두 `ci_result` None에 갇힘 확인, fix② 되돌리기 → 재평가가 첫 값(`fail`)에 갇힘 확인.
- [x] 인접 회귀 스윕(로컬 pg16, 131개): `test_2893_gate_pr_scoped_isolation_realdb` · `test_2156_merge_gate_evidence_realdb` · `test_2520/2813/2853/3035` · `test_bot_l1_pr_story_link` · `test_bot_m2_webhook_integration` · `test_h1_s6_github_webhook` · `test_2826_gate_pr_lifecycle_creation_realdb` 전부 green.
- [x] 회귀 2건 발견·정정: `test_2156`의 mock `session.execute` side_effect 순서에 `upsert_link`의 신규 SELECT 1건 반영, `test_e_ui_daegbyeon_174be6bc_scope_violation_realdb`의 두 "침묵" 테스트가 "링크 행 없음"을 "scope_check 증거 없음"의 프록시로 쓰고 있었던 것을 진짜 불변식(증거 안 지어냄, evidence에 `scope_check` 키 없음)으로 좁혀 정정 — SID 캐싱 행은 이제 남지만 별개 목적.
- [x] `pytest --collect-only` 전수(7999개) 수집 성공.
- [x] `python -m py_compile` 변경 파일 clean.

## Out of scope (별도 처리)
旣머지 PR#3188(gate `48e7c44f`)의 진짜 고아 게이트 — admin 전용 `/void` 필요(agent 403 확認), PO/팀 admin 액션으로 별도 처리 요청됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn3Q9V8KkMkxDp5G34Amwo