### PR TITLE
[SID:3183] DS 순감소 리팩터 1호 — story-detail-panel raw <button> 37건 → Button 이관

### DIFF
--- a/apps/web/scripts/raw-button-baseline.json
+++ b/apps/web/scripts/raw-button-baseline.json
@@ -3,7 +3,9 @@
     "story #3164(DS 게이트 키스톤) grandfather baseline — 이 가드 첫 도입 시점 develop의 기존 raw <button>.",
     "마이그레이션 대상 아님 — 이 게이트는 \"더 늘지 않는다\"만 보장한다(freeze, 개별 수리는 후속 표면 리팩터 판).",
     "story #3177(S3a) AC5 순감소 — chat-list-view.tsx 4건→0건(<Button> 전환, 이 스토리가 그 파일을",
-    "건드리며 실측 제거). 186f/511occ → 185f/507occ."
+    "건드리며 실측 제거). 186f/511occ → 185f/507occ.",
+    "story #3183(DS 순감소 리팩터 1호) — story-detail-panel.tsx 37건→0건(<Button variant=\"ghost\">",
+    "전량 전환, baseline 단일 파일 최다 채무 소거). 185f/507occ → 184f/470occ."
   ],
   "counts": {
     "app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx": 3,
@@ -142,7 +144,6 @@
     "components/kanban/kanban-list-view.tsx": 1,
     "components/kanban/kanban-trust-column.tsx": 1,
     "components/kanban/story-card.tsx": 6,
-    "components/kanban/story-detail-panel.tsx": 37,
     "components/locale-switcher.tsx": 1,
     "components/loop-queue/loop-queue-client.tsx": 3,
     "components/loops/artifact-preview.tsx": 2,

--- a/apps/web/scripts/tint-color-text-baseline.json
+++ b/apps/web/scripts/tint-color-text-baseline.json
@@ -71,7 +71,14 @@
     "baseline에 «잘못된 자리»로 등재해뒀을 뿐, 실제 이 자리(#1557 부근)가 진짜 검사",
     "대상으로 잡힌 적이 이제까지 없었다 — grandfather로 얼리되(AC4류 개별수리는 이",
     "스토리 몫이 아니다, 위 여러 전례와 동일 판정), 은폐가 걷혔다는 사실 자체를 여기",
-    "남긴다. 넷 다 develop 기존 코드(이 PR의 diff 아님) — git diff로 재확認."
+    "남긴다. 넷 다 develop 기존 코드(이 PR의 diff 아님) — git diff로 재확認.",
+    "",
+    "story #3183(2026-08-28, PR#3588) — story-detail-panel.tsx의 raw <button> 37건을",
+    "<Button variant=\"ghost\">로 이관하며 이 파일 destructive 항목의 className 리터럴이",
+    "바뀌었다(min-h-0/min-w-0 추가·transition 제거 — 순수 리팩터, 색 자체는 무변경). 옛",
+    "리터럴 키는 develop에 더는 없어 stale로 남고, 새 리터럴을 grandfather로 추가 등재한다",
+    "(카디르 QA가 merge-base 대조로 \"신규 위반 아님, exact-string 미스매치\"로 판독 —",
+    "PO 지시: 색 자체를 고치지 말 것, 그건 이 스토리의 \"변경 0\" 원칙 밖·별도 기존 채무)."
   ],
   "keys": [
     "app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx::success::border-success bg-success-tint text-success",
@@ -91,6 +98,7 @@
     "components/hypotheses/hypothesis-gate-badge.tsx::success::h-7 gap-1 text-success hover:bg-success-tint hover:text-success",
     "components/inbox/approvals-queue.tsx::success::h-7 gap-1 text-success hover:bg-success-tint hover:text-foreground",
     "components/kanban/story-detail-panel.tsx::destructive::absolute right-1 top-1 hidden rounded bg-destructive/20 p-0.5 text-destructive transition group-hover:block hover:bg-destructive/30",
+    "components/kanban/story-detail-panel.tsx::destructive::h-auto min-h-0 min-w-0 absolute right-1 top-1 hidden rounded bg-destructive/20 p-0.5 text-destructive group-hover:block hover:bg-destructive/30",
     "components/nav/profile-menu.tsx::destructive::flex items-center gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive",
     "components/settings/workflow-line-editor-section.tsx::success::gap-1 text-success hover:bg-success-tint hover:text-foreground",
     "components/storage/storage-delete-dialog.tsx::destructive::grid size-[30px] shrink-0 place-items-center rounded-full bg-destructive/10 text-destructive",

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1336,22 +1336,23 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 </div>
               </div>
             ) : (
-              <button
+              <Button
                 type="button"
-                className="group flex w-full items-start gap-1 text-left"
+                variant="ghost"
+                className="group h-auto min-h-0 w-full min-w-0 items-start justify-start gap-1 p-0 text-left font-normal"
                 onClick={() => setEditingTitle(true)}
               >
                 <h2 className="text-lg font-semibold text-foreground">{story.title}</h2>
                 <span className="mt-1 shrink-0 text-xs text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">✎</span>
-              </button>
+              </Button>
             )}
             <div className="flex items-center gap-2">
               <DropdownMenu>
                 <DropdownMenuTrigger
                   render={
-                    <button type="button" disabled={savingStatus} aria-label={t('status')}>
+                    <Button type="button" variant="ghost" className="h-auto min-h-0 min-w-0 p-0" disabled={savingStatus} aria-label={t('status')}>
                       <StatusBadge status={localStatus} label={statusLabel} interactive />
-                    </button>
+                    </Button>
                   }
                 />
                 <DropdownMenuContent align="start">
@@ -1391,14 +1392,15 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   {t('verificationPending')}
                 </span>
               ) : (
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() => void handleRequestVerification()}
                   disabled={requestingVerification}
-                  className="inline-flex items-center gap-1 rounded-[7px] border border-border px-2 py-0.5 text-[11px] font-medium text-muted-foreground hover:text-foreground disabled:opacity-50"
+                  className="h-auto min-h-0 min-w-0 inline-flex items-center gap-1 rounded-[7px] border border-border px-2 py-0.5 text-[11px] font-medium text-muted-foreground hover:text-foreground disabled:opacity-50"
                 >
                   {requestingVerification ? t('loading') : t('requestVerification')}
-                </button>
+                </Button>
               )}
             </div>
             {/* E-VERIFY V0-S3 Lv1/Lv2 + P0-04 Claimed-vs-Verified — 완료 badge의 연장으로 읽히도록
@@ -1422,16 +1424,17 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 수 없는 조작). 에이전트 계정에도 트리거를 열어두면 #2091/#2103과 같은 결함이라
                 미리 숨긴다. */}
             <HumanOnlyAction>
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 onClick={() => setShowDeleteConfirm(true)}
-                className="flex items-center gap-1 rounded-md border border-destructive/40 px-2.5 py-1.5 text-xs text-foreground transition hover:bg-destructive/10"
+                className="h-auto min-h-0 min-w-0 flex items-center gap-1 rounded-md border border-destructive/40 px-2.5 py-1.5 text-xs text-foreground hover:bg-destructive/10"
                 aria-label={t('deleteStory')}
               >
                 <Trash2 className="h-3.5 w-3.5" />
-              </button>
+              </Button>
             </HumanOnlyAction>
-            <button type="button" onClick={onClose} className="rounded-md border border-border px-3 py-2 text-muted-foreground transition hover:text-foreground hover:bg-muted/50">✕</button>
+            <Button type="button" variant="ghost" onClick={onClose} className="h-auto min-h-0 min-w-0 rounded-md border border-border px-3 py-2 text-muted-foreground hover:text-foreground hover:bg-muted/50">✕</Button>
           </div>
         </div>
         {/* story #2528 — 전역 스크롤바 숨김(#2165) 하에선 스크롤은 되나 바가 안 보여 하단
@@ -1477,48 +1480,52 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               <div className="flex items-center justify-between">
                 <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('assignee')}</span>
                 {!editingAssignee && (
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
                     onClick={() => setEditingAssignee(true)}
-                    className="text-xs text-muted-foreground transition hover:text-foreground"
+                    className="h-auto min-h-0 min-w-0 p-0 text-xs font-normal text-muted-foreground hover:text-foreground"
                   >
                     ✎ {t('edit')}
-                  </button>
+                  </Button>
                 )}
               </div>
               {editingAssignee ? (
                 <div className="mt-1 flex flex-col gap-1 rounded-md border border-border bg-muted/30 p-1">
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
                     onClick={() => void handleClearAssignees()}
-                    className="w-full rounded px-2 py-1.5 text-left text-sm text-muted-foreground hover:bg-muted"
+                    className="h-auto min-h-0 w-full min-w-0 justify-start rounded px-2 py-1.5 text-left text-sm font-normal text-muted-foreground hover:bg-muted"
                   >
                     — {t('clearAssignees')}
-                  </button>
+                  </Button>
                   {members.filter((m, i, arr) => arr.findIndex((x) => x.id === m.id) === i).map((m) => {
                     const selected = localAssigneeIds.includes(m.id);
                     return (
-                      <button
+                      <Button
                         key={m.id}
                         type="button"
+                        variant="ghost"
                         onClick={() => void handleToggleAssignee(m.id)}
-                        className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted ${selected ? 'font-medium text-foreground' : 'text-muted-foreground'}`}
+                        className={`h-auto min-h-0 w-full min-w-0 items-center justify-start gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted ${selected ? 'font-medium text-foreground' : 'font-normal text-muted-foreground'}`}
                       >
                         <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-foreground">
                           {m.name.slice(0, 2).toUpperCase()}
                         </span>
                         {m.name}
                         {selected && <span className="ml-auto text-primary">✓</span>}
-                      </button>
+                      </Button>
                     );
                   })}
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
                     onClick={() => setEditingAssignee(false)}
-                    className="mt-1 w-full rounded px-2 py-1 text-center text-xs text-muted-foreground hover:bg-muted"
+                    className="h-auto min-h-0 mt-1 w-full min-w-0 rounded px-2 py-1 text-center text-xs font-normal text-muted-foreground hover:bg-muted"
                   >
                     {t('cancel')}
-                  </button>
+                  </Button>
                 </div>
               ) : (
                 <p className="mt-1 text-sm text-foreground">
@@ -1579,13 +1586,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               <div className="flex items-center justify-between">
                 <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('description')}</span>
                 {!editingDescription && (
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
                     onClick={() => setEditingDescription(true)}
-                    className="text-xs text-muted-foreground transition hover:text-foreground"
+                    className="h-auto min-h-0 min-w-0 p-0 text-xs font-normal text-muted-foreground hover:text-foreground"
                   >
                     ✎ {t('edit')}
-                  </button>
+                  </Button>
                 )}
               </div>
               {editingDescription ? (
@@ -1623,13 +1631,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   <DescriptionViewer description={story.description} references={outgoingRefs} bareNumberTargets={bareNumberTargets} />
                 </div>
               ) : (
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() => setEditingDescription(true)}
-                  className="mt-2 w-full rounded-md border border-dashed border-border py-3 text-sm text-muted-foreground transition hover:border-primary hover:text-primary"
+                  className="h-auto min-h-0 mt-2 w-full min-w-0 rounded-md border border-dashed border-border py-3 text-sm font-normal text-muted-foreground hover:border-primary hover:text-primary"
                 >
                   + {t('addDescription')}
-                </button>
+                </Button>
               )}
             </div>
 
@@ -1638,13 +1647,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               <div className="flex items-center justify-between">
                 <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('acceptanceCriteria')}</span>
                 {!editingAC && (
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
                     onClick={() => setEditingAC(true)}
-                    className="text-xs text-muted-foreground transition hover:text-foreground"
+                    className="h-auto min-h-0 min-w-0 p-0 text-xs font-normal text-muted-foreground hover:text-foreground"
                   >
                     ✎ {t('edit')}
-                  </button>
+                  </Button>
                 )}
               </div>
               {editingAC ? (
@@ -1675,13 +1685,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   <DescriptionViewer description={story.acceptance_criteria} references={outgoingRefs} bareNumberTargets={bareNumberTargets} />
                 </div>
               ) : (
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() => setEditingAC(true)}
-                  className="mt-2 w-full rounded-md border border-dashed border-border py-3 text-sm text-muted-foreground transition hover:border-primary hover:text-primary"
+                  className="h-auto min-h-0 mt-2 w-full min-w-0 rounded-md border border-dashed border-border py-3 text-sm font-normal text-muted-foreground hover:border-primary hover:text-primary"
                 >
                   + {t('addAcceptanceCriteria')}
-                </button>
+                </Button>
               )}
             </div>
 
@@ -1695,14 +1706,15 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
             <div>
               <div className="flex items-center justify-between">
                 <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('attachments')}</span>
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() => attachInputRef.current?.click()}
                   disabled={uploadingAttachment || (story.attachments?.length ?? 0) >= STORY_ATTACHMENT_LIMIT}
-                  className="flex items-center gap-1 text-xs text-muted-foreground transition hover:text-foreground disabled:opacity-40"
+                  className="h-auto min-h-0 min-w-0 flex items-center gap-1 p-0 text-xs font-normal text-muted-foreground hover:text-foreground disabled:opacity-40"
                 >
                   <Paperclip className="size-3" /> + 추가
-                </button>
+                </Button>
               </div>
               <input
                 ref={attachInputRef}
@@ -1728,26 +1740,28 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                             <AttachmentFile storedUrl={att.url} storyId={story.id} label={label} Icon={Icon} />
                           )
                         ) : null}
-                        <button
+                        <Button
                           type="button"
+                          variant="ghost"
                           onClick={() => void handleRemoveAttachment(att.url)}
-                          className="absolute right-1 top-1 hidden rounded bg-destructive/20 p-0.5 text-destructive transition group-hover:block hover:bg-destructive/30"
+                          className="h-auto min-h-0 min-w-0 absolute right-1 top-1 hidden rounded bg-destructive/20 p-0.5 text-destructive group-hover:block hover:bg-destructive/30"
                           aria-label="첨부 삭제"
                         >
                           <X className="size-3" />
-                        </button>
+                        </Button>
                       </div>
                     );
                   })}
                 </div>
               ) : !uploadingAttachment ? (
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() => attachInputRef.current?.click()}
-                  className="mt-2 w-full rounded-md border border-dashed border-border py-3 text-sm text-muted-foreground transition hover:border-primary hover:text-primary"
+                  className="h-auto min-h-0 mt-2 w-full min-w-0 rounded-md border border-dashed border-border py-3 text-sm font-normal text-muted-foreground hover:border-primary hover:text-primary"
                 >
                   + {t('addAttachment')}
-                </button>
+                </Button>
               ) : null}
               {uploadingAttachment && (
                 <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
@@ -1768,13 +1782,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   <Tag className="size-3" />
                   <span>Labels</span>
                 </div>
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() => setShowLabelPicker((v) => !v)}
-                  className="rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-muted transition-colors"
+                  className="h-auto min-h-0 min-w-0 rounded px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground hover:bg-muted"
                 >
                   {showLabelPicker ? '닫기' : '+ 추가'}
-                </button>
+                </Button>
               </div>
 
               {loadingLabels ? (
@@ -1786,14 +1801,15 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                       {storyLabels.map((label) => (
                         <span key={label.itemLabelId} className="group relative inline-flex">
                           <LabelChip label={label} />
-                          <button
+                          <Button
                             type="button"
+                            variant="ghost"
                             onClick={() => void handleDetachLabel(label.itemLabelId)}
-                            className="absolute -right-1 -top-1 hidden h-3.5 w-3.5 items-center justify-center rounded-full bg-muted-foreground/20 text-foreground hover:bg-destructive/80 hover:text-destructive-foreground group-hover:flex"
+                            className="h-3.5 min-h-0 w-3.5 min-w-0 absolute -right-1 -top-1 hidden items-center justify-center rounded-full bg-muted-foreground/20 p-0 text-foreground hover:bg-destructive/80 hover:text-destructive-foreground group-hover:flex"
                             aria-label={`Remove ${label.name}`}
                           >
                             <X className="size-2" />
-                          </button>
+                          </Button>
                         </span>
                       ))}
                     </div>
@@ -1809,15 +1825,16 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                           {orgLabels
                             .filter((l) => !storyLabels.some((sl) => sl.id === l.id))
                             .map((label) => (
-                              <button
+                              <Button
                                 key={label.id}
                                 type="button"
+                                variant="ghost"
                                 onClick={() => void handleAttachLabel(label.id)}
-                                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-2 py-0.5 text-xs text-foreground transition hover:bg-muted"
+                                className="h-auto min-h-0 min-w-0 items-center gap-1.5 rounded-full border border-border bg-background px-2 py-0.5 text-xs font-normal text-foreground hover:bg-muted"
                               >
                                 <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: label.color ?? '#8A8F98' }} />
                                 {label.name}
-                              </button>
+                              </Button>
                             ))}
                         </div>
                       )}
@@ -1825,11 +1842,12 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                       <div className="flex items-center gap-1.5">
                         <div className="flex gap-1">
                           {LABEL_PRESET_COLORS.map((hex) => (
-                            <button
+                            <Button
                               key={hex}
                               type="button"
+                              variant="ghost"
                               onClick={() => setNewLabelColor(hex)}
-                              className={`h-4 w-4 rounded-full border-2 transition ${newLabelColor === hex ? 'border-foreground' : 'border-transparent'}`}
+                              className={`h-4 min-h-0 w-4 min-w-0 rounded-full border-2 p-0 ${newLabelColor === hex ? 'border-foreground' : 'border-transparent'}`}
                               style={{ backgroundColor: hex }}
                               aria-label={hex}
                             />
@@ -1843,14 +1861,15 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                           placeholder="새 라벨 이름"
                           className="min-w-0 flex-1 rounded border border-border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary"
                         />
-                        <button
+                        <Button
                           type="button"
+                          variant="ghost"
                           onClick={() => void handleCreateLabel()}
                           disabled={!newLabelName.trim() || creatingLabel}
-                          className="rounded bg-primary px-2 py-1 text-xs text-primary-foreground disabled:opacity-50 hover:bg-primary/90 transition"
+                          className="h-auto min-h-0 min-w-0 rounded bg-primary px-2 py-1 text-xs font-normal text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
                         >
                           {creatingLabel ? '...' : '생성'}
-                        </button>
+                        </Button>
                       </div>
                     </div>
                   )}
@@ -1865,13 +1884,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   <GitFork className="size-3" />
                   <span>Dependencies</span>
                 </div>
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() => setShowAddDep((v) => !v)}
-                  className="flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-muted transition-colors"
+                  className="h-auto min-h-0 min-w-0 flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-normal text-muted-foreground hover:bg-muted"
                 >
                   <Plus className="size-3" />{t('dep.add')}
-                </button>
+                </Button>
               </div>
 
               {/* 미완선행 경고 strip */}
@@ -1913,18 +1933,18 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                     const blocker = storyMap[d.from_id];
                     return (
                       <div key={d.id} className="group flex w-full items-center gap-2 rounded-md border border-warning-border bg-warning-tint px-2.5 py-1.5 text-xs text-foreground">
-                        <button type="button" onClick={() => onNavigate?.(d.from_id)} className="flex min-w-0 flex-1 items-center gap-2 text-left" disabled={!onNavigate}>
+                        <Button type="button" variant="ghost" onClick={() => onNavigate?.(d.from_id)} className="h-auto min-h-0 min-w-0 flex flex-1 items-center justify-start gap-2 p-0 text-left font-normal" disabled={!onNavigate}>
                           <AlertTriangle className="size-3 shrink-0" />
                           <span className="font-medium shrink-0">Blocked by</span>
                           <span className="min-w-0 truncate">{blocker?.title ?? `#${d.from_id.slice(0, 6)}`}</span>
                           {blocker?.status ? <span className="ml-auto shrink-0 font-mono text-[10px] opacity-60">{blocker.status}</span> : null}
-                        </button>
-                        <button type="button" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="hidden shrink-0 rounded p-0.5 hover:bg-warning/20 group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
+                        </Button>
+                        <Button type="button" variant="ghost" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="h-auto min-h-0 min-w-0 hidden shrink-0 rounded p-0.5 hover:bg-warning/20 group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
                           <ArrowLeftRight className="size-3" />
-                        </button>
-                        <button type="button" onClick={() => void handleRemoveDep(d.id)} className="hidden shrink-0 rounded p-0.5 hover:bg-warning/20 group-hover:block" aria-label="Remove">
+                        </Button>
+                        <Button type="button" variant="ghost" onClick={() => void handleRemoveDep(d.id)} className="h-auto min-h-0 min-w-0 hidden shrink-0 rounded p-0.5 hover:bg-warning/20 group-hover:block" aria-label="Remove">
                           <X className="size-3" />
-                        </button>
+                        </Button>
                       </div>
                     );
                   })}
@@ -1934,18 +1954,18 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                     const blocked = storyMap[d.to_id];
                     return (
                       <div key={d.id} className="group flex w-full items-center gap-2 rounded-md border border-border bg-muted/40 px-2.5 py-1.5 text-xs text-muted-foreground">
-                        <button type="button" onClick={() => onNavigate?.(d.to_id)} className="flex min-w-0 flex-1 items-center gap-2 text-left" disabled={!onNavigate}>
+                        <Button type="button" variant="ghost" onClick={() => onNavigate?.(d.to_id)} className="h-auto min-h-0 min-w-0 flex flex-1 items-center justify-start gap-2 p-0 text-left font-normal" disabled={!onNavigate}>
                           <GitFork className="size-3 shrink-0" />
                           <span className="font-medium shrink-0">Blocking</span>
                           <span className="min-w-0 truncate">{blocked?.title ?? `#${d.to_id.slice(0, 6)}`}</span>
                           {blocked?.status ? <span className="ml-auto shrink-0 font-mono text-[10px] opacity-60">{blocked.status}</span> : null}
-                        </button>
-                        <button type="button" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
+                        </Button>
+                        <Button type="button" variant="ghost" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="h-auto min-h-0 min-w-0 hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
                           <ArrowLeftRight className="size-3" />
-                        </button>
-                        <button type="button" onClick={() => void handleRemoveDep(d.id)} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label="Remove">
+                        </Button>
+                        <Button type="button" variant="ghost" onClick={() => void handleRemoveDep(d.id)} className="h-auto min-h-0 min-w-0 hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label="Remove">
                           <X className="size-3" />
-                        </button>
+                        </Button>
                       </div>
                     );
                   })}
@@ -1955,18 +1975,18 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                     const target = storyMap[d.to_id];
                     return (
                       <div key={d.id} className="group flex w-full items-center gap-2 rounded-md border border-border bg-muted/20 px-2.5 py-1.5 text-xs text-muted-foreground">
-                        <button type="button" onClick={() => onNavigate?.(d.to_id)} className="flex min-w-0 flex-1 items-center gap-2 text-left" disabled={!onNavigate}>
+                        <Button type="button" variant="ghost" onClick={() => onNavigate?.(d.to_id)} className="h-auto min-h-0 min-w-0 flex flex-1 items-center justify-start gap-2 p-0 text-left font-normal" disabled={!onNavigate}>
                           <GitFork className="size-3 shrink-0 rotate-90" />
                           <span className="font-medium shrink-0">Depends on</span>
                           <span className="min-w-0 truncate">{target?.title ?? `#${d.to_id.slice(0, 6)}`}</span>
                           {target?.status ? <span className="ml-auto shrink-0 font-mono text-[10px] opacity-60">{target.status}</span> : null}
-                        </button>
-                        <button type="button" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
+                        </Button>
+                        <Button type="button" variant="ghost" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="h-auto min-h-0 min-w-0 hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
                           <ArrowLeftRight className="size-3" />
-                        </button>
-                        <button type="button" onClick={() => void handleRemoveDep(d.id)} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label="Remove">
+                        </Button>
+                        <Button type="button" variant="ghost" onClick={() => void handleRemoveDep(d.id)} className="h-auto min-h-0 min-w-0 hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label="Remove">
                           <X className="size-3" />
-                        </button>
+                        </Button>
                       </div>
                     );
                   })}
@@ -1976,18 +1996,18 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                     const source = storyMap[d.from_id];
                     return (
                       <div key={d.id} className="group flex w-full items-center gap-2 rounded-md border border-border bg-muted/20 px-2.5 py-1.5 text-xs text-muted-foreground">
-                        <button type="button" onClick={() => onNavigate?.(d.from_id)} className="flex min-w-0 flex-1 items-center gap-2 text-left" disabled={!onNavigate}>
+                        <Button type="button" variant="ghost" onClick={() => onNavigate?.(d.from_id)} className="h-auto min-h-0 min-w-0 flex flex-1 items-center justify-start gap-2 p-0 text-left font-normal" disabled={!onNavigate}>
                           <GitFork className="size-3 shrink-0 -rotate-90" />
                           <span className="font-medium shrink-0">Depended by</span>
                           <span className="min-w-0 truncate">{source?.title ?? `#${d.from_id.slice(0, 6)}`}</span>
                           {source?.status ? <span className="ml-auto shrink-0 font-mono text-[10px] opacity-60">{source.status}</span> : null}
-                        </button>
-                        <button type="button" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
+                        </Button>
+                        <Button type="button" variant="ghost" onClick={() => void handleToggleDepType(d)} disabled={updatingDepId === d.id} className="h-auto min-h-0 min-w-0 hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label={t('dep.toggleType')} title={t('dep.toggleType')}>
                           <ArrowLeftRight className="size-3" />
-                        </button>
-                        <button type="button" onClick={() => void handleRemoveDep(d.id)} className="hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label="Remove">
+                        </Button>
+                        <Button type="button" variant="ghost" onClick={() => void handleRemoveDep(d.id)} className="h-auto min-h-0 min-w-0 hidden shrink-0 rounded p-0.5 hover:bg-muted group-hover:block" aria-label="Remove">
                           <X className="size-3" />
-                        </button>
+                        </Button>
                       </div>
                     );
                   })}
@@ -1999,14 +2019,15 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 <div className="mt-2 space-y-2 rounded-lg border border-border bg-muted/20 p-2">
                   <div className="flex gap-1">
                     {(['blocks', 'depends_on'] as const).map((type) => (
-                      <button
+                      <Button
                         key={type}
                         type="button"
+                        variant="ghost"
                         onClick={() => setDepType(type)}
-                        className={`rounded px-2 py-0.5 text-[10px] font-medium transition ${depType === type ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'}`}
+                        className={`h-auto min-h-0 min-w-0 rounded px-2 py-0.5 text-[10px] font-medium ${depType === type ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'}`}
                       >
                         {type === 'blocks' ? t('dep.typeBlocks') : t('dep.typeDepends')}
-                      </button>
+                      </Button>
                     ))}
                   </div>
                   <input
@@ -2035,11 +2056,12 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                         )}
                         {items.map((s) => (
                           <li key={s.id}>
-                            <button
+                            <Button
                               type="button"
+                              variant="ghost"
                               onClick={() => void handleAddDep(s.id)}
                               disabled={addingDep}
-                              className="w-full px-2 py-1.5 text-left text-xs hover:bg-muted disabled:opacity-50"
+                              className="h-auto min-h-0 w-full min-w-0 flex-col items-start justify-start px-2 py-1.5 text-left text-xs font-normal hover:bg-muted disabled:opacity-50"
                             >
                               <span className="block truncate">{s.title}</span>
                               {showingCandidates ? (
@@ -2048,7 +2070,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                                   {'matched_snippet' in s && s.matched_snippet ? ` · ${s.matched_snippet}` : ''}
                                 </span>
                               ) : null}
-                            </button>
+                            </Button>
                           </li>
                         ))}
                       </ul>
@@ -2193,13 +2215,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                               <span>·</span>
                               <span>{new Date(activity.created_at).toLocaleString()}</span>
                               {isLong ? (
-                                <button
+                                <Button
                                   type="button"
+                                  variant="ghost"
                                   onClick={() => setExpandedActivityId(expanded ? null : activity.id)}
-                                  className="ml-auto rounded px-1.5 py-0.5 text-muted-foreground transition hover:bg-muted hover:text-foreground"
+                                  className="h-auto min-h-0 min-w-0 ml-auto rounded px-1.5 py-0.5 font-normal text-muted-foreground hover:bg-muted hover:text-foreground"
                                 >
                                   {expanded ? '접기' : '펼치기'}
-                                </button>
+                                </Button>
                               ) : null}
                             </div>
                           </li>


### PR DESCRIPTION
## 배경
[[DS 순감소 리팩터 1호] story-detail-panel raw <button> 37건 → Button 이관 (키스톤 baseline 최다 파일)](entity:story:627b54bf-a9b4-499b-bbce-b057bad52cf6)

키스톤(#3164)으로 「신규 증가 0」 게이트는 섰고, 이제 grandfather baseline을 실제로 줄이는 리팩터 판. `components/kanban/story-detail-panel.tsx`가 baseline 단일 파일 최다(raw button 37건) — S3a `chat-list-view.tsx` 4건 전환과 동형 패턴으로 순수 리팩터한다.

## 동작 변경 0 — 전량 `<Button variant="ghost">` 전환
원본 className은 그대로 보존하고, Button 기본 클래스(`h-9`·`min-h-11`·`min-w-11`·`px-3`·`font-medium`)가 원본 레이아웃/타이포를 덮어쓰지 않도록 파일별 조합에 맞춰 `h-auto`/`min-h-0`/`min-w-0`/`p-0`/`font-normal`/`justify-start`/`flex-col`을 개별 보정.

## 회귀 방지 3종(변환 중 자체 발견·직접 보정)
- **`min-h-11` 강제 높이**: Button 기본 size는 `min-height:2.75rem`(44px) 터치 타깃 하한을 건다 — `height`(`h-auto`)와 `min-height`(`min-h-11`)는 다른 CSS 속성이라 `h-auto`만으론 안 풀린다. 컴팩트 아이콘 버튼(라벨 삭제 X·색상 스와치 등)은 전부 `min-h-0 min-w-0`도 함께 넣어 원래 크기로 고정.
- **`font-medium` 강제 굵기**: 원본에 font-weight 클래스가 없던 버튼(대부분)은 Button 기본값 `font-medium`이 조용히 굵게 만든다 — 그런 자리엔 전부 `font-normal`을 명시 추가. 조건부 굵기(담당자 토글의 선택/미선택)는 삼항 else 분기에도 `font-normal`을 명시해 원본 동작을 그대로 보존.
- **`inline-flex`의 stacking 파괴**: dep 후보 검색 결과 항목(제목+힌트 두 줄)은 원본이 flex 없이 block 자식이 자연히 세로로 쌓이던 자리였다 — Button의 기본 `inline-flex items-center`(가로 정렬)로 바뀌면 두 줄이 나란히 붙어버려 `flex-col`을 명시 추가해 원래 세로 배치를 복원했다.

## 검증
`story-detail-panel.test.tsx` 34건 + 소비처(`kanban-board`·`description-viewer`·`epic-swimlane-board`·`flow-node-story-panel`) 105건 전부 PASS(동작 회귀 0 실측), 전체 `vitest` 530파일/4964건 PASS, `tsc --noEmit`/`pnpm lint` 0 에러, `pnpm build` 성공.

## 순감소 실측
`raw-button-baseline.json`: `story-detail-panel.tsx` 항목 삭제(37→0), 185f/507occ → 184f/470occ(스토리 예측치와 정확히 일치). 두 키스톤 가드 재실행 0 신규위반.

## 잔여
라이트/다크·hover/active 상태의 실 픽셀 대조는 유나양 design 게이트 몫(스토리 AC4 명시) — 이 PR은 클래스 조합 근거를 커밋 메시지·diff에 명확히 남겨 그 판정을 돕는다. prod 무접촉(승격 별도).

## Test plan
- [ ] 유나양 design 게이트: 라이트/다크·hover/active 상태 실 픽셀 대조(스토리 상세는 최상위 빈도 표면)
- [ ] 카디르군 QA: 담당자/라벨/의존성 편집 플로우 실클릭 왕복