### PR TITLE
[챗·신규] 미연결 에이전트 대화 침묵 fix — 상태 배너 + 상대 선택기 배지

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3667,6 +3667,8 @@
     "noMessages": "Send the first message",
     "connectionLost": "Connection lost",
     "refreshNow": "Refresh",
+    "agentNotConnectedBanner": "{name} isn't connected yet — your message may not go through.",
+    "agentNotConnectedBannerMulti": "{count} agents aren't connected yet — your messages may not go through.",
     "create": "Start chat",
     "myChatsTab": "My Chats",
     "agentChatsTab": "Agent Chats",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3667,6 +3667,8 @@
     "noMessages": "첫 메시지를 보내보세요",
     "connectionLost": "연결이 끊겼어요",
     "refreshNow": "새로고침",
+    "agentNotConnectedBanner": "{name}이(가) 아직 연결되지 않았어요 — 메시지가 전달되지 않을 수 있어요.",
+    "agentNotConnectedBannerMulti": "에이전트 {count}명이 아직 연결되지 않았어요 — 메시지가 전달되지 않을 수 있어요.",
     "create": "대화 시작",
     "myChatsTab": "내 대화",
     "agentChatsTab": "에이전트 대화",

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -23,6 +23,9 @@ interface Participant {
   type?: string;
   // S8b: list participants 직렬화에 runtime_type 노출(미머지 시 필드 부재=undefined → #2 경고 미표시 graceful).
   runtime_type?: string | null;
+  // story #3194 — 미연결 배너 판별용(아래 fetchPresence가 채움). conversation 응답 자체엔
+  // 없는 필드라 항상 undefined로 시작 — merge된 값만 ChatView에 내려간다(mutate 아님).
+  verified?: boolean | null;
 }
 
 interface ConversationMeta {
@@ -146,18 +149,25 @@ export default function ConversationPage() {
 
   // 1aeecdde P2: 에이전트 presence_status(연결축 dot) 폴링 — P1 진실값. 15s 갱신(시간 기반 상태).
   const [presenceById, setPresenceById] = useState<Record<string, PresenceStatus>>({});
+  // story #3194 — 같은 응답의 verified(#2751 get_verified_map, 발명 0)도 같이 읽는다 — 별도
+  // fetch를 새로 만들지 않고 이미 15s마다 도는 이 폴링에 얹는다(연결되면 다음 사이클에
+  // 자연 갱신 → 배너 자연 소멸, AC2).
+  const [verifiedById, setVerifiedById] = useState<Record<string, boolean | null>>({});
   const fetchPresence = useCallback(async () => {
     try {
       const res = await fetchWithAuth('/api/team-members?type=agent');
       if (!res.ok) return;
-      const json = await res.json() as { data?: Array<{ id: string; presence_status?: string | null }> };
+      const json = await res.json() as { data?: Array<{ id: string; presence_status?: string | null; verified?: boolean | null }> };
       const map: Record<string, PresenceStatus> = {};
+      const vMap: Record<string, boolean | null> = {};
       for (const m of json.data ?? []) {
         if (m.presence_status === 'online' || m.presence_status === 'idle' || m.presence_status === 'offline') {
           map[m.id] = m.presence_status;
         }
+        vMap[m.id] = m.verified ?? null;
       }
       setPresenceById(map);
+      setVerifiedById(vMap);
     } catch { /* non-critical */ }
   }, []);
 
@@ -335,7 +345,7 @@ export default function ConversationPage() {
             presenceById={presenceById}
             scrollToMessageId={scrollToMessageId}
             initialLastReadAt={meta ? meta.lastReadAt : undefined}
-            participants={meta?.participants ?? []}
+            participants={(meta?.participants ?? []).map((p) => ({ ...p, verified: verifiedById[p.member_id] }))}
           />
         )}
       </div>

--- a/apps/web/src/components/chat/chat-view-unconnected-agent.test.ts
+++ b/apps/web/src/components/chat/chat-view-unconnected-agent.test.ts
@@ -1,0 +1,73 @@
+// story #3194 — 미연결 에이전트 참가자 판별의 pin. 무거운 ChatView 전체 마운트 없이(use-
+// reading-panel-stack.test.tsx와 동형 관례) 추출된 순수함수만 직접 잰다.
+import { describe, expect, it } from 'vitest';
+import { filterUnconnectedAgentParticipants } from './chat-view';
+
+const ME = 'me-1';
+
+describe('filterUnconnectedAgentParticipants', () => {
+  it('verified===false인 에이전트 참가자(본인 제외)만 남긴다', () => {
+    const result = filterUnconnectedAgentParticipants(
+      [
+        { member_id: ME, name: '나', type: 'human', verified: null },
+        { member_id: 'agent-1', name: '올리베이라', type: 'agent', verified: false },
+        { member_id: 'human-1', name: '동료', type: 'human', verified: null },
+      ],
+      ME,
+    );
+    expect(result.map((p) => p.member_id)).toEqual(['agent-1']);
+  });
+
+  it('verified===true(연결됨)인 에이전트는 제외된다 — AC2(연결되면 자연 소멸)의 근거', () => {
+    const result = filterUnconnectedAgentParticipants(
+      [{ member_id: 'agent-1', name: '올리베이라', type: 'agent', verified: true }],
+      ME,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('verified가 undefined/null(판별 불가)이면 제외된다 — 침묵 실패보다 과소표시가 안전한 방향', () => {
+    const undef = filterUnconnectedAgentParticipants(
+      [{ member_id: 'agent-1', name: '올리베이라', type: 'agent' }],
+      ME,
+    );
+    const nullish = filterUnconnectedAgentParticipants(
+      [{ member_id: 'agent-1', name: '올리베이라', type: 'agent', verified: null }],
+      ME,
+    );
+    expect(undef).toEqual([]);
+    expect(nullish).toEqual([]);
+  });
+
+  it('human 참가자는 verified===false여도(방어적 입력) 대상이 아니다 — type 가드', () => {
+    const result = filterUnconnectedAgentParticipants(
+      [{ member_id: 'human-1', name: '동료', type: 'human', verified: false }],
+      ME,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('본인은 verified===false여도 제외된다(자기 자신 배너 방지)', () => {
+    const result = filterUnconnectedAgentParticipants(
+      [{ member_id: ME, name: '나', type: 'agent', verified: false }],
+      ME,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('group 대화 — 미연결 에이전트 다수를 전부 반환한다(배너의 count 문구가 소비)', () => {
+    const result = filterUnconnectedAgentParticipants(
+      [
+        { member_id: 'agent-1', name: 'A', type: 'agent', verified: false },
+        { member_id: 'agent-2', name: 'B', type: 'agent', verified: false },
+        { member_id: 'agent-3', name: 'C', type: 'agent', verified: true },
+      ],
+      ME,
+    );
+    expect(result.map((p) => p.member_id)).toEqual(['agent-1', 'agent-2']);
+  });
+
+  it('participants가 undefined면 빈 배열(graceful)', () => {
+    expect(filterUnconnectedAgentParticipants(undefined, ME)).toEqual([]);
+  });
+});

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronLeft, RefreshCw, WifiOff } from 'lucide-react';
+import { ChevronLeft, RefreshCw, WifiOff, UserX } from 'lucide-react';
+import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { ChatBubble } from './chat-bubble';
@@ -55,7 +56,10 @@ interface ChatViewProps {
   // (doc steer-event-axis-design-2927 §4) POST /events/publish의 conversation_id 오버라이드
   // fail-closed(§2 보강, 422 conversation_target_mismatch)를 애초에 안 만난다. 없으면(구
   // 호출부·비-2942 화면) STEER 토글 자체를 숨긴다(graceful — 신규 표면 0 강제 아님).
-  participants?: { member_id: string; name: string | null }[];
+  // story #3194 — type/verified 추가(둘 다 optional·graceful). verified는 agent_verify.py::
+  // get_verified_map()과 같은 정의(#2751 설계②가 워크포스 "연결 안 됨" 배지에 쓰는 그 판별자,
+  // 발명 0) — false=stdio verify 미완주. undefined/null/human이면 미연결 배너 미표시.
+  participants?: { member_id: string; name: string | null; type?: string; verified?: boolean | null }[];
 }
 
 interface MessageGroup {
@@ -97,10 +101,27 @@ export function resolveBackfillMarkReadIso(latest: ChatMessage[] | undefined, ne
   return latest[latest.length - 1]!.created_at;
 }
 
+// story #3194 — 미연결 에이전트 참가자(본인 제외) 판별을 순수함수로 뽑아 직접 단위테스트
+// 가능하게 한다(mergeBackfilledMessages/resolveBackfillMarkReadIso와 동형 관례). verified
+// ===false만 대상(undefined/null=판별 불가라 배너 미표시 — agent-management-tab.tsx와 동일
+// 안전 방향, 침묵 실패보다 과소표시가 낫다). 판정 자체는 #2751 get_verified_map 그대로(발명
+// 0) — 이 함수는 그 결과를 소비만 한다.
+export function filterUnconnectedAgentParticipants(
+  participants: { member_id: string; name: string | null; type?: string; verified?: boolean | null }[] | undefined,
+  currentTeamMemberId: string,
+): { member_id: string; name: string | null; type?: string; verified?: boolean | null }[] {
+  return (participants ?? []).filter(
+    (p) => p.member_id !== currentTeamMemberId && p.type === 'agent' && p.verified === false,
+  );
+}
+
 export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix = '/api/chats', backHref = '/chats', commandTargets, presenceById, scrollToMessageId, initialLastReadAt, participants }: ChatViewProps) {
   const router = useRouter();
   const pathname = usePathname();
   const t = useTranslations('chats');
+  // story #3194 — 'agents' 네임스페이스의 viewConnectionSettings 키를 그대로 재사용(발명 0,
+  // agent-management-tab.tsx의 동일 CTA와 문구 일치).
+  const ta = useTranslations('agents');
   const isMobile = useIsMobile();
   const { toasts, addToast, dismissToast } = useToast();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -819,6 +840,8 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   const isMobileReadingView = readingPanelStack.length > 0;
   const isMobileRightPanelView = isMobileThreadView || isMobileReadingView;
 
+  const unconnectedAgentParticipants = filterUnconnectedAgentParticipants(participants, currentTeamMemberId);
+
   // story #461e9a54(P0) — 채팅 하위 트리 전체(메시지·입력창 포함)를 이 Provider로 감싼다.
   // EntityChip(embed-card.tsx)·approval-request-card.tsx가 이 값을 useReadingPanel()로
   // 직접 소비 — prop-drilling 없이도 새 임베드 소비처가 자동으로 패널行 된다.
@@ -867,6 +890,28 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
                 <RefreshCw className="h-3 w-3" />
                 {t('refreshNow')}
               </button>
+            </div>
+          )}
+          {/* story #3194(PO 신규 회원 친절도 실측) — 미연결 에이전트에게 첫 메시지를 보내도
+              화면 어디에도 신호가 없어 "제품이 죽었다"로 읽히던 결함. 판별자(verified===false)
+              는 #2751이 워크포스 목록에 쓰는 get_verified_map 그대로(발명 0) — 여기서 새
+              판정을 만들지 않는다. 연결되면(다음 폴링 사이클, page.tsx fetchPresence 15s)
+              participants의 verified가 갱신돼 이 배너는 조건이 저절로 꺼진다(자연 소멸,
+              별도 dismiss 상태 불요). */}
+          {unconnectedAgentParticipants.length > 0 && (
+            <div className="flex flex-shrink-0 items-center gap-2 border-b border-warning-border bg-warning-tint px-3 py-2 text-xs text-foreground">
+              <UserX className="h-3.5 w-3.5 flex-shrink-0" />
+              <span className="flex-1">
+                {unconnectedAgentParticipants.length === 1
+                  ? t('agentNotConnectedBanner', { name: unconnectedAgentParticipants[0]!.name ?? '?' })
+                  : t('agentNotConnectedBannerMulti', { count: unconnectedAgentParticipants.length })}
+              </span>
+              <Link
+                href={`/organization/workforce/${unconnectedAgentParticipants[0]!.member_id}`}
+                className="flex items-center gap-1 rounded px-1.5 py-1 font-medium hover:bg-warning-border/40"
+              >
+                {ta('viewConnectionSettings')}
+              </Link>
             </div>
           )}
           {/* Messages */}

--- a/apps/web/src/components/chat/new-conversation-modal.tsx
+++ b/apps/web/src/components/chat/new-conversation-modal.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { X, Check } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { AgentIdentity } from '@/components/ui/agent-identity';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { buildPolicyDeniedMessage, parseAgentMessagePolicyDenied } from '@/lib/agent-message-policy-error';
@@ -14,6 +15,9 @@ interface Member {
   id: string;
   name: string;
   type: string;
+  // story #3194 — /api/members(정본 SSOT)엔 없는 필드라 별도 /api/team-members?type=agent
+  // 조회로 채운다(#2751 get_verified_map 그대로 재사용, 발명 0). human/미조회는 undefined.
+  verified?: boolean | null;
 }
 
 // story #2613 — 정책 거부(AGENT_MESSAGE_POLICY_DENIED)는 대상 에이전트로의 워크포스 설정
@@ -28,7 +32,11 @@ interface NewConversationModalProps {
 
 export function NewConversationModal({ projectId, onClose, onCreated }: NewConversationModalProps) {
   const t = useTranslations('chats');
+  // story #3194 — agentNotConnected 배지 문구 재사용(발명 0, agent-management-tab.tsx와 동일 키).
+  const ta = useTranslations('agents');
   const [members, setMembers] = useState<Member[]>([]);
+  // story #3194 — 별도 state로 둔다(members setter와 순서 경쟁 없이 항상 render에서만 merge).
+  const [verifiedById, setVerifiedById] = useState<Record<string, boolean | null>>({});
   const [selected, setSelected] = useState<string[]>([]);
   const [groupTitle, setGroupTitle] = useState('');
   const [loading, setLoading] = useState(true);
@@ -41,6 +49,19 @@ export function NewConversationModal({ projectId, onClose, onCreated }: NewConve
       .then((json) => setMembers((json.data ?? []) as Member[]))
       .catch(() => {})
       .finally(() => setLoading(false));
+    // story #3194 — 연결 상태(발명 0, #2751 get_verified_map)는 /api/members가 안 실어주는
+    // 필드라 team-members 쪽에서 따로 받는다. 별개 state로 둬 위 members fetch와의 완료
+    // 순서에 안 낚인다(render에서만 merge, 실패해도 배지만 안 뜰 뿐 graceful).
+    fetchWithAuth('/api/team-members?type=agent')
+      .then((r) => r.json())
+      .then((json) => {
+        const vMap: Record<string, boolean | null> = {};
+        for (const m of (json.data ?? []) as Array<{ id: string; verified?: boolean | null }>) {
+          vMap[m.id] = m.verified ?? null;
+        }
+        setVerifiedById(vMap);
+      })
+      .catch(() => {});
   }, [projectId]);
 
   const toggle = (id: string) => {
@@ -122,6 +143,11 @@ export function NewConversationModal({ projectId, onClose, onCreated }: NewConve
                     {/* story #3049(2984-S1) — AgentIdentity 프리미티브(헤어라인+proof-blue
                         신호 dot) 채택, soft-fill 폐지. */}
                     {m.type === 'agent' && <AgentIdentity />}
+                    {/* story #3194(AC3) — 새 대화 상대 선택기에도 연결 상태 노출(발명 0, #2751
+                        get_verified_map 그대로 — agent-management-tab.tsx와 동일 배지). */}
+                    {m.type === 'agent' && verifiedById[m.id] === false ? (
+                      <Badge variant="warning" className="shrink-0">{ta('agentNotConnected')}</Badge>
+                    ) : null}
                     {selected.includes(m.id) && <Check className="h-3.5 w-3.5 flex-shrink-0 text-primary" />}
                   </button>
                 </li>


### PR DESCRIPTION
[SID:3194]

## 요약
신규 계정이 온보딩 체크리스트가 시키는 대로 미연결 에이전트에게 첫 메시지를 보내면 대화 화면·리스트 어디에도 "연결 안 됨" 신호가 없어 완전 침묵 — 신규 회원에게는 "제품이 죽었다"로 읽히는 골든 모먼트 파괴였습니다.

## 설계 — 발명 0
판별자는 새로 만들지 않았습니다. `backend/app/services/agent_verify.py::get_verified_map()`(story #2751 설계②가 워크포스 목록 "연결 안 됨" 배지에 이미 쓰는 그 함수)를 그대로 소비만 합니다 — 백엔드 코드는 **전혀 건드리지 않았습니다**(#3197이 이 판별자 소스를 병행 확장 중이라는 언급이 있어, 소비만 하고 판정 로직은 손대지 않았습니다).

CTA도 재사용입니다 — `agent-management-tab.tsx`가 이미 쓰는 `viewConnectionSettings` i18n 키 그대로, `/organization/workforce/{agentId}`(story #2751이 만든 연결 설정 재조회 진입점) 딥링크입니다.

## 변경

1. **`chat-view.tsx`** — 대화 참가자 중 `verified===false`인 에이전트(본인 제외)가 있으면 기존 "연결 끊김" 배너(`showDisconnectedBanner`)와 동형 스타일(warning-tint)의 배너를 표시 + "연결 설정 보기" 링크. 연결되면 다음 폴링 사이클에 `verified`가 갱신돼 배너가 자연 소멸합니다(별도 dismiss 상태 불요, AC2). 판별 로직은 `filterUnconnectedAgentParticipants()`로 순수함수 추출(이 파일의 기존 `mergeBackfilledMessages`/`resolveBackfillMarkReadIso`와 동형 관례) — 무거운 컴포넌트 마운트 없이 단위테스트 가능합니다.
2. **`chats/[conversation_id]/page.tsx`** — 이미 15초마다 도는 presence 폴링(`fetchPresence`, `/api/team-members?type=agent`)에 `verified` 필드를 얹어 재사용했습니다(신규 폴링 0). `verifiedById` 맵을 `participants`에 merge해 `ChatView`로 내려보냅니다.
3. **`new-conversation-modal.tsx`** — 새 대화 상대 선택기(AC3)의 각 에이전트 행에도 동일한 `agentNotConnected` 배지를 노출합니다. `/api/members`(정본 SSOT, `verified` 필드 없음)와 `/api/team-members?type=agent`(있음) 두 응답을 클라이언트에서 id로 merge — 두 fetch의 완료 순서에 안 낚이도록 `verifiedById`를 별도 state로 분리했습니다(members state를 직접 mutate하지 않음).

## AC 대조
- AC1(미연결 상태+다음 행동이 대화 화면에 보인다) — chat-view.tsx 배너+링크.
- AC2(연결되면 자연 소멸) — 기존 15s 폴링에 얹었으므로 별도 배선 없이 자연 충족.
- AC3(새 대화 상대 선택기에 연결 상태 노출) — new-conversation-modal.tsx 배지.

## 테스트
- `pnpm vitest run apps/web/src/components/chat` — 54 files, 619 tests pass(신규 `chat-view-unconnected-agent.test.ts` 7종 포함, 회귀 0).
- `pnpm exec tsc --noEmit`, `pnpm exec eslint` — 변경 파일 clean.
- `check-i18n-keys.js`, `verify-no-i18n-phrase-collision`, `verify-no-duplicate-i18n-keys` — 전부 통과(신규 `agentNotConnectedBanner`/`agentNotConnectedBannerMulti` 키 en/ko 동봉, 충돌 0).
- **라이브 실측(신규 kindness2 계정 리그·실제 미연결 에이전트)은 dev 배포 후 별도 필요** — 이 PR 스코프 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)