### PR TITLE
[SID:3054] 2984-S6 — proof-capsule/verify/nav 색-fill→재질 + claim serif 검증 포인트

### DIFF
--- a/apps/web/src/components/nav/app-sidebar.test.tsx
+++ b/apps/web/src/components/nav/app-sidebar.test.tsx
@@ -227,4 +227,15 @@ describe('AppSidebar — story #2681 NAV_GROUPS 렌더 회귀가드(AC1) + story
     const businessInfoToggle = [...container.querySelectorAll('button')].find((b) => b.getAttribute('aria-expanded') !== null);
     expect(businessInfoToggle).toBeDefined();
   });
+
+  // story #3054(2984-S6) — Chat Center CTA가 헤어라인+elev를 쓰고 bg-proof-blue-soft는
+  // 안 쓴다.
+  it('Chat Center CTA가 헤어라인+elev를 쓰고 bg-proof-blue-soft는 안 쓴다', async () => {
+    await mount();
+    const link = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/chats');
+    expect(link).toBeDefined();
+    expect(link!.className).toContain('border-proof-blue');
+    expect(link!.className).toContain('shadow-[var(--elev-card)]');
+    expect(link!.className).not.toContain('bg-proof-blue-soft');
+  });
 });

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -183,11 +183,11 @@ export function AppSidebar({
       <div className="mx-2.5 mt-2">
         <Link
           href={CHAT_CENTER_ITEM.path}
-          // hover 시 solid fill로 전환하는 톤 자체는 GATE_BUTTON_TONE.primary(proof-capsule.tsx)와
-          // 동형이지만, 그 기존 패턴의 hover:text-white는 다크 모드에서 3.21(AA 4.5 미달·수동
-          // 확認)이라 그대로 베끼지 않고 여기서는 sidebar-primary-foreground(다크=근흑색, 위
-          // 배지와 동일 근거)로 바꿔 통과시킨다.
-          className="flex items-center gap-2 rounded-[9px] border border-proof-blue bg-proof-blue-soft px-2.5 py-2 text-proof-blue transition hover:bg-sidebar-primary hover:text-sidebar-primary-foreground"
+          // story #3054(2984-S6) — GATE_BUTTON_TONE.primary(proof-capsule.tsx)와 동형으로
+          // 헤어라인+elev 채택, bg-proof-blue-soft 채움 폐지. hover는 이제 solid 전환 대신
+          // bg-sidebar-accent(기존 다른 nav 항목의 hover 관례와 정합) — AA 대비 이슈였던
+          // hover:text-white/sidebar-primary-foreground 분기 자체가 불필요해졌다.
+          className="flex items-center gap-2 rounded-[9px] border border-proof-blue bg-transparent px-2.5 py-2 text-proof-blue shadow-[var(--elev-card)] transition hover:bg-sidebar-accent"
         >
           <MessageSquare className="size-[18px] shrink-0" />
           <span className="flex-1 truncate text-[13px] font-bold">{t(CHAT_CENTER_ITEM.labelKey)}</span>

--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -498,3 +498,53 @@ describe('ProofCapsule — story #32dcc294 headerAside/cardHeader(card 밀도 �
     expect(markup).toContain(BASE.claim);
   });
 });
+
+// story #3054(2984-S6) — gate action 버튼(full 밀도)+GATE_BUTTON_TONE 3톤이 헤어라인/elev를
+// 쓰고 bg-proof-blue-soft/bg-proof-green-soft 채움은 안 쓴다.
+describe('ProofCapsule — story #3054 gate 버튼 헤어라인(soft-fill 폐지)', () => {
+  it('full 밀도 gate 버튼이 헤어라인+elev를 쓰고 bg-proof-blue-soft는 안 쓴다', () => {
+    const markup = renderWithIntl(
+      <ProofCapsule {...BASE} gate={{ action: '승인', href: '/gates/g1' }} />,
+    );
+    expect(markup).toContain('border-proof-line');
+    expect(markup).toContain('shadow-[var(--elev-card)]');
+    expect(markup).not.toContain('bg-proof-blue-soft');
+  });
+
+  it('row 밀도 GATE_BUTTON_TONE 3톤(primary/neutral/ready) 전부 soft-fill이 없다', () => {
+    for (const tone of ['primary', 'neutral', 'ready'] as const) {
+      const markup = renderWithIntl(
+        <ProofCapsule {...BASE} density="row" gate={{ action: '진행', tone }} />,
+      );
+      expect(markup).not.toContain('bg-proof-blue-soft');
+      expect(markup).not.toContain('bg-proof-green-soft');
+    }
+  });
+});
+
+// story #3054(2984-S6 §3.4) — claim 헤드라인(full 밀도)은 proofState==='green'(검증됨)일
+// 때만 font-serif, 다른 상태는 sans 그대로. 본문/라벨/칩엔 serif 없음(2974 규율).
+describe('ProofCapsule — story #3054 serif 포인트(claim→Verified 전이만)', () => {
+  it('proofState=green이면 claim 헤드라인이 font-serif를 쓴다', () => {
+    const markup = renderWithIntl(<ProofCapsule {...BASE} proofState="green" />);
+    const claimIdx = markup.indexOf(BASE.claim);
+    const claimTagStart = markup.lastIndexOf('<div', claimIdx);
+    const claimTag = markup.slice(claimTagStart, claimIdx);
+    expect(claimTag).toContain('font-serif');
+  });
+
+  it('proofState=blue/amber/red는 claim 헤드라인에 font-serif가 없다', () => {
+    for (const state of ['blue', 'amber', 'red'] as const) {
+      const markup = renderWithIntl(<ProofCapsule {...BASE} proofState={state} />);
+      const claimIdx = markup.indexOf(BASE.claim);
+      const claimTagStart = markup.lastIndexOf('<div', claimIdx);
+      const claimTag = markup.slice(claimTagStart, claimIdx);
+      expect(claimTag).not.toContain('font-serif');
+    }
+  });
+
+  it('card 밀도(본문 규모)는 proofState=green이어도 font-serif가 없다(2974 — 본문/칩 금지)', () => {
+    const markup = renderWithIntl(<ProofCapsule {...BASE} density="card" proofState="green" />);
+    expect(markup).not.toContain('font-serif');
+  });
+});

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -229,9 +229,10 @@ function GateRow({ gate, human }: { gate: ProofCapsuleGate; human: ProofCapsuleH
         {gate.risk ? (
           <span className="font-mono text-[10.5px]">{t('gate.risk', { risk: t(`risk.${RISK_KEY[gate.risk]}`) })}</span>
         ) : null}
+        {/* story #3054(2984-S6) — 헤어라인+elev CTA 채택, bg-proof-blue-soft 채움 폐지. */}
         <a
           href={gate.href}
-          className="ml-auto inline-flex items-center gap-1 rounded-[6px] border border-proof-blue bg-proof-blue-soft px-3 py-1 text-[11.5px] font-semibold text-proof-blue transition-colors duration-[140ms] hover:bg-proof-blue hover:text-white"
+          className="ml-auto inline-flex items-center gap-1 rounded-[6px] border border-proof-line bg-proof-panel px-3 py-1 text-[11.5px] font-semibold text-foreground shadow-[var(--elev-card)] transition-colors duration-[140ms] hover:bg-muted"
         >
           {gate.action}
           <ArrowRight className="size-3" aria-hidden="true" />
@@ -269,7 +270,11 @@ function FullVariant({
         <div className="mb-1 mt-3 text-[8.5px] font-bold uppercase tracking-[0.12em] text-proof-ink-3">
           {t('claim.label')}
         </div>
-        <div className="text-[19px] font-bold leading-[1.25] tracking-[-0.012em] text-proof-ink">{claim}</div>
+        {/* story #3054(2984-S6 §3.4) — serif는 claim→Verified 전이의 최종 판정 헤드라인
+            "포인트"에만(2974 규율: 본문/라벨/칩은 절대 금지) — proofState==='green'(검증됨)
+            일 때만 font-serif(Source Serif 4, layout.tsx 기배선) 켠다. 다른 상태(blue/amber/
+            red)는 무변경(sans 그대로). */}
+        <div className={cn('text-[19px] font-bold leading-[1.25] tracking-[-0.012em] text-proof-ink', proofState === 'green' && 'font-serif')}>{claim}</div>
         <div className="mt-2.5 flex flex-wrap items-center gap-3 text-[11px] text-proof-ink-3">
           {human ? (
             <span className="inline-flex items-center gap-1.5">
@@ -355,10 +360,13 @@ function CardVariant({
   );
 }
 
+// story #3054(2984-S6) — primary/ready 채움 폐지, 헤어라인 채택. neutral은 이미 헤어라인이라
+// 무변경(3톤 일관 확認) — border/text 색(blue=주요·green=준비됨)은 액션 의미 신호라 존치,
+// fill만 제거.
 const GATE_BUTTON_TONE: Record<NonNullable<ProofCapsuleGate['tone']>, string> = {
-  primary: 'border-proof-blue bg-proof-blue-soft text-proof-blue hover:bg-proof-blue hover:text-white',
+  primary: 'border-proof-blue text-proof-blue hover:bg-proof-sunk',
   neutral: 'border-proof-line text-proof-ink-2 hover:bg-proof-sunk',
-  ready: 'border-proof-green bg-proof-green-soft text-proof-green hover:bg-proof-green hover:text-white',
+  ready: 'border-proof-green text-proof-green hover:bg-proof-sunk',
 };
 
 function InlineRow({

--- a/apps/web/src/components/verify/trust-seal.test.tsx
+++ b/apps/web/src/components/verify/trust-seal.test.tsx
@@ -42,6 +42,16 @@ describe('TrustSeal (claimed — Green 무결성 SOUL-LOCK, claimed-vs-verified-
     expect(markup).toContain('에이전트 주장');
     expect(markup).not.toContain('undefined');
   });
+
+  // story #3054(2984-S6) — 컨테이너 재질이 헤어라인+엠보스 inset(VerificationStamp 재질
+  // 언어)을 쓰고 bg-proof-amber-soft 채움은 안 쓴다. Green 무결성 SOUL-LOCK은 위 테스트로
+  // 이미 고정 — 여기선 material만 본다.
+  it('story #3054 — 헤어라인+엠보스 inset을 쓰고 bg-proof-amber-soft는 안 쓴다', () => {
+    const markup = render({ variant: 'claimed', agentInitial: '미' });
+    expect(markup).toContain('border-proof-line');
+    expect(markup).toContain('shadow-[var(--elev-inset)]');
+    expect(markup).not.toContain('bg-proof-amber-soft');
+  });
 });
 
 describe('TrustSeal (verified — 인간 책임자 서명, spec §1.2)', () => {

--- a/apps/web/src/components/verify/trust-seal.tsx
+++ b/apps/web/src/components/verify/trust-seal.tsx
@@ -46,7 +46,10 @@ export function TrustSeal(props: TrustSealProps) {
 
   if (props.variant === 'claimed') {
     return (
-      <div className={cn('flex items-center gap-2 rounded-[10px] bg-proof-amber-soft px-2.5 py-2 text-[11.5px]', props.className)}>
+      // story #3054(2984-S6) — VerificationStamp(S1) 재질 언어(헤어라인+엠보스 inset) 채택,
+      // bg-proof-amber-soft 채움 폐지. Green 무결성 SOUL-LOCK 무변경(green 토큰 미참조) —
+      // amber 라벨("검증 대기")은 실제 상태 신호라 그대로 KEEP.
+      <div className={cn('flex items-center gap-2 rounded-[10px] border border-proof-line bg-proof-panel px-2.5 py-2 text-[11.5px] shadow-[var(--elev-inset)]', props.className)}>
         {/* story #3049(2984-S1) — AGENT_MARK_FILL_CLASS(헤어라인 border 유지·soft-fill
             폐지) 채택. border는 이미 있었으니 배경만 투명으로 교체. */}
         <span className={cn('flex size-[22px] shrink-0 items-center justify-center rounded-full border border-proof-blue text-[9px] font-bold', AGENT_MARK_FILL_CLASS)}>

--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -527,4 +527,18 @@ describe('Workcell — story #5b3aea5e Brief 콘텐츠 층(마크다운 스트�
     expect(markup).not.toContain('##');
     expect(markup).not.toContain('- `tsc');
   });
+
+  // story #3054(2984-S6) — runNextNeed 콜아웃이 헤어라인을 쓰고 bg-proof-blue-soft 채움은
+  // 안 쓴다. ⚠️elev(--elev-card)는 안 쓴다 — bentoLayout=false "완전 복귀" 계약(§6, 아래
+  // 테스트)과 충돌하는 걸 실측으로 잡았던 자리(pre-fix 상태에서 이 회귀가 실제로 났었다).
+  it('runNextNeed 콜아웃이 헤어라인을 쓰고 bg-proof-blue-soft/elev-card 둘 다 안 쓴다', () => {
+    const markup = renderKo(<Workcell {...BASE} />);
+    expect(markup).toContain(BASE.run.nextNeed);
+    const idx = markup.indexOf(BASE.run.nextNeed);
+    const tagStart = markup.lastIndexOf('<div', idx);
+    const tag = markup.slice(tagStart, idx);
+    expect(tag).toContain('border-proof-line');
+    expect(tag).not.toContain('bg-proof-blue-soft');
+    expect(tag).not.toContain('shadow-[var(--elev-card)]');
+  });
 });

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -428,7 +428,11 @@ function RunLayer({ run }: { run: WorkcellRun }) {
       <div className="mb-2 text-[11.5px] text-proof-ink-3">
         {t('runBlocked')}: <b className={cn('font-semibold', run.blocked ? 'text-proof-amber' : 'text-proof-ink-2')}>{run.blocked ?? t('none')}</b>
       </div>
-      <div className="flex items-center gap-1.5 rounded-[6px] border border-proof-blue/25 bg-proof-blue-soft px-2.5 py-1.5 text-[12.5px] text-proof-blue">
+      {/* story #3054(2984-S6) — 헤어라인 채택, bg-proof-blue-soft 채움 폐지. ⚠️elev(그림자)는
+          안 얹는다 — 이 콜아웃은 bentoLayout 여부와 무관하게 항상 렌더되는 공유 요소라
+          (story #2990 §6 가역성 1급 회귀가드가 실측으로 적발) elev를 얹으면 bentoLayout=false
+          "완전 복귀" 계약을 깬다. 순수 헤어라인만. */}
+      <div className="flex items-center gap-1.5 rounded-[6px] border border-proof-line bg-proof-panel px-2.5 py-1.5 text-[12.5px] text-foreground">
         → {t('runNextNeed')}: <b className="font-bold">{run.nextNeed}</b>
       </div>
     </div>


### PR DESCRIPTION
## 요약

2984 재질 스윕 S6(도크 인벤토리 § 기준) — S1 프리미티브(헤어라인+elev) 소비만. proof-capsule/verify/nav 3개 표면의 soft-fill CTA/스트립/콜아웃을 헤어라인+elev로 전환, §3.4 serif 검증 포인트 신설.

### SHIFT

| 파일 | 대상 | before | after |
|---|---|---|---|
| `proof-capsule.tsx` | gate action CTA(full) | `bg-proof-blue-soft` | `border-proof-line` + `shadow-[var(--elev-card)]` |
| `proof-capsule.tsx` | GATE_BUTTON_TONE(row, 3톤) | soft-fill | 헤어라인(neutral과 동형) |
| `trust-seal.tsx` | claimed 컨테이너 | `bg-proof-amber-soft` | 헤어라인 + `shadow-[var(--elev-inset)]` |
| `app-sidebar.tsx` | Chat Center CTA | `bg-proof-blue-soft` | 헤어라인 + `shadow-[var(--elev-card)]` |
| `workcell.tsx` | runNextNeed 콜아웃 | `bg-proof-blue-soft` | 순수 헤어라인(⚠️elev 없음, 아래 참고) |

**workcell.tsx 특이사항**: 처음엔 다른 3곳과 동형으로 elev-card를 얹었으나, 이 콜아웃이 `bentoLayout` 여부와 무관하게 항상 렌더되는 공유 요소라는 걸 기존 회귀가드(story #2990 §6 "bentoLayout=false 완전 복귀")가 실측으로 잡아냈다 — elev를 얹으면 legacy 복귀 계약이 깨짐. 순수 헤어라인만으로 재수정.

**trust-seal.tsx**: Green 무결성 SOUL-LOCK 무변경(claimed 분기는 여전히 green 토큰 미참조) — amber "검증 대기" 라벨은 실제 상태 신호라 그대로 KEEP.

### §3.4 serif 검증 포인트

`proof-capsule.tsx` `FullVariant`의 claim 헤드라인(19px)에 `proofState==='green'`(검증됨)일 때만 `font-serif`(Source Serif 4, `layout.tsx`에 story #2974 D0단계로 이미 배선 — 이번이 최초 소비). blue/amber/red 상태 및 card 밀도(12.5px line-clamp-2 본문급)는 sans 그대로 — 2974 규율("본문/라벨/칩은 절대 금지") 준수.

### KEEP(무변경 확인)

- `tabs.tsx:69` 활성 탭 언더라인(citron, 2px 순수 라인 신호)
- `proof-capsule.tsx` claim.running 라이브 펄스 점(citron)
- 사이드바 unread count 배지(기능적 카운트 신호, 스코프 밖)

### ⚠️AC1↔S1 정의 상충 (design 확인 대기 중)

AC1은 "trust-seal.tsx:49 claimed → **VerificationStamp**(S1) 채택"을 명시하는데, S1(#3049)의 VerificationStamp 컴포넌트 자체 docstring은 "verified 씰(S6)이 채택 대상"이라고 명시(claimed 아닌 verified 지목). VerificationStamp는 compact badge 형태(avatar 없음)라 claimed 스트립의 avatar+텍스트+amber상태를 그대로 담을 수 없어, 이번엔 컴포넌트 자체 스왑 대신 같은 재질 언어(헤어라인+elev-inset)만 채택해 기존 정보를 보존 — 페드루군 접수, 유나양 design 확定 대기 중.

## 검증

- 신규 회귀가드 6건 — pre-fix `git diff→checkout HEAD→재실행(genuine RED 6/6)→git apply→재실행(6/6 GREEN)` 확인
- 전체 vitest 506 files / 4530 tests green
- `tsc --noEmit` clean
- `eslint .` 0 errors (pre-existing unrelated warning 5개)
- `pnpm build` EXIT=0

## 시각 확인

Puppeteer 세션 내내 dead — 실 vitest `renderToStaticMarkup` 덤프에서 정확한 클래스 추출, `globals.css` 실측 토큰 hex로 손수 재구성한 before/after 비교 아티팩트로 대체(라이브 픽셀 최종 확인은 카디르 QA 위임, 명시적 고지).

Sprintable 산출물: SID 3054(2984-S6) — proof-capsule·verify·nav 재질 실렌더(라이트/다크 390px) (artifact `bc5fcdf5-90cf-4564-8f8c-b6b38c059690`, story #3054 연결)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>