### PR TITLE
[SID:3209] PR-2 결제 완료 메일 신설 — v2 브랜드 셸+로케일 사전 골격 재사용

### DIFF
--- a/backend/app/services/billing_charge.py
+++ b/backend/app/services/billing_charge.py
@@ -21,6 +21,7 @@ PO 정밀 리뷰(#2882, 2026-08-07) — 「돈 움직이는」 스토리가 지�
 """
 from __future__ import annotations
 
+import logging
 import uuid
 
 from sqlalchemy import func, select, update
@@ -30,6 +31,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.billing_order import BillingOrder
 from app.models.org_billing_key import OrgBillingKey
 from app.services.billing_key_crypto import decrypt_billing_key, ensure_configured
+
+logger = logging.getLogger(__name__)
 from app.services.billing_ledger import record_ledger_entry
 from app.services.payment.toss_adapter import DUPLICATED_ORDER_ID, TossAdapter, TossApiError
 
@@ -66,18 +69,35 @@ async def _confirm_with_ledger(
     receipt_url(story #3209 PR-1): 호출자가 이미 받아둔 Toss payment 응답의
     `receipt.url`을 그대로 전달 — 이 함수가 별도로 Toss를 다시 조회하지 않는다(모든
     호출자가 이미 그 응답을 들고 이 함수에 들어온다, charge_org/_reconcile_duplicated_order/
-    sweep_stale_pending_orders 공통)."""
+    sweep_stale_pending_orders 공통).
+
+    story #3209 PR-2 — 이 UPDATE가 실제로 이 order를 confirmed로 **처음** 전이시켰을
+    때만(rowcount==1) 결제 완료 메일을 발송한다. 이미 confirmed인 order에 재진입(멱등
+    재시도 등)하면 WHERE 가드로 rowcount==0이라 자동으로 재발송을 안 한다 — 별도
+    dedup 플래그 불요, claim/confirmed-update 자체가 이미 그 신호다. 발송 실패는
+    결제 확정 자체를 되돌리지 않는다(try/except, 로그만)."""
     await record_ledger_entry(
         session, org_id=org_id, entry_type=entry_type, amount_minor=amount_minor,
         currency=currency, direction="credit", provider="toss", provider_ref=payment_key,
         metadata=ledger_metadata,
     )
-    await session.execute(
+    update_result = await session.execute(
         update(BillingOrder)
         .where(BillingOrder.order_id == order_id, BillingOrder.status != "confirmed")
         .values(status="confirmed", payment_key=payment_key, receipt_url=receipt_url, updated_at=func.now())
     )
     await session.commit()
+    if update_result.rowcount == 1:
+        try:
+            from app.services.billing_receipt_email import send_payment_receipt_email
+            await send_payment_receipt_email(
+                session, org_id=org_id, receipt_url=receipt_url,
+                amount_minor=amount_minor, currency=currency,
+            )
+        except Exception:
+            logger.exception(
+                "payment receipt email dispatch failed — order_id=%s org_id=%s", order_id, org_id,
+            )
     return await _refetch(session, order_id)
 
 

--- a/backend/app/services/billing_receipt_email.py
+++ b/backend/app/services/billing_receipt_email.py
@@ -1,0 +1,77 @@
+"""story #3209(PR-2) — 결제 완료 안내 메일. billing_charge.py(순수 확정/원장 메커니즘)와
+분리해 이메일 발송 관심사만 여기 둔다(cron.py의 storage/AU 경고 메일과 동일 역할분리
+관례 — 원장 로직 파일이 SMTP/Resend 세부를 몰라도 되게).
+
+`_confirm_with_ledger`가 order를 confirmed로 **처음** 전이시켰을 때만 호출한다(그 함수의
+UPDATE rowcount==1 가드 — 재시도/이미-confirmed 재진입에서 중복 발송 안 함). receipt_url이
+없으면(Toss 응답에 receipt 필드 자체가 없는 극히 드문 케이스) 조용히 skip — CTA 없는
+메일을 지어내지 않는다(발명 금지, PO 안 §2 "«영수증 보기» 버튼 CTA" 그대로).
+
+이메일 발송 실패는 결제 확정 자체를 되돌리지 않는다(호출자가 try/except로 감싸 로그만
+남긴다 — 돈은 이미 실제로 움직였고, 안내 메일 실패로 그 사실을 무효화할 이유가 없다)."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project import OrgMember
+from app.models.user import User
+from app.services.agent_onboarding_config import resolve_locale
+from app.services.email import render_action_email, send_email
+from app.services.email_copy import TRANSACTIONAL_COPY
+
+logger = logging.getLogger(__name__)
+
+
+def _format_krw(amount_minor: int, locale: str) -> str:
+    # KRW는 무소수 통화라 amount_minor가 곧 원 단위 정수(toss_adapter.py의 기존 규율과 동형).
+    formatted = f"{amount_minor:,}"
+    return f"{formatted}원" if locale == "ko" else f"₩{formatted}"
+
+
+async def send_payment_receipt_email(
+    session: AsyncSession, *, org_id: uuid.UUID, receipt_url: str | None,
+    amount_minor: int, currency: str,
+) -> None:
+    """cron.py의 STORAGE_WARN_COPY/AU_WARN_COPY 발송 패턴과 동형 — 수신자=org owner/admin
+    전원(OrgMember JOIN User, 개별 locale), 발송 실패는 개별 로그만(다른 수신자 발송을
+    막지 않음). 결제는 KRW 고정(Toss 원화 정기결제 전제, toss_adapter.py §0)이라 currency
+    파라미터는 현재 이 함수 안에서 미사용(향후 통화 확장 대비 시그니처만 보존)."""
+    if receipt_url is None:
+        logger.info("payment receipt email skip — no receipt_url (order org_id=%s)", org_id)
+        return
+
+    recipients = (
+        await session.execute(
+            select(User.email, User.locale)
+            .join(OrgMember, User.id == OrgMember.user_id)
+            .where(
+                OrgMember.org_id == org_id,
+                OrgMember.role.in_(["owner", "admin"]),
+                OrgMember.deleted_at.is_(None),
+            )
+        )
+    ).all()
+
+    for email, locale_value in recipients:
+        locale = resolve_locale(locale_value)
+        copy = TRANSACTIONAL_COPY["payment_receipt"][locale]
+        amount_display = _format_krw(amount_minor, locale)
+        intro_lines = [line.format(amount=amount_display) for line in copy["intro_lines"]]
+        html_body = render_action_email(
+            intro_lines=intro_lines,
+            cta_label=copy["cta_label"],
+            cta_url=receipt_url,
+            expiry_note=copy["expiry_note"],
+            security_note=copy["security_note"],
+            fallback_label=copy["fallback_label"],
+            locale=locale,
+        )
+        try:
+            await asyncio.to_thread(send_email, email, copy["subject"], html_body)
+        except Exception:
+            logger.exception("payment receipt email failed — org_id=%s to=%s", org_id, email)

--- a/backend/app/services/email_copy.py
+++ b/backend/app/services/email_copy.py
@@ -61,6 +61,39 @@ TRANSACTIONAL_COPY: dict[str, dict[str, dict]] = {
             "fallback_label": "If the button doesn't work, paste this address into your browser:",
         },
     },
+    # story #3209(PR-2, 2026-08-29) — 결제 완료 안내. 다른 트랜잭셔널 3종과 골격 동일
+    # (intro_lines/cta_label/expiry_note/security_note/fallback_label — render_action_email
+    # 그대로 재사용, 새 렌더러 발명 없음). intro_lines[1]은 결제액 삽입용 {amount} 자리
+    # 표시자(billing_receipt_email.py가 .format()으로 채움 — STORAGE_WARN_COPY의 {pct}
+    # 등과 동형 관례). expiry_note/security_note는 "만료/보안" 문면 그대로가 아니라 영수증
+    # 맥락에 맞게 내용을 바꿔 채웠다(파라미터 이름은 골격 재사용, 내용은 이 메일의 실제
+    # 의미에 맞춤 — expiry_note 자리엔 "영수증은 Toss가 제공하며 링크로 계속 확인 가능"을,
+    # security_note 자리엔 "본인 결제가 아니면 즉시 문의" 안내를 담는다). en은 유나 검수
+    # 대기 초안(다른 5종과 동일 상태).
+    "payment_receipt": {
+        "ko": {
+            "subject": "Sprintable 결제가 완료됐습니다",
+            "intro_lines": [
+                "결제가 정상적으로 완료됐습니다.",
+                "결제 금액: {amount}",
+            ],
+            "cta_label": "영수증 보기",
+            "expiry_note": "영수증은 결제사(Toss)가 제공하며, 이 링크로 언제든 다시 확인하실 수 있습니다.",
+            "security_note": "본인이 결제하지 않으셨다면 즉시 고객센터로 문의해 주세요.",
+            "fallback_label": "버튼이 열리지 않으면 아래 주소를 브라우저에 붙여넣어 주세요:",
+        },
+        "en": {
+            "subject": "Your Sprintable payment is complete",
+            "intro_lines": [
+                "Your payment was completed successfully.",
+                "Amount charged: {amount}",
+            ],
+            "cta_label": "View receipt",
+            "expiry_note": "The receipt is provided by our payment processor (Toss) and can be viewed anytime via this link.",
+            "security_note": "If you didn't make this payment, please contact support immediately.",
+            "fallback_label": "If the button doesn't work, paste this address into your browser:",
+        },
+    },
 }
 
 REMINDER_COPY: dict[str, dict[str, str]] = {

--- a/backend/tests/test_3209_billing_receipt_email.py
+++ b/backend/tests/test_3209_billing_receipt_email.py
@@ -1,0 +1,85 @@
+"""story #3209(PR-2) — send_payment_receipt_email 단위 테스트.
+cron.py의 storage/AU 경고 메일 발송 패턴(수신자=owner/admin 전원, 개별 locale, 개별
+실패 격리)과 동형 관례를 그대로 따르는지 고정한다."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_skips_entirely_when_receipt_url_is_none():
+    """receipt_url이 없으면(Toss 응답에 receipt 필드 자체가 없는 극히 드문 케이스) 조회도
+    발송도 안 한다 — CTA 없는 메일을 지어내지 않는다."""
+    from app.services.billing_receipt_email import send_payment_receipt_email
+
+    session = AsyncMock()
+    with patch("app.services.billing_receipt_email.send_email") as send_email_mock:
+        await send_payment_receipt_email(
+            session, org_id=uuid.uuid4(), receipt_url=None, amount_minor=49000, currency="krw",
+        )
+    session.execute.assert_not_awaited()
+    send_email_mock.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_sends_to_owner_admin_recipients_with_per_recipient_locale():
+    """owner/admin 전원에게, 각자의 locale로 발송한다(cron.py storage/AU 경고와 동형)."""
+    from app.services.billing_receipt_email import send_payment_receipt_email
+
+    org_id = uuid.uuid4()
+    session = AsyncMock()
+    recipients_result = MagicMock()
+    recipients_result.all.return_value = [
+        ("owner@example.com", "ko"),
+        ("admin@example.com", "en"),
+    ]
+    session.execute = AsyncMock(return_value=recipients_result)
+
+    with patch("app.services.billing_receipt_email.send_email") as send_email_mock, \
+         patch("app.services.billing_receipt_email.asyncio.to_thread", new=AsyncMock(side_effect=lambda fn, *a: fn(*a))):
+        await send_payment_receipt_email(
+            session, org_id=org_id, receipt_url="https://dashboard.tosspayments.com/receipt/abc",
+            amount_minor=49000, currency="krw",
+        )
+
+    assert send_email_mock.call_count == 2
+    ko_call = next(c for c in send_email_mock.call_args_list if c.args[0] == "owner@example.com")
+    en_call = next(c for c in send_email_mock.call_args_list if c.args[0] == "admin@example.com")
+    assert ko_call.args[1] == "Sprintable 결제가 완료됐습니다"
+    assert "49,000원" in ko_call.args[2]
+    assert "https://dashboard.tosspayments.com/receipt/abc" in ko_call.args[2]
+    assert en_call.args[1] == "Your Sprintable payment is complete"
+    assert "₩49,000" in en_call.args[2]
+
+
+@pytest.mark.anyio
+async def test_one_recipient_send_failure_does_not_block_the_other():
+    """한 명 발송 실패가 나머지 발송을 막지 않는다(개별 로그만, cron.py 경고 메일과 동형)."""
+    from app.services.billing_receipt_email import send_payment_receipt_email
+
+    org_id = uuid.uuid4()
+    session = AsyncMock()
+    recipients_result = MagicMock()
+    recipients_result.all.return_value = [
+        ("fails@example.com", "ko"),
+        ("ok@example.com", "ko"),
+    ]
+    session.execute = AsyncMock(return_value=recipients_result)
+
+    async def _to_thread(fn, *args):
+        if args[0] == "fails@example.com":
+            raise RuntimeError("smtp down")
+        return fn(*args)
+
+    with patch("app.services.billing_receipt_email.send_email") as send_email_mock, \
+         patch("app.services.billing_receipt_email.asyncio.to_thread", new=AsyncMock(side_effect=_to_thread)):
+        await send_payment_receipt_email(
+            session, org_id=org_id, receipt_url="https://dashboard.tosspayments.com/receipt/abc",
+            amount_minor=49000, currency="krw",
+        )
+
+    ok_calls = [c for c in send_email_mock.call_args_list if c.args[0] == "ok@example.com"]
+    assert len(ok_calls) == 1

--- a/backend/tests/test_e_2493_c2_charge_ledger.py
+++ b/backend/tests/test_e_2493_c2_charge_ledger.py
@@ -522,3 +522,88 @@ async def test_charge_org_duplicated_order_id_not_done_marks_failed(monkeypatch)
 
     assert result.status == "failed"
     svc.record_ledger_entry.assert_not_awaited()
+
+
+# ─── story #3209 PR-2 — _confirm_with_ledger의 결제 완료 메일 배선 ──────────
+
+def _rowcount_result(rowcount: int, refetch_row=None) -> MagicMock:
+    """update() 실행 결과 mock — rowcount만 쓴다(_claimed_result와 동형, 이름만 이 파일
+    문맥에 맞게)."""
+    r = MagicMock()
+    r.rowcount = rowcount
+    return r
+
+
+@pytest.mark.anyio
+async def test_confirm_with_ledger_sends_receipt_email_on_first_confirmation(monkeypatch):
+    """rowcount==1(실제로 이번 호출이 confirmed로 전이시킴)이면 결제 완료 메일을 정확한
+    kwargs로 1회 발송한다."""
+    import app.services.billing_charge as svc
+    import app.services.billing_receipt_email as email_svc
+
+    org_id = uuid.uuid4()
+    confirmed_row = MagicMock()
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_rowcount_result(1), _row_result(confirmed_row)])
+
+    monkeypatch.setattr(svc, "record_ledger_entry", AsyncMock())
+    send_mock = AsyncMock()
+    monkeypatch.setattr(email_svc, "send_payment_receipt_email", send_mock)
+
+    result = await svc._confirm_with_ledger(
+        session, org_id=org_id, order_id="ord-1", amount_minor=49000, currency="krw",
+        payment_key="pay_1", receipt_url="https://dashboard.tosspayments.com/receipt/abc",
+    )
+
+    assert result is confirmed_row
+    send_mock.assert_awaited_once_with(
+        session, org_id=org_id, receipt_url="https://dashboard.tosspayments.com/receipt/abc",
+        amount_minor=49000, currency="krw",
+    )
+
+
+@pytest.mark.anyio
+async def test_confirm_with_ledger_skips_email_on_idempotent_reentry(monkeypatch):
+    """rowcount==0(이미 confirmed였던 order — 재시도/중복 진입)이면 재발송하지 않는다.
+    별도 dedup 플래그 없이 claim/confirmed-update의 WHERE 가드 자체가 이 신호다."""
+    import app.services.billing_charge as svc
+    import app.services.billing_receipt_email as email_svc
+
+    org_id = uuid.uuid4()
+    already_confirmed_row = MagicMock()
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_rowcount_result(0), _row_result(already_confirmed_row)])
+
+    monkeypatch.setattr(svc, "record_ledger_entry", AsyncMock())
+    send_mock = AsyncMock()
+    monkeypatch.setattr(email_svc, "send_payment_receipt_email", send_mock)
+
+    result = await svc._confirm_with_ledger(
+        session, org_id=org_id, order_id="ord-2", amount_minor=49000, currency="krw",
+        payment_key="pay_2", receipt_url="https://dashboard.tosspayments.com/receipt/xyz",
+    )
+
+    assert result is already_confirmed_row
+    send_mock.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_confirm_with_ledger_email_failure_does_not_break_confirmation(monkeypatch):
+    """메일 발송 실패(예외)가 결제 확정 자체를 되돌리지 않는다 — 돈은 이미 움직였다."""
+    import app.services.billing_charge as svc
+    import app.services.billing_receipt_email as email_svc
+
+    org_id = uuid.uuid4()
+    confirmed_row = MagicMock()
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_rowcount_result(1), _row_result(confirmed_row)])
+
+    monkeypatch.setattr(svc, "record_ledger_entry", AsyncMock())
+    monkeypatch.setattr(email_svc, "send_payment_receipt_email", AsyncMock(side_effect=RuntimeError("smtp down")))
+
+    result = await svc._confirm_with_ledger(
+        session, org_id=org_id, order_id="ord-3", amount_minor=49000, currency="krw",
+        payment_key="pay_3", receipt_url="https://dashboard.tosspayments.com/receipt/qwe",
+    )
+
+    assert result is confirmed_row  # 예외가 새지 않고, confirmed 결과가 그대로 반환된다.


### PR DESCRIPTION
## 요약
- [\[빌링·영수증\] 결제 완료 영수증 처리 — Toss receipt.url 저장·결제 완료 메일 신설·빌링 내역 노출](entity:story:e712ec19-502d-44f6-9db9-408b3f8dc9a5) — PR-2(결제 완료 메일). PR-1(receipt_url 저장+빌링 내역 화면)은 #3605에서 이미 머지됨.

## 배경
PO 방향 §2: "«영수증 보기» 버튼 CTA. v2 브랜드 셸+email_copy 로케일 사전(#3205) 골격 그대로(새 메커니즘 발명 금지)". 전제(#3604 로케일 분기, #3606 v2 셸) develop 착지 확認 후 착수.

## 신규 카피 — email_copy.py
`TRANSACTIONAL_COPY["payment_receipt"]`(ko/en) — 다른 트랜잭셔널 3종(verify_email/reset_password)과 동일 파라미터 골격, `render_action_email` 그대로 재사용. `{amount}` 자리표시자는 `STORAGE_WARN_COPY`의 `{pct}`와 동형 관례. en은 다른 5종과 동일하게 유나 검수 대기 초안.

## 발신 로직 — billing_receipt_email.py(신설)
cron.py의 storage/AU 경고 메일 발송 패턴과 동형(수신자=org owner/admin 전원, 개별 locale, 개별 실패 격리). receipt_url이 없으면 조회·발송 모두 skip. `billing_charge.py`(순수 확정/원장 메커니즘)와 관심사 분리.

## 배선 지점 — `_confirm_with_ledger` 단일 지점(SSOT)
order가 confirmed로 **처음** 전이됐을 때만(UPDATE rowcount==1) 발송. 이미 confirmed 재진입은 rowcount==0이라 자동 dedup(별도 플래그 불요). `charge_org`/`_reconcile_duplicated_order`/`sweep_stale_pending_orders` 3개 호출자 전부 이 단일 지점을 통해 자동 커버. 메일 발송 실패는 결제 확정을 되돌리지 않음(try/except).

## 검증
- 신규 pin 6건 — `_confirm_with_ledger`(첫 확정 시 정확 kwargs 발송·idempotent 재진입 미발송·발송실패가 확정을 안 깨뜨림) + `send_payment_receipt_email`(receipt_url=None skip·owner/admin 개별 locale 발송·1인 실패가 나머지 안 막음).
- py_compile OK · 전체 pytest(-m "not destructive_schema") 5098 passed(14 failed는 기존 환경 갭, 무관 파일).

prod 무접촉(develop 대상).