### PR TITLE
fix(#3175): usage_meters ORM↔실DB nullability 드리프트 정렬

### DIFF
--- a/backend/app/models/usage_meter.py
+++ b/backend/app/models/usage_meter.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Integer, Text
+from sqlalchemy import DateTime, Integer, Text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -46,4 +46,17 @@ class UsageMeter(Base):
     current_value: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     limit_value: Mapped[int | None] = mapped_column(Integer, nullable=True)
     period_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    period_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # story #3175 — 실DB(baseline schema.sql)는 NOT NULL·디폴트 없음이 원본(S48 도입
+    # 커밋부터, 마이그레이션으로 바뀐 적 0건). "미터는 기간이 필수"가 의미상 맞고, 이
+    # 컬럼을 실제로 쓰는 write 경로가 지금 0건이라 정본을 DB→ORM 방향으로 정렬한다
+    # (ORM이 nullable=True로 지어낸 행은 DB가 거부하는데 그 실패가 커밋 시점까지 잠복).
+    period_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # story #3175 — 같은 테이블 형제 컬럼 일괄 대조에서 발견: ORM에 아예 없었다(baseline엔
+    # 둘 다 DEFAULT now() NOT NULL로 실재). 읽기 코드가 없어 지금까지 조용했을 뿐 — 다른
+    # 모델들과 동일 스타일(server_default=func.now(), a2a_task.py 등 참고)로 채운다.
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/schemas/usage.py
+++ b/backend/app/schemas/usage.py
@@ -11,4 +11,6 @@ class UsageMeterOut(BaseModel):
     current_value: int
     limit_value: int | None = None
     period_start: datetime
-    period_end: datetime | None = None
+    # story #3175 — DB가 NOT NULL(디폴트 없음)로 정본 확定, ORM도 정렬 완료. 실제로 None인
+    # 행은 존재할 수 없다(CHECK가 아니라 컬럼 자체 제약).
+    period_end: datetime

--- a/backend/tests/test_3175_usage_meter_nullability_parity_realdb.py
+++ b/backend/tests/test_3175_usage_meter_nullability_parity_realdb.py
@@ -1,0 +1,75 @@
+"""story #3175(위생·BE) — usage_meters ORM↔실DB nullability 정합 회귀.
+
+발견(PR#3575 qa:changes 수리 중, 2026-08-28): `app/models/usage_meter.py`의 `period_end`가
+ORM에선 nullable=True인데 baseline 실DB는 NOT NULL(디폴트 없음, S48 도입 커밋부터 — 마이그
+0건). ORM이 "DB가 거부할 행"을 합법으로 지어낼 수 있었다(커밋 시점까지 잠복하는
+NotNullViolation). 정본 판별: DB가 정본(미터는 기간 필수, 실제 write 경로 0건이라 데이터
+호환성 리스크 없음) — ORM을 nullable=False로 정렬. 같은 대조에서 created_at/updated_at이
+ORM에 아예 없던 것도 발견(baseline엔 둘 다 DEFAULT now() NOT NULL로 실재) — 같이 채움.
+
+이 테스트는 `information_schema.columns`를 실PG에서 직접 읽어 ORM 모델의 모든 컬럼과
+nullable 여부를 1:1 대조한다 — 재발(제3의 컬럼이 또 갈리거나, period_end가 다시 갈라지는
+경우) 시 컬럼 이름째 정확히 찍혀 빨강이 뜨도록."""
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.models.usage_meter import UsageMeter
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_usage_meters_orm_nullability_matches_live_db():
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            rows = (
+                await session.execute(
+                    text(
+                        "SELECT column_name, is_nullable FROM information_schema.columns "
+                        "WHERE table_schema='public' AND table_name='usage_meters'"
+                    )
+                )
+            ).all()
+            assert rows, "usage_meters 테이블이 실DB에 없음 — 대조 자체가 성립 안 됨"
+            live_nullable = {r[0]: (r[1] == "YES") for r in rows}
+
+            orm_columns = set(UsageMeter.__table__.columns.keys())
+            live_columns = set(live_nullable.keys())
+
+            # 형제 컬럼 일괄 대조 — ORM에 없는 실DB 컬럼(과거 created_at/updated_at처럼
+            # 조용히 누락되는 클래스)이 있으면 정확히 그 이름으로 실패.
+            missing_from_orm = live_columns - orm_columns
+            assert not missing_from_orm, (
+                f"ORM에 없는 실DB 컬럼: {missing_from_orm} — usage_meter.py에 매핑 추가 필요"
+            )
+
+            mismatches = []
+            for col in UsageMeter.__table__.columns:
+                if col.name not in live_nullable:
+                    continue  # 위 missing_from_orm과 반대 방향(ORM만 있음)은 별도 정책 이슈, 이 테스트 범위 밖
+                orm_nullable = col.nullable
+                db_nullable = live_nullable[col.name]
+                if orm_nullable != db_nullable:
+                    mismatches.append(
+                        f"{col.name}: ORM nullable={orm_nullable} vs DB nullable={db_nullable}"
+                    )
+            assert not mismatches, "nullability 드리프트: " + "; ".join(mismatches)
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_usage.py
+++ b/backend/tests/test_usage.py
@@ -51,7 +51,9 @@ async def test_get_usage_200():
         row.current_value = 3
         row.limit_value = 10
         row.period_start = datetime(2026, 4, 1, tzinfo=timezone.utc)
-        row.period_end = None
+        # story #3175 — period_end는 DB NOT NULL이 정본(ORM도 정렬 완료), None 픽스처는
+        # 이제 실제로 못 나오는 상태를 흉내내는 것이라 실제 기간말 값으로 교체.
+        row.period_end = datetime(2026, 4, 30, 23, 59, 59, tzinfo=timezone.utc)
         mock_result = MagicMock()
         mock_result.all.return_value = [row]
         session.execute = AsyncMock(return_value=mock_result)


### PR DESCRIPTION
## Summary
[SID:3175]

`app/models/usage_meter.py`의 `period_end`가 ORM에선 `nullable=True`인데 baseline
실DB는 `NOT NULL`(디폴트 없음, S48 도입 커밋(7cf0e16ae, 2026-04-30)부터 — 마이그레이션
으로 바뀐 적 0건). PR #3575 qa:changes 수리 중 발견됐다(period_end 누락 INSERT가
CHECK가 아니라 NotNullViolation으로 먼저 터짐 — 스코프 밖이라 그때는 보고만, story
#3175로 별도 등재됨).

## 정본 판별
DB가 정본 — "미터는 기간이 필수"가 의미상 맞고, `usage_meters`에 실제로 쓰는 write
경로가 지금 0건(조회 전용, `app/routers/usage.py`)이라 정렬에 데이터 호환성 리스크가
없다. ORM을 `nullable=False`로 정렬.

## 형제 컬럼 일괄 대조 (AC②) — 추가 발견
`created_at`/`updated_at`이 ORM에 아예 없었다(baseline엔 둘 다 `DEFAULT now() NOT NULL`로
실재). 읽기 코드가 없어 지금까지 조용했을 뿐 — 다른 모델과 동일 스타일
(`server_default=func.now()`, `a2a_task.py` 등 선례)로 채움.

## 부수 변경
- `schemas/usage.py`의 `UsageMeterOut.period_end`: `datetime | None` → `datetime`
  (DB가 보장하니 실제로 None인 행은 없음).
- `test_usage.py`의 `period_end=None` 목 픽스처 → 실제 datetime(더는 못 나오는 상태를
  흉내내고 있었음).

## Evidence — 실PG 뮤테이션 이중검증
`test_3175_usage_meter_nullability_parity_realdb.py`(신규) — `information_schema.columns`를
실PG에서 읽어 ORM 전 컬럼의 nullable을 1:1 대조 + ORM에 없는 실DB 컬럼(형제 드리프트
재발 클래스)도 감지.
- **뮤테이션 ①**: `period_end`를 `nullable=True`로 되돌려 정확히 그 컬럼명으로 RED
  확認 → 복원.
- **뮤테이션 ②**: `created_at`을 ORM에서 제거해 "누락 컬럼" 분기도 별도로 RED 확認
  → 복원.
- 둘 다 로컬 postgres@16 scratch DB에서 baseline DDL 원문 그대로(sed 추출, 재입력 아님)
  재구축해 검증.
- 기존 realdb 3건(#2473 CHECK 확장)·mock 2건(#2473 상수) + `test_usage.py` 2건과 같은
  스키마 위에서 8/8 green 확認.

## Test plan
- [ ] CI: 위 관련 pytest 전량 green
- [ ] 카디르 QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)