### PR TITLE
[SID:3121] oauth_handoff_codes callback_mode+return_uri (AC1 BE 절반)

### DIFF
--- a/apps/web/src/app/api/auth/callback/[provider]/route.test.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.test.ts
@@ -92,8 +92,58 @@ describe('GET /api/auth/callback/[provider] — native OAuth-handoff branch', ()
     const [issueUrl, issueOpts] = mockFetch.mock.calls[1] as [string, RequestInit];
     expect(issueUrl).toContain('/api/v2/internal/auth/oauth-handoff/issue');
     expect(issueUrl).not.toContain('native-bootstrap');
-    const sentBody = JSON.parse(issueOpts.body as string) as { user_id: string; code_challenge: string };
-    expect(sentBody).toEqual({ user_id: 'user-123', code_challenge: 'a'.repeat(43) });
+    const sentBody = JSON.parse(issueOpts.body as string) as {
+      user_id: string; code_challenge: string; callback_mode: string; return_uri: string;
+    };
+    // story #3121 AC1 — callback_mode 쿠키 부재 시 https로 기본 유도(구버전 클라 대비).
+    expect(sentBody).toEqual({
+      user_id: 'user-123',
+      code_challenge: 'a'.repeat(43),
+      callback_mode: 'https',
+      return_uri: 'https://dev-app.sprintable.ai/native/oauth-return',
+    });
+  });
+
+  // story #3121 AC1 — custom_scheme 쿠키가 있으면 issue 호출에 그대로 실어 보낸다(https 기본값
+  // 오버라이드). return_uri는 App.js OAUTH_RETURN_SCHEME_URL과 byte-exact 고정값이라 별도
+  // env(MOBILE_APP_LINK_ORIGIN)에 안 흔들린다 — 그것도 같이 확認.
+  it('with callback_mode=custom_scheme cookie: sends custom_scheme + fixed ai.sprintable return_uri to issue', async () => {
+    stubCookies({ oauth_native_challenge_google: 'a'.repeat(43), oauth_native_callback_mode_google: 'custom_scheme' });
+    process.env['MOBILE_APP_LINK_ORIGIN'] = 'https://app.sprintable.ai'; // custom_scheme엔 무영향이어야 함
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { access_token: fakeJwt({ sub: 'user-123' }), refresh_token: 'legacy-rt' } }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ code: 'handoff-code-xyz' }) });
+
+    await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+    const [, issueOpts] = mockFetch.mock.calls[1] as [string, RequestInit];
+    const sentBody = JSON.parse(issueOpts.body as string) as { callback_mode: string; return_uri: string };
+    expect(sentBody.callback_mode).toBe('custom_scheme');
+    expect(sentBody.return_uri).toBe('ai.sprintable:/oauth-return');
+  });
+
+  // 자기검증(뮤테이션) — 쿠키 값이 스키마 밖(임의 문자열)이면 https로 안전 폴백해야지, 그
+  // 값을 그대로 흘려보내면 안 된다(BE가 Literal["https","custom_scheme"]로 거부하는 자리를
+  // BFF가 미리 안 막으면 native 로그인 전체가 400으로 죽는다).
+  it('with an invalid callback_mode cookie value: falls back to https (never forwards garbage)', async () => {
+    stubCookies({ oauth_native_challenge_google: 'a'.repeat(43), oauth_native_callback_mode_google: 'not-a-real-mode' });
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { access_token: fakeJwt({ sub: 'user-123' }), refresh_token: 'legacy-rt' } }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ code: 'x' }) });
+
+    await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+    const [, issueOpts] = mockFetch.mock.calls[1] as [string, RequestInit];
+    const sentBody = JSON.parse(issueOpts.body as string) as { callback_mode: string };
+    expect(sentBody.callback_mode).toBe('https');
+  });
+
+  it('with a native challenge cookie: deletes the callback_mode cookie (single-use, like the other oauth_* cookies)', async () => {
+    stubCookies({ oauth_native_challenge_google: 'a'.repeat(43), oauth_native_callback_mode_google: 'custom_scheme' });
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { access_token: fakeJwt({ sub: 'user-123' }), refresh_token: 'legacy-rt' } }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ code: 'x' }) });
+
+    await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+    expect(h.cookiesDeleteMock).toHaveBeenCalledWith('oauth_native_callback_mode_google');
   });
 
   it('with a native challenge cookie: redirects to the App Link return URL with the handoff code, no-store + no-referrer', async () => {

--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -4,6 +4,7 @@ import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 import { safeNextPath } from '@/lib/auth/session-redirect';
 import { resolveAppUrl } from '@/services/app-url';
+import { isOAuthCallbackMode, expectedReturnUri } from '@/lib/auth/oauth-callback-mode';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 // e-mobile-oauth-native-handoff-contract §2: returnUrl = 검증된 App Link. dev/prod 도메인·서명
@@ -77,6 +78,13 @@ async function handleCallback(request: Request, provider: string, code: string |
   // e-mobile-oauth-native-handoff-contract §7.4/§5 — 격리 rail(오르테가 확定, /auth/native
   // 무접촉). native OAuth-start에서만 세팅되는 challenge — 있으면 이 콜백도 native 취급.
   const nativeChallenge = cookieStore.get(`oauth_native_challenge_${provider}`)?.value ?? null;
+  // story #3121 AC1 — 모바일이 OAuth 시작 시 선택한 호환 모드(계약 §2). 쿠키 부재/형식오류는
+  // https로 기본 유도(BE Phase 1 확장-축소 계약과 동일 원칙 — 조용히 안 채우고 기본값 하나로
+  // 수렴). 값 자체(return_uri 문자열)는 여기서 고정 매핑으로 계산 — 클라 입력을 URI로 안 믿는다.
+  const nativeCallbackMode = (() => {
+    const raw = cookieStore.get(`oauth_native_callback_mode_${provider}`)?.value ?? null;
+    return isOAuthCallbackMode(raw) ? raw : 'https';
+  })();
   // story #3122(계정 연결) — auth/link/route.ts만 세팅하는 단명 쿠키. provider가 돌려주는
   // code/state 자체엔 "로그인이냐 연결이냐" 구분이 없어(authorize 요청 파라미터가 로그인과
   // 동일하게 생겼다, 의도된 설계) 이 쿠키가 유일한 분기 신호다.
@@ -86,6 +94,7 @@ async function handleCallback(request: Request, provider: string, code: string |
   cookieStore.delete(`oauth_invite_token_${provider}`);
   cookieStore.delete(`oauth_next_${provider}`);
   cookieStore.delete(`oauth_native_challenge_${provider}`);
+  cookieStore.delete(`oauth_native_callback_mode_${provider}`);
   cookieStore.delete(`oauth_link_${provider}`);
 
   // ⛔통과 조건은 원래와 동일(storedState 존재 AND 일치) — 분기는 로그용일 뿐, 검증 자체는
@@ -154,13 +163,20 @@ async function handleCallback(request: Request, provider: string, code: string |
       return NextResponse.redirect(`${origin}/login?error=oauth_native_issue_failed`);
     }
     const internalSecret = process.env['FIREBASE_BFF_INTERNAL_SECRET'];
+    // story #3121 AC1 — return_uri는 고정 매핑으로 계산(클라 입력 아님). APP_LINK_ORIGIN()은
+    // 기존 App Link 리다이렉트 목적지 계산과 동일 출처(아래 returnUrl 참조) — 새 소스 안 만든다.
     const issueRes = await fetch(`${FASTAPI_URL()}/api/v2/internal/auth/oauth-handoff/issue`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         ...(internalSecret ? { Authorization: `Bearer ${internalSecret}` } : {}),
       },
-      body: JSON.stringify({ user_id: userId, code_challenge: nativeChallenge }),
+      body: JSON.stringify({
+        user_id: userId,
+        code_challenge: nativeChallenge,
+        callback_mode: nativeCallbackMode,
+        return_uri: expectedReturnUri(nativeCallbackMode, APP_LINK_ORIGIN()),
+      }),
     }).catch(() => null);
 
     if (!issueRes || !issueRes.ok) {

--- a/apps/web/src/app/auth/login/route.test.ts
+++ b/apps/web/src/app/auth/login/route.test.ts
@@ -72,4 +72,30 @@ describe('GET /auth/login — native OAuth-start branch', () => {
     const cookieNames = h.cookiesSetMock.mock.calls.map((c) => c[0] as string);
     expect(cookieNames).not.toContain('oauth_native_challenge_google');
   });
+
+  // story #3121 AC1 — 모바일이 OAuth 시작 전 정적으로 고른 호환 모드를 그대로 쿠키에 심는다.
+  it('native=1 + callback_mode=custom_scheme: sets the callback_mode cookie with the exact value', async () => {
+    await GET(makeRequest({ provider: 'google', native: '1', code_challenge: VALID_CHALLENGE, callback_mode: 'custom_scheme' }));
+    const call = h.cookiesSetMock.mock.calls.find((c) => c[0] === 'oauth_native_callback_mode_google');
+    expect(call).toBeDefined();
+    expect(call?.[1]).toBe('custom_scheme');
+  });
+
+  it('native=1 + callback_mode=https: sets the callback_mode cookie', async () => {
+    await GET(makeRequest({ provider: 'google', native: '1', code_challenge: VALID_CHALLENGE, callback_mode: 'https' }));
+    const call = h.cookiesSetMock.mock.calls.find((c) => c[0] === 'oauth_native_callback_mode_google');
+    expect(call?.[1]).toBe('https');
+  });
+
+  it('invalid callback_mode value: does not set the cookie (콜백이 https 기본값으로 유도)', async () => {
+    await GET(makeRequest({ provider: 'google', native: '1', code_challenge: VALID_CHALLENGE, callback_mode: 'android' }));
+    const cookieNames = h.cookiesSetMock.mock.calls.map((c) => c[0] as string);
+    expect(cookieNames).not.toContain('oauth_native_callback_mode_google');
+  });
+
+  it('callback_mode present but native flag absent: no callback_mode cookie set (legacy flow unchanged)', async () => {
+    await GET(makeRequest({ provider: 'google', code_challenge: VALID_CHALLENGE, callback_mode: 'custom_scheme' }));
+    const cookieNames = h.cookiesSetMock.mock.calls.map((c) => c[0] as string);
+    expect(cookieNames).not.toContain('oauth_native_callback_mode_google');
+  });
 });

--- a/apps/web/src/app/auth/login/route.ts
+++ b/apps/web/src/app/auth/login/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { resolveAppUrl } from '@/services/app-url';
 import { oauthCookieOptions } from '@/lib/auth/oauth-cookies';
+import { isOAuthCallbackMode } from '@/lib/auth/oauth-callback-mode';
 
 const FASTAPI_BASE = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -16,6 +17,10 @@ export async function GET(request: Request) {
   // issue 호출에 씀(격리 rail, /auth/native 무접촉).
   const native = searchParams.get('native') === '1';
   const codeChallenge = searchParams.get('code_challenge');
+  // story #3121 AC1 — 모바일이 OAuth 시작 전 정적으로 결정한 호환 모드(계약 §2). 값 자체가
+  // 아니라 셸렉터일 뿐이라 여기선 형식만 검증(https|custom_scheme) — 실제 return_uri 문자열은
+  // 콜백(callback/[provider]/route.ts)에서 lib/auth/oauth-callback-mode 고정 매핑으로 계산한다.
+  const callbackModeParam = searchParams.get('callback_mode');
   const origin = resolveAppUrl(null);
 
   // story #3118(Sign in with Apple) — apple 추가. 노출 여부(iOS/macOS 셸 한정)는 로그인
@@ -53,6 +58,12 @@ export async function GET(request: Request) {
   // 핸드오프 자체를 시작하지 않는다(방어적, 최종 검증은 BE issue가 authoritative).
   if (native && codeChallenge && /^[A-Za-z0-9_-]{43,}$/.test(codeChallenge)) {
     cookieStore.set(`oauth_native_challenge_${provider}`, codeChallenge, cookieOpts);
+    // story #3121 AC1 — 형식이 다르면(구버전 클라 미전송 포함) 조용히 기본값(https)으로 유도
+    // 되게 쿠키 자체를 세팅 안 한다(콜백에서 쿠키 부재 = https). 잘못된 값은 저장하지 않는다
+    // (오배선을 그대로 실어 나르지 않는다).
+    if (isOAuthCallbackMode(callbackModeParam)) {
+      cookieStore.set(`oauth_native_callback_mode_${provider}`, callbackModeParam, cookieOpts);
+    }
   }
 
   return NextResponse.redirect(url);

--- a/apps/web/src/app/auth/oauth-handoff/route.test.ts
+++ b/apps/web/src/app/auth/oauth-handoff/route.test.ts
@@ -1,7 +1,14 @@
 // e-mobile-oauth-native-handoff-contract §5/§6/§10 — 격리 rail consume 착지 회귀가드.
-// 핵심 불변식: (1) FIREBASE_OAUTH_HANDOFF_ENABLED 기본 off, (2) code+code_verifier만 받고
-// 다른 필드는 계약에 없음(installation_id 등 attested 필드가 여기 섞이면 격리 위반),
-// (3) mint 대상=레거시 sp_at/sp_rt(Firebase 아님), (4) 실패는 전부 동일 401(enumeration 방지).
+// 핵심 불변식: (1) FIREBASE_OAUTH_HANDOFF_ENABLED 기본 off, (2) code+code_verifier(+#3121
+// AC1 callback_mode)만 받고 다른 필드는 계약에 없음(installation_id 등 attested 필드가
+// 여기 섞이면 격리 위반), (3) mint 대상=레거시 sp_at/sp_rt(Firebase 아님), (4) 실패는 전부
+// 동일 401(enumeration 방지).
+//
+// story #3121 AC1 추가분 — 이 라우트는 issue 시점 쿠키와 연속성이 없는 웹뷰 top-level POST라
+// callback_mode는 요청 body에서만 온다(§ route.ts 상단 주석). 핵심: (5) callback_mode 없으면
+// (구버전 클라) BE 호출에서 그 필드 자체를 뺀다(반쪽만 보내지 않는다 — BE Phase 1 계약과
+// 대칭), (6) 있으면 형식 검증 후 그대로 전달+return_uri는 고정 매핑으로 계산(클라 입력 URI를
+// 안 믿는다), (7) 형식이 틀리면 거부한다.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const h = vi.hoisted(() => ({ csrfCheck: vi.fn() }));
@@ -30,7 +37,7 @@ function makeUrlencodedRequest(fields: Record<string, string>): Request {
   });
 }
 
-const ENV_KEYS = ['FIREBASE_OAUTH_HANDOFF_ENABLED', 'FIREBASE_BFF_INTERNAL_SECRET', 'NEXT_PUBLIC_FASTAPI_URL'];
+const ENV_KEYS = ['FIREBASE_OAUTH_HANDOFF_ENABLED', 'FIREBASE_BFF_INTERNAL_SECRET', 'NEXT_PUBLIC_FASTAPI_URL', 'MOBILE_APP_LINK_ORIGIN'];
 
 describe('POST /auth/oauth-handoff', () => {
   beforeEach(() => {
@@ -169,5 +176,57 @@ describe('POST /auth/oauth-handoff', () => {
     mockFetch.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt' }) });
     const res = await POST(makeJsonRequest({ code: 'c', code_verifier: 'v', redirect_path: '//evil.com/phish' }));
     expect(res.headers.get('location')).toBe('http://localhost:3108/glance');
+  });
+
+  // ── story #3121 AC1 — callback_mode consume 절반 ──────────────────────────────
+  describe('callback_mode (#3121 AC1)', () => {
+    it('without callback_mode (legacy client): omits callback_mode/return_uri from the BE call entirely (never sends just one)', async () => {
+      process.env['FIREBASE_OAUTH_HANDOFF_ENABLED'] = 'true';
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt' }) });
+      await POST(makeJsonRequest({ code: 'c', code_verifier: 'v' }));
+      const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const sentBody = JSON.parse(opts.body as string) as Record<string, unknown>;
+      expect(sentBody).not.toHaveProperty('callback_mode');
+      expect(sentBody).not.toHaveProperty('return_uri');
+    });
+
+    it('with callback_mode=https: forwards callback_mode + the fixed https return_uri', async () => {
+      process.env['FIREBASE_OAUTH_HANDOFF_ENABLED'] = 'true';
+      process.env['MOBILE_APP_LINK_ORIGIN'] = 'https://dev-app.sprintable.ai';
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt' }) });
+      await POST(makeJsonRequest({ code: 'c', code_verifier: 'v', callback_mode: 'https' }));
+      const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const sentBody = JSON.parse(opts.body as string) as { callback_mode: string; return_uri: string };
+      expect(sentBody.callback_mode).toBe('https');
+      expect(sentBody.return_uri).toBe('https://dev-app.sprintable.ai/native/oauth-return');
+    });
+
+    it('with callback_mode=custom_scheme: forwards the byte-exact ai.sprintable return_uri, unaffected by MOBILE_APP_LINK_ORIGIN', async () => {
+      process.env['FIREBASE_OAUTH_HANDOFF_ENABLED'] = 'true';
+      process.env['MOBILE_APP_LINK_ORIGIN'] = 'https://app.sprintable.ai';
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt' }) });
+      await POST(makeJsonRequest({ code: 'c', code_verifier: 'v', callback_mode: 'custom_scheme' }));
+      const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const sentBody = JSON.parse(opts.body as string) as { callback_mode: string; return_uri: string };
+      expect(sentBody.callback_mode).toBe('custom_scheme');
+      expect(sentBody.return_uri).toBe('ai.sprintable:/oauth-return');
+    });
+
+    it('with an invalid callback_mode value: rejects the request (never forwards garbage to BE)', async () => {
+      process.env['FIREBASE_OAUTH_HANDOFF_ENABLED'] = 'true';
+      const res = await POST(makeJsonRequest({ code: 'c', code_verifier: 'v', callback_mode: 'android' }));
+      expect(res.status).toBe(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    // 자기검증(뮤테이션) — "반쪽만 보내면 안 된다" 불변식이 실제로 지켜지는지: callback_mode가
+    // 없을 때 return_uri **혼자** 새 나가면 안 된다(半-공급은 BE Literal 스키마를 아예 못 만족).
+    it('mut: never sends return_uri without callback_mode, or vice versa', async () => {
+      process.env['FIREBASE_OAUTH_HANDOFF_ENABLED'] = 'true';
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt' }) });
+      await POST(makeJsonRequest({ code: 'c', code_verifier: 'v' }));
+      const sentBody = JSON.parse((mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string) as Record<string, unknown>;
+      expect('callback_mode' in sentBody).toBe('return_uri' in sentBody);
+    });
   });
 });

--- a/apps/web/src/app/auth/oauth-handoff/route.ts
+++ b/apps/web/src/app/auth/oauth-handoff/route.ts
@@ -27,8 +27,13 @@ import { verifyCsrfOrigin } from '@/lib/auth/csrf';
 import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { resolveAppUrl } from '@/services/app-url';
+import { isOAuthCallbackMode, expectedReturnUri } from '@/lib/auth/oauth-callback-mode';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+// story #3121 AC1 — issue 시점(callback/[provider]/route.ts)과 동일 출처. 이 라우트는 웹뷰
+// top-level POST라 쿠키/세션 연속성이 없다(§ 상단 주석) — 모바일이 code/code_verifier와
+// **같은 요청에** callback_mode를 실어 보내야만(App.js) issue 시점 값과 대조가 가능하다.
+const APP_LINK_ORIGIN = () => process.env['MOBILE_APP_LINK_ORIGIN'] ?? 'https://dev-app.sprintable.ai';
 
 function logHandoffFailure(reason: string): void {
   // §10.4: code/verifier/원문 절대 로그 금지 — reason enum만.
@@ -45,6 +50,9 @@ function handoffFailedResponse(): NextResponse {
 interface HandoffBody {
   code?: unknown;
   code_verifier?: unknown;
+  // story #3121 AC1 — 옵션(구버전 클라 대비). 있으면 형식 검증 후 BE에 그대로 전달, 없으면
+  // 필드 자체를 BE 호출에서 뺀다(BE Phase 1 확장-축소 계약 — 둘 다 없으면 https로 유도).
+  callback_mode?: unknown;
 }
 
 async function parseBody(request: Request): Promise<HandoffBody | null> {
@@ -55,7 +63,11 @@ async function parseBody(request: Request): Promise<HandoffBody | null> {
     }
     const raw = await request.text();
     const params = new URLSearchParams(raw);
-    return { code: params.get('code') ?? undefined, code_verifier: params.get('code_verifier') ?? undefined };
+    return {
+      code: params.get('code') ?? undefined,
+      code_verifier: params.get('code_verifier') ?? undefined,
+      callback_mode: params.get('callback_mode') ?? undefined,
+    };
   } catch {
     return null;
   }
@@ -83,6 +95,21 @@ export async function POST(request: Request) {
     return handoffFailedResponse();
   }
 
+  // story #3121 AC1 — 있으면 형식 검증(값 자체가 아니라 셸렉터), 없으면 필드 자체를 BE 호출에서
+  // 뺀다(구버전 클라 대비 — BE Phase 1이 "둘 다 없으면 https로 유도"를 이미 보장). 있는데
+  // 형식이 틀리면(변조/버그) missing_fields와 동일하게 거부 — 반쪽만 실어 보내는 조합은 없다.
+  let callbackModeFields: { callback_mode: string; return_uri: string } | Record<string, never> = {};
+  if (body.callback_mode !== undefined) {
+    if (typeof body.callback_mode !== 'string' || !isOAuthCallbackMode(body.callback_mode)) {
+      logHandoffFailure('bad_callback_mode');
+      return handoffFailedResponse();
+    }
+    callbackModeFields = {
+      callback_mode: body.callback_mode,
+      return_uri: expectedReturnUri(body.callback_mode, APP_LINK_ORIGIN()),
+    };
+  }
+
   const internalSecret = process.env['FIREBASE_BFF_INTERNAL_SECRET'];
   const consumeRes = await fetch(`${FASTAPI_URL()}/api/v2/internal/auth/oauth-handoff/consume`, {
     method: 'POST',
@@ -90,7 +117,7 @@ export async function POST(request: Request) {
       'Content-Type': 'application/json',
       ...(internalSecret ? { Authorization: `Bearer ${internalSecret}` } : {}),
     },
-    body: JSON.stringify({ code: body.code, code_verifier: body.code_verifier }),
+    body: JSON.stringify({ code: body.code, code_verifier: body.code_verifier, ...callbackModeFields }),
   }).catch(() => null);
 
   if (!consumeRes || !consumeRes.ok) {

--- a/apps/web/src/lib/auth/oauth-callback-mode.test.ts
+++ b/apps/web/src/lib/auth/oauth-callback-mode.test.ts
@@ -1,0 +1,44 @@
+// story #3121 AC1 — lib/auth/oauth-callback-mode 순수함수 단위테스트. BE
+// backend/app/routers/auth_firebase_internal.py의 _expected_return_uri()와 값이 반드시
+// 같아야 하는 고정 매핑(둘 다 수동으로 맞춰 유지 — 자동 대조 불가, 값 바뀌면 여기·BE·모바일
+// App.js OAUTH_RETURN_SCHEME_URL 셋 다 같이 고쳐야 한다).
+import { describe, expect, it } from 'vitest';
+import { expectedReturnUri, isOAuthCallbackMode } from './oauth-callback-mode';
+
+describe('isOAuthCallbackMode', () => {
+  it('accepts https and custom_scheme', () => {
+    expect(isOAuthCallbackMode('https')).toBe(true);
+    expect(isOAuthCallbackMode('custom_scheme')).toBe(true);
+  });
+
+  it('rejects anything else, including null/undefined/empty', () => {
+    expect(isOAuthCallbackMode('android')).toBe(false);
+    expect(isOAuthCallbackMode('')).toBe(false);
+    expect(isOAuthCallbackMode(null)).toBe(false);
+    expect(isOAuthCallbackMode(undefined)).toBe(false);
+    expect(isOAuthCallbackMode('HTTPS')).toBe(false); // 대소문자 무관용(exact) — BE Literal과 동형
+  });
+});
+
+describe('expectedReturnUri', () => {
+  it('https: appLinkOrigin + /native/oauth-return', () => {
+    expect(expectedReturnUri('https', 'https://dev-app.sprintable.ai')).toBe(
+      'https://dev-app.sprintable.ai/native/oauth-return',
+    );
+    expect(expectedReturnUri('https', 'https://app.sprintable.ai')).toBe(
+      'https://app.sprintable.ai/native/oauth-return',
+    );
+  });
+
+  it('custom_scheme: fixed ai.sprintable URI regardless of appLinkOrigin (single slash, RFC 8252 opaque)', () => {
+    expect(expectedReturnUri('custom_scheme', 'https://dev-app.sprintable.ai')).toBe('ai.sprintable:/oauth-return');
+    expect(expectedReturnUri('custom_scheme', 'https://app.sprintable.ai')).toBe('ai.sprintable:/oauth-return');
+  });
+
+  // 자기검증 — 두 모드가 실제로 다른 문자열을 낸다(항상 같은 값을 반환하는 죽은 분기 방지).
+  it('mut: https and custom_scheme produce different values for the same origin', () => {
+    const a = expectedReturnUri('https', 'https://dev-app.sprintable.ai');
+    const b = expectedReturnUri('custom_scheme', 'https://dev-app.sprintable.ai');
+    expect(a).not.toBe(b);
+  });
+});

--- a/apps/web/src/lib/auth/oauth-callback-mode.ts
+++ b/apps/web/src/lib/auth/oauth-callback-mode.ts
@@ -1,0 +1,27 @@
+// story #3121 AC1(BFF/모바일 정합 절반) — 계약 doc e-mobile-oauth-native-handoff-contract §2/§10.7.
+//
+// iOS 17.4 미만은 ASWebAuthenticationSession의 legacy callbackURLScheme 경로로 가야 하고(모바일
+// PR #71/#72), 그 경로가 실제로 https 리다이렉트를 못 잡아 custom scheme(`ai.sprintable`) 폴백
+// 홉이 필요하다(apps/web `/native/oauth-return` 페이지·PR #3524). 어느 모드로 갈지는 모바일
+// 셸이 OAuth 시작 "전"에 정적으로(OS 버전만 보고) 결정한다 — BFF는 그 선택을 전달만 하고,
+// 실제 return_uri 문자열은 **여기서 고정값으로 계산**한다(클라가 임의 URI를 선언하게 두지
+// 않는다 — BE `_expected_return_uri()`와 동일한 고정 매핑, byte-exact 유지가 계약).
+//
+// ⚠️custom_scheme 값은 모바일 App.js `OAUTH_RETURN_SCHEME_URL`·apps/web
+// `/native/oauth-return/page.tsx`의 이동 대상과 byte-exact(`ai.sprintable:/oauth-return`,
+// 단일 슬래시 — RFC 8252 opaque URI 형식). 세 곳 중 하나만 바뀌면 조용히 깨진다.
+
+export type OAuthCallbackMode = 'https' | 'custom_scheme';
+
+const CUSTOM_SCHEME_RETURN_URI = 'ai.sprintable:/oauth-return';
+const NATIVE_RETURN_PATH = '/native/oauth-return';
+
+export function isOAuthCallbackMode(value: string | null | undefined): value is OAuthCallbackMode {
+  return value === 'https' || value === 'custom_scheme';
+}
+
+// appLinkOrigin: 호출자가 `APP_LINK_ORIGIN()`(callback/[provider]/route.ts 기존 값)을 넘긴다 —
+// 새 소스를 안 만든다(이미 App Link 리다이렉트 목적지 계산에 쓰는 값과 동일 출처 유지).
+export function expectedReturnUri(mode: OAuthCallbackMode, appLinkOrigin: string): string {
+  return mode === 'custom_scheme' ? CUSTOM_SCHEME_RETURN_URI : `${appLinkOrigin}${NATIVE_RETURN_PATH}`;
+}

--- a/backend/alembic/versions/0284_oauth_handoff_codes_callback_mode.py
+++ b/backend/alembic/versions/0284_oauth_handoff_codes_callback_mode.py
@@ -1,0 +1,44 @@
+"""story #3121 AC1(계약 doc `e-mobile-oauth-native-handoff-contract` §2/§10.7·산티아고 SSOT) —
+oauth_handoff_codes에 callback_mode+exact return_uri 컬럼 신설. iOS 17.4 미만 custom-scheme
+fallback은 계약 §2에 따라 "association 실패 후 동적 전환"이 아니라 "OAuth 시작 전 정적으로
+결정되는 호환 모드" — 이 값을 issue 시점에 코드 행에 고정해 consume 시 그대로 대조한다
+(다른 모드/URI로 소비 시도 시 원자 UPDATE의 WHERE절에서 매치 실패 → 미소비 상태 유지).
+
+기존 행(있다면 전부 TTL 120초 지나 이미 만료·무해)에 대한 NOT NULL 충족용 server_default만
+목적 — 애플리케이션 계층은 항상 명시적 값을 쓴다(0282 vat_rate_bp와 동형 패턴).
+
+Revision ID: 0284
+Revises: 0283
+Create Date: 2026-08-27
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0284"
+down_revision = "0283"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "oauth_handoff_codes",
+        sa.Column("callback_mode", sa.Text(), nullable=False, server_default="https"),
+    )
+    op.add_column(
+        "oauth_handoff_codes",
+        sa.Column("return_uri", sa.Text(), nullable=False, server_default=""),
+    )
+    op.create_check_constraint(
+        "ck_oauth_handoff_codes_callback_mode",
+        "oauth_handoff_codes",
+        "callback_mode IN ('https', 'custom_scheme')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_oauth_handoff_codes_callback_mode", "oauth_handoff_codes", type_="check")
+    op.drop_column("oauth_handoff_codes", "return_uri")
+    op.drop_column("oauth_handoff_codes", "callback_mode")

--- a/backend/app/models/oauth_handoff_code.py
+++ b/backend/app/models/oauth_handoff_code.py
@@ -18,7 +18,7 @@ consume의 optional 분기로 구현 금지" 요구를 코드 레벨에서 다�
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Text
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -27,6 +27,11 @@ from app.core.database import Base
 
 class OAuthHandoffCode(Base):
     __tablename__ = "oauth_handoff_codes"
+    __table_args__ = (
+        CheckConstraint(
+            "callback_mode IN ('https', 'custom_scheme')", name="ck_oauth_handoff_codes_callback_mode"
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     user_id: Mapped[uuid.UUID] = mapped_column(
@@ -37,6 +42,16 @@ class OAuthHandoffCode(Base):
     purpose: Mapped[str] = mapped_column(Text, nullable=False)
     # PKCE S256: base64url(SHA256(code_verifier)) — consume 시점에 재계산해 등가 비교.
     code_challenge: Mapped[str] = mapped_column(Text, nullable=False)
+    # story #3121 AC1(계약 doc §2/§10.7) — iOS 17.4 미만 custom-scheme fallback은 "association
+    # 실패 후 동적 전환"이 아니라 "OAuth 시작 전 정적으로 결정되는 호환 모드"(계약 §2). 이 값과
+    # 아래 return_uri는 issue 시점에 고정돼 consume 시 그대로 대조된다 — 코드가 발급된 모드와
+    # 다른 모드/URI로 소비하려는 시도(예: https용으로 발급된 코드를 custom_scheme 경로로 소비)를
+    # 원자 UPDATE의 WHERE절에서 차단한다(§10.9 exact-origin 고정과 동형).
+    callback_mode: Mapped[str] = mapped_column(Text, nullable=False)
+    # 위 모드에 대응하는 정확한 return URI — https는 `{app_url}/native/oauth-return`,
+    # custom_scheme은 `ai.sprintable:/oauth-return`(단일 슬래시, App.js OAUTH_RETURN_SCHEME_URL과
+    # byte-exact). 값 자체는 issue 라우터가 모드별 고정값과 대조해 검증(이 컬럼은 저장만).
+    return_uri: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -20,6 +20,7 @@ import hashlib
 import logging
 import uuid
 from datetime import datetime, timezone
+from typing import Literal
 
 from fastapi import APIRouter, Depends, Header, HTTPException, status
 from pydantic import BaseModel, ConfigDict
@@ -473,15 +474,33 @@ async def consume_native_bootstrap(
 # access/refresh 토큰 쌍을 mint한다.
 _OAUTH_HANDOFF_MIN_CHALLENGE_LEN = 43  # base64url(SHA256) 무패딩 최소 길이(RFC 7636)
 
+# story #3121 AC1(계약 doc §2·산티아고 §10.9 exact-origin) — custom scheme은 App.js
+# OAUTH_RETURN_SCHEME_URL/apps/web native/oauth-return page.tsx와 byte-exact 고정(단일
+# 슬래시). https는 환경별 app_url + 동일 페이지 경로 — 클라 입력을 그대로 신뢰하지 않고 이
+# 고정값과 정확히 일치하는지 issue 시점에 검증한다(둘 다 서버가 계산·클라는 선언만).
+_OAUTH_NATIVE_RETURN_PATH = "/native/oauth-return"
+_OAUTH_CUSTOM_SCHEME_RETURN_URI = "ai.sprintable:/oauth-return"
+
+
+def _expected_return_uri(callback_mode: str) -> str:
+    if callback_mode == "custom_scheme":
+        return _OAUTH_CUSTOM_SCHEME_RETURN_URI
+    return f"{settings.app_url}{_OAUTH_NATIVE_RETURN_PATH}"
+
 
 class OAuthHandoffIssueRequest(BaseModel):
     # 산티아고 §10.1.2 계열 defense-in-depth: 이 내부 엔드포인트는 BFF 전용이라 공개 공격면은
-    # 아니지만, 스키마가 정의한 두 필드 외 어떤 것도 조용히 무시하지 않는다(§10.6 음성테스트 7과
+    # 아니지만, 스키마가 정의한 필드 외 어떤 것도 조용히 무시하지 않는다(§10.6 음성테스트 7과
     # 동일 원칙 — "무시 아님, 거부").
     model_config = ConfigDict(extra="forbid")
 
     user_id: str  # BFF가 oauth_callback()으로 이미 해소한 서버-확定 subject.
     code_challenge: str  # PKCE S256 = base64url(SHA256(code_verifier)), 패딩 없음
+    # story #3121 AC1 — 계약 §2: custom-scheme fallback은 OAuth 시작 전 정적으로 결정되는
+    # compatibility mode(association 실패 후 동적 전환 아님). BFF가 OAuth-start 시점에 이미
+    # 확定한 값을 그대로 선언 — 서버는 이 선언을 `_expected_return_uri()` 고정값과 대조만 한다.
+    callback_mode: Literal["https", "custom_scheme"]
+    return_uri: str
 
 
 class OAuthHandoffIssueResponse(BaseModel):
@@ -506,6 +525,12 @@ async def issue_oauth_handoff(
     if len(body.code_challenge) < _OAUTH_HANDOFF_MIN_CHALLENGE_LEN:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid code_challenge")
 
+    # story #3121 AC1 — return_uri는 클라 선언을 그대로 저장하지 않는다: 모드별 서버 고정값과
+    # byte-exact 일치해야 발급 자체를 진행(§10.9 exact-origin). 불일치는 오배선/변조 신호.
+    if body.return_uri != _expected_return_uri(body.callback_mode):
+        logger.warning("auth.oauth_handoff.issue rejected reason=return_uri_mismatch")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid return_uri")
+
     try:
         user_uuid = uuid.UUID(body.user_id)
     except ValueError:
@@ -528,7 +553,14 @@ async def issue_oauth_handoff(
     await _reject_if_before_cutover(user_uuid, int(now.timestamp()), db)
 
     code, code_hash = generate_handoff_code()
-    await issue_handoff_code(db, code_hash=code_hash, user_id=user_uuid, code_challenge=body.code_challenge)
+    await issue_handoff_code(
+        db,
+        code_hash=code_hash,
+        user_id=user_uuid,
+        code_challenge=body.code_challenge,
+        callback_mode=body.callback_mode,
+        return_uri=body.return_uri,
+    )
 
     logger.info("auth.oauth_handoff.issue success")
     return OAuthHandoffIssueResponse(code=code, expires_in=OAUTH_HANDOFF_TTL_SECONDS)
@@ -540,10 +572,16 @@ class OAuthHandoffConsumeRequest(BaseModel):
     # assertion/ID token/임의 user·install ID 등 다른 어떤 필드도 "무시"가 아니라 요청 자체를
     # 거부해야 한다(extra="forbid"). native consume의 `existing_session_user_id`류 부가 필드를
     # 여기 들여오지 않는다 — 이 흐름은 애초에 기존 세션이 없는 최초 로그인 핸드오프다.
+    #
+    # story #3121 AC1 — callback_mode/return_uri 추가(계약 §2 확장, 위 §3 고정 취지와 상충
+    # 아님: 이 두 필드는 "다른 인증 재료"가 아니라 issue 시점에 이미 고정된 값을 그대로
+    # 재선언해 대조하는 것뿐 — 새 신뢰축을 열지 않는다).
     model_config = ConfigDict(extra="forbid")
 
     code: str
     code_verifier: str
+    callback_mode: Literal["https", "custom_scheme"]
+    return_uri: str
 
 
 class OAuthHandoffConsumeResponse(BaseModel):
@@ -576,7 +614,13 @@ async def consume_oauth_handoff(
     if not settings.firebase_oauth_handoff_enabled:
         raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="OAuth handoff not enabled")
 
-    consumed = await consume_handoff_code(db, code=body.code, code_verifier=body.code_verifier)
+    consumed = await consume_handoff_code(
+        db,
+        code=body.code,
+        code_verifier=body.code_verifier,
+        callback_mode=body.callback_mode,
+        return_uri=body.return_uri,
+    )
     if consumed is None:
         logger.warning("auth.oauth_handoff.consume rejected reason=code_consume_failed")
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired code")

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -22,7 +22,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Literal
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -31,6 +31,7 @@ from app.core.config import settings
 from app.dependencies.database import get_db
 from app.models.auth_identity import AuthIdentity, AuthMigration
 from app.models.device_installation import DeviceInstallation
+from app.models.login_audit_log import LoginAuditLog
 from app.models.user import User
 from app.services.android_key_attestation import AndroidAttestationVerificationError, verify_bootstrap_signature
 from app.services.apple_app_attest import AppAttestVerificationError, verify_assertion
@@ -48,6 +49,7 @@ from app.services.firebase_verifier import verify_firebase_id_token
 from app.services.native_bootstrap import consume_bootstrap_code
 from app.services.oauth_handoff import DEFAULT_TTL_SECONDS as OAUTH_HANDOFF_TTL_SECONDS
 from app.services.oauth_handoff import consume_handoff_code, generate_handoff_code, issue_handoff_code
+from app.services.rate_limiter import get_rate_limiter
 
 
 def _b64_decode(value: str | None) -> bytes | None:
@@ -516,6 +518,51 @@ def _resolve_callback_mode_and_uri(
     return callback_mode, return_uri
 
 
+# story #3121 AC2 — custom-mode(iOS 17.4 미만 fallback)는 계약 §9 잔여위험(client
+# impersonation) 축이 https보다 넓다: 역도메인 scheme은 호출 앱의 정체 증명이 아니라 다른
+# 앱도 동일 scheme을 등록해 가로챌 수 있다(§9 "iOS legacy callback 계약 고정 문구"). 그래서
+# custom_scheme 트래픽에만 «별도»(공용 8-route 로그인 limiter와 무관한 독립 버킷) rate limit을
+# 건다 — https 경로는 이 한도의 영향을 받지 않는다. 60초 창(`app/services/rate_limiter.py`
+# WINDOW_SECS 고정), IP 키(내부시크릿 게이트 우회/유출 시나리오의 방어심화 — 정상 경로는 BFF가
+# 중계하므로 IP가 실사용자를 구분 못 하는 게 알려진 한계, resend_verification_limiter의
+# "인스턴스별 카운터 느슨함"과 동급 별개 우려로 스코프 밖).
+_OAUTH_HANDOFF_CUSTOM_SCHEME_ISSUE_LIMIT = 5
+_OAUTH_HANDOFF_CUSTOM_SCHEME_CONSUME_LIMIT = 10
+
+
+def _client_ip(request: Request) -> str:
+    return request.client.host if request.client else "unknown"
+
+
+async def _enforce_custom_scheme_rate_limit(request: Request, callback_mode: str, *, scope: str, limit: int) -> None:
+    if callback_mode != "custom_scheme":
+        return
+    key = f"oauth_handoff_custom_scheme_{scope}:{_client_ip(request)}"
+    allowed, _remaining, retry_after = await get_rate_limiter().check(key, limit)
+    if not allowed:
+        logger.warning("auth.oauth_handoff.%s rejected reason=custom_scheme_rate_limited", scope)
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={"code": "RATE_LIMITED", "message": "Too many requests", "retry_after": retry_after},
+            headers={"Retry-After": str(retry_after)},
+        )
+
+
+# story #3121 AC3 — callback_mode별 start(issue)/consume 로그 축. 기존 `login_audit_logs`
+# (app/routers/auth.py `_write_audit`와 동형 shape) 재사용 — 새 테이블 불요, `detail`에
+# mode를 실어 mode별 필터링 가능하게 한다.
+def _write_oauth_handoff_audit(
+    db: AsyncSession, event_type: str, *, user_id: uuid.UUID | None, callback_mode: str, request: Request,
+) -> None:
+    db.add(LoginAuditLog(
+        event_type=event_type,
+        user_id=user_id,
+        ip_address=_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+        detail=f"callback_mode={callback_mode}",
+    ))
+
+
 class OAuthHandoffIssueRequest(BaseModel):
     # 산티아고 §10.1.2 계열 defense-in-depth: 이 내부 엔드포인트는 BFF 전용이라 공개 공격면은
     # 아니지만, 스키마가 정의한 필드 외 어떤 것도 조용히 무시하지 않는다(§10.6 음성테스트 7과
@@ -540,6 +587,7 @@ class OAuthHandoffIssueResponse(BaseModel):
 
 @router.post("/oauth-handoff/issue", response_model=OAuthHandoffIssueResponse)
 async def issue_oauth_handoff(
+    request: Request,
     body: OAuthHandoffIssueRequest,
     authorization: str | None = Header(default=None),
     db: AsyncSession = Depends(get_db),
@@ -565,6 +613,11 @@ async def issue_oauth_handoff(
         logger.warning("auth.oauth_handoff.issue rejected reason=return_uri_mismatch")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid return_uri")
 
+    # story #3121 AC2 — custom_scheme 트래픽만 별도 rate limit(https는 영향 없음).
+    await _enforce_custom_scheme_rate_limit(
+        request, callback_mode, scope="issue", limit=_OAUTH_HANDOFF_CUSTOM_SCHEME_ISSUE_LIMIT,
+    )
+
     try:
         user_uuid = uuid.UUID(body.user_id)
     except ValueError:
@@ -587,6 +640,10 @@ async def issue_oauth_handoff(
     await _reject_if_before_cutover(user_uuid, int(now.timestamp()), db)
 
     code, code_hash = generate_handoff_code()
+    # story #3121 AC3 — 코드 행과 같은 commit에 실려야 "발급됐는데 감사기록만 유실"이 없다.
+    _write_oauth_handoff_audit(
+        db, "oauth_handoff_issued", user_id=user_uuid, callback_mode=callback_mode, request=request,
+    )
     await issue_handoff_code(
         db,
         code_hash=code_hash,
@@ -635,6 +692,7 @@ _OAUTH_HANDOFF_AUTH_SOURCE = "oauth_handoff"
 
 @router.post("/oauth-handoff/consume", response_model=OAuthHandoffConsumeResponse)
 async def consume_oauth_handoff(
+    request: Request,
     body: OAuthHandoffConsumeRequest,
     authorization: str | None = Header(default=None),
     db: AsyncSession = Depends(get_db),
@@ -653,6 +711,11 @@ async def consume_oauth_handoff(
     callback_mode, return_uri = _resolve_callback_mode_and_uri(
         body.callback_mode, body.return_uri, log_event="auth.oauth_handoff.consume",
     )
+    # story #3121 AC2 — custom_scheme 트래픽만 별도 rate limit(https는 영향 없음).
+    await _enforce_custom_scheme_rate_limit(
+        request, callback_mode, scope="consume", limit=_OAUTH_HANDOFF_CUSTOM_SCHEME_CONSUME_LIMIT,
+    )
+
     consumed = await consume_handoff_code(
         db,
         code=body.code,
@@ -662,6 +725,13 @@ async def consume_oauth_handoff(
     )
     if consumed is None:
         logger.warning("auth.oauth_handoff.consume rejected reason=code_consume_failed")
+        # story #3121 AC3 — 실패도 mode 축으로 남긴다(AC1이 막는 mode/URI 불일치 시도 자체가
+        # 이 reason으로 수렴하므로, 이 로그가 그 시도의 관측 지점이다). user_id는 미상(코드가
+        # 안 태워졌으니 누구 것인지 특정 불가 — login_failure의 user=None과 동형).
+        _write_oauth_handoff_audit(
+            db, "oauth_handoff_consume_failed", user_id=None, callback_mode=callback_mode, request=request,
+        )
+        await db.commit()
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired code")
 
     user = await db.get(User, consumed.user_id)
@@ -691,6 +761,10 @@ async def consume_oauth_handoff(
         auth_source=_OAUTH_HANDOFF_AUTH_SOURCE, device_attested=False,
     )
     refresh_expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    # story #3121 AC3 — RT 저장과 같은 commit에 실린다(_store_refresh_token이 commit).
+    _write_oauth_handoff_audit(
+        db, "oauth_handoff_consumed", user_id=consumed.user_id, callback_mode=callback_mode, request=request,
+    )
     await _store_refresh_token(db, user, tokens["refresh_token"], refresh_expires_at)
 
     # mint 직후(레거시 토큰 서명+RT 저장 커밋 이후) 재확인 — native consume의 "3번째

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -488,6 +488,34 @@ def _expected_return_uri(callback_mode: str) -> str:
     return f"{settings.app_url}{_OAUTH_NATIVE_RETURN_PATH}"
 
 
+_DEFAULT_CALLBACK_MODE = "https"
+
+
+def _resolve_callback_mode_and_uri(
+    callback_mode: str | None, return_uri: str | None, *, log_event: str,
+) -> tuple[str, str]:
+    """story #3121 AC1 — PO delta(2026-08-27, PR #3538 리뷰): expand-contract Phase 1.
+    현행 BFF(민군 절반 착지 전)는 이 두 필드를 아예 안 보낸다 — 필수로 걸면 머지 즉시
+    기존 이슈/consume 호출이 422로 전멸(dev 핸드오프 전면 다운). 미제공(둘 다 None)이면
+    https로 유도하되 조용히 넘어가지 않고 로그 한 줄로 파생임을 남긴다. 오늘 BFF가
+    custom_scheme을 아예 안 보내므로(#3116 활성화 트랙 전) https 유도가 실사용과 정합.
+
+    ⚠️Phase 2 승격 조건(코드 주석 고정 — 기한 없는 과도기 방지): 민군 BFF 절반(이슈
+    호출부 callback_mode/return_uri 명시 배선 + consume 호출부 동일)이 dev에 착지·배포
+    확認되면 이 두 필드를 Optional→필수로 승격하는 소PR을 낸다. 그 전까지는 두 필드
+    모두 명시 제공(둘 다 있어야 함 — 하나만 있는 반쪽 선언은 오배선 신호라 거부)하거나
+    둘 다 생략(레거시 유도)만 허용."""
+    if callback_mode is None and return_uri is None:
+        logger.info("%s callback_mode_derived reason=legacy_caller_no_mode_field mode=%s", log_event, _DEFAULT_CALLBACK_MODE)
+        return _DEFAULT_CALLBACK_MODE, _expected_return_uri(_DEFAULT_CALLBACK_MODE)
+    if callback_mode is None or return_uri is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="callback_mode and return_uri must both be provided or both omitted",
+        )
+    return callback_mode, return_uri
+
+
 class OAuthHandoffIssueRequest(BaseModel):
     # 산티아고 §10.1.2 계열 defense-in-depth: 이 내부 엔드포인트는 BFF 전용이라 공개 공격면은
     # 아니지만, 스키마가 정의한 필드 외 어떤 것도 조용히 무시하지 않는다(§10.6 음성테스트 7과
@@ -499,8 +527,10 @@ class OAuthHandoffIssueRequest(BaseModel):
     # story #3121 AC1 — 계약 §2: custom-scheme fallback은 OAuth 시작 전 정적으로 결정되는
     # compatibility mode(association 실패 후 동적 전환 아님). BFF가 OAuth-start 시점에 이미
     # 확定한 값을 그대로 선언 — 서버는 이 선언을 `_expected_return_uri()` 고정값과 대조만 한다.
-    callback_mode: Literal["https", "custom_scheme"]
-    return_uri: str
+    # PO delta(PR #3538) — Optional/None(Phase 1 expand-contract, `_resolve_callback_mode_and_uri`
+    # 참조). 민군 BFF 절반 착지 확認 후 필수 승격 예정.
+    callback_mode: Literal["https", "custom_scheme"] | None = None
+    return_uri: str | None = None
 
 
 class OAuthHandoffIssueResponse(BaseModel):
@@ -527,7 +557,11 @@ async def issue_oauth_handoff(
 
     # story #3121 AC1 — return_uri는 클라 선언을 그대로 저장하지 않는다: 모드별 서버 고정값과
     # byte-exact 일치해야 발급 자체를 진행(§10.9 exact-origin). 불일치는 오배선/변조 신호.
-    if body.return_uri != _expected_return_uri(body.callback_mode):
+    # PO delta(PR #3538, Phase 1) — 둘 다 미제공이면 레거시 BFF로 보고 https로 유도.
+    callback_mode, return_uri = _resolve_callback_mode_and_uri(
+        body.callback_mode, body.return_uri, log_event="auth.oauth_handoff.issue",
+    )
+    if return_uri != _expected_return_uri(callback_mode):
         logger.warning("auth.oauth_handoff.issue rejected reason=return_uri_mismatch")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid return_uri")
 
@@ -558,8 +592,8 @@ async def issue_oauth_handoff(
         code_hash=code_hash,
         user_id=user_uuid,
         code_challenge=body.code_challenge,
-        callback_mode=body.callback_mode,
-        return_uri=body.return_uri,
+        callback_mode=callback_mode,
+        return_uri=return_uri,
     )
 
     logger.info("auth.oauth_handoff.issue success")
@@ -580,8 +614,10 @@ class OAuthHandoffConsumeRequest(BaseModel):
 
     code: str
     code_verifier: str
-    callback_mode: Literal["https", "custom_scheme"]
-    return_uri: str
+    # PO delta(PR #3538) — Optional/None(Phase 1 expand-contract, `_resolve_callback_mode_and_uri`
+    # 참조). 민군 BFF 절반 착지 확認 후 필수 승격 예정.
+    callback_mode: Literal["https", "custom_scheme"] | None = None
+    return_uri: str | None = None
 
 
 class OAuthHandoffConsumeResponse(BaseModel):
@@ -614,12 +650,15 @@ async def consume_oauth_handoff(
     if not settings.firebase_oauth_handoff_enabled:
         raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="OAuth handoff not enabled")
 
+    callback_mode, return_uri = _resolve_callback_mode_and_uri(
+        body.callback_mode, body.return_uri, log_event="auth.oauth_handoff.consume",
+    )
     consumed = await consume_handoff_code(
         db,
         code=body.code,
         code_verifier=body.code_verifier,
-        callback_mode=body.callback_mode,
-        return_uri=body.return_uri,
+        callback_mode=callback_mode,
+        return_uri=return_uri,
     )
     if consumed is None:
         logger.warning("auth.oauth_handoff.consume rejected reason=code_consume_failed")

--- a/backend/app/services/oauth_handoff.py
+++ b/backend/app/services/oauth_handoff.py
@@ -39,6 +39,11 @@ DEFAULT_TTL_SECONDS = 120  # 산티아고 §10.4 확定(non-sliding·non-renewab
 # 4단계/§10.1.1의 정확한 리터럴 — 오르테가군 relay 확인.
 PURPOSE_NATIVE_OAUTH_HANDOFF = "oauth_webview_handoff_v1"
 
+# story #3121 AC1(계약 §2) — 정적 compatibility mode. 값 유효성은 router의 Literal 스키마+DB
+# CHECK(ck_oauth_handoff_codes_callback_mode)가 이중으로 강제 — 이 서비스 계층은 전달만 한다.
+CALLBACK_MODE_HTTPS = "https"
+CALLBACK_MODE_CUSTOM_SCHEME = "custom_scheme"
+
 
 def _hash_code(code: str) -> str:
     return hashlib.sha256(code.encode()).hexdigest()
@@ -62,17 +67,23 @@ async def issue_handoff_code(
     code_hash: str,
     user_id,
     code_challenge: str,
+    callback_mode: str,
+    return_uri: str,
     ttl_seconds: int = DEFAULT_TTL_SECONDS,
     commit: bool = True,
 ) -> None:
     """`code_hash`는 `generate_handoff_code()`로 미리 계산된 값 — raw code는 이 함수에
-    전달되지 않는다(DB엔 hash만, 로그에도 남기지 않는다)."""
+    전달되지 않는다(DB엔 hash만, 로그에도 남기지 않는다). `callback_mode`/`return_uri`(story
+    #3121 AC1)는 호출부(router)가 이미 모드별 고정값과 대조 검증한 뒤 넘기는 값 — 이 함수는
+    그대로 저장만 한다."""
     now = datetime.now(timezone.utc)
     row = OAuthHandoffCode(
         user_id=user_id,
         code_hash=code_hash,
         purpose=PURPOSE_NATIVE_OAUTH_HANDOFF,
         code_challenge=code_challenge,
+        callback_mode=callback_mode,
+        return_uri=return_uri,
         created_at=now,
         expires_at=now + timedelta(seconds=ttl_seconds),
     )
@@ -94,11 +105,19 @@ async def consume_handoff_code(
     *,
     code: str,
     code_verifier: str,
+    callback_mode: str,
+    return_uri: str,
     commit: bool = True,
 ) -> ConsumedHandoffCode | None:
-    """원자적 1회 소비 — code_hash(+purpose+미소비+미만료)만으로 먼저 태운 뒤, PKCE
-    challenge를 constant-time 비교한다(§10.3/.4 MUST). verifier가 틀려도 코드는 이미
-    소모돼 재시도 불가 — 무제한 verifier 추측 방지."""
+    """원자적 1회 소비 — code_hash(+purpose+미소비+미만료+callback_mode+return_uri)만으로
+    먼저 태운 뒤, PKCE challenge를 constant-time 비교한다(§10.3/.4 MUST). verifier가 틀려도
+    코드는 이미 소모돼 재시도 불가 — 무제한 verifier 추측 방지.
+
+    story #3121 AC1(계약 §2/§10.7) — callback_mode/return_uri는 code_hash/purpose와 같은
+    WHERE절 조건(비밀값 아닌 선언값이라 constant-time 비교 불요, PKCE challenge와 다른 성격).
+    issue 시점에 고정된 값과 다른 모드/URI로 소비를 시도하면 그냥 매치되는 행이 없어
+    None(=재시도 가능, 코드 안 태움) — 모드/URI는 비밀이 아니므로 verifier처럼 "틀려도 태워야
+    추측 방지" 근거가 없다."""
     code_hash = _hash_code(code)
     now = datetime.now(timezone.utc)
 
@@ -109,6 +128,8 @@ async def consume_handoff_code(
             OAuthHandoffCode.purpose == PURPOSE_NATIVE_OAUTH_HANDOFF,
             OAuthHandoffCode.consumed_at.is_(None),
             OAuthHandoffCode.expires_at > now,
+            OAuthHandoffCode.callback_mode == callback_mode,
+            OAuthHandoffCode.return_uri == return_uri,
         )
         .values(consumed_at=now)
         .returning(OAuthHandoffCode.user_id, OAuthHandoffCode.created_at, OAuthHandoffCode.code_challenge)

--- a/backend/tests/test_1931_oauth_handoff_realdb.py
+++ b/backend/tests/test_1931_oauth_handoff_realdb.py
@@ -95,6 +95,15 @@ def _https_return_uri() -> str:
 _CUSTOM_SCHEME_RETURN_URI = "ai.sprintable:/oauth-return"
 
 
+# story #3121 AC2/AC3 — issue/consume가 이제 Request를 받는다(rate limit IP 키·감사기록
+# ip/user-agent). 직접함수호출 스타일 테스트라 ASGI 스택 없이 최소 shape만 흉내낸다(기존
+# test_cbd578d4_c4_bootstrap_flow_realdb.py의 _FakeRequest 관행과 동형).
+class _FakeRequest:
+    def __init__(self, ip: str = "127.0.0.1"):
+        self.client = type("_FakeClient", (), {"host": ip})()
+        self.headers: dict[str, str] = {}
+
+
 def _issue_req(user_id, challenge, *, callback_mode="https", return_uri=None):
     from app.routers.auth_firebase_internal import OAuthHandoffIssueRequest
     return OAuthHandoffIssueRequest(
@@ -123,11 +132,11 @@ async def test_issue_and_consume_round_trip_success(monkeypatch):
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
+            issued = await issue_oauth_handoff(_FakeRequest(), _issue_req(user_id, challenge), authorization=None, db=s)
         assert issued.code
 
         async with Session() as s:
-            consumed = await consume_oauth_handoff(
+            consumed = await consume_oauth_handoff(_FakeRequest(), 
                 _consume_req(issued.code, verifier), authorization=None, db=s,
             )
         assert consumed.access_token
@@ -156,12 +165,12 @@ async def test_consume_wrong_verifier_rejected(monkeypatch):
 
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
+            issued = await issue_oauth_handoff(_FakeRequest(), _issue_req(user_id, challenge), authorization=None, db=s)
 
         wrong_verifier, _ = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await consume_oauth_handoff(
+                await consume_oauth_handoff(_FakeRequest(), 
                     _consume_req(issued.code, wrong_verifier), authorization=None, db=s,
                 )
             assert exc_info.value.status_code == 401
@@ -185,18 +194,18 @@ async def test_consume_wrong_verifier_burns_code_no_retry(monkeypatch):
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
+            issued = await issue_oauth_handoff(_FakeRequest(), _issue_req(user_id, challenge), authorization=None, db=s)
 
         wrong_verifier, _ = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException):
-                await consume_oauth_handoff(
+                await consume_oauth_handoff(_FakeRequest(), 
                     _consume_req(issued.code, wrong_verifier), authorization=None, db=s,
                 )
 
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await consume_oauth_handoff(
+                await consume_oauth_handoff(_FakeRequest(), 
                     _consume_req(issued.code, verifier), authorization=None, db=s,
                 )
             assert exc_info.value.status_code == 401
@@ -216,16 +225,16 @@ async def test_consume_replay_after_success_rejected(monkeypatch):
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
+            issued = await issue_oauth_handoff(_FakeRequest(), _issue_req(user_id, challenge), authorization=None, db=s)
 
         req = _consume_req(issued.code, verifier)
         async with Session() as s:
-            first = await consume_oauth_handoff(req, authorization=None, db=s)
+            first = await consume_oauth_handoff(_FakeRequest(), req, authorization=None, db=s)
         assert first.access_token
 
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await consume_oauth_handoff(req, authorization=None, db=s)
+                await consume_oauth_handoff(_FakeRequest(), req, authorization=None, db=s)
             assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
@@ -244,14 +253,14 @@ async def test_concurrent_consume_exactly_one_succeeds(monkeypatch):
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
+            issued = await issue_oauth_handoff(_FakeRequest(), _issue_req(user_id, challenge), authorization=None, db=s)
 
         req = _consume_req(issued.code, verifier)
 
         async def _attempt():
             async with Session() as s:
                 try:
-                    return await consume_oauth_handoff(req, authorization=None, db=s)
+                    return await consume_oauth_handoff(_FakeRequest(), req, authorization=None, db=s)
                 except HTTPException:
                     return None
 
@@ -276,7 +285,7 @@ async def test_issue_rejected_when_feature_disabled(monkeypatch):
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
+                await issue_oauth_handoff(_FakeRequest(), _issue_req(user_id, challenge), authorization=None, db=s)
             assert exc_info.value.status_code == 501
     finally:
         await engine.dispose()
@@ -292,7 +301,7 @@ async def test_issue_rejected_unknown_user(monkeypatch):
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await issue_oauth_handoff(_issue_req(uuid.uuid4(), challenge), authorization=None, db=s)
+                await issue_oauth_handoff(_FakeRequest(), _issue_req(uuid.uuid4(), challenge), authorization=None, db=s)
             assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
@@ -318,7 +327,7 @@ async def test_issue_rejected_inactive_user(monkeypatch):
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
+                await issue_oauth_handoff(_FakeRequest(), _issue_req(user_id, challenge), authorization=None, db=s)
             assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
@@ -336,7 +345,7 @@ async def test_issue_rejected_short_code_challenge(monkeypatch):
 
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await issue_oauth_handoff(
+                await issue_oauth_handoff(_FakeRequest(), 
                     _issue_req(user_id, "too-short"), authorization=None, db=s,
                 )
             assert exc_info.value.status_code == 400
@@ -359,14 +368,14 @@ async def test_orphan_finding_revoke_between_issue_and_consume_rejected(monkeypa
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
+            issued = await issue_oauth_handoff(_FakeRequest(), _issue_req(user_id, challenge), authorization=None, db=s)
 
         async with Session() as s:
             await revoke_user_sessions(s, user_id, firebase_uid=None)
 
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await consume_oauth_handoff(
+                await consume_oauth_handoff(_FakeRequest(), 
                     _consume_req(issued.code, verifier), authorization=None, db=s,
                 )
             assert exc_info.value.status_code == 401
@@ -392,7 +401,7 @@ async def test_issue_rejected_return_uri_mismatch_for_mode(monkeypatch):
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await issue_oauth_handoff(
+                await issue_oauth_handoff(_FakeRequest(), 
                     _issue_req(user_id, challenge, callback_mode="https", return_uri=_CUSTOM_SCHEME_RETURN_URI),
                     authorization=None, db=s,
                 )
@@ -416,13 +425,13 @@ async def test_consume_rejected_when_callback_mode_mismatches_issued(monkeypatch
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(
+            issued = await issue_oauth_handoff(_FakeRequest(), 
                 _issue_req(user_id, challenge, callback_mode="https"), authorization=None, db=s,
             )
 
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await consume_oauth_handoff(
+                await consume_oauth_handoff(_FakeRequest(), 
                     _consume_req(
                         issued.code, verifier,
                         callback_mode="custom_scheme", return_uri=_CUSTOM_SCHEME_RETURN_URI,
@@ -448,13 +457,13 @@ async def test_consume_rejected_when_return_uri_mismatches_issued(monkeypatch):
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(
+            issued = await issue_oauth_handoff(_FakeRequest(), 
                 _issue_req(user_id, challenge, callback_mode="https"), authorization=None, db=s,
             )
 
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await consume_oauth_handoff(
+                await consume_oauth_handoff(_FakeRequest(), 
                     _consume_req(
                         issued.code, verifier,
                         callback_mode="https", return_uri="https://evil.example.com/native/oauth-return",
@@ -485,14 +494,14 @@ async def test_issue_and_consume_omitted_mode_fields_defaults_to_https_round_tri
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(
+            issued = await issue_oauth_handoff(_FakeRequest(), 
                 OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge=challenge),
                 authorization=None, db=s,
             )
         assert issued.code
 
         async with Session() as s:
-            consumed = await consume_oauth_handoff(
+            consumed = await consume_oauth_handoff(_FakeRequest(), 
                 OAuthHandoffConsumeRequest(code=issued.code, code_verifier=verifier),
                 authorization=None, db=s,
             )
@@ -516,13 +525,213 @@ async def test_issue_rejects_half_declared_mode_fields(monkeypatch):
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await issue_oauth_handoff(
+                await issue_oauth_handoff(_FakeRequest(), 
                     OAuthHandoffIssueRequest(
                         user_id=str(user_id), code_challenge=challenge, callback_mode="https",
                     ),
                     authorization=None, db=s,
                 )
             assert exc_info.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+# ─── story #3121 AC2 — custom_scheme 전용 rate limit ────────────────────────────────────
+
+def _reset_rate_limiter(monkeypatch):
+    """전역 싱글턴(`get_rate_limiter()`)이 프로세스 전체에서 재사용되므로, 테스트 간 카운터
+    누적을 막기 위해 매 rate-limit 테스트 시작 시 강제로 새 인스턴스로 교체한다."""
+    from app.services import rate_limiter as rate_limiter_module
+    monkeypatch.setattr(rate_limiter_module, "_limiter", None)
+
+
+@pytest.mark.anyio
+async def test_issue_custom_scheme_rate_limited_after_limit(monkeypatch):
+    """계약 §9 잔여위험(custom scheme = client impersonation 가능) — custom_scheme 발급은
+    별도(공용 로그인 limiter와 무관) 버킷으로 제한돼야 한다."""
+    from app.routers.auth_firebase_internal import (
+        _OAUTH_HANDOFF_CUSTOM_SCHEME_ISSUE_LIMIT, issue_oauth_handoff,
+    )
+
+    _reset_rate_limiter(monkeypatch)
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_eligible_user(s)
+
+        for _ in range(_OAUTH_HANDOFF_CUSTOM_SCHEME_ISSUE_LIMIT):
+            _verifier, challenge = _pkce_pair()
+            async with Session() as s:
+                issued = await issue_oauth_handoff(
+                    _FakeRequest(),
+                    _issue_req(user_id, challenge, callback_mode="custom_scheme", return_uri=_CUSTOM_SCHEME_RETURN_URI),
+                    authorization=None, db=s,
+                )
+            assert issued.code
+
+        _verifier, challenge = _pkce_pair()
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await issue_oauth_handoff(
+                    _FakeRequest(),
+                    _issue_req(user_id, challenge, callback_mode="custom_scheme", return_uri=_CUSTOM_SCHEME_RETURN_URI),
+                    authorization=None, db=s,
+                )
+            assert exc_info.value.status_code == 429
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_issue_https_mode_unaffected_by_custom_scheme_rate_limit(monkeypatch):
+    """«별도» 버킷임의 증거 — custom_scheme 한도를 초과하는 횟수만큼 https 발급을 반복해도
+    막히지 않아야 한다(같은 IP·같은 유저라도 축이 다름)."""
+    from app.routers.auth_firebase_internal import (
+        _OAUTH_HANDOFF_CUSTOM_SCHEME_ISSUE_LIMIT, issue_oauth_handoff,
+    )
+
+    _reset_rate_limiter(monkeypatch)
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_eligible_user(s)
+
+        for _ in range(_OAUTH_HANDOFF_CUSTOM_SCHEME_ISSUE_LIMIT + 3):
+            _verifier, challenge = _pkce_pair()
+            async with Session() as s:
+                issued = await issue_oauth_handoff(
+                    _FakeRequest(), _issue_req(user_id, challenge, callback_mode="https"),
+                    authorization=None, db=s,
+                )
+            assert issued.code
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_consume_custom_scheme_rate_limited_after_limit(monkeypatch):
+    """rate limit 검사가 code 유효성 검증보다 먼저 걸린다 — 매번 무효한 code라도(401) 한도
+    소진 후엔 429로 바뀐다."""
+    from app.routers.auth_firebase_internal import (
+        _OAUTH_HANDOFF_CUSTOM_SCHEME_CONSUME_LIMIT, consume_oauth_handoff,
+    )
+
+    _reset_rate_limiter(monkeypatch)
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        for _ in range(_OAUTH_HANDOFF_CUSTOM_SCHEME_CONSUME_LIMIT):
+            async with Session() as s:
+                with pytest.raises(HTTPException) as exc_info:
+                    await consume_oauth_handoff(
+                        _FakeRequest(),
+                        _consume_req(
+                            "bogus-code", "bogus-verifier",
+                            callback_mode="custom_scheme", return_uri=_CUSTOM_SCHEME_RETURN_URI,
+                        ),
+                        authorization=None, db=s,
+                    )
+                assert exc_info.value.status_code == 401
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_oauth_handoff(
+                    _FakeRequest(),
+                    _consume_req(
+                        "bogus-code", "bogus-verifier",
+                        callback_mode="custom_scheme", return_uri=_CUSTOM_SCHEME_RETURN_URI,
+                    ),
+                    authorization=None, db=s,
+                )
+            assert exc_info.value.status_code == 429
+    finally:
+        await engine.dispose()
+
+
+# ─── story #3121 AC3 — callback_mode별 start/consume 감사 기록 ──────────────────────────
+
+async def _last_audit_row(session, event_type: str):
+    from sqlalchemy import select
+    from app.models.login_audit_log import LoginAuditLog
+
+    result = await session.execute(
+        select(LoginAuditLog).where(LoginAuditLog.event_type == event_type).order_by(LoginAuditLog.created_at.desc())
+    )
+    return result.scalars().first()
+
+
+@pytest.mark.anyio
+async def test_issue_success_writes_mode_tagged_audit_log(monkeypatch):
+    from app.routers.auth_firebase_internal import issue_oauth_handoff
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_eligible_user(s)
+
+        _verifier, challenge = _pkce_pair()
+        async with Session() as s:
+            await issue_oauth_handoff(
+                _FakeRequest(), _issue_req(user_id, challenge, callback_mode="custom_scheme", return_uri=_CUSTOM_SCHEME_RETURN_URI),
+                authorization=None, db=s,
+            )
+
+        async with Session() as s:
+            row = await _last_audit_row(s, "oauth_handoff_issued")
+        assert row is not None
+        assert row.user_id == user_id
+        assert row.detail == "callback_mode=custom_scheme"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_consume_success_writes_mode_tagged_audit_log(monkeypatch):
+    from app.routers.auth_firebase_internal import consume_oauth_handoff, issue_oauth_handoff
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_eligible_user(s)
+
+        verifier, challenge = _pkce_pair()
+        async with Session() as s:
+            issued = await issue_oauth_handoff(_FakeRequest(), _issue_req(user_id, challenge), authorization=None, db=s)
+
+        async with Session() as s:
+            await consume_oauth_handoff(_FakeRequest(), _consume_req(issued.code, verifier), authorization=None, db=s)
+
+        async with Session() as s:
+            row = await _last_audit_row(s, "oauth_handoff_consumed")
+        assert row is not None
+        assert row.user_id == user_id
+        assert row.detail == "callback_mode=https"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_consume_failure_writes_mode_tagged_audit_log(monkeypatch):
+    from app.routers.auth_firebase_internal import consume_oauth_handoff
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException):
+                await consume_oauth_handoff(
+                    _FakeRequest(), _consume_req("bogus-code", "bogus-verifier"), authorization=None, db=s,
+                )
+
+        async with Session() as s:
+            row = await _last_audit_row(s, "oauth_handoff_consume_failed")
+        assert row is not None
+        assert row.user_id is None
+        assert row.detail == "callback_mode=https"
     finally:
         await engine.dispose()
 
@@ -598,7 +807,7 @@ async def test_oauth_handoff_code_not_consumable_via_attested_native_consume(mon
 
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
+            issued = await issue_oauth_handoff(_FakeRequest(), _issue_req(user_id, challenge), authorization=None, db=s)
 
         # oauth-handoff 코드에는 대응하는 installation/challenge가 애초에 존재하지 않는다 —
         # 임의(존재하지 않는) installation_id/challenge_id로 시도해도 attested 테이블에서

--- a/backend/tests/test_1931_oauth_handoff_realdb.py
+++ b/backend/tests/test_1931_oauth_handoff_realdb.py
@@ -8,7 +8,12 @@ issue/consume — attested native-bootstrap(§7.5, C4)과 물리적으로 분리
 
 §10.6 필수 음성 테스트 7종 중 이 파일이 커버하는 것: 1(assertion류 필드 주입 거부)·
 3(잘못된 verifier 거부)·4(동시 소비 정확히 1회)·7(위조 필드 schema 거부, 무시 아님) —
-2(구 attested consume이 신규 코드를 소비 못 함)는 물리적 테이블 분리 자체가 증명."""
+2(구 attested consume이 신규 코드를 소비 못 함)는 물리적 테이블 분리 자체가 증명.
+
+story #3121 AC1(계약 §2/§10.7) 추가: callback_mode/return_uri issue-time 고정 + consume-time
+대조 — `test_issue_rejected_return_uri_mismatch_for_mode`·
+`test_consume_rejected_when_callback_mode_mismatches_issued`·
+`test_consume_rejected_when_return_uri_mismatches_issued`."""
 from __future__ import annotations
 
 import asyncio
@@ -80,11 +85,35 @@ def _pkce_pair():
     return verifier, pkce_challenge_from_verifier(verifier)
 
 
+# story #3121 AC1 — 대부분의 기존 테스트는 mode/URI 매칭 자체가 관심사가 아니므로(verifier
+# 오류·replay·동시성·cutover 등 다른 축을 검증), 일관된 https 기본값을 재사용한다.
+def _https_return_uri() -> str:
+    from app.core.config import settings
+    return f"{settings.app_url}/native/oauth-return"
+
+
+_CUSTOM_SCHEME_RETURN_URI = "ai.sprintable:/oauth-return"
+
+
+def _issue_req(user_id, challenge, *, callback_mode="https", return_uri=None):
+    from app.routers.auth_firebase_internal import OAuthHandoffIssueRequest
+    return OAuthHandoffIssueRequest(
+        user_id=str(user_id), code_challenge=challenge,
+        callback_mode=callback_mode, return_uri=return_uri if return_uri is not None else _https_return_uri(),
+    )
+
+
+def _consume_req(code, verifier, *, callback_mode="https", return_uri=None):
+    from app.routers.auth_firebase_internal import OAuthHandoffConsumeRequest
+    return OAuthHandoffConsumeRequest(
+        code=code, code_verifier=verifier,
+        callback_mode=callback_mode, return_uri=return_uri if return_uri is not None else _https_return_uri(),
+    )
+
+
 @pytest.mark.anyio
 async def test_issue_and_consume_round_trip_success(monkeypatch):
-    from app.routers.auth_firebase_internal import (
-        OAuthHandoffConsumeRequest, OAuthHandoffIssueRequest, consume_oauth_handoff, issue_oauth_handoff,
-    )
+    from app.routers.auth_firebase_internal import consume_oauth_handoff, issue_oauth_handoff
 
     _setup_common(monkeypatch)
     engine, Session = await _session_factory()
@@ -94,15 +123,12 @@ async def test_issue_and_consume_round_trip_success(monkeypatch):
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(
-                OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge=challenge),
-                authorization=None, db=s,
-            )
+            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
         assert issued.code
 
         async with Session() as s:
             consumed = await consume_oauth_handoff(
-                OAuthHandoffConsumeRequest(code=issued.code, code_verifier=verifier), authorization=None, db=s,
+                _consume_req(issued.code, verifier), authorization=None, db=s,
             )
         assert consumed.access_token
         assert consumed.refresh_token
@@ -120,9 +146,7 @@ async def test_issue_and_consume_round_trip_success(monkeypatch):
 
 @pytest.mark.anyio
 async def test_consume_wrong_verifier_rejected(monkeypatch):
-    from app.routers.auth_firebase_internal import (
-        OAuthHandoffConsumeRequest, OAuthHandoffIssueRequest, consume_oauth_handoff, issue_oauth_handoff,
-    )
+    from app.routers.auth_firebase_internal import consume_oauth_handoff, issue_oauth_handoff
 
     _setup_common(monkeypatch)
     engine, Session = await _session_factory()
@@ -132,17 +156,13 @@ async def test_consume_wrong_verifier_rejected(monkeypatch):
 
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(
-                OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge=challenge),
-                authorization=None, db=s,
-            )
+            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
 
         wrong_verifier, _ = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
                 await consume_oauth_handoff(
-                    OAuthHandoffConsumeRequest(code=issued.code, code_verifier=wrong_verifier),
-                    authorization=None, db=s,
+                    _consume_req(issued.code, wrong_verifier), authorization=None, db=s,
                 )
             assert exc_info.value.status_code == 401
     finally:
@@ -155,9 +175,7 @@ async def test_consume_wrong_verifier_burns_code_no_retry(monkeypatch):
     원자 소비하고 그 다음 constant-time PKCE 비교를 하므로, 틀린 verifier로 한 번 시도하면
     코드가 이미 소모돼 그 뒤 올바른 verifier로도 재시도가 불가해야 한다(무제한 verifier
     추측 방지)."""
-    from app.routers.auth_firebase_internal import (
-        OAuthHandoffConsumeRequest, OAuthHandoffIssueRequest, consume_oauth_handoff, issue_oauth_handoff,
-    )
+    from app.routers.auth_firebase_internal import consume_oauth_handoff, issue_oauth_handoff
 
     _setup_common(monkeypatch)
     engine, Session = await _session_factory()
@@ -167,24 +185,19 @@ async def test_consume_wrong_verifier_burns_code_no_retry(monkeypatch):
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(
-                OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge=challenge),
-                authorization=None, db=s,
-            )
+            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
 
         wrong_verifier, _ = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException):
                 await consume_oauth_handoff(
-                    OAuthHandoffConsumeRequest(code=issued.code, code_verifier=wrong_verifier),
-                    authorization=None, db=s,
+                    _consume_req(issued.code, wrong_verifier), authorization=None, db=s,
                 )
 
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
                 await consume_oauth_handoff(
-                    OAuthHandoffConsumeRequest(code=issued.code, code_verifier=verifier),
-                    authorization=None, db=s,
+                    _consume_req(issued.code, verifier), authorization=None, db=s,
                 )
             assert exc_info.value.status_code == 401
     finally:
@@ -193,9 +206,7 @@ async def test_consume_wrong_verifier_burns_code_no_retry(monkeypatch):
 
 @pytest.mark.anyio
 async def test_consume_replay_after_success_rejected(monkeypatch):
-    from app.routers.auth_firebase_internal import (
-        OAuthHandoffConsumeRequest, OAuthHandoffIssueRequest, consume_oauth_handoff, issue_oauth_handoff,
-    )
+    from app.routers.auth_firebase_internal import consume_oauth_handoff, issue_oauth_handoff
 
     _setup_common(monkeypatch)
     engine, Session = await _session_factory()
@@ -205,12 +216,9 @@ async def test_consume_replay_after_success_rejected(monkeypatch):
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(
-                OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge=challenge),
-                authorization=None, db=s,
-            )
+            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
 
-        req = OAuthHandoffConsumeRequest(code=issued.code, code_verifier=verifier)
+        req = _consume_req(issued.code, verifier)
         async with Session() as s:
             first = await consume_oauth_handoff(req, authorization=None, db=s)
         assert first.access_token
@@ -226,9 +234,7 @@ async def test_consume_replay_after_success_rejected(monkeypatch):
 @pytest.mark.anyio
 async def test_concurrent_consume_exactly_one_succeeds(monkeypatch):
     """산티아고 §9/§10 native consume 게이트와 동형 요구 — 병렬 N-way 동시성에도 정확히 1회만 mint."""
-    from app.routers.auth_firebase_internal import (
-        OAuthHandoffConsumeRequest, OAuthHandoffIssueRequest, consume_oauth_handoff, issue_oauth_handoff,
-    )
+    from app.routers.auth_firebase_internal import consume_oauth_handoff, issue_oauth_handoff
 
     _setup_common(monkeypatch)
     engine, Session = await _session_factory()
@@ -238,12 +244,9 @@ async def test_concurrent_consume_exactly_one_succeeds(monkeypatch):
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(
-                OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge=challenge),
-                authorization=None, db=s,
-            )
+            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
 
-        req = OAuthHandoffConsumeRequest(code=issued.code, code_verifier=verifier)
+        req = _consume_req(issued.code, verifier)
 
         async def _attempt():
             async with Session() as s:
@@ -261,7 +264,7 @@ async def test_concurrent_consume_exactly_one_succeeds(monkeypatch):
 
 @pytest.mark.anyio
 async def test_issue_rejected_when_feature_disabled(monkeypatch):
-    from app.routers.auth_firebase_internal import OAuthHandoffIssueRequest, issue_oauth_handoff
+    from app.routers.auth_firebase_internal import issue_oauth_handoff
     from app.core.config import settings
 
     _setup_common(monkeypatch)
@@ -273,10 +276,7 @@ async def test_issue_rejected_when_feature_disabled(monkeypatch):
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await issue_oauth_handoff(
-                    OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge=challenge),
-                    authorization=None, db=s,
-                )
+                await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
             assert exc_info.value.status_code == 501
     finally:
         await engine.dispose()
@@ -284,7 +284,7 @@ async def test_issue_rejected_when_feature_disabled(monkeypatch):
 
 @pytest.mark.anyio
 async def test_issue_rejected_unknown_user(monkeypatch):
-    from app.routers.auth_firebase_internal import OAuthHandoffIssueRequest, issue_oauth_handoff
+    from app.routers.auth_firebase_internal import issue_oauth_handoff
 
     _setup_common(monkeypatch)
     engine, Session = await _session_factory()
@@ -292,10 +292,7 @@ async def test_issue_rejected_unknown_user(monkeypatch):
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await issue_oauth_handoff(
-                    OAuthHandoffIssueRequest(user_id=str(uuid.uuid4()), code_challenge=challenge),
-                    authorization=None, db=s,
-                )
+                await issue_oauth_handoff(_issue_req(uuid.uuid4(), challenge), authorization=None, db=s)
             assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
@@ -303,7 +300,7 @@ async def test_issue_rejected_unknown_user(monkeypatch):
 
 @pytest.mark.anyio
 async def test_issue_rejected_inactive_user(monkeypatch):
-    from app.routers.auth_firebase_internal import OAuthHandoffIssueRequest, issue_oauth_handoff
+    from app.routers.auth_firebase_internal import issue_oauth_handoff
     from app.core.security import hash_password
     from app.models.user import User
 
@@ -321,10 +318,7 @@ async def test_issue_rejected_inactive_user(monkeypatch):
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await issue_oauth_handoff(
-                    OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge=challenge),
-                    authorization=None, db=s,
-                )
+                await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
             assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
@@ -332,7 +326,7 @@ async def test_issue_rejected_inactive_user(monkeypatch):
 
 @pytest.mark.anyio
 async def test_issue_rejected_short_code_challenge(monkeypatch):
-    from app.routers.auth_firebase_internal import OAuthHandoffIssueRequest, issue_oauth_handoff
+    from app.routers.auth_firebase_internal import issue_oauth_handoff
 
     _setup_common(monkeypatch)
     engine, Session = await _session_factory()
@@ -343,8 +337,7 @@ async def test_issue_rejected_short_code_challenge(monkeypatch):
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
                 await issue_oauth_handoff(
-                    OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge="too-short"),
-                    authorization=None, db=s,
+                    _issue_req(user_id, "too-short"), authorization=None, db=s,
                 )
             assert exc_info.value.status_code == 400
     finally:
@@ -355,9 +348,7 @@ async def test_issue_rejected_short_code_challenge(monkeypatch):
 async def test_orphan_finding_revoke_between_issue_and_consume_rejected(monkeypatch):
     """Story A(bea25062)/C4 orphan-finding 회귀와 동형 — issue 이후(120초 내 미만료) revoke가
     발생하면 consume이 cutover 재검증에서 거부돼야 한다(레거시 세션도 동일 §17d 메커니즘)."""
-    from app.routers.auth_firebase_internal import (
-        OAuthHandoffConsumeRequest, OAuthHandoffIssueRequest, consume_oauth_handoff, issue_oauth_handoff,
-    )
+    from app.routers.auth_firebase_internal import consume_oauth_handoff, issue_oauth_handoff
     from app.services.auth_cutover import revoke_user_sessions
 
     _setup_common(monkeypatch)
@@ -368,10 +359,7 @@ async def test_orphan_finding_revoke_between_issue_and_consume_rejected(monkeypa
 
         verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(
-                OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge=challenge),
-                authorization=None, db=s,
-            )
+            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
 
         async with Session() as s:
             await revoke_user_sessions(s, user_id, firebase_uid=None)
@@ -379,7 +367,98 @@ async def test_orphan_finding_revoke_between_issue_and_consume_rejected(monkeypa
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
                 await consume_oauth_handoff(
-                    OAuthHandoffConsumeRequest(code=issued.code, code_verifier=verifier),
+                    _consume_req(issued.code, verifier), authorization=None, db=s,
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+# ─── story #3121 AC1 — callback_mode/return_uri issue-time 고정 + consume-time 대조 ───────
+
+@pytest.mark.anyio
+async def test_issue_rejected_return_uri_mismatch_for_mode(monkeypatch):
+    """계약 §2/§10.9 exact-origin — https 모드인데 custom-scheme URI를 선언(혹은 그 반대)하면
+    issue 자체가 거부돼야 한다. 클라 선언을 그대로 저장하지 않고 서버 고정값과 대조한다는
+    것의 직접 증거."""
+    from app.routers.auth_firebase_internal import issue_oauth_handoff
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_eligible_user(s)
+
+        _verifier, challenge = _pkce_pair()
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await issue_oauth_handoff(
+                    _issue_req(user_id, challenge, callback_mode="https", return_uri=_CUSTOM_SCHEME_RETURN_URI),
+                    authorization=None, db=s,
+                )
+            assert exc_info.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_consume_rejected_when_callback_mode_mismatches_issued(monkeypatch):
+    """코드가 https 모드로 발급됐는데 custom_scheme 모드(+그 모드의 정당한 URI)로 소비를
+    시도하면 원자 UPDATE의 WHERE절에서 매치되는 행이 없어 거부돼야 한다 — 올바른 code+verifier를
+    가진 공격자가 모드만 바꿔 다른 채널로 세션을 mint하는 시나리오의 직접 방어."""
+    from app.routers.auth_firebase_internal import consume_oauth_handoff, issue_oauth_handoff
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_eligible_user(s)
+
+        verifier, challenge = _pkce_pair()
+        async with Session() as s:
+            issued = await issue_oauth_handoff(
+                _issue_req(user_id, challenge, callback_mode="https"), authorization=None, db=s,
+            )
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_oauth_handoff(
+                    _consume_req(
+                        issued.code, verifier,
+                        callback_mode="custom_scheme", return_uri=_CUSTOM_SCHEME_RETURN_URI,
+                    ),
+                    authorization=None, db=s,
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_consume_rejected_when_return_uri_mismatches_issued(monkeypatch):
+    """같은 https 모드라도 issue 시점과 다른 return_uri(예: 다른 오리진)로 consume을 시도하면
+    거부돼야 한다 — mode만이 아니라 exact URI도 독립적으로 대조축임을 증명."""
+    from app.routers.auth_firebase_internal import consume_oauth_handoff, issue_oauth_handoff
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_eligible_user(s)
+
+        verifier, challenge = _pkce_pair()
+        async with Session() as s:
+            issued = await issue_oauth_handoff(
+                _issue_req(user_id, challenge, callback_mode="https"), authorization=None, db=s,
+            )
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_oauth_handoff(
+                    _consume_req(
+                        issued.code, verifier,
+                        callback_mode="https", return_uri="https://evil.example.com/native/oauth-return",
+                    ),
                     authorization=None, db=s,
                 )
             assert exc_info.value.status_code == 401
@@ -395,7 +474,10 @@ def test_consume_schema_rejects_unknown_fields():
     from app.routers.auth_firebase_internal import OAuthHandoffConsumeRequest
 
     with pytest.raises(ValidationError):
-        OAuthHandoffConsumeRequest(code="c", code_verifier="v", existing_session_user_id="attacker-uid")
+        OAuthHandoffConsumeRequest(
+            code="c", code_verifier="v", callback_mode="https", return_uri="x",
+            existing_session_user_id="attacker-uid",
+        )
 
 
 def test_consume_schema_rejects_attestation_shaped_fields():
@@ -406,14 +488,31 @@ def test_consume_schema_rejects_attestation_shaped_fields():
 
     for bad_field in ("installation_id", "assertion_b64", "signature_b64", "challenge_id", "key_version"):
         with pytest.raises(ValidationError):
-            OAuthHandoffConsumeRequest(code="c", code_verifier="v", **{bad_field: "x"})
+            OAuthHandoffConsumeRequest(
+                code="c", code_verifier="v", callback_mode="https", return_uri="x", **{bad_field: "x"},
+            )
 
 
 def test_issue_schema_rejects_unknown_fields():
     from app.routers.auth_firebase_internal import OAuthHandoffIssueRequest
 
     with pytest.raises(ValidationError):
-        OAuthHandoffIssueRequest(user_id=str(uuid.uuid4()), code_challenge="c" * 43, installation_id="x")
+        OAuthHandoffIssueRequest(
+            user_id=str(uuid.uuid4()), code_challenge="c" * 43,
+            callback_mode="https", return_uri="x", installation_id="x",
+        )
+
+
+def test_issue_schema_rejects_unknown_callback_mode():
+    """story #3121 AC1 — callback_mode는 Literal["https","custom_scheme"] 고정. 임의 문자열
+    (예: 향후 오추가될 제3의 모드나 오타)은 schema 레벨에서 거부돼야 한다."""
+    from app.routers.auth_firebase_internal import OAuthHandoffIssueRequest
+
+    with pytest.raises(ValidationError):
+        OAuthHandoffIssueRequest(
+            user_id=str(uuid.uuid4()), code_challenge="c" * 43,
+            callback_mode="ftp", return_uri="x",
+        )
 
 
 # ─── §10.6 voice test 2 — 물리적 테이블 분리(구 attested consume이 신규 코드 소비 불가) ──
@@ -425,7 +524,7 @@ async def test_oauth_handoff_code_not_consumable_via_attested_native_consume(mon
     거기서 조회 자체가 안 되고(0 rows), attested 스키마가 요구하는 installation_id/
     challenge_id도 애초에 없어 값 자체를 구성할 수 없다(구성 시도만으로도 무의미함을 실증)."""
     from app.routers.auth_firebase_internal import (
-        NativeBootstrapConsumeRequest, OAuthHandoffIssueRequest, consume_native_bootstrap, issue_oauth_handoff,
+        NativeBootstrapConsumeRequest, consume_native_bootstrap, issue_oauth_handoff,
     )
     from app.core.config import settings
 
@@ -438,10 +537,7 @@ async def test_oauth_handoff_code_not_consumable_via_attested_native_consume(mon
 
         _verifier, challenge = _pkce_pair()
         async with Session() as s:
-            issued = await issue_oauth_handoff(
-                OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge=challenge),
-                authorization=None, db=s,
-            )
+            issued = await issue_oauth_handoff(_issue_req(user_id, challenge), authorization=None, db=s)
 
         # oauth-handoff 코드에는 대응하는 installation/challenge가 애초에 존재하지 않는다 —
         # 임의(존재하지 않는) installation_id/challenge_id로 시도해도 attested 테이블에서

--- a/backend/tests/test_1931_oauth_handoff_realdb.py
+++ b/backend/tests/test_1931_oauth_handoff_realdb.py
@@ -466,6 +466,67 @@ async def test_consume_rejected_when_return_uri_mismatches_issued(monkeypatch):
         await engine.dispose()
 
 
+# ─── story #3121 AC1 Phase 1 delta(PR #3538 PO 리뷰) — expand-contract 하위호환 ──────────
+
+@pytest.mark.anyio
+async def test_issue_and_consume_omitted_mode_fields_defaults_to_https_round_trip(monkeypatch):
+    """민군 BFF 절반 착지 전 레거시 payload({user_id, code_challenge}만·{code, code_verifier}만)
+    재현 — callback_mode/return_uri를 아예 안 보내도 서버가 https로 유도해 이슈+consume
+    왕복이 여전히 성공해야 한다(머지 즉시 422 전멸 방지가 이 delta의 목적)."""
+    from app.routers.auth_firebase_internal import (
+        OAuthHandoffConsumeRequest, OAuthHandoffIssueRequest, consume_oauth_handoff, issue_oauth_handoff,
+    )
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_eligible_user(s)
+
+        verifier, challenge = _pkce_pair()
+        async with Session() as s:
+            issued = await issue_oauth_handoff(
+                OAuthHandoffIssueRequest(user_id=str(user_id), code_challenge=challenge),
+                authorization=None, db=s,
+            )
+        assert issued.code
+
+        async with Session() as s:
+            consumed = await consume_oauth_handoff(
+                OAuthHandoffConsumeRequest(code=issued.code, code_verifier=verifier),
+                authorization=None, db=s,
+            )
+        assert consumed.access_token
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_issue_rejects_half_declared_mode_fields(monkeypatch):
+    """callback_mode만 있고 return_uri가 없는(혹은 그 반대) 반쪽 선언은 레거시 유도 대상이
+    아니다 — 오배선 신호로 보고 명시 거부한다(조용히 한쪽만 기본값으로 채우지 않음)."""
+    from app.routers.auth_firebase_internal import OAuthHandoffIssueRequest, issue_oauth_handoff
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_eligible_user(s)
+
+        _verifier, challenge = _pkce_pair()
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await issue_oauth_handoff(
+                    OAuthHandoffIssueRequest(
+                        user_id=str(user_id), code_challenge=challenge, callback_mode="https",
+                    ),
+                    authorization=None, db=s,
+                )
+            assert exc_info.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
 # ─── §10.6 음성 테스트 — schema-level 거부(extra="forbid") ─────────────────────
 
 def test_consume_schema_rejects_unknown_fields():


### PR DESCRIPTION
[SID:3121]

## 배경
계약 doc `e-mobile-oauth-native-handoff-contract` §2/§10.7·산티아고 SSOT — iOS 17.4 미만 custom-scheme fallback은 "association 실패 후 동적 전환"이 아니라 "OAuth 시작 전 정적으로 결정되는 compatibility mode"(계약 §2). AC1(BE 절반, 페드루 배정)은 이 mode+exact return URI를 `oauth_handoff_codes`에 고정하고 consume 시 대조하는 것.

## 변경
- 마이그레이션 0284: `callback_mode`(CHECK IN https|custom_scheme)+`return_uri` 컬럼 신설. 모델에도 동일 CheckConstraint 미러(CI SQLite create_all 경로가 PG CHECK를 못 잡는 블라인드스팟 방지).
- `OAuthHandoffIssueRequest`에 두 필드 추가 — 클라 선언 `return_uri`를 그대로 저장하지 않고 서버 고정값(`_expected_return_uri()`: https는 `settings.app_url`+`/native/oauth-return`, custom_scheme은 `ai.sprintable:/oauth-return` 고정)과 byte-exact 대조 후 저장. 불일치 시 400.
- `OAuthHandoffConsumeRequest`에도 동일 필드 추가, `consume_handoff_code()`의 원자 UPDATE WHERE절에 `callback_mode`/`return_uri` 등가 조건 편입 — 다른 모드/URI로 소비 시도 시 매치되는 행이 없어 그냥 거부(코드는 안 태움: mode/URI는 비밀값이 아니라 PKCE verifier와 달리 "틀려도 태워야 추측 방지" 근거가 없음).

## 검증
- 로컬 realdb(PG16) 2경로 교차검증: `create_all()` 기반 + 실 alembic 마이그레이션 체인(baseline→0284, upgrade/downgrade/재upgrade 왕복) 둘 다 성공.
- `test_1931_oauth_handoff_realdb.py`: 기존 13건 유지(헬퍼 정리)+신규 5건 — issue return_uri 모드불일치 거부·consume mode 불일치 거부·consume URI 불일치 거부·issue schema 미지원 callback_mode 거부·기존 테스트 헬퍼화. 신규 핵심 3건은 이중 뮤테이션(검증 로직 제거·WHERE절 조건 제거) genuine RED 확認 後 복원.
- 91/91 관련 realdb 테스트 green(oauth_handoff+인접 5개 파일).
- 커스텀 AST guard lint 5종(query_sentinel/candidate_source_ownership/project_access_403/dependency_override_get_read_db/commit_before_validate) 전량 새 위반 0건.

## 스코프 경계
BFF/모바일 정합 절반(민 레군)은 이 PR 밖 — 이슈 스키마 필드명(`callback_mode`/`return_uri`)·모드값(`https`|`custom_scheme`)이 인터페이스 확定분. 민군 착수 전 페드루군 조율 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)