### PR TITLE
feat(#2254): 스토리 description/acceptance_criteria 원자적 append+1-depth 되돌리기

### DIFF
--- a/backend/alembic/versions/0281_story_previous_description_ac.py
+++ b/backend/alembic/versions/0281_story_previous_description_ac.py
@@ -1,0 +1,31 @@
+"""story #2254(그라운딩 doc e5bc0789, 2026-08-25) — 스토리 본문 덧붙이기·되돌리기.
+
+description/acceptance_criteria 통째 교체로 조사 기록을 잃는 실사고(디디 자진 보고,
+2026-07-28)의 남은 갭 — append 능력(원자적 이어붙이기)과 직전 값 1-depth 되돌리기.
+shrink-guard(#2346)·낙관적 동시성(#2868)은 이미 있어 이번엔 이 컬럼 2개만 추가.
+
+nullable — 기존 row는 previous_*가 없는 게 정상(과거 이력을 소급 생성하지 않음).
+
+Revision ID: 0281
+Revises: 0280
+Create Date: 2026-08-25
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0281"
+down_revision = "0280"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("stories", sa.Column("previous_description", sa.Text(), nullable=True))
+    op.add_column("stories", sa.Column("previous_acceptance_criteria", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("stories", "previous_acceptance_criteria")
+    op.drop_column("stories", "previous_description")

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -152,6 +152,12 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     story_points: Mapped[int | None] = mapped_column(Integer, nullable=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     acceptance_criteria: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #2254(그라운딩 doc e5bc0789, 2026-08-25) — 직전 값 1-depth 스냅샷(전체 히스토리
+    # 아님, 사고 직후 1회 복구가 목표). description/acceptance_criteria가 plain/append/
+    # restore 어느 경로로든 «실제로» 바뀌는 매 update마다 라우터(stories.py::update_story)가
+    # 적용 前 현재 값을 여기 덮어쓴다. restore_*=True 요청은 여기 값을 읽어 현재값과 swap.
+    previous_description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    previous_acceptance_criteria: Mapped[str | None] = mapped_column(Text, nullable=True)
     position: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     # E-CAGE-REFEREE P1: 데이터 오염 마킹 (삭제 아닌 플래그, 신뢰점수 집계 제외용)
     is_excluded: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false", default=False)

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -2099,13 +2099,44 @@ async def update_story(
     # assignee_ids만 제공되면 단일 assignee_id(주담당)를 첫 요소로 동기화 → 기존 event/notify 로직 재사용.
     if assignee_ids_in is not None and "assignee_id" not in data:
         data["assignee_id"] = assignee_ids_in[0] if assignee_ids_in else None
+    # story #2254(그라운딩 doc e5bc0789, 2026-08-25) — append/restore도 stories 컬럼이
+    # 아니므로 분리(allow_shrink와 동형). 실제 반영은 아래 story_before 조회 블록에서.
+    _append_by_field = {
+        "description": data.pop("description_append", None),
+        "acceptance_criteria": data.pop("acceptance_criteria_append", None),
+    }
+    _restore_by_field = {
+        "description": data.pop("restore_description", False),
+        "acceptance_criteria": data.pop("restore_acceptance_criteria", False),
+    }
+    # 같은 필드에 plain/append/restore 중 둘 이상이 동시에 오면 호출 의도가 모호하다 —
+    # 조용히 아무거나 골라 처리하지 않고 즉시 거부(#2254 AC2: "어느 쪽인지 부르는 쪽이
+    # 알 수 있게" — 서버가 대신 추측하지 않는 것도 그 원칙의 일부).
+    for _f in _LENGTH_TRACKED_FIELDS:
+        _modes_set = sum((
+            _f in data, _append_by_field[_f] is not None, bool(_restore_by_field[_f]),
+        ))
+        if _modes_set > 1:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "AMBIGUOUS_UPDATE_MODE",
+                    "message": f"{_f}에 plain 값/append/restore 중 하나만 지정하세요(동시 지정 불가).",
+                },
+            )
+    _restore_driven_fields = {f for f in _LENGTH_TRACKED_FIELDS if _restore_by_field[f]}
     old_assignee_id: uuid.UUID | None = None
     old_position: int | None = None
     old_field_lengths: dict[str, int] = {}
     story_before = None
     # story #2172 AC2: position 변경도 old-value 대조가 필요해 assignee_id와 같은 사전조회를 공유.
     # story #2346 AC3: 긴 텍스트 필드 급감 기록도 같은 사전조회(repo.update() 前 old 값)가 필요.
-    if "assignee_id" in data or "position" in data or any(f in data for f in _LENGTH_TRACKED_FIELDS):
+    # story #2254: append/restore도 old 값(이어붙일 대상·되돌릴 previous_*)이 있어야 계산 가능
+    # 하므로 같은 사전조회를 공유.
+    if (
+        "assignee_id" in data or "position" in data or any(f in data for f in _LENGTH_TRACKED_FIELDS)
+        or any(v is not None for v in _append_by_field.values()) or _restore_driven_fields
+    ):
         story_before = await repo.get(id)
         if story_before:
             old_assignee_id = story_before.assignee_id
@@ -2113,9 +2144,38 @@ async def update_story(
             # ⛔story_before는 같은 세션의 identity map이라 repo.update() 뒤 story와 «같은
             # 객체»가 된다(속성이 그 자리서 덮어써짐) — old_assignee_id/old_position처럼
             # «스칼라 값»으로 지금 떠 둬야 update 前 값을 실제로 보존한다.
+            # story #2254 AC1 — append: 서버측 원자적 이어붙이기(클라 read-modify-write
+            # 경합을 애초에 제거 — #2254 사고의 근본원인).
+            for _f, _append_val in _append_by_field.items():
+                if _append_val is None:
+                    continue
+                _cur = getattr(story_before, _f) or ""
+                data[_f] = f"{_cur}\n\n{_append_val}" if _cur else _append_val
+            # story #2254 AC3 — restore: previous_* ↔ 현재값 swap(되돌리기 자체도 되돌릴
+            # 수 있게 — 별도 구현 없이 이 규칙에서 공짜로 성립).
+            for _f in _restore_driven_fields:
+                _prev_val = getattr(story_before, f"previous_{_f}")
+                if not _prev_val:
+                    raise HTTPException(
+                        status_code=422,
+                        detail={
+                            "code": "NOTHING_TO_RESTORE",
+                            "message": f"{_f}에 되돌릴 직전 값이 없습니다.",
+                        },
+                    )
+                data[_f] = _prev_val
+            # story #2254 AC3 — 실제로 값이 바뀌는 tracked field는 적용 前 old 값을
+            # previous_*에 1-depth 스냅샷(전체 히스토리 아님, 사고 직후 1회 복구가 목표).
+            # restore driven field는 shrink-guard 대상에서 뺀다 — 되돌리기는 명시적 의도된
+            # 행동이라 «축소=사고 신호» 전제가 안 맞는다(직전 값이 현재보다 짧아도 정상).
             for _f in _LENGTH_TRACKED_FIELDS:
-                if _f in data:
-                    old_field_lengths[_f] = len(getattr(story_before, _f) or "")
+                if _f not in data:
+                    continue
+                _old_val = getattr(story_before, _f) or ""
+                if (data[_f] or "") != _old_val:
+                    data[f"previous_{_f}"] = _old_val
+                if _f not in _restore_driven_fields:
+                    old_field_lengths[_f] = len(_old_val)
     # ⛔story #2346 AC7: 긴 텍스트 필드가 50% 이상 줄면 거부 — 오늘 실제 3건 사고(모두 -80%대)가
     # 전부 이 게이트에 막혔을 것이다. allow_shrink=true로 명시 승인(정당한 축약)만 통과.
     if old_field_lengths and not allow_shrink:

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -165,6 +165,15 @@ class StoryUpdate(BaseModel):
     story_points: int | None = None
     description: str | None = None
     acceptance_criteria: str | None = None
+    # story #2254(그라운딩 doc e5bc0789, 2026-08-25) — 서버측 원자적 이어붙이기(클라
+    # read-modify-write 경합 자체를 제거, #2254 사고의 근본원인). plain description/
+    # acceptance_criteria와 동시 지정은 422(모호성 거부 — stories.py::update_story).
+    description_append: str | None = None
+    acceptance_criteria_append: str | None = None
+    # story #2254 — 직전 값(previous_description/previous_acceptance_criteria)과 현재값을
+    # swap. True면 되돌리기 자체도 되돌릴 수 있게(1-depth). plain/append와 동시 지정 시 422.
+    restore_description: bool = False
+    restore_acceptance_criteria: bool = False
     position: int | None = None
     # E-OUTCOME-LOOP: 의도 필드 (Update 허용)
     success_hypothesis: str | None = None
@@ -264,6 +273,10 @@ class StoryResponse(BaseModel):
     story_points: int | None = None
     description: str | None = None
     acceptance_criteria: str | None = None
+    # story #2254 — 실 컬럼(ORM 그대로 노출). 값이 있으면 restore_description=true로 되돌릴
+    # 직전 값이 있다는 뜻(클라가 "되돌리기 가능" UI를 이 필드 존재로 판단할 수 있게).
+    previous_description: str | None = None
+    previous_acceptance_criteria: str | None = None
     position: int | None = None
     # E-OUTCOME-LOOP: 의도 필드
     success_hypothesis: str | None = None

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -117,6 +117,18 @@ class UpdateStoryInput(SprintableInput):
     # 자리). 이 필드가 없으면 «의도적으로» 줄이려는 정당한 요청도 되돌릴 방법이 없어 도구가
     # 그 상황에서 막다른 골목이 된다 — 단순 누락이 아니라 실제 워크플로우 차단이었다.
     allow_shrink: bool | None = None
+    # story #2254(그라운딩 doc e5bc0789, 2026-08-25) — 한 절을 덧붙이려고 description/
+    # acceptance_criteria 전문을 다시 보내다 기존 내용을 통째로 지운 실사고(디디 자진 보고,
+    # 2026-07-28)의 근본 처방. description_append/acceptance_criteria_append를 쓰면 서버가
+    # 「기존값+개행 2줄+이 값」을 원자적으로 이어붙인다(호출자가 현재값을 먼저 읽어올 필요
+    # 없음 — read-modify-write 경합 자체가 사라진다). plain description/acceptance_criteria와
+    # 동시 지정하면 BE가 422로 거부(호출 의도가 모호함 — 조용히 아무거나 고르지 않는다).
+    description_append: str | None = None
+    acceptance_criteria_append: str | None = None
+    # 직전 값(응답의 previous_description/previous_acceptance_criteria)으로 되돌린다(현재값과
+    # swap — 되돌리기 자체도 다시 되돌릴 수 있다). 되돌릴 직전 값이 없으면 BE가 422.
+    restore_description: bool | None = None
+    restore_acceptance_criteria: bool | None = None
 
 
 class AssignStoryToSprintInput(SprintableInput):
@@ -219,6 +231,11 @@ async def add_story(args: AddStoryInput) -> list[TextContent]:
 async def update_story(args: UpdateStoryInput) -> list[TextContent]:
     """스토리 수정.
 
+    ⭐한 절만 덧붙일 땐 description/acceptance_criteria에 전문을 다시 쓰지 말 것 —
+    description_append/acceptance_criteria_append를 쓰면 서버가 원자적으로 이어붙인다
+    (읽어와서 합쳐 재전송하다 실수로 기존 내용을 지우는 사고를 원천 차단, story #2254).
+    직전 값으로 되돌리려면 restore_description/restore_acceptance_criteria=true.
+
     story #2389 후속 — StoryUpdate에 있지만 이 도구에 «의도적으로 안 넣은» 셋:
       - position: 보드 드래그앤드롭 순서(정수, 이웃 상대적 계산 전제) — 자연어로 지시된 절대
         정수값을 그대로 넣으면 다른 카드들과의 순서가 어긋나기 쉽다. UI 드래그 전용으로 남긴다.
@@ -253,6 +270,14 @@ async def update_story(args: UpdateStoryInput) -> list[TextContent]:
         updates["measure_after"] = args.measure_after
     if args.allow_shrink is not None:
         updates["allow_shrink"] = args.allow_shrink
+    if args.description_append is not None:
+        updates["description_append"] = args.description_append
+    if args.acceptance_criteria_append is not None:
+        updates["acceptance_criteria_append"] = args.acceptance_criteria_append
+    if args.restore_description is not None:
+        updates["restore_description"] = args.restore_description
+    if args.restore_acceptance_criteria is not None:
+        updates["restore_acceptance_criteria"] = args.restore_acceptance_criteria
     if args.epic_id is not None:
         updates["epic_id"] = args.epic_id
     if args.declared_scope_paths is not None:

--- a/backend/tests/test_2254_story_append_undo_realdb.py
+++ b/backend/tests/test_2254_story_append_undo_realdb.py
@@ -1,0 +1,286 @@
+"""story #2254(그라운딩 doc e5bc0789, 2026-08-25) — 스토리 description/acceptance_criteria
+append+1-depth 되돌리기 회귀가드.
+
+핵심 검증축:
+①description_append — 원자적 이어붙이기(기존값+개행2줄+append값), previous_description에
+  이전값 스냅샷.
+②plain+append 동시 지정 — 422 AMBIGUOUS_UPDATE_MODE.
+③restore_description — previous_description↔description swap(되돌리기 자체도 되돌릴 수 있음).
+④previous_description 없이 restore 시도 — 422 NOTHING_TO_RESTORE.
+⑤restore는 shrink-guard를 우회한다(축소라도 allow_shrink 불요 — 명시적 의도된 행동).
+⑥acceptance_criteria도 description과 대칭으로 동작(append).
+⑦기존 plain full-replace 경로는 무회귀 — previous_description이 부수효과로 정확히 채워짐.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("22540000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("22540000-0000-0000-0000-000000000002")
+STORY = uuid.UUID("22540000-0000-0000-0000-000000000003")
+AGENT_IN = uuid.UUID("22540000-0000-0000-0000-0000000000a1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(AGENT_IN), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(ORG),
+    )
+
+
+async def _seed(s, *, description: str = "", acceptance_criteria: str = "",
+                 previous_description: str | None = None) -> None:
+    for sql in [
+        f"DELETE FROM activity_logs WHERE org_id='{ORG}'",
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','2254SD','s2254-org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_IN}','{ORG}','agent','AgentIn')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES ('{PROJ}','{AGENT_IN}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.execute(
+        text(
+            "INSERT INTO stories "
+            "(id,org_id,project_id,title,status,priority,description,acceptance_criteria,"
+            " previous_description,story_number) "
+            "VALUES (:id,:org,:proj,'test story','backlog','medium',:desc,:ac,:prev_desc,2254)"
+        ),
+        {
+            "id": STORY, "org": ORG, "proj": PROJ, "desc": description, "ac": acceptance_criteria,
+            "prev_desc": previous_description,
+        },
+    )
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _fetch_story(Session):
+    from app.models.pm import Story
+    from sqlalchemy import select
+    async with Session() as s:
+        return (await s.execute(select(Story).where(Story.id == STORY))).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_description_append_concatenates_atomically_and_snapshots_previous():
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s, description="Original findings.")
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            await update_story(
+                STORY, StoryUpdate(description_append="New appendix section."), bg,
+                repo=repo, db=s, auth=_auth(),
+            )
+            await bg()
+
+        story = await _fetch_story(Session)
+        assert story.description == "Original findings.\n\nNew appendix section.", story.description
+        assert story.previous_description == "Original findings."
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_plain_and_append_together_rejected_422():
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s, description="Original.")
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            with pytest.raises(HTTPException) as exc_info:
+                await update_story(
+                    STORY, StoryUpdate(description="Replaced whole.", description_append="Also this."), bg,
+                    repo=repo, db=s, auth=_auth(),
+                )
+            assert exc_info.value.status_code == 422
+            assert exc_info.value.detail["code"] == "AMBIGUOUS_UPDATE_MODE"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_restore_description_swaps_current_and_previous():
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s, description="Current value.", previous_description="Older value.")
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            await update_story(
+                STORY, StoryUpdate(restore_description=True), bg, repo=repo, db=s, auth=_auth(),
+            )
+            await bg()
+
+        story = await _fetch_story(Session)
+        assert story.description == "Older value.", "restore가 previous_description으로 되돌리지 않음"
+        assert story.previous_description == "Current value.", (
+            "restore 자체도 되돌릴 수 있어야 한다(swap) — previous_*에 되돌리기 前 현재값이 남아야 함"
+        )
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_restore_without_previous_value_rejected_422():
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s, description="Only current, no history.")  # previous_description=None
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            with pytest.raises(HTTPException) as exc_info:
+                await update_story(
+                    STORY, StoryUpdate(restore_description=True), bg, repo=repo, db=s, auth=_auth(),
+                )
+            assert exc_info.value.status_code == 422
+            assert exc_info.value.detail["code"] == "NOTHING_TO_RESTORE"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_restore_bypasses_shrink_guard_without_allow_shrink():
+    """⑤ — restore는 명시적 의도(되돌리기)라 shrink-guard(#2346 AC7)를 우회한다. 여기서
+    previous_description(50자)이 현재값(3000자)보다 훨씬 짧아 allow_shrink=false로도
+    통과해야 한다(일반 plain 축소였다면 400으로 막혔을 크기)."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        long_current = "x" * 3000
+        short_previous = "y" * 50
+        async with Session() as s:
+            await _seed(s, description=long_current, previous_description=short_previous)
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            # allow_shrink 미지정(기본 False) — 그래도 restore는 통과해야 한다.
+            await update_story(
+                STORY, StoryUpdate(restore_description=True), bg, repo=repo, db=s, auth=_auth(),
+            )
+            await bg()
+
+        story = await _fetch_story(Session)
+        assert story.description == short_previous
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_acceptance_criteria_append_symmetric_with_description():
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s, acceptance_criteria="AC1: base criterion.")
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            await update_story(
+                STORY, StoryUpdate(acceptance_criteria_append="AC2: added criterion."), bg,
+                repo=repo, db=s, auth=_auth(),
+            )
+            await bg()
+
+        story = await _fetch_story(Session)
+        assert story.acceptance_criteria == "AC1: base criterion.\n\nAC2: added criterion."
+        assert story.previous_acceptance_criteria == "AC1: base criterion."
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_plain_full_replace_still_snapshots_previous_no_regression():
+    """⑦ — 기존 plain full-replace 경로(append/restore 미사용)는 그대로 동작하되,
+    previous_description이 부수효과로 정확히 채워진다(회귀 아님·의도된 확장)."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import update_story
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s, description="Before replace.")
+
+        async with Session() as s:
+            repo = StoryRepository(s, ORG)
+            bg = BackgroundTasks()
+            await update_story(
+                STORY, StoryUpdate(description="After replace."), bg, repo=repo, db=s, auth=_auth(),
+            )
+            await bg()
+
+        story = await _fetch_story(Session)
+        assert story.description == "After replace."
+        assert story.previous_description == "Before replace."
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_e_cage_referee_p1_exclusion.py
+++ b/backend/tests/test_e_cage_referee_p1_exclusion.py
@@ -122,6 +122,9 @@ async def test_patch_story_is_excluded_true():
     marked_story.story_points = 3
     marked_story.description = None
     marked_story.acceptance_criteria = None
+    # story #2254 — 신규 필드(위 파일들의 기존 "MagicMock 자동 속성" 경고와 동일 이유로 명시 세팅).
+    marked_story.previous_description = None
+    marked_story.previous_acceptance_criteria = None
     marked_story.position = None
     marked_story.is_excluded = True  # 마킹됨
     marked_story.success_hypothesis = None

--- a/backend/tests/test_e_cage_referee_p1_participation_api.py
+++ b/backend/tests/test_e_cage_referee_p1_participation_api.py
@@ -44,6 +44,9 @@ def _mock_story_obj(assignee_id=None):
     s.story_points = 3
     s.description = None
     s.acceptance_criteria = None
+    # story #2254 — 신규 필드(MagicMock 자동 속성이 Pydantic 검증 실패시키므로 명시 세팅).
+    s.previous_description = None
+    s.previous_acceptance_criteria = None
     s.position = None
     s.is_excluded = False
     s.success_hypothesis = None

--- a/backend/tests/test_e_event_inject_s3_assignment_wake.py
+++ b/backend/tests/test_e_event_inject_s3_assignment_wake.py
@@ -46,6 +46,9 @@ def _story(assignee_id):
     s.priority = "medium"
     s.story_points = None
     s.acceptance_criteria = None
+    # story #2254 — 신규 필드(MagicMock 자동 속성이 Pydantic 검증 실패시키므로 명시 세팅).
+    s.previous_description = None
+    s.previous_acceptance_criteria = None
     s.position = None
     s.is_excluded = False
     s.success_hypothesis = None

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -42,6 +42,9 @@ def _mock_story(status: str = "backlog") -> MagicMock:
     s.story_points = 3
     s.description = None
     s.acceptance_criteria = None
+    # story #2254 — 신규 필드(위 주석의 "매번 명시 세팅" 경고 그대로 적용).
+    s.previous_description = None
+    s.previous_acceptance_criteria = None
     s.position = None
     # E-CAGE-REFEREE P1: 오염 마킹 필드
     s.is_excluded = False


### PR DESCRIPTION
## Summary
[SID:2254]

⚠️**머지 보류 예상** — #2041 PR들과 같은 취급일 가능성 높음(오늘 밤 promote 이후), 페드루 PO 확認 예정. PR 오픈·QA는 지금 진행.

재실측 그라운딩([스토리 본문 덧붙이기·되돌리기 — 재실측 그라운딩+설계 (#2254, 2026-08-25)](https://) doc e5bc0789) 결과 — shrink-guard(#2346)·낙관적 동시성(#2868)은 이미 있어 진짜 남은 갭은 AC1(append)+AC3(직전 값 1-step 되돌리기)뿐. 한 절 덧붙이려다 `description` 전문을 잘못 다시 보내 조사 기록을 통째로 잃은 실사고(디디 자진 보고, 2026-07-28)의 근본 처방.

- `Story.previous_description`/`previous_acceptance_criteria` 신설(migration 0281, nullable Text — 1-depth만, 전체 히스토리 아님).
- `StoryUpdate`에 `description_append`/`acceptance_criteria_append`(서버측 원자적 이어붙이기 — 클라 read-modify-write 경합 자체를 제거) + `restore_description`/`restore_acceptance_criteria`(현재↔previous swap — 되돌리기 자체도 되돌릴 수 있음) 4개 파라미터 추가.
- `update_story`: plain/append/restore 동시 지정 시 422 `AMBIGUOUS_UPDATE_MODE`(호출 의도 모호성 거부). restore 대상에 `previous_*`가 없으면 422 `NOTHING_TO_RESTORE`. restore는 명시적 의도된 행동이라 shrink-guard(#2346 AC7)를 우회. 실제로 값이 바뀌는 매 update마다 `previous_*`에 old 값 1-depth 스냅샷.
- MCP tool(`sprintable_mcp/tools/stories.py::update_story`) 같은 사이클에 포함(페드루 PO 지시 — 같은 리포 `backend/sprintable_mcp`, hosted MCP dev cloudbuild 자동배포라 머지가 곧 함대 도달).

## Test plan
- [x] 신규 7건(`test_2254_story_append_undo_realdb.py`) — append 원자성+snapshot / plain+append 동시 422 / restore swap / restore 前 previous 없음 422 / restore가 shrink-guard 우회 / AC 대칭 / 기존 plain 경로 무회귀
- [x] shrink-guard(#2346) 8건 + CAS(#2874) 7건 + `test_stories.py` 27건 — 전부 fresh migrated PG(`alembic upgrade heads` 실제 완주)로 GREEN
- [x] 부수 발견·수정: `test_stories.py`의 MagicMock 픽스처가 신규 필드에 명시 None 세팅이 누락돼 있던 것(파일 자체의 기존 경고 주석대로) 발견 즉시 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sug9Biqoh5ZKVmMFEHbtY