### PR TITLE
fix(#3062): event_seq.py _fire_pending_wakes SAVEPOINT 유령 wake 가드

### DIFF
--- a/backend/app/services/event_seq.py
+++ b/backend/app/services/event_seq.py
@@ -87,6 +87,18 @@ def _schedule_wake_after_commit(db: AsyncSession, recipient_id: str, seq: int) -
 
 
 def _fire_pending_wakes(sync_session: Session) -> None:
+    """⚠️SAVEPOINT 유령 wake(story #3062, approval_delivery.py의 `_fire_pending_gate_created_
+    pushes`/PR#3467·카디르 QA REQUEST_CHANGES②와 완전히 동형 — 이 함수가 그 패턴의 원본) —
+    `after_commit`은 outer 최종 commit뿐 아니라 `begin_nested()` SAVEPOINT를
+    release(`nested.commit()`)할 때도 발화한다(실측: 콜백 안에서 `in_nested_transaction()`이
+    그 순간 True). outer 트랜잭션이 이후 rollback돼도 이미 wake가 나가버려, 존재하지 않게 될
+    recipient_seq를 가리키는 유령 재조회 신호가 라이브로 새는 결함이었다.
+    `in_nested_transaction()`이 True인 발화(=SAVEPOINT release)는 pending을 비우지 않고
+    그대로 둔다 — 언젠가 진짜 outer commit의 after_commit이 다시 발화할 때(그때는
+    in_nested_transaction()=False) 최종 발사된다. outer가 끝내 rollback되면 after_rollback
+    훅(_clear_pending_wakes_on_rollback)이 비운다."""
+    if sync_session.in_nested_transaction():
+        return
     pending = sync_session.info.pop(_PENDING_WAKES_KEY, None) or []
     if not pending:
         return

--- a/backend/tests/test_2381_wake_after_commit_race_realdb.py
+++ b/backend/tests/test_2381_wake_after_commit_race_realdb.py
@@ -208,6 +208,73 @@ async def test_rollback_never_fires_wake(monkeypatch):
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+async def test_savepoint_release_does_not_fire_wake_but_outer_commit_does(monkeypatch):
+    """story #3062 — approval_delivery.py의 `_schedule_gate_created_push_after_commit`
+    (PR#3467, 카디르 QA REQUEST_CHANGES② 발견)과 완전히 동형인 SAVEPOINT 유령 wake 결함이
+    이 원본(`_schedule_wake_after_commit`, story #2381)에도 동일하게 잠복해 있는지 카디르
+    최소재현 그대로 고정한다. SQLAlchemy `after_commit`은 outer 최종 commit뿐 아니라
+    `begin_nested()` SAVEPOINT release(`nested.commit()`)에도 발화한다 — outer가 그 뒤
+    rollback돼도 이미 wake가 나가버리면 존재하지 않게 될 recipient_seq를 가리키는 유령
+    재조회 신호가 라이브로 샌다. ①SAVEPOINT release=0회 ②outer commit=1회 ③outer
+    rollback=0회를 정확히 고정한다.
+
+    실전 경로: `approval_delivery.dispatch_approval_request_cards`의 승인자별 SAVEPOINT
+    격리 루프(`db.begin_nested()`)가 승인자/요청자가 agent일 때 `_dispatch_conversation_event`
+    → `assign_recipient_seq`를 그 SAVEPOINT 안에서 부른다 — 이 테스트와 동일한 실전 재현
+    지점이다.
+    """
+    engine, Session = await _session()
+    try:
+        async with Session() as seed_s:
+            org, proj, agent_id = await _seed_org_project_agent(seed_s)
+
+        import app.routers.agent_gateway as gw_mod
+        from app.models.event import Event
+        from app.services.event_seq import assign_recipient_seq
+
+        woken: list[tuple[str, int]] = []
+        monkeypatch.setattr(gw_mod, "wake_agent", lambda rid, seq: woken.append((rid, seq)))
+
+        # ① SAVEPOINT release — wake가 아직 나가면 안 된다(outer가 살아있다).
+        async with Session() as s:
+            nested = await s.begin_nested()
+            event = Event(
+                project_id=proj, org_id=org, event_type="dispatched",
+                recipient_id=agent_id, recipient_type="agent",
+                payload={"content": "x"}, status="pending",
+            )
+            s.add(event)
+            await s.flush()
+            seq = await assign_recipient_seq(s, event)
+            await nested.commit()
+            assert woken == [], "SAVEPOINT release에서 wake가 나가면 안 된다(outer 미확定)"
+
+            # ② outer 진짜 commit — 이제서야 나간다.
+            await s.commit()
+            assert woken == [(str(agent_id), seq)], f"outer commit 直後 정확히 1회 발화해야 하는데: {woken}"
+
+        # ③ outer rollback 케이스 — 별도 세션으로 독립 재현.
+        woken.clear()
+        async with Session() as s:
+            nested = await s.begin_nested()
+            event2 = Event(
+                project_id=proj, org_id=org, event_type="dispatched",
+                recipient_id=agent_id, recipient_type="agent",
+                payload={"content": "y"}, status="pending",
+            )
+            s.add(event2)
+            await s.flush()
+            await assign_recipient_seq(s, event2)
+            await nested.commit()
+            assert woken == [], "SAVEPOINT release에서 wake가 나가면 안 된다"
+            await s.rollback()
+        assert woken == [], "outer rollback 후에도 SAVEPOINT release 시점 wake가 새면 안 된다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
 async def test_multiple_dispatches_same_session_each_wake_exactly_once(monkeypatch):
     """한 세션에서 여러 번 commit(=여러 dispatch)해도 매번 그 트랜잭션분만 정확히 한 번씩
     발화한다 — 세션 재사용 시 리스너 중복등록(이중발화)도, 예약 누락(무발화)도 없어야 한다."""


### PR DESCRIPTION
[SID:3062]

## 요약
story #3044(PR#3467) 카디르 QA REQUEST_CHANGES② — approval_delivery.py의 `_fire_pending_gate_created_pushes`에서 발견된 "SAVEPOINT 유령 push" 결함(SQLAlchemy `after_commit`이 outer 최종 commit뿐 아니라 `begin_nested()` SAVEPOINT release에도 발화)이, 그 구현이 동형 복제한 원본인 `event_seq.py`의 `_fire_pending_wakes`(story #2381)에도 동일하게 잠복해 있었다. PR#3467과 완전히 동형인 `sync_session.in_nested_transaction()` 가드를 이식.

## AC 체크
- [x] **AC1(실전 영향 확認)** — `approval_delivery.dispatch_approval_request_cards()`의 승인자별 SAVEPOINT 격리 루프(`db.begin_nested()`, 기존 코드)가 `conversations.py::_dispatch_conversation_event` → `assign_recipient_seq`를 그 SAVEPOINT 안에서 호출한다(요청자 또는 승인자가 agent일 때). 이론적 결함이 아니라 실 call path.
- [x] **AC2(카디르 3케이스 고정)** — `test_savepoint_release_does_not_fire_wake_but_outer_commit_does` 신규: ①SAVEPOINT release=0회 ②outer commit=1회 ③outer rollback=0회. fix 前 genuine RED 확認(①에서 AssertionError로 실제 재현), fix 後 GREEN.
- [x] **AC3(회귀 0)** — `test_2381_wake_after_commit_race_realdb.py` 기존 4개 + `test_2381_ac4_live_wake_delivery_realdb.py` 2개 전부 pass.

## 구현
`event_seq.py::_fire_pending_wakes`에 가드 추가 — `in_nested_transaction()`이 True(=SAVEPOINT release)면 pending을 비우지 않고 그대로 둔다. 진짜 outer commit의 `after_commit`이 다시 발화할 때(그때는 `in_nested_transaction()=False`) 최종 발사. outer가 끝내 rollback되면 기존 `after_rollback` 훅(`_clear_pending_wakes_on_rollback`)이 비운다.

## 로그 흔적 스윕 (페드루 PO 요청)
dev backend Cloud Run 로그 30일 윈도우에서 wake/push 관련 스킵·실패 로그시그니처("post-commit wake_agent failed", "approval-request 카드 배달 실패" 등) 검색 — **0건**. pre-fix 코드엔 SAVEPOINT-release 발화와 정상 outer-commit 발화를 구분하는 로그 자체가 없어(둘 다 동일하게 `wake_agent` 성공 호출로만 보임) "과거에 실제로 새어나갔다"를 로그만으로 직접 확認할 수는 없었다 — 재현 테스트(AC2)가 이 결함의 실재를 증명하는 권위 있는 증거.

## 인접 결함 — 분리 처리(페드루 PO 승인)
카디르가 probe로 추가 발견한 반대방향 결함 — [SAVEPOINT rollback이 after_rollback 발화, 같은 세션 다른 recipient의 정상 pending push까지 유실](entity:story:09b4b2fe-f8ac-471a-b254-855f6842c1b6)(#3063, low/비차단) — 은 이 PR과 분리한다. 방향(rollback측 과잉삭제 vs 이 PR의 commit측 유령발사)도 처방 무게(pending을 SAVEPOINT 경계별로 격리하는 구조 변경 vs 가드 한 줄)도 달라서다. #3063 착수 시 event_seq.py+approval_delivery.py 두 쌍둥이를 한 PR에서 동시 처리하도록 스토리 본문에 권고를 남겨뒀다.

## 검증
- `PARITY_TEST_DATABASE_URL`(create_all 스크래치 PG)로 `test_2381_wake_after_commit_race_realdb.py`(5) + `test_2381_ac4_live_wake_delivery_realdb.py`(2) = 7/7 pass.
- 관련 mocked-path 회귀(`test_agent_dispatch.py`·`test_event1config_message_gating.py`·`test_l2_e2e_status_changed.py`) 12/12 pass.
- ruff clean(`event_seq.py`), 테스트 파일은 내가 추가한 블록 기준 사전 존재 lint debt 대비 순증 0.

## 리뷰 요청
- 카디르군 QA

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>