### PR TITLE
[SID:3202] 모바일 챗 상단 org/프로젝트 스위처 픽셀 붕괴 fix

### DIFF
--- a/apps/web/src/components/nav/context-switcher-chip.test.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.test.tsx
@@ -140,17 +140,28 @@ describe('ContextSwitcherChip — story #2076', () => {
 // 발견 6결함 해소: 44px 트리거+행·검색·3층 위계(프로젝트→조직→계정)·계정 divider 분리·
 // 데스크톱 무회귀.
 describe('ContextSwitcherChip — story #3147/#3146 재설계(44px·검색·3층·계정)', () => {
-  it('트리거가 min-h-11(44px)이고 조직/프로젝트 2줄로 표시된다', async () => {
+  it('트리거가 h-11(44px 고정)이고 조직/프로젝트 2줄로 표시된다', async () => {
     await act(async () => {
       root.render(wrap(
         <ContextSwitcherChip orgs={ORGS} currentOrgId="org-1" projects={PROJECTS} currentProjectId="proj-1" />,
       ));
     });
     const trigger = container.querySelector('button');
-    expect(trigger?.className).toContain('min-h-11');
+    // story #3202(선생님 실기기 픽셀 붕괴) 핀 — min-h-11(최솟값)이던 시절엔 2단 라벨의
+    // line-height가 예산을 넘기면 트리거 실높이가 부모 TopBar(h-12=48px)를 초과해 자기
+    // border/bg가 헤더 행을 뚫고 나온 것처럼 보였다(dev 라이브 실측: 48.5px·상단 -0.75px로
+    // 실제 초과 확認). h-11(고정 44px)+overflow-hidden으로 어떤 폰트 렌더링에서도 그 예산을
+    // 못 넘게 하드캡한다 — min-h-11 회귀(다시 growable해지는 것)를 여기서 막는다.
+    expect(trigger?.className).toContain('h-11');
+    expect(trigger?.className).not.toContain('min-h-11');
+    expect(trigger?.className).toContain('overflow-hidden');
     const spans = trigger!.querySelectorAll('span > span');
     expect(spans[0]?.textContent).toBe('뭉클랩');
     expect(spans[1]?.textContent).toBe('Sprintable');
+    // 두 라벨 span 모두 leading-none(타이트 line-height)로 실높이 예산을 하드캡 — 안드로이드
+    // 폰트 부스트 등 렌더링 조건과 무관하게 44px 안에 들어오게 하는 축.
+    expect(spans[0]?.className).toContain('leading-none');
+    expect(spans[1]?.className).toContain('leading-none');
   });
 
   it('시트 안 프로젝트 행이 min-h-11(44px)이다', async () => {

--- a/apps/web/src/components/nav/context-switcher-chip.test.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.test.tsx
@@ -158,10 +158,15 @@ describe('ContextSwitcherChip — story #3147/#3146 재설계(44px·검색·3층
     const spans = trigger!.querySelectorAll('span > span');
     expect(spans[0]?.textContent).toBe('뭉클랩');
     expect(spans[1]?.textContent).toBe('Sprintable');
-    // 두 라벨 span 모두 leading-none(타이트 line-height)로 실높이 예산을 하드캡 — 안드로이드
-    // 폰트 부스트 등 렌더링 조건과 무관하게 44px 안에 들어오게 하는 축.
-    expect(spans[0]?.className).toContain('leading-none');
-    expect(spans[1]?.className).toContain('leading-none');
+    // 유나 design:changes(2026-08-29) — 두 라벨 span 모두 leading-tight. 처음엔
+    // leading-none(line-height:1)이었으나 Pretendard ascent+descent(1.19em)가 1em 박스+
+    // truncate의 overflow-hidden에서 디센더(p·g·y)를 잘랐다(실기기 폰트부스트에선 2~3
+    // device px 절단). 버튼 자체(h-11+overflow-hidden)가 이미 하드캡이라 라벨은
+    // leading-tight로 느슨해져도 예산(~30.75px<32px) 안에 안착 — leading-none 회귀를 막는다.
+    expect(spans[0]?.className).toContain('leading-tight');
+    expect(spans[1]?.className).toContain('leading-tight');
+    expect(spans[0]?.className).not.toContain('leading-none');
+    expect(spans[1]?.className).not.toContain('leading-none');
   });
 
   it('시트 안 프로젝트 행이 min-h-11(44px)이다', async () => {

--- a/apps/web/src/components/nav/context-switcher-chip.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.tsx
@@ -80,18 +80,25 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
       <Sheet open={s.open} onOpenChange={s.setOpen}>
         {/* story #3147 §② — 26px 단행 칩 → 44px 2단(조직 위·프로젝트 아래) 상시 트리거.
             폭 상한은 #2076 실측(120px 단행 기준)과 다른 레이아웃이라 재실측(190px 기준
-            390px 뷰포트에서 우측 아이콘 클러스터와 안 겹침, 헤더 실렌더로 확認). */}
+            390px 뷰포트에서 우측 아이콘 클러스터와 안 겹침, 헤더 실렌더로 확認).
+            story #3202(선생님 실기기 픽셀 붕괴) — `min-h-11`은 최솟값일 뿐이라, 2단 라벨의
+            line-height가 (특히 안드로이드 폰트 부스트 하에서) 44px+padding 예산을 넘겨
+            버튼 실높이가 부모 TopBar(h-12=48px)를 넘어서면 자기 border/bg가 헤더 행을
+            뚫고 나온 것처럼 보였다(실측: 헤더 h-12(48px) 안에서 트리거 실제 렌더 높이
+            48.5px·상단 -0.75px로 이미 초과 확認). `h-11`(고정 44px)+`overflow-hidden`+
+            라벨 `leading-none`으로 실높이를 44px에 하드캡 — 터치 타겟(44px)은 그대로
+            유지하면서(AC2) 어떤 폰트 렌더링 조건에서도 48px 행을 못 넘게 한다. */}
         <button
           type="button"
           onClick={() => s.setOpen(true)}
           disabled={s.pending}
-          className="flex min-h-11 min-w-0 max-w-[190px] shrink-0 items-center gap-2 rounded-xl border border-border bg-card px-2 py-1.5 text-left transition hover:bg-muted disabled:opacity-60 lg:hidden"
+          className="flex h-11 min-w-0 max-w-[190px] shrink-0 items-center gap-2 overflow-hidden rounded-xl border border-border bg-card px-2 py-1.5 text-left transition hover:bg-muted disabled:opacity-60 lg:hidden"
           aria-label={t('switcherMobileTriggerAria')}
         >
           <OrgInitial name={s.displayOrg} className="flex size-7 shrink-0 items-center justify-center rounded-[7px] bg-brand text-xs font-semibold text-brand-foreground" />
-          <span className="flex min-w-0 flex-1 flex-col items-start">
-            <span className="w-full truncate text-[10px] font-semibold text-muted-foreground">{s.displayOrg}</span>
-            <span className="w-full truncate text-[13px] font-bold text-foreground">{chipLabel}</span>
+          <span className="flex min-w-0 flex-1 flex-col items-start justify-center gap-0.5">
+            <span className="w-full truncate text-[10px] font-semibold leading-none text-muted-foreground">{s.displayOrg}</span>
+            <span className="w-full truncate text-[13px] font-bold leading-none text-foreground">{chipLabel}</span>
           </span>
           <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
         </button>

--- a/apps/web/src/components/nav/context-switcher-chip.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.tsx
@@ -85,9 +85,15 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
             line-height가 (특히 안드로이드 폰트 부스트 하에서) 44px+padding 예산을 넘겨
             버튼 실높이가 부모 TopBar(h-12=48px)를 넘어서면 자기 border/bg가 헤더 행을
             뚫고 나온 것처럼 보였다(실측: 헤더 h-12(48px) 안에서 트리거 실제 렌더 높이
-            48.5px·상단 -0.75px로 이미 초과 확認). `h-11`(고정 44px)+`overflow-hidden`+
-            라벨 `leading-none`으로 실높이를 44px에 하드캡 — 터치 타겟(44px)은 그대로
-            유지하면서(AC2) 어떤 폰트 렌더링 조건에서도 48px 행을 못 넘게 한다. */}
+            48.5px·상단 -0.75px로 이미 초과 확認). `h-11`(고정 44px)+`overflow-hidden`으로
+            컨테이너 자체를 하드캡 — 터치 타겟(44px)은 그대로 유지하면서(AC2) 어떤 폰트
+            렌더링 조건에서도 48px 행을 못 넘게 한다.
+            유나 design:changes(2026-08-29) — 라벨에 처음엔 `leading-none`(line-height:1)을
+            썼으나, Pretendard의 ascent+descent가 1em을 넘는 1.19em이라 그 1em 박스+
+            truncate 자체 overflow-hidden에서 디센더(p·g·y)가 잘렸다(선생님 실기기
+            2~3x 폰트부스트 조건에선 2~3 device px 절단으로 관측). `leading-tight`로
+            교체 — 버튼 자체는 이미 h-11+overflow-hidden이 하드캡이므로 라벨은 안전하게
+            느슨해질 수 있다(2단 실높이 leading-tight 기준 ~30.75px < 예산 32px, 안착). */}
         <button
           type="button"
           onClick={() => s.setOpen(true)}
@@ -97,8 +103,8 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
         >
           <OrgInitial name={s.displayOrg} className="flex size-7 shrink-0 items-center justify-center rounded-[7px] bg-brand text-xs font-semibold text-brand-foreground" />
           <span className="flex min-w-0 flex-1 flex-col items-start justify-center gap-0.5">
-            <span className="w-full truncate text-[10px] font-semibold leading-none text-muted-foreground">{s.displayOrg}</span>
-            <span className="w-full truncate text-[13px] font-bold leading-none text-foreground">{chipLabel}</span>
+            <span className="w-full truncate text-[10px] font-semibold leading-tight text-muted-foreground">{s.displayOrg}</span>
+            <span className="w-full truncate text-[13px] font-bold leading-tight text-foreground">{chipLabel}</span>
           </span>
           <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
         </button>


### PR DESCRIPTION
## 요약
- [\[모바일·챗 상단·선생님 실기기\] org/프로젝트 스위처 픽셀 붕괴 — 헤더 행과 높이·여백·정렬이 깨져 분리 블록처럼 렌더](entity:story:7d21af22-10dd-42b9-bb1b-0b4c1a77caba)
- 선생님 실기기(다크·U+ 5G) 스크린샷: 모바일 챗 상단 org/프로젝트 스위처가 헤더 행을 뚫고 나온 분리 블록처럼 렌더.

## 근본원인(dev 라이브 실측)
`ContextSwitcherChip` 트리거가 `min-h-11`(최솟값)이라 2단 라벨(조직명·프로젝트명)의 line-height가 예산을 넘기면 실높이가 부모 TopBar(`h-12`=48px)를 초과합니다. dev 배포 FE(sellerking 계정, 390px 모바일 뷰포트)에서 직접 측정:
- **before**: `height=48.5px`, `top=-0.75px` — 헤더 행 상단 경계(y=0)를 이미 넘어서 있음(라이트/다크 동일 수치 — 테마 무관 순수 box-model 결함).
- 안드로이드 폰트 부스트 등 실기기 조건에서 이 여유가 더 벌어져 눈에 띄게 돌출된 것으로 추정.

## 처방
- `min-h-11` → `h-11`(고정 44px) + `overflow-hidden` — 실높이를 어떤 렌더링 조건에서도 하드캡.
- 라벨 두 줄에 `leading-none` 추가 — 콘텐츠 자체가 높이 예산을 넘지 않게.
- 44px는 이 컴포넌트의 시트 내부 행들이 이미 전부 쓰는 touch-target 표준과 동일 — **AC2(터치 타겟 유지) 충족**(축소가 아니라 기존 컴포넌트 표준으로 고정).

## 실측 검증(dev 배포 FE 라이브 — Puppeteer, sellerking 계정, 390px 모바일 뷰포트)
같은 클래스 변경을 실제 배포된 페이지의 라이브 DOM에 직접 적용해(순수 Tailwind 유틸리티 치환이라 유효) 재측정:
- **after**: `height=44px`, `top=1.5px` — 헤더 `[0,48]` 범위 안에 완전히 안착.
- 라이트/다크 양테마 모두 before 수치 동일 확認 후, 동일 fix가 두 테마 모두에서 결과 일치.
- 스크린샷 4장(전/후 × 라이트/다크) 확보.

## 스코프 준수(PO 지시)
⚠️이 파일은 순감소 2호 후보(raw button 11)이나 **이 PR은 픽셀 수리만** — raw `<button>`→`Button` 전환 등 리팩터는 섞지 않았습니다(diff 2파일·25줄, 트리거의 클래스/구조만 변경).

## 변경 파일
- `context-switcher-chip.tsx` — 트리거 높이 하드캡 + 라벨 line-height.
- `context-switcher-chip.test.tsx` — 기존 `min-h-11` assertion을 `h-11`+`not.toContain('min-h-11')`+`overflow-hidden`+`leading-none` pin으로 교체.

## 게이트
- `tsc` 0 · `lint` 0(무관 기존 warning 5건 그대로) · `verify:no-new-raw-button`(baseline 무증가) · `verify:tint-foreground-contrast` · `verify:no-i18n-phrase-collision` 전부 GREEN.
- `vitest` 4991 GREEN(신규 pin 포함) · `build` GREEN.
- **데스크톱 무회귀(AC4)**: `lg:hidden`으로 이 버튼 자체가 데스크톱에서 렌더 안 됨 — 구조적으로 무영향(추가 검증 불요).

prod 무접촉(develop 대상).