### PR TITLE
approval-request 카드 배달 관측성 — 전멸 WARNING + 지정 결재자 에코

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -459,11 +459,23 @@ async def create_decision_request(
     # story #d9c09f4b(2026-08-27) — 카드 배달(_notify_decision_request_card, best-effort)
     # 성패와 완전히 독립된 별도 조회. 카드가 조용히 성공(엉뚱한 대상)하든 실패하든 이
     # 필드는 "approver_member_id가 실제로 가리키는 사람"을 있는 그대로 보여준다 — 그게 이
-    # 필드의 존재 이유(호출자 자가검증)라 실패를 삼키면 안 된다(조회 실패 자체는 None 폴백,
-    # 지어내지 않는다 — 없으면 없는 대로 보여준다).
-    from app.services.member_resolver import lookup_members_by_ids
-    _designated = (await lookup_members_by_ids({body.approver_member_id}, session)).get(body.approver_member_id)
-    resp.designated_approver_name = _designated.name if _designated is not None else None
+    # 필드의 존재 이유(호출자 자가검증)라 조회 결과(미확인 멤버)는 None 폴백, 지어내지
+    # 않는다.
+    # ⛔카디르 QA(#3550): 위 "None 폴백"은 멤버-미존재만 커버할 의도였는데, try/except가
+    # 없어 조회 자체가 예외로 죽으면(레이스·일시적 DB 오류 등) 이미 성공한 게이트 생성이
+    # HTTP 500으로 뒤집혔다(강제 raise 재현) — 관측성 필드 하나가 본 기능(게이트 생성 자체는
+    # 이미 커밋 완료)을 죽이는 본말전도. 기존 best-effort 관용구(이 파일 전역 다수 — 예:
+    # _notify_decision_request_card)와 동형으로 감싼다.
+    try:
+        from app.services.member_resolver import lookup_members_by_ids
+        _designated = (await lookup_members_by_ids({body.approver_member_id}, session)).get(body.approver_member_id)
+        resp.designated_approver_name = _designated.name if _designated is not None else None
+    except Exception:  # noqa: BLE001 — best-effort, 조회 실패가 이미 성공한 게이트 생성 응답을 깨면 안 됨.
+        logger.warning(
+            "designated_approver_name 조회 실패(비차단) gate=%s approver=%s",
+            gate.id, body.approver_member_id, exc_info=True,
+        )
+        resp.designated_approver_name = None
     # story #1972 SSOT 재사용(제네릭 create_gate_endpoint가 이 필드를 아예 안 채우는 기존
     # 갭을 여기서까지 상속하면 FE deriveRiskLevel이 null→'unknown'으로 읽어 low 등재의
     # 목적(원탭 승인)이 생성 응답 자체에서는 무효화된다 — 자체 신규 테스트로 발견·직접 수정).

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -186,6 +186,13 @@ class GateResponse(BaseModel):
     # from_attributes로 자동 채워짐(resolver_id와 동일 선례) — 오늘(#2985) 이 필드 자체를
     # 빠뜨렸던 걸 여기서 보강.
     designated_approver_id: uuid.UUID | None = None
+    # story #d9c09f4b(2026-08-27, customer-zero) — 카드가 어디로도 실패하지 않고 「엉뚱한
+    # 실사람」에게 정확히 배달된 실사고(호출자가 approver_member_id를 오지정·배달층 자체는
+    # 무결)의 해독제. 배달 성공/실패와 무관하게 "이 게이트가 실제로 누구를 가리키는지"를
+    # 응답에서 즉시 에코 — 호출자가 원탭 자가검증 가능. create_decision_request만 채움
+    # (additive·nullable, risk_grade/project_id와 동일 선례 — 타 엔드포인트는 이 속성이
+    # ORM에 없어 from_attributes 기본값 None으로 조용히 통과).
+    designated_approver_name: str | None = None
     held_until: datetime | None = None  # S31: status='held' 시 시한부 만료(무기한이면 None)·additive
     neutral_facts: dict[str, Any] | None = None
     # H1-S3: merge verdict gate evidence metadata (0118)·additive·하위호환 default.
@@ -449,6 +456,14 @@ async def create_decision_request(
     await session.refresh(gate)
     resp = GateResponse.model_validate(gate)
     resp.project_id = project_id
+    # story #d9c09f4b(2026-08-27) — 카드 배달(_notify_decision_request_card, best-effort)
+    # 성패와 완전히 독립된 별도 조회. 카드가 조용히 성공(엉뚱한 대상)하든 실패하든 이
+    # 필드는 "approver_member_id가 실제로 가리키는 사람"을 있는 그대로 보여준다 — 그게 이
+    # 필드의 존재 이유(호출자 자가검증)라 실패를 삼키면 안 된다(조회 실패 자체는 None 폴백,
+    # 지어내지 않는다 — 없으면 없는 대로 보여준다).
+    from app.services.member_resolver import lookup_members_by_ids
+    _designated = (await lookup_members_by_ids({body.approver_member_id}, session)).get(body.approver_member_id)
+    resp.designated_approver_name = _designated.name if _designated is not None else None
     # story #1972 SSOT 재사용(제네릭 create_gate_endpoint가 이 필드를 아예 안 채우는 기존
     # 갭을 여기서까지 상속하면 FE deriveRiskLevel이 null→'unknown'으로 읽어 low 등재의
     # 목적(원탭 승인)이 생성 응답 자체에서는 무효화된다 — 자체 신규 테스트로 발견·직접 수정).

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -180,6 +180,14 @@ async def dispatch_approval_request_cards(
     # 케이스를 배제해야 층2가 실제로 의미가 있다).
     _primary_conv_id_for_designated: uuid.UUID | None = None
 
+    # story #d9c09f4b(2026-08-27, customer-zero 실사고) — best-effort try/except가 "개별
+    # 실패"와 "전멸"을 같은 무음으로 취급했다(실사고 자체는 배달이 아니라 잘못된
+    # approver_member_id로 인한 오배달이었지만, 이 카운터는 그것과 별개로 유효한 방어층 —
+    # DM insert 레이스 등 실제 예외가 recipients 전원에서 나는 케이스는 지금 로그 0줄로
+    # 새 나간다). recipients가 이미 비지 않았음을 위에서 확인했으므로, 끝까지 돌고도
+    # delivered_count==0이면 "성공과 전멸이 같은 무음"인 그 갭 그대로다.
+    delivered_count = 0
+
     for approver_id in recipients:
         try:
             async with db.begin_nested():
@@ -216,11 +224,22 @@ async def dispatch_approval_request_cards(
                 db.add(msg)
                 await db.flush()
                 await _dispatch_conversation_event(db, conv, msg, org_id, requester)
+            delivered_count += 1
         except Exception:  # noqa: BLE001 — best-effort, 개별 승인자 실패가 상신을 막지 않음.
             logger.warning(
                 "approval-request 카드 배달 실패 %s=%s approver=%s",
                 work_item_type, work_item_id, approver_id, exc_info=True,
             )
+
+    if delivered_count == 0:
+        # ⚠️AC③ — 성공(delivered_count>0)과 전멸(모든 approver가 예외로 빠짐)이 지금까지
+        # 같은 무음이었다(개별 실패는 WARNING이 나지만, "그래서 결국 몇 건 착지했나"는 어디도
+        # 안 남았다). recipients가 이미 비지 않은 상태로 여기 도달했으므로, 이 WARNING은
+        # "받을 사람이 원래 없었다"(위의 project_id/approver_ids 가드)와 확실히 구분된다.
+        logger.warning(
+            "approval-request 카드 배달 0건(전멸) %s=%s recipients=%s",
+            work_item_type, work_item_id, recipients,
+        )
 
     # story #3044(2026-08-25) — 카드가 실제로 간 recipients와 정확히 같은 대상에게
     # conversation.gate_created(순수 SSE, 새 챗버블 없음)도 심는다 — 결재함 목록이

--- a/backend/tests/test_2604_approval_request_cards.py
+++ b/backend/tests/test_2604_approval_request_cards.py
@@ -210,8 +210,82 @@ async def test_one_approver_failure_does_not_poison_session_for_others():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
-async def test_no_approvers_no_dm_created():
-    from app.services.approval_delivery import dispatch_approval_request_cards
+async def test_all_approvers_failing_logs_zero_delivery_warning(caplog):
+    """story #d9c09f4b(2026-08-27, customer-zero) — recipients가 비지 않았는데도(위
+    test_no_approvers_no_dm_created과 구분) 개별 승인자 전원이 실패하면, 지금까지는 각자
+    "카드 배달 실패" WARNING만 나고 "그래서 결국 0건 착지했다"는 어디에도 안 남았다
+    (성공과 전멸이 같은 무음). 전멸 전용 WARNING이 추가로 나야 한다."""
+    import logging
+
+    from app.services.approval_delivery import dispatch_approval_request_cards, logger as _logger
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_human(s, org_id, project_id)
+            doc = await _seed_doc(s, org_id, project_id)
+            # 둘 다 team_members에 없음 → 둘 다 FK 위반으로 실패(test_one_approver_failure의
+            # nonexistent_approver 관례 재사용, 신규 실패유도 메커니즘 발명 0).
+            nonexistent_1, nonexistent_2 = uuid.uuid4(), uuid.uuid4()
+
+            with caplog.at_level(logging.WARNING, logger=_logger.name):
+                await dispatch_approval_request_cards(
+                    s, org_id=org_id, work_item_type="doc", work_item_id=doc.id,
+                    project_id=doc.project_id, title=doc.title, gate_id=uuid.uuid4(),
+                    requester_id=requester_id, approver_ids=[nonexistent_1, nonexistent_2],
+                )
+            await s.commit()
+
+            from sqlalchemy import select
+            from app.models.conversation import Conversation
+
+            convs = (await s.execute(select(Conversation).where(Conversation.org_id == org_id))).scalars().all()
+            assert convs == [], "전원 실패 — 방 자체가 하나도 안 생김"
+            assert any("전멸" in r.message for r in caplog.records), \
+                "recipients는 비지 않았는데 delivered_count==0인 전멸 케이스는 전용 WARNING이 나야 한다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_partial_success_does_not_log_zero_delivery_warning(caplog):
+    """1명이라도 성공하면(test_one_approver_failure_does_not_poison_session_for_others와
+    동일 시드) 전멸 WARNING은 나지 않아야 한다 — 개별 실패 WARNING과 전멸 WARNING을
+    혼동하면 성공 케이스까지 시끄러워진다(과잉 알림도 방어 대상)."""
+    import logging
+
+    from app.services.approval_delivery import dispatch_approval_request_cards, logger as _logger
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            requester_id = await _seed_human(s, org_id, project_id)
+            good_approver = await _seed_human(s, org_id, project_id)
+            nonexistent_approver = uuid.uuid4()
+            doc = await _seed_doc(s, org_id, project_id)
+
+            with caplog.at_level(logging.WARNING, logger=_logger.name):
+                await dispatch_approval_request_cards(
+                    s, org_id=org_id, work_item_type="doc", work_item_id=doc.id,
+                    project_id=doc.project_id, title=doc.title, gate_id=uuid.uuid4(),
+                    requester_id=requester_id, approver_ids=[nonexistent_approver, good_approver],
+                )
+            await s.commit()
+
+            assert not any("전멸" in r.message for r in caplog.records)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_no_approvers_no_dm_created(caplog):
+    import logging
+
+    from app.services.approval_delivery import dispatch_approval_request_cards, logger as _logger
     from app.models.conversation import Conversation
 
     engine, Session = await _realdb_session()
@@ -221,12 +295,17 @@ async def test_no_approvers_no_dm_created():
             requester_id = await _seed_human(s, org_id, project_id)
             doc = await _seed_doc(s, org_id, project_id)
 
-            await dispatch_approval_request_cards(
-                s, org_id=org_id, work_item_type="doc", work_item_id=doc.id,
-                project_id=doc.project_id, title=doc.title, gate_id=uuid.uuid4(),
-                requester_id=requester_id, approver_ids=[],
-            )
+            with caplog.at_level(logging.WARNING, logger=_logger.name):
+                await dispatch_approval_request_cards(
+                    s, org_id=org_id, work_item_type="doc", work_item_id=doc.id,
+                    project_id=doc.project_id, title=doc.title, gate_id=uuid.uuid4(),
+                    requester_id=requester_id, approver_ids=[],
+                )
             await s.commit()
+            # story #d9c09f4b — "받을 사람이 원래 없었다"(project_id/approver_ids 가드)와
+            # "recipients는 있었는데 전멸했다"(위 test_all_approvers_failing_...)는 서로 다른
+            # 사실이라 같은 WARNING을 공유하면 안 된다.
+            assert not any("전멸" in r.message for r in caplog.records)
 
             from sqlalchemy import select
 

--- a/backend/tests/test_2709_agent_decision_request.py
+++ b/backend/tests/test_2709_agent_decision_request.py
@@ -326,6 +326,54 @@ async def test_response_echoes_designated_approver_identity_for_self_verificatio
 
 
 @pytest.mark.anyio
+async def test_designated_approver_name_lookup_exception_does_not_break_response(monkeypatch, caplog):
+    """카디르 QA(#3550) — designated_approver_name 조회가 «미확인 멤버»가 아니라 **예외**로
+    죽으면(레이스·일시적 DB 오류) 이미 커밋된 게이트 생성 응답이 500으로 뒤집히면 안 된다.
+    lookup_members_by_ids를 강제로 예외 발생시켜 응답이 여전히 201·필드는 None 폴백임을
+    고정한다(관측성 필드가 본 기능을 죽이는 회귀 방지)."""
+    import logging
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            caller_id = uuid.uuid4()
+            await _seed_human_member(s, org_id, user_id=caller_id, role="member")
+            approver_member_id = await _seed_human_member(s, org_id, role="admin")
+        await _setup_app_jwt(app, Session, org_id, project_id, caller_id)
+
+        import app.services.member_resolver as member_resolver_mod
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("simulated lookup failure")
+
+        monkeypatch.setattr(member_resolver_mod, "lookup_members_by_ids", _boom)
+
+        client = _client_for(app)
+        try:
+            with caplog.at_level(logging.WARNING):
+                resp = await client.post(
+                    "/api/v2/gates/decisions",
+                    json={
+                        "question": "approach A or B?", "assumption": "A",
+                        "approver_member_id": str(approver_member_id),
+                    },
+                )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["status"] == "pending", "게이트 생성 자체는 이미 커밋 완료 — 관측성 조회 실패로 뒤집히면 안 됨"
+            assert body["designated_approver_name"] is None
+            assert any("designated_approver_name 조회 실패" in r.message for r in caplog.records)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_http_endpoint_missing_org_or_project_403():
     """음성대조 — org_id/project_id를 못 얻으면(예: X-Project-Id 없는 API키 컨텍스트에서
     project 미해소) 403(get_scope_context 경유, 조용히 통과 안 함)."""

--- a/backend/tests/test_2709_agent_decision_request.py
+++ b/backend/tests/test_2709_agent_decision_request.py
@@ -276,6 +276,56 @@ async def test_http_endpoint_creates_pending_low_risk_decision_gate():
 
 
 @pytest.mark.anyio
+async def test_response_echoes_designated_approver_identity_for_self_verification():
+    """story #d9c09f4b(2026-08-27, customer-zero) — 실사고 재발 방지: 카드 배달층은 무결했고
+    호출자가 approver_member_id를 오지정(다른 실사람)한 게 진짜 원인이었다. 배달 성공/실패와
+    무관하게 응답이 "실제로 누구를 가리키는지" 이름/이메일로 에코해야 호출자가 즉시
+    자가검증할 수 있다 — 이 테스트는 응답의 designated_approver_name이 seed 시 지정한
+    approver의 실제 email과 정확히 일치함을 고정한다(다른 값이면 즉시 RED)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            caller_id = uuid.uuid4()
+            await _seed_human_member(s, org_id, user_id=caller_id, role="member")
+            approver_user_id = uuid.uuid4()
+            approver_email = f"designated-{approver_user_id.hex[:8]}@test.com"
+            from app.core.security import hash_password
+            from app.models.project import OrgMember
+            from app.models.user import User
+
+            s.add(User(
+                id=approver_user_id, email=approver_email,
+                hashed_password=hash_password("x"), is_active=True, email_verified=True,
+            ))
+            await s.commit()
+            approver_member_id = uuid.uuid4()
+            s.add(OrgMember(id=approver_member_id, org_id=org_id, user_id=approver_user_id, role="admin"))
+            await s.commit()
+        await _setup_app_jwt(app, Session, org_id, project_id, caller_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/gates/decisions",
+                json={
+                    "question": "approach A or B?", "assumption": "A",
+                    "approver_member_id": str(approver_member_id),
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["designated_approver_id"] == str(approver_member_id)
+            assert body["designated_approver_name"] == approver_email
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_http_endpoint_missing_org_or_project_403():
     """음성대조 — org_id/project_id를 못 얻으면(예: X-Project-Id 없는 API키 컨텍스트에서
     project 미해소) 403(get_scope_context 경유, 조용히 통과 안 함)."""


### PR DESCRIPTION
[SID:3142]

## 요약
customer-zero 실사고(게이트 81943fba·a7a97528) 실측 그라운딩 — `dispatch_approval_request_cards` 배달층 자체는 무결(카드 생성·커밋·`Event.status='delivered'` 확인 완료). 진짜 원인은 호출자가 `approver_member_id`를 사부님(e75ca548·owner)이 아닌 다른 admin(2fd14616·서명용 별계정)으로 오지정해, 카드가 정확히 "엉뚱한 실사람"에게 배달된 것 — 원 스토리가 가정한 세 갈래(빈 approver 해소/DM 생성 실패/flush 후 유실)는 pgstat-probe-dev 실측으로 전부 반증됨.

PO(페드루) 확인·수리 범위 승인(①+②, ③은 기각 — "의도한 사람" 추측을 서버에 넣는 건 또 다른 침묵 오배달의 씨앗).

## 변경
- `approval_delivery.dispatch_approval_request_cards`: recipients가 있었는데도 전원 개별 실패한 "전멸" 케이스에 전용 WARNING 추가. 지금까지는 성공(delivered_count>0)과 전멸이 같은 무음이었음.
- `create_decision_request` 응답에 `designated_approver_name` 필드 추가(additive·nullable) — 카드 배달 성패와 완전히 독립적으로, "approver_member_id가 실제로 가리키는 사람"을 이름/이메일로 에코. 이번 실사고의 실질 해독제(호출자가 응답만 보고 즉시 "어 이 사람 아닌데" 자가검증 가능).

## 테스트
- `test_2604_approval_request_cards.py`: 전멸 WARNING(신규 2건) + 무-recipient 케이스가 전멸 WARNING과 안 섞임(회귀 가드).
- `test_2709_agent_decision_request.py`: HTTP 왕복으로 `designated_approver_name`이 seed한 approver의 실제 email과 정확히 일치함을 고정(신규 1건).
- 뮤테이션 테스트 양쪽 다 genuine RED 확인 후 복원 → GREEN.
- 관련 gate/approval 계열 기존 테스트 14개 파일 스윕 — 16건 실패는 baseline(변경 전 코드)에서도 동일하게 재현되는 기존 test-환경 갭(create_all 기반 테스트 DB가 실 마이그 스키마의 `team_members` VIEW 투영을 재현 못함, 회귀 아님을 stash 대조로 확인).

## Test plan
- [x] 신규 realdb 테스트 3건 GREEN + 뮤테이션 검증
- [x] AST 가드 lint 5종 무위반
- [x] 관련 기존 테스트 스윕(16건 pre-existing 실패, 회귀 0 확인)