### PR TITLE
feat(#3084): 결재 카드 토스 — 층1(GNB 도달 뱃지)+층3(수동 토스 API) BE

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field, field_validator
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import get_current_user, get_scope_context, get_verified_org_id
@@ -844,6 +844,35 @@ async def list_gates(
         elif g.id in eligible_ids:
             filtered.append(resp)
     return filtered
+
+
+class GateDesignatedPendingCountResponse(BaseModel):
+    count: int
+
+
+@router.get("/designated-pending-count", response_model=GateDesignatedPendingCountResponse)
+async def get_designated_pending_count(
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> GateDesignatedPendingCountResponse:
+    """story #3084(2026-08-25, 정렬 v1 층1 — 도달 보장의 불변 바닥) — GNB "미확認" 뱃지 소스.
+
+    `assigned_to_me`(list_gates)는 WHO(승인 자격 — project access+not-author)를 묻는
+    넓은 집합이라, 이 스토리의 층1이 필요로 하는 좁은 질문("이 사람이 designated로 지정된
+    미해소 건이 몇 개인가")과 다르다 — 카드가 어느 conversation에 심겼든(페어와이즈 DM이든
+    토스 사본이든) 이 카운트는 그 방을 전혀 참조하지 않는 순수 Gate.designated_approver_id
+    쿼리라, "주 대화 추론"이 틀려도(층2가 best-effort인 이유) 이 뱃지는 항상 정확하다
+    (AC1이 이 층에서 닫히는 근거)."""
+    resolved = await resolve_member(auth, org_id, session)
+    count = (await session.execute(
+        select(func.count()).select_from(Gate).where(
+            Gate.org_id == org_id,
+            Gate.designated_approver_id == resolved.id,
+            Gate.status == "pending",
+        )
+    )).scalar_one()
+    return GateDesignatedPendingCountResponse(count=count)
 
 
 class HitlInboxItem(BaseModel):
@@ -1861,6 +1890,104 @@ async def delegate_gate_endpoint(
     await dispatch_gate_delegation(
         session, _gate, old_approver_id=old_approver_id, new_approver_id=body.new_approver_member_id,
     )
+
+    return GateResponse.model_validate(_gate)
+
+
+class GateTossRequest(BaseModel):
+    target_conversation_id: uuid.UUID
+
+
+@router.post("/{id}/toss", response_model=GateResponse)
+async def toss_gate_endpoint(
+    id: uuid.UUID,
+    body: GateTossRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> GateResponse:
+    """story #3084(2026-08-25, 선생님 지시 — 결재 카드 «토스») — 상신자 또는 designated
+    결재자 본인이, designated 본인이 참여한 다른 conversation에 카드 **사본**을 심는다
+    (원 카드 잔존). #3001 delegate("사람" 축 — 정체성 재지정)와 다른 "방" 축(같은
+    designated에게로 가는 도달 경로를 하나 더 여는 것) — 페드루 PO 정렬 확定(2026-08-25):
+    과거 기각된 "여러 사람으로의 카드 확산" 정책과는 축이 달라 상충하지 않는다. 권한 범위도
+    delegate와 달리 admin 확장 없이 requester+designated 본인 한정(PO 판정, 실사고 근거
+    없어 admin 확장 기각).
+
+    target_conversation_id 검증(designated 본인이 참여자인지)이 «카드=지정 라인 전용»
+    정책(#3001)의 집행 지점 — 임의 방으로 결재 액션 링크가 새는 것을 여기서 막는다."""
+    resolved = await resolve_member(auth, org_id, session)
+    _gate = (await session.execute(
+        select(Gate).where(Gate.id == id, Gate.org_id == org_id).with_for_update()
+    )).scalar_one_or_none()
+    if _gate is None:
+        raise HTTPException(status_code=404, detail="Gate not found")
+    if _gate.status != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "gate_already_resolved", "message": "이미 처리된 결재는 토스할 수 없습니다."},
+        )
+    if _gate.designated_approver_id is None:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "no_designated_approver", "message": "지정 결재자가 없는 게이트는 토스할 수 없습니다."},
+        )
+
+    from app.services.gate_service import resolve_designatable_gate_context
+    ctx = await resolve_designatable_gate_context(session, _gate)
+    if ctx is None:
+        raise HTTPException(status_code=422, detail="이 게이트 유형은 토스를 지원하지 않습니다.")
+    title, project_id, requester_id = ctx
+
+    if resolved.id not in (requester_id, _gate.designated_approver_id):
+        raise HTTPException(status_code=403, detail="상신자 또는 지정 결재자 본인만 토스할 수 있습니다.")
+
+    # story #3001 정책 집행 — 대상 conversation에 designated 본인이 참여자여야 한다(카드=
+    # 지정 라인 전용, 임의 방으로 액션 링크가 새는 것 방지). org 스코프도 함께 강제.
+    from app.models.conversation import Conversation, ConversationParticipant
+    target_conv = (await session.execute(
+        select(Conversation).where(Conversation.id == body.target_conversation_id, Conversation.org_id == org_id)
+    )).scalar_one_or_none()
+    if target_conv is None:
+        raise HTTPException(status_code=404, detail="Target conversation not found")
+    participant = (await session.execute(
+        select(ConversationParticipant.conversation_id).where(
+            ConversationParticipant.conversation_id == body.target_conversation_id,
+            ConversationParticipant.member_id == _gate.designated_approver_id,
+        ).limit(1)
+    )).first()
+    if participant is None:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "target_approver_not_participant",
+                "message": "대상 대화에 지정 결재자가 참여하고 있지 않습니다.",
+            },
+        )
+
+    from app.services.approval_delivery import dispatch_approval_card_toss
+    inserted = await dispatch_approval_card_toss(
+        session, org_id=org_id, work_item_type=_gate.work_item_type, work_item_id=_gate.work_item_id,
+        title=title, gate_id=_gate.id, designated_approver_id=_gate.designated_approver_id,
+        target_conversation_id=body.target_conversation_id, tossed_by_id=resolved.id,
+    )
+    if inserted:
+        from app.services.activity_log import ActivityLogService
+        await ActivityLogService(session).record(
+            org_id=org_id, action="gate_tossed", actor_id=resolved.id, actor_type="human",
+            entity_type="gate", entity_id=_gate.id,
+            context={"target_conversation_id": str(body.target_conversation_id)},
+        )
+    await session.commit()
+    await session.refresh(_gate)
+
+    if inserted:
+        # best-effort — 기존 사본 보유자 전체에 다방 동기 반영(브로드캐스트 실패가 토스
+        # 자체 — 위 commit으로 이미 확정된 카드 삽입+감사기록 — 를 막지 않는다).
+        from app.services.gate_service import dispatch_gate_toss
+        await dispatch_gate_toss(
+            session, _gate, target_conversation_id=body.target_conversation_id, tossed_by_id=resolved.id,
+        )
 
     return GateResponse.model_validate(_gate)
 

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -729,6 +729,170 @@ async def notify_gate_delegated_to_old_approver(
     )]
 
 
+async def dispatch_approval_card_toss(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    work_item_type: str,
+    work_item_id: uuid.UUID,
+    title: str,
+    gate_id: uuid.UUID,
+    designated_approver_id: uuid.UUID,
+    target_conversation_id: uuid.UUID,
+    tossed_by_id: uuid.UUID,
+) -> bool:
+    """story #3084(2026-08-25, 선생님 정렬 v1 층3) — designated 결재자 본인 또는 상신자가
+    카드를 다른(designated 본인이 참여한) conversation에 **복제** 심는다. #3001 delegate
+    ("사람" 축 — 정체성 재지정, 카드 1개 유지)와 다른 "방" 축 — 같은 designated에게로
+    가는 도달 경로를 하나 더 여는 것뿐이라, 과거 기각된 "여러 사람으로의 카드 확산" 정책과
+    상충하지 않는다(페드루 PO 정렬 확定 2026-08-25).
+
+    카드 스키마 신설 없음(미르코 FE 그라운딩) — dispatch_approval_request_cards와 동일
+    모양의 ConversationMessage를 대상 conversation에 한 번 더 심을 뿐, gate_id 역참조
+    (msg_metadata.approval_target.gate_id) 하나로 여러 conversation의 카드가 전부 같은
+    게이트를 가리키는 기존 다중-approver 배달 구조를 그대로 재사용한다 — 신규 잠금/멱등
+    메커니즘도 불요(Gate.status FOR UPDATE가 이미 SSOT, notify_gate_card_recipients_
+    resolved가 이미 gate_id 기준 전체 conversation을 커버).
+
+    멱등: 대상 conversation에 이미 이 gate_id를 가리키는 카드가 있으면 새로 심지 않고
+    False를 반환(호출부가 "이미 토스됨"으로 조용히 취급 — 에러 아님). 신규 삽입 시 True.
+
+    인가(호출자가 requester/designated 본인인지)·대상 검증(designated가 target_
+    conversation 참여자인지, 카드=지정 라인 전용 정책 유지)은 라우터(gates.py::
+    toss_gate_endpoint)가 이 함수 호출 **전에** 이미 강제한다 — 이 함수 자신은 인가를
+    다시 하지 않는다(SoD 판정은 단일 지점, #3001 delegate와 동일 분업)."""
+    existing = (await db.execute(
+        select(ConversationMessage.id).where(
+            ConversationMessage.conversation_id == target_conversation_id,
+            ConversationMessage.msg_metadata["approval_target"]["gate_id"].astext == str(gate_id),
+        ).limit(1)
+    )).first()
+    if existing is not None:
+        return False
+
+    from app.routers.conversations import _dispatch_conversation_event
+    from app.services.member_resolver import lookup_members_by_ids
+
+    members = await lookup_members_by_ids({designated_approver_id, tossed_by_id}, db)
+    tossed_by = members.get(tossed_by_id)
+    designated_member = members.get(designated_approver_id)
+    if tossed_by is None:
+        logger.warning("gate toss 카드 삽입 스킵 — tossed_by 미확인 gate=%s", gate_id)
+        return False
+
+    conv = (await db.execute(
+        select(Conversation).where(Conversation.id == target_conversation_id, Conversation.org_id == org_id)
+    )).scalar_one_or_none()
+    if conv is None:
+        logger.warning(
+            "gate toss 카드 삽입 스킵 — 대상 conversation 미확인 gate=%s conv=%s",
+            gate_id, target_conversation_id,
+        )
+        return False
+
+    async with db.begin_nested():
+        msg = ConversationMessage(
+            conversation_id=conv.id,
+            sender_id=tossed_by_id,
+            content=f"'{title}' 결재 요청 (토스됨)",
+            mentioned_ids=[designated_approver_id],
+            msg_metadata={
+                "activation": {
+                    "audience": [str(designated_approver_id)],
+                    "kind": "request",
+                    "expects_response": True,
+                },
+                "approval_target": {
+                    "work_item_type": work_item_type,
+                    "work_item_id": str(work_item_id),
+                    "gate_id": str(gate_id),
+                    "actions": ["approve", "reject"],
+                    "designated": True,
+                    "designated_approver_name": designated_member.name if designated_member is not None else None,
+                    "tossed": True,
+                    "tossed_by_id": str(tossed_by_id),
+                },
+            },
+        )
+        db.add(msg)
+        await db.flush()
+        await _dispatch_conversation_event(db, conv, msg, org_id, tossed_by)
+    return True
+
+
+async def notify_gate_tossed(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    gate_id: uuid.UUID,
+    target_conversation_id: uuid.UUID,
+    tossed_by_id: uuid.UUID,
+) -> list[tuple[str, dict]]:
+    """story #3084 층3 — notify_gate_card_recipients_resolved/notify_gate_delegated_to_
+    old_approver와 동형(gate_id 기준 reverse-lookup, 새 ConversationMessage는 안 만듦,
+    순수 SSE) — 새 사본이 하나 더 생겼음을 **기존에 이미 카드를 갖고 있던 모든 conversation
+    의 수신자**에게 알린다. 미르코 FE 요건② — mux 구독(gate_resolved/gate_delegated와
+    동일 패턴)이 conversation_id 무관 gate_id 매칭이라, 이 이벤트 하나로 다방 동기 전이가
+    끝난다(이미 열린 화면 전부에 닿는다)."""
+    rows = (await db.execute(
+        select(ConversationMessage.conversation_id, ConversationMessage.mentioned_ids).where(
+            ConversationMessage.msg_metadata["approval_target"]["gate_id"].astext == str(gate_id),
+        )
+    )).all()
+    if not rows:
+        return []
+
+    conv_ids = {row.conversation_id for row in rows}
+    conv_project_ids = dict((await db.execute(
+        select(Conversation.id, Conversation.project_id).where(Conversation.id.in_(conv_ids))
+    )).all())
+
+    recipient_project_ids: dict[uuid.UUID, uuid.UUID] = {}
+    for row in rows:
+        proj_id = conv_project_ids.get(row.conversation_id)
+        if proj_id is None:
+            continue  # project 없는 conversation은 스킵(Event.project_id NOT NULL) — 조용히 건너뜀.
+        for mid in (row.mentioned_ids or []):
+            try:
+                recipient_project_ids[uuid.UUID(str(mid))] = proj_id
+            except (ValueError, TypeError, AttributeError):
+                continue  # 손상된/구형 payload — 지어내지 않고 건너뜀.
+    if not recipient_project_ids:
+        return []
+
+    from app.services.member_resolver import lookup_members_by_ids
+    members = await lookup_members_by_ids(set(recipient_project_ids), db)
+
+    payload_base = {
+        "gate_id": str(gate_id),
+        "target_conversation_id": str(target_conversation_id),
+        "tossed_by_id": str(tossed_by_id),
+    }
+
+    events: list[Event] = []
+    for member_id, proj_id in recipient_project_ids.items():
+        member = members.get(member_id)
+        m_type = member.type if member is not None else "human"
+        event = Event(
+            project_id=proj_id, org_id=org_id, event_type="conversation.gate_tossed",
+            source_entity_type="gate", source_entity_id=gate_id,
+            sender_id=tossed_by_id, recipient_id=member_id, recipient_type=m_type,
+            payload=payload_base, status="pending",
+        )
+        db.add(event)
+        events.append(event)
+
+    await db.flush()
+    pushes: list[tuple[str, dict]] = []
+    for event in events:
+        pushes.append((
+            str(event.recipient_id),
+            {"event_id": str(event.id), "event_type": "conversation.gate_tossed", **payload_base,
+             "recipient_id": str(event.recipient_id)},
+        ))
+    return pushes
+
+
 async def maybe_nudge_draft_doc_shared_in_chat(
     db: AsyncSession,
     *,

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -1373,7 +1373,7 @@ async def _resolve_doc_gate(session: AsyncSession, gate: Gate, new_status: str) 
     await session.flush()
 
 
-async def _resolve_designatable_gate_context(
+async def resolve_designatable_gate_context(
     session: AsyncSession, gate: Gate,
 ) -> tuple[str, uuid.UUID, uuid.UUID] | None:
     """story #3001 — 위임(delegate) 대상 카드 배달용 (title, project_id, requester_id) 해소.
@@ -1417,7 +1417,7 @@ async def dispatch_gate_delegation(
 
     best-effort(카드/이벤트 배달 실패가 위임 자체 — gate.designated_approver_id 갱신+
     ActivityLog — 를 막지 않는다, 라우터가 이미 그 둘을 먼저 commit한 後 이 함수를 부른다)."""
-    ctx = await _resolve_designatable_gate_context(session, gate)
+    ctx = await resolve_designatable_gate_context(session, gate)
     if ctx is None:
         logger.warning("gate delegate 컨텍스트 해소 실패 gate=%s — 카드/이벤트 배달 스킵", gate.id)
         return
@@ -1451,6 +1451,34 @@ async def dispatch_gate_delegation(
             _push_to_agent(pid_str, payload)
     except Exception:  # noqa: BLE001 — best-effort, 실시간 반영 실패가 위임 자체를 막지 않음.
         logger.warning("gate delegate 실시간 반영 배선 실패 gate=%s", gate.id, exc_info=True)
+
+
+async def dispatch_gate_toss(
+    session: AsyncSession, gate: Gate, *, target_conversation_id: uuid.UUID, tossed_by_id: uuid.UUID,
+) -> None:
+    """story #3084(2026-08-25 정렬 v1 층3) — 토스의 브로드캐스트 절반만 담당. 카드 삽입
+    자체(dispatch_approval_card_toss)는 라우터(gates.py::toss_gate_endpoint)가 인가 검증
+    직후 이미 커밋했다 — "토스됐다"는 응답이 카드 존재를 보장해야 하므로 삽입은 best-effort가
+    아니다(#2142 "조용히 넘어가는 게 제일 나쁜 것" 원칙과 동형, dispatch_gate_delegation의
+    신규 카드 배달 단계와 대비되는 지점 — 위임은 새 지정자에게 처음 가는 카드라 best-effort로
+    족하지만, 토스는 "이미 있던 카드를 옮겼다"는 사용자 확인 응답 자체이므로 다르다).
+
+    여기서 하는 일은 기존 사본 보유자 전체에 대한 conversation.gate_tossed 다방 동기 반영
+    (notify_gate_tossed)뿐 — 이건 delegate의 notify_gate_delegated_to_old_approver와 동일
+    이유로 best-effort(실시간 반영 실패가 토스 자체를 무효화하지 않음, 재조회하면 결국
+    맞는 상태를 본다)."""
+    try:
+        from app.services.approval_delivery import notify_gate_tossed
+        pushes = await notify_gate_tossed(
+            session, org_id=gate.org_id, gate_id=gate.id,
+            target_conversation_id=target_conversation_id, tossed_by_id=tossed_by_id,
+        )
+        await session.commit()
+        for pid_str, payload in pushes:
+            from app.routers.events import _push_to_agent
+            _push_to_agent(pid_str, payload)
+    except Exception:  # noqa: BLE001 — best-effort, 실시간 반영 실패가 토스 자체를 막지 않음.
+        logger.warning("gate toss 실시간 반영 배선 실패 gate=%s", gate.id, exc_info=True)
 
 
 async def _notify_doc_gate_requester(session: AsyncSession, gate: Gate, new_status: str) -> None:

--- a/backend/tests/test_3084_gate_toss_realdb.py
+++ b/backend/tests/test_3084_gate_toss_realdb.py
@@ -1,0 +1,415 @@
+"""story #3084(2026-08-25, 선생님 지시 — 결재 카드 «토스») 층1+층3 검증축:
+①POST /api/v2/gates/{id}/toss — requester 또는 designated 본인만 토스 가능(403: 제3자)
+②대상 conversation에 designated 본인이 참여자여야(422 target_approver_not_participant)
+③성공 시 대상 conversation에 카드 사본(같은 gate_id) 삽입+conversation.gate_tossed
+  Event(원 카드 보유 conversation 수신자에게)+ActivityLog(gate_tossed) 기록, 원 카드는 잔존
+④같은 대상에 재토스 시 멱등(카드 중복 삽입 없음)
+⑤이미 해소된 게이트는 토스 불가(409)
+⑥GET /api/v2/gates/designated-pending-count — designated_approver_id=me AND status=pending
+  카운트, 카드가 심긴 conversation 개수·토스 여부와 무관(층1의 "room 불문" 불변식)
+로컬 PG 미설정 시 skip(CI 관례 동일)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.activity_log  # noqa: F401 — toss 엔드포인트가 ActivityLog를 씀.
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_org_member(session, org_id, project_id, *, role="member", name="member"):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.team import TeamMember
+
+    user = User(id=uuid.uuid4(), email=f"{name}-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    session.add(TeamMember(
+        id=om.id, org_id=org_id, project_id=project_id, type="human", name=name, is_active=True,
+    ))
+    await session.commit()
+    return user.id, om.id
+
+
+async def _seed_scenario(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.doc import Doc
+    from app.models.gate import Gate
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    org = Organization(id=uuid.uuid4(), name="Org3084", slug=f"org3084-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    requester_user_id, requester_member_id = await _seed_org_member(session, org.id, project.id, name="requester")
+    designated_user_id, designated_member_id = await _seed_org_member(
+        session, org.id, project.id, role="owner", name="designated",
+    )
+    outsider_user_id, outsider_member_id = await _seed_org_member(session, org.id, project.id, name="outsider")
+
+    doc = Doc(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="#3084 토스 검증 문서",
+        content="본문", status="pending", slug=f"doc-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(doc)
+    await session.commit()
+
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org.id, work_item_id=doc.id, work_item_type="doc",
+        gate_type="doc_approval", status="pending",
+        designated_approver_id=designated_member_id,
+        neutral_facts={"requested_by_member_id": str(requester_member_id), "doc_title": doc.title},
+    )
+    session.add(gate)
+    await session.commit()
+
+    # 실 상신 카드(원 카드) — requester↔designated 페어와이즈 DM.
+    from app.services.approval_delivery import dispatch_approval_request_cards
+    await dispatch_approval_request_cards(
+        session, org_id=org.id, work_item_type="doc", work_item_id=doc.id,
+        project_id=project.id, title=doc.title, gate_id=gate.id,
+        requester_id=requester_member_id, approver_ids=[designated_member_id],
+        designated_approver_id=designated_member_id,
+    )
+    await session.commit()
+
+    # 토스 대상 conversation — designated가 참여한 별도 방(예: PO와의 주 채널 아날로그).
+    target_conv = Conversation(id=uuid.uuid4(), org_id=org.id, project_id=project.id, type="group", title="주 채널")
+    session.add(target_conv)
+    await session.commit()
+    session.add(ConversationParticipant(id=uuid.uuid4(), conversation_id=target_conv.id, member_id=designated_member_id))
+    await session.commit()
+
+    # designated 미참여 conversation — 422 검증용.
+    no_designated_conv = Conversation(id=uuid.uuid4(), org_id=org.id, project_id=project.id, type="group", title="무관 방")
+    session.add(no_designated_conv)
+    await session.commit()
+    session.add(ConversationParticipant(id=uuid.uuid4(), conversation_id=no_designated_conv.id, member_id=outsider_member_id))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "doc_id": doc.id, "gate_id": gate.id,
+        "requester_user_id": requester_user_id, "requester_member_id": requester_member_id,
+        "designated_user_id": designated_user_id, "designated_member_id": designated_member_id,
+        "outsider_user_id": outsider_user_id, "outsider_member_id": outsider_member_id,
+        "target_conversation_id": target_conv.id,
+        "no_designated_conversation_id": no_designated_conv.id,
+    }
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_toss_success_inserts_copy_and_broadcasts_and_logs():
+    from app.main import app
+    from app.models.conversation import ConversationMessage
+    from app.models.event import Event
+    from app.models.activity_log import ActivityLog
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_scenario(s)
+
+        # designated 본인이 토스(자기가 다른 방으로 옮기는 경우).
+        await _setup_app(app, Session, seeded["org_id"], seeded["designated_user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{seeded['gate_id']}/toss",
+                json={"target_conversation_id": str(seeded["target_conversation_id"])},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            copies = (await s.execute(
+                select(ConversationMessage).where(
+                    ConversationMessage.msg_metadata["approval_target"]["gate_id"].astext == str(seeded["gate_id"]),
+                )
+            )).scalars().all()
+            # 원 카드(requester↔designated DM) + 토스 사본(target_conversation) = 2개.
+            assert len(copies) == 2
+            conv_ids = {c.conversation_id for c in copies}
+            assert seeded["target_conversation_id"] in conv_ids
+            tossed = next(c for c in copies if c.conversation_id == seeded["target_conversation_id"])
+            assert tossed.msg_metadata["approval_target"]["tossed"] is True
+            assert tossed.mentioned_ids == [seeded["designated_member_id"]]
+
+            events = (await s.execute(
+                select(Event).where(Event.event_type == "conversation.gate_tossed")
+            )).scalars().all()
+            assert len(events) >= 1
+            assert events[0].payload["target_conversation_id"] == str(seeded["target_conversation_id"])
+
+            logs = (await s.execute(
+                select(ActivityLog).where(
+                    ActivityLog.entity_id == seeded["gate_id"], ActivityLog.action == "gate_tossed",
+                )
+            )).scalars().all()
+            assert len(logs) == 1
+            assert logs[0].context["target_conversation_id"] == str(seeded["target_conversation_id"])
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_toss_allowed_for_requester_too():
+    """PO 판정(2026-08-25) — 권한은 requester+designated 본인 한정(admin 확장 기각).
+    requester가 «designated가 실제로 있는 방을 안다»는 케이스를 커버."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_scenario(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["requester_user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{seeded['gate_id']}/toss",
+                json={"target_conversation_id": str(seeded["target_conversation_id"])},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_toss_forbidden_for_third_party():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_scenario(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["outsider_user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{seeded['gate_id']}/toss",
+                json={"target_conversation_id": str(seeded["target_conversation_id"])},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_toss_rejects_target_without_designated_participant():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_scenario(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["designated_user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{seeded['gate_id']}/toss",
+                json={"target_conversation_id": str(seeded["no_designated_conversation_id"])},
+            )
+            assert resp.status_code == 422, resp.text
+            assert resp.json()["error"]["code"] == "target_approver_not_participant"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_toss_idempotent_no_duplicate_copy_on_retoss():
+    from app.main import app
+    from app.models.conversation import ConversationMessage
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_scenario(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["designated_user_id"])
+        client = _client_for(app)
+        try:
+            for _ in range(2):
+                resp = await client.post(
+                    f"/api/v2/gates/{seeded['gate_id']}/toss",
+                    json={"target_conversation_id": str(seeded["target_conversation_id"])},
+                )
+                assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            copies = (await s.execute(
+                select(ConversationMessage).where(
+                    ConversationMessage.conversation_id == seeded["target_conversation_id"],
+                    ConversationMessage.msg_metadata["approval_target"]["gate_id"].astext == str(seeded["gate_id"]),
+                )
+            )).scalars().all()
+            assert len(copies) == 1  # 재토스는 멱등 — 중복 삽입 없음.
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_toss_already_resolved_gate_rejected():
+    from app.main import app
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_scenario(s)
+            gate = (await s.execute(select(Gate).where(Gate.id == seeded["gate_id"]))).scalar_one()
+            gate.status = "approved"
+            gate.resolver_id = seeded["designated_member_id"]
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["designated_user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{seeded['gate_id']}/toss",
+                json={"target_conversation_id": str(seeded["target_conversation_id"])},
+            )
+            assert resp.status_code == 409, resp.text
+            assert resp.json()["error"]["code"] == "gate_already_resolved"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_designated_pending_count_room_agnostic():
+    """층1 불변식 — 카드가 몇 개 방에 심겼든(토스 전/후 무관) 카운트는 오직
+    designated_approver_id=me AND status=pending 로만 결정된다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_scenario(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["designated_user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/gates/designated-pending-count")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["count"] == 1
+
+            # 토스해도(카드가 방 2개가 돼도) 카운트는 그대로 1 — room 불문.
+            toss_resp = await client.post(
+                f"/api/v2/gates/{seeded['gate_id']}/toss",
+                json={"target_conversation_id": str(seeded["target_conversation_id"])},
+            )
+            assert toss_resp.status_code == 200, toss_resp.text
+
+            resp2 = await client.get("/api/v2/gates/designated-pending-count")
+            assert resp2.status_code == 200, resp2.text
+            assert resp2.json()["count"] == 1
+        finally:
+            await client.aclose()
+
+        # outsider(무관자)는 0.
+        await _setup_app(app, Session, seeded["org_id"], seeded["outsider_user_id"])
+        client2 = _client_for(app)
+        try:
+            resp3 = await client2.get("/api/v2/gates/designated-pending-count")
+            assert resp3.status_code == 200, resp3.text
+            assert resp3.json()["count"] == 0
+        finally:
+            await client2.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
[SID:3084]

선생님 지시(2026-08-25, #3081 승인 사유 동반) — 원탭 결재 카드가 상신자↔designated 페어와이즈 DM에만 심겨 designated의 주 채널에 도달 못 하는 사고 재발 방지. 페드루 PO 정렬 확定 v1(층1=도달 보장 불변 바닥·층2=자동 심기 best-effort 후순위·층3=수동 토스) 따라 이 PR은 층1+층3만 구현(층2는 스코프 밖, 후속). 설계 노트: [결재 카드 토스 — BE 설계 노트](https://) 참고(Sprintable doc 4a29c3b9-da07-43ca-969f-a3991ed459bc).

- `GET /api/v2/gates/designated-pending-count` — GNB "미확認" 뱃지 소스. 카드가 어느 conversation에 심겼든 무관한 순수 `Gate.designated_approver_id`+`status=pending` 카운트(room 추론 0 — AC1이 이 층에서 닫히는 근거).
- `POST /api/v2/gates/{id}/toss` — 상신자 또는 현재 designated 본인이, designated가 참여한 다른 conversation에 카드 사본을 심는다(원 카드 잔존). 대상 conversation에 designated 본인이 참여자여야(422 `target_approver_not_participant`) — #3001 "카드=지정 라인 전용" 정책의 집행 지점. 멱등·게이트 pending 가드(409)·ActivityLog(`gate_tossed`) 기록.
- `approval_delivery.py`: `dispatch_approval_card_toss`(카드 삽입, 신규 스키마 0)+`notify_gate_tossed`(gate_id 기준 reverse-lookup 브로드캐스트, 기존 `notify_gate_card_recipients_resolved`/`notify_gate_delegated_to_old_approver`와 동형).
- `gate_service.py`: `resolve_designatable_gate_context` cross-module 공개+`dispatch_gate_toss`(브로드캐스트 best-effort).

카드 스키마 신설 없음(미르코 FE 그라운딩 확認) — `gate_id` JSONB 역참조 하나로 여러 conversation의 카드가 이미 동작하던 기존 구조 재사용. 대상 conversation 목록 엔드포인트는 기존 `GET /api/v2/conversations` 재사용(신규 불요).

## Test plan
- [x] 신규 realdb 스위트 7건(`test_3084_gate_toss_realdb.py`) — 성공 삽입+브로드캐스트+감사로그 / requester도 허용 / 제3자 403 / 대상 미참여 422 / 재토스 멱등 / 이미해소 409 / GNB 카운트 room-무관 — 실 PG 전수 GREEN
- [x] 인접 회귀 250건(delegate #3001·gate_created #3044 등 gates/approval 전 목록) — 무회귀(#3044의 기존 4건 실패는 패치 전부터 있던 무관 테스트-인프라 갭, 스태시 대조로 확認)
- [x] `bash -n`/`ast.parse`/모듈 import 스모크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sug9Biqoh5ZKVmMFEHbtY