### PR TITLE
fix(#3174): MCP_ALLOWED_TOKEN_REFS 미설정=fail-open → fail-closed 재설계

### DIFF
--- a/apps/web/src/lib/mcp-secrets.test.ts
+++ b/apps/web/src/lib/mcp-secrets.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+
+import { listAllowedMcpTokenRefs, mcpTokenRefSchema, resolveMcpTokenRef } from './mcp-secrets';
+
+/**
+ * story #3174(보안·EE) — MCP_ALLOWED_TOKEN_REFS 미설정 시 fail-open(빈 allowlist=무제한
+ * 허용)이던 기본값을 fail-closed로 정정. 도입 커밋(0fa2c8d42)의 원 테스트가 성공 케이스
+ * 마다 매번 MCP_ALLOWED_TOKEN_REFS를 명시로 채워 시험했음에도 정작 라이브러리 코드는
+ * "미설정=허용"으로 짜여 있던 drift — 그 drift를 값으로 고정한다.
+ *
+ * AC3 회귀 3종: 빈/미설정=거부(신규 처방 실증) · 등재=허용(기존 동작 무회귀) ·
+ * 미등재=거부(기존에도 있던 동작, 재확認).
+ */
+describe('resolveMcpTokenRef', () => {
+  const env = (overrides: Record<string, string | undefined>): NodeJS.ProcessEnv =>
+    ({ ...overrides }) as NodeJS.ProcessEnv;
+
+  it('AC3① — MCP_ALLOWED_TOKEN_REFS 미설정이면 실제 토큰이 존재해도 거부한다(fail-closed)', () => {
+    expect(() =>
+      resolveMcpTokenRef('MCP_TOKEN_DOCS', env({ MCP_TOKEN_DOCS: 'secret-value' })),
+    ).toThrow('token_ref_not_allowlisted: MCP_TOKEN_DOCS');
+  });
+
+  it('AC3① — MCP_ALLOWED_TOKEN_REFS가 빈 문자열이어도 거부한다', () => {
+    expect(() =>
+      resolveMcpTokenRef(
+        'MCP_TOKEN_DOCS',
+        env({ MCP_TOKEN_DOCS: 'secret-value', MCP_ALLOWED_TOKEN_REFS: '' }),
+      ),
+    ).toThrow('token_ref_not_allowlisted: MCP_TOKEN_DOCS');
+  });
+
+  it('AC3② — 등재된 ref는 여전히 허용된다(무회귀)', () => {
+    const token = resolveMcpTokenRef(
+      'MCP_TOKEN_DOCS',
+      env({ MCP_TOKEN_DOCS: 'secret-value', MCP_ALLOWED_TOKEN_REFS: 'MCP_TOKEN_DOCS' }),
+    );
+    expect(token).toBe('secret-value');
+  });
+
+  it('AC3② — 콤마로 여러 건 등재된 목록 중 하나만 요청해도 허용된다', () => {
+    const token = resolveMcpTokenRef(
+      'MCP_TOKEN_B',
+      env({
+        MCP_TOKEN_B: 'b-value',
+        MCP_ALLOWED_TOKEN_REFS: 'MCP_TOKEN_A, MCP_TOKEN_B ,MCP_TOKEN_C',
+      }),
+    );
+    expect(token).toBe('b-value');
+  });
+
+  it('AC3③ — 미등재 ref는 allowlist가 비어있지 않아도 거부된다(기존 동작 유지)', () => {
+    expect(() =>
+      resolveMcpTokenRef(
+        'MCP_TOKEN_OTHER',
+        env({ MCP_TOKEN_OTHER: 'x', MCP_ALLOWED_TOKEN_REFS: 'MCP_TOKEN_DOCS' }),
+      ),
+    ).toThrow('token_ref_not_allowlisted: MCP_TOKEN_OTHER');
+  });
+
+  it('네임스페이스 규제 — MCP_TOKEN_ 접두 아닌 값(예: SUPABASE_SERVICE_ROLE_KEY)은 allowlist 등재 여부와 무관하게 거부', () => {
+    expect(() =>
+      resolveMcpTokenRef(
+        'SUPABASE_SERVICE_ROLE_KEY',
+        env({
+          SUPABASE_SERVICE_ROLE_KEY: 'leak-me',
+          MCP_ALLOWED_TOKEN_REFS: 'SUPABASE_SERVICE_ROLE_KEY',
+        }),
+      ),
+    ).toThrow(/invalid_token_ref_namespace/);
+  });
+
+  it('등재+네임스페이스 통과했지만 실제 env 값이 없으면 missing_token_ref', () => {
+    expect(() =>
+      resolveMcpTokenRef('MCP_TOKEN_DOCS', env({ MCP_ALLOWED_TOKEN_REFS: 'MCP_TOKEN_DOCS' })),
+    ).toThrow('missing_token_ref: MCP_TOKEN_DOCS');
+  });
+});
+
+describe('listAllowedMcpTokenRefs', () => {
+  it('미설정/빈 문자열 → 빈 배열', () => {
+    expect(listAllowedMcpTokenRefs(undefined)).toEqual([]);
+    expect(listAllowedMcpTokenRefs('')).toEqual([]);
+    expect(listAllowedMcpTokenRefs('   ')).toEqual([]);
+  });
+
+  it('콤마 분리+공백 제거+중복 제거', () => {
+    expect(listAllowedMcpTokenRefs('MCP_TOKEN_A, MCP_TOKEN_B ,MCP_TOKEN_A')).toEqual([
+      'MCP_TOKEN_A',
+      'MCP_TOKEN_B',
+    ]);
+  });
+});
+
+describe('mcpTokenRefSchema', () => {
+  it('MCP_TOKEN_ 네임스페이스만 통과', () => {
+    expect(mcpTokenRefSchema.safeParse('MCP_TOKEN_DOCS').success).toBe(true);
+    expect(mcpTokenRefSchema.safeParse('SUPABASE_SERVICE_ROLE_KEY').success).toBe(false);
+    expect(mcpTokenRefSchema.safeParse('').success).toBe(false);
+  });
+});

--- a/apps/web/src/lib/mcp-secrets.ts
+++ b/apps/web/src/lib/mcp-secrets.ts
@@ -15,8 +15,15 @@ export function resolveMcpTokenRef(tokenRef: string, env: NodeJS.ProcessEnv = pr
     throw new Error(`invalid_token_ref_namespace: ${tokenRef}`);
   }
 
+  // story #3174 — 이전엔 `allowlist.length > 0 && ...`라 MCP_ALLOWED_TOKEN_REFS가
+  // 미설정/빈 문자열이면 이 검사 자체가 통째로 스킵됐다(fail-open — 다른 baseline
+  // 항목들과 위험 방향이 반대). 도입 커밋(0fa2c8d42, "restrict external mcp token
+  // refs")의 자기 테스트 전부가 성공 케이스마다 MCP_ALLOWED_TOKEN_REFS를 명시로
+  // 채워서 시험했다 — "미설정=허용"을 의도해서 검증한 흔적이 0건이었다(스캐폴딩
+  // 단계에서 배선을 미루다 잠긴 gap으로 판단). allowlist가 정본이므로 비어 있으면
+  // "아무것도 허용 안 함"이 안전측 — 값을 채워야만 통과한다.
   const allowlist = listAllowedMcpTokenRefs(env.MCP_ALLOWED_TOKEN_REFS);
-  if (allowlist.length > 0 && !allowlist.includes(tokenRef)) {
+  if (!allowlist.includes(tokenRef)) {
     throw new Error(`token_ref_not_allowlisted: ${tokenRef}`);
   }
 


### PR DESCRIPTION
## Summary
[SID:3174]

`resolveMcpTokenRef()`가 `allowlist.length > 0 && !allowlist.includes(tokenRef)`로
검사해, `MCP_ALLOWED_TOKEN_REFS`가 미설정/빈 문자열이면 이 검사 자체가 통째로
스킵됐다(빈 allowlist=무제한 허용) — `infra/manual-env-allowlist.yml`의 다른 baseline
항목들(전부 fail-closed)과 위험 방향이 반대였다(story #3168 triage 중 발견).

## 판별 (착수 前 이력 확認)
도입 커밋(`0fa2c8d42`, "fix(SID:455): restrict external mcp token refs")의 원 테스트를
전수 대조 — 성공 케이스마다 예외 없이 `process.env.MCP_ALLOWED_TOKEN_REFS`를 명시로
채워서 시험했다("미설정=허용"을 의도해서 검증한 흔적 0건). "미설정=무제한"은 설계
의도가 아니라 스캐폴딩 단계에서 값 배선을 미루다 잠긴 채 방치된 gap으로 판단 —
⓪정공(기본값 fail-closed 전환)으로 간다.

## 처방
`allowlist.length > 0 &&` 조건 제거 — allowlist가 비어 있으면 무조건
`token_ref_not_allowlisted`. 네임스페이스 정규식(`MCP_TOKEN_` 접두)이 이미 1차
방어선(임의 env var 접근 자체는 이 값과 무관하게 항상 차단)이었고, 이 fail-closed
전환은 2차 방어선(등록된 `MCP_TOKEN_*` 중에서도 명시 승인분만) 정합을 맞춘다.

## ⚠️ 미완 — 실 라이브 값 배선은 이 세션 권한 밖
IaC 실측(`cloudbuild.yaml`·GHA workflow·`infra/cloudbuild-secret-manifest.txt`) —
`MCP_TOKEN_*`·`MCP_ALLOWED_TOKEN_REFS` 어디에도 배선 0건. `mcp_servers`(project
ai-settings) 설정은 프론트 직결 Supabase 저장이라(백엔드 model 0건) 실제 라이브 사용
여부는 이 세션 권한 밖(Supabase 크리덴셜 없음) — "값 채우기" 축은 미착수. **있다면
이 fix 착지 즉시 그 프로젝트의 외부 MCP 연동이 막힌다**(의도된 fail-closed지만
PO/product의 라이브 확認 필요).

## Evidence
- `apps/web/src/lib/mcp-secrets.test.ts`(신규, 10건): 미설정/빈문자열=거부(신규 처방
  실증, 실제 토큰 존재해도)·등재=허용(무회귀, 콤마 다건 포함)·미등재=거부(기존 동작
  재확認)+네임스페이스 규제 재확認+`listAllowedMcpTokenRefs` 파싱(콤마/공백/중복).
- `vitest run` 10/10 green, `tsc --noEmit` 0 에러.

## Test plan
- [ ] CI: 관련 vitest/tsc/lint green
- [ ] 카디르 QA
- [ ] PO/product가 dev·prod 라이브 `mcp_servers` 설정에 실제 외부 MCP 연동이 있는지
      확認(Supabase 직접 조회 — 이 세션 권한 밖)

🤖 Generated with [Claude Code](https://claude.com/claude-code)