### PR TITLE
[SID:3077] 결재 카드 doc 미리보기 — content_format=html 태그 원문 노출 fix

### DIFF
--- a/apps/web/src/components/chat/embed-card.doc-html-preview.test.tsx
+++ b/apps/web/src/components/chat/embed-card.doc-html-preview.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+//
+// story #3776ccfe(FE·결재 카드, 선생님 실사용 발견) — doc 미리보기(EntityPreviewModal→
+// renderEntityDetail doc 분기)가 content_format을 안 보고 항상 MdBody(마크다운 전용)에
+// content를 먹였다. content_format='html'인 doc은 태그가 렌더 안 되고 이스케이프 텍스트로
+// 그대로 찍혔다(선생님이 doc ea94dac4에서 실제로 본 그 증상) — 이 회귀가드가 그 결함을 고정한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EntityPreviewModal } from './embed-card';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function stubDocFetch(content: string, contentFormat: string) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url.includes('/api/docs/preview')) {
+      return {
+        ok: true,
+        json: async () => ({ data: { slug: 'd-1', projectId: 'p-1', orgSlug: 'org', projectSlug: 'proj' } }),
+      };
+    }
+    if (url.includes('/api/docs?')) {
+      return {
+        ok: true,
+        json: async () => ({ data: { content, content_format: contentFormat } }),
+      };
+    }
+    return { ok: true, json: async () => ({}) };
+  }));
+}
+
+async function mount(content: string, contentFormat: string) {
+  stubDocFetch(content, contentFormat);
+  await act(async () => {
+    root.render(
+      <EntityPreviewModal
+        entityType="doc" entityId="d-1" title="문서" status={null} href={null}
+        onClose={() => {}} embedded
+      />,
+    );
+  });
+  await flush();
+}
+
+describe('EntityPreviewModal doc 미리보기 — content_format 분기(story #3776ccfe)', () => {
+  it('content_format=html이면 태그가 텍스트로 노출되지 않고 실제 HTML로 렌더된다', async () => {
+    await mount('<h3>제목</h3><p>본문 <b>강조</b></p>', 'html');
+    // 태그 원문 노출 0 — 이스케이프 텍스트로 "<h3>" 같은 문자열이 그대로 안 보인다.
+    expect(container.textContent).not.toContain('<h3>');
+    expect(container.textContent).not.toContain('<p>');
+    // 실제로 HTML 엘리먼트로 렌더됐다(sanitize 통과 후 dangerouslySetInnerHTML).
+    expect(container.querySelector('h3')?.textContent).toBe('제목');
+    expect(container.querySelector('b')?.textContent).toBe('강조');
+  });
+
+  it('content_format=html의 위험 태그(script)는 DOMPurify sanitize로 제거된다(XSS 회귀가드)', async () => {
+    await mount('<p>안전</p><script>alert(1)</script><img src=x onerror="alert(2)">', 'html');
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.innerHTML).not.toContain('onerror');
+  });
+
+  it('content_format=markdown(기본값)은 기존 MdBody 그대로 렌더된다(회귀 0)', async () => {
+    await mount('# 제목\n\n본문 **강조**', 'markdown');
+    expect(container.querySelector('h1')?.textContent).toBe('제목');
+    expect(container.querySelector('strong')?.textContent).toBe('강조');
+  });
+});

--- a/apps/web/src/components/chat/embed-card.doc-html-preview.test.tsx
+++ b/apps/web/src/components/chat/embed-card.doc-html-preview.test.tsx
@@ -86,4 +86,18 @@ describe('EntityPreviewModal doc 미리보기 — content_format 분기(story #3
     expect(container.querySelector('h1')?.textContent).toBe('제목');
     expect(container.querySelector('strong')?.textContent).toBe('강조');
   });
+
+  // story #3776ccfe — 유나 design PASS 관찰(비차단, PR#3481): table/code가 미스타일이었다.
+  // sanitize된 원시 HTML엔 class가 없다 — 스타일은 래퍼 div의 Tailwind 자손 셀렉터
+  // ([&_table]:... 등)가 담당하므로, 그 래퍼가 규칙을 갖는지로 검증한다.
+  it('content_format=html의 table/code/pre 자손 셀렉터가 래퍼에 있다(유나 관찰 반영)', async () => {
+    await mount('<table><tr><th>열</th></tr><tr><td>값</td></tr></table><p>인라인 <code>코드</code></p>', 'html');
+    expect(container.querySelector('table')).not.toBeNull();
+    expect(container.querySelector('th')).not.toBeNull();
+    expect(container.querySelector('code')).not.toBeNull();
+    const wrapper = container.querySelector('table')?.parentElement;
+    expect(wrapper?.className).toContain('[&_table]:border-collapse');
+    expect(wrapper?.className).toContain('[&_th]:border');
+    expect(wrapper?.className).toContain('[&_code]:font-mono');
+  });
 });

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -14,6 +14,7 @@ import { docViewUrl } from '@/components/docs/lib/doc-project-url';
 import { resolveScopedEntityHref, storyBoardUrl, goalUrl, sprintUrl, assetStorageUrl } from '@/lib/entity-project-url';
 import { renderEntityStatusLabel, translateEntityStatus, type EntityStatusFetchState } from './entity-status-labels';
 import { ArtifactThumbnail } from '@/components/canvas/artifact-thumbnail';
+import { sanitizeDocHtml } from '@/components/docs/doc-content-renderer';
 import { fetchWithAuth } from '@/lib/db/client';
 import { parseEntityRef } from './entity-ref';
 // story #2888(S2a) — 이관 후 재수출(기존 소비처 4곳 import 경로 무변경, 회귀 0). 정본은
@@ -204,8 +205,23 @@ function renderEntityDetail(entityType: string, entityId: string, detail: Record
   }
 
   if (entityType === 'doc') {
-    const d = detail as { content?: string };
-    return d.content ? <MdBody content={d.content} /> : null;
+    // story #3776ccfe(FE·결재 카드, 선생님 실사용 발견) — content_format을 안 보고 항상
+    // MdBody(마크다운 전용)에 먹였다: html doc이면 태그가 렌더 안 되고 이스케이프 텍스트로
+    // 그대로 찍혔다(react-markdown은 rehype-raw 없이는 raw HTML을 실행 안 함). doc-content-
+    // renderer.tsx(전체 읽기 뷰)가 이미 쓰는 DOMPurify sanitize 정본(sanitizeDocHtml)을
+    // 재사용해 html이면 sanitize 後 dangerouslySetInnerHTML, 그 외(markdown 기본값)는
+    // 기존 MdBody 그대로(회귀 0) — sanitize를 우회할 새 경로를 만들지 않는다.
+    const d = detail as { content?: string; content_format?: string };
+    if (!d.content) return null;
+    if (d.content_format === 'html') {
+      return (
+        <div
+          className="text-sm leading-6 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-bold [&_h2]:mb-2 [&_h2]:text-base [&_h2]:font-bold [&_h3]:mb-1.5 [&_h3]:text-sm [&_h3]:font-bold [&_p]:mb-2 [&_ul]:mb-2 [&_ul]:ml-4 [&_ul]:list-disc [&_ol]:mb-2 [&_ol]:ml-4 [&_ol]:list-decimal"
+          dangerouslySetInnerHTML={{ __html: sanitizeDocHtml(d.content) }}
+        />
+      );
+    }
+    return <MdBody content={d.content} />;
   }
 
   // story #2614 — 부모(story/epic/doc)가 없는 독립 artifact(챗에 바로 올린 mockup 등)는 풋터에

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -214,9 +214,12 @@ function renderEntityDetail(entityType: string, entityId: string, detail: Record
     const d = detail as { content?: string; content_format?: string };
     if (!d.content) return null;
     if (d.content_format === 'html') {
+      // 유나 design PASS 관찰(비차단, PR#3481) — table/code가 미스타일이었다. mdBodyComponents
+      // (markdown 경로)의 pre/code 사이징을 그대로 옮기고, table은 이 렌더러의 첫 소비처라
+      // 신규 최소셋(테두리+헤더 강조)만 준다 — 과설계 금지.
       return (
         <div
-          className="text-sm leading-6 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-bold [&_h2]:mb-2 [&_h2]:text-base [&_h2]:font-bold [&_h3]:mb-1.5 [&_h3]:text-sm [&_h3]:font-bold [&_p]:mb-2 [&_ul]:mb-2 [&_ul]:ml-4 [&_ul]:list-disc [&_ol]:mb-2 [&_ol]:ml-4 [&_ol]:list-decimal"
+          className="text-sm leading-6 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-bold [&_h2]:mb-2 [&_h2]:text-base [&_h2]:font-bold [&_h3]:mb-1.5 [&_h3]:text-sm [&_h3]:font-bold [&_p]:mb-2 [&_ul]:mb-2 [&_ul]:ml-4 [&_ul]:list-disc [&_ol]:mb-2 [&_ol]:ml-4 [&_ol]:list-decimal [&_pre]:mb-2 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-muted [&_pre]:p-3 [&_pre]:text-[13px] [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[13px] [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_table]:mb-2 [&_table]:w-full [&_table]:border-collapse [&_table]:text-[13px] [&_th]:border [&_th]:border-border [&_th]:bg-muted [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_th]:font-semibold [&_td]:border [&_td]:border-border [&_td]:px-2 [&_td]:py-1"
           dangerouslySetInnerHTML={{ __html: sanitizeDocHtml(d.content) }}
         />
       );

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -800,7 +800,11 @@ function ShikiCodeBlock({
   );
 }
 
-function sanitizeDocHtml(content: string): string {
+// story #3776ccfe(FE·결재 카드) — embed-card.tsx의 doc 미리보기(renderEntityDetail)가
+// content_format='html' doc을 마크다운 전용 렌더러(MdBody)에 먹여 태그가 텍스트로 그대로
+// 찍히던 결함을 고치며 이 sanitize 정본을 재사용한다(사본 분화 금지 — decorateHtmlContent의
+// TOC/코드카피 장식은 그 소비처 전용이라 안 가져감, 순수 sanitize만).
+export function sanitizeDocHtml(content: string): string {
   const maybePurifier = DOMPurify as unknown as {
     sanitize?: (value: string) => string;
     default?: { sanitize?: (value: string) => string };


### PR DESCRIPTION
## 선생님 실사용 발견 배경

감確認 카드(doc ea94dac4, content_format=html) 승인 시 미리보기에서 HTML 태그가 원문 그대로 보였다("미리보기 카드에서 html 태그 뭔지?"). 표면 특정에 두 차례 반증-후-정정을 거쳤다(페드루 실측 협업).

## 근본 원인 추적

`EntityPreviewModal`(embed-card.tsx, #3076이 채팅 컨텍스트에서 패널로 라우팅한 그 표면)의 doc fetch는 apps/web 자체 `ApiDocRepository.getBySlug()`(packages/storage-api)를 거치는데, 이게 내부적으로 2단 호출한다: ①`GET /api/v2/docs?slug=`(list, content 없음, id 해소용) ②`GET /api/v2/docs/{id}`(단건, `DocResponse`=content+content_format 포함). 최종 응답은 ②를 그대로 반환 — `content_format='html'` doc이면 `d.content`에 raw HTML 문자열이 실린다.

`renderEntityDetail`의 doc 분기가 이 `content_format`을 무시하고 항상 `<MdBody>`(react-markdown, rehype-raw 없음)에 먹였다 — raw HTML은 실행 안 되고 이스케이프 텍스트로 그대로 찍힌다(선생님이 정확히 그 증상을 봄).

## 처방 — 기존 sanitize 정본 재사용(사본 분화 금지)

`doc-content-renderer.tsx`(문서 전체 읽기 뷰)가 이미 `content_format='html'`을 DOMPurify(`sanitizeDocHtml`)+`dangerouslySetInnerHTML`로 안전하게 처리 중 — 그 함수를 export해 `renderEntityDetail`의 doc 분기에서 재사용한다. `content_format='html'`이면 sanitize 後 렌더, 그 외(markdown 기본값)는 기존 `MdBody` 그대로(회귀 0) — `decorateHtmlContent`(TOC·코드카피 장식)는 전체 읽기 뷰 전용이라 안 가져옴(순수 sanitize만).

## AC2 — 동류 미리보기 표면 전수 확認

전 `<MdBody>` 소비처(7곳) grep 조사 — story/epic/hypothesis 필드(description·objective·acceptance_criteria·statement)는 애초에 `content_format` 개념 자체가 없는 순수 markdown 필드라 이 결함 클래스 밖. `file-viewer.tsx`의 MdBody는 업로드 파일 원문(별개 문제 클래스, doc 엔티티 content_format과 무관) — 이번 스코프 밖으로 확인만 남김. doc 분기 1곳이 유일한 실 결함 지점.

## 검증

- 신규 회귀가드 3건(html→실 렌더+태그 이스케이프 노출 0, html의 script/onerror 등 위험 요소 DOMPurify 제거 확認 XSS 가드, markdown 기본값 회귀 0) — `git diff→checkout HEAD→재실행(genuine RED — 실제로 &lt;h3&gt;... 이스케이프 텍스트가 그대로 노출되는 정확한 재현 확認)→git apply→재실행(3/3 GREEN)`
- 영향받은 8개 기존 테스트 파일 78/78 green
- 전체 vitest 508 files / 4544 tests green
- `tsc --noEmit` clean
- `eslint` 0 errors
- `pnpm build` EXIT=0

## 잔여

모바일(sprintable-mobile) 앱의 결재 카드가 동일 결함 클래스를 갖는지는 별도 확認 필요(페드루 지시, 이 PR 이후 착수).

Sprintable 산출물: 결재 카드 html 태그 노출 fix 실렌더(artifact `76f07947-f29a-401b-a9c7-df3b2d84178c`, doc ea94dac4 실 발췌 before/after)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>