### PR TITLE
fix(#2041 PR-C): GA4 채점 크론 2종 worker pool 이관 + 동기 gRPC to_thread 포장

### DIFF
--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -4,6 +4,7 @@ All endpoints require CRON_SECRET via Authorization: Bearer header.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import uuid
@@ -451,13 +452,26 @@ async def retry_agent_runs(
 @router.post("/score-ga4-outcomes")
 async def score_ga4_outcomes(
     request: Request,
-    session: AsyncSession = Depends(get_db),
+    session: AsyncSession = Depends(get_worker_db),
 ) -> JSONResponse:
     """E-OUTCOME-LOOP S5: GA4 지연 채점 잡.
 
     measure_after <= now AND outcome_status = 'pending' AND source = 'ga4'인
     story·sprint를 GA4 Data API로 채점.
-    """
+
+    story #2041(그라운딩 doc 67b44d1e, PR-C) 근본수정 — ①`get_db`(요청 primary pool) 대신
+    `get_worker_db`(story #2461과 동일 전용 소형 풀)로 이관 — GA4 Data API 왕복이 아무리
+    길어져도 요청 커넥션 예산을 소모하지 않는다. ②`score_ga4_outcome`의 실 구현(`ga4_client.
+    fetch_ga4_metric`)이 동기 blocking gRPC 호출이라 `asyncio.to_thread`로 감싸 이벤트루프도
+    블록하지 않게 한다(같은 프로세스의 다른 요청이 이 크론 동안 멈추던 문제 해소).
+
+    ⚠️겹침 방지 미비(그라운딩 시 확認, 이 PR이 새로 만든 결함 아님) — 이 엔드포인트는
+    `outcome_status == 'pending'` WHERE 필터 하나뿐, `FOR UPDATE`/advisory lock 등 행 단위
+    claim이 없다. 크론 스케줄러가 중첩 호출을 안 만든다는 전제(verify_cron은 인증만, 겹침
+    방지 아님)로 원래부터 동작해 왔다 — 이 PR은 그 전제를 바꾸지 않는다(worker pool 이관+
+    to_thread 포장 모두 SELECT/커밋 시점 자체는 안 건드림). 겹침 시 최악은 같은 GA4 채점
+    호출 중복(비용·quota 낭비)이지 데이터 훼손은 아니다(마지막 write가 이김, 멱등). 실 겹침
+    위험이 실측되면 별도 스토리로 SKIP LOCKED/advisory lock 도입 검토."""
     verify_cron(request)
 
     from app.models.pm import Goal, Sprint, Story
@@ -481,7 +495,7 @@ async def score_ga4_outcomes(
             if not md or md.get("source") != "ga4":
                 continue
             try:
-                scoring = score_ga4_outcome(md)
+                scoring = await asyncio.to_thread(score_ga4_outcome, md)
                 sprint.outcome_status = scoring["outcome_status"]
                 sprint.outcome_result = scoring["outcome_result"]
                 scored.append({"type": "sprint", "id": str(sprint.id), "outcome_status": scoring["outcome_status"]})
@@ -503,7 +517,7 @@ async def score_ga4_outcomes(
             if not md or md.get("source") != "ga4":
                 continue
             try:
-                scoring = score_ga4_outcome(md)
+                scoring = await asyncio.to_thread(score_ga4_outcome, md)
                 story.outcome_status = scoring["outcome_status"]
                 story.outcome_result = scoring["outcome_result"]
                 scored.append({"type": "story", "id": str(story.id), "outcome_status": scoring["outcome_status"]})
@@ -532,7 +546,7 @@ async def score_ga4_outcomes(
             source = md.get("source")
             try:
                 if source == "ga4":
-                    scoring = score_ga4_outcome(md)
+                    scoring = await asyncio.to_thread(score_ga4_outcome, md)
                 elif source == "internal_ops":
                     # 하위 스토리 진행률 계산
                     story_rows = await session.execute(
@@ -597,14 +611,18 @@ async def score_ga4_outcomes(
 @router.post("/score-hypotheses")
 async def score_hypotheses_cron(
     request: Request,
-    session: AsyncSession = Depends(get_db),
+    session: AsyncSession = Depends(get_worker_db),
 ) -> JSONResponse:
     """E1-S4: Hypothesis 지연 채점 잡(블루프린트 §8.3).
 
     measure_after <= now 인 active/measuring 가설을 채점 — active→measuring 전이 후
     ga4/internal_ops 지표로 verified|falsified 판정(실패·미지원은 measuring 유지). legacy
     /score-ga4-outcomes와 분리(hypotheses 테이블만). 스케줄 배선은 별도 운영 story.
-    """
+
+    story #2041(그라운딩 doc 67b44d1e, PR-C) — `score-ga4-outcomes`와 동일 근거로
+    `get_db`(요청 primary pool) 대신 `get_worker_db`로 이관. GA4 채점 자체(동기 blocking
+    호출 to_thread 포장)는 `hypothesis_scorer.score_hypotheses` 내부에서 처리(단일 소유
+    지점 유지 — 이 함수는 세션 소스만 바꾼다)."""
     verify_cron(request)
 
     from app.services.hypothesis_scorer import score_hypotheses

--- a/backend/app/services/hypothesis_scorer.py
+++ b/backend/app/services/hypothesis_scorer.py
@@ -28,6 +28,7 @@ session.begin_nested()(SAVEPOINT)로 격리해, 한 hypothesis의 DB abort가 �
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Any
@@ -104,7 +105,11 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
                 # Postgres 에러를 내도 이 hypothesis 처리만 롤백되고 batch 나머지(이미 flush된
                 # active→measuring 등)는 오염되지 않는다. except는 이 async with 밖에서 잡는다.
                 if source == "ga4":
-                    scoring = score_ga4_outcome(md)
+                    # story #2041(그라운딩 doc 67b44d1e, PR-C) — 동기 blocking gRPC 호출
+                    # (ga4_client.fetch_ga4_metric)이 이벤트루프를 막지 않도록 to_thread로
+                    # 포장. md는 순수 dict라 SAVEPOINT/session과 무관하게 안전(session을
+                    # 참조하지 않는 스레드 실행).
+                    scoring = await asyncio.to_thread(score_ga4_outcome, md)
                 elif source == "internal_ops":
                     pct = await _linked_story_completion_pct(session, hyp.id)
                     result = score_epic_outcome(md, pct)

--- a/backend/tests/test_2041_ga4_scorer_worker_pool.py
+++ b/backend/tests/test_2041_ga4_scorer_worker_pool.py
@@ -1,0 +1,99 @@
+"""story #2041(그라운딩 doc 67b44d1e, PR-C) — GA4 채점 크론 2종(score-ga4-outcomes·
+score-hypotheses) 회귀가드.
+
+핵심 검증축:
+①두 크론 라우터 엔드포인트가 `get_db`(요청 primary pool)가 아니라 `get_worker_db`(전용
+  소형 풀)를 의존한다 — FastAPI 의존성 그래프 검사로 직접 고정(런타임 커넥션 소스 실측
+  대안 없이도 배선 자체를 확実히 잡는다).
+②`score_ga4_outcome` 호출이 메인 이벤트루프 스레드가 아니라 별도 스레드(asyncio.to_thread)
+  에서 실행된다 — 이벤트루프 블록 해소가 실제로 걸렸는지 스레드 식별로 직접 증명.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_score_ga4_outcomes_endpoint_depends_on_worker_db():
+    from app.dependencies.database import get_worker_db
+    from app.routers.cron import score_ga4_outcomes
+
+    deps = {p.name: p.default for p in __import__("inspect").signature(score_ga4_outcomes).parameters.values()}
+    session_default = deps["session"]
+    assert session_default.dependency is get_worker_db, (
+        "score_ga4_outcomes가 여전히 get_db(요청 primary pool)를 쓰면 story #2041의 GA4 "
+        "외부 I/O 커넥션 예산 이관이 회귀한다"
+    )
+
+
+def test_score_hypotheses_cron_endpoint_depends_on_worker_db():
+    from app.dependencies.database import get_worker_db
+    from app.routers.cron import score_hypotheses_cron
+
+    deps = {p.name: p.default for p in __import__("inspect").signature(score_hypotheses_cron).parameters.values()}
+    session_default = deps["session"]
+    assert session_default.dependency is get_worker_db
+
+
+async def test_score_hypotheses_ga4_branch_runs_off_event_loop_thread():
+    """②— score_hypotheses가 GA4 채점을 to_thread로 넘기는지, 메인 루프 스레드 식별로 직접 증명."""
+    from app.services import hypothesis_scorer as sc
+
+    main_thread = threading.current_thread()
+    seen_threads: list[threading.Thread] = []
+
+    def _fake_score_ga4_outcome(md):
+        seen_threads.append(threading.current_thread())
+        return {"outcome_status": "hit", "outcome_result": {"actual": 1, "metric": "x", "scored_at": None}}
+
+    hyp = type("H", (), {})()
+    hyp.id = "hyp-1"
+    hyp.status = "active"
+    hyp.metric_definition = {"source": "ga4", "metric": "signups", "target": 1, "direction": "up"}
+    hyp.outcome_result = None
+
+    class _FakeSession:
+        def begin_nested(self):
+            return self
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def execute(self, *a, **kw):
+            class _R:
+                def scalars(self_inner):
+                    class _S:
+                        def all(self_inner2):
+                            return [hyp]
+                    return _S()
+            return _R()
+
+    async def _async_record(*a, **kw):
+        return {"skipped_reason": "no_linked_story", "bet": [], "execution": []}
+
+    async def _async_attribute(*a, **kw):
+        return {"skipped_reason": "no_measuring_loop", "attributed": []}
+
+    with patch.object(sc, "score_ga4_outcome", side_effect=_fake_score_ga4_outcome), \
+         patch("app.services.hypothesis_outcome_verdict.record_outcome_verdicts", new=_async_record), \
+         patch("app.services.loop_outcome_attribution.attribute_loop_outcome", new=_async_attribute):
+        await sc.score_hypotheses(_FakeSession())
+
+    assert len(seen_threads) == 1, "score_ga4_outcome이 정확히 1회 호출돼야 한다"
+    assert seen_threads[0] is not main_thread, (
+        "score_ga4_outcome이 메인 이벤트루프 스레드에서 그대로 실행됨 — "
+        "asyncio.to_thread 포장이 빠졌거나 회귀했다(story #2041 재발)"
+    )

--- a/backend/tests/test_e_board_schema_s1_epic_outcome.py
+++ b/backend/tests/test_e_board_schema_s1_epic_outcome.py
@@ -290,7 +290,7 @@ async def test_cron_epic_internal_ops_hit():
     """pending 에픽 + 하위 스토리 75% 완료 → completion_pct=75 → hit(target=50)."""
     from app.main import app
     from app.dependencies.auth import get_current_user
-    from app.dependencies.database import get_db
+    from app.dependencies.database import get_worker_db
     from httpx import ASGITransport, AsyncClient
 
     ctx = MagicMock()
@@ -326,7 +326,7 @@ async def test_cron_epic_internal_ops_hit():
     async def override_auth():
         return ctx
 
-    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_worker_db] = override_db
     app.dependency_overrides[get_current_user] = override_auth
 
     try:
@@ -351,7 +351,7 @@ async def test_cron_epic_does_not_change_epic_status():
     """채점 후 epic.status(active/done 등)는 절대 변경되지 않음."""
     from app.main import app
     from app.dependencies.auth import get_current_user
-    from app.dependencies.database import get_db
+    from app.dependencies.database import get_worker_db
     from httpx import ASGITransport, AsyncClient
 
     ctx = MagicMock()
@@ -387,7 +387,7 @@ async def test_cron_epic_does_not_change_epic_status():
     async def override_auth():
         return ctx
 
-    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_worker_db] = override_db
     app.dependency_overrides[get_current_user] = override_auth
 
     try:


### PR DESCRIPTION
## Summary
[SID:2041]

⚠️**머지 보류** — PR-A/B와 동일 취급, 오늘 밤 promote(실시간성+토스 검증 범위) 이후로. PR 오픈·QA는 지금 진행(페드루 PO 지시).

재실측 그라운딩([커넥션 장기점유 제거 — 재실측 그라운딩 (#2041, 2026-08-25)](https://) doc 67b44d1e) 지점①-GA4 — `score-ga4-outcomes`/`score-hypotheses` 크론이 요청 primary pool(`get_db`) 세션을 연 채 GA4 Data API를 채점 대상 row 수만큼 순차 호출했다. `score_ga4_outcome`의 실 구현(`ga4_client.fetch_ga4_metric`)이 동기 blocking gRPC라 이벤트루프까지 같이 막았다 — 그라운딩 판정 "3갈래 중 가장 나쁨"의 근거.

처방 2단(`embedding_backlog.py` #2461이 이미 쓰는 전용 소형 풀 패턴 재사용, 새 메커니즘 발명 0):
1. `score_ga4_outcomes`·`score_hypotheses_cron` 두 엔드포인트 모두 `Depends(get_db)`→`Depends(get_worker_db)`로 이관 — GA4 왕복이 아무리 길어져도 요청 커넥션 예산 무관.
2. `score_ga4_outcome(md)` 호출 3곳(cron.py sprint/story/epic 3갈래)+`hypothesis_scorer.py` GA4 분기를 `asyncio.to_thread`로 포장 — `md`는 순수 dict라 세션/SAVEPOINT와 무관하게 스레드 안전.

Goal 루프의 internal_ops 분기(DB 서브쿼리)는 손대지 않음 — GA4처럼 순수 외부 I/O가 아니라 이미 세션 안에서 도는 게 맞는 경로.

⚠️**겹침 방지 미비는 그라운딩 기존 상태**(이 PR이 만든 결함 아님, 페드루 PO 리뷰 축 요청으로 사전 확인) — 두 엔드포인트 모두 `FOR UPDATE`/advisory lock 없이 `outcome_status='pending'` 필터 하나뿐. 실 겹침 위험이 실측되면 별도 스토리로 SKIP LOCKED/advisory lock 도입 검토.

## Test plan
- [x] 신규 3건(`test_2041_ga4_scorer_worker_pool.py`) — 엔드포인트 의존성 배선 고정 2건 + GA4 호출이 메인 이벤트루프 스레드가 아닌 별도 스레드에서 실행됨을 직접 증명 1건
- [x] 인접 GA4/hypothesis 채점 회귀 47건(unit 34 + realdb 13) — 무회귀
- [x] 사전 발견·수정: `test_e_board_schema_s1_epic_outcome.py` 2건이 `get_db` override라 (엔드포인트 의존성 변경으로) 실 DB 연결 시도로 깨졌던 것을 `get_worker_db`로 정정(발견 즉시 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sug9Biqoh5ZKVmMFEHbtY