### PR TITLE
fix(#2041 PR-A): shutdown 시 pg_pubsub fire-and-forget 태스크 bounded drain

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -190,6 +190,15 @@ async def lifespan(app: FastAPI):
                 except asyncio.CancelledError:
                     pass
         finally:
+            # story #2041(그라운딩 doc 67b44d1e, PR-A) — 위 listen_loop.finally가 닫는 건 LISTEN
+            # 전용 raw 커넥션 하나뿐이다. pg_notify()가 fire_and_forget()으로 흩뿌린 개별
+            # 태스크(각자 async_session_factory() 세션을 짧게 쥠)는 이 5개 named task cancel+
+            # await가 전부 끝난 지금까지도 진행 중일 수 있다 — dispose보다 먼저 bounded 대기+
+            # cancel해 커넥션을 붙든 채 강제종료되지 않게 한다(named task 5개가 이미 정지했으므로
+            # 이 시점 이후 신규 발사가 없다 — drain_background_tasks 자체 docstring 참조).
+            from app.services.pg_pubsub import drain_background_tasks
+            await drain_background_tasks()
+
             # 좀비 연결 박멸(S:33e0c681): SIGTERM(Cloud Run 인스턴스 교체·스케일다운·리비전 삭제)
             # 시 SQLAlchemy 풀의 전 DB 연결을 정상 종료. dispose 누락 시 구 인스턴스가 연결을 안
             # 놓아 좀비 누적 → prod 100 cap 초과 → TooManyConnections(전 엔드포인트 500). lifespan

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -55,6 +55,41 @@ def fire_and_forget(coro: "Coroutine[Any, Any, Any]") -> None:
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.discard)
 
+
+async def drain_background_tasks(timeout: float = 5.0) -> None:
+    """story #2041(그라운딩 doc 67b44d1e, PR-A) — shutdown 시 fire_and_forget() 미완료
+    태스크를 커넥션 붙든 채 강제종료시키지 않는다. main.py lifespan이 named task 5개
+    (listen_loop·l2_task·redis_shadow_task·outbox_dispatcher_task·delivery_dispatcher_task)를
+    이미 cancel+await한 **뒤**, `engine.dispose()` **전**에 호출할 것 — 그 순서 자체가
+    "새 작업 수락 중지"를 만족한다(위 5개가 fire_and_forget의 실질적 유일한 발사원이고,
+    lifespan shutdown은 in-flight HTTP 요청 drain 이후 실행되므로 이 시점 이후 새
+    pg_notify 발사가 구조적으로 없다 — 별도 accept-gate 플래그 불요). dispose가 먼저
+    실행되면 여기 남은 태스크의 `async_session_factory()`가 이미 닫힌 풀을 참조하게 된다.
+
+    페드루 PO 지시(2026-08-25, PR-A 착수 GO) 구현 주의 2건 반영:
+    ①`list(_background_tasks)`로 **스냅샷**을 떠서 대기한다 — 드레인 도중(bounded wait
+    구간) 이론상 새 task가 set에 더해져도 그 신규분까지 기다리며 무한정 늘어나지 않는다.
+    ②timeout은 파라미터로 명시(기본 5s — Dockerfile의 `--timeout-graceful-shutdown 5`와
+    동일 예산 공유, 그 안에서 끝나야 함).
+
+    best-effort — webhook/activity 등은 durable outbox가 아니라 fire-and-forget(pg_notify
+    자체가 로컬 SSE 전파용 사이드채널)이라, timeout 안에 못 끝나면 cancel한다. 이 함수의
+    목적은 데이터 유실 0 보장이 아니라 «커넥션을 붙든 채 강제종료»를 막는 것 — 유실 허용
+    범위는 pg_notify 자체가 이미 best-effort(실패해도 로컬 전파는 별도 유지)라는 이 모듈
+    상단 docstring과 동일선."""
+    pending = list(_background_tasks)
+    if not pending:
+        return
+    _, still_pending = await asyncio.wait(pending, timeout=timeout)
+    if not still_pending:
+        return
+    logger.warning(
+        "pg_pubsub drain timeout(%ss) — 미완료 태스크 %d건 cancel", timeout, len(still_pending),
+    )
+    for t in still_pending:
+        t.cancel()
+    await asyncio.gather(*still_pending, return_exceptions=True)
+
 # ── NOTIFY 발행 ────────────────────────────────────────────────────────────────
 
 async def pg_notify(

--- a/backend/tests/test_2041_pg_pubsub_shutdown_drain.py
+++ b/backend/tests/test_2041_pg_pubsub_shutdown_drain.py
@@ -1,0 +1,152 @@
+"""story #2041(그라운딩 doc 67b44d1e, PR-A) — pg_pubsub.drain_background_tasks() 회귀가드.
+
+핵심 검증축:
+①미완료 fire_and_forget 태스크가 dispose()보다 먼저 drain(대기/취소)된다(순서 위반=레이스).
+②timeout 안에 끝나면 정상 완료를 기다린다(불필요한 cancel 없음).
+③timeout을 넘기면 cancel한다(영구 대기 금지).
+④스냅샷 의미 — drain 진입 시점의 task만 대상. 그 뒤 추가된 task는 이번 호출이 기다리지 않는다
+  (페드루 PO 지시 ① 반영, 무한정 확장 방지).
+⑤`_background_tasks`가 비어 있으면 즉시 반환(no-op, sleep/wait 없음).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _clean_background_tasks():
+    """모듈 전역 set — 테스트 간 오염 방지(다른 테스트 파일이 fire_and_forget을 실제로 썼다면
+    잔여 task가 있을 수 있음)."""
+    from app.services import pg_pubsub
+    pg_pubsub._background_tasks.clear()
+    yield
+    pg_pubsub._background_tasks.clear()
+
+
+async def test_drain_awaits_pending_task_that_finishes_within_timeout():
+    from app.services import pg_pubsub
+
+    finished = asyncio.Event()
+
+    async def _quick():
+        await asyncio.sleep(0.01)
+        finished.set()
+
+    pg_pubsub.fire_and_forget(_quick())
+    assert len(pg_pubsub._background_tasks) == 1
+
+    await pg_pubsub.drain_background_tasks(timeout=1.0)
+
+    assert finished.is_set(), "timeout 안에 끝나는 태스크는 정상 완료까지 기다려야 한다"
+    assert len(pg_pubsub._background_tasks) == 0
+
+
+async def test_drain_cancels_task_that_exceeds_timeout():
+    from app.services import pg_pubsub
+
+    cancelled = asyncio.Event()
+
+    async def _forever():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    pg_pubsub.fire_and_forget(_forever())
+
+    await pg_pubsub.drain_background_tasks(timeout=0.05)
+
+    assert cancelled.is_set(), "timeout을 넘긴 태스크는 cancel돼야 한다(영구 대기 금지)"
+
+
+async def test_drain_no_op_when_no_pending_tasks():
+    """빈 set이면 즉시 반환 — asyncio.wait([])는 ValueError이므로 이 가드가 실제로 의미 있다."""
+    from app.services import pg_pubsub
+
+    assert len(pg_pubsub._background_tasks) == 0
+    await pg_pubsub.drain_background_tasks(timeout=1.0)  # ValueError 나면 여기서 실패
+
+
+async def test_drain_snapshot_ignores_tasks_added_after_drain_started():
+    """④ — drain 진입 시점 이후 추가된 task는 같은 호출이 기다리지 않는다(스냅샷 의미)."""
+    from app.services import pg_pubsub
+
+    late_task_added = asyncio.Event()
+    late_finished = asyncio.Event()
+
+    async def _late():
+        await asyncio.sleep(0.03)
+        late_finished.set()
+
+    async def _early():
+        # drain이 스냅샷을 뜬 뒤(대기 진입 후) 새 task를 추가 — 이번 drain 호출 대상에 안 들어가야 함.
+        await asyncio.sleep(0.005)
+        pg_pubsub.fire_and_forget(_late())
+        late_task_added.set()
+
+    pg_pubsub.fire_and_forget(_early())
+
+    await pg_pubsub.drain_background_tasks(timeout=1.0)
+
+    assert late_task_added.is_set(), "_early가 끝나 _late를 추가했어야 한다"
+    # drain 호출은 이미 반환했다 — _late는 그 반환 시점에 끝나 있지 않았을 수 있다(스냅샷 밖).
+    assert pg_pubsub._background_tasks, (
+        "스냅샷 밖에서 추가된 _late 태스크는 이번 drain이 기다리지 않아 아직 set에 남아 있어야 한다"
+    )
+    await late_finished.wait()  # 정리 — 다음 테스트로 pending 태스크가 새지 않게.
+
+
+async def test_shutdown_drains_before_dispose_end_to_end(monkeypatch):
+    """①/③ 통합 — main.lifespan 실제 shutdown 경로에서 drain이 engine.dispose()보다 먼저
+    관측된다. test_lifespan_engine_dispose_33e0c681.py의 _FakeEngine 패턴 재사용."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.main import lifespan
+    from app.services import pg_pubsub
+
+    fake_engine = MagicMock()
+    call_order: list[str] = []
+
+    async def _fake_dispose():
+        call_order.append("engine_dispose")
+
+    fake_engine.dispose = AsyncMock(side_effect=_fake_dispose)
+    monkeypatch.setattr("app.core.database.engine", fake_engine)
+
+    started = asyncio.Event()
+
+    async def fake_listen():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            return
+
+    monkeypatch.setattr("app.services.pg_pubsub.listen_loop", fake_listen)
+
+    # 기본 timeout(5s)까지 실제로 블록하지 않도록, 정상 완료(취소 아님)로 순서를 검증한다 —
+    # cancel-on-timeout 경로는 test_drain_cancels_task_that_exceeds_timeout이 짧은 timeout으로
+    # 이미 따로 덮는다. 여기서는 "drain이 dispose보다 먼저 일어난다"만 end-to-end로 확인.
+    async def _pending_pubsub_work():
+        await asyncio.sleep(0.01)
+        call_order.append("pending_task_finished")
+
+    async with lifespan(MagicMock()):
+        await asyncio.wait_for(started.wait(), timeout=1)
+        # 상신 중인 pg_notify류 fire-and-forget 태스크를 흉내낸다(예: 결재 카드 알림).
+        pg_pubsub.fire_and_forget(_pending_pubsub_work())
+
+    assert "pending_task_finished" in call_order, "미완료 fire_and_forget 태스크가 drain되지 않음"
+    assert call_order.index("pending_task_finished") < call_order.index("engine_dispose"), (
+        f"순서 위반 — engine.dispose()가 pg_pubsub drain보다 먼저(또는 동시에) 일어남: {call_order}"
+    )

--- a/backend/tests/test_2041_pg_pubsub_shutdown_drain.py
+++ b/backend/tests/test_2041_pg_pubsub_shutdown_drain.py
@@ -32,6 +32,25 @@ def _clean_background_tasks():
     pg_pubsub._background_tasks.clear()
 
 
+@pytest.fixture(autouse=True)
+def _reset_shutdown_event_after():
+    """CI 실측(2026-08-26, 페드루 PO 재현·delta) — 이 파일의 test_shutdown_drains_before_
+    dispose_end_to_end만 실 `app.main.lifespan()`을 왕복한다. 그 finally가 프로세스 전역
+    `app.core.shutdown.shutdown_event`를 set()하는데(shutdown.py 계약), 이후 같은 pytest
+    프로세스에서 그 이벤트를 다시 startup 경로로 reset하는 코드가 전혀 없으면 "이미
+    셧다운됨" 상태가 그대로 남는다 — 알파벳순으로 이 파일 뒤에 도는
+    test_2143_agent_stream_legacy_push_id_omission.py의 agent_stream() SSE 제너레이터가
+    (`app/routers/agent_gateway.py`의 shutdown_task가 즉시 done) presence 프레임 도달 전에
+    "event: shutdown_reconnect"를 내고 즉시 return — StopIteration으로 관측됐다(단독 실행 시
+    통과·이 조합에서만 3/3 결정적 재현, 실측 완료). shutdown_event는 이 테스트만 건드리므로
+    (다른 4개는 pg_pubsub 함수 단위) 여기서 자기 발자국을 스스로 지운다 — main.py startup과
+    동일한 공개 API(reset_shutdown_event)로 되돌려 "이 테스트 실행 전/후 전역 상태 불변"을
+    복원한다(테스트가 안 건드렸으면 no-op와 동형이라 나머지 4개엔 부작용 없음)."""
+    yield
+    from app.core import shutdown as shutdown_module
+    shutdown_module.reset_shutdown_event()
+
+
 async def test_drain_awaits_pending_task_that_finishes_within_timeout():
     from app.services import pg_pubsub
 


### PR DESCRIPTION
## Summary
[SID:2041]

⚠️**머지 보류** — 오늘 밤 promote(실시간성+토스 검증 범위) 이후로. PR 오픈·QA는 지금 진행, 페드루 PO 지시(#3483과 동일 취급 — 검증 안 된 인프라 변화를 승격 직전 스냅샷에 안 태움).

재실측 그라운딩([커넥션 장기점유 제거 — 재실측 그라운딩 (#2041, 2026-08-25)](https://) doc 67b44d1e) 결과 확認된 지점③ — `main.py` lifespan shutdown이 named task 5개(listen_loop·l2_task·redis_shadow_task·outbox_dispatcher_task·delivery_dispatcher_task)는 cancel+await하지만 `pg_notify()`의 `fire_and_forget()`으로 흩뿌린 개별 태스크(각자 `async_session_factory()` 세션을 짧게 쥠)는 손대지 않아 `engine.dispose()` 시점까지 진행 중이면 커넥션을 붙든 채 강제종료됐다.

- `pg_pubsub.drain_background_tasks(timeout=5.0)` 신설 — named task 5개 cancel+await 이후·`engine.dispose()` 이전(다른 3개 엔진도 아직 안 닫힌 지점)에서 호출.
- bounded wait(기본 5s, `Dockerfile`의 `--timeout-graceful-shutdown 5`와 동일 예산) → 넘기면 cancel+`gather(return_exceptions=True)`.
- `list(_background_tasks)`로 스냅샷을 떠서(페드루 PO 지시①) 드레인 도중 추가되는 신규 task는 이번 호출이 기다리지 않음 — 무한 확장 방지.
- "새 작업 수락 중지"는 별도 플래그 없이 호출 순서 자체로 만족(named task 5개가 fire_and_forget의 실질적 유일 발사원이고, lifespan shutdown은 in-flight 요청 drain 이후 실행되므로 이 시점 이후 신규 발사가 구조적으로 없음 — `drain_background_tasks` docstring에 근거 명시).

## Test plan
- [x] 신규 5건(`test_2041_pg_pubsub_shutdown_drain.py`) — 정상완료 대기·timeout cancel·빈 set no-op·스냅샷 의미·lifespan e2e 순서(drain이 dispose보다 먼저) — 전부 GREEN
- [x] 인접 shutdown/dispose/fire-and-forget 회귀 38건(`test_lifespan_engine_dispose_33e0c681.py` 등) 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sug9Biqoh5ZKVmMFEHbtY