### PR TITLE
fix(#aec3ec09): [SID:3116] oauth-return 페이지 custom scheme 버튼

### DIFF
--- a/apps/web/src/app/native/oauth-return/page.test.tsx
+++ b/apps/web/src/app/native/oauth-return/page.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+//
+// [P1 후속] 산티아고 조건부 허용(2026-08-26) — custom scheme(ai.sprintable) 홉은 사용자 탭
+// 없이 자동 발동 금지(intent-squatting 공격면 완화). 이 페이지가 자동 location.replace를
+// 하지 않고 버튼 탭에서만 이동하는지, 이동 대상 URI가 App.js OAUTH_RETURN_SCHEME_URL과
+// byte-exact(ai.sprintable:/oauth-return, 단일 슬래시)인지가 이 테스트의 핵심 축.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const h = vi.hoisted(() => ({ searchParams: new URLSearchParams() }));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => h.searchParams,
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.resetModules();
+});
+
+async function mountAndWait() {
+  const { default: NativeOauthReturnPage } = await import('./page');
+  await act(async () => { root.render(<NativeOauthReturnPage />); });
+}
+
+describe('NativeOauthReturnPage — custom scheme 버튼 (P1 후속)', () => {
+  it('code 쿼리를 그대로 전달하는 ai.sprintable:/oauth-return 앵커를 렌더한다(자동 리다이렉트 없음)', async () => {
+    h.searchParams = new URLSearchParams('code=abc123');
+    await mountAndWait();
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toBe('ai.sprintable:/oauth-return?code=abc123');
+  });
+
+  it('쿼리가 없으면 물음표 없는 base URI 그대로(가짜 빈 쿼리 접미 금지)', async () => {
+    h.searchParams = new URLSearchParams();
+    await mountAndWait();
+    const anchor = container.querySelector('a');
+    expect(anchor?.getAttribute('href')).toBe('ai.sprintable:/oauth-return');
+  });
+
+  it('scheme은 이중 슬래시가 아니다(ai.sprintable:/ — App.js OAUTH_RETURN_SCHEME_URL과 byte-exact)', async () => {
+    h.searchParams = new URLSearchParams('code=xyz');
+    await mountAndWait();
+    const anchor = container.querySelector('a');
+    expect(anchor?.getAttribute('href')).not.toContain('ai.sprintable://');
+  });
+
+  it('자동 이동 스크립트 없음 — location.replace/href 대입이 마운트만으로 실행되지 않는다', async () => {
+    const originalHref = window.location.href;
+    h.searchParams = new URLSearchParams('code=abc123');
+    await mountAndWait();
+    expect(window.location.href).toBe(originalHref);
+  });
+
+  it('여러 쿼리 파라미터도 순서 보존해 그대로 전달한다', async () => {
+    h.searchParams = new URLSearchParams('code=abc123&state=xyz');
+    await mountAndWait();
+    const anchor = container.querySelector('a');
+    expect(anchor?.getAttribute('href')).toBe('ai.sprintable:/oauth-return?code=abc123&state=xyz');
+  });
+});

--- a/apps/web/src/app/native/oauth-return/page.tsx
+++ b/apps/web/src/app/native/oauth-return/page.tsx
@@ -1,17 +1,40 @@
-// [P1 인시던트] AASA 미서빙으로 유니버설 링크 복귀가 실패하면 인앱 브라우저가 이 경로를 직접
-// 로드한다 — 그 경우에도 raw 404는 안 된다(PO 지시). custom scheme 폴백은 별건 HOLD 스토리
-// (E-MOBILE OAuth 복귀 App Link 단일 의존 제거)라 여기서 자동 리다이렉트를 시도하지 않는다 —
-// 로그인 자체는 이미 끝났다는 것만 알리고 사용자가 직접 앱으로 돌아가게 안내한다.
-export const metadata = { title: 'Sprintable' };
+'use client';
+
+// [P1 인시던트→P1 후속] AASA 미서빙으로 유니버설 링크 복귀가 실패하면(또는 iOS 17.4 미만 —
+// ASWebAuthenticationSession의 https 콜백 인식 자체가 그 미만에서 성립하지 않는다, App.js
+// supportsUniversalLinkCallback 참조) 인앱 시트가 이 경로를 직접 로드한다.
+//
+// 이 페이지가 실제로 렌더된다는 것 자체가 이미 "17.4+ https 자동 복귀"가 아닌 경로라는 뜻이다
+// — 17.4+ 기기는 OS가 유니버설 링크를 세션 안에서 가로채 이 페이지가 로드되기 전에 시트를
+// 닫는다. 그래서 모드 감지 로직은 불요: 여기 도달했으면 항상 custom scheme(ai.sprintable)
+// 폴백 대상이다(선생님 직권 확定+산티아고 사후 조건부 허용, 2026-08-26).
+//
+// ⛔산티아고 조건: custom scheme 홉은 **사용자 탭(명시적 상호작용)** 없이 자동 발동 금지 —
+// intent-squatting 공격면 완화 조건 중 하나(계약 doc 5e2964d6 재검토). 자동 location.replace
+// 금지, 버튼 탭에서만 이동한다. scheme·path는 App.js OAUTH_RETURN_SCHEME_URL과 byte-exact
+// (`ai.sprintable:/oauth-return` — 단일 슬래시).
+import { useSearchParams } from 'next/navigation';
+
+const OAUTH_RETURN_SCHEME_URL = 'ai.sprintable:/oauth-return';
 
 export default function NativeOauthReturnPage() {
+  const searchParams = useSearchParams();
+  const query = searchParams.toString();
+  const appReturnUrl = query ? `${OAUTH_RETURN_SCHEME_URL}?${query}` : OAUTH_RETURN_SCHEME_URL;
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-muted px-4">
       <div className="max-w-sm rounded-2xl bg-background p-8 text-center shadow-sm">
         <h1 className="mb-2 text-lg font-semibold text-foreground">로그인이 완료됐습니다</h1>
-        <p className="text-sm text-muted-foreground">
-          이 화면은 닫으시고 Sprintable 앱으로 돌아가 주세요.
+        <p className="mb-6 text-sm text-muted-foreground">
+          아래 버튼을 눌러 Sprintable 앱으로 돌아가 주세요.
         </p>
+        <a
+          href={appReturnUrl}
+          className="inline-flex min-h-[44px] w-full items-center justify-center rounded-lg bg-brand px-4 py-3 text-sm font-medium text-brand-foreground transition hover:bg-brand/90"
+        >
+          Sprintable 앱으로 돌아가기
+        </a>
       </div>
     </div>
   );


### PR DESCRIPTION
## 무엇

선생님 dev 실기기(iOS 16.7) 왕복 불발 후속 — iOS 17.4 미만은 ASWebAuthenticationSession legacy `callbackURLScheme` 경로(모바일 [PR #72](https://github.com/moonklabs/sprintable-mobile/pull/72))로 가는데, 그 경로가 실제로 완결되려면 이 페이지가 custom scheme(`ai.sprintable`)으로 한 홉 더 이동해야 한다.

관련 스토리: [\[P1 후속·E-MOBILE\] OAuth 핸드오프 활성화](entity:story:aec3ec09-6033-47b5-a44d-0b2239ab49ac)

## 왜 모드 감지가 불요한가(그라운딩, PO 확認)

이 페이지가 실제로 렌더된다는 것 자체가 이미 "17.4+ https 자동 복귀"가 아닌 경로라는 뜻이다 — 17.4+ 기기는 OS가 유니버설 링크를 세션 안에서 가로채 이 페이지가 로드되기 전에 시트를 닫는다. 그래서 여기 도달하면 **항상** custom scheme 폴백 대상 — 별도 모드 감지 로직 불요.

## 산티아고 조건(intent-squatting 완화, 2026-08-26)

custom scheme 홉은 **사용자 탭 없이 자동 발동 금지**. `location.replace` 자동 리다이렉트 대신 "Sprintable 앱으로 돌아가기" 버튼(명시적 상호작용)만 이동을 트리거한다.

## 무엇을 고쳤나

`/native/oauth-return` 페이지를 클라이언트 컴포넌트로 전환 — `useSearchParams()`로 쿼리(예 `code=...`)를 읽어 `ai.sprintable:/oauth-return?<query>` 앵커를 렌더. 이동 대상 URI는 모바일 `App.js`의 `OAUTH_RETURN_SCHEME_URL`과 byte-exact(단일 슬래시 `:/` — RFC 8252 opaque URI 형태).

## 증거

- `vitest` 신규 5개(href 정확값·빈 쿼리·이중슬래시 회귀가드·자동이동 없음·다중 쿼리 순서보존) 포함 `apps/web` 516개 파일/4648개 테스트 전체 그린.
- `tsc --noEmit` 클린, `eslint` 0.
- `next build` 그린, 라우트 매니페스트에 `/native/oauth-return` 확認.
- `next start` + curl 실측: 실제 렌더된 HTML의 `<a href>`가 `ai.sprintable:/oauth-return?code=abc123test` — 쿼리 그대로 전달 확認.

## Test plan

- [x] vitest 신규 회귀가드 + 전체 스위트 그린
- [x] tsc/eslint 클린
- [x] next build + curl 실측(href 정확값)
- [ ] dev 실기기(iOS 16.7) 재설치 + Google 로그인 왕복에서 이 버튼 탭 → 앱 세션 확립 실측(모바일 PR #72와 짝)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZzVLFLVJ3MePFeprri6mK