### PR TITLE
[SID:3181] activation checklist met 항목 text-foreground — info 배너 blue-soft 대비 정공

### DIFF
--- a/apps/web/src/components/dashboard/activation-checklist-banner.tsx
+++ b/apps/web/src/components/dashboard/activation-checklist-banner.tsx
@@ -124,8 +124,12 @@ export function ActivationChecklistBanner() {
       <ul className="col-start-2 mt-2 space-y-1.5">
         {stepItems.map(({ key, label }) => {
           const met = state.steps[key];
+          // story #3181 — met 항목은 text-foreground. text-success(#1F9D57 계열색)는 info Alert의
+          // blue-soft(#EAEEFF) 배경 위에서 대비 미달(≈2.8:1<4.5·axe color-contrast 신규 위반). #2420
+          // 규율(tint 위 계열색 글자는 text-foreground)·완료 여부는 CircleCheck vs Circle 모양이 전달하므로
+          // 색 의존을 제거해도 신호 손실 0(색맹 접근성↑). 아이콘도 li 색 상속으로 함께 정리.
           return (
-            <li key={key} className={cn('flex items-center gap-1.5 text-sm', met ? 'text-success' : 'text-muted-foreground')}>
+            <li key={key} className={cn('flex items-center gap-1.5 text-sm', met ? 'text-foreground' : 'text-muted-foreground')}>
               {met ? <CircleCheck className="size-3.5 shrink-0" /> : <Circle className="size-3.5 shrink-0" />}
               <span>{label}</span>
             </li>


### PR DESCRIPTION
## 배경 (story #3181)
develop CI Contrast guard(axe color-contrast 런타임)가 `/dashboard::light::#1f9d57/#eaeeff` 신규 위반으로 데이터 조건부로 간헐 적색화됐다(PR #3579 BE 머지 run에서 처음 노출 — BE diff가 activation 데이터 상태를 바꿔 잠복 결함이 드러난 것).

## 위반 지점
`activation-checklist-banner.tsx` — 배너 루트가 `<Alert variant="info">`(bg-info-tint = **#EAEEFF** blue-soft)이고, 체크리스트 완료(met) 항목 `<li>`가 **`text-success`(#1F9D57 green)** 로 렌더된다. 완료 초록 글자가 info 배너 blue-soft 배경 위에 앉아 **≈2.8:1 < 4.5(AA)** 미달. 직접 페어링 grep 0의 cross-element 조합(Alert 컨테이너 bg × li 텍스트)이라 정적 스캐너 사각.

## 처방 — 정공(baseline 시드 아님)
- `met ? 'text-success'` → **`met ? 'text-foreground'`** (#2420 규율: tint 위 계열색 글자는 text-foreground).
- 완료 여부는 `CircleCheck`(완료) vs `Circle`(미완) **모양**이 전달하므로 색 의존 제거로 신호 손실 0 — 색맹 접근성은 오히려 향상. 아이콘도 li 색 상속으로 함께 정리.
- baseline 시드를 택하지 않은 근거: story #2611(solid 이관 89곳)로 이 baseline을 `keys:[]`로 비워 둔 상태 → 시드는 can-only-shrink 역행 + 실 접근성 defect 마스킹. 배너는 retention 기능이라 /dashboard 폐합(S3c) 후에도 홈=chat로 이전 생존 → 정공이 throwaway 아님.

## 검증
- 픽셀: 완료 항목 글자 색만 green→foreground(구조·문구·아이콘 모양 불변).
- CI: develop Contrast guard `/dashboard::light::#1f9d57/#eaeeff` green 복원(다음 axe run 실측·AC3=유나 재확認).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
