### PR TITLE
[SID:3159] P1 hotfix — activation checklist 응답 이중 봉투로 dev 全 authenticated 페이지 크래시

### DIFF
--- a/backend/app/routers/activation.py
+++ b/backend/app/routers/activation.py
@@ -20,32 +20,39 @@ from app.services.onboarding_activation import get_activation_state, unsubscribe
 router = APIRouter(prefix="/api/v2/activation", tags=["activation", "Organization"])
 
 
-def _ok(data: object, status: int = 200) -> JSONResponse:
-    return JSONResponse({"data": data, "error": None, "meta": None}, status_code=status)
-
-
 def _err(code: str, message: str, status: int) -> JSONResponse:
     return JSONResponse({"data": None, "error": {"code": code, "message": message}, "meta": None}, status_code=status)
 
 
+# ⚠️P1 실사고(2026-08-27, dev 전 authenticated 페이지 크래시·페드루 발견) — 아래 두 성공 경로는
+# 반드시 raw dict를 그대로 반환한다(`_ok()`류 자체 {data,error,meta} 래핑 금지). Next.js
+# 프록시(apps/web `api/activation/*/route.ts`)가 `apiSuccess(await _r.json())`로 **이미**
+# {data,error,meta} 봉투를 씌운다 — 여기서 한 번 더 씌우면 FE가 받는 게 {data:{data:{...
+# 실 payload...},error,meta},error,meta}로 이중 래핑되고, FE는 `json.data`를 실 payload로
+# 기대하므로 `state.steps`가 undefined가 돼 렌더 전체가 크래시한다(cron.py류 서버-서버
+# 전용 엔드포인트의 `_ok()` 관례를 그대로 옮겨오다 생긴 실수 — cron 응답은 FE가 `.data.x`로
+# 안 읽어 지금까지 안 드러났을 뿐, 구조는 동일 결함). me.py/assets.py(예: storage-usage)처럼
+# FE가 실제로 소비하는 엔드포인트는 raw payload를 그대로 반환하는 게 이 레포의 정공이다.
 @router.get("/checklist")
 async def get_checklist(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-) -> JSONResponse:
+) -> dict:
     user = await db.get(User, uuid.UUID(auth.user_id))
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    state = await get_activation_state(db, user)
-    return _ok(state)
+    return await get_activation_state(db, user)
 
 
 # unsubscribe는 이메일 링크 클릭이라 pre-auth(브라우저에 세션 없을 수 있음) — 토큰 자체가 인가.
-@router.get("/unsubscribe")
+# 에러 경로만 {data,error,meta} 명시 래핑 유지 — Next.js 프록시가 `!_r.ok`면 apiSuccess를
+# 안 타고 이 응답을 그대로 통과시키므로(이중래핑 없음), FE(app/unsubscribe/page.tsx)가 기대하는
+# `json.error?.code` 분기가 성공 경로와 달리 여기선 안전하다.
+@router.get("/unsubscribe", response_model=None)
 async def get_unsubscribe(
     token: str = Query(...),
     db: AsyncSession = Depends(get_db),
-) -> JSONResponse:
+) -> dict | JSONResponse:
     try:
         payload = decode_email_unsubscribe_token(token)
     except JWTError:
@@ -54,4 +61,4 @@ async def get_unsubscribe(
     found = await unsubscribe_user(db, user_id)
     if not found:
         return _err("NOT_FOUND", "Account not found", 404)
-    return _ok({"unsubscribed": True})
+    return {"unsubscribed": True}

--- a/backend/tests/test_3159_activation_router.py
+++ b/backend/tests/test_3159_activation_router.py
@@ -50,14 +50,21 @@ async def test_get_checklist_404_when_user_missing():
 
 @pytest.mark.anyio
 async def test_get_checklist_returns_state():
+    # P1 실사고 회귀가드(2026-08-27, dev 全 authenticated 페이지 크래시) — get_checklist가
+    # {data,error,meta}로 자체 래핑하면(구 `_ok()`) Next.js 프록시(apiSuccess)의 래핑과
+    # 이중이 돼 FE `json.data.steps`가 undefined로 크래시한다. raw dict를 그대로 반환해야
+    # 그 프록시 한 겹만 남는다 — 여기서 dict 최상위에 `steps`가 직접 있는지까지 고정한다.
     db = AsyncMock()
     user = object()
     db.get = AsyncMock(return_value=user)
     auth = type("A", (), {"user_id": str(uuid.uuid4())})()
-    state = {"steps": {}, "completed": 3, "total": 5, "all_complete": False}
+    state = {"steps": {"email_verified": True}, "completed": 3, "total": 5, "all_complete": False}
     with patch("app.routers.activation.get_activation_state", AsyncMock(return_value=state)):
         res = await get_checklist(db=db, auth=auth)
-    assert res.status_code == 200
+    assert isinstance(res, dict)
+    assert not hasattr(res, "status_code")  # JSONResponse류 자체래핑이면 이 속성이 있다 — 없어야 정공
+    assert res["steps"]["email_verified"] is True
+    assert "data" not in res  # {"data": {...}} 이중래핑 재발 방지
 
 
 @pytest.mark.anyio
@@ -80,9 +87,11 @@ async def test_get_unsubscribe_not_found_404():
 
 @pytest.mark.anyio
 async def test_get_unsubscribe_success_200():
+    # 위 checklist와 동일 근거(P1 회귀가드) — 성공 경로는 raw dict, 이중래핑 없음.
     db = AsyncMock()
     uid = str(uuid.uuid4())
     with patch("app.routers.activation.decode_email_unsubscribe_token", return_value={"sub": uid}), \
          patch("app.routers.activation.unsubscribe_user", AsyncMock(return_value=True)):
         res = await get_unsubscribe(token="tok", db=db)
-    assert res.status_code == 200
+    assert isinstance(res, dict)
+    assert res == {"unsubscribed": True}


### PR DESCRIPTION
## 증상
dev 全 authenticated 페이지("This page couldn't load") — 페드루군 발견, 헤드리스 크롬으로 미르코 재현 확定.

## 근본
`GET /api/activation/checklist` 응답이 이중 봉투(`{"data":{"data":{...실 payload...},error,meta},error,meta}`) — PR#3565에서 cron.py류 서버-서버 엔드포인트의 `_ok()` 자체래핑 관례를 FE-소비 엔드포인트에 그대로 옮겨온 게 원인. Next.js 프록시(`apiSuccess(await _r.json())`)가 이미 한 겹 씌우므로 이중이 됐고, FE `ActivationChecklistBanner`가 `state.steps[key]`를 map 안에서 접근하다 `state.steps`가 undefined라 크래시 — 이게 dashboard-shell에 마운트돼 있어 모든 authenticated 페이지가 죽었다.

## 처방
`get_checklist`/`get_unsubscribe` 성공 경로를 raw dict 반환으로 교체(me.py/assets.py 컨벤션과 동일). `get_unsubscribe`는 성공(dict)/실패(JSONResponse) 유니온이라 `response_model=None` 명시 필요.

## 검증
- 이중래핑 회귀가드 라우터 테스트 추가(수정 前 코드로 되돌리면 즉시 RED).
- realdb 4건 + 라우터 유닛 7건 + `app.main` import 클린 + 백엔드 8247 테스트 collect 성공.
- apps/web tsc 클린 + 배너 테스트 6건(무변경, mock이라 이 클래스는 원래 못 잡음 — 실사고가 mock-vs-real 계약갭 사례).
- 헤드리스 크롬 dev `/api/activation/checklist` 응답 실물 대조로 진단 확定. 배포 후 puppeteer 재확認 필요.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>