### PR TITLE
fix(#aec3ec09): firebase_oauth_handoff_enabled prod on

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -196,10 +196,9 @@ jobs:
             # 손대지 않는다(#2120/#2121/#2122와 동일 단계적 승격 원칙). 명시 false로 다른
             # 플래그들과 동일 컨벤션 유지(암묵 fallback 대신 의도 명시).
             echo "backend_sse_transient_replay_enabled=false" >> "$GITHUB_OUTPUT"
-            # story aec3ec09([P1 후속] OAuth 핸드오프 활성화) — dev 실기기 왕복 통과 전까지
-            # prod는 손대지 않는다(위 transient_replay와 동일 단계적 승격 원칙). 통과 후
-            # 이 한 줄만 "true"로 바꾸는 게 다음 처방(별도 PR).
-            echo "firebase_oauth_handoff_enabled=false" >> "$GITHUB_OUTPUT"
+            # story aec3ec09([P1 후속] OAuth 핸드오프 활성화) — dev 실기기 왕복 통과(2026-08-26,
+            # 선생님 iOS 앱 내 메시지 발신까지 확認·세션 확립 실증) 확認 후 prod on으로 승격.
+            echo "firebase_oauth_handoff_enabled=true" >> "$GITHUB_OUTPUT"
             # ⚠️승격 병합(promo/20260727·PO): 위 프론트 인스턴스 수·transient replay 스위치(develop #2077)와
             # 아래 REALTIME_URL 전환(main #2142/#2439)은 **서로 무관한 prod env 출력**이라 둘 다 보존한다.
             # 직전 승격(promo/backplane-20260723)이 같은 자리에서 같은 판단을 했고 그 근거가 아래 주석에 남아 있다.


### PR DESCRIPTION
## 무엇

선생님 dev 실기기(iOS 16.7, custom scheme 폴백 경로) Google 로그인 왕복 통과 — iOS 앱 내에서 메시지 발신까지 확認, 세션 확립 실증(2026-08-26).

관련 스토리: [\[P1 후속·E-MOBILE\] OAuth 핸드오프 활성화](entity:story:aec3ec09-6033-47b5-a44d-0b2239ab49ac)

## 무엇을 고쳤나

`cloud-build.yml` prod 분기 `firebase_oauth_handoff_enabled`를 `false`→`true`로 승격. dev는 이미 #3519에서 `true`(무변화) — 이 한 줄이 유일한 변경.

## 증거

- YAML 파싱 확인.
- 값 변경만(false→true), 문자 길이 차이 무시 가능 — 별도 바이트 한도 재측정 불요.

## Test plan

- [x] YAML 파싱 확인
- [ ] 머지+prod 배포 후 `sprintable-backend-prod` 서비스 env 실측 확인
- [ ] prod TestFlight 빌드 제출(병행 진행 중)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZzVLFLVJ3MePFeprri6mK