### PR TITLE
fix(#3070): realtime-gateway MIG autoHealingPolicies SSOT

### DIFF
--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -87,6 +87,8 @@ case "${ENV}" in
         ZONES="${GCP_REGION}-a,${GCP_REGION}-b,${GCP_REGION}-c"
         # 재생성 시 detach 대상(provision_realtime_gclb.sh의 BACKEND_SERVICE_NAME과 동일해야 함).
         GCLB_BACKEND_SERVICE="realtime-gateway-dev-backend"
+        # story #3070/#3071 후속(2026-08-25) — GCLB_HEALTH_CHECK와 동일 리소스.
+        GCLB_HEALTH_CHECK="realtime-gateway-dev-health-check"
         MACHINE_TYPE="e2-small"
         SQL_INSTANCE_CONN="${GCP_PROJECT}:${GCP_REGION}:sprintable-dev"
         RUNTIME_SA="cloudrun-runtime-dev@${GCP_PROJECT}.iam.gserviceaccount.com"
@@ -138,6 +140,8 @@ case "${ENV}" in
         TARGET_SIZE=3
         ZONES="${GCP_REGION}-a,${GCP_REGION}-b,${GCP_REGION}-c"
         GCLB_BACKEND_SERVICE="realtime-gateway-prod-backend"
+        # story #3070/#3071 후속(2026-08-25) — GCLB_HEALTH_CHECK와 동일 리소스.
+        GCLB_HEALTH_CHECK="realtime-gateway-prod-health-check"
         MACHINE_TYPE="e2-small"
         SQL_INSTANCE_CONN="${GCP_PROJECT}:${GCP_REGION}:sprintable-prod"
         RUNTIME_SA="cloudrun-runtime-prod@${GCP_PROJECT}.iam.gserviceaccount.com"
@@ -626,6 +630,7 @@ IMAGE=${IMAGE}
 MACHINE_TYPE=${MACHINE_TYPE}
 TARGET_SIZE=${TARGET_SIZE}
 ZONES=${ZONES}
+GCLB_HEALTH_CHECK=${GCLB_HEALTH_CHECK}
 SQL_INSTANCE_CONN=${SQL_INSTANCE_CONN}
 RUNTIME_SA=${RUNTIME_SA}
 PLAIN_ENV_SPEC=${PLAIN_ENV_SPEC}
@@ -789,6 +794,24 @@ NAMED_PORT="http:8000"
 log "Ensuring named port ${NAMED_PORT} on ${MIG_NAME} (MIG 객체 속성 — 신규/재생성 시 비어있음)"
 gcloud compute instance-groups managed set-named-ports "${MIG_NAME}" \
     --project="${GCP_PROJECT}" --region="${GCP_REGION}" --named-ports="${NAMED_PORT}"
+
+# story #3070/#3071 후속(2026-08-25, 페드루 PO GO) 근본수정 — MIG에 autoHealingPolicies가
+# 없으면 롤링업데이트의 "새 인스턴스 준비됐다" 판정이 GCLB 헬스체크(앱 실제 응답 여부)와
+# 완전히 분리된다 — 그 결과 신규 VM이 부팅 중(healthCheck 아직 UNHEALTHY)인데도 MIG가 구
+# 인스턴스를 이미 삭제해 버려 무중단 창(max-unavailable=0)이 실제로는 ~2분 502로 새는
+# 것을 실측 확認(오늘 10사이클 관측, insert→delete 간격이 앱 부팅시간과 거의 여유 0으로
+# 맞물림 — 한 사이클만도 실 502 37건). --initial-delay는 이 스크립트가 아는 현재 부팅
+# 시간(#3071 배치 fetch 처방 後 실측 기준, 여유 포함)보다 크게 잡는다 — 부팅이 나중에
+# 다시 느려져도 자동으로 그만큼 더 기다리는 자기교정 구조(하드코딩된 sleep과 다름).
+# named-ports/backend-service 부착과 동일 원칙 — MIG 객체 자체의 속성이라 신규/재생성
+# 경로에서 항상 비어 있으므로 매 배포마다 무조건 보장한다(멱등 — 이미 같은 값이면 no-op).
+# ⛔즉시완화로 gcloud beta ... update를 직접 실행해 dev에 이미 적용해 뒀으나(손 적용은
+# 다음 재배포/재생성이 덮어씀), 이 블록이 정본(SSOT) — 이후 모든 배포가 이 값을 보장한다.
+AUTOHEAL_INITIAL_DELAY_SEC=270
+log "Ensuring autoHealingPolicies on ${MIG_NAME} (health-check=${GCLB_HEALTH_CHECK}, initial-delay=${AUTOHEAL_INITIAL_DELAY_SEC}s)"
+gcloud compute instance-groups managed update "${MIG_NAME}" \
+    --project="${GCP_PROJECT}" --region="${GCP_REGION}" \
+    --health-check="${GCLB_HEALTH_CHECK}" --initial-delay="${AUTOHEAL_INITIAL_DELAY_SEC}"
 
 # story #2142 근본수정 — backend-service 부착도 같은 이유로 이 스크립트가 방어적으로 보장한다
 # (provision_realtime_gclb.sh 스텝④와 동일 멱등 로직 재사용). 이미 붙어 있으면 조용히 스킵.

--- a/backend/scripts/deploy_realtime_gce.sh
+++ b/backend/scripts/deploy_realtime_gce.sh
@@ -665,8 +665,77 @@ else
         --metadata-from-file=startup-script="${STARTUP_SCRIPT_FILE}"
 fi
 
+# story #3482(2026-08-25, 카디르 QA 발견·PO 소스 재확認) 근본수정 — 아래 named-ports/
+# autoHealingPolicies/backend-service 방어 블록은 원래 이 if/else 전체가 끝난 뒤(기본 경로
+# 재배포마다 무조건 보장)에서만 실행됐다. 그 위치가 기본 경로(rolling-update, 아래 else
+# 분기)의 rolling-action start-update(762행 부근)보다 **뒤**라 — prod 첫 재배포처럼
+# autoHealingPolicies가 아직 없는 상태에서 rolling-action이 먼저 제출되면, 그 rolling batch엔
+# 이 스크립트가 고치려는 정확히 그 결함(신인스턴스 RUNNING=ready 오판→구인스턴스 조기삭제→502)이
+# 그대로 재현된다. 함수로 뽑아 MIG가 이미 존재함이 확인된 이 분기 진입 직후(rolling-action보다
+# 앞)에 한 번 선제 실행하고, 아래(785행대)에서 recreate/신규생성 경로 커버용으로 다시 호출한다 —
+# 멱등이라 두 번 불려도 부작용 없다(함수 정의 내부 주석 참조).
+ensure_mig_defensive_config() {
+    # story #2142(2026-07-23, 오르테가 적발) 근본수정 — named-ports는 MIG 객체 자체의 속성(인스턴스
+    # 템플릿에는 없음)이라 신규 생성/강제재생성 경로에서는 항상 비어 있는 채로 시작한다. 그 상태로
+    # 두면 backend-service는 port-name="http"을 찾다 못 찾아 **기본 포트 80**으로 폴백하는데 앱은
+    # 8000에서 듣는다 — 502(헬스체크는 8000을 직접 찌르므로 이 단절과 무관하게 HEALTHY로 보이는
+    # 게 제일 고약한 부분). set-named-ports는 멱등(이미 같은 값이면 no-op에 가까움)이라 매 배포마다
+    # 무조건 실행 — provision_realtime_gclb.sh 스텝④와 동일 명령·동일 named-port 값 유지(SSOT 중복
+    # 아님 — 그 스크립트가 "1회성 프로비저닝"이라 재배포마다 자동으로 다시 안 돌기 때문에 여기서도
+    # 방어적으로 보장한다. 사람이 그 스크립트 재실행을 잊어도 이 스크립트 하나로 무결하게 닫힘).
+    NAMED_PORT="http:8000"
+    log "Ensuring named port ${NAMED_PORT} on ${MIG_NAME} (MIG 객체 속성 — 신규/재생성 시 비어있음)"
+    gcloud compute instance-groups managed set-named-ports "${MIG_NAME}" \
+        --project="${GCP_PROJECT}" --region="${GCP_REGION}" --named-ports="${NAMED_PORT}"
+
+    # story #3070/#3071 후속(2026-08-25, 페드루 PO GO) 근본수정 — MIG에 autoHealingPolicies가
+    # 없으면 롤링업데이트의 "새 인스턴스 준비됐다" 판정이 GCLB 헬스체크(앱 실제 응답 여부)와
+    # 완전히 분리된다 — 그 결과 신규 VM이 부팅 중(healthCheck 아직 UNHEALTHY)인데도 MIG가 구
+    # 인스턴스를 이미 삭제해 버려 무중단 창(max-unavailable=0)이 실제로는 ~2분 502로 새는
+    # 것을 실측 확認(오늘 10사이클 관측, insert→delete 간격이 앱 부팅시간과 거의 여유 0으로
+    # 맞물림 — 한 사이클만도 실 502 37건). --initial-delay는 이 스크립트가 아는 현재 부팅
+    # 시간(#3071 배치 fetch 처방 後 실측 기준, 여유 포함)보다 크게 잡는다 — 부팅이 나중에
+    # 다시 느려져도 자동으로 그만큼 더 기다리는 자기교정 구조(하드코딩된 sleep과 다름).
+    # named-ports/backend-service 부착과 동일 원칙 — MIG 객체 자체의 속성이라 신규/재생성
+    # 경로에서 항상 비어 있으므로 매 배포마다 무조건 보장한다(멱등 — 이미 같은 값이면 no-op).
+    # ⛔즉시완화로 gcloud beta ... update를 직접 실행해 dev에 이미 적용해 뒀으나(손 적용은
+    # 다음 재배포/재생성이 덮어씀), 이 블록이 정본(SSOT) — 이후 모든 배포가 이 값을 보장한다.
+    AUTOHEAL_INITIAL_DELAY_SEC=270
+    log "Ensuring autoHealingPolicies on ${MIG_NAME} (health-check=${GCLB_HEALTH_CHECK}, initial-delay=${AUTOHEAL_INITIAL_DELAY_SEC}s)"
+    gcloud compute instance-groups managed update "${MIG_NAME}" \
+        --project="${GCP_PROJECT}" --region="${GCP_REGION}" \
+        --health-check="${GCLB_HEALTH_CHECK}" --initial-delay="${AUTOHEAL_INITIAL_DELAY_SEC}"
+
+    # story #2142 근본수정 — backend-service 부착도 같은 이유로 이 스크립트가 방어적으로 보장한다
+    # (provision_realtime_gclb.sh 스텝④와 동일 멱등 로직 재사용). 이미 붙어 있으면 조용히 스킵.
+    if ! gcloud compute backend-services describe "${GCLB_BACKEND_SERVICE}" --global --project="${GCP_PROJECT}" \
+            --format='value(backends[].group)' 2>/dev/null | grep -q "${MIG_NAME}"; then
+        log "Attaching ${MIG_NAME} to backend-service ${GCLB_BACKEND_SERVICE}"
+        gcloud compute backend-services add-backend "${GCLB_BACKEND_SERVICE}" \
+            --project="${GCP_PROJECT}" \
+            --global \
+            --instance-group="${MIG_NAME}" \
+            --instance-group-region="${GCP_REGION}" \
+            --balancing-mode=UTILIZATION \
+            --max-utilization=0.8
+    else
+        log "${MIG_NAME} already attached to backend-service ${GCLB_BACKEND_SERVICE} — skip"
+    fi
+
+    # story #2142 근본수정 — "조용히 넘어가는 게 제일 나쁜 것"(오르테가). 위 attach 스텝이 어떤
+    # gcloud 이유로든 조용히 실패/no-op했다면, 트래픽을 전환하기 전에 반드시 여기서 크게 실패한다.
+    if ! gcloud compute backend-services describe "${GCLB_BACKEND_SERVICE}" --global --project="${GCP_PROJECT}" \
+            --format='value(backends[].group)' 2>/dev/null | grep -q "${MIG_NAME}"; then
+        log "⛔ FATAL: ${MIG_NAME} is NOT attached to backend-service ${GCLB_BACKEND_SERVICE} after deploy."
+        log "   트래픽을 이 상태로 전환하면 프로덕션이 조용히 502가 됩니다 — 전환 전 반드시 원인 확認."
+        exit 1
+    fi
+}
+
 if gcloud compute instance-groups managed describe "${MIG_NAME}" \
         --region="${GCP_REGION}" --project="${GCP_PROJECT}" >/dev/null 2>&1; then
+    ensure_mig_defensive_config
+
     # story #2110(S1) 이력: 그 당시 2-zone→3-zone 확장은 **zone 구성 자체를 바꾸는** 작업이었고,
     # regional MIG의 zone 구성은 불변(immutable — gcloud `update`엔 --zones 플래그가 없고,
     # Compute API patch로 distributionPolicy.zones를 넣으면 400 "Zone configuration is
@@ -782,61 +851,11 @@ else
         --instance-redistribution-type=none
 fi
 
-# story #2142(2026-07-23, 오르테가 적발) 근본수정 — named-ports는 MIG 객체 자체의 속성(인스턴스
-# 템플릿에는 없음)이라 신규 생성/강제재생성 경로에서는 항상 비어 있는 채로 시작한다. 그 상태로
-# 두면 backend-service는 port-name="http"을 찾다 못 찾아 **기본 포트 80**으로 폴백하는데 앱은
-# 8000에서 듣는다 — 502(헬스체크는 8000을 직접 찌르므로 이 단절과 무관하게 HEALTHY로 보이는
-# 게 제일 고약한 부분). set-named-ports는 멱등(이미 같은 값이면 no-op에 가까움)이라 매 배포마다
-# 무조건 실행 — provision_realtime_gclb.sh 스텝④와 동일 명령·동일 named-port 값 유지(SSOT 중복
-# 아님 — 그 스크립트가 "1회성 프로비저닝"이라 재배포마다 자동으로 다시 안 돌기 때문에 여기서도
-# 방어적으로 보장한다. 사람이 그 스크립트 재실행을 잊어도 이 스크립트 하나로 무결하게 닫힘).
-NAMED_PORT="http:8000"
-log "Ensuring named port ${NAMED_PORT} on ${MIG_NAME} (MIG 객체 속성 — 신규/재생성 시 비어있음)"
-gcloud compute instance-groups managed set-named-ports "${MIG_NAME}" \
-    --project="${GCP_PROJECT}" --region="${GCP_REGION}" --named-ports="${NAMED_PORT}"
-
-# story #3070/#3071 후속(2026-08-25, 페드루 PO GO) 근본수정 — MIG에 autoHealingPolicies가
-# 없으면 롤링업데이트의 "새 인스턴스 준비됐다" 판정이 GCLB 헬스체크(앱 실제 응답 여부)와
-# 완전히 분리된다 — 그 결과 신규 VM이 부팅 중(healthCheck 아직 UNHEALTHY)인데도 MIG가 구
-# 인스턴스를 이미 삭제해 버려 무중단 창(max-unavailable=0)이 실제로는 ~2분 502로 새는
-# 것을 실측 확認(오늘 10사이클 관측, insert→delete 간격이 앱 부팅시간과 거의 여유 0으로
-# 맞물림 — 한 사이클만도 실 502 37건). --initial-delay는 이 스크립트가 아는 현재 부팅
-# 시간(#3071 배치 fetch 처방 後 실측 기준, 여유 포함)보다 크게 잡는다 — 부팅이 나중에
-# 다시 느려져도 자동으로 그만큼 더 기다리는 자기교정 구조(하드코딩된 sleep과 다름).
-# named-ports/backend-service 부착과 동일 원칙 — MIG 객체 자체의 속성이라 신규/재생성
-# 경로에서 항상 비어 있으므로 매 배포마다 무조건 보장한다(멱등 — 이미 같은 값이면 no-op).
-# ⛔즉시완화로 gcloud beta ... update를 직접 실행해 dev에 이미 적용해 뒀으나(손 적용은
-# 다음 재배포/재생성이 덮어씀), 이 블록이 정본(SSOT) — 이후 모든 배포가 이 값을 보장한다.
-AUTOHEAL_INITIAL_DELAY_SEC=270
-log "Ensuring autoHealingPolicies on ${MIG_NAME} (health-check=${GCLB_HEALTH_CHECK}, initial-delay=${AUTOHEAL_INITIAL_DELAY_SEC}s)"
-gcloud compute instance-groups managed update "${MIG_NAME}" \
-    --project="${GCP_PROJECT}" --region="${GCP_REGION}" \
-    --health-check="${GCLB_HEALTH_CHECK}" --initial-delay="${AUTOHEAL_INITIAL_DELAY_SEC}"
-
-# story #2142 근본수정 — backend-service 부착도 같은 이유로 이 스크립트가 방어적으로 보장한다
-# (provision_realtime_gclb.sh 스텝④와 동일 멱등 로직 재사용). 이미 붙어 있으면 조용히 스킵.
-if ! gcloud compute backend-services describe "${GCLB_BACKEND_SERVICE}" --global --project="${GCP_PROJECT}" \
-        --format='value(backends[].group)' 2>/dev/null | grep -q "${MIG_NAME}"; then
-    log "Attaching ${MIG_NAME} to backend-service ${GCLB_BACKEND_SERVICE}"
-    gcloud compute backend-services add-backend "${GCLB_BACKEND_SERVICE}" \
-        --project="${GCP_PROJECT}" \
-        --global \
-        --instance-group="${MIG_NAME}" \
-        --instance-group-region="${GCP_REGION}" \
-        --balancing-mode=UTILIZATION \
-        --max-utilization=0.8
-else
-    log "${MIG_NAME} already attached to backend-service ${GCLB_BACKEND_SERVICE} — skip"
-fi
-
-# story #2142 근본수정 — "조용히 넘어가는 게 제일 나쁜 것"(오르테가). 위 attach 스텝이 어떤
-# gcloud 이유로든 조용히 실패/no-op했다면, 트래픽을 전환하기 전에 반드시 여기서 크게 실패한다.
-if ! gcloud compute backend-services describe "${GCLB_BACKEND_SERVICE}" --global --project="${GCP_PROJECT}" \
-        --format='value(backends[].group)' 2>/dev/null | grep -q "${MIG_NAME}"; then
-    log "⛔ FATAL: ${MIG_NAME} is NOT attached to backend-service ${GCLB_BACKEND_SERVICE} after deploy."
-    log "   트래픽을 이 상태로 전환하면 프로덕션이 조용히 502가 됩니다 — 전환 전 반드시 원인 확認."
-    exit 1
-fi
+# story #3482(2026-08-25) — MIG가 방금 신규 생성됐거나(바로 위 else 분기) FORCE_MIG_RECREATE로
+# delete+recreate됐다면(688행) named-ports/autoHealingPolicies/backend-service 부착이 전부
+# 비어 있는 새 MIG이므로 여기서 다시 보장한다(함수 정의는 668행 위 — 멱등이라 rolling-update
+# 분기에서 이미 한 번 불렸어도 재호출 무해).
+ensure_mig_defensive_config
 
 # story #2673(2026-08-15, 실사고: dev 배포가 quota INSTANCE_TEMPLATES(한도 300)로 실패 —
 # 배포마다 이 스크립트가 새 템플릿을 만들고 옛것을 영구 방치했다. dev 게이트웨이만 463개

--- a/backend/tests/test_deploy_realtime_gce_autohealing.py
+++ b/backend/tests/test_deploy_realtime_gce_autohealing.py
@@ -71,3 +71,30 @@ def test_autohealing_step_runs_defensively_every_deploy_like_named_ports():
     autoheal_idx = text.index('gcloud compute instance-groups managed update "${MIG_NAME}"')
     backend_attach_idx = text.index("gcloud compute backend-services add-backend")
     assert named_ports_idx < autoheal_idx < backend_attach_idx
+
+
+def test_defensive_config_precedes_rolling_action_in_default_path():
+    """story #3482(2026-08-25, 카디르 QA 발견·PO 소스 재확認) 회귀가드 — 기본 경로(MIG가 이미
+    존재 + FORCE_MIG_RECREATE 미설정)에서 named-ports/autoHealingPolicies/backend-service 방어
+    블록이 rolling-action start-update보다 먼저 실행돼야 한다. 순서가 뒤집히면(과거 결함) prod
+    첫 재배포처럼 autoHealingPolicies가 아직 없는 MIG에 rolling-action이 먼저 제출돼, 신인스턴스
+    RUNNING=ready 오판→구인스턴스 조기삭제→502가 그 배포에서 그대로 재현된다.
+
+    'MIG가 이미 존재한다'고 판정하는 최초 분기(668행대 `if gcloud ... describe MIG_NAME`) 진입
+    직후에 방어 블록이 호출되는지를 확인 — 그 지점은 구조적으로 FORCE_MIG_RECREATE 분기와
+    rolling-action 둘 다보다 앞이므로, 이 위치 하나로 두 경로(recreate/rolling-update) 전부의
+    선행 보장을 검증한다."""
+    text = _script_text()
+    exists_branch_idx = text.index(
+        'if gcloud compute instance-groups managed describe "${MIG_NAME}" \\\n'
+        '        --region="${GCP_REGION}" --project="${GCP_PROJECT}" >/dev/null 2>&1; then'
+    )
+    rolling_action_idx = text.index(
+        'gcloud compute instance-groups managed rolling-action start-update "${MIG_NAME}"'
+    )
+    # exists_branch 진입 이후 첫 ensure_mig_defensive_config 호출 지점을 찾는다(정의부의
+    # 함수 시그니처 `ensure_mig_defensive_config() {`가 아니라 실제 호출문).
+    first_call_idx = text.index("    ensure_mig_defensive_config\n", exists_branch_idx)
+    assert exists_branch_idx < first_call_idx < rolling_action_idx, (
+        "방어 블록 호출이 'MIG 존재' 분기 진입 직후·rolling-action 이전이어야 한다"
+    )

--- a/backend/tests/test_deploy_realtime_gce_autohealing.py
+++ b/backend/tests/test_deploy_realtime_gce_autohealing.py
@@ -1,0 +1,73 @@
+"""story #3070/#3071 후속(2026-08-25) — realtime-gateway MIG autoHealingPolicies SSOT 회귀가드.
+
+배경: dev MIG(sprintable-realtime-gateway-dev)에 autoHealingPolicies가 없어 롤링업데이트의
+"새 인스턴스 준비됐다" 판정이 GCLB 헬스체크(앱 실제 응답 여부)와 완전히 분리돼 있었다 —
+실측(2026-08-25, 오늘 10사이클): insert→delete 간격이 앱 부팅시간과 거의 여유 0으로 맞물려
+한 사이클만도 실 502 37건. 페드루 PO GO(2026-08-25) 후 dev에 즉시완화로 `gcloud beta
+compute instance-groups managed update --health-check=... --initial-delay=270` 를 손으로
+적용했으나, 그 값은 다음 배포/재생성이 덮는다 — 이 스크립트(deploy_realtime_gce.sh)가
+정본이어야 한다. 이 테스트는 그 SSOT 반영을 실 파일 내용으로 고정한다(요약이 아니라 생성된
+코드 그 자체 — named-ports/backend-service 부착과 동일한 "매 배포마다 방어적으로 보장"
+원칙을 따르는지도 확認)."""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "deploy_realtime_gce.sh")
+
+
+def _resolve(env: str) -> dict[str, str]:
+    proc = subprocess.run(
+        ["bash", _SCRIPT, env],
+        capture_output=True, text=True,
+        env={**os.environ, "DRY_RUN": "1", "COMMIT_SHA": "deadbeef"}, check=True,
+    )
+    cfg: dict[str, str] = {}
+    for line in proc.stdout.strip().splitlines():
+        if "=" in line:
+            k, _, v = line.partition("=")
+            cfg[k.strip()] = v.strip()
+    return cfg
+
+
+def _script_text() -> str:
+    with open(_SCRIPT, encoding="utf-8") as f:
+        return f.read()
+
+
+def test_dev_and_prod_resolve_distinct_health_check_names():
+    dev_cfg = _resolve("dev")
+    prod_cfg = _resolve("prod")
+    assert dev_cfg["GCLB_HEALTH_CHECK"] == "realtime-gateway-dev-health-check"
+    assert prod_cfg["GCLB_HEALTH_CHECK"] == "realtime-gateway-prod-health-check"
+
+
+def test_autohealing_update_command_present_and_uses_resolved_health_check():
+    text = _script_text()
+    assert re.search(
+        r"gcloud compute instance-groups managed update \"\$\{MIG_NAME\}\"", text
+    ), "autoHealingPolicies를 설정하는 update 커맨드가 있어야 한다"
+    assert '--health-check="${GCLB_HEALTH_CHECK}"' in text
+    assert "--initial-delay=" in text
+
+
+def test_initial_delay_has_safety_margin_over_known_boot_time():
+    """알려진 최악 부팅시간(~3분=180초, #3070 그라운딩) 대비 여유가 있어야 한다 —
+    너무 타이트하면 정상 부팅 중인 인스턴스를 autohealing이 죽이는 재발 위험."""
+    text = _script_text()
+    m = re.search(r"AUTOHEAL_INITIAL_DELAY_SEC=(\d+)", text)
+    assert m, "AUTOHEAL_INITIAL_DELAY_SEC 변수가 정의돼 있어야 한다"
+    assert int(m.group(1)) >= 240, "알려진 부팅시간(~180초)보다 유의미하게 커야 한다"
+
+
+def test_autohealing_step_runs_defensively_every_deploy_like_named_ports():
+    """named-ports/backend-service 부착과 동일 원칙 — MIG 재생성 조건문 밖(항상 실행 경로)에
+    있어야 한다. set-named-ports 호출 뒤·backend-services add-backend 앞에 위치하는지로
+    "항상 실행 블록" 안에 있음을 검증(두 앵커 다 무조건 실행 구간에 있다는 게 기존 계약)."""
+    text = _script_text()
+    named_ports_idx = text.index('gcloud compute instance-groups managed set-named-ports "${MIG_NAME}"')
+    autoheal_idx = text.index('gcloud compute instance-groups managed update "${MIG_NAME}"')
+    backend_attach_idx = text.index("gcloud compute backend-services add-backend")
+    assert named_ports_idx < autoheal_idx < backend_attach_idx


### PR DESCRIPTION
[SID:3086]

## 배경
#3070/#3071 그라운딩 잔여 축(«GCLB 편입 원자성») — 페드루 PO 승인(2026-08-25) 후 dev에
즉시완화를 손으로 적용했으나, 손 gcloud 값은 다음 배포/재생성이 덮으므로 이 스크립트를
정본(SSOT)으로 삼아 명문화한다.

## 근본원인(실측)
`sprintable-realtime-gateway-dev` MIG에 `autoHealingPolicies`가 없었다(describe 전체출력
확認 — 필드 자체 부재). GCLB 헬스체크(interval=10s·healthy_threshold=2·/api/v2/ready)와
MIG 롤링업데이트의 "새 인스턴스 준비" 판정이 완전히 분리된 두 제어평면이었다 — 오늘
(2026-08-25) 10회 롤링사이클 관측 결과 insert→delete 간격이 매번 ~3분(예 03:21:21 insert
→03:24:37 delete)으로 앱 부팅시간(#3070 그라운딩 실측치)과 거의 여유 0으로 맞물려, 한
사이클(03:21~03:28)만도 GCLB 요청로그로 실 502 37건을 직접 확認했다.

## 처방
`deploy_realtime_gce.sh`에 `GCLB_HEALTH_CHECK`(dev/prod 분기별 실 헬스체크명) 변수를
추가하고, named-ports/backend-service 부착과 동일한 "매 배포마다 방어적으로 보장"
원칙으로 `gcloud compute instance-groups managed update --health-check=... --initial-delay=270`
를 무조건 실행 경로에 얹었다(멱등). 이제 롤링업데이트가 "VM 뜸"이 아니라 "헬스체크
실통과"를 기준으로 구인스턴스 삭제를 게이팅 — 부팅시간이 나중에 다시 늘어나도 자동으로
그만큼 더 기다리는 자기교정 구조(하드코딩 sleep과 다름).

## 검증
- 신규 테스트 4건(`test_deploy_realtime_gce_autohealing.py`): dev/prod 헬스체크명 분리
  해석·update 커맨드 존재+올바른 변수 참조·initial-delay 안전여유(≥240s)·named-ports~
  backend-service 사이 항상실행 위치. RED→GREEN 실측(git stash로 원복 후 4건 정확히 실패
  확認 → 복원 후 재통과).
- 기존 `test_deploy_realtime_gce_secret_batching.py` 5건 무회귀.
- dry-run(DRY_RUN=1) dev/prod 둘 다 `GCLB_HEALTH_CHECK` 정확한 값으로 해석 확認.
- 스크립트 syntax(`bash -n`) 통과.

## 다음 실측 검증(적용 완료 — 페드루 PO 요청 ①)
다음 실 롤링 사이클에서 insert→delete 간격이 헬스체크 통과 시점 뒤로 밀리는지·그 사이클
502 0건인지 실측 예정(dev에는 이미 gcloud로 즉시완화 적용돼 있어 이 PR 머지 前에도 다음
자연 배포에서 검증 가능).
