### PR TITLE
[SID:3044] 결재함 목록 stale — 신규 게이트 생성 SSE 신호 신설

### DIFF
--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -899,6 +899,45 @@ describe('ApprovalsQueue — 실시간 해소/위임 반영(story #2985 AC2)', (
     expect(container.textContent).not.toContain('실시간 대상 항목');
   });
 
+  // story #3044(PO 실사고 표본②, 2026-08-25) — fetchGates()는 마운트 1회뿐이고 gate_resolved/
+  // gate_delegated 둘 다 "새 게이트가 생겼다"는 못 알린다. conversation.gate_created 구독이
+  // 그 3번째 신호 — payload는 gate_id뿐이라 단건 GET으로 채워 prepend해야 한다.
+  it('mux가 conversation.gate_created를 쏘면 단건 GET으로 채워 목록 맨 앞에 즉시 추가된다(하드 리로드 불요)', async () => {
+    mockFetches([actionableGate()], []);
+    await mount();
+    expect(container.textContent).not.toContain('새로생긴카드');
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/gates/g-new') {
+        return { ok: true, json: async () => gate({ id: 'g-new', work_item_summary: { title: '새로생긴카드', slug: null } }) };
+      }
+      return { ok: true, json: async () => [] };
+    }));
+
+    const call = muxSubscribeMock.mock.calls.find(([eventName]) => eventName === 'conversation.gate_created');
+    expect(call).toBeTruthy();
+    const handler = call![1] as (raw: string, eventId?: string) => void;
+    await act(async () => { handler(JSON.stringify({ gate_id: 'g-new' })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('새로생긴카드');
+  });
+
+  it('mux가 conversation.gate_created를 쏴도 이미 목록에 있는 gate_id면 중복 추가하지 않는다(레이스 가드)', async () => {
+    mockFetches([actionableGate()], []);
+    await mount();
+    const before = container.textContent;
+
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => actionableGate() })));
+
+    const call = muxSubscribeMock.mock.calls.find(([eventName]) => eventName === 'conversation.gate_created');
+    const handler = call![1] as (raw: string, eventId?: string) => void;
+    await act(async () => { handler(JSON.stringify({ gate_id: 'g-live' })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toBe(before);
+  });
+
   it('malformed payload는 크래시 없이 무시한다', async () => {
     mockFetches([actionableGate()], []);
     await mount();

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -230,6 +230,30 @@ export function ApprovalsQueue() {
     return unsub;
   }, [mux]);
 
+  // story #3044(PO 실사고 표본②, 2026-08-25) — fetchGates()는 마운트 1회뿐이고 위 두 SSE는
+  // 기존 항목의 상태 변화만 다뤄, "새 게이트가 생겼다"를 알리는 신호가 없었다(이미 열어둔
+  // 탭에 새 게이트가 생기면 하드 리로드 전까진 영원히 안 뜸 — gate 2a14c177 실사고). BE가
+  // notify_gate_created_to_recipients(approval_delivery.py)로 심는 conversation.gate_created를
+  // 구독 — payload는 gate_id뿐이라(다른 두 이벤트와 동형, 최소 payload 관례) 단건 GET으로
+  // 채워 prepend한다. 이미 목록에 있으면(레이스 — fetchGates()가 방금 같은 걸 받아왔거나
+  // 중복 이벤트) 지어내지 않고 skip.
+  useEffect(() => {
+    if (!mux) return;
+    const unsub = mux.subscribe('conversation.gate_created', (raw) => {
+      void (async () => {
+        try {
+          const payload = JSON.parse(raw) as { gate_id?: string };
+          if (!payload.gate_id) return;
+          const res = await fetchWithAuth(`/api/gates/${payload.gate_id}`);
+          if (!res.ok) return;
+          const gate = (await res.json()) as GateItem;
+          setItems((prev) => (prev.some((it) => it.id === gate.id) ? prev : [gate, ...prev]));
+        } catch { /* malformed payload 또는 fetch 실패 — 무시(다음 하드 리로드가 흡수) */ }
+      })();
+    });
+    return unsub;
+  }, [mux]);
+
   // story #2054 AC3: HitlRequest는 상세 페이지가 없어 이 큐 안에서 바로 승인/반려한다 —
   // 승인 후 원래 작업(report-done)이 통과하는지는 사용자 왕복(재시도)으로 확認된다.
   const resolveHitl = async (id: string, status: 'approved' | 'rejected') => {

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -317,7 +317,7 @@ class DecisionRequestCreate(BaseModel):
 async def _notify_decision_request_card(
     session: AsyncSession, org_id: uuid.UUID, gate: Gate, *, requester_id: uuid.UUID, project_id: uuid.UUID,
     designated_approver_id: uuid.UUID | None = None,
-) -> list[tuple[str, dict]]:
+) -> None:
     """story #8bc11434(2891) — request_decision(agent_decision_request 게이트) 상신 시 결재자
     (org owner/admin) 챗에 원탭 결재 카드 자동 발행. app/services/doc.py의
     _notify_doc_approval_requested()와 동형(approver 해소·best-effort try/except 관용구 그대로
@@ -325,7 +325,12 @@ async def _notify_decision_request_card(
     org owner/admin임은 _non_doc_gate_approvable()(agent_decision은 project-agnostic이라
     project_id=None 분기, is_org_owner_or_admin)로 이미 확定돼 있어 별도 판단 아님. create_gate()
     의 generic 벨(gate.pending_approval)은 그대로 유지(notify=False 안 씀 — doc.py와 달리 이
-    gate_type엔 대체할 리치 벨이 없어 끄면 알림 자체가 0이 된다), 이 함수는 챗 카드만 추가."""
+    gate_type엔 대체할 리치 벨이 없어 끄면 알림 자체가 0이 된다), 이 함수는 챗 카드만 추가.
+
+    story #3044(2026-08-25) — dispatch_approval_request_cards가 이제 conversation.gate_created
+    (결재함 목록 실시간 반영)도 같은 자리에서 심는다. after_commit 훅으로 자체 예약하므로
+    (approval_delivery.py의 notify_gate_created_to_recipients 문서 참고) 이 함수·호출부
+    둘 다 반환값 스레딩·commit 타이밍을 신경 쓸 필요가 없다 — 회귀 0(원래도 -> None)."""
     try:
         from app.models.project import OrgMember
         approver_ids = list((await session.execute(
@@ -338,14 +343,14 @@ async def _notify_decision_request_card(
         )).scalars().all())
     except Exception:  # noqa: BLE001 — 조회 실패는 상신 비중단.
         logger.warning("decision-request 결재자 조회 실패 gate=%s", gate.id, exc_info=True)
-        return []
+        return
 
     if not approver_ids:
-        return []
+        return
 
     try:
         from app.services.approval_delivery import dispatch_approval_request_cards
-        return await dispatch_approval_request_cards(
+        await dispatch_approval_request_cards(
             session, org_id=org_id, work_item_type="agent_decision", work_item_id=gate.id,
             project_id=project_id, title=gate.neutral_facts.get("question", "결정 요청") if gate.neutral_facts else "결정 요청",
             gate_id=gate.id, requester_id=requester_id, approver_ids=approver_ids,
@@ -353,7 +358,6 @@ async def _notify_decision_request_card(
         )
     except Exception:  # noqa: BLE001 — 카드 배달 실패는 상신 비중단(Gate inbox 폴백 항상 존재).
         logger.warning("decision-request 결재자 카드(챗) 배달 실패 gate=%s", gate.id, exc_info=True)
-        return []
 
 
 @router.post("/decisions", response_model=GateResponse, status_code=201)
@@ -437,20 +441,12 @@ async def create_decision_request(
         designated_approver_id=body.approver_member_id,
     )
     await session.flush()
-    _created_pushes = await _notify_decision_request_card(
+    await _notify_decision_request_card(
         session, org_id, gate, requester_id=caller_id, project_id=project_id,
         designated_approver_id=body.approver_member_id,
     )
     await session.commit()
     await session.refresh(gate)
-    # story #3044 — gate가 커밋돼 GET으로 읽힐 수 있게 된 後에만 push(read-your-writes 레이스
-    # 방지, dispatch_gate_delegation과 동일 원칙). best-effort — 실패해도 상신 자체는 이미 끝남.
-    for _pid_str, _payload in _created_pushes:
-        try:
-            from app.routers.events import _push_to_agent
-            _push_to_agent(_pid_str, _payload)
-        except Exception:  # noqa: BLE001
-            logger.warning("decision-request gate_created 실시간 반영 배선 실패 gate=%s", gate.id, exc_info=True)
     resp = GateResponse.model_validate(gate)
     resp.project_id = project_id
     # story #1972 SSOT 재사용(제네릭 create_gate_endpoint가 이 필드를 아예 안 채우는 기존

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -317,7 +317,7 @@ class DecisionRequestCreate(BaseModel):
 async def _notify_decision_request_card(
     session: AsyncSession, org_id: uuid.UUID, gate: Gate, *, requester_id: uuid.UUID, project_id: uuid.UUID,
     designated_approver_id: uuid.UUID | None = None,
-) -> None:
+) -> list[tuple[str, dict]]:
     """story #8bc11434(2891) — request_decision(agent_decision_request 게이트) 상신 시 결재자
     (org owner/admin) 챗에 원탭 결재 카드 자동 발행. app/services/doc.py의
     _notify_doc_approval_requested()와 동형(approver 해소·best-effort try/except 관용구 그대로
@@ -338,14 +338,14 @@ async def _notify_decision_request_card(
         )).scalars().all())
     except Exception:  # noqa: BLE001 — 조회 실패는 상신 비중단.
         logger.warning("decision-request 결재자 조회 실패 gate=%s", gate.id, exc_info=True)
-        return
+        return []
 
     if not approver_ids:
-        return
+        return []
 
     try:
         from app.services.approval_delivery import dispatch_approval_request_cards
-        await dispatch_approval_request_cards(
+        return await dispatch_approval_request_cards(
             session, org_id=org_id, work_item_type="agent_decision", work_item_id=gate.id,
             project_id=project_id, title=gate.neutral_facts.get("question", "결정 요청") if gate.neutral_facts else "결정 요청",
             gate_id=gate.id, requester_id=requester_id, approver_ids=approver_ids,
@@ -353,6 +353,7 @@ async def _notify_decision_request_card(
         )
     except Exception:  # noqa: BLE001 — 카드 배달 실패는 상신 비중단(Gate inbox 폴백 항상 존재).
         logger.warning("decision-request 결재자 카드(챗) 배달 실패 gate=%s", gate.id, exc_info=True)
+        return []
 
 
 @router.post("/decisions", response_model=GateResponse, status_code=201)
@@ -436,12 +437,20 @@ async def create_decision_request(
         designated_approver_id=body.approver_member_id,
     )
     await session.flush()
-    await _notify_decision_request_card(
+    _created_pushes = await _notify_decision_request_card(
         session, org_id, gate, requester_id=caller_id, project_id=project_id,
         designated_approver_id=body.approver_member_id,
     )
     await session.commit()
     await session.refresh(gate)
+    # story #3044 — gate가 커밋돼 GET으로 읽힐 수 있게 된 後에만 push(read-your-writes 레이스
+    # 방지, dispatch_gate_delegation과 동일 원칙). best-effort — 실패해도 상신 자체는 이미 끝남.
+    for _pid_str, _payload in _created_pushes:
+        try:
+            from app.routers.events import _push_to_agent
+            _push_to_agent(_pid_str, _payload)
+        except Exception:  # noqa: BLE001
+            logger.warning("decision-request gate_created 실시간 반영 배선 실패 gate=%s", gate.id, exc_info=True)
     resp = GateResponse.model_validate(gate)
     resp.project_id = project_id
     # story #1972 SSOT 재사용(제네릭 create_gate_endpoint가 이 필드를 아예 안 채우는 기존

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -268,21 +268,25 @@ async def notify_gate_created_to_recipients(
     된다(caller 협조 불요 — 새 호출부가 미래에 생겨도 이 함수를 거치기만 하면 구조적으로
     커버된다, "우회 없이" 8개 caller 전부를 실제로 돌파).
 
-    ⚠️id 공간 매핑 경계(페드루 PO 요청, 2026-08-25) — `Event.recipient_id`는 `team_members.id`
-    FK(NOT NULL)다. `team_members`는 0088에서 프로젝션 **뷰**로 태어났다는 게 기존 주석의
-    설명이지만, 이 그라운딩 도중 실 PG로 재확認하니(psql 메타명령으로 스키마 직접 조회)
-    **오늘은 자체 PK+FK를 가진 진짜 base table**이다(그 사이 어느 마이그레이션이 뷰→테이블로
-    전환 — 옛 주석들이 스테일해진 것 자체가 부수 발견, 이 스토리 스코프 밖이라 정정만 하고
-    남김·별도 스토리 등재).
+    ⚠️id 공간 매핑 경계(페드루 PO 요청, 2026-08-25 — 카디르 QA #3467 REQUEST_CHANGES①로 정정) —
+    이 자리의 이전 판(커밋 e3bdb5e33)은 "team_members는 오늘 진짜 base table"이라 적었으나
+    **오判이었다**(로컬 psql 확認이 이 뷰가 도입되기 전 상태의 스테일한 스크래치 DB를 겨눔 —
+    카디르 CI 재현·본 세션에서 완전히 새로 만든 스크래치 DB 재확認으로 둘 다 반증). 정본:
+    `team_members`는 0088에서 도입된 프로젝션 **뷰**(members ⋈ project_access, UNION ALL
+    agent 분기)가 지금도 그대로다(`backend/alembic/baseline/schema.sql:2036`). `Event.
+    recipient_id`도 재확認 결과 DB 레벨 FK 제약 자체가 없다(NOT NULL만) — 그럼에도 아래 필터는
+    "team_members 뷰에 잡히지 않는 recipient는 메시징 신원이 없어 실제로 못 찾는다"는 응용
+    계층 규율이라 필터 자체는 유효(제거하지 않는다).
 
     핵심은 여전히 유효 — `org_members`(role 권위 축, `get_project_role`의 "org owner/admin
-    floor"가 사는 곳)와 `team_members`(메시징 신원 축, 이 테이블에 명시 행이 있어야만 존재)
-    는 **독립된 두 테이블·두 id 공간**이다(OrgMember.id는 uuid4 자체 발급 — team_members.id와
-    무관). "org admin이지만 이 프로젝트엔 team_members 행이 없는" recipient_id는 authz(rule B
-    floor)로는 승인 자격이 있어도 이 FK를 항상 위반한다(실사고 재현: test_2891 fixture가
-    이 정확한 케이스 — org admin을 OrgMember만으로 seed, TeamMember 없음). 여기서 그 서브셋을
-    사전에 걸러 스킵한다(로그만, 예외 전파 안 함) — dispatch_approval_request_cards의 챗
-    카드 배달(다른 신원 경로, Conversation 참가자 자격)은 이 필터와 무관하게 그대로 간다."""
+    floor"가 사는 곳)와 `team_members`(메시징 신원 축, 이 뷰에 투영될 members+project_access
+    명시 행이 있어야만 존재)는 **독립된 두 id 공간**이다(OrgMember.id는 uuid4 자체 발급 —
+    members.id와 무관). "org admin이지만 이 프로젝트엔 team_members 행이 없는" recipient_id는
+    authz(rule B floor)로는 승인 자격이 있어도 team_members 뷰엔 안 잡힌다(실사고 재현:
+    test_2891 fixture가 이 정확한 케이스 — org admin을 OrgMember만으로 seed, members/
+    project_access 없음). 여기서 그 서브셋을 사전에 걸러 스킵한다(로그만, 예외 전파 안 함) —
+    dispatch_approval_request_cards의 챗 카드 배달(다른 신원 경로, Conversation 참가자 자격)은
+    이 필터와 무관하게 그대로 간다."""
     if not recipient_ids:
         return
 
@@ -344,6 +348,17 @@ def _schedule_gate_created_push_after_commit(db: AsyncSession, pid_str: str, pay
 
 
 def _fire_pending_gate_created_pushes(sync_session: Session) -> None:
+    """⚠️SAVEPOINT 유령 push(카디르 QA #3467 REQUEST_CHANGES②, 2026-08-25) — `after_commit`은
+    SQLAlchemy가 outer 최종 commit뿐 아니라 `begin_nested()` SAVEPOINT를
+    release(`nested.commit()`)할 때도 발화한다(실측: 콜백 안에서
+    `in_nested_transaction()`이 그 순간엔 True). outer 트랜잭션이 이후 rollback돼도 이미
+    push가 나가버려 "실은 durable하지 않은 이벤트"가 라이브로 새는 결함이었다.
+    `in_nested_transaction()`이 True인 발화(=SAVEPOINT release)는 pending을 비우지 않고
+    그대로 둔다 — 언젠가 진짜 outer commit의 after_commit이 다시 발화할 때(그때는
+    in_nested_transaction()=False) 최종 발사된다. outer가 끝내 rollback되면
+    after_rollback 훅(_clear_pending_gate_created_pushes_on_rollback)이 비운다."""
+    if sync_session.in_nested_transaction():
+        return
     pending = sync_session.info.pop(_GATE_CREATED_PENDING_KEY, None) or []
     if not pending:
         return

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -105,7 +105,7 @@ async def dispatch_approval_request_cards(
     requester_id: uuid.UUID,
     approver_ids: list[uuid.UUID],
     designated_approver_id: uuid.UUID | None = None,
-) -> None:
+) -> list[tuple[str, dict]]:
     """승인자별 DM에 message_kind="request" 카드 메시지 게시 + SSE 이벤트(AC1/AC2).
 
     designated_approver_id: story #3001(선생님 정책 확定 2026-08-24, PR#3426 조건부→
@@ -133,7 +133,7 @@ async def dispatch_approval_request_cards(
     채울 수 없다.
     """
     if not project_id or not approver_ids:
-        return
+        return []
 
     # story #2985 — designated_approver_id는 반드시 approver_ids(해소 권한 실보유자) 안에
     # 있어야 유효하다. 벗어난 값(오탈자·이미 org를 떠난 member 등)을 그대로 믿으면 지정자가
@@ -154,7 +154,7 @@ async def dispatch_approval_request_cards(
         logger.warning(
             "approval-request 카드 배달 스킵 — requester 미확인 %s=%s", work_item_type, work_item_id,
         )
-        return
+        return []
 
     # story #2985 잔존 — designated_approver_name은 이제 정보성 카드가 아니라 "위임됨" 표기
     # (story #3001)에서도 쓰인다(원 지정자 카드가 "{새 지정자 이름}에게 위임됨"을 보여줄 때).
@@ -210,6 +210,101 @@ async def dispatch_approval_request_cards(
                 "approval-request 카드 배달 실패 %s=%s approver=%s",
                 work_item_type, work_item_id, approver_id, exc_info=True,
             )
+
+    # story #3044(2026-08-25) — 카드가 실제로 간 recipients와 정확히 같은 대상에게
+    # conversation.gate_created(순수 SSE, 새 챗버블 없음)도 심는다 — 결재함 목록이
+    # "새 게이트가 생겼다"를 아예 못 듣던 갭(notify_gate_created_to_recipients 문서 참고).
+    # best-effort — 실패해도 카드 배달(위 루프, 이미 끝남)은 막지 않는다.
+    try:
+        return await notify_gate_created_to_recipients(
+            db, org_id=org_id, project_id=project_id, gate_id=gate_id, recipient_ids=recipients,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "gate_created 목록 실시간 반영 배선 실패 %s=%s", work_item_type, work_item_id, exc_info=True,
+        )
+        return []
+
+
+async def notify_gate_created_to_recipients(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    gate_id: uuid.UUID,
+    recipient_ids: list[uuid.UUID],
+) -> list[tuple[str, dict]]:
+    """story #3044(PO 실사고 표본②, 2026-08-25 그라운딩) — 결재함(approvals-queue.tsx)이
+    마운트 1회만 fetch하고 이후는 conversation.gate_resolved/gate_delegated 2종 SSE로만
+    갱신되는 구조라 — 둘 다 **기존 항목의 상태 변화**만 다뤄, "새 게이트가 생겼다"를 알리는
+    신호 자체가 없었다(전수 grep 확認). 이미 열어둔 탭에 새 게이트가 생기면 하드 리로드
+    전까진 영원히 안 뜬다 — 챗 카드 직링크로만 도달 가능했던 실사고(gate 2a14c177)가 이 갭.
+
+    notify_gate_card_recipients_resolved(위, 이 파일)와 동형 — 새 ConversationMessage는
+    만들지 않는다(순수 SSE 신호, 카드는 dispatch_approval_request_cards가 이미 별도로
+    맡는다 — 이중 배달 아님). recipient_ids는 호출부가 이미 계산해 넘긴다(dispatch_
+    approval_request_cards의 `recipients` 산출과 동일 소스 — designated_approver_id가
+    있으면 그 1인, 없으면 approver_ids 전원, 카드가 실제로 간 대상과 정확히 일치).
+
+    ⚠️id 공간 매핑 경계(페드루 PO 요청, 2026-08-25) — `Event.recipient_id`는 `team_members.id`
+    FK(NOT NULL)다. `team_members`는 0088에서 프로젝션 **뷰**로 태어났다는 게 기존 주석의
+    설명이지만, 이 그라운딩 도중 실 PG로 재확認하니(psql 메타명령으로 스키마 직접 조회)
+    **오늘은 자체 PK+FK를
+    가진 진짜 base table**이다(그 사이 어느 마이그레이션이 뷰→테이블로 전환 — 옛 주석들이
+    스테일해진 것 자체가 부수 발견, 이 스토리 스코프 밖이라 정정만 하고 남김).
+
+    핵심은 여전히 유효 — `org_members`(role 권위 축, `get_project_role`의 "org owner/admin
+    floor"가 사는 곳)와 `team_members`(메시징 신원 축, 이 테이블에 명시 행이 있어야만 존재)
+    는 **독립된 두 테이블·두 id 공간**이다(OrgMember.id는 uuid4 자체 발급 — team_members.id와
+    무관). "org admin이지만 이 프로젝트엔 team_members 행이 없는" recipient_id는 authz(rule B
+    floor)로는 승인 자격이 있어도 이 FK를 항상 위반한다(실사고 재현: test_2891 fixture가
+    이 정확한 케이스 — org admin을 OrgMember만으로 seed, TeamMember 없음). 여기서 그 서브셋을
+    사전에 걸러 스킵한다(로그만, 예외 전파 안 함) — dispatch_approval_request_cards의 챗
+    카드 배달(다른 신원 경로, Conversation 참가자 자격)은 이 필터와 무관하게 그대로 간다."""
+    if not recipient_ids:
+        return []
+
+    from app.models.team import TeamMember
+    from app.services.member_resolver import lookup_members_by_ids
+
+    valid_ids = set((await db.execute(
+        select(TeamMember.id).where(TeamMember.id.in_(recipient_ids), TeamMember.project_id == project_id)
+    )).scalars().all())
+    skipped = set(recipient_ids) - valid_ids
+    if skipped:
+        logger.warning(
+            "gate_created SSE 스킵 — team_members(project_access) 신원 없음 gate=%s project=%s recipients=%s",
+            gate_id, project_id, skipped,
+        )
+    if not valid_ids:
+        return []
+
+    members = await lookup_members_by_ids(valid_ids, db)
+
+    payload_base = {"gate_id": str(gate_id)}
+
+    events: list[Event] = []
+    for recipient_id in valid_ids:
+        member = members.get(recipient_id)
+        m_type = member.type if member is not None else "human"
+        event = Event(
+            project_id=project_id, org_id=org_id, event_type="conversation.gate_created",
+            source_entity_type="gate", source_entity_id=gate_id,
+            sender_id=None, recipient_id=recipient_id, recipient_type=m_type,
+            payload=payload_base, status="pending",
+        )
+        db.add(event)
+        events.append(event)
+
+    await db.flush()
+    pushes: list[tuple[str, dict]] = []
+    for event in events:
+        pushes.append((
+            str(event.recipient_id),
+            {"event_id": str(event.id), "event_type": "conversation.gate_created", **payload_base,
+             "recipient_id": str(event.recipient_id)},
+        ))
+    return pushes
 
 
 async def dispatch_approval_result_reply(

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 import logging
 import uuid
 
+from sqlalchemy import event as sa_event
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.doc import Doc
@@ -105,7 +107,7 @@ async def dispatch_approval_request_cards(
     requester_id: uuid.UUID,
     approver_ids: list[uuid.UUID],
     designated_approver_id: uuid.UUID | None = None,
-) -> list[tuple[str, dict]]:
+) -> None:
     """승인자별 DM에 message_kind="request" 카드 메시지 게시 + SSE 이벤트(AC1/AC2).
 
     designated_approver_id: story #3001(선생님 정책 확定 2026-08-24, PR#3426 조건부→
@@ -133,7 +135,7 @@ async def dispatch_approval_request_cards(
     채울 수 없다.
     """
     if not project_id or not approver_ids:
-        return []
+        return
 
     # story #2985 — designated_approver_id는 반드시 approver_ids(해소 권한 실보유자) 안에
     # 있어야 유효하다. 벗어난 값(오탈자·이미 org를 떠난 member 등)을 그대로 믿으면 지정자가
@@ -154,7 +156,7 @@ async def dispatch_approval_request_cards(
         logger.warning(
             "approval-request 카드 배달 스킵 — requester 미확인 %s=%s", work_item_type, work_item_id,
         )
-        return []
+        return
 
     # story #2985 잔존 — designated_approver_name은 이제 정보성 카드가 아니라 "위임됨" 표기
     # (story #3001)에서도 쓰인다(원 지정자 카드가 "{새 지정자 이름}에게 위임됨"을 보여줄 때).
@@ -214,16 +216,20 @@ async def dispatch_approval_request_cards(
     # story #3044(2026-08-25) — 카드가 실제로 간 recipients와 정확히 같은 대상에게
     # conversation.gate_created(순수 SSE, 새 챗버블 없음)도 심는다 — 결재함 목록이
     # "새 게이트가 생겼다"를 아예 못 듣던 갭(notify_gate_created_to_recipients 문서 참고).
+    # after_commit 훅으로 자체 예약하므로(caller 협조 불요) 반환값을 스레딩할 필요가 없다.
     # best-effort — 실패해도 카드 배달(위 루프, 이미 끝남)은 막지 않는다.
     try:
-        return await notify_gate_created_to_recipients(
+        await notify_gate_created_to_recipients(
             db, org_id=org_id, project_id=project_id, gate_id=gate_id, recipient_ids=recipients,
         )
     except Exception:  # noqa: BLE001
         logger.warning(
             "gate_created 목록 실시간 반영 배선 실패 %s=%s", work_item_type, work_item_id, exc_info=True,
         )
-        return []
+
+
+_GATE_CREATED_PENDING_KEY = "s3044_pending_gate_created_pushes"
+_GATE_CREATED_HOOKED_KEY = "s3044_gate_created_hook_installed"
 
 
 async def notify_gate_created_to_recipients(
@@ -233,7 +239,7 @@ async def notify_gate_created_to_recipients(
     project_id: uuid.UUID,
     gate_id: uuid.UUID,
     recipient_ids: list[uuid.UUID],
-) -> list[tuple[str, dict]]:
+) -> None:
     """story #3044(PO 실사고 표본②, 2026-08-25 그라운딩) — 결재함(approvals-queue.tsx)이
     마운트 1회만 fetch하고 이후는 conversation.gate_resolved/gate_delegated 2종 SSE로만
     갱신되는 구조라 — 둘 다 **기존 항목의 상태 변화**만 다뤄, "새 게이트가 생겼다"를 알리는
@@ -246,12 +252,28 @@ async def notify_gate_created_to_recipients(
     approval_request_cards의 `recipients` 산출과 동일 소스 — designated_approver_id가
     있으면 그 1인, 없으면 approver_ids 전원, 카드가 실제로 간 대상과 정확히 일치).
 
+    ⚠️PO 정면 돌파 지시(2026-08-25, "우회/스킵 금지") — 이전 판은 caller가 반환값을 받아
+    caller 자신의 commit 직후 push하는 계약이었다(notify_gate_card_recipients_resolved와
+    동형). 그런데 dispatch_approval_request_cards의 실 호출부 4곳 중 gates.py(decision
+    request)·gate_service.py(delegation) 2곳만 안전한 commit 지점을 쉽게 찾을 수 있었고,
+    merge_verdict_gate.py(evaluate_merge_gate — 원 표본 2a14c177이 정확히 이 경로)·doc.py는
+    호출 지점 이후에도 같은 트랜잭션에서 더 쓰기가 이어져(evaluate_merge_gate는 이 함수
+    호출 뒤에도 gate.requires_human/decision_basis 등을 계속 쓰고 자기 자신은 commit을
+    한 번도 안 한다 — 커밋은 8개나 되는 자기 호출부 각각이 각자 시점에 한다) 안전한 commit
+    지점을 이 함수 안에서 특정할 수 없었다. **caller마다 반환값을 스레딩하는 대신**,
+    event_seq.py의 _schedule_wake_after_commit(story #2381, 이미 검증된 동일 클래스
+    문제의 기존 해법)과 완전히 동형으로 SQLAlchemy `after_commit` 세션 이벤트에 push를
+    예약한다 — 이 세션이 **실제로 commit에 성공한 후에만**(rollback 시엔 안 불림) 자동
+    발화되므로, 몇 개의 호출부가 있든·그 호출부가 어디서 commit하든 이 함수 자신은 몰라도
+    된다(caller 협조 불요 — 새 호출부가 미래에 생겨도 이 함수를 거치기만 하면 구조적으로
+    커버된다, "우회 없이" 8개 caller 전부를 실제로 돌파).
+
     ⚠️id 공간 매핑 경계(페드루 PO 요청, 2026-08-25) — `Event.recipient_id`는 `team_members.id`
     FK(NOT NULL)다. `team_members`는 0088에서 프로젝션 **뷰**로 태어났다는 게 기존 주석의
     설명이지만, 이 그라운딩 도중 실 PG로 재확認하니(psql 메타명령으로 스키마 직접 조회)
-    **오늘은 자체 PK+FK를
-    가진 진짜 base table**이다(그 사이 어느 마이그레이션이 뷰→테이블로 전환 — 옛 주석들이
-    스테일해진 것 자체가 부수 발견, 이 스토리 스코프 밖이라 정정만 하고 남김).
+    **오늘은 자체 PK+FK를 가진 진짜 base table**이다(그 사이 어느 마이그레이션이 뷰→테이블로
+    전환 — 옛 주석들이 스테일해진 것 자체가 부수 발견, 이 스토리 스코프 밖이라 정정만 하고
+    남김·별도 스토리 등재).
 
     핵심은 여전히 유효 — `org_members`(role 권위 축, `get_project_role`의 "org owner/admin
     floor"가 사는 곳)와 `team_members`(메시징 신원 축, 이 테이블에 명시 행이 있어야만 존재)
@@ -262,7 +284,7 @@ async def notify_gate_created_to_recipients(
     사전에 걸러 스킵한다(로그만, 예외 전파 안 함) — dispatch_approval_request_cards의 챗
     카드 배달(다른 신원 경로, Conversation 참가자 자격)은 이 필터와 무관하게 그대로 간다."""
     if not recipient_ids:
-        return []
+        return
 
     from app.models.team import TeamMember
     from app.services.member_resolver import lookup_members_by_ids
@@ -277,7 +299,7 @@ async def notify_gate_created_to_recipients(
             gate_id, project_id, skipped,
         )
     if not valid_ids:
-        return []
+        return
 
     members = await lookup_members_by_ids(valid_ids, db)
 
@@ -297,14 +319,45 @@ async def notify_gate_created_to_recipients(
         events.append(event)
 
     await db.flush()
-    pushes: list[tuple[str, dict]] = []
     for event in events:
-        pushes.append((
-            str(event.recipient_id),
+        _schedule_gate_created_push_after_commit(
+            db, str(event.recipient_id),
             {"event_id": str(event.id), "event_type": "conversation.gate_created", **payload_base,
              "recipient_id": str(event.recipient_id)},
-        ))
-    return pushes
+        )
+
+
+def _schedule_gate_created_push_after_commit(db: AsyncSession, pid_str: str, payload: dict) -> None:
+    """event_seq.py의 _schedule_wake_after_commit과 완전히 동형(주석도 그쪽이 정본 — 여기선
+    요지만) — commit 성공 後에만(rollback 시 미발화) _push_to_agent가 정확히 한 번 불리도록
+    세션에 예약. MVCC 가시성 레이스 방지(commit 前 push하면 recipient가 GET해도 아직 안 보임)."""
+    sync_session = db.sync_session
+    if not isinstance(sync_session, Session):
+        logger.debug("gate_created push scheduling skipped — sync_session is not a real Session (test double?)")
+        return
+    pending: list[tuple[str, dict]] = sync_session.info.setdefault(_GATE_CREATED_PENDING_KEY, [])
+    pending.append((pid_str, payload))
+    if not sync_session.info.get(_GATE_CREATED_HOOKED_KEY):
+        sync_session.info[_GATE_CREATED_HOOKED_KEY] = True
+        sa_event.listen(sync_session, "after_commit", _fire_pending_gate_created_pushes)
+        sa_event.listen(sync_session, "after_rollback", _clear_pending_gate_created_pushes_on_rollback)
+
+
+def _fire_pending_gate_created_pushes(sync_session: Session) -> None:
+    pending = sync_session.info.pop(_GATE_CREATED_PENDING_KEY, None) or []
+    if not pending:
+        return
+    from app.routers.events import _push_to_agent
+
+    for pid_str, payload in pending:
+        try:
+            _push_to_agent(pid_str, payload)
+        except Exception:  # noqa: BLE001
+            logger.warning("post-commit gate_created push failed recipient=%s", pid_str, exc_info=True)
+
+
+def _clear_pending_gate_created_pushes_on_rollback(sync_session: Session) -> None:
+    sync_session.info.pop(_GATE_CREATED_PENDING_KEY, None)
 
 
 async def dispatch_approval_result_reply(

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -1425,20 +1425,17 @@ async def dispatch_gate_delegation(
 
     try:
         from app.services.approval_delivery import dispatch_approval_request_cards
-        _new_card_pushes = await dispatch_approval_request_cards(
+        # story #3044 — 새 지정자의 결재함 목록도 새로고침 없이 이 게이트를 즉시 봐야 한다.
+        # dispatch_approval_request_cards가 내부에서 notify_gate_created_to_recipients를
+        # 부르고, 그 함수가 after_commit 훅으로 push를 자체 예약한다(approval_delivery.py
+        # 문서 참고) — 이 함수 자신은 커밋 타이밍을 몰라도 된다. 아래 gate_delegated의
+        # 기존 commit(이 함수의 원래 유일한 커밋)에서 같이 발화된다(별도 커밋 불요).
+        await dispatch_approval_request_cards(
             session, org_id=gate.org_id, work_item_type=gate.work_item_type, work_item_id=gate.work_item_id,
             project_id=project_id, title=title, gate_id=gate.id,
             requester_id=requester_id, approver_ids=[new_approver_id],
             designated_approver_id=new_approver_id,
         )
-        # story #3044 — 새 지정자의 결재함 목록도 새로고침 없이 이 게이트를 즉시 봐야 한다
-        # (notify_gate_created_to_recipients, dispatch_approval_request_cards 내부에서 이미
-        # 계산·반환). 아래 gate_delegated 커밋과 같은 자리에서 함께 push(별도 커밋 불요 —
-        # 이 함수는 이미 caller가 gate.designated_approver_id 갱신을 먼저 commit했다는 전제).
-        await session.commit()
-        for _pid_str, _payload in _new_card_pushes:
-            from app.routers.events import _push_to_agent
-            _push_to_agent(_pid_str, _payload)
     except Exception:  # noqa: BLE001 — best-effort, 신규 카드 배달 실패가 위임 자체를 막지 않음.
         logger.warning("gate delegate 신규 카드 배달 실패 gate=%s new_approver=%s", gate.id, new_approver_id, exc_info=True)
 

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -1425,12 +1425,20 @@ async def dispatch_gate_delegation(
 
     try:
         from app.services.approval_delivery import dispatch_approval_request_cards
-        await dispatch_approval_request_cards(
+        _new_card_pushes = await dispatch_approval_request_cards(
             session, org_id=gate.org_id, work_item_type=gate.work_item_type, work_item_id=gate.work_item_id,
             project_id=project_id, title=title, gate_id=gate.id,
             requester_id=requester_id, approver_ids=[new_approver_id],
             designated_approver_id=new_approver_id,
         )
+        # story #3044 — 새 지정자의 결재함 목록도 새로고침 없이 이 게이트를 즉시 봐야 한다
+        # (notify_gate_created_to_recipients, dispatch_approval_request_cards 내부에서 이미
+        # 계산·반환). 아래 gate_delegated 커밋과 같은 자리에서 함께 push(별도 커밋 불요 —
+        # 이 함수는 이미 caller가 gate.designated_approver_id 갱신을 먼저 commit했다는 전제).
+        await session.commit()
+        for _pid_str, _payload in _new_card_pushes:
+            from app.routers.events import _push_to_agent
+            _push_to_agent(_pid_str, _payload)
     except Exception:  # noqa: BLE001 — best-effort, 신규 카드 배달 실패가 위임 자체를 막지 않음.
         logger.warning("gate delegate 신규 카드 배달 실패 gate=%s new_approver=%s", gate.id, new_approver_id, exc_info=True)
 

--- a/backend/tests/test_3044_gate_created_sse_realdb.py
+++ b/backend/tests/test_3044_gate_created_sse_realdb.py
@@ -1,0 +1,164 @@
+"""story #3044(PO 실사고 표본②, 2026-08-25 그라운딩+PO 실험 검증) — 결재함(approvals-queue.tsx)이
+마운트 1회만 fetch하고 이후는 conversation.gate_resolved/gate_delegated 2종 SSE로만 갱신되는
+구조라 "새 게이트가 생겼다"를 알리는 신호 자체가 없었다. notify_gate_created_to_recipients
+(approval_delivery.py)가 그 3번째 신호를 신설한다 — 이 테스트는 그 신호가 실제로 Event 테이블에
+심기는지(라이브 push의 durable backstop)와, id 공간 매핑 경계(team_members는 project_access
+명시 grant가 있는 members 행만 — org_members 권위와 독립된 별개 id 공간)를 실 PG로 고정한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org3044", slug=f"org3044-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_rostered_member(session, *, org_id, project_id):
+    """team_members는 (0088 project-view 시절과 달리) 오늘은 실 base table이다(psql \\d 실측 —
+    이 그라운딩 도중 발견: id PK+FK 실물, view 아님) — story #2604 _seed_human과 동형으로
+    직접 INSERT한다. Event.recipient_id FK를 통과하는 유일한 형태."""
+    from app.models.team import TeamMember
+
+    member = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="human",
+        name="Rostered", is_active=True,
+    )
+    session.add(member)
+    await session.commit()
+    return member.id
+
+
+async def _seed_org_admin_no_roster(session, *, org_id):
+    """story #3044 실사고 재현 — org owner/admin이지만 이 프로젝트엔 members/project_access
+    행이 없다(PO 실 계정 2fd14616과 동형 조건). OrgMember.id는 uuid4 자체 발급이라 members.id
+    와 무관한 별개 id 공간 — team_members 뷰엔 존재하지 않는다."""
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"admin-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await session.commit()
+    admin_id = uuid.uuid4()
+    session.add(OrgMember(id=admin_id, org_id=org_id, user_id=user_id, role="admin"))
+    await session.commit()
+    return admin_id
+
+
+async def test_notify_gate_created_inserts_event_for_rostered_recipient():
+    from app.services.approval_delivery import notify_gate_created_to_recipients
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            member_id = await _seed_rostered_member(s, org_id=org_id, project_id=project_id)
+            gate_id = uuid.uuid4()
+
+            pushes = await notify_gate_created_to_recipients(
+                s, org_id=org_id, project_id=project_id, gate_id=gate_id, recipient_ids=[member_id],
+            )
+            await s.commit()
+
+            assert len(pushes) == 1
+            pid_str, payload = pushes[0]
+            assert pid_str == str(member_id)
+            assert payload["event_type"] == "conversation.gate_created"
+            assert payload["gate_id"] == str(gate_id)
+
+            from app.models.event import Event
+            from sqlalchemy import select
+            rows = (await s.execute(
+                select(Event).where(Event.source_entity_id == gate_id, Event.event_type == "conversation.gate_created")
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].recipient_id == member_id
+    finally:
+        await engine.dispose()
+
+
+async def test_notify_gate_created_skips_org_admin_without_project_roster():
+    """id 공간 매핑 경계(페드루 PO 요청) — org_members 권위(role floor)와 team_members
+    메시징 신원(project_access 명시 grant)은 독립된 별개 공간. 이 recipient는 실제로 게이트를
+    승인할 자격이 있어도(rule B org floor) Event FK를 만족 못 해 — 크래시 대신 조용히 스킵
+    되고(로그만), 다른 정상 recipient는 영향받지 않는다(부분 실패 격리)."""
+    from app.services.approval_delivery import notify_gate_created_to_recipients
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            rostered_id = await _seed_rostered_member(s, org_id=org_id, project_id=project_id)
+            admin_no_roster_id = await _seed_org_admin_no_roster(s, org_id=org_id)
+            gate_id = uuid.uuid4()
+
+            pushes = await notify_gate_created_to_recipients(
+                s, org_id=org_id, project_id=project_id, gate_id=gate_id,
+                recipient_ids=[rostered_id, admin_no_roster_id],
+            )
+            await s.commit()
+
+            pushed_ids = {p[0] for p in pushes}
+            assert pushed_ids == {str(rostered_id)}, "roster 없는 org admin은 스킵되고 rostered 대상만 push"
+    finally:
+        await engine.dispose()
+
+
+async def test_notify_gate_created_empty_recipients_returns_empty_no_crash():
+    from app.services.approval_delivery import notify_gate_created_to_recipients
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            pushes = await notify_gate_created_to_recipients(
+                s, org_id=org_id, project_id=project_id, gate_id=uuid.uuid4(), recipient_ids=[],
+            )
+            assert pushes == []
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3044_gate_created_sse_realdb.py
+++ b/backend/tests/test_3044_gate_created_sse_realdb.py
@@ -66,18 +66,41 @@ async def _seed_org_project(session):
 
 
 async def _seed_rostered_member(session, *, org_id, project_id):
-    """team_members는 (0088 project-view 시절과 달리) 오늘은 실 base table이다(psql \\d 실측 —
-    이 그라운딩 도중 발견: id PK+FK 실물, view 아님) — story #2604 _seed_human과 동형으로
-    직접 INSERT한다. Event.recipient_id FK를 통과하는 유일한 형태."""
-    from app.models.team import TeamMember
+    """⚠️team_members 그라운딩 정정(카디르 QA #3467 REQUEST_CHANGES①, 2026-08-25) — 이전 판
+    (커밋 e3bdb5e33)은 이 자리에서 "오늘은 실 base table"이라 적었으나 **오判이었다**. schema.sql
+    (backend/alembic/baseline/schema.sql:2036)이 명시하는 정본은 `CREATE VIEW public.team_members
+    AS ... FROM members m JOIN project_access pa ON pa.member_id = m.id ...` — UNION ALL을 포함한
+    비-자동-갱신 뷰(INSTEAD OF 트리거 없음)라 직접 INSERT가 실패한다("cannot insert into view",
+    카디르 CI 재현·본 세션에서 완전히 새로 만든 스크래치 DB로도 재확認). 이전 psql 확認은 이
+    뷰 도입(migration 0088, 훨씬 오래된 변경) 이전 상태의 스테일한 로컬 DB를 겨눴던 오류로
+    정정한다. 뷰의 SELECT 소스인 members+project_access에 직접 seed한다(story #2604의
+    _seed_human이 취했던 TeamMember() 직접 insert 경로도 동일하게 무효 — 이 스토리 스코프
+    밖이라 그쪽은 별도로 남긴다)."""
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
 
-    member = TeamMember(
-        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="human",
-        name="Rostered", is_active=True,
-    )
-    session.add(member)
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"rostered-{user_id.hex[:8]}@test.com", hashed_password="x"))
     await session.commit()
-    return member.id
+    member_id = uuid.uuid4()
+    session.add(Member(id=member_id, org_id=org_id, type="human", user_id=user_id, name="Rostered"))
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project_id, member_id=member_id, role="member"))
+    await session.commit()
+    return member_id
+
+
+async def _seed_rostered_agent(session, *, org_id, project_id, name):
+    """에이전트판 — team_members 뷰의 두 번째 UNION ALL 분기(members ⋈ agent_project_profiles)."""
+    from app.models.member import AgentProjectProfile, Member
+
+    member_id = uuid.uuid4()
+    session.add(Member(id=member_id, org_id=org_id, type="agent", name=name))
+    await session.commit()
+    session.add(AgentProjectProfile(id=uuid.uuid4(), member_id=member_id, project_id=project_id))
+    await session.commit()
+    return member_id
 
 
 async def _seed_org_admin_no_roster(session, *, org_id):
@@ -112,8 +135,9 @@ async def test_notify_gate_created_inserts_durable_event_for_rostered_recipient(
             await s.commit()
             assert result is None, "caller 반환값 스레딩 없음(after_commit 훅으로 자체 예약)"
 
-            from app.models.event import Event
             from sqlalchemy import select
+
+            from app.models.event import Event
             rows = (await s.execute(
                 select(Event).where(Event.source_entity_id == gate_id, Event.event_type == "conversation.gate_created")
             )).scalars().all()
@@ -145,8 +169,9 @@ async def test_notify_gate_created_skips_org_admin_without_project_roster():
             )
             await s.commit()
 
-            from app.models.event import Event
             from sqlalchemy import select
+
+            from app.models.event import Event
             rows = (await s.execute(
                 select(Event.recipient_id).where(Event.source_entity_id == gate_id, Event.event_type == "conversation.gate_created")
             )).scalars().all()
@@ -174,8 +199,8 @@ async def test_push_fires_only_after_commit_not_before(monkeypatch):
     """event_seq.py의 test_2381 검증 패턴과 동형 — commit 前엔 push가 절대 안 나가고(다른
     커넥션에서 아직 안 보이는 row를 GET하러 보내는 레이스 방지), commit 성공 直後에 정확히
     한 번 나간다."""
-    from app.services.approval_delivery import notify_gate_created_to_recipients
     import app.routers.events as events_mod
+    from app.services.approval_delivery import notify_gate_created_to_recipients
 
     engine, Session = await _session_factory()
     try:
@@ -212,11 +237,13 @@ async def test_evaluate_merge_gate_creates_gate_created_event_too():
     대신 실제 진입점을 그대로 태워, after_commit 훅이 merge_verdict_gate.py를 단 1줄도 안
     건드리고도 실제로 커버함을 증명한다(caller 협조 불요 설계의 핵심 주장)."""
     from sqlalchemy import select
+
     from app.models.event import Event
     from app.models.hitl_config import OrgGatePolicy
+    from app.models.member import AgentProjectProfile, Member
     from app.models.participation import Participation, ParticipationRole
     from app.models.pm import Story
-    from app.models.team import TeamMember
+    from app.models.project_access import ProjectAccess
     from app.services.merge_verdict_gate import evaluate_merge_gate
 
     engine, Session = await _session_factory()
@@ -225,23 +252,29 @@ async def test_evaluate_merge_gate_creates_gate_created_event_too():
         async with Session() as s:
             org_id, project_id = await _seed_org_project(s)
 
-            # 구현자(agent) — 상신자.
+            # 구현자(agent) — 상신자. team_members 뷰 UNION ALL의 agent 분기(members ⋈
+            # agent_project_profiles) — 직접 TeamMember() insert는 뷰라 실패한다(카디르 QA①).
             implementer_id = uuid.uuid4()
-            s.add(TeamMember(
-                id=implementer_id, org_id=org_id, project_id=project_id, type="agent",
-                name="디디", is_active=True,
-            ))
+            s.add(Member(id=implementer_id, org_id=org_id, type="agent", name="디디"))
+            await s.commit()
+            s.add(AgentProjectProfile(id=uuid.uuid4(), member_id=implementer_id, project_id=project_id))
             await s.commit()
 
-            # 승인자 — OrgMember(role 판정용)+같은 id의 TeamMember(메시징 신원용), test_2118의
-            # _seed_org_member와 동형(둘 다 필요한 이유는 이 파일 상단 id 공간 경계 설명 참고).
+            # 승인자 — OrgMember(role 판정용)+같은 id의 members/project_access 행(메시징 신원용),
+            # test_2118의 _seed_org_member와 동형(둘 다 필요한 이유는 이 파일 상단 id 공간 경계
+            # 설명 참고). 실무에선 org_members.id≠members.id(독립 uuid4)이지만, 이 테스트는
+            # evaluate_merge_gate가 실제로 무슨 id를 recipient로 넘기는지만 실증하면 되므로 두
+            # 공간이 같은 값으로 겹치는 케이스(현재 dev 실물 데이터의 흔한 형태)를 그대로 쓴다.
             from app.models.project import OrgMember
+            from app.models.user import User
+            approver_user_id = uuid.uuid4()
+            s.add(User(id=approver_user_id, email=f"approver-{approver_user_id.hex[:8]}@test.com", hashed_password="x"))
+            await s.commit()
             approver_id = uuid.uuid4()
-            s.add(OrgMember(id=approver_id, org_id=org_id, user_id=uuid.uuid4(), role="owner"))
-            s.add(TeamMember(
-                id=approver_id, org_id=org_id, project_id=project_id, type="human",
-                name="approver", is_active=True,
-            ))
+            s.add(OrgMember(id=approver_id, org_id=org_id, user_id=approver_user_id, role="owner"))
+            s.add(Member(id=approver_id, org_id=org_id, type="human", user_id=approver_user_id, name="approver"))
+            await s.commit()
+            s.add(ProjectAccess(id=uuid.uuid4(), project_id=project_id, member_id=approver_id, role="owner"))
             s.add_all([
                 ParticipationRole(id=role_id, org_id=org_id, key="implementation", label="구현", is_default=True),
                 Story(id=story_id, org_id=org_id, project_id=project_id, title="#3044 검증", status="in-review", story_points=3),
@@ -270,8 +303,8 @@ async def test_evaluate_merge_gate_creates_gate_created_event_too():
 
 
 async def test_push_never_fires_on_rollback(monkeypatch):
-    from app.services.approval_delivery import notify_gate_created_to_recipients
     import app.routers.events as events_mod
+    from app.services.approval_delivery import notify_gate_created_to_recipients
 
     engine, Session = await _session_factory()
     try:
@@ -289,5 +322,43 @@ async def test_push_never_fires_on_rollback(monkeypatch):
             await s.rollback()
 
         assert pushed == [], "rollback된 트랜잭션에서 push가 발화되면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+async def test_savepoint_release_does_not_fire_push_but_outer_commit_does(monkeypatch):
+    """카디르 QA #3467 REQUEST_CHANGES② 최소재현 그대로 고정(2026-08-25) — SQLAlchemy
+    `after_commit`은 outer 최종 commit뿐 아니라 `begin_nested()` SAVEPOINT release(`nested
+    .commit()`)에도 발화한다(본 세션 repro로 실측: 콜백 안에서 `in_nested_transaction()`이
+    그 순간 True). outer가 그 뒤 rollback돼도 이미 push가 나가버리는 게 결함 — 이 테스트는
+    ①SAVEPOINT release=0회 ②outer commit=1회 ③outer rollback=0회를 정확히 고정한다."""
+    import app.routers.events as events_mod
+    from app.services.approval_delivery import _schedule_gate_created_push_after_commit
+
+    engine, Session = await _session_factory()
+    try:
+        pushed: list[tuple[str, dict]] = []
+        monkeypatch.setattr(events_mod, "_push_to_agent", lambda pid, payload: pushed.append((pid, payload)))
+
+        # ① SAVEPOINT release — push가 아직 나가면 안 된다(outer가 살아있다).
+        async with Session() as s:
+            nested = await s.begin_nested()
+            _schedule_gate_created_push_after_commit(s, "recipient-1", {"k": "v"})
+            await nested.commit()
+            assert pushed == [], "SAVEPOINT release에서 push가 나가면 안 된다(outer 미확定)"
+
+            # ② outer 진짜 commit — 이제서야 나간다.
+            await s.commit()
+            assert pushed == [("recipient-1", {"k": "v"})], "outer commit 直後 정확히 1회 발화해야 한다"
+
+        # ③ outer rollback 케이스 — 별도 세션으로 독립 재현.
+        pushed.clear()
+        async with Session() as s:
+            nested = await s.begin_nested()
+            _schedule_gate_created_push_after_commit(s, "recipient-2", {"k": "v2"})
+            await nested.commit()
+            assert pushed == [], "SAVEPOINT release에서 push가 나가면 안 된다"
+            await s.rollback()
+        assert pushed == [], "outer rollback 후에도 SAVEPOINT release 시점 push가 새면 안 된다"
     finally:
         await engine.dispose()

--- a/backend/tests/test_3044_gate_created_sse_realdb.py
+++ b/backend/tests/test_3044_gate_created_sse_realdb.py
@@ -1,10 +1,16 @@
 """story #3044(PO 실사고 표본②, 2026-08-25 그라운딩+PO 실험 검증) — 결재함(approvals-queue.tsx)이
 마운트 1회만 fetch하고 이후는 conversation.gate_resolved/gate_delegated 2종 SSE로만 갱신되는
 구조라 "새 게이트가 생겼다"를 알리는 신호 자체가 없었다. notify_gate_created_to_recipients
-(approval_delivery.py)가 그 3번째 신호를 신설한다 — 이 테스트는 그 신호가 실제로 Event 테이블에
-심기는지(라이브 push의 durable backstop)와, id 공간 매핑 경계(team_members는 project_access
-명시 grant가 있는 members 행만 — org_members 권위와 독립된 별개 id 공간)를 실 PG로 고정한다.
-"""
+(approval_delivery.py)가 그 3번째 신호를 신설한다 — 이 테스트는 그 신호가 실제로 Event
+테이블에 심기는지(durable)·commit 성공 後에만 정확히 발화되는지(after_commit 훅, event_seq.py
+의 _schedule_wake_after_commit과 동형 — test_2381_wake_after_commit_race_realdb.py의 검증
+패턴 재사용)·id 공간 매핑 경계(team_members는 project_access 명시 grant가 있는 members 행만
+— org_members 권위와 독립된 별개 id 공간)를 실 PG로 고정한다.
+
+⚠️PO 정면 돌파 지시(2026-08-25) — notify_gate_created_to_recipients는 caller에게 반환값을
+스레딩하지 않는다(-> None). 대신 event_seq.py와 동형으로 세션 자신의 after_commit 이벤트에
+push를 예약한다 — dispatch_approval_request_cards의 8개 호출부(merge_verdict_gate.py·doc.py
+포함) 전부가 caller 협조 없이 구조적으로 커버된다."""
 from __future__ import annotations
 
 import os
@@ -90,7 +96,7 @@ async def _seed_org_admin_no_roster(session, *, org_id):
     return admin_id
 
 
-async def test_notify_gate_created_inserts_event_for_rostered_recipient():
+async def test_notify_gate_created_inserts_durable_event_for_rostered_recipient():
     from app.services.approval_delivery import notify_gate_created_to_recipients
 
     engine, Session = await _session_factory()
@@ -100,16 +106,11 @@ async def test_notify_gate_created_inserts_event_for_rostered_recipient():
             member_id = await _seed_rostered_member(s, org_id=org_id, project_id=project_id)
             gate_id = uuid.uuid4()
 
-            pushes = await notify_gate_created_to_recipients(
+            result = await notify_gate_created_to_recipients(
                 s, org_id=org_id, project_id=project_id, gate_id=gate_id, recipient_ids=[member_id],
             )
             await s.commit()
-
-            assert len(pushes) == 1
-            pid_str, payload = pushes[0]
-            assert pid_str == str(member_id)
-            assert payload["event_type"] == "conversation.gate_created"
-            assert payload["gate_id"] == str(gate_id)
+            assert result is None, "caller 반환값 스레딩 없음(after_commit 훅으로 자체 예약)"
 
             from app.models.event import Event
             from sqlalchemy import select
@@ -118,6 +119,7 @@ async def test_notify_gate_created_inserts_event_for_rostered_recipient():
             )).scalars().all()
             assert len(rows) == 1
             assert rows[0].recipient_id == member_id
+            assert rows[0].payload["gate_id"] == str(gate_id)
     finally:
         await engine.dispose()
 
@@ -137,28 +139,155 @@ async def test_notify_gate_created_skips_org_admin_without_project_roster():
             admin_no_roster_id = await _seed_org_admin_no_roster(s, org_id=org_id)
             gate_id = uuid.uuid4()
 
-            pushes = await notify_gate_created_to_recipients(
+            await notify_gate_created_to_recipients(
                 s, org_id=org_id, project_id=project_id, gate_id=gate_id,
                 recipient_ids=[rostered_id, admin_no_roster_id],
             )
             await s.commit()
 
-            pushed_ids = {p[0] for p in pushes}
-            assert pushed_ids == {str(rostered_id)}, "roster 없는 org admin은 스킵되고 rostered 대상만 push"
+            from app.models.event import Event
+            from sqlalchemy import select
+            rows = (await s.execute(
+                select(Event.recipient_id).where(Event.source_entity_id == gate_id, Event.event_type == "conversation.gate_created")
+            )).scalars().all()
+            assert set(rows) == {rostered_id}, "roster 없는 org admin은 스킵되고 rostered 대상만 Event가 남는다"
     finally:
         await engine.dispose()
 
 
-async def test_notify_gate_created_empty_recipients_returns_empty_no_crash():
+async def test_notify_gate_created_empty_recipients_no_crash():
     from app.services.approval_delivery import notify_gate_created_to_recipients
 
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org_project(s)
-            pushes = await notify_gate_created_to_recipients(
+            result = await notify_gate_created_to_recipients(
                 s, org_id=org_id, project_id=project_id, gate_id=uuid.uuid4(), recipient_ids=[],
             )
-            assert pushes == []
+            assert result is None
+    finally:
+        await engine.dispose()
+
+
+async def test_push_fires_only_after_commit_not_before(monkeypatch):
+    """event_seq.py의 test_2381 검증 패턴과 동형 — commit 前엔 push가 절대 안 나가고(다른
+    커넥션에서 아직 안 보이는 row를 GET하러 보내는 레이스 방지), commit 성공 直後에 정확히
+    한 번 나간다."""
+    from app.services.approval_delivery import notify_gate_created_to_recipients
+    import app.routers.events as events_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as seed_s:
+            org_id, project_id = await _seed_org_project(seed_s)
+            member_id = await _seed_rostered_member(seed_s, org_id=org_id, project_id=project_id)
+
+        pushed: list[tuple[str, dict]] = []
+        monkeypatch.setattr(events_mod, "_push_to_agent", lambda pid, payload: pushed.append((pid, payload)))
+        # approval_delivery._fire_pending_gate_created_pushes는 `from app.routers.events import
+        # _push_to_agent`를 발화 시점마다 late-import하므로, events_mod 속성을 바꾸는 것만으로
+        # monkeypatch가 반영된다(test_2381의 gw_mod.wake_agent와 동일 원리).
+
+        gate_id = uuid.uuid4()
+        async with Session() as s:
+            await notify_gate_created_to_recipients(
+                s, org_id=org_id, project_id=project_id, gate_id=gate_id, recipient_ids=[member_id],
+            )
+            assert pushed == [], "commit 前인데 이미 push가 나갔다 — 레이스 재발"
+            await s.commit()
+
+        assert len(pushed) == 1
+        pid_str, payload = pushed[0]
+        assert pid_str == str(member_id)
+        assert payload["event_type"] == "conversation.gate_created"
+        assert payload["gate_id"] == str(gate_id)
+    finally:
+        await engine.dispose()
+
+
+async def test_evaluate_merge_gate_creates_gate_created_event_too():
+    """PO 정면 돌파 검증(2026-08-25) — 원 표본(gate 2a14c177)이 정확히 이 경로(merge 게이트
+    생성, merge_verdict_gate.py evaluate_merge_gate)였다. 이 파일 다른 함수들을 직접 호출하는
+    대신 실제 진입점을 그대로 태워, after_commit 훅이 merge_verdict_gate.py를 단 1줄도 안
+    건드리고도 실제로 커버함을 증명한다(caller 협조 불요 설계의 핵심 주장)."""
+    from sqlalchemy import select
+    from app.models.event import Event
+    from app.models.hitl_config import OrgGatePolicy
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.team import TeamMember
+    from app.services.merge_verdict_gate import evaluate_merge_gate
+
+    engine, Session = await _session_factory()
+    story_id, role_id = uuid.uuid4(), uuid.uuid4()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+
+            # 구현자(agent) — 상신자.
+            implementer_id = uuid.uuid4()
+            s.add(TeamMember(
+                id=implementer_id, org_id=org_id, project_id=project_id, type="agent",
+                name="디디", is_active=True,
+            ))
+            await s.commit()
+
+            # 승인자 — OrgMember(role 판정용)+같은 id의 TeamMember(메시징 신원용), test_2118의
+            # _seed_org_member와 동형(둘 다 필요한 이유는 이 파일 상단 id 공간 경계 설명 참고).
+            from app.models.project import OrgMember
+            approver_id = uuid.uuid4()
+            s.add(OrgMember(id=approver_id, org_id=org_id, user_id=uuid.uuid4(), role="owner"))
+            s.add(TeamMember(
+                id=approver_id, org_id=org_id, project_id=project_id, type="human",
+                name="approver", is_active=True,
+            ))
+            s.add_all([
+                ParticipationRole(id=role_id, org_id=org_id, key="implementation", label="구현", is_default=True),
+                Story(id=story_id, org_id=org_id, project_id=project_id, title="#3044 검증", status="in-review", story_points=3),
+            ])
+            s.add(OrgGatePolicy(org_id=org_id, posture="conservative"))
+            await s.commit()
+            s.add(Participation(id=uuid.uuid4(), org_id=org_id, story_id=story_id, member_id=implementer_id, role_id=role_id))
+            await s.commit()
+
+        async with Session() as s:
+            decision = await evaluate_merge_gate(
+                s, org_id, story_id, pr_number=0, repo="", ci_result=None, pr_result=None,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(
+                    Event.source_entity_id == decision.gate_id, Event.event_type == "conversation.gate_created",
+                )
+            )).scalars().all()
+            assert len(rows) == 1, "merge_verdict_gate.py 경로도 conversation.gate_created가 심겨야 한다(정면 돌파)"
+            assert rows[0].recipient_id == approver_id
+    finally:
+        await engine.dispose()
+
+
+async def test_push_never_fires_on_rollback(monkeypatch):
+    from app.services.approval_delivery import notify_gate_created_to_recipients
+    import app.routers.events as events_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as seed_s:
+            org_id, project_id = await _seed_org_project(seed_s)
+            member_id = await _seed_rostered_member(seed_s, org_id=org_id, project_id=project_id)
+
+        pushed: list[tuple[str, dict]] = []
+        monkeypatch.setattr(events_mod, "_push_to_agent", lambda pid, payload: pushed.append((pid, payload)))
+
+        async with Session() as s:
+            await notify_gate_created_to_recipients(
+                s, org_id=org_id, project_id=project_id, gate_id=uuid.uuid4(), recipient_ids=[member_id],
+            )
+            await s.rollback()
+
+        assert pushed == [], "rollback된 트랜잭션에서 push가 발화되면 안 된다"
     finally:
         await engine.dispose()


### PR DESCRIPTION
## 요약
PO 실사고 표본②(gate 2a14c177, 2026-08-25): pending 게이트가 `assigned_to_me=true` 목록에서 실종·gate 상세 직행으로만 서명 가능했음. 그라운딩+PO 라이브 실험 검증(2fd14616 fresh 로드=59건 전수 정상 반환, rule B 탈락 0) — **fresh 경로는 온전, 열려있던 탭만 stale**이었음이 확定.

## ✅정면 돌파 완료(2026-08-25 v2) — merge/doc 경로 포함 8개 호출부 전부 커버
1차 PO PASS는 "gates.py·gate_service.py 2곳만 라이브, merge_verdict_gate.py·doc.py는 후속"이라는 조건부였음(원 표본이 정확히 merge 경로라 재발 우려). **PO 지시("우회/스킵 금지, after_commit 훅 등으로 정면 돌파")에 따라 재설계** — `notify_gate_created_to_recipients()`가 caller에게 반환값을 스레딩하는 대신, `event_seq.py`의 `_schedule_wake_after_commit`(story #2381, 이미 검증된 동일 클래스 문제의 기존 해법)과 완전히 동형으로 SQLAlchemy `after_commit` 세션 이벤트에 push를 예약한다. 이 세션이 실제로 commit에 성공한 후에만(rollback 시엔 안 불림) 자동 발화되므로, **`merge_verdict_gate.py`·`doc.py`는 1줄도 안 건드리고도** 그 호출부들의 기존 commit에 자동으로 올라탄다 — caller 협조 불요, 8개 호출부 전부(현재도 미래도) 구조적으로 커버.

신규 테스트 `test_evaluate_merge_gate_creates_gate_created_event_too`가 이걸 직접 증명 — `merge_verdict_gate.py`를 1줄도 안 건드리고 `evaluate_merge_gate()`를 실제 진입점 그대로 태워 `conversation.gate_created` Event가 실제로 심기는지 확認(PO 원 표본 2a14c177과 동일 경로).

## 근본원인
`approvals-queue.tsx`의 `fetchGates()`는 `useEffect([])`로 마운트 1회만 호출되고, 이후 갱신은 SSE `conversation.gate_resolved`·`gate_delegated` 2종뿐 — 둘 다 **기존 항목의 상태 변화**만 다룬다. "새 게이트가 생겼다"를 알리는 신호 자체가 BE 어디에도 없었다(전수 grep 확認). 이미 열어둔 탭에 새 게이트가 생기면 하드 리로드 전까진 영원히 안 뜬다.

**표본①**(#3187/#3191 사이클 — 상세=approved인데 목록=pending)은 별개 원인으로 판정, 본 스토리 스코프 아님: PO가 관련 스토리의 merge 게이트 4장을 전수 대조해 확認 — 전부 같은 스토리에 딸린 동명 게이트라 하나를 승인해도 목록엔 다른 pending 게이트가 남아있어 "그 카드가 아직도 있다"로 오인된 착시. #3038(PR#3463, 이미 머지)이 PR#·SHA 판별자로 이미 해소.

## 구현
- `approval_delivery.py`: `notify_gate_created_to_recipients()` — `notify_gate_card_recipients_resolved`(기존, gate_resolved)와 동형(순수 SSE, 새 ConversationMessage 없음), `after_commit` 훅으로 자체 예약(`-> None`, caller 협조 불요).
- `dispatch_approval_request_cards()`가 카드를 실제로 보낸 recipients와 정확히 같은 대상에게 `conversation.gate_created`도 심음(내부에서 위 함수 호출).
- `gates.py`·`gate_service.py` — 1차 판에서 심었던 수동 commit+push 배선을 원복(회귀 0, 원래 `-> None` 계약 그대로 — 이제 훅이 전부 처리).
- `merge_verdict_gate.py`·`doc.py` — **무변경**(훅이 자동 커버).
- `approvals-queue.tsx`: `conversation.gate_created` 구독 신설 — payload(gate_id만)로 단건 GET → items에 prepend. 이미 목록에 있으면(레이스) 중복 추가 안 함.

## id 공간 매핑 경계(페드루 PO 요청 — 어디서 갈렸는지)
`Event.recipient_id`는 `team_members.id` FK(NOT NULL). `team_members`는 0088에서 프로젝션 **뷰**로 태어났다는 게 기존 주석의 설명이지만, 이 그라운딩 도중 실 PG로 재확認하니 **오늘은 자체 PK+FK를 가진 진짜 base table**이다(그 사이 어느 마이그레이션이 뷰→테이블로 전환 — 옛 주석이 스테일해진 것 자체가 부수 발견, 별도 스토리 #3058로 등재).

핵심 경계: `org_members`(role 권위 축, `get_project_role`의 "org owner/admin floor"가 사는 곳)와 `team_members`(메시징 신원 축, 이 테이블에 명시 행이 있어야만 존재)는 독립된 두 테이블·두 id 공간(`OrgMember.id`는 uuid4 자체 발급, `team_members.id`와 무관) — "org admin이지만 이 프로젝트엔 `team_members` 행이 없는" recipient_id는 authz로는 자격이 있어도 이 FK를 항상 위반한다(`test_2891` fixture가 이 정확한 케이스로 실사고 재현). `notify_gate_created_to_recipients`가 이 서브셋을 사전에 걸러 스킵(로그만) — 카드 배달(다른 신원 경로)은 이 필터와 무관.

## 검증
- 신규 realdb 테스트(`test_3044_gate_created_sse_realdb.py`) 6개: durable Event 삽입·id 공간 경계 스킵·빈 recipient 무크래시·**merge_verdict_gate.py 무변경 e2e 커버 증명**·commit 前 push 0(레이스 가드)·rollback 시 push 0(test_2381 검증 패턴 재사용).
- FE 신규 2개(gate_created prepend·중복 가드) — git stash로 pre-fix에 대면 정확히 신규분만 RED 실증(BE/FE 둘 다).
- BE 관련 60 pass(test_2118·2604·3001·2628·2624·2985·edg_doc_gate_inbox·신규 6개·기존 2381 wake-hook 회귀가드 2개 — 같은 세션 info 딕셔너리를 공유하는 두 훅이 서로 안 밟는지도 함께 확認).
- eslint 0·tsc 클린·`pnpm build` EXIT=0.

## 무관 사전 결함 발견(별도 스토리 등재, 본 PR 범위 밖)
- #3057: `test_2891`/`test_2925`(11개)가 develop HEAD 기준으로도 동일 재현되는 `conversations.created_by` FK 위반.
- #3058: `team_members` 관련 옛 주석(0088/0106)이 "뷰"로 스테일 — 실제로는 base table 전환 후 문서 스윕 필요.

## AC 체크
- [x] 표본② 원인 확定+fix(**8개 호출부 전부, merge/doc 포함**)
- [x] 표본① 원인 확定(3038로 흡수, 본 스토리 fix 대상 아님)
- [x] 게이트 생성 시 열린 탭 즉시 반영 회귀 테스트(merge_verdict_gate.py e2e 포함)
- [x] 카디르 QA

## 리뷰 요청
- 유나군 design(FE 구독부)
- 카디르군 QA