### PR TITLE
fix(#3171): org_subscriptions.currency NULL 레거시 행 — 하향/취소 예약 400

### DIFF
--- a/backend/app/services/org_subscription_downgrade.py
+++ b/backend/app/services/org_subscription_downgrade.py
@@ -18,6 +18,16 @@ doc `billing-policy-scenario-audit-20260821` 4·5번 갭: 자발 하향 write �
   자체를 구현하진 않는다, 좌석초과 자체가 «하향 무산» 사유일 뿐).
 ④예약 철회(재상향 아닌 단순 취소)는 별도 엔드포인트로 연다 — pending_*만 클리어,
   구독 자체는 원 tier 그대로 무변화.
+
+**fix(story #3171, P1)**: `_offering_or_raise`를 `currency=sub.currency`로 호출하면
+`org_subscriptions.currency`가 NULL인 행(#2471 도입 시 nullable·"기존 행/어댑터
+미기입 행은 NULL"이 설계상 정상 상태, `app/models/org_subscription.py` 참고)에서
+`OfferingVersion.currency == None` → SQLAlchemy가 `IS NULL`로 컴파일 → 활성
+offering_version이 실재해도(전부 currency='krw') 매치 0건 → 400. `org_subscription_
+checkout.py`/`org_subscription_tier_change.py`는 애초에 이 함정을 안 밟는다 —
+신규 구독 생성 경로라 "krw"를 직접 하드코딩하기 때문. 이 모듈은 기존 구독을 다루므로
+같은 하드코딩 대신 `sub.currency or "krw"`로 legacy-NULL 행을 흡수한다(현재 라이브
+통화가 krw 하나뿐이라는 사실은 동일 — provider=통화의 함수, #2471 설계 그대로).
 """
 from __future__ import annotations
 
@@ -105,7 +115,7 @@ async def reserve_downgrade(session: AsyncSession, *, org_id: uuid.UUID, new_tie
             f"{sub.tier!r}→{new_tier!r}는 하향이 아님(상향/동일) — 상향은 story #2880(change-tier)"
         )
 
-    new_offering = await _offering_or_raise(session, tier=new_tier, currency=sub.currency)
+    new_offering = await _offering_or_raise(session, tier=new_tier, currency=sub.currency or "krw")
     return await _reserve_pending_change(session, sub=sub, new_tier=new_tier, offering_id=new_offering.id)
 
 
@@ -127,7 +137,7 @@ async def cancel_subscription(session: AsyncSession, *, org_id: uuid.UUID) -> Or
 
     월납만(연납은 §12의 별도 환불식이 필요해 미착수 — story #2880/#2881과 동일 선례)."""
     sub = await _active_paid_sub_or_raise(session, org_id)
-    free_offering = await _offering_or_raise(session, tier="free", currency=sub.currency)
+    free_offering = await _offering_or_raise(session, tier="free", currency=sub.currency or "krw")
     return await _reserve_pending_change(session, sub=sub, new_tier="free", offering_id=free_offering.id)
 
 

--- a/backend/tests/test_3171_offering_version_currency_null_realdb.py
+++ b/backend/tests/test_3171_offering_version_currency_null_realdb.py
@@ -1,0 +1,129 @@
+"""story #3171(P1) — 실PG 검증. `org_subscriptions.currency`가 NULL인 레거시 행(#2471
+도입 시 nullable·"기존 행/어댑터 미기입 행은 NULL"이 설계상 정상 상태)에서 하향/취소
+예약이 «활성 offering_version이 실재하는데도» 400으로 막히던 결함(`_offering_or_raise`가
+`currency=sub.currency`를 그대로 넘겨 `OfferingVersion.currency == None` → SQLAlchemy가
+`IS NULL`로 컴파일 → krw 행만 있는 카탈로그에서 매치 0건)의 회귀 가드.
+
+커버:
+  AC2/3 양성 — currency=NULL(레거시 행) 상태에서도 reserve_downgrade·cancel_subscription
+             둘 다 200 상당(성공) — pending_* 예약이 실제로 걸린다.
+  AC3 음성대조 — «진짜 활성 offering_version이 없는» 경우(카탈로그에 없는 통화)는 여전히
+             DowngradeError(400) — 이번 수정이 조회 안전판 자체를 무력화한 게 아님을 실증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_org(session):
+    org_id = uuid.uuid4()
+    await session.execute(
+        text("INSERT INTO organizations (id, name, slug, plan) VALUES (:id, :name, :slug, 'free')"),
+        {"id": org_id, "name": f"test-org-{org_id}", "slug": f"slug-{org_id}"},
+    )
+    await session.commit()
+    return org_id
+
+
+async def _seed_legacy_subscription(session, org_id, *, tier="business", currency=None, provider=None, period_end=None):
+    """currency/provider/offering_version_id 전부 NULL — #2471 이전(어댑터 미기입) 실제
+    레거시 행 모양 그대로 재현. offering_version_id도 NULL(grandfather 미백필)이라
+    org_subscription_downgrade 쪽 조회가 오직 `sub.currency`(=None) 하나에만 의존한다."""
+    period_end = period_end or (datetime.now(timezone.utc) + timedelta(days=20))
+    await session.execute(
+        text(
+            "INSERT INTO org_subscriptions "
+            "(id, org_id, tier, billing_cycle, status, currency, provider, offering_version_id, "
+            " current_period_start, current_period_end) "
+            "VALUES (:id, :org_id, :tier, 'monthly', 'active', :currency, :provider, NULL, :ps, :pe)"
+        ),
+        {
+            "id": uuid.uuid4(),
+            "org_id": org_id,
+            "tier": tier,
+            "currency": currency,
+            "provider": provider,
+            "ps": period_end - timedelta(days=10),
+            "pe": period_end,
+        },
+    )
+    await session.commit()
+    return period_end
+
+
+@pytest.mark.anyio
+async def test_reserve_downgrade_succeeds_with_legacy_null_currency_realdb():
+    from app.services.org_subscription_downgrade import reserve_downgrade
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            await _seed_legacy_subscription(session, org_id, tier="business", currency=None, provider=None)
+
+            sub = await reserve_downgrade(session, org_id=org_id, new_tier="starter")
+
+            assert sub.tier == "business", "즉시 전이 없음"
+            assert sub.pending_tier == "starter"
+            assert sub.pending_offering_version_id is not None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cancel_subscription_succeeds_with_legacy_null_currency_realdb():
+    from app.services.org_subscription_downgrade import cancel_subscription
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            await _seed_legacy_subscription(session, org_id, tier="team", currency=None, provider=None)
+
+            sub = await cancel_subscription(session, org_id=org_id)
+
+            assert sub.tier == "team", "즉시 전이 없음"
+            assert sub.pending_tier == "free"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_offering_lookup_still_rejects_currency_with_no_active_catalog_row_realdb():
+    """음성대조 — 카탈로그에 없는 통화(usd, 현재 krw만 존재)면 fallback도 못 구해내고
+    여전히 DowngradeError. `sub.currency or "krw"`가 «항상 통과»로 바뀐 게 아님을 실증."""
+    from app.services.org_subscription_downgrade import DowngradeError, reserve_downgrade
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            # currency가 명시적으로 채워져 있으므로 `or "krw"` fallback이 안 탄다 — 진짜
+            # 없는 통화 그대로 조회돼 여전히 거부돼야 한다.
+            await _seed_legacy_subscription(session, org_id, tier="business", currency="usd", provider="polar")
+
+            with pytest.raises(DowngradeError, match="활성 offering_version"):
+                await reserve_downgrade(session, org_id=org_id, new_tier="starter")
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
[SID:3171]

- `reserve_downgrade`/`cancel_subscription`이 `_offering_or_raise(currency=sub.currency)`를 호출하는데, `org_subscriptions.currency`는 #2471에서 nullable로 설계됐고 어댑터 미기입 레거시 행(예: org `54bac162…`, moonklabs)은 NULL이다. SQLAlchemy가 `Column == None`을 `IS NULL`로 컴파일하므로, `offering_versions`에 활성 krw 행 4개가 실재해도 매치 0건 → `DowngradeError` → 400.
- `org_subscription_checkout.py`/`org_subscription_tier_change.py`/`billing_scheduler.py`는 이미 `"krw"`를 직접 하드코딩해 이 함정을 안 밟는다(현재 라이브 통화가 krw 하나뿐 — #2471 "provider = 통화의 함수" 설계 그대로). `org_subscription_downgrade.py` 두 호출부만 `sub.currency`를 그대로 넘기던 게 형제 코드와 어긋난 지점 — `sub.currency or "krw"`로 정정.
- story #2991(선생님 지시 건, 해지/다운그레이드 예약 취소 라이브 왕복 검증)의 첫 다리를 막던 선행 결함.

## ⛔ 스코프 경계
이 PR은 **조회 코드**만 고친다(currency=NULL 행도 올바르게 krw 카탈로그를 찾도록). **데이터 근본 backfill**(레거시 `org_subscriptions.currency`/`provider`/`offering_version_id`를 실제로 채우는 것, 「두 구독 스키마 통합」)은 범위 밖 — [\[결제②-A1후속\] 두 구독 스키마 통합 — org_subscriptions(정본) ↔ legacy subscriptions(死스키마) 정리](entity:story:5348afbf-d77d-433d-8a4c-ed99f2f926c5) 몫이다. `or "krw"` fallback은 그 통합 전까지의 임시 안전판이 아니라 — 현재 라이브 통화가 krw 하나뿐이라는 사실 자체를 반영한 정공법(형제 코드 3곳과 동일 패턴)이라 통합 이후에도 유효하다.

## Evidence
- pgstat-probe-dev 읽기전용 조회(실 dev DB): `org_subscriptions`에 active 2행 — `adfc74d3…`(currency='krw', provider='toss')는 정상, `54bac162…`(currency=NULL, provider=NULL)가 레거시 행. `offering_versions` 4행(free/starter/team/business) 전부 currency='krw'·effective_to=NULL(활성).
- SQLAlchemy 오프라인 컴파일: `OfferingVersion.currency == None` → `offering_versions.currency IS NULL`(매치 0건 확인). `sub.currency or "krw"` 적용 후 → `offering_versions.currency = 'krw'`(매치됨).
- 신규 실PG 회귀 테스트(`tests/test_3171_offering_version_currency_null_realdb.py`, `ALEMBIC_DATABASE_URL`/`PARITY_TEST_DATABASE_URL` 설정된 CI에서 실행):
  - `test_reserve_downgrade_succeeds_with_legacy_null_currency_realdb` — currency=NULL 레거시 행 + 활성 offering_version 실재 → 하향 예약 200 상당 성공.
  - `test_cancel_subscription_succeeds_with_legacy_null_currency_realdb` — 같은 조건에서 취소 예약 성공.
  - `test_offering_lookup_still_rejects_currency_with_no_active_catalog_row_realdb` — 양성대조: 카탈로그에 «진짜 없는» 통화(usd)는 여전히 400(안전판 무력화 아님을 실증).
- 로컬 실PG 스핀업은 이번 세션 환경 리소스 제약(shared memory 부족)으로 실패 — 대신 SQLAlchemy 쿼리 오프라인 컴파일 + 라이브 dev DB 읽기전용 조회로 기전 확인. `pytest --collect-only`로 신규/기존 테스트 파일 임포트·수집 정상 확인.

## Test plan
- [ ] CI: Backend pytest(신규 realdb 3건 + 기존 test_2881/test_2882 회귀 무변화 확인)
- [ ] CI: 전체 gate green
- [ ] 카디르 QA
- [ ] 착지 후 PO가 dev 라이브에서 #2991 왕복 2건 재실측

🤖 Generated with [Claude Code](https://claude.com/claude-code)