### PR TITLE
[SID:3201] 연결 완주 직후 "첫 지시" 유도 — 1차 깔때기 절벽 처방

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1148,6 +1148,8 @@
     "advancedSubtitle": "Webhook notifications · alternate transports (HTTP, SSE)",
     "advancedNote": "Configure webhook notifications and alternate connection methods later.",
     "dashboardCta": "Go to dashboard",
+    "firstInstructionCta": "Send your first instruction",
+    "firstInstructionStarting": "Opening chat…",
     "connectFooterHint": "Once verified you're ready — you can skip for now.",
     "transportHosted": "Hosted",
     "transportLocal": "Local (uvx)",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1148,6 +1148,8 @@
     "advancedSubtitle": "Webhook 알림 · 대체 연결 방식 (HTTP, SSE)",
     "advancedNote": "Webhook 알림과 대체 연결 방식은 나중에 설정할 수 있습니다.",
     "dashboardCta": "대시보드로",
+    "firstInstructionCta": "첫 지시 보내기",
+    "firstInstructionStarting": "대화 여는 중…",
     "connectFooterHint": "확인되면 준비 완료 — 지금 건너뛰어도 됩니다.",
     "transportHosted": "호스팅",
     "transportLocal": "로컬 (uvx)",

--- a/apps/web/src/app/onboarding/connect-step.test.tsx
+++ b/apps/web/src/app/onboarding/connect-step.test.tsx
@@ -7,6 +7,13 @@ import { ConnectStep, inferTransport, maskApiKey } from './connect-step';
 import { RAIL_ORDER, HTTP_RAIL_ORDER, VERIFY_TIMEOUT_MS } from './verify-rail';
 import ko from '../../../messages/ko.json';
 
+// story #3201 — "첫 지시 보내기" CTA가 쓰는 공유 헬퍼. mock으로 대체해 이 파일의 다른
+// describe(makeFetch 기반)들이 /api/conversations·/api/team-members를 몰라도 안전.
+const createFirstInstructionConversationMock = vi.fn();
+vi.mock('@/lib/onboarding/first-instruction', () => ({
+  createFirstInstructionConversation: (...args: unknown[]) => createFirstInstructionConversationMock(...args),
+}));
+
 describe('inferTransport (E-MCP-OPT S3 — transport 미지정 default-resolve 응답 판별)', () => {
   it('reads type:"http" from a hosted artifact', () => {
     const content = JSON.stringify({
@@ -101,7 +108,7 @@ describe('ConnectStep — story #4cdad425 (검증 안내 표시 렌더)', () => 
     await act(async () => {
       root.render(
         <NextIntlClientProvider locale="ko" messages={ko} timeZone="Asia/Seoul">
-          <ConnectStep agentId="a1" apiKey="sk_live_1234" onFinish={() => {}} />
+          <ConnectStep agentId="a1" apiKey="sk_live_1234" projectId="p1" onFinish={() => {}} />
         </NextIntlClientProvider>,
       );
       // 최초 아티팩트 fetch → transport 해소 → 폴 effect → verification-status fetch까지 마이크로태스크 flush.
@@ -183,7 +190,7 @@ describe('ConnectStep — story #3192 (연결 아티팩트 shape 회귀 pin)', (
     await act(async () => {
       root.render(
         <NextIntlClientProvider locale="ko" messages={ko} timeZone="Asia/Seoul">
-          <ConnectStep agentId="a1" apiKey={REAL_KEY} onFinish={() => {}} />
+          <ConnectStep agentId="a1" apiKey={REAL_KEY} projectId="p1" onFinish={() => {}} />
         </NextIntlClientProvider>,
       );
       await vi.advanceTimersByTimeAsync(100);
@@ -211,5 +218,82 @@ describe('ConnectStep — story #3192 (연결 아티팩트 shape 회귀 pin)', (
     await mount('empty-files');
     expect(container.textContent).not.toContain(PENDING);
     expect(container.textContent).toContain(ERROR);
+  });
+});
+
+// story #3201(activation·절벽 처방) — 1차 깔때기 "연결까지 온 사람 중 첫 왕복 0%" 절벽에
+// 대한 처방. PO 확定: verified 무관 상시 노출.
+describe('ConnectStep — story #3201 ("첫 지시 보내기" CTA)', () => {
+  function makeFetch(verified: boolean) {
+    return vi.fn(async (url: string) => {
+      if (url.includes('connection-artifact')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              files: [{
+                filename: '.mcp.json',
+                content: JSON.stringify({ mcpServers: { 'sprintable-mcp': { type: 'stdio', command: 'uvx', args: ['sprintable-mcp'], env: { AGENT_API_KEY: '<YOUR_AGENT_API_KEY>' } } } }),
+              }],
+              mcp_config: null,
+              api_key: null,
+            },
+          }),
+        };
+      }
+      if (url.includes('verification-status')) {
+        const rail = verified
+          ? [{ state: 'config_copied', status: 'done' }, { state: 'verified', status: 'done' }]
+          : [{ state: 'config_copied', status: 'done' }, { state: 'waiting', status: 'active' }];
+        return { ok: true, json: async () => ({ data: { verified, rail } }) };
+      }
+      return { ok: false, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+  }
+
+  let container: HTMLElement;
+  let root: ReturnType<typeof createRoot>;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createFirstInstructionConversationMock.mockReset();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  async function mount(verified: boolean) {
+    global.fetch = makeFetch(verified);
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={ko} timeZone="Asia/Seoul">
+          <ConnectStep agentId="a1" apiKey="sk_live_1234" projectId="p1" onFinish={() => {}} />
+        </NextIntlClientProvider>,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+  }
+
+  it('미검증 상태에도 CTA가 노출된다(PO 확定: verified 무관 상시 노출)', async () => {
+    await mount(false);
+    const cta = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('첫 지시 보내기'));
+    expect(cta).not.toBeUndefined();
+    expect((cta as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('클릭하면 agentId·projectId를 그대로 넘겨 공유 헬퍼를 호출한다(제3경로 발명 금지)', async () => {
+    createFirstInstructionConversationMock.mockResolvedValue('conv-xyz');
+    await mount(true);
+    const cta = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('첫 지시 보내기')) as HTMLButtonElement;
+    await act(async () => {
+      cta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    expect(createFirstInstructionConversationMock).toHaveBeenCalledWith('p1', 'a1');
   });
 });

--- a/apps/web/src/app/onboarding/connect-step.tsx
+++ b/apps/web/src/app/onboarding/connect-step.tsx
@@ -13,7 +13,8 @@ import {
 } from './verify-rail';
 import { emitOnboardingEvent, beaconOnboardingEvent } from './onboarding-telemetry';
 
-import { fetchWithAuth } from '@/lib/db/client';
+import { fetchWithAuth, refreshAuthTokens } from '@/lib/db/client';
+import { createFirstInstructionConversation } from '@/lib/onboarding/first-instruction';
 
 // story #2407 — Transport는 이제 verify-rail.tsx가 소유(useVerificationRail이 그 값을 직접
 // 다룸). 이 re-export는 기존 소비자(onboarding-form.tsx 등)의 import 경로를 안 건드리려는
@@ -35,6 +36,7 @@ export function inferTransport(content: string): Transport {
 interface ConnectStepProps {
   agentId: string | null;
   apiKey: string | null;
+  projectId: string | null;
   onFinish: () => void;
 }
 
@@ -93,7 +95,7 @@ export function HighlightedJson({ text }: { text: string }) {
   );
 }
 
-export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
+export function ConnectStep({ agentId, apiKey, projectId, onFinish }: ConnectStepProps) {
   const t = useTranslations('onboarding');
 
   // transport=null: 최초 default-resolve 응답 대기 中(BE edition 기본 판별 前).
@@ -172,24 +174,18 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
   }, [agentId]);
 
   // 최초 마운트 — transport 미지정 요청으로 BE edition 기본 판별.
-  // ⚠️story #2407 정리 中 처음 걸린 lint(react-hooks/set-state-in-effect) — fetchArtifact가
-  // 비동기로 setState하므로 정적분석이 "effect 안 setState"로 잡는다. 이 파일 다른 자리(§2
-  // 아티팩트 fetch 전체)와 동형인 기존 패턴(pristine origin/develop에도 있던 자리 — #2407가
-  // 만든 게 아니라 리팩터로 컴파일러 분석이 더 깊이 들어가면서 드러난 것)이라 이 스토리
-  // 범위에서 effect 아키텍처를 통째로 바꾸지 않는다 — 이 코드베이스 기존 관례(use-swipe-drawer.ts
-  // 등, PO 지적 2026-08-02 기준 이 PR로 여덟 번째)를 따라 disable로 명시한다.
-  // ⛔이 disable은 면제가 아니라 부채다 — «걷을 조건»: 이 세 effect(§아티팩트 fetch) 구조를
-  // 다시 손대는 판이 오면(예: fetchArtifact를 재설계·SWR류로 옮기는 스토리) 이 disable 세 개도
-  // 함께 재평가한다. 조용히 영구화하지 않는다.
+  // story #2407 정리 中 걸렸던 lint(react-hooks/set-state-in-effect, fetchArtifact 비동기
+  // setState를 정적분석이 "effect 안 setState"로 잡던 자리)에 disable 세 개를 부채로
+  // 명시해 뒀었다 — story #3201로 이 컴포넌트에 새 상태/핸들러가 늘며 분석 범위가 바뀌어
+  // (재평가 조건 그대로 발동, 위 원래 주석 참고) eslint가 세 disable 전부 "unused"로 재판정
+  // 했다(재확認: 이 세 effect 자체는 손 안 댐). 부채 걷음 — disable 제거.
   useEffect(() => {
     if (!agentId || !apiKey) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void fetchArtifact();
   }, [agentId, apiKey, fetchArtifact]);
 
   useEffect(() => {
     if (!needsStdioFallback) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setNeedsStdioFallback(false);
     void fetchArtifact('stdio');
   }, [needsStdioFallback, fetchArtifact]);
@@ -199,7 +195,6 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
     if (!agentId || !apiKey || !transport) return;
     if (artifacts[transport]) return;
     if (transport === 'http' && hostedUnavailable) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void fetchArtifact(transport);
   }, [agentId, apiKey, transport, artifacts, hostedUnavailable, fetchArtifact]);
 
@@ -257,6 +252,33 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
       emitOnboardingEvent('abandoned_explicit', { agent_id: agentId, failure_reason: 'abandoned_explicit', flow: 'onboarding' });
     }
     onFinish();
+  };
+
+  // story #3201(activation·절벽 처방) — 1차 깔때기 "연결까지 온 사람 중 첫 왕복 0%" 절벽.
+  // PO 확定(2026-08-29): verified 무관 상시 노출(미연결인 채 눌러도 새 DM에서 #3194 침묵
+  // 배너가 다음 행동을 안내하는 자기정합 구조). 생성 실패 시 onFinish()로 폴백(제3경로
+  // 발명 대신 기존 대시보드 이동 재사용 — 사용자를 막다른 곳에 두지 않음).
+  const [startingInstruction, setStartingInstruction] = useState(false);
+  const handleFirstInstruction = async () => {
+    if (!projectId || startingInstruction) return;
+    leftRef.current = true;
+    setStartingInstruction(true);
+    try {
+      const convId = await createFirstInstructionConversation(projectId, agentId);
+      if (!convId) {
+        onFinish();
+        return;
+      }
+      // story #2691 가드(verify-no-new-raw-fetch-api) — onboarding-form.tsx::finishToHome()의
+      // auth 토큰 갱신 raw fetch 호출을 그대로 베끼지 않고, 같은 목적의 기존 헬퍼
+      // (lib/db/client.ts의 refreshAuthTokens, callAuthRoute 경유)를 재사용한다.
+      await refreshAuthTokens().catch(() => null);
+      window.location.href = `/chats/${convId}`;
+    } catch {
+      onFinish();
+    } finally {
+      setStartingInstruction(false);
+    }
   };
 
   // 키 발급 실패 폴백(기존 동작 보존) — 아티팩트 없이 멤버 관리로 유도.
@@ -486,17 +508,34 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
         )}
       </section>
 
-      {/* 푸터 */}
-      <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
+      {/* 푸터 — story #3201: "첫 지시 보내기"가 주 CTA(1차 깔때기 절벽 처방), 대시보드 가기는
+          보조. verified 무관 상시 노출(PO 확定 — 미연결인 채 눌러도 새 DM에서 #3194 침묵
+          배너가 다음 행동을 안내). */}
+      <div className="flex flex-col items-stretch gap-3 border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between">
         <p className="min-w-0 text-xs text-muted-foreground">{t('connectFooterHint')}</p>
-        <Button
-          variant={verified ? 'hero' : 'glass'}
-          size="sm"
-          onClick={handleDashboard}
-          className="shrink-0 whitespace-nowrap"
-        >
-          {t('dashboardCta')}
-        </Button>
+        <div className="flex shrink-0 flex-wrap justify-end gap-2">
+          <Button
+            variant="glass"
+            size="sm"
+            onClick={handleDashboard}
+            className="whitespace-nowrap"
+          >
+            {t('dashboardCta')}
+          </Button>
+          <Button
+            variant="hero"
+            size="sm"
+            onClick={() => void handleFirstInstruction()}
+            disabled={!projectId || startingInstruction}
+            className="whitespace-nowrap"
+          >
+            {startingInstruction ? (
+              <><Loader2 className="h-3.5 w-3.5 animate-spin" />{t('firstInstructionStarting')}</>
+            ) : (
+              t('firstInstructionCta')
+            )}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -461,7 +461,7 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
         )}
 
         {step === 'connect' && (
-          <ConnectStep agentId={agentId} apiKey={newApiKey} onFinish={handleFinish} />
+          <ConnectStep agentId={agentId} apiKey={newApiKey} projectId={projectId} onFinish={handleFinish} />
         )}
       </div>
       {showUpgrade && <UpgradeModal message={upgradeReason} onClose={() => setShowUpgrade(false)} />}

--- a/apps/web/src/components/dashboard/activation-checklist-banner.test.tsx
+++ b/apps/web/src/components/dashboard/activation-checklist-banner.test.tsx
@@ -6,6 +6,20 @@ import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { ActivationChecklistBanner } from './activation-checklist-banner';
 
+// story #3201 — useDashboardContext(projectId)·useRouter 신규 의존성. storage-capacity-
+// banner.test.tsx와 동일 패턴(실 dashboard-shell.tsx 전체 모듈 그래프를 끌어들이지 않음).
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => ({ projectId: 'proj-1' }),
+}));
+const routerPushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: routerPushMock }),
+}));
+const createFirstInstructionConversationMock = vi.fn();
+vi.mock('@/lib/onboarding/first-instruction', () => ({
+  createFirstInstructionConversation: (...args: unknown[]) => createFirstInstructionConversationMock(...args),
+}));
+
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 const COMPLETE_KEY = 'sprintable_activation_checklist_complete';
@@ -34,6 +48,8 @@ let root: Root;
 
 beforeEach(() => {
   stubStorages();
+  routerPushMock.mockClear();
+  createFirstInstructionConversationMock.mockReset();
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
@@ -62,6 +78,7 @@ function stubChecklist(data: {
   completed: number;
   total: number;
   all_complete: boolean;
+  first_instruction_conversation_id?: string | null;
 }) {
   vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data }) })));
 }
@@ -71,6 +88,7 @@ const PARTIAL = {
   completed: 2,
   total: 5,
   all_complete: false,
+  first_instruction_conversation_id: null,
 };
 
 const COMPLETE = {
@@ -150,5 +168,51 @@ describe('ActivationChecklistBanner — 조회 실패 시 미노출', () => {
     await act(async () => { root.render(wrap(<ActivationChecklistBanner />)); });
     await flush();
     expect(container.textContent).toBe('');
+  });
+});
+
+// story #3201(AC2) — "첫 지시…" 항목만 클릭 가능(해당 대화로 이동).
+describe('ActivationChecklistBanner — "첫 지시…" 항목 클릭(story #3201)', () => {
+  it('first_instruction_conversation_id가 있으면 신규 생성 없이 바로 그 대화로 이동한다', async () => {
+    stubChecklist({ ...PARTIAL, first_instruction_conversation_id: 'conv-abc' });
+    await act(async () => { root.render(wrap(<ActivationChecklistBanner />)); });
+    await flush();
+
+    const target = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('첫 지시 보내고 회신 받기'),
+    ) as HTMLButtonElement;
+    expect(target).not.toBeUndefined();
+    await act(async () => { target.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(createFirstInstructionConversationMock).not.toHaveBeenCalled();
+    expect(routerPushMock).toHaveBeenCalledWith('/chats/conv-abc');
+  });
+
+  it('first_instruction_conversation_id가 null이면 신규 DM 생성 경로(connect-step과 동일)를 타 그 대화로 이동한다', async () => {
+    stubChecklist({ ...PARTIAL, first_instruction_conversation_id: null });
+    createFirstInstructionConversationMock.mockResolvedValue('conv-new');
+    await act(async () => { root.render(wrap(<ActivationChecklistBanner />)); });
+    await flush();
+
+    const target = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('첫 지시 보내고 회신 받기'),
+    ) as HTMLButtonElement;
+    await act(async () => { target.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    expect(createFirstInstructionConversationMock).toHaveBeenCalledWith('proj-1');
+    expect(routerPushMock).toHaveBeenCalledWith('/chats/conv-new');
+  });
+
+  it('다른 항목(예: 이메일 인증하기)은 여전히 클릭 불가능한 li다', async () => {
+    stubChecklist(PARTIAL);
+    await act(async () => { root.render(wrap(<ActivationChecklistBanner />)); });
+    await flush();
+
+    const emailItem = Array.from(container.querySelectorAll('li')).find(
+      (li) => li.textContent?.includes('이메일 인증하기'),
+    );
+    expect(emailItem?.querySelector('button')).toBeNull();
   });
 });

--- a/apps/web/src/components/dashboard/activation-checklist-banner.tsx
+++ b/apps/web/src/components/dashboard/activation-checklist-banner.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { ChevronDown, ChevronUp, Circle, CircleCheck } from 'lucide-react';
+import { ChevronDown, ChevronUp, Circle, CircleCheck, Loader2 } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { fetchWithAuth } from '@/lib/db/client';
+import { createFirstInstructionConversation } from '@/lib/onboarding/first-instruction';
 import { cn } from '@/lib/utils';
 
 /**
@@ -32,6 +35,8 @@ interface ActivationState {
   completed: number;
   total: number;
   all_complete: boolean;
+  // story #3201 — 왕복 성사된 대화(또는 org 최초 agent DM) id, 없으면 null.
+  first_instruction_conversation_id: string | null;
 }
 
 function readLocalFlag(key: string): boolean {
@@ -45,8 +50,11 @@ function readLocalFlag(key: string): boolean {
 
 export function ActivationChecklistBanner() {
   const t = useTranslations('activation');
+  const router = useRouter();
+  const { projectId } = useDashboardContext();
   const [state, setState] = useState<ActivationState | null>(null);
   const [skip] = useState<boolean>(() => readLocalFlag(COMPLETE_KEY));
+  const [navigatingToInstruction, setNavigatingToInstruction] = useState(false);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
     try {
@@ -94,6 +102,25 @@ export function ActivationChecklistBanner() {
     }
   };
 
+  // story #3201(AC2) — "첫 지시…" 항목만 클릭 가능(전 항목 클릭화는 범위 밖·#3196 잔존分
+  // 그대로). PO 확定 우선순위: BE first_instruction_conversation_id 있으면 그대로 이동,
+  // 없으면 connect-step CTA와 동일한 신규 DM 생성 경로 재사용(제3경로 발명 금지).
+  const handleFirstInstructionClick = async () => {
+    if (navigatingToInstruction) return;
+    if (state?.first_instruction_conversation_id) {
+      router.push(`/chats/${state.first_instruction_conversation_id}`);
+      return;
+    }
+    if (!projectId) return;
+    setNavigatingToInstruction(true);
+    try {
+      const convId = await createFirstInstructionConversation(projectId);
+      if (convId) router.push(`/chats/${convId}`);
+    } finally {
+      setNavigatingToInstruction(false);
+    }
+  };
+
   const stepItems: { key: keyof ActivationState['steps']; label: string }[] = [
     { key: 'email_verified', label: t('stepEmailVerified') },
     { key: 'org_created', label: t('stepOrgCreated') },
@@ -128,9 +155,31 @@ export function ActivationChecklistBanner() {
           // blue-soft(#EAEEFF) 배경 위에서 대비 미달(≈2.8:1<4.5·axe color-contrast 신규 위반). #2420
           // 규율(tint 위 계열색 글자는 text-foreground)·완료 여부는 CircleCheck vs Circle 모양이 전달하므로
           // 색 의존을 제거해도 신호 손실 0(색맹 접근성↑). 아이콘도 li 색 상속으로 함께 정리.
+          const icon = met ? <CircleCheck className="size-3.5 shrink-0" /> : <Circle className="size-3.5 shrink-0" />;
+          // story #3201(AC2) — "첫 지시…" 항목만 클릭 가능(해당 대화로 이동). 다른 항목은
+          // 기존 그대로 비-인터랙티브 li(스코프 밖, #3196 잔존分).
+          if (key === 'first_roundtrip') {
+            return (
+              <li key={key}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => void handleFirstInstructionClick()}
+                  disabled={navigatingToInstruction || !projectId}
+                  className={cn(
+                    'h-auto w-full min-w-0 justify-start gap-1.5 rounded px-1 py-0.5 text-left text-sm font-normal hover:underline disabled:no-underline',
+                    met ? 'text-foreground' : 'text-muted-foreground',
+                  )}
+                >
+                  {navigatingToInstruction ? <Loader2 className="size-3.5 shrink-0 animate-spin" /> : icon}
+                  <span>{label}</span>
+                </Button>
+              </li>
+            );
+          }
           return (
             <li key={key} className={cn('flex items-center gap-1.5 text-sm', met ? 'text-foreground' : 'text-muted-foreground')}>
-              {met ? <CircleCheck className="size-3.5 shrink-0" /> : <Circle className="size-3.5 shrink-0" />}
+              {icon}
               <span>{label}</span>
             </li>
           );

--- a/apps/web/src/lib/onboarding/first-instruction.ts
+++ b/apps/web/src/lib/onboarding/first-instruction.ts
@@ -1,0 +1,33 @@
+import { fetchWithAuth } from '@/lib/db/client';
+
+/**
+ * story #3201(activation·절벽 처방) — connect-step "첫 지시 보내기" CTA와 온보딩
+ * 체크리스트 "첫 지시…" 항목의 딥링크-부재 폴백이 공유하는 단일 DM 생성 경로(PO 확定
+ * 2026-08-29: 제3의 경로 발명 금지). `POST /api/conversations`는 always-new(EF-S2/
+ * db75ecd0) — 호출할 때마다 신규 DM 1개를 만든다, get-or-create 아님.
+ *
+ * agentId 미지정 시(체크리스트 폴백 경로 — connect-step은 항상 agentId를 안다) 프로젝트의
+ * 첫 agent를 조회해 대상으로 삼는다.
+ */
+export async function createFirstInstructionConversation(
+  projectId: string,
+  agentId?: string | null,
+): Promise<string | null> {
+  let targetAgentId = agentId ?? undefined;
+  if (!targetAgentId) {
+    const res = await fetchWithAuth(`/api/team-members?project_id=${projectId}&type=agent`);
+    if (!res.ok) return null;
+    const json = (await res.json()) as { data?: { id: string }[] };
+    targetAgentId = json.data?.[0]?.id;
+    if (!targetAgentId) return null;
+  }
+
+  const res = await fetchWithAuth('/api/conversations', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ type: 'dm', participant_ids: [targetAgentId], project_id: projectId }),
+  });
+  if (!res.ok) return null;
+  const data = (await res.json()) as { id?: string };
+  return data.id ?? null;
+}

--- a/backend/app/services/onboarding_activation.py
+++ b/backend/app/services/onboarding_activation.py
@@ -23,7 +23,7 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from app.models.conversation import Conversation, ConversationMessage
+from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.project import OrgMember
 from app.models.team import TeamMember
 from app.models.user import User
@@ -104,11 +104,71 @@ async def is_org_first_roundtrip_done(db: AsyncSession, org_id: uuid.UUID) -> bo
     return row is not None
 
 
+async def get_first_instruction_conversation_id(db: AsyncSession, org_id: uuid.UUID) -> uuid.UUID | None:
+    """story #3201 — 체크리스트 "첫 지시 보내고 회신 받기" 클릭의 딥링크 타겟.
+
+    DM 생성(`POST /api/conversations`)이 의도적으로 always-new라서(EF-S2/db75ecd0,
+    uq_conversations_dm_pair도 과거에 일부러 drop됨) "그 에이전트와의 대화"가 BE에 원래
+    자명하지 않다. PO 확定(2026-08-29) 우선순위 3단:
+      ①왕복(휴먼→에이전트 응답) 성사된 그 대화(가장 이른 것) — is_org_first_roundtrip_done과
+        동일 조인, SELECT 대상만 conversation id로 바꾼 것(두 벌 판정 로직 아님).
+      ②없으면 org 최초(created_at 가장 이른) agent 참여 DM.
+      ③그것도 없으면 None — FE는 None이면 신규 DM 생성 CTA(story #3201 A안)를 그대로
+        재사용한다(제3의 경로 발명 금지, PO 지시).
+    """
+    HumanMsg = aliased(ConversationMessage)
+    HumanSender = aliased(TeamMember)
+    AgentSender = aliased(TeamMember)
+
+    human_before = (
+        select(HumanMsg.id)
+        .join(HumanSender, HumanSender.id == HumanMsg.sender_id)
+        .where(
+            HumanMsg.conversation_id == ConversationMessage.conversation_id,
+            HumanSender.type == "human",
+            HumanMsg.created_at < ConversationMessage.created_at,
+        )
+        .exists()
+    )
+    roundtrip_conv_id = (await db.execute(
+        select(Conversation.id)
+        .join(ConversationMessage, ConversationMessage.conversation_id == Conversation.id)
+        .join(AgentSender, AgentSender.id == ConversationMessage.sender_id)
+        .where(
+            Conversation.org_id == org_id,
+            AgentSender.type == "agent",
+            human_before,
+        )
+        .order_by(ConversationMessage.created_at.asc())
+        .limit(1)
+    )).scalar_one_or_none()
+    if roundtrip_conv_id is not None:
+        return roundtrip_conv_id
+
+    return (await db.execute(
+        select(Conversation.id)
+        .join(ConversationParticipant, ConversationParticipant.conversation_id == Conversation.id)
+        .join(TeamMember, TeamMember.id == ConversationParticipant.member_id)
+        .where(
+            Conversation.org_id == org_id,
+            Conversation.type == "dm",
+            TeamMember.type == "agent",
+        )
+        .order_by(Conversation.created_at.asc())
+        .limit(1)
+    )).scalar_one_or_none()
+
+
 async def get_activation_state(db: AsyncSession, user: User) -> dict:
     """체크리스트/리마인드 공용 — 5단계 완료 여부 + 요약."""
     org_id = await get_owner_org_id(db, user.id)
     agent_connected = await is_org_agent_connected(db, org_id) if org_id else False
     roundtrip_done = await is_org_first_roundtrip_done(db, org_id) if org_id else False
+    # story #3201 — 체크리스트 "첫 지시…" 항목 클릭 딥링크. org_id 없으면(온보딩 미완주)
+    # 애초에 org 스코프 쿼리 자체가 무의미 — None(FE 신규 DM CTA 폴백).
+    first_instruction_conv_id = (
+        await get_first_instruction_conversation_id(db, org_id) if org_id else None
+    )
     steps = {
         "signed_up": True,
         "email_verified": user.email_verified,
@@ -122,6 +182,9 @@ async def get_activation_state(db: AsyncSession, user: User) -> dict:
         "completed": completed,
         "total": len(steps),
         "all_complete": completed == len(steps),
+        "first_instruction_conversation_id": (
+            str(first_instruction_conv_id) if first_instruction_conv_id else None
+        ),
     }
 
 

--- a/backend/tests/test_3159_onboarding_activation_realdb.py
+++ b/backend/tests/test_3159_onboarding_activation_realdb.py
@@ -201,6 +201,87 @@ async def test_is_org_agent_connected_falls_back_to_roundtrip_for_http_agents():
 
 
 @pytest.mark.anyio
+async def test_get_first_instruction_conversation_id_priority_order():
+    """story #3201 — 체크리스트 "첫 지시…" 클릭 딥링크 타겟. PO 확定 우선순위 3단:
+    ①org 대화 0건→None ②DM만 있고 왕복 前→org 최초 agent DM ③왕복 성사된 대화가
+    있으면 그게 최우선(DM 여러 개 중에서도)."""
+    eng, Session = await _engine()
+    async with Session() as s:
+        await _wipe(s, ORG)
+        try:
+            proj = _uuid()
+            human_member, agent_member = _uuid(), _uuid()
+            app_id = _uuid()
+            await s.execute(text(
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','O','story3159-o','free')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{proj}','{ORG}','P','none')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO members (id,org_id,type,name) VALUES "
+                f"('{human_member}','{ORG}','human','H'),('{agent_member}','{ORG}','agent','A')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO agent_project_profiles (id,member_id,project_id) VALUES ('{app_id}','{agent_member}','{proj}')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO project_access (id,project_id,member_id,role) VALUES ('{_uuid()}','{proj}','{human_member}','member')"
+            ))
+            await s.commit()
+
+            # ① org에 대화 0건 — None.
+            assert (await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG))) is None
+
+            # ② DM 1개 생성(왕복 前) — 그 DM이 반환돼야.
+            dm1 = _uuid()
+            await s.execute(text(
+                f"INSERT INTO conversations (id,org_id,project_id,type,created_at) VALUES "
+                f"('{dm1}','{ORG}','{proj}','dm', now() - interval '2 hours')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO conversation_participants (id,conversation_id,member_id) VALUES "
+                f"('{_uuid()}','{dm1}','{human_member}'),('{_uuid()}','{dm1}','{agent_member}')"
+            ))
+            await s.commit()
+            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG))
+            assert str(result) == dm1
+
+            # ②b DM을 하나 더(더 이른 created_at) 만들면 org 최초(가장 이른) 쪽이 반환돼야.
+            dm0 = _uuid()
+            await s.execute(text(
+                f"INSERT INTO conversations (id,org_id,project_id,type,created_at) VALUES "
+                f"('{dm0}','{ORG}','{proj}','dm', now() - interval '3 hours')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO conversation_participants (id,conversation_id,member_id) VALUES "
+                f"('{_uuid()}','{dm0}','{human_member}'),('{_uuid()}','{dm0}','{agent_member}')"
+            ))
+            await s.commit()
+            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG))
+            assert str(result) == dm0
+
+            # ③ 왕복(휴먼→에이전트 응답) 성사된 대화가 생기면, DM들보다 우선해 그게 반환돼야.
+            roundtrip_conv = _uuid()
+            now = datetime.now(timezone.utc)
+            t0, t1 = now - timedelta(hours=1), now
+            await s.execute(text(
+                f"INSERT INTO conversations (id,org_id,project_id,type) VALUES ('{roundtrip_conv}','{ORG}','{proj}','group')"
+            ))
+            await s.execute(text(
+                f"INSERT INTO conversation_messages (id,conversation_id,sender_id,content,created_at) VALUES "
+                f"('{_uuid()}','{roundtrip_conv}','{human_member}','hi','{t0.isoformat()}'),"
+                f"('{_uuid()}','{roundtrip_conv}','{agent_member}','hello','{t1.isoformat()}')"
+            ))
+            await s.commit()
+            result = await svc.get_first_instruction_conversation_id(s, uuid.UUID(ORG))
+            assert str(result) == roundtrip_conv
+        finally:
+            await _wipe(s, ORG)
+    await eng.dispose()
+
+
+@pytest.mark.anyio
 async def test_is_org_first_roundtrip_order_sensitive():
     """디디 대조 확定 조건(#3157) — 존재만으론 불충분, 휴먼 발신 "이후"에 온 agent 발신이어야."""
     eng, Session = await _engine()


### PR DESCRIPTION
## 요약
- [\[activation·절벽 처방\] 연결 완주 직후 «첫 지시» 유도 — 연결 후 무발화 절벽(1차 깔때기 첫 왕복 0%)을 닫는 표면](entity:story:f1d0bde6-a378-49fb-95fb-c9e2e526d165)
- 1차 깔때기 실측: 연결까지 온 43명 중 첫 왕복 0% — "연결 후 아무도 말을 걸지 않음" 절벽.

## 실측→갈림길→PO 판정 (3190 패턴)
착수 실측 결과를 PO에 갈림길 2개로 보고 후 판정받아 진행:
- **A(CTA 위치)**: connect-step 완주 화면 CTA만 채택(대시보드 가기 옆, verified 무관 상시 노출). `/chats` 빈 상태 CTA는 안 함 — 스킵 코호트는 #3194(침묵 배너)가 이미 커버, 발명 최소.
- **B(체크리스트 딥링크)**: DM 생성(`POST /api/conversations`)이 의도적으로 always-new(EF-S2/db75ecd0, dedup 0)라 "그 대화"가 BE에 자명하지 않음을 실측으로 확인 → `get_activation_state`에 `first_instruction_conversation_id` 신설(마이그 0). 우선순위 3단(PO 확定): ①왕복 성사된 대화 ②없으면 org 최초 agent DM ③null이면 FE가 A의 CTA 액션(신규 DM 생성)을 그대로 재사용(제3경로 발명 금지).

## 변경
- `apps/web/src/lib/onboarding/first-instruction.ts` (신규) — connect-step CTA와 체크리스트 클릭 폴백이 공유하는 단일 DM 생성 헬퍼.
- `connect-step.tsx` — "첫 지시 보내기" CTA(대시보드 가기 옆), `projectId` prop 추가.
- `activation-checklist-banner.tsx` — "첫 지시…" 항목만 클릭 가능(다른 항목은 그대로, #3196 잔존分 범위 확장 금지).
- `backend/app/services/onboarding_activation.py` — `get_first_instruction_conversation_id` 신설 + `get_activation_state` 응답에 필드 추가.
- 테스트: FE 3파일(신규 클릭 시나리오 + 기존 회귀), BE realdb 우선순위 3단 신규 테스트.

## 게이트 왕복(투명 기록)
1차 통과 후 `verify:*` 전체를 마저 돌리다 2건 잡음 — 즉시 정정:
- `verify:no-new-raw-fetch-api`: 새 raw `fetch('/api/auth/refresh')`를 기존 헬퍼 `refreshAuthTokens()`(lib/db/client.ts)로 교체.
- `verify:no-new-raw-button`: 체크리스트 항목의 raw `<button>`을 `Button` 컴포넌트로 교체.
- 부수 발견: `connect-step.tsx`의 `react-hooks/set-state-in-effect` disable 3개가 이 변경으로 eslint 자체가 "unused"로 재판정 — 그 파일 자신의 기존 주석("§2407 부채, 재평가 조건 발동 시 다시 봄")이 예고한 조건이 실제로 발동한 것 확인 후 제거.

## 게이트
- FE: `tsc` 0 · `lint` 0(신규, 무관 기존 warning 5건 그대로) · `verify:*` 전체 GREEN · `vitest` 4991 GREEN · `build` GREEN.
- BE: `py_compile` GREEN · 관련 mock 테스트(`test_3159_activation_router.py`) GREEN · 전체 스위트(`-m "not destructive_schema"`, #3186 처방 준수) 5065 passed, 무관 실패 14건 그대로(파일 스코프 재확認).
- realdb 신규 2건(`get_first_instruction_conversation_id` 우선순위 3단)은 로컬 PG 기동 실패(shm 고갈, 세션 내내 지속)로 skip — dev CI 확인 필요.

## AC 대조
1. 연결 완주/스킵 직후 "첫 지시" 클릭 1회 경로 — connect-step CTA로 충족.
2. 체크리스트 "첫 지시…" 클릭=해당 대화 이동 — `first_instruction_conversation_id` 딥링크(없으면 신규 DM 생성 폴백).
3. 카피·표면은 유나 design 게이트 경유 — 기존 Alert/Button 컴포넌트·토큰만 재사용(신규 시각 패턴 0), PR 게이트에서 최종 판정.
4. dev까지만 — prod 무접촉.

prod 무접촉(develop 대상).