### PR TITLE
feat(#3101): Board IA 1단계 B — 기본 착지=보드(칸반)·페이지 타이틀 «흐름»→«보드»

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -618,7 +618,7 @@
     "definerDerivedNone": "None"
   },
   "flow": {
-    "title": "Flow",
+    "title": "Board",
     "loading": "Loading…",
     "viewHypothesis": "Hypotheses",
     "viewFlow": "Flow",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -618,7 +618,7 @@
     "definerDerivedNone": "없음"
   },
   "flow": {
-    "title": "흐름",
+    "title": "보드",
     "loading": "불러오는 중…",
     "viewHypothesis": "가설",
     "viewFlow": "갈래",

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
@@ -319,21 +319,23 @@ describe('FlowPageClient — story #2365 후속(유나·PO, 2026-07-31) — 서�
   });
 });
 
-// story #2531(E-FLOW-V4 S1, PO 게이트 2026-08-08 재정의) — 「본체가 지도로 서는가」는
-// 이제 «칸반 탈피»가 아니라 «가설이 기본 랜딩(?view= 없음)으로 최상위를 차지하는가»다.
-// 그라운딩으로 밝혀진 대로 NextMakerScreen(갈래)은 이미 07-31에 칸반을 대체했었으므로,
-// 이 스토리가 실제로 바꾸는 것은 «기본값이 flow에서 hypothesis로 이동»한다는 것 하나 —
-// 그 값을 정확히 잰다.
-describe('FlowPageClient — story #2531(E-FLOW-V4 S1) 가설이 기본·최상위로 선다', () => {
-  it('?view= 없이 진입하면 기본으로 지구층(HypothesisEarthLayer)이 렌더된다 — 갈래·칸반이 아니다', async () => {
+// story #2531(E-FLOW-V4 S1, PO 게이트 2026-08-08 재정의) — 당시엔 「본체가 지도로
+// 서는가」를 «가설이 기본 랜딩(?view= 없음)으로 최상위를 차지하는가»로 판정해 데스크톱
+// 기본값을 hypothesis로 세웠다. ⛔story #3101(Board IA 1단계 B, PO 확定 2026-08-26)이
+// 그 판정을 다시 뒤집었다 — 탭 이름이 이미 "보드"인데 첫 착지가 가설 화면이면 명명과
+// 렌더가 어긋난다(§3043이 모바일에서 겪은 것과 같은 클래스, 이번엔 데스크톱) — 그래서
+// 데스크톱도 모바일처럼 list(칸반)가 기본이 됐다. 이 describe 이름·아래 첫 테스트는
+// #2531 당시의 값을 남겨두되(역사 기록), 실제 값은 #3101 기준으로 갱신한다.
+describe('FlowPageClient — story #2531→#3101 기본 랜딩 변천(현재=list/칸반)', () => {
+  it('?view= 없이 진입하면 기본으로 목록(KanbanBoard)이 렌더된다 — 가설·갈래가 아니다(#3101)', async () => {
     await renderFlowClient();
 
-    expect(container.querySelector('[data-testid="hypothesis-earth-layer-stub"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="kanban-board-stub"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="hypothesis-earth-layer-stub"]')).toBeNull();
     expect(container.querySelector('[data-testid="next-maker-screen-stub"]')).toBeNull();
-    expect(container.querySelector('[data-testid="kanban-board-stub"]')).toBeNull();
   });
 
-  it('세그에 가설·갈래·목록 3탭이 모두 뜨고, 가설 탭이 기본 활성 상태다', async () => {
+  it('세그에 가설·갈래·목록 3탭이 모두 뜬다', async () => {
     await renderFlowClient();
 
     const buttons = Array.from(container.querySelectorAll('button')).map((b) => b.textContent);
@@ -342,7 +344,7 @@ describe('FlowPageClient — story #2531(E-FLOW-V4 S1) 가설이 기본·최상�
     expect(buttons).toContain(koMessages.flow.viewList);
   });
 
-  it('갈래 탭(?view=flow)을 누르면 URL이 view=flow로 바뀌고(가설 기본에서 벗어남을 push로 확認)', async () => {
+  it('갈래 탭(?view=flow)을 누르면 URL이 view=flow로 바뀐다', async () => {
     await renderFlowClient();
 
     const flowTabButton = Array.from(container.querySelectorAll('button')).find(
@@ -358,7 +360,11 @@ describe('FlowPageClient — story #2531(E-FLOW-V4 S1) 가설이 기본·최상�
     expect(pushedUrl).toContain('view=flow');
   });
 
-  it('가설 탭으로 돌아가면(setView("hypothesis")) URL에서 view= 쿼리를 지운다(기본값=파라미터 없음)', async () => {
+  // story #3101 — 기본값이 list로 옮겨가며 "URL을 깨끗이 지워도 되는" 자격도 hypothesis에서
+  // list로 옮겨갔다(setView 주석 참고). 가설 탭을 누르면 이제 view=hypothesis를 명시로
+  // 남겨야 한다 — 예전처럼 지우면 parseView가 빈 URL을 list로 되돌려 읽어 가설 화면이
+  // 증발한다(G1 위반).
+  it('가설 탭을 누르면 URL에 view=hypothesis가 명시로 남는다(#3101, 기본값이 list로 바뀌어 지우면 안 됨)', async () => {
     currentSearch = 'view=flow';
     await renderFlowClient();
 
@@ -367,6 +373,21 @@ describe('FlowPageClient — story #2531(E-FLOW-V4 S1) 가설이 기본·최상�
     );
     await act(async () => {
       hypothesisTabButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const pushedUrl = pushMock.mock.calls[0]?.[0] as string;
+    expect(pushedUrl).toContain('view=hypothesis');
+  });
+
+  it('목록 탭으로 돌아가면(setView("list")) URL에서 view= 쿼리를 지운다(#3101, 기본값=파라미터 없음=list)', async () => {
+    currentSearch = 'view=flow';
+    await renderFlowClient();
+
+    const listTabButton = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === koMessages.flow.viewList,
+    );
+    await act(async () => {
+      listTabButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
     const pushedUrl = pushMock.mock.calls[0]?.[0] as string;
@@ -382,7 +403,7 @@ describe('FlowPageClient — story #2531(E-FLOW-V4 S1) 가설이 기본·최상�
 // dead-end였다(PO가 "모바일에 보드 없다"고 오답할 정도의 실사고). 이제 세그를 모바일에서도
 // 그대로 그리고(아래 새 describe), 파라미터 없을 때의 기본값도 list(칸반)로 바꾼다 — 원
 // 신고("보드가 안 보인다")에 가장 가까운 화면을 첫 진입 기본값으로 세운다.
-describe('FlowPageClient — story #3043(PO+유나 IA 확定) 모바일 기본값=list(칸반)', () => {
+describe('FlowPageClient — story #3043→#3101 기본값=list(칸반), 모바일·데스크톱 공용', () => {
   it('모바일(isMobile=true)·?view= 없음 이면 기본값이 list(KanbanBoard)다', async () => {
     isMobileMock = true;
     await renderFlowClient();
@@ -392,11 +413,16 @@ describe('FlowPageClient — story #3043(PO+유나 IA 확定) 모바일 기본�
     expect(container.querySelector('[data-testid="next-maker-screen-stub"]')).toBeNull();
   });
 
-  it('데스크톱(isMobile=false)·?view= 없음 이면 기존대로 가설이 기본값이다(회귀 없음)', async () => {
+  // story #3101(2026-08-26) — #2531 시절엔 이 케이스가 "가설이 기본값(회귀 없음)"이었으나,
+  // 그 판정 자체가 뒤집혔다(탭 이름="보드"인데 첫 착지가 가설이면 명명과 렌더가 어긋남).
+  // 이제 데스크톱도 모바일과 같은 기본값을 쓴다 — isMobile 분기가 parseView에서 아예
+  // 사라졌다(parseView 시그니처에서 isMobile 파라미터 제거).
+  it('데스크톱(isMobile=false)·?view= 없음 이면 이제 list(KanbanBoard)가 기본값이다(#3101)', async () => {
     isMobileMock = false;
     await renderFlowClient();
 
-    expect(container.querySelector('[data-testid="hypothesis-earth-layer-stub"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="kanban-board-stub"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="hypothesis-earth-layer-stub"]')).toBeNull();
   });
 
   it('모바일이라도 세그(가설|갈래|칸반)가 그려진다(예전엔 isMobile이면 렌더 자체를 안 했다)', async () => {
@@ -446,8 +472,10 @@ describe('FlowPageClient — story #3043(PO+유나 IA 확定) 모바일 기본�
 });
 
 describe('FlowPageClient — 카디르 QA fix(2026-08-09) ②패널 경계(구 2값 FlowView 잔재)', () => {
-  it('기본(가설) 뷰에서 ?story=<id>가 있어도 FlowNodeStoryPanel이 새지 않는다(가설 뷰엔 선택 UI 자체가 없다)', async () => {
-    currentSearch = 'story=story-leak';
+  it('가설 뷰에서 ?story=<id>가 있어도 FlowNodeStoryPanel이 새지 않는다(가설 뷰엔 선택 UI 자체가 없다)', async () => {
+    // story #3101 — 기본값이 list로 바뀌어(#2531 시절의 "기본=가설" 전제가 깨짐) 이 테스트가
+    // 실제로 검증하려는 뷰(가설)를 명시로 고정한다 — 기본값에 기대면 안 됨.
+    currentSearch = 'view=hypothesis&story=story-leak';
     await renderFlowClient();
 
     expect(container.querySelector('[data-testid="hypothesis-earth-layer-stub"]')).not.toBeNull();
@@ -457,7 +485,10 @@ describe('FlowPageClient — 카디르 QA fix(2026-08-09) ②패널 경계(구 2
 
 // story #2533(E-FLOW-V4 S3) — 가설 카드 클릭→수직 서사 패널.
 describe('FlowPageClient — story #2533 가설 카드 클릭이 서사 패널을 연다', () => {
-  it('가설 카드를 선택하면 ?hypothesis=<id>가 URL에 붙고 패널이 뜬다(view는 안 건드림)', async () => {
+  it('가설 카드를 선택하면 ?hypothesis=<id>가 URL에 붙고 패널이 뜬다(기존 view는 안 건드림)', async () => {
+    // story #3101 — 기본값이 list로 바뀌어 가설 뷰(HypothesisEarthLayer가 실제로 마운트되는
+    // 상태)를 명시로 고정해야 한다.
+    currentSearch = 'view=hypothesis';
     await renderFlowClient();
     expect(container.querySelector('[data-testid="hypothesis-narrative-panel-stub"]')).toBeNull();
 
@@ -470,7 +501,10 @@ describe('FlowPageClient — story #2533 가설 카드 클릭이 서사 패널�
     expect(pushMock).toHaveBeenCalledTimes(1);
     const pushedUrl = pushMock.mock.calls[0]?.[0] as string;
     expect(pushedUrl).toContain('hypothesis=hyp-abc');
-    expect(pushedUrl).not.toContain('view=');
+    // handleSelectHypothesis는 view를 안 건드린다 — 기존 view=hypothesis가 그대로 보존됨을
+    // 확認(#3101 전엔 기본값=파라미터없음=hypothesis라 "view= 자체가 없음"으로 이 불변식을
+    // 쟀으나, 이제 기본값이 list라 hypothesis 뷰 자체가 view=hypothesis 명시를 요구한다).
+    expect(pushedUrl).toContain('view=hypothesis');
   });
 
   it('?hypothesis=<id>가 이미 URL에 있으면(딥링크) 마운트 즉시 패널이 열린다', async () => {
@@ -535,6 +569,8 @@ describe('FlowPageClient — story #2535 지구→대륙→도시 드릴다운',
   });
 
   it('축척 브레드크럼은 가설 뷰에서는 flow-client 레벨에서 안 뜬다(HypothesisEarthLayer가 자기 안에서 이미 그림, 중복 방지)', async () => {
+    // story #3101 — 기본값이 list로 바뀌어 가설 뷰를 명시로 고정해야 한다(기본값 의존 금지).
+    currentSearch = 'view=hypothesis';
     await renderFlowClient();
     // HypothesisEarthLayer는 얇은 스텁이라 사다리를 자체적으로 안 그린다 — 그런데도 사다리
     // 특유 라벨(대륙/건물)이 뜨면 flow-client.tsx가 중복으로 그리고 있다는 뜻이다.
@@ -559,6 +595,19 @@ describe('FlowPageClient — story #2535 지구→대륙→도시 드릴다운',
 
 // story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — TopBar 타이틀=Heading
 // 무게로 재분류(크기는 TopBar 유지·구조 불변).
+// story #3101(Board IA 1단계 B, 명명 정합) — 탭 이름(sidebar "보드")과 페이지 타이틀이
+// 그동안 갈려 있었다("흐름"). 첫 착지 렌더가 list(칸반)로 바뀐 것과 한 이름 계열로 맞춘다.
+describe('FlowPageClient — 페이지 타이틀 "보드"(story #3101 명명 정합)', () => {
+  it('TopBar 타이틀 h1 텍스트가 "보드"다(탭 이름과 동일 계열, 예전 "흐름" 아님)', async () => {
+    await renderFlowClient();
+
+    const h1 = container.querySelector('h1');
+    expect(h1?.textContent).toBe(koMessages.flow.title);
+    expect(h1?.textContent).toBe('보드');
+    expect(h1?.textContent).not.toBe('흐름');
+  });
+});
+
 describe('FlowPageClient — TopBar 타이틀 Heading 무게(story #2969 PR-5)', () => {
   it('TopBar 타이틀 h1이 font-extrabold를 갖고 크기(text-sm)는 그대로다', async () => {
     await renderFlowClient();

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -55,12 +55,18 @@ type FlowView = 'hypothesis' | 'flow' | 'list';
 // 없으면(공유 링크·새로고침의 흔한 형태) 위 모바일 기본값(flow)이 이겨 서사 패널이
 // 렌더되지 않았다(패널은 view==='hypothesis'에서만 뜬다). hypothesis 파라미터가 있으면
 // «명시 view»와 동급으로 존중 — 모바일이어도 그 가설을 보러 온 것이 명백하므로.
-function parseView(raw: string | null, isMobile: boolean, hasHypothesisParam: boolean): FlowView {
+// story #3101(Board IA 1단계 B, 유나 규격 doc 85808039 SSOT, PO 확定 2026-08-26) — 데스크톱
+// 기본 랜딩도 모바일과 같은 이유로 'hypothesis'→'list'(보드/칸반)로 옮긴다: 탭 이름이 이미
+// "보드"인데(app-sidebar.tsx) 첫 착지가 가설 화면이면 명명과 렌더가 어긋난다(§2224/§3043이
+// 모바일에서 겪은 것과 같은 클래스, 이번엔 데스크톱). 불변식 「탭 이름=첫 착지 렌더」를 여기서
+// 만족시킨다. `?view=`/`?hypothesis=` 명시 파라미터는 그대로 존중(위 3줄 무변경) — 가설·갈래는
+// 세그 1클릭으로 여전히 도달 가능(G1, 매핑 고아 0).
+function parseView(raw: string | null, hasHypothesisParam: boolean): FlowView {
   if (raw === 'list' || raw === 'kanban') return 'list';
   if (raw === 'flow') return 'flow';
   if (raw === 'hypothesis') return 'hypothesis';
   if (hasHypothesisParam) return 'hypothesis';
-  return isMobile ? 'list' : 'hypothesis';
+  return 'list';
 }
 
 /**
@@ -90,10 +96,12 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
   // AC3와 같은 규율) — useIsMobile로 렌더 자체를 가른다. `?view=`는 모바일에서도 URL 정본
   // 그대로라 세그가 없어도 주소로 칸반 진입은 가능하다.
   const isMobile = useIsMobile();
-  // story #2531 — 기본값(파라미터 없음) 판정이 데스크톱/모바일에 따라 갈리므로 isMobile이
-  // 정해진 뒤에 view를 센다(카디르 ①HIGH fix). hasHypothesisParam은 카디르 재QA 비차단②
-  // (S3) — 모바일에서 `?hypothesis=`만 있는 공유링크/새로고침이 패널을 못 열던 것 fix.
-  const view = parseView(searchParams.get('view'), isMobile, searchParams.get('hypothesis') !== null);
+  // story #3101 — 기본값(파라미터 없음)이 이제 데스크톱/모바일 무관 'list' 하나로 고정돼
+  // parseView가 isMobile을 더는 받지 않는다(#2531 시절의 기기별 분기 fix는 여기서 소멸 —
+  // 애초에 「기본값이 기기마다 다르다」는 전제가 이번 정합으로 사라졌다). hasHypothesisParam은
+  // 카디르 재QA 비차단②(S3) — 모바일에서 `?hypothesis=`만 있는 공유링크/새로고침이 패널을
+  // 못 열던 것 fix, 이건 그대로 유지.
+  const view = parseView(searchParams.get('view'), searchParams.get('hypothesis') !== null);
 
   const [data, setData] = useState<GlanceData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -132,9 +140,14 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
     return () => { cancelledRef.cancelled = true; };
   }, [projectId, fetchData, orgSyncVersion]);
 
+  // story #3101 — 기본값(parseView의 파라미터-없음 폴백)이 'hypothesis'→'list'로
+  // 바뀌었으니, "URL을 깨끗이 지워도 되는" 뷰도 같이 옮겨야 한다. 예전 그대로 'hypothesis'
+  // 클릭 시 params.delete('view')를 두면 parseView가 그 빈 URL을 'list'로 되돌려 읽어
+  // 가설 탭을 눌러도 목록이 뜨는 회귀가 난다(G1 위반 — 가설 화면 증발) — 깨끗한 URL의
+  // 자격을 새 기본값(list)로 옮긴다.
   const setView = useCallback((next: FlowView) => {
     const params = new URLSearchParams(searchParams.toString());
-    if (next === 'hypothesis') params.delete('view');
+    if (next === 'list') params.delete('view');
     else params.set('view', next);
     const qs = params.toString();
     router.push(`/${wsSlug}/${projSlug}/flow${qs ? `?${qs}` : ''}`);


### PR DESCRIPTION
[SID:3101]

#3093(선생님 승인 시안) 단계 분해 1단계 B — 유나 규격 doc 85808039 SSOT, PO 확定 2026-08-26. 사이드바 탭은 이미 "보드"(nav-config.ts)인데 /flow 첫 착지 렌더는 가설 화면(§2531)이라 명명과 렌더가 어긋나 있었다 — 불변식 「탭 이름=첫 착지 렌더」를 이 PR로 만족시킨다. 경로는 /flow 유지(라벨-only, PO 확定).

## 변경
- `parseView()` — 데스크톱 기본값(파라미터 없음) 'hypothesis'→'list'(#3043이 이미 모바일에 적용한 것과 동형). `isMobile` 파라미터 제거(더는 이 함수와 무관).
- `setView()` — ⚠️함께 안 고치면 실사고 나는 지점: "URL을 깨끗이 지워도 되는" 뷰의 자격이 기본값과 함께 hypothesis→list로 옮겨간다. 안 고치면 가설 탭 클릭이 view= 를 지워 parseView가 빈 URL을 list로 되돌려 읽는 바람에 가설 탭을 눌러도 목록이 뜨는 회귀가 난다(G1 위반 — 가설 화면 증발). list만 지우고 hypothesis/flow는 명시로 남기도록 반전.
- i18n(ko/en) `flow.title` — "흐름"/"Flow" → "보드"/"Board".
- `?view=`/`?hypothesis=` 명시 딥링크는 전부 무변화(회귀 0).

## 검증
- flow-client.test.tsx 35건 GREEN — 기존 default-hypothesis 전제 테스트 6건을 명시 view= 고정으로 정정+setView 반전 테스트 갱신+신규 타이틀 텍스트 핀.
- 전체 vitest 512파일/4603건 GREEN. eslint/tsc 클린.
- G1(가설·갈래 1클릭 도달) 확認 — 신규/갱신 테스트로 고정.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>