### PR TITLE
[SID:3153] 침묵의 정체 org-wide 커버리지 갭 메움

### DIFF
--- a/apps/web/src/app/api/glance/attention/org-stalled/route.ts
+++ b/apps/web/src/app/api/glance/attention/org-stalled/route.ts
@@ -1,0 +1,20 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// GET /api/glance/attention/org-stalled — story #3153(93b076c8 후속) «침묵의 정체» org-wide
+// 커버리지. BE `/api/v2/glance/attention/org-stalled`로 프록시(project_id 쿼리파라미터 없음 —
+// 접근 가능한 전 프로젝트를 BE가 순회). project별 접근권 가드는 BE(accessible_project_ids_in_org)가 수행.
+export async function GET(request: Request) {
+  try {
+    const me = await getOrgProjectAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+    const res = await proxyToFastapi(request, '/api/v2/glance/attention/org-stalled');
+    if (!res.ok) return res;
+    return apiSuccess(await res.json());
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.test.tsx
@@ -23,7 +23,7 @@ const EMPTY_SILENT_STALL: { totalCount: number; populationCount: number; buckets
 function silentStallItem(overrides: Partial<SilentStallItem> = {}): SilentStallItem {
   return {
     id: 's1', title: '스토리', enteredStateAt: '2026-08-25T00:00:00Z', ageHours: 60,
-    assigneeMemberId: null, href: '/board?story=s1', ...overrides,
+    assigneeMemberId: null, href: '/board?story=s1', crossProjectLabel: null, ...overrides,
   };
 }
 
@@ -160,6 +160,28 @@ describe('AttentionClusterBoard', () => {
       const toggle = container.querySelector('button[aria-expanded]') as HTMLButtonElement;
       await act(async () => { toggle.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
       expect(container.textContent).toContain(koMessages.orgBriefing.clusterSilentStallUnassigned);
+    });
+
+    // story #3153(org-wide 커버리지) — 다른 프로젝트 소속 항목만 프로젝트 태그가 붙는다.
+    it('crossProjectLabel이 있는 항목만 프로젝트 태그가 보인다', async () => {
+      await act(async () => {
+        root.render(wrap(
+          <AttentionClusterBoard
+            falsified={[]}
+            silentStall={silentStallClusters({
+              '1mo+': [
+                silentStallItem({ id: 's-same', title: '같은 프로젝트', crossProjectLabel: null }),
+                silentStallItem({ id: 's-other', title: '다른 프로젝트', crossProjectLabel: 'other-proj' }),
+              ],
+            })}
+            {...NO_LOOP}
+          />,
+        ));
+      });
+      const toggle = container.querySelector('button[aria-expanded]') as HTMLButtonElement;
+      await act(async () => { toggle.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(container.textContent).toContain('other-proj');
+      expect(container.textContent?.match(/other-proj/g)).toHaveLength(1);
     });
   });
 

--- a/apps/web/src/components/org-briefing/attention-cluster-board.tsx
+++ b/apps/web/src/components/org-briefing/attention-cluster-board.tsx
@@ -223,7 +223,10 @@ function ageDaysLabel(t: ReturnType<typeof useTranslations>, ageHours: number): 
 function SilentStallExpandedRow({
   item, memberNames, t,
 }: {
-  item: { id: string; title: string; ageHours: number; assigneeMemberId: string | null; href: string };
+  item: {
+    id: string; title: string; ageHours: number; assigneeMemberId: string | null; href: string;
+    crossProjectLabel: string | null;
+  };
   memberNames: Record<string, string>;
   t: ReturnType<typeof useTranslations>;
 }) {
@@ -235,6 +238,9 @@ function SilentStallExpandedRow({
     >
       <span className="w-12 shrink-0 font-mono text-xs text-warning-strong">{ageDaysLabel(t, item.ageHours)}</span>
       <span className="min-w-0 flex-1 truncate text-xs text-foreground">{item.title}</span>
+      {/* story #3153(org-wide) — 항목이 뷰어 활성 프로젝트와 다를 때만 병기(노이즈 절제,
+          derive-attention-clusters.ts의 기존 cross-project 관례와 동형). */}
+      <CrossProjectTag label={item.crossProjectLabel} />
       <span className="shrink-0 truncate text-[10.5px] text-muted-foreground">{owner}</span>
     </Link>
   );

--- a/apps/web/src/components/org-briefing/derive-silent-stall-clusters.test.ts
+++ b/apps/web/src/components/org-briefing/derive-silent-stall-clusters.test.ts
@@ -19,6 +19,8 @@ function item(overrides: Partial<RawSilentStallItem>): RawSilentStallItem {
     entered_state_at: hoursAgo(72),
     entered_state_at_precision: 'exact',
     assignee_member_id: null,
+    project_id: null,
+    project_slug: null,
     ...overrides,
   };
 }
@@ -29,7 +31,7 @@ function response(items: RawSilentStallItem[], populationCount = items.length): 
 
 describe('deriveSilentStallClusters', () => {
   it('null 응답이면 빈 4구간(에러가 아니라 정직한 미가용)', () => {
-    const clusters = deriveSilentStallClusters(null, undefined, null, NOW);
+    const clusters = deriveSilentStallClusters(null, undefined, NOW);
     expect(clusters.totalCount).toBe(0);
     expect(clusters.buckets).toHaveLength(4);
     expect(clusters.buckets.every((b) => b.items.length === 0)).toBe(true);
@@ -38,7 +40,7 @@ describe('deriveSilentStallClusters', () => {
   it('kind가 stalled가 아닌 항목(다른 5신호가 섞여 와도)은 무시한다', () => {
     const clusters = deriveSilentStallClusters(
       response([item({ kind: 'merge_ready', story_id: 's-mr' }), item({ story_id: 's-stalled' })]),
-      undefined, null, NOW,
+      undefined, NOW,
     );
     expect(clusters.totalCount).toBe(1);
     expect(clusters.buckets.flatMap((b) => b.items).map((i) => i.id)).toEqual(['s-stalled']);
@@ -52,7 +54,7 @@ describe('deriveSilentStallClusters', () => {
         item({ story_id: 's-2w', entered_state_at: hoursAgo(24 * 20) }),   // 2w-1mo
         item({ story_id: 's-1mo', entered_state_at: hoursAgo(24 * 45) }),  // 1mo+
       ]),
-      undefined, null, NOW,
+      undefined, NOW,
     );
     const byKey = Object.fromEntries(clusters.buckets.map((b) => [b.key, b.items.map((i) => i.id)]));
     expect(byKey['48h-1w']).toEqual(['s-48h']);
@@ -68,7 +70,7 @@ describe('deriveSilentStallClusters', () => {
         item({ story_id: 's-exact-1w', entered_state_at: hoursAgo(24 * 7) }),
         item({ story_id: 's-exact-1mo', entered_state_at: hoursAgo(24 * 30) }),
       ]),
-      undefined, null, NOW,
+      undefined, NOW,
     );
     const byKey = Object.fromEntries(clusters.buckets.map((b) => [b.key, b.items.map((i) => i.id)]));
     expect(byKey['48h-1w']).toEqual(['s-exact-48h']);
@@ -82,7 +84,7 @@ describe('deriveSilentStallClusters', () => {
         item({ story_id: 's-oldest', entered_state_at: hoursAgo(24 * 40) }),
         item({ story_id: 's-newer', entered_state_at: hoursAgo(24 * 32) }),
       ]),
-      undefined, null, NOW,
+      undefined, NOW,
     );
     // 둘 다 1mo+ 버킷 — BE 순서(oldest 먼저) 그대로 유지돼야 한다.
     const bucket = clusters.buckets.find((b) => b.key === '1mo+')!;
@@ -90,7 +92,7 @@ describe('deriveSilentStallClusters', () => {
   });
 
   it('populationCount·computedAt·totalCount를 raw에서 그대로 옮긴다(지어내지 않음)', () => {
-    const clusters = deriveSilentStallClusters(response([item({})], 42), undefined, null, NOW);
+    const clusters = deriveSilentStallClusters(response([item({})], 42), undefined, NOW);
     expect(clusters.totalCount).toBe(1);
     expect(clusters.populationCount).toBe(42);
     expect(clusters.computedAt).toBe('2026-08-27T12:00:00Z');
@@ -98,29 +100,64 @@ describe('deriveSilentStallClusters', () => {
 
   it('assigneeMemberId를 그대로 옮긴다(이름 해소는 렌더 몫)', () => {
     const clusters = deriveSilentStallClusters(
-      response([item({ assignee_member_id: 'm1' })]), undefined, null, NOW,
+      response([item({ assignee_member_id: 'm1' })]), undefined, NOW,
     );
     expect(clusters.buckets.flatMap((b) => b.items)[0]!.assigneeMemberId).toBe('m1');
   });
 
-  it('href는 projectHref로 조립 — viewer+slug 있으면 project-scoped path', () => {
-    const clusters = deriveSilentStallClusters(
-      response([item({ story_id: 's1' })]),
-      { orgSlug: 'moonklabs', activeProjectId: 'p1' }, 'sprintable', NOW,
-    );
-    expect(clusters.buckets.flatMap((b) => b.items)[0]!.href).toBe('/moonklabs/sprintable/board?story=s1');
-  });
-
   it('items가 배열이 아니면(형상 불일치 — 범용 fetch 스텁 등) crash 없이 빈 4구간으로 삼킨다', () => {
     const brokenShape = { items: 'not-an-array' } as unknown as RawSilentStallResponse;
-    expect(() => deriveSilentStallClusters(brokenShape, undefined, null, NOW)).not.toThrow();
-    expect(deriveSilentStallClusters(brokenShape, undefined, null, NOW).totalCount).toBe(0);
+    expect(() => deriveSilentStallClusters(brokenShape, undefined, NOW)).not.toThrow();
+    expect(deriveSilentStallClusters(brokenShape, undefined, NOW).totalCount).toBe(0);
   });
 
   it('viewer 미제공이면 bare path로 폴백(회귀 0)', () => {
     const clusters = deriveSilentStallClusters(
-      response([item({ story_id: 's1' })]), undefined, null, NOW,
+      response([item({ story_id: 's1', project_id: 'p1', project_slug: 'sprintable' })]), undefined, NOW,
     );
     expect(clusters.buckets.flatMap((b) => b.items)[0]!.href).toBe('/board?story=s1');
+  });
+
+  // story #3153(93b076c8 후속, org-wide 커버리지) — 항목별 project_id/project_slug로
+  // href/병기를 조립한다(더는 단일 activeProjectSlug 인자가 없음 — org-stalled가 여러
+  // 프로젝트를 섞어 낼 수 있어서).
+  describe('cross-project(story #3153)', () => {
+    it('href는 그 항목 소속 프로젝트 slug로 지어진다(뷰어의 활성 프로젝트와 달라도)', () => {
+      const clusters = deriveSilentStallClusters(
+        response([item({ story_id: 's1', project_id: 'p-other', project_slug: 'other-proj' })]),
+        { orgSlug: 'moonklabs', activeProjectId: 'p-active' }, NOW,
+      );
+      expect(clusters.buckets.flatMap((b) => b.items)[0]!.href).toBe('/moonklabs/other-proj/board?story=s1');
+    });
+
+    it('같은 프로젝트 소속이면 crossProjectLabel이 null(노이즈 절제)', () => {
+      const clusters = deriveSilentStallClusters(
+        response([item({ story_id: 's1', project_id: 'p-active', project_slug: 'sprintable' })]),
+        { orgSlug: 'moonklabs', activeProjectId: 'p-active' }, NOW,
+      );
+      expect(clusters.buckets.flatMap((b) => b.items)[0]!.crossProjectLabel).toBeNull();
+    });
+
+    it('다른 프로젝트 소속이면 crossProjectLabel에 project_slug가 채워진다', () => {
+      const clusters = deriveSilentStallClusters(
+        response([item({ story_id: 's1', project_id: 'p-other', project_slug: 'other-proj' })]),
+        { orgSlug: 'moonklabs', activeProjectId: 'p-active' }, NOW,
+      );
+      expect(clusters.buckets.flatMap((b) => b.items)[0]!.crossProjectLabel).toBe('other-proj');
+    });
+
+    it('서로 다른 두 프로젝트 항목이 한 버킷에 섞여도 각자 자기 slug로 href를 갖는다', () => {
+      const clusters = deriveSilentStallClusters(
+        response([
+          item({ story_id: 's-a', project_id: 'p-a', project_slug: 'proj-a', entered_state_at: hoursAgo(72) }),
+          item({ story_id: 's-b', project_id: 'p-b', project_slug: 'proj-b', entered_state_at: hoursAgo(80) }),
+        ]),
+        { orgSlug: 'moonklabs', activeProjectId: 'p-active' }, NOW,
+      );
+      const bucket = clusters.buckets.find((b) => b.key === '48h-1w')!;
+      const byId = Object.fromEntries(bucket.items.map((i) => [i.id, i.href]));
+      expect(byId['s-a']).toBe('/moonklabs/proj-a/board?story=s-a');
+      expect(byId['s-b']).toBe('/moonklabs/proj-b/board?story=s-b');
+    });
   });
 });

--- a/apps/web/src/components/org-briefing/derive-silent-stall-clusters.ts
+++ b/apps/web/src/components/org-briefing/derive-silent-stall-clusters.ts
@@ -1,15 +1,16 @@
 /**
  * story #93b076c8(2250) FE — 「침묵의 정체」구간 묶음. doc `silence-stall-display-spec-93b076c8`
- * (유나 홈, 페드루 GO 2026-08-27). BE(`/api/v2/glance/attention` kind="stalled")는 무변경 계약 —
+ * (유나 홈, 페드루 GO 2026-08-27). BE(`/api/v2/glance/attention/org-stalled` kind="stalled")는
  * 전량·무변화 내림차순 배열만 낸다. 이 파일이 그 배열을 4구간(exclusive)으로 그룹만 한다
  * (개수 자르기 없음 — top-N 기각, «자르면 또 침묵»).
  *
- * ⛔이 엔드포인트는 이미 `project_id` 쿼리파라미터로 스코프돼 응답 전체가 **한 프로젝트**
- * 소속이다 — org-briefing의 다른 클러스터(falsified/loop 등)와 달리 cross-project 표시가
- * 필요 없다(모든 항목이 뷰어의 활성 프로젝트 소속). href 조립은 `projectHref`(기존 재사용,
- * 새 규약 발명 0).
+ * story #3153(93b076c8 후속, org-wide 커버리지 갭) — 소스가 project-scope 단일 `/attention`
+ * 에서 org-wide `/attention/org-stalled`로 바뀌었다(페드루 GO) — 항목이 이제 **여러 프로젝트**
+ * 소속일 수 있다. 그래서 href/병기는 org-briefing의 다른 클러스터(falsified/loop 등)와 동형으로
+ * `projectHref`/`crossProjectLabel`을 항목별 `project_id`/`project_slug`로 조립한다(새 규약
+ * 발명 0 — 기존 재사용).
  */
-import { projectHref, type ViewerContext } from './derive-attention-clusters';
+import { crossProjectLabel, projectHref, type ViewerContext } from './derive-attention-clusters';
 
 export interface RawSilentStallItem {
   kind: string;
@@ -18,6 +19,10 @@ export interface RawSilentStallItem {
   entered_state_at: string | null;
   entered_state_at_precision: string | null;
   assignee_member_id: string | null;
+  // story #3153 — org-stalled 엔드포인트만 채운다(단일-project `/attention` 소비자는 항상
+  // null, BE 계약 그대로 — 회귀 0).
+  project_id: string | null;
+  project_slug: string | null;
 }
 
 export interface RawSilentStallResponse {
@@ -33,6 +38,7 @@ export interface SilentStallItem {
   ageHours: number;
   assigneeMemberId: string | null;
   href: string;
+  crossProjectLabel: string | null;
 }
 
 export type SilentStallBucketKey = '48h-1w' | '1w-2w' | '2w-1mo' | '1mo+';
@@ -74,13 +80,12 @@ function bucketKeyFor(ageHours: number): SilentStallBucketKey | null {
 }
 
 /**
- * raw `/glance/attention` 응답 → 4구간 클러스터. `now`는 테스트 주입용(기본 `Date.now()`) —
- * 순수 함수 유지(파일 어디도 암묵적으로 시각을 캡처하지 않는다).
+ * raw `/glance/attention/org-stalled` 응답 → 4구간 클러스터. `now`는 테스트 주입용(기본
+ * `Date.now()`) — 순수 함수 유지(파일 어디도 암묵적으로 시각을 캡처하지 않는다).
  */
 export function deriveSilentStallClusters(
   raw: RawSilentStallResponse | null,
   viewer: ViewerContext | undefined,
-  activeProjectSlug: string | null,
   now: number = Date.now(),
 ): SilentStallClusters {
   // derive-exception-signals.ts와 동형 shape-safety — 같은 프록시(apiSuccess 이중랩) 소스라
@@ -97,7 +102,8 @@ export function deriveSilentStallClusters(
         enteredStateAt: i.entered_state_at as string,
         ageHours,
         assigneeMemberId: i.assignee_member_id,
-        href: projectHref(viewer, activeProjectSlug, `/board?story=${i.story_id}`),
+        href: projectHref(viewer, i.project_slug, `/board?story=${i.story_id}`),
+        crossProjectLabel: crossProjectLabel(viewer, i.project_id, i.project_slug),
       };
     });
 

--- a/apps/web/src/components/org-briefing/now-face.tsx
+++ b/apps/web/src/components/org-briefing/now-face.tsx
@@ -29,22 +29,18 @@ interface NowFaceLoad {
   memberNames: Record<string, string>;
 }
 
-async function loadNowFace(
-  t: NowFaceTranslator, viewer: ViewerContext, projectId: string | undefined, projectSlug: string | undefined,
-): Promise<NowFaceLoad> {
+async function loadNowFace(t: NowFaceTranslator, viewer: ViewerContext): Promise<NowFaceLoad> {
   // story #2689 — 콜드 재진입 시 raw fetch는 401을 재시도 없이 삼켜(!r.ok=>null) "지금" 면이
   // 빈 채로 60초 REFRESH_MS까지 안 채워졌다. fetchWithAuth로 401→refresh→재시도 경로에 태운다.
   // story #2852 — agent_auth_failure 클러스터가 member_id만 갖고 있어(BE가 이름을 안 줌)
   // 이름 표시엔 /api/team-members가 필요하다(workforce-face.tsx parseTeamMembers와 동형 소비).
-  // story #93b076c8(2250) — 「침묵의 정체」는 project-scope 전용 별도 BE 엔드포인트라
-  // projectId 없인 조회 자체가 무의미(다른 세 fetch와 달리 조건부).
+  // story #3153(93b076c8 후속) — 「침묵의 정체」는 이제 org-wide 엔드포인트(접근 가능한 전
+  // 프로젝트를 BE가 순회) — project_id 조건부 fetch가 아니라 다른 fetch들과 동형 무조건 호출.
   const [ma, notifs, membersJson, attentionJson] = await Promise.all([
     fetchWithAuth('/api/dashboard/my-actions').then((r) => (r.ok ? r.json() : null)).catch(() => null),
     fetchWithAuth('/api/notifications?type=task_completed&unread=true').then((r) => (r.ok ? r.json() : null)).catch(() => null),
     fetchWithAuth('/api/team-members').then((r) => (r.ok ? r.json() : null)).catch(() => null),
-    projectId
-      ? fetchWithAuth(`/api/glance/attention?project_id=${projectId}`).then((r) => (r.ok ? r.json() : null)).catch(() => null)
-      : Promise.resolve(null),
+    fetchWithAuth('/api/glance/attention/org-stalled').then((r) => (r.ok ? r.json() : null)).catch(() => null),
   ]);
   const raw = parseMyActions(ma);
   return {
@@ -64,7 +60,7 @@ async function loadNowFace(
     // FE 프록시가 apiSuccess로 한 번 더 감싸 실제 payload는 {data:{items,…}}다(derive-exception-
     // signals.ts와 동형 크럭스 — glance.py AttentionResponse envelope 이중랩).
     silentStall: deriveSilentStallClusters(
-      (attentionJson as { data?: RawSilentStallResponse } | null)?.data ?? null, viewer, projectSlug ?? null,
+      (attentionJson as { data?: RawSilentStallResponse } | null)?.data ?? null, viewer,
     ),
     memberNames: parseTeamMembers(membersJson),
   };
@@ -124,13 +120,13 @@ export function NowFace() {
   // story #2842 — loop-face.tsx와 동형(orgMemberships에서 orgSlug 파생). useMemo로 orgId/
   // projectId(원시값)가 실제로 바뀔 때만 새 참조를 만든다 — 매 렌더 새 객체면 아래 effect가
   // 무한 재구독된다.
-  const { orgId, orgMemberships, projectId, currentProjectSlug } = useDashboardContext();
+  const { orgId, orgMemberships, projectId } = useDashboardContext();
   const orgSlug = orgMemberships.find((o) => o.orgId === orgId)?.orgSlug;
   const viewer = useMemo<ViewerContext>(() => ({ orgSlug, activeProjectId: projectId }), [orgSlug, projectId]);
 
   useEffect(() => {
     const load = async () => {
-      const result = await loadNowFace(t, viewer, projectId, currentProjectSlug);
+      const result = await loadNowFace(t, viewer);
       setItems(result.items);
       setClusters(result.clusters);
       setSilentStall(result.silentStall);
@@ -139,7 +135,7 @@ export function NowFace() {
     void load();
     const id = setInterval(() => void load(), REFRESH_MS);
     return () => clearInterval(id);
-  }, [t, viewer, projectId, currentProjectSlug]);
+  }, [t, viewer]);
 
   const list = items ?? [];
   const shown = expanded ? list : list.slice(0, CAP);

--- a/backend/app/routers/glance.py
+++ b/backend/app/routers/glance.py
@@ -59,9 +59,10 @@ from app.models.gate import AUTO_VERIFY_MAP as _GATE_AUTO_VERIFY_MAP
 from app.models.gate import Gate
 from app.models.member import Member
 from app.models.pm import Story, StoryActivity
+from app.models.project import Project
 from app.models.workflow_line import WorkflowLineStepApproval
 from app.services.evidence_service import batch_human_verified
-from app.services.project_auth import has_project_access
+from app.services.project_auth import accessible_project_ids_in_org, has_project_access
 from app.services.trust_pipeline import batch_unresolved_blocker, batch_verify_fail
 
 router = APIRouter(prefix="/api/v2/glance", tags=["glance", "Work"])
@@ -159,6 +160,13 @@ class AttentionItem(BaseModel):
     # 기존 memberNames 해소 사슬으로 이름을 붙인다). stalled 외 5종은 항상 None(기존 소비자
     # 무영향 — 아래 회귀 테스트로 고정).
     assignee_member_id: uuid.UUID | None = None
+    # story #3153(93b076c8 후속·org-wide 커버리지 갭) — org-stalled 전용 additive 필드.
+    # 이 project_id 단일-스코프 엔드포인트(`/attention`)의 5+1종 소비자는 항상 None(무회귀) —
+    # 프로젝트가 쿼리파라미터로 이미 고정돼 있어 항목마다 반복해 실을 이유가 없었다. org 전체를
+    # 훑는 `/attention/org-stalled`만 이 필드를 채운다(항목이 어느 프로젝트 소속인지 FE가
+    # projectHref/crossProjectLabel로 라우팅하려면 필수).
+    project_id: uuid.UUID | None = None
+    project_slug: str | None = None
 
 
 class AttentionResponse(BaseModel):
@@ -177,19 +185,14 @@ class AttentionResponse(BaseModel):
     stalled_population_count: int
 
 
-@router.get("/attention", response_model=AttentionResponse)
-async def glance_attention(
-    project_id: uuid.UUID = Query(...),
-    # story #2451(§6 Phase3 A1): 대시보드 집계·create→self-read 흐름 없음 → read replica.
-    session: AsyncSession = Depends(get_read_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
-    auth: AuthContext = Depends(get_current_user),
+async def _compute_attention_for_project(
+    session: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID,
 ) -> AttentionResponse:
-    """현 프로젝트 예외 스트림. project-scope 실신호만·활동량/순위 0·없으면 빈배열."""
-    # project-scope 가드(resource-actual): 접근권 없는 project의 예외 신호 노출 차단(404·존재 비노출).
-    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
-        raise HTTPException(status_code=404, detail="Project not found")
-
+    """story #3153 — `/attention`(단일 project)과 `/attention/org-stalled`(org 전체) 양쪽이
+    공유하는 실 계산 본체. 호출자가 이미 접근권을 확인했다고 가정한다(이 함수는 access
+    check를 안 함 — org-stalled 쪽은 project별로 이미 `accessible_project_ids_in_org`로
+    걸러진 id만 넘긴다). 로직 재구현 0(쌍둥이 시스템 금지) — org-wide 집계도 이 프로젝트가
+    단독으로 계산했을 때와 100% 같은 결과(AC5 배타 포함)를 낸다."""
     items: list[AttentionItem] = []
 
     # ① gate_pending = 프로젝트의 pending blocking approval(그 gate의 story title enrich).
@@ -411,6 +414,70 @@ async def glance_attention(
     return AttentionResponse(
         items=items, stalled_computed_at=_now,
         stalled_population_count=len(stalled_population_rows),
+    )
+
+
+@router.get("/attention", response_model=AttentionResponse)
+async def glance_attention(
+    project_id: uuid.UUID = Query(...),
+    # story #2451(§6 Phase3 A1): 대시보드 집계·create→self-read 흐름 없음 → read replica.
+    session: AsyncSession = Depends(get_read_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> AttentionResponse:
+    """현 프로젝트 예외 스트림. project-scope 실신호만·활동량/순위 0·없으면 빈배열."""
+    # project-scope 가드(resource-actual): 접근권 없는 project의 예외 신호 노출 차단(404·존재 비노출).
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+    return await _compute_attention_for_project(session, org_id, project_id)
+
+
+@router.get("/attention/org-stalled", response_model=AttentionResponse)
+async def glance_attention_org_stalled(
+    session: AsyncSession = Depends(get_read_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> AttentionResponse:
+    """story #3153(93b076c8 후속) — 「침묵의 정체」org-wide 커버리지 갭 메움.
+
+    `/attention`은 project_id 단일 스코프라 org-briefing처럼 "전 프로젝트"를 훑는 표면에서
+    다른 프로젝트의 침묵을 못 본다(옛 story_stalled 신호는 org-wide였는데 신규 신호는
+    project-scope인 회귀 — 페드루 판정, story #3556 후속 등재). 이 엔드포인트는 사용자가
+    접근 가능한 전 프로젝트에 대해 `_compute_attention_for_project`를 그대로(재구현 0)
+    돌려 kind="stalled"만 뽑아 합친다 — 5종(gate_pending 등)은 이미 프로젝트별 보드/글랜스에
+    각자 표시되므로 org-wide로 안 낸다(스코프 유지, 이 엔드포인트 존재 이유가 아님).
+
+    ⚠️N-프로젝트 쿼리 비용 — 프로젝트마다 `_compute_attention_for_project` 전체(6종 계산)를
+    돈다(stalled AC5 배타가 나머지 5종 계산을 요구하므로 부분 재사용 불가). 프로젝트 수가
+    많은 org에서는 비용이 선형 증가한다 — 지금은 dev 실측(소수 프로젝트) 기준으로 충분하나,
+    프로젝트 수가 커지면 재검토 필요(후속 스코프, 이 PR에서 최적화 안 함)."""
+    project_ids = await accessible_project_ids_in_org(session, uuid.UUID(auth.user_id), org_id)
+    if not project_ids:
+        return AttentionResponse(items=[], stalled_computed_at=datetime.now(timezone.utc), stalled_population_count=0)
+
+    slug_rows = (
+        await session.execute(select(Project.id, Project.slug).where(Project.id.in_(project_ids)))
+    ).all()
+    slug_map = {pid: slug for pid, slug in slug_rows}
+
+    all_stalled: list[AttentionItem] = []
+    total_population = 0
+    for project_id in project_ids:
+        resp = await _compute_attention_for_project(session, org_id, project_id)
+        total_population += resp.stalled_population_count
+        for item in resp.items:
+            if item.kind != "stalled":
+                continue
+            item.project_id = project_id
+            item.project_slug = slug_map.get(project_id)
+            all_stalled.append(item)
+
+    # ⛔BE는 top-N으로 자르지 않는다(단일-프로젝트 `/attention`과 동일 규율) — 무변화
+    # 내림차순(entered_state_at 오름차순, 가장 오래 안 바뀐 것 먼저) 전량 정렬.
+    all_stalled.sort(key=lambda item: item.entered_state_at)
+    return AttentionResponse(
+        items=all_stalled, stalled_computed_at=datetime.now(timezone.utc),
+        stalled_population_count=total_population,
     )
 
 

--- a/backend/tests/test_3153_glance_org_stalled_realdb.py
+++ b/backend/tests/test_3153_glance_org_stalled_realdb.py
@@ -1,0 +1,304 @@
+"""story #3153(93b076c8/#2250 후속) 실PG 테스트 — `/api/v2/glance/attention/org-stalled`.
+
+문제: `/attention`은 project_id 단일 스코프라 org-briefing처럼 "전 프로젝트"를 훑는 표면에서
+다른 프로젝트의 침묵을 못 본다(옛 story_stalled는 org-wide였는데 신규 stalled 신호는
+project-scope인 회귀). 이 엔드포인트는 접근 가능한 전 프로젝트에 대해 기존 `/attention`과
+동일 계산(`_compute_attention_for_project`, 재구현 0)을 돌려 kind="stalled"만 합친다.
+
+AC 축: ①여러 프로젝트의 stalled가 하나로 합쳐짐 ②각 항목에 project_id/project_slug가 실림
+(단일 `/attention`은 이 필드가 항상 None — 회귀 0) ③population_count가 프로젝트별 합
+④접근권 없는 프로젝트는 절대 안 섞임(has_project_access 3-branch 우회 없음) ⑤AC5(1~6 배타)가
+org-wide에서도 유지 — 한 프로젝트에서 gate_pending인 스토리가 그 프로젝트에서는 stalled로
+안 나옴(재구현이 아니라 같은 함수 재사용이므로 당연 성립·회귀 가드용) ⑥정렬(전량, 가장 오래
+무변화 먼저) 유지.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _story(org_id, project_id, title, status="in-progress"):
+    from app.models.pm import Story
+    return Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status=status)
+
+
+async def _seed_two_projects(session):
+    """org 1개 + project 2개(caller가 둘 다 접근 가능) + 접근권 없는 project 1개(누출 가드용)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="A", slug="proj-a")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="B", slug="proj-b")
+    project_forbidden = Project(id=uuid.uuid4(), org_id=org.id, name="Forbidden", slug="proj-forbidden")
+    session.add_all([project_a, project_b, project_forbidden])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(om)
+    await session.commit()
+    # caller는 A·B만 grant — forbidden은 의도적으로 안 줌(누출 가드).
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=project_a.id, org_member_id=om.id, permission="granted", role="member"),
+        ProjectAccess(id=uuid.uuid4(), project_id=project_b.id, org_member_id=om.id, permission="granted", role="member"),
+    ])
+    await session.commit()
+    return {
+        "org_id": org.id, "caller_id": caller_id,
+        "project_a": project_a.id, "project_b": project_b.id, "project_forbidden": project_forbidden.id,
+    }
+
+
+async def _seed_status_changed_activity(session, org_id, project_id, story_id, created_at, new_value="in-progress"):
+    from app.models.pm import StoryActivity
+    from sqlalchemy import update
+    row = StoryActivity(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, story_id=story_id,
+        activity_type="status_changed", old_value="backlog", new_value=new_value,
+        created_by=uuid.uuid4(),
+    )
+    session.add(row)
+    await session.flush()
+    await session.execute(update(StoryActivity).where(StoryActivity.id == row.id).values(created_at=created_at))
+    await session.commit()
+    return row
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+_OLD = timedelta(hours=72)
+
+
+@pytest.mark.anyio
+async def test_stalled_items_merged_across_accessible_projects_with_project_tags():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_projects(s)
+            story_a = _story(seeded["org_id"], seeded["project_a"], "Silent A")
+            story_b = _story(seeded["org_id"], seeded["project_b"], "Silent B")
+            s.add_all([story_a, story_b])
+            await s.commit()
+            now = datetime.now(timezone.utc)
+            await _seed_status_changed_activity(s, seeded["org_id"], seeded["project_a"], story_a.id, now - _OLD)
+            await _seed_status_changed_activity(s, seeded["org_id"], seeded["project_b"], story_b.id, now - _OLD)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/glance/attention/org-stalled")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            ids = {i["story_id"] for i in body["items"]}
+            assert ids == {str(story_a.id), str(story_b.id)}
+            by_id = {i["story_id"]: i for i in body["items"]}
+            assert by_id[str(story_a.id)]["project_id"] == str(seeded["project_a"])
+            assert by_id[str(story_a.id)]["project_slug"] == "proj-a"
+            assert by_id[str(story_b.id)]["project_id"] == str(seeded["project_b"])
+            assert by_id[str(story_b.id)]["project_slug"] == "proj-b"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_single_project_attention_never_carries_project_tags_no_regression():
+    """기존 `/attention`(단일 project) 소비자는 이 필드가 항상 None — 회귀 0."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_projects(s)
+            story = _story(seeded["org_id"], seeded["project_a"], "Silent")
+            s.add(story)
+            await s.commit()
+            await _seed_status_changed_activity(
+                s, seeded["org_id"], seeded["project_a"], story.id, datetime.now(timezone.utc) - _OLD,
+            )
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['project_a']}")
+            assert resp.status_code == 200, resp.text
+            item = next(i for i in resp.json()["items"] if i["kind"] == "stalled")
+            assert item["project_id"] is None
+            assert item["project_slug"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_forbidden_project_never_leaks_into_org_stalled():
+    """접근권 없는 프로젝트의 stalled는 org-stalled에도 절대 안 섞인다(has_project_access와
+    동일 3-branch 우회 없음 — accessible_project_ids_in_org 재사용 회귀가드)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_projects(s)
+            forbidden_story = _story(seeded["org_id"], seeded["project_forbidden"], "Secret Stalled")
+            s.add(forbidden_story)
+            await s.commit()
+            await _seed_status_changed_activity(
+                s, seeded["org_id"], seeded["project_forbidden"], forbidden_story.id,
+                datetime.now(timezone.utc) - _OLD,
+            )
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/glance/attention/org-stalled")
+            assert resp.status_code == 200, resp.text
+            ids = {i["story_id"] for i in resp.json()["items"]}
+            assert str(forbidden_story.id) not in ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_population_count_sums_across_projects():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_projects(s)
+            # A에 2건(모집단), B에 1건(모집단) — 48h 문턱 무관, non-done/non-backlog 활성이면 모집단.
+            s.add_all([
+                _story(seeded["org_id"], seeded["project_a"], "A1"),
+                _story(seeded["org_id"], seeded["project_a"], "A2"),
+                _story(seeded["org_id"], seeded["project_b"], "B1"),
+            ])
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/glance/attention/org-stalled")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["stalled_population_count"] == 3
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_accessible_projects_returns_empty_not_error():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        from app.models.organization import Organization
+        from app.models.user import User
+
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="EmptyOrg", slug=f"empty-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            caller_id = uuid.uuid4()
+            s.add(User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x"))
+            await s.commit()
+
+        await _setup_app(app, Session, caller_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/glance/attention/org-stalled")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["items"] == []
+            assert body["stalled_population_count"] == 0
+            assert body["stalled_computed_at"] is not None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
[SID:3153]

## Summary
- 원인: 옛 story_stalled(org-wide)를 대체한 신규 stalled 신호(`/glance/attention`)는 project_id 단일 스코프라, org-briefing처럼 "전 프로젝트"를 훑는 표면에서 다른 프로젝트의 침묵을 못 보는 회귀(story #93b076c8 후속 등재분).
- BE: `glance.py`의 6종 계산 본체를 `_compute_attention_for_project()`로 추출(재구현 0) — 기존 `/attention`은 접근권 확인 후 이 함수에 위임하는 얇은 래퍼로만 남아 회귀 0. 신규 `GET /attention/org-stalled`가 `accessible_project_ids_in_org`로 접근 가능한 전 프로젝트를 순회해 같은 함수를 돌리고 `kind="stalled"`만 뽑아 합친다(AC5 배타가 나머지 5종 계산을 요구해 부분 재사용 불가 — 쿼리 비용은 프로젝트 수에 선형, dev 실측 기준 소수 프로젝트라 수용 가능 판단, docstring에 후속 검토 필요성 명기).
- `AttentionItem`에 `project_id`/`project_slug` additive 필드(org-stalled 엔드포인트만 채움, 기존 `/attention` 소비자는 항상 None — 회귀 0).
- FE: `now-face.tsx`가 project_id 조건부 단일-프로젝트 fetch에서 org-stalled 무조건 fetch로 전환. `derive-silent-stall-clusters.ts`가 단일 `activeProjectSlug` 인자 대신 항목별 `project_id`/`project_slug`로 `projectHref`/`crossProjectLabel` 조립(`derive-attention-clusters.ts`의 기존 cross-project 관례 재사용, 새 규약 발명 0). `SilentStallExpandedRow`에 `CrossProjectTag` 추가.

## Test plan
- [x] 신규 realdb 테스트(`test_3153_glance_org_stalled_realdb.py`, 5건): 다중 프로젝트 stalled 병합+프로젝트 태그, 단일 `/attention`은 태그 항상 None(회귀), 접근권 없는 프로젝트 누출 가드, population_count 프로젝트간 합산, 접근 가능 프로젝트 0건 시 빈 응답
- [x] 인접 glance/command_center 스위트 65건 전수 green(회귀 0)
- [x] FE `tsc --noEmit` 0, `eslint` 0
- [x] FE `vitest run`(전체) — 522 files / 4855 tests green
- [x] 접근권 가드(BE)와 href/crossProjectLabel 로직(FE) 모두 mutation-test로 RED 확인 후 GREEN 복원

🤖 Generated with [Claude Code](https://claude.com/claude-code)