### PR TITLE
fix(#2041 PR-B): _dispatch_discord_outbound가 DB 세션 닫은 뒤 외부 POST하도록 재배치

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1011,7 +1011,15 @@ async def _dispatch_discord_outbound(
     ChannelRouter가 discord 선택한 수신자 → webhook_configs Discord endpoint 발송.
     Discord 선택 시 SSE 동시 발송 금지 (AC10).
     Discord endpoint 미설정 시 sse fallback (AC11).
-    """
+
+    story #2041(그라운딩 doc 67b44d1e, PR-B) 근본수정 — 예전엔 DB 세션을 연 채로 discord
+    멤버 수만큼 `httpx.AsyncClient().post()`를 순차 호출했다(웹훅 URL 조회↔외부 POST가
+    루프 안에서 번갈아 일어남) — Discord가 느리거나 멤버가 많으면 그 시간만큼 커넥션
+    풀을 통째로 붙들었다. 처방: DB 세션 구간에서 웹훅 URL을 **평면값(dict)으로 전부
+    미리 뽑아둔** 뒤 세션을 닫고, 그 다음에야 외부 HTTP 호출 루프를 돈다 — 쿼리 자체
+    (조건·`.first()` 픽 규칙)는 원본과 동일, 실행 시점만 앞으로 당겼다(결과 기록 DB
+    write는 원래도 없었으므로 — 실패는 로그만 — "짧은 별도 트랜잭션"이 별도로 필요
+    없다)."""
     from app.core.database import async_session_factory
     from app.services.channel_router import ChannelRouterError, route_message
     from sqlalchemy import select
@@ -1027,9 +1035,11 @@ async def _dispatch_discord_outbound(
         if not discord_members:
             return
 
-        import httpx
+        # 세션이 열린 동안 웹훅 URL만 평면값(dict)으로 전부 뽑아둔다 — 쿼리·픽 규칙은
+        # 원본 그대로(member_id별 channel="discord"·is_active 필터·`.first()`), 실행
+        # 시점만 세션이 열린 이 구간 안으로 모았다(외부 I/O는 세션 밖에서 돈다).
+        webhook_url_by_member: dict[uuid.UUID, str] = {}
         for decision in discord_members:
-            # discord channel WebhookConfig 조회
             wh = (await db.execute(
                 select(WebhookConfig).where(
                     WebhookConfig.member_id == decision.member_id,
@@ -1037,33 +1047,39 @@ async def _dispatch_discord_outbound(
                     WebhookConfig.is_active.is_(True),
                 )
             )).scalars().first()
+            if wh is not None:
+                webhook_url_by_member[decision.member_id] = wh.url
 
-            if wh is None:
-                # AC11: Discord endpoint 미설정 → sse fallback (SSE는 이미 _dispatch_conversation_event에서 처리)
-                logger.info(
-                    "Discord endpoint not configured for member %s — SSE fallback already dispatched",
-                    decision.member_id,
-                )
-                continue
-
-            # Discord URL이면 content/embeds 포맷, 아니면 generic JSON
-            is_discord_url = (
-                "discord.com/api/webhooks" in wh.url
-                or "discordapp.com/api/webhooks" in wh.url
+    # 세션 닫힘 — 여기부터는 순수 외부 HTTP 호출뿐, DB 커넥션을 전혀 점유하지 않는다.
+    import httpx
+    for decision in discord_members:
+        wh_url = webhook_url_by_member.get(decision.member_id)
+        if wh_url is None:
+            # AC11: Discord endpoint 미설정 → sse fallback (SSE는 이미 _dispatch_conversation_event에서 처리)
+            logger.info(
+                "Discord endpoint not configured for member %s — SSE fallback already dispatched",
+                decision.member_id,
             )
-            content_text = f"[conversation:message] message_id: {message_id}"
-            if is_discord_url:
-                discord_payload: dict = {"content": content_text}
-            else:
-                discord_payload = {"event_type": "conversation.message_created", "message_id": str(message_id)}
+            continue
 
-            try:
-                async with httpx.AsyncClient(timeout=10.0) as client:
-                    await client.post(wh.url, json=discord_payload)
-            except Exception:
-                logger.warning(
-                    "Discord outbound failed member_id=%s url=%s", decision.member_id, wh.url, exc_info=True
-                )
+        # Discord URL이면 content/embeds 포맷, 아니면 generic JSON
+        is_discord_url = (
+            "discord.com/api/webhooks" in wh_url
+            or "discordapp.com/api/webhooks" in wh_url
+        )
+        content_text = f"[conversation:message] message_id: {message_id}"
+        if is_discord_url:
+            discord_payload: dict = {"content": content_text}
+        else:
+            discord_payload = {"event_type": "conversation.message_created", "message_id": str(message_id)}
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                await client.post(wh_url, json=discord_payload)
+        except Exception:
+            logger.warning(
+                "Discord outbound failed member_id=%s url=%s", decision.member_id, wh_url, exc_info=True
+            )
 
 
 async def _create_conversation_record(

--- a/backend/tests/test_2041_discord_outbound_session_hold.py
+++ b/backend/tests/test_2041_discord_outbound_session_hold.py
@@ -1,0 +1,152 @@
+"""story #2041(그라운딩 doc 67b44d1e, PR-B) — `_dispatch_discord_outbound`가 DB 세션을
+연 채 외부 HTTP(discord webhook) 호출을 하지 않는지 회귀가드.
+
+핵심 검증축:
+①세션이 닫힌 **뒤**에 첫 httpx POST가 일어난다(연결 보유 시간 단축이 이 PR의 목적).
+②원본과 동일 픽 규칙(member_id별 channel="discord"·is_active·`.first()`)으로 웹훅 URL을
+  뽑아 discord 멤버 전원에게 정확히 전달한다(동작 무변화 — 회귀 0).
+③웹훅 미설정 멤버는 스킵(AC11, 기존 로그 경로 유지).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _FakeSession:
+    """async_session_factory()의 `async with` 대상 — __aexit__ 호출 시점을 외부에서
+    관측할 수 있게 call_order 리스트에 직접 기록한다.
+
+    ⚠️`async with`는 dunder(`__aenter__`/`__aexit__`)를 **타입**에서 찾는다(인스턴스
+    속성 재대입으로는 가로챌 수 없음) — 그래서 인스턴스별 mock 대신 이 클래스 자체가
+    call_order를 받아 기록하게 짰다."""
+
+    def __init__(self, state: dict, execute_side_effect, call_order: list[str] | None = None):
+        call_order = call_order if call_order is not None else []
+        self._state = state
+        self._execute_side_effect = execute_side_effect
+        self._call_order = call_order
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self._state["session_closed"] = True
+        self._call_order.append("session_closed")
+        return False
+
+    async def execute(self, *args, **kwargs):
+        return self._execute_side_effect(*args, **kwargs)
+
+
+def _make_scalars_result(row):
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = row
+    return result
+
+
+async def test_httpx_post_happens_after_session_closed_and_all_members_dispatched():
+    from app.routers.conversations import _dispatch_discord_outbound
+    from app.services.channel_router import DeliveryDecision
+
+    org_id = uuid.uuid4()
+    message_id = uuid.uuid4()
+    member_with_hook = uuid.uuid4()
+    member_without_hook = uuid.uuid4()
+
+    decisions = [
+        DeliveryDecision(member_id=member_with_hook, channel="discord", level="full", reason="test"),
+        DeliveryDecision(member_id=member_without_hook, channel="discord", level="full", reason="test"),
+    ]
+
+    wh_row = MagicMock()
+    wh_row.url = "https://discord.com/api/webhooks/123/abc"
+
+    def _execute_side_effect(*args, **kwargs):
+        # 첫 호출은 member_with_hook, 두 번째는 member_without_hook — 원본과 동일하게
+        # 호출 순서대로 decisions를 훑으므로, 호출 카운터로 어느 멤버 차례인지 흉내낸다.
+        _execute_side_effect.calls += 1
+        if _execute_side_effect.calls == 1:
+            return _make_scalars_result(wh_row)
+        return _make_scalars_result(None)
+    _execute_side_effect.calls = 0
+
+    state: dict = {"session_closed": False}
+    call_order: list[str] = []
+    fake_session = _FakeSession(state, _execute_side_effect, call_order)
+
+    posted_urls: list[str] = []
+
+    class _FakeAsyncClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, json=None):
+            call_order.append(f"post:{url}")
+            posted_urls.append(url)
+            return MagicMock(status_code=204)
+
+    with patch("app.core.database.async_session_factory", return_value=fake_session), \
+         patch("app.services.channel_router.route_message", new=AsyncMock(return_value=decisions)), \
+         patch("httpx.AsyncClient", new=_FakeAsyncClient):
+        await _dispatch_discord_outbound(message_id, org_id)
+
+    assert state["session_closed"] is True
+    assert posted_urls == ["https://discord.com/api/webhooks/123/abc"], (
+        "웹훅이 설정된 멤버 1명에게만, 정확한 URL로 1회 POST돼야 한다(회귀 0)"
+    )
+    assert call_order.index("session_closed") < call_order.index(f"post:{posted_urls[0]}"), (
+        f"순서 위반 — httpx POST가 DB 세션 종료보다 먼저(또는 동시에) 일어남: {call_order}. "
+        "세션을 닫기 전에 외부 I/O를 하면 그 시간만큼 커넥션을 붙든다(story #2041 재발)."
+    )
+
+
+async def test_no_discord_members_skips_dispatch_without_opening_httpx():
+    from app.routers.conversations import _dispatch_discord_outbound
+    from app.services.channel_router import DeliveryDecision
+
+    org_id = uuid.uuid4()
+    message_id = uuid.uuid4()
+    decisions = [
+        DeliveryDecision(member_id=uuid.uuid4(), channel="sse", level="full", reason="test"),
+    ]
+
+    state: dict = {"session_closed": False}
+    fake_session = _FakeSession(state, lambda *a, **kw: _make_scalars_result(None))
+
+    httpx_client_created = {"n": 0}
+
+    class _FakeAsyncClient:
+        def __init__(self, *a, **kw):
+            httpx_client_created["n"] += 1
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, json=None):
+            return MagicMock(status_code=204)
+
+    with patch("app.core.database.async_session_factory", return_value=fake_session), \
+         patch("app.services.channel_router.route_message", new=AsyncMock(return_value=decisions)), \
+         patch("httpx.AsyncClient", new=_FakeAsyncClient):
+        await _dispatch_discord_outbound(message_id, org_id)
+
+    assert httpx_client_created["n"] == 0, "discord 채널 결정이 없으면 httpx조차 열지 않아야 한다"


### PR DESCRIPTION
## Summary
[SID:2041]

⚠️**머지 보류** — PR-A와 동일 취급, 오늘 밤 promote(실시간성+토스 검증 범위) 이후로. PR 오픈·QA는 지금 진행(페드루 PO 지시).

재실측 그라운딩([커넥션 장기점유 제거 — 재실측 그라운딩 (#2041, 2026-08-25)](https://) doc 67b44d1e) 지점①-discord — `_dispatch_discord_outbound`가 DB 세션을 연 채 discord 멤버 수만큼 `httpx` POST를 순차 호출했다(웹훅 URL 조회↔외부 POST가 루프 안에서 번갈아 발생). Discord가 느리거나 멤버가 많으면 그 시간만큼 primary pool 커넥션을 붙들었다.

처방: 세션이 열린 구간에서 웹훅 URL을 평면값(dict)으로 전부 미리 뽑아둔 뒤 세션을 닫고, 그 다음에야 외부 HTTP 호출 루프를 돈다. 쿼리 자체(`member_id`별 `channel="discord"`·`is_active` 필터·`.first()` 픽 규칙)는 원본과 완전히 동일 — 실행 시점만 세션이 열린 구간 안으로 모았다. 결과 기록 DB write가 원래도 없었으므로(실패는 로그만) "짧은 별도 트랜잭션" 단계는 불필요.

**AC5(산식)**: discord 멤버 N명·webhook 응답 평균 T초 기준, 기존엔 세션이 최대 N×T초 점유됐다(순차 POST 사이사이 커넥션 계속 보유) — 이제 0초(세션이 외부 I/O 시작 前 이미 닫힘).

## Test plan
- [x] 신규 2건(`test_2041_discord_outbound_session_hold.py`) — 세션 종료가 첫 POST보다 먼저 / discord 결정 없으면 httpx조차 안 엶(기존 동작 100% 보존 확인 포함)
- [x] 인접 `channel_router`/`conversations` 회귀 40건 — 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sug9Biqoh5ZKVmMFEHbtY