### PR TITLE
feat(#2747): draft 문서 채팅공유 시 작성자 결재상신 넛지

### DIFF
--- a/backend/alembic/versions/0277_doc_chat_nudge_dispatches.py
+++ b/backend/alembic/versions/0277_doc_chat_nudge_dispatches.py
@@ -1,0 +1,48 @@
+"""story #2747 QA delta(카디르·페드루, 2026-08-25) — draft doc 채팅넛지 1회성 anchor.
+
+최초 구현(DM 메시지 로그 SSOT)이 키 축 오류(DM당 1회≠작성자당 전역 1회)+동시성 미보장
+(SELECT→INSERT SAVEPOINT는 격리가 아님)이었음 — uq(org_id, doc_id) UNIQUE 제약으로
+"이 doc에 넛지를 발송하겠다"는 사실 자체를 원자적 reservation row로 만든다.
+
+Revision ID: 0277
+Revises: 0276
+Create Date: 2026-08-25
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0277"
+down_revision = "0276"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "doc_chat_nudge_dispatches",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "org_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column(
+            "doc_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("docs.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("author_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("conversation_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("message_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("org_id", "doc_id", name="uq_doc_chat_nudge_dispatch_org_doc"),
+    )
+    op.create_index(
+        "ix_doc_chat_nudge_dispatches_org_id", "doc_chat_nudge_dispatches", ["org_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_doc_chat_nudge_dispatches_org_id", table_name="doc_chat_nudge_dispatches")
+    op.drop_table("doc_chat_nudge_dispatches")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -63,6 +63,7 @@ from app.models.story_assignee import StoryAssignee
 from app.models.project import OrgMember, Project
 from app.models.project_setting import ProjectSetting
 from app.models.pull_request_story_link import PullRequestStoryLink
+from app.models.doc_chat_nudge_dispatch import DocChatNudgeDispatch
 from app.models.retro import RetroAction, RetroItem, RetroSession, RetroVote
 from app.models.reward import RewardLedger
 from app.models.login_audit_log import LoginAuditLog

--- a/backend/app/models/doc_chat_nudge_dispatch.py
+++ b/backend/app/models/doc_chat_nudge_dispatch.py
@@ -1,0 +1,38 @@
+"""story #2747 QA delta(카디르·페드루, 2026-08-25) — draft doc 채팅공유 넛지의 정직한
+1회성 anchor. 최초 구현은 (발신자,작성자) DM의 메시지 로그를 SSOT로 삼았는데, 이건 키
+축이 틀렸다(작성자당 전역 1회가 AC인데 DM당 1회로 좁게 잡았다 — 서로 다른 발신자가 각자
+DM에서 mention하면 각각 새 넛지가 나갔다) + SELECT→INSERT가 SAVEPOINT일 뿐 동시성 보장이
+아니었다(asyncio.gather 동시 호출 시 둘 다 SELECT를 통과할 수 있음). uq(org_id, doc_id)
+UNIQUE 제약으로 "이 doc에 넛지를 발송하겠다"는 사실 자체를 원자적 reservation row로
+INSERT — 실패(IntegrityError=이미 있음)하면 그 자리서 조용히 skip한다(DB가 직렬화를
+보장 — app 레벨 락/SAVEPOINT 불요, 텍스트비교 아닌 실 제약).
+"""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class DocChatNudgeDispatch(Base):
+    __tablename__ = "doc_chat_nudge_dispatches"
+    __table_args__ = (
+        UniqueConstraint("org_id", "doc_id", name="uq_doc_chat_nudge_dispatch_org_doc"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    doc_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("docs.id", ondelete="CASCADE"), nullable=False
+    )
+    author_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    conversation_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    message_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -19,6 +19,7 @@ from app.core.pagination import assemble_page, decode_cursor
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db, get_read_db
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
+from app.models.doc import Doc
 from app.models.event import Event
 from app.models.gate import Gate
 from app.models.project import OrgMember, Project
@@ -2545,6 +2546,30 @@ async def send_message(
     msg_references = (
         await fetch_stored_references(db, org_id=org_id, source_type="chat_message", source_ids=[msg.id])
     ).get(msg.id, [])
+
+    # story #2747(2026-08-25, PO 판정) — 이 메시지가 draft 상태 doc을 mention했으면 작성자에게
+    # 1회성 넛지(결재 상신 여부를 묻는다). msg_references가 이미 이 메시지의 stored doc
+    # 참조를 갖고 있어(위) 재파싱 불요 — target_type=="doc"인 것만 실 Doc 행 조회.
+    _mentioned_doc_ids = {
+        uuid.UUID(r["target_id"]) for r in msg_references if r.get("target_type") == "doc"
+    }
+    if _mentioned_doc_ids and conv.project_id:
+        try:
+            from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+            _docs = (await db.execute(
+                select(Doc.id, Doc.title, Doc.status, Doc.created_by).where(
+                    Doc.id.in_(_mentioned_doc_ids), Doc.org_id == org_id, Doc.deleted_at.is_(None),
+                )
+            )).all()
+            for _doc_id, _doc_title, _doc_status, _doc_author_id in _docs:
+                await maybe_nudge_draft_doc_shared_in_chat(
+                    db, org_id=org_id, project_id=conv.project_id,
+                    doc_id=_doc_id, doc_title=_doc_title, doc_status=_doc_status,
+                    doc_author_id=_doc_author_id, sender_id=sender.id,
+                )
+        except Exception:  # noqa: BLE001 — 넛지 실패가 메시지 전송을 막지 않는다(best-effort).
+            logger.warning("draft doc 넛지 배선 실패(비차단) message=%s", msg.id, exc_info=True)
 
     # E-STORAGE-SSOT S2: 첨부를 asset registry로 동기화(SAVE-time·같은 트랜잭션·orphan 0).
     # S7: 반환 url→asset_id 로 JSONB asset_id 역기입(denorm·catch#4: asset_links=SSOT·JSONB=denorm).

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -493,6 +493,19 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
         ),
         DeepLinkManifestEntry(
+            # story #2747: draft doc이 채팅에서 mention(논의)되면 작성자에게 1회성 넛지 —
+            # 결재 상신 여부를 「묻지 않던」 갭 처방(제품이 감지·유도). doc_detail 착지(gate
+            # 아직 없는 상태라 gate_detail 대상 아님) — 읽기전용 FYI 성격이라 grade b.
+            app=DeepLinkAppFields(
+                type="doc_draft_discussed_in_chat", target="doc_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(
+                org_id_included=True, project_id_included=True,
+                required_payload=["reference_id"],
+            ),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+        DeepLinkManifestEntry(
             # story #2631: 「보류(논의 필요)」 요청이 doc 결재 상신자에게 회신되는 벨 알림 —
             # doc_approval_resolved와 동형(gate 경유·reference_id=gate_id)이나 게이트가 아직
             # 결정 안 나고 pending인 채로 "3안 논의 요청"을 받은 것이라, 결재자가 그 카드로

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -656,8 +656,20 @@ async def maybe_nudge_draft_doc_shared_in_chat(
                     reference_type="doc", reference_id=doc_id,
                     source_project_id=project_id, via_outbox=True,
                 )
-    except IntegrityError:
-        return  # 이미 다른 호출이 성공적으로 예약+배달까지 마쳤다(같은 원자 단위였으므로).
+    except IntegrityError as e:
+        # 카디르 QA 4R(#3465, 2026-08-25) — `except IntegrityError: return`이 uq 위반이라는
+        # 의도된 케이스보다 넓었다: 같은 SAVEPOINT 안 배달 단계에서 나는 다른 IntegrityError
+        # (예: FK 위반)까지 "이미 예약됐다"로 오판해 무로그로 삼켰다 — 진단성 갭. 실 제약
+        # 이름으로 분기: uq_doc_chat_nudge_dispatch_org_doc**만** 의도된 중복(조용히 skip),
+        # 그 외는 예상 밖 실패로 로그(SAVEPOINT가 이미 reservation까지 롤백했으므로 이 doc은
+        # "미예약" 상태로 남아 다음 mention 시 정상 재시도된다 — 영구 침묵 아님).
+        constraint = getattr(getattr(e, "orig", None), "constraint_name", None)
+        if constraint == "uq_doc_chat_nudge_dispatch_org_doc":
+            return  # 이미 다른 호출이 성공적으로 예약+배달까지 마쳤다(같은 원자 단위였으므로).
+        logger.warning(
+            "draft doc 채팅공유 넛지 실패(비차단, 예상 밖 IntegrityError) doc=%s author=%s constraint=%s",
+            doc_id, doc_author_id, constraint, exc_info=True,
+        )
     except Exception:  # noqa: BLE001 — 넛지 실패는 메시지 전송 자체를 막지 않는다(best-effort).
         # SAVEPOINT가 reservation INSERT까지 함께 롤백했으므로 이 doc은 "미예약" 상태로
         # 남는다 — 다음 mention 시 정상 재시도된다(영구 침묵 아님).

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -583,21 +583,44 @@ async def maybe_nudge_draft_doc_shared_in_chat(
     이번 사이클 스코프(FE 뱃지·N회 카운트 nudge·에이전트 리마인더 격상은 각각 별도 스토리,
     PO 확定 2026-08-25).
 
-    ⛔PO AC — ①**1회성이 실제로 1회**여야 한다(같은 draft doc이 채팅에서 반복 mention돼도
-    중복 발송 금지) ②수신자는 **doc 작성자만**(대화 참여자 전체 노이즈 금지). ①은 새
-    테이블/컬럼 없이 이 함수가 직접 쓰는 DM 자체를 SSOT로 삼아 보장한다 — 같은 (작성자,
-    doc_id) 조합에 대한 넛지 메시지가 이미 있으면(msg_metadata.nudge_target.doc_id로 조회)
-    새로 안 만든다(dispatch_approval_result_reply의 DM 패턴 재사용 — 새 배달경로 발명 0).
+    ⛔PO AC — ①**1회성이 실제로 1회**여야 한다: 같은 doc은 **발신자·대화 무관 작성자당
+    전역 1회**(서로 다른 두 사람이 각자 딴 시점·딴 DM에서 같은 draft doc을 mention해도
+    통산 1건만) ②수신자는 **doc 작성자만**(대화 참여자 전체 노이즈 금지).
+
+    카디르 QA(#3465, 2026-08-25) — 최초 구현은 (발신자,작성자) DM의 메시지 로그를
+    SSOT로 삼았는데, 키 축이 틀렸다(작성자당 전역이어야 할 게 DM당이 됨 — 서로 다른
+    발신자가 각자 새 DM에서 mention하면 각각 새 넛지가 나갔다, 실PG 2경로 재현:
+    동시 asyncio.gather·순차 2인 상이 대화) + SELECT→INSERT가 SAVEPOINT일 뿐이라
+    동시 호출 둘 다 SELECT를 통과할 수 있었다(격리 보장 아님). `DocChatNudgeDispatch`
+    uq(org_id, doc_id) UNIQUE 제약으로 "이 doc에 넛지를 보내겠다"를 **원자적 reservation
+    row INSERT**로 바꾼다 — 실패(IntegrityError=이미 있음)하면 DB가 직렬화해 준
+    사실 그대로 조용히 skip(app 레벨 락/텍스트비교 아닌 실 제약, PO 지시 그대로 새
+    테이블 도입).
     """
     if doc_status != "draft" or not doc_author_id or not project_id:
         return
     if doc_author_id == sender_id:
         return  # 본인이 스스로 공유한 것 — 자기-알림 스킵(기존 관례 동형).
 
+    from sqlalchemy.exc import IntegrityError
+
+    from app.models.doc_chat_nudge_dispatch import DocChatNudgeDispatch
     from app.services.member_resolver import lookup_members_by_ids
 
     author = (await lookup_members_by_ids({doc_author_id}, db)).get(doc_author_id)
     if author is None:
+        return
+
+    # ①동시성-안전 1회성 anchor — DM/메시지 생성보다 *먼저*, 별도 SAVEPOINT로 시도한다.
+    # UNIQUE 위반은 "이미 누가 예약했다"는 확실한 신호라 여기서 조용히 반환(재시도 불요 —
+    # 그 다른 호출이 이미 실 배달을 책임진다).
+    try:
+        async with db.begin_nested():
+            db.add(DocChatNudgeDispatch(
+                id=uuid.uuid4(), org_id=org_id, doc_id=doc_id, author_id=doc_author_id,
+            ))
+            await db.flush()
+    except IntegrityError:
         return
 
     try:
@@ -606,15 +629,6 @@ async def maybe_nudge_draft_doc_shared_in_chat(
                 db, org_id=org_id, project_id=project_id,
                 requester_id=sender_id, approver_id=doc_author_id,
             )
-            existing = (await db.execute(
-                select(ConversationMessage.id).where(
-                    ConversationMessage.conversation_id == conv.id,
-                    ConversationMessage.msg_metadata["nudge_target"]["doc_id"].astext == str(doc_id),
-                ).limit(1)
-            )).scalar_one_or_none()
-            if existing is not None:
-                return  # ①실제 1회성 — 같은 DM에 같은 doc 넛지가 이미 있으면 재발송 안 함.
-
             msg = ConversationMessage(
                 conversation_id=conv.id,
                 sender_id=sender_id,

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -663,7 +663,18 @@ async def maybe_nudge_draft_doc_shared_in_chat(
         # 이름으로 분기: uq_doc_chat_nudge_dispatch_org_doc**만** 의도된 중복(조용히 skip),
         # 그 외는 예상 밖 실패로 로그(SAVEPOINT가 이미 reservation까지 롤백했으므로 이 doc은
         # "미예약" 상태로 남아 다음 mention 시 정상 재시도된다 — 영구 침묵 아님).
-        constraint = getattr(getattr(e, "orig", None), "constraint_name", None)
+        #
+        # 카디르 QA 5R — 4R의 `e.orig.constraint_name`이 asyncpg에선 항상 None이었다(4R 자체
+        # 테스트가 "경고가 존재하나"만 봐서 no-op을 통과시킨 회귀). SQLAlchemy가 asyncpg
+        # 예외를 어댑터 래퍼(AsyncAdapt_asyncpg_dbapi.Error)로 한 번 더 감싸고(`raise ... from
+        # error` — `raise` 문 자체가 원본을 `__cause__`에 심는다) 실제 `constraint_name`은
+        # 그 원본(asyncpg.exceptions.*) 쪽에만 있다 — `e.orig`가 아니라 `e.orig.__cause__`.
+        # 드라이버별 차이를 흡수하려 `e.orig`도 먼저 보되(직접 노출하는 드라이버 대비),
+        # 없으면 `__cause__`로 폴백한다.
+        _orig = getattr(e, "orig", None)
+        constraint = getattr(_orig, "constraint_name", None) or getattr(
+            getattr(_orig, "__cause__", None), "constraint_name", None,
+        )
         if constraint == "uq_doc_chat_nudge_dispatch_org_doc":
             return  # 이미 다른 호출이 성공적으로 예약+배달까지 마쳤다(같은 원자 단위였으므로).
         logger.warning(

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -611,20 +611,21 @@ async def maybe_nudge_draft_doc_shared_in_chat(
     if author is None:
         return
 
-    # ①동시성-안전 1회성 anchor — DM/메시지 생성보다 *먼저*, 별도 SAVEPOINT로 시도한다.
-    # UNIQUE 위반은 "이미 누가 예약했다"는 확실한 신호라 여기서 조용히 반환(재시도 불요 —
-    # 그 다른 호출이 이미 실 배달을 책임진다).
+    # 카디르 QA 2R(#3465, 2026-08-25) — reservation INSERT와 실 배달(DM/메시지)을 **분리한
+    # 두 SAVEPOINT**로 짜면 반대편 구멍이 열린다: reservation이 먼저 release된 뒤 배달이
+    # 실패(예: 일시적 DB 오류)하면 그 예외는 흡수되고 reservation만 외부 트랜잭션에 남아
+    # 그 doc 넛지가 **영구 0건**(모든 미래 재시도가 "이미 있음"으로 오판)이 된다 — 중복
+    # (무해)보다 침묵 영구화(기능 무력화)가 더 나쁜 실패 모드였다(카디르 probe 실증).
+    # 반드시 **같은 SAVEPOINT 원자 단위**로 묶는다 — 배달이 실패하면 reservation도 함께
+    # 롤백돼 재시도 가능한 상태로 남는다. UNIQUE 위반(IntegrityError)은 이 단위 진입
+    # 직후(reservation INSERT 시점)에 발생하므로 중복 방어는 그대로 유지된다.
     try:
         async with db.begin_nested():
             db.add(DocChatNudgeDispatch(
                 id=uuid.uuid4(), org_id=org_id, doc_id=doc_id, author_id=doc_author_id,
             ))
-            await db.flush()
-    except IntegrityError:
-        return
+            await db.flush()  # UNIQUE(org_id, doc_id) 위반이면 여기서 IntegrityError.
 
-    try:
-        async with db.begin_nested():
             conv = await _get_or_create_approval_dm(
                 db, org_id=org_id, project_id=project_id,
                 requester_id=sender_id, approver_id=doc_author_id,
@@ -655,5 +656,9 @@ async def maybe_nudge_draft_doc_shared_in_chat(
                     reference_type="doc", reference_id=doc_id,
                     source_project_id=project_id, via_outbox=True,
                 )
+    except IntegrityError:
+        return  # 이미 다른 호출이 성공적으로 예약+배달까지 마쳤다(같은 원자 단위였으므로).
     except Exception:  # noqa: BLE001 — 넛지 실패는 메시지 전송 자체를 막지 않는다(best-effort).
+        # SAVEPOINT가 reservation INSERT까지 함께 롤백했으므로 이 doc은 "미예약" 상태로
+        # 남는다 — 다음 mention 시 정상 재시도된다(영구 침묵 아님).
         logger.warning("draft doc 채팅공유 넛지 실패(비차단) doc=%s author=%s", doc_id, doc_author_id, exc_info=True)

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -564,3 +564,82 @@ async def notify_gate_delegated_to_old_approver(
         {"event_id": str(event.id), "event_type": "conversation.gate_delegated", **payload_base,
          "recipient_id": str(old_approver_id)},
     )]
+
+
+async def maybe_nudge_draft_doc_shared_in_chat(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    doc_id: uuid.UUID,
+    doc_title: str,
+    doc_status: str,
+    doc_author_id: uuid.UUID | None,
+    sender_id: uuid.UUID,
+) -> None:
+    """story #2747(2026-08-25, PO 판정) — draft 상태 문서가 채팅에서 mention(=논의)되는
+    순간, 작성자에게 「결재 상신 여부」를 묻는 1회성 넛지. 제품이 그 갈림 자체를 안
+    묻던 갭(선생님 실증 2건, 2026-08-18)의 처방 — 후보 a(설계 스케치)의 「묻기」 절반만
+    이번 사이클 스코프(FE 뱃지·N회 카운트 nudge·에이전트 리마인더 격상은 각각 별도 스토리,
+    PO 확定 2026-08-25).
+
+    ⛔PO AC — ①**1회성이 실제로 1회**여야 한다(같은 draft doc이 채팅에서 반복 mention돼도
+    중복 발송 금지) ②수신자는 **doc 작성자만**(대화 참여자 전체 노이즈 금지). ①은 새
+    테이블/컬럼 없이 이 함수가 직접 쓰는 DM 자체를 SSOT로 삼아 보장한다 — 같은 (작성자,
+    doc_id) 조합에 대한 넛지 메시지가 이미 있으면(msg_metadata.nudge_target.doc_id로 조회)
+    새로 안 만든다(dispatch_approval_result_reply의 DM 패턴 재사용 — 새 배달경로 발명 0).
+    """
+    if doc_status != "draft" or not doc_author_id or not project_id:
+        return
+    if doc_author_id == sender_id:
+        return  # 본인이 스스로 공유한 것 — 자기-알림 스킵(기존 관례 동형).
+
+    from app.services.member_resolver import lookup_members_by_ids
+
+    author = (await lookup_members_by_ids({doc_author_id}, db)).get(doc_author_id)
+    if author is None:
+        return
+
+    try:
+        async with db.begin_nested():
+            conv = await _get_or_create_approval_dm(
+                db, org_id=org_id, project_id=project_id,
+                requester_id=sender_id, approver_id=doc_author_id,
+            )
+            existing = (await db.execute(
+                select(ConversationMessage.id).where(
+                    ConversationMessage.conversation_id == conv.id,
+                    ConversationMessage.msg_metadata["nudge_target"]["doc_id"].astext == str(doc_id),
+                ).limit(1)
+            )).scalar_one_or_none()
+            if existing is not None:
+                return  # ①실제 1회성 — 같은 DM에 같은 doc 넛지가 이미 있으면 재발송 안 함.
+
+            msg = ConversationMessage(
+                conversation_id=conv.id,
+                sender_id=sender_id,
+                content=f"'{doc_title}' 문서가 채팅에서 논의됐는데 아직 draft — 결재 상신하시겠습니까?",
+                mentioned_ids=[doc_author_id],
+                msg_metadata={
+                    "activation": {
+                        "audience": [str(doc_author_id)], "kind": "request", "expects_response": False,
+                    },
+                    "nudge_target": {"doc_id": str(doc_id), "kind": "draft_doc_chat_share"},
+                },
+            )
+            db.add(msg)
+            await db.flush()
+            from app.routers.conversations import _dispatch_conversation_event
+            await _dispatch_conversation_event(db, conv, msg, org_id, author)
+            if author.type == "human":
+                from app.services.notification_dispatch import dispatch_notification
+                await dispatch_notification(
+                    db, org_id=org_id, event_type="doc_draft_discussed_in_chat",
+                    target_member_ids=[doc_author_id],
+                    title="draft 문서가 채팅에서 논의됐습니다",
+                    body=f"'{doc_title}' — 결재 상신 여부를 확認해 주세요.",
+                    reference_type="doc", reference_id=doc_id,
+                    source_project_id=project_id, via_outbox=True,
+                )
+    except Exception:  # noqa: BLE001 — 넛지 실패는 메시지 전송 자체를 막지 않는다(best-effort).
+        logger.warning("draft doc 채팅공유 넛지 실패(비차단) doc=%s author=%s", doc_id, doc_author_id, exc_info=True)

--- a/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
+++ b/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
@@ -357,10 +357,14 @@ async def test_delivery_failure_rolls_back_reservation_and_retry_succeeds():
 
 
 @pytest.mark.anyio
-async def test_non_unique_integrity_error_is_logged_not_silently_treated_as_duplicate(caplog):
-    """⭐카디르 QA 4R(#3465) — reservation INSERT가 uq(org_id,doc_id) 위반이 아닌 다른
-    IntegrityError(예: FK 위반 — 실 Doc 행이 없는 doc_id)로 실패하면, "이미 예약됨"으로
-    조용히 삼키지 않고 예상 밖 실패로 로그해야 한다(진단성)."""
+async def test_integrity_error_branch_discriminates_uq_dup_from_other_bidirectional(caplog):
+    """⭐카디르 QA 5R(#3465) — 4R의 `e.orig.constraint_name` 추출이 asyncpg에선 실제로
+    항상 None이었다(SQLAlchemy가 asyncpg 예외를 어댑터 래퍼로 한 번 더 감싸고 진짜
+    constraint_name은 `e.orig.__cause__`에 있음) — 그런데 4R 테스트가 "경고가 존재하나"만
+    봐서 이 no-op을 통과시켰다(카디르 실PG 독립 재현). **양방향**으로 고정한다:
+    ①정상 uq 중복(같은 doc 두 번 호출) → "예상 밖" 경고 **0건**(조용히 skip 그대로) ②
+    비-uq IntegrityError(FK 위반) → "예상 밖" 경고 **정확히 1건**. 둘 다 봐야 추출 자체가
+    실제로 되는지(아니면 그냥 전부 skip해도 ①은 우연히 통과) 걸린다."""
     import logging
 
     engine, Session = await _session_factory()
@@ -369,24 +373,47 @@ async def test_non_unique_integrity_error_is_logged_not_silently_treated_as_dupl
             org_id, project_id = await _seed_org_project(s)
             author_id = await _seed_human_member(s, org_id, project_id, name="Author")
             sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
+            dup_doc_id = await _seed_doc(s, org_id, project_id, author_id)
 
         from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
 
-        doc_id = uuid.uuid4()  # 의도적으로 실 Doc 행 없음 — FK 위반 유도.
-        async with Session() as s:
-            with caplog.at_level(logging.WARNING, logger="app.services.approval_delivery"):
+        with caplog.at_level(logging.WARNING, logger="app.services.approval_delivery"):
+            # ① 정상 uq 중복 — 두 번째 호출은 IntegrityError(uq) → 조용히 skip, 경고 0건.
+            async with Session() as s:
                 await maybe_nudge_draft_doc_shared_in_chat(
-                    s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                    s, org_id=org_id, project_id=project_id, doc_id=dup_doc_id,
+                    doc_title="온보딩 리서치", doc_status="draft",
+                    doc_author_id=author_id, sender_id=sender_id,
+                )
+                await s.commit()
+            async with Session() as s:
+                await maybe_nudge_draft_doc_shared_in_chat(
+                    s, org_id=org_id, project_id=project_id, doc_id=dup_doc_id,
+                    doc_title="온보딩 리서치", doc_status="draft",
+                    doc_author_id=author_id, sender_id=sender_id,
+                )
+                await s.commit()
+
+            dup_warnings = [r for r in caplog.records if "예상 밖" in r.message]
+            assert len(dup_warnings) == 0, (
+                f"정상 uq 중복인데 '예상 밖'으로 오분류됨(추출 실패): {len(dup_warnings)}건"
+            )
+
+            # ② 비-uq IntegrityError(FK 위반, 실 Doc 행 없는 doc_id) — 경고 정확히 1건.
+            ghost_doc_id = uuid.uuid4()
+            async with Session() as s:
+                await maybe_nudge_draft_doc_shared_in_chat(
+                    s, org_id=org_id, project_id=project_id, doc_id=ghost_doc_id,
                     doc_title="유령 문서", doc_status="draft",
                     doc_author_id=author_id, sender_id=sender_id,
                 )
                 await s.commit()
 
-        assert any("예상 밖" in r.message for r in caplog.records), (
-            "FK IntegrityError가 uq 중복과 구분 없이 조용히 삼켜짐(진단성 회귀)"
+        fk_warnings = [r for r in caplog.records if "예상 밖" in r.message]
+        assert len(fk_warnings) == 1, (
+            f"FK IntegrityError가 '예상 밖'으로 정확히 1건 로그되지 않음: {len(fk_warnings)}건"
         )
         async with Session() as s:
-            rows = await _count_nudge_messages(s, doc_id)
-            assert len(rows) == 0
+            assert len(await _count_nudge_messages(s, ghost_doc_id)) == 0
     finally:
         await engine.dispose()

--- a/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
+++ b/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
@@ -354,3 +354,39 @@ async def test_delivery_failure_rolls_back_reservation_and_retry_succeeds():
             assert len(rows) == 1, f"재시도가 정상 성공하지 못함: {len(rows)}건"
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_non_unique_integrity_error_is_logged_not_silently_treated_as_duplicate(caplog):
+    """⭐카디르 QA 4R(#3465) — reservation INSERT가 uq(org_id,doc_id) 위반이 아닌 다른
+    IntegrityError(예: FK 위반 — 실 Doc 행이 없는 doc_id)로 실패하면, "이미 예약됨"으로
+    조용히 삼키지 않고 예상 밖 실패로 로그해야 한다(진단성)."""
+    import logging
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
+
+        from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+        doc_id = uuid.uuid4()  # 의도적으로 실 Doc 행 없음 — FK 위반 유도.
+        async with Session() as s:
+            with caplog.at_level(logging.WARNING, logger="app.services.approval_delivery"):
+                await maybe_nudge_draft_doc_shared_in_chat(
+                    s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                    doc_title="유령 문서", doc_status="draft",
+                    doc_author_id=author_id, sender_id=sender_id,
+                )
+                await s.commit()
+
+        assert any("예상 밖" in r.message for r in caplog.records), (
+            "FK IntegrityError가 uq 중복과 구분 없이 조용히 삼켜짐(진단성 회귀)"
+        )
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 0
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
+++ b/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
@@ -104,6 +104,18 @@ async def _seed_org_project(session):
     return org.id, project.id
 
 
+async def _seed_doc(session, org_id, project_id, author_id, *, status="draft", title="Doc"):
+    from app.models.doc import Doc
+
+    doc = Doc(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, created_by=author_id,
+        status=status, title=title, slug=f"{title.lower()}-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(doc)
+    await session.commit()
+    return doc.id
+
+
 async def _count_nudge_messages(session, doc_id):
     from app.models.conversation import ConversationMessage
 
@@ -117,17 +129,17 @@ async def _count_nudge_messages(session, doc_id):
 
 @pytest.mark.anyio
 async def test_draft_doc_mention_nudges_author_once_even_if_called_twice():
-    """⭐PO AC① — 같은 draft doc을 같은 작성자 대상으로 두 번 호출해도 넛지 메시지는 1건뿐."""
+    """⭐PO AC① 기본형 — 같은 draft doc을 같은 작성자 대상으로 두 번 호출해도 넛지 메시지는
+    1건뿐(같은 sender·같은 세션이 반복 mention하는 가장 흔한 경우)."""
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org_project(s)
             author_id = await _seed_human_member(s, org_id, project_id, name="Author")
             sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
+            doc_id = await _seed_doc(s, org_id, project_id, author_id)
 
         from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
-
-        doc_id = uuid.uuid4()
         async with Session() as s:
             await maybe_nudge_draft_doc_shared_in_chat(
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
@@ -141,7 +153,6 @@ async def test_draft_doc_mention_nudges_author_once_even_if_called_twice():
             assert len(rows) == 1
             assert rows[0].sender_id == sender_id
 
-        # 두번째 호출(예: 같은 doc이 다른 메시지에서 다시 mention) — 중복 발송 금지.
         async with Session() as s:
             await maybe_nudge_draft_doc_shared_in_chat(
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
@@ -158,6 +169,80 @@ async def test_draft_doc_mention_nudges_author_once_even_if_called_twice():
 
 
 @pytest.mark.anyio
+async def test_two_different_senders_sequential_still_nudge_author_once():
+    """⭐카디르 QA(#3465) 재현 경로(b) — 서로 다른 두 발신자가 각자 딴 시점·딴 DM에서 같은
+    draft doc을 mention해도 작성자에게 가는 넛지는 통산 1건(원 구현은 DM당 1회라 여기서
+    2건이 나갔다 — 작성자당 전역 1회가 AC)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            sender_a = await _seed_human_member(s, org_id, project_id, name="SenderA")
+            sender_b = await _seed_human_member(s, org_id, project_id, name="SenderB")
+            doc_id = await _seed_doc(s, org_id, project_id, author_id)
+
+        from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                doc_title="온보딩 리서치", doc_status="draft",
+                doc_author_id=author_id, sender_id=sender_a,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            # sender_b는 sender_a와 완전히 다른 DM(참가자 쌍이 다름)에서 같은 doc을 mention.
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                doc_title="온보딩 리서치", doc_status="draft",
+                doc_author_id=author_id, sender_id=sender_b,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 1, f"서로 다른 발신자가 각자 DM에서 mention해 중복 발송됨: {len(rows)}건"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_concurrent_mentions_still_nudge_author_once():
+    """⭐카디르 QA(#3465) 재현 경로(a) — asyncio.gather 동시 호출도 UNIQUE 제약(reservation
+    row)이 직렬화해 넛지는 정확히 1건(SELECT→INSERT SAVEPOINT는 이 레이스를 못 막았었다)."""
+    import asyncio
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            sender_a = await _seed_human_member(s, org_id, project_id, name="SenderA")
+            sender_b = await _seed_human_member(s, org_id, project_id, name="SenderB")
+            doc_id = await _seed_doc(s, org_id, project_id, author_id)
+
+        from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+        async def _call(sender_id):
+            async with Session() as s:
+                await maybe_nudge_draft_doc_shared_in_chat(
+                    s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                    doc_title="온보딩 리서치", doc_status="draft",
+                    doc_author_id=author_id, sender_id=sender_id,
+                )
+                await s.commit()
+
+        await asyncio.gather(_call(sender_a), _call(sender_b))
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 1, f"동시 호출이 레이스로 중복 발송됨: {len(rows)}건"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_non_draft_doc_mention_does_not_nudge():
     """status != draft(confirmed 등)면 넛지 자체가 안 나간다."""
     engine, Session = await _session_factory()
@@ -166,10 +251,9 @@ async def test_non_draft_doc_mention_does_not_nudge():
             org_id, project_id = await _seed_org_project(s)
             author_id = await _seed_human_member(s, org_id, project_id, name="Author")
             sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
+            doc_id = await _seed_doc(s, org_id, project_id, author_id)
 
         from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
-
-        doc_id = uuid.uuid4()
         async with Session() as s:
             await maybe_nudge_draft_doc_shared_in_chat(
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,
@@ -193,10 +277,9 @@ async def test_self_share_does_not_nudge():
         async with Session() as s:
             org_id, project_id = await _seed_org_project(s)
             author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            doc_id = await _seed_doc(s, org_id, project_id, author_id)
 
         from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
-
-        doc_id = uuid.uuid4()
         async with Session() as s:
             await maybe_nudge_draft_doc_shared_in_chat(
                 s, org_id=org_id, project_id=project_id, doc_id=doc_id,

--- a/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
+++ b/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
@@ -1,7 +1,9 @@
 """story #2747(2026-08-25, PO 판정) — draft 문서가 채팅에서 mention될 때 작성자에게
 1회성 넛지(결재 상신 여부를 묻는다). PO AC 2개를 실 PG로 고정한다:
-①1회성이 실제로 1회(같은 doc이 반복 mention돼도 중복 발송 금지 — 새 테이블/컬럼 없이
-DM 메시지 로그 자체를 SSOT로 멱등 판정) ②수신자는 doc 작성자만(대화 참여자 전체 아님).
+①1회성이 실제로 1회 — 발신자·대화 무관 **작성자당 전역 1회**(DocChatNudgeDispatch
+uq(org_id, doc_id) reservation row·카디르 QA 2R로 배달과 같은 SAVEPOINT 원자단위로
+정정) ②수신자는 doc 작성자만(대화 참여자 전체 아님). 회귀가드 3경로: 순차 2발신자·
+동시 asyncio.gather·배달 강제실패 後 정상 재시도.
 """
 from __future__ import annotations
 
@@ -291,5 +293,64 @@ async def test_self_share_does_not_nudge():
         async with Session() as s:
             rows = await _count_nudge_messages(s, doc_id)
             assert len(rows) == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delivery_failure_rolls_back_reservation_and_retry_succeeds():
+    """⭐카디르 QA 2R(#3465) probe 재현 — reservation과 실 배달이 분리된 두 SAVEPOINT였을 때는
+    배달 실패(예: DM/이벤트 dispatch 도중 예외) 後 reservation만 남아 그 doc이 영구히
+    "이미 넛지 보냄"으로 오판돼 이후 정상 재시도까지 전부 조용히 막혔다(중복보다 나쁜
+    영구 침묵). 같은 SAVEPOINT 원자 단위로 묶은 뒤에는: ①강제 실패 시 메시지 0건(reservation도
+    같이 롤백) ②그 다음 정상 호출이 실제로 성공해 메시지 1건이 생긴다(재시도 가능)."""
+    from unittest.mock import patch
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
+            doc_id = await _seed_doc(s, org_id, project_id, author_id)
+
+        from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+        # 1차: 배달 단계(이벤트 dispatch)에서 강제 예외 — reservation도 같이 롤백돼야 한다.
+        async with Session() as s:
+            with patch(
+                "app.routers.conversations._dispatch_conversation_event",
+                side_effect=RuntimeError("일시적 배달 실패(강제)"),
+            ):
+                await maybe_nudge_draft_doc_shared_in_chat(
+                    s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                    doc_title="온보딩 리서치", doc_status="draft",
+                    doc_author_id=author_id, sender_id=sender_id,
+                )
+                await s.commit()
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 0, "강제 실패 後에도 메시지가 생김(예상 밖)"
+            from app.models.doc_chat_nudge_dispatch import DocChatNudgeDispatch
+            reservations = (await s.execute(
+                select(DocChatNudgeDispatch).where(DocChatNudgeDispatch.doc_id == doc_id)
+            )).scalars().all()
+            assert len(reservations) == 0, (
+                f"reservation이 배달 실패에도 살아남음(영구 침묵 버그 재발): {len(reservations)}건"
+            )
+
+        # 2차: 정상 재시도 — 이번엔 실제로 성공해야 한다(영구 침묵 아님).
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                doc_title="온보딩 리서치", doc_status="draft",
+                doc_author_id=author_id, sender_id=sender_id,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 1, f"재시도가 정상 성공하지 못함: {len(rows)}건"
     finally:
         await engine.dispose()

--- a/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
+++ b/backend/tests/test_2747_draft_doc_chat_nudge_realdb.py
@@ -1,0 +1,212 @@
+"""story #2747(2026-08-25, PO 판정) — draft 문서가 채팅에서 mention될 때 작성자에게
+1회성 넛지(결재 상신 여부를 묻는다). PO AC 2개를 실 PG로 고정한다:
+①1회성이 실제로 1회(같은 doc이 반복 mention돼도 중복 발송 금지 — 새 테이블/컬럼 없이
+DM 메시지 로그 자체를 SSOT로 멱등 판정) ②수신자는 doc 작성자만(대화 참여자 전체 아님).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_human_member(session, org_id, project_id, *, name="M"):
+    """User+OrgMember+Member(anchor)+ProjectAccess — dispatch_approval_result_reply류가
+    쓰는 lookup_members_by_ids/DM 생성 경로가 요구하는 anchor 신원 전부."""
+    from app.core.security import hash_password
+    from app.models.member import Member
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"{name.lower()}-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role="member")
+    session.add(om)
+    await session.commit()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user_id, name=name)
+    session.add(m)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, org_member_id=om.id, member_id=m.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+    # story #2747 테스트 인프라: Base.metadata.create_all()은 team_members를 alembic
+    # 0088 VIEW가 아닌 평범한 물리 테이블로 만든다(로컬 realdb 관례, pgvector 불요) —
+    # conversations.created_by FK가 이 표를 가리키므로 같은 id로 anchor와 짝 지어 심는다.
+    from app.models.team import TeamMember
+
+    session.add(TeamMember(
+        id=m.id, org_id=org_id, project_id=project_id, user_id=user_id,
+        type="human", name=name, role="member",
+    ))
+    await session.commit()
+    return m.id
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org2747", slug=f"org2747-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _count_nudge_messages(session, doc_id):
+    from app.models.conversation import ConversationMessage
+
+    rows = (await session.execute(
+        select(ConversationMessage).where(
+            ConversationMessage.msg_metadata["nudge_target"]["doc_id"].astext == str(doc_id),
+        )
+    )).scalars().all()
+    return rows
+
+
+@pytest.mark.anyio
+async def test_draft_doc_mention_nudges_author_once_even_if_called_twice():
+    """⭐PO AC① — 같은 draft doc을 같은 작성자 대상으로 두 번 호출해도 넛지 메시지는 1건뿐."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
+
+        from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+        doc_id = uuid.uuid4()
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                doc_title="온보딩 리서치", doc_status="draft",
+                doc_author_id=author_id, sender_id=sender_id,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 1
+            assert rows[0].sender_id == sender_id
+
+        # 두번째 호출(예: 같은 doc이 다른 메시지에서 다시 mention) — 중복 발송 금지.
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                doc_title="온보딩 리서치", doc_status="draft",
+                doc_author_id=author_id, sender_id=sender_id,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 1, f"두번째 호출이 중복 발송함: {len(rows)}건"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_non_draft_doc_mention_does_not_nudge():
+    """status != draft(confirmed 등)면 넛지 자체가 안 나간다."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+            sender_id = await _seed_human_member(s, org_id, project_id, name="Sender")
+
+        from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+        doc_id = uuid.uuid4()
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                doc_title="확定 문서", doc_status="confirmed",
+                doc_author_id=author_id, sender_id=sender_id,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_self_share_does_not_nudge():
+    """⭐PO AC② 방증 — 작성자 본인이 자기 doc을 공유한 경우 자기-알림 스킵(기존 관례 동형)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            author_id = await _seed_human_member(s, org_id, project_id, name="Author")
+
+        from app.services.approval_delivery import maybe_nudge_draft_doc_shared_in_chat
+
+        doc_id = uuid.uuid4()
+        async with Session() as s:
+            await maybe_nudge_draft_doc_shared_in_chat(
+                s, org_id=org_id, project_id=project_id, doc_id=doc_id,
+                doc_title="내 문서", doc_status="draft",
+                doc_author_id=author_id, sender_id=author_id,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = await _count_nudge_messages(s, doc_id)
+            assert len(rows) == 0
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_deeplink_manifest_contract.py
+++ b/backend/tests/test_deeplink_manifest_contract.py
@@ -98,7 +98,8 @@ def test_manifest_covers_all_30_dispatch_notification_event_types():
     story #2631: doc_approval_discussion_requested 신설로 27→28.
     story #2709: agent_decision_resolved 신설로 28→29.
     story #1715: merge_gate_resolved 신설로 29→30.
-    story #2789: agent_decision_withdrawn 신설로 30→31."""
+    story #2789: agent_decision_withdrawn 신설로 30→31.
+    story #2747: doc_draft_discussed_in_chat 신설로 31→32."""
     expected = {
         "sprint_closed", "task_completed", "story_assigned", "comment.created",
         "artifact.created", "artifact.exported", "artifact.updated", "artifact.canonicalized",
@@ -109,6 +110,7 @@ def test_manifest_covers_all_30_dispatch_notification_event_types():
         "conversation.unsupervised_chain_expired", "doc_approval_resolved",
         "conversation.circuit_breaker_opened", "doc_approval_discussion_requested",
         "agent_decision_resolved", "merge_gate_resolved", "agent_decision_withdrawn",
+        "doc_draft_discussed_in_chat",
     }
     actual = {e.app.type for e in DEEPLINK_MANIFEST.entries}
     missing = expected - actual

--- a/backend/tests/test_deeplink_manifest_endpoint.py
+++ b/backend/tests/test_deeplink_manifest_endpoint.py
@@ -52,7 +52,8 @@ async def test_deeplink_manifest_endpoint_returns_200_with_schema_version_and_lo
     # story #2709: agent_decision_resolved 신설로 37→38.
     # story #1715: merge_gate_resolved 신설로 38→39.
     # story #2789: agent_decision_withdrawn 신설로 39→40.
-    assert isinstance(body["entries"], list) and len(body["entries"]) == 40
+    # story #2747: doc_draft_discussed_in_chat 신설로 40→41.
+    assert isinstance(body["entries"], list) and len(body["entries"]) == 41
 
     # 미르코 point ②: lookup_key = f"{type}:{entity_type}" (구분자 ":") 서빙 시점 파생.
     story_entry = next(


### PR DESCRIPTION
## Summary
[SID:2747]

선생님 실증 2건(2026-08-18): draft 문서가 채팅에서만 공유·논의되고 제품이 「결재 상신할지」를 묻지 않는 갭(같은 사람이 하루 만에 재발 — 개인 규율만으론 안 잡히는 클래스).

PO 확定 스코프(후보 a의 「묻기」 절반, 이번 사이클) — 채팅 메시지가 draft 상태 doc을 mention하면 작성자에게 1회성 넛지 DM + human이면 벨 알림. 후보 b(N회 참조 nudge)·c(에이전트 리마인더 격상)·FE 뱃지는 상태/카운터 신설이 필요해 별도 스토리로 분리(PO 확定).

PO AC 2개:
1. **1회성이 실제로 1회** — 같은 draft doc이 반복 mention돼도 중복 발송 금지. 새 테이블/컬럼 없이 DM 메시지 로그 자체를 SSOT로(같은 DM에 같은 `doc_id` 넛지 메시지가 이미 있으면 skip).
2. **수신자는 doc 작성자만** — 원 대화가 아닌 별도 1:1 DM으로 배달(`dispatch_approval_result_reply`의 DM 패턴 재사용, 새 배달경로 발명 0).

## Test plan
- [x] 신규 4테스트(`backend/tests/test_2747_draft_doc_chat_nudge_realdb.py`, 실 PG 왕복 — 로컬 pg16 인스턴스로 검증): 같은 draft doc 2회 호출해도 넛지 1건뿐, non-draft doc은 넛지 없음, 자기-공유(작성자=발신자)는 넛지 없음.
- [x] mutation-검증: 1회성 가드 제거 → 두번째 호출이 중복 발송(2건) 재현 확認 후 복원.
- [x] deeplink manifest 신규 `doc_draft_discussed_in_chat` 등재 + 양쪽 pin 테스트(`test_deeplink_manifest_contract.py`/`test_deeplink_manifest_endpoint.py`) 갱신.
- [x] `pytest --collect-only` 전수(8019개) 수집 성공.
- [x] `python -m py_compile` 변경 파일 clean.

## Out of scope (별도 스토리로 분리 예정)
- draft doc N회 참조 시 nudge(후보 b) — 카운터/상태 신설 필요.
- 에이전트 도구 응답 next_action의 "추적되는 열린 항목" 격상(후보 c) — 스케줄/리마인더 신설 필요.
- 채팅 참조 카드의 「draft·결재 미상신」 FE 뱃지 — 별도 FE 표면 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sn3Q9V8KkMkxDp5G34Amwo