### PR TITLE
[SID:3049] 재질 프리미티브 5종 + 에이전트 정체성 통일(2984-S1 선행 게이트)

### DIFF
--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, ChevronDown, ChevronRight, Inbox as InboxIcon, Zap, ZapOff, 
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { Badge } from '@/components/ui/badge';
+import { AgentIdentity } from '@/components/ui/agent-identity';
 import { ApprovalsQueue } from '@/components/inbox/approvals-queue';
 import { AttentionQueueView } from '@/components/attention-queue/attention-queue-view';
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
@@ -674,16 +675,12 @@ export default function InboxPage() {
                             {notification.body ? (
                               <p className="line-clamp-1 text-xs text-muted-foreground">{notification.body}</p>
                             ) : null}
-                            {/* 목업 ⑤: 타입 1급 — agent_joined=Bot 칩·도달사유 칩. story #3010(로드맵
-                                P3, L5) — 정적 정체성 마킹은 citron이 아니라 proof-blue-soft
-                                (P1 PR-B 챗 Bot배지·avatar.tsx 관례와 동형). */}
+                            {/* 목업 ⑤: 타입 1급 — agent_joined=Bot 칩·도달사유 칩. story #3049
+                                (2984-S1) — AgentIdentity 프리미티브(헤어라인+proof-blue 신호
+                                dot) 채택, soft-fill 폐지. */}
                             {(notification.type === 'agent_joined' || reasonKey) ? (
                               <div className="flex flex-wrap items-center gap-1.5">
-                                {notification.type === 'agent_joined' ? (
-                                  <Badge className="gap-0.5 bg-proof-blue-soft text-foreground text-[10px]">
-                                    <Bot className="size-2.5" />Bot
-                                  </Badge>
-                                ) : null}
+                                {notification.type === 'agent_joined' ? <AgentIdentity /> : null}
                                 {reasonKey ? <Badge variant="info" className="text-[10px]">{t(reasonKey)}</Badge> : null}
                               </div>
                             ) : null}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -475,6 +475,12 @@
      오프셋/블러/스프레드 40~50%·불투명도 ~59%로 축소(같은 carbon-tint, 2레이어 구조 유지). */
   --elev-card: 0 1px 2px rgba(20, 21, 15, .04), 0 4px 14px -4px rgba(20, 21, 15, .13);
 
+  /* story #3049(2984-S1, doc diff-axis-2984-color-to-material-inventory §4) — CountBadge·
+     VerificationStamp 전용 엠보스 inset(시안 0bead718/3df21f43 `.badge-count`/`.stamp`
+     box-shadow 그대로 토큰화). 인라인 표면 hairline+elevation 위에 "눌린 도장/새김" 물성을
+     더하는 2차 레이어 — elev-card/overlay(뜬 표면용)와 별개, 절대 함께 안 쓴다. */
+  --elev-inset: inset 0 1px 0 rgba(255, 255, 255, .6), inset 0 -1px 0 rgba(20, 21, 15, .05);
+
   /* story #2955 §5(doc docs-index-reader-redesign-handoff) — 컷코너 3단 토큰 정식화.
      기존 산발 clip-path 4곳(proof-capsule.tsx CutCornerShell·attention-queue-view.tsx·
      artifact-gallery-view.tsx·workcell.tsx)이 정본 없이 각자 인라인으로 같은 지오메트리를
@@ -641,6 +647,11 @@
      40~50%·불투명도 ~59%)를 다크 --elev-overlay에 적용해 유도(값-SSOT 재사용, 임의 신규
      불투명도 없음). */
   --elev-card: 0 1px 2px rgba(0, 0, 0, .4), 0 4px 16px -4px rgba(0, 0, 0, .36);
+
+  /* story #3049 — 다크 엠보스 inset. 라이트의 흰색 하이라이트(rgba(255,255,255,.6))는 다크
+     패널(#17191C대)에 그대로 쓰면 과도하게 튀어(carbon-tint 위반) — 라이트보다 옅은 흰색
+     상단 하이라이트(0.08)로 축소, 하단 그림자는 검정 자체가 배경과 거의 안 갈려 생략. */
+  --elev-inset: inset 0 1px 0 rgba(255, 255, 255, .08);
 }
 
 /* Sidebar: open triggers get active background */

--- a/apps/web/src/components/chat/add-participant-modal.test.tsx
+++ b/apps/web/src/components/chat/add-participant-modal.test.tsx
@@ -102,10 +102,10 @@ describe('AddParticipantModal — 에이전트 정책 거부 구조화 안내(st
   });
 });
 
-// story #3000 로드맵 PR-B(L5) — 후보 목록의 Bot 배지 배경은 정적 정체성 마킹이라 citron이
-// 아니라 proof-blue-soft여야 한다.
-describe('AddParticipantModal — 로드맵 PR-B L5(Bot 배지 배경 proof-blue-soft)', () => {
-  it('agent 후보 항목의 Bot 배지가 bg-proof-blue-soft를 쓰고 bg-accent-claim은 안 쓴다', async () => {
+// story #3049(2984-S1) — 후보 목록의 Bot 배지는 AgentIdentity(헤어라인+proof-blue 신호 dot),
+// soft-fill 폐지(옛 PR-B의 proof-blue-soft 결정을 대체).
+describe('AddParticipantModal — story #3049(AgentIdentity 헤어라인+신호 dot)', () => {
+  it('agent 후보 항목의 Bot 배지가 AgentIdentity를 쓰고 soft-fill/accent-claim은 안 쓴다', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.startsWith('/api/members')) return { ok: true, json: async () => ({ data: MEMBERS }) };
       return { ok: true, json: async () => ({}) };
@@ -119,9 +119,10 @@ describe('AddParticipantModal — 로드맵 PR-B L5(Bot 배지 배경 proof-blue
       ));
     });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); });
-    const badge = document.body.querySelector('.rounded-sm.bg-proof-blue-soft');
+    const badge = document.body.querySelector('.border-proof-line');
     expect(badge).toBeTruthy();
     expect(badge?.textContent).toBe('Bot');
+    expect(badge?.className).not.toContain('bg-proof-blue-soft');
     expect(document.body.querySelector('.bg-accent-claim\\/15')).toBeNull();
   });
 });

--- a/apps/web/src/components/chat/add-participant-modal.tsx
+++ b/apps/web/src/components/chat/add-participant-modal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { X, Check } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { AgentIdentity } from '@/components/ui/agent-identity';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { buildPolicyDeniedMessage, parseAgentMessagePolicyDenied } from '@/lib/agent-message-policy-error';
@@ -122,11 +123,9 @@ export function AddParticipantModal({
                       {m.name?.slice(0, 2)?.toUpperCase() ?? '?'}
                     </div>
                     <span className="flex-1 truncate">{m.name}</span>
-                    {/* story #3000 로드맵 PR-B(L5) — 정적 Bot 배지 배경은 citron이 아니라
-                        proof-blue-soft(정체성 마킹). */}
-                    {m.type === 'agent' && (
-                      <span className="rounded-sm bg-proof-blue-soft px-1 py-0.5 text-[9px] font-medium text-foreground">Bot</span>
-                    )}
+                    {/* story #3049(2984-S1) — AgentIdentity 프리미티브(헤어라인+proof-blue
+                        신호 dot) 채택, soft-fill 폐지. */}
+                    {m.type === 'agent' && <AgentIdentity />}
                     {selected === m.id && <Check className="h-3.5 w-3.5 flex-shrink-0 text-primary" />}
                   </button>
                 </li>

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1707,18 +1707,17 @@ describe('ChatBubble — story #2921 S4(유나 확定, 버블·아바타 Proofli
 // story #3000 로드맵 PR-B(L5) — Bot 배지 배경은 정적(비-pulse) 정체성 마킹이라 citron이 아니라
 // proof-blue-soft여야 한다(story-card 아바타·avatar.tsx idle 링과 정합).
 describe('ChatBubble — 로드맵 PR-B L5(Bot 배지 배경 proof-blue-soft)', () => {
-  it('agent 발신 메시지의 Bot 배지가 bg-proof-blue-soft를 쓰고 citron은 안 쓴다', async () => {
-    // ⛔avatar.tsx의 "AI" 코너 배지(별개 소비처 — 같은 PR-B에서 동승 수정됨, avatar.test.tsx
-    // 참고)도 bg-proof-blue-soft를 쓰므로 이 원소 자신의 클래스만 좁혀서 잰다(container 전체
-    // grep이 아니라).
+  it('story #3049(2984-S1) — agent 발신 메시지의 Bot 배지가 AgentIdentity(헤어라인+신호 dot)를 쓰고 soft-fill은 안 쓴다', async () => {
     const plainMessage: ChatMessage = { ...baseMessage, content: '봇 메시지', sender_type: 'agent' };
     await act(async () => {
       root.render(wrap(<ChatBubble message={{ ...plainMessage, references: [] }} isMine={false} />));
     });
-    const badge = container.querySelector('.rounded-sm.bg-proof-blue-soft');
+    const badge = container.querySelector('.border-proof-line');
     expect(badge).toBeTruthy();
     expect(badge?.textContent).toBe('Bot');
+    expect(badge?.className).not.toContain('bg-proof-blue-soft');
     expect(badge?.className).not.toContain('accent-claim');
+    expect(badge?.querySelector('.bg-proof-blue')).toBeTruthy();
   });
 });
 

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -7,6 +7,7 @@ import remarkBreaks from 'remark-breaks';
 import { Check, Copy, MessageSquare, Terminal } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
+import { AgentIdentity } from '@/components/ui/agent-identity';
 import { commandName, dequoteLiteral, isCommand } from '@/lib/command-classifier';
 import { EmbedCard, EntityChip, getEntityHref } from '@/components/chat/embed-card';
 import { parseEntityRef } from '@/components/chat/entity-ref';
@@ -533,11 +534,9 @@ export function ChatBubble({
                 {displayName}
               </span>
               {isAgent && (
-                // story #3000 로드맵 PR-B(L5) — 정적(비-pulse) Bot 배지 배경은 citron이 아니라
-                // proof-blue-soft(정체성 마킹, story-card 아바타·avatar.tsx idle 링과 정합).
-                <span className="rounded-sm bg-proof-blue-soft px-1 py-0.5 text-[9px] font-medium text-foreground">
-                  Bot
-                </span>
+                // story #3049(2984-S1) — AgentIdentity 프리미티브(헤어라인+proof-blue 신호
+                // dot) 채택, soft-fill 폐지.
+                <AgentIdentity />
               )}
             </div>
           )}

--- a/apps/web/src/components/chat/new-conversation-modal.test.tsx
+++ b/apps/web/src/components/chat/new-conversation-modal.test.tsx
@@ -135,10 +135,10 @@ describe('NewConversationModal — 에이전트 정책 거부 구조화 안내(s
   });
 });
 
-// story #3000 로드맵 PR-B(L5) — 후보 목록의 Bot 배지 배경은 정적 정체성 마킹이라 citron이
-// 아니라 proof-blue-soft여야 한다.
-describe('NewConversationModal — 로드맵 PR-B L5(Bot 배지 배경 proof-blue-soft)', () => {
-  it('agent 후보 항목의 Bot 배지가 bg-proof-blue-soft를 쓰고 bg-accent-claim은 안 쓴다', async () => {
+// story #3049(2984-S1) — 후보 목록의 Bot 배지는 AgentIdentity(헤어라인+proof-blue 신호 dot),
+// soft-fill 폐지(옛 PR-B의 proof-blue-soft 결정을 대체).
+describe('NewConversationModal — story #3049(AgentIdentity 헤어라인+신호 dot)', () => {
+  it('agent 후보 항목의 Bot 배지가 AgentIdentity를 쓰고 soft-fill/accent-claim은 안 쓴다', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.startsWith('/api/members')) return { ok: true, json: async () => ({ data: MEMBERS }) };
       return { ok: true, json: async () => ({}) };
@@ -147,9 +147,10 @@ describe('NewConversationModal — 로드맵 PR-B L5(Bot 배지 배경 proof-blu
       root.render(wrap(<NewConversationModal projectId={PROJECT_ID} onClose={() => {}} onCreated={() => {}} />));
     });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); });
-    const badge = document.body.querySelector('.rounded-sm.bg-proof-blue-soft');
+    const badge = document.body.querySelector('.border-proof-line');
     expect(badge).toBeTruthy();
     expect(badge?.textContent).toBe('Bot');
+    expect(badge?.className).not.toContain('bg-proof-blue-soft');
     expect(document.body.querySelector('.bg-accent-claim\\/15')).toBeNull();
   });
 });

--- a/apps/web/src/components/chat/new-conversation-modal.tsx
+++ b/apps/web/src/components/chat/new-conversation-modal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { X, Check } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { AgentIdentity } from '@/components/ui/agent-identity';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { buildPolicyDeniedMessage, parseAgentMessagePolicyDenied } from '@/lib/agent-message-policy-error';
@@ -118,11 +119,9 @@ export function NewConversationModal({ projectId, onClose, onCreated }: NewConve
                       {m.name?.slice(0, 2)?.toUpperCase() ?? '?'}
                     </div>
                     <span className="flex-1 truncate">{m.name}</span>
-                    {/* story #3000 로드맵 PR-B(L5) — 정적 Bot 배지 배경은 citron이 아니라
-                        proof-blue-soft(정체성 마킹). */}
-                    {m.type === 'agent' && (
-                      <span className="rounded-sm bg-proof-blue-soft px-1 py-0.5 text-[9px] font-medium text-foreground">Bot</span>
-                    )}
+                    {/* story #3049(2984-S1) — AgentIdentity 프리미티브(헤어라인+proof-blue
+                        신호 dot) 채택, soft-fill 폐지. */}
+                    {m.type === 'agent' && <AgentIdentity />}
                     {selected.includes(m.id) && <Check className="h-3.5 w-3.5 flex-shrink-0 text-primary" />}
                   </button>
                 </li>

--- a/apps/web/src/components/kanban/story-card.test.tsx
+++ b/apps/web/src/components/kanban/story-card.test.tsx
@@ -37,13 +37,13 @@ describe('StoryCard — 로드맵 PR-A L1(floating 팝업 elev-overlay)', () => 
   });
 });
 
-// story #2998 로드맵 PR-A(L5) — agent 정적 아바타 테두리는 citron(live pulse 전용)이 아니라
-// proof-blue(정체성 마킹, avatar.tsx idle 링과 정합)여야 한다.
-describe('StoryCard — 로드맵 PR-A L5(agent 아바타 정적 identity=proof-blue)', () => {
-  it('agent assignee 아바타가 border-proof-blue/bg-proof-blue-soft를 쓰고 citron은 안 쓴다', () => {
+// story #3049(2984-S1) — agent 정적 아바타 테두리는 proof-blue(정체성 마킹, avatar.tsx idle
+// 링과 정합)를 유지하되, 배경 soft-fill은 폐지(AGENT_MARK_FILL_CLASS=투명, 헤어라인만 남김).
+describe('StoryCard — story #3049(agent 아바타 헤어라인, soft-fill 폐지)', () => {
+  it('agent assignee 아바타가 border-proof-blue를 쓰고 soft-fill/citron은 안 쓴다', () => {
     const markup = render(makeStory(), [{ id: 'a1', name: '에이전트군', type: 'agent' }]);
     expect(markup).toContain('border-proof-blue/30');
-    expect(markup).toContain('bg-proof-blue-soft');
+    expect(markup).not.toContain('bg-proof-blue-soft');
     expect(markup).not.toContain('border-accent-claim');
     expect(markup).not.toContain('bg-accent-claim/10');
   });

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -9,7 +9,9 @@ import type { KanbanStory, KanbanMember, LineStatusSummary } from './types';
 import { parseStoryCardTitle } from '@/lib/story-card-title';
 import { Badge } from '@/components/ui/badge';
 import { AlertTriangle, ChevronRight, EyeOff, History, Pause, Rocket, Zap, ZapOff, type LucideIcon } from 'lucide-react';
+import { AGENT_MARK_FILL_CLASS } from '@/components/ui/agent-identity';
 import { LabelChip } from '@/components/ui/label-chip';
+import { cn } from '@/lib/utils';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { TrustSeal } from '@/components/verify/trust-seal';
 import { deriveTrustStage } from '@/services/verify';
@@ -401,13 +403,14 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                     {assigneeList.slice(0, 3).map((m) => (
                       <div
                         key={m.id}
-                        // story #2998 로드맵 PR-A(L5) — 정적(비-pulse) agent 정체성 마킹은
-                        // proof-blue(avatar.tsx idle 링과 정합) — citron은 live pulse(실행) 전용.
-                        className={`relative flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-medium ring-1 ring-background ${
+                        // story #3049(2984-S1) — AGENT_MARK_FILL_CLASS(헤어라인 border 유지·
+                        // soft-fill 폐지) 채택. border는 이미 있었으니 배경/텍스트색만 교체.
+                        className={cn(
+                          'relative flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-medium ring-1 ring-background',
                           m.type === 'agent'
-                            ? 'border-proof-blue/30 bg-proof-blue-soft text-foreground'
-                            : 'border-border bg-muted text-muted-foreground'
-                        }`}
+                            ? cn('border-proof-blue/30', AGENT_MARK_FILL_CLASS)
+                            : 'border-border bg-muted text-muted-foreground',
+                        )}
                         title={m.name}
                       >
                         {getInitials(m.name)}

--- a/apps/web/src/components/shared/avatar.test.tsx
+++ b/apps/web/src/components/shared/avatar.test.tsx
@@ -66,16 +66,16 @@ describe('Avatar — story #2887 S2g', () => {
     expect(container.querySelector('[role="img"]')).not.toBeNull(); // PresenceDot
   });
 
-  // story #3000 로드맵 PR-B(L5, 페드루군 동승 판정) — 정적 "AI" 코너배지는 citron이 아니라
-  // proof-blue 틴트여야 한다(정체성 마킹 — citron은 live pulse 전용).
-  it('AI 코너배지가 border-proof-blue/bg-proof-blue-soft를 쓰고 citron은 안 쓴다', async () => {
+  // story #3049(2984-S1) — 정적 "AI" 코너배지 border는 proof-blue 유지(정체성 마킹), 배경
+  // soft-fill은 폐지(AGENT_MARK_FILL_CLASS=투명, 헤어라인만 남김).
+  it('AI 코너배지가 border-proof-blue를 쓰고 soft-fill/citron은 안 쓴다', async () => {
     await act(async () => {
       root.render(wrap(<Avatar name="유나" avatarUrl={null} actorType="agent" />));
     });
     const badge = [...container.querySelectorAll('span')].find((s) => s.textContent === 'AI');
     expect(badge).toBeTruthy();
     expect(badge?.className).toContain('border-proof-blue/40');
-    expect(badge?.className).toContain('bg-proof-blue-soft');
+    expect(badge?.className).not.toContain('bg-proof-blue-soft');
     expect(badge?.className).not.toContain('accent-claim');
   });
 

--- a/apps/web/src/components/shared/avatar.tsx
+++ b/apps/web/src/components/shared/avatar.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Bot, User } from 'lucide-react';
 import { PresenceDot, AGENT_LIVE_RING_CLASS, type PresenceStatus } from '@/components/chat/presence-dot';
+import { AGENT_MARK_FILL_CLASS } from '@/components/ui/agent-identity';
 import { avatarColor, initials } from '@/lib/storage/format';
 import { cn } from '@/lib/utils';
 
@@ -97,11 +98,10 @@ export function Avatar({
       </div>
 
       {isAgent && (
-        // story #3000 로드맵 PR-B(L5, 페드루군 동승 판정) — 정적 "AI" 코너배지는 citron이
-        // 아니라 proof-blue 틴트(정체성 마킹 — citron은 live pulse 전용, AGENT_LIVE_RING_CLASS
-        // 참고). 텍스트는 기왕 text-foreground.
+        // story #3049(2984-S1) — AGENT_MARK_FILL_CLASS(헤어라인 border 유지·soft-fill
+        // 폐지) 채택. border는 이미 있었으니 배경/텍스트색만 교체(단일 정의 재사용).
         <span
-          className="absolute -right-1.5 -top-1.5 rounded border border-proof-blue/40 bg-proof-blue-soft font-bold text-foreground"
+          className={cn('absolute -right-1.5 -top-1.5 rounded border border-proof-blue/40 font-bold', AGENT_MARK_FILL_CLASS)}
           style={{ fontSize: Math.max(7, Math.round(badgeSize * 0.55)), lineHeight: 1, padding: '2px 3px' }}
         >
           AI

--- a/apps/web/src/components/ui/agent-identity.tsx
+++ b/apps/web/src/components/ui/agent-identity.tsx
@@ -1,0 +1,41 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * story #3049(2984-S1, doc diff-axis-2984-color-to-material-inventory §4) — 에이전트 정체성
+ * 마킹 재질 프리미티브. soft-fill 색 배경(`bg-proof-blue-soft`)으로 "이건 에이전트다"를
+ * 표시하던 ~9곳(아바타 배경 4·Bot 칩 5)을 헤어라인 컨테이너 + proof-blue 신호 dot/마크로
+ * 통일한다 — «에이전트» 자체는 여전히 신호라 dot/마크의 색(proof-blue)은 KEEP(제거 아님,
+ * §1 판별: 지우면 "에이전트임"이 안 읽히므로 신호).
+ *
+ * 두 형태:
+ * - `AgentSignalDot` — dot 자체(story-card.tsx agent dot 등 이미 dot인 자리는 그대로 KEEP,
+ *   여기선 재사용 편의를 위해서만 내보낸다).
+ * - `AgentIdentity` — "Bot" 텍스트 칩(inbox·add-participant-modal·chat-bubble·
+ *   new-conversation-modal 4곳이 지금까지 각자 복붙해온 `bg-proof-blue-soft` 배지의
+ *   단일 대체 정의).
+ * - `AGENT_MARK_FILL_CLASS` — 아바타/아이콘류 배경 원·사각(story-card.tsx 멤버 아바타·
+ *   avatar.tsx 이니셜 배경+AI 코너배지·trust-seal.tsx claimed 아이콘·lib/storage/format.ts의
+ *   avatarColor 헬퍼) 4곳이 채택하는 배경 클래스 — 이 4곳은 이미 각자 자기 경계(ring 또는
+ *   border-proof-blue)를 갖고 있어(§2 형태 신호 문법, 호출부마다 다른 모양) 새 border를
+ *   더하지 않는다. fill만 투명으로 교체하는 것이 "SHIFT"의 정확한 범위(단일 정의 재사용,
+ *   사본 분화 금지).
+ */
+export const AGENT_MARK_FILL_CLASS = 'bg-transparent text-proof-blue';
+
+export function AgentSignalDot({ className }: { className?: string }) {
+  return <span aria-hidden="true" className={cn('inline-block size-1.5 shrink-0 rounded-full bg-proof-blue', className)} />;
+}
+
+export function AgentIdentity({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-sm border border-proof-line px-1 py-0.5 text-[9px] font-medium text-muted-foreground',
+        className,
+      )}
+    >
+      <AgentSignalDot />
+      Bot
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/count-badge.tsx
+++ b/apps/web/src/components/ui/count-badge.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * story #3049(2984-S1, doc diff-axis-2984-color-to-material-inventory §4) — mono·엠보스
+ * inset 카운트 배지(시안 3df21f43 `.badge-count` 그대로 토큰화). soft-fill 색 배경으로
+ * 강조하던 카운트류(그룹 배지 「38건」 등)를 대체하는 재질 프리미티브. S4~S5 표면 스토리가
+ * 채택 — 이 파일 자체는 신규 소비처를 만들지 않는다(정의만).
+ */
+export function CountBadge({ count, suffix, className }: { count: number; suffix?: string; className?: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-baseline gap-0.5 rounded-full border border-proof-line px-2.5 py-[3px] font-mono text-xs font-bold text-foreground shadow-[var(--elev-inset)]',
+        className,
+      )}
+    >
+      {count}
+      {suffix ? <span className="text-[9px] font-medium text-muted-foreground">{suffix}</span> : null}
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/material-chip.tsx
+++ b/apps/web/src/components/ui/material-chip.tsx
@@ -1,0 +1,20 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * story #3049(2984-S1, doc diff-axis-2984-color-to-material-inventory §4) — 헤어라인 무채
+ * 칩(fill 0). soft-fill 색 배경(`bg-*-soft`)으로 구분하던 카테고리 칩·타입 배지류를 대체하는
+ * 재질 프리미티브 1종(시안 0bead718 `.chip-line`/3df21f43 `.type-line` 그대로 토큰화). S2~S6
+ * 표면 스토리가 채택 — 이 파일 자체는 신규 소비처를 만들지 않는다(정의만).
+ */
+export function MaterialChip({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-md border border-proof-line bg-transparent px-2 py-[3.5px] text-[10.5px] font-semibold tracking-[0.04em] text-muted-foreground',
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/material-primitives.test.tsx
+++ b/apps/web/src/components/ui/material-primitives.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+//
+// story #3049(2984-S1) — 재질 프리미티브 5종(MaterialChip·CountBadge·VerificationStamp·
+// AgentIdentity·#num) 단위 테스트. soft-fill(bg-*-soft) 대신 헤어라인/mono/엠보스/신호 dot
+// 재질을 쓰는지 고정한다.
+import { describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { MaterialChip } from './material-chip';
+import { CountBadge } from './count-badge';
+import { VerificationStamp } from './verification-stamp';
+import { AgentIdentity, AgentSignalDot, AGENT_MARK_FILL_CLASS } from './agent-identity';
+
+function mount() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { container, root };
+}
+
+describe('MaterialChip', () => {
+  it('헤어라인 border만 쓰고 soft-fill 배경은 안 쓴다', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<MaterialChip>모바일 IA</MaterialChip>); });
+    const el = container.querySelector('span');
+    expect(el?.textContent).toBe('모바일 IA');
+    expect(el?.className).toContain('border-proof-line');
+    expect(el?.className).toContain('bg-transparent');
+    expect(el?.className).not.toMatch(/bg-\S+-soft/);
+  });
+});
+
+describe('CountBadge', () => {
+  it('mono 카운트+엠보스 inset(soft-fill 아님)을 쓴다', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<CountBadge count={38} suffix="건" />); });
+    const el = container.querySelector('span');
+    expect(el?.textContent).toBe('38건');
+    expect(el?.className).toContain('font-mono');
+    expect(el?.className).toContain('shadow-[var(--elev-inset)]');
+    expect(el?.className).not.toMatch(/bg-\S+-soft/);
+  });
+
+  it('suffix 없으면 숫자만 렌더한다', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<CountBadge count={7} />); });
+    expect(container.querySelector('span')?.textContent).toBe('7');
+  });
+});
+
+describe('VerificationStamp', () => {
+  it('success 톤은 seal이 success 색이고 soft-fill 배경은 안 쓴다', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<VerificationStamp>완료 주장</VerificationStamp>); });
+    const el = container.querySelector('span');
+    expect(el?.textContent).toBe('완료 주장');
+    expect(el?.className).toContain('shadow-[var(--elev-inset)]');
+    expect(el?.querySelector('.border-success')).toBeTruthy();
+    expect(el?.className).not.toMatch(/bg-\S+-soft/);
+  });
+
+  it('neutral 톤은 seal이 무채(proof-faint)다', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<VerificationStamp tone="neutral">검토 중</VerificationStamp>); });
+    expect(container.querySelector('.border-proof-faint')).toBeTruthy();
+    expect(container.querySelector('.border-success')).toBeNull();
+  });
+});
+
+describe('AgentIdentity', () => {
+  it('헤어라인+proof-blue 신호 dot을 쓰고 soft-fill은 안 쓴다("Bot" 텍스트)', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<AgentIdentity />); });
+    const el = container.querySelector('span');
+    expect(el?.textContent).toBe('Bot');
+    expect(el?.className).toContain('border-proof-line');
+    expect(el?.className).not.toMatch(/bg-\S+-soft/);
+    expect(el?.querySelector('.bg-proof-blue')).toBeTruthy();
+  });
+
+  it('AgentSignalDot 단독 렌더도 proof-blue를 쓴다(KEEP 신호)', async () => {
+    const { container, root } = mount();
+    await act(async () => { root.render(<AgentSignalDot />); });
+    expect(container.querySelector('.bg-proof-blue')).toBeTruthy();
+  });
+
+  it('AGENT_MARK_FILL_CLASS는 배경 투명+proof-blue 텍스트만 지정한다(border는 호출부 몫)', () => {
+    expect(AGENT_MARK_FILL_CLASS).toBe('bg-transparent text-proof-blue');
+    expect(AGENT_MARK_FILL_CLASS).not.toMatch(/bg-\S+-soft/);
+  });
+});

--- a/apps/web/src/components/ui/verification-stamp.tsx
+++ b/apps/web/src/components/ui/verification-stamp.tsx
@@ -1,0 +1,38 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * story #3049(2984-S1, doc diff-axis-2984-color-to-material-inventory §4) — 엠보스 inset +
+ * seal(검증/claim 상태) 재질(시안 0bead718 `.stamp`/`.seal` 그대로 토큰화). soft-fill 색
+ * 배경(연두 틴트 등)으로 표시하던 claim/검증 상태를 대체하는 재질 프리미티브. seal 색은
+ * 여전히 신호(success=녹색 유지, §1 "제거는 신호가 사라지나" 판별 — 도장 자체가 검증
+ * "결과"라 색 신호로 남긴다). trust-seal.tsx의 verified 씰(S6, story #3054)이 채택 대상 —
+ * 이 파일 자체는 신규 소비처를 만들지 않는다(정의만).
+ */
+export function VerificationStamp({
+  children,
+  tone = 'success',
+  className,
+}: {
+  children: React.ReactNode;
+  tone?: 'success' | 'neutral';
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-[5px] rounded-[5px] border border-proof-line px-2 py-1 pl-[7px] text-[10px] font-bold tracking-[0.06em] text-muted-foreground uppercase shadow-[var(--elev-inset)]',
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          'flex size-3 shrink-0 items-center justify-center rounded-full border-[1.5px]',
+          tone === 'success' ? 'border-success' : 'border-proof-faint',
+        )}
+      >
+        <span className={cn('size-[5px] rounded-full', tone === 'success' ? 'bg-success' : 'bg-proof-faint')} />
+      </span>
+      {children}
+    </span>
+  );
+}

--- a/apps/web/src/components/verify/trust-seal.tsx
+++ b/apps/web/src/components/verify/trust-seal.tsx
@@ -1,5 +1,6 @@
 import { Bot, Check } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { AGENT_MARK_FILL_CLASS } from '@/components/ui/agent-identity';
 import { cn } from '@/lib/utils';
 import { initials } from '@/lib/storage/format';
 
@@ -46,7 +47,9 @@ export function TrustSeal(props: TrustSealProps) {
   if (props.variant === 'claimed') {
     return (
       <div className={cn('flex items-center gap-2 rounded-[10px] bg-proof-amber-soft px-2.5 py-2 text-[11.5px]', props.className)}>
-        <span className="flex size-[22px] shrink-0 items-center justify-center rounded-full border border-proof-blue bg-proof-blue-soft text-[9px] font-bold text-proof-blue">
+        {/* story #3049(2984-S1) — AGENT_MARK_FILL_CLASS(헤어라인 border 유지·soft-fill
+            폐지) 채택. border는 이미 있었으니 배경만 투명으로 교체. */}
+        <span className={cn('flex size-[22px] shrink-0 items-center justify-center rounded-full border border-proof-blue text-[9px] font-bold', AGENT_MARK_FILL_CLASS)}>
           {props.agentInitial ?? <Bot className="size-3" aria-hidden="true" />}
         </span>
         <span className="min-w-0 flex-1 text-proof-ink-3">

--- a/apps/web/src/lib/storage/format.ts
+++ b/apps/web/src/lib/storage/format.ts
@@ -3,6 +3,7 @@
  * 파일 크기 포맷은 재구현 금지 → `formatFileSize`(file-node.tsx) 재사용. 여기엔 그 외 표시 유틸만.
  */
 
+import { AGENT_MARK_FILL_CLASS } from '@/components/ui/agent-identity';
 import type { AssetSourceLink } from '@/lib/storage/types';
 
 /** 파일 아이콘 틴트 분류 — 목업 `.fic.*` 5종에 1:1 대응. */
@@ -56,7 +57,10 @@ export function fileTypeTint(contentType: string): FileTint {
  * 별도로 하드코딩하지 않게 한다(밝은 -soft 배경 위 흰 글자 가독성 문제 원천 차단).
  */
 export function avatarColor(isAgent: boolean): string {
-  return isAgent ? 'bg-proof-blue-soft text-proof-blue' : 'bg-proof-sunk text-proof-ink-2';
+  // story #3049(2984-S1) — agent 이니셜 배경은 AGENT_MARK_FILL_CLASS(투명·§2 형태로 이미
+  // 있는 ring/border가 경계를 짊어짐). human 배경(무채 sunk)은 재질 이전 대상 밖(신호 없는
+  // 중립 배경이라 SHIFT 항목이 아님) — 무변경.
+  return isAgent ? AGENT_MARK_FILL_CLASS : 'bg-proof-sunk text-proof-ink-2';
 }
 
 export function initials(name: string): string {


### PR DESCRIPTION
## 요약
doc `diff-axis-2984-color-to-material-inventory`(§0~§4, 선생님 원탭 승인 2026-08-25) 스윕의 foundation·선행 게이트(2984-S1). 선생님 교정: "색깔로 UI를 차별화 하려 하지 말고 모양·형태를 확장적 사고로" — soft-fill(`bg-*-soft`) 색 배경으로 구분하던 자리를 헤어라인·mono·엠보스·신호 dot 재질로 이전. 색은 «신호»(에이전트=proof-blue dot 등)로만 후퇴 — 제거가 아니다.

## 신설 프리미티브
- **MaterialChip** — 헤어라인(`border-proof-line`) 무채 칩, fill 0.
- **CountBadge** — mono·엠보스 inset(`--elev-inset` 신규 토큰) 카운트 배지.
- **VerificationStamp** — 엠보스 inset + seal(success/neutral 톤).
- **AgentIdentity** — 헤어라인 컨테이너 + proof-blue 신호 dot/"Bot" 마크(+`AgentSignalDot`·`AGENT_MARK_FILL_CLASS` 부속 export).

## 에이전트 정체성 9곳 통일 채택
- Bot 텍스트 칩(AgentIdentity 직접) 4곳: `inbox/page.tsx`·`add-participant-modal.tsx`·`chat-bubble.tsx`·`new-conversation-modal.tsx` — 4곳이 복붙해오던 동일 마크업을 단일 정의로 수렴.
- 아바타/아이콘 배경(`AGENT_MARK_FILL_CLASS`) 4곳: `story-card.tsx`·`avatar.tsx`(AI 코너배지)·`trust-seal.tsx`(claimed 아이콘)·`lib/storage/format.ts`의 `avatarColor` 헬퍼(→`avatar.tsx:90` 이니셜 배경 자동 적용).

## KEEP(신호, 회귀 0)
agent dot 자체·`avatar.tsx`의 idle 링·isWorking pulse — 전부 무변경(제거하면 "에이전트임"이 안 읽히는 신호는 색 유지).

## #num 색 — 검토 결과: 변경 없음(재확認 요청)
아티팩트의 "#8D9088(3.1:1 AA미달)→#5f6158" 처방을 독립 계산으로 재검증했다 — 라이트 목업 배경에 다크 토큰값을 얹은 예시 조합으로 보이며, 실제 다크 배경(`--proof-bg #0B0C0D`·`--proof-panel #17191C`)에 대한 WCAG 상대휘도 계산은 5.44~6.04:1로 AA(4.5:1) 여유 통과(story #2917 "다크는 이미 AA 여유" 판정과 일치). 공유 토큰 `--proof-ink-3`(다크)를 무근거로 바꾸면 다른 `text-muted-foreground` 소비처 전반에 회귀 위험이 있어 손대지 않음 — 계산 근거 첨부, 페드루/유나 재확認 요청.

## 검증
- 신규 단위 테스트 8개(`material-primitives.test.tsx`) — soft-fill 클래스 부재 정규식 단언 포함.
- 9곳 채택에 걸린 기존 회귀가드 5개(story #2998/#3000 로드맵, 옛 soft-fill lock)를 새 헤어라인 계약으로 갱신.
- git diff→checkout HEAD(+신규 primitive 4파일 임시 제거)→테스트→git apply 방식으로 pre-fix genuine RED 확認 — 6개 테스트 파일 전부 정확히 실패 후 복원.
- apps/web 전체 회귀 스윕: **505 files/4503 tests 100% pass**. eslint 0·tsc 클린·`pnpm build` EXIT=0.
- 실 vitest DOM 캡처(class 1글자도 안 고침) 클래스 목록을 정확한 토큰 hex로 1:1 치환한 라이트/다크 390px 재현을 [Sprintable 산출물](entity:artifact:73ba7288-b32d-4843-8b34-c25bfad4fc27)로 게시 — ⚠️puppeteer 세션이 이번 세션 내내(3038/3043/3044/3040/3049 전부) 죽어있어 라이브 스크린샷은 카디르군 QA로 위임.

## AC 체크
- [x] 프리미티브 5종 정의+양테마+390px 렌더(단위테스트+정적 재현, 라이브 픽셀은 QA 위임)
- [x] agent 정체성 9곳이 AgentIdentity/AGENT_MARK_FILL_CLASS로 통일 채택
- [x] KEEP agent 신호(dot/마크) 회귀 0 — 전체 스윕 100% pass로 확認
- [ ] 유나 design · 카디르 QA(라이브 픽셀 포함)

## 리뷰 요청
- 유나군 design(#num 색 finding 재확認 부탁)
- 카디르군 QA