### PR TITLE
[SID:3177] S3a Chat 허브 「지금」 스트립 — attention 7종 흡수

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3473,6 +3473,13 @@
     "authFailureTooltipInvalid": "API key not recognized · {n} failures in last 5 min"
   },
   "chats": {
+    "nowStripLabel": "Now",
+    "nowStripCount": "· {count}",
+    "nowStripCollapse": "Collapse",
+    "nowStripExpand": "Expand",
+    "nowStripGroupDanger": "Action needed",
+    "nowStripGroupWarn": "Attention",
+    "nowStripGroupInfo": "Observe · Learn",
     "reportViewFull": "View full →",
     "reportCollapse": "Collapse",
     "reportEvidenceLabel": "Evidence",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3473,6 +3473,13 @@
     "authFailureTooltipInvalid": "API 키 인식 불가 · 최근 5분 {n}회"
   },
   "chats": {
+    "nowStripLabel": "지금",
+    "nowStripCount": "· {count}건",
+    "nowStripCollapse": "접기",
+    "nowStripExpand": "펼치기",
+    "nowStripGroupDanger": "행동 필요",
+    "nowStripGroupWarn": "주의",
+    "nowStripGroupInfo": "관찰 · 학습",
     "reportViewFull": "전문 보기 →",
     "reportCollapse": "접기",
     "reportEvidenceLabel": "근거",

--- a/apps/web/scripts/handrolled-card-baseline.json
+++ b/apps/web/scripts/handrolled-card-baseline.json
@@ -1,7 +1,9 @@
 {
   "_comment": [
     "story #3164(DS 게이트 키스톤) grandfather baseline — 이 가드 첫 도입 시점 develop의 기존 손코딩 카드.",
-    "마이그레이션 대상 아님 — 이 게이트는 \"더 늘지 않는다\"만 보장한다(freeze, 개별 수리는 후속 표면 리팩터 판)."
+    "마이그레이션 대상 아님 — 이 게이트는 \"더 늘지 않는다\"만 보장한다(freeze, 개별 수리는 후속 표면 리팩터 판).",
+    "story #3177(S3a) AC5 순감소 — action-zone.tsx 5건→0건(cardVariants() cva 호출로 전환, 이",
+    "스토리가 그 파일을 건드리며 실측 제거). 269키 → 264키."
   ],
   "keys": [
     "app/(authenticated)/[ws]/[proj]/docs/docs-client-layout.tsx::mx-2 mt-1.5 space-y-1.5 rounded-lg border border-border bg-card p-2",
@@ -105,11 +107,6 @@
     "components/chat/message-context-menu.tsx::fixed z-50 min-w-[160px] overflow-hidden rounded-lg border border-border bg-popover py-1 shadow-[var(--elev-overlay)]",
     "components/chat/sender-profile-popover.tsx::fixed z-50 min-w-[200px] overflow-hidden rounded-lg border border-border bg-popover py-2 shadow-[var(--elev-overlay)]",
     "components/dashboard/activation-checklist-banner.tsx::flex w-full items-center justify-between gap-2 rounded-lg border border-border bg-muted/50 px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted",
-    "components/dashboard/command-center/action-zone.tsx::flex items-center gap-2 rounded-lg border border-border bg-card p-2.5 text-xs text-muted-foreground transition hover:border-muted-foreground/30",
-    "components/dashboard/command-center/action-zone.tsx::flex items-center gap-2 rounded-lg border border-l-2 border-border bg-card p-2.5 text-xs transition hover:border-muted-foreground/30  ",
-    "components/dashboard/command-center/action-zone.tsx::flex items-center gap-2 rounded-lg border border-l-2 border-dashed border-border bg-card p-2.5 text-xs text-muted-foreground",
-    "components/dashboard/command-center/action-zone.tsx::flex items-start gap-2 rounded-lg border border-border bg-card p-2.5 text-xs",
-    "components/dashboard/command-center/action-zone.tsx::space-y-3 rounded-xl border border-border bg-card/40 p-3",
     "components/dashboard/command-center/overview-zone.tsx::space-y-4 rounded-xl border border-border bg-card/40 p-3",
     "components/docs/doc-assignee-control.tsx::absolute right-0 top-full z-50 mt-1 w-72 rounded-lg border border-border bg-popover p-2 shadow-[var(--elev-overlay)]",
     "components/docs/doc-content-renderer.tsx::[&_pre]:overflow-x-auto [&_pre]:rounded-xl [&_pre]:border [&_pre]:border-border [&_pre]:bg-muted [&_pre]:text-foreground [&_pre]:p-4 [&_pre]:text-xs [&_pre]:leading-6",

--- a/apps/web/scripts/raw-button-baseline.json
+++ b/apps/web/scripts/raw-button-baseline.json
@@ -1,7 +1,9 @@
 {
   "_comment": [
     "story #3164(DS 게이트 키스톤) grandfather baseline — 이 가드 첫 도입 시점 develop의 기존 raw <button>.",
-    "마이그레이션 대상 아님 — 이 게이트는 \"더 늘지 않는다\"만 보장한다(freeze, 개별 수리는 후속 표면 리팩터 판)."
+    "마이그레이션 대상 아님 — 이 게이트는 \"더 늘지 않는다\"만 보장한다(freeze, 개별 수리는 후속 표면 리팩터 판).",
+    "story #3177(S3a) AC5 순감소 — chat-list-view.tsx 4건→0건(<Button> 전환, 이 스토리가 그 파일을",
+    "건드리며 실측 제거). 186f/511occ → 185f/507occ."
   ],
   "counts": {
     "app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx": 3,
@@ -67,7 +69,6 @@
     "components/chat/attachment-media.tsx": 2,
     "components/chat/chat-bubble.tsx": 4,
     "components/chat/chat-input.tsx": 6,
-    "components/chat/chat-list-view.tsx": 4,
     "components/chat/chat-view.tsx": 4,
     "components/chat/citation-compose-bar.tsx": 2,
     "components/chat/delivery-contract-modal.tsx": 2,

--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -11,6 +11,11 @@ import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { ChatListView } from './chat-list-view';
 
+// story #3177(S3a) — ChatListView가 이제 NowStrip을 항상 마운트한다. 이 테스트의 관심사는
+// 대화 목록 자체(SSE/아바타/URL 조립)라 NowStrip의 전역 RefreshContext 폴링 배선까지
+// 실 provider로 끌고 오지 않는다(useChatSse와 동일 관례 — 교차관심사 훅은 no-op mock).
+vi.mock('@/hooks/use-auto-refresh', () => ({ useAutoRefresh: () => {} }));
+
 const { useDashboardContextMock, pushMock } = vi.hoisted(() => ({
   useDashboardContextMock: vi.fn(),
   pushMock: vi.fn(),

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -11,6 +11,8 @@ import { useChatSse, type SseConversationReadPayload } from '@/hooks/use-chat-ss
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { queuePendingToast } from './cross-project-toast-provider';
 import { Avatar } from '@/components/shared/avatar';
+import { Button } from '@/components/ui/button';
+import { NowStrip } from './now-strip';
 
 import { fetchWithAuth } from '@/lib/db/client';
 
@@ -173,10 +175,11 @@ function ConversationRow({
   ) : null;
 
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
       onClick={onClick}
-      className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-muted/60 active:bg-muted"
+      className="h-auto w-full items-center justify-start gap-3 rounded-lg px-3 py-2.5 text-left font-normal transition hover:bg-muted/60 active:bg-muted"
     >
       {/* story #2968 — 1:1(DM·agent 탭)은 avatar.tsx 정본으로 실사진(3단 폴백은 그 컴포넌트
           책임). group은 특정 1인 사진이 의미가 없어(다인원) 기존 아이콘 자리를 유지한다. */}
@@ -213,7 +216,7 @@ function ConversationRow({
           )}
         </div>
       </div>
-    </button>
+    </Button>
   );
 }
 
@@ -241,10 +244,11 @@ function OutsideProjectRow({
       : conv.type === 'dm' ? t('dmWith') : t('groupSection'));
 
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
       onClick={onClick}
-      className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-muted/60 active:bg-muted"
+      className="h-auto w-full items-center justify-start gap-3 rounded-lg px-3 py-2.5 text-left font-normal transition hover:bg-muted/60 active:bg-muted"
     >
       <div className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full text-sm font-medium ${
         conv.type === 'dm' ? 'bg-primary/15 text-primary' : 'bg-info/15 text-info'
@@ -257,7 +261,7 @@ function OutsideProjectRow({
         {/* ⭐AC③ — 프로젝트명 병기("왜 여기 있지"를 그 자리서 답한다) */}
         <p className="truncate text-xs text-muted-foreground">{conv.project_name}</p>
       </div>
-    </button>
+    </Button>
   );
 }
 
@@ -507,14 +511,15 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
         </div>
       )}
       {conversations.length < myTotal && (
-        <button
+        <Button
           type="button"
+          variant="ghost"
           onClick={() => { setLoadingMore(true); void fetchConversations(myOffset, true); }}
           disabled={loadingMore}
-          className="w-full rounded-lg py-2 text-xs text-muted-foreground transition hover:text-foreground disabled:opacity-50"
+          className="h-auto w-full rounded-lg py-2 text-xs font-normal text-muted-foreground transition hover:text-foreground disabled:opacity-50"
         >
           {loadingMore ? '불러오는 중…' : `더 보기 (${myTotal - conversations.length}건)`}
-        </button>
+        </Button>
       )}
     </div>
   );
@@ -552,19 +557,25 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
         <ConversationRow key={conv.id} conv={conv} currentMemberId={currentTeamMemberId} isAgentConv onClick={() => router.push(`/chats/${conv.id}`)} />
       ))}
       {allConversations.length < agentTotal && (
-        <button
+        <Button
           type="button"
+          variant="ghost"
           onClick={() => void fetchAllConversations(agentOffset, true)}
-          className="w-full rounded-lg py-2 text-xs text-muted-foreground transition hover:text-foreground"
+          className="h-auto w-full rounded-lg py-2 text-xs font-normal text-muted-foreground transition hover:text-foreground"
         >
           더 보기 ({agentTotal - allConversations.length}건)
-        </button>
+        </Button>
       )}
     </div>
   );
 
   return (
     <div className="flex h-full flex-col">
+      {/* story #3177(S3a) — chat 구심점 최상단 고정 「지금」 스트립(대화 스크롤과 분리,
+          훑기 밀도 보존). Tabs 밖에 둔다 — my/agent 탭 전환과 무관하게 항상 상단 고정. */}
+      <div className="px-2 pt-2">
+        <NowStrip />
+      </div>
       {isAdminOrOwner ? (
         <Tabs defaultValue="my" onValueChange={(v) => { if (v === 'agent') loadAgentConversationsOnce(); }} className="flex min-h-0 flex-1 flex-col">
           <TabsList className="mx-4 mt-2 w-auto self-start">

--- a/apps/web/src/components/chat/derive-now-strip.test.ts
+++ b/apps/web/src/components/chat/derive-now-strip.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import type { useTranslations } from 'next-intl';
+import type { AttentionItem } from '@/components/dashboard/command-center/types';
+import {
+  normalizeSeverity,
+  nowStripItemKey,
+  nowStripItemHref,
+  buildNowStripItems,
+  summarizeSeverity,
+} from './derive-now-strip';
+
+// story #3177(S3a) — 스텁 번역기(내용은 action-zone.test.tsx가 이미 attentionDetailText로
+// 잰다, 여기선 derive-now-strip 자신의 로직만: 정렬·key·href·severity 정규화·요약). next-intl
+// 번역기 실 타입(rich/markup/raw/has)은 이 순수함수 유닛테스트 관심사가 아니라 캐스트로
+// 좁힌다.
+const t = ((key: string, values?: Record<string, string | number>) =>
+  values ? `${key}(${JSON.stringify(values)})` : key) as unknown as ReturnType<typeof useTranslations>;
+
+const AGENT_STUCK: AttentionItem = {
+  type: 'agent_stuck',
+  severity: 'warn',
+  auto_detected: true,
+  entity_type: 'story',
+  entity_id: 's-1',
+  gate_type: 'merge',
+  stuck_since: '2026-08-20T00:00:00Z',
+};
+
+const AGENT_AUTH_FAILURE: AttentionItem = {
+  type: 'agent_auth_failure',
+  severity: 'danger',
+  auto_detected: true,
+  member_id: 'm-1',
+  reason: 'revoked',
+  failure_count: 3,
+  first_failed_at: null,
+  last_failed_at: null,
+};
+
+const UNANSWERED_BLOCKER: AttentionItem = {
+  type: 'unanswered_blocker',
+  severity: 'warn',
+  auto_detected: true,
+  blocked_story_id: 'story-2',
+  blocker_id: 'story-3',
+  blocked_story_title: '온보딩 완주 체크',
+  age_days: 5,
+  project_id: 'p-1',
+};
+
+const HYPOTHESIS_FALSIFIED: AttentionItem = {
+  type: 'hypothesis_falsified',
+  severity: 'info',
+  auto_detected: true,
+  hypothesis_id: 'h-1',
+  statement: '가입 전환율 개선 가설',
+  outcome_result: null,
+  falsified_days: 3,
+  superseded_by_hypothesis_id: null,
+  project_id: 'p-1',
+};
+
+const LOOP_OVERDUE_HYPOTHESIS: AttentionItem = {
+  type: 'loop_overdue_hypothesis',
+  severity: 'warn',
+  auto_detected: true,
+  hypothesis_id: 'h-2',
+  statement: '리텐션 D7 가설',
+  owner_member_id: null,
+  overdue_days: 4,
+  project_id: 'p-1',
+};
+
+const LOOP_OVERDUE_GOAL: AttentionItem = {
+  type: 'loop_overdue_goal',
+  severity: 'warn',
+  auto_detected: true,
+  goal_id: 'g-1',
+  title: '가입 전환율 개선',
+  owner_member_id: null,
+  overdue_days: 10,
+  project_id: 'p-1',
+};
+
+const LOOP_OUTCOME_MISSING_GOAL: AttentionItem = {
+  type: 'loop_outcome_missing_goal',
+  severity: 'warn',
+  auto_detected: true,
+  goal_id: 'g-2',
+  title: '온보딩 완주율',
+  owner_member_id: null,
+  done_days: 7,
+  project_id: 'p-1',
+};
+
+const ALL_SEVEN = [
+  AGENT_STUCK,
+  AGENT_AUTH_FAILURE,
+  UNANSWERED_BLOCKER,
+  HYPOTHESIS_FALSIFIED,
+  LOOP_OVERDUE_HYPOTHESIS,
+  LOOP_OVERDUE_GOAL,
+  LOOP_OUTCOME_MISSING_GOAL,
+];
+
+describe('normalizeSeverity — no-fiction: 모르는 값은 info로 가라앉힌다(danger를 지어내지 않음)', () => {
+  it.each(['danger', 'warn', 'info'] as const)('%s는 그대로 통과한다', (s) => {
+    expect(normalizeSeverity(s)).toBe(s);
+  });
+
+  it('모르는 문자열은 info로 떨어진다', () => {
+    expect(normalizeSeverity('critical')).toBe('info');
+    expect(normalizeSeverity('')).toBe('info');
+  });
+});
+
+describe('nowStripItemKey — 7종 각자 안정 key(SID 3150 회귀 금지, generic entity_id 미의존)', () => {
+  it('7종 전부 고유하고 안정적인 key를 만든다', () => {
+    const keys = ALL_SEVEN.map(nowStripItemKey);
+    expect(new Set(keys).size).toBe(7);
+    expect(keys).toContain('agent_stuck-s-1');
+    expect(keys).toContain('agent_auth_failure-m-1');
+    expect(keys).toContain('unanswered_blocker-story-2');
+    expect(keys).toContain('hypothesis_falsified-h-1');
+    expect(keys).toContain('loop_overdue_hypothesis-h-2');
+    expect(keys).toContain('loop_overdue_goal-g-1');
+    expect(keys).toContain('loop_outcome_missing_goal-g-2');
+  });
+});
+
+describe('nowStripItemHref — §1a 링크 대상(원탭 도달)', () => {
+  it('agent_stuck(entity_type=story)은 보드로', () => {
+    expect(nowStripItemHref(AGENT_STUCK)).toBe('/board?story=s-1');
+  });
+
+  it('agent_stuck(entity_type≠story, 예: epic)은 게이트 인박스로(제네릭 폴백)', () => {
+    expect(nowStripItemHref({ ...AGENT_STUCK, entity_type: 'epic' })).toBe('/inbox?tab=gates');
+  });
+
+  it('agent_auth_failure는 워크포스 멤버 상세로', () => {
+    expect(nowStripItemHref(AGENT_AUTH_FAILURE)).toBe('/organization/workforce/m-1');
+  });
+
+  it('unanswered_blocker는 차단 스토리 보드로', () => {
+    expect(nowStripItemHref(UNANSWERED_BLOCKER)).toBe('/board?story=story-2');
+  });
+
+  it('hypothesis 2종(falsified/overdue)은 전용 상세 페이지가 없어(embed-card.tsx 실측) /flow로', () => {
+    expect(nowStripItemHref(HYPOTHESIS_FALSIFIED)).toBe('/flow');
+    expect(nowStripItemHref(LOOP_OVERDUE_HYPOTHESIS)).toBe('/flow');
+  });
+
+  it('goal 2종(overdue/outcome-missing)은 /goals/[id]로', () => {
+    expect(nowStripItemHref(LOOP_OVERDUE_GOAL)).toBe('/goals/g-1');
+    expect(nowStripItemHref(LOOP_OUTCOME_MISSING_GOAL)).toBe('/goals/g-2');
+  });
+});
+
+describe('buildNowStripItems — severity 정렬(danger→warn→info)', () => {
+  it('입력 순서와 무관하게 danger가 먼저, info가 마지막에 온다', () => {
+    const items = buildNowStripItems(ALL_SEVEN, t);
+    expect(items).toHaveLength(7);
+    const severities = items.map((i) => i.severity);
+    const firstInfoIdx = severities.indexOf('info');
+    const lastDangerIdx = severities.lastIndexOf('danger');
+    const firstWarnIdx = severities.indexOf('warn');
+    expect(lastDangerIdx).toBeLessThan(firstWarnIdx === -1 ? Infinity : firstWarnIdx);
+    expect(firstWarnIdx === -1 || firstWarnIdx < firstInfoIdx || firstInfoIdx === -1).toBe(true);
+    expect(severities[0]).toBe('danger'); // AGENT_AUTH_FAILURE(유일한 danger)가 앞으로.
+  });
+
+  it('resolveName/epicTitles를 안 넘겨도 no-fiction 폴백(entity_type)으로 죽지 않는다', () => {
+    const items = buildNowStripItems([AGENT_STUCK], t);
+    expect(items[0]!.title).toBe('story'); // resolveName 없음 → entity_type 폴백.
+  });
+
+  it('agent_stuck 라벨은 resolveName이 있으면 그걸 우선한다(action-zone.tsx attentionEntityLabel 재사용 증거)', () => {
+    const items = buildNowStripItems([AGENT_STUCK], t, (id) => (id === 's-1' ? '온보딩 완주 체크' : null));
+    expect(items[0]!.title).toBe('온보딩 완주 체크');
+  });
+
+  it('빈 배열이면 빈 배열을 낸다', () => {
+    expect(buildNowStripItems([], t)).toEqual([]);
+  });
+});
+
+describe('summarizeSeverity — collapsed 「지금 N」 정직 카운트', () => {
+  it('7종(danger 1·warn 5·info 1)을 정확히 센다', () => {
+    const items = buildNowStripItems(ALL_SEVEN, t);
+    expect(summarizeSeverity(items)).toEqual({ danger: 1, warn: 5, info: 1, total: 7 });
+  });
+
+  it('빈 목록은 전부 0', () => {
+    expect(summarizeSeverity([])).toEqual({ danger: 0, warn: 0, info: 0, total: 0 });
+  });
+});

--- a/apps/web/src/components/chat/derive-now-strip.ts
+++ b/apps/web/src/components/chat/derive-now-strip.ts
@@ -1,0 +1,121 @@
+/**
+ * story #3177(S3a·SID 3177) — chat 구심점 상단 고정 「지금」 스트립. command-center attention
+ * 7종을 chat 임베드 카드로 흡수한다. AC 뼈 = doc 「S3 와이어 심화」§1(entity:doc:14bf3247-
+ * ae2f-49d0-92b0-986e8902d00a). BE 계약(PO 확定 2026-08-28) — 신규 BE 0, 기존
+ * `GET /api/dashboard/my-actions`(attention.items) 그대로 재사용.
+ *
+ * ⚠️ SID 3150(58건 공백 렌더) 회귀 금지 — 7종 중 6종은 entity_id/entity_type이 없다
+ * (types.ts AttentionItem 주석). 이 파일은 generic entity_id에 의존하지 않고 §1a 표의
+ * 타입별 «라벨 근거 필드»만 쓴다 — action-zone.tsx의 attentionEntityLabel/attentionDayCount/
+ * attentionDetailText를 그대로 재사용한다(두 벌 금지, §1b).
+ *
+ * BE가 attention 종을 늘리면 이 파일도 함께 고쳐야 한다(3곳 동기화 경계: types.ts +
+ * action-zone.tsx attentionEntityLabel/attentionDayCount + 이 파일의 href/icon 매핑).
+ */
+import type { useTranslations } from 'next-intl';
+import type { AttentionItem } from '@/components/dashboard/command-center/types';
+import { attentionEntityLabel, attentionDetailText } from '@/components/dashboard/command-center/action-zone';
+
+export type NowStripSeverity = 'danger' | 'warn' | 'info';
+
+// BE severity(자유 문자열)를 렌더 가능한 3종으로 좁힌다 — 모르는 값은 no-fiction 원칙상
+// 가장 눈에 덜 띄는 info로 가라앉힌다(위조로 danger를 지어내지 않는다).
+const KNOWN_SEVERITIES = new Set<NowStripSeverity>(['danger', 'warn', 'info']);
+export function normalizeSeverity(raw: string): NowStripSeverity {
+  return (KNOWN_SEVERITIES.has(raw as NowStripSeverity) ? raw : 'info') as NowStripSeverity;
+}
+
+const SEVERITY_RANK: Record<NowStripSeverity, number> = { danger: 0, warn: 1, info: 2 };
+
+/** attention item의 안정 key — 7종 각자 id 필드명이 달라(action-zone.tsx attentionItemKey와
+ * 동형 문제) 타입별로 뽑는다. */
+export function nowStripItemKey(item: AttentionItem): string {
+  switch (item.type) {
+    case 'agent_stuck': return `agent_stuck-${item.entity_id}`;
+    case 'agent_auth_failure': return `agent_auth_failure-${item.member_id}`;
+    case 'unanswered_blocker': return `unanswered_blocker-${item.blocked_story_id}`;
+    case 'hypothesis_falsified': return `hypothesis_falsified-${item.hypothesis_id}`;
+    case 'loop_overdue_hypothesis': return `loop_overdue_hypothesis-${item.hypothesis_id}`;
+    case 'loop_overdue_goal': return `loop_overdue_goal-${item.goal_id}`;
+    case 'loop_outcome_missing_goal': return `loop_outcome_missing_goal-${item.goal_id}`;
+  }
+}
+
+/** §1a 「링크 대상(도달)」— 원탭 도달 경로. agent_stuck은 NowFace(org-briefing/derive-now-face.ts)
+ * 선례와 동형(entity_type이 story면 보드로, 아니면 게이트 인박스로). agent_auth_failure는
+ * organization/workforce/[id](member_id) 상세로. loop_overdue_goal/loop_outcome_missing_goal은
+ * `/goals/[id]/page.tsx`(실존 라우트)로.
+ *
+ * ⚠️hypothesis(hypothesis_falsified/loop_overdue_hypothesis)는 전용 상세 페이지가 없다
+ * (embed-card.tsx 실측 그라운딩 — hypothesis는 epic/story/sprint 다대다 링크테이블이라 "담긴
+ * 곳 하나"를 못 정해 getEntityHref류가 늘 null을 반환한다, 그 파일 주석: "hypothesis 전용
+ * 화면이 생기면 승격"). action-zone.tsx의 기존 AttentionRow도 이 두 타입엔 애초에 href
+ * 자체가 없다(비-인터랙티브 div) — 그래서 `/flow`(가설이 실제로 보이는 일반 캔버스,
+ * goal-stem-card.tsx/guided-hypothesis-entry.tsx 소비처)로 보낸다. 특정 가설로 바로
+ * 스크롤/하이라이트하는 정밀 도달은 전용 화면이 생기기 전엔 구조적으로 불가 — 이 스토리
+ * 범위 밖(후속 표면 작업 몫, embed-card.tsx와 동일 한계 상속).
+ *
+ * 이 스토리(구조 층) 범위에서는 project_slug 기반 완전 경로 조립(§2842 교훈)까지는 하지
+ * 않는다 — project_id/slug가 없는 6종은 활성 프로젝트 쿠키로 해소된다(action-zone.tsx
+ * AttentionRow와 동일 한계). §1a 표는 「무엇에 도달하나」만 규정하지 「어느 프로젝트로」는
+ * 이 스토리 범위 밖(크로스 프로젝트 정합은 후속 표면 작업 몫).
+ */
+export function nowStripItemHref(item: AttentionItem): string {
+  switch (item.type) {
+    case 'agent_stuck':
+      return item.entity_type === 'story' ? `/board?story=${item.entity_id}` : '/inbox?tab=gates';
+    case 'agent_auth_failure':
+      return `/organization/workforce/${item.member_id}`;
+    case 'unanswered_blocker':
+      return `/board?story=${item.blocked_story_id}`;
+    case 'hypothesis_falsified':
+    case 'loop_overdue_hypothesis':
+      return '/flow';
+    case 'loop_overdue_goal':
+    case 'loop_outcome_missing_goal':
+      return `/goals/${item.goal_id}`;
+  }
+}
+
+export interface NowStripItem {
+  key: string;
+  type: AttentionItem['type'];
+  severity: NowStripSeverity;
+  title: string;
+  detail: string;
+  href: string;
+}
+
+/** raw attention.items → 렌더 항목. resolveName/epicTitles는 agent_stuck 라벨에만 쓰인다
+ * (action-zone.tsx와 동일 계약) — chat 목록 표면은 팀원 이름 맵을 따로 안 갖고 있을 수
+ * 있어 둘 다 옵셔널, 없으면 attentionEntityLabel 자체의 폴백(entity_type)이 no-fiction을
+ * 지킨다. */
+export function buildNowStripItems(
+  items: AttentionItem[],
+  t: ReturnType<typeof useTranslations>,
+  resolveName: (id: string | null | undefined) => string | null = () => null,
+  epicTitles: Record<string, string> = {},
+): NowStripItem[] {
+  const out = items.map((item) => ({
+    key: nowStripItemKey(item),
+    type: item.type,
+    severity: normalizeSeverity(item.severity),
+    title: attentionEntityLabel(item, resolveName, epicTitles),
+    detail: attentionDetailText(t, item),
+    href: nowStripItemHref(item),
+  }));
+  return out.sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]);
+}
+
+export interface NowStripSeveritySummary {
+  danger: number;
+  warn: number;
+  info: number;
+  total: number;
+}
+
+export function summarizeSeverity(items: NowStripItem[]): NowStripSeveritySummary {
+  const summary = { danger: 0, warn: 0, info: 0, total: items.length };
+  for (const item of items) summary[item.severity]++;
+  return summary;
+}

--- a/apps/web/src/components/chat/now-strip.test.tsx
+++ b/apps/web/src/components/chat/now-strip.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+//
+// story #3177(S3a) — chat 구심점 상단 고정 「지금」 스트립(attention 7종 흡수). AC1(타입별
+// 라벨 재사용)·AC2(SID 3150 no-fiction 회귀 금지)·AC3(severity 정렬·collapsed/expanded)·
+// AC4(원탭 도달) 회귀가드.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { NowStrip } from './now-strip';
+import type { AttentionItem } from '@/components/dashboard/command-center/types';
+
+const { fetchWithAuthMock, useAutoRefreshMock } = vi.hoisted(() => ({
+  fetchWithAuthMock: vi.fn(),
+  useAutoRefreshMock: vi.fn(),
+}));
+vi.mock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
+// story #3177 — 전역 RefreshContext(폴링 주기) 배선 자체는 useAutoRefreshMock 호출 인자로만
+// 검증한다(register 자체를 재구현하지 않는다, chat-list-view.test.tsx와 동일 관례).
+vi.mock('@/hooks/use-auto-refresh', () => ({ useAutoRefresh: (key: string, fn: () => void) => useAutoRefreshMock(key, fn) }));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+function mockAttention(items: AttentionItem[]) {
+  fetchWithAuthMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: { action_queue: { scope: 'org', items: [] }, attention: { scope: 'org', items, pending: [] }, is_clear: items.length === 0 } }),
+  });
+}
+
+const AGENT_STUCK: AttentionItem = {
+  type: 'agent_stuck', severity: 'warn', auto_detected: true,
+  entity_type: 'story', entity_id: 's-1', gate_type: 'merge', stuck_since: null,
+};
+const AGENT_AUTH_FAILURE: AttentionItem = {
+  type: 'agent_auth_failure', severity: 'danger', auto_detected: true,
+  member_id: 'm-1', reason: 'revoked', failure_count: 1, first_failed_at: null, last_failed_at: null,
+};
+// SID 3150 회귀 케이스 그대로: entity_id/entity_type이 없는 6종 중 하나.
+const HYPOTHESIS_FALSIFIED: AttentionItem = {
+  type: 'hypothesis_falsified', severity: 'info', auto_detected: true,
+  hypothesis_id: 'h-1', statement: '가입 전환율 개선 가설', outcome_result: null,
+  falsified_days: 3, superseded_by_hypothesis_id: null, project_id: 'p-1',
+};
+
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  fetchWithAuthMock.mockReset();
+  useAutoRefreshMock.mockReset();
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+describe('NowStrip — attention 0건이면 스트립 자체가 안 보인다', () => {
+  it('빈 attention.items면 아무것도 렌더하지 않는다', async () => {
+    mockAttention([]);
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    expect(container.textContent).toBe('');
+  });
+
+  it('fetch가 실패해도(네트워크 오류) 조용히 빈 상태로 남는다(크래시 없음)', async () => {
+    fetchWithAuthMock.mockRejectedValue(new Error('network'));
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    expect(container.textContent).toBe('');
+  });
+});
+
+describe('NowStrip — AC3 collapsed 기본·severity 카운트', () => {
+  it('collapsed 기본 상태로 「지금 · N건」과 severity 카운트만 보이고 카드는 안 보인다', async () => {
+    mockAttention([AGENT_STUCK, AGENT_AUTH_FAILURE, HYPOTHESIS_FALSIFIED]);
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    expect(container.textContent).toContain('지금');
+    expect(container.textContent).toContain('3');
+    // 카드 상세(가설 반증 라벨)는 아직 접힌 상태라 안 보여야 한다.
+    expect(container.textContent).not.toContain('가입 전환율 개선 가설');
+  });
+
+  it('헤더를 누르면 펼쳐져 카드가 보인다(AC1 타입별 라벨)', async () => {
+    mockAttention([AGENT_STUCK, AGENT_AUTH_FAILURE, HYPOTHESIS_FALSIFIED]);
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    const header = container.querySelector('button[aria-expanded]');
+    expect(header).toBeTruthy();
+    await act(async () => { header!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.textContent).toContain('가입 전환율 개선 가설');
+  });
+
+  it('다시 누르면 접힌다(토글)', async () => {
+    mockAttention([HYPOTHESIS_FALSIFIED]);
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    const header = container.querySelector('button[aria-expanded]')!;
+    await act(async () => { header.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.textContent).toContain('가입 전환율 개선 가설');
+    await act(async () => { header.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(container.textContent).not.toContain('가입 전환율 개선 가설');
+  });
+});
+
+describe('NowStrip — AC2 SID 3150 회귀 금지(no-fiction, entity_id 없는 타입도 공백 렌더 0)', () => {
+  it('entity_id/entity_type이 없는 6종(hypothesis_falsified)도 자기 필드(statement)로 라벨된다 — 공백 아님', async () => {
+    mockAttention([HYPOTHESIS_FALSIFIED]);
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    const header = container.querySelector('button[aria-expanded]')!;
+    await act(async () => { header.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const titleEl = Array.from(container.querySelectorAll('a')).find((a) => a.textContent?.includes('가입 전환율 개선 가설'));
+    expect(titleEl).toBeTruthy();
+    expect(titleEl!.textContent?.trim()).not.toBe('');
+  });
+});
+
+describe('NowStrip — AC4 원탭 도달(카드는 실 href를 가진 링크)', () => {
+  it('agent_stuck(entity_type=story) 카드는 /board?story=로 향한다', async () => {
+    mockAttention([AGENT_STUCK]);
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    const header = container.querySelector('button[aria-expanded]')!;
+    await act(async () => { header.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const link = container.querySelector('a[href="/board?story=s-1"]');
+    expect(link).toBeTruthy();
+  });
+});
+
+describe('NowStrip — 폴링 배선(AC4 조정: 실시간 아닌 기존 RefreshContext 주기)', () => {
+  it('useAutoRefresh가 고유 key와 refetch 함수로 등록된다', async () => {
+    mockAttention([]);
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    expect(useAutoRefreshMock).toHaveBeenCalledWith('chat-now-strip', expect.any(Function));
+  });
+});

--- a/apps/web/src/components/chat/now-strip.tsx
+++ b/apps/web/src/components/chat/now-strip.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+/**
+ * story #3177(S3a·SID 3177) — chat 구심점 상단 고정 「지금」 스트립. command-center attention
+ * 7종을 임베드 카드로 흡수한다(AC 뼈 = doc 「S3 와이어 심화」§1·시안 렌더 doc
+ * s3a-now-strip-mockup-render-20260828). 데이터원 = 기존 `/api/dashboard/my-actions`
+ * 재사용(PO BE 계약 확定 2026-08-28, 신규 BE 0). collapsed/expanded 문법은 embed-group.tsx의
+ * GateGroup(S2c③④)을 재사용(신규 패턴 0).
+ *
+ * ⚠️소멸 타이밍(AC4, PO 조정 2026-08-28): 진짜 실시간(SSE attention-changed)이 아니라
+ * useAutoRefresh(전역 RefreshContext 폴링 주기, 기본 30초) 내 무회귀다 — 이벤트 기반 즉시
+ * 소멸은 별 후속 스토리(entity:story:2b129e0b-b38d-4597-816a-914f43a5dfb3)로 분리됐다.
+ *
+ * ⚠️구조/데이터 층 우선(PO 지시 2026-08-28) — 시안(하이파이 mockup)의 좌측 그라데이션
+ * 장식바·메타/시간 두 슬롯 분리 같은 미세 픽셀 디테일은 이 커밋에서 실 DS 프리미티브로
+ * 근사만 하고, 최종 픽셀 대조는 QA 라이브 확認 라운드에서 조정한다(신규색 0은 이미 지킴).
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { ChevronDown, ChevronUp, AlertTriangle, Clock, Ban, Target, FlaskConical } from 'lucide-react';
+import { fetchWithAuth } from '@/lib/db/client';
+import { cn } from '@/lib/utils';
+import { cardVariants } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useAutoRefresh } from '@/hooks/use-auto-refresh';
+import type { AttentionItem, MyActions } from '@/components/dashboard/command-center/types';
+import { buildNowStripItems, summarizeSeverity, type NowStripItem, type NowStripSeverity } from './derive-now-strip';
+
+// 카드 좌측 심각도 바 + 점 요약(둘 다 solid 배경색, 텍스트 아님) — tint 배경 위 계열색
+// «글자» 조합은 만들지 않는다(story #2420 회귀가드 — bg-tint+text-family 공존 금지).
+// 아이콘 배지는 중립(bg-muted/text-muted-foreground)만 쓴다.
+const SEVERITY_SOLID_BG: Record<NowStripSeverity, string> = {
+  danger: 'bg-destructive',
+  warn: 'bg-warning',
+  info: 'bg-info',
+};
+
+const TYPE_ICON: Record<AttentionItem['type'], typeof AlertTriangle> = {
+  agent_stuck: Clock,
+  agent_auth_failure: AlertTriangle,
+  unanswered_blocker: Ban,
+  hypothesis_falsified: FlaskConical,
+  loop_overdue_hypothesis: FlaskConical,
+  loop_overdue_goal: Target,
+  loop_outcome_missing_goal: Target,
+};
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function unwrap<T>(json: unknown): T | null {
+  if (!isRecord(json)) return null;
+  const d = json['data'];
+  return (d ?? json) as T;
+}
+
+function NowStripCard({ item }: { item: NowStripItem }) {
+  const Icon = TYPE_ICON[item.type];
+  return (
+    <Link
+      href={item.href}
+      className={cn(
+        cardVariants({ radius: 'card' }),
+        'flex items-center gap-2.5 p-2.5 text-xs transition hover:border-muted-foreground/30',
+      )}
+    >
+      <span className={cn('h-full w-[3px] shrink-0 self-stretch rounded-full', SEVERITY_SOLID_BG[item.severity])} aria-hidden="true" />
+      <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+        <Icon className="size-3.5" aria-hidden="true" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium text-foreground">{item.title}</span>
+        <span className="block truncate text-muted-foreground">{item.detail}</span>
+      </span>
+    </Link>
+  );
+}
+
+const SEVERITY_GROUP_LABEL_KEY: Record<NowStripSeverity, string> = {
+  danger: 'nowStripGroupDanger',
+  warn: 'nowStripGroupWarn',
+  info: 'nowStripGroupInfo',
+};
+
+const SEVERITY_GROUP_TEXT: Record<NowStripSeverity, string> = {
+  danger: 'text-destructive',
+  warn: 'text-foreground',
+  info: 'text-info',
+};
+
+function groupBySeverity(items: NowStripItem[]): { severity: NowStripSeverity; items: NowStripItem[] }[] {
+  const order: NowStripSeverity[] = ['danger', 'warn', 'info'];
+  return order
+    .map((severity) => ({ severity, items: items.filter((i) => i.severity === severity) }))
+    .filter((g) => g.items.length > 0);
+}
+
+export interface NowStripProps {
+  /** agent_stuck 라벨용(action-zone.tsx와 동일 계약) — 없으면 attentionEntityLabel 자체의
+   * entity_type 폴백(no-fiction)으로 떨어진다, 필수 아님. */
+  resolveName?: (id: string | null | undefined) => string | null;
+}
+
+export function NowStrip({ resolveName }: NowStripProps) {
+  const t = useTranslations('chats');
+  const tDashboard = useTranslations('dashboard');
+  const [items, setItems] = useState<AttentionItem[] | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetchWithAuth('/api/dashboard/my-actions');
+      if (!res.ok) return;
+      const json = await res.json().catch(() => null);
+      const ma = unwrap<MyActions>(json);
+      setItems(ma?.attention.items ?? null);
+    } catch {
+      // non-critical — 스트립이 비어도 chat 목록 본체엔 영향 없음.
+    }
+  }, []);
+
+  // command-center.tsx의 동형 마운트-fetch 패턴(load가 setItems를 비동기로 호출) — 정적분석이
+  // "effect 안 setState"로 잡는 기존 코드베이스 관례(connect-step.tsx 등)를 따라 disable.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { void load(); }, [load]);
+  useAutoRefresh('chat-now-strip', () => { void load(); });
+
+  const noopResolveName = useCallback((): string | null => null, []);
+  const stripItems = useMemo(
+    () => buildNowStripItems(items ?? [], tDashboard, resolveName ?? noopResolveName, {}),
+    [items, tDashboard, resolveName, noopResolveName],
+  );
+
+  if (stripItems.length === 0) return null;
+
+  const summary = summarizeSeverity(stripItems);
+  const groups = groupBySeverity(stripItems);
+
+  return (
+    <div className={cn(cardVariants({ radius: 'card' }), 'sticky top-0 z-10 mb-2')}>
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={() => setExpanded((v) => !v)}
+        className="h-auto w-full items-center justify-start gap-2.5 rounded-b-none px-3 py-2.5 text-left font-normal hover:bg-muted/40"
+        aria-expanded={expanded}
+      >
+        <span className="text-[12.5px] font-semibold text-foreground">{t('nowStripLabel')}</span>
+        <span className="font-mono text-[12.5px] font-semibold text-foreground">{t('nowStripCount', { count: summary.total })}</span>
+        <span className="ml-0.5 flex items-center gap-2">
+          {summary.danger > 0 && (
+            <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+              <span className={cn('size-2 rounded-full', SEVERITY_SOLID_BG.danger)} aria-hidden="true" />{summary.danger}
+            </span>
+          )}
+          {summary.warn > 0 && (
+            <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+              <span className={cn('size-2 rounded-full', SEVERITY_SOLID_BG.warn)} aria-hidden="true" />{summary.warn}
+            </span>
+          )}
+          {summary.info > 0 && (
+            <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+              <span className={cn('size-2 rounded-full', SEVERITY_SOLID_BG.info)} aria-hidden="true" />{summary.info}
+            </span>
+          )}
+        </span>
+        {expanded ? (
+          <ChevronUp className="ml-auto size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+        ) : (
+          <ChevronDown className="ml-auto size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+        )}
+        <span className="sr-only">{expanded ? t('nowStripCollapse') : t('nowStripExpand')}</span>
+      </Button>
+      {expanded && (
+        <div className="space-y-2 border-t border-border p-2 pt-1.5">
+          {groups.map((g) => (
+            <div key={g.severity} className="space-y-1">
+              <p className={cn('px-1 pt-1 text-[10.5px] font-semibold tracking-wide uppercase', SEVERITY_GROUP_TEXT[g.severity])}>
+                {t(SEVERITY_GROUP_LABEL_KEY[g.severity])}
+              </p>
+              {g.items.map((item) => <NowStripCard key={item.key} item={item} />)}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/command-center/action-zone.tsx
+++ b/apps/web/src/components/dashboard/command-center/action-zone.tsx
@@ -6,6 +6,8 @@ import { useTranslations } from 'next-intl';
 import { ShieldCheck, GitPullRequest, Ban, AlertTriangle, CheckCircle2, ChevronRight, History, Clock } from 'lucide-react';
 import { type MyActions, type Priority, type QueueItem, type AttentionItem } from './types';
 import { selectVisibleQueue, splitRenderableQueue, countChangedSince, countAttentionChangedSince, gateTypeLabelKey, getLastSeenMs, markSeenNow, minutesAgo } from './derive-action-zone';
+import { cn } from '@/lib/utils';
+import { cardVariants } from '@/components/ui/card';
 
 const QUEUE_CAP = 5; // now-face.tsx CAP 관례 재사용(§7-4 잘림-보이기).
 
@@ -32,7 +34,8 @@ function gateLabel(t: ReturnType<typeof useTranslations>, gateType: string | nul
 // 필요(entity_id가 멤버/에픽 id)하고, 나머지 6종은 BE(#2538 계약)가 title/statement/
 // blocked_story_title을 이미 직접 싣는다 — 그 필드를 그대로 쓰면 된다(재해소 시도 자체가
 // 이 버그의 원인이었다: resolveName이 멤버/에픽 id만 알아 story 스코프 항목에서 늘 null).
-function attentionEntityLabel(
+// story #3177(S3a) — chat 「지금」 스트립이 이 계산을 재사용한다(§1b·두 벌 금지). export.
+export function attentionEntityLabel(
   item: AttentionItem,
   resolveName: (id: string | null | undefined) => string | null,
   epicTitles: Record<string, string>,
@@ -57,14 +60,24 @@ function attentionEntityLabel(
 // BE가 실어 보내는 경과일수 필드(타입마다 이름이 다르다 — age_days/falsified_days/
 // overdue_days/done_days) 중 있는 것을 그대로 보여준다(no-fiction: 실측값만, 지어낸 사유
 // 문구 0).
-function attentionDetailText(t: ReturnType<typeof useTranslations>, item: AttentionItem): string {
+// story #3177(S3a) — 7종 중 5종(agent_stuck/agent_auth_failure 제외)의 경과일수 필드는
+// 이름이 다르다(age_days/falsified_days/overdue_days/done_days) — 그 5종에 공통인 「일수」
+// 하나로 추출해 재사용(§1b "attentionDayCount 재사용" 전제 — 두 벌 금지). agent_stuck/
+// agent_auth_failure는 애초에 「일수」 개념이 없어(경과 timestamp·count가 별도 축) null.
+export function attentionDayCount(item: AttentionItem): number | null {
+  if (item.type === 'agent_stuck' || item.type === 'agent_auth_failure') return null;
+  if (item.type === 'unanswered_blocker') return item.age_days;
+  if (item.type === 'hypothesis_falsified') return item.falsified_days;
+  if (item.type === 'loop_overdue_hypothesis' || item.type === 'loop_overdue_goal') return item.overdue_days;
+  return item.done_days; // loop_outcome_missing_goal
+}
+
+// story #3177(S3a) — 「지금」 스트립도 같은 부제 텍스트를 쓴다(attentionEntityLabel/
+// attentionDayCount와 같은 재사용 결 — no-fiction 문구 생성 로직을 두 벌 두지 않는다).
+export function attentionDetailText(t: ReturnType<typeof useTranslations>, item: AttentionItem): string {
   if (item.type === 'agent_stuck') return t('ccAgentStuck', { gate: gateLabel(t, item.gate_type) });
   if (item.type === 'agent_auth_failure') return t('ccAttentionAuthFailure', { count: item.failure_count });
-  const days =
-    item.type === 'unanswered_blocker' ? item.age_days
-    : item.type === 'hypothesis_falsified' ? item.falsified_days
-    : item.type === 'loop_overdue_hypothesis' || item.type === 'loop_overdue_goal' ? item.overdue_days
-    : item.done_days; // loop_outcome_missing_goal
+  const days = attentionDayCount(item);
   return days != null ? t('ccAttentionDays', { days }) : t('ccAttentionGeneric');
 }
 
@@ -94,7 +107,7 @@ export function QueueRow({ item }: { item: QueueItem }) {
     return (
       <Link
         href="/inbox?tab=gates"
-        className={`flex items-center gap-2 rounded-lg border border-l-2 border-border bg-card p-2.5 text-xs transition hover:border-muted-foreground/30 ${PRIORITY_BORDER[item.priority]}`}
+        className={cn(cardVariants({ radius: 'card' }), 'flex items-center gap-2 border-l-2 p-2.5 text-xs transition hover:border-muted-foreground/30', PRIORITY_BORDER[item.priority])}
       >
         <ShieldCheck className="size-3.5 shrink-0 text-warning-strong" />
         <span className="min-w-0 flex-1 truncate text-foreground">
@@ -110,7 +123,7 @@ export function QueueRow({ item }: { item: QueueItem }) {
     return (
       <Link
         href={ctx.blocked_story_id ? `/board?story=${ctx.blocked_story_id}` : '/board'}
-        className={`flex items-center gap-2 rounded-lg border border-l-2 border-border bg-card p-2.5 text-xs transition hover:border-muted-foreground/30 ${PRIORITY_BORDER[item.priority]}`}
+        className={cn(cardVariants({ radius: 'card' }), 'flex items-center gap-2 border-l-2 p-2.5 text-xs transition hover:border-muted-foreground/30', PRIORITY_BORDER[item.priority])}
       >
         <Ban className="size-3.5 shrink-0 text-warning-strong" />
         <span className="min-w-0 flex-1 truncate text-foreground">
@@ -124,7 +137,7 @@ export function QueueRow({ item }: { item: QueueItem }) {
     return (
       <Link
         href={ctx.story_id ? `/board?story=${ctx.story_id}` : '/board'}
-        className={`flex items-center gap-2 rounded-lg border border-l-2 border-border bg-card p-2.5 text-xs transition hover:border-muted-foreground/30 ${PRIORITY_BORDER[item.priority]}`}
+        className={cn(cardVariants({ radius: 'card' }), 'flex items-center gap-2 border-l-2 p-2.5 text-xs transition hover:border-muted-foreground/30', PRIORITY_BORDER[item.priority])}
       >
         <GitPullRequest className="size-3.5 shrink-0 text-muted-foreground" />
         <span className="min-w-0 flex-1 truncate text-foreground">
@@ -143,7 +156,7 @@ export function QueueRow({ item }: { item: QueueItem }) {
     console.warn('ActionZone/QueueRow: unrecognized action_queue item type', { type: unknownType });
   }
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-l-2 border-dashed border-border bg-card p-2.5 text-xs text-muted-foreground">
+    <div className={cn(cardVariants({ radius: 'card' }), 'flex items-center gap-2 border-l-2 border-dashed p-2.5 text-xs text-muted-foreground')}>
       <span className="min-w-0 flex-1 truncate">{t('ccQueueUnknownType')}</span>
     </div>
   );
@@ -164,7 +177,7 @@ function WaitingRow({ item }: { item: QueueItem }) {
   return (
     <Link
       href={ctx.story_id ? `/board?story=${ctx.story_id}` : '/board'}
-      className="flex items-center gap-2 rounded-lg border border-border bg-card p-2.5 text-xs text-muted-foreground transition hover:border-muted-foreground/30"
+      className={cn(cardVariants({ radius: 'card' }), 'flex items-center gap-2 p-2.5 text-xs text-muted-foreground transition hover:border-muted-foreground/30')}
     >
       <Clock className="size-3.5 shrink-0" aria-hidden="true" />
       <span className="min-w-0 flex-1 truncate">{t('ccWaitingGateReason', { gate: gateLabel(t, ctx.gate_type) })}</span>
@@ -181,7 +194,7 @@ function AttentionRow({ item, resolveName, epicTitles }: { item: AttentionItem; 
   const entity = attentionEntityLabel(item, resolveName, epicTitles);
   const detail = attentionDetailText(t, item);
   return (
-    <div className="flex items-start gap-2 rounded-lg border border-border bg-card p-2.5 text-xs">
+    <div className={cn(cardVariants({ radius: 'card' }), 'flex items-start gap-2 p-2.5 text-xs')}>
       <span className="mt-1 size-1.5 shrink-0 rounded-full bg-info/60" aria-hidden="true" />
       <p className="min-w-0 flex-1 text-foreground">
         <span className="font-medium">{entity}</span>{' '}
@@ -232,7 +245,7 @@ export function ActionZone({ data, resolveName, epicTitles }: {
     : t('ccDayAgo', { n: Math.floor(lastSeenMinutesAgo / 1440) });
 
   return (
-    <section aria-label={t('ccZoneActions')} className="space-y-3 rounded-xl border border-border bg-card/40 p-3">
+    <section aria-label={t('ccZoneActions')} className={cn(cardVariants({ radius: 'compact' }), 'space-y-3 bg-card/40 p-3')}>
       <h3 className="text-sm font-semibold text-foreground">{t('ccZoneActions')}</h3>
 
       {/* 큐+주의 0 & is_clear → 차분한 "괜찮다" 빈 상태(loud X) */}


### PR DESCRIPTION
## 배경
[[S3a·Chat 허브] 「지금」 스트립 — command-center attention 7종을 chat 구심점 상단으로 흡수](entity:story:b0719dbf-087c-41d0-8ab5-e6114a5656cd) · AC 뼈 = [S3 와이어 심화](entity:doc:14bf3247-ae2f-49d0-92b0-986e8902d00a)§1 · 시안 = [S3a 시안 렌더](entity:doc:f6cba794-1fc1-4808-831c-a5646af70622)

PO 지시(2026-08-28)에 따라 **구조/데이터 층**을 이번 커밋에서 완결한다 — 미세 픽셀 디테일(시안의 좌측 그라데이션 장식바 등)은 QA 라이브 확認 라운드에서 조정 대상.

## 데이터원 — 신규 BE 0(PO 계약 확定)
기존 `GET /api/dashboard/my-actions`(attention.items) 재사용. 폴링은 전역 RefreshContext(`useAutoRefresh`, 기본 30초) — AC4 "실시간"은 PO가 "현행 폴링 주기 내 무회귀"로 조정(SSE 이벤트 소멸은 [후속 스토리](entity:story:2b129e0b-b38d-4597-816a-914f43a5dfb3)로 분리).

## AC1/AC2 — SID 3150 회귀 금지·재사용
`action-zone.tsx`의 `attentionEntityLabel`/`attentionDetailText`를 export해 그대로 재사용, 인라인이던 day-count 로직을 `attentionDayCount()`로 추출·export(§1b "두 벌 금지" 명시 요구). `derive-now-strip.ts`는 generic `entity_id`에 의존하지 않고 타입별 자기 필드(§1a 표)로만 라벨한다.

## AC3 — severity 정렬·collapsed/expanded
`embed-group.tsx` `GateGroup`(S2c③④)의 collapsed/expanded 토글 문법을 그대로 재사용(신규 패턴 0). collapsed 기본 「지금 · N건」+severity 점 요약 → 펼치면 그룹(행동 필요/주의/관찰·학습).

## AC4 — 원탭 도달
- `agent_stuck` → 보드/게이트 인박스
- `agent_auth_failure` → workforce 멤버 상세
- `unanswered_blocker` → 차단 스토리 보드
- goal 2종 → `/goals/[id]`
- **hypothesis 2종은 전용 상세 페이지가 없다** — `embed-card.tsx` 실측으로 확認(다대다 링크테이블이라 getEntityHref류가 항상 `null` 반환, 그 파일 자체 주석: "hypothesis 전용 화면이 생기면 승격"). 기존 `AttentionRow`도 이 두 타입엔 애초에 href가 없었다(비-인터랙티브). 정밀 도달은 전용 화면 신설 전엔 구조적으로 불가 — `/flow`(가설이 실제로 보이는 캔버스)로 폴백, 문서화된 한계.

## AC5 — 순감소(net-decrease) 실측
이 스토리가 건드리는 두 파일이 키스톤([#3164](entity:story:47fc75df-2764-4350-bf4b-d02aa8238153)) baseline에 있어 **항목을 실제로 제거**하고 baseline을 갱신했다:
- `chat-list-view.tsx`: raw button 4건→0건(`<Button variant="ghost">` 전환)
- `action-zone.tsx`: 손코딩 카드 5건→0건(`cardVariants()` cva 호출로 전환)
- `raw-button-baseline.json` 186f/511occ→185f/507occ, `handrolled-card-baseline.json` 269키→264키
- 신규 파일(`now-strip.tsx`)도 `cardVariants()`만 쓰고 raw button은 전부 `<Button>` — 두 키스톤 가드 자체 실행 0 신규위반 확認.

## AC6
라이트/다크는 전부 시맨틱 토큰(`text-foreground`/`text-destructive`/`text-info` 등, 신규색 0) 경유라 테마 무관 동작. 모바일 반응형·정밀 픽셀 대조는 QA 라이브 확認 라운드 몫(PO 층 분리 지시).

## 검증
`chat`/`dashboard/command-center` 디렉터리 + 두 키스톤 가드 테스트 683건 PASS(신규 25건), 전체 `vitest` 528파일/4943건 PASS, `tsc --noEmit`/`pnpm lint` 0 에러, `pnpm build` 성공. 두 키스톤 가드 자체 실행 시 0 신규위반. prod 무접촉(dev 완주 후 승격).

## Test plan
- [ ] 카디르군 QA: 라이브 dev에서 attention 항목 있는 계정으로 collapsed→expanded 토글, 카드 원탭 도달 실측
- [ ] 유나양: 픽셀 대조(시안 대비 델타) — 좌측 그라데이션 바 등 미세 디테일 반영 여부 판단
- [ ] 라이트/다크·모바일 스크린샷