### PR TITLE
[SID:3110] dev DATABASE_URL(PgBouncer)도 sprintable 앱유저로 스왑

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -602,11 +602,14 @@ steps:
         if [ "${_DEPLOY_ENV}" != "prod" ] && [ -n "${_GOTENBERG_SERVICE_URL}" ]; then
           ENV_VARS="$${ENV_VARS},GOTENBERG_SERVICE_URL=${_GOTENBERG_SERVICE_URL}"
         fi
-        # story #2445/#3110/#3118 — DATABASE_URL(PgBouncer)·DATABASE_URL_DIRECT(dev=sprintable
-        # 앱유저·prod=postgres 직결)·DATABASE_URL_READ(prod만)·APPLE_PRIVATE_KEY 시크릿 바인딩.
+        # story #2445/#3110/#3118 — DATABASE_URL(PgBouncer, dev/prod 둘 다 sprintable 앱유저)·
+        # DATABASE_URL_DIRECT(dev=sprintable 앱유저·prod=postgres 직결)·DATABASE_URL_READ(prod만)·
+        # APPLE_PRIVATE_KEY 시크릿 바인딩. dev pgbouncer 경유분은 #3110 2보(userlist에 sprintable
+        # 유저 등재+DATABASE_URL_DEV_PGBOUNCER_SPRINTABLE 시크릿 신설, PO 집행)로 sprintable
+        # 유저 전환 완료 — dev 서빙이 postgres 수퍼유저 DSN을 쓰는 자리가 이제 0개.
         SECRETS_FLAG=""
         if [ "${_DEPLOY_ENV}" == "dev" ]; then
-          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV_SPRINTABLE:latest,APPLE_PRIVATE_KEY=APPLE_SIWA_PRIVATE_KEY:latest"
+          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER_SPRINTABLE:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV_SPRINTABLE:latest,APPLE_PRIVATE_KEY=APPLE_SIWA_PRIVATE_KEY:latest"
         elif [ "${_DEPLOY_ENV}" == "prod" ]; then
           SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_PROD_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_PROD:latest,DATABASE_URL_READ=DATABASE_URL_READ:latest,APPLE_PRIVATE_KEY=APPLE_SIWA_PRIVATE_KEY:latest"
         fi


### PR DESCRIPTION
[SID:3110]

## 배경
story #3110 2보(PgBouncer userlist에 sprintable 유저 등재+`DATABASE_URL_DEV_PGBOUNCER_SPRINTABLE` 시크릿 신설+cloudrun-runtime-dev SA secretAccessor 바인딩)가 PO 집행으로 완료됨. 1보(PR #3516, `DATABASE_URL_DIRECT`)에 이어 SSOT(`cloudbuild.yaml:614` `SECRETS_FLAG`) 스왑.

## 변경
`DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER:latest` → `DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER_SPRINTABLE:latest` (dev 분기만). 이걸로 dev 서빙(`sprintable-backend-dev`)이 postgres 수퍼유저 DSN을 쓰는 자리가 0개가 된다 — prod(`:623`, 이미 sprintable 기반)와 동형 패턴으로 수렴.

sprintable 유저는 story #3110 본문에 기록된 실측대로 이미 197/197 테이블 전권 GRANT 확認 완료 — 이 diff는 배선 교체뿐, 신규 권한 작업 없음. 값(비밀번호/시크릿 내용)은 이 diff에 없음.

## 검증
YAML 유효성·관련 테스트 134건(`test_deploy_backend_redis_secret_conflict`·`test_deploy_env`·`test_cloudbuild_migrate_wiring`·env drift 2종·realtime path filter류) green. AST guard lint 5종 새 위반 0건.

## 후속
착지하면 story #7fc81b1e(pgstat-probe-dev DSN 평문 노출)의 postgres 수퍼유저 비번 로테이션이 "프로브뿐" 조건으로 풀린다(story #3110 순서 의존 명시).

🤖 Generated with [Claude Code](https://claude.com/claude-code)