### PR TITLE
[SID:3092] 에이전트 아바타 코너배지 «AI»→«Agent» 텍스트 교체 (1단계)

### DIFF
--- a/apps/web/src/components/shared/avatar.test.tsx
+++ b/apps/web/src/components/shared/avatar.test.tsx
@@ -49,30 +49,31 @@ describe('Avatar — story #2887 S2g', () => {
     expect(container.textContent).toContain('송');
   });
 
-  it('휴먼은 링·AI배지·dot이 없다', async () => {
+  it('휴먼은 링·Agent배지·dot이 없다', async () => {
     await act(async () => {
       root.render(wrap(<Avatar name="송윤재" avatarUrl={null} actorType="human" presenceStatus="online" />));
     });
-    expect(container.textContent).not.toContain('AI');
+    expect(container.textContent).not.toContain('Agent');
     expect(container.querySelector('[role="img"]')).toBeNull();
   });
 
-  it('에이전트는 이미지가 있어도 AI 배지가 유지된다', async () => {
+  it('에이전트는 이미지가 있어도 Agent 배지가 유지된다', async () => {
     await act(async () => {
       root.render(wrap(<Avatar name="유나" avatarUrl="https://example.com/a.png" actorType="agent" presenceStatus="online" />));
     });
     expect(container.querySelector('img')).not.toBeNull();
-    expect(container.textContent).toContain('AI');
+    expect(container.textContent).toContain('Agent');
     expect(container.querySelector('[role="img"]')).not.toBeNull(); // PresenceDot
   });
 
-  // story #3049(2984-S1) — 정적 "AI" 코너배지 border는 proof-blue 유지(정체성 마킹), 배경
+  // story #3049(2984-S1) — 정적 "Agent" 코너배지 border는 proof-blue 유지(정체성 마킹), 배경
   // soft-fill은 폐지(AGENT_MARK_FILL_CLASS=투명, 헤어라인만 남김).
-  it('AI 코너배지가 border-proof-blue를 쓰고 soft-fill/citron은 안 쓴다', async () => {
+  // story #3092(선생님 전달 제안 1단계) — 배지 텍스트 "AI"→"Agent"로 교체.
+  it('Agent 코너배지가 border-proof-blue를 쓰고 soft-fill/citron은 안 쓴다', async () => {
     await act(async () => {
       root.render(wrap(<Avatar name="유나" avatarUrl={null} actorType="agent" />));
     });
-    const badge = [...container.querySelectorAll('span')].find((s) => s.textContent === 'AI');
+    const badge = [...container.querySelectorAll('span')].find((s) => s.textContent === 'Agent');
     expect(badge).toBeTruthy();
     expect(badge?.className).toContain('border-proof-blue/40');
     expect(badge?.className).not.toContain('bg-proof-blue-soft');

--- a/apps/web/src/components/shared/avatar.tsx
+++ b/apps/web/src/components/shared/avatar.tsx
@@ -104,7 +104,7 @@ export function Avatar({
           className={cn('absolute -right-1.5 -top-1.5 rounded border border-proof-blue/40 font-bold', AGENT_MARK_FILL_CLASS)}
           style={{ fontSize: Math.max(7, Math.round(badgeSize * 0.55)), lineHeight: 1, padding: '2px 3px' }}
         >
-          AI
+          Agent
         </span>
       )}
       {isAgent && presenceStatus ? (


### PR DESCRIPTION
## 배경
선생님 전달 제안(2026-08-26): 아바타 위 «AI» 표기를 ①기본 «Agent»로, ②커넥터 연결 시 공식 로고로. 1단계(«Agent» 텍스트 교체) GO — PO 판정.

## 변경
단일 정의 컴포넌트 `components/shared/avatar.tsx`의 코너배지 하드코딩 문자열만 `AI`→`Agent`로 교체. 스타일(border-proof-blue/40·bg-transparent·text-proof-blue)·크기 로직·위치는 전부 무변경.

소비처 9곳(챗 버블·챗 목록·발신자 팝오버·조직 인력 상세·아바타 편집 카드·팀 프레즌스 패널·프로필 메뉴·워크셀) 전부 이 한 파일 수정으로 동시 반영됩니다.

커넥터 공식 로고(2단계)는 유나 브랜드 가이드라인 규격 산출 후 별도 트랙 — 이번 PR은 손대지 않았습니다.

## 검증
- [x] `pnpm build` 성공(EXIT 0)
- [x] `pnpm exec tsc --noEmit` 통과
- [x] `pnpm exec eslint` 대상 파일 경고 0개
- [x] `avatar.test.tsx`(11건) + 소비처 테스트(chat-bubble/chat-list-view/team-presence-panel/workcell/proof-capsule, 221건) 전부 통과
- [x] 실 클래스명 재현 정적 프리뷰로 최소 사용 크기(16px, 채팅 아바타)부터 40px까지 배지 오버플로/깨짐 없음 픽셀 확인 — 16px에서는 "Agent" 텍스트가 아바타 원보다 넓어 다소 두드러지지만(기존 "AI"보다 큰 차이는 폭뿐, 위치/줄바꿈 이상 없음) 이는 선생님 제안 자체의 의도(로고보다 텍스트가 최소크기에서 그나마 읽힌다)와 일치

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011js9VYShN84eGzG3nSPYBn