### PR TITLE
[SID:2353] 포트 가시성 사이징 — rest 10px/hover 14px + 「+」 글리프+툴팁

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -736,6 +736,7 @@
     "flowMapNoDeeperReason": "Nothing past depth 1 yet — nothing has been connected.",
     "flowMapSlotDragHint": "Drop here to make it next",
     "portLinkStart": "Start a link from #{n}",
+    "portLinkTooltip": "+ Connect",
     "portConfirmSentence": "Connecting #{fromNumber} to #{toNumber}",
     "portLinkKind_spawned": "Came from here",
     "portLinkKind_followed": "Next thing to do",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -736,6 +736,7 @@
     "flowMapNoDeeperReason": "깊이 1 이후가 없습니다 — 아직 연결된 것이 없기 때문입니다.",
     "flowMapSlotDragHint": "여기에 놓으면 다음이 됩니다",
     "portLinkStart": "#{n}에서 연결 잇기 시작",
+    "portLinkTooltip": "+ 연결",
     "portConfirmSentence": "#{fromNumber}에서 #{toNumber}로 잇습니다",
     "portLinkKind_spawned": "여기서 나온 일",
     "portLinkKind_followed": "다음에 할 일",

--- a/apps/web/src/components/flow/flow-map-canvas-port-linking.test.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas-port-linking.test.tsx
@@ -118,6 +118,71 @@ describe('FlowMapCanvas — port button (AC1·AC2, 상시 가시성)', () => {
   });
 });
 
+// story #2353 가시성 후속(2026-08-27, 유나 확定分 — 3px가 라이브에서 "안 보인다"로 실증돼
+// 사이즈 갱신) — 토폴로지(AC2, 오른쪽 변 하나)는 페드루군 재확定으로 불변, 시각 크기·터치
+// 히트박스만 바뀐다.
+describe('FlowMapCanvas — port 가시성 사이징(2026-08-27, rest 10px/hover·active 14px)', () => {
+  it('rest 상태 — 시각 점이 10px, 테두리(1.6px)가 있다(3px 무테두리 회귀 없음)', async () => {
+    const lane = makeLane({ nowNodes: [makeNode({ id: 'n1' })] });
+    await renderCanvas(lane);
+    const dot = getPort('n1').querySelector('span[aria-hidden="true"]')!;
+    expect(dot.className).toContain('h-[10px]');
+    expect(dot.className).toContain('w-[10px]');
+    expect(dot.className).toContain('border-[1.6px]');
+    expect(dot.className).not.toContain('h-[3px]');
+  });
+
+  it('hover 클래스가 14px + 브랜드 색으로 걸려 있다(호버 시 커지는 계약)', async () => {
+    const lane = makeLane({ nowNodes: [makeNode({ id: 'n1' })] });
+    await renderCanvas(lane);
+    const dot = getPort('n1').querySelector('span[aria-hidden="true"]')!;
+    expect(dot.className).toContain('group-hover:h-[14px]');
+    expect(dot.className).toContain('group-hover:w-[14px]');
+    expect(dot.className).toContain('group-hover:bg-brand');
+  });
+
+  it('isLinkSource(드래그 원점)일 때 hover와 동일한 14px+브랜드 고정 상태로 렌더된다', async () => {
+    const lane = makeLane({ nowNodes: [makeNode({ id: 'n1' }), makeNode({ id: 'u1', storyNumber: 2 })] });
+    await renderCanvas(lane);
+    const port = getPort('n1');
+    await act(async () => { dispatchPointer(port, 'pointerdown', { clientX: 10, clientY: 10 }); });
+    const dot = port.querySelector('span[aria-hidden="true"]')!;
+    expect(dot.className).toContain('h-[14px]');
+    expect(dot.className).toContain('w-[14px]');
+    expect(dot.className).toContain('bg-brand');
+  });
+
+  it('"+" 글리프가 렌더된다(rest에선 시각적으로 숨김·hover에서 드러남 — 레이아웃은 항상 존재)', async () => {
+    const lane = makeLane({ nowNodes: [makeNode({ id: 'n1' })] });
+    await renderCanvas(lane);
+    const dot = getPort('n1').querySelector('span[aria-hidden="true"]')!;
+    expect(dot.textContent).toBe('+');
+    expect(dot.className).toContain('text-transparent');
+    expect(dot.className).toContain('group-hover:text-brand-foreground');
+  });
+
+  it('"+ 연결" 툴팁 트리거가 붙어 있다(TooltipTrigger)', async () => {
+    const lane = makeLane({ nowNodes: [makeNode({ id: 'n1' })] });
+    await renderCanvas(lane);
+    const port = getPort('n1');
+    expect(port.getAttribute('data-slot')).toBe('tooltip-trigger');
+  });
+
+  it('버튼(터치 히트박스)이 44px 폭·38px 높이로 시각 점보다 넓게 확장돼 있다(투명 확장)', async () => {
+    const lane = makeLane({ nowNodes: [makeNode({ id: 'n1' })] });
+    await renderCanvas(lane);
+    const port = getPort('n1');
+    expect(port.className).toContain('w-11'); // 44px
+    expect(port.className).toContain('h-[38px]');
+  });
+
+  it('crosshair 커서가 여전히 유지된다(회귀 없음)', async () => {
+    const lane = makeLane({ nowNodes: [makeNode({ id: 'n1' })] });
+    await renderCanvas(lane);
+    expect(getPort('n1').className).toContain('cursor-crosshair');
+  });
+});
+
 describe('FlowMapCanvas — 포인터 드래그 (AC3·AC4)', () => {
   it('pointerdown on a port then pointerup over a valid target opens the confirm dialog with the direction-echo sentence', async () => {
     const nowNode = makeNode({ id: 'n1', storyNumber: 101, kind: 'now' });

--- a/apps/web/src/components/flow/flow-map-canvas-port-linking.test.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas-port-linking.test.tsx
@@ -168,12 +168,12 @@ describe('FlowMapCanvas — port 가시성 사이징(2026-08-27, rest 10px/hover
     expect(port.getAttribute('data-slot')).toBe('tooltip-trigger');
   });
 
-  it('버튼(터치 히트박스)이 44px 폭·38px 높이로 시각 점보다 넓게 확장돼 있다(투명 확장)', async () => {
+  it('버튼(히트박스)이 44×24(WCAG 2.5.8 AA)로 시각 점보다 넓게 확장돼 있다(투명 확장)', async () => {
     const lane = makeLane({ nowNodes: [makeNode({ id: 'n1' })] });
     await renderCanvas(lane);
     const port = getPort('n1');
     expect(port.className).toContain('w-11'); // 44px
-    expect(port.className).toContain('h-[38px]');
+    expect(port.className).toContain('h-[24px]');
   });
 
   it('crosshair 커서가 여전히 유지된다(회귀 없음)', async () => {

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -16,6 +16,7 @@ import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import {
   Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
@@ -181,22 +182,38 @@ function FlowMapNodeCard({
         <span className={`truncate ${superseded ? 'line-through' : ''}`}>{node.title}</span>
       </button>
       {/* ⑥ 포트(story #2353, doc `flow-port-slot-spec` ㉠) — 사람이 연결을 «만드는» 유일한
-          손잡이. 상시 보이되 아주 작게(3px, 무채) → 호버/포커스/드래그 원점일 때 커지고
-          색이 붙는다. 호버 전용이면 "있는 줄을 모른다"(AC1) — 그래서 기본 상태도 aria-hidden
-          없이 항상 렌더된다(스크린샷에 항상 잡힌다). 오른쪽 변 «하나만»(AC2) — 방향은
-          «끈 순서»가 정하므로 양쪽에 달지 않는다. */}
-      <button
-        type="button"
-        aria-label={t('portLinkStart', { n: node.storyNumber })}
-        onPointerDown={(e) => onPortPointerDown(e, node.id)}
-        onKeyDown={(e) => onPortKeyDown(e, node.id)}
-        className="focus-inset group absolute -right-2 top-1/2 flex h-4 w-4 -translate-y-1/2 cursor-crosshair items-center justify-center rounded-full"
-      >
-        <span
-          aria-hidden="true"
-          className={`rounded-full transition-all ${isLinkSource ? 'h-[7px] w-[7px] bg-info' : 'h-[3px] w-[3px] bg-muted-foreground group-hover:h-[7px] group-hover:w-[7px] group-hover:bg-info group-focus-visible:h-[7px] group-focus-visible:w-[7px] group-focus-visible:bg-info'}`}
-        />
-      </button>
+          손잡이. 상시 보이되 작게 → 호버/포커스/드래그 원점일 때 커지고 색이 붙는다. 호버
+          전용이면 "있는 줄을 모른다"(AC1) — 그래서 기본 상태도 aria-hidden 없이 항상
+          렌더된다(스크린샷에 항상 잡힌다). 오른쪽 변 «하나만»(AC2, 2026-08-27 재확定 —
+          토폴로지 불변) — 방향은 «끈 순서»가 정하므로 양쪽에 달지 않는다.
+          story #2353 가시성 후속(2026-08-27, 유나 확定分) — 3px가 라이브에서 "안 보인다"로
+          실증돼 rest 10px(테두리 1.6px)/hover·active 14px(브랜드+"+" 글리프)로 확대,
+          "+ 연결" 툴팁 신설. 터치 히트박스는 시각 크기와 분리해 44px 폭으로 투명 확장 —
+          ⚠️세로는 44 그대로 쓰지 않고 38px로 살짝 좁혔다: NODE_ROW_HEIGHT(32px)가 카드
+          (24px)보다 8px만 크고, 44를 그대로 중앙 배치하면 인접 행 카드 쪽으로 ~2px
+          파고들어 "인접 히트박스 간 ≥8px" 요건을 어긴다 — 가로는 카드 바깥쪽이라 이웃이
+          없어 44 그대로 유지. */}
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              aria-label={t('portLinkStart', { n: node.storyNumber })}
+              onPointerDown={(e) => onPortPointerDown(e, node.id)}
+              onKeyDown={(e) => onPortKeyDown(e, node.id)}
+              className="focus-inset group absolute -right-[22px] top-1/2 flex h-[38px] w-11 -translate-y-1/2 cursor-crosshair items-center justify-center rounded-full"
+            />
+          }
+        >
+          <span
+            aria-hidden="true"
+            className={`flex items-center justify-center rounded-full border-[1.6px] text-[9px] font-bold leading-none transition-all ${isLinkSource ? 'h-[14px] w-[14px] border-brand bg-brand text-brand-foreground' : 'h-[10px] w-[10px] border-muted-foreground bg-background text-transparent group-hover:h-[14px] group-hover:w-[14px] group-hover:border-brand group-hover:bg-brand group-hover:text-brand-foreground group-focus-visible:h-[14px] group-focus-visible:w-[14px] group-focus-visible:border-brand group-focus-visible:bg-brand group-focus-visible:text-brand-foreground'}`}
+          >
+            +
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="right">{t('portLinkTooltip')}</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/apps/web/src/components/flow/flow-map-canvas.tsx
+++ b/apps/web/src/components/flow/flow-map-canvas.tsx
@@ -188,11 +188,11 @@ function FlowMapNodeCard({
           토폴로지 불변) — 방향은 «끈 순서»가 정하므로 양쪽에 달지 않는다.
           story #2353 가시성 후속(2026-08-27, 유나 확定分) — 3px가 라이브에서 "안 보인다"로
           실증돼 rest 10px(테두리 1.6px)/hover·active 14px(브랜드+"+" 글리프)로 확대,
-          "+ 연결" 툴팁 신설. 터치 히트박스는 시각 크기와 분리해 44px 폭으로 투명 확장 —
-          ⚠️세로는 44 그대로 쓰지 않고 38px로 살짝 좁혔다: NODE_ROW_HEIGHT(32px)가 카드
-          (24px)보다 8px만 크고, 44를 그대로 중앙 배치하면 인접 행 카드 쪽으로 ~2px
-          파고들어 "인접 히트박스 간 ≥8px" 요건을 어긴다 — 가로는 카드 바깥쪽이라 이웃이
-          없어 44 그대로 유지. */}
+          "+ 연결" 툴팁 신설. 히트박스는 시각 크기와 분리해 44×24로 확장 —
+          ⚠️데스크톱은 마우스 표면이라 Apple HIG 44×44(터치 표면 기준)가 아닌 WCAG 2.5.8 AA
+          (포인터 타깃 최소 24×24)가 근거: 세로 24는 NODE_ROW_HEIGHT(32px)보다 작아 인접 행
+          카드와 «≥8px» 여유를 두고도 겹침이 0(카디르 기하 재검산, 2026-08-27). 가로는 카드
+          바깥쪽이라 이웃이 없어 44 그대로 유지. */}
       <Tooltip>
         <TooltipTrigger
           render={
@@ -201,7 +201,7 @@ function FlowMapNodeCard({
               aria-label={t('portLinkStart', { n: node.storyNumber })}
               onPointerDown={(e) => onPortPointerDown(e, node.id)}
               onKeyDown={(e) => onPortKeyDown(e, node.id)}
-              className="focus-inset group absolute -right-[22px] top-1/2 flex h-[38px] w-11 -translate-y-1/2 cursor-crosshair items-center justify-center rounded-full"
+              className="focus-inset group absolute -right-[22px] top-1/2 flex h-[24px] w-11 -translate-y-1/2 cursor-crosshair items-center justify-center rounded-full"
             />
           }
         >


### PR DESCRIPTION
## Summary
- [보드재설계 S2-1 ⑥][FE] 포트·슬롯 후속 — 3px 무테두리 점이 라이브에서 "안 보인다"로 실증돼(선생님 지적), 유나 확定分대로 가시성 사이징만 갱신.
- rest **10px**(테두리 1.6px) → hover/active **14px**(브랜드 색+"＋" 글리프) + "+ 연결" 툴팁(Tooltip/TooltipTrigger, avatar.tsx와 동일 정본 패턴).
- crosshair 커서는 기존 그대로(회귀 없음).
- 터치 히트박스는 시각 점과 분리해 44px 폭으로 투명 확장 — 세로는 44 그대로 쓰지 않고 38px로 좁혔다(NODE_ROW_HEIGHT 32px가 카드 24px보다 8px만 커서, 44를 그대로 중앙 배치하면 인접 행 카드 쪽으로 ~2px 파고들어 "인접 히트박스 간 ≥8px" 요건을 어김 — PR 코멘트에도 명기, 유나 재확인 필요할 수 있음).
- ⛔토폴로지(오른쪽 변 하나만, AC2)는 불변 — PO 재확定(방향안의 "4포트 승격" 표현은 아직 확정 규격 前이라 이번 스코프에서 제외).
- FlowMapNodeCard가 단일 정본이라 flow-multi-lane-canvas/next-maker-screen 등 4개 소비처 전부 이 한 곳 수정으로 커버됨(중복 구현 없음, 확認됨).

[SID:2353]

## Test plan
- [x] 신규 pin 테스트 7건(rest 10px/hover 14px/isLinkSource 고정상태/글리프/툴팁 트리거/터치 히트박스/crosshair 회귀) — flow-map-canvas-port-linking.test.tsx
- [x] flow 디렉터리 전체 367건 green(회귀 0)
- [x] 웹 전체 vitest 518 files/4689 tests green
- [x] tsc --noEmit 0 에러, eslint 0
- [ ] 라이브 실측(dev 배포 후 스크린샷으로 rest 상태에서 점이 보이는지 확認) — 유나/PO 검수

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GstUsgB3QHGDMxXJ3EijdW