### PR TITLE
[SID:3121] BFF/모바일 정합 절반(AC1) — callback_mode/return_uri 배선

### DIFF
--- a/apps/web/src/app/api/auth/callback/[provider]/route.test.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.test.ts
@@ -92,8 +92,58 @@ describe('GET /api/auth/callback/[provider] — native OAuth-handoff branch', ()
     const [issueUrl, issueOpts] = mockFetch.mock.calls[1] as [string, RequestInit];
     expect(issueUrl).toContain('/api/v2/internal/auth/oauth-handoff/issue');
     expect(issueUrl).not.toContain('native-bootstrap');
-    const sentBody = JSON.parse(issueOpts.body as string) as { user_id: string; code_challenge: string };
-    expect(sentBody).toEqual({ user_id: 'user-123', code_challenge: 'a'.repeat(43) });
+    const sentBody = JSON.parse(issueOpts.body as string) as {
+      user_id: string; code_challenge: string; callback_mode: string; return_uri: string;
+    };
+    // story #3121 AC1 — callback_mode 쿠키 부재 시 https로 기본 유도(구버전 클라 대비).
+    expect(sentBody).toEqual({
+      user_id: 'user-123',
+      code_challenge: 'a'.repeat(43),
+      callback_mode: 'https',
+      return_uri: 'https://dev-app.sprintable.ai/native/oauth-return',
+    });
+  });
+
+  // story #3121 AC1 — custom_scheme 쿠키가 있으면 issue 호출에 그대로 실어 보낸다(https 기본값
+  // 오버라이드). return_uri는 App.js OAUTH_RETURN_SCHEME_URL과 byte-exact 고정값이라 별도
+  // env(MOBILE_APP_LINK_ORIGIN)에 안 흔들린다 — 그것도 같이 확認.
+  it('with callback_mode=custom_scheme cookie: sends custom_scheme + fixed ai.sprintable return_uri to issue', async () => {
+    stubCookies({ oauth_native_challenge_google: 'a'.repeat(43), oauth_native_callback_mode_google: 'custom_scheme' });
+    process.env['MOBILE_APP_LINK_ORIGIN'] = 'https://app.sprintable.ai'; // custom_scheme엔 무영향이어야 함
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { access_token: fakeJwt({ sub: 'user-123' }), refresh_token: 'legacy-rt' } }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ code: 'handoff-code-xyz' }) });
+
+    await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+    const [, issueOpts] = mockFetch.mock.calls[1] as [string, RequestInit];
+    const sentBody = JSON.parse(issueOpts.body as string) as { callback_mode: string; return_uri: string };
+    expect(sentBody.callback_mode).toBe('custom_scheme');
+    expect(sentBody.return_uri).toBe('ai.sprintable:/oauth-return');
+  });
+
+  // 자기검증(뮤테이션) — 쿠키 값이 스키마 밖(임의 문자열)이면 https로 안전 폴백해야지, 그
+  // 값을 그대로 흘려보내면 안 된다(BE가 Literal["https","custom_scheme"]로 거부하는 자리를
+  // BFF가 미리 안 막으면 native 로그인 전체가 400으로 죽는다).
+  it('with an invalid callback_mode cookie value: falls back to https (never forwards garbage)', async () => {
+    stubCookies({ oauth_native_challenge_google: 'a'.repeat(43), oauth_native_callback_mode_google: 'not-a-real-mode' });
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { access_token: fakeJwt({ sub: 'user-123' }), refresh_token: 'legacy-rt' } }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ code: 'x' }) });
+
+    await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+    const [, issueOpts] = mockFetch.mock.calls[1] as [string, RequestInit];
+    const sentBody = JSON.parse(issueOpts.body as string) as { callback_mode: string };
+    expect(sentBody.callback_mode).toBe('https');
+  });
+
+  it('with a native challenge cookie: deletes the callback_mode cookie (single-use, like the other oauth_* cookies)', async () => {
+    stubCookies({ oauth_native_challenge_google: 'a'.repeat(43), oauth_native_callback_mode_google: 'custom_scheme' });
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { access_token: fakeJwt({ sub: 'user-123' }), refresh_token: 'legacy-rt' } }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ code: 'x' }) });
+
+    await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+    expect(h.cookiesDeleteMock).toHaveBeenCalledWith('oauth_native_callback_mode_google');
   });
 
   it('with a native challenge cookie: redirects to the App Link return URL with the handoff code, no-store + no-referrer', async () => {

--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -4,6 +4,7 @@ import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 import { safeNextPath } from '@/lib/auth/session-redirect';
 import { resolveAppUrl } from '@/services/app-url';
+import { isOAuthCallbackMode, expectedReturnUri } from '@/lib/auth/oauth-callback-mode';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 // e-mobile-oauth-native-handoff-contract §2: returnUrl = 검증된 App Link. dev/prod 도메인·서명
@@ -77,6 +78,13 @@ async function handleCallback(request: Request, provider: string, code: string |
   // e-mobile-oauth-native-handoff-contract §7.4/§5 — 격리 rail(오르테가 확定, /auth/native
   // 무접촉). native OAuth-start에서만 세팅되는 challenge — 있으면 이 콜백도 native 취급.
   const nativeChallenge = cookieStore.get(`oauth_native_challenge_${provider}`)?.value ?? null;
+  // story #3121 AC1 — 모바일이 OAuth 시작 시 선택한 호환 모드(계약 §2). 쿠키 부재/형식오류는
+  // https로 기본 유도(BE Phase 1 확장-축소 계약과 동일 원칙 — 조용히 안 채우고 기본값 하나로
+  // 수렴). 값 자체(return_uri 문자열)는 여기서 고정 매핑으로 계산 — 클라 입력을 URI로 안 믿는다.
+  const nativeCallbackMode = (() => {
+    const raw = cookieStore.get(`oauth_native_callback_mode_${provider}`)?.value ?? null;
+    return isOAuthCallbackMode(raw) ? raw : 'https';
+  })();
   // story #3122(계정 연결) — auth/link/route.ts만 세팅하는 단명 쿠키. provider가 돌려주는
   // code/state 자체엔 "로그인이냐 연결이냐" 구분이 없어(authorize 요청 파라미터가 로그인과
   // 동일하게 생겼다, 의도된 설계) 이 쿠키가 유일한 분기 신호다.
@@ -86,6 +94,7 @@ async function handleCallback(request: Request, provider: string, code: string |
   cookieStore.delete(`oauth_invite_token_${provider}`);
   cookieStore.delete(`oauth_next_${provider}`);
   cookieStore.delete(`oauth_native_challenge_${provider}`);
+  cookieStore.delete(`oauth_native_callback_mode_${provider}`);
   cookieStore.delete(`oauth_link_${provider}`);
 
   // ⛔통과 조건은 원래와 동일(storedState 존재 AND 일치) — 분기는 로그용일 뿐, 검증 자체는
@@ -154,13 +163,20 @@ async function handleCallback(request: Request, provider: string, code: string |
       return NextResponse.redirect(`${origin}/login?error=oauth_native_issue_failed`);
     }
     const internalSecret = process.env['FIREBASE_BFF_INTERNAL_SECRET'];
+    // story #3121 AC1 — return_uri는 고정 매핑으로 계산(클라 입력 아님). APP_LINK_ORIGIN()은
+    // 기존 App Link 리다이렉트 목적지 계산과 동일 출처(아래 returnUrl 참조) — 새 소스 안 만든다.
     const issueRes = await fetch(`${FASTAPI_URL()}/api/v2/internal/auth/oauth-handoff/issue`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         ...(internalSecret ? { Authorization: `Bearer ${internalSecret}` } : {}),
       },
-      body: JSON.stringify({ user_id: userId, code_challenge: nativeChallenge }),
+      body: JSON.stringify({
+        user_id: userId,
+        code_challenge: nativeChallenge,
+        callback_mode: nativeCallbackMode,
+        return_uri: expectedReturnUri(nativeCallbackMode, APP_LINK_ORIGIN()),
+      }),
     }).catch(() => null);
 
     if (!issueRes || !issueRes.ok) {

--- a/apps/web/src/app/auth/login/route.test.ts
+++ b/apps/web/src/app/auth/login/route.test.ts
@@ -72,4 +72,30 @@ describe('GET /auth/login — native OAuth-start branch', () => {
     const cookieNames = h.cookiesSetMock.mock.calls.map((c) => c[0] as string);
     expect(cookieNames).not.toContain('oauth_native_challenge_google');
   });
+
+  // story #3121 AC1 — 모바일이 OAuth 시작 전 정적으로 고른 호환 모드를 그대로 쿠키에 심는다.
+  it('native=1 + callback_mode=custom_scheme: sets the callback_mode cookie with the exact value', async () => {
+    await GET(makeRequest({ provider: 'google', native: '1', code_challenge: VALID_CHALLENGE, callback_mode: 'custom_scheme' }));
+    const call = h.cookiesSetMock.mock.calls.find((c) => c[0] === 'oauth_native_callback_mode_google');
+    expect(call).toBeDefined();
+    expect(call?.[1]).toBe('custom_scheme');
+  });
+
+  it('native=1 + callback_mode=https: sets the callback_mode cookie', async () => {
+    await GET(makeRequest({ provider: 'google', native: '1', code_challenge: VALID_CHALLENGE, callback_mode: 'https' }));
+    const call = h.cookiesSetMock.mock.calls.find((c) => c[0] === 'oauth_native_callback_mode_google');
+    expect(call?.[1]).toBe('https');
+  });
+
+  it('invalid callback_mode value: does not set the cookie (콜백이 https 기본값으로 유도)', async () => {
+    await GET(makeRequest({ provider: 'google', native: '1', code_challenge: VALID_CHALLENGE, callback_mode: 'android' }));
+    const cookieNames = h.cookiesSetMock.mock.calls.map((c) => c[0] as string);
+    expect(cookieNames).not.toContain('oauth_native_callback_mode_google');
+  });
+
+  it('callback_mode present but native flag absent: no callback_mode cookie set (legacy flow unchanged)', async () => {
+    await GET(makeRequest({ provider: 'google', code_challenge: VALID_CHALLENGE, callback_mode: 'custom_scheme' }));
+    const cookieNames = h.cookiesSetMock.mock.calls.map((c) => c[0] as string);
+    expect(cookieNames).not.toContain('oauth_native_callback_mode_google');
+  });
 });

--- a/apps/web/src/app/auth/login/route.ts
+++ b/apps/web/src/app/auth/login/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { resolveAppUrl } from '@/services/app-url';
 import { oauthCookieOptions } from '@/lib/auth/oauth-cookies';
+import { isOAuthCallbackMode } from '@/lib/auth/oauth-callback-mode';
 
 const FASTAPI_BASE = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -16,6 +17,10 @@ export async function GET(request: Request) {
   // issue 호출에 씀(격리 rail, /auth/native 무접촉).
   const native = searchParams.get('native') === '1';
   const codeChallenge = searchParams.get('code_challenge');
+  // story #3121 AC1 — 모바일이 OAuth 시작 전 정적으로 결정한 호환 모드(계약 §2). 값 자체가
+  // 아니라 셸렉터일 뿐이라 여기선 형식만 검증(https|custom_scheme) — 실제 return_uri 문자열은
+  // 콜백(callback/[provider]/route.ts)에서 lib/auth/oauth-callback-mode 고정 매핑으로 계산한다.
+  const callbackModeParam = searchParams.get('callback_mode');
   const origin = resolveAppUrl(null);
 
   // story #3118(Sign in with Apple) — apple 추가. 노출 여부(iOS/macOS 셸 한정)는 로그인
@@ -53,6 +58,12 @@ export async function GET(request: Request) {
   // 핸드오프 자체를 시작하지 않는다(방어적, 최종 검증은 BE issue가 authoritative).
   if (native && codeChallenge && /^[A-Za-z0-9_-]{43,}$/.test(codeChallenge)) {
     cookieStore.set(`oauth_native_challenge_${provider}`, codeChallenge, cookieOpts);
+    // story #3121 AC1 — 형식이 다르면(구버전 클라 미전송 포함) 조용히 기본값(https)으로 유도
+    // 되게 쿠키 자체를 세팅 안 한다(콜백에서 쿠키 부재 = https). 잘못된 값은 저장하지 않는다
+    // (오배선을 그대로 실어 나르지 않는다).
+    if (isOAuthCallbackMode(callbackModeParam)) {
+      cookieStore.set(`oauth_native_callback_mode_${provider}`, callbackModeParam, cookieOpts);
+    }
   }
 
   return NextResponse.redirect(url);

--- a/apps/web/src/app/auth/oauth-handoff/route.test.ts
+++ b/apps/web/src/app/auth/oauth-handoff/route.test.ts
@@ -1,7 +1,14 @@
 // e-mobile-oauth-native-handoff-contract §5/§6/§10 — 격리 rail consume 착지 회귀가드.
-// 핵심 불변식: (1) FIREBASE_OAUTH_HANDOFF_ENABLED 기본 off, (2) code+code_verifier만 받고
-// 다른 필드는 계약에 없음(installation_id 등 attested 필드가 여기 섞이면 격리 위반),
-// (3) mint 대상=레거시 sp_at/sp_rt(Firebase 아님), (4) 실패는 전부 동일 401(enumeration 방지).
+// 핵심 불변식: (1) FIREBASE_OAUTH_HANDOFF_ENABLED 기본 off, (2) code+code_verifier(+#3121
+// AC1 callback_mode)만 받고 다른 필드는 계약에 없음(installation_id 등 attested 필드가
+// 여기 섞이면 격리 위반), (3) mint 대상=레거시 sp_at/sp_rt(Firebase 아님), (4) 실패는 전부
+// 동일 401(enumeration 방지).
+//
+// story #3121 AC1 추가분 — 이 라우트는 issue 시점 쿠키와 연속성이 없는 웹뷰 top-level POST라
+// callback_mode는 요청 body에서만 온다(§ route.ts 상단 주석). 핵심: (5) callback_mode 없으면
+// (구버전 클라) BE 호출에서 그 필드 자체를 뺀다(반쪽만 보내지 않는다 — BE Phase 1 계약과
+// 대칭), (6) 있으면 형식 검증 후 그대로 전달+return_uri는 고정 매핑으로 계산(클라 입력 URI를
+// 안 믿는다), (7) 형식이 틀리면 거부한다.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const h = vi.hoisted(() => ({ csrfCheck: vi.fn() }));
@@ -30,7 +37,7 @@ function makeUrlencodedRequest(fields: Record<string, string>): Request {
   });
 }
 
-const ENV_KEYS = ['FIREBASE_OAUTH_HANDOFF_ENABLED', 'FIREBASE_BFF_INTERNAL_SECRET', 'NEXT_PUBLIC_FASTAPI_URL'];
+const ENV_KEYS = ['FIREBASE_OAUTH_HANDOFF_ENABLED', 'FIREBASE_BFF_INTERNAL_SECRET', 'NEXT_PUBLIC_FASTAPI_URL', 'MOBILE_APP_LINK_ORIGIN'];
 
 describe('POST /auth/oauth-handoff', () => {
   beforeEach(() => {
@@ -169,5 +176,57 @@ describe('POST /auth/oauth-handoff', () => {
     mockFetch.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt' }) });
     const res = await POST(makeJsonRequest({ code: 'c', code_verifier: 'v', redirect_path: '//evil.com/phish' }));
     expect(res.headers.get('location')).toBe('http://localhost:3108/glance');
+  });
+
+  // ── story #3121 AC1 — callback_mode consume 절반 ──────────────────────────────
+  describe('callback_mode (#3121 AC1)', () => {
+    it('without callback_mode (legacy client): omits callback_mode/return_uri from the BE call entirely (never sends just one)', async () => {
+      process.env['FIREBASE_OAUTH_HANDOFF_ENABLED'] = 'true';
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt' }) });
+      await POST(makeJsonRequest({ code: 'c', code_verifier: 'v' }));
+      const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const sentBody = JSON.parse(opts.body as string) as Record<string, unknown>;
+      expect(sentBody).not.toHaveProperty('callback_mode');
+      expect(sentBody).not.toHaveProperty('return_uri');
+    });
+
+    it('with callback_mode=https: forwards callback_mode + the fixed https return_uri', async () => {
+      process.env['FIREBASE_OAUTH_HANDOFF_ENABLED'] = 'true';
+      process.env['MOBILE_APP_LINK_ORIGIN'] = 'https://dev-app.sprintable.ai';
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt' }) });
+      await POST(makeJsonRequest({ code: 'c', code_verifier: 'v', callback_mode: 'https' }));
+      const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const sentBody = JSON.parse(opts.body as string) as { callback_mode: string; return_uri: string };
+      expect(sentBody.callback_mode).toBe('https');
+      expect(sentBody.return_uri).toBe('https://dev-app.sprintable.ai/native/oauth-return');
+    });
+
+    it('with callback_mode=custom_scheme: forwards the byte-exact ai.sprintable return_uri, unaffected by MOBILE_APP_LINK_ORIGIN', async () => {
+      process.env['FIREBASE_OAUTH_HANDOFF_ENABLED'] = 'true';
+      process.env['MOBILE_APP_LINK_ORIGIN'] = 'https://app.sprintable.ai';
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt' }) });
+      await POST(makeJsonRequest({ code: 'c', code_verifier: 'v', callback_mode: 'custom_scheme' }));
+      const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const sentBody = JSON.parse(opts.body as string) as { callback_mode: string; return_uri: string };
+      expect(sentBody.callback_mode).toBe('custom_scheme');
+      expect(sentBody.return_uri).toBe('ai.sprintable:/oauth-return');
+    });
+
+    it('with an invalid callback_mode value: rejects the request (never forwards garbage to BE)', async () => {
+      process.env['FIREBASE_OAUTH_HANDOFF_ENABLED'] = 'true';
+      const res = await POST(makeJsonRequest({ code: 'c', code_verifier: 'v', callback_mode: 'android' }));
+      expect(res.status).toBe(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    // 자기검증(뮤테이션) — "반쪽만 보내면 안 된다" 불변식이 실제로 지켜지는지: callback_mode가
+    // 없을 때 return_uri **혼자** 새 나가면 안 된다(半-공급은 BE Literal 스키마를 아예 못 만족).
+    it('mut: never sends return_uri without callback_mode, or vice versa', async () => {
+      process.env['FIREBASE_OAUTH_HANDOFF_ENABLED'] = 'true';
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt' }) });
+      await POST(makeJsonRequest({ code: 'c', code_verifier: 'v' }));
+      const sentBody = JSON.parse((mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string) as Record<string, unknown>;
+      expect('callback_mode' in sentBody).toBe('return_uri' in sentBody);
+    });
   });
 });

--- a/apps/web/src/app/auth/oauth-handoff/route.ts
+++ b/apps/web/src/app/auth/oauth-handoff/route.ts
@@ -27,8 +27,13 @@ import { verifyCsrfOrigin } from '@/lib/auth/csrf';
 import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { resolveAppUrl } from '@/services/app-url';
+import { isOAuthCallbackMode, expectedReturnUri } from '@/lib/auth/oauth-callback-mode';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+// story #3121 AC1 — issue 시점(callback/[provider]/route.ts)과 동일 출처. 이 라우트는 웹뷰
+// top-level POST라 쿠키/세션 연속성이 없다(§ 상단 주석) — 모바일이 code/code_verifier와
+// **같은 요청에** callback_mode를 실어 보내야만(App.js) issue 시점 값과 대조가 가능하다.
+const APP_LINK_ORIGIN = () => process.env['MOBILE_APP_LINK_ORIGIN'] ?? 'https://dev-app.sprintable.ai';
 
 function logHandoffFailure(reason: string): void {
   // §10.4: code/verifier/원문 절대 로그 금지 — reason enum만.
@@ -45,6 +50,9 @@ function handoffFailedResponse(): NextResponse {
 interface HandoffBody {
   code?: unknown;
   code_verifier?: unknown;
+  // story #3121 AC1 — 옵션(구버전 클라 대비). 있으면 형식 검증 후 BE에 그대로 전달, 없으면
+  // 필드 자체를 BE 호출에서 뺀다(BE Phase 1 확장-축소 계약 — 둘 다 없으면 https로 유도).
+  callback_mode?: unknown;
 }
 
 async function parseBody(request: Request): Promise<HandoffBody | null> {
@@ -55,7 +63,11 @@ async function parseBody(request: Request): Promise<HandoffBody | null> {
     }
     const raw = await request.text();
     const params = new URLSearchParams(raw);
-    return { code: params.get('code') ?? undefined, code_verifier: params.get('code_verifier') ?? undefined };
+    return {
+      code: params.get('code') ?? undefined,
+      code_verifier: params.get('code_verifier') ?? undefined,
+      callback_mode: params.get('callback_mode') ?? undefined,
+    };
   } catch {
     return null;
   }
@@ -83,6 +95,21 @@ export async function POST(request: Request) {
     return handoffFailedResponse();
   }
 
+  // story #3121 AC1 — 있으면 형식 검증(값 자체가 아니라 셸렉터), 없으면 필드 자체를 BE 호출에서
+  // 뺀다(구버전 클라 대비 — BE Phase 1이 "둘 다 없으면 https로 유도"를 이미 보장). 있는데
+  // 형식이 틀리면(변조/버그) missing_fields와 동일하게 거부 — 반쪽만 실어 보내는 조합은 없다.
+  let callbackModeFields: { callback_mode: string; return_uri: string } | Record<string, never> = {};
+  if (body.callback_mode !== undefined) {
+    if (typeof body.callback_mode !== 'string' || !isOAuthCallbackMode(body.callback_mode)) {
+      logHandoffFailure('bad_callback_mode');
+      return handoffFailedResponse();
+    }
+    callbackModeFields = {
+      callback_mode: body.callback_mode,
+      return_uri: expectedReturnUri(body.callback_mode, APP_LINK_ORIGIN()),
+    };
+  }
+
   const internalSecret = process.env['FIREBASE_BFF_INTERNAL_SECRET'];
   const consumeRes = await fetch(`${FASTAPI_URL()}/api/v2/internal/auth/oauth-handoff/consume`, {
     method: 'POST',
@@ -90,7 +117,7 @@ export async function POST(request: Request) {
       'Content-Type': 'application/json',
       ...(internalSecret ? { Authorization: `Bearer ${internalSecret}` } : {}),
     },
-    body: JSON.stringify({ code: body.code, code_verifier: body.code_verifier }),
+    body: JSON.stringify({ code: body.code, code_verifier: body.code_verifier, ...callbackModeFields }),
   }).catch(() => null);
 
   if (!consumeRes || !consumeRes.ok) {

--- a/apps/web/src/lib/auth/oauth-callback-mode.test.ts
+++ b/apps/web/src/lib/auth/oauth-callback-mode.test.ts
@@ -1,0 +1,44 @@
+// story #3121 AC1 — lib/auth/oauth-callback-mode 순수함수 단위테스트. BE
+// backend/app/routers/auth_firebase_internal.py의 _expected_return_uri()와 값이 반드시
+// 같아야 하는 고정 매핑(둘 다 수동으로 맞춰 유지 — 자동 대조 불가, 값 바뀌면 여기·BE·모바일
+// App.js OAUTH_RETURN_SCHEME_URL 셋 다 같이 고쳐야 한다).
+import { describe, expect, it } from 'vitest';
+import { expectedReturnUri, isOAuthCallbackMode } from './oauth-callback-mode';
+
+describe('isOAuthCallbackMode', () => {
+  it('accepts https and custom_scheme', () => {
+    expect(isOAuthCallbackMode('https')).toBe(true);
+    expect(isOAuthCallbackMode('custom_scheme')).toBe(true);
+  });
+
+  it('rejects anything else, including null/undefined/empty', () => {
+    expect(isOAuthCallbackMode('android')).toBe(false);
+    expect(isOAuthCallbackMode('')).toBe(false);
+    expect(isOAuthCallbackMode(null)).toBe(false);
+    expect(isOAuthCallbackMode(undefined)).toBe(false);
+    expect(isOAuthCallbackMode('HTTPS')).toBe(false); // 대소문자 무관용(exact) — BE Literal과 동형
+  });
+});
+
+describe('expectedReturnUri', () => {
+  it('https: appLinkOrigin + /native/oauth-return', () => {
+    expect(expectedReturnUri('https', 'https://dev-app.sprintable.ai')).toBe(
+      'https://dev-app.sprintable.ai/native/oauth-return',
+    );
+    expect(expectedReturnUri('https', 'https://app.sprintable.ai')).toBe(
+      'https://app.sprintable.ai/native/oauth-return',
+    );
+  });
+
+  it('custom_scheme: fixed ai.sprintable URI regardless of appLinkOrigin (single slash, RFC 8252 opaque)', () => {
+    expect(expectedReturnUri('custom_scheme', 'https://dev-app.sprintable.ai')).toBe('ai.sprintable:/oauth-return');
+    expect(expectedReturnUri('custom_scheme', 'https://app.sprintable.ai')).toBe('ai.sprintable:/oauth-return');
+  });
+
+  // 자기검증 — 두 모드가 실제로 다른 문자열을 낸다(항상 같은 값을 반환하는 죽은 분기 방지).
+  it('mut: https and custom_scheme produce different values for the same origin', () => {
+    const a = expectedReturnUri('https', 'https://dev-app.sprintable.ai');
+    const b = expectedReturnUri('custom_scheme', 'https://dev-app.sprintable.ai');
+    expect(a).not.toBe(b);
+  });
+});

--- a/apps/web/src/lib/auth/oauth-callback-mode.ts
+++ b/apps/web/src/lib/auth/oauth-callback-mode.ts
@@ -1,0 +1,27 @@
+// story #3121 AC1(BFF/모바일 정합 절반) — 계약 doc e-mobile-oauth-native-handoff-contract §2/§10.7.
+//
+// iOS 17.4 미만은 ASWebAuthenticationSession의 legacy callbackURLScheme 경로로 가야 하고(모바일
+// PR #71/#72), 그 경로가 실제로 https 리다이렉트를 못 잡아 custom scheme(`ai.sprintable`) 폴백
+// 홉이 필요하다(apps/web `/native/oauth-return` 페이지·PR #3524). 어느 모드로 갈지는 모바일
+// 셸이 OAuth 시작 "전"에 정적으로(OS 버전만 보고) 결정한다 — BFF는 그 선택을 전달만 하고,
+// 실제 return_uri 문자열은 **여기서 고정값으로 계산**한다(클라가 임의 URI를 선언하게 두지
+// 않는다 — BE `_expected_return_uri()`와 동일한 고정 매핑, byte-exact 유지가 계약).
+//
+// ⚠️custom_scheme 값은 모바일 App.js `OAUTH_RETURN_SCHEME_URL`·apps/web
+// `/native/oauth-return/page.tsx`의 이동 대상과 byte-exact(`ai.sprintable:/oauth-return`,
+// 단일 슬래시 — RFC 8252 opaque URI 형식). 세 곳 중 하나만 바뀌면 조용히 깨진다.
+
+export type OAuthCallbackMode = 'https' | 'custom_scheme';
+
+const CUSTOM_SCHEME_RETURN_URI = 'ai.sprintable:/oauth-return';
+const NATIVE_RETURN_PATH = '/native/oauth-return';
+
+export function isOAuthCallbackMode(value: string | null | undefined): value is OAuthCallbackMode {
+  return value === 'https' || value === 'custom_scheme';
+}
+
+// appLinkOrigin: 호출자가 `APP_LINK_ORIGIN()`(callback/[provider]/route.ts 기존 값)을 넘긴다 —
+// 새 소스를 안 만든다(이미 App Link 리다이렉트 목적지 계산에 쓰는 값과 동일 출처 유지).
+export function expectedReturnUri(mode: OAuthCallbackMode, appLinkOrigin: string): string {
+  return mode === 'custom_scheme' ? CUSTOM_SCHEME_RETURN_URI : `${appLinkOrigin}${NATIVE_RETURN_PATH}`;
+}


### PR DESCRIPTION
## Summary
- 디디군 BE 절반(#3538)이 갖춘 `callback_mode`/`return_uri` 인터페이스를 BFF 양쪽 호출부(issue·consume)에 실제로 배선
- `lib/auth/oauth-callback-mode.ts`(신규): 모드 검증 + 고정 return_uri 매핑 — 클라 입력 URI를 신뢰하지 않는다
- `auth/login/route.ts`: 모바일 callback_mode 쿼리 → 쿠키 보존
- `api/auth/callback/[provider]/route.ts`: 쿠키 → issue 호출 body(https 기본 유도)
- `auth/oauth-handoff/route.ts`: 요청 body의 callback_mode → consume 호출(반쪽만 보내지 않음)

## 순서 (중요)
이 PR은 `feat-3121-oauth-callback-mode`(디디군 BE #3538) 위에 얹혀 있는 — 그 브랜치가 develop에 먼저 머지된 후 이 PR을 따라 머지하는 순서 권장. BE issue 스키마가 callback_mode/return_uri를 모르는 상태에서 이 BFF 코드만 먼저 develop에 들어가면 `extra=forbid` 스키마 때문에 issue 호출이 400날 위험.

모바일 절반은 별도 리포(sprintable-mobile) PR로 감 — App.js/lib/oauthHandoff.js가 같은 callback_mode 값을 OAuth-start 쿼리+consume POST에 실어 보내도록.

## Test plan
- [x] 신규 테스트 4파일 49건 그린(기존 회귀 0 — 원래 테스트는 그대로, 추가만)
- [x] `tsc --noEmit` 클린
- [x] `eslint` 클린
- [ ] E2E(dev 실기기 https+custom_scheme 왕복) — BE PR #3538 머지 후 통합 검증 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Haz8TMQftowKYbyppMyqxK