### PR TITLE
[SID:3103] runtimeLabel 미등록 폴백 ?? key → ?? null — raw key 노출 클래스 닫기

### DIFF
--- a/apps/web/src/components/shared/avatar.test.tsx
+++ b/apps/web/src/components/shared/avatar.test.tsx
@@ -200,7 +200,10 @@ describe('Avatar — story #3092 2단계 커넥터 hover 툴팁', () => {
     expect(document.body.querySelector('[data-slot="tooltip-content"]')?.textContent).toBe('유나Agent');
   });
 
-  it('runtimeType이 registry 미등록 원값이어도 raw key를 그대로 노출하지 않고(runtimeLabel 계약) 보여준다', async () => {
+  // story #3103(DS·후속, 3505 design 판정 필수) — runtimeLabel() 미등록 폴백이
+  // `?? key`(원값 보존)에서 `?? null`로 바뀌었다(raw key 노출 0 전역 규칙과 정합). 이 테스트는
+  // 그 새 계약을 물려받아 "Agent" 단독 폴백으로 갱신한다(옛 원값 보존 기대치 폐기).
+  it('runtimeType이 registry 미등록 원값이면 raw key를 노출하지 않고 "Agent" 단독으로 폴백한다', async () => {
     await act(async () => {
       root.render(wrap(<Avatar name="유나" actorType="agent" runtimeType="unknown-runtime-x" />));
     });
@@ -209,8 +212,8 @@ describe('Avatar — story #3092 2단계 커넥터 hover 툴팁', () => {
       trigger.focus();
       await new Promise((r) => setTimeout(r, 900));
     });
-    // runtimeLabel()의 기존 계약(미등록값=원값 보존, S2 ⑤ 패턴)을 그대로 물려받는다 —
-    // 이 파일은 그 계약을 재정의하지 않는다. 여기선 "폴백이 죽지 않는다"만 고정.
-    expect(document.body.querySelector('[data-slot="tooltip-content"]')?.textContent).toBe('유나Agent · unknown-runtime-x');
+    const content = document.body.querySelector('[data-slot="tooltip-content"]')?.textContent;
+    expect(content).toBe('유나Agent');
+    expect(content).not.toContain('unknown-runtime-x');
   });
 });

--- a/apps/web/src/lib/runtime-capabilities.test.ts
+++ b/apps/web/src/lib/runtime-capabilities.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { runtimeLabel, RUNTIME_REGISTRY } from './runtime-capabilities';
+
+// story #3103(DS·후속, 3505 design 판정 필수) — runtimeLabel()의 미등록 폴백을
+// `?? key`(원값 보존)에서 `?? null`로 닫는다. registry 미등재 runtime_type이 raw key
+// 그대로 UI에 노출되던 잠복 클래스를 이 계약 변경으로 전면 차단한다.
+describe('runtimeLabel — story #3103 미등록 폴백 null 계약', () => {
+  it('null/undefined/빈 문자열은 null을 반환한다(기존 계약, 무변경)', () => {
+    expect(runtimeLabel(null)).toBeNull();
+    expect(runtimeLabel(undefined)).toBeNull();
+    expect(runtimeLabel('')).toBeNull();
+  });
+
+  it('registry 미등록 키는 raw key를 보존하지 않고 null을 반환한다(신규 계약)', () => {
+    expect(runtimeLabel('unknown-runtime-x')).toBeNull();
+    expect(runtimeLabel('internal-beta')).toBeNull();
+  });
+
+  it('양성대조 — registry에 등록된 9종 키는 전부 고유명사 라벨을 그대로 반환한다(회귀 없음)', () => {
+    for (const def of RUNTIME_REGISTRY) {
+      expect(runtimeLabel(def.key)).toBe(def.label);
+    }
+  });
+});

--- a/apps/web/src/lib/runtime-capabilities.ts
+++ b/apps/web/src/lib/runtime-capabilities.ts
@@ -86,10 +86,17 @@ export function resolveRuntimeStatus(runtimeType: string | null | undefined): Ru
 
 /**
  * runtime_type 키 → 사람이 읽는 표시명 (E-CHAT-CMD S8 #1 — hint·경고 카피의 {runtime} 바인딩용).
- * 등록키 → label(claude-code→"Claude Code") · 미등록값 → 원값 보존(S2 ⑤ 패턴) ·
- * null/빈값 → null(호출부가 i18n "런타임 미설정"으로 치환 — 순수 util은 번역 컨텍스트 없음).
+ * 등록키 → label(claude-code→"Claude Code") · null/빈값/미등록값 → null(호출부가 i18n
+ * "런타임 미설정"으로 치환하거나 라벨 자체를 생략 — 순수 util은 번역 컨텍스트가 없다).
+ *
+ * story #3103(DS·후속, 3505 design 판정 필수) — 미등록값 「원값 보존」(구 S2 ⑤ 패턴)을
+ * 폐기했다. registry 미등재 runtime_type이 실제로 들어오면 raw key(예: "internal-beta")가
+ * UI에 그대로 노출되는 잠복 클래스였다 — 전역 폴백 규칙("raw key 노출 0")과 충돌. 소비처
+ * 전수 확認 결과 모든 호출부(command-hint-notice·chat-input·team-presence-panel·Avatar
+ * 툴팁·workforce 상세 배지)가 이미 `?? fallback` 또는 truthy 체크로 null을 우아하게
+ * 처리하고 있어 이 변경만으로 닫힌다(호출부 수정 0).
  */
 export function runtimeLabel(key: string | null | undefined): string | null {
   if (!key) return null;
-  return getRuntimeDef(key)?.label ?? key;
+  return getRuntimeDef(key)?.label ?? null;
 }


### PR DESCRIPTION
## 배경
유나 #3505 design 판정(2026-08-26)에서 필수 후속으로 지정된 건. `runtimeLabel()`(lib/runtime-capabilities.ts)의 미등록 폴백이 `?? key`(원값 보존)라, registry 미등재 `runtime_type`이 들어오면 raw key가 UI에 그대로 노출되는 잠복 클래스였습니다(현재 registry 9종이 실사용 값을 전부 커버해 실노출 0이지만, 향후 신규 커넥터 추가 지연 등으로 미등록 값이 유입되면 즉시 재현).

## 변경
```diff
 export function runtimeLabel(key: string | null | undefined): string | null {
   if (!key) return null;
-  return getRuntimeDef(key)?.label ?? key;
+  return getRuntimeDef(key)?.label ?? null;
 }
```

## 소비처 전수 확認 (AC②)
grep으로 `runtimeLabel(` 호출부 전수 확인 — **호출부 수정 0건**(전부 이미 null을 우아 처리하는 계약으로 지어져 있었음):
- `command-hint-notice.tsx` / `chat-input.tsx` — `runtimeLabel(...) ?? t('runtimeUnsetLabel')`
- `team-presence-panel.tsx`(#3505) — `[role, runtimeLabel(...)].filter(Boolean).join(' · ')`
- `Avatar` 툴팁(#3505) — `runtimeLbl ? \`Agent · ${runtimeLbl}\` : 'Agent'`
- `organization/workforce/[id]/page.tsx` 커넥터 배지(#3505) — `runtimeLabel(...) ? <Badge>...</Badge> : null`

## ⚠️ DB DISTINCT runtime_type 실측 (AC③) — 미완, 권한 부재
이 세션 환경에서 dev/prod DB나 백엔드 API에 접근할 자격증명이 없습니다(로컬 `.env`의 `DATABASE_URL`은 `localhost:5432`를 가리키지만 실제로는 존재하지 않는 DB이고, 로컬 Postgres엔 과거 pytest 스크래치 DB들만 있어 실 데이터가 없습니다). 따라서 미등록 `runtime_type` 실재 여부를 직접 확認하지 못했습니다.

**다만 이 변경 자체는 실측 결과와 무관하게 안전합니다** — 위 소비처 전수 확認대로 모든 호출부가 이미 null을 우아하게 처리해, 최악의 경우도 "라벨이 조용히 사라짐"이지 크래시나 다른 회귀가 아닙니다. DB 실측은 디디군 또는 백엔드 접근 권한이 있는 쪽에 별도 요청이 필요합니다.

## 검증
- [x] `pnpm build`/`tsc --noEmit`/`eslint` 전부 클린
- [x] 신규 `runtime-capabilities.test.ts`(3건: null/미등록→null 핀 + registry 9종 양성대조)
- [x] `avatar.test.tsx`의 3505 "미등록값 원값 보존" 테스트를 새 계약("Agent" 단독 폴백)으로 갱신 + 관련 전체 스위트(18건) 통과

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011js9VYShN84eGzG3nSPYBn