### PR TITLE
[결제②-C] AU 한도 집행 — 80/90% 경고 + 100%+유예 일시중지

### DIFF
--- a/backend/alembic/versions/0288_org_subscriptions_au_enforcement.py
+++ b/backend/alembic/versions/0288_org_subscriptions_au_enforcement.py
@@ -1,0 +1,55 @@
+"""story #3176(결제②-C) — AU 한도 집행: org_subscriptions에 크론-캐시 상태 컬럼 5종 신설.
+
+doc `au-limit-enforcement-grounding-3176`(페드루 PO 승인 2026-08-28) §1.3 — AU는 기존
+storage/seats/agent 5종(즉시 단일임계 402)과 달리 80%/90% 2단계 경고+유예(110%/7일)+
+일시중지 구조라, 크로싱 시각을 기억할 신규 상태가 필요하다. paused 여부는 요청마다
+재계산하지 않고 크론(`au-usage-warn`)이 주기적으로 캐시(`au_paused_at`)에 박아두고
+미들웨어/인증 dependency는 그 캐시만 읽는다 — `au_eval_at`(크론이 매 실행마다 무조건
+갱신하는 last-evaluated 마커)로 fail-open을 구현한다(크론이 죽거나 캐시가 stale이면
+차단하지 않는다, 페드루 PO 조건).
+
+Revision ID: 0288
+Revises: 0287
+Create Date: 2026-08-28
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0288"
+down_revision = "0287"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "org_subscriptions",
+        sa.Column("au_warn_80_notified_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "org_subscriptions",
+        sa.Column("au_warn_90_notified_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "org_subscriptions",
+        sa.Column("au_grace_started_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "org_subscriptions",
+        sa.Column("au_paused_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "org_subscriptions",
+        sa.Column("au_eval_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("org_subscriptions", "au_eval_at")
+    op.drop_column("org_subscriptions", "au_paused_at")
+    op.drop_column("org_subscriptions", "au_grace_started_at")
+    op.drop_column("org_subscriptions", "au_warn_90_notified_at")
+    op.drop_column("org_subscriptions", "au_warn_80_notified_at")

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import async_session_factory
 from app.core.security import JWTError, decode_jwt, hash_token
 from app.dependencies.database import get_db
+from app.services.au_metering import STREAMING_PATHS as _AU_STREAMING_PATHS
 
 logger = logging.getLogger(__name__)
 
@@ -484,14 +485,30 @@ async def get_current_user(
         credentials=credentials, x_agent_api_key=x_agent_api_key,
         x_mcp_transport=x_mcp_transport, request=request,
     )
-    # story #3173(결제②-B) — 소비처: app/middleware/au_metering.py(app/main.py에 등록)가
-    # 응답 완료 후 이 값들을 읽어 AU 계측 대상 여부·귀속 조직을 정한다. FastAPI dependency는
-    # 라우터 안에서만 살고 ASGI 미들웨어 레이어로 안 새어나가므로, 여기서 request.state에
-    # 명시 기록해야 미들웨어가 볼 수 있다. ⛔이 값들의 유일한 소비처가 저 미들웨어다 — 새
-    # 소비처가 생기면 이 주석도 같이 갱신할 것(형제 드리프트 재발 방지, #3175 교훈).
+    # story #3173(결제②-B) — 소비처①: app/services/au_metering.py(AUMeteringMiddleware,
+    # app/main.py에 등록)가 응답 완료 후 이 값들을 읽어 AU 계측 대상 여부·귀속 조직을 정한다.
+    # FastAPI dependency는 라우터 안에서만 살고 ASGI 미들웨어 레이어로 안 새어나가므로,
+    # 여기서 request.state에 명시 기록해야 미들웨어가 볼 수 있다.
+    # ⛔소비처②(story #3176, 결제②-C, 2026-08-28 추가): AU 한도 집행(check_au_not_paused)도
+    # 여기서 직접 부른다 — AUMeteringMiddleware.dispatch()에 얹지 못한 이유는 그 미들웨어가
+    # `call_next()`(=이 dependency 포함 전체 라우팅)보다 **먼저** 실행돼 request.state.
+    # au_actor 자체가 아직 없는 시점이기 때문(doc `au-limit-enforcement-grounding-3176` §1.4
+    # 원안은 미들웨어 사전체크였으나, 실제 타이밍 제약 확認 후 이 지점으로 옮김). 새 소비처가
+    # 또 생기면 이 주석도 같이 갱신할 것(형제 드리프트 재발 방지, #3175 교훈).
     if request is not None:
         request.state.au_actor = "agent" if is_au_billable_agent(auth) else "human"
         request.state.au_org_id = auth.org_id
+        if (
+            request.state.au_actor == "agent"
+            and request.method in _WRITE_METHODS
+            and request.url.path not in _AU_STREAMING_PATHS
+            and auth.org_id
+        ):
+            from app.core.config import settings as _settings
+            if _settings.is_ee_enabled:
+                from ee.plan_limits import check_au_not_paused  # type: ignore[import]
+                async with async_session_factory() as _au_session:
+                    await check_au_not_paused(_au_session, uuid.UUID(auth.org_id))
     return auth
 
 

--- a/backend/app/models/org_subscription.py
+++ b/backend/app/models/org_subscription.py
@@ -60,6 +60,17 @@ class OrgSubscription(Base):
         UUID(as_uuid=True), ForeignKey("offering_versions.id"), nullable=True
     )
     pending_change_apply_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # story #3176(결제②-C, doc au-limit-enforcement-grounding-3176 §1.3) — AU는 storage_
+    # warn_notified_at과 달리 2단계 경고(80%/90%)+유예(110%/7일)라 크론(`au-usage-warn`)이
+    # 계산할 상태가 더 필요하다. paused 여부는 요청마다 재계산하지 않고 크론이 캐시에
+    # 박아두는 값만 읽는다(au_metering.py::check_au_not_paused) — au_eval_at은 크론이 매
+    # 실행마다 무조건 갱신하는 last-evaluated 마커로, 이게 stale이면(크론이 죽으면) 캐시된
+    # au_paused_at을 신뢰하지 않고 fail-open한다(페드루 PO 조건, 2026-08-28).
+    au_warn_80_notified_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    au_warn_90_notified_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    au_grace_started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    au_paused_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    au_eval_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -938,6 +938,147 @@ async def storage_usage_warn(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── story #3176(결제②-C): AU 80%/90%/유예 경고 + paused 캐시 크론 ──────────────
+
+_AU_WARN_80_THRESHOLD = 0.8
+_AU_WARN_90_THRESHOLD = 0.9
+_AU_WARN_90_COOLDOWN = timedelta(days=7)  # storage_usage_warn과 동형(90%만 이메일 대상).
+_AU_GRACE_WINDOW = timedelta(days=7)
+_AU_GRACE_OVERAGE_RATIO = 1.10  # 110%
+
+
+@router.get("/au-usage-warn")
+async def au_usage_warn(
+    request: Request,
+    session: AsyncSession = Depends(get_worker_db),
+) -> JSONResponse:
+    """story #3176 — doc `au-limit-enforcement-grounding-3176` §1.3 구현. AU는 storage와
+    달리 80%(마커만·이메일 없음, §11.1 "제품내경고"는 FE 별도 스토리 — 페드루 PO 조건②)·
+    90%(관리자 메일, storage_usage_warn과 동형 cooldown/re-arm)·100%+유예(110% 또는 7일 중
+    먼저, Free는 유예 없이 즉시)의 3단계를 이 크론 한 번의 순회로 전부 계산해 캐시한다.
+
+    ⛔`au_paused_at`은 요청마다 재계산하지 않는다(§1.3 (b)안, PO 승인) — 미들웨어/auth
+    dependency(`ee/plan_limits.py::check_au_not_paused`)는 이 크론이 써둔 캐시만 읽는다.
+    `au_eval_at`은 **처리된 모든 org에 대해 무조건** now()로 갱신한다 — 크론이 죽거나 이
+    org까지 못 왔으면(예외로 중간에 멈추면) 그 org의 au_eval_at이 그대로 stale해지고,
+    check_au_not_paused()가 stale 캐시를 fail-open으로 처리한다(페드루 PO 조건, 2026-08-28).
+    """
+    verify_cron(request)
+    try:
+        from ee.plan_limits import KNOWN_TIERS  # type: ignore[import]
+
+        now = datetime.now(timezone.utc)
+        period_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        subs = list((await session.execute(
+            select(OrgSubscription).where(OrgSubscription.status == "active")
+        )).scalars().all())
+        # storage_usage_warn과 동일 규율 — tier당 대표 1행(currency 무관·ASC 결정적).
+        au_limits = {
+            t: lim for t, lim in (await session.execute(
+                text(
+                    "SELECT DISTINCT ON (tier) tier, au_limit FROM offering_versions "
+                    "WHERE effective_to IS NULL ORDER BY tier, currency ASC"
+                )
+            )).all()
+        }
+        evaluated = 0
+        notified_90 = 0
+        newly_paused = 0
+        for sub in subs:
+            if sub.tier not in KNOWN_TIERS:
+                logger.error("au-usage-warn: unknown tier %r org_id=%s — skipping(fail-open)", sub.tier, sub.org_id)
+                continue  # au_eval_at도 갱신 안 함 — 다음 요청은 stale 캐시로 자연히 fail-open.
+            au_limit = au_limits.get(sub.tier)
+            if not au_limit or au_limit <= 0:
+                logger.error("au-usage-warn: no/invalid au_limit for tier=%r org_id=%s — skipping(fail-open)", sub.tier, sub.org_id)
+                continue
+            current = int((await session.execute(
+                text(
+                    "SELECT current_value FROM usage_meters WHERE org_id = :oid "
+                    "AND meter_type = 'automation_units' AND period_start = :ps"
+                ),
+                {"oid": str(sub.org_id), "ps": period_start},
+            )).scalar() or 0)
+            pct = current / au_limit
+
+            values: dict = {"au_eval_at": now}
+
+            # 80% — 마커만(이메일 없음, FE 노출은 별도 스토리).
+            if pct >= _AU_WARN_80_THRESHOLD:
+                if sub.au_warn_80_notified_at is None:
+                    values["au_warn_80_notified_at"] = now
+            elif sub.au_warn_80_notified_at is not None:
+                values["au_warn_80_notified_at"] = None  # re-arm
+
+            # 90% — 관리자 메일(storage_usage_warn과 동형 cooldown).
+            if pct >= _AU_WARN_90_THRESHOLD:
+                if (
+                    sub.au_warn_90_notified_at is None
+                    or (now - sub.au_warn_90_notified_at) >= _AU_WARN_90_COOLDOWN
+                ):
+                    emails = [
+                        r[0] for r in (await session.execute(
+                            select(User.email)
+                            .join(OrgMember, User.id == OrgMember.user_id)
+                            .where(
+                                OrgMember.org_id == sub.org_id,
+                                OrgMember.role.in_(["owner", "admin"]),
+                                OrgMember.deleted_at.is_(None),
+                            )
+                        )).all()
+                    ]
+                    pct_display = round(pct * 100, 1)
+                    subject = f"[Sprintable] Automation usage (AU) at {pct_display}%"
+                    html = (
+                        f"<p>Your organization's automation usage (AU) has reached "
+                        f"<b>{pct_display}%</b> ({current} / {au_limit} AU this month).</p>"
+                        f"<p>At 100% MCP/API writes and automation will pause (reads and human "
+                        f"UI stay available). Consider upgrading before the limit is reached.</p>"
+                    )
+                    for em in emails:
+                        try:
+                            await asyncio.to_thread(send_email, em, subject, html)
+                        except Exception:
+                            logger.warning("au-usage-warn email 실패 org=%s", sub.org_id, exc_info=True)
+                    values["au_warn_90_notified_at"] = now
+                    notified_90 += 1
+            elif sub.au_warn_90_notified_at is not None:
+                values["au_warn_90_notified_at"] = None  # re-arm
+
+            # 100%+유예 — Free는 유예 없이 즉시 paused(§11.2 "Free AU: 즉시 경고→쓰기 중지").
+            if pct >= 1.0:
+                if sub.tier == "free":
+                    paused = True
+                else:
+                    grace_started = sub.au_grace_started_at
+                    if grace_started is None:
+                        grace_started = now
+                        values["au_grace_started_at"] = grace_started
+                    grace_expired = (now - grace_started) >= _AU_GRACE_WINDOW
+                    overage_expired = pct >= _AU_GRACE_OVERAGE_RATIO
+                    paused = grace_expired or overage_expired
+            else:
+                paused = False
+                if sub.au_grace_started_at is not None:
+                    values["au_grace_started_at"] = None  # 100% 아래로 복귀 — 유예 해제.
+
+            if paused and sub.au_paused_at is None:
+                values["au_paused_at"] = now
+                newly_paused += 1
+            elif not paused and sub.au_paused_at is not None:
+                values["au_paused_at"] = None
+
+            await session.execute(
+                update(OrgSubscription).where(OrgSubscription.id == sub.id).values(**values)
+            )
+            evaluated += 1
+        await session.commit()
+        return _ok({"evaluated_orgs": evaluated, "notified_90pct": notified_90, "newly_paused": newly_paused})
+    except Exception as exc:
+        logger.exception("au-usage-warn cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 # ─── GET /api/v2/internal/cron/db-connection-stats ─────────────────────────
 
 @router.get("/db-connection-stats")

--- a/backend/app/services/au_metering.py
+++ b/backend/app/services/au_metering.py
@@ -49,7 +49,12 @@ logger = logging.getLogger(__name__)
 # GET /api/v2/events/stream(events.py)·GET /api/v2/agent/stream(agent_gateway.py). 각
 # 라우터 파일의 다른 엔드포인트(POST /events 등)는 정상 AU 계측 대상이라 라우터 prefix
 # 전체가 아니라 이 두 정확 경로만 denylist한다.
-_STREAMING_PATHS = frozenset({"/api/v2/events/stream", "/api/v2/agent/stream"})
+#
+# story #3176(결제②-C) — 언더스코어 없는 이름(모듈 밖 재사용 의도 명시): `ee/plan_limits.py`
+# ::check_au_not_paused()를 호출하는 `app/dependencies/auth.py`가 「이 요청이 애초에 AU
+# 집행 판정 대상인지」(스트리밍 제외)를 같은 축으로 재사용한다 — 판별 로직 두 곳에 따로
+# 짜면 드리프트(한쪽만 갱신)가 재발 클래스(feedback_shared_primitive_move_test_sweep 동형).
+STREAMING_PATHS = frozenset({"/api/v2/events/stream", "/api/v2/agent/stream"})
 
 _READ_METHODS = frozenset({"GET", "HEAD"})
 _WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
@@ -208,7 +213,7 @@ class AUMeteringMiddleware(BaseHTTPMiddleware):
     def _plan_metering(self, request: Request, response: Response) -> tuple[uuid.UUID | None, int]:
         """순수 판단(I/O 없음) — 이 요청이 계측 대상인지·몇 AU인지만 정한다. 실제 쓰기는
         호출부가 별도 태스크로 던진다(위 클래스 docstring 참고)."""
-        if request.url.path in _STREAMING_PATHS:
+        if request.url.path in STREAMING_PATHS:
             return None, 0
         if response.status_code >= 400:
             return None, 0

--- a/backend/ee/plan_limits.py
+++ b/backend/ee/plan_limits.py
@@ -15,10 +15,17 @@ Member/Agent 제한(story #2776, 2026-08-18 — 가격표 정본 `offering_versi
     team/business) 밖의 값이면(예: 0228 마이그가 놓친 'pro' 잔존값) 조용히 free로
     취급하지 않는다(유료 org를 잘못 막을 위험) — fail loud 로그 + 그 요청은 무제한
     통과(안전측 — «막는 사고»보다 «캡 미검사 통과»가 안전).
+
+AU 집행(story #3176, doc `au-limit-enforcement-grounding-3176` §1) — 위 5종과 달리
+**요청마다 재계산하지 않는다.** 크론(`cron.py::au_usage_warn`)이 80%/90% 경고+100%+유예
+(110%/7일)를 주기적으로 계산해 `org_subscriptions.au_paused_at`에 캐시하고,
+`check_au_not_paused()`는 그 캐시만 읽는다 — `au_eval_at`(크론 최종 평가 시각)이 stale이면
+(크론이 죽으면) 캐시를 신뢰하지 않고 fail-open한다(페드루 PO 조건, 2026-08-28).
 """
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 
 from fastapi import HTTPException
 from sqlalchemy import text
@@ -34,7 +41,7 @@ FREE_LIMITS: dict[str, int] = {
 # org_subscriptions.tier로 실제 나타날 수 있는, offering_versions가 정의하는 tier 집합.
 # 'overage'는 구독 tier가 아니라 사용량과금 축이라 여기 포함 안 됨(구독 tier로 저장되는
 # 값이 아님 — 그라운딩 확認).
-_KNOWN_TIERS = frozenset({"free", "starter", "team", "business"})
+KNOWN_TIERS = frozenset({"free", "starter", "team", "business"})
 
 # API 초과 과금 정책 (per call, USD)
 API_OVERAGE_RATES: dict[str, float] = {
@@ -195,7 +202,7 @@ async def check_storage_capacity(session: AsyncSession, org_id, attachments: lis
     if not attachments:
         return
     tier = await _get_org_tier(session, org_id)
-    if tier not in _KNOWN_TIERS:
+    if tier not in KNOWN_TIERS:
         logger.error("check_storage_capacity: unknown tier %r for org_id=%s — skipping cap(fail-open)", tier, org_id)
         return
     limits = await _get_org_storage_limits(session, tier)
@@ -264,7 +271,7 @@ async def check_member_invite_limit(session: AsyncSession, org_id) -> None:
     선차단해 애초에 캡을 넘길 만큼의 초대가 쌓이지 못하게 한다.
     """
     tier = await _get_org_tier(session, org_id)
-    if tier not in _KNOWN_TIERS:
+    if tier not in KNOWN_TIERS:
         logger.error("check_member_invite_limit: unknown tier %r for org_id=%s — skipping cap(fail-open)", tier, org_id)
         return
     offering = await _get_offering_limits(session, tier)
@@ -288,7 +295,7 @@ async def check_member_accept_limit(session: AsyncSession, org_id) -> None:
     함수가 아니라 호출부의 락이 담당).
     """
     tier = await _get_org_tier(session, org_id)
-    if tier not in _KNOWN_TIERS:
+    if tier not in KNOWN_TIERS:
         logger.error("check_member_accept_limit: unknown tier %r for org_id=%s — skipping cap(fail-open)", tier, org_id)
         return
     offering = await _get_offering_limits(session, tier)
@@ -306,7 +313,7 @@ async def check_agent_add_limit(session: AsyncSession, org_id) -> None:
     read 0이던 그 값). None=무제한(free만 유한 3). 미지 tier/미시드 offering은 §미지tier
     방어와 동일 원칙(fail-open+로그) — 유료 org를 잘못 막지 않는다."""
     tier = await _get_org_tier(session, org_id)
-    if tier not in _KNOWN_TIERS:
+    if tier not in KNOWN_TIERS:
         logger.error("check_agent_add_limit: unknown tier %r for org_id=%s — skipping cap(fail-open)", tier, org_id)
         return
     offering = await _get_offering_limits(session, tier)
@@ -325,3 +332,63 @@ async def check_agent_add_limit(session: AsyncSession, org_id) -> None:
     )).scalar() or 0
     if count >= max_agents:
         raise _plan_limit_error("agent", max_agents, current=count, tier=tier)
+
+
+# story #3176 — 크론 주기(5분, cron.py::au_usage_warn) 대비 3배 여유. 이 창 안에서 크론이
+# 재실행 못 했으면 캐시를 신뢰하지 않는다(페드루 PO 조건 — fail-open).
+_AU_PAUSE_CACHE_STALENESS = timedelta(minutes=15)
+
+
+def _au_paused_error(tier: str) -> HTTPException:
+    """§2906 관례(선생님 확定 2026-08-21) 그대로 — 고객 대면 문구는 한국어로 「무슨 일이
+    일어났는지 + 무엇을 하면 되는지」. business는 업그레이드할 상위 tier가 없어(유나양 지적,
+    _storage_limit_error와 동형) 안내를 갈음한다."""
+    upgrade_required = tier != "business"
+    if upgrade_required:
+        msg = (
+            f"이번 달 자동화 사용량(AU) 한도를 초과해 MCP/API 쓰기와 자동화가 일시중지되었습니다"
+            f"({tier} 플랜). 다음 달 초기화를 기다리시거나 플랜을 업그레이드해 주세요. "
+            f"사람 웹 UI 사용과 기존 데이터 읽기는 계속 가능합니다."
+        )
+    else:
+        msg = (
+            "이번 달 자동화 사용량(AU) 한도를 초과해 MCP/API 쓰기와 자동화가 일시중지되었습니다. "
+            "다음 달 초기화를 기다려 주세요. 사람 웹 UI 사용과 기존 데이터 읽기는 계속 가능합니다."
+        )
+    return HTTPException(
+        status_code=402,
+        detail={
+            "code": "PLAN_LIMIT_EXCEEDED",
+            "resource": "automation_units",
+            "tier": tier,
+            "upgrade_required": upgrade_required,
+            "message": msg,
+        },
+    )
+
+
+async def check_au_not_paused(session: AsyncSession, org_id) -> None:
+    """story #3176(결제②-C) — AU 100%+유예(110%/7일) 초과로 크론이 paused 캐시해둔 org의
+    MCP/API 쓰기·자동화를 402로 막는다. 호출부(`app/dependencies/auth.py::get_current_user`)
+    가 이미 「agent+write+非스트리밍」만 걸러 부른다(doc §1.4) — 여기는 순수 캐시 조회.
+
+    ⛔재계산 안 함 — paused 여부는 크론이 이미 계산해 `au_paused_at`에 박아둔 값을 그대로
+    믿는다(요청 경로에 usage_meters 집계 쿼리를 얹지 않기 위한 PO 승인 (b)안, doc §1.3).
+    `au_eval_at`이 stale(크론 정지 추정)이면 캐시를 신뢰하지 않고 통과시킨다 — 결제 차단은
+    잘못 «켜지는» 쪽이 위험하다(다른 5종 미지-tier/미시드-offering fail-open과 동형 철학)."""
+    row = (await session.execute(
+        text("SELECT tier, au_paused_at, au_eval_at FROM org_subscriptions WHERE org_id = :oid"),
+        {"oid": str(org_id)},
+    )).first()
+    if row is None:
+        return  # 구독 행 자체가 없음(온보딩 갭 등) — fail-open
+    tier, paused_at, eval_at = row
+    if paused_at is None or eval_at is None:
+        return  # 크론이 아직 이 org를 평가 안 했거나 지금은 paused 아님
+    if datetime.now(timezone.utc) - eval_at > _AU_PAUSE_CACHE_STALENESS:
+        logger.warning(
+            "check_au_not_paused: stale au_eval_at(%s) for org_id=%s — skipping pause(fail-open)",
+            eval_at, org_id,
+        )
+        return
+    raise _au_paused_error(tier or "free")

--- a/backend/tests/test_2776_offering_catalog_gating_realdb.py
+++ b/backend/tests/test_2776_offering_catalog_gating_realdb.py
@@ -212,7 +212,8 @@ async def test_team_tier_member_invite_now_enforced_via_catalog():
 
 @pytest.mark.asyncio
 async def test_unknown_tier_fails_open_not_blocked():
-    """org_subscriptions.tier가 _KNOWN_TIERS 밖(예: 0257 백필 누락/미래 값)이면 조용히
+    """org_subscriptions.tier가 KNOWN_TIERS(story #3176 리네임, 구 _KNOWN_TIERS) 밖(예: 0257
+    백필 누락/미래 값)이면 조용히
     free로 오분류해 부당 차단하지 않고, fail-open(무제한 통과)해야 한다 — PO 판정 pin."""
     from ee.plan_limits import check_agent_add_limit, check_member_invite_limit
 

--- a/backend/tests/test_3176_au_usage_warn_cron_realdb.py
+++ b/backend/tests/test_3176_au_usage_warn_cron_realdb.py
@@ -1,0 +1,324 @@
+"""story #3176(결제②-C) — `cron.py::au_usage_warn()` 실PG 검증.
+
+doc `au-limit-enforcement-grounding-3176` §1.3 3단계(80%마커·90%메일·100%+유예)를 한 크론
+순회가 전부 계산해 `org_subscriptions`에 캐시하는지 확認. Free tier는 유예 없이 즉시
+paused(§11.2), 유료 tier는 110% 또는 7일 유예 — 이 둘의 갈림이 이 파일의 핵심 pin이다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import text
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _month_period(now: datetime) -> tuple[datetime, datetime]:
+    start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    end = start.replace(year=start.year + 1, month=1) if start.month == 12 else start.replace(month=start.month + 1)
+    return start, end
+
+
+async def _seed_org_with_usage(session, *, tier: str, current_value: int, **sub_overrides) -> dict:
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    await session.execute(
+        text("INSERT INTO organizations (id,name,slug,plan) VALUES (:id,:name,:slug,'free')"),
+        {"id": org_id, "name": f"org-{org_id}", "slug": f"slug-{org_id}"},
+    )
+    await session.execute(
+        text(
+            "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+            "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+            "(:id,:email,'x','U',true,true,0,false,0)"
+        ),
+        {"id": user_id, "email": f"u-{org_id}@test.local"},
+    )
+    await session.execute(
+        text("INSERT INTO org_members (id,org_id,user_id,role) VALUES (gen_random_uuid(),:org_id,:uid,'owner')"),
+        {"org_id": org_id, "uid": user_id},
+    )
+    cols = {"tier": tier, **sub_overrides}
+    col_names = ", ".join(cols.keys())
+    col_binds = ", ".join(f":{k}" for k in cols.keys())
+    sub_id = uuid.uuid4()
+    await session.execute(
+        text(
+            f"INSERT INTO org_subscriptions (id,org_id,status,currency,provider,{col_names}) "
+            f"VALUES (:sid,:o,'active','krw','toss',{col_binds})"
+        ),
+        {"sid": sub_id, "o": org_id, **cols},
+    )
+    now = datetime.now(timezone.utc)
+    period_start, period_end = _month_period(now)
+    await session.execute(
+        text(
+            "INSERT INTO usage_meters (id,org_id,meter_type,current_value,period_start,period_end) "
+            "VALUES (gen_random_uuid(),:o,'automation_units',:v,:ps,:pe)"
+        ),
+        {"o": org_id, "v": current_value, "ps": period_start, "pe": period_end},
+    )
+    await session.commit()
+    return {"org_id": org_id, "sub_id": sub_id, "owner_email": f"u-{org_id}@test.local"}
+
+
+async def _sub_row(session, sub_id):
+    row = (await session.execute(
+        text(
+            "SELECT au_warn_80_notified_at, au_warn_90_notified_at, au_grace_started_at, "
+            "au_paused_at, au_eval_at FROM org_subscriptions WHERE id = :id"
+        ),
+        {"id": sub_id},
+    )).first()
+    return {
+        "warn_80": row[0], "warn_90": row[1], "grace_started": row[2],
+        "paused": row[3], "eval": row[4],
+    }
+
+
+@pytest.mark.anyio
+async def test_below_80pct_no_markers_realdb():
+    from app.routers import cron
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_with_usage(s, tier="team", current_value=100_000)  # 10%
+            await cron.au_usage_warn(MagicMock(), session=s)
+            row = await _sub_row(s, seeded["sub_id"])
+            assert row["warn_80"] is None
+            assert row["warn_90"] is None
+            assert row["paused"] is None
+            assert row["eval"] is not None, "au_eval_at은 처리된 모든 org에 무조건 갱신돼야 함"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_80pct_sets_marker_no_email_realdb(monkeypatch):
+    from app.routers import cron
+
+    sent: list = []
+    monkeypatch.setattr(cron, "send_email", lambda to, subject, html: sent.append(to) or True)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_with_usage(s, tier="team", current_value=850_000)  # 85%
+            await cron.au_usage_warn(MagicMock(), session=s)
+            row = await _sub_row(s, seeded["sub_id"])
+            assert row["warn_80"] is not None
+            assert row["warn_90"] is None
+            assert seeded["owner_email"] not in sent, "80%는 마커만 — 이메일 없음(§11.1, 페드루 PO 조건②)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_90pct_sends_email_and_sets_marker_realdb(monkeypatch):
+    from app.routers import cron
+
+    sent: list = []
+    monkeypatch.setattr(cron, "send_email", lambda to, subject, html: sent.append(to) or True)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_with_usage(s, tier="team", current_value=950_000)  # 95%
+            await cron.au_usage_warn(MagicMock(), session=s)
+            row = await _sub_row(s, seeded["sub_id"])
+            assert row["warn_80"] is not None
+            assert row["warn_90"] is not None
+            assert seeded["owner_email"] in sent
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_90pct_cooldown_no_duplicate_email_realdb(monkeypatch):
+    """dedup — cooldown(7일) 내 재발송 금지(storage_usage_warn과 동형)."""
+    from app.routers import cron
+
+    sent: list = []
+    monkeypatch.setattr(cron, "send_email", lambda to, subject, html: sent.append(to) or True)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            recent_notify = datetime.now(timezone.utc) - timedelta(days=1)
+            seeded = await _seed_org_with_usage(
+                s, tier="team", current_value=950_000, au_warn_90_notified_at=recent_notify,
+            )
+            await cron.au_usage_warn(MagicMock(), session=s)
+            assert seeded["owner_email"] not in sent, "cooldown 내 재발송 금지"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_re_arm_below_threshold_clears_markers_realdb(monkeypatch):
+    """80%/90% 미만 복귀 시 마커 re-arm(재크로싱 시 즉시 재경고 가능해야 함)."""
+    from app.routers import cron
+
+    monkeypatch.setattr(cron, "send_email", lambda to, subject, html: True)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            now = datetime.now(timezone.utc)
+            seeded = await _seed_org_with_usage(
+                s, tier="team", current_value=100_000,  # 10% — 임계 아래로 복귀
+                au_warn_80_notified_at=now, au_warn_90_notified_at=now,
+            )
+            await cron.au_usage_warn(MagicMock(), session=s)
+            row = await _sub_row(s, seeded["sub_id"])
+            assert row["warn_80"] is None, "80% 미만 복귀 — re-arm"
+            assert row["warn_90"] is None, "90% 미만 복귀 — re-arm"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_paid_tier_100pct_within_grace_not_paused_realdb():
+    """team tier가 100%를 막 넘겼으면(유예 시작) 아직 paused 아님 — 7일/110% 둘 다 미달."""
+    from app.routers import cron
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_with_usage(s, tier="team", current_value=1_050_000)  # 105%
+            await cron.au_usage_warn(MagicMock(), session=s)
+            row = await _sub_row(s, seeded["sub_id"])
+            assert row["grace_started"] is not None, "100% 크로싱 — 유예 시작 시각 기록"
+            assert row["paused"] is None, "105% < 110%이고 유예 7일 미경과 — 아직 paused 아님"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_paid_tier_over_110pct_paused_immediately_within_grace_window_realdb():
+    """유예 «기간» 안이어도 110%를 넘기면 즉시 paused(둘 중 먼저 오는 조건, §11.2)."""
+    from app.routers import cron
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            recent_grace_start = datetime.now(timezone.utc) - timedelta(hours=1)
+            seeded = await _seed_org_with_usage(
+                s, tier="team", current_value=1_150_000,  # 115% >= 110%
+                au_grace_started_at=recent_grace_start,
+            )
+            await cron.au_usage_warn(MagicMock(), session=s)
+            row = await _sub_row(s, seeded["sub_id"])
+            assert row["paused"] is not None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_paid_tier_grace_window_expired_paused_realdb():
+    """유예 7일 경과 시 110% 미달이어도 paused(둘 중 먼저 오는 조건, 반대편)."""
+    from app.routers import cron
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            old_grace_start = datetime.now(timezone.utc) - timedelta(days=8)
+            seeded = await _seed_org_with_usage(
+                s, tier="team", current_value=1_020_000,  # 102% < 110%
+                au_grace_started_at=old_grace_start,
+            )
+            await cron.au_usage_warn(MagicMock(), session=s)
+            row = await _sub_row(s, seeded["sub_id"])
+            assert row["paused"] is not None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_free_tier_100pct_paused_immediately_no_grace_realdb():
+    """§11.2 "Free AU: 즉시 경고→쓰기 중지" — 유예 없이 즉시 paused."""
+    from app.routers import cron
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_with_usage(s, tier="free", current_value=50_000)  # 정확히 100%
+            await cron.au_usage_warn(MagicMock(), session=s)
+            row = await _sub_row(s, seeded["sub_id"])
+            assert row["paused"] is not None, "Free는 유예 없이 100%에서 즉시 paused"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_drop_below_100pct_clears_grace_and_pause_realdb():
+    """사용량이 (다음 달 리셋 등으로) 100% 아래로 내려가면 유예·paused 둘 다 해제."""
+    from app.routers import cron
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            now = datetime.now(timezone.utc)
+            seeded = await _seed_org_with_usage(
+                s, tier="team", current_value=100_000,  # 10% — 이미 정상 범위
+                au_grace_started_at=now - timedelta(days=1), au_paused_at=now - timedelta(days=1),
+            )
+            await cron.au_usage_warn(MagicMock(), session=s)
+            row = await _sub_row(s, seeded["sub_id"])
+            assert row["grace_started"] is None
+            assert row["paused"] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unknown_tier_skipped_eval_at_untouched_realdb():
+    """미지 tier — au_eval_at도 안 건드림(다음 요청이 stale 캐시로 자연 fail-open하도록,
+    "평가했다"는 잘못된 신호를 남기지 않는다)."""
+    from app.routers import cron
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_with_usage(s, tier="pro_legacy_ghost", current_value=100_000)
+            await cron.au_usage_warn(MagicMock(), session=s)
+            row = await _sub_row(s, seeded["sub_id"])
+            assert row["eval"] is None, "미지 tier는 평가 자체를 스킵 — eval_at 안 채움"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3176_check_au_not_paused_realdb.py
+++ b/backend/tests/test_3176_check_au_not_paused_realdb.py
@@ -1,0 +1,173 @@
+"""story #3176(결제②-C) — `ee/plan_limits.py::check_au_not_paused()` 실PG 검증.
+
+doc `au-limit-enforcement-grounding-3176` §1.3/§1.4·페드루 PO 승인(2026-08-28): paused
+여부는 요청마다 재계산하지 않고 크론이 캐시해둔 `org_subscriptions.au_paused_at`만 읽는다.
+`au_eval_at`(크론 최종 평가 시각)이 stale이면(크론이 죽은 것으로 추정) 캐시를 신뢰하지
+않고 fail-open — 이게 이 파일의 핵심 pin이다(페드루 PO 명시 조건).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_subscription(session, *, tier="team", **overrides) -> uuid.UUID:
+    org_id = uuid.uuid4()
+    await session.execute(
+        text("INSERT INTO organizations (id,name,slug,plan) VALUES (:id,:name,:slug,'free')"),
+        {"id": org_id, "name": f"org-{org_id}", "slug": f"slug-{org_id}"},
+    )
+    cols = {"tier": tier, **overrides}
+    col_names = ", ".join(cols.keys())
+    col_binds = ", ".join(f":{k}" for k in cols.keys())
+    await session.execute(
+        text(
+            f"INSERT INTO org_subscriptions (id,org_id,status,currency,provider,{col_names}) "
+            f"VALUES (gen_random_uuid(),:o,'active','krw','toss',{col_binds})"
+        ),
+        {"o": org_id, **cols},
+    )
+    await session.commit()
+    return org_id
+
+
+@pytest.mark.anyio
+async def test_no_subscription_row_fails_open_realdb():
+    from ee.plan_limits import check_au_not_paused
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            await check_au_not_paused(s, uuid.uuid4())  # 구독 행 자체 없음 — 예외 없어야 함
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_paused_at_null_passes_through_realdb():
+    from ee.plan_limits import check_au_not_paused
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org_subscription(s, tier="team")
+            await check_au_not_paused(s, org_id)  # au_paused_at NULL — 통과
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_paused_with_fresh_eval_raises_402_realdb():
+    from ee.plan_limits import check_au_not_paused
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            now = datetime.now(timezone.utc)
+            org_id = await _seed_org_subscription(
+                s, tier="team", au_paused_at=now, au_eval_at=now,
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                await check_au_not_paused(s, org_id)
+            assert exc_info.value.status_code == 402
+            assert exc_info.value.detail["code"] == "PLAN_LIMIT_EXCEEDED"
+            assert exc_info.value.detail["resource"] == "automation_units"
+            assert exc_info.value.detail["upgrade_required"] is True
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_paused_business_tier_no_upgrade_wording_realdb():
+    """유나양 조건(§2906 관례 동형) — business는 더 위 tier가 없어 업그레이드 권유 문구를 뺀다."""
+    from ee.plan_limits import check_au_not_paused
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            now = datetime.now(timezone.utc)
+            org_id = await _seed_org_subscription(
+                s, tier="business", au_paused_at=now, au_eval_at=now,
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                await check_au_not_paused(s, org_id)
+            assert exc_info.value.detail["upgrade_required"] is False
+            assert "업그레이드" not in exc_info.value.detail["message"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_stale_eval_fails_open_realdb():
+    """핵심 pin(페드루 PO 명시 조건, 2026-08-28) — au_eval_at이 stale(크론 정지 추정)이면
+    au_paused_at이 세팅돼 있어도 차단하지 않는다."""
+    from ee.plan_limits import check_au_not_paused
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            now = datetime.now(timezone.utc)
+            stale_eval = now - timedelta(minutes=30)  # _AU_PAUSE_CACHE_STALENESS(15분) 초과
+            org_id = await _seed_org_subscription(
+                s, tier="team", au_paused_at=now, au_eval_at=stale_eval,
+            )
+            await check_au_not_paused(s, org_id)  # 예외 없어야 함 — fail-open
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_eval_just_within_staleness_window_still_blocks_realdb():
+    """경계값 반대편 — staleness 창 «안»이면 정상적으로 차단해야 함(살아있는 캐시 무시 방지)."""
+    from ee.plan_limits import check_au_not_paused
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            now = datetime.now(timezone.utc)
+            recent_eval = now - timedelta(minutes=5)
+            org_id = await _seed_org_subscription(
+                s, tier="team", au_paused_at=now, au_eval_at=recent_eval,
+            )
+            with pytest.raises(HTTPException):
+                await check_au_not_paused(s, org_id)
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3176_get_current_user_au_pause_wiring.py
+++ b/backend/tests/test_3176_get_current_user_au_pause_wiring.py
@@ -1,0 +1,143 @@
+"""story #3176(결제②-C) — `get_current_user()`가 AU paused 체크를 호출하는 조건 pin.
+
+doc `au-limit-enforcement-grounding-3176` §1.4: `AUMeteringMiddleware.dispatch()`는
+`call_next()`보다 먼저 실행돼 `request.state.au_actor`가 아직 없는 시점이라, 집행은
+이 auth dependency로 옮겼다(원안은 미들웨어 사전체크였으나 타이밍 제약으로 구체화 변경).
+이 파일은 그 판별 조건(agent+write+非스트리밍+EE-enabled)만 실 DB 없이 mock으로 고정한다
+— check_au_not_paused 자체의 판정 로직은 test_3176_check_au_not_paused_realdb.py가 커버.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException, Request
+
+from app.dependencies import auth as auth_mod
+from app.dependencies.auth import AuthContext, get_current_user
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _fake_request(method: str, path: str) -> Request:
+    scope = {
+        "type": "http", "method": method, "path": path,
+        "headers": [], "query_string": b"", "server": ("test", 80),
+        "scheme": "http", "client": ("test", 1234),
+    }
+    return Request(scope)
+
+
+def _patch_common(monkeypatch, *, is_ee_enabled: bool, org_id: str | None = "11111111-1111-1111-1111-111111111111"):
+    auth_ctx = AuthContext(
+        user_id="22222222-2222-2222-2222-222222222222", email=None,
+        claims={"app_metadata": {"api_key_id": "some-key", "actor_type": "agent"}},
+        org_id=org_id,
+    )
+    monkeypatch.setattr(auth_mod, "_resolve_current_user_auth_context", AsyncMock(return_value=auth_ctx))
+
+    spy = AsyncMock()
+    monkeypatch.setattr("ee.plan_limits.check_au_not_paused", spy)
+
+    # is_ee_enabled는 property(license_consent 파생)라 인스턴스 직접 setattr 불가
+    # (test_2906_storage_quota_enforcement_realdb.py와 동일 우회 — 파생원본을 패치).
+    from app.core.config import settings as _settings
+    monkeypatch.setattr(_settings, "license_consent", "agreed" if is_ee_enabled else "declined")
+
+    return spy
+
+
+@pytest.mark.anyio
+async def test_agent_write_ee_enabled_calls_check(monkeypatch):
+    spy = _patch_common(monkeypatch, is_ee_enabled=True)
+    request = _fake_request("POST", "/api/v2/stories")
+
+    await get_current_user(credentials=None, x_agent_api_key=None, x_mcp_transport=None, request=request)
+
+    spy.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_agent_read_not_called(monkeypatch):
+    spy = _patch_common(monkeypatch, is_ee_enabled=True)
+    request = _fake_request("GET", "/api/v2/stories")
+
+    await get_current_user(credentials=None, x_agent_api_key=None, x_mcp_transport=None, request=request)
+
+    spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_streaming_path_not_called(monkeypatch):
+    spy = _patch_common(monkeypatch, is_ee_enabled=True)
+    request = _fake_request("POST", "/api/v2/events/stream")
+
+    await get_current_user(credentials=None, x_agent_api_key=None, x_mcp_transport=None, request=request)
+
+    spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_ee_disabled_not_called(monkeypatch):
+    """OSS 빌드(is_ee_enabled=False) — 다른 5종 plan_limits 게이트와 동형으로 집행 자체가
+    로드되지 않는다(agents.py::create_org_level_agent 등과 동일 관례)."""
+    spy = _patch_common(monkeypatch, is_ee_enabled=False)
+    request = _fake_request("POST", "/api/v2/stories")
+
+    await get_current_user(credentials=None, x_agent_api_key=None, x_mcp_transport=None, request=request)
+
+    spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_human_actor_not_called(monkeypatch):
+    auth_ctx = AuthContext(
+        user_id="22222222-2222-2222-2222-222222222222", email="a@b.com",
+        claims={"app_metadata": {}}, org_id="11111111-1111-1111-1111-111111111111",
+    )
+    monkeypatch.setattr(auth_mod, "_resolve_current_user_auth_context", AsyncMock(return_value=auth_ctx))
+    spy = AsyncMock()
+    monkeypatch.setattr("ee.plan_limits.check_au_not_paused", spy)
+    from app.core.config import settings as _settings
+    monkeypatch.setattr(_settings, "license_consent", "agreed")
+
+    request = _fake_request("POST", "/api/v2/stories")
+    await get_current_user(credentials=None, x_agent_api_key=None, x_mcp_transport=None, request=request)
+
+    spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_no_org_id_not_called(monkeypatch):
+    spy = _patch_common(monkeypatch, is_ee_enabled=True, org_id=None)
+    request = _fake_request("POST", "/api/v2/stories")
+
+    await get_current_user(credentials=None, x_agent_api_key=None, x_mcp_transport=None, request=request)
+
+    spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_402_from_check_propagates(monkeypatch):
+    """paused org의 쓰기는 get_current_user 자체가 402를 던져 라우터 핸들러까지 안 감."""
+    auth_ctx = AuthContext(
+        user_id="22222222-2222-2222-2222-222222222222", email=None,
+        claims={"app_metadata": {"api_key_id": "some-key", "actor_type": "agent"}},
+        org_id="11111111-1111-1111-1111-111111111111",
+    )
+    monkeypatch.setattr(auth_mod, "_resolve_current_user_auth_context", AsyncMock(return_value=auth_ctx))
+    monkeypatch.setattr(
+        "ee.plan_limits.check_au_not_paused",
+        AsyncMock(side_effect=HTTPException(status_code=402, detail={"code": "PLAN_LIMIT_EXCEEDED"})),
+    )
+    from app.core.config import settings as _settings
+    monkeypatch.setattr(_settings, "license_consent", "agreed")
+
+    request = _fake_request("POST", "/api/v2/stories")
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(credentials=None, x_agent_api_key=None, x_mcp_transport=None, request=request)
+    assert exc_info.value.status_code == 402

--- a/backend/tests/test_e_org_multi_s5_5_plan_limits.py
+++ b/backend/tests/test_e_org_multi_s5_5_plan_limits.py
@@ -111,7 +111,9 @@ def test_team_pro_skips_project_limit_but_not_member_limit():
     assert "free" in project_source
 
     member_source = inspect.getsource(check_member_invite_limit)
-    assert "_KNOWN_TIERS" in member_source  # free 단독분기가 아니라 known-tier 집합 방어
+    # story #3176 — KNOWN_TIERS로 리네임(언더스코어 제거, 모듈 밖 재사용 의도 명시 —
+    # cron.py::au_usage_warn이 이제 이 집합을 가져다 쓴다). 값·의미는 무변경.
+    assert "KNOWN_TIERS" in member_source  # free 단독분기가 아니라 known-tier 집합 방어
     assert '!= "free"' not in member_source and "!= 'free'" not in member_source
 
 


### PR DESCRIPTION
[SID:3176]

## 요약
doc `au-limit-enforcement-grounding-3176`(페드루 PO 승인 2026-08-28) 구현. AU 1종만 이번 패스 집행 — 나머지 4종(realtime_connections·webhooks·automation_rules·event_replay_days)은 별도 스토리(#3187/#3188/#3189)로 분리(PO 판정).

## 구현
- **마이그레이션 0288**: `org_subscriptions`에 크론-캐시 상태 5컬럼(`au_warn_80/90_notified_at`·`au_grace_started_at`·`au_paused_at`·`au_eval_at`) 추가. CHECK 제약 없음(baseline schema.sql 동기화 불요 — org_subscriptions 자체가 이미 다수 컬럼 누락된 구스냅샷, 이 규율은 CHECK 변경에만 적용).
- **크론 `au-usage-warn`**(`cron.py`): `storage_usage_warn` 패턴 그대로 재사용해 한 순회로 3단계 계산:
  - 80% — 마커만(이메일 없음, §11.1 "제품내경고"는 FE 별도 스토리, 페드루 PO 조건②).
  - 90% — 관리자 메일 + cooldown(7일) + re-arm(storage와 동형).
  - 100%+ — 유료 tier는 유예(110% 또는 7일 중 먼저 도달), Free는 유예 없이 즉시 paused(§11.2 정확히 그대로).
  - `au_eval_at`은 처리된 모든 org에 무조건 갱신 — 크론이 도중에 죽거나 특정 org를 못 보면 그 org는 stale 캐시로 남아 자연히 fail-open.
- **`ee/plan_limits.py::check_au_not_paused()`**: 요청마다 재계산 안 함 — 크론 캐시만 읽는 402 게이트. `au_eval_at`이 stale(15분, 크론 5분 주기 대비 3배 여유)이면 캐시를 신뢰하지 않고 통과(페드루 PO 명시 조건 — "결제 차단은 잘못 켜지는 쪽이 위험"). 402 문구는 #2906 관례(한국어, business는 업그레이드 문구 제외).
- **`app/dependencies/auth.py::get_current_user()`**에 사전체크 배선. 그라운딩 doc 원안은 `AUMeteringMiddleware.dispatch()`의 `call_next()` 前 체크였으나, 실제 구현 중 확인한 타이밍 제약(그 미들웨어가 이 dependency보다 먼저 실행돼 `request.state.au_actor` 자체가 아직 없음)으로 이 dependency 안으로 옮김 — 관찰 가능한 동작(agent+write만 402, read/human은 항상 통과)은 doc 그대로.
- `KNOWN_TIERS`(`ee/plan_limits.py`)·`STREAMING_PATHS`(`app/services/au_metering.py`)를 언더스코어 제거해 공개 — cron.py/auth.py가 재사용(판별 로직 드리프트 방지).

## 테스트 (전부 뮤테이션 검증 GREEN→RED→GREEN)
- `test_3176_check_au_not_paused_realdb.py` — 구독 행 없음/paused=NULL/paused+fresh eval(402)/business tier 문구/stale eval(fail-open)/경계값(15분 안쪽은 여전히 차단).
- `test_3176_au_usage_warn_cron_realdb.py` — 80%/90%/re-arm/cooldown/유예-안(paused 아님)/110%즉시paused/7일경과paused/Free즉시paused/100%아래복귀 시 해제/미지tier 스킵(eval_at도 안 건드림).
- `test_3176_get_current_user_au_pause_wiring.py` — agent+write+EE에서만 호출, read/human/streaming/EE off/org_id 없음일 때 미호출, 402 전파.
- 실PG 마이그레이션 upgrade→downgrade→upgrade 왕복 확인.
- 기존 회귀: `stories|goals|docs|events|conversations|au_metering|plan_limits|org_subscription` 257 passed. `auth|get_current_user` 304 passed. `KNOWN_TIERS` 리네임으로 깨진 기존 테스트 2건(`test_e_org_multi_s5_5_plan_limits.py`·`test_2776_offering_catalog_gating_realdb.py`) 이름만 갱신, 로직 무변경.
- `python -m py_compile` + `import app.main` 클린.

## Test plan
- [x] 신규 pin 테스트 뮤테이션 검증(GREEN→RED→GREEN)
- [x] 기존 회귀 스윕 무손상 확인(KNOWN_TIERS 리네임 여파 2건 수정 완료)
- [ ] CI green 확인(진행 중)