### PR TITLE
[SID:3160] 웹 프록시 /api/stories exclude_status/no_sprint 배선 + 재발봉인 가드

### DIFF
--- a/apps/web/src/app/api/stories/route.test.ts
+++ b/apps/web/src/app/api/stories/route.test.ts
@@ -105,3 +105,55 @@ describe('/api/stories GET — unattached=true 분기(story #2534, 카디르 QA 
     expect(res.status).toBe(500);
   });
 });
+
+// story #3160(#3148 라이브 대조 중 PO 발견) — no_sprint=true도 unattached와 동형으로 raw
+// proxy 조기분기를 타야 한다(BE list_backlog 분기는 cursor 미지원·X-Total-Count 계약이라
+// 아래 cursor 페이지네이션 가정과 안 맞음). exclude_status는 cursor 경로(일반 service.list)
+// 에도 화이트리스트로 추가돼 있어야 한다(«화이트리스트 유지+3자리 추가» PO 판정).
+describe('/api/stories GET — no_sprint=true 분기 라우팅(story #3160)', () => {
+  beforeEach(() => {
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createStoryRepository.mockResolvedValue({});
+  });
+
+  it('no_sprint=true는 unattached와 동형으로 raw proxy를 탄다(StoryService 미호출)', async () => {
+    h.proxyToFastapi.mockResolvedValue(new Response(
+      JSON.stringify([story('1')]),
+      { status: 200, headers: { 'x-total-count': '9' } },
+    ));
+    const res = await GET(new Request('http://localhost/api/stories?project_id=p&no_sprint=true&exclude_status=done,in-review'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.meta.total).toBe(9);
+    expect(h.list).not.toHaveBeenCalled();
+    // raw proxy는 원본 쿼리스트링을 그대로 전달(fastapi-proxy.ts url.search) — exclude_status가
+    // 이 분기에선 화이트리스트 없이 이미 통과한다는 것을 호출 인자로 확인.
+    expect(h.proxyToFastapi).toHaveBeenCalledWith(expect.any(Request), '/api/v2/stories');
+    const forwardedUrl = (h.proxyToFastapi.mock.calls[0]![0] as Request).url;
+    expect(forwardedUrl).toContain('no_sprint=true');
+    expect(forwardedUrl).toContain('exclude_status=done,in-review');
+  });
+});
+
+describe('/api/stories GET — exclude_status 화이트리스트 전달(cursor 경로, story #3148/#3160)', () => {
+  beforeEach(() => {
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createStoryRepository.mockResolvedValue({});
+  });
+
+  it('exclude_status가 (no_sprint 없이도) StoryService.list()에 전달된다 — 프록시가 삼키지 않는다', async () => {
+    h.list.mockResolvedValue([story('1')]);
+    await GET(new Request('http://localhost/api/stories?project_id=p&exclude_status=done'));
+    const calledWith = h.list.mock.calls[0]![0] as { exclude_status?: string };
+    expect(calledWith.exclude_status).toBe('done');
+  });
+
+  it('exclude_status 미지정이면 undefined로 넘어간다(지어내지 않음, 회귀 0)', async () => {
+    h.list.mockResolvedValue([story('1')]);
+    await GET(new Request('http://localhost/api/stories?project_id=p'));
+    const calledWith = h.list.mock.calls[0]![0] as { exclude_status?: string };
+    expect(calledWith.exclude_status).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/api/stories/route.ts
+++ b/apps/web/src/app/api/stories/route.ts
@@ -54,7 +54,14 @@ export async function GET(request: Request) {
     // 레벨에서 걸러 X-Total-Count로 «정확한 전체 총계»를 이미 낸다(story #2190 backlog
     // route와 동형 헤더) — StoryService 추상 대신 raw proxy로 그 헤더를 그대로 meta.total에
     // 실어 보낸다(limit=100은 목록 표시용으로 그대로, 카운트만 헤더 기준으로 정직해진다).
-    if (searchParams.get('unattached') === 'true') {
+    //
+    // story #3160 — no_sprint=true도 같은 이유로 이 조기 분기에 합류한다: BE가 no_sprint일 때
+    // 완전히 다른 분기(list_backlog, cursor 미지원·X-Total-Count 계약)를 타서 아래 cursor
+    // 페이지네이션(service.list) 가정과 안 맞는다(#2534와 동형 판단, story #3160). raw proxy는
+    // 원본 쿼리스트링을 그대로 전달하므로(fastapi-proxy.ts) exclude_status 등 다른 파라미터도
+    // 이 분기에선 이미 화이트리스트 없이 통과한다 — «화이트리스트 유지」 결정은 아래 cursor
+    // 경로(service.list)에만 적용된다.
+    if (searchParams.get('unattached') === 'true' || searchParams.get('no_sprint') === 'true') {
       const _r = await proxyToFastapi(request, '/api/v2/stories');
       if (!_r.ok) return _r;
       const data = await _r.json();
@@ -100,6 +107,10 @@ export async function GET(request: Request) {
       epic_ids: searchParams.get('epic_ids')?.split(',').map((id) => id.trim()).filter(Boolean),
       epic_unassigned: searchParams.get('epic_unassigned') === 'true' ? true : undefined,
       done_within_days: searchParams.get('done_within_days') ? Number(searchParams.get('done_within_days')) : undefined,
+      // story #3148/#3160 — 같은 클래스 재발(위 boost_candidates_from/epic_ids류와 동형)
+      // 방지로 신설과 동시에 포함. cursor 페이지네이션과 안 섞이는 no_sprint와 달리 이
+      // 필터는 WHERE 절 추가일 뿐이라 cursor 경로와 안전하게 공존한다.
+      exclude_status: searchParams.get('exclude_status') ?? undefined,
       limit: pageInput.limit + 1,  // RC3: 오버페치 → buildCursorPageMeta hasMore 판단
       cursor: pageInput.cursor,
     });

--- a/backend/tests/test_3160_stories_query_param_fe_parity.py
+++ b/backend/tests/test_3160_stories_query_param_fe_parity.py
@@ -1,0 +1,108 @@
+"""story #3160(PO #3148 라이브 대조 중 발견, PO 재발봉인 지시) — «경계 넘는 이름이 양쪽 다르면
+조용히 버려진다» 클래스 재발 봉인. `GET /api/v2/stories`(list_stories)의 Query 파라미터명
+전수를, FE 3중 화이트리스트 체인(route.ts·IStoryRepository.ts·ApiStoryRepository.ts) 소스
+텍스트와 대조한다.
+
+이 파일에서만 이미 5번 재발했다(주석에 흔적 남음): q(083176e8)·unattached·story_number·
+boost_candidates_from·epic_ids/include_unassigned/done_within_days — 전부 "BE엔 있는데 FE
+어디에도 문자열로 안 나타남"이 원인이었다. 이 가드는 그 필요조건(FE 3파일 어딘가에 그
+파라미터명이 리터럴로 등장하는지)만 본다 — «올바르게 배선됐는지»(값이 실제로 쓰이는지)는
+검증 못 한다(그건 route.test.ts/ApiStoryRepository.test.ts류 왕복 테스트의 몫).
+
+⛔KNOWN_INTENTIONALLY_UNEXPOSED — "안 잊었다, 일부러 안 낸다" 파라미터. story #3160
+판정(no_sprint): BE에서 이 값이 true면 cursor 페이지네이션이 완전히 다른(비cursor·
+X-Total-Count) 분기로 빠져 일반 list() 계약과 안 맞는다 — route.ts의 조기 raw-proxy
+분기(`no_sprint`문자열 리터럴 자체는 route.ts에 있음)에서만 다루고 IStoryRepository/
+ApiStoryRepository 레이어에는 의도적으로 안 올린다. 이 세트에 새 이름을 추가할 땐 반드시
+이 파일에도 판정 근거를 남긴다(조용히 빼지 않는다, cloudbuild_secret_refs.py
+_DECLARED_UNCOVERED_SCRIPTS와 동일 원칙).
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _find_repo_root(start: Path) -> Path:
+    cur = start.resolve()
+    for _ in range(20):
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    raise RuntimeError(f"repo root(.git 표식)를 {start} 위로 못 찾음")
+
+
+_REPO_ROOT = _find_repo_root(Path(__file__).resolve().parent)
+_STORIES_ROUTER = _REPO_ROOT / "backend" / "app" / "routers" / "stories.py"
+_FE_FILES = [
+    _REPO_ROOT / "apps" / "web" / "src" / "app" / "api" / "stories" / "route.ts",
+    _REPO_ROOT / "packages" / "core-storage" / "src" / "interfaces" / "IStoryRepository.ts",
+    _REPO_ROOT / "packages" / "storage-api" / "src" / "ApiStoryRepository.ts",
+]
+
+# story #3160 — «가입」이 아니라 「접근권 부여」류로 다른 축인 것들, 또는 이 함수의 실제
+# 쿼리 파라미터가 아닌 것(FastAPI 특수 주입)은 대상에서 제외한다.
+_NOT_QUERY_PARAMS = {"response", "repo", "auth"}
+
+# story #3160 판정 — 의도적으로 FE 3파일 «전부»에 안 올리는 이름(적어도 하나엔 등장해야
+# 하므로 여기 있어도 완전 무시는 아니다 — _FE_FILES 어디서도 안 보이면 여전히 이 가드가
+# 문다. 이 세트는 "몇 개 파일에 있어야 하는지 완화"가 아니라 향후 진짜 예외가 생기면 쓸
+# 자리로 비워 둔다).
+_KNOWN_INTENTIONALLY_UNEXPOSED: set[str] = set()
+
+
+def _extract_query_param_names(router_source: str, func_name: str) -> set[str]:
+    """AST로 `func_name` 함수의 `Query(...)` 기본값 파라미터명(alias 있으면 alias)을 뽑는다.
+    scripts/lint_query_sentinel_direct_calls.py의 find_router_functions와 동형 기법
+    (재구현 아님 — 이 파일 전용으로 좁혀 alias까지 뽑는 점만 다름)."""
+    tree = ast.parse(router_source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            args = node.args
+            all_positional = list(args.posonlyargs) + list(args.args)
+            defaults = list(args.defaults)
+            pad = len(all_positional) - len(defaults)
+            names: set[str] = set()
+            for i, a in enumerate(all_positional):
+                if i < pad or a.arg in _NOT_QUERY_PARAMS:
+                    continue
+                default = defaults[i - pad]
+                if not (isinstance(default, ast.Call) and isinstance(default.func, ast.Name) and default.func.id == "Query"):
+                    continue
+                alias = None
+                for kw in default.keywords:
+                    if kw.arg == "alias" and isinstance(kw.value, ast.Constant):
+                        alias = kw.value.value
+                names.add(alias or a.arg)
+            return names
+    raise AssertionError(f"{func_name}() 함수를 {_STORIES_ROUTER}에서 못 찾음 — 파일이 리네임/이동됐을 가능성")
+
+
+def test_list_stories_query_params_all_appear_somewhere_in_fe_whitelist_chain():
+    be_params = _extract_query_param_names(_STORIES_ROUTER.read_text(encoding="utf-8"), "list_stories")
+    assert be_params, "BE에서 파라미터를 0개 추출 — 추출기 자체가 깨졌을 가능성(우연한 그린 방지)"
+
+    fe_combined_text = "\n".join(f.read_text(encoding="utf-8") for f in _FE_FILES)
+
+    missing = sorted(
+        name for name in be_params
+        if name not in fe_combined_text and name not in _KNOWN_INTENTIONALLY_UNEXPOSED
+    )
+    assert not missing, (
+        f"BE list_stories()가 받는 Query 파라미터 {missing}가 FE 화이트리스트 3파일"
+        f"({', '.join(str(f.relative_to(_REPO_ROOT)) for f in _FE_FILES)}) 어디에도 안 보임 — "
+        "«경계 넘는 이름이 양쪽 다르면 조용히 버려진다» 클래스 재발(q/unattached/story_number/"
+        "boost_candidates_from/epic_ids류와 동형). 신규면 3파일에 배선하고, 의도적 미노출이면 "
+        "_KNOWN_INTENTIONALLY_UNEXPOSED에 판정 근거와 함께 등재할 것."
+    )
+
+
+def test_known_intentionally_unexposed_params_still_exist_on_be():
+    """선언(_KNOWN_INTENTIONALLY_UNEXPOSED)이 낡지 않았는지 — 가리키는 파라미터가 BE에서
+    사라졌으면(리네임 등) 이 예외 등재 자체가 유령이 된다(cloudbuild_secret_refs.py
+    _DECLARED_UNCOVERED_SCRIPTS 존재검증과 동일 원칙)."""
+    be_params = _extract_query_param_names(_STORIES_ROUTER.read_text(encoding="utf-8"), "list_stories")
+    for name in _KNOWN_INTENTIONALLY_UNEXPOSED:
+        assert name in be_params, f"{name}이 BE list_stories()에 더는 없음 — 예외 등재가 낡음, 제거할 것"

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -122,6 +122,13 @@ export interface StoryListFilters extends PaginationOptions {
   /** story #3019 — status=done row만 created_at이 최근 N일 이내인 것으로 제한(list_board의
    * done-7일 관례를 제네릭 경로에 일반화). done 아닌 상태는 나이 무관 전부 포함. */
   done_within_days?: number;
+  /** story #3148/#3160 — comma-separated status 목록(IN 부정, BE stories.py exclude_status).
+   * `status`(단일 일치)와 별개 축. ⛔`no_sprint`는 여기 없다 — BE에서 이 필드가 true면
+   * cursor 페이지네이션이 아예 다른(비cursor·X-Total-Count) 분기로 빠지는데(list_backlog),
+   * 이 인터페이스는 cursor 기반 `list()` 계약이라 섞으면 조용히 틀린 페이지 메타를 낸다
+   * (route.ts의 `unattached==='true'` 조기 raw-proxy 분기와 동형 이유로 no_sprint도 그
+   * 조기 분기에서만 다룬다 — story #3160 판정, 일반 list() 필터로 안 올림). */
+  exclude_status?: string;
 }
 
 export interface IStoryRepository {

--- a/packages/storage-api/src/ApiStoryRepository.test.ts
+++ b/packages/storage-api/src/ApiStoryRepository.test.ts
@@ -96,3 +96,35 @@ describe('ApiStoryRepository.list — unattached(story #2534 E-FLOW-V4 S4) 파�
     expect(requestedUrl).not.toContain('unattached=');
   });
 });
+
+describe('ApiStoryRepository.list — exclude_status(story #3148/#3160) 파라미터가 실제 요청 URL에 실린다', () => {
+  // story #3160(PO #3148 라이브 대조 중 발견) — BE(stories.py exclude_status)는 이미 받는데
+  // 이 query 객체엔 없었다 — q 소실(083176e8)·unattached 소실(#2534)과 같은 클래스, 이번엔
+  // exclude_status가 조립 지점에서만 빠져 있었다.
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+    })) as unknown as ReturnType<typeof vi.fn>;
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('includes exclude_status in the outgoing query string when filters.exclude_status is set', async () => {
+    const repo = new ApiStoryRepository('token');
+    await repo.list({ project_id: 'proj-1', exclude_status: 'done,in-review' });
+
+    const requestedUrl = (fetchMock.mock.calls[0]![0] as URL | string).toString();
+    expect(requestedUrl).toContain(`exclude_status=${encodeURIComponent('done,in-review')}`);
+  });
+
+  it('omits exclude_status from the query string when filters.exclude_status is undefined', async () => {
+    const repo = new ApiStoryRepository('token');
+    await repo.list({ project_id: 'proj-1' });
+
+    const requestedUrl = (fetchMock.mock.calls[0]![0] as URL | string).toString();
+    expect(requestedUrl).not.toContain('exclude_status=');
+  });
+});

--- a/packages/storage-api/src/ApiStoryRepository.ts
+++ b/packages/storage-api/src/ApiStoryRepository.ts
@@ -34,6 +34,10 @@ export class ApiStoryRepository implements IStoryRepository {
         epic_ids: filters.epic_ids?.join(','),
         include_unassigned: filters.epic_unassigned,
         done_within_days: filters.done_within_days,
+        // story #3148/#3160 — 같은 클래스 재발(q/unattached/story_number/boost_candidates_
+        // from/epic_ids류와 동형) 방지로 신설과 동시에 여기 포함. no_sprint는 여기 없음(위
+        // interface 주석 참조 — cursor 페이지네이션과 안 섞인다, route.ts 조기분기 전용).
+        exclude_status: filters.exclude_status,
       },
     });
   }


### PR DESCRIPTION
[SID:3160]

## Summary
- 원인: `GET /api/stories?exclude_status=...`가 무차이(BE 직접 경로는 정상). "프록시가 삼킨다"가 아니라 3중 명시 화이트리스트 체인(`route.ts`→`StoryListFilters`→`ApiStoryRepository.list()`)에 신규 파라미터가 아직 안 올라간 것 — 이 파일에 이미 5번 재발한 클래스(`q` 소실 083176e8·`unattached`·`story_number`·`boost_candidates_from`·`epic_ids`/`done_within_days`).
- PO 판정(AC2): pass-through 대신 화이트리스트 유지+3자리 추가(5전 5패턴 일관성, pass-through는 `cursor`/`limit` 안전상한과 충돌하는 구조 변경이라 보안 함의가 다름).
- `exclude_status`: 3파일 전부에 추가(cursor 페이지네이션과 안전 공존 — WHERE 절 추가일 뿐).
- `no_sprint`: `route.ts`의 `unattached==='true'` 조기 raw-proxy 분기에만 합류(`StoryListFilters`/`ApiStoryRepository`엔 의도적으로 안 올림) — BE에서 `no_sprint=true`면 cursor 미지원·`X-Total-Count` 계약의 완전히 다른 분기(`list_backlog`)로 빠져 일반 `list()`의 cursor 페이지네이션 가정과 안 맞기 때문(그라운딩 중 발견 — 그대로 얹었으면 새 정합성 버그를 심었을 자리).
- 재발봉인 가드(PO 추가 지시): `backend/app/routers/stories.py`의 `list_stories()` Query 파라미터 전수(AST 추출)를 FE 3파일 화이트리스트 소스 텍스트와 대조하는 테스트 신설 — 새 BE 파라미터가 FE 어디에도 안 보이면 RED, 의도적 미노출은 `_KNOWN_INTENTIONALLY_UNEXPOSED`에 판정 근거와 함께 등재하는 계약.

## Test plan
- [x] FE `tsc --noEmit` 0(apps/web + packages/core-storage + packages/storage-api)
- [x] `eslint` 0
- [x] `vitest run` — apps/web 전체 522파일/4854건 + packages/storage-api 24건 green
- [x] 신규 가드 테스트(`test_3160_stories_query_param_fe_parity.py`) 2건 — 더미 파라미터 주입으로 mutation-test RED 확인 후 GREEN 복원, `_KNOWN_INTENTIONALLY_UNEXPOSED` 낡음 감지도 동형 검증
- [x] `route.test.ts`/`ApiStoryRepository.test.ts` 신규 5건(no_sprint 라우팅·exclude_status 전달 양쪽) — 각 배선 지점 mutation-test RED 확인 후 GREEN 복원
- [x] 인접 `list_stories`/`list_backlog` 계열 realdb 스위트 70건 전수 green(회귀 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)