### PR TITLE
[SID:3076] 채팅 임베드 «전부» 우측 ReadingPanel로 — 모달 누수 2자리 봉합

### DIFF
--- a/apps/web/src/components/chat/approval-request-card.test.tsx
+++ b/apps/web/src/components/chat/approval-request-card.test.tsx
@@ -12,6 +12,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { ApprovalRequestCard, toEntityType } from './approval-request-card';
 import type { GateItem } from '@/components/kanban/types';
+import { ReadingPanelProvider } from '@/components/chat/reading-panel-context';
 
 describe('toEntityType (story #2118) — Gate.work_item_type ↔ entity_type 어휘 변환', () => {
   it('visual_artifact → artifact(embed-card.tsx 어휘로 변환)', () => {
@@ -143,6 +144,36 @@ describe('ApprovalRequestCard — 제목 미리보기 진입점, canPreviewEntit
     const titleButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(title));
     expect(titleButton).toBeFalsy();
     expect(container.textContent).toContain(title);
+  });
+});
+
+// story #461e9a54(P0) — 채팅 컨텍스트(ReadingPanelProvider 하위)에서는 제목 클릭이 Dialog
+// 모달이 아니라 우측 ReadingPanel을 연다. approvals-queue.tsx(인박스, 채팅 밖)는 Provider가
+// 없어 기존 Dialog 모달 그대로(위 "visual_artifact 클릭 시... 모달이 연다" 테스트가 이미
+// 그 폴백을 고정한다 — 회귀 0).
+describe('ApprovalRequestCard — story #461e9a54 ReadingPanel 라우팅(채팅 컨텍스트)', () => {
+  it('ReadingPanelProvider 하위에서 제목 클릭 시 open()이 정확한 target으로 불리고, Dialog는 안 뜬다', async () => {
+    const open = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/gates/')) {
+        return { ok: true, json: async () => ({ data: gate({ work_item_type: 'story', work_item_id: 'story-9', work_item_summary: { title: '패널 라우팅 대조', slug: null } }) }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <ReadingPanelProvider value={{ open, close: vi.fn(), navigateTo: vi.fn() }}>
+            <ApprovalRequestCard target={{ work_item_type: 'story', work_item_id: 'story-9', gate_id: 'g-panel' }} />
+          </ReadingPanelProvider>
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const titleButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('패널 라우팅 대조'));
+    await act(async () => { titleButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(open).toHaveBeenCalledWith(expect.objectContaining({ kind: 'entity', entityType: 'story', entityId: 'story-9', title: '패널 라우팅 대조' }));
+    expect(document.body.querySelector('[data-slot="dialog-content"]')).toBeNull();
   });
 });
 

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -11,6 +11,7 @@ import { GateUndoButton, isUndoEligible } from '@/components/cage/gate-undo-butt
 import { GateDiscussDialog } from '@/components/cage/gate-discuss-dialog';
 import { deriveRiskLevel, usesSignatureFlow, deriveGateProofState } from '@/components/cage/gate-risk';
 import { EntityPreviewModal, canPreviewEntity, getEntityHref } from '@/components/chat/embed-card';
+import { useReadingPanel } from '@/components/chat/reading-panel-context';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import type { GateItem } from '@/components/kanban/types';
 import { parseBlockTemplate, renderBlockTemplate, type EventDefinitionSummary } from '@/lib/block-template';
@@ -108,6 +109,9 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalR
   // story #2926(P0-F F1) — claim 클릭(제목 미리보기)이 이제 ProofCapsule 셸 소관이라 이
   // state도 그쪽에 맞춰 여기(바깥 컴포넌트)로 끌어올렸다(기존 ApprovalRequestBody 소유였음).
   const [showPreview, setShowPreview] = useState(false);
+  // story #461e9a54(P0) — approvals-queue.tsx(인박스, 채팅 밖)에서도 이 카드가 쓰인다 —
+  // Provider 밖이면 null이라 기존 Dialog 모달 폴백(회귀 0).
+  const readingPanel = useReadingPanel();
 
   const fetchGate = useCallback(async () => {
     try {
@@ -262,7 +266,16 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalR
         proofState={proofState}
         stateLabel={stateLabel}
         claim={title}
-        onClaimClick={canPreview ? () => setShowPreview(true) : undefined}
+        onClaimClick={canPreview ? () => {
+          if (readingPanel) {
+            readingPanel.open({
+              kind: 'entity', entityType: previewEntityType, entityId: gate.work_item_id,
+              title, status: null, href: getEntityHref(previewEntityType, gate.work_item_id),
+            });
+            return;
+          }
+          setShowPreview(true);
+        } : undefined}
         className="max-w-full"
         footer={
           <ApprovalRequestBody
@@ -285,7 +298,7 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalR
         submitting={discussSubmitting}
         error={discussError}
       />
-      {showPreview && (
+      {!readingPanel && showPreview && (
         <EntityPreviewModal
           entityType={previewEntityType}
           entityId={gate.work_item_id}

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -12,6 +12,7 @@ import { ChatInput, type CommandTarget } from './chat-input';
 import { ThreadPanel } from './thread-panel';
 import { ReadingPanel, type ReadingPanelTarget } from './reading-panel';
 import { useReadingPanelStack } from './use-reading-panel-stack';
+import { ReadingPanelProvider } from './reading-panel-context';
 import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeToMessage, useChatSse, type SseWorkingPayload } from '@/hooks/use-chat-sse';
@@ -771,7 +772,16 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   const isMobileReadingView = readingPanelStack.length > 0;
   const isMobileRightPanelView = isMobileThreadView || isMobileReadingView;
 
+  // story #461e9a54(P0) — 채팅 하위 트리 전체(메시지·입력창 포함)를 이 Provider로 감싼다.
+  // EntityChip(embed-card.tsx)·approval-request-card.tsx가 이 값을 useReadingPanel()로
+  // 직접 소비 — prop-drilling 없이도 새 임베드 소비처가 자동으로 패널行 된다.
+  const readingPanelContextValue = useMemo(
+    () => ({ open: openReadingPanel, close: closeReadingPanel, navigateTo: navigateReadingPanelTo }),
+    [openReadingPanel, closeReadingPanel, navigateReadingPanelTo],
+  );
+
   return (
+    <ReadingPanelProvider value={readingPanelContextValue}>
     <div className="flex h-full flex-col overflow-hidden">
       {/* Mobile thread back — only while a thread panel is open (closes it). The page
           TopBar owns the conversation header, so this no longer duplicates it (S2). */}
@@ -1063,5 +1073,6 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
         onConfirm={() => { if (!blockSubmitting) void handleConfirmBlockUser(); }}
       />
     </div>
+    </ReadingPanelProvider>
   );
 }

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -16,6 +16,7 @@ import { renderEntityStatusLabel, translateEntityStatus, type EntityStatusFetchS
 import { ArtifactThumbnail } from '@/components/canvas/artifact-thumbnail';
 import { fetchWithAuth } from '@/lib/db/client';
 import { parseEntityRef } from './entity-ref';
+import { useReadingPanel } from './reading-panel-context';
 // story #2888(S2a) — 이관 후 재수출(기존 소비처 4곳 import 경로 무변경, 회귀 0). 정본은
 // entity-registry.tsx 참고.
 import { ENTITY_ICONS, ENTITY_COLORS, GRAY_STATE_COLOR, resolveEntityIcon, EntityGlyph } from './entity-registry';
@@ -917,6 +918,9 @@ export function EntityChip({
   entityStatus?: EntityStatusFetchState;
 } & VariantProps<typeof entityChipLabelVariants>) {
   const [showModal, setShowModal] = useState(false);
+  // story #461e9a54(P0) — 채팅 트리(ReadingPanelProvider 하위)에서는 패널로, 밖(doc-content-
+  // renderer.tsx·story-detail-panel.tsx 등)에서는 null이라 기존 Dialog 모달로 폴백(회귀 0).
+  const readingPanel = useReadingPanel();
   const colorClass = ghost ? GRAY_STATE_COLOR : (ENTITY_COLORS[entityType] ?? GRAY_STATE_COLOR);
 
   // story #2669(B2) — doc이 chat-view.tsx 배치조회로 draft라고 확認되면, 상신 가능(project
@@ -1030,7 +1034,13 @@ export function EntityChip({
     ) : null;
     const triggerButtonProps = {
       type: 'button' as const,
-      onClick: () => setShowModal(true),
+      onClick: () => {
+        if (readingPanel) {
+          readingPanel.open({ kind: 'entity', entityType, entityId, title: label, status: null, href });
+          return;
+        }
+        setShowModal(true);
+      },
       className: 'inline-flex no-underline transition hover:opacity-80 motion-safe:active:scale-[0.98]',
     };
     const chipButton = tooltipContent ? (
@@ -1045,7 +1055,7 @@ export function EntityChip({
       <span className="inline-flex flex-wrap items-center gap-1">
         {chipButton}
         {docCta}
-        {showModal && (
+        {!readingPanel && showModal && (
           <EntityPreviewModal
             entityType={entityType}
             entityId={entityId}

--- a/apps/web/src/components/chat/entity-chip.test.tsx
+++ b/apps/web/src/components/chat/entity-chip.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { EntityChip } from './embed-card';
+import { ReadingPanelProvider } from './reading-panel-context';
 
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
   useDashboardContext: () => ({ projectMemberships: [] }),
@@ -102,5 +103,33 @@ describe('EntityChip ghost — variant 무관 무동작 유지', () => {
     });
     expect(container.textContent).toContain('대상이 없습니다');
     expect(container.querySelector('button')).toBeNull();
+  });
+});
+
+// story #461e9a54(P0) — 채팅 임베드는 전부 우측 ReadingPanel로(모달 0). ReadingPanelProvider
+// 유무로 갈리는 두 경로를 각각 고정한다.
+describe('EntityChip — story #461e9a54 ReadingPanel 라우팅', () => {
+  it('ReadingPanelProvider 하위에서 클릭하면 open()이 정확한 target으로 불리고, Dialog는 안 뜬다', async () => {
+    const open = vi.fn();
+    await act(async () => {
+      root.render(
+        <ReadingPanelProvider value={{ open, close: vi.fn(), navigateTo: vi.fn() }}>
+          <EntityChip entityType="story" entityId="s-1" label="스토리 제목" href="/board?story=s-1" />
+        </ReadingPanelProvider>,
+      );
+    });
+    await act(async () => { container.querySelector('button')!.click(); });
+    expect(open).toHaveBeenCalledWith({
+      kind: 'entity', entityType: 'story', entityId: 's-1', title: '스토리 제목', status: null, href: '/board?story=s-1',
+    });
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('Provider 밖(doc-content-renderer·story-detail-panel 등)에서 클릭하면 기존 Dialog 모달이 뜬다(회귀 0)', async () => {
+    await act(async () => {
+      root.render(<EntityChip entityType="story" entityId="s-1" label="스토리 제목" href="/board?story=s-1" />);
+    });
+    await act(async () => { container.querySelector('button')!.click(); });
+    expect(document.body.querySelector('[role="dialog"]')).not.toBeNull();
   });
 });

--- a/apps/web/src/components/chat/reading-panel-context.tsx
+++ b/apps/web/src/components/chat/reading-panel-context.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import type { ReadingPanelTarget } from './reading-panel';
+
+/**
+ * story #461e9a54(P0·선생님 반복 지시, design 스펙 doc 6cf077fc) — 채팅 임베드 엔티티는
+ * «전부» 우측 ReadingPanel로. 기존엔 onOpenReadingPanel을 chat-view.tsx→ChatBubble→EmbedCard로
+ * 손수 prop-drilling했는데, 그 경로 밖(EntityChip 인라인 멘션·approval-request-card 미리보기)은
+ * 배선이 안 닿아 각자 Dialog 모달로 새고 있었다. Context로 "채팅 하위 어디서든 useReadingPanel()"
+ * 을 만들면 미래에 새 임베드가 생겨도 자동으로 패널行(모달 재누수 원천 차단, doc §③ "클래스로
+ * 닫기"). Provider 밖(EntityChip이 doc-content-renderer.tsx·story-detail-panel.tsx 등 채팅
+ * 밖에서도 재사용되는 자리)에서는 null — 소비부가 null이면 기존 Dialog 모달로 폴백(회귀 0).
+ */
+export interface ReadingPanelContextValue {
+  open: (target: ReadingPanelTarget) => void;
+  close: () => void;
+  /** 스택 내 breadcrumb 이동(use-reading-panel-stack.ts와 동일 계약, index 기반) — 새 대상을
+   * 여는 건 항상 open()이다(스택에 이미 열려있으면 push, 닫혀있으면 새 스택으로 그 안에서
+   * 처리된다). */
+  navigateTo: (index: number) => void;
+}
+
+const ReadingPanelContext = createContext<ReadingPanelContextValue | null>(null);
+
+export const ReadingPanelProvider = ReadingPanelContext.Provider;
+
+export function useReadingPanel(): ReadingPanelContextValue | null {
+  return useContext(ReadingPanelContext);
+}


### PR DESCRIPTION
## 선생님 반복 지시 배경

채팅에 임베드된 엔티티(doc·artifact·story·goal·file) 클릭이 페이지 이동/모달로 채팅을 벗어나면 안 되고, 우측 ReadingPanel이 열려 채팅을 유지해야 한다는 지시가 여러 차례 있었으나 등재조차 안 돼 있었다. design 스펙 [doc 6cf077fc](entity:doc:6cf077fc-2391-412a-a149-0f90bf4cae41)(유나): 분할 뷰어(`ReadingPanel`, story #2766)는 이미 있고 블록 임베드(`EmbedCard`)도 이미 패널로 라우팅되지만, 그 밖 prop-drilling이 안 닿는 2자리가 Dialog 모달로 새고 있었다.

## 갭 2자리(doc §②) 확인·봉합

- **①인라인 엔티티 멘션**(`EntityChip`, embed-card.tsx — 본문 `[제목](entity:…)` 토큰 렌더처) — 자체 `showModal`→Dialog. `onOpenReadingPanel` 미수신이 원인(주 갭).
- **②결재 카드 문서 미리보기**(`approval-request-card.tsx`) — claim 클릭 시 `showPreview`→`EntityPreviewModal`(Dialog). 패널 라우팅 미배선.
- **③chat-input 작성 미리보기**(doc이 우려한 자리) — 실측 결과 `chat-input.tsx`에 EntityChip/Dialog/Modal 렌더 자체가 0건(grep 확인). 존재하지 않는 리스크였다 — AC에도 없어 이 PR 스코프에서 제외.

## 처방 — ReadingPanelContext (doc §③ "클래스로 닫기")

새 `reading-panel-context.tsx`: `createContext<ReadingPanelContextValue | null>(null)` + `useReadingPanel()`. `chat-view.tsx`가 자신의 렌더 트리 전체(메시지+ChatInput 포함)를 `<ReadingPanelProvider value={{ open: openReadingPanel, close: closeReadingPanel, navigateTo: navigateReadingPanelTo }}>`로 감싼다 — 이제 채팅 하위 어디서든 `useReadingPanel()`로 직접 열 수 있어, 미래에 새 임베드가 생겨도 prop 배선 없이 자동 패널行(모달 재누수 원천 차단).

`EntityChip`/`ApprovalRequestCard` 둘 다 **컨텍스트 유무로 분기**한다 — Provider 하위(채팅)면 `open({kind:'entity', ...})`로 패널, Provider 밖(`EntityChip`은 `doc-content-renderer.tsx`·`story-detail-panel.tsx`에서도 재사용, `ApprovalRequestCard`는 `approvals-queue.tsx` 인박스에서도 재사용)이면 기존 로컬 `showModal` state+Dialog 그대로(회귀 0) — `EntityPreviewModal` 자체는 손대지 않는다(헤더/본문/풋터가 이미 `embedded` prop으로 패널·모달 양쪽을 100% 공유 재사용 중, doc §① 확인).

## 검증

- 신규 회귀가드 3건(EntityChip: Provider 하위→open() 정확 target+Dialog 0 / Provider 밖→기존 Dialog 유지 / ApprovalRequestCard: Provider 하위→open()+Dialog 0) — `git diff→checkout HEAD(+신규 컨텍스트 파일 제거)→재실행(genuine RED — 모듈 자체가 없어 import 실패로 확인)→git apply(+파일 재생성)→재실행(GREEN)` 확인
- 영향받은 6개 테스트 파일 72/72 green(entity-chip 9·approval-request-card 22·embed-card 계열 41)
- `chat-bubble.test.tsx` 104/104 무변경(블록 임베드 경로 회귀 0)
- 전체 vitest 507 files / 4541 tests green
- `tsc --noEmit` clean
- `eslint` 0 errors
- `pnpm build` EXIT=0

## 잔여(스코프 밖)

AC3(모바일 풀스크린 시트)·AC4(풋터 "페이지로 열기" 보조 링크)는 doc §①에 따르면 기존 ReadingPanel/EntityPreviewModal이 이미 구현·검증된 것이라 이 PR의 새 코드 없음(라우팅 봉합만이 이 PR의 실 변경). 실 렌더 확인은 카디르 QA 위임.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>