### PR TITLE
feat(#3097): 청구 시점 VAT 10% 가산 — platform_settings.vat_rate_bp 어드민 관리값

### DIFF
--- a/backend/alembic/versions/0282_platform_settings_vat_rate_bp.py
+++ b/backend/alembic/versions/0282_platform_settings_vat_rate_bp.py
@@ -1,0 +1,38 @@
+"""story #3097(선생님 결정 2026-08-26) — platform_settings.vat_rate_bp.
+
+v2.3 확定가는 공급가(부가세 별도) — 청구 시점에 VAT를 가산한다. 실측(디디, #3097)으로
+백엔드 청구 파이프라인 전체에 VAT 승수가 없었음을 확認(구독 체크아웃 표시=VAT 포함
+31,900원인데 실 Toss 청구는 29,000원 그대로 — 표시≠청구 10% 불일치). 하드코딩 금지
+원칙(AC6 — dunning_grace_days와 동일 선례)에 따라 어드민 관리값으로 — 기본 1000bp(10%,
+현행 부가세율)로 시드.
+
+basis points(1bp=0.01%) 정수 표현 — 부동소수점 반올림 오차를 DB 계층에서부터 배제.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0282"
+down_revision = "0281"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column("vat_rate_bp", sa.Integer(), nullable=False, server_default="1000"),
+    )
+    op.create_check_constraint(
+        "ck_platform_settings_vat_rate_bp_range",
+        "platform_settings",
+        "vat_rate_bp >= 0 AND vat_rate_bp <= 10000",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_platform_settings_vat_rate_bp_range", "platform_settings", type_="check",
+    )
+    op.drop_column("platform_settings", "vat_rate_bp")

--- a/backend/app/models/platform_setting.py
+++ b/backend/app/models/platform_setting.py
@@ -42,3 +42,8 @@ class PlatformSetting(Base, TimestampMixin):
     # D+dunning_grace_days, downgrade 트리거일=D+dunning_grace_days+1. 하드코딩 금지
     # 원칙(AC6)에 따라 어드민 관리값으로 — 기본 7일(마이그 0270 시드).
     dunning_grace_days: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("7"))
+    # story #3097(선생님 결정 2026-08-26) — 청구 시점 VAT 가산율(basis points, 1bp=0.01%).
+    # v2.3 확정가=공급가라 charge_org로 넘어가는 최종 amount_minor는 이 값으로 가산된
+    # 금액이어야 한다(billing_charge_amount.py/billing_pack.py 참고). 기본 1000(10%,
+    # 마이그 0282 시드) — 하드코딩 금지 원칙(dunning_grace_days와 동일 선례).
+    vat_rate_bp: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("1000"))

--- a/backend/app/services/billing_charge_amount.py
+++ b/backend/app/services/billing_charge_amount.py
@@ -37,8 +37,30 @@ class ChargeAmountError(Exception):
 def apply_vat_minor(amount_minor: int, vat_rate_bp: int) -> int:
     """story #3097(선생님 결정 2026-08-26) — 공급가(minor unit)에 VAT를 가산한 최종
     청구액. `vat_rate_bp`는 platform_settings.vat_rate_bp(basis points, 1bp=0.01%) —
-    호출부가 하드코딩하지 않고 매번 이 파라미터로 받는다. 반올림은 FE `withVatKrw`
-    (`Math.round(krw * (1 + VAT_RATE))`)와 동일 관례(표시-청구 반올림 방식 일치)."""
+    호출부가 하드코딩하지 않고 매번 이 파라미터로 받는다.
+
+    ⚠️FE `withVatKrw`(apps/web/src/ee/components/billing/pricing-data.ts,
+    `Math.round(krw * (1 + VAT_RATE))`)와 **지금은 결과가 같지만 두 사본**이다 —
+    근본(율 단일 출처화)은 아직 안 닫혔다(페드루 PO 리뷰, PR#3506, 2026-08-26 —
+    후속 story #3104 「VAT율 단일 출처화 — FE가 BE platform_settings.vat_rate_bp를
+    소비하도록」에 등재). 구체적으로 갈리는 축 3개:
+      ①**출처** — FE `VAT_RATE=0.1`은 하드코딩 상수, BE는 이 함수의 `vat_rate_bp`
+        인자(어드민이 platform_settings에서 바꿀 수 있음) — 어드민이 vat_rate_bp를
+        1000(10%) 밖으로 바꾸는 순간 FE 표시와 BE 실 청구가 갈라진다.
+      ②**가산 순서** — 구독 청구(`_compute_amount_for_offering`)는 여기처럼 합산
+        後 가산(FE와 동형)이지만, **팩 구매**(billing_pack.py::purchase_packs)는
+        개당 가산 後 quantity를 곱한다(그래야 `_packs_reserved_this_period`의
+        총액÷개당가 역산이 나눠떨어진다 — purchase_packs 주석 참고) — FE
+        `PackPurchaseDialog`는 `withVatKrw(pack.priceKrwPerPack * quantity)`로
+        합산 後 가산이라 이 둘도 산식 자체가 다르다(현재 가격대에선 우연히 결과가
+        같음 — 카탈로그가 1,000원 단위라 나눗셈 잔차가 안 생기는 것뿐).
+      ③**반올림 규칙** — Python `round()`는 5 근처에서 은행가 반올림(round-half-
+        to-even), JS `Math.round()`는 항상 올림(round-half-up) — 정확히 .5로
+        떨어지는 금액이면 이 둘이 다른 정수로 갈 수 있다(현재 카탈로그 가격들은
+        이 경계에 안 걸림, 실측 확認 — test_3097_vat_fe_be_cross_pin.py 참고).
+    이 함수/파일을 고칠 때는 위 세 축이 여전히 우연 일치인지, 근본(단일 출처화)이
+    닫혔는지부터 확認할 것 — 안 닫혔으면 test_3097_vat_fe_be_cross_pin.py가 먼저
+    빨개지는 걸 신뢰(가격/율/산식 변경의 조기경보 tripwire)."""
     return round(amount_minor * (10_000 + vat_rate_bp) / 10_000)
 
 

--- a/backend/app/services/billing_charge_amount.py
+++ b/backend/app/services/billing_charge_amount.py
@@ -26,11 +26,20 @@ from app.models.billing_ledger_entry import BillingLedgerEntry
 from app.models.offering_version import OfferingVersion
 from app.models.org_subscription import OrgSubscription
 from app.models.project import OrgMember
+from app.services.platform_settings import get_platform_settings
 
 
 class ChargeAmountError(Exception):
     """청구액을 계산할 수 없는 상태(구독/카탈로그 불변식 위반) — 잘못된 금액으로 조용히
     진행하는 대신 명시적으로 실패한다."""
+
+
+def apply_vat_minor(amount_minor: int, vat_rate_bp: int) -> int:
+    """story #3097(선생님 결정 2026-08-26) — 공급가(minor unit)에 VAT를 가산한 최종
+    청구액. `vat_rate_bp`는 platform_settings.vat_rate_bp(basis points, 1bp=0.01%) —
+    호출부가 하드코딩하지 않고 매번 이 파라미터로 받는다. 반올림은 FE `withVatKrw`
+    (`Math.round(krw * (1 + VAT_RATE))`)와 동일 관례(표시-청구 반올림 방식 일치)."""
+    return round(amount_minor * (10_000 + vat_rate_bp) / 10_000)
 
 
 async def count_human_seats(session: AsyncSession, org_id: uuid.UUID) -> int:
@@ -129,7 +138,17 @@ async def _compute_amount_for_offering(
             f"org_subscription.currency={sub.currency!r} for org_id={org_id}"
         )
 
-    return base_amount + seat_amount + pack_amount, offering.currency
+    # story #3097(선생님 결정 2026-08-26) — VAT는 base+seat(공급가)에만 가산한다.
+    # pack_amount는 compute_pack_charge_minor가 billing_ledger_entries(entry_type=
+    # 'pack_purchase')에서 합산한 값 — 그 원장은 purchase_packs()가 기입 시점에 이미
+    # VAT를 가산해 기록한다(billing_pack.py 참고). 여기서 pack_amount까지 다시 VAT를
+    # 매기면 이중가산이 된다 — 그래서 base+seat 합만 가산하고 pack_amount는 그대로
+    # 더한다(현재 subscription_id 미기입 갭으로 pack_amount는 항상 0 — compute_pack_
+    # charge_minor 독스트링 참고 — 이 분기는 그 갭이 닫힐 미래를 위한 정확성 보장).
+    settings = await get_platform_settings(session)
+    taxed_base_and_seat = apply_vat_minor(base_amount + seat_amount, settings.vat_rate_bp)
+
+    return taxed_base_and_seat + pack_amount, offering.currency
 
 
 async def _load_sub(session: AsyncSession, org_id: uuid.UUID) -> OrgSubscription:

--- a/backend/app/services/billing_pack.py
+++ b/backend/app/services/billing_pack.py
@@ -16,7 +16,9 @@ from app.models.billing_order import BillingOrder
 from app.models.offering_version import OfferingVersion
 from app.models.org_subscription import OrgSubscription
 from app.services.billing_charge import charge_org
+from app.services.billing_charge_amount import apply_vat_minor
 from app.services.payment.toss_adapter import TossApiError
+from app.services.platform_settings import get_platform_settings
 
 
 class PackPurchaseError(Exception):
@@ -37,7 +39,7 @@ def _pack_order_id(org_id: uuid.UUID, resource: str, idempotency_key: str) -> st
 
 
 async def _packs_reserved_this_period(
-    session: AsyncSession, *, org_id: uuid.UUID, resource: str, price_minor: int,
+    session: AsyncSession, *, org_id: uuid.UUID, resource: str, taxed_price_minor: int,
     period_start: datetime, period_end: datetime,
 ) -> int:
     """이번 결제 주기 동안 이 자원의 팩이 몇 개 «예약/구매»됐는지 — billing_orders에서
@@ -47,7 +49,12 @@ async def _packs_reserved_this_period(
     카운트에 안 잡혀 캡을 같이 넘길 수 있었다. pending도 세면(=claim된 순간부터 카운트)
     그 창이 막힌다 — pending으로 남는 order는 실패든 성공이든 이 자원의 «시도 중인
     청구»라 사실상 자리를 차지하는 게 맞다(실패로 끝나면 다음 조회부터 그 order는
-    'failed'가 되어 자연히 카운트에서 빠진다)."""
+    'failed'가 되어 자연히 카운트에서 빠진다).
+
+    story #3097(선생님 결정 2026-08-26) — `billing_orders.amount_minor`는 purchase_packs가
+    VAT 가산 後 저장한 값(charge_org로 넘어간 실제 청구액)이라, 개수로 역산하려면 divisor도
+    같은 단위(VAT 가산된 개당 가격)여야 한다 — 원가 `price_minor`로 나누면 반올림 누적
+    오차로 수량이 큰 구간(예: q=10)에서 개수를 과다산정할 수 있다(직접 대조로 확認)."""
     total_amount = (
         await session.execute(
             text(
@@ -58,7 +65,7 @@ async def _packs_reserved_this_period(
             {"prefix": f"pack:{org_id}:{resource}:%", "start": period_start, "end": period_end},
         )
     ).scalar_one()
-    return int(total_amount) // price_minor if price_minor else 0
+    return int(total_amount) // taxed_price_minor if taxed_price_minor else 0
 
 
 async def purchase_packs(
@@ -95,6 +102,13 @@ async def purchase_packs(
         )
 
     price_minor = pack["price_minor"]
+    settings = await get_platform_settings(session)
+    # story #3097(선생님 결정 2026-08-26) — v2.3 확정가=공급가, 청구는 VAT 가산액. 개당
+    # 가산 後 quantity를 곱한다(가산 後 합산이 아니라) — _packs_reserved_this_period의
+    # 역산(총액÷개당가)이 임의 quantity에서 반올림 잔차 없이 정확히 나누어떨어지도록
+    # 하는 유일하게 안전한 순서(합산 後 가산은 나눗셈 역산 시 큰 quantity에서 드리프트
+    # 위험 — apply_vat_minor 독스트링 옆 계산 참고).
+    taxed_price_minor = apply_vat_minor(price_minor, settings.vat_rate_bp)
     max_packs = pack.get("max_packs")
     if max_packs is not None:
         if sub.current_period_start is None or sub.current_period_end is None:
@@ -112,7 +126,7 @@ async def purchase_packs(
         )
 
         already = await _packs_reserved_this_period(
-            session, org_id=org_id, resource=resource, price_minor=price_minor,
+            session, org_id=org_id, resource=resource, taxed_price_minor=taxed_price_minor,
             period_start=sub.current_period_start, period_end=sub.current_period_end,
         )
         if already + quantity > max_packs:
@@ -123,7 +137,7 @@ async def purchase_packs(
                 f"예약/구매, {quantity}개 추가 요청"
             )
 
-    amount_minor = price_minor * quantity
+    amount_minor = taxed_price_minor * quantity
     order_id = _pack_order_id(org_id, resource, idempotency_key)
 
     try:

--- a/backend/app/services/org_subscription_tier_change.py
+++ b/backend/app/services/org_subscription_tier_change.py
@@ -45,11 +45,13 @@ from app.models.org_subscription import OrgSubscription
 from app.services.billing_charge import charge_org
 from app.services.billing_charge_amount import (
     ChargeAmountError,
+    apply_vat_minor,
     compute_full_charge_for_new_offering,
     prorate_minor,
 )
 from app.services.billing_period import new_subscription_period
 from app.services.billing_refund import refund_org
+from app.services.platform_settings import get_platform_settings
 from app.services.org_subscription_checkout import STALE_CLAIM_WINDOW
 from app.services.payment.toss_adapter import TossApiError
 
@@ -236,8 +238,15 @@ async def change_tier(session: AsyncSession, *, org_id: uuid.UUID, new_tier: str
         # 직후 잔여 팩분 정산 등 예외 상태) 부분취소할 대상 자체가 없다는 뜻 — charge는
         # 이미 confirmed로 완결됐으니 여기서 실패로 되돌리지 않고 조용히 skip(로그만).
         if old_confirmed_order is not None:
+            # story #3097(선생님 결정 2026-08-26) — old_confirmed_order.amount_minor는
+            # 원래 청구 시점에 이미 VAT 가산된 값이다(compute_full_charge_for_new_offering
+            # 경로가 이 fix로 그렇게 청구한다) — 부분취소도 그 실제로 걷은 금액 기준으로
+            # 일할해야 한다. raw monthly_price_minor(공급가)로 그대로 일할하면 환불액이
+            # VAT분만큼 과소산정된다(실 청구액보다 덜 돌려줌).
+            settings = await get_platform_settings(session)
+            taxed_old_monthly = apply_vat_minor(old_offering.monthly_price_minor, settings.vat_rate_bp)
             refund_amount = prorate_minor(
-                old_offering.monthly_price_minor, now=now,
+                taxed_old_monthly, now=now,
                 period_start=old_period_start, period_end=old_period_end,
             )
             if refund_amount > 0:

--- a/backend/tests/test_2880_tier_change_upgrade_proration_realdb.py
+++ b/backend/tests/test_2880_tier_change_upgrade_proration_realdb.py
@@ -63,6 +63,13 @@ async def _seed_org(session):
     return org_id
 
 
+async def _vat_rate_bp(session):
+    """story #3097 — 실 DB의 platform_settings.vat_rate_bp(마이그 0282 기본 1000=10%)."""
+    row = (await session.execute(text("SELECT vat_rate_bp FROM platform_settings LIMIT 1"))).first()
+    assert row is not None, "platform_settings 행 없음 — 0255/0282 마이그 확認"
+    return row.vat_rate_bp
+
+
 async def _offering(session, tier):
     row = (
         await session.execute(
@@ -171,15 +178,24 @@ async def test_upgrade_charges_full_new_price_and_partial_refunds_prior_order_re
             await _seed_active_billing_key(session, org_id)
             prior_order_id, prior_payment_key = await _seed_prior_confirmed_order(session, org_id, amount_minor=starter_price)
 
-            toss_charge_response = {"paymentKey": f"pay-new-{uuid.uuid4()}", "totalAmount": team_price}
-            expected_refund_upper = math.floor(starter_price * (period_end - datetime.now(timezone.utc)).total_seconds() / (period_end - period_start).total_seconds())
+            # story #3097(선생님 결정 2026-08-26) — v2.3 확정가=공급가, 청구/부분취소 둘 다
+            # VAT 가산액 기준(compute_full_charge_for_new_offering·prorate_minor 호출부 fix).
+            from app.services.billing_charge_amount import apply_vat_minor
+            vat_rate_bp = await _vat_rate_bp(session)
+            taxed_team_price = apply_vat_minor(team_price, vat_rate_bp)
+            taxed_starter_price = apply_vat_minor(starter_price, vat_rate_bp)
+
+            toss_charge_response = {"paymentKey": f"pay-new-{uuid.uuid4()}", "totalAmount": taxed_team_price}
+            expected_refund_upper = math.floor(taxed_starter_price * (period_end - datetime.now(timezone.utc)).total_seconds() / (period_end - period_start).total_seconds())
             toss_cancel_response = _toss_cancel_response(expected_refund_upper)
 
             call_log = []
+            cancel_bodies = []
 
-            async def _fake_post(self, path, **kwargs):
+            async def _fake_post(self, path, *, json, **kwargs):
                 call_log.append(path)
                 if "cancel" in path:
+                    cancel_bodies.append(json)
                     return toss_cancel_response
                 return toss_charge_response
 
@@ -188,15 +204,30 @@ async def test_upgrade_charges_full_new_price_and_partial_refunds_prior_order_re
                 sub = await change_tier(session, org_id=org_id, new_tier="team")
             after_call = datetime.now(timezone.utc)
 
-            # AC① — 신 offering 전액 청구(delta 아님).
+            # AC① — 신 offering 전액(VAT 가산) 청구(delta 아님).
             new_order_row = (
                 await session.execute(
                     text("SELECT status, amount_minor FROM billing_orders WHERE org_id=:oid AND amount_minor=:amt AND order_id != :prior"),
-                    {"oid": org_id, "amt": team_price, "prior": prior_order_id},
+                    {"oid": org_id, "amt": taxed_team_price, "prior": prior_order_id},
                 )
             ).first()
-            assert new_order_row is not None, "신 offering 전액(team_price) 청구 row가 없음"
+            assert new_order_row is not None, "신 offering 전액(VAT 가산 team_price) 청구 row가 없음"
             assert new_order_row.status == "confirmed"
+
+            # story #3097 — 부분취소 cancelAmount가 VAT 가산 구 요금 기준으로 일할됐는지 직접
+            # 대조(원 공급가로 일할하면 환불액이 VAT분만큼 과소산정된다). prorate_minor의
+            # 내부 now()는 [before_call, after_call] 구간 안에서 찍히므로(코드 진입이
+            # before_call보다 늦고 반환이 after_call보다 이르다 — 정확한 스냅샷 시각을 몰라도
+            # 그 구간의 상/하한으로 범위를 좁힐 수 있다), 그 구간 양끝으로 계산한 범위 안에
+            # 실측값이 들어오는지로 검증한다(하드 동일값 비교는 ms 타이밍 레이스로 flaky).
+            assert len(cancel_bodies) == 1
+            lower_bound = math.floor(taxed_starter_price * (period_end - after_call).total_seconds() / (period_end - period_start).total_seconds())
+            upper_bound = math.floor(taxed_starter_price * (period_end - before_call).total_seconds() / (period_end - period_start).total_seconds())
+            assert lower_bound <= cancel_bodies[0]["cancelAmount"] <= upper_bound
+            # VAT 미가산(구 코드 산식)이었다면 이 범위보다 명확히 작았을 것 — 실제로 가산됐음을
+            # 방향성으로도 재확認.
+            raw_upper_bound = math.floor(starter_price * (period_end - before_call).total_seconds() / (period_end - period_start).total_seconds())
+            assert cancel_bodies[0]["cancelAmount"] > raw_upper_bound
 
             # AC③ — period 리셋.
             assert sub.tier == "team"

--- a/backend/tests/test_3097_vat_fe_be_cross_pin.py
+++ b/backend/tests/test_3097_vat_fe_be_cross_pin.py
@@ -1,0 +1,69 @@
+"""story #3097 delta-lite(페드루 PO 리뷰, PR#3506, 2026-08-26) — BE `apply_vat_minor`와
+FE `withVatKrw`(apps/web/src/ee/components/billing/pricing-data.ts)는 지금 값에서만
+일치하는 두 사본이다(율 하드코딩 vs 어드민값·가산 순서·반올림 규칙 3축이 다름 —
+billing_charge_amount.py::apply_vat_minor 독스트링 참고). 근본(단일 출처화)은 story
+#3104로 별도 추적 — 이 파일은 그 근본이 닫히기 전까지의 조기경보(tripwire)다.
+
+이 테스트가 빨개지면: vat_rate_bp 기본값·카탈로그 가격·반올림 산식 중 하나가 바뀌어
+FE 표시와 BE 실 청구가 갈라질 실측 신호 — story #3104를 당길 근거가 된다."""
+from __future__ import annotations
+
+from app.services.billing_charge_amount import apply_vat_minor
+
+# 마이그 0282 시드값과 동일 — FE `VAT_RATE=0.1`(pricing-data.ts) 하드코딩과의 현재
+# 일치 지점. 이 상수 자체가 바뀌면(어드민이 platform_settings.vat_rate_bp를 조정)
+# 이 파일의 기대값도 같이 갱신해야 한다 — 그 자체가 "드리프트 발생"의 신호다.
+_CURRENT_VAT_RATE_BP = 1000
+
+
+def test_apply_vat_minor_matches_current_default_rate():
+    """마이그 0282 기본값(1000bp=10%)과 일치 — 이 상수가 바뀌면 아래 FE 교차핀들도
+    전부 재검토 대상이 된다는 걸 여기서 먼저 알린다."""
+    assert _CURRENT_VAT_RATE_BP == 1000
+
+
+def test_automation_pack_single_unit_matches_fe_expected_total():
+    """FE billing-tab.test.tsx: automation 팩 1개 — withVatKrw(5,000) == 5,500."""
+    price_minor = 5_000
+    quantity = 1
+    # billing_pack.py::purchase_packs와 동일 순서(개당 가산 後 quantity 곱).
+    total = apply_vat_minor(price_minor, _CURRENT_VAT_RATE_BP) * quantity
+    assert total == 5_500
+
+
+def test_storage_pack_two_units_matches_fe_expected_total():
+    """FE billing-tab.test.tsx: storage 팩 2개 — withVatKrw(3,000*2) == 6,600."""
+    price_minor = 3_000
+    quantity = 2
+    total = apply_vat_minor(price_minor, _CURRENT_VAT_RATE_BP) * quantity
+    assert total == 6_600
+    # FE는 «합산 後 가산»(withVatKrw(price*quantity)) — 이 카탈로그 값(1,000원 단위)
+    # 에서는 BE의 «개당 가산 後 곱»과 결과가 우연히 일치한다. 그 우연 일치 자체를
+    # 명시로 고정 — 이 assert가 실패하면 두 산식이 갈렸다는 뜻(예: 가격이 1,000원
+    # 단위가 아니게 바뀌거나 vat_rate_bp가 나눗셈 잔차를 만드는 값으로 바뀔 때).
+    assert apply_vat_minor(price_minor, _CURRENT_VAT_RATE_BP) * quantity == apply_vat_minor(
+        price_minor * quantity, _CURRENT_VAT_RATE_BP
+    )
+
+
+def test_starter_subscription_matches_fe_expected_total():
+    """FE billing-tab.test.tsx(UpgradeCheckoutDialog 계열): withVatKrw(29,000) == 31,900
+    — 구독 청구(_compute_amount_for_offering)와 동일 «합산 後 가산» 순서."""
+    monthly_price_minor = 29_000
+    assert apply_vat_minor(monthly_price_minor, _CURRENT_VAT_RATE_BP) == 31_900
+
+
+def test_per_unit_then_multiply_can_diverge_from_total_then_vat_in_general():
+    """⚠️일러스트레이션(실 카탈로그 값 아님) — «개당 가산 後 곱»과 «합산 後 가산»이
+    항상 같지는 않다는 것을 보여준다. 가격이 10원 단위가 아니면(예: 1,111원) 반올림
+    잔차가 quantity배로 누적돼 두 산식이 다른 정수로 갈릴 수 있다 — 지금 카탈로그가
+    전부 1,000원 단위라 이 클래스의 실 발현이 안 보일 뿐, 산식 자체의 동치가 보장된
+    건 아니라는 걸 코드로 증명해 둔다(story #3104가 닫히기 전까지 카탈로그에 10원
+    단위 미만 가격을 넣지 말아야 하는 이유)."""
+    odd_price_minor = 1_111
+    quantity = 7
+    per_unit_then_multiply = apply_vat_minor(odd_price_minor, _CURRENT_VAT_RATE_BP) * quantity
+    total_then_vat = apply_vat_minor(odd_price_minor * quantity, _CURRENT_VAT_RATE_BP)
+    assert per_unit_then_multiply != total_then_vat, (
+        "이 케이스가 우연히 같아졌다면 예시 값을 다시 골라 divergence를 실제로 보여줄 것"
+    )

--- a/backend/tests/test_e_2500_charge_amount.py
+++ b/backend/tests/test_e_2500_charge_amount.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -45,6 +45,20 @@ def _exec_result(scalar_value):
     r.scalar_one.return_value = scalar_value
     r.scalar_one_or_none.return_value = scalar_value
     return r
+
+
+def _fake_settings(vat_rate_bp=1000):
+    """story #3097 — platform_settings.vat_rate_bp 목(default 1000bp=10%)."""
+    s = MagicMock()
+    s.vat_rate_bp = vat_rate_bp
+    return s
+
+
+def _patch_settings(vat_rate_bp=1000):
+    return patch(
+        "app.services.billing_charge_amount.get_platform_settings",
+        new=AsyncMock(return_value=_fake_settings(vat_rate_bp)),
+    )
 
 
 # ─── count_human_seats ──────────────────────────────────────────────────────
@@ -113,9 +127,11 @@ async def test_compute_charge_amount_base_only_no_overage_no_packs():
     session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(5)])
     session.get = AsyncMock(return_value=offering)
 
-    amount, currency = await compute_charge_amount(session, org_id=org_id)
+    with _patch_settings():
+        amount, currency = await compute_charge_amount(session, org_id=org_id)
 
-    assert amount == 59_000
+    # story #3097 — VAT 10% 가산(공급가 59,000 → 청구 64,900).
+    assert amount == 64_900
     assert currency == "krw"
 
 
@@ -131,9 +147,11 @@ async def test_compute_charge_amount_uses_annual_price_for_annual_cycle():
     session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(5)])
     session.get = AsyncMock(return_value=offering)
 
-    amount, _ = await compute_charge_amount(session, org_id=org_id)
+    with _patch_settings():
+        amount, _ = await compute_charge_amount(session, org_id=org_id)
 
-    assert amount == 590_000
+    # story #3097 — VAT 10% 가산(공급가 590,000 → 청구 649,000).
+    assert amount == 649_000
 
 
 @pytest.mark.anyio
@@ -149,9 +167,11 @@ async def test_compute_charge_amount_adds_seat_overage_at_extra_seat_price():
     session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(7)])
     session.get = AsyncMock(return_value=offering)
 
-    amount, _ = await compute_charge_amount(session, org_id=org_id)
+    with _patch_settings():
+        amount, _ = await compute_charge_amount(session, org_id=org_id)
 
-    assert amount == 59_000 + 2 * 11_000
+    # story #3097 — VAT 10% 가산(공급가 81,000 → 청구 89,100).
+    assert amount == round((59_000 + 2 * 11_000) * 1.1)
 
 
 @pytest.mark.anyio
@@ -166,9 +186,11 @@ async def test_compute_charge_amount_business_tier_uses_its_own_extra_seat_price
     session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(16)])
     session.get = AsyncMock(return_value=offering)
 
-    amount, _ = await compute_charge_amount(session, org_id=org_id)
+    with _patch_settings():
+        amount, _ = await compute_charge_amount(session, org_id=org_id)
 
-    assert amount == 219_000 + 1 * 9_900
+    # story #3097 — VAT 10% 가산.
+    assert amount == round((219_000 + 1 * 9_900) * 1.1)
 
 
 @pytest.mark.anyio
@@ -205,9 +227,15 @@ async def test_compute_charge_amount_includes_pack_charge_when_period_bounds_set
     session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(5), _exec_result(7_000)])
     session.get = AsyncMock(return_value=offering)
 
-    amount, _ = await compute_charge_amount(session, org_id=org_id)
+    # story #3097 — get_platform_settings는 별도 patch로 우회하므로(실제 구현은
+    # session.execute를 한 번 더 태우지만, 그 호출은 이 side_effect 리스트가 아니라
+    # 아래 _patch_settings()가 가로챈다) 위 side_effect는 sub/seat/pack 3건 그대로 유지.
+    with _patch_settings():
+        amount, _ = await compute_charge_amount(session, org_id=org_id)
 
-    assert amount == 59_000 + 7_000
+    # VAT는 base+seat(59,000)에만 가산, pack_amount(7,000)는 이미 원장에 VAT 가산되어
+    # 기록된 값이라(purchase_packs) 그대로 더한다(이중가산 방지).
+    assert amount == round(59_000 * 1.1) + 7_000
     assert session.execute.await_count == 3
 
 
@@ -225,9 +253,11 @@ async def test_compute_charge_amount_pack_charge_zero_without_period_bounds():
     session.execute = AsyncMock(side_effect=[_exec_result(sub), _exec_result(5)])
     session.get = AsyncMock(return_value=offering)
 
-    amount, _ = await compute_charge_amount(session, org_id=org_id)
+    with _patch_settings():
+        amount, _ = await compute_charge_amount(session, org_id=org_id)
 
-    assert amount == 59_000
+    # story #3097 — VAT 10% 가산.
+    assert amount == round(59_000 * 1.1)
     assert session.execute.await_count == 2
 
 

--- a/backend/tests/test_e_2500_charge_amount_realdb.py
+++ b/backend/tests/test_e_2500_charge_amount_realdb.py
@@ -63,7 +63,8 @@ async def test_team_tier_no_overage_realdb():
         async with Session() as session:
             org_id = await _seed_org(session, tier="team", billing_cycle="monthly", human_seats=5)
             amount, currency = await compute_charge_amount(session, org_id=org_id)
-            assert amount == 59_000
+            # story #3097 — VAT 10%(마이그 0282 기본 vat_rate_bp=1000) 가산.
+            assert amount == round(59_000 * 1.1)
             assert currency == "krw"
     finally:
         await engine.dispose()
@@ -80,7 +81,8 @@ async def test_team_tier_seat_overage_realdb():
             # included_seats=5, 7명 실좌석 → 2석 초과 * 11,000
             org_id = await _seed_org(session, tier="team", billing_cycle="monthly", human_seats=7)
             amount, currency = await compute_charge_amount(session, org_id=org_id)
-            assert amount == 59_000 + 2 * 11_000
+            # story #3097 — VAT 10% 가산(base+seat 합에).
+            assert amount == round((59_000 + 2 * 11_000) * 1.1)
             assert currency == "krw"
     finally:
         await engine.dispose()
@@ -96,7 +98,8 @@ async def test_business_tier_annual_cycle_realdb():
         async with Session() as session:
             org_id = await _seed_org(session, tier="business", billing_cycle="annual", human_seats=15)
             amount, currency = await compute_charge_amount(session, org_id=org_id)
-            assert amount == 2_190_000
+            # story #3097 — VAT 10% 가산.
+            assert amount == round(2_190_000 * 1.1)
             assert currency == "krw"
     finally:
         await engine.dispose()
@@ -147,7 +150,9 @@ async def test_pack_purchase_ledger_entries_included_when_period_set_realdb():
             )
 
             amount, _ = await compute_charge_amount(session, org_id=org_id)
-            assert amount == 59_000 + 7_000
+            # story #3097 — VAT는 base+seat에만 가산, 이미 기입된 pack 원장(7,000)은
+            # 그대로 더한다(이중가산 방지 — billing_charge_amount.py 주석 참고).
+            assert amount == round(59_000 * 1.1) + 7_000
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_e_2505_pack_purchase.py
+++ b/backend/tests/test_e_2505_pack_purchase.py
@@ -37,6 +37,20 @@ def _exec_result(scalar_value):
     return r
 
 
+def _fake_settings(vat_rate_bp=1000):
+    """story #3097 — platform_settings.vat_rate_bp 목(default 1000bp=10%)."""
+    s = MagicMock()
+    s.vat_rate_bp = vat_rate_bp
+    return s
+
+
+def _patch_settings(vat_rate_bp=1000):
+    return patch(
+        "app.services.billing_pack.get_platform_settings",
+        new=AsyncMock(return_value=_fake_settings(vat_rate_bp)),
+    )
+
+
 # ─── purchase_packs — 입력/전제 검증 ────────────────────────────────────────
 
 @pytest.mark.anyio
@@ -106,11 +120,11 @@ async def test_purchase_packs_raises_when_exceeding_max_packs():
     session.execute = AsyncMock(side_effect=[
         _exec_result(sub),          # sub lookup
         MagicMock(),                # advisory xact lock 획득
-        _exec_result(4 * 5_000),    # 이미 4개(20,000원어치) 예약/구매
+        _exec_result(4 * 5_500),    # 이미 4개(VAT 가산 개당 5,500원 × 4 = 22,000원어치) 예약/구매
     ])
     session.get = AsyncMock(return_value=offering)
 
-    with pytest.raises(PackPurchaseError, match="max_packs"):
+    with _patch_settings(), pytest.raises(PackPurchaseError, match="max_packs"):
         await purchase_packs(session, org_id=org_id, resource="au", quantity=2, idempotency_key="k1")  # 4+2 > 5
 
     session.rollback.assert_awaited_once()  # 락을 즉시 해제
@@ -131,11 +145,13 @@ async def test_purchase_packs_allows_up_to_max_packs_exactly():
     session.execute = AsyncMock(side_effect=[
         _exec_result(sub),
         MagicMock(),              # advisory xact lock 획득
-        _exec_result(3 * 5_000),  # 3개 이미 예약/구매
+        _exec_result(3 * 5_500),  # 3개 이미 예약/구매(VAT 가산 개당 5,500원)
     ])
     session.get = AsyncMock(return_value=offering)
 
-    with patch("app.services.billing_pack.charge_org", new=AsyncMock(return_value=confirmed_order)) as mock_charge:
+    with _patch_settings(), patch(
+        "app.services.billing_pack.charge_org", new=AsyncMock(return_value=confirmed_order)
+    ) as mock_charge:
         result = await purchase_packs(session, org_id=org_id, resource="au", quantity=2, idempotency_key="k1")  # 3+2=5=max
 
     assert result.status == "confirmed"
@@ -154,10 +170,15 @@ async def test_purchase_packs_no_cap_when_max_packs_none():
     confirmed_order.status = "confirmed"
 
     session = AsyncMock()
-    session.execute = AsyncMock(return_value=_exec_result(sub))  # max_packs None → 두번째 조회(구매이력) 안 함
+    # sub lookup(1)만 있으면 된다 — max_packs None → advisory lock/구매이력 조회 스킵.
+    # get_platform_settings는 session.execute가 아니라 별도 패치로 우회하므로 이 리스트에
+    # 안 섞인다.
+    session.execute = AsyncMock(return_value=_exec_result(sub))
     session.get = AsyncMock(return_value=offering)
 
-    with patch("app.services.billing_pack.charge_org", new=AsyncMock(return_value=confirmed_order)):
+    with _patch_settings(), patch(
+        "app.services.billing_pack.charge_org", new=AsyncMock(return_value=confirmed_order)
+    ):
         result = await purchase_packs(session, org_id=org_id, resource="lab_credit", quantity=100, idempotency_key="k1")
 
     assert result.status == "confirmed"
@@ -180,11 +201,14 @@ async def test_purchase_packs_charges_price_times_quantity_with_pack_purchase_en
     session.execute = AsyncMock(side_effect=[_exec_result(sub), MagicMock(), _exec_result(0)])
     session.get = AsyncMock(return_value=offering)
 
-    with patch("app.services.billing_pack.charge_org", new=AsyncMock(return_value=confirmed_order)) as mock_charge:
+    with _patch_settings(), patch(
+        "app.services.billing_pack.charge_org", new=AsyncMock(return_value=confirmed_order)
+    ) as mock_charge:
         await purchase_packs(session, org_id=org_id, resource="au", quantity=3, idempotency_key="click-1")
 
     kwargs = mock_charge.await_args.kwargs
-    assert kwargs["amount_minor"] == 5_000 * 3
+    # story #3097 — 청구액은 VAT 가산 後(개당 5,000×1.1=5,500 반올림 × 3).
+    assert kwargs["amount_minor"] == 5_500 * 3
     assert kwargs["currency"] == "krw"
     assert kwargs["entry_type"] == "pack_purchase"
     assert kwargs["ledger_metadata"] == {"resource": "au", "quantity": 3, "unit": 150_000}
@@ -204,11 +228,13 @@ async def test_purchase_packs_same_idempotency_key_is_deterministic_order_id():
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[
         _exec_result(sub), MagicMock(), _exec_result(0),
-        _exec_result(sub), MagicMock(), _exec_result(5_000),
+        _exec_result(sub), MagicMock(), _exec_result(5_500),
     ])
     session.get = AsyncMock(return_value=offering)
 
-    with patch("app.services.billing_pack.charge_org", new=AsyncMock(return_value=confirmed_order)) as mock_charge:
+    with _patch_settings(), patch(
+        "app.services.billing_pack.charge_org", new=AsyncMock(return_value=confirmed_order)
+    ) as mock_charge:
         await purchase_packs(session, org_id=org_id, resource="au", quantity=1, idempotency_key="same-key")
         await purchase_packs(session, org_id=org_id, resource="au", quantity=1, idempotency_key="same-key")
 
@@ -231,7 +257,7 @@ async def test_purchase_packs_declined_raises_with_order_attached():
     session.execute = AsyncMock(side_effect=[_exec_result(sub), MagicMock(), _exec_result(0), _exec_result(failed_order)])
     session.get = AsyncMock(return_value=offering)
 
-    with patch(
+    with _patch_settings(), patch(
         "app.services.billing_pack.charge_org",
         new=AsyncMock(side_effect=TossApiError("CARD_DECLINED", "카드 거절", status_code=400)),
     ):

--- a/backend/tests/test_e_2505_pack_purchase_realdb.py
+++ b/backend/tests/test_e_2505_pack_purchase_realdb.py
@@ -85,7 +85,8 @@ async def test_purchase_pack_confirms_and_writes_pack_purchase_ledger_realdb():
                 )
 
             assert order.status == "confirmed"
-            assert order.amount_minor == 10_000  # 5,000 * 2
+            # story #3097 — VAT 10% 가산(개당 5,000×1.1=5,500 × 2).
+            assert order.amount_minor == 11_000
 
             entry = (
                 await session.execute(
@@ -97,7 +98,7 @@ async def test_purchase_pack_confirms_and_writes_pack_purchase_ledger_realdb():
                 )
             ).first()
             assert entry.entry_type == "pack_purchase"
-            assert entry.amount_minor == 10_000
+            assert entry.amount_minor == 11_000
     finally:
         await engine.dispose()
 
@@ -238,6 +239,7 @@ async def test_purchase_pack_concurrent_requests_do_not_exceed_max_packs_realdb(
                     {"prefix": f"pack:{org_id}:au:%"},
                 )
             ).scalar_one()
-            assert total_packs_amount == 25_000  # 5개 * 5,000 — 6개(30,000)로 안 샘
+            # story #3097 — VAT 10% 가산(개당 5,500) — 5개 * 5,500. 6개(33,000)로 안 샘.
+            assert total_packs_amount == 27_500
     finally:
         await engine.dispose()

--- a/backend/tests/test_e_2506_subscription_checkout_realdb.py
+++ b/backend/tests/test_e_2506_subscription_checkout_realdb.py
@@ -108,7 +108,8 @@ async def test_checkout_full_flow_activates_subscription_and_writes_ledger_reald
                 )
             ).first()
             assert order_row.status == "confirmed"
-            assert order_row.amount_minor == 59_000
+            # story #3097 — VAT 10% 가산(공급가 59,000 → 청구 64,900).
+            assert order_row.amount_minor == 64_900
 
             # 원장(A2)에 charge 엔트리가 실제로 기입됐는지.
             ledger_row = (
@@ -118,7 +119,7 @@ async def test_checkout_full_flow_activates_subscription_and_writes_ledger_reald
                 )
             ).first()
             assert ledger_row.entry_type == "charge"
-            assert ledger_row.amount_minor == 59_000
+            assert ledger_row.amount_minor == 64_900
             assert ledger_row.direction == "credit"
     finally:
         await engine.dispose()


### PR DESCRIPTION
[SID:3097]

선생님 결정(2026-08-26) — v2.3 확定가=공급가(부가세 별도)·청구 시점 VAT 가산 구현. 실측(디디)으로 백엔드 청구 파이프라인 전체(billing_charge.py·toss_adapter.py·billing_charge_amount.py)에 VAT 승수가 없었음을 확認 — 구독 체크아웃 표시는 "(VAT 포함) 31,900원"인데 실 Toss 청구는 29,000원 그대로 청구되고 있었다(10% 표시≠청구 불일치).

## 변경
- `platform_settings.vat_rate_bp`(마이그 0282, basis points, 기본 1000=10%) — `dunning_grace_days`와 동일 선례(하드코딩·env var 금지, 어드민 관리값).
- `apply_vat_minor()`(billing_charge_amount.py) — 신규 순수 함수, FE `withVatKrw`와 동일 반올림 관례.
- 구독 청구(`_compute_amount_for_offering`) — base+seat(공급가)에만 VAT 가산, pack_amount는 그대로(이미 원장에 VAT 가산되어 기록된 값 — 이중가산 방지).
- 팩 구매(`billing_pack.py::purchase_packs`) — 개당 VAT 가산 後 quantity 곱(합산 後 가산이 아니라 — `_packs_reserved_this_period`의 총액÷개당가 역산이 임의 quantity에서 정확히 나누어떨어지려면 이 순서가 필수).
- tier 상향 부분취소(`org_subscription_tier_change.py`) — 구 요금 일할취소도 VAT 가산 기준(원 공급가로 일할하면 환불액이 VAT분만큼 과소산정된다).

## 검증
- mock 단위 테스트 78건 GREEN.
- realdb 30건 GREEN(로컬 disposable PG, alembic upgrade head) — tier 상향 부분취소는 실제 Toss 요청 바디의 cancelAmount를 캡처해 VAT 가산 기준 정확히 일할됐는지 직접 대조.
- 인접 billing 전체 회귀 341건 GREEN.

## 후속
FE(PackPurchaseDialog VAT 표시)는 별도 PR — story #3102(게이트 voided 클래스 선제 방지, #3100 교훈 적용).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>