### PR TITLE
[SID:3186] destructive_schema 마커 혼합 수집 차단 — seed 헬퍼 NOT NULL 전제 반증·정정

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,11 @@
 """Shared pytest fixtures for backend tests.
 
+⚠️로컬에서 realdb 테스트를 폭넓게(예: `-k realdb`) 돌릴 땐 반드시 `-m "not destructive_schema"`도
+같이 붙여라 — destructive_schema 테스트는 실행 직전 공유 스키마를 DROP SCHEMA로 지우고 재
+마이그레이션 없이 두므로, 마커 없이 섞어 돌리면 나머지 전부가 연쇄로 깨진다(story #3186 실사고).
+아래 `pytest_collection_modifyitems`가 이 혼합을 collection 시점에 즉시 거부한다(README 대용
+— 이 파일이 모든 테스트 실행의 첫 관문이라 여기 적어야 실제로 읽힌다).
+
 ⛔⛔라우터 함수를 직접 호출할 때: `Query(...)`/`Depends(...)` 기본값은 실값이 아니라
 «센티널 객체»다 — 명시로 안 넘기면 그 객체 자체가 그대로 들어간다(story #2191이 2026-07-XX
 `test_2193_doc_summary_created_at_realdb.py`에서 처음 겪었고, #2659(2026-07-30)가 CI 21건
@@ -224,6 +230,13 @@ def _calls_destructive_schema_api(filepath: Path) -> bool:
     return _calls_raw_ddl_literal(tree)
 
 
+# story #3186 — trylast=True 필수(실측으로 발견한 함정): 이 훅이 기본 순서로 등록되면
+# pytest 내장 -k/-m 디셀렉션 훅보다 **먼저** 불려 `items`가 아직 필터링 전 전체 8289건
+# 그대로다. 그 상태로 아래 「혼합 수집 차단」을 재면 -m "not destructive_schema"를 명시해도
+# (필터 적용 前 스냅샷을 보므로) 매번 오탐 차단된다 — CI 두 job(Backend pytest·backend-
+# test-destructive) 자체가 못 돌 뻔한 실사고. trylast=True로 내장 디셀렉션 다음에 돌게
+# 고정해 `items`가 최종 선택 결과를 반영하게 한다.
+@pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(items: list) -> None:
     checked: dict[Path, bool] = {}
     violations: set[str] = set()
@@ -241,6 +254,40 @@ def pytest_collection_modifyitems(items: list) -> None:
             "무관한 테스트를 연쇄 실패시킬 수 있음 — story 8236bbc3/#2643). 파일 최상단에 "
             f"`pytestmark = pytest.mark.{_MARKER_NAME}` 를 추가하세요:\n"
             + "\n".join(sorted(violations))
+        )
+
+    # story #3186(2026-08-28, 카디르 QA·PO 처방) — «혼합 수집 차단» 게이트. 실사고 그라운딩:
+    # destructive_schema 테스트는 실행 직전 _reset_schema_for_destructive_tests(위)가
+    # `DROP SCHEMA public CASCADE`로 전체 스키마를 지우고 **재마이그레이션 없이** 둔다(그
+    # 테스트 자신이 파일 안에서 스스로 create_all/drop_all 하는 걸 전제) — 이게 non-destructive
+    # 테스트와 **같은 세션**에 섞여 수집되면, destructive 항목 하나가 실행된 뒤로 나머지 전부가
+    # "relation ... does not exist"로 연쇄 FAIL한다(실측: `-k realdb`만으로 광범위 수집 시
+    # 1058건 연쇄실패, `-m "not destructive_schema"`로 정확히 배제하면 0건 — 원인은 seed
+    # 헬퍼가 아니라 이 혼합 수집이었다, 스토리 본문 정정 기록 참조).
+    #
+    # 처방(PO 확定 2026-08-28) — README 경고문(안 읽은 사람을 못 막는다)도, 리셋 후 자동
+    # 재마이그레이션(«지원할 이유 없는 실행 모드»를 비싸게 지원하는 과투자)도 아니라, 지원
+    # 안 하는 모드 자체를 **수집 시점에 즉시 거부**한다 — 조용한 대량 오염을 시끄러운 즉시
+    # 실패로 바꾼다. CI의 두 job(Backend pytest=`-m "not destructive_schema"`·
+    # backend-test-destructive=파일별 격리)은 태생적으로 이 조건에 걸리지 않는다(항상 한쪽만
+    # 선택) — 이 가드가 실제로 막는 것은 로컬에서 마커 없이 광범위하게(`-k` 등) 실행하는
+    # 바로 그 위험한 패턴이다.
+    destructive_items = [i for i in items if i.get_closest_marker(_MARKER_NAME) is not None]
+    non_destructive_items = [i for i in items if i.get_closest_marker(_MARKER_NAME) is None]
+    if destructive_items and non_destructive_items:
+        destructive_files = sorted({str(Path(str(i.fspath))) for i in destructive_items})
+        preview = destructive_files[:5]
+        more = f" 외 {len(destructive_files) - 5}개 파일" if len(destructive_files) > 5 else ""
+        raise pytest.UsageError(
+            f"destructive_schema 마커 테스트 {len(destructive_items)}건과 non-destructive 테스트 "
+            f"{len(non_destructive_items)}건이 같은 세션에 함께 수집됐습니다 — 지원하지 않는 실행 "
+            "모드입니다(story #3186 실사고: destructive 테스트가 DROP SCHEMA로 공유 스키마를 "
+            "지운 뒤 재마이그레이션 없이 두어, 이후 모든 non-destructive 테스트가 "
+            "'relation ... does not exist'로 연쇄 실패합니다).\n"
+            "올바른 실행법 — 둘 중 하나만 선택하세요:\n"
+            '  · non-destructive만: uv run pytest -m "not destructive_schema" ...\n'
+            "  · destructive만(파일별 독립 신선 DB 권장): uv run pytest -m destructive_schema ...\n"
+            f"이번 수집에 섞인 destructive 파일{more}:\n" + "\n".join(preview)
         )
 
 

--- a/backend/tests/test_3186_mixed_collection_guard.py
+++ b/backend/tests/test_3186_mixed_collection_guard.py
@@ -1,0 +1,114 @@
+"""story #3186 — conftest.py 「혼합 수집 차단」 가드 양성대조.
+
+배경(2026-08-28, 카디르 QA·실사고 그라운딩): 스토리 원 전제("공유 seed 헬퍼가 NOT NULL
+컬럼을 못 채운다")는 실측으로 반증됐다 — organizations.plan은 DB server_default='free'가
+실존해(psql \\d로 직접 확認) seed 누락이 애초에 문제가 안 된다. 진짜 원인은
+conftest.py::_reset_schema_for_destructive_tests(autouse) — destructive_schema 마커
+테스트 실행 直前 `DROP SCHEMA public CASCADE`로 전체 스키마를 지우고 재마이그레이션 없이
+둔다(그 테스트 자신이 파일 안에서 스스로 create_all/drop_all 하는 걸 전제). 이게
+non-destructive 테스트와 **같은 세션**에 섞여 수집되면, destructive 항목 하나가 실행된
+뒤로 나머지 전부가 "relation ... does not exist"로 연쇄 FAIL한다.
+
+실측 대조(로컬 disposable PG, alembic upgrade heads):
+- `pytest -k realdb`(마커 무시, 광범위 selector) → 1058 FAIL.
+- `pytest -k realdb -m "not destructive_schema"`(CI "Backend pytest"가 실제로 쓰는 정확한
+  필터) → 1837 PASSED · 0 FAIL.
+이 대조가 AC2("왜 CI green이었나")의 답이다 — CI는 애초에 두 축을 절대 안 섞는다(Backend
+pytest=`-m "not destructive_schema"`·backend-test-destructive=파일별 격리 신선 DB).
+
+처방(PO 확定 2026-08-28) — README 경고문(안 읽은 사람을 못 막는다)도 자동 재마이그레이션
+(«지원할 이유 없는 실행 모드»를 비싸게 지원하는 과투자)도 아니라, 지원 안 하는 모드 자체를
+collection 시점에 즉시 거부한다(조용한 대량 오염 → 시끄러운 즉시 실패). 이 파일은 그
+처방(conftest.py::pytest_collection_modifyitems 확장분)이 실제로 작동하는지 실 pytest
+서브프로세스로 검증한다(test_2643_destructive_schema_ddl_guard.py와 동일 subprocess+
+tmp_path 관례).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def _copy_conftest(tmp_path: Path) -> None:
+    conftest_src = (Path(__file__).parent / "conftest.py").read_text(encoding="utf-8")
+    (tmp_path / "conftest.py").write_text(conftest_src, encoding="utf-8")
+
+
+_DESTRUCTIVE_VICTIM = """
+    import pytest
+    from sqlalchemy import text
+
+    pytestmark = pytest.mark.destructive_schema
+
+    def test_wipes_schema(x_conn):
+        x_conn.execute(text("DROP TABLE IF EXISTS foo"))
+"""
+
+_NON_DESTRUCTIVE_VICTIM = """
+    def test_ordinary():
+        assert 1 + 1 == 2
+"""
+
+
+def test_positive_control_mixed_collection_rejected_at_collect_time(tmp_path: Path):
+    """AC — destructive_schema 마커 파일과 non-destructive 파일이 같은 세션에 함께
+    수집되면 즉시 UsageError(exit code 4)로 죽는지 실측(story #3186 실사고 재현)."""
+    (tmp_path / "test_3186_destructive_victim.py").write_text(textwrap.dedent(_DESTRUCTIVE_VICTIM))
+    (tmp_path / "test_3186_ordinary_victim.py").write_text(textwrap.dedent(_NON_DESTRUCTIVE_VICTIM))
+    _copy_conftest(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(tmp_path), "--collect-only", "-q"],
+        capture_output=True, text=True, cwd=tmp_path,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 4, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "같은 세션에 함께 수집됐습니다" in combined
+    assert "not destructive_schema" in combined
+    assert "test_3186_destructive_victim.py" in combined
+
+
+def test_positive_control_marker_filter_excludes_destructive_and_passes(tmp_path: Path):
+    """처방 그 자체의 유효성 — `-m "not destructive_schema"`(CI가 실제로 쓰는 필터)를
+    같은 두 파일에 걸면 destructive 파일이 디셀렉트되어 혼합이 사라지고 정상 통과한다
+    (trylast=True 배선이 -k/-m 디셀렉션 *이후*에 items를 보는지까지 함께 고정 —
+    이게 없으면 필터를 걸어도 여전히 필터 前 스냅샷을 보고 오탐 차단된다, 실사고 2회차)."""
+    (tmp_path / "test_3186_destructive_victim.py").write_text(textwrap.dedent(_DESTRUCTIVE_VICTIM))
+    (tmp_path / "test_3186_ordinary_victim.py").write_text(textwrap.dedent(_NON_DESTRUCTIVE_VICTIM))
+    _copy_conftest(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(tmp_path), "-m", "not destructive_schema", "--collect-only", "-q"],
+        capture_output=True, text=True, cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+
+
+def test_positive_control_destructive_only_selection_passes(tmp_path: Path):
+    """destructive만 골라 돌리는 것(CI backend-test-destructive의 파일별 격리 순회와 동형
+    선택)도 혼합이 아니므로 정상 통과 — 이 가드가 destructive 자체를 막는 게 아니라
+    «섞임»만 막는다는 것을 함께 고정."""
+    (tmp_path / "test_3186_destructive_victim.py").write_text(textwrap.dedent(_DESTRUCTIVE_VICTIM))
+    (tmp_path / "test_3186_ordinary_victim.py").write_text(textwrap.dedent(_NON_DESTRUCTIVE_VICTIM))
+    _copy_conftest(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(tmp_path), "-m", "destructive_schema", "--collect-only", "-q"],
+        capture_output=True, text=True, cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+
+
+def test_no_regression_single_kind_directories_still_collect_fine(tmp_path: Path):
+    """회귀가드 — non-destructive 파일 «하나만» 있는 흔한 경우(이 조직 실 tests/ 스위트
+    대부분)는 기존처럼 아무 방해 없이 수집된다."""
+    (tmp_path / "test_3186_only_ordinary.py").write_text(textwrap.dedent(_NON_DESTRUCTIVE_VICTIM))
+    _copy_conftest(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(tmp_path), "--collect-only", "-q"],
+        capture_output=True, text=True, cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"


### PR DESCRIPTION
## 배경
[[테스트 인프라] destructive_schema 마커 혼합 수집 시 스키마 삭제 잔존 → non-destructive realdb 연쇄오염(원 전제 「seed 헬퍼 NOT NULL 미반영」은 반증·기각)](entity:story:89d5feec-dfda-4766-a360-73cb87975100)

카디르 QA가 "신선 DB에서 realdb 26+건 실FAIL — 공유 seed 헬퍼가 NOT NULL 컬럼(org.plan·users.marketing_email_opt_out)을 못 채운다"고 보고했으나, **실측으로 이 전제를 반증했다.**

## 반증 3단계
1. 신선 disposable PG(alembic upgrade heads, HEAD 0287)에서 `organizations.plan` 직접 확認 — DB에 `server_default='free'` 실존(psql \d). seed가 안 채워도 Postgres가 자동 채움.
2. 카디르 예시 6파일 29건 개별 실행 — 전부 PASS.
3. `pytest -k realdb`(마커 무시, 광범위 selector) → **1058 FAIL**. `pytest -k realdb -m "not destructive_schema"`(CI "Backend pytest"가 실제로 쓰는 정확한 필터) → **1837 PASSED · 0 FAIL**.

## 진짜 원인
`tests/conftest.py::_reset_schema_for_destructive_tests`(autouse)가 `destructive_schema` 마커 테스트 실행 直前 `DROP SCHEMA public CASCADE`로 전체 스키마를 지우고 **재마이그레이션 없이** 둔다(그 테스트 자신이 파일 안에서 스스로 create_all/drop_all 하는 걸 전제). non-destructive realdb 테스트와 같은 세션에 섞여 수집되면, destructive 항목 하나가 실행된 뒤로 나머지 전부가 `relation ... does not exist`로 연쇄 FAIL한다.

**AC2 답(왜 CI green이었나)**: CI "Backend pytest" job은 정확히 `-m "not destructive_schema"`만 돈다(destructive 94개는 별도 격리 job이 파일별 신선 DB로 순회) — 애초에 두 축이 절대 안 섞인다. 카디르(그리고 처음 나)는 로컬에서 마커 없이 광범위하게(`-k realdb` 등) 돌려서 우연히 섞여 연쇄오염을 겪은 것.

## 처방(PO 확定, 2026-08-28)
README 경고문(안 읽은 사람을 못 막는다)도, 리셋 후 자동 재마이그레이션(«지원할 이유 없는 실행 모드»를 비싸게 지원하는 과투자)도 아니라, **지원 안 하는 모드 자체를 collection 시점에 즉시 거부**한다 — 조용한 대량 오염을 시끄러운 즉시 실패로 바꾼다.

## 변경
- `conftest.py::pytest_collection_modifyitems`에 「혼합 수집 차단」 게이트 추가 — destructive_schema 마커 항목과 non-destructive 항목이 같은 세션에 함께 수집되면 `pytest.UsageError`(exit 4)로 즉시 거부, 메시지에 올바른 실행법 2줄 명기.
  - ⚠️`@pytest.hookimpl(trylast=True)` 필수 — 없으면 이 훅이 pytest 내장 `-k`/`-m` 디셀렉션보다 먼저 불려 `items`가 필터 前 전체 스냅샷이라, `-m "not destructive_schema"`를 명시해도 매번 오탐 차단된다(실측으로 발견 — CI 두 job 자체가 못 돌 뻔한 사고를 push 전에 잡음).
- `test_3186_mixed_collection_guard.py` 신설 — 양성대조 4건(혼합→exit4, `-m "not destructive_schema"`→exit0, `-m destructive_schema`만→exit0, 단일종류만→exit0).
- conftest.py 모듈 docstring에 경고 1단락 추가(README 대용 — 이 파일이 모든 테스트 실행의 첫 관문).
- 스토리 제목·본문 정정(원 전제는 반증 기록으로 보존).

## 검증
- 신규 양성대조 4건 PASS.
- 기존 관련 가드 테스트(test_2643·test_2662·test_shard_destructive_tests) 35건 PASS — 무회귀.
- CI "Backend pytest" 동형(`-m "not destructive_schema"`) 전체 스위트: 7082 passed·8 failed — 8건 전부 stash 대조로 **이 PR과 무관한 로컬 머신 .mcp.json 경로 의존 사전 존재 실패**임을 실측 확認(다른 에이전트의 로컬 워크스페이스 경로를 검사하는 테스트류).
- CI "backend-test-destructive" 동형(`-m destructive_schema`) 샘플 39건 PASS.

## Test plan
- [ ] CI "Backend pytest"·"backend-test-destructive" 두 job 모두 무회귀 green 확認(이 가드가 정확히 두 job의 실제 호출 패턴과 충돌하지 않는지)