### PR TITLE
feat(#2473): usage_meters.meter_type CHECK을 v2.3 한도표 축으로 확장

### DIFF
--- a/backend/alembic/baseline/schema.sql
+++ b/backend/alembic/baseline/schema.sql
@@ -2142,7 +2142,7 @@ CREATE TABLE public.usage_meters (
     period_end timestamp with time zone NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT usage_meters_meter_type_check CHECK ((meter_type = ANY (ARRAY['ai_calls'::text, 'storage_mb'::text, 'members'::text, 'agents'::text, 'stt_minutes'::text])))
+    CONSTRAINT usage_meters_meter_type_check CHECK ((meter_type = ANY (ARRAY['ai_calls'::text, 'storage_mb'::text, 'members'::text, 'agents'::text, 'stt_minutes'::text, 'automation_units'::text, 'realtime_connections'::text, 'webhooks'::text, 'automation_rules'::text, 'event_replay_days'::text])))
 );
 
 

--- a/backend/alembic/versions/0287_usage_meters_v2_3_meter_types.py
+++ b/backend/alembic/versions/0287_usage_meters_v2_3_meter_types.py
@@ -1,0 +1,60 @@
+"""story #2473(결제②-A3): usage_meters.meter_type CHECK를 v2.3 한도표 축으로 확장.
+
+기존 5종(ai_calls/storage_mb/members/agents/stt_minutes)은 그대로 두고 v2.3 한도표
+(doc pricing-policy-v2-3 Part 3)의 신규 계측 축 5종을 더한다 — automation_units(AU)·
+realtime_connections·webhooks·automation_rules·event_replay_days. 순수 확장(추가)이라
+기존 값 파괴·데이터 변형 0 — CHECK 재정의만이라 기존 row는 옛 값 그대로 신규 CHECK를
+통과한다(옛 값이 새 집합의 부분집합).
+
+⛔한도 「집행」(ee/plan_limits 등)은 이 스토리 범위 밖 — usage_meters는 값을 담을
+그릇만 넓힌다.
+
+Revision ID: 0287
+Revises: 0286
+Create Date: 2026-08-28
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0287"
+down_revision = "0286"
+branch_labels = None
+depends_on = None
+
+_NEW_TYPES = (
+    "ai_calls",
+    "storage_mb",
+    "members",
+    "agents",
+    "stt_minutes",
+    "automation_units",
+    "realtime_connections",
+    "webhooks",
+    "automation_rules",
+    "event_replay_days",
+)
+_OLD_TYPES = ("ai_calls", "storage_mb", "members", "agents", "stt_minutes")
+
+
+def _check_sql(values: tuple[str, ...]) -> str:
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"meter_type IN ({quoted})"
+
+
+def upgrade() -> None:
+    op.drop_constraint("usage_meters_meter_type_check", "usage_meters", type_="check")
+    op.create_check_constraint(
+        "usage_meters_meter_type_check",
+        "usage_meters",
+        _check_sql(_NEW_TYPES),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("usage_meters_meter_type_check", "usage_meters", type_="check")
+    op.create_check_constraint(
+        "usage_meters_meter_type_check",
+        "usage_meters",
+        _check_sql(_OLD_TYPES),
+    )

--- a/backend/app/models/usage_meter.py
+++ b/backend/app/models/usage_meter.py
@@ -7,6 +7,35 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
 
+# story #2473(결제②-A3) — usage_meters.meter_type CHECK(DB, migration 0287)이 허용하는
+# 전체 값의 Python 쪽 거울. 기존 5종(ai_calls/storage_mb/members/agents/stt_minutes) +
+# v2.3 한도표(doc pricing-policy-v2-3 Part 3) 신규 축 5종. 값을 바꾸려면 migration도 같이
+# 갱신할 것 — 이 상수 자체가 DB 제약을 대체하지 않는다.
+ALLOWED_METER_TYPES = frozenset(
+    {
+        "ai_calls",
+        "storage_mb",
+        "members",
+        "agents",
+        "stt_minutes",
+        "automation_units",
+        "realtime_connections",
+        "webhooks",
+        "automation_rules",
+        "event_replay_days",
+    }
+)
+
+# story #2473 — AU(automation_units) 가중치 계측 seam(v2.1 §4.5 · v2.3 Part2 D15:
+# "읽기 1 · 쓰기 5 · 배치는 엔티티 1개당 5"). 값을 "기록할 자리"만 정의한다 — 실제
+# 호출부 배선(어디서 이 가중치로 usage_meters.current_value를 올릴지)과 한도 집행은
+# 이 스토리 범위 밖(후속 스토리 B, ee/plan_limits 확장)이다.
+AU_WEIGHTS: dict[str, int] = {
+    "read": 1,
+    "write": 5,
+    "batch_per_entity": 5,
+}
+
 
 class UsageMeter(Base):
     __tablename__ = "usage_meters"

--- a/backend/app/routers/usage.py
+++ b/backend/app/routers/usage.py
@@ -1,9 +1,9 @@
 """GET /api/v2/usage — org별 사용량 미터 조회.
 
 story #2394: mockups.py에서 분리했다 — 이 엔드포인트/UsageMeter 모델은 mockups 도메인
-전용이 아니다(meter_type CHECK가 허용하는 값은 ai_calls/storage_mb/members/agents/
-stt_minutes이고 'mockups'는 그중에 없다). mockups.py를 통째로 지우면서 이것까지 같이
-지우면 무관한 기능을 스코프 밖에서 없애는 것이라 별도 파일로 옮겨 살려뒀다.
+전용이 아니다(meter_type CHECK가 허용하는 값은 app.models.usage_meter.ALLOWED_METER_TYPES
+참고, 'mockups'는 그중에 없다). mockups.py를 통째로 지우면서 이것까지 같이 지우면
+무관한 기능을 스코프 밖에서 없애는 것이라 별도 파일로 옮겨 살려뒀다.
 """
 from __future__ import annotations
 

--- a/backend/tests/test_2473_usage_meter_constants.py
+++ b/backend/tests/test_2473_usage_meter_constants.py
@@ -1,0 +1,18 @@
+"""story #2473(결제②-A3) — usage_meter.py의 Python 상수(ALLOWED_METER_TYPES/AU_WEIGHTS)가
+migration 0287의 DB CHECK와 어긋나지 않는지 pin. 실PG 불요(순수 상수 검증) — 실제 DB
+CHECK 자체는 test_2473_usage_meters_v2_3_meter_types_realdb.py가 커버한다."""
+from __future__ import annotations
+
+from app.models.usage_meter import ALLOWED_METER_TYPES, AU_WEIGHTS
+
+
+def test_allowed_meter_types_has_old_and_new_axes():
+    old = {"ai_calls", "storage_mb", "members", "agents", "stt_minutes"}
+    new = {"automation_units", "realtime_connections", "webhooks", "automation_rules", "event_replay_days"}
+    assert old <= ALLOWED_METER_TYPES
+    assert new <= ALLOWED_METER_TYPES
+    assert ALLOWED_METER_TYPES == old | new
+
+
+def test_au_weights_seam_matches_policy_v2_1_section_4_5():
+    assert AU_WEIGHTS == {"read": 1, "write": 5, "batch_per_entity": 5}

--- a/backend/tests/test_2473_usage_meters_v2_3_meter_types_realdb.py
+++ b/backend/tests/test_2473_usage_meters_v2_3_meter_types_realdb.py
@@ -1,0 +1,137 @@
+"""story #2473(결제②-A3) — 실PG 검증. usage_meters.meter_type CHECK를 v2.3 한도표
+축(automation_units·realtime_connections·webhooks·automation_rules·event_replay_days)
+으로 확장(migration 0287)했다. 이 스토리는 «미터가 값을 담을 그릇»만 넓히는 것이라
+한도 집행 로직은 다루지 않는다 — 여기서 검증하는 것도 순수 DB CHECK 경계뿐이다.
+
+커버:
+  AC① — 신규 5종 전부 INSERT 성공(그릇이 실제로 넓어졌다).
+  AC② — 기존 5종(ai_calls/storage_mb/members/agents/stt_minutes)도 여전히 INSERT
+        성공(확장이 파괴가 아님 — 옛 값이 새 CHECK를 여전히 통과).
+  AC③ — CHECK 자체가 살아있다는 음성대조(negative control): v2.3 한도표에도 없는
+        임의 문자열은 여전히 거부된다 — CHECK가 통째로 사라진 게 아님을 실증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+NEW_METER_TYPES = (
+    "automation_units",
+    "realtime_connections",
+    "webhooks",
+    "automation_rules",
+    "event_replay_days",
+)
+OLD_METER_TYPES = ("ai_calls", "storage_mb", "members", "agents", "stt_minutes")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_org(session):
+    org_id = uuid.uuid4()
+    await session.execute(
+        text("INSERT INTO organizations (id, name, slug, plan) VALUES (:id, :name, :slug, 'free')"),
+        {"id": org_id, "name": f"test-org-{org_id}", "slug": f"slug-{org_id}"},
+    )
+    await session.commit()
+    return org_id
+
+
+async def _insert_meter(session, *, org_id, meter_type):
+    now = datetime.now(timezone.utc)
+    await session.execute(
+        text(
+            "INSERT INTO usage_meters (id, org_id, meter_type, current_value, period_start) "
+            "VALUES (:id, :org_id, :meter_type, 0, :period_start)"
+        ),
+        {"id": uuid.uuid4(), "org_id": org_id, "meter_type": meter_type, "period_start": now},
+    )
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_new_v2_3_meter_types_accepted():
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            try:
+                for meter_type in NEW_METER_TYPES:
+                    await _insert_meter(session, org_id=org_id, meter_type=meter_type)
+
+                rows = (
+                    await session.execute(
+                        text("SELECT meter_type FROM usage_meters WHERE org_id = :org_id"),
+                        {"org_id": org_id},
+                    )
+                ).scalars().all()
+                assert set(rows) == set(NEW_METER_TYPES)
+            finally:
+                await session.execute(text("DELETE FROM usage_meters WHERE org_id = :org_id"), {"org_id": org_id})
+                await session.execute(text("DELETE FROM organizations WHERE id = :org_id"), {"org_id": org_id})
+                await session.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_existing_meter_types_still_accepted_after_check_expansion():
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            try:
+                for meter_type in OLD_METER_TYPES:
+                    await _insert_meter(session, org_id=org_id, meter_type=meter_type)
+
+                rows = (
+                    await session.execute(
+                        text("SELECT meter_type FROM usage_meters WHERE org_id = :org_id"),
+                        {"org_id": org_id},
+                    )
+                ).scalars().all()
+                assert set(rows) == set(OLD_METER_TYPES)
+            finally:
+                await session.execute(text("DELETE FROM usage_meters WHERE org_id = :org_id"), {"org_id": org_id})
+                await session.execute(text("DELETE FROM organizations WHERE id = :org_id"), {"org_id": org_id})
+                await session.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unlisted_meter_type_still_rejected():
+    """음성대조 — v2.3 한도표에도 없는 값은 CHECK가 여전히 막는다(확장 ≠ 무제한)."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = await _seed_org(session)
+            try:
+                with pytest.raises(IntegrityError):
+                    await _insert_meter(session, org_id=org_id, meter_type="not_a_real_meter_type")
+            finally:
+                await session.rollback()
+                await session.execute(text("DELETE FROM usage_meters WHERE org_id = :org_id"), {"org_id": org_id})
+                await session.execute(text("DELETE FROM organizations WHERE id = :org_id"), {"org_id": org_id})
+                await session.commit()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2473_usage_meters_v2_3_meter_types_realdb.py
+++ b/backend/tests/test_2473_usage_meters_v2_3_meter_types_realdb.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import text
@@ -54,13 +54,23 @@ async def _seed_org(session):
 
 
 async def _insert_meter(session, *, org_id, meter_type):
+    """카디르 QA(PR#3575, 2026-08-28) 발견 — usage_meters.period_end는 baseline schema.sql상
+    NOT NULL(디폴트 없음, ORM 모델의 nullable=True와 어긋나는 기존 drift — 이 스토리 범위
+    밖이라 건드리지 않음, PO에 별건 보고). 누락 시 NotNullViolation이 CHECK보다 먼저 터져
+    음성대조(test_unlisted_meter_type_still_rejected)가 «맞는 이유로» 거부되는지 증명 못했다."""
     now = datetime.now(timezone.utc)
     await session.execute(
         text(
-            "INSERT INTO usage_meters (id, org_id, meter_type, current_value, period_start) "
-            "VALUES (:id, :org_id, :meter_type, 0, :period_start)"
+            "INSERT INTO usage_meters (id, org_id, meter_type, current_value, period_start, period_end) "
+            "VALUES (:id, :org_id, :meter_type, 0, :period_start, :period_end)"
         ),
-        {"id": uuid.uuid4(), "org_id": org_id, "meter_type": meter_type, "period_start": now},
+        {
+            "id": uuid.uuid4(),
+            "org_id": org_id,
+            "meter_type": meter_type,
+            "period_start": now,
+            "period_end": now + timedelta(days=30),
+        },
     )
     await session.commit()
 
@@ -119,14 +129,18 @@ async def test_existing_meter_types_still_accepted_after_check_expansion():
 
 @pytest.mark.anyio
 async def test_unlisted_meter_type_still_rejected():
-    """음성대조 — v2.3 한도표에도 없는 값은 CHECK가 여전히 막는다(확장 ≠ 무제한)."""
+    """음성대조 — v2.3 한도표에도 없는 값은 CHECK가 여전히 막는다(확장 ≠ 무제한).
+
+    카디르 QA 지적: period_end NOT NULL 누락 시에도 IntegrityError는 뜨지만 원인이
+    NotNullViolation이라 «CHECK가 살아있다」를 증명 못 한다 — 제약 이름을 예외 메시지에서
+    직접 확認해 «맞는 이유로» 거부됐는지까지 고정한다."""
     engine = create_async_engine(_ASYNC)
     Session = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with Session() as session:
             org_id = await _seed_org(session)
             try:
-                with pytest.raises(IntegrityError):
+                with pytest.raises(IntegrityError, match="usage_meters_meter_type_check"):
                     await _insert_meter(session, org_id=org_id, meter_type="not_a_real_meter_type")
             finally:
                 await session.rollback()


### PR DESCRIPTION
## Summary
[SID:2473]

v2.3 집행 축(AU·연결 등)을 «계측할 수 있게» `usage_meters`를 확장 — 기존 5종
(ai_calls/storage_mb/members/agents/stt_minutes)에 v2.3 한도표(doc `pricing-policy-v2-3`
Part 3) 신규 계측 축 5종을 더한다: `automation_units`(AU)·`realtime_connections`·
`webhooks`·`automation_rules`·`event_replay_days`. 순수 확장(추가)이라 기존 값 파괴 0.

⛔ 한도 **집행**(ee/plan_limits 등)은 이 스토리 범위 밖 — 그릇만 넓힌다.

## 변경
- `alembic/versions/0287_usage_meters_v2_3_meter_types.py` — `usage_meters_meter_type_check`
  DROP+재생성(#0279 `delivery_jobs.kind` 확장 선례와 동형 패턴).
- `alembic/baseline/schema.sql` — CHECK 정의 동기 갱신(CI SQLite가 PG CHECK 위반을
  못 잡는 blind spot 방지).
- `app/models/usage_meter.py` — `ALLOWED_METER_TYPES`(DB CHECK의 Python 거울) +
  `AU_WEIGHTS`(AU 가중치 계측 seam, v2.1 §4.5 "읽기1·쓰기5·배치 엔티티당5" — 값을
  기록할 자리만 정의, 호출부 배선/집행은 범위 밖).
- `app/routers/usage.py` — 옛 5종을 하드코딩 나열하던 스테일 독스트링 정정.

## Evidence — 실PG 뮤테이션 검증(로컬)
로컬 postgres@16 scratch DB에 baseline과 동일한 `organizations`/`usage_meters` DDL(옛 CHECK 포함)을 만들고, Alembic Operations API로 migration 0287의 `upgrade()`를 직접 구동해 왕복 확인:
1. **RED(마이그 前)**: `automation_units` INSERT → CHECK violation(예상대로 거부).
2. migration 0287 `upgrade()` 적용.
3. **GREEN**: 신규 5종 + 기존 5종 전부 10/10 INSERT 성공.
4. **음성대조**: `not_a_real_meter_type` INSERT → 여전히 CHECK violation(CHECK 자체가 살아있음, 무제한이 된 게 아님).
5. `downgrade()`도 별도로 구동해 DDL 역방향 정확성 확인.

## Test plan
- [x] `test_2473_usage_meter_constants.py` — Python 상수 pin(로컬 통과, 2/2).
- [ ] CI: `test_2473_usage_meters_v2_3_meter_types_realdb.py`(실PG, 위와 동일 3-케이스를 alembic-migrated CI DB에서 재확인)
- [ ] CI 전체 gate green
- [ ] 카디르 QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)