### PR TITLE
[SID:3128] gate 상세에 대상 문서/아티팩트 진입 경로 추가

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3938,6 +3938,8 @@
     "queueResolvedRejected": "Rejected",
     "queueViewRecord": "View record →",
     "gateDetailOrgContext": "Org {org}",
+    "gateDetailViewTargetDoc": "View document →",
+    "gateDetailViewTargetArtifact": "View artifact →",
     "riskUnknown": "Risk pending",
     "riskHigh": "High risk · review closely",
     "diffFactsFileCount": "{count} files",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3938,6 +3938,8 @@
     "queueResolvedRejected": "반려됨",
     "queueViewRecord": "기록 보기 →",
     "gateDetailOrgContext": "조직 {org}",
+    "gateDetailViewTargetDoc": "문서 원문 보기 →",
+    "gateDetailViewTargetArtifact": "아티팩트 보기 →",
     "riskUnknown": "위험도 확인 중",
     "riskHigh": "고위험 · 신중 결재",
     "diffFactsFileCount": "파일 {count}",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -657,7 +657,10 @@ describe('GateDetailPage — story #3128 대상 실물 진입 경로', () => {
   });
 
   it('doc/artifact가 아닌 다른 gate 유형(merge 등)은 대상 링크를 렌더하지 않는다(엉뚱한 경로 지어내지 않음)', async () => {
-    await mount(gate({ gate_type: 'merge_gate', work_item_type: 'story', can_approve: true, risk_grade: 'low' }));
+    // PO AC 리뷰(PR#3542) 사소 지적 — 'merge'가 실존 gate_type(hitl_config.py GATE_TYPES).
+    // 'merge_gate'는 이 파일 기존 기본 픽스처값(line 57)일 뿐 실존 타입 아님 — 내 신규
+    // 테스트는 정확한 값으로.
+    await mount(gate({ gate_type: 'merge', work_item_type: 'story', can_approve: true, risk_grade: 'low' }));
     expect(container.textContent).not.toContain(koMessages.cage.gateDetailViewTargetDoc);
     expect(container.textContent).not.toContain(koMessages.cage.gateDetailViewTargetArtifact);
   });

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -624,3 +624,50 @@ describe('GateDetailPage — story #3113 결정 게이트(agent_decision_request
     expect(approveBtn.disabled).toBe(false);
   });
 });
+
+// story #3128(#3113의 doc_approval판, 페드루 PO 3529 라이브 검증 중 부수 발견) — 「내용으로
+// 직접 판단」하라면서 대상 문서/아티팩트로 가는 경로가 카드 어디에도 없던 결함.
+describe('GateDetailPage — story #3128 대상 실물 진입 경로', () => {
+  it('doc_approval + work_item_summary.slug가 있으면 원문 링크가 /docs/{slug}로 뜬다', async () => {
+    await mount(gate({
+      gate_type: 'doc_approval', work_item_type: 'doc', can_approve: true, risk_grade: 'low',
+      work_item_summary: { title: '온보딩 재실측', slug: 'onboarding-remeasure' },
+    }));
+    const link = [...container.querySelectorAll('a')].find((a) => a.textContent === koMessages.cage.gateDetailViewTargetDoc);
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute('href')).toBe('/docs/onboarding-remeasure');
+  });
+
+  it('doc_approval인데 slug가 없으면(예외적 미해소) 링크를 렌더하지 않는다(없는 경로를 지어내지 않음)', async () => {
+    await mount(gate({
+      gate_type: 'doc_approval', work_item_type: 'doc', can_approve: true, risk_grade: 'low',
+      work_item_summary: null,
+    }));
+    expect(container.textContent).not.toContain(koMessages.cage.gateDetailViewTargetDoc);
+  });
+
+  it('artifact_canonicalize는 work_item_summary 없이도 work_item_id로 /artifacts/{id} 링크가 뜬다', async () => {
+    await mount(gate({
+      gate_type: 'artifact_canonicalize', work_item_type: 'visual_artifact', work_item_id: 'artifact-42',
+      can_approve: true, risk_grade: 'low', work_item_summary: null,
+    }));
+    const link = [...container.querySelectorAll('a')].find((a) => a.textContent === koMessages.cage.gateDetailViewTargetArtifact);
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute('href')).toBe('/artifacts/artifact-42');
+  });
+
+  it('doc/artifact가 아닌 다른 gate 유형(merge 등)은 대상 링크를 렌더하지 않는다(엉뚱한 경로 지어내지 않음)', async () => {
+    await mount(gate({ gate_type: 'merge_gate', work_item_type: 'story', can_approve: true, risk_grade: 'low' }));
+    expect(container.textContent).not.toContain(koMessages.cage.gateDetailViewTargetDoc);
+    expect(container.textContent).not.toContain(koMessages.cage.gateDetailViewTargetArtifact);
+  });
+
+  it('이미 해소된(approved) doc 게이트도 원문 링크가 그대로 남는다(감사 가치는 액션 여부와 무관 — decisionFacts·GateActivityHistory와 동원칙)', async () => {
+    await mount(gate({
+      gate_type: 'doc_approval', work_item_type: 'doc', status: 'approved', resolver_id: null,
+      work_item_summary: { title: '온보딩 재실측', slug: 'onboarding-remeasure' },
+    }));
+    const link = [...container.querySelectorAll('a')].find((a) => a.textContent === koMessages.cage.gateDetailViewTargetDoc);
+    expect(link).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { ChevronLeft, CheckCircle, XCircle } from 'lucide-react';
@@ -132,6 +133,23 @@ export default function GateDetailPage() {
   // 승인 가능한 것처럼 보이는 게 실 결함이라 canonical의 첫 라이브 실측에서 바로 잡았다.
   const isDocGate = gate?.work_item_type === 'doc' || gate?.gate_type === 'doc_approval';
   const isCanonicalizeGate = gate?.gate_type === 'artifact_canonicalize';
+  // story #3128(#3113의 doc_approval판, 페드루 PO 3529 라이브 검증 중 부수 발견) — 카드가
+  // 「근거 데이터 없음 — 내용으로 직접 판단」이라 안내하면서도 대상 실물(문서/아티팩트)로 가는
+  // 경로가 카드 안에 0개였다. doc은 work_item_summary.slug(BE #1970 기존 계약, doc gate만
+  // 채워짐)로 `/docs/{slug}` bare 경로(notification-bell.tsx와 동형 관행 — org/project
+  // slug 없이도 middleware가 현재 활성 프로젝트로 해소, 크로스 프로젝트 게이트는 기존
+  // org/project 이름 표시와 같은 알려진 한계). artifact_canonicalize(work_item_type=
+  // 'visual_artifact')는 BE work_item_summary가 이 타입엔 항상 null(_resolve_work_item_summary
+  // fail-soft)이지만, gate.work_item_id 자체는 항상 있어 slug 없이도 `/artifacts/{id}`
+  // bare 경로(legacy-resource-tables.ts MIGRATED_RESOURCES 등재 확認)로 충분 — 같은
+  // «비용 작으면 잔여 0» 원칙으로 이번 PR에 같이 닫는다. 다른 gate 유형(loop_decision의
+  // hypothesis 초안 verdict·workflow_config_publish)은 전수 점검했으나 링크 대상 라우트가
+  // 불명확해 이번 PR 스코프 밖 — 페드루군에 별도 사이징 보고.
+  const targetLink = isDocGate && gate?.work_item_summary?.slug
+    ? { href: `/docs/${gate.work_item_summary.slug}`, labelKey: 'gateDetailViewTargetDoc' as const }
+    : isCanonicalizeGate && gate?.work_item_id
+    ? { href: `/artifacts/${gate.work_item_id}`, labelKey: 'gateDetailViewTargetArtifact' as const }
+    : null;
   const needsAction = !!gate && gate.status === 'pending' && (gateNeedsAction(gate) || isDocGate || isCanonicalizeGate);
   // story #2091(P0) — needsAction은 "이 게이트가 사람의 판단을 필요로 하는가"만 답한다(gate 자체의
   // 속성). "이 화면을 보는 나(caller)에게 승인 권한이 있는가"는 별개 질문인데 여태 이 둘을 섞어서
@@ -289,6 +307,15 @@ export default function GateDetailPage() {
                     ? ` · ${projectMemberships.find((p) => p.projectId === gate.project_id)?.projectName ?? gate.project_id.slice(0, 8)}`
                     : ''}
                 </p>
+
+                {/* story #3128 — needsAction/canAct와 무관하게 항상 렌더(이미 해소된 카드도
+                    "무엇을 승인했는지" 원문을 감사할 수 있어야 한다 — decisionFacts·
+                    GateActivityHistory와 같은 원칙). */}
+                {targetLink ? (
+                  <Link href={targetLink.href} className="text-xs font-medium text-primary hover:underline">
+                    {t(targetLink.labelKey)}
+                  </Link>
+                ) : null}
 
                 {/* story #3113(AC2) — 「카드를 눌러도 내용을 볼 수 있는 상세 뷰 자체가 없다」
                     처방. needsAction/canAct와 무관하게 항상 렌더(이미 해소된 결정도 «무엇을


### PR DESCRIPTION
[SID:3128]

## 배경 (#3113의 doc_approval판)
페드루 PO 3529 라이브 검증 중 부수 발견 — doc_approval 결재 카드(`/gates/{id}`)가 근거 절에 "근거 데이터 없음 — 내용으로 직접 판단"이라 안내하면서도 대상 문서로 가는 링크가 카드 어디에도 없음(전역 nav 4개뿐, `a` 태그 전수 덤프로 실측). [#3113](entity:story:aac8f9a6-5ad4-42ad-a965-66a7dc5dc1a4)(agent_decision 카드 내용 열람 불가) 처방과 같은 클래스의 doc_approval판 잔여.

## 구현
- doc: `work_item_summary.slug`(BE #1970 기존 계약, doc gate만 채워짐)로 `/docs/{slug}` bare 경로 — `notification-bell.tsx`와 동형 관행(org/project slug 없이도 middleware가 현재 활성 프로젝트로 해소). slug 없으면 링크 자체를 안 그린다.
- artifact_canonicalize: BE `work_item_summary`가 이 타입엔 항상 null(`work_item_type='visual_artifact'`)이지만 `gate.work_item_id`는 항상 있어 `/artifacts/{id}` bare 경로로 충분 — 같은 primitive로 비용 거의 0이라 같이 닫음.
- 링크는 `needsAction`/`canAct`와 무관하게 항상 렌더(이미 해소된 카드도 감사 가치가 있다 — `decisionFacts`·`GateActivityHistory`와 같은 원칙).

## 전수 점검 (페드루 지시 — 다른 gate 유형도 같은 자로)
| gate_type | 대상 실물 진입 경로 |
|---|---|
| merge / pr_review / deploy / qa | ✅ `GatePrChip`(neutral_facts.pr_links)로 이미 커버 |
| agent_decision_request | ✅ #3113로 이미 커버 |
| doc_approval | ✅ 이 PR |
| artifact_canonicalize | ✅ 이 PR |
| loop_decision | ⚠️ 초안 verdict 텍스트(`HypothesisOutcomeDraft`)는 보이나 근거 hypothesis/story로 가는 링크는 없음 |
| workflow_config_publish | ❓ 대상 라우트 확認 필요 |

뒤 둘(`loop_decision`, `workflow_config_publish`)은 타겟 라우트가 불명확해 이번 PR 스코프 밖 — 별도 사이징 필요하면 후속 스토리로.

## 검증
신규 테스트 5건(doc 링크·slug 없을 때 미렌더·artifact 링크·비대상 유형 미렌더·해소된 게이트도 링크 존치) — 핵심 3건은 뮤테이션(targetLink 무력화) genuine RED 확認 後 복원. 34/34 관련 테스트 green, tsc/eslint/i18n-key-parity/next build 전부 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)