### PR TITLE
[SID:3115] 승격 리드타임 — 링크 후시딩 gate 미생성 갭 + 취소를 CI 실패로 오판

### DIFF
--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -216,6 +216,16 @@ async def create_explicit_link(
         link_source="explicit", confidence="high", created_by=created_by,
         evidence={"by": "explicit_api"},
     )
+    # story #3115(2026-08-26, 승격 리드타임) — explicit link 생성도 story #2893 후속(참여
+    # 등록)과 동형 갭이었다: PR opened(링크 無)→action_required 발행(gate 미생성)→이 API로
+    # 뒤늦게 링크→**이후 재평가 훅 0**→다음 실 웹훅(재오픈 등)까지 gate가 영구 미생성.
+    # trigger_gate_creation_for_late_participation은 "story에 연결된 PR마다 gate 없으면
+    # 만든다"는 일반 훅이라 참여 등록만이 아니라 이 링크 생성에도 그대로 재사용된다(새 규칙
+    # 발명 0). 방금 flush된 링크 행을 같은 트랜잭션(commit 前)에서 즉시 봐야 하므로 커밋 前에
+    # 호출 — participation.py::add_participation과 동일 순서 규율.
+    from app.services.merge_verdict_gate import trigger_gate_creation_for_late_participation
+
+    await trigger_gate_creation_for_late_participation(session, org_id, body.story_id)
     await session.commit()
     return JSONResponse(
         content={

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -841,6 +841,16 @@ async def trigger_gate_creation_for_late_participation(
     조합을 그대로 재사용 — get_pull_request로 현재 head SHA/merged를, fetch_status_check_
     rollup으로 CI를 읽어 evaluate_merge_gate 재호출. 새 규칙 발명 0).
 
+    story #3115(2026-08-26, 승격 리드타임) 후속 — 이 함수는 "story에 링크된 PR마다 gate가
+    없으면 만든다"는 참여-불특정 일반 훅이라, 참여 등록 갭과 완전히 동형인 **링크 생성 갭**
+    (PR opened(링크 無)→action_required 발행→`POST /github/links`(explicit link)로 뒤늦게
+    링크→재평가 훅 0→gate 영구 미생성)에도 그대로 재사용된다 —
+    `github_integration.py::create_explicit_link`도 이제 이 훅을 부른다(새 규칙 발명 0,
+    참여 쪽과 동일 chokepoint 원칙). 두 갭이 순서 무관하게 어느 쪽이든 먼저 채워지면(링크
+    먼저·참여 먼저 둘 다) 그 즉시 이 함수가 시도하고, 아직 안 채워진 나머지 한쪽이
+    evaluate_merge_gate 내부에서 계속 막으면(예: 링크는 있는데 참여가 아직 없음) 그 나머지
+    쪽이 채워질 때 같은 훅이 다시 성공한다 — 재오픈 없이 두 갭 모두 닫힌다.
+
     ⚠️호출자의 세션을 그대로 받는다(별도 세션 아님) — 방금 `flush`된(아직 커밋 前) participation
     행을 evaluate_merge_gate가 같은 트랜잭션 안에서 즉시 봐야 하기 때문(실측: 별도 세션으로
     분리했더니 그 세션엔 아직 안 보이는 미커밋 행 탓에 "no implementation participation"으로

--- a/backend/app/services/verdict_capture.py
+++ b/backend/app/services/verdict_capture.py
@@ -284,7 +284,17 @@ async def capture_pr_ci_verdict(
         recorded.append("pr")
 
     # source=ci: CI 결과
-    if ci_result is not None:
+    # story #3115(2026-08-26, 승격 리드타임 — «재오픈 연쇄의 취소 오염») — ci_result="cancelled"
+    # (router._normalize_ci, ci.yml의 cancel-in-progress:true가 만드는 정상 흐름: 재오픈/재push로
+    # 새 workflow_run이 뜨면 concurrency 그룹의 옛 run이 취소된다)는 「실패」가 아니라 「이
+    # 실행에서 판정 안 남」이다. 예전엔 `"pass" if ... else "fail"`이 cancelled까지 fail로
+    # 밀어넣어 CI 게이트를 rejected로 그르치고(resolve_gate_from_verdict — verdict_result≠pass는
+    # 즉시 rejected, gate_service.py) story trust 이력에도 거짓 실패가 남았다(「직렬 재실행
+    # 정화」가 필요했던 그 오염). cancelled는 완전히 skip — 다른 곳의 "모름을 위조하지 않는다"
+    # 원칙(merge_verdict_gate.py의 pr_result=None 등)과 동일 축.
+    if ci_result is not None and ci_result.lower() == "cancelled":
+        pass
+    elif ci_result is not None:
         normalized = "pass" if ci_result.lower() in ("pass", "success") else "fail"
         await record_verdict(
             session, org_id, participation.id,

--- a/backend/tests/test_3115_late_link_gate_creation_realdb.py
+++ b/backend/tests/test_3115_late_link_gate_creation_realdb.py
@@ -1,0 +1,228 @@
+"""story #3115(2026-08-26, 승격 리드타임 단축) — 순서 조합 갭의 거울쌍.
+
+story #2893 후속(PR#3357)이 고친 "참여가 링크보다 늦으면 gate가 영구 미생성"과 정확히 대칭인
+갭: **링크가 참여보다 늦으면**(participation 먼저 등록돼 있는데 story-link만 늦게 생기는 순서)도
+동일하게 gate가 영구 미생성이었다 — `POST /integrations/github/links`(explicit link, 사람이
+action_required 안내를 보고 쓰는 그 API)가 `upsert_link` 후 재평가 훅을 전혀 안 불렀기 때문.
+
+처방: `trigger_gate_creation_for_late_participation`(참여 쪽 기존 훅 — "story에 링크된 PR마다
+gate 없으면 만든다"는 참여-불특정 일반 로직)을 `create_explicit_link`에도 그대로 재사용(새 규칙
+발명 0). 이 파일은 test_2893_pr4_late_participation_gate_creation_realdb.py와 동일 하네스·
+동일 패턴을 그대로 재사용해 "참여 선시딩 → 링크 후시딩" 순서로 정확히 거울 재현한다.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from tests.test_2893_gate_pr_scoped_isolation_realdb import (
+    _seed_installation,
+    _session_factory,
+)
+from tests.test_2893_pr4_late_participation_gate_creation_realdb import (
+    _gates_for_story,
+    _live_pr_patches,
+)
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _seed_org_project_story_with_participation(s):
+    """참여를 story-link보다 먼저 시드한다(late-participation 테스트의 정확한 거울)."""
+    from app.models.organization import Organization
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    s.add(org)
+    await s.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    s.add(project)
+    await s.commit()
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="in-progress")
+    s.add(story)
+    await s.commit()
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="implementation", label="Impl", is_default=True)
+    s.add(role)
+    await s.commit()
+    s.add(Participation(id=uuid.uuid4(), org_id=org.id, story_id=story.id, member_id=uuid.uuid4(), role_id=role.id))
+    await s.commit()
+    return org, project, story
+
+
+@pytest.mark.anyio
+async def test_explicit_link_endpoint_creates_missing_gate_when_participation_already_exists():
+    """핵심 재현 — participation이 이미 있는 story에 뒤늦게 explicit link를 걸면(재오픈 없이)
+    그 즉시 gate가 생겨야 한다."""
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.main import app
+    from httpx import ASGITransport, AsyncClient
+    from tests.conftest import override_db_and_read
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project, story = await _seed_org_project_story_with_participation(s)
+            await _seed_installation(s, org, installation_id=680603)
+            story_id = story.id
+
+            from app.models.project import OrgMember
+            from app.models.project_access import ProjectAccess
+            from app.models.user import User
+
+            caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+            s.add(caller)
+            await s.commit()
+            caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
+            s.add(caller_om)
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+            caller_id = caller.id
+
+        async def _db():
+            async with Session() as s:
+                try:
+                    yield s
+                    await s.commit()
+                except Exception:
+                    await s.rollback()
+                    raise
+
+        async def _auth():
+            return AuthContext(user_id=str(caller_id), email="caller@test", claims={"app_metadata": {}})
+
+        async def _org():
+            return org.id
+
+        override_db_and_read(app, _db)
+        app.dependency_overrides[get_current_user] = _auth
+        app.dependency_overrides[get_verified_org_id] = _org
+
+        client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+        try:
+            p1, p2, p3 = _live_pr_patches(head_sha="sha-late-link-1", ci_result="success")
+            with p1, p2, p3:
+                resp = await client.post(
+                    "/api/v2/integrations/github/links",
+                    json={
+                        "story_id": str(story_id),
+                        "repo_full_name": "moonklabs/sprintable",
+                        "pr_number": 603,
+                    },
+                )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert len(gates) == 1, "explicit link 라우터도 게이트 생성 훅을 태워야 함(재오픈 불요)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_explicit_link_hook_noop_when_participation_still_missing():
+    """음성대조 — participation이 아직 없으면(링크만 먼저 생김) 훅이 조용히 no-op해야 한다
+    (evaluate_merge_gate 내부의 참여 요건이 여전히 막음 — 이 훅이 그 요건을 우회하면 안 됨).
+    이후 참여가 생기면 기존 late-participation 훅이 이어받아 닫는다(#2893 계열과 순서 무관 합류)."""
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.main import app
+    from httpx import ASGITransport, AsyncClient
+    from tests.conftest import override_db_and_read
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project, OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+            s.add(project)
+            await s.commit()
+            story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="in-progress")
+            s.add(story)
+            await s.commit()
+            await _seed_installation(s, org, installation_id=680604)
+            story_id = story.id
+
+            caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+            s.add(caller)
+            await s.commit()
+            caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
+            s.add(caller_om)
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+            caller_id = caller.id
+
+        async def _db():
+            async with Session() as s:
+                try:
+                    yield s
+                    await s.commit()
+                except Exception:
+                    await s.rollback()
+                    raise
+
+        async def _auth():
+            return AuthContext(user_id=str(caller_id), email="caller@test", claims={"app_metadata": {}})
+
+        async def _org():
+            return org.id
+
+        override_db_and_read(app, _db)
+        app.dependency_overrides[get_current_user] = _auth
+        app.dependency_overrides[get_verified_org_id] = _org
+
+        client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+        try:
+            p1, p2, p3 = _live_pr_patches(head_sha="sha-late-link-2", ci_result="success")
+            with p1, p2, p3:
+                resp = await client.post(
+                    "/api/v2/integrations/github/links",
+                    json={
+                        "story_id": str(story_id),
+                        "repo_full_name": "moonklabs/sprintable",
+                        "pr_number": 604,
+                    },
+                )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            gates = await _gates_for_story(s, story_id)
+            assert gates == [], "참여가 없으면 게이트가 만들어지면 안 됨(요건 우회 금지)"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_cage_referee_p1_verdict_capture.py
+++ b/backend/tests/test_e_cage_referee_p1_verdict_capture.py
@@ -178,6 +178,31 @@ async def test_capture_ci_fail_records_ci_verdict():
 
 
 @pytest.mark.anyio
+async def test_capture_ci_cancelled_skips_verdict_no_false_fail():
+    """⭐story #3115(2026-08-26, 승격 리드타임 — «재오픈 연쇄의 취소 오염») — cancelled(재오픈/
+    재push로 새 workflow_run이 concurrency 그룹의 옛 run을 취소한 정상 흐름)를 fail로
+    채점하면 CI 게이트가 거짓 rejected되고 story trust 이력도 오염된다. cancelled는 완전히
+    skip(verdict 기록도 gate 해소도 안 함) — recorded에도 안 들어가야 한다."""
+    from app.services.verdict_capture import capture_pr_ci_verdict
+
+    session = AsyncMock()
+    participation = MagicMock()
+    participation.id = PARTICIPATION_ID
+
+    with patch("app.services.verdict_capture.resolve_implementation_participation", new_callable=AsyncMock) as mock_resolve, \
+         patch("app.services.verdict_capture.record_verdict", new_callable=AsyncMock) as mock_record:
+        mock_resolve.return_value = participation
+
+        result = await capture_pr_ci_verdict(
+            session, ORG_ID, STORY_ID, pr_number=1108,
+            repo="moonklabs/sprintable", merged=False, ci_result="cancelled"
+        )
+
+        assert "ci" not in result["recorded"]
+        mock_record.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_capture_no_participation_skips():
     """participation 없으면 skip (거짓기록 금지)."""
     from app.services.verdict_capture import capture_pr_ci_verdict


### PR DESCRIPTION
## Summary
- [프로세스·승격] 선생님 지적(2026-08-26) — 승격 서명→배포 완료 ~1시간, 전부 절차 마찰(코드 결함 0).
- **AC2**: story-link가 participation보다 늦게 생기면(`POST /integrations/github/links`로 뒤늦게 연결) gate가 영구 미생성이던 갭. participation 쪽은 이미 처방 완료(#2893 후속, PR#3357)였는데, 그 거울쌍인 링크 쪽은 미처방이었다 — 참여 쪽 기존 훅(`trigger_gate_creation_for_late_participation`, "story에 링크된 PR마다 gate 없으면 즉시 만든다")을 `create_explicit_link`에도 그대로 재사용(새 규칙 발명 0). 이제 링크·참여 어느 쪽이 먼저든 나중 쪽이 채워지는 즉시 gate가 생겨 PR 재오픈이 불필요해진다.
- **AC3**: `capture_pr_ci_verdict`가 `ci_result="cancelled"`(ci.yml의 `cancel-in-progress:true`가 재오픈/재push 시 만드는 정상 신호)까지 `"fail"`로 채점해 CI 게이트를 즉시 `rejected`로 그르치고 story trust 이력에도 거짓 실패를 남겼다 — cancelled는 완전 skip으로 정정("모름을 위조하지 않는다" 기존 원칙과 동일 축).
- **AC1**(승격 PR 자동 스토리생성/링크/claim 또는 게이트 프로파일 면제)은 이번 AC2 fix로 마찰이 이미 크게 줄었다고 판단해 이 PR 범위 밖으로 남김 — story #3115 본문에 판단 요청 기록(AC2로 충분한지, 완전 자동화가 여전히 필요한지).

[SID:3115]

## Test plan
- [x] 신규 realdb pin 테스트 2건(`test_3115_late_link_gate_creation_realdb.py` — explicit-link 훅 정방향+참여 아직 없을 때 no-op 음성대조)
- [x] cancelled-skip pin 테스트 1건(`test_e_cage_referee_p1_verdict_capture.py`)
- [x] 게이트 생태계 회귀 스위트 244건 전부 green(신선 disposable PG, 회귀 0)
- [x] YAML/py_compile 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GstUsgB3QHGDMxXJ3EijdW