### PR TITLE
[SID:3169] 스토리 삭제 404 오보 실패 토스트 + Flow 잔존 표시 처방

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/flow/flow-client.tsx
@@ -150,6 +150,18 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
   }, [selectedStoryId]);
   const handleClosePanel = useCallback(() => setPanelOpen(false), []);
 
+  // story #3169(P2·prod 실사용·선생님 제보) — FlowNodeStoryPanel(위)에서 스토리를 삭제해도
+  // NextMakerScreen은 자기 자신의 fetch로 노드를 그리는 별도 컴포넌트라(kanban-board.tsx의
+  // `stories` 로컬 state와 달리 여기선 부모가 그 목록을 안 들고 있다) 삭제 신호가 갈 곳이
+  // 없었다 — 패널만 닫히고 갈래 캔버스엔 이미 지워진 스토리가 노드로 계속 남는 「잔존
+  // 표시」 표면이었다(다시 눌러 재삭제 시도 → 404 → 실패로 오인, 판별 A②). 전역
+  // bumpOrgSyncVersion()(project-context-client.ts)은 "org 전환 직후" 전용 계약이라 여기
+  // 재사용하지 않는다 — 이 페이지 스코프로 좁힌 자체 refetch 트리거만 하나 둔다.
+  const [flowRefetchToken, setFlowRefetchToken] = useState(0);
+  const handleFlowStoryDeleted = useCallback(() => {
+    setFlowRefetchToken((v) => v + 1);
+  }, []);
+
   // story #2533(E-FLOW-V4 S3) — 가설 생애 수직 서사 패널. story 패널(위)과 달리 「닫아도
   // 선택 유지」 뉘앙스가 AC에 없어 훨씬 단순하게: URL의 `?hypothesis=`가 곧 열림 상태의
   // 단일 소스다(별도 panelOpen 불필요) — 닫으면 파라미터 자체를 지운다.
@@ -268,6 +280,7 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
               onSelectStory={handleSelectStory}
               selectedNodeId={selectedStoryId}
               focusGoalId={focusGoalId}
+              refetchToken={flowRefetchToken}
             />
           )
         )}
@@ -283,7 +296,7 @@ export default function FlowPageClient({ projectId, wsSlug, projSlug }: FlowPage
         {view === 'flow' && panelOpen && selectedStoryId ? (
           // key={selectedStoryId} — 다른 노드를 연달아 누르면 통째로 다시 마운트시킨다(초기
           // loading 상태가 매번 자연히 맞다, flow-node-story-panel.tsx 문서 참고).
-          <FlowNodeStoryPanel key={selectedStoryId} storyId={selectedStoryId} onClose={handleClosePanel} />
+          <FlowNodeStoryPanel key={selectedStoryId} storyId={selectedStoryId} onClose={handleClosePanel} onDeleteSuccess={handleFlowStoryDeleted} />
         ) : null}
 
         {/* story #2533(E-FLOW-V4 S3) — 가설 생애 수직 서사. 가설 뷰에서만(다른 탭엔 가설 카드

--- a/apps/web/src/components/flow/flow-node-story-panel.test.tsx
+++ b/apps/web/src/components/flow/flow-node-story-panel.test.tsx
@@ -14,7 +14,10 @@ import { bumpOrgSyncVersion } from '@/lib/project-context-client';
 import koMessages from '../../../messages/ko.json';
 
 vi.mock('@/components/kanban/story-detail-panel', () => ({
-  StoryDetailPanel: ({ story, onClose, overlayPosition }: { story: { title: string }; onClose: () => void; overlayPosition?: { top: number; heightPx: number } }) => (
+  StoryDetailPanel: ({ story, onClose, onDeleteSuccess, overlayPosition }: {
+    story: { id: string; title: string }; onClose: () => void;
+    onDeleteSuccess?: (id: string) => void; overlayPosition?: { top: number; heightPx: number };
+  }) => (
     <div data-testid="story-detail-panel-stub" data-mode={overlayPosition ? 'overlay' : 'fullscreen'}>
       <span data-testid="stub-title">{story.title}</span>
       {overlayPosition ? (
@@ -24,6 +27,8 @@ vi.mock('@/components/kanban/story-detail-panel', () => ({
         </>
       ) : null}
       <button type="button" onClick={onClose}>close</button>
+      {/* story #3169 — onDeleteSuccess 배선을 값으로 잰다(잔존 표시 처방). */}
+      <button type="button" onClick={() => onDeleteSuccess?.(story.id)}>delete</button>
     </div>
   ),
 }));
@@ -130,6 +135,59 @@ describe('FlowNodeStoryPanel — 자립 fetch (story #2354 AC8, 새 BE 0)', () =
       '/api/tasks?story_id=story-abc&limit=20',
     ]);
     expect(container.querySelector('[data-testid="stub-title"]')?.textContent).toBe('앵커 시험 스토리');
+  });
+});
+
+// story #3169(P2·prod 실사용) — 이 패널이 그동안 StoryDetailPanel에 onDeleteSuccess를 안
+// 물려줘(fullscreen·overlay 두 렌더 분기 다) 갈래 캔버스(NextMakerScreen)가 스토리 삭제를
+// 몰라 노드가 유령처럼 남았다(잔존 표시 표면, flow-client.tsx가 상위에서 refetch 트리거로
+// 소비). 여기선 이 패널이 받은 onDeleteSuccess를 두 렌더 분기 모두 그대로 물려주는지만 잰다.
+describe('FlowNodeStoryPanel — onDeleteSuccess 물려주기(story #3169, 잔존 표시 처방)', () => {
+  it('fullscreen 분기(모바일)에서 StoryDetailPanel의 onDeleteSuccess가 그대로 불린다', async () => {
+    stubFetch([]);
+    setViewportWidth(390); // isMobile=true → fullscreen 분기
+    placeAnchor('story-abc', { top: 100, bottom: 130 });
+    const onDeleteSuccess = vi.fn();
+
+    await act(async () => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} onDeleteSuccess={onDeleteSuccess} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const deleteButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'delete');
+    await act(async () => { deleteButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(onDeleteSuccess).toHaveBeenCalledWith('story-abc');
+  });
+
+  it('overlay 분기(데스크톱)에서도 StoryDetailPanel의 onDeleteSuccess가 그대로 불린다', async () => {
+    stubFetch([]);
+    placeAnchor('story-abc', { top: 100, bottom: 130 });
+    const onDeleteSuccess = vi.fn();
+
+    await act(async () => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} onDeleteSuccess={onDeleteSuccess} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(container.querySelector('[data-testid="story-detail-panel-stub"]')?.getAttribute('data-mode')).toBe('overlay');
+    const deleteButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'delete');
+    await act(async () => { deleteButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(onDeleteSuccess).toHaveBeenCalledWith('story-abc');
+  });
+
+  it('onDeleteSuccess 미지정(구 호출부 대비)이어도 delete 클릭이 크래시하지 않는다(회귀 0)', async () => {
+    stubFetch([]);
+    placeAnchor('story-abc', { top: 100, bottom: 130 });
+
+    await act(async () => {
+      root.render(wrap(<FlowNodeStoryPanel storyId="story-abc" onClose={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const deleteButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'delete');
+    expect(() => deleteButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))).not.toThrow();
   });
 });
 

--- a/apps/web/src/components/flow/flow-node-story-panel.tsx
+++ b/apps/web/src/components/flow/flow-node-story-panel.tsx
@@ -19,6 +19,13 @@ const OVERLAY_MAX_HEIGHT_RATIO = 0.5; // AC5 — 뷰포트 절반 이하
 interface FlowNodeStoryPanelProps {
   storyId: string;
   onClose: () => void;
+  /** story #3169(P2·prod 실사용) — StoryDetailPanel의 onDeleteSuccess를 그대로 물려받아
+   * 상위(flow-client.tsx)에 전달한다. 이게 없으면 삭제가 서버에서 실제로 성공해도 갈래
+   * 캔버스(NextMakerScreen)의 자체 fetch 데이터엔 그 스토리가 노드로 그대로 남는다
+   * (「잔존 표시」 표면 — 이 패널은 KanbanBoard의 StoryDetailPanel과 달리 그동안 안 물려주고
+   * 있었다). 생략하면(undefined) 기존처럼 패널만 닫힌다(회귀 0, 다른 호출부 없음 — 이
+   * 컴포넌트는 flow-client.tsx가 유일한 소비처). */
+  onDeleteSuccess?: (storyId: string) => void;
 }
 
 type LoadState =
@@ -67,7 +74,7 @@ function computeOverlayPosition(rect: DOMRect | null, viewportHeight: number): {
  * 뛰고 `StoryDetailPanel`에 overlayPosition을 안 넘긴다 — 그러면 그 컴포넌트가 이미 갖고
  * 있는 전체화면 드로어 모드(KanbanBoard가 쓰는 그 경로 그대로, 새 컴포넌트 아님)로 뜬다.
  */
-export function FlowNodeStoryPanel({ storyId, onClose }: FlowNodeStoryPanelProps) {
+export function FlowNodeStoryPanel({ storyId, onClose, onDeleteSuccess }: FlowNodeStoryPanelProps) {
   const t = useTranslations('flow');
   const isMobile = useIsMobile();
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
@@ -194,7 +201,7 @@ export function FlowNodeStoryPanel({ storyId, onClose }: FlowNodeStoryPanelProps
     // StoryDetailPanel이 이미 갖고 있는 전체화면 드로어 모드로 뜬다(KanbanBoard와 동일 경로).
     return (
       <>
-        <StoryDetailPanel story={state.story} tasks={state.tasks} onClose={onClose} />
+        <StoryDetailPanel story={state.story} tasks={state.tasks} onClose={onClose} onDeleteSuccess={onDeleteSuccess} />
         {reviewEntry}
         {reviewDialog}
       </>
@@ -207,6 +214,7 @@ export function FlowNodeStoryPanel({ storyId, onClose }: FlowNodeStoryPanelProps
         story={state.story}
         tasks={state.tasks}
         onClose={onClose}
+        onDeleteSuccess={onDeleteSuccess}
         overlayPosition={{ top: overlayPosition!.top, heightPx: overlayPosition!.heightPx }}
       />
       {reviewEntry}

--- a/apps/web/src/components/flow/next-maker-screen.test.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.test.tsx
@@ -468,6 +468,46 @@ describe('NextMakerScreen — org-sync 성공 後 재요청 (story #2545)', () =
   });
 });
 
+// story #3169(P2·prod 실사용·선생님 제보) — FlowNodeStoryPanel에서 스토리를 삭제해도 이
+// 화면은 자기 자신의 fetch로 노드를 그리는 별도 컴포넌트라(부모가 목록을 안 들고 있음)
+// 삭제 신호가 갈 곳이 없어 이미 지워진 스토리가 노드로 계속 남았다(잔존 표시). 위
+// org-sync 재요청 테스트와 동일 계약 — `refetchToken`이 바뀌면 projectId가 그대로여도
+// 재요청되는지 고정한다(bumpOrgSyncVersion과 달리 이 값은 flow-client.tsx가 로컬로 들고
+// 있는 페이지 스코프 트리거 — project-context-client.ts의 전역 계약과 별개).
+describe('NextMakerScreen — refetchToken 변경 時 재요청(story #3169)', () => {
+  it('refetchToken이 바뀌면 projectId가 그대로여도 재요청된다', async () => {
+    const calledUrls: string[] = [];
+    vi.stubGlobal('fetch', buildFetchMock(calledUrls));
+
+    await act(async () => {
+      root.render(wrap(<NextMakerScreen projectId="p1" memberMap={{}} onSelectStory={() => {}} refetchToken={0} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    const goalsCallsAfterMount = calledUrls.filter((u) => u.startsWith('/api/goals?')).length;
+    expect(goalsCallsAfterMount).toBeGreaterThan(0);
+
+    await act(async () => {
+      root.render(wrap(<NextMakerScreen projectId="p1" memberMap={{}} onSelectStory={() => {}} refetchToken={1} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const goalsCallsAfterBump = calledUrls.filter((u) => u.startsWith('/api/goals?')).length;
+    expect(goalsCallsAfterBump).toBeGreaterThan(goalsCallsAfterMount);
+  });
+
+  it('refetchToken 미지정(구 호출부 대비)이어도 마운트 시 정상 fetch된다(회귀 0)', async () => {
+    const calledUrls: string[] = [];
+    vi.stubGlobal('fetch', buildFetchMock(calledUrls));
+
+    await act(async () => {
+      root.render(wrap(<NextMakerScreen projectId="p1" memberMap={{}} onSelectStory={() => {}} />));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(calledUrls.filter((u) => u.startsWith('/api/goals?')).length).toBeGreaterThan(0);
+  });
+});
+
 // story #2224 후속(2026-08-16, 미르코) — dev 실측(활성 목표 39건인데 화면은 "목표 0개")의
 // 근본원인 회귀가드. fetchAllPages가 `if (!res.ok) break`로 실패를 «페이지네이션 끝»과
 // 구분 없이 삼켜, 어떤 실패든(이번엔 401·일반화하면 5xx도 동형) items=[]가 "정상 0건"인

--- a/apps/web/src/components/flow/next-maker-screen.tsx
+++ b/apps/web/src/components/flow/next-maker-screen.tsx
@@ -30,6 +30,12 @@ interface NextMakerScreenProps {
    * 이 목표가 30일 무변화로 접힘 대상이었어도 강제로 펼침(카드 폭발 회피를 «구조»로 —
    * 다른 레인은 안 건드리고 이 레인 «하나»만 예외로 편다) + 그 레인으로 스크롤+하이라이트. */
   focusGoalId?: string | null;
+  /** story #3169(P2·prod 실사용) — flow-client.tsx가 FlowNodeStoryPanel의 삭제 성공을 받아
+   * 올리는 로컬 카운터(bumpOrgSyncVersion과 별개 — 그건 "org 전환 직후" 전용 계약이라 이
+   * 페이지 스코프 이벤트에 재사용하지 않는다, orgSyncVersion 사용 부분 참고). 값이 바뀔
+   * 때마다 아래 로드 effect가 재요청돼 방금 삭제된 스토리가 노드에서 빠진다. 생략하면
+   * (undefined) 기존 동작 그대로(회귀 0). */
+  refetchToken?: number;
 }
 
 interface Envelope<T> { data: T; meta?: unknown }
@@ -129,7 +135,7 @@ type LoadState =
  *
  * ⛔done 스토리는 이 화면에서 fetch하지 않는다(goals.total_stories/done_stories로 충분).
  */
-export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedNodeId = null, focusGoalId = null }: NextMakerScreenProps) {
+export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedNodeId = null, focusGoalId = null, refetchToken = 0 }: NextMakerScreenProps) {
   const t = useTranslations('flow');
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   // story #2545(카디르 라이브 재QA 5단계) — org 불일치 자동교정(switch-org) 성공 直後 이
@@ -189,7 +195,7 @@ export function NextMakerScreen({ projectId, memberMap, onSelectStory, selectedN
       }
     })();
     return () => { cancelled = true; };
-  }, [projectId, orgSyncVersion]);
+  }, [projectId, orgSyncVersion, refetchToken]);
 
   // 까심 QA REQUEST_CHANGES(2026-07-31) 후속 — 「다음으로」는 backlog→ready-for-dev로 상태를
   // 바꾸는 동작이라 되돌릴 길이 없으면 누르기가 무서워진다. 되돌리기 자체도 진짜 서버 PATCH이지

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -729,3 +729,100 @@ describe('StoryDetailPanel — Workcell Conversation 구획 대화근거 요약 
     expect(container.textContent).toContain('연결된 대화 없음');
   });
 });
+
+// story #3169(P2·prod 실사용·선생님 제보) — prod 실사고 재현: DELETE 200(성공) 4초 뒤 같은
+// id에 재시도 DELETE→404가 handleDelete의 `!res.ok` 무조건 실패 분기(#2485)에 걸려 "이미
+// 지워졌다(=사실상 성공)"인데도 실패 토스트로 표시됐다. 이 스위트는 ①404를 성공 경로와
+// 합류시키는지 ②진짜 실패(5xx)는 여전히 실패로 남는지 ③동기 더블클릭이 fetch를 한 번만
+// 내보내는지(in-flight ref 가드) 값으로 고정한다.
+describe('StoryDetailPanel — 삭제 404/이중발사 처방(story #3169)', () => {
+  async function clickDeleteThenConfirm() {
+    const deleteButton = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.getAttribute('aria-label') === '스토리 삭제',
+    );
+    await act(async () => { deleteButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    // 확認 다이얼로그는 Dialog(Radix 계열, document.body에 포탈)라 container 안에는 없다.
+    const confirmButton = Array.from(document.body.querySelectorAll('button')).find((b) => b.textContent === '영구 삭제');
+    return confirmButton;
+  }
+
+  it('DELETE 404(이미 삭제됨) — 실패 토스트 없이 onDeleteSuccess+onClose가 성공과 동일하게 불린다', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: { method?: string }) => {
+      if (url === '/api/stories/s1' && init?.method === 'DELETE') {
+        return { ok: false, status: 404, json: async () => ({ error: 'Story not found' }) };
+      }
+      return { ok: false, json: async () => null };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const onDeleteSuccess = vi.fn();
+    const onClose = vi.fn();
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={makeStory()} tasks={[]} onClose={onClose} onDeleteSuccess={onDeleteSuccess} />));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const confirmButton = await clickDeleteThenConfirm();
+    await act(async () => { confirmButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).not.toContain('스토리 삭제에 실패했습니다.');
+    expect(onDeleteSuccess).toHaveBeenCalledWith('s1');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('DELETE 500(진짜 실패) — 여전히 실패 토스트가 뜨고 onDeleteSuccess/onClose는 안 불린다(회귀 0)', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: { method?: string }) => {
+      if (url === '/api/stories/s1' && init?.method === 'DELETE') {
+        return { ok: false, status: 500, json: async () => ({ error: 'boom' }) };
+      }
+      return { ok: false, json: async () => null };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const onDeleteSuccess = vi.fn();
+    const onClose = vi.fn();
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={makeStory()} tasks={[]} onClose={onClose} onDeleteSuccess={onDeleteSuccess} />));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const confirmButton = await clickDeleteThenConfirm();
+    await act(async () => { confirmButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('스토리 삭제에 실패했습니다.');
+    expect(onDeleteSuccess).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('확認 버튼이 같은 tick에 두 번(동기 더블클릭) 눌려도 DELETE fetch는 한 번만 나간다(in-flight ref 가드)', async () => {
+    let resolveDelete: (() => void) | null = null;
+    const fetchMock = vi.fn(async (url: string, init?: { method?: string }) => {
+      if (url === '/api/stories/s1' && init?.method === 'DELETE') {
+        await new Promise<void>((resolve) => { resolveDelete = resolve; });
+        return { ok: true, status: 200, json: async () => null };
+      }
+      return { ok: false, json: async () => null };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={makeStory()} tasks={[]} onClose={() => {}} />));
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const confirmButton = await clickDeleteThenConfirm();
+    // 두 번째 dispatch까지 await 없이 같은 act 안에서 동기로 — deletingRef가 없으면 둘 다
+    // 첫 fetch(아직 in-flight, resolveDelete 미호출)를 지나쳐 두 번째 fetch까지 나간다.
+    await act(async () => {
+      confirmButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      confirmButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const deleteCalls = fetchMock.mock.calls.filter(
+      ([url, init]) => url === '/api/stories/s1' && (init as { method?: string } | undefined)?.method === 'DELETE',
+    );
+    expect(deleteCalls.length).toBe(1);
+
+    resolveDelete!();
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+  });
+});

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -487,11 +487,21 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [newLabelColor, setNewLabelColor] = useState<string>(LABEL_PRESET_COLORS[0]);
   const [creatingLabel, setCreatingLabel] = useState(false);
 
+  // story #3169(P2·prod 실사용·선생님 제보) — 확認 다이얼로그 클릭이 React state(`deleting`)
+  // 재렌더 커밋 前에 두 번 처리되면(더블클릭·터치 중복 이벤트 등) `disabled={deleting}`만으론
+  // 못 막는다 — ref는 동기 즉시 반영이라 같은 tick 안 두 번째 호출도 확실히 걸러낸다.
+  const deletingRef = useRef(false);
   const handleDelete = useCallback(async () => {
+    if (deletingRef.current) return;
+    deletingRef.current = true;
     setDeleting(true);
     try {
       const res = await fetch(`/api/stories/${story.id}`, { method: 'DELETE' });
-      if (!res.ok) {
+      // story #3169 — prod 실사고: 이미 삭제된(404) 대상에 재시도 DELETE가 붙으면(이중
+      // 발사·다른 화면의 잔존 표시 재클릭 등) 서버 관점에선 "지금 이 스토리가 없다"는
+      // 목표 상태가 이미 달성돼 있다 — 사용자에게는 성공과 동일한 결과다. 여기서만
+      // generic 실패 토스트(#2485)를 건너뛰고 성공 경로(뷰 제거+패널 닫기)와 합류시킨다.
+      if (!res.ok && res.status !== 404) {
         // story #2485 — backend delete_story()는 generic HTTP상태 코드만 낸다(진짜
         // 비즈니스 code 없음, 그라운딩 확認) — raw 서버 message 노출 대신 고정 문구.
         addToast({ type: 'error', title: '스토리 삭제에 실패했습니다.' });
@@ -502,6 +512,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     } catch {
       addToast({ type: 'error', title: '스토리 삭제에 실패했습니다.' });
     } finally {
+      deletingRef.current = false;
       setDeleting(false);
       setShowDeleteConfirm(false);
     }


### PR DESCRIPTION
## 배경
[[P2·prod 실사용·선생님 제보] 스토리 삭제 «성공을 실패로 보고» — 재시도 404가 generic 실패 토스트 + 이중 DELETE 발사 의심 + 삭제 후 잔존 표시 표면 판별](entity:story:bbe8181f-9639-4c11-803c-518fb852e51c)

prod: DELETE 200(성공) 4초 뒤 같은 id에 재시도 DELETE→404가 `handleDelete`의 무조건 `!res.ok` 실패 분기(#2485)에 걸려 "이미 지워짐(=사실상 성공)"인데도 실패 토스트로 표시됨.

## AC1 — 404 = 성공과 동등 처리
`story-detail-panel.tsx::handleDelete` — `!res.ok && res.status !== 404`로 좁혀 404를 성공 경로(`onDeleteSuccess`+`onClose`, 토스트 없음)와 합류.

## AC2① — in-flight ref 가드(이중 발사 방어)
`disabled={deleting}`만으론 React state 재렌더 커밋 前 동기 두 번째 클릭을 못 막는다 — `deletingRef`(동기 즉시 반영)로 같은 tick 두 번째 호출을 원천 차단.

## AC2②/B — 판별: 잔존 표시 표면 = Flow(갈래 캔버스)
grep 그라운딩으로 확인: `<StoryDetailPanel>` 렌더 3곳(`kanban-board.tsx`·`epic-swimlane-board.tsx`·`flow-node-story-panel.tsx`) 중 **`flow-node-story-panel.tsx`(mobile·overlay 두 분기 다)만 `onDeleteSuccess`를 안 물려주고 있었다** — SSE 기반 삭제 전파 자체가 이 코드베이스에 없어(grep 확인), Flow 캔버스(`NextMakerScreen`)는 자기 자신의 fetch로만 노드를 그리는데 그 신호를 받을 길이 없었다. 삭제해도 노드가 유령처럼 남아 사용자가 다시 눌러 재삭제를 시도하면 그게 곧 두 번째(404) DELETE다 — prod의 "4초 간격"과 부합하는 설명(밀리초 단위 동시클릭보다 이쪽이 더 유력).

처방: `FlowNodeStoryPanel` → `flow-client.tsx`(로컬 `refetchToken`, `project-context-client.ts`의 전역 `bumpOrgSyncVersion`과 별개 — 그건 "org 전환 직후" 전용 계약이라 재사용하지 않음) → `NextMakerScreen`(`refetchToken`을 로드 effect 의존성에 추가)로 삭제 신호를 실제로 흘려보낸다.

## AC3 — 회귀 가드
- `story-detail-panel.test.tsx`: 404=성공 합류·500=여전히 실패(회귀 0)·동기 더블클릭 시 DELETE fetch 1회만.
- `flow-node-story-panel.test.tsx`: `onDeleteSuccess`가 두 렌더 분기(mobile/overlay) 모두 물려짐 + 미지정 시 크래시 없음.
- `next-maker-screen.test.tsx`: `refetchToken` 변경 時 `projectId` 그대로여도 재요청(org-sync 재요청 테스트와 동일 계약) + 미지정 시 회귀 0.

## AC4 — 남은 것
dev 배포 후 실기기/실브라우저 **단일 클릭**으로 이중발사 자체가 여전히 재현되는지(밀리초 레이스 vs 이번 처방으로 해소되는 잔존표시 재클릭) 최종 판별은 PO/카디르 라이브 검증 몫 — in-flight 가드는 원인이 무엇이든 방어가 되므로 판별 결과와 무관하게 유효.

## 검증
관련 vitest 3파일 신규분 전부 PASS(story-detail-panel 34건·flow-node-story-panel 7건·next-maker-screen +2건) + kanban/flow/epics 전체 585건 PASS, `tsc --noEmit`·`pnpm lint` 0 에러, `pnpm build` 성공.

## Test plan
- [ ] 카디르군 QA: dev에서 실브라우저 단일 클릭으로 삭제 왕복(성공 토스트/침묵 확인) + 이미 삭제된 스토리 재클릭 시나리오(직접 404 유도)
- [ ] PO 페드루: Flow 뷰에서 노드 삭제 후 캔버스에서 실제로 사라지는지 라이브 확인