### PR TITLE
[SID:2074] 채팅 결재카드 GET /api/gates/{id} N+1 배치조회로 처방

### DIFF
--- a/apps/web/src/components/chat/approval-request-card.test.tsx
+++ b/apps/web/src/components/chat/approval-request-card.test.tsx
@@ -661,3 +661,52 @@ describe('ApprovalRequestCard — story #3151 agent_decision 결정 재료(질�
     expect(buttons.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(true);
   });
 });
+
+// story #5ace2e84 — 채팅 결재카드 N+1 처방. chat-view.tsx가 대화 단위로 배치조회한 gate를
+// initialGate prop으로 물려받으면 이 카드는 독립 GET /api/gates/{id}를 안 태워야 한다(PO
+// 실측: 대화 진입당 최대 51발 N+1의 직접 원인). use-gate-batch.ts는 별도 단위테스트로
+// 순수함수(collectUnrequestedGateIds)를 커버하므로, 여기서는 소비부(카드)가 initialGate를
+// 실제로 존중하는지만 값으로 단언한다.
+describe('ApprovalRequestCard — initialGate(story #5ace2e84 배치조회 소비)', () => {
+  it('initialGate={kind:ready}면 독립 fetchGate()를 안 태우고 그 값으로 바로 렌더된다', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
+    vi.stubGlobal('fetch', fetchMock);
+    const gateData = gate({ work_item_summary: { title: '배치조회 대조', slug: null } });
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <ApprovalRequestCard
+            target={{ work_item_type: gateData.work_item_type, work_item_id: gateData.work_item_id, gate_id: gateData.id, actions: ['approve', 'reject'] }}
+            initialGate={{ kind: 'ready', gate: gateData }}
+          />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain('배치조회 대조');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('initialGate={kind:loading}이면(배치 진행 중) 완료를 기다리고 독립 fetchGate()도 안 태운다', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
+    vi.stubGlobal('fetch', fetchMock);
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <ApprovalRequestCard
+            target={{ work_item_type: 'story', work_item_id: 'w-1', gate_id: 'g-1', actions: ['approve', 'reject'] }}
+            initialGate={{ kind: 'loading' }}
+          />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('initialGate 미지정(배치 커버 밖)이면 기존처럼 개별 fetchGate()로 폴백한다(회귀 0)', async () => {
+    const gateData = gate({ work_item_summary: { title: '개별폴백 대조', slug: null } });
+    await mount(gateData);
+    expect(container.textContent).toContain('개별폴백 대조');
+  });
+});

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -49,9 +49,19 @@ interface ApprovalRequestCardProps {
    * resolved(회신) 분기가 이 카탈로그의 preset.gate.verdict 항목을 찾아 정적 표현부(text·
    * fields)만 소비한다 — pending(요청·서명·버튼) 분기는 그대로다. */
   eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
+  /** story #5ace2e84 — chat-view.tsx가 대화 단위로 배치조회한 이 gate_id의 결과(use-gate-batch.ts,
+   * eventDefinitionsByKey와 동일 물려받기 패턴). 있으면(loading 포함) 이 카드는 독립
+   * fetchGate()를 안 태운다 — PO 실측 N+1(대화당 최대 51발)의 직접 처방. undefined면(배치
+   * 커버 밖 — 예: approvals-queue.tsx처럼 채팅 밖에서 쓰이거나, SSE로 대화 도중 새로 도착한
+   * 카드라 배치 effect가 아직 못 훑음) 기존처럼 마운트 시 개별 fetchGate()로 자연 폴백
+   * (회귀 0). */
+  initialGate?: CardState;
 }
 
-type CardState =
+/** story #5ace2e84 — use-gate-batch.ts(chat-view.tsx 대화 단위 배치조회)와 정확히 같은 shape을
+ * 공유하기 위해 export한다(타입 두 벌 갈라지는 drift 방지 — entity-status-labels.ts의
+ * EntityStatusFetchState와 동일 정신). */
+export type CardState =
   | { kind: 'loading' }
   /** 게이트가 없다(삭제 등) — AC4류 폴백: 조용한 실패 대신 정직한 문구. */
   | { kind: 'not-found' }
@@ -100,7 +110,7 @@ const RESOLVED_STATUS_LABEL_KEYS: Record<string, string> = {
  * (`GateSignatureApproval`)와 형제로 렌더돼 모달 열람/닫기가 그 로컬 state(근거확인·사유)를
  * 건드리지 않는다(AC③, 언마운트 없음).
  */
-export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalRequestCardProps) {
+export function ApprovalRequestCard({ target, eventDefinitionsByKey, initialGate }: ApprovalRequestCardProps) {
   const t = useTranslations('chats');
   // story #2926(P0-F 잔여 fast-follow, 카디르 F2 QA LOW①) — 아래 stateLabel 유도가
   // deriveGateProofState()의 통일 키(gateStatus*)를 쓴다 — 그 키들은 'cage' 네임스페이스.
@@ -133,7 +143,15 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey }: ApprovalR
     }
   }, [target.gate_id]);
 
-  useEffect(() => { void fetchGate(); }, [fetchGate]);
+  // story #5ace2e84 — initialGate가 있으면(대화 단위 배치조회가 이 gate_id를 이미 커버) 이
+  // 카드는 독립 fetchGate()를 안 태운다: 배치가 아직 진행 중(loading)이면 그 완료를 기다리고,
+  // 이미 resolved(ready/not-found/error)면 그 값을 바로 반영한다. initialGate가 undefined인
+  // 경우만(배치 커버 밖 — approvals-queue.tsx 등 채팅 밖 사용, 또는 SSE로 대화 도중 새로
+  // 도착해 배치 effect가 아직 못 훑은 카드) 기존 개별 fetchGate()로 자연 폴백한다(회귀 0).
+  useEffect(() => {
+    if (initialGate) { setState(initialGate); return; }
+    void fetchGate();
+  }, [fetchGate, initialGate]);
 
   // story #2985 AC2(PO 계약 확定 2026-08-24) — 다른 승인자가 이 게이트를 먼저 해소하면,
   // 이 카드를 보고 있는 화면도 새로고침 없이 "처리됨"으로 갱신된다. BE가

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -28,7 +28,7 @@ import { ReferenceSuggestionRow } from './reference-suggestion-row';
 import { IntentSuggestionCard } from './intent-suggestion-card';
 import { parseHitlRequest } from '@/lib/hitl-classifier';
 import { HitlApprovalCard, type HitlAnswer } from './hitl-approval-card';
-import { ApprovalRequestCard } from './approval-request-card';
+import { ApprovalRequestCard, type CardState } from './approval-request-card';
 import { EventBlockCard } from './event-block-card';
 import { parseBlockTemplate, type EventDefinitionSummary } from '@/lib/block-template';
 import { segmentMessageContent } from './message-segments';
@@ -75,6 +75,11 @@ interface ChatBubbleProps {
   /** story #2637 — chat-view.tsx가 대화당 1회 배치조회한 event_definitions 카탈로그(entityStatusByKey와
    * 동일 패턴). 생략하면(undefined) 이벤트 메시지도 BE 제네릭 폴백 텍스트로 안전하게 그려진다. */
   eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
+  /** story #5ace2e84 — chat-view.tsx가 대화 단위로 배치조회한 gate_id→상태 캐시(entityStatusByKey와
+   * 동일 물려받기 패턴, use-gate-batch.ts). ApprovalRequestCard의 initialGate로 그대로
+   * 넘어가 독립 fetchGate() N+1을 없앤다. 생략하면(undefined) 카드가 기존처럼 개별 fetch로
+   * 안전 폴백(회귀 0). */
+  gateByKey?: Record<string, CardState>;
   /** story #2766(레인 A) — ChatView가 물려주면 doc 임베드 미리보기·비-이미지 첨부 클릭이
    * 중앙 모달/새 탭 대신 우측 ReadingPanel을 연다. 생략하면(undefined, ThreadPanel 등 아직
    * 안 물려주는 호출부) 기존 동작(모달·window.open) 그대로 — 회귀 없음. */
@@ -367,7 +372,7 @@ const LONG_PRESS_MS = 500;
 export function ChatBubble({
   message, isMine, isGrouped = false, onOpenThread, onDelete, onBlockUser, presenceStatus, isWorking = false,
   highlight = false, projectId, isCiteAnchor = false, isCiteInRange = false, citeAction, entityStatusByKey,
-  hitlAnswer = null, onRespondHitl, eventDefinitionsByKey, onOpenReadingPanel, onFillComposer,
+  hitlAnswer = null, onRespondHitl, eventDefinitionsByKey, onOpenReadingPanel, onFillComposer, gateByKey,
 }: ChatBubbleProps) {
   const t = useTranslations('chats');
   const isAgent = message.sender_type === 'agent';
@@ -582,7 +587,11 @@ export function ChatBubble({
               </button>
             </div>
           ) : approvalTarget ? (
-            <ApprovalRequestCard target={approvalTarget} eventDefinitionsByKey={eventDefinitionsByKey} />
+            <ApprovalRequestCard
+              target={approvalTarget}
+              eventDefinitionsByKey={eventDefinitionsByKey}
+              initialGate={gateByKey?.[approvalTarget.gate_id]}
+            />
           ) : eventTarget && eventBlockTemplate ? (
             <EventBlockCard
               template={eventBlockTemplate}

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -20,6 +20,8 @@ import { isHitlReply, parseHitlRequest } from '@/lib/hitl-classifier';
 import type { HitlAnswer } from './hitl-approval-card';
 import type { EntityStatusFetchState } from '@/components/chat/entity-status-labels';
 import { useEntityStatusBatchFetch } from '@/hooks/use-entity-status-batch';
+import { useGateBatchFetch } from '@/hooks/use-gate-batch';
+import type { CardState as GateCardState } from '@/components/chat/approval-request-card';
 import type { EventDefinitionSummary } from '@/lib/block-template';
 import { useMessageRangeSelection } from '@/hooks/use-message-range-selection';
 import { CitationComposeBar, type CitationSaveState } from './citation-compose-bar';
@@ -135,6 +137,12 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   // 이 값을 읽어 effect의 재실행 여부를 판단하지 않기 때문(state로 하면 setState가 effect를
   // 재트리거해 순환 위험). messages만 dependency로 두고 "새로 보인 참조가 있는가"만 본다.
   const requestedEntityStatusKeysRef = useRef<Set<string>>(new Set());
+  // story #5ace2e84 — 결재카드 gate 배치조회 캐시(entityStatusByKey와 동일 정신·같은
+  // requestedKeysRef 패턴). PO 실측: 카드마다 독립 fetchGate()가 대화당 최대 51발(고유 38·
+  // 중복 13) N+1을 냈다 — 대화 전체 메시지를 한 번에 훑어 `?ids=` 배치(use-gate-batch.ts)로
+  // 수렴시킨다.
+  const [gateByKey, setGateByKey] = useState<Record<string, GateCardState>>({});
+  const requestedGateIdsRef = useRef<Set<string>>(new Set());
   // story #2637 — event_definitions 카탈로그(block_template 포함) 배치조회. entityStatusByKey와
   // 같은 이유로 대화당 1회만 fetch(카탈로그는 event_key 조합에 무관하게 항상 전체를 돌려주는
   // 응답이라, 메시지별로 다시 부를 이유가 없다 — 메시지가 100개여도 fetch는 1회).
@@ -247,6 +255,10 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   // 같은 장부·같은 캐시로 잡힌다(PO 지적 2026-08-08 — 이전엔 스레드 전용 참조가 영원히
   // "아직 모름"에 고착됐었다).
   useEntityStatusBatchFetch(messages, requestedEntityStatusKeysRef, setEntityStatusByKey);
+  // story #5ace2e84 — 결재카드 gate 배치조회(위 entityStatusByKey와 동일 패턴). requestedGateIdsRef·
+  // setGateByKey를 ThreadPanel에도 그대로 물려줘(아래 렌더부) 스레드 답글의 결재카드도 같은
+  // 장부·같은 캐시로 잡힌다.
+  useGateBatchFetch(messages, requestedGateIdsRef, setGateByKey);
   // story #1977: mark-read 중복 POST 가드 — 이미 이 up_to까지 보냈으면 재전송 안 함(멱등이라
   // 서버는 안전하지만, 스크롤/신규메시지마다 매번 쏘는 낭비 방지).
   const markedReadUpToRef = useRef<string | null>(null);
@@ -949,6 +961,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
                             projectId={projectId}
                             entityStatusByKey={entityStatusByKey}
               eventDefinitionsByKey={eventDefinitionsByKey}
+                            gateByKey={gateByKey}
                             onFillComposer={handleFillComposer}
                             hitlAnswer={hitlAnswers.get(msg.id) ?? null}
                             onRespondHitl={(content) => handleSend(content)}
@@ -1075,6 +1088,9 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
               eventDefinitionsByKey={eventDefinitionsByKey}
               requestedEntityStatusKeysRef={requestedEntityStatusKeysRef}
               setEntityStatusByKey={setEntityStatusByKey}
+              gateByKey={gateByKey}
+              requestedGateIdsRef={requestedGateIdsRef}
+              setGateByKey={setGateByKey}
             />
           </div>
         )}

--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -8,6 +8,8 @@ import { ChatBubble } from './chat-bubble';
 import { ChatInput } from './chat-input';
 import type { EntityStatusFetchState } from '@/components/chat/entity-status-labels';
 import { useEntityStatusBatchFetch } from '@/hooks/use-entity-status-batch';
+import { useGateBatchFetch } from '@/hooks/use-gate-batch';
+import type { CardState as GateCardState } from '@/components/chat/approval-request-card';
 import type { EventDefinitionSummary } from '@/lib/block-template';
 
 import { fetchWithAuth } from '@/lib/db/client';
@@ -51,6 +53,13 @@ interface ThreadPanelProps {
   /** story #2637 — chat-view.tsx의 event_definitions 카탈로그 캐시를 그대로 물려받는다
    * (entityStatusByKey와 동일 이유·별도로 안 만든다). */
   eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
+  /** story #5ace2e84 — chat-view.tsx의 gate 배치조회 캐시·요청장부를 그대로 물려받는다
+   * (entityStatusByKey와 동일 이유). 스레드 답글에 걸린 결재카드도 같은 장부를 공유해
+   * 부모 메시지 카드와 중복 fetch가 안 난다. 둘 다 생략하면(undefined) 이 패널의 gate
+   * 배치조회가 꺼지고 카드는 개별 fetchGate()로 자연 폴백(회귀 0). */
+  gateByKey?: Record<string, GateCardState>;
+  requestedGateIdsRef?: RefObject<Set<string>>;
+  setGateByKey?: (updater: (prev: Record<string, GateCardState>) => Record<string, GateCardState>) => void;
   /** 답글 뱃지 안 꺼지는 버그 fix(2026-08-24, 선생님 리포트) — chat-view.tsx의 markRead(top-level
    * mark-read와 동일 엔드포인트·멱등 GREATEST 래칫)를 그대로 물려받는다. 이 패널은 열리면 항상
    * 최신 답글까지 자동 스크롤(위 shouldScrollToBottomRef)이라 "열람=끝까지 봄"이 성립 — 로드
@@ -72,6 +81,9 @@ export function ThreadPanel({
   requestedEntityStatusKeysRef,
   setEntityStatusByKey,
   eventDefinitionsByKey,
+  gateByKey,
+  requestedGateIdsRef,
+  setGateByKey,
   onMarkRead,
 }: ThreadPanelProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -89,6 +101,15 @@ export function ThreadPanel({
     setEntityStatusByKey ? messages : EMPTY_THREAD_MESSAGES,
     requestedEntityStatusKeysRef ?? localRequestedKeysRef,
     setEntityStatusByKey ?? noopSetEntityStatusByKey,
+  );
+
+  // story #5ace2e84 — 위 entityStatusByKey와 동일 정신(꺼짐 폴백 패턴 그대로).
+  const localRequestedGateIdsRef = useRef<Set<string>>(new Set());
+  const noopSetGateByKey = useCallback(() => {}, []);
+  useGateBatchFetch(
+    setGateByKey ? messages : EMPTY_THREAD_MESSAGES,
+    requestedGateIdsRef ?? localRequestedGateIdsRef,
+    setGateByKey ?? noopSetGateByKey,
   );
 
   const fetchThreadMessages = useCallback(async () => {
@@ -217,6 +238,7 @@ export function ThreadPanel({
           projectId={projectId}
           entityStatusByKey={entityStatusByKey}
           eventDefinitionsByKey={eventDefinitionsByKey}
+          gateByKey={gateByKey}
         />
       </div>
 
@@ -247,6 +269,7 @@ export function ThreadPanel({
                   projectId={projectId}
                   entityStatusByKey={entityStatusByKey}
                   eventDefinitionsByKey={eventDefinitionsByKey}
+                  gateByKey={gateByKey}
                 />
               );
             })}

--- a/apps/web/src/hooks/use-gate-batch.test.tsx
+++ b/apps/web/src/hooks/use-gate-batch.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+//
+// story #5ace2e84 — 채팅 결재카드 N+1 처방. use-entity-status-batch.test.tsx(#2262 PR②)와
+// 동일 정신·동일 하네스 구조 — chat-view.tsx(메인)와 thread-panel.tsx(스레드)가 같은
+// requestedIdsRef·같은 setGateByKey를 공유해 부르는 계약을 실제 렌더로 고정한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, useRef, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useGateBatchFetch } from './use-gate-batch';
+import type { CardState } from '@/components/chat/approval-request-card';
+import type { GateItem } from '@/components/kanban/types';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+type Msg = { approval_target?: { gate_id: string } | null };
+
+function Harness({ mainMessages, threadMessages }: { mainMessages: Msg[]; threadMessages: Msg[] }) {
+  const [gateByKey, setGateByKey] = useState<Record<string, CardState>>({});
+  const requestedIdsRef = useRef<Set<string>>(new Set());
+  // chat-view.tsx 역할
+  useGateBatchFetch(mainMessages, requestedIdsRef, setGateByKey);
+  // thread-panel.tsx 역할 — 같은 ref·같은 setter를 공유
+  useGateBatchFetch(threadMessages, requestedIdsRef, setGateByKey);
+  return <div data-testid="dump">{JSON.stringify(gateByKey)}</div>;
+}
+
+async function flush(times = 4) {
+  await act(async () => {
+    for (let i = 0; i < times; i++) await Promise.resolve();
+  });
+}
+
+function gateStub(id: string): GateItem {
+  return {
+    id, org_id: 'org-1', work_item_id: 'w-1', work_item_type: 'story',
+    gate_type: 'merge_gate', status: 'pending', resolver_id: null, resolved_at: null,
+    resolution_note: null, neutral_facts: null, created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(), can_approve: true, risk_grade: 'low',
+    work_item_summary: null,
+  };
+}
+
+describe('useGateBatchFetch — 메인+스레드 두 messages를 같은 캐시로 공유(story #5ace2e84)', () => {
+  it('approval_target.gate_id들을 ?ids= 배치 하나로 모아 GET /api/gates에 실어보낸다(BE list_gates 배열 계약)', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toContain('/api/gates?ids=');
+      expect(url).toContain('gate-1');
+      expect(url).toContain('gate-2');
+      return { ok: true, json: async () => [gateStub('gate-1'), gateStub('gate-2')] };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => {
+      root.render(
+        <Harness
+          mainMessages={[{ approval_target: { gate_id: 'gate-1' } }, { approval_target: { gate_id: 'gate-2' } }]}
+          threadMessages={[]}
+        />,
+      );
+    });
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const dump = container.querySelector('[data-testid="dump"]')?.textContent ?? '';
+    expect(dump).toContain('"gate-1":{"kind":"ready"');
+    expect(dump).toContain('"gate-2":{"kind":"ready"');
+  });
+
+  it('메인·스레드 양쪽이 같은 gate_id를 참조해도 fetch는 한 번만 나간다(공유 requestedIdsRef)', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => [gateStub('shared-gate')] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await act(async () => {
+      root.render(
+        <Harness
+          mainMessages={[{ approval_target: { gate_id: 'shared-gate' } }]}
+          threadMessages={[{ approval_target: { gate_id: 'shared-gate' } }]}
+        />,
+      );
+    });
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('BE가 project 접근권 없어 조용히 뺀 gate(응답 배열에 없음)는 not-found로 떨어진다(#2042 authz 필터와 대칭)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => [] })));
+
+    await act(async () => {
+      root.render(<Harness mainMessages={[{ approval_target: { gate_id: 'no-access-gate' } }]} threadMessages={[]} />);
+    });
+    await flush();
+
+    const dump = container.querySelector('[data-testid="dump"]')?.textContent ?? '';
+    expect(dump).toContain('"no-access-gate":{"kind":"not-found"}');
+  });
+});

--- a/apps/web/src/hooks/use-gate-batch.ts
+++ b/apps/web/src/hooks/use-gate-batch.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, type RefObject } from 'react';
+import { fetchWithAuth } from '@/lib/db/client';
+import type { CardState } from '@/components/chat/approval-request-card';
+import type { GateItem } from '@/components/kanban/types';
+
+/** story #5ace2e84 — 채팅 결재카드 N+1 처방. PO 실측(웜 dev): 대화 하나 진입 시
+ * `GET /api/gates/{id}` 단건 호출이 최대 51발(고유 38·중복 13) 붙어 1.08s→8.56s 스팬(p50
+ * 894ms·max 7,470ms)을 먹었다 — approval-request-card.tsx 인스턴스마다 독립 fetchGate()가
+ * 원인. use-entity-status-batch.ts(참조 칩 「지금 상태」 배치조회, story #2262 PR②)와 동일
+ * 정신 — chat-view.tsx가 로드된 메시지 창에서 approval_target.gate_id를 모아 `?ids=`
+ * 배치(GET /api/gates, story #5ace2e84 BE 처방)로 한 번에 당긴다. 카드는 이 결과가 있으면
+ * (loading 포함) 독립 fetchGate()를 안 태운다(approval-request-card.tsx 소비부 참고) —
+ * 배치 커버 밖(예: SSE로 대화 도중 새로 도착한 카드)만 기존 개별 fetch로 자연 폴백. */
+const GATE_BATCH_API_PATH = '/api/gates';
+// BE list_gates ids= 과대 IN 방어(422, backend/app/routers/gates.py)와 동일 상한 — 넘으면
+// chunk로 쪼갠다(콜 수는 여전히 ceil(N/200), 무제한 팬아웃으로 되돌아가지 않는다).
+const GATE_IDS_BATCH_CHUNK = 200;
+
+function collectUnrequestedGateIds(
+  messages: Array<{ approval_target?: { gate_id: string } | null }>,
+  alreadyRequestedIds: Set<string>,
+): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const msg of messages) {
+    const gateId = msg.approval_target?.gate_id;
+    if (!gateId || seen.has(gateId) || alreadyRequestedIds.has(gateId)) continue;
+    seen.add(gateId);
+    ids.push(gateId);
+  }
+  return ids;
+}
+
+export function useGateBatchFetch(
+  messages: Array<{ approval_target?: { gate_id: string } | null }>,
+  requestedIdsRef: RefObject<Set<string>>,
+  setGateByKey: (updater: (prev: Record<string, CardState>) => Record<string, CardState>) => void,
+) {
+  useEffect(() => {
+    const ids = collectUnrequestedGateIds(messages, requestedIdsRef.current);
+    if (ids.length === 0) return;
+    for (const id of ids) requestedIdsRef.current.add(id);
+
+    setGateByKey((prev) => {
+      const next = { ...prev };
+      for (const id of ids) next[id] = { kind: 'loading' };
+      return next;
+    });
+
+    let cancelled = false;
+    const chunks: string[][] = [];
+    for (let i = 0; i < ids.length; i += GATE_IDS_BATCH_CHUNK) {
+      chunks.push(ids.slice(i, i + GATE_IDS_BATCH_CHUNK));
+    }
+
+    for (const chunk of chunks) {
+      fetchWithAuth(`${GATE_BATCH_API_PATH}?ids=${chunk.map(encodeURIComponent).join(',')}`)
+        .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`status ${res.status}`))))
+        // BE list_gates는 배열을 그대로 반환한다(story #2054 approvals-queue.tsx의 /api/gates/inbox와
+        // 동일 계약 — {data:[...]} envelope 아님, fastapi-proxy가 그대로 통과).
+        .then((data: GateItem[]) => {
+          if (cancelled) return;
+          const byId = new Map(data.map((g) => [g.id, g]));
+          setGateByKey((prev) => {
+            const next = { ...prev };
+            for (const id of chunk) {
+              const gate = byId.get(id);
+              // project 접근권이 없어 BE가 조용히 뺀 경우(story #5ace2e84 authz 필터)도 같은
+              // 자리로 떨어진다 — 카드는 not-found와 동일하게 정직한 "게이트가 없다" 문구로
+              // graceful degrade(존재 비노출 규율과 대칭, 새 상태 분기 0).
+              next[id] = gate ? { kind: 'ready', gate } : { kind: 'not-found' };
+            }
+            return next;
+          });
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setGateByKey((prev) => {
+            const next = { ...prev };
+            for (const id of chunk) next[id] = { kind: 'error' };
+            return next;
+          });
+        });
+    }
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- requestedIdsRef·setGateByKey는 부모가 안정적으로 물려주는 참조(ref·useState setter)다.
+  }, [messages]);
+}

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -43,6 +43,7 @@ from app.services.gate_service import (
 )
 from app.services.member_resolver import resolve_member
 from app.services.project_auth import (
+    accessible_project_ids_in_org,
     get_project_role,
     has_project_access,
     is_org_owner,
@@ -585,6 +586,16 @@ async def list_gates(
     work_item_id: uuid.UUID | None = Query(default=None),
     work_item_type: str | None = Query(default=None),
     status: str | None = Query(default=None),
+    # story #5ace2e84 — 대화 안 결재카드 N+1 처방(PO 실측: 대화 진입당 /api/gates/{id} 최대
+    # 51발·p50 894ms·max 7.47s). stories.py `ids` 파라미터(comma-separated 배치 앵커 조회)와
+    # 동형 계약 — ORDER BY/limit/기타 필터 전부 무시하는 고정 집합 조회. 단건 GET /{id}와
+    # 동일하게 project 접근권을 gate별로 강제한다(아래 gate_ids 분기, #2042와 같은 비대칭
+    # 재발 방지 — 목록이라고 단건보다 느슨해지면 안 됨).
+    # ⚠️바로 위 #2864 주석과 동일 이유로 Annotated(실 None 기본값) — list_gate_inbox()가 이
+    # 파라미터를 안 넘기고 list_gates()를 직접 호출한다(아래) — raw `Query(default=None)`이면
+    # 그 직접호출 경로에서 Query 객체 자체가 기본값으로 들어가 `ids is not None`이 항상 참이
+    # 되고 `.split(",")`가 Query 객체엔 없어 즉시 TypeError로 터진다.
+    ids: Annotated[str | None, Query(description="comma-separated gate ids — 배치 앵커 조회")] = None,
     # story #2864(P0, 침묵 스왈로): gate_type·limit·offset이 시그니처에 아예 없어 FastAPI가
     # 미등재 쿼리 파라미터를 조용히 무시했다(#2863 zod dead-code와 동일 클래스 — 있다≠지금
     # 쓰는 것). ⚠️`= Query(...)`를 직접 기본값으로 쓰지 않고 Annotated로 뺀 이유 — 이
@@ -613,6 +624,20 @@ async def list_gates(
         from app.models.hitl_config import GATE_TYPES
         if gate_type not in GATE_TYPES:
             raise HTTPException(status_code=422, detail=f"gate_type must be one of {sorted(GATE_TYPES)}")
+
+    # story #5ace2e84 — ids 배치 앵커 조회 파싱(stories.py list_stories와 동형: comma-separated·
+    # invalid UUID=422·과대 IN 방어). ids가 오면 아래 work_item_id/status/gate_type 등 나머지
+    # 필터는 전부 무시하는 고정 집합 조회로 갈린다(stories.py와 동일 계약).
+    gate_ids: list[uuid.UUID] | None = None
+    if ids is not None:
+        try:
+            gate_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
+        except ValueError:
+            raise HTTPException(status_code=422, detail="invalid gate id in ids")
+        if not gate_ids:
+            return []
+        if len(gate_ids) > 200:  # stories.py ids 파라미터와 동형 방어(과대 IN 금지).
+            raise HTTPException(status_code=422, detail="too many ids (max 200)")
 
     # story #2042(P0, 침묵 스왈로 대칭 — 이번엔 authz 방향): work_item_id로 필터할 때 이
     # 라우트는 org_id 스코프만 걸고 project 접근권을 아예 안 물었다(has_project_access 호출
@@ -648,29 +673,34 @@ async def list_gates(
                 raise HTTPException(status_code=404, detail="Gate not found")
 
     q = select(Gate).where(Gate.org_id == org_id)
-    if work_item_id:
-        q = q.where(Gate.work_item_id == work_item_id)
-    if work_item_type:
-        q = q.where(Gate.work_item_type == work_item_type)
-    if status:
-        q = q.where(Gate.status == status)
-    if gate_type:
-        q = q.where(Gate.gate_type == gate_type)
-    # story #1973(P1a-S4): ?sort=urgency = SLA overdue 최상위 → age(created_at) 오래된 순 →
-    # held(향후 만료) 최하단(gate_service.apply_gate_urgency_sort). 미지정 시(기본) 기존 동작
-    # (무정렬/삽입순) 그대로 — 회귀 없음.
-    if sort == "urgency":
-        q = apply_gate_urgency_sort(q)
-    elif limit is not None or offset:
-        # story #2864: limit/offset이 결정적이려면 순서가 고정돼야 한다 — 무정렬(삽입순 암묵
-        # 의존)이었던 기존 동작을, 페이지네이션을 실제로 쓰는 호출에서만 created_at desc(최신
-        # 우선, 다른 목록 API들과 동형)로 명시. limit/offset 둘 다 안 쓰면 기존 무정렬 그대로
-        # (list_gate_inbox 등 기존 호출부 회귀 0).
-        q = q.order_by(Gate.created_at.desc())
-    if limit is not None:
-        q = q.limit(limit)
-    if offset:
-        q = q.offset(offset)
+    if gate_ids is not None:
+        # story #5ace2e84 — ids 배치는 고정 집합 앵커 조회(stories.py list_stories ids 분기와
+        # 동형). 나머지 필터/정렬/페이지네이션은 의미가 없어 전부 건너뛴다.
+        q = q.where(Gate.id.in_(gate_ids))
+    else:
+        if work_item_id:
+            q = q.where(Gate.work_item_id == work_item_id)
+        if work_item_type:
+            q = q.where(Gate.work_item_type == work_item_type)
+        if status:
+            q = q.where(Gate.status == status)
+        if gate_type:
+            q = q.where(Gate.gate_type == gate_type)
+        # story #1973(P1a-S4): ?sort=urgency = SLA overdue 최상위 → age(created_at) 오래된 순 →
+        # held(향후 만료) 최하단(gate_service.apply_gate_urgency_sort). 미지정 시(기본) 기존 동작
+        # (무정렬/삽입순) 그대로 — 회귀 없음.
+        if sort == "urgency":
+            q = apply_gate_urgency_sort(q)
+        elif limit is not None or offset:
+            # story #2864: limit/offset이 결정적이려면 순서가 고정돼야 한다 — 무정렬(삽입순 암묵
+            # 의존)이었던 기존 동작을, 페이지네이션을 실제로 쓰는 호출에서만 created_at desc(최신
+            # 우선, 다른 목록 API들과 동형)로 명시. limit/offset 둘 다 안 쓰면 기존 무정렬 그대로
+            # (list_gate_inbox 등 기존 호출부 회귀 0).
+            q = q.order_by(Gate.created_at.desc())
+        if limit is not None:
+            q = q.limit(limit)
+        if offset:
+            q = q.offset(offset)
     result = await session.execute(q)
     gates = list(result.scalars().all())
     responses = [GateResponse.model_validate(g) for g in gates]
@@ -836,6 +866,23 @@ async def list_gates(
     # caller·project 무권한 전부에서 자연히 유지된다(eligible_ids 에 없으면 False).
     for resp, g in non_doc_gates:
         resp.can_approve = g.id in eligible_ids and is_valid_transition(g.status, "approved")
+
+    if gate_ids is not None:
+        # story #5ace2e84 — ids 배치는 work_item_id 필터가 물던 project 접근권 검사(#2042)를
+        # 안 거친다(work_item_id가 None이라 위 그 블록 자체가 스킵) — 단건 GET /{id}
+        # (get_gate_endpoint)와 동일한 강제를 여기서 명시로 건다. project_id는 위에서 이미
+        # 배치 해소돼 있어 신규 N+1 없음(1 쿼리로 caller 접근 가능 project 집합만 추가 조회).
+        accessible_project_ids = set(await accessible_project_ids_in_org(session, uuid.UUID(auth.user_id), org_id))
+        visible: list[GateResponse] = []
+        for resp, g in zip(responses, gates):
+            pid = project_id_by_work_item.get(g.work_item_id)
+            if pid is not None:
+                if pid in accessible_project_ids:
+                    visible.append(resp)
+            elif is_known_project_agnostic_work_item_type(g.work_item_type):
+                visible.append(resp)
+            # else: project_id 해소 실패(work_item이 이 org에 없음 등) → fail-closed(제외).
+        return visible
 
     if not assigned_to_me:
         return responses

--- a/backend/tests/test_5ace2e84_gates_batch_ids_realdb.py
+++ b/backend/tests/test_5ace2e84_gates_batch_ids_realdb.py
@@ -1,0 +1,239 @@
+"""story #5ace2e84 — 채팅 결재카드 N+1 처방. PO 실측(웜 dev·로그인 세션): 대화 하나 진입 시
+`GET /api/gates/{id}` 단건 호출이 최대 51발(고유 38·중복 13) 붙어 1.08s→8.56s 스팬을 먹었다
+(p50 894ms·max 7,470ms) — approval-request-card.tsx 인스턴스마다 독립 fetchGate()가 원인.
+
+처방: `GET /api/gates`에 `ids=`(comma-separated) 배치 앵커 조회를 얹는다(stories.py list_stories
+`ids`와 동형 계약) — FE는 로드된 메시지 창의 approval_target.gate_id를 모아 1콜로 수렴시킨다
+(뒤따르는 stories/스토리 참고 SID#5ace2e84 FE PR).
+
+이 파일이 실측하는 것:
+  ① ids로 요청한 게이트가 그대로(project 접근권 있는 것만) 돌아온다.
+  ② project 접근권이 없는 게이트는 목록에서 조용히 빠진다(단건 GET /{id}의 404-존재비노출과
+     동일 판정 — 배치라고 더 느슨해지면 #2042와 같은 authz 비대칭 재발).
+  ③ ids에 없는 uuid(잘못된 형식)는 422.
+  ④ ids 200개 초과는 422(stories.py 과대 IN 방어와 동형).
+  ⑤ ids에 같은 id를 중복으로 넣어도 결과는 1건(IN절 자연 dedup — FE 중복 13발의 근본 처방).
+
+#2853/#2845/#2857과 동일 정신 — 격리 로컬 throwaway realdb만 사용(라이브 배포 시스템 무접촉).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("5ace2e84-0000-0000-0000-000000000001")
+PROJ_A = uuid.UUID("5ace2e84-0000-0000-0000-0000000000a1")  # caller가 접근권을 가진 project
+PROJ_B = uuid.UUID("5ace2e84-0000-0000-0000-0000000000b1")  # caller가 접근권이 없는 project
+STORY_A1 = uuid.UUID("5ace2e84-0000-0000-0000-0000000000c1")
+STORY_A2 = uuid.UUID("5ace2e84-0000-0000-0000-0000000000c2")
+STORY_B1 = uuid.UUID("5ace2e84-0000-0000-0000-0000000000c3")
+CALLER_USER = uuid.UUID("5ace2e84-0000-0000-0000-0000000000d1")
+CALLER_OM = uuid.UUID("5ace2e84-0000-0000-0000-0000000000e1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth_human(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(ORG))
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed(s) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
+    """ORG · PROJ_A(caller 접근권 有) · PROJ_B(caller 접근권 無). 각 project에 story 1(2)건 +
+    gate 1건씩. gate_a1·gate_a2(PROJ_A) · gate_b1(PROJ_B) 3건 반환(created_at 순서 무관, id로만 씀)."""
+    gate_a1, gate_a2, gate_b1 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    for sql in [
+        f"DELETE FROM gate WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{CALLER_USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S5ACE2E84','s5ace2e84-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{CALLER_USER}','caller@s5ace2e84.test','x','Caller',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{CALLER_OM}','{ORG}','{CALLER_USER}','member')",
+        f"INSERT INTO projects (id,org_id,name,slug,violation_level) VALUES "
+        f"('{PROJ_A}','{ORG}','A','s5ace2e84-proj-a','warn'),"
+        f"('{PROJ_B}','{ORG}','B','s5ace2e84-proj-b','warn')",
+        # PROJ_A만 project_access(granted) — PROJ_B는 caller에게 아무 접근권도 없다.
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) VALUES "
+        f"(gen_random_uuid(),'{PROJ_A}','{CALLER_OM}','granted','member')",
+        f"INSERT INTO stories (id,org_id,project_id,title,status,priority) VALUES "
+        f"('{STORY_A1}','{ORG}','{PROJ_A}','SA1','backlog','medium'),"
+        f"('{STORY_A2}','{ORG}','{PROJ_A}','SA2','backlog','medium'),"
+        f"('{STORY_B1}','{ORG}','{PROJ_B}','SB1','backlog','medium')",
+        "INSERT INTO gate (id,org_id,work_item_id,work_item_type,gate_type,status,neutral_facts,created_at) VALUES "
+        f"('{gate_a1}','{ORG}','{STORY_A1}','story','merge','pending','{{}}',now()),"
+        f"('{gate_a2}','{ORG}','{STORY_A2}','story','qa','pending','{{}}',now()),"
+        f"('{gate_b1}','{ORG}','{STORY_B1}','story','merge','pending','{{}}',now())",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+    return gate_a1, gate_a2, gate_b1
+
+
+# ───────────── ① ids로 요청한 접근가능 게이트가 그대로 돌아온다 ─────────────
+
+@pytest.mark.anyio
+async def test_ids_batch_returns_requested_accessible_gates():
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            gate_a1, gate_a2, _gate_b1 = await _seed(s)
+        async with Session() as s:
+            listed = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, gate_type=None,
+                ids=f"{gate_a1},{gate_a2}",
+                sort=None, assigned_to_me=False, limit=None, offset=0,
+                session=s, org_id=ORG, auth=_auth_human(CALLER_USER),
+            )
+        assert {g.id for g in listed} == {gate_a1, gate_a2}, (
+            "ids로 명시 요청한 접근가능 게이트 2건이 그대로 돌아와야 한다"
+        )
+    finally:
+        await eng.dispose()
+
+
+# ───────────── ② project 접근권 없는 게이트는 배치에서도 조용히 빠진다(#2042 authz 비대칭 재발 금지) ─────────────
+
+@pytest.mark.anyio
+async def test_ids_batch_silently_drops_gate_without_project_access():
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            gate_a1, _gate_a2, gate_b1 = await _seed(s)
+        async with Session() as s:
+            listed = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, gate_type=None,
+                ids=f"{gate_a1},{gate_b1}",
+                sort=None, assigned_to_me=False, limit=None, offset=0,
+                session=s, org_id=ORG, auth=_auth_human(CALLER_USER),
+            )
+        got_ids = {g.id for g in listed}
+        assert got_ids == {gate_a1}, (
+            f"PROJ_B(caller 접근권 없음) 소속 게이트가 배치 응답에 새 나가면 안 된다: {got_ids}"
+        )
+    finally:
+        await eng.dispose()
+
+
+# ───────────── ③ 잘못된 uuid = 422 ─────────────
+
+@pytest.mark.anyio
+async def test_ids_batch_invalid_uuid_rejected_422():
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await list_gates(
+                    work_item_id=None, work_item_type=None, status=None, gate_type=None,
+                    ids="not-a-uuid",
+                    sort=None, assigned_to_me=False, limit=None, offset=0,
+                    session=s, org_id=ORG, auth=_auth_human(CALLER_USER),
+                )
+        assert exc_info.value.status_code == 422
+    finally:
+        await eng.dispose()
+
+
+# ───────────── ④ 200개 초과 = 422(과대 IN 방어) ─────────────
+
+@pytest.mark.anyio
+async def test_ids_batch_over_cap_rejected_422():
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        too_many = ",".join(str(uuid.uuid4()) for _ in range(201))
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await list_gates(
+                    work_item_id=None, work_item_type=None, status=None, gate_type=None,
+                    ids=too_many,
+                    sort=None, assigned_to_me=False, limit=None, offset=0,
+                    session=s, org_id=ORG, auth=_auth_human(CALLER_USER),
+                )
+        assert exc_info.value.status_code == 422
+    finally:
+        await eng.dispose()
+
+
+# ───────────── ⑤ 중복 id는 1건으로 수렴(FE 중복 13발의 근본 처방) ─────────────
+
+@pytest.mark.anyio
+async def test_ids_batch_dedupes_duplicate_ids():
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            gate_a1, _gate_a2, _gate_b1 = await _seed(s)
+        async with Session() as s:
+            listed = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, gate_type=None,
+                ids=f"{gate_a1},{gate_a1},{gate_a1}",
+                sort=None, assigned_to_me=False, limit=None, offset=0,
+                session=s, org_id=ORG, auth=_auth_human(CALLER_USER),
+            )
+        assert len(listed) == 1 and listed[0].id == gate_a1, (
+            f"같은 id를 세 번 넣어도 결과는 1건이어야 한다(IN절 자연 dedup): {[g.id for g in listed]}"
+        )
+    finally:
+        await eng.dispose()
+
+
+# ───────────── ⑥ ids 미지정(기존 호출부)은 회귀 0 — list_gate_inbox 직접호출 안전 확인 ─────────────
+
+@pytest.mark.anyio
+async def test_ids_omitted_matches_pre_existing_default_behavior():
+    """list_gate_inbox()가 list_gates()를 ids= 없이 직접 파이썬 호출한다(라우터 파일 내부) —
+    Annotated 실 None 기본값이 아니면 이 직접호출 경로에서 Query 객체가 그대로 들어가
+    `.split(",")`가 즉시 TypeError로 터진다(#2864 주석이 이미 경고한 바로 그 함정)."""
+    from app.routers.gates import list_gates
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            gate_a1, gate_a2, gate_b1 = await _seed(s)
+        async with Session() as s:
+            listed = await list_gates(
+                work_item_id=None, work_item_type=None, status=None, gate_type=None,
+                sort=None, assigned_to_me=False, limit=None, offset=0,
+                session=s, org_id=ORG, auth=_auth_human(CALLER_USER),
+            )
+        # ids 미지정 + work_item_id 미지정 = 기존(#5ace2e84 이전) 그대로 org 스코프 무필터 목록 —
+        # PROJ_B(caller 접근권 없음) 게이트도 여기선 걸러지지 않는다(#2042가 손댄 건 work_item_id
+        # 필터 경로뿐, 이 일반 목록 경로는 그때도 지금도 동일 — 이 테스트는 회귀 0만 확인).
+        assert {g.id for g in listed} == {gate_a1, gate_a2, gate_b1}, (
+            "ids 파라미터 추가가 기존(일반 목록, ids/work_item_id 둘 다 미지정) 경로의 동작을 "
+            "바꾸면 안 된다 — 회귀"
+        )
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## 배경
[채팅 리스트·상세 첫 진입이 5~8초 — 첫 로딩만 정신병적, 이후엔 빠릿 (선생님 실기기)](entity:story:5ace2e84-92f7-4330-8137-01f7e8898c88)

- 2026-07-21 1차 그라운딩: BE API(100ms대)·FE SSR 워터폴(0.5-1s대) 둘 다 5~8초를 못 설명 → Cloud Run "no available instance" 콜드스타트로 판정, minScale 응급조치 후 FE 스코프 종료.
- 2026-08-27 디디 재그라운딩: 응급조치 후 인스턴스-부족 신호 14일간 0건 — 서버측 재현 안 됨.
- 2026-08-28 오늘, PO 페드루 웜 dev·로그인 세션 실측: **`GET /api/gates/{id}` 단건 호출이 대화 하나 진입 시 최대 51발(고유 38·중복 13) 붙어 1.08s→8.56s 스팬(p50 894ms·max 7,470ms)** — 웜 상태에서도 5~8초 증상이 재현되는 새 원인을 특정. `approval-request-card.tsx`(결재요청/결과 카드)가 카드 인스턴스마다 독립 `fetchGate()`를 태우는 게 근본.

## 처방
**BE** (`backend/app/routers/gates.py`, `list_gates`): `stories.py`의 `ids=`(comma-separated) 배치 앵커 조회와 동형 계약 추가.
- 나머지 필터/정렬/페이지네이션 무시하는 고정 집합(`Gate.id.in_(...)`) 조회, 200개 상한(422).
- ⚠️`work_item_id` 필터 경로가 이미 걸던 project 접근권 강제(#2042, 목록이 단건보다 느슨해지면 정보 노출)를 `ids` 경로에도 명시로 건다 — `accessible_project_ids_in_org` 1쿼리로 batched(N+1 아님), project 밖 게이트는 조용히 배제(존재 비노출 관례).
- `ids` 파라미터는 `Annotated[str | None, Query()] = None`(실 `None` 기본값) — `list_gate_inbox()`가 이 함수를 파라미터 생략하고 직접 파이썬 호출하므로, raw `Query(default=None)`이면 그 경로에서 `Query` 객체가 그대로 들어가 `.split(",")`가 TypeError로 터진다(#2864가 이미 겪은 함정, 회귀 테스트로 고정).

**FE**: `use-gate-batch.ts`(신규, `use-entity-status-batch.ts`와 동일 패턴) — `chat-view.tsx`가 로드된 메시지 창의 `approval_target.gate_id`를 모아 배치 1콜로 수렴. `ApprovalRequestCard`는 `initialGate` prop이 있으면(배치가 커버) 독립 fetch를 안 태운다 — 배치 커버 밖(SSE로 대화 도중 새로 도착한 카드, `approvals-queue.tsx`처럼 채팅 밖에서 쓰이는 경우)은 기존 개별 `fetchGate()`로 자연 폴백(회귀 0). `thread-panel.tsx`도 같은 캐시·요청장부 공유(스레드 답글 결재카드까지 커버).

## 남은 갭(의도적 스코프 밖)
- `chat-bubble.tsx`의 "gate 단건 sole-link 참조" 카드(`entity:gate:id` 단독 링크 문단)·`embed-group.tsx`의 `GateGroup`은 `approval_target` 기반이 아니라 이 배치의 커버 대상이 아니다(더 드문 경로, PO 실측 51발의 지배적 기여자는 아니라고 판단) — 필요시 후속.
- 이 스토리의 AC5("네트워크·BE로 원인을 돌리지 않는다")는 07-21 시점 판정 — 오늘 PO의 새 실측이 그 전제를 갱신했다(BE 원인 존재 확認). PO 판단으로 스코프 확장 지시받아 처방.

## 검증
- 신규 realdb 테스트 6건(`test_5ace2e84_gates_batch_ids_realdb.py`) — 배치 반환·authz 배제·422(잘못된 uuid/200개 초과)·dedup·`ids` 생략 회귀 0 — 전부 PASS.
- 기존 gates realdb 테스트 31건(`test_2864`/`test_2042`/`test_2054`/`test_1970`) 전부 PASS(회귀 0).
- FE vitest `src/components/chat` + `src/hooks` 662건 전부 PASS(신규 6건 포함).
- `tsc --noEmit` 0 에러, `pnpm lint` 0 에러, `pnpm build` 성공.

## Test plan
- [ ] 카디르군 QA: dev 배포 후 결재 카드 많은 대화 진입 시 Network 탭에서 `/api/gates` 콜 수·시간 실측 대조(before 51발/8.56s → after 1~2발)
- [ ] PO 페드루: 웜 dev 라이브 트레이스 재실측으로 5~8초 해소 확認