### PR TITLE
[SID:3090] ProofCapsule StateHeader 라벨 AA 미달 수정 — 결재카드 색 위화감 근본원인

### DIFF
--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -446,7 +446,7 @@ describe('ProofCapsule — story #32dcc294 headerAside/cardHeader(card 밀도 �
   it('headerAside를 안 넘기면 wrapper div 자체가 렌더되지 않는다 — StateHeader가 옛 구조 그대로 outer div의 직계 자식(byte-identical, 고정 문자열 대조)', () => {
     const markup = renderWithIntl(<ProofCapsule {...BASE} density="card" />);
     expect(markup).toContain(
-      '<div class="min-w-0 flex-1 px-3 py-2.5"><span class="inline-flex items-center gap-1.5 text-[11px] font-semibold text-proof-green">',
+      '<div class="min-w-0 flex-1 px-3 py-2.5"><span class="inline-flex items-center gap-1.5 text-[11px] font-semibold text-proof-ink">',
     );
     // 새 wrapper(headerAside 전용)는 아예 없어야 한다.
     expect(markup).not.toContain('class="flex items-center justify-between gap-2"');
@@ -455,7 +455,7 @@ describe('ProofCapsule — story #32dcc294 headerAside/cardHeader(card 밀도 �
   it('양성대조 — headerAside를 주면 위 "직계 자식" 단언이 실제로 깨진다(가드가 진짜 실패할 수 있음을 증명)', () => {
     const markup = renderWithIntl(<ProofCapsule {...BASE} density="card" headerAside={<span>x</span>} />);
     expect(markup).not.toContain(
-      '<div class="min-w-0 flex-1 px-3 py-2.5"><span class="inline-flex items-center gap-1.5 text-[11px] font-semibold text-proof-green">',
+      '<div class="min-w-0 flex-1 px-3 py-2.5"><span class="inline-flex items-center gap-1.5 text-[11px] font-semibold text-proof-ink">',
     );
     expect(markup).toContain('class="flex items-center justify-between gap-2"');
   });

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -154,7 +154,7 @@ function CutCornerShell({ state, className, children }: { state: ProofState; cla
 
 function StateHeader({ state, label }: { state: ProofState; label: string }) {
   const tone: Record<ProofState, string> = {
-    blue: 'text-proof-blue', amber: 'text-proof-amber', green: 'text-proof-green', red: 'text-proof-red',
+    blue: 'text-proof-ink', amber: 'text-proof-ink', green: 'text-proof-ink', red: 'text-proof-red',
   };
   const dotTone: Record<ProofState, string> = {
     blue: 'bg-proof-blue', amber: 'bg-proof-amber', green: 'bg-proof-green', red: 'bg-proof-red',


### PR DESCRIPTION
## 배경
선생님이 prod 승격 머지 게이트 카드 승인 사유란에 직접 지적한 «결재카드 색이 왜 이런지» — 유나 그라운딩(story #654a74ba)으로 근본원인 확定. PO GO(유나 diff 릴레이) 반영.

## 근본원인
`ProofCapsule`의 `StateHeader`(공용 컴포넌트, 챗 결재 카드·보드 카드·워크셀·글랜스·인박스·rail·gates/[id] 등 전 소비처가 공유)가 라벨 텍스트(11px semibold)에 `text-proof-{state}`를 직접 사용 — 라이트 테마에서 amber/green이 AA(4.5:1) 미달이었습니다.

## 변경
`proof-capsule.tsx` StateHeader tone map:
```diff
   const tone: Record<ProofState, string> = {
-    blue: 'text-proof-blue', amber: 'text-proof-amber', green: 'text-proof-green', red: 'text-proof-red',
+    blue: 'text-proof-ink', amber: 'text-proof-ink', green: 'text-proof-ink', red: 'text-proof-red',
   };
```
- `dotTone`(점)은 **무변경** — 상태 색 신호는 점이 그대로 담당
- `red`만 색 텍스트 예외 유지(kill=최강 신호·AA 이미 통과)
- `proof-capsule.test.tsx`의 byte-identical 마크업 단언 1건을 새 렌더 결과(`text-proof-green`→`text-proof-ink`)로 갱신

## AA 실측(직접 재계산, 유나 수치와 교차검증 일치)
| 상태 | 라이트 old | 라이트 new | 다크(무변경) |
|---|---|---|---|
| amber | 3.64 ❌ | 18.64 ✅(text-proof-ink) | 원래 PASS |
| green | 3.49 ❌ | 18.64 ✅ | 원래 PASS |
| blue | 5.33 ✅(참고: 일관성 위해 동형 처리) | 18.64 ✅ | 원래 PASS |
| red(예외 유지) | 5.24 ✅ | 5.24 ✅(무변경) | 5.29 ✅ |

## 스크린샷 — before/after 4상태 라이트·다크 비교
(빌드 산출 Tailwind CSS 그대로 로드한 정적 프리뷰 — 세션 환경 제약으로 인증 dev 라이브 대신 사용. 라이브 픽셀 design:pass 판정은 유나 몫)

## 검증
- [x] `pnpm build` 성공(EXIT 0)
- [x] `pnpm exec tsc --noEmit` 통과
- [x] `pnpm exec eslint` 대상 파일 경고 0개
- [x] 소비처 테스트 전수 재실행: proof-capsule/kanban story-card/workcell/glance/inbox/attention-queue(272건) + gates/[id] page + approval-request-card(53건) 전부 통과
- [x] `verify-muted-foreground-contrast.ts` / `verify-no-new-tint-color-text.ts` 무회귀
- [x] 다른 소비처(workcell.tsx L110, goals-client.tsx L679)에 동일 패턴의 **독립된** amber/green 소형텍스트 사용이 있으나 StateHeader와 별개 tone map이라 이번 diff로 자동 수정되지 않음 — 스코프 밖(별도 follow-up 필요, 아래 참고)

## 스코프 밖 발견(비차단, 별건)
`workcell.tsx`(L110)와 `goals-client.tsx`(L679)에 StateHeader와 동일한 `text-proof-amber`/`text-proof-green` 소형텍스트 사용이 **각자 독립적으로** 존재합니다(같은 근본원인, 다른 소비처 — ProofCapsule을 안 거치므로 이번 diff로 자동 수정 안 됨). PO 확定 GO는 "공용 ProofCapsule StateHeader"로 스코프가 명시돼 있어 이번 PR은 손대지 않았습니다. 필요하면 별도 스토리로 등재 바랍니다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011js9VYShN84eGzG3nSPYBn