### PR TITLE
feat(#2087): 에이전트 API 키 사용 이력 감사 트레일 신설

### DIFF
--- a/backend/alembic/versions/0280_agent_api_key_usage_logs.py
+++ b/backend/alembic/versions/0280_agent_api_key_usage_logs.py
@@ -1,0 +1,47 @@
+"""story #2087([BE] 에이전트 API 키 사용 이력 감사 트레일 부재) — agent_api_key_usage_logs 원장 신설.
+
+성공 인증(get_current_user/get_current_user_streaming의 API-key 경로) 매 요청마다
+append-only로 기록한다. story cd10e123 계열 인시던트 조사에서 "악용 여부"를 증명도 반증도
+못 했던 갭을 메운다.
+
+Revision ID: 0280
+Revises: 0279
+Create Date: 2026-08-25
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0280"
+down_revision = "0279"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_api_key_usage_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("api_key_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("member_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("endpoint", sa.Text(), nullable=False),
+        sa.Column("method", sa.Text(), nullable=False),
+        sa.Column("remote_ip", sa.Text(), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_agent_api_key_usage_logs_api_key_id", "agent_api_key_usage_logs", ["api_key_id"])
+    op.create_index("ix_agent_api_key_usage_logs_org_id", "agent_api_key_usage_logs", ["org_id"])
+    op.create_index(
+        "ix_agent_api_key_usage_logs_key_occurred", "agent_api_key_usage_logs",
+        ["api_key_id", "occurred_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_api_key_usage_logs_key_occurred", table_name="agent_api_key_usage_logs")
+    op.drop_index("ix_agent_api_key_usage_logs_org_id", table_name="agent_api_key_usage_logs")
+    op.drop_index("ix_agent_api_key_usage_logs_api_key_id", table_name="agent_api_key_usage_logs")
+    op.drop_table("agent_api_key_usage_logs")

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -109,6 +109,7 @@ async def _touch_api_key_last_used(api_key_id: uuid.UUID) -> None:
 
 async def _resolve_api_key(
     raw_key: str, db: AsyncSession, transport: str | None = None,
+    request: Request = None,  # type: ignore[assignment]
 ) -> AuthContext:
     """sk_live_* API key를 DB에서 조회하여 AuthContext 반환.
 
@@ -248,6 +249,13 @@ async def _resolve_api_key(
         await _persist_first_auth_seen(member_id, org_id, project_id, transport=transport)
     if _needs_touch:
         await _touch_api_key_last_used(api_key.id)
+
+    # story #2087 — 성공 인증마다 사용 이력 1행(스로틀 없음, last_used_at과 다름 — 위 모듈
+    # docstring/agent_api_key_usage.py 참조).
+    from app.services.agent_api_key_usage import record_api_key_usage
+    await record_api_key_usage(
+        api_key_id=api_key.id, org_id=uuid.UUID(org_id), member_id=member_id, request=request,
+    )
 
     return AuthContext(
         user_id=str(member_id),
@@ -444,6 +452,7 @@ async def get_current_user(
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     x_agent_api_key: str | None = Header(default=None, alias="x-agent-api-key"),
     x_mcp_transport: str | None = Header(default=None, alias="X-MCP-Transport"),
+    request: Request = None,  # type: ignore[assignment]
 ) -> AuthContext:
     """story #2459(§6 봉합①): 요청-수명 ``Depends(get_db)`` 대신 브랜치별 전용 단명 세션 —
     get_current_user_streaming(SSE 전용 변형, 아래)과 동일 패턴을 기본 경로에도 적용한다.
@@ -458,7 +467,7 @@ async def get_current_user(
     # x-agent-api-key 헤더 우선 처리 (SSE 브릿지 직접 연결용)
     if x_agent_api_key and x_agent_api_key.startswith("sk_live_"):
         async with async_session_factory() as db:
-            return await _resolve_api_key(x_agent_api_key, db, transport=x_mcp_transport)
+            return await _resolve_api_key(x_agent_api_key, db, transport=x_mcp_transport, request=request)
 
     if credentials is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
@@ -468,7 +477,7 @@ async def get_current_user(
     # sk_live_* prefix → API key 경로 (DB 조회)
     if token.startswith("sk_live_"):
         async with async_session_factory() as db:
-            return await _resolve_api_key(token, db, transport=x_mcp_transport)
+            return await _resolve_api_key(token, db, transport=x_mcp_transport, request=request)
 
     # story #1940 — hu_live_* 휴먼 개인 API key. ⛔의도적으로 x-agent-api-key 헤더 경로(위)에는
     # 이 분기를 안 붙인다 — 그 헤더는 이 코드베이스에서 "에이전트 SSE 브릿지 전용"으로 이미
@@ -996,6 +1005,7 @@ async def get_scope_context_no_key_scope_check(
 async def get_current_user_streaming(
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     x_agent_api_key: str | None = Header(default=None, alias="x-agent-api-key"),
+    request: Request = None,  # type: ignore[assignment]
 ) -> AuthContext:
     """get_current_user의 SSE 전용 변형 — get_db 미점유.
 
@@ -1004,7 +1014,7 @@ async def get_current_user_streaming(
     """
     if x_agent_api_key and x_agent_api_key.startswith("sk_live_"):
         async with async_session_factory() as db:
-            return await _resolve_api_key(x_agent_api_key, db)
+            return await _resolve_api_key(x_agent_api_key, db, request=request)
 
     if credentials is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
@@ -1012,7 +1022,7 @@ async def get_current_user_streaming(
     token = credentials.credentials
     if token.startswith("sk_live_"):
         async with async_session_factory() as db:
-            return await _resolve_api_key(token, db)
+            return await _resolve_api_key(token, db, request=request)
 
     # story #1940 — get_current_user와 동형(x-agent-api-key 헤더 경로엔 의도적으로 안 붙임).
     if token.startswith("hu_live_"):

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -28,6 +28,7 @@ from app.models.user import RefreshToken, User
 from app.models.workflow_version import WorkflowVersion
 from app.models.api_key import ApiKey
 from app.models.agent_auth_failure import AgentAuthFailure
+from app.models.agent_api_key_usage_log import AgentApiKeyUsageLog
 from app.models.human_api_key import HumanApiKey
 from app.models.org_subscription import OrgSubscription
 from app.models.pricing_version import PricingVersion

--- a/backend/app/models/agent_api_key_usage_log.py
+++ b/backend/app/models/agent_api_key_usage_log.py
@@ -1,0 +1,43 @@
+"""story #2087([BE] 에이전트 API 키 사용 이력 감사 트레일 부재) — 성공 인증 요청마다 1행.
+
+story cd10e123 계열(mcp-dev AGENT_API_KEY 유출 인시던트, 2026-07-21) 조사 중 "악용 여부"를
+증명도 반증도 못 한 근본원인 — 이 원장이 그 갭을 메운다.
+
+append-only. FK 미부여(AgentAuthFailure와 동일 원칙) — 키가 회전/폐기되거나 멤버가 삭제돼도
+그 시점까지의 사용 이력은 감사 목적상 그대로 남아야 한다(CASCADE로 지워지면 감사 트레일의
+존재 이유 자체가 무너진다).
+
+⚠️스로틀 없음(의도적, `_touch_api_key_last_used`(story #2457, 5분 스로틀)와 다름) — 그
+스로틀은 last_used_at 값 자체가 대략적 시각이면 충분해 볼륨 절감이 이득이었지만, 이
+원장의 존재 이유는 「모든 호출」의 완전성이다(오늘 실제로 이 완전성 부재 때문에 조사가
+막혔다) — 샘플링하면 원장의 목적 자체가 무효화된다."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class AgentApiKeyUsageLog(Base):
+    __tablename__ = "agent_api_key_usage_logs"
+    __table_args__ = (
+        Index("ix_agent_api_key_usage_logs_key_occurred", "api_key_id", "occurred_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    api_key_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    # invalid 판정 없이(성공 인증만 기록) 항상 알려진 값이나, AgentAuthFailure와 동일하게
+    # nullable로 둔다 — org 해소 자체가 실패해도(방어적) 기록 자체는 남아야 하므로.
+    org_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    endpoint: Mapped[str] = mapped_column(Text, nullable=False)
+    method: Mapped[str] = mapped_column(Text, nullable=False)
+    remote_ip: Mapped[str | None] = mapped_column(Text, nullable=True)
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/api_keys.py
+++ b/backend/app/routers/api_keys.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -10,9 +10,11 @@ from app.repositories.api_key import ApiKeyRepository
 from app.schemas.api_key import (
     ApiKeyCreatedResponse,
     ApiKeyResponse,
+    ApiKeyUsageLogResponse,
     CreateApiKeyRequest,
     RotateApiKeyRequest,
 )
+from app.services.agent_api_key_usage import DEFAULT_LIST_LIMIT, list_api_key_usage
 from app.services.recruit_service import acquire_agent_mutation_lock
 
 router = APIRouter(prefix="/api/v2", tags=["api-keys", "Organization"])
@@ -52,6 +54,28 @@ async def rotate_api_key(
     await ensure_creator_allowlisted(session, new_key.team_member_id)
     data = ApiKeyResponse.model_validate(new_key)
     return ApiKeyCreatedResponse(**data.model_dump(), api_key=plaintext)
+
+
+@router.get("/api-keys/{key_id}/logs", response_model=list[ApiKeyUsageLogResponse])
+async def list_api_key_logs(
+    key_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    repo: ApiKeyRepository = Depends(_get_repo),
+    limit: int = Query(DEFAULT_LIST_LIMIT, ge=1, le=200),
+) -> list[ApiKeyUsageLogResponse]:
+    """story #2087 — FE `apps/web/src/app/api/api-keys/[id]/logs/route.ts`가 그동안 가리키던
+    죽은 경로를 살린다. 자매 엔드포인트(rotate/list/create/revoke)와 동일하게
+    ``assert_agent_owner``로 대상 키의 소유(호출자 org+생성자 or org admin/owner)를
+    먼저 확認한다(story 561fd294 IDOR 교훈 — org_id dependency·ownership 검증 없이 열면
+    타 org 키의 사용 이력이 그대로 샌다)."""
+    existing = await repo.get(key_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="API key not found")
+    await assert_agent_owner(existing.team_member_id, session, org_id, uuid.UUID(auth.user_id))
+    logs = await list_api_key_usage(session, key_id, limit=limit)
+    return [ApiKeyUsageLogResponse.model_validate(log) for log in logs]
 
 
 @router.get("/agents/{agent_id}/api-keys", response_model=list[ApiKeyResponse])

--- a/backend/app/schemas/api_key.py
+++ b/backend/app/schemas/api_key.py
@@ -28,6 +28,19 @@ class ApiKeyCreatedResponse(ApiKeyResponse):
     api_key: str
 
 
+class ApiKeyUsageLogResponse(BaseModel):
+    """story #2087 — 키별 사용 이력 1행."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    api_key_id: uuid.UUID
+    endpoint: str
+    method: str
+    remote_ip: str | None = None
+    occurred_at: datetime
+
+
 class RotateApiKeyRequest(BaseModel):
     api_key_id: uuid.UUID
 

--- a/backend/app/services/agent_api_key_usage.py
+++ b/backend/app/services/agent_api_key_usage.py
@@ -1,0 +1,69 @@
+"""story #2087 — 에이전트 API 키 사용 이력 감사 트레일. 기록(write)+조회(read) 둘 다.
+
+write(`record_api_key_usage`)는 `_resolve_api_key`(auth.py) 성공 경로 말미에서 호출된다 —
+`_touch_api_key_last_used`/`record_auth_failure`(story #2457/#2836)와 동형: 전용 단명
+세션(caller `db` 트랜잭션과 분리 커밋)+fail-silent(인증 자체는 절대 안 막음). caller 세션을
+쓰지 않는 이유는 story #2457 그대로다 — `get_current_user`는 REST 전반의 공용 진입점이라
+caller 세션에 write를 얹으면 그 row/트랜잭션이 응답 완료까지 커넥션을 물고, 부하 시 primary
+풀을 고갈시킨다(#2457 실측).
+
+⚠️스로틀 없음(의도적) — `_touch_api_key_last_used`(5분 스로틀)와 다르다. 그 스로틀은
+last_used_at 값의 대략적 정확도로 충분해 볼륨 절감이 이득이었지만, 이 원장은 «완전성»이
+존재 이유(오늘 실제로 그 완전성 부재 때문에 키 유출 인시던트의 악용 여부를 증명도 반증도
+못 했다) — 샘플링하면 목적 자체가 무효화된다."""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from fastapi import Request
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LIST_LIMIT = 50
+MAX_LIST_LIMIT = 200
+
+
+async def record_api_key_usage(
+    *,
+    api_key_id: uuid.UUID,
+    org_id: uuid.UUID | None,
+    member_id: uuid.UUID | None,
+    request: "Request | None",
+) -> None:
+    try:
+        from app.core.database import async_session_factory
+        from app.models.agent_api_key_usage_log import AgentApiKeyUsageLog
+
+        endpoint = request.url.path if request is not None else "unknown"
+        method = request.method if request is not None else "unknown"
+        remote_ip = request.client.host if request is not None and request.client else None
+
+        async with async_session_factory() as s:
+            s.add(AgentApiKeyUsageLog(
+                id=uuid.uuid4(), api_key_id=api_key_id, org_id=org_id, member_id=member_id,
+                endpoint=endpoint, method=method, remote_ip=remote_ip,
+            ))
+            await s.commit()
+    except Exception:
+        logger.warning("record_api_key_usage failed api_key_id=%s", api_key_id, exc_info=True)
+
+
+async def list_api_key_usage(session: AsyncSession, api_key_id: uuid.UUID, *, limit: int = DEFAULT_LIST_LIMIT):
+    """읽기 전용 — caller 세션(요청-수명 get_db) 그대로 사용해도 안전(REST 전반 공용 hot-path인
+    write와 달리, 이 조회는 admin/owner가 명시로 여는 화면 1건당 1회뿐)."""
+    from app.models.agent_api_key_usage_log import AgentApiKeyUsageLog
+
+    limit = min(max(limit, 1), MAX_LIST_LIMIT)
+    result = await session.execute(
+        select(AgentApiKeyUsageLog)
+        .where(AgentApiKeyUsageLog.api_key_id == api_key_id)
+        .order_by(AgentApiKeyUsageLog.occurred_at.desc())
+        .limit(limit)
+    )
+    return list(result.scalars().all())

--- a/backend/tests/test_2087_agent_api_key_usage_audit_trail_realdb.py
+++ b/backend/tests/test_2087_agent_api_key_usage_audit_trail_realdb.py
@@ -1,0 +1,280 @@
+"""story #2087([BE] 에이전트 API 키 사용 이력 감사 트레일 부재) — 실PG 검증.
+
+`record_api_key_usage`(write, 스로틀 없음)·`list_api_key_usage`(read, 최신순+limit)·
+`_resolve_api_key` 성공 경로가 실제로 usage log를 남기는지·GET /api/v2/api-keys/{id}/logs
+엔드포인트가 죽은 FE 경로를 실제로 살렸는지(+cross-org 소유권 거부)를 실PG로 검증한다."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _bypass_fk(session) -> None:
+    from sqlalchemy import text as _text
+    await session.execute(_text("SET session_replication_role = replica"))
+
+
+async def _seed_agent(session, *, org_id: uuid.UUID | None = None):
+    from app.models.team import TeamMember
+
+    await _bypass_fk(session)
+    member = TeamMember(
+        id=uuid.uuid4(), org_id=org_id or uuid.uuid4(), project_id=uuid.uuid4(), type="agent",
+        name="2087 Test Agent", role="member", is_active=True,
+    )
+    session.add(member)
+    await session.flush()
+    return member
+
+
+async def _drop_all(engine) -> None:
+    from app.core.database import Base
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+class _PatchedSessionFactory:
+    """story #2836 선례와 동일 — record_api_key_usage/_resolve_api_key가 내부에서 쓰는
+    전역 `app.core.database.async_session_factory`는 최초 사용 시점의 이벤트루프에
+    바인딩된다. pytest-asyncio가 테스트 함수마다 새 루프를 쓰므로, 이 전역을 이 테스트의
+    per-test 엔진 sessionmaker로 임시 교체해야 "attached to a different loop" 없이 돈다."""
+
+    def __init__(self, session_factory):
+        self._session_factory = session_factory
+        self._orig = None
+
+    async def __aenter__(self):
+        import app.core.database as _dbmod
+        self._orig = _dbmod.async_session_factory
+        _dbmod.async_session_factory = self._session_factory
+        return self
+
+    async def __aexit__(self, *exc):
+        import app.core.database as _dbmod
+        _dbmod.async_session_factory = self._orig
+
+
+# ── record_api_key_usage / list_api_key_usage — 단위 ────────────────────────
+
+
+@pytest.mark.anyio
+async def test_record_api_key_usage_writes_a_row_with_expected_fields():
+    from app.services.agent_api_key_usage import list_api_key_usage, record_api_key_usage
+
+    engine, Session = await _session()
+    try:
+        api_key_id = uuid.uuid4()
+        org_id = uuid.uuid4()
+        member_id = uuid.uuid4()
+
+        class _FakeClient:
+            host = "203.0.113.9"
+
+        class _FakeRequest:
+            url = type("_U", (), {"path": "/api/v2/agents/x/stream"})()
+            method = "GET"
+            client = _FakeClient()
+
+        async with _PatchedSessionFactory(Session):
+            await record_api_key_usage(
+                api_key_id=api_key_id, org_id=org_id, member_id=member_id, request=_FakeRequest(),
+            )
+
+        async with Session() as s:
+            rows = await list_api_key_usage(s, api_key_id)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.api_key_id == api_key_id
+        assert row.org_id == org_id
+        assert row.member_id == member_id
+        assert row.endpoint == "/api/v2/agents/x/stream"
+        assert row.method == "GET"
+        assert row.remote_ip == "203.0.113.9"
+        assert row.occurred_at is not None
+    finally:
+        await _drop_all(engine)
+
+
+@pytest.mark.anyio
+async def test_record_api_key_usage_handles_missing_request_gracefully():
+    """직접호출(테스트·`_resolve_api_key`의 request=None 기본값)에서도 실패하면 안 된다 —
+    인증 자체를 절대 막지 않는다는 계약(fail-silent) 그대로."""
+    from app.services.agent_api_key_usage import list_api_key_usage, record_api_key_usage
+
+    engine, Session = await _session()
+    try:
+        api_key_id = uuid.uuid4()
+        async with _PatchedSessionFactory(Session):
+            await record_api_key_usage(api_key_id=api_key_id, org_id=None, member_id=None, request=None)
+
+        async with Session() as s:
+            rows = await list_api_key_usage(s, api_key_id)
+        assert len(rows) == 1
+        assert rows[0].endpoint == "unknown"
+        assert rows[0].method == "unknown"
+        assert rows[0].remote_ip is None
+    finally:
+        await _drop_all(engine)
+
+
+@pytest.mark.anyio
+async def test_list_api_key_usage_is_not_throttled_every_call_recorded():
+    """last_used_at(5분 스로틀, story #2457)과 달리 이 원장은 완전성이 목적 — 짧은 간격
+    연속 호출도 전부 남아야 한다."""
+    from app.services.agent_api_key_usage import list_api_key_usage, record_api_key_usage
+
+    engine, Session = await _session()
+    try:
+        api_key_id = uuid.uuid4()
+        async with _PatchedSessionFactory(Session):
+            for _ in range(5):
+                await record_api_key_usage(api_key_id=api_key_id, org_id=None, member_id=None, request=None)
+
+        async with Session() as s:
+            rows = await list_api_key_usage(s, api_key_id)
+        assert len(rows) == 5
+    finally:
+        await _drop_all(engine)
+
+
+@pytest.mark.anyio
+async def test_list_api_key_usage_orders_newest_first_and_respects_limit():
+    from app.models.agent_api_key_usage_log import AgentApiKeyUsageLog
+    from app.services.agent_api_key_usage import list_api_key_usage
+
+    engine, Session = await _session()
+    try:
+        api_key_id = uuid.uuid4()
+        async with Session() as s:
+            base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+            for i in range(3):
+                s.add(AgentApiKeyUsageLog(
+                    id=uuid.uuid4(), api_key_id=api_key_id, org_id=None, member_id=None,
+                    endpoint=f"/api/v2/x/{i}", method="GET", remote_ip=None,
+                    occurred_at=base.replace(hour=i),
+                ))
+            await s.commit()
+
+        async with Session() as s:
+            rows = await list_api_key_usage(s, api_key_id, limit=2)
+        assert len(rows) == 2
+        assert [r.endpoint for r in rows] == ["/api/v2/x/2", "/api/v2/x/1"], "최신순이어야 함"
+    finally:
+        await _drop_all(engine)
+
+
+@pytest.mark.anyio
+async def test_list_api_key_usage_scoped_to_the_given_key_only():
+    from app.services.agent_api_key_usage import list_api_key_usage, record_api_key_usage
+
+    engine, Session = await _session()
+    try:
+        key_a, key_b = uuid.uuid4(), uuid.uuid4()
+        async with _PatchedSessionFactory(Session):
+            await record_api_key_usage(api_key_id=key_a, org_id=None, member_id=None, request=None)
+            await record_api_key_usage(api_key_id=key_b, org_id=None, member_id=None, request=None)
+
+        async with Session() as s:
+            rows_a = await list_api_key_usage(s, key_a)
+        assert len(rows_a) == 1
+        assert rows_a[0].api_key_id == key_a
+    finally:
+        await _drop_all(engine)
+
+
+# ── _resolve_api_key 성공 경로 통합 — usage log가 실제로 남는지 ────────────────
+
+
+@pytest.mark.anyio
+async def test_resolve_api_key_success_records_usage_log():
+    from app.dependencies.auth import _resolve_api_key
+    from app.services.agent_api_key_usage import list_api_key_usage
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            member = await _seed_agent(s)
+            from app.repositories.api_key import ApiKeyRepository
+            repo = ApiKeyRepository(s)
+            key, plaintext = await repo.create(team_member_id=member.id, scope=["read"], expires_at=None)
+            # member_id 미러(dual-write, E-MEMBER-SSOT) — repo.create가 member_id를 채우는지
+            # 이 테스트 스코프 밖이라(회귀는 다른 테스트가 커버) 직접 채워 legacy 경로로만 검증.
+            await s.commit()
+
+        async with Session() as s:
+            class _FakeClient:
+                host = "198.51.100.7"
+
+            class _FakeRequest:
+                url = type("_U", (), {"path": "/api/v2/agents/stream"})()
+                method = "GET"
+                client = _FakeClient()
+
+            async with _PatchedSessionFactory(Session):
+                await _resolve_api_key(plaintext, s, request=_FakeRequest())
+
+        async with Session() as s:
+            rows = await list_api_key_usage(s, key.id)
+        assert len(rows) == 1
+        assert rows[0].endpoint == "/api/v2/agents/stream"
+        assert rows[0].remote_ip == "198.51.100.7"
+    finally:
+        await _drop_all(engine)
+
+
+@pytest.mark.anyio
+async def test_resolve_api_key_failure_does_not_record_usage_log():
+    """401(존재하지 않는 키)은 사용 이력이 아니다 — agent_auth_failure 원장의 몫."""
+    from fastapi import HTTPException
+
+    from app.dependencies.auth import _resolve_api_key
+    from app.services.agent_api_key_usage import list_api_key_usage
+
+    engine, Session = await _session()
+    try:
+        # story OB-4(#1720) 규율 — sk_live_ 접두+긴 무작위 문자열은 GitHub push protection이
+        # 실 시크릿 형태로 오탐한다(가짜여도). 런타임 조립으로 리터럴 매치를 피한다.
+        _fake_key = "sk_live_" + "nonexistent" + "0" * 13
+        async with Session() as s, _PatchedSessionFactory(Session):
+            with pytest.raises(HTTPException):
+                await _resolve_api_key(_fake_key, s)
+
+        async with Session() as s:
+            # 존재하지 않는 키라 api_key_id 자체를 모르므로, 테이블 전체가 비어 있어야 함.
+            from sqlalchemy import select
+            from app.models.agent_api_key_usage_log import AgentApiKeyUsageLog
+            count = (await s.execute(select(AgentApiKeyUsageLog))).scalars().all()
+        assert count == []
+    finally:
+        await _drop_all(engine)

--- a/backend/tests/test_2087_api_key_logs_endpoint_realdb.py
+++ b/backend/tests/test_2087_api_key_logs_endpoint_realdb.py
@@ -1,0 +1,168 @@
+"""story #2087 — GET /api/v2/api-keys/{key_id}/logs 엔드포인트(죽은 FE 경로 소생) 실PG 검증.
+
+story 561fd294(rotate cross-org IDOR)와 동일 원칙 — 자매 엔드포인트와 같은
+``assert_agent_owner`` 가드를 새 read 엔드포인트에도 반드시 태워야 한다. 이 테스트는
+①owner 정상 조회 ②cross-org 시도 거부+실제로 남의 로그가 안 새는지 둘 다 확認한다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _drop_all(engine) -> None:
+    from app.core.database import Base
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+async def _seed_agent_with_key(session, *, org_id: uuid.UUID, project_id: uuid.UUID, created_by: uuid.UUID):
+    from sqlalchemy import text as _text
+    from app.models.team import TeamMember
+    from app.repositories.api_key import ApiKeyRepository
+
+    await session.execute(_text("SET session_replication_role = replica"))
+    agent = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent",
+        name="2087 Owner Test Agent", role="member", created_by=created_by,
+    )
+    session.add(agent)
+    await session.flush()
+    key, _plaintext = await ApiKeyRepository(session).create(
+        team_member_id=agent.id, scope=["read"], expires_at=None,
+    )
+    await session.commit()
+    return agent, key
+
+
+@pytest.mark.anyio
+async def test_owner_can_list_own_key_usage_logs():
+    from types import SimpleNamespace
+
+    from app.models.agent_api_key_usage_log import AgentApiKeyUsageLog
+    from app.repositories.api_key import ApiKeyRepository
+    from app.routers.api_keys import list_api_key_logs
+
+    engine, Session = await _session()
+    try:
+        org_id, project_id, owner_user_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        async with Session() as s:
+            agent, key = await _seed_agent_with_key(
+                s, org_id=org_id, project_id=project_id, created_by=owner_user_id,
+            )
+            s.add(AgentApiKeyUsageLog(
+                id=uuid.uuid4(), api_key_id=key.id, org_id=org_id, member_id=agent.id,
+                endpoint="/api/v2/agents/stream", method="GET", remote_ip="203.0.113.1",
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            result = await list_api_key_logs(
+                key_id=key.id,
+                session=s,
+                auth=SimpleNamespace(user_id=str(owner_user_id)),
+                org_id=org_id,
+                repo=ApiKeyRepository(s),
+                limit=50,
+            )
+        assert len(result) == 1
+        assert result[0].api_key_id == key.id
+        assert result[0].endpoint == "/api/v2/agents/stream"
+    finally:
+        await _drop_all(engine)
+
+
+@pytest.mark.anyio
+async def test_cross_org_caller_cannot_list_another_orgs_key_logs():
+    """story 561fd294와 동형 — org_id dependency는 있어도 ownership 검증을 빼먹으면 같은
+    IDOR이 read 표면에도 그대로 재현된다."""
+    from types import SimpleNamespace
+
+    from fastapi import HTTPException
+
+    from app.models.agent_api_key_usage_log import AgentApiKeyUsageLog
+    from app.repositories.api_key import ApiKeyRepository
+    from app.routers.api_keys import list_api_key_logs
+
+    engine, Session = await _session()
+    try:
+        victim_org_id, attacker_org_id, project_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        async with Session() as s:
+            _victim_agent, victim_key = await _seed_agent_with_key(
+                s, org_id=victim_org_id, project_id=project_id, created_by=uuid.uuid4(),
+            )
+            s.add(AgentApiKeyUsageLog(
+                id=uuid.uuid4(), api_key_id=victim_key.id, org_id=victim_org_id,
+                member_id=_victim_agent.id, endpoint="/api/v2/agents/stream", method="GET",
+                remote_ip="203.0.113.2",
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await list_api_key_logs(
+                    key_id=victim_key.id,
+                    session=s,
+                    auth=SimpleNamespace(user_id=str(uuid.uuid4())),
+                    org_id=attacker_org_id,
+                    repo=ApiKeyRepository(s),
+                    limit=50,
+                )
+            assert ei.value.status_code in (403, 404)
+    finally:
+        await _drop_all(engine)
+
+
+@pytest.mark.anyio
+async def test_unknown_key_id_returns_404():
+    from types import SimpleNamespace
+
+    from fastapi import HTTPException
+
+    from app.repositories.api_key import ApiKeyRepository
+    from app.routers.api_keys import list_api_key_logs
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await list_api_key_logs(
+                    key_id=uuid.uuid4(),
+                    session=s,
+                    auth=SimpleNamespace(user_id=str(uuid.uuid4())),
+                    org_id=uuid.uuid4(),
+                    repo=ApiKeyRepository(s),
+                    limit=50,
+                )
+            assert ei.value.status_code == 404
+    finally:
+        await _drop_all(engine)

--- a/backend/tests/test_e_mcp_opt_s5_hardening.py
+++ b/backend/tests/test_e_mcp_opt_s5_hardening.py
@@ -134,7 +134,10 @@ async def test_get_current_user_passes_x_mcp_transport_header_through():
         await get_current_user(
             credentials=None, x_agent_api_key="sk_live_abc", x_mcp_transport="http",
         )
-    resolve.assert_awaited_once_with("sk_live_abc", resolve.await_args.args[1], transport="http")
+    # story #2087 — get_current_user가 이제 request도 _resolve_api_key로 전달한다(직접호출이라 None).
+    resolve.assert_awaited_once_with(
+        "sk_live_abc", resolve.await_args.args[1], transport="http", request=None,
+    )
 
 
 def test_mcp_client_sends_x_mcp_transport_header(monkeypatch):


### PR DESCRIPTION
[SID:2087]

## 배경
story cd10e123 계열(mcp-dev AGENT_API_KEY 유출 인시던트, 2026-07-21) 조사 중 "악용 여부"를
증명도 반증도 못 했던 근본원인 — 성공 요청을 api_key_id로 잇는 사용 이력이 아예 없었다
(있는 건 `api_key.last_used_at` 단일 타임스탬프뿐, 5분 스로틀). FE에 이미 `apps/web/src/
app/api/api-keys/[id]/logs/route.ts`(키별 사용 이력 UI 개념)가 있었지만 그게 호출하는
`/api/v2/api-keys/{id}/logs`는 레포에 없는 죽은 경로였다.

## 구현
- `agent_api_key_usage_logs` 신규 테이블(migration 0280) — append-only, FK 없음(감사
  목적상 키 회전/멤버 삭제와 무관하게 이력이 그대로 남아야 함, `agent_auth_failure`와
  동일 원칙).
- `record_api_key_usage`(write) — `_touch_api_key_last_used`/`record_auth_failure`
  (story #2457/#2836)와 동형: 전용 단명 세션(caller 트랜잭션과 분리)+fail-silent(인증
  자체는 절대 안 막음). **스로틀 없음**(의도적 — last_used_at과 다름: 이 원장의 존재
  이유가 완전성이라 샘플링하면 목적 자체가 무효화된다).
- `_resolve_api_key` 성공 경로 말미(양쪽 분기 공통 exit point)에 배선. `get_current_user`/
  `get_current_user_streaming`이 이제 `Request`를 전달한다 — FastAPI가 `Request | None`
  Optional-union을 특수 injection 대상으로 인식 못 해(`FastAPIError: Invalid args for
  response field!`) `request: Request = None`(bare Request, None 기본값)으로 처리, 기존
  직접호출 테스트(키워드 인자만 쓰는 다수 파일)와도 호환.
- `GET /api/v2/api-keys/{key_id}/logs` — 죽은 FE 경로 소생. 자매 엔드포인트(rotate/list/
  create/revoke)와 동일한 `assert_agent_owner` 가드(story 561fd294 IDOR 교훈 재사용 —
  org_id dependency만으론 부족, ownership 검증 없이 열면 타 org 키의 사용 이력이 샌다).

## 검증
- 신규 실PG 테스트 10건: write 완전성(스로틀 없음 확認)·read 정렬/limit/키-scope·
  `_resolve_api_key` 통합(성공 시 기록·401 시 미기록)·엔드포인트(owner 성공·cross-org
  IDOR 거부·404). 전부 RED→GREEN 실측(기능 비활성화 시 정확히 실패 확認 후 복원).
- 인접 auth 테스트(mcp_opt_s5 외 6파일, `get_current_user`/`_resolve_api_key` 직접호출
  다수) 무회귀 — `request` 파라미터 추가로 깨진 시그니처-assert 1건만 갱신.
- 전체 스위트(`--ignore=tests/mcp`, DB 없이): 5188 pass·49 fail — 49건 전부 clean
  develop(변경 前)에서도 동일하게 실패함을 개별 확認(DATABASE_URL 미설정 realdb류·로컬
  `sprintable_mcp` 경로 부재류, 이 PR과 무관한 pre-existing).
- GitHub push protection 1건 걸림(테스트 안 `sk_live_`+긴 문자열 리터럴, OB-4 #1720과
  동일 클래스) — 런타임 조립으로 정정 후 재푸시.

## 스코프 밖(원 스토리 부속 맥락, 페드루 PO 지시 — 등재만·확장 금지)
키 로테이션 무중단(즉시 revoke가 grace 없이 물려있는 호출자를 죽이는 갭)은 이 스토리의
본체가 아니다 — 그라운딩 중 실체가 잡히면 별도 스토리로.