### PR TITLE
[SID:3185] S3c 후속 — /dashboard 잔여 참조 마저 정리

### DIFF
--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -195,8 +195,9 @@ async function handleCallback(request: Request, provider: string, code: string |
     return nativeRes;
   }
 
-  // AC3: 세션 만료로 OAuth 재로그인한 경우 작업 경로 복귀(safeNextPath 가드)·없으면 기존 /inbox.
-  const destination = inviteToken ? `${origin}/dashboard` : `${origin}${safeNextPath(nextCookie)}`;
+  // AC3: 세션 만료로 OAuth 재로그인한 경우 작업 경로 복귀(safeNextPath 가드)·없으면 홈(chat).
+  // story #3179(S3c) 후속(추가 실측 발견) — /dashboard 폐합, 홈=chat 재조준.
+  const destination = inviteToken ? `${origin}/chats` : `${origin}${safeNextPath(nextCookie)}`;
   const res = NextResponse.redirect(destination);
   res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });

--- a/apps/web/src/app/invite/accept/invite-accept-client.tsx
+++ b/apps/web/src/app/invite/accept/invite-accept-client.tsx
@@ -40,7 +40,8 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
         setResult({ type: 'error', text: inviteErrorMessage(tInvite, json.error?.code, 'acceptFailed') });
       } else {
         setResult({ type: 'success', text: `${tInvite('success')} ${tInvite('redirecting')}` });
-        setTimeout(() => { window.location.href = '/dashboard'; }, 1500);
+        // story #3179(S3c) 후속(카디르 QA 발견) — /dashboard 폐합, 홈=chat 재조준.
+        setTimeout(() => { window.location.href = '/chats'; }, 1500);
       }
     } finally {
       setAccepting(false);

--- a/apps/web/src/app/onboarding/onboarding-form.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.test.tsx
@@ -127,8 +127,8 @@ describe('OnboardingForm — error.code 분기 (story #2484)', () => {
 
   it('create-agent 실패 — raw/하드코딩 영문 대신 번역 문구(#2484)', async () => {
     // initialStep="project" prop은 컴포넌트 자체 로직상 "새로고침 재개"를 뜻해 프로젝트
-    // 생성 성공 時 agent 단계로 안 가고 바로 대시보드로 finishToDashboard()한다 — agent
-    // 단계에 실제 projectId를 갖고 도달하려면 org→project 전 과정을 그대로 밟아야 한다.
+    // 생성 성공 時 agent 단계로 안 가고 바로 홈으로 finishToHome()한다(story #3179 S3c) —
+    // agent 단계에 실제 projectId를 갖고 도달하려면 org→project 전 과정을 그대로 밟아야 한다.
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) };
       if (url === '/api/organizations') return { ok: true, json: async () => ({ data: { id: 'org-1' } }) };

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -159,12 +159,12 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
     }
   };
 
-  // E-ONB S5: 온보딩 완료 후 /dashboard 이동 전 토큰 refresh.
+  // E-ONB S5: 온보딩 완료 후 홈(chat, story #3179 S3c) 이동 전 토큰 refresh.
   // register JWT는 app_metadata 비어(org_id 없음) — TeamMember는 project 생성 시 최초 생기므로,
   // 그 후 refresh로 새 JWT(sp_at)에 org_id 반영해야 보드/스토리 등 앱 전반 API가 차단되지 않는다.
-  const finishToDashboard = async () => {
+  const finishToHome = async () => {
     await fetch('/api/auth/refresh', { method: 'POST' }).catch(() => null);
-    window.location.href = '/dashboard';
+    window.location.href = '/chats';
   };
 
   const handleCreateProject = async () => {
@@ -216,7 +216,7 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
       }).catch(() => null);
 
       if (initialStep === 'project') {
-        await finishToDashboard();
+        await finishToHome();
         return;
       }
       setStep('agent');
@@ -274,7 +274,7 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
   };
 
   const handleFinish = () => {
-    void finishToDashboard();
+    void finishToHome();
   };
 
   return (

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -11,7 +11,6 @@ import {
   FolderKanban,
   GitPullRequest,
   Inbox,
-  LayoutDashboard,
   MessageSquareMore,
   Search,
   UserPlus,
@@ -49,7 +48,8 @@ interface StoryTitleResult {
 // (없으면 이 bare '/docs' 로 폴백 — 미들웨어 리다이렉트 안전망이 받는다).
 const STATIC_ITEMS: CommandItem[] = [
   { id: 'go-inbox', group: 'navigate', icon: Inbox, labelKey: 'goInbox', href: '/inbox', shortcut: ['G', 'I'] },
-  { id: 'go-dashboard', group: 'navigate', icon: LayoutDashboard, labelKey: 'goDashboard', href: '/dashboard', shortcut: ['G', 'D'] },
+  // story #3179(S3c) 후속(추가 실측 발견) — 'go-dashboard'(/dashboard) 제거. /dashboard가
+  // 폐합돼 go-chats(아래, G M)와 같은 목적지(/chats)를 가리키는 중복 단축키였다.
   { id: 'go-board', group: 'navigate', icon: FolderKanban, labelKey: 'goBoard', href: '/board', shortcut: ['G', 'B'] },
   // story #2930 I3(PO 확定 2026-08-22) — nav-config.ts work 존에서 'sprints'가 'board'로
   // 접혀 사이드바 진입점이 사라진 뒤, 이 리터럴 href가 verify-no-orphan-resource-routes

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -558,12 +558,13 @@ async function resolveAndRespond(
     }
   }
 
-  // story #3179(S3c) 조사 — 이 분기는 죽은 코드였다: '/login'은 PUBLIC_EXACT에 있어(§L587-591)
-  // proxy()가 항상 그 앞에서 조기 반환한다 — resolveAndRespond까지 「이미 로그인된 채 /login
-  // 방문」 요청이 도달할 길이 없다(그래서 원래도 '/inbox' 타깃이 실제로 한 번도 안 쓰였다). 로그인
-  // 랜딩(AC2)의 진짜 메커니즘은 lib/auth/session-redirect.ts의 safeNextPath/buildLoginRedirect
-  // (login/page.tsx의 router.replace(safeNextPath(nextParam)) 소비) — 거기를 고쳤다. 여기 죽은
-  // 분기는 혼동을 남기지 않게 제거한다.
+  // story #3179(S3c) 조사(카디르 QA 정정 — 배열명 오기) — 이 분기는 죽은 코드였다: '/login'은
+  // PUBLIC_PREFIX에 있어(§L64 근방, startsWith prefix로 매칭) proxy()가 항상 그 앞에서 조기
+  // 반환한다 — resolveAndRespond까지 「이미 로그인된 채 /login 방문」 요청이 도달할 길이 없다
+  // (그래서 원래도 '/inbox' 타깃이 실제로 한 번도 안 쓰였다). 로그인 랜딩(AC2)의 진짜 메커니즘은
+  // lib/auth/session-redirect.ts의 safeNextPath/buildLoginRedirect(login/page.tsx의
+  // router.replace(safeNextPath(nextParam)) 소비) — 거기를 고쳤다. 여기 죽은 분기는 혼동을
+  // 남기지 않게 제거한다.
 
   return response;
 }


### PR DESCRIPTION
## 배경
[[S3c·Chat 허브] /dashboard 폐합 + 로그인 랜딩=chat + 단일 홈 (S5 통 B)](entity:story:a58612c4-bd9f-468a-978d-f5c2984d5045) — PR#3586 머지 후 카디르군 QA가 남긴 비차단 2건 정리 마이크로 PR (PO 승인 지시).

## 카디르 QA 발견 2건
- `proxy.ts` 주석 오기 정정 — `'/login'`은 `PUBLIC_EXACT`가 아니라 `PUBLIC_PREFIX`에 있다(startsWith 매칭). 죽은 코드라는 결론 자체는 안 바뀐다(어느 배열이든 조기 반환은 동일) — 인용한 배열명만 틀렸었다.
- `invite-accept-client.tsx`의 7번째 자리(`handleAccept` 성공 후 `window.location.href = '/dashboard'`) — 원래 스토리(PR#3586) grep이 href/push() 스타일만 잡아 이 대입 스타일을 놓쳤다. `/chats`로 재조준.

## 자체 재실측 3건(같은 미탐 패턴 재발 방지 차 전체 재sweep)
같은 실수(대입 스타일 미탐)가 또 있을까 봐 리포 전체를 다시 훑었다 — 3건 더 발견:
- `onboarding-form.tsx` — `finishToDashboard()` → `finishToHome()`(이름·목적지 둘 다 수정). 함수명 자체가 죽은 개념을 담고 있어 리네임까지.
- `command-palette.tsx` — `'go-dashboard'` 단축키(`G D`, href=`/dashboard`) 삭제. 이미 `'go-chats'`(`G M`, href=`/chats`)가 있어 같은 목적지 중복 단축키였다(`nav-config.ts`의 '대시보드' 항목 제거와 동일 근거).
- `api/auth/callback/[provider]/route.ts` — OAuth 콜백에 `inviteToken`이 있을 때 목적지가 `${origin}/dashboard`였다. `${origin}/chats`로 재조준.

## 스코프 경계(의도적으로 안 건드림)
`upgrade-modal.tsx`의 `href="/dashboard/settings"`는 그대로 둔다 — `/dashboard/settings`는 이 스토리(command-center) 이전부터 있던 별개 redirect(→ `/settings`, 무변경)라 "홈=chat 이사" 스코프 밖이다(2-hop 정상, 카디르 verdict의 동일 판단 재적용).

## 검증
전체 `vitest` 530파일/4964건 PASS, `tsc --noEmit`/`pnpm lint` 0 에러, `pnpm build` 성공. prod 무접촉.