### PR TITLE
[SID:3151] 채팅 결재 카드 «#해시 껍데기» — agent_decision 결정 재료(질문·선택지·전제·요청자) 추가

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3499,6 +3499,8 @@
     "approvalRequestStatusHeld": "Held",
     "approvalRequestStatusVoided": "Voided",
     "approvalRequestResolutionNote": "Reason: {note}",
+    "approvalRequestAssumption": "Assumption: {assumption}",
+    "approvalRequestRequestedBy": "Requested by: {name}",
     "approvalRequestDelegatedAway": "This approval has been delegated to another approver.",
     "approvalRequestWaitingOn": "Waiting on {name}'s approval",
     "approvalRequestTossTrigger": "Send to another room",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3499,6 +3499,8 @@
     "approvalRequestStatusHeld": "보류됨",
     "approvalRequestStatusVoided": "무효화됨",
     "approvalRequestResolutionNote": "사유: {note}",
+    "approvalRequestAssumption": "전제: {assumption}",
+    "approvalRequestRequestedBy": "요청자: {name}",
     "approvalRequestDelegatedAway": "다른 담당자에게 위임된 결재입니다.",
     "approvalRequestWaitingOn": "{name}님의 결재를 기다리는 중",
     "approvalRequestTossTrigger": "다른 방에도 보내기",

--- a/apps/web/src/components/chat/approval-request-card.test.tsx
+++ b/apps/web/src/components/chat/approval-request-card.test.tsx
@@ -586,3 +586,78 @@ describe('ApprovalRequestCard — 토스(story #3084) pending 3분기 + 토스 �
     expect(getCount).toBe(2);
   });
 });
+
+// story #3151(선생님 실기기 발견) — agent_decision 결재 카드가 「결재 대기 / #해시 / 버튼」만
+// 보이고 결정 재료(질문·선택지·요청자)가 전무했다. neutral_facts.question/options/assumption
+// (backend/app/routers/gates.py::DecisionRequestCreate)을 카드가 한 번도 안 읽던 것이 원인.
+describe('ApprovalRequestCard — story #3151 agent_decision 결정 재료(질문·선택지·전제·요청자)', () => {
+  async function mountDecision(neutralFacts: Record<string, unknown> | null, statusOverrides: Partial<GateItem> = {}) {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/team-members')) {
+        return { ok: true, json: async () => ({ data: [{ id: 'member-7', name: '페드루 올리베이라' }] }) };
+      }
+      if (url.includes('/api/gates/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: gate({
+              work_item_type: 'agent_decision', work_item_summary: null, neutral_facts: neutralFacts,
+              ...statusOverrides,
+            }),
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({}) };
+    }));
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <ApprovalRequestCard target={{ work_item_type: 'agent_decision', work_item_id: 'w-1', gate_id: 'g-1', actions: ['approve', 'reject'] }} />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+  }
+
+  it('질문 전문+선택지+전제+요청자 전부 렌더된다 — 「#해시」뿐이던 회귀가드', async () => {
+    await mountDecision({
+      question: 'A/B 실험을 새 알고리즘으로 즉시 전환할까요, 아니면 1주 더 관찰할까요?',
+      options: ['즉시 전환', '1주 더 관찰'],
+      assumption: '현재 표본 수가 유의성 판정에 충분하지 않을 수 있음',
+      requested_by_member_id: 'member-7',
+    });
+    expect(container.textContent).toContain('A/B 실험을 새 알고리즘으로 즉시 전환할까요, 아니면 1주 더 관찰할까요?');
+    expect(container.textContent).toContain('즉시 전환');
+    expect(container.textContent).toContain('1주 더 관찰');
+    expect(container.textContent).toContain('현재 표본 수가 유의성 판정에 충분하지 않을 수 있음');
+    expect(container.textContent).toContain('페드루 올리베이라');
+  });
+
+  it('options 없으면 선택지 목록 자체가 안 뜬다(no-fiction — 지어내지 않음)', async () => {
+    await mountDecision({ question: '이대로 진행해도 될까요?', assumption: null, requested_by_member_id: null });
+    expect(container.textContent).toContain('이대로 진행해도 될까요?');
+    expect(container.querySelector('ul')).toBeNull();
+  });
+
+  it('question이 없으면(비-agent_decision 등 재료 자체가 없는 케이스) 결정 재료 블록이 통째로 생략된다', async () => {
+    await mountDecision(null);
+    expect(container.querySelector('ul')).toBeNull();
+    // 기존 「#해시」 폴백 자체는 이 스토리의 스코프 밖(work_item_summary 없는 agent_decision의
+    // claim 표기는 BE에 대응 엔티티가 없어 불가피 — 이 스토리는 그 아래 결정 재료를 채운다).
+  });
+
+  it('resolved(회신) 상태에서도 결정 재료가 그대로 보인다(뷰어 역할·상태와 무관 — AC1)', async () => {
+    await mountDecision(
+      { question: '배포를 지금 진행할까요?', options: ['진행', '보류'], requested_by_member_id: 'member-7' },
+      { status: 'approved', resolver_id: 'member-1' },
+    );
+    expect(container.textContent).toContain('배포를 지금 진행할까요?');
+    expect(container.textContent).toContain('진행');
+  });
+
+  it('기존 액션 버튼(승인/반려)은 결정 재료 블록 추가 후에도 회귀 없이 그대로 뜬다', async () => {
+    await mountDecision({ question: '진행할까요?', options: ['예', '아니오'] });
+    const buttons = Array.from(container.querySelectorAll('button')).map((b) => b.textContent);
+    expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(true);
+  });
+});

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -376,9 +376,13 @@ function ApprovalRequestBody({
   const isRequesterViewer = !isDesignatedViewer && !!requesterId && requesterId === currentTeamMemberId;
   const needsDesignatedName = gate.status === 'pending' && hasDesignatedLine && !isDesignatedViewer;
   const needsResolverName = gate.status !== 'pending' && !!gate.resolver_id && gate.resolver_id !== currentTeamMemberId;
+  // story #3151 — AC1 "요청자 표시"는 뷰어 역할과 무관하게 항상 필요(대기/기결 둘 다, 결정
+  // 재료의 일부라 승인자·구경꾼 가리지 않는다) — 위 두 플래그(대기 상태·본인 여부로 분기)와
+  // 다른 축이라 별도 플래그로 둔다.
+  const needsRequesterName = !!requesterId && requesterId !== currentTeamMemberId;
   useEffect(() => {
-    const idsKey = `${needsDesignatedName ? gate.designated_approver_id : ''}|${needsResolverName ? gate.resolver_id : ''}`;
-    if (idsKey === '|' || fetchedNameIdsRef.current === idsKey) return;
+    const idsKey = `${needsDesignatedName ? gate.designated_approver_id : ''}|${needsResolverName ? gate.resolver_id : ''}|${needsRequesterName ? requesterId : ''}`;
+    if (idsKey === '||' || fetchedNameIdsRef.current === idsKey) return;
     fetchedNameIdsRef.current = idsKey;
     void fetchWithAuth('/api/team-members')
       .then((r) => (r.ok ? r.json() : null))
@@ -389,7 +393,7 @@ function ApprovalRequestBody({
         setMemberNames((prev) => ({ ...prev, ...names }));
       })
       .catch(() => { /* non-critical — id 스니펫 폴백으로 graceful */ });
-  }, [needsDesignatedName, needsResolverName, gate.designated_approver_id, gate.resolver_id]);
+  }, [needsDesignatedName, needsResolverName, needsRequesterName, gate.designated_approver_id, gate.resolver_id, requesterId]);
   const designatedApproverName = gate.designated_approver_id
     ? memberNames[gate.designated_approver_id] ?? gate.designated_approver_id.slice(0, 8)
     : null;
@@ -439,6 +443,22 @@ function ApprovalRequestBody({
   const isDelegatedAway = gate.status === 'pending' && !!gate.designated_approver_id && gate.designated_approver_id !== currentTeamMemberId;
   const canDelegate = canAct && !isDelegatedAway && !!gate.designated_approver_id && gate.designated_approver_id === currentTeamMemberId;
 
+  // story #3151(선생님 실기기 발견) — agent_decision 카드가 「결재 대기 / #해시 / 버튼」만
+  // 보이고 무엇을 결재하는지가 전무했다. 게이트 실물(neutral_facts.question/options/
+  // assumption, backend/app/routers/gates.py::DecisionRequestCreate)엔 재료가 이미 있는데
+  // 이 카드가 한 번도 읽지 않았다 — work_item_summary(title 소스)가 agent_decision엔 애초
+  // null이라 claim이 #해시로 폴백하는 것과 별개로, 그 아래 body에도 대체 재료가 없었다.
+  // status·뷰어 역할과 무관하게 항상 보여야(AC1: "채팅 밖으로 안 나가고 결정 끝나나") 최상단
+  // (위험 배지 다음)에 둔다.
+  const isDecisionGate = gate.work_item_type === 'agent_decision';
+  const decisionQuestion = isDecisionGate && typeof gate.neutral_facts?.['question'] === 'string'
+    ? (gate.neutral_facts['question'] as string) : null;
+  const decisionOptions = isDecisionGate && Array.isArray(gate.neutral_facts?.['options'])
+    ? (gate.neutral_facts['options'] as unknown[]).filter((o): o is string => typeof o === 'string') : [];
+  const decisionAssumption = isDecisionGate && typeof gate.neutral_facts?.['assumption'] === 'string'
+    ? (gate.neutral_facts['assumption'] as string) : null;
+  const requesterName = requesterId ? (memberNames[requesterId] ?? requesterId.slice(0, 8)) : null;
+
   return (
     <div className="space-y-2">
       {/* story #2926(P0-F F1) — 제목(claim)·미리보기 진입점·EntityPreviewModal은 이제 바깥
@@ -448,6 +468,27 @@ function ApprovalRequestBody({
         <Badge variant={riskLevel === 'high' ? 'warning' : 'outline'} className={riskLevel === 'unknown' ? 'text-muted-foreground' : undefined}>
           {riskLevel === 'high' ? tCage('riskHigh') : tCage('riskUnknown')}
         </Badge>
+      ) : null}
+
+      {/* story #3151 — 결정 재료(질문 전문·선택지·요청자). no-fiction: neutral_facts에 실린
+          값만 그대로 보이고, 없는 필드(assumption 등)는 그 줄 자체를 안 그린다. */}
+      {decisionQuestion ? (
+        <div className="min-w-0 space-y-1 rounded-lg border border-border bg-muted/40 p-2 [overflow-wrap:anywhere]">
+          <p className="text-xs font-medium text-foreground">{decisionQuestion}</p>
+          {decisionOptions.length > 0 ? (
+            <ul className="space-y-0.5 pl-3 text-xs text-foreground">
+              {decisionOptions.map((opt, i) => (
+                <li key={i} className="list-disc">{opt}</li>
+              ))}
+            </ul>
+          ) : null}
+          {decisionAssumption ? (
+            <p className="text-[11px] text-muted-foreground">{t('approvalRequestAssumption', { assumption: decisionAssumption })}</p>
+          ) : null}
+          {requesterName ? (
+            <p className="text-[11px] text-muted-foreground">{t('approvalRequestRequestedBy', { name: requesterName })}</p>
+          ) : null}
+        </div>
       ) : null}
 
       {gate.status !== 'pending' ? (


### PR DESCRIPTION
## 배경 (critical, 선생님 실기기 발견)
agent_decision 결재 카드가 채팅에 착지했는데 「결재 대기 / #eacade67 / 승인·반려·보류·위임」뿐, 무엇을 결재하는지 전혀 없었다. "이거 보고 뭘 결재를 하는지?"

## 근본
게이트 실물(`neutral_facts.question`/`options`/`assumption` — `backend/app/routers/gates.py::DecisionRequestCreate`)엔 재료가 처음부터 있었다. `agent_decision`은 대응하는 doc/story/task 엔티티가 없어(`_resolve_work_item_summary`가 doc/story/task만 지원, 의도된 설계) `work_item_summary`가 항상 `null` — 카드 헤드라인(claim)이 `#해시`로 폴백하는 것과 별개로, `ApprovalRequestBody` 어디에도 `neutral_facts.question`/`options`/`assumption`을 읽는 코드가 **아예 없었다**. «결재함 해시 벽»(#3038)의 채팅 카드판.

## fix
`agent_decision` 게이트에 한해 위험배지 다음 자리에 결정 재료 블록 신설 — 질문 전문 + 선택지(있으면) + 전제(있으면) + 요청자(기존 `requesterId` 해소 로직 확장, 뷰어 역할과 무관하게 항상 조회). no-fiction: `neutral_facts`에 없는 필드는 그 줄 자체를 안 그린다. 기존 액션 버튼(승인/반려/보류/위임) 로직은 완전히 그대로.

## AC2(타 gate_type 점검)
doc/story/task `work_item_type`은 `_resolve_work_item_summary`가 실 제목을 채우고 있어(agent_decision과 다른 클래스) 이 결함 대상이 아님을 코드로 확認 — 별도 처방 불요.

## AC3(모바일 실렌더) — 별도 사전존재 결함 발견, 분리 등재
검증 중 **#3151 변경분과 무관한 사전존재 결함**(카드 셸이 390px 뷰포트에서 승인/반려 버튼 우측을 잘라먹음)을 발견 — plain 카드(결정 재료 블록 없이 기존 story gate)로도 동일 재현 확認, 이 PR이 만든 게 아님을 확定. #3152로 분리 등재(이 PR 스코프 밖, 별도 처방 필요).

## 검증
- 신규 5 테스트(질문+선택지+전제+요청자 렌더 · no-fiction 폴백 · resolved 상태 유지 · 액션 버튼 회귀 0 포함) + 기존 30 = **35 passed**.
- 전체 chat 스위트 **557 passed**, 회귀 0.
- `tsc --noEmit`/`eslint`/`next build` 전부 green.
- 헤드리스 크롬 실렌더(라이트/다크/모바일폭) 육안 확認.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>