### PR TITLE
fix(#3098): path-filter 참조점 해석 실패 — cloudrun 갈래 format+digest 이중버그 해소

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -419,6 +419,18 @@ jobs:
           AR_REGION="asia-northeast3"
           git fetch --unshallow --quiet 2>/dev/null || git fetch --quiet 2>/dev/null || true
 
+          # story #3098(2026-08-26) — 이 갈래 자체(describe 필드·sed·정규식)는 실측상 정상이다
+          # (동일 명령을 사람 계정으로 재현하면 "sprintable-realtime-gateway-dev-91ba3643-9a8753"
+          # 같은 실 템플릿명에서 8자 SHA가 그대로 뽑힌다 — 이름 패턴 불일치가 원인이 아니었다).
+          # 진짜 원인은 IAM: github-actions@${GCP_PROJECT}.iam.gserviceaccount.com에 부여된
+          # 역할이 artifactregistry.writer/cloudbuild.builds.editor/iam.serviceAccountUser/
+          # run.admin/secretmanager.secretAccessor/serviceusage.serviceUsageConsumer/
+          # storage.admin뿐 — compute.* 역할이 전무하다(project IAM policy 직접 조회로 확認).
+          # `compute.instanceGroupManagers.get` 권한이 없으니 이 describe는 매번 권한거부로
+          # 조용히 실패(stderr는 /dev/null)하고 빈 문자열만 돌아온다 — "최초 배포/이름 패턴
+          # 변경"이 아니라 "애초에 조회 권한이 없음"이 실제 사유. ⚠️IAM 부여는 인프라 lane
+          # (PO 전담) — 이 코드는 안 건드림. 필요한 조치: 이 SA에 roles/compute.viewer
+          # (또는 최소 compute.instanceGroupManagers.get) 부여, story #3098 참조.
           gce_skip="false"
           current_template="$(gcloud compute instance-groups managed describe sprintable-realtime-gateway-dev \
             --region="${AR_REGION}" --project="${GCP_PROJECT}" \
@@ -433,24 +445,51 @@ jobs:
             gce_skip="true"
           fi
 
+          # story #3098(2026-08-26, PO 실측 run 32919036744) — 이 갈래는 실측 결과 두 겹으로
+          # 깨져 있었다(둘 다 이번 delta로 해소):
+          # ①`--format='value(status.traffic.filter(percent=100).revisionName)'`가 gcloud
+          #   포맷 트랜스폼 파서 자체를 태워 매 호출 ERROR("Transform function expected") →
+          #   stderr는 /dev/null로 삼켜지고 serving_revision은 항상 빈 문자열. 실 트래픽
+          #   스플릿과 무관하게 100% 확定 실패(직접 재현·gcloud 에러 메시지 확認).
+          #   → json + jq로 percent==100 항목을 직접 골라낸다(gcloud 포맷 트랜스폼 문법에
+          #   더는 의존하지 않음, GHA ubuntu-latest 기본 이미지에 jq 상시 포함).
+          # ②①을 고쳐도 다음 겹이 바로 막는다 — Cloud Run은 `--image=...backend:${COMMIT_SHA}`
+          #   로 태그를 받아 배포해도 `describe`가 돌려주는 `spec.containers[0].image`는 항상
+          #   digest 고정형(`repo@sha256:...`)이다(Cloud Run 자체 동작 — 태그가 아니라
+          #   불변 digest로 리비전을 고정, 실측 확認). 기존 `${last_image##*:}`는 이 digest의
+          #   sha256 hex를 git SHA로 착각해 그대로 check_realtime_relevant_diff.sh에 넘겼다
+          #   (git이 못 알아들어 fail-safe로만 떨어지고 스킵은 영원히 못 탐 — ①만 고치면
+          #   증상이 "빈 값"에서 "매번 배포 진행"으로 바뀔 뿐 근본은 그대로였을 것).
+          #   → Artifact Registry에 그 digest를 가리키는 태그를 역질의해(같은 digest에
+          #   COMMIT_SHA 태그와 `latest-dev` 플로팅 태그가 동시에 붙어 있음, 실측 확認) 40자
+          #   git SHA 패턴만 골라낸다.
           cloudrun_skip="false"
           serving_revision="$(gcloud run services describe sprintable-realtime-dev \
             --region="${AR_REGION}" --project="${GCP_PROJECT}" \
-            --format='value(status.traffic.filter(percent=100).revisionName)' 2>/dev/null || echo '')"
+            --format=json 2>/dev/null \
+            | jq -r '.status.traffic[]? | select(.percent==100) | .revisionName' 2>/dev/null \
+            | head -1 || echo '')"
           if [ -z "${serving_revision}" ]; then
             echo "[cloudrun] 100% 트래픽 서빙 리비전을 못 읽음(최초 배포이거나 트래픽 스플릿 중) — 배포 진행"
           else
-            last_image="$(gcloud run revisions describe "${serving_revision}" \
+            serving_digest="$(gcloud run revisions describe "${serving_revision}" \
               --region="${AR_REGION}" --project="${GCP_PROJECT}" \
               --format='value(spec.containers[0].image)' 2>/dev/null || echo '')"
-            cloudrun_last_sha="${last_image##*:}"
-            if [ -z "${cloudrun_last_sha}" ] || [ "${cloudrun_last_sha}" = "${last_image}" ]; then
-              echo "[cloudrun] 서빙 리비전 이미지 태그를 못 읽음 — 배포 진행"
-            elif bash backend/scripts/check_realtime_relevant_diff.sh "${cloudrun_last_sha}" "${GITHUB_SHA}"; then
-              echo "[cloudrun] 관련 경로 변경 있음 — 배포 진행"
+            if [ -z "${serving_digest}" ] || [ "${serving_digest#*@}" = "${serving_digest}" ]; then
+              echo "[cloudrun] 서빙 리비전 이미지 digest를 못 읽음 — 배포 진행"
             else
-              echo "[cloudrun] ${cloudrun_last_sha}..${GITHUB_SHA} 사이 realtime-관련 경로 변경 없음 — 스킵"
-              cloudrun_skip="true"
+              cloudrun_last_sha="$(gcloud artifacts docker tags list "${serving_digest%@*}" \
+                --filter="version:${serving_digest#*@}" \
+                --format='value(tag)' 2>/dev/null \
+                | sed 's#.*/##' | grep -E '^[0-9a-f]{40}$' | head -1 || echo '')"
+              if [ -z "${cloudrun_last_sha}" ]; then
+                echo "[cloudrun] 서빙 digest를 가리키는 커밋 SHA 태그를 못 찾음 — 배포 진행"
+              elif bash backend/scripts/check_realtime_relevant_diff.sh "${cloudrun_last_sha}" "${GITHUB_SHA}"; then
+                echo "[cloudrun] 관련 경로 변경 있음 — 배포 진행"
+              else
+                echo "[cloudrun] ${cloudrun_last_sha}..${GITHUB_SHA} 사이 realtime-관련 경로 변경 없음 — 스킵"
+                cloudrun_skip="true"
+              fi
             fi
           fi
 

--- a/backend/tests/test_cloud_build_realtime_path_filter_gha.py
+++ b/backend/tests/test_cloud_build_realtime_path_filter_gha.py
@@ -12,11 +12,24 @@ cloudbuild.yaml에 넘긴다. 이 테스트는 그 GHA 스텝의 구조 계약�
 읽기 쪽 계약은 test_3031_realtime_cloudrun_deploy_path_filter.py가 별도로 고정)."""
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
+import pytest
 import yaml
 
 _WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "cloud-build.yml"
+
+# story #3098 delta(2026-08-26, 카디르 QA 반려) — 원래 잣대는 run.count("check_realtime_
+# relevant_diff.sh")로 파일명의 순수 텍스트 언급 수를 셌다. #3098이 설명 주석(문서·근거
+# 서술)에서 그 파일명을 한 번 더 적기만 했는데도(실 호출은 여전히 2곳 그대로) 오탐 RED가
+# 났다 — "언급 수"는 주석까지 세는 부서지기 쉬운 자다. 실 호출 패턴(`bash backend/scripts/
+# check_realtime_relevant_diff.sh`)만 세도록 좁힌다.
+_INVOCATION_PATTERN = re.compile(r"bash backend/scripts/check_realtime_relevant_diff\.sh\b")
+
+
+def _invocation_count(run: str) -> int:
+    return len(_INVOCATION_PATTERN.findall(run))
 
 
 def _load():
@@ -54,9 +67,21 @@ def test_gate_step_unshallows_before_diffing():
 
 def test_gate_step_reuses_shared_diff_script_for_both_targets():
     """GCE·Cloud Run 판정 로직이 이중선언되면 안 된다 — 둘 다 SSOT(check_realtime_relevant_diff.sh)
-    재사용."""
+    재사용. 잣대=실 호출 패턴 개수(_INVOCATION_PATTERN) — 주석·문서의 언급은 안 셈(위 모듈
+    독스트링 참조)."""
     run = _gate_step()["run"]
-    assert run.count("check_realtime_relevant_diff.sh") == 2
+    assert _invocation_count(run) == 2
+
+
+def test_gate_step_reuses_shared_diff_script_guard_catches_third_invocation():
+    """양성대조(카디르 QA 요구, 2026-08-26) — 잣대를 실 호출 패턴으로 좁혀도 가드 의도(제3의
+    실 호출 추가 시 genuine RED)는 그대로 살아 있는지 직접 증명한다. 호출 라인 하나를
+    그대로 복제(주석이 아니라 실행 가능한 코드로) — 이 복제가 없으면 위 테스트 하나만으론
+    "우연히 2"인지 "실제로 실 호출만 정확히 세고 있는지" 구분이 안 된다."""
+    run = _gate_step()["run"]
+    mutated = run + '\nbash backend/scripts/check_realtime_relevant_diff.sh "extra_from" "extra_to"\n'
+    with pytest.raises(AssertionError):
+        assert _invocation_count(mutated) == 2
 
 
 def test_gate_step_reads_serving_revision_not_template_spec_for_cloudrun():


### PR DESCRIPTION
[SID:3098]

PR#3483 머지 후 PO 손 대조(run 32919036744) — git 층은 살았는데 참조점(직전 배포 SHA) 해석이 양 갈래 다 fail-safe로 떨어져 "필터 없음과 동치" 상태 지속. 실측으로 원인을 갈랐다.

## GCE 갈래 — 코드 정상, 원인은 IAM (이 PR은 안 건드림)
describe+sed+정규식을 사람 계정으로 재현하면 정상 동작(실 템플릿명에서 8자 SHA 정확 추출). Project IAM policy 직접 조회 결과 `github-actions@` 서비스계정에 `compute.*` 역할이 전무 — describe가 매번 권한거부로 조용히 실패하는 게 실사유.

**PO 조치 필요**: `github-actions@sprintable-494803.iam.gserviceaccount.com`에 `roles/compute.viewer`(또는 최소 `compute.instanceGroupManagers.get`) 부여.

## Cloud Run 갈래 — 이중 버그, 둘 다 code fix
1. `--format='value(status.traffic.filter(percent=100).revisionName)'`가 gcloud 포맷 트랜스폼 파서를 태워 매 호출 ERROR — json+jq로 교체.
2. ①만 고쳐도 막힘 — Cloud Run describe가 돌려주는 이미지는 항상 digest 고정형(`repo@sha256:...`), 태그가 아님(Cloud Run 자체 동작). 기존 로직은 이 digest hex를 git SHA로 착각했다. → Artifact Registry에 digest→태그 역질의해 40자 git SHA 패턴만 채택.

fail-safe 방향(판별 불가→배포)은 완전히 유지 — 참조점 "해석" 로직만 고쳤다.

## 검증(양성·음성 대조 쌍, 실측)
- 수정된 전체 블록을 실 dev GCP 상태로 로컬 실행 — GCE·cloudrun 양 갈래 모두 현재 배포 SHA를 정확히 resolve(서로 일치)·현재 HEAD와의 무관 range에서 "스킵" 정확 발동.
- `check_realtime_relevant_diff.sh`를 realtime-관련 경로 변경 range로 직접 호출 — "관련 경로 변경 있음"·배포 정확 발동.
- YAML 파싱 + bash 문법 검사 OK.

## 후속
GCE 갈래는 IAM 부여 후 실제 GHA 재실행으로 최종 검산(이 PR 머지와 별개 타이밍일 수 있음).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>