### PR TITLE
[SID:1282] MCP send_chat_message command_gate 값-테스트

### DIFF
--- a/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
+++ b/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
@@ -175,6 +175,43 @@ async def test_send_chat_message_with_attachment_still_surfaces_references_sideb
 
 
 @pytest.mark.anyio
+async def test_send_chat_message_surfaces_command_gate_sideband():
+    """story #1282 AC2(E-CHAT-CMD follow-up, S6 라이브 검증 2026-06-09 발견) — agent가 MCP로
+    `/cmd`를 보냈는데 수신 에이전트 런타임이 그 커맨드를 지원 안 하면, 백엔드는
+    `command_gate.blocked[]` hint를 응답 sibling에 싣는다(REST 직접 호출은 이미 받음).
+    이 hint가 MCP 경로에서도 살아남는지 — references 테스트(위)와 동일 구조(`references`
+    ↔ `command_gate`, 둘 다 story #2294 ③이 도입한 같은 sibling-preserve 메커니즘) — 이
+    테스트가 없으면 그 메커니즘이 command_gate 앞에서도 실제로 작동하는지 아무도 값으로
+    안 잰 상태였다(AC1 구현 자체는 이미 있었으나 AC2 값-테스트가 없었다)."""
+    args = SendChatInput(thread_id="conv-1", content="/deploy")
+    backend_response = {
+        "data": {"id": "m1", "content": "/deploy"},
+        "command_gate": {"blocked": ["deploy"]},
+    }
+
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value=backend_response)):
+        result = await send_chat_message(args)
+
+    import json
+    body = json.loads(result[0].text)
+    assert body["id"] == "m1"
+    assert body["command_gate"] == {"blocked": ["deploy"]}
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_omits_command_gate_when_backend_omits_it():
+    """command_gate가 없는(정상 발신) 응답에선 그 키 자체가 결과에 안 생긴다 — 항상
+    `{"blocked": []}`류로 조용히 채워 넣지 않는다(있을 때만 surface, 없는 걸 지어내지 않음)."""
+    args = SendChatInput(thread_id="conv-1", content="hi")
+    with patch.object(chat_mod.client, "post_full", new=AsyncMock(return_value={"data": {"id": "m1"}})):
+        result = await send_chat_message(args)
+
+    import json
+    body = json.loads(result[0].text)
+    assert "command_gate" not in body
+
+
+@pytest.mark.anyio
 async def test_send_chat_message_upload_failure_does_not_call_message_create():
     args = SendChatInput(
         thread_id="conv-1", content="x",


### PR DESCRIPTION
[SID:1282]

## 배경
S6 라이브 검증(2026-06-09) 발견 — MCP `sprintable_send_chat_message` 응답이 백엔드의 `command_gate.blocked[]`를 strip해서, agent가 MCP로 미지원 런타임에 `/cmd`를 보내면 자기 커맨드가 막힌 걸 모르는 갭.

## 그라운딩 결과 — AC1은 이미 구현됨
story #2294 ③ 후속(2026-07-29, `chat.py` 주석 확認)이 `references`/`command_gate`/`forked`/`forked_conversation_id`를 같은 sibling-preserve 메커니즘으로 이미 얹었다(`send_chat_message`의 `sibling_key` 루프). AC1(MCP가 command_gate를 surface)은 코드 변경 없이 이미 충족.

다만 그 사실을 값으로 잰 AC2 테스트가 없었다 — `references` 쪽은 `test_send_chat_message_with_attachment_still_surfaces_references_sideband`가 있는데 `command_gate`는 한 번도 직접 검증된 적 없었다.

## 변경
신규 테스트 2건:
1. 백엔드가 `command_gate.blocked`를 실으면 MCP 응답에도 그대로 나온다(agent `/cmd` → 미지원 런타임 시나리오 재현).
2. 백엔드가 안 실으면 그 키 자체가 결과에 없다(조용히 `{"blocked": []}`류로 지어내지 않음).

(1)은 뮤테이션(`sibling_key` 튜플에서 `command_gate` 제거) genuine RED 확認 後 복원.

## 검증
16/16 관련 테스트 green, 인접 MCP 스위트(unwrap/attachment upload/toolset) 무영향. AST guard lint 5종 새 위반 0건. 코드 변경 0 — 순수 회귀가드 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)