### PR TITLE
[SID:3080] 접힌 프리뷰 entity 참조 토큰 raw 노출 fix

### DIFF
--- a/apps/web/src/lib/chat-report-density.test.ts
+++ b/apps/web/src/lib/chat-report-density.test.ts
@@ -161,6 +161,17 @@ describe('extractLeadSentence (story #ec57c80c — 첫 문장 verbatim, 3015 규
       expect(lead).not.toContain('](entity:');
       expect(lead).toBe('문장. 안에 마침표가 있는 라벨 뒤이어지는 내용.');
     });
+
+    it('라벨 내부 이스케이프(\\]) 다음에 마침표가 오면 조기 절단으로 오판하지 않는다(story #3486 카디르 QA #3448 재발견 — isBalancedCut 이스케이프 미처리)', () => {
+      // 카디르 재현: 원문 세는 대괄호 카운트가 `\]`를 실제 닫는 대괄호로 착각해 "[label \]."
+      // 에서 조기 절단 → entity 토큰 정규식과 안 맞아 raw `[label \].`가 그대로 샌다.
+      const uuid = '55555555-5555-5555-5555-555555555555';
+      const raw = `[label \\]. rest](entity:story:${uuid}) next.`;
+      const lead = extractLeadSentence(raw);
+      expect(lead).not.toContain('[label');
+      expect(lead).not.toContain('](entity:');
+      expect(lead).toBe('label ]. rest next.');
+    });
   });
 });
 

--- a/apps/web/src/lib/chat-report-density.test.ts
+++ b/apps/web/src/lib/chat-report-density.test.ts
@@ -121,6 +121,47 @@ describe('extractLeadSentence (story #ec57c80c — 첫 문장 verbatim, 3015 규
         .toBe('매우 중요 그리고 일반 강조도 있다');
     });
   });
+
+  // story #3080(선생님 실사용 발견) — entity 참조 토큰이 안 벗겨져 raw `[라벨](entity:...)`
+  // 그대로 접힌 프리뷰에 노출됐다(스크린샷 실물). stripInlineMarkers가 볼드/코드만 다루고
+  // 참조 링크 문법은 처음부터 대상 밖이었다.
+  describe('story #3080 — entity 참조 토큰 스트립(라벨만 남기고 문법 벗김)', () => {
+    it('[라벨](entity:type:uuid)에서 라벨만 남는다', () => {
+      const uuid = '11111111-1111-1111-1111-111111111111';
+      expect(extractLeadSentence(`작업 완료 — [스토리 제목](entity:story:${uuid}) 확認했는.`))
+        .toBe(`작업 완료 — 스토리 제목 확認했는.`);
+    });
+
+    it('라벨 자체가 대괄호를 포함해도(팀 관례 "[P0·...] 제목") 백슬래시 이스케이프가 원복된다', () => {
+      const uuid = '22222222-2222-2222-2222-222222222222';
+      const raw = `[\\[P0·재질\\] 코너컷 처분](entity:story:${uuid}) 완주했는.`;
+      expect(extractLeadSentence(raw)).toBe('[P0·재질] 코너컷 처분 완주했는.');
+    });
+
+    it('한 줄에 참조가 여럿이어도 전부 벗겨진다', () => {
+      const a = '11111111-1111-1111-1111-111111111111';
+      const b = '22222222-2222-2222-2222-222222222222';
+      const raw = `[문서A](entity:doc:${a})와 [문서B](entity:doc:${b}) 둘 다 확認했는.`;
+      expect(extractLeadSentence(raw)).toBe('문서A와 문서B 둘 다 확認했는.');
+    });
+
+    it('라벨 안에 중첩된 볼드도 함께 벗겨진다(볼드 스트립이 먼저 돌아야 함)', () => {
+      const uuid = '33333333-3333-3333-3333-333333333333';
+      expect(extractLeadSentence(`[**강조 제목**](entity:story:${uuid}) 처리됨.`))
+        .toBe('강조 제목 처리됨.');
+    });
+
+    it('참조 토큰 중간에 마침표가 걸리면(마커 불균형) 전체 폴백으로 원문이 안전하게 보존된다', () => {
+      // 대괄호 균형이 깨지는 절단 지점(마침표가 라벨 안에 있음)은 건너뛰고 문자열 끝까지 간다
+      // — #3030과 동형의 "미절단 폴백" 정직 측 원칙(진짜 온전한 참조 토큰이 최종적으로 스트립됨).
+      const uuid = '44444444-4444-4444-4444-444444444444';
+      const raw = `[문장. 안에 마침표가 있는 라벨](entity:story:${uuid}) 뒤이어지는 내용.`;
+      const lead = extractLeadSentence(raw);
+      expect(lead).not.toContain('[문장');
+      expect(lead).not.toContain('](entity:');
+      expect(lead).toBe('문장. 안에 마침표가 있는 라벨 뒤이어지는 내용.');
+    });
+  });
 });
 
 describe('extractTopLevelItems (story #ec57c80c — 최상위 목록만, 하위/표/산문 제외)', () => {

--- a/apps/web/src/lib/chat-report-density.ts
+++ b/apps/web/src/lib/chat-report-density.ts
@@ -70,11 +70,17 @@ export function deriveKicker(content: string, messageKind?: string | null): stri
 // story #3080 — entity 참조 토큰(`[라벨](entity:...)`)도 같은 결함 클래스: 마침표가 토큰
 // 중간(라벨 안·href 안)에 떨어지면 절단 결과가 여는 대괄호만 남은 `[라벨 일부`가 그대로
 // 샌다. 대괄호 개수 균형도 함께 본다 — 같은 "미절단 폴백" 정직 측 원칙 재사용.
+// story #3486(카디르 QA #3448 재발견) — 이 함수는 stripInlineMarkers(42행) 적용 前 원문
+// 위에서 세는데, 라벨 안 리터럴 대괄호를 이스케이프한 `\[`/`\]`(42행 관례)를 실제 여닫는
+// 대괄호로 착각해 균형을 오판한다("[label \]. rest]..."가 "\]"까지만 보고 1:1로 착각) —
+// 카운트용 사본에서 백슬래시 이스케이프 시퀀스부터 걷어낸다(42행의 원복과 달리 여기선
+// 문법 문자로도 안 세야 하므로 통째로 제거).
 function isBalancedCut(text: string): boolean {
-  const boldCount = (text.match(/\*\*/g) ?? []).length;
-  const codeCount = (text.match(/`/g) ?? []).length;
-  const openBracket = (text.match(/\[/g) ?? []).length;
-  const closeBracket = (text.match(/\]/g) ?? []).length;
+  const unescaped = text.replace(/\\./g, '');
+  const boldCount = (unescaped.match(/\*\*/g) ?? []).length;
+  const codeCount = (unescaped.match(/`/g) ?? []).length;
+  const openBracket = (unescaped.match(/\[/g) ?? []).length;
+  const closeBracket = (unescaped.match(/\]/g) ?? []).length;
   return boldCount % 2 === 0 && codeCount % 2 === 0 && openBracket === closeBracket;
 }
 

--- a/apps/web/src/lib/chat-report-density.ts
+++ b/apps/web/src/lib/chat-report-density.ts
@@ -32,6 +32,14 @@ function stripInlineMarkers(text: string): string {
     .replace(/\*\*\*([^*]+)\*\*\*/g, '$1')
     .replace(/\*\*([^*]+)\*\*/g, '$1')
     .replace(/`([^`]*)`/g, '$1')
+    // story #3080(선생님 실사용 발견) — entity 참조 토큰 `[라벨](entity:type:uuid)`이 안
+    // 벗겨져 접힌 프리뷰에 원문 그대로(백슬래시 이스케이프 포함) 노출됐다. 이 팀 스토리
+    // 제목 관례("[P0·...] 제목")상 라벨 자체가 대괄호를 포함하는 경우가 흔해, 자동 참조
+    // 링커가 라벨 내부 대괄호를 `\[`/`\]`로 이스케이프해 저장한다 — 그 이스케이프까지
+    // 원복해 라벨만 남긴다(no-fiction: 원문 라벨 그대로, 참조 문법만 벗김). 볼드/코드
+    // 스트립보다 반드시 뒤에 와야 한다 — 라벨 안에 중첩된 `**`가 먼저 벗겨져 있어야
+    // 정확한 라벨을 얻는다(반대 순서면 `[**title**](entity:...)`의 라벨에 `**`가 남는다).
+    .replace(/\[((?:\\.|[^[\]\\])*)\]\(entity:\w+:[0-9a-f-]+\)/gi, (_m, label: string) => label.replace(/\\(.)/g, '$1'))
     .trim();
 }
 
@@ -59,10 +67,15 @@ export function deriveKicker(content: string, messageKind?: string | null): stri
 // 중간에 떨어지면 절단 결과가 "**Summary."(닫는 ** 없음)가 돼 미완성 마커가 그대로
 // 화면에 샌다. 굵게·인라인코드 마커(짝수 개수) 균형이 안 맞는 절단은 "미절단 폴백"(정직
 // 측)으로 건너뛴다.
+// story #3080 — entity 참조 토큰(`[라벨](entity:...)`)도 같은 결함 클래스: 마침표가 토큰
+// 중간(라벨 안·href 안)에 떨어지면 절단 결과가 여는 대괄호만 남은 `[라벨 일부`가 그대로
+// 샌다. 대괄호 개수 균형도 함께 본다 — 같은 "미절단 폴백" 정직 측 원칙 재사용.
 function isBalancedCut(text: string): boolean {
   const boldCount = (text.match(/\*\*/g) ?? []).length;
   const codeCount = (text.match(/`/g) ?? []).length;
-  return boldCount % 2 === 0 && codeCount % 2 === 0;
+  const openBracket = (text.match(/\[/g) ?? []).length;
+  const closeBracket = (text.match(/\]/g) ?? []).length;
+  return boldCount % 2 === 0 && codeCount % 2 === 0 && openBracket === closeBracket;
 }
 
 /** 첫 문장을 verbatim으로 추출(리라이트 0). 문장 경계 = 마침표/느낌표/물음표+공백(또는


### PR DESCRIPTION
## 요약
긴 report성 채팅 메시지가 「전문 보기」 접힘 상태일 때, 본문의 entity 참조 토큰(`[라벨](entity:type:uuid)`)이 링크로 렌더되지 않고 **백슬래시 이스케이프 포함 raw 원문 그대로** 노출되던 결함(선생님 실사용/스크린샷 발견) 수정.

## 근본원인
접힌 프리뷰(`ReportMessageSummary`)는 no-fiction 원칙상 원문 substring 추출(`chat-report-density.ts`) 방식이라, 렌더러가 아니라 마크다운 "기호"만 벗기는 `stripInlineMarkers`를 거친다. 이 함수가 `**볼드**`·`` `코드` `` 만 다루고 entity 참조 링크 문법은 대상 밖이었다 — 그래서 볼드는 정상으로 보였지만(마커만 벗겨져 평문화) 참조 토큰은 문법째로 그대로 샜다.

## 변경
- `stripInlineMarkers`에 `[라벨](entity:type:uuid)` 스트립 추가(라벨만 남기고 문법 제거) — 볼드/코드 스트립 **이후**에 실행(중첩 볼드 라벨 대응). 라벨 자체의 대괄호 이스케이프(`\[`/`\]`, 팀 스토리 제목 관례 "[P0·...] 제목" 대응)도 원복.
- `isBalancedCut`에 대괄호 균형 체크 추가 — #3030과 동형 결함 클래스(문장 경계가 참조 토큰 중간에 떨어지면 미완성 `[라벨 일부`가 새는 것 방지, "미절단 폴백" 정직측 원칙 재사용).

## 검증
- `tsc --noEmit` clean · `eslint` clean
- `chat-report-density.test.ts` 신규 5건 — genuine RED 확인(수정 전 재현→재적용), 32/32 green
- 전체 vitest 508 files / 4549 tests green
- `pnpm build` EXIT=0

## 시각 증거
before/after — 실 `extractLeadSentence()` 결과값 그대로 재구성:
https://sprintable.dev (artifact e398dc34-f361-467b-bcd6-27cf16df1f50, story #3080 연결)

## 반응형/확장
데스크톱/모바일 공통 로직(`chat-report-density.ts`는 순수 함수, DOM 무관) — 별도 뷰포트별 검증 불필요.