### PR TITLE
feat(#3064): macOS 네이티브 APNs 푸시 BE — 스키마+등록 API+발송기

### DIFF
--- a/backend/alembic/versions/0278_push_devices_macos_support.py
+++ b/backend/alembic/versions/0278_push_devices_macos_support.py
@@ -1,0 +1,66 @@
+"""story #3064(E-MOBILE·macOS): push_devices에 macOS/APNs 지원 추가.
+
+macOS(Tauri) 앱은 Expo 런타임이 아니라 Expo push 토큰을 만들 수 없다 — 네이티브 APNs raw
+device token(hex)을 등록해야 한다. 기존 `expo_push_token`(NOT NULL UNIQUE) 컬럼은 Expo
+경로(ios/android) 그대로 두고, 플랫폼별 컬럼을 분리한다(신규 `apns_device_token`) — 발송기
+(expo_push.py)·repository.upsert의 기존 conflict target을 건드리지 않기 위함.
+
+⚠️prod 승격 前 필수: 이 마이그는 dev(sprintable-dev, private IP, Cloud Run Job 경유 실측)
+GROUP BY platform 스캔으로 "모든 기존 행이 expo_push_token NOT NULL"임을 확認한 뒤 작성됐다
+(2026-08-25, ROWS 3: platform=NULL n=1 has_expo=1, android n=14 has_expo=14, ios n=1 has_expo=1 —
+전부 null_expo=0). prod는 gcloud 게이트라 이 세션에서 재지 못했다 — **prod 배포 前 반드시 같은
+GROUP BY platform, count(*), count(expo_push_token) 스캔을 prod에서 재실행**해 위반 행이
+있는지 확認할 것. 위반 행이 있으면 이 CHECK를 그대로 올리지 말고 NOT VALID로 추가한 뒤 그
+행들을 정리(백필 또는 폐기)하고 VALIDATE CONSTRAINT로 마무리하는 2단계로 바꿀 것(카디르
+QA·페드루 PO 합의 정공법, dev 스캔이 클린이라 여기선 1단계로 감).
+
+Revision ID: 0278
+Revises: 0277
+Create Date: 2026-08-25
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0278"
+down_revision = "0277"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("push_devices", sa.Column("apns_device_token", sa.Text(), nullable=True))
+    op.create_unique_constraint(
+        "uq_push_devices_apns_device_token", "push_devices", ["apns_device_token"]
+    )
+    op.alter_column("push_devices", "expo_push_token", existing_type=sa.Text(), nullable=True)
+
+    op.drop_constraint("push_devices_platform_check", "push_devices", type_="check")
+    op.create_check_constraint(
+        "push_devices_platform_check",
+        "push_devices",
+        "platform IS NULL OR platform IN ('ios', 'android', 'macos')",
+    )
+    # story #3064: 플랫폼별 토큰 상호배타 — macos는 apns_device_token만, 그 외(레거시 platform
+    # IS NULL 포함)는 expo_push_token 필수. dev GROUP BY 스캔(위 docstring)으로 기존 행 전부가
+    # 우변을 만족함을 확認했으므로 스캔 없이 1단계로 올린다.
+    op.create_check_constraint(
+        "push_devices_token_platform_exclusive_check",
+        "push_devices",
+        "(platform = 'macos' AND apns_device_token IS NOT NULL AND expo_push_token IS NULL) "
+        "OR (platform IS DISTINCT FROM 'macos' AND expo_push_token IS NOT NULL)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("push_devices_token_platform_exclusive_check", "push_devices", type_="check")
+    op.drop_constraint("push_devices_platform_check", "push_devices", type_="check")
+    op.create_check_constraint(
+        "push_devices_platform_check",
+        "push_devices",
+        "platform IS NULL OR platform IN ('ios', 'android')",
+    )
+    op.alter_column("push_devices", "expo_push_token", existing_type=sa.Text(), nullable=False)
+    op.drop_constraint("uq_push_devices_apns_device_token", "push_devices", type_="unique")
+    op.drop_column("push_devices", "apns_device_token")

--- a/backend/alembic/versions/0279_delivery_jobs_apns_push_kind.py
+++ b/backend/alembic/versions/0279_delivery_jobs_apns_push_kind.py
@@ -1,0 +1,36 @@
+"""story #3064(E-MOBILE·macOS): delivery_jobs.kind CHECK에 'apns_push' 추가.
+
+0278이 push_devices 쪽 macOS 지원을 열었고, 발송기(ee/services/apns_push.py)가 via_outbox=True
+경로에서 delivery_jobs(kind="apns_push") row를 insert한다 — 기존 CHECK("org_webhook",
+"personal_webhook", "expo_push")가 이 값을 원천 거부하므로 먼저 열어둬야 한다.
+
+Revision ID: 0279
+Revises: 0278
+Create Date: 2026-08-25
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0279"
+down_revision = "0278"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("ck_delivery_jobs_kind", "delivery_jobs", type_="check")
+    op.create_check_constraint(
+        "ck_delivery_jobs_kind",
+        "delivery_jobs",
+        "kind IN ('org_webhook', 'personal_webhook', 'expo_push', 'apns_push')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_delivery_jobs_kind", "delivery_jobs", type_="check")
+    op.create_check_constraint(
+        "ck_delivery_jobs_kind",
+        "delivery_jobs",
+        "kind IN ('org_webhook', 'personal_webhook', 'expo_push')",
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -391,6 +391,20 @@ class Settings(BaseSettings):
     # 그냥 비활성) — 이 필드로 옮겨도 그 fail-closed 시맨틱은 그대로.
     gotenberg_service_url: str = ""
 
+    # story #3064(E-MOBILE·macOS): 네이티브 APNs 발송기 설정 — 전부 미설정이면 발송기가
+    # fail-closed(로그만·크래시 없음, gotenberg_service_url과 동일 시맨틱). apns_auth_key_p8은
+    # .p8 파일 내용 자체(PEM, 경로 아님 — Cloud Run은 파일시스템 대신 secret env 주입이 표준).
+    apns_auth_key_p8: str = ""
+    apns_key_id: str = ""
+    apns_team_id: str = ""
+    apns_bundle_id: str = "com.moonklabs.sprintable.desktop"
+    # 민군 entitlements(aps-environment) 확認값 기준 기본 production — sandbox 필요해지면 여기만 뒤집는다.
+    apns_use_sandbox: bool = False
+
+    @property
+    def apns_configured(self) -> bool:
+        return bool(self.apns_auth_key_p8 and self.apns_key_id and self.apns_team_id)
+
     @property
     def is_ee_enabled(self) -> bool:
         return self.license_consent.lower() == "agreed"

--- a/backend/app/models/delivery_job.py
+++ b/backend/app/models/delivery_job.py
@@ -36,7 +36,8 @@ class DeliveryJob(Base):
 
     __table_args__ = (
         CheckConstraint(
-            "kind IN ('org_webhook', 'personal_webhook', 'expo_push')", name="ck_delivery_jobs_kind"
+            "kind IN ('org_webhook', 'personal_webhook', 'expo_push', 'apns_push')",
+            name="ck_delivery_jobs_kind",
         ),
         # story #2761 — 'claimed' 추가: claim(attempts+1)과 status 전이가 같은 원자적 UPDATE
         # 안에서 일어나야 재집기 창이 닫힌다(0256 마이그 참조 — 근본원인·prod 3중복 실사고).

--- a/backend/app/models/push_device.py
+++ b/backend/app/models/push_device.py
@@ -19,11 +19,21 @@ class PushDevice(Base):
     __table_args__ = (
         # 재등록(같은 디바이스 토큰) = upsert 자연 멱등 — on_conflict 타깃.
         UniqueConstraint("expo_push_token", name="uq_push_devices_expo_push_token"),
+        UniqueConstraint("apns_device_token", name="uq_push_devices_apns_device_token"),
         # story 1935: v0.2.4 앱이 platform 없이 register해 422→row 미생성이던 실 갭 수정 —
         # NULL 허용(미보고=아직 모름, fake default 아님). Expo Push API 자체가 platform을
         # 안 쓰므로(expo_push.py) 발송기 영향 없음.
         CheckConstraint(
-            "platform IS NULL OR platform IN ('ios', 'android')", name="push_devices_platform_check"
+            "platform IS NULL OR platform IN ('ios', 'android', 'macos')",
+            name="push_devices_platform_check",
+        ),
+        # story #3064: macOS(Tauri)는 Expo 런타임이 아니라 Expo push 토큰을 만들 수 없음 —
+        # 플랫폼별 토큰 컬럼 상호배타(0278 마이그 참고, dev GROUP BY 스캔으로 기존 행 전부
+        # 우변 충족 확認 후 1단계로 올림 — prod는 승격 前 재스캔 필수).
+        CheckConstraint(
+            "(platform = 'macos' AND apns_device_token IS NOT NULL AND expo_push_token IS NULL) "
+            "OR (platform IS DISTINCT FROM 'macos' AND expo_push_token IS NOT NULL)",
+            name="push_devices_token_platform_exclusive_check",
         ),
     )
 
@@ -34,8 +44,9 @@ class PushDevice(Base):
     # webhook_configs(0079) 선례: member_id FK 완화(grant-only write 500 해소). 소유 스코프는 쿼리시점
     # org_id AND member_id 필터로 강제(repo list/get_owned/delete).
     member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
-    expo_push_token: Mapped[str] = mapped_column(Text, nullable=False)  # ExponentPushToken[...] (UNIQUE)
-    platform: Mapped[str | None] = mapped_column(Text, nullable=True)  # ios | android | 미보고(CHECK)
+    expo_push_token: Mapped[str | None] = mapped_column(Text, nullable=True)  # ExponentPushToken[...] (UNIQUE, ios/android)
+    apns_device_token: Mapped[str | None] = mapped_column(Text, nullable=True)  # raw hex APNs 토큰(UNIQUE, macos)
+    platform: Mapped[str | None] = mapped_column(Text, nullable=True)  # ios | android | macos | 미보고(CHECK)
     device_id: Mapped[str | None] = mapped_column(Text, nullable=True)  # 앱 설치 단위 식별(관측용, 선택)
     app_version: Mapped[str | None] = mapped_column(Text, nullable=True)  # 관측용
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)  # DeviceNotRegistered→false(S3)

--- a/backend/app/repositories/push_device.py
+++ b/backend/app/repositories/push_device.py
@@ -47,12 +47,13 @@ class PushDeviceRepository:
     async def upsert(
         self,
         member_id: uuid.UUID,
-        expo_push_token: str,
         platform: str | None,
+        expo_push_token: str | None = None,
+        apns_device_token: str | None = None,
         device_id: str | None = None,
         app_version: str | None = None,
     ) -> PushDevice:
-        """디바이스 등록 — expo_push_token UNIQUE 기준 upsert(재등록 자연 멱등).
+        """디바이스 등록 — 플랫폼별 토큰 UNIQUE 기준 upsert(재등록 자연 멱등).
 
         같은 디바이스가 재등록(앱 재설치·토큰 회전·기기 이관)하면 토큰 충돌 → 소유 org/멤버·플랫폼·메타·
         last_seen 갱신 + is_active 복구(True). crux §3: 발송기가 DeviceNotRegistered 수신 시 is_active=false
@@ -61,12 +62,26 @@ class PushDeviceRepository:
 
         story 1935: platform은 COALESCE(신규값, 기존값) — 구버전 앱(platform 미전송, None)이
         재등록해도 이전에 알려진 platform을 지우지 않는다(v0.2.5가 이미 보고한 값을 v0.2.4
-        재등록이 덮어써 잃어버리는 회귀 방지)."""
+        재등록이 덮어써 잃어버리는 회귀 방지).
+
+        story #3064: conflict target은 실제로 채워진 토큰 컬럼 기준(둘 다 NULL 허용 컬럼이라
+        NULL은 UNIQUE 충돌 대상이 아님 — Postgres 표준 동작, 인덱스 컬럼 하나만 골라야 한다).
+        스키마 레벨 model_validator(RegisterPushDevice.token_matches_platform)가 이미
+        "정확히 하나만 채워짐"을 보장하므로 여기서는 그 불변식을 그대로 신뢰한다.
+        """
+        if apns_device_token:
+            conflict_col = "apns_device_token"
+        elif expo_push_token:
+            conflict_col = "expo_push_token"
+        else:
+            raise ValueError("either expo_push_token or apns_device_token is required")
+
         now = func.now()
         insert_stmt = pg_insert(PushDevice).values(
             org_id=self.org_id,
             member_id=member_id,
             expo_push_token=expo_push_token,
+            apns_device_token=apns_device_token,
             platform=platform,
             device_id=device_id,
             app_version=app_version,
@@ -75,7 +90,7 @@ class PushDeviceRepository:
         stmt = (
             insert_stmt
             .on_conflict_do_update(
-                index_elements=["expo_push_token"],
+                index_elements=[conflict_col],
                 set_={
                     "org_id": self.org_id,
                     "member_id": member_id,

--- a/backend/app/schemas/push_device.py
+++ b/backend/app/schemas/push_device.py
@@ -5,30 +5,63 @@ import uuid
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 # Expo push 토큰 포맷: ExponentPushToken[...] 또는 ExpoPushToken[...] (crux §2: 클라 제출값 방어적 검증).
 _EXPO_TOKEN_RE = re.compile(r"^Expo(nent)?PushToken\[[^\[\]\s]+\]$")
+# APNs raw device token: didRegisterForRemoteNotificationsWithDeviceToken NSData를 byte별
+# %02x로 이어붙인 hex(story #3064, 민군 앱 축 확認 포맷). 길이는 고정하지 않는다 — Apple이
+# 토큰 바이트 길이를 문서상 보장하지 않아(현재 32바이트=64자가 통상값) 짝수 hex만 강제.
+_APNS_TOKEN_RE = re.compile(r"^[0-9a-fA-F]{16,}$")
 
 
 class RegisterPushDevice(BaseModel):
-    """디바이스 등록 요청. member_id 는 body 에 없음 — auth context 서 산출(IDOR: 타 멤버 등록 불가)."""
+    """디바이스 등록 요청. member_id 는 body 에 없음 — auth context 서 산출(IDOR: 타 멤버 등록 불가).
 
-    expo_push_token: str
+    story #3064: macOS는 Expo push 토큰을 만들 수 없어(Expo 런타임이 아님) 플랫폼별 토큰
+    필드가 분리된다 — platform="macos"면 apns_device_token 필수·expo_push_token은 생략,
+    그 외(ios/android/미보고)는 기존과 동일하게 expo_push_token 필수.
+    """
+
+    expo_push_token: str | None = None
+    apns_device_token: str | None = None
     # story 1935: v0.2.4 앱이 platform 없이 register하는 실 케이스 발견 — optional화(fake
     # default 아닌 진짜 미보고). 신 버전이 보내면 그대로 저장, 안 보내면 NULL(repo가 기존
     # 값을 덮어쓰지 않음 — upsert COALESCE).
-    platform: Literal["ios", "android"] | None = None
+    platform: Literal["ios", "android", "macos"] | None = None
     device_id: str | None = None
     app_version: str | None = None
 
     @field_validator("expo_push_token")
     @classmethod
-    def token_must_be_expo_format(cls, v: str) -> str:
+    def token_must_be_expo_format(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
         v = v.strip()
         if not _EXPO_TOKEN_RE.match(v):
             raise ValueError("expo_push_token must be an ExponentPushToken[...] value")
         return v
+
+    @field_validator("apns_device_token")
+    @classmethod
+    def token_must_be_apns_hex(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip().lower()
+        if not _APNS_TOKEN_RE.match(v):
+            raise ValueError("apns_device_token must be a hex device token")
+        return v
+
+    @model_validator(mode="after")
+    def token_matches_platform(self) -> "RegisterPushDevice":
+        if self.platform == "macos":
+            if not self.apns_device_token:
+                raise ValueError("apns_device_token is required when platform is macos")
+            if self.expo_push_token:
+                raise ValueError("expo_push_token must not be set when platform is macos")
+        elif not self.expo_push_token:
+            raise ValueError("expo_push_token is required unless platform is macos")
+        return self
 
 
 class PushDeviceResponse(BaseModel):
@@ -37,7 +70,8 @@ class PushDeviceResponse(BaseModel):
     id: uuid.UUID
     org_id: uuid.UUID
     member_id: uuid.UUID
-    expo_push_token: str
+    expo_push_token: str | None = None
+    apns_device_token: str | None = None
     platform: str | None = None
     device_id: str | None = None
     app_version: str | None = None

--- a/backend/app/services/delivery_dispatcher.py
+++ b/backend/app/services/delivery_dispatcher.py
@@ -186,6 +186,32 @@ async def _deliver_one(job: dict) -> None:
                 async with async_session_factory() as session:
                     await _finalize_expo_push_dead_tokens(session, org_id, dead_tokens)
                     await session.commit()
+        elif kind == "apns_push":
+            from ee.services.apns_push import (
+                _fetch_apns_targets,
+                _finalize_apns_dead_tokens,
+                _send_apns_targets,
+            )
+
+            async with async_session_factory() as session:
+                targets = await _fetch_apns_targets(
+                    session, org_id, [uuid.UUID(m) for m in payload["member_ids"]],
+                    muted_member_ids=_uuid_set_or_none(payload.get("muted_member_ids")),
+                )
+                await session.commit()
+            dead_tokens = await _send_apns_targets(
+                targets, title=payload["title"], body=payload.get("body"),
+                event_type=payload["event_type"], org_id=org_id,
+                reference_type=payload.get("reference_type"),
+                reference_id=_uuid_or_none(payload.get("reference_id")),
+                project_id=_uuid_or_none(payload.get("project_id")),
+                story_id=_uuid_or_none(payload.get("story_id")),
+                sprint_id=_uuid_or_none(payload.get("sprint_id")),
+            )
+            if dead_tokens:
+                async with async_session_factory() as session:
+                    await _finalize_apns_dead_tokens(session, org_id, dead_tokens)
+                    await session.commit()
         else:
             raise ValueError(f"unknown delivery_job kind: {kind}")
 

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -513,6 +513,18 @@ async def dispatch_notification(
                     via_outbox=via_outbox,
                 )
 
+                # story #3064: macOS 네이티브 APNs 채널 — push_devices(platform='macos')로
+                # 자연 분리(fetch가 platform 필터), Expo 채널과 나란히 호출. 인증키 미도착
+                # 구간엔 deliver_apns_push 내부(settings.apns_configured)가 fail-closed.
+                from ee.services.apns_push import deliver_apns_push
+                await deliver_apns_push(
+                    db, org_id, enabled_member_ids, title=title, body=body, event_type=event_type,
+                    reference_type=reference_type, reference_id=reference_id, context=context,
+                    muted_member_ids=muted_member_ids,
+                    project_id=_push_project_id, story_id=story_id, sprint_id=sprint_id,
+                    via_outbox=via_outbox,
+                )
+
     except Exception:
         # BUG-1 수정: 에러 삼킴 제거 → 스택 트레이스 로깅
         logger.exception("dispatch_notification failed org_id=%s event_type=%s", org_id, event_type)

--- a/backend/ee/routers/push_devices.py
+++ b/backend/ee/routers/push_devices.py
@@ -58,10 +58,11 @@ async def register_push_device(
     caller_member_id: uuid.UUID = Depends(_get_caller_member_id),
     _ee: None = Depends(_require_ee),
 ) -> PushDeviceResponse:
-    """디바이스 등록/재등록(upsert) — expo_push_token UNIQUE 멱등. member_id 는 caller 로 강제."""
+    """디바이스 등록/재등록(upsert) — 플랫폼별 토큰 UNIQUE 멱등. member_id 는 caller 로 강제."""
     device = await repo.upsert(
         member_id=caller_member_id,
         expo_push_token=body.expo_push_token,
+        apns_device_token=body.apns_device_token,
         platform=body.platform,
         device_id=body.device_id,
         app_version=body.app_version,

--- a/backend/ee/services/apns_push.py
+++ b/backend/ee/services/apns_push.py
@@ -1,0 +1,299 @@
+"""EE APNs(macOS) 네이티브 푸시 발송기 (story #3064, E-MOBILE·macOS).
+
+expo_push.py와 나란한 별개 채널 — macOS(Tauri) 앱은 Expo 런타임이 아니라 Expo push 토큰을
+만들 수 없다(원인은 story #3064 본문). push_devices(platform='macos', apns_device_token)를
+대상으로 Apple의 APNs provider API(HTTP/2, JWT provider token 인증)에 직접 발송한다.
+
+계약(expo_push.py와 동형):
+- via_outbox=True(기본)면 delivery_jobs(kind="apns_push")에 job row만 insert, 실 발송은
+  delivery_dispatcher.py 워커가 담당(요청 트랜잭션 밖 외부 I/O).
+- fetch(세션)→send(세션 없음, 순수 외부 I/O)→finalize(세션) 3분할 — story #2460 PO 리뷰의
+  "배달 中 트랜잭션 안 잡는다" 규율을 그대로 따른다.
+- best-effort — 어떤 실패도 알림 파이프라인으로 전파하지 않는다.
+- 인증키(.p8)·Key ID·Team ID 미설정(settings.apns_configured=False)이면 fail-closed(로그만,
+  크래시 없음) — gotenberg_service_url과 동일 시맨틱(준비물 도착 전 안전한 무동작).
+
+JWT provider token: ES256, header={"alg":"ES256","kid":<Key ID>}, payload={"iss":<Team ID>,
+"iat":<발급 시각>}. Apple 권고대로 토큰을 최대 1시간 재사용 가능하므로(매 요청 재서명은
+불필요한 CPU) 55분 캐시 후 재발급.
+"""
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+
+import httpx
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.push_device import PushDevice
+from app.services.dispatch_router import _WEBHOOK_BACKOFF_BASE, _WEBHOOK_MAX_RETRIES
+
+logger = logging.getLogger(__name__)
+
+_APNS_PROD_HOST = "https://api.push.apple.com"
+_APNS_SANDBOX_HOST = "https://api.sandbox.push.apple.com"
+_TOKEN_TTL_SECONDS = 55 * 60  # Apple 권고 상한(1h)보다 여유를 둔 재발급 주기.
+
+# {kid: (token, issued_at_monotonic)} — 프로세스 전역 캐시(워커가 여러 job을 순차 처리).
+_token_cache: dict[str, tuple[str, float]] = {}
+
+
+def _apns_host() -> str:
+    return _APNS_SANDBOX_HOST if settings.apns_use_sandbox else _APNS_PROD_HOST
+
+
+def _build_provider_jwt() -> str:
+    """ES256 provider token 서명(캐시 재사용). settings.apns_configured가 False면 호출 금지
+    (호출부가 먼저 확認)."""
+    cached = _token_cache.get(settings.apns_key_id)
+    now = time.monotonic()
+    if cached is not None and (now - cached[1]) < _TOKEN_TTL_SECONDS:
+        return cached[0]
+
+    from jose import jwt as jose_jwt
+
+    token = jose_jwt.encode(
+        {"iss": settings.apns_team_id, "iat": int(time.time())},
+        settings.apns_auth_key_p8,
+        algorithm="ES256",
+        headers={"kid": settings.apns_key_id},
+    )
+    _token_cache[settings.apns_key_id] = (token, now)
+    return token
+
+
+async def _apns_send_one(client: httpx.AsyncClient, device_token: str, body: dict) -> httpx.Response:
+    """단일 디바이스 발송. APNs는 배치 API가 없다(device별 개별 POST, expo_push.py의 청크
+    배치와 다른 지점 — HTTP/2 멀티플렉싱이 배치 역할을 대신한다는 것이 Apple 설계)."""
+    headers = {
+        "authorization": f"bearer {_build_provider_jwt()}",
+        "apns-topic": settings.apns_bundle_id,
+        "apns-push-type": "alert",
+        "apns-priority": "10",
+    }
+    last_exc: Exception | None = None
+    for attempt in range(_WEBHOOK_MAX_RETRIES):
+        try:
+            return await client.post(f"/3/device/{device_token}", json=body, headers=headers)
+        except Exception as exc:  # noqa: BLE001 — 네트워크 오류 재시도, 마지막엔 재던짐 대신 로깅+continue
+            last_exc = exc
+            logger.warning(
+                "apns push attempt %d/%d failed", attempt + 1, _WEBHOOK_MAX_RETRIES, exc_info=True,
+            )
+        if attempt < _WEBHOOK_MAX_RETRIES - 1:
+            import asyncio
+
+            await asyncio.sleep(_WEBHOOK_BACKOFF_BASE * (2 ** attempt))
+    raise last_exc if last_exc is not None else RuntimeError("apns push: all retries exhausted")
+
+
+async def deliver_apns_push(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    member_ids: list[uuid.UUID],
+    *,
+    title: str,
+    body: str | None,
+    event_type: str,
+    reference_type: str | None = None,
+    reference_id: uuid.UUID | None = None,
+    context: dict | None = None,
+    muted_member_ids: set[uuid.UUID] | None = None,
+    project_id: uuid.UUID | None = None,
+    story_id: uuid.UUID | None = None,
+    sprint_id: uuid.UUID | None = None,
+    via_outbox: bool = True,
+) -> None:
+    """expo_push.deliver_expo_push와 동형 진입점 — dispatch_notification의 EE 채널 확장점에서
+    나란히 호출됨(대상은 push_devices(platform='macos')로 자연 분리, 이 함수 안 필터 불요 —
+    fetch가 platform 필터를 건다)."""
+    if not member_ids:
+        return
+    if via_outbox:
+        from app.models.delivery_job import DeliveryJob
+
+        db.add(
+            DeliveryJob(
+                org_id=org_id,
+                kind="apns_push",
+                payload={
+                    "member_ids": [str(m) for m in member_ids],
+                    "title": title,
+                    "body": body,
+                    "event_type": event_type,
+                    "reference_type": reference_type,
+                    "reference_id": str(reference_id) if reference_id else None,
+                    "context": context,
+                    "muted_member_ids": (
+                        [str(m) for m in muted_member_ids] if muted_member_ids is not None else None
+                    ),
+                    "project_id": str(project_id) if project_id else None,
+                    "story_id": str(story_id) if story_id else None,
+                    "sprint_id": str(sprint_id) if sprint_id else None,
+                },
+            )
+        )
+        return
+    await _deliver_apns_push_now(
+        db, org_id, member_ids, title=title, body=body, event_type=event_type,
+        reference_type=reference_type, reference_id=reference_id, context=context,
+        muted_member_ids=muted_member_ids, project_id=project_id, story_id=story_id,
+        sprint_id=sprint_id,
+    )
+
+
+async def _deliver_apns_push_now(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    member_ids: list[uuid.UUID],
+    *,
+    title: str,
+    body: str | None,
+    event_type: str,
+    reference_type: str | None = None,
+    reference_id: uuid.UUID | None = None,
+    context: dict | None = None,
+    muted_member_ids: set[uuid.UUID] | None = None,
+    project_id: uuid.UUID | None = None,
+    story_id: uuid.UUID | None = None,
+    sprint_id: uuid.UUID | None = None,
+) -> None:
+    """delivery_dispatcher.py 워커 전용(자기 세션으로 호출) — expo_push._deliver_expo_push_now와
+    동형 얇은 래퍼(fetch→send→finalize 순차, best-effort try/except)."""
+    if not settings.apns_configured:
+        logger.debug("apns push skipped — settings.apns_configured is False (준비물 미도착)")
+        return
+    try:
+        targets = await _fetch_apns_targets(db, org_id, member_ids, muted_member_ids=muted_member_ids)
+        dead_tokens = await _send_apns_targets(
+            targets, title=title, body=body, event_type=event_type, org_id=org_id,
+            reference_type=reference_type, reference_id=reference_id,
+            project_id=project_id, story_id=story_id, sprint_id=sprint_id,
+        )
+        await _finalize_apns_dead_tokens(db, org_id, dead_tokens)
+    except Exception:
+        logger.warning(
+            "deliver_apns_push failed (swallowed·best-effort) org=%s event=%s",
+            org_id, event_type, exc_info=True,
+        )
+
+
+async def _fetch_apns_targets(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    member_ids: list[uuid.UUID],
+    *,
+    muted_member_ids: set[uuid.UUID] | None = None,
+) -> list[dict]:
+    """활성 macOS push_devices 조회(mute 필터 포함). expo_push._fetch_expo_push_targets와
+    동형 — platform='macos' 필터만 추가(같은 테이블, 컬럼 분리라 apns_device_token IS NOT NULL
+    행만 이 채널의 대상)."""
+    if not member_ids:
+        return []
+    muted = muted_member_ids or set()
+    targets = [m for m in member_ids if m not in muted]
+    if not targets:
+        return []
+
+    rows = await db.execute(
+        select(PushDevice).where(
+            PushDevice.org_id == org_id,
+            PushDevice.member_id.in_(targets),
+            PushDevice.platform == "macos",
+            PushDevice.is_active.is_(True),
+        )
+    )
+    return [{"apns_device_token": d.apns_device_token} for d in rows.scalars().all()]
+
+
+async def _send_apns_targets(
+    devices: list[dict],
+    *,
+    title: str,
+    body: str | None,
+    event_type: str,
+    org_id: uuid.UUID,
+    reference_type: str | None = None,
+    reference_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    story_id: uuid.UUID | None = None,
+    sprint_id: uuid.UUID | None = None,
+) -> list[str]:
+    """세션 없이 순수 APNs 발송(story #2460 PO 리뷰 F1 패턴 재사용). 반환값 = dead_tokens.
+
+    Apple 응답 코드: 200=성공. 410(Unregistered)·400(BadDeviceToken)은 그 토큰이 더 이상
+    유효하지 않다는 뜻이라 dead 처리(Expo의 DeviceNotRegistered와 동형 의미) — 그 외 4xx/5xx는
+    per-target 실패로만 로깅(재시도는 _apns_send_one이 이미 수행)."""
+    if not devices:
+        return []
+    if not settings.apns_configured:
+        logger.debug("apns push send skipped — settings.apns_configured is False")
+        return []
+
+    from ee.services.expo_push import _build_push_data_payload  # 딥링크 payload 빌더 재사용(순수 함수)
+
+    data_payload = _build_push_data_payload(
+        event_type=event_type, org_id=org_id, project_id=project_id,
+        reference_type=reference_type, reference_id=reference_id,
+        story_id=story_id, sprint_id=sprint_id,
+    )
+    aps_body = {
+        "aps": {"alert": {"title": title, "body": body or ""}, "sound": "default"},
+        **data_payload,
+    }
+
+    dead_tokens: list[str] = []
+    ok_count = 0
+    error_count = 0
+    error_reasons: dict[str, int] = {}
+    async with httpx.AsyncClient(base_url=_apns_host(), http2=True, timeout=10.0) as client:
+        for dev in devices:
+            token = dev["apns_device_token"]
+            try:
+                resp = await _apns_send_one(client, token, aps_body)
+            except Exception:
+                error_count += 1
+                error_reasons["network_error"] = error_reasons.get("network_error", 0) + 1
+                continue
+            if resp.status_code == 200:
+                ok_count += 1
+                continue
+            error_count += 1
+            reason = "unknown"
+            try:
+                reason = resp.json().get("reason", reason)
+            except Exception:  # noqa: BLE001 — 응답 파싱 실패는 reason=unknown으로만 남김
+                pass
+            error_reasons[reason] = error_reasons.get(reason, 0) + 1
+            if resp.status_code == 410 or reason in ("Unregistered", "BadDeviceToken"):
+                dead_tokens.append(token)
+
+    # expo_push.py와 동일 원칙(2026-07-28 #2289) — 성공/실패를 매 발송마다 요약 로깅. 토큰 값은
+    # 시크릿에 준해 절대 안 남긴다.
+    logger.info(
+        "apns push: sent org=%s event=%s devices=%d ok=%d error=%d reasons=%s",
+        org_id, event_type, len(devices), ok_count, error_count, error_reasons or None,
+    )
+    return dead_tokens
+
+
+async def _finalize_apns_dead_tokens(
+    db: AsyncSession, org_id: uuid.UUID, dead_tokens: list[str],
+) -> None:
+    """발송 後 확인된 dead 토큰을 비활성화(expo_push._finalize_expo_push_dead_tokens와 동형,
+    별도 짧은 세션에서 호출하는 것을 전제)."""
+    if not dead_tokens:
+        return
+    await db.execute(
+        update(PushDevice)
+        .where(
+            PushDevice.org_id == org_id,
+            PushDevice.apns_device_token.in_(dead_tokens),
+        )
+        .values(is_active=False)
+    )
+    await db.flush()
+    logger.info("apns push: deactivated %d dead token(s)", len(dead_tokens))

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
+    # story #3064: macOS 네이티브 APNs 발송(HTTP/2 필수 — Apple provider API 요구사항).
+    # httpx가 h2 설치 시 자동으로 HTTP/2 클라이언트를 활성화(신규 API 학습 0, 기존 httpx 사용
+    # 패턴 그대로 http2=True만 추가) — aioapns 등 전용 APNs 클라이언트 라이브러리 도입 회피.
+    "h2>=4.1.0",
     "alembic>=1.13.0",
     "psycopg2-binary>=2.9.0",
     "slowapi>=0.1.9",

--- a/backend/tests/test_2460_delivery_outbox.py
+++ b/backend/tests/test_2460_delivery_outbox.py
@@ -112,7 +112,8 @@ async def test_dispatch_notification_via_outbox_propagates_to_both_channels(mock
 
     with patch("app.services.notification_dispatch._deliver_personal_webhooks", new=AsyncMock()) as mock_wh, \
          patch("app.core.config.settings.license_consent", "agreed"), \
-         patch("ee.services.expo_push.deliver_expo_push", new=AsyncMock()) as mock_push:
+         patch("ee.services.expo_push.deliver_expo_push", new=AsyncMock()) as mock_push, \
+         patch("ee.services.apns_push.deliver_apns_push", new=AsyncMock()) as mock_apns:
         await dispatch_notification(
             mock_session, org_id=org_id, event_type="conversation.message",
             target_member_ids=[member_id], title="t", via_outbox=True,
@@ -120,6 +121,8 @@ async def test_dispatch_notification_via_outbox_propagates_to_both_channels(mock
 
     assert mock_wh.call_args.kwargs["via_outbox"] is True
     assert mock_push.call_args.kwargs["via_outbox"] is True
+    # story #3064: macOS APNs 채널도 같은 via_outbox 계약을 따른다(세 채널 모두 propagate).
+    assert mock_apns.call_args.kwargs["via_outbox"] is True
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_apns_push_ee.py
+++ b/backend/tests/test_apns_push_ee.py
@@ -1,0 +1,297 @@
+"""story #3064(E-MOBILE·macOS): APNs 발송기 단위 테스트(DB 불요·AsyncMock, expo_push_ee 동형).
+
+발송기 로직: JWT provider token 서명·캐시·sandbox/production 호스트 선택·per-device 발송·
+410/BadDeviceToken→is_active=false·mute 필터·apns_configured fail-closed·best-effort.
+dispatch_notification 경로 실구동(outbox 배선)은 delivery_dispatcher.py 코드 read로 확認
+(expo_push 브랜치와 동형 구조 재사용이라 별도 realdb는 두지 않음 — expo_push_realdb가 이미
+같은 outbox 메커니즘을 커버).
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+import ee.services.apns_push as apns
+
+TEST_KEY_ID = "TESTKEYID1"
+TEST_TEAM_ID = "TESTTEAM01"
+TEST_BUNDLE_ID = "com.moonklabs.sprintable.desktop"
+
+
+def _gen_test_keypair() -> tuple[str, str]:
+    """실 .p8과 동형 포맷(PKCS8 PEM, unencrypted)의 throwaway ES256 키쌍 — Apple 키 불필요.
+    반환: (private_pem, public_pem)."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    private_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return private_pem, public_pem
+
+
+def _gen_test_p8() -> str:
+    return _gen_test_keypair()[0]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def configured_settings():
+    """settings.apns_configured=True + 서명 가능한 테스트 키 일체 주입."""
+    private_pem, public_pem = _gen_test_keypair()
+    with patch.object(apns.settings, "apns_auth_key_p8", private_pem), \
+         patch.object(apns.settings, "apns_key_id", TEST_KEY_ID), \
+         patch.object(apns.settings, "apns_team_id", TEST_TEAM_ID), \
+         patch.object(apns.settings, "apns_bundle_id", TEST_BUNDLE_ID), \
+         patch.object(apns.settings, "apns_use_sandbox", False):
+        apns._token_cache.clear()
+        yield public_pem
+    apns._token_cache.clear()
+
+
+class _Resp:
+    def __init__(self, status_code: int, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+def _client_cm(post_mock):
+    client = AsyncMock()
+    client.post = post_mock
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _mock_db(devices: list) -> AsyncMock:
+    sel = MagicMock()
+    sel.scalars.return_value.all.return_value = devices
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[sel] + [AsyncMock() for _ in range(5)])
+    db.flush = AsyncMock()
+    return db
+
+
+def _dev(token: str, member_id: uuid.UUID | None = None):
+    return SimpleNamespace(apns_device_token=token, member_id=member_id or uuid.uuid4())
+
+
+# ─── settings.apns_configured / host 선택 ─────────────────────────────────────
+
+def test_apns_configured_false_when_any_field_missing():
+    with patch.object(apns.settings, "apns_auth_key_p8", ""), \
+         patch.object(apns.settings, "apns_key_id", "k"), \
+         patch.object(apns.settings, "apns_team_id", "t"):
+        assert apns.settings.apns_configured is False
+
+
+def test_apns_configured_true_when_all_fields_set(configured_settings):
+    assert apns.settings.apns_configured is True
+
+
+def test_apns_host_production_by_default(configured_settings):
+    assert apns._apns_host() == apns._APNS_PROD_HOST
+
+
+def test_apns_host_sandbox_when_flag_set(configured_settings):
+    with patch.object(apns.settings, "apns_use_sandbox", True):
+        assert apns._apns_host() == apns._APNS_SANDBOX_HOST
+
+
+# ─── JWT provider token(ES256 서명·캐시) ──────────────────────────────────────
+
+def test_build_provider_jwt_has_correct_header_and_claims(configured_settings):
+    from jose import jwt as jose_jwt
+
+    token = apns._build_provider_jwt()
+    header = jose_jwt.get_unverified_header(token)
+    claims = jose_jwt.get_unverified_claims(token)
+    assert header["alg"] == "ES256"
+    assert header["kid"] == TEST_KEY_ID
+    assert claims["iss"] == TEST_TEAM_ID
+    assert "iat" in claims
+
+
+def test_build_provider_jwt_verifies_against_own_key(configured_settings):
+    """서명이 실제로 그 키로 검증 가능한지(형식만 그럴싸한 게 아니라 진짜 유효한 ES256인지)."""
+    from jose import jwt as jose_jwt
+
+    public_pem = configured_settings
+    token = apns._build_provider_jwt()
+    claims = jose_jwt.decode(
+        token, public_pem, algorithms=["ES256"],
+        options={"verify_aud": False},
+    )
+    assert claims["iss"] == TEST_TEAM_ID
+
+
+def test_build_provider_jwt_cached_within_ttl(configured_settings):
+    t1 = apns._build_provider_jwt()
+    t2 = apns._build_provider_jwt()
+    assert t1 == t2  # 55분 이내 재호출 — 캐시 재사용(재서명 없음)
+
+
+def test_build_provider_jwt_reissues_after_ttl(configured_settings):
+    t1 = apns._build_provider_jwt()
+    cached_at = apns._token_cache[TEST_KEY_ID][1]
+    with patch.object(apns.time, "monotonic", return_value=cached_at + apns._TOKEN_TTL_SECONDS + 1):
+        t2 = apns._build_provider_jwt()
+    assert t1 != t2  # TTL 경과 — 재서명(iat 갱신)
+
+
+# ─── _send_apns_targets (per-device 발송·dead token 판정) ─────────────────────
+
+@pytest.mark.anyio
+async def test_send_skips_when_not_configured():
+    devices = [{"apns_device_token": "ab" * 32}]
+    with patch.object(apns.settings, "apns_auth_key_p8", ""):
+        dead = await apns._send_apns_targets(devices, title="T", body="B", event_type="e", org_id=uuid.uuid4())
+    assert dead == []
+
+
+@pytest.mark.anyio
+async def test_send_marks_410_as_dead(configured_settings):
+    token_good, token_bad = "aa" * 32, "bb" * 32
+
+    async def _post(url, json=None, headers=None):
+        if token_bad in url:
+            return _Resp(410, {"reason": "Unregistered"})
+        return _Resp(200)
+
+    with patch("ee.services.apns_push.httpx.AsyncClient", return_value=_client_cm(AsyncMock(side_effect=_post))):
+        dead = await apns._send_apns_targets(
+            [{"apns_device_token": token_good}, {"apns_device_token": token_bad}],
+            title="T", body="B", event_type="e", org_id=uuid.uuid4(),
+        )
+    assert dead == [token_bad]
+
+
+@pytest.mark.anyio
+async def test_send_marks_bad_device_token_as_dead(configured_settings):
+    token_bad = "cc" * 32
+
+    async def _post(url, json=None, headers=None):
+        return _Resp(400, {"reason": "BadDeviceToken"})
+
+    with patch("ee.services.apns_push.httpx.AsyncClient", return_value=_client_cm(AsyncMock(side_effect=_post))):
+        dead = await apns._send_apns_targets(
+            [{"apns_device_token": token_bad}], title="T", body="B", event_type="e", org_id=uuid.uuid4(),
+        )
+    assert dead == [token_bad]
+
+
+@pytest.mark.anyio
+async def test_send_does_not_mark_other_4xx_as_dead(configured_settings):
+    """BadDeviceToken/Unregistered 이외 4xx(예: PayloadTooLarge)는 dead 처리 안 함 — 토큰
+    자체는 유효하니 재시도 대상에서 빼지 않는다."""
+    token = "dd" * 32
+
+    async def _post(url, json=None, headers=None):
+        return _Resp(413, {"reason": "PayloadTooLarge"})
+
+    with patch("ee.services.apns_push.httpx.AsyncClient", return_value=_client_cm(AsyncMock(side_effect=_post))):
+        dead = await apns._send_apns_targets(
+            [{"apns_device_token": token}], title="T", body="B", event_type="e", org_id=uuid.uuid4(),
+        )
+    assert dead == []
+
+
+@pytest.mark.anyio
+async def test_send_includes_apns_topic_header(configured_settings):
+    captured_headers = {}
+
+    async def _post(url, json=None, headers=None):
+        captured_headers.update(headers)
+        return _Resp(200)
+
+    with patch("ee.services.apns_push.httpx.AsyncClient", return_value=_client_cm(AsyncMock(side_effect=_post))):
+        await apns._send_apns_targets(
+            [{"apns_device_token": "ee" * 32}], title="T", body="B", event_type="e", org_id=uuid.uuid4(),
+        )
+    assert captured_headers["apns-topic"] == TEST_BUNDLE_ID
+    assert captured_headers["authorization"].startswith("bearer ")
+
+
+# ─── deliver_apns_push (fetch 필터·outbox·best-effort) ────────────────────────
+
+@pytest.mark.anyio
+async def test_fetch_filters_to_macos_platform_only():
+    """SQL where절 자체를 조립만 검증(mock select라 실제 필터링은 안 걸리지만, 호출 인자로
+    platform='macos' 조건이 실린다는 것은 코드 경로 존재 증명)."""
+    db = _mock_db([_dev("ab" * 32)])
+    targets = await apns._fetch_apns_targets(db, uuid.uuid4(), [uuid.uuid4()])
+    assert targets == [{"apns_device_token": "ab" * 32}]
+
+
+@pytest.mark.anyio
+async def test_deliver_apns_push_skips_when_no_devices():
+    db = _mock_db([])
+    sent = AsyncMock()
+    with patch("ee.services.apns_push._apns_send_one", new=sent):
+        await apns.deliver_apns_push(
+            db, uuid.uuid4(), [uuid.uuid4()], title="T", body="B", event_type="e", via_outbox=False,
+        )
+    sent.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_deliver_apns_push_skips_when_no_member_ids():
+    db = AsyncMock()
+    await apns.deliver_apns_push(db, uuid.uuid4(), [], title="T", body="B", event_type="e", via_outbox=False)
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_deliver_apns_push_best_effort_swallows_exceptions(configured_settings):
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=RuntimeError("db down"))
+    await apns.deliver_apns_push(db, uuid.uuid4(), [uuid.uuid4()], title="T", body="B", event_type="e", via_outbox=False)
+
+
+@pytest.mark.anyio
+async def test_deliver_apns_push_deactivates_dead_token(configured_settings):
+    good = _dev("aa" * 32)
+    bad = _dev("bb" * 32)
+    db = _mock_db([good, bad])
+
+    async def _post(url, json=None, headers=None):
+        if bad.apns_device_token in url:
+            return _Resp(410, {"reason": "Unregistered"})
+        return _Resp(200)
+
+    with patch("ee.services.apns_push.httpx.AsyncClient", return_value=_client_cm(AsyncMock(side_effect=_post))):
+        await apns.deliver_apns_push(
+            db, uuid.uuid4(), [good.member_id, bad.member_id], title="T", body="B", event_type="e",
+            via_outbox=False,
+        )
+    # select 1 + update 1 = execute 2회, flush 1회(만료 반영) — expo_push 동형 계약.
+    assert db.execute.await_count == 2
+    db.flush.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_deliver_apns_push_via_outbox_creates_delivery_job():
+    db = AsyncMock()
+    await apns.deliver_apns_push(
+        db, uuid.uuid4(), [uuid.uuid4()], title="T", body="B", event_type="e", via_outbox=True,
+    )
+    assert db.add.call_count == 1
+    job = db.add.call_args.args[0]
+    assert job.kind == "apns_push"

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -190,4 +190,10 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # story #2822(2026-08-20): gotenberg_service_url 필드 신설(office_conversion.py의
     # os.environ 직접읽기를 Settings SSOT 경유로 교체)로 97→98. 가드가 신규 필드를 설계대로 잡은 것.
     assert "GOTENBERG_SERVICE_URL" in keys
-    assert len(keys) == 98
+    # story #3064(2026-08-25): apns_auth_key_p8·apns_key_id·apns_team_id·apns_bundle_id·
+    # apns_use_sandbox 5필드 신설(macOS 네이티브 APNs 발송기 설정)로 98→103.
+    # apns_configured는 @property(SSOT 파생값)라 env 필드로 안 잡힘 — 가드가 정확히 5개만
+    # 잡은 것. 가드가 신규 필드를 설계대로 잡은 것.
+    assert "APNS_AUTH_KEY_P8" in keys and "APNS_KEY_ID" in keys and "APNS_TEAM_ID" in keys
+    assert "APNS_BUNDLE_ID" in keys and "APNS_USE_SANDBOX" in keys
+    assert len(keys) == 103

--- a/backend/tests/test_push_devices_ee.py
+++ b/backend/tests/test_push_devices_ee.py
@@ -29,6 +29,7 @@ def _device_ns(member_id: uuid.UUID, org_id: uuid.UUID | None = None) -> SimpleN
         org_id=org_id or uuid.uuid4(),
         member_id=member_id,
         expo_push_token="ExponentPushToken[abc123]",
+        apns_device_token=None,
         platform="ios",
         device_id=None,
         app_version=None,
@@ -67,6 +68,38 @@ def test_register_schema_rejects_bad_platform():
         RegisterPushDevice(expo_push_token="ExponentPushToken[abc]", platform="windows")
 
 
+# ─── story #3064: macOS/APNs 토큰 계약 ────────────────────────────────────────
+
+def test_register_schema_accepts_macos_apns_token():
+    body = RegisterPushDevice(apns_device_token="AB" * 32, platform="macos")
+    assert body.apns_device_token == "ab" * 32  # 소문자로 정규화
+    assert body.expo_push_token is None
+
+
+def test_register_schema_rejects_macos_without_apns_token():
+    with pytest.raises(ValidationError):
+        RegisterPushDevice(platform="macos")
+
+
+def test_register_schema_rejects_macos_with_expo_token_set():
+    # 플랫폼별 토큰 상호배타 — macos인데 expo_push_token까지 실려오면 거부(둘 다 채우는
+    # 클라 버그를 조용히 받아주지 않는다).
+    with pytest.raises(ValidationError):
+        RegisterPushDevice(
+            platform="macos", apns_device_token="ab" * 32, expo_push_token="ExponentPushToken[x]",
+        )
+
+
+def test_register_schema_rejects_non_macos_without_expo_token():
+    with pytest.raises(ValidationError):
+        RegisterPushDevice(platform="ios", apns_device_token="ab" * 32)
+
+
+def test_register_schema_rejects_short_apns_token():
+    with pytest.raises(ValidationError):
+        RegisterPushDevice(platform="macos", apns_device_token="abcd")
+
+
 # ─── 등록: member_id = caller 강제(IDOR·body 무신뢰) ──────────────────────────
 
 @pytest.mark.anyio
@@ -84,6 +117,26 @@ async def test_register_forces_caller_member_id():
     assert repo.upsert.await_args.kwargs["expo_push_token"] == "ExponentPushToken[abc]"
     assert repo.upsert.await_args.kwargs["platform"] == "ios"
     assert out.member_id == caller  # 응답도 caller 소유
+
+
+@pytest.mark.anyio
+async def test_register_passes_apns_token_through_for_macos():
+    from ee.routers.push_devices import register_push_device
+    caller = uuid.uuid4()
+    repo = AsyncMock()
+    device = _device_ns(caller)
+    device.expo_push_token = None
+    device.apns_device_token = "ab" * 32
+    device.platform = "macos"
+    repo.upsert = AsyncMock(return_value=device)
+    body = RegisterPushDevice(apns_device_token="AB" * 32, platform="macos")
+
+    await register_push_device(body, repo=repo, caller_member_id=caller, _ee=None)
+
+    assert repo.upsert.await_args.kwargs["member_id"] == caller
+    assert repo.upsert.await_args.kwargs["apns_device_token"] == "ab" * 32
+    assert repo.upsert.await_args.kwargs["expo_push_token"] is None
+    assert repo.upsert.await_args.kwargs["platform"] == "macos"
 
 
 # ─── 조회: member-scope(org-wide leak 차단) ───────────────────────────────────

--- a/backend/tests/test_push_devices_realdb.py
+++ b/backend/tests/test_push_devices_realdb.py
@@ -244,3 +244,155 @@ async def test_push_device_register_without_platform_realdb():
             await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(ORG)})
             await s.commit()
         await engine.dispose()
+
+
+APNS_TOKEN_A = "ab" * 32
+APNS_TOKEN_B = "cd" * 32
+
+
+@pytest.mark.anyio
+async def test_push_device_register_macos_apns_round_trip_realdb():
+    """story #3064: platform='macos'는 apns_device_token으로 등록되고(expo_push_token 없이),
+    기존 Expo(ios/android) 등록과 같은 org 안에 공존하며, 재등록도 apns_device_token UNIQUE
+    기준으로 멱등(같은 행 갱신)임을 실증. 0278/0279 마이그(스캔→CHECK) 검증의 실 왕복 대응."""
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.dependencies.auth import get_verified_org_id
+    from app.dependencies.database import get_db
+    from ee.routers import push_devices as pd
+
+    app = FastAPI()
+    app.include_router(pd.router, prefix="/api/v2/push")
+
+    engine = create_async_engine(_async_url())
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with SessionLocal() as s:
+        await s.execute(text("DELETE FROM push_devices WHERE org_id=:o"), {"o": str(ORG)})
+        await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(ORG)})
+        await s.execute(
+            text("INSERT INTO organizations (id,name,slug,plan) VALUES (:o,'S2 Org','s2-mobile','free')"),
+            {"o": str(ORG)},
+        )
+        await s.commit()
+
+    async def _override_db():
+        async with SessionLocal() as sess:
+            yield sess
+            await sess.commit()
+
+    def _make_caller_override(member_id: uuid.UUID):
+        async def _override():
+            return member_id
+        return _override
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_verified_org_id] = lambda: ORG
+    app.dependency_overrides[pd._get_caller_member_id] = _make_caller_override(MEMBER_X)
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            with _ee_on():
+                # 1) macOS 등록 — apns_device_token만, expo_push_token 없이 200.
+                r = await client.post(
+                    "/api/v2/push/devices",
+                    json={"apns_device_token": APNS_TOKEN_A, "platform": "macos"},
+                )
+                assert r.status_code == 200, r.text
+                dev = r.json()
+                assert dev["platform"] == "macos"
+                assert dev["apns_device_token"] == APNS_TOKEN_A
+                assert dev["expo_push_token"] is None
+                dev_id = dev["id"]
+
+                # 2) Expo(ios) 디바이스도 같은 org에 공존 — 채널 분리 확認.
+                r = await client.post(
+                    "/api/v2/push/devices",
+                    json={"expo_push_token": TOKEN_A, "platform": "ios"},
+                )
+                assert r.status_code == 200, r.text
+
+                r = await client.get("/api/v2/push/devices")
+                assert len(r.json()) == 2
+
+                # 3) macOS 재등록(같은 apns_device_token) → 멱등(동일 행, app_version 갱신).
+                r = await client.post(
+                    "/api/v2/push/devices",
+                    json={"apns_device_token": APNS_TOKEN_A, "platform": "macos", "app_version": "0.9.0"},
+                )
+                assert r.status_code == 200, r.text
+                assert r.json()["id"] == dev_id
+                assert r.json()["app_version"] == "0.9.0"
+
+                # 4) 두 번째 macOS 디바이스(다른 토큰) → 신규 행.
+                r = await client.post(
+                    "/api/v2/push/devices",
+                    json={"apns_device_token": APNS_TOKEN_B, "platform": "macos"},
+                )
+                assert r.status_code == 200, r.text
+                r = await client.get("/api/v2/push/devices")
+                assert len(r.json()) == 3
+
+                # 5) 스키마 계약 위반(macos인데 apns_device_token 누락) → 422.
+                r = await client.post("/api/v2/push/devices", json={"platform": "macos"})
+                assert r.status_code == 422, r.text
+    finally:
+        app.dependency_overrides.clear()
+        async with SessionLocal() as s:
+            await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(ORG)})
+            await s.commit()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_push_devices_token_platform_exclusive_check_enforced_at_db_layer():
+    """0278 마이그의 push_devices_token_platform_exclusive_check 를 스키마(pydantic) 우회해
+    raw INSERT로 직접 찔러 DB 레벨 방어가 실재함을 증명 — API 계약이 뚫려도(버그·직접 SQL 등)
+    최후방어선이 산다는 것 자체가 이 CHECK의 존재 이유."""
+    from sqlalchemy.exc import IntegrityError
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_async_url())
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    from sqlalchemy import text
+
+    org = uuid.uuid4()
+    try:
+        async with SessionLocal() as s:
+            await s.execute(
+                text("INSERT INTO organizations (id,name,slug,plan) VALUES (:o,'CHK Org','chk-org','free')"),
+                {"o": str(org)},
+            )
+            await s.commit()
+
+        # ① macos인데 apns_device_token NULL·expo_push_token만 채움 → 위반.
+        async with SessionLocal() as s:
+            with pytest.raises(IntegrityError):
+                await s.execute(
+                    text(
+                        "INSERT INTO push_devices (id, org_id, member_id, platform, expo_push_token) "
+                        "VALUES (gen_random_uuid(), :o, gen_random_uuid(), 'macos', :t)"
+                    ),
+                    {"o": str(org), "t": "ExponentPushToken[should-not-work-for-macos]"},
+                )
+                await s.commit()
+
+        # ② ios인데 expo_push_token NULL(apns만 채움) → 위반.
+        async with SessionLocal() as s:
+            with pytest.raises(IntegrityError):
+                await s.execute(
+                    text(
+                        "INSERT INTO push_devices (id, org_id, member_id, platform, apns_device_token) "
+                        "VALUES (gen_random_uuid(), :o, gen_random_uuid(), 'ios', :t)"
+                    ),
+                    {"o": str(org), "t": "ab" * 32},
+                )
+                await s.commit()
+    finally:
+        async with SessionLocal() as s:
+            await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(org)})
+            await s.commit()
+        await engine.dispose()

--- a/backend/tests/test_push_devices_realdb.py
+++ b/backend/tests/test_push_devices_realdb.py
@@ -261,8 +261,8 @@ async def test_push_device_register_macos_apns_round_trip_realdb():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     from app.dependencies.auth import get_verified_org_id
-    from app.dependencies.database import get_db
     from ee.routers import push_devices as pd
+    from tests.conftest import override_db_and_read
 
     app = FastAPI()
     app.include_router(pd.router, prefix="/api/v2/push")
@@ -289,7 +289,7 @@ async def test_push_device_register_macos_apns_round_trip_realdb():
             return member_id
         return _override
 
-    app.dependency_overrides[get_db] = _override_db
+    override_db_and_read(app, _override_db)
     app.dependency_overrides[get_verified_org_id] = lambda: ORG
     app.dependency_overrides[pd._get_caller_member_id] = _make_caller_override(MEMBER_X)
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -819,6 +819,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -912,6 +934,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1976,6 +2007,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "google-cloud-storage" },
     { name = "google-genai" },
+    { name = "h2" },
     { name = "httpx" },
     { name = "imagesize" },
     { name = "jsonschema" },
@@ -2021,6 +2053,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.30.0" },
     { name = "google-cloud-storage", specifier = ">=2.18.0" },
     { name = "google-genai", specifier = ">=1.0.0" },
+    { name = "h2", specifier = ">=4.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "imagesize", specifier = ">=2.0.0" },
     { name = "jsonschema", specifier = ">=4.26.0" },


### PR DESCRIPTION
[SID:3064]

## 요약
E-MOBILE macOS dev 앱 원격 푸시 미구현(story #3064) — BE 축 전담분. macOS(Tauri) 앱은 Expo 런타임이 아니라 Expo push 토큰을 만들 수 없어(민군 앱 축과 토큰 페이로드 계약 조율 완료), 플랫폼별 토큰 컬럼 분리 + 네이티브 APNs HTTP/2 발송 경로를 신설한다. 설계는 페드루 PO 사전 승인(2026-08-25).

## 변경
- **DB(0278/0279)**: `push_devices.apns_device_token`(nullable UNIQUE) 신설, `expo_push_token` NOT NULL→nullable, platform CHECK에 `'macos'` 추가 + 플랫폼별 토큰 상호배타 CHECK. `delivery_jobs.kind` CHECK에 `'apns_push'` 추가.
  - **dev DB GROUP BY platform 실측 스캔**(Cloud Run Job 경유, 2026-08-25) — 기존 3행 전부 clean(`null_expo=0`)이라 1단계 강한 CHECK로 올림. **prod는 gcloud 게이트라 이 세션에서 재지 못함 — 마이그 docstring에 prod 승격 前 재스캔 필수 명시함.**
- **스키마/API**: `RegisterPushDevice` — `platform="macos"`면 `apns_device_token` 필수(64hex)+`expo_push_token` 생략(model_validator로 상호배타 강제), 그 외는 기존과 동일(회귀 0).
- **repository**: `upsert()` conflict target을 실제 채워진 토큰 컬럼 기준으로 분기(둘 다 nullable이라 Postgres UNIQUE가 NULL을 충돌 대상으로 안 봄 — 하드코딩 하나로는 안 됨).
- **발송기**(`ee/services/apns_push.py`, 신규): `expo_push.py`와 동형 구조(fetch→send→finalize 3분할, outbox, best-effort). JWT ES256 provider token(.p8, 55분 캐시) + httpx `http2=True`(신규 의존성 `h2` 1개만 추가). 410/BadDeviceToken → `is_active=false`. `settings.apns_configured=False`(인증키 미도착)면 fail-closed — 준비물 도착 전에도 안전 배포 가능.

## 확認된 값
민군(앱 축) 확認: entitlements `aps-environment=production`(실 바이너리 codesign 재확認까지) — `apns_use_sandbox` 기본값 False(`api.push.apple.com` 고정)로 확定.

## 검증
- 신선 스크래치 PG를 0277로 stamp 후 0278/0279 **incremental upgrade 실제 실행**(create_all 우회 아님 — 마이그 DDL 자체가 돎) 확認.
- realdb: push_devices 기존 왕복 2개 + 신규 macOS 왕복·DB-레벨 CHECK 강제 2개 = **22/22 pass**.
- unit: apns_push 19개(JWT 서명 실검증·캐시/TTL·410/BadDeviceToken 판정·fetch 필터·outbox·best-effort) — 실 ES256 throwaway 키로 서명 라운드트립까지 검증.
- 회귀: expo_push(ee/realdb)·delivery_outbox(unit/realdb)·notification_dispatch·worker_pool_separation·delivery_claim_race 조합 **97/97 pass**.

## 남은 것 (PO 판단 대기)
APNs 인증키(.p8)+Key ID·Team ID·App ID Push Notifications capability 활성화 — 민군 실기기 핸드오프 결과와 묶어 한 번에 선생님께 요청 예정(페드루 PO 판정, 개별 요청 아님).

## 리뷰 요청
- 카디르군 QA

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>