### PR TITLE
[SID:3180] S3 후속 — chat SSE attention.changed 신호 (지금 스트립 즉시 소멸)

### DIFF
--- a/apps/web/src/components/chat/now-strip.test.tsx
+++ b/apps/web/src/components/chat/now-strip.test.tsx
@@ -11,14 +11,19 @@ import koMessages from '../../../messages/ko.json';
 import { NowStrip } from './now-strip';
 import type { AttentionItem } from '@/components/dashboard/command-center/types';
 
-const { fetchWithAuthMock, useAutoRefreshMock } = vi.hoisted(() => ({
+const { fetchWithAuthMock, useAutoRefreshMock, subscribeMock, useSseMultiplexerContextMock } = vi.hoisted(() => ({
   fetchWithAuthMock: vi.fn(),
   useAutoRefreshMock: vi.fn(),
+  subscribeMock: vi.fn(),
+  useSseMultiplexerContextMock: vi.fn(),
 }));
 vi.mock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
 // story #3177 — 전역 RefreshContext(폴링 주기) 배선 자체는 useAutoRefreshMock 호출 인자로만
 // 검증한다(register 자체를 재구현하지 않는다, chat-list-view.test.tsx와 동일 관례).
 vi.mock('@/hooks/use-auto-refresh', () => ({ useAutoRefresh: (key: string, fn: () => void) => useAutoRefreshMock(key, fn) }));
+// story #3180 — mux는 useSseMultiplexerContextMock으로 대체(use-team-presence.test.tsx와
+// 동형 관례가 없어 최소 구현 — subscribe만 검증, 나머지 핸들 필드는 미사용이라 생략).
+vi.mock('@/components/realtime-provider', () => ({ useSseMultiplexerContext: () => useSseMultiplexerContextMock() }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -65,6 +70,10 @@ beforeEach(() => {
   root = createRoot(container);
   fetchWithAuthMock.mockReset();
   useAutoRefreshMock.mockReset();
+  subscribeMock.mockReset();
+  useSseMultiplexerContextMock.mockReset();
+  // 기본값 — 플래그 OFF/Provider 밖과 동형(대부분의 기존 테스트는 mux 무관이라 null 폴백).
+  useSseMultiplexerContextMock.mockReturnValue(null);
 });
 
 afterEach(async () => {
@@ -152,5 +161,39 @@ describe('NowStrip — 폴링 배선(AC4 조정: 실시간 아닌 기존 Refresh
     await act(async () => { root.render(wrap(<NowStrip />)); });
     await flush();
     expect(useAutoRefreshMock).toHaveBeenCalledWith('chat-now-strip', expect.any(Function));
+  });
+});
+
+describe('NowStrip — story #3180 attention.changed 신호(AC2 즉시 재조회·AC3 하위호환)', () => {
+  it('mux가 없으면(플래그 OFF·Provider 밖) subscribe를 호출하지 않는다 — 폴링만 남는다', async () => {
+    useSseMultiplexerContextMock.mockReturnValue(null);
+    mockAttention([]);
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    expect(subscribeMock).not.toHaveBeenCalled();
+  });
+
+  it('mux가 있으면 attention.changed를 구독한다', async () => {
+    const unsubscribe = vi.fn();
+    subscribeMock.mockReturnValue(unsubscribe);
+    useSseMultiplexerContextMock.mockReturnValue({ subscribe: subscribeMock, subscribeMessage: vi.fn(), subscribeReconnect: vi.fn(), connected: true });
+    mockAttention([]);
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    expect(subscribeMock).toHaveBeenCalledWith('attention.changed', expect.any(Function));
+  });
+
+  it('attention.changed 신호 수신 시 폴링 주기 대기 없이 즉시 재조회한다', async () => {
+    let handler: (() => void) | undefined;
+    subscribeMock.mockImplementation((_name: string, fn: () => void) => { handler = fn; return vi.fn(); });
+    useSseMultiplexerContextMock.mockReturnValue({ subscribe: subscribeMock, subscribeMessage: vi.fn(), subscribeReconnect: vi.fn(), connected: true });
+    mockAttention([]);
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    const callsAfterMount = fetchWithAuthMock.mock.calls.length;
+    expect(handler).toBeTruthy();
+    await act(async () => { handler!(); });
+    await flush();
+    expect(fetchWithAuthMock.mock.calls.length).toBe(callsAfterMount + 1);
   });
 });

--- a/apps/web/src/components/chat/now-strip.tsx
+++ b/apps/web/src/components/chat/now-strip.tsx
@@ -7,9 +7,11 @@
  * 재사용(PO BE 계약 확定 2026-08-28, 신규 BE 0). collapsed/expanded 문법은 embed-group.tsx의
  * GateGroup(S2c③④)을 재사용(신규 패턴 0).
  *
- * ⚠️소멸 타이밍(AC4, PO 조정 2026-08-28): 진짜 실시간(SSE attention-changed)이 아니라
- * useAutoRefresh(전역 RefreshContext 폴링 주기, 기본 30초) 내 무회귀다 — 이벤트 기반 즉시
- * 소멸은 별 후속 스토리(entity:story:2b129e0b-b38d-4597-816a-914f43a5dfb3)로 분리됐다.
+ * ⚠️소멸 타이밍(AC4, PO 조정 2026-08-28) 갱신 — story #3180(위 후속 스토리, S3 트랙 완주 後
+ * 착수)이 착지해 이제 진짜 이벤트 기반 즉시 소멸이 있다: 기존 chat SSE 채널의
+ * `attention.changed` 신호(payload 없음 — 재조회 트리거) 수신 시 아래 `load()`를 즉시
+ * 1회 더 부른다. useAutoRefresh(전역 RefreshContext 폴링, 기본 30초)는 신호를 못 받는
+ * 환경(mux 비활성·SSE 끊김)의 **폴백**으로 그대로 유지한다(무회귀).
  *
  * ⚠️구조/데이터 층 우선(PO 지시 2026-08-28) — 시안(하이파이 mockup)의 좌측 그라데이션
  * 장식바·메타/시간 두 슬롯 분리 같은 미세 픽셀 디테일은 이 커밋에서 실 DS 프리미티브로
@@ -24,6 +26,7 @@ import { cn } from '@/lib/utils';
 import { cardVariants } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useAutoRefresh } from '@/hooks/use-auto-refresh';
+import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import type { AttentionItem, MyActions } from '@/components/dashboard/command-center/types';
 import { buildNowStripItems, summarizeSeverity, type NowStripItem, type NowStripSeverity } from './derive-now-strip';
 
@@ -136,6 +139,16 @@ export function NowStrip({ resolveName, expanded: expandedProp, onExpandedChange
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { void load(); }, [load]);
   useAutoRefresh('chat-now-strip', () => { void load(); });
+
+  const mux = useSseMultiplexerContext();
+  useEffect(() => {
+    // story #3180(S3 후속) — 신호 수신 시 폴링 주기(useAutoRefresh) 대기 없이 즉시 재조회
+    // (AC2). payload 미사용 — presence(use-team-presence.ts)와 동형 트리거뿐이라 dedup
+    // 불필요(재배달돼도 재조회 1회 더 도는 것뿐, 멱등). mux가 null이면(플래그 OFF·Provider
+    // 밖) 그냥 무동작 — 위 useAutoRefresh 폴백만 돈다(AC3 하위호환).
+    const unsub = mux?.subscribe('attention.changed', () => { void load(); });
+    return () => unsub?.();
+  }, [mux, load]);
 
   const noopResolveName = useCallback((): string | null => null, []);
   const stripItems = useMemo(

--- a/apps/web/src/components/org-briefing/now-face.test.tsx
+++ b/apps/web/src/components/org-briefing/now-face.test.tsx
@@ -10,6 +10,11 @@ import { NextIntlClientProvider } from 'next-intl';
 import { NowFace } from './now-face';
 import koMessages from '../../../messages/ko.json';
 
+// story #3180 — mux는 mock으로 대체(now-strip.test.tsx와 동형 관례). 기본 null 반환이라
+// 기존 테스트 전부(mux 미언급)는 「Provider 밖」 폴백 경로 그대로 무회귀.
+const { useSseMultiplexerContextMock } = vi.hoisted(() => ({ useSseMultiplexerContextMock: vi.fn() }));
+vi.mock('@/components/realtime-provider', () => ({ useSseMultiplexerContext: () => useSseMultiplexerContextMock() }));
+
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 let container: HTMLDivElement;
@@ -27,6 +32,8 @@ beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
+  useSseMultiplexerContextMock.mockReset();
+  useSseMultiplexerContextMock.mockReturnValue(null);
 });
 
 afterEach(async () => {
@@ -154,5 +161,33 @@ describe('NowFace', () => {
     );
     await mount();
     expect(container.textContent).not.toContain('other-proj');
+  });
+});
+
+describe('NowFace — story #3180 attention.changed 신호(AC2 즉시 재조회·AC3 하위호환)', () => {
+  it('mux가 없으면(플래그 OFF·Provider 밖) subscribe를 호출하지 않는다 — 폴링만 남는다', async () => {
+    const subscribe = vi.fn();
+    useSseMultiplexerContextMock.mockReturnValue(null);
+    stubFetch({ action_queue: { items: [] }, attention: { items: [] } }, { data: [] });
+    await mount();
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it('mux가 있으면 attention.changed를 구독하고, 신호 수신 시 즉시 재조회한다', async () => {
+    let handler: (() => void) | undefined;
+    const subscribe = vi.fn((name: string, fn: () => void) => { handler = fn; return vi.fn(); });
+    useSseMultiplexerContextMock.mockReturnValue({ subscribe, subscribeMessage: vi.fn(), subscribeReconnect: vi.fn(), connected: true });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/api/dashboard/my-actions')) return { ok: true, json: async () => ({ action_queue: { items: [] }, attention: { items: [] } }) };
+      if (url.includes('/api/notifications')) return { ok: true, json: async () => ({ data: [] }) };
+      return { ok: false, json: async () => null };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await mount();
+    expect(subscribe).toHaveBeenCalledWith('attention.changed', expect.any(Function));
+    const callsAfterMount = fetchMock.mock.calls.length;
+    expect(handler).toBeTruthy();
+    await act(async () => { handler!(); await Promise.resolve(); await Promise.resolve(); });
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterMount);
   });
 });

--- a/apps/web/src/components/org-briefing/now-face.tsx
+++ b/apps/web/src/components/org-briefing/now-face.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { fetchWithAuth } from '@/lib/db/client';
 import { cn } from '@/lib/utils';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { useSseMultiplexerContext } from '@/components/realtime-provider';
 import {
   buildNowFace, parseCompletionNotifications, parseMyActions,
   type NowFaceItem, type NowFaceTranslator,
@@ -124,6 +125,8 @@ export function NowFace() {
   const orgSlug = orgMemberships.find((o) => o.orgId === orgId)?.orgSlug;
   const viewer = useMemo<ViewerContext>(() => ({ orgSlug, activeProjectId: projectId }), [orgSlug, projectId]);
 
+  const mux = useSseMultiplexerContext();
+
   useEffect(() => {
     const load = async () => {
       const result = await loadNowFace(t, viewer);
@@ -134,8 +137,17 @@ export function NowFace() {
     };
     void load();
     const id = setInterval(() => void load(), REFRESH_MS);
-    return () => clearInterval(id);
-  }, [t, viewer]);
+    // story #3180(S3 후속) — 「지금」 스트립의 attention 소비 축. 폴링(REFRESH_MS)은 그대로
+    // 폴백 유지(AC3 — mux가 null이거나 신호가 안 오면 이 subscribe는 그냥 무동작이고 기존
+    // 폴링만 돈다). 신호 수신 시 폴링 주기 대기 없이 즉시 1회 재조회(AC2). payload 미사용 —
+    // presence(use-team-presence.ts)와 동형 트리거뿐이라 dedup 불필요(재배달돼도 재조회
+    // 1회 더 도는 것뿐, 멱등).
+    const unsubAttention = mux?.subscribe('attention.changed', () => { void load(); });
+    return () => {
+      clearInterval(id);
+      unsubAttention?.();
+    };
+  }, [t, viewer, mux]);
 
   const list = items ?? [];
   const shown = expanded ? list : list.slice(0, CAP);

--- a/apps/web/src/lib/realtime/sse-cursor-eligibility.test.ts
+++ b/apps/web/src/lib/realtime/sse-cursor-eligibility.test.ts
@@ -12,6 +12,10 @@ describe('isCursorEligibleEventName', () => {
     expect(isCursorEligibleEventName('conversation.working')).toBe(false);
   });
 
+  it('알려진 B계열(attention.changed, story #3180)은 커서 승격 불가', () => {
+    expect(isCursorEligibleEventName('attention.changed')).toBe(false);
+  });
+
   it('그 외 named 이벤트(예: story.status_changed)는 승격 가능', () => {
     expect(isCursorEligibleEventName('story.status_changed')).toBe(true);
     expect(isCursorEligibleEventName('story.assignee_changed')).toBe(true);

--- a/apps/web/src/lib/realtime/sse-cursor-eligibility.ts
+++ b/apps/web/src/lib/realtime/sse-cursor-eligibility.ts
@@ -13,11 +13,16 @@
  * 않는다 — B계열이 오기 전 마지막으로 승격된(A계열) id가 그대로 유지되어, 다음 재연결도
  * 해소 가능한 커서로 나간다.
  *
- * ⚠️ 알려진 B계열만 명시한다(추측 금지 — story #2162 조사에서 실제로 확認된 두 이름뿐이다).
+ * ⚠️ 알려진 B계열만 명시한다(추측 금지 — story #2162 조사에서 실제로 확認된 두 이름 + story
+ * #3180이 추가한 세 번째뿐이다).
  * 새로운 transient(DB-row 없는) named 이벤트를 추가할 땐 **반드시 여기에도 추가할 것** —
  * 안 그러면 목록에 없는 이름은 전부 "커서 승격 가능"으로 취급돼 이 버그가 조용히 재발한다.
+ *
+ * story #3180 — `attention.changed`(backend/app/services/attention_events.py::
+ * notify_attention_changed → push_to_org_members(..., {})) 도 presence와 동일 모양의 B계열
+ * (Event DB row 0, payload 없음)이라 여기 편입한다.
  */
-const TRANSIENT_EVENT_NAMES = new Set(['presence', 'conversation.working']);
+const TRANSIENT_EVENT_NAMES = new Set(['presence', 'conversation.working', 'attention.changed']);
 
 /**
  * true면 이 이벤트의 네이티브 SSE id를 재개 커서로 승격해도 안전(DB로 해소 가능하다고 알려짐

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -650,6 +650,13 @@ async def score_hypotheses_cron(
     try:
         summary = await score_hypotheses(session)
         await session.commit()
+        # story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — commit-then-publish. 배치가
+        # 여러 org에 걸칠 수 있어(measure_after 도래 가설 전역 쿼리) org별 1회 push(과다발화
+        # 방지 — score_hypotheses가 이미 dedup된 집합을 반환).
+        for _org_id in summary.get("attention_org_ids", []):
+            from app.services.attention_events import notify_attention_changed
+
+            await notify_attention_changed(_org_id)
         return _ok(summary)
     except Exception as exc:
         logger.exception("score-hypotheses cron error: %s", exc)

--- a/backend/app/routers/dependencies.py
+++ b/backend/app/routers/dependencies.py
@@ -130,6 +130,11 @@ async def create_dependency(
         from app.services.attention_events import notify_attention_changed
 
         await session.commit()
+        # story 50662d49(commit-then-model_validate refresh lint, 카디르 QA 재지적) — commit
+        # 직후 model_validate 前 명시 refresh. expire_on_commit=False라 즉시 크래시는 안 나지만
+        # (MissingGreenlet류) 이 레포 성문 규칙은 그 안전판에 기대지 말고 항상 refresh하라는
+        # 것 — 다른 세션/인스턴스가 commit 사이에 같은 행을 바꿨을 stale-read 가능성까지 닫는다.
+        await session.refresh(dep)
         await notify_attention_changed(org_id)
 
     return DependencyResponse.model_validate(dep)
@@ -193,6 +198,8 @@ async def update_dependency(
         from app.services.attention_events import notify_attention_changed
 
         await repo.session.commit()
+        # story 50662d49(commit-then-model_validate refresh lint) — create_dependency와 동형.
+        await repo.session.refresh(updated)
         await notify_attention_changed(repo.org_id)
 
     return DependencyResponse.model_validate(updated)

--- a/backend/app/routers/dependencies.py
+++ b/backend/app/routers/dependencies.py
@@ -119,10 +119,17 @@ async def create_dependency(
             session, org_id, body.to_id, _trust_before, actor_id=user_id
         )
 
-    # story #3180(S3 후속) — 새 blocks 의존성 = unanswered_blocker 파생의 생성 입력(attention).
+    # story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — «attention.changed»는 FE가 수신
+    # 즉시 my-actions를 재조회한다. get_db가 커밋을 핸들러 반환 後(implicit, app/dependencies/
+    # database.py::get_db)로 미루므로, 여기서 커밋 前에 push하면 재조회가 아직 안 보이는 상태를
+    # 읽어 마치 «해소 안 됐다»처럼 보이는 창이 생긴다 — 폴백 폴링이 그 실패를 가려 조용히
+    # 넘어가던 것(REQUEST_CHANGES 근거). 이 라우트는 이 지점 이후 추가 쓰기가 없으므로 명시
+    # commit으로 반환-前 확定 후에만 push한다(session async_session_factory는 expire_on_commit
+    # =False라 이후 model_validate(dep) 접근에 안전 — app/core/database.py 확認).
     if body.item_type == "story" and body.dep_type == "blocks":
         from app.services.attention_events import notify_attention_changed
 
+        await session.commit()
         await notify_attention_changed(org_id)
 
     return DependencyResponse.model_validate(dep)
@@ -179,11 +186,13 @@ async def update_dependency(
             repo.session, repo.org_id, dep.to_id, _trust_before, actor_id=user_id
         )
 
-    # story #3180(S3 후속) — dep_type이 어느 방향으로든 blocks를 넘나들면(생성·해소 둘 다)
-    # unanswered_blocker 파생의 입력이 바뀐 것 — 위 trust_before 게이팅과 동일 조건.
+    # story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — commit-then-publish로 정렬(create_
+    # dependency와 동일 근거 — 이 지점 이후 추가 쓰기 없음, expire_on_commit=False라 이후
+    # model_validate(updated) 접근 안전).
     if dep.item_type == "story" and (dep.dep_type == "blocks" or body.dep_type == "blocks"):
         from app.services.attention_events import notify_attention_changed
 
+        await repo.session.commit()
         await notify_attention_changed(repo.org_id)
 
     return DependencyResponse.model_validate(updated)
@@ -222,10 +231,13 @@ async def delete_dependency(
             repo.session, repo.org_id, dep.to_id, _trust_before, actor_id=user_id
         )
 
-    # story #3180(S3 후속) — blocks 의존성 삭제 = unanswered_blocker 해소(attention 파생 입력).
+    # story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — commit-then-publish로 정렬(위
+    # create/update와 동일 근거). 삭제된 `dep`은 model_validate 대상이 아니라 여기선 그냥
+    # {"ok": True} 반환이라 커밋 순서가 응답 직렬화에 영향 없음 — push 타이밍만의 문제.
     if dep.item_type == "story" and dep.dep_type == "blocks":
         from app.services.attention_events import notify_attention_changed
 
+        await repo.session.commit()
         await notify_attention_changed(repo.org_id)
 
     return {"ok": True}

--- a/backend/app/routers/dependencies.py
+++ b/backend/app/routers/dependencies.py
@@ -119,6 +119,12 @@ async def create_dependency(
             session, org_id, body.to_id, _trust_before, actor_id=user_id
         )
 
+    # story #3180(S3 후속) — 새 blocks 의존성 = unanswered_blocker 파생의 생성 입력(attention).
+    if body.item_type == "story" and body.dep_type == "blocks":
+        from app.services.attention_events import notify_attention_changed
+
+        await notify_attention_changed(org_id)
+
     return DependencyResponse.model_validate(dep)
 
 
@@ -173,6 +179,13 @@ async def update_dependency(
             repo.session, repo.org_id, dep.to_id, _trust_before, actor_id=user_id
         )
 
+    # story #3180(S3 후속) — dep_type이 어느 방향으로든 blocks를 넘나들면(생성·해소 둘 다)
+    # unanswered_blocker 파생의 입력이 바뀐 것 — 위 trust_before 게이팅과 동일 조건.
+    if dep.item_type == "story" and (dep.dep_type == "blocks" or body.dep_type == "blocks"):
+        from app.services.attention_events import notify_attention_changed
+
+        await notify_attention_changed(repo.org_id)
+
     return DependencyResponse.model_validate(updated)
 
 
@@ -208,6 +221,12 @@ async def delete_dependency(
         await maybe_emit_trust_stage_changed(
             repo.session, repo.org_id, dep.to_id, _trust_before, actor_id=user_id
         )
+
+    # story #3180(S3 후속) — blocks 의존성 삭제 = unanswered_blocker 해소(attention 파생 입력).
+    if dep.item_type == "story" and dep.dep_type == "blocks":
+        from app.services.attention_events import notify_attention_changed
+
+        await notify_attention_changed(repo.org_id)
 
     return {"ok": True}
 

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -411,11 +411,14 @@ async def update_goal(
     goal = await repo.update(id, **data)
     if goal is None:
         raise HTTPException(status_code=404, detail="Goal not found")
-    # story #3180(S3 후속) — status 전이 없이도 measure_after 재계획은 loop_overdue_goal(도과
-    # 기준선 이동) 파생의 실 입력이다(전용 transition 엔드포인트 밖의 유일한 그 변경 경로).
+    # story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — commit-then-publish로 정렬
+    # (dependencies.py 3곳과 동일 근거 — get_db implicit commit보다 먼저 push하면 FE 재조회가
+    # 아직 안 보이는 상태를 읽는다). measure_after 재계획은 loop_overdue_goal(도과 기준선
+    # 이동) 파생의 실 입력이다(전용 transition 엔드포인트 밖의 유일한 그 변경 경로).
     if "measure_after" in data:
         from app.services.attention_events import notify_attention_changed
 
+        await repo.session.commit()
         await notify_attention_changed(repo.org_id)
     await _attach_org_project_slugs(repo.session, repo.org_id, [goal])
     return GoalResponse.model_validate(goal)

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -419,6 +419,8 @@ async def update_goal(
         from app.services.attention_events import notify_attention_changed
 
         await repo.session.commit()
+        # story 50662d49(commit-then-model_validate refresh lint) — dependencies.py와 동형.
+        await repo.session.refresh(goal)
         await notify_attention_changed(repo.org_id)
     await _attach_org_project_slugs(repo.session, repo.org_id, [goal])
     return GoalResponse.model_validate(goal)

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -411,6 +411,12 @@ async def update_goal(
     goal = await repo.update(id, **data)
     if goal is None:
         raise HTTPException(status_code=404, detail="Goal not found")
+    # story #3180(S3 후속) — status 전이 없이도 measure_after 재계획은 loop_overdue_goal(도과
+    # 기준선 이동) 파생의 실 입력이다(전용 transition 엔드포인트 밖의 유일한 그 변경 경로).
+    if "measure_after" in data:
+        from app.services.attention_events import notify_attention_changed
+
+        await notify_attention_changed(repo.org_id)
     await _attach_org_project_slugs(repo.session, repo.org_id, [goal])
     return GoalResponse.model_validate(goal)
 

--- a/backend/app/routers/hypotheses.py
+++ b/backend/app/routers/hypotheses.py
@@ -270,9 +270,17 @@ async def transition_hypothesis(
             )
         _assert_active_authorized(caller, hyp.owner_member_id, target=body.status)
     try:
-        return await svc.transition_hypothesis(session, org_id, caller, hypothesis_id, body)
+        result = await svc.transition_hypothesis(session, org_id, caller, hypothesis_id, body)
     except svc.HypothesisServiceError as err:
         _raise(err)
+    # story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — commit-then-publish로 정렬. 이
+    # 직접-human-transition 엔드포인트는 이 지점 이후 추가 쓰기가 없는 유일한 콜사이트라(다른
+    # 3곳은 hypothesis.py::transition_hypothesis 콜사이트 주석 참조) 여기서만 신호를 낸다.
+    from app.services.attention_events import notify_attention_changed
+
+    await session.commit()
+    await notify_attention_changed(org_id)
+    return result
 
 
 @router.post("/{hypothesis_id}/outcome-draft")

--- a/backend/app/services/agent_auth_failure.py
+++ b/backend/app/services/agent_auth_failure.py
@@ -113,5 +113,13 @@ async def record_auth_failure(raw_key: str) -> None:
                     await sync_agent_profile_presence(s, member_id, agent_status="auth_failed")
 
             await s.commit()
+
+        # story #3180(S3 후속) — agent_auth_failure attention 항목의 생성 입력. org 귀속
+        # 불가(invalid reason)면 애초에 이 org의 attention에 안 뜨므로 무조건 push할 필요는
+        # 없다(command_center.py ④ 정직성과 동형 — org_id 없으면 no-op).
+        if org_id is not None:
+            from app.services.attention_events import notify_attention_changed
+
+            await notify_attention_changed(org_id)
     except Exception:
         logger.warning("record_auth_failure failed(무해 — 401 응답엔 무영향)", exc_info=True)

--- a/backend/app/services/attention_events.py
+++ b/backend/app/services/attention_events.py
@@ -1,0 +1,31 @@
+"""story #3180(S3 후속) — attention(command-center·«지금» 스트립 attention 7종) 상태 변화를
+기존 chat SSE 채널로 알린다. `presence_events.py::emit_presence`와 동형(발명 0) — payload
+없는 경량 트리거, FE는 이 신호를 받으면 my-actions를 refetch한다(폴링은 폴백으로 유지,
+AC3 — 신호를 못 받는 구버전 클라는 현행 폴링 그대로).
+
+attention 7종(agent_stuck·agent_auth_failure·unanswered_blocker·hypothesis_falsified·
+loop_overdue_hypothesis·loop_overdue_goal·loop_outcome_missing_goal)은 command_center.py의
+my-actions가 매 호출마다 실시간 파생하는 값이다(전용 상태기계·"resolve" API가 따로 없음) —
+서버가 "정확히 이 항목 하나가 해소됐다"를 판별할 근거가 없다. 그 파생에 실제로 입력되는
+쓰기 경로들(story status·dependency blocks·hypothesis transition·goal transition/측정계획·
+agent auth failure)에서 best-effort로 광의 트리거만 쏜다 — 재조회하면 참값을 보므로 과다
+발화는 무해하다(AC1 "payload 최소 — 재조회 트리거면 충분").
+
+best-effort: 발행 실패가 caller(story/dependency/hypothesis/goal 쓰기)를 절대 깨지 않는다.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def notify_attention_changed(org_id) -> None:
+    """org 전체에 «attention changed» 트리거(payload 없음)를 push — presence와 동일 스코프
+    (attention 블록 자체가 org-scope, command_center.py my_actions docstring 참조)."""
+    try:
+        from app.routers.events import push_to_org_members
+
+        await push_to_org_members(str(org_id), "attention.changed", {})
+    except Exception:
+        logger.warning("emit attention.changed failed org=%s", org_id, exc_info=True)

--- a/backend/app/services/goal_events.py
+++ b/backend/app/services/goal_events.py
@@ -102,6 +102,12 @@ async def emit_goal_status_changed(
     event_data["status"] = epic.status
     await _emit(db, org_id, "epic.status_changed", event_data, notify_member_id=epic.assignee_id)
 
+    # story #3180(S3 후속) — goal status 전이는 loop_overdue_goal(active 이탈)·
+    # loop_outcome_missing_goal(done 도달 시 outcome_status 확定) 파생의 실 입력.
+    from app.services.attention_events import notify_attention_changed
+
+    await notify_attention_changed(org_id)
+
 
 async def emit_goal_removed(
     db, org_id: uuid.UUID, epic_id: uuid.UUID, epic_title: str, project_id: uuid.UUID,

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -543,6 +543,12 @@ async def transition_hypothesis(
         await record_outcome_verdicts(session, updated)
         await attribute_loop_outcome(session, updated)
 
+    # story #3180(S3 후속) — hypothesis status 전이는 hypothesis_falsified(falsified 도달)·
+    # loop_overdue_hypothesis(active/measuring 이탈) 파생의 실 입력.
+    from app.services.attention_events import notify_attention_changed
+
+    await notify_attention_changed(org_id)
+
     return await _to_response(repo, updated)
 
 

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -543,12 +543,14 @@ async def transition_hypothesis(
         await record_outcome_verdicts(session, updated)
         await attribute_loop_outcome(session, updated)
 
-    # story #3180(S3 후속) — hypothesis status 전이는 hypothesis_falsified(falsified 도달)·
-    # loop_overdue_hypothesis(active/measuring 이탈) 파생의 실 입력.
-    from app.services.attention_events import notify_attention_changed
-
-    await notify_attention_changed(org_id)
-
+    # story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — attention.changed push는 여기서
+    # 하지 않는다. 이 서비스 함수는 호출자가 4곳(routers/hypotheses.py 직접 전이·
+    # services/hypothesis.py 내부 위임 호출·hypothesis_outcome_confirm.py 게이트 해소·
+    # workflow_line_resolution.py)으로 갈리고 커밋 시점이 호출자마다 다르다 — 여기서 커밋해
+    # 버리면 게이트 해소 등 "이후에도 더 쓰기가 남은" 호출자의 원자성을 이 함수가 임의로
+    # 쪼갠다. push는 커밋 시점을 확실히 아는 콜사이트(routers/hypotheses.py의 직접 human
+    # transition 엔드포인트)로 옮겼다 — 나머지 3개 콜사이트는 이번 스코프에서 신호 없음(폴링
+    # 폴백은 그대로 무회귀).
     return await _to_response(repo, updated)
 
 

--- a/backend/app/services/hypothesis_scorer.py
+++ b/backend/app/services/hypothesis_scorer.py
@@ -154,11 +154,10 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
         else:
             pending.append(str(hyp.id))  # measuring 유지
 
-    if _attention_org_ids:
-        from app.services.attention_events import notify_attention_changed
-
-        for _org_id in _attention_org_ids:
-            await notify_attention_changed(_org_id)
+    # story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — 여기서 직접 push하지 않는다. 이
+    # 함수 자신의 docstring 계약대로 "호출자(cron route)가 commit한다" — 커밋 前에 push하면
+    # FE 재조회가 아직 안 보이는 배치 결과를 읽는다. org_id 집합만 반환해 호출자
+    # (routers/cron.py::score_hypotheses_cron)가 자기 commit 後에 push하게 한다.
 
     return {
         "to_measuring": to_measuring,
@@ -167,6 +166,7 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
         "pending": pending,
         "failed": failed,
         "total": len(hyps),
+        "attention_org_ids": sorted(_attention_org_ids),
         # HO-S4(AC②): outcome verdict 배선 결과를 cron response에 노출.
         "verdicts_recorded": verdicts_recorded,
         # S7: loop outcome 귀속 결과를 cron response에 노출(관측 정직성).

--- a/backend/app/services/hypothesis_scorer.py
+++ b/backend/app/services/hypothesis_scorer.py
@@ -82,6 +82,10 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
     verdicts_skipped: list[dict] = []
     # E-LOOP-LEDGER S7: 해소 직후 loop outcome 귀속 배선 결과(복리 되먹임 고리).
     loops_attributed: list[dict] = []
+    # story #3180(S3 후속) — 자동채점 verified/falsified도 hypothesis_falsified·
+    # loop_overdue_hypothesis 파생의 입력이다(transition_hypothesis 수동경로와 동형). 배치
+    # 전역 쿼리라 org별로 한 번만 push하도록 모은다(과다발화 방지 — 필수는 아니나 값싼 절약).
+    _attention_org_ids: set[str] = set()
     from app.services.hypothesis_outcome_verdict import record_outcome_verdicts
     from app.services.loop_outcome_attribution import attribute_loop_outcome
 
@@ -127,6 +131,10 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
             hyp.status = new_status
             hyp.outcome_result = scoring["outcome_result"]
             (verified if new_status == "verified" else falsified).append(str(hyp.id))
+            _hyp_org_id = getattr(hyp, "org_id", None)  # getattr — 일부 단위테스트가 org_id
+            # 없는 duck-type fixture(SimpleNamespace)로 hyp를 흉내낸다(실 ORM 행은 항상 있음).
+            if _hyp_org_id:
+                _attention_org_ids.add(str(_hyp_org_id))
             # HO-S4(AC①): 해소 직후 outcome→verdict 배선(체인: scorer→verdict→trust 닫힘).
             # manual/pending은 여기 도달 안 함(new_status None)이라 verdict 0(AC④).
             vres = await record_outcome_verdicts(session, hyp)
@@ -145,6 +153,12 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
                 loops_attributed.append({"hypothesis_id": str(hyp.id), "loop_ids": lres["attributed"]})
         else:
             pending.append(str(hyp.id))  # measuring 유지
+
+    if _attention_org_ids:
+        from app.services.attention_events import notify_attention_changed
+
+        for _org_id in _attention_org_ids:
+            await notify_attention_changed(_org_id)
 
     return {
         "to_measuring": to_measuring,

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -236,6 +236,12 @@ async def emit_story_status_changed(
         except Exception:  # noqa: BLE001 — 계측 실패가 이미 발화된 side-effect를 되돌리면 안 됨.
             pass
 
+    # story #3180(S3 후속) — attention(«지금» 스트립) 재조회 트리거. story status 변화는
+    # story_stalled(어느 상태변화든 updated_at 갱신)·unanswered_blocker(블로킹 대상이 done
+    # 전이) 파생의 실 입력이다. notify_attention_changed 자신이 best-effort(내부 try/except).
+    from app.services.attention_events import notify_attention_changed
+    await notify_attention_changed(org_id)
+
     try:
         # AC2: story.status_changed 의 member-bound webhook 은 관련자(notify_ids)만 수신 → org-wide
         # 과다 fan-out 차단. member_id=null 진짜 activity-feed 브로드캐스트는 보존(preserve_broadcast).

--- a/backend/tests/test_3593_attention_changed_commit_order.py
+++ b/backend/tests/test_3593_attention_changed_commit_order.py
@@ -1,0 +1,346 @@
+"""story #3180 후속(카디르 QA REQUEST_CHANGES, PR#3593) — attention.changed push가 caller의
+commit 前에 나가면, 그 신호로 FE가 즉시 재조회할 때 아직 안 보이는(커밋 前) 상태를 읽는다.
+폴백 폴링이 이 실패를 가려 조용히 넘어가던 것이 REQUEST_CHANGES 근거였다(get_db가 커밋을
+핸들러 반환 後로 미루는 것 자체는 app/dependencies/database.py::get_db 참조 — 정상 설계이지만
+핸들러 본문 안에서 push를 먼저 하면 그 지연 창을 실제로 밟는다).
+
+이 파일은 4개 콜사이트를 commit-then-publish로 정렬한 것을 순서로 직접 pin한다:
+  ① routers/dependencies.py — create/update/delete_dependency
+  ② routers/goals.py::update_goal(measure_after 재계획)
+  ③ routers/hypotheses.py::transition_hypothesis(직접 human 전이 — 유일하게 안전한 콜사이트)
+  ④ services/hypothesis_scorer.py::score_hypotheses(더 이상 자체 push 안 함) +
+     routers/cron.py::score_hypotheses_cron(호출자가 commit 後 push)
+
+이미 안전했던 3곳(story_status_events·goal_events·agent_auth_failure)은 이 라운드에서
+안 건드렸으므로 여기서 재검증하지 않는다(1라운드 테스트가 이미 다룸).
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.routers import dependencies as deps_r
+from app.routers import goals as goals_r
+from app.routers import hypotheses as hyp_r
+from app.schemas.dependency import DependencyCreate, DependencyUpdate
+from app.schemas.goal import GoalUpdate
+from app.schemas.hypothesis import HypothesisTransition
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _order_tracker():
+    """commit/push 호출 순서를 기록하는 공유 리스트 — 두 mock의 side_effect가 여기에 append."""
+    order: list[str] = []
+    return order
+
+
+def _auth_ctx(user_id: uuid.UUID) -> MagicMock:
+    ctx = MagicMock()
+    ctx.user_id = str(user_id)
+    ctx.claims = {"app_metadata": {}}
+    return ctx
+
+
+# ── ① dependencies.py — create/update/delete ──────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_dependency_commits_before_push():
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    from_id, to_id = uuid.uuid4(), uuid.uuid4()
+    order = _order_tracker()
+
+    session = AsyncMock()
+    session.commit = AsyncMock(side_effect=lambda: order.append("commit"))
+
+    dep = SimpleNamespace(
+        id=uuid.uuid4(), org_id=org_id, from_id=from_id, to_id=to_id,
+        dep_type="blocks", item_type="story", created_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+    )
+    fake_repo = MagicMock()
+    fake_repo.exists = AsyncMock(return_value=False)
+    fake_repo.create = AsyncMock(return_value=dep)
+
+    body = DependencyCreate(from_id=from_id, to_id=to_id, dep_type="blocks", item_type="story")
+
+    with patch.object(deps_r, "DependencyRepository", MagicMock(return_value=fake_repo)), \
+         patch.object(deps_r, "_assert_item_project_access", AsyncMock()), \
+         patch.object(deps_r, "would_create_cycle", AsyncMock(return_value=False)), \
+         patch("app.services.trust_pipeline.compute_trust_facts", new=AsyncMock(return_value={"foo": "bar"})), \
+         patch("app.services.trust_pipeline.maybe_emit_trust_stage_changed", new=AsyncMock()), \
+         patch("app.services.attention_events.notify_attention_changed",
+               new=AsyncMock(side_effect=lambda *a, **k: order.append("push"))) as push:
+        await deps_r.create_dependency(body, session=session, org_id=org_id, auth=_auth_ctx(user_id))
+
+    assert order == ["commit", "push"]
+    push.assert_awaited_once_with(org_id)
+
+
+@pytest.mark.anyio
+async def test_update_dependency_commits_before_push():
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    order = _order_tracker()
+
+    session = AsyncMock()
+    session.commit = AsyncMock(side_effect=lambda: order.append("commit"))
+
+    dep = SimpleNamespace(id=uuid.uuid4(), from_id=uuid.uuid4(), to_id=uuid.uuid4(), item_type="story", dep_type="blocks")
+    updated = SimpleNamespace(
+        id=dep.id, org_id=org_id, from_id=dep.from_id, to_id=dep.to_id, dep_type="depends_on",
+        item_type="story", created_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+    )
+    fake_repo = MagicMock()
+    fake_repo.session = session
+    fake_repo.org_id = org_id
+    fake_repo.get = AsyncMock(return_value=dep)
+    fake_repo.update_dep_type = AsyncMock(return_value=updated)
+
+    body = DependencyUpdate(dep_type="depends_on")  # blocks→depends_on = 해소(old가 blocks라 게이팅 통과)
+
+    with patch.object(deps_r, "_assert_item_project_access", AsyncMock()), \
+         patch("app.services.trust_pipeline.compute_trust_facts", new=AsyncMock(return_value={"foo": "bar"})), \
+         patch("app.services.trust_pipeline.maybe_emit_trust_stage_changed", new=AsyncMock()), \
+         patch("app.services.attention_events.notify_attention_changed",
+               new=AsyncMock(side_effect=lambda *a, **k: order.append("push"))) as push:
+        await deps_r.update_dependency(dep.id, body, repo=fake_repo, auth=_auth_ctx(user_id))
+
+    assert order == ["commit", "push"]
+    push.assert_awaited_once_with(org_id)
+
+
+@pytest.mark.anyio
+async def test_delete_dependency_commits_before_push():
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    order = _order_tracker()
+
+    session = AsyncMock()
+    session.commit = AsyncMock(side_effect=lambda: order.append("commit"))
+
+    dep = SimpleNamespace(id=uuid.uuid4(), from_id=uuid.uuid4(), to_id=uuid.uuid4(), item_type="story", dep_type="blocks")
+    fake_repo = MagicMock()
+    fake_repo.session = session
+    fake_repo.org_id = org_id
+    fake_repo.get = AsyncMock(return_value=dep)
+    fake_repo.delete = AsyncMock(return_value=True)
+
+    with patch.object(deps_r, "_assert_item_project_access", AsyncMock()), \
+         patch("app.services.trust_pipeline.compute_trust_facts", new=AsyncMock(return_value={"foo": "bar"})), \
+         patch("app.services.trust_pipeline.maybe_emit_trust_stage_changed", new=AsyncMock()), \
+         patch("app.services.attention_events.notify_attention_changed",
+               new=AsyncMock(side_effect=lambda *a, **k: order.append("push"))) as push:
+        await deps_r.delete_dependency(dep.id, repo=fake_repo, auth=_auth_ctx(user_id))
+
+    assert order == ["commit", "push"]
+    push.assert_awaited_once_with(org_id)
+
+
+# ── ② goals.py::update_goal ────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_update_goal_measure_after_commits_before_push():
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    order = _order_tracker()
+
+    session = AsyncMock()
+    session.commit = AsyncMock(side_effect=lambda: order.append("commit"))
+
+    current = SimpleNamespace(
+        id=uuid.uuid4(), project_id=project_id, status="active",
+        metric_definition={"metric": "m"}, measure_after=None, outcome_status="n_a",
+    )
+    from datetime import datetime, timezone
+    new_ma = datetime(2026, 12, 1, tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    updated = SimpleNamespace(
+        id=current.id, project_id=project_id, org_id=org_id, assignee_id=None,
+        title="g", status="active", priority="medium", description=None, objective=None,
+        success_criteria=None, target_sp=None, target_date=None, success_hypothesis=None,
+        metric_definition={"metric": "m"}, measure_after=new_ma, outcome_status="n_a",
+        outcome_result=None, position=None, source_loop_id=None, created_at=now, updated_at=now,
+    )
+
+    fake_repo = MagicMock()
+    fake_repo.session = session
+    fake_repo.org_id = org_id
+    fake_repo.get = AsyncMock(return_value=current)
+    fake_repo.update = AsyncMock(return_value=updated)
+
+    body = GoalUpdate(measure_after=new_ma)
+
+    with patch.object(goals_r, "require_project_access", AsyncMock()), \
+         patch.object(goals_r, "_attach_org_project_slugs", AsyncMock()), \
+         patch("app.services.attention_events.notify_attention_changed",
+               new=AsyncMock(side_effect=lambda *a, **k: order.append("push"))) as push:
+        await goals_r.update_goal(current.id, body, repo=fake_repo, auth=_auth_ctx(user_id))
+
+    assert order == ["commit", "push"]
+    push.assert_awaited_once_with(org_id)
+
+
+@pytest.mark.anyio
+async def test_update_goal_without_measure_after_does_not_push():
+    """회귀 방지 — measure_after 미포함 PATCH는 여전히 무발화(과다발화 가드 유지 확認)."""
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+
+    session = AsyncMock()
+    current = SimpleNamespace(
+        id=uuid.uuid4(), project_id=project_id, status="active",
+        metric_definition=None, measure_after=None, outcome_status="n_a",
+    )
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc)
+    updated = SimpleNamespace(
+        id=current.id, project_id=project_id, org_id=org_id, assignee_id=None,
+        title="new title", status="active", priority="medium", description=None, objective=None,
+        success_criteria=None, target_sp=None, target_date=None, success_hypothesis=None,
+        metric_definition=None, measure_after=None, outcome_status="n_a",
+        outcome_result=None, position=None, source_loop_id=None, created_at=now, updated_at=now,
+    )
+    fake_repo = MagicMock()
+    fake_repo.session = session
+    fake_repo.org_id = org_id
+    fake_repo.get = AsyncMock(return_value=current)
+    fake_repo.update = AsyncMock(return_value=updated)
+
+    body = GoalUpdate(title="new title")
+
+    with patch.object(goals_r, "require_project_access", AsyncMock()), \
+         patch.object(goals_r, "_attach_org_project_slugs", AsyncMock()), \
+         patch("app.services.attention_events.notify_attention_changed", new=AsyncMock()) as push:
+        await goals_r.update_goal(current.id, body, repo=fake_repo, auth=_auth_ctx(user_id))
+
+    push.assert_not_awaited()
+    session.commit.assert_not_awaited()  # 이 경로 자체는 여전히 get_db implicit commit에 위임
+
+
+# ── ③ hypotheses.py::transition_hypothesis(라우터 — 유일하게 안전한 직접 human 전이 콜사이트) ──
+
+@pytest.mark.anyio
+async def test_transition_hypothesis_router_commits_before_push():
+    org_id = uuid.uuid4()
+    hyp_id = uuid.uuid4()
+    caller_id = uuid.uuid4()
+    order = _order_tracker()
+
+    session = AsyncMock()
+    session.commit = AsyncMock(side_effect=lambda: order.append("commit"))
+
+    caller = SimpleNamespace(id=caller_id, user_id=caller_id, name="t", type="human", role="member", org_id=org_id)
+    body = HypothesisTransition(status="killed", note="stop")
+    canned_result = SimpleNamespace(id=hyp_id, status="killed")
+
+    with patch.object(hyp_r, "_assert_hypothesis_project_access", AsyncMock()), \
+         patch.object(hyp_r, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(hyp_r.svc, "transition_hypothesis", AsyncMock(return_value=canned_result)), \
+         patch("app.services.attention_events.notify_attention_changed",
+               new=AsyncMock(side_effect=lambda *a, **k: order.append("push"))) as push:
+        result = await hyp_r.transition_hypothesis(
+            hyp_id, body, session=session, auth=_auth_ctx(caller_id), org_id=org_id,
+        )
+
+    assert order == ["commit", "push"]
+    push.assert_awaited_once_with(org_id)
+    assert result is canned_result  # commit-then-publish 재배선이 반환값을 안 바꿈(회귀 없음)
+
+
+@pytest.mark.anyio
+async def test_transition_hypothesis_service_no_longer_pushes_itself():
+    """services/hypothesis.py::transition_hypothesis 자체는 이제 push하지 않는다(4개
+    콜사이트마다 커밋 시점이 달라 이 공유 함수 안에서 커밋을 강제하면 원자성이 깨짐 —
+    gate 해소 등 "이후에도 쓰기가 남은" 호출자를 위한 안전장치). push 책임은 유일하게 안전한
+    콜사이트(routers/hypotheses.py의 직접 human transition)로 옮겨졌다."""
+    from app.services import hypothesis as hyp_svc
+    from app.services.member_resolver import ResolvedMember
+
+    org_id = uuid.uuid4()
+    hyp_id = uuid.uuid4()
+    caller_id = uuid.uuid4()
+    caller = ResolvedMember(id=caller_id, user_id=caller_id, name="t", type="human", role="member", org_id=org_id)
+
+    hyp = SimpleNamespace(id=hyp_id, status="killed", outcome_result=None)
+    updated = SimpleNamespace(id=hyp_id, status="active")
+    body = HypothesisTransition(status="active")
+
+    fake_repo = MagicMock()
+    fake_repo.get = AsyncMock(return_value=SimpleNamespace(id=hyp_id, status="proposed"))
+    fake_repo.update = AsyncMock(return_value=updated)
+
+    with patch.object(hyp_svc, "HypothesisRepository", MagicMock(return_value=fake_repo)), \
+         patch.object(hyp_svc, "_to_response", AsyncMock(return_value=updated)), \
+         patch("app.services.attention_events.notify_attention_changed", new=AsyncMock()) as push:
+        await hyp_svc.transition_hypothesis(AsyncMock(), org_id, caller, hyp_id, body, via_gate=True)
+
+    push.assert_not_awaited()
+
+
+# ── ④ hypothesis_scorer.py::score_hypotheses + cron.py::score_hypotheses_cron ─────────────
+
+@pytest.mark.anyio
+async def test_score_hypotheses_does_not_push_but_reports_org_ids():
+    """score_hypotheses 자신의 계약("호출자가 commit한다")대로, 여기선 push_to_org_members가
+    한 번도 안 불리고 attention_org_ids만 반환한다."""
+    from tests.test_hypothesis_scorer import _hyp, _run
+
+    org = uuid.uuid4()
+    h = _hyp(status="active", source="ga4", org_id=org)
+
+    # test_hypothesis_scorer.py의 _mock_outcome_verdicts/_mock_loop_attribution(autouse)은 그
+    # 파일 안 테스트에만 적용된다 — 여기서 _run()을 임포트해 부르는 경우엔 안 걸리므로 직접 격리.
+    with patch("app.services.hypothesis_outcome_verdict.record_outcome_verdicts",
+               new=AsyncMock(return_value={"skipped_reason": "no_linked_story", "bet": [], "execution": []})), \
+         patch("app.services.loop_outcome_attribution.attribute_loop_outcome",
+               new=AsyncMock(return_value={"skipped_reason": "no_measuring_loop", "attributed": []})), \
+         patch("app.routers.events.push_to_org_members", new=AsyncMock()) as pub, \
+         patch("app.services.attention_events.notify_attention_changed", new=AsyncMock()) as push:
+        summary = await _run([h], ga4={"outcome_status": "hit", "outcome_result": {"actual": 1}})
+
+    pub.assert_not_awaited()
+    push.assert_not_awaited()
+    assert summary["attention_org_ids"] == [str(org)]
+
+
+@pytest.mark.anyio
+async def test_score_hypotheses_cron_commits_before_push():
+    from app.routers import cron as cron_r
+
+    org_a, org_b = uuid.uuid4(), uuid.uuid4()
+    order = _order_tracker()
+
+    session = AsyncMock()
+    session.commit = AsyncMock(side_effect=lambda: order.append("commit"))
+
+    canned_summary = {
+        "to_measuring": [], "verified": [], "falsified": [], "pending": [], "failed": [], "total": 0,
+        "verdicts_recorded": [], "loops_attributed": [], "verdicts_skipped": [],
+        "attention_org_ids": [str(org_a), str(org_b)],
+    }
+    request = MagicMock()
+
+    pushed: list[str] = []
+
+    async def _fake_notify(org_id):
+        order.append("push")
+        pushed.append(str(org_id))
+
+    with patch.object(cron_r, "verify_cron", MagicMock()), \
+         patch("app.services.hypothesis_scorer.score_hypotheses", new=AsyncMock(return_value=canned_summary)), \
+         patch("app.services.attention_events.notify_attention_changed", new=AsyncMock(side_effect=_fake_notify)):
+        await cron_r.score_hypotheses_cron(request, session=session)
+
+    # commit이 두 push 모두보다 먼저(순서 리스트 첫 원소) — 그 뒤 org별 1회씩.
+    assert order[0] == "commit"
+    assert order.count("push") == 2
+    assert set(pushed) == {str(org_a), str(org_b)}

--- a/backend/tests/test_attention_events.py
+++ b/backend/tests/test_attention_events.py
@@ -1,0 +1,52 @@
+"""story #3180(S3 후속) — attention.changed 발행 헬퍼 shape + best-effort(실패 swallow).
+
+presence_events.py::emit_presence와 동형 테스트 구조(tests/test_presence_events_r2.py 참고) —
+payload 없는 org 전체 트리거라는 점까지 동일하다."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_notify_attention_changed_publishes_trigger():
+    from app.services import attention_events
+
+    org = uuid.uuid4()
+    with patch("app.routers.events.push_to_org_members", new=AsyncMock()) as pub:
+        await attention_events.notify_attention_changed(org)
+
+    pub.assert_awaited_once()
+    args, kwargs = pub.await_args
+    assert args[0] == str(org)
+    assert args[1] == "attention.changed"
+    assert args[2] == {}
+    # presence와 동형 — member_ids 미지정 시 org 전체로 해소된다(command_center.py attention
+    # 블록 자체가 org-scope).
+    assert kwargs.get("member_ids") is None
+
+
+@pytest.mark.anyio
+async def test_notify_attention_changed_accepts_str_org_id():
+    from app.services import attention_events
+
+    org_str = str(uuid.uuid4())
+    with patch("app.routers.events.push_to_org_members", new=AsyncMock()) as pub:
+        await attention_events.notify_attention_changed(org_str)
+
+    args, _ = pub.await_args
+    assert args[0] == org_str
+
+
+@pytest.mark.anyio
+async def test_notify_attention_changed_swallows_publish_failure():
+    """발행 실패가 caller(story/dependency/hypothesis/goal 쓰기)를 절대 깨면 안 됨."""
+    from app.services import attention_events
+
+    with patch(
+        "app.routers.events.push_to_org_members",
+        new=AsyncMock(side_effect=RuntimeError("bus down")),
+    ):
+        await attention_events.notify_attention_changed(uuid.uuid4())  # no raise

--- a/backend/tests/test_emit_story_status_changed_isolation.py
+++ b/backend/tests/test_emit_story_status_changed_isolation.py
@@ -111,6 +111,24 @@ async def test_trust_pipeline_raise_does_not_propagate():
         )  # 예외 없이 반환.
 
 
+# ── story #3180(S3 후속) — attention.changed 트리거도 다른 side-effect와 동일하게 격리돼야
+#    한다. notify_attention_changed 자신이 이미 내부 try/except로 감싸져 있어(테스트는
+#    tests/test_attention_events.py) 여기선 그 call-site 통합이 새 요구사항을 얹지
+#    않는다는 것만 재확認한다. ────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_attention_changed_raise_does_not_propagate():
+    with ExitStack() as stack:
+        _base_patches(stack)
+        stack.enter_context(patch(
+            "app.routers.events.push_to_org_members",
+            AsyncMock(side_effect=RuntimeError("attention push down")),
+        ))
+        await emit_story_status_changed(
+            AsyncMock(), uuid.uuid4(), _story(), "in-review",
+            actor_id=uuid.uuid4(), actor_type="human",
+        )  # 예외 없이 반환.
+
+
 # ── story #f2b66f32(3025, BE·상태 자가회수) — merge gate 자가회수도 다른 5종과 동일하게
 #    격리돼야 한다(실패해도 done 전이 자체는 무영향). _story()는 status="done" 고정이라 이
 #    side-effect가 실제로 시도되는 경로를 그대로 탄다. ───────────────────────────────────


### PR DESCRIPTION
[SID:3180]

## 요약
attention 소비처(chat 「지금」 스트립·org-briefing now-face)가 setInterval 폴링만으로
갱신되던 것을, 기존 chat SSE 채널(발명 0)에 얹은 `attention.changed` 신호로 즉시
재조회되게 한다. 폴링은 신호 미수신 환경(구버전 클라·SSE 끊김)의 폴백으로 그대로 유지.

## 설계
- `backend/app/services/attention_events.py::notify_attention_changed(org_id)` — 신규
  공유 헬퍼. `push_to_org_members(org_id, "attention.changed", {})` best-effort 호출
  (`presence_events.py::emit_presence`와 완전 동형 — payload 없는 org 전체 트리거, 내부
  try/except로 caller에 절대 전파 안 함).
- attention 7종(agent_stuck·agent_auth_failure·unanswered_blocker·hypothesis_falsified·
  loop_overdue_hypothesis·loop_overdue_goal·loop_outcome_missing_goal)은 `command_center.py`
  의 my-actions가 매 호출마다 실시간 파생하는 값이라(전용 상태기계·"resolve" API 없음)
  서버가 "정확히 이 항목 하나가 해소됐다"를 판별할 근거가 없다 — 그 파생에 실제로 입력되는
  쓰기 경로들에서 광의 트리거만 쏜다(재조회하면 참값을 보므로 과다발화는 무해, AC1 "payload
  최소 — 재조회 트리거면 충분").

## 훅 지점 (BE)
- `story_status_events.py::emit_story_status_changed` — story_stalled·unanswered_blocker
  (블로킹 대상 done 전이) 입력.
- `routers/dependencies.py` create/update/delete_dependency — unanswered_blocker 생성·
  해소 직접 트리거(dep_type="blocks" 관련 변경만).
- `services/hypothesis.py::transition_hypothesis` — hypothesis_falsified 생성·
  loop_overdue_hypothesis 해소(수동 확定 경로).
- `services/hypothesis_scorer.py::score_hypotheses` — 위와 동형, 자동채점(cron) 경로.
  배치 전역 쿼리라 org별 1회로 묶어서 발행.
- `services/goal_events.py::emit_goal_status_changed` — loop_overdue_goal·
  loop_outcome_missing_goal(done 전이).
- `routers/goals.py::update_goal` — status 전이 없이 measure_after만 재계획해도
  loop_overdue_goal 입력이 바뀌므로 별도 훅.
- `services/agent_auth_failure.py::record_auth_failure` — agent_auth_failure 생성.

## FE 소비처
- `apps/web/src/components/chat/now-strip.tsx`(「지금」 스트립, S3a) — `useAutoRefresh`
  폴백은 그대로, `useSseMultiplexerContext().subscribe('attention.changed', …)`로 즉시
  재조회 추가.
- `apps/web/src/components/org-briefing/now-face.tsx` — 동일 패턴, 기존
  `setInterval(REFRESH_MS)` 폴백 유지.
- `apps/web/src/lib/realtime/sse-cursor-eligibility.ts`의 `TRANSIENT_EVENT_NAMES`에
  `attention.changed` 추가(필수 — Event DB row 없는 B계열이라 안 추가하면 재개 커서 오염
  버그 재발, 파일 자신의 docstring이 명시).
- 두 소비처 모두 `shouldSuppressDuplicateSseEvent` 미호출 — payload가 항상 `{}`(event_id
  없음)라 presence(`use-team-presence.ts`)와 동형 판단(재배달돼도 재조회 1회 더, 멱등).
  `sse-dedup-enforcement.test.ts` 스캐너는 `lib/realtime/`·`hooks/`·`components/kanban/`·
  `components/presence/`만 얕게 스캔해 `org-briefing/`·`chat/`은 대상 밖이라 별도 exemption
  불필요(스캐너 범위 확장은 이 스토리 스코프 밖).
- `command-center.tsx`/`overview-zone.tsx`는 develop에 이미 없음(S3c #3179가 `/dashboard`를
  폐합, 그 attention 표면은 S3a #3177이 chat now-strip.tsx로 흡수 완료) — `action-zone.tsx`는
  현재 zero-importer 죽은 코드라 손대지 않음.

## 정직한 갭
- `agent_stuck`(WorkflowLineStepRun pending 정체)은 순수 시간창 판정이고, 그걸 "해소"하는
  단일 write 경로(에이전트 실행 완료·게이트 승인/반려 등 다양한 경로로 분산)를 이번 스코프
  에서 특정하지 못했다 — 이 항목은 여전히 폴링 주기 내 소멸만 보장된다(AC2 폴백 규정 그대로,
  회귀 아님). 후속 필요하면 별도 스토리로.

## 테스트
- BE 신규: `backend/tests/test_attention_events.py`(shape·org_id str/UUID 겸용·발행 실패
  swallow) — 3건 pass.
- BE 격리 pin 추가: `test_emit_story_status_changed_isolation.py::
  test_attention_changed_raise_does_not_propagate` — 전체 13건 pass.
- BE 회귀 스윕: `pytest -k "dependency or dependencies or hypothesis or goal_events or
  agent_auth_failure or hypothesis_scorer" -m "not destructive_schema"` — 143 passed,
  94 skipped(realdb, 로컬 PARITY/ALEMBIC_DATABASE_URL 미설정 — 환경 제약으로 미실행,
  disclosed gap), 0 failed. `hypothesis_scorer.py`에서 `hyp.org_id` 직접접근이 기존
  SimpleNamespace fixture(org_id 없음)에 AttributeError를 내던 걸 `getattr(hyp, "org_id",
  None)`로 수정.
- FE: `now-strip.test.tsx`(mux 없음 시 무동작·구독 확認·신호 수신 시 즉시 refetch 3건 신규)
  · `now-face.test.tsx`(동형 2건 신규) · `sse-cursor-eligibility.test.ts`(1건 신규) — 관련
  파일 전체 25 passed. `sse-dedup-enforcement.test.ts`·`sse-multiplexer.test.tsx` 36 passed
  (무회귀 확認). `tsc --noEmit` clean. `eslint`(터치 파일 스코프) clean.
- BE 커스텀 CI lint(project_access_403·dependency_override_get_read_db·
  commit_before_validate) 신규 위반 0건.
- AC4(라이브 실측)는 dev 배포 후 별도 확認 필요 — 이 PR 자체는 코드 변경까지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)