### PR TITLE
feat(#3094): 결재 카드 재토스 응답에 inserted 플래그 추가 — BE

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1898,14 +1898,22 @@ class GateTossRequest(BaseModel):
     target_conversation_id: uuid.UUID
 
 
-@router.post("/{id}/toss", response_model=GateResponse)
+class GateTossResponse(GateResponse):
+    # story #3094(2026-08-26, #3492 리뷰 "알려진 축소" 잔여분) — dispatch_approval_card_toss가
+    # 이미 신규삽입/멱등no-op을 bool로 구분해 반환하는데(#3488 PO 비차단 관찰 — False는 오직
+    # 멱등만 의미) 이 값이 HTTP 응답까지 안 올라와 FE가 "이미 있음" 여부를 알 방법이 없었다.
+    # additive(GateResponse 상속, 기존 필드 비파괴) — 게이트 멱등 시맨틱스·단일 처리는 불변.
+    inserted: bool
+
+
+@router.post("/{id}/toss", response_model=GateTossResponse)
 async def toss_gate_endpoint(
     id: uuid.UUID,
     body: GateTossRequest,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
-) -> GateResponse:
+) -> GateTossResponse:
     """story #3084(2026-08-25, 선생님 지시 — 결재 카드 «토스») — 상신자 또는 designated
     결재자 본인이, designated 본인이 참여한 다른 conversation에 카드 **사본**을 심는다
     (원 카드 잔존). #3001 delegate("사람" 축 — 정체성 재지정)와 다른 "방" 축(같은
@@ -1989,7 +1997,7 @@ async def toss_gate_endpoint(
             session, _gate, target_conversation_id=body.target_conversation_id, tossed_by_id=resolved.id,
         )
 
-    return GateResponse.model_validate(_gate)
+    return GateTossResponse(**GateResponse.model_validate(_gate).model_dump(), inserted=inserted)
 
 
 class GateReassignRequest(BaseModel):

--- a/backend/tests/test_3084_gate_toss_realdb.py
+++ b/backend/tests/test_3084_gate_toss_realdb.py
@@ -189,6 +189,7 @@ async def test_toss_success_inserts_copy_and_broadcasts_and_logs():
                 json={"target_conversation_id": str(seeded["target_conversation_id"])},
             )
             assert resp.status_code == 200, resp.text
+            assert resp.json()["inserted"] is True  # story #3094 — 신규 삽입 시 inserted=True.
         finally:
             await client.aclose()
 
@@ -317,12 +318,16 @@ async def test_toss_idempotent_no_duplicate_copy_on_retoss():
         await _setup_app(app, Session, seeded["org_id"], seeded["designated_user_id"])
         client = _client_for(app)
         try:
-            for _ in range(2):
+            # story #3094 — 신규 삽입(1회차)은 inserted=True, 재토스(2회차, 멱등 no-op)는
+            # inserted=False. FE가 이 값으로 «이미 있음» 칩/토스트 문구를 구분한다.
+            expected_inserted = [True, False]
+            for expected in expected_inserted:
                 resp = await client.post(
                     f"/api/v2/gates/{seeded['gate_id']}/toss",
                     json={"target_conversation_id": str(seeded["target_conversation_id"])},
                 )
                 assert resp.status_code == 200, resp.text
+                assert resp.json()["inserted"] is expected, resp.text
         finally:
             await client.aclose()
 


### PR DESCRIPTION
[SID:3094]

## 요약
- #3084 PR#3492 리뷰에서 "알려진 축소"로 분리했던 잔여분 — BE 절반.
- `dispatch_approval_card_toss`는 이미 신규삽입/멱등no-op을 bool로 구분해 반환하는데(#3488 PO 비차단 관찰) 이 값이 HTTP 응답까지 안 올라와 FE가 "이미 있음" 여부를 알 방법이 없었다.
- `GateTossResponse(GateResponse)` 신설, `inserted: bool` 추가 — additive, 기존 필드/타 gate 엔드포인트 응답 shape 비파괴. 게이트 멱등 시맨틱스·단일 처리 불변.

## 검증
- `test_3084_gate_toss_realdb.py` 8건 전수 GREEN(로컬 실PG, disposable db, create_all).
  - 신규 assert: 신규삽입 시 `inserted=True`, 재토스(멱등 no-op) 시 `inserted=False`.
- 인접 회귀(gate PR-scope/slot/sha-race/wake/merge-card realdb) 28건 무회귀.

## 후속
FE("이미 있음" 칩 + 토스트 문구 정정, 유나 규격 c40bf168 SSOT)는 별도 PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>