### PR TITLE
[긴급] allowlist until 일괄 만료 해소 — CI 전면 차단 복구 (+ 테스트 2건 동반 수리)

### DIFF
--- a/backend/tests/test_check_env_drift_code_read_axis.py
+++ b/backend/tests/test_check_env_drift_code_read_axis.py
@@ -361,7 +361,17 @@ def test_ac6_dynamic_key_construction_is_not_detected(tmp_path):
 # 되지 않도록: baseline에 없는 새 ㉠은 FAIL, baseline 안은 count만, self-expiring ──────
 
 
-def _entry(reason="r", declared_by="PO", until="2026-08-27"):
+def _entry(reason="r", declared_by="PO", until=None):
+    """`until` 기본값은 호출 시점 기준 **상대** 계산(오늘+7일) — 절대 날짜를 하드코딩하면
+    시간이 지나 그 날짜를 지나는 순간 이 픽스처를 쓰는 테스트가 스스로 무너진다(실사고,
+    2026-08-28 — 구 기본값 "2026-08-27"이 자연 만료돼 이 헬퍼를 쓰는 테스트 2건이 얼어붙은
+    날짜 때문에 매일 낡아가고 있었다). 30일 상한보다 훨씬 안쪽(7일)이라 만료·상한 두 축
+    모두 항상 통과하는 «중립» 기본값 — 언제 실행해도 같은 의미(=유효한 baseline 항목)를
+    유지한다(개별 만료/상한-초과 시나리오를 테스트하는 곳은 `until=`을 명시로 오버라이드해
+    이 기본값과 무관하다)."""
+    from datetime import date, timedelta
+    if until is None:
+        until = (date.today() + timedelta(days=7)).isoformat()
     return {"reason": reason, "declared_by": declared_by, "until": until}
 
 

--- a/backend/tests/test_mcp_path_contract_guard.py
+++ b/backend/tests/test_mcp_path_contract_guard.py
@@ -150,13 +150,31 @@ def test_norm_ignores_path_param_names():
 
 
 def test_repo_allowlist_entries_are_wellformed():
-    """저장소에 실제로 커밋된 선언(infra/mcp-path-contract-allowlist.yml)이 형식을 지키는지."""
+    """저장소에 실제로 커밋된 선언(infra/mcp-path-contract-allowlist.yml)이 형식을 지키는지 —
+    가드 자신의 `_today()`(실시간)로 재야 «지금 이 레포 상태가 유효한가»라는 이 테스트의
+    본뜻과 맞는다(실사고, 2026-08-28 — 구 코드는 `date(2026, 7, 28)`을 얼어붙은 기준일로
+    하드코딩해서, 30일 상한을 그 frozen 날짜 기준으로 재는 바람에 이후 어떤 정당한 `until`
+    연장도 영원히 이 테스트를 못 지나갔다 — until 갱신 자체가 불가능해지는 자기모순)."""
     mod = _load()
+    today = mod._today()
     mismatches, indirect = mod._load_allowlist()
     for kind, entries in (("declared_mismatches", mismatches), ("declared_indirect", indirect)):
         for key, entry in entries.items():
-            problem = mod._expired(entry, date(2026, 7, 28))
+            problem = mod._expired(entry, today)
             assert problem is None, f"{kind}/{key}: {problem}"
+
+
+def test_repo_allowlist_wellformed_check_still_enforces_horizon_cap():
+    """양성대조(페드루 지시, 2026-08-28) — 바로 위 테스트를 frozen date(2026,7,28) 대신
+    `mod._today()`(실시간)로 바꾼 뒤에도 30일 상한 집행 자체가 죽지 않았는지 값으로
+    고정한다: 상한을 넘는(45일 뒤) until을 넣으면 실시간 기준으로도 여전히 FAIL이어야
+    한다(날짜 기준을 동적으로 바꾸면서 상한 집행이 조용히 무력화되는 회귀를 막는다)."""
+    from datetime import timedelta
+    mod = _load()
+    today = mod._today()
+    over_cap = _entry(until=(today + timedelta(days=45)).isoformat())
+    problem = mod._expired(over_cap, today)
+    assert problem is not None and "너무 멀다" in problem
 
 
 def test_repo_current_state_is_green():

--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -552,52 +552,75 @@ code_read_exempt:
 # 파일이 낡은 것).
 code_read_high_baseline:
   - key: AGENT_INBOX_HMAC_SECRET
-    reason: apps/web/src/services/inbox-item.service.ts — 기본값 없음, 미triage.
+    reason: >-
+      apps/web/src/services/inbox-item.service.ts — 기본값 없음, 미triage.
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"
   - key: APP_BASE_URL
-    reason: apps/web/src/lib/auth/cookies.ts — 기본값 없음, 미triage(Amplify 레거시 override 후보).
+    reason: >-
+      apps/web/src/lib/auth/cookies.ts — 기본값 없음, 미triage(Amplify 레거시 override 후보).
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"
   - key: FIREBASE_AUTH_ISSUE_SESSION
-    reason: apps/web/src/app/api/auth/firebase/session/route.ts — 기본값 없음, 미triage.
+    reason: >-
+      apps/web/src/app/api/auth/firebase/session/route.ts — 기본값 없음, 미triage.
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"
   - key: FIREBASE_AUTH_MOBILE_ISSUE
-    reason: apps/web/src/app/auth/native/route.ts — 기본값 없음, 미triage.
+    reason: >-
+      apps/web/src/app/auth/native/route.ts — 기본값 없음, 미triage.
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"
   - key: FIREBASE_OAUTH_HANDOFF_ENABLED
-    reason: apps/web/src/app/auth/oauth-handoff/route.ts — 기본값 없음, 미triage(기능 플래그 추정).
+    reason: >-
+      apps/web/src/app/auth/oauth-handoff/route.ts — 기본값 없음, 미triage(기능 플래그 추정).
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"
   - key: MCP_ALLOWED_TOKEN_REFS
-    reason: apps/web/src/lib/mcp-secrets.ts — 기본값 없음, 미triage.
+    reason: >-
+      apps/web/src/lib/mcp-secrets.ts — 기본값 없음, 미triage.
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"
   - key: NEXT_PUBLIC_APP_URL
-    reason: apps/web/src/lib/auth/cookies.ts 등 — 기본값 없음, 미triage.
+    reason: >-
+      apps/web/src/lib/auth/cookies.ts 등 — 기본값 없음, 미triage.
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"
   - key: NEXT_PUBLIC_FIREBASE_API_KEY
     reason: >-
       apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage. NEXT_PUBLIC_*
       빌드타임 인라이닝 모호성 있음(AC6 한계 참고).
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"
   - key: NEXT_PUBLIC_FIREBASE_APP_ID
-    reason: apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(위와 동일 축).
+    reason: >-
+      apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(위와 동일 축).
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"
   - key: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
-    reason: apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(위와 동일 축).
+    reason: >-
+      apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(위와 동일 축).
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"
   - key: NEXT_PUBLIC_FIREBASE_AUTH_ENABLED
-    reason: apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(기능 플래그 추정).
+    reason: >-
+      apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(기능 플래그 추정).
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"
   - key: NEXT_PUBLIC_FIREBASE_PROJECT_ID
-    reason: apps/web/src/lib/auth/firebase-client.ts·lib/db/server.ts — 기본값 없음, 미triage(위와 동일 축).
+    reason: >-
+      apps/web/src/lib/auth/firebase-client.ts·lib/db/server.ts — 기본값 없음, 미triage(위와 동일 축).
+      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: PO
-    until: "2026-08-27"
+    until: "2026-09-26"

--- a/infra/mcp-path-contract-allowlist.yml
+++ b/infra/mcp-path-contract-allowlist.yml
@@ -39,9 +39,10 @@ declared_indirect:
       경로를 인자로 받는 공용 업로드 헬퍼(client.post(upload_path, ...)). 호출부 3곳 수기 추적:
       docs.py:164(/docs/{id}/attachments) · chat.py:121(/conversations/{id}/attachments) ·
       stories.py:147(/stories/{id}/attachments) — 서버 라우트 3곳(stories.py:578/docs.py:967/
-      conversations.py:2162) 전부 실재 확認됨(2026-07-28)
+      conversations.py:2162) 전부 실재 확認됨(2026-07-28). 2026-08-28 일괄 만료로 파이프라인
+      전면 차단 해소 — 실 triage는 story #3168로 이관.
     declared_by: 까심 아르야
-    until: "2026-08-27"
+    until: "2026-09-26"
   - module: chat
     function: _resolve_mention_content
     reason: >-
@@ -57,6 +58,7 @@ declared_indirect:
       GET /{id}) · /api/v2/visual-artifacts/{id}(visual_artifacts.py:214 GET /{id}) ·
       /api/v2/hypotheses/{id}(hypotheses.py:159 GET /{hypothesis_id}) ·
       /api/v2/evidence/{id}(evidence.py GET /{id}, story #2314 신설) — 여덟 다 실재
-      확認됨(2026-07-29).
+      확認됨(2026-07-29). 2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는
+      story #3168로 이관.
     declared_by: 디디 은와추쿠
-    until: "2026-08-27"
+    until: "2026-09-26"


### PR DESCRIPTION
## 배경
`infra/manual-env-allowlist.yml`(code_read_high_baseline 12건)·`infra/mcp-path-contract-allowlist.yml`(declared_indirect 2건)의 «미triage» 항목 전부가 `until="2026-08-27"`로 오늘(UTC 08-28) 일괄 만료 → Backend pytest 5건 FAIL → **오늘자 모든 PR CI 차단**([PR#3571](https://github.com/moonklabs/sprintable/pull/3571)이 첫 피격, diff 무관).

PO 페드루 승인·발주. 실 triage는 [\[인프라·부채 상환\] env code-read HIGH 15 + mcp path 2 — «미triage» 채무 실제 triage \(연장 반복 금지·값을 채우거나 exempt 확定\)](entity:story:faacbebc-4ded-4127-933f-5b08f2f43dab)(story #3168, 디디 은와추쿠 다음 슬롯)로 이관.

## 바뀌는 지점

### ① yml 2건 — until 연장만
14건 전부 `until: "2026-09-26"`(오늘 기준 30일 상한 이내)로 연장, `reason`에 "2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관" 명기. `declared_by`는 기존 그대로(PO/까심 아르야/디디 은와추쿠) 유지.

### ② 테스트 2건 — 동일 결함 클래스(얼어붙은 절대 날짜) 동반 수리
yml만 고쳐서는 5건 중 **3건만 해소됨을 로컬 실측으로 확인** — 나머지는 완전 별개(2건)이거나 이번 연장이 새로 깨움(1건):

1. **`test_check_env_drift_code_read_axis.py::_entry()`** — `until="2026-08-27"` 절대 하드코딩 기본값이 오늘부로 자연 만료돼 이 헬퍼를 쓰는 2개 테스트(`test_baseline_known_high_is_not_escalated`·`test_baseline_entry_without_reason_is_escalated`)가 **yml과 무관하게** 이미 빨강이었음(develop HEAD 클린 체크아웃으로 교차 확認). 처방: 호출 시점 기준 **상대** 계산(오늘+7일)으로 교체 — 30일 상한보다 훨씬 안쪽이라 언제 실행해도 유효.
2. **`test_mcp_path_contract_guard.py::test_repo_allowlist_entries_are_wellformed`** — `date(2026, 7, 28)` 얼어붙은 기준일로 실 레포의 `until`을 검사해, **어떤 정당한 연장도 그 frozen 기준 30일을 못 넘겨 영원히 FAIL하는 자기모순** 구조였음(이번 ①의 연장이 새로 깨움). 처방: 가드 자신의 `_today()`(실시간)로 교체 — "지금 레포가 유효한가"라는 이 테스트의 본뜻과 일치.

각 파일에서 같은 결함 클래스(하드코딩 절대 날짜, 실시간과 비교되는 것)를 grep으로 전수 확認 — 위 2곳뿐. 나머지 절대 날짜 리터럴(`_stub`/`_entry`의 `_today()`가 이미 완전히 모킹된 자기완결 시나리오, `test_baseline_entry_expired_is_escalated`의 명시적 고정쌍)은 wall-clock과 무관해 안전 — 불필요 변경 배제.

### ③ 양성대조 추가(PO 지시)
`test_repo_allowlist_wellformed_check_still_enforces_horizon_cap` 신설 — frozen→실시간 기준으로 바꾼 뒤에도 30일 상한 초과 항목(+45일)은 여전히 FAIL임을 값으로 고정(날짜 기준 전환이 상한 집행 자체를 조용히 무력화하지 않았음을 증명).

## 검증
관련 guard pytest 8개 파일(env_drift 축 전부 + mcp_path_contract) 전수 재실행 — 수정 前 **5 FAIL**, 수정 後 **98 passed, 0 failed**.

## Test plan
- [ ] 카디르군 QA(스코프: 형식 확認 → 테스트 수리 2건 포함, 페드루 사전 통보 済)
- [ ] 페드루 머지 → PR#3571 CI rerun