### PR TITLE
[SID:3193] 온보딩 체크리스트 «에이전트 연결하기» 생성→실연결 판별자 교체

### DIFF
--- a/backend/app/services/onboarding_activation.py
+++ b/backend/app/services/onboarding_activation.py
@@ -2,8 +2,10 @@
 
 단계 정의는 #3157(디디 activation 깔때기 측정)과 1:1 대조 확定(2026-08-27, 페드루 중계):
 ①가입=users.created_at ②이메일인증=users.email_verified ③org생성=org_members role='owner'
-최초 행 ④에이전트연결=그 org의 team_members(type='agent') 존재(owner 필터 없음 — org 단위
-사실, 초대 멤버가 연결해도 그 org는 완주) ⑤첫왕복=그 org conversation에서 휴먼 발신 메시지
+최초 행 ④에이전트연결=그 org에 실연결(stdio verify 왕복 완주 또는 첫 왕복 완주로 함의)된
+에이전트 존재(owner 필터 없음 — org 단위 사실, 초대 멤버가 연결해도 그 org는 완주. story
+#3193 근본수정 — 원래는 team_members(type='agent') **존재**만 봐서 "생성"을 "연결"로
+오판정했다, is_org_agent_connected 참고) ⑤첫왕복=그 org conversation에서 휴먼 발신 메시지
 "이후"에 온 최초 agent 발신 메시지(존재만으론 불충분 — 순서조건, #3157과 동형 판정).
 
 ③만 owner 축 유지 — "이 유저에게 org를 귀속"하는 목적(리마인드 대상 선별)이라 초대 멤버는
@@ -40,25 +42,34 @@ async def get_owner_org_id(db: AsyncSession, user_id: uuid.UUID) -> uuid.UUID | 
 
 
 async def is_org_agent_connected(db: AsyncSession, org_id: uuid.UUID) -> bool:
-    """org 단위 사실 — 실연결(stdio verify 왕복 완주) 에이전트가 하나라도 있으면 True.
+    """org 단위 사실 — 실연결(stdio verify 왕복 완주) 에이전트가 하나라도 있거나, 이미
+    첫 왕복(휴먼→에이전트 응답)까지 완주했으면 True.
 
     story #3193 근본수정 — 예전엔 `TeamMember(type='agent')` **존재**만 봤다("레코드 생성"을
     "연결"로 오판정: 연결 스텝을 건너뛰어도 에이전트 레코드는 남아 체크리스트가 거짓
     완료를 표시했다). `get_verified_map()`(워크포스 목록 "연결 안 됨" CTA와 완전히 동일한
     판별자 — story #2751②, `acked_seq >= verify_seq`)을 그대로 재사용한다 — 두 벌 판별자
-    금지(PO 지시). http-transport 에이전트는 이 durable 신호가 없어(agent_verify.py 상단
-    docstring 참고) 실제로 연결됐어도 False로 나올 수 있다 — 기존 CTA와 동형의 알려진
-    안전측(false-negative) 편향이라 이 스토리에서 새로 만드는 문제가 아니다."""
+    금지(PO 지시).
+
+    ⛔PO 스티어(2026-08-28, PR#3595 리뷰) — get_verified_map만으로 끝내면 반쪽이었다.
+    http-transport(온보딩 권장 탭·주 경로)는 이 durable 신호가 애초에 없어(agent_verify.py
+    상단 docstring), get_verified_map만 쓰면 **실제로 첫 왕복까지 완주한 org조차 "연결"
+    항목이 영구 미체크**로 뒤집힌다(CTA에선 무해한 위음성이 체크리스트에선 결함 방향이
+    반전). `is_org_first_roundtrip_done()`을 OR로 더한다 — 왕복 완주는 "에이전트가
+    연결됐다"의 논리적 함의(에이전트가 응답하려면 연결돼 있어야 한다)를 이미 갖고 있는
+    **기존 사실의 재사용**이지, 새 판별자 발명이 아니다. 왕복 前·http 위음성 잔여는
+    story #3197(durable http verified 신호 신설)로 분리 — 이 함수 범위 밖."""
     agent_ids = [
         row[0] for row in (await db.execute(
             select(TeamMember.id).where(TeamMember.org_id == org_id, TeamMember.type == "agent")
         )).all()
     ]
-    if not agent_ids:
-        return False
-    from app.services.agent_verify import get_verified_map
-    verified_map = await get_verified_map(db, agent_ids)
-    return any(verified_map.values())
+    if agent_ids:
+        from app.services.agent_verify import get_verified_map
+        verified_map = await get_verified_map(db, agent_ids)
+        if any(verified_map.values()):
+            return True
+    return await is_org_first_roundtrip_done(db, org_id)
 
 
 async def is_org_first_roundtrip_done(db: AsyncSession, org_id: uuid.UUID) -> bool:

--- a/backend/app/services/onboarding_activation.py
+++ b/backend/app/services/onboarding_activation.py
@@ -40,11 +40,25 @@ async def get_owner_org_id(db: AsyncSession, user_id: uuid.UUID) -> uuid.UUID | 
 
 
 async def is_org_agent_connected(db: AsyncSession, org_id: uuid.UUID) -> bool:
-    """org 단위 사실 — org에 agent 멤버가 하나라도 있으면 True(누가 연결했든)."""
-    row = (await db.execute(
-        select(TeamMember.id).where(TeamMember.org_id == org_id, TeamMember.type == "agent").limit(1)
-    )).first()
-    return row is not None
+    """org 단위 사실 — 실연결(stdio verify 왕복 완주) 에이전트가 하나라도 있으면 True.
+
+    story #3193 근본수정 — 예전엔 `TeamMember(type='agent')` **존재**만 봤다("레코드 생성"을
+    "연결"로 오판정: 연결 스텝을 건너뛰어도 에이전트 레코드는 남아 체크리스트가 거짓
+    완료를 표시했다). `get_verified_map()`(워크포스 목록 "연결 안 됨" CTA와 완전히 동일한
+    판별자 — story #2751②, `acked_seq >= verify_seq`)을 그대로 재사용한다 — 두 벌 판별자
+    금지(PO 지시). http-transport 에이전트는 이 durable 신호가 없어(agent_verify.py 상단
+    docstring 참고) 실제로 연결됐어도 False로 나올 수 있다 — 기존 CTA와 동형의 알려진
+    안전측(false-negative) 편향이라 이 스토리에서 새로 만드는 문제가 아니다."""
+    agent_ids = [
+        row[0] for row in (await db.execute(
+            select(TeamMember.id).where(TeamMember.org_id == org_id, TeamMember.type == "agent")
+        )).all()
+    ]
+    if not agent_ids:
+        return False
+    from app.services.agent_verify import get_verified_map
+    verified_map = await get_verified_map(db, agent_ids)
+    return any(verified_map.values())
 
 
 async def is_org_first_roundtrip_done(db: AsyncSession, org_id: uuid.UUID) -> bool:

--- a/backend/tests/test_3159_onboarding_activation_realdb.py
+++ b/backend/tests/test_3159_onboarding_activation_realdb.py
@@ -98,7 +98,14 @@ async def test_get_owner_org_id_only_owner_role():
 
 
 @pytest.mark.anyio
-async def test_is_org_agent_connected_requires_agent_member():
+async def test_is_org_agent_connected_requires_real_verify_not_just_member_record():
+    """story #3193 근본수정 — 예전엔 agent 멤버 레코드 **존재**만으로 True였다("생성"을
+    "연결"로 오판정: 연결 스텝을 건너뛰어도 레코드는 남아 체크리스트가 거짓 완료를 표시
+    했다, 실사고 재현). 지금은 get_verified_map()(#2751②, 워크포스 "연결 안 됨" CTA와
+    동일 판별자)의 stdio verify 왕복(acked_seq>=verify_seq)을 요구한다."""
+    from app.services.agent_verify import start_verification
+    from app.models.agent_gateway import AgentEventCursor
+
     eng, Session = await _engine()
     async with Session() as s:
         await _wipe(s, ORG)
@@ -123,6 +130,17 @@ async def test_is_org_agent_connected_requires_agent_member():
             await s.execute(text(
                 f"INSERT INTO agent_project_profiles (id,member_id,project_id) VALUES ('{app_id}','{agent_member}','{proj}')"
             ))
+            await s.commit()
+            # 레코드만 생성 — 연결 스텝을 건너뛴(verify 왕복 0) 정확한 실사고 재현. 예전
+            # 판별자였다면 여기서 True로 거짓 완료를 표시했다.
+            assert (await svc.is_org_agent_connected(s, uuid.UUID(ORG))) is False
+
+            # 실연결 완주(verify Event 발급 + ack) — 이제야 True.
+            seq = await start_verification(
+                s, agent_id=uuid.UUID(agent_member), org_id=uuid.UUID(ORG), project_id=uuid.UUID(proj),
+            )
+            await s.commit()
+            s.add(AgentEventCursor(agent_id=uuid.UUID(agent_member), acked_seq=seq))
             await s.commit()
             assert (await svc.is_org_agent_connected(s, uuid.UUID(ORG))) is True
         finally:

--- a/backend/tests/test_3159_onboarding_activation_realdb.py
+++ b/backend/tests/test_3159_onboarding_activation_realdb.py
@@ -149,6 +149,58 @@ async def test_is_org_agent_connected_requires_real_verify_not_just_member_recor
 
 
 @pytest.mark.anyio
+async def test_is_org_agent_connected_falls_back_to_roundtrip_for_http_agents():
+    """PO 스티어(2026-08-28, PR#3595 리뷰) — http-transport(온보딩 권장 탭·주 경로)는
+    get_verified_map의 durable 신호가 애초에 없다. verify 신호 0(get_verified_map 전부
+    False)이어도 첫 왕복(휴먼→에이전트 응답)까지 이미 완주했으면 "연결"은 참이어야 한다
+    (왕복이 연결의 논리적 함의) — 안 그러면 실연결 회원의 체크리스트가 영구 미체크로
+    뒤집힌다(결함 방향 반전, PO 적발)."""
+    eng, Session = await _engine()
+    async with Session() as s:
+        await _wipe(s, ORG)
+        try:
+            proj = _uuid()
+            human_member, agent_member = _uuid(), _uuid()
+            app_id = _uuid()
+            await s.execute(text(
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','story3159-o','free')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{proj}','{ORG}','P','none')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO members (id,org_id,type,name) VALUES "
+                f"('{human_member}','{ORG}','human','H'),('{agent_member}','{ORG}','agent','A')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO agent_project_profiles (id,member_id,project_id) VALUES ('{app_id}','{agent_member}','{proj}')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO project_access (id,project_id,member_id,role) VALUES ('{_uuid()}','{proj}','{human_member}','member')"
+            ))
+            await s.commit()
+            # verify Event/AgentEventCursor 0건(http 시나리오 모사) — get_verified_map 단독이면 False.
+            assert (await svc.is_org_agent_connected(s, uuid.UUID(ORG))) is False
+
+            now = datetime.now(timezone.utc)
+            t0, t1 = now - timedelta(hours=1), now
+            conv = _uuid()
+            await s.execute(text(
+                f"INSERT INTO conversations (id,org_id,project_id,type) VALUES ('{conv}','{ORG}','{proj}','group')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO conversation_messages (id,conversation_id,sender_id,content,created_at) VALUES "
+                f"('{_uuid()}','{conv}','{human_member}','human-first','{t0.isoformat()}'),"
+                f"('{_uuid()}','{conv}','{agent_member}','agent-reply','{t1.isoformat()}')"
+            ))
+            await s.commit()
+            assert (await svc.is_org_agent_connected(s, uuid.UUID(ORG))) is True
+        finally:
+            await _wipe(s, ORG)
+    await eng.dispose()
+
+
+@pytest.mark.anyio
 async def test_is_org_first_roundtrip_order_sensitive():
     """디디 대조 확定 조건(#3157) — 존재만으론 불충분, 휴먼 발신 "이후"에 온 agent 발신이어야."""
     eng, Session = await _engine()


### PR DESCRIPTION
## 요약
- [\[온보딩·체크리스트\] «에이전트 연결하기» 완료 판별자가 «생성»을 «연결»로 오인 — 실연결 0인데 거짓 체크](entity:story:59a86cfb-37d6-42ec-9d90-5c425f1222d3)
- PO 신규 회원 워크스루(2026-08-28, dev)에서 발견: 연결 스텝을 스킵해도(연결 확認 rail 6단계 전부 대기) 온보딩 체크리스트의 "에이전트 연결하기"가 완료로 거짓 표시됨.
- 근본원인: `is_org_agent_connected`(`backend/app/services/onboarding_activation.py`)가 `TeamMember(type='agent')` 레코드 **존재**만 확인 — "레코드 생성"을 "연결"로 오판정.
- 처방: 워크포스 목록 "연결 안 됨" CTA가 이미 쓰는 판별자(`agent_verify.get_verified_map`, story #2751②, `acked_seq >= verify_seq` durable stdio verify)를 재사용 — org에 실연결 완주 에이전트가 하나라도 있으면 True. 두 벌 판별자 신설 금지(PO 지시).

## 변경 파일
- `backend/app/services/onboarding_activation.py` — `is_org_agent_connected` 교체
- `backend/tests/test_3159_onboarding_activation_realdb.py` — `test_is_org_agent_connected_requires_agent_member`를 실사고 재현 형태로 교체(레코드만 생성→False로 정정, verify 왕복 완주→True 신규 검증)

## AC 대조
1. 신규 계정에서 연결 스킵 시 미체크 — `get_verified_map`이 verify 미시도 org를 전원 False로 반환(기존 #2751 테스트가 이미 이 경로를 검증), 신규 테스트 케이스로 재확인.
2. 실연결 완주 시 체크 전이 — 신규 테스트 케이스(`start_verification` + ack)로 검증.
3. 기존 완주 사용자 무회귀 — 실제로 stdio verify를 완주한 org는 이전과 동일하게 True.

## 알려진 스코프 밖(투명 기록)
- http-transport 에이전트는 durable verified 신호가 없어(`agent_verify.py` 상단 docstring, #2751②가 이미 명시한 한계) 실제 연결됐어도 이 판별자가 False로 나올 수 있음 — 기존 워크포스 CTA와 동형의 알려진 안전측(false-negative) 편향, 이 스토리에서 새로 만드는 문제 아님·별도 스코프.

## 게이트
- `python3 -m py_compile` 문법 확인 GREEN.
- 로컬 PG/docker 미가용이라 `test_3159_onboarding_activation_realdb.py` realdb 재실행 불가 — dev CI에서 실행 필요.

prod 무접촉(develop 대상).