### PR TITLE
[SID:3052] 인박스 색-fill→재질(2984-S4) — kicker MaterialChip + 최근변경 행 헤어라인

### DIFF
--- a/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
@@ -15,6 +15,8 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
+import { AttentionRow } from './attention-queue-view';
+import type { AttentionQueueItem } from './derive-attention-queue';
 
 const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn() }));
 
@@ -247,5 +249,34 @@ describe('AttentionQueueView — 로드맵 P3 L6(섹션 제목 editorial weight)
     expect(h2?.className).toContain('font-editorial-heading');
     expect(h2?.className).toContain('text-[19px]');
     expect(h2?.className).not.toContain('font-extrabold');
+  });
+});
+
+// story #3052(2984-S4) — "최근 변경" highlighted 행은 fill(bg-proof-citron/15 wash) 대신
+// 헤어라인 좌측 액센트(border-l-proof-citron)를 쓴다. 색 신호(citron) 자체는 KEEP.
+describe('AttentionRow — story #3052 헤어라인 액센트(citron fill 폐지)', () => {
+  const item: AttentionQueueItem = {
+    id: 'a1', kind: 'decision_needed', bucket: 'GATE', kindLabel: '게이트',
+    proofState: 'amber', claim: '테스트 항목', actor: null,
+    actionLabel: '검토', actionTone: 'primary', href: '/board?story=s1',
+    enteredStateAtMs: null, sortKey: 0,
+  };
+
+  it('highlighted=true면 border-l-proof-citron을 쓰고 bg-proof-citron 채움은 안 쓴다', async () => {
+    await act(async () => {
+      root.render(wrap(<AttentionRow item={item} highlighted onNavigate={() => {}} />));
+    });
+    const row = container.querySelector('[role="button"]');
+    expect(row?.className).toContain('border-l-proof-citron');
+    expect(row?.className).not.toContain('bg-proof-citron');
+  });
+
+  it('highlighted=false면 border-l-transparent만 쓴다', async () => {
+    await act(async () => {
+      root.render(wrap(<AttentionRow item={item} highlighted={false} onNavigate={() => {}} />));
+    });
+    const row = container.querySelector('[role="button"]');
+    expect(row?.className).toContain('border-l-transparent');
+    expect(row?.className).not.toContain('border-l-proof-citron');
   });
 });

--- a/apps/web/src/components/attention-queue/attention-queue-view.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.tsx
@@ -73,7 +73,9 @@ function RowSkeleton() {
   return <div className="h-[52px] animate-pulse border-b border-proof-line-soft bg-proof-sunk/60 last:border-b-0" />;
 }
 
-function AttentionRow({ item, highlighted, onNavigate }: {
+// story #3052(2984-S4) — 헤어라인 액센트(회귀가드) 단위 테스트를 위해 export(전체 폴링
+// 생명주기를 시뮬레이션하지 않고 highlighted prop만 직접 검증).
+export function AttentionRow({ item, highlighted, onNavigate }: {
   item: AttentionQueueItem; highlighted: boolean; onNavigate: (href: string) => void;
 }) {
   // story #2923 AQ1(PO 실측, 2026-08-22) — inbox 병합 항목 중 origin_chain이 story/memo 어느
@@ -92,10 +94,12 @@ function AttentionRow({ item, highlighted, onNavigate }: {
         if (e.key === 'Enter') onNavigate(item.href!);
       } : undefined}
       className={cn(
-        'border-b border-proof-line-soft last:border-b-0',
+        'border-b border-b-proof-line-soft border-l-2 border-l-transparent last:border-b-0',
         navigable && 'cursor-pointer hover:bg-proof-sunk',
         'motion-safe:transition-colors motion-safe:duration-700',
-        highlighted && 'motion-safe:bg-proof-citron/15',
+        // story #3052(2984-S4) — "최근 변경" 신호는 fill(citron/15 배경 wash) 대신 헤어라인
+        // 액센트(좌측 테두리)로. 색 신호 자체는 KEEP(citron 유지) — fill만 제거.
+        highlighted && 'motion-safe:border-l-proof-citron',
       )}
     >
       <ProofCapsule

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1771,6 +1771,20 @@ describe('ChatBubble — story #ec57c80c report성 메시지 밀도(kicker+리�
     expect(container.textContent).not.toContain('인라인 카드 elev-card 토큰 확認');
   });
 
+  // story #3052(2984-S4) — kicker는 MaterialChip(S1, 헤어라인+fill 0)을 쓴다. 옛
+  // bg-proof-blue-soft 채움은 폐지.
+  it('story #3052 — kicker가 MaterialChip(헤어라인)을 쓰고 bg-proof-blue-soft는 안 쓴다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble message={{ ...baseMessage, content: REPORT_CONTENT, message_kind: 'result', references: [] }} isMine={false} />,
+      ));
+    });
+    const kicker = Array.from(container.querySelectorAll('span')).find((s) => s.textContent === '판정');
+    expect(kicker).toBeTruthy();
+    expect(kicker?.className).toContain('border-proof-line');
+    expect(kicker?.className).not.toContain('bg-proof-blue-soft');
+  });
+
   it('「전문 보기」 클릭 시 실제로 펼쳐져 하위 상세까지 전부 보인다(정보 소실 0) — 실 클릭 시뮬레이션', async () => {
     await act(async () => {
       root.render(wrap(

--- a/apps/web/src/components/chat/report-message-summary.tsx
+++ b/apps/web/src/components/chat/report-message-summary.tsx
@@ -7,6 +7,7 @@ import type { EntityStatusFetchState } from './entity-status-labels';
 import type { ReadingPanelTarget } from './reading-panel';
 import type { EventDefinitionSummary } from '@/lib/block-template';
 import { ChatMarkdown } from './chat-bubble';
+import { MaterialChip } from '@/components/ui/material-chip';
 import { computeReportDensity } from '@/lib/chat-report-density';
 
 interface ReportMessageSummaryProps {
@@ -55,9 +56,9 @@ export function ReportMessageSummary({
   return (
     <div>
       {density.kicker ? (
-        <span className="mb-1.5 inline-flex items-center gap-1 rounded-md bg-proof-blue-soft px-2 py-0.5 text-[10px] font-bold text-proof-blue">
-          {density.kicker}
-        </span>
+        // story #3052(2984-S4) — MaterialChip(S1, 헤어라인+fill 0) 채택, bg-proof-blue-soft
+        // 채움 폐지(§2 doc ⓒ kicker 판정 — 순수 SHIFT, 신호 아님).
+        <MaterialChip className="mb-1.5">{density.kicker}</MaterialChip>
       ) : null}
       <p className={`mb-1.5 text-sm font-medium leading-relaxed [overflow-wrap:anywhere] ${density.kicker ? '' : 'mt-0'}`}>
         {density.lead}


### PR DESCRIPTION
## 요약
doc `diff-axis-2984-color-to-material-inventory` §3.2(시안 확定) 채택 스토리. S1(#3049, PR#3470, 이미 merged) 프리미티브를 소비만 한다 — 신규 발명 0.

## SHIFT — 검토 결과: 3곳 중 1곳은 이미 완료(S1)
- `inbox/page.tsx:683` agent_joined Bot 칩 — grep 재확認 결과 S1에서 이미 AgentIdentity 채택 완료(스토리 본문 자체가 S1과 겹침으로 나열했던 자리) — 이 PR 추가 변경 없음.
- `report-message-summary.tsx:58` 리포트 kicker(`bg-proof-blue-soft`) → **MaterialChip**(S1, 헤어라인+fill 0) 채택.
- `attention-queue-view.tsx:98` highlighted(최근 변경) 행 배경(`bg-proof-citron/15` wash) → 좌측 **헤어라인 액센트**(`border-l-proof-citron`)로 대체. citron 색 신호 자체는 KEEP(§2 doc "dot/헤어라인으로 신호만 남기고 fill 제거" 처방 그대로).

## #num AA(#5f6158) — 검토 결과: 적용하지 않음(S1에서 이미 반증)
S4 AC2가 요구하는 `#5f6158` 적용은 S1 리뷰에서 유나양이 이미 철회한 처방이다 — 실측(WCAG 상대휘도 재계산)으로 다크 테마에서 오히려 AA가 3.11로 깨지는 게 확認됐다(유나 design PASS 코멘트, PR#3470). 이 stale AC 항목은 적용하지 않았다.

## 검증
- 신규 회귀가드 3개: `AttentionRow`(export 추가, highlighted=true/false 각 1개)+kicker 1개.
- git diff→checkout HEAD→테스트→git apply 방식으로 pre-fix genuine RED 확認(3개 전부 정확히 실패 후 복원).
- **부수 발견**: 최초 구현에서 `border-proof-line-soft`(all-sides)와 `border-l-transparent`가 twMerge 충돌로 후자가 삭제되는 버그를 회귀가드가 실측으로 적발 — `border-b-proof-line-soft`(방향 한정)로 교정해 해소.
- apps/web 전체 회귀 스윕: **505 files/4520 tests 100% pass**. eslint 0(pre-existing 5개 무관 경고만)·tsc 클린·`pnpm build` EXIT=0.
- 실 컴포넌트(`renderToStaticMarkup`) 방출 클래스를 정확한 토큰 hex로 치환한 라이트/다크 390px 재현을 [Sprintable 산출물](entity:artifact:718365e0-7135-42d4-987f-10def87c0e86)로 게시 — ⚠️puppeteer 세션이 이번 세션 내내 죽어있어 라이브 스크린샷은 카디르군 QA로 위임.

## AC 체크
- [x] Bot칩·kicker·highlighted soft-fill→재질(시안 §3.2 1:1)
- [x] #num AA — S1의 반증 결과 적용 안 함(finding)
- [x] KEEP 신호(citron) 회귀 0 — 전체 스윕 100% pass로 확認
- [ ] 유나 design · 카디르 QA(라이브 픽셀 포함)

## 리뷰 요청
- 유나군 design
- 카디르군 QA