### PR TITLE
[SID:3156] i18n 키 파서 이원화 해소 — 공유 모듈 하나로 일원화

### DIFF
--- a/apps/web/src/lib/i18n-key-coverage.test.ts
+++ b/apps/web/src/lib/i18n-key-coverage.test.ts
@@ -17,35 +17,23 @@
 //      디렉터리 자체가 없음, 2026-07-27 확인) 지금은 사실상 구멍이 아니다. 새 앱이
 //      추가되면 이 캐비엇이 다시 유효해진다.
 //
-// 방법론(2026-07-27 교훈, 이 스토리 자체에서 확定): 소스 정적 스캔은 주석 스트립이
-// 첫 단계다 — 안 걷으면 주석 속 옛 코드 설명 문장이 실호출로 오판된다(#2210 조사 중
-// inbox.title 오탐 1건 실측).
+// story #3156 — 이 가드의 파서(stripComments·훅 바인딩 추출·extractKeyUsages)는
+// `scripts/check-i18n-keys.js`(CI 스크립트)와 완전 별개 독립 구현이었다. #3149(PR#3558)에서
+// 실증: 멤버접근 오귀속 결함을 한쪽만 고치자 다른 쪽이 같은 오탐으로 계속 붉혔다 — 파서를
+// `scripts/i18n-key-parser.js`(공유 모듈)로 일원화해 두 소비처가 같은 구현을 import한다.
+// 파서 자체의 회귀가드(extractKeyUsages 멤버접근 제외 등)는 `scripts/i18n-key-parser.test.js`
+// 로 이관됐다 — 여기 남기지 않는다(중복 방지, 그 파일이 정본).
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+// story #3156: repo-root scripts/(node CJS, apps/web 워크스페이스 밖)의 공유 파서.
+// moduleResolution:bundler+allowJs라 vitest/tsc 양쪽에서 해석 가능(tsconfig.json의
+// @sprintable/* 크로스-패키지 import와 동일 패턴).
+import { stripComments, extractHookBindings, extractKeyUsages } from '../../../../scripts/i18n-key-parser.js';
 import ko from '../../messages/ko.json';
 import en from '../../messages/en.json';
 
 const SRC_ROOT = path.resolve(__dirname, '..');
-
-function stripComments(text: string): string {
-  let out = text.replace(/\/\*[\s\S]*?\*\//g, '');
-  out = out
-    .split('\n')
-    .map((line) => {
-      const idx = line.indexOf('//');
-      if (idx === -1) return line;
-      const before = line.slice(0, idx);
-      const quotes = (before.match(/"/g) || []).length
-        + (before.match(/'/g) || []).length
-        + (before.match(/`/g) || []).length;
-      // 대략적 판별 — 앞부분 따옴표 개수 합이 짝수면(문자열 밖) //를 진짜 주석으로 본다.
-      // i18n 호출 라인에는 //가 문자열 속에 섞이는 경우가 사실상 없어 이 근사로 충분하다.
-      return quotes % 2 === 0 ? before : line;
-    })
-    .join('\n');
-  return out;
-}
 
 function collectSourceFiles(dir: string): string[] {
   const out: string[] = [];
@@ -71,29 +59,16 @@ function hasKey(messages: unknown, dotted: string): boolean {
   return typeof cur === 'string';
 }
 
-const ASSIGN_RE = /(\w+)\s*=\s*useTranslations\(\s*['"]([\w.]+)['"]\s*\)/g;
-
-// story #3149(카디르 QA 실측·미르코 근본추적, PR#3558) — check-i18n-keys.js와 별개·독립
-// 구현인 이 가드가 같은 결함을 그대로 갖고 있었다: `\b${varName}\(`의 워드바운더리는 '.'
-// 앞에서도 통과해(`.`은 `\w`가 아님) 멤버접근(`acc.t('title')`)이 파일 자신의 로컬
-// `t`(다른 네임스페이스에 바인딩)로 오귀속됐다. check-i18n-keys.js의 처방과 동형으로
-// 룩비하인드에 `.`을 추가(`(?<![\w$.])`) — 멤버접근은 이제 로컬 varName 호출로 안 잡히고
-// 기존 워드바운더리 방어(`get('x')`의 `t('x')`류)는 그대로 보존.
-function extractKeyUsages(text: string, varName: string): string[] {
-  const re = new RegExp(`(?<![\\w$.])${varName}\\(\\s*['"]([\\w.]+)['"]`, 'g');
-  return [...text.matchAll(re)].map((m) => m[1]!);
-}
-
 function collectMissingKeys(): { key: string; locations: string[] }[] {
   const referenced = new Map<string, Set<string>>();
   for (const file of collectSourceFiles(SRC_ROOT)) {
     const raw = fs.readFileSync(file, 'utf-8');
     const text = stripComments(raw);
-    const assigns = [...text.matchAll(ASSIGN_RE)];
-    if (assigns.length === 0) continue;
+    const bindings = extractHookBindings(text);
+    if (bindings.size === 0) continue;
     const rel = path.relative(SRC_ROOT, file);
-    for (const [, varName, ns] of assigns) {
-      for (const key of extractKeyUsages(text, varName!)) {
+    for (const [varName, ns] of bindings) {
+      for (const key of extractKeyUsages(text, varName)) {
         const full = `${ns}.${key}`;
         if (!referenced.has(full)) referenced.set(full, new Set());
         referenced.get(full)!.add(rel);
@@ -110,27 +85,8 @@ function collectMissingKeys(): { key: string; locations: string[] }[] {
   return missing.sort((a, b) => a.key.localeCompare(b.key));
 }
 
-describe('extractKeyUsages — ㉥ 멤버접근(`obj.t(...)`)은 로컬 t() 호출로 오귀속되지 않는다 (#3149)', () => {
-  it('바로 호출(`t(...)`)은 정상적으로 잡힌다', () => {
-    expect(extractKeyUsages("t('title');", 't')).toEqual(['title']);
-  });
-
-  it('멤버접근(`acc.t(...)`)은 varName=t로 조회할 때 안 잡힌다', () => {
-    expect(extractKeyUsages("acc.t('title');", 't')).toEqual([]);
-  });
-
-  it('한 파일에 로컬 t(...)와 멤버접근 acc.t(...)가 공존해도 로컬 호출만 잡힌다', () => {
-    const content = "t('switcherMobileTriggerAria');\nacc.t('title');\nacc.t('signOutAll');";
-    expect(extractKeyUsages(content, 't')).toEqual(['switcherMobileTriggerAria']);
-  });
-
-  it('식별자 끝에 우연히 걸리는 것도 여전히 안 잡힌다(기존 워드바운더리 보존 — get(\'x\')의 t(\'x\')류)', () => {
-    expect(extractKeyUsages("get('title');", 't')).toEqual([]);
-  });
-});
-
 describe('i18n 키 커버리지 — 코드가 참조하는 키는 ko/en 양쪽에 다 있어야 한다 (#2210)', () => {
-  it('apps/web/src의 모든 useTranslations(ns)(\'key\') 호출이 ko.json·en.json에 존재한다', () => {
+  it('apps/web/src의 모든 useTranslations(ns)(\'key\')/getTranslations(ns)(\'key\') 호출이 ko.json·en.json에 존재한다', () => {
     const missing = collectMissingKeys();
     if (missing.length > 0) {
       const report = missing.map((m) => `  ${m.key}  <-  ${m.locations.join(', ')}`).join('\n');

--- a/scripts/check-i18n-keys.js
+++ b/scripts/check-i18n-keys.js
@@ -49,113 +49,9 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
+const { flatten, escapeRegExp, stripComments, extractKeyUsages, extractHookBindings } = require('./i18n-key-parser');
 
 const rootDir = path.join(__dirname, '..');
-
-function flatten(obj, prefix = '') {
-  const out = {};
-  for (const [k, v] of Object.entries(obj)) {
-    const p = prefix ? `${prefix}.${k}` : k;
-    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
-      Object.assign(out, flatten(v, p));
-    } else {
-      out[p] = v;
-    }
-  }
-  return out;
-}
-
-function escapeRegExp(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/**
- * ㉤ — AC2 positive-control로 새로 찾은 5번째 결함(스토리 원문에도 없던 것). 주석 안에 예시로
- * 남은 옛 호출(`t('title')`처럼 은퇴 사유를 설명하는 주석 — inbox/page.tsx:188, story #2164)
- * 을 실제 호출로 오인해 「missing」 오탐을 냈다(en/ko 모두 `inbox.title` 자체가 없어 즉시
- * 눈에 띄었다 — AC9-c와 같은 교훈: 놀란 수가 나오면 자리부터 볼 게 아니라 자부터 본다).
- * 문자열/템플릿 리터럴 내용은 보존하고 `//`·`/* *\/` 주석만 제거한다.
- */
-// story #3023(카디르 QA #3445 근본추적) — 정규식 리터럴 안의 백틱을 아래 backtick 분기가
-// 문자열 델리미터로 오인하면, 짝이 안 맞는(홀수 개) 백틱을 담은 정규식(예:
-// `INLINE_CODE_SPAN_RE = /`[^`\n]*`/g`처럼 백틱 자체를 매칭하는 패턴 — story-detail-
-// panel.tsx L144 실측)이 그 뒤 남은 파일 전체를 "닫히지 않은 문자열 안"으로 착각시켜,
-// 그 이후의 진짜 `//` 주석이 전부 인식을 놓친다(실제로 지금까지 벌어진 CI 오탐의 원인).
-// '/' 직전의 마지막 유의미 문자가 이 목록에 있을 때만(정규식 리터럴이 실제로 오는 흔한
-// 문맥 — `= /../`, `(/../`, `, /../` 등) 정규식으로 판별해 안쪽을 통째로(백틱·따옴표
-// 델리미터 취급 없이) 건너뛴다. 일부러 좁게(allowlist) 잡았다 — `<`(JSX 닫는 태그
-// `</div>`)처럼 정규식이 아닌데 '/' 앞에 오는 문맥까지 넓히면 JSX가 널린 .tsx 전체에서
-// 새로운 오탐을 만든다. `return /regex/` 류(직전이 식별자 끝 문자라 division 취급되는
-// 소수 케이스)는 이 좁은 스코프 밖(story AC 범위 — 알려진 한계로 남김).
-const REGEX_LITERAL_CONTEXT_CHARS = new Set(['=', '(', ',', ':', ';', '!', '&', '|', '?', '[']);
-
-function stripComments(source) {
-  let out = '';
-  let i = 0;
-  const n = source.length;
-  let lastSig = ''; // 마지막으로 출력한 공백 아닌 문자(정규식 vs 나눗셈 판별용).
-  const emit = (ch) => {
-    out += ch;
-    if (!/\s/.test(ch)) lastSig = ch;
-  };
-  while (i < n) {
-    const c = source[i];
-    const c2 = source[i + 1];
-    if (c === '/' && c2 === '/') {
-      while (i < n && source[i] !== '\n') i++;
-      continue;
-    }
-    if (c === '/' && c2 === '*') {
-      i += 2;
-      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i++;
-      i += 2;
-      continue;
-    }
-    if (c === '/' && c2 !== '/' && c2 !== '*' && REGEX_LITERAL_CONTEXT_CHARS.has(lastSig)) {
-      let j = i + 1;
-      let inClass = false;
-      let closed = false;
-      while (j < n && source[j] !== '\n') {
-        if (source[j] === '\\') { j += 2; continue; }
-        if (source[j] === '[') { inClass = true; j++; continue; }
-        if (source[j] === ']') { inClass = false; j++; continue; }
-        if (source[j] === '/' && !inClass) { j++; closed = true; break; }
-        j++;
-      }
-      if (closed) {
-        while (j < n && /[a-z]/i.test(source[j])) j++; // 플래그(g/i/m/s/u/y 등) 소비.
-        for (let k = i; k < j; k++) emit(source[k]);
-        i = j;
-        continue;
-      }
-      // 줄 끝까지 닫는 '/'를 못 찾으면 정규식이 아니었다(오판) — 아래 일반 처리로 폴백.
-    }
-    if (c === '"' || c === "'") {
-      const quote = c;
-      emit(c); i++;
-      while (i < n && source[i] !== quote) {
-        if (source[i] === '\\') { emit(source[i]); i++; if (i < n) { emit(source[i]); i++; } continue; }
-        emit(source[i]); i++;
-      }
-      if (i < n) { emit(source[i]); i++; }
-      continue;
-    }
-    if (c === '`') {
-      emit(c); i++;
-      let depth = 0;
-      while (i < n) {
-        if (source[i] === '\\') { emit(source[i]); i++; if (i < n) { emit(source[i]); i++; } continue; }
-        if (source[i] === '`' && depth === 0) { emit(source[i]); i++; break; }
-        if (source[i] === '$' && source[i + 1] === '{') { depth++; emit(source[i]); emit(source[i + 1]); i += 2; continue; }
-        if (source[i] === '}' && depth > 0) { depth--; emit(source[i]); i++; continue; }
-        emit(source[i]); i++;
-      }
-      continue;
-    }
-    emit(c); i++;
-  }
-  return out;
-}
 
 /**
  * AC4 — 동적 조합 화이트리스트. AC3(②)보다 먼저 서야 하는 이유: 이게 없으면 아래 접두사를
@@ -198,24 +94,8 @@ function isDynamicallyComposed(flatKeyPath) {
   });
 }
 
-// ㉣ — 훅이 바인딩되는 실제 로컬 변수명을 파일마다 잡는다(하드코딩 `t` 가정을 버린다).
-const HOOK_BIND_RE = /const\s+(\w+)\s*=\s*(?:await\s+)?(?:useTranslations|getTranslations)\(\s*['"]([\w.]+)['"]/g;
-
-/**
- * ㉥ — story #3149(카디르 QA 실측·미르코 근본추적, PR#3558) — 워드바운더리
- * `(?<![\w$])varName\(`가 멤버 접근(`acc.t('title')`)의 `.t(`도 매치했다. `.`은 `\w`도
- * `$`도 아니라 룩비하인드를 통과 — 파일이 `const t = useTranslations('nav')`를 갖고
- * *동시에* 다른 객체(커스텀 훅이 반환한 `{ t, ... }`)의 `.t(...)`도 부르면, 후자가 전자
- * (`nav`)로 오귀속돼 「missing」 거짓 양성을 낸다(context-switcher-chip.tsx가 useAccountSwitcher
- * 훅에서 받은 `acc.t(...)`을 파일 자신의 `t`(nav)로 오판, 실렌더는 정상인데 CI만 빨간
- * 사례). 룩비하인드에 `.`을 추가해 「바로 앞이 단어문자·`$`·`.` 중 어느 것도 아닐 때만」
- * 매치하도록 좁힌다 — 로컬 `t()` 직접 호출(정상 케이스)은 앞이 공백·`(`·`{` 등이라
- * 영향 없고, 멤버 접근(`xxx.t(...)`)만 제외된다.
- */
-function extractKeyUsages(content, varName) {
-  const re = new RegExp(`(?<![\\w$.])${escapeRegExp(varName)}\\(\\s*['"]([\\w.]+)['"]`, 'g');
-  return [...content.matchAll(re)].map(m => m[1]);
-}
+// story #3156 — HOOK_BIND_RE/extractKeyUsages는 i18n-key-parser.js(공유 모듈)로 이관.
+// ㉣(훅 변수명 하드코딩 t 가정 폐기)·㉥(멤버접근 오귀속, story #3149) 둘 다 그쪽에서 관리.
 
 // main()으로 감싸 CLI 실행(require.main === module)일 때만 돈다 — 그래야 테스트가 순수함수
 // (flatten/stripComments/isDynamicallyComposed)만 require해 쓸 때 이 스캔 전체(파일 I/O·
@@ -238,10 +118,7 @@ function main() {
   files.forEach(file => {
     const content = stripComments(fs.readFileSync(path.join(rootDir, file), 'utf8'));
 
-    const varToNamespace = new Map();
-    for (const m of content.matchAll(HOOK_BIND_RE)) {
-      varToNamespace.set(m[1], m[2]);
-    }
+    const varToNamespace = extractHookBindings(content);
     if (varToNamespace.size === 0) return;
 
     for (const [varName, namespace] of varToNamespace) {

--- a/scripts/i18n-key-parser.js
+++ b/scripts/i18n-key-parser.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * story #3156 — i18n 키 추출 파서 공유 모듈. `scripts/check-i18n-keys.js`(CI, plain node)와
+ * `apps/web/src/lib/i18n-key-coverage.test.ts`(vitest)가 같은 판정("코드가 쓰는 i18n 키가
+ * messages에 있나")을 서로 다른 독립 regex 구현으로 수행해 왔다 — #3149(PR#3558)에서 실증:
+ * 멤버접근 오귀속 결함(`acc.t()`를 로컬 `t`로 셈)을 한쪽만 고치자 다른 쪽이 같은 오탐으로
+ * CI를 계속 붉혔다. 이 파일이 그 파서를 한 곳으로 합친다 — 두 소비처가 여기서 import한다.
+ *
+ * plain CJS인 이유 — `check-i18n-keys.js`가 `node scripts/check-i18n-keys.js`로 직접 실행되고
+ * (tsx/바벨 등 로더 없음, package.json `verify:i18n-keys`), apps/web은 `allowJs`+
+ * `moduleResolution: bundler`라 vitest/tsc 양쪽에서 이 파일을 그대로 require/import할 수
+ * 있다 — TS로 옮기면 CI 스크립트 쪽이 실행 전 컴파일 스텝을 새로 필요로 하게 된다.
+ */
+
+function flatten(obj, prefix = '') {
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const p = prefix ? `${prefix}.${k}` : k;
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      Object.assign(out, flatten(v, p));
+    } else {
+      out[p] = v;
+    }
+  }
+  return out;
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// story #3023(카디르 QA #3445 근본추적) — 정규식 리터럴 안의 백틱을 아래 backtick 분기가
+// 문자열 델리미터로 오인하면, 짝이 안 맞는(홀수 개) 백틱을 담은 정규식(예:
+// `INLINE_CODE_SPAN_RE = /`[^`\n]*`/g`처럼 백틱 자체를 매칭하는 패턴)이 그 뒤 남은 파일
+// 전체를 "닫히지 않은 문자열 안"으로 착각시켜, 그 이후의 진짜 `//` 주석이 전부 인식을 놓친다.
+// '/' 직전의 마지막 유의미 문자가 이 목록에 있을 때만(정규식 리터럴이 실제로 오는 흔한
+// 문맥 — `= /../`, `(/../`, `, /../` 등) 정규식으로 판별해 안쪽을 통째로 건너뛴다.
+const REGEX_LITERAL_CONTEXT_CHARS = new Set(['=', '(', ',', ':', ';', '!', '&', '|', '?', '[']);
+
+function stripComments(source) {
+  let out = '';
+  let i = 0;
+  const n = source.length;
+  let lastSig = ''; // 마지막으로 출력한 공백 아닌 문자(정규식 vs 나눗셈 판별용).
+  const emit = (ch) => {
+    out += ch;
+    if (!/\s/.test(ch)) lastSig = ch;
+  };
+  while (i < n) {
+    const c = source[i];
+    const c2 = source[i + 1];
+    if (c === '/' && c2 === '/') {
+      while (i < n && source[i] !== '\n') i++;
+      continue;
+    }
+    if (c === '/' && c2 === '*') {
+      i += 2;
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (c === '/' && c2 !== '/' && c2 !== '*' && REGEX_LITERAL_CONTEXT_CHARS.has(lastSig)) {
+      let j = i + 1;
+      let inClass = false;
+      let closed = false;
+      while (j < n && source[j] !== '\n') {
+        if (source[j] === '\\') { j += 2; continue; }
+        if (source[j] === '[') { inClass = true; j++; continue; }
+        if (source[j] === ']') { inClass = false; j++; continue; }
+        if (source[j] === '/' && !inClass) { j++; closed = true; break; }
+        j++;
+      }
+      if (closed) {
+        while (j < n && /[a-z]/i.test(source[j])) j++; // 플래그(g/i/m/s/u/y 등) 소비.
+        for (let k = i; k < j; k++) emit(source[k]);
+        i = j;
+        continue;
+      }
+      // 줄 끝까지 닫는 '/'를 못 찾으면 정규식이 아니었다(오판) — 아래 일반 처리로 폴백.
+    }
+    if (c === '"' || c === "'") {
+      const quote = c;
+      emit(c); i++;
+      while (i < n && source[i] !== quote) {
+        if (source[i] === '\\') { emit(source[i]); i++; if (i < n) { emit(source[i]); i++; } continue; }
+        emit(source[i]); i++;
+      }
+      if (i < n) { emit(source[i]); i++; }
+      continue;
+    }
+    if (c === '`') {
+      emit(c); i++;
+      let depth = 0;
+      while (i < n) {
+        if (source[i] === '\\') { emit(source[i]); i++; if (i < n) { emit(source[i]); i++; } continue; }
+        if (source[i] === '`' && depth === 0) { emit(source[i]); i++; break; }
+        if (source[i] === '$' && source[i + 1] === '{') { depth++; emit(source[i]); emit(source[i + 1]); i += 2; continue; }
+        if (source[i] === '}' && depth > 0) { depth--; emit(source[i]); i++; continue; }
+        emit(source[i]); i++;
+      }
+      continue;
+    }
+    emit(c); i++;
+  }
+  return out;
+}
+
+// 훅이 바인딩되는 실제 로컬 변수명을 파일마다 잡는다(하드코딩 `t` 가정을 버린다) — 서버
+// `getTranslations()`도 실측상 useTranslations와 동형 인자(단순 문자열 네임스페이스)라 같이 잡는다.
+const HOOK_BIND_RE = /const\s+(\w+)\s*=\s*(?:await\s+)?(?:useTranslations|getTranslations)\(\s*['"]([\w.]+)['"]/g;
+
+/**
+ * story #3149(카디르 QA 실측·미르코 근본추적, PR#3558) — 워드바운더리 `(?<![\w$])varName\(`가
+ * 멤버 접근(`acc.t('title')`)의 `.t(`도 매치했다. `.`은 `\w`도 `$`도 아니라 룩비하인드를
+ * 통과 — 파일이 `const t = useTranslations('nav')`를 갖고 *동시에* 다른 객체(커스텀 훅이
+ * 반환한 `{ t, ... }`)의 `.t(...)`도 부르면, 후자가 전자(`nav`)로 오귀속돼 「missing」 거짓
+ * 양성을 낸다. 룩비하인드에 `.`을 추가해 「바로 앞이 단어문자·`$`·`.` 중 어느 것도 아닐
+ * 때만」 매치하도록 좁힌다 — 로컬 `t()` 직접 호출(정상 케이스)은 앞이 공백·`(`·`{` 등이라
+ * 영향 없고, 멤버 접근(`xxx.t(...)`)만 제외된다.
+ */
+function extractKeyUsages(content, varName) {
+  const re = new RegExp(`(?<![\\w$.])${escapeRegExp(varName)}\\(\\s*['"]([\\w.]+)['"]`, 'g');
+  return [...content.matchAll(re)].map((m) => m[1]);
+}
+
+/** 파일 하나(주석 제거 완료 상태)에서 훅 바인딩(varName→namespace) 전부를 Map으로. */
+function extractHookBindings(content) {
+  const map = new Map();
+  for (const m of content.matchAll(HOOK_BIND_RE)) {
+    map.set(m[1], m[2]);
+  }
+  return map;
+}
+
+module.exports = {
+  flatten,
+  escapeRegExp,
+  stripComments,
+  extractKeyUsages,
+  extractHookBindings,
+  HOOK_BIND_RE,
+};

--- a/scripts/i18n-key-parser.test.js
+++ b/scripts/i18n-key-parser.test.js
@@ -1,0 +1,91 @@
+// story #3156 — 공유 파서(i18n-key-parser.js) 회귀가드 정본. check-i18n-keys.test.js와
+// i18n-key-coverage.test.ts에 각각 있던 중복 extractKeyUsages 테스트를 여기로 통합했다 —
+// 파서 결함 수리는 이제 이 한 곳만 고치면 두 소비처(CI 스크립트·vitest) 모두에 반영된다.
+import { describe, expect, it } from 'vitest';
+import {
+  flatten,
+  stripComments,
+  extractKeyUsages,
+  extractHookBindings,
+} from './i18n-key-parser.js';
+
+describe('flatten — 2단 이상 중첩 dot-path 평탄화', () => {
+  it('flattens arbitrarily deep nesting into dot-joined leaf paths', () => {
+    const nested = { a: { b: { c: 'leaf1', d: 'leaf2' }, e: 'leaf3' }, f: 'leaf4' };
+    expect(flatten(nested)).toEqual({
+      'a.b.c': 'leaf1',
+      'a.b.d': 'leaf2',
+      'a.e': 'leaf3',
+      f: 'leaf4',
+    });
+  });
+});
+
+describe('stripComments — 주석 제거·문자열/정규식 리터럴 보존', () => {
+  it('// 라인 주석과 /* */ 블록 주석을 제거하되 문자열 내용은 보존한다', () => {
+    const src = "const t = 1; // strip me\n/* block */ const s = '// not a comment';";
+    const out = stripComments(src);
+    expect(out).not.toContain('strip me');
+    expect(out).not.toContain('block');
+    expect(out).toContain("'// not a comment'");
+  });
+
+  it('story #3023 — 백틱을 포함한 정규식 리터럴이 그 뒤 //  주석 인식을 깨뜨리지 않는다', () => {
+    const src = 'const RE = /`[^`\\n]*`/g;\n// real comment\nconst x = 1;';
+    const out = stripComments(src);
+    expect(out).not.toContain('real comment');
+    expect(out).toContain('const x = 1;');
+  });
+
+  it('주석 안 예시 코드(t(\'title\') 등)는 실제 호출로 안 잡힌다(story #2164 오탐 재발가드)', () => {
+    const src = "// old code: t('title')\nconst t = 1;";
+    const out = stripComments(src);
+    expect(out).not.toContain("t('title')");
+  });
+});
+
+describe('extractKeyUsages — 멤버접근(`obj.t(...)`)은 로컬 t() 호출로 오귀속되지 않는다 (story #3149)', () => {
+  it('바로 호출(`t(...)`)은 정상적으로 잡힌다', () => {
+    expect(extractKeyUsages("t('title');", 't')).toEqual(['title']);
+  });
+
+  it('멤버접근(`acc.t(...)`)은 varName=t로 조회할 때 안 잡힌다(실제 재현: context-switcher-chip.tsx의 acc.t(...) vs 파일 자신의 useTranslations(\'nav\') t)', () => {
+    expect(extractKeyUsages("acc.t('title');", 't')).toEqual([]);
+  });
+
+  it('한 파일에 로컬 t(...)와 멤버접근 acc.t(...)가 공존해도 로컬 호출만 잡힌다', () => {
+    const content = "t('switcherMobileTriggerAria');\nacc.t('title');\nacc.t('signOutAll');";
+    expect(extractKeyUsages(content, 't')).toEqual(['switcherMobileTriggerAria']);
+  });
+
+  it('식별자 끝에 우연히 걸리는 것도 여전히 안 잡힌다(워드바운더리 보존 — get(\'x\')의 t(\'x\')류)', () => {
+    expect(extractKeyUsages("get('title');", 't')).toEqual([]);
+  });
+
+  it('점 표기 네임스페이스 키(settings.mcpConnections류)도 통째로 잡힌다', () => {
+    expect(extractKeyUsages("t('settings.mcpConnections.title');", 't')).toEqual(['settings.mcpConnections.title']);
+  });
+});
+
+describe('extractHookBindings — useTranslations/getTranslations 훅 바인딩 추출', () => {
+  it('const 변수명 = useTranslations(ns) 패턴을 잡는다', () => {
+    const map = extractHookBindings("const t = useTranslations('nav');");
+    expect(map.get('t')).toBe('nav');
+  });
+
+  it('임의의 변수명(tc/th/tGlance 등)도 하드코딩 t 가정 없이 잡는다', () => {
+    const map = extractHookBindings("const tGlance = useTranslations('glance');\nconst tc = useTranslations('common');");
+    expect(map.get('tGlance')).toBe('glance');
+    expect(map.get('tc')).toBe('common');
+  });
+
+  it('서버 컴포넌트 getTranslations(await 포함)도 useTranslations와 동형으로 잡는다', () => {
+    const map = extractHookBindings("const t = await getTranslations('dashboard');");
+    expect(map.get('t')).toBe('dashboard');
+  });
+
+  it('const가 아닌 대입(let/멤버 대입)은 안 잡는다(실사용 관례 — 오탐 방지)', () => {
+    const map = extractHookBindings("let t = useTranslations('nav');");
+    expect(map.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## 배경
카디르 QA 발견(3558 QA 중) — `scripts/check-i18n-keys.js`(#2371 CI 가드)와 `apps/web/src/lib/i18n-key-coverage.test.ts`(#3111계 vitest)가 같은 판정(코드가 쓰는 i18n 키가 messages에 있나)을 서로 다른 독립 regex 구현으로 수행해 왔다. #3149(PR#3558)에서 실증: 멤버접근 오귀속 결함(`acc.t()`를 로컬 t로 셈)을 한쪽만 고치자 다른 쪽이 같은 오탐으로 CI를 계속 붉혔다.

## 처방
- `scripts/i18n-key-parser.js`(신규, CJS) — `stripComments`(#3023 정규식-리터럴 백틱 방어 포함)·`extractHookBindings`(useTranslations/getTranslations, const만)·`extractKeyUsages`(멤버접근 제외 룩비하인드, #3149)·`flatten`을 한 곳으로. plain CJS인 이유: check-i18n-keys.js가 `node`로 직접 실행돼(로더 없음) TS로 옮기면 CI 스크립트에 컴파일 스텝이 새로 생긴다.
- `check-i18n-keys.js` — 위 4개를 require, 로컬 중복 정의 131줄 제거. `DYNAMIC_KEY_PREFIXES`/`isDynamicallyComposed`/`main()`은 이 파일 고유 관심사라 유지. 기존 `module.exports`는 그대로(`check-i18n-keys.test.js` 무변경으로 호환).
- `i18n-key-coverage.test.ts` — 로컬 stripComments/ASSIGN_RE/extractKeyUsages 74줄 제거, 공유 모듈 import로 교체(`../../../../scripts/i18n-key-parser.js` — apps/web tsconfig가 이미 `@sprintable/*`로 워크스페이스 밖 크로스-임포트를 쓰고 있어 같은 패턴). **부수 효과**: 이전엔 `getTranslations()`(서버 컴포넌트)를 못 봤는데 이제 check-i18n-keys.js와 동일하게 잡는다 — 재스캔해도 missing 0건으로 두 도구가 정확히 합의(일원화의 실증).
- `scripts/i18n-key-parser.test.js`(신규) — 양쪽에 중복돼 있던 extractKeyUsages 회귀가드(멤버접근 제외 4건)를 정본으로 통합 + stripComments(#3023 백틱 방어·#2164 주석-예시 오탐 방지)·extractHookBindings 신규 커버리지 추가.

## AC3(파서 결함 수리는 이제 «한 번») 구조 확認
i18n-key-coverage.test.ts에서 로컬 파서 정의가 물리적으로 사라졌다 — 다음에 파서 버그가 나오면 고칠 파일이 i18n-key-parser.js 하나뿐이라 "한쪽만 고치고 다른 쪽을 잊는" 시나리오 자체가 성립하지 않는다.

## 검증
- `node scripts/check-i18n-keys.js` exit 0(missing 0건, 리팩터 前과 동일).
- root `pnpm vitest run` — **547 files·5097 tests all passed**(apps/web+scripts+packages 전체, `check-i18n-keys.test.js` 무변경으로 green 확認 포함).
- apps/web `tsc --noEmit` 클린(크로스-워크스페이스 import 문제 없음) + eslint 타깃 파일 0 warning + `next build` exit 0.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>