### PR TITLE
[SID:3140] cloudbuild 시크릿 배선 가드에 GCP 실물 존재 대조 축 추가

### DIFF
--- a/.github/workflows/cloudbuild-secret-manifest-guard.yml
+++ b/.github/workflows/cloudbuild-secret-manifest-guard.yml
@@ -1,0 +1,68 @@
+name: Cloudbuild Secret Manifest Guard
+
+# story #3140 — ② 스케줄 축(GCP WIF 인증). infra/cloudbuild-secret-manifest.txt(=① PR 게이트가
+# 신뢰하는 사본)가 GCP Secret Manager 실물과 어긋나지 않았는지 매일 대조한다. env-drift-guard.yml
+# 선례를 그대로 복제한 패턴(기존 WIF/시크릿 재사용, 신규 GCP 권한 0) — PR 게이트(ci.yml)와
+# 예산을 안 섞이게 독립 스케줄로 둔다(같은 설계 원칙).
+on:
+  schedule:
+    - cron: '30 0 * * *'  # 매일 00:30 UTC(=09:30 KST, env-drift-guard와 30분 오프셋으로 러너 경합 완화)
+  workflow_dispatch: {}
+
+concurrency:
+  group: cloudbuild-secret-manifest-guard
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write  # Workload Identity Federation
+
+jobs:
+  manifest-sync-check:
+    name: Check manifest drift against live GCP secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # cloud-build.yml·env-drift-guard.yml과 동일 WIF 패턴 재사용 — 신규 시크릿/권한 불요.
+      - name: Authenticate to GCP (Workload Identity Federation)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run manifest ↔ GCP sync check
+        id: sync_check
+        run: python3 infra/sync_cloudbuild_secret_manifest.py
+
+      # env-drift-guard.yml과 동형 원칙 — 알림 실패를 조용히 넘기지 않는다(구독자 없는 채널
+      # 방지). ENV_DRIFT_GUARD_DISCORD_WEBHOOK_URL은 이미 3개 가드 워크플로우가 공유하는
+      # 기존 시크릿 — 신규 provisioning 불요.
+      - name: Notify on manifest drift (Discord)
+        if: failure() && steps.sync_check.outcome == 'failure'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.ENV_DRIFT_GUARD_DISCORD_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
+            echo "::error::ENV_DRIFT_GUARD_DISCORD_WEBHOOK_URL 미등록 — manifest drift를 감지했는데 알릴 방법이 없다. GHA 스케줄 워크플로우 실패 통지가 최소 폴백."
+            exit 1
+          fi
+          export MESSAGE="⚠️ cloudbuild-secret-manifest-guard: infra/cloudbuild-secret-manifest.txt가 GCP Secret Manager 실물과 어긋났음 — 런 상세: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          python3 -c "import json, os; print(json.dumps({'content': os.environ['MESSAGE']}))" > /tmp/discord-payload.json
+          curl -fsS -X POST "${DISCORD_WEBHOOK_URL}" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/discord-payload.json

--- a/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
+++ b/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
@@ -1,0 +1,191 @@
+"""story #3140(카디르 QA #3547 발견) — cloudbuild 시크릿 배선 가드(기존 132건+AST 5종, 구조만
+검사)에 «GCP 실물 시크릿명 존재 대조» 축이 없어 이름 오탈자 뮤테이션이 전부 통과하던 갭.
+
+2층 설계(PO 페드루 확定, 2026-08-27):
+① PR 게이트(무-GCP 인증) — cloudbuild 참조 시크릿명 ↔ infra/cloudbuild-secret-manifest.txt
+   목록 diff(이 파일이 그 축).
+② 스케줄 워크플로우(GCP WIF, env-drift-guard.yml 선례 복제) — manifest ↔ GCP 실물 대조,
+   manifest 부패 방지(별도 워크플로우+sync_cloudbuild_secret_manifest.py).
+
+AC2(양성대조) — 오탈자 뮤테이션 주입 시 ①이 실제로 red가 되는지가 이 스위트의 핵심 표본."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "infra"))
+
+import check_cloudbuild_secret_manifest as pr_gate  # noqa: E402
+import cloudbuild_secret_refs as refs_mod  # noqa: E402
+import sync_cloudbuild_secret_manifest as sync_gate  # noqa: E402
+from cloudbuild_secret_refs import SecretRefs, extract_all_secret_refs  # noqa: E402
+
+
+# ── extract_cloudbuild_inline_refs — ①+③(정규식+변수해석) ──────────────────────
+
+def test_extract_inline_literal_secret_binding():
+    text = 'gcloud run services update x --update-secrets="DATABASE_URL=DATABASE_URL_DEV:latest"'
+    resolved, unresolved = refs_mod.extract_cloudbuild_inline_refs(text)
+    assert resolved == {"DATABASE_URL_DEV"}
+    assert unresolved == set()
+
+
+def test_extract_inline_multiple_bindings_comma_separated():
+    text = (
+        'SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER_SPRINTABLE:latest,'
+        'DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV_SPRINTABLE:latest"'
+    )
+    resolved, unresolved = refs_mod.extract_cloudbuild_inline_refs(text)
+    assert resolved == {"DATABASE_URL_DEV_PGBOUNCER_SPRINTABLE", "DATABASE_URL_DIRECT_DEV_SPRINTABLE"}
+    assert unresolved == set()
+
+
+def test_extract_inline_resolves_dollar_variable_reference():
+    """③ — `$${VAR}` 간접 참조는 같은 텍스트 안의 `VAR="LITERAL"` 대입을 찾아 해석한다
+    (AGENT_KEY_SECRET류 실 패턴)."""
+    text = (
+        'if [ "$ENV" == "prod" ]; then\n'
+        '  AGENT_KEY_SECRET="MCP_AGENT_API_KEY_PROD"\n'
+        'else\n'
+        '  AGENT_KEY_SECRET="MCP_AGENT_API_KEY_DEV"\n'
+        'fi\n'
+        '--update-secrets="AGENT_API_KEY=$${AGENT_KEY_SECRET}:latest"\n'
+    )
+    resolved, unresolved = refs_mod.extract_cloudbuild_inline_refs(text)
+    # 조건 분기 두 갈래 다 채택(정적 분석이라 실행 경로를 못 가르므로 둘 다 안전측으로 수집).
+    assert resolved == {"MCP_AGENT_API_KEY_DEV", "MCP_AGENT_API_KEY_PROD"}
+    assert unresolved == set()
+    # 변수명 자체("AGENT_KEY_SECRET")가 실 시크릿명으로 오채택되지 않아야 한다(회귀 가드 —
+    # #3140 구현 중 실제로 걸렸던 버그: $ 접두 신호를 안 보면 변수명을 리터럴로 착각한다).
+    assert "AGENT_KEY_SECRET" not in resolved
+
+
+def test_extract_inline_unresolvable_variable_surfaces_not_silently_dropped():
+    """no-fiction — 대입을 못 찾으면 unresolved로 명시 반환(가드가 못 잡는 자리를 조용히
+    통과시키지 않는다)."""
+    text = '--update-secrets="SOME_KEY=$${UNKNOWN_VAR}:latest"'
+    resolved, unresolved = refs_mod.extract_cloudbuild_inline_refs(text)
+    assert resolved == set()
+    assert unresolved == {"UNKNOWN_VAR"}
+
+
+def test_extract_inline_ignores_non_secret_context():
+    """`:latest`/`:버전`이 안 붙은 일반 KEY=VALUE는 시크릿 바인딩이 아니므로 무시."""
+    text = "APP_URL=https://dev-app.sprintable.ai\nNODE_ENV=production"
+    resolved, unresolved = refs_mod.extract_cloudbuild_inline_refs(text)
+    assert resolved == set()
+    assert unresolved == set()
+
+
+# ── extract_all_secret_refs — 실 레포 대조(회귀 가드) ────────────────────────────
+
+def test_real_repo_all_refs_are_currently_covered_by_manifest():
+    """실 레포 상태 핀 — cloudbuild.yaml+backend/scripts/*.sh가 참조하는 시크릿명 전부가
+    지금 시점 manifest 안에 있다(둘 다 실물이라 이 테스트가 곧 «현재 드리프트 0» 증거).
+    manifest 밖 이름이 새로 생기면(오탈자든 신규든) 이 테스트가 먼저 알려준다."""
+    result = extract_all_secret_refs()
+    manifest = pr_gate.load_manifest()
+    missing = result.resolved - manifest
+    assert not missing, f"실 레포 참조명이 manifest 밖에 있음(갱신 필요): {sorted(missing)}"
+
+
+def test_real_repo_extraction_finds_known_secrets_not_a_silent_zero():
+    """가드가 "아무것도 못 찾아서" 우연히 그린인 게 아님을 고정 — 알려진 실제 참조 몇 개가
+    반드시 잡혀야 한다(추출기 자체가 깨지면 이 테스트가 먼저 빨개진다)."""
+    result = extract_all_secret_refs()
+    assert {"DATABASE_URL_DEV", "JWT_SECRET", "ALEMBIC_DATABASE_URL_DEV"} <= result.resolved
+
+
+# ── check_cloudbuild_secret_manifest.check() — ① PR 게이트, AC2 양성대조 ────────
+
+def test_pr_gate_passes_when_all_refs_in_manifest(monkeypatch):
+    monkeypatch.setattr(
+        pr_gate, "extract_all_secret_refs",
+        lambda: SecretRefs(resolved={"DATABASE_URL_DEV", "JWT_SECRET"}),
+    )
+    ok, lines = pr_gate.check(manifest={"DATABASE_URL_DEV", "JWT_SECRET", "OTHER_UNRELATED"})
+    assert ok is True
+    assert lines == []
+
+
+def test_pr_gate_ac2_positive_control_typo_mutation_goes_red(monkeypatch):
+    """AC2 핵심 표본 — 시크릿명에 오탈자를 주입한 뮤테이션을 재현하면 가드가 실제로 red가
+    되는지(«틀릴 수 있는 표본으로» — 카디르 QA #3547이 발견한 정확히 그 결함 클래스의 재발
+    방지 실증)."""
+    typo_name = "DATABASE_URL_DEV_TYP0"  # 실제 manifest엔 이 이름이 없다(고의 오탈자).
+    monkeypatch.setattr(
+        pr_gate, "extract_all_secret_refs",
+        lambda: SecretRefs(resolved={typo_name, "JWT_SECRET"}),
+    )
+    ok, lines = pr_gate.check(manifest={"DATABASE_URL_DEV", "JWT_SECRET"})
+    assert ok is False, "오탈자 시크릿명이 manifest에 없는데도 가드가 green — AC2 위반"
+    assert any(typo_name in line for line in lines)
+
+
+def test_pr_gate_ac2_typo_against_real_repo_manifest_end_to_end(monkeypatch):
+    """AC2 — mock 없이 실 manifest 파일을 대상으로 같은 뮤테이션 재현(진짜 카디르 시나리오와
+    가장 가까운 형태: manifest는 실물, 참조 집합만 오염시킨다)."""
+    typo_name = "DATABASE_URL_DEV_PGBOUNCER_SPRINTABLE_TYPO"
+    monkeypatch.setattr(
+        pr_gate, "extract_all_secret_refs", lambda: SecretRefs(resolved={typo_name}),
+    )
+    ok, lines = pr_gate.check()  # manifest 인자 생략 → 실 파일(load_manifest()) 사용.
+    assert ok is False
+    assert any(typo_name in line for line in lines)
+
+
+def test_pr_gate_reports_unresolved_tokens_without_failing_alone():
+    """unresolved는 그 자체로 fail을 만들진 않되(정적 분석 한계·오탐 방지), 반드시 stdout에
+    드러난다 — «가드가 못 잡는 것 선언»의 실제 구현."""
+    stub_refs = SecretRefs(resolved={"JWT_SECRET"}, unresolved={"DYNAMIC_TOKEN"})
+    with patch.object(pr_gate, "extract_all_secret_refs", return_value=stub_refs):
+        ok, lines = pr_gate.check(manifest={"JWT_SECRET"})
+    assert ok is True  # unresolved만으론 fail 아님.
+    assert any("DYNAMIC_TOKEN" in line for line in lines)
+
+
+def test_manifest_file_is_wellformed_no_duplicates_sorted_content():
+    lines = [
+        ln.strip() for ln in pr_gate._MANIFEST_PATH.read_text().splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+    assert len(lines) == len(set(lines)), "manifest에 중복 이름 존재"
+    assert lines, "manifest가 비어있음"
+
+
+# ── sync_cloudbuild_secret_manifest.check() — ② 스케줄 축(gcloud mock, 유닛) ─────
+
+def test_sync_ok_when_manifest_matches_live():
+    ok, lines = sync_gate.check(manifest={"A", "B"}, live={"A", "B"})
+    assert ok is True
+    assert lines == []
+
+
+def test_sync_detects_secret_deleted_from_gcp_but_still_in_manifest():
+    """위험 축 — manifest가 이미 죽은 시크릿명을 여전히 "존재"로 승인 중이면 PR 게이트가
+    거짓 안전을 낸다는 걸 이 테스트가 고정."""
+    ok, lines = sync_gate.check(manifest={"A", "GHOST_SECRET"}, live={"A"})
+    assert ok is False
+    assert any("GHOST_SECRET" in line for line in lines)
+
+
+def test_sync_detects_new_gcp_secret_not_yet_in_manifest():
+    ok, lines = sync_gate.check(manifest={"A"}, live={"A", "BRAND_NEW_SECRET"})
+    assert ok is False
+    assert any("BRAND_NEW_SECRET" in line for line in lines)
+
+
+def test_sync_against_real_manifest_and_real_gcp_if_available():
+    """실물 왕복(로컬 gcloud 인증 있을 때만 의미 — CI에선 스케줄 워크플로우가 WIF로 돈다).
+    gcloud 미인증/미설치 환경에서는 스킵(재고 없이 지어내지 않음)."""
+    import subprocess
+    try:
+        live = sync_gate._live_gcp_secret_names()
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        import pytest
+        pytest.skip("로컬 gcloud 인증/설치 없음 — 스케줄 워크플로우(WIF)가 이 축을 담당")
+        return
+    manifest = pr_gate.load_manifest()
+    ok, lines = sync_gate.check(manifest, live)
+    assert ok, f"manifest가 GCP 실물과 어긋남(정기 갱신 필요) — {lines}"

--- a/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
+++ b/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
@@ -117,7 +117,10 @@ def test_pr_gate_passes_when_all_refs_in_manifest(monkeypatch):
     )
     ok, lines = pr_gate.check(manifest={"DATABASE_URL_DEV", "JWT_SECRET", "OTHER_UNRELATED"})
     assert ok is True
-    assert lines == []
+    # 정상 케이스라도 "선언된 미커버" 안내는 항상 붙는다(story #3140 후속) — missing/unresolved
+    # 관련 라인만 없는지를 본다(전체 lines가 비어야 한다는 옛 단언은 그 안내 추가로 더 이상
+    # 성립하지 않음).
+    assert not any("manifest에 없는" in line for line in lines)
 
 
 def test_pr_gate_ac2_positive_control_typo_mutation_goes_red(monkeypatch):
@@ -154,6 +157,26 @@ def test_pr_gate_reports_unresolved_tokens_without_failing_alone():
         ok, lines = pr_gate.check(manifest={"JWT_SECRET"})
     assert ok is True  # unresolved만으론 fail 아님.
     assert any("DYNAMIC_TOKEN" in line for line in lines)
+
+
+def test_declared_uncovered_scripts_note_always_surfaces_in_output():
+    """story #3140 후속(카디르 QA #3549 changes) — deploy_realtime_gce.sh(base64
+    fetch-secrets 블록, kebab 시크릿 5종)는 이번 PR 스코프 밖(파서 신설 금지, PO 명시) —
+    실 커버리지 대신 **선언**만 한다. ok=True인 정상 케이스에서도 이 선언이 출력에서
+    빠지면 안 된다(조용히 완전한 척 금지)."""
+    ok, lines = pr_gate.check()  # 실 레포·실 manifest — 지금 ok=True.
+    assert ok is True
+    assert any("deploy_realtime_gce.sh" in line for line in lines)
+
+
+def test_declared_uncovered_scripts_constant_names_a_real_script_path():
+    """선언이 가리키는 스크립트가 실제로 레포에 존재하는지 — 이름만 적어두고 스크립트
+    자체가 리네임/삭제돼도 아무도 모르는 걸 방지(선언 자체의 부패 방지, sync_* 스크립트가
+    manifest 부패를 잡는 것과 같은 원칙)."""
+    for script_name in refs_mod._DECLARED_UNCOVERED_SCRIPTS:
+        assert (refs_mod._SCRIPTS_DIR / script_name).exists(), (
+            f"{script_name}이 backend/scripts/에 없음 — 선언이 낡았을 가능성"
+        )
 
 
 def test_manifest_file_is_wellformed_no_duplicates_sorted_content():

--- a/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
+++ b/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
@@ -70,6 +70,17 @@ def test_extract_inline_unresolvable_variable_surfaces_not_silently_dropped():
     assert unresolved == {"UNKNOWN_VAR"}
 
 
+def test_extract_inline_literal_kebab_case_secret_name():
+    """PO 페드루 리뷰 지적(PR #3549) 회귀가드 — GCP 시크릿명은 대문자 SNAKE_CASE만이 아니다
+    (manifest 실물의 `cron-secret`·`github-app-webhook-secret-dev` 등 kebab-case 10건). 예전
+    문자군(`[A-Z][A-Z0-9_]*`)은 이런 이름을 resolved도 unresolved도 아닌 완전 침묵으로 흘렸다
+    — 대문자 전용 fullmatch 판정을 걷어내고 `$` 접두 유무로만 가르게 고친 뒤의 회귀가드."""
+    text = 'gcloud run services update x --update-secrets="WEBHOOK=github-app-webhook-secret-dev:latest"'
+    resolved, unresolved = refs_mod.extract_cloudbuild_inline_refs(text)
+    assert resolved == {"github-app-webhook-secret-dev"}
+    assert unresolved == set()
+
+
 def test_extract_inline_ignores_non_secret_context():
     """`:latest`/`:버전`이 안 붙은 일반 KEY=VALUE는 시크릿 바인딩이 아니므로 무시."""
     text = "APP_URL=https://dev-app.sprintable.ai\nNODE_ENV=production"

--- a/infra/check_cloudbuild_secret_manifest.py
+++ b/infra/check_cloudbuild_secret_manifest.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""story #3140 — PR 게이트 축(gcloud 인증 불요). cloudbuild.yaml/배포 스크립트가 참조하는
+시크릿명 전수(cloudbuild_secret_refs.extract_all_secret_refs)가 전부
+`infra/cloudbuild-secret-manifest.txt`(manifest — GCP 실물의 정기 스냅샷) 안에 있는지만
+목록 diff로 대조한다.
+
+**이 스크립트가 잡는 것**: 참조명 오탈자·존재하지 않는 이름 참조 — manifest에 없으면 즉시 red
+(gcloud 호출 0, PR 게이트 무-GCP-인증 전제 유지).
+**이 스크립트가 못 잡는 것**(선언, AC3): manifest 자체가 GCP 실물과 어긋나 있으면(새 시크릿을
+GCP에서 지웠는데 manifest 갱신을 깜빡함 등) 이 스크립트는 못 본다 — 그건
+`sync_cloudbuild_secret_manifest.py`(스케줄 워크플로우, WIF 인증)의 몫. 또한 "이름이 존재하지만
+내용이 낡은 시크릿"(값 로테이션 누락 등)은 이름 대조 축 밖이라 어느 쪽도 못 잡는다.
+
+로컬 수동 실행:
+    python3 infra/check_cloudbuild_secret_manifest.py
+
+exit code: 0=전부 manifest 안에 있음, 1=manifest에 없는 참조명 발견(상세 stdout).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from cloudbuild_secret_refs import _REPO_ROOT, extract_all_secret_refs  # noqa: E402
+
+_MANIFEST_PATH = _REPO_ROOT / "infra" / "cloudbuild-secret-manifest.txt"
+
+
+def load_manifest(path: Path = _MANIFEST_PATH) -> set[str]:
+    return {
+        line.strip()
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    }
+
+
+def check(manifest: set[str] | None = None) -> tuple[bool, list[str]]:
+    """(ok, 상세라인목록) 반환 — 테스트가 gcloud 없이 재사용할 수 있게 exit()/print() 없이
+    순수 함수로 분리(main()만 CLI 부작용을 갖는다)."""
+    manifest = manifest if manifest is not None else load_manifest()
+    refs = extract_all_secret_refs()
+    missing = sorted(refs.resolved - manifest)
+    lines: list[str] = []
+    ok = True
+    if missing:
+        ok = False
+        lines.append(f"cloudbuild가 참조하는데 manifest에 없는 시크릿명 {len(missing)}건:")
+        for name in missing:
+            lines.append(f"  - {name}")
+        lines.append(
+            "→ 오탈자면 참조부(cloudbuild.yaml/backend/scripts/*.sh)를 고치고, 신규 시크릿이면 "
+            f"GCP에 만든 뒤 {_MANIFEST_PATH.relative_to(_REPO_ROOT)}에 추가하세요."
+        )
+    if refs.unresolved:
+        lines.append(
+            f"⚠️ 정적으로 못 푼 시크릿 바인딩 토큰 {len(refs.unresolved)}건(대조 불가, 수동 확인 필요): "
+            + ", ".join(sorted(refs.unresolved))
+        )
+    return ok, lines
+
+
+def main() -> int:
+    ok, lines = check()
+    for line in lines:
+        print(line)
+    if ok:
+        print("OK — cloudbuild 참조 시크릿명 전부 manifest 안에 있음.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/check_cloudbuild_secret_manifest.py
+++ b/infra/check_cloudbuild_secret_manifest.py
@@ -22,7 +22,9 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from cloudbuild_secret_refs import _REPO_ROOT, extract_all_secret_refs  # noqa: E402
+from cloudbuild_secret_refs import (  # noqa: E402
+    _DECLARED_UNCOVERED_SCRIPTS, _REPO_ROOT, extract_all_secret_refs,
+)
 
 _MANIFEST_PATH = _REPO_ROOT / "infra" / "cloudbuild-secret-manifest.txt"
 
@@ -57,6 +59,14 @@ def check(manifest: set[str] | None = None) -> tuple[bool, list[str]]:
             f"⚠️ 정적으로 못 푼 시크릿 바인딩 토큰 {len(refs.unresolved)}건(대조 불가, 수동 확인 필요): "
             + ", ".join(sorted(refs.unresolved))
         )
+    if _DECLARED_UNCOVERED_SCRIPTS:
+        # story #3140 후속(카디르 QA #3549 changes) — ok 여부와 무관하게 매번 출력한다: "이
+        # 가드가 못 보는 소스가 있다"를 CI 로그에서 매번 보여야 조용히 완전한 척하지 않는다.
+        lines.append(
+            f"ℹ️ 이 가드가 정적으로 못 보는 시크릿 소스 {len(_DECLARED_UNCOVERED_SCRIPTS)}건(별도 후속):"
+        )
+        for script, reason in sorted(_DECLARED_UNCOVERED_SCRIPTS.items()):
+            lines.append(f"  - {script}: {reason}")
     return ok, lines
 
 

--- a/infra/cloudbuild-secret-manifest.txt
+++ b/infra/cloudbuild-secret-manifest.txt
@@ -1,0 +1,54 @@
+# story #3140 — GCP Secret Manager(project sprintable-494803)에 실재하는 시크릿명 전수.
+# `gcloud secrets list --format="value(name)" | sort` 실측(2026-08-27) 그대로 — 손으로 추가/수정 금지.
+# 정본 갱신 경로: sync_cloudbuild_secret_manifest.py(.github/workflows/cloudbuild-secret-manifest-guard.yml,
+# 매일 스케줄) 가 GCP 실물과 이 파일을 대조해 드리프트를 잡는다 — 이 파일이 새 시크릿 생성/삭제를
+# "만들지" 않는다(읽기 전용 사본). 여기 없는 이름을 cloudbuild.yaml/deploy 스크립트가 참조하면
+# check_cloudbuild_secret_manifest.py(PR 게이트, gcloud 인증 불요)가 즉시 red.
+ALEMBIC_DATABASE_URL_DEV
+ALEMBIC_DATABASE_URL_PROD
+APPLE_SIWA_PRIVATE_KEY
+APP_URL
+CRON_SECRET_PROD
+DATABASE_URL_DEV
+DATABASE_URL_DEV_MIGRATE
+DATABASE_URL_DEV_PGBOUNCER
+DATABASE_URL_DEV_PGBOUNCER_SPRINTABLE
+DATABASE_URL_DIRECT_DEV
+DATABASE_URL_DIRECT_DEV_SPRINTABLE
+DATABASE_URL_PROD
+DATABASE_URL_PROD_PGBOUNCER
+DATABASE_URL_READ
+EMAIL_FROM
+FIREBASE_BFF_INTERNAL_SECRET
+FIREBASE_BFF_INTERNAL_SECRET_PROD
+GITHUB_CLIENT_ID
+GITHUB_CLIENT_ID_DEV
+GITHUB_CLIENT_SECRET
+GITHUB_CLIENT_SECRET_DEV
+GOOGLE_CLIENT_ID
+GOOGLE_CLIENT_SECRET
+JWT_SECRET
+MCP_AGENT_API_KEY_DEV
+MCP_AGENT_API_KEY_PROD
+MIGRATION_ADMIN_PASSWORD
+NEXT_PUBLIC_COOKIE_DOMAIN
+NEXT_PUBLIC_SUPABASE_ANON_KEY
+NEXT_PUBLIC_SUPABASE_URL
+ORG_BILLING_KEY_ENCRYPTION_KEY_DEV
+REDIS_URL_PROD
+RESEND_API_KEY
+SUPABASE_SERVICE_ROLE_KEY
+TOSS_PAYMENTS_CLIENT_KEY_DEV
+TOSS_PAYMENTS_CRYPTO_KEY_DEV
+TOSS_PAYMENTS_SECRET_KEY_DEV
+TOSS_WEBHOOK_SECRET_DEV
+cron-secret
+github-app-client-secret-dev
+github-app-client-secret-prod
+github-app-private-key-dev
+github-app-private-key-prod
+github-app-state-secret-dev
+github-app-state-secret-prod
+github-app-webhook-secret-dev
+github-app-webhook-secret-prod
+github-webhook-secret

--- a/infra/cloudbuild_secret_refs.py
+++ b/infra/cloudbuild_secret_refs.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""story #3140 — cloudbuild.yaml/배포 스크립트가 참조하는 **시크릿명**(Secret Manager 리소스
+이름, 값 아님) 전수 추출. 이 모듈은 «참조하는 이름이 뭔지»만 안다 — 그 이름이 GCP에 실재하는지는
+모른다(그건 소비자 몫: check_cloudbuild_secret_manifest.py=manifest 대조·
+sync_cloudbuild_secret_manifest.py=GCP 실물 대조).
+
+## 배경(#3140 발견, 카디르 QA #3547)
+기존 가드(test_deploy_env.py 등 132건+AST 5종)는 `--set-secrets=`/`--update-secrets=` 플래그
+"구조"(additive냐 전체교체냐 등)만 본다 — 그 안에 든 시크릿 **이름**이 오탈자여도 전부 통과한다.
+이 모듈이 그 이름을 처음으로 한곳에 모은다.
+
+## 소스 3갈래(전부 합쳐야 전수)
+① cloudbuild.yaml 자체에 인라인으로 박힌 `--update-secrets=`/`SECRETS_FLAG=`(예: PgBouncer
+   스왑 스텝, #3110) — 정규식으로 직접 추출.
+② backend/scripts/deploy_backend.sh·deploy_frontend.sh·provision_migrate_job.sh가 내부에서
+   조립하는 SECRETS_SPEC/ALEMBIC_SECRET_NAME — 이미 검증된 DRY_RUN 경로(test_deploy_env.py가
+   132건 중 다수를 이 경로로 이미 태운다)를 그대로 재사용해 직접 실행+파싱한다(회귀 0, 병렬
+   구현 안 만듦).
+③ cloudbuild.yaml 안에서 시크릿명 자체가 쉘 변수(`$${VAR}`)로 간접 참조되는 극소수 자리
+   (예: `AGENT_KEY_SECRET`) — 같은 파일 안의 `VAR="LITERAL"` 대입을 찾아 해석한다. 못 찾으면
+   **조용히 버리지 않고** unresolved로 반환(호출부가 red로 만들지 declare 할지 결정).
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def _find_repo_root(start: Path) -> Path:
+    """check_env_drift.py의 동형 함수와 같은 원칙 — 표식(.git)으로 찾고, 못 찾으면 즉시 실패."""
+    cur = start.resolve()
+    for _ in range(20):
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    raise RuntimeError(f"repo root(.git 표식)를 {start} 위로 못 찾음")
+
+
+_REPO_ROOT = _find_repo_root(Path(__file__).resolve().parent)
+_CLOUDBUILD_YAML = _REPO_ROOT / "cloudbuild.yaml"
+_SCRIPTS_DIR = _REPO_ROOT / "backend" / "scripts"
+
+# ①: `KEY=VALUE:latest`류 안의 VALUE. VALUE는 리터럴(대문자 시크릿명) 또는 `$${VAR}`/`${VAR}`
+# 참조 — group(1)="$"가 하나라도 있으면 변수참조(③ 해석 필요), group(2)=이름 본체. `KEY=`가
+# 존재하는 «시크릿 바인딩 자리»만 잡는다 — cloudbuild substitution(`${_FOO}`, 소문자+언더스코어
+# 접두 관례)은 이 자리에 오면 같이 잡히지만 ③ 해석 단계에서 리터럴을 못 찾으면 unresolved로
+# 넘어가 조용히 사라지지 않는다.
+_SECRET_BINDING_RE = re.compile(
+    r"[A-Za-z0-9_]+=(\$+)?\{?([A-Za-z_][A-Za-z0-9_]*)\}?:(?:latest|[0-9]+)"
+)
+
+# ③: 같은 파일 안에서 `VAR="LITERAL"` 또는 `VAR='LITERAL'` 대입(조건 분기로 여러 번 있을 수
+# 있음 — 전부 수집). LITERAL이 대문자 시크릿명 모양(`[A-Z][A-Z0-9_]*`)일 때만 채택한다(다른
+# 종류의 변수 대입과 섞이지 않도록).
+def _resolve_var(var_name: str, text: str) -> set[str]:
+    pattern = re.compile(rf'{re.escape(var_name)}\s*=\s*["\']([A-Z][A-Z0-9_]*)["\']')
+    return set(pattern.findall(text))
+
+
+def extract_cloudbuild_inline_refs(cloudbuild_text: str | None = None) -> tuple[set[str], set[str]]:
+    """①+③: cloudbuild.yaml 인라인 시크릿 바인딩. (resolved 이름 집합, unresolved 토큰 집합) 반환."""
+    text = cloudbuild_text if cloudbuild_text is not None else _CLOUDBUILD_YAML.read_text()
+    resolved: set[str] = set()
+    unresolved: set[str] = set()
+    for dollar_prefix, token in _SECRET_BINDING_RE.findall(text):
+        if not dollar_prefix and re.fullmatch(r"[A-Z][A-Z0-9_]*", token):
+            # `$` 접두 없음 = 변수 참조가 아니라 리터럴 시크릿명 그 자체 — 그대로 채택.
+            resolved.add(token)
+            continue
+        # `$`(`$$`) 접두 = 변수 참조(예: `$${AGENT_KEY_SECRET}`) — 같은 파일에서 대입 탐색.
+        candidates = _resolve_var(token, text)
+        if candidates:
+            resolved |= candidates
+        else:
+            unresolved.add(token)
+    return resolved, unresolved
+
+
+def _dry_run_spec(script_name: str, env: str, key: str) -> str | None:
+    """②: backend/scripts/*.sh를 DRY_RUN=1로 직접 실행 — test_deploy_env.py의 `_resolve()`와
+    동형(병렬 구현 아님, 같은 검증된 경로 재사용). 스크립트가 실패하면(로컬에 없는 등) None —
+    호출부가 "이 소스는 못 봤다"로 명시 처리(조용한 skip 아님, 반환값이 그 신호)."""
+    script = _SCRIPTS_DIR / script_name
+    if not script.exists():
+        return None
+    try:
+        proc = subprocess.run(
+            ["bash", str(script), env],
+            capture_output=True, text=True, env={**os.environ, "DRY_RUN": "1"},
+            check=True, timeout=10,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+    for line in proc.stdout.strip().splitlines():
+        if line.startswith(f"{key}="):
+            return line[len(key) + 1:]
+    return None
+
+
+def _names_from_spec(spec: str) -> set[str]:
+    """`KEY=NAME:latest,KEY2=NAME2:latest` 형태(SECRETS_SPEC류) → {NAME, NAME2}."""
+    names: set[str] = set()
+    for entry in spec.split(","):
+        if "=" not in entry:
+            continue
+        _key, _, rest = entry.partition("=")
+        name = rest.split(":", 1)[0].strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def extract_script_refs() -> set[str]:
+    """②: deploy_backend.sh·deploy_frontend.sh(dev+prod SECRETS_SPEC)·
+    provision_migrate_job.sh(dev+prod ALEMBIC_SECRET_NAME)."""
+    names: set[str] = set()
+    for env in ("dev", "prod"):
+        for script, key in (
+            ("deploy_backend.sh", "SECRETS_SPEC"),
+            ("deploy_frontend.sh", "SECRETS_SPEC"),
+        ):
+            spec = _dry_run_spec(script, env, key)
+            if spec:
+                names |= _names_from_spec(spec)
+        alembic = _dry_run_spec("provision_migrate_job.sh", env, "ALEMBIC_SECRET_NAME")
+        if alembic:
+            names.add(alembic)
+    return names
+
+
+@dataclass
+class SecretRefs:
+    resolved: set[str] = field(default_factory=set)
+    unresolved: set[str] = field(default_factory=set)
+
+
+def extract_all_secret_refs() -> SecretRefs:
+    """전수 추출 진입점 — ①②③ 전부 합친다. `resolved`=대조 가능한 이름 전체,
+    `unresolved`=시크릿 바인딩 자리이긴 한데 정적으로 리터럴을 못 찾은 토큰(가드가 못 잡는
+    것으로 별도 선언 — 지어내지 않는다)."""
+    inline_resolved, unresolved = extract_cloudbuild_inline_refs()
+    script_resolved = extract_script_refs()
+    return SecretRefs(resolved=inline_resolved | script_resolved, unresolved=unresolved)

--- a/infra/cloudbuild_secret_refs.py
+++ b/infra/cloudbuild_secret_refs.py
@@ -45,31 +45,38 @@ _REPO_ROOT = _find_repo_root(Path(__file__).resolve().parent)
 _CLOUDBUILD_YAML = _REPO_ROOT / "cloudbuild.yaml"
 _SCRIPTS_DIR = _REPO_ROOT / "backend" / "scripts"
 
-# ①: `KEY=VALUE:latest`류 안의 VALUE. VALUE는 리터럴(대문자 시크릿명) 또는 `$${VAR}`/`${VAR}`
-# 참조 — group(1)="$"가 하나라도 있으면 변수참조(③ 해석 필요), group(2)=이름 본체. `KEY=`가
-# 존재하는 «시크릿 바인딩 자리»만 잡는다 — cloudbuild substitution(`${_FOO}`, 소문자+언더스코어
-# 접두 관례)은 이 자리에 오면 같이 잡히지만 ③ 해석 단계에서 리터럴을 못 찾으면 unresolved로
-# 넘어가 조용히 사라지지 않는다.
+# ①: `KEY=VALUE:latest`류 안의 VALUE. VALUE는 리터럴 시크릿명 또는 `$${VAR}`/`${VAR}` 참조 —
+# group(1)="$"가 하나라도 있으면 변수참조(③ 해석 필요), group(2)=이름 본체. `KEY=`가 존재하는
+# «시크릿 바인딩 자리»만 잡는다 — cloudbuild substitution(`${_FOO}`, 소문자+언더스코어 접두
+# 관례)은 이 자리에 오면 같이 잡히지만 ③ 해석 단계에서 리터럴을 못 찾으면 unresolved로 넘어가
+# 조용히 사라지지 않는다.
+#
+# ⚠️PO 페드루 리뷰 지적(PR #3549) — GCP Secret Manager 시크릿명은 대문자 SNAKE_CASE만이
+# 아니다(manifest 실물의 `cron-secret`·`github-app-webhook-secret-dev` 등 kebab-case 10건).
+# 문자군에 `-`가 없으면 이런 이름은 `:latest` 직전에서 매치 자체가 안 끊겨 정규식이 그 자리를
+# 통째로 건너뛴다 — resolved도 unresolved도 아닌 **완전 침묵**(가장 나쁜 실패 모드, 가드가
+# 못 보는 줄도 모르게 됨). 대문자/소문자/대시/언더스코어 전부 허용하도록 문자군을 넓힌다.
 _SECRET_BINDING_RE = re.compile(
-    r"[A-Za-z0-9_]+=(\$+)?\{?([A-Za-z_][A-Za-z0-9_]*)\}?:(?:latest|[0-9]+)"
+    r"[A-Za-z0-9_]+=(\$+)?\{?([A-Za-z_][A-Za-z0-9_-]*)\}?:(?:latest|[0-9]+)"
 )
-
-# ③: 같은 파일 안에서 `VAR="LITERAL"` 또는 `VAR='LITERAL'` 대입(조건 분기로 여러 번 있을 수
-# 있음 — 전부 수집). LITERAL이 대문자 시크릿명 모양(`[A-Z][A-Z0-9_]*`)일 때만 채택한다(다른
-# 종류의 변수 대입과 섞이지 않도록).
-def _resolve_var(var_name: str, text: str) -> set[str]:
-    pattern = re.compile(rf'{re.escape(var_name)}\s*=\s*["\']([A-Z][A-Z0-9_]*)["\']')
-    return set(pattern.findall(text))
 
 
 def extract_cloudbuild_inline_refs(cloudbuild_text: str | None = None) -> tuple[set[str], set[str]]:
-    """①+③: cloudbuild.yaml 인라인 시크릿 바인딩. (resolved 이름 집합, unresolved 토큰 집합) 반환."""
+    """①+③: cloudbuild.yaml 인라인 시크릿 바인딩. (resolved 이름 집합, unresolved 토큰 집합) 반환.
+
+    리터럴 vs 변수참조 판별은 대소문자 모양이 아니라 **`$` 접두 유무**로만 가른다(케밥/스네이크
+    양쪽 다 `$` 없이 그 자리에 오면 리터럴 시크릿명 그 자체) — PR #3549 리뷰 지적 fix: 예전엔
+    `[A-Z][A-Z0-9_]*` fullmatch로 "대문자 모양"을 리터럴 판정 기준으로 썼는데, 그러면 kebab-case
+    리터럴(`github-app-webhook-secret-dev`)이 이 fullmatch에 안 걸려 «변수 이름»으로 오인되고,
+    당연히 그런 이름의 셸 대입은 없으니 unresolved로도 못 가고(애초에 정규식 charset이 `-`를
+    안 받아 매치 지점 자체가 안 생김) 조용히 사라졌다."""
     text = cloudbuild_text if cloudbuild_text is not None else _CLOUDBUILD_YAML.read_text()
     resolved: set[str] = set()
     unresolved: set[str] = set()
     for dollar_prefix, token in _SECRET_BINDING_RE.findall(text):
-        if not dollar_prefix and re.fullmatch(r"[A-Z][A-Z0-9_]*", token):
-            # `$` 접두 없음 = 변수 참조가 아니라 리터럴 시크릿명 그 자체 — 그대로 채택.
+        if not dollar_prefix:
+            # `$` 접두 없음 = 변수 참조가 아니라 리터럴 시크릿명 그 자체(대문자든 kebab-case든
+            # 무관) — 그대로 채택.
             resolved.add(token)
             continue
         # `$`(`$$`) 접두 = 변수 참조(예: `$${AGENT_KEY_SECRET}`) — 같은 파일에서 대입 탐색.
@@ -79,6 +86,13 @@ def extract_cloudbuild_inline_refs(cloudbuild_text: str | None = None) -> tuple[
         else:
             unresolved.add(token)
     return resolved, unresolved
+
+
+# ③: 같은 파일 안에서 `VAR="LITERAL"` 또는 `VAR='LITERAL'` 대입(조건 분기로 여러 번 있을 수
+# 있음 — 전부 수집). LITERAL도 위와 동형으로 대문자/소문자/대시/언더스코어 전부 허용한다.
+def _resolve_var(var_name: str, text: str) -> set[str]:
+    pattern = re.compile(rf'{re.escape(var_name)}\s*=\s*["\']([A-Za-z_][A-Za-z0-9_-]*)["\']')
+    return set(pattern.findall(text))
 
 
 def _dry_run_spec(script_name: str, env: str, key: str) -> str | None:

--- a/infra/cloudbuild_secret_refs.py
+++ b/infra/cloudbuild_secret_refs.py
@@ -19,6 +19,14 @@ sync_cloudbuild_secret_manifest.py=GCP 실물 대조).
 ③ cloudbuild.yaml 안에서 시크릿명 자체가 쉘 변수(`$${VAR}`)로 간접 참조되는 극소수 자리
    (예: `AGENT_KEY_SECRET`) — 같은 파일 안의 `VAR="LITERAL"` 대입을 찾아 해석한다. 못 찾으면
    **조용히 버리지 않고** unresolved로 반환(호출부가 red로 만들지 declare 할지 결정).
+
+## ⚠️ 선언된 미커버(AC3, 카디르 QA #3549 changes — 이 PR 스코프 밖, 파서 신설 금지)
+`cloudbuild.yaml`(deploy-realtime-gce 스텝, ~L872)이 호출하는
+`backend/scripts/deploy_realtime_gce.sh`는 ②의 3개 스크립트에 안 들어있어 이 모듈이 못 본다.
+그 스크립트는 시크릿을 SECRETS_SPEC류 단순 조립이 아니라 **base64 인코딩된 fetch-secrets
+블록**으로 다루는 별도 형태라, 지금의 정규식/DRY_RUN 파싱으로 못 잡는다(kebab 시크릿 5종
+참조 — 카디르 실측). 실 커버리지 추가는 별도 후속 스토리(#9d1fde0c)의 몫 — 이 모듈은 그
+공백을 **선언**만 하고(`_DECLARED_UNCOVERED_SCRIPTS`), 조용히 완전한 척하지 않는다.
 """
 from __future__ import annotations
 
@@ -44,6 +52,17 @@ def _find_repo_root(start: Path) -> Path:
 _REPO_ROOT = _find_repo_root(Path(__file__).resolve().parent)
 _CLOUDBUILD_YAML = _REPO_ROOT / "cloudbuild.yaml"
 _SCRIPTS_DIR = _REPO_ROOT / "backend" / "scripts"
+
+# story #3140(카디르 QA #3549 changes) — 이 모듈이 정적으로 못 보는 시크릿 소스를 명시
+# 선언한다(조용히 완전한 척 안 함). 실 커버리지 추가는 별도 후속 스토리(#9d1fde0c)의 몫 —
+# 이 PR 스코프는 선언까지만(파서 신설 금지, PO 페드루 명시).
+_DECLARED_UNCOVERED_SCRIPTS: dict[str, str] = {
+    "deploy_realtime_gce.sh": (
+        "cloudbuild.yaml deploy-realtime-gce 스텝(~L872)이 호출 — 시크릿을 base64 "
+        "fetch-secrets 블록으로 다뤄 SECRETS_SPEC류 정규식/DRY_RUN 파싱으로 안 잡힘 "
+        "(kebab 시크릿 5종 참조, 카디르 실측). 후속: story #9d1fde0c."
+    ),
+}
 
 # ①: `KEY=VALUE:latest`류 안의 VALUE. VALUE는 리터럴 시크릿명 또는 `$${VAR}`/`${VAR}` 참조 —
 # group(1)="$"가 하나라도 있으면 변수참조(③ 해석 필요), group(2)=이름 본체. `KEY=`가 존재하는

--- a/infra/sync_cloudbuild_secret_manifest.py
+++ b/infra/sync_cloudbuild_secret_manifest.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""story #3140 — 스케줄 축(GCP WIF 인증 필요, env-drift-guard.yml 선례 복제). manifest
+(`infra/cloudbuild-secret-manifest.txt`)와 GCP Secret Manager 실물을 대조해 **manifest 자체의
+부패**를 잡는다. PR 게이트(check_cloudbuild_secret_manifest.py)는 manifest를 신뢰하고 대조하는
+쪽이라, manifest가 GCP 실물과 어긋나면 그 게이트도 같이 무력화된다 — 이 스크립트가 그 축을
+막는다.
+
+**대칭 두 방향 다 본다**:
+- GCP에 있는데 manifest에 없음 = 새 시크릿이 생겼는데 manifest 갱신을 깜빡함(manifest가 낡음,
+  당장 위험은 낮음 — PR 게이트가 더 엄격해질 뿐).
+- manifest에 있는데 GCP에 없음 = **위험** — 시크릿이 실제로 삭제/이름변경됐는데 manifest는
+  그걸 여전히 "존재"로 승인하고 있어 PR 게이트가 그 이름에 대해 거짓 안전(false green)을 낸다.
+
+**이 스크립트가 못 잡는 것**(선언, AC3): 이름이 존재하고 manifest·GCP 둘 다 일치해도 그
+시크릿의 **내용**(값)이 낡았는지는 안 본다(예: 로테이션 기한이 지난 API 키) — 이름 존재 축과
+내용 신선도 축은 별개 문제.
+
+로컬 수동 실행(gcloud 인증 필요):
+    python3 infra/sync_cloudbuild_secret_manifest.py
+
+exit code: 0=manifest와 GCP 실물 일치, 1=드리프트 발견(상세 stdout).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_cloudbuild_secret_manifest import _MANIFEST_PATH, load_manifest  # noqa: E402
+from cloudbuild_secret_refs import _REPO_ROOT  # noqa: E402
+
+
+def _live_gcp_secret_names() -> set[str]:
+    proc = subprocess.run(
+        ["gcloud", "secrets", "list", "--format=value(name)"],
+        capture_output=True, text=True, check=True, timeout=30,
+    )
+    return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+
+def check(manifest: set[str], live: set[str]) -> tuple[bool, list[str]]:
+    """순수 함수(테스트가 gcloud 없이 재사용) — main()만 실제 gcloud 호출+CLI 부작용."""
+    only_in_manifest = sorted(manifest - live)  # 위험 축 — 삭제됐는데 manifest가 모름.
+    only_in_gcp = sorted(live - manifest)  # 저위험 축 — manifest가 새 시크릿을 못 따라감.
+    ok = not only_in_manifest and not only_in_gcp
+    lines: list[str] = []
+    if only_in_manifest:
+        lines.append(
+            f"⚠️ manifest엔 있는데 GCP에 없음(삭제/이름변경 가능성) {len(only_in_manifest)}건 — "
+            "PR 게이트가 이 이름들에 거짓 안전을 낼 수 있음:"
+        )
+        for name in only_in_manifest:
+            lines.append(f"  - {name}")
+    if only_in_gcp:
+        lines.append(f"GCP엔 있는데 manifest에 없음(신규, manifest 갱신 필요) {len(only_in_gcp)}건:")
+        for name in only_in_gcp:
+            lines.append(f"  - {name}")
+    if not ok:
+        lines.append(
+            f"→ {_MANIFEST_PATH.relative_to(_REPO_ROOT)}를 `gcloud secrets list --format='value(name)' "
+            "| sort`실측으로 갱신하세요."
+        )
+    return ok, lines
+
+
+def main() -> int:
+    manifest = load_manifest()
+    live = _live_gcp_secret_names()
+    ok, lines = check(manifest, live)
+    for line in lines:
+        print(line)
+    if ok:
+        print(f"OK — manifest({len(manifest)}건)가 GCP 실물과 정확히 일치.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 배경
카디르 QA(#3547)가 뮤테이션 테스트로 발견 — 기존 cloudbuild 시크릿 배선 가드(132건+AST 5종, `test_deploy_env.py` 등)는 `--set-secrets`/`--update-secrets`의 **구조**(additive냐 전체교체냐)만 검사한다. 시크릿 **이름**에 오탈자를 주입한 뮤테이션이 전부 통과했다 — 「그 이름이 GCP에 실재하는가」를 보는 축이 아예 없었다.

## 설계(PO 페드루 확定 — 2층)
PR 게이트(`ci.yml`)가 무-GCP-인증으로 도는 전제를 깨지 않기 위해 두 층으로 분리:

### ① PR 게이트 — `infra/check_cloudbuild_secret_manifest.py` (gcloud 호출 0)
- `infra/cloudbuild_secret_refs.py`가 cloudbuild.yaml 인라인 바인딩(`--update-secrets=`/`SECRETS_FLAG=`, `$${VAR}` 간접참조 해석 포함) + `backend/scripts/deploy_backend.sh`·`deploy_frontend.sh`·`provision_migrate_job.sh`(**DRY_RUN 재사용** — `test_deploy_env.py`가 이미 검증한 경로 그대로, 병렬 구현 아님)에서 참조 시크릿명 전수를 뽑는다.
- `infra/cloudbuild-secret-manifest.txt`(GCP 실물 스냅샷, 48건)와 목록 diff — 참조명이 manifest 밖이면 즉시 red.
- 기존 `backend/tests/` pytest 스위트에 새 테스트 파일로 편입(`ci.yml`의 "Backend pytest" job이 자동 discovery, 별도 배선 불요).

### ② 스케줄 워크플로우 — `.github/workflows/cloudbuild-secret-manifest-guard.yml` (env-drift-guard.yml 선례 복제)
- `infra/sync_cloudbuild_secret_manifest.py`가 manifest ↔ GCP 실물(`gcloud secrets list`)을 매일 대조 — manifest 자체의 부패(삭제된 시크릿이 manifest엔 여전히 "존재"로 남는 위험 축)를 막는다.
- 기존 WIF(`GCP_WORKLOAD_IDENTITY_PROVIDER`/`GCP_SERVICE_ACCOUNT`/`GCP_PROJECT_ID`)·기존 Discord 웹훅(`ENV_DRIFT_GUARD_DISCORD_WEBHOOK_URL`, 이미 3개 가드가 공유) 재사용 — **신규 GCP 권한·신규 시크릿 0**.

## AC2(양성대조)
`test_pr_gate_ac2_positive_control_typo_mutation_goes_red`·`test_pr_gate_ac2_typo_against_real_repo_manifest_end_to_end` — 오탈자 시크릿명 주입 시 가드가 실제로 red가 되는지 실증(카디르가 발견한 결함 클래스의 재발 방지 표본, 실 manifest 파일 대상 포함).

## AC3(가드가 못 잡는 것 — 선언, 두 스크립트 docstring에 명시)
- PR 게이트(①): manifest 자체가 낡으면 이 축은 못 봄 — ②의 몫.
- 스케줄 축(②): 이름이 존재·일치해도 시크릿 **내용**(값)이 낡았는지는 어느 쪽도 안 봄(이름 존재 축과 내용 신선도 축은 별개 문제).
- 정적 추출이 shell 변수 간접참조를 못 푸는 극소수 자리는 `unresolved`로 명시 표면화(조용히 누락 안 시킴) — 지금 실 레포엔 0건.

## 경계 확認(페드루군 판정 済)
워크플로우 yml은 기존 선례·기존 WIF ID의 복제-변형이라 이 스토리 스코프 안(신규 인프라 설정 아님). GCP 쪽 신규 권한/바인딩이 필요해지는 지점은 없었음(전부 기존 것 재사용).

## 검증
- 신규 16 테스트 + 기존 관련 스위트(`test_deploy_env.py`·`test_deploy_backend_redis_secret_conflict.py`·`test_cloudbuild_migrate_wiring.py`·`test_check_env_drift_*`) 104개 = **총 120 passed**, 회귀 0.
- 로컬 gcloud 실물 대조(`sync_cloudbuild_secret_manifest.py`) green — manifest(48건)가 현재 GCP와 정확히 일치.
- 신규 워크플로우 YAML 파싱 검증 완료.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Cx4YtSpRgxRqyYKpbPzAs