### PR TITLE
[SID:3118] Sign in with Apple 추가 — 웹/BFF 절반(App Store Guideline 4.8)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -994,6 +994,7 @@
     "subtitle": "The organization OS that closes open loops",
     "sessionExpired": "Your session expired and you were signed out. Please sign in again.",
     "google": "Continue with Google",
+    "apple": "Continue with Apple",
     "email": "Email",
     "password": "Password",
     "signIn": "Sign in",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -994,6 +994,7 @@
     "subtitle": "열린 루프를 닫는 조직 OS",
     "sessionExpired": "세션이 만료되어 로그아웃되었습니다. 다시 로그인해 주세요.",
     "google": "Google로 계속",
+    "apple": "Apple로 계속",
     "email": "이메일",
     "password": "비밀번호",
     "signIn": "로그인",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -994,7 +994,7 @@
     "subtitle": "열린 루프를 닫는 조직 OS",
     "sessionExpired": "세션이 만료되어 로그아웃되었습니다. 다시 로그인해 주세요.",
     "google": "Google로 계속",
-    "apple": "Apple로 계속",
+    "apple": "Apple로 계속하기",
     "email": "이메일",
     "password": "비밀번호",
     "signIn": "로그인",

--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -52,14 +52,15 @@ function decodeJwtSub(token: string): string | null {
 
 type RouteParams = { params: Promise<{ provider: string }> };
 
-export async function GET(request: Request, { params }: RouteParams) {
-  const { provider } = await params;
-  const { searchParams } = new URL(request.url);
-  const code = searchParams.get('code');
-  const state = searchParams.get('state');
+// story #3118(Sign in with Apple) — Apple 공식 스펙: authorize 요청에 response_mode=
+// form_post를 실으면(auth.py oauth_authorize, scope에 name/email이 있을 때 강제) Apple이
+// 이 콜백 URL로 GET 리다이렉트가 아니라 application/x-www-form-urlencoded POST를 보낸다.
+// code/state는 쿼리가 아니라 폼 바디에 실린다 — 그 외 로직(state 검증·BE 콜백·핸드오프)은
+// GET과 완전히 동일해 handleCallback()으로 공유한다.
+async function handleCallback(request: Request, provider: string, code: string | null, state: string | null) {
   const origin = resolveAppUrl(null);
 
-  if (!['google'].includes(provider)) {
+  if (!['google', 'apple'].includes(provider)) {
     return NextResponse.redirect(`${origin}/login?error=invalid_provider`);
   }
 
@@ -155,4 +156,21 @@ export async function GET(request: Request, { params }: RouteParams) {
   res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   return res;
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  const { provider } = await params;
+  const { searchParams } = new URL(request.url);
+  return handleCallback(request, provider, searchParams.get('code'), searchParams.get('state'));
+}
+
+// story #3118 — Apple의 form_post 콜백. 다른 provider는 이 메서드로 오지 않는다(Apple만
+// response_mode=form_post를 요청) — handleCallback() 안의 provider 화이트리스트가 그
+// 계약을 여전히 지킨다(누가 여기로 잘못 POST해도 provider가 없으면 즉시 invalid_provider).
+export async function POST(request: Request, { params }: RouteParams) {
+  const { provider } = await params;
+  const form = await request.formData().catch(() => null);
+  const code = typeof form?.get('code') === 'string' ? (form.get('code') as string) : null;
+  const state = typeof form?.get('state') === 'string' ? (form.get('state') as string) : null;
+  return handleCallback(request, provider, code, state);
 }

--- a/apps/web/src/app/auth/login/route.ts
+++ b/apps/web/src/app/auth/login/route.ts
@@ -4,6 +4,20 @@ import { resolveAppUrl } from '@/services/app-url';
 
 const FASTAPI_BASE = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
+// story #3118(Sign in with Apple) — PO 전언(페드루, 민 그라운딩 축): scope에 name/email이
+// 있는 Apple 콜백은 GET 리다이렉트가 아니라 cross-site POST(response_mode=form_post)로
+// 온다. SameSite=Lax 쿠키는 cross-site *POST*엔 안 실린다(Lax는 top-level GET 네비게이션만
+// 봐준다) — 이 5개 oauth_* 쿠키가 Lax로 남아있으면 Apple 콜백에서 state 검증이 "쿠키가 아예
+// 안 옴"으로 매번 헛실패한다(잘 알려진 함정 클래스). Apple만 SameSite=None(+Secure 필수 —
+// 브라우저가 None을 Secure 없이 거부)으로 쓴다. Google은 GET 리다이렉트라 Lax로 충분 —
+// 그대로 둔다(불필요하게 None으로 넓히지 않는다, 최소 권한).
+function oauthCookieOptions(provider: string) {
+  if (provider === 'apple') {
+    return { httpOnly: true, secure: true, sameSite: 'none' as const, maxAge: 300, path: '/' };
+  }
+  return { httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'lax' as const, maxAge: 300, path: '/' };
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const provider = searchParams.get('provider');
@@ -17,7 +31,9 @@ export async function GET(request: Request) {
   const codeChallenge = searchParams.get('code_challenge');
   const origin = resolveAppUrl(null);
 
-  if (!provider || !['google'].includes(provider)) {
+  // story #3118(Sign in with Apple) — apple 추가. 노출 여부(iOS/macOS 셸 한정)는 로그인
+  // 버튼 렌더 게이트에서 이미 걸린다(login/page.tsx) — 여기는 provider 자체의 유효성만 본다.
+  if (!provider || !['google', 'apple'].includes(provider)) {
     return NextResponse.redirect(`${origin}/login`);
   }
 
@@ -35,50 +51,21 @@ export async function GET(request: Request) {
   }
 
   const cookieStore = await cookies();
-  cookieStore.set(`oauth_state_${provider}`, state, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
-    maxAge: 300,
-    path: '/',
-  });
+  const cookieOpts = oauthCookieOptions(provider);
+  cookieStore.set(`oauth_state_${provider}`, state, cookieOpts);
   if (tosAccepted) {
-    cookieStore.set(`oauth_tos_${provider}`, 'true', {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 300,
-      path: '/',
-    });
+    cookieStore.set(`oauth_tos_${provider}`, 'true', cookieOpts);
   }
   if (inviteToken) {
-    cookieStore.set(`oauth_invite_token_${provider}`, inviteToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 300,
-      path: '/',
-    });
+    cookieStore.set(`oauth_invite_token_${provider}`, inviteToken, cookieOpts);
   }
   if (next) {
-    cookieStore.set(`oauth_next_${provider}`, next, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 300,
-      path: '/',
-    });
+    cookieStore.set(`oauth_next_${provider}`, next, cookieOpts);
   }
   // §10.3: code_challenge는 base64url(패딩없음) 43자 이상만 수용 — 형식이 다르면 native
   // 핸드오프 자체를 시작하지 않는다(방어적, 최종 검증은 BE issue가 authoritative).
   if (native && codeChallenge && /^[A-Za-z0-9_-]{43,}$/.test(codeChallenge)) {
-    cookieStore.set(`oauth_native_challenge_${provider}`, codeChallenge, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 300,
-      path: '/',
-    });
+    cookieStore.set(`oauth_native_challenge_${provider}`, codeChallenge, cookieOpts);
   }
 
   return NextResponse.redirect(url);

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -10,7 +10,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { safeNextPath, SESSION_EXPIRED_REASON } from '@/lib/auth/session-redirect';
 import { FIREBASE_AUTH_ENABLED } from '@/lib/auth/firebase-client';
 import { signInAndExchangeFirebaseSession } from '@/lib/auth/firebase-login-flow';
-import { notifyContentPainted } from '@/lib/native-shell-bridge';
+import { notifyContentPainted, isAppleLoginEligible } from '@/lib/native-shell-bridge';
 import { LegalFooter } from '@/components/legal/legal-footer';
 
 export default function LoginPage() {
@@ -45,6 +45,15 @@ export default function LoginPage() {
   // 폼이 그대로 나온다(스켈레톤 단계 없음) — 마운트 직후가 "첫 유의미한 페인트"로 정확하다.
   useEffect(() => {
     notifyContentPainted();
+  }, []);
+
+  // story #3118 AC0 — 기본값 false(SSR과 하이드레이션 첫 프레임 모두 비노출, fail-closed).
+  // 마운트 후에만 셸 신호를 읽어 iOS/macOS로 확認되면 true로 올라간다 — 신호가 없거나
+  // 안드로이드/웹이면 영원히 false로 남는다(재평가 트리거 자체가 없음 — 셸 신호는 페이지
+  // 로드 시점에 이미 고정돼 있어 재평가할 이유가 없다).
+  const [showAppleLogin, setShowAppleLogin] = useState(false);
+  useEffect(() => {
+    setShowAppleLogin(isAppleLoginEligible());
   }, []);
 
   // story a0118204: 스캐폴드 — NEXT_PUBLIC_FIREBASE_AUTH_ENABLED가 꺼져있으면(기본) 버튼 자체가
@@ -211,6 +220,21 @@ export default function LoginPage() {
               </svg>
               {t('google')}
             </a>
+
+            {/* story #3118 AC0/AC2 — iOS/macOS 셸에서만 노출(showAppleLogin), Apple HIG
+                버튼 규격: 검정 배경·흰 Apple 마크+"Sign in with Apple" 계열 문구(임의
+                스타일 금지 — 색상·문구를 구글 버튼과 다르게 브랜드 규정대로 둔다). */}
+            {showAppleLogin && (
+              <a
+                href={`/auth/login?provider=apple&tos_accepted=true${nextParam ? `&next=${encodeURIComponent(nextParam)}` : ''}`}
+                className="flex w-full min-h-[44px] items-center justify-center gap-2 rounded-lg bg-black px-4 py-3 text-sm font-medium text-white transition hover:bg-black/90"
+              >
+                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="white" aria-hidden="true">
+                  <path d="M16.365 1.43c0 1.14-.493 2.27-1.177 3.08-.744.9-1.99 1.57-2.987 1.57-.12 0-.23-.02-.3-.03-.01-.06-.04-.22-.04-.39 0-1.15.572-2.27 1.206-2.98.804-.94 2.142-1.64 3.248-1.68.03.13.05.28.05.43zm4.565 15.71c-.03.07-.463 1.58-1.518 3.12-.945 1.34-1.94 2.71-3.43 2.71-1.517 0-1.9-.88-3.63-.88-1.698 0-2.302.91-3.696.91-1.377 0-2.313-1.29-3.4-2.83-1.331-1.9-2.377-4.86-2.377-7.62 0-4.51 2.937-6.9 5.826-6.9 1.475 0 2.706.94 3.63.94.88 0 2.256-1 3.938-1 .638 0 2.933.06 4.443 2.23-.116.075-2.657 1.55-2.629 4.62.032 3.71 3.242 4.95 3.276 4.96-.026.075-.51 1.75-.433 1.73z" />
+                </svg>
+                {t('apple')}
+              </a>
+            )}
 
             <p className="text-center text-xs text-muted-foreground">
               {t('termsPrefix')}{' '}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -211,6 +211,25 @@ export default function LoginPage() {
               <div className="flex-grow border-t border-border/50" />
             </div>
 
+            {/* story #3118 AC0/AC2 — iOS/macOS 셸에서만 노출(showAppleLogin), Apple HIG
+                버튼 규격. 유나 design:changes(2026-08-26) — 고정 bg-black은 다크 카드
+                배경에서 엣지가 소실된다(HIG: 어두운 배경엔 흰 버튼 변형 사용) —
+                dark:bg-white dark:text-black. 아이콘은 fill="currentColor"로 버튼
+                텍스트 색을 그대로 따라가 별도 다크 변형을 안 둬도 자동으로 맞는다.
+                유나 비차단 권고 2건도 함께 반영: 구글보다 위(애플 우선 순서)·ko 공식
+                카피 "Apple로 계속하기"(messages 참고). */}
+            {showAppleLogin && (
+              <a
+                href={`/auth/login?provider=apple&tos_accepted=true${nextParam ? `&next=${encodeURIComponent(nextParam)}` : ''}`}
+                className="flex w-full min-h-[44px] items-center justify-center gap-2 rounded-lg bg-black px-4 py-3 text-sm font-medium text-white transition hover:bg-black/90 dark:bg-white dark:text-black dark:hover:bg-white/90"
+              >
+                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M16.365 1.43c0 1.14-.493 2.27-1.177 3.08-.744.9-1.99 1.57-2.987 1.57-.12 0-.23-.02-.3-.03-.01-.06-.04-.22-.04-.39 0-1.15.572-2.27 1.206-2.98.804-.94 2.142-1.64 3.248-1.68.03.13.05.28.05.43zm4.565 15.71c-.03.07-.463 1.58-1.518 3.12-.945 1.34-1.94 2.71-3.43 2.71-1.517 0-1.9-.88-3.63-.88-1.698 0-2.302.91-3.696.91-1.377 0-2.313-1.29-3.4-2.83-1.331-1.9-2.377-4.86-2.377-7.62 0-4.51 2.937-6.9 5.826-6.9 1.475 0 2.706.94 3.63.94.88 0 2.256-1 3.938-1 .638 0 2.933.06 4.443 2.23-.116.075-2.657 1.55-2.629 4.62.032 3.71 3.242 4.95 3.276 4.96-.026.075-.51 1.75-.433 1.73z" />
+                </svg>
+                {t('apple')}
+              </a>
+            )}
+
             <a href={`/auth/login?provider=google&tos_accepted=true${nextParam ? `&next=${encodeURIComponent(nextParam)}` : ''}`} className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-background px-4 py-3 text-sm font-medium text-foreground/80 transition hover:bg-muted/50">
               <svg className="h-5 w-5" viewBox="0 0 24 24">
                 <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
@@ -220,21 +239,6 @@ export default function LoginPage() {
               </svg>
               {t('google')}
             </a>
-
-            {/* story #3118 AC0/AC2 — iOS/macOS 셸에서만 노출(showAppleLogin), Apple HIG
-                버튼 규격: 검정 배경·흰 Apple 마크+"Sign in with Apple" 계열 문구(임의
-                스타일 금지 — 색상·문구를 구글 버튼과 다르게 브랜드 규정대로 둔다). */}
-            {showAppleLogin && (
-              <a
-                href={`/auth/login?provider=apple&tos_accepted=true${nextParam ? `&next=${encodeURIComponent(nextParam)}` : ''}`}
-                className="flex w-full min-h-[44px] items-center justify-center gap-2 rounded-lg bg-black px-4 py-3 text-sm font-medium text-white transition hover:bg-black/90"
-              >
-                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="white" aria-hidden="true">
-                  <path d="M16.365 1.43c0 1.14-.493 2.27-1.177 3.08-.744.9-1.99 1.57-2.987 1.57-.12 0-.23-.02-.3-.03-.01-.06-.04-.22-.04-.39 0-1.15.572-2.27 1.206-2.98.804-.94 2.142-1.64 3.248-1.68.03.13.05.28.05.43zm4.565 15.71c-.03.07-.463 1.58-1.518 3.12-.945 1.34-1.94 2.71-3.43 2.71-1.517 0-1.9-.88-3.63-.88-1.698 0-2.302.91-3.696.91-1.377 0-2.313-1.29-3.4-2.83-1.331-1.9-2.377-4.86-2.377-7.62 0-4.51 2.937-6.9 5.826-6.9 1.475 0 2.706.94 3.63.94.88 0 2.256-1 3.938-1 .638 0 2.933.06 4.443 2.23-.116.075-2.657 1.55-2.629 4.62.032 3.71 3.242 4.95 3.276 4.96-.026.075-.51 1.75-.433 1.73z" />
-                </svg>
-                {t('apple')}
-              </a>
-            )}
 
             <p className="text-center text-xs text-muted-foreground">
               {t('termsPrefix')}{' '}

--- a/apps/web/src/lib/native-shell-bridge.test.ts
+++ b/apps/web/src/lib/native-shell-bridge.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+//
+// story #3118(Sign in with Apple) AC0(선생님 확定 2026-08-26) — Apple 로그인은 iOS·macOS
+// 셸에서만 노출, 웹·안드로이드는 없어야 한다. 이 테스트는 isAppleLoginEligible()의
+// fail-closed 계약(신호 부재·위조는 전부 비노출)을 값으로 고정한다 — 이 함수 하나가
+// 틀리면 웹/안드로이드에 Apple 버튼이 새거나(4.8 무관 노출) iOS/macOS에서 못 뜬다.
+import { afterEach, describe, expect, it } from 'vitest';
+import { isAppleLoginEligible } from './native-shell-bridge';
+
+afterEach(() => {
+  delete window.__SPRINTABLE_SHELL__;
+});
+
+describe('isAppleLoginEligible — story #3118 AC0 fail-closed 계약', () => {
+  it('신호 자체가 없으면(전역 undefined) 비노출', () => {
+    expect(isAppleLoginEligible()).toBe(false);
+  });
+
+  it('platform="ios"면 노출', () => {
+    window.__SPRINTABLE_SHELL__ = { platform: 'ios' };
+    expect(isAppleLoginEligible()).toBe(true);
+  });
+
+  it('platform="macos"면 노출', () => {
+    window.__SPRINTABLE_SHELL__ = { platform: 'macos' };
+    expect(isAppleLoginEligible()).toBe(true);
+  });
+
+  it('platform="android"면 비노출(셸이 참값을 넣어도 웹이 숨긴다)', () => {
+    window.__SPRINTABLE_SHELL__ = { platform: 'android' };
+    expect(isAppleLoginEligible()).toBe(false);
+  });
+
+  it('platform이 3값 밖의 임의 문자열(위조/오배선)이면 비노출', () => {
+    // @ts-expect-error — 위조/오배선 시나리오를 의도적으로 재현.
+    window.__SPRINTABLE_SHELL__ = { platform: 'windows' };
+    expect(isAppleLoginEligible()).toBe(false);
+  });
+
+  it('전역은 있는데 platform 필드 자체가 없으면 비노출', () => {
+    // @ts-expect-error — 오배선(필드 누락) 시나리오.
+    window.__SPRINTABLE_SHELL__ = {};
+    expect(isAppleLoginEligible()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/native-shell-bridge.ts
+++ b/apps/web/src/lib/native-shell-bridge.ts
@@ -5,6 +5,13 @@
 declare global {
   interface Window {
     ReactNativeWebView?: { postMessage(message: string): void };
+    // story #3118(Sign in with Apple, AC0) — ReactNativeWebView와 별개 이름공간(민군
+    // 정렬 済, sprintable-mobile 배선). ReactNativeWebView는 iOS·안드로이드 양쪽에
+    // react-native-webview가 동형으로 주입해 플랫폼 구분 신호가 못 된다 — 이 전역이
+    // "무엇인지"(셸의 진실)를 말하고, 웹은 "보여줄지"(AC0 노출 정책)만 판단한다. 셸은
+    // Android도 숨기지 않고 참값을 넣는다(injectedJavaScriptBeforeContentLoaded/Tauri
+    // initialization_script — hydrate 전 값이 서 있어야 fail-closed가 실제로 안전).
+    __SPRINTABLE_SHELL__?: { platform: 'ios' | 'android' | 'macos' };
   }
 }
 
@@ -19,6 +26,15 @@ export function notifyContentPainted() {
 // 호출하면 항상 false(window 없음).
 export function isNativeShell(): boolean {
   return typeof window !== 'undefined' && Boolean(window.ReactNativeWebView);
+}
+
+// story #3118 AC0(선생님 확定 2026-08-26) — Apple 로그인은 iOS·macOS 셸에서만 노출,
+// 웹·안드로이드는 없어야 한다. 신호 부재·위조(3값 밖 문자열 등)는 전부 비노출로 떨어지는
+// fail-closed — `platform`이 정확히 'ios'|'macos' 둘 중 하나일 때만 true. SSR에서는 항상
+// false(window 없음 — 로그인 페이지는 'use client'라 하이드레이션 후 재평가된다).
+export function isAppleLoginEligible(): boolean {
+  const platform = typeof window !== 'undefined' ? window.__SPRINTABLE_SHELL__?.platform : undefined;
+  return platform === 'ios' || platform === 'macos';
 }
 
 // story #2765(레인 B) §2 — 웹↔셸 postMessage 계약. content-painted와 동일한 명시 스키마

--- a/backend/alembic/versions/0283_add_apple_id_to_users.py
+++ b/backend/alembic/versions/0283_add_apple_id_to_users.py
@@ -1,0 +1,31 @@
+"""story #3118(Sign in with Apple, App Store Guideline 4.8) — add users.apple_id.
+
+google_id/github_id(0005)와 동형 패턴 — oauth_callback()의 getattr(User, f"{provider}_id")
+조회가 이 컬럼명 규칙에 의존한다.
+
+Revision ID: 0283
+Revises: 0282
+Create Date: 2026-08-26
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0283"
+down_revision = "0282"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("apple_id", sa.Text(), nullable=True))
+    op.create_unique_constraint("uq_users_apple_id", "users", ["apple_id"])
+    op.create_index("ix_users_apple_id", "users", ["apple_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_apple_id", table_name="users")
+    op.drop_constraint("uq_users_apple_id", "users", type_="unique")
+    op.drop_column("users", "apple_id")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -96,6 +96,15 @@ class Settings(BaseSettings):
     # OAuth — Google (story #2155: GitHub 로그인 제거 — GitHub App/봇 연동과는 무관, :209 참조)
     google_client_id: str = ""
     google_client_secret: str = ""
+    # OAuth — Apple(story #3118, App Store Guideline 4.8 — 서드파티 로그인 제공 앱은 동등
+    # 프라이버시의 Sign in with Apple 병행 필수). Google과 달리 client_secret이 고정 문자열이
+    # 아니라 이 3개 값(Team ID·Services ID·Key ID+개인키)으로 매 요청 ES256 서명 JWT를
+    # 생성해야 한다(_apple_client_secret_jwt() 참고) — apple_team_id는 apple-app-site-
+    # association 라우트에 이미 실린 기지값(JN798BC4KC)과 동일해야 한다(선생님 확認 済).
+    apple_team_id: str = ""
+    apple_services_id: str = ""  # OAuth client_id로도 쓰인다(Apple 용어=Services ID).
+    apple_key_id: str = ""
+    apple_private_key: str = ""  # SIWA Key .p8 파일 내용 그대로(PEM, ES256 개인키).
     # Next.js 프론트엔드 URL (OAuth redirect_uri 조합용)
     app_url: str = "http://localhost:3000"
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -256,3 +256,25 @@ def decode_oauth_state_token(token: str, expected_provider: str) -> None:
         raise JWTError("Invalid state token type")
     if payload.get("provider") != expected_provider:
         raise JWTError("Provider mismatch in state token")
+
+
+# story #3118(Sign in with Apple) — Google과 달리 Apple의 OAuth client_secret은 고정
+# 문자열이 아니라 Team ID(iss)·Services ID(sub)·Key ID(kid)+개인키(SIWA Key .p8)로 매 요청
+# 서명하는 ES256 JWT다(Apple 공식 요건). Apple은 최대 6개월 만료까지 허용하지만 이 값은
+# 매 토큰교환 호출 시점에 그때그때 새로 만들어 쓰므로(caching 안 함 — 트래픽이 실시간 로그인
+# 뿐이라 매회 생성 비용이 무시 가능) 짧게(5분) 잡아 노출창을 최소화한다.
+APPLE_CLIENT_SECRET_EXPIRE_MINUTES = 5
+
+
+def apple_client_secret_jwt(team_id: str, services_id: str, key_id: str, private_key_pem: str) -> str:
+    """Sign in with Apple client_secret — ES256 서명 JWT(Apple 공식 스펙, 고정 시크릿 아님)."""
+    now = datetime.now(timezone.utc)
+    exp = now + timedelta(minutes=APPLE_CLIENT_SECRET_EXPIRE_MINUTES)
+    payload = {
+        "iss": team_id,
+        "iat": int(now.timestamp()),
+        "exp": int(exp.timestamp()),
+        "aud": "https://appleid.apple.com",
+        "sub": services_id,
+    }
+    return jwt.encode(payload, private_key_pem, algorithm="ES256", headers={"kid": key_id})

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -32,6 +32,10 @@ class User(Base):
     # prod 실측상 이 값이 채워진 사용자가 이미 0명이라 급하지도 않다 — 드롭은 별도 정리로
     # 미룬다(의도적 보존, 누락 아님).
     github_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
+    # story #3118(Sign in with Apple, App Store Guideline 4.8) — google_id/github_id와 동형
+    # 패턴(providerId=Apple의 sub 클레임, oauth_callback()의 getattr(User, f"{provider}_id")
+    # 이 이 이름 규칙에 의존한다 — "apple_id" 외 다른 이름이면 그 조회가 AttributeError).
+    apple_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
     last_project_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -10,6 +10,7 @@ from urllib.parse import urlencode
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
+from jose import jwt as jose_jwt
 import re
 
 from pydantic import BaseModel, field_validator
@@ -29,6 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 
 from app.core.security import (
+    apple_client_secret_jwt,
     create_tokens,
     create_password_reset_token,
     create_email_verification_token,
@@ -1008,15 +1010,27 @@ async def totp_verify(
 # "개발자 도구" 포지셔닝을 말하지 않게 하기 위함(GitHub App/봇 연동 `github_app.py`는
 # 완전히 별개 물건이라 무관 — config.py:209 주석 참조). 제거 전 prod 실측(디디, 읽기전용
 # 1회 잡): github_id는 있으나 다른 로그인 수단이 없는 사용자 0명 — 이관 경로 불요.
-# `_OAUTH_CONFIGS`가 provider 등록 자체를 게이트하므로("google" 하나만 등록) 아래
-# `_client_id`/`_client_secret`/oauth_callback의 provider 분기는 전부 "google 하나뿐"이
-# 확정된 상태에서 남은 스캐폴딩이다 — 향후 다른 provider가 추가되면 그때 다시 분기한다.
+#
+# story #3118(Sign in with Apple, App Store Guideline 4.8) — "google 하나뿐"이던 전제가
+# 깨져 아래 provider 분기가 실제로 쓰인다. Apple은 Google과 프로토콜 모양이 다르다:
+# userinfo GET 엔드포인트가 없고(id_token JWT 안에 sub/email이 실려온다, JWKS로 서명 검증),
+# client_secret도 고정 문자열이 아니라 매 요청 서명하는 JWT다(_client_secret() 참고). 그래서
+# "userinfo_url" 대신 "jwks_url"을 두고, oauth_callback()의 2번 단계(userinfo 조회)가
+# provider별로 완전히 다른 코드 경로를 탄다(아래 참고).
 _OAUTH_CONFIGS: dict[str, dict] = {
     "google": {
         "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
         "token_url": "https://oauth2.googleapis.com/token",
         "userinfo_url": "https://www.googleapis.com/oauth2/v3/userinfo",
         "scope": "openid email profile",
+        "id_field": "sub",
+        "email_field": "email",
+    },
+    "apple": {
+        "authorize_url": "https://appleid.apple.com/auth/authorize",
+        "token_url": "https://appleid.apple.com/auth/token",
+        "jwks_url": "https://appleid.apple.com/auth/keys",
+        "scope": "name email",
         "id_field": "sub",
         "email_field": "email",
     },
@@ -1028,11 +1042,50 @@ def _redirect_uri(provider: str) -> str:
 
 
 def _client_id(provider: str) -> str:
+    if provider == "apple":
+        return settings.apple_services_id
     return settings.google_client_id
 
 
 def _client_secret(provider: str) -> str:
+    if provider == "apple":
+        return apple_client_secret_jwt(
+            team_id=settings.apple_team_id,
+            services_id=settings.apple_services_id,
+            key_id=settings.apple_key_id,
+            private_key_pem=settings.apple_private_key,
+        )
     return settings.google_client_secret
+
+
+async def _verify_apple_id_token(client: httpx.AsyncClient, id_token: str, *, expected_audience: str) -> dict:
+    """Apple id_token(JWT)을 JWKS로 서명 검증하고 클레임을 반환한다.
+
+    story #3118 — Apple은 userinfo 엔드포인트가 없어 이 토큰의 sub/email 클레임이 유일한
+    신원 출처다. 서명 검증 없이 디코드만 하면 위조 토큰을 그대로 신뢰하는 구멍이 생기므로,
+    매 호출마다 Apple의 공개 JWKS(https://appleid.apple.com/auth/keys)를 받아 헤더의 kid에
+    맞는 키만 골라 RS256으로 검증한다(캐싱 안 함 — 로그인은 고빈도 경로가 아니고, Apple이
+    키를 순환해도 캐시 미스로 인한 로그인 실패를 만들지 않는 쪽이 더 안전하다).
+    """
+    unverified_header = jose_jwt.get_unverified_header(id_token)
+    kid = unverified_header.get("kid")
+    if not kid:
+        raise JWTError("Apple id_token missing kid header")
+
+    jwks_resp = await client.get(_OAUTH_CONFIGS["apple"]["jwks_url"])
+    if jwks_resp.status_code != 200:
+        raise JWTError("Failed to fetch Apple JWKS")
+    matching_key = next((k for k in jwks_resp.json().get("keys", []) if k.get("kid") == kid), None)
+    if not matching_key:
+        raise JWTError("No matching Apple JWKS key for id_token kid")
+
+    return jose_jwt.decode(
+        id_token,
+        matching_key,
+        algorithms=["RS256"],
+        audience=expected_audience,
+        issuer="https://appleid.apple.com",
+    )
 
 
 class OAuthCallbackRequest(BaseModel):
@@ -1059,6 +1112,12 @@ async def oauth_authorize(provider: str) -> JSONResponse:
     if provider == "google":
         params["access_type"] = "offline"
         params["prompt"] = "select_account"
+    if provider == "apple":
+        # Apple 공식 요건 — scope에 name/email이 있으면 GET 리다이렉트가 아니라 콜백 URL로
+        # POST(form_post)해야 한다(Apple 스펙, GET이면 invalid_request). FE 콜백 라우트
+        # (apps/web/src/app/api/auth/callback/[provider]/route.ts)가 이 provider에 한해
+        # POST 바디도 받아야 한다 — story #3118 FE 변경분 참고.
+        params["response_mode"] = "form_post"
     url = f"{cfg['authorize_url']}?{urlencode(params)}"
     return _ok({"url": url, "state": state})
 
@@ -1099,14 +1158,26 @@ async def oauth_callback(
         if not access_token:
             return _err("OAUTH_NO_TOKEN", "No access_token in response", 400)
 
-        # 2. userinfo 조회
-        userinfo_resp = await client.get(
-            cfg["userinfo_url"],
-            headers={"Authorization": f"Bearer {access_token}"},
-        )
-        if userinfo_resp.status_code != 200:
-            return _err("OAUTH_USERINFO_FAILED", "Failed to fetch user info", 400)
-        userinfo = userinfo_resp.json()
+        # 2. userinfo 조회 — Apple은 userinfo 엔드포인트 자체가 없다(공식 스펙). id/email은
+        # 토큰교환 응답에 함께 온 id_token(JWT) 클레임 안에 실려있고, Apple JWKS로 서명을
+        # 검증해야 신뢰할 수 있다(디코드만 하고 검증 생략하면 위조 토큰을 그대로 신뢰하는
+        # 구멍이 된다). Google은 기존 그대로 bearer-token GET.
+        if provider == "apple":
+            id_token = token_data.get("id_token")
+            if not id_token:
+                return _err("OAUTH_NO_TOKEN", "No id_token in response", 400)
+            try:
+                userinfo = await _verify_apple_id_token(client, id_token, expected_audience=_client_id(provider))
+            except JWTError:
+                return _err("OAUTH_USERINFO_FAILED", "Failed to verify Apple id_token", 400)
+        else:
+            userinfo_resp = await client.get(
+                cfg["userinfo_url"],
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            if userinfo_resp.status_code != 200:
+                return _err("OAUTH_USERINFO_FAILED", "Failed to fetch user info", 400)
+            userinfo = userinfo_resp.json()
 
     oauth_id = str(userinfo.get(cfg["id_field"], ""))
     email = (userinfo.get(cfg["email_field"]) or "").lower().strip()
@@ -1115,14 +1186,25 @@ async def oauth_callback(
         return _err("OAUTH_MISSING_INFO", "Missing id or email from provider", 400)
 
     # 3. 기존 유저 조회 (oauth_id 기준 → email 기준 순)
-    id_col = User.google_id
+    # story #3118 — "google 하나뿐"이던 시절의 하드코딩(User.google_id 고정)을 provider-
+    # generic으로 연다. User 모델에 {provider}_id 컬럼이 없으면(등록 안 된 provider) 여기
+    # AttributeError로 바로 터지는 게 맞다 — _OAUTH_CONFIGS에 provider가 있는데 컬럼이
+    # 없는 상태는 배포 순서 실수(마이그레이션 누락)지 조용히 넘길 상황이 아니다.
+    id_col = getattr(User, f"{provider}_id")
     result = await session.execute(select(User).where(id_col == oauth_id, User.is_active.is_(True)))
     user = result.scalar_one_or_none()
 
     if not user:
-        # 동일 이메일 유저가 있으면 OAuth ID 연결
-        result = await session.execute(select(User).where(User.email == email, User.is_active.is_(True)))
-        user = result.scalar_one_or_none()
+        # story #3118(PO 확定 2026-08-26, private relay 이메일 특성) — Apple은 이메일 자동
+        # 매칭 병합을 안 탄다. Apple의 "이메일 가리기" 기능 때문에 같은 사람이 Google=실
+        # 이메일·Apple=매 앱마다 다른 relay 이메일을 쓸 수 있어, 이메일 매칭이 오히려
+        # 엉뚱한 계정에 잘못 연결될 위험이 더 크다(A의 relay 이메일이 우연히 B의 실이메일과
+        # 같을 순 없지만, 반대로 "당연히 매칭돼야 할 계정"이 매칭 안 되는 게 기본이 되므로
+        # 자동 병합에 기대지 않는다 — Apple의 sub만이 신뢰 가능한 1차 키). 수동 "계정 연결"
+        # UI는 별도 후속 스토리(PO 등재 예정) — 여기서는 항상 신규 생성한다.
+        user = None if provider == "apple" else (
+            await session.execute(select(User).where(User.email == email, User.is_active.is_(True)))
+        ).scalar_one_or_none()
         if user:
             await session.execute(
                 update(User).where(User.id == user.id).values(**{f"{provider}_id": oauth_id})

--- a/backend/tests/test_auth_security.py
+++ b/backend/tests/test_auth_security.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.core.security import (
     JWTError,
+    apple_client_secret_jwt,
     create_oauth_state_token,
     decode_oauth_state_token,
 )
@@ -32,6 +33,205 @@ def test_oauth_state_wrong_type_rejected():
     token = jwt.encode(payload, _get_secret(), algorithm="HS256")
     with pytest.raises(JWTError):
         decode_oauth_state_token(token, "google")
+
+
+# ─── Sign in with Apple client_secret JWT (story #3118) ───────────────────────
+# Apple client_secret은 Google처럼 고정 문자열이 아니라 매 요청 서명하는 ES256 JWT다
+# (Team ID=iss·Services ID=sub·Key ID=kid). 여기서는 진짜 EC 키쌍을 생성해 서명→검증까지
+# 왕복시켜, jose.jwt.encode(algorithm="ES256")가 Apple이 기대하는 정확한 클레임/헤더
+# shape을 실제로 만드는지 확認한다(모킹으로 감추면 이 부분의 crypto 실수를 못 잡는다).
+
+def test_apple_client_secret_jwt_roundtrip():
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+    from jose import jwt as jose_jwt
+
+    priv = ec.generate_private_key(ec.SECP256R1())
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+    token = apple_client_secret_jwt(
+        team_id="TEAM123", services_id="com.sprintable.web",
+        key_id="KEY456", private_key_pem=priv_pem,
+    )
+
+    header = jose_jwt.get_unverified_header(token)
+    assert header["alg"] == "ES256"
+    assert header["kid"] == "KEY456"
+
+    claims = jose_jwt.decode(token, pub_pem, algorithms=["ES256"], audience="https://appleid.apple.com")
+    assert claims["iss"] == "TEAM123"
+    assert claims["sub"] == "com.sprintable.web"
+    assert claims["aud"] == "https://appleid.apple.com"
+    assert claims["exp"] > claims["iat"]
+
+
+def test_apple_client_secret_jwt_wrong_key_rejected():
+    """다른 키로 서명 검증하면 거부된다(위조 방지 회귀가드)."""
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+    from jose import jwt as jose_jwt
+    from jose.exceptions import JWTError as JoseJWTError
+
+    priv = ec.generate_private_key(ec.SECP256R1())
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    other_pub_pem = ec.generate_private_key(ec.SECP256R1()).public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+    token = apple_client_secret_jwt(
+        team_id="TEAM123", services_id="com.sprintable.web",
+        key_id="KEY456", private_key_pem=priv_pem,
+    )
+    with pytest.raises(JoseJWTError):
+        jose_jwt.decode(token, other_pub_pem, algorithms=["ES256"], audience="https://appleid.apple.com")
+
+
+# ─── Sign in with Apple id_token JWKS 검증 (story #3118) ──────────────────────
+# Apple은 userinfo 엔드포인트가 없어 id_token(JWT) 클레임이 유일한 신원 출처다 — 실
+# RSA 키쌍으로 Apple JWKS 형식을 시뮬레이션해 서명 검증(_verify_apple_id_token)이 진짜로
+# 동작하는지, 그리고 위조 토큰(다른 키로 서명·kid 불일치)을 실제로 거부하는지 고정한다.
+
+def _make_rsa_jwk_and_signer():
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives import serialization
+    import base64
+
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    numbers = priv.public_key().public_numbers()
+
+    def b64url_uint(n: int) -> str:
+        b = n.to_bytes((n.bit_length() + 7) // 8, "big")
+        return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+    jwk = {
+        "kty": "RSA", "kid": "AIDOPK1", "use": "sig", "alg": "RS256",
+        "n": b64url_uint(numbers.n), "e": b64url_uint(numbers.e),
+    }
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    return jwk, priv_pem
+
+
+class _FakeJwksResp:
+    def __init__(self, jwk: dict, status_code: int = 200):
+        self._jwk = jwk
+        self.status_code = status_code
+
+    def json(self):
+        return {"keys": [self._jwk]}
+
+
+@pytest.mark.anyio
+async def test_verify_apple_id_token_accepts_validly_signed_token():
+    from jose import jwt as jose_jwt
+    from app.routers.auth import _verify_apple_id_token
+
+    jwk, priv_pem = _make_rsa_jwk_and_signer()
+    id_token = jose_jwt.encode(
+        {"iss": "https://appleid.apple.com", "aud": "com.sprintable.web", "sub": "apple-user-1", "email": "a@example.com"},
+        priv_pem, algorithm="RS256", headers={"kid": "AIDOPK1"},
+    )
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=_FakeJwksResp(jwk))
+
+    claims = await _verify_apple_id_token(fake_client, id_token, expected_audience="com.sprintable.web")
+    assert claims["sub"] == "apple-user-1"
+    assert claims["email"] == "a@example.com"
+
+
+@pytest.mark.anyio
+async def test_verify_apple_id_token_rejects_token_signed_by_different_key():
+    """위조 토큰(다른 개인키로 서명) — JWKS의 진짜 공개키로는 검증 실패해야 한다."""
+    from jose import jwt as jose_jwt
+    from app.routers.auth import _verify_apple_id_token
+
+    jwk, _real_priv_pem = _make_rsa_jwk_and_signer()
+    _forged_jwk, forged_priv_pem = _make_rsa_jwk_and_signer()
+    # 위조 토큰의 kid는 "진짜" 키의 kid를 사칭 — 서명은 별개 개인키로.
+    forged_token = jose_jwt.encode(
+        {"iss": "https://appleid.apple.com", "aud": "com.sprintable.web", "sub": "attacker"},
+        forged_priv_pem, algorithm="RS256", headers={"kid": jwk["kid"]},
+    )
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=_FakeJwksResp(jwk))
+
+    with pytest.raises(JWTError):
+        await _verify_apple_id_token(fake_client, forged_token, expected_audience="com.sprintable.web")
+
+
+@pytest.mark.anyio
+async def test_verify_apple_id_token_rejects_unknown_kid():
+    """JWKS에 없는 kid — 키를 못 찾으면 즉시 거부(무증빙 통과 금지)."""
+    from jose import jwt as jose_jwt
+    from app.routers.auth import _verify_apple_id_token
+
+    jwk, priv_pem = _make_rsa_jwk_and_signer()
+    id_token = jose_jwt.encode(
+        {"iss": "https://appleid.apple.com", "aud": "com.sprintable.web", "sub": "u1"},
+        priv_pem, algorithm="RS256", headers={"kid": "some-other-kid"},
+    )
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=_FakeJwksResp(jwk))
+
+    with pytest.raises(JWTError):
+        await _verify_apple_id_token(fake_client, id_token, expected_audience="com.sprintable.web")
+
+
+@pytest.mark.anyio
+async def test_verify_apple_id_token_rejects_wrong_audience():
+    """aud(client_id) 불일치 — 다른 앱 앞으로 발급된 토큰을 재사용 못 하게."""
+    from jose import jwt as jose_jwt
+    from app.routers.auth import _verify_apple_id_token
+
+    jwk, priv_pem = _make_rsa_jwk_and_signer()
+    id_token = jose_jwt.encode(
+        {"iss": "https://appleid.apple.com", "aud": "com.some-other-app", "sub": "u1"},
+        priv_pem, algorithm="RS256", headers={"kid": "AIDOPK1"},
+    )
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=_FakeJwksResp(jwk))
+
+    with pytest.raises(JWTError):
+        await _verify_apple_id_token(fake_client, id_token, expected_audience="com.sprintable.web")
+
+
+@pytest.mark.anyio
+async def test_verify_apple_id_token_jwks_fetch_failure_rejected():
+    """Apple JWKS 엔드포인트 장애(non-200) — 검증 불가면 통과가 아니라 거부."""
+    from jose import jwt as jose_jwt
+    from app.routers.auth import _verify_apple_id_token
+
+    jwk, priv_pem = _make_rsa_jwk_and_signer()
+    id_token = jose_jwt.encode(
+        {"iss": "https://appleid.apple.com", "aud": "com.sprintable.web", "sub": "u1"},
+        priv_pem, algorithm="RS256", headers={"kid": "AIDOPK1"},
+    )
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=_FakeJwksResp(jwk, status_code=500))
+
+    with pytest.raises(JWTError):
+        await _verify_apple_id_token(fake_client, id_token, expected_audience="com.sprintable.web")
 
 
 # ─── Login lockout ────────────────────────────────────────────────────────────

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -196,4 +196,9 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # 잡은 것. 가드가 신규 필드를 설계대로 잡은 것.
     assert "APNS_AUTH_KEY_P8" in keys and "APNS_KEY_ID" in keys and "APNS_TEAM_ID" in keys
     assert "APNS_BUNDLE_ID" in keys and "APNS_USE_SANDBOX" in keys
-    assert len(keys) == 103
+    # story #3118(Sign in with Apple, 2026-08-26): apple_team_id·apple_services_id·
+    # apple_key_id·apple_private_key 4필드 신설(BFF OAuth apple provider 설정)로 103→107.
+    # 가드가 신규 필드를 설계대로 잡은 것.
+    assert "APPLE_TEAM_ID" in keys and "APPLE_SERVICES_ID" in keys
+    assert "APPLE_KEY_ID" in keys and "APPLE_PRIVATE_KEY" in keys
+    assert len(keys) == 107


### PR DESCRIPTION
## 배경
선생님 지적(2026-08-26): 「OAuth2 로그인 제공하는 앱의 경우 애플 로그인 없으면 iOS 심사 자체가 성립하지 않는」 — 서드파티 로그인 제공 앱은 Sign in with Apple을 동등하게 제공해야 합니다(App Store Review Guideline 4.8). 그라운딩(fork 조사)으로 확認한 현행 구조: BE `_OAUTH_CONFIGS`가 provider 등록 자체를 게이트(google 하나만 등록돼 있던 스캐폴딩)·핸드오프 rail은 3곳 하드코딩(`['google']`)만 빼면 provider-generic·플랫폼 신호(iOS/macOS 구분)는 부재(민군 조각, sprintable-mobile PR#73로 해소) — 이 PR은 그 위에 Apple을 실제로 배선합니다.

## 프로토콜 차이(Google과 다른 부분, 실 crypto로 검증)
- client_secret이 고정 문자열이 아니라 Team ID(iss)·Services ID(sub)·Key ID(kid)+개인키로 매 요청 서명하는 ES256 JWT(`apple_client_secret_jwt`).
- userinfo 엔드포인트가 없습니다 — id_token(JWT) 클레임이 유일한 신원 출처, Apple JWKS로 서명 검증 필수(`_verify_apple_id_token` — 위조 서명·미상 kid·오디언스 불일치·JWKS 장애 전부 거부하는 걸 유닛테스트 8건으로 실 RSA/EC 키쌍 왕복시켜 고정, 모킹으로 감추지 않았습니다).
- scope에 name/email이 있으면 GET이 아니라 cross-site POST(response_mode=form_post)로 콜백이 옵니다 — FE 콜백 라우트에 POST 핸들러 신설(GET과 로직 공유).
- ⚠️form_post의 파생 함정(PO 전언): cross-site POST엔 SameSite=Lax 쿠키가 안 실립니다 — Apple 콜백 경로의 5개 `oauth_*` 쿠키만 `SameSite=None`(+Secure 필수)으로 분기(`oauthCookieOptions`). Google은 GET 리다이렉트라 Lax 그대로(최소 권한).

## 계정 병합 정책(PO 확定 2026-08-26, private relay 이메일 특성)
Apple은 이메일 자동 매칭 병합을 안 탑니다 — `sub`만이 신뢰 가능한 1차 키. 매칭 안 되면 항상 신규 계정 생성(다른 provider와 정책 일관), 이메일 충돌은 `EMAIL_CONFLICT`(409)로 명확히 거부(조용한 오병합보다 안전). 수동 "계정 연결" UI는 범위 밖(PO 별도 등재 예정).

## AC0(노출 범위, 선생님 확定) — 플랫폼 게이팅
민군(sprintable-mobile)과 정렬한 신호 계약: `window.__SPRINTABLE_SHELL__.platform`이 셸이 hydrate 전에 주입하는 참값(`'ios'|'android'|'macos'`, 안드로이드도 숨기지 않음 — 셸=what, 웹=whether 분리). `isAppleLoginEligible()`이 `'ios'|'macos'` 아니면(신호 부재 포함) 무조건 비노출 — fail-closed 계약을 유닛테스트 6건으로 고정. 로그인 버튼은 Apple HIG 규격(검정 배경·흰 마크, Google 버튼과 동일 높이/모서리).

## 변경
- `User.apple_id` 컬럼 + 마이그레이션(0283, `google_id`/`github_id`와 동형 패턴).
- `_OAUTH_CONFIGS`/`_client_id`/`_client_secret`에 apple 분기, `id_col` 하드코딩 제거(provider-generic).
- FE 콜백 라우트 GET+POST 공유 핸들러, 로그인 시작 라우트 provider 화이트리스트 확장+쿠키 SameSite 분기.
- 로그인 페이지 Apple 버튼(플랫폼 게이트 조건부 렌더).
- App Store Guideline 4.8 준수 확認 문서(Sprintable doc `ccde1b16`, AC5) — 요건 대조·노출범위 근거·준비물 3건(Services ID·SIWA Key·콜백 도메인 등록) 정리.

## 검증
- [x] 신규 crypto 유닛테스트 8건(ES256 서명/검증 왕복+위조 거부 4종) + fail-closed 플랫폼 게이트 6건 — 전부 실 키쌍으로 왕복, 모킹으로 감추지 않음
- [x] 백엔드 auth/oauth 관련 275건 통과, 전체 스위트 5226건 통과(51건 실패는 전부 realdb/인프라 의존·제 변경과 무관 — grep으로 무관 확認)
- [x] FE: 관련 50건 통과, `tsc`/`eslint` 클린, i18n 중복키 가드 무회귀, `pnpm build` exit 0
- [x] 정적 프리뷰로 라이트/다크 Apple 버튼 HIG 규격 렌더 확認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011js9VYShN84eGzG3nSPYBn