### PR TITLE
[온보딩·크럭스] connect 스텝 아티팩트 shape mismatch로 API 키 영구 미표시 fix

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1132,6 +1132,7 @@
     "verifyTimeoutTitle": "Not connected yet",
     "verifyTimeoutHint": "Make sure you restarted Claude Code and that the config above was saved correctly, then press Retry.",
     "artifactPending": "Preparing connection config…",
+    "artifactError": "Couldn't load the connection config — please retry.",
     "artifactRetry": "Retry",
     "verifyTitle": "Verify connection",
     "verifyRetry": "Run test",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1132,6 +1132,7 @@
     "verifyTimeoutTitle": "아직 연결이 확인되지 않았어요",
     "verifyTimeoutHint": "Claude Code를 재시작했는지 확인하고, 위 설정이 올바르게 저장됐는지 점검한 뒤 「다시 시도」를 눌러 주세요.",
     "artifactPending": "연결 설정 생성 중…",
+    "artifactError": "설정을 불러오지 못했습니다 — 다시 시도해 주세요.",
     "artifactRetry": "다시 시도",
     "verifyTitle": "연결 확인",
     "verifyRetry": "다시 테스트",

--- a/apps/web/src/app/onboarding/connect-step.test.tsx
+++ b/apps/web/src/app/onboarding/connect-step.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
-import { ConnectStep, inferTransport } from './connect-step';
+import { ConnectStep, inferTransport, maskApiKey } from './connect-step';
 import { RAIL_ORDER, HTTP_RAIL_ORDER, VERIFY_TIMEOUT_MS } from './verify-rail';
 import ko from '../../../messages/ko.json';
 
@@ -54,7 +54,22 @@ describe('ConnectStep — story #4cdad425 (검증 안내 표시 렌더)', () => 
   function makeFetch(verified: boolean) {
     return vi.fn(async (url: string) => {
       if (url.includes('connection-artifact')) {
-        return { ok: true, json: async () => ({ data: { content: JSON.stringify({ mcpServers: { 'sprintable-mcp': { type: 'http', url: 'https://mcp.x/mcp', headers: {}, env: { AGENT_API_KEY: '<YOUR_AGENT_API_KEY>' } } } }) } }) };
+        // story #3192 — BE 실 응답 shape(`{data: {files: [{filename, content}]}}`, agents.py::
+        // _connection_artifact) 그대로. 옛 `{data: {content}}` 단일필드 mock은 실제로는 이미
+        // 존재하지 않는 shape을 검증하고 있었다(그린인데 틀린 테스트 — 이 스토리의 근본원인).
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              files: [{
+                filename: '.mcp.json',
+                content: JSON.stringify({ mcpServers: { 'sprintable-mcp': { type: 'http', url: 'https://mcp.x/mcp', headers: {}, env: { AGENT_API_KEY: '<YOUR_AGENT_API_KEY>' } } } }),
+              }],
+              mcp_config: null,
+              api_key: null,
+            },
+          }),
+        };
       }
       if (url.includes('verification-status')) {
         const rail = verified
@@ -117,5 +132,84 @@ describe('ConnectStep — story #4cdad425 (검증 안내 표시 렌더)', () => 
     await act(async () => { await vi.advanceTimersByTimeAsync(VERIFY_TIMEOUT_MS + 100); });
     expect(container.textContent).not.toContain(WAITING);
     expect(container.textContent).not.toContain(TIMEOUT);
+  });
+});
+
+// story #3192(온보딩·크럭스) — 신규 계정이 connect 스텝에서 API 키를 한 번도 못 받던 근본원인의
+// pin. BE 응답 shape이 `{files: [{filename, content}]}`인데(agents.py::_connection_artifact,
+// AgentConnectionSettingsSection이 이미 그렇게 소비 중이었음) 이 파일의 fetchArtifact만 옛
+// `{content}` 단일필드를 읽어 항상 undefined → 아티팩트가 영구 pending에 갇히고, 실 API 키를
+// 대입할 자리(renderArtifact) 자체에 도달하지 못했다.
+describe('ConnectStep — story #3192 (연결 아티팩트 shape 회귀 pin)', () => {
+  const PENDING = '연결 설정 생성 중…'; // artifactPending
+  const ERROR = '설정을 불러오지 못했습니다'; // artifactError
+  const REAL_KEY = 'sk_live_realkey0001';
+
+  function makeArtifactFetch(kind: 'real-shape' | 'stale-shape' | 'empty-files') {
+    return vi.fn(async (url: string) => {
+      if (url.includes('connection-artifact')) {
+        if (kind === 'stale-shape') {
+          // 이 스토리 착수 前 실제로 왔던 응답 — content가 top-level에 없다(BE가 이미 files[]로
+          // 바뀐 뒤). 픽스 前에는 이걸 파싱 실패로도 못 알아채고 계속 "생성 중…"만 보여줬다.
+          return { ok: true, json: async () => ({ data: { content: 'stale-shape-should-not-exist' } }) };
+        }
+        const files = kind === 'empty-files' ? [] : [{ filename: '.mcp.json', content: JSON.stringify({ mcpServers: { 'sprintable-mcp': { type: 'stdio', command: 'uvx', args: ['sprintable-mcp'], env: { AGENT_API_KEY: '<YOUR_AGENT_API_KEY>' } } } }) }];
+        return { ok: true, json: async () => ({ data: { files, mcp_config: null, api_key: null } }) };
+      }
+      if (url.includes('verification-status')) {
+        return { ok: true, json: async () => ({ data: { verified: false, rail: [{ state: 'config_copied', status: 'active' }] } }) };
+      }
+      return { ok: false, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+  }
+
+  let container: HTMLElement;
+  let root: ReturnType<typeof createRoot>;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  async function mount(kind: 'real-shape' | 'stale-shape' | 'empty-files') {
+    global.fetch = makeArtifactFetch(kind);
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={ko} timeZone="Asia/Seoul">
+          <ConnectStep agentId="a1" apiKey={REAL_KEY} onFinish={() => {}} />
+        </NextIntlClientProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+  }
+
+  it('실 BE shape(files[]) 응답이면 아티팩트가 채워지고 placeholder가 실 키(마스킹)로 치환된다(고착 재현 없음)', async () => {
+    await mount('real-shape');
+    expect(container.textContent).not.toContain(PENDING);
+    // 화면 표시는 마스킹(maskApiKey — display=마스킹/copy=실키, renderArtifact 계약)이라
+    // 평문 REAL_KEY는 그대로 나오지 않는다 — placeholder가 사라지고 마스킹 형태가 온 것으로
+    // "치환이 실제로 일어났다"를 확인한다(치환 전이면 `<YOUR_AGENT_API_KEY>`가 그대로 남는다).
+    expect(container.textContent).not.toContain('<YOUR_AGENT_API_KEY>');
+    expect(container.textContent).toContain(maskApiKey(REAL_KEY));
+  });
+
+  it('옛 shape(content 단일필드) 응답이면 "생성 중…"에 영구 고착하지 않고 정직한 에러로 전환된다', async () => {
+    await mount('stale-shape');
+    expect(container.textContent).not.toContain(PENDING);
+    expect(container.textContent).toContain(ERROR);
+    expect(container.textContent).toContain('다시 시도'); // artifactRetry 버튼 동반
+  });
+
+  it('files가 빈 배열이어도(.mcp.json 부재) 같은 정직한 에러 경로를 탄다', async () => {
+    await mount('empty-files');
+    expect(container.textContent).not.toContain(PENDING);
+    expect(container.textContent).toContain(ERROR);
   });
 });

--- a/apps/web/src/app/onboarding/connect-step.tsx
+++ b/apps/web/src/app/onboarding/connect-step.tsx
@@ -143,8 +143,19 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
         else setInitialError(true);
         return;
       }
-      const json = (await res.json()) as { data?: { content?: string }; content?: string };
-      const content = json?.data?.content ?? json?.content;
+      // story #3192(온보딩·크럭스) — BE 응답 shape이 이미 `{content}` 단일파일에서 `{files[],
+      // mcp_config, api_key}`(agents.py::_connection_artifact, `⚠️BREAKING(dev-only)` 주석
+      // 참조)로 바뀐 뒤였는데 이 fetchArtifact만 옛 `content` 필드를 계속 읽고 있었다 — 신규
+      // 계정은 항상 `content=undefined`라 아티팩트가 절대 안 채워지는(재시도해도 동일 mismatch
+      // 재발) 크럭스였다. agent-connection-settings-section.tsx(story #2751, 같은 BE 응답을
+      // 먼저 새 shape으로 고쳐 소비하던 자매 소비처)의 파싱을 그대로 재사용(발명 0).
+      const json = (await res.json()) as {
+        data?: { files?: { filename: string; content: string }[] };
+        files?: { filename: string; content: string }[];
+      };
+      const payload = json?.data ?? json;
+      const mcpFile = (payload?.files ?? []).find((f) => f.filename === '.mcp.json');
+      const content = mcpFile?.content;
       if (typeof content !== 'string') {
         if (reqTransport) setArtifactErrors((p) => ({ ...p, [reqTransport]: true }));
         else setInitialError(true);
@@ -338,8 +349,11 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
               <div className={cn('h-3 w-1/2 rounded bg-muted', !artifactError && !isHostedUnavailable && 'animate-pulse')} />
               <div className={cn('h-3 w-2/3 rounded bg-muted', !artifactError && !isHostedUnavailable && 'animate-pulse')} />
               <div className="flex items-center gap-2 pt-1">
+                {/* story #3192 ② — api_key:null 200(또는 shape mismatch) 후 실패 상태를 계속
+                    "생성 중…"으로 위장하던 분기 제거. artifactError면 정직하게 실패를 알린다 —
+                    재시도 버튼과 짝을 이루는 문구라야 "눌러도 안 됨"으로 안 읽힌다. */}
                 <p className="text-xs text-muted-foreground">
-                  {isHostedUnavailable ? t('artifactUnavailable') : t('artifactPending')}
+                  {isHostedUnavailable ? t('artifactUnavailable') : artifactError ? t('artifactError') : t('artifactPending')}
                 </p>
                 {artifactError && !isHostedUnavailable && (
                   <Button


### PR DESCRIPTION
[SID:3192]

## 요약
신규 계정이 온보딩 4/4 「에이전트 연결」 스텝에 도달하면 `.mcp.json` 아티팩트가 "연결 설정 생성 중…"에 영구 고착되고, 재시도해도 동일 증상이 재발하며, 화면 어디에도 붙여넣을 API 키가 뜨지 않는 결함을 고쳤습니다.

## 원인 확定
`GET /api/agents/{id}/connection-artifact`의 응답 shape이 예전 `{content}` 단일필드에서 `{files: [{filename, content}], mcp_config, api_key}`로 이미 바뀌어 있었는데(`backend/app/routers/agents.py`의 기존 `⚠️BREAKING(dev-only, 착수 전 미르코군 조율)` 주석 — 이 PR 이전 커밋), 온보딩 위저드의 `apps/web/src/app/onboarding/connect-step.tsx::fetchArtifact()`만 옛 `json.data.content`/`json.content`를 계속 읽고 있었습니다. 새 shape엔 top-level `content` 필드가 없으므로 이 값은 항상 `undefined` → 매 요청마다 파싱 실패 → 아티팩트가 절대 채워지지 않았습니다(재시도해도 같은 mismatch가 재발하니 무효).

같은 백엔드 응답을 소비하는 자매 컴포넌트 `apps/web/src/components/agents/agent-connection-settings-section.tsx`(story #2751, 워크포스 › 에이전트 상세 "연결 설정" 섹션)는 이미 새 `files[]` shape을 올바르게 파싱하고 있었습니다 — 온보딩 위저드 쪽만 그 갱신을 놓친 전형적인 쌍둥이-소비처 드리프트였습니다.

내부 org 계정은 전원 기연결 상태라 이 위저드 경로를 다시 타지 않으므로 재현되지 않았고(customer-zero 사각), 생판 신규 계정만 매번 재현됩니다.

## 변경
1. **근본 수정** — `connect-step.tsx::fetchArtifact()`가 `payload.files`에서 `filename === '.mcp.json'`인 항목의 `content`를 읽도록 수정(`agent-connection-settings-section.tsx`와 동일 파싱 재사용, 새 패턴 0).
2. **정직한 실패 표시** — `api_key:null`/파싱 실패로 인한 200 응답을 계속 "생성 중…"으로 위장하던 분기 제거. `artifactError`일 때는 새 i18n 키 `artifactError`("설정을 불러오지 못했습니다 — 다시 시도해 주세요.")로 전환, 기존 재시도 버튼과 짝을 이룹니다.
3. **테스트** — `connect-step.test.tsx`의 기존 mock이 옛(이미 존재하지 않는) shape을 가정하고 있어 "그린인데 틀린" 테스트였던 것을 새 shape으로 교정. 이 회귀를 직접 pin하는 케이스 3종 추가: 실 shape 응답 시 placeholder→마스킹 실키 치환 확인, 옛 shape 응답 시 "생성 중…" 영구고착 대신 정직한 에러 전환 확認, `files:[]`(빈 배열)도 동일 에러 경로.

## 스코프 밖(확認했으나 원인 아님)
- 에이전트 생성 응답(`POST /api/team-members`)의 `api_key` 평문 발급 자체는 정상(`onboarding-form.tsx::handleCreateAgent`가 이미 `memberJson.data.api_key`를 `apiKey` prop으로 정상 배선) — 문제는 순수하게 이 아티팩트 GET의 content 파싱뿐이었습니다.
- 백엔드 `_connection_artifact()`는 변경하지 않았습니다 — 실 계약은 이미 올바르고(`tests/test_e_recruit_s5_connection_artifact_realdb.py`가 `files[]` shape을 이미 pin), FE만 안 따라오고 있었습니다.

## 검증
- `pnpm vitest run apps/web/src/app/onboarding` — 7 files, 55 tests pass (connect-step.test.tsx 12/12 포함, 신규 3종 포함).
- `pnpm exec eslint`, `pnpm exec tsc --noEmit` — 변경 파일 clean.
- `node scripts/check-i18n-keys.js`, `verify:no-i18n-phrase-collision`, `verify:no-duplicate-i18n-keys` — 전부 통과(신규 `artifactError` 키 en/ko 동봉, 충돌 0).
- 백엔드 무변경이므로 백엔드 테스트 재실행 불요(기존 realdb 테스트가 이미 계약을 pin).
- **AC3(생판 신규 계정 라이브 완주)는 dev 배포 후 별도 실측 필요** — 이 PR 스코프 밖(dev 배포 의존).

🤖 Generated with [Claude Code](https://claude.com/claude-code)