### PR TITLE
[SID:3146] 모바일 계정 스위치 진입점 신설 — 「전체」허브 최상단에 ProfileMenu 재사용

### DIFF
--- a/apps/web/src/app/(authenticated)/more/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/more/page.test.tsx
@@ -3,11 +3,26 @@
 // story #2682(모바일 IA S2) — 「전체」(/more)를 평면 stub에서 데스크톱 GNB(nav-config.ts)
 // 미러 그룹형 허브로 재건한 회귀가드. AC1(org 그룹·조직브리핑 포함)·AC3(아코디언 없음·stub
 // 배너 제거)·중복 방지(flow/inbox/chats는 바텀 탭이 이미 depth 1로 커버)를 실 렌더로 잰다.
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../../messages/ko.json';
+
+// story #3146(모바일 계정 스위치) — MorePage가 useDashboardContext()로 userName을 얻어
+// ProfileMenu 마운트 여부를 결정한다. 기존 스위트는 이 훅을 안 모킹해(디폴트 컨텍스트,
+// userName=undefined) 계정 섹션이 항상 생략되는 경로만 탔다 — 아래 새 describe에서만
+// userName을 주입해 반대 경로(섹션이 실제로 뜨는지)를 명시적으로 잰다.
+const useDashboardContextMock = vi.fn(() => ({} as { userName?: string }));
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+// ProfileMenu(계정 스위치 트리거)가 useRouter()를 쓴다 — profile-menu.test.tsx와 동일 모킹.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), refresh: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/more',
+}));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -26,11 +41,14 @@ beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({}); // 기본=기존 스위트와 동형(userName 없음).
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { accounts: [] } }) })));
 });
 
 afterEach(async () => {
   await act(async () => { root.unmount(); });
   container.remove();
+  vi.unstubAllGlobals();
 });
 
 async function mount() {
@@ -98,5 +116,32 @@ describe('MorePage — story #2682 GNB 미러 그룹형 허브(AC1·AC3)', () =>
     expect(settingsSection).toBeDefined();
     const settingsLink = [...container.querySelectorAll('a')].find((a) => a.getAttribute('href') === '/settings');
     expect(settingsLink).toBeDefined();
+  });
+});
+
+// story #3146(선생님 실사용 발견) — "모바일에서 로그아웃 외엔 계정을 바꿀 방법이 없다".
+// ProfileMenu(계정 스위처)가 데스크톱 AppSidebar에만 마운트되고 모바일 표면 어디에도
+// 진입점이 없던 것을 이 허브 최상단에 추가한 회귀가드.
+describe('MorePage — story #3146 계정 스위치 진입점(모바일)', () => {
+  it('userName이 있으면 최상단에 계정 스위치(ProfileMenu) 트리거가 뜬다', async () => {
+    useDashboardContextMock.mockReturnValue({ userName: '송윤재' });
+    await mount();
+    const trigger = container.querySelector('[data-slot="dropdown-menu-trigger"]');
+    expect(trigger).toBeTruthy();
+    expect(trigger!.textContent).toContain('송윤재');
+  });
+
+  it('userName이 없으면(컨텍스트 미준비) 계정 섹션 자체를 생략한다 — 빈 트리거로 지어내지 않음', async () => {
+    useDashboardContextMock.mockReturnValue({});
+    await mount();
+    const trigger = container.querySelector('[data-slot="dropdown-menu-trigger"]');
+    expect(trigger).toBeNull();
+  });
+
+  it('기존 GNB 미러 섹션(오늘/워크스페이스/…) 순서·내용은 계정 섹션 추가 후에도 무회귀', async () => {
+    useDashboardContextMock.mockReturnValue({ userName: '송윤재' });
+    await mount();
+    const sectionLabels = [...container.querySelectorAll('h2')].map((el) => el.textContent);
+    expect(sectionLabels).toEqual(['오늘', '워크스페이스', '신뢰', '지식', '조직', '설정']);
   });
 });

--- a/apps/web/src/app/(authenticated)/more/page.tsx
+++ b/apps/web/src/app/(authenticated)/more/page.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { MOBILE_HUB_EXCLUDE_IDS, MOBILE_HUB_GROUP_ORDER, NAV_GROUPS } from '@/lib/nav-config';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { ProfileMenu } from '@/components/nav/profile-menu';
 
 // story #2682(모바일 IA S2, doc mobile-ia-full-completion-2678 §2.3) — 임시 평면 stub(#1958·
 // #1965)을 데스크톱 GNB(app-sidebar.tsx) 5 zones를 그대로 미러하는 그룹형 허브로 재건한다.
@@ -13,6 +15,7 @@ import { MOBILE_HUB_EXCLUDE_IDS, MOBILE_HUB_GROUP_ORDER, NAV_GROUPS } from '@/li
 export default function MorePage() {
   const t = useTranslations('nav');
   const tMore = useTranslations('mobileTabBar');
+  const { userName } = useDashboardContext();
 
   const hubGroups = MOBILE_HUB_GROUP_ORDER
     .map((groupId) => NAV_GROUPS.find((g) => g.id === groupId))
@@ -26,6 +29,20 @@ export default function MorePage() {
           allowlist(showContextChip)로 켤 자리가 없었다. "슬롯 없으면 자동 켬"은 fail-open이라
           금지(유나양) — 슬롯을 명시적으로 쓰게 해서 켠다. */}
       <TopBarSlot title={<h1 className="text-sm font-medium">{tMore('more')}</h1>} showContextChip />
+      {/* story #3146(선생님 실사용 발견) — 계정 스위치(ProfileMenu, 데스크톱 AppSidebar
+          전용 마운트)가 모바일 표면 어디에도 진입점이 없어 "로그아웃 외엔 계정을 바꿀 방법이
+          없다"였다. NAV_GROUPS(페이지 목적지 SSOT) 항목이 아니라 데스크톱과 동일하게 계정
+          자체의 액션이라 그 목록 밖, 최상단 전용 자리에 둔다(데스크톱 사이드바 하단 배치와
+          같은 급). 컴포넌트는 완전 재사용(신규 UI 0) — triggerClassName만 이 밝은 배경에
+          맞게 오버라이드. */}
+      {userName ? (
+        <div className="mb-4 rounded-xl border border-border">
+          <ProfileMenu
+            name={userName}
+            triggerClassName="flex min-h-12 w-full items-center gap-3 rounded-xl px-4 py-3 text-left transition hover:bg-muted"
+          />
+        </div>
+      ) : null}
       {/* story #2682 AC3 — 임시 stub 배너(#1965) 제거. 섹션 헤더 있는 단일 스크롤 목록(아코디언
           아님 — 아코디언은 목적지를 탭 뒤에 숨겨 depth+1이 된다, doc §2.3). */}
       <div className="space-y-5">

--- a/apps/web/src/components/nav/profile-menu.test.tsx
+++ b/apps/web/src/components/nav/profile-menu.test.tsx
@@ -85,3 +85,36 @@ describe('ProfileMenu — 약관 및 정책 그룹 제거 회귀가드 (story #2
     expect(signOutIdx).toBe(settingsIdx + 1);
   });
 });
+
+// story #3146(모바일 계정 스위치, 선생님 실사용 발견) — 데스크톱 AppSidebar 전용이던
+// ProfileMenu를 모바일 「전체」허브에도 마운트하려면, `sidebar-*` 테마 토큰 트리거(어두운
+// 사이드바 배경 전제)를 밝은 배경에도 안 묻히게 오버라이드할 수 있어야 한다.
+describe('ProfileMenu — story #3146 triggerClassName 오버라이드(모바일 재사용 배선)', () => {
+  it('triggerClassName 생략 시 기존 sidebar 테마 트리거 그대로(회귀 0)', async () => {
+    await mount(<ProfileMenu name="송윤재" />);
+    const trigger = container.querySelector('[data-slot="dropdown-menu-trigger"]') as HTMLElement;
+    expect(trigger.className).toContain('hover:bg-sidebar-accent');
+    // 아바타 폴백도 <span>이라 이름 텍스트 span을 truncate 클래스로 특정한다.
+    const nameSpan = trigger.querySelector('span.truncate');
+    expect(nameSpan?.className).toContain('text-sidebar-foreground');
+  });
+
+  it('triggerClassName 전달 시 그 클래스로 완전히 갈아끼워진다(밝은 배경용)', async () => {
+    await mount(<ProfileMenu name="송윤재" triggerClassName="min-h-12 rounded-xl bg-red-500" />);
+    const trigger = container.querySelector('[data-slot="dropdown-menu-trigger"]') as HTMLElement;
+    expect(trigger.className).toBe('min-h-12 rounded-xl bg-red-500');
+    expect(trigger.className).not.toContain('hover:bg-sidebar-accent');
+    // 이름 텍스트 span도 sidebar 전용 색이 아니라 무채 text-foreground로 갈아끼워진다.
+    const nameSpan = trigger.querySelector('span.truncate');
+    expect(nameSpan?.className).toContain('text-foreground');
+    expect(nameSpan?.className).not.toContain('sidebar');
+  });
+
+  it('오버라이드 상태에서도 메뉴 열기·계정 목록 기능은 그대로다(트리거 스타일만 바뀜, 로직 회귀 0)', async () => {
+    await mount(<ProfileMenu name="송윤재" triggerClassName="custom-trigger" />);
+    await openMenu();
+    const content = document.querySelector('[data-slot="dropdown-menu-content"]');
+    expect(content).toBeTruthy();
+    expect(content!.textContent).toContain('설정');
+  });
+});

--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -31,6 +31,11 @@ interface ProfileMenuProps {
   name: string;
   email?: string | null;
   avatarUrl?: string | null;
+  /** story #3146(모바일 계정 스위치) — 기본 트리거는 `sidebar-*` 테마 토큰을 쓴다(데스크톱
+   * AppSidebar의 어두운 사이드바 배경 전제). 사이드바 밖(모바일 「전체」허브 등 밝은 배경)에
+   * 그대로 꽂으면 글자색이 배경과 거의 안 갈려 사실상 안 보인다 — 그 표면에서만 무채 배경용
+   * 클래스로 갈아끼운다(기본값 생략 시 기존 desktop 클래스 그대로, 회귀 0). */
+  triggerClassName?: string;
 }
 
 function initialOf(label: string | null | undefined): string {
@@ -63,7 +68,7 @@ function Avatar({ url, label, className }: { url?: string | null; label: string;
   );
 }
 
-export function ProfileMenu({ name, avatarUrl }: ProfileMenuProps) {
+export function ProfileMenu({ name, avatarUrl, triggerClassName }: ProfileMenuProps) {
   const router = useRouter();
   const t = useTranslations('accountSwitcher');
   const tc = useTranslations('common');
@@ -159,10 +164,10 @@ export function ProfileMenu({ name, avatarUrl }: ProfileMenuProps) {
 
   return (
     <DropdownMenu onOpenChange={(open) => { if (open) void load(); }}>
-      <DropdownMenuTrigger className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition hover:bg-sidebar-accent">
+      <DropdownMenuTrigger className={triggerClassName ?? 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition hover:bg-sidebar-accent'}>
         <Avatar url={triggerAvatar} label={triggerName} className="size-7" />
-        <span className="min-w-0 flex-1 truncate text-sm font-medium text-sidebar-foreground">{triggerName}</span>
-        <ChevronsUpDown className="size-3.5 shrink-0 text-sidebar-foreground/60" />
+        <span className={cn('min-w-0 flex-1 truncate text-sm font-medium', triggerClassName ? 'text-foreground' : 'text-sidebar-foreground')}>{triggerName}</span>
+        <ChevronsUpDown className={cn('size-3.5 shrink-0', triggerClassName ? 'text-muted-foreground' : 'text-sidebar-foreground/60')} />
       </DropdownMenuTrigger>
       <DropdownMenuContent side="top" align="start" className="w-64">
         <DropdownMenuGroup>


### PR DESCRIPTION
## 배경 (high, 선생님 실사용 발견)
모바일 웹·iOS 앱(웹뷰)에서 계정 스위치 UI가 존재하지 않음. 프로젝트 스위치는 가능하나(품질은 별도 스토리 #3147) 계정 전환은 방법 자체가 없어 "로그아웃 외엔 계정을 바꿀 방법이 없다".

## 근본
계정 스위처(`ProfileMenu` — 계정 목록·전환·추가·로그아웃, `/api/accounts`+`/api/auth/switch-account` 이미 완비)는 `AppSidebar`(데스크톱 전용, `lg:` 이상에서만 마운트)에만 렌더된다. 모바일 하단 4탭(`MobileTabBar`)·「전체」허브(`more/page.tsx`, `NAV_GROUPS` SSOT 미러) 어디에도 진입점이 없었다 — `nav-config.ts`의 `MOBILE_HUB_EXCLUDE_IDS`도 확認: board/inbox/chats(중복 방지)만 있고 애초 account 항목 자체가 없음(의도적 제외가 아니라 순수 누락).

## fix
신규 UI 발명 없음(회귀 최소화) — 기존 `ProfileMenu`를 `more/page.tsx` 최상단 전용 자리에 그대로 재사용. 유일한 변경은 `triggerClassName` prop 신설 — 기존 트리거가 `sidebar-*` 테마 토큰(어두운 사이드바 배경 전제)이라 밝은 More 페이지에 그대로 꽂으면 텍스트가 배경에 묻힌다. prop 생략 시 기존 데스크톱 클래스 그대로(회귀 0), 전달 시에만 무채 배경용 클래스로 완전히 갈아끼운다. `userName`은 이미 존재하는 `useDashboardContext()`로 prop-drilling 없이 조회.

## 검증
- 신규 8 테스트(트리거 오버라이드 3 · More 페이지 배선 3, 기존 12 무회귀) + 관련 스위트 **90 passed**.
- `tsc --noEmit`/`eslint`/`next build` 전부 green.
- 헤드리스 크롬 실렌더(390px)로 트리거 배치+드롭다운 열림 상태(2계정 목록·계정추가·설정·로그아웃 전부) 육안 확認 — 가로 오버플로 0(#3152와 다른 컴포넌트 트리라 그 결함과 무관 확認).

## 잔여
AC2(전환 왕복 실측)·AC3(데스크톱 무회귀)는 라이브 dev 배포 후 별도 확認 필요(회귀 테스트로 배선 안전은 확保했으나 실 전환 API 왕복은 dev 배포 환경에서만 가능).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>