### PR TITLE
[온보딩·3196-⑤] 인증·비밀번호 재설정 이메일 카피/톤 배선

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -603,13 +603,20 @@ async def register(
         verification_token = create_email_verification_token(str(user.id))
         app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
         verify_link = f"{app_url}/verify-email?token={verification_token}"
-        from app.services.email import send_email
+        from app.services.email import render_action_email, send_email
         delivered = send_email(
             to=user.email,
-            subject="Sprintable 이메일 인증",
-            html_body=(
-                f"<p>아래 링크를 클릭하여 이메일 인증을 완료해 주세요. 24시간 유효합니다.</p>"
-                f"<p><a href='{verify_link}'>이메일 인증하기</a></p>"
+            # story #3196-⑤(유나 카피·톤 제안) — 기존 "Sprintable 이메일 인증"에서 행위형으로.
+            subject="Sprintable 이메일 인증을 완료해 주세요",
+            html_body=render_action_email(
+                intro_lines=[
+                    "Sprintable에 가입해 주셔서 감사합니다.",
+                    "아래 버튼을 눌러 이메일 인증을 완료하시면 바로 시작하실 수 있습니다.",
+                ],
+                cta_label="이메일 인증하기",
+                cta_url=verify_link,
+                expiry_note="이 링크는 24시간 동안 유효합니다.",
+                security_note="본인이 요청한 가입이 아니라면 이 메일을 무시하셔도 됩니다.",
             ),
         )
         if not delivered:
@@ -1431,14 +1438,20 @@ async def forgot_password(
         token = create_password_reset_token(str(user.id), user.hashed_password)
         app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
         reset_link = f"{app_url}/reset-password?token={token}"
-        from app.services.email import send_email
+        from app.services.email import render_action_email, send_email
         send_email(
             to=user.email,
-            subject="Sprintable 비밀번호 재설정",
-            html_body=(
-                f"<p>비밀번호 재설정 링크입니다. 30분 내에 사용 바랍니다.</p>"
-                f"<p><a href='{reset_link}'>비밀번호 재설정</a></p>"
-                f"<p>요청하지 않으셨다면 이 메일을 무시하세요.</p>"
+            # story #3196-⑤(유나 카피·톤 제안)
+            subject="Sprintable 비밀번호 재설정 안내",
+            html_body=render_action_email(
+                intro_lines=[
+                    "비밀번호 재설정을 요청하셨습니다.",
+                    "아래 버튼을 눌러 새 비밀번호를 설정해 주세요.",
+                ],
+                cta_label="비밀번호 재설정",
+                cta_url=reset_link,
+                expiry_note="이 링크는 30분 동안 유효합니다.",
+                security_note="본인이 요청하지 않으셨다면 이 메일을 무시하셔도 됩니다 — 비밀번호는 변경되지 않습니다.",
             ),
         )
     return _ok({"message": "If the email exists, a reset link has been sent"})
@@ -1560,13 +1573,21 @@ async def resend_verification(
     verification_token = create_email_verification_token(str(user.id))
     app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
     verify_link = f"{app_url}/verify-email?token={verification_token}"
-    from app.services.email import send_email
+    # story #3196-⑤ — register()의 인증메일과 동일 카피/렌더러(발명 0, 같은 내용의 재발송이라
+    # 두 벌 카피를 유지할 이유가 없다 — 여태 문자 그대로 중복이었던 자리 그대로 정합).
+    from app.services.email import render_action_email, send_email
     delivered = send_email(
         to=user.email,
-        subject="Sprintable 이메일 인증",
-        html_body=(
-            f"<p>아래 링크를 클릭하여 이메일 인증을 완료해 주세요. 24시간 유효합니다.</p>"
-            f"<p><a href='{verify_link}'>이메일 인증하기</a></p>"
+        subject="Sprintable 이메일 인증을 완료해 주세요",
+        html_body=render_action_email(
+            intro_lines=[
+                "Sprintable에 가입해 주셔서 감사합니다.",
+                "아래 버튼을 눌러 이메일 인증을 완료하시면 바로 시작하실 수 있습니다.",
+            ],
+            cta_label="이메일 인증하기",
+            cta_url=verify_link,
+            expiry_note="이 링크는 24시간 동안 유효합니다.",
+            security_note="본인이 요청한 가입이 아니라면 이 메일을 무시하셔도 됩니다.",
         ),
     )
     if not delivered:

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,4 +1,5 @@
 """이메일 발송 서비스 — Resend API 우선, SMTP fallback, 콘솔 최종 fallback."""
+import html
 import logging
 import os
 import smtplib
@@ -6,6 +7,43 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 logger = logging.getLogger(__name__)
+
+
+def render_action_email(
+    *,
+    intro_lines: list[str],
+    cta_label: str,
+    cta_url: str,
+    expiry_note: str,
+    security_note: str,
+) -> str:
+    """story #3196-⑤(카피·톤 제안 — 유나 홀름, doc auth-email-copy-proposal-3196) — 인사/
+    맥락 → CTA 버튼 → 만료 → 폴백 평문 링크 → 보안 안내, 트랜잭셔널 메일 3종(가입 인증·
+    인증 재발송·비밀번호 재설정) 공용 골격. 리마인드 메일(_reminder_email_body)과 같은
+    합니다체·구조를 쓰되, 그쪽은 마케팅성(수신거부 있음)이라 별도 함수로 남긴다 — 이
+    렌더러는 트랜잭셔널 전용(보안 안내가 필수 파라미터인 이유).
+
+    카피·톤·구조는 제안 그대로, 버튼 인라인 CSS는 이 함수(배선측 권한, 제안 doc 명시)
+    — 이메일 클라이언트 호환을 위해 flexbox/grid 없이 순수 인라인 스타일만 사용.
+    cta_url은 이미 서버가 만든 신뢰 URL(app_url + 서버 발급 토큰)만 들어온다 — 사용자
+    입력이 아니므로 URL 자체는 escape하지 않되(속성값 내 홑따옴표가 안 섞이는 내부 생성값),
+    사람이 쓰는 텍스트(intro_lines·cta_label·expiry_note·security_note)는 html.escape로
+    XSS/마크업 주입을 방지한다.
+    """
+    intro_html = "".join(f"<p>{html.escape(line)}</p>" for line in intro_lines)
+    return (
+        f"{intro_html}"
+        f"<p style='margin:24px 0'>"
+        f"<a href='{cta_url}' "
+        f"style='display:inline-block;padding:12px 24px;background:#2952E3;color:#ffffff;"
+        f"text-decoration:none;border-radius:6px;font-weight:600'>"
+        f"{html.escape(cta_label)}</a></p>"
+        f"<p>{html.escape(expiry_note)}</p>"
+        f"<p style='font-size:12px;color:#595959'>"
+        f"버튼이 열리지 않으면 아래 주소를 브라우저에 붙여넣어 주세요:<br>"
+        f"<a href='{cta_url}'>{cta_url}</a></p>"
+        f"<p style='font-size:12px;color:#595959'>{html.escape(security_note)}</p>"
+    )
 
 
 def send_email(to: str, subject: str, html_body: str) -> bool:

--- a/backend/tests/test_render_action_email.py
+++ b/backend/tests/test_render_action_email.py
@@ -1,0 +1,56 @@
+"""story #3196-⑤(유나 카피·톤 제안 배선) — render_action_email() 공용 렌더러 pin.
+
+트랜잭셔널 메일 3종(가입 인증·인증 재발송·비밀번호 재설정)이 전부 이 함수를 쓴다 — 골격
+(인사/맥락→CTA 버튼→만료→폴백 링크→보안 안내)과 escape 정직성만 순수 단위테스트로 고정.
+"""
+from __future__ import annotations
+
+from app.services.email import render_action_email
+
+
+def test_renders_all_sections_in_order():
+    html_body = render_action_email(
+        intro_lines=["첫 줄", "둘째 줄"],
+        cta_label="버튼 라벨",
+        cta_url="https://app.sprintable.ai/verify-email?token=abc",
+        expiry_note="24시간 유효",
+        security_note="요청 안 했으면 무시하세요",
+    )
+    for expected in ("첫 줄", "둘째 줄", "버튼 라벨", "24시간 유효", "요청 안 했으면 무시하세요"):
+        assert expected in html_body
+    # cta_url이 버튼 href·폴백 링크 href·폴백 링크의 가시 텍스트 3곳에 실린다(버튼이 안
+    # 뜨는 클라이언트 대비 — 폴백은 href뿐 아니라 사람이 직접 복사할 수 있게 텍스트로도 보임).
+    assert html_body.count("https://app.sprintable.ai/verify-email?token=abc") == 3
+    # 순서: intro가 버튼보다 먼저, 버튼이 만료 안내보다 먼저, 만료가 보안 안내보다 먼저.
+    idx_intro = html_body.index("첫 줄")
+    idx_cta = html_body.index("버튼 라벨")
+    idx_expiry = html_body.index("24시간 유효")
+    idx_security = html_body.index("요청 안 했으면 무시하세요")
+    assert idx_intro < idx_cta < idx_expiry < idx_security
+
+
+def test_escapes_html_in_user_facing_text_but_not_url():
+    """intro_lines/cta_label/expiry_note/security_note는 이 레포 내부 리터럴이지만, 이 함수
+    자체가 «신뢰 못 할 입력이 들어와도 마크업 주입이 안 된다»는 계약을 지켜야 한다 — cta_url은
+    서버가 만든 토큰 URL이라 escape 대상이 아니다(계약 그대로: URL은 원문 유지)."""
+    html_body = render_action_email(
+        intro_lines=["<script>alert(1)</script>"],
+        cta_label="<b>버튼</b>",
+        cta_url="https://app.sprintable.ai/x?token=a&b=1",
+        expiry_note="<i>만료</i>",
+        security_note="<u>보안</u>",
+    )
+    assert "<script>" not in html_body
+    assert "&lt;script&gt;" in html_body
+    assert "<b>버튼</b>" not in html_body
+    assert "&lt;b&gt;버튼&lt;/b&gt;" in html_body
+    # URL 자체는 그대로(escape로 깨지면 안 됨 — & 등이 %26으로 변형되지 않는다).
+    assert "https://app.sprintable.ai/x?token=a&b=1" in html_body
+
+
+def test_no_flexbox_or_grid_inline_style_for_email_client_compat():
+    html_body = render_action_email(
+        intro_lines=["줄"], cta_label="라벨", cta_url="https://x", expiry_note="만료", security_note="보안",
+    )
+    assert "display:flex" not in html_body
+    assert "display:grid" not in html_body


### PR DESCRIPTION
[SID:3196]

## 요약
story #3196 항목 ⑤(인증 메일이 극도로 밋밋 — 본문 한 줄+링크뿐, 환영 문구·브랜드·다음 단계 안내 0)의 배선. 카피·톤은 [인증 메일 카피·톤 제안 (3196-⑤)](entity:doc:c21c5553-e93f-4d93-8d4b-324a8d212d17)(유나 홀름, PO confirm 済·무수정) 그대로입니다. ①②③④⑥은 #3601로 이미 머지되어 이 PR은 ⑤만 다룹니다.

## 변경

### 공용 렌더러 추출 — `email.py::render_action_email()`
제안 doc의 권장(강제 아님, 배선 판단은 이쪽 몫)에 따라 트랜잭셔널 메일 3종이 공유하는 골격(인사/맥락 → CTA 버튼 → 만료 안내 → 폴백 평문 링크 → 보안 안내)을 추출했습니다. 리마인드 메일(`onboarding_activation.py::_reminder_email_body`)과는 별도로 유지합니다 — 그쪽은 마케팅성(수신거부 링크 포함)이라 성격이 다릅니다.

- 버튼 인라인 CSS는 이메일 클라이언트 호환을 위해 flexbox/grid 없이 순수 인라인 스타일만 사용(배선측 재량, 제안 doc이 명시적으로 위임).
- 사람이 보는 텍스트(intro/cta_label/expiry/security)는 `html.escape`, `cta_url`(서버가 만든 토큰 URL, 사용자 입력 아님)은 원문 유지.

### 배선 3곳
1. `register()` — 가입 인증 메일: "Sprintable 이메일 인증" → "Sprintable 이메일 인증을 완료해 주세요"
2. `resend_verification()` — 인증 재발송: register()와 **문자 그대로 동일했던 옛 카피**를 그대로 정합(발견 즉시 수정 — 두 벌 카피 유지할 이유가 없어 같은 렌더러 호출로 통일)
3. `forgot_password()` — 비밀번호 재설정: "Sprintable 비밀번호 재설정" → "Sprintable 비밀번호 재설정 안내"

## 스코프 밖(제안 doc이 이미 범위 밖으로 명기)
- locale(ko) 하드코딩 — en 사용자도 ko 메일을 받는 상태는 무변경. 별도 i18n 과제 후보로 doc에 이미 기록됨.
- CTA 버튼의 세부 시각 디자인(그라디언트, 폰트 등)은 이번 PR의 실용적 인라인 스타일 수준에 그칩니다.

## 테스트
- `backend/tests/test_render_action_email.py` 신규 3종 — 구조 순서(intro→CTA→만료→폴백→보안)·escape 정직성(사용자 텍스트는 escape, cta_url은 원문 유지)·이메일 클라이언트 호환(flex/grid 미사용) pin.
- 관련 기존 스위트 22개(`test_auth_email_verification`·`test_auth_password_reset`·`test_register_email_delivered`·`test_2444_resend_verification_rate_limit_redis`·`test_register_email_silent_fail` 등) — 전부 pass, 회귀 0(옛 카피를 하드코딩해 검증하던 테스트 0건이라 충돌 없음).
- `ast.parse` 구문 확認.
- **라이브 실측(dev 실제 발송 또는 콘솔 폴백으로 카피 확認)은 배포 후 별도** — 이 PR 스코프 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)