### PR TITLE
[SID:2227] glance 리다이렉트 회귀가드 신설 (board와 짝)

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -809,6 +809,30 @@ describe('proxy — legacy resource redirect generalized to non-docs resources (
     expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/board?story=abc');
   });
 
+  // story #2227(2026-08-27, 판정: 「board와 같은 표·같은 제네릭 코드경로」라는 아키텍처
+  // 주장을 board처럼 직접 테스트로 pin — glance는 board와 똑같이 MIGRATED_RESOURCES에
+  // 등록돼 있는데도 이 파일에 자신의 회귀가드가 하나도 없었다(board만 있었다). 리소스별
+  // 특수분기가 코드에 전혀 없으므로(순수 표 조회) 동작이 board와 같을 거라는 추론은
+  // 맞았지만, 「맞을 것」과 「pin된 테스트로 증명됨」은 다르다.
+  it('story #2227: bare /glance?story=X → 301 /{ws}/{proj}/glance?story=X(board와 동일 MIGRATED_RESOURCES 경로, 쿼리 보존)', async () => {
+    const token = await makeAccessToken({ orgId: 'org-1', projectId: 'proj-1' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/me')) {
+        return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+      }
+      if (url.includes('/api/v2/organizations/org-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
+      }
+      if (url.includes('/api/v2/projects/proj-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'proj-1', slug: 'sprintable' }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    const response = await middleware(makeRequest('/glance?story=abc', { sp_at: token }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/glance?story=abc');
+  });
+
   it('story #1999: 쿠키와 JWT project_id가 다르면 쿠키 우선(명시 switch-project 결과 존중)', async () => {
     const token = await makeAccessToken({ orgId: 'org-1', projectId: 'proj-old' });
     mockFetch.mockImplementation((url: string) => {
@@ -878,6 +902,16 @@ describe('proxy — 경로 리터럴 rename 301(story 8fc51517): [ws]/[proj]/boa
     expect(response.status).toBe(301);
     expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/flow');
     // 3번째 세그먼트만 교체하는 순수 문자열 치환이라 org/project fetch가 전혀 없어야 한다.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('story #2227: /{ws}/{proj}/glance → 301 /{ws}/{proj}/flow(glance도 RENAMED_RESOURCES 대상 — board와 짝인 회귀가드, 이 전엔 없었다)', async () => {
+    const token = await makeAccessToken({ orgId: 'org-1' });
+    const response = await middleware(makeRequest('/moonklabs/sprintable/glance', {
+      sp_at: token, sprintable_current_project_id: 'proj-1',
+    }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/flow');
     expect(mockFetch).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
[SID:2227]

## 배경
스토리 #2227 판정(페드루, 2026-08-27) — 전제(구 `/board` 단독 라우트)는 이미 붕괴돼 `/flow?view=list`로 통합됐으므로, 남은 실질은 "내림의 뒷정리 검증": story #2224 §5가 실측한 **449건**(채팅 본문 423 + docs 26)의 영속 텍스트가 `/board?`·`/glance`를 참조하는데, 이게 실제로 404인지 리다이렉트되는지 확인.

## 실측 결과 — 둘 다 이미 리다이렉트됨, 404 아님
- `/{ws}/{proj}/board?story=X&task_id=Y` → 307 → `/{ws}/{proj}/flow?...&view=list`(쿼리 보존) — 로컬 `pnpm dev`+curl로 라이브 확認(`next.config.ts` 규칙).
- bare `/board?story=X` / `/glance` → `proxy.ts`의 `redirectLegacyResourcePath`(MIGRATED_RESOURCES)가 org/project를 재조회해 `/{ws}/{proj}/{resource}`로 301 → `redirectRenamedResourcePath`(RENAMED_RESOURCES: `board:'flow'`, `glance:'flow'`)가 세그먼트만 교체해 `/{ws}/{proj}/flow`로 다시 301. 두 함수 모두 리소스별 특수분기 없는 순수 표 조회라 board와 glance가 동일하게 동작한다.

## 발견한 갭 — 코드 결함 아님, 테스트 커버리지 격차
`board`는 `proxy.test.ts`에 `#2373` 회귀가드까지 포함해 여러 pin 테스트가 있었지만, **`glance`는 두 표에 등록만 돼 있을 뿐 자신의 회귀가드가 하나도 없었다.** "제네릭 코드경로라 board와 같을 것"이라는 추론은 맞았지만, 직접 pin하지 않은 채로는 증명이 아니었다(`feedback_guard_must_declare_what_it_misses`/`feedback_pin_declarations_as_tests` 규율).

## 변경
- `apps/web/src/proxy.test.ts`에 board의 기존 두 테스트(bare 리다이렉트·rename 리다이렉트)와 짝을 이루는 glance 테스트 2건 추가.
- 프로덕션 코드 변경 없음 — 신설 테스트 2건 모두 **기존 코드 그대로 그린**(사전 결함 없음을 실증).

## 결론
449건의 `/board`·`/glance` 영속 참조는 이미 전부 리다이렉트로 커버돼 있다. 이 PR은 그 사실을 코드 결함 수정이 아니라 회귀가드 추가로 닫는다 — story #2227은 "원 목표(언제 내려도 되는가) 기준 종결(이미 내려짐·뒷정리 済)"로 상신 예정.

## 검증
- `pnpm exec vitest run src/proxy.test.ts` — 72/72 pass (신설 2건 포함)
- `eslint src/proxy.test.ts` — clean