### PR TITLE
[SID:3091] fix(#57526f21): [P1] iOS TestFlight 구글 로그인 후 404 — AASA 서빙

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,18 @@ NEXT_PUBLIC_FASTAPI_URL=http://localhost:8000
 # Frontend port (default: 3108)
 # PORT=3108
 
+# 모바일 앱 유니버설 링크(OAuth 복귀) 대상 origin — Apple/Android 앱 링크 검증파일이
+# 호스트별로 갈라지는 축(dev-app.sprintable.ai vs app.sprintable.ai). 이 값에 따라
+# /.well-known/apple-app-site-association의 iOS bundle id(.dev 접미) 도 갈린다.
+# 미설정 시 dev로 폴백 — prod 배포는 이 값을 반드시 https://app.sprintable.ai로 설정할 것
+# (PO/인프라 lane 설정 축, e-mobile-oauth-native-handoff-contract §2).
+MOBILE_APP_LINK_ORIGIN=https://dev-app.sprintable.ai
+
+# Apple Developer Team ID — /.well-known/apple-app-site-association 서빙에 필요.
+# 이 값이 없으면 AASA 라우트가 500(미구성)을 낸다 — Apple Developer 계정 값이라 리포에
+# 커밋하지 않고 배포 시 시크릿/env로 주입([P1] iOS TestFlight 구글 로그인 후 404 인시던트).
+APPLE_TEAM_ID=
+
 # -----------------------------------------------------------------------------
 # AI (optional — required for AI features)
 # -----------------------------------------------------------------------------

--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -222,6 +222,11 @@ jobs:
             # `tr '|' ','`로 콤마 복원한다(앱이 받는 최종 env var 값 자체는 무변경 — MCP_ALLOWED_HOSTS
             # 는 여전히 콤마구분).
             echo "mcp_allowed_hosts=sprintable-mcp-prod-787818285179.asia-northeast3.run.app|mcp.sprintable.ai" >> "$GITHUB_OUTPUT"
+            # [P1] iOS TestFlight 구글 로그인 후 404 인시던트(#3499 리뷰 delta) — AASA(apple-app-
+            # site-association) 라우트가 읽는 두 env. Team ID는 AASA 응답으로 공개되는 값이라
+            # 시크릿 아님(dev/prod 동일 계정). origin은 REALTIME_URL과 동일하게 호스트별로 갈린다.
+            echo "apple_team_id=JN798BC4KC" >> "$GITHUB_OUTPUT"
+            echo "mobile_app_link_origin=https://app.sprintable.ai" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
@@ -381,6 +386,10 @@ jobs:
             # cloudbuild.yaml deploy-mcp가 이 값이 비어 있으면 그 env var 자체를 안 실어(조건
             # 분기), dev 서비스에 새로 빈 문자열 env가 안 생긴다(오늘 실측 그대로 무변경).
             echo "mcp_allowed_hosts=" >> "$GITHUB_OUTPUT"
+            # [P1] iOS TestFlight 구글 로그인 후 404 인시던트(#3499 리뷰 delta) — prod 분기와
+            # 동일 이유, dev 호스트 값만 다르다.
+            echo "apple_team_id=JN798BC4KC" >> "$GITHUB_OUTPUT"
+            echo "mobile_app_link_origin=https://dev-app.sprintable.ai" >> "$GITHUB_OUTPUT"
           fi
 
       # story #3079(2026-08-25, #3070/#3031/#2089 근본원인 공통수정) — realtime path-filter
@@ -542,13 +551,17 @@ jobs:
           V_FRONTEND_MAX_INSTANCES: ${{ steps.env.outputs.frontend_max_instances }}
           V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED: ${{ steps.env.outputs.backend_sse_transient_replay_enabled }}
           V_MCP_ALLOWED_HOSTS: ${{ steps.env.outputs.mcp_allowed_hosts }}
+          # [P1] iOS TestFlight 구글 로그인 후 404 인시던트(#3499 리뷰 delta) — AASA 라우트가
+          # 읽는 env 2종. REALTIME_URL과 동일 패턴(env별 값·deploy-frontend --update-env-vars).
+          V_APPLE_TEAM_ID: ${{ steps.env.outputs.apple_team_id }}
+          V_MOBILE_APP_LINK_ORIGIN: ${{ steps.env.outputs.mobile_app_link_origin }}
         run: |
           # story #3079 — prod push는 위 gate 스텝이 안 돌아(if: target==dev) 빈 문자열이다.
           # 빈 값을 "false"(=배포 진행, 기존 fail-safe 방향과 동일)로 명시 치환 — cloudbuild.yaml
           # 쪽은 정확히 "true" 문자열만 스킵으로 취급하므로 다른 값은 전부 안전측(배포)이다.
           V_REALTIME_GCE_SKIP="${V_REALTIME_GCE_SKIP:-false}"
           V_REALTIME_CLOUDRUN_SKIP="${V_REALTIME_CLOUDRUN_SKIP:-false}"
-          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\",_MCP_ALLOWED_HOSTS=\"${V_MCP_ALLOWED_HOSTS}\",_EE_ENABLED=\"${V_EE_ENABLED}\",_LICENSE_CONSENT=\"${V_LICENSE_CONSENT}\",_TOSS_CLIENT_KEY=\"${V_TOSS_CLIENT_KEY}\",_NEXT_PUBLIC_APP_URL=\"${V_NEXT_PUBLIC_APP_URL}\",_REALTIME_GCE_SKIP=\"${V_REALTIME_GCE_SKIP}\",_REALTIME_CLOUDRUN_SKIP=\"${V_REALTIME_CLOUDRUN_SKIP}\""
+          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\",_MCP_ALLOWED_HOSTS=\"${V_MCP_ALLOWED_HOSTS}\",_EE_ENABLED=\"${V_EE_ENABLED}\",_LICENSE_CONSENT=\"${V_LICENSE_CONSENT}\",_TOSS_CLIENT_KEY=\"${V_TOSS_CLIENT_KEY}\",_NEXT_PUBLIC_APP_URL=\"${V_NEXT_PUBLIC_APP_URL}\",_REALTIME_GCE_SKIP=\"${V_REALTIME_GCE_SKIP}\",_REALTIME_CLOUDRUN_SKIP=\"${V_REALTIME_CLOUDRUN_SKIP}\",_APPLE_TEAM_ID=\"${V_APPLE_TEAM_ID}\",_MOBILE_APP_LINK_ORIGIN=\"${V_MOBILE_APP_LINK_ORIGIN}\""
           echo "substitutions=${SUBST}" >> "$GITHUB_OUTPUT"
 
       - name: Submit Cloud Build

--- a/apps/web/src/app/.well-known/apple-app-site-association/route.test.ts
+++ b/apps/web/src/app/.well-known/apple-app-site-association/route.test.ts
@@ -1,0 +1,32 @@
+// [P1] AASA 서버 조건(print-aasa.js --checklist) 3종 회귀가드: 무리다이렉트·Content-Type
+// 정확히 application/json(charset 파라미터 없이)·유효 JSON 본문.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { GET } from './route';
+
+const ENV_KEYS = ['APPLE_TEAM_ID', 'MOBILE_APP_LINK_ORIGIN'];
+
+describe('GET /.well-known/apple-app-site-association', () => {
+  beforeEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  it('serves 200 with exactly application/json (no charset) and no redirect when configured', async () => {
+    process.env['APPLE_TEAM_ID'] = 'JN798BC4KC';
+    process.env['MOBILE_APP_LINK_ORIGIN'] = 'https://app.sprintable.ai';
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    expect(res.headers.get('Location')).toBeNull();
+    const body = await res.json();
+    expect(body.applinks.details[0].appID).toBe('JN798BC4KC.com.moonklabs.sprintable');
+  });
+
+  it('fails loud (500, not a broken 200) when APPLE_TEAM_ID is missing on this deploy', async () => {
+    process.env['MOBILE_APP_LINK_ORIGIN'] = 'https://app.sprintable.ai';
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/src/app/.well-known/apple-app-site-association/route.ts
+++ b/apps/web/src/app/.well-known/apple-app-site-association/route.ts
@@ -1,0 +1,7 @@
+// §10.2 — iOS Universal Link 검증기가 인증 쿠키 없이 호출하는 자리(proxy.ts PUBLIC_PREFIX
+// '/.well-known/'). 본문은 native-app-links.ts 단일 출처.
+import { aasaRouteResponse } from '@/lib/native-app-links';
+
+export async function GET() {
+  return aasaRouteResponse();
+}

--- a/apps/web/src/app/apple-app-site-association/route.test.ts
+++ b/apps/web/src/app/apple-app-site-association/route.test.ts
@@ -1,0 +1,11 @@
+// 루트 폴백이 .well-known과 완전히 동일한 핸들러를 재수출하는지 확인 — 두 파일이 갈라져
+// 하나만 고쳐지는 드리프트를 막는다.
+import { describe, expect, it } from 'vitest';
+import { GET as rootGet } from './route';
+import { GET as wellKnownGet } from '../.well-known/apple-app-site-association/route';
+
+describe('GET /apple-app-site-association (root fallback)', () => {
+  it('re-exports the same handler as .well-known/apple-app-site-association', () => {
+    expect(rootGet).toBe(wellKnownGet);
+  });
+});

--- a/apps/web/src/app/apple-app-site-association/route.ts
+++ b/apps/web/src/app/apple-app-site-association/route.ts
@@ -1,0 +1,4 @@
+// 루트 경로 폴백 — 일부 구형 swcd가 `.well-known/` 전에 이 경로도 훑는다. proxy.ts
+// PUBLIC_PREFIX에 이미 '/apple-app-site-association'이 공개로 등록돼 있다(§10.2).
+// 본문은 .well-known 쪽과 완전히 동일 — native-app-links.ts 단일 출처를 그대로 재사용.
+export { GET } from '../.well-known/apple-app-site-association/route';

--- a/apps/web/src/app/native/oauth-return/page.tsx
+++ b/apps/web/src/app/native/oauth-return/page.tsx
@@ -1,0 +1,18 @@
+// [P1 인시던트] AASA 미서빙으로 유니버설 링크 복귀가 실패하면 인앱 브라우저가 이 경로를 직접
+// 로드한다 — 그 경우에도 raw 404는 안 된다(PO 지시). custom scheme 폴백은 별건 HOLD 스토리
+// (E-MOBILE OAuth 복귀 App Link 단일 의존 제거)라 여기서 자동 리다이렉트를 시도하지 않는다 —
+// 로그인 자체는 이미 끝났다는 것만 알리고 사용자가 직접 앱으로 돌아가게 안내한다.
+export const metadata = { title: 'Sprintable' };
+
+export default function NativeOauthReturnPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted px-4">
+      <div className="max-w-sm rounded-2xl bg-background p-8 text-center shadow-sm">
+        <h1 className="mb-2 text-lg font-semibold text-foreground">로그인이 완료됐습니다</h1>
+        <p className="text-sm text-muted-foreground">
+          이 화면은 닫으시고 Sprintable 앱으로 돌아가 주세요.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/native-app-links.test.ts
+++ b/apps/web/src/lib/native-app-links.test.ts
@@ -1,0 +1,71 @@
+// [P1] iOS TestFlight 구글 로그인 후 404 — AASA 미서빙 인시던트 회귀가드.
+// 기대값은 손으로 적지 않고 sprintable-mobile 레포의 `node scripts/print-aasa.js JN798BC4KC`
+// (prod)·`EXPO_PUBLIC_WEB_URL=https://dev-app.sprintable.ai node scripts/print-aasa.js
+// JN798BC4KC`(dev) 실측 출력을 그대로 옮겼다(2026-08-26) — 이 리포는 그 스크립트를 직접
+// import할 수 없어(별개 레포) 구조를 미러링하되 값은 실측 출력과 대조해 맞춘다.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildAasaDocument, MissingAppleTeamIdError } from './native-app-links';
+
+const ENV_KEYS = ['APPLE_TEAM_ID', 'MOBILE_APP_LINK_ORIGIN'];
+
+describe('buildAasaDocument', () => {
+  beforeEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  it('throws MissingAppleTeamIdError when APPLE_TEAM_ID is unset — must not silently serve a broken app id', () => {
+    process.env['MOBILE_APP_LINK_ORIGIN'] = 'https://app.sprintable.ai';
+    expect(() => buildAasaDocument()).toThrow(MissingAppleTeamIdError);
+  });
+
+  it('matches sprintable-mobile print-aasa.js prod output byte-for-byte in structure', () => {
+    process.env['APPLE_TEAM_ID'] = 'JN798BC4KC';
+    process.env['MOBILE_APP_LINK_ORIGIN'] = 'https://app.sprintable.ai';
+    const doc = buildAasaDocument();
+    expect(doc).toEqual({
+      applinks: {
+        apps: [],
+        details: [
+          {
+            appIDs: ['JN798BC4KC.com.moonklabs.sprintable'],
+            components: [
+              { '/': '/native/oauth-return*', comment: 'OAuth 복귀 — 앱이 안 잡으면 로그인이 브라우저에서 끝난다' },
+            ],
+            appID: 'JN798BC4KC.com.moonklabs.sprintable',
+            paths: ['/native/oauth-return*'],
+          },
+        ],
+      },
+    });
+  });
+
+  it('matches sprintable-mobile print-aasa.js dev output byte-for-byte in structure (.dev bundle suffix)', () => {
+    process.env['APPLE_TEAM_ID'] = 'JN798BC4KC';
+    process.env['MOBILE_APP_LINK_ORIGIN'] = 'https://dev-app.sprintable.ai';
+    const doc = buildAasaDocument();
+    expect(doc).toEqual({
+      applinks: {
+        apps: [],
+        details: [
+          {
+            appIDs: ['JN798BC4KC.com.moonklabs.sprintable.dev'],
+            components: [
+              { '/': '/native/oauth-return*', comment: 'OAuth 복귀 — 앱이 안 잡으면 로그인이 브라우저에서 끝난다' },
+            ],
+            appID: 'JN798BC4KC.com.moonklabs.sprintable.dev',
+            paths: ['/native/oauth-return*'],
+          },
+        ],
+      },
+    });
+  });
+
+  it('defaults to dev bundle id when MOBILE_APP_LINK_ORIGIN is unset — fail toward "developer notices", not "wrong app id in prod"', () => {
+    process.env['APPLE_TEAM_ID'] = 'JN798BC4KC';
+    const doc = buildAasaDocument();
+    expect(doc.applinks.details[0]?.appID).toBe('JN798BC4KC.com.moonklabs.sprintable.dev');
+  });
+});

--- a/apps/web/src/lib/native-app-links.ts
+++ b/apps/web/src/lib/native-app-links.ts
@@ -1,0 +1,69 @@
+// iOS Universal Link 검증파일(AASA, apple-app-site-association) 본문 — sprintable-mobile
+// 레포 lib/appLinks.js가 선언한 경로 단일 출처(`/native/oauth-return*`)를 미러링한다.
+// [P1 인시던트] 선생님 실기기 iOS TestFlight Google 로그인 후 404 — 이 파일이 여태 없어서
+// 유니버설 링크 복귀가 앱으로 반사되지 않고 웹이 직접 로드돼 404가 났다.
+//
+// 두 리포로 갈라진 선언이라(Android는 앱 매니페스트, iOS는 이 서버 파일) 손으로 옮겨 적으면
+// 드리프트가 생긴다 — `node scripts/print-aasa.js <TEAM_ID>` 실측 출력과 구조를 맞춘 값이다
+// (native-app-links.test.ts가 그 출력과 대조).
+import { NextResponse } from 'next/server';
+
+const APP_LINK_PATH = '/native/oauth-return*';
+const APP_LINK_COMMENT = 'OAuth 복귀 — 앱이 안 잡으면 로그인이 브라우저에서 끝난다';
+
+// mobile lib/webOrigin.js와 같은 규율: 기본값은 dev — 환경변수 설정을 까먹었을 때
+// "사용자에게 prod 앱ID가 잘못 박히는" 쪽이 아니라 "개발자가 알아채는" 쪽으로 실패해야 한다.
+const PROD_APP_LINK_ORIGIN = 'https://app.sprintable.ai';
+const DEV_APP_LINK_ORIGIN = 'https://dev-app.sprintable.ai';
+const BASE_BUNDLE_ID = 'com.moonklabs.sprintable';
+
+export function currentAppLinkOrigin(env: NodeJS.ProcessEnv = process.env): string {
+  return env['MOBILE_APP_LINK_ORIGIN']?.trim() || DEV_APP_LINK_ORIGIN;
+}
+
+// app.config.js(#2979)의 isDev 판정과 동형 — dev 호스트는 bundle id에 `.dev`가 붙는다.
+export function bundleIdForOrigin(origin: string): string {
+  return origin === PROD_APP_LINK_ORIGIN ? BASE_BUNDLE_ID : `${BASE_BUNDLE_ID}.dev`;
+}
+
+export class MissingAppleTeamIdError extends Error {}
+
+export function buildAasaDocument(env: NodeJS.ProcessEnv = process.env) {
+  const teamId = env['APPLE_TEAM_ID']?.trim();
+  if (!teamId) {
+    throw new MissingAppleTeamIdError('APPLE_TEAM_ID env var missing — cannot build AASA');
+  }
+  const bundleId = bundleIdForOrigin(currentAppLinkOrigin(env));
+  const appId = `${teamId}.${bundleId}`;
+  return {
+    applinks: {
+      apps: [], // legacy(iOS 12 이하) 규격 — 반드시 빈 배열
+      details: [
+        {
+          appIDs: [appId],
+          components: [{ '/': APP_LINK_PATH, comment: APP_LINK_COMMENT }],
+          appID: appId, // legacy 자리 — 신형(components)과 같은 값 중복
+          paths: [APP_LINK_PATH],
+        },
+      ],
+    },
+  };
+}
+
+// 조건 1(리다이렉트 금지)·2(Content-Type: application/json 정확히, charset 파라미터 없이)를
+// NextResponse.json()의 기본 charset 부착 없이 직접 못박는다 — iOS AASA 검증기는 까다롭다.
+export function aasaRouteResponse(): NextResponse {
+  try {
+    const doc = buildAasaDocument();
+    return new NextResponse(JSON.stringify(doc), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+    });
+  } catch (err) {
+    if (err instanceof MissingAppleTeamIdError) {
+      console.error('aasa.missing_team_id — APPLE_TEAM_ID env var not set on this deploy');
+      return NextResponse.json({ error: 'aasa_not_configured' }, { status: 500 });
+    }
+    throw err;
+  }
+}

--- a/apps/web/src/lib/route-resolve.ts
+++ b/apps/web/src/lib/route-resolve.ts
@@ -64,9 +64,14 @@ export const RESERVED_FIRST_SEGMENTS = new Set([
   // ② 손 스냅샷(의도적, 2026-08-01 재실측) — 라이브 top-level 페이지 라우트(`app/*`+
   // `app/(authenticated)/*`, `[ws]`/`(authenticated)` 제외) + Next.js 메타데이터 파일
   // 라우트. `scripts/verify-reserved-first-segments-sync.ts`가 어긋남을 CI에서 잡는다.
-  'activity', 'api', 'apple-icon.png', 'auth', 'channel', 'chats', 'dashboard',
+  '.well-known', 'activity', 'api', 'apple-app-site-association', 'apple-icon.png', 'auth',
+  'channel', 'chats', 'dashboard',
   'favicon.ico', 'forgot-password', 'gates', 'icon.svg', 'inbox', 'internal-dogfood',
-  'invite', 'login', 'loop-queue', 'manifest.webmanifest', 'meetings', 'mfa', 'more', 'onboarding',
+  'invite', 'login', 'loop-queue', 'manifest.webmanifest', 'meetings', 'mfa', 'more',
+  // [P1] iOS TestFlight 구글 로그인 후 404 인시던트 — AASA(.well-known/apple-app-site-association)
+  // + native/oauth-return 신설(verify-reserved-first-segments-sync.test.ts가 이 목록 누락을
+  // 실측으로 잡았다).
+  'native', 'onboarding',
   'org-briefing', 'organization', 'privacy', 'refund-policy', 'register', 'reset-password',
   'rewards', 'settings', 'share', 'terms', 'verify-email',
 ]);

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -104,6 +104,18 @@ describe('proxy', () => {
     expect(response.status).toBe(200);
   });
 
+  it('treats /.well-known/apple-app-site-association as public — [P1] iOS TestFlight 구글 로그인 후 404 인시던트, 실제 AASA 경로(§10.2)', async () => {
+    const response = await middleware(makeRequest('/.well-known/apple-app-site-association'));
+    expect(response.status).toBe(200);
+  });
+
+  it('treats /native/oauth-return as public (no cookie) — [P1] 실측(next start+curl)으로 발견: 누락 시 307-to-login으로 폴백 페이지가 렌더되지 않았다', async () => {
+    // native 핸드오프 콜백은 이 응답에 웹 세션 쿠키를 세팅하지 않으므로(격리 rail) 쿠키 없는
+    // 요청이 정상 케이스 — /auth/native와 동일 결함 클래스.
+    const response = await middleware(makeRequest('/native/oauth-return?code=test-code'));
+    expect(response.status).toBe(200);
+  });
+
   it('passes all /api/* paths without JWT check', async () => {
     const apiPaths = [
       '/api/v1/bridge/slack/interactions',

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -90,6 +90,14 @@ const PUBLIC_PREFIX = [
   // §10.2: App Link/Universal Link 검증파일 — OS 레벨 검증기가 인증 쿠키 없이 호출.
   '/.well-known/',
   '/apple-app-site-association',
+  // [P1] iOS TestFlight 구글 로그인 후 404 인시던트 — AASA 미서빙으로 유니버설 링크 복귀가
+  // 실패하면 인앱 브라우저가 이 경로를 직접 로드한다(?code=...). native 핸드오프 콜백은
+  // 이 응답에 웹 세션 쿠키를 절대 세팅하지 않으므로(route.ts §7.4/§10.1 — 격리 rail) 쿠키가
+  // 없는 게 정상 — /auth/native·/auth/oauth-handoff(story 26170479/PR#2224)와 동일한
+  // "세션 생성 전 라우트가 보호 라우트로 오인돼 307" 결함 클래스. 실측(next start + curl)으로
+  // 발견: 이 목록 누락 시 /login?next=%2Fnative%2Foauth-return 307로 튕겨 폴백 페이지가
+  // 렌더되지 않았다.
+  '/native/oauth-return',
   '/invite',
   '/internal-dogfood',
   '/terms',

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -110,6 +110,13 @@ substitutions:
   # 메일 링크가 prod로 갔다. dev-safe 기본값은 prod URL(수동 gcloud submit 시 최소한
   # prod와 같은 안전값) — GHA가 dev 브랜치에서만 dev 도메인으로 override.
   _NEXT_PUBLIC_APP_URL: "https://app.sprintable.ai"
+  # [P1] iOS TestFlight 구글 로그인 후 404 인시던트(story 57526f21, #3499 PR 리뷰 delta) —
+  # /.well-known/apple-app-site-association 라우트(apps/web)가 읽는 env 2종. dev-safe
+  # 기본값(수동 gcloud builds submit override 없을 때) — GHA cloud-build.yml이 main에서
+  # MOBILE_APP_LINK_ORIGIN만 prod로 override(_FASTAPI_URL과 동일 배선 패턴). Team ID는
+  # AASA 응답으로 공개되는 값이라 시크릿 아니고 dev/prod 동일해 override 불요.
+  _APPLE_TEAM_ID: "JN798BC4KC"
+  _MOBILE_APP_LINK_ORIGIN: "https://dev-app.sprintable.ai"
   # story #2078(E-ARCH 0단계) — SSE 멀티플렉서 롤백 플래그. dev-safe 기본값 'false'(수동
   # `gcloud builds submit` override 없을 때 안전). GHA가 dev 브랜치에서만 'true' 주입 —
   # prod는 develop→main 일괄승격에 검증 안 된 플래그를 얹지 않는다(오르테가군 판정,
@@ -452,7 +459,10 @@ steps:
       # E-ARCH 1단계(story #2078) — /api/event-stream 프록시 라우트가 REALTIME_URL을 읽어
       # SSE/LISTEN 전용 realtime-gateway로 향한다(REALTIME_URL 없으면 기존 FASTAPI_URL로
       # 폴백 — 이 값을 비우면 코드 변경·재배포 없이 즉시 원복). --update-env-vars(additive).
-      - --update-env-vars=REALTIME_URL=${_REALTIME_URL}
+      # [P1] iOS TestFlight 구글 로그인 후 404 인시던트(story 57526f21) — APPLE_TEAM_ID·
+      # MOBILE_APP_LINK_ORIGIN 없으면 /.well-known/apple-app-site-association 라우트가
+      # 설계대로 500(fail-loud)을 낸다. 같은 --update-env-vars에 동반(additive, 기존 env 보존).
+      - --update-env-vars=REALTIME_URL=${_REALTIME_URL},APPLE_TEAM_ID=${_APPLE_TEAM_ID},MOBILE_APP_LINK_ORIGIN=${_MOBILE_APP_LINK_ORIGIN}
       - --quiet
     waitFor: [push-frontend]
 


### PR DESCRIPTION
## 무엇

선생님 실기기 iOS TestFlight에서 Google 로그인 후 매번 404. 웹 레포에 `apple-app-site-association`이 아예 없어(prod·dev 둘 다 404 — Android `assetlinks.json`은 200) 유니버설 링크 복귀가 앱으로 반사되지 않고, 인앱 브라우저가 `/native/oauth-return`을 직접 로드해 404가 나는 구조였다.

관련 스토리: [\[P1·인시던트·선생님 실기기\] iOS TestFlight Google 로그인 후 404 — AASA 미서빙으로 유니버설 링크 복귀 실패](entity:story:57526f21-f669-469b-8698-e750bccc3d52)

## 무엇을 고쳤나

- `/.well-known/apple-app-site-association` · `/apple-app-site-association`(루트 폴백) 라우트 핸들러 신설. `MOBILE_APP_LINK_ORIGIN`(호스트)·`APPLE_TEAM_ID`(env)로 dev/prod bundle id(`.dev` 접미)를 갈라 생성 — 값은 sprintable-mobile의 `scripts/print-aasa.js` 실측 출력과 구조 대조로 맞췄다(손으로 안 적음).
- `/native/oauth-return` 웹 폴백 페이지 신설(raw 404 금지). custom scheme 자동 리다이렉트는 시도하지 않음(별건 HOLD 스토리 스코프 — 상신 없이 선조치 금지).
- 실측 중 발견한 부수 결함 2건도 같은 PR에서 봉합:
  - `proxy.ts` `PUBLIC_PREFIX`에 `/native/oauth-return` 누락 — native 핸드오프 콜백은 이 응답에 세션 쿠키를 세팅하지 않는데(격리 rail) 목록에 없어 폴백 페이지가 `/login`으로 307 튕겼다(`next start`+curl 실측 발견, 뮤테이션 셀프체크로 RED 확인 후 그린).
  - `route-resolve.ts` `RESERVED_FIRST_SEGMENTS`에 `.well-known`/`apple-app-site-association`/`native` 미등록 — 신설 라우트가 워크스페이스 slug로 오인될 뻔한 걸 기존 sync 가드 테스트(story #2393 AC3)가 실측으로 잡았다.
- `.env.example`에 `APPLE_TEAM_ID`·`MOBILE_APP_LINK_ORIGIN` 문서화(둘 다 기존에 무배선이었음).

## 증거

- `pnpm vitest run` (apps/web): 514 files · 4598 tests 그린(신규 회귀가드 다수 포함).
- `tsc --noEmit`: 클린. `eslint`(변경 파일): 0.
- `next build`: 그린, `.well-known/apple-app-site-association` · `apple-app-site-association` · `native/oauth-return` 라우트 매니페스트 확인.
- `next start` + curl로 prod(`MOBILE_APP_LINK_ORIGIN=https://app.sprintable.ai`)·dev(미설정) 둘 다 실측:
  - `200`, `Location` 헤더 없음(무리다이렉트), `Content-Type: application/json`(charset 없이 정확히).
  - 응답 JSON을 `node scripts/print-aasa.js JN798BC4KC`(prod)·`EXPO_PUBLIC_WEB_URL=https://dev-app.sprintable.ai node scripts/print-aasa.js JN798BC4KC`(dev) 실측 출력과 구조 대조 — 둘 다 MATCH.
  - `/native/oauth-return?code=...`를 쿠키 없이 호출 — 픽스 전 307(`/login?next=...`) 재현 → 픽스 후 200 확인.

## 잔여 리스크 (미검증)

- **ASWebAuthenticationSession이 이 AASA를 실제로 반사하는지는 실기기에서만 확인 가능** — dev 실기기 재설치 + Google 로그인 왕복 실측이 남아 있음(선생님/디바이스 보유자 몫으로 별도 요청).
- prod/dev Cloud Run 서비스에 `APPLE_TEAM_ID` env가 실제로 반영됐는지는 PO/인프라 lane 확인 필요(`MOBILE_APP_LINK_ORIGIN`도 prod 서비스에 `https://app.sprintable.ai`로 설정돼 있는지 재확인 권장).
- 위 실기기 검증이 불발이면 custom scheme 폴백 스토리(HOLD) 해제를 상신 — 이 PR에서 선조치하지 않음.

## Test plan

- [x] `pnpm vitest run` (apps/web) 전체 그린
- [x] `tsc --noEmit` 클린
- [x] `next build` 그린 + 라우트 매니페스트 확인
- [x] `next start` + curl로 prod/dev AASA 5조건 실측
- [x] `print-aasa.js` 실측 출력과 구조 대조
- [x] 뮤테이션 셀프체크(proxy.ts 프록시 결함 RED→그린)
- [ ] dev 실기기 재설치 + Google 로그인 왕복 실측 (별도 요청 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZzVLFLVJ3MePFeprri6mK