### PR TITLE
perf(#3071): realtime-gateway GCE 부팅 시크릿 배치 fetch(컨테이너 기동 N+1→1회)

### DIFF
--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -501,17 +501,56 @@ trap 'rm -f "${STARTUP_SCRIPT_FILE}"' EXIT
     echo '# ⚠️반드시 gcr.io 호스팅 이미지 사용 — Docker Hub(google/cloud-sdk)는 PGA 커버 밖이라'
     echo '#   외부IP 없는 VM에서 pull 불가. gcr.io/google.com/cloudsdktool/cloud-sdk는 PGA로 도달.'
     echo 'docker pull gcr.io/google.com/cloudsdktool/cloud-sdk:slim >/dev/null'
-    echo '# 개별 secret을 컨테이너 gcloud로 읽어 bash 변수에 담는다(값은 stdout로만·디스크 미경유).'
+    echo ''
+    # story #3071(재발방지, 2026-08-25) — story #3070 그라운딩: 예전엔 시크릿 N개(+AR 토큰
+    # 1개)를 각각 별도 `docker run --rm cloud-sdk:slim gcloud ...`로 순차 fetch했다
+    # (컨테이너 N+1회 개별 기동 — 매 부팅마다 cold-start 오버헤드가 겹겹이 쌓여, 신규 서지
+    # VM이 실제로 `/api/v2/ready` 200을 내기까지 3분+ 걸렸고, 그 창에서 GCLB가 502를 냈다).
+    # 컨테이너 기동을 1회로 줄인다 — 안에서 gcloud 프로세스를 N+1번 호출하는 건 그대로지만
+    # (조회 자체를 배치 API로 묶을 만큼 값어치 있는 재작성은 아니다), 컨테이너 기동
+    # 오버헤드(수백ms~1s급)가 겹겹이 쌓이는 부분만 걷어낸다.
+    # NUL(\0) 구분자로 값을 나눈다 — GITHUB_APP_PRIVATE_KEY가 멀티라인 PEM이라 개행 기준
+    # 분리는 안전하지 않다. 각 값은 (기존 `$(...)` 개별 fetch와 동일하게) 후행 개행만
+    # 벗겨진 채로 bash 변수에 담긴다 — 바이트 동일, 회귀 0.
+    echo '# story #3071 — 시크릿 N개+AR 토큰을 한 컨테이너 안에서 순차 조회(컨테이너 기동은 1회).'
+    echo "cat > /tmp/fetch-secrets.sh <<'FETCH_SECRETS_EOF'"
+    echo '#!/bin/bash'
+    echo 'set -euo pipefail'
+    echo 'for name in "$@"; do'
+    echo '  if [ "$name" = "__AR_TOKEN__" ]; then'
+    echo '    val="$(gcloud auth print-access-token)"'
+    echo '  else'
+    echo '    val="$(gcloud secrets versions access latest --secret="$name" --project="$GCP_PROJECT")"'
+    echo '  fi'
+    echo '  printf '"'"'%s\0'"'"' "$val"'
+    echo 'done'
+    echo 'FETCH_SECRETS_EOF'
+    echo ''
+    _secret_names_literal=""
+    _secret_env_names_literal=""
     for pair in ${SECRET_PAIRS}; do
         secret_name="${pair%%:*}"
         env_name="${pair##*:}"
-        echo "${env_name}=\$(docker run --rm gcr.io/google.com/cloudsdktool/cloud-sdk:slim gcloud secrets versions access latest --secret=${secret_name} --project=${GCP_PROJECT})"
+        _secret_names_literal="${_secret_names_literal} '${secret_name}'"
+        _secret_env_names_literal="${_secret_env_names_literal} '${env_name}'"
     done
+    echo "_secret_names=(${_secret_names_literal} '__AR_TOKEN__')"
+    echo "_secret_env_names=(${_secret_env_names_literal} '_AR_TOKEN')"
+    echo "mapfile -d '' -t _secret_values < <(docker run --rm -e GCP_PROJECT=\"${GCP_PROJECT}\" -v /tmp/fetch-secrets.sh:/fetch-secrets.sh:ro gcr.io/google.com/cloudsdktool/cloud-sdk:slim bash /fetch-secrets.sh \"\${_secret_names[@]}\")"
+    echo '# 순서(secret_names/secret_values/env_names 셋)가 어긋나면 엉뚱한 시크릿이 엉뚱한'
+    echo '# env로 실릴 수 있다 — 개수 불일치를 fail-closed로 잡는다(조용한 어긋남보다 배포 중단이 낫다).'
+    echo 'if [ "${#_secret_values[@]}" -ne "${#_secret_names[@]}" ]; then'
+    echo '  echo "FATAL: fetched ${#_secret_values[@]} secrets, expected ${#_secret_names[@]}" >&2'
+    echo '  exit 1'
+    echo 'fi'
+    echo 'for _i in "${!_secret_env_names[@]}"; do'
+    echo '  declare "${_secret_env_names[$_i]}=${_secret_values[$_i]}"'
+    echo 'done'
+    echo '# story #3071 fetch-secrets block end (DRY_RUN sed 종료 마커 — 지우지 말 것)'
     echo ''
     echo '# 앱 이미지는 사설 Artifact Registry에 있어 docker 인증 필요 — COS docker는 AR 자동인증이'
     echo '# 안 된다(public gcr.io는 무인증 pull됐지만 사설 AR은 "Unauthenticated request" 거절, 실측).'
     echo '# VM SA(artifactregistry.reader 보유)의 access token으로 해당 AR 호스트에 docker login.'
-    echo "_AR_TOKEN=\$(docker run --rm gcr.io/google.com/cloudsdktool/cloud-sdk:slim gcloud auth print-access-token)"
     echo "echo \"\${_AR_TOKEN}\" | docker login -u oauth2accesstoken --password-stdin https://${_AR_HOST}"
     echo ''
     # ⛔story #2142(2026-07-23, 오르테가 지적 — 자기 지시가 만든 결함 자인) — 이전엔 여기서
@@ -576,6 +615,9 @@ if [ "${DRY_RUN}" = "1" ]; then
     # startup-script에 실제로 적힌 uvicorn 커맨드 그 줄 자체를 노출해, 변수→실제 산출물
     # 배선이 끊기지 않았는지 테스트가 직접 대조할 수 있게 한다.
     _GENERATED_UVICORN_CMD_LINE="$(grep '^  uvicorn ' "${STARTUP_SCRIPT_FILE}")"
+    # story #3071 — 같은 관례: 시크릿 배치 fetch 로직(embedded fetch-secrets.sh + 재조립
+    # 루프)이 실제로 생성된 그대로를 노출한다(요약 변수가 아니라 산출물 자체).
+    _GENERATED_FETCH_SECRETS_BLOCK_B64="$(sed -n '/^cat > \/tmp\/fetch-secrets\.sh/,/^# story #3071 fetch-secrets block end/p' "${STARTUP_SCRIPT_FILE}" | base64 | tr -d '\n')"
     cat <<EOF
 ENV=${ENV}
 MIG_NAME=${MIG_NAME}
@@ -591,6 +633,7 @@ SECRET_PAIRS=${SECRET_PAIRS}
 GENERATED_PLAIN_ENV_FILE_B64=${_GENERATED_PLAIN_ENV_FILE_B64}
 UVICORN_APP_MODULE=${UVICORN_APP_MODULE}
 GENERATED_UVICORN_CMD_LINE=${_GENERATED_UVICORN_CMD_LINE}
+GENERATED_FETCH_SECRETS_BLOCK_B64=${_GENERATED_FETCH_SECRETS_BLOCK_B64}
 EOF
     exit 0
 fi

--- a/backend/tests/test_deploy_realtime_gce_secret_batching.py
+++ b/backend/tests/test_deploy_realtime_gce_secret_batching.py
@@ -1,0 +1,196 @@
+"""story #3071(재발방지, 2026-08-25) — realtime-gateway GCE startup-script의 시크릿
+배치 fetch 회귀가드.
+
+배경: story #3070 그라운딩 — 시크릿 12개+AR 토큰 1개를 매번 별도
+`docker run --rm cloud-sdk:slim gcloud ...`로 순차 fetch(컨테이너 13회 개별 기동)하던 것이
+신규 서지 VM의 실제 서빙 가능 시점을 3분+로 늘려, MIG 롤링배포(max-surge=zone수·
+max-unavailable=0, 설계상 무중단)에도 실측 ~2분 502 창을 만들었다. 컨테이너 기동을
+1회로 줄이는 처방(deploy_realtime_gce.sh)의 두 계약을 여기서 고정한다:
+
+①구조: 생성된 startup-script가 실제로 컨테이너 기동을 1회만 쓰는지(docker run 1건).
+②동작: NUL(\\0) 구분 재조립이 멀티라인 시크릿(GITHUB_APP_PRIVATE_KEY류 PEM)에서도
+  값이 안 섞이고, 각 값이 기존 `$(...)` 개별 fetch와 동일하게 후행 개행만 벗겨진
+  채로 정확한 env 변수에 실리는지 — 실 bash 서브프로세스로 스텁 gcloud/docker를 통해
+  검증한다(요약이 아니라 생성된 코드 그 자체를 실행).
+"""
+from __future__ import annotations
+
+import base64
+import os
+import re
+import stat
+import subprocess
+import tempfile
+
+_SCRIPTS = os.path.join(os.path.dirname(__file__), "..", "scripts")
+_DEPLOY_GCE = os.path.join(_SCRIPTS, "deploy_realtime_gce.sh")
+
+
+def _resolve(env: str) -> dict[str, str]:
+    proc = subprocess.run(
+        ["bash", _DEPLOY_GCE, env],
+        capture_output=True, text=True, env={**os.environ, "DRY_RUN": "1"}, check=True,
+    )
+    cfg: dict[str, str] = {}
+    for line in proc.stdout.strip().splitlines():
+        if "=" in line:
+            k, _, v = line.partition("=")
+            cfg[k.strip()] = v.strip()
+    return cfg
+
+
+def _fetch_secrets_block(env: str = "dev") -> str:
+    cfg = _resolve(env)
+    return base64.b64decode(cfg["GENERATED_FETCH_SECRETS_BLOCK_B64"]).decode()
+
+
+# ─── ①구조: 컨테이너 기동 1회(N+1회가 아니라) ─────────────────────────────────
+
+def test_secret_fetch_uses_exactly_one_docker_run_invocation():
+    block = _fetch_secrets_block()
+    # heredoc(cat > /tmp/fetch-secrets.sh ... FETCH_SECRETS_EOF) 안의 gcloud 호출은
+    # 컨테이너 기동이 아니다(컨테이너 「안에서」 도는 프로세스) — 실제 `docker run`
+    # 호출 자체만 센다.
+    docker_run_calls = re.findall(r"\bdocker run --rm\b", block)
+    assert len(docker_run_calls) == 1, f"docker run 호출이 1건이어야 하는데: {docker_run_calls}"
+
+
+def test_secret_names_array_matches_secret_pairs_order_plus_ar_token():
+    cfg = _resolve("dev")
+    block = _fetch_secrets_block()
+    pair_secret_names = [p.split(":", 1)[0] for p in cfg["SECRET_PAIRS"].split()]
+    expected = pair_secret_names + ["__AR_TOKEN__"]
+
+    m = re.search(r"^_secret_names=\(([^)]*)\)", block, flags=re.MULTILINE)
+    assert m, "startup-script에 _secret_names 배열이 있어야 한다"
+    actual = re.findall(r"'([^']*)'", m.group(1))
+    assert actual == expected
+
+
+def test_secret_env_names_array_matches_secret_pairs_order_plus_ar_token_var():
+    cfg = _resolve("dev")
+    block = _fetch_secrets_block()
+    pair_env_names = [p.split(":", 1)[1] for p in cfg["SECRET_PAIRS"].split()]
+    expected = pair_env_names + ["_AR_TOKEN"]
+
+    m = re.search(r"^_secret_env_names=\(([^)]*)\)", block, flags=re.MULTILINE)
+    assert m, "startup-script에 _secret_env_names 배열이 있어야 한다"
+    actual = re.findall(r"'([^']*)'", m.group(1))
+    assert actual == expected
+
+
+def test_secret_count_mismatch_is_fail_closed():
+    """순서가 어긋나 개수가 안 맞으면(예: docker/gcloud 부분 실패) 조용히 진행하지
+    않고 명시적으로 죽어야 한다 — «조용한 어긋남보다 배포 중단이 낫다»."""
+    block = _fetch_secrets_block()
+    assert '"${#_secret_values[@]}" -ne "${#_secret_names[@]}"' in block
+    assert "exit 1" in block
+
+
+# ─── ②동작: NUL 구분 재조립 — 실 bash 서브프로세스, 스텁 gcloud/docker ─────────
+
+_STUB_GCLOUD = """#!/bin/bash
+# 테스트 스텁 — 실제 gcloud 대신 알려진 값을 돌려준다. 각 값은 실 Secret Manager
+# payload처럼 "그 자체"를 stdout에 낸다(트레일링 개행 유무는 값마다 다르게 둬서
+# $(...) 트레일링-개행-스트립 동작이 배치 경로에서도 유지되는지 검증).
+if [ "$1" = "auth" ] && [ "$2" = "print-access-token" ]; then
+  printf 'stub-ar-token\\n'
+  exit 0
+fi
+# gcloud secrets versions access latest --secret=NAME --project=PROJ
+secret_name=""
+for arg in "$@"; do
+  case "$arg" in
+    --secret=*) secret_name="${arg#--secret=}" ;;
+  esac
+done
+case "$secret_name" in
+  DATABASE_URL_DEV) printf 'postgresql://u:p@host/db\\n\\n\\n' ;;  # 트레일링 개행 여러 개 — 전부 스트립돼야 함
+  github-app-private-key-dev)
+    # PEM 멀티라인 — 내부 개행은 절대 깨지면 안 됨(이 테스트의 핵심 대상).
+    printf -- '-----BEGIN RSA PRIVATE KEY-----\\nline1\\nline2\\nline3\\n-----END RSA PRIVATE KEY-----\\n'
+    ;;
+  *) printf 'stub-value-for-%s' "$secret_name" ;;  # 트레일링 개행 아예 없는 값도 커버
+esac
+"""
+
+_STUB_DOCKER = """#!/bin/bash
+# 실 컨테이너 없이 fetch-secrets.sh를 그 자리에서 직접 돈다 — 이 테스트는 "컨테이너를
+# 실제로 격리하는가"가 아니라 "생성된 fetch-secrets.sh + 재조립 로직이 올바른가"만
+# 본다(컨테이너화 자체는 story #3070/#3071 그라운딩에서 이미 실 배포로 확認됨).
+# docker run --rm -e GCP_PROJECT="..." -v /path/fetch-secrets.sh:/fetch-secrets.sh:ro IMAGE bash /fetch-secrets.sh NAME...
+# 실 docker는 -e KEY=VALUE를 컨테이너 프로세스 환경에 자동 주입한다 — 스텁도 동일하게
+# 그 값을 export해 자식 bash(fetch-secrets.sh)가 $GCP_PROJECT를 받도록 재현한다.
+script_path=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-v" ]; then
+    script_path="${arg%%:*}"
+  fi
+  if [ "$prev" = "-e" ]; then
+    export "$arg"
+  fi
+  prev="$arg"
+done
+shift_count=0
+found_bash=0
+args=()
+for arg in "$@"; do
+  if [ "$found_bash" = "1" ]; then
+    if [ "$arg" = "/fetch-secrets.sh" ]; then continue; fi
+    args+=("$arg")
+  fi
+  if [ "$arg" = "bash" ]; then found_bash=1; fi
+done
+exec bash "$script_path" "${args[@]}"
+"""
+
+
+def test_batched_secret_fetch_preserves_multiline_pem_and_strips_trailing_newlines_only():
+    block = _fetch_secrets_block()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        stub_bin = os.path.join(tmp, "bin")
+        os.makedirs(stub_bin)
+        gcloud_path = os.path.join(stub_bin, "gcloud")
+        docker_path = os.path.join(stub_bin, "docker")
+        with open(gcloud_path, "w") as f:
+            f.write(_STUB_GCLOUD)
+        with open(docker_path, "w") as f:
+            f.write(_STUB_DOCKER)
+        os.chmod(gcloud_path, os.stat(gcloud_path).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        os.chmod(docker_path, os.stat(docker_path).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+        # fetch-secrets.sh 자신은 heredoc이 실제로 /tmp에 쓴다고 가정하지만, 여기선
+        # startup-script 전체를 그대로 실행해 그 heredoc이 스스로를 파일로 떨어뜨리게
+        # 한다(생성된 코드 자체를 실행 — 재구현 아님). 그 뒤 재조립 결과를 echo로 확인.
+        harness = block + "\necho \"__RESULT_DATABASE_URL__=${DATABASE_URL}\"\n"
+        harness += "echo \"__RESULT_PEM_BEGIN__\"\n"
+        harness += 'printf "%s" "${GITHUB_APP_PRIVATE_KEY}"\n'
+        harness += "echo \"__RESULT_PEM_END__\"\n"
+        harness += "echo \"__RESULT_AR_TOKEN__=${_AR_TOKEN}\"\n"
+        harness += 'echo "__RESULT_JWT__=${JWT_SECRET}"\n'
+
+        proc = subprocess.run(
+            ["bash", "-c", harness],
+            capture_output=True, text=True,
+            env={**os.environ, "PATH": f"{stub_bin}:{os.environ['PATH']}"},
+        )
+        assert proc.returncode == 0, f"stderr:\n{proc.stderr}\nstdout:\n{proc.stdout}"
+
+        # story #2442류 트레일링 개행 스트립 — 배치 경로도 $(...) 개별 fetch와 바이트 동일해야 함.
+        assert "__RESULT_DATABASE_URL__=postgresql://u:p@host/db" in proc.stdout
+        assert "postgresql://u:p@host/db\n\n" not in proc.stdout  # 트레일링 개행이 안 남아야 함
+
+        # 멀티라인 PEM — 내부 개행 보존, 다른 시크릿과 안 섞임(NUL 구분의 핵심 증명).
+        pem_start = proc.stdout.index("__RESULT_PEM_BEGIN__\n") + len("__RESULT_PEM_BEGIN__\n")
+        pem_end = proc.stdout.index("__RESULT_PEM_END__")
+        pem_value = proc.stdout[pem_start:pem_end]
+        # $(...) 캡처는 모든 시크릿에 대해(멀티라인이어도) 후행 개행만 벗긴다 — 기존
+        # per-secret `$(docker run ...)` 캡처와 정확히 동일한 규칙. 내부 개행 3곳은 보존.
+        assert pem_value == (
+            "-----BEGIN RSA PRIVATE KEY-----\nline1\nline2\nline3\n-----END RSA PRIVATE KEY-----"
+        )
+
+        assert "__RESULT_AR_TOKEN__=stub-ar-token" in proc.stdout
+        assert "__RESULT_JWT__=stub-value-for-JWT_SECRET" in proc.stdout


### PR DESCRIPTION
[SID:3071]

## 요약
story #3070 그라운딩(P0 라이브 장애) — `sprintable-realtime-gateway-dev` MIG 롤링배포(`--max-unavailable=0 --max-surge=<zone수>`, 설계상 무중단)인데도 실측 ~2분 502가 났다. 근본원인 一部: startup-script가 시크릿 12개(prod는 14개)+AR 토큰 1개를 매번 개별 `docker run --rm cloud-sdk:slim gcloud ...`로 순차 fetch(컨테이너 13~15회 개별 기동) — 신규 서지 VM이 실제로 `/api/v2/ready` 200을 내기까지 3분+ 걸려 무중단 창의 실제 타이트함을 늘렸다.

## 변경
컨테이너 기동을 1회로 줄인다 — 시크릿 이름 목록을 하나의 `fetch-secrets.sh`에 넘겨 그 안에서 `gcloud`를 N+1번 순차 호출한다(gcloud 프로세스 호출 자체는 그대로지만, 컨테이너 cold-start 오버헤드만 걷어낸다). NUL(`\0`) 구분자로 값을 나눠 `GITHUB_APP_PRIVATE_KEY` 같은 멀티라인 PEM 값도 안전하게 처리 — 개행 기준 파싱은 이 값 때문에 애초에 못 쓴다. 각 값은 기존 `$(...)` 개별 fetch와 동일하게 후행 개행만 벗겨진다(바이트 동일, 회귀 0). 개수 불일치는 fail-closed(조용한 어긋남보다 배포 중단이 낫다).

## 검증
- DRY_RUN에 `GENERATED_FETCH_SECRETS_BLOCK_B64` 필드 신설 — 기존 `GENERATED_PLAIN_ENV_FILE_B64`/`GENERATED_UVICORN_CMD_LINE`과 동일 관례(요약이 아니라 실제 생성된 산출물을 검증 대상으로 삼는다, story #2142 교훈).
- 신규 테스트 5건(`test_deploy_realtime_gce_secret_batching.py`):
  - `docker run` 호출 정확히 1건.
  - `_secret_names`/`_secret_env_names` 배열이 `SECRET_PAIRS` 순서와 정확히 일치(dev 확認).
  - 개수 불일치 fail-closed 코드 존재.
  - **실 bash 서브프로세스 + 스텁 `gcloud`/`docker`로 멀티라인 PEM 왕복 검증** — 내부 개행 보존·후행 개행만 스트립·AR 토큰/JWT 등 다른 시크릿과 안 섞임(NUL 구분의 핵심 증명). 이 테스트가 실제로 스텁 자체의 버그 2건(docker `-e` 환경변수 미전달·정규식 앵커 오류)을 잡아 재현→수정했다.
- 기존 `test_deploy_realtime_gce_env.py` 39건 회귀 0.
- `bash -n` 문법 체크·`shellcheck` — 신규 경고 0(기존 SC2016류는 파일 전체의 기존 관례, 이 PR과 무관).
- `DRY_RUN=1`로 dev(13개)·prod(14개, `REDIS_URL_PROD` 포함) 둘 다 수동 확認.

## 스코프 밖(story #3071 본문에 별도 등재)
- GCLB 신규-인스턴스 편입 타이밍(서지 인스턴스 그룹 편입↔헬스 판정 원자성) 조사·완화는 이 PR 스코프 밖 — 부팅 시간 단축만으로도 무중단 창이 실질적으로 넓어져 완화 효과가 있으나, 근본적인 원자성 문제 자체는 별도 판단 필요.

## 리뷰 요청
- 인프라 변경 성격이라 페드루 PO 판단 위임

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>