### PR TITLE
fix(chat): window.focus 강제 재연결·backfill mark-read·페이지 병합

### DIFF
--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -318,6 +318,36 @@ describe('ChatListView — SSE 재연결·백그라운드 복귀 재fetch (story
   });
 });
 
+describe('ChatListView — window.focus 강제 재fetch·중복 coalescing (story #3081)', () => {
+  it('window.focus가 오면(visibilitychange 없이도) 목록이 재fetch된다', async () => {
+    stubFetch([]);
+    await mount();
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const beforeCount = countMyConversationsFetchCalls(fetchMock);
+
+    await act(async () => { window.dispatchEvent(new Event('focus')); });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(countMyConversationsFetchCalls(fetchMock)).toBe(beforeCount + 1);
+  });
+
+  it('SSE onReconnect와 focus가 근접 시점에 겹치면 재fetch가 1회로 coalesce된다', async () => {
+    stubFetch([]);
+    await mount();
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const beforeCount = countMyConversationsFetchCalls(fetchMock);
+
+    const opts = useChatSseMock.mock.calls.at(-1)?.[0] as { onReconnect?: () => void } | undefined;
+    await act(async () => {
+      opts!.onReconnect!();
+      window.dispatchEvent(new Event('focus'));
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(countMyConversationsFetchCalls(fetchMock)).toBe(beforeCount + 1); // 2가 아니라 1
+  });
+});
+
 // story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — 대화명=Claim(600)로 재분류
 // (구조·크기 불변, preview는 이미 Body-small 부합이라 무편집).
 describe('ChatListView — 대화명 Claim 무게(story #2969 PR-5)', () => {

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -423,7 +423,16 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
   // handleReconnect(fetchMessages 재호출)와 동형 — "재연결됐다"는 신호를 받으면 목록을
   // 통째로 다시 가져와 서버 truth로 백필한다. agent 탭은 이미 연 적 있을 때만(lazy 유지 원칙,
   // loadAgentConversationsOnce와 동일 가드).
+  // story #3081 — SSE onReconnect(연결 자체의 재연결)와 아래 visibility/focus 리스너가
+  // 근접 시점에 겹쳐 부르면(예: 짧은 네트워크 끊김 직후 탭 포커스 복귀) 같은 재fetch가
+  // 중복 실행된다. 결과 자체는 idempotent라 데이터 오염은 없지만 불필요한 API 처칭을
+  // 억제한다.
+  const lastReconnectFetchAtRef = useRef(0);
+  const RECONNECT_COALESCE_MS = 1_000;
   const handleReconnect = useCallback(() => {
+    const now = Date.now();
+    if (now - lastReconnectFetchAtRef.current < RECONNECT_COALESCE_MS) return;
+    lastReconnectFetchAtRef.current = now;
     void fetchConversations(0, false);
     if (agentLoadedRef.current) void fetchAllConversations(0, false);
   }, [fetchConversations, fetchAllConversations]);
@@ -438,12 +447,18 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
   // story #1978(트랙C) — onReconnect(SSE 커넥션 자체의 재연결)와는 다른 축: 탭이 백그라운드에
   // 있는 동안엔 SSE가 안 끊겨도(브라우저가 살려둘 수 있음) 목록이 갱신 안 됐을 수 있다.
   // use-chat-unread-total.ts와 동일 패턴(document.visibilitychange, !document.hidden에서만).
+  // story #3081 — 데스크톱 셸(창은 계속 visible)에서 OS 포커스만 잃었다 되찾는 경우
+  // visibilitychange는 안 fire하므로 window.focus를 같은 핸들러에 추가 배선한다.
   useEffect(() => {
     const handleVisibility = () => {
       if (!document.hidden) handleReconnect();
     };
     document.addEventListener('visibilitychange', handleVisibility);
-    return () => document.removeEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('focus', handleVisibility);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('focus', handleVisibility);
+    };
   }, [handleReconnect]);
 
   const handleCreated = (conversationId: string) => {

--- a/apps/web/src/components/chat/chat-view-backfill.test.ts
+++ b/apps/web/src/components/chat/chat-view-backfill.test.ts
@@ -1,0 +1,64 @@
+// story #3081(선생님 P0 지시, 2026-08-25) — codex 재검증 정본 ③·⑤ 회귀가드. ChatView
+// 전체(1097줄, ThreadPanel·ReadingPanel·chat-rail-context 등 무거운 의존성)를 마운트하지
+// 않고, 그 안에서 뽑아낸 순수함수 두 개(mergeBackfilledMessages·resolveBackfillMarkReadIso)
+// 만 직접 검증한다 — 이 파일이 실제 배선(chat-view.tsx의 fetchMessages/handleReconnect)에
+// 물려 있는지는 소스 대조로 확인했다(그 두 함수를 그대로 호출).
+import { describe, expect, it } from 'vitest';
+import { mergeBackfilledMessages, resolveBackfillMarkReadIso } from './chat-view';
+import type { ChatMessage } from '@/hooks/use-chat-sse';
+
+function msg(id: string, created_at: string): ChatMessage {
+  return {
+    id, memo_id: 'c1', created_by: 'u1', sender_name: 'test', sender_type: 'human',
+    sender_avatar_url: null, content: id, attachments: [], created_at,
+  };
+}
+
+describe('mergeBackfilledMessages — story #3081 정본 ⑤', () => {
+  it('data가 비어있으면 prev를 그대로 반환한다(재연결 직후 응답이 빈 페이지인 경우)', () => {
+    const prev = [msg('a', '2026-08-25T00:00:00Z')];
+    expect(mergeBackfilledMessages(prev, [])).toBe(prev);
+  });
+
+  it('과거로 스크롤해 loadMore로 펼쳐 둔 옛 페이지를 날리지 않는다(핵심 회귀 — 옛날엔 setMessages(data)로 통째 교체했다)', () => {
+    const oldPage = [msg('old-1', '2026-08-20T00:00:00Z'), msg('old-2', '2026-08-21T00:00:00Z')];
+    const freshLatest = [msg('new-1', '2026-08-25T09:00:00Z'), msg('new-2', '2026-08-25T09:05:00Z')];
+    const result = mergeBackfilledMessages(oldPage, freshLatest);
+    expect(result.map((m) => m.id)).toEqual(['old-1', 'old-2', 'new-1', 'new-2']);
+  });
+
+  it('data와 겹치는 id는 prev 쪽을 버리고 새 값을 신뢰한다(dedup)', () => {
+    const prev = [msg('old-1', '2026-08-20T00:00:00Z'), msg('shared', '2026-08-25T09:00:00Z')];
+    const data = [msg('shared', '2026-08-25T09:00:00Z'), msg('new-1', '2026-08-25T09:05:00Z')];
+    const result = mergeBackfilledMessages(prev, data);
+    expect(result.map((m) => m.id)).toEqual(['old-1', 'shared', 'new-1']);
+    expect(result.filter((m) => m.id === 'shared')).toHaveLength(1);
+  });
+
+  it('prev 항목이 data[0]보다 최신(=신규 페이지 구간에 포함)이면 보존하지 않는다', () => {
+    const prev = [msg('stale-mid', '2026-08-25T09:02:00Z')]; // data[0]보다 최신 — 신규 구간 내부
+    const data = [msg('new-1', '2026-08-25T09:00:00Z'), msg('new-2', '2026-08-25T09:05:00Z')];
+    const result = mergeBackfilledMessages(prev, data);
+    expect(result.map((m) => m.id)).toEqual(['new-1', 'new-2']); // stale-mid는 빠진다(신규분이 정답)
+  });
+});
+
+describe('resolveBackfillMarkReadIso — story #3081 정본 ③', () => {
+  it('하단 근처(nearBottom=true)에서 backfill로 신규 메시지가 채워지면 최신 시각을 반환한다', () => {
+    const latest = [msg('a', '2026-08-25T09:00:00Z'), msg('b', '2026-08-25T09:05:00Z')];
+    expect(resolveBackfillMarkReadIso(latest, true)).toBe('2026-08-25T09:05:00Z');
+  });
+
+  it('하단이 아니면(스크롤 위) mark-read하지 않는다 — null', () => {
+    const latest = [msg('a', '2026-08-25T09:00:00Z')];
+    expect(resolveBackfillMarkReadIso(latest, false)).toBeNull();
+  });
+
+  it('backfill 결과가 비어있으면(신규 메시지 없음) null', () => {
+    expect(resolveBackfillMarkReadIso([], true)).toBeNull();
+  });
+
+  it('fetchMessages가 실패해 undefined를 반환해도 안전하게 null', () => {
+    expect(resolveBackfillMarkReadIso(undefined, true)).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -76,6 +76,25 @@ function groupByDate(messages: ChatMessage[]): MessageGroup[] {
   return Object.entries(groups).map(([date, msgs]) => ({ date, messages: msgs }));
 }
 
+// story #3081(정본 ⑤) — 재연결·focus 재조회(before 없는 fetchMessages 호출)가 서버 최신
+// 50개로 통째로 setMessages(data)하면 사용자가 위로 스크롤해 loadMore로 펼쳐 둔 과거
+// 페이지가 날아간다. data[0](가장 오래된 신규 항목)보다 더 과거인 prev 항목만 보존해
+// 앞에 붙인다 — dedup은 id로(data와 겹치는 구간은 새 값을 신뢰).
+export function mergeBackfilledMessages(prev: ChatMessage[], data: ChatMessage[]): ChatMessage[] {
+  if (!data.length) return prev;
+  const newIds = new Set(data.map((m) => m.id));
+  const olderKept = prev.filter((m) => !newIds.has(m.id) && m.created_at < data[0]!.created_at);
+  return [...olderKept, ...data];
+}
+
+// story #3081(정본 ③) — backfill(fetchMessages 재조회)이 채운 신규 메시지도 addMessage(SSE
+// 실시간 수신)와 동일하게 「활성 뷰어가 하단을 보고 있으면 mark-read」돼야 한다. 표시할
+// up_to 시각을 판정만 순수함수로 뽑는다(호출 자체는 handleReconnect가 한다).
+export function resolveBackfillMarkReadIso(latest: ChatMessage[] | undefined, nearBottom: boolean): string | null {
+  if (!latest?.length || !nearBottom) return null;
+  return latest[latest.length - 1]!.created_at;
+}
+
 export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix = '/api/chats', backHref = '/chats', commandTargets, presenceById, scrollToMessageId, initialLastReadAt, participants }: ChatViewProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -248,24 +267,26 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     return el.scrollHeight - el.scrollTop - el.clientHeight <= 50;
   }, []);
 
-  const fetchMessages = useCallback(async (before?: string) => {
+  const fetchMessages = useCallback(async (before?: string): Promise<ChatMessage[] | undefined> => {
+    let merged: ChatMessage[] | undefined;
     try {
       const params = new URLSearchParams({ limit: '50' });
       if (before) params.set('before', before);
       const res = await fetch(`${apiPrefix}/${threadId}/messages?${params.toString()}`);
-      if (!res.ok) return;
+      if (!res.ok) return undefined;
       // Backend: { data: _to_chat_message[], meta: { next_cursor, has_more } }
       const raw = await res.json() as Record<string, unknown>;
       const rawData = (Array.isArray(raw) ? raw : (raw.data ?? [])) as Record<string, unknown>[];
       const meta = Array.isArray(raw) ? null : raw.meta as { next_cursor?: string; has_more?: boolean } | undefined;
       const data = rawData.map(normalizeToMessage);
       if (before) {
-        setMessages((prev) => [...data, ...prev]);
+        setMessages((prev) => { merged = [...data, ...prev]; return merged; });
       } else {
-        setMessages(data);
+        setMessages((prev) => { merged = mergeBackfilledMessages(prev, data); return merged; });
       }
       setCursor(meta?.next_cursor ?? null);
       setHasMore(meta?.has_more ?? false);
+      return merged;
     } finally {
       setLoading(false);
       setLoadingMore(false);
@@ -343,9 +364,16 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   }, [threadId, addMessage]);
 
   // AC4: 재연결 시 누락 메시지 backfill
+  // story #3081(정본 ③) — backfill이 놓친 신규 메시지를 채워도 이 fetchMessages 경로는
+  // addMessage(SSE 실시간 수신)와 달리 markRead를 안 태웠다 — 활성 뷰어가 하단을 보고
+  // 있어도 배지가 안 꺼지는 갭. fetchMessages가 반환하는 실 데이터(merged 결과)로
+  // 최신 메시지를 판별해 addMessage와 동일 조건(isNearBottom)으로 mark-read한다.
   const handleReconnect = useCallback(() => {
-    fetchMessages();
-  }, [fetchMessages]);
+    void fetchMessages().then((latest) => {
+      const markReadIso = resolveBackfillMarkReadIso(latest, isNearBottom());
+      if (markReadIso) markRead(markReadIso);
+    });
+  }, [fetchMessages, isNearBottom, markRead]);
 
   // 1aeecdde P2: working 폴링(#1353 GET /working·in-memory 45s TTL) → typingAgents.
   // 이름=commandTargets(없으면 미표시 graceful). poll이 BE working 셋 그대로 반영(클라 TTL 불요).

--- a/apps/web/src/hooks/use-chat-sse.test.tsx
+++ b/apps/web/src/hooks/use-chat-sse.test.tsx
@@ -272,6 +272,42 @@ describe('useChatSse — 가시성 복귀 강제 재연결(#2987, standalone-fal
   });
 });
 
+// story #3081(선생님 P0 지시, standalone-fallback 경로) — sse-multiplexer.test.tsx의
+// "window.focus 강제 재연결" 회귀가드와 동형. 위 #2987 스위트(visibilitychange 축)와 달리
+// hidden 이력 없이 focus만으로도 재연결이 걸려야 한다.
+describe('useChatSse — window.focus 강제 재연결(#3081, 가시성 축과 독립, standalone-fallback)', () => {
+  it('hidden 이력 없이 window.focus만 와도 기존 커넥션을 닫고 새로 연다', async () => {
+    await act(async () => { root.render(<Harness currentTeamMemberId="m1" />); });
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    act(() => { window.dispatchEvent(new Event('focus')); });
+
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(FakeEventSource.instances[0]!.closed).toBe(true);
+  });
+
+  it('짧은 시간 내 중복 focus는 두 번째부터 throttle되어 재연결하지 않는다', async () => {
+    await act(async () => { root.render(<Harness currentTeamMemberId="m1" />); });
+
+    act(() => { window.dispatchEvent(new Event('focus')); });
+    expect(FakeEventSource.instances).toHaveLength(2);
+
+    act(() => { window.dispatchEvent(new Event('focus')); });
+    expect(FakeEventSource.instances).toHaveLength(2); // throttle(3s) 안 — 재연결 안 함
+  });
+
+  it('focus 강제 재연결이 열리면 onReconnect가 불린다(backfill 트리거)', async () => {
+    const onReconnect = vi.fn();
+    await act(async () => { root.render(<Harness currentTeamMemberId="m1" onReconnect={onReconnect} />); });
+    expect(onReconnect).not.toHaveBeenCalled();
+
+    act(() => { window.dispatchEvent(new Event('focus')); });
+    act(() => { FakeEventSource.instances[1]!.onopen?.(); });
+
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+});
+
 // story 6ddaa086(critical, 선생님 실사고) — 「연결이 끊겼어요」 배너가 실 연결(readyState=1
 // OPEN) 정상 도달 뒤에도 안 풀리던 결함. 근본원인: mux 핸들(sse-multiplexer.ts)이 #2144
 // 처방으로 참조안정적인데, chat-view의 배너는 mux.connected를 getter로 직접 읽어 그 값이

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -324,8 +324,20 @@ export function useChatSse({ currentTeamMemberId, onConversationMessage, onWorki
     };
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
+    // story #3081 — visibilitychange 축과 독립: 데스크톱 셸(창은 계속 visible)에서 OS
+    // 포커스만 잃었다 되찾는 경우 위 handleVisibilityChange는 안 fire한다(sse-visibility-
+    // reconnect.ts의 onFocusRegained 주석 참고). sse-multiplexer.ts와 동일 처방.
+    const handleWindowFocus = () => {
+      if (visibilityState.onFocusRegained()) {
+        pendingForcedReconnect = true;
+        connect();
+      }
+    };
+    window.addEventListener('focus', handleWindowFocus);
+
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('focus', handleWindowFocus);
       // #3388 카디르 QA MEDIUM과 동일 근거 — clearTimeout만으론 stale ref가 남아, 재마운트
       // (memberId 전환) 직후 대기 中이던 백오프 재시도가 stale ref에 걸려 건너뛸 수 있었다.
       if (reconnectTimerRef.current) {

--- a/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
+++ b/apps/web/src/lib/realtime/sse-multiplexer.test.tsx
@@ -453,4 +453,49 @@ describe('useSseMultiplexer — story #2078', () => {
       vi.useRealTimers();
     });
   });
+
+  // story #3081(선생님 P0 지시) — visibilitychange만으론 "창은 계속 visible인 채 OS 포커스만
+  // 오간" 복귀를 못 잡는다(document.visibilityState가 한 번도 'hidden'이 안 되므로 위 #2987
+  // 로직 자체가 안 걸림). window.focus를 hidden 이력과 무관한 독립 신호로 추가.
+  describe('window.focus 강제 재연결(#3081, 가시성 축과 독립)', () => {
+    it('document.visibilityState가 계속 visible이었어도(hidden 이력 0) window.focus만으로 강제 재연결한다', async () => {
+      await act(async () => { root.render(<Harness memberId="me-1" enabled />); });
+      act(() => { instances[0]!.onopen?.(); });
+      expect(instances).toHaveLength(1);
+
+      act(() => { window.dispatchEvent(new Event('focus')); });
+
+      expect(instances).toHaveLength(2);
+      expect(instances[0]!.closed).toBe(true);
+    });
+
+    it('짧은 시간 내 중복 focus는 throttle되어 추가 재연결을 안 만든다', async () => {
+      vi.useFakeTimers();
+      await act(async () => { root.render(<Harness memberId="me-1" enabled />); });
+      act(() => { instances[0]!.onopen?.(); });
+
+      act(() => { window.dispatchEvent(new Event('focus')); });
+      expect(instances).toHaveLength(2);
+
+      act(() => { instances[1]!.onopen?.(); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(1_000); });
+      act(() => { window.dispatchEvent(new Event('focus')); });
+
+      expect(instances).toHaveLength(2); // throttle 창(3s) 안 — 추가 재연결 없음
+      vi.useRealTimers();
+    });
+
+    it('focus 강제 재연결도 subscribeReconnect 핸들러를 불러 backfill을 트리거한다', async () => {
+      await act(async () => { root.render(<Harness memberId="me-1" enabled />); });
+      const onReconnect = vi.fn();
+      await act(async () => { handle!.subscribeReconnect(onReconnect); });
+      act(() => { instances[0]!.onopen?.(); });
+      expect(onReconnect).not.toHaveBeenCalled();
+
+      act(() => { window.dispatchEvent(new Event('focus')); });
+      act(() => { instances[1]!.onopen?.(); });
+
+      expect(onReconnect).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/apps/web/src/lib/realtime/sse-multiplexer.ts
+++ b/apps/web/src/lib/realtime/sse-multiplexer.ts
@@ -192,10 +192,23 @@ export function useSseMultiplexer(memberId: string | undefined, enabled: boolean
     };
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
+    // story #3081(선생님 P0 지시) — visibilitychange 하나만으론 "창은 계속 visible인 채
+    // OS 포커스만 오간" 복귀를 못 잡는다(sse-visibility-reconnect.ts 모듈 docstring 참고 —
+    // onVisible()은 hidden 이력이 없으면 구조적으로 항상 false). window.focus를 독립
+    // 신호로 추가 — hidden 이력과 무관하게 강제 재연결하되 짧은 throttle로 중복 억제.
+    const handleWindowFocus = () => {
+      if (visibilityState.onFocusRegained()) {
+        pendingForcedReconnect = true;
+        connect();
+      }
+    };
+    window.addEventListener('focus', handleWindowFocus);
+
     return () => {
       closed = true;
       setConnected(false);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('focus', handleWindowFocus);
       // 카디르 QA(PR#3388) MEDIUM — clearTimeout만으론 stale ref가 남아, 재마운트(예: memberId
       // 전환) 직후 대기 중이던 백오프 재시도의 scheduleRetry()가 `if (retryTimerRef.current)
       // return` 가드에 stale 값으로 걸려 재시도를 건너뛸 수 있었다. null로 명시 리셋.

--- a/apps/web/src/lib/realtime/sse-visibility-reconnect.test.ts
+++ b/apps/web/src/lib/realtime/sse-visibility-reconnect.test.ts
@@ -47,3 +47,40 @@ describe('createVisibilityReconnectState — story #2987', () => {
     expect(state.onVisible()).toBe(false);
   });
 });
+
+describe('createVisibilityReconnectState.onFocusRegained — story #3081', () => {
+  it('onHidden이 한 번도 안 불려도(창이 계속 visible이었던 채 포커스만 복귀) true를 반환한다', () => {
+    // 이게 이 fix의 핵심 계약 — onVisible()은 hidden 이력이 없으면 구조적으로 항상 false라
+    // (위 "onHidden 없이 onVisible" 테스트 참고) focus만으로는 재연결이 안 걸렸었다.
+    const state = createVisibilityReconnectState(() => 0);
+    expect(state.onFocusRegained()).toBe(true);
+  });
+
+  it('짧은 시간 내 중복 focus는 두 번째부터 throttle되어 false다', () => {
+    let t = 0;
+    const state = createVisibilityReconnectState(() => t);
+    expect(state.onFocusRegained()).toBe(true);
+    t += 1_000; // throttle 창(3s) 안
+    expect(state.onFocusRegained()).toBe(false);
+  });
+
+  it('throttle 창을 넘겨 다시 focus되면 다시 true다', () => {
+    let t = 0;
+    const state = createVisibilityReconnectState(() => t);
+    expect(state.onFocusRegained()).toBe(true);
+    t += 3_000;
+    expect(state.onFocusRegained()).toBe(true);
+  });
+
+  it('onHidden/onVisible(가시성 축)과 완전히 독립적이다 — 서로 상태를 공유하지 않는다', () => {
+    let t = 0;
+    const state = createVisibilityReconnectState(() => t);
+    // 가시성 축을 "숨겨진 적 없음"으로 소진시켜도 focus 축엔 영향 없음.
+    expect(state.onVisible()).toBe(false);
+    expect(state.onFocusRegained()).toBe(true);
+    // 반대로 focus 축을 소진시켜도 가시성 축 판정(hidden 이력 기반)은 그대로 동작.
+    state.onHidden();
+    t += 3_000;
+    expect(state.onVisible()).toBe(true);
+  });
+});

--- a/apps/web/src/lib/realtime/sse-visibility-reconnect.ts
+++ b/apps/web/src/lib/realtime/sse-visibility-reconnect.ts
@@ -18,17 +18,40 @@
  */
 const HIDDEN_RECONNECT_THRESHOLD_MS = 3_000;
 
+/**
+ * story #3081(선생님 P0 지시, 2026-08-25) — 「나갔다 들어와야 갱신된다」 재발.
+ *
+ * 위 hidden/visible 판정(`onHidden`/`onVisible`)은 "탭이 실제로 숨겨졌다가 다시 보이게
+ * 됐다"만 잡는다. 그런데 데스크톱 앱(WebView 셸)에서 창이 최소화되거나 다른 탭으로
+ * 전환되지 않은 채(=`document.visibilityState`가 계속 `'visible'`) OS 포커스만 잃었다가
+ * 되찾는 경우가 있다 — 이 경우 `onHidden()`이 호출된 적이 없어 `hiddenAt`이 계속 `null`이고,
+ * `onVisible()`은 hidden 이력 유무를 hidden 자체를 aggregate하는 게 아니라 "hidden 이력이
+ * 있어야만" true를 낼 수 있는 구조라 이 케이스에서 **항상 false**를 반환한다(재검증,
+ * 페드루 PO+codex exec, 2026-08-25) — `focus` 이벤트를 기존 핸들러에 그냥 이어붙이는
+ * 것만으로는 이 케이스가 안 고쳐진다.
+ *
+ * 그래서 hidden 이력과 완전히 독립된 별도 판정을 둔다 — `window.focus`는 실제 창 전환
+ * 시에만 발생하므로(같은 창 안 요소 간 포커스 이동으로는 안 뜸) hidden 지속시간 같은
+ * 게이트가 없어도 안전하다. 다만 짧은 시간 내 중복 focus(예: 포커스가 빠르게 왕복하는
+ * 경우)로 강제 재연결이 반복되는 것만 throttle로 억제한다.
+ */
+const FOCUS_RECONNECT_THROTTLE_MS = 3_000;
+
 export interface VisibilityReconnectState {
   /** 페이지가 hidden이 될 때 호출(visibilitychange, document.visibilityState==='hidden'). */
   onHidden: () => void;
   /** 페이지가 다시 visible이 될 때 호출 — true면 강제 재연결해야 한다(숨겨진 시간이 임계값
    * 이상). false면 순간 전환이었으니 기존 커넥션을 그대로 둔다. */
   onVisible: () => boolean;
+  /** `window.focus` 이벤트에서 호출 — hidden 이력과 무관하게 판정한다. true면 강제
+   * 재연결(짧은 throttle 안에 중복 호출이면 false). */
+  onFocusRegained: () => boolean;
 }
 
 /** 테스트에서 결정적 값을 주입할 수 있도록 시계 소스를 분리(기본 Date.now). */
 export function createVisibilityReconnectState(now: () => number = Date.now): VisibilityReconnectState {
   let hiddenAt: number | null = null;
+  let lastFocusReconnectAt: number | null = null;
 
   return {
     onHidden() {
@@ -39,6 +62,14 @@ export function createVisibilityReconnectState(now: () => number = Date.now): Vi
       const hiddenDuration = now() - hiddenAt;
       hiddenAt = null;
       return hiddenDuration >= HIDDEN_RECONNECT_THRESHOLD_MS;
+    },
+    onFocusRegained() {
+      const nowTs = now();
+      if (lastFocusReconnectAt !== null && nowTs - lastFocusReconnectAt < FOCUS_RECONNECT_THROTTLE_MS) {
+        return false;
+      }
+      lastFocusReconnectAt = nowTs;
+      return true;
     },
   };
 }


### PR DESCRIPTION
## Summary

[SID:3081]

「앱 안에서 채팅방을 나갔다 들어와야 새 내용이 반영된다」+ 읽음 뱃지 즉시 안 꺼짐(선생님 P0 직접 지시) 재발 처방. 코덱스(codex exec) 독립 재검증으로 확정된 5점 구현 정본을 그대로 반영:

1. **`sse-visibility-reconnect.ts`** — `onHidden`/`onVisible`(기존 #2987 처방)과 완전히 독립된 `onFocusRegained()` 신설. 데스크톱 셸(창은 계속 `visible`인 채 OS 포커스만 잃었다 되찾는 경우) `onVisible()`은 hidden 이력이 없으면 구조적으로 항상 `false`를 반환해 — 기존 핸들러에 focus 리스너를 그냥 이어붙이는 것만으로는 이 케이스가 안 고쳐진다는 게 재검증의 핵심 발견.
2. **설치 3곳** — `sse-multiplexer.ts`(mux 공유 커넥션)·`use-chat-sse.ts`(폴백 EventSource)·`chat-list-view.tsx`(목록 재조회)에 각각 `window.addEventListener('focus', ...)` 배선.
3. **`chat-view.tsx` `handleReconnect`** — backfill(`fetchMessages` 재조회)로 채운 신규 메시지가 `addMessage`(SSE 실시간 수신)와 달리 mark-read를 안 태우던 갭 보정. `resolveBackfillMarkReadIso()`로 순수함수화.
4. **`chat-list-view.tsx` `handleReconnect`** — SSE `onReconnect`와 visibility/focus 리스너가 근접 시점에 겹치면 재fetch가 중복 실행되던 것을 throttle(1s)로 coalesce.
5. **`chat-view.tsx` `fetchMessages`** — 재연결·focus 재조회(non-pagination 분기)가 `setMessages(data)`로 통째 교체하며 사용자가 위로 스크롤해 `loadMore`로 펼쳐 둔 과거 페이지를 날리던 것을 병합으로 수정. `mergeBackfilledMessages()`로 순수함수화.

## Test plan

- [x] `sse-visibility-reconnect.test.ts` — `onFocusRegained` 4개 신규 테스트(hidden 이력 무관 true·throttle·throttle 만료·가시성 축과 독립) + 기존 5개, 총 9개 GREEN
- [x] `sse-multiplexer.test.tsx` — `window.focus` 강제 재연결 3개 신규 테스트, 총 26개 GREEN, RED(stash로 배선만 되돌려 3개 실패 확인)→GREEN 확인
- [x] `use-chat-sse.test.tsx` — 폴백 경로 동형 3개 신규 테스트, 총 22개 GREEN, RED→GREEN 확인
- [x] `chat-list-view.test.tsx` — focus 재fetch + onReconnect/focus coalescing 2개 신규 테스트, 총 17개 GREEN, RED→GREEN 확인
- [x] `chat-view-backfill.test.ts`(신규 파일) — `mergeBackfilledMessages`·`resolveBackfillMarkReadIso` 순수함수 8개 테스트, RED→GREEN 확인 (ChatView 자체는 1097줄·의존성 다수라 마운트 테스트 없이 추출한 순수 로직만 pin)
- [x] `tsc --noEmit` 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMtUfZBTEZyqjxocDaJFX5