### PR TITLE
[SID:3099] ProofCapsule 밖 독립 amber/green 소형텍스트 AA 미달 6곳 중립화 (#3090 후속)

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
@@ -161,11 +161,14 @@ describe('GoalsClient — 결과 원장 재조립(§2 이중 신호·§3 마스�
     expect(container.querySelector('.bg-primary')).toBeNull();
   });
 
-  it('결과(Verified) 줄 — outcome_status=hit이면 초록 톤 "적중" 텍스트가 뜬다', async () => {
+  // story #3099(DS·AA 후속) — green 소형텍스트 AA 미달로 text-proof-ink 중립화(#3090과 동형).
+  // "적중" 문구 자체가 이미 의미를 병기하므로 색 손실은 아니다.
+  it('결과(Verified) 줄 — outcome_status=hit이면 "적중" 텍스트가 중립 톤(text-proof-ink)으로 뜬다', async () => {
     stubFetch([{ id: 'e1', title: '달성 목표', status: 'done', total_stories: 2, done_stories: 2, outcome_status: 'hit' }]);
     await mount();
     expect(container.textContent).toContain('적중');
-    expect(container.querySelector('.text-proof-green')).not.toBeNull();
+    expect(container.querySelector('.text-proof-ink')).not.toBeNull();
+    expect(container.querySelector('.text-proof-green')).toBeNull();
   });
 
   // PR#3387 카디르 QA(2026-08-23)·PO soul-lock 확定 — 이 테스트가 "text-destructive 없음"만

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -675,8 +675,11 @@ function GoalRow({ epic, isSelected, onClick, onDeleteRequest, sortable }: GoalR
         ) : null}
         <div className="flex items-center gap-2">
           <span className="w-8 shrink-0 font-mono text-[10px] text-muted-foreground">{t('outcomeLabel')}</span>
+          {/* story #3099(DS·AA 후속, #3090과 동형) — green/blue 소형텍스트(12px) AA 미달(라이트
+              green 3.49), 별도 dot 없는 자리라 text-proof-ink로 중립화(일관성 위해 blue도 동형
+              처리 — #3090 선례). 의미는 텍스트 자체(outcomeLine.text)가 이미 병기. */}
           <span className={`text-xs font-semibold ${
-            outcomeLine.tone === 'green' ? 'text-proof-green' : outcomeLine.tone === 'blue' ? 'text-proof-blue' : 'text-muted-foreground'
+            outcomeLine.tone === 'green' || outcomeLine.tone === 'blue' ? 'text-proof-ink' : 'text-muted-foreground'
           }`}
           >
             {outcomeLine.text}

--- a/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.test.tsx
@@ -280,3 +280,21 @@ describe('AttentionRow — story #3052 헤어라인 액센트(citron fill 폐지
     expect(row?.className).not.toContain('border-l-proof-citron');
   });
 });
+
+// story #3099(DS·AA 후속, #3090과 동형 문법) — 「모두 처리됨」 빈 상태 문구(11px bold)가
+// 라이트에서 text-proof-green AA 미달(3.49)이었다. 텍스트는 text-proof-ink로 중립화하고
+// 색 신호는 ShieldCheck 아이콘 하나로 좁힌다(아이콘은 non-text 3:1 기준 PASS).
+describe('AttentionQueueView — story #3099 빈 상태(모두 처리됨) 텍스트 AA 중립화', () => {
+  it('빈 큐 안내 텍스트는 text-proof-ink이고, 색 신호는 ShieldCheck 아이콘에만 있다', async () => {
+    await mount(async (url: string) => {
+      if (url.includes('/api/glance/attention')) return { ok: true, json: async () => ({ data: { items: [] } }) };
+      return { ok: true, json: async () => ({ data: [] }) };
+    });
+    const label = [...container.querySelectorAll('div')].find((d) => d.textContent?.trim() === 'ALL CLEAR');
+    expect(label).toBeTruthy();
+    expect(label?.className).toContain('text-proof-ink');
+    expect(label?.className).not.toContain('text-proof-green');
+    const icon = label?.querySelector('svg');
+    expect(icon?.getAttribute('class')).toContain('text-proof-green');
+  });
+});

--- a/apps/web/src/components/attention-queue/attention-queue-view.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.tsx
@@ -227,8 +227,11 @@ export function AttentionQueueView({ projectId, memberId }: { projectId: string;
         <div>{Array.from({ length: 3 }).map((_, i) => <RowSkeleton key={i} />)}</div>
       ) : shown.length === 0 ? (
         <div className="flex flex-col items-center gap-2 px-5 py-10 text-center">
-          <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[0.02em] text-proof-green">
-            <ShieldCheck className="size-3.5" aria-hidden="true" />{t('allClear')}
+          {/* story #3099(DS·AA 후속) — green 소형텍스트(11px bold) AA 미달, 텍스트는 중립화
+              (text-proof-ink)하고 색 신호는 아이콘 하나로 좁힌다(#3090과 동형: 색은 그래픽,
+              텍스트는 중립 — 아이콘은 3:1 non-text 기준으로 이미 PASS). */}
+          <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[0.02em] text-proof-ink">
+            <ShieldCheck className="size-3.5 text-proof-green" aria-hidden="true" />{t('allClear')}
           </div>
           <p className="text-[15px] font-semibold text-proof-ink-2">{t('emptyTitle')}</p>
           <p className="text-[12.5px] text-proof-ink-3">{t('emptyBody')}</p>

--- a/apps/web/src/components/goals/goal-trust-rail.tsx
+++ b/apps/web/src/components/goals/goal-trust-rail.tsx
@@ -108,7 +108,9 @@ export function GoalTrustRail({ outcomeStatus, measureAfter, createdAt, epicId, 
       <div className="mt-6 border border-border bg-muted/30 p-3">
         <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">{t('trustRailColorRuleTitle')}</div>
         <div className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
-          <strong className="text-proof-green">{t('trustRailColorRuleGreen')}</strong> {t('trustRailColorRuleBody')}
+          {/* story #3099(DS·AA 후속) — green 소형텍스트(12px) AA 미달, text-proof-ink로
+              중립화(별도 dot 없는 범례 문구 — 텍스트 자체가 이미 규칙을 서술). */}
+          <strong className="text-proof-ink">{t('trustRailColorRuleGreen')}</strong> {t('trustRailColorRuleBody')}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/verify/trust-seal.test.tsx
+++ b/apps/web/src/components/verify/trust-seal.test.tsx
@@ -28,9 +28,13 @@ describe('TrustSeal (claimed — Green 무결성 SOUL-LOCK, claimed-vs-verified-
     expect(markup.toLowerCase()).not.toContain('text-success');
   });
 
-  it('renders the amber "주장" framing with a specific agent avatar when agentInitial is given', () => {
+  // story #3099(DS·AA 후속, #3090과 동형) — "검증 대기" 라벨(10.5px bold)이 라이트에서
+  // proof-amber AA 미달(3.64)이라 text-proof-ink로 중립화. amber 토큰 자체를 더는 참조하지
+  // 않는다(별도 dot 없는 자리라 텍스트만 — SOUL-LOCK인 "green 미참조"는 무변경).
+  it('renders the neutral(ink) "주장" framing with a specific agent avatar when agentInitial is given', () => {
     const markup = render({ variant: 'claimed', agentInitial: '미' });
-    expect(markup).toContain('proof-amber');
+    expect(markup).toContain('text-proof-ink');
+    expect(markup).not.toContain('proof-amber');
     expect(markup).toContain('에이전트 주장');
     expect(markup).toContain('인간 검증 대기');
     expect(markup).toContain('>미<');

--- a/apps/web/src/components/verify/trust-seal.tsx
+++ b/apps/web/src/components/verify/trust-seal.tsx
@@ -58,7 +58,9 @@ export function TrustSeal(props: TrustSealProps) {
         <span className="min-w-0 flex-1 text-proof-ink-3">
           <b className="font-bold text-proof-ink">{t('trustSealClaimedBy')}</b> · {t('trustSealAwaitingVerificationLong')}
         </span>
-        <span className="shrink-0 text-[10.5px] font-bold text-proof-amber">{t('trustSealAwaitingVerification')}</span>
+        {/* story #3099(DS·AA 후속) — amber 소형텍스트(10.5px) AA 미달, text-proof-ink로
+            중립화(별도 dot 없는 자리 — "검증 대기" 문구 자체가 이미 의미 병기). */}
+        <span className="shrink-0 text-[10.5px] font-bold text-proof-ink">{t('trustSealAwaitingVerification')}</span>
       </div>
     );
   }

--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -180,24 +180,45 @@ describe('Workcell — story #2922 W6 스테퍼 트러스트-시맨틱 컬러(�
     return m[1];
   }
 
-  it('merge_ready가 current일 때, 이미 지나온 Running 단계는 강제로 green이 되지 않고 자기 고유색(blue) 유지', () => {
+  // story #3099(DS·AA 후속, #3090과 동형) — 라벨 텍스트는 amber/green/blue 전부 AA 미달이라
+  // text-proof-ink로 중립화됐다. 트러스트-시맨틱 색은 이제 dot(라벨 span 안의 두 번째
+  // class="..." — size-1.5 rounded-full span)만 싣는다.
+  function stageDotClass(markup: string, label: string): string {
+    const block = markup.split('role="listitem"').slice(1).find((b) => b.includes(`>${label}</span>`));
+    if (!block) throw new Error(`stage block not found for label: ${label}`);
+    const matches = [...block.matchAll(/class="([^"]*)"/g)];
+    if (matches.length < 2) throw new Error(`dot class attr not found for label: ${label}`);
+    return matches[1]![1];
+  }
+
+  it('라벨 텍스트는 상태와 무관하게 항상 중립(text-proof-ink) — 색 신호는 텍스트가 아니라 dot이 싣는다(AA 미달 방지)', () => {
     const markup = renderKo(<Workcell {...BASE} pipelineStage="merge_ready" bentoLayout={false} />);
-    const runningClass = stageWrapperClass(markup, 'Running');
-    expect(runningClass.split(/\s+/)).toContain('text-proof-blue');
-    expect(runningClass.split(/\s+/)).not.toContain('text-proof-green');
+    for (const label of ['Running', 'Needs input', 'Claimed done', 'Verified', 'Merge-ready']) {
+      const cls = stageWrapperClass(markup, label).split(/\s+/);
+      expect(cls).toContain('text-proof-ink');
+      expect(cls).not.toEqual(expect.arrayContaining(['text-proof-blue', 'text-proof-amber', 'text-proof-green']));
+    }
   });
 
-  it('verified가 current일 때 그 자신은 green(자기 색이 진짜 green이므로)', () => {
+  it('merge_ready가 current일 때, 이미 지나온 Running 단계는 강제로 green이 되지 않고 자기 고유색(blue) 유지 — dot 기준', () => {
+    const markup = renderKo(<Workcell {...BASE} pipelineStage="merge_ready" bentoLayout={false} />);
+    const runningDotClass = stageDotClass(markup, 'Running');
+    expect(runningDotClass.split(/\s+/)).toContain('border-proof-blue');
+    expect(runningDotClass.split(/\s+/)).not.toContain('bg-proof-green');
+  });
+
+  it('verified가 current일 때 그 자신은 green(자기 색이 진짜 green이므로) — dot 기준', () => {
     const markup = renderKo(<Workcell {...BASE} pipelineStage="verified" bentoLayout={false} />);
-    const verifiedClass = stageWrapperClass(markup, 'Verified');
-    expect(verifiedClass.split(/\s+/)).toContain('text-proof-green');
-    expect(verifiedClass.split(/\s+/)).toContain('font-bold');
+    const verifiedDotClass = stageDotClass(markup, 'Verified');
+    expect(verifiedDotClass.split(/\s+/)).toContain('bg-proof-green');
+    const verifiedWrapperClass = stageWrapperClass(markup, 'Verified');
+    expect(verifiedWrapperClass.split(/\s+/)).toContain('font-bold');
   });
 
-  it('claimed_done이 current일 때 그 자신은 blue(주장·미검증 — 아직 green 아님)', () => {
+  it('claimed_done이 current일 때 그 자신은 blue(주장·미검증 — 아직 green 아님) — dot 기준', () => {
     const markup = renderKo(<Workcell {...BASE} pipelineStage="claimed_done" bentoLayout={false} />);
-    const claimedClass = stageWrapperClass(markup, 'Claimed done');
-    expect(claimedClass.split(/\s+/)).toContain('text-proof-blue');
+    const claimedDotClass = stageDotClass(markup, 'Claimed done');
+    expect(claimedDotClass.split(/\s+/)).toContain('bg-proof-blue');
   });
 });
 

--- a/apps/web/src/components/workcell/workcell.tsx
+++ b/apps/web/src/components/workcell/workcell.tsx
@@ -106,8 +106,11 @@ const PIPELINE_STAGE_TRUST_COLOR: Partial<Record<WorkcellPipelineStage, ProofSta
   running: 'blue', needs_input: 'amber', claimed_done: 'blue', verified: 'green', merge_ready: 'green',
 };
 
+// story #3099(DS·AA 후속, #3090과 동형 문법) — 라벨 텍스트(9px)가 라이트에서 amber 3.64/
+// green 3.49 AA 미달이라 중립화(text-proof-ink). 색 신호는 아래 dot(BG/BORDER/RING)이
+// 그대로 싣는다 — red만 예외(kill=최강 신호·AA 통과).
 const TRUST_TEXT_CLASS: Record<ProofState, string> = {
-  blue: 'text-proof-blue', amber: 'text-proof-amber', green: 'text-proof-green', red: 'text-proof-red',
+  blue: 'text-proof-ink', amber: 'text-proof-ink', green: 'text-proof-ink', red: 'text-proof-red',
 };
 const TRUST_BG_CLASS: Record<ProofState, string> = {
   blue: 'bg-proof-blue', amber: 'bg-proof-amber', green: 'bg-proof-green', red: 'bg-proof-red',
@@ -428,7 +431,9 @@ function RunLayer({ run }: { run: WorkcellRun }) {
         {run.scopes.length > 0 ? <span className="min-w-0 break-words font-mono text-[10.5px]">{t('runScopes')} {run.scopes.join(', ')}</span> : null}
       </div>
       <div className="mb-2 text-[11.5px] text-proof-ink-3">
-        {t('runBlocked')}: <b className={cn('font-semibold', run.blocked ? 'text-proof-amber' : 'text-proof-ink-2')}>{run.blocked ?? t('none')}</b>
+        {/* story #3099(DS·AA 후속) — amber 소형텍스트(11.5px) AA 미달, text-proof-ink로 중립화
+            (별도 dot 없는 자리라 "Blocked: {값}" 문구 자체가 이미 의미를 병기 — no-fiction). */}
+        {t('runBlocked')}: <b className={cn('font-semibold', run.blocked ? 'text-proof-ink' : 'text-proof-ink-2')}>{run.blocked ?? t('none')}</b>
       </div>
       {/* story #3054(2984-S6) — 헤어라인 채택, bg-proof-blue-soft 채움 폐지. ⚠️elev(그림자)는
           안 얹는다 — 이 콜아웃은 bentoLayout 여부와 무관하게 항상 렌더되는 공유 요소라


### PR DESCRIPTION
## 배경
#3090(ProofCapsule StateHeader tone맵 중립화·PR#3501) 구현 중 발견한 스코프 밖 결함 — story #3099. 지시대로 지정된 2곳(workcell.tsx L110·goals-client.tsx L679) 처리 전에 같은 패턴의 추가 사본을 전수 grep했습니다.

## grep 전수 결과
`text-proof-amber`/`text-proof-green`(아이콘/그래픽 용도 제외) 전체 검색 — **총 6곳**(지정 2곳 + 신규 4곳):

| 파일 | 자리 | 크기 | 라이트 AA(구) | 처방 |
|---|---|---|---|---|
| workcell.tsx L109 | PipelineStepper 라벨(TRUST_TEXT_CLASS) | 9px | amber 3.64·green 3.49 FAIL | text-proof-ink, dot 무변경 |
| workcell.tsx L431(신규 발견) | RunLayer runBlocked 값 | 11.5px | amber 3.64 FAIL | text-proof-ink(별도 dot 없음) |
| goals-client.tsx L679 | Goal 카드 «결과» 줄(outcomeLine) | 12px | green 3.49 FAIL | text-proof-ink(blue도 일관 처리) |
| trust-seal.tsx L61(신규 발견) | TrustSeal claimed "검증 대기" | 10.5px | amber 3.64 FAIL | text-proof-ink |
| goal-trust-rail.tsx L111(신규 발견) | 색 규칙 범례 문구 | 12px | green 3.49 FAIL | text-proof-ink |
| attention-queue-view.tsx L230(신규 발견) | 「ALL CLEAR」 빈 상태 | 11px | green 3.49 FAIL | 텍스트=ink, 아이콘만 green 유지 |

`trust-seal.tsx`는 `story-card.tsx`(칸반 보드 카드)에서 실제로 라이브 렌더되는 자리라 실사용자에게 가장 체감 큰 곳이었습니다. `workcell.tsx`의 PipelineStepper는 `bentoLayout=false`일 때만 타는 폴백 경로(기본은 ConfidenceGauge)라 현재 prod 기본 화면엔 안 뜨지만, 가역성 스위치 계약상 항상 정상이어야 해서 같이 고쳤습니다.

## 처방 문법 (#3090과 동형)
- 색 신호는 **dot/아이콘**에만(이미 dot 인프라가 있는 workcell PipelineStepper·attention-queue ShieldCheck는 그대로 유지)
- 텍스트는 **중립화**(text-proof-ink) — dot이 없는 자리(runBlocked·trust-seal·goal-trust-rail·outcomeLine)는 새 UI 요소를 만들지 않고 텍스트만 중립화(문구 자체가 이미 의미를 병기하므로 정보 손실 없음)
- red는 예외 없음(이번 6곳 중 red 케이스 자체가 없음 — workcell tone map만 red 보유, 그건 무변경)

## 검증
- [x] `pnpm build`/`tsc --noEmit`/`eslint` 전부 클린
- [x] 영향 테스트 4개 파일 88건 전부 통과(workcell·goals-client·trust-seal·attention-queue-view)
- [x] byte-identical/클래스 단언 갱신(workcell dot-기반 재작성 포함) + 신규 회귀가드 2건(trust-seal·attention-queue) 추가
- [x] `verify-muted-foreground-contrast`/`verify-no-new-tint-color-text`/`verify-cross-element-tint-text` 전부 무회귀(신규 위반 0건)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011js9VYShN84eGzG3nSPYBn