### PR TITLE
[SID:3136] message_kind 발신 채택 + result 카드 3존 — ③구조화 회신 (AC1+AC2)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3423,6 +3423,8 @@
   "chats": {
     "reportViewFull": "View full →",
     "reportCollapse": "Collapse",
+    "reportEvidenceLabel": "Evidence",
+    "reportNextActionLabel": "Next",
     "unreadMarker": "Unread from here",
     "citationAnchored": "Cited from here — pick the last message",
     "citationSelectedCount": "{count} messages selected",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3423,6 +3423,8 @@
   "chats": {
     "reportViewFull": "전문 보기 →",
     "reportCollapse": "접기",
+    "reportEvidenceLabel": "근거",
+    "reportNextActionLabel": "다음",
     "unreadMarker": "여기부터 안읽음",
     "citationAnchored": "여기부터 인용 — 끝 메시지를 마저 골라 주세요",
     "citationSelectedCount": "{count}개 메시지 선택됨",

--- a/apps/web/src/components/chat/report-message-summary.test.tsx
+++ b/apps/web/src/components/chat/report-message-summary.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+// story #5c29454b(③ result 카드, doc result-card-final-spec-5c29454b) — 3존 규격(판정 dot·
+// 근거 라벨·다음 행동 박스) 실렌더 검증. no-fiction 원칙(원문에 없으면 안 뜬다)이 핵심이라
+// 정적 코드 리뷰보다 실 DOM 렌더로 확認한다.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { ReportMessageSummary } from './report-message-summary';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+// isReportDense 임계값(8줄/400자) 이상을 확실히 넘기는 PASS 판정 report 본문.
+const PASS_REPORT = [
+  '**전체 판정 — PASS**',
+  '오늘 배포한 3개 표면 전부 실측 완료.',
+  '**① 3009 — PASS**',
+  '- 인라인 카드 elev-card 토큰 확認',
+  '**② 3010 — PASS**',
+  '- inbox Bot칩 확認',
+  '**③ 3011 — PASS**',
+  '- Workcell 잘림 fix 확認',
+].join('\n');
+
+const FAIL_REPORT = [
+  '**전체 판정 — FAIL**',
+  '오늘 배포한 3개 표면 전부 반려.',
+  '**① 3009 — FAIL**',
+  '- 인라인 카드 elev-card 토큰 회귀',
+  '**② 3010 — FAIL**',
+  '- inbox Bot칩 회귀',
+  '**③ 3011 — FAIL**',
+  '- Workcell 잘림 fix 회귀',
+].join('\n');
+
+describe('ReportMessageSummary — story #5c29454b 판정 dot', () => {
+  it('kind=result·PASS 어휘면 success dot(bg-success)이 뜬다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ReportMessageSummary content={PASS_REPORT} messageKind="result" isMine={false} references={undefined} />,
+      ));
+    });
+    expect(container.querySelector('.bg-success')).not.toBeNull();
+    expect(container.querySelector('.bg-destructive')).toBeNull();
+  });
+
+  it('kind=result·FAIL 어휘면 destructive dot이 뜬다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ReportMessageSummary content={FAIL_REPORT} messageKind="result" isMine={false} references={undefined} />,
+      ));
+    });
+    expect(container.querySelector('.bg-destructive')).not.toBeNull();
+    expect(container.querySelector('.bg-success')).toBeNull();
+  });
+
+  it('kicker가 «판정»이 아니면(kind=request) dot 자체가 안 뜬다', async () => {
+    const raw = [
+      '**요청 사항**',
+      '이 부분 검토 부탁하는.',
+      '- 항목 1',
+      '- 항목 2',
+      '- 항목 3',
+      '- 항목 4',
+      '- 항목 5',
+      '- 항목 6',
+    ].join('\n');
+    await act(async () => {
+      root.render(wrap(
+        <ReportMessageSummary content={raw} messageKind="request" isMine={false} references={undefined} />,
+      ));
+    });
+    expect(container.querySelector('.bg-success')).toBeNull();
+    expect(container.querySelector('.bg-destructive')).toBeNull();
+    expect(container.textContent).toContain('요청');
+  });
+});
+
+describe('ReportMessageSummary — story #5c29454b 근거 라벨', () => {
+  it('topLevelItems가 있으면 «근거» 라벨이 뜬다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ReportMessageSummary content={PASS_REPORT} messageKind="result" isMine={false} references={undefined} />,
+      ));
+    });
+    expect(container.textContent).toContain('근거');
+  });
+
+  it('topLevelItems가 0개면 «근거» 라벨이 안 뜬다', async () => {
+    const raw = '그냥 아주 긴 산문 설명입니다. '.repeat(30);
+    await act(async () => {
+      root.render(wrap(
+        <ReportMessageSummary content={raw} messageKind="result" isMine={false} references={undefined} />,
+      ));
+    });
+    expect(container.textContent).not.toContain('근거');
+  });
+});
+
+describe('ReportMessageSummary — story #5c29454b 다음 행동 박스(no-fiction)', () => {
+  it('원문에 «다음: ...»이 있으면 다음 행동 박스가 뜬다', async () => {
+    const raw = `${PASS_REPORT}\n다음: 카디르군 QA 요청`;
+    await act(async () => {
+      root.render(wrap(
+        <ReportMessageSummary content={raw} messageKind="result" isMine={false} references={undefined} />,
+      ));
+    });
+    expect(container.textContent).toContain('다음');
+    expect(container.textContent).toContain('카디르군 QA 요청');
+  });
+
+  it('원문에 «다음» 구분자가 없으면 다음 행동 박스 자체가 안 뜬다(지어내지 않음)', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ReportMessageSummary content={PASS_REPORT} messageKind="result" isMine={false} references={undefined} />,
+      ));
+    });
+    // "다음 행동" 라벨/박스가 없어야 한다 — reportViewFull("전문 보기 →")과는 무관.
+    expect(container.textContent).not.toContain('카디르군');
+    const boxes = Array.from(container.querySelectorAll('div')).filter((d) =>
+      d.className.includes('bg-brand/10'));
+    expect(boxes.length).toBe(0);
+  });
+});
+
+describe('ReportMessageSummary — 발동 조건 미충족(회귀 0)', () => {
+  it('밀도 임계값 미달이면 3존 렌더 자체가 없고 기존 ChatMarkdown 경로로 폴백한다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ReportMessageSummary content="짧은 메시지" messageKind="result" isMine={false} references={undefined} />,
+      ));
+    });
+    expect(container.querySelector('.bg-success')).toBeNull();
+    expect(container.textContent).toContain('짧은 메시지');
+  });
+});

--- a/apps/web/src/components/chat/report-message-summary.tsx
+++ b/apps/web/src/components/chat/report-message-summary.tsx
@@ -8,7 +8,7 @@ import type { ReadingPanelTarget } from './reading-panel';
 import type { EventDefinitionSummary } from '@/lib/block-template';
 import { ChatMarkdown } from './chat-bubble';
 import { MaterialChip } from '@/components/ui/material-chip';
-import { computeReportDensity } from '@/lib/chat-report-density';
+import { computeReportDensity, RESULT_KICKER_LABEL } from '@/lib/chat-report-density';
 
 interface ReportMessageSummaryProps {
   content: string;
@@ -53,27 +53,58 @@ export function ReportMessageSummary({
     );
   }
 
+  // story #5c29454b(③ result 카드, doc result-card-final-spec-5c29454b) — 판정 dot은
+  // kicker가 정확히 «판정»일 때만(요청/핸드오프/확인 kicker엔 성공/반려 개념이 없다).
+  const isVerdictKicker = density.kicker === RESULT_KICKER_LABEL;
+  const verdictDotClass = isVerdictKicker
+    ? density.verdictTone === 'success'
+      ? 'bg-success'
+      : density.verdictTone === 'destructive'
+        ? 'bg-destructive'
+        : 'bg-muted-foreground'
+    : null;
+
   return (
     <div>
       {density.kicker ? (
         // story #3052(2984-S4) — MaterialChip(S1, 헤어라인+fill 0) 채택, bg-proof-blue-soft
         // 채움 폐지(§2 doc ⓒ kicker 판정 — 순수 SHIFT, 신호 아님).
-        <MaterialChip className="mb-1.5">{density.kicker}</MaterialChip>
+        // story #5c29454b — 판정 dot(그래픽 신호, 텍스트는 계속 중립)을 chip 앞에 붙인다.
+        <div className="mb-1.5 flex items-center gap-1.5">
+          {verdictDotClass ? <span className={`size-1.5 shrink-0 rounded-full ${verdictDotClass}`} aria-hidden /> : null}
+          <MaterialChip>{density.kicker}</MaterialChip>
+        </div>
       ) : null}
       <p className={`mb-1.5 text-sm font-medium leading-relaxed [overflow-wrap:anywhere] ${density.kicker ? '' : 'mt-0'}`}>
         {density.lead}
       </p>
       {density.topLevelItems.length > 0 ? (
-        <ul className="mb-1.5 flex flex-col gap-0.5">
-          {density.topLevelItems.map((item, i) => (
-            <li key={i} className="text-sm leading-relaxed [overflow-wrap:anywhere]">{item.text}</li>
-          ))}
-        </ul>
+        <>
+          <p className="mb-1 mt-2.5 text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
+            {t('reportEvidenceLabel')}
+          </p>
+          <ul className="mb-1.5 flex flex-col gap-0.5">
+            {density.topLevelItems.map((item, i) => (
+              <li key={i} className="text-sm leading-relaxed [overflow-wrap:anywhere]">{item.text}</li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+      {density.nextAction ? (
+        // story #5c29454b — 「다음 행동」 존. 원문에 명시적 구분자(다음:/→ 다음/Next:)가
+        // 있을 때만 뜬다(no-fiction — 지어낸 다음 행동 금지, computeReportDensity 참조).
+        <div className="mt-2.5 flex gap-2 rounded-lg border border-brand/15 bg-brand/10 px-2.5 py-2">
+          <span className="font-bold text-brand" aria-hidden>→</span>
+          <p className="[overflow-wrap:anywhere]">
+            <span className="font-semibold text-primary">{t('reportNextActionLabel')}</span>
+            <span className="text-[12.5px] text-foreground"> {density.nextAction}</span>
+          </p>
+        </div>
       ) : null}
       <button
         type="button"
         onClick={() => setExpanded(true)}
-        className="text-[11.5px] font-semibold text-primary hover:underline"
+        className="mt-1.5 text-[11.5px] font-semibold text-primary hover:underline"
       >
         {t('reportViewFull')}
       </button>

--- a/apps/web/src/lib/chat-report-density.test.ts
+++ b/apps/web/src/lib/chat-report-density.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
-  computeReportDensity, deriveKicker, extractLeadSentence, extractTopLevelItems, isReportDense,
-  REPORT_DENSITY_MIN_CHARS, REPORT_DENSITY_MIN_LINES,
+  computeReportDensity, deriveKicker, deriveVerdictTone, extractLeadSentence, extractNextAction,
+  extractTopLevelItems, isReportDense, REPORT_DENSITY_MIN_CHARS, REPORT_DENSITY_MIN_LINES,
 } from './chat-report-density';
 
 describe('isReportDense (story #ec57c80c, 발동 임계값)', () => {
@@ -198,6 +198,55 @@ describe('extractTopLevelItems (story #ec57c80c — 최상위 목록만, 하위/
   });
 });
 
+describe('deriveVerdictTone (story #5c29454b — 판정 dot 색, 모호=중립 안전측)', () => {
+  it('PASS/승인/완료만 있으면 success', () => {
+    expect(deriveVerdictTone('**결과 — PASS**')).toBe('success');
+    expect(deriveVerdictTone('선생님이 승인했는')).toBe('success');
+    expect(deriveVerdictTone('작업 완료')).toBe('success');
+  });
+
+  it('FAIL/반려만 있으면 destructive', () => {
+    expect(deriveVerdictTone('**결과 — FAIL**')).toBe('destructive');
+    expect(deriveVerdictTone('사유 없이 반려됐는')).toBe('destructive');
+  });
+
+  it('둘 다 없거나 둘 다 있으면(모호) neutral', () => {
+    expect(deriveVerdictTone('그냥 진행 상황 업데이트')).toBe('neutral');
+    expect(deriveVerdictTone('이전엔 반려였는데 이번엔 승인')).toBe('neutral');
+  });
+});
+
+describe('extractNextAction (story #5c29454b — 다음 행동, no-fiction 보수 패턴)', () => {
+  it('"다음: ..." 구분자가 있으면 뒤의 문구를 verbatim으로 뽑는다', () => {
+    expect(extractNextAction('본문\n다음: 카디르군 QA 요청')).toBe('카디르군 QA 요청');
+  });
+
+  it('"다음 행동: ..." / "→ 다음 ..." / "Next: ..." 변형도 매치한다', () => {
+    expect(extractNextAction('다음 행동: PR 머지')).toBe('PR 머지');
+    expect(extractNextAction('→ 다음: 배포 확인')).toBe('배포 확인');
+    expect(extractNextAction('Next: review needed')).toBe('review needed');
+  });
+
+  it('구분자 없는 «다음»(사인오프·타맥락)은 매치하지 않는다(오분류 방지)', () => {
+    expect(extractNextAction('다음 오는 것 잇는')).toBeNull();
+    expect(extractNextAction('다음 재호출 시 반영되는')).toBeNull();
+    expect(extractNextAction('다음 차례에 처리하는')).toBeNull();
+  });
+
+  it('구분자 자체가 없으면 null(지어내지 않음)', () => {
+    expect(extractNextAction('그냥 평범한 보고문입니다.')).toBeNull();
+  });
+
+  it('여러 줄이 매치되면 마지막(결론) 매치를 채택한다', () => {
+    const raw = '다음: 초안\n중간 내용\n다음: 최종 확定 — 배포 진행';
+    expect(extractNextAction(raw)).toBe('최종 확定 — 배포 진행');
+  });
+
+  it('마크다운 마커는 스트립된 verbatim 텍스트로 나온다', () => {
+    expect(extractNextAction('다음: **PR#3541** 머지')).toBe('PR#3541 머지');
+  });
+});
+
 describe('computeReportDensity (story #ec57c80c — 통합, 발동 게이트)', () => {
   it('발동 조건 미충족이면 null(호출부가 기존 렌더로 폴백)', () => {
     expect(computeReportDensity('짧은 메시지', 'result')).toBeNull();
@@ -243,5 +292,37 @@ describe('computeReportDensity (story #ec57c80c — 통합, 발동 게이트)', 
     expect(result!.lead).toBe('요약 문장입니다');
     expect(result!.topLevelItems.map((i) => i.text)).toEqual(['두 번째 헤더', '세 번째 헤더', '네 번째 헤더']);
     expect(result!.topLevelItems.some((i) => i.text === result!.lead)).toBe(false);
+  });
+
+  it('story #5c29454b — verdictTone/nextAction도 함께 채운다', () => {
+    const raw = [
+      '**전체 판정 — PASS**',
+      '오늘 배포한 3개 표면 전부 실측 완료.',
+      '**① 3009 — PASS**',
+      '- 인라인 카드 elev-card 토큰 확認',
+      '**② 3010 — PASS**',
+      '- inbox Bot칩 확認',
+      '**③ 3011 — PASS**',
+      '- Workcell 잘림 fix 확認',
+      '다음: 유나군 design 게이트 대기',
+    ].join('\n');
+    const result = computeReportDensity(raw, 'result');
+    expect(result!.verdictTone).toBe('success');
+    expect(result!.nextAction).toBe('유나군 design 게이트 대기');
+  });
+
+  it('story #5c29454b — «다음» 구분자가 원문에 없으면 nextAction=null(지어내지 않음)', () => {
+    const raw = [
+      '**전체 판정 — PASS**',
+      '오늘 배포한 3개 표면 전부 실측 완료.',
+      '**① 3009 — PASS**',
+      '- 인라인 카드 elev-card 토큰 확認',
+      '**② 3010 — PASS**',
+      '- inbox Bot칩 확認',
+      '**③ 3011 — PASS**',
+      '- Workcell 잘림 fix 확認',
+    ].join('\n');
+    const result = computeReportDensity(raw, 'result');
+    expect(result!.nextAction).toBeNull();
   });
 });

--- a/apps/web/src/lib/chat-report-density.ts
+++ b/apps/web/src/lib/chat-report-density.ts
@@ -11,6 +11,10 @@ const MESSAGE_KIND_LABEL: Record<MessageKind, string> = {
   request: '요청', handoff: '핸드오프', result: '판정', ack: '확인',
 };
 
+// story #5c29454b — 판정 dot 게이팅용(호출부가 density.kicker와 문자열 비교). 이 라벨은
+// i18n 대상이 아니다(위 MESSAGE_KIND_LABEL 전체가 그렇듯 이 파일은 로케일 무관 내부 상수).
+export const RESULT_KICKER_LABEL = MESSAGE_KIND_LABEL.result;
+
 // story #2985 — FE ChatMessage.message_kind는 BE 계약을 앞서 좁히지 않으려 `string | null`로
 // 느슨하게 타입돼 있다(이 세션의 다른 필드들과 동일 관례). 4-enum 소속 여부는 여기서
 // 런타임으로만 판별한다 — 구서버·오염값은 항상 안전하게 폴백(무표시 또는 휴리스틱)한다.
@@ -53,6 +57,48 @@ export function isReportDense(content: string): boolean {
 // PASS/FAIL/REQUEST_CHANGES)가 볼드 라인에 있을 때만 kicker를 단다. 그 외(모호)는 전부
 // 미표시 — 오분류 kicker는 지어냄이라 미표시가 항상 안전측(story AC2).
 const VERDICT_PATTERN = /\*\*[^*]*\b(PASS|FAIL|REQUEST_CHANGES)\b[^*]*\*\*/;
+
+// story #5c29454b(③ result 카드, doc result-card-final-spec-5c29454b) — 판정 dot 색.
+// «확실한 어휘»일 때만 색을 준다(모호=중립 dot, 오분류=지어냄이라 안전측 폴백). 두 신호가
+// 동시에 있으면(예: 전/후 상태가 섞인 요약) 어느 한쪽으로 단정 못 하니 중립.
+export type VerdictTone = 'success' | 'destructive' | 'neutral';
+
+const SUCCESS_WORDS = /\bPASS\b|승인|완료/;
+const DESTRUCTIVE_WORDS = /\bFAIL\b|반려/;
+
+export function deriveVerdictTone(content: string): VerdictTone {
+  const hasSuccess = SUCCESS_WORDS.test(content);
+  const hasDestructive = DESTRUCTIVE_WORDS.test(content);
+  if (hasSuccess && !hasDestructive) return 'success';
+  if (hasDestructive && !hasSuccess) return 'destructive';
+  return 'neutral';
+}
+
+// story #5c29454b — 「다음 행동」 추출. 보수 패턴(구분자 명시 필요) — 「다음 오는 것」·
+// 「다음 재호출 시」·「다음 차례」류 구분자 없는 «다음»은 애초에 매치 안 된다(오분류 방지,
+// doc §③ 제외 목록). 여러 줄이 매치되면 마지막(가장 나중에 오는=결론) 매치를 채택한다.
+const NEXT_ACTION_PATTERNS: RegExp[] = [
+  /다음\s*[:=]\s*(.+)/,
+  /→\s*다음[\s:]\s*(.+)/,
+  /다음\s*행동\s*[:=]?\s*(.+)/,
+  /[Nn]ext\s*:\s*(.+)/,
+];
+
+/** 원문에 명시적 「다음: ...」류 구분자가 있을 때만 추출(verbatim substring). 없으면
+ * null(미표시 — kicker 보수 폴백과 동형 no-fiction 원칙). */
+export function extractNextAction(content: string): string | null {
+  let found: string | null = null;
+  for (const line of content.split('\n')) {
+    for (const pattern of NEXT_ACTION_PATTERNS) {
+      const m = line.match(pattern);
+      if (m?.[1]) {
+        found = stripInlineMarkers(m[1]);
+        break;
+      }
+    }
+  }
+  return found || null;
+}
 
 /** kicker 라벨. 1차 소스=message_kind(있으면 그걸로 확定), 없으면 보수적 패턴 폴백,
  * 그것도 아니면 null(미표시 — 지어내지 않음). */
@@ -140,6 +186,9 @@ export interface ReportDensity {
   kicker: string | null;
   lead: string;
   topLevelItems: TopLevelListItem[];
+  // story #5c29454b — kicker가 «판정»일 때만 의미 있다(호출부가 그 조건으로 게이팅).
+  verdictTone: VerdictTone;
+  nextAction: string | null;
 }
 
 /** 발동 조건(isReportDense) 미충족이면 null — 호출부는 null이면 기존 렌더를 그대로 쓴다
@@ -155,5 +204,7 @@ export function computeReportDensity(content: string, messageKind?: string | nul
     kicker: deriveKicker(content, messageKind),
     lead,
     topLevelItems,
+    verdictTone: deriveVerdictTone(content),
+    nextAction: extractNextAction(content),
   };
 }

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -161,6 +161,23 @@ class SendChatInput(ConversationScopedInput):
     )
     reply_thread_id: str | None = None
     message_type: str | None = None
+    # story #5c29454b(③ 구조화 회신, AC1 발신 계약) — BE `SendMessageRequest.message_kind`
+    # (conversations.py, E-ACTIVATION S1)가 이미 받는 4-enum 발신 신호인데, 이 MCP 도구가
+    # 여태 노출을 안 해 발신측이 kind를 실을 길이 없었다(FE result 카드 레일이 헛도는
+    # 근본원인 — doc result-card-final-spec-5c29454b). message_type(위, 별개 필드 — meta에
+    # 얹혀 review UI류에 쓰이는 기존 계약)과 이름이 비슷해 보이지만 완전히 다른 축이다:
+    # message_type은 metadata 안 자유 문자열, message_kind는 top-level 4-enum이라 BE가
+    # `_ACTIVATION_KINDS`로 검증한다. 명시 안 하면 None 유지(조용한 유도 금지 — no-fiction).
+    message_kind: Literal["request", "handoff", "result", "ack"] | None = Field(
+        default=None,
+        description=(
+            "이 메시지의 의미 유형(4개뿐, message_type과 별개 축). result로 보내면 FE가 "
+            "«판정+근거+다음 행동» 카드로 렌더한다(긴 report성 메시지일 때) — 판정을 보고할 "
+            "땐 반드시 이걸 실어라, 안 실으면 보수적 어휘 추론(PASS/FAIL 등)에만 기대야 "
+            "하고 판정 dot(성공/반려 색)도 안 뜬다. 원문에 「다음: ...」류 다음 행동 문구를 "
+            "같이 적어야 다음 행동 박스가 뜬다(지어내지 않음)."
+        ),
+    )
     review_type: str | None = None
     metadata: dict | None = None
     # [{content_base64, name, content_type}, ...] — 스샷/작은 문서(최대 5개·파일당 2MiB·총 6MiB).
@@ -262,6 +279,10 @@ async def send_chat_message(args: SendChatInput) -> list[TextContent]:
             payload["thread_id"] = args.reply_thread_id
         if args.mentioned_ids:
             payload["mentioned_ids"] = args.mentioned_ids
+        # story #5c29454b AC1 — top-level 필드(meta에 얹지 않는다, BE가 top-level에서만
+        # 읽는다 — conversations.py SendMessageRequest.message_kind).
+        if args.message_kind:
+            payload["message_kind"] = args.message_kind
         meta: dict = {}
         if args.metadata:
             meta.update(args.metadata)

--- a/backend/tests/test_5c29454b_mcp_message_kind.py
+++ b/backend/tests/test_5c29454b_mcp_message_kind.py
@@ -1,0 +1,66 @@
+"""story #5c29454b(③ 구조화 회신, AC1 발신 계약) — MCP `sprintable_send_chat_message`에
+`message_kind` 배선. BE `SendMessageRequest.message_kind`(app/routers/conversations.py,
+E-ACTIVATION S1)는 이미 4-enum을 받는데, MCP `SendChatInput`엔 이 필드가 없어 발신측이
+kind를 실을 길이 없었다(doc result-card-final-spec-5c29454b가 지목한 근본원인 — FE result
+카드 density 레일이 헛돎). `message_type`(기존, metadata에 얹히는 별개 축)과 이름이 비슷해
+혼동하기 쉬워 그 구분도 함께 고정한다.
+
+`test_2618_mcp_mentioned_ids.py`와 동일 컨벤션(mock 기반 payload 배선 확認)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from sprintable_mcp.tools.chat import SendChatInput, send_chat_message
+from sprintable_mcp.tools import chat as chat_mod
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_message_kind_forwarded_top_level_to_rest_payload():
+    args = SendChatInput(conversation_id="conv-1", content="PASS — 전부 그린", message_kind="result")
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m:
+        result = await send_chat_message(args)
+        _, kwargs = m.call_args
+        assert kwargs["json"]["message_kind"] == "result"
+        assert "Error" not in result[0].text
+
+
+@pytest.mark.anyio
+async def test_message_kind_omitted_no_key_in_payload_no_regression():
+    """명시 안 하면 payload에 키 자체가 안 실린다 — 조용한 유도 금지(no-fiction), 회귀 0."""
+    args = SendChatInput(conversation_id="conv-1", content="hi there")
+    assert args.message_kind is None
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m:
+        await send_chat_message(args)
+        _, kwargs = m.call_args
+        assert "message_kind" not in kwargs["json"]
+
+
+@pytest.mark.anyio
+async def test_message_kind_rejects_values_outside_4_enum():
+    """BE `_ACTIVATION_KINDS`와 동형 4-enum만 허용 — 오탈자/자유문자열은 MCP 경계에서 즉시 422급
+    ValidationError(서버 왕복 없이 여기서 잡는다, 헤더 오염 방지 원칙과 동형)."""
+    with pytest.raises(ValidationError):
+        SendChatInput(conversation_id="conv-1", content="hi", message_kind="done")
+
+
+@pytest.mark.anyio
+async def test_message_kind_is_top_level_not_nested_in_metadata():
+    """message_type(기존, meta에 얹힘)과 message_kind(신규, top-level)는 별개 축 — 함께 보내도
+    서로 안 섞인다(회귀 축 — 향후 이름 혼동으로 둘을 합치는 실수 방지)."""
+    args = SendChatInput(
+        conversation_id="conv-1", content="결과 보고", message_kind="result", message_type="report",
+    )
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})) as m:
+        await send_chat_message(args)
+        _, kwargs = m.call_args
+        assert kwargs["json"]["message_kind"] == "result"
+        assert kwargs["json"]["metadata"]["message_type"] == "report"
+        assert "message_kind" not in kwargs["json"]["metadata"]


### PR DESCRIPTION
## 배경
doc `chat-action-messages-round1-draft`(v4)·`result-card-final-spec-5c29454b`(유나 확定 SSOT) — `message_kind` 4-enum·`chat-report-density` 레일은 이미 서 있었으나 발신측이 kind를 실을 길이 없어 헛돌던 갭.

## AC1(발신 계약) — `backend/sprintable_mcp/tools/chat.py`
BE `SendMessageRequest.message_kind`(`conversations.py`, E-ACTIVATION S1)는 이미 top-level 4-enum 필드였는데, MCP `SendChatInput`엔 그 필드가 아예 없었다 — 대신 이름이 비슷한 `message_type`(metadata에 얹히는 별개 축, review UI류 용도)만 있어 혼동하기 쉬웠다.

- `message_kind: Literal["request","handoff","result","ack"] | None` 필드 신설.
- payload **최상위**에 그대로 실어 보냄(`metadata`에 안 얹음 — BE는 top-level에서만 읽는다).
- 미지정 시 payload에 키 자체가 안 실림(조용한 유도 금지, no-fiction).
- Field description으로 `message_type`과의 구분을 도구 스키마 자체에 명시(향후 같은 혼동 재발 방지).

## AC2(result 카드 3존) — `chat-report-density.ts` + `report-message-summary.tsx`
- `deriveVerdictTone(content)`: PASS/승인/완료 vs FAIL/반려 **확실한 어휘일 때만** success/destructive, 모호(둘 다 있거나 둘 다 없음)는 neutral — 오분류 안전측.
- `extractNextAction(content)`: 「다음:」/「다음 행동:」/「→ 다음」/「Next:」류 **명시 구분자가 있을 때만** 추출(verbatim substring), 없으면 null — 「다음 오는 것」류 구분자 없는 사인오프는 패턴 자체가 매치 안 돼 자연히 제외된다.
- `report-message-summary.tsx`: kicker=«판정»일 때만 색 dot(그래픽 신호, 텍스트는 계속 중립) + 근거 라벨(topLevelItems 있을 때만) + 다음 행동 박스(nextAction 있을 때만, no-fiction). **BE 무변경**(content는 그대로, 렌더 시점 변환만).

## AC3(fleet 채택)
HEARTBEAT/AGENTS 반영은 PO 지시대로 별도 커밋. **실 대화 result 카드 렌더 실증은 이 PR 머지·배포 후 진행** — 현재 세션이 쓰는 MCP는 배포된 구버전이라 이 브랜치의 message_kind 배선이 아직 안 실려 있어 지금은 왕복 실증이 물리적으로 불가능하다(정직하게 명시).

## AC4(회귀 0)
구서버·kind 없는 메시지는 기존 휴리스틱(`VERDICT_PATTERN`) 폴백 그대로 — 신규 필드는 전부 opt-in, 기존 호출부 무변경.

## 근거(양 테마 — PASS/FAIL 두 케이스)
vitest(jsdom)로 `ReportMessageSummary` 렌더 → 빌드된 CSS로 라이트/다크 캡처. 판정 dot(초록/빨강)·근거 라벨·다음 행동 박스(화살표+«다음»+본문) 전부 spec대로 렌더 확認.

## 검증
- FE: `chat-report-density.test.ts`(44)+`report-message-summary.test.tsx`(8, 신규)+`chat-bubble.test.tsx`(106) = **158 passed** · `tsc --noEmit` clean · `eslint` 0 · `pnpm build` 성공.
- BE: `test_5c29454b_mcp_message_kind.py`(4, 신규)+MCP chat 관련 기존 33개 = **37 passed**(8 realdb skip, 로컬 PG 없음 — 정상).

유나군 design 게이트(chat 실렌더·양 테마·«다음»이 원문 있을 때만) + 페드루군 AC 리뷰 대기.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Cx4YtSpRgxRqyYKpbPzAs