### PR TITLE
[SID:3118] Sign in with Apple 배포 SSOT — env 3값+개인키 secretKeyRef

### DIFF
--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -23,6 +23,13 @@ Cloud Build보다 관대했던 것 — 테스트가 모델링한 계층과 실�
 `test_deploy_backend_no_unescaped_shell_vars_in_cloudbuild_substitution_syntax`가(주석 포함
 전문 스캔으로) 회귀를 원천 차단한다(추출한 스크립트를 실행하지 않고 정적으로 스캔 — 셸
 계층과 무관).
+
+story #3118(Sign in with Apple, PO 확定 2026-08-26) — deploy-backend에 Apple OAuth 식별자
+3종(APPLE_SERVICES_ID·APPLE_KEY_ID·APPLE_TEAM_ID, plain env)+개인키 1종(APPLE_PRIVATE_KEY,
+Secret Manager `APPLE_SIWA_PRIVATE_KEY`, dev/prod 공용) 추가. Services ID/Key ID는 공개돼도
+무해한 식별자(시크릿 아님) — Team ID는 기존 `_APPLE_TEAM_ID`(AASA 라우트, deploy-frontend)를
+그대로 재사용한다(같은 값, 새 substitution 아님). 셋 다 cloudbuild.yaml 인라인 주석은 story
+#3031 바이트 한도(아래) 여유가 빠듯해 짧게만 남기고, 전체 맥락은 이 docstring이 SSOT다.
 """
 from __future__ import annotations
 
@@ -57,6 +64,11 @@ _DECLARED_SUBSTITUTIONS = {
     "_GCS_AVATARS_BUCKET",
     # story #3079 — realtime path-filter 판정을 GHA에서 계산해 넘기는 skip 플래그(GCE·Cloud Run).
     "_REALTIME_GCE_SKIP", "_REALTIME_CLOUDRUN_SKIP",
+    # story #3118(Sign in with Apple) — deploy-backend(bash entrypoint)가 이제 이 3개를
+    # 직접 참조한다. _APPLE_TEAM_ID는 이전엔 deploy-frontend(순수 gcloud args 리스트 —
+    # 이 가드가 스캔하는 4개 bash 스텝 밖)에서만 쓰여 이 목록에 없어도 무해했으나, backend
+    # 쪽으로도 재사용하며 처음 걸린다.
+    "_APPLE_SERVICES_ID", "_APPLE_KEY_ID", "_APPLE_TEAM_ID",
     "PROJECT_ID", "PROJECT_NUMBER", "BUILD_ID", "COMMIT_SHA", "SHORT_SHA",
     "REPO_NAME", "BRANCH_NAME", "TAG_NAME", "REVISION_ID", "LOCATION",
 }
@@ -135,6 +147,11 @@ def _run_env_vars_assembly(deploy_env: str, redis_url: str, gotenberg_url: str =
         # story #2771 — 기본 빈 문자열(substitutions 기본값과 정합, set -u라 미설정이면 스크립트가
         # 죽는다 — 여기 없으면 이 테스트 전체가 붕괴).
         "_GOTENBERG_SERVICE_URL": gotenberg_url,
+        # story #3118 — set -u라 미설정이면 스크립트가 죽는다(GOTENBERG_SERVICE_URL과 동일 이유).
+        # 값은 cloudbuild.yaml substitutions 기본값과 정합(비밀 아님, dev/prod 동일).
+        "_APPLE_SERVICES_ID": "ai.sprintable.web",
+        "_APPLE_KEY_ID": "DF2G3UV649",
+        "_APPLE_TEAM_ID": "JN798BC4KC",
     }
     proc = subprocess.run(
         ["bash", "-c", assembly_only],
@@ -316,6 +333,10 @@ def test_deploy_backend_dev_env_vars_unchanged_by_prod_branch():
         "SSE_TRANSIENT_REPLAY_ENABLED=false,LICENSE_CONSENT=agreed,"
         "NEXT_PUBLIC_APP_URL=https://example.run.app,DEPLOY_ENV=dev,"
         "FIREBASE_OAUTH_HANDOFF_ENABLED=false,"
+        # story #3118 — 베이스 ENV_VARS 조립 문자열의 맨 끝(FIREBASE_OAUTH_HANDOFF_ENABLED
+        # 다음)에 이어붙는다 — REDIS_URL/ADMIN_OPERATOR_*/GCS_AVATARS_BUCKET은 그 뒤에
+        # 조건부로 append되는 후속 라인이라 실제 순서상 APPLE_*가 먼저 온다.
+        "APPLE_SERVICES_ID=ai.sprintable.web,APPLE_KEY_ID=DF2G3UV649,APPLE_TEAM_ID=JN798BC4KC,"
         "REDIS_URL=redis://10.164.120.243:6379,"
         "ADMIN_OPERATOR_AUDIENCE=https://example-audience.run.app,"
         "ADMIN_OPERATOR_ALLOWLIST=operator@example.iam.gserviceaccount.com,"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -125,6 +125,14 @@ substitutions:
   # AASA 응답으로 공개되는 값이라 시크릿 아니고 dev/prod 동일해 override 불요.
   _APPLE_TEAM_ID: "JN798BC4KC"
   _MOBILE_APP_LINK_ORIGIN: "https://dev-app.sprintable.ai"
+  # story #3118(Sign in with Apple, PO 확定 2026-08-26) — backend가 읽는 Apple OAuth
+  # provider 식별자 2종. Services ID(=OAuth client_id)·Key ID 둘 다 공개돼도 무해한
+  # 식별자(시크릿 아님, 위 _APPLE_TEAM_ID와 동일 원칙) — dev/prod 동일 값(PO가 app/
+  # dev-app 콜백 도메인 양쪽을 이 하나의 Services ID에 이미 등록 済, override 불요).
+  # 실제 비밀(SIWA 개인키)은 여기 두지 않는다 — deploy-backend 스텝의 --update-secrets
+  # (Secret Manager `APPLE_SIWA_PRIVATE_KEY`)로만 바인딩.
+  _APPLE_SERVICES_ID: "ai.sprintable.web"
+  _APPLE_KEY_ID: "DF2G3UV649"
   # story #2078(E-ARCH 0단계) — SSE 멀티플렉서 롤백 플래그. dev-safe 기본값 'false'(수동
   # `gcloud builds submit` override 없을 때 안전). GHA가 dev 브랜치에서만 'true' 주입 —
   # prod는 develop→main 일괄승격에 검증 안 된 플래그를 얹지 않는다(오르테가군 판정,
@@ -583,7 +591,10 @@ steps:
         # 에서 정정(구 `REDIS_CONSUME_ENABLED`는 Settings 필드와 안 맞아 무시되던 키) — 구 키는
         # --remove-env-vars로 명시 제거(안 지우면 두 키 공존, additive 함정).
         # story #2123 S0-b: FANOUT_WAKE_REDIS_ENABLED(dev만 true, prod는 손대지 않음).
-        ENV_VARS="FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=${_DB_POOL_SIZE},DB_MAX_OVERFLOW=${_DB_MAX_OVERFLOW},DB_PGBOUNCER=${_BACKEND_DB_PGBOUNCER},PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},EVENT_BROKER_REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED},EVENT_BROKER_REDIS_DISPATCH_ENABLED=${_BACKEND_REDIS_DISPATCH_ENABLED},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=${_BACKEND_REDIS_DUAL_PUBLISH_ENABLED},FANOUT_WAKE_REDIS_ENABLED=${_BACKEND_FANOUT_WAKE_REDIS_ENABLED},PRESENCE_REDIS_ENABLED=${_BACKEND_PRESENCE_REDIS_ENABLED},PRESENCE_ONLINE_REDIS_ENABLED=${_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED},SSE_LEASE_REDIS_ENABLED=${_BACKEND_SSE_LEASE_REDIS_ENABLED},SSE_TRANSIENT_REPLAY_ENABLED=${_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED},LICENSE_CONSENT=${_LICENSE_CONSENT},NEXT_PUBLIC_APP_URL=${_NEXT_PUBLIC_APP_URL},DEPLOY_ENV=${_DEPLOY_ENV},FIREBASE_OAUTH_HANDOFF_ENABLED=${_FIREBASE_OAUTH_HANDOFF_ENABLED}"
+        # story #3118(Sign in with Apple, PO 확定 2026-08-26) — APPLE_SERVICES_ID/APPLE_KEY_ID/
+        # APPLE_TEAM_ID 3종(비밀 아님, dev/prod 동일값) 추가. 개인키(APPLE_PRIVATE_KEY)는
+        # 이 plain env가 아니라 아래 SECRETS_FLAG(Secret Manager)로만 바인딩한다.
+        ENV_VARS="FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=${_DB_POOL_SIZE},DB_MAX_OVERFLOW=${_DB_MAX_OVERFLOW},DB_PGBOUNCER=${_BACKEND_DB_PGBOUNCER},PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},EVENT_BROKER_REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED},EVENT_BROKER_REDIS_DISPATCH_ENABLED=${_BACKEND_REDIS_DISPATCH_ENABLED},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=${_BACKEND_REDIS_DUAL_PUBLISH_ENABLED},FANOUT_WAKE_REDIS_ENABLED=${_BACKEND_FANOUT_WAKE_REDIS_ENABLED},PRESENCE_REDIS_ENABLED=${_BACKEND_PRESENCE_REDIS_ENABLED},PRESENCE_ONLINE_REDIS_ENABLED=${_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED},SSE_LEASE_REDIS_ENABLED=${_BACKEND_SSE_LEASE_REDIS_ENABLED},SSE_TRANSIENT_REPLAY_ENABLED=${_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED},LICENSE_CONSENT=${_LICENSE_CONSENT},NEXT_PUBLIC_APP_URL=${_NEXT_PUBLIC_APP_URL},DEPLOY_ENV=${_DEPLOY_ENV},FIREBASE_OAUTH_HANDOFF_ENABLED=${_FIREBASE_OAUTH_HANDOFF_ENABLED},APPLE_SERVICES_ID=${_APPLE_SERVICES_ID},APPLE_KEY_ID=${_APPLE_KEY_ID},APPLE_TEAM_ID=${_APPLE_TEAM_ID}"
         # ⛔story #2141(2026-07-23, prod Redis Memorystore 전환): REDIS_URL을 여기서 이 스텝이
         # 예전엔 dev/prod 공용으로 plain env 넘겼다 — prod는 Secret Manager 바인딩(REDIS_URL_PROD,
         # AUTH 필요)으로 전환하는데, 같은 배포에 plain REDIS_URL 키까지 넘기면 Cloud Run이
@@ -643,7 +654,10 @@ steps:
         # 갱신과 짝이라(안 맞추면 dev 서빙 인증 실패) #3110 2보로 분리.
         SECRETS_FLAG=""
         if [ "${_DEPLOY_ENV}" == "dev" ]; then
-          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV_SPRINTABLE:latest"
+          # story #3118 — APPLE_PRIVATE_KEY(SIWA 개인키, Secret Manager `APPLE_SIWA_PRIVATE_KEY`)
+          # 는 dev/prod 공용 시크릿(PO 발급·양쪽 런타임 SA에 secretAccessor 부여 済) — DB 시크릿과
+          # 같은 --update-secrets 한 호출에 동봉(additive, 기존 다른 시크릿 preserve).
+          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV_SPRINTABLE:latest,APPLE_PRIVATE_KEY=APPLE_SIWA_PRIVATE_KEY:latest"
         elif [ "${_DEPLOY_ENV}" == "prod" ]; then
           # story #2445 Phase1(2026-08-04) — prod cutover: DATABASE_URL→PgBouncer VIP(DATABASE_URL_PROD_PGBOUNCER,
           # =10.178.0.111:6432), DATABASE_URL_DIRECT→직결(DATABASE_URL_PROD). _BACKEND_DB_PGBOUNCER=true와 짝.
@@ -652,7 +666,8 @@ steps:
           #   sprintable_read 풀 경유). 지금까지 라이브 «수동 바인딩»이라 배포 SSOT 어디에도 선언이 없어
           #   env-drift-guard 축①이 매일 빨강이었다(additive --update-secrets 라 값은 보존됐으나 미선언=fragile:
           #   --set-secrets 리팩터·서비스 재생성 時 조용히 소실→reads가 primary 로 새 병목 악화). 여기 편입해 durable화.
-          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_PROD_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_PROD:latest,DATABASE_URL_READ=DATABASE_URL_READ:latest"
+          # story #3118 — dev와 동일 시크릿(APPLE_SIWA_PRIVATE_KEY, dev/prod 공용) 동봉.
+          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_PROD_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_PROD:latest,DATABASE_URL_READ=DATABASE_URL_READ:latest,APPLE_PRIVATE_KEY=APPLE_SIWA_PRIVATE_KEY:latest"
         fi
         gcloud run deploy sprintable-backend-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA} \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -591,9 +591,7 @@ steps:
         # 에서 정정(구 `REDIS_CONSUME_ENABLED`는 Settings 필드와 안 맞아 무시되던 키) — 구 키는
         # --remove-env-vars로 명시 제거(안 지우면 두 키 공존, additive 함정).
         # story #2123 S0-b: FANOUT_WAKE_REDIS_ENABLED(dev만 true, prod는 손대지 않음).
-        # story #3118(Sign in with Apple, PO 확定 2026-08-26) — APPLE_SERVICES_ID/APPLE_KEY_ID/
-        # APPLE_TEAM_ID 3종(비밀 아님, dev/prod 동일값) 추가. 개인키(APPLE_PRIVATE_KEY)는
-        # 이 plain env가 아니라 아래 SECRETS_FLAG(Secret Manager)로만 바인딩한다.
+        # story #3118 — Apple OAuth 식별자 3종(비밀 아님) 추가, 개인키는 아래 SECRETS_FLAG로.
         ENV_VARS="FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=${_DB_POOL_SIZE},DB_MAX_OVERFLOW=${_DB_MAX_OVERFLOW},DB_PGBOUNCER=${_BACKEND_DB_PGBOUNCER},PG_LISTEN_ENABLED=${_BACKEND_PG_LISTEN_ENABLED},EVENT_BROKER_REDIS_CONSUME_ENABLED=${_BACKEND_REDIS_CONSUME_ENABLED},EVENT_BROKER_REDIS_DISPATCH_ENABLED=${_BACKEND_REDIS_DISPATCH_ENABLED},EVENT_BROKER_REDIS_DUAL_PUBLISH_ENABLED=${_BACKEND_REDIS_DUAL_PUBLISH_ENABLED},FANOUT_WAKE_REDIS_ENABLED=${_BACKEND_FANOUT_WAKE_REDIS_ENABLED},PRESENCE_REDIS_ENABLED=${_BACKEND_PRESENCE_REDIS_ENABLED},PRESENCE_ONLINE_REDIS_ENABLED=${_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED},SSE_LEASE_REDIS_ENABLED=${_BACKEND_SSE_LEASE_REDIS_ENABLED},SSE_TRANSIENT_REPLAY_ENABLED=${_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED},LICENSE_CONSENT=${_LICENSE_CONSENT},NEXT_PUBLIC_APP_URL=${_NEXT_PUBLIC_APP_URL},DEPLOY_ENV=${_DEPLOY_ENV},FIREBASE_OAUTH_HANDOFF_ENABLED=${_FIREBASE_OAUTH_HANDOFF_ENABLED},APPLE_SERVICES_ID=${_APPLE_SERVICES_ID},APPLE_KEY_ID=${_APPLE_KEY_ID},APPLE_TEAM_ID=${_APPLE_TEAM_ID}"
         # ⛔story #2141(2026-07-23, prod Redis Memorystore 전환): REDIS_URL을 여기서 이 스텝이
         # 예전엔 dev/prod 공용으로 plain env 넘겼다 — prod는 Secret Manager 바인딩(REDIS_URL_PROD,
@@ -654,9 +652,7 @@ steps:
         # 갱신과 짝이라(안 맞추면 dev 서빙 인증 실패) #3110 2보로 분리.
         SECRETS_FLAG=""
         if [ "${_DEPLOY_ENV}" == "dev" ]; then
-          # story #3118 — APPLE_PRIVATE_KEY(SIWA 개인키, Secret Manager `APPLE_SIWA_PRIVATE_KEY`)
-          # 는 dev/prod 공용 시크릿(PO 발급·양쪽 런타임 SA에 secretAccessor 부여 済) — DB 시크릿과
-          # 같은 --update-secrets 한 호출에 동봉(additive, 기존 다른 시크릿 preserve).
+          # story #3118 — SIWA 개인키(dev/prod 공용 시크릿) 동봉.
           SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV_SPRINTABLE:latest,APPLE_PRIVATE_KEY=APPLE_SIWA_PRIVATE_KEY:latest"
         elif [ "${_DEPLOY_ENV}" == "prod" ]; then
           # story #2445 Phase1(2026-08-04) — prod cutover: DATABASE_URL→PgBouncer VIP(DATABASE_URL_PROD_PGBOUNCER,
@@ -666,7 +662,7 @@ steps:
           #   sprintable_read 풀 경유). 지금까지 라이브 «수동 바인딩»이라 배포 SSOT 어디에도 선언이 없어
           #   env-drift-guard 축①이 매일 빨강이었다(additive --update-secrets 라 값은 보존됐으나 미선언=fragile:
           #   --set-secrets 리팩터·서비스 재생성 時 조용히 소실→reads가 primary 로 새 병목 악화). 여기 편입해 durable화.
-          # story #3118 — dev와 동일 시크릿(APPLE_SIWA_PRIVATE_KEY, dev/prod 공용) 동봉.
+          # story #3118 — dev와 동일 시크릿 동봉.
           SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_PROD_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_PROD:latest,DATABASE_URL_READ=DATABASE_URL_READ:latest,APPLE_PRIVATE_KEY=APPLE_SIWA_PRIVATE_KEY:latest"
         fi
         gcloud run deploy sprintable-backend-${_DEPLOY_ENV} \


### PR DESCRIPTION
## 배경
PO 확定(2026-08-26, 값 일괄 전달·시크릿/SA 권한은 PO가 사전 프로비저닝): client_id(Services ID)=`ai.sprintable.web`·Key ID=`DF2G3UV649`·Team ID=`JN798BC4KC`(기존 `_APPLE_TEAM_ID` 재사용, AASA 라우트와 동일 값)·개인키=Secret Manager `APPLE_SIWA_PRIVATE_KEY`(dev/prod 공용, 양쪽 런타임 SA에 secretAccessor 부여 済). 코드 PR(#3526)이 머지돼도 이 배선 없이는 「돌 자리 없음」 클래스라 별도 PR로 붙입니다.

## 변경
- substitutions에 `_APPLE_SERVICES_ID`/`_APPLE_KEY_ID` 신설(비밀 아닌 값, dev/prod 동일 — 기존 `_APPLE_TEAM_ID`와 동일 원칙, override 불요).
- deploy-backend 스텝 ENV_VARS에 `APPLE_SERVICES_ID`/`APPLE_KEY_ID`/`APPLE_TEAM_ID` 추가(plain env — `--update-env-vars` additive, 기존 env 보존).
- deploy-backend 스텝 dev/prod 양쪽 SECRETS_FLAG에 `APPLE_PRIVATE_KEY=APPLE_SIWA_PRIVATE_KEY:latest` 동봉(`--update-secrets` additive, 기존 DB 시크릿 preserve).
- GHA(`cloud-build.yml`) 변경 없음 — cloudbuild.yaml 파일 기본값이 dev/prod 무관 그대로 쓰이므로(SUBST 문자열에 안 실린 substitution은 파일 기본값 유지, Team ID의 기존 관례와 동일 판단).

콜백 도메인/Return URL은 app/dev-app 양쪽 `/api/auth/callback/apple`로 이미 등록 済(PO 콘솔 확認) — 코드 쪽 `_redirect_uri()` 조합값과 일치(#3526).

## 검증
- [x] YAML 파싱 확認(`python yaml.safe_load`) — substitutions 신규 2키 값 확認
- [x] `config.py` Settings 필드↔env var 이름 매핑 실왕복 확認(APPLE_TEAM_ID/APPLE_SERVICES_ID/APPLE_KEY_ID/APPLE_PRIVATE_KEY 4종 전부 정확히 바인딩)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011js9VYShN84eGzG3nSPYBn