### PR TITLE
[SID:2074] 결재카드 배치 소비 첫 마운트 레이스 수리 — AC4 라이브 재측 적발

### DIFF
--- a/apps/web/src/components/chat/approval-request-card.test.tsx
+++ b/apps/web/src/components/chat/approval-request-card.test.tsx
@@ -663,12 +663,19 @@ describe('ApprovalRequestCard — story #3151 agent_decision 결정 재료(질�
 });
 
 // story #5ace2e84 — 채팅 결재카드 N+1 처방. chat-view.tsx가 대화 단위로 배치조회한 gate를
-// initialGate prop으로 물려받으면 이 카드는 독립 GET /api/gates/{id}를 안 태워야 한다(PO
+// gateByKey 맵으로 물려받으면 이 카드는 독립 GET /api/gates/{id}를 안 태워야 한다(PO
 // 실측: 대화 진입당 최대 51발 N+1의 직접 원인). use-gate-batch.ts는 별도 단위테스트로
-// 순수함수(collectUnrequestedGateIds)를 커버하므로, 여기서는 소비부(카드)가 initialGate를
+// 순수함수(collectUnrequestedGateIds)를 커버하므로, 여기서는 소비부(카드)가 gateByKey를
 // 실제로 존중하는지만 값으로 단언한다.
-describe('ApprovalRequestCard — initialGate(story #5ace2e84 배치조회 소비)', () => {
-  it('initialGate={kind:ready}면 독립 fetchGate()를 안 태우고 그 값으로 바로 렌더된다', async () => {
+//
+// ⚠️2026-08-28 라이브 재측(AC4)에서 구판(단건 initialGate lookup)의 첫 마운트 레이스를
+// 실측으로 적발했다 — 자식(카드) effect가 부모(useGateBatchFetch) effect보다 먼저 돌아,
+// 맵이 아직 `{}`인 첫 렌더에 모든 카드가 "커버 안 됨"으로 오판해 개별 fetchGate()를 전원
+// 발사했다(대화당 여전히 ~50발, 배치 자체는 정확히 1콜로 묶였는데도). 아래 두 번째 테스트
+// (`gateByKey={{}}`)가 바로 그 레이스의 회귀가드 — 맵 객체가 정의돼 있으면(빈 값이라도)
+// 항목이 아직 없어도 기다려야 한다.
+describe('ApprovalRequestCard — gateByKey 배치조회 소비(story #5ace2e84)', () => {
+  it('gateByKey에 이 gate_id가 {kind:ready}로 있으면 독립 fetchGate()를 안 태우고 그 값으로 바로 렌더된다', async () => {
     const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
     vi.stubGlobal('fetch', fetchMock);
     const gateData = gate({ work_item_summary: { title: '배치조회 대조', slug: null } });
@@ -677,7 +684,7 @@ describe('ApprovalRequestCard — initialGate(story #5ace2e84 배치조회 소�
         <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
           <ApprovalRequestCard
             target={{ work_item_type: gateData.work_item_type, work_item_id: gateData.work_item_id, gate_id: gateData.id, actions: ['approve', 'reject'] }}
-            initialGate={{ kind: 'ready', gate: gateData }}
+            gateByKey={{ [gateData.id]: { kind: 'ready', gate: gateData } }}
           />
         </NextIntlClientProvider>,
       );
@@ -687,7 +694,7 @@ describe('ApprovalRequestCard — initialGate(story #5ace2e84 배치조회 소�
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('initialGate={kind:loading}이면(배치 진행 중) 완료를 기다리고 독립 fetchGate()도 안 태운다', async () => {
+  it('«첫 마운트 레이스» 회귀가드 — gateByKey={{}}(맵은 있으나 이 gate_id 항목이 아직 없음)여도 독립 fetchGate()를 안 태운다', async () => {
     const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
     vi.stubGlobal('fetch', fetchMock);
     await act(async () => {
@@ -695,7 +702,7 @@ describe('ApprovalRequestCard — initialGate(story #5ace2e84 배치조회 소�
         <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
           <ApprovalRequestCard
             target={{ work_item_type: 'story', work_item_id: 'w-1', gate_id: 'g-1', actions: ['approve', 'reject'] }}
-            initialGate={{ kind: 'loading' }}
+            gateByKey={{}}
           />
         </NextIntlClientProvider>,
       );
@@ -704,7 +711,24 @@ describe('ApprovalRequestCard — initialGate(story #5ace2e84 배치조회 소�
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('initialGate 미지정(배치 커버 밖)이면 기존처럼 개별 fetchGate()로 폴백한다(회귀 0)', async () => {
+  it('gateByKey에 이 gate_id가 {kind:loading}으로 있으면(배치 진행 중) 완료를 기다리고 독립 fetchGate()도 안 태운다', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
+    vi.stubGlobal('fetch', fetchMock);
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <ApprovalRequestCard
+            target={{ work_item_type: 'story', work_item_id: 'w-1', gate_id: 'g-1', actions: ['approve', 'reject'] }}
+            gateByKey={{ 'g-1': { kind: 'loading' } }}
+          />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('gateByKey 자체가 미지정(배치 컨텍스트 없음 — approvals-queue.tsx 등)이면 기존처럼 개별 fetchGate()로 폴백한다(회귀 0)', async () => {
     const gateData = gate({ work_item_summary: { title: '개별폴백 대조', slug: null } });
     await mount(gateData);
     expect(container.textContent).toContain('개별폴백 대조');

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -49,13 +49,17 @@ interface ApprovalRequestCardProps {
    * resolved(회신) 분기가 이 카탈로그의 preset.gate.verdict 항목을 찾아 정적 표현부(text·
    * fields)만 소비한다 — pending(요청·서명·버튼) 분기는 그대로다. */
   eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
-  /** story #5ace2e84 — chat-view.tsx가 대화 단위로 배치조회한 이 gate_id의 결과(use-gate-batch.ts,
-   * eventDefinitionsByKey와 동일 물려받기 패턴). 있으면(loading 포함) 이 카드는 독립
-   * fetchGate()를 안 태운다 — PO 실측 N+1(대화당 최대 51발)의 직접 처방. undefined면(배치
-   * 커버 밖 — 예: approvals-queue.tsx처럼 채팅 밖에서 쓰이거나, SSE로 대화 도중 새로 도착한
-   * 카드라 배치 effect가 아직 못 훑음) 기존처럼 마운트 시 개별 fetchGate()로 자연 폴백
+  /** story #5ace2e84(2026-08-28 라이브 재측 후속) — chat-view.tsx가 대화 단위로 배치조회한
+   * gate_id→상태 맵 «전체»(use-gate-batch.ts). ⚠️단건 lookup만 넘기던 구판은 첫 마운트
+   * 레이스가 있었다 — React는 같은 커밋에서 자식(이 카드) effect를 부모(useGateBatchFetch)
+   * effect보다 먼저 돌리므로, 그 시점 맵이 아직 `{}`라 모든 카드가 "커버 안 됨"으로 오판해
+   * 배치가 뜨기도 전에 개별 fetchGate()를 전원 발사했다(라이브 실측: 대화당 여전히 ~50발 —
+   * 배치 자체는 33개를 1콜로 정확히 묶었지만 개별 콜을 막지 못함). 처방: **맵 객체 자체**
+   * (이 gate_id 항목이 아직 없어도, 빈 `{}`라도)를 "이 화면은 배치가 관장한다"는 신호로
+   * 쓴다 — 정의돼 있으면 항목이 없어도 기다리고, undefined(배치 컨텍스트 자체가 없음 —
+   * approvals-queue.tsx처럼 채팅 밖에서 쓰이는 경우)일 때만 개별 fetchGate()로 폴백
    * (회귀 0). */
-  initialGate?: CardState;
+  gateByKey?: Record<string, CardState>;
 }
 
 /** story #5ace2e84 — use-gate-batch.ts(chat-view.tsx 대화 단위 배치조회)와 정확히 같은 shape을
@@ -110,7 +114,7 @@ const RESOLVED_STATUS_LABEL_KEYS: Record<string, string> = {
  * (`GateSignatureApproval`)와 형제로 렌더돼 모달 열람/닫기가 그 로컬 state(근거확인·사유)를
  * 건드리지 않는다(AC③, 언마운트 없음).
  */
-export function ApprovalRequestCard({ target, eventDefinitionsByKey, initialGate }: ApprovalRequestCardProps) {
+export function ApprovalRequestCard({ target, eventDefinitionsByKey, gateByKey }: ApprovalRequestCardProps) {
   const t = useTranslations('chats');
   // story #2926(P0-F 잔여 fast-follow, 카디르 F2 QA LOW①) — 아래 stateLabel 유도가
   // deriveGateProofState()의 통일 키(gateStatus*)를 쓴다 — 그 키들은 'cage' 네임스페이스.
@@ -143,15 +147,17 @@ export function ApprovalRequestCard({ target, eventDefinitionsByKey, initialGate
     }
   }, [target.gate_id]);
 
-  // story #5ace2e84 — initialGate가 있으면(대화 단위 배치조회가 이 gate_id를 이미 커버) 이
-  // 카드는 독립 fetchGate()를 안 태운다: 배치가 아직 진행 중(loading)이면 그 완료를 기다리고,
-  // 이미 resolved(ready/not-found/error)면 그 값을 바로 반영한다. initialGate가 undefined인
-  // 경우만(배치 커버 밖 — approvals-queue.tsx 등 채팅 밖 사용, 또는 SSE로 대화 도중 새로
-  // 도착해 배치 effect가 아직 못 훑은 카드) 기존 개별 fetchGate()로 자연 폴백한다(회귀 0).
+  // story #5ace2e84(2026-08-28 라이브 재측 후속) — gateByKey «맵 객체 자체»가 정의돼 있으면
+  // (빈 `{}`라도) 이 화면은 배치가 관장한다는 뜻 — 이 gate_id 항목이 아직 안 채워졌어도
+  // 독립 fetchGate()를 안 태우고 기다린다(첫 마운트 레이스 처방, 위 prop 문서 참고).
+  // gateByKey 자체가 undefined일 때만(배치 컨텍스트 자체가 없음 — approvals-queue.tsx 등)
+  // 기존 개별 fetchGate()로 자연 폴백한다(회귀 0).
+  const initialGate = gateByKey?.[target.gate_id];
   useEffect(() => {
     if (initialGate) { setState(initialGate); return; }
+    if (gateByKey !== undefined) return; // 배치가 관장 중 — 항목 도착까지 대기.
     void fetchGate();
-  }, [fetchGate, initialGate]);
+  }, [fetchGate, initialGate, gateByKey]);
 
   // story #2985 AC2(PO 계약 확定 2026-08-24) — 다른 승인자가 이 게이트를 먼저 해소하면,
   // 이 카드를 보고 있는 화면도 새로고침 없이 "처리됨"으로 갱신된다. BE가

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -76,9 +76,11 @@ interface ChatBubbleProps {
    * 동일 패턴). 생략하면(undefined) 이벤트 메시지도 BE 제네릭 폴백 텍스트로 안전하게 그려진다. */
   eventDefinitionsByKey?: Record<string, EventDefinitionSummary> | null;
   /** story #5ace2e84 — chat-view.tsx가 대화 단위로 배치조회한 gate_id→상태 캐시(entityStatusByKey와
-   * 동일 물려받기 패턴, use-gate-batch.ts). ApprovalRequestCard의 initialGate로 그대로
-   * 넘어가 독립 fetchGate() N+1을 없앤다. 생략하면(undefined) 카드가 기존처럼 개별 fetch로
-   * 안전 폴백(회귀 0). */
+   * 동일 물려받기 패턴, use-gate-batch.ts). ApprovalRequestCard에 맵 «전체»를 그대로 넘긴다
+   * (단건 lookup을 여기서 미리 뽑지 않는다 — 그러면 "항목 없음"과 "맵 자체가 없음"이
+   * undefined 하나로 뭉개져 첫 마운트 레이스가 재발한다, approval-request-card.tsx의
+   * gateByKey prop 문서 참고). 생략하면(undefined) 카드가 기존처럼 개별 fetch로 안전 폴백
+   * (회귀 0). */
   gateByKey?: Record<string, CardState>;
   /** story #2766(레인 A) — ChatView가 물려주면 doc 임베드 미리보기·비-이미지 첨부 클릭이
    * 중앙 모달/새 탭 대신 우측 ReadingPanel을 연다. 생략하면(undefined, ThreadPanel 등 아직
@@ -590,7 +592,7 @@ export function ChatBubble({
             <ApprovalRequestCard
               target={approvalTarget}
               eventDefinitionsByKey={eventDefinitionsByKey}
-              initialGate={gateByKey?.[approvalTarget.gate_id]}
+              gateByKey={gateByKey}
             />
           ) : eventTarget && eventBlockTemplate ? (
             <EventBlockCard


### PR DESCRIPTION
## 배경
PO 지시로 [SID:2074] AC4 웜 재실측 진행 중, dev(리비전 02761, PR#3571 탑재) 실제 `/chats/f374b5c8` 대화(gate 33개)를 Puppeteer로 로그인 재현 + `performance.getEntriesByType('resource')`로 직접 재본 결과:

- 배치 콜(`GET /api/gates?ids=...`, 33개) 자체는 **정확히 1콜**로 묶임 — 배치 메커니즘 자체는 정상.
- 그런데 그와 별개로 **개별 `GET /api/gates/{id}`가 여전히 ~50발(중복 포함) 나감** — 처방이 절반만 먹힌 채 이미 develop에 merge돼 있었다.

## 근본원인
`ApprovalRequestCard`가 받던 `initialGate`는 `chat-view.tsx`의 `gateByKey` 맵에서 **단건 lookup한 결과**였다. React는 같은 커밋에서 자식(카드) effect를 부모(`useGateBatchFetch`) effect보다 먼저 돌리므로, 최초 마운트 시점엔 맵이 아직 `{}`라 모든 카드의 `initialGate`가 `undefined`로 평가됐다 — **"배치가 아직 이 항목을 못 채웠다"와 "배치 컨텍스트 자체가 없다(approvals-queue.tsx 등)"가 `undefined` 하나로 뭉개져**, 배치가 뜨기도 전에 카드 전원이 개별 `fetchGate()`를 발사했다. 정확히 대화 첫 진입(=원 증상이 재현되는 그 순간)에만 걸리는 레이스라 vitest 단위테스트(effect 순서를 사람이 흉내내는 구조)로는 못 잡고 라이브 실측에서만 드러났다.

## 처방
단건 lookup 대신 **맵 객체 자체**를 `ApprovalRequestCard`에 그대로 넘긴다(`gateByKey?: Record<string, CardState>`). 맵이 정의돼 있으면(항목이 아직 없어도, 빈 `{}`라도) "배치가 관장 중"으로 판단해 기다리고, 맵 자체가 `undefined`일 때만(배치 컨텍스트 없음) 기존 개별 `fetchGate()`로 폴백한다. `chat-bubble.tsx`는 단건 lookup을 미리 뽑지 않고 맵을 그대로 전달만 하도록 수정.

## 회귀가드
`gateByKey={{}}`(맵은 있으나 이 gate_id 항목이 아직 없음)여도 독립 fetch를 안 태우는지 값으로 고정 — 이번에 실제로 깨졌던 바로 그 시나리오.

## 검증
`src/components/chat` + `src/hooks` 663건 전부 PASS(신규 회귀가드 포함), `tsc --noEmit`·`pnpm lint` 0 에러.

## Test plan
- [ ] dev 착지 후 같은 대화(f374b5c8)로 Resource Timing 재실측 — `/api/gates?ids=` 1콜 + 개별 `/api/gates/{id}` 0콜 확인
- [ ] 카디르군 QA