### PR TITLE
[SID:3053] goals·문서 색-fill→재질(2984-S5) — 프리미티브 채택 7곳

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.test.tsx
@@ -137,6 +137,26 @@ describe('DocsClientLayout — 레일 v2 재조립 후 6 능력 회귀가드(§1
     expect(calls.some((u) => u.includes('tags='))).toBe(true);
   });
 
+  // story #3053(2984-S5) — 선택 태그 칩은 헤어라인(border-proof-line+bg-transparent)을 쓰고
+  // 옛 bg-proof-blue-soft 채움은 안 쓴다. 태그 접었을 때 카운트는 CountBadge(mono+엠보스)로.
+  it('④재질 — 선택 태그 칩이 헤어라인을 쓰고 bg-proof-blue-soft는 안 쓴다, 접으면 CountBadge가 뜬다', async () => {
+    stubFetch();
+    await mount();
+    const tagToggle = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('태그'));
+    await act(async () => { tagToggle!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const tagChip = [...container.querySelectorAll('button')].find((b) => b.textContent === '#스펙');
+    await act(async () => { tagChip!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(tagChip?.className).toContain('border-proof-line');
+    expect(tagChip?.className).not.toContain('bg-proof-blue-soft');
+
+    // 접으면 카운트 배지(CountBadge, mono+엠보스 inset)가 뜬다.
+    await act(async () => { tagToggle!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const badge = container.querySelector('.font-mono.shadow-\\[var\\(--elev-inset\\)\\]');
+    expect(badge).toBeTruthy();
+    expect(badge?.textContent).toBe('1');
+    expect(container.querySelector('.bg-proof-blue-soft')).toBeNull();
+  });
+
   it('③정렬 3모드 — "내 폴더" 뷰에서 정렬 토글 3개가 뜨고 클릭이 sortMode를 localStorage에 저장한다', async () => {
     stubFetch();
     await mount();

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -15,6 +15,7 @@ import { TreeSearchInput } from '@/components/docs/tree-search-input';
 import { DocSearchResults, type DocSearchResult } from '@/components/docs/doc-search-results';
 import { useTreeExpanded } from '@/components/docs/use-tree-expanded';
 import { Button } from '@/components/ui/button';
+import { CountBadge } from '@/components/ui/count-badge';
 import { EmptyState } from '@/components/ui/empty-state';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
@@ -471,8 +472,10 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
               <span className="flex items-center gap-1.5">
                 {tagsCollapsed ? <ChevronRight className="size-3" /> : <ChevronDown className="size-3" />}
                 {t('tagFilter')}
+                {/* story #3053(2984-S5) — CountBadge(S1, mono+엠보스 inset) 채택,
+                    bg-proof-blue-soft 채움 폐지. */}
                 {tagsCollapsed && selectedTags.length > 0 && (
-                  <span className="proof-cut-xs bg-proof-blue-soft px-1.5 py-0.5 text-[10px] font-semibold text-foreground">{selectedTags.length}</span>
+                  <CountBadge count={selectedTags.length} />
                 )}
               </span>
             </button>
@@ -481,10 +484,10 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
             {!tagsCollapsed && (
               <div className="flex max-h-[120px] flex-wrap gap-1 overflow-y-auto px-4 py-1">
                 {allTags.map((tag) => (
-                  // AC4(#2420 캐논) — tint 배경 위 계열색 텍스트 금지, StatusChip과 동일하게
-                  // text-foreground(선택)로 대비를 지킨다(시안 원안의 text-proof-blue는 이
-                  // 규율과 충돌해 안 따름).
-                  <button key={tag} type="button" onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((tg) => tg !== tag) : [...prev, tag])} className={`proof-cut-xs px-2 py-0.5 text-[11px] font-semibold transition ${selectedTags.includes(tag) ? 'bg-proof-blue-soft text-foreground' : 'bg-proof-sunk text-proof-ink-3 hover:bg-muted'}`}>
+                  // story #3053(2984-S5) — 선택 상태는 subtle 헤어라인 채택, bg-proof-blue-soft
+                  // 채움 폐지(비선택 bg-proof-sunk는 무채 중립 배경이라 SHIFT 대상 밖 — S1
+                  // 선례와 동형).
+                  <button key={tag} type="button" onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((tg) => tg !== tag) : [...prev, tag])} className={`proof-cut-xs px-2 py-0.5 text-[11px] font-semibold transition ${selectedTags.includes(tag) ? 'border border-proof-line bg-transparent text-foreground' : 'bg-proof-sunk text-proof-ink-3 hover:bg-muted'}`}>
                     #{tag}
                   </button>
                 ))}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.test.tsx
@@ -167,4 +167,13 @@ describe('DocsIndex — 문서 있음(§2 마스트헤드+목록)', () => {
     await act(async () => { draftChip!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(container.textContent).toContain('조건에 맞는 문서가 없습니다');
   });
+
+  // story #3053(2984-S5) — lead 문서 좌측 액센트가 무채(border-proof-line-strong)를 쓰고
+  // citron 정적 장식은 안 쓴다(citron은 live pulse 전용).
+  it('lead 문서 좌측 액센트가 무채 헤어라인을 쓰고 bg-proof-citron은 안 쓴다', async () => {
+    useDocsLayoutMock.mockReturnValue({ ...BASE_CTX, tree });
+    await mount();
+    expect(container.querySelector('.bg-proof-line-strong')).toBeTruthy();
+    expect(container.querySelector('.bg-proof-citron')).toBeNull();
+  });
 });

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
@@ -240,7 +240,10 @@ export function DocsIndex() {
               onClick={() => goToDoc(lead.slug)}
               className="relative mb-3 flex w-full flex-col items-start gap-2 border border-border bg-card px-6 py-5 pl-7 text-left transition hover:border-foreground/30"
             >
-              <span className="absolute inset-y-0 left-0 w-1 bg-proof-citron" aria-hidden="true" />
+              {/* story #3053(2984-S5) — 무채 헤어라인 액센트 채택, citron 정적 장식 폐지
+                  (citron은 live pulse 신호 전용 — 위 §2983 주석과 동일 규율, 이 스트라이프는
+                  라이브가 아닌 정적 "lead" 표식이라 애초에 citron 대상이 아니었다). */}
+              <span className="absolute inset-y-0 left-0 w-1 bg-proof-line-strong" aria-hidden="true" />
               <div className="flex items-center gap-2.5">
                 <StatusChip status={lead.status} />
                 <span className="font-mono text-[11px] uppercase tracking-[0.05em] text-muted-foreground">{t('indexLeadBadge')}</span>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.test.tsx
@@ -318,4 +318,22 @@ describe('EpicDetailPage — 결과 캡슐 재조립(§2 이중 신호·§4 신�
     await mountByUrl({ outcome_status: 'n_a' });
     expect(container.textContent).toContain('목표 생성');
   });
+
+  // story #3053(2984-S5) — Outcome Capsule은 헤어라인+elev(border-proof-line·bg-proof-panel·
+  // --elev-card)를 쓰고 bg-proof-blue-soft 채움은 안 쓴다.
+  it('결과 캡슐 — 헤어라인+elev를 쓰고 bg-proof-blue-soft는 안 쓴다', async () => {
+    await mountByUrl({ outcome_status: 'hit' });
+    const capsule = container.querySelector('.proof-cut.border-proof-line');
+    expect(capsule).toBeTruthy();
+    expect(capsule?.className).toContain('shadow-[var(--elev-card)]');
+    expect(container.querySelector('.bg-proof-blue-soft')).toBeNull();
+  });
+
+  // story #3053(2984-S5) — KEEP 재검(§2): 「생성」노드 dot이 형제(가설) 노드와 같은 solid
+  // bg-proof-blue를 쓰고 옛 -soft(옅은 틴트)는 안 쓴다.
+  it('신뢰 레일 — "생성" 노드 dot이 solid bg-proof-blue를 쓰고 bg-proof-blue-soft는 안 쓴다', async () => {
+    await mountByUrl({ outcome_status: 'n_a' });
+    expect(container.querySelector('.bg-proof-blue')).toBeTruthy();
+    expect(container.querySelector('.bg-proof-blue-soft')).toBeNull();
+  });
 });

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
@@ -431,7 +431,11 @@ export default function EpicDetailPage() {
             </div>
             <div className="mt-2 text-[11px] text-muted-foreground">{t('taskCapsuleHint')}</div>
           </div>
-          <div className="proof-cut border border-proof-blue/25 bg-proof-blue-soft px-4 py-3.5">
+          {/* story #3053(2984-S5) — 헤어라인+elev(S1 재질 언어) 채택, bg-proof-blue-soft 채움
+              폐지. 강조 색은 이 카드의 항상-고정 blue(상태별 분기 없음, 기존 동작 그대로)를
+              proof-line 헤어라인+elev-card 깊이로 이전 — 텍스트 강조는 유지(신호가 아니라
+              위계라 색 텍스트는 남긴다, MaterialChip류의 "장식 fill"과는 다른 자리). */}
+          <div className="proof-cut border border-proof-line bg-proof-panel px-4 py-3.5 shadow-[var(--elev-card)]">
             <div className="font-mono text-[10px] uppercase tracking-[0.1em] text-proof-blue">{t('outcomeCapsuleTitle')}</div>
             <div className="mt-1.5 font-editorial-heading text-[22px] tracking-[-0.02em] text-proof-blue">
               {epic.outcome_status === 'hit' ? t('outcomeCapsuleHit')

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
@@ -182,7 +182,7 @@ describe('GoalsClient — 결과 원장 재조립(§2 이중 신호·§3 마스�
 
   // PR#3387 QA 처방 ①② — status==='done'만으론 상태 칩이 green이면 안 된다. outcome_status별
   // 명시 케이스로 고정(회귀 재발 시 바로 여기서 걸린다).
-  it('상태 칩 — done+miss는 초록이 아니라 중립(sunk)이다', async () => {
+  it('상태 칩 — done+miss는 초록이 아니라 중립(faint dot)이다', async () => {
     stubFetch([{ id: 'e1', title: 'M', status: 'done', total_stories: 1, done_stories: 1, outcome_status: 'miss' }]);
     await mount();
     expect(container.querySelector('.bg-proof-green-soft')).toBeNull();
@@ -193,7 +193,7 @@ describe('GoalsClient — 결과 원장 재조립(§2 이중 신호·§3 마스�
     expect(container.querySelector('.bg-proof-sunk')).toBeNull();
   });
 
-  it('상태 칩 — done+unmeasured는 초록이 아니라 중립(sunk)이다', async () => {
+  it('상태 칩 — done+unmeasured는 초록이 아니라 중립(faint dot)이다', async () => {
     stubFetch([{ id: 'e1', title: 'U', status: 'done', total_stories: 1, done_stories: 1, outcome_status: 'unmeasured' }]);
     await mount();
     expect(container.querySelector('.bg-proof-green-soft')).toBeNull();
@@ -204,7 +204,7 @@ describe('GoalsClient — 결과 원장 재조립(§2 이중 신호·§3 마스�
     expect(container.querySelector('.bg-proof-sunk')).toBeNull();
   });
 
-  it('상태 칩 — done+pending(아직 판정 없음)은 초록이 아니라 중립(sunk)이다', async () => {
+  it('상태 칩 — done+pending(아직 판정 없음)은 초록이 아니라 중립(faint dot)이다', async () => {
     stubFetch([{ id: 'e1', title: 'P', status: 'done', total_stories: 1, done_stories: 1, outcome_status: 'pending' }]);
     await mount();
     expect(container.querySelector('.bg-proof-green-soft')).toBeNull();

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
@@ -186,21 +186,33 @@ describe('GoalsClient — 결과 원장 재조립(§2 이중 신호·§3 마스�
     stubFetch([{ id: 'e1', title: 'M', status: 'done', total_stories: 1, done_stories: 1, outcome_status: 'miss' }]);
     await mount();
     expect(container.querySelector('.bg-proof-green-soft')).toBeNull();
-    expect(container.querySelector('.bg-proof-sunk')).not.toBeNull();
+    // story #3053(2984-S5) — MaterialChip 채택 후 상태 칩은 항상 헤어라인(border-proof-line
+    // bg-transparent)이고, active/비active 구분은 내부 dot(bg-proof-blue/bg-proof-faint)이
+    // 짊어진다 — bg-proof-sunk 채움 자체가 이제 없다(옛 fill 규율의 흔적 제거).
+    expect(container.querySelector('.bg-proof-faint')).not.toBeNull();
+    expect(container.querySelector('.bg-proof-sunk')).toBeNull();
   });
 
   it('상태 칩 — done+unmeasured는 초록이 아니라 중립(sunk)이다', async () => {
     stubFetch([{ id: 'e1', title: 'U', status: 'done', total_stories: 1, done_stories: 1, outcome_status: 'unmeasured' }]);
     await mount();
     expect(container.querySelector('.bg-proof-green-soft')).toBeNull();
-    expect(container.querySelector('.bg-proof-sunk')).not.toBeNull();
+    // story #3053(2984-S5) — MaterialChip 채택 후 상태 칩은 항상 헤어라인(border-proof-line
+    // bg-transparent)이고, active/비active 구분은 내부 dot(bg-proof-blue/bg-proof-faint)이
+    // 짊어진다 — bg-proof-sunk 채움 자체가 이제 없다(옛 fill 규율의 흔적 제거).
+    expect(container.querySelector('.bg-proof-faint')).not.toBeNull();
+    expect(container.querySelector('.bg-proof-sunk')).toBeNull();
   });
 
   it('상태 칩 — done+pending(아직 판정 없음)은 초록이 아니라 중립(sunk)이다', async () => {
     stubFetch([{ id: 'e1', title: 'P', status: 'done', total_stories: 1, done_stories: 1, outcome_status: 'pending' }]);
     await mount();
     expect(container.querySelector('.bg-proof-green-soft')).toBeNull();
-    expect(container.querySelector('.bg-proof-sunk')).not.toBeNull();
+    // story #3053(2984-S5) — MaterialChip 채택 후 상태 칩은 항상 헤어라인(border-proof-line
+    // bg-transparent)이고, active/비active 구분은 내부 dot(bg-proof-blue/bg-proof-faint)이
+    // 짊어진다 — bg-proof-sunk 채움 자체가 이제 없다(옛 fill 규율의 흔적 제거).
+    expect(container.querySelector('.bg-proof-faint')).not.toBeNull();
+    expect(container.querySelector('.bg-proof-sunk')).toBeNull();
   });
 
   // PR#3387 처방 갱신(유나 원작자 정본 채택, PO 2026-08-23) — 미르코의 첫 처방("done&&hit만

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -13,6 +13,7 @@ import { useGoalsRoute } from './goals-context';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { Badge } from '@/components/ui/badge';
+import { MaterialChip } from '@/components/ui/material-chip';
 import { EmptyState } from '@/components/ui/empty-state';
 
 // story 3995840c(doc resource-view-firsttouch-identity-pattern §4 "에픽" 행 — 정체성=하나의 큰
@@ -608,14 +609,13 @@ function GoalRow({ epic, isSelected, onClick, onDeleteRequest, sortable }: GoalR
             {/* story #2969 PR-1 발견 버그 — 아래 proof-cut-xs가 --proof-cut 값만 바꾸고
                 clip-path 자체를 여는 proof-cut 베이스 클래스가 빠져 있어(#2958 원 커밋 실수)
                 컷 자체가 안 그려지고 있었다(globals.css 참고). 즉시 수정. */}
-            <span
-              className={`proof-cut proof-cut-xs inline-flex items-center gap-1 px-2 py-0.5 text-[10.5px] font-bold ${
-                epic.status === 'active' ? 'bg-proof-blue-soft text-proof-blue' : 'bg-proof-sunk text-proof-ink-3'
-              }`}
-            >
+            {/* story #3053(2984-S5) — MaterialChip(S1, 헤어라인+fill 0) 채택, 상태별
+                bg-proof-blue-soft/bg-proof-sunk 채움 폐지. dot 신호(active=blue·비active=
+                faint)는 이미 있던 신호라 그대로 KEEP. */}
+            <MaterialChip className="gap-1 text-[10.5px]">
               <span className={`size-1.5 rounded-full ${epic.status === 'active' ? 'bg-proof-blue' : 'bg-proof-faint'}`} />
               {statusLabel[epic.status]}
-            </span>
+            </MaterialChip>
             {epic.outcome_status && epic.outcome_status !== 'n_a' ? <OutcomeStatusBadge status={epic.outcome_status} /> : null}
           </div>
           <p className="min-w-0 flex-1 text-editorial-claim font-editorial-claim leading-snug text-foreground">{epic.title}</p>
@@ -1116,11 +1116,13 @@ export function GoalsClient({ projectId, orgId }: GoalsClientProps) {
           **커밋 성공 後에만** 표시(드래그 아님·no-fiction). 지정 수신자만 표기·활동량/타임스탬프 0.
           Proof Blue·부드러운 호흡·reduced-motion 대응. */}
       {justDispatched ? (
-        <div className="flex shrink-0 items-center gap-2 border-y border-proof-line-soft bg-proof-blue-soft px-4 py-2 text-[11.5px] font-semibold text-proof-blue">
+        // story #3053(2984-S5) — 헤어라인+elev(S1 재질 언어) 채택, bg-proof-blue-soft 채움
+        // 폐지. pulse dot(라이브 신호)은 그대로 KEEP — proof-blue.
+        <div className="flex shrink-0 items-center gap-2 border-y border-proof-line bg-proof-panel px-4 py-2 text-[11.5px] font-semibold text-foreground shadow-[var(--elev-card)]">
           <span className="size-1.5 shrink-0 rounded-full bg-proof-blue motion-safe:animate-pulse" aria-hidden="true" />
           <span>{t('steerHandoffReceived')} · <b className="font-bold">{t('steerHandoffOrchestrating')}</b></span>
           {dispatchedTo.length > 0 ? (
-            <span className="ml-auto max-w-[45%] truncate text-[9.5px] font-bold text-proof-blue/80">{dispatchedTo.join(', ')}</span>
+            <span className="ml-auto max-w-[45%] truncate text-[9.5px] font-bold text-muted-foreground">{dispatchedTo.join(', ')}</span>
           ) : null}
         </div>
       ) : null}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/steer-dispatch-modal.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/steer-dispatch-modal.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+//
+// story #3053(2984-S5) — 에이전트 선택 버튼 on 상태 회귀가드. subtle 헤어라인(border-proof-
+// blue/40+bg-transparent) 채택, bg-proof-blue-soft 채움 폐지(체크박스 solid fill은 기능
+// 신호라 무변경).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../../../messages/ko.json';
+import { SteerDispatchModal } from './steer-dispatch-modal';
+
+const { fetchWithAuthMock } = vi.hoisted(() => ({ fetchWithAuthMock: vi.fn() }));
+vi.mock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  fetchWithAuthMock.mockReset();
+  fetchWithAuthMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      data: [{ id: 'a1', name: '디디', type: 'agent', is_active: true }],
+    }),
+  });
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+describe('SteerDispatchModal — story #3053 에이전트 선택 헤어라인(soft-fill 폐지)', () => {
+  it('선택(on) 상태가 bg-transparent를 쓰고 bg-proof-blue-soft는 안 쓴다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <SteerDispatchModal projectId="proj-1" items={[{ id: 'e1', position: 0 }]} onClose={() => {}} onDispatched={() => {}} />,
+      ));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    // story #3053 — Dialog(base-ui)는 document.body에 포탈되므로 container가 아니라
+    // document.body에서 찾는다.
+    const agentBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent?.includes('디디'));
+    expect(agentBtn).toBeTruthy();
+    await act(async () => { agentBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(agentBtn?.className).toContain('bg-transparent');
+    expect(agentBtn?.className).not.toContain('bg-proof-blue-soft');
+    expect(agentBtn?.className).toContain('border-proof-blue/40');
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/steer-dispatch-modal.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/steer-dispatch-modal.tsx
@@ -143,8 +143,10 @@ export function SteerDispatchModal({ projectId, items, onClose, onDispatched }: 
                       type="button"
                       onClick={() => toggle(a.id)}
                       aria-pressed={on}
+                      // story #3053(2984-S5) — subtle 헤어라인 채택, bg-proof-blue-soft 채움
+                      // 폐지(체크박스 자체의 solid fill은 기능 신호라 KEEP).
                       className={`flex w-full items-center gap-2.5 rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
-                        on ? 'border-proof-blue/40 bg-proof-blue-soft text-foreground' : 'border-border hover:bg-muted/50'
+                        on ? 'border-proof-blue/40 bg-transparent text-foreground' : 'border-border hover:bg-muted/50'
                       }`}
                     >
                       <span className={`flex size-4 shrink-0 items-center justify-center rounded border ${

--- a/apps/web/src/components/goals/goal-trust-rail.tsx
+++ b/apps/web/src/components/goals/goal-trust-rail.tsx
@@ -96,7 +96,10 @@ export function GoalTrustRail({ outcomeStatus, measureAfter, createdAt, epicId, 
 
         {/* 생성 — 항상. created_by 필드가 BE 스키마에 없어(그라운딩 확認) 이름은 안 지어낸다. */}
         <li className="relative">
-          <span className="absolute -left-[19px] top-2 size-2 rounded-full border-2 border-background bg-proof-blue-soft" />
+          {/* story #3053(2984-S5) — KEEP 재검(doc §2): 형제 노드(위 hypotheses)는 solid
+              bg-proof-amber인데 이 dot만 -soft(옅은 틴트)라 재질 불일치였다 — dot은 신호라
+              유지하되, 솔리드 채도로 정합(제거 아니라 정제). */}
+          <span className="absolute -left-[19px] top-2 size-2 rounded-full border-2 border-background bg-proof-blue" />
           <div className="text-[13px] font-medium text-foreground">{t('trustRailCreated')}</div>
           <div className="font-mono text-[11px] text-muted-foreground">{fmtDate(createdAt)}</div>
         </li>


### PR DESCRIPTION
## 요약
doc `diff-axis-2984-color-to-material-inventory` §2 인벤토리(goals·docs 표면) 채택 스토리. S1(#3049, PR#3470, merged) 프리미티브를 소비만 한다 — 신규 발명 0.

## SHIFT(7곳)
- `goals-client.tsx:613` Epic 상태 칩 — 상태별 채움 → **MaterialChip**(dot 신호는 KEEP).
- `goals-client.tsx:1118` 조타 핸드오프 배너 — 채움 → 헤어라인+elev(pulse dot KEEP).
- `steer-dispatch-modal.tsx:147` 에이전트 선택 on 상태 — 채움 → subtle 헤어라인(체크박스 solid fill은 무변경).
- `goals/[id]/page.tsx:434` Outcome Capsule 패널 — 채움 → 헤어라인+elev(강조 텍스트 색은 위계라 존치).
- `docs-client-layout.tsx:475` 태그 카운트 배지 — 채움 → **CountBadge**.
- `docs-client-layout.tsx:487` #tag 필터 선택 배경 — 채움 → subtle 헤어라인(비선택 bg-proof-sunk는 무채 중립이라 무변경).
- `docs-index.tsx:243` lead 문서 좌측 액센트 — citron(정적 장식) → 무채(citron은 live pulse 전용이라 자체 모순이던 자리).

## KEEP 재검 — `goal-trust-rail.tsx:99`
"생성" 노드 dot이 형제(가설) 노드와 달리 `bg-proof-blue-soft`(옅은 틴트)라 재질 불일치였다 — solid `bg-proof-blue`로 정합(제거가 아니라 정제).

## 검증
- 신규 회귀가드 8개(6개 파일 갱신+`steer-dispatch-modal.test.tsx` 신규). 기존 상태 칩 회귀가드 3개(PR#3387)는 새 재질 계약에 맞게 갱신.
- git diff→checkout HEAD→테스트→git apply 방식으로 pre-fix genuine RED 확認(5개 테스트 파일 10개 테스트 전부 정확히 실패 후 복원).
- apps/web 전체 회귀 스윕: **506 files/4522 tests 100% pass**. eslint 0(pre-existing 5개 무관 경고만)·tsc 클린·`pnpm build` EXIT=0.
- 7곳 정확한 토큰 hex 매핑 라이트/다크 390px 재현을 [Sprintable 산출물](entity:artifact:2214abba-865a-485e-8f56-8466d453eba1)로 게시 — ⚠️puppeteer 세션이 이번 세션 내내 죽어있어 라이브 스크린샷은 카디르군 QA로 위임.

## AC 체크
- [x] goals·docs 8곳(SHIFT 7+KEEP 재검 1) soft-fill→재질
- [x] KEEP 신호(dot 등) 회귀 0 — 전체 스윕 100% pass로 확認
- [ ] 유나 design · 카디르 QA(라이브 픽셀 포함)

## 리뷰 요청
- 유나군 design
- 카디르군 QA