### PR TITLE
보드재설계 BE — 침묵의 정체(stalled) 신호 신설

### DIFF
--- a/backend/app/routers/glance.py
+++ b/backend/app/routers/glance.py
@@ -1,10 +1,21 @@
 """글랜스 '손이 필요한 것' 예외 스트림 BE (story db7eb049·E-GLANCE 2D).
 
 현 프로젝트의 human-attention **실신호만** 반환한다 — gate_pending(인간 승인 대기)·blocked(의존 대기)·
-merge_ready(리뷰/머지 대기)·needs_input·verify_fail. 유나 spec(glance-focus-legible-fe-spec-handoff
-ⓓ) 계약: 활동량/순위 0·감시 아니라 신뢰(주어=프로젝트/팀·예외만)·실신호 없으면 정직 빈배열(FE
-"손 필요한 것 없음"). 5 신호 전부 project_id 직스코프(approval.project_id·story.project_id 직결·
-조인은 title enrich만).
+merge_ready(리뷰/머지 대기)·needs_input·verify_fail·stalled(침묵의 정체, story #2250). 유나 spec
+(glance-focus-legible-fe-spec-handoff ⓓ) 계약: 활동량/순위 0·감시 아니라 신뢰(주어=프로젝트/팀·예외만)·
+실신호 없으면 정직 빈배열(FE "손 필요한 것 없음"). 6 신호 전부 project_id 직스코프(approval.
+project_id·story.project_id 직결·조인은 title enrich만).
+
+story #2250(⛔"침묵의 정체", doc `flow-board-blocked-taxonomy`) — 1~5(여기선 표시상 6종 중
+gate_pending/blocked/merge_ready/needs_input/verify_fail)는 전부 "스스로를 선언"하는 막힘이다.
+그 무엇도 아니면서 오랫동안 무변화인 항목은 화면에서 완전히 사라졌다(1~5만 그리면 "막힌 것
+없음"이라 거짓말하게 됨) — 그 빈자리를 stalled가 메운다. 정의(오르테가군 확定, 페드루 GO
+2026-08-27): `StoryActivity(activity_type=status_changed)` 최신 시각(㉠좁은 정의) 기준 48h+
+무변화. 모집단은 backlog 제외 활성(in-review/in-progress/ready-for-dev만 — backlog은 "아직
+시작 안 함"이지 "멈춰 섬"이 아니다, #2250 §6-1 실측) 중 위 5종에 이미 잡힌 story_id는 제외
+(AC5 — 7번을 1~6과 섞지 않는다). ⛔BE는 이 신호를 자르지 않는다(top-N 없음, 전량 반환) —
+"8~12건 표시"는 화면 설계(유나) 몫이지 신호의 정의가 아니다(페드루 판정 2026-08-27, #2250
+재실측이 분포에 깨끗한 단층이 없음을 보여줌 — 자르면 그 잘림 자체가 새로운 침묵이 된다).
 
 story #2249: 「그 상태에 들어간 시각」(entered_state_at) — kind별 소스가 다르다(전수):
   gate_pending → WorkflowLineStepApproval.created_at(row가 매 사이클 새 INSERT라 정확) — exact
@@ -32,7 +43,7 @@ story #2249: 「그 상태에 들어간 시각」(entered_state_at) — kind별 
 옵셔널 필드(모르는 필드 무시가 기본 — 회귀 0).
 """
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -62,6 +73,19 @@ _LIMIT = 100
 # story #2249(오르테가군 리뷰): entered_state_at의 정밀도 — 모듈 docstring 참조.
 _PRECISION_EXACT = "exact"
 
+# story #2250 — stalled 모집단(backlog은 "아직 시작 안 함"이지 "멈춰 섬"이 아니라 별도 제외 —
+# _OPEN_EXCLUDED_STATUSES와 다른 축이라 이름을 안 겹친다).
+_STALLED_EXCLUDED_STATUSES = ("done", "backlog")
+
+# ⛔⛔story #2250 AC3-1(유나 발견·규율, 2026-07-28) — "N은 한 번 정하면 고정한다":
+# 8~12건이 뜨는 지점을 계속 "유지"하려고 이 값을 계속 올리면, 막힘이 늘어도 임계가 따라
+# 올라가 화면은 늘 비슷한 건수만 보여주게 되고 그 순간 이 지표는 자기충족이 되어 "막힘을
+# 감추는 손잡이"가 된다. 48h는 페드루 확定값(2026-08-27, #2250 재실측 — 모집단 123건 중
+# 48h+ 81건·분포에 깨끗한 단층 없음을 근거로 「자르지 않고 전량 낸다」로 판정. 표시 단의
+# top-N/집계 배지는 유나 몫). 이 값을 다시 재는 사유는 "건수가 많아져서"가 아니라 "작업
+# 방식이 바뀌어서"여야 한다.
+_STALLED_THRESHOLD_HOURS = 48
+
 
 async def _batch_story_entered_in_review_at(
     session: AsyncSession, org_id: uuid.UUID, story_ids: list[uuid.UUID],
@@ -86,15 +110,44 @@ async def _batch_story_entered_in_review_at(
     return {story_id: entered_at for story_id, entered_at in rows}
 
 
+async def _batch_latest_status_changed_at(
+    session: AsyncSession, org_id: uuid.UUID, story_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, datetime]:
+    """story #2250 stalled 신호원 — `_batch_story_entered_in_review_at`과 동형이나 `new_value`
+    필터가 없다(어느 상태로 전이했든 "가장 최근 상태 변화" 그 자체가 관심사 — ㉠좁은 정의,
+    #2250 §"측정 준비" 오르테가군 확定). 행이 아예 없는 story는 반환 dict에서 빠진다 —
+    "그 story는 언제 마지막으로 바뀌었는지 모른다"는 뜻이라 호출부가 별도로 None 취급한다
+    (created_at 등으로 대체해 추측하지 않는다 — blocked 신호와 동일 "모르면 안 준다" 원칙)."""
+    if not story_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(StoryActivity.story_id, func.max(StoryActivity.created_at))
+            .where(
+                StoryActivity.org_id == org_id,
+                StoryActivity.story_id.in_(story_ids),
+                StoryActivity.activity_type == "status_changed",
+            )
+            .group_by(StoryActivity.story_id)
+        )
+    ).all()
+    return {story_id: latest for story_id, latest in rows}
+
+
 class AttentionItem(BaseModel):
     # P0-04(doc trust-pipeline-be-design §6): AQ 5신호 계약(attention-queue-fe-spec-handoff §6).
     # scope_violation은 §7 확定②로 이번 스코프 미구현 — 항상 빈 신호(kind로 등장 안 함·정직한 미가용).
-    kind: str  # "gate_pending" | "blocked" | "merge_ready" | "needs_input" | "verify_fail"
+    # stalled(story #2250, 2026-08-27)는 6번째 신호 — 위 5종과 달리 "스스로를 선언"하지 않는
+    # 무변화 항목이라 AC5(섞지 않는다)에 따라 kind로 명확히 구분해 낸다.
+    kind: str  # "gate_pending" | "blocked" | "merge_ready" | "needs_input" | "verify_fail" | "stalled"
     story_id: uuid.UUID | None = None
     title: str | None = None
     ref: dict = Field(default_factory=dict)
     # story #2249: 「그 상태에 들어간 시각」(UTC·마지막 진입). 소스는 kind별로 다름(모듈 docstring
     # 참조) — 원천이 아예 없거나(edge case) 조회 실패 시 None(옵셔널·모르는 필드 무시가 기본).
+    # stalled: 「마지막으로 무언가 바뀐 시각」(StoryActivity status_changed 최신) — 소비자가
+    # `now - entered_state_at`으로 무변화 일수를 직접 계산한다(페드루 판정 2026-08-27 —
+    # 별도 "일수" 필드를 새로 만들지 않는다, 기존 필드 재사용).
     entered_state_at: datetime | None = None
     # 오르테가군 리뷰(2026-07-28): "근사"가 화면에서 "정확"처럼 보이면 유나 설계(체류시간이
     # 위계를 만든다)의 정렬 신뢰가 무너진다 — 값과 함께 정밀도를 싣는다. "exact"|None만 존재
@@ -105,6 +158,12 @@ class AttentionItem(BaseModel):
 
 class AttentionResponse(BaseModel):
     items: list[AttentionItem]
+    # story #2250 AC6 — "0건일 때의 의미를 정한다: 정말 없음인가 못 세고 있음인가." stalled가
+    # 0건이어도 이 필드가 항상 채워져 있으면 "계산이 실제로 돌았다"는 증거가 된다(계산 자체가
+    # 실패했다면 이 응답을 만들 수 없었을 것이므로 — 이 필드는 항상 datetime.now(UTC), None을
+    # 반환할 일이 없다. 다른 5종 신호와 달리 이 값이 필요한 이유: stalled만 "무신호=진짜 0건"과
+    # "무신호=계산 자체가 안 도는 중"을 구분할 별도 근거가 없다).
+    stalled_computed_at: datetime
 
 
 @router.get("/attention", response_model=AttentionResponse)
@@ -294,7 +353,50 @@ async def glance_attention(
 
     # scope_violation: §7 확定② — 이번 스코프 미구현. 쿼리 자체가 없음(정직한 미가용·항상 빈 신호).
 
-    return AttentionResponse(items=items)
+    # ⑥ stalled = story #2250 "침묵의 정체" — 위 1~5(gate_pending/blocked/merge_ready/
+    # needs_input/verify_fail) 중 무엇도 아니면서 오래 무변화인 항목. AC5(섞지 않는다)에 따라
+    # 위에서 이미 만든 항목의 story_id는 후보에서 뺀다 — 같은 story가 stalled와 다른 kind로
+    # 동시에 뜨면 "할 일 목록"이 "사정 나열"이 된다(유나 규칙, 모듈 docstring 참조).
+    _already_signaled_ids = {item.story_id for item in items if item.story_id is not None}
+    stalled_population_rows = (
+        await session.execute(
+            select(Story.id, Story.title)
+            .where(
+                Story.org_id == org_id,
+                Story.project_id == project_id,
+                Story.status.not_in(_STALLED_EXCLUDED_STATUSES),
+                Story.deleted_at.is_(None),
+            )
+        )
+    ).all()
+    stalled_candidates = [
+        (story_id, title) for story_id, title in stalled_population_rows
+        if story_id not in _already_signaled_ids
+    ]
+    latest_changed_map = await _batch_latest_status_changed_at(
+        session, org_id, [story_id for story_id, _ in stalled_candidates],
+    )
+    _now = datetime.now(timezone.utc)
+    stalled_items: list[AttentionItem] = []
+    for story_id, title in stalled_candidates:
+        latest_changed = latest_changed_map.get(story_id)
+        # 「모르면 안 준다」(blocked와 동일 원칙, 모듈 docstring 참조) — 이 story가 언제
+        # 마지막으로 바뀌었는지 자체를 모르면(status_changed 행이 아예 없음) 48h+ 여부를
+        # 판정할 근거가 없다 — created_at 등으로 대체 추측하지 않고 stalled 후보에서 뺀다.
+        if latest_changed is None:
+            continue
+        if (_now - latest_changed).total_seconds() < _STALLED_THRESHOLD_HOURS * 3600:
+            continue
+        stalled_items.append(AttentionItem(
+            kind="stalled", story_id=story_id, title=title,
+            entered_state_at=latest_changed, entered_state_at_precision=_PRECISION_EXACT,
+        ))
+    # ⛔BE는 top-N으로 자르지 않는다(모듈 docstring·#2250 페드루 판정 2026-08-27) — 무변화
+    # 내림차순(=entered_state_at 오름차순, 가장 오래 안 바뀐 것 먼저)으로 전량 정렬만 한다.
+    stalled_items.sort(key=lambda item: item.entered_state_at)
+    items.extend(stalled_items)
+
+    return AttentionResponse(items=items, stalled_computed_at=_now)
 
 
 # ── hero ProofCapsule envelope (story b464daa1·E-GLANCE 2D) ─────────────────────

--- a/backend/tests/test_2250_stalled_signal_realdb.py
+++ b/backend/tests/test_2250_stalled_signal_realdb.py
@@ -1,0 +1,378 @@
+"""story #2250(93b076c8, "침묵의 정체") 실PG 테스트 — `/api/v2/glance/attention`의 6번째
+신호(kind="stalled"). AC 축: ①정의(StoryActivity status_changed 최신, ㉠좁은) ②48h+ 임계
+③backlog 제외(아직 시작 안 함≠멈춰 섬) ④1~5(gate_pending/blocked/merge_ready/needs_input/
+verify_fail)와 섞지 않음(AC5) ⑤status_changed 행 자체가 없으면 "모르면 안 준다"로 제외
+⑥stalled_computed_at 항상 present(0건이 "정말 없음"과 "계산 안 됨"을 가름) ⑦정렬(가장 오래
+무변화 먼저) ⑧BE는 자르지 않는다(전량 반환).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _story(org_id, project_id, title, status="in-progress"):
+    from app.models.pm import Story
+    return Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status=status)
+
+
+async def _seed_base(session):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(om)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project.id, org_member_id=om.id,
+                               permission="granted", role="member"))
+    await session.commit()
+    return {"org_id": org.id, "project_id": project.id, "caller_id": caller_id}
+
+
+async def _seed_status_changed_activity(session, org_id, project_id, story_id, created_at, new_value="in-progress"):
+    from app.models.pm import StoryActivity
+    row = StoryActivity(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, story_id=story_id,
+        activity_type="status_changed", old_value="backlog", new_value=new_value,
+        created_by=uuid.uuid4(),
+    )
+    session.add(row)
+    await session.flush()
+    # created_at은 server_default=func.now() — 과거 시각을 강제로 심으려면 커밋 후 UPDATE.
+    from sqlalchemy import update
+    from app.models.pm import StoryActivity as SA
+    await session.execute(update(SA).where(SA.id == row.id).values(created_at=created_at))
+    await session.commit()
+    return row
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_stalled_item_surfaces_past_48h_threshold():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story = _story(seeded["org_id"], seeded["project_id"], "Silent Story")
+            s.add(story)
+            await s.commit()
+            old_at = datetime.now(timezone.utc) - timedelta(hours=72)
+            await _seed_status_changed_activity(s, seeded["org_id"], seeded["project_id"], story.id, old_at)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["stalled_computed_at"] is not None
+            item = next(i for i in body["items"] if i["kind"] == "stalled")
+            assert item["story_id"] == str(story.id)
+            got = datetime.fromisoformat(item["entered_state_at"].replace("Z", "+00:00"))
+            assert abs((got - old_at).total_seconds()) < 1
+            assert item["entered_state_at_precision"] == "exact"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_fresh_activity_under_threshold_not_stalled():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story = _story(seeded["org_id"], seeded["project_id"], "Fresh Story")
+            s.add(story)
+            await s.commit()
+            recent_at = datetime.now(timezone.utc) - timedelta(hours=2)
+            await _seed_status_changed_activity(s, seeded["org_id"], seeded["project_id"], story.id, recent_at)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            stalled = [i for i in resp.json()["items"] if i["kind"] == "stalled"]
+            assert stalled == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_backlog_story_never_stalled_even_if_ancient():
+    """backlog은 "아직 시작 안 함"이지 "멈춰 섬"이 아니다(#2250 §6-1) — activity가 아무리
+    오래됐어도(또는 아예 없어도) 모집단에서 빠진다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story = _story(seeded["org_id"], seeded["project_id"], "Backlog Story", status="backlog")
+            s.add(story)
+            await s.commit()
+            ancient_at = datetime.now(timezone.utc) - timedelta(days=100)
+            await _seed_status_changed_activity(s, seeded["org_id"], seeded["project_id"], story.id, ancient_at, new_value="backlog")
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            stalled = [i for i in resp.json()["items"] if i["kind"] == "stalled"]
+            assert stalled == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_status_changed_activity_excluded_not_guessed():
+    """「모르면 안 준다」— status_changed 행이 아예 없는 story는 (created_at 등으로 대체
+    추측하지 않고) stalled 후보에서 그냥 빠진다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story = _story(seeded["org_id"], seeded["project_id"], "No Activity Story")
+            s.add(story)
+            await s.commit()
+            # StoryActivity 행 자체를 안 만든다.
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            stalled = [i for i in resp.json()["items"] if i["kind"] == "stalled"]
+            assert stalled == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_already_merge_ready_signal_excluded_from_stalled():
+    """AC5 — 1~5 중 하나로 이미 뜬 story는 status_changed가 아무리 오래돼도 stalled로
+    또 뜨면 안 된다(섞으면 "할 일 목록"이 "사정 나열"이 된다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story = _story(seeded["org_id"], seeded["project_id"], "Merge Ready + Old Activity", status="in-review")
+            s.add(story)
+            await s.commit()
+            old_at = datetime.now(timezone.utc) - timedelta(hours=200)
+            await _seed_status_changed_activity(s, seeded["org_id"], seeded["project_id"], story.id, old_at, new_value="in-review")
+
+            # merge_ready 자격: human_verified(Evidence gate_approval) + blocker/verify_fail 없음.
+            from app.models.evidence import Evidence
+            s.add(Evidence(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id, work_item_type="story",
+                type="gate_approval", created_by=seeded["caller_id"], ref="",
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["items"]
+            story_items = [i for i in items if i["story_id"] == str(story.id)]
+            kinds = {i["kind"] for i in story_items}
+            assert "merge_ready" in kinds
+            assert "stalled" not in kinds, "이미 merge_ready로 뜬 story가 stalled로도 중복 노출됨"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_stalled_computed_at_present_even_when_zero_items():
+    """AC6 — stalled 0건이어도 stalled_computed_at은 항상 채워져 "계산이 실제로 돌았다"를
+    증명한다(무신호=정말 없음 vs 무신호=계산 안 됨을 가른다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            # 아무 story도 안 만든다 — 진짜 빈 프로젝트.
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["items"] == []
+            assert body["stalled_computed_at"] is not None
+            computed_at = datetime.fromisoformat(body["stalled_computed_at"].replace("Z", "+00:00"))
+            assert (datetime.now(timezone.utc) - computed_at).total_seconds() < 30
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_multiple_stalled_items_sorted_oldest_first_and_no_cap():
+    """⛔BE는 자르지 않는다(top-N 없음) — 전량 반환 + 가장 오래 무변화인 항목이 먼저(내림차순
+    무변화 일수 = entered_state_at 오름차순)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            newer_story = _story(seeded["org_id"], seeded["project_id"], "Newer Stall", status="in-progress")
+            older_story = _story(seeded["org_id"], seeded["project_id"], "Older Stall", status="in-progress")
+            s.add_all([newer_story, older_story])
+            await s.commit()
+            newer_at = datetime.now(timezone.utc) - timedelta(hours=50)
+            older_at = datetime.now(timezone.utc) - timedelta(hours=500)
+            await _seed_status_changed_activity(s, seeded["org_id"], seeded["project_id"], newer_story.id, newer_at)
+            await _seed_status_changed_activity(s, seeded["org_id"], seeded["project_id"], older_story.id, older_at)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            stalled = [i for i in resp.json()["items"] if i["kind"] == "stalled"]
+            assert len(stalled) == 2
+            assert stalled[0]["story_id"] == str(older_story.id), "가장 오래 무변화인 것이 먼저 와야 한다"
+            assert stalled[1]["story_id"] == str(newer_story.id)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_done_story_excluded_from_stalled_population():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story = _story(seeded["org_id"], seeded["project_id"], "Done Story", status="done")
+            s.add(story)
+            await s.commit()
+            old_at = datetime.now(timezone.utc) - timedelta(hours=1000)
+            await _seed_status_changed_activity(s, seeded["org_id"], seeded["project_id"], story.id, old_at, new_value="done")
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            stalled = [i for i in resp.json()["items"] if i["kind"] == "stalled"]
+            assert stalled == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
[SID:2250]

## 배경
doc `flow-board-blocked-taxonomy`(유나) — 「막혔다」의 7종 중 6종은 스스로를 선언하지만(gate_pending/blocked/merge_ready/needs_input/verify_fail) 7번째("침묵의 정체")는 아무 신호도 없다. 1~6만 그리면 화면은 「막힌 것 없음」이라 거짓말하게 된다.

## 재실측(2026-08-27, dev 실DB) — 규모가 완전히 달라짐
- 모집단(backlog 제외 활성): **29건(7/23) → 123건(오늘)**.
- 기존 5신호도 7/23엔 전부 real-0이었으나 지금은 **merge_ready 37·needs_input 2·verify_fail 3**(41건 고유 story) 실신호로 전환.
- stalled 후보(위 41건 제외) = **83건**, 그중 **48h+ 81건(98%)** — 분포에 깨끗한 단층 없음(2주=52건·1개월=16건).
- 7/23 positive control 7건 중 3건은 done으로 해소, 4건은 지금도 살아있고 그중 2건은 각 40일+ 방치 확認.

## 판정(페드루, 2026-08-27)
① 정의 = `StoryActivity(activity_type=status_changed)` 최신 시각(㉠좁은 정의, 오르테가 확定 — merge_ready의 `_batch_story_entered_in_review_at`과 동일 패턴 재사용).
② 임계 48h(1차값, AC3-1 규율에 따라 코드 주석으로 "N은 고정" 명문화).
③ **BE는 자르지 않는다** — top-N 없이 전량 반환 + 무변화 내림차순 정렬. "8~12건 표시"는 화면 설계(유나) 몫이지 신호의 정의가 아니라는 것이 이번 재실측(단층 없음)의 결론.

## 구현
- `GET /api/v2/glance/attention`에 6번째 kind="stalled" 추가(새 엔드포인트 없음).
- 모집단: backlog 제외 활성(in-review/in-progress/ready-for-dev) — backlog은 "아직 시작 안 함"이지 "멈춰 섬"이 아님(#2250 §6-1).
- AC5: 1~5에 이미 잡힌 story_id는 stalled 후보에서 제외(같은 story가 두 kind로 안 뜸).
- 「모르면 안 준다」(blocked와 동일 원칙): `status_changed` 행 자체가 없는 story는 created_at 등으로 대체 추측하지 않고 후보에서 제외.
- `AttentionResponse.stalled_computed_at` 신설(AC6) — stalled 0건이 "정말 없음"인지 "계산 자체가 안 됨"인지 구분하는 증거.
- entered_state_at을 그대로 재사용(새 "무변화 일수" 필드 발명 없음 — 소비자가 `now - entered_state_at`으로 직접 계산, 페드루 판정).

## 테스트
- `test_2250_stalled_signal_realdb.py` 8건: 임계 통과/미달, backlog 제외, activity 행 부재 시 제외("모르면 안 준다"), AC5 중복방지(merge_ready와 동시에 안 뜸), 0건일 때 stalled_computed_at 존재, 다건 정렬+무절단, done 제외.
- 핵심 가드 2종(AC5 제외셋 제거·임계 체크 제거) 뮤테이션 검증 — genuine RED 확인 후 복원.
- 기존 `/glance/attention` 테스트 9건(test_2249_glance_entered_state_at_realdb·test_e_glance_attention_realdb) 회귀 0 확認.
- AST 가드 lint 5종 무위반.

## 남은 것
FE(유나 확定 픽셀 규격, doc `67a20b3c` — ClusterShell tone=warning 재사용·4구간 exclusive·BE 무변경 확認 済)는 별도 판단(가벼운 편·미르코 여력 없어 디디 단독 재량으로 이어갈지 검토 중).

## Test plan
- [x] 신규 realdb 테스트 8건 GREEN
- [x] 뮤테이션 테스트(AC5 제외·임계 체크) genuine RED 확인 후 복원
- [x] 기존 attention 테스트 9건 회귀 0
- [x] AST 가드 lint 5종 무위반
- [ ] dev 라이브 확認(AC7) — 머지 후