### PR TITLE
feat(#3094): 재토스 «이미 있음» 칩 + no-op 토스트 문구 정정 — FE

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3489,6 +3489,8 @@
     "approvalRequestTossEmptyTitle": "No conversations to send to",
     "approvalRequestTossEmptyBody": "{name} needs to be in a conversation first",
     "approvalRequestTossSuccessToast": "Sent to {conversation}",
+    "approvalRequestTossAlreadyThereChip": "Already there",
+    "approvalRequestTossAlreadyThereToast": "Already in {conversation}",
     "approvalRequestDelegate": "Delegate to another approver",
     "approvalRequestDelegateLoading": "Loading…",
     "approvalRequestDelegatePickPlaceholder": "Choose an approver",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3489,6 +3489,8 @@
     "approvalRequestTossEmptyTitle": "보낼 수 있는 대화가 없습니다",
     "approvalRequestTossEmptyBody": "{name}님이 참여한 대화가 필요합니다",
     "approvalRequestTossSuccessToast": "{conversation}(으)로 보냈습니다",
+    "approvalRequestTossAlreadyThereChip": "이미 있음",
+    "approvalRequestTossAlreadyThereToast": "{conversation}에 이미 있습니다",
     "approvalRequestDelegate": "다른 결재자에게 위임",
     "approvalRequestDelegateLoading": "불러오는 중…",
     "approvalRequestDelegatePickPlaceholder": "위임할 결재자 선택",

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -599,8 +599,13 @@ function ApprovalRequestBody({
           currentTeamMemberId={currentTeamMemberId ?? ''}
           designatedApproverId={gate.designated_approver_id ?? ''}
           designatedApproverName={designatedApproverName}
-          onTossed={(conversationTitle) => {
-            addToast({ type: 'info', title: t('approvalRequestTossSuccessToast', { conversation: conversationTitle }) });
+          onTossed={(conversationTitle, inserted) => {
+            addToast({
+              type: 'info',
+              title: inserted
+                ? t('approvalRequestTossSuccessToast', { conversation: conversationTitle })
+                : t('approvalRequestTossAlreadyThereToast', { conversation: conversationTitle }),
+            });
             onUndone();
           }}
           onAlreadyResolved={() => {

--- a/apps/web/src/components/chat/toss-sheet.test.tsx
+++ b/apps/web/src/components/chat/toss-sheet.test.tsx
@@ -93,12 +93,12 @@ describe('TossSheet — 대상 피커(designated 참여 대화만)', () => {
 });
 
 describe('TossSheet — 제출(성공/409/기타 에러)', () => {
-  it('선택 후 보내기 — 성공 시 onTossed(대상 이름)+onOpenChange(false)', async () => {
+  it('선택 후 보내기 — 성공(신규 삽입) 시 onTossed(대상 이름, inserted=true)+onOpenChange(false)', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
       if (init?.method === 'POST') {
         expect(url).toContain('/api/gates/gate-1/toss');
         expect(JSON.parse(init.body ?? '{}')).toEqual({ target_conversation_id: 'conv-3' });
-        return { ok: true, json: async () => ({ data: {} }) };
+        return { ok: true, json: async () => ({ inserted: true }) };
       }
       return { ok: true, json: async () => ({ data: CONVERSATIONS }) };
     }));
@@ -111,8 +111,74 @@ describe('TossSheet — 제출(성공/409/기타 에러)', () => {
     await act(async () => { sendBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 
-    expect(onTossed).toHaveBeenCalledWith('릴리스 채널');
+    expect(onTossed).toHaveBeenCalledWith('릴리스 채널', true);
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('재토스(멱등 no-op) — onTossed(대상 이름, inserted=false)+재오픈 시 «이미 있음» 칩(story #3094)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      if (init?.method === 'POST') {
+        expect(url).toContain('/api/gates/gate-1/toss');
+        expect(JSON.parse(init.body ?? '{}')).toEqual({ target_conversation_id: 'conv-3' });
+        return { ok: true, json: async () => ({ inserted: false }) };
+      }
+      return { ok: true, json: async () => ({ data: CONVERSATIONS }) };
+    }));
+    const onTossed = vi.fn();
+    const onAlreadyResolved = vi.fn();
+    let isOpen = true;
+    const onOpenChange = vi.fn((next: boolean) => { isOpen = next; });
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <TossSheet
+            open={isOpen}
+            onOpenChange={onOpenChange}
+            gateId="gate-1"
+            projectId="proj-1"
+            currentTeamMemberId="member-1"
+            designatedApproverId="member-9"
+            designatedApproverName="선생님"
+            onTossed={onTossed}
+            onAlreadyResolved={onAlreadyResolved}
+          />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const row = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent?.includes('릴리스 채널'));
+    await act(async () => { row?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const sendBtn = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent === koMessages.chats.approvalRequestTossSend);
+    await act(async () => { sendBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(onTossed).toHaveBeenCalledWith('릴리스 채널', false);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    // 재오픈(재토스 진입) — 같은 인스턴스가 학습한 «이미 있음» 칩이 그 대상에 사전 표시된다.
+    isOpen = true;
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <TossSheet
+            open={isOpen}
+            onOpenChange={onOpenChange}
+            gateId="gate-1"
+            projectId="proj-1"
+            currentTeamMemberId="member-1"
+            designatedApproverId="member-9"
+            designatedApproverName="선생님"
+            onTossed={onTossed}
+            onAlreadyResolved={onAlreadyResolved}
+          />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const reopenedRow = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent?.includes('릴리스 채널'));
+    expect(reopenedRow?.textContent).toContain(koMessages.chats.approvalRequestTossAlreadyThereChip);
   });
 
   it('보내기 버튼은 선택 전엔 비활성', async () => {

--- a/apps/web/src/components/chat/toss-sheet.tsx
+++ b/apps/web/src/components/chat/toss-sheet.tsx
@@ -184,7 +184,10 @@ export function TossSheet({
                   </span>
                   <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">{name}</span>
                   {alreadyThere ? (
-                    <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10.5px] font-semibold text-primary">
+                    // 유나 규격 정정(design gate 반려, 2026-08-26) — text-primary는 bg-primary/10
+                    // 위에서 opacity-70(부모 row)과 겹치면 라이트 2.83/다크 3.04로 AA 미달
+                    // (hover 시 더 낮음). text-foreground는 같은 조건에서 5.4~6.9 PASS.
+                    <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10.5px] font-semibold text-foreground">
                       {t('approvalRequestTossAlreadyThereChip')}
                     </span>
                   ) : (

--- a/apps/web/src/components/chat/toss-sheet.tsx
+++ b/apps/web/src/components/chat/toss-sheet.tsx
@@ -41,9 +41,9 @@ export interface TossSheetProps {
   currentTeamMemberId: string;
   designatedApproverId: string;
   designatedApproverName: string | null;
-  /** 200 성공(신규 삽입이든 기존 사본 재확인이든 — BE가 멱등이라 구분 안 함, story #3084
-   * dispatch_approval_card_toss 멱등 계약). 호출부가 성공 토스트+게이트 재조회를 담당. */
-  onTossed: (targetConversationTitle: string) => void;
+  /** 200 성공 — inserted=신규 삽입 여부(story #3094, GateTossResponse.inserted). false=멱등
+   * no-op(대상에 이미 카드 사본이 있었음). 호출부가 문구 분기+게이트 재조회를 담당. */
+  onTossed: (targetConversationTitle: string, inserted: boolean) => void;
   /** 409(gate_already_resolved) — 시트를 닫고 "이미 처리된 결재" 안내(유나 규격 §2). */
   onAlreadyResolved: () => void;
 }
@@ -57,11 +57,12 @@ export interface TossSheetProps {
  * 사람(requester/designated 본인) 스스로 그 방에 없으면 애초에 픽커에 골라 넣을 수 없는
  * 게 맞는 제약(비참여 방으로 몰래 보내는 경로 자체가 없다).
  *
- * ⚠️알려진 축소(2026-08-25, 미르코 그라운딩) — 유나 규격의 "이미 있음" 칩(이미 토스된
- * 대상 표시)은 BE에 "이 gate_id 카드가 이미 있는 conversation 목록"을 물을 데이터 소스가
- * 없어(PR#3488 계약에 미포함) 이번 스코프에서 뺐다. 이미 토스된 대상을 다시 선택해도
- * BE가 멱등으로 조용히 무해 처리(dispatch_approval_card_toss existing-check)하므로 기능
- * 정합성은 유지된다 — 사전 안내만 없을 뿐.
+ * story #3094(2026-08-26, 유나 규격 c40bf168 §2 SSOT) — 위 "알려진 축소" 후속. BE에
+ * "이 gate_id 카드가 이미 있는 conversation 전체 목록"을 물을 데이터 소스는 여전히 없다
+ * (신규 리스팅 엔드포인트는 이번 스코프 밖) — 대신 이 세션에서 실제로 토스를 시도한
+ * 대상만 결과(inserted)로 학습해 "이미 있음" 칩을 붙인다. 시트를 닫았다 다시 열어도(재토스
+ * 진입) 같은 TossSheet 인스턴스가 유지되는 한 칩이 남아 — 방금 토스했던 대상을 실수로
+ * 다시 골라도(멱등 자체는 무해) 사전에 "이미 있음"이 보인다.
  */
 export function TossSheet({
   open, onOpenChange, gateId, projectId, currentTeamMemberId, designatedApproverId, designatedApproverName,
@@ -74,6 +75,7 @@ export function TossSheet({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [alreadyThereIds, setAlreadyThereIds] = useState<Set<string>>(new Set());
   const fetchedRef = useRef(false);
 
   useEffect(() => {
@@ -113,8 +115,11 @@ export function TossSheet({
         body: JSON.stringify({ target_conversation_id: selectedId }),
       });
       if (res.ok) {
+        const body = await res.json().catch(() => null) as { inserted?: boolean } | null;
+        const inserted = body?.inserted ?? true;
+        setAlreadyThereIds((prev) => new Set(prev).add(selectedId));
         onOpenChange(false);
-        onTossed(target ? conversationDisplayName(target, currentTeamMemberId) : '');
+        onTossed(target ? conversationDisplayName(target, currentTeamMemberId) : '', inserted);
         return;
       }
       const body = await res.json().catch(() => null) as { error?: { message?: string; code?: string } } | null;
@@ -160,6 +165,8 @@ export function TossSheet({
             candidates.map((c) => {
               const name = conversationDisplayName(c, currentTeamMemberId);
               const selected = selectedId === c.id;
+              // story #3094(유나 규격 §2 .pick.done) — 이 세션에서 이미 토스 시도한 대상.
+              const alreadyThere = alreadyThereIds.has(c.id);
               return (
                 <button
                   key={c.id}
@@ -168,20 +175,27 @@ export function TossSheet({
                   aria-pressed={selected}
                   className={cn(
                     'flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left hover:bg-muted',
-                    selected && 'bg-muted'
+                    selected && 'bg-muted',
+                    alreadyThere && 'opacity-70'
                   )}
                 >
                   <span className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
                     {c.type === 'dm' ? <MessageSquare className="h-3.5 w-3.5" /> : <Users className="h-3.5 w-3.5" />}
                   </span>
                   <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">{name}</span>
-                  <span
-                    className={cn(
-                      'size-4 shrink-0 rounded-full border-2',
-                      selected ? 'border-primary bg-primary' : 'border-border'
-                    )}
-                    aria-hidden
-                  />
+                  {alreadyThere ? (
+                    <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10.5px] font-semibold text-primary">
+                      {t('approvalRequestTossAlreadyThereChip')}
+                    </span>
+                  ) : (
+                    <span
+                      className={cn(
+                        'size-4 shrink-0 rounded-full border-2',
+                        selected ? 'border-primary bg-primary' : 'border-border'
+                      )}
+                      aria-hidden
+                    />
+                  )}
                 </button>
               );
             })


### PR DESCRIPTION
[SID:3100]

## 요약
BE(PR#3497, PO AC PASS·head 02e3e7577)가 준 `GateTossResponse.inserted`를 소비해 #3492 "알려진 축소" 잔여분 마무리. 유나 규격 c40bf168 §2가 SSOT.

- 리스팅 엔드포인트는 여전히 없음(신규 BE 스코프 밖) — 전체 사전 목록 대신, 이 세션에서 실제로 토스를 시도한 대상만 결과(inserted)로 학습해 "이미 있음" 칩을 붙인다. 재토스 진입(시트 재오픈) 시 방금 보낸 대상이 사전 표시됨.
- `toss-sheet.tsx`: `onTossed(title, inserted)` — POST 응답의 `inserted`를 파싱해 콜백에 전달. `alreadyThereIds` 세션 상태로 칩 렌더(라디오 대체).
- `approval-request-card.tsx`: `inserted=false`면 "보냄" 토스트 대신 "이미 있음" 토스트로 분기.
- i18n(ko/en): `approvalRequestTossAlreadyThereChip`/`-Toast` 신설.
- `toss-sheet.test.tsx`: 신규삽입 케이스 `inserted` 값 검증 갱신 + 재토스(no-op) 케이스 신규(`onTossed(.., false)` + 재오픈 칩 표시).

## 검증
- vitest 511파일/4590건 GREEN(develop 기준 재설치 후 재확인).
- eslint 무경고 · `tsc --noEmit` 무오류 · `pnpm build` EXIT 0.

## 후속
라이브 검증은 BE PR#3497 develop 머지 + dev 배포 후.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
