### PR TITLE
[SID:3126] latest_story_activity_at BE 공유 파생 필드 신설 (Phase 1)

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.test.tsx
@@ -129,8 +129,10 @@ describe('GoalsClient — 목표 first-touch 정체성', () => {
 // Claimed/결과 Verified) 재조립 회귀가드.
 describe('GoalsClient — 결과 원장 재조립(§2 이중 신호·§3 마스트헤드)', () => {
   it('마스트헤드(kicker+H1+dek)가 목표 활성/완료 카운트와 함께 렌더된다', async () => {
+    // story #3126 — 활성 카운트는 status='active'뿐 아니라 latest_story_activity_at이
+    // dormancy 임계 안(최근 움직임 실재)이어야 센다. 이 목표A는 방금 움직였다는 신호.
     stubFetch([
-      { id: 'e1', title: '목표A', status: 'active', total_stories: 2, done_stories: 1 },
+      { id: 'e1', title: '목표A', status: 'active', total_stories: 2, done_stories: 1, latest_story_activity_at: new Date().toISOString() },
       { id: 'e2', title: '목표B', status: 'done', total_stories: 4, done_stories: 4 },
     ]);
     await mount();
@@ -138,6 +140,17 @@ describe('GoalsClient — 결과 원장 재조립(§2 이중 신호·§3 마스�
     expect(container.querySelector('h1')?.textContent).toBe('목표');
     expect(container.textContent).toContain('활성 1');
     expect(container.textContent).toContain('완료 1');
+  });
+
+  it('story #3126: an active-status goal with NO recent story movement(latest_story_activity_at 없음/dormancy 밖) is NOT counted in 활성 — 52개 중 실제로 도는 것만 센다', async () => {
+    stubFetch([
+      { id: 'e1', title: '목표A(방금 움직임)', status: 'active', total_stories: 2, done_stories: 1, latest_story_activity_at: new Date().toISOString() },
+      { id: 'e2', title: '목표B(오래 조용함)', status: 'active', total_stories: 3, done_stories: 0, latest_story_activity_at: new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString() },
+      { id: 'e3', title: '목표C(신호 자체 없음)', status: 'active', total_stories: 1, done_stories: 0 },
+    ]);
+    await mount();
+    // status='active' 3개 중 실제로 최근 움직인 것은 1개뿐 — "3 active"가 아니라 "1 active".
+    expect(container.textContent).toContain('활성 1');
   });
 
   // story #2974 §1/§3(PR-D0) — 마스트헤드 h1이 font-display 토큰 경유(D0=Pretendard, 시각 무변화).

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -103,6 +103,25 @@ interface Goal {
   // 제안 hook — 실 배선 P3/v2, v1은 미표시(no-fiction).
   position?: number | null;
   source_loop_id?: string | null;
+  // story #3126(#2341 AC1 후속) — `?include=glance` 옵트인 시에만 실린다. 이 goal 소속
+  // non-done story의 updated_at 최댓값(없으면 null) — "status='active' 52개 중 몇 개가
+  // «정말» 움직이는가"를 이 필드+dormancy_threshold_hours로 가른다("active" 미포함 이름).
+  latest_story_activity_at?: string | null;
+}
+
+// story #3126 — epics-progress-lane fetch가 실패했을 때만 쓰는 폴백(옛 코드가 이 신호 자체가
+// 없던 시절과 동일하게 «전부 active로 인정»하지 않기 위한 최소값이 아니라, next-maker-screen.tsx
+// 의 동일 상수와 정합해 같은 실패-시나리오에서 같은 값을 쓴다).
+const DEFAULT_DORMANCY_THRESHOLD_HOURS = 720;
+
+// story #3126 — Goal.status='active'(lifecycle)이면서 latest_story_activity_at이 dormancy
+// 임계 밖(또는 아예 없음)인 것을 "잠든 active"로 판별. status 자체의 뜻은 안 건드린다(lifecycle
+// SSOT는 무변경) — 이 판별은 오직 표시용 카운트에만 쓰인다.
+function isDormantActiveGoal(goal: Goal, dormancyThresholdHours: number, nowMs: number): boolean {
+  if (!goal.latest_story_activity_at) return true;
+  const t = new Date(goal.latest_story_activity_at).getTime();
+  if (Number.isNaN(t)) return true;
+  return nowMs - t > dormancyThresholdHours * 3600_000;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -938,6 +957,8 @@ export function GoalsClient({ projectId, orgId }: GoalsClientProps) {
   const [showDispatch, setShowDispatch] = useState(false);
   const [justDispatched, setJustDispatched] = useState(false);
   const [dispatchedTo, setDispatchedTo] = useState<string[]>([]); // 지정 수신자 이름(핸드오프 표시용)
+  // story #3126 — BE 단일소스(epics-progress-lane), fetch 실패 시에만 폴백.
+  const [dormancyThresholdHours, setDormancyThresholdHours] = useState(DEFAULT_DORMANCY_THRESHOLD_HOURS);
   const sensors = useSensors(useSensor(MousePointerSensor, { activationConstraint: { distance: 8 } }));
   // story #2545(카디르 라이브 재QA 2단계) — org 불일치 자동교정(switch-org)이 이 fetch 直後
   // 성공하면 project는 안 바뀌므로 재요청 트리거가 없었다(project-context-client.ts 참고).
@@ -947,7 +968,11 @@ export function GoalsClient({ projectId, orgId }: GoalsClientProps) {
   // 커서를 발행하지 않으므로 이어달리기(cursor pagination) 없이 전량(상위 STEER_LIMIT) 로드한다(AC4).
   const fetchGoals = useCallback(async () => {
     try {
-      const params = new URLSearchParams({ project_id: projectId, limit: String(STEER_LIMIT), order_by: 'position' });
+      // story #3126 — include=glance로 latest_story_activity_at을 같이 받는다(신규 round-trip
+      // 없음, 이미 하던 이 fetch에 옵트인 파라미터만 추가).
+      const params = new URLSearchParams({
+        project_id: projectId, limit: String(STEER_LIMIT), order_by: 'position', include: 'glance',
+      });
       const res = await fetchWithAuth(`/api/goals?${params.toString()}`);
       if (!res.ok) throw new Error(`Failed to fetch epics: ${res.status}`);
       const { data } = await res.json() as { data: Goal[] };
@@ -1049,6 +1074,25 @@ export function GoalsClient({ projectId, orgId }: GoalsClientProps) {
     void fetchGoals();
   }, [fetchGoals]);
 
+  // story #3126 — dormancy_threshold_hours를 1회 조회(project_id 변경 시 재조회). 실패 시
+  // DEFAULT_DORMANCY_THRESHOLD_HOURS 유지(위 useState 초기값 그대로, 별도 처리 불요).
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetchWithAuth(`/api/analytics/epics-progress-lane?project_id=${projectId}`);
+        if (!res.ok || cancelled) return;
+        const { data } = await res.json() as { data?: { dormancy_threshold_hours?: number } };
+        if (!cancelled && typeof data?.dormancy_threshold_hours === 'number') {
+          setDormancyThresholdHours(data.dormancy_threshold_hours);
+        }
+      } catch {
+        // 폴백 유지 — silent이되 파괴적이지 않음(옛 하드코딩과 동일 값이 그대로 쓰인다).
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [projectId]);
+
   if (loading) {
     return (
       <>
@@ -1066,7 +1110,14 @@ export function GoalsClient({ projectId, orgId }: GoalsClientProps) {
   // 커밋("조타 보내기")은 큐레이션(position≠null)이 하나라도 있을 때만 의미 있다.
   const hasCurated = epics.some((e) => typeof e.position === 'number');
 
-  const activeCount = epics.filter((e) => e.status === 'active').length;
+  // story #3126(#2341 §「52개 중 3개만 실제로 돈다」) — status='active'는 lifecycle(안 끝난
+  // 것 전부)이라 이 헤드라인 카운트를 있는 그대로 쓰면 "52 active"처럼 부풀려진 수를 그대로
+  // 노출한다. status='active' 중에서도 최근 dormancy 임계 안에 실제 움직임(latest_story_
+  // activity_at)이 있는 것만 센다 — status 자체의 뜻(lifecycle)은 안 건드리고 이 카운트만
+  // "정말 도는가"로 좁힌다.
+  const activeCount = epics.filter(
+    (e) => e.status === 'active' && !isDormantActiveGoal(e, dormancyThresholdHours, Date.now()),
+  ).length;
   const doneCount = epics.filter((e) => e.status === 'done').length;
 
   const listPanel = (

--- a/apps/web/src/app/api/analytics/epics-progress-lane/route.test.ts
+++ b/apps/web/src/app/api/analytics/epics-progress-lane/route.test.ts
@@ -8,7 +8,7 @@ import { GET } from './route';
 
 const PATH = '/api/v2/analytics/epics-progress-lane';
 const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
-const okRes = (b: unknown = { epics: {}, zones: {}, stall_threshold_hours: 168, stories_without_epic: 0 }) =>
+const okRes = (b: unknown = { epics: {}, zones: {}, stall_threshold_hours: 168, dormancy_threshold_hours: 720, stories_without_epic: 0 }) =>
   new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } });
 const req = () => new Request('http://localhost/api/analytics/epics-progress-lane?project_id=p');
 

--- a/apps/web/src/components/flow/derive-flow.test.ts
+++ b/apps/web/src/components/flow/derive-flow.test.ts
@@ -26,6 +26,7 @@ function makeLaneData(overrides: Partial<EpicsProgressLaneResponse> = {}): Epics
       e1: { title: 'Epic 1', total: 10, done: 4, pct: 40, past_cnt: 4, now_cnt: 2, upcoming_cnt: 4 },
     },
     stall_threshold_hours: 168,
+    dormancy_threshold_hours: 720,
     stories_without_epic: 0,
     ...overrides,
   };

--- a/apps/web/src/components/flow/derive-flow.ts
+++ b/apps/web/src/components/flow/derive-flow.ts
@@ -31,6 +31,11 @@ export interface EpicsProgressLaneResponse {
   epics: Record<string, EpicLaneCounts>;
   zones: Record<string, EpicZoneCounts>;
   stall_threshold_hours: number;
+  // story #3126(#2341 AC1 후속, 페드루 판정 2026-08-27) — stall_threshold_hours(168h, story
+  // 하나의 단기 정체 신호)와 「같은 질문 두 값」이 아니다: dormancy=goal 전체의 장기 활동
+  // 분류(fold/은퇴 판정). 위계상 세부가 먼저 시들고 상위가 나중에 은퇴하므로 값이 다른 게
+  // 정직하다 — `derive-next-maker.ts`의 옛 하드코딩 30일(THIRTY_DAYS_MS)을 이 값으로 대체한다.
+  dormancy_threshold_hours: number;
   stories_without_epic: number;
 }
 

--- a/apps/web/src/components/flow/derive-next-maker.test.ts
+++ b/apps/web/src/components/flow/derive-next-maker.test.ts
@@ -218,13 +218,13 @@ describe('deriveOrphanStories', () => {
 // story #2224 AC1(멀티레인) — 「레인이 몇 개까지 서는가」는 수가 아니라 성질(30일 안 변화)로
 // 가른다. 스토리 0건은 이 함수에 아예 안 들어온다(호출부가 미리 거름) — expand/fold 둘 다
 // «스토리가 있는» 목표만의 문제다.
-describe('deriveActiveLaneGoals — 30일 안 변화로 펼침/접힘을 가른다(story #2224 AC1)', () => {
+describe('deriveActiveLaneGoals — dormancy 임계(호출부 전달, story #3126부터 BE 단일소스) 안 변화로 펼침/접힘을 가른다(story #2224 AC1)', () => {
   const NOW = new Date('2026-07-31T00:00:00Z').getTime();
 
   it('expands a goal whose most recent active story updated within the last 30 days', () => {
     const goals = [goal({ id: 'e1' })];
     const stories = [story({ epicId: 'e1', updatedAt: '2026-07-20T00:00:00Z' })]; // 11일 전
-    const result = deriveActiveLaneGoals(goals, stories, NOW);
+    const result = deriveActiveLaneGoals(goals, stories, 720, NOW);
     expect(result.expand.map((g) => g.id)).toEqual(['e1']);
     expect(result.fold).toEqual([]);
   });
@@ -232,14 +232,14 @@ describe('deriveActiveLaneGoals — 30일 안 변화로 펼침/접힘을 가른�
   it('folds a goal whose most recent active story updated more than 30 days ago', () => {
     const goals = [goal({ id: 'e1' })];
     const stories = [story({ epicId: 'e1', updatedAt: '2026-06-01T00:00:00Z' })]; // 60일 전
-    const result = deriveActiveLaneGoals(goals, stories, NOW);
+    const result = deriveActiveLaneGoals(goals, stories, 720, NOW);
     expect(result.fold.map((g) => g.id)).toEqual(['e1']);
     expect(result.expand).toEqual([]);
   });
 
   it('folds a goal with NO active stories at all (can\'t prove "recent" — does not guess)', () => {
     const goals = [goal({ id: 'e1' })];
-    const result = deriveActiveLaneGoals(goals, [], NOW);
+    const result = deriveActiveLaneGoals(goals, [], 720, NOW);
     expect(result.fold.map((g) => g.id)).toEqual(['e1']);
     expect(result.expand).toEqual([]);
   });
@@ -250,7 +250,7 @@ describe('deriveActiveLaneGoals — 30일 안 변화로 펼침/접힘을 가른�
       story({ id: 's-old', epicId: 'e1', updatedAt: '2026-01-01T00:00:00Z' }),
       story({ id: 's-new', epicId: 'e1', updatedAt: '2026-07-25T00:00:00Z' }), // 6일 전
     ];
-    const result = deriveActiveLaneGoals(goals, stories, NOW);
+    const result = deriveActiveLaneGoals(goals, stories, 720, NOW);
     expect(result.expand.map((g) => g.id)).toEqual(['e1']);
   });
 
@@ -258,14 +258,14 @@ describe('deriveActiveLaneGoals — 30일 안 변화로 펼침/접힘을 가른�
     const goals = [goal({ id: 'e1' })];
     const thirtyDaysAgo = new Date(NOW - 30 * 24 * 60 * 60 * 1000).toISOString();
     const stories = [story({ epicId: 'e1', updatedAt: thirtyDaysAgo })];
-    const result = deriveActiveLaneGoals(goals, stories, NOW);
+    const result = deriveActiveLaneGoals(goals, stories, 720, NOW);
     expect(result.expand.map((g) => g.id)).toEqual(['e1']);
   });
 
   it('ignores stories belonging to a different epic', () => {
     const goals = [goal({ id: 'e1' }), goal({ id: 'e2' })];
     const stories = [story({ epicId: 'e2', updatedAt: '2026-07-30T00:00:00Z' })];
-    const result = deriveActiveLaneGoals(goals, stories, NOW);
+    const result = deriveActiveLaneGoals(goals, stories, 720, NOW);
     expect(result.expand.map((g) => g.id)).toEqual(['e2']);
     expect(result.fold.map((g) => g.id)).toEqual(['e1']);
   });
@@ -273,8 +273,15 @@ describe('deriveActiveLaneGoals — 30일 안 변화로 펼침/접힘을 가른�
   it('every input goal ends up in exactly one of expand/fold (no goal dropped, no duplicate)', () => {
     const goals = [goal({ id: 'e1' }), goal({ id: 'e2' }), goal({ id: 'e3' })];
     const stories = [story({ epicId: 'e2', updatedAt: '2026-07-30T00:00:00Z' })];
-    const result = deriveActiveLaneGoals(goals, stories, NOW);
+    const result = deriveActiveLaneGoals(goals, stories, 720, NOW);
     const all = [...result.expand, ...result.fold].map((g) => g.id).sort();
     expect(all).toEqual(['e1', 'e2', 'e3']);
+  });
+
+  it('story #3126 — the caller-supplied dormancyThresholdHours is genuinely load-bearing(hardcoded 30일 잔존 0 검산): the same 11-day-old story expands under 720h(30일) but folds under a much narrower 24h', () => {
+    const goals = [goal({ id: 'e1' })];
+    const stories = [story({ epicId: 'e1', updatedAt: '2026-07-20T00:00:00Z' })]; // 11일 전
+    expect(deriveActiveLaneGoals(goals, stories, 720, NOW).expand.map((g) => g.id)).toEqual(['e1']);
+    expect(deriveActiveLaneGoals(goals, stories, 24, NOW).fold.map((g) => g.id)).toEqual(['e1']);
   });
 });

--- a/apps/web/src/components/flow/derive-next-maker.test.ts
+++ b/apps/web/src/components/flow/derive-next-maker.test.ts
@@ -285,3 +285,68 @@ describe('deriveActiveLaneGoals — dormancy 임계(호출부 전달, story #312
     expect(deriveActiveLaneGoals(goals, stories, 24, NOW).fold.map((g) => g.id)).toEqual(['e1']);
   });
 });
+
+// story #3126(페드루 조건, 2026-08-27 09:25) — «존치를 승인하되 조용히 갈라지지 못하게».
+// deriveActiveLaneGoals의 lastActiveByEpic 로컬 계산(activeStories로부터)과 BE
+// `GoalRepository.attach_glance_aggregates`의 latest_story_activity_at 공식이 같은
+// 정의(non-done story의 updated_at 최댓값)·같은 비교연산자(<=, 초과가 아니라 이상 포함)를
+// 지켜야 한다. 여기 오라클은 소스코드(deriveActiveLaneGoals 내부 Map 루프)와 «다른 방식»으로
+// 같은 규칙을 재구현한다(reduce 체인) — 소스와 같은 스타일로 베끼면 로직 버그가 그대로
+// 복제돼도 이 테스트가 못 잡는다.
+describe('deriveActiveLaneGoals — BE 공식(non-done MAX·<=) 등가 pin(story #3126, 페드루 조건)', () => {
+  const NOW = new Date('2026-07-31T00:00:00Z').getTime();
+
+  // BE app/repositories/goal.py::attach_glance_aggregates의 latest_story_activity_at
+  // 정의를 독립 재구현(SELECT MAX(updated_at) WHERE status != 'done' GROUP BY epic_id) —
+  // 소스(deriveActiveLaneGoals)와 다른 스타일(reduce)로 짜서 같은 버그를 복제하지 않는다.
+  function beFormulaOracle(
+    goals: NextMakerGoal[],
+    stories: NextMakerStory[],
+    dormancyThresholdHours: number,
+    now: number,
+  ): { expand: string[]; fold: string[] } {
+    const nonDone = stories.filter((s) => s.status !== 'done' && s.epicId != null);
+    const latestByEpic = nonDone.reduce<Record<string, number>>((acc, s) => {
+      const t = new Date(s.updatedAt).getTime();
+      if (Number.isNaN(t)) return acc;
+      const cur = acc[s.epicId as string];
+      acc[s.epicId as string] = cur === undefined ? t : Math.max(cur, t);
+      return acc;
+    }, {});
+    const thresholdMs = dormancyThresholdHours * 3600_000;
+    const expand: string[] = [];
+    const fold: string[] = [];
+    for (const g of goals) {
+      const latest = latestByEpic[g.id];
+      if (latest !== undefined && now - latest <= thresholdMs) expand.push(g.id);
+      else fold.push(g.id);
+    }
+    return { expand, fold };
+  }
+
+  it.each([
+    { name: '단일 non-done story, 임계 안', hours: 720, stories: [story({ epicId: 'e1', status: 'in-progress', updatedAt: '2026-07-20T00:00:00Z' })] },
+    { name: '단일 non-done story, 임계 밖', hours: 24, stories: [story({ epicId: 'e1', status: 'in-progress', updatedAt: '2026-07-20T00:00:00Z' })] },
+    { name: 'done story만 있음(제외되어 latest 없음)', hours: 720, stories: [story({ epicId: 'e1', status: 'done', updatedAt: '2026-07-30T23:00:00Z' })] },
+    {
+      name: 'done+non-done 혼재 — done의 더 최근 값이 안 섞인다',
+      hours: 720,
+      stories: [
+        story({ id: 's-done', epicId: 'e1', status: 'done', updatedAt: '2026-07-30T23:00:00Z' }),
+        story({ id: 's-old', epicId: 'e1', status: 'backlog', updatedAt: '2026-01-01T00:00:00Z' }),
+      ],
+    },
+    {
+      name: '경계값(정확히 임계) — <=라 expand',
+      hours: 720,
+      stories: [story({ epicId: 'e1', status: 'ready-for-dev', updatedAt: new Date(NOW - 720 * 3600_000).toISOString() })],
+    },
+    { name: '스토리 0건(latest 자체가 없음)', hours: 720, stories: [] },
+  ])('$name', ({ hours, stories }) => {
+    const goals = [goal({ id: 'e1' })];
+    const actual = deriveActiveLaneGoals(goals, stories, hours, NOW);
+    const expected = beFormulaOracle(goals, stories, hours, NOW);
+    expect(actual.expand.map((g) => g.id)).toEqual(expected.expand);
+    expect(actual.fold.map((g) => g.id)).toEqual(expected.fold);
+  });
+});

--- a/apps/web/src/components/flow/derive-next-maker.ts
+++ b/apps/web/src/components/flow/derive-next-maker.ts
@@ -116,10 +116,15 @@ export function deriveActiveLaneGoals(
   dormancyThresholdHours: number,
   now: number,
 ): LaneGoalGrouping {
+  // story #3126(페드루 조건, parity-pin이 실제로 잡은 갭) — "done 제외"는 예전엔 호출부
+  // 계약(next-maker-screen.tsx가 done을 애초에 fetch 안 함)에만 의존하는 «외부» 보장이었다.
+  // BE `attach_glance_aggregates`의 공식은 `Story.status != "done"`을 SQL WHERE에서 직접
+  // 강제(«내부» 보장)한다 — 두 정의가 조용히 갈라지지 않으려면 이 함수도 같은 필터를
+  // 자체적으로 걸어야 한다(호출부가 언젠가 done을 섞어 넘겨도 동일하게 방어).
   const dormancyThresholdMs = dormancyThresholdHours * 60 * 60 * 1000;
   const lastActiveByEpic = new Map<string, number>();
   for (const s of activeStories) {
-    if (!s.epicId) continue;
+    if (!s.epicId || s.status === 'done') continue;
     const t = new Date(s.updatedAt).getTime();
     if (Number.isNaN(t)) continue;
     const prev = lastActiveByEpic.get(s.epicId);

--- a/apps/web/src/components/flow/derive-next-maker.ts
+++ b/apps/web/src/components/flow/derive-next-maker.ts
@@ -83,13 +83,21 @@ export interface LaneGoalGrouping {
   fold: NextMakerGoal[];
 }
 
-const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
-
 /**
  * story #2224 AC1(멀티레인, 2026-07-31, 목업 84abdf43 v5 + PO/미르코군 정정) — 「레인이 몇
  * 개까지 서는가」의 답은 «수»가 아니라 «성질»이다: 목업의 "펼친 8"은 우연히 8이었을 뿐,
- * 규격은 "최근 30일 안에 변화가 있었던 목표는 펼치고, 나머지는 하나의 접힘 줄로 묶는다"다
- * (기존 과거-묶음 카드 패턴과 같은 결 — 개수를 하드코딩하지 않고 성질로 가른다).
+ * 규격은 "최근 dormancyThresholdHours 안에 변화가 있었던 목표는 펼치고, 나머지는 하나의
+ * 접힘 줄로 묶는다"다(기존 과거-묶음 카드 패턴과 같은 결 — 개수를 하드코딩하지 않고 성질로
+ * 가른다).
+ *
+ * story #3126(#2341 AC1 후속, 페드루 판정 2026-08-27) — 옛 하드코딩 THIRTY_DAYS_MS(30일)를
+ * 걷어내고 BE `epics-progress-lane`이 내려주는 `dormancy_threshold_hours`를 단일 소스로
+ * 받는다(호출부가 시간 단위를 넘긴다). ⚠️`lastActiveByEpic`(아래 activeStories로부터의 계산)은
+ * 걷어내지 않는다 — next-maker-screen.tsx가 스토리를 로컬에서 다른 목표로 재배정할 때
+ * "왕복이 화면에 바로 보이는 것이 완료 조건"(PO, story #2224)이라 서버 재조회 없이 즉시
+ * 반영돼야 하는데, BE `latest_story_activity_at`(#3126 Phase 1)은 마지막 fetch 시점 스냅샷이라
+ * 이 즉시성을 못 준다 — 옛 계산 그대로 두고 «임계값만» BE 단일 소스로 교체하는 것이 이
+ * 함수가 만족해야 할 두 계약(PO 즉시반영 확定 + #3126 임계 단일소스) 모두를 지킨다.
  *
  * ⛔스토리가 «정말 0건»인 목표는 이 함수에 아예 안 들어온다(expand도 fold도 아님) — PO
  * 정정(2026-07-31): 「접힘(활동은 있었으나 최근 안 움직인 것)」과 「0건(그릴 대상 자체가
@@ -105,8 +113,10 @@ const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 export function deriveActiveLaneGoals(
   goals: NextMakerGoal[],
   activeStories: NextMakerStory[],
+  dormancyThresholdHours: number,
   now: number,
 ): LaneGoalGrouping {
+  const dormancyThresholdMs = dormancyThresholdHours * 60 * 60 * 1000;
   const lastActiveByEpic = new Map<string, number>();
   for (const s of activeStories) {
     if (!s.epicId) continue;
@@ -120,7 +130,7 @@ export function deriveActiveLaneGoals(
   const fold: NextMakerGoal[] = [];
   for (const g of goals) {
     const lastActive = lastActiveByEpic.get(g.id);
-    if (lastActive !== undefined && now - lastActive <= THIRTY_DAYS_MS) {
+    if (lastActive !== undefined && now - lastActive <= dormancyThresholdMs) {
       expand.push(g);
     } else {
       fold.push(g);

--- a/apps/web/src/components/flow/next-maker-screen.test.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.test.tsx
@@ -73,6 +73,10 @@ function buildFetchMock(
   // 까심 QA REQUEST_CHANGES(2026-07-31) 회귀 가드용 — 「다음으로」 PATCH의 응답을 시나리오별로
   // 흔들기 위한 훅. 'fail'=HTTP 비-ok 응답, 'throw'=네트워크 자체가 끊김(unhandled rejection 재현).
   promoteStatusMode: 'ok' | 'fail' | 'throw' = 'ok',
+  // story #3126 — undefined면 기존 그대로(lane 응답에 필드 자체가 없음, 화면은 폴백 720h를
+  // 씀). 명시값을 주면 그 값을 lane 응답에 실어 화면이 «실제로 그 값을 읽어 쓰는지»를
+  // 별도 테스트에서 pin할 수 있게 한다(값을 안 주면 아무 기존 테스트의 동작도 안 바뀐다).
+  dormancyThresholdHours: number | undefined = undefined,
 ) {
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
@@ -108,7 +112,12 @@ function buildFetchMock(
       return jsonResponse([]);
     }
     if (url.startsWith('/api/analytics/epics-progress-lane')) {
-      return jsonResponse({ data: { epics: {}, zones: {}, stall_threshold_hours: 168, stories_without_epic: 0 } });
+      return jsonResponse({
+        data: {
+          epics: {}, zones: {}, stall_threshold_hours: 168, stories_without_epic: 0,
+          ...(dormancyThresholdHours !== undefined ? { dormancy_threshold_hours: dormancyThresholdHours } : {}),
+        },
+      });
     }
     // NextActionsStrip을 펼치면(GoalStemCard 마운트) 부르는 것들 — 승격 후보 계산 + 그 목표의
     // 단일-레인 캔버스는 showCanvas=false라 여기선 안 뜨지만 reference-candidates는 그대로 부른다.
@@ -204,6 +213,37 @@ describe('NextMakerScreen — real fetch orchestration + lane grouping', () => {
     // 스토리가 0건이라도 그 목표가 조용한지/승격 후보가 없는지는 여전히 물을 수 있다.
     expect(container.querySelector('[data-testid="expand-titles"]')?.textContent).toBe('E-Recent');
     expect(container.querySelector('[data-testid="folded-count"]')?.textContent).toBe('1');
+  });
+
+  // story #3126(2026-08-27) — 옛 하드코딩 30일이 아니라 BE `dormancy_threshold_hours`를
+  // «실제로 읽어 쓰는지» pin. E-Recent의 스토리는 5일(120h) 전 갱신 — lane 응답이 720h(기존
+  // 폴백과 동일값)를 주면 여전히 펼침이지만, 48h(2일)를 주면 120h > 48h라 접혀야 한다. 두
+  // 케이스가 다른 결과를 내야 화면이 진짜 이 값을 쓰고 있다는 증거다(같은 값이면 폴백만
+  // pin하는 것일 수 있어 가짜 회귀가드가 된다).
+  it('story #3126: uses the BE-supplied dormancy_threshold_hours, not a hardcoded 30일 — a narrower threshold folds a goal that a wider one would expand', async () => {
+    const wideUrls: string[] = [];
+    vi.stubGlobal('fetch', buildFetchMock(wideUrls, [], 'ok', 720));
+    await act(async () => {
+      root.render(wrap(<NextMakerScreen projectId="p1" memberMap={{}} onSelectStory={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(container.querySelector('[data-testid="expand-titles"]')?.textContent).toBe('E-Recent');
+    await act(async () => { root.unmount(); });
+    container.remove();
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    const narrowUrls: string[] = [];
+    vi.stubGlobal('fetch', buildFetchMock(narrowUrls, [], 'ok', 48));
+    await act(async () => {
+      root.render(wrap(<NextMakerScreen projectId="p1" memberMap={{}} onSelectStory={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    // 48h면 E-Recent(120h 전)·E-Stale(60일 전) 둘 다 접힌다(720h일 땐 E-Recent만 펼쳐졌던 것과
+    // 대비 — 접힌 개수 자체가 달라지는 것이 임계값이 실제로 화면에 반영된다는 증거).
+    expect(container.querySelector('[data-testid="expand-titles"]')?.textContent).toBe('');
+    expect(container.querySelector('[data-testid="folded-count"]')?.textContent).toBe('2');
   });
 
   // story #2535(E-FLOW-V4 S5) — 지구→대륙→도시 드릴다운 착지. focusGoalId가 fold 쪽에

--- a/apps/web/src/components/flow/next-maker-screen.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.tsx
@@ -45,6 +45,9 @@ function unwrap<T>(json: unknown): T | null {
 // total_stories/done_stories로 충분하다).
 const ACTIVE_STATUSES = ['backlog', 'ready-for-dev', 'in-progress', 'in-review'] as const;
 const PAGE_LIMIT = 100; // /api/goals, /api/stories FE 프록시 상한(parseCursorPageInput maxLimit).
+// story #3126 — epics-progress-lane fetch가 실패했을 때만 쓰는 폴백(옛 하드코딩 THIRTY_DAYS_MS와
+// 동일한 30일). 정상 경로는 항상 BE dormancy_threshold_hours를 쓴다.
+const DEFAULT_DORMANCY_THRESHOLD_HOURS = 720;
 const SAFETY_MAX_PAGES = 50; // 무한루프 방어 — 100*50=5000건, 오늘 이 project 규모를 넉넉히 상회.
 
 // story #2224 후속(2026-08-16, 미르코 그라운딩) — dev 실측: 활성 목표 39건이 존재하는데
@@ -96,6 +99,9 @@ type LoadState =
       // epics-progress-lane을 이미 부르고 있어(위 문서 §I-6 "두 벌 서지 않는다") 그 응답에서
       // 그대로 뽑는다 — FlowMultiLaneCanvas가 따로 fetch/하드코딩하지 않는다.
       stallThresholdHours: number | undefined;
+      // story #3126 페드루 판정(2026-08-27) — stall(168h, 레인 단기 주의)과 dormancy(720h,
+      // 목표 장기 활동 분류)는 «같은 질문의 다른 값»이 아니라 별개 질문이라 병존한다.
+      dormancyThresholdHours: number;
     };
 
 /**
@@ -163,13 +169,21 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedN
         const recentlyClosedEpicIds = deriveRecentlyClosedEpicIds(nextUp, activeStories);
         const recentlyClosedTargetIds = new Set(nextUp.filter((r) => r.isRecent).map((r) => r.targetId));
 
-        const laneData = unwrap<{ epics: Record<string, { blocked: number }>; stall_threshold_hours?: number }>(laneRes);
+        const laneData = unwrap<{
+          epics: Record<string, { blocked: number }>;
+          stall_threshold_hours?: number;
+          dormancy_threshold_hours?: number;
+        }>(laneRes);
         const blockedCount = laneData
           ? Object.values(laneData.epics).reduce((sum, e) => sum + (e.blocked ?? 0), 0)
           : 0;
         const stallThresholdHours = laneData?.stall_threshold_hours;
+        // story #3126 — 이 화면의 옛 하드코딩 30일(THIRTY_DAYS_MS)을 대체하는 BE 단일소스값.
+        // lane fetch 자체가 실패(laneData null)하면 옛 30일과 동일한 값으로 폴백 — 이 화면이
+        // 이 fetch 전에도 항상 30일로 동작했으니 실패 시 그 이상도 이하도 아닌 안전한 자리.
+        const dormancyThresholdHours = laneData?.dormancy_threshold_hours ?? DEFAULT_DORMANCY_THRESHOLD_HOURS;
 
-        setState({ kind: 'ready', goals, activeStories, recentlyClosedEpicIds, recentlyClosedTargetIds, blockedCount, stallThresholdHours });
+        setState({ kind: 'ready', goals, activeStories, recentlyClosedEpicIds, recentlyClosedTargetIds, blockedCount, stallThresholdHours, dormancyThresholdHours });
       } catch {
         if (!cancelled) setState({ kind: 'error' });
       }
@@ -275,15 +289,16 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedN
   const [nowMs] = useState(() => Date.now());
 
   // story #2224 AC1 — 스토리가 «정말 0건»인 목표는 레인 자체를 안 그린다(PO 정정: 접힘과
-  // 0건은 다른 사정이라 섞으면 뜻이 흐려진다). 나머지만 30일-변화 성질로 펼침/접힘을 가른다.
+  // 0건은 다른 사정이라 섞으면 뜻이 흐려진다). 나머지만 dormancy-변화 성질로 펼침/접힘을
+  // 가른다(story #3126부터 임계는 BE dormancy_threshold_hours 단일소스, 옛 30일 하드코딩 걷음).
   //
-  // story #2535(E-FLOW-V4 S5) — focusGoalId가 30일 무변화로 fold 쪽에 떨어졌으면 그 목표
+  // story #2535(E-FLOW-V4 S5) — focusGoalId가 dormancy 무변화로 fold 쪽에 떨어졌으면 그 목표
   // «하나»만 강제로 expand로 옮긴다(다른 레인은 그대로 접힌 채 — 카드 폭발 회피를 구조로
   // 지킨다). 지구→대륙→도시 드릴다운으로 왔는데 목표가 안 보이면 다리가 끊긴 것이다.
   const laneGrouping = useMemo(() => {
     if (state.kind !== 'ready') return { expand: [], fold: [] };
     const goalsWithStories = effectiveGoals.filter((g) => g.totalStories > 0);
-    const base = deriveActiveLaneGoals(goalsWithStories, effectiveActiveStories, nowMs);
+    const base = deriveActiveLaneGoals(goalsWithStories, effectiveActiveStories, state.dormancyThresholdHours, nowMs);
     if (!focusGoalId || base.expand.some((g) => g.id === focusGoalId)) return base;
     const foldedTarget = base.fold.find((g) => g.id === focusGoalId);
     if (!foldedTarget) return base;

--- a/apps/web/src/components/glance/load-glance-data.test.ts
+++ b/apps/web/src/components/glance/load-glance-data.test.ts
@@ -133,19 +133,19 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
     expect(data.heroStory?.id).toBe('s-real');
   });
 
-  it('story #2341 AC2: among multiple active epics that each have a focal_story, picks the most recently updated one(updated_at tie-break — "먼저 오는 하나"가 아니라 "가장 최근에 움직인 하나")', async () => {
+  it('story #3126: among multiple active epics that each have a focal_story, picks the one with the most recent latest_story_activity_at(«먼저 오는 하나»가 아니라 «지금 실제로 움직이는 하나»)', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.startsWith('/api/goals')) {
         return jsonResponse([
           {
-            // ⛔카디르 QA(2026-08-27) — created_at을 e-fresh보다 이르게 둬야 confound 없는
-            // 표본이 된다: tie-break를 제거해도 배열순서(scopeRoadmapEpics의 created_at ASC
-            // 폴백) 자체가 e-fresh를 먼저 골라버리면, 이 테스트는 tie-break 로직이 아니라
-            // 우연히 같은 결과를 내는 폴백 정렬을 pin하는 것이 된다(제거해도 그린 — 가짜
-            // 회귀가드). e-stale이 배열상 «먼저»(created_at 이름) 오게 만들어, tie-break를
-            // 지우면 실제로 RED가 나는 것을 카디르가 직접 재현 확認.
-            id: 'e-stale', title: 'E-STALE(오래전 갱신, 배열순서상 먼저 옴)', status: 'active',
-            created_at: '2026-05-01T00:00:00Z', updated_at: '2026-06-01T00:00:00Z', participant_ids: [],
+            // ⛔이 표본은 created_at·updated_at·배열순서 셋 다 e-fresh보다 «늦게»(더 최근)
+            // 둬서, 이 tie-break가 정말 latest_story_activity_at만 읽는지를 가른다 — 옛
+            // updated_at 기반 계산이 실수로 되살아나도(#2341 AC2 델타 잔존), 혹은 배열/생성일
+            // 폴백만으로 우연히 같은 결과가 나와도 이 테스트는 통과하지 않는다(카디르 QA
+            // confound 제거 관행 계승, story #2341 AC2 선례).
+            id: 'e-stale', title: 'E-STALE(에픽 row 자체는 방금 갱신·소속 스토리는 조용)', status: 'active',
+            created_at: '2026-06-15T00:00:00Z', updated_at: '2026-08-27T00:00:00Z',
+            latest_story_activity_at: '2026-06-01T00:00:00Z', participant_ids: [],
             focal_story: {
               id: 's-stale', title: '오래된 진행중 스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
               proof_count: 0, auto_verify: null, gate: null,
@@ -153,12 +153,12 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
             },
           },
           {
-            // created_at도 배열순서도 e-stale보다 «뒤»(늦음) — tie-break가 순서/생성일이
-            // 아니라 updated_at 최신성으로 고르는지가 이 테스트의 핵심. tie-break를 지우면
-            // (roadmap.find가 배열 첫 매치를 집는 옛 로직으로 돌아가면) e-stale이 먼저 뽑혀
-            // 이 단언이 깨진다(카디르 재현 확認).
-            id: 'e-fresh', title: 'E-FRESH(방금 갱신, 배열순서상 뒤에 옴)', status: 'active',
-            created_at: '2026-06-15T00:00:00Z', updated_at: '2026-08-27T00:00:00Z', participant_ids: [],
+            // 에픽 row 자체(created_at/updated_at)는 e-stale보다 이르지만, 소속 스토리가
+            // 방금 움직였다(latest_story_activity_at가 가장 최신) — tie-break가 정확히 이
+            // 필드로 고르는지가 이 테스트의 핵심.
+            id: 'e-fresh', title: 'E-FRESH(에픽 row는 오래전·소속 스토리가 방금 움직임)', status: 'active',
+            created_at: '2026-05-01T00:00:00Z', updated_at: '2026-06-01T00:00:00Z',
+            latest_story_activity_at: '2026-08-27T00:00:00Z', participant_ids: [],
             focal_story: {
               id: 's-fresh', title: '방금 진행중 스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
               proof_count: 0, auto_verify: null, gate: null,
@@ -174,6 +174,41 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
     }));
     const data = await loadGlanceData('proj-recency-tiebreak');
     expect(data.heroStory?.id).toBe('s-fresh');
+  });
+
+  it('story #3126: an active epic whose focal_story has no latest_story_activity_at(무-non-done 스토리) loses the tie-break to one that has a real value', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/goals')) {
+        return jsonResponse([
+          {
+            id: 'e-null', title: 'E-NULL(소속 non-done 스토리 없음)', status: 'active',
+            created_at: '2026-07-01T00:00:00Z', updated_at: '2026-08-27T00:00:00Z',
+            latest_story_activity_at: null, participant_ids: [],
+            focal_story: {
+              id: 's-null', title: '스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
+              proof_count: 0, auto_verify: null, gate: null,
+              trust: { self_reported: false, human_verified: false, human_verified_by: null, human_verified_at: null },
+            },
+          },
+          {
+            id: 'e-real', title: 'E-REAL(실 값 존재)', status: 'active',
+            created_at: '2026-05-01T00:00:00Z', updated_at: '2026-05-01T00:00:00Z',
+            latest_story_activity_at: '2026-06-01T00:00:00Z', participant_ids: [],
+            focal_story: {
+              id: 's-real', title: '스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
+              proof_count: 0, auto_verify: null, gate: null,
+              trust: { self_reported: false, human_verified: false, human_verified_by: null, human_verified_at: null },
+            },
+          },
+        ]);
+      }
+      if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
+      if (url.startsWith('/api/team-members')) return jsonResponse([]);
+      if (url.startsWith('/api/glance/attention')) return jsonResponse({ items: [] });
+      return jsonResponse([]);
+    }));
+    const data = await loadGlanceData('proj-recency-null-tiebreak');
+    expect(data.heroStory?.id).toBe('s-real');
   });
 
   it('falls back to the first active epic when none of the active epics have a focal_story(진짜 0건 — 정직한 빈 상태 유지)', async () => {

--- a/apps/web/src/components/glance/load-glance-data.test.ts
+++ b/apps/web/src/components/glance/load-glance-data.test.ts
@@ -138,13 +138,16 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
       if (url.startsWith('/api/goals')) {
         return jsonResponse([
           {
-            // ⛔이 표본은 created_at·updated_at·배열순서 셋 다 e-fresh보다 «늦게»(더 최근)
-            // 둬서, 이 tie-break가 정말 latest_story_activity_at만 읽는지를 가른다 — 옛
-            // updated_at 기반 계산이 실수로 되살아나도(#2341 AC2 델타 잔존), 혹은 배열/생성일
-            // 폴백만으로 우연히 같은 결과가 나와도 이 테스트는 통과하지 않는다(카디르 QA
-            // confound 제거 관행 계승, story #2341 AC2 선례).
-            id: 'e-stale', title: 'E-STALE(에픽 row 자체는 방금 갱신·소속 스토리는 조용)', status: 'active',
-            created_at: '2026-06-15T00:00:00Z', updated_at: '2026-08-27T00:00:00Z',
+            // ⛔페드루 QA 재지적(2026-08-27, #2341 AC2와 같은 confound 클래스 재발) — «필드
+            // 축»(latest_story_activity_at vs updated_at) confound는 첫 판에서 죽였으나
+            // «배열순서 축»(scopeRoadmapEpics의 position-없음 created_at ASC 폴백) confound가
+            // 남아있었다. 이 표본은 e-stale(질 쪽)의 created_at을 e-fresh보다 «이르게» 둬서
+            // 배열상 e-stale이 «먼저» 오게 만든다 — sort를 통째로 제거해도(폴백 배열순서만
+            // 남아도) e-stale이 뽑히면 이 tie-break가 진짜 latest_story_activity_at으로
+            // 정렬한다는 걸 증명 못 한다. updated_at은 반대로(e-stale이 더 최근) 둬서 옛
+            // updated_at 기반 계산이 되살아나도 걸리게 한다(필드축+배열축 이중 confound 제거).
+            id: 'e-stale', title: 'E-STALE(배열상 먼저 옴·에픽 row updated_at은 최근·소속 스토리는 조용)', status: 'active',
+            created_at: '2026-05-01T00:00:00Z', updated_at: '2026-08-27T00:00:00Z',
             latest_story_activity_at: '2026-06-01T00:00:00Z', participant_ids: [],
             focal_story: {
               id: 's-stale', title: '오래된 진행중 스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
@@ -153,11 +156,11 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
             },
           },
           {
-            // 에픽 row 자체(created_at/updated_at)는 e-stale보다 이르지만, 소속 스토리가
-            // 방금 움직였다(latest_story_activity_at가 가장 최신) — tie-break가 정확히 이
-            // 필드로 고르는지가 이 테스트의 핵심.
-            id: 'e-fresh', title: 'E-FRESH(에픽 row는 오래전·소속 스토리가 방금 움직임)', status: 'active',
-            created_at: '2026-05-01T00:00:00Z', updated_at: '2026-06-01T00:00:00Z',
+            // 배열상 e-stale보다 «뒤»(created_at 늦음)·에픽 row updated_at도 e-stale보다 이르다
+            // — 배열순서 폴백으로도, updated_at 기반 계산으로도 이 쪽이 이길 수 없다. 오직
+            // latest_story_activity_at가 가장 최신이라는 사실만으로 뽑혀야 이 테스트가 유효.
+            id: 'e-fresh', title: 'E-FRESH(배열상 뒤에 옴·에픽 row updated_at은 오래전·소속 스토리가 방금 움직임)', status: 'active',
+            created_at: '2026-06-15T00:00:00Z', updated_at: '2026-06-01T00:00:00Z',
             latest_story_activity_at: '2026-08-27T00:00:00Z', participant_ids: [],
             focal_story: {
               id: 's-fresh', title: '방금 진행중 스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
@@ -181,8 +184,11 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
       if (url.startsWith('/api/goals')) {
         return jsonResponse([
           {
-            id: 'e-null', title: 'E-NULL(소속 non-done 스토리 없음)', status: 'active',
-            created_at: '2026-07-01T00:00:00Z', updated_at: '2026-08-27T00:00:00Z',
+            // e-null(질 쪽)의 created_at을 e-real보다 «이르게» 둬서 배열상 먼저 오게 만든다
+            // — sort를 통째로 제거하면 e-null이 뽑혀 이 단언이 깨진다(배열축 confound 제거,
+            // 위 tie-break 테스트와 같은 관행).
+            id: 'e-null', title: 'E-NULL(배열상 먼저 옴·소속 non-done 스토리 없음)', status: 'active',
+            created_at: '2026-05-01T00:00:00Z', updated_at: '2026-08-27T00:00:00Z',
             latest_story_activity_at: null, participant_ids: [],
             focal_story: {
               id: 's-null', title: '스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],
@@ -191,8 +197,8 @@ describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup
             },
           },
           {
-            id: 'e-real', title: 'E-REAL(실 값 존재)', status: 'active',
-            created_at: '2026-05-01T00:00:00Z', updated_at: '2026-05-01T00:00:00Z',
+            id: 'e-real', title: 'E-REAL(배열상 뒤에 옴·실 값 존재)', status: 'active',
+            created_at: '2026-07-01T00:00:00Z', updated_at: '2026-05-01T00:00:00Z',
             latest_story_activity_at: '2026-06-01T00:00:00Z', participant_ids: [],
             focal_story: {
               id: 's-real', title: '스토리', status: 'in-progress', assignee_id: null, assignee_ids: [],

--- a/apps/web/src/components/glance/load-glance-data.ts
+++ b/apps/web/src/components/glance/load-glance-data.ts
@@ -120,14 +120,15 @@ export async function loadGlanceData(projectId: string): Promise<GlanceData> {
   // 스토리 실재)을 두고 E-CHAT-REALTIME(진행중 스토리 0건)이 "지금"으로 뽑혀 초점 스트립이
   // 항상 빈 채로 뜬 사례가 실측됨. focal_story가 실재하는 active 에픽을 우선한다 — 그런 에픽이
   // 하나도 없을 때만(=진짜 0건) 기존처럼 첫 active로 폴백(정직한 빈 상태).
-  // story #2341 AC2 delta(2026-08-27) — "먼저 오는 하나"가 아니라 «가장 최근에 움직인 하나»로
-  // 좁힌다. 이전 주석은 "BeEpicListItem엔 updated_at이 없다(BE 계약에 없음)"고 적어 뒀으나
-  // 재그라운딩 결과 틀렸다 — `GoalResponse.updated_at`은 이미 존재했다(BE 신규 작업 0, FE
-  // 노출만 누락돼 있었다). focal_story 유무로 먼저 가르고, 같은 그룹 안에서 updated_at 내림차순
-  // tie-break. #2341 AC1의 근본 방향(㉡ "active"를 파생값化)은 아직 미결 — 이 tie-break는
-  // 그 방향이 확정되기 전까지의 완화(PR#2680 계열)에 그친다.
+  // story #3126(2026-08-27) — "먼저 오는 하나"가 아니라 «가장 최근에 움직인 하나»로 좁힌다.
+  // #2341 AC2 델타는 이 tie-break를 에픽 자신의 `updated_at`로 근사했으나(재료 부재로 인한
+  // 완화), 이제 BE 공유 파생 필드 `latest_story_activity_at`(에픽 소속 non-done 스토리
+  // updated_at MAX)로 정식 대체한다 — "에픽 row가 언제 손댔는가"가 아니라 "그 안 스토리가
+  // 지금 움직이는가"를 직접 잰다(옛 updated_at 기반 계산은 이 함수에서 완전히 걷었다).
+  // focal_story 유무로 먼저 가르고, 같은 그룹 안에서 latest_story_activity_at 내림차순
+  // tie-break(스토리 0건·done뿐 = null은 "움직임 없음"으로 최하위 취급).
   const byRecency = (a: RoadmapEpic, b: RoadmapEpic) =>
-    (rawById.get(b.id)?.updated_at ?? '').localeCompare(rawById.get(a.id)?.updated_at ?? '');
+    (rawById.get(b.id)?.latest_story_activity_at ?? '').localeCompare(rawById.get(a.id)?.latest_story_activity_at ?? '');
   const activeWithFocal = roadmap.filter((e) => e.roadmapStatus === 'active' && rawById.get(e.id)?.focal_story);
   const activeAny = roadmap.filter((e) => e.roadmapStatus === 'active');
   const activeEpic =

--- a/apps/web/src/services/glance.ts
+++ b/apps/web/src/services/glance.ts
@@ -53,11 +53,10 @@ export interface BeEpicListItem {
   title: string;
   status: string;
   created_at: string;
-  // story #2341 AC2 — `GoalResponse.updated_at`(backend/app/schemas/goal.py:96, `GoalWithGlanceResponse`가
-  // 상속하므로 `?include=glance` 응답에도 항상 실린다, git blame 6462ad1af4·2026-04-29부터 계약에
-  // 존재)를 tie-break 재료로 노출. load-glance-data.ts가 "active 에픽 52개 중 먼저 오는 하나"
-  // 문제를 이 필드로 좁힌다(#2341 AC1의 근본 방향(㉡ active를 파생값化)과는 별개 — 그게 오기
-  // 전까지의 완화).
+  // `GoalResponse.updated_at`(backend/app/schemas/goal.py:96) — 에픽 레코드 자체의 최종수정
+  // 시각. story #3126부터 load-glance-data.ts의 tie-break 재료는 이 필드가 아니라
+  // `latest_story_activity_at`(아래)로 옮겼다 — 에픽 row가 갱신됐다는 것과 "그 안 스토리가
+  // 지금 움직인다"는 것은 다른 축이라(#2341 AC1 그라운딩), 후자를 재는 이름으로 분리했다.
   updated_at: string;
   // E-GLANCE wedge #2(로드맵 조타): 큐레이션 순서(null=미조타). 아크는 이 순서를 소비만 한다
   // (드래그 없음). BE order_by=position 미지정/미보유 시 전부 null 취급 → 기존 created_at 정렬과
@@ -66,6 +65,11 @@ export interface BeEpicListItem {
   // story #2298(3단 웨이터폴 근절) — `?include=glance` 옵트인일 때만 실린다(미지정 시 undefined,
   // BE byte-identical 계약 그대로). participant_ids: 이 에픽의 고유 assignee_id 집합(캡 없음).
   participant_ids?: string[];
+  // story #3126 Phase 1(`GoalWithGlanceResponse.latest_story_activity_at`) — 이 에픽 소속
+  // non-done 스토리 updated_at 최댓값(스토리 0건·done뿐이면 null). "먼저 오는 하나"가 아니라
+  // «지금 실제로 움직이는 하나»를 고르는 load-glance-data.ts tie-break의 정식 재료 — 옛
+  // `updated_at`(#2341 AC2 완화) 기반 tie-break를 이 필드로 대체한다(구현 제약③: 옛 계산 잔존 0).
+  latest_story_activity_at?: string | null;
   focal_story?: BeFocalStory | null;
 }
 

--- a/backend/app/repositories/goal.py
+++ b/backend/app/repositories/goal.py
@@ -172,14 +172,31 @@ class GoalRepository(BaseRepository[Goal]):
         데이터)를 갖고 평가된다(`GlanceFocalStory` docstring 참조 — 기존엔 재료가 없어 죽어
         있던 분기). story #2303부터 `focal_story`가 `/api/glance/hero?story_id=`가 주던
         9필드(assignee_ids·proof_count·auto_verify·gate.*·trust.*)까지 싣는다 — 전부 픽된
-        focal story id 집합(페이지 전체 goal 기준)으로 배치 조회, N+1 없음."""
+        focal story id 집합(페이지 전체 goal 기준)으로 배치 조회, N+1 없음.
+
+        latest_story_activity_at: story #3126 — 에픽별 non-done story updated_at 최댓값
+        (없으면 None). `derive-next-maker.ts`의 기존 client-side 계산과 동일 정의를 BE로
+        승격 — GROUP BY 단일 쿼리, N+1 없음."""
         for goal in goals:
             goal.participant_ids = []  # type: ignore[attr-defined]
             goal.focal_story = None  # type: ignore[attr-defined]
+            goal.latest_story_activity_at = None  # type: ignore[attr-defined]
         if not goals:
             return
 
         goal_ids = [g.id for g in goals]
+
+        activity_rows = await self.session.execute(
+            select(Story.epic_id, func.max(Story.updated_at)).where(
+                Story.epic_id.in_(goal_ids), Story.org_id == self.org_id,
+                Story.deleted_at.is_(None), Story.status != "done",
+            ).group_by(Story.epic_id)
+        )
+        activity_by_goal: dict[uuid.UUID, datetime] = dict(activity_rows.all())
+        for goal in goals:
+            latest = activity_by_goal.get(goal.id)
+            if latest is not None:
+                goal.latest_story_activity_at = latest  # type: ignore[attr-defined]
 
         participant_rows = await self.session.execute(
             select(Story.epic_id, Story.assignee_id).where(

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -120,6 +120,7 @@ async def get_epics_progress_lane(
         epics={k: EpicProgressLane.model_validate(v) for k, v in result["lanes"].items()},
         zones={k: EpicZoneCounts.model_validate(v) for k, v in result["zones"].items()},
         stall_threshold_hours=168,
+        dormancy_threshold_hours=720,  # story #3126 — 30일, derive-next-maker.ts 옛 THIRTY_DAYS_MS와 동치
         stories_without_epic=result["stories_without_epic"],
     )
 

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -142,6 +142,12 @@ class EpicsProgressLaneResponse(BaseModel):
     zones: dict[str, EpicZoneCounts]
     stall_threshold_hours: int
     stories_without_epic: int
+    # story #3126(#2341 AC1 후속, 페드루 판정 2026-08-27) — stall_threshold_hours(168h)와
+    # 「같은 질문 두 값」이 아니다: stall=«단기 주의 신호»(story 하나가 조용함), dormancy=
+    # «장기 활동 분류»(goal 전체가 아직 사는가 — fold/은퇴 판정). 세부가 먼저 시들고 상위가
+    # 나중에 은퇴하는 위계라 값이 다른 게 정직하다 — 임계는 여기서만(BE 단일 소스),
+    # FE `derive-next-maker.ts`의 옛 하드코딩 30일을 이 값으로 대체한다.
+    dormancy_threshold_hours: int
 
 
 class FlowNode(BaseModel):

--- a/backend/app/schemas/goal.py
+++ b/backend/app/schemas/goal.py
@@ -195,9 +195,16 @@ class GoalWithGlanceResponse(GoalResponse):
 
     participant_ids: 이 goal(에픽)에 연결된 story들의 고유 assignee_id 집합(FE
     `deriveCollaboration` 이관 — "참여=presence만, 개수 집계 0"과 동일 의미. 집합 계산이라
-    부분 반환("N건 더")이 불가능 — 캡을 두면 그 자체로 값이 틀려진다, 그래서 캡을 두지 않는다."""
+    부분 반환("N건 더")이 불가능 — 캡을 두면 그 자체로 값이 틀려진다, 그래서 캡을 두지 않는다.
+
+    latest_story_activity_at: story #3126(#2341 AC1 후속, ㉡′ — PO 승인 2026-08-27) — 이
+    goal 소속 non-done story의 updated_at 최댓값(없으면 None). 이름에 일부러 "active"를
+    안 쓴다(Goal.status='active'와의 겸직이 이번 병의 뿌리였다 — 재는 값 그대로의 이름).
+    판정(임계 적용)은 소비처(FE) 몫 — 이 필드는 원값만 정직하게 노출한다. `derive-next-maker.ts`
+    의 기존 client-side 계산(비-done story updatedAt MAX)과 동일 정의를 BE로 승격한 것."""
     participant_ids: list[uuid.UUID] = []
     focal_story: GlanceFocalStory | None = None
+    latest_story_activity_at: datetime | None = None
 
 
 class GoalProgressResponse(BaseModel):

--- a/backend/tests/test_2224_epics_progress_lane_realdb.py
+++ b/backend/tests/test_2224_epics_progress_lane_realdb.py
@@ -146,6 +146,10 @@ async def test_epics_progress_lane_buckets_correctly_and_one_call():
             # 없어 blocked에 안 잡히고, status=in-progress라 in_progress로 떨어져야 한다.
             assert sum(lane.values()) == 6, "네 칸(진행/대기/막힘/멈춤) + other == total_stories 항상 성립해야 함"
             assert body["stall_threshold_hours"] == 168
+            # story #3126 — stall(168h, story-level 단기 주의)과 dormancy(720h=30일, goal-level
+            # 장기 활동 분류)는 「같은 질문 두 값」이 아니다(페드루 판정 2026-08-27) — 값이
+            # 다른 게 정직하다.
+            assert body["dormancy_threshold_hours"] == 720
             assert body["stories_without_epic"] == 1, "epic 없는 story(story_no_epic) 1건이 응답에 실려야 함"
             assert call_count["n"] == 1, f"repo 메서드가 {call_count['n']}번 불림(N+1 의심)"
 

--- a/backend/tests/test_3126_latest_story_activity_realdb.py
+++ b/backend/tests/test_3126_latest_story_activity_realdb.py
@@ -1,0 +1,269 @@
+"""story #3126(#2341 AC1 후속, ㉡′ — PO 승인 2026-08-27) —
+`GET /api/v2/goals?include=glance`의 `latest_story_activity_at` 실PG 검증.
+
+계약 핵심:
+  ①이 goal 소속 non-done story의 updated_at 최댓값(있으면)
+  ②story가 전부 done이거나 0건이면 None(모름을 임의값으로 위조하지 않는다)
+  ③done story의 updated_at은 최댓값 계산에서 제외된다(설령 그게 더 최근이어도)
+  ④`include=glance` 없으면 노출되지 않는다(#2298의 byte-identical 계약과 동일 축)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _make_org(session, name="Org"):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _make_project(session, org_id, name="P"):
+    from app.models.project import Project
+    project = Project(id=uuid.uuid4(), org_id=org_id, name=name)
+    session.add(project)
+    await session.commit()
+    return project
+
+
+async def _make_human_member(session, org_id, project_id, name="Human"):
+    from app.models.user import User
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.member import Member
+
+    user = User(id=uuid.uuid4(), email=f"u-{uuid.uuid4().hex[:8]}@test.local", hashed_password="x")
+    session.add(user)
+    await session.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role="member")
+    session.add(om)
+    await session.flush()
+    m = Member(id=om.id, org_id=org_id, type="human", user_id=user.id, name=name)
+    session.add(m)
+    await session.flush()
+    session.add(ProjectAccess(project_id=project_id, org_member_id=om.id, member_id=m.id, role="member"))
+    await session.commit()
+    return m.id, user.id
+
+
+async def _make_goal(session, org_id, project_id, title="Goal"):
+    from app.models.pm import Goal
+    goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status="active")
+    session.add(goal)
+    await session.commit()
+    return goal
+
+
+async def _make_story(session, org_id, project_id, epic_id, status="backlog", title="Story", updated_at=None):
+    from app.models.pm import Story
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, epic_id=epic_id,
+        title=title, status=status,
+    )
+    session.add(story)
+    await session.commit()
+    if updated_at is not None:
+        # updated_at은 onupdate=MONOTONIC_UPDATED_AT_ONUPDATE라 insert 값을 그대로 두지 않는다
+        # (server_default=func.now()) — 표본을 정확한 시각으로 통제하려면 별도 UPDATE로 덮는다.
+        from sqlalchemy import update
+        from app.models.pm import Story as StoryModel
+        await session.execute(update(StoryModel).where(StoryModel.id == story.id).values(updated_at=updated_at))
+        await session.commit()
+        await session.refresh(story)
+    return story
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def test_no_stories_yields_none_not_a_fabricated_timestamp():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            await _make_goal(s, org.id, project.id)
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/goals", params={"project_id": str(project.id), "include": "glance"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()[0]["latest_story_activity_at"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_only_done_stories_yields_none_done_excluded_from_max():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            # done story의 updated_at이 아무리 최근이어도(오늘 방금 done 처리됐어도) 최댓값
+            # 계산에서 빠져야 한다 — "닫힌 것"은 "지금 움직이는 중"이 아니다.
+            await _make_story(
+                s, org.id, project.id, goal.id, status="done", title="Done",
+                updated_at=datetime.now(timezone.utc),
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/goals", params={"project_id": str(project.id), "include": "glance"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()[0]["latest_story_activity_at"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_picks_max_updated_at_among_non_done_stories_only():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        now = datetime.now(timezone.utc)
+        older = now - timedelta(days=10)
+        newest_non_done = now - timedelta(hours=1)
+        newest_overall_but_done = now  # 가장 최근이지만 done — 뽑히면 안 됨(양성대조 겸함).
+
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            await _make_story(s, org.id, project.id, goal.id, status="backlog", title="Old", updated_at=older)
+            await _make_story(
+                s, org.id, project.id, goal.id, status="in-progress", title="Newest-non-done",
+                updated_at=newest_non_done,
+            )
+            await _make_story(
+                s, org.id, project.id, goal.id, status="done", title="Newest-but-done",
+                updated_at=newest_overall_but_done,
+            )
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/goals", params={"project_id": str(project.id), "include": "glance"},
+            )
+            assert resp.status_code == 200, resp.text
+            got = resp.json()[0]["latest_story_activity_at"]
+            assert got is not None
+            got_dt = datetime.fromisoformat(got.replace("Z", "+00:00"))
+            # 초 단위 비교(직렬화 round-trip 오차 감안) — done story의 시각(newest_overall_but_done)이
+            # 아니라 non-done 중 최댓값(newest_non_done)과 일치해야 한다.
+            assert abs((got_dt - newest_non_done).total_seconds()) < 2
+            assert abs((got_dt - newest_overall_but_done).total_seconds()) > 1800
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def test_without_include_glance_the_field_is_absent():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _make_org(s)
+            project = await _make_project(s, org.id)
+            caller_id, caller_user_id = await _make_human_member(s, org.id, project.id)
+            goal = await _make_goal(s, org.id, project.id)
+            await _make_story(s, org.id, project.id, goal.id, status="in-progress", title="S")
+
+        await _setup_app_human(app, Session, caller_user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/goals", params={"project_id": str(project.id)})
+            assert resp.status_code == 200, resp.text
+            assert "latest_story_activity_at" not in resp.json()[0]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
[SID:3126]

## 배경
#2341 AC1 사이징 그라운딩(2026-08-27) 결과 — Goal.status='active'가 두 축을 겸직 中: ⓐlifecycle(BE `command_center.py`×3·`loop_measure_due.py`×2가 `measure_after` 스케줄링 게이팅에 이미 사용) ⓑ"지금 정말 움직이는가"(FE가 원하는 것). FE 두 화면(`derive-next-maker.ts`·`load-glance-data.ts`)이 ⓑ를 서로 다르게 계산 중이던 것도 실증(같은 병 2회).

## 확定 방향 = ㉡′ (PO 승인 2026-08-27 09:08)
- `Goal.status` 컬럼과 BE lifecycle 소비처 5곳은 **무변경**.
- `derive-next-maker.ts`가 이미 client-side로 계산 중이던 "goal 소속 non-done story updated_at 최댓값" 정의를 BE 공유 필드로 승격 — FE 4곳이 이후 이 필드로 전환(Phase 2, 후속 PR).

## 이 PR의 스코프 (Phase 1만)
- `GoalWithGlanceResponse.latest_story_activity_at: datetime | None` 신설 — `?include=glance` 옵트인 전용, 기존 `GoalResponse` 계약 무변경(byte-identical 유지).
- `GoalRepository.attach_glance_aggregates`에 단일 GROUP BY 쿼리 추가(N+1 없음, `participant_ids`/`focal_story`와 동일 배치조회 패턴).
- 구현 제약①(이름에 "active" 미포함) 준수 — status와의 겸직이 이번 병의 뿌리였다.

## 검증
- 신규 realdb 테스트 4건: 무스토리→None · done만→None(done 제외 확認) · non-done 중 MAX 정확 선택(done의 더 최근 updated_at이 안 섞이는 양성대조 포함) · `include` 없으면 필드 자체가 부재.
- mutation 검증 — 계산 로직 제거 시 3/4은 원래도 None이라 그대로 통과(가짜 세이프티넷 아님을 확認), MAX-선택 테스트 1건만 genuine RED → 복원.
- 인접 `test_2298_goals_glance_include_realdb.py`+`test_2303_goals_glance_focal_story_fields_realdb.py` 21/21 green(간섭 없음).
- `pytest --collect-only` 8151건 정상 수집(import 파손 0).

## 후속(Phase 2, 별도 PR) — 팀 확認 필요한 미결 1건
구현 제약②: 임계는 신설하지 않고 기존 `stall_threshold_hours`(168h, `epics-progress-lane`이 이미 나르는 상수)와 단일 소스 정합해야 하는데, `derive-next-maker.ts`의 `deriveActiveLaneGoals`는 **하드코딩 30일(720h)**을 쓴다 — 두 임계가 같은 "얼마나 조용해야 정체인가" 질문에 다른 값으로 공존 中. 이 PR은 원값(`latest_story_activity_at`)만 노출하고 판정(임계 적용)은 아직 얹지 않았다 — 어느 쪽이 정본인지 유나·PO 확認 필요(스토리 본문 구현 제약②). 확定되면 Phase 2에서 FE 4곳(goals-client 뱃지/카운트·glance.ts anchor·load-glance-data의 #2341 임시 tie-break 대체·derive-next-maker.ts 통합) 전환 + "옛 계산 잔존 0" 검산(구현 제약③).