### PR TITLE
[SID:3162] 채팅 #+숫자 자동링크 오인용 결함 수리

### DIFF
--- a/apps/web/src/components/chat/chat-input-entity-tokens.ts
+++ b/apps/web/src/components/chat/chat-input-entity-tokens.ts
@@ -22,10 +22,17 @@ export function getEntityQuery(value: string, cursorPos: number): string | null 
 // 안 친 채로(=피커가 열린 채로) 전송하려고 Enter를 누르면, 화살표로 후보를 능동 선택한 적이
 // 없어도(entityIndex는 새 결과 도착 시 자동으로 0번을 가리킨다) 그 최상위 후보가 조용히
 // 토큰으로 삽입돼버렸다(실사례: backlink 오염). hasNavigated(moveUp/moveDown을 최소 1회
-// 거쳤는지)가 true일 때만 Enter가 수락한다 — Tab은 전송 키가 아니라 위험이 없어 늘 수락.
+// 거쳤는지)가 true일 때만 Enter/Tab이 수락한다.
+//
+// ⛔story #3162(채팅·치환 결함 조사, customer-zero 다수) — Tab은 애초에 "전송 키가 아니라
+// 위험 없다"고 판단해 이 게이트 밖이었다(무조건 true). 그 판단이 틀렸다: Tab은 필드 이동
+// 습관(다른 UI로 넘어가려고·코드에디터 습관)으로 «메시지를 보낼 의도 없이도» 흔히 눌리는
+// 키다 — 화살표로 후보를 한 번도 안 훑은 채 Tab을 누르면 최상위 후보가 조용히 삽입되는
+// 것은 Enter 쪽과 완전히 같은 실패 클래스다(실사고: hex 색상 코드 `#595959` 타이핑 중
+// Tab 습관이 무관 스토리를 삽입). Enter와 동일하게 hasNavigated 게이트를 적용한다 —
+// d6f8e025가 절반만 고쳤던 것을 완성.
 export function shouldAcceptEntityPickerSelection(key: string, hasNavigated: boolean): boolean {
-  if (key === 'Tab') return true;
-  if (key === 'Enter') return hasNavigated;
+  if (key === 'Tab' || key === 'Enter') return hasNavigated;
   return false;
 }
 

--- a/apps/web/src/components/chat/chat-input.entity-picker-enter-guard.test.ts
+++ b/apps/web/src/components/chat/chat-input.entity-picker-enter-guard.test.ts
@@ -3,6 +3,11 @@
  * 능동 선택한 적 없이(entityIndex는 새 결과 도착 시 자동으로 0번을 가리킨다) Enter를
  * 눌러 전송하려던 것이 조용히 최상위 후보를 토큰으로 삽입해버린 실사례(backlink 오염)를
  * 재발 안 되게 고정한다.
+ *
+ * story #3162(채팅·치환 결함 조사, customer-zero 다수) — d6f8e025는 Enter만 고쳤다(Tab은
+ * "전송 키가 아니라 위험 없다"고 판단해 게이트 밖). 그 판단이 틀렸다는 게 실사고로
+ * 드러났다(hex 색상 코드 `#595959` 타이핑 중 습관적 Tab이 무관 스토리를 삽입) — Tab에도
+ * 같은 hasNavigated 게이트를 적용해 d6f8e025를 완성한다.
  */
 import { describe, expect, it } from 'vitest';
 import { shouldAcceptEntityPickerSelection, shouldHighlightEntityCandidate } from './chat-input-entity-tokens';
@@ -16,8 +21,11 @@ describe('shouldAcceptEntityPickerSelection', () => {
     expect(shouldAcceptEntityPickerSelection('Enter', true)).toBe(true);
   });
 
-  it('Tab은 능동 탐색 여부와 무관하게 늘 수락한다(전송 키가 아니라 위험 없음)', () => {
-    expect(shouldAcceptEntityPickerSelection('Tab', false)).toBe(true);
+  it('story #3162 — 능동 탐색 없이 Tab도 수락하지 않는다(습관적 Tab이 참조를 조용히 삽입하던 실사고 재발 방지)', () => {
+    expect(shouldAcceptEntityPickerSelection('Tab', false)).toBe(false);
+  });
+
+  it('화살표로 최소 1회 탐색한 뒤 Tab — 수락한다(Enter와 동형)', () => {
     expect(shouldAcceptEntityPickerSelection('Tab', true)).toBe(true);
   });
 

--- a/backend/app/services/story_ref_promoter.py
+++ b/backend/app/services/story_ref_promoter.py
@@ -64,6 +64,19 @@ _FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
 _ENTITY_TOKEN_RE = re.compile(r"\[[^\]]*\]\(entity:[a-z_]+:[^)]+\)")
 
+# story #3162(채팅·치환 결함 조사) — 인용부호/블록인용 안의 `#N`은 「예시로 재인용」이지
+# 「새로 참조하려는 의도」가 아니다(디캄포 오늘 밤 재발 실사고: 정정 메시지에서 오염된
+# 원문을 그대로 다시 인용해 재승격됨). 코드블록·인라인코드와 같은 성격의 "이 안은 예시
+# 영역"으로 취급한다 — 같은 줄 안에서 닫히는 짝만(여러 줄에 걸친 따옴표는 보호 대상
+# 밖으로 두어 과잉 보호를 피한다, 기존 인라인코드 규율과 동형). 한글 채팅 관례의
+# 「」『』《》〈〉도 같은 원칙으로 포함.
+_DOUBLE_QUOTE_RE = re.compile(r'"[^"\n]*"')
+_SINGLE_QUOTE_RE = re.compile(r"'[^'\n]*'")
+_KOREAN_BRACKET_QUOTE_RE = re.compile(r"「[^」\n]*」|『[^』\n]*』|《[^》\n]*》|〈[^〉\n]*〉")
+# 블록인용(마크다운 `>` 관례) — 줄 전체를 보호(그 줄 안의 `#N`은 다른 사람 말/과거 발화를
+# 그대로 옮긴 것이지 이 발신자의 새 참조 의도가 아니다).
+_BLOCKQUOTE_LINE_RE = re.compile(r"^>.*$", re.MULTILINE)
+
 
 def extract_bare_story_ref_candidates(content: str) -> list[tuple[int, int, int]]:
     """본문에서 «#숫자» 후보 위치를 뽑는다(DB 조회 없는 순수 함수 — 모양만 본다, 존재 여부는
@@ -95,10 +108,14 @@ def extract_bare_story_ref_candidates(content: str) -> list[tuple[int, int, int]
 
 
 def _protected_spans(content: str) -> list[tuple[int, int]]:
-    """fenced 코드블록·인라인 코드·기존 entity 토큰의 (start, end) 구간. 이 구간에서
-    시작하는 후보는 승격 대상에서 제외한다(AC2 — 코드블록 미변환·이중 변환 금지)."""
+    """fenced 코드블록·인라인 코드·기존 entity 토큰·인용부호·블록인용의 (start, end) 구간.
+    이 구간에서 시작하는 후보는 승격 대상에서 제외한다(AC2 — 코드블록 미변환·이중 변환
+    금지, story #3162 — 인용부호/블록인용도 같은 "예시 영역" 원칙으로 추가)."""
     spans: list[tuple[int, int]] = []
-    for pat in (_FENCED_CODE_RE, _INLINE_CODE_RE, _ENTITY_TOKEN_RE):
+    for pat in (
+        _FENCED_CODE_RE, _INLINE_CODE_RE, _ENTITY_TOKEN_RE,
+        _DOUBLE_QUOTE_RE, _SINGLE_QUOTE_RE, _KOREAN_BRACKET_QUOTE_RE, _BLOCKQUOTE_LINE_RE,
+    ):
         spans.extend(m.span() for m in pat.finditer(content))
     return spans
 

--- a/backend/tests/test_2629_bare_story_ref_promotion.py
+++ b/backend/tests/test_2629_bare_story_ref_promotion.py
@@ -225,6 +225,82 @@ async def test_promote_skips_existing_entity_token():
         await engine.dispose()
 
 
+# story #3162(채팅·치환 결함) — 인용부호/블록인용 안의 #N은 재인용이지 새 참조 의도가
+# 아니다(디캄포 오늘 밤 재발 실사고: 정정 메시지에서 오염된 원문을 그대로 다시 인용해
+# 재승격됨). 코드블록/인라인코드와 같은 "예시 영역" 원칙을 확장.
+async def test_promote_skips_double_quoted_number():
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            content = '방금 메시지의 "#24" 인용은 예시일 뿐인'
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            assert result == content
+            assert promoted_ids == set()
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_skips_korean_bracket_quoted_number():
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            content = "원문 그대로 재인용하는 — 「#24는 오탈자였는」"
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            assert result == content
+            assert promoted_ids == set()
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_skips_blockquote_line():
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            content = "인용:\n> 예전에 #24라고 썼던\n지금은 아닌"
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            assert result == content
+            assert promoted_ids == set()
+    finally:
+        await engine.dispose()
+
+
+async def test_promote_bare_ref_outside_quotes_still_promotes_no_regression():
+    """따옴표 밖의 정상 참조는 회귀 0 — 보호구간 확장이 정상 승격까지 죽이지 않는다."""
+    from app.services.story_ref_promoter import promote_bare_story_refs
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org, project = await _seed_org_project(s)
+            story = await _seed_story(s, org.id, project.id, number=24, title="보드 리팩터")
+            content = '"예시"는 무시하고 #24 보드 확인 부탁하는'
+            result, promoted_ids = await promote_bare_story_refs(
+                s, org_id=org.id, project_id=project.id, content=content,
+            )
+            assert promoted_ids == {story.id}
+            assert "#24" not in result
+    finally:
+        await engine.dispose()
+
+
 # ── ③ 실 DB resolve ────────────────────────────────────────────────────────────
 async def test_promote_resolves_existing_story_to_entity_token():
     from app.services.story_ref_promoter import promote_bare_story_refs


### PR DESCRIPTION
[SID:3162]

## Summary
- customer-zero 실물 다수(팀 5인 전원, 하룻밤). 조사(AC1) 결과 독립적인 두 메커니즘이 확認됨.
- **① 서버**(`story_ref_promoter.py`, 전 발신자 공통): 채팅 저장 시점에 bare `#숫자`를 org+project 스코프 실재 `story_number`와 대조해 치환. 존재검증은 이미 있지만 "존재하는데 딴 스토리"(우연한 번호 충돌)는 구조적으로 못 막음. 보호구간(`_protected_spans`)이 코드블록·인라인코드·기존 entity 토큰만 막고 인용부호/블록인용은 안 막아, "예시로 재인용한 번호"가 그대로 재승격되는 재발 사고를 냄.
- **② 클라이언트**(`chat-input-entity-tokens.ts`, 브라우저 입력 전용): `#`+단어문자 타이핑 시 뜨는 엔티티 피커에서 **Tab 키가 `hasNavigated`(화살표 능동 탐색) 여부와 무관하게 항상 최상위 검색결과를 수락**. story d6f8e025가 같은 클래스의 실사고(Enter 키)를 이미 고쳤으나 Tab은 "전송 키가 아니라 위험 없다"고 판단해 게이트 밖에 남겨 — 그 판단이 이번 사고의 직접 원인.
- PO 원문 대조로 최종 확定: 6자리 순수숫자 자체가 뚫린 게 아니라, 부분 문자열 안의 실재하는 짧은 story_number가 ①+② 조합으로 뚫린 것.

## Fix
- ① `_protected_spans`에 인용부호(`" "`·`' '`)·한글꺾쇠(「」『』《》〈〉)·블록인용(`>` 줄) 추가.
- ② `shouldAcceptEntityPickerSelection`의 Tab을 Enter와 동일하게 `hasNavigated` 게이트로 통합(d6f8e025 완성).
- 비채택(PO 판정 동의): opt-in 명시 문법 강제 — 이 모듈이 이미 3개 선례(#2629/#2651/#2660)의 dev 실측 GROUP BY 근거로 "한글 조사 직결 bare `#N`이 정상 참조의 다수 형태"임을 확인하고 그걸 지키는 방향으로 설계돼 있어 정면충돌.

## Test plan
- [x] FE `tsc --noEmit` 0, `eslint` 0
- [x] `vitest run`(전체) — 522 files / 4856 tests green(회귀 0) — 기존 "Tab은 늘 수락" 테스트를 새 계약으로 갱신
- [x] BE 신규 4건(인용부호·한글꺾쇠·블록인용 각 스킵 + 보호구간 밖 정상승격 무회귀) green
- [x] 기존 ①②③ 섹션(25건) 전수 green — ④ `send_message` 5건은 로컬 DB `team_members` FK 환경 갭(패치 전/후 동일 실패 시그니처로 무관 확認, 회귀 아님 — PR 코멘트에 상세)
- [x] 두 axis(Tab 게이트·보호구간 확장) 모두 mutation-test로 RED 확인 후 GREEN 복원

🤖 Generated with [Claude Code](https://claude.com/claude-code)