### PR TITLE
[SID:3111] ScaleLadder activeLevel 매핑 정정 — view=list가 «작업»을 켜던 오류

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.test.tsx
@@ -578,18 +578,30 @@ describe('FlowPageClient — story #2535 지구→대륙→도시 드릴다운',
     expect(container.textContent).not.toContain(koMessages.flow.ladderName_building);
   });
 
-  it('갈래(view=flow) 뷰에서는 축척 브레드크럼이 "도시"를 활성으로 보인다', async () => {
+  // story #3111(Board IA·D0 선행 하드픽스, 유나 D0 그라운딩 발견) — activeLevel 매핑 전수를
+  // "텍스트가 존재한다"(항상 참 — 5개 rung 이름은 활성 여부와 무관하게 전부 렌더된다)가
+  // 아니라 실제 active 강조 클래스(scale-ladder.test.tsx와 동일 패턴)로 핀한다. 이전엔
+  // view=list가 «건물»(작업)을 활성화했는데, 칸반(view=list)의 단위는 스토리이므로 오류였다.
+  it('갈래(view=flow) 뷰에서는 축척 브레드크럼이 "도시"를 활성으로 보인다(가설·목표·거리·건물은 비활성)', async () => {
     currentSearch = 'view=flow';
     await renderFlowClient();
 
-    expect(container.textContent).toContain(koMessages.flow.ladderName_city);
+    const rungs = Array.from(container.querySelector('.flex.overflow-hidden')?.children ?? []);
+    const cityRung = rungs.find((d) => d.textContent?.includes(koMessages.flow.ladderName_city));
+    expect(cityRung?.className).toContain('bg-gradient-to-b');
+    expect(rungs.filter((d) => d.className.includes('bg-gradient-to-b'))).toHaveLength(1);
   });
 
-  it('목록(view=list) 뷰에서는 축척 브레드크럼이 "건물"을 활성으로 보인다', async () => {
+  it('목록(view=list) 뷰에서는 축척 브레드크럼이 "스토리"를 활성으로 보인다 — 이전엔 "건물"(작업)로 오매핑됐다(#3111)', async () => {
     currentSearch = 'view=list';
     await renderFlowClient();
 
-    expect(container.textContent).toContain(koMessages.flow.ladderName_building);
+    const rungs = Array.from(container.querySelector('.flex.overflow-hidden')?.children ?? []);
+    const streetRung = rungs.find((d) => d.textContent?.includes(koMessages.flow.ladderName_street));
+    const buildingRung = rungs.find((d) => d.textContent?.includes(koMessages.flow.ladderName_building));
+    expect(streetRung?.className).toContain('bg-gradient-to-b');
+    expect(buildingRung?.className).not.toContain('bg-gradient-to-b');
+    expect(rungs.filter((d) => d.className.includes('bg-gradient-to-b'))).toHaveLength(1);
   });
 });
 

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -273,9 +273,10 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
 
         {/* story #2535(E-FLOW-V4 S5) — 축척 브레드크럼. 가설 뷰는 HypothesisEarthLayer가
             자기 안에서 이미 사다리를 그리므로(지구=활성) 여기서 중복 안 그린다. 갈래=도시·
-            목록=건물 — 「지금 보는 층 = 묻는 질문 전환」을 탭 전환마다 같은 자리에서 보인다. */}
+            목록=거리(칸반의 단위는 스토리 — story #3111에서 «건물»=작업 오매핑 정정) —
+            「지금 보는 층 = 묻는 질문 전환」을 탭 전환마다 같은 자리에서 보인다. */}
         {view !== 'hypothesis' ? (
-          <ScaleLadder activeLevel={view === 'flow' ? 'city' : 'building'} compact={isMobile} />
+          <ScaleLadder activeLevel={view === 'flow' ? 'city' : 'street'} compact={isMobile} />
         ) : null}
 
         {view === 'hypothesis' ? (


### PR DESCRIPTION
## 배경
유나 D0 그라운딩(2026-08-26)서 발견: `flow-client.tsx`의 `activeLevel` 삼항이 `view === 'flow' ? 'city' : 'building'`이라 view=list(칸반=스토리 보드)에서도 'building'(작업)을 활성화하고 있었습니다. 칸반의 단위는 스토리이므로 'street'(스토리)가 맞습니다. D0 방향 결정(카드 520beb8b, 선생님 pending)과 무관한 즉발 매핑 버그입니다.

## 변경
- `flow-client.tsx`: `view === 'flow' ? 'city' : 'building'` → `'street'`. `ScaleLadder`를 렌더하는 조건(`view !== 'hypothesis'`) 안에서 'flow' 아닌 나머지는 'list' 뿐이라 else 분기 교체만으로 완결됩니다. 옆 주석도 "목록=건물"→"목록=거리"로 정정.
- `flow-client.test.tsx`: 기존 두 테스트가 "텍스트 존재"(active 여부와 무관하게 5개 rung 이름이 항상 렌더돼 참이 되는 약한 단언)만 검사해 이 버그를 못 잡고 있었습니다. 실제 active 강조 클래스(`scale-ladder.test.tsx`와 동일 패턴)로 강화했습니다 — view=list 테스트 제목·단언을 "건물 활성"에서 "스토리 활성(건물은 비활성)"으로 정정, view=flow도 동일 강도로 보강(다른 4칸 비활성 검증 추가).

## 스코프
AC2대로 하이라이트 위치만입니다 — 클릭 배선 등 D0 본체(«축척 네비게이터» 승격)는 이 PR 밖(선생님 pending, 후속 스토리 #7170cf29).

## 검증
- [x] `flow-client.test.tsx` + `scale-ladder.test.tsx` 43건 통과
- [x] `tsc --noEmit`/`eslint` 클린
- [x] `pnpm build` exit 0
- [x] 정적 프리뷰로 view=list → "스토리" 활성 렌더 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011js9VYShN84eGzG3nSPYBn