### PR TITLE
[SID:3209] PR-1 결제 영수증 처리 — Toss receipt_url 저장·빌링 내역 화면 신설

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2644,7 +2644,16 @@
     "paymentMethodDeleteSuccess": "Payment method removed.",
     "paymentMethodDeleteBlocked": "You have an active paid subscription ({tier}) — you can't remove your payment method yet.",
     "paymentMethodDeleteBlockedUntil": "Your active paid subscription ({tier}) runs until {date}. You can remove your payment method after that.",
-    "paymentMethodDeleteError": "Couldn't remove the payment method. Please try again."
+    "paymentMethodDeleteError": "Couldn't remove the payment method. Please try again.",
+    "orderHistoryTitle": "Billing history",
+    "orderHistoryEmpty": "No billing history yet.",
+    "orderHistoryLoadError": "Couldn't load billing history.",
+    "orderHistoryStatusConfirmed": "Paid",
+    "orderHistoryStatusPending": "Processing",
+    "orderHistoryStatusFailed": "Failed",
+    "orderHistoryPurposeCharge": "Subscription",
+    "orderHistoryPurposePackPurchase": "Pack purchase",
+    "orderHistoryReceiptLink": "View receipt"
   },
   "usage": {
     "eyebrow": "OPERATOR USAGE",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2653,7 +2653,12 @@
     "orderHistoryStatusFailed": "Failed",
     "orderHistoryPurposeCharge": "Subscription",
     "orderHistoryPurposePackPurchase": "Pack purchase",
-    "orderHistoryReceiptLink": "View receipt"
+    "orderHistoryReceiptLink": "View receipt",
+    "orderHistoryColDate": "Date",
+    "orderHistoryColPurpose": "Type",
+    "orderHistoryColAmount": "Amount",
+    "orderHistoryColStatus": "Status",
+    "orderHistoryColReceipt": "Receipt"
   },
   "usage": {
     "eyebrow": "OPERATOR USAGE",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2644,7 +2644,16 @@
     "paymentMethodDeleteSuccess": "결제수단이 삭제되었습니다.",
     "paymentMethodDeleteBlocked": "활성 유료 구독({tier})이 있어 결제수단을 삭제할 수 없습니다.",
     "paymentMethodDeleteBlockedUntil": "활성 유료 구독({tier})은 {date}까지 유효합니다. 그 이후에 결제수단을 삭제할 수 있어요.",
-    "paymentMethodDeleteError": "결제수단 삭제에 실패했습니다. 잠시 후 다시 시도해주세요."
+    "paymentMethodDeleteError": "결제수단 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    "orderHistoryTitle": "결제 내역",
+    "orderHistoryEmpty": "결제 내역이 없습니다.",
+    "orderHistoryLoadError": "결제 내역을 불러올 수 없습니다.",
+    "orderHistoryStatusConfirmed": "결제 완료",
+    "orderHistoryStatusPending": "처리 중",
+    "orderHistoryStatusFailed": "실패",
+    "orderHistoryPurposeCharge": "정기결제",
+    "orderHistoryPurposePackPurchase": "팩 구매",
+    "orderHistoryReceiptLink": "영수증 보기"
   },
   "usage": {
     "eyebrow": "OPERATOR USAGE",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2653,7 +2653,12 @@
     "orderHistoryStatusFailed": "실패",
     "orderHistoryPurposeCharge": "정기결제",
     "orderHistoryPurposePackPurchase": "팩 구매",
-    "orderHistoryReceiptLink": "영수증 보기"
+    "orderHistoryReceiptLink": "영수증 보기",
+    "orderHistoryColDate": "결제일",
+    "orderHistoryColPurpose": "구분",
+    "orderHistoryColAmount": "금액",
+    "orderHistoryColStatus": "상태",
+    "orderHistoryColReceipt": "영수증"
   },
   "usage": {
     "eyebrow": "OPERATOR USAGE",

--- a/apps/web/src/app/api/billing/orders/route.test.ts
+++ b/apps/web/src/app/api/billing/orders/route.test.ts
@@ -1,0 +1,40 @@
+// story #3209(PR-1) — 카디르 QA 블로킹(PR#3605): FE 컴포넌트 테스트가 `fetchWithAuth`를
+// 모듈째 mock해 이 프록시 경로(route.ts → proxyToFastapiWrapped → apiSuccess) 자체를 안
+// 지나가서, BE가 `{"data": [...]}`를 반환하면 최종 응답이 `{data: {data: [...]}}`로
+// 이중래핑되는 버그를 못 잡았다. 이 파일은 그 실경로(fastapi-proxy.test.ts와 동형 —
+// global.fetch mock으로 BE 응답을 흉내내고 route의 GET을 직접 호출)를 지나며 최종 JSON
+// 모양을 고정한다 — "로직 증명"이 아니라 "실경로 도달" 증명.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getServerSessionMock } = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+}));
+
+vi.mock('@/lib/db/server', () => ({ getServerSession: getServerSessionMock }));
+
+import { GET } from './route';
+
+describe('/api/billing/orders — 이중래핑 회귀가드(story #3209, 카디르 QA)', () => {
+  beforeEach(() => {
+    getServerSessionMock.mockReset();
+    getServerSessionMock.mockResolvedValue({ access_token: 'token-1', org_id: 'org-1' });
+  });
+
+  it('BE가 flat list를 반환하면 FE 최종 응답은 단일래핑 {data: [...]}이다(이중래핑 금지)', async () => {
+    const beOrders = [{
+      order_id: 'order-1', created_at: '2026-08-29T10:00:00Z', amount_minor: 49000,
+      currency: 'KRW', status: 'confirmed', purpose: 'charge',
+      receipt_url: 'https://dashboard.tosspayments.com/receipt/abc123',
+    }];
+    // BE 라우터(list_billing_orders)가 실제로 반환하는 형상 — flat list(dict로 감싸지 않음).
+    global.fetch = vi.fn(async () => new Response(JSON.stringify(beOrders), { status: 200 }));
+
+    const res = await GET(new Request('http://localhost/api/billing/orders'));
+    const json = await res.json();
+
+    // 이중래핑이었다면 json.data가 {data: [...]}(object)였을 것 — 배열 자체여야 한다.
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data).toEqual(beOrders);
+    expect(json.error).toBeNull();
+  });
+});

--- a/apps/web/src/app/api/billing/orders/route.ts
+++ b/apps/web/src/app/api/billing/orders/route.ts
@@ -1,0 +1,9 @@
+import { proxyToFastapiWrapped } from '@/lib/fastapi-proxy';
+
+/**
+ * GET /api/billing/orders — story #3209(PR-1). status/route.ts와 동일 프록시 이유(X-Org-Id
+ * 인터셉터+CSP connect-src는 same-origin /api/* 경유일 때만 적용).
+ */
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapiWrapped(request, '/api/v2/billing/orders');
+}

--- a/apps/web/src/ee/components/billing/billing-tab.tsx
+++ b/apps/web/src/ee/components/billing/billing-tab.tsx
@@ -32,6 +32,7 @@ import { PricingLimitsTable } from './pricing-limits-table';
 import { PricingPacks, type PackKind } from './pricing-packs';
 import { completeCheckout, startBillingAuth, type CheckoutOutcome } from './toss-checkout';
 import { PaymentMethodSection } from './payment-method-section';
+import { OrderHistorySection } from './order-history-section';
 import {
   cancelSubscription,
   changeTier,
@@ -235,6 +236,7 @@ export function BillingTab({ orgId }: { orgId: string }) {
       )}
 
       <PaymentMethodSection canManage={canManage} />
+      <OrderHistorySection canManage={canManage} />
 
       {isPricePublic && (
         <Tabs value={cycle} onValueChange={(v) => setCycle(v as 'monthly' | 'yearly')}>

--- a/apps/web/src/ee/components/billing/order-history-section.test.tsx
+++ b/apps/web/src/ee/components/billing/order-history-section.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+//
+// story #3209(PR-1) — OrderHistorySection 실 렌더 검증. 이전엔 결제 내역을 보여줄
+// 표면 자체가 없었다(그라운딩 실측) — 이 파일이 그 신규 표면의 회귀가드.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../messages/ko.json';
+import { OrderHistorySection } from './order-history-section';
+import { fetchWithAuth } from '@/lib/db/client';
+
+vi.mock('@/lib/db/client', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+async function mount(node: React.ReactNode) {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => { root.render(wrap(node)); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+  vi.mocked(fetchWithAuth).mockReset();
+});
+
+describe('OrderHistorySection(story #3209)', () => {
+  it('canManage=false면 아무것도 안 그린다(payment-method-section.tsx와 동형 게이팅)', async () => {
+    await mount(<OrderHistorySection canManage={false} />);
+    expect(fetchWithAuth).not.toHaveBeenCalled();
+    expect(container.textContent).toBe('');
+  });
+
+  it('내역이 없으면 빈 상태 문구를 보여준다(지어내지 않음)', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({ ok: true, json: async () => ({ data: [] }) } as Response);
+    await mount(<OrderHistorySection canManage={true} />);
+    expect(container.textContent).toContain(koMessages.pricingPlans.orderHistoryEmpty);
+  });
+
+  it('confirmed 주문은 영수증 링크(receipt_url)를 새 탭으로 연다', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{
+          order_id: 'order-1', created_at: '2026-08-29T10:00:00Z', amount_minor: 49000,
+          currency: 'KRW', status: 'confirmed', purpose: 'charge',
+          receipt_url: 'https://dashboard.tosspayments.com/receipt/abc123',
+        }],
+      }),
+    } as Response);
+    await mount(<OrderHistorySection canManage={true} />);
+    expect(container.textContent).toContain('49,000원');
+    expect(container.textContent).toContain(koMessages.pricingPlans.orderHistoryStatusConfirmed);
+    const link = container.querySelector('a[href="https://dashboard.tosspayments.com/receipt/abc123"]');
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute('target')).toBe('_blank');
+    expect(link?.getAttribute('rel')).toContain('noopener');
+  });
+
+  it('receipt_url이 없는 주문(pending/failed)은 상태만 뜨고 영수증 링크가 없다 — uuid 등 지어낸 링크 금지', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{
+          order_id: 'order-2', created_at: '2026-08-29T10:00:00Z', amount_minor: 49000,
+          currency: 'KRW', status: 'failed', purpose: 'charge', receipt_url: null,
+        }],
+      }),
+    } as Response);
+    await mount(<OrderHistorySection canManage={true} />);
+    expect(container.textContent).toContain(koMessages.pricingPlans.orderHistoryStatusFailed);
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('조회 실패(non-ok)면 에러 문구를 보여준다', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({ ok: false, status: 500, json: async () => ({}) } as Response);
+    await mount(<OrderHistorySection canManage={true} />);
+    expect(container.textContent).toContain(koMessages.pricingPlans.orderHistoryLoadError);
+  });
+});

--- a/apps/web/src/ee/components/billing/order-history-section.test.tsx
+++ b/apps/web/src/ee/components/billing/order-history-section.test.tsx
@@ -89,6 +89,38 @@ describe('OrderHistorySection(story #3209)', () => {
     expect(container.querySelector('a')).toBeNull();
   });
 
+  // story #3209 유나 design:changes(2026-08-29) — 3상태 전부 무색이면 실패=성공 시각
+  // 구분 불가("실패도 보여준다"는 명분과 자가당착) 지적 반영 pin.
+  it('실패 상태는 text-destructive, 완료 상태는 text-success로 색이 갈린다', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { order_id: 'order-3', created_at: '2026-08-29T10:00:00Z', amount_minor: 49000, currency: 'KRW', status: 'failed', purpose: 'charge', receipt_url: null },
+          { order_id: 'order-4', created_at: '2026-08-28T10:00:00Z', amount_minor: 49000, currency: 'KRW', status: 'confirmed', purpose: 'charge', receipt_url: 'https://dashboard.tosspayments.com/receipt/xyz' },
+        ],
+      }),
+    } as Response);
+    await mount(<OrderHistorySection canManage={true} />);
+    const failedCell = Array.from(container.querySelectorAll('td')).find((td) => td.textContent === koMessages.pricingPlans.orderHistoryStatusFailed);
+    const confirmedCell = Array.from(container.querySelectorAll('td')).find((td) => td.textContent === koMessages.pricingPlans.orderHistoryStatusConfirmed);
+    expect(failedCell?.className).toContain('text-destructive');
+    expect(confirmedCell?.className).toContain('text-success');
+  });
+
+  it('표에 컬럼 헤더(thead)가 있다 — 스크린리더 컬럼 연결', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ order_id: 'order-5', created_at: '2026-08-29T10:00:00Z', amount_minor: 49000, currency: 'KRW', status: 'confirmed', purpose: 'charge', receipt_url: null }],
+      }),
+    } as Response);
+    await mount(<OrderHistorySection canManage={true} />);
+    const headers = Array.from(container.querySelectorAll('th'));
+    expect(headers.length).toBe(5);
+    expect(headers.every((h) => h.getAttribute('scope') === 'col')).toBe(true);
+  });
+
   it('조회 실패(non-ok)면 에러 문구를 보여준다', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue({ ok: false, status: 500, json: async () => ({}) } as Response);
     await mount(<OrderHistorySection canManage={true} />);

--- a/apps/web/src/ee/components/billing/order-history-section.test.tsx
+++ b/apps/web/src/ee/components/billing/order-history-section.test.tsx
@@ -90,8 +90,10 @@ describe('OrderHistorySection(story #3209)', () => {
   });
 
   // story #3209 유나 design:changes(2026-08-29) — 3상태 전부 무색이면 실패=성공 시각
-  // 구분 불가("실패도 보여준다"는 명분과 자가당착) 지적 반영 pin.
-  it('실패 상태는 text-destructive, 완료 상태는 text-success로 색이 갈린다', async () => {
+  // 구분 불가("실패도 보여준다"는 명분과 자가당착) 지적 반영. 유나 재확認 정정 —
+  // confirmed=text-success는 라이트 AA 미달(3.49:1<4.5 실측)이라 PO 판정으로 드롭,
+  // muted 원복(failed=destructive만 유지).
+  it('실패 상태는 text-destructive, 완료 상태는 muted(색 없음)다', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -105,7 +107,8 @@ describe('OrderHistorySection(story #3209)', () => {
     const failedCell = Array.from(container.querySelectorAll('td')).find((td) => td.textContent === koMessages.pricingPlans.orderHistoryStatusFailed);
     const confirmedCell = Array.from(container.querySelectorAll('td')).find((td) => td.textContent === koMessages.pricingPlans.orderHistoryStatusConfirmed);
     expect(failedCell?.className).toContain('text-destructive');
-    expect(confirmedCell?.className).toContain('text-success');
+    expect(confirmedCell?.className).toContain('text-muted-foreground');
+    expect(confirmedCell?.className).not.toContain('text-success');
   });
 
   it('표에 컬럼 헤더(thead)가 있다 — 스크린리더 컬럼 연결', async () => {

--- a/apps/web/src/ee/components/billing/order-history-section.tsx
+++ b/apps/web/src/ee/components/billing/order-history-section.tsx
@@ -46,7 +46,9 @@ function purposeKey(purpose: string): 'orderHistoryPurposeCharge' | 'orderHistor
 // 시각 동일해진다("실패 시도도 보여준다"는 pending/failed 포함 명분과 자가당착). 결제
 // 완료=success 색은 재량으로 payment-method-section.tsx 자매 섹션의 성공 배너와 맞춘다.
 function statusColorClass(status: string): string {
-  if (status === 'confirmed') return 'text-success';
+  // 유나 재확認 정정(2026-08-29) — confirmed=text-success는 라이트 AA 미달(3.49:1<4.5,
+  // 실측). PO 판정(유나 ①안) — confirmed 색 드롭, muted 원복. failed=destructive만
+  // 유지(실패 스캔 목적은 그걸로 이미 달성, 완료는 기본값이라 색 불요).
   if (status === 'failed') return 'text-destructive';
   return 'text-muted-foreground';
 }

--- a/apps/web/src/ee/components/billing/order-history-section.tsx
+++ b/apps/web/src/ee/components/billing/order-history-section.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+/**
+ * story #3209(PR-1) — 웹 빌링 내역(주문별). 그라운딩 실측: 이 화면 자체가 아예 없었다
+ * (payment-method-section.tsx는 "지금 등록된 카드"만 보여줄 뿐, "과거에 뭘 얼마나
+ * 냈는지"를 보여줄 표면이 0 — 이 섹션이 그 갭). payment-method-section.tsx와 동형
+ * 관례(canManage 게이팅 시 fetch 자체를 안 함·자기완결적 fetch/상태).
+ *
+ * receipt_url은 confirmed order에서만 값이 있다(billing_charge.py._confirm_with_ledger,
+ * Toss payment 객체의 receipt.url — 공식 문서 확認·신규 발급/렌더 없이 Toss 호스팅
+ * URL 그대로 링크). pending/failed는 링크 없이 상태만 노출 — "실패한 시도도 안 보이면
+ * 사용자가 재시도 여부를 판단 못 한다"는 BE 엔드포인트 설계와 짝.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ExternalLink } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { fetchWithAuth } from '@/lib/db/client';
+import { formatKrw } from './pricing-data';
+
+interface BillingOrderItem {
+  order_id: string;
+  created_at: string;
+  amount_minor: number;
+  currency: string;
+  status: string;
+  purpose: string;
+  receipt_url: string | null;
+}
+
+function statusKey(status: string): 'orderHistoryStatusConfirmed' | 'orderHistoryStatusPending' | 'orderHistoryStatusFailed' | null {
+  if (status === 'confirmed') return 'orderHistoryStatusConfirmed';
+  if (status === 'pending') return 'orderHistoryStatusPending';
+  if (status === 'failed') return 'orderHistoryStatusFailed';
+  return null;
+}
+
+function purposeKey(purpose: string): 'orderHistoryPurposeCharge' | 'orderHistoryPurposePackPurchase' | null {
+  if (purpose === 'charge') return 'orderHistoryPurposeCharge';
+  if (purpose === 'pack_purchase') return 'orderHistoryPurposePackPurchase';
+  return null;
+}
+
+export function OrderHistorySection({ canManage }: { canManage: boolean }) {
+  const t = useTranslations('pricingPlans');
+  const [orders, setOrders] = useState<BillingOrderItem[] | null | undefined>(undefined);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    // payment-method-section.tsx와 동일 가드 — 무권한이면 조회 자체를 안 한다(BE도
+    // 403이지만, 매 마운트마다 실패할 GET을 던지는 낭비+"내역이 있는지" 조용히 아는
+    // 부작용을 FE 레벨에서 미리 막는다).
+    if (!canManage) return;
+    fetchWithAuth('/api/billing/orders', { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((json: { data: BillingOrderItem[] }) => setOrders(json.data))
+      .catch(() => {
+        setOrders(null);
+        setError(true);
+      });
+  }, [canManage]);
+
+  if (!canManage || orders === undefined) return null;
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <p className="mb-2 text-sm font-semibold text-foreground">{t('orderHistoryTitle')}</p>
+
+      {error && (
+        <Alert variant="destructive" className="mb-2">
+          <AlertDescription>{t('orderHistoryLoadError')}</AlertDescription>
+        </Alert>
+      )}
+
+      {!error && (orders == null || orders.length === 0) && (
+        <p className="text-sm text-muted-foreground">{t('orderHistoryEmpty')}</p>
+      )}
+
+      {!error && orders != null && orders.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <tbody className="divide-y divide-border">
+              {orders.map((order) => {
+                const sKey = statusKey(order.status);
+                const pKey = purposeKey(order.purpose);
+                return (
+                  <tr key={order.order_id}>
+                    <td className="py-2 pr-3 text-muted-foreground">{order.created_at.slice(0, 10)}</td>
+                    <td className="py-2 pr-3 text-muted-foreground">{pKey ? t(pKey) : order.purpose}</td>
+                    <td className="py-2 pr-3 font-medium text-foreground">{formatKrw(order.amount_minor)}</td>
+                    <td className="py-2 pr-3 text-muted-foreground">{sKey ? t(sKey) : order.status}</td>
+                    <td className="py-2">
+                      {order.receipt_url ? (
+                        <a
+                          href={order.receipt_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-primary hover:underline"
+                        >
+                          {t('orderHistoryReceiptLink')}
+                          <ExternalLink className="h-3 w-3" aria-hidden />
+                        </a>
+                      ) : null}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/ee/components/billing/order-history-section.tsx
+++ b/apps/web/src/ee/components/billing/order-history-section.tsx
@@ -42,6 +42,15 @@ function purposeKey(purpose: string): 'orderHistoryPurposeCharge' | 'orderHistor
   return null;
 }
 
+// story #3209 유나 design:changes(2026-08-29) — 3상태가 전부 무색이면 실패가 성공과
+// 시각 동일해진다("실패 시도도 보여준다"는 pending/failed 포함 명분과 자가당착). 결제
+// 완료=success 색은 재량으로 payment-method-section.tsx 자매 섹션의 성공 배너와 맞춘다.
+function statusColorClass(status: string): string {
+  if (status === 'confirmed') return 'text-success';
+  if (status === 'failed') return 'text-destructive';
+  return 'text-muted-foreground';
+}
+
 export function OrderHistorySection({ canManage }: { canManage: boolean }) {
   const t = useTranslations('pricingPlans');
   const [orders, setOrders] = useState<BillingOrderItem[] | null | undefined>(undefined);
@@ -80,6 +89,17 @@ export function OrderHistorySection({ canManage }: { canManage: boolean }) {
       {!error && orders != null && orders.length > 0 && (
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
+            {/* 유나 design:changes — 스크린리더 컬럼 연결(a11y). 시각적으로는 기존 톤(연한
+                muted 헤더)만 얹고 레이아웃엔 관여하지 않는다. */}
+            <thead>
+              <tr className="text-left text-xs text-muted-foreground">
+                <th scope="col" className="pb-1.5 pr-3 font-medium">{t('orderHistoryColDate')}</th>
+                <th scope="col" className="pb-1.5 pr-3 font-medium">{t('orderHistoryColPurpose')}</th>
+                <th scope="col" className="pb-1.5 pr-3 font-medium">{t('orderHistoryColAmount')}</th>
+                <th scope="col" className="pb-1.5 pr-3 font-medium">{t('orderHistoryColStatus')}</th>
+                <th scope="col" className="pb-1.5 font-medium">{t('orderHistoryColReceipt')}</th>
+              </tr>
+            </thead>
             <tbody className="divide-y divide-border">
               {orders.map((order) => {
                 const sKey = statusKey(order.status);
@@ -89,7 +109,7 @@ export function OrderHistorySection({ canManage }: { canManage: boolean }) {
                     <td className="py-2 pr-3 text-muted-foreground">{order.created_at.slice(0, 10)}</td>
                     <td className="py-2 pr-3 text-muted-foreground">{pKey ? t(pKey) : order.purpose}</td>
                     <td className="py-2 pr-3 font-medium text-foreground">{formatKrw(order.amount_minor)}</td>
-                    <td className="py-2 pr-3 text-muted-foreground">{sKey ? t(sKey) : order.status}</td>
+                    <td className={`py-2 pr-3 ${statusColorClass(order.status)}`}>{sKey ? t(sKey) : order.status}</td>
                     <td className="py-2">
                       {order.receipt_url ? (
                         <a

--- a/backend/alembic/versions/0291_billing_orders_receipt_url.py
+++ b/backend/alembic/versions/0291_billing_orders_receipt_url.py
@@ -1,0 +1,34 @@
+"""story #3209(PR-1) — billing_orders에 Toss receipt_url 저장.
+
+Toss 결제 승인 응답(payment 객체)의 `receipt.url`(공식 문서 확認, 2026-08-29 —
+docs.tosspayments.com/reference §Payment — "구매자에게 제공할 수 있는 결제수단별
+영수증", 카드=매출전표·가상계좌=무통장 거래명세서 등)을 confirmed 시점에 정본으로
+저장한다. 신규 발급/렌더 없이 Toss 호스팅 URL을 그대로 링크(PO 안 §1). nullable —
+과거(이 컬럼 신설 前) confirmed order는 소급 채움 없이 NULL로 남는다(신규 컬럼 add만,
+기존 행 UPDATE 없음 — 이번 PR 스코프 밖).
+
+Revision ID: 0291
+Revises: 0290
+Create Date: 2026-08-29
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0291"
+down_revision = "0290"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "billing_orders",
+        sa.Column("receipt_url", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("billing_orders", "receipt_url")

--- a/backend/app/models/billing_order.py
+++ b/backend/app/models/billing_order.py
@@ -36,3 +36,7 @@ class BillingOrder(Base, TimestampMixin, OrgScopedMixin):
     # 원 charge(status='confirmed')를 되돌리지 않는다(선생님 지시) — 그래서 실패 표기는
     # status가 아니라 이 별도 필드다.
     refund_status: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #3209(PR-1) — Toss 결제 승인 응답의 `receipt.url`(호스팅 매출전표 등, 공식
+    # 문서 §Payment). confirmed 시점에만 채워짐(pending/failed는 NULL) — billing_charge.py의
+    # _confirm_with_ledger 단일 지점에서만 쓴다(신규 발급 로직 없이 Toss URL 그대로 저장).
+    receipt_url: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/services/billing_charge.py
+++ b/backend/app/services/billing_charge.py
@@ -55,12 +55,18 @@ async def _confirm_with_ledger(
     session: AsyncSession, *, org_id: uuid.UUID, order_id: str,
     amount_minor: int, currency: str, payment_key: str,
     entry_type: str = "charge", ledger_metadata: dict | None = None,
+    receipt_url: str | None = None,
 ) -> BillingOrder:
     """⛔블로커2 fix — 원장을 confirmed-update **前**에 먼저(멱등 provider_ref).
 
     entry_type(#2505, story 확장): 기본 "charge"(정기결제)지만 팩 구매처럼 별개
     entry_type으로 원장에 남겨야 하는 호출자를 위해 파라미터화 — direction은 여전히
-    "credit"(돈이 들어옴)로 고정, 팩/정기결제 둘 다 매출이라 방향은 같다."""
+    "credit"(돈이 들어옴)로 고정, 팩/정기결제 둘 다 매출이라 방향은 같다.
+
+    receipt_url(story #3209 PR-1): 호출자가 이미 받아둔 Toss payment 응답의
+    `receipt.url`을 그대로 전달 — 이 함수가 별도로 Toss를 다시 조회하지 않는다(모든
+    호출자가 이미 그 응답을 들고 이 함수에 들어온다, charge_org/_reconcile_duplicated_order/
+    sweep_stale_pending_orders 공통)."""
     await record_ledger_entry(
         session, org_id=org_id, entry_type=entry_type, amount_minor=amount_minor,
         currency=currency, direction="credit", provider="toss", provider_ref=payment_key,
@@ -69,7 +75,7 @@ async def _confirm_with_ledger(
     await session.execute(
         update(BillingOrder)
         .where(BillingOrder.order_id == order_id, BillingOrder.status != "confirmed")
-        .values(status="confirmed", payment_key=payment_key, updated_at=func.now())
+        .values(status="confirmed", payment_key=payment_key, receipt_url=receipt_url, updated_at=func.now())
     )
     await session.commit()
     return await _refetch(session, order_id)
@@ -93,9 +99,11 @@ async def _reconcile_duplicated_order(
         await _mark_failed_if_not_confirmed(session, order_id, "duplicated order lookup missing paymentKey")
         return await _refetch(session, order_id)
 
+    receipt_url = (lookup.get("receipt") or {}).get("url")
     return await _confirm_with_ledger(
         session, org_id=org_id, order_id=order_id, amount_minor=amount_minor,
         currency=currency, payment_key=payment_key, entry_type=entry_type, ledger_metadata=ledger_metadata,
+        receipt_url=receipt_url,
     )
 
 
@@ -197,7 +205,11 @@ async def charge_org(
         await _mark_failed_if_not_confirmed(session, order_id, "Toss charge response missing paymentKey")
         raise RuntimeError("Toss charge response missing paymentKey")
 
+    # story #3209(PR-1) — receipt는 nullable object(공식 문서)라 .get("receipt")가
+    # None일 수 있다 — or {}로 방어.
+    receipt_url = (result.get("receipt") or {}).get("url")
     return await _confirm_with_ledger(
         session, org_id=org_id, order_id=order_id, amount_minor=amount_minor,
         currency=currency, payment_key=payment_key, entry_type=entry_type, ledger_metadata=ledger_metadata,
+        receipt_url=receipt_url,
     )

--- a/backend/app/services/billing_scheduler.py
+++ b/backend/app/services/billing_scheduler.py
@@ -388,10 +388,12 @@ async def sweep_stale_pending_orders(session: AsyncSession, *, now: datetime | N
             continue
 
         if lookup.get("status") == "DONE" and lookup.get("paymentKey"):
+            # story #3209(PR-1) — 이 대사 경로로 confirmed되는 order도 동일하게 receipt_url을 채운다.
             await _confirm_with_ledger(
                 session, org_id=order.org_id, order_id=order.order_id,
                 amount_minor=order.amount_minor, currency=order.currency,
                 payment_key=lookup["paymentKey"],
+                receipt_url=(lookup.get("receipt") or {}).get("url"),
             )
             confirmed += 1
         else:

--- a/backend/ee/routers/billing.py
+++ b/backend/ee/routers/billing.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.billing_order import BillingOrder
 from app.models.org_subscription import OrgSubscription
 from app.models.pricing_version import PricingVersion
 from app.models.project import OrgMember
@@ -123,6 +124,53 @@ async def get_billing_status(
         "au_current": au_current,
         "au_limit": au_limit,
         "au_paused": sub.au_paused_at is not None,
+    }
+
+
+@router.get("/orders")
+async def list_billing_orders(
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+    _ee: None = Depends(_require_ee),
+) -> dict:
+    """story #3209(PR-1) — 웹 빌링 내역(주문별). /status와 동일 can_manage 축(owner/admin만
+    — 결제 금액·영수증은 billing 관리 권한과 같은 민감도로 취급, 이 라우터의 기존
+    관례를 그대로 따른다). 최근 순 최대 50건 — pending/failed도 포함(진짜 "내역"이라
+    confirmed만 거르면 실패한 시도가 안 보여 사용자가 재시도 여부를 판단 못 한다).
+    receipt_url은 confirmed에서만 값이 있다(billing_charge.py._confirm_with_ledger)."""
+    role_result = await session.execute(
+        select(OrgMember.role).where(
+            OrgMember.org_id == org_id,
+            OrgMember.user_id == uuid.UUID(auth.user_id),
+            OrgMember.deleted_at.is_(None),
+        )
+    )
+    caller_role = role_result.scalar_one_or_none() or "member"
+    if caller_role not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="billing history requires owner/admin role")
+
+    orders = (
+        await session.execute(
+            select(BillingOrder)
+            .where(BillingOrder.org_id == org_id)
+            .order_by(BillingOrder.created_at.desc())
+            .limit(50)
+        )
+    ).scalars().all()
+    return {
+        "data": [
+            {
+                "order_id": o.order_id,
+                "created_at": o.created_at.isoformat(),
+                "amount_minor": o.amount_minor,
+                "currency": o.currency,
+                "status": o.status,
+                "purpose": o.purpose,
+                "receipt_url": o.receipt_url,
+            }
+            for o in orders
+        ]
     }
 
 

--- a/backend/ee/routers/billing.py
+++ b/backend/ee/routers/billing.py
@@ -133,12 +133,18 @@ async def list_billing_orders(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
     _ee: None = Depends(_require_ee),
-) -> dict:
+) -> list[dict]:
     """story #3209(PR-1) — 웹 빌링 내역(주문별). /status와 동일 can_manage 축(owner/admin만
     — 결제 금액·영수증은 billing 관리 권한과 같은 민감도로 취급, 이 라우터의 기존
     관례를 그대로 따른다). 최근 순 최대 50건 — pending/failed도 포함(진짜 "내역"이라
     confirmed만 거르면 실패한 시도가 안 보여 사용자가 재시도 여부를 판단 못 한다).
-    receipt_url은 confirmed에서만 값이 있다(billing_charge.py._confirm_with_ledger)."""
+    receipt_url은 confirmed에서만 값이 있다(billing_charge.py._confirm_with_ledger).
+
+    카디르 QA(PR#3605) — flat list로 반환한다(**{"data": [...]}로 감싸지 않음**).
+    FE 프록시(`proxyToFastapiWrapped`)가 이 BE 응답 바디를 그대로 `apiSuccess(raw)`에
+    넘겨 `{data: raw, ...}`로 감싼다 — 여기서 이미 `{"data": [...]}`를 반환하면 FE가
+    받는 최종 모양이 `{data: {data: [...]}}`로 이중래핑돼(화면이 조용히 빈 채/크래시)
+    `/status`(이 라우터의 자매 엔드포인트, 항상 flat dict 반환)와 동일 계약을 따른다."""
     role_result = await session.execute(
         select(OrgMember.role).where(
             OrgMember.org_id == org_id,
@@ -158,20 +164,18 @@ async def list_billing_orders(
             .limit(50)
         )
     ).scalars().all()
-    return {
-        "data": [
-            {
-                "order_id": o.order_id,
-                "created_at": o.created_at.isoformat(),
-                "amount_minor": o.amount_minor,
-                "currency": o.currency,
-                "status": o.status,
-                "purpose": o.purpose,
-                "receipt_url": o.receipt_url,
-            }
-            for o in orders
-        ]
-    }
+    return [
+        {
+            "order_id": o.order_id,
+            "created_at": o.created_at.isoformat(),
+            "amount_minor": o.amount_minor,
+            "currency": o.currency,
+            "status": o.status,
+            "purpose": o.purpose,
+            "receipt_url": o.receipt_url,
+        }
+        for o in orders
+    ]
 
 
 async def _get_au_usage(

--- a/backend/tests/test_e_2494_c3_scheduler.py
+++ b/backend/tests/test_e_2494_c3_scheduler.py
@@ -376,6 +376,8 @@ async def test_sweep_stale_pending_confirms_when_toss_lookup_done(monkeypatch):
         session, org_id=stale_order.org_id, order_id=stale_order.order_id,
         amount_minor=stale_order.amount_minor, currency=stale_order.currency,
         payment_key="pay_recovered",
+        # story #3209 — lookup 응답에 receipt 키가 없으면(이 테스트 mock) None.
+        receipt_url=None,
     )
     fail_mock.assert_not_awaited()
 


### PR DESCRIPTION
## 요약
- [\[빌링·영수증\] 결제 완료 영수증 처리 — Toss receipt.url 저장·결제 완료 메일 신설·빌링 내역 노출](entity:story:e712ec19-502d-44f6-9db9-408b3f8dc9a5) — PR-1(receipt_url 저장+빌링 내역 화면). PR-2(결제 완료 메일)는 PO 지시대로 별도(v2 브랜드 셸/#3604 골격 위에 얹음, 이번 스코프 밖).

## receipt_url 저장
Toss 결제 승인 응답(payment 객체)의 `receipt.url`(공식 문서 직접 대조 — docs.tosspayments.com/reference §Payment, nullable object)을 confirmed 시점에 `billing_orders.receipt_url`로 저장(마이그 0291, down_revision=0290). `_confirm_with_ledger` 단일 지점에 파라미터 추가 — 호출자 3곳(`charge_org`의 동기 `charge()` 응답 · `_reconcile_duplicated_order`/`sweep_stale_pending_orders`의 `get_payment_by_order_id()` 응답) 전부 배선. 신규 발급/렌더 없이 Toss 호스팅 URL 그대로 저장.

## 빌링 내역 화면 신설(PO 방향 ① 채택)
그라운딩 실측 — "빌링 내역"(주문별 목록)이 org 설정도 어드민 콘솔도 아예 존재하지 않았음(BE 목록 엔드포인트 0·FE엔 "지금 등록된 카드"만). PO 확認 후 최소기능 목록까지 이번 PR에 포함:
- `GET /api/v2/billing/orders`(신설) — can_manage(owner/admin) 게이팅(`/status`와 동일 축), 최근 50건, pending/failed 포함(실패 시도도 보여야 재시도 판단 가능).
- FE 프록시 `apps/web/src/app/api/billing/orders/route.ts`(status/route.ts와 동형).
- `order-history-section.tsx`(신설) — payment-method-section.tsx와 동형 관례(무권한 시 fetch 자체 스킵). 표: 주문일·목적(정기결제/팩구매)·금액·상태·영수증 링크(confirmed만, `target=_blank`+`rel=noopener`). `billing-tab.tsx`에 배선.

## 마이그 번호 재조정
PO 지적 — 0290은 PR#3604(users.locale)가 선점. 0291·down_revision=0290으로 재번호 + 3604 develop 착지(06eac0a5e) 확認 후 rebase 완료(충돌 0).

## 검증
- 신규 FE pin 5건(`order-history-section.test.tsx`) — canManage=false 무렌더 · 빈상태 · confirmed 링크(target/rel 속성 포함) · pending/failed 링크 없음(지어낸 링크 금지) · 조회실패 에러문구.
- tsc 0 · lint 0(무관 기존 5건) · verify:raw-fetch/raw-button/i18n 전부 GREEN · 전체 vitest 534파일/5004건 GREEN · build GREEN.
- backend: py_compile·alembic heads(단일 0291)·pytest(billing/member_ssot 관련 144 passed) 전부 GREEN.

## ⚠️ AC1 라이브 검증 — 머지 後 필요(구조적으로 사전 불가)
dev 테스트 결제 1건으로 실제 receipt_url 저장+화면 노출을 확인하는 절차는 이 PR이 **dev에 배포된 뒤에만** 가능(현재 dev는 develop 브랜치 코드로 동작 — 이 feature 브랜치의 신규 코드는 아직 그 어떤 환경에도 안 떠 있음). 머지→dev 배포 확認 후 실 결제 리그로 라이브 검증 마무리 예정(내가 하거나 카디르 QA 라운드에서 겸함).

prod 무접촉(develop 대상).