### PR TITLE
fix(#3079): realtime path-filter GHA로 이전 — Cloud Build .git 부재로 상시 배포되던 것 근본수정

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -383,6 +383,80 @@ jobs:
             echo "mcp_allowed_hosts=" >> "$GITHUB_OUTPUT"
           fi
 
+      # story #3079(2026-08-25, #3070/#3031/#2089 근본원인 공통수정) — realtime path-filter
+      # (GCE #2089 · Cloud Run #3031) 둘 다 merge 이후 단 한 번도 실제로 스킵을 실행한 적이
+      # 없었다: 실 root cause=Cloud Build가 `gcloud builds submit --source=.`(로컬소스 tarball
+      # 업로드)로 도는데 레포에 `.gcloudignore`가 없어 gcloud 기본 규칙(.gitignore 기반 자동
+      # 생성+`.git` 항상 제외)이 적용돼 Cloud Build 워크스페이스엔 `.git`이 아예 없었다 —
+      # 두 필터의 `git diff`/`git fetch`가 매번 "Not a git repository"(rc=129)로 실패해 각자의
+      # fail-safe("판별 불가 → 배포 진행")로 항상 떨어졌다(실 Cloud Build 로그 원문으로 확定).
+      #
+      # 처방: git diff 판정을 Cloud Build 안이 아니라 **여기(GHA, 실 .git 보유)**에서 계산해
+      # skip/deploy 결과만 substitution으로 넘긴다 — Cloud Build 워크스페이스에 `.git`을
+      # 살리려는 시도(`.gcloudignore`로 포함 허용 등)보다 안전(tarball 업로드 크기/보안 노출
+      # 우려 없음). `check_realtime_relevant_diff.sh`(#2089 SSOT)는 그대로 재사용 — 로직
+      # 이중선언 없음.
+      #
+      # ⛔fetch-depth: `actions/checkout@v4` 기본값(fetch-depth=1, shallow)이라 임의 과거
+      # last_sha와의 diff가 불가능 — `git fetch --unshallow`로 전체 이력을 먼저 받는다.
+      # ⛔fail-safe 방향(페드루 PO 재판단 요청, 2026-08-25): 필터가 실제로 한 번도 안 돌던
+      # 예전엔 "판별 불가 → 배포 진행"이 사실상 무해했다(항상 그 경로였으므로) — 이제 필터가
+      # 진짜로 돌면 **잘못된 skip 판정**(실제 관련 변경이 있는데 스킵)이 새로 생기는 위험이다.
+      # 그래도 방향은 유지한다 — `check_realtime_relevant_diff.sh` 자신의 원 설계 철학
+      # ("정확성을 빈도보다 우선" — 조용히 스킵보다 조용히 배포가 안전)과 동일 원칙이고,
+      # 판별 불가 상황(최초 배포·트래픽 스플릿 중·describe 실패)은 여전히 드물고 명시적으로
+      # 로그에 남으므로 사람이 알아챌 수 있다. REALTIME_RELEVANT_PATHS 목록의 완전성이
+      # 이제부터 진짜로 중요해진다는 점만 리뷰어가 유념할 것.
+      #
+      # #3031(Cloud Run path-filter "로그 도장")은 이 fix에 흡수됨 — 별도 후속 불요.
+      - name: Resolve realtime deploy path-filter (GHA — 실 git 보유, Cloud Build엔 없음)
+        id: realtime_gate
+        if: steps.env.outputs.target == 'dev'
+        env:
+          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          set -uo pipefail
+          AR_REGION="asia-northeast3"
+          git fetch --unshallow --quiet 2>/dev/null || git fetch --quiet 2>/dev/null || true
+
+          gce_skip="false"
+          current_template="$(gcloud compute instance-groups managed describe sprintable-realtime-gateway-dev \
+            --region="${AR_REGION}" --project="${GCP_PROJECT}" \
+            --format='value(versions[0].instanceTemplate)' 2>/dev/null | sed 's#.*/##' || echo '')"
+          gce_last_sha="$(echo "${current_template}" | grep -oE '[0-9a-f]{8}' | head -1 || echo '')"
+          if [ -z "${gce_last_sha}" ]; then
+            echo "[gce] 직전 SHA를 인스턴스 템플릿 이름에서 못 읽음(최초 배포이거나 이름 패턴 변경) — 배포 진행"
+          elif bash backend/scripts/check_realtime_relevant_diff.sh "${gce_last_sha}" "${GITHUB_SHA}"; then
+            echo "[gce] 관련 경로 변경 있음 — 배포 진행"
+          else
+            echo "[gce] ${gce_last_sha}..${GITHUB_SHA} 사이 realtime-관련 경로 변경 없음 — 스킵"
+            gce_skip="true"
+          fi
+
+          cloudrun_skip="false"
+          serving_revision="$(gcloud run services describe sprintable-realtime-dev \
+            --region="${AR_REGION}" --project="${GCP_PROJECT}" \
+            --format='value(status.traffic.filter(percent=100).revisionName)' 2>/dev/null || echo '')"
+          if [ -z "${serving_revision}" ]; then
+            echo "[cloudrun] 100% 트래픽 서빙 리비전을 못 읽음(최초 배포이거나 트래픽 스플릿 중) — 배포 진행"
+          else
+            last_image="$(gcloud run revisions describe "${serving_revision}" \
+              --region="${AR_REGION}" --project="${GCP_PROJECT}" \
+              --format='value(spec.containers[0].image)' 2>/dev/null || echo '')"
+            cloudrun_last_sha="${last_image##*:}"
+            if [ -z "${cloudrun_last_sha}" ] || [ "${cloudrun_last_sha}" = "${last_image}" ]; then
+              echo "[cloudrun] 서빙 리비전 이미지 태그를 못 읽음 — 배포 진행"
+            elif bash backend/scripts/check_realtime_relevant_diff.sh "${cloudrun_last_sha}" "${GITHUB_SHA}"; then
+              echo "[cloudrun] 관련 경로 변경 있음 — 배포 진행"
+            else
+              echo "[cloudrun] ${cloudrun_last_sha}..${GITHUB_SHA} 사이 realtime-관련 경로 변경 없음 — 스킵"
+              cloudrun_skip="true"
+            fi
+          fi
+
+          echo "gce_skip=${gce_skip}" >> "$GITHUB_OUTPUT"
+          echo "cloudrun_skip=${cloudrun_skip}" >> "$GITHUB_OUTPUT"
+
       # story #2827 P0 핫픽스 2차(2026-08-03, 페드루 dispatch-test 실측) — 1차 핫픽스가 조립
       # 로직을 "Set deploy environment" 스텝(위, 이미 표현식 1개+대량 주석으로 16000자대) 안에
       # 넣었더니 그 스텝이 "Exceeded max expression length 21000"으로 새로 걸렸다(주석 삭제로도
@@ -395,6 +469,11 @@ jobs:
         env:
           V_DEPLOY_ENV: ${{ steps.env.outputs.target }}
           V_FASTAPI_URL: ${{ steps.env.outputs.fastapi_url }}
+          # story #3079 — 위 gate 스텝이 prod에선 안 도므로(if: target==dev) 빈 문자열일 수
+          # 있다 — SUBST 조립부에서 빈 값을 "false"(=배포 진행, 기존 fail-safe 방향과 동일)로
+          # 명시 치환한다.
+          V_REALTIME_GCE_SKIP: ${{ steps.realtime_gate.outputs.gce_skip }}
+          V_REALTIME_CLOUDRUN_SKIP: ${{ steps.realtime_gate.outputs.cloudrun_skip }}
           V_BACKEND_MIN_INSTANCES: ${{ steps.env.outputs.backend_min_instances }}
           V_BACKEND_MAX_INSTANCES: ${{ steps.env.outputs.backend_max_instances }}
           V_DB_POOL_SIZE: ${{ steps.env.outputs.db_pool_size }}
@@ -425,7 +504,12 @@ jobs:
           V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED: ${{ steps.env.outputs.backend_sse_transient_replay_enabled }}
           V_MCP_ALLOWED_HOSTS: ${{ steps.env.outputs.mcp_allowed_hosts }}
         run: |
-          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\",_MCP_ALLOWED_HOSTS=\"${V_MCP_ALLOWED_HOSTS}\",_EE_ENABLED=\"${V_EE_ENABLED}\",_LICENSE_CONSENT=\"${V_LICENSE_CONSENT}\",_TOSS_CLIENT_KEY=\"${V_TOSS_CLIENT_KEY}\",_NEXT_PUBLIC_APP_URL=\"${V_NEXT_PUBLIC_APP_URL}\""
+          # story #3079 — prod push는 위 gate 스텝이 안 돌아(if: target==dev) 빈 문자열이다.
+          # 빈 값을 "false"(=배포 진행, 기존 fail-safe 방향과 동일)로 명시 치환 — cloudbuild.yaml
+          # 쪽은 정확히 "true" 문자열만 스킵으로 취급하므로 다른 값은 전부 안전측(배포)이다.
+          V_REALTIME_GCE_SKIP="${V_REALTIME_GCE_SKIP:-false}"
+          V_REALTIME_CLOUDRUN_SKIP="${V_REALTIME_CLOUDRUN_SKIP:-false}"
+          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\",_MCP_ALLOWED_HOSTS=\"${V_MCP_ALLOWED_HOSTS}\",_EE_ENABLED=\"${V_EE_ENABLED}\",_LICENSE_CONSENT=\"${V_LICENSE_CONSENT}\",_TOSS_CLIENT_KEY=\"${V_TOSS_CLIENT_KEY}\",_NEXT_PUBLIC_APP_URL=\"${V_NEXT_PUBLIC_APP_URL}\",_REALTIME_GCE_SKIP=\"${V_REALTIME_GCE_SKIP}\",_REALTIME_CLOUDRUN_SKIP=\"${V_REALTIME_CLOUDRUN_SKIP}\""
           echo "substitutions=${SUBST}" >> "$GITHUB_OUTPUT"
 
       - name: Submit Cloud Build

--- a/backend/tests/test_3031_realtime_cloudrun_deploy_path_filter.py
+++ b/backend/tests/test_3031_realtime_cloudrun_deploy_path_filter.py
@@ -1,35 +1,16 @@
-"""story #3031(2026-08-24) — deploy-realtime-gce(GCE, story #2089)엔 이미 realtime-relevant
-path-filter가 있었는데 **실제로 브라우저 SSE를 서빙하는** deploy-realtime(Cloud Run) 스텝엔
-그게 없어, 관련 없는 코드만 섞인 develop merge에서도 매번 무조건 재배포됐다 — 오늘(08-24)
-sprintable-realtime-dev 리비전 12개(PO 실측), 롤아웃마다 라이브 SSE 전 연결 절단(재연결/
-백필 사이클 반복). #3026/#3029로 고친 건 코드층 dedup 버그이고, 이건 별개의 인프라층
-원인 — 둘 다 있어야 #2985 AC② 라이브 재검이 안정된다.
+"""story #3031(2026-08-24, 원안) → story #3079(2026-08-25, 근본수정)로 대체.
 
-이 테스트는 그 비대칭이 해소됐음을 cloudbuild.yaml 내용으로 고정한다(test_2178_realtime_
-flag_parity.py와 동일 관례 — 실제 gcloud/git 호출은 CI 밖이라 실행 자체를 테스트할 수
-없고, "무조건 재배포하던 이전 상태로 되돌아가지 않는다"를 구조 검사로 pin한다).
+원안(#3031)은 cloudbuild.yaml `deploy-realtime` 스텝 안에서 직접 `git diff`/서빙 리비전
+조회를 했으나, 실 Cloud Build 로그로 그 판정이 **단 한 번도 실제로 스킵을 실행한 적이
+없었다**는 게 드러났다(#3079 그라운딩) — Cloud Build가 로컬소스(tarball) 업로드로 도는데
+레포에 `.gcloudignore`가 없어 `.git`이 워크스페이스에 아예 없고, `git diff`가 매번 "Not a
+git repository"(rc=129)로 실패해 fail-safe("판별 불가 → 배포 진행")로 항상 떨어졌다.
 
-## 설계 상세(원래 cloudbuild.yaml 스텝 주석에 있었으나, deploy-realtime 스텝이 UTF-8
-바이트 한도(10,000, Cloud Build args 제약)를 넘겨 2연속 배포 실패를 낸 핫픽스로 여기
-이관됨 — 한글 주석 1자=UTF-8 3바이트라 문자수로는 안 걸리던 게 함정의 본체였다):
-
-- GCE MIG는 인스턴스 템플릿 이름에서 직전 SHA를 grep으로 뽑아야 했지만(임의 이름이라),
-  Cloud Run은 서빙 리비전의 이미지 태그 자체가 정확히 그 SHA다(`--image=...:${COMMIT_SHA}`
-  컨벤션 그대로) — grep 휴리스틱 불요, 태그를 그대로 쓴다.
-- "서빙"(트래픽 100%) 리비전이어야 한다 — `describe`의 `spec.template`은 다음 배포
-  대상이지 실제 트래픽이 아니다(배포 실효=서빙 리비전 digest 교훈, #2985 조사에서
-  재확인). `status.traffic[]`에서 100%를 받는 리비전 이름을 먼저 뽑고, 그 리비전 자체를
-  describe해 이미지 태그를 읽는다.
-- fail-safe는 GCE 선례와 동일: 판별 불가(첫 배포·트래픽 스플릿 중·describe 실패)면
-  스킵하지 않고 배포로 진행(`check_realtime_relevant_diff.sh` 자체의 fail-safe도 동일
-  방향 — "필터가 실수로 좁아도 조용히 안 새게").
-- story #2421 교훈(deploy-backend 핫픽스, `test_deploy_backend_redis_secret_conflict.py`
-  가드) — Cloud Build 자신의 substitution 파서가 bash 실행 前에 args 문자열 전체를 먼저
-  훑어, `${선언안된이름}`을 substitution 오류로 build submit 자체를 거부한다. 그래서 이
-  스텝 안에서 새로 짓는 로컬 셸 변수(`serving_revision`·`last_image`·`last_sha`)는
-  참조할 때마다 `$$`로 이스케이프해야 한다(Cloud Build가 `$$`→`$`로 한 번 접어 bash에
-  넘긴다) — GCE 선례(`current_template`·`last_sha`, `deploy-realtime-gce` 스텝)는 이
-  가드 대상 스텝 목록 밖이라 안 걸렸을 뿐, 실제로는 같은 함정 자리다."""
+처방(#3079): 판정을 Cloud Build 밖(GHA, 실 `.git` 보유 — `.github/workflows/cloud-build.yml`
+"Resolve realtime deploy path-filter" 스텝, 회귀가드는
+`test_cloud_build_realtime_path_filter_gha.py`)으로 옮기고, cloudbuild.yaml `deploy-realtime`
+스텝은 그 결과(`_REALTIME_CLOUDRUN_SKIP` substitution)만 읽는다. 이 파일은 그 단순화된
+읽기-전용 계약만 고정한다."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -47,27 +28,28 @@ def _deploy_realtime_step_script() -> str:
     return step["args"][1]
 
 
-def test_deploy_realtime_reuses_shared_path_filter_script():
-    """GCE 선례와 같은 스크립트 재사용(SSOT — 판별 로직 이중선언 금지)."""
+def test_deploy_realtime_no_longer_attempts_git_diff_inside_cloud_build():
+    """#3079 회귀 방지 핵심 — Cloud Build 안에서 git diff/서빙 리비전 재조회를 다시 하면
+    같은 결함(rc=129 fail-safe 상시배포)이 재발한다. 이 스텝은 GHA가 넘긴 skip 플래그만
+    읽어야 한다."""
     script = _deploy_realtime_step_script()
-    assert "backend/scripts/check_realtime_relevant_diff.sh" in script
+    assert "git diff" not in script
+    assert "git fetch" not in script
+    assert "check_realtime_relevant_diff.sh" not in script
+
+
+def test_deploy_realtime_reads_gha_computed_skip_flag():
+    script = _deploy_realtime_step_script()
+    assert '"${_REALTIME_CLOUDRUN_SKIP}" = "true"' in script
 
 
 def test_deploy_realtime_skip_branch_exits_before_actual_deploy():
-    """스킵 결정이 실제 `gcloud run deploy`보다 앞서야 한다 — 순서가 뒤바뀌면 스킵이 무의미.
-
-    ⚠️두 함정을 각각 피한다:
-    ①"skip deploy-realtime:" 앵커는 이 스텝 맨 앞(prod-gate skip, story #2078 이전부터
-    존재)에도 나온다 — story #3031 전용 스킵 메시지를 별도로 찾아야 한다.
-    ②"exit 0"를 skip 메시지~배포커맨드 «전체 구간»에서 substring 검색하면 그 사이에
-    껴 있는 무관한 산문 주석(story #2442, "함수 진입 전에 exit 0)")에 우연히 매치돼
-    거짓양성이 난다(실제 겪음 — mutation으로 exit 0를 지워도 4/4 그대로 통과했었다).
-    «스킵 echo 바로 다음 줄»이 정확히 exit 0인지, 줄 단위 인접성으로 좁혀야 한다."""
+    """스킵 결정이 실제 `gcloud run deploy`보다 앞서야 한다 — 순서가 뒤바뀌면 스킵이 무의미."""
     script = _deploy_realtime_step_script()
     lines = script.splitlines()
     skip_line_idx = next(
         i for i, l in enumerate(lines)
-        if "skip deploy-realtime:" in l and "story #3031 path-filter" in l
+        if "skip deploy-realtime:" in l and "story #3079" in l
     )
     deploy_line_idx = next(
         i for i, l in enumerate(lines)
@@ -75,31 +57,8 @@ def test_deploy_realtime_skip_branch_exits_before_actual_deploy():
     )
     assert skip_line_idx < deploy_line_idx, "path-filter 스킵 판단이 실제 배포 커맨드보다 뒤에 있음"
 
-    next_nonblank = next(l.strip() for l in lines[skip_line_idx + 1 :] if l.strip())
+    next_nonblank = next(l.strip() for l in lines[skip_line_idx + 1:] if l.strip())
     assert next_nonblank == "exit 0", (
         f"스킵 echo 바로 다음 줄이 'exit 0'가 아님(실제: {next_nonblank!r}) — "
         "로그만 찍고 실제로 안 빠져나가면 그 아래 배포가 그대로 실행됨"
     )
-
-
-def test_deploy_realtime_reads_serving_revision_not_template_spec():
-    """describe의 spec.template은 다음 배포 대상이지 실제 트래픽이 아니다(배포 실효=서빙
-    리비전 digest 교훈) — 100% 트래픽 리비전을 명시로 골라야 한다."""
-    script = _deploy_realtime_step_script()
-    assert "status.traffic.filter(percent=100).revisionName" in script
-
-
-def test_deploy_realtime_fails_safe_when_serving_revision_unknown():
-    """최초 배포·트래픽 스플릿 중처럼 직전 SHA를 못 구하면 스킵하지 않고 배포로 진행해야
-    한다(GCE 선례·check_realtime_relevant_diff.sh 자체의 fail-safe와 동일 방향 — "필터가
-    실수로 좁아도 조용히 안 새게")."""
-    script = _deploy_realtime_step_script()
-    # ⚠️`$$`로 이스케이프돼 있다 — Cloud Build 자신의 substitution 파서가 bash 실행 前에
-    # 이 args 문자열을 먼저 훑어(test_deploy_backend_redis_secret_conflict.py 가드), 미선언
-    # `${serving_revision}` 참조를 build submit 자체 거부로 처리한다. 원문 그대로 대조한다.
-    assert 'if [ -z "$$serving_revision" ]; then' in script
-    # 그 분기 본문에 exit이 없어야(=스킵하지 않고 이어서 배포 진행) fail-safe가 성립.
-    branch_start = script.index('if [ -z "$$serving_revision" ]; then')
-    branch_end = script.index("else", branch_start)
-    branch_body = script[branch_start:branch_end]
-    assert "exit" not in branch_body, "serving_revision 판별 불가 분기에서 exit 하면 fail-safe(배포 진행)가 아니라 fail-closed가 됨"

--- a/backend/tests/test_cloud_build_realtime_path_filter_gha.py
+++ b/backend/tests/test_cloud_build_realtime_path_filter_gha.py
@@ -1,0 +1,93 @@
+"""story #3079(2026-08-25) — realtime path-filter(GCE #2089 · Cloud Run #3031) 근본수정.
+
+실 Cloud Build 로그로 확定된 근본원인: `gcloud builds submit --source=.`(로컬소스 tarball
+업로드)가 `.gcloudignore` 부재로 gcloud 기본 규칙(`.git` 항상 제외)에 걸려, Cloud Build
+워크스페이스엔 `.git`이 아예 없었다 — 두 필터의 `git diff`/`git fetch`가 매번 "Not a git
+repository"(rc=129)로 실패해 fail-safe("판별 불가 → 배포 진행")로 상시 떨어졌다(merge 이후
+단 한 번도 실제 스킵 없음).
+
+처방: 판정을 `.github/workflows/cloud-build.yml`의 "Resolve realtime deploy path-filter"
+스텝(실 `.git` 보유)으로 옮기고, 결과(`gce_skip`/`cloudrun_skip`)만 substitution으로
+cloudbuild.yaml에 넘긴다. 이 테스트는 그 GHA 스텝의 구조 계약을 고정한다(cloudbuild.yaml
+읽기 쪽 계약은 test_3031_realtime_cloudrun_deploy_path_filter.py가 별도로 고정)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "cloud-build.yml"
+
+
+def _load():
+    return yaml.safe_load(_WORKFLOW_PATH.read_text())
+
+
+def _steps():
+    return _load()["jobs"]["cloud-build"]["steps"]
+
+
+def _step(name_substr: str) -> dict:
+    for s in _steps():
+        if name_substr in (s.get("name") or ""):
+            return s
+    raise AssertionError(f"step containing {name_substr!r} not found")
+
+
+def _gate_step() -> dict:
+    return _step("Resolve realtime deploy path-filter")
+
+
+def test_gate_step_only_runs_for_dev_target():
+    """GCE·Cloud Run realtime 배포 둘 다 dev 전용이라(cloudbuild.yaml 하드게이트) prod push에서
+    이 조회 자체가 낭비·오탐 소지다."""
+    step = _gate_step()
+    assert step["if"] == "steps.env.outputs.target == 'dev'"
+
+
+def test_gate_step_unshallows_before_diffing():
+    """actions/checkout@v4 기본 fetch-depth=1(shallow)이라 임의 과거 last_sha와의 diff가
+    불가능 — unshallow 없이는 이 스텝도 #3079와 같은 클래스로 무력해진다."""
+    run = _gate_step()["run"]
+    assert "git fetch --unshallow" in run
+
+
+def test_gate_step_reuses_shared_diff_script_for_both_targets():
+    """GCE·Cloud Run 판정 로직이 이중선언되면 안 된다 — 둘 다 SSOT(check_realtime_relevant_diff.sh)
+    재사용."""
+    run = _gate_step()["run"]
+    assert run.count("check_realtime_relevant_diff.sh") == 2
+
+
+def test_gate_step_reads_serving_revision_not_template_spec_for_cloudrun():
+    """describe의 spec.template은 다음 배포 대상이지 실제 트래픽이 아니다(배포 실효=서빙
+    리비전 digest 교훈, #2985 조사) — 100% 트래픽 리비전을 명시로 골라야 한다."""
+    run = _gate_step()["run"]
+    assert "status.traffic.filter(percent=100).revisionName" in run
+
+
+def test_gate_step_emits_both_skip_outputs():
+    run = _gate_step()["run"]
+    assert 'echo "gce_skip=${gce_skip}" >> "$GITHUB_OUTPUT"' in run
+    assert 'echo "cloudrun_skip=${cloudrun_skip}" >> "$GITHUB_OUTPUT"' in run
+
+
+def test_gate_step_fails_safe_to_deploy_when_last_sha_unresolvable():
+    """GCE last_sha를 못 구하면(최초 배포 등) gce_skip이 여전히 기본값 false(=배포 진행)여야
+    한다 — 판별 불가를 스킵으로 오판하면 진짜 변경분을 놓친다."""
+    run = _gate_step()["run"]
+    gce_branch_start = run.index('if [ -z "${gce_last_sha}" ]; then')
+    gce_branch_end = run.index("elif", gce_branch_start)
+    gce_branch_body = run[gce_branch_start:gce_branch_end]
+    assert "gce_skip=" not in gce_branch_body, "판별 불가 분기에서 gce_skip을 건드리면 초기값(false) 보장이 깨짐"
+
+
+def test_substitutions_default_missing_gate_output_to_deploy():
+    """gate 스텝이 안 도는 경우(prod push)엔 outputs가 빈 문자열 — Assemble 스텝이 이를
+    명시로 "false"(배포 진행)로 치환해야 한다."""
+    subst_step = _step("Assemble Cloud Build substitutions")
+    run = subst_step["run"]
+    assert 'V_REALTIME_GCE_SKIP="${V_REALTIME_GCE_SKIP:-false}"' in run
+    assert 'V_REALTIME_CLOUDRUN_SKIP="${V_REALTIME_CLOUDRUN_SKIP:-false}"' in run
+    assert "_REALTIME_GCE_SKIP=\\\"${V_REALTIME_GCE_SKIP}\\\"" in run
+    assert "_REALTIME_CLOUDRUN_SKIP=\\\"${V_REALTIME_CLOUDRUN_SKIP}\\\"" in run

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -53,6 +53,8 @@ _DECLARED_SUBSTITUTIONS = {
     "_GOTENBERG_SERVICE_URL", "_OFFICE_CONVERTER_MAX_INSTANCES",
     # story #2887 — avatar 전용 GCS 버킷, deploy-backend dev 분기(ADMIN_OPERATOR_*와 동일 패턴).
     "_GCS_AVATARS_BUCKET",
+    # story #3079 — realtime path-filter 판정을 GHA에서 계산해 넘기는 skip 플래그(GCE·Cloud Run).
+    "_REALTIME_GCE_SKIP", "_REALTIME_CLOUDRUN_SKIP",
     "PROJECT_ID", "PROJECT_NUMBER", "BUILD_ID", "COMMIT_SHA", "SHORT_SHA",
     "REPO_NAME", "BRANCH_NAME", "TAG_NAME", "REVISION_ID", "LOCATION",
 }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,6 +8,11 @@
 substitutions:
   _AR_REGION: asia-northeast3
   _AR_REPO: sprintable
+  # story #3079 — 기본값 "false"(=배포 진행). GHA gate 스텝(cloud-build.yml)이 계산해 넘기지
+  # 않는 호출(수동 gcloud builds submit 등)에서도 안전측(배포)으로 fail — 스킵은 정확히
+  # "true" 문자열일 때만.
+  _REALTIME_GCE_SKIP: "false"
+  _REALTIME_CLOUDRUN_SKIP: "false"
   _DEPLOY_ENV: dev
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
   # story #2701 — dev-safe 기본값(빈 문자열 = 이 env var 자체를 안 싣는다, 아래 deploy-mcp
@@ -652,29 +657,15 @@ steps:
           echo "      --substitutions 에 _REALTIME_URL=<realtime 서비스 URL> 을 명시할 것."
           exit 1
         fi
-        # story #3031 — realtime path-filter(Cloud Run). 근거·설계 전문은
-        # backend/tests/test_3031_realtime_cloudrun_deploy_path_filter.py 참조(이 스텝의
-        # UTF-8 바이트 한도 초과 핫픽스로 이관). 로컬 변수는 $$ 이스케이프 필수(Cloud
-        # Build 자신의 substitution 파서가 bash 실행 前에 미선언 substitution 참조를 거부).
-        serving_revision="$(gcloud run services describe sprintable-realtime-${_DEPLOY_ENV} \
-          --region="${_AR_REGION}" --project="${PROJECT_ID}" \
-          --format='value(status.traffic.filter(percent=100).revisionName)' 2>/dev/null || echo '')"
-        if [ -z "$$serving_revision" ]; then
-          echo "deploy-realtime: 100% 트래픽 서빙 리비전을 못 읽음(최초 배포이거나 트래픽 스플릿 중) — path-filter 건너뛰고 배포 진행"
-        else
-          last_image="$(gcloud run revisions describe "$$serving_revision" \
-            --region="${_AR_REGION}" --project="${PROJECT_ID}" \
-            --format='value(spec.containers[0].image)' 2>/dev/null || echo '')"
-          last_sha="$${last_image##*:}"
-          if [ -z "$$last_sha" ] || [ "$$last_sha" = "$$last_image" ]; then
-            echo "deploy-realtime: 서빙 리비전 이미지 태그를 못 읽음 — path-filter 건너뛰고 배포 진행"
-          else
-            git fetch --unshallow >/dev/null 2>&1 || true
-            if ! bash backend/scripts/check_realtime_relevant_diff.sh "$$last_sha" "${COMMIT_SHA}"; then
-              echo "skip deploy-realtime: $$last_sha..${COMMIT_SHA} 사이 realtime-관련 경로 변경 없음(story #3031 path-filter, 스킵 사유는 위 로그 참고)"
-              exit 0
-            fi
-          fi
+        # story #3079(2026-08-25) 근본수정 — #3031이 여기 심었던 git-diff 기반 path-filter는
+        # Cloud Build 워크스페이스에 `.git`이 없어(로컬소스 tarball 업로드, `.gcloudignore`
+        # 미비로 gcloud 기본 규칙이 `.git` 항상 제외) 단 한 번도 실제로 스킵하지 못했다 —
+        # 매번 "판별 불가" fail-safe로 떨어져 상시 배포였다(실 로그로 확定). 판정을 Cloud
+        # Build 밖(GHA, 실 .git 보유 — cloud-build.yml "Resolve realtime deploy path-filter"
+        # 스텝)으로 옮기고 결과만 이 substitution으로 받는다.
+        if [ "${_REALTIME_CLOUDRUN_SKIP}" = "true" ]; then
+          echo "skip deploy-realtime: GHA path-filter(story #3079)가 realtime-관련 경로 변경 없음으로 판정"
+          exit 0
         fi
         # ⚠️story #2078 긴급수정(2026-07-21): PG_LISTEN_ENABLED가 여기 true로 하드코딩돼
         # 있었다 — PO가 라이브에서 손으로 false로 전환(LISTEN 제거·Redis 단독 dispatch 확認
@@ -862,39 +853,18 @@ steps:
           exit 0
         fi
 
-        # story #2089 (a) — realtime path-filter(페드루 PO 판정, 2026-08-17). #2182
-        # 그라운딩에서 오늘까지의 502 rolling 중 75.3%가 "realtime 코드가 실제로 안 바뀐
-        # 커밋"에서 유발됐음을 실측(2주 162커밋 대조) — 매 develop 머지가 무조건 이
-        # 스텝을 재실행시키던 걸 여기서 끊는다. 별도 GCB 트리거로 안 쪼갠다(SSOT 유지,
-        # 페드루 지시) — 기존 파이프라인 안 조건부 스텝 그대로.
-        #
-        # 판별 기준: 현재 MIG가 물고 있는 인스턴스 템플릿 이름에서 직전 배포 SHA를 뽑아,
-        # 그 SHA부터 이번 COMMIT_SHA까지 realtime-관련 경로(backend/scripts/
-        # check_realtime_relevant_diff.sh의 목록, 보수적 채택 — 공유 파일 포함 24.7%셋)가
-        # 바뀌었는지 본다. 얕은 클론이면 옛 SHA가 히스토리에 없을 수 있어 unshallow를
-        # 먼저 시도(실패해도 계속 — 아래 diff 성패로 최종 fail-safe 판단).
-        #
-        # ⛔hotfix 2차(2026-08-17, 페드루 P0) — 1차 fix(언더스코어 제거)로도 여전히 막혔다:
-        # GCB는 밑줄 없는 대문자 이름도 built-in substitution 후보로 검사한다("not a valid
-        # built-in substitution" 에러) — 즉 밑줄 유무와 무관하게 대문자 이름 자체가 GCB run
-        # 블록에서 위험하다. 이 파일의 다른 로컬변수(served·expected·names, 604~617행)가
-        # 안전했던 진짜 이유는 밑줄이 없어서가 아니라 **소문자**였기 때문 — 그 관행과 완전히
-        # 동형으로 맞춘다(대문자→소문자, 파서의 두 층 모두 회피). 교훈: 이 run 블록 안에서
-        # 새로 짓는 로컬 셸 변수는 소문자로만 짓는다(대문자는 사용자 substitution이든
-        # built-in이든 GCB 자체 치환 후보로 스캔된다).
-        current_template="$(gcloud compute instance-groups managed describe sprintable-realtime-gateway-dev \
-          --region="${_AR_REGION}" --project="${PROJECT_ID}" \
-          --format='value(versions[0].instanceTemplate)' 2>/dev/null | sed 's#.*/##' || echo '')"
-        last_sha="$(echo "$current_template" | grep -oE '[0-9a-f]{8}' | head -1 || echo '')"
-
-        if [ -z "$last_sha" ]; then
-          echo "deploy-realtime-gce: 기존 MIG 템플릿에서 직전 SHA를 못 읽음(최초 배포이거나 이름 패턴 변경) — path-filter 건너뛰고 배포 진행"
-        else
-          git fetch --unshallow >/dev/null 2>&1 || true
-          if ! bash backend/scripts/check_realtime_relevant_diff.sh "$last_sha" "${COMMIT_SHA}"; then
-            echo "skip deploy-realtime-gce: $last_sha..${COMMIT_SHA} 사이 realtime-관련 경로 변경 없음(story #2089 path-filter, 스킵 사유는 위 로그 참고)"
-            exit 0
-          fi
+        # story #2089(원안, 페드루 PO 판정 2026-08-17) — realtime path-filter.
+        # ⛔story #3079(2026-08-25) 근본수정 — 여기 있던 git-diff 기반 판정은 Cloud Build
+        # 워크스페이스에 `.git`이 없어(로컬소스 tarball 업로드, `.gcloudignore` 미비로
+        # gcloud 기본 규칙이 `.git` 항상 제외) 단 한 번도 실제로 스킵하지 못했다 — 매번
+        # "판별 불가" fail-safe로 떨어져 상시 배포였다(실 로그로 확定: `git diff ... 실패
+        # rc=129: Not a git repository`). 판정을 Cloud Build 밖(GHA, 실 .git 보유 —
+        # cloud-build.yml "Resolve realtime deploy path-filter" 스텝)으로 옮기고 결과만
+        # 이 substitution으로 받는다(SSOT 이전 — 로직 이중선언 아님, check_realtime_
+        # relevant_diff.sh 자체는 그 스텝에서 그대로 재사용).
+        if [ "${_REALTIME_GCE_SKIP}" = "true" ]; then
+          echo "skip deploy-realtime-gce: GHA path-filter(story #3079)가 realtime-관련 경로 변경 없음으로 판정"
+          exit 0
         fi
 
         GCP_PROJECT="${PROJECT_ID}" GCP_REGION="${_AR_REGION}" COMMIT_SHA="${COMMIT_SHA}" \


### PR DESCRIPTION
[SID:3079]
[SID:3031]
[SID:2089]

⛔**머지 타이밍**: 페드루 PO 지시(2026-08-25) — 공유 배포 파이프라인 핵심부 변경이라, PR 준비는
지금 GO하되 **머지는 오늘 밤 승격(develop→main) 완료 후**. 머지 타이밍은 페드루 PO가 직접 잡음.

## 배경
story #3031(Cloud Run realtime path-filter) 착수 중 실 Cloud Build 로그를 직접 열어 확認한 결과,
GCE(#2089)·Cloud Run(#3031) 두 path-filter 모두 **merge 이후 단 한 번도 실제로 스킵을 실행한
적이 없었다**는 것을 발견했다(story #3079로 등재·근본원인 갱신).

## 근본원인(실 로그로 확定)
```
Step #11 - "deploy-realtime": deploy-realtime: 100% 트래픽 서빙 리비전을 못 읽음
  (최초 배포이거나 트래픽 스플릿 중) — path-filter 건너뛰고 배포 진행
Step #13 - "deploy-realtime-gce": check_realtime_relevant_diff: git diff ... 실패
  (rc=129: warning: Not a git repository. Use --no-index to compare two paths outside a working tree)
```
`.github/workflows/cloud-build.yml`의 `gcloud builds submit --config=cloudbuild.yaml ... .`은
**로컬소스(tarball) 업로드** 방식이다. 레포에 `.gcloudignore`가 없어(확認 완료) gcloud 기본
규칙(`.gitignore` 기반 자동생성 + `.git` 항상 제외)이 적용됐다 — Cloud Build 워크스페이스엔
`.git`이 아예 없다. 두 필터의 `git diff`/`git fetch`가 매번 실패해 각자의 fail-safe("판별
불가 → 배포 진행")로 상시 떨어졌다 — 관측된 고빈도 재배포(GCE 10사이클/6h·Cloud Run
20+리비전/~20h)는 "관련 커밋이 많아서"가 아니라 이 구조적 결함의 결과였다.

## 처방
git diff 계산을 Cloud Build 안이 아니라 **GHA**(`.github/workflows/cloud-build.yml`, 실
`.git` 보유)로 옮긴다 — 새 스텝 "Resolve realtime deploy path-filter"가:
1. `git fetch --unshallow`로 전체 이력 확보(`actions/checkout@v4` 기본 fetch-depth=1이라 필수).
2. GCE(인스턴스 템플릿 이름에서 SHA grep)·Cloud Run(서빙 리비전 이미지 태그) 각각의 직전
   배포 SHA를 조회 — 기존 cloudbuild.yaml 스텝들이 하던 조회와 동일 커맨드, 위치만 이전.
3. `check_realtime_relevant_diff.sh`(#2089 SSOT, 로직 이중선언 없음)로 판정.
4. 결과를 `gce_skip`/`cloudrun_skip` output으로 내보내고, `_REALTIME_GCE_SKIP`/
   `_REALTIME_CLOUDRUN_SKIP` substitution으로 Cloud Build에 전달.

cloudbuild.yaml의 `deploy-realtime`·`deploy-realtime-gce` 두 스텝은 이제 그 substitution만
읽는 얇은 게이트로 단순화(git 관련 로직 완전 제거 — Cloud Build 안에서 다시 살리려는 시도
자체가 같은 함정).

## 페드루 PO 재검토 요청 반영
- **①GHA fetch-depth**: `git fetch --unshallow`로 해결(위).
- **②fail-safe 방향**: "판별 불가 → 배포 진행"을 그대로 유지했다. 필터가 실제로 돌기
  시작하면 잘못된 skip(진짜 관련 변경 누락)이 새 위험이 되는 건 맞지만, `check_realtime_
  relevant_diff.sh` 자신의 원 설계 철학("정확성이 빈도보다 우선")과 동일 방향이고 판별
  불가 상황은 로그에 명시적으로 남아 사람이 알아챌 수 있다. `REALTIME_RELEVANT_PATHS`
  목록의 완전성이 이제부터 실제로 중요해진다는 점만 리뷰 시 유념 — 근거는 커밋 코멘트에도
  남겼다.
- **③3031 흡수 여부**: 이 PR이 #3031을 완전히 흡수한다(Cloud Run 쪽 git-diff 로직 자체를
  대체) — 별도 후속 불요.

## 검증
- 신규 `test_cloud_build_realtime_path_filter_gha.py`(7건) — GHA gate 스텝 구조(dev 전용·
  unshallow·SSOT 재사용·서빙 리비전 명시 조회·양쪽 output emit·fail-safe 방향·Assemble
  단계 기본값 치환).
- `test_3031_realtime_cloudrun_deploy_path_filter.py` 재작성(3건) — cloudbuild.yaml
  `deploy-realtime`이 더 이상 git 시도를 안 하고 GHA 결과만 읽는지.
- `test_deploy_backend_redis_secret_conflict.py` — 신규 substitution 2종(`_REALTIME_GCE_SKIP`·
  `_REALTIME_CLOUDRUN_SKIP`)을 선언 목록에 추가(story #2461류 재발 방지 가드 동기화).
- RED→GREEN 실측: git stash로 원복 후 10건 정확히 실패 확認 → 복원 후 재통과.
- 인접 CI 테스트 87건(#2005/#2178/#2806/env-drift 2종/migrate-wiring/deploy_env) 무회귀.
- YAML 문법(`yaml.safe_load`) 양쪽 파일 통과.