### PR TITLE
[SID:3130] scale-ladder 「작업」 칸 dead→reserved

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -633,6 +633,8 @@
     "ladderLabelLens": "Lens",
     "ladderLabelMove": "Go",
     "ladderLabelPending": "No surface yet",
+    "ladderReservedChip": "◇ Inside a story",
+    "ladderReservedInfo": "\"Task\" doesn't have its own screen yet. It's tracked as a subtask inside stories for now — that's not broken, this scale just doesn't have a dedicated surface yet. This tile activates once that surface exists.",
     "earthSectionTitle": "Questions being verified now",
     "earthEpicCount": "{n} goal(s) linked",
     "earthMetric": "Metric",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -633,6 +633,8 @@
     "ladderLabelLens": "렌즈",
     "ladderLabelMove": "이동",
     "ladderLabelPending": "표면 대기",
+    "ladderReservedChip": "◇ 스토리 안에 있음",
+    "ladderReservedInfo": "「작업」은 별도 화면이 없습니다. 지금은 스토리 안의 subtask로 관리됩니다 — 고장이 아니라 이 축척엔 아직 전용 표면이 없는 것입니다. 표면이 생기면 이 칸이 활성화됩니다.",
     "earthSectionTitle": "지금 검증 중인 질문",
     "earthEpicCount": "목표 {n}개 연결",
     "earthMetric": "지표",

--- a/apps/web/src/components/flow/scale-ladder.test.tsx
+++ b/apps/web/src/components/flow/scale-ladder.test.tsx
@@ -144,24 +144,108 @@ describe('ScaleLadder', () => {
       expect(rung?.textContent).toContain('↗');
     });
 
-    it('작업 rung은 클릭 요소가 아니다(button도 a도 아님) — 전용 표면 없음, 거짓 ↗ 금지(조건①)', () => {
+    it('작업 rung은 목표(A)처럼 표면 이동 링크가 아니다 — 거짓 ↗ 금지는 여전히 유효(조건①)', () => {
       act(() => { root.render(wrap(<ScaleLadder />)); });
       const rung = findRung(koMessages.flow.ladderName_building);
-      expect(rung?.tagName).not.toBe('BUTTON');
       expect(rung?.tagName).not.toBe('A');
       expect(rung?.textContent).not.toContain('↗');
       act(() => { rung!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
       expect(pushMock).not.toHaveBeenCalled();
     });
 
-    it('렌즈/이동/대기 라벨로 이중 표식된다(조건① — 화살표만으론 부족, 텍스트 라벨도 동반)', () => {
+    it('렌즈/이동 라벨로 이중 표식된다(조건① — 화살표만으론 부족, 텍스트 라벨도 동반)', () => {
       act(() => { root.render(wrap(<ScaleLadder />)); });
       const earthRung = findRung(koMessages.flow.ladderName_earth);
       const goalRung = findRung(koMessages.flow.ladderName_continent);
-      const taskRung = findRung(koMessages.flow.ladderName_building);
       expect(earthRung?.textContent).toContain(koMessages.flow.ladderLabelLens);
       expect(goalRung?.textContent).toContain(koMessages.flow.ladderLabelMove);
-      expect(taskRung?.textContent).toContain(koMessages.flow.ladderLabelPending);
+    });
+  });
+
+  // story #3130(유나 SSOT doc 4f6cba9b) — 「작업」 dead(클릭 불가·«고장»으로 읽힘) →
+  // reserved(클릭 가능·안내 팝오버) 전환. 선생님이 "왜 안 눌리는지" 재차 물은 실목격 정정.
+  describe('작업 rung 예약 신호(story #3130)', () => {
+    function findRung(name: string): HTMLElement | undefined {
+      return Array.from(container.querySelector('.flex.overflow-hidden')?.children ?? []).find(
+        (d) => d.textContent?.includes(name),
+      ) as HTMLElement | undefined;
+    }
+
+    it('«표면 대기» 대신 칩(«◇ 스토리 안에 있음»)이 렌더된다 — 옛 라벨은 잔존하지 않는다', () => {
+      act(() => { root.render(wrap(<ScaleLadder />)); });
+      const taskRung = findRung(koMessages.flow.ladderName_building);
+      expect(taskRung?.textContent).toContain(koMessages.flow.ladderReservedChip);
+      expect(taskRung?.textContent).not.toContain(koMessages.flow.ladderLabelPending);
+    });
+
+    it('dead가 아니라 reserved다 — cursor-not-allowed가 아니라 cursor-help, aria-disabled 없음', () => {
+      act(() => { root.render(wrap(<ScaleLadder />)); });
+      const taskRung = findRung(koMessages.flow.ladderName_building);
+      expect(taskRung?.className).toContain('cursor-help');
+      expect(taskRung?.className).not.toContain('cursor-not-allowed');
+      expect(taskRung?.getAttribute('aria-disabled')).toBeNull();
+    });
+
+    it('클릭 가능한 button이 내부에 있다 — 클릭해도 push는 안 하지만(전용 표면 없음) 안내 팝오버가 뜬다', () => {
+      act(() => { root.render(wrap(<ScaleLadder />)); });
+      const taskRung = findRung(koMessages.flow.ladderName_building);
+      const trigger = taskRung?.querySelector('button');
+      expect(trigger).toBeTruthy();
+      expect(container.textContent).not.toContain(koMessages.flow.ladderReservedInfo);
+      act(() => { trigger!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(pushMock).not.toHaveBeenCalled();
+      expect(container.textContent).toContain(koMessages.flow.ladderReservedInfo);
+      // doc(4f6cba9b) MUST — «고장이 아니라» 절이 문구에 verbatim으로 있어야 한다.
+      expect(koMessages.flow.ladderReservedInfo).toContain('고장이 아니라');
+    });
+
+    it('열렸을 때만 aria-describedby가 팝오버 id를 가리킨다', () => {
+      act(() => { root.render(wrap(<ScaleLadder />)); });
+      const taskRung = findRung(koMessages.flow.ladderName_building);
+      const trigger = taskRung!.querySelector('button')!;
+      expect(trigger.getAttribute('aria-describedby')).toBeNull();
+      act(() => { trigger.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      const describedBy = trigger.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      const info = container.querySelector(`#${describedBy}`);
+      expect(info?.textContent).toBe(koMessages.flow.ladderReservedInfo);
+    });
+
+    it('다시 클릭하면(토글) 팝오버가 닫힌다', () => {
+      act(() => { root.render(wrap(<ScaleLadder />)); });
+      const trigger = findRung(koMessages.flow.ladderName_building)!.querySelector('button')!;
+      act(() => { trigger.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(container.textContent).toContain(koMessages.flow.ladderReservedInfo);
+      act(() => { trigger.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(container.textContent).not.toContain(koMessages.flow.ladderReservedInfo);
+    });
+
+    it('바깥을 클릭하면 팝오버가 닫힌다', () => {
+      act(() => { root.render(wrap(<ScaleLadder />)); });
+      const trigger = findRung(koMessages.flow.ladderName_building)!.querySelector('button')!;
+      act(() => { trigger.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(container.textContent).toContain(koMessages.flow.ladderReservedInfo);
+      act(() => { document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true })); });
+      expect(container.textContent).not.toContain(koMessages.flow.ladderReservedInfo);
+    });
+
+    it('Escape 키로 팝오버가 닫힌다', () => {
+      act(() => { root.render(wrap(<ScaleLadder />)); });
+      const trigger = findRung(koMessages.flow.ladderName_building)!.querySelector('button')!;
+      act(() => { trigger.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(container.textContent).toContain(koMessages.flow.ladderReservedInfo);
+      act(() => { document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })); });
+      expect(container.textContent).not.toContain(koMessages.flow.ladderReservedInfo);
+    });
+
+    it('compact 모드도 작업 칩 클릭 시 같은 안내 팝오버가 뜬다(터치는 hover가 없어 유일한 안내 경로)', () => {
+      act(() => { root.render(wrap(<ScaleLadder compact />)); });
+      const trigger = Array.from(container.querySelectorAll('button')).find(
+        (b) => b.textContent?.includes(koMessages.flow.ladderName_building),
+      );
+      expect(trigger).toBeTruthy();
+      act(() => { trigger!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(container.textContent).toContain(koMessages.flow.ladderReservedInfo);
     });
   });
 

--- a/apps/web/src/components/flow/scale-ladder.tsx
+++ b/apps/web/src/components/flow/scale-ladder.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
+import { Info } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 
@@ -31,14 +33,17 @@ export type LadderLevel = (typeof LADDER_LEVELS)[number];
 
 type LensView = 'hypothesis' | 'flow' | 'list';
 
-type RungBehavior = { kind: 'lens'; view: LensView } | { kind: 'move' } | { kind: 'dead' };
+// story #3130(유나 SSOT doc jakup-reserved-signal-final-spec-3731984e, 2026-08-27) — 「작업」
+// 칸의 dead(클릭 불가·«고장»으로 읽힘)를 reserved(클릭 가능·안내 팝오버)로 전환. `dead`
+// kind는 타입에서 제거하지 않는다(doc: "추가" — 향후 다른 kind가 필요할 자리로 존치).
+type RungBehavior = { kind: 'lens'; view: LensView } | { kind: 'move' } | { kind: 'dead' } | { kind: 'reserved' };
 
 const RUNG_BEHAVIOR: Record<LadderLevel, RungBehavior> = {
   earth: { kind: 'lens', view: 'hypothesis' },
   continent: { kind: 'move' },
   city: { kind: 'lens', view: 'flow' },
   street: { kind: 'lens', view: 'list' },
-  building: { kind: 'dead' },
+  building: { kind: 'reserved' },
 };
 
 export function ScaleLadder({ activeLevel = 'earth', compact = false }: { activeLevel?: LadderLevel; compact?: boolean }) {
@@ -67,8 +72,34 @@ export function ScaleLadder({ activeLevel = 'earth', compact = false }: { active
     const behavior = RUNG_BEHAVIOR[level];
     if (behavior.kind === 'move') return t('ladderLabelMove');
     if (behavior.kind === 'dead') return t('ladderLabelPending');
+    if (behavior.kind === 'reserved') return t('ladderLabelPending'); // 도달 안 함 — reserved는 전용 칩 렌더로 대체.
     return t('ladderLabelLens');
   }
+
+  // story #3130 — reserved rung 클릭 시 안내 팝오버. 한 번에 하나만 열린다(래더 전체에 예약
+  // rung이 여럿이어도 상태 하나 공유 — 오늘은 building 뿐이라 실질적으로 무관하지만 향후
+  // 확장 대비). ref는 열린 rung의 wrapper에만 붙는다 — 트리거 버튼 클릭이 "바깥 클릭"으로
+  // 오인돼 즉시 재닫히는 것을 막는다(sender-profile-popover.tsx와 동형 관행).
+  const [openReservedLevel, setOpenReservedLevel] = useState<LadderLevel | null>(null);
+  const reservedWrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (openReservedLevel === null) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (reservedWrapperRef.current && !reservedWrapperRef.current.contains(e.target as Node)) {
+        setOpenReservedLevel(null);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpenReservedLevel(null);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [openReservedLevel]);
 
   // story #3043(PO+유나 IA 확定 ⓐ, 2026-08-25) — <lg에서 이 카드열(이름+질문 5칸, py-2.5)이
   // 「주」처럼 보여 보드(칸반) 콘텐츠를 아래로 밀어냈다(유나 실측). 래더는 원래 역할이 보드의
@@ -89,6 +120,7 @@ export function ScaleLadder({ activeLevel = 'earth', compact = false }: { active
             'shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium transition',
             active ? 'bg-brand/10 text-brand' : 'text-muted-foreground',
             behavior.kind === 'dead' && 'cursor-not-allowed opacity-60',
+            behavior.kind === 'reserved' && 'cursor-help',
           );
           if (behavior.kind === 'lens') {
             return (
@@ -102,6 +134,36 @@ export function ScaleLadder({ activeLevel = 'earth', compact = false }: { active
               <Link key={level} href={goalsHref} className={chipClassName}>
                 {t(`ladderName_${level}`)}
               </Link>
+            );
+          }
+          if (behavior.kind === 'reserved') {
+            // compact 칩 텍스트는 이름 그대로 유지(«스토리 안» 축약은 폭 예산상 생략) — (i)+
+            // 클릭 팝오버로 "예약/안내"임을 전달하는 것으로 충분하다고 판단(doc: 칩 축약은
+            // "가능"이지 필수 아님). 터치 기기는 hover가 없어 이 클릭 팝오버가 유일한 안내
+            // 경로다(doc 명시).
+            const open = openReservedLevel === level;
+            const infoId = `ladder-reserved-info-compact-${level}`;
+            return (
+              <div key={level} ref={open ? reservedWrapperRef : undefined} className="relative shrink-0">
+                <button
+                  type="button"
+                  aria-describedby={open ? infoId : undefined}
+                  onClick={() => setOpenReservedLevel(open ? null : level)}
+                  className={cn(chipClassName, 'inline-flex items-center gap-1')}
+                >
+                  {t(`ladderName_${level}`)}
+                  <Info aria-hidden="true" className="size-3" />
+                </button>
+                {open && (
+                  <div
+                    id={infoId}
+                    role="tooltip"
+                    className="absolute left-0 top-full z-20 mt-2 w-56 rounded-lg border border-border bg-popover p-3 text-xs text-popover-foreground shadow-[var(--elev-overlay)]"
+                  >
+                    {t('ladderReservedInfo')}
+                  </div>
+                )}
+              </div>
             );
           }
           return (
@@ -123,7 +185,10 @@ export function ScaleLadder({ activeLevel = 'earth', compact = false }: { active
           'relative flex-1 border-r border-border px-3 py-2.5 pb-6 text-left last:border-r-0',
           active && 'bg-gradient-to-b from-brand/10 to-transparent',
           behavior.kind === 'dead' && 'cursor-not-allowed bg-muted/40',
-          behavior.kind !== 'dead' && 'cursor-pointer hover:bg-muted/30',
+          // story #3130 — reserved는 bg-muted/40을 유지한다(«죽음 회색»이 아니라 «예약» 신호로
+          // doc이 명시 — 색 자체는 안 바꾸고 cursor-help+hover 강화로 클릭 가능함만 알린다).
+          behavior.kind === 'reserved' && 'cursor-help bg-muted/40 hover:bg-muted/60',
+          behavior.kind !== 'dead' && behavior.kind !== 'reserved' && 'cursor-pointer hover:bg-muted/30',
         );
         const inner = (
           <>
@@ -161,6 +226,42 @@ export function ScaleLadder({ activeLevel = 'earth', compact = false }: { active
             <Link key={level} href={goalsHref} className={rungClassName}>
               {inner}
             </Link>
+          );
+        }
+        if (behavior.kind === 'reserved') {
+          // story #3130(유나 SSOT doc 4f6cba9b) — dot/라벨이 lens·move와 달라 공유 `inner`를
+          // 재사용하지 않는다: 점선 dot(placeholder 관용어)·이름 자리 우측의 (i) 아이콘·바닥의
+          // 라벨(9.5px uppercase 캡션) 대신 칩(«◇ 스토리 안에 있음»). 클릭 → 팝오버 토글.
+          const open = openReservedLevel === level;
+          const infoId = `ladder-reserved-info-${level}`;
+          return (
+            <div key={level} ref={open ? reservedWrapperRef : undefined} className={rungClassName}>
+              <button
+                type="button"
+                aria-describedby={open ? infoId : undefined}
+                onClick={() => setOpenReservedLevel(open ? null : level)}
+                className="block h-full w-full text-left"
+              >
+                <div className="text-sm font-semibold text-muted-foreground">{t(`ladderName_${level}`)}</div>
+                <div className="mt-1 text-[11px] leading-snug text-muted-foreground">{t(`ladderQuestion_${level}`)}</div>
+                <span aria-hidden="true" className="absolute top-2.5 right-2.5 flex items-center gap-1">
+                  <Info className="size-3 text-muted-foreground" />
+                  <span className="size-2 rounded-full border border-dashed border-border" />
+                </span>
+                <span className="absolute bottom-2 left-3 inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-[10.5px] font-semibold text-muted-foreground">
+                  {t('ladderReservedChip')}
+                </span>
+              </button>
+              {open && (
+                <div
+                  id={infoId}
+                  role="tooltip"
+                  className="absolute left-3 top-full z-20 mt-2 w-56 rounded-lg border border-border bg-popover p-3 text-xs text-popover-foreground shadow-[var(--elev-overlay)]"
+                >
+                  {t('ladderReservedInfo')}
+                </div>
+              )}
+            </div>
           );
         }
         return (


### PR DESCRIPTION
[SID:3130]

## 배경
선생님 실목격(2026-08-27) — #3112로 축척 네비게이터 승격 후에도 「작업」 칸이 왜 클릭 안 되는지 재차 물음. 현행 dead 처리(aria-disabled div·cursor-not-allowed·9.5px 「표면 대기」 라벨)가 "대기 중"이 아니라 "고장/이상함"으로 읽힌다는 실증.

## 구현
유나 design SSOT doc([`jakup-reserved-signal-final-spec-3731984e`](entity:doc:4f6cba9b-3fa2-4393-8aa8-76447815a88c))의 확定 규격 그대로:
- `RungBehavior`에 `reserved` kind 추가(`dead`는 doc 지시대로 존치).
- 시각: 채운 dot → 점선 dot(placeholder 관용어) + (i) 아이콘. 바닥 라벨 → 칩(「◇ 스토리 안에 있음」, 신규 i18n `ladderReservedChip`). 배경(`bg-muted/40`)은 유지하되 `cursor-help`+`hover:bg-muted/60`로 클릭 가능 신호만 추가.
- 클릭 → 안내 팝오버 토글(문구 verbatim, 신규 i18n `ladderReservedInfo` — "고장이 아니라" 절 포함, PO 확定). `aria-describedby`로 트리거↔팝오버 연결. 바깥 클릭/Escape로 닫힘(기존 `sender-profile-popover.tsx` 관행 재사용 — 새 Popover 프리미티브 도입 안 함).
- compact(모바일)도 동일 처리 — 터치는 hover가 없어 클릭 팝오버가 유일한 안내 경로.

## 검증
- 기존 테스트 2건(옛 dead 가정)을 신규 동작에 맞게 갱신 + 신규 8건(칩 텍스트·cursor-help·클릭→팝오버·aria-describedby 열림/닫힘·토글·바깥클릭 닫힘·Escape 닫힘·compact 클릭) — 25/25 green.
- tsc/eslint/i18n-key-parity(`scripts/check-i18n-keys.js`)/`next build` 전부 green.

## 스코프 경계
design 게이트(라이브 클릭 왕복·양 테마 확認)는 유나군 몫 — 이 PR은 구현까지. 「작업 층 표면 신설」(doc ③)은 별도 기획 라운드, 이 PR 범위 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)