### PR TITLE
fix(#2041 PR-D): storage 크론 2종 worker pool 이관 + 동기 email to_thread 포장

### DIFF
--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -4,6 +4,7 @@ All endpoints require CRON_SECRET via Authorization: Bearer header.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import uuid
@@ -734,13 +735,17 @@ _STORAGE_WARN_COOLDOWN = timedelta(days=7)
 @router.get("/assets-grace-hard-delete")
 async def assets_grace_hard_delete(
     request: Request,
-    session: AsyncSession = Depends(get_db),
+    session: AsyncSession = Depends(get_worker_db),
 ) -> JSONResponse:
     """S8: soft-delete(deleted_at) 7일 경과 asset hard-delete — blob(provider)+row(asset_links FK CASCADE).
 
     best-effort: blob delete 성공(또는 이미 없음=멱등) 시에만 row 삭제. blob delete 실패 시 row 보존
     →다음 tick 재시도(orphan 0). tick당 최대 500건(폭주 방지).
-    """
+
+    story #2041(그라운딩 doc 67b44d1e, PR-D) 근본수정 — 최대 500건 순차 GCS 왕복(provider.
+    delete_object, 내부적으로 이미 to_thread 포장돼 이벤트루프는 안 막음) 동안 세션을 붙들고
+    있었다. `get_db`(요청 primary pool) 대신 `get_worker_db`(#2461과 동일 전용 소형 풀)로
+    이관 — 이 배치가 아무리 오래 걸려도 요청 커넥션 예산과 무관해진다."""
     verify_cron(request)
     try:
         cutoff = datetime.now(timezone.utc) - timedelta(days=_ASSET_GRACE_DAYS)
@@ -807,13 +812,17 @@ async def agent_run_timeout_sweep(
 @router.get("/storage-usage-warn")
 async def storage_usage_warn(
     request: Request,
-    session: AsyncSession = Depends(get_db),
+    session: AsyncSession = Depends(get_worker_db),
 ) -> JSONResponse:
     """S8: SaaS org storage 사용량이 캡의 80%+ 면 owner/admin 경고 메일(dedup·cooldown 7일).
 
     org_subscription(active) 대상. 캡 미정의 tier=무제한(skip). 80% 미만 복귀 시 마커 re-arm(재크로싱 시
     즉시 재경고). 메일 실패는 best-effort(개별 흡수). cooldown 내 재발송 금지(storage_warn_notified_at).
-    """
+
+    story #2041(그라운딩 doc 67b44d1e, PR-D) 근본수정 — ①`get_db`→`get_worker_db`(#2461과
+    동일 전용 소형 풀). ②`send_email`이 완전 동기(blocking resend/smtplib)라 세션 점유+
+    이벤트루프 블록이 동시에 났다(그라운딩 판정 "storage 2크론 중 더 나쁨") — `asyncio.
+    to_thread`로 포장."""
     verify_cron(request)
     try:
         now = datetime.now(timezone.utc)
@@ -876,7 +885,7 @@ async def storage_usage_warn(
             )
             for em in emails:
                 try:
-                    send_email(em, subject, html)
+                    await asyncio.to_thread(send_email, em, subject, html)
                 except Exception:
                     logger.warning("storage-usage-warn email 실패 org=%s", sub.org_id, exc_info=True)
             await session.execute(

--- a/backend/tests/test_2041_storage_crons_worker_pool.py
+++ b/backend/tests/test_2041_storage_crons_worker_pool.py
@@ -1,0 +1,109 @@
+"""story #2041(그라운딩 doc 67b44d1e, PR-D) — storage 크론 2종(assets-grace-hard-delete·
+storage-usage-warn) 회귀가드.
+
+핵심 검증축(PR-C의 GA4 검증과 동형 — DB 불요, 배선/스레드만 직접 고정):
+①두 크론 라우터 엔드포인트가 `get_db`(요청 primary pool)가 아니라 `get_worker_db`(전용
+  소형 풀)를 의존한다.
+②`storage_usage_warn`의 `send_email` 호출이 메인 이벤트루프 스레드가 아니라 별도 스레드
+  (asyncio.to_thread)에서 실행된다.
+
+realdb 회귀(test_asset_registry_realdb.py·test_2906_storage_quota_enforcement_realdb.py)는
+이 세션의 로컬 scratch PG(bare `createdb`, 마이그 미적용)로는 검증 불가 — 두 파일 모두
+ALEMBIC_DATABASE_URL(CI의 alembic-fresh-db 잡·마이그 완료된 실 PG) 전제라, 무수정 develop
+HEAD에서도 동일 "relation ... does not exist"로 실패함을 diff-only 대조로 확認(사전 존재
+갭, 이 PR이 만든 회귀 아님) — CI가 최종 판정."""
+from __future__ import annotations
+
+import inspect
+import threading
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_assets_grace_hard_delete_depends_on_worker_db():
+    from app.dependencies.database import get_worker_db
+    from app.routers.cron import assets_grace_hard_delete
+
+    params = inspect.signature(assets_grace_hard_delete).parameters
+    assert params["session"].default.dependency is get_worker_db, (
+        "assets_grace_hard_delete가 여전히 get_db(요청 primary pool)를 쓰면 story #2041의 "
+        "GCS 배치 커넥션 예산 이관이 회귀한다"
+    )
+
+
+def test_storage_usage_warn_depends_on_worker_db():
+    from app.dependencies.database import get_worker_db
+    from app.routers.cron import storage_usage_warn
+
+    params = inspect.signature(storage_usage_warn).parameters
+    assert params["session"].default.dependency is get_worker_db
+
+
+async def test_storage_usage_warn_send_email_runs_off_event_loop_thread():
+    """② — storage_usage_warn이 send_email을 to_thread로 넘기는지, 메인 루프 스레드
+    식별로 직접 증명(실 DB/HTTP 없이 함수 소스만으로는 증명 안 됨 — 실행으로 잡는다)."""
+    import uuid
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.routers import cron
+
+    main_thread = threading.current_thread()
+    seen_threads: list[threading.Thread] = []
+
+    def _fake_send_email(to, subject, html):
+        seen_threads.append(threading.current_thread())
+        return True
+
+    org_id = uuid.uuid4()
+    sub = SimpleNamespace(
+        id=uuid.uuid4(), org_id=org_id, tier="pro", storage_warn_notified_at=None,
+    )
+
+    # 실 함수 본문의 session.execute 호출 순서 그대로 흉내(cron.py::storage_usage_warn):
+    # ①subs(active OrgSubscription) 목록 ②caps(offering_versions) ③used bytes 합계
+    # (cap의 80% 이상이 되도록·cooldown 미적용이라 바로 발송 분기) ④owner/admin 이메일 목록
+    # ⑤storage_warn_notified_at 갱신 UPDATE.
+    cap_mb = 1000
+    used_bytes = int(cap_mb * 1024 * 1024 * 0.9)  # 90% — 경고 임계(80%) 초과
+    responses = [
+        lambda r: setattr(r.scalars.return_value.all, "return_value", [sub]),
+        lambda r: setattr(r.all, "return_value", [("pro", cap_mb)]),
+        lambda r: setattr(r.scalar_one, "return_value", used_bytes),
+        lambda r: setattr(r.all, "return_value", [("owner@example.com",)]),
+        lambda r: None,  # UPDATE storage_warn_notified_at — 반환값 미사용.
+    ]
+    call_count = 0
+
+    async def _execute(stmt, *a, **kw):
+        nonlocal call_count
+        result = MagicMock()
+        if call_count < len(responses):
+            responses[call_count](result)
+        call_count += 1
+        return result
+
+    mock_session = AsyncMock()
+    mock_session.execute = _execute
+    mock_session.commit = AsyncMock()
+
+    with patch.object(cron, "send_email", side_effect=_fake_send_email), \
+         patch.object(cron, "verify_cron", return_value=None):
+        await cron.storage_usage_warn(MagicMock(), session=mock_session)
+
+    assert len(seen_threads) == 1, (
+        f"send_email이 정확히 1회 호출됐어야 한다(호출 {len(seen_threads)}회) — 픽스처 mock "
+        "순서를 다시 확인할 것"
+    )
+    assert seen_threads[0] is not main_thread, (
+        "send_email이 메인 이벤트루프 스레드에서 그대로 실행됨 — asyncio.to_thread 포장이 "
+        "빠졌거나 회귀했다(story #2041 재발)"
+    )


### PR DESCRIPTION
## Summary
[SID:2041]

⚠️**머지 보류** — A/B/C와 동일 취급, 오늘 밤 promote(실시간성+토스 검증 범위) 이후로. PR 오픈·QA는 지금 진행(페드루 PO 지시). 이로써 [커넥션 장기점유 제거 — 재실측 그라운딩 (#2041, 2026-08-25)](https://) doc 67b44d1e의 소PR 절단 4개(A/B/C/D) 전부 오픈 완료.

재실측 그라운딩 지점①-storage — `assets-grace-hard-delete`(최대 500건 순차 GCS 삭제)·`storage-usage-warn`(동기 `send_email`) 두 크론이 요청 primary pool 세션을 붙든 채 돌았다. `storage-usage-warn`이 더 나쁨(`send_email`이 완전 동기라 세션 점유+이벤트루프 블록 동시 발생 — GA4(#3493)와 동일 클래스).

처방(`embedding_backlog.py` #2461 패턴 재사용, 새 메커니즘 발명 0):
1. 두 엔드포인트 모두 `Depends(get_db)`→`Depends(get_worker_db)` 이관. GCS `delete_object`는 `storage/gcs.py` 내부에서 이미 `to_thread` 포장돼 있어 이벤트루프 블록은 원래 없었음(풀 이관만으로 충분).
2. `storage_usage_warn`의 `send_email(em, subject, html)` 호출을 `asyncio.to_thread`로 포장.

## Test plan
- [x] 신규 3건(`test_2041_storage_crons_worker_pool.py`) — 엔드포인트 의존성 배선 고정 2건 + `send_email`이 메인 이벤트루프 스레드가 아닌 별도 스레드에서 실행됨을 직접 증명 1건
- [x] 인접 cron/worker-pool 회귀 22건 — 무회귀
- [ ] realdb 스위트(`test_asset_registry_realdb.py`·`test_2906_storage_quota_enforcement_realdb.py`)는 이 세션 로컬 scratch PG(마이그 미적용)로는 검증 불가 — **무수정 develop HEAD에서도 동일 실패**함을 diff-only 대조로 확認(사전 존재 환경 갭, 이 PR의 회귀 아님) — CI의 alembic-fresh-db 잡이 최종 판정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sug9Biqoh5ZKVmMFEHbtY