### PR TITLE
[SID:3074] 데스크톱 실 알림 발화 코드 신설 — notify_show 호출부 0건 fix

### DIFF
--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -332,3 +332,81 @@ describe('NotificationBell — 로드맵 P2·PR-E L1(드롭다운 패널 elevati
     expect(desktopPanel?.className).not.toMatch(/(^|\s)shadow-lg(\s|$)/);
   });
 });
+
+// story #3074 — 데스크톱 실 알림 발화 코드 신설. window.__sprintableBridge가 있으면 그 경로
+// «만»(브라우저 Notification 병행 금지), 없으면 기존 브라우저 경로 그대로(회귀 0).
+describe('NotificationBell — story #3074 데스크톱 브리지 notify_show', () => {
+  function stubBrowserNotification() {
+    const ctor = vi.fn();
+    vi.stubGlobal('Notification', Object.assign(ctor, { permission: 'granted' }));
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+    return ctor;
+  }
+
+  function emitLiveNotification(overrides: Record<string, unknown> = {}) {
+    const es = FakeEventSource.instances[0]!;
+    return act(async () => {
+      es.emit('notification', {
+        id: 'live-1', event_type: 'story.status_changed', source_entity_type: 'epic', source_entity_id: 'e-9',
+        payload: { summary: '스토리 상태 변경', sender_name: '유나 홀름' }, read_at: null, created_at: '2026-08-25T01:00:00Z',
+        ...overrides,
+      });
+    });
+  }
+
+  it('브리지가 있으면 notify_show를 snake_case payload로 부르고, 브라우저 Notification은 안 부른다', async () => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    stubFetchSequenceByOffset({ 0: { items: [], hasMore: false } });
+    const notificationCtor = stubBrowserNotification();
+    const notifyShow = vi.fn().mockResolvedValue(true);
+    (window as unknown as { __sprintableBridge?: unknown }).__sprintableBridge = { notify_show: notifyShow };
+
+    await openBell();
+    await emitLiveNotification();
+
+    expect(notifyShow).toHaveBeenCalledTimes(1);
+    expect(notifyShow).toHaveBeenCalledWith({
+      event_type: 'story.status_changed',
+      body: '유나 홀름 · 스토리 상태 변경',
+      deeplink_path: '/goals/e-9',
+    });
+    expect(notificationCtor).not.toHaveBeenCalled();
+
+    delete (window as unknown as { __sprintableBridge?: unknown }).__sprintableBridge;
+  });
+
+  it('브리지가 없으면(일반 브라우저) 기존 Notification 경로가 그대로 동작한다(회귀 0)', async () => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    stubFetchSequenceByOffset({ 0: { items: [], hasMore: false } });
+    const notificationCtor = stubBrowserNotification();
+    delete (window as unknown as { __sprintableBridge?: unknown }).__sprintableBridge;
+
+    await openBell();
+    await emitLiveNotification();
+
+    expect(notificationCtor).toHaveBeenCalledTimes(1);
+    expect(notificationCtor).toHaveBeenCalledWith('스토리 상태 변경', { body: '유나 홀름', icon: '/favicon.ico' });
+  });
+
+  it('딥링크로 못 푸는 알림(source_entity_id 없음)이면 deeplink_path가 "/"로 안전 폴백한다', async () => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    stubFetchSequenceByOffset({ 0: { items: [], hasMore: false } });
+    stubBrowserNotification();
+    const notifyShow = vi.fn().mockResolvedValue(true);
+    (window as unknown as { __sprintableBridge?: unknown }).__sprintableBridge = { notify_show: notifyShow };
+
+    await openBell();
+    await emitLiveNotification({ source_entity_type: null, source_entity_id: null, payload: { summary: '시스템 공지' } });
+
+    expect(notifyShow).toHaveBeenCalledWith({
+      event_type: 'story.status_changed',
+      body: '시스템 공지',
+      deeplink_path: '/',
+    });
+
+    delete (window as unknown as { __sprintableBridge?: unknown }).__sprintableBridge;
+  });
+});

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -18,6 +18,7 @@ import { useSseNotifications, type SseEventNotification } from '@/hooks/use-sse-
 import { useFocusTrap } from '@/hooks/use-focus-trap';
 import { useMediaQuery } from '@/lib/use-media-query';
 import { getEventTypeCopy } from '@/services/notification-display';
+import { hasDesktopNotifyBridge, notifyViaDesktopBridge } from '@/lib/desktop-notify-bridge';
 
 type FilterTab = 'all' | 'story' | 'system';
 
@@ -54,7 +55,9 @@ export interface EventNotification {
 
 // export — story #2956 QA changes(카디르+codex, 2026-08-23) 회귀가드(notification-bell.test.tsx)가
 // 전체 컴포넌트 마운트 없이 딥링크 판정만 직접 검증.
-export function getEntityHref(notification: EventNotification): string | null {
+export function getEntityHref(
+  notification: Pick<EventNotification, 'source_entity_type' | 'source_entity_id' | 'payload'>,
+): string | null {
   const { source_entity_type, source_entity_id } = notification;
   if (!source_entity_id) return null;
   switch (source_entity_type) {
@@ -404,9 +407,23 @@ export function NotificationBell() {
       };
       return [notification, ...prev];
     });
+    // story #3074 — 데스크톱 셸(bridge-init.js가 top-frame+정확 origin에서만 window.__sprintableBridge를
+    // 노출)이 있으면 그 경로«만» 쓴다 — 중복/포커스 억제는 네이티브 단독 판정이라 document.hidden
+    // 조건 없이 항상 부른다. 브리지가 없을 때(일반 브라우저)만 기존 웹 Notification 경로(회귀 0).
+    const summary = incoming.payload?.summary ?? getEventTypeCopy(t, incoming.event_type);
+    if (hasDesktopNotifyBridge()) {
+      const body = incoming.payload?.sender_name ? `${incoming.payload.sender_name} · ${summary}` : summary;
+      void notifyViaDesktopBridge({
+        event_type: incoming.event_type,
+        body,
+        deeplink_path: getEntityHref(incoming) ?? '/',
+      });
+      return;
+    }
+
     // 탭 비활성 상태에서 브라우저 알림 표시
     if (document.hidden && 'Notification' in window && Notification.permission === 'granted') {
-      void new Notification(incoming.payload?.summary ?? getEventTypeCopy(t, incoming.event_type), {
+      void new Notification(summary, {
         body: incoming.payload?.sender_name ?? undefined,
         icon: '/favicon.ico',
       });

--- a/apps/web/src/lib/desktop-notify-bridge.ts
+++ b/apps/web/src/lib/desktop-notify-bridge.ts
@@ -1,0 +1,29 @@
+// 데스크톱 셸(sprintable-desktop) ↔ 웹 브릿지 — story #3074(민 레포 bridge-init.js+commands.rs
+// 실물 확인, 페드루 전달). 모바일 native-shell-bridge.ts(window.ReactNativeWebView)와는 완전히
+// 별개 계약 — 이쪽은 top-frame+정확 origin에서만 window.__sprintableBridge가 non-enumerable·
+// writable=false로 노출된다(일반 브라우저·iframe에서는 항상 undefined).
+
+export interface DesktopNotifyPayload {
+  /** 앱이 event_type→고정 렌더한다 — title은 이 계약에 없다(자유문 제목은 설계상 무시). */
+  event_type?: string;
+  body: string;
+  /** 앱 쪽 allowlist 검증(예: "/inbox?tab=gates") — 거부되면 반환값이 false. */
+  deeplink_path: string;
+}
+
+declare global {
+  interface Window {
+    __sprintableBridge?: {
+      notify_show(payload: DesktopNotifyPayload): Promise<boolean>;
+    };
+  }
+}
+
+/** Tauri IPC(rename_all)가 camelCase를 전건 거부하므로 payload 키는 반드시 snake_case. */
+export function hasDesktopNotifyBridge(): boolean {
+  return typeof window !== 'undefined' && typeof window.__sprintableBridge?.notify_show === 'function';
+}
+
+export function notifyViaDesktopBridge(payload: DesktopNotifyPayload): Promise<boolean> {
+  return window.__sprintableBridge!.notify_show(payload);
+}


### PR DESCRIPTION
## 근본 원인

apps/web(웹 코어) 전수에 `__sprintableBridge.notify_show` 호출부가 **0건**이었다(PO grep으로 확定, 본 PR 작업 중 재확인). desktop 수신측(`bridge-init.js`→`commands::notify_show`→`mac_notify::show`, 현대 UN API+권한 granted 확認済)은 완비였지만, 그 API를 **부르는 코드**가 웹 어디에도 없어 실 알림이 구조적으로 발화 불가였다.

### ⚠️AC2 정정 (git 고고학)

`git log --all -S"notify_show"` / `-S"__sprintableBridge"` / `-S"sprintablebridge"`를 이 레포 **전체 히스토리·전체 브랜치**에서 실행해도 매치 **0건**. "리팩터로 호출부가 유실됐다"는 원 스토리 서술은 반증된다 — **애초에 존재한 적이 없었다**가 정확한 표현(페드루 확인·스토리 본문 정정 접수). 7/20 로그의 `notify_show: suppressed` 발신자 정체는 desktop측 사정이라 이 PR 스코프 밖.

## 처방

- 새 `lib/desktop-notify-bridge.ts` — `window.__sprintableBridge` 감지(top-frame+정확 origin에서만 non-enumerable로 노출, `typeof` check)+`notify_show` 래퍼.
- `notification-bell.tsx` `handleSseNotification`에 분기 신설: 브리지 있으면 그 경로**만**(중복/포커스 억제는 네이티브 단독 판정이라 `document.hidden` 조건 없이 항상 호출), 없으면 기존 브라우저 `Notification` 경로 그대로(회귀 0).
- payload는 민 레포 `bridge-init.js`+`commands.rs` 실물 확인 시그니처(페드루 전달) 그대로: snake_case `{ event_type?, body, deeplink_path }` — Tauri IPC `rename_all`이 camelCase를 전건 거부하므로 `title` 필드는 보내지 않는다(앱이 `event_type`→고정 렌더).
- `deeplink_path`는 기존 `getEntityHref` 로직 재사용(파라미터 타입을 `EventNotification` 풀타입에서 필요 필드만의 `Pick`으로 완화 — 회귀 0), 못 풀면 `/` 안전 폴백.

## 검증

- 신규 회귀가드 3건(브리지 있음→bridge만 호출+정확한 payload, 브리지 없음→기존 브라우저 경로 유지, deeplink 폴백) — `git diff→checkout HEAD(+lib 파일 제거)→재실행(genuine RED 2/2)→git apply(+lib 파일 재생성)→재실행(GREEN)` 확인
- 기존 14건 전부 무변경 유지(총 17건)
- 전체 vitest 507 files / 4530 tests green
- `tsc --noEmit` clean
- `eslint` 0 errors
- `pnpm build` EXIT=0

## 잔여

AC3(실기기 왕복 검증)은 이 PR 스코프 밖 — develop 배포 후 선생님 실기기로 확인 필요.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>