### PR TITLE
feat(#3102): 팩 구매 확인창 VAT 표시 정정 — «VAT 별도»→«VAT 포함»

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2547,7 +2547,7 @@
     "packDialogAutomationAmount": "+{amount} automation units / mo",
     "packDialogStorageAmount": "+{amount}GB / mo",
     "packDialogChargeLabel": "Added charge",
-    "packDialogChargeValue": "{price}/mo (excl. VAT)",
+    "packDialogChargeValue": "{price}/mo (VAT included)",
     "packDialogAppliesLabel": "Applies",
     "packDialogAppliesValue": "Immediately · reflected from the next billing cycle",
     "packDialogCancel": "Cancel",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2547,7 +2547,7 @@
     "packDialogAutomationAmount": "+{amount} 자동화 단위 / 월",
     "packDialogStorageAmount": "+{amount}GB / 월",
     "packDialogChargeLabel": "추가 청구",
-    "packDialogChargeValue": "월 {price} (VAT 별도)",
+    "packDialogChargeValue": "월 {price} (VAT 포함)",
     "packDialogAppliesLabel": "적용",
     "packDialogAppliesValue": "즉시 · 다음 결제부터 반영",
     "packDialogCancel": "취소",

--- a/apps/web/src/ee/components/billing/billing-tab.test.tsx
+++ b/apps/web/src/ee/components/billing/billing-tab.test.tsx
@@ -4,7 +4,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../../messages/ko.json';
-import { BillingTab, UpgradeCheckoutDialog } from './billing-tab';
+import { BillingTab, PackPurchaseDialog, UpgradeCheckoutDialog } from './billing-tab';
 
 const replaceMock = vi.fn();
 let searchParams = new URLSearchParams();
@@ -345,5 +345,36 @@ describe('UpgradeCheckoutDialog — 확인 클릭 시 Toss 위젯을 연다(stor
       );
     });
     expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+  });
+});
+
+describe('PackPurchaseDialog — 청구 확인창은 VAT 가산액을 그대로 보인다(story #3097)', () => {
+  // story #3097(선생님 결정 2026-08-26) — v2.3 확정가=공급가, BE(billing_pack.py)가 이제
+  // 청구 시점에 실제로 VAT 10%를 가산한다. 이 확인창(청구 직전)도 UpgradeCheckoutDialog와
+  // 동일 원칙 — 실 청구액을 그대로 보여야 한다(withVatKrw 적용, "VAT 별도" 카피는 더는
+  // 정직하지 않음 — 실제로 VAT가 걸리기 때문).
+  it('automation 팩 1개 — 공급가 5,000원 → 표시 5,500원 "(VAT 포함)"', async () => {
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <PackPurchaseDialog target={{ kind: 'automation', quantity: 1 }} onClose={() => {}} />
+        </NextIntlClientProvider>,
+      );
+    });
+    expect(document.body.textContent).toContain('5,500원');
+    expect(document.body.textContent).toContain('VAT 포함');
+    expect(document.body.textContent).not.toContain('VAT 별도');
+  });
+
+  it('storage 팩 2개 — 공급가 3,000원×2=6,000원 → 표시 6,600원 "(VAT 포함)"', async () => {
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <PackPurchaseDialog target={{ kind: 'storage', quantity: 2 }} onClose={() => {}} />
+        </NextIntlClientProvider>,
+      );
+    });
+    expect(document.body.textContent).toContain('6,600원');
+    expect(document.body.textContent).toContain('VAT 포함');
   });
 });

--- a/apps/web/src/ee/components/billing/billing-tab.tsx
+++ b/apps/web/src/ee/components/billing/billing-tab.tsx
@@ -631,7 +631,7 @@ function CancelSubscriptionConfirmDialog({
   );
 }
 
-function PackPurchaseDialog({
+export function PackPurchaseDialog({
   target,
   onClose,
 }: {
@@ -641,7 +641,12 @@ function PackPurchaseDialog({
   const t = useTranslations('pricingPlans');
   if (target == null) return null;
   const pack = target.kind === 'automation' ? AUTOMATION_PACK : STORAGE_PACK;
-  const priceKrw = pack.priceKrwPerPack * target.quantity;
+  // story #3097(선생님 결정 2026-08-26) — v2.3 확정가=공급가, 청구 시점 VAT 10% 가산이
+  // BE(billing_pack.py::purchase_packs)에 이제 실제로 걸린다 — 이 확인창은 UpgradeCheckoutDialog/
+  // ChangeTierConfirmDialog와 동일 원칙(청구 직전 확인창=실 청구액을 그대로 보여준다)을
+  // 따라 withVatKrw를 적용한다. 마케팅 카탈로그(pricing-plan-card.tsx/pricing-packs.tsx)는
+  // 확정가(공급가)를 그대로 보이는 게 맞아 별개 — 그쪽은 안 건드림.
+  const priceKrw = withVatKrw(pack.priceKrwPerPack * target.quantity);
   const packTitleKey = target.kind === 'automation' ? 'automationPackTitle' : 'storagePackTitle';
 
   return (


### PR DESCRIPTION
[SID:3102]

선생님 결정(2026-08-26, #3097) — v2.3 확定가=공급가, BE가 이제 청구 시점에 실제로 VAT 10%를 가산한다(PR #3506). PackPurchaseDialog는 UpgradeCheckoutDialog/ChangeTierConfirmDialog와 동일 원칙(청구 직전 확인창=실 청구액을 그대로 보여준다)을 따라야 하는데, 지금까지는 공급가를 그대로 보이고 "VAT 별도" 라벨을 달고 있었다 — 이제 이 표시가 실 청구액보다 10% 낮게 보인다.

## 변경
- `PackPurchaseDialog`(billing-tab.tsx) — `priceKrw`에 `withVatKrw()` 적용.
- i18n(ko/en) `packDialogChargeValue` — "VAT 별도"→"VAT 포함".
- 마케팅 카탈로그(`pricing-plan-card.tsx`/`pricing-packs.tsx`)는 안 건드림 — 확정가(공급가)를 그대로 광고하는 게 맞는 별개 축(청구 직전 확인창과 다른 UX 맥락).

## 검증
- 신규 vitest 2건(automation/storage 팩 VAT 가산액+"VAT 포함" 카피 핀 고정).
- 전체 vitest 511파일/4592건 GREEN. eslint/tsc 클린.

## 선행
BE(#3097, PR #3506)가 먼저 착지 — 게이트 층 정합(work_item 단위 게이트가 형제 PR 머지 시 voided되는 클래스, #3100 실사고 교훈 선제 적용으로 스토리도 처음부터 분리).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>