### PR TITLE
[SID:3197] http-transport durable verified 신호 신설 — first_connected_at

### DIFF
--- a/backend/alembic/versions/0289_agent_project_profiles_first_connected.py
+++ b/backend/alembic/versions/0289_agent_project_profiles_first_connected.py
@@ -1,0 +1,36 @@
+"""story #3197(연결·판별자) — agent_project_profiles에 durable "최초 연결 완료" 마커 신설.
+
+doc 배경: `get_verified_map`(agent_verify.py)의 stdio 레일(`acked_seq >= verify_seq`)은
+durable이지만, http-transport(온보딩 권장 탭·주 경로)는 heartbeat freshness(TTL 만료 시
+소멸)뿐이라 "한 번이라도 연결 완료"의 durable 기록이 없었다(#2751 당시 스코프 밖).
+
+`first_connected_at`은 그 org의 이 에이전트가 처음 online으로 관측된 시각 — 한 번 채워지면
+지우지 않는다(last_seen_at은 disconnect 시 None으로 되돌지만 이 컬럼은 그대로 둔다,
+`sync_agent_profile_presence` 참고). transport 무관 공용 컬럼(stdio도 같은 경로로 채워짐 —
+새 판별자를 transport별로 쪼개지 않는다, PO "판별 로직 한 곳 유지" 지시).
+
+Revision ID: 0289
+Revises: 0288
+Create Date: 2026-08-29
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0289"
+down_revision = "0288"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_project_profiles",
+        sa.Column("first_connected_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_project_profiles", "first_connected_at")

--- a/backend/app/models/member.py
+++ b/backend/app/models/member.py
@@ -108,6 +108,11 @@ class AgentProjectProfile(Base):
     agent_role: Mapped[str | None] = mapped_column(Text, nullable=True)
     fakechat_port: Mapped[int | None] = mapped_column(Integer, nullable=True)
     last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # story #3197 — durable "최초 연결 완료" 마커. last_seen_at은 disconnect 시 None으로
+    # 되돌지만(agent_gateway.py _mark_agent_disconnected) 이 컬럼은 한 번 채워지면 지우지
+    # 않는다(sync_agent_profile_presence 참고) — http-transport 에이전트의 "한 번이라도
+    # 연결 완료"를 durable로 남기는 최소 장치(get_verified_map이 OR로 셈).
+    first_connected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     active_story_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy import update as sa_update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -284,11 +284,21 @@ async def sync_agent_profile_presence(session: AsyncSession, member_id: uuid.UUI
     AC3-4 뷰가 last_seen_at/active_story_id/agent_status를 agent_project_profiles서 읽으므로 cutover 전
     동기 유지. member_id(=agent team_member.id, 1:1)로 단일 profile 행 UPDATE. 행 없으면 0건(무해).
     cutover(2-2) 후 레거시 team_members UPDATE 제거 시 이 경로가 유일 write가 된다.
+
+    story #3197 — 이 함수가 "agent가 online으로 관측됐다"(last_seen_at=NOW 세팅)를 쓰는
+    유일한 choke point다(stdio SSE connect·http heartbeat 둘 다 여기로 수렴). `last_seen_at`이
+    non-None 값으로 오면(=online write, offline인 last_seen_at=None과 구분) 같은 UPDATE에
+    `first_connected_at = COALESCE(first_connected_at, :그 값)`을 얹는다 — 별도 write 0,
+    한 번 채워지면 이후 online 갱신에 덮이지 않는다(COALESCE가 기존 값 우선).
     """
     allowed = {"last_seen_at", "active_story_id", "agent_status"}
     upd = {k: v for k, v in fields.items() if k in allowed}
     if not upd:
         return
+    if upd.get("last_seen_at") is not None:
+        upd["first_connected_at"] = func.coalesce(
+            AgentProjectProfile.__table__.c.first_connected_at, upd["last_seen_at"]
+        )
     await session.execute(
         sa_update(AgentProjectProfile.__table__)
         .where(AgentProjectProfile.__table__.c.member_id == member_id)

--- a/backend/app/services/agent_verify.py
+++ b/backend/app/services/agent_verify.py
@@ -227,16 +227,16 @@ async def get_verified_map(db: AsyncSession, agent_ids: list[uuid.UUID]) -> dict
     `get_verification_state()`와 **같은 정의**(``acked_seq >= verify_seq``, stdio 레일) —
     두 번째 판정 기준을 새로 만들지 않는다. 다만 목록은 에이전트 수에 비례해 N번 호출하면
     안 되므로(fan-out 금지, PO 확定 — `_inject_active_stories()`의 `Story.id.in_()` 배치와
-    동형 패턴) GROUP BY로 agent_ids 전체를 한 번에 집계한다(상수 쿼리 2회 — agent 수 무관).
+    동형 패턴) GROUP BY로 agent_ids 전체를 한 번에 집계한다(상수 쿼리 3회 — agent 수 무관).
     요청한 agent_ids 전원에 대해 키가 채워진다(verify 자체를 한 번도 안 한 이탈자도
     False — 그게 이 CTA가 잡으려는 정확히 그 집단이다).
 
-    ⚠️scope: stdio 전용(`acked_seq >= verify_seq`는 durable — 한 번 참이면 영구 유지). http
-    transport는 heartbeat freshness(`_has_fresh_heartbeat`)가 유일한 신호인데 그건 "현재
-    도달 가능"이지 "한 번이라도 연결 완료"의 durable 기록이 아니다 — http 에이전트의 durable
-    verified 신호는 신규 컬럼 없이는 못 만들어 이번 스코프 밖. 지금은 실제로 정상 연결된
-    http 에이전트가 이 map에서 False로 나올 수 있다(false positive 방향 — "이미 괜찮은데
-    CTA가 뜬다"는 눈에 띄지만 안전한 실패 모드, 반대(진짜 이탈자를 숨김)보다 낫다)."""
+    story #3197(2026-08-29) — stdio 레일 OR `agent_project_profiles.first_connected_at IS
+    NOT NULL`. http-transport(온보딩 권장 탭·주 경로)는 `acked_seq >= verify_seq`를 만들
+    discrete 이벤트 왕복 자체가 없어(모듈 docstring) stdio 레일만으론 실연결 http 에이전트가
+    영구 False였다(#2751 당시 스코프 밖 처리 — 이번에 닫음). `first_connected_at`은 transport
+    무관 공용 컬럼(sync_agent_profile_presence choke point에서 한 번 채워지면 안 지워짐)이라
+    stdio 에이전트도 자연히 같은 조건으로 커버된다 — 판별 로직은 여전히 이 함수 한 곳."""
     if not agent_ids:
         return {}
 
@@ -256,11 +256,22 @@ async def get_verified_map(db: AsyncSession, agent_ids: list[uuid.UUID]) -> dict
     )).all()
     acked_seq_map = {row[0]: row[1] for row in acked_seq_rows}
 
+    first_connected_rows = (await db.execute(
+        select(AgentProjectProfile.member_id).where(
+            AgentProjectProfile.member_id.in_(agent_ids),
+            AgentProjectProfile.first_connected_at.isnot(None),
+        )
+    )).all()
+    ever_connected = {row[0] for row in first_connected_rows}
+
     return {
         agent_id: (
-            agent_id in verify_seq_map
-            and agent_id in acked_seq_map
-            and acked_seq_map[agent_id] >= verify_seq_map[agent_id]
+            agent_id in ever_connected
+            or (
+                agent_id in verify_seq_map
+                and agent_id in acked_seq_map
+                and acked_seq_map[agent_id] >= verify_seq_map[agent_id]
+            )
         )
         for agent_id in agent_ids
     }

--- a/backend/tests/test_2751_agent_verified_map_realdb.py
+++ b/backend/tests/test_2751_agent_verified_map_realdb.py
@@ -165,8 +165,9 @@ async def test_ack_below_seq_returns_false():
 @pytest.mark.asyncio
 async def test_batch_query_handles_multiple_agents_with_mixed_states_in_constant_queries():
     """N=3 에이전트(각기 다른 상태) — 쿼리 수가 에이전트 수에 비례하지 않는지(fan-out 금지)
-    실측. `session.execute` 호출 횟수를 세어 2회(verify_seq 배치·acked_seq 배치)로 고정임을
-    직접 증명한다(PO가 명시적으로 fan-out 금지를 못박은 조건 — 문서 주장이 아니라 계측)."""
+    실측. `session.execute` 호출 횟수를 세어 3회(verify_seq 배치·acked_seq 배치·story #3197
+    first_connected_at 배치)로 고정임을 직접 증명한다(PO가 명시적으로 fan-out 금지를 못박은
+    조건 — 문서 주장이 아니라 계측)."""
     from unittest.mock import AsyncMock
 
     from app.services.agent_verify import get_verified_map, start_verification
@@ -195,7 +196,7 @@ async def test_batch_query_handles_multiple_agents_with_mixed_states_in_constant
 
             result = await get_verified_map(s, [never_verified, fully_verified, sent_not_acked])
 
-            assert call_count["n"] == 2  # 에이전트 수(3)와 무관 — 상수 쿼리.
+            assert call_count["n"] == 3  # 에이전트 수(3)와 무관 — 상수 쿼리.
             assert result == {
                 never_verified: False,
                 fully_verified: True,
@@ -215,5 +216,63 @@ async def test_empty_agent_ids_returns_empty_dict_without_query():
         async with Session() as s:
             result = await get_verified_map(s, [])
             assert result == {}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_http_agent_first_connected_at_marks_verified_durably():
+    """story #3197(AC1) — http-transport는 verify Event/AgentEventCursor를 아예 안 쓴다
+    (discrete 이벤트 왕복이 구조적으로 불가). `sync_agent_profile_presence`(heartbeat/SSE
+    connect 공용 choke point)로 한 번 online 관측되면 first_connected_at이 채워지고,
+    이후 offline(last_seen_at=None)로 되돌아가도(연결 済·오프라인 상태 모사) 계속 True다
+    (durable — freshness가 아니다)."""
+    from datetime import datetime, timezone
+
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
+    from app.services.agent_verify import get_verified_map
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            http_agent = await _seed_agent(s, org_id, project_id)
+
+            # verify Event 0건 — 순수 http 시나리오. stdio 레일만이면 여기서 영구 False.
+            result = await get_verified_map(s, [http_agent])
+            assert result == {http_agent: False}
+
+            # heartbeat 1회(choke point) — first_connected_at 채워짐.
+            await sync_agent_profile_presence(
+                s, http_agent, last_seen_at=datetime.now(timezone.utc), agent_status="online",
+            )
+            await s.commit()
+            result = await get_verified_map(s, [http_agent])
+            assert result == {http_agent: True}
+
+            # 연결 종료(offline) 후에도 durable 유지 — freshness가 아니라 "한 번이라도" 판정.
+            await sync_agent_profile_presence(s, http_agent, last_seen_at=None, agent_status="offline")
+            await s.commit()
+            result = await get_verified_map(s, [http_agent])
+            assert result == {http_agent: True}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_never_connected_agent_stays_false_after_first_connected_column_added():
+    """story #3197(AC3) 음성대조 — 새 컬럼 신설이 기존 «미연결 이탈자=False» 판정을
+    건드리지 않는다(첫 배치조회는 first_connected_at NULL이니 회귀 0)."""
+    from app.services.agent_verify import get_verified_map
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            result = await get_verified_map(s, [agent_id])
+
+            assert result == {agent_id: False}
     finally:
         await engine.dispose()

--- a/backend/tests/test_2751_agent_verified_map_realdb.py
+++ b/backend/tests/test_2751_agent_verified_map_realdb.py
@@ -279,38 +279,6 @@ async def test_never_connected_agent_stays_false_after_first_connected_column_ad
 
 
 @pytest.mark.asyncio
-async def test_auth_failed_write_does_not_stamp_first_connected_at():
-    """PO 핀 지시①(2026-08-28, 카디르 뮤테이션 실측 — 현재 코드는 정확하나 회귀테스트 0건
-    이었던 안전 속성). `sync_agent_profile_presence(..., agent_status="auth_failed")`
-    (record_auth_failure.py 실 호출부와 동형 — last_seen_at 키 자체를 안 실음)는
-    first_connected_at을 채우면 안 된다. 안 그러면 "인증 실패가 연결 완료로 둔갑"하는
-    제품 판정 오염 클래스(pin 없이 두면 다음 리팩터가 조용히 깨뜨릴 수 있다)."""
-    from sqlalchemy import select
-
-    from app.models.member import AgentProjectProfile
-    from app.services.agent_anchor_sync import sync_agent_profile_presence
-
-    engine, Session = await _session_factory()
-    try:
-        async with Session() as s:
-            org_id, project_id = await _seed_org_project(s)
-            agent_id = await _seed_agent(s, org_id, project_id)
-
-            # record_auth_failure.py 실 호출부와 정확히 동형 — agent_status만, last_seen_at 없음.
-            await sync_agent_profile_presence(s, agent_id, agent_status="auth_failed")
-            await s.commit()
-
-            first_connected_at = (await s.execute(
-                select(AgentProjectProfile.first_connected_at).where(
-                    AgentProjectProfile.member_id == agent_id
-                )
-            )).scalar_one()
-            assert first_connected_at is None
-    finally:
-        await engine.dispose()
-
-
-@pytest.mark.asyncio
 async def test_first_connected_at_coalesce_never_overwrites_existing_value():
     """PO 핀 지시②(2026-08-28, 카디르 뮤테이션 실측). t1에 처음 online 관측되면
     first_connected_at=t1. 이후(t2>t1) 재차 online 갱신이 와도 COALESCE가 기존 값을

--- a/backend/tests/test_2751_agent_verified_map_realdb.py
+++ b/backend/tests/test_2751_agent_verified_map_realdb.py
@@ -276,3 +276,74 @@ async def test_never_connected_agent_stays_false_after_first_connected_column_ad
             assert result == {agent_id: False}
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_auth_failed_write_does_not_stamp_first_connected_at():
+    """PO 핀 지시①(2026-08-28, 카디르 뮤테이션 실측 — 현재 코드는 정확하나 회귀테스트 0건
+    이었던 안전 속성). `sync_agent_profile_presence(..., agent_status="auth_failed")`
+    (record_auth_failure.py 실 호출부와 동형 — last_seen_at 키 자체를 안 실음)는
+    first_connected_at을 채우면 안 된다. 안 그러면 "인증 실패가 연결 완료로 둔갑"하는
+    제품 판정 오염 클래스(pin 없이 두면 다음 리팩터가 조용히 깨뜨릴 수 있다)."""
+    from sqlalchemy import select
+
+    from app.models.member import AgentProjectProfile
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            # record_auth_failure.py 실 호출부와 정확히 동형 — agent_status만, last_seen_at 없음.
+            await sync_agent_profile_presence(s, agent_id, agent_status="auth_failed")
+            await s.commit()
+
+            first_connected_at = (await s.execute(
+                select(AgentProjectProfile.first_connected_at).where(
+                    AgentProjectProfile.member_id == agent_id
+                )
+            )).scalar_one()
+            assert first_connected_at is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_first_connected_at_coalesce_never_overwrites_existing_value():
+    """PO 핀 지시②(2026-08-28, 카디르 뮤테이션 실측). t1에 처음 online 관측되면
+    first_connected_at=t1. 이후(t2>t1) 재차 online 갱신이 와도 COALESCE가 기존 값을
+    우선해 first_connected_at은 t1 그대로여야 한다(durable = "최초" 시각, 매 heartbeat마다
+    갱신되는 last_seen_at과 혼동 금지)."""
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import select
+
+    from app.models.member import AgentProjectProfile
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            t1 = datetime.now(timezone.utc) - timedelta(hours=2)
+            await sync_agent_profile_presence(s, agent_id, last_seen_at=t1, agent_status="online")
+            await s.commit()
+
+            t2 = datetime.now(timezone.utc)
+            await sync_agent_profile_presence(s, agent_id, last_seen_at=t2, agent_status="online")
+            await s.commit()
+
+            row = (await s.execute(
+                select(AgentProjectProfile.first_connected_at, AgentProjectProfile.last_seen_at).where(
+                    AgentProjectProfile.member_id == agent_id
+                )
+            )).one()
+            first_connected_at, last_seen_at = row
+            assert first_connected_at == t1  # 최초 관측 시각 그대로 — t2로 덮이지 않음.
+            assert last_seen_at == t2  # last_seen_at은 매번 갱신(대조군 — 회귀 아님을 확인).
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2836_agent_auth_failure_realdb.py
+++ b/backend/tests/test_2836_agent_auth_failure_realdb.py
@@ -294,3 +294,47 @@ async def test_threshold_crossing_sets_agent_status_not_before():
             _dbmod.async_session_factory = _orig
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_threshold_crossing_does_not_stamp_first_connected_at():
+    """story #3197 PO 핀 지시①(2026-08-29, 카디르 뮤테이션 실측 재교체) — 이전 버전
+    (sync_agent_profile_presence를 직접 호출하는 흉내 테스트)은 가짜 양성대조였다: 실
+    호출부(record_auth_failure.py)에 last_seen_at을 추가하는 회귀(뮤테이션A)를 넣어도
+    호출부를 안 거치니 GREEN을 유지했다. 이 테스트는 위 threshold-crossing 리그를 그대로
+    재사용해 `record_auth_failure()` 자체를 end-to-end로 호출 — 임계 도달로 agent_status가
+    "auth_failed"로 바뀌어도(=실 호출부가 진짜 도는지 확인) first_connected_at은 절대
+    채워지면 안 된다("인증 실패가 연결 완료로 둔갑"하는 제품 판정 오염 클래스)."""
+    from sqlalchemy import select
+
+    from app.services.agent_auth_failure import AUTH_FAILURE_THRESHOLD, record_auth_failure
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_key(s, revoked=True)
+            s.add(AgentProjectProfile(
+                id=uuid.uuid4(), member_id=seeded["member_id"], project_id=seeded["project_id"],
+                agent_status="online",
+            ))
+            await s.commit()
+
+        import app.core.database as _dbmod
+        _orig = _dbmod.async_session_factory
+        _dbmod.async_session_factory = Session
+        try:
+            for _ in range(AUTH_FAILURE_THRESHOLD):
+                await record_auth_failure(seeded["raw_key"])
+
+            async with Session() as s:
+                prof = (await s.execute(
+                    select(AgentProjectProfile).where(AgentProjectProfile.member_id == seeded["member_id"])
+                )).scalar_one()
+                # 임계 실제로 넘었는지(=이 테스트가 진짜 경로를 탔는지) 먼저 확認 — 도달
+                # 못 했으면 아래 first_connected_at 단언이 우연히 통과하는 거짓양성이 된다.
+                assert prof.agent_status == "auth_failed"
+                assert prof.first_connected_at is None
+        finally:
+            _dbmod.async_session_factory = _orig
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_2836_agent_auth_failure_realdb.py
+++ b/backend/tests/test_2836_agent_auth_failure_realdb.py
@@ -307,6 +307,7 @@ async def test_threshold_crossing_does_not_stamp_first_connected_at():
     채워지면 안 된다("인증 실패가 연결 완료로 둔갑"하는 제품 판정 오염 클래스)."""
     from sqlalchemy import select
 
+    from app.models.member import AgentProjectProfile
     from app.services.agent_auth_failure import AUTH_FAILURE_THRESHOLD, record_auth_failure
 
     engine, Session = await _session_factory()


### PR DESCRIPTION
## 요약
- [\[연결·판별자\] http-transport 에이전트의 durable verified 신호 부재 — CTA·온보딩 체크리스트가 실연결에도 영구 위음성](entity:story:bfb18123-2aba-4b5f-831b-9ca80f0629b6)
- `get_verified_map`(agent_verify.py)의 stdio 레일(`acked_seq>=verify_seq`)만으론 온보딩 권장 탭=호스팅=http 경로에서 "한 번이라도 연결 완료"의 durable 기록이 없었다(#2751 당시 스코프 밖). 워크포스 CTA + 온보딩 체크리스트(#3193/#3595) 둘 다 이 판별자를 소비하면서 위음성이 주 경로에 걸리는 문제로 격상.

## 처방
- migration 0289: `agent_project_profiles.first_connected_at`(신규 nullable 컬럼) — 한 번 채워지면 지우지 않는 durable 마커. transport 무관 공용.
- `sync_agent_profile_presence`(agent_anchor_sync.py) — stdio SSE connect·http heartbeat 둘 다 수렴하는 유일한 "online 관측" choke point. `last_seen_at`이 non-None으로 오면 같은 UPDATE에 `first_connected_at = COALESCE(first_connected_at, 그 값)` 추가(별도 write 0).
- `get_verified_map` — stdio 레일 OR `first_connected_at IS NOT NULL`. **판별 로직은 이 함수 한 곳 유지**(두 벌 금지, PO 지시). 상수 쿼리 2→3회(fan-out 여전히 0 — 에이전트 수 무관).

## AC 대조
1. http 에이전트가 실연결 완료 후 CTA·체크리스트 모두 참 — `get_verified_map` 단일 판별자를 두 소비처가 그대로 재사용하므로 자동 충족. 신규 테스트(`test_http_agent_first_connected_at_marks_verified_durably`)로 검증.
2. 판별 로직 한 곳 유지 — `is_org_agent_connected`(#3193, `get_verified_map` 호출)·워크포스 CTA 둘 다 여전히 이 함수 하나만 호출.
3. 미연결 이탈자 여전히 False — 신규 음성대조 테스트(`test_never_connected_agent_stays_false_after_first_connected_column_added`).

## 인터페이스
`get_verified_map`의 시그니처/반환 타입(`dict[UUID, bool]`) 불변 — story #3194(디디, 침묵 배너 소비처)에 영향 없음.

## 변경 파일
- `backend/alembic/versions/0289_agent_project_profiles_first_connected.py` (신규)
- `backend/app/models/member.py` — `AgentProjectProfile.first_connected_at`
- `backend/app/services/agent_anchor_sync.py` — `sync_agent_profile_presence` choke point
- `backend/app/services/agent_verify.py` — `get_verified_map` OR 조건 확장
- `backend/tests/test_2751_agent_verified_map_realdb.py` — http 시나리오·음성대조 신규 2건 + 배치쿼리 호출횟수 assertion 2→3 갱신

## 게이트(이번엔 실측 강화)
- venv(`backend/.venv`) 확보해 `alembic heads`/`history`로 마이그레이션 체인 무결성 **실확인**(단일 head, 0288→0289 정상 연결).
- mock 기반 비-realdb 전체 스위트(`-m "not destructive_schema"`, #3186 처방 그대로 준수): **5065 passed**, 14 failed — 실패 14건 전부 파일 스코프로 무관 확인(DB URL 미설정 `test_2268_session_context_realdb.py`, MCP 툴리스트/경로 체크 `test_s6_4_dod`/`test_s7_2_epic_dod`/`test_e2e_dev`). agent_verify/agent_anchor_sync/member/team_members 관련 테스트(test_team_members·test_agent_gateway·test_2602_heartbeat_freshness·test_ob2_verify_connection·test_2467_verify_signal_seam·test_e_mcp_opt_s3_hosted_transport·test_member_ssot_ac3_1b·test_onboarding_member_anchor_0b115f5d·test_org_agent_grant_profile) 전부 개별 재확인 GREEN.
- realdb 3건(2751 신규 2건 포함)은 로컬 PG 기동 실패(`-c shared_memory_type=mmap` initdb 시도했으나 호스트 SysV shm 고갈, shmget ENOSPC)로 skip — dev CI 확인 필요.

prod 무접촉(develop 대상).