### PR TITLE
[SID:3206] 발송 메일 공통 브랜드 셸 배선 — 유나 v2 시안

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -612,7 +612,8 @@ async def register(
         from app.services.email import render_action_email, send_email
         from app.services.email_copy import TRANSACTIONAL_COPY
         # story #3205 — locale=ko 유저 → ko 메일·locale=en 유저 → en 메일(AC1).
-        copy = TRANSACTIONAL_COPY["verify_email"][resolve_locale(user.locale)]
+        locale = resolve_locale(user.locale)
+        copy = TRANSACTIONAL_COPY["verify_email"][locale]
         delivered = send_email(
             to=user.email,
             subject=copy["subject"],
@@ -622,6 +623,7 @@ async def register(
                 cta_url=verify_link,
                 expiry_note=copy["expiry_note"],
                 security_note=copy["security_note"],
+                locale=locale,
                 fallback_label=copy["fallback_label"],
             ),
         )
@@ -1451,7 +1453,8 @@ async def forgot_password(
         from app.services.agent_onboarding_config import resolve_locale
         from app.services.email import render_action_email, send_email
         from app.services.email_copy import TRANSACTIONAL_COPY
-        copy = TRANSACTIONAL_COPY["reset_password"][resolve_locale(user.locale)]
+        locale = resolve_locale(user.locale)
+        copy = TRANSACTIONAL_COPY["reset_password"][locale]
         send_email(
             to=user.email,
             subject=copy["subject"],
@@ -1459,6 +1462,7 @@ async def forgot_password(
                 intro_lines=copy["intro_lines"],
                 cta_label=copy["cta_label"],
                 cta_url=reset_link,
+                locale=locale,
                 expiry_note=copy["expiry_note"],
                 security_note=copy["security_note"],
                 fallback_label=copy["fallback_label"],
@@ -1589,7 +1593,8 @@ async def resend_verification(
     from app.services.agent_onboarding_config import resolve_locale
     from app.services.email import render_action_email, send_email
     from app.services.email_copy import TRANSACTIONAL_COPY
-    copy = TRANSACTIONAL_COPY["verify_email"][resolve_locale(user.locale)]
+    locale = resolve_locale(user.locale)
+    copy = TRANSACTIONAL_COPY["verify_email"][locale]
     delivered = send_email(
         to=user.email,
         subject=copy["subject"],
@@ -1600,6 +1605,7 @@ async def resend_verification(
             expiry_note=copy["expiry_note"],
             security_note=copy["security_note"],
             fallback_label=copy["fallback_label"],
+            locale=locale,
         ),
     )
     if not delivered:

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -25,7 +25,7 @@ from app.models.org_subscription import OrgSubscription
 from app.models.project import OrgMember
 from app.models.user import User
 from app.services.agent_onboarding_config import resolve_locale
-from app.services.email import send_email
+from app.services.email import render_email_shell, send_email
 from app.services.email_copy import AU_WARN_COPY, STORAGE_WARN_COPY
 from app.services.storage import get_storage_provider
 
@@ -925,9 +925,11 @@ async def storage_usage_warn(
             pct = round(used / cap_bytes * 100, 1)
             # story #3205(AC3) — 어드민 locale 기준 분기(수신자별 개별). 기존엔 en 고정이었다.
             for em, locale_value in recipients:
-                copy = STORAGE_WARN_COPY[resolve_locale(locale_value)]
+                recipient_locale = resolve_locale(locale_value)
+                copy = STORAGE_WARN_COPY[recipient_locale]
                 subject = copy["subject"].format(pct=pct)
-                html = copy["body"].format(pct=pct, used_mb=used // (1024 * 1024), cap_mb=cap_mb)
+                content = copy["body"].format(pct=pct, used_mb=used // (1024 * 1024), cap_mb=cap_mb)
+                html = render_email_shell(content, locale=recipient_locale)
                 try:
                     await asyncio.to_thread(send_email, em, subject, html)
                 except Exception:
@@ -1037,9 +1039,11 @@ async def au_usage_warn(
                     pct_display = round(pct * 100, 1)
                     # story #3205(AC3) — 어드민 locale 기준 분기(수신자별 개별). 기존엔 en 고정.
                     for em, locale_value in recipients:
-                        copy = AU_WARN_COPY[resolve_locale(locale_value)]
+                        recipient_locale = resolve_locale(locale_value)
+                        copy = AU_WARN_COPY[recipient_locale]
                         subject = copy["subject"].format(pct=pct_display)
-                        html = copy["body"].format(pct=pct_display, current=current, au_limit=au_limit)
+                        content = copy["body"].format(pct=pct_display, current=current, au_limit=au_limit)
+                        html = render_email_shell(content, locale=recipient_locale)
                         try:
                             await asyncio.to_thread(send_email, em, subject, html)
                         except Exception:

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -41,7 +41,8 @@ def render_email_shell(content_html: str, *, locale: str = "ko") -> str:
     privacy_url = f"{app_url}/privacy"
     return f"""<!DOCTYPE html>
 <html lang="{locale}">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light dark"><meta name="supported-color-schemes" content="light dark"></head>
 <body style="margin:0;padding:0;background:#e9e7e1;font-family:-apple-system,'Segoe UI',Roboto,'Apple SD Gothic Neo','Malgun Gothic',sans-serif;">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#e9e7e1;padding:24px 0;">
     <tr><td align="center">

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -3,10 +3,67 @@ import html
 import logging
 import os
 import smtplib
+from datetime import datetime, timezone
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 logger = logging.getLogger(__name__)
+
+# story #3206(유나 v2 시안, doc email-brand-shell-proposal-3206, 아티팩트 afaeca1f) —
+# apps/web/src/lib/legal/business-info.ts(전자상거래법 §10 SSOT)와 자구 그대로 일치시킨
+# 백엔드측 사본. 그 파일이 앱 내 유일 정본이라 import는 못 하지만(별도 런타임), 값은
+# 글자 단위로 동일해야 한다 — 그쪽이 바뀌면 이쪽도 같이 바뀌어야 함(자동 동기화 없음).
+_COMPANY_NAME = "주식회사 뭉클랩"
+_COMPANY_CEO = "윤도선"
+_COMPANY_REG_NO = "488-88-02579"
+_COMPANY_ADDRESS = "경기도 고양시 일산동구 무궁화로 20-38, 5층 502호"
+_COMPANY_PHONE = "070-8098-5775"
+
+
+def render_email_shell(content_html: str, *, locale: str = "ko") -> str:
+    """story #3206 — 발송 메일 공용 브랜드 셸(유나 v2 시안, 아티팩트 afaeca1f).
+
+    v1(색 헤더 바·tint 푸터)이 실기기 반증(선생님 갤럭시 Gmail 다크 = bgcolor 강제
+    재배색으로 색 헤더 바·버튼 bg·카드 bg가 통째 소실)으로 폐기되고, v2는 위계를
+    **구분선·여백·타이포 굵기**로만 세운다(색 fill에 의존한 위계는 반전되면 사라짐).
+    로고도 이미지 미표시가 실기기 확認이라 텍스트 워드마크만 쓴다.
+
+    호출자는 내부 콘텐츠 HTML만 만들어 넘기면 된다 — 문서 골격(DOCTYPE/table 셸/
+    헤더/푸터)은 전부 이 함수 책임(단일 조립 지점, 사이트 전체 발송 메일 공통).
+
+    ⚠️ 푸터에 "도움말" 링크는 넣지 않는다 — 시안엔 있으나 실제 목적지 페이지가
+    앱에 없다(grounding 확認: `/help` 라우트 부재). 임의 URL을 짓지 않고 이용약관·
+    개인정보처리방침(실존 라우트, business-info.ts LEGAL_DOC_ROUTES)만 남긴다 —
+    페이지가 생기면 그때 추가."""
+    year = datetime.now(timezone.utc).year
+    app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
+    terms_url = f"{app_url}/terms"
+    privacy_url = f"{app_url}/privacy"
+    return f"""<!DOCTYPE html>
+<html lang="{locale}">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#e9e7e1;font-family:-apple-system,'Segoe UI',Roboto,'Apple SD Gothic Neo','Malgun Gothic',sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#e9e7e1;padding:24px 0;">
+    <tr><td align="center">
+      <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;margin:0 auto;background:#ffffff;border-radius:10px;overflow:hidden;border:1px solid #ececec;">
+        <tr><td style="padding:22px 32px 16px;border-bottom:1px solid #ececec;">
+          <span style="font-size:20px;font-weight:800;letter-spacing:-.3px;color:#3157FF;">Sprintable</span>
+        </td></tr>
+        <tr><td style="padding:22px 32px;font-size:14px;line-height:1.6;color:#1a1a1a;">
+          {content_html}
+        </td></tr>
+        <tr><td style="border-top:1px solid #ececec;padding:16px 32px;font-size:11px;line-height:1.7;color:#9a9a9a;">
+          <span style="font-weight:700;color:#6b6b6b;">Sprintable</span> · Ship with AI agents<br>
+          {_COMPANY_NAME} · 대표이사 {_COMPANY_CEO} · 사업자등록번호 {_COMPANY_REG_NO}<br>
+          {_COMPANY_ADDRESS} · {_COMPANY_PHONE}<br>
+          <a href="{terms_url}" style="color:#8b8b8b;text-decoration:underline;">이용약관</a> · <a href="{privacy_url}" style="color:#8b8b8b;text-decoration:underline;">개인정보처리방침</a><br>
+          © {year} Sprintable
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>"""
 
 
 def render_action_email(
@@ -17,6 +74,7 @@ def render_action_email(
     expiry_note: str,
     security_note: str,
     fallback_label: str,
+    locale: str = "ko",
 ) -> str:
     """story #3196-⑤(카피·톤 제안 — 유나 홀름, doc auth-email-copy-proposal-3196) — 인사/
     맥락 → CTA 버튼 → 만료 → 폴백 평문 링크 → 보안 안내, 트랜잭셔널 메일 3종(가입 인증·
@@ -34,21 +92,26 @@ def render_action_email(
     story #3205 QA(까디르, 2026-08-29) — fallback_label이 예전엔 렌더러 내부에 ko로
     하드코딩돼 있어 en 메일에도 한국어 한 줄이 섞였다(호출자가 카피를 100% 못 갈아끼우는
     구조적 결함). 다른 4개 필드와 동형으로 파라미터화.
+
+    story #3206(유나 v2 시안, 실기기 반증 반영) — 버튼은 bg+테두리 병용(#3157FF, Gmail
+    다크가 bg를 죽여도 테두리 상자+굵은 글자로 여전히 버튼으로 읽힘)·전체를
+    render_email_shell()로 감싸 헤더(워드마크+구분선)·푸터(구분선+회사정보)를 얹는다.
     """
-    intro_html = "".join(f"<p>{html.escape(line)}</p>" for line in intro_lines)
-    return (
+    intro_html = "".join(f"<p style='margin:0 0 10px'>{html.escape(line)}</p>" for line in intro_lines)
+    content = (
         f"{intro_html}"
-        f"<p style='margin:24px 0'>"
+        f"<p style='margin:20px 0'>"
         f"<a href='{cta_url}' "
-        f"style='display:inline-block;padding:12px 24px;background:#2952E3;color:#ffffff;"
-        f"text-decoration:none;border-radius:6px;font-weight:600'>"
+        f"style='display:inline-block;padding:12px 24px;background:#3157FF;border:2px solid #3157FF;"
+        f"color:#ffffff;text-decoration:none;border-radius:6px;font-weight:700;font-size:14px'>"
         f"{html.escape(cta_label)}</a></p>"
-        f"<p>{html.escape(expiry_note)}</p>"
-        f"<p style='font-size:12px;color:#595959'>"
+        f"<p style='font-size:13px;color:#595959;margin:0 0 8px'>{html.escape(expiry_note)}</p>"
+        f"<p style='font-size:12px;color:#8b8b8b;margin:0 0 8px'>"
         f"{html.escape(fallback_label)}<br>"
-        f"<a href='{cta_url}'>{cta_url}</a></p>"
-        f"<p style='font-size:12px;color:#595959'>{html.escape(security_note)}</p>"
+        f"<a href='{cta_url}' style='color:#3157FF;text-decoration:underline'>{cta_url}</a></p>"
+        f"<p style='font-size:12px;color:#8b8b8b;margin:0'>{html.escape(security_note)}</p>"
     )
+    return render_email_shell(content, locale=locale)
 
 
 def send_email(to: str, subject: str, html_body: str) -> bool:

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -109,7 +109,7 @@ def render_action_email(
         f"<p style='font-size:13px;color:#595959;margin:0 0 8px'>{html.escape(expiry_note)}</p>"
         f"<p style='font-size:12px;color:#8b8b8b;margin:0 0 8px'>"
         f"{html.escape(fallback_label)}<br>"
-        f"<a href='{cta_url}' style='color:#3157FF;text-decoration:underline'>{cta_url}</a></p>"
+        f"<a href='{cta_url}' style='color:#3157FF;text-decoration:underline;word-break:break-all'>{cta_url}</a></p>"
         f"<p style='font-size:12px;color:#8b8b8b;margin:0'>{html.escape(security_note)}</p>"
     )
     return render_email_shell(content, locale=locale)

--- a/backend/app/services/email_copy.py
+++ b/backend/app/services/email_copy.py
@@ -94,11 +94,12 @@ INVITE_COPY: dict[str, dict[str, str]] = {
         "sub_body": "아래 버튼을 클릭하면 초대를 수락할 수 있습니다. 링크는 7일간 유효합니다.",
         "cta_label": "초대 수락하기",
         "fallback_label": "버튼이 보이지 않으면 아래 주소를 브라우저에 붙여 넣으세요:",
-        # 유나 검수 수정의견①(2026-08-29, doc email-locale-copy-proposal-3205) — 고정 연도 stale
-        # 방지, 동적 {year} 삽입(발송 시점 기준).
-        "footer": "© {year} Sprintable. 이 이메일은 초대 발송으로 자동 생성되었습니다.",
+        # story #3206 — 공용 셸(render_email_shell)이 회사정보·연도·법적 링크 푸터를
+        # 전담하면서 이 필드의 "© {year} Sprintable." 부분은 셸과 중복이라 걷어냈다(유나
+        # doc email-brand-shell-proposal-3206 ③ 수렴 지시). "왜 이 메일을 받았는지"만
+        # 콘텐츠 영역 마지막 줄로 남긴다.
+        "auto_generated_note": "이 이메일은 초대 발송으로 자동 생성되었습니다.",
         "default_inviter": "팀 관리자",
-        "html_lang": "ko",
     },
     "en": {
         "subject": "[Sprintable] You've been invited to {org_name}",
@@ -109,9 +110,8 @@ INVITE_COPY: dict[str, dict[str, str]] = {
         "sub_body": "Click the button below to accept the invitation. This link is valid for 7 days.",
         "cta_label": "Accept invitation",
         "fallback_label": "If the button doesn't work, paste this address into your browser:",
-        "footer": "© {year} Sprintable. This email was sent automatically because you were invited.",
+        "auto_generated_note": "This email was sent automatically because you were invited.",
         "default_inviter": "a team admin",
-        "html_lang": "en",
     },
 }
 

--- a/backend/app/services/onboarding_activation.py
+++ b/backend/app/services/onboarding_activation.py
@@ -217,16 +217,22 @@ async def find_reminder_candidates(db: AsyncSession, *, now: datetime | None = N
 
 
 def _reminder_email_body(*, app_url: str, unsub_link: str, locale: str) -> str:
+    from app.services.email import render_email_shell
     from app.services.email_copy import REMINDER_COPY
     copy = REMINDER_COPY[locale]
-    return (
-        f"<p>{copy['intro']}</p>"
-        f"<p><a href='{app_url}'>{copy['cta_label']}</a></p>"
+    # story #3206 — 트랜잭셔널 3종과 동형 버튼(bg+테두리, Gmail 다크 bg 소실에도 상자로 식별).
+    content = (
+        f"<p style='margin:0 0 10px'>{copy['intro']}</p>"
+        f"<p style='margin:20px 0'>"
+        f"<a href='{app_url}' style='display:inline-block;padding:12px 24px;background:#3157FF;"
+        f"border:2px solid #3157FF;color:#ffffff;text-decoration:none;border-radius:6px;"
+        f"font-weight:700;font-size:14px'>{copy['cta_label']}</a></p>"
         # 유나 design:pass 권장(2026-08-27) — #888은 흰 배경 대비 3.5:1로 AA(4.5) 미달.
         # #595959로 7:1(AAA) 확保.
-        "<p style='font-size:12px;color:#595959'>"
-        f"<a href='{unsub_link}'>{copy['unsub_label']}</a></p>"
+        "<p style='font-size:12px;color:#595959;margin:0'>"
+        f"<a href='{unsub_link}' style='color:#595959'>{copy['unsub_label']}</a></p>"
     )
+    return render_email_shell(content, locale=locale)
 
 
 async def send_activation_reminder(db: AsyncSession, user: User) -> bool:

--- a/backend/app/services/org_invite_email.py
+++ b/backend/app/services/org_invite_email.py
@@ -43,7 +43,7 @@ def _build_invite_html(*, org_name: str, inviter_name: str, accept_link: str, ro
         f"<p style='margin:20px 0'><a href='{accept_link}' style='{_BUTTON_STYLE}'>{copy['cta_label']}</a></p>"
         f"<p style='margin:0 0 8px;font-size:12px;color:#8b8b8b'>"
         f"{copy['fallback_label']}<br>"
-        f"<a href='{accept_link}' style='color:#3157FF;text-decoration:underline'>{accept_link}</a></p>"
+        f"<a href='{accept_link}' style='color:#3157FF;text-decoration:underline;word-break:break-all'>{accept_link}</a></p>"
         f"<p style='margin:0;font-size:12px;color:#8b8b8b'>{copy['auto_generated_note']}</p>"
     )
     return render_email_shell(content, locale=locale)

--- a/backend/app/services/org_invite_email.py
+++ b/backend/app/services/org_invite_email.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 import logging
 import os
 
-from app.services.email import send_email
+from app.services.email import render_email_shell, send_email
 from app.services.email_copy import INVITE_COPY
 
 logger = logging.getLogger(__name__)
 
+# story #3206 — 트랜잭셔널 3종·리마인드와 동형 버튼(bg+테두리 병용, Gmail 다크 bg 소실
+# 대응). 기존 #6366f1(인디고) 단색 버튼은 v2 브랜드색(#3157FF)+셸 공통 톤으로 정합.
 _BUTTON_STYLE = (
-    "display:inline-block;padding:12px 28px;background:#6366f1;color:#ffffff;"
-    "text-decoration:none;border-radius:8px;font-weight:600;font-size:15px;"
+    "display:inline-block;padding:12px 24px;background:#3157FF;border:2px solid #3157FF;"
+    "color:#ffffff;text-decoration:none;border-radius:6px;font-weight:700;font-size:14px;"
 )
 
 
@@ -26,50 +28,25 @@ def _en_role_with_article(role: str) -> str:
 
 
 def _build_invite_html(*, org_name: str, inviter_name: str, accept_link: str, role: str, locale: str) -> str:
-    from datetime import datetime, timezone
-
+    """story #3206 — 공용 셸(render_email_shell)이 헤더/푸터를 전담. 이 함수는 콘텐츠
+    영역(제목·본문·버튼·폴백 링크·자동생성 안내)만 만든다 — 예전엔 이 함수가 DOCTYPE/
+    body/헤더바(#6366f1)/카드/tint 푸터까지 전부 자체 소유했는데(v1 스타일), 유나 v2
+    시안이 그 인디고 헤더 바 자체를 실기기 반증으로 폐기했고(색 fill 위계 → 구분선
+    위계) 푸터도 회사정보 SSOT가 중복되던 걸 셸 쪽으로 수렴시켰다."""
     copy = INVITE_COPY[locale]
     role_display = _en_role_with_article(role) if locale == "en" else role
     body = copy["body"].format(inviter_name=inviter_name, org_name=org_name, role=role, role_display=role_display)
-    footer = copy["footer"].format(year=datetime.now(timezone.utc).year)
-    return f"""<!DOCTYPE html>
-<html lang="{copy['html_lang']}">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
-<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
-  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:40px 0;">
-    <tr><td align="center">
-      <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.1);">
-        <!-- Header -->
-        <tr><td style="background:#6366f1;padding:28px 40px;">
-          <span style="color:#ffffff;font-size:20px;font-weight:700;">Sprintable</span>
-        </td></tr>
-        <!-- Body -->
-        <tr><td style="padding:40px 40px 32px;">
-          <h2 style="margin:0 0 16px;font-size:22px;color:#111827;">{copy['heading']}</h2>
-          <p style="margin:0 0 12px;color:#374151;line-height:1.6;">
-            {body}
-          </p>
-          <p style="margin:0 0 32px;color:#6b7280;font-size:14px;line-height:1.6;">
-            {copy['sub_body']}
-          </p>
-          <a href="{accept_link}" style="{_BUTTON_STYLE}">{copy['cta_label']}</a>
-          <hr style="margin:32px 0;border:none;border-top:1px solid #e5e7eb;">
-          <p style="margin:0;color:#9ca3af;font-size:13px;line-height:1.6;">
-            {copy['fallback_label']}<br>
-            <a href="{accept_link}" style="color:#6366f1;word-break:break-all;">{accept_link}</a>
-          </p>
-        </td></tr>
-        <!-- Footer -->
-        <tr><td style="background:#f9fafb;padding:20px 40px;border-top:1px solid #e5e7eb;">
-          <p style="margin:0;color:#9ca3af;font-size:12px;">
-            {footer}
-          </p>
-        </td></tr>
-      </table>
-    </td></tr>
-  </table>
-</body>
-</html>"""
+    content = (
+        f"<h2 style='margin:0 0 16px;font-size:20px;color:#1a1a1a'>{copy['heading']}</h2>"
+        f"<p style='margin:0 0 12px'>{body}</p>"
+        f"<p style='margin:0 0 20px;font-size:13px;color:#595959'>{copy['sub_body']}</p>"
+        f"<p style='margin:20px 0'><a href='{accept_link}' style='{_BUTTON_STYLE}'>{copy['cta_label']}</a></p>"
+        f"<p style='margin:0 0 8px;font-size:12px;color:#8b8b8b'>"
+        f"{copy['fallback_label']}<br>"
+        f"<a href='{accept_link}' style='color:#3157FF;text-decoration:underline'>{accept_link}</a></p>"
+        f"<p style='margin:0;font-size:12px;color:#8b8b8b'>{copy['auto_generated_note']}</p>"
+    )
+    return render_email_shell(content, locale=locale)
 
 
 def send_invite_email(

--- a/backend/tests/test_3205_email_locale_routing.py
+++ b/backend/tests/test_3205_email_locale_routing.py
@@ -162,6 +162,9 @@ async def test_send_activation_reminder_uses_user_locale(monkeypatch):
     assert "이어서 진행하기" in sent[0]["html_body"]
     assert sent[1]["subject"] == "Sprintable — a few steps left to finish setup"
     assert "Continue setup" in sent[1]["html_body"]
+    # story #3206(AC1) — 리마인드도 공용 셸 경유(회사정보 푸터 존재로 확認).
+    assert "주식회사 뭉클랩" in sent[0]["html_body"]
+    assert "주식회사 뭉클랩" in sent[1]["html_body"]
 
 
 def test_send_invite_email_uses_locale_param(monkeypatch):
@@ -188,7 +191,13 @@ def test_send_invite_email_uses_locale_param(monkeypatch):
     assert "as an admin" in sent["html_body"]
     # 유나 검수 수정의견①: footer 연도가 고정 2025가 아니라 동적.
     assert "© 2025 Sprintable" not in sent["html_body"]
-    assert "Sprintable. This email was sent automatically" in sent["html_body"]
+    # story #3206 — 셸 공용 푸터가 연도/회사정보를 전담(중복 제거), 이 카피는
+    # "왜 이 메일을 받았는지"만 남는다.
+    assert "This email was sent automatically because you were invited." in sent["html_body"]
+    # story #3206(AC1) — 초대도 공용 셸 경유(v1 자체 인디고 헤더바/tint 푸터가 아니라
+    # 셸의 회사정보 푸터로 대체됐는지).
+    assert "주식회사 뭉클랩" in sent["html_body"]
+    assert "background:#6366f1" not in sent["html_body"]
 
 
 def test_send_invite_email_defaults_to_ko(monkeypatch):

--- a/backend/tests/test_email_copy.py
+++ b/backend/tests/test_email_copy.py
@@ -35,11 +35,11 @@ def test_invite_copy_formats_without_error_both_locales():
         copy = INVITE_COPY[locale]
         subject = copy["subject"].format(org_name="Acme")
         body = copy["body"].format(inviter_name="Jay", org_name="Acme", role="admin", role_display="an admin")
-        footer = copy["footer"].format(year=2026)
         assert "Acme" in subject
         assert "Jay" in body and "admin" in body
-        assert "2026" in footer
-        assert copy["html_lang"] == locale
+        # story #3206 — 연도/회사정보 footer는 render_email_shell이 전담(중복 제거),
+        # 이 필드는 "왜 이 메일을 받았는지"만 남는다.
+        assert copy["auto_generated_note"]
 
 
 def test_storage_warn_copy_formats_without_error_both_locales():

--- a/backend/tests/test_email_shell.py
+++ b/backend/tests/test_email_shell.py
@@ -1,0 +1,81 @@
+"""story #3206(유나 v2 시안, 아티팩트 afaeca1f) — render_email_shell() 공용 브랜드 셸 pin.
+
+v2 원칙(실기기 반증 반영, 선생님 갤럭시 Gmail 다크)만 순수 단위테스트로 고정:
+색-fill 위계 대신 구분선/굵기, 버튼은 bg+테두리 병용, 로고=텍스트 워드마크,
+회사정보는 apps/web/src/lib/legal/business-info.ts와 자구 일치.
+"""
+from __future__ import annotations
+
+from app.services.email import render_email_shell
+
+
+def test_wraps_content_with_wordmark_header_and_divider():
+    html_body = render_email_shell("<p>본문</p>")
+    assert "본문" in html_body
+    # 로고=텍스트 워드마크(이미지 아님) — 실기기서 이미지 미표시 확認.
+    assert "Sprintable" in html_body
+    assert "<img" not in html_body
+    # 헤더 구분선(색 fill 헤더 바가 아니라 border-bottom) — v1(색 헤더 바)은 실기기 반증으로 폐기.
+    assert "border-bottom:1px solid #ececec" in html_body
+
+
+def test_footer_matches_business_info_ssot_verbatim():
+    """apps/web/src/lib/legal/business-info.ts와 글자 단위 일치 확認(story #2741 SSOT 규율,
+    이 파일은 import 못 하는 별도 런타임이라 값을 손으로 맞춰 유지 — 그 파일이 바뀌면
+    이 assertion과 email.py 상수 둘 다 같이 갱신해야 한다)."""
+    html_body = render_email_shell("<p>본문</p>")
+    assert "주식회사 뭉클랩" in html_body
+    assert "대표이사 윤도선" in html_body
+    assert "488-88-02579" in html_body
+    assert "경기도 고양시 일산동구 무궁화로 20-38, 5층 502호" in html_body
+    assert "070-8098-5775" in html_body
+
+
+def test_footer_has_dynamic_year_not_stale_literal():
+    import datetime
+    html_body = render_email_shell("<p>본문</p>")
+    this_year = datetime.datetime.now(datetime.timezone.utc).year
+    assert f"© {this_year} Sprintable" in html_body
+
+
+def test_footer_links_to_real_routes_only_no_invented_help_page():
+    """grounding 확認 — apps/web에 /help 라우트가 없다. 시안엔 "도움말" 링크가 있지만
+    실제 목적지가 없어 넣지 않는다(추측 URL 금지) — 실존 라우트(이용약관·개인정보처리방침)만."""
+    html_body = render_email_shell("<p>본문</p>")
+    assert "/terms" in html_body
+    assert "/privacy" in html_body
+    assert "도움말" not in html_body
+    assert "/help" not in html_body
+
+
+def test_locale_sets_html_lang_attribute():
+    assert 'lang="ko"' in render_email_shell("<p>x</p>", locale="ko")
+    assert 'lang="en"' in render_email_shell("<p>x</p>", locale="en")
+
+
+def test_no_flexbox_or_grid_for_email_client_compat():
+    html_body = render_email_shell("<p>본문</p>")
+    assert "display:flex" not in html_body
+    assert "display:grid" not in html_body
+
+
+def test_no_color_fill_header_bar_v1_pattern_stays_gone():
+    """v1(색 헤더 바·#6366f1 인디고 배경)이 실기기 반증으로 폐기됐다 — 헤더 <td>에
+    background色 채움이 없어야 한다(border-bottom 구분선만)."""
+    html_body = render_email_shell("<p>본문</p>")
+    header_section = html_body.split("border-bottom:1px solid #ececec")[0]
+    assert "background:#6366f1" not in header_section
+    assert "background:#3157FF" not in header_section  # 헤더도 색 fill 없음, 워드마크만 색.
+
+
+def test_render_action_email_button_uses_border_plus_bg_v2_pattern():
+    from app.services.email import render_action_email
+    html_body = render_action_email(
+        intro_lines=["줄"], cta_label="버튼", cta_url="https://x",
+        expiry_note="만료", security_note="보안", fallback_label="폴백",
+    )
+    # v2 — bg 소실(Gmail 다크)돼도 테두리 상자로 여전히 버튼 식별 가능해야 한다.
+    assert "border:2px solid #3157FF" in html_body
+    assert "background:#3157FF" in html_body
+    # 셸을 통과했는지(헤더 워드마크+푸터 회사정보 존재).
+    assert "주식회사 뭉클랩" in html_body

--- a/backend/tests/test_email_shell.py
+++ b/backend/tests/test_email_shell.py
@@ -48,6 +48,15 @@ def test_footer_links_to_real_routes_only_no_invented_help_page():
     assert "/help" not in html_body
 
 
+def test_declares_color_scheme_meta_for_dark_mode_aware_clients():
+    """PO 리뷰 지적(2026-08-29, doc email-brand-shell-proposal-3206 ④) — 다크 클라이언트가
+    팔레트 판단에 쓰는 신호. color-scheme(표준)과 supported-color-schemes(Apple Mail 등
+    구현체 페어)를 함께 선언한다."""
+    html_body = render_email_shell("<p>x</p>")
+    assert '<meta name="color-scheme" content="light dark">' in html_body
+    assert '<meta name="supported-color-schemes" content="light dark">' in html_body
+
+
 def test_locale_sets_html_lang_attribute():
     assert 'lang="ko"' in render_email_shell("<p>x</p>", locale="ko")
     assert 'lang="en"' in render_email_shell("<p>x</p>", locale="en")

--- a/backend/tests/test_email_shell.py
+++ b/backend/tests/test_email_shell.py
@@ -88,3 +88,24 @@ def test_render_action_email_button_uses_border_plus_bg_v2_pattern():
     assert "background:#3157FF" in html_body
     # 셸을 통과했는지(헤더 워드마크+푸터 회사정보 존재).
     assert "주식회사 뭉클랩" in html_body
+
+
+def test_fallback_link_word_breaks_long_tokens_no_mobile_overflow():
+    """까디르 QA 지적(2026-08-29, PR#3606 qa:changes) — 초대 폴백 링크의
+    word-break:break-all이 셸 전환 중 탈락(develop 대조 확定, 모바일 넘침+CTA 실패
+    시 복구 경로 기능 영향). 트랜잭셔널 3종 폴백 링크(긴 JWT 토큰 URL, 공백 없음)도
+    같은 위험이라 동시에 넣는다 — pin으로 재발 방지."""
+    from app.services.email import render_action_email
+    from app.services.org_invite_email import _build_invite_html
+
+    action_html = render_action_email(
+        intro_lines=["줄"], cta_label="버튼", cta_url="https://x?token=abc",
+        expiry_note="만료", security_note="보안", fallback_label="폴백",
+    )
+    assert "word-break:break-all" in action_html
+
+    invite_html = _build_invite_html(
+        org_name="Acme", inviter_name="Jay", accept_link="https://x?token=abc",
+        role="admin", locale="ko",
+    )
+    assert "word-break:break-all" in invite_html


### PR DESCRIPTION
[SID:3206]

## 배경
선생님 「전부 다 plain text + button으로 할 건지?」(2026-08-29) — 유나 v2 시안
(doc `email-brand-shell-proposal-3206`, 아티팩트 `afaeca1f`) 그대로 배선.

v1(색 헤더 바·tint 푸터)은 실기기 반증으로 폐기됐다 — 선생님 갤럭시 Gmail 다크
실수신에서 bgcolor가 강제 재배색되며 헤더 바·버튼 bg·카드 bg가 통째 소실. v2는
위계를 **구분선·여백·타이포 굵기**로만 세운다(색 fill 의존 위계는 반전되면 사라짐).

## 변경
- `render_email_shell(content_html, *, locale)` 신설(`email.py`) — 발송 메일
  단일 조립 지점. 헤더(텍스트 워드마크+구분선)·푸터(구분선+회사정보 SSOT+동적
  연도+이용약관/개인정보처리방침)를 전 메일 공통으로 얹는다.
- `render_action_email()` — 버튼을 bg+테두리 병용(`#3157FF`)으로 변경(Gmail이
  bg를 죽여도 테두리 상자+굵은 글자로 여전히 버튼 식별). 셸로 감싸도록 배선.
- `_reminder_email_body()` — 셸 경유 + 동형 버튼.
- `_build_invite_html()` — 예전엔 이 함수가 DOCTYPE/자체 헤더바(`#6366f1`)/tint
  푸터까지 통째로 소유했는데, 셸이 흡수 — 콘텐츠 영역만 만들도록 축소(유나 doc
  ③ footer 중복 조율 수렴).
- 스토리지/AU 임계 알림(`cron.py`) — 셸 경유 추가.

## grounding
시안의 "도움말" 링크는 넣지 않았다 — 실제 목적지(`/help` 라우트)가 앱에 없어
임의 URL을 짓는 대신 실존 라우트(이용약관·개인정보처리방침)만 남김(추측 구현
금지). 회사정보는 `apps/web/src/lib/legal/business-info.ts`와 자구 일치(그
파일이 SSOT — import는 못 하는 별도 런타임이라 손으로 동기화, 주석에 명시).

## ⚠️ 미해소 관문
doc의 "관문(신규)": **실발송 → 선생님 갤럭시 Gmail 다크 실수신 확認**이 최종
판정이다. 이 PR은 구조·단위테스트까지만이고, 실기기 확認은 배포 후 별도
필요(내가 실 디바이스 접근 없음 — 정직 기록, 최종 승인 前 반드시 확인 요청).

## Test plan
- [x] `test_email_shell.py`(신규 8종) — 구조·회사정보 SSOT 일치·동적 연도·도움말
      미포함·flex/grid 0·v1 색헤더 폐기 확認·버튼 v2 패턴
- [x] `test_render_action_email.py`·`test_email_copy.py`·`test_3205_email_locale_routing.py`·
      `test_2041_storage_crons_worker_pool.py`·`test_e_org_multi_s3_1/2*.py`·
      `test_register_email_delivered.py`·`test_bug_invite_org_invite_auto_accept.py`
      — 전부 갱신 반영·재통과(56개)
- [x] `uv run pytest tests/ -m "not destructive_schema" -k "auth or invite or onboarding_activation or cron or reminder or oauth or email"` — 399 passed, 0 failed
- [x] `scripts/lint_dependency_override_get_read_db.py` 로컬 직접 실행 — 신규 위반 0건
- [ ] **실기기(선생님 갤럭시 Gmail 다크) 실수신 확認 — 배포 후 별도 관문**