### PR TITLE
fix(deploy): dev DATABASE_URL_DIRECT — postgres 수퍼유저→sprintable 앱 유저

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -609,9 +609,17 @@ steps:
         # 경유 시크릿으로 재바인딩(--update-secrets=additive, 기존 다른 시크릿 preserve — REDIS_URL_
         # PROD 등과 동일 컨벤션). prod는 이 플래그 자체를 안 넘겨 현재 DATABASE_URL_PROD 바인딩
         # 무변경. 시크릿 자체(DATABASE_URL_DEV_PGBOUNCER/DATABASE_URL_DIRECT_DEV)는 PO가 생성.
+        #
+        # story #3110 1보(2026-08-26, 보안 위생) — DATABASE_URL_DIRECT는 postgres 수퍼유저
+        # DSN(DATABASE_URL_DIRECT_DEV)이었다(pg_pubsub.py LISTEN/NOTIFY 전용 소비 — 애초에
+        # 수퍼유저가 필요 없는 경로). sprintable 앱 유저는 이미 public 197테이블 전부에 GRANT
+        # 보유(#3110 실측, postgres 116/197보다도 넓음) — 신규 시크릿 DATABASE_URL_DIRECT_DEV_
+        # SPRINTABLE(PO 발급·PO 실왕복 검증: current_user=sprintable·SELECT OK)로 전환.
+        # ⛔DATABASE_URL(PgBouncer 경유)은 이번 스코프 밖 — 유저 스왑이 PgBouncer userlist
+        # 갱신과 짝이라(안 맞추면 dev 서빙 인증 실패) #3110 2보로 분리.
         SECRETS_FLAG=""
         if [ "${_DEPLOY_ENV}" == "dev" ]; then
-          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV:latest"
+          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV_SPRINTABLE:latest"
         elif [ "${_DEPLOY_ENV}" == "prod" ]; then
           # story #2445 Phase1(2026-08-04) — prod cutover: DATABASE_URL→PgBouncer VIP(DATABASE_URL_PROD_PGBOUNCER,
           # =10.178.0.111:6432), DATABASE_URL_DIRECT→직결(DATABASE_URL_PROD). _BACKEND_DB_PGBOUNCER=true와 짝.


### PR DESCRIPTION
## Summary
- [보안 위생·dev #3110 1보] `cloudbuild.yaml:614`의 dev `DATABASE_URL_DIRECT` 시크릿 바인딩을 `DATABASE_URL_DIRECT_DEV`(postgres 수퍼유저) → `DATABASE_URL_DIRECT_DEV_SPRINTABLE`(sprintable 앱 유저)로 교체.
- 근거: 이 env가 유일하게 소비되는 지점(`pg_pubsub.py` LISTEN/NOTIFY)은 애초에 수퍼유저 권한이 필요 없고, sprintable 유저는 이미 public 197테이블 전부에 GRANT 보유(postgres 116/197보다도 넓음) — 최소 권한 원칙 위반 시정.
- 신규 시크릿은 PO 발급(값은 다루지 않음) + PO가 실왕복 검증(current_user=sprintable·SELECT OK) 완료.
- prod는 이미 sprintable 유저로 정상 배선(DATABASE_URL_PROD/PGBOUNCER 둘 다) — 이번 변경은 dev만, prod 무영향.
- ⛔범위 밖: `DATABASE_URL`(PgBouncer 경유)은 유저 스왑이 PgBouncer userlist 갱신과 짝이라 이번 PR에 안 넣음 — #3110 2보로 분리(그라운딩 진행 중).

[SID:3110]

## Test plan
- [x] `tests/test_deploy_backend_redis_secret_conflict.py`·`test_deploy_env.py`·`test_check_env_drift_code_read_axis.py`·`test_cloudbuild_migrate_wiring.py` 71건 green(하드코딩 시크릿명 충돌 없음 확認)
- [x] cloudbuild.yaml YAML 파싱 확認
- [ ] 다음 dev 배포에서 sprintable-backend-dev 기동 후 SSE(LISTEN/NOTIFY) 정상 동작 라이브 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GstUsgB3QHGDMxXJ3EijdW