### PR TITLE
[SID:3043] 모바일 IA — 칸반 진입 경로 재설계(세그 렌더+legibility+단일열)

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
@@ -375,13 +375,21 @@ describe('FlowPageClient — story #2531(E-FLOW-V4 S1) 가설이 기본·최상�
 });
 
 // 카디르 라이브 QA(2026-08-09, S1) — REQUEST_CHANGES 2건 회귀가드.
-describe('FlowPageClient — 카디르 QA fix(2026-08-09) ①모바일 dead-end', () => {
-  it('모바일(isMobile=true)·?view= 없음 이면 기본값이 가설이 아니라 flow(NextMakerScreen)다 — 갈래·목록으로 갈 UI 경로가 0이 되는 dead-end 방지', async () => {
+// story #3043(PO+유나 IA 확定 ⓑ, 2026-08-25) — 모바일 기본값이 다시 갈렸다. 예전엔
+// #2225(모바일 3화면 대체 세그)가 곧 착지할 것을 전제로 flow(NextMakerScreen)를 기본값
+// 삼았으나, #2225는 실제로 한 줄도 안 짜인 채 status=backlog로 남아있었다(그라운딩 확認)
+// — 세그 자체도 숨겨져 있었으니 모바일에서 갈래·목록(칸반) 둘 다 도달 UI 경로가 0인
+// dead-end였다(PO가 "모바일에 보드 없다"고 오답할 정도의 실사고). 이제 세그를 모바일에서도
+// 그대로 그리고(아래 새 describe), 파라미터 없을 때의 기본값도 list(칸반)로 바꾼다 — 원
+// 신고("보드가 안 보인다")에 가장 가까운 화면을 첫 진입 기본값으로 세운다.
+describe('FlowPageClient — story #3043(PO+유나 IA 확定) 모바일 기본값=list(칸반)', () => {
+  it('모바일(isMobile=true)·?view= 없음 이면 기본값이 list(KanbanBoard)다', async () => {
     isMobileMock = true;
     await renderFlowClient();
 
-    expect(container.querySelector('[data-testid="next-maker-screen-stub"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="kanban-board-stub"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="hypothesis-earth-layer-stub"]')).toBeNull();
+    expect(container.querySelector('[data-testid="next-maker-screen-stub"]')).toBeNull();
   });
 
   it('데스크톱(isMobile=false)·?view= 없음 이면 기존대로 가설이 기본값이다(회귀 없음)', async () => {
@@ -389,6 +397,24 @@ describe('FlowPageClient — 카디르 QA fix(2026-08-09) ①모바일 dead-end'
     await renderFlowClient();
 
     expect(container.querySelector('[data-testid="hypothesis-earth-layer-stub"]')).not.toBeNull();
+  });
+
+  it('모바일이라도 세그(가설|갈래|칸반)가 그려진다(예전엔 isMobile이면 렌더 자체를 안 했다)', async () => {
+    isMobileMock = true;
+    await renderFlowClient();
+
+    const labels = Array.from(container.querySelectorAll('button')).map((b) => b.textContent);
+    expect(labels).toContain(koMessages.flow.viewHypothesis);
+    expect(labels).toContain(koMessages.flow.viewFlow);
+    expect(labels).toContain(koMessages.flow.viewList);
+  });
+
+  it('모바일이라도 ?view=flow가 명시돼 있으면 그 값을 그대로 존중한다(주소로 갈래 진입 회귀 없음)', async () => {
+    isMobileMock = true;
+    currentSearch = 'view=flow';
+    await renderFlowClient();
+
+    expect(container.querySelector('[data-testid="next-maker-screen-stub"]')).not.toBeNull();
   });
 
   it('모바일이라도 ?view=hypothesis가 URL에 명시돼 있으면 그대로 존중한다(주소로는 진입 가능)', async () => {

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -261,7 +261,9 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
         {/* story #2535(E-FLOW-V4 S5) — 축척 브레드크럼. 가설 뷰는 HypothesisEarthLayer가
             자기 안에서 이미 사다리를 그리므로(지구=활성) 여기서 중복 안 그린다. 갈래=도시·
             목록=건물 — 「지금 보는 층 = 묻는 질문 전환」을 탭 전환마다 같은 자리에서 보인다. */}
-        {view !== 'hypothesis' ? <ScaleLadder activeLevel={view === 'flow' ? 'city' : 'building'} /> : null}
+        {view !== 'hypothesis' ? (
+          <ScaleLadder activeLevel={view === 'flow' ? 'city' : 'building'} compact={isMobile} />
+        ) : null}
 
         {view === 'hypothesis' ? (
           // story #2531(E-FLOW-V4 S1) — 새 기본 랜딩. 가설(질문)을 최상위 조직 단위로 삼는

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -44,12 +44,13 @@ type FlowView = 'hypothesis' | 'flow' | 'list';
 // NextMakerScreen)에서 'hypothesis'로 이동한다. 갈래·목록은 폐기 아님 — 나란한 탭으로
 // 남아 v3.4 계승(§6)을 만족한다. 가설→갈래 드릴다운은 S5(축척 전환) 몫이라 이번엔 병렬.
 //
-// ⛔카디르 라이브 QA(2026-08-09, ①HIGH) — 모바일(390px)은 세그 자체를 안 그리므로(#2225
-// 탭이 대신함), 기본값을 데스크톱과 똑같이 가설로 바꾸면 모바일에서 갈래(NextMakerScreen
-// 상호작용 보드)·목록(칸반)으로 갈 UI 경로가 0이 되는 dead-end였다. 모바일 가설 축척은
-// #2225(모바일 3화면)/S5 몫이라 — 데스크톱만 가설 기본, 모바일은 기존(flow=NextMakerScreen)
-// 유지한다. `?view=`가 URL에 명시돼 있으면(모바일도 주소로는 들어올 수 있으므로) 그 값을
-// 그대로 존중 — 이 폴백은 «파라미터가 아예 없을 때»만 개입한다.
+// story #3043(선생님 실사고·민 실측 2026-08-25, PO+유나 IA 확定 ⓑ) — #2225(모바일 3화면
+// 대체 세그)는 실제론 status=backlog·한 줄도 안 짜여 있었다(그라운딩으로 기각) — 그런데도
+// 아래 세그를 `isMobile ? null : ...`로 숨겨온 탓에 모바일에서 갈래·목록(칸반) 둘 다 도달
+// UI 경로가 0이었다(PO가 "모바일에 보드 없다"고 오답할 정도). 세그를 모바일에서도 그리고
+// (아래), 파라미터 없을 때의 모바일 기본값도 flow(갈래 캔버스)에서 list(칸반)로 바꾼다 —
+// 「보드가 안 보인다」는 원 신고에 가장 가까운 화면을 첫 진입 기본값으로 세운다. `?view=`가
+// URL에 명시돼 있으면 그대로 존중(이 폴백은 파라미터가 아예 없을 때만 개입) — 회귀 없음.
 // ⛔카디르 재QA 비차단②(2026-08-09, S3) — 모바일에서 `?hypothesis=<id>`만 있고 `?view=`가
 // 없으면(공유 링크·새로고침의 흔한 형태) 위 모바일 기본값(flow)이 이겨 서사 패널이
 // 렌더되지 않았다(패널은 view==='hypothesis'에서만 뜬다). hypothesis 파라미터가 있으면
@@ -59,7 +60,7 @@ function parseView(raw: string | null, isMobile: boolean, hasHypothesisParam: bo
   if (raw === 'flow') return 'flow';
   if (raw === 'hypothesis') return 'hypothesis';
   if (hasHypothesisParam) return 'hypothesis';
-  return isMobile ? 'flow' : 'hypothesis';
+  return isMobile ? 'list' : 'hypothesis';
 }
 
 /**
@@ -228,33 +229,34 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
             시안(`e15905e8`)에서 되찾은 것(IA 개정 때 조용히 지워졌던 것, 유나 지적
             2026-07-30) 그대로 — 폐기 아니라 나란한 탭으로 유지(v3.4 계승). ⛔"현황판" 세
             번째 칸은 선생님 재정정으로 지웠었다(그 자리에 이제 "가설"이 대신 선다 — 다른
-            이유·다른 칸). 모바일은 #2225의 갈래·막힘·멈춤 탭이 이 자리를 대신하므로 세그를
-            그리지 않는다(isMobile===undefined인 최초 렌더에서도 안전하게 숨김). */}
-        {isMobile ? null : (
-          <div className="flex items-center gap-1 border-b border-border pb-2">
-            <button
-              type="button"
-              onClick={() => setView('hypothesis')}
-              className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${view === 'hypothesis' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
-            >
-              {t('viewHypothesis')}
-            </button>
-            <button
-              type="button"
-              onClick={() => setView('flow')}
-              className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${view === 'flow' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
-            >
-              {t('viewFlow')}
-            </button>
-            <button
-              type="button"
-              onClick={() => setView('list')}
-              className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${view === 'list' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
-            >
-              {t('viewList')}
-            </button>
-          </div>
-        )}
+            이유·다른 칸). story #3043(PO+유나 IA 확定 ⓑ) — 예전엔 모바일에서 이 세그를
+            숨기고 #2225(미구현으로 그라운딩 확認) 대체 탭이 그 자리를 대신한다고 가정했으나,
+            그 대체물이 실재하지 않아 모바일에 세그도 대체도 둘 다 없는 dead-end였다. 이제
+            모바일에서도 그대로 그린다 — 새 모바일 전용 UI를 만들지 않고 데스크톱과 동일
+            컴포넌트를 재사용(회귀 위험 최소·유지보수 표면 1개). */}
+        <div className="flex items-center gap-1 border-b border-border pb-2">
+          <button
+            type="button"
+            onClick={() => setView('hypothesis')}
+            className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${view === 'hypothesis' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+          >
+            {t('viewHypothesis')}
+          </button>
+          <button
+            type="button"
+            onClick={() => setView('flow')}
+            className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${view === 'flow' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+          >
+            {t('viewFlow')}
+          </button>
+          <button
+            type="button"
+            onClick={() => setView('list')}
+            className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${view === 'list' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+          >
+            {t('viewList')}
+          </button>
+        </div>
 
         {/* story #2535(E-FLOW-V4 S5) — 축척 브레드크럼. 가설 뷰는 HypothesisEarthLayer가
             자기 안에서 이미 사다리를 그리므로(지구=활성) 여기서 중복 안 그린다. 갈래=도시·

--- a/apps/web/src/components/flow/scale-ladder.test.tsx
+++ b/apps/web/src/components/flow/scale-ladder.test.tsx
@@ -76,4 +76,30 @@ describe('ScaleLadder', () => {
     expect(cityRung?.className).toContain('bg-gradient-to-b');
     expect(earthRung?.className).not.toContain('bg-gradient-to-b');
   });
+
+  // story #3043(PO+유나 IA 확定 ⓐ, 2026-08-25) — <lg에서 이 카드열(이름+질문 5칸)이 「주」처럼
+  // 보여 보드(칸반) 콘텐츠를 아래로 밀어냈다(유나 실측). compact 모드는 이름만 남긴 칩열이다.
+  describe('compact(ⓐ 렌즈/필터 축소)', () => {
+    it('compact=true면 질문 문구(ladderQuestion_*)는 안 그린다 — 이름만 남는다', () => {
+      act(() => { root.render(wrap(<ScaleLadder compact />)); });
+      expect(container.textContent).toContain(koMessages.flow.ladderName_earth);
+      expect(container.textContent).not.toContain(koMessages.flow.ladderQuestion_earth);
+    });
+
+    it('compact=true여도 activeLevel 강조는 유지된다(정보 손실 없음)', () => {
+      act(() => { root.render(wrap(<ScaleLadder compact activeLevel="city" />)); });
+      const chips = Array.from(container.querySelectorAll('span')).filter((s) =>
+        Object.values(koMessages.flow).some((v) => v === s.textContent),
+      );
+      const cityChip = chips.find((s) => s.textContent === koMessages.flow.ladderName_city);
+      const earthChip = chips.find((s) => s.textContent === koMessages.flow.ladderName_earth);
+      expect(cityChip?.className).toContain('text-brand');
+      expect(earthChip?.className).not.toContain('text-brand');
+    });
+
+    it('compact=false(기본값)는 기존 카드열 그대로다(회귀 없음)', () => {
+      act(() => { root.render(wrap(<ScaleLadder />)); });
+      expect(container.textContent).toContain(koMessages.flow.ladderQuestion_earth);
+    });
+  });
 });

--- a/apps/web/src/components/flow/scale-ladder.tsx
+++ b/apps/web/src/components/flow/scale-ladder.tsx
@@ -15,8 +15,36 @@ import { cn } from '@/lib/utils';
 export const LADDER_LEVELS = ['earth', 'continent', 'city', 'street', 'building'] as const;
 export type LadderLevel = (typeof LADDER_LEVELS)[number];
 
-export function ScaleLadder({ activeLevel = 'earth' }: { activeLevel?: LadderLevel }) {
+export function ScaleLadder({ activeLevel = 'earth', compact = false }: { activeLevel?: LadderLevel; compact?: boolean }) {
   const t = useTranslations('flow');
+
+  // story #3043(PO+유나 IA 확定 ⓐ, 2026-08-25) — <lg에서 이 카드열(이름+질문 5칸, py-2.5)이
+  // 「주」처럼 보여 보드(칸반) 콘텐츠를 아래로 밀어냈다(유나 실측). 래더는 원래 역할이 보드의
+  // 렌즈/필터(지금 보는 층 표시)일 뿐이라 — 칩열로 낮춘다. 질문 문구(ladderQuestion_*)는
+  // 이 압축판에서 뺀다(공간 예산 안에서 이름만으로도 "지금 보는 층" 신호는 충분 — active
+  // 강조·순서 자체가 이미 그 정보를 나른다). 상호작용(onClick)은 원본에도 없던 것이라
+  // 여기서도 추가하지 않는다(read-only 브레드크럼 그대로, 회귀 0).
+  if (compact) {
+    return (
+      <div className="flex items-center gap-1 overflow-x-auto rounded-lg border border-border bg-card px-1.5 py-1">
+        {LADDER_LEVELS.map((level) => {
+          const active = level === activeLevel;
+          return (
+            <span
+              key={level}
+              className={cn(
+                'shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium transition',
+                active ? 'bg-brand/10 text-brand' : 'text-muted-foreground',
+              )}
+            >
+              {t(`ladderName_${level}`)}
+            </span>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <div className="flex overflow-hidden rounded-xl border border-border bg-card">
       {LADDER_LEVELS.map((level) => {

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -24,6 +24,16 @@ vi.mock('@/components/nav/top-bar-slot', () => ({
   ),
 }));
 
+// story #3043(PO+유나 IA 확定 ⓒ, 2026-08-25) — viewMode 기본값이 이제 useIsMobile()로 갈리므로
+// (예전엔 'board' 하드코딩) jsdom엔 window.matchMedia가 없어(use-mobile.ts가 그걸 직접 부른다)
+// 이 파일의 기존 테스트 전부가 크래시했다. flow-client.test.tsx와 동일 패턴 — 훅 자체를
+// 모킹해 desktop(false)을 기본값으로 고정, 이 스토리의 신규 describe에서만 true로 override.
+let isMobileMock = false;
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => isMobileMock,
+  MOBILE_BREAKPOINT: 1024,
+}));
+
 const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
   useDashboardContext: () => useDashboardContextMock(),
@@ -139,6 +149,7 @@ beforeEach(() => {
   stubEventSource();
   useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'human' });
   capturedDragEndHandlers.length = 0;
+  isMobileMock = false;
 });
 
 afterEach(async () => {
@@ -906,5 +917,55 @@ describe('KanbanBoard — 6단계 신뢰축 뷰(story #2933 H4)', () => {
       // 것 — 지금은 bulk 응답의 새 trust_stage('running')가 병합돼 여전히 렌더된다.
       expect(container.textContent).toContain('완료복귀카드');
     });
+  });
+});
+
+// story #3043(PO+유나 IA 확定 ⓒ, 2026-08-25) — viewMode('board'|'list')가 예전엔 뷰포트 무관
+// 'board'로 하드코딩돼 있었다(유나 실측: flow-client의 view='list' 세그로 진입해도 여기서
+// 다시 'board'로 떨어져 3.55배 가로 overflow 재발 — 이름이 같은 두 「board/list」 개념 충돌).
+describe('KanbanBoard — story #3043 <lg 기본값=list(칸반 다열은 opt-in)', () => {
+  it('모바일(isMobile=true)이면 기본값이 list다 — board 다열 컬럼이 아니라 KanbanListView가 뜬다', async () => {
+    isMobileMock = true;
+    stubFetch([{ id: 's-mobile', title: '모바일카드', status: 'backlog', priority: 'medium' }]);
+    await mount();
+
+    // board 뷰 전용 placeholder("스토리가 없습니다", 빈 컬럼마다 반복)는 list 뷰엔 없다 —
+    // list 뷰는 상태별 그룹 헤더(카운트 배지)로만 존재를 표현한다.
+    expect(container.textContent).not.toContain('스토리가 없습니다');
+    expect(container.textContent).toContain('모바일카드');
+  });
+
+  it('데스크톱(isMobile=false)이면 기존대로 board가 기본값이다(회귀 없음)', async () => {
+    isMobileMock = false;
+    stubFetch([{ id: 's-desktop', title: '데스크톱카드', status: 'backlog', priority: 'medium' }]);
+    await mount();
+
+    expect(container.textContent).toContain('스토리가 없습니다');
+  });
+
+  it('모바일이라도 다열(board) 토글을 직접 누르면 그 선택이 뷰포트와 무관하게 유지된다(칸반 opt-in)', async () => {
+    isMobileMock = true;
+    stubFetch([{ id: 's-toggle', title: '토글카드', status: 'backlog', priority: 'medium' }]);
+    await mount();
+
+    const boardToggle = container.querySelector<HTMLButtonElement>('button[title="Board view"]');
+    expect(boardToggle).not.toBeNull();
+    await act(async () => { boardToggle!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(container.textContent).toContain('스토리가 없습니다');
+  });
+
+  it('list 뷰의 행은 board 뷰와 동일한 StoryCard atom(SID 3018)을 재사용한다 — full-width(max-w-none)로', async () => {
+    isMobileMock = true;
+    stubFetch([{ id: 's-atom', title: '원자카드', status: 'backlog', priority: 'medium' }]);
+    await mount();
+
+    // CardVariant(ProofCapsule density="card")의 CutCornerShell 마커 — 예전 ListStoryRow
+    // 자체 마크업(rounded-lg border, proof-cut 없음)엔 없던 클래스라 진짜 atom 재사용의 증거.
+    expect(container.innerHTML).toContain('proof-cut');
+    // max-w-[280px](desktop 컬럼 고정폭 전제) 캡이 이 경로에선 max-w-none으로 override돼야
+    // full-width row가 된다 — cn()=twMerge라 나중 클래스가 이긴다(story-card.tsx 확認).
+    expect(container.innerHTML).toContain('max-w-none');
+    expect(container.innerHTML).not.toContain('max-w-[280px]');
   });
 });

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Input } from '@/components/ui/input';
 import { useRenderNonce } from '@/hooks/use-render-nonce';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { useOrgSyncVersion } from '@/lib/project-context-client';
 import {
   DropdownMenu,
@@ -167,7 +168,15 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [showSearch, setShowSearch] = useState(false);
   const [assigneeTypeFilter, setAssigneeTypeFilter] = useState<'' | 'human' | 'agent'>('');
-  const [viewMode, setViewMode] = useState<'board' | 'list'>('board');
+  // story #3043(PO+유나 IA 확定 ⓒ, 2026-08-25) — 예전엔 이 state가 뷰포트 무관 'board'로
+  // 하드코딩돼 있었다(유나 실측: flow-client의 view='list' 세그로 진입해도 여기서 다시
+  // 'board'로 떨어져 3.55배 가로 overflow가 재발 — 이름이 같은 두 「board/list」 개념 충돌).
+  // null=아직 사용자가 명시로 안 고름(URL이나 클릭 없음) → isMobile로 유도한 기본값을 쓴다.
+  // 사용자가 토글 버튼을 누르면(setViewMode 직접 호출) 그 이후엔 뷰포트 변화와 무관하게
+  // 그 선택을 고정 존중(flow-client.tsx의 `?view=` 우선·isMobile 폴백과 동일한 위계).
+  const [viewModeOverride, setViewMode] = useState<'board' | 'list' | null>(null);
+  const isMobile = useIsMobile();
+  const viewMode = viewModeOverride ?? (isMobile ? 'list' : 'board');
   // story #2933 H4(P0-H) — 5-status/6단계 신뢰축 컬럼 축 토글. viewMode(board/list)와 직교
   // (list 뷰는 이번 슬라이스 스코프 밖 — trust 축은 board 렌더 안에서만). doneCollapsed와
   // 동형 localStorage 패턴(project별) — 재방문해도 마지막 선택 유지.
@@ -1561,6 +1570,12 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
               memberMap={memberMap}
               onStoryClick={handleStoryClick}
               onChangeStatus={handleChangeStatus}
+              executionMap={executionMap}
+              blockedByMap={blockedByMap}
+              storyLabelsMap={storyLabelsMap}
+              storyGatesMap={storyGatesMap}
+              storyLineMap={storyLineMap}
+              projectId={projectId}
             />
           </div>
         ) : axisMode === 'trust' ? (

--- a/apps/web/src/components/kanban/kanban-list-view.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.tsx
@@ -1,18 +1,12 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Badge } from '@/components/ui/badge';
-import { COLUMNS, VALID_TRANSITIONS, type KanbanStory, type KanbanMember } from './types';
-
-const PRIORITY_BADGE: Record<string, 'default' | 'info' | 'success' | 'destructive' | 'outline'> = {
-  critical: 'destructive',
-  high: 'outline',
-  medium: 'info',
-  low: 'default',
-};
+import { COLUMNS, type KanbanStory, type KanbanMember, type LineStatusSummary } from './types';
+import { StoryCard } from './story-card';
+import type { LabelData } from '@/components/ui/label-chip';
 
 interface KanbanListViewProps {
   stories: KanbanStory[];
@@ -20,108 +14,16 @@ interface KanbanListViewProps {
   memberMap: Record<string, KanbanMember>;
   onStoryClick: (story: KanbanStory) => void;
   onChangeStatus: (storyId: string, newStatus: string) => Promise<void>;
-}
-
-interface ListStoryRowProps {
-  story: KanbanStory;
-  epicMap: Record<string, string>;
-  memberMap: Record<string, KanbanMember>;
-  onStoryClick: (story: KanbanStory) => void;
-  onChangeStatus: (storyId: string, newStatus: string) => Promise<void>;
-}
-
-function ListStoryRow({ story, epicMap, memberMap, onStoryClick, onChangeStatus }: ListStoryRowProps) {
-  const t = useTranslations('board');
-  const [statusOpen, setStatusOpen] = useState(false);
-  const validNext = VALID_TRANSITIONS[story.status] ?? [];
-
-  const handleStatusChange = useCallback(
-    async (newStatus: string) => {
-      setStatusOpen(false);
-      await onChangeStatus(story.id, newStatus);
-    },
-    [story.id, onChangeStatus],
-  );
-
-  const currentColumn = COLUMNS.find((c) => c.id === story.status);
-
-  return (
-    <div className={`relative flex items-center gap-3 rounded-lg border px-4 py-3 transition-all ${
-      story.assignee_id && memberMap[story.assignee_id]?.type === 'agent'
-        ? 'border-accent-claim/50 bg-background shadow-[0_0_15px_color-mix(in_oklch,var(--accent-claim),transparent_85%)] hover:border-accent-claim/80 hover:shadow-[0_0_20px_color-mix(in_oklch,var(--accent-claim),transparent_75%)]'
-        : 'border-border bg-background hover:border-primary/30 hover:bg-muted/50'
-    }`}>
-      {story.assignee_id && memberMap[story.assignee_id]?.type === 'agent' && (
-        <div className="absolute inset-0 pointer-events-none rounded-lg border border-transparent bg-gradient-to-r from-accent-claim/10 to-purple-500/10 opacity-50" />
-      )}
-      <button
-        className="min-h-[44px] flex-1 text-left"
-        onClick={() => onStoryClick(story)}
-      >
-        <div className="flex flex-wrap items-center gap-2">
-          {story.epic_id && epicMap[story.epic_id] && (
-            <Badge variant="info" className="text-[10px]">{epicMap[story.epic_id]}</Badge>
-          )}
-          {story.priority && (
-            <Badge variant={PRIORITY_BADGE[story.priority] ?? 'default'} className="text-[10px] capitalize">{story.priority as string}</Badge>
-          )}
-          {story.story_points != null && (
-            <span className="text-[10px] text-muted-foreground">{t('storyPointsBadge', { count: story.story_points })}</span>
-          )}
-        </div>
-        <p className="mt-1 text-sm font-medium text-foreground line-clamp-2 relative z-10">
-          {story.story_number ? <span className="mr-1 text-muted-foreground">#{story.story_number}</span> : null}
-          {story.title}
-        </p>
-        {story.assignee_id && memberMap[story.assignee_id] && (
-          <div className="mt-1 flex items-center gap-2 relative z-10">
-            <p className="text-xs text-muted-foreground">{memberMap[story.assignee_id].name}</p>
-            {memberMap[story.assignee_id].type === 'agent' && (
-              <div className="flex items-center gap-1.5 text-[10px] font-mono text-foreground">
-                <span className="relative flex h-1.5 w-1.5">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-claim opacity-75"></span>
-                  <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-accent-claim"></span>
-                </span>
-                <span>&gt; Agent active</span>
-              </div>
-            )}
-          </div>
-        )}
-      </button>
-
-      <div className="relative shrink-0">
-        <button
-          className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-border bg-muted/50 px-2 text-xs text-muted-foreground transition hover:bg-muted relative z-10"
-          onClick={(e) => {
-            e.stopPropagation();
-            setStatusOpen((prev) => !prev);
-          }}
-        >
-          <span className="max-w-[80px] truncate">{currentColumn ? t(currentColumn.i18nKey) : story.status}</span>
-          <ChevronDown className="ml-1 size-3 shrink-0" />
-        </button>
-
-        {statusOpen && validNext.length > 0 && (
-          // story #3007(로드맵 P2·PR-E, L1) — 드롭다운은 floating이라 --elev-overlay.
-          <div className="absolute right-0 top-full z-50 mt-1 min-w-[140px] rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-[var(--elev-overlay)]">
-            {validNext.map((nextStatus) => {
-              const col = COLUMNS.find((c) => c.id === nextStatus);
-              if (!col) return null;
-              return (
-                <button
-                  key={nextStatus}
-                  className="w-full rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
-                  onClick={() => void handleStatusChange(nextStatus)}
-                >
-                  {t(col.i18nKey)}
-                </button>
-              );
-            })}
-          </div>
-        )}
-      </div>
-    </div>
-  );
+  // story #3043(PO+유나 IA 확定 ⓒ, 2026-08-25) — 이 뷰의 행 atom을 자체 마크업(ListStoryRow)
+  // 대신 SID 3018 보드 카드(StoryCard)로 교체하면서 board 뷰(KanbanColumn)와 동일한 부가
+  // 데이터가 필요해졌다. 전부 optional(map에 키 없으면 story-card.tsx 자체 기본값으로
+  // 후퇴 — 카드 쪽이 이미 그 후퇴를 규율하므로 여기서 재구현하지 않는다).
+  executionMap?: Record<string, { status: string; rule_name?: string | null; completed_at?: string | null }>;
+  blockedByMap?: Record<string, string[]>;
+  storyLabelsMap?: Record<string, LabelData[]>;
+  storyGatesMap?: Record<string, { id: string; gate_type: string; status: string }[]>;
+  storyLineMap?: Record<string, LineStatusSummary>;
+  projectId?: string;
 }
 
 interface StatusGroupProps {
@@ -132,14 +34,24 @@ interface StatusGroupProps {
   memberMap: Record<string, KanbanMember>;
   onStoryClick: (story: KanbanStory) => void;
   onChangeStatus: (storyId: string, newStatus: string) => Promise<void>;
+  executionMap?: KanbanListViewProps['executionMap'];
+  blockedByMap?: KanbanListViewProps['blockedByMap'];
+  storyLabelsMap?: KanbanListViewProps['storyLabelsMap'];
+  storyGatesMap?: KanbanListViewProps['storyGatesMap'];
+  storyLineMap?: KanbanListViewProps['storyLineMap'];
+  projectId?: string;
 }
 
-function StatusGroup({ columnId, label, stories, epicMap, memberMap, onStoryClick, onChangeStatus }: StatusGroupProps) {
+function StatusGroup({
+  columnId, label, stories, epicMap, memberMap, onStoryClick, onChangeStatus,
+  executionMap, blockedByMap, storyLabelsMap, storyGatesMap, storyLineMap, projectId,
+}: StatusGroupProps) {
   const [expanded, setExpanded] = useState(columnId !== 'done');
 
   return (
     <div>
       <button
+        type="button"
         className="flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-sm font-semibold text-foreground hover:bg-muted/50"
         onClick={() => setExpanded((p) => !p)}
       >
@@ -153,15 +65,28 @@ function StatusGroup({ columnId, label, stories, epicMap, memberMap, onStoryClic
           {stories.length === 0 ? (
             <p className="px-3 text-xs text-muted-foreground">—</p>
           ) : (
+            // story #3043 AC ⓒ — <lg 단일열은 컬럼을 가로로 두지 않는다(status는 이 섹션
+            // 그룹 헤더가 이미 표현). full-width(w-full)만 얹고 카드 재질 자체는 board 뷰와
+            // 완전히 동일한 StoryCard를 재사용(kanban-column.tsx의 호출부와 동형).
             stories.map((story) => (
-              <ListStoryRow
-                key={story.id}
-                story={story}
-                epicMap={epicMap}
-                memberMap={memberMap}
-                onStoryClick={onStoryClick}
-                onChangeStatus={onChangeStatus}
-              />
+              <div key={story.id} className="w-full">
+                <StoryCard
+                  className="max-w-none"
+                  story={story}
+                  epicName={story.epic_id ? epicMap[story.epic_id] : undefined}
+                  assignee={story.assignee_id ? memberMap[story.assignee_id] : undefined}
+                  assignees={(story.assignee_ids ?? []).flatMap((id) => (memberMap[id] ? [memberMap[id]] : []))}
+                  onClick={() => onStoryClick(story)}
+                  onChangeStatus={(storyId, newStatus) => void onChangeStatus(storyId, newStatus)}
+                  projectId={projectId}
+                  lastExecution={executionMap?.[story.id] ?? null}
+                  blockedBy={blockedByMap?.[story.id] ?? []}
+                  labels={storyLabelsMap?.[story.id] ?? []}
+                  gates={storyGatesMap?.[story.id] ?? []}
+                  lineStatus={storyLineMap?.[story.id]}
+                  verifiedBy={story.human_verified_by ? memberMap[story.human_verified_by] : undefined}
+                />
+              </div>
             ))
           )}
         </div>
@@ -170,7 +95,10 @@ function StatusGroup({ columnId, label, stories, epicMap, memberMap, onStoryClic
   );
 }
 
-export function KanbanListView({ stories, epicMap, memberMap, onStoryClick, onChangeStatus }: KanbanListViewProps) {
+export function KanbanListView({
+  stories, epicMap, memberMap, onStoryClick, onChangeStatus,
+  executionMap, blockedByMap, storyLabelsMap, storyGatesMap, storyLineMap, projectId,
+}: KanbanListViewProps) {
   const t = useTranslations('board');
 
   return (
@@ -187,6 +115,12 @@ export function KanbanListView({ stories, epicMap, memberMap, onStoryClick, onCh
             memberMap={memberMap}
             onStoryClick={onStoryClick}
             onChangeStatus={onChangeStatus}
+            executionMap={executionMap}
+            blockedByMap={blockedByMap}
+            storyLabelsMap={storyLabelsMap}
+            storyGatesMap={storyGatesMap}
+            storyLineMap={storyLineMap}
+            projectId={projectId}
           />
         );
       })}

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -111,9 +111,14 @@ interface StoryCardProps {
    * `disabled: !sortable`류 기존 관례 재사용) "상태 변경" 우클릭 메뉴도 숨긴다(수동 상태변경도
    * 이 카드엔 안 맞음 — 게이트가 정하므로). 클릭(상세 열기)은 그대로 살아있다. */
   locked?: boolean;
+  /** story #3043(PO+유나 IA 확定 ⓒ, 2026-08-25) — CardVariant(ProofCapsule density="card")가
+   * `max-w-[280px]`를 하드코딩(desktop KanbanColumn 고정폭 전제) — 모바일 단일열(list) 재사용 시
+   * full-width row가 되려면 이 캡을 호출부가 override해야 한다. `cn()`이 twMerge라 나중 클래스가
+   * 이긴다 — 새 prop 없이 max-w-none을 넘기면 그대로 해소(신규 시각 언어 발명 없음). */
+  className?: string;
 }
 
-export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [], gates = [], lineStatus, verifiedBy, locked = false }: StoryCardProps) {
+export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [], gates = [], lineStatus, verifiedBy, locked = false, className }: StoryCardProps) {
   const t = useTranslations('board');
   // E-BOARD S6: 복수 assignee. assignees 우선, 없으면 단일 assignee 폴백. agent 한 명이라도 있으면 agent 취급(glow).
   const assigneeList = (assignees && assignees.length > 0) ? assignees : (assignee ? [assignee] : []);
@@ -488,6 +493,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
             </div>
           </div>
         }
+        className={className}
       />
 
       {/* Context Menu — body portal + position:fixed(뷰포트 좌표 clamp), 카드 위치와 무관하게 항상 화면 안 */}

--- a/apps/web/src/components/workspace/workspace-frame-tabs.test.tsx
+++ b/apps/web/src/components/workspace/workspace-frame-tabs.test.tsx
@@ -17,6 +17,15 @@ vi.mock('next/navigation', () => ({
   useParams: () => ({ ws: 'my-ws', proj: 'my-proj' }),
 }));
 
+// story #3043(PO+유나 IA 확定 ⓐ, 2026-08-25) — <lg에서 이 탭행 텍스트·인디케이터가 커진다
+// (useIsMobile). jsdom엔 window.matchMedia가 없어 훅 자체를 모킹(flow-client.test.tsx와
+// 동일 패턴) — 기존 6개 테스트는 desktop(false) 기본값으로 회귀 0 유지.
+let isMobileMock = false;
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => isMobileMock,
+  MOBILE_BREAKPOINT: 1024,
+}));
+
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 let container: HTMLDivElement;
@@ -34,6 +43,7 @@ beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
+  isMobileMock = false;
 });
 
 afterEach(async () => {
@@ -88,5 +98,36 @@ describe('WorkspaceFrameTabs — story #2930 I3', () => {
     await act(async () => { root.render(wrap(<WorkspaceFrameTabs active="board" />, enMessages)); });
     const tabs = [...container.querySelectorAll('[role="tab"]')];
     expect(tabs.map((t) => t.textContent)).toEqual(['Board', 'Sprints', 'Epic']);
+  });
+
+  // story #3043(PO+유나 IA 확定 ⓐ, 2026-08-25) — "「지금」 탭을 열 때 여기가 보드인 것이
+  // 즉시 읽히게" 시각 위계 승격. PR#3358 규율(상위=underline·내부=pill)은 유지하고 그 안에서
+  // <lg만 텍스트·인디케이터를 키운다.
+  describe('<lg 시각 위계 승격', () => {
+    it('모바일이면 탭 텍스트가 더 커진다(text-base) — 데스크톱은 text-sm 그대로', async () => {
+      isMobileMock = true;
+      const { WorkspaceFrameTabs } = await import('./workspace-frame-tabs');
+      await act(async () => { root.render(wrap(<WorkspaceFrameTabs active="board" />)); });
+      const boardTab = [...container.querySelectorAll('[role="tab"]')].find((t) => t.textContent === '보드');
+      expect(boardTab?.className).toContain('text-base');
+      expect(boardTab?.className).not.toContain('text-sm');
+    });
+
+    it('데스크톱(기본값)이면 기존 text-sm 그대로다(회귀 없음)', async () => {
+      const { WorkspaceFrameTabs } = await import('./workspace-frame-tabs');
+      await act(async () => { root.render(wrap(<WorkspaceFrameTabs active="board" />)); });
+      const boardTab = [...container.querySelectorAll('[role="tab"]')].find((t) => t.textContent === '보드');
+      expect(boardTab?.className).toContain('text-sm');
+    });
+
+    it('모바일에서도 라우팅·aria-selected 동작은 회귀 없다', async () => {
+      isMobileMock = true;
+      const { WorkspaceFrameTabs } = await import('./workspace-frame-tabs');
+      await act(async () => { root.render(wrap(<WorkspaceFrameTabs active="sprints" />)); });
+      const boardTab = [...container.querySelectorAll('[role="tab"]')].find((t) => t.textContent === '보드');
+      expect(boardTab?.getAttribute('aria-selected')).toBe('false');
+      await act(async () => { boardTab!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(pushMock).toHaveBeenCalledWith('/my-ws/my-proj/flow');
+    });
   });
 });

--- a/apps/web/src/components/workspace/workspace-frame-tabs.tsx
+++ b/apps/web/src/components/workspace/workspace-frame-tabs.tsx
@@ -2,6 +2,8 @@
 
 import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
 
 const TABS = [
   { key: 'board', path: 'flow' },
@@ -28,6 +30,11 @@ export function WorkspaceFrameTabs({ active }: { active: WorkspaceFrameTabKey })
   const t = useTranslations('nav');
   const router = useRouter();
   const params = useParams<{ ws: string; proj: string }>();
+  // story #3043(PO+유나 IA 확定 ⓐ, 2026-08-25) — "「지금」 탭을 열 때 여기가 보드인 것이
+  // 즉시 읽히게" 시각 위계 승격. PR#3358(유나 QA)이 세운 「상위 프레임=underline·내부 뷰
+  // 탭=rounded pill」구분 자체는 유효한 규율이라 유지(pill로 갈아타지 않음 — 재규격이 아니라
+  // <lg에서만 이 underline 계열 안에서 텍스트·인디케이터 두께를 키운다).
+  const isMobile = useIsMobile();
 
   return (
     // 유나 QA 블로커(PR#3358, 2026-08-22) — flow-client 내부 3탭(가설/갈래/칸반)과 스타일이
@@ -43,7 +50,12 @@ export function WorkspaceFrameTabs({ active }: { active: WorkspaceFrameTabKey })
           role="tab"
           aria-selected={active === tab.key}
           onClick={() => router.push(`/${params.ws}/${params.proj}/${tab.path}`)}
-          className={`-mb-px border-b-2 px-1 pb-2 text-sm font-semibold transition ${active === tab.key ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}`}
+          className={cn(
+            'font-semibold transition',
+            isMobile
+              ? `-mb-px border-b-[3px] px-1 pb-2.5 text-base ${active === tab.key ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}`
+              : `-mb-px border-b-2 px-1 pb-2 text-sm ${active === tab.key ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}`,
+          )}
         >
           {t(tab.key)}
         </button>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
     },
   },
   test: {
+    // story #3466(카디르 QA REQUEST_CHANGES, 2026-08-25) — window.matchMedia jsdom 갭 전역 폴백.
+    // vitest.setup.ts 참고(왜 top-level 1회가 아니라 beforeEach인지 그 파일에 설명). 절대경로로
+    // 넘긴다 — apps/web에서 CWD로 실행되는 vitest 호출부(package.json test 스크립트 등)가
+    // './vitest.setup.ts'를 자기 CWD 기준으로 잘못 찾는 것을 막는다(위 resolve.alias와 동일 원칙).
+    setupFiles: [fileURLToPath(new URL('./vitest.setup.ts', import.meta.url))],
     exclude: [
       '**/node_modules/**',
       '**/dist/**',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,26 @@
+// story #3466(카디르 QA REQUEST_CHANGES, 2026-08-25) — WorkspaceFrameTabs에 얹은 useIsMobile()
+// (story #3043 ⓐ)이 jsdom엔 없는 window.matchMedia를 직접 호출해, 이 훅을 개별 모킹하지 않은
+// 다른 소비처(EpicSwimlaneBoard 등 — WorkspaceFrameTabs를 공유 컴포넌트로 임포트하는 모든 테스트)
+// 31개가 "matchMedia is not a function"으로 깨졌다. 파일마다 matchMedia stub을 흩는 반창고 대신
+// (다음 소비처가 또 깨지는 구조) 여기 전역 beforeEach로 기본 무결점(false=desktop) 폴리필을
+// 심는다 — 기존 개별 stub(vi.stubGlobal('matchMedia', ...) 또는 vi.mock('@/hooks/use-mobile', ...))
+// 을 쓰는 파일은 자기 값으로 뒤이어 덮어쓰므로 회귀 없음(전수 grep 확認, 11개 파일 전부 vi.stubGlobal
+// 패턴이라 「나중 호출이 이긴다」로 충돌 0). beforeEach(최상위 아님)로 심는 이유 — 일부 파일이
+// 자기 afterEach에서 vi.unstubAllGlobals()를 호출해(kanban-board.test.tsx 등) top-level 1회
+// 설정은 그 파일의 2번째 테스트부터 사라진다 — 매 테스트 앞에서 다시 세워야 항상 안전하다.
+import { beforeEach } from 'vitest';
+
+beforeEach(() => {
+  if (typeof window === 'undefined') return;
+  if (typeof window.matchMedia === 'function') return;
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+});


### PR DESCRIPTION
## 요약
- **증상**(민 실측·선생님 확定): 모바일에 칸반 보드 실물이 존재하지만(흐름→칸반 탭·컬럼 4·카드 구조 정상) 접근 경로가 하단 탭이 아니라 «흐름» 메뉴 안쪽 — PO조차 "모바일에 보드 없다"고 오답할 정도의 발견성 결함.
- **그라운딩 확認**: `#2225`(모바일 3화면 대체 세그)는 실제론 status=backlog, 한 줄도 안 짜여 있었음(코드 전수 확認) — 그런데도 `flow-client.tsx`는 "#2225가 그 자리를 대신한다"는 전제로 모바일에서 가설|갈래|칸반 세그를 숨겨왔음. 결과: 모바일에서 갈래·칸반 둘 다 도달 UI 경로가 완전히 0.
- **PO+유나 IA 확定 3층(ⓐⓑⓒ)**: ①7/17 Job 정의는 유효(보드=Job2 "파악" 표면, "지금" 이웃 유지) ②발견성 갭은 Job 모델 실패가 아니라 legibility+폼 결함 → 3안 중 ①전체승격·②탭재편 기각, "파악 이웃 유지 + legibility + 폼 수리"로 확定.

## 구현 (커밋 1 — ⓑ)
- `flow-client.tsx`: `parseView()` 모바일 기본값 flow→list(칸반), 세그 스위처 `isMobile ? null : ...` 가드 제거(모바일에서도 렌더).

## 구현 (커밋 2 — ⓐⓒ)
### ⓐ 진입 legibility
- `workspace-frame-tabs.tsx`: <lg에서 탭 텍스트·인디케이터 승격(text-sm→text-base, border-b-2→border-b-[3px]). PR#3358 규율(상위=underline·내부=pill 구분) 유지.
- `scale-ladder.tsx`: 새 `compact` prop — <lg에선 질문 문구를 뺀 칩열로 낮춰 보드 콘텐츠가 밀려나지 않게.

### ⓒ list = 진짜 모바일 단일열
- `kanban-board.tsx`: 내부 `viewMode` state가 뷰포트 무관 `'board'`로 하드코딩돼 있던 것이 "`?view=list`로 들어와도 다시 board(다열)로 떨어지는" 진짜 원인(flow-client의 `view`와 이름만 같은 별개 축, 유나 실측: 3.55배 overflow). `<lg`면 `viewMode` 기본값=`list`, 사용자가 토글을 직접 누르면 그 선택을 뷰포트와 무관하게 고정 존중(다열 board는 opt-in).
- `kanban-list-view.tsx`: 자체 마크업(`ListStoryRow`) 대신 board 뷰와 동일한 `StoryCard` atom(SID 3018 — 카테고리 칩·claim·「다음:」·#num) 재사용.
- `story-card.tsx`: `CardVariant`의 `max-w-[280px]` 하드코딩(desktop 컬럼 고정폭 전제)을 새 `className` prop으로 override 가능하게(`cn()`=twMerge). list 뷰는 `max-w-none`으로 full-width row.

## 검증
- 회귀가드 11개 신설(flow-client 2·kanban-board 4·scale-ladder 3·workspace-frame-tabs 3, jsdom `matchMedia` 갭은 `useIsMobile` mock으로 해소) — git stash로 pre-fix 대면 정확히 신규분만 RED(다른 기존 테스트 전부 무관 통과) 실증.
- eslint 0 warning·tsc 클린·`pnpm build` EXIT=0·vitest 186 pass.
- ⚠️**puppeteer 세션이 작업 전체 기간 detached frame으로 완전 사망**(재시도 5회+ 전부 실패, 환경 이슈로 판단·제 쪽에서 복구 불가) — 390px 실렌더 라이트/다크 라이브 확認을 못 함. 실 컴포넌트 렌더 마크업(vitest 실측 캡처)을 그대로 옮긴 정적 리프로는 준비돼 있으나, 라이브 스크린샷 자체는 **카디르군 QA 단계에서 재확認 요청**.

## AC 체크
- [x] 핵심 표면(칸반) 모바일 진입 동선 확定(유나 IA 판단+PO 확認)
- [ ] 390px 실렌더 라이브(라이트/다크) — puppeteer 환경 이슈로 미완, 카디르 QA 위임
- [x] 유나 design(이미 IA 배선 참여)
- [ ] 카디르 QA

## 리뷰 요청
- 유나군 design(IA 구현 결과 재확認)
- 카디르군 QA — 특히 390px 라이브 픽셀(puppeteer 환경 이슈로 제가 못 한 부분)