### PR TITLE
[SID:3205] 발송 메일 언어를 유저 로케일로 분기

### DIFF
--- a/backend/alembic/versions/0290_users_locale.py
+++ b/backend/alembic/versions/0290_users_locale.py
@@ -1,0 +1,41 @@
+"""story #3205(선생님 방향 결정 2026-08-29) — users에 locale 판별원 신설.
+
+발송 메일 7종이 수신자 무관 고정 언어였던 문제(트랜잭셔널 3종+리마인드+초대=ko 고정,
+운영 알림 2종=en 고정)의 근본은 "유저 로케일을 물어볼 곳이 없다"였다 — 판별원 실측
+결과 users에 locale 컬럼 없음, FE도 쿠키 전용(story 11f1087c 크루스 — 라이브 렌더용
+locale은 의도적으로 DB에 안 둔다)이라 async 발송(cron 리마인드 등, 살아있는 요청이
+없는 경로) 시점엔 그 쿠키를 읽을 수 없다.
+
+이 컬럼은 그 크루스를 뒤집는 게 아니라 다른 축이다 — FE 라이브 렌더링은 여전히 쿠키
+기준(그대로 유지), 이건 "계정에 매달린, 요청 밖에서도 읽을 수 있는" 발송 전용 신호.
+nullable — 가입 시 Accept-Language로 1회 포착(추측 아님, agents.py/role_templates.py 등
+기존 여러 엔드포인트가 이미 쓰는 resolve_locale_from_request와 동일 파싱 재사용)하되
+기존 유저는 채워지지 않는다. 폴백 규칙은 코드(resolve_locale, DEFAULT_LOCALE="ko")와
+동일 — 이 마이그레이션은 백필하지 않는다(과거 유저의 실제 선호를 아는 방법이 없어
+추측 백필은 오히려 거짓 신호).
+
+Revision ID: 0290
+Revises: 0289
+Create Date: 2026-08-29
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0290"
+down_revision = "0289"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("locale", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "locale")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -25,6 +25,11 @@ class User(Base):
     totp_fail_count: Mapped[int] = mapped_column(nullable=False, default=0)
     totp_locked_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     display_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #3205 — 발송 메일 로케일 분기 판별원. FE 라이브 렌더링 locale은 여전히 쿠키
+    # 전용(story 11f1087c 크루스 무회귀) — 이건 요청 밖(cron 등)에서도 읽을 수 있는
+    # 발송 전용 신호. nullable, 가입 시 Accept-Language로 1회 포착. None이면
+    # resolve_locale()이 DEFAULT_LOCALE("ko")로 폴백한다(추측 백필 없음).
+    locale: Mapped[str | None] = mapped_column(Text, nullable=True)
     google_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
     # story #2155(2026-07-23): GitHub 로그인 자체를 제거했다(app/routers/auth.py — provider
     # dispatch에서 "github" 삭제). 이 컬럼은 로그인 외 용도가 0곳(PO grep 확認 — 커밋 귀속·

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -622,6 +622,7 @@ async def register(
                 cta_url=verify_link,
                 expiry_note=copy["expiry_note"],
                 security_note=copy["security_note"],
+                fallback_label=copy["fallback_label"],
             ),
         )
         if not delivered:
@@ -1460,6 +1461,7 @@ async def forgot_password(
                 cta_url=reset_link,
                 expiry_note=copy["expiry_note"],
                 security_note=copy["security_note"],
+                fallback_label=copy["fallback_label"],
             ),
         )
     return _ok({"message": "If the email exists, a reset link has been sent"})
@@ -1597,6 +1599,7 @@ async def resend_verification(
             cta_url=verify_link,
             expiry_note=copy["expiry_note"],
             security_note=copy["security_note"],
+            fallback_label=copy["fallback_label"],
         ),
     )
     if not delivered:

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -568,6 +568,7 @@ async def register(
     if existing:
         return _err("EMAIL_TAKEN", "Email already registered", 409)
 
+    from app.services.agent_onboarding_config import resolve_locale_from_request
     user = User(
         email=body.email,
         hashed_password=hash_password(body.password),
@@ -575,6 +576,10 @@ async def register(
         is_active=True,
         email_verified=False,
         tos_accepted_at=datetime.now(timezone.utc),
+        # story #3205 — 가입 시 Accept-Language 1회 포착(agents.py 등 기존 엔드포인트와
+        # 동일 헬퍼 재사용, 새 파서 발명 없음). FE 명시 전달값은 없음(가입 폼에 locale
+        # 필드가 없다) — 브라우저가 항상 보내는 헤더뿐이라 FE 변경 불요.
+        locale=resolve_locale_from_request(None, request.headers.get("accept-language")),
     )
     session.add(user)
     try:
@@ -603,20 +608,20 @@ async def register(
         verification_token = create_email_verification_token(str(user.id))
         app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
         verify_link = f"{app_url}/verify-email?token={verification_token}"
+        from app.services.agent_onboarding_config import resolve_locale
         from app.services.email import render_action_email, send_email
+        from app.services.email_copy import TRANSACTIONAL_COPY
+        # story #3205 — locale=ko 유저 → ko 메일·locale=en 유저 → en 메일(AC1).
+        copy = TRANSACTIONAL_COPY["verify_email"][resolve_locale(user.locale)]
         delivered = send_email(
             to=user.email,
-            # story #3196-⑤(유나 카피·톤 제안) — 기존 "Sprintable 이메일 인증"에서 행위형으로.
-            subject="Sprintable 이메일 인증을 완료해 주세요",
+            subject=copy["subject"],
             html_body=render_action_email(
-                intro_lines=[
-                    "Sprintable에 가입해 주셔서 감사합니다.",
-                    "아래 버튼을 눌러 이메일 인증을 완료하시면 바로 시작하실 수 있습니다.",
-                ],
-                cta_label="이메일 인증하기",
+                intro_lines=copy["intro_lines"],
+                cta_label=copy["cta_label"],
                 cta_url=verify_link,
-                expiry_note="이 링크는 24시간 동안 유효합니다.",
-                security_note="본인이 요청한 가입이 아니라면 이 메일을 무시하셔도 됩니다.",
+                expiry_note=copy["expiry_note"],
+                security_note=copy["security_note"],
             ),
         )
         if not delivered:
@@ -1192,6 +1197,7 @@ async def oauth_authorize(provider: str) -> JSONResponse:
 
 @router.post("/oauth/callback")
 async def oauth_callback(
+    request: Request,
     body: OAuthCallbackRequest,
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
@@ -1245,12 +1251,15 @@ async def oauth_callback(
             # 신규 유저 생성 (비밀번호 없음 — OAuth 전용, 이메일 인증 완료)
             if not body.tos_accepted:
                 return _err("TOS_NOT_ACCEPTED", "You must accept the Terms of Service to register", 400)
+            from app.services.agent_onboarding_config import resolve_locale_from_request
             user = User(
                 email=email,
                 hashed_password="",
                 is_active=True,
                 email_verified=True,
                 tos_accepted_at=datetime.now(timezone.utc),
+                # story #3205 — register()와 동일 포착(발명 0).
+                locale=resolve_locale_from_request(None, request.headers.get("accept-language")),
                 **{f"{provider}_id": oauth_id},
             )
             session.add(user)
@@ -1438,20 +1447,19 @@ async def forgot_password(
         token = create_password_reset_token(str(user.id), user.hashed_password)
         app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
         reset_link = f"{app_url}/reset-password?token={token}"
+        from app.services.agent_onboarding_config import resolve_locale
         from app.services.email import render_action_email, send_email
+        from app.services.email_copy import TRANSACTIONAL_COPY
+        copy = TRANSACTIONAL_COPY["reset_password"][resolve_locale(user.locale)]
         send_email(
             to=user.email,
-            # story #3196-⑤(유나 카피·톤 제안)
-            subject="Sprintable 비밀번호 재설정 안내",
+            subject=copy["subject"],
             html_body=render_action_email(
-                intro_lines=[
-                    "비밀번호 재설정을 요청하셨습니다.",
-                    "아래 버튼을 눌러 새 비밀번호를 설정해 주세요.",
-                ],
-                cta_label="비밀번호 재설정",
+                intro_lines=copy["intro_lines"],
+                cta_label=copy["cta_label"],
                 cta_url=reset_link,
-                expiry_note="이 링크는 30분 동안 유효합니다.",
-                security_note="본인이 요청하지 않으셨다면 이 메일을 무시하셔도 됩니다 — 비밀번호는 변경되지 않습니다.",
+                expiry_note=copy["expiry_note"],
+                security_note=copy["security_note"],
             ),
         )
     return _ok({"message": "If the email exists, a reset link has been sent"})
@@ -1575,19 +1583,20 @@ async def resend_verification(
     verify_link = f"{app_url}/verify-email?token={verification_token}"
     # story #3196-⑤ — register()의 인증메일과 동일 카피/렌더러(발명 0, 같은 내용의 재발송이라
     # 두 벌 카피를 유지할 이유가 없다 — 여태 문자 그대로 중복이었던 자리 그대로 정합).
+    # story #3205 — locale 분기도 register()와 동일 사전(TRANSACTIONAL_COPY) 재사용.
+    from app.services.agent_onboarding_config import resolve_locale
     from app.services.email import render_action_email, send_email
+    from app.services.email_copy import TRANSACTIONAL_COPY
+    copy = TRANSACTIONAL_COPY["verify_email"][resolve_locale(user.locale)]
     delivered = send_email(
         to=user.email,
-        subject="Sprintable 이메일 인증을 완료해 주세요",
+        subject=copy["subject"],
         html_body=render_action_email(
-            intro_lines=[
-                "Sprintable에 가입해 주셔서 감사합니다.",
-                "아래 버튼을 눌러 이메일 인증을 완료하시면 바로 시작하실 수 있습니다.",
-            ],
-            cta_label="이메일 인증하기",
+            intro_lines=copy["intro_lines"],
+            cta_label=copy["cta_label"],
             cta_url=verify_link,
-            expiry_note="이 링크는 24시간 동안 유효합니다.",
-            security_note="본인이 요청한 가입이 아니라면 이 메일을 무시하셔도 됩니다.",
+            expiry_note=copy["expiry_note"],
+            security_note=copy["security_note"],
         ),
     )
     if not delivered:

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -24,7 +24,9 @@ from app.models.hitl import HitlRequest
 from app.models.org_subscription import OrgSubscription
 from app.models.project import OrgMember
 from app.models.user import User
+from app.services.agent_onboarding_config import resolve_locale
 from app.services.email import send_email
+from app.services.email_copy import AU_WARN_COPY, STORAGE_WARN_COPY
 from app.services.storage import get_storage_provider
 
 logger = logging.getLogger(__name__)
@@ -909,9 +911,9 @@ async def storage_usage_warn(
                 and (now - sub.storage_warn_notified_at) < _STORAGE_WARN_COOLDOWN
             ):
                 continue  # cooldown 내 — 재발송 금지(dedup)
-            emails = [
-                r[0] for r in (await session.execute(
-                    select(User.email)
+            recipients = [
+                r for r in (await session.execute(
+                    select(User.email, User.locale)
                     .join(OrgMember, User.id == OrgMember.user_id)
                     .where(
                         OrgMember.org_id == sub.org_id,
@@ -921,13 +923,11 @@ async def storage_usage_warn(
                 )).all()
             ]
             pct = round(used / cap_bytes * 100, 1)
-            subject = f"[Sprintable] Storage usage at {pct}%"
-            html = (
-                f"<p>Your organization's storage usage has reached <b>{pct}%</b> "
-                f"({used // (1024 * 1024)}MB / {cap_mb}MB).</p>"
-                f"<p>Free up space (delete unused files) or upgrade your plan to avoid upload limits.</p>"
-            )
-            for em in emails:
+            # story #3205(AC3) — 어드민 locale 기준 분기(수신자별 개별). 기존엔 en 고정이었다.
+            for em, locale_value in recipients:
+                copy = STORAGE_WARN_COPY[resolve_locale(locale_value)]
+                subject = copy["subject"].format(pct=pct)
+                html = copy["body"].format(pct=pct, used_mb=used // (1024 * 1024), cap_mb=cap_mb)
                 try:
                     await asyncio.to_thread(send_email, em, subject, html)
                 except Exception:
@@ -1023,9 +1023,9 @@ async def au_usage_warn(
                     sub.au_warn_90_notified_at is None
                     or (now - sub.au_warn_90_notified_at) >= _AU_WARN_90_COOLDOWN
                 ):
-                    emails = [
-                        r[0] for r in (await session.execute(
-                            select(User.email)
+                    recipients = [
+                        r for r in (await session.execute(
+                            select(User.email, User.locale)
                             .join(OrgMember, User.id == OrgMember.user_id)
                             .where(
                                 OrgMember.org_id == sub.org_id,
@@ -1035,14 +1035,11 @@ async def au_usage_warn(
                         )).all()
                     ]
                     pct_display = round(pct * 100, 1)
-                    subject = f"[Sprintable] Automation usage (AU) at {pct_display}%"
-                    html = (
-                        f"<p>Your organization's automation usage (AU) has reached "
-                        f"<b>{pct_display}%</b> ({current} / {au_limit} AU this month).</p>"
-                        f"<p>At 100% MCP/API writes and automation will pause (reads and human "
-                        f"UI stay available). Consider upgrading before the limit is reached.</p>"
-                    )
-                    for em in emails:
+                    # story #3205(AC3) — 어드민 locale 기준 분기(수신자별 개별). 기존엔 en 고정.
+                    for em, locale_value in recipients:
+                        copy = AU_WARN_COPY[resolve_locale(locale_value)]
+                        subject = copy["subject"].format(pct=pct_display)
+                        html = copy["body"].format(pct=pct_display, current=current, au_limit=au_limit)
                         try:
                             await asyncio.to_thread(send_email, em, subject, html)
                         except Exception:

--- a/backend/app/routers/org_invites.py
+++ b/backend/app/routers/org_invites.py
@@ -15,6 +15,22 @@ from app.services.org_invite_email import send_invite_email
 router = APIRouter(prefix="/api/v2/organizations", tags=["org-invites", "Organization"])
 
 
+async def _resolve_invitee_locale(session: AsyncSession, email: str) -> str:
+    """story #3205 — 피초대자가 이미 이 플랫폼의 기존 유저(다른 org에서 가입 이력)면
+    그 계정의 locale, 아니면(아직 계정 없는 신규 피초대자 — 절대다수) DEFAULT_LOCALE로
+    폴백한다. 신규 피초대자는 물어볼 곳 자체가 없다(가입 前) — 여기서 추측하지 않고
+    기존 ko 고정 동작을 그대로 유지(무회귀)."""
+    from sqlalchemy import select
+
+    from app.models.user import User
+    from app.services.agent_onboarding_config import resolve_locale
+
+    locale_value = (
+        await session.execute(select(User.locale).where(User.email == email))
+    ).scalar_one_or_none()
+    return resolve_locale(locale_value)
+
+
 def _to_response(invite) -> OrgInviteResponse:
     """Invitation ORM → OrgInviteResponse. pending + 미만료인 경우만 invite_url 세팅."""
     base = OrgInviteResponse.model_validate(invite)
@@ -94,7 +110,10 @@ async def create_org_invite(
         __import__("app.models.organization", fromlist=["Organization"]).Organization, id
     )
     org_name = org.name if org else str(id)
-    error = send_invite_email(to=invite.email, org_name=org_name, token=invite.token, role=invite.role)
+    invitee_locale = await _resolve_invitee_locale(session, invite.email)
+    error = send_invite_email(
+        to=invite.email, org_name=org_name, token=invite.token, role=invite.role, locale=invitee_locale,
+    )
     sent_at = None if error else datetime.now(timezone.utc)
     await invite_repo.update_email_result(invite.id, sent_at=sent_at, error=error)
     await session.commit()
@@ -125,7 +144,10 @@ async def resend_org_invite(
         __import__("app.models.organization", fromlist=["Organization"]).Organization, id
     )
     org_name = org.name if org else str(id)
-    error = send_invite_email(to=invite.email, org_name=org_name, token=invite.token, role=invite.role)
+    invitee_locale = await _resolve_invitee_locale(session, invite.email)
+    error = send_invite_email(
+        to=invite.email, org_name=org_name, token=invite.token, role=invite.role, locale=invitee_locale,
+    )
     sent_at = None if error else datetime.now(timezone.utc)
     await invite_repo.update_email_result(invite.id, sent_at=sent_at, error=error)
     await session.commit()

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -16,6 +16,7 @@ def render_action_email(
     cta_url: str,
     expiry_note: str,
     security_note: str,
+    fallback_label: str,
 ) -> str:
     """story #3196-⑤(카피·톤 제안 — 유나 홀름, doc auth-email-copy-proposal-3196) — 인사/
     맥락 → CTA 버튼 → 만료 → 폴백 평문 링크 → 보안 안내, 트랜잭셔널 메일 3종(가입 인증·
@@ -27,8 +28,12 @@ def render_action_email(
     — 이메일 클라이언트 호환을 위해 flexbox/grid 없이 순수 인라인 스타일만 사용.
     cta_url은 이미 서버가 만든 신뢰 URL(app_url + 서버 발급 토큰)만 들어온다 — 사용자
     입력이 아니므로 URL 자체는 escape하지 않되(속성값 내 홑따옴표가 안 섞이는 내부 생성값),
-    사람이 쓰는 텍스트(intro_lines·cta_label·expiry_note·security_note)는 html.escape로
-    XSS/마크업 주입을 방지한다.
+    사람이 쓰는 텍스트(intro_lines·cta_label·expiry_note·security_note·fallback_label)는
+    html.escape로 XSS/마크업 주입을 방지한다.
+
+    story #3205 QA(까디르, 2026-08-29) — fallback_label이 예전엔 렌더러 내부에 ko로
+    하드코딩돼 있어 en 메일에도 한국어 한 줄이 섞였다(호출자가 카피를 100% 못 갈아끼우는
+    구조적 결함). 다른 4개 필드와 동형으로 파라미터화.
     """
     intro_html = "".join(f"<p>{html.escape(line)}</p>" for line in intro_lines)
     return (
@@ -40,7 +45,7 @@ def render_action_email(
         f"{html.escape(cta_label)}</a></p>"
         f"<p>{html.escape(expiry_note)}</p>"
         f"<p style='font-size:12px;color:#595959'>"
-        f"버튼이 열리지 않으면 아래 주소를 브라우저에 붙여넣어 주세요:<br>"
+        f"{html.escape(fallback_label)}<br>"
         f"<a href='{cta_url}'>{cta_url}</a></p>"
         f"<p style='font-size:12px;color:#595959'>{html.escape(security_note)}</p>"
     )

--- a/backend/app/services/email_copy.py
+++ b/backend/app/services/email_copy.py
@@ -21,6 +21,7 @@ TRANSACTIONAL_COPY: dict[str, dict[str, dict]] = {
             "cta_label": "이메일 인증하기",
             "expiry_note": "이 링크는 24시간 동안 유효합니다.",
             "security_note": "본인이 요청한 가입이 아니라면 이 메일을 무시하셔도 됩니다.",
+            "fallback_label": "버튼이 열리지 않으면 아래 주소를 브라우저에 붙여넣어 주세요:",
         },
         "en": {
             "subject": "Please verify your Sprintable email",
@@ -31,6 +32,8 @@ TRANSACTIONAL_COPY: dict[str, dict[str, dict]] = {
             "cta_label": "Verify email",
             "expiry_note": "This link is valid for 24 hours.",
             "security_note": "If you didn't sign up for this, you can safely ignore this email.",
+            # 유나 홀름 결선(2026-08-29) — 초대 메일 기존 en 폴백과 자구 정렬(work/open 통일).
+            "fallback_label": "If the button doesn't work, paste this address into your browser:",
         },
     },
     "reset_password": {
@@ -43,6 +46,7 @@ TRANSACTIONAL_COPY: dict[str, dict[str, dict]] = {
             "cta_label": "비밀번호 재설정",
             "expiry_note": "이 링크는 30분 동안 유효합니다.",
             "security_note": "본인이 요청하지 않으셨다면 이 메일을 무시하셔도 됩니다 — 비밀번호는 변경되지 않습니다.",
+            "fallback_label": "버튼이 열리지 않으면 아래 주소를 브라우저에 붙여넣어 주세요:",
         },
         "en": {
             "subject": "Reset your Sprintable password",
@@ -53,6 +57,7 @@ TRANSACTIONAL_COPY: dict[str, dict[str, dict]] = {
             "cta_label": "Reset password",
             "expiry_note": "This link is valid for 30 minutes.",
             "security_note": "If you didn't request this, you can safely ignore this email — your password will not be changed.",
+            "fallback_label": "If the button doesn't open, paste this address into your browser:",
         },
     },
 }

--- a/backend/app/services/email_copy.py
+++ b/backend/app/services/email_copy.py
@@ -88,18 +88,22 @@ INVITE_COPY: dict[str, dict[str, str]] = {
         "sub_body": "아래 버튼을 클릭하면 초대를 수락할 수 있습니다. 링크는 7일간 유효합니다.",
         "cta_label": "초대 수락하기",
         "fallback_label": "버튼이 보이지 않으면 아래 주소를 브라우저에 붙여 넣으세요:",
-        "footer": "© 2025 Sprintable. 이 이메일은 초대 발송으로 자동 생성되었습니다.",
+        # 유나 검수 수정의견①(2026-08-29, doc email-locale-copy-proposal-3205) — 고정 연도 stale
+        # 방지, 동적 {year} 삽입(발송 시점 기준).
+        "footer": "© {year} Sprintable. 이 이메일은 초대 발송으로 자동 생성되었습니다.",
         "default_inviter": "팀 관리자",
         "html_lang": "ko",
     },
     "en": {
         "subject": "[Sprintable] You've been invited to {org_name}",
         "heading": "You're invited!",
-        "body": "<strong>{inviter_name}</strong> invited you to join <strong>{org_name}</strong> as <strong>{role}</strong>.",
+        # 유나 검수 수정의견②(2026-08-29) — role은 소문자 raw 값(member/admin/owner)이라
+        # 관사 없이 "as admin"은 어색. _build_invite_html이 관사 붙인 role_display를 넘긴다.
+        "body": "<strong>{inviter_name}</strong> invited you to join <strong>{org_name}</strong> as {role_display}.",
         "sub_body": "Click the button below to accept the invitation. This link is valid for 7 days.",
         "cta_label": "Accept invitation",
         "fallback_label": "If the button doesn't work, paste this address into your browser:",
-        "footer": "© 2025 Sprintable. This email was sent automatically because you were invited.",
+        "footer": "© {year} Sprintable. This email was sent automatically because you were invited.",
         "default_inviter": "a team admin",
         "html_lang": "en",
     },
@@ -119,6 +123,7 @@ STORAGE_WARN_COPY: dict[str, dict[str, str]] = {
     "en": {
         "subject": "[Sprintable] Storage usage at {pct}%",
         "body": (
+            "<p>Hello, this is Sprintable.</p>"
             "<p>Your organization's storage usage has reached <b>{pct}%</b>"
             " ({used_mb}MB / {cap_mb}MB).</p>"
             "<p>Free up space (delete unused files) or upgrade your plan to avoid upload limits.</p>"
@@ -140,6 +145,7 @@ AU_WARN_COPY: dict[str, dict[str, str]] = {
     "en": {
         "subject": "[Sprintable] Automation usage (AU) at {pct}%",
         "body": (
+            "<p>Hello, this is Sprintable.</p>"
             "<p>Your organization's automation usage (AU) has reached <b>{pct}%</b>"
             " ({current} / {au_limit} AU this month).</p>"
             "<p>At 100% MCP/API writes and automation will pause (reads and human UI stay"

--- a/backend/app/services/email_copy.py
+++ b/backend/app/services/email_copy.py
@@ -1,0 +1,149 @@
+"""story #3205(선생님 방향 결정 2026-08-29) — 발송 메일 7종의 locale별 카피 사전.
+
+로케일 판별은 `app.services.agent_onboarding_config.resolve_locale`/`SUPPORTED_LOCALES`/
+`DEFAULT_LOCALE`을 그대로 재사용한다(이 파일은 새 locale 정규화 로직을 만들지 않는다).
+
+ko 카피는 기존 발송 문구 그대로(무회귀 — #3196-⑤ 유나 카피 제안이 이미 확定한 톤).
+en 카피는 이 스토리에서 신규 추가 — **유나 검수 대기 초안**이다(doc
+`email-locale-copy-proposal-3205`으로 상신). 검수 확정 전까지는 구조/파라미터만
+믿을 것 — en 문면 자체는 검수 결과로 바뀔 수 있다.
+"""
+from __future__ import annotations
+
+TRANSACTIONAL_COPY: dict[str, dict[str, dict]] = {
+    "verify_email": {
+        "ko": {
+            "subject": "Sprintable 이메일 인증을 완료해 주세요",
+            "intro_lines": [
+                "Sprintable에 가입해 주셔서 감사합니다.",
+                "아래 버튼을 눌러 이메일 인증을 완료하시면 바로 시작하실 수 있습니다.",
+            ],
+            "cta_label": "이메일 인증하기",
+            "expiry_note": "이 링크는 24시간 동안 유효합니다.",
+            "security_note": "본인이 요청한 가입이 아니라면 이 메일을 무시하셔도 됩니다.",
+        },
+        "en": {
+            "subject": "Please verify your Sprintable email",
+            "intro_lines": [
+                "Thank you for signing up for Sprintable.",
+                "Click the button below to verify your email and get started right away.",
+            ],
+            "cta_label": "Verify email",
+            "expiry_note": "This link is valid for 24 hours.",
+            "security_note": "If you didn't sign up for this, you can safely ignore this email.",
+        },
+    },
+    "reset_password": {
+        "ko": {
+            "subject": "Sprintable 비밀번호 재설정 안내",
+            "intro_lines": [
+                "비밀번호 재설정을 요청하셨습니다.",
+                "아래 버튼을 눌러 새 비밀번호를 설정해 주세요.",
+            ],
+            "cta_label": "비밀번호 재설정",
+            "expiry_note": "이 링크는 30분 동안 유효합니다.",
+            "security_note": "본인이 요청하지 않으셨다면 이 메일을 무시하셔도 됩니다 — 비밀번호는 변경되지 않습니다.",
+        },
+        "en": {
+            "subject": "Reset your Sprintable password",
+            "intro_lines": [
+                "We received a request to reset your password.",
+                "Click the button below to set a new password.",
+            ],
+            "cta_label": "Reset password",
+            "expiry_note": "This link is valid for 30 minutes.",
+            "security_note": "If you didn't request this, you can safely ignore this email — your password will not be changed.",
+        },
+    },
+}
+
+REMINDER_COPY: dict[str, dict[str, str]] = {
+    "ko": {
+        "subject": "Sprintable — 가입 완료까지 몇 단계 남았습니다",
+        "intro": (
+            "Sprintable 가입을 환영합니다. 아직 에이전트 연결이나 첫 지시를 완료하지 않으셨네요"
+            " — 몇 분이면 끝나는 남은 단계를 마무리하면 Sprintable의 진짜 가치를 바로 확인하실 수"
+            " 있습니다."
+        ),
+        "cta_label": "이어서 진행하기",
+        "unsub_label": "이런 안내를 더 이상 받고 싶지 않다면 여기를 눌러 주세요",
+    },
+    "en": {
+        "subject": "Sprintable — a few steps left to finish setup",
+        "intro": (
+            "Welcome to Sprintable. You haven't finished connecting an agent or sending your"
+            " first instruction yet — the remaining steps take just a few minutes and show you"
+            " what Sprintable can really do."
+        ),
+        "cta_label": "Continue setup",
+        "unsub_label": "Click here if you'd rather not receive these reminders",
+    },
+}
+
+INVITE_COPY: dict[str, dict[str, str]] = {
+    "ko": {
+        "subject": "[Sprintable] {org_name} 조직에 초대됐습니다",
+        "heading": "팀에 초대됐어요!",
+        "body": "<strong>{inviter_name}</strong>님이 <strong>{org_name}</strong> 조직에 <strong>{role}</strong>로 초대했습니다.",
+        "sub_body": "아래 버튼을 클릭하면 초대를 수락할 수 있습니다. 링크는 7일간 유효합니다.",
+        "cta_label": "초대 수락하기",
+        "fallback_label": "버튼이 보이지 않으면 아래 주소를 브라우저에 붙여 넣으세요:",
+        "footer": "© 2025 Sprintable. 이 이메일은 초대 발송으로 자동 생성되었습니다.",
+        "default_inviter": "팀 관리자",
+        "html_lang": "ko",
+    },
+    "en": {
+        "subject": "[Sprintable] You've been invited to {org_name}",
+        "heading": "You're invited!",
+        "body": "<strong>{inviter_name}</strong> invited you to join <strong>{org_name}</strong> as <strong>{role}</strong>.",
+        "sub_body": "Click the button below to accept the invitation. This link is valid for 7 days.",
+        "cta_label": "Accept invitation",
+        "fallback_label": "If the button doesn't work, paste this address into your browser:",
+        "footer": "© 2025 Sprintable. This email was sent automatically because you were invited.",
+        "default_inviter": "a team admin",
+        "html_lang": "en",
+    },
+}
+
+# 운영 알림 2종(스토리지/AU 임계) — 기존엔 en 고정이었다(이 스토리 이전엔 ko 카피 자체가
+# 없었음 — 무회귀 대상이 없는 신규 추가).
+STORAGE_WARN_COPY: dict[str, dict[str, str]] = {
+    "ko": {
+        "subject": "[Sprintable] 스토리지 사용량 {pct}% 도달",
+        "body": (
+            "<p>안녕하세요, Sprintable입니다.</p>"
+            "<p>조직의 스토리지 사용량이 <b>{pct}%</b>({used_mb}MB / {cap_mb}MB)에 도달했습니다.</p>"
+            "<p>업로드 제한을 피하려면 사용하지 않는 파일을 정리하거나 플랜을 업그레이드해 주세요.</p>"
+        ),
+    },
+    "en": {
+        "subject": "[Sprintable] Storage usage at {pct}%",
+        "body": (
+            "<p>Your organization's storage usage has reached <b>{pct}%</b>"
+            " ({used_mb}MB / {cap_mb}MB).</p>"
+            "<p>Free up space (delete unused files) or upgrade your plan to avoid upload limits.</p>"
+        ),
+    },
+}
+
+AU_WARN_COPY: dict[str, dict[str, str]] = {
+    "ko": {
+        "subject": "[Sprintable] 자동화 사용량(AU) {pct}% 도달",
+        "body": (
+            "<p>안녕하세요, Sprintable입니다.</p>"
+            "<p>조직의 이번 달 자동화 사용량(AU)이 <b>{pct}%</b>({current} / {au_limit} AU)에"
+            " 도달했습니다.</p>"
+            "<p>100%에 도달하면 MCP/API 쓰기 및 자동화가 일시 중지됩니다(읽기와 사람 UI는 계속"
+            " 사용 가능합니다). 한도에 도달하기 전 플랜 업그레이드를 검토해 주세요.</p>"
+        ),
+    },
+    "en": {
+        "subject": "[Sprintable] Automation usage (AU) at {pct}%",
+        "body": (
+            "<p>Your organization's automation usage (AU) has reached <b>{pct}%</b>"
+            " ({current} / {au_limit} AU this month).</p>"
+            "<p>At 100% MCP/API writes and automation will pause (reads and human UI stay"
+            " available). Consider upgrading before the limit is reached.</p>"
+        ),
+    },
+}

--- a/backend/app/services/email_copy.py
+++ b/backend/app/services/email_copy.py
@@ -57,7 +57,8 @@ TRANSACTIONAL_COPY: dict[str, dict[str, dict]] = {
             "cta_label": "Reset password",
             "expiry_note": "This link is valid for 30 minutes.",
             "security_note": "If you didn't request this, you can safely ignore this email — your password will not be changed.",
-            "fallback_label": "If the button doesn't open, paste this address into your browser:",
+            # 유나 홀름 결선(2026-08-29) — 전 템플릿 work로 통일(open 잔존은 페드루군 지적).
+            "fallback_label": "If the button doesn't work, paste this address into your browser:",
         },
     },
 }

--- a/backend/app/services/onboarding_activation.py
+++ b/backend/app/services/onboarding_activation.py
@@ -216,16 +216,16 @@ async def find_reminder_candidates(db: AsyncSession, *, now: datetime | None = N
     return candidates
 
 
-def _reminder_email_body(*, app_url: str, unsub_link: str) -> str:
+def _reminder_email_body(*, app_url: str, unsub_link: str, locale: str) -> str:
+    from app.services.email_copy import REMINDER_COPY
+    copy = REMINDER_COPY[locale]
     return (
-        "<p>Sprintable 가입을 환영합니다. 아직 에이전트 연결이나 첫 지시를 완료하지 않으셨네요"
-        " — 몇 분이면 끝나는 남은 단계를 마무리하면 Sprintable의 진짜 가치를 바로 확인하실 수"
-        " 있습니다.</p>"
-        f"<p><a href='{app_url}'>이어서 진행하기</a></p>"
+        f"<p>{copy['intro']}</p>"
+        f"<p><a href='{app_url}'>{copy['cta_label']}</a></p>"
         # 유나 design:pass 권장(2026-08-27) — #888은 흰 배경 대비 3.5:1로 AA(4.5) 미달.
         # #595959로 7:1(AAA) 확保.
         "<p style='font-size:12px;color:#595959'>"
-        f"<a href='{unsub_link}'>이런 안내를 더 이상 받고 싶지 않다면 여기를 눌러 주세요</a></p>"
+        f"<a href='{unsub_link}'>{copy['unsub_label']}</a></p>"
     )
 
 
@@ -233,16 +233,20 @@ async def send_activation_reminder(db: AsyncSession, user: User) -> bool:
     """이력 스탬프는 발송 시도 여부와 무관하게 항상 기록(재시도 폭주 방지 — email.py의
     False 반환도 "재시도 가능한 일시 실패"가 아니라 "provider 미설정"이라 재시도해도 무의미)."""
     from app.core.security import create_email_unsubscribe_token
+    from app.services.agent_onboarding_config import resolve_locale
     from app.services.email import send_email
+    from app.services.email_copy import REMINDER_COPY
 
     app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
     unsub_token = create_email_unsubscribe_token(str(user.id))
     unsub_link = f"{app_url}/unsubscribe?token={unsub_token}"
+    # story #3205 — locale=ko 유저 → ko 메일·locale=en 유저 → en 메일(AC1).
+    locale = resolve_locale(user.locale)
     delivered = send_email(
         to=user.email,
         # 유나 design:pass 권장(2026-08-27) — 해요체("완료예요") → 합니다체 정합.
-        subject="Sprintable — 가입 완료까지 몇 단계 남았습니다",
-        html_body=_reminder_email_body(app_url=app_url, unsub_link=unsub_link),
+        subject=REMINDER_COPY[locale]["subject"],
+        html_body=_reminder_email_body(app_url=app_url, unsub_link=unsub_link, locale=locale),
     )
     user.onboarding_reminder_sent_at = datetime.now(timezone.utc)
     db.add(user)

--- a/backend/app/services/org_invite_email.py
+++ b/backend/app/services/org_invite_email.py
@@ -19,6 +19,8 @@ def _en_role_with_article(role: str) -> str:
     """유나 검수 수정의견②(2026-08-29) — role은 소문자 raw 값(member/admin/owner)이라
     영어에서 관사 없이는 어색("as admin"). 첫 글자 발음 기준 a/an만 판단(그 외 문법
     보정은 발명하지 않는다 — 이 3개 role 외 값이 생기면 별도 검토)."""
+    if not role:
+        return role
     article = "an" if role[:1].lower() in "aeiou" else "a"
     return f"{article} {role}"
 

--- a/backend/app/services/org_invite_email.py
+++ b/backend/app/services/org_invite_email.py
@@ -15,9 +15,21 @@ _BUTTON_STYLE = (
 )
 
 
+def _en_role_with_article(role: str) -> str:
+    """유나 검수 수정의견②(2026-08-29) — role은 소문자 raw 값(member/admin/owner)이라
+    영어에서 관사 없이는 어색("as admin"). 첫 글자 발음 기준 a/an만 판단(그 외 문법
+    보정은 발명하지 않는다 — 이 3개 role 외 값이 생기면 별도 검토)."""
+    article = "an" if role[:1].lower() in "aeiou" else "a"
+    return f"{article} {role}"
+
+
 def _build_invite_html(*, org_name: str, inviter_name: str, accept_link: str, role: str, locale: str) -> str:
+    from datetime import datetime, timezone
+
     copy = INVITE_COPY[locale]
-    body = copy["body"].format(inviter_name=inviter_name, org_name=org_name, role=role)
+    role_display = _en_role_with_article(role) if locale == "en" else role
+    body = copy["body"].format(inviter_name=inviter_name, org_name=org_name, role=role, role_display=role_display)
+    footer = copy["footer"].format(year=datetime.now(timezone.utc).year)
     return f"""<!DOCTYPE html>
 <html lang="{copy['html_lang']}">
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
@@ -48,7 +60,7 @@ def _build_invite_html(*, org_name: str, inviter_name: str, accept_link: str, ro
         <!-- Footer -->
         <tr><td style="background:#f9fafb;padding:20px 40px;border-top:1px solid #e5e7eb;">
           <p style="margin:0;color:#9ca3af;font-size:12px;">
-            {copy['footer']}
+            {footer}
           </p>
         </td></tr>
       </table>

--- a/backend/app/services/org_invite_email.py
+++ b/backend/app/services/org_invite_email.py
@@ -5,6 +5,7 @@ import logging
 import os
 
 from app.services.email import send_email
+from app.services.email_copy import INVITE_COPY
 
 logger = logging.getLogger(__name__)
 
@@ -14,9 +15,11 @@ _BUTTON_STYLE = (
 )
 
 
-def _build_invite_html(*, org_name: str, inviter_name: str, accept_link: str, role: str) -> str:
+def _build_invite_html(*, org_name: str, inviter_name: str, accept_link: str, role: str, locale: str) -> str:
+    copy = INVITE_COPY[locale]
+    body = copy["body"].format(inviter_name=inviter_name, org_name=org_name, role=role)
     return f"""<!DOCTYPE html>
-<html lang="ko">
+<html lang="{copy['html_lang']}">
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
 <body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
   <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:40px 0;">
@@ -28,25 +31,24 @@ def _build_invite_html(*, org_name: str, inviter_name: str, accept_link: str, ro
         </td></tr>
         <!-- Body -->
         <tr><td style="padding:40px 40px 32px;">
-          <h2 style="margin:0 0 16px;font-size:22px;color:#111827;">팀에 초대됐어요!</h2>
+          <h2 style="margin:0 0 16px;font-size:22px;color:#111827;">{copy['heading']}</h2>
           <p style="margin:0 0 12px;color:#374151;line-height:1.6;">
-            <strong>{inviter_name}</strong>님이 <strong>{org_name}</strong> 조직에
-            <strong>{role}</strong>로 초대했습니다.
+            {body}
           </p>
           <p style="margin:0 0 32px;color:#6b7280;font-size:14px;line-height:1.6;">
-            아래 버튼을 클릭하면 초대를 수락할 수 있습니다. 링크는 7일간 유효합니다.
+            {copy['sub_body']}
           </p>
-          <a href="{accept_link}" style="{_BUTTON_STYLE}">초대 수락하기</a>
+          <a href="{accept_link}" style="{_BUTTON_STYLE}">{copy['cta_label']}</a>
           <hr style="margin:32px 0;border:none;border-top:1px solid #e5e7eb;">
           <p style="margin:0;color:#9ca3af;font-size:13px;line-height:1.6;">
-            버튼이 보이지 않으면 아래 주소를 브라우저에 붙여 넣으세요:<br>
+            {copy['fallback_label']}<br>
             <a href="{accept_link}" style="color:#6366f1;word-break:break-all;">{accept_link}</a>
           </p>
         </td></tr>
         <!-- Footer -->
         <tr><td style="background:#f9fafb;padding:20px 40px;border-top:1px solid #e5e7eb;">
           <p style="margin:0;color:#9ca3af;font-size:12px;">
-            © 2025 Sprintable. 이 이메일은 초대 발송으로 자동 생성되었습니다.
+            {copy['footer']}
           </p>
         </td></tr>
       </table>
@@ -63,23 +65,32 @@ def send_invite_email(
     token: str,
     role: str,
     inviter_name: str = "",
+    locale: str = "ko",
 ) -> str | None:
-    """초대 이메일 발송. 성공 시 None, 실패 시 오류 메시지 반환."""
+    """초대 이메일 발송. 성공 시 None, 실패 시 오류 메시지 반환.
+
+    story #3205 — locale은 호출자(org_invites.py)가 「초대 이메일이 이미 이 플랫폼의
+    기존 유저 것이면 그 유저의 locale, 아니면(아직 계정 없는 신규 피초대자) DEFAULT_LOCALE」
+    로 판별해 넘긴다 — 여기서는 그 값을 그대로 소비만 한다(추측 0, 기존 무회귀 동작이
+    바로 그 else 분기).
+    """
     app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
     accept_link = f"{app_url}/invite/accept?token={token}"
-    display_inviter = inviter_name or "팀 관리자"
+    copy = INVITE_COPY[locale]
+    display_inviter = inviter_name or copy["default_inviter"]
 
     html_body = _build_invite_html(
         org_name=org_name,
         inviter_name=display_inviter,
         accept_link=accept_link,
         role=role,
+        locale=locale,
     )
 
     try:
         delivered = send_email(
             to=to,
-            subject=f"[Sprintable] {org_name} 조직에 초대됐습니다",
+            subject=copy["subject"].format(org_name=org_name),
             html_body=html_body,
         )
         if not delivered:

--- a/backend/tests/test_2041_storage_crons_worker_pool.py
+++ b/backend/tests/test_2041_storage_crons_worker_pool.py
@@ -78,7 +78,8 @@ async def test_storage_usage_warn_send_email_runs_off_event_loop_thread():
         lambda r: setattr(r.scalars.return_value.all, "return_value", [sub]),
         lambda r: setattr(r.all, "return_value", [("pro", cap_mb)]),
         lambda r: setattr(r.scalar_one, "return_value", used_bytes),
-        lambda r: setattr(r.all, "return_value", [("owner@example.com",)]),
+        # story #3205: 조회가 (email, locale) 2열로 확장됨.
+        lambda r: setattr(r.all, "return_value", [("owner@example.com", "ko")]),
         lambda r: None,  # UPDATE storage_warn_notified_at — 반환값 미사용.
     ]
     call_count = 0

--- a/backend/tests/test_3205_email_locale_routing.py
+++ b/backend/tests/test_3205_email_locale_routing.py
@@ -177,6 +177,11 @@ def test_send_invite_email_uses_locale_param(monkeypatch):
     assert "You're invited!" in sent["html_body"]
     assert "Jay" in sent["html_body"] and "Acme" in sent["html_body"]
     assert 'lang="en"' in sent["html_body"]
+    # 유나 검수 수정의견②: raw role(admin)에 관사가 붙어야 자연스러움.
+    assert "as an admin" in sent["html_body"]
+    # 유나 검수 수정의견①: footer 연도가 고정 2025가 아니라 동적.
+    assert "© 2025 Sprintable" not in sent["html_body"]
+    assert "Sprintable. This email was sent automatically" in sent["html_body"]
 
 
 def test_send_invite_email_defaults_to_ko(monkeypatch):

--- a/backend/tests/test_3205_email_locale_routing.py
+++ b/backend/tests/test_3205_email_locale_routing.py
@@ -1,0 +1,196 @@
+"""story #3205 — 발송 메일 locale 분기 pin. mock 세션(test_register_email_delivered.py와
+동형 패턴, 실PG 불요) — AC1: locale=ko 유저 → ko 메일·locale=en 유저 → en 메일."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _register_client():
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_result.scalars.return_value.all.return_value = []
+    mock_result.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.flush = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session.add = MagicMock()
+
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+def _payload():
+    return {
+        "email": f"new-{uuid.uuid4().hex}@example.com",
+        "password": "TestPass1!",
+        "display_name": "Test User",
+        "tos_accepted": True,
+    }
+
+
+@pytest.mark.anyio
+async def test_register_captures_locale_from_accept_language_and_sends_en_copy(monkeypatch):
+    sent = {}
+
+    def _fake_send_email(**kwargs):
+        sent.update(kwargs)
+        return True
+
+    monkeypatch.setattr("app.services.email.send_email", _fake_send_email)
+    client, session, app = await _register_client()
+    try:
+        async with client as c:
+            resp = await c.post(
+                "/api/v2/auth/register",
+                json=_payload(),
+                headers={"Accept-Language": "en-US,en;q=0.9"},
+            )
+        assert resp.status_code == 201
+        # session.add(user)·session.add(refresh_token) 둘 다 찍힌다 — User 인스턴스만 골라 확인.
+        from app.models.user import User
+        added_user = next(c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], User))
+        assert added_user.locale == "en"
+        assert sent["subject"] == "Please verify your Sprintable email"
+        assert "Verify email" in sent["html_body"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_register_defaults_to_ko_without_accept_language_header(monkeypatch):
+    sent = {}
+
+    def _fake_send_email(**kwargs):
+        sent.update(kwargs)
+        return True
+
+    monkeypatch.setattr("app.services.email.send_email", _fake_send_email)
+    client, session, app = await _register_client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/register", json=_payload())
+        assert resp.status_code == 201
+        from app.models.user import User
+        added_user = next(c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], User))
+        assert added_user.locale == "ko"
+        assert sent["subject"] == "Sprintable 이메일 인증을 완료해 주세요"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_forgot_password_sends_locale_matched_copy(monkeypatch):
+    from app.main import app
+    from app.dependencies.database import get_db
+    from app.models.user import User
+
+    en_user = User(
+        id=uuid.uuid4(), email="en-user@example.com", hashed_password="x",
+        is_active=True, email_verified=True, locale="en",
+    )
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = en_user
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    async def override_db():
+        yield mock_session
+
+    sent = {}
+
+    def _fake_send_email(**kwargs):
+        sent.update(kwargs)
+        return True
+
+    monkeypatch.setattr("app.services.email.send_email", _fake_send_email)
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/api/v2/auth/forgot-password", json={"email": en_user.email})
+        assert resp.status_code == 200
+        assert sent["subject"] == "Reset your Sprintable password"
+        assert "Reset password" in sent["html_body"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_send_activation_reminder_uses_user_locale(monkeypatch):
+    from app.models.user import User
+    from app.services.onboarding_activation import send_activation_reminder
+
+    ko_user = User(id=uuid.uuid4(), email="ko@example.com", hashed_password="x", locale="ko")
+    en_user = User(id=uuid.uuid4(), email="en@example.com", hashed_password="x", locale="en")
+
+    sent = []
+
+    def _fake_send_email(**kwargs):
+        sent.append(kwargs)
+        return True
+
+    monkeypatch.setattr("app.services.email.send_email", _fake_send_email)
+    db = AsyncMock()
+    db.add = MagicMock()
+
+    await send_activation_reminder(db, ko_user)
+    await send_activation_reminder(db, en_user)
+
+    assert sent[0]["subject"] == "Sprintable — 가입 완료까지 몇 단계 남았습니다"
+    assert "이어서 진행하기" in sent[0]["html_body"]
+    assert sent[1]["subject"] == "Sprintable — a few steps left to finish setup"
+    assert "Continue setup" in sent[1]["html_body"]
+
+
+def test_send_invite_email_uses_locale_param(monkeypatch):
+    from app.services.org_invite_email import send_invite_email
+
+    sent = {}
+
+    def _fake_send_email(**kwargs):
+        sent.update(kwargs)
+        return True
+
+    monkeypatch.setattr("app.services.org_invite_email.send_email", _fake_send_email)
+
+    err = send_invite_email(
+        to="invitee@example.com", org_name="Acme", token="tok123", role="admin",
+        inviter_name="Jay", locale="en",
+    )
+    assert err is None
+    assert sent["subject"] == "[Sprintable] You've been invited to Acme"
+    assert "You're invited!" in sent["html_body"]
+    assert "Jay" in sent["html_body"] and "Acme" in sent["html_body"]
+    assert 'lang="en"' in sent["html_body"]
+
+
+def test_send_invite_email_defaults_to_ko(monkeypatch):
+    """locale 인자 생략 시 기존 무회귀(ko) — 계정 없는 신규 피초대자 케이스."""
+    from app.services.org_invite_email import send_invite_email
+
+    sent = {}
+
+    def _fake_send_email(**kwargs):
+        sent.update(kwargs)
+        return True
+
+    monkeypatch.setattr("app.services.org_invite_email.send_email", _fake_send_email)
+    err = send_invite_email(to="invitee@example.com", org_name="Acme", token="tok123", role="admin")
+    assert err is None
+    assert sent["subject"] == "[Sprintable] Acme 조직에 초대됐습니다"
+    assert "팀에 초대됐어요!" in sent["html_body"]

--- a/backend/tests/test_3205_email_locale_routing.py
+++ b/backend/tests/test_3205_email_locale_routing.py
@@ -68,6 +68,11 @@ async def test_register_captures_locale_from_accept_language_and_sends_en_copy(m
         assert added_user.locale == "en"
         assert sent["subject"] == "Please verify your Sprintable email"
         assert "Verify email" in sent["html_body"]
+        # 까디르 QA(2026-08-29) 재발 방지 — fallback_label이 렌더러에 ko로 하드코딩돼 있어
+        # en 메일에도 "버튼이 열리지 않으면…" 한 줄이 섞이던 결함. en 메일엔 ko가 없어야 한다.
+        assert "버튼이 열리지 않으면" not in sent["html_body"]
+        # html.escape가 작은따옴표를 &#x27;로 바꾸므로 그 형태로 확인.
+        assert "If the button doesn&#x27;t work, paste this address into your browser:" in sent["html_body"]
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_3205_email_locale_routing.py
+++ b/backend/tests/test_3205_email_locale_routing.py
@@ -16,7 +16,7 @@ def anyio_backend():
 
 async def _register_client():
     from app.main import app
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     mock_session = AsyncMock()
     mock_result = MagicMock()
@@ -31,7 +31,8 @@ async def _register_client():
     async def override_db():
         yield mock_session
 
-    app.dependency_overrides[get_db] = override_db
+    # story #2451(§6 Phase3) — get_db만 걸고 get_read_db를 잊는 회귀 방지, 공용 헬퍼 경유.
+    override_db_and_read(app, override_db)
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
 
 
@@ -102,8 +103,8 @@ async def test_register_defaults_to_ko_without_accept_language_header(monkeypatc
 @pytest.mark.anyio
 async def test_forgot_password_sends_locale_matched_copy(monkeypatch):
     from app.main import app
-    from app.dependencies.database import get_db
     from app.models.user import User
+    from tests.conftest import override_db_and_read
 
     en_user = User(
         id=uuid.uuid4(), email="en-user@example.com", hashed_password="x",
@@ -124,7 +125,8 @@ async def test_forgot_password_sends_locale_matched_copy(monkeypatch):
         return True
 
     monkeypatch.setattr("app.services.email.send_email", _fake_send_email)
-    app.dependency_overrides[get_db] = override_db
+    # story #2451(§6 Phase3) — get_db만 걸고 get_read_db를 잊는 회귀 방지, 공용 헬퍼 경유.
+    override_db_and_read(app, override_db)
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
             resp = await c.post("/api/v2/auth/forgot-password", json={"email": en_user.email})

--- a/backend/tests/test_e_org_multi_s3_1_org_invite.py
+++ b/backend/tests/test_e_org_multi_s3_1_org_invite.py
@@ -56,6 +56,11 @@ async def _client(user_id: uuid.UUID = USER_ID):
     ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
 
     mock_session = AsyncMock()
+    # story #3205: create/resend invite가 _resolve_invitee_locale()로 session.execute()를
+    # 추가 호출한다 — 기본은 "기존 유저 없음"(None → DEFAULT_LOCALE, 기존 ko 무회귀).
+    _execute_result = MagicMock()
+    _execute_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=_execute_result)
 
     async def override_db():
         yield mock_session

--- a/backend/tests/test_e_org_multi_s3_2_invite_email.py
+++ b/backend/tests/test_e_org_multi_s3_2_invite_email.py
@@ -64,6 +64,11 @@ async def _client(user_id: uuid.UUID = USER_ID):
     ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
 
     mock_session = AsyncMock()
+    # story #3205: resend invite가 _resolve_invitee_locale()로 session.execute()를 추가
+    # 호출한다 — 기본은 "기존 유저 없음"(None → DEFAULT_LOCALE, 기존 ko 무회귀).
+    _execute_result = MagicMock()
+    _execute_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=_execute_result)
 
     async def override_db():
         yield mock_session

--- a/backend/tests/test_email_copy.py
+++ b/backend/tests/test_email_copy.py
@@ -1,0 +1,70 @@
+"""story #3205 — email_copy.py 사전 형태 pin. DB 불요(순수 dict)."""
+from __future__ import annotations
+
+from app.services.email_copy import (
+    AU_WARN_COPY,
+    INVITE_COPY,
+    REMINDER_COPY,
+    STORAGE_WARN_COPY,
+    TRANSACTIONAL_COPY,
+)
+
+_LOCALES = ("ko", "en")
+
+
+def test_transactional_copy_has_both_locales_and_required_fields():
+    for kind in ("verify_email", "reset_password"):
+        for locale in _LOCALES:
+            copy = TRANSACTIONAL_COPY[kind][locale]
+            assert copy["subject"]
+            assert copy["intro_lines"] and isinstance(copy["intro_lines"], list)
+            assert copy["cta_label"]
+            assert copy["expiry_note"]
+            assert copy["security_note"]
+
+
+def test_reminder_copy_has_both_locales():
+    for locale in _LOCALES:
+        copy = REMINDER_COPY[locale]
+        assert copy["subject"] and copy["intro"] and copy["cta_label"] and copy["unsub_label"]
+
+
+def test_invite_copy_formats_without_error_both_locales():
+    for locale in _LOCALES:
+        copy = INVITE_COPY[locale]
+        subject = copy["subject"].format(org_name="Acme")
+        body = copy["body"].format(inviter_name="Jay", org_name="Acme", role="admin")
+        assert "Acme" in subject
+        assert "Jay" in body and "admin" in body
+        assert copy["html_lang"] == locale
+
+
+def test_storage_warn_copy_formats_without_error_both_locales():
+    for locale in _LOCALES:
+        copy = STORAGE_WARN_COPY[locale]
+        subject = copy["subject"].format(pct=82.3)
+        body = copy["body"].format(pct=82.3, used_mb=800, cap_mb=1000)
+        assert "82.3" in subject
+        assert "800" in body and "1000" in body
+
+
+def test_au_warn_copy_formats_without_error_both_locales():
+    for locale in _LOCALES:
+        copy = AU_WARN_COPY[locale]
+        subject = copy["subject"].format(pct=91.0)
+        body = copy["body"].format(pct=91.0, current=910, au_limit=1000)
+        assert "91.0" in subject
+        assert "910" in body and "1000" in body
+
+
+def test_ko_transactional_copy_unchanged_from_pre_3205_wording():
+    """무회귀 — #3196-⑤에서 확定된 ko 문구가 그대로인지(문자열 리터럴 그대로 이전)."""
+    verify = TRANSACTIONAL_COPY["verify_email"]["ko"]
+    assert verify["subject"] == "Sprintable 이메일 인증을 완료해 주세요"
+    assert verify["cta_label"] == "이메일 인증하기"
+    reset = TRANSACTIONAL_COPY["reset_password"]["ko"]
+    assert reset["subject"] == "Sprintable 비밀번호 재설정 안내"
+    reminder = REMINDER_COPY["ko"]
+    assert reminder["subject"] == "Sprintable — 가입 완료까지 몇 단계 남았습니다"
+    invite = INVITE_COPY["ko"]
+    assert invite["heading"] == "팀에 초대됐어요!"

--- a/backend/tests/test_email_copy.py
+++ b/backend/tests/test_email_copy.py
@@ -33,9 +33,11 @@ def test_invite_copy_formats_without_error_both_locales():
     for locale in _LOCALES:
         copy = INVITE_COPY[locale]
         subject = copy["subject"].format(org_name="Acme")
-        body = copy["body"].format(inviter_name="Jay", org_name="Acme", role="admin")
+        body = copy["body"].format(inviter_name="Jay", org_name="Acme", role="admin", role_display="an admin")
+        footer = copy["footer"].format(year=2026)
         assert "Acme" in subject
         assert "Jay" in body and "admin" in body
+        assert "2026" in footer
         assert copy["html_lang"] == locale
 
 

--- a/backend/tests/test_email_copy.py
+++ b/backend/tests/test_email_copy.py
@@ -21,6 +21,7 @@ def test_transactional_copy_has_both_locales_and_required_fields():
             assert copy["cta_label"]
             assert copy["expiry_note"]
             assert copy["security_note"]
+            assert copy["fallback_label"]
 
 
 def test_reminder_copy_has_both_locales():

--- a/backend/tests/test_render_action_email.py
+++ b/backend/tests/test_render_action_email.py
@@ -2,6 +2,9 @@
 
 트랜잭셔널 메일 3종(가입 인증·인증 재발송·비밀번호 재설정)이 전부 이 함수를 쓴다 — 골격
 (인사/맥락→CTA 버튼→만료→폴백 링크→보안 안내)과 escape 정직성만 순수 단위테스트로 고정.
+
+story #3205 QA(까디르, 2026-08-29) — fallback_label이 렌더러 내부 ko 하드코딩이라 en
+메일에도 한국어가 섞이던 결함 수정 후, 파라미터화됨(다른 4개 필드와 동형).
 """
 from __future__ import annotations
 
@@ -15,8 +18,9 @@ def test_renders_all_sections_in_order():
         cta_url="https://app.sprintable.ai/verify-email?token=abc",
         expiry_note="24시간 유효",
         security_note="요청 안 했으면 무시하세요",
+        fallback_label="버튼이 열리지 않으면:",
     )
-    for expected in ("첫 줄", "둘째 줄", "버튼 라벨", "24시간 유효", "요청 안 했으면 무시하세요"):
+    for expected in ("첫 줄", "둘째 줄", "버튼 라벨", "24시간 유효", "요청 안 했으면 무시하세요", "버튼이 열리지 않으면:"):
         assert expected in html_body
     # cta_url이 버튼 href·폴백 링크 href·폴백 링크의 가시 텍스트 3곳에 실린다(버튼이 안
     # 뜨는 클라이언트 대비 — 폴백은 href뿐 아니라 사람이 직접 복사할 수 있게 텍스트로도 보임).
@@ -39,11 +43,14 @@ def test_escapes_html_in_user_facing_text_but_not_url():
         cta_url="https://app.sprintable.ai/x?token=a&b=1",
         expiry_note="<i>만료</i>",
         security_note="<u>보안</u>",
+        fallback_label="<em>폴백</em>",
     )
     assert "<script>" not in html_body
     assert "&lt;script&gt;" in html_body
     assert "<b>버튼</b>" not in html_body
     assert "&lt;b&gt;버튼&lt;/b&gt;" in html_body
+    assert "<em>폴백</em>" not in html_body
+    assert "&lt;em&gt;폴백&lt;/em&gt;" in html_body
     # URL 자체는 그대로(escape로 깨지면 안 됨 — & 등이 %26으로 변형되지 않는다).
     assert "https://app.sprintable.ai/x?token=a&b=1" in html_body
 
@@ -51,6 +58,7 @@ def test_escapes_html_in_user_facing_text_but_not_url():
 def test_no_flexbox_or_grid_inline_style_for_email_client_compat():
     html_body = render_action_email(
         intro_lines=["줄"], cta_label="라벨", cta_url="https://x", expiry_note="만료", security_note="보안",
+        fallback_label="폴백",
     )
     assert "display:flex" not in html_body
     assert "display:grid" not in html_body


### PR DESCRIPTION
[SID:3205]

## 배경
선생님 방향 결정(2026-08-29): 발송 메일 7종이 수신자 locale과 무관하게 고정 언어였다
— 트랜잭셔널 3종(가입 인증·재발송·비밀번호 재설정)+온보딩 리마인드+조직 초대=ko 고정,
스토리지/AU 임계 알림 2종(어드민向)=en 고정.

## grounding 결론
`users`에 locale 필드 없음 → 이 스토리 범위로 신설(story 설명에 명시된 대로).
FE 라이브 렌더링 locale은 story 11f1087c 크루스로 DB에 없고 쿠키 전용 — 그 결정은
그대로 두고, 이건 요청 밖(cron 등)에서도 읽어야 하는 **발송 전용** 신호로 별도 축.

## 변경
- alembic 0290: `users.locale`(nullable, 백필 없음 — 과거 유저 선호를 알 방법이 없음)
- `register()`/`oauth_callback()`: 가입 시 `Accept-Language` 헤더로 1회 포착
  (기존 `resolve_locale_from_request` 재사용 — agents.py 등과 동일 헬퍼, 새 파서 없음)
- `email_copy.py`(신규): 7종 전체 ko/en 사전. ko는 #3196-⑤ 확定본 그대로(무회귀),
  en 5종은 이 스토리 신규 — **유나 검수 대기**(doc `email-locale-copy-proposal-3205`)
- 트랜잭셔널 3종·리마인드·조직초대: `user.locale`(초대는 기존 계정 있으면 그 locale,
  없으면 ko — 신규 피초대자가 절대다수라 무회귀) 기준 분기
- 스토리지/AU 임계 알림: 다중 수신자(owner/admin 전원)라 **수신자별 개별** locale 분기로 확장

## 스코프 밖(비교 참고만, 미포함)
`billing_scheduler.py`(dunning)·`org_subscription_downgrade.py`(auto-cancel) 알림 2종은
이번 7종 밖. 과거 PR#3308에서 유나가 "로케일별 분기 정책 없음"을 이유로 en 반려한
이력이 있어 이 스토리가 그 정책을 채운 셈이지만, 킥오프 경계 준수로 별도 후속 과제로
남김 — 팀 공유용으로만 언급.

## Test plan
- [x] `backend/tests/test_email_copy.py` — 사전 형태·포맷 pin(6 tests, 순수 dict, DB 불요)
- [x] `backend/tests/test_3205_email_locale_routing.py` — register() Accept-Language
      포착·forgot-password/reminder/invite locale 분기(6 tests, mock 세션)
- [x] `backend/tests/test_render_action_email.py` — 기존 회귀 없음 재확인
- [x] `backend/tests/test_2041_storage_crons_worker_pool.py`,
      `test_e_org_multi_s3_1/2_org_invite*.py` — query shape 확장에 맞춰 mock 갱신, 재통과
- [x] `uv run pytest tests/ -m "not destructive_schema"` 전체 실행 — 5083 passed, 13 failed
      (전부 무관 pre-existing: mcp e2e 도구수 stale assert·s6/s7 로컬 python path 체크·
      session_context realdb — 이 diff 파일과 무접점, 별도 확인 완료)
- [ ] AC1(실발송 실측, ko/en 각 1) — dev 배포 후 QA