### PR TITLE
[SID:3135] «변경 요청» 아이콘 X→✎ — 결정 4의미 아이콘 분리

### DIFF
--- a/apps/web/src/components/cage/gate-signature-approval.tsx
+++ b/apps/web/src/components/cage/gate-signature-approval.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { CheckCircle, XCircle } from 'lucide-react';
+import { CheckCircle, Pencil } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { GateEvidence } from '@/components/cage/gate-evidence';
 import type { GateItem } from '@/components/kanban/types';
@@ -98,7 +98,7 @@ export function GateSignatureApproval({
             disabled={resolving}
             onClick={() => onReject(reason)}
           >
-            <XCircle className="size-4" />
+            <Pencil className="size-4" />
             {t('sigRequestChanges')}
           </Button>
           <Button

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { CheckCircle, ChevronDown, ChevronUp, XCircle } from 'lucide-react';
+import { CheckCircle, ChevronDown, ChevronUp, Pencil, XCircle } from 'lucide-react';
 import { deriveRiskLevel, usesSignatureFlow, deriveDiffFacts, isDecisionGate, deriveDecisionFacts } from '@/components/cage/gate-risk';
 import { gateNeedsAction } from '@/components/cage/gate-evidence';
 import { GateUndoButton, UNDO_WINDOW_MS } from '@/components/cage/gate-undo-button';
@@ -646,7 +646,7 @@ export function ApprovalsQueue() {
                   disabled={disabled}
                   onClick={rejectOnClick}
                 >
-                  <XCircle className="size-3.5" />
+                  <Pencil className="size-3.5" />
                   {t('sigRequestChanges')}
                 </Button>
                 {/* story #2631(PO 결정③) — 「보류(논의 필요)」는 결재함 전 게이트 타입 단일 표면. */}


### PR DESCRIPTION
## 변경 사항
결재 카드/결재함의 «변경 요청» 버튼이 X(⊗, XCircle)를 써서 «거절/닫기» 관용어와 충돌하던 것을 ✎(Pencil)로 교체. 라벨·동작 무변경, 아이콘만 교체.

## 같은 결정 버튼군을 쓰는 표면 전수(AC2)
| 파일 | 표면 | 처리 |
|---|---|---|
| `gate-signature-approval.tsx` | 공유 컴포넌트 — 챗 결재 카드(`approval-request-card.tsx`)와 `gates/[id]/page.tsx` 고위험 서명 플로우 양쪽이 재사용 | ✅ Pencil로 교체(1곳 수정 = 2표면 반영) |
| `approvals-queue.tsx` | 결재함 인라인 액션(고위험) | ✅ Pencil로 교체 |

**의도적으로 안 건드린 XCircle**(실제 «반려»=X가 맞는 자리, 라벨 확認 후 제외 — 관용어 충돌 없음):
- `approval-request-card.tsx` 저위험 경로의 실제 반려 버튼(`gateReject`)
- `gates/[id]/page.tsx` 저위험 경로의 실제 반려 버튼(`gateReject`)
- `approvals-queue.tsx`의 HITL 반려 버튼(`gateReject`)·해소완료 상태 배지(과거 이력 표시, 결정 버튼 아님)

## 근거(양 테마)
GateSignatureApproval을 vitest(jsdom)로 렌더해 실제 DOM을 캡처, 빌드된 CSS로 라이트/다크 양쪽 확인.

## 검증
- 관련 테스트 5개 파일(gates/[id]/page.test.tsx·approvals-queue.test.tsx·chat-bubble.test.tsx·doc-status-rail.test.tsx·doc-gate-section.test.tsx) — 216 passed(라벨 텍스트만 어서트해 아이콘 교체로 인한 회귀 없음 확認)
- `tsc --noEmit` clean
- `eslint` 0 warning
- `pnpm build` 성공
- 반응형: 레이아웃 변경 없음(아이콘 컴포넌트만 교체, 크기/margin 클래스 동일)

유나군 design 게이트(양 테마) 대기.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Cx4YtSpRgxRqyYKpbPzAs