### PR TITLE
[SID:3203] 대화 리스트 상대명 uuid 노출 표시결함 — 폴백 사람 언어화

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3666,6 +3666,7 @@
     "groupTitle": "Group name (optional)",
     "groupTitlePlaceholder": "Group chat name",
     "dmWith": "DM",
+    "unknownMember": "Unknown member",
     "noMessages": "Send the first message",
     "connectionLost": "Connection lost",
     "refreshNow": "Refresh",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3666,6 +3666,7 @@
     "groupTitle": "그룹 이름 (선택)",
     "groupTitlePlaceholder": "그룹 채팅 이름",
     "dmWith": "DM",
+    "unknownMember": "알 수 없는 멤버",
     "noMessages": "첫 메시지를 보내보세요",
     "connectionLost": "연결이 끊겼어요",
     "refreshNow": "새로고침",

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -51,14 +51,16 @@ function isValidProjectId(value: string | null): value is string {
   return !!value && UUID_RE.test(value);
 }
 
-function formatHeaderTitle(meta: ConversationMeta, currentMemberId: string): string {
+function formatHeaderTitle(meta: ConversationMeta, currentMemberId: string, t: (key: string) => string): string {
   if (meta.title) return meta.title;
   const others = meta.participants.filter((p) => p.member_id !== currentMemberId);
   if (others.length === 0) return meta.type === 'dm' ? 'DM' : '그룹 채팅';
-  if (meta.type === 'dm') return others[0]?.name ?? '?';
+  // story #3203(카디르 QA·PO 지시) — 같은 participants 계약 소비처, chat-list-view.tsx의
+  // formatParticipantNames와 동일 사람언어 폴백으로 통일('?'는 비인간어).
+  if (meta.type === 'dm') return others[0]?.name ?? t('unknownMember');
   const MAX = 3;
-  if (others.length <= MAX) return others.map((p) => p.name ?? '?').join(', ');
-  return `${others.slice(0, MAX).map((p) => p.name ?? '?').join(', ')} 외 ${others.length - MAX}명`;
+  if (others.length <= MAX) return others.map((p) => p.name ?? t('unknownMember')).join(', ');
+  return `${others.slice(0, MAX).map((p) => p.name ?? t('unknownMember')).join(', ')} 외 ${others.length - MAX}명`;
 }
 
 export default function ConversationPage() {
@@ -201,7 +203,7 @@ export default function ConversationPage() {
   }
 
   const headerTitle = meta
-    ? formatHeaderTitle(meta, currentTeamMemberId)
+    ? formatHeaderTitle(meta, currentTeamMemberId, t)
     : (meta === null ? '채팅' : '로딩 중…');
 
   // story #2968 — 리스트(chat-list-view.tsx)와 동일 원칙: 1:1(DM)만 상대가 특정되므로
@@ -214,7 +216,8 @@ export default function ConversationPage() {
   // (S8b 미머지 → runtime_type undefined → commandTargets 빈 배열 → 경고 미표시 graceful.)
   const commandTargets = (meta?.participants ?? [])
     .filter((p) => p.type === 'agent' && p.member_id !== currentTeamMemberId && p.runtime_type !== undefined)
-    .map((p) => ({ agentId: p.member_id, agentName: p.name ?? '?', runtimeType: p.runtime_type ?? null }));
+    // story #3203(카디르 QA·PO 지시) — 같은 participants 계약 소비처, 사람언어 폴백 통일.
+    .map((p) => ({ agentId: p.member_id, agentName: p.name ?? t('unknownMember'), runtimeType: p.runtime_type ?? null }));
 
   return (
     <>
@@ -246,7 +249,8 @@ export default function ConversationPage() {
             </button>
             {headerAvatarParticipant && (
               <Avatar
-                name={headerAvatarParticipant.name ?? '?'}
+                // story #3203(카디르 QA·PO 지시) — 같은 participants 계약 소비처, 사람언어 폴백 통일.
+                name={headerAvatarParticipant.name ?? t('unknownMember')}
                 avatarUrl={headerAvatarParticipant.avatar_url ?? null}
                 actorType={headerAvatarParticipant.type === 'agent' ? 'agent' : 'human'}
                 size={24}

--- a/apps/web/src/components/chat/chat-input.test.tsx
+++ b/apps/web/src/components/chat/chat-input.test.tsx
@@ -402,6 +402,28 @@ describe('ChatInput — STEER 모드(story #2942)', () => {
     // 패널은 열린 채 유지(재시도 가능 — 대상 재선택 등).
     expect(container.textContent).toContain('방향 전환 지시');
   });
+
+  // story #3203(카디르 QA 블로킹·2026-08-29) — BE가 orphan participant.name을 이제 null로
+  // 실어보낸다(예전엔 uuid 앞 8자였으나 그마저 없어짐). 대상 select가 `p.name ?? p.member_id`
+  // 폴백을 쓰고 있어 36자 uuid 전체가 옵션 텍스트로 그대로 새는 회귀였다 — 이 PR의 BE 변경이
+  // 처음 깨운 것이라 pin 필수.
+  it('대상 참가자의 name이 null이면(BE orphan 폴백) "알 수 없는 멤버"로 뜬다 — uuid 전체 노출 금지', async () => {
+    const orphanId = '767988e5-df5b-48e8-9964-7062fe84d691';
+    await act(async () => {
+      root.render(withIntl(
+        <ChatInput
+          threadId="c1"
+          onSend={vi.fn()}
+          currentTeamMemberId="me"
+          participants={[{ member_id: 'me', name: '나' }, { member_id: orphanId, name: null }]}
+        />,
+      ));
+    });
+    await act(async () => { toggleBtn()!.click(); });
+    const select = container.querySelector('select') as HTMLSelectElement;
+    expect(select.textContent).toContain('알 수 없는 멤버');
+    expect(select.textContent).not.toContain(orphanId);
+  });
 });
 
 // story #3000 로드맵 PR-B(L1) — floating 드롭다운(멘션 등)은 --elev-overlay 토큰이어야 한다

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -674,7 +674,10 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
             >
               <option value="">{t('steerPanelTargetPlaceholder')}</option>
               {steerTargets.map((p) => (
-                <option key={p.member_id} value={p.member_id}>{p.name ?? p.member_id}</option>
+                // story #3203(카디르 QA 블로킹) — BE가 orphan participant.name을 이제 null로
+                // 실어보낸다(예전엔 uuid 앞 8자였으나 그마저 없어짐) — p.member_id 그대로 쓰면
+                // 36자 uuid 전체가 노출된다(예전보다 더 심함). 사람 언어 폴백으로 통일.
+                <option key={p.member_id} value={p.member_id}>{p.name ?? t('unknownMember')}</option>
               ))}
             </select>
             <div className="relative min-w-0 flex-1">

--- a/apps/web/src/components/chat/chat-list-view.test.tsx
+++ b/apps/web/src/components/chat/chat-list-view.test.tsx
@@ -414,3 +414,24 @@ describe('ChatListView — 대화명 Claim 무게(story #2969 PR-5)', () => {
     expect(nameEl?.className).not.toContain('font-medium');
   });
 });
+
+// story #3203(선생님 실사고·2026-08-29) — 대화 리스트 상대명 자리에 raw uuid가 노출된
+// 표시결함 pin. 근본원인은 BE resolver의 orphan 폴백이 uuid 앞 8자를 "이름"처럼 지어내던
+// 것(member_resolver.py) — 이제 BE는 name=null을 실어보내고, FE가 그 null을 '?' 1글자가
+// 아니라 사람 언어 문구로 폴백해야 한다.
+describe('ChatListView — 참가자 이름 해석 실패 폴백(story #3203)', () => {
+  it('DM 상대의 name이 null이면(BE orphan 폴백) "알 수 없는 멤버"로 뜬다 — uuid도 물음표도 아니다', async () => {
+    stubFetchWithConversations([{
+      id: 'conv-dm-orphan-1', type: 'dm', title: null,
+      latest_message: null, updated_at: '2026-08-29T00:00:00Z', unread_count: 0,
+      participants: [
+        { member_id: 'me-1', name: '나', avatar_url: null, type: 'human' },
+        { member_id: '767988e5-df5b-48e8-9964-7062fe84d691', name: null, avatar_url: null, type: 'human' },
+      ],
+    }]);
+    await mount();
+    const nameEl = [...container.querySelectorAll('span')].find((el) => el.textContent === '알 수 없는 멤버');
+    expect(nameEl).not.toBeUndefined();
+    expect(container.textContent).not.toContain('767988e5');
+  });
+});

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -137,7 +137,9 @@ function ConversationRow({
         <span className="rounded bg-muted px-1 py-0.5 font-medium text-muted-foreground">{t('you')}</span>
         <span>↔</span>
         <span className="max-w-[80px] truncate rounded bg-muted px-1 py-0.5 font-medium text-muted-foreground">
-          {others[0]?.name ?? '...'}
+          {/* story #3203(카디르 QA·PO 지시) — 같은 participants 계약 소비처, formatParticipantNames와
+              동일 사람언어 폴백으로 통일('...'는 비인간어). */}
+          {others[0]?.name ?? t('unknownMember')}
         </span>
         {/* story #2023 ⓑ: L5(시스템 상태), 브랜드 아님 */}
         {isAgentInConv && (
@@ -171,7 +173,7 @@ function ConversationRow({
         <span className="truncate">
           {isAgentInConv && agentCount > 0
             ? t('agentCount', { count: agentCount })
-            : `${t('personCount', { count: others.length + 1 })} · ${others.slice(0, 2).map((p) => p.name ?? '?').join(', ')}${others.length > 2 ? ` ${t('participantsOthers', { count: others.length - 2 })}` : ''}`
+            : `${t('personCount', { count: others.length + 1 })} · ${others.slice(0, 2).map((p) => p.name ?? t('unknownMember')).join(', ')}${others.length > 2 ? ` ${t('participantsOthers', { count: others.length - 2 })}` : ''}`
           }
         </span>
       </div>

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -77,10 +77,13 @@ function formatParticipantNames(
 ): string {
   const others = participants.filter((p) => p.member_id !== currentMemberId);
   if (others.length === 0) return type === 'dm' ? 'DM' : t('groupSection');
-  if (type === 'dm') return others[0]?.name ?? '?';
+  // story #3203 — 이름 해석 실패(orphan/삭제 멤버, BE participant.name=null) 폴백은
+  // '?' 1글자가 아니라 사람 언어 문구로("uuid 노출" 실사고 재발 방지 축 — BE는 raw
+  // 식별자를 아예 안 실어 보내게 고쳤으니 FE 폴백도 그 계약과 짝을 맞춘다).
+  if (type === 'dm') return others[0]?.name ?? t('unknownMember');
   const MAX = 3;
-  if (others.length <= MAX) return others.map((p) => p.name ?? '?').join(', ');
-  const visible = others.slice(0, MAX).map((p) => p.name ?? '?').join(', ');
+  if (others.length <= MAX) return others.map((p) => p.name ?? t('unknownMember')).join(', ');
+  const visible = others.slice(0, MAX).map((p) => p.name ?? t('unknownMember')).join(', ');
   return `${visible} ${t('participantsOthers', { count: others.length - MAX })}`;
 }
 

--- a/apps/web/src/components/chat/toss-sheet.test.tsx
+++ b/apps/web/src/components/chat/toss-sheet.test.tsx
@@ -227,3 +227,18 @@ describe('TossSheet — 제출(성공/409/기타 에러)', () => {
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 });
+
+// story #3203(선생님 실사고·2026-08-29) — 참가자 이름 해석 실패(BE orphan 폴백, name=null)
+// 시 uuid가 그대로 새던 표시결함 pin. conversationDisplayName의 그룹-무참가자 폴백(conv.id
+// 앞 8자)·참가자 이름 폴백('?') 둘 다 사람 언어("알 수 없는 멤버")로 통일했다.
+describe('TossSheet — 참가자 이름 해석 실패 폴백(story #3203)', () => {
+  it('DM 상대의 name이 null이면 "알 수 없는 멤버"로 뜬다 — uuid도 물음표도 아니다', async () => {
+    const convs = [
+      { id: 'conv-orphan-1', type: 'dm', title: null, participants: [{ member_id: 'member-9', name: null }, { member_id: 'member-1', name: '나' }] },
+    ];
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: convs }) })));
+    await mount();
+    expect(document.body.textContent).toContain('알 수 없는 멤버');
+    expect(document.body.textContent).not.toContain('conv-orph');
+  });
+});

--- a/apps/web/src/components/chat/toss-sheet.tsx
+++ b/apps/web/src/components/chat/toss-sheet.tsx
@@ -26,11 +26,18 @@ interface TossConversation {
 // 동형(DM은 상대 1인, group은 최대 3인+나머지 카운트) — 별도 모듈로 뽑지 않고 이 파일 소비
 // 범위만 최소 재구현한다(chat-list-view.tsx도 이미 호출부 2곳에 동형 로직을 각자 갖는
 // 관례 — 이 파일이 그 세 번째 자리라 해도 기존 컨벤션과 어긋나지 않는다).
-function conversationDisplayName(conv: TossConversation, currentTeamMemberId: string): string {
+function conversationDisplayName(
+  conv: TossConversation,
+  currentTeamMemberId: string,
+  t: (key: string) => string,
+): string {
   if (conv.title) return conv.title;
   const others = (conv.participants ?? []).filter((p) => p.member_id !== currentTeamMemberId);
-  if (others.length === 0) return conv.type === 'dm' ? 'DM' : conv.id.slice(0, 8);
-  return others.map((p) => p.name ?? '?').join(', ');
+  // story #3203 — group 무참가자 폴백이 conv.id 앞 8자를 지어냈다(uuid 노출 표시결함,
+  // chat-list-view.tsx의 formatParticipantNames와 동형 fix — unknownMember로 통일).
+  // 참가자 이름 해석 실패(BE participant.name=null)도 '?' 대신 같은 문구.
+  if (others.length === 0) return conv.type === 'dm' ? 'DM' : t('unknownMember');
+  return others.map((p) => p.name ?? t('unknownMember')).join(', ');
 }
 
 export interface TossSheetProps {
@@ -100,8 +107,8 @@ export function TossSheet({
     );
     const q = query.trim().toLowerCase();
     if (!q) return list;
-    return list.filter((c) => conversationDisplayName(c, currentTeamMemberId).toLowerCase().includes(q));
-  }, [conversations, designatedApproverId, query, currentTeamMemberId]);
+    return list.filter((c) => conversationDisplayName(c, currentTeamMemberId, t).toLowerCase().includes(q));
+  }, [conversations, designatedApproverId, query, currentTeamMemberId, t]);
 
   const submit = async () => {
     if (!selectedId) return;
@@ -119,7 +126,7 @@ export function TossSheet({
         const inserted = body?.inserted ?? true;
         setAlreadyThereIds((prev) => new Set(prev).add(selectedId));
         onOpenChange(false);
-        onTossed(target ? conversationDisplayName(target, currentTeamMemberId) : '', inserted);
+        onTossed(target ? conversationDisplayName(target, currentTeamMemberId, t) : '', inserted);
         return;
       }
       const body = await res.json().catch(() => null) as { error?: { message?: string; code?: string } } | null;
@@ -136,7 +143,8 @@ export function TossSheet({
     }
   };
 
-  const approverLabel = designatedApproverName ?? designatedApproverId.slice(0, 8);
+  // story #3203 — 결재자 이름 미해석 폴백도 같은 사람언어 문구로(예전엔 id 앞 8자 노출).
+  const approverLabel = designatedApproverName ?? t('unknownMember');
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -163,7 +171,7 @@ export function TossSheet({
             />
           ) : (
             candidates.map((c) => {
-              const name = conversationDisplayName(c, currentTeamMemberId);
+              const name = conversationDisplayName(c, currentTeamMemberId, t);
               const selected = selectedId === c.id;
               // story #3094(유나 규격 §2 .pick.done) — 이 세션에서 이미 토스 시도한 대상.
               const alreadyThere = alreadyThereIds.has(c.id);

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -406,9 +406,15 @@ async def _fetch_conversation_participants(
     conv_participants: dict[uuid.UUID, list[dict]] = defaultdict(list)
     for r in p_rows:
         resolved = resolved_map.get(r.member_id)
+        # story #3203 — `lookup_members_by_ids`는 요청한 모든 id에 값을 채운다(orphan도
+        # 자체 placeholder ResolvedMember 반환)이라 이 `resolved`가 실제로 None인 경우는
+        # 없다(all_member_ids가 비어 resolved_map={}일 때뿐인데 그럼 p_rows 자체가 없다) —
+        # 이 삼항은 방어적 죽은 분기. 예전엔 여기서도 uuid 앞 8자를 지어냈으나(FE로 그대로
+        # 새는 표시결함 원인지 중 하나), 이제 resolved.name 자체가 orphan이면 None이라
+        # (member_resolver.py 참고) FE Participant.name(`string | null`) 계약과 맞는다.
         conv_participants[r.conversation_id].append({
             "member_id": str(r.member_id),
-            "name": resolved.name if resolved else str(r.member_id)[:8],
+            "name": resolved.name if resolved else None,
             "avatar_url": getattr(resolved, "avatar_url", None) if resolved else None,
             "type": resolved.type if resolved else "human",
             "runtime_type": runtime_type_map.get(r.member_id),

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -27,10 +27,21 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ResolvedMember:
-    """통합 멤버 신원 — 휴먼(org_member.id) 또는 에이전트(team_member.id)."""
+    """통합 멤버 신원 — 휴먼(org_member.id) 또는 에이전트(team_member.id).
+
+    story #3203 — name은 orphan/삭제 멤버(TM도 OrgMember도 아닌 id, org_id=
+    uuid.UUID(int=0) sentinel) fallback에서 None일 수 있다. 예전엔 `str(id)[:8]`
+    (uuid 앞 8자)로 "이름처럼 보이는" 값을 지어냈으나, 그건 FE 화면에 raw 식별자가
+    그대로 새는 표시결함이었다(#3203 실사고 — 대화 리스트 상대명 자리에 uuid 노출).
+    소비처 4곳 전수 확認: gates.py/activity_logs.py는 이미 `if rm and rm.name`
+    truthy 가드, backlinks.py는 org_id sentinel로 orphan을 name 읽기 前에 걸러냄
+    (셋 다 None 안전) — conversations.py(_fetch_conversation_participants)만 FE로
+    그대로 흘려보내는데, FE Participant.name은 원래 `string | null`이었다(폴백
+    로직이 처음부터 null을 전제하고 설계돼 있었다는 뜻 — 이 fix는 그 계약을
+    실제로 채우는 것)."""
     id: uuid.UUID
     user_id: uuid.UUID | None      # users.id (휴먼) | None (에이전트)
-    name: str
+    name: str | None
     type: str                      # "human" | "agent"
     role: str
     org_id: uuid.UUID
@@ -290,12 +301,14 @@ async def _lookup_members_by_ids_legacy(
                 project_id=None,
             )
 
-    # orphan/삭제 멤버: TM도 OrgMember도 아닌 ID → fallback(크래시 방지)
+    # orphan/삭제 멤버: TM도 OrgMember도 아닌 ID → fallback(크래시 방지). story #3203 —
+    # name=None(예전엔 str(mid)[:8] — uuid 노출 표시결함 원인지 중 하나, ResolvedMember
+    # 클래스 docstring 참고).
     for mid in ids:
         if mid not in result:
             result[mid] = ResolvedMember(
                 id=mid, user_id=None,
-                name=str(mid)[:8],
+                name=None,
                 type="human", role="member",
                 org_id=uuid.UUID(int=0),
                 project_id=None,
@@ -388,11 +401,12 @@ async def _lookup_members_by_ids_anchor(
                 avatar_url=m.avatar_url,
             )
 
-    # 3. 진짜 orphan(member/alias 모두 없음) — telemetry-only + 크래시 방지 placeholder
+    # 3. 진짜 orphan(member/alias 모두 없음) — telemetry-only + 크래시 방지 placeholder.
+    # story #3203 — name=None(legacy 경로와 동형 fix, ResolvedMember docstring 참고).
     for oid in ids - set(result.keys()):
         logger.warning("member_resolver(anchor): unresolved orphan id=%s — no member/alias", oid)
         result[oid] = ResolvedMember(
-            id=oid, user_id=None, name=str(oid)[:8],
+            id=oid, user_id=None, name=None,
             type="human", role="member", org_id=uuid.UUID(int=0), project_id=None,
         )
 

--- a/backend/tests/test_member_ssot_phase0.py
+++ b/backend/tests/test_member_ssot_phase0.py
@@ -231,6 +231,25 @@ async def test_lookup_members_falls_back_to_org_member():
     assert result[ORG_MEMBER_ID].avatar_url is None  # story #2901 — OrgMember 소싱, 컬럼 없음
 
 
+@pytest.mark.anyio
+async def test_lookup_members_orphan_name_is_none():
+    """story #3203(선생님 실사고) — TeamMember도 OrgMember도 아닌 진짜 orphan id의
+    placeholder.name은 None이어야 한다. 예전엔 `str(mid)[:8]`로 uuid 앞 8자를 "이름"처럼
+    지어냈고, 이게 대화 리스트 상대명 자리에 raw uuid가 그대로 노출된 표시결함의 근원지
+    중 하나였다(_fetch_conversation_participants가 이 name을 FE로 그대로 흘려보냄 —
+    FE Participant.name은 원래 `string | null`이 계약이었다)."""
+    orphan_id = uuid.uuid4()
+    session = AsyncMock()
+    empty_tm = MagicMock(); empty_tm.scalars.return_value.all.return_value = []
+    empty_om = MagicMock(); empty_om.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(side_effect=[empty_tm, empty_om])  # user 쿼리는 om이 비어 skip
+
+    result = await lookup_members_by_ids({orphan_id}, session)
+    assert orphan_id in result
+    assert result[orphan_id].name is None
+    assert result[orphan_id].org_id == uuid.UUID(int=0)  # orphan sentinel(회귀 확認 겸)
+
+
 # ── _enforce_agent_creator_policy 유닛 테스트 ────────────────────────────────
 
 @pytest.mark.anyio

--- a/backend/tests/test_member_ssot_resolver_shadow.py
+++ b/backend/tests/test_member_ssot_resolver_shadow.py
@@ -166,7 +166,11 @@ async def test_anchor_lookup_alias_canonicalizes(monkeypatch):
 
 @pytest.mark.anyio
 async def test_anchor_lookup_true_orphan_telemetry(monkeypatch):
-    """member·alias 모두 없으면 telemetry-only + 크래시 방지 placeholder (가짜 resolve 아님)."""
+    """member·alias 모두 없으면 telemetry-only + 크래시 방지 placeholder (가짜 resolve 아님).
+
+    story #3203(선생님 실사고) — placeholder.name은 None이어야 한다. 예전엔 `str(id)[:8]`로
+    uuid 앞 8자를 "이름"처럼 지어냈고, 이게 대화 리스트 상대명 자리에 raw uuid가 그대로
+    노출된 표시결함의 근원지 중 하나였다(FE Participant.name은 원래 `string | null`)."""
     import app.services.member_resolver as mr
 
     monkeypatch.setattr(mr.settings, "member_ssot_resolver_shadow", True)
@@ -178,4 +182,5 @@ async def test_anchor_lookup_true_orphan_telemetry(monkeypatch):
     with patch.object(mr.logger, "warning") as mock_warn:
         out = await mr.lookup_members_by_ids({orphan}, session)
     assert orphan in out  # placeholder
+    assert out[orphan].name is None  # story #3203 — uuid 앞 8자 지어내기 금지
     assert mock_warn.called  # telemetry 로그


### PR DESCRIPTION
## 요약
- [\[챗·표시\] 대화 리스트에 상대명이 raw uuid로 노출(«767988e5») — 이름 해석 실패 시 식별자 폴백이 그대로 화면에](entity:story:264925df-42e3-47bf-b21f-06047ee7a247)
- 선생님 모바일 스크린샷 부수 관측: 대화 리스트 DM 행 상대명 자리에 «767988e5» raw uuid 노출.

## AC1(원인) — PO 승인 하에 "재현 불가·현시점 정상" 닫음
그라운딩 2라운드(PO DB 프로브 포함) — 근원 conversation을 정확히 특정(`767988e5-df5b-...`, type=dm, title="오르테가 ↔ 민 레 (E-MOBILE)"), 참가자 둘 다 생존/이름有. BE 단건조회·목록조회(admin-bypass 포함) 둘 다 지금 완전 정상 반환, conv `updated_at`이 스크린샷보다 이틀 앞서(2026-08-27) "스크린샷 이후 title 세팅" 가설도 기각. `git blame`으로 관련 FE 코드(ConversationRow displayName 3개월+ 무변경, toss-sheet 생성 후 무수정)가 최근 변경되지 않았음도 확認 — "이미 고쳐진 옛 결함" 흔적 0건. 유력 잔존 가설(SSE title-rename 이벤트 커버리지 갭 — 선생님 세션이 title-null 시절 캐시를 물고 있었을 가능성)은 **후보 등재만**, 이번 스코프 밖.

## AC2(표시) — 이번 PR 스코프
uuid 폴백 근원은 `member_resolver.py`의 orphan/삭제 멤버 fallback이 `str(id)[:8]`로 uuid 앞 8자를 "이름"처럼 지어내던 것(legacy·anchor 경로 둘 다). 소비처 4곳 전수 확認 후(gates.py/activity_logs.py는 이미 truthy 가드, backlinks.py는 org_id sentinel로 orphan을 name 읽기 前에 걸러냄 — 셋 다 None 안전) `ResolvedMember.name`을 `str | None`으로 넓히고 orphan fallback을 `None`으로 교체. FE는 그 null을 신규 i18n 키 `chats.unknownMember`("알 수 없는 멤버"/"Unknown member")로 폴백 — chat-list-view.tsx `formatParticipantNames` 3곳 + toss-sheet.tsx `conversationDisplayName` group-무참가자/결재자 이름 폴백 2곳, 총 5개 호출부 통일.

## 검증
- 신규 BE pin: legacy·anchor 양쪽 orphan `.name is None` — mock 기반 68 GREEN.
- 신규 FE pin: chat-list-view 20/20, toss-sheet 9/9 GREEN — `name: null` 참가자가 "알 수 없는 멤버"로 뜨고 uuid는 안 새는 것 고정.
- tsc 0 · lint 0(무관 기존 5건) · 전체 vitest 532파일/4991건 GREEN · build GREEN.
- 전체 backend pytest(-m "not destructive_schema") 5067 passed · 14 failed 전수 확認 — 전부 realdb URL 미설정/mcp 인스턴스·경로 의존(이 세션 기존 환경 갭, 이번 변경과 무관 파일들).

prod 무접촉(develop 대상).