### PR TITLE
feat(#3173): AU(automation_units) 계측 배선 — request.state 판별+미들웨어+웹훅

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -448,6 +448,22 @@ async def _resolve_firebase_session(token: str, db: AsyncSession) -> AuthContext
     )
 
 
+def is_au_billable_agent(auth: AuthContext) -> bool:
+    """story #3173(결제②-B) — AU(automation_units) 과금 판별자. doc `pricing-policy-
+    proposal-v1` §4.5: "사람이 웹 UI에서 수행한 작업 = 0 AU(좌석이 이미 받음)" — AU는
+    MCP/API(에이전트) 트래픽만 잰다.
+
+    ⛔단순히 `api_key_id` claim 존재만 보면 안 된다 — `_resolve_human_api_key`(hu_live_*,
+    휴먼 개인 API key)가 `"human_api_key_id"`로 싣고 `"actor_type": "human"`을 명시하는
+    기존 예외 경로가 있다(§6 참고). 그 경로를 에이전트로 오분류하면 사람 UI/개인키
+    작업에 AU를 잘못 부과해 스펙(사람=0)을 위반한다. 판별자는 반드시 이 둘을 함께 본다.
+    """
+    app_metadata = auth.claims.get("app_metadata", {})
+    is_api_key = bool(app_metadata.get("api_key_id"))
+    is_human_claimed = app_metadata.get("actor_type") == "human"
+    return is_api_key and not is_human_claimed
+
+
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     x_agent_api_key: str | None = Header(default=None, alias="x-agent-api-key"),
@@ -464,6 +480,27 @@ async def get_current_user(
     caller 세션에 write가 남아있었다면 여기서 명시 커밋 없이 `async with`만 쓰는 건 그 write를
     조용히 롤백시키는 회귀였을 것 — 이 순서(② #2457 → #2459) 자체가 안전장치다.
     """
+    auth = await _resolve_current_user_auth_context(
+        credentials=credentials, x_agent_api_key=x_agent_api_key,
+        x_mcp_transport=x_mcp_transport, request=request,
+    )
+    # story #3173(결제②-B) — 소비처: app/middleware/au_metering.py(app/main.py에 등록)가
+    # 응답 완료 후 이 값들을 읽어 AU 계측 대상 여부·귀속 조직을 정한다. FastAPI dependency는
+    # 라우터 안에서만 살고 ASGI 미들웨어 레이어로 안 새어나가므로, 여기서 request.state에
+    # 명시 기록해야 미들웨어가 볼 수 있다. ⛔이 값들의 유일한 소비처가 저 미들웨어다 — 새
+    # 소비처가 생기면 이 주석도 같이 갱신할 것(형제 드리프트 재발 방지, #3175 교훈).
+    if request is not None:
+        request.state.au_actor = "agent" if is_au_billable_agent(auth) else "human"
+        request.state.au_org_id = auth.org_id
+    return auth
+
+
+async def _resolve_current_user_auth_context(
+    credentials: HTTPAuthorizationCredentials | None,
+    x_agent_api_key: str | None,
+    x_mcp_transport: str | None,
+    request: Request,
+) -> AuthContext:
     # x-agent-api-key 헤더 우선 처리 (SSE 브릿지 직접 연결용)
     if x_agent_api_key and x_agent_api_key.startswith("sk_live_"):
         async with async_session_factory() as db:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -348,6 +348,13 @@ app.add_middleware(
     ],
 )
 
+# story #3173(결제②-B) — AU(automation_units) 계측. app/dependencies/auth.py의
+# get_current_user()가 request.state.au_actor/au_org_id를 심어두면 여기서 응답 완료 후
+# 읽어 usage_meters에 쌓는다. 전체 fail-open(계측 예외가 요청에 영향 0) — 모듈 docstring 참고.
+from app.services.au_metering import AUMeteringMiddleware  # noqa: E402
+
+app.add_middleware(AUMeteringMiddleware)
+
 app.include_router(auth.router)
 app.include_router(health.router)
 app.include_router(activity_logs.router)

--- a/backend/app/services/au_metering.py
+++ b/backend/app/services/au_metering.py
@@ -1,0 +1,164 @@
+"""story #3173(결제②-B) — AU(automation_units) 계측 기록 + ASGI 미들웨어.
+
+doc `pricing-policy-proposal-v1` §4.5: AU는 **MCP/API(에이전트) 트래픽만** 잰다 — 사람이
+웹 UI에서 수행한 작업은 0(좌석이 이미 받음). 판별자는
+`app.dependencies.auth.is_au_billable_agent()`(SSOT) — 이 모듈은 그 판별 결과
+(`request.state.au_actor`/`au_org_id`, auth dependency가 심음)를 읽기만 한다.
+
+⛔한도 «집행»(차단/경고)은 이 스토리 범위 밖 — 여기는 usage_meters에 값을 쌓는 계측
+축만 담당한다(story #d43ea270 선례: 한도값은 어드민 가변 데이터, 이 모듈은 손 안 댐).
+
+⚠️Phase 1 알려진 축소(스펙 §4.5 원문과의 편차 — **한도 집행을 켜기 前 반드시 보완**,
+story #3173 본문 "필수 보완" 조건 참고):
+  - 쓰기는 항상 엔티티 1개(5 AU)로 계상한다. 진짜 배치 엔드포인트(다건 동시 변경)가
+    응답 헤더 `X-Affected-Entities: N`을 명시하면 그 값을 쓴다 — 헤더 없으면 1(과소계상
+    방향, 자동 초과 청구 없음 철학과 정합·과금 안전측). 지금 어떤 엔드포인트도 이
+    헤더를 안 보낸다 — 배치 엔드포인트 전수 조사·헤더 배선은 후속.
+  - 읽기의 "100개 초과 반환 시 100개마다 +1" 규칙은 Phase 1 미구현(항상 1 AU) — 같은
+    이유(84개 라우터 파일이 응답 봉투가 제각각이라 범용 파싱 불가, 그라운딩 doc
+    `au-metering-grounding-3173` §4 참고).
+  - 성공 응답이 클라이언트에 못 닿고(네트워크 유실) 재시도되는 경우 멱등키 부재로 진짜
+    이중계상 가능(Toss `orderId`류 대응물 없음) — Phase 2 idempotency-key 후속 필요.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from app.core.database import async_session_factory
+from app.models.usage_meter import AU_WEIGHTS
+
+logger = logging.getLogger(__name__)
+
+# 스트리밍 응답(SSE) 정확 경로 — 코드베이스 전수 확認(2026-08-28, grep 0건 외 이 2곳뿐):
+# GET /api/v2/events/stream(events.py)·GET /api/v2/agent/stream(agent_gateway.py). 각
+# 라우터 파일의 다른 엔드포인트(POST /events 등)는 정상 AU 계측 대상이라 라우터 prefix
+# 전체가 아니라 이 두 정확 경로만 denylist한다.
+_STREAMING_PATHS = frozenset({"/api/v2/events/stream", "/api/v2/agent/stream"})
+
+_READ_METHODS = frozenset({"GET", "HEAD"})
+_WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def _current_month_period(now: datetime) -> tuple[datetime, datetime]:
+    start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if start.month == 12:
+        end = start.replace(year=start.year + 1, month=1)
+    else:
+        end = start.replace(month=start.month + 1)
+    return start, end
+
+
+async def record_au_usage(org_id: uuid.UUID, delta: int) -> None:
+    """usage_meters(meter_type='automation_units')를 이번 달 기준 원자적으로 증분한다.
+
+    행이 없으면 새로 만든다. 동시 요청이 같은 org의 같은 달 행을 놓고 경합할 수 있어
+    (unique 제약이 usage_meters에 없음 — 신설은 이 스토리 범위 밖, 기존 컬럼만 씀)
+    `pg_advisory_xact_lock`으로 org 단위 직렬화한다(check-then-insert TOCTOU를 SELECT
+    FOR UPDATE로는 못 막는 클래스 — feedback_check_then_insert_toctou와 동형 처방).
+
+    ⛔fire-and-forget 호출부(미들웨어)가 이 함수를 try/except로 감싸므로, 여기서 올라간
+    예외는 절대 응답을 막지 않는다 — 대신 로그로 반드시 남긴다(호출부 책임 분리:
+    이 함수는 실패 시 그냥 raise, 삼키지 않는다)."""
+    if delta <= 0:
+        return
+    now = datetime.now(timezone.utc)
+    period_start, period_end = _current_month_period(now)
+
+    async with async_session_factory() as session:
+        async with session.begin():
+            await session.execute(
+                text("SELECT pg_advisory_xact_lock(hashtext('au_metering:' || :org_id))"),
+                {"org_id": str(org_id)},
+            )
+            updated = await session.execute(
+                text(
+                    "UPDATE usage_meters SET current_value = current_value + :delta, "
+                    "updated_at = now() "
+                    "WHERE org_id = :org_id AND meter_type = 'automation_units' "
+                    "AND period_start = :period_start"
+                ),
+                {"org_id": org_id, "delta": delta, "period_start": period_start},
+            )
+            if updated.rowcount == 0:
+                await session.execute(
+                    text(
+                        "INSERT INTO usage_meters "
+                        "(id, org_id, meter_type, current_value, period_start, period_end) "
+                        "VALUES (:id, :org_id, 'automation_units', :delta, :period_start, :period_end)"
+                    ),
+                    {
+                        "id": uuid.uuid4(),
+                        "org_id": org_id,
+                        "delta": delta,
+                        "period_start": period_start,
+                        "period_end": period_end,
+                    },
+                )
+
+
+def _affected_entities(response: Response) -> int:
+    """§4.5 배치 옵트인 — 진짜 배치 엔드포인트가 `X-Affected-Entities` 응답 헤더로 명시한
+    변경 엔티티 수. 헤더 없거나 파싱 불가면 안전측 기본값 1(과소계상 방향)."""
+    raw = response.headers.get("X-Affected-Entities")
+    if not raw:
+        return 1
+    try:
+        n = int(raw)
+    except ValueError:
+        return 1
+    return n if n > 0 else 1
+
+
+def _au_weight_for(method: str, response: Response) -> int:
+    if method in _WRITE_METHODS:
+        return AU_WEIGHTS["write"] * _affected_entities(response)
+    if method in _READ_METHODS:
+        return AU_WEIGHTS["read"]
+    return 0
+
+
+class AUMeteringMiddleware(BaseHTTPMiddleware):
+    """story #3173 — 응답 완료 후 에이전트 트래픽만 골라 AU를 usage_meters에 쌓는다.
+
+    ⛔조건ⓐ(페드루 PO, 2026-08-28) — 계측 경로 전체가 fail-open이어야 한다: 이 미들웨어의
+    어떤 예외도 원 요청/응답에 영향을 주면 안 된다. `call_next()` 자체의 예외는 그대로
+    전파하되(그건 이 미들웨어의 책임이 아님), 계측 로직(아래 `_meter` 블록)은 통째로
+    try/except로 감싸 로그만 남기고 삼킨다."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        try:
+            await self._meter(request, response)
+        except Exception:
+            logger.error(
+                "AU metering failed path=%s method=%s", request.url.path, request.method,
+                exc_info=True,
+            )
+        return response
+
+    async def _meter(self, request: Request, response: Response) -> None:
+        if request.url.path in _STREAMING_PATHS:
+            return
+        if response.status_code >= 400:
+            return
+        au_actor = getattr(request.state, "au_actor", None)
+        if au_actor != "agent":
+            return
+        org_id_raw = getattr(request.state, "au_org_id", None)
+        if not org_id_raw:
+            return
+        weight = _au_weight_for(request.method, response)
+        if weight <= 0:
+            return
+        await record_au_usage(uuid.UUID(str(org_id_raw)), weight)

--- a/backend/app/services/au_metering.py
+++ b/backend/app/services/au_metering.py
@@ -136,6 +136,20 @@ async def _record_au_usage_safe(org_id: uuid.UUID, delta: int) -> None:
         logger.error("AU metering failed org_id=%s delta=%s", org_id, delta, exc_info=True)
 
 
+# 페드루 PO 리뷰(PR#3579, 2026-08-28) — `asyncio.create_task()`의 반환값을 아무 데도 안
+# 잡아두면 이벤트루프가 그 태스크를 약참조로만 들고 있어, 완료 前에 GC될 수 있다(파이썬
+# 공식 문서 명시 경고 — ruff RUF006이 잡는 클래스). 이 경로에서 그게 터지면 로그 한 줄
+# 없는 무흔적 유실이라 "조용한 실패 금지" 원칙에 정면으로 걸린다 — 표준 처방(강한 참조
+# set + 완료 시 자기 자신을 discard)으로 막는다.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _spawn_background(coro) -> None:
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
 class AUMeteringMiddleware(BaseHTTPMiddleware):
     """story #3173 — 응답 완료 후 에이전트 트래픽만 골라 AU를 usage_meters에 쌓는다.
 
@@ -148,9 +162,10 @@ class AUMeteringMiddleware(BaseHTTPMiddleware):
     advisory lock 포함)를 `dispatch()` 안에서 inline `await`해, 설계(§6 "fire-and-forget")와
     어긋나게 **모든 에이전트 요청**에 계측 DB 왕복을 응답 임계경로에 직렬로 얹고 있었다 —
     평시엔 무해하지만 같은 org 동시 버스트 시 advisory lock 직렬화가 꼬리 지연을 문다. 지금은
-    「무엇을 셀지」(동기·순수 판단, `_should_meter`/`_au_weight_for` — I/O 없음)와 「실제로
-    쓰는 것」(`_record_au_usage_safe`, DB 왕복)을 분리해, 후자만 `asyncio.create_task`로
-    응답 반환 밖으로 던진다 — 클라이언트는 계측을 기다리지 않는다."""
+    「무엇을 셀지」(동기·순수 판단, `_plan_metering`/`_au_weight_for` — I/O 없음)와 「실제로
+    쓰는 것」(`_record_au_usage_safe`, DB 왕복)을 분리해, 후자만 `_spawn_background()`
+    (강한 참조 유지 — 아래 참고)로 응답 반환 밖으로 던진다 — 클라이언트는 계측을
+    기다리지 않는다."""
 
     def __init__(self, app: ASGIApp) -> None:
         super().__init__(app)
@@ -160,7 +175,7 @@ class AUMeteringMiddleware(BaseHTTPMiddleware):
         try:
             org_id, weight = self._plan_metering(request, response)
             if org_id is not None and weight > 0:
-                asyncio.create_task(_record_au_usage_safe(org_id, weight))
+                _spawn_background(_record_au_usage_safe(org_id, weight))
         except Exception:
             logger.error(
                 "AU metering planning failed path=%s method=%s", request.url.path, request.method,

--- a/backend/app/services/au_metering.py
+++ b/backend/app/services/au_metering.py
@@ -22,7 +22,6 @@ story #3173 본문 "필수 보완" 조건 참고):
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -35,6 +34,7 @@ from starlette.types import ASGIApp
 
 from app.core.database import async_session_factory
 from app.models.usage_meter import AU_WEIGHTS
+from app.services.pg_pubsub import fire_and_forget
 
 logger = logging.getLogger(__name__)
 
@@ -127,27 +127,13 @@ def _au_weight_for(method: str, response: Response) -> int:
 
 
 async def _record_au_usage_safe(org_id: uuid.UUID, delta: int) -> None:
-    """`asyncio.create_task`로 던져지는 실제 DB 왕복 — 이 코루틴 자신이 예외를 전부
-    삼켜야 한다(안 그러면 "Task exception was never retrieved" — 아무도 안 기다리는
+    """`pg_pubsub.fire_and_forget()`로 던져지는 실제 DB 왕복 — 이 코루틴 자신이 예외를
+    전부 삼켜야 한다(안 그러면 "Task exception was never retrieved" — 아무도 안 기다리는
     태스크의 예외는 로그 없이 사라지거나 인터프리터 경고로만 남는다)."""
     try:
         await record_au_usage(org_id, delta)
     except Exception:
         logger.error("AU metering failed org_id=%s delta=%s", org_id, delta, exc_info=True)
-
-
-# 페드루 PO 리뷰(PR#3579, 2026-08-28) — `asyncio.create_task()`의 반환값을 아무 데도 안
-# 잡아두면 이벤트루프가 그 태스크를 약참조로만 들고 있어, 완료 前에 GC될 수 있다(파이썬
-# 공식 문서 명시 경고 — ruff RUF006이 잡는 클래스). 이 경로에서 그게 터지면 로그 한 줄
-# 없는 무흔적 유실이라 "조용한 실패 금지" 원칙에 정면으로 걸린다 — 표준 처방(강한 참조
-# set + 완료 시 자기 자신을 discard)으로 막는다.
-_background_tasks: set[asyncio.Task] = set()
-
-
-def _spawn_background(coro) -> None:
-    task = asyncio.create_task(coro)
-    _background_tasks.add(task)
-    task.add_done_callback(_background_tasks.discard)
 
 
 class AUMeteringMiddleware(BaseHTTPMiddleware):
@@ -163,9 +149,16 @@ class AUMeteringMiddleware(BaseHTTPMiddleware):
     어긋나게 **모든 에이전트 요청**에 계측 DB 왕복을 응답 임계경로에 직렬로 얹고 있었다 —
     평시엔 무해하지만 같은 org 동시 버스트 시 advisory lock 직렬화가 꼬리 지연을 문다. 지금은
     「무엇을 셀지」(동기·순수 판단, `_plan_metering`/`_au_weight_for` — I/O 없음)와 「실제로
-    쓰는 것」(`_record_au_usage_safe`, DB 왕복)을 분리해, 후자만 `_spawn_background()`
-    (강한 참조 유지 — 아래 참고)로 응답 반환 밖으로 던진다 — 클라이언트는 계측을
-    기다리지 않는다."""
+    쓰는 것」(`_record_au_usage_safe`, DB 왕복)을 분리해, 후자만 응답 반환 밖으로 던진다.
+
+    ⛔재구현 정정(페드루 PO 자인, 2026-08-28, 카디르 QA 적발) — 위 분리 자체는 맞았으나
+    최초 델타가 `asyncio.create_task` + 모듈 로컬 `set`을 직접 새로 짰다(리뷰 지시가 grep
+    없이 "3줄" 처방을 준 것이 원인). 이 레포엔 이미 정확히 이 문제(fire-and-forget 태스크
+    GC 조기수거)를 잡은 canonical 헬퍼 `pg_pubsub.fire_and_forget()`이 있고, 그 모듈의
+    `drain_background_tasks()`가 main.py lifespan shutdown에 이미 배선돼 있다 — 로컬
+    set을 따로 만들면 그 drain 대상에서 빠져 graceful shutdown 시 이미 닫힌 커넥션
+    풀을 참조하는 위험을 새로 만든다(test_no_unreferenced_fire_and_forget.py가 적발).
+    지금은 `fire_and_forget()`을 그대로 재사용 — 새 세트·새 drain 로직 0."""
 
     def __init__(self, app: ASGIApp) -> None:
         super().__init__(app)
@@ -175,7 +168,7 @@ class AUMeteringMiddleware(BaseHTTPMiddleware):
         try:
             org_id, weight = self._plan_metering(request, response)
             if org_id is not None and weight > 0:
-                _spawn_background(_record_au_usage_safe(org_id, weight))
+                fire_and_forget(_record_au_usage_safe(org_id, weight))
         except Exception:
             logger.error(
                 "AU metering planning failed path=%s method=%s", request.url.path, request.method,

--- a/backend/app/services/au_metering.py
+++ b/backend/app/services/au_metering.py
@@ -22,6 +22,7 @@ story #3173 본문 "필수 보완" 조건 참고):
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -125,13 +126,31 @@ def _au_weight_for(method: str, response: Response) -> int:
     return 0
 
 
+async def _record_au_usage_safe(org_id: uuid.UUID, delta: int) -> None:
+    """`asyncio.create_task`로 던져지는 실제 DB 왕복 — 이 코루틴 자신이 예외를 전부
+    삼켜야 한다(안 그러면 "Task exception was never retrieved" — 아무도 안 기다리는
+    태스크의 예외는 로그 없이 사라지거나 인터프리터 경고로만 남는다)."""
+    try:
+        await record_au_usage(org_id, delta)
+    except Exception:
+        logger.error("AU metering failed org_id=%s delta=%s", org_id, delta, exc_info=True)
+
+
 class AUMeteringMiddleware(BaseHTTPMiddleware):
     """story #3173 — 응답 완료 후 에이전트 트래픽만 골라 AU를 usage_meters에 쌓는다.
 
     ⛔조건ⓐ(페드루 PO, 2026-08-28) — 계측 경로 전체가 fail-open이어야 한다: 이 미들웨어의
     어떤 예외도 원 요청/응답에 영향을 주면 안 된다. `call_next()` 자체의 예외는 그대로
-    전파하되(그건 이 미들웨어의 책임이 아님), 계측 로직(아래 `_meter` 블록)은 통째로
-    try/except로 감싸 로그만 남기고 삼킨다."""
+    전파하되(그건 이 미들웨어의 책임이 아님), 계측 로직은 통째로 try/except로 감싸 로그만
+    남기고 삼킨다.
+
+    ⛔지연 편차 정정(페드루 PO, 2026-08-28, PR#3579 리뷰) — 최초 구현이 `_meter`(DB 왕복+
+    advisory lock 포함)를 `dispatch()` 안에서 inline `await`해, 설계(§6 "fire-and-forget")와
+    어긋나게 **모든 에이전트 요청**에 계측 DB 왕복을 응답 임계경로에 직렬로 얹고 있었다 —
+    평시엔 무해하지만 같은 org 동시 버스트 시 advisory lock 직렬화가 꼬리 지연을 문다. 지금은
+    「무엇을 셀지」(동기·순수 판단, `_should_meter`/`_au_weight_for` — I/O 없음)와 「실제로
+    쓰는 것」(`_record_au_usage_safe`, DB 왕복)을 분리해, 후자만 `asyncio.create_task`로
+    응답 반환 밖으로 던진다 — 클라이언트는 계측을 기다리지 않는다."""
 
     def __init__(self, app: ASGIApp) -> None:
         super().__init__(app)
@@ -139,26 +158,30 @@ class AUMeteringMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
         try:
-            await self._meter(request, response)
+            org_id, weight = self._plan_metering(request, response)
+            if org_id is not None and weight > 0:
+                asyncio.create_task(_record_au_usage_safe(org_id, weight))
         except Exception:
             logger.error(
-                "AU metering failed path=%s method=%s", request.url.path, request.method,
+                "AU metering planning failed path=%s method=%s", request.url.path, request.method,
                 exc_info=True,
             )
         return response
 
-    async def _meter(self, request: Request, response: Response) -> None:
+    def _plan_metering(self, request: Request, response: Response) -> tuple[uuid.UUID | None, int]:
+        """순수 판단(I/O 없음) — 이 요청이 계측 대상인지·몇 AU인지만 정한다. 실제 쓰기는
+        호출부가 별도 태스크로 던진다(위 클래스 docstring 참고)."""
         if request.url.path in _STREAMING_PATHS:
-            return
+            return None, 0
         if response.status_code >= 400:
-            return
+            return None, 0
         au_actor = getattr(request.state, "au_actor", None)
         if au_actor != "agent":
-            return
+            return None, 0
         org_id_raw = getattr(request.state, "au_org_id", None)
         if not org_id_raw:
-            return
+            return None, 0
         weight = _au_weight_for(request.method, response)
         if weight <= 0:
-            return
-        await record_au_usage(uuid.UUID(str(org_id_raw)), weight)
+            return None, 0
+        return uuid.UUID(str(org_id_raw)), weight

--- a/backend/app/services/delivery_dispatcher.py
+++ b/backend/app/services/delivery_dispatcher.py
@@ -142,7 +142,7 @@ async def _deliver_one(job: dict) -> None:
                 )
                 await session.commit()
             # ⬇ 이 구간은 세션이 닫혀 있다(커넥션 풀에 반납됨) — 외부 I/O만.
-            await _send_webhook_targets(targets, payload["event"], payload["data"])
+            await _send_webhook_targets(targets, payload["event"], payload["data"], org_id)
         elif kind == "personal_webhook":
             from app.services.notification_dispatch import (
                 _fetch_personal_webhook_targets,
@@ -159,6 +159,7 @@ async def _deliver_one(job: dict) -> None:
                 targets, title=payload["title"], body=payload.get("body"),
                 event_type=payload["event_type"], reference_type=payload.get("reference_type"),
                 reference_id=_uuid_or_none(payload.get("reference_id")), context=payload.get("context"),
+                org_id=org_id,
             )
         elif kind == "expo_push":
             from ee.services.expo_push import (

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -134,6 +134,7 @@ async def _deliver_personal_webhooks_now(
     await _send_personal_webhook_targets(
         targets, title=title, body=body, event_type=event_type,
         reference_type=reference_type, reference_id=reference_id, context=context,
+        org_id=org_id,
     )
 
 
@@ -181,8 +182,13 @@ async def _send_personal_webhook_targets(
     reference_type: str | None = None,
     reference_id: uuid.UUID | None = None,
     context: dict | None = None,
+    org_id: uuid.UUID | None = None,
 ) -> None:
-    """세션 없이 순수 HTTP POST만(story #2460 PO 리뷰 F1)."""
+    """세션 없이 순수 HTTP POST만(story #2460 PO 리뷰 F1).
+
+    story #3173(결제②-B) — doc `pricing-policy-proposal-v1` §4.5 "성공한 외부 웹훅 전달 =
+    전달 1건당 1 AU". `_post_with_retry`가 True를 반환한 경우만 계측(webhook_dispatch.py의
+    org webhook 경로와 동형 — org_id 없으면 계측 생략, 실패는 fail-open)."""
     if not targets:
         return
     from app.core.ssrf import validate_webhook_url_async
@@ -214,9 +220,17 @@ async def _send_personal_webhook_targets(
                 "context": context or {},
             }
         try:
-            await _post_with_retry(url, payload, secret, str(member_id))
+            delivered = await _post_with_retry(url, payload, secret, str(member_id))
         except Exception:
             logger.warning("personal webhook POST failed (swallowed) member=%s", member_id)
+            continue
+        if delivered and org_id is not None:
+            try:
+                from app.services.au_metering import record_au_usage
+
+                await record_au_usage(org_id, 1)
+            except Exception:
+                logger.error("AU metering(personal webhook) failed org_id=%s", org_id, exc_info=True)
 
 
 async def dispatch_notification(

--- a/backend/app/services/webhook_dispatch.py
+++ b/backend/app/services/webhook_dispatch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import logging
 import time
 import uuid
 from typing import Any
@@ -16,6 +17,8 @@ from app.core.ssrf import validate_webhook_url_async
 from app.models.webhook_config import WebhookConfig
 # c60dd33c: Discord 페이로드 정규화 공용 헬퍼(채팅 경로와 단일화).
 from app.services.discord_webhook import is_discord_url, to_discord_event_payload
+
+logger = logging.getLogger(__name__)
 
 
 def _build_signature_headers(secret: str | None, body: str) -> dict[str, str]:
@@ -105,7 +108,7 @@ async def _fire_webhooks_now(
         session, org_id, event,
         recipient_member_ids=recipient_member_ids, preserve_broadcast=preserve_broadcast,
     )
-    await _send_webhook_targets(targets, event, data)
+    await _send_webhook_targets(targets, event, data, org_id)
 
 
 async def _fetch_webhook_targets(
@@ -142,9 +145,16 @@ async def _fetch_webhook_targets(
     return targets
 
 
-async def _send_webhook_targets(targets: list[dict[str, Any]], event: str, data: dict[str, Any]) -> None:
+async def _send_webhook_targets(
+    targets: list[dict[str, Any]], event: str, data: dict[str, Any], org_id: uuid.UUID | None = None,
+) -> None:
     """세션 없이 순수 HTTP POST만(story #2460 PO 리뷰 F1) — SSRF 재검증도 이 자리(발송
-    직전 재검증이 목적이라 fetch 단계로 옮기면 안 됨 — DNS rebinding 방지 의도가 죽는다)."""
+    직전 재검증이 목적이라 fetch 단계로 옮기면 안 됨 — DNS rebinding 방지 의도가 죽는다).
+
+    story #3173(결제②-B) — doc `pricing-policy-proposal-v1` §4.5 "성공한 외부 웹훅 전달 =
+    전달 1건당 1 AU". `org_id`는 하위호환 위해 선택 인자(기존 호출부 무회귀) — None이면
+    계측 생략(값을 지어내지 않음, 과소계상 방향 안전측). 계측은 기존 예외-삼킴 제어흐름을
+    안 건드리고 완전 별도 try/except로 감싼다(fail-open, 계측 실패가 배달을 막으면 안 됨)."""
     if not targets:
         return
     envelope_body = json.dumps({"event": event, "data": data})
@@ -166,9 +176,16 @@ async def _send_webhook_targets(targets: list[dict[str, Any]], event: str, data:
                 body = envelope_body
                 headers = {"Content-Type": "application/json", **_build_signature_headers(secret, body)}
             try:
-                await client.post(url, content=body, headers=headers)
+                resp = await client.post(url, content=body, headers=headers)
             except Exception:
-                pass
+                continue
+            if org_id is not None and 200 <= resp.status_code < 300:
+                try:
+                    from app.services.au_metering import record_au_usage
+
+                    await record_au_usage(org_id, 1)
+                except Exception:
+                    logger.error("AU metering(webhook) failed org_id=%s", org_id, exc_info=True)
 
 
 async def deliver_test_webhook(url: str, secret: str | None) -> tuple[bool, str | None]:

--- a/backend/tests/test_2460_delivery_outbox_realdb.py
+++ b/backend/tests/test_2460_delivery_outbox_realdb.py
@@ -209,9 +209,10 @@ async def test_send_phase_holds_no_connection_from_fetch_phase(monkeypatch):
 
         probe_succeeded = {"value": False}
 
-        async def _send_probe(targets, event, data):
-            # send가 실행되는 이 시점에 fetch 단계 커넥션이 반납돼 있어야, pool_size=1인
-            # 이 엔진으로 새 세션을 여는 이 호출이 안 멈추고 통과한다.
+        async def _send_probe(targets, event, data, org_id=None):
+            # story #3173 — _send_webhook_targets가 이제 4번째 인자(org_id, AU 계측용)를
+            # 받는다. send가 실행되는 이 시점에 fetch 단계 커넥션이 반납돼 있어야,
+            # pool_size=1인 이 엔진으로 새 세션을 여는 이 호출이 안 멈추고 통과한다.
             async with AsyncSession(engine) as probe_session:
                 await probe_session.execute(select(DeliveryJob.id).limit(1))
             probe_succeeded["value"] = True

--- a/backend/tests/test_3173_au_billable_agent_predicate.py
+++ b/backend/tests/test_3173_au_billable_agent_predicate.py
@@ -1,0 +1,38 @@
+"""story #3173(결제②-B) — `is_au_billable_agent()` 판별자 회귀(페드루 PO §2 조건).
+
+doc `pricing-policy-proposal-v1` §4.5: "사람이 웹 UI에서 수행한 작업 = 0 AU". 판별자가
+`api_key_id` claim 존재만 보면 `_resolve_human_api_key`(hu_live_*, 휴먼 개인 API key —
+`"human_api_key_id"`로 싣고 `"actor_type": "human"`을 명시하는 기존 경로)를 에이전트로
+오분류할 위험이 있다 — 이 케이스가 AU=0으로 남는 것을 값으로 고정한다."""
+from __future__ import annotations
+
+from app.dependencies.auth import AuthContext, is_au_billable_agent
+
+
+def _ctx(app_metadata: dict) -> AuthContext:
+    return AuthContext(user_id="u1", email=None, claims={"app_metadata": app_metadata}, org_id="org1")
+
+
+def test_human_personal_api_key_is_not_au_billable():
+    """_resolve_human_api_key()가 실제로 만드는 claims 형태 그대로(hu_live_* 경로)."""
+    ctx = _ctx({"human_api_key_id": "key-1", "actor_type": "human"})
+    assert is_au_billable_agent(ctx) is False
+
+
+def test_agent_api_key_is_au_billable():
+    """_resolve_api_key()가 만드는 claims 형태(sk_live_* 경로, api_key_id 존재·actor_type 없음)."""
+    ctx = _ctx({"api_key_id": "key-2", "org_id": "org1"})
+    assert is_au_billable_agent(ctx) is True
+
+
+def test_api_key_id_present_but_explicitly_marked_human_is_not_billable():
+    """방어적 케이스 — api_key_id가 있어도 actor_type="human"이 명시되면 항상 사람 취급
+    (판별자 문서화된 근거를 실제로 지키는지 값으로 고정)."""
+    ctx = _ctx({"api_key_id": "key-3", "actor_type": "human"})
+    assert is_au_billable_agent(ctx) is False
+
+
+def test_plain_human_jwt_without_api_key_claim_is_not_billable():
+    """일반 사람 JWT(app_metadata에 api_key_id 자체가 없음)도 당연히 비과금."""
+    ctx = _ctx({"org_id": "org1"})
+    assert is_au_billable_agent(ctx) is False

--- a/backend/tests/test_3173_au_metering_middleware.py
+++ b/backend/tests/test_3173_au_metering_middleware.py
@@ -1,16 +1,37 @@
 """story #3173(결제②-B) — AUMeteringMiddleware 판정 로직 회귀(실 DB 불요, record_au_usage
-자체는 모킹). 미들웨어가 «언제 세고 언제 안 세는지»만 고정한다."""
+자체는 모킹). 미들웨어가 «언제 세고 언제 안 세는지»·«응답 경로에서 분리됐는지»를 고정한다.
+
+⚠️페드루 PO 리뷰(PR#3579, 2026-08-28) — 계측 DB 왕복은 `asyncio.create_task`로 응답
+반환 밖에 던져진다(fire-and-forget, §6 설계). 그래서 여기는 sync `TestClient`가 아니라
+`httpx.AsyncClient`+`ASGITransport`로 같은 이벤트루프를 유지하고, 매 요청 뒤
+`_drain_background_tasks()`로 스케줄된 태스크가 실제로 끝나길 기다린 다음에야 assert한다
+— 안 그러면 백그라운드 태스크가 돌기도 전에 테스트 함수가 끝나 항상 거짓양성(비어있음)이 뜬다."""
 from __future__ import annotations
 
+import asyncio
 import uuid
 from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 
 from app.services.au_metering import AUMeteringMiddleware
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _drain_background_tasks() -> None:
+    """dispatch()가 asyncio.create_task로 던진 계측 태스크가 실제로 끝날 때까지 대기.
+    현재 실행 중인 테스트 코루틴 자신은 제외해야 한다(자기 자신을 gather하면 데드락)."""
+    current = asyncio.current_task()
+    pending = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
+    if pending:
+        await asyncio.gather(*pending)
 
 
 def _build_app(monkeypatch, *, au_actor: str | None, org_id: str | None = "11111111-1111-1111-1111-111111111111"):
@@ -50,77 +71,140 @@ def _build_app(monkeypatch, *, au_actor: str | None, org_id: str | None = "11111
         recorded.append((str(org_id), delta))
 
     monkeypatch.setattr("app.services.au_metering.record_au_usage", AsyncMock(side_effect=_fake_record))
-    return app, recorded
+    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+    return client, recorded
 
 
-def test_agent_read_success_records_one_au(monkeypatch):
-    app, recorded = _build_app(monkeypatch, au_actor="agent")
-    client = TestClient(app)
-    resp = client.get("/api/v2/widgets")
+@pytest.mark.anyio
+async def test_metering_is_scheduled_as_background_task_not_awaited_inline(monkeypatch):
+    """조건(페드루 PO, PR#3579) — dispatch()가 record_au_usage를 inline await하지 않는다.
+    record_au_usage를 절대 안 끝나는 코루틴으로 바꿔도 응답은 즉시 돌아와야 한다."""
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _fake_auth(request: Request, call_next):
+        request.state.au_actor = "agent"
+        request.state.au_org_id = "11111111-1111-1111-1111-111111111111"
+        return await call_next(request)
+
+    app.add_middleware(AUMeteringMiddleware)
+
+    @app.get("/api/v2/widgets")
+    async def read_widgets():
+        return JSONResponse({"data": []})
+
+    hung = asyncio.Event()
+
+    async def _never_returns(org_id, delta):
+        await hung.wait()  # 응답이 이걸 기다리면 이 테스트 자체가 타임아웃으로 실패한다.
+
+    monkeypatch.setattr("app.services.au_metering.record_au_usage", AsyncMock(side_effect=_never_returns))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await asyncio.wait_for(client.get("/api/v2/widgets"), timeout=2.0)
+    assert resp.status_code == 200
+    hung.set()  # 정리 — 매달린 태스크 해제.
+    await _drain_background_tasks()
+
+
+@pytest.mark.anyio
+async def test_agent_read_success_records_one_au(monkeypatch):
+    client, recorded = _build_app(monkeypatch, au_actor="agent")
+    async with client:
+        resp = await client.get("/api/v2/widgets")
+        await _drain_background_tasks()
     assert resp.status_code == 200
     assert recorded == [("11111111-1111-1111-1111-111111111111", 1)]
 
 
-def test_agent_write_success_records_five_au(monkeypatch):
-    app, recorded = _build_app(monkeypatch, au_actor="agent")
-    client = TestClient(app)
-    resp = client.post("/api/v2/widgets")
+@pytest.mark.anyio
+async def test_agent_write_success_records_five_au(monkeypatch):
+    client, recorded = _build_app(monkeypatch, au_actor="agent")
+    async with client:
+        resp = await client.post("/api/v2/widgets")
+        await _drain_background_tasks()
     assert resp.status_code == 201
     assert recorded == [("11111111-1111-1111-1111-111111111111", 5)]
 
 
-def test_agent_batch_write_uses_affected_entities_header(monkeypatch):
-    app, recorded = _build_app(monkeypatch, au_actor="agent")
-    client = TestClient(app)
-    resp = client.post("/api/v2/widgets/batch")
+@pytest.mark.anyio
+async def test_agent_batch_write_uses_affected_entities_header(monkeypatch):
+    client, recorded = _build_app(monkeypatch, au_actor="agent")
+    async with client:
+        resp = await client.post("/api/v2/widgets/batch")
+        await _drain_background_tasks()
     assert resp.status_code == 201
     assert recorded == [("11111111-1111-1111-1111-111111111111", 35)], (
         "X-Affected-Entities: 7 -> 5*7=35이어야 함"
     )
 
 
-def test_human_traffic_never_counted(monkeypatch):
+@pytest.mark.anyio
+async def test_human_traffic_never_counted(monkeypatch):
     """doc §4.5 — 사람 웹 UI 작업은 0 AU."""
-    app, recorded = _build_app(monkeypatch, au_actor="human")
-    client = TestClient(app)
-    client.get("/api/v2/widgets")
-    client.post("/api/v2/widgets")
+    client, recorded = _build_app(monkeypatch, au_actor="human")
+    async with client:
+        await client.get("/api/v2/widgets")
+        await client.post("/api/v2/widgets")
+        await _drain_background_tasks()
     assert recorded == []
 
 
-def test_unauthenticated_traffic_never_counted(monkeypatch):
+@pytest.mark.anyio
+async def test_unauthenticated_traffic_never_counted(monkeypatch):
     """au_actor가 아예 안 심긴(공개 엔드포인트 등) 경우도 세지 않는다."""
-    app, recorded = _build_app(monkeypatch, au_actor=None)
-    client = TestClient(app)
-    client.get("/api/v2/widgets")
+    client, recorded = _build_app(monkeypatch, au_actor=None)
+    async with client:
+        await client.get("/api/v2/widgets")
+        await _drain_background_tasks()
     assert recorded == []
 
 
-def test_failed_response_never_counted(monkeypatch):
+@pytest.mark.anyio
+async def test_failed_response_never_counted(monkeypatch):
     """doc §4.5 — 인증 실패·유효성 실패·서버 5xx는 0 AU."""
-    app, recorded = _build_app(monkeypatch, au_actor="agent")
-    client = TestClient(app)
-    resp = client.get("/api/v2/widgets/missing")
+    client, recorded = _build_app(monkeypatch, au_actor="agent")
+    async with client:
+        resp = await client.get("/api/v2/widgets/missing")
+        await _drain_background_tasks()
     assert resp.status_code == 404
     assert recorded == []
 
 
-def test_streaming_path_never_counted(monkeypatch):
+@pytest.mark.anyio
+async def test_streaming_path_never_counted(monkeypatch):
     """SSE denylist — 정확 경로만(라우터 prefix 전체 아님)."""
-    app, recorded = _build_app(monkeypatch, au_actor="agent")
-    client = TestClient(app)
-    resp = client.get("/api/v2/events/stream")
+    client, recorded = _build_app(monkeypatch, au_actor="agent")
+    async with client:
+        resp = await client.get("/api/v2/events/stream")
+        await _drain_background_tasks()
     assert resp.status_code == 200
     assert recorded == []
 
 
-def test_metering_exception_never_breaks_the_response(monkeypatch):
-    """조건ⓐ(페드루 PO) — 계측 자체가 죽어도 응답은 절대 안 죽는다(fail-open)."""
-    app, _ = _build_app(monkeypatch, au_actor="agent")
+@pytest.mark.anyio
+async def test_metering_exception_never_breaks_the_response(monkeypatch):
+    """조건ⓐ(페드루 PO) — 계측 자체가 죽어도 응답은 절대 안 죽는다(fail-open). 백그라운드
+    태스크 안에서 터진 예외도(_record_au_usage_safe) 삼켜져야 한다 — 안 그러면 "Task
+    exception was never retrieved"로 인터프리터가 시끄러워진다."""
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _fake_auth(request: Request, call_next):
+        request.state.au_actor = "agent"
+        request.state.au_org_id = "11111111-1111-1111-1111-111111111111"
+        return await call_next(request)
+
+    app.add_middleware(AUMeteringMiddleware)
+
+    @app.get("/api/v2/widgets")
+    async def read_widgets():
+        return JSONResponse({"data": []})
+
     monkeypatch.setattr(
         "app.services.au_metering.record_au_usage",
         AsyncMock(side_effect=RuntimeError("boom")),
     )
-    client = TestClient(app)
-    resp = client.get("/api/v2/widgets")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/v2/widgets")
+        await _drain_background_tasks()  # 예외를 삼키는지까지 확認(안 삼키면 여기서 raise)
     assert resp.status_code == 200, "계측 예외가 응답을 깨뜨림 — fail-open 조건 위반"

--- a/backend/tests/test_3173_au_metering_middleware.py
+++ b/backend/tests/test_3173_au_metering_middleware.py
@@ -107,6 +107,32 @@ async def test_metering_is_scheduled_as_background_task_not_awaited_inline(monke
 
 
 @pytest.mark.anyio
+async def test_spawned_task_is_strongly_referenced_until_done(monkeypatch):
+    """페드루 PO 리뷰(PR#3579) — `asyncio.create_task()`의 반환값을 안 잡아두면 이벤트루프가
+    약참조로만 들고 있어 완료 前 GC될 수 있다(ruff RUF006 클래스). `_spawn_background()`가
+    모듈 레벨 set에 강한 참조를 잡아뒀다가 완료 시에만 비우는지 직접 확認한다."""
+    import app.services.au_metering as au_metering
+
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    async def _slow(org_id, delta):
+        started.set()
+        await release.wait()
+
+    monkeypatch.setattr(au_metering, "record_au_usage", AsyncMock(side_effect=_slow))
+
+    assert len(au_metering._background_tasks) == 0
+    au_metering._spawn_background(au_metering._record_au_usage_safe(uuid.uuid4(), 1))
+    await started.wait()
+    assert len(au_metering._background_tasks) == 1, "spawn 직후엔 강한 참조가 set에 있어야 함"
+
+    release.set()
+    await _drain_background_tasks()
+    assert len(au_metering._background_tasks) == 0, "완료 후엔 done_callback이 discard해야 함"
+
+
+@pytest.mark.anyio
 async def test_agent_read_success_records_one_au(monkeypatch):
     client, recorded = _build_app(monkeypatch, au_actor="agent")
     async with client:

--- a/backend/tests/test_3173_au_metering_middleware.py
+++ b/backend/tests/test_3173_au_metering_middleware.py
@@ -1,0 +1,126 @@
+"""story #3173(결제②-B) — AUMeteringMiddleware 판정 로직 회귀(실 DB 불요, record_au_usage
+자체는 모킹). 미들웨어가 «언제 세고 언제 안 세는지»만 고정한다."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from app.services.au_metering import AUMeteringMiddleware
+
+
+def _build_app(monkeypatch, *, au_actor: str | None, org_id: str | None = "11111111-1111-1111-1111-111111111111"):
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _fake_auth(request: Request, call_next):
+        request.state.au_actor = au_actor
+        request.state.au_org_id = org_id
+        return await call_next(request)
+
+    app.add_middleware(AUMeteringMiddleware)
+
+    @app.get("/api/v2/widgets")
+    async def read_widgets():
+        return JSONResponse({"data": []})
+
+    @app.post("/api/v2/widgets")
+    async def write_widget():
+        return JSONResponse({"data": {"id": 1}}, status_code=201)
+
+    @app.post("/api/v2/widgets/batch")
+    async def write_widgets_batch():
+        return JSONResponse({"data": []}, status_code=201, headers={"X-Affected-Entities": "7"})
+
+    @app.get("/api/v2/widgets/missing")
+    async def read_missing():
+        return JSONResponse({"error": "nope"}, status_code=404)
+
+    @app.get("/api/v2/events/stream")
+    async def stream():
+        return JSONResponse({"data": "would-be-sse"})
+
+    recorded = []
+
+    async def _fake_record(org_id, delta):
+        recorded.append((str(org_id), delta))
+
+    monkeypatch.setattr("app.services.au_metering.record_au_usage", AsyncMock(side_effect=_fake_record))
+    return app, recorded
+
+
+def test_agent_read_success_records_one_au(monkeypatch):
+    app, recorded = _build_app(monkeypatch, au_actor="agent")
+    client = TestClient(app)
+    resp = client.get("/api/v2/widgets")
+    assert resp.status_code == 200
+    assert recorded == [("11111111-1111-1111-1111-111111111111", 1)]
+
+
+def test_agent_write_success_records_five_au(monkeypatch):
+    app, recorded = _build_app(monkeypatch, au_actor="agent")
+    client = TestClient(app)
+    resp = client.post("/api/v2/widgets")
+    assert resp.status_code == 201
+    assert recorded == [("11111111-1111-1111-1111-111111111111", 5)]
+
+
+def test_agent_batch_write_uses_affected_entities_header(monkeypatch):
+    app, recorded = _build_app(monkeypatch, au_actor="agent")
+    client = TestClient(app)
+    resp = client.post("/api/v2/widgets/batch")
+    assert resp.status_code == 201
+    assert recorded == [("11111111-1111-1111-1111-111111111111", 35)], (
+        "X-Affected-Entities: 7 -> 5*7=35이어야 함"
+    )
+
+
+def test_human_traffic_never_counted(monkeypatch):
+    """doc §4.5 — 사람 웹 UI 작업은 0 AU."""
+    app, recorded = _build_app(monkeypatch, au_actor="human")
+    client = TestClient(app)
+    client.get("/api/v2/widgets")
+    client.post("/api/v2/widgets")
+    assert recorded == []
+
+
+def test_unauthenticated_traffic_never_counted(monkeypatch):
+    """au_actor가 아예 안 심긴(공개 엔드포인트 등) 경우도 세지 않는다."""
+    app, recorded = _build_app(monkeypatch, au_actor=None)
+    client = TestClient(app)
+    client.get("/api/v2/widgets")
+    assert recorded == []
+
+
+def test_failed_response_never_counted(monkeypatch):
+    """doc §4.5 — 인증 실패·유효성 실패·서버 5xx는 0 AU."""
+    app, recorded = _build_app(monkeypatch, au_actor="agent")
+    client = TestClient(app)
+    resp = client.get("/api/v2/widgets/missing")
+    assert resp.status_code == 404
+    assert recorded == []
+
+
+def test_streaming_path_never_counted(monkeypatch):
+    """SSE denylist — 정확 경로만(라우터 prefix 전체 아님)."""
+    app, recorded = _build_app(monkeypatch, au_actor="agent")
+    client = TestClient(app)
+    resp = client.get("/api/v2/events/stream")
+    assert resp.status_code == 200
+    assert recorded == []
+
+
+def test_metering_exception_never_breaks_the_response(monkeypatch):
+    """조건ⓐ(페드루 PO) — 계측 자체가 죽어도 응답은 절대 안 죽는다(fail-open)."""
+    app, _ = _build_app(monkeypatch, au_actor="agent")
+    monkeypatch.setattr(
+        "app.services.au_metering.record_au_usage",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    )
+    client = TestClient(app)
+    resp = client.get("/api/v2/widgets")
+    assert resp.status_code == 200, "계측 예외가 응답을 깨뜨림 — fail-open 조건 위반"

--- a/backend/tests/test_3173_au_metering_middleware.py
+++ b/backend/tests/test_3173_au_metering_middleware.py
@@ -1,8 +1,9 @@
 """story #3173(결제②-B) — AUMeteringMiddleware 판정 로직 회귀(실 DB 불요, record_au_usage
 자체는 모킹). 미들웨어가 «언제 세고 언제 안 세는지»·«응답 경로에서 분리됐는지»를 고정한다.
 
-⚠️페드루 PO 리뷰(PR#3579, 2026-08-28) — 계측 DB 왕복은 `asyncio.create_task`로 응답
-반환 밖에 던져진다(fire-and-forget, §6 설계). 그래서 여기는 sync `TestClient`가 아니라
+⚠️페드루 PO 리뷰(PR#3579, 2026-08-28) — 계측 DB 왕복은 `pg_pubsub.fire_and_forget()`
+(canonical GC-safe 헬퍼, main.py lifespan의 drain과 이미 연동)로 응답 반환 밖에
+던져진다(§6 설계). 그래서 여기는 sync `TestClient`가 아니라
 `httpx.AsyncClient`+`ASGITransport`로 같은 이벤트루프를 유지하고, 매 요청 뒤
 `_drain_background_tasks()`로 스케줄된 태스크가 실제로 끝나길 기다린 다음에야 assert한다
 — 안 그러면 백그라운드 태스크가 돌기도 전에 테스트 함수가 끝나 항상 거짓양성(비어있음)이 뜬다."""
@@ -107,11 +108,15 @@ async def test_metering_is_scheduled_as_background_task_not_awaited_inline(monke
 
 
 @pytest.mark.anyio
-async def test_spawned_task_is_strongly_referenced_until_done(monkeypatch):
-    """페드루 PO 리뷰(PR#3579) — `asyncio.create_task()`의 반환값을 안 잡아두면 이벤트루프가
-    약참조로만 들고 있어 완료 前 GC될 수 있다(ruff RUF006 클래스). `_spawn_background()`가
-    모듈 레벨 set에 강한 참조를 잡아뒀다가 완료 시에만 비우는지 직접 확認한다."""
+async def test_metering_task_uses_canonical_fire_and_forget(monkeypatch):
+    """페드루 PO 자인(PR#3579, 카디르 QA 적발) — 최초 델타가 GC 조기수거 처방을 모듈
+    로컬 `asyncio.create_task`+새 set으로 직접 재구현했다가, 이미 레포에 있던 canonical
+    헬퍼 `pg_pubsub.fire_and_forget()`(main.py lifespan의 `drain_background_tasks()`와
+    이미 연동된 바로 그 강한참조 세트)를 재사용하도록 정정됐다. 이 테스트는 au_metering이
+    독자적인 태스크 세트를 다시 만들지 않고 `pg_pubsub`의 세트를 그대로 쓰는지 직접
+    확認한다 — 재발 시(다시 로컬 set을 만들면) 이 assert가 곧바로 잡는다."""
     import app.services.au_metering as au_metering
+    from app.services import pg_pubsub
 
     release = asyncio.Event()
     started = asyncio.Event()
@@ -122,14 +127,16 @@ async def test_spawned_task_is_strongly_referenced_until_done(monkeypatch):
 
     monkeypatch.setattr(au_metering, "record_au_usage", AsyncMock(side_effect=_slow))
 
-    assert len(au_metering._background_tasks) == 0
-    au_metering._spawn_background(au_metering._record_au_usage_safe(uuid.uuid4(), 1))
+    before = len(pg_pubsub._background_tasks)
+    au_metering.fire_and_forget(au_metering._record_au_usage_safe(uuid.uuid4(), 1))
     await started.wait()
-    assert len(au_metering._background_tasks) == 1, "spawn 직후엔 강한 참조가 set에 있어야 함"
+    assert len(pg_pubsub._background_tasks) == before + 1, (
+        "au_metering이 pg_pubsub의 canonical 강한참조 세트를 쓰고 있어야 함"
+    )
 
     release.set()
     await _drain_background_tasks()
-    assert len(au_metering._background_tasks) == 0, "완료 후엔 done_callback이 discard해야 함"
+    assert len(pg_pubsub._background_tasks) == before, "완료 후엔 done_callback이 discard해야 함"
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_3173_record_au_usage_realdb.py
+++ b/backend/tests/test_3173_record_au_usage_realdb.py
@@ -1,0 +1,105 @@
+"""story #3173(결제②-B) — record_au_usage() 실PG 검증. 신규 행 생성 + 기존 행 원자적
+증분(같은 달 재호출 시 새 행이 아니라 current_value가 누적)을 확認한다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_org(session):
+    org_id = uuid.uuid4()
+    await session.execute(
+        text("INSERT INTO organizations (id, name, slug, plan) VALUES (:id, :name, :slug, 'free')"),
+        {"id": org_id, "name": f"test-org-{org_id}", "slug": f"slug-{org_id}"},
+    )
+    await session.commit()
+    return org_id
+
+
+@pytest.mark.anyio
+async def test_record_au_usage_creates_then_increments_same_period_row():
+    # au_metering.py가 `from app.core.database import async_session_factory`로 이름을
+    # 자기 모듈 네임스페이스에 바인딩해 두므로, 패치는 반드시 au_metering 모듈 자체의
+    # 속성을 갈아끼워야 한다(app.core.database 쪽을 바꿔봐야 이미 바인딩된 이름엔 무영향).
+    import app.services.au_metering as au_metering_module
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    original_factory = au_metering_module.async_session_factory
+    au_metering_module.async_session_factory = Session
+    try:
+        from app.services.au_metering import record_au_usage
+
+        async with Session() as session:
+            org_id = await _seed_org(session)
+        try:
+            await record_au_usage(org_id, 5)
+            await record_au_usage(org_id, 5)
+
+            async with Session() as session:
+                rows = (
+                    await session.execute(
+                        text(
+                            "SELECT meter_type, current_value FROM usage_meters "
+                            "WHERE org_id = :org_id"
+                        ),
+                        {"org_id": org_id},
+                    )
+                ).all()
+                assert len(rows) == 1, f"기간당 정확히 1행이어야 함 — {rows}"
+                assert rows[0][0] == "automation_units"
+                assert rows[0][1] == 10, "두 번 호출(5+5) 누적 안 됨 — 원자적 증분 실패"
+        finally:
+            async with Session() as session:
+                await session.execute(text("DELETE FROM usage_meters WHERE org_id = :org_id"), {"org_id": org_id})
+                await session.execute(text("DELETE FROM organizations WHERE id = :org_id"), {"org_id": org_id})
+                await session.commit()
+    finally:
+        au_metering_module.async_session_factory = original_factory
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_record_au_usage_zero_delta_is_noop():
+    import app.services.au_metering as au_metering_module
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    original_factory = au_metering_module.async_session_factory
+    au_metering_module.async_session_factory = Session
+    try:
+        from app.services.au_metering import record_au_usage
+
+        async with Session() as session:
+            org_id = await _seed_org(session)
+        try:
+            await record_au_usage(org_id, 0)
+            async with Session() as session:
+                count = (
+                    await session.execute(
+                        text("SELECT count(*) FROM usage_meters WHERE org_id = :org_id"),
+                        {"org_id": org_id},
+                    )
+                ).scalar_one()
+                assert count == 0
+        finally:
+            async with Session() as session:
+                await session.execute(text("DELETE FROM organizations WHERE id = :org_id"), {"org_id": org_id})
+                await session.commit()
+    finally:
+        au_metering_module.async_session_factory = original_factory
+        await engine.dispose()

--- a/backend/tests/test_c60dd33c_webhook_payload_gating.py
+++ b/backend/tests/test_c60dd33c_webhook_payload_gating.py
@@ -98,13 +98,20 @@ class _MockClient:
 
     async def post(self, url, content=None, headers=None):
         self._sink.append({"url": url, "body": content, "headers": headers or {}})
-        return MagicMock()
+        # story #3173 — _send_webhook_targets가 이제 resp.status_code를 실제로 읽는다
+        # (AU 계측 성공 판정). 실제 httpx.Response 모양으로 200을 명시.
+        resp = MagicMock()
+        resp.status_code = 200
+        return resp
 
 
 def _patches(sink):
     return [
         patch.object(wd.httpx, "AsyncClient", lambda *a, **k: _MockClient(sink)),
         patch.object(wd, "validate_webhook_url_async", new=AsyncMock()),
+        # story #3173 — AU 계측이 실제 DB 세션을 열려 하지 않도록 차단(이 테스트의 관심사는
+        # discord 변환+게이팅이지 AU 계측이 아님 — 그건 test_3173_* 파일들이 전담).
+        patch("app.services.au_metering.record_au_usage", new=AsyncMock()),
     ]
 
 


### PR DESCRIPTION
## Summary
[SID:3173]

doc `pricing-policy-proposal-v1` §4.5: AU는 **MCP/API(에이전트) 트래픽만** 잰다 — 사람
웹 UI 작업은 0(좌석이 이미 받음). 그라운딩(doc `au-metering-grounding-3173`) 결과
라우터 핸들러 939개 중 84개 파일이 응답형태가 제각각이라(공유 응답봉투 0) 공통 지점에서
가로채 계측할 기존 seam이 없었다 — ASGI 미들웨어 신설로 처방(84파일 개별배선은 신규
엔드포인트마다 잊는 재발기계라 기각, 페드루 PO 판정 3지점 조건부 승인).

## 변경
- `app/dependencies/auth.py`: `is_au_billable_agent()` SSOT 판별자 신설(`api_key_id`
  존재 AND `actor_type != "human"` — `_resolve_human_api_key`의 기존 `actor_type=human`
  예외 케이스를 에이전트로 오분류하면 스펙 위반). `get_current_user`가
  `request.state.au_actor`/`au_org_id`를 배선(소비처 주석 명시 — #3175 형제드리프트
  교훈 반영).
- `app/services/au_metering.py`(신규): `AUMeteringMiddleware`(CORS 옆 등록) — **fail-open**
  (계측 예외가 응답에 영향 0, 페드루 PO 조건ⓐ), 스트리밍 정확경로 2곳만 denylist
  (`/api/v2/events/stream`·`/api/v2/agent/stream` — 라우터 prefix 전체 아님, 같은 파일의
  다른 엔드포인트는 정상 계측 대상). `record_au_usage()` — usage_meters 원자적 upsert
  (`pg_advisory_xact_lock` org 단위 직렬화, feedback_check_then_insert_toctou 동형
  처방 — unique 제약 없는 기존 스키마 그대로 사용).
- 웹훅 성공 전달 1AU(§4.5) — `webhook_dispatch.py`(org webhook)·`notification_dispatch.py`
  (개인 webhook) 양쪽 성공 콜백에 배선(`org_id` 선택 인자, 없으면 계측 생략 — 하위호환
  무회귀).

## ⛔Phase 1 필수 보완 (격상 — "알려진 한계"가 아니라 후속 스토리 #3176 착수 前 블로커)
스토리 본문·코드 주석(`au_metering.py` docstring) 양쪽에 등재:
1. 배치 쓰기는 엔티티 1개(5AU) 기본값 — 진짜 배치 엔드포인트는 `X-Affected-Entities`
   헤더 옵트인해야 정확(지금 0곳 배선).
2. 읽기 "100개 초과 목록 +1/100개" 규칙 미구현.
3. 성공 응답이 클라이언트에 못 닿고 재시도되는 경우 멱등키 부재로 이중계상 가능
   (Phase 2: idempotency-key 도입 필요성 재평가).

한도 «집행»(대조·차단/경고)은 [\[결제②-C\]](entity:story:20afb368-389a-449d-b5e7-59717d02e4a9)로 분리 등재(페드루 PO 판정) — 이 PR은 레코딩 축만.

## Evidence
- `is_au_billable_agent()` 회귀 4케이스(페드루 PO §2 조건) — 사람 개인키(`hu_live_*`
  실제 claims 형태)·에이전트키·방어적 혼합(api_key_id+actor_type=human)·일반 사람JWT.
- 미들웨어 8케이스 — agent 읽기(1AU)/쓰기(5AU)/배치헤더(5×N)·사람 트래픽 0건·미인증
  0건·실패응답 0건·스트리밍 denylist·**계측 예외가 응답을 안 깨뜨림(fail-open, 조건ⓐ)**.
- 실PG 뮤테이션 — `record_au_usage()` 신규행 생성+같은 기간 재호출 원자적 누적(5+5=10)
  확認, delta=0 no-op.
- 기존 회귀 85건(auth·웹훅게이팅·개인웹훅·워커풀) green — `_send_webhook_targets`가
  이제 `resp.status_code`를 실제로 읽어 기존 mock fixture 3건 보강 필요(`MagicMock()`이
  status_code 비교를 지원 안 해 TypeError → 실제 httpx.Response 모양으로 200 명시 +
  AU 계측이 실 DB를 안 열도록 `record_au_usage` 목킹 추가).

## Test plan
- [ ] CI: 관련 pytest 전량 green
- [ ] 카디르 QA
- [ ] #3176(집행) 착수 前 위 필수 보완 3건 처리 확認

🤖 Generated with [Claude Code](https://claude.com/claude-code)