### PR TITLE
[SID:3075] P0 코너컷(proof-cut) 전면 폐지 — 체감되는 재질(그레인+깊이+엠보스)로 교체

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx
@@ -479,15 +479,16 @@ export function DocsClientLayout({ children, wsSlug, projSlug, projectId }: Docs
                 )}
               </span>
             </button>
-            {/* story #2963 §2 — collapsible pill → .proof-cut 칩(선택=blue-soft/blue·비선택=
-                sunk/ink-3). selectedTags state·toggle 로직은 완전 무변경. */}
+            {/* story #2963 §2 — collapsible pill 칩. selectedTags state·toggle 로직은 완전
+                무변경. story #7d7634ee(P0) — proof-cut-xs(컷코너) 폐지, proof-surface-press
+                (재질 언어) 채택. */}
             {!tagsCollapsed && (
               <div className="flex max-h-[120px] flex-wrap gap-1 overflow-y-auto px-4 py-1">
                 {allTags.map((tag) => (
                   // story #3053(2984-S5) — 선택 상태는 subtle 헤어라인 채택, bg-proof-blue-soft
                   // 채움 폐지(비선택 bg-proof-sunk는 무채 중립 배경이라 SHIFT 대상 밖 — S1
                   // 선례와 동형).
-                  <button key={tag} type="button" onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((tg) => tg !== tag) : [...prev, tag])} className={`proof-cut-xs px-2 py-0.5 text-[11px] font-semibold transition ${selectedTags.includes(tag) ? 'border border-proof-line bg-transparent text-foreground' : 'bg-proof-sunk text-proof-ink-3 hover:bg-muted'}`}>
+                  <button key={tag} type="button" onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((tg) => tg !== tag) : [...prev, tag])} className={`proof-surface proof-surface-press px-2 py-0.5 text-[11px] font-semibold transition ${selectedTags.includes(tag) ? 'border border-proof-line bg-transparent text-foreground' : 'bg-proof-sunk text-proof-ink-3 hover:bg-muted'}`}>
                     #{tag}
                   </button>
                 ))}

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-index.tsx
@@ -36,12 +36,15 @@ type StatusFilter = DocStatusFilter;
 const STATUS_FILTERS: StatusFilter[] = ['confirmed', 'pending', 'denied', 'draft'];
 const UNCATEGORIZED = '__uncategorized__';
 
-function StatusChip({ status, size = 'sm' }: { status: string | undefined; size?: 'sm' | 'xs' }) {
+// story #7d7634ee(P0) — proof-cut(컷코너, 옛 sm/xs 사선 크기 모디파이어)는 폐지되고
+// proof-surface(13px 균일 라운드)로 수렴 — size prop이 지오메트리 결정에만 쓰였으므로 그
+// 존재 이유가 없어져 제거(호출부 중 유일하게 size="xs"를 넘기던 자리도 함께 정리).
+function StatusChip({ status }: { status: string | undefined }) {
   const t = useTranslations('docs');
   const s = toDocStatusFilter(status);
   const tone = DOC_STATUS_TONE[s];
   return (
-    <span className={`proof-cut proof-cut-${size} inline-flex shrink-0 items-center gap-1.5 px-2.5 py-1 text-[11.5px] font-bold ${tone.bg} ${tone.text}`}>
+    <span className={`proof-surface proof-surface-press inline-flex shrink-0 items-center gap-1.5 px-2.5 py-1 text-[11.5px] font-bold ${tone.bg} ${tone.text}`}>
       <span className={`size-1.5 rounded-full ${tone.dot}`} aria-hidden="true" />
       {t(docStatusLabelKey(s))}
     </span>
@@ -226,7 +229,7 @@ export function DocsIndex() {
               onClick={() => goToDoc(doc.slug)}
               className="flex flex-col items-start gap-2 rounded-lg border border-border bg-card p-4 text-left transition hover:border-foreground/30"
             >
-              <StatusChip status={doc.status} size="xs" />
+              <StatusChip status={doc.status} />
               <span className="text-editorial-claim font-editorial-claim text-foreground line-clamp-2">{doc.title}</span>
               <span className="mt-auto font-mono text-[10.5px] text-muted-foreground">{formatDate(doc.updated_at)}</span>
             </button>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.test.tsx
@@ -319,13 +319,14 @@ describe('EpicDetailPage — 결과 캡슐 재조립(§2 이중 신호·§4 신�
     expect(container.textContent).toContain('목표 생성');
   });
 
-  // story #3053(2984-S5) — Outcome Capsule은 헤어라인+elev(border-proof-line·bg-proof-panel·
-  // --elev-card)를 쓰고 bg-proof-blue-soft 채움은 안 쓴다.
-  it('결과 캡슐 — 헤어라인+elev를 쓰고 bg-proof-blue-soft는 안 쓴다', async () => {
+  // story #3053(2984-S5) — Outcome Capsule은 헤어라인+elev(border-proof-line·bg-proof-panel)를
+  // 쓰고 bg-proof-blue-soft 채움은 안 쓴다.
+  // story #7d7634ee(P0) — proof-cut(컷코너) 폐지, proof-surface-lift(재질 언어) 채택.
+  it('결과 캡슐 — 헤어라인+재질을 쓰고 bg-proof-blue-soft는 안 쓴다', async () => {
     await mountByUrl({ outcome_status: 'hit' });
-    const capsule = container.querySelector('.proof-cut.border-proof-line');
+    const capsule = container.querySelector('.proof-surface.border-proof-line');
     expect(capsule).toBeTruthy();
-    expect(capsule?.className).toContain('shadow-[var(--elev-card)]');
+    expect(capsule?.className).toContain('proof-surface-lift');
     expect(container.querySelector('.bg-proof-blue-soft')).toBeNull();
   });
 

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
@@ -420,7 +420,7 @@ export default function EpicDetailPage() {
             story #2974(PR-D0) delta — 아래 두 숫자는 doc상 Display 대상이 아니라(유나 확定)
             font-display는 안 붙이고 font-editorial-heading(무게 유틸, 820)만 유지한다. */}
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          <div className="proof-cut border border-border bg-card px-4 py-3.5">
+          <div className="proof-surface proof-surface-lift border border-border bg-card px-4 py-3.5">
             <div className="font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">{t('taskCapsuleTitle')}</div>
             <div className="mt-1.5 flex items-baseline gap-2">
               <span className="font-editorial-heading text-[26px] tracking-[-0.02em] text-foreground">{done}/{stories.length}</span>
@@ -433,9 +433,11 @@ export default function EpicDetailPage() {
           </div>
           {/* story #3053(2984-S5) — 헤어라인+elev(S1 재질 언어) 채택, bg-proof-blue-soft 채움
               폐지. 강조 색은 이 카드의 항상-고정 blue(상태별 분기 없음, 기존 동작 그대로)를
-              proof-line 헤어라인+elev-card 깊이로 이전 — 텍스트 강조는 유지(신호가 아니라
-              위계라 색 텍스트는 남긴다, MaterialChip류의 "장식 fill"과는 다른 자리). */}
-          <div className="proof-cut border border-proof-line bg-proof-panel px-4 py-3.5 shadow-[var(--elev-card)]">
+              proof-line 헤어라인+깊이로 이전 — 텍스트 강조는 유지(신호가 아니라 위계라 색
+              텍스트는 남긴다, MaterialChip류의 "장식 fill"과는 다른 자리).
+              story #7d7634ee(P0) — elev-card는 proof-surface-lift로 흡수(두 elevation
+              시스템 이중 적용 방지, box-shadow 충돌 제거). */}
+          <div className="proof-surface proof-surface-lift border border-proof-line bg-proof-panel px-4 py-3.5">
             <div className="font-mono text-[10px] uppercase tracking-[0.1em] text-proof-blue">{t('outcomeCapsuleTitle')}</div>
             <div className="mt-1.5 font-editorial-heading text-[22px] tracking-[-0.02em] text-proof-blue">
               {epic.outcome_status === 'hit' ? t('outcomeCapsuleHit')

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
@@ -218,21 +218,16 @@ describe('GoalsClient — 결과 원장 재조립(§2 이중 신호·§3 마스�
   // PR#3387 처방 갱신(유나 원작자 정본 채택, PO 2026-08-23) — 미르코의 첫 처방("done&&hit만
   // green")조차 두 축(작업/결과)을 섞는 것이었다. 최종 규율: **상태 칩은 green을 아예 안 쓴다**
   // (done+hit이어도) — green은 결과 필(OutcomeStatusBadge, bg-success-tint)에만 존재한다.
+  // ⚠️story #7d7634ee(P0) 작업 중 실측 발견 — 이 두 테스트는 `.proof-cut-xs` 셀렉터로 상태
+  // 칩을 찾았으나, story #3053(2984-S5)이 이미 상태 칩을 MaterialChip(proof-cut 계열 아님,
+  // rounded-md 헤어라인)으로 교체해서 origin/develop HEAD 기준으로도 이미 죽은 셀렉터였다
+  // (querySelector가 null 반환 → 두 테스트 다 무단언으로 조용히 깨져 있었음, #3399 clip-path
+  // 가드는 그 기제 자체가 이 요소엔 원래 없었으니 통째로 무의미해 삭제 — 아래 첫 테스트만
+  // MaterialChip의 새 `data-slot="material-chip"` 훅으로 셀렉터 갱신해 되살린다).
   it('상태 칩 — done+hit이어도 상태 칩 자체엔 green 클래스가 없다(두 축 분리)', async () => {
     stubFetch([{ id: 'e1', title: 'H', status: 'done', total_stories: 1, done_stories: 1, outcome_status: 'hit' }]);
     await mount();
-    expect(container.querySelector('.proof-cut-xs')?.className).not.toContain('proof-green');
-  });
-
-  // QA독립검증(카디르, PR#3399) — globals.css의 .proof-cut-xs는 --proof-cut 값만 바꾸고
-  // clip-path 자체를 여는 .proof-cut 베이스 클래스가 없으면 컷이 안 그려진다(#2958 원 커밋
-  // 버그, #3399가 수정). 이 회귀를 잡는 전용 테스트가 없었다 — 뮤테이션으로 확인(베이스 클래스
-  // 제거해도 기존 16건 전부 그대로 PASS) 후 신설. PR-2(card 층)에 편입 예정(PO 처분).
-  it('상태 칩이 proof-cut 베이스 클래스를 갖는다(proof-cut-xs만으론 clip-path 안 열림, #3399 회귀가드)', async () => {
-    stubFetch([{ id: 'e1', title: 'H', status: 'done', total_stories: 1, done_stories: 1 }]);
-    await mount();
-    const chip = container.querySelector('.proof-cut-xs');
-    expect(chip?.className.split(' ')).toContain('proof-cut');
+    expect(container.querySelector('[data-slot="material-chip"]')?.className).not.toContain('proof-green');
   });
 
   it('green은 결과 필(OutcomeStatusBadge)에서만 뜬다 — outcome=hit일 때 bg-success-tint가 존재', async () => {

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -597,18 +597,18 @@ function GoalRow({ epic, isSelected, onClick, onDeleteRequest, sortable }: GoalR
         onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onClick(); }}
       >
         <div className="flex items-start justify-between gap-2">
-          {/* story #2958 §2/§3 — 상태 칩(proof-cut-xs)+결과 필이 이중 신호의 «상태·결과» 열.
-              status 배지(원래 shadcn Badge)는 그대로 두되(우측 무리에 존속, 회귀 없음), 왼쪽에
-              proof 색규율을 따르는 신규 컷코너 칩을 하나 더 앞세운다 — outcome은 기존
-              OutcomeStatusBadge를 그대로 재사용(발명 0, 색 의미 불변).
+          {/* story #2958 §2/§3 — 상태 칩+결과 필이 이중 신호의 «상태·결과» 열. status 배지
+              (원래 shadcn Badge)는 그대로 두되(우측 무리에 존속, 회귀 없음), 왼쪽에 proof
+              색규율을 따르는 신규 칩을 하나 더 앞세운다 — outcome은 기존 OutcomeStatusBadge를
+              그대로 재사용(발명 0, 색 의미 불변). ⚠️상태 칩 자체는 story #3053(2984-S5)이 아래
+              MaterialChip으로 대체해 컷코너(proof-cut-xs)는 이 자리에서 이미 죽은 얘기다(주석만
+              #2969 PR-1의 원 버그·#2958 원 커밋 실수 이력을 참고용으로 남겨둠) — story
+              #7d7634ee(P0) 컷코너 전면 폐지와도 무관(여기는 애초에 clip-path가 없었음).
               ⚠️PR#3387 카디르 QA(2026-08-23)·유나 원작자 정본 채택(PO 갱신 지시) — **상태 칩은
               green을 아예 안 쓴다**(done+hit이어도). green은 결과(Verified) 필(OutcomeStatusBadge)
               전용 — 두 축이 색에서도 안 섞여야 "일 끝≠목표 달성"이 시각으로 선다(작업 축의 첫
               처방 "done&&hit만 green"조차 두 축을 섞는 것이라 유나 판정으로 대체됨). */}
           <div className="flex shrink-0 flex-col items-start gap-1">
-            {/* story #2969 PR-1 발견 버그 — 아래 proof-cut-xs가 --proof-cut 값만 바꾸고
-                clip-path 자체를 여는 proof-cut 베이스 클래스가 빠져 있어(#2958 원 커밋 실수)
-                컷 자체가 안 그려지고 있었다(globals.css 참고). 즉시 수정. */}
             {/* story #3053(2984-S5) — MaterialChip(S1, 헤어라인+fill 0) 채택, 상태별
                 bg-proof-blue-soft/bg-proof-sunk 채움 폐지. dot 신호(active=blue·비active=
                 faint)는 이미 있던 신호라 그대로 KEEP. */}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -306,8 +306,9 @@
   --chart-5: oklch(0.274 0.006 286.033);
   /* story #2969 §1.1(PR-T, 유나 확定 2026-08-23) — 0.625rem(10px, shadcn 기본값)→0.25rem(4px).
      전 표면 균일 soft round(default 결)를 크리스프로. 파생 스케일(sm~4xl)은 이 값의 calc()라
-     자동 추종 — 별도 편집 불요. 시그니처면(히어로 카드·활성 상태 등)은 이 반경 대신 `.proof-cut`
-     컷코너를 쓴다(적용 표면 목록=doc proofline-system-layer-2969 §1.4가 정본, 이 PR은 토큰만). */
+     자동 추종 — 별도 편집 불요. 시그니처면(히어로 카드·활성 상태 등)은 이 반경 대신
+     `.proof-surface`(story #7d7634ee, 옛 `.proof-cut` 컷코너 폐지 후 계승)를 쓴다(적용
+     표면 목록=doc proofline-system-layer-2969 §1.4가 원 정본, 재질은 doc ea94dac4가 갱신). */
   --radius: 0.25rem;
   /* story #2917: sidebar도 --card/--primary/--muted/--border/--ring과 같은 값을 거울처럼
      따라간다(기존 #2318 불변식 — "안 맞추면 사이드바만 옛 파랑" 그대로 유지, 소스만 proof-*로). */
@@ -481,28 +482,57 @@
      더하는 2차 레이어 — elev-card/overlay(뜬 표면용)와 별개, 절대 함께 안 쓴다. */
   --elev-inset: inset 0 1px 0 rgba(255, 255, 255, .6), inset 0 -1px 0 rgba(20, 21, 15, .05);
 
-  /* story #2955 §5(doc docs-index-reader-redesign-handoff) — 컷코너 3단 토큰 정식화.
-     기존 산발 clip-path 4곳(proof-capsule.tsx CutCornerShell·attention-queue-view.tsx·
-     artifact-gallery-view.tsx·workcell.tsx)이 정본 없이 각자 인라인으로 같은 지오메트리를
-     반복하다 artifact-gallery-view.tsx만 22px로 드리프트했다(정본 부재가 벌린 값 그 자체가
-     정식화 근거). 라이트/다크 무관(색이 아니라 지오메트리)이라 이 블록 한 곳에서만 정의. */
-  --proof-cut: 24px;
-  --proof-cut-sm: 16px;
-  --proof-cut-xs: 8px;
+  /* story #7d7634ee(P0·선생님 직접 지시, 감確認 doc ea94dac4 §③~⑤) — 컷코너(clip-path 사선)
+     전면 폐지. "빼기"(헤어라인+옅은 그림자)가 질감으로 안 읽힌다는 질책 → "더하기"(그레인·
+     방향 깊이·엠보스)로 정정. 소프트 라운드 13px가 사선 클립을 대체한다. */
+  --proof-radius-soft: 13px;
+
+  /* §⑤ 정본 — SVG fractalNoise baseFrequency 0.62. RGB는 0으로 죽이고 alpha만 노이즈값을
+     실어 순수 그레인 텍스처로 쓴다(색조는 오버레이하는 쪽의 opacity/mix-blend-mode가 결정 —
+     라이트/다크가 같은 SVG를 공유해도 되는 이유). 강도(라이트 22%/다크 16%)와 블렌드모드
+     (라이트 multiply/다크 overlay)는 별도 변수로 분리해 테마별로만 오버라이드한다. */
+  --paper-grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.62' numOctaves='2' stitchTiles='stitch' result='noise'/%3E%3CfeColorMatrix in='noise' type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  --paper-grain-opacity: .22;
+  --paper-grain-blend: multiply;
+
+  /* §⑤ 정본값 그대로 — "뜬" 표면(카드·캡슐)의 방향성 다층 그림자 + 상단 하이라이트. */
+  --elev-lift: 0 10px 24px -8px rgba(20, 21, 15, .20), 0 2px 6px -2px rgba(20, 21, 15, .14), inset 0 1px 0 rgba(255, 255, 255, .85);
+
+  /* §⑤ 정본값 그대로 — "눌린" 표면(씰·칩)의 인셋 프레스. */
+  --emboss-press: inset 0 1px 2px rgba(20, 21, 15, .14), inset 0 -1px 0 rgba(255, 255, 255, .7);
+
+  /* §⑤ — 프로스티드 글래스, 오버레이/모달 전용(이 PR의 A/B/C급 소비처엔 아직 없음 — 토큰만
+     선신설, 실 소비는 모달/오버레이 표면 착수 시). */
+  --glass-overlay-filter: blur(14px) saturate(1.3);
+  --glass-overlay-bg: rgba(252, 251, 247, .62);
 }
 
-/* story #2955 §5 — `.proof-cut`가 지오메트리 계산 유일 정본. 크기 모디파이어
-   (`.proof-cut-sm`/`.proof-cut-xs`)는 `--proof-cut` 값만 바꿔치기하고 계산식은 재정의하지
-   않는다(합성 — `className="proof-cut proof-cut-sm"`). 인스턴스별 임의값이 필요하면(예:
-   CutCornerShell의 동적 `cut` prop) 인라인 style로 `--proof-cut`만 오버라이드한다. */
-.proof-cut {
-  clip-path: polygon(0 0, calc(100% - var(--proof-cut)) 0, 100% var(--proof-cut), 100% 100%, 0 100%);
+/* story #7d7634ee — `.proof-surface`가 재질 지오메트리 유일 정본(구 `.proof-cut` 계승,
+   doc ea94dac4 유나 확定: "컷 소멸이라 재질명으로 리네임"). 그레인은 `::before`로 얹는다 —
+   `border-radius: inherit`가 배경을 부모 라운드 안에 자동으로 가둬 별도 overflow-hidden
+   불요(배경은 기본 border-box에서 클립된다). 깊이 방향은 합성 모디파이어로 분리:
+   `proof-surface-lift`(뜬 표면)·`proof-surface-press`(눌린 표면) 중 하나를 반드시 곁들인다
+   (`className="proof-surface proof-surface-lift"` 관례, 구 `-sm`/`-xs` 합성과 동형). */
+.proof-surface {
+  position: relative;
+  border-radius: var(--proof-radius-soft);
 }
-.proof-cut-sm {
-  --proof-cut: var(--proof-cut-sm);
+.proof-surface::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background-image: var(--paper-grain);
+  background-repeat: repeat;
+  opacity: var(--paper-grain-opacity);
+  mix-blend-mode: var(--paper-grain-blend);
+  pointer-events: none;
 }
-.proof-cut-xs {
-  --proof-cut: var(--proof-cut-xs);
+.proof-surface-lift {
+  box-shadow: var(--elev-lift);
+}
+.proof-surface-press {
+  box-shadow: var(--emboss-press);
 }
 
 /* ─── Dark Mode (OKLCH zinc) ─── */
@@ -652,6 +682,16 @@
      패널(#17191C대)에 그대로 쓰면 과도하게 튀어(carbon-tint 위반) — 라이트보다 옅은 흰색
      상단 하이라이트(0.08)로 축소, 하단 그림자는 검정 자체가 배경과 거의 안 갈려 생략. */
   --elev-inset: inset 0 1px 0 rgba(255, 255, 255, .08);
+
+  /* story #7d7634ee — §⑤가 그레인 강도/블렌드는 명시(다크 16%·overlay)했지만 --elev-lift/
+     --emboss-press의 다크 수치는 안 줬다(라이트 전용 정본). 기존 --elev-card/--elev-inset의
+     라이트→다크 축소비(검정 베이스로 교체+하이라이트를 .6~.85→.08로 대폭 축소)를 그대로
+     따라 유도했다 — 임의 신규값 아님, 이 파일 자체의 기존 다크 변환 관례 재사용. 유나
+     확認 대기(다른 수치를 원하면 이 블록만 교체하면 되도록 단일 지점에 묶어둠). */
+  --paper-grain-opacity: .16;
+  --paper-grain-blend: overlay;
+  --elev-lift: 0 10px 24px -8px rgba(0, 0, 0, .55), 0 2px 6px -2px rgba(0, 0, 0, .42), inset 0 1px 0 rgba(255, 255, 255, .08);
+  --emboss-press: inset 0 1px 2px rgba(0, 0, 0, .35), inset 0 -1px 0 rgba(255, 255, 255, .08);
 }
 
 /* Sidebar: open triggers get active background */

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -686,12 +686,20 @@
   /* story #7d7634ee — §⑤가 그레인 강도/블렌드는 명시(다크 16%·overlay)했지만 --elev-lift/
      --emboss-press의 다크 수치는 안 줬다(라이트 전용 정본). 기존 --elev-card/--elev-inset의
      라이트→다크 축소비(검정 베이스로 교체+하이라이트를 .6~.85→.08로 대폭 축소)를 그대로
-     따라 유도했다 — 임의 신규값 아님, 이 파일 자체의 기존 다크 변환 관례 재사용. 유나
-     확認 대기(다른 수치를 원하면 이 블록만 교체하면 되도록 단일 지점에 묶어둠). */
-  --paper-grain-opacity: .16;
-  --paper-grain-blend: overlay;
+     따라 유도했다 — 임의 신규값 아님, 이 파일 자체의 기존 다크 변환 관례 재사용. */
   --elev-lift: 0 10px 24px -8px rgba(0, 0, 0, .55), 0 2px 6px -2px rgba(0, 0, 0, .42), inset 0 1px 0 rgba(255, 255, 255, .08);
   --emboss-press: inset 0 1px 2px rgba(0, 0, 0, .35), inset 0 -1px 0 rgba(255, 255, 255, .08);
+
+  /* story #7d7634ee — 카디르 QA 재측 발견: 최초 처방(다크 16%·overlay, 위 주석의 검정-베이스
+     축소 관례 그대로 적용)은 수학적으로 소멸한다 — near-black(#0B0C0D대) 패널 위에 "검정"
+     노이즈를 overlay하면 어두운 픽셀끼리 곱해져(overlay는 밝은 곳만 multiply, 어두운 곳은
+     거의 무변화) 실측상 거의 안 보였다(라이트 대비 7~8%). 유나 정정(RMS 정량 검증) — 다크는
+     흰-노이즈(feColorMatrix RGB=1·A=noise, 아래 SVG)+screen 블렌드+20% 로 라이트와 파리티
+     (RMS 20.6~22.7%, 라이트 22%와 근접) 달성. 라이트 정의(위 :root, 검정-노이즈·multiply·22%)
+     는 무변경 — 이 블록에서 다크만 --paper-grain 자체를 흰-노이즈로 오버라이드. */
+  --paper-grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.62' numOctaves='2' stitchTiles='stitch' result='noise'/%3E%3CfeColorMatrix in='noise' type='matrix' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  --paper-grain-opacity: .20;
+  --paper-grain-blend: screen;
 }
 
 /* Sidebar: open triggers get active background */

--- a/apps/web/src/components/attention-queue/attention-queue-view.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.tsx
@@ -202,8 +202,10 @@ export function AttentionQueueView({ projectId, memberId }: { projectId: string;
   const { shown, overflow, overflowHasGate } = buildAttentionQueue(items, CAP);
 
   return (
-    // story #2955 §5 — 인라인 clip-path를 정본 `.proof-cut` 유틸(globals.css)로 이관(24px 기본값 그대로).
-    <div className="proof-cut overflow-hidden rounded-2xl border border-proof-line bg-proof-panel">
+    // story #7d7634ee(P0·선생님 직접 지시) — 컷코너(clip-path) 폐지, proof-surface(13px 균일
+    // 라운드)+proof-surface-lift(뜬 표면 재질) 채택. 옛 rounded-2xl은 proof-surface의
+    // --proof-radius-soft로 흡수(중복 라운드 선언 제거).
+    <div className="proof-surface proof-surface-lift overflow-hidden border border-proof-line bg-proof-panel">
       <div className="flex items-baseline justify-between gap-3 border-b border-proof-line-soft px-5 py-3.5">
         {/* story #3010(로드맵 P3, L5 대비) — text-proof-faint 라이트 대비 미달(story #2993
             유나 처방과 동일 클래스) → text-proof-ink-3(아래 kicker·empty body 2곳). */}

--- a/apps/web/src/components/canvas/artifact-gallery-view.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.tsx
@@ -366,9 +366,10 @@ export function ArtifactGalleryView({ projectId }: { projectId: string }) {
             {railContent}
           </div>
 
-          {/* story #2955 §5 — 정본 부재로 22px 드리프트(24px가 맞음)였다. `.proof-cut` 유틸
-              (globals.css)로 이관해 정본값으로 정정. */}
-          <div className="proof-cut overflow-hidden rounded-xl border border-border bg-card px-5 py-4">
+          {/* story #7d7634ee(P0·선생님 직접 지시) — 컷코너(clip-path, §2955 §5가 22px 드리프트를
+              24px 정본으로 정정했던 그 자리) 전면 폐지, proof-surface(13px 균일 라운드)+
+              proof-surface-lift(뜬 표면 재질) 채택. 옛 rounded-xl은 흡수. */}
+          <div className="proof-surface proof-surface-lift overflow-hidden border border-border bg-card px-5 py-4">
             <div className="mb-3 text-[11px] font-bold uppercase tracking-wide text-muted-foreground">{axisLabel(axis)}</div>
             {!selectedGroup || selectedGroup.artifacts.length === 0 ? (
               <p className="py-8 text-center text-[12.5px] text-muted-foreground">{t('galleryGroupEmpty')}</p>

--- a/apps/web/src/components/docs/doc-status-rail.tsx
+++ b/apps/web/src/components/docs/doc-status-rail.tsx
@@ -141,7 +141,7 @@ export function DocStatusHeader({ docId, status, editHref, onTransitioned }: { d
   // draft — 접힌 박스의 "검토 요청" CTA를 그대로 상시 승격(§7: 새 상태·새 API 0).
   if (state === 'draft') {
     return (
-      <div className="proof-cut flex flex-wrap items-center gap-3 border border-proof-line bg-proof-panel px-4 py-3">
+      <div className="proof-surface proof-surface-lift flex flex-wrap items-center gap-3 border border-proof-line bg-proof-panel px-4 py-3">
         <Icon className="size-5 shrink-0 text-muted-foreground" />
         <p className="min-w-0 flex-1 text-sm text-muted-foreground">{t('docGateRequestReviewHint')}</p>
         <Button size="sm" className="focus-outset" disabled={busy} onClick={() => void docTransition('pending', onTransitioned)}>
@@ -153,7 +153,7 @@ export function DocStatusHeader({ docId, status, editHref, onTransitioned }: { d
   }
 
   return (
-    <div className={`proof-cut flex flex-wrap items-center gap-3 border px-4 py-3.5 ${
+    <div className={`proof-surface proof-surface-lift flex flex-wrap items-center gap-3 border px-4 py-3.5 ${
       state === 'confirmed' ? 'border-success/30 bg-success-tint' : state === 'denied' ? 'border-destructive/30 bg-destructive/10' : 'border-warning/30 bg-warning-tint'
     }`}
     >

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -280,13 +280,12 @@ describe('ApprovalsQueue', () => {
   // story #2926(P0-F F3) — 클릭-스루 전용 항목은 ProofCapsule density="row"(컷코너+신뢰단계
   // 레일)로 셸이 바뀐다. 3버튼 인라인 결재 카드·resolved 카드는 F3 스코프 밖(현행 rounded-xl
   // border 카드 그대로 — 2923이 다룰 표면)이라 이 항목만 겨냥해 확認한다.
-  it('클릭-스루 항목(inlineResolvable=false·미해소)은 ProofCapsule row 셸(컷코너)로 렌더된다', async () => {
+  it('클릭-스루 항목(inlineResolvable=false·미해소)은 ProofCapsule row 셸(재질)로 렌더된다', async () => {
     mockFetches([gate({ id: 'g-row' })], []);
     await mount();
-    // ProofCapsule의 CutCornerShell 자체 시그니처 — 컷코너. story #2955 §5로 clip-path
-    // 지오메트리 계산이 인라인 style에서 globals.css `.proof-cut` 정본으로 이관돼, 이제
-    // 클래스명으로 식별한다(인라인 style엔 --proof-cut 변수 오버라이드만 남는다).
-    const capsule = container.querySelector('.proof-cut');
+    // ProofCapsule의 CutCornerShell 자체 시그니처. story #7d7634ee(P0)로 컷코너(clip-path)가
+    // proof-surface(재질)로 교체됐다 — 클래스명으로 식별.
+    const capsule = container.querySelector('.proof-surface');
     expect(capsule).toBeTruthy();
     expect(capsule?.className).toContain('bg-proof-panel');
   });

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -961,8 +961,9 @@ describe('KanbanBoard — story #3043 <lg 기본값=list(칸반 다열은 opt-in
     await mount();
 
     // CardVariant(ProofCapsule density="card")의 CutCornerShell 마커 — 예전 ListStoryRow
-    // 자체 마크업(rounded-lg border, proof-cut 없음)엔 없던 클래스라 진짜 atom 재사용의 증거.
-    expect(container.innerHTML).toContain('proof-cut');
+    // 자체 마크업(rounded-lg border, proof-surface 없음)엔 없던 클래스라 진짜 atom 재사용의
+    // 증거. story #7d7634ee(P0)로 컷코너(proof-cut)가 재질(proof-surface)로 교체됨.
+    expect(container.innerHTML).toContain('proof-surface');
     // max-w-[280px](desktop 컬럼 고정폭 전제) 캡이 이 경로에선 max-w-none으로 override돼야
     // full-width row가 된다 — cn()=twMerge라 나중 클래스가 이긴다(story-card.tsx 확認).
     expect(container.innerHTML).toContain('max-w-none');

--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -55,13 +55,13 @@ describe('ProofCapsule (density variants)', () => {
     }
   });
 
-  it('applies a clip-path cut-corner on full/card/row (not a plain rounded-full pill anywhere)', () => {
-    // story #2955 §5 — clip-path 지오메트리 계산이 인라인 style에서 globals.css의 `.proof-cut`
-    // 단일 정본으로 이관됐다(CutCornerShell). 렌더 마크업엔 이제 'polygon(' 리터럴이 없다
-    // (외부 스타일시트가 그 값을 갖는다) — 클래스명으로 컷코너 적용 자체를 검증한다.
+  // story #7d7634ee(P0·선생님 직접 지시) — 컷코너(clip-path) 전면 폐지, proof-surface(재질
+  // 언어)로 교체(doc ea94dac4). 이 스위트 제목·assert도 그 재질로 갱신.
+  it('applies proof-surface material(soft round + lift) on full/card/row (not a plain rounded-full pill anywhere)', () => {
     for (const density of ['full', 'card', 'row'] as const) {
       const markup = renderWithIntl(<ProofCapsule {...BASE} density={density} />);
-      expect(markup).toContain('proof-cut');
+      expect(markup).toContain('proof-surface');
+      expect(markup).toContain('proof-surface-lift');
     }
   });
 
@@ -72,11 +72,12 @@ describe('ProofCapsule (density variants)', () => {
     // overflow-hidden이 감춰 조상 스크롤러가 넘침을 못 본다.
     // ⚠️row/audit 밀도는 셸 내부 아이콘 span 등에 무관한 shrink-0가 이미 있어 단순
     // `.toContain('shrink-0')`는 이 fix와 무관하게도 통과하는 약한 assert가 된다 — 반드시
-    // CutCornerShell 자신의 리터럴 클래스 조합("proof-cut flex shrink-0")으로 특정한다
-    // (mutation-검증: shrink-0 제거 시 이 assert만 RED, 위 span들은 무관).
+    // CutCornerShell 자신의 리터럴 클래스 조합("proof-surface proof-surface-lift flex
+    // shrink-0", story #7d7634ee 재질 갱신)으로 특정한다(mutation-검증: shrink-0 제거 시
+    // 이 assert만 RED, 위 span들은 무관).
     for (const density of ['full', 'card', 'row'] as const) {
       const markup = renderWithIntl(<ProofCapsule {...BASE} density={density} />);
-      expect(markup).toContain('proof-cut flex shrink-0');
+      expect(markup).toContain('proof-surface proof-surface-lift flex shrink-0');
     }
   });
 });

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -132,22 +132,20 @@ export function ProofCapsule({
   );
 }
 
-function CutCornerShell({ state, cut, className, children }: { state: ProofState; cut: number; className?: string; children: React.ReactNode }) {
-  // story #2955 §5 — 지오메트리 계산은 globals.css의 `.proof-cut`(단일 정본)에 위임하고,
-  // 이 컴포넌트는 `--proof-cut`만 오버라이드한다(24/16 두 호출부 그대로 — 값-SSOT는 여기가
-  // 아니라 CSS에 있다).
+function CutCornerShell({ state, className, children }: { state: ProofState; className?: string; children: React.ReactNode }) {
+  // story #7d7634ee(P0·선생님 직접 지시, 감確認 doc ea94dac4) — 컷코너(clip-path) 전면 폐지,
+  // 소프트 라운드(proof-surface, --proof-radius-soft 13px)+뜬 표면 그림자(proof-surface-lift)
+  // 로 교체. 옛 `cut`(24/16px) prop은 클립 크기 조절용이었는데 클립 자체가 없어져 무의미 —
+  // 제거(호출부 3곳 전부 --proof-cut 오버라이드가 아니라 그냥 균일 13px 라운드로 수렴).
   // story #2978(선생님 실사용 발견) — 이 셸의 `overflow-hidden`은 CSS flexbox 스펙상 자신의
   // "automatic minimum size"를 0으로 만든다(overflow!=visible인 flex item의 스펙 규칙). 즉
   // 세로 flex 체인(예: /gates/[id] 상세 뷰의 dashboard-shell overflow-y-auto 스크롤러 하위)
   // 안에서 뷰포트가 좁으면 이 셸이 컨텐츠 실제 높이보다 더 작게 "찌그러들며" 잘림을
   // overflow-hidden이 감춰버려 — 조상 스크롤러가 scrollHeight>clientHeight를 못 보고
   // 스크롤이 원천 봉쇄된다. shrink-0으로 자기 내용 실제 높이를 지키면 초과분이 정상적으로
-  // 조상 체인을 타고 올라가 진짜 스크롤러에서 스크롤 가능해진다(컷코너·헤어라인 결 무변경).
+  // 조상 체인을 타고 올라가 진짜 스크롤러에서 스크롤 가능해진다(재질만 바뀜, 이 규칙 무변경).
   return (
-    <div
-      className={cn('proof-cut flex shrink-0 overflow-hidden rounded-[6px] border border-proof-line bg-proof-panel', className)}
-      style={{ '--proof-cut': `${cut}px` } as React.CSSProperties}
-    >
+    <div className={cn('proof-surface proof-surface-lift flex shrink-0 overflow-hidden border border-proof-line bg-proof-panel', className)}>
       <Proofline state={state} />
       {children}
     </div>
@@ -264,7 +262,7 @@ function FullVariant({
   const t = useTranslations('proofCapsule');
   const sweep = useEvidenceSweep(evidence);
   return (
-    <CutCornerShell state={proofState} cut={24} className={className}>
+    <CutCornerShell state={proofState} className={className}>
       <div className="min-w-0 flex-1 px-4.5 py-4">
         <StateHeader state={proofState} label={stateLabel} />
         <div className="mb-1 mt-3 text-[8.5px] font-bold uppercase tracking-[0.12em] text-proof-ink-3">
@@ -316,7 +314,7 @@ function CardVariant({
   proofState, stateLabel, claim, evidence, footer, className, onClaimClick, headerAside, cardHeader,
 }: Pick<ProofCapsuleProps, 'proofState' | 'stateLabel' | 'claim' | 'evidence' | 'footer' | 'className' | 'onClaimClick' | 'headerAside' | 'cardHeader'>) {
   return (
-    <CutCornerShell state={proofState} cut={16} className={cn('w-full max-w-[280px]', className)}>
+    <CutCornerShell state={proofState} className={cn('w-full max-w-[280px]', className)}>
       <div className="min-w-0 flex-1 px-3 py-2.5">
         {/* 카디르 QA(#3446) REQUEST_CHANGES 적출 — 이전엔 headerAside 유무와 무관하게
             justify-between div로 항상 감쌌다("영향 없음"은 시각적 얘기였을 뿐, DOM은
@@ -373,7 +371,7 @@ function InlineRow({
   proofState, stateLabel, claim, human, agent, gate, duration, className, typeBadge,
 }: Pick<ProofCapsuleProps, 'proofState' | 'stateLabel' | 'claim' | 'human' | 'agent' | 'gate' | 'duration' | 'className' | 'typeBadge'>) {
   return (
-    <CutCornerShell state={proofState} cut={16} className={cn('w-full', className)}>
+    <CutCornerShell state={proofState} className={cn('w-full', className)}>
       <div className="flex min-h-[52px] min-w-0 flex-1 items-center gap-2.5 px-3 py-2">
         <span className="flex shrink-0 items-center gap-1.5">
           {/* story #2923 AQ2(Yuna 확定 2026-08-22) — 개입유형(GATE/STEER/BLOCK/Q) compact

--- a/apps/web/src/components/ui/badge.test.tsx
+++ b/apps/web/src/components/ui/badge.test.tsx
@@ -54,3 +54,22 @@ describe('Badge — chip variant 대비(story #2937)', () => {
     }
   });
 });
+
+// story #7d7634ee(P0·카디르 QA REQUEST_CHANGES) — badge.tsx 뿌리 base className이 이
+// PR의 최대 가치(76파일/223콜사이트 자동 캐스케이드)인데, 그 자리를 직접 고정하는 가드가
+// 없었다(구버전 proof-cut으로 되돌리는 mutation에도 전체 스위트 0건 실패 — 카디르 실측
+// 적발). 다른 파일의 렌더 결과로 간접 확인하는 게 아니라 badge.tsx 자신의 className을
+// 직접 대조한다.
+describe('Badge — story #7d7634ee proof-surface 뿌리 회귀가드(76파일/223콜사이트 캐스케이드)', () => {
+  it('proof-surface + proof-surface-press를 쓰고, 폐지된 proof-cut/proof-cut-xs는 남아있지 않다', async () => {
+    await act(async () => {
+      root.render(<Badge>기본</Badge>);
+    });
+    const el = container.querySelector('[data-slot="badge"]') as HTMLElement;
+    const classes = el.className.split(' ');
+    expect(classes).toContain('proof-surface');
+    expect(classes).toContain('proof-surface-press');
+    expect(classes).not.toContain('proof-cut');
+    expect(classes).not.toContain('proof-cut-xs');
+  });
+});

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -5,15 +5,19 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  // story #2969 §1.4/§2 PR-1(doc proofline-system-layer-2969) — badge.tsx는 §1.4 "proof-cut-xs
-  // 소 컷(태그·마커류)" 목록에 명시 등재. rounded-full→proof-cut+proof-cut-xs 컷태그로,
-  // shadow-sm 제거(§1.2: 인라인 표면은 그림자 대신 라인 — border-transparent(default/success
-  // 등)는 이미 그 자리 없이도 무회귀, 계열 variant는 기존 border-*/70 hairline이 그대로 그
-  // 역할). ⚠️mono 라벨(라틴 전용) 스타일은 이 공유 primitive에 넣지 않는다 — 이 앱 배지
-  // 소비처 대다수가 한글 텍스트라 전역 적용 시 [[feedback-ui-text-agent-tone]] 부류가 아니라
-  // 2967 교훈(mono가 한글서 흐림)을 그대로 재현한다. 라틴 전용 콘텐츠(있다면)는 호출부가
-  // 개별 className으로 옵트인.
-  "group/badge proof-cut proof-cut-xs inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  // story #7d7634ee(P0·선생님 직접 지시, 감確認 doc ea94dac4) — 코너컷(proof-cut proof-cut-xs)
+  // 전면 폐지, 소프트 라운드+체감되는 재질(그레인+엠보스)로 교체. badge.tsx가 이 base
+  // className에 무조건 굽고 있던 게 앱 전체 76파일/223콜사이트의 "75곳" 체감 뿌리였다 —
+  // 이 한 줄 교체가 그 전부에 자동 캐스케이드된다. proof-surface-press(눌린 엠보스)는 doc
+  // §⑤ 토큰표가 "씰/칩"을 emboss-press의 명시 예시로 들었다.
+  // story #2969 §1.4/§2 PR-1(doc proofline-system-layer-2969) — shadow-sm 제거(§1.2: 인라인
+  // 표면은 그림자 대신 라인 — border-transparent(default/success 등)는 이미 그 자리 없이도
+  // 무회귀, 계열 variant는 기존 border-*/70 hairline이 그대로 그 역할). ⚠️mono 라벨(라틴
+  // 전용) 스타일은 이 공유 primitive에 넣지 않는다 — 이 앱 배지 소비처 대다수가 한글
+  // 텍스트라 전역 적용 시 [[feedback-ui-text-agent-tone]] 부류가 아니라 2967 교훈(mono가
+  // 한글서 흐림)을 그대로 재현한다. 라틴 전용 콘텐츠(있다면)는 호출부가 개별 className으로
+  // 옵트인.
+  "group/badge proof-surface proof-surface-press inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {

--- a/apps/web/src/components/ui/card.test.tsx
+++ b/apps/web/src/components/ui/card.test.tsx
@@ -92,13 +92,6 @@ describe('Card 신규 프리미티브 — variant·서브컴포넌트 (story #28
     expect(cardVariants({ surface: 'plain', radius: 'inline' })).not.toContain('shadow-sm');
   });
 
-  // story #2969 §1.4(doc proofline-system-layer-2969) — 히어로/시그니처 카드 전용 옵트인.
-  it('radius=signature는 rounded-* 대신 proof-cut(컷코너) 클래스를 낸다', () => {
-    const classes = cardVariants({ surface: 'solid', radius: 'signature' });
-    expect(classes).toContain('proof-cut');
-    expect(classes).not.toMatch(/rounded-(lg|xl|2xl)\b/);
-  });
-
   it('solid surface는 shadow-sm이 없다(§1.2 — 인라인 표면은 그림자 대신 hairline)', () => {
     expect(cardVariants({ surface: 'solid', radius: 'card' })).not.toContain('shadow-sm');
   });

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -27,9 +27,9 @@ export const cardVariants = cva('border text-card-foreground', {
       card: 'rounded-lg',
       compact: 'rounded-xl',
       inline: 'rounded-lg',
-      // story #2969 §1.4 — 히어로/시그니처 카드(섹션 리드·활성·측정 중 카드 1종, 화면당 소수)
-      // 전용 옵트인. 라운드 대신 컷코너(큰 시그니처 컷, --proof-cut 기본 24px).
-      signature: 'proof-cut',
+      // story #7d7634ee(P0·선생님 직접 지시) — radius=signature(컷코너 옵트인, §2969 §1.4)
+      // 폐지. 실사용 0건이었고(전 코드베이스에서 radius="signature" 호출 자체가 없었다),
+      // proof-cut 전면 처분 대상이라 대체 없이 제거한다.
     },
   },
   defaultVariants: { surface: 'solid', radius: 'card' },

--- a/apps/web/src/components/ui/label-chip.test.tsx
+++ b/apps/web/src/components/ui/label-chip.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+//
+// story #7d7634ee(P0·카디르 QA REQUEST_CHANGES 동류 확장) — badge.tsx와 동형으로 label-chip.tsx도
+// A급 뿌리(2파일 소비처, story #2969 §1.4 "proof-cut-xs 소 컷" 목록에 badge.tsx와 함께 등재됐던
+// 자리)인데 이 파일 자체엔 회귀가드가 아예 없었다(신설). badge.tsx 가드와 동형 구조.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { LabelChip } from './label-chip';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+describe('LabelChip — story #7d7634ee proof-surface 뿌리 회귀가드', () => {
+  it('proof-surface + proof-surface-press를 쓰고, 폐지된 proof-cut/proof-cut-xs는 남아있지 않다', async () => {
+    await act(async () => {
+      root.render(<LabelChip label={{ id: '1', name: '스펙', color: '#3E7DC2' }} />);
+    });
+    const el = container.querySelector('span') as HTMLElement;
+    const classes = el.className.split(' ');
+    expect(classes).toContain('proof-surface');
+    expect(classes).toContain('proof-surface-press');
+    expect(classes).not.toContain('proof-cut');
+    expect(classes).not.toContain('proof-cut-xs');
+  });
+});

--- a/apps/web/src/components/ui/label-chip.tsx
+++ b/apps/web/src/components/ui/label-chip.tsx
@@ -16,11 +16,10 @@ export const LABEL_PRESET_COLORS = [
 ] as const;
 
 export function LabelChip({ label, className }: { label: LabelData; className?: string }) {
-  // story #2969 §1.4(doc proofline-system-layer-2969) — label-chip.tsx는 §1.4 "proof-cut-xs
-  // 소 컷(태그·마커류)" 목록에 badge.tsx/status-badge.tsx와 함께 명시 등재. rounded-full→
-  // proof-cut+proof-cut-xs.
+  // story #7d7634ee(P0·선생님 직접 지시, 감確認 doc ea94dac4) — 코너컷 폐지, 소프트 라운드+
+  // 그레인+엠보스(proof-surface-press, "씰/칩" doc §⑤ 명시 예시)로 교체.
   return (
-    <span className={cn('proof-cut proof-cut-xs inline-flex items-center gap-1.5 bg-muted px-2 py-0.5 text-xs font-medium text-foreground', className)}>
+    <span className={cn('proof-surface proof-surface-press inline-flex items-center gap-1.5 bg-muted px-2 py-0.5 text-xs font-medium text-foreground', className)}>
       <span
         className="h-2 w-2 shrink-0 rounded-full"
         style={{ backgroundColor: label.color ?? '#8A8F98' }}

--- a/apps/web/src/components/ui/material-chip.tsx
+++ b/apps/web/src/components/ui/material-chip.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils';
 export function MaterialChip({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
     <span
+      data-slot="material-chip"
       className={cn(
         'inline-flex items-center rounded-md border border-proof-line bg-transparent px-2 py-[3.5px] text-[10.5px] font-semibold tracking-[0.04em] text-muted-foreground',
         className,

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -244,8 +244,10 @@ export function Workcell({ title, pipelineStage, brief, run, evidence, conversat
   const t = useTranslations('workcell');
   const railState = pipelineStage ? PIPELINE_STAGE_TRUST_COLOR[pipelineStage] : undefined;
   return (
-    // story #2955 §5 — 인라인 clip-path를 정본 `.proof-cut` 유틸(globals.css)로 이관(24px 기본값 그대로).
-    <div className={cn('proof-cut flex overflow-hidden rounded-[6px] border border-proof-line bg-proof-panel', className)}>
+    // story #7d7634ee(P0·선생님 직접 지시) — 컷코너(clip-path) 폐지, proof-surface(13px 균일
+    // 라운드)+proof-surface-lift(뜬 표면 재질) 채택. 옛 rounded-[6px]는 proof-surface의
+    // --proof-radius-soft로 흡수.
+    <div className={cn('proof-surface proof-surface-lift flex overflow-hidden border border-proof-line bg-proof-panel', className)}>
       {/* story #2922 W6(선행 조각) — Proofline 좌측 레일(ProofCapsule CutCornerShell과 동형
           부품 재사용, 신규 컴포넌트 0). */}
       {railState ? <Proofline state={railState} /> : <div className="w-1 shrink-0 self-stretch bg-proof-line" aria-hidden="true" />}


### PR DESCRIPTION
## 선생님 직접 지시 배경

①proof-cut(모서리 사선 clip-path) 강한 불호 ②2984 색→재질 스윕(S1~S6)이 전량 머지·서빙 중임에도 "질감 반영 0" 체감. 감確認 doc [ea94dac4](entity:doc:ea94dac4-f69c-4ae2-af4d-9712ee192e30)(유나 자기진단): 2984는 "빼기"(색 채움 제거+옅은 헤어라인/그림자)였고 선생님 기대는 "더하기"(그레인·깊이·엠보스)였다는 방향 갭.

## 「75곳」의 정체 실측 정정

리터럴 grep은 29건뿐이라 "75곳"과 안 맞았다 — 원인: `badge.tsx`/`label-chip.tsx`가 자기 base className에 `proof-cut`을 무조건(옵트인 아님) 굽고 있어 소비 파일엔 문자열이 없어도 화면엔 컷이 찍혔다. `<Badge>` 실사용처가 정확히 **76파일/223콜사이트**로 "75곳"과 거의 일치.

## 신규 재질 토큰(globals.css, doc §⑤ 정본값)

`--proof-radius-soft`(13px 균일 라운드) · `--paper-grain`(SVG fractalNoise baseFrequency 0.62, 라이트 22%/multiply·다크 16%/overlay) · `--elev-lift`(뜬 표면, 카드·캡슐용) · `--emboss-press`(눌린 표면, 씰·칩용 — doc §⑤가 명시 예시) · `--glass-overlay-*`(모달 전용 토큰만 선신설, 이 PR엔 소비처 없음).

`elev-lift`/`emboss-press`의 다크 수치는 doc이 라이트만 명시해 이 파일 기존 `--elev-card`/`--elev-inset`의 라이트→다크 축소비를 그대로 유도했다(단일 지점에 묶어 유나 재확인 쉽게).

`.proof-surface`(신규 정본, 유나 확定: "컷 소멸이라 재질명으로 리네임")가 그레인을 `::before`(`border-radius:inherit`로 배경 자동 클립, `overflow-hidden` 불요)로 얹고, 깊이는 `.proof-surface-lift`/`.proof-surface-press` 모디파이어로 합성.

## 등급별 처분

- **A급**(뿌리 1~2파일 = 76파일 자동 캐스케이드): `badge.tsx`·`label-chip.tsx` → `proof-surface proof-surface-press`
- **B급**(자기완결 단일파일): `proof-capsule.tsx` `CutCornerShell`(cut prop 폐지) · `card.tsx` `radius:'signature'` variant 삭제(실사용 0건)
- **C급**(산발 직접적용 8파일): goals-client·goals/[id]·docs-client-layout·docs-index(size prop도 제거)·attention-queue-view·doc-status-rail·workcell·artifact-gallery-view — 중복 `rounded-*`/`shadow-[var(--elev-card)]` 흡수

## 발견 즉시수정(선재 결함, 이 작업과 무관)

`goals-client.test.tsx`의 두 회귀가드가 `.proof-cut-xs` 셀렉터를 썼는데, story #3053(2984-S5)이 이미 그 자리를 MaterialChip으로 교체해서 origin/develop HEAD 기준으로도 조용히 깨져 있었다(내 변경과 무관하게 선재). MaterialChip에 `data-slot="material-chip"` 훅을 추가해 되살리고, 기제 자체가 무의미해진 #3399 가드는 삭제.

## 검증

- 신규/개정 회귀가드 6건 — `git diff→checkout HEAD(source 13파일)→재실행(genuine RED 6/6)→git apply→재실행(6/6 GREEN)` 확인
- 영향받은 13개 테스트 파일 308/308 green
- 전체 vitest 507 files / 4533 tests green
- `tsc --noEmit` clean
- `eslint` 0 errors (pre-existing unrelated warning 5개)
- `pnpm build` EXIT=0

## 시각 확인

Puppeteer 세션 내내 dead — 실 vitest `renderToStaticMarkup` 덤프에서 badge/label-chip 정확한 클래스 추출, globals.css 실측 토큰 + **실 정본 그레인 SVG data URI**(코드와 완전 동일값)로 재구성한 before/after 아티팩트로 대체(라이브 픽셀 최종 확인은 카디르 QA 위임, 명시적 고지).

Sprintable 산출물: P0 코너컷→체감 재질 실렌더 (badge/label-chip/CutCornerShell) (artifact `f8776594-556b-461f-a139-3514a73b4e3c`, story #7d7634ee 연결)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>