### PR TITLE
[SID:3154] dashboard command-center의 story_stalled 죽은 소비자 정리

### DIFF
--- a/apps/web/src/components/dashboard/command-center/action-zone.test.tsx
+++ b/apps/web/src/components/dashboard/command-center/action-zone.test.tsx
@@ -52,11 +52,13 @@ describe('ActionZone attention row (command-center-surveillance-reframe-handoff 
   });
 });
 
-// story #3150(시연 리허설 발견) — AttentionItem이 실제로는 8종인데 AttentionRow가
-// 'agent_stuck' 전용 필드(entity_id/entity_type)만 읽어 나머지 7종은 <span class="font-medium">
+// story #3150(시연 리허설 발견) — AttentionItem이 실제로는 (당시)8종인데 AttentionRow가
+// 'agent_stuck' 전용 필드(entity_id/entity_type)만 읽어 나머지는 <span class="font-medium">
 // 이 통째로 공백 렌더되던 것(58건 실측). 각 타입이 BE(#2538 계약)가 이미 싣는 title/
-// statement/blocked_story_title을 그대로 보여주는지 회귀가드.
-describe('ActionZone attention row — story #3150 8종 전수(BE title/statement 폴백 없이 직접 소비)', () => {
+// statement/blocked_story_title을 그대로 보여주는지 회귀가드. ⛔story #3154 — 'story_stalled'
+// 는 BE가 완전 제거해(story #93b076c8, twin 신호 정리) 지금은 7종 → 6종 전수(이 describe
+// 스코프)만 남았다.
+describe('ActionZone attention row — story #3150 6종 전수(BE title/statement 폴백 없이 직접 소비)', () => {
   function attentionData(item: MyActions['attention']['items'][number]): MyActions {
     return {
       action_queue: { scope: 'project', items: [] },
@@ -64,16 +66,6 @@ describe('ActionZone attention row — story #3150 8종 전수(BE title/statemen
       is_clear: false,
     };
   }
-
-  it('story_stalled — title+stalled_days를 그대로 보여준다(공백 아님)', () => {
-    const markup = renderToStaticMarkup(wrap(<ActionZone
-      data={attentionData({ type: 'story_stalled', severity: 'warn', auto_detected: true, title: '결제 마이그레이션 정리', story_id: 's1', stalled_days: 42, project_id: 'p1' })}
-      resolveName={() => null} epicTitles={{}}
-    />));
-    expect(markup).toContain('결제 마이그레이션 정리');
-    expect(markup).toContain('42일째');
-    expect(markup).not.toContain('<span class="font-medium"></span>'); // 회귀가드 — 정확히 이 실측 공백 패턴
-  });
 
   it('unanswered_blocker — blocked_story_title+age_days를 그대로 보여준다', () => {
     const markup = renderToStaticMarkup(wrap(<ActionZone

--- a/apps/web/src/components/dashboard/command-center/action-zone.tsx
+++ b/apps/web/src/components/dashboard/command-center/action-zone.tsx
@@ -28,8 +28,8 @@ function gateLabel(t: ReturnType<typeof useTranslations>, gateType: string | nul
   return key ? t(key) : t('ccGateGeneric');
 }
 
-// story #3150 — AttentionItem 8종(types.ts 참조) 공통 식별명 추출. agent_stuck만 id 재해소가
-// 필요(entity_id가 멤버/에픽 id)하고, 나머지 7종은 BE(#2538 계약)가 title/statement/
+// story #3150 — AttentionItem 7종(types.ts 참조) 공통 식별명 추출. agent_stuck만 id 재해소가
+// 필요(entity_id가 멤버/에픽 id)하고, 나머지 6종은 BE(#2538 계약)가 title/statement/
 // blocked_story_title을 이미 직접 싣는다 — 그 필드를 그대로 쓰면 된다(재해소 시도 자체가
 // 이 버그의 원인이었다: resolveName이 멤버/에픽 id만 알아 story 스코프 항목에서 늘 null).
 function attentionEntityLabel(
@@ -42,7 +42,6 @@ function attentionEntityLabel(
       return resolveName(item.entity_id) ?? epicTitles[item.entity_id] ?? item.entity_type;
     case 'agent_auth_failure':
       return resolveName(item.member_id) ?? item.reason;
-    case 'story_stalled':
     case 'loop_overdue_goal':
     case 'loop_outcome_missing_goal':
       return item.title;
@@ -55,28 +54,26 @@ function attentionEntityLabel(
 }
 
 // story #3150 — 부제 텍스트. agent_stuck은 기존 게이트 카피 그대로 유지(회귀 0). 나머지는
-// BE가 실어 보내는 경과일수 필드(타입마다 이름이 다르다 — stalled_days/age_days/
-// falsified_days/overdue_days/done_days) 중 있는 것을 그대로 보여준다(no-fiction: 실측값만,
-// 지어낸 사유 문구 0).
+// BE가 실어 보내는 경과일수 필드(타입마다 이름이 다르다 — age_days/falsified_days/
+// overdue_days/done_days) 중 있는 것을 그대로 보여준다(no-fiction: 실측값만, 지어낸 사유
+// 문구 0).
 function attentionDetailText(t: ReturnType<typeof useTranslations>, item: AttentionItem): string {
   if (item.type === 'agent_stuck') return t('ccAgentStuck', { gate: gateLabel(t, item.gate_type) });
   if (item.type === 'agent_auth_failure') return t('ccAttentionAuthFailure', { count: item.failure_count });
   const days =
-    item.type === 'story_stalled' ? item.stalled_days
-    : item.type === 'unanswered_blocker' ? item.age_days
+    item.type === 'unanswered_blocker' ? item.age_days
     : item.type === 'hypothesis_falsified' ? item.falsified_days
     : item.type === 'loop_overdue_hypothesis' || item.type === 'loop_overdue_goal' ? item.overdue_days
     : item.done_days; // loop_outcome_missing_goal
   return days != null ? t('ccAttentionDays', { days }) : t('ccAttentionGeneric');
 }
 
-// story #3150 — 8종 각자 id 필드명이 달라(entity_id/member_id/story_id/blocked_story_id/
+// story #3150 — 7종 각자 id 필드명이 달라(entity_id/member_id/blocked_story_id/
 // hypothesis_id/goal_id) React key용 공통 추출.
 function attentionItemKey(item: AttentionItem): string {
   switch (item.type) {
     case 'agent_stuck': return item.entity_id;
     case 'agent_auth_failure': return item.member_id;
-    case 'story_stalled': return item.story_id;
     case 'unanswered_blocker': return item.blocked_story_id;
     case 'hypothesis_falsified':
     case 'loop_overdue_hypothesis': return item.hypothesis_id;

--- a/apps/web/src/components/dashboard/command-center/types.ts
+++ b/apps/web/src/components/dashboard/command-center/types.ts
@@ -25,11 +25,14 @@ export interface QueueItem {
 }
 
 // story #3150(시연 리허설 발견) — 이 타입이 'agent_stuck' 하나뿐이라고 선언돼 있었는데
-// command_center.py는 실제로 8종을 낸다(agent_stuck·agent_auth_failure·story_stalled·
-// unanswered_blocker·hypothesis_falsified·loop_overdue_hypothesis·loop_overdue_goal·
-// loop_outcome_missing_goal — grep '"type": "' command_center.py 전수). 나머지 7종은
-// entity_id/entity_type이 아예 없는데 AttentionRow가 그 필드만 읽어(resolveName 경유)
-// 공백을 렌더했다 — 이 타입을 실제 union으로 넓혀 각 shape이 실 payload와 맞게 한다.
+// command_center.py는 실제로 7종을 낸다(agent_stuck·agent_auth_failure·unanswered_blocker·
+// hypothesis_falsified·loop_overdue_hypothesis·loop_overdue_goal·loop_outcome_missing_goal
+// — grep '"type": "' command_center.py 전수). ⛔story #93b076c8(2250)에서 'story_stalled'
+// (org-wide·Story.updated_at 기준·부정확 확定)를 BE가 완전 제거(twin 신호 정리, org-briefing
+// NowFace의 「침묵의 정체」org-wide 클러스터로 대체) — story #3154에서 이 죽은 소비자 가지를
+// FE에서도 걷어냈다(BE가 안 내는 타입을 union에 남겨 두면 다음 사람이 아직 산 것으로 착각).
+// 나머지 6종은 entity_id/entity_type이 아예 없는데 AttentionRow가 그 필드만 읽어(resolveName
+// 경유) 공백을 렌더했다 — 이 타입을 실제 union으로 넓혀 각 shape이 실 payload와 맞게 한다.
 // ⛔QueueItem 상단 주석과 같은 재발방지 원칙 — BE가 종을 늘리면 여기·action-zone.tsx
 // attentionEntityLabel/attentionDayCount 둘 다 맞춰야 한다.
 export type AttentionItem =
@@ -51,15 +54,6 @@ export type AttentionItem =
       failure_count: number;
       first_failed_at: string | null;
       last_failed_at: string | null;
-    }
-  | {
-      type: 'story_stalled';
-      severity: string;
-      auto_detected: boolean;
-      title: string;
-      story_id: string;
-      stalled_days: number | null;
-      project_id: string;
     }
   | {
       type: 'unanswered_blocker';


### PR DESCRIPTION
[SID:3154]

## Summary
- PR#3554(SID:3150) 착지 시점엔 아직 살아있던 `story_stalled` 타입을 story #93b076c8(2250) PR#3556이 BE(`command_center.py`)에서 완전 제거(twin 신호 정리, org-briefing NowFace의 「침묵의 정체」org-wide 클러스터로 대체) — 이 대시보드 표면(`dashboard/command-center`)만 그 타입을 여전히 union·렌더 분기·테스트에 들고 있던 죽은 가지였다(BE가 안 내는 타입, 당장 깨지진 않지만 죽은 배선).
- `types.ts`의 `AttentionItem` union에서 `story_stalled` variant 제거.
- `action-zone.tsx`의 3개 switch/조건 분기(`attentionEntityLabel`·`attentionDetailText`·`attentionItemKey`) 정리.
- `action-zone.test.tsx`의 전용 테스트 제거 — 나머지 6종 각각의 동형 회귀가드는 그대로 유지("58건 공백 렌더" 회귀 클래스 커버리지 무손).
- 재접속(project-scope stalled 신호를 이 화면에 다시 연결할지) 여부는 이 PR 스코프 밖 — org-briefing NowFace가 이미 org-wide 「침묵의 정체」를 잘 다루고 있어 지금은 재구현 불요로 판단, 재검토 필요 시 별도 판정 요청.

## Test plan
- [x] FE `tsc --noEmit` 0
- [x] `eslint` 0
- [x] `vitest run`(전체) — 522 files / 4850 tests green(회귀 0)
- [x] 남은 6종 각각의 개별 non-blank 렌더 회귀가드 그대로 통과 확인(story #3150 공백 렌더 재발 클래스 커버리지 무손)

🤖 Generated with [Claude Code](https://claude.com/claude-code)