### PR TITLE
[SID:3050] 보드/칸반 카테고리 칩 → MaterialChip 채택(2984-S2)

### DIFF
--- a/apps/web/src/components/kanban/kanban-list-view.test.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.test.tsx
@@ -1,0 +1,34 @@
+// story #3050(2984-S2, 유나 design PASS 비차단 finding) — 그룹 헤더 카운트 pill이
+// CountBadge(S1, mono+엠보스 inset)를 쓰고 옛 bg-muted 채움은 안 쓴다.
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import { KanbanListView } from './kanban-list-view';
+import koMessages from '../../../messages/ko.json';
+import type { KanbanStory } from './types';
+
+function story(overrides: Partial<KanbanStory> = {}): KanbanStory {
+  return {
+    id: 's1', title: 'Story', status: 'backlog', story_points: null,
+    ...overrides,
+  } as KanbanStory;
+}
+
+describe('KanbanListView — story #3050 그룹 헤더 카운트 pill', () => {
+  it('CountBadge(mono+엠보스 inset)를 쓰고 bg-muted 채움은 안 쓴다', () => {
+    const markup = renderToStaticMarkup(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <KanbanListView
+          stories={[story({ status: 'backlog' })]}
+          epicMap={{}}
+          memberMap={{}}
+          onStoryClick={() => {}}
+          onChangeStatus={async () => {}}
+        />
+      </NextIntlClientProvider>,
+    );
+    expect(markup).toContain('font-mono');
+    expect(markup).toContain('shadow-[var(--elev-inset)]');
+    expect(markup).not.toContain('rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground');
+  });
+});

--- a/apps/web/src/components/kanban/kanban-list-view.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils';
 import { COLUMNS, type KanbanStory, type KanbanMember, type LineStatusSummary } from './types';
 import { StoryCard } from './story-card';
 import type { LabelData } from '@/components/ui/label-chip';
+import { CountBadge } from '@/components/ui/count-badge';
 
 interface KanbanListViewProps {
   stories: KanbanStory[];
@@ -57,7 +58,9 @@ function StatusGroup({
       >
         {expanded ? <ChevronDown className="size-4 shrink-0" /> : <ChevronRight className="size-4 shrink-0" />}
         <span>{label}</span>
-        <span className="ml-auto rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">{stories.length}</span>
+        {/* story #3050(2984-S2, 유나 design PASS 비차단 finding) — CountBadge(S1) 채택,
+            bg-muted 채움 폐지. */}
+        <CountBadge count={stories.length} className="ml-auto" />
       </button>
 
       {expanded && (

--- a/apps/web/src/components/kanban/story-card.test.tsx
+++ b/apps/web/src/components/kanban/story-card.test.tsx
@@ -98,6 +98,17 @@ describe('StoryCard — story #32dcc294 제목 파싱(카테고리 칩+lead)', (
     expect(markup).toContain('태그 없는 평범한 제목');
   });
 
+  // story #3050(2984-S2) — 카테고리 칩은 MaterialChip(S1, 헤어라인+fill 0)을 쓴다. 옛
+  // bg-muted 채움은 폐지.
+  it('story #3050 — 카테고리 칩이 MaterialChip(헤어라인)을 쓰고 bg-muted 채움은 안 쓴다', () => {
+    const markup = renderKo(
+      <StoryCard story={story({ title: '[Workcell·콘텐츠 ③] goal/DoD 구조화 소스 트랙' })} onClick={() => {}} />,
+    );
+    expect(markup).toContain('border-proof-line');
+    expect(markup).toContain('bg-transparent');
+    expect(markup).not.toContain('bg-muted px-1.5');
+  });
+
   it('story_number가 있으면 #번호가 별도 배지로 렌더되고, 더 이상 제목 문자열에 접두되지 않는다', () => {
     const markup = renderKo(<StoryCard story={story({ title: '번호배지 테스트', story_number: 3018 })} onClick={() => {}} />);
     expect(markup).toContain('#3018');

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -11,6 +11,7 @@ import { Badge } from '@/components/ui/badge';
 import { AlertTriangle, ChevronRight, EyeOff, History, Pause, Rocket, Zap, ZapOff, type LucideIcon } from 'lucide-react';
 import { AGENT_MARK_FILL_CLASS } from '@/components/ui/agent-identity';
 import { LabelChip } from '@/components/ui/label-chip';
+import { MaterialChip } from '@/components/ui/material-chip';
 import { cn } from '@/lib/utils';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { TrustSeal } from '@/components/verify/trust-seal';
@@ -360,9 +361,8 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
             ) : null}
             {categoryTag ? (
               <div className="mb-1.5">
-                <span className="inline-block rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold text-muted-foreground">
-                  {categoryTag}
-                </span>
+                {/* story #3050(2984-S2) — MaterialChip(S1) 채택, bg-muted fill 폐지. */}
+                <MaterialChip>{categoryTag}</MaterialChip>
               </div>
             ) : null}
           </>


### PR DESCRIPTION
## 요약
doc `diff-axis-2984-color-to-material-inventory` §3.1(시안 확定) 채택 스토리. S1(#3049, PR#3470, 이미 merged) 프리미티브를 소비만 한다 — 신규 발명 0.

## SHIFT
- `story-card.tsx` 카테고리 칩(`[태그]` 파싱 결과) — `bg-muted` 채움 → **MaterialChip**(헤어라인, fill 0).
- `story-card.tsx:408` agent 아바타 배경 — 이미 S1(PR#3470)에서 `AGENT_MARK_FILL_CLASS`로 처리 완료 확認(grep 재확認, 이 PR 추가 변경 없음).
- `kanban-list-view.tsx` 그룹 헤더 카운트 pill(`{stories.length}`) — `bg-muted` 채움 → **CountBadge**(mono·엠보스 inset). 유나 design PASS 비차단 finding + 페드루 PO 지시로 amend 반영.

## KEEP(신호, 회귀 0) — 확認만
- `story-card.tsx` agent dot(카드 하단 "에이전트" 라벨의 accent-claim dot) — 무변경.
- `avatar.tsx`의 idle 링·isWorking pulse — 무변경(S1에서 이미 KEEP 확定).

## AC 항목 소실 finding — `kanban-list-view.tsx:51·55·82·83`("Agent active" ping·행 glow/gradient)
grep 전수 확認 결과 이 스토리 등재 시점(2026-08-25 04:34) 이후, 같은 세션에서 앞서 완주한 story #3043(모바일 IA 리팩터, PR#3466, MERGED)가 `kanban-list-view.tsx`의 자체 행 렌더 로직 전체를 걷어내고 `StoryCard` 재사용으로 전환했다(commit `cbd79182a`) — 그 과정에서 "Agent active" ping 애니메이션과 행 glow/gradient가 완전히 제거됐다(별도 대체 없음). `git log -p`로 정확한 삭제 커밋까지 추적 확認 — AC가 지목한 자리 자체가 이제 존재하지 않아, 재검할 대상이 없다.

## 검증
- 신규 회귀가드 2개(`story-card.test.tsx`·`kanban-list-view.test.tsx` 신규) — 카테고리 칩/카운트 pill이 각각 새 재질 클래스를 쓰고 옛 `bg-muted`는 안 쓴다.
- git diff→checkout HEAD→테스트→git apply 방식으로 pre-fix genuine RED 확認(둘 다 정확히 실패 후 복원).
- apps/web 전체 회귀 스윕: **506 files/4519 tests 100% pass**. eslint 0(pre-existing 5개 무관 경고만)·tsc 클린·`pnpm build` EXIT=0.
- 실 컴포넌트(`renderToStaticMarkup`) 방출 클래스를 정확한 토큰 hex로 치환한 라이트/다크 390px 재현을 [Sprintable 산출물](entity:artifact:ebc05a5d-5303-4608-b4c4-0b1fd2a94a54)로 게시 — ⚠️puppeteer 세션이 이번 세션 내내 죽어있어 라이브 스크린샷은 카디르군 QA로 위임.

## AC 체크
- [x] 보드 카드 soft-fill→재질(시안 §3.1 1:1) — 카테고리 칩+그룹 카운트 pill
- [x] KEEP 신호(agent dot·idle 링) 회귀 0 — 전체 스윕 100% pass로 확認
- [x] ping/glow AC 항목 — #3043 리팩터로 이미 소실 확認(finding, 손댈 대상 없음)
- [x] 유나 design PASS(비차단 finding amend 반영)
- [ ] 카디르 QA(라이브 픽셀 포함)

## 리뷰 요청
- 카디르군 QA