### PR TITLE
[SID:2341] active 에픽 hero 선택에 updated_at tie-break 추가 (AC2)

### DIFF
--- a/apps/web/src/components/glance/load-glance-data.test.ts
+++ b/apps/web/src/components/glance/load-glance-data.test.ts
@@ -133,6 +133,41 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
     expect(data.heroStory?.id).toBe('s-real');
   });
 
+  it('story #2341 AC2: among multiple active epics that each have a focal_story, picks the most recently updated one(updated_at tie-break — "먼저 오는 하나"가 아니라 "가장 최근에 움직인 하나")', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/goals')) {
+        return jsonResponse([
+          {
+            id: 'e-stale', title: 'E-STALE(오래전 갱신)', status: 'active',
+            created_at: '2026-06-01T00:00:00Z', updated_at: '2026-06-01T00:00:00Z', participant_ids: [],
+            focal_story: {
+              id: 's-stale', title: '오래된 진행중 스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
+              proof_count: 0, auto_verify: null, gate: null,
+              trust: { self_reported: false, human_verified: false, human_verified_by: null, human_verified_at: null },
+            },
+          },
+          {
+            // 배열 순서상 뒤에 오지만(먼저 오는 하나가 아님) updated_at이 더 최근 — tie-break가
+            // 순서가 아니라 최신성으로 고르는지가 이 테스트의 핵심.
+            id: 'e-fresh', title: 'E-FRESH(방금 갱신)', status: 'active',
+            created_at: '2026-05-01T00:00:00Z', updated_at: '2026-08-27T00:00:00Z', participant_ids: [],
+            focal_story: {
+              id: 's-fresh', title: '방금 진행중 스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
+              proof_count: 0, auto_verify: null, gate: null,
+              trust: { self_reported: false, human_verified: false, human_verified_by: null, human_verified_at: null },
+            },
+          },
+        ]);
+      }
+      if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
+      if (url.startsWith('/api/team-members')) return jsonResponse([]);
+      if (url.startsWith('/api/glance/attention')) return jsonResponse({ items: [] });
+      return jsonResponse([]);
+    }));
+    const data = await loadGlanceData('proj-recency-tiebreak');
+    expect(data.heroStory?.id).toBe('s-fresh');
+  });
+
   it('falls back to the first active epic when none of the active epics have a focal_story(진짜 0건 — 정직한 빈 상태 유지)', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.startsWith('/api/goals')) {

--- a/apps/web/src/components/glance/load-glance-data.test.ts
+++ b/apps/web/src/components/glance/load-glance-data.test.ts
@@ -138,8 +138,14 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
       if (url.startsWith('/api/goals')) {
         return jsonResponse([
           {
-            id: 'e-stale', title: 'E-STALE(오래전 갱신)', status: 'active',
-            created_at: '2026-06-01T00:00:00Z', updated_at: '2026-06-01T00:00:00Z', participant_ids: [],
+            // ⛔카디르 QA(2026-08-27) — created_at을 e-fresh보다 이르게 둬야 confound 없는
+            // 표본이 된다: tie-break를 제거해도 배열순서(scopeRoadmapEpics의 created_at ASC
+            // 폴백) 자체가 e-fresh를 먼저 골라버리면, 이 테스트는 tie-break 로직이 아니라
+            // 우연히 같은 결과를 내는 폴백 정렬을 pin하는 것이 된다(제거해도 그린 — 가짜
+            // 회귀가드). e-stale이 배열상 «먼저»(created_at 이름) 오게 만들어, tie-break를
+            // 지우면 실제로 RED가 나는 것을 카디르가 직접 재현 확認.
+            id: 'e-stale', title: 'E-STALE(오래전 갱신, 배열순서상 먼저 옴)', status: 'active',
+            created_at: '2026-05-01T00:00:00Z', updated_at: '2026-06-01T00:00:00Z', participant_ids: [],
             focal_story: {
               id: 's-stale', title: '오래된 진행중 스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
               proof_count: 0, auto_verify: null, gate: null,
@@ -147,10 +153,12 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
             },
           },
           {
-            // 배열 순서상 뒤에 오지만(먼저 오는 하나가 아님) updated_at이 더 최근 — tie-break가
-            // 순서가 아니라 최신성으로 고르는지가 이 테스트의 핵심.
-            id: 'e-fresh', title: 'E-FRESH(방금 갱신)', status: 'active',
-            created_at: '2026-05-01T00:00:00Z', updated_at: '2026-08-27T00:00:00Z', participant_ids: [],
+            // created_at도 배열순서도 e-stale보다 «뒤»(늦음) — tie-break가 순서/생성일이
+            // 아니라 updated_at 최신성으로 고르는지가 이 테스트의 핵심. tie-break를 지우면
+            // (roadmap.find가 배열 첫 매치를 집는 옛 로직으로 돌아가면) e-stale이 먼저 뽑혀
+            // 이 단언이 깨진다(카디르 재현 확認).
+            id: 'e-fresh', title: 'E-FRESH(방금 갱신, 배열순서상 뒤에 옴)', status: 'active',
+            created_at: '2026-06-15T00:00:00Z', updated_at: '2026-08-27T00:00:00Z', participant_ids: [],
             focal_story: {
               id: 's-fresh', title: '방금 진행중 스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
               proof_count: 0, auto_verify: null, gate: null,

--- a/apps/web/src/components/glance/load-glance-data.ts
+++ b/apps/web/src/components/glance/load-glance-data.ts
@@ -120,15 +120,19 @@ export async function loadGlanceData(projectId: string): Promise<GlanceData> {
   // 스토리 실재)을 두고 E-CHAT-REALTIME(진행중 스토리 0건)이 "지금"으로 뽑혀 초점 스트립이
   // 항상 빈 채로 뜬 사례가 실측됨. focal_story가 실재하는 active 에픽을 우선한다 — 그런 에픽이
   // 하나도 없을 때만(=진짜 0건) 기존처럼 첫 active로 폴백(정직한 빈 상태).
-  // ⛔불완전한 처방: active 에픽 52개 중에서도 여전히 roadmap 배열 순서상 «먼저 오는 하나»를
-  // 고르는 것뿐 — "가장 최근에 움직인 에픽"으로 좁히려면 에픽의 updated_at이 필요한데
-  // `BeEpicListItem`엔 created_at만 있고 updated_at이 없다(BE 계약에 없음). 그 필드가
-  // 오면(#2341, BE 후속 — "상태 자가회수" 스토리 AC2) "focal_story 있음" 다음 tie-break로
-  // 최신순 정렬을 추가한다. #2341 AC1은 더 근본적으로 "active"를 파생값으로 바꾸는 방향도
-  // 검토 중 — 이 tie-break는 그 방향이 확정되기 전까지의 완화(PR#2680)에 그친다.
+  // story #2341 AC2 delta(2026-08-27) — "먼저 오는 하나"가 아니라 «가장 최근에 움직인 하나»로
+  // 좁힌다. 이전 주석은 "BeEpicListItem엔 updated_at이 없다(BE 계약에 없음)"고 적어 뒀으나
+  // 재그라운딩 결과 틀렸다 — `GoalResponse.updated_at`은 이미 존재했다(BE 신규 작업 0, FE
+  // 노출만 누락돼 있었다). focal_story 유무로 먼저 가르고, 같은 그룹 안에서 updated_at 내림차순
+  // tie-break. #2341 AC1의 근본 방향(㉡ "active"를 파생값化)은 아직 미결 — 이 tie-break는
+  // 그 방향이 확정되기 전까지의 완화(PR#2680 계열)에 그친다.
+  const byRecency = (a: RoadmapEpic, b: RoadmapEpic) =>
+    (rawById.get(b.id)?.updated_at ?? '').localeCompare(rawById.get(a.id)?.updated_at ?? '');
+  const activeWithFocal = roadmap.filter((e) => e.roadmapStatus === 'active' && rawById.get(e.id)?.focal_story);
+  const activeAny = roadmap.filter((e) => e.roadmapStatus === 'active');
   const activeEpic =
-    roadmap.find((e) => e.roadmapStatus === 'active' && rawById.get(e.id)?.focal_story) ??
-    roadmap.find((e) => e.roadmapStatus === 'active') ??
+    [...activeWithFocal].sort(byRecency)[0] ??
+    [...activeAny].sort(byRecency)[0] ??
     null;
   const focal = activeEpic ? (rawById.get(activeEpic.id)?.focal_story ?? null) : null;
   const heroStory: HeroStory | null = focal

--- a/apps/web/src/services/glance.test.ts
+++ b/apps/web/src/services/glance.test.ts
@@ -24,7 +24,8 @@ describe('deriveRoadmapStatus (epic.status → 3버킷, done/archived 통합)', 
 
 describe('scopeRoadmapEpics ("현재 궤적" window — 유나 서사 확定(b), active(들)를 anchor로 앞뒤 소수만)', () => {
   function epicAt(id: string, status: string, day: number): BeEpicListItem {
-    return { id, title: id, status, created_at: `2026-01-${String(day).padStart(2, '0')}T00:00:00Z` };
+    const ts = `2026-01-${String(day).padStart(2, '0')}T00:00:00Z`;
+    return { id, title: id, status, created_at: ts, updated_at: ts };
   }
 
   it('anchors on the single active epic and takes `behind` done epics before it, `ahead` upcoming after', () => {
@@ -87,7 +88,8 @@ describe('scopeRoadmapEpics ("현재 궤적" window — 유나 서사 확定(b),
 
 describe('scopeRoadmapEpics — 로드맵 조타 curated-first 소비(wedge #2·position 반영·#2056 회귀0)', () => {
   function epic(id: string, status: string, day: number, position?: number | null): BeEpicListItem {
-    return { id, title: id, status, created_at: `2026-01-${String(day).padStart(2, '0')}T00:00:00Z`, position };
+    const ts = `2026-01-${String(day).padStart(2, '0')}T00:00:00Z`;
+    return { id, title: id, status, created_at: ts, updated_at: ts, position };
   }
 
   it('position 전무(미조타) 시 created_at ASC 폴백 — 기존 렌더와 동일(#2056 회귀0)', () => {
@@ -110,9 +112,9 @@ describe('scopeRoadmapEpics — 로드맵 조타 curated-first 소비(wedge #2·
 
 describe('mergeRoadmap (epic 목록 순서 SSOT + 별도 진척 엔드포인트 병합)', () => {
   const epics: BeEpicListItem[] = [
-    { id: 'e1', title: 'E-VERIFY', status: 'done', created_at: '2026-06-01T00:00:00Z' },
-    { id: 'e2', title: 'E-CANVAS', status: 'active', created_at: '2026-06-15T00:00:00Z' },
-    { id: 'e3', title: 'E-GLANCE', status: 'draft', created_at: '2026-07-01T00:00:00Z' },
+    { id: 'e1', title: 'E-VERIFY', status: 'done', created_at: '2026-06-01T00:00:00Z', updated_at: '2026-06-01T00:00:00Z' },
+    { id: 'e2', title: 'E-CANVAS', status: 'active', created_at: '2026-06-15T00:00:00Z', updated_at: '2026-06-15T00:00:00Z' },
+    { id: 'e3', title: 'E-GLANCE', status: 'draft', created_at: '2026-07-01T00:00:00Z', updated_at: '2026-07-01T00:00:00Z' },
   ];
 
   it('preserves the epic list order and merges progress by epic_id', () => {

--- a/apps/web/src/services/glance.ts
+++ b/apps/web/src/services/glance.ts
@@ -53,6 +53,12 @@ export interface BeEpicListItem {
   title: string;
   status: string;
   created_at: string;
+  // story #2341 AC2 — `GoalResponse.updated_at`(backend/app/schemas/goal.py:96, `GoalWithGlanceResponse`가
+  // 상속하므로 `?include=glance` 응답에도 항상 실린다, git blame 6462ad1af4·2026-04-29부터 계약에
+  // 존재)를 tie-break 재료로 노출. load-glance-data.ts가 "active 에픽 52개 중 먼저 오는 하나"
+  // 문제를 이 필드로 좁힌다(#2341 AC1의 근본 방향(㉡ active를 파생값化)과는 별개 — 그게 오기
+  // 전까지의 완화).
+  updated_at: string;
   // E-GLANCE wedge #2(로드맵 조타): 큐레이션 순서(null=미조타). 아크는 이 순서를 소비만 한다
   // (드래그 없음). BE order_by=position 미지정/미보유 시 전부 null 취급 → 기존 created_at 정렬과
   // 동일(#2056 회귀0).


### PR DESCRIPTION
[SID:2341]

## 배경
스토리 #2341 "「active」라는 이름 하나가 코드 세 곳에서 서로 다른 축을 가리킨다" — ①Goal.status='active'(52/179 vs 실제 in-progress 3개) ②judgment_core "active" ③07-29 철회건, 3개 인스턴스를 각각 재그라운딩.

## 재그라운딩 결과
- **①은 부분 완화만 돼 있었다.** `scopeRoadmapEpics`(화면 윈도잉, ㉢)와 `load-glance-data.ts`의 hero-pick(focal_story 있는 active 우선, PR#2680)까지는 이미 반영. 남은 갭은 코드 주석이 스스로 지목: "active 에픽 52개 중에서도 여전히 «먼저 오는 하나»를 고르는 것뿐 — updated_at이 오면(#2341 AC2) tie-break 추가".
- **그 주석의 전제("BeEpicListItem엔 updated_at이 없다, BE 계약에 없음")가 틀렸다.** `backend/app/schemas/goal.py:96` `GoalResponse.updated_at: datetime`은 이미 2026-04-29(커밋 6462ad1af4)부터 계약에 있었고, `GoalWithGlanceResponse(GoalResponse)`가 상속하므로 `?include=glance` 응답(load-glance-data.ts가 실제로 부르는 엔드포인트)에도 이미 실려있다. **BE 작업 불요 — FE 노출 누락만 메우면 됐다.**
- ②judgment_core "active"(kind≠correction)는 이미 정확히 설계대로 동작 — `correction_ids`로 매 원소를 decorate해 소비자가 철회여부를 즉시 안다(`judgment_core.py:28-41,145-154`). 코드 변경 불요.
- ③07-29 철회건은 story #2308이 이미 고쳤다(같은 correction_ids 기법, `judgment_core.py:1,11,28` 주석에 명시).

## 변경 — AC2만 (①의 근본 방향(AC1: ㉠/㉡/㉢ 택1)은 별개 미결)
- `apps/web/src/services/glance.ts`: `BeEpicListItem`에 `updated_at` 필드 추가.
- `apps/web/src/components/glance/load-glance-data.ts`: activeEpic 선택 로직을 `roadmap.find(...)`(배열 순서상 첫 매치) → focal_story 유무로 먼저 가르고 같은 그룹 안에서 `updated_at` 내림차순 tie-break로 교체.
- 신규 테스트 1건: 배열 순서상 뒤에 오지만 더 최근에 갱신된 active 에픽이 선택되는지 pin.

이 delta는 AC1(active를 파생값化하는 근본 방향, ㉡)이 확定되기 전까지의 완화 — 스토리 본문에 그대로 기록. AC1은 PO가 이미 ㉡ 선호를 밝혔으나 규모산정이 필요해 이 PR 스코프 밖으로 분리, 스토리 채널에 후속 스토리 분리 여부 확認 요청 예정.

## 검증
- `pnpm exec vitest run` — 4683/4683 pass (전체 스위트, 신규 1건 포함)
- `tsc --noEmit` — clean
- `eslint` — clean