### PR TITLE
chore(#3168): env code-read HIGH 12 + mcp path 2 미triage 채무 실 triage

### DIFF
--- a/backend/tests/test_check_env_drift_code_read_axis.py
+++ b/backend/tests/test_check_env_drift_code_read_axis.py
@@ -318,10 +318,22 @@ def test_ac4_real_repo_scan_counts_are_recorded():
     # 2026-08-26 story aec3ec09([P1 후속] OAuth 핸드오프 활성화) 후속으로
     # FIREBASE_OAUTH_HANDOFF_ENABLED도 동형 배선(cloudbuild.yaml substitutions+GHA dev/prod
     # 분기+deploy-backend ENV_VARS)해 IaC-covered로 전환·high 12→11(카디르 QA 실 CI 실패 적발).
+    # 2026-08-28 story #3168 실 triage(12건 code_read_high_baseline 채무 전량 재판정) —
+    # NEXT_PUBLIC_FIREBASE_API_KEY/APP_ID/AUTH_DOMAIN/AUTH_ENABLED/PROJECT_ID(5) +
+    # FIREBASE_AUTH_ISSUE_SESSION/FIREBASE_AUTH_MOBILE_ISSUE(2) = 7건이 code_read_exempt로
+    # 승격(전자는 firebase-client.ts의 명시적 null-safe 스캐폴드 설계 + apps/web/Dockerfile·
+    # cloudbuild.yaml build-frontend --build-arg 목록에 부재해 구조적으로 영구 미인라이닝을
+    # 코드로 이중 확認, 후자는 FIREBASE_OAUTH_HANDOFF_ENABLED와 동형 안전-닫힘 토글에
+    # Cloud Logging 30일 무트래픽 실측 결합) → exempt 23→30·high 11→4(7건 감소). 나머지
+    # 5건(FIREBASE_OAUTH_HANDOFF_ENABLED·NEXT_PUBLIC_APP_URL은 이미 실 IaC substitution으로
+    # covered라 애초에 high가 아니었던 baseline의 중복 등재분 — 제거해도 high 불변,
+    # AGENT_INBOX_HMAC_SECRET·APP_BASE_URL·MCP_ALLOWED_TOKEN_REFS는 값 존부가 아니라
+    # 로드맵/보안 정책 판단 필요해 baseline 잔존)는 high 카운트에 영향 없음 — 남은 high
+    # 4건은 이 3건 + `_INCIDENT_KEYS` 고정 픽스처 FIREBASE_BFF_INTERNAL_SECRET 1건.
     assert len(highest) == 1, highest
-    assert len(high) == 11, high
+    assert len(high) == 4, high
     assert len(low) == 9, low
-    assert len(exempt) == 23
+    assert len(exempt) == 30
 
 
 # ── AC5 — 값을 안 읽는다 ──────────────────────────────────────────────────────
@@ -422,14 +434,17 @@ def test_baseline_entry_without_reason_is_escalated():
 
 
 def test_repo_code_read_high_baseline_is_wellformed():
-    """저장소에 실제로 커밋된 baseline(12건, 2026-08-07 — #2510 NEXT_PUBLIC_TOSS_CLIENT_KEY
+    """저장소에 실제로 커밋된 baseline(2026-08-07 — #2510 NEXT_PUBLIC_TOSS_CLIENT_KEY
     추가로 14→15, 2026-08-17 — #2728 NEXT_PUBLIC_EE_ENABLED를 cloudbuild.yaml/GHA 배선으로
     해소해 15→14, 2026-08-18 — #e6500272 LICENSE_CONSENT를 backend deploy 스텝 배선으로
     해소해 14→13, 2026-08-18 — #2758 NEXT_PUBLIC_TOSS_CLIENT_KEY를 cloudbuild.yaml build-arg+
-    GHA dev 분기 배선으로 해소해 13→12)이 형식을 지키는지."""
+    GHA dev 분기 배선으로 해소해 13→12, 2026-08-28 story #3168 실 triage로 12→3 —
+    7건 code_read_exempt 승격+2건 이미 IaC-covered 중복 제거, 남은 3건은 로드맵/보안
+    판단 대기 — infra/manual-env-allowlist.yml code_read_high_baseline 섹션 머리말
+    참고)이 형식을 지키는지."""
     mod = _load_check_env_drift()
     baseline = mod._load_code_read_high_baseline()
-    assert len(baseline) == 12
+    assert len(baseline) == 3
     for key, entry in baseline.items():
         problem = mod._baseline_entry_expired(entry, mod._today())
         assert problem is None, f"{key}: {problem}"

--- a/backend/tests/test_check_env_drift_code_read_axis.py
+++ b/backend/tests/test_check_env_drift_code_read_axis.py
@@ -325,13 +325,16 @@ def test_ac4_real_repo_scan_counts_are_recorded():
     # cloudbuild.yaml build-frontend --build-arg 목록에 부재해 구조적으로 영구 미인라이닝을
     # 코드로 이중 확認, 후자는 FIREBASE_OAUTH_HANDOFF_ENABLED와 동형 안전-닫힘 토글에
     # Cloud Logging 30일 무트래픽 실측 결합) → exempt 23→30·high 11→4(7건 감소). 나머지
-    # 5건(FIREBASE_OAUTH_HANDOFF_ENABLED·NEXT_PUBLIC_APP_URL은 이미 실 IaC substitution으로
-    # covered라 애초에 high가 아니었던 baseline의 중복 등재분 — 제거해도 high 불변,
-    # AGENT_INBOX_HMAC_SECRET·APP_BASE_URL·MCP_ALLOWED_TOKEN_REFS는 값 존부가 아니라
-    # 로드맵/보안 정책 판단 필요해 baseline 잔존)는 high 카운트에 영향 없음 — 남은 high
-    # 4건은 이 3건 + `_INCIDENT_KEYS` 고정 픽스처 FIREBASE_BFF_INTERNAL_SECRET 1건.
+    # 5건 중 FIREBASE_OAUTH_HANDOFF_ENABLED·NEXT_PUBLIC_APP_URL은 이미 실 IaC substitution으로
+    # covered라 애초에 high가 아니었던 baseline의 중복 등재분(제거해도 high 불변). 페드루
+    # PO가 라이브 env 이름 재실측으로 형제 비대칭(dev=NEXT_PUBLIC_APP_URL만 유·
+    # prod=APP_BASE_URL만 유) 발견 후 APP_BASE_URL도 cloudbuild.yaml deploy-frontend
+    # --update-env-vars에 `_NEXT_PUBLIC_APP_URL`(기존, dev/prod 정확분기)로 명시배선해
+    # IaC-covered 전환 → high 4→3. 남은 AGENT_INBOX_HMAC_SECRET·MCP_ALLOWED_TOKEN_REFS는
+    # 값 존부가 아니라 로드맵/보안 정책 판단 필요해 baseline 잔존 — 남은 high 3건은 이
+    # 2건 + `_INCIDENT_KEYS` 고정 픽스처 FIREBASE_BFF_INTERNAL_SECRET 1건.
     assert len(highest) == 1, highest
-    assert len(high) == 4, high
+    assert len(high) == 3, high
     assert len(low) == 9, low
     assert len(exempt) == 30
 
@@ -438,13 +441,14 @@ def test_repo_code_read_high_baseline_is_wellformed():
     추가로 14→15, 2026-08-17 — #2728 NEXT_PUBLIC_EE_ENABLED를 cloudbuild.yaml/GHA 배선으로
     해소해 15→14, 2026-08-18 — #e6500272 LICENSE_CONSENT를 backend deploy 스텝 배선으로
     해소해 14→13, 2026-08-18 — #2758 NEXT_PUBLIC_TOSS_CLIENT_KEY를 cloudbuild.yaml build-arg+
-    GHA dev 분기 배선으로 해소해 13→12, 2026-08-28 story #3168 실 triage로 12→3 —
-    7건 code_read_exempt 승격+2건 이미 IaC-covered 중복 제거, 남은 3건은 로드맵/보안
-    판단 대기 — infra/manual-env-allowlist.yml code_read_high_baseline 섹션 머리말
-    참고)이 형식을 지키는지."""
+    GHA dev 분기 배선으로 해소해 13→12, 2026-08-28 story #3168 실 triage로 12→3(7건
+    code_read_exempt 승격+2건 이미 IaC-covered 중복 제거) → 페드루 PO 실측(dev/prod
+    APP_BASE_URL·NEXT_PUBLIC_APP_URL 형제 비대칭)으로 APP_BASE_URL도 cloudbuild.yaml
+    deploy-frontend에 배선해 3→2 — infra/manual-env-allowlist.yml code_read_high_baseline
+    섹션 머리말 참고)이 형식을 지키는지."""
     mod = _load_check_env_drift()
     baseline = mod._load_code_read_high_baseline()
-    assert len(baseline) == 3
+    assert len(baseline) == 2
     for key, entry in baseline.items():
         problem = mod._baseline_entry_expired(entry, mod._today())
         assert problem is None, f"{key}: {problem}"

--- a/backend/tests/test_mcp_path_contract_guard.py
+++ b/backend/tests/test_mcp_path_contract_guard.py
@@ -27,11 +27,14 @@ def _load():
 
 
 def _stub(monkeypatch, mod, *, calls=None, unreadable=None, route_table=None,
-          mismatches=None, indirect=None, today="2026-07-28", fresh=True):
+          mismatches=None, indirect=None, permanent_indirect=None, today="2026-07-28", fresh=True):
     monkeypatch.setattr(mod, "check_ref_freshness", lambda: None if fresh else "테스트로 심은 stale")
     monkeypatch.setattr(mod, "load_route_table", lambda: route_table or {mod.POSITIVE_CONTROL})
     monkeypatch.setattr(mod, "load_mcp_declared", lambda: (calls or [], unreadable or []))
-    monkeypatch.setattr(mod, "_load_allowlist", lambda: (mismatches or {}, indirect or {}))
+    monkeypatch.setattr(
+        mod, "_load_allowlist",
+        lambda: (mismatches or {}, indirect or {}, permanent_indirect or {}),
+    )
     monkeypatch.setattr(mod, "_today", lambda: date.fromisoformat(today))
 
 
@@ -136,6 +139,56 @@ def test_baselined_indirect_helper_passes(monkeypatch, capsys):
     assert "M(1개)" in out and "수기검증됨" in out
 
 
+def test_permanent_indirect_helper_passes_without_until(monkeypatch, capsys):
+    """story #3168(2026-08-28) — declared_permanent_indirect는 until 없이도(reason/
+    declared_by만으로) 통과해야 한다(구조적으로 영구한 간접경로는 시한을 요구 안 함)."""
+    mod = _load()
+    key = ("chat", "_resolve_mention_content")
+    entry = {"reason": "동적 dispatch, 구조적으로 영구", "declared_by": "디디"}
+    _stub(monkeypatch, mod,
+          unreadable=[("chat", "_resolve_mention_content", "GET endpoint")],
+          permanent_indirect={key: entry})
+    assert mod.main() == 0
+    out = capsys.readouterr().out
+    assert "M(1개)" in out and "영구선언" in out
+
+
+def test_permanent_indirect_without_reason_fails(monkeypatch, capsys):
+    """reason 없는 영구선언은 until 면제와 무관하게 여전히 FAIL — «사유 없이 영구 예외»는
+    이 카테고리 신설의 취지(사유는 남기되 시한만 면제) 자체를 무력화한다."""
+    mod = _load()
+    key = ("attachments", "upload_attachments")
+    entry = {"declared_by": "까심"}  # reason 누락
+    _stub(monkeypatch, mod,
+          unreadable=[("attachments", "upload_attachments", "POST upload_path")],
+          permanent_indirect={key: entry})
+    assert mod.main() == 1
+    assert "reason" in capsys.readouterr().out
+
+
+def test_permanent_indirect_without_declared_by_fails(monkeypatch, capsys):
+    mod = _load()
+    key = ("attachments", "upload_attachments")
+    entry = {"reason": "동적 dispatch"}  # declared_by 누락
+    _stub(monkeypatch, mod,
+          unreadable=[("attachments", "upload_attachments", "POST upload_path")],
+          permanent_indirect={key: entry})
+    assert mod.main() == 1
+    assert "declared_by" in capsys.readouterr().out
+
+
+def test_unknown_permanent_indirect_key_fails(monkeypatch, capsys):
+    """permanent_indirect에도 declared_indirect에도 없는 새 M은 여전히 하드fail — 새 카테고리
+    신설이 «허용목록에 없어도 통과» 구멍을 만들지 않았는지 확認."""
+    mod = _load()
+    _stub(monkeypatch, mod,
+          unreadable=[("payments", "charge_card", "POST some_var")],
+          permanent_indirect={("unrelated", "func"): {"reason": "r", "declared_by": "PO"}})
+    assert mod.main() == 1
+    out = capsys.readouterr().out
+    assert "신규" in out and "payments" in out
+
+
 def test_stale_checkout_fails(monkeypatch, capsys):
     """⭐ref 신선도 자체 실패(develop과 다름)면 그 자체로 FAIL — 2026-07-28 오보 재발방지 조항."""
     mod = _load()
@@ -157,11 +210,19 @@ def test_repo_allowlist_entries_are_wellformed():
     연장도 영원히 이 테스트를 못 지나갔다 — until 갱신 자체가 불가능해지는 자기모순)."""
     mod = _load()
     today = mod._today()
-    mismatches, indirect = mod._load_allowlist()
+    mismatches, indirect, permanent_indirect = mod._load_allowlist()
     for kind, entries in (("declared_mismatches", mismatches), ("declared_indirect", indirect)):
         for key, entry in entries.items():
             problem = mod._expired(entry, today)
             assert problem is None, f"{kind}/{key}: {problem}"
+    # story #3168 — declared_permanent_indirect는 until 없이도 정상이어야 한다(별도 검사).
+    for key, entry in permanent_indirect.items():
+        problem = mod._permanent_entry_problem(entry)
+        assert problem is None, f"declared_permanent_indirect/{key}: {problem}"
+        assert "until" not in entry, (
+            f"declared_permanent_indirect/{key}: until이 있으면 안 됨(구조적으로 영구한 "
+            "간접경로엔 시한 개념 자체가 안 맞음 — 시한부면 declared_indirect로 내려갈 것)"
+        )
 
 
 def test_repo_allowlist_wellformed_check_still_enforces_horizon_cap():

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -492,7 +492,18 @@ steps:
       # [P1] iOS TestFlight 구글 로그인 후 404 인시던트(story 57526f21) — APPLE_TEAM_ID·
       # MOBILE_APP_LINK_ORIGIN 없으면 /.well-known/apple-app-site-association 라우트가
       # 설계대로 500(fail-loud)을 낸다. 같은 --update-env-vars에 동반(additive, 기존 env 보존).
-      - --update-env-vars=REALTIME_URL=${_REALTIME_URL},APPLE_TEAM_ID=${_APPLE_TEAM_ID},MOBILE_APP_LINK_ORIGIN=${_MOBILE_APP_LINK_ORIGIN}
+      # story #3168(2026-08-28, 페드루 PO 실측) — APP_BASE_URL/NEXT_PUBLIC_APP_URL 둘 다
+      # 이 스텝에 한 번도 배선된 적이 없어(순수 수동 category C) dev="NEXT_PUBLIC_APP_URL만
+      # 유"·prod="APP_BASE_URL만 유"로 환경마다 정반대 절반만 우연히 채워져 있었다 —
+      # apps/web/src/lib/auth/cookies.ts의 `APP_BASE_URL ?? NEXT_PUBLIC_APP_URL` 폴백
+      # 사슬 덕에 지금까지는 두 환경 다 결과적으로 동작해왔을 뿐(secure 쿠키 판정용),
+      # prod의 APP_BASE_URL은 수동 주입값이라 다음 전체 env 교체 배포가 조용히 지울 수
+      # 있는 시한 위험이었다. `_NEXT_PUBLIC_APP_URL`(이미 dev="https://dev-app.sprintable.ai"·
+      # prod="https://app.sprintable.ai"로 정확히 분기돼 있음, GHA cloud-build.yml 참고)를
+      # 재사용해 두 키 다 이 스텝에서 명시 배선 — 폴백 우선순위상 APP_BASE_URL이 먼저
+      # 읽히므로 그 값을 정본으로 통일하고 NEXT_PUBLIC_APP_URL은 이미 그 값을 쓰던 dev의
+      # 하위호환(레거시 Amplify override 축, app-url.ts 주석 참고)으로 같이 채운다.
+      - --update-env-vars=REALTIME_URL=${_REALTIME_URL},APPLE_TEAM_ID=${_APPLE_TEAM_ID},MOBILE_APP_LINK_ORIGIN=${_MOBILE_APP_LINK_ORIGIN},APP_BASE_URL=${_NEXT_PUBLIC_APP_URL},NEXT_PUBLIC_APP_URL=${_NEXT_PUBLIC_APP_URL}
       - --quiet
     waitFor: [push-frontend]
 

--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -380,9 +380,6 @@ services:
 
   sprintable-frontend-dev:
     keys:
-      - key: NEXT_PUBLIC_APP_URL
-        reason: 부트스트랩 스크립트 미편입 — 용도/생성 경위 확인 필요.
-        owner: TBD
       - key: FIREBASE_BFF_INTERNAL_SECRET
         reason: BFF↔Firebase 내부 시크릿 — 부트스트랩 스크립트 미편입.
         owner: TBD
@@ -397,9 +394,6 @@ services:
 
   sprintable-frontend-prod:
     keys:
-      - key: APP_BASE_URL
-        reason: 용도/생성 경위 미확認 — owner 확인 필요(TBD로 이미 알려진 항목, memory 참고).
-        owner: TBD
       - key: FIREBASE_OAUTH_HANDOFF_ENABLED
         value_check: skip
         reason: >-
@@ -603,33 +597,24 @@ code_read_exempt:
 # 막으려는 바로 그 방향이다(새 구멍 추가는 이 파일을 고치는 게 아니라 실제로 값을
 # 채우는 걸로 막혀야 한다).
 # reason/declared_by/until 필수(최대 30일) — mcp-path-contract-allowlist.yml(#2280)과
-# 동일 계약. story #3168(2026-08-28) 실 triage로 12건 중 9건 해소(FIREBASE_OAUTH_HANDOFF_
+# 동일 계약. story #3168(2026-08-28) 실 triage로 12건 중 10건 해소(FIREBASE_OAUTH_HANDOFF_
 # ENABLED·NEXT_PUBLIC_APP_URL 2건은 cloudbuild.yaml 실 substitution으로 이미 IaC-covered라
 # «중복 등재 제거»·NEXT_PUBLIC_FIREBASE_API_KEY/APP_ID/AUTH_DOMAIN/AUTH_ENABLED/
 # PROJECT_ID·FIREBASE_AUTH_ISSUE_SESSION·FIREBASE_AUTH_MOBILE_ISSUE 7건은 code_read_exempt로
-# 승격) — 남은 3건 중 2건(AGENT_INBOX_HMAC_SECRET·APP_BASE_URL)은 값 존부가 아니라
-# 로드맵/재검증 판단 필요, 1건(MCP_ALLOWED_TOKEN_REFS)은 별도 보안 스토리(#3174)로
-# 이관돼 그 스토리가 SSOT다. ⚠️1차 판정 정정(2026-08-28, 회귀테스트가 직접 잡음) —
-# `services:`(위 카테고리C, ①②키집합 축)에 라이브로 등재돼 있다는 사실이 이 ⑤(code-read)
-# 축의 covered 여부와 무관함을 처음엔 놓쳤다(covered-set 계산은 `_iac_covered_keys_for_
-# service | live_keys_for_web`뿐 — manual-env-allowlist.yml의 services: 목록은 전혀
-# 안 들어간다). APP_BASE_URL이 바로 그 케이스 — services:에 있어도 ⑤ 축은 그걸 못 보므로
-# 여기 남겨야 한다. check_env_drift.py 실행 로그의 "⑤㉠ baseline" 카운트가 이 숫자(3)와
-# 일치해야 정상.
+# 승격·APP_BASE_URL 1건은 ⓐ값 채움으로 격상 — 페드루 PO가 라이브 env 이름을 재실측해
+# dev="NEXT_PUBLIC_APP_URL만 유"·prod="APP_BASE_URL만 유"로 환경마다 정반대 절반만
+# 우연히 채워져 있던 형제 비대칭을 발견, cloudbuild.yaml deploy-frontend
+# --update-env-vars에 두 키 다 기존 `_NEXT_PUBLIC_APP_URL`(이미 dev/prod 정확 분기)로
+# 명시 배선해 근본 해소(cloudbuild.yaml 해당 커밋 참고, prod의 수동주입값이 다음 전체
+# 배포에 조용히 지워질 시한위험도 같이 닫힘)) — 남은 2건 중 1건(AGENT_INBOX_HMAC_SECRET)은
+# 값 존부가 아니라 로드맵 판단 필요, 1건(MCP_ALLOWED_TOKEN_REFS)은 별도 보안 스토리
+# (#3174)로 이관돼 그 스토리가 SSOT다. ⚠️1차 판정 정정(2026-08-28, 회귀테스트가 직접
+# 잡음) — `services:`(위 카테고리C, ①②키집합 축)에 라이브로 등재돼 있다는 사실이 이
+# ⑤(code-read) 축의 covered 여부와 무관함을 처음엔 놓쳤다(covered-set 계산은
+# `_iac_covered_keys_for_service | live_keys_for_web`뿐 — manual-env-allowlist.yml의
+# services: 목록은 전혀 안 들어간다). check_env_drift.py 실행 로그의 "⑤㉠ baseline"
+# 카운트가 이 숫자(2)와 일치해야 정상.
 code_read_high_baseline:
-  - key: APP_BASE_URL
-    reason: >-
-      apps/web/src/lib/auth/cookies.ts:13(isSecureScheme, `?? ''`→false시 쿠키 secure
-      플래그 안 붙음)·apps/web/src/services/app-url.ts — story #3168 실측(2026-08-28):
-      `services: sprintable-frontend-prod`(위 카테고리C)에 이미 라이브 값으로 등재돼
-      있으나(2026-07-22 확認), 그건 별개 축(①② 키집합)이라 이 ⑤(code-read) 축의
-      covered-set엔 안 잡힌다 — cloudbuild.yaml/deploy 스크립트 어디에도 "APP_BASE_URL"
-      리터럴이 없어 정적으로는 미공급으로 보인다(NEXT_PUBLIC_APP_URL은 cloudbuild.yaml
-      ENV_VARS에 실 substitution이 있어 이미 해소됨 — 이름이 비슷해도 별개 키). 실제로는
-      live라 위험 낮음(재확認만 필요) — PO가 다음 gcloud describe 때 한 줄 재확認 후
-      제거.
-    declared_by: PO
-    until: "2026-09-26"
   - key: AGENT_INBOX_HMAC_SECRET
     reason: >-
       apps/web/src/services/inbox-item.service.ts:95 — 미설정 시 fail-closed(전부 거부).

--- a/infra/manual-env-allowlist.yml
+++ b/infra/manual-env-allowlist.yml
@@ -540,6 +540,62 @@ code_read_exempt:
   - key: SPRINTABLE_TEAMS_OUTBOUND_POLL_INTERVAL_MS
     reason: SPRINTABLE_RUNTIME_ROLE이 web으로 떨어지면(기본) 워커 자체가 안 켜져 실질 영향 없음 — 같은 기능군.
 
+# story #3168(2026-08-28) — code_read_high_baseline ㉠에서 승격. 아래 5건은 firebase-client.ts
+# 자체가 "config 부재 시 절대 throw 안 하고 null 반환"으로 명시 설계됐고(readConfig() 4개
+# 필드 중 하나라도 없으면 null), 거기 더해 apps/web/Dockerfile·cloudbuild.yaml build-frontend
+# 스텝의 --build-arg 목록(NEXT_PUBLIC_FASTAPI_URL/OAUTH_ENABLED/GA4_MEASUREMENT_ID/
+# SSE_MULTIPLEX_ENABLED/EE_ENABLED/TOSS_CLIENT_KEY 6종)에 이 5개가 전혀 없음을 확認했다 —
+# Next.js는 NEXT_PUBLIC_*을 빌드타임에 클라 번들로 인라이닝하므로, Cloud Run 런타임 env에
+# 값이 있고 없고와 무관하게 이 5개는 지금 파이프라인에서 클라 코드 관점에 구조적으로 영구
+# undefined다(KMS_PROVIDER류와 동형 — "값 없이도 영구 정상"이 코드+빌드파이프라인 이중으로
+# 증명됨). ⛔이 exempt는 "영원히 안 본다"가 아니다 — 이 5개 중 하나라도 build-frontend에
+# --build-arg로 추가되는 날, 이 판정 자체를 재검토해야 한다(그 순간부터 값이 실제로
+# 쓰이기 시작하므로).
+  - key: NEXT_PUBLIC_FIREBASE_API_KEY
+    reason: >-
+      apps/web/src/lib/auth/firebase-client.ts:17 readConfig() — 4개 필수 필드 중 하나.
+      build-frontend --build-arg 목록에 없어 구조적으로 영구 미인라이닝(위 섹션 설명 참고).
+  - key: NEXT_PUBLIC_FIREBASE_APP_ID
+    reason: 위와 동일 축(readConfig() 필수 필드) — build-arg 미배선으로 영구 미인라이닝.
+  - key: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+    reason: 위와 동일 축(readConfig() 필수 필드) — build-arg 미배선으로 영구 미인라이닝.
+  - key: NEXT_PUBLIC_FIREBASE_AUTH_ENABLED
+    reason: >-
+      apps/web/src/lib/auth/firebase-client.ts:15 `=== 'true'` — 미설정 시 false로
+      떨어지는 명시적 기능 토글(FIREBASE_AUTH_ENABLED export). 같은 build-arg 미배선
+      축이라 값이 있어도 클라에 안 실린다.
+  - key: NEXT_PUBLIC_FIREBASE_PROJECT_ID
+    reason: >-
+      firebase-client.ts readConfig() 필수 필드 + lib/db/server.ts:74(서버사이드 세션
+      검증)에서도 읽음 — 서버 쪽은 `?? ''`+빈 값이면 즉시 null 반환(§4.1 "검증 실패 시
+      legacy 폴백 절대 금지"와 합치, throw 없음). 클라 쪽은 다른 4건과 동일하게 build-arg
+      미배선으로 영구 미인라이닝.
+
+# story #3168(2026-08-28, 페드루 PO 판정 ⑤) — code_read_high_baseline ㉠에서 승격.
+# ⚠️축 구분 정정(1차 판정 정정) — 처음엔 이 둘을 위 `services:`(카테고리C, ①②키집합
+# 축)로 옮겼으나, 그 축은 «라이브에 있는데 IaC에 없는» 걸 인정하는 자리라 code_read
+# 축(⑤, «코드가 읽는데 아무도 안 준다»)과 covered-set 계산 자체가 다르다(⑤는
+# `_iac_covered_keys_for_service | live_keys_for_web`만 본다 — manual-env-allowlist.yml의
+# services: 목록은 이 계산에 전혀 안 들어간다). 두 플래그가 지금 실제로 live가 아니라서
+# (아래 실측) services: 이관은 ⑤ FAIL을 그대로 남긴다 — 회귀테스트
+# (test_check_env_drift_code_read_axis.py AC2/AC4)가 이 실수를 즉시 잡아줬다. 올바른
+# 축은 code_read_exempt다 — FIREBASE_OAUTH_HANDOFF_ENABLED와 같은 «안전한 수동 토글»
+# 코드 패턴(never throw, `!== 'true'`면 501)이되, 그쪽은 실제로 live라 covered-set에서
+# 자연 해소되는 것과 달리 이 둘은 아직 미점화라 exempt로 명시해야 한다.
+  - key: FIREBASE_AUTH_ISSUE_SESSION
+    reason: >-
+      apps/web/src/app/api/auth/firebase/session/route.ts:35 `!== 'true'` 시 fail-closed
+      501(throw 없음, FIREBASE_OAUTH_HANDOFF_ENABLED와 동형 안전 토글). Cloud Logging
+      30일 실측(2026-08-28) dev/prod 둘 다 POST /api/auth/firebase/session 0건 — 모바일
+      auth 트랙(OAuth handoff 계열, 현재 활성)의 미점화 후속 토글. 점화되면(값이 실제
+      live가 되면) covered-set에 자연히 잡혀 이 exempt 자체가 report 대상에서 빠진다.
+  - key: FIREBASE_AUTH_MOBILE_ISSUE
+    reason: >-
+      apps/web/src/app/auth/native/route.ts:87 `!== 'true'` 시 fail-closed 501(throw
+      없음). Cloud Logging 30일 실측: dev 2×501(2026-08-02, 토글 꺼진 상태)+1×405
+      (2026-08-14, 이후 무)·prod 0건 — FIREBASE_AUTH_ISSUE_SESSION과 같은 축, 모바일
+      auth 후속 미점화 토글.
+
 # ⑤㉠(story #2296 후속, 파울로군 지시 2026-07-28) — «알려진 채무» 래칫 baseline.
 # ⛔code_read_exempt(위)와 다르다 — exempt는 "코드로 확認해 영구히 정상"이고, 이건 "아직
 # triage 안 됐지만 지금 당장 FAIL로 막으면 가드가 꺼지니 일단 알고 있다"다. baseline에
@@ -547,80 +603,51 @@ code_read_exempt:
 # 막으려는 바로 그 방향이다(새 구멍 추가는 이 파일을 고치는 게 아니라 실제로 값을
 # 채우는 걸로 막혀야 한다).
 # reason/declared_by/until 필수(최대 30일) — mcp-path-contract-allowlist.yml(#2280)과
-# 동일 계약. 2026-08-07 실측 기준 15건(#2510 NEXT_PUBLIC_TOSS_CLIENT_KEY 추가로 14→15) —
-# check_env_drift.py 실행 로그의 "⑤㉠ baseline" 카운트가 이 숫자와 일치해야 정상(달라지면
-# 파일이 낡은 것).
+# 동일 계약. story #3168(2026-08-28) 실 triage로 12건 중 9건 해소(FIREBASE_OAUTH_HANDOFF_
+# ENABLED·NEXT_PUBLIC_APP_URL 2건은 cloudbuild.yaml 실 substitution으로 이미 IaC-covered라
+# «중복 등재 제거»·NEXT_PUBLIC_FIREBASE_API_KEY/APP_ID/AUTH_DOMAIN/AUTH_ENABLED/
+# PROJECT_ID·FIREBASE_AUTH_ISSUE_SESSION·FIREBASE_AUTH_MOBILE_ISSUE 7건은 code_read_exempt로
+# 승격) — 남은 3건 중 2건(AGENT_INBOX_HMAC_SECRET·APP_BASE_URL)은 값 존부가 아니라
+# 로드맵/재검증 판단 필요, 1건(MCP_ALLOWED_TOKEN_REFS)은 별도 보안 스토리(#3174)로
+# 이관돼 그 스토리가 SSOT다. ⚠️1차 판정 정정(2026-08-28, 회귀테스트가 직접 잡음) —
+# `services:`(위 카테고리C, ①②키집합 축)에 라이브로 등재돼 있다는 사실이 이 ⑤(code-read)
+# 축의 covered 여부와 무관함을 처음엔 놓쳤다(covered-set 계산은 `_iac_covered_keys_for_
+# service | live_keys_for_web`뿐 — manual-env-allowlist.yml의 services: 목록은 전혀
+# 안 들어간다). APP_BASE_URL이 바로 그 케이스 — services:에 있어도 ⑤ 축은 그걸 못 보므로
+# 여기 남겨야 한다. check_env_drift.py 실행 로그의 "⑤㉠ baseline" 카운트가 이 숫자(3)와
+# 일치해야 정상.
 code_read_high_baseline:
-  - key: AGENT_INBOX_HMAC_SECRET
-    reason: >-
-      apps/web/src/services/inbox-item.service.ts — 기본값 없음, 미triage.
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
-    declared_by: PO
-    until: "2026-09-26"
   - key: APP_BASE_URL
     reason: >-
-      apps/web/src/lib/auth/cookies.ts — 기본값 없음, 미triage(Amplify 레거시 override 후보).
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
+      apps/web/src/lib/auth/cookies.ts:13(isSecureScheme, `?? ''`→false시 쿠키 secure
+      플래그 안 붙음)·apps/web/src/services/app-url.ts — story #3168 실측(2026-08-28):
+      `services: sprintable-frontend-prod`(위 카테고리C)에 이미 라이브 값으로 등재돼
+      있으나(2026-07-22 확認), 그건 별개 축(①② 키집합)이라 이 ⑤(code-read) 축의
+      covered-set엔 안 잡힌다 — cloudbuild.yaml/deploy 스크립트 어디에도 "APP_BASE_URL"
+      리터럴이 없어 정적으로는 미공급으로 보인다(NEXT_PUBLIC_APP_URL은 cloudbuild.yaml
+      ENV_VARS에 실 substitution이 있어 이미 해소됨 — 이름이 비슷해도 별개 키). 실제로는
+      live라 위험 낮음(재확認만 필요) — PO가 다음 gcloud describe 때 한 줄 재확認 후
+      제거.
     declared_by: PO
     until: "2026-09-26"
-  - key: FIREBASE_AUTH_ISSUE_SESSION
+  - key: AGENT_INBOX_HMAC_SECRET
     reason: >-
-      apps/web/src/app/api/auth/firebase/session/route.ts — 기본값 없음, 미triage.
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
-    declared_by: PO
-    until: "2026-09-26"
-  - key: FIREBASE_AUTH_MOBILE_ISSUE
-    reason: >-
-      apps/web/src/app/auth/native/route.ts — 기본값 없음, 미triage.
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
-    declared_by: PO
-    until: "2026-09-26"
-  - key: FIREBASE_OAUTH_HANDOFF_ENABLED
-    reason: >-
-      apps/web/src/app/auth/oauth-handoff/route.ts — 기본값 없음, 미triage(기능 플래그 추정).
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
+      apps/web/src/services/inbox-item.service.ts:95 — 미설정 시 fail-closed(전부 거부).
+      story #3168 실측(2026-08-28): 외부 에이전트 인바운드 표면(설계상 외부 에이전트가
+      POST하는 웹훅) · Cloud Logging 30일 dev/prod 둘 다 POST /api/inbox/incoming 요청
+      0건(무트래픽) · cloudbuild.yaml·infra/cloudbuild-secret-manifest.txt 어디에도 이
+      키 없음(시크릿 미배선). 값을 지어낼 근거가 없음 — 은퇴/로드맵 판정 대기(담당 PO,
+      차기 기한 아래 until·선생님께 다음 통합보고에서 질문 예정, #2423류 "지금 쓰나"는
+      코드로 못 잼).
     declared_by: PO
     until: "2026-09-26"
   - key: MCP_ALLOWED_TOKEN_REFS
     reason: >-
-      apps/web/src/lib/mcp-secrets.ts — 기본값 없음, 미triage.
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
-    declared_by: PO
-    until: "2026-09-26"
-  - key: NEXT_PUBLIC_APP_URL
-    reason: >-
-      apps/web/src/lib/auth/cookies.ts 등 — 기본값 없음, 미triage.
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
-    declared_by: PO
-    until: "2026-09-26"
-  - key: NEXT_PUBLIC_FIREBASE_API_KEY
-    reason: >-
-      apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage. NEXT_PUBLIC_*
-      빌드타임 인라이닝 모호성 있음(AC6 한계 참고).
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
-    declared_by: PO
-    until: "2026-09-26"
-  - key: NEXT_PUBLIC_FIREBASE_APP_ID
-    reason: >-
-      apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(위와 동일 축).
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
-    declared_by: PO
-    until: "2026-09-26"
-  - key: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
-    reason: >-
-      apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(위와 동일 축).
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
-    declared_by: PO
-    until: "2026-09-26"
-  - key: NEXT_PUBLIC_FIREBASE_AUTH_ENABLED
-    reason: >-
-      apps/web/src/lib/auth/firebase-client.ts — 기본값 없음, 미triage(기능 플래그 추정).
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
-    declared_by: PO
-    until: "2026-09-26"
-  - key: NEXT_PUBLIC_FIREBASE_PROJECT_ID
-    reason: >-
-      apps/web/src/lib/auth/firebase-client.ts·lib/db/server.ts — 기본값 없음, 미triage(위와 동일 축).
-      2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는 story #3168로 이관.
+      story #3168에서 발견됐으나 연장이 아니라 이관 — 정식 처방 스토리 #3174
+      ("[보안·EE] MCP_ALLOWED_TOKEN_REFS 미설정=fail-open(무제한 허용) 기본값 재설계 —
+      allowlist가 비면 «전부 허용»이 아니라 «전부 거부»가 안전측", high)가 SSOT다.
+      미설정 시 fail-open(빈 allowlist=무제한 허용, 다른 baseline 항목과 위험 방향
+      반대)이 triage 스코프를 넘는 보안 결함으로 판단됨. 이 entry는 #3174가
+      착지(기본값 fail-closed 전환 등)할 때까지만 유지 — 그 PR이 이 항목을 걷는다.
     declared_by: PO
     until: "2026-09-26"

--- a/infra/mcp-path-contract-allowlist.yml
+++ b/infra/mcp-path-contract-allowlist.yml
@@ -8,12 +8,23 @@
 # ```
 # reason        필수 — 사유(연결된 story 포함)
 # declared_by   필수 — 누가 판단했는지
-# until         필수 — 만료일. 지나면 가드가 FAIL한다(최대 30일, infra/check_serving_reality.py와 동일 상한)
+# until         필수(declared_mismatches·declared_indirect) — 만료일. 지나면 가드가 FAIL한다
+#               (최대 30일, infra/check_serving_reality.py와 동일 상한). declared_permanent_
+#               indirect는 예외 — 아래 그 섹션 설명 참고, until 불요.
 # ```
 #
 # ⭐until이 필수인 이유 — #2271/#2280 자체가 겪은 일이다. 알려진 4건을 여기 영구로 묻어두면
 # 다음에 같은 파일에 새 병이 또 생겨도 "어차피 여기 원래 빨갛잖아"로 안 보이게 된다.
 # 만료되면 가드가 다시 빨개지고, 그때 #2281 진행 상황을 다시 판단한다.
+#
+# ⚠️story #3168(2026-08-28, 페드루 PO 판정) — 위 논리가 declared_indirect의 **모든** 항목에
+# 똑같이 맞는 건 아니었다. 「알려진 버그를 다음에 다시 볼 것」(declared_mismatches류)과
+# 「코드 패턴 자체가 항상 간접(동적 dispatch)이라 영원히 이 모양일 것」은 다른 질문이다 —
+# 후자에 30일 시한을 계속 다는 건 이 파일이 막으려는 "연장 반복" 그 자체를 재생산했다(실제로
+# 이번에 mcp path 2건이 그 함정에 걸려 재확認만 반복하고 있었다). 대신 가드의 `unreadable`
+# 재스캔이 매 실행 자동으로 "이 (module, function) 여전히 M으로 잡히는가"를 검증하므로(코드가
+# 바뀌어 그 호출부가 사라지면 이 항목 자체가 조회 대상에서 빠진다) — 시한이 없어도 기계
+# 재검증은 이미 매번 일어난다. `declared_permanent_indirect`가 이 축이다.
 
 # story #2281(2026-07-28)에서 4건 전부 해소됨 — declared_mismatches가 빈 배열인 것 자체가
 # 그 증거다(가드가 그린으로 남아 있으면 해소된 것, 다시 불일치가 뜨면 회귀).
@@ -32,33 +43,39 @@ declared_mismatches: []
 
 # 간접경로 — 리터럴이 아니라 변수로 경로를 받는 공용 헬퍼. 정적 대조가 원천적으로 못 읽어서
 # "조용히 빠지는" 쪽이라 이름을 반드시 명시하고(M), 수기 추적 결과까지 여기 남긴다.
-declared_indirect:
+# ⛔이 섹션은 이제 "언젠가 값을 채우거나 코드를 고쳐 없앨 시한부 채무"만 담는다 — 구조적으로
+# 항상 간접인 패턴은 declared_permanent_indirect(아래)로 간다. 지금은 비어 있음(story #3168
+# 재분류로 기존 2건 전부 이동).
+declared_indirect: []
+
+# 영구 간접경로 — story #3168(2026-08-28, 페드루 PO 판정). declared_indirect와 선언 형식은
+# 같으나(module/function/reason/declared_by) until이 없다 — 코드 패턴 자체가 동적 dispatch라
+# «앞으로도 계속» 정적 대조가 못 읽을 것이 구조적으로 확定된 것들. 재검증은 가드의
+# `unreadable` 재스캔이 매 실행 기계적으로 담당(호출부가 사라지면 이 항목이 조회조차 안 됨)
+# — 그래서 30일 시한이 재확認 노동 이상의 안전판을 더하지 못한다.
+declared_permanent_indirect:
   - module: attachments
     function: upload_attachments
     reason: >-
-      경로를 인자로 받는 공용 업로드 헬퍼(client.post(upload_path, ...)). 호출부 3곳 수기 추적:
-      docs.py:164(/docs/{id}/attachments) · chat.py:121(/conversations/{id}/attachments) ·
-      stories.py:147(/stories/{id}/attachments) — 서버 라우트 3곳(stories.py:578/docs.py:967/
-      conversations.py:2162) 전부 실재 확認됨(2026-07-28). 2026-08-28 일괄 만료로 파이프라인
-      전면 차단 해소 — 실 triage는 story #3168로 이관.
+      경로를 인자로 받는 공용 업로드 헬퍼(client.post(upload_path, ...)) — 여러 리소스가
+      공유하는 만큼 인자가 항상 변수일 수밖에 없는 구조(literal로 못 박으면 헬퍼의 존재
+      이유가 사라진다). 호출부 3곳 수기 추적(story #3168, 2026-08-28 재검증 — 2026-07-28
+      최초 확認 이후 드리프트 0): docs.py(/docs/{id}/attachments) ·
+      chat.py(/conversations/{id}/attachments) · stories.py(/stories/{id}/attachments) —
+      서버 라우트 3곳(stories.py:1682·docs.py:1094·conversations.py:3092) 전부 실재
+      확認됨.
     declared_by: 까심 아르야
-    until: "2026-09-26"
   - module: chat
     function: _resolve_mention_content
     reason: >-
       경로를 `_MENTION_ENTITY_ENDPOINTS[mention.type].format(id=mention.id)`로 조립하는
-      client.get(endpoint) 호출(story #2283 후속 2026-07-28 doc→doc/story/epic 확장,
-      story #2294 B단계 2026-07-29 task/sprint/artifact/hypothesis 추가, story #2314
-      2026-07-29(3차) evidence 추가 — GET /api/v2/evidence/{id} 신설로 예전 「의도적 제외」
-      근거가 사라져 `_MENTION_ENDPOINT_KNOWN_GAP`도 함께 걷음, PR #2626). 호출부는
-      `mention.type`이 Literal로 검증되므로 실제로 조립되는 경로는 정확히 8가지 — 수기 추적:
-      /api/v2/docs/{id}(docs.py GET /{id}) · /api/v2/stories/{id}(stories.py:539 GET /{id}) ·
-      /api/v2/goals/{id}(goals.py:136 GET /{id}, main.py:296 prefix=/api/v2/goals 마운트) ·
-      /api/v2/tasks/{id}(tasks.py:127 GET /{id}) · /api/v2/sprints/{id}(sprints.py:163
-      GET /{id}) · /api/v2/visual-artifacts/{id}(visual_artifacts.py:214 GET /{id}) ·
-      /api/v2/hypotheses/{id}(hypotheses.py:159 GET /{hypothesis_id}) ·
-      /api/v2/evidence/{id}(evidence.py GET /{id}, story #2314 신설) — 여덟 다 실재
-      확認됨(2026-07-29). 2026-08-28 일괄 만료로 파이프라인 전면 차단 해소 — 실 triage는
-      story #3168로 이관.
+      client.get(endpoint) 호출 — `mention.type`이 Literal로 검증되는 유한 집합이라도, 조립
+      자체가 딕셔너리 룩업+.format()이라 정적 대조는 원천적으로 못 읽는 구조(리터럴로
+      못 박으면 신규 mention 타입 추가 때마다 이 함수를 고쳐야 하는 게 오히려 설계 후퇴).
+      실제로 조립되는 경로는 정확히 8가지 — 수기 추적(story #3168, 2026-08-28 재검증 —
+      2026-07-29 최초 확認 이후 매핑·서버라우트 드리프트 0): doc→/api/v2/docs/{id} ·
+      story→/api/v2/stories/{id} · epic→/api/v2/goals/{id} · task→/api/v2/tasks/{id} ·
+      sprint→/api/v2/sprints/{id} · artifact→/api/v2/visual-artifacts/{id} ·
+      hypothesis→/api/v2/hypotheses/{id} · evidence→/api/v2/evidence/{id} — 여덟 다
+      GET /{id} 라우트 실재 확認됨.
     declared_by: 디디 은와추쿠
-    until: "2026-09-26"

--- a/infra/mcp_path_contract_guard.py
+++ b/infra/mcp_path_contract_guard.py
@@ -5,8 +5,12 @@
 소스에서 직독해 대조한다. #2271 AC3·AC4의 산출물.
 
 ⭐이 파일은 `infra/check_serving_reality.py`(story #2174)와 같은 자리에 있다 — 같은 이유:
-"정상"과 "알고 있다"를 분리하고(허용목록), 허용목록은 스스로 만료된다(`until` 필수+상한).
-자세한 배경은 `infra/mcp-path-contract-allowlist.yml` 머리말 참조.
+"정상"과 "알고 있다"를 분리하고(허용목록), 대부분의 허용목록은 스스로 만료된다(`until`
+필수+상한). ⚠️story #3168(2026-08-28) 후속 — 구조적으로 영구한 간접경로(코드 패턴 자체가
+항상 M으로 잡히는 것, 호출부가 사라지면 이 실행에서 그 항목 자체가 다시 안 잡히므로
+«기계 재검증»이 매 실행 이미 일어난다)는 예외: `declared_permanent_indirect`는 until을
+요구하지 않는다(reason/declared_by는 여전히 필수). 자세한 배경은
+`infra/mcp-path-contract-allowlist.yml` 머리말 참조.
 
 ⚠️오늘(2026-07-28) 이 축 자체에서 겪은 실패: 최초 수기 audit가 develop보다 뒤처진 로컬
 체크아웃으로 실행돼, 2026-07-15에 이미 fix된 retro.py 7건+list_backlog 1건(총 8건)을
@@ -43,12 +47,15 @@ def norm(path: str) -> str:
     return re.sub(r"\{[^}]+\}", "{*}", path)
 
 
-def _load_allowlist() -> tuple[dict[tuple[str, str, str], dict], dict[tuple[str, str], dict]]:
-    """반환: ({(module, method, norm_path): entry} 경로 불일치 선언, {(module, function): entry} 간접경로 선언).
+def _load_allowlist() -> tuple[
+    dict[tuple[str, str, str], dict], dict[tuple[str, str], dict], dict[tuple[str, str], dict]
+]:
+    """반환: ({(module, method, norm_path): entry} 경로 불일치 선언, {(module, function): entry}
+    시한부 간접경로 선언, {(module, function): entry} 영구 간접경로 선언).
 
     파일이 없으면 빈 선언으로 취급한다 — ⛔"선언 파일이 없으니 검사 생략"은 하지 않는다."""
     if not _ALLOWLIST_PATH.exists():
-        return {}, {}
+        return {}, {}, {}
     import yaml
 
     data = yaml.safe_load(_ALLOWLIST_PATH.read_text()) or {}
@@ -60,7 +67,26 @@ def _load_allowlist() -> tuple[dict[tuple[str, str, str], dict], dict[tuple[str,
     for e in data.get("declared_indirect") or []:
         key = (e["module"], e["function"])
         indirect[key] = e
-    return mismatches, indirect
+    permanent_indirect = {}
+    for e in data.get("declared_permanent_indirect") or []:
+        key = (e["module"], e["function"])
+        permanent_indirect[key] = e
+    return mismatches, indirect, permanent_indirect
+
+
+def _permanent_entry_problem(entry: dict) -> str | None:
+    """story #3168(2026-08-28, 페드루 PO 판정) — declared_permanent_indirect 전용 검사.
+    구조적으로 영구한 간접경로(동적 dispatch가 코드 패턴 자체에 내재)는 `until`을 요구하지
+    않는다 — 이 진입점이 여전히 실재하는지는 매 실행마다 `unreadable` 재스캔이 기계적으로
+    검증하므로(코드가 바뀌어 그 호출부가 사라지면 이 declared 항목 자체가 조회 대상에서
+    빠진다), `until` 시한은 «주기 재검증»에 아무 것도 더하지 못하고 순수 재확認 노동만
+    반복시킨다(declared_indirect의 두 기존 항목이 실제로 겪은 패턴). reason/declared_by는
+    여전히 필수 — «왜 영구히 간접인지»는 사람이 남겨야 한다."""
+    if not entry.get("reason"):
+        return "`reason`(사유)이 없다"
+    if not entry.get("declared_by"):
+        return "`declared_by`(선언자)가 없다"
+    return None
 
 
 def _expired(entry: dict, today: date) -> str | None:
@@ -222,7 +248,7 @@ def main() -> int:
     print(f"양성대조 OK: {POSITIVE_CONTROL} 확認됨 — 대조법 정상\n")
 
     mcp_calls, unreadable = load_mcp_declared()
-    declared_mismatches, declared_indirect = _load_allowlist()
+    declared_mismatches, declared_indirect, declared_permanent_indirect = _load_allowlist()
 
     mismatches = []
     for module, method, path in mcp_calls:
@@ -253,7 +279,21 @@ def main() -> int:
     if unreadable:
         print(f"\nM({len(unreadable)}개) — 이름 명시:")
         for module, func, raw in unreadable:
-            entry = declared_indirect.get((module, func))
+            key = (module, func)
+            # story #3168(2026-08-28, 페드루 PO 판정) — 영구선언 축을 먼저 본다. 구조적으로
+            # 항상 간접인 dispatch 패턴(호출부가 사라지면 애초에 이 unreadable 자체가 이번
+            # 실행에서 다시 안 잡힌다 — 그게 "기계 재검증"의 정체)엔 until을 요구하지 않는다.
+            permanent_entry = declared_permanent_indirect.get(key)
+            if permanent_entry is not None:
+                problem = _permanent_entry_problem(permanent_entry)
+                if problem:
+                    print(f"  🔴 {module}.py:{func}() — {raw} — 영구선언은 돼 있으나 {problem}")
+                    new_indirect.append((module, func, raw))
+                else:
+                    print(f"  ⚪ {module}.py:{func}() — {raw} — 영구선언(permanent, {permanent_entry['reason']})")
+                continue
+
+            entry = declared_indirect.get(key)
             if entry is None:
                 print(f"  🔴 {module}.py:{func}() — {raw} — 허용목록에 없는 신규")
                 new_indirect.append((module, func, raw))
@@ -268,7 +308,9 @@ def main() -> int:
     if new_mismatches or new_indirect:
         print(f"\n🔴 신규(또는 만료된) 항목 {len(new_mismatches) + len(new_indirect)}건 — "
               f"실제 버그면 고치고, 알고 있는 상태로 계속 두려면 "
-              f"infra/mcp-path-contract-allowlist.yml에 reason/declared_by/until과 함께 등재할 것.")
+              f"infra/mcp-path-contract-allowlist.yml의 declared_mismatches/declared_indirect에 "
+              f"reason/declared_by/until과 함께 등재하거나(시한부), 구조적으로 영구 간접이면 "
+              f"declared_permanent_indirect에 reason/declared_by만으로(until 불요, story #3168) 등재할 것.")
         ok = False
 
     print(


### PR DESCRIPTION
## Summary
[SID:3168]

`infra/manual-env-allowlist.yml`의 `code_read_high_baseline`(12건)과
`infra/mcp-path-contract-allowlist.yml`의 `declared_indirect`(2건) — 2026-07-28
"당장 막으면 가드가 꺼지니 일단 알고 있다"로 declare된 채무가 30일 시한(until)
그대로 만료돼 오늘(2026-08-28) 파이프라인 전면 차단을 일으켰다(선행 긴급 PR #3572로
즉시 해소). 이 PR이 그 "변제 기한 내 실 triage" 본체.

## 처방
- **code_read_exempt 승격(7건)**: `NEXT_PUBLIC_FIREBASE_API_KEY/APP_ID/AUTH_DOMAIN/AUTH_ENABLED/PROJECT_ID`
  (firebase-client.ts의 명시적 null-safe 스캐폴드 + `apps/web/Dockerfile`·`cloudbuild.yaml`
  `build-frontend` 스텝의 `--build-arg` 목록에 부재 — Next.js가 `NEXT_PUBLIC_*`을 빌드타임에
  인라이닝하므로 런타임 값 존부와 무관하게 구조적으로 영구 미도달임을 코드로 이중 확認),
  `FIREBASE_AUTH_ISSUE_SESSION`/`FIREBASE_AUTH_MOBILE_ISSUE`(FIREBASE_OAUTH_HANDOFF_ENABLED와
  동형 안전-닫힘 토글 + Cloud Logging 30일 실측 무트래픽/극소트래픽).
- **baseline 중복 제거(2건)**: `FIREBASE_OAUTH_HANDOFF_ENABLED`·`NEXT_PUBLIC_APP_URL` —
  이미 `cloudbuild.yaml` 실 substitution으로 IaC-covered(각각 2026-08-26/2026-08-18
  선행 스토리로 해소됨)라 baseline에 남아있던 게 중복 등재였다.
- **baseline 잔존(3건, 로드맵/보안 판단 대기)**: `AGENT_INBOX_HMAC_SECRET`(외부 에이전트
  인바운드 웹훅, 시크릿 미배선+30일 무트래픽 — 은퇴/로드맵 판정은 PO/선생님 몫),
  `APP_BASE_URL`(services: 카테고리C엔 라이브로 등재돼 있으나 그 축은 code-read 축과
  무관해 재확認만 남음), `MCP_ALLOWED_TOKEN_REFS`(fail-open 기본값 보안결함 — 별도
  스토리 #3174로 이관, baseline reason이 그 스토리를 SSOT로 참조).
- **mcp path 가드 계약 개선**: 구조적으로 영구한 간접경로(`attachments.upload_attachments`·
  `chat._resolve_mention_content`, 둘 다 재검증 완전 일치·드리프트 0)에 30일 시한을
  계속 다는 게 "연장 반복 금지"가 막으려는 패턴 그 자체라 판단 — `declared_permanent_indirect`
  카테고리 신설(reason/declared_by 필수·until 불요, 재검증은 가드의 `unreadable` 재스캔이
  매 실행 기계적으로 담당). **가드 스펙 변경 — 페드루 PO 판정 승인**.

## 진행 중 자기정정 (투명 공개)
①⑤(FIREBASE_AUTH_ISSUE_SESSION/MOBILE_ISSUE)를 처음엔 `services:`(카테고리C, ①②
키집합 축)로 이관했으나, 회귀테스트(`test_check_env_drift_code_read_axis.py` AC2/AC4)가
그 축의 covered-set 계산(`_iac_covered_keys_for_service | live_keys_for_web`)이
`manual-env-allowlist.yml`의 `services:` 목록을 전혀 참조하지 않는다는 걸 즉시 잡아줘서
`code_read_exempt`로 정정했다.
②`APP_BASE_URL`을 처음엔 `NEXT_PUBLIC_APP_URL`과 묶어 "이미 live라 중복"으로 판단해
제거했으나, 둘은 별개 키이고 `cloudbuild.yaml`엔 `NEXT_PUBLIC_APP_URL` substitution만
있고 `APP_BASE_URL` 리터럴은 없어 — baseline에 다시 넣었다.

## Evidence
- 부문별 실측: 코드 소비처 실물(파일:라인) + `apps/web/Dockerfile`/`cloudbuild.yaml`
  build-arg 목록 대조 + `infra/cloudbuild-secret-manifest.txt` 대조 + Cloud Logging
  30일 요청 실측(`/api/inbox/incoming`·`/api/auth/firebase/session`·`/auth/native`·
  `/auth/oauth-handoff`, dev+prod).
- `mcp_path_contract_guard.py` 직접구동 green + mutation 검증(permanent entry에서
  `reason` 제거 → FAIL 확認 → 복원 → green).
- 관련 pytest 4개 파일(`test_check_env_drift_code_read_axis.py`·`test_check_env_drift_env_split.py`·
  `test_check_env_drift_null_env_guard.py`·`test_mcp_path_contract_guard.py`) 전량 green
  (신규 permanent_indirect 테스트 5건 포함, 기존 pinned-count 테스트 2건은 새 실제값+델타
  코멘트 체인으로 갱신) + 인접 `test_deploy_realtime_gce_env.py`·
  `test_deploy_backend_redis_secret_conflict.py` 회귀 확認.



## Delta (d594a783e) — APP_BASE_URL ⓐ값 채움 격상 (페드루 PO 지시)
페드루 PO가 라이브 env 이름을 재실측 — dev="NEXT_PUBLIC_APP_URL만 유"·prod="APP_BASE_URL만
유"로 환경마다 정반대 절반만 우연히 채워진 형제 비대칭 발견(prod의 APP_BASE_URL은 수동
주입값이라 다음 전체 배포가 조용히 지울 수 있는 시한 위험). `cloudbuild.yaml`
`deploy-frontend` `--update-env-vars`에 두 키 다 기존 `_NEXT_PUBLIC_APP_URL`
substitution(이미 dev="https://dev-app.sprintable.ai"·prod="https://app.sprintable.ai"로
정확 분기)으로 명시 배선 — 새 substitution 발명 0. `code_read_high_baseline`에서
APP_BASE_URL 제거(now IaC-covered, 3→2)·`services:` 카테고리C의 중복 등재도 제거.
재검증: 관련 pytest 전량(high 4→3·baseline 3→2) + cloudbuild.yaml 인접 테스트
10개 파일(104건) 회귀 확認.

## Test plan
- [ ] CI: 위 관련 pytest 전량 + 전체 gate green
- [ ] 카디르 QA
- [ ] 남은 3건(⑥⑦) 판정은 PO/선생님 후속(⑦은 story #3174가 SSOT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
