### PR TITLE
[SID:3134] gate 상세에 loop_decision 대상 진입 경로 추가

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3942,6 +3942,7 @@
     "gateDetailOrgContext": "Org {org}",
     "gateDetailViewTargetDoc": "View document →",
     "gateDetailViewTargetArtifact": "View artifact →",
+    "gateDetailViewTargetLoop": "View loop →",
     "riskUnknown": "Risk pending",
     "riskHigh": "High risk · review closely",
     "diffFactsFileCount": "{count} files",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3942,6 +3942,7 @@
     "gateDetailOrgContext": "조직 {org}",
     "gateDetailViewTargetDoc": "문서 원문 보기 →",
     "gateDetailViewTargetArtifact": "아티팩트 보기 →",
+    "gateDetailViewTargetLoop": "루프 보기 →",
     "riskUnknown": "위험도 확인 중",
     "riskHigh": "고위험 · 신중 결재",
     "diffFactsFileCount": "파일 {count}",

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.test.tsx
@@ -665,6 +665,28 @@ describe('GateDetailPage — story #3128 대상 실물 진입 경로', () => {
     expect(container.textContent).not.toContain(koMessages.cage.gateDetailViewTargetArtifact);
   });
 
+  // story #3134(#3128 전수점검 잔여) — loop_decision의 work_item_id는 LoopRun.id, `/loops/{id}`가
+  // 실 상세 페이지.
+  it('loop_decision은 work_item_id로 /loops/{id} 링크가 뜬다', async () => {
+    await mount(gate({
+      gate_type: 'loop_decision', work_item_type: 'loop', work_item_id: 'loop-7',
+      can_approve: true, risk_grade: 'low', work_item_summary: null,
+    }));
+    const link = [...container.querySelectorAll('a')].find((a) => a.textContent === koMessages.cage.gateDetailViewTargetLoop);
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute('href')).toBe('/loops/loop-7');
+  });
+
+  it('workflow_config_publish는 이번에도 대상 링크가 없다(실 뷰어 부재 — 억지 진입점 금지, #2118 AC④)', async () => {
+    await mount(gate({
+      gate_type: 'workflow_config_publish', work_item_type: 'wf_line_version', work_item_id: 'wf-9',
+      can_approve: true, risk_grade: 'low', work_item_summary: null,
+    }));
+    expect(container.textContent).not.toContain(koMessages.cage.gateDetailViewTargetDoc);
+    expect(container.textContent).not.toContain(koMessages.cage.gateDetailViewTargetArtifact);
+    expect(container.textContent).not.toContain(koMessages.cage.gateDetailViewTargetLoop);
+  });
+
   it('이미 해소된(approved) doc 게이트도 원문 링크가 그대로 남는다(감사 가치는 액션 여부와 무관 — decisionFacts·GateActivityHistory와 동원칙)', async () => {
     await mount(gate({
       gate_type: 'doc_approval', work_item_type: 'doc', status: 'approved', resolver_id: null,

--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -133,22 +133,25 @@ export default function GateDetailPage() {
   // 승인 가능한 것처럼 보이는 게 실 결함이라 canonical의 첫 라이브 실측에서 바로 잡았다.
   const isDocGate = gate?.work_item_type === 'doc' || gate?.gate_type === 'doc_approval';
   const isCanonicalizeGate = gate?.gate_type === 'artifact_canonicalize';
-  // story #3128(#3113의 doc_approval판, 페드루 PO 3529 라이브 검증 중 부수 발견) — 카드가
-  // 「근거 데이터 없음 — 내용으로 직접 판단」이라 안내하면서도 대상 실물(문서/아티팩트)로 가는
-  // 경로가 카드 안에 0개였다. doc은 work_item_summary.slug(BE #1970 기존 계약, doc gate만
-  // 채워짐)로 `/docs/{slug}` bare 경로(notification-bell.tsx와 동형 관행 — org/project
-  // slug 없이도 middleware가 현재 활성 프로젝트로 해소, 크로스 프로젝트 게이트는 기존
-  // org/project 이름 표시와 같은 알려진 한계). artifact_canonicalize(work_item_type=
-  // 'visual_artifact')는 BE work_item_summary가 이 타입엔 항상 null(_resolve_work_item_summary
-  // fail-soft)이지만, gate.work_item_id 자체는 항상 있어 slug 없이도 `/artifacts/{id}`
-  // bare 경로(legacy-resource-tables.ts MIGRATED_RESOURCES 등재 확認)로 충분 — 같은
-  // «비용 작으면 잔여 0» 원칙으로 이번 PR에 같이 닫는다. 다른 gate 유형(loop_decision의
-  // hypothesis 초안 verdict·workflow_config_publish)은 전수 점검했으나 링크 대상 라우트가
-  // 불명확해 이번 PR 스코프 밖 — 페드루군에 별도 사이징 보고.
+  // story #3134(#3128 전수점검 잔여 — loop_decision) — HypothesisOutcomeDraft(gate-evidence.tsx)가
+  // 초안 verdict(verified/falsified/killed·actual·reason) 텍스트는 보여주지만, 그 판정이 어느
+  // loop을 재는지로 가는 링크가 없었다. loop_decision의 work_item_id는 `LoopRun.id`(BE
+  // loop.py:303 create_gate 호출·work_item_type='loop')다 — `/loops/{id}` 가 실 상세 페이지
+  // (loop-detail-client.tsx, 268줄 실 콘텐츠 확認)라 artifact와 동일 primitive로 닫는다.
+  // ⛔workflow_config_publish는 이번에도 스코프 밖 — 그라운딩 결과 `wf_line_version`은 FE
+  // entity 계열에 아예 등록 안 됨(embed-card.tsx 자체 주석: RICH_PREVIEW_TYPES·ENTITY_API·
+  // getEntityHref 셋 다 없음) + 대상 페이지(organization/workforce/workflow)가 "지금 사는
+  // config"만 보여줄 뿐 "이 버전(review 대상)"을 볼 방법이 아예 없다 — 링크를 억지로 달면
+  // #2118 P2.2 AC④가 이미 금지한 "미리보기 없는 타입에 빈 모달 여는 거짓 진입점"이 된다.
+  // 이건 BE(neutral_facts에 config diff 임베드) 또는 신규 FE 뷰어가 필요한 더 큰 스코프 —
+  // 페드루군에 사이징 보고.
+  const isLoopDecisionGate = gate?.gate_type === 'loop_decision';
   const targetLink = isDocGate && gate?.work_item_summary?.slug
     ? { href: `/docs/${gate.work_item_summary.slug}`, labelKey: 'gateDetailViewTargetDoc' as const }
     : isCanonicalizeGate && gate?.work_item_id
     ? { href: `/artifacts/${gate.work_item_id}`, labelKey: 'gateDetailViewTargetArtifact' as const }
+    : isLoopDecisionGate && gate?.work_item_id
+    ? { href: `/loops/${gate.work_item_id}`, labelKey: 'gateDetailViewTargetLoop' as const }
     : null;
   const needsAction = !!gate && gate.status === 'pending' && (gateNeedsAction(gate) || isDocGate || isCanonicalizeGate);
   // story #2091(P0) — needsAction은 "이 게이트가 사람의 판단을 필요로 하는가"만 답한다(gate 자체의


### PR DESCRIPTION
[SID:3134]

## 배경 (#3128 전수점검 잔여)
gate 유형별 「대상 실물 진입 경로」 전수점검(#3128)에서 스코프 밖으로 남겼던 2종 중 `loop_decision`을 닫는다.

## 구현
`HypothesisOutcomeDraft`(gate-evidence.tsx)가 초안 verdict(verified/falsified/killed·actual·reason) 텍스트는 보여주지만, 그 판정이 어느 loop을 재는지로 가는 링크가 없었다. `loop_decision`의 `work_item_id`는 `LoopRun.id`(BE `loop.py:303` `create_gate` 호출·`work_item_type='loop'`) — `/loops/{id}`가 실 상세 페이지(`loop-detail-client.tsx`, 268줄 실 콘텐츠 확認)라 `artifact_canonicalize`와 동일 primitive(work_item_id 직접, BE 계약 변경 0)로 닫는다.

## workflow_config_publish는 이번에도 스코프 밖
그라운딩 결과:
- `wf_line_version`은 FE entity 계열에 아예 미등록(`embed-card.tsx` 자체 주석: `RICH_PREVIEW_TYPES`·`ENTITY_API`·`getEntityHref` 셋 다 없음).
- 대상 페이지(`organization/workforce/workflow`)는 "지금 사는 config"만 보여줄 뿐 "이 버전(review 대상)"을 볼 방법 자체가 없음.
- 링크를 억지로 달면 story #2118 P2.2 AC④가 이미 금지한 "미리보기 없는 타입에 빈 모달 여는 거짓 진입점"이 된다.

BE(neutral_facts에 config diff 임베드) 또는 신규 FE 뷰어가 필요한 더 큰 스코프 — 별도 사이징 필요.

## 검증
신규 테스트 2건(loop 링크·workflow_config_publish 여전히 미렌더) — loop 링크는 뮤테이션(targetLink 분기 제거) genuine RED 확認 後 복원. 36/36 관련 테스트 green, tsc/eslint/i18n-key-parity/next build 전부 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)