### PR TITLE
[SID:3129] 커맨드 렌더에서도 참조 토큰 파싱

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -1882,3 +1882,37 @@ describe('ChatBubble — story #3106 sender_runtime_type → Avatar 배선', () 
     expect(container.textContent).toContain('Agent');
   });
 });
+
+// story #3129(선생님 실목격 2026-08-27) — 게이트웨이 reply로 나간 커맨드형 메시지가 커맨드
+// 박스로 렌더되는 것 자체는 정상(isCommand는 content-only 판정, S8 설계 그대로)이나, 그
+// args 안의 참조 토큰이 링크/칩으로 안 풀리고 `[제목](entity:type:id)` 원문 그대로 노출되던
+// 결함(②)의 회귀가드. 커맨드 args도 일반 메시지와 같은 ChatMarkdown 경로를 타야 한다.
+describe('ChatBubble — story #3129 커맨드 렌더에서도 참조 토큰 파싱', () => {
+  it('커맨드 args 안의 참조 토큰이 원문 노출이 아니라 칩 라벨로 렌더된다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble
+          message={{ ...baseMessage, content: `/review [제안서.md](entity:doc:${DOC_ID})`, references: undefined }}
+          isMine={false}
+        />,
+      ));
+    });
+    // 커맨드 박스 식별(이름은 여전히 code로 고정 렌더).
+    expect(container.textContent).toContain('/review');
+    // 결함 재현 조건 — 고쳐지기 전엔 이 원문 마크다운 문자열이 그대로 텍스트로 남는다.
+    expect(container.textContent).not.toContain('entity:doc:');
+    expect(container.textContent).not.toContain('](');
+    // 대신 칩 라벨이 파싱되어 보인다.
+    expect(container.textContent).toContain('제안서.md');
+  });
+
+  it('args 없는 순수 커맨드(`/review`)는 참조 렌더 블록 자체가 안 생긴다(회귀 0)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChatBubble message={{ ...baseMessage, content: '/review', references: undefined }} isMine={false} />,
+      ));
+    });
+    expect(container.textContent).toContain('/review');
+    expect(container.querySelector('button')).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -8,7 +8,7 @@ import { Check, Copy, MessageSquare, Terminal } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { AgentIdentity } from '@/components/ui/agent-identity';
-import { commandName, dequoteLiteral, isCommand } from '@/lib/command-classifier';
+import { commandArgs, commandName, dequoteLiteral, isCommand } from '@/lib/command-classifier';
 import { EmbedCard, EntityChip, getEntityHref } from '@/components/chat/embed-card';
 import { parseEntityRef } from '@/components/chat/entity-ref';
 import { resolveEmbedDecision } from '@/components/chat/embed-renderer';
@@ -391,6 +391,7 @@ export function ChatBubble({
   const isLiteral = !isCmd && message.content.startsWith('//');
   const displayContent = isLiteral ? dequoteLiteral(message.content) : message.content;
   const cmdName = isCmd ? commandName(message.content) : null;
+  const args = isCmd ? commandArgs(message.content) : '';
   const displayName = isMine ? t('you') : (message.sender_name || t('team'));
   const time = new Intl.DateTimeFormat('ko-KR', { hour: '2-digit', minute: '2-digit' }).format(new Date(message.created_at));
   const replyCount = message.reply_count ?? 0;
@@ -592,10 +593,23 @@ export function ChatBubble({
                 <Terminal className="h-3 w-3" aria-hidden />
                 {t('commandTag')}
               </div>
-              <code className="block whitespace-pre-wrap [overflow-wrap:anywhere] font-mono text-sm">
-                <span className="text-foreground">/{cmdName}</span>
-                <span className="text-muted-foreground">{message.content.slice(1 + (cmdName?.length ?? 0))}</span>
-              </code>
+              {/* story #3129 — 커맨드 렌더도 args 안의 참조 토큰(`[제목](entity:type:id)`)은
+                  링크/칩으로 풀려야 한다. `/cmdName`만 code로 고정하고, args는 일반 메시지와
+                  동일한 ChatMarkdown 경로(references·엔티티 칩 SSOT 공유)로 넘긴다 — args가
+                  순수 텍스트뿐이면 마크다운 매치가 없어 기존과 동일하게 보인다(회귀 0). */}
+              <code className="font-mono text-sm text-foreground">/{cmdName}</code>
+              {args && (
+                <div className="mt-0.5 font-mono text-sm text-muted-foreground [&_p]:mb-0">
+                  <ChatMarkdown
+                    content={args}
+                    isMine={isMine}
+                    references={message.references}
+                    entityStatusByKey={entityStatusByKey}
+                    onOpenReadingPanel={onOpenReadingPanel}
+                    eventDefinitionsByKey={eventDefinitionsByKey}
+                  />
+                </div>
+              )}
             </div>
           ) : (
             /* story #2921 S4(유나 확定) — 버블=무채 panel(내 메시지=blue-soft). 옛

--- a/apps/web/src/lib/command-classifier.test.ts
+++ b/apps/web/src/lib/command-classifier.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { commandName, dequoteLiteral, isCommand } from './command-classifier';
+import { commandArgs, commandName, dequoteLiteral, isCommand } from './command-classifier';
 
 /**
  * Parity 테스트 — `backend/app/services/command_classifier.py` 규칙과 일치 어서트(drift 가드).
@@ -41,6 +41,22 @@ describe('command-classifier — BE parity', () => {
       expect(commandName(' /review')).toBeNull();
       expect(commandName('hi')).toBeNull();
       expect(commandName(null)).toBeNull();
+    });
+  });
+
+  describe('commandArgs (이름 뒤 인자, BE CommandCandidate.args와 동형)', () => {
+    it('`/review` (인자 없음) → \'\'', () => expect(commandArgs('/review')).toBe(''));
+    it('`/review foo` → `foo`', () => expect(commandArgs('/review foo')).toBe('foo'));
+    it('`/review foo bar` → `foo bar` (첫 공백만 분리)', () => expect(commandArgs('/review foo bar')).toBe('foo bar'));
+    it('`/review   foo` (연속 공백) → `foo`', () => expect(commandArgs('/review   foo')).toBe('foo'));
+    it('`/review foo  ` (트레일링) → `foo`', () => expect(commandArgs('/review foo  ')).toBe('foo'));
+    it('참조 토큰 포함 `/review [제목](entity:story:abc)` → 토큰 그대로 보존', () =>
+      expect(commandArgs('/review [제목](entity:story:abc)')).toBe('[제목](entity:story:abc)'));
+    it('비-커맨드 → \'\'', () => {
+      expect(commandArgs('//review foo')).toBe('');
+      expect(commandArgs(' /review foo')).toBe('');
+      expect(commandArgs('hi')).toBe('');
+      expect(commandArgs(null)).toBe('');
     });
   });
 });

--- a/apps/web/src/lib/command-classifier.ts
+++ b/apps/web/src/lib/command-classifier.ts
@@ -31,3 +31,11 @@ export function commandName(text: string | null | undefined): string | null {
   const firstToken = text.trim().split(/\s+/)[0] ?? '';
   return firstToken.slice(1);
 }
+
+/** 커맨드 이름 뒤 인자(trim). 커맨드 아니거나 인자 없으면 ''(BE `CommandCandidate.args`와 동형). */
+export function commandArgs(text: string | null | undefined): string {
+  if (!text || !COMMAND_RE.test(text)) return '';
+  const body = text.trim().slice(1);
+  const split = body.split(/\s+([\s\S]*)/);
+  return split[1]?.trim() ?? '';
+}


### PR DESCRIPTION
## 변경 사항
스토리 #3129(선생님 실목격 2026-08-27) 결함 절반(②)만 스코프: 게이트웨이 reply로 발신된 메시지가 슬래시 커맨드로 분류될 때(`isCommand` — content-only 판정, S8 설계 그대로), 그 커맨드 args 안의 참조 토큰(`[제목](entity:type:id)`)이 링크/칩으로 안 풀리고 원문 그대로 노출되던 결함을 고쳤다.

- `isCmd` 브랜치가 `message.content`를 raw slice해 `<code>`로 그대로 찍던 것을, `/cmdName`만 code로 고정하고 args는 일반 메시지와 동일한 `ChatMarkdown` 경로(references·엔티티 칩 SSOT 공유)로 렌더하도록 변경.
- `commandArgs()` 헬퍼 신설(`command-classifier.ts`) — 백엔드 `CommandCandidate.args`와 동형(parity 테스트 추가).

## 스코프 밖(①, PO 보고 완료)
스토리가 지목한 결함 절반 중 ①(게이트웨이 reply가 애초에 content 맨 앞에 `/`로 시작하게 되는 경로)은 조사 결과, 백엔드 `send_message`(`POST /api/v2/conversations/{id}/messages`)가 게이트웨이/일반 API 발신을 구분하지 않는 단일 엔드포인트이고 커맨드 판정이 순전히 content 기반(`classify_command`)이라 — 이 레포 안에서 "message_type 필드"로 교정할 층 자체가 없다는 점을 확認, PO(페드루 올리베이라)에게 보고했다. 원 콘텐츠가 `/`로 시작하게 되는 정확한 경로는 게이트웨이 발신 클라이언트(레포 밖)에 있어 별도 확인 필요.

## 근거(before/after)
동일 fixture(`/review [제안서.md](entity:doc:...)`)를 vitest(jsdom)로 렌더해 실제 DOM을 캡처 — before는 원문(`[제안서.md](entity:doc:...)`)이 그대로 텍스트로 노출, after는 참조 토큰이 문서 임베드 카드(아이콘+라벨+열기 버튼)로 파싱된다. 스크린샷은 Sprintable 채팅으로 별도 첨부(카디르군 QA 검수 시 참조).

## 검증
- `pnpm vitest run src/lib/command-classifier.test.ts src/components/chat/chat-bubble.test.tsx` — 133 passed (신규 회귀가드 2건 포함: 참조 토큰 파싱 확認 + args 없는 순수 커맨드 회귀 0)
- `tsc --noEmit` clean
- `eslint` 0 warning (변경 파일 4개)
- `pnpm build` 성공
- 반응형: 레이아웃/브레이크포인트 변경 없음 — 기존 채팅 버블 컨테이너(`max-w-[72%]`, 반응형 그대로) 안에서 args 렌더 경로만 교체.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Cx4YtSpRgxRqyYKpbPzAs