### PR TITLE
[SID:3148] MCP list_backlog가 done/in-review를 백로그로 반환하던 결함 수리

### DIFF
--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -268,6 +268,7 @@ class StoryRepository(BaseRepository[Story]):
         story_number: int | None = None,
         q: str | None = None,
         unattached: bool = False,
+        exclude_statuses: list[str] | None = None,
     ) -> tuple[list[Story], int]:
         """sprint 미배정 + 삭제되지 않은 스토리만 서버사이드 필터.
 
@@ -291,6 +292,13 @@ class StoryRepository(BaseRepository[Story]):
         를 타지 이 분기로 안 온다. "URL이 `/stories/backlog`니까 이 분기겠지"로 단정한 게
         오판 원인이었다 — #2190의 진짜 원인은 그 프록시가 `apiSuccess()`에 meta를 안 넘겨
         `hasMore`가 구조적으로 항상 false인 것(다른 층의 결함)이라 이 메서드와 무관하다.
+
+        story #3148 — `exclude_statuses`(신규, opt-in): sprint 미배정만으론 done/in-review도
+        섞인다(완료됐지만 sprint에 안 걸려 있던 스토리) — MCP `sprintable_list_backlog`가 이걸
+        「백로그」로 반환해 PO 오배분 사고를 냈다. `status`(단일 일치)와 별개 축이라 함께 못
+        쓴다는 제약은 없지만 실용상 상호배타적으로 쓰인다. 미지정(None) 시 기존 계약 무회귀
+        (test_2188_list_backlog_filter_drop_realdb.py::test_backlog_no_extra_filters_unspecified_
+        no_regression 고정) — 이 메서드의 기본 동작은 그대로 두고 호출부가 명시적으로 켠다.
         """
         query = select(Story).where(
             self._org_filter(),
@@ -304,6 +312,8 @@ class StoryRepository(BaseRepository[Story]):
             query = query.where(Story.assignee_id == assignee_id)
         if status:
             query = query.where(Story.status == status)
+        if exclude_statuses:
+            query = query.where(Story.status.notin_(exclude_statuses))
         if story_number is not None:
             query = query.where(Story.story_number == story_number)
         if q:

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -134,6 +134,13 @@ async def list_stories(
     assignee_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
     no_sprint: bool = Query(default=False, description="sprint 미배정 스토리만 반환"),
+    exclude_status: str | None = Query(
+        default=None,
+        description=(
+            "story #3148 — comma-separated status 목록(IN 부정) — no_sprint(list_backlog) "
+            "분기 전용. status(단일 일치)와 별개 축, 미지정 시 무영향(무회귀)."
+        ),
+    ),
     unattached: bool = Query(
         default=False,
         description=(
@@ -193,6 +200,10 @@ async def list_stories(
     include_unassigned = include_unassigned if isinstance(include_unassigned, bool) else False
     epic_ids = epic_ids if isinstance(epic_ids, str) else None
     done_within_days = done_within_days if isinstance(done_within_days, int) else None
+    # story #3148 — 동일 Query(...) 센티널 함정(위 두 줄과 동형). 신규 파라미터라 기존
+    # 직접호출 테스트들은 이 kwarg를 아예 안 넘기므로 함수 기본값(Query 객체)이 그대로
+    # 들어온다 — isinstance 가드 없으면 `.split(",")`가 Query 객체에서 AttributeError.
+    exclude_status = exclude_status if isinstance(exclude_status, str) else None
 
     parsed_epic_ids: list[uuid.UUID] | None = None
     if epic_ids is not None:
@@ -243,9 +254,13 @@ async def list_stories(
         # story #2428: list_backlog가 이제 (stories, total) — X-Total-Count로 호출부가
         # "더 있는지"를 알 수 있게 한다(이 분기는 cursor 미지원, 위 docstring 참조 — 더
         # 필요하면 limit을 올려 재호출하는 것이 유일한 다음 페이지 수단).
+        parsed_exclude_statuses = (
+            [x.strip() for x in exclude_status.split(",") if x.strip()] if exclude_status else None
+        )
         stories, total = await repo.list_backlog(
             project_id, limit=limit, epic_id=epic_id, assignee_id=assignee_id,
             status=status_filter, story_number=story_number, q=q, unattached=unattached,
+            exclude_statuses=parsed_exclude_statuses,
         )
         if response is not None:
             response.headers["X-Total-Count"] = str(total)

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -436,8 +436,9 @@ _TOOL_DEFS: list[tuple] = [
      "([제목](entity:story:id))을 준다 — 채팅 등에 그대로 쓰면 참조가 생긴다(story #2282).",
      ListStoriesInput, list_stories),
     ("sprintable_list_backlog",
-     "[일감] 백로그 스토리 목록 (스프린트 미배정). limit(선택)로 상한 조정 — 서버 기본은"
-     " limit 미지정 시 유지(무회귀). cursor 페이지네이션은 지원 안 함(limit 올려 재호출).",
+     "[일감] 백로그 스토리 목록 (스프린트 미배정 · done/in-review 제외, story #3148). limit"
+     "(선택)로 상한 조정 — 서버 기본은 limit 미지정 시 유지(무회귀). cursor 페이지네이션은"
+     " 지원 안 함(limit 올려 재호출).",
      ListBacklogInput, list_backlog),
     ("sprintable_add_story",
      "[일감] 스토리 생성. 응답 reference_token 필드가 이 스토리를 가리키는 참조 토큰"

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -173,12 +173,18 @@ async def list_stories(args: ListStoriesInput) -> list[TextContent]:
 
 
 async def list_backlog(args: ListBacklogInput) -> list[TextContent]:
-    """백로그 스토리 목록 (스프린트 미배정)."""
+    """백로그 스토리 목록 (스프린트 미배정 · done/in-review 제외)."""
     # b5870c4c: 전용 `/stories/backlog` 라우트 부재 → `/{id}` 로 shadow 돼 422(id="backlog" 非-UUID).
     # 기존 list 엔드포인트 + `no_sprint` 필터(server-side repo.list_backlog·sprint 미배정·docstring 정합) 재사용.
     # ⚠️ no_sprint 는 project_id 와 함께여야 backlog 분기 동작(stories.py list_stories).
+    # story #3148 — sprint 미배정만으론 done/in-review도 섞인다(PO가 이 도구로 오배분한
+    # 실사고 원인). exclude_status는 이 도구가 항상 고정으로 보낸다 — 이름이 「백로그」인
+    # 도구가 완료·검토중 항목을 내는 건 이름의 약속 위반이라 옵션이 아니라 기본 동작이다.
     try:
-        params: dict = {"project_id": client.require_project_id(), "no_sprint": "true"}
+        params: dict = {
+            "project_id": client.require_project_id(), "no_sprint": "true",
+            "exclude_status": "done,in-review",
+        }
         if args.limit:
             params["limit"] = args.limit
         items, headers = await client.get_with_headers("/api/v2/stories", params=params)

--- a/backend/tests/test_2188_no_sprint_alone_contract_pin.py
+++ b/backend/tests/test_2188_no_sprint_alone_contract_pin.py
@@ -89,6 +89,8 @@ async def test_actual_behavior_no_sprint_without_project_id_falls_through_to_gen
             # story #3019: epic_ids/include_unassigned/done_within_days 신규 Query
             # 파라미터 — 위와 동일 이유로 명시(boost_candidates_from만 baseline 그대로 유지).
             epic_ids=None, include_unassigned=False, done_within_days=None,
+            # story #3148: exclude_status 신규 Query 파라미터 — 위와 동일 이유로 명시.
+            exclude_status=None,
         )
         assert result == []
         repo.list.assert_awaited_once()

--- a/backend/tests/test_2642_entity_slug_exposure.py
+++ b/backend/tests/test_2642_entity_slug_exposure.py
@@ -150,6 +150,8 @@ async def test_story_list_and_get_carry_org_project_slug():
                 # 파라미터 — sentinel lint(scripts/lint_query_sentinel_direct_calls.py)
                 # baseline과 missing-set을 맞추기 위해 명시.
                 epic_ids=None, include_unassigned=False, done_within_days=None,
+                # story #3148: exclude_status 신규 Query 파라미터 — 위와 동일 이유로 명시.
+                exclude_status=None,
             )
             assert len(listed) == 1
             assert listed[0].org_slug == org.slug
@@ -236,6 +238,8 @@ async def test_story_list_slug_resolution_is_not_n_plus_1():
                     # story #3019: epic_ids/include_unassigned/done_within_days 신규
                     # Query 파라미터 — sentinel lint baseline과 missing-set을 맞추기 위해 명시.
                     epic_ids=None, include_unassigned=False, done_within_days=None,
+                    # story #3148: exclude_status 신규 Query 파라미터 — 위와 동일 이유로 명시.
+                    exclude_status=None,
                 )
             finally:
                 event.remove(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)

--- a/backend/tests/test_3148_list_backlog_exclude_status_realdb.py
+++ b/backend/tests/test_3148_list_backlog_exclude_status_realdb.py
@@ -1,0 +1,190 @@
+"""story #3148(2026-08-27, PO 실사용 오배분 사고) — 실 PG.
+
+`sprintable_list_backlog`(no_sprint=True 분기)가 sprint 미배정만 걸고 status는 안 걸러
+done/in-review까지 «백로그」로 반환 — PO가 이 목록으로 이미 끝난 스토리에 새 작업을
+배분한 실사고의 원인. `list_backlog()`에 opt-in `exclude_statuses` 축을 신설하고 MCP
+`sprintable_list_backlog` 툴이 이를 항상 고정 전송(`exclude_status=done,in-review`)하도록
+배선한 fix — 이 파일은 SQL 필터 그 자체(repo→router 경로)를 실 PG로 검증한다(MCP 계층
+쪽 "고정 전송" 자체는 test_mcp_list_backlog_b5870c4c.py::
+test_list_backlog_always_excludes_done_and_in_review가 별도로 고정).
+
+⛔ exclude_statuses 미지정 시 기존 계약(done 포함 전량 반환)은 절대 안 바뀐다 —
+test_2188_list_backlog_filter_drop_realdb.py::test_backlog_no_extra_filters_unspecified_
+no_regression이 그 축을 이미 고정하고 있어 이 파일에서 재확인하지 않는다(중복 아님, 축이
+다르다: 그 테스트는 "미지정 무회귀", 이 테스트는 "지정 시 실제로 걸러지는지").
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _auth(agent_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(agent_id), email=None, claims={"app_metadata": {}})
+
+
+async def _seed(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted"))
+    await session.commit()
+
+    # 전부 sprint_id=None(no_sprint 분기 대상) — status만 4갈래.
+    s_backlog = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="B", status="backlog", story_number=1)
+    s_progress = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="IP", status="in-progress", story_number=2)
+    s_review = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="IR", status="in-review", story_number=3)
+    s_done = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="D", status="done", story_number=4)
+    session.add_all([s_backlog, s_progress, s_review, s_done])
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "agent_id": agent.id,
+        "s_backlog": s_backlog.id, "s_progress": s_progress.id,
+        "s_review": s_review.id, "s_done": s_done.id,
+    }
+
+
+async def _call_list_stories(session, org_id, agent_id, **kwargs):
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import list_stories
+
+    repo = StoryRepository(session, org_id)
+    params = dict(
+        project_id=None, epic_id=None, sprint_id=None, assignee_id=None,
+        status_filter=None, no_sprint=False, exclude_status=None, ids=None,
+        story_number=None, q=None, limit=1000, cursor=None, response=None,
+    )
+    params.update(kwargs)
+    return await list_stories(repo=repo, auth=_auth(agent_id), **params)
+
+
+async def test_exclude_status_filters_done_and_in_review():
+    """⭐본체 — exclude_status="done,in-review" 지정 시 그 둘만 빠지고 나머지(backlog·
+    in-progress)는 그대로 남는다(«백로그» 이름이 약속한 «아직 할 일»만)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], no_sprint=True, exclude_status="done,in-review",
+            )
+            returned_ids = {r.id for r in result}
+            assert returned_ids == {seeded["s_backlog"], seeded["s_progress"]}
+            assert seeded["s_done"] not in returned_ids
+            assert seeded["s_review"] not in returned_ids
+    finally:
+        await engine.dispose()
+
+
+async def test_exclude_status_total_count_reflects_post_filter_not_pre_filter():
+    """X-Total-Count(응답 헤더)가 exclude 적용 「後」 값이어야 한다 — pagination truncation
+    함정(unattached 선례, Python 후필터 방식이 헤더 거짓값을 냈던 결함 클래스)과 동형 회귀
+    가드. SQL WHERE 레벨 필터라 이 값이 자동으로 맞는지 실증."""
+    from unittest.mock import MagicMock
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            fake_response = MagicMock()
+            fake_response.headers = {}
+            await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], no_sprint=True, exclude_status="done,in-review",
+                response=fake_response,
+            )
+            assert fake_response.headers["X-Total-Count"] == "2"
+    finally:
+        await engine.dispose()
+
+
+async def test_exclude_status_whitespace_tolerant():
+    """comma-separated 파싱이 공백에도 관대한지(사람이 "done, in-review"처럼 보낼 수 있음)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], no_sprint=True, exclude_status="done, in-review",
+            )
+            returned_ids = {r.id for r in result}
+            assert seeded["s_done"] not in returned_ids
+            assert seeded["s_review"] not in returned_ids
+    finally:
+        await engine.dispose()
+
+
+async def test_exclude_status_unspecified_still_returns_done_no_regression():
+    """이 파일 자체 내에서도 재확인 — exclude_status=None(기본)이면 done도 그대로 섞여 온다
+    (기존 계약 무회귀, test_2188 쌍둥이 축과 별개로 이 파일의 seed 데이터로도 재현)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"],
+                project_id=seeded["project_id"], no_sprint=True,
+            )
+            returned_ids = {r.id for r in result}
+            assert returned_ids == {
+                seeded["s_backlog"], seeded["s_progress"], seeded["s_review"], seeded["s_done"],
+            }
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_ca37b2b0_stories_ids_batch_realdb.py
+++ b/backend/tests/test_ca37b2b0_stories_ids_batch_realdb.py
@@ -104,6 +104,8 @@ async def _call_list_stories(session, org_id, agent_id, ids_param):
         unattached=False,
         # story #3019: epic_ids/include_unassigned/done_within_days 신규 Query 파라미터 — 동일 이유로 명시.
         epic_ids=None, include_unassigned=False, done_within_days=None,
+        # story #3148: exclude_status 신규 Query 파라미터 — 동일 이유로 명시.
+        exclude_status=None,
     )
 
 

--- a/backend/tests/test_mcp_list_backlog_b5870c4c.py
+++ b/backend/tests/test_mcp_list_backlog_b5870c4c.py
@@ -33,3 +33,28 @@ async def test_list_backlog_targets_existing_endpoint_with_no_sprint(monkeypatch
     # no_sprint(+project_id)로 server-side backlog(sprint 미배정) 분기.
     assert captured["params"].get("no_sprint") == "true"
     assert captured["params"].get("project_id") == "proj-1"
+
+
+@pytest.mark.anyio
+async def test_list_backlog_always_excludes_done_and_in_review(monkeypatch):
+    """story #3148 — 「백로그」 이름이 약속한 필터(미완료)를 도구가 항상 고정 전송하는지.
+
+    호출자가 손댈 여지 없는 도구 기본 동작이어야 한다(ListBacklogInput에 status류 필드가
+    없다 — 사용자가 빠뜨려서 새는 게 아니라 도구가 애초에 항상 켠다는 것을 고정)."""
+    captured: dict = {}
+
+    class _FakeClient:
+        project_id = "proj-1"
+        org_id = None
+
+        def require_project_id(self):
+            return self.project_id
+
+        async def get_with_headers(self, path, params=None):
+            captured["params"] = params or {}
+            return [], {"x-total-count": "0"}
+
+    monkeypatch.setattr(st, "client", _FakeClient())
+    await st.list_backlog(st.ListBacklogInput())
+
+    assert captured["params"].get("exclude_status") == "done,in-review", captured


### PR DESCRIPTION
[SID:3148]

## Summary
- 원인 확定: `no_sprint`(sprint 미배정) 분기가 status를 전혀 안 걸러 완료·검토중 스토리까지 「백로그」로 반환 — PO가 이 목록으로 이미 끝난 스토리에 새 작업을 배분한 실사고를 냈다.
- 수리: `StoryRepository.list_backlog()`에 opt-in `exclude_statuses`(SQL WHERE 레벨 IN 부정) 신설 — `status`(단일 일치)와 별개 축, 미지정 시 기존 계약 무회귀.
- 라우터에 `exclude_status`(comma-separated) 쿼리파라미터 배선 — 기존 `unattached`/`epic_ids`/`done_within_days`와 동형 Query(...) 센티널 함정 방어(isinstance 가드) 포함.
- MCP `sprintable_list_backlog` 툴이 `exclude_status=done,in-review`를 항상 고정 전송 — 이름("백로그")이 약속한 것과 구현을 일치시킨다(사용자가 끌 수 있는 옵션이 아니라 도구 기본 동작).

## Test plan
- [x] 신규 realdb 테스트(`test_3148_list_backlog_exclude_status_realdb.py`, 4건): 제외 동작 본체, X-Total-Count가 post-filter 값인지(unattached 선례의 truncation 함정 회귀가드), comma 공백 관용, exclude_status 미지정 시 무회귀
- [x] MCP 레벨 고정전송 pin(`test_mcp_list_backlog_b5870c4c.py`에 추가): 도구가 항상 `exclude_status=done,in-review`를 보내는지
- [x] 인접 스위트 전수 green(회귀 0): test_2188_list_backlog_filter_drop_realdb·test_2188_no_sprint_alone_contract_pin·test_2188_board_branch_filter_drop_realdb·test_2189_generic_branch_cursor_pagination_realdb·test_2428_list_backlog_total_count_realdb·test_2428_mcp_stories_header_pagination·test_2787_tool_def_input_class_wiring_guard·test_3019_epic_swimlane_scope_reduction_realdb (8파일) + 신규 4건 + MCP pin 1건 = 52건
- [x] 두 축(SQL 필터, MCP 고정전송) 모두 mutation-test로 RED 확인 후 GREEN 복원
- [x] 회귀 영향 조사: FE `ApiStoryRepository.backlog()`는 라이브 콜러 0(죽은 코드, 기존 문서화된 사실 재확인) — 이 분기의 유일한 실 소비처는 MCP 툴뿐이라 blast radius 최소

🤖 Generated with [Claude Code](https://claude.com/claude-code)