### PR TITLE
fix(#3069): 결재함 gate SSE 이벤트 mux-fallback 불변식

### DIFF
--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -12,10 +12,11 @@ import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import type { GateItem, HitlInboxItem } from '../kanban/types';
 
-const { useDashboardContextMock, pushMock, muxSubscribeMock } = vi.hoisted(() => ({
+const { useDashboardContextMock, pushMock, muxSubscribeMock, useSseMultiplexerContextMock } = vi.hoisted(() => ({
   useDashboardContextMock: vi.fn(),
   pushMock: vi.fn(),
   muxSubscribeMock: vi.fn((_eventName: string, _handler: (raw: string, eventId?: string) => void) => () => {}),
+  useSseMultiplexerContextMock: vi.fn(),
 }));
 
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
@@ -27,8 +28,15 @@ vi.mock('next/navigation', () => ({
 }));
 
 // story #2985 AC2 — approval-request-card.test.tsx와 동일 전략.
+// story #3069(2026-08-25) — 이 파일이 이제 mux.subscribe를 직접 안 부르고
+// useSseNotifications(use-sse-notifications.ts)를 경유한다(그 훅이 mux 有/無를 갈라
+// 폴백까지 구조적으로 보장 — 컴포넌트는 mux를 몰라도 됨). 그 훅의 mux 분기가
+// subscribeMessage도 무조건 부르므로(NOTIFICATION_EVENT_NAMES 자체 구독과 무관하게)
+// 목(mock)에 없으면 런타임 TypeError — 완전한 SseMultiplexerHandle 형태로 맞춘다.
+// useSseMultiplexerContextMock을 vi.fn()으로 둬 개별 테스트가 null(=mux 비활성/미연결)로
+// override할 수 있게 한다 — «mux 폴백 부재» 재발을 막는 회귀가드(story #3069)의 핵심.
 vi.mock('@/components/realtime-provider', () => ({
-  useSseMultiplexerContext: () => ({ subscribe: muxSubscribeMock }),
+  useSseMultiplexerContext: () => useSseMultiplexerContextMock(),
 }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -91,8 +99,17 @@ beforeEach(() => {
     orgMemberships: [{ orgId: 'org-1', orgName: '뭉클랩' }],
     projectMemberships: [],
     currentMemberType: 'human',
+    currentTeamMemberId: 'member-1',
   });
   muxSubscribeMock.mockClear();
+  // 기본값 = mux 활성(기존 스위트 전부가 이 전제) — mux 비활성/폴백 경로를 검증하는
+  // 케이스만 개별로 useSseMultiplexerContextMock.mockReturnValueOnce(null) override.
+  useSseMultiplexerContextMock.mockReturnValue({
+    subscribe: muxSubscribeMock,
+    subscribeMessage: () => () => {},
+    subscribeReconnect: () => () => {},
+    connected: true,
+  });
 });
 
 afterEach(async () => {
@@ -946,5 +963,102 @@ describe('ApprovalsQueue — 실시간 해소/위임 반영(story #2985 AC2)', (
     const delegatedHandler = muxSubscribeMock.mock.calls.find(([e]) => e === 'conversation.gate_delegated')![1] as (raw: string) => void;
     expect(() => resolvedHandler('not-json{')).not.toThrow();
     expect(() => delegatedHandler('not-json{')).not.toThrow();
+  });
+});
+
+// story #3069(P1, 2026-08-25) — mux가 null(피처플래그 off·미연결 등)이어도 이 세 이벤트가
+// 여전히 최소 한 곳에서 리스닝돼야 한다는 불변식의 회귀가드. 예전엔 mux.subscribe만 있고
+// fallback이 없어 mux가 죽으면 이 세 이벤트가 페이지 전체에서 리스너 자체를 잃었다(실사고
+// — BE는 정상 delivered인데 화면 카드 0건). useSseNotifications의 독립 EventSource 폴백
+// (mux === null일 때만 타는 effect)을 거쳐 여기서도 정확히 살아있는지 직접 증명한다.
+class FakeEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+  static instances: FakeEventSource[] = [];
+  listeners: Record<string, Array<(e: { data: string; lastEventId?: string }) => void>> = {};
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string; lastEventId?: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+  readyState = 0;
+  constructor(public url: string, _opts?: unknown) {
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(type: string, cb: (e: { data: string; lastEventId?: string }) => void) {
+    (this.listeners[type] ??= []).push(cb);
+  }
+  close() { this.closed = true; }
+  emit(type: string, data: string, lastEventId?: string) {
+    for (const cb of this.listeners[type] ?? []) cb({ data, lastEventId });
+  }
+}
+
+describe('ApprovalsQueue — mux 비활성 시 fallback EventSource(story #3069, 실사고 재발가드)', () => {
+  function actionableGate(overrides: Partial<GateItem> = {}): GateItem {
+    return gate({
+      id: 'g-live', gate_type: 'merge_gate', status: 'pending', requires_human: true,
+      can_approve: true, risk_grade: 'low', work_item_summary: { title: '실시간 대상 항목', slug: null },
+      ...overrides,
+    });
+  }
+
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    (globalThis as unknown as { EventSource: typeof FakeEventSource }).EventSource = FakeEventSource;
+    // 이 describe만 mux를 null로 — RealtimeProvider가 피처플래그 off거나 미연결일 때와 동형.
+    useSseMultiplexerContextMock.mockReturnValue(null);
+  });
+
+  it('mux가 null이어도 conversation.gate_resolved가 fallback EventSource로 리스닝된다', async () => {
+    mockFetches([actionableGate()], []);
+    await mount();
+
+    expect(FakeEventSource.instances.length).toBeGreaterThan(0);
+    const es = FakeEventSource.instances[0]!;
+    expect(es.listeners['conversation.gate_resolved']).toBeTruthy();
+
+    await act(async () => {
+      es.emit('conversation.gate_resolved', JSON.stringify({ gate_id: 'g-live', status: 'approved' }));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain(koMessages.cage.queueResolvedApproved);
+  });
+
+  it('mux가 null이어도 conversation.gate_delegated가 fallback EventSource로 리스닝된다', async () => {
+    mockFetches([actionableGate()], []);
+    await mount();
+    expect(container.textContent).toContain('실시간 대상 항목');
+
+    const es = FakeEventSource.instances[0]!;
+    await act(async () => {
+      es.emit('conversation.gate_delegated', JSON.stringify({ gate_id: 'g-live' }));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).not.toContain('실시간 대상 항목');
+  });
+
+  it('mux가 null이어도 conversation.gate_created가 fallback EventSource로 리스닝돼 단건 GET 후 prepend된다', async () => {
+    mockFetches([actionableGate()], []);
+    await mount();
+    expect(container.textContent).not.toContain('새로생긴카드');
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/gates/g-new') {
+        return { ok: true, json: async () => gate({ id: 'g-new', work_item_summary: { title: '새로생긴카드', slug: null } }) };
+      }
+      return { ok: true, json: async () => [] };
+    }));
+
+    const es = FakeEventSource.instances[0]!;
+    expect(es.listeners['conversation.gate_created']).toBeTruthy();
+    await act(async () => {
+      es.emit('conversation.gate_created', JSON.stringify({ gate_id: 'g-new' }));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('새로생긴카드');
   });
 });

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
@@ -16,7 +16,7 @@ import { GateSignatureApproval } from '@/components/cage/gate-signature-approval
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateInboxItem, GateItem, HitlInboxItem } from '@/components/kanban/types';
 import { ProofCapsule, type ProofState } from '@/components/proof-capsule/proof-capsule';
-import { useSseMultiplexerContext } from '@/components/realtime-provider';
+import { useSseNotifications } from '@/hooks/use-sse-notifications';
 
 import { fetchWithAuth } from '@/lib/db/client';
 
@@ -116,7 +116,7 @@ export function ApprovalsQueue() {
   // 같은 버그클래스: 이 큐는 그 판정을 미리 안 보고 에이전트 계정에도 승인/반려 버튼을
   // 무조건 열었다. Gate와 달리 HitlInboxItem엔 per-item can_approve 필드가 없어(BE 응답
   // shape 차이) 계정 자체의 type(human/agent, DashboardContext #2103 신규)으로 게이팅한다.
-  const { orgMemberships, currentMemberType } = useDashboardContext();
+  const { orgMemberships, currentMemberType, currentTeamMemberId } = useDashboardContext();
   const canResolveHitl = currentMemberType === 'human';
   const [items, setItems] = useState<GateInboxItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -197,62 +197,66 @@ export function ApprovalsQueue() {
   // undo 버튼이 뜨면 안 된다, 위 resolvedAtMs 주석 참조). BE 계약은 approval-request-
   // card.tsx/gates/[id]/page.tsx와 동일(notify_gate_card_recipients_resolved, 신규 배관 0).
   // ⚠️items를 deps에 넣지 않는다(items.some(...) 멤버십 가드는 fetchGates 완료 前 빈
-  // 배열을 캡처한 stale effect가 재구독으로 안 씻겨나가는 함정이 있다 — mux.subscribe가
-  // 리스너 목록에 append만 하고 이전 것을 안 지우는 구현이면 첫 구독(빈 items)이 계속 살아
-  // 있어 항상 no-op이 된다). 대신 무조건 기록 — items에 없는 gate_id가 들어와도 그 키는
-  // 그냥 안 쓰일 뿐(렌더는 items.map()이 도는 항목만 resolvedGates[gate.id]를 읽는다).
-  const mux = useSseMultiplexerContext();
-  useEffect(() => {
-    if (!mux) return;
-    const unsub = mux.subscribe('conversation.gate_resolved', (raw) => {
-      try {
-        const payload = JSON.parse(raw) as { gate_id?: string; status?: 'approved' | 'rejected' };
-        if (!payload.gate_id || !payload.status) return;
-        setResolvedGates((prev) => ({ ...prev, [payload.gate_id!]: payload.status! }));
-      } catch { /* malformed — 무시 */ }
-    });
-    return unsub;
-  }, [mux]);
+  // 배열을 캡처한 stale effect가 재구독으로 안 씻겨나가는 함정이 있다). 대신 무조건 기록 —
+  // items에 없는 gate_id가 들어와도 그 키는 그냥 안 쓰일 뿐(렌더는 items.map()이 도는
+  // 항목만 resolvedGates[gate.id]를 읽는다).
+  //
+  // story #3069(P1, 2026-08-25 PO 실측·디디 그라운딩) — 이 세 이벤트를 예전엔
+  // `useSseMultiplexerContext()`가 준 mux에 직접 `mux.subscribe(...)`로만 걸었다. mux는
+  // 피처플래그(SSE_MULTIPLEX_ENABLED) off거나 이 컴포넌트 마운트 시점에 미연결이면 null을
+  // 주고, 그 경우 `if (!mux) return;`으로 조용히 no-op — 즉 폴백 경로가 아예 없어 세 이벤트
+  // 전부가 페이지 전체에서 리스너 자체를 잃었다(BE는 정상 발화·delivered 마킹했는데도 화면
+  // 카드는 0건, 실사고 재현). `use-chat-sse.ts`/`use-sse-notifications.ts`(원 3훅)는 이미
+  // mux 없으면 자체 독립 EventSource로 폴백하는 설계라 그 사이드에선 안 죽었다 — 이 컴포넌트만
+  // 그 불변식(мux 유무 무관 항상 최소 1곳에서 리스닝)을 안 지켰던 것.
+  // 처방: 새 EventSource를 직접 열지 않고(발명 0) `useSseNotifications`의 `extraEventNames`
+  // 경로를 재사용한다 — 그 훅이 mux 有=mux.subscribe, mux 無=자체 폴백 EventSource를 이미
+  // 구조적으로 갈라주므로 이 컴포넌트는 mux 존재 여부를 더 이상 알 필요가 없다(그 훅의 dedup
+  // ·backoff·visibility-reconnect·cursor 승격까지 전부 공짜로 상속).
+  const handleGateEvent = useCallback((eventName: string, data: unknown) => {
+    if (typeof data !== 'object' || data === null) return;
+    const payload = data as { gate_id?: string; status?: 'approved' | 'rejected' };
+    if (!payload.gate_id) return;
 
-  // story #3001(위임) — 이 큐는 assigned_to_me=true로 이미 스코프돼 있다. 지정자가
-  // 위임으로 밀려나면 그 게이트는 더 이상 "내 할 일"이 아니므로(재조회하면 안 옴), 목록에서
-  // 바로 제거한다 — gate_resolved(완료 오버레이 유지)와 다르게 여긴 실제 삭제가 재조회
-  // 결과와 정확히 일치한다.
-  useEffect(() => {
-    if (!mux) return;
-    const unsub = mux.subscribe('conversation.gate_delegated', (raw) => {
-      try {
-        const payload = JSON.parse(raw) as { gate_id?: string };
-        if (!payload.gate_id) return;
-        setItems((prev) => prev.filter((it) => it.id !== payload.gate_id));
-      } catch { /* malformed — 무시 */ }
-    });
-    return unsub;
-  }, [mux]);
+    if (eventName === 'conversation.gate_resolved') {
+      if (!payload.status) return;
+      setResolvedGates((prev) => ({ ...prev, [payload.gate_id!]: payload.status! }));
+      return;
+    }
 
-  // story #3044(PO 실사고 표본②, 2026-08-25) — fetchGates()는 마운트 1회뿐이고 위 두 SSE는
-  // 기존 항목의 상태 변화만 다뤄, "새 게이트가 생겼다"를 알리는 신호가 없었다(이미 열어둔
-  // 탭에 새 게이트가 생기면 하드 리로드 전까진 영원히 안 뜸 — gate 2a14c177 실사고). BE가
-  // notify_gate_created_to_recipients(approval_delivery.py)로 심는 conversation.gate_created를
-  // 구독 — payload는 gate_id뿐이라(다른 두 이벤트와 동형, 최소 payload 관례) 단건 GET으로
-  // 채워 prepend한다. 이미 목록에 있으면(레이스 — fetchGates()가 방금 같은 걸 받아왔거나
-  // 중복 이벤트) 지어내지 않고 skip.
-  useEffect(() => {
-    if (!mux) return;
-    const unsub = mux.subscribe('conversation.gate_created', (raw) => {
+    if (eventName === 'conversation.gate_delegated') {
+      // story #3001(위임) — 이 큐는 assigned_to_me=true로 이미 스코프돼 있다. 지정자가
+      // 위임으로 밀려나면 그 게이트는 더 이상 "내 할 일"이 아니므로(재조회하면 안 옴), 목록
+      // 에서 바로 제거한다 — gate_resolved(완료 오버레이 유지)와 다르게 여긴 실제 삭제가
+      // 재조회 결과와 정확히 일치한다.
+      setItems((prev) => prev.filter((it) => it.id !== payload.gate_id));
+      return;
+    }
+
+    if (eventName === 'conversation.gate_created') {
+      // story #3044(PO 실사고 표본②, 2026-08-25) — fetchGates()는 마운트 1회뿐이고 위 두
+      // SSE는 기존 항목의 상태 변화만 다뤄, "새 게이트가 생겼다"를 알리는 신호가 없었다
+      // (이미 열어둔 탭에 새 게이트가 생기면 하드 리로드 전까진 영원히 안 뜸 — gate
+      // 2a14c177 실사고). BE가 notify_gate_created_to_recipients(approval_delivery.py)로
+      // 심는 conversation.gate_created를 구독 — payload는 gate_id뿐이라(다른 두 이벤트와
+      // 동형, 최소 payload 관례) 단건 GET으로 채워 prepend한다. 이미 목록에 있으면(레이스
+      // — fetchGates()가 방금 같은 걸 받아왔거나 중복 이벤트) 지어내지 않고 skip.
       void (async () => {
         try {
-          const payload = JSON.parse(raw) as { gate_id?: string };
-          if (!payload.gate_id) return;
           const res = await fetchWithAuth(`/api/gates/${payload.gate_id}`);
           if (!res.ok) return;
           const gate = (await res.json()) as GateItem;
           setItems((prev) => (prev.some((it) => it.id === gate.id) ? prev : [gate, ...prev]));
-        } catch { /* malformed payload 또는 fetch 실패 — 무시(다음 하드 리로드가 흡수) */ }
+        } catch { /* fetch 실패 — 무시(다음 하드 리로드가 흡수) */ }
       })();
-    });
-    return unsub;
-  }, [mux]);
+    }
+  }, []);
+
+  useSseNotifications({
+    memberId: currentTeamMemberId,
+    extraEventNames: ['conversation.gate_resolved', 'conversation.gate_delegated', 'conversation.gate_created'],
+    onExtraEvent: handleGateEvent,
+  });
 
   // story #2054 AC3: HitlRequest는 상세 페이지가 없어 이 큐 안에서 바로 승인/반려한다 —
   // 승인 후 원래 작업(report-done)이 통과하는지는 사용자 왕복(재시도)으로 확認된다.


### PR DESCRIPTION
[SID:3069]

## 요약
`approvals-queue.tsx`의 `conversation.gate_created`/`gate_resolved`/`gate_delegated` 구독이 `mux.subscribe()` 하나뿐이라, mux가 null(피처플래그 off·미연결 등)이면 폴백 없이 조용히 no-op이었다. `use-chat-sse.ts`/`use-sse-notifications.ts`(원 3훅)는 이미 mux 없으면 자체 독립 EventSource로 폴백하는데 이 컴포넌트만 그 불변식을 안 지켰다 — 2026-08-25 PO 실측 중 대조 실험으로 확定(BE는 정상 delivered, 페이지는 카드 0건).

## 처방
새 EventSource를 직접 열지 않고(발명 0) `useSseNotifications`의 `extraEventNames`/`onExtraEvent` 경로를 재사용 — 그 훅이 mux 有/無를 구조적으로 갈라(mux 有=mux.subscribe, mux 無=자체 폴백 EventSource) dedup·backoff·visibility-reconnect·cursor 승격까지 전부 상속한다.

## SSE_MULTIPLEX_ENABLED dev 실런타임값 확定(PO 추가 AC)
GHA 빌드로그 직접 대조(commit `513077d1b`, run `32831177286`) — `_SSE_MULTIPLEX_ENABLED="true"`. dev는 mux가 실제로 켜져 있다. story #3069 그라운딩 당시의 "독립 커서 쌍" 관측은 mux 비활성이 아니라 story #3070(배포 중 502 폭풍) 동반 재연결 레이스로 재해석하는 게 더 정합. 이 PR의 처방은 그와 무관하게 유효 — mux on/off 어느 쪽이든 세 이벤트가 항상 최소 1곳에서 리스닝된다는 불변식 자체를 지킨다.

## 검증
- 신규 회귀가드 3건 — mux를 null로 override해 fallback EventSource가 실제로 attach되는지, 이벤트 emit 시 정확히 동작하는지 직접 증명. **수정 前 코드로 git stash 후 재실행 → genuine RED(3건 실패, fallback 자체가 없어 EventSource 인스턴스 0개/리스너 없음) 확認 → 원복 후 GREEN.**
- 기존 53개 mux-path 테스트 전부 회귀 0(마이그레이션: mux mock이 완전한 `SseMultiplexerHandle` 형태를 갖추도록 `subscribeMessage`/`subscribeReconnect`/`connected` 보강만 — 실 로직 무변경).
- `tsc --noEmit` clean·`eslint` clean.

## 리뷰 요청
- 카디르군 QA(story #3069 본문의 대조 실험 절차 그대로)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>