### PR TITLE
[SID:3122] 계정 연결(link) — 다른 로그인 provider를 기존 계정에 수동 연결

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -27,6 +27,7 @@ import { StandupDeadlineSection } from '@/components/settings/standup-deadline-s
 import { GateLevelMatrix } from '@/components/settings/gate-level-matrix';
 import { TwoFactorSection } from '@/components/settings/two-factor-section';
 import { SetPasswordSection } from '@/components/settings/set-password-section';
+import { LinkedAccountsSection } from '@/components/settings/linked-accounts-section';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { canSubmitOrgDelete } from './org-delete-gate';
 import { Badge } from '@/components/ui/badge';
@@ -794,6 +795,7 @@ export default function SettingsPage() {
               <div className="space-y-6">
                 <MyProfileSection />
                 <SetPasswordSection />
+                <LinkedAccountsSection />
                 <TwoFactorSection />
                 {currentProjectId && (
                   <MyNotificationChannelSection

--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -77,11 +77,16 @@ async function handleCallback(request: Request, provider: string, code: string |
   // e-mobile-oauth-native-handoff-contract §7.4/§5 — 격리 rail(오르테가 확定, /auth/native
   // 무접촉). native OAuth-start에서만 세팅되는 challenge — 있으면 이 콜백도 native 취급.
   const nativeChallenge = cookieStore.get(`oauth_native_challenge_${provider}`)?.value ?? null;
+  // story #3122(계정 연결) — auth/link/route.ts만 세팅하는 단명 쿠키. provider가 돌려주는
+  // code/state 자체엔 "로그인이냐 연결이냐" 구분이 없어(authorize 요청 파라미터가 로그인과
+  // 동일하게 생겼다, 의도된 설계) 이 쿠키가 유일한 분기 신호다.
+  const linkMode = cookieStore.get(`oauth_link_${provider}`)?.value === 'true';
   cookieStore.delete(`oauth_state_${provider}`);
   cookieStore.delete(`oauth_tos_${provider}`);
   cookieStore.delete(`oauth_invite_token_${provider}`);
   cookieStore.delete(`oauth_next_${provider}`);
   cookieStore.delete(`oauth_native_challenge_${provider}`);
+  cookieStore.delete(`oauth_link_${provider}`);
 
   // ⛔통과 조건은 원래와 동일(storedState 존재 AND 일치) — 분기는 로그용일 뿐, 검증 자체는
   // 안 바뀐다. 두 실패 분기 다 사용자에게는 동일한 csrf_mismatch로 리다이렉트한다.
@@ -94,6 +99,30 @@ async function handleCallback(request: Request, provider: string, code: string |
     return NextResponse.redirect(`${origin}/login?error=csrf_mismatch`);
   }
   logOauthStateCheck('ok', request, provider, nativeChallenge, state.length, storedState.length);
+
+  // story #3122 — 계정 연결 콜백. 로그인 rail(/oauth/callback)과 완전히 다른 BE 엔드포인트로
+  // 간다(AC4: 로그인 mint 아님 — 새 JWT를 안 받고, 기존 sp_at/sp_rt 쿠키를 그대로 둔다).
+  // 링크는 "로그인된 채로" 시작한 흐름이라 이 시점 sp_at이 여전히 유효해야 한다 — 최대
+  // OAUTH_STATE_EXPIRE_MINUTES(10분) 왕복 동안 세션이 끊기면(로그아웃 등) BE가 401을 주고,
+  // 그대로 실패로 리다이렉트한다(별도 처리 불요 — settings 쪽이 에러 코드로 안내).
+  if (linkMode) {
+    const spAt = cookieStore.get(SP_AT_COOKIE)?.value;
+    if (!spAt) {
+      return NextResponse.redirect(`${origin}/settings?link_error=SESSION_EXPIRED`);
+    }
+    const linkRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/oauth/${provider}/link/callback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${spAt}` },
+      body: JSON.stringify({ provider, code, state }),
+    }).catch(() => null);
+
+    if (!linkRes?.ok) {
+      const errBody = await linkRes?.json().catch(() => null) as { error?: { code?: string } } | null;
+      const errCode = errBody?.error?.code ?? 'LINK_FAILED';
+      return NextResponse.redirect(`${origin}/settings?link_error=${errCode}`);
+    }
+    return NextResponse.redirect(`${origin}/settings?linked=${provider}`);
+  }
 
   // FastAPI OAuth callback
   const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/oauth/callback`, {

--- a/apps/web/src/app/api/auth/oauth/unlink/route.ts
+++ b/apps/web/src/app/api/auth/oauth/unlink/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { SP_AT_COOKIE } from '@/lib/db/server';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+/** POST /api/auth/oauth/unlink — story #3122 AC3, {provider} 연결 해제(최소 1개 로그인
+ * 수단 보장은 BE가 매번 재계산해 강제한다 — 이 라우트는 순수 프록시). */
+export async function POST(request: Request) {
+  const me = await getAuthContext(request);
+  if (!me) return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }, { status: 401 });
+
+  const body = await request.json() as { provider?: string };
+  const provider = body.provider;
+  if (!provider || !['google', 'apple'].includes(provider)) {
+    return NextResponse.json({ error: { code: 'INVALID_PROVIDER', message: 'Unsupported provider' } }, { status: 400 });
+  }
+
+  const cookieStore = await cookies();
+  const spAt = cookieStore.get(SP_AT_COOKIE)?.value ?? '';
+
+  const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/oauth/${provider}/unlink`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${spAt}` },
+  });
+
+  const json = await fastapiRes.json() as Record<string, unknown>;
+  if (!fastapiRes.ok) {
+    return NextResponse.json({ error: json['error'] ?? { code: 'FAILED', message: 'Failed to unlink' } }, { status: fastapiRes.status });
+  }
+  return NextResponse.json({ data: json['data'] });
+}

--- a/apps/web/src/app/auth/link/route.ts
+++ b/apps/web/src/app/auth/link/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { resolveAppUrl } from '@/services/app-url';
+import { oauthCookieOptions } from '@/lib/auth/oauth-cookies';
+import { SP_AT_COOKIE } from '@/lib/db/server';
+
+const FASTAPI_BASE = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+// story #3122(계정·후속 — 수동 계정 연결) — auth/login/route.ts와 형태는 닮았지만 의미가
+// 다르다: 저건 "아직 로그인 안 된 사람을 로그인/가입시키는" rail이고 이건 "이미 로그인된
+// 이 계정에 다른 provider를 붙이는" rail이다. 그래서 별도 route로 뺐다(tos_accepted·
+// invite_token 같은 로그인 전용 파라미터가 여기엔 의미가 없고, sp_at 쿠키가 반드시 있어야
+// 하는 게 진입 조건 자체다). BE authorize 호출에 Authorization 헤더로 그 sp_at을 실어야
+// state에 link_user_id(누구에게 붙일지)가 실린다(auth.py oauth_link_authorize).
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const provider = searchParams.get('provider');
+  const origin = resolveAppUrl(null);
+
+  if (!provider || !['google', 'apple'].includes(provider)) {
+    return NextResponse.redirect(`${origin}/settings?link_error=INVALID_PROVIDER`);
+  }
+
+  const cookieStore = await cookies();
+  const spAt = cookieStore.get(SP_AT_COOKIE)?.value;
+  if (!spAt) {
+    // 링크는 로그인된 계정 전용 — 세션이 없으면 로그인부터.
+    return NextResponse.redirect(`${origin}/login?next=${encodeURIComponent('/settings')}`);
+  }
+
+  const res = await fetch(`${FASTAPI_BASE}/api/v2/auth/oauth/${provider}/link/authorize`, {
+    headers: { Authorization: `Bearer ${spAt}` },
+  }).catch(() => null);
+  if (!res?.ok) {
+    return NextResponse.redirect(`${origin}/settings?link_error=LINK_INIT_FAILED`);
+  }
+
+  const json = await res.json() as { data?: { url?: string; state?: string } };
+  const url = json.data?.url;
+  const state = json.data?.state;
+  if (!url || !state) {
+    return NextResponse.redirect(`${origin}/settings?link_error=LINK_INIT_FAILED`);
+  }
+
+  const cookieOpts = oauthCookieOptions(provider);
+  cookieStore.set(`oauth_state_${provider}`, state, cookieOpts);
+  // 콜백(api/auth/callback/[provider]/route.ts)이 이 쿠키의 존재로 "로그인이 아니라 연결
+  // 콜백"임을 판별한다 — provider 쪽에서 보내는 code/state 자체엔 이 구분이 없다(authorize
+  // 요청 파라미터가 로그인과 동일하게 생겼다, 의도된 설계 — 콘솔 콜백 도메인 재등록 불요).
+  cookieStore.set(`oauth_link_${provider}`, 'true', cookieOpts);
+
+  return NextResponse.redirect(url);
+}

--- a/apps/web/src/app/auth/login/route.ts
+++ b/apps/web/src/app/auth/login/route.ts
@@ -1,22 +1,9 @@
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { resolveAppUrl } from '@/services/app-url';
+import { oauthCookieOptions } from '@/lib/auth/oauth-cookies';
 
 const FASTAPI_BASE = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
-
-// story #3118(Sign in with Apple) — PO 전언(페드루, 민 그라운딩 축): scope에 name/email이
-// 있는 Apple 콜백은 GET 리다이렉트가 아니라 cross-site POST(response_mode=form_post)로
-// 온다. SameSite=Lax 쿠키는 cross-site *POST*엔 안 실린다(Lax는 top-level GET 네비게이션만
-// 봐준다) — 이 5개 oauth_* 쿠키가 Lax로 남아있으면 Apple 콜백에서 state 검증이 "쿠키가 아예
-// 안 옴"으로 매번 헛실패한다(잘 알려진 함정 클래스). Apple만 SameSite=None(+Secure 필수 —
-// 브라우저가 None을 Secure 없이 거부)으로 쓴다. Google은 GET 리다이렉트라 Lax로 충분 —
-// 그대로 둔다(불필요하게 None으로 넓히지 않는다, 최소 권한).
-function oauthCookieOptions(provider: string) {
-  if (provider === 'apple') {
-    return { httpOnly: true, secure: true, sameSite: 'none' as const, maxAge: 300, path: '/' };
-  }
-  return { httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'lax' as const, maxAge: 300, path: '/' };
-}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);

--- a/apps/web/src/components/settings/linked-accounts-section.test.tsx
+++ b/apps/web/src/components/settings/linked-accounts-section.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+//
+// story #3122(계정·후속) — 수동 «계정 연결(link)». #3118 그라운딩(Apple private relay
+// 이메일이면 자동 이메일 병합 불가)에 대한 처방: 사용자 주도 수동 연결 UI.
+// AC1(연결 표면)·AC2(다른 계정에 이미 묶인 provider 명시 거부 문구)·AC3(최소 1개 로그인
+// 수단 — 클라 disabled + 서버 거부 시 문구 분기)를 렌더 레벨에서 고정한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const { useSearchParamsMock } = vi.hoisted(() => ({
+  useSearchParamsMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => useSearchParamsMock(),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useSearchParamsMock.mockReturnValue(new URLSearchParams());
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+async function mount(meData: { linked_providers: string[]; has_password?: boolean }) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url === '/api/me') return { ok: true, json: async () => ({ data: meData }) };
+    throw new Error('unexpected fetch: ' + url);
+  }));
+  const { LinkedAccountsSection } = await import('./linked-accounts-section');
+  await act(async () => { root.render(<LinkedAccountsSection />); });
+  await flush();
+}
+
+describe('LinkedAccountsSection — 연결 상태 렌더 (AC1)', () => {
+  it('linked_providers에 있으면 Connected+Disconnect, 없으면 Not connected+Connect', async () => {
+    await mount({ linked_providers: ['google'], has_password: true });
+    const items = Array.from(container.querySelectorAll('li'));
+    const googleItem = items.find((li) => li.textContent?.includes('Google'));
+    const appleItem = items.find((li) => li.textContent?.includes('Apple'));
+    expect(googleItem?.textContent).toContain('Connected');
+    expect(googleItem?.querySelector('button')?.textContent).toBe('Disconnect');
+    expect(appleItem?.textContent).toContain('Not connected');
+    expect(appleItem?.querySelector('a')?.getAttribute('href')).toBe('/auth/link?provider=apple');
+  });
+
+  it('Connect 링크는 /auth/link?provider={id}로 나간다', async () => {
+    await mount({ linked_providers: [], has_password: true });
+    const links = Array.from(container.querySelectorAll('a'));
+    expect(links.map((a) => a.getAttribute('href'))).toEqual(
+      expect.arrayContaining(['/auth/link?provider=google', '/auth/link?provider=apple']),
+    );
+  });
+});
+
+describe('LinkedAccountsSection — 최소 1개 로그인 수단 가드 (AC3)', () => {
+  it('연결된 provider 1개뿐 + has_password=false면 Disconnect 버튼이 disabled', async () => {
+    await mount({ linked_providers: ['apple'], has_password: false });
+    const items = Array.from(container.querySelectorAll('li'));
+    const appleItem = items.find((li) => li.textContent?.includes('Apple'));
+    const btn = appleItem?.querySelector('button');
+    expect(btn?.disabled).toBe(true);
+  });
+
+  it('연결된 provider 2개면(비밀번호 없어도) 둘 다 Disconnect 활성', async () => {
+    await mount({ linked_providers: ['google', 'apple'], has_password: false });
+    const buttons = Array.from(container.querySelectorAll('button'));
+    expect(buttons.every((b) => !b.disabled)).toBe(true);
+  });
+
+  it('서버가 LAST_LOGIN_METHOD로 거부하면 전용 안내 문구', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: { linked_providers: ['google', 'apple'], has_password: false } }) };
+      if (url === '/api/auth/oauth/unlink' && init) {
+        return { ok: false, json: async () => ({ error: { code: 'LAST_LOGIN_METHOD' } }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    const { LinkedAccountsSection } = await import('./linked-accounts-section');
+    await act(async () => { root.render(<LinkedAccountsSection />); });
+    await flush();
+    const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'Disconnect');
+    await act(async () => { btn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+    expect(container.textContent).toContain('This is your only sign-in method');
+  });
+});
+
+describe('LinkedAccountsSection — 콜백 리다이렉트 쿼리 문구 (AC2)', () => {
+  it('linked=apple면 성공 문구', async () => {
+    useSearchParamsMock.mockReturnValue(new URLSearchParams('linked=apple'));
+    await mount({ linked_providers: ['apple'] });
+    expect(container.textContent).toContain('Apple account connected.');
+  });
+
+  it('link_error=PROVIDER_ALREADY_LINKED면 "다른 계정에 이미 연결됨" 문구(병합 아님을 명시)', async () => {
+    useSearchParamsMock.mockReturnValue(new URLSearchParams('link_error=PROVIDER_ALREADY_LINKED'));
+    await mount({ linked_providers: [] });
+    expect(container.textContent).toContain('already linked to a different Sprintable account');
+  });
+
+  it('link_error=LINK_SESSION_MISMATCH면 세션 변경 안내', async () => {
+    useSearchParamsMock.mockReturnValue(new URLSearchParams('link_error=LINK_SESSION_MISMATCH'));
+    await mount({ linked_providers: [] });
+    expect(container.textContent).toContain('Your session changed during linking');
+  });
+});

--- a/apps/web/src/components/settings/linked-accounts-section.tsx
+++ b/apps/web/src/components/settings/linked-accounts-section.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { fetchWithAuth } from '@/lib/db/client';
+
+type ProviderId = 'google' | 'apple';
+
+const PROVIDERS: { id: ProviderId; label: string }[] = [
+  { id: 'google', label: 'Google' },
+  { id: 'apple', label: 'Apple' },
+];
+
+// story #3122(계정·후속) — #3118 그라운딩: Apple private relay 이메일이면 자동 이메일
+// 병합이 원천 불가해 항상 신규 계정이 생긴다. PO 확定 정책: 병합은 사용자 주도 수동
+// 연결로. has_password 유무로만 렌더 여부가 갈리는 SetPasswordSection과 달리 이 섹션은
+// has_password와 무관하게 항상 보인다(로그인 방법이 뭐든 추가 provider 연결은 유효한
+// 동작) — SetPasswordSection과 같은 하드코딩 영문 톤(이 컴포넌트군은 next-intl 미배선)을
+// 그대로 따른다.
+export function LinkedAccountsSection() {
+  const searchParams = useSearchParams();
+  const [linkedProviders, setLinkedProviders] = useState<ProviderId[] | null>(null);
+  const [hasPassword, setHasPassword] = useState<boolean | null>(null);
+  const [unlinking, setUnlinking] = useState<ProviderId | null>(null);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const refresh = async () => {
+    const res = await fetchWithAuth('/api/me');
+    if (!res.ok) return;
+    const json = await res.json() as { data?: { linked_providers?: ProviderId[]; has_password?: boolean } };
+    setLinkedProviders(json.data?.linked_providers ?? []);
+    setHasPassword(json.data?.has_password ?? null);
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  useEffect(() => {
+    const linked = searchParams.get('linked');
+    const linkError = searchParams.get('link_error');
+    if (linked) {
+      setMessage({ type: 'success', text: `${linked === 'apple' ? 'Apple' : 'Google'} account connected.` });
+      void refresh();
+    } else if (linkError) {
+      // story #3122 AC2 — PROVIDER_ALREADY_LINKED는 "이미 연결됨"이 아니라 "다른 계정에
+      // 묶여있어 거부됨"이라 문구를 갈라야 사용자가 오해하지 않는다(병합이 아니라는 것).
+      const text = linkError === 'PROVIDER_ALREADY_LINKED'
+        ? 'That account is already linked to a different Sprintable account.'
+        : linkError === 'LINK_SESSION_MISMATCH'
+          ? 'Your session changed during linking. Please try again.'
+          : linkError === 'SESSION_EXPIRED'
+            ? 'Your session expired before linking finished. Please try again.'
+            : 'Failed to connect account.';
+      setMessage({ type: 'error', text });
+    }
+  }, [searchParams]);
+
+  const handleUnlink = async (provider: ProviderId) => {
+    setUnlinking(provider);
+    setMessage(null);
+    try {
+      const res = await fetch('/api/auth/oauth/unlink', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider }),
+      });
+      const json = await res.json() as { error?: { code?: string } };
+      if (!res.ok) {
+        const text = json.error?.code === 'LAST_LOGIN_METHOD'
+          ? 'This is your only sign-in method — set a password or connect another account before disconnecting.'
+          : 'Failed to disconnect account.';
+        setMessage({ type: 'error', text });
+        return;
+      }
+      setMessage({ type: 'success', text: `${provider === 'apple' ? 'Apple' : 'Google'} account disconnected.` });
+      await refresh();
+    } finally {
+      setUnlinking(null);
+    }
+  };
+
+  if (linkedProviders === null) return null;
+
+  const loginMethodCount = (hasPassword ? 1 : 0) + linkedProviders.length;
+
+  return (
+    <SectionCard>
+      <SectionCardHeader>
+        <div className="space-y-1">
+          <h2 className="text-base font-semibold text-foreground">Connected Accounts</h2>
+          <p className="text-sm text-muted-foreground">
+            Connect another sign-in method to this account, or disconnect one you no longer use.
+          </p>
+        </div>
+      </SectionCardHeader>
+      <SectionCardBody className="space-y-4">
+        {message && (
+          <p
+            role={message.type === 'success' ? 'status' : 'alert'}
+            aria-live={message.type === 'success' ? 'polite' : 'assertive'}
+            aria-atomic="true"
+            className={`text-sm ${message.type === 'success' ? 'text-success' : 'text-destructive'}`}
+          >
+            {message.text}
+          </p>
+        )}
+
+        <ul className="divide-y divide-border max-w-sm">
+          {PROVIDERS.map(({ id, label }) => {
+            const connected = linkedProviders.includes(id);
+            const canUnlink = connected && loginMethodCount > 1;
+            return (
+              <li key={id} className="flex items-center justify-between py-3">
+                <div>
+                  <p className="text-sm font-medium text-foreground">{label}</p>
+                  <p className="text-xs text-muted-foreground">{connected ? 'Connected' : 'Not connected'}</p>
+                </div>
+                {connected ? (
+                  <button
+                    onClick={() => void handleUnlink(id)}
+                    disabled={!canUnlink || unlinking === id}
+                    title={canUnlink ? undefined : 'This is your only sign-in method'}
+                    className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted/50 disabled:opacity-50"
+                  >
+                    {unlinking === id ? '...' : 'Disconnect'}
+                  </button>
+                ) : (
+                  <a
+                    href={`/auth/link?provider=${id}`}
+                    className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted/50"
+                  >
+                    Connect
+                  </a>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </SectionCardBody>
+    </SectionCard>
+  );
+}

--- a/apps/web/src/components/settings/linked-accounts-section.tsx
+++ b/apps/web/src/components/settings/linked-accounts-section.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { Check } from 'lucide-react';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { fetchWithAuth } from '@/lib/db/client';
 
@@ -97,12 +98,17 @@ export function LinkedAccountsSection() {
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">
         {message && (
+          // 유나 design:changes(2026-08-26, PR#3532) — 라이트 테마 text-success on 배경이
+          // 3.49:1로 AA(4.5) 미달 실측(StateHeader §654a74ba 선례 동형). 처방: 성공 텍스트는
+          // text-foreground(중립, 양테마 AA 보장)로 두고 상태 신호는 그래픽(체크 아이콘,
+          // 장식용 aria-hidden)으로만 준다 — "색은 그래픽·텍스트는 중립".
           <p
             role={message.type === 'success' ? 'status' : 'alert'}
             aria-live={message.type === 'success' ? 'polite' : 'assertive'}
             aria-atomic="true"
-            className={`text-sm ${message.type === 'success' ? 'text-success' : 'text-destructive'}`}
+            className={`flex items-center gap-1.5 text-sm ${message.type === 'success' ? 'text-foreground' : 'text-destructive'}`}
           >
+            {message.type === 'success' && <Check className="size-3.5 shrink-0 text-success" aria-hidden="true" />}
             {message.text}
           </p>
         )}

--- a/apps/web/src/components/settings/linked-accounts-section.tsx
+++ b/apps/web/src/components/settings/linked-accounts-section.tsx
@@ -62,7 +62,7 @@ export function LinkedAccountsSection() {
     setUnlinking(provider);
     setMessage(null);
     try {
-      const res = await fetch('/api/auth/oauth/unlink', {
+      const res = await fetchWithAuth('/api/auth/oauth/unlink', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ provider }),

--- a/apps/web/src/lib/auth/oauth-cookies.ts
+++ b/apps/web/src/lib/auth/oauth-cookies.ts
@@ -1,0 +1,19 @@
+// story #3118(Sign in with Apple) — PO 전언(페드루, 민 그라운딩 축): scope에 name/email이
+// 있는 Apple 콜백은 GET 리다이렉트가 아니라 cross-site POST(response_mode=form_post)로
+// 온다. SameSite=Lax 쿠키는 cross-site *POST*엔 안 실린다(Lax는 top-level GET 네비게이션만
+// 봐준다) — 이 oauth_* 단명 쿠키들이 Lax로 남아있으면 Apple 콜백에서 state 검증이 "쿠키가
+// 아예 안 옴"으로 매번 헛실패한다(잘 알려진 함정 클래스). Apple만 SameSite=None(+Secure
+// 필수 — 브라우저가 None을 Secure 없이 거부)으로 쓴다. Google은 GET 리다이렉트라 Lax로
+// 충분 — 그대로 둔다(불필요하게 None으로 넓히지 않는다, 최소 권한).
+//
+// story #3122(계정 연결) — 로그인 rail(auth/login/route.ts)과 link rail(auth/link/route.ts)
+// 둘 다 같은 함정을 겪는다(Apple form_post는 어느 쪽이든 cross-site POST). route.ts는
+// GET/POST 외의 임의 named export를 Next App Router 빌드가 라우트 핸들러로 오인해 거부할
+// 수 있어(경로 규칙) 여기 lib로 분리해 두 route.ts가 공유한다 — 복붙 두 벌을 두면 한쪽만
+// 고치고 잊는 사고가 나기 쉽다(SameSite 실수는 반나절 삽질급 함정이라고 페드루가 직접 경고).
+export function oauthCookieOptions(provider: string) {
+  if (provider === 'apple') {
+    return { httpOnly: true, secure: true, sameSite: 'none' as const, maxAge: 300, path: '/' };
+  }
+  return { httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'lax' as const, maxAge: 300, path: '/' };
+}

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -236,8 +236,14 @@ def decode_email_verification_token(token: str) -> dict:
 OAUTH_STATE_EXPIRE_MINUTES = 10
 
 
-def create_oauth_state_token(provider: str) -> str:
-    """10분 만료 OAuth state JWT. CSRF 방지용."""
+def create_oauth_state_token(provider: str, *, link_user_id: str | None = None) -> str:
+    """10분 만료 OAuth state JWT. CSRF 방지용.
+
+    story #3122(계정 연결) — link_user_id가 있으면 이 state는 "로그인"이 아니라 "이미
+    로그인된 이 유저에게 provider를 연결"하는 요청이라는 신원을 자체 서명으로 실어 나른다.
+    self-signed HS256이라 왕복 중 위조 불가 — 콜백에서 이 값과 그 시점의 실제 로그인
+    유저를 대조하면(auth.py oauth_link_callback) 10분 창 안에 브라우저 탭에서 계정을
+    전환해도 엉뚱한 계정에 연결되는 걸 막는다."""
     now = datetime.now(timezone.utc)
     exp = now + timedelta(minutes=OAUTH_STATE_EXPIRE_MINUTES)
     payload = {
@@ -246,16 +252,22 @@ def create_oauth_state_token(provider: str) -> str:
         "iat": int(now.timestamp()),
         "exp": int(exp.timestamp()),
     }
+    if link_user_id is not None:
+        payload["link_user_id"] = link_user_id
     return jwt.encode(payload, _get_secret(), algorithm="HS256")
 
 
-def decode_oauth_state_token(token: str, expected_provider: str) -> None:
-    """OAuth state token 검증. 만료/타입/provider 불일치 시 JWTError."""
+def decode_oauth_state_token(token: str, expected_provider: str) -> dict:
+    """OAuth state token 검증. 만료/타입/provider 불일치 시 JWTError.
+
+    story #3122 — link_user_id를 호출부가 읽을 수 있도록 payload 전체를 반환하도록 확장
+    (기존 반환값 None은 호출부가 어차피 안 쓰고 있었다 — 무회귀)."""
     payload = decode_jwt(token)
     if payload.get("type") != "oauth_state":
         raise JWTError("Invalid state token type")
     if payload.get("provider") != expected_provider:
         raise JWTError("Provider mismatch in state token")
+    return payload
 
 
 # story #3118(Sign in with Apple) — Google과 달리 Apple의 OAuth client_secret은 고정

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1088,6 +1088,67 @@ async def _verify_apple_id_token(client: httpx.AsyncClient, id_token: str, *, ex
     )
 
 
+class OAuthExchangeError(Exception):
+    """code→token/userinfo 교환 실패. .code/.message가 그대로 _err() 응답에 매핑된다.
+
+    story #3122 — 로그인 콜백(oauth_callback)과 계정연결 콜백(oauth_link_callback)이
+    같은 프로토콜 단계(code→token→userinfo, Apple이면 JWKS 서명검증까지)를 공유한다.
+    Apple id_token 검증 같은 보안 로직을 두 곳에 복붙해두면 한쪽만 고치고 잊는 사고가
+    나기 쉬워 단일 헬퍼(_exchange_oauth_code_for_userinfo)로 추출했다."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+async def _exchange_oauth_code_for_userinfo(
+    client: httpx.AsyncClient, provider: str, cfg: dict, code: str,
+) -> tuple[str, str]:
+    """code→access_token 교환 후 (oauth_id, email) 반환. email은 provider가 안 주면 ""(빈
+    문자열) — Apple은 최초 인가 이후 재인가에서 email을 아예 안 돌려주는 게 공식 동작이라
+    "필수 여부" 판단은 호출부 책임으로 남긴다(oauth_callback은 신규가입에 이메일이 필수라
+    직접 검사하고, oauth_link_callback은 oauth_id만 있으면 충분 — 이메일로 아무것도 안 함)."""
+    token_resp = await client.post(
+        cfg["token_url"],
+        data={
+            "client_id": _client_id(provider),
+            "client_secret": _client_secret(provider),
+            "code": code,
+            "redirect_uri": _redirect_uri(provider),
+            "grant_type": "authorization_code",
+        },
+        headers={"Accept": "application/json"},
+    )
+    if token_resp.status_code != 200:
+        raise OAuthExchangeError("OAUTH_TOKEN_EXCHANGE_FAILED", "Failed to exchange code for token")
+    token_data = token_resp.json()
+    access_token = token_data.get("access_token")
+    if not access_token:
+        raise OAuthExchangeError("OAUTH_NO_TOKEN", "No access_token in response")
+
+    if provider == "apple":
+        id_token = token_data.get("id_token")
+        if not id_token:
+            raise OAuthExchangeError("OAUTH_NO_TOKEN", "No id_token in response")
+        try:
+            userinfo = await _verify_apple_id_token(client, id_token, expected_audience=_client_id(provider))
+        except JWTError:
+            raise OAuthExchangeError("OAUTH_USERINFO_FAILED", "Failed to verify Apple id_token")
+    else:
+        userinfo_resp = await client.get(
+            cfg["userinfo_url"],
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        if userinfo_resp.status_code != 200:
+            raise OAuthExchangeError("OAUTH_USERINFO_FAILED", "Failed to fetch user info")
+        userinfo = userinfo_resp.json()
+
+    oauth_id = str(userinfo.get(cfg["id_field"], ""))
+    email = (userinfo.get(cfg["email_field"]) or "").lower().strip()
+    return oauth_id, email
+
+
 class OAuthCallbackRequest(BaseModel):
     provider: str
     code: str
@@ -1139,48 +1200,10 @@ async def oauth_callback(
         return _err("INVALID_STATE", "OAuth state is invalid or expired", 400)
 
     async with httpx.AsyncClient(timeout=15) as client:
-        # 1. code → access_token 교환
-        token_resp = await client.post(
-            cfg["token_url"],
-            data={
-                "client_id": _client_id(provider),
-                "client_secret": _client_secret(provider),
-                "code": body.code,
-                "redirect_uri": _redirect_uri(provider),
-                "grant_type": "authorization_code",
-            },
-            headers={"Accept": "application/json"},
-        )
-        if token_resp.status_code != 200:
-            return _err("OAUTH_TOKEN_EXCHANGE_FAILED", "Failed to exchange code for token", 400)
-        token_data = token_resp.json()
-        access_token = token_data.get("access_token")
-        if not access_token:
-            return _err("OAUTH_NO_TOKEN", "No access_token in response", 400)
-
-        # 2. userinfo 조회 — Apple은 userinfo 엔드포인트 자체가 없다(공식 스펙). id/email은
-        # 토큰교환 응답에 함께 온 id_token(JWT) 클레임 안에 실려있고, Apple JWKS로 서명을
-        # 검증해야 신뢰할 수 있다(디코드만 하고 검증 생략하면 위조 토큰을 그대로 신뢰하는
-        # 구멍이 된다). Google은 기존 그대로 bearer-token GET.
-        if provider == "apple":
-            id_token = token_data.get("id_token")
-            if not id_token:
-                return _err("OAUTH_NO_TOKEN", "No id_token in response", 400)
-            try:
-                userinfo = await _verify_apple_id_token(client, id_token, expected_audience=_client_id(provider))
-            except JWTError:
-                return _err("OAUTH_USERINFO_FAILED", "Failed to verify Apple id_token", 400)
-        else:
-            userinfo_resp = await client.get(
-                cfg["userinfo_url"],
-                headers={"Authorization": f"Bearer {access_token}"},
-            )
-            if userinfo_resp.status_code != 200:
-                return _err("OAUTH_USERINFO_FAILED", "Failed to fetch user info", 400)
-            userinfo = userinfo_resp.json()
-
-    oauth_id = str(userinfo.get(cfg["id_field"], ""))
-    email = (userinfo.get(cfg["email_field"]) or "").lower().strip()
+        try:
+            oauth_id, email = await _exchange_oauth_code_for_userinfo(client, provider, cfg, body.code)
+        except OAuthExchangeError as exc:
+            return _err(exc.code, exc.message, 400)
 
     if not oauth_id or not email:
         return _err("OAUTH_MISSING_INFO", "Missing id or email from provider", 400)
@@ -1255,6 +1278,144 @@ async def oauth_callback(
         "token_type": "bearer",
         "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
     })
+
+
+# ─── OAuth Account Linking (story #3122) ──────────────────────────────────────
+# #3118(Sign in with Apple) 그라운딩: Apple private relay 이메일이면 자동 이메일 병합이
+# 원천 불가해(oauth_callback 위 주석 참고) 항상 신규 계정이 생긴다 — PO 확定 정책은
+# "자동 병합에 안 기댄다, 병합은 사용자 주도 수동 연결로"였다. 이 3개 엔드포인트가 그
+# link rail: authorize(로그인 rail과 별개 — 이미 로그인된 유저 전용)·callback(신규 JWT를
+# 안 민팅한다 — 기존 세션에 provider_id만 붙인다)·unlink(최소 1개 로그인 수단 보장).
+
+@router.get("/oauth/{provider}/link/authorize")
+async def oauth_link_authorize(
+    provider: str,
+    auth: AuthContext = Depends(get_current_user),
+) -> JSONResponse:
+    if provider not in _OAUTH_CONFIGS:
+        return _err("INVALID_PROVIDER", f"Unsupported provider: {provider}", 400)
+    cfg = _OAUTH_CONFIGS[provider]
+    # redirect_uri는 로그인 rail과 완전히 동일한 물리 경로(_redirect_uri) — Google/Apple
+    # 콘솔에 등록된 콜백 도메인을 이 스토리 때문에 새로 추가할 필요가 없다. link 여부는
+    # state의 link_user_id 클레임과 FE의 별도 oauth_link_{provider} 쿠키(BFF route)로만
+    # 갈린다 — provider 쪽에서 보면 로그인 요청과 구분되지 않는다(의도된 설계).
+    state = create_oauth_state_token(provider, link_user_id=auth.user_id)
+    params = {
+        "client_id": _client_id(provider),
+        "redirect_uri": _redirect_uri(provider),
+        "response_type": "code",
+        "scope": cfg["scope"],
+        "state": state,
+    }
+    if provider == "google":
+        params["access_type"] = "offline"
+        params["prompt"] = "select_account"
+    if provider == "apple":
+        params["response_mode"] = "form_post"
+    url = f"{cfg['authorize_url']}?{urlencode(params)}"
+    return _ok({"url": url, "state": state})
+
+
+class OAuthLinkCallbackRequest(BaseModel):
+    provider: str
+    code: str
+    state: str
+
+
+@router.post("/oauth/{provider}/link/callback")
+async def oauth_link_callback(
+    provider: str,
+    body: OAuthLinkCallbackRequest,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> JSONResponse:
+    if provider not in _OAUTH_CONFIGS or provider != body.provider:
+        return _err("INVALID_PROVIDER", f"Unsupported provider: {provider}", 400)
+    cfg = _OAUTH_CONFIGS[provider]
+
+    try:
+        state_payload = decode_oauth_state_token(body.state, provider)
+    except JWTError:
+        return _err("INVALID_STATE", "OAuth state is invalid or expired", 400)
+
+    # 방어: state 발급 시점 유저 ≠ 콜백 시점 유저(10분 창 안에 로그아웃/계정전환) — 엉뚱한
+    # 계정에 연결되는 걸 막는다. authorize 자체가 auth 필수라 link_user_id는 항상 있다.
+    if state_payload.get("link_user_id") != auth.user_id:
+        return _err("LINK_SESSION_MISMATCH", "Your session changed during linking — please try again", 409)
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        try:
+            oauth_id, _email = await _exchange_oauth_code_for_userinfo(client, provider, cfg, body.code)
+        except OAuthExchangeError as exc:
+            return _err(exc.code, exc.message, 400)
+
+    if not oauth_id:
+        return _err("OAUTH_MISSING_INFO", "Missing id from provider", 400)
+
+    id_col = getattr(User, f"{provider}_id")
+    existing = (await session.execute(
+        select(User).where(id_col == oauth_id, User.is_active.is_(True))
+    )).scalar_one_or_none()
+
+    current_user_id = uuid.UUID(auth.user_id)
+    if existing and existing.id != current_user_id:
+        # AC2 — 이미 다른 계정에 묶인 provider_id. 병합이 아니라 명시 거부(계정 탈취 방지).
+        await _write_audit(
+            session, "oauth_link_rejected_conflict", user_id=current_user_id,
+            detail=f"provider={provider} already_linked_to={existing.id}",
+            ip_address=request.client.host if request.client else None,
+        )
+        await session.commit()
+        return _err("PROVIDER_ALREADY_LINKED", f"This {provider} account is already linked to a different account", 409)
+
+    if existing and existing.id == current_user_id:
+        return _ok({"provider": provider, "linked": True})  # 멱등 — 이미 본인 계정에 연결됨
+
+    await session.execute(
+        update(User).where(User.id == current_user_id).values(**{f"{provider}_id": oauth_id})
+    )
+    await _write_audit(
+        session, "oauth_link", user_id=current_user_id, detail=f"provider={provider}",
+        ip_address=request.client.host if request.client else None,
+    )
+    await session.commit()
+    return _ok({"provider": provider, "linked": True})
+
+
+@router.post("/oauth/{provider}/unlink")
+async def oauth_unlink(
+    provider: str,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> JSONResponse:
+    if provider not in _OAUTH_CONFIGS:
+        return _err("INVALID_PROVIDER", f"Unsupported provider: {provider}", 400)
+
+    user = await _get_user_by_id(session, uuid.UUID(auth.user_id))
+    if user is None:
+        return _err("USER_NOT_FOUND", "User not found", 404)
+
+    id_col_name = f"{provider}_id"
+    if getattr(user, id_col_name) is None:
+        return _err("PROVIDER_NOT_LINKED", f"No {provider} account linked", 400)
+
+    # AC3 — 로그인 수단이 이거 하나뿐이면 해제 거부(계정 잠금 방지). 비밀번호 + 등록된
+    # provider 전부를 센다(구글/애플뿐 아니라 향후 provider 추가돼도 자동 정합).
+    login_method_count = (1 if user.hashed_password else 0) + sum(
+        1 for p in _OAUTH_CONFIGS if getattr(user, f"{p}_id") is not None
+    )
+    if login_method_count <= 1:
+        return _err("LAST_LOGIN_METHOD", "Cannot unlink your only sign-in method", 400)
+
+    await session.execute(update(User).where(User.id == user.id).values(**{id_col_name: None}))
+    await _write_audit(
+        session, "oauth_unlink", user_id=user.id, detail=f"provider={provider}",
+        ip_address=request.client.host if request.client else None,
+    )
+    await session.commit()
+    return _ok({"provider": provider, "linked": False})
 
 
 # ─── Password Reset ───────────────────────────────────────────────────────────

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.routers.auth import _OAUTH_CONFIGS
 from app.models.member import Member
 from app.models.project import OrgMember
 from app.models.team import TeamMember
@@ -21,6 +22,12 @@ from app.schemas.human_api_key import (
 from app.schemas.me import MeResponse, UpdateMe
 
 router = APIRouter(prefix="/api/v2/me", tags=["me", "Organization"])
+
+
+def _linked_providers(user: User) -> list[str]:
+    """story #3122 — user에 붙은 provider_id 컬럼들을 _OAUTH_CONFIGS 등록 순서대로 나열.
+    새 provider가 auth.py에 등록되면 여기 손 안 대도 자동으로 잡힌다(단일 SSOT)."""
+    return [p for p in _OAUTH_CONFIGS if getattr(user, f"{p}_id", None) is not None]
 
 
 async def _resolve_current_human_member(
@@ -194,6 +201,7 @@ async def get_me(
                     role=org_member.role,
                     is_active=True,
                     has_password=bool(user.hashed_password) if user else None,
+                    linked_providers=_linked_providers(user) if user else [],
                 )
 
     if member is None:
@@ -208,6 +216,7 @@ async def get_me(
         user = user_result.scalar_one_or_none()
         if user:
             data.has_password = bool(user.hashed_password)
+            data.linked_providers = _linked_providers(user)
             data.email = user.email  # E-ONBOARDING S2: User.email 노출
 
     # S-MBR-03: org owner/admin → effective role 상속. /me role이 JWT role과 일치하도록.
@@ -382,6 +391,7 @@ async def update_me(
                     role=org_member.role,
                     is_active=True,
                     has_password=bool(user.hashed_password) if user else None,
+                    linked_providers=_linked_providers(user) if user else [],
                 )
 
     if member is None:

--- a/backend/app/schemas/me.py
+++ b/backend/app/schemas/me.py
@@ -20,6 +20,11 @@ class MeResponse(BaseModel):
     is_active: bool
     project_name: str | None = None
     has_password: bool | None = None
+    # story #3122(계정 연결) — 설정 화면이 "어떤 provider가 이미 연결돼 있는지" 그리는 데 씀.
+    # linked_providers=[]가 has_password=False와 같이 오면(둘 다 로그인 수단 0) 그 자체가
+    # 이상 상태(가입 rail 어딘가 결함)라 unlink 가드(auth.py LAST_LOGIN_METHOD)가 막는다 —
+    # 이 응답 필드는 순수 표시용, unlink 허용 판정은 서버가 매번 다시 계산한다(신뢰 안 함).
+    linked_providers: list[str] = []
 
 
 class UpdateMe(BaseModel):

--- a/backend/tests/test_3122_oauth_account_link.py
+++ b/backend/tests/test_3122_oauth_account_link.py
@@ -145,7 +145,7 @@ def _mock_session_returning(scalar_value) -> AsyncMock:
 
 async def _link_callback_client(app, session: AsyncMock, ctx: MagicMock):
     from app.dependencies.auth import get_current_user
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     async def _override_db():
         yield session
@@ -153,7 +153,9 @@ async def _link_callback_client(app, session: AsyncMock, ctx: MagicMock):
     async def _override_auth():
         return ctx
 
-    app.dependency_overrides[get_db] = _override_db
+    # story #2451(§6 Phase3) 가드 — get_db만 오버라이드하고 get_read_db를 놓치면
+    # read-replica 경유 라우트가 실 DB를 타 이 테스트의 mock 격리가 조용히 깨진다.
+    override_db_and_read(app, _override_db)
     app.dependency_overrides[get_current_user] = _override_auth
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 

--- a/backend/tests/test_3122_oauth_account_link.py
+++ b/backend/tests/test_3122_oauth_account_link.py
@@ -1,0 +1,418 @@
+"""story #3122(계정·후속) — 수동 «계정 연결(link)».
+
+#3118(Sign in with Apple) 그라운딩: Apple private relay 이메일이면 자동 이메일 병합이
+원천 불가해 항상 신규 계정이 생긴다. PO 확定 정책: 자동 병합에 안 기댄다 — 병합은
+사용자 주도 수동 연결로. 이 파일은 그 link rail 3개 엔드포인트를 검증한다.
+
+- oauth_link_authorize: 인증 필수, state에 link_user_id(현재 로그인 유저) 클레임을 싣는다.
+- oauth_link_callback: 로그인 mint 없음(AC4) — state의 link_user_id가 콜백 시점 유저와
+  일치해야 하고(계정전환 방어), 다른 유저에 이미 묶인 provider_id면 명시 거부(AC2, 병합
+  아님 — 계정 탈취 방지), 자기 자신에 이미 연결돼 있으면 멱등 200.
+- oauth_unlink: 로그인 수단이 이거 하나뿐이면 거부(AC3).
+
+httpx 프로토콜 단계(_exchange_oauth_code_for_userinfo)는 test_auth_security.py가 이미
+Apple JWKS 검증 등 크립토 축을 실키페어로 검증했다 — 이 파일은 그 함수 자체를 monkeypatch로
+대체하고, 이 스토리가 신설한 "state 대조·충돌 거부·최소수단 가드·감사기록" 로직만 본다."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.security import JWTError, create_oauth_state_token, decode_oauth_state_token
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── security.py: state token link_user_id 왕복 ───────────────────────────────
+
+def test_oauth_state_token_carries_link_user_id():
+    uid = str(uuid.uuid4())
+    token = create_oauth_state_token("apple", link_user_id=uid)
+    payload = decode_oauth_state_token(token, "apple")
+    assert payload["link_user_id"] == uid
+    assert payload["provider"] == "apple"
+
+
+def test_oauth_state_token_without_link_user_id_has_no_claim():
+    """로그인 rail(oauth_authorize)이 여전히 link_user_id 없이 부르는 기존 경로 — 무회귀."""
+    token = create_oauth_state_token("google")
+    payload = decode_oauth_state_token(token, "google")
+    assert "link_user_id" not in payload
+
+
+def test_oauth_state_token_expired_or_forged_raises():
+    with pytest.raises(JWTError):
+        decode_oauth_state_token("not-a-real-jwt", "google")
+
+
+# ─── me.py: _linked_providers 순수 함수 ────────────────────────────────────────
+
+def test_linked_providers_lists_only_set_columns():
+    from app.routers.me import _linked_providers
+
+    user = MagicMock()
+    user.google_id = "g-123"
+    user.apple_id = None
+    assert _linked_providers(user) == ["google"]
+
+    user.apple_id = "a-456"
+    assert _linked_providers(user) == ["google", "apple"]
+
+    user.google_id = None
+    user.apple_id = None
+    assert _linked_providers(user) == []
+
+
+# ─── oauth_link_authorize ──────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_oauth_link_authorize_requires_auth():
+    """인증 없이 부르면 401 — 로그인 rail(oauth_authorize)과 달리 이 엔드포인트는
+    "이미 로그인된 유저"가 전제다."""
+    from app.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/v2/auth/oauth/google/link/authorize")
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_oauth_link_authorize_state_binds_current_user(monkeypatch):
+    from app.core.config import settings
+    from app.dependencies.auth import get_current_user
+    from app.main import app
+
+    monkeypatch.setattr(settings, "jwt_secret", "test-jwt-secret", raising=False)
+    monkeypatch.setattr(settings, "google_client_id", "test-google-client-id", raising=False)
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+
+    async def _override_auth():
+        return ctx
+
+    app.dependency_overrides[get_current_user] = _override_auth
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/v2/auth/oauth/google/link/authorize")
+        assert resp.status_code == 200
+        body = resp.json()["data"]
+        assert "test-google-client-id" in body["url"]
+        payload = decode_oauth_state_token(body["state"], "google")
+        assert payload["link_user_id"] == ctx.user_id
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_oauth_link_authorize_invalid_provider_rejected(monkeypatch):
+    from app.dependencies.auth import get_current_user
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+
+    async def _override_auth():
+        return ctx
+
+    app.dependency_overrides[get_current_user] = _override_auth
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/v2/auth/oauth/github/link/authorize")
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "INVALID_PROVIDER"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── oauth_link_callback ────────────────────────────────────────────────────────
+
+def _mock_session_returning(scalar_value) -> AsyncMock:
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar_value
+    session.execute = AsyncMock(return_value=result)
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    return session
+
+
+async def _link_callback_client(app, session: AsyncMock, ctx: MagicMock):
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    async def _override_db():
+        yield session
+
+    async def _override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_current_user] = _override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.anyio
+async def test_oauth_link_callback_rejects_invalid_state():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    session = _mock_session_returning(None)
+
+    client = await _link_callback_client(app, session, ctx)
+    try:
+        async with client as c:
+            resp = await c.post(
+                "/api/v2/auth/oauth/google/link/callback",
+                json={"provider": "google", "code": "irrelevant", "state": "garbage"},
+            )
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "INVALID_STATE"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_oauth_link_callback_rejects_session_mismatch(monkeypatch):
+    """state 발급 시점 유저 ≠ 콜백 시점 유저 — 계정 전환/탈취 방어(AC 근접 §4)."""
+    from app.core.config import settings
+    from app.main import app
+
+    monkeypatch.setattr(settings, "jwt_secret", "test-jwt-secret", raising=False)
+
+    issuing_user_id = str(uuid.uuid4())
+    calling_user_id = str(uuid.uuid4())
+    state = create_oauth_state_token("google", link_user_id=issuing_user_id)
+
+    ctx = MagicMock()
+    ctx.user_id = calling_user_id
+    session = _mock_session_returning(None)
+
+    client = await _link_callback_client(app, session, ctx)
+    try:
+        async with client as c:
+            resp = await c.post(
+                "/api/v2/auth/oauth/google/link/callback",
+                json={"provider": "google", "code": "code-1", "state": state},
+            )
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "LINK_SESSION_MISMATCH"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_oauth_link_callback_success_new_link(monkeypatch):
+    from app.core.config import settings
+    import app.routers.auth as auth_router
+    from app.main import app
+
+    monkeypatch.setattr(settings, "jwt_secret", "test-jwt-secret", raising=False)
+    monkeypatch.setattr(
+        auth_router, "_exchange_oauth_code_for_userinfo",
+        AsyncMock(return_value=("google-oauth-id-1", "user@example.com")),
+    )
+
+    uid = str(uuid.uuid4())
+    state = create_oauth_state_token("google", link_user_id=uid)
+
+    ctx = MagicMock()
+    ctx.user_id = uid
+    session = _mock_session_returning(None)  # 기존 매칭 유저 없음 → 신규 연결
+
+    client = await _link_callback_client(app, session, ctx)
+    try:
+        async with client as c:
+            resp = await c.post(
+                "/api/v2/auth/oauth/google/link/callback",
+                json={"provider": "google", "code": "code-1", "state": state},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {"provider": "google", "linked": True}
+        session.commit.assert_awaited()
+        # select(existing) + update(link) — 정확히 2회.
+        assert session.execute.await_count == 2
+        # audit log가 성공 이벤트로 기록됐는지(2번째 add 호출이 감사행).
+        assert any(
+            getattr(call.args[0], "event_type", None) == "oauth_link"
+            for call in session.add.call_args_list
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_oauth_link_callback_rejects_conflict_different_user(monkeypatch):
+    """AC2 — 이미 다른 계정에 묶인 provider_id는 병합이 아니라 명시 거부(계정 탈취 방지)."""
+    from app.core.config import settings
+    import app.routers.auth as auth_router
+    from app.main import app
+
+    monkeypatch.setattr(settings, "jwt_secret", "test-jwt-secret", raising=False)
+    monkeypatch.setattr(
+        auth_router, "_exchange_oauth_code_for_userinfo",
+        AsyncMock(return_value=("google-oauth-id-1", "other@example.com")),
+    )
+
+    uid = str(uuid.uuid4())
+    other_user = MagicMock()
+    other_user.id = uuid.uuid4()  # ≠ uid — 다른 계정에 이미 연결됨
+
+    state = create_oauth_state_token("google", link_user_id=uid)
+    ctx = MagicMock()
+    ctx.user_id = uid
+    session = _mock_session_returning(other_user)
+
+    client = await _link_callback_client(app, session, ctx)
+    try:
+        async with client as c:
+            resp = await c.post(
+                "/api/v2/auth/oauth/google/link/callback",
+                json={"provider": "google", "code": "code-1", "state": state},
+            )
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "PROVIDER_ALREADY_LINKED"
+        # UPDATE(User.google_id 배선)가 절대 실행되지 않아야 한다 — select 1회뿐.
+        assert session.execute.await_count == 1
+        assert any(
+            getattr(call.args[0], "event_type", None) == "oauth_link_rejected_conflict"
+            for call in session.add.call_args_list
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_oauth_link_callback_idempotent_when_already_self_linked(monkeypatch):
+    from app.core.config import settings
+    import app.routers.auth as auth_router
+    from app.main import app
+
+    monkeypatch.setattr(settings, "jwt_secret", "test-jwt-secret", raising=False)
+    monkeypatch.setattr(
+        auth_router, "_exchange_oauth_code_for_userinfo",
+        AsyncMock(return_value=("google-oauth-id-1", "user@example.com")),
+    )
+
+    uid = str(uuid.uuid4())
+    self_user = MagicMock()
+    self_user.id = uuid.UUID(uid)
+
+    state = create_oauth_state_token("google", link_user_id=uid)
+    ctx = MagicMock()
+    ctx.user_id = uid
+    session = _mock_session_returning(self_user)
+
+    client = await _link_callback_client(app, session, ctx)
+    try:
+        async with client as c:
+            resp = await c.post(
+                "/api/v2/auth/oauth/google/link/callback",
+                json={"provider": "google", "code": "code-1", "state": state},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {"provider": "google", "linked": True}
+        # 이미 본인 계정에 연결돼있으니 쓰기 자체가 없다 — select 1회뿐, commit 없음.
+        assert session.execute.await_count == 1
+        session.commit.assert_not_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── oauth_unlink ───────────────────────────────────────────────────────────────
+
+def _user_with(*, hashed_password: str = "", google_id: str | None = None, apple_id: str | None = None) -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.hashed_password = hashed_password
+    user.google_id = google_id
+    user.apple_id = apple_id
+    return user
+
+
+@pytest.mark.anyio
+async def test_oauth_unlink_rejects_last_login_method():
+    from app.main import app
+
+    user = _user_with(hashed_password="", google_id=None, apple_id="apple-id-1")  # 로그인 수단 1개뿐
+    ctx = MagicMock()
+    ctx.user_id = str(user.id)
+    session = _mock_session_returning(user)
+
+    client = await _link_callback_client(app, session, ctx)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/oauth/apple/unlink")
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "LAST_LOGIN_METHOD"
+        session.commit.assert_not_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_oauth_unlink_succeeds_with_password_remaining():
+    from app.main import app
+
+    user = _user_with(hashed_password="hash", google_id=None, apple_id="apple-id-1")
+    ctx = MagicMock()
+    ctx.user_id = str(user.id)
+    session = _mock_session_returning(user)
+
+    client = await _link_callback_client(app, session, ctx)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/oauth/apple/unlink")
+        assert resp.status_code == 200
+        assert resp.json()["data"] == {"provider": "apple", "linked": False}
+        session.commit.assert_awaited()
+        assert any(
+            getattr(call.args[0], "event_type", None) == "oauth_unlink"
+            for call in session.add.call_args_list
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_oauth_unlink_succeeds_with_other_provider_remaining():
+    from app.main import app
+
+    user = _user_with(hashed_password="", google_id="g-1", apple_id="apple-id-1")
+    ctx = MagicMock()
+    ctx.user_id = str(user.id)
+    session = _mock_session_returning(user)
+
+    client = await _link_callback_client(app, session, ctx)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/oauth/apple/unlink")
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_oauth_unlink_rejects_not_linked():
+    from app.main import app
+
+    user = _user_with(hashed_password="hash", google_id=None, apple_id=None)
+    ctx = MagicMock()
+    ctx.user_id = str(user.id)
+    session = _mock_session_returning(user)
+
+    client = await _link_callback_client(app, session, ctx)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/oauth/apple/unlink")
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "PROVIDER_NOT_LINKED"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## 배경
#3118(Sign in with Apple) 그라운딩: Apple private relay 이메일이면 「구글=실이메일 가입·Apple=relay 로그인」 조합에서 이메일 매칭 병합이 원천 불가해 항상 신규 계정이 생긴다. PO 확定 정책: 자동 병합에 안 기댄다 — 병합은 사용자 주도 수동 연결로.

## 변경
**BE — link 전용 rail(로그인 mint 아님, AC4)**
- `security.py`: state token에 `link_user_id` 옵션(self-signed, 위조 불가) — 왕복 중 계정전환 방어에 씀.
- `auth.py`: `_exchange_oauth_code_for_userinfo` 공유 헬퍼로 code→token→userinfo(Apple JWKS 검증 포함)를 로그인 콜백과 계정연결 콜백이 재사용.
  - `GET /oauth/{provider}/link/authorize`(인증 필수) — redirect_uri는 로그인 rail과 동일 물리경로(콘솔 재등록 불요).
  - `POST /oauth/{provider}/link/callback`(인증 필수, 신규 JWT 안 민팅) — state의 link_user_id≠콜백 유저면 409, 다른 계정에 이미 묶인 provider_id면 **병합이 아니라 409 명시 거부**(AC2), 본인 계정에 이미 연결돼있으면 멱등 200. 성공/거부 둘 다 감사기록.
  - `POST /oauth/{provider}/unlink` — 로그인 수단이 1개뿐이면 400 LAST_LOGIN_METHOD(AC3).
- `me.py`/`schemas/me.py`: `MeResponse.linked_providers` 신설.

**FE — 설정 화면 표면(AC1)**
- `lib/auth/oauth-cookies.ts`: SameSite 분기(Apple form_post cross-site POST 함정)를 로그인/link rail이 공유.
- `auth/link/route.ts`: sp_at 필수, BE link/authorize를 Bearer로 호출, `oauth_link_{provider}` 쿠키로 콜백 분기 신호.
- `api/auth/callback/[provider]/route.ts`: link 모드면 로그인 분기를 완전히 건너뛰고 link/callback으로 — 세션 쿠키 재발급 없음.
- `components/settings/linked-accounts-section.tsx`: Connect/Disconnect UI, 최소 1수단 가드(클라 disabled+서버 재검증 이중), 콜백 후 문구(linked/link_error 쿼리).

## 검증
- BE 신규 `test_3122_oauth_account_link.py` 16건 통과(state round-trip·인증가드·state대조/충돌거부/멱등·unlink 최소수단가드). 기존 auth_security/env-drift/MeResponse 소비 테스트 8개 파일 무회귀.
- FE 신규 `linked-accounts-section.test.tsx` 8건 통과. 기존 callback/login/native-shell-bridge 25건 무회귀. tsc/eslint 클린.
- `pnpm build` exit 0.
- 라이브 실픽셀은 authenticated 라우트라 로컬 mock 인증 불가 — dev 배포 후 유나 design/카디르 QA 게이트에서 실측 예정(관례).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011js9VYShN84eGzG3nSPYBn