### PR TITLE
Chat ②층 P1 BE — 서버 집행 커맨드 카탈로그(/done·/assign·/priority)

### DIFF
--- a/backend/alembic/versions/0285_chat_command_audit_logs.py
+++ b/backend/alembic/versions/0285_chat_command_audit_logs.py
@@ -1,0 +1,51 @@
+"""story #3143(9a5abc24, Chat ②층 P1 BE) — chat_command_audit_logs 신설.
+
+서버 집행 커맨드(/done·/assign·/priority)의 행위자·대상·전후 값·결과를 기록한다. 기존
+agent_audit_logs(agent_id NOT NULL)·permission_audit_logs(role 변경 전용 스키마) 둘 다
+휴먼 발신 커맨드를 담을 수 없거나 필드가 이 도메인과 안 맞아 새 테이블로 분리한다.
+
+Revision ID: 0285
+Revises: 0284
+Create Date: 2026-08-27
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0285"
+down_revision = "0284"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_command_audit_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("conversation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("message_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("actor_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("actor_type", sa.Text(), nullable=False),
+        sa.Column("command", sa.Text(), nullable=False),
+        sa.Column("raw_args", sa.Text(), nullable=False),
+        sa.Column("target_type", sa.Text(), nullable=True),
+        sa.Column("target_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("outcome", sa.Text(), nullable=False),
+        sa.Column("before_value", sa.Text(), nullable=True),
+        sa.Column("after_value", sa.Text(), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("metadata", postgresql.JSONB(), nullable=False, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_chat_command_audit_logs_org_id", "chat_command_audit_logs", ["org_id"])
+    op.create_index("ix_chat_command_audit_logs_message_id", "chat_command_audit_logs", ["message_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_chat_command_audit_logs_message_id", table_name="chat_command_audit_logs")
+    op.drop_index("ix_chat_command_audit_logs_org_id", table_name="chat_command_audit_logs")
+    op.drop_table("chat_command_audit_logs")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.auth_identity import AuthIdentity, AuthMigration, AuthMigrationE
 from app.models.auth_native_bootstrap import AuthNativeBootstrapCode
 from app.models.oauth_handoff_code import OAuthHandoffCode
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
+from app.models.chat_command_audit_log import ChatCommandAuditLog
 from app.models.deletion_audit import DeletionAuditLog
 from app.models.dependency import ItemDependency
 from app.models.device_installation import DeviceInstallation, DeviceProofChallenge

--- a/backend/app/models/chat_command_audit_log.py
+++ b/backend/app/models/chat_command_audit_log.py
@@ -1,0 +1,45 @@
+"""story #3143(9a5abc24, Chat ②층 P1 BE) — 서버 집행 커맨드(/done·/assign·/priority) 감사 로그.
+
+기존 `AgentAuditLog`(agent_id NOT NULL — 휴먼 발신 커맨드를 못 담음)·`AuditLog`
+(permission_audit_logs, role 변경 전용 스키마)는 둘 다 이 용도에 맞지 않는다(전자는 발신자
+축이 좁고, 후자는 old_role/new_role/target_user_id가 이 도메인과 무관) — 새 테이블로 분리.
+
+actor_type: 'human' | 'agent'(auth.claims.api_key_id 유무로 판정, gate_service.py의
+동일 관례 재사용). outcome: 'executed' | 'denied' | 'not_found' | 'ambiguous' | 'invalid_args'.
+before_value/after_value는 필드 하나만 다루는 커맨드 특성상 단일 스칼라 문자열로 충분
+(json 값 강제 지어내지 않음 — before는 실패 케이스에서 None일 수 있다).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class ChatCommandAuditLog(Base):
+    __tablename__ = "chat_command_audit_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    message_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    actor_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    actor_type: Mapped[str] = mapped_column(Text, nullable=False)
+    command: Mapped[str] = mapped_column(Text, nullable=False)
+    raw_args: Mapped[str] = mapped_column(Text, nullable=False)
+    target_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    target_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    outcome: Mapped[str] = mapped_column(Text, nullable=False)
+    before_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    after_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    audit_metadata: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -2683,9 +2683,31 @@ async def send_message(
     except Exception:
         logger.warning("ChannelRouter pre-check failed message_id=%s — no SSE exclusion", msg.id)
 
+    # story #3143(9a5abc24, Chat ②층 P1 BE) — 서버 집행 커맨드(카탈로그 3종) 우선 판정.
+    # 명중하면 서버가 즉시 집행+결과 카드까지 이 자리에서 심는다(doc §"서버 카탈로그
+    # 우선(결정적) → 나머지 기존 게이트 흐름"). 미명중(카탈로그 밖 커맨드·비-커맨드)은
+    # 아무 부작용 없이 False — 아래 capability gate·에이전트 dispatch가 그대로 진행된다.
+    from app.services.chat_command_catalog import try_execute_server_command
+    server_command_executed = await try_execute_server_command(db, org_id=org_id, conv=conv, msg=msg, sender=sender)
+
     # E-CHAT-CMD S4: capability gate — 슬래시 커맨드를 미지원 런타임 에이전트에 주입 차단(+audit+hint).
     # 비-command 면 빈 결과 → 무영향. 차단 대상은 dispatch exclude 로 합쳐 주입 0.
     blocked_agent_ids, command_hints = await _command_capability_gate(db, conv, msg, sender, org_id)
+    if server_command_executed:
+        # 서버가 이미 결정적으로 집행했다 — 이 원본 메시지가 에이전트에게 또 dispatch되면
+        # 자연어로 같은 조작을 중복 시도할 위험이 있다(예: 에이전트가 "/done 3110"을 스스로
+        # 해석해 MCP로 한 번 더 done 전이 시도). capability gate와 동일한 exclude 축(SSE·
+        # 멘션·알림 전부 이 한 집합으로 걸러진다)에 이 conversation의 에이전트 참가자
+        # 전원을 합쳐 이중 집행을 막는다 — 새 exclude 축 발명 0.
+        _agent_participant_ids = set((await db.execute(
+            select(TeamMember.id)
+            .join(ConversationParticipant, ConversationParticipant.member_id == TeamMember.id)
+            .where(
+                ConversationParticipant.conversation_id == conv.id,
+                TeamMember.type == "agent", TeamMember.id != sender.id,
+            )
+        )).scalars().all())
+        blocked_agent_ids = blocked_agent_ids | _agent_participant_ids
 
     # story #2349 AC3 — 「이 발신자를 차단한 수신자」는 대화 메시지 SSE/멘션/알림에서 감산한다.
     # PO 경계(2026-08-02): 이건 conversations.py::send_message(대화)만이다 — 스토리 멘션(업무)은

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -611,6 +611,9 @@ def _msg_payload(
     payload.update(_approval_payload(msg))
     # story #2637 AC 0-a: 이벤트 발행 메시지 스키마 top-level 노출(없으면 None·additive).
     payload.update(_event_payload(msg))
+    # story #3143(9a5abc24) PO 리뷰 델타: 서버 집행 커맨드 결과 카드 스키마 top-level
+    # 노출(없으면 None·additive) — FE가 텍스트 휴리스틱 없이 이 카드를 식별하는 축.
+    payload.update(_server_command_payload(msg))
     return payload
 
 
@@ -683,6 +686,17 @@ def _event_payload(msg: "ConversationMessage") -> dict:
     meta = (getattr(msg, "__dict__", None) or {}).get("msg_metadata")
     event = meta.get("event") if isinstance(meta, dict) else None
     return {"event": event if isinstance(event, dict) else None}
+
+
+def _server_command_payload(msg: "ConversationMessage") -> dict:
+    """story #3143(9a5abc24) PO 리뷰 델타 — msg_metadata['server_command'] → payload
+    top-level(없으면 None). _approval_payload/_event_payload와 동형(additive·__dict__
+    전용 read — 동일 greenlet_spawn 회피 이유). FE(#92f00dc4, 유나 규격 ⚡배지+4상태)가
+    이 필드 하나로 "서버가 직접 집행한 카드"임을 텍스트 휴리스틱 없이 판별한다 — 카드
+    렌더는 FE 몫, 여기는 스키마(command/outcome)만 실어 나른다."""
+    meta = (getattr(msg, "__dict__", None) or {}).get("msg_metadata")
+    server_command = meta.get("server_command") if isinstance(meta, dict) else None
+    return {"server_command": server_command if isinstance(server_command, dict) else None}
 
 
 async def _viewer_blocked_sender_ids(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession) -> set[uuid.UUID]:

--- a/backend/app/services/chat_command_catalog.py
+++ b/backend/app/services/chat_command_catalog.py
@@ -167,6 +167,11 @@ class CommandOutcome:
     # 배열만(id는 재조회 없이 이름→서버 재검증이 이미 /assign 재호출 경로라 불필요 — 이
     # 필드는 "무엇을 다시 물어봤는지"만 보여준다).
     candidates: list[str] | None = None
+    # story #3143 PO 리뷰 델타 3회차(2026-08-27, 미르코 FE 배선) — ambiguous 후보 클릭이
+    # "해소된 명령"(`/assign #<번호> <이름>`)을 채우려면 원 스토리 참조가 필요한데, 이
+    # CommandOutcome은 이미 target_id(story.id, UUID)를 갖고 있지만 사람이 타이핑하는
+    # 형태(story_number)가 아니다. ambiguous 한정으로 그 값을 그대로 실어 보낸다.
+    target_story_number: int | None = None
 
 
 async def _execute_done(
@@ -245,7 +250,10 @@ async def _execute_assign(
         if match.candidates:
             candidate_names = [m.name for m in match.candidates]
             names = ", ".join(candidate_names)
-            return CommandOutcome("ambiguous", f"'/assign' 실패 — 「{rest}」에 일치하는 멤버가 여럿입니다: {names} (정확한 이름을 입력하세요)", target_type="story", target_id=story_id, reason="ambiguous_member", candidates=candidate_names)
+            target_story_number = (await db.execute(
+                select(Story.story_number).where(Story.id == story_id)
+            )).scalar_one_or_none()
+            return CommandOutcome("ambiguous", f"'/assign' 실패 — 「{rest}」에 일치하는 멤버가 여럿입니다: {names} (정확한 이름을 입력하세요)", target_type="story", target_id=story_id, reason="ambiguous_member", candidates=candidate_names, target_story_number=target_story_number)
         return CommandOutcome("not_found", f"'/assign' 실패 — 「{rest}」에 일치하는 멤버를 찾을 수 없습니다.", target_type="story", target_id=story_id, reason="member_not_found")
 
     before = (await db.execute(select(Story.assignee_id).where(Story.id == story_id))).scalar_one_or_none()
@@ -312,6 +320,10 @@ async def try_execute_server_command(
             # PO 리뷰 델타 2회차 — ambiguous일 때만. FE가 reply_content의 comma-join
             # 문장을 파싱하지 않고 이 배열로 클릭형 후보 행을 바로 그린다.
             _server_command_meta["candidates"] = result.candidates
+        if result.target_story_number is not None:
+            # PO 리뷰 델타 3회차 — ambiguous 후보 클릭이 "/assign #<번호> <이름>"으로
+            # 해소된 명령을 채우려면 원 스토리 참조(사람이 타이핑하는 형태)가 필요하다.
+            _server_command_meta["target_story_number"] = result.target_story_number
         reply = ConversationMessage(
             conversation_id=conv.id, sender_id=sender.id, content=result.reply_content,
             mentioned_ids=[sender.id],

--- a/backend/app/services/chat_command_catalog.py
+++ b/backend/app/services/chat_command_catalog.py
@@ -161,6 +161,12 @@ class CommandOutcome:
     before_value: str | None = None
     after_value: str | None = None
     reason: str | None = None
+    # story #3143 PO 리뷰 델타 2회차(2026-08-27, 미르코 FE 정독 적출) — ambiguous outcome
+    # 전용. reply_content의 comma-join 문장만으론 FE가 후보 행(클릭→입력창 채움)을 만들려면
+    # 문장 파싱을 해야 해 server_command 식별자를 세운 취지와 모순됐다. 멤버 이름 문자열
+    # 배열만(id는 재조회 없이 이름→서버 재검증이 이미 /assign 재호출 경로라 불필요 — 이
+    # 필드는 "무엇을 다시 물어봤는지"만 보여준다).
+    candidates: list[str] | None = None
 
 
 async def _execute_done(
@@ -237,8 +243,9 @@ async def _execute_assign(
     match = await _resolve_member_by_query(db, project_id=project_id, query=rest)
     if match.member is None:
         if match.candidates:
-            names = ", ".join(m.name for m in match.candidates)
-            return CommandOutcome("ambiguous", f"'/assign' 실패 — 「{rest}」에 일치하는 멤버가 여럿입니다: {names} (정확한 이름을 입력하세요)", target_type="story", target_id=story_id, reason="ambiguous_member")
+            candidate_names = [m.name for m in match.candidates]
+            names = ", ".join(candidate_names)
+            return CommandOutcome("ambiguous", f"'/assign' 실패 — 「{rest}」에 일치하는 멤버가 여럿입니다: {names} (정확한 이름을 입력하세요)", target_type="story", target_id=story_id, reason="ambiguous_member", candidates=candidate_names)
         return CommandOutcome("not_found", f"'/assign' 실패 — 「{rest}」에 일치하는 멤버를 찾을 수 없습니다.", target_type="story", target_id=story_id, reason="member_not_found")
 
     before = (await db.execute(select(Story.assignee_id).where(Story.id == story_id))).scalar_one_or_none()
@@ -300,6 +307,11 @@ async def try_execute_server_command(
         from app.services.member_resolver import lookup_members_by_ids
 
         sender_resolved = (await lookup_members_by_ids({sender.id}, db)).get(sender.id)
+        _server_command_meta: dict = {"command": candidate.name, "outcome": result.outcome}
+        if result.candidates:
+            # PO 리뷰 델타 2회차 — ambiguous일 때만. FE가 reply_content의 comma-join
+            # 문장을 파싱하지 않고 이 배열로 클릭형 후보 행을 바로 그린다.
+            _server_command_meta["candidates"] = result.candidates
         reply = ConversationMessage(
             conversation_id=conv.id, sender_id=sender.id, content=result.reply_content,
             mentioned_ids=[sender.id],
@@ -309,7 +321,7 @@ async def try_execute_server_command(
                 # 카드를 텍스트 휴리스틱 없이 판별하는 기계 식별자. approval_target/event와
                 # 동일 additive namespace 선례(conversations.py::_server_command_payload가
                 # payload top-level로 노출).
-                "server_command": {"command": candidate.name, "outcome": result.outcome},
+                "server_command": _server_command_meta,
             },
         )
         db.add(reply)

--- a/backend/app/services/chat_command_catalog.py
+++ b/backend/app/services/chat_command_catalog.py
@@ -303,7 +303,14 @@ async def try_execute_server_command(
         reply = ConversationMessage(
             conversation_id=conv.id, sender_id=sender.id, content=result.reply_content,
             mentioned_ids=[sender.id],
-            msg_metadata={"activation": {"kind": "result", "audience": [str(sender.id)], "expects_response": False}},
+            msg_metadata={
+                "activation": {"kind": "result", "audience": [str(sender.id)], "expects_response": False},
+                # story #3143 PO 리뷰 델타 — FE(#92f00dc4, 유나 규격 ⚡배지+4상태)가 이
+                # 카드를 텍스트 휴리스틱 없이 판별하는 기계 식별자. approval_target/event와
+                # 동일 additive namespace 선례(conversations.py::_server_command_payload가
+                # payload top-level로 노출).
+                "server_command": {"command": candidate.name, "outcome": result.outcome},
+            },
         )
         db.add(reply)
         await db.flush()

--- a/backend/app/services/chat_command_catalog.py
+++ b/backend/app/services/chat_command_catalog.py
@@ -1,0 +1,315 @@
+"""story #3143(9a5abc24, Chat ②층·P1·BE) — 서버 집행 커맨드 카탈로그+집행기.
+
+doc `chat-action-messages-round1-draft`(v6) §"서버 집행 커맨드" 확定분 — 결정적 엔티티
+조작(3종: /done·/assign·/priority)만 서버가 `command_classifier.classify_command()` 결과를
+직접 집행한다. 새 파서·새 권한 층 발명 0:
+
+- 판정: 기존 `classify_command()`(S3) 결과의 ``name``이 이 모듈의 ``CATALOG``에 정확히
+  일치할 때만 진입(미명중은 호출자가 기존 경로 그대로 진행 — 회귀 0).
+- 권한: 발신자의 **기존 API 권한 그대로** — `app.routers.stories`의 `update_story_status`/
+  `update_story` 엔드포인트 함수를 in-process로 그대로 호출한다(재구현 0, 새 권한 판정
+  없음). HTTP 요청 컨텍스트가 없는 자리에서 엔드포인트를 부르는 관용구는
+  `app.routers.events.publish_preset_event`가 이미 쓰는 패턴과 동형 — 자체
+  ``BackgroundTasks()``를 만들어 호출 직후 수동 실행한다.
+- 발신자→합성 AuthContext 매핑: `has_project_access`(project_auth.py)의 human 분기가
+  ``TeamMember.id == user_id OR TeamMember.user_id == user_id`` 양쪽을 다 받아주므로,
+  human 발신자는 raw `users.id`(ResolvedMember.user_id/TeamMember.user_id)를, agent
+  발신자는 자기 team_member.id를 그대로 `auth.user_id`에 실으면 실제 JWT/API-key 인증
+  경로와 동일한 권한 판정이 그대로 재현된다.
+- 결과 회신: `message_kind="result"` + 자연어 본문(story #5c29454b 3존 카드 레일 —
+  ``deriveVerdictTone``의 성공/실패 어휘(완료/승인 vs 반려/FAIL)와 ``extractNextAction``의
+  「다음: ...」 구분자를 그대로 태운다. **새 JSON 스키마를 만들지 않는다** — 그 레일은
+  순수 텍스트 렌더 변환이라 서버는 잘 쓰인 평문만 내보내면 된다).
+- 감사: 성공/실패(권한거부·미존재·모호·인자오류) 전 건을 `ChatCommandAuditLog`에 기록.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+from fastapi import BackgroundTasks, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext
+from app.models.chat_command_audit_log import ChatCommandAuditLog
+from app.models.conversation import Conversation, ConversationMessage
+from app.models.pm import Story
+from app.models.team import TeamMember
+from app.services.command_classifier import CommandCandidate
+
+logger = logging.getLogger(__name__)
+
+VALID_PRIORITIES = ("critical", "high", "medium", "low")
+
+# args 맨 앞이 entity mention 토큰(`[라벨](entity:story:uuid)`)이면 그대로 통째로 매치 —
+# mention_parser.py의 `_CHAT_TOKEN_RE`와 동일 모양(그 정규식은 모듈 private이라 새로 못
+# 불러온다 — 토큰 문법 자체가 이 코드베이스 전역 SSOT라 재정의는 이 상수 하나뿐, 매치
+# 실패 시엔 아래 bare-number 분기로 자연 폴백한다).
+_STORY_MENTION_PREFIX_RE = re.compile(
+    r"^\[(?:[^\]\\]|\\.)*\]\(entity:story:([0-9a-fA-F-]{36})\)\s*(.*)$", re.DOTALL,
+)
+
+
+def _split_first_arg(args: str) -> tuple[str, str]:
+    """args 맨 앞 토큰(story 참조)과 나머지를 가른다. entity mention 토큰은 내부에 공백이
+    있어도 통째로 하나의 토큰 — 단순 whitespace split이면 라벨 중간에서 잘린다."""
+    m = _STORY_MENTION_PREFIX_RE.match(args)
+    if m:
+        return f"[](entity:story:{m.group(1)})", m.group(2).strip()
+    parts = args.split(maxsplit=1)
+    if not parts:
+        return "", ""
+    return parts[0], parts[1].strip() if len(parts) > 1 else ""
+
+
+async def _resolve_story_id(
+    db: AsyncSession, *, org_id: uuid.UUID, project_id: uuid.UUID, ref: str,
+) -> uuid.UUID | None:
+    """story 참조 토큰(bare 번호 또는 entity mention)을 story.id로 해소. 형식 자체가
+    해석 불가면 None(invalid_args) — 존재/프로젝트 소속 여부는 호출자가 실행 시점에
+    (update_story*의 기존 404) 판정하므로 여기서 별도 존재 검증을 하지 않는다."""
+    m = re.match(r"^\[\]\(entity:story:([0-9a-fA-F-]{36})\)$", ref)
+    if m:
+        return uuid.UUID(m.group(1))
+    bare = ref.lstrip("#")
+    if not bare.isdigit():
+        return None
+    story_number = int(bare)
+    row = (await db.execute(
+        select(Story.id).where(
+            Story.org_id == org_id, Story.project_id == project_id,
+            Story.story_number == story_number,
+        )
+    )).scalar_one_or_none()
+    return row
+
+
+@dataclass
+class MemberMatch:
+    member: TeamMember | None
+    candidates: list[TeamMember]
+
+
+async def _resolve_member_by_query(
+    db: AsyncSession, *, project_id: uuid.UUID, query: str,
+) -> MemberMatch:
+    """정확명(대소문자 무시) 우선, 없으면 유일 prefix. 0건/모호(2건 이상)는 candidates로
+    구분(len(candidates)==0 → 대상 없음, >=2 → 모호)."""
+    q = query.strip().lower()
+    if not q:
+        return MemberMatch(None, [])
+    rows = list((await db.execute(
+        select(TeamMember).where(TeamMember.project_id == project_id, TeamMember.is_active.is_(True))
+    )).scalars().all())
+    exact = [m for m in rows if m.name.lower() == q]
+    if len(exact) == 1:
+        return MemberMatch(exact[0], [])
+    if len(exact) > 1:
+        return MemberMatch(None, exact)
+    prefix = [m for m in rows if m.name.lower().startswith(q)]
+    if len(prefix) == 1:
+        return MemberMatch(prefix[0], [])
+    return MemberMatch(None, prefix)
+
+
+def _synthetic_auth_for_sender(sender, org_id: uuid.UUID) -> AuthContext:
+    """발신자 신원 → 합성 AuthContext. `require_project_access`/`has_project_access`가
+    human 축을 ``TeamMember.id == user_id OR TeamMember.user_id == user_id`` 양쪽으로
+    받아주므로(project_auth.py `_project_access_predicate`), human은 raw users.id를,
+    agent는 자기 team_member.id를 그대로 실으면 실제 인증 경로와 동일 권한이 재현된다."""
+    sender_type = getattr(sender, "type", None)
+    if sender_type == "agent":
+        return AuthContext(
+            user_id=str(sender.id), email=None,
+            claims={"app_metadata": {"api_key_id": "chat-server-command"}}, org_id=str(org_id),
+        )
+    user_id = getattr(sender, "user_id", None) or sender.id
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(org_id))
+
+
+def _denial_reason(exc: HTTPException) -> str:
+    detail = exc.detail
+    if isinstance(detail, dict):
+        return str(detail.get("message") or detail.get("code") or detail)
+    return str(detail)
+
+
+async def _call_endpoint_in_process(
+    fn: Callable[..., Awaitable], /, **kwargs,
+) -> tuple[object | None, HTTPException | None]:
+    """HTTP 요청 컨텍스트 밖에서 엔드포인트 함수를 그대로 부른다 — BackgroundTasks() 자체
+    생성+수동 실행 관용구는 `app.routers.events.publish_preset_event`와 동형(재발명 0)."""
+    background_tasks = BackgroundTasks()
+    try:
+        result = await fn(background_tasks=background_tasks, **kwargs)
+    except HTTPException as exc:
+        return None, exc
+    await background_tasks()
+    return result, None
+
+
+@dataclass
+class CommandOutcome:
+    outcome: str  # executed | denied | not_found | ambiguous | invalid_args
+    reply_content: str
+    target_type: str | None = None
+    target_id: uuid.UUID | None = None
+    before_value: str | None = None
+    after_value: str | None = None
+    reason: str | None = None
+
+
+async def _execute_done(
+    db: AsyncSession, *, org_id: uuid.UUID, auth: AuthContext, candidate: CommandCandidate,
+    project_id: uuid.UUID,
+) -> CommandOutcome:
+    ref, _rest = _split_first_arg(candidate.args)
+    if not ref:
+        return CommandOutcome("invalid_args", "'/done' 사용법: `/done <스토리#>`", reason="missing_story_ref")
+    story_id = await _resolve_story_id(db, org_id=org_id, project_id=project_id, ref=ref)
+    if story_id is None:
+        return CommandOutcome("invalid_args", f"'/done' 실패 — 스토리 참조를 해석할 수 없습니다: `{ref}`", reason="unparseable_story_ref")
+
+    before = (await db.execute(select(Story.status).where(Story.id == story_id))).scalar_one_or_none()
+
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import StoryStatusUpdate, update_story_status
+
+    resp, exc = await _call_endpoint_in_process(
+        update_story_status, id=story_id, body=StoryStatusUpdate(status="done"),
+        repo=StoryRepository(db, org_id), db=db, auth=auth,
+    )
+    if exc is not None:
+        outcome = "not_found" if exc.status_code == 404 else "denied"
+        return CommandOutcome(outcome, f"'/done' 실패 — {_denial_reason(exc)}", target_type="story", target_id=story_id, before_value=before, reason=_denial_reason(exc))
+    return CommandOutcome(
+        "executed", f"'/done' 완료 — 스토리가 done으로 전이됐습니다.\n다음: 결과를 확인하세요.",
+        target_type="story", target_id=story_id, before_value=before, after_value="done",
+    )
+
+
+async def _execute_priority(
+    db: AsyncSession, *, org_id: uuid.UUID, auth: AuthContext, candidate: CommandCandidate,
+    project_id: uuid.UUID,
+) -> CommandOutcome:
+    ref, rest = _split_first_arg(candidate.args)
+    if not ref or not rest:
+        return CommandOutcome("invalid_args", "'/priority' 사용법: `/priority <스토리#> <critical|high|medium|low>`", reason="missing_args")
+    level = rest.split(maxsplit=1)[0].strip().lower()
+    if level not in VALID_PRIORITIES:
+        return CommandOutcome("invalid_args", f"'/priority' 실패 — 알 수 없는 우선순위: `{level}` (critical/high/medium/low 중 하나)", reason="invalid_priority_level")
+    story_id = await _resolve_story_id(db, org_id=org_id, project_id=project_id, ref=ref)
+    if story_id is None:
+        return CommandOutcome("invalid_args", f"'/priority' 실패 — 스토리 참조를 해석할 수 없습니다: `{ref}`", reason="unparseable_story_ref")
+
+    before = (await db.execute(select(Story.priority).where(Story.id == story_id))).scalar_one_or_none()
+
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import StoryUpdate, update_story
+
+    resp, exc = await _call_endpoint_in_process(
+        update_story, id=story_id, body=StoryUpdate(priority=level),
+        repo=StoryRepository(db, org_id), db=db, auth=auth,
+    )
+    if exc is not None:
+        outcome = "not_found" if exc.status_code == 404 else "denied"
+        return CommandOutcome(outcome, f"'/priority' 실패 — {_denial_reason(exc)}", target_type="story", target_id=story_id, before_value=before, reason=_denial_reason(exc))
+    return CommandOutcome(
+        "executed", f"'/priority' 완료 — 우선순위가 {before}에서 {level}로 변경됐습니다.\n다음: 결과를 확인하세요.",
+        target_type="story", target_id=story_id, before_value=before, after_value=level,
+    )
+
+
+async def _execute_assign(
+    db: AsyncSession, *, org_id: uuid.UUID, project_id: uuid.UUID, auth: AuthContext, candidate: CommandCandidate,
+) -> CommandOutcome:
+    ref, rest = _split_first_arg(candidate.args)
+    if not ref or not rest:
+        return CommandOutcome("invalid_args", "'/assign' 사용법: `/assign <스토리#> <멤버명>`", reason="missing_args")
+    story_id = await _resolve_story_id(db, org_id=org_id, project_id=project_id, ref=ref)
+    if story_id is None:
+        return CommandOutcome("invalid_args", f"'/assign' 실패 — 스토리 참조를 해석할 수 없습니다: `{ref}`", reason="unparseable_story_ref")
+
+    match = await _resolve_member_by_query(db, project_id=project_id, query=rest)
+    if match.member is None:
+        if match.candidates:
+            names = ", ".join(m.name for m in match.candidates)
+            return CommandOutcome("ambiguous", f"'/assign' 실패 — 「{rest}」에 일치하는 멤버가 여럿입니다: {names} (정확한 이름을 입력하세요)", target_type="story", target_id=story_id, reason="ambiguous_member")
+        return CommandOutcome("not_found", f"'/assign' 실패 — 「{rest}」에 일치하는 멤버를 찾을 수 없습니다.", target_type="story", target_id=story_id, reason="member_not_found")
+
+    before = (await db.execute(select(Story.assignee_id).where(Story.id == story_id))).scalar_one_or_none()
+
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import StoryUpdate, update_story
+
+    resp, exc = await _call_endpoint_in_process(
+        update_story, id=story_id, body=StoryUpdate(assignee_ids=[match.member.id]),
+        repo=StoryRepository(db, org_id), db=db, auth=auth,
+    )
+    if exc is not None:
+        outcome = "not_found" if exc.status_code == 404 else "denied"
+        return CommandOutcome(outcome, f"'/assign' 실패 — {_denial_reason(exc)}", target_type="story", target_id=story_id, before_value=str(before) if before else None, reason=_denial_reason(exc))
+    return CommandOutcome(
+        "executed", f"'/assign' 완료 — {match.member.name}에게 배정됐습니다.\n다음: 결과를 확인하세요.",
+        target_type="story", target_id=story_id, before_value=str(before) if before else None, after_value=str(match.member.id),
+    )
+
+
+CATALOG: dict[str, Callable] = {"done": _execute_done, "assign": _execute_assign, "priority": _execute_priority}
+
+
+async def try_execute_server_command(
+    db: AsyncSession, *, org_id: uuid.UUID, conv: Conversation, msg: ConversationMessage, sender,
+) -> bool:
+    """카탈로그 명중이면 집행+감사+결과카드까지 전부 처리하고 True. 미명중(카탈로그 밖
+    커맨드·비-커맨드 메시지)이면 아무것도 안 하고 False — 호출자는 기존 경로(capability
+    gate·에이전트-매개)를 그대로 진행한다(회귀 0). `_command_capability_gate`와 동형으로
+    이 함수 자신이 `classify_command()`를 부른다(판정은 이 모듈이 새로 안 하고 그대로
+    재사용 — 호출부가 후보를 이중 스레딩할 필요 없음)."""
+    from app.services.command_classifier import classify_command
+
+    candidate = classify_command(msg.content)
+    if candidate is None or candidate.name not in CATALOG or not conv.project_id:
+        return False
+
+    auth = _synthetic_auth_for_sender(sender, org_id)
+    handler = CATALOG[candidate.name]
+    try:
+        if candidate.name == "assign":
+            result = await handler(db, org_id=org_id, project_id=conv.project_id, auth=auth, candidate=candidate)
+        else:
+            result = await handler(db, org_id=org_id, auth=auth, candidate=candidate, project_id=conv.project_id)
+    except Exception:  # noqa: BLE001 — 집행 실패가 메시지 전송 자체를 막으면 안 된다(best-effort 회신).
+        logger.warning("서버 집행 커맨드 처리 중 예외 command=%s message=%s", candidate.name, msg.id, exc_info=True)
+        result = CommandOutcome("denied", f"'/{candidate.name}' 처리 중 오류가 발생했습니다.", reason="internal_error")
+
+    db.add(ChatCommandAuditLog(
+        org_id=org_id, project_id=conv.project_id, conversation_id=conv.id, message_id=msg.id,
+        actor_id=sender.id, actor_type=getattr(sender, "type", "human") or "human",
+        command=candidate.name, raw_args=candidate.args,
+        target_type=result.target_type, target_id=result.target_id, outcome=result.outcome,
+        before_value=result.before_value, after_value=result.after_value, reason=result.reason,
+    ))
+
+    try:
+        from app.routers.conversations import _dispatch_conversation_event
+        from app.services.member_resolver import lookup_members_by_ids
+
+        sender_resolved = (await lookup_members_by_ids({sender.id}, db)).get(sender.id)
+        reply = ConversationMessage(
+            conversation_id=conv.id, sender_id=sender.id, content=result.reply_content,
+            mentioned_ids=[sender.id],
+            msg_metadata={"activation": {"kind": "result", "audience": [str(sender.id)], "expects_response": False}},
+        )
+        db.add(reply)
+        await db.flush()
+        if sender_resolved is not None:
+            await _dispatch_conversation_event(db, conv, reply, org_id, sender_resolved)
+    except Exception:  # noqa: BLE001 — 회신 배달 실패가 집행 자체(이미 위에서 끝남)를 되돌리지 않는다.
+        logger.warning("서버 집행 커맨드 결과 카드 배달 실패(비차단) command=%s message=%s", candidate.name, msg.id, exc_info=True)
+
+    return True

--- a/backend/tests/test_3143_chat_server_command_catalog.py
+++ b/backend/tests/test_3143_chat_server_command_catalog.py
@@ -1,0 +1,569 @@
+"""story #3143(9a5abc24, Chat ②층·P1·BE) — 서버 집행 커맨드 카탈로그(/done·/assign·/priority) 실 PG 검증.
+
+축: ①카탈로그 명중 시 실제 story 뮤테이션(권한=발신자 기존 API 권한 그대로, 새 판정 없음)
+②실패(권한거부·미존재·모호·인자오류) 전부 명시 outcome+회신(침묵 0) ③전 건 audit log
+④결과 회신 = message_kind=result(3존 카드 레일 — 텍스트 어휘만으로 렌더, 새 스키마 0)
+⑤미명중(카탈로그 밖 커맨드·비-커맨드)은 완전 무부작용(회귀 0) ⑥HTTP 왕복(진짜 send_message
+엔드포인트를 통해 human 발신 1건)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org3143", slug=f"org3143-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_team_member(session, org_id, project_id, *, type_="human", name="member", user_id=None, is_active=True):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type=type_, name=name,
+        user_id=user_id or (uuid.uuid4() if type_ == "human" else None), is_active=is_active,
+    )
+    session.add(m)
+    await session.commit()
+    if type_ == "agent":
+        # ⚠️real dev/prod에선 team_members가 members⋈project_access UNION 뷰라 agent 행은
+        # Member.id==TeamMember.id로 자동 투영되지만, 이 테스트는 create_all(진짜 테이블)이라
+        # 자동 투영이 없다 — project_auth._project_access_predicate의 agent_grant_branch가
+        # ProjectAccess.member_id→Member.id(type='agent')를 직접 요구하므로 수동으로 짝을
+        # 맞춰준다(같은 id를 그대로 재사용 — 실 뷰의 투영 규칙과 동형).
+        from app.models.member import Member
+        from app.models.project_access import ProjectAccess
+
+        session.add(Member(id=m.id, org_id=org_id, type="agent", name=name))
+        await session.commit()
+        session.add(ProjectAccess(
+            id=uuid.uuid4(), project_id=project_id, org_member_id=None,
+            member_id=m.id, permission="granted", role="member",
+        ))
+        await session.commit()
+    return m
+
+
+async def _seed_story(session, org_id, project_id, *, priority="medium", status="in-progress"):
+    from app.models.pm import Story
+    from sqlalchemy import select as _select, func as _func
+    max_num = (await session.execute(
+        _select(_func.coalesce(_func.max(Story.story_number), 0)).where(Story.project_id == project_id)
+    )).scalar_one()
+    story = Story(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="T",
+        status=status, priority=priority, story_number=max_num + 1,
+    )
+    session.add(story)
+    await session.commit()
+    return story
+
+
+async def _seed_conversation(session, org_id, project_id, member_ids):
+    from app.models.conversation import Conversation, ConversationParticipant
+
+    conv = Conversation(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="group")
+    session.add(conv)
+    await session.flush()
+    for mid in member_ids:
+        session.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+    await session.commit()
+    return conv
+
+
+async def _seed_message(session, conv_id, sender_id, content):
+    from app.models.conversation import ConversationMessage
+
+    msg = ConversationMessage(conversation_id=conv_id, sender_id=sender_id, content=content)
+    session.add(msg)
+    await session.commit()
+    return msg
+
+
+def _classify(text):
+    from app.services.command_classifier import classify_command
+    return classify_command(text)
+
+
+# ── 카탈로그 명중: 실행 성공 ────────────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_done_command_transitions_story_and_posts_result_card():
+    from app.services.chat_command_catalog import try_execute_server_command
+    from app.models.chat_command_audit_log import ChatCommandAuditLog
+    from app.models.conversation import ConversationMessage
+    from app.models.pm import Story
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender = await _seed_team_member(s, org_id, project_id, name="sender")
+            story = await _seed_story(s, org_id, project_id, status="in-review")
+            conv = await _seed_conversation(s, org_id, project_id, [sender.id])
+            msg = await _seed_message(s, conv.id, sender.id, f"/done {story.story_number}")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=sender)
+            await s.commit()
+
+            assert executed is True
+            await s.refresh(story)
+            assert story.status == "done"
+
+            audit = (await s.execute(
+                select(ChatCommandAuditLog).where(ChatCommandAuditLog.message_id == msg.id)
+            )).scalars().one()
+            assert audit.outcome == "executed"
+            assert audit.command == "done"
+            assert audit.target_id == story.id
+            assert audit.after_value == "done"
+
+            replies = (await s.execute(
+                select(ConversationMessage).where(
+                    ConversationMessage.conversation_id == conv.id, ConversationMessage.id != msg.id,
+                )
+            )).scalars().all()
+            assert len(replies) == 1
+            reply = replies[0]
+            assert reply.msg_metadata["activation"]["kind"] == "result"
+            assert "완료" in reply.content
+            assert "다음:" in reply.content
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_priority_command_updates_priority():
+    from app.services.chat_command_catalog import try_execute_server_command
+    from app.models.chat_command_audit_log import ChatCommandAuditLog
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender = await _seed_team_member(s, org_id, project_id)
+            story = await _seed_story(s, org_id, project_id, priority="medium")
+            conv = await _seed_conversation(s, org_id, project_id, [sender.id])
+            msg = await _seed_message(s, conv.id, sender.id, f"/priority {story.story_number} high")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=sender)
+            await s.commit()
+
+            assert executed is True
+            await s.refresh(story)
+            assert story.priority == "high"
+            audit = (await s.execute(
+                select(ChatCommandAuditLog).where(ChatCommandAuditLog.message_id == msg.id)
+            )).scalars().one()
+            assert audit.outcome == "executed"
+            assert audit.before_value == "medium"
+            assert audit.after_value == "high"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_assign_command_by_exact_name():
+    from app.services.chat_command_catalog import try_execute_server_command
+    from sqlalchemy import select
+    from app.models.pm import Story
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender = await _seed_team_member(s, org_id, project_id, name="sender")
+            target_member = await _seed_team_member(s, org_id, project_id, name="Mirko")
+            story = await _seed_story(s, org_id, project_id)
+            conv = await _seed_conversation(s, org_id, project_id, [sender.id, target_member.id])
+            msg = await _seed_message(s, conv.id, sender.id, f"/assign {story.story_number} Mirko")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=sender)
+            await s.commit()
+
+            assert executed is True
+            refreshed = (await s.execute(select(Story).where(Story.id == story.id))).scalar_one()
+            assert refreshed.assignee_id == target_member.id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_assign_command_by_unique_prefix():
+    from app.services.chat_command_catalog import try_execute_server_command
+    from sqlalchemy import select
+    from app.models.pm import Story
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender = await _seed_team_member(s, org_id, project_id, name="sender")
+            target_member = await _seed_team_member(s, org_id, project_id, name="Santiago")
+            story = await _seed_story(s, org_id, project_id)
+            conv = await _seed_conversation(s, org_id, project_id, [sender.id, target_member.id])
+            msg = await _seed_message(s, conv.id, sender.id, f"/assign {story.story_number} San")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=sender)
+            await s.commit()
+
+            assert executed is True
+            refreshed = (await s.execute(select(Story).where(Story.id == story.id))).scalar_one()
+            assert refreshed.assignee_id == target_member.id
+    finally:
+        await engine.dispose()
+
+
+# ── 실패 경로: 명시 회신·무-뮤테이션 ────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_assign_ambiguous_prefix_lists_candidates_and_does_not_mutate():
+    from app.services.chat_command_catalog import try_execute_server_command
+    from app.models.chat_command_audit_log import ChatCommandAuditLog
+    from app.models.conversation import ConversationMessage
+    from sqlalchemy import select
+    from app.models.pm import Story
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender = await _seed_team_member(s, org_id, project_id, name="sender")
+            m1 = await _seed_team_member(s, org_id, project_id, name="Santiago")
+            m2 = await _seed_team_member(s, org_id, project_id, name="Santi")
+            story = await _seed_story(s, org_id, project_id)
+            conv = await _seed_conversation(s, org_id, project_id, [sender.id, m1.id, m2.id])
+            msg = await _seed_message(s, conv.id, sender.id, f"/assign {story.story_number} San")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=sender)
+            await s.commit()
+
+            assert executed is True
+            refreshed = (await s.execute(select(Story).where(Story.id == story.id))).scalar_one()
+            assert refreshed.assignee_id is None, "모호하면 절대 집행하지 않는다"
+
+            audit = (await s.execute(
+                select(ChatCommandAuditLog).where(ChatCommandAuditLog.message_id == msg.id)
+            )).scalars().one()
+            assert audit.outcome == "ambiguous"
+
+            reply = (await s.execute(
+                select(ConversationMessage).where(
+                    ConversationMessage.conversation_id == conv.id, ConversationMessage.id != msg.id,
+                )
+            )).scalars().one()
+            assert "Santiago" in reply.content and "Santi" in reply.content
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_priority_invalid_level_rejected_without_mutation():
+    from app.services.chat_command_catalog import try_execute_server_command
+    from app.models.chat_command_audit_log import ChatCommandAuditLog
+    from sqlalchemy import select
+    from app.models.pm import Story
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender = await _seed_team_member(s, org_id, project_id)
+            story = await _seed_story(s, org_id, project_id, priority="medium")
+            conv = await _seed_conversation(s, org_id, project_id, [sender.id])
+            msg = await _seed_message(s, conv.id, sender.id, f"/priority {story.story_number} urgent")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=sender)
+            await s.commit()
+
+            assert executed is True
+            refreshed = (await s.execute(select(Story).where(Story.id == story.id))).scalar_one()
+            assert refreshed.priority == "medium", "알 수 없는 우선순위는 절대 반영되지 않는다"
+            audit = (await s.execute(
+                select(ChatCommandAuditLog).where(ChatCommandAuditLog.message_id == msg.id)
+            )).scalars().one()
+            assert audit.outcome == "invalid_args"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_done_unknown_story_number_not_found_no_mutation():
+    from app.services.chat_command_catalog import try_execute_server_command
+    from app.models.chat_command_audit_log import ChatCommandAuditLog
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender = await _seed_team_member(s, org_id, project_id)
+            conv = await _seed_conversation(s, org_id, project_id, [sender.id])
+            msg = await _seed_message(s, conv.id, sender.id, "/done 999999")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=sender)
+            await s.commit()
+
+            assert executed is True
+            audit = (await s.execute(
+                select(ChatCommandAuditLog).where(ChatCommandAuditLog.message_id == msg.id)
+            )).scalars().one()
+            assert audit.outcome == "invalid_args", "존재하지 않는 story_number는 애초에 참조 해석 단계에서 걸러진다"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_no_project_access_sender_denied_no_mutation():
+    """발신자가 이 project에 접근권이 없으면(다른 project 소속) — 기존 API 권한과 동일하게
+    거부되고(existence-hiding 404 정책 그대로 상속 — outcome="not_found") 뮤테이션은 없다."""
+    from app.services.chat_command_catalog import try_execute_server_command
+    from app.models.chat_command_audit_log import ChatCommandAuditLog
+    from sqlalchemy import select
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            other_project = Project(id=uuid.uuid4(), org_id=org_id, name="Other")
+            s.add(other_project)
+            await s.commit()
+            # sender는 other_project 소속 TeamMember뿐 — target story의 project_id엔 접근권 없음.
+            sender = await _seed_team_member(s, org_id, other_project.id, name="outsider")
+            story = await _seed_story(s, org_id, project_id, status="in-review")
+            conv = await _seed_conversation(s, org_id, project_id, [])  # sender는 이 conv 참가자도 아님(catalog 자체는 참가자 검증을 안 함 — send_message가 그 축은 이미 처리)
+            msg = await _seed_message(s, conv.id, sender.id, f"/done {story.story_number}")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=sender)
+            await s.commit()
+
+            assert executed is True
+            await s.refresh(story)
+            assert story.status == "in-review", "접근권 없는 발신자의 커맨드는 절대 집행되면 안 된다"
+            audit = (await s.execute(
+                select(ChatCommandAuditLog).where(ChatCommandAuditLog.message_id == msg.id)
+            )).scalars().one()
+            assert audit.outcome == "not_found"
+    finally:
+        await engine.dispose()
+
+
+# ── 미명중: 완전 무부작용(회귀 0) ────────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_non_catalog_command_returns_false_no_side_effects():
+    from app.services.chat_command_catalog import try_execute_server_command
+    from app.models.chat_command_audit_log import ChatCommandAuditLog
+    from app.models.conversation import ConversationMessage
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender = await _seed_team_member(s, org_id, project_id)
+            conv = await _seed_conversation(s, org_id, project_id, [sender.id])
+            msg = await _seed_message(s, conv.id, sender.id, "/help")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=sender)
+            await s.commit()
+
+            assert executed is False
+            assert (await s.execute(select(ChatCommandAuditLog))).scalars().all() == []
+            other_msgs = (await s.execute(
+                select(ConversationMessage).where(ConversationMessage.id != msg.id)
+            )).scalars().all()
+            assert other_msgs == []
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_plain_message_returns_false_no_side_effects():
+    from app.services.chat_command_catalog import try_execute_server_command
+    from app.models.chat_command_audit_log import ChatCommandAuditLog
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender = await _seed_team_member(s, org_id, project_id)
+            conv = await _seed_conversation(s, org_id, project_id, [sender.id])
+            msg = await _seed_message(s, conv.id, sender.id, "그냥 평범한 메시지인데 done 이 단어가 들어있어도 커맨드 아님")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=sender)
+            await s.commit()
+
+            assert executed is False
+            assert (await s.execute(select(ChatCommandAuditLog))).scalars().all() == []
+    finally:
+        await engine.dispose()
+
+
+# ── 에이전트 발신자 경로 ─────────────────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_agent_sender_can_execute_same_as_human():
+    from app.services.chat_command_catalog import try_execute_server_command
+    from sqlalchemy import select
+    from app.models.pm import Story
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_sender = await _seed_team_member(s, org_id, project_id, type_="agent", name="AgentSender")
+            story = await _seed_story(s, org_id, project_id, status="in-review")
+            conv = await _seed_conversation(s, org_id, project_id, [agent_sender.id])
+            msg = await _seed_message(s, conv.id, agent_sender.id, f"/done {story.story_number}")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=agent_sender)
+            await s.commit()
+
+            assert executed is True
+            refreshed = (await s.execute(select(Story).where(Story.id == story.id))).scalar_one()
+            assert refreshed.status == "done"
+    finally:
+        await engine.dispose()
+
+
+# ── entity mention 토큰으로 story 참조 ──────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_done_with_entity_mention_story_ref():
+    from app.services.chat_command_catalog import try_execute_server_command
+    from sqlalchemy import select
+    from app.models.pm import Story
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            sender = await _seed_team_member(s, org_id, project_id)
+            story = await _seed_story(s, org_id, project_id, status="in-review")
+            conv = await _seed_conversation(s, org_id, project_id, [sender.id])
+            msg = await _seed_message(s, conv.id, sender.id, f"/done [스토리 제목](entity:story:{story.id})")
+
+            executed = await try_execute_server_command(s, org_id=org_id, conv=conv, msg=msg, sender=sender)
+            await s.commit()
+
+            assert executed is True
+            refreshed = (await s.execute(select(Story).where(Story.id == story.id))).scalar_one()
+            assert refreshed.status == "done"
+    finally:
+        await engine.dispose()
+
+
+# ── 진짜 HTTP 왕복(휴먼 발신) ────────────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_http_round_trip_human_sends_done_command():
+    """진짜 POST /api/v2/conversations/{id}/messages 엔드포인트를 통해 human 발신
+    '/done'이 실제로 story를 전이시키고 result 카드까지 남기는지(AC6 절반 — 나머지 절반인
+    에이전트 발신+dev 라이브 검증은 별도)."""
+    from app.main import app
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+    from app.routers.conversations import get_verified_org_id
+    from tests.conftest import override_db_and_read
+    from httpx import AsyncClient, ASGITransport
+    from sqlalchemy import select
+    from app.models.pm import Story
+    from app.models.conversation import ConversationMessage
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            human_user_id = uuid.uuid4()
+            sender = await _seed_team_member(s, org_id, project_id, name="human-sender", user_id=human_user_id)
+            story = await _seed_story(s, org_id, project_id, status="in-review")
+            conv = await _seed_conversation(s, org_id, project_id, [sender.id])
+
+        async def _db():
+            async with Session() as s:
+                try:
+                    yield s
+                    await s.commit()
+                except Exception:
+                    await s.rollback()
+                    raise
+
+        async def _auth():
+            return AuthContext(user_id=str(human_user_id), email="human@test", claims={"app_metadata": {}})
+
+        async def _org():
+            return org_id
+
+        override_db_and_read(app, _db)
+        app.dependency_overrides[get_current_user] = _auth
+        app.dependency_overrides[get_verified_org_id] = _org
+
+        client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+        try:
+            resp = await client.post(
+                f"/api/v2/conversations/{conv.id}/messages",
+                json={"content": f"/done {story.story_number}"},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            refreshed = (await s.execute(select(Story).where(Story.id == story.id))).scalar_one()
+            assert refreshed.status == "done"
+            msgs = (await s.execute(
+                select(ConversationMessage).where(ConversationMessage.conversation_id == conv.id)
+            )).scalars().all()
+            result_msgs = [m for m in msgs if (m.msg_metadata or {}).get("activation", {}).get("kind") == "result"]
+            assert len(result_msgs) == 1
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3143_chat_server_command_catalog.py
+++ b/backend/tests/test_3143_chat_server_command_catalog.py
@@ -167,6 +167,7 @@ async def test_done_command_transitions_story_and_posts_result_card():
             # PO 리뷰 델타(2026-08-27) — FE(#92f00dc4)가 텍스트 휴리스틱 없이 이 카드를
             # 판별하는 기계 식별자. approval_target/event와 동일 additive namespace.
             assert reply.msg_metadata["server_command"] == {"command": "done", "outcome": "executed"}
+            assert "candidates" not in reply.msg_metadata["server_command"], "candidates는 ambiguous 전용 — 다른 outcome엔 키 자체가 없어야 한다"
     finally:
         await engine.dispose()
 
@@ -296,7 +297,11 @@ async def test_assign_ambiguous_prefix_lists_candidates_and_does_not_mutate():
                 )
             )).scalars().one()
             assert "Santiago" in reply.content and "Santi" in reply.content
-            assert reply.msg_metadata["server_command"] == {"command": "assign", "outcome": "ambiguous"}
+            # PO 리뷰 델타 2회차(2026-08-27, 미르코 FE 정독) — FE가 문장 파싱 없이 클릭형
+            # 후보 행을 그리는 축. 순서는 DB 조회 순서에 의존하지 않게 집합으로 비교.
+            sc = reply.msg_metadata["server_command"]
+            assert sc["command"] == "assign" and sc["outcome"] == "ambiguous"
+            assert set(sc["candidates"]) == {"Santiago", "Santi"}
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_3143_chat_server_command_catalog.py
+++ b/backend/tests/test_3143_chat_server_command_catalog.py
@@ -168,6 +168,7 @@ async def test_done_command_transitions_story_and_posts_result_card():
             # 판별하는 기계 식별자. approval_target/event와 동일 additive namespace.
             assert reply.msg_metadata["server_command"] == {"command": "done", "outcome": "executed"}
             assert "candidates" not in reply.msg_metadata["server_command"], "candidates는 ambiguous 전용 — 다른 outcome엔 키 자체가 없어야 한다"
+            assert "target_story_number" not in reply.msg_metadata["server_command"], "target_story_number도 ambiguous 전용"
     finally:
         await engine.dispose()
 
@@ -302,6 +303,9 @@ async def test_assign_ambiguous_prefix_lists_candidates_and_does_not_mutate():
             sc = reply.msg_metadata["server_command"]
             assert sc["command"] == "assign" and sc["outcome"] == "ambiguous"
             assert set(sc["candidates"]) == {"Santiago", "Santi"}
+            # PO 리뷰 델타 3회차(2026-08-27) — 후보 클릭이 "/assign #<번호> <이름>"으로
+            # 채워지려면 원 스토리 번호가 필요하다(story_id는 UUID라 사람이 못 타이핑).
+            assert sc["target_story_number"] == story.story_number
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_3143_chat_server_command_catalog.py
+++ b/backend/tests/test_3143_chat_server_command_catalog.py
@@ -164,6 +164,9 @@ async def test_done_command_transitions_story_and_posts_result_card():
             assert reply.msg_metadata["activation"]["kind"] == "result"
             assert "완료" in reply.content
             assert "다음:" in reply.content
+            # PO 리뷰 델타(2026-08-27) — FE(#92f00dc4)가 텍스트 휴리스틱 없이 이 카드를
+            # 판별하는 기계 식별자. approval_target/event와 동일 additive namespace.
+            assert reply.msg_metadata["server_command"] == {"command": "done", "outcome": "executed"}
     finally:
         await engine.dispose()
 
@@ -293,6 +296,7 @@ async def test_assign_ambiguous_prefix_lists_candidates_and_does_not_mutate():
                 )
             )).scalars().one()
             assert "Santiago" in reply.content and "Santi" in reply.content
+            assert reply.msg_metadata["server_command"] == {"command": "assign", "outcome": "ambiguous"}
     finally:
         await engine.dispose()
 
@@ -553,6 +557,14 @@ async def test_http_round_trip_human_sends_done_command():
                 json={"content": f"/done {story.story_number}"},
             )
             assert resp.status_code == 201, resp.text
+
+            # PO 리뷰 델타(2026-08-27) — GET 목록 응답에도 server_command가 top-level로
+            # 노출되는지(FE #92f00dc4가 실제로 소비하는 자리) 진짜 HTTP 왕복으로 고정.
+            list_resp = await client.get(f"/api/v2/conversations/{conv.id}/messages")
+            assert list_resp.status_code == 200, list_resp.text
+            result_items = [m for m in list_resp.json()["data"] if m.get("message_kind") == "result"]
+            assert len(result_items) == 1
+            assert result_items[0]["server_command"] == {"command": "done", "outcome": "executed"}
         finally:
             await client.aclose()
 


### PR DESCRIPTION
[SID:3143]

## 배경
사부님 승인(2026-08-27 채팅 결재 — 카드 배달 결함 #3142로 텍스트 승인이 정본, 09:11 「진행하기 바라는」). doc `chat-action-messages-round1-draft`(v6) §"서버 집행 커맨드" 확定분 — 결정적 엔티티 조작(/done·/assign·/priority)만 서버가 직접 집행, 복합 지시는 현행 에이전트-매개 유지.

## 설계 앵커(신규 발명 0)
- **판정**: 기존 `command_classifier.classify_command()` 결과의 `name`이 카탈로그에 정확히 일치할 때만 진입. 미명중은 기존 capability-gate/에이전트-매개 경로 그대로(회귀 0).
- **권한 = 발신자의 기존 API 권한 그대로**: `app.routers.stories`의 `update_story_status`/`update_story` 엔드포인트 함수를 in-process로 그대로 호출(재구현 0, 새 권한 판정 없음). HTTP 컨텍스트 밖에서 엔드포인트를 부르는 관용구는 `app.routers.events.publish_preset_event`가 이미 쓰는 패턴과 동형(자체 `BackgroundTasks()` 생성+수동 실행). 발신자→합성 AuthContext 매핑은 `project_auth._project_access_predicate`의 human 분기(`TeamMember.id`/`user_id` 양쪽 매치)가 그대로 받아준다.
- **인자 해석**: story#는 bare 번호·`entity:story:` 멘션 토큰 둘 다 수용. 멤버는 정확명 우선·유일 prefix만(모호하면 후보 나열, 절대 집행 안 함).
- **실패 명시**: 권한거부·미존재·모호·인자오류 전부 명시 outcome + 회신(침묵 0).
- **결과 회신**: `message_kind="result"` 자연어 텍스트 — story #5c29454b가 이미 라이브에 올린 3존 카드 레일(`deriveVerdictTone`/`extractNextAction`, 순수 텍스트 렌더 변환)을 그대로 태운다. **새 JSON 스키마 0**.
- **감사**: 전 건 `ChatCommandAuditLog`(신규 테이블, migration 0285) 기록 — 기존 `agent_audit_logs`(agent_id NOT NULL, 휴먼 발신 못 담음)·`permission_audit_logs`(role 변경 전용 스키마) 둘 다 이 도메인과 안 맞아 분리.
- **이중 집행 방지**: 서버가 이미 집행한 메시지는 이 conversation의 다른 에이전트 참가자를 기존 capability-gate의 `blocked_agent_ids`에 합쳐 dispatch에서 제외(에이전트가 같은 커맨드를 자연어로 재해석해 중복 집행하는 것 방지) — 새 exclude 축 발명 0.

## 테스트
- `test_3143_chat_server_command_catalog.py`(13건, 실PG): 성공 3종(done/assign 정확명/assign prefix)·priority 값 변경·실패 4종(모호·존재하지않는 인자·우선순위값 오류·프로젝트 접근권 없음)·미명중 2종(카탈로그 밖 커맨드·비-커맨드, 완전 무부작용)·에이전트 발신자 경로·entity mention story 참조·**진짜 HTTP 왕복**(POST /messages → 실제 story 전이+result 카드 확인).
- migration 0285: 로컬 실PG에 upgrade/downgrade 직접 구동 검증(env.py/pgvector 우회, Operations API) — 컬럼/인덱스/downgrade 원복 전부 확認.
- 핵심 가드 2종 뮤테이션 테스트: ①권한거부 우회 시도(exc 무시) → genuine RED ②모호 매칭 우회 시도(prefix 여러 개 중 아무거나 선택) → genuine RED. 둘 다 원복 후 GREEN.
- 관련 기존 회귀스윕: `test_command_classifier.py`(28)·`test_agent_runtime_capability.py`(10)·`test_conversations.py`(20)·`test_human_intervention_270c87e6.py`(5) 전부 그린. 나머지 스윕 대상 파일은 baseline(내 변경 반영 전 conversations.py로 patch 제거 후 재확인)에서도 동일하게 재현되는 기존 test-DB 환경 갭(`_reset_schema_for_destructive_tests`/스키마 미생성류)이라 회귀 아님을 확인.
- AST 가드 lint 5종 무위반.

## 남은 것
AC6(라이브 검증: 휴먼 발신 1건+에이전트 발신 1건, dev)은 PR 머지·배포 후 진행. FE 짝 스토리(#3144, 자동완성 chip+결과 카드 UI, 미르코 담당)는 별도 트랙.

## Test plan
- [x] 신규 realdb 테스트 13건 GREEN
- [x] migration 0285 upgrade/downgrade 실PG 검증
- [x] 뮤테이션 테스트(권한거부·모호매칭) genuine RED 확인 후 복원
- [x] 관련 기존 테스트 회귀스윕 + baseline 대조로 무관 확인
- [x] AST 가드 lint 5종 무위반
- [ ] dev 라이브 왕복(휴먼+에이전트 각 1건) — 머지 후