### PR TITLE
fix(deploy): GCS_AVATARS_BUCKET prod 배선 — 아바타 업로드 503 실사고 해소

### DIFF
--- a/backend/tests/test_check_env_drift_service_subset_axis.py
+++ b/backend/tests/test_check_env_drift_service_subset_axis.py
@@ -134,6 +134,46 @@ def test_comment_only_service_name_is_not_a_real_declaration():
     assert mod._SERVICE_NAME_RE.findall(comment_only) == ["sprintable-ghost-dev"]
 
 
+def test_bucket_keyed_literal_is_not_a_service_declaration():
+    """⭐story #3117(2026-08-26, PR#3520 카디르 qa:changes) — GCS_AVATARS_BUCKET을 prod에도
+    명시 배선(`GCS_AVATARS_BUCKET=sprintable-avatars-prod`)하자 이 스캐너가 유령 서비스로
+    오탐해 CI를 3연쇄 실패시켰다. 개별 리터럴 예외 추가(밴드에이드)가 아니라 "BUCKET이 든
+    key/변수의 값"이라는 컨텍스트로 구조적으로 걸러지는지 확認 — 다음 버킷 리터럴에도
+    재발하지 않아야 하므로 avatars가 아닌 **다른** 버킷명으로 증명한다."""
+    mod = _load_check_env_drift()
+    for line in (
+        'GCS_WIDGETS_BUCKET=sprintable-widgets-prod',
+        '_GCS_WIDGETS_BUCKET: sprintable-widgets-dev',
+        'BUCKET="sprintable-widgets-prod"',
+    ):
+        m = mod._SERVICE_NAME_RE.search(line)
+        assert m is not None, f"테스트 전제 실패 — 정규식 자체가 {line!r}에서 매치 안 됨"
+        assert mod._looks_like_resource_literal(line, m.start()), (
+            f"{line!r}이 서비스 선언으로 오판됨(BUCKET 컨텍스트 제외 실패)"
+        )
+
+
+def test_gs_uri_prefixed_literal_is_not_a_service_declaration():
+    """`gs://` 직후 리터럴도 GCS 리소스로 컨텍스트 배제 — 버킷명에 BUCKET이 안 든 경우까지
+    커버(예: `gcloud storage buckets update gs://sprintable-x-prod`)."""
+    mod = _load_check_env_drift()
+    line = "gcloud storage buckets update gs://sprintable-x-prod --cors-file=foo.json"
+    m = mod._SERVICE_NAME_RE.search(line)
+    assert m is not None
+    assert mod._looks_like_resource_literal(line, m.start())
+
+
+def test_real_service_declaration_still_caught_beside_bucket_literal():
+    """음성대조 — 버킷 컨텍스트 제외가 과해서 진짜 서비스 선언까지 삼키면 안 된다. 같은 파일
+    안에 버킷 리터럴과 유령 서비스 선언이 같이 있으면 유령만 걸려야 한다."""
+    mod = _load_check_env_drift()
+    line = 'GCS_WIDGETS_BUCKET=sprintable-widgets-prod; gcloud run deploy sprintable-typo-dev'
+    matches = list(mod._SERVICE_NAME_RE.finditer(line))
+    assert len(matches) == 2, "테스트 전제 실패 — 매치 2건이어야 함"
+    kept = [m.group(0) for m in matches if not mod._looks_like_resource_literal(line, m.start())]
+    assert kept == ["sprintable-typo-dev"]
+
+
 def test_external_iac_wellformed_positive_control(tmp_path, monkeypatch):
     """실제 리포 파일 대신 임시 디렉터리에 유령 서비스명을 심어 위반이 잡히는지 증명 —
     리포 원본은 건드리지 않는다."""

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -262,11 +262,14 @@ def test_deploy_backend_dev_includes_avatars_bucket_env_var():
     assert "GCS_AVATARS_BUCKET=sprintable-avatars-dev" in result
 
 
-def test_deploy_backend_prod_excludes_avatars_bucket_env_var():
-    """⭐prod 버킷 미프로비저닝 상태 — 값이 있어도 prod에는 이 키 자체가 없어야 한다(REDIS_URL/
-    ADMIN_OPERATOR_*와 동일 원칙, cloudbuild.yaml의 story #2887 주석 참고)."""
+def test_deploy_backend_prod_includes_avatars_bucket_env_var():
+    """⭐story #3117(2026-08-26, prod 실사고 후속) — prod 버킷(gs://sprintable-avatars-prod)을
+    PO가 프로비저닝 완료해 REDIS_URL/ADMIN_OPERATOR_*와 같던 "prod엔 키 자체가 없어야 안전"
+    유보가 풀렸다. 그 유보가 실사용 503(AVATAR_UPLOAD_NOT_CONFIGURED)으로 터진 게 이 스토리라
+    이제 prod는 substitution이 아닌 prod 전용 리터럴 버킷명을 싣는다(dev와 다른 값 — 취급
+    혼동 방지 위해 하드코딩 확인)."""
     result = _run_env_vars_assembly("prod", "")
-    assert "GCS_AVATARS_BUCKET" not in result
+    assert "GCS_AVATARS_BUCKET=sprintable-avatars-prod" in result
 
 
 def test_deploy_backend_includes_gotenberg_service_url_when_set():

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,11 +27,14 @@ substitutions:
   # 자체의 _reject_prod() 가드까지 삼중.
   _ADMIN_OPERATOR_AUDIENCE: https://sprintable-backend-dev-57iommnikq-du.a.run.app
   _ADMIN_OPERATOR_ALLOWLIST: sprintable-admin-web@sprintable-494803.iam.gserviceaccount.com
-  # story #2887(BE 아바타 업로드) — REDIS_URL/ADMIN_OPERATOR_*와 동일 원칙: dev만 싣는다.
-  # 버킷은 avatar 전용 신규 격리 버킷(sprintable-avatars-dev, public-read·uniform bucket-level
-  # access·cloudrun-runtime-dev=objectAdmin — 페드루 확定 2026-08-21)이고 prod 버킷은 아직
-  # 프로비저닝 전(심사 후 일괄)이라 prod에는 이 키 자체가 없어야 한다(설정 부재 시 코드가
-  # 업로드 발급을 503으로 fail-closed — REDIS_URL/GOTENBERG_SERVICE_URL과 동일 이중가드 원칙).
+  # story #2887(BE 아바타 업로드) — dev 버킷(sprintable-avatars-dev, public-read·uniform
+  # bucket-level access·cloudrun-runtime-dev=objectAdmin — 페드루 확定 2026-08-21).
+  # ⛔story #3117(2026-08-26, prod 실사고 — 선생님 아바타 업로드 503) 후속: 당시 "prod 버킷
+  # 미프로비저닝이라 prod에는 이 키 자체가 없어야 안전"이라 dev만 실었던 게 그대로 실사용에서
+  # 터졌다(AVATAR_UPLOAD_NOT_CONFIGURED fail-closed). prod 버킷(gs://sprintable-avatars-prod,
+  # 동형 IAM+CORS)을 PO가 프로비저닝 완료해 그 전제가 사라졌다 — 아래 배포 스텝에서 REDIS_URL/
+  # ADMIN_OPERATOR_*와 달리 이제 dev/prod 둘 다 명시 값으로 싣는다(prod는 substitution이 아닌
+  # 버킷명 리터럴 — DATABASE_URL_PROD류처럼 prod 값은 여기 substitutions에 안 둔다).
   _GCS_AVATARS_BUCKET: sprintable-avatars-dev
   # story #2771(pptx 서버 변환, doc 84ef0cb7 §7-4) — office-converter는 아래 deploy-office-
   # converter 스텝이 매 배포마다 재생성/갱신한다. **부트스트랩 완료(페드루군, 2026-08-19)**:
@@ -314,9 +317,14 @@ steps:
         echo "OK: dev Cloud Run regional origin confirmed in applied CORS"
     waitFor: ['-']
 
-  # story #2887 — avatar 전용 버킷(sprintable-avatars-dev) CORS. dev 전용 게이트(prod 버킷
-  # 미프로비저닝 — office-converter와 동일 스킵 관례). PUT까지 필요(memo-attachments는
-  # GET/HEAD뿐 — 아바타는 FE가 서명 URL로 직접 PUT하는 업로드 흐름이라 다름).
+  # story #2887 — avatar 전용 버킷 CORS. PUT까지 필요(memo-attachments는 GET/HEAD뿐 — 아바타는
+  # FE가 서명 URL로 직접 PUT하는 업로드 흐름이라 다름). CORS json(infra/gcs-avatars-cors.json)
+  # 자체는 dev/prod origin을 이미 다 실은 공용 파일(memo-attachments와 동일 관례) — 버킷명만
+  # env별로 갈린다.
+  # story #3117(2026-08-26, prod 실사고 후속) — 여태 dev 전용 게이트(prod 버킷 미프로비저닝)
+  # 였다가, PO가 prod 버킷(gs://sprintable-avatars-prod) CORS를 손으로 1회 적용해 그 유보를
+  # 풀었었다 — 그 손적용 자체가 드리프트 씨앗(다음 배포가 검증 안 하면 재적용 없이 방치)이라
+  # 여기 SSOT로 편입해 매 배포마다 멱등 재적용+검증하게 한다.
   - id: apply-gcs-avatars-cors
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
     entrypoint: bash
@@ -324,20 +332,29 @@ steps:
       - -c
       - |
         set -euo pipefail
-        if [ "${_DEPLOY_ENV}" != "dev" ]; then
-          echo "skip apply-gcs-avatars-cors: prod bucket pending (story #2887, 심사 후 일괄)"
-          exit 0
+        if [ "${_DEPLOY_ENV}" == "prod" ]; then
+          BUCKET="sprintable-avatars-prod"
+        else
+          BUCKET="${_GCS_AVATARS_BUCKET}"
         fi
-        gcloud storage buckets update gs://${_GCS_AVATARS_BUCKET} \
+        gcloud storage buckets update gs://$${BUCKET} \
           --cors-file=infra/gcs-avatars-cors.json \
           --quiet
-        applied=$(gcloud storage buckets describe gs://${_GCS_AVATARS_BUCKET} --format='value(cors_config)')
-        echo "${_GCS_AVATARS_BUCKET} CORS applied = $${applied}"
-        case "$${applied}" in
-          *https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app*) ;;
-          *) echo "FAIL: dev Cloud Run regional origin missing from applied CORS — 배포 검증 실패" >&2; exit 1 ;;
-        esac
-        echo "OK: dev Cloud Run regional origin confirmed in applied CORS"
+        applied=$(gcloud storage buckets describe gs://$${BUCKET} --format='value(cors_config)')
+        echo "$${BUCKET} CORS applied = $${applied}"
+        if [ "${_DEPLOY_ENV}" == "prod" ]; then
+          case "$${applied}" in
+            *https://app.sprintable.ai*) ;;
+            *) echo "FAIL: prod origin missing from applied CORS — 배포 검증 실패" >&2; exit 1 ;;
+          esac
+          echo "OK: prod origin confirmed in applied CORS"
+        else
+          case "$${applied}" in
+            *https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app*) ;;
+            *) echo "FAIL: dev Cloud Run regional origin missing from applied CORS — 배포 검증 실패" >&2; exit 1 ;;
+          esac
+          echo "OK: dev Cloud Run regional origin confirmed in applied CORS"
+        fi
     waitFor: ['-']
 
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
@@ -588,11 +605,13 @@ steps:
         if [ "${_DEPLOY_ENV}" != "prod" ]; then
           ENV_VARS="$${ENV_VARS},ADMIN_OPERATOR_AUDIENCE=${_ADMIN_OPERATOR_AUDIENCE},ADMIN_OPERATOR_ALLOWLIST=${_ADMIN_OPERATOR_ALLOWLIST}"
         fi
-        # story #2887 — GCS_AVATARS_BUCKET도 위와 동일 원칙(dev만). prod 버킷 미프로비저닝
-        # 상태에서 이 키가 prod에 실리면 코드 기본값(미설정)이 아니라 존재하지 않는 버킷명이
-        # 박혀 avatar 업로드가 500으로 터질 수 있다 — REDIS_URL/ADMIN_OPERATOR_*와 동일하게
-        # "값의 유무가 아니라 prod에는 이 키 자체가 없어야 안전" 원칙.
-        if [ "${_DEPLOY_ENV}" != "prod" ]; then
+        # story #3117(2026-08-26, prod 실사고 후속) — GCS_AVATARS_BUCKET은 REDIS_URL/
+        # ADMIN_OPERATOR_*와 달리 이제 dev/prod 양쪽 다 명시 값으로 싣는다(prod 버킷
+        # gs://sprintable-avatars-prod PO 프로비저닝 완료 — story #2887의 "prod엔 키 자체가
+        # 없어야 안전" 유보 전제가 사라짐, 그 유보가 실사용 503으로 터진 게 이 스토리).
+        if [ "${_DEPLOY_ENV}" == "prod" ]; then
+          ENV_VARS="$${ENV_VARS},GCS_AVATARS_BUCKET=sprintable-avatars-prod"
+        else
           ENV_VARS="$${ENV_VARS},GCS_AVATARS_BUCKET=${_GCS_AVATARS_BUCKET}"
         fi
         # ⛔QA catch(카디르군, 2026-08-19) — office-converter 자체가 dev 전용 하드게이트인데

--- a/infra/check_env_drift.py
+++ b/infra/check_env_drift.py
@@ -395,16 +395,34 @@ _WEB_CODE_SERVICES = {"sprintable-frontend-dev", "sprintable-frontend-prod"}
 _SERVICE_NAME_RE = re.compile(r"sprintable-[a-z]+-(?:dev|prod)")
 
 # `_SERVICE_NAME_RE`는 모양(`sprintable-*-{dev,prod}`)만 보는 정규식이라, Cloud Run 서비스가
-# 아닌 다른 리소스(GCS 버킷 등)의 이름이 우연히 같은 모양이면 구분 못한다. 마스터
-# (_SERVICE_SCRIPT_MAP)는 "실 서비스 8개"로 고정된 목록이라 여기 편입시키면 그 불변식이
-# 깨진다 — 그 대신 사유와 함께 여기서 명시 제외한다(주석-스트립과 같은 종류의 오탐 방지,
-# 다만 "주석"이 아니라 "다른 리소스 종류"가 원인).
-_NON_SERVICE_LITERAL_ALLOWLIST: dict[str, str] = {
-    "sprintable-avatars-dev": (
-        "story #2887 — avatar 업로드 전용 GCS 버킷(cloudbuild.yaml _GCS_AVATARS_BUCKET). "
-        "Cloud Run 서비스가 아님."
-    ),
-}
+# 아닌 다른 리소스(GCS 버킷 등)의 이름이 우연히 같은 모양이면 구분 못한다.
+#
+# ⛔story #3117(2026-08-26, PR#3520 카디르 qa:changes) — GCS_AVATARS_BUCKET을 prod에도 명시
+# 배선(`GCS_AVATARS_BUCKET=sprintable-avatars-prod`·`BUCKET="sprintable-avatars-prod"`)하자
+# 이 스캐너가 그 리터럴을 "유령 서비스"로 오탐해 CI를 3연쇄 실패시켰다. 개별 리터럴을
+# `_NON_SERVICE_LITERAL_ALLOWLIST`에 하나씩 추가하는 건 밴드에이드다(다음 버킷/GCS 리소스
+# 리터럴마다 재발하는 클래스) — 대신 매치 **직전 컨텍스트**로 "이건 GCS 버킷 참조다"를
+# 구조적으로 가른다: 이 저장소의 모든 버킷 참조는 예외 없이 (a) `gs://` 뒤에 오거나
+# (b) 이름에 BUCKET이 들어간 키/변수(`_GCS_AVATARS_BUCKET:`·`GCS_AVATARS_BUCKET=`·
+# `BUCKET="`류)의 값으로만 등장한다(실측: 이 파일들의 서비스 선언 8종 — SERVICE_NAME=·
+# FASTAPI_SERVICE=·FASTAPI_URL=·https:// 자동생성 URL·`gcloud run deploy/services` 커맨드 —
+# 그 어느 것도 이름에 BUCKET이 없다). `_looks_like_resource_literal()`이 이 두 컨텍스트를
+# 매치 직전 텍스트로 판별한다 — 새 버킷을 몇 개를 더 만들어도 이 두 관례(BUCKET named
+# key/`gs://`)만 지키면 이 가드가 자동으로 걸러낸다(마스터 불변식은 그대로 유지).
+_NON_SERVICE_LITERAL_ALLOWLIST: dict[str, str] = {}
+
+# BUCKET이 들어간 key/변수명 뒤에(`:`/`=`, 옵션 인용부호) 곧바로 오는 값 — GCS 버킷 참조.
+_BUCKET_KEY_CONTEXT_RE = re.compile(r"[A-Za-z_]*BUCKET[A-Za-z_]*\s*[:=]\s*[\"']?$", re.IGNORECASE)
+
+
+def _looks_like_resource_literal(line: str, match_start: int) -> bool:
+    """매치 직전 컨텍스트(같은 줄, 매치 앞부분)로 "Cloud Run 서비스명이 아니라 다른 GCP
+    리소스(GCS 버킷 등) 리터럴"인지 판별. `gs://` 직후이거나, BUCKET이 든 key/변수의 값이면
+    True(서비스명 후보에서 제외)."""
+    prefix = line[:match_start]
+    if prefix.endswith("gs://"):
+        return True
+    return bool(_BUCKET_KEY_CONTEXT_RE.search(prefix))
 
 
 def _service_subset_wellformed_violations() -> list[str]:
@@ -451,7 +469,11 @@ def _external_iac_service_literals() -> set[str]:
     names: set[str] = set()
     for path in targets:
         for line in path.read_text().splitlines():
-            names |= set(_SERVICE_NAME_RE.findall(_strip_comment(line)))
+            stripped = _strip_comment(line)
+            for m in _SERVICE_NAME_RE.finditer(stripped):
+                if _looks_like_resource_literal(stripped, m.start()):
+                    continue
+                names.add(m.group(0))
     return names - set(_NON_SERVICE_LITERAL_ALLOWLIST)
 
 


### PR DESCRIPTION
## Summary
- [P2·prod 실사고] 선생님 아바타 업로드 503(`AVATAR_UPLOAD_NOT_CONFIGURED`) — story #2887이 "prod 버킷 미프로비저닝이라 prod엔 이 키 자체가 없어야 안전"으로 dev만 `GCS_AVATARS_BUCKET`을 실었던 유보가 그대로 실사용에서 터졌다.
- PO가 prod 버킷(`gs://sprintable-avatars-prod`, ASIA-NORTHEAST3·uniform·runtime-prod objectAdmin+allUsers objectViewer·CORS 3 origin)을 프로비저닝 완료 — 전제 해소.
- `cloudbuild.yaml` 배포 스텝: dev/prod 양쪽 다 `GCS_AVATARS_BUCKET`을 명시 값으로(prod는 리터럴 `sprintable-avatars-prod`).
- `apply-gcs-avatars-cors` 스텝: dev 전용 스킵 게이트를 풀어 prod 버킷도 매 배포 CORS 멱등 재적용+검증 — PO의 1회성 손적용이 드리프트 씨앗이 되는 걸 막음(SSOT 편입).

[SID:3117]

## Test plan
- [x] `test_deploy_backend_redis_secret_conflict.py`(cloudbuild.yaml 스크립트를 동적 추출해 실행하는 회귀가드, 13건 — substitution-escape 스캔·byte-limit 가드 포함) green, `GCS_AVATARS_BUCKET` prod 테스트를 exclude→include로 갱신
- [x] 인접 deploy 테스트 111건(realtime GCE·migrate wiring 등) green
- [x] cloudbuild.yaml YAML 파싱 확認
- [ ] 머지→prod 배포 후 라이브 검증(upload-url 200+실업로드 왕복+public read) — PO가 닫음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GstUsgB3QHGDMxXJ3EijdW