### PR TITLE
feat(#3084 층2): designated 최근 활성 conversation 자동 카드 심기(best-effort)

### DIFF
--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -173,6 +173,13 @@ async def dispatch_approval_request_cards(
     # 안 갈 사람은 애초에 이 루프 자체에 안 들어온다).
     recipients = [designated_approver_id] if designated_approver_id is not None else approver_ids
 
+    # story #3084 층2(2026-08-25) — designated 케이스의 primary 카드가 실제로 심긴
+    # conversation.id를 기억해 둔다(아래 자동 심기 best-effort가 같은 방을 "또 다른 방"으로
+    # 오판해 무의미한 재삽입을 시도하지 않도록 — dispatch_approval_card_toss 자체는 멱등이라
+    # 안전하지만, 방금 만든 신규 DM이 "최근 활성 1위"로 잡혀 매번 같은 방만 고르는 흔한
+    # 케이스를 배제해야 층2가 실제로 의미가 있다).
+    _primary_conv_id_for_designated: uuid.UUID | None = None
+
     for approver_id in recipients:
         try:
             async with db.begin_nested():
@@ -183,6 +190,8 @@ async def dispatch_approval_request_cards(
                     requester_id=requester_id,
                     approver_id=approver_id,
                 )
+                if approver_id == designated_approver_id:
+                    _primary_conv_id_for_designated = conv.id
                 msg = ConversationMessage(
                     conversation_id=conv.id,
                     sender_id=requester_id,
@@ -226,6 +235,70 @@ async def dispatch_approval_request_cards(
         logger.warning(
             "gate_created 목록 실시간 반영 배선 실패 %s=%s", work_item_type, work_item_id, exc_info=True,
         )
+
+    # story #3084 층2(2026-08-25, 정렬 v1 후순위·best-effort) — designated의 "최근 활성"
+    # conversation(방금 심은 페어와이즈 DM과 다른 곳)에 카드 사본을 한 곳 더 심어본다.
+    # 층1(GNB 뱃지)이 이미 도달을 보장하므로 이 규칙은 정교할 필요가 없다(정렬 결론) — 엉뚱한
+    # 방을 고르거나 실패해도 사고가 아니다, 그래서 실패는 그냥 삼킨다(로그만·상신 자체는 이미
+    # 위에서 끝났다).
+    if designated_approver_id is not None and _primary_conv_id_for_designated is not None:
+        try:
+            await _maybe_auto_seed_designated_secondary_conversation(
+                db, org_id=org_id, project_id=project_id, work_item_type=work_item_type,
+                work_item_id=work_item_id, title=title, gate_id=gate_id,
+                designated_approver_id=designated_approver_id, requester_id=requester_id,
+                exclude_conversation_id=_primary_conv_id_for_designated,
+            )
+        except Exception:  # noqa: BLE001 — 정의상 best-effort.
+            logger.warning(
+                "gate 자동 심기(층2) 실패(비차단) %s=%s designated=%s",
+                work_item_type, work_item_id, designated_approver_id, exc_info=True,
+            )
+
+
+async def _maybe_auto_seed_designated_secondary_conversation(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    work_item_type: str,
+    work_item_id: uuid.UUID,
+    title: str,
+    gate_id: uuid.UUID,
+    designated_approver_id: uuid.UUID,
+    requester_id: uuid.UUID,
+    exclude_conversation_id: uuid.UUID,
+) -> None:
+    """story #3084 층2 — designated가 참여 중이고 방금 심은 페어와이즈 DM(exclude_
+    conversation_id)이 아닌 conversation 중 가장 최근 활성(Conversation.updated_at desc)
+    1곳에 한해 카드 사본을 추가 삽입. `dispatch_approval_card_toss`를 그대로 재사용(신규
+    삽입/멱등 로직 발명 0) — "시스템이 상신자를 대신해 미리 토스해 두는 것"과 동형이라
+    `tossed_by_id=requester_id`.
+
+    "최근 활성" 판정 오류(엉뚱한 방을 고름)는 사고가 아니다 — 층1(GNB 뱃지)이 이미 도달을
+    보장하므로 이 규칙은 최선 추정이면 충분하다(정렬 결론, 정교한 «주 대화 결정 규칙» 설계는
+    하지 않는다). 후보가 없으면(designated가 이 프로젝트에 다른 conversation이 없음) 조용히
+    반환 — 층1이 여전히 도달을 보장하므로 실패로 취급하지 않는다."""
+    candidate = (await db.execute(
+        select(Conversation.id)
+        .join(ConversationParticipant, ConversationParticipant.conversation_id == Conversation.id)
+        .where(
+            Conversation.org_id == org_id,
+            Conversation.project_id == project_id,
+            Conversation.id != exclude_conversation_id,
+            ConversationParticipant.member_id == designated_approver_id,
+        )
+        .order_by(Conversation.updated_at.desc())
+        .limit(1)
+    )).first()
+    if candidate is None:
+        return
+
+    await dispatch_approval_card_toss(
+        db, org_id=org_id, work_item_type=work_item_type, work_item_id=work_item_id, title=title,
+        gate_id=gate_id, designated_approver_id=designated_approver_id,
+        target_conversation_id=candidate[0], tossed_by_id=requester_id,
+    )
 
 
 _GATE_CREATED_PENDING_KEY = "s3044_pending_gate_created_pushes"
@@ -757,6 +830,13 @@ async def dispatch_approval_card_toss(
     멱등: 대상 conversation에 이미 이 gate_id를 가리키는 카드가 있으면 새로 심지 않고
     False를 반환(호출부가 "이미 토스됨"으로 조용히 취급 — 에러 아님). 신규 삽입 시 True.
 
+    ⚠️페드루 PO 비차단 관찰(PR#3488 리뷰, 2026-08-25) — False가 «멱등»과 «lookup 실패»
+    둘을 겸용하면 안 된다: 이 함수는 비-best-effort(카드 삽입=토스 "됐다"는 응답 그 자체,
+    #2142 "조용히 넘어가는 게 제일 나쁜 것" 원칙)라, tossed_by/target_conversation을 못
+    찾는 건 "이미 있다"와 의미가 완전히 다르다(전자는 예상 밖 실패, 후자는 정상 상태).
+    False는 **오직 멱등 no-op**만 의미하도록 좁히고, lookup 실패는 예외로 올려 caller가
+    (현재는 라우터의 사전 검증으로 도달 불가하지만) 침묵 200으로 착시되지 않게 한다.
+
     인가(호출자가 requester/designated 본인인지)·대상 검증(designated가 target_
     conversation 참여자인지, 카드=지정 라인 전용 정책 유지)은 라우터(gates.py::
     toss_gate_endpoint)가 이 함수 호출 **전에** 이미 강제한다 — 이 함수 자신은 인가를
@@ -777,18 +857,15 @@ async def dispatch_approval_card_toss(
     tossed_by = members.get(tossed_by_id)
     designated_member = members.get(designated_approver_id)
     if tossed_by is None:
-        logger.warning("gate toss 카드 삽입 스킵 — tossed_by 미확인 gate=%s", gate_id)
-        return False
+        raise RuntimeError(f"gate toss 카드 삽입 실패 — tossed_by 미확인 gate={gate_id} tossed_by_id={tossed_by_id}")
 
     conv = (await db.execute(
         select(Conversation).where(Conversation.id == target_conversation_id, Conversation.org_id == org_id)
     )).scalar_one_or_none()
     if conv is None:
-        logger.warning(
-            "gate toss 카드 삽입 스킵 — 대상 conversation 미확인 gate=%s conv=%s",
-            gate_id, target_conversation_id,
+        raise RuntimeError(
+            f"gate toss 카드 삽입 실패 — 대상 conversation 미확인 gate={gate_id} conv={target_conversation_id}",
         )
-        return False
 
     async with db.begin_nested():
         msg = ConversationMessage(

--- a/backend/tests/test_3084_gate_toss_realdb.py
+++ b/backend/tests/test_3084_gate_toss_realdb.py
@@ -7,6 +7,8 @@
 ⑤이미 해소된 게이트는 토스 불가(409)
 ⑥GET /api/v2/gates/designated-pending-count — designated_approver_id=me AND status=pending
   카운트, 카드가 심긴 conversation 개수·토스 여부와 무관(층1의 "room 불문" 불변식)
+⑦층2(best-effort 자동 심기) — designated가 상신 시점에 이미 참여 중인 다른 conversation이
+  있으면 dispatch_approval_request_cards가 그 방에도 카드 사본을 자동으로 심는다
 로컬 PG 미설정 시 skip(CI 관례 동일)."""
 from __future__ import annotations
 
@@ -412,4 +414,84 @@ async def test_designated_pending_count_room_agnostic():
             await client2.aclose()
     finally:
         app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_layer2_auto_seeds_designated_preexisting_conversation():
+    """층2(best-effort 자동 심기) — designated가 상신 *시점에 이미* 참여 중인 다른
+    conversation이 있으면(방금 만든 페어와이즈 DM 말고) dispatch_approval_request_cards가
+    그 방에도 카드 사본을 자동으로 심는다. "최근 활성" 판정 — 방금 만든 신규 DM(updated_at=
+    지금)이 아니라 그 pre-existing 방이 선택되는지가 이 테스트의 핵심(방금 만든 DM이 항상
+    "최근"으로 잡혀 층2가 매번 no-op이 되는 회귀를 잡는다)."""
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.doc import Doc
+    from app.models.gate import Gate
+    from app.models.conversation import Conversation, ConversationParticipant, ConversationMessage
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="Org3084L2", slug=f"org3084l2-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+            s.add(project)
+            await s.commit()
+
+            requester_user_id, requester_member_id = await _seed_org_member(s, org.id, project.id, name="requester")
+            designated_user_id, designated_member_id = await _seed_org_member(
+                s, org.id, project.id, role="owner", name="designated",
+            )
+
+            # designated가 상신 *이전부터* 참여 중이던 방(예: PO와의 주 채널 아날로그).
+            preexisting_conv = Conversation(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id, type="group", title="주 채널",
+            )
+            s.add(preexisting_conv)
+            await s.commit()
+            s.add(ConversationParticipant(
+                id=uuid.uuid4(), conversation_id=preexisting_conv.id, member_id=designated_member_id,
+            ))
+            await s.commit()
+
+            doc = Doc(
+                id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="#3084 층2 검증 문서",
+                content="본문", status="pending", slug=f"doc-{uuid.uuid4().hex[:8]}",
+            )
+            s.add(doc)
+            await s.commit()
+
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org.id, work_item_id=doc.id, work_item_type="doc",
+                gate_type="doc_approval", status="pending",
+                designated_approver_id=designated_member_id,
+                neutral_facts={"requested_by_member_id": str(requester_member_id), "doc_title": doc.title},
+            )
+            s.add(gate)
+            await s.commit()
+
+            from app.services.approval_delivery import dispatch_approval_request_cards
+            await dispatch_approval_request_cards(
+                s, org_id=org.id, work_item_type="doc", work_item_id=doc.id,
+                project_id=project.id, title=doc.title, gate_id=gate.id,
+                requester_id=requester_member_id, approver_ids=[designated_member_id],
+                designated_approver_id=designated_member_id,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            copies = (await s.execute(
+                select(ConversationMessage).where(
+                    ConversationMessage.msg_metadata["approval_target"]["gate_id"].astext == str(gate.id),
+                )
+            )).scalars().all()
+            conv_ids = {c.conversation_id for c in copies}
+            # 원 카드(신규 페어와이즈 DM) + 층2 자동 심기(preexisting_conv) = 2개.
+            assert len(copies) == 2
+            assert preexisting_conv.id in conv_ids
+    finally:
         await engine.dispose()


### PR DESCRIPTION
## Summary
[SID:3084]

**#3488(층1+층3) 위에 쌓인 스택 PR** — base=`feat/3084-approval-card-toss`(develop 아님, 의도적). #3488이 develop에 머지되면 이 PR의 base를 develop으로 재타겟하거나, #3488 머지 직후 순차 머지할 것.

페드루 PO 정렬 확定 v1 층2 — designated가 상신 시점에 이미 참여 중인 다른 conversation(방금 만든 페어와이즈 DM 제외, `updated_at desc` 최근 1곳)에 카드 사본을 자동으로 추가 삽입. 층1(GNB 뱃지)이 이미 도달을 보장하므로 이 규칙은 최선-추정이면 충분 — 판정이 틀리거나 실패해도 사고가 아니다(로그만 남기고 삼킴).

`dispatch_approval_card_toss`(#3488, 층3)를 그대로 재사용(신규 삽입/멱등 로직 발명 0) — "시스템이 상신자를 대신해 미리 토스해 두는 것"과 동형.

### 부수 수정 — #3488 PO 리뷰 비차단 관찰 반영
`dispatch_approval_card_toss`의 `False` 반환이 «멱등(기존 사본 존재)»과 «lookup 실패»를 겸용했던 것을 분리: `False`는 이제 멱등 no-op만 의미하고, tossed_by/target_conversation lookup 실패는 예외로 올린다(현재 도달 가능한 호출 경로는 없음 — 라우터 사전검증이 항상 앞서 막음 — 이지만 "조용히 200"으로 착시되는 것을 막는 방어).

## Test plan
- [x] 신규 층2 realdb 1건 — pre-existing conversation 자동 심기("방금 만든 신규 DM이 항상 최근 1위로 잡혀 매번 no-op"이 되는 회귀를 잡음)
- [x] 기존 toss 7건 + delegate(#3001)/dispatch_approval_request_cards 인접 회귀 28건 — 실PG 전수 GREEN(총 36건, 무회귀)
- [x] `ast.parse`/모듈 import 스모크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sug9Biqoh5ZKVmMFEHbtY