### PR TITLE
[SID:3207] dunning·구독 하향취소 알림 2종 로케일 분기 편입

### DIFF
--- a/backend/app/services/billing_scheduler.py
+++ b/backend/app/services/billing_scheduler.py
@@ -105,40 +105,46 @@ def _renewal_order_id(org_id: uuid.UUID, offering_version_id: uuid.UUID, period_
 _TIER_DISPLAY_NAMES = {"free": "Free", "starter": "Starter", "team": "Team", "business": "Business"}
 
 
-def _dunning_email_content(*, tier: str, grace_expires_at) -> tuple[str, str]:
+def _dunning_email_content(*, tier: str, grace_expires_at, locale: str = "ko") -> tuple[str, str]:
     """story #2907 AC3 — 매 실패마다 발송할 문안. 「언제(grace 만료일)」·「어떻게(free
     전이+신규 업로드만 차단·데이터 삭제 없음)」를 명시. tone=nice(선생님 지시) — 고객
     대면 문구라 개야갤 톤 사용 금지.
 
     fast-follow(유나양 design 비차단 권고, 2026-08-21) — ①raw enum(tier) 대신 표시명
     ②billing 페이지(`/settings?tab=billing`, FE `BillingTab` 딥링크 확認) CTA 링크
-    추가. `NEXT_PUBLIC_APP_URL`은 `org_invite_email.py`가 이미 쓰는 동일 패턴 재사용."""
+    추가. `NEXT_PUBLIC_APP_URL`은 `org_invite_email.py`가 이미 쓰는 동일 패턴 재사용.
+
+    story #3207 — locale 분기(email_copy.DUNNING_COPY 경유, #3205와 동형)+공용 셸
+    (render_email_shell)로 감싼다."""
+    from app.services.email import render_email_shell
+    from app.services.email_copy import DUNNING_COPY
+
     grace_date_str = grace_expires_at.strftime("%Y-%m-%d")
     tier_display = _TIER_DISPLAY_NAMES.get(tier, tier)
     app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
     billing_link = f"{app_url}/settings?tab=billing"
-    subject = "[Sprintable] 결제가 처리되지 않았습니다 — 확인해 주세요"
-    html_body = (
-        f"<p>안녕하세요, Sprintable입니다.</p>"
-        f"<p>정기결제 시도가 처리되지 않았습니다. 저희 쪽에서 매일 자동으로 재시도하고 "
-        f"있으니, 등록하신 카드 정보를 확인해 주시면 감사하겠습니다.</p>"
-        f"<p><b>{grace_date_str}</b>까지 결제가 완료되지 않으면 조직의 플랜이 자동으로 "
-        f"Free로 전환됩니다. Free로 전환되어도 <b>기존 데이터는 삭제되지 않으며</b>, "
-        f"신규 업로드만 제한됩니다. 이후 결제를 완료하시면 즉시 원래 플랜({tier_display})으로 "
-        f"복귀합니다.</p>"
-        f"<p><a href=\"{billing_link}\">결제 정보 확인하러 가기</a></p>"
-        f"<p>문의사항이 있으시면 언제든 회신해 주세요.</p>"
+    copy = DUNNING_COPY[locale]
+    grace_note = copy["grace_note"].format(grace_date=grace_date_str, tier_display=tier_display)
+    content = (
+        f"<p>{copy['greeting']}</p>"
+        f"<p>{copy['intro']}</p>"
+        f"<p>{grace_note}</p>"
+        f"<p><a href=\"{billing_link}\">{copy['cta_label']}</a></p>"
+        f"<p>{copy['closing']}</p>"
     )
-    return subject, html_body
+    return copy["subject"], render_email_shell(content, locale=locale)
 
 
 async def _notify_dunning_failure(session: AsyncSession, org_id: uuid.UUID, *, tier: str, grace_expires_at) -> None:
     """실패 통보 메일 — org owner/admin 전원 수신(storage-usage-warn과 동일 조회 패턴,
-    S8). best-effort(개별 흡수) — 메일 실패가 스윕 자체를 막으면 안 된다."""
-    subject, html_body = _dunning_email_content(tier=tier, grace_expires_at=grace_expires_at)
-    emails = [
-        r[0] for r in (await session.execute(
-            select(User.email)
+    S8). best-effort(개별 흡수) — 메일 실패가 스윕 자체를 막으면 안 된다.
+
+    story #3207 — 수신자별 locale 분기(storage/AU 임계 알림과 동형, users.locale 기준)."""
+    from app.services.agent_onboarding_config import resolve_locale
+
+    recipients = [
+        r for r in (await session.execute(
+            select(User.email, User.locale)
             .join(OrgMember, User.id == OrgMember.user_id)
             .where(
                 OrgMember.org_id == org_id,
@@ -147,7 +153,9 @@ async def _notify_dunning_failure(session: AsyncSession, org_id: uuid.UUID, *, t
             )
         )).all()
     ]
-    for em in emails:
+    for em, locale_value in recipients:
+        recipient_locale = resolve_locale(locale_value)
+        subject, html_body = _dunning_email_content(tier=tier, grace_expires_at=grace_expires_at, locale=recipient_locale)
         try:
             send_email(em, subject, html_body)
         except Exception:

--- a/backend/app/services/email_copy.py
+++ b/backend/app/services/email_copy.py
@@ -195,9 +195,11 @@ DOWNGRADE_AUTO_CANCEL_COPY: dict[str, dict[str, str]] = {
         "closing": "문의사항이 있으시면 언제든 회신해 주세요.",
     },
     "en": {
-        "subject": "[Sprintable] Your scheduled downgrade was cancelled — seat limit exceeded",
+        # 유나 검수 수정의견②(2026-08-29) — apps/web/messages/en.json의 기존 관례
+        # (checkoutCanceled)와 자구 정렬, 미국식 단일-L.
+        "subject": "[Sprintable] Your scheduled downgrade was canceled — seat limit exceeded",
         "greeting": "Hello, this is Sprintable.",
-        "body1": "Your scheduled downgrade to the {tier} plan was automatically cancelled. Your organization currently has {seat_count} members, which exceeds that plan's included seats ({included_seats}).",
+        "body1": "Your scheduled downgrade to the {tier} plan was automatically canceled. Your organization currently has {seat_count} members, which exceeds that plan's included seats ({included_seats}).",
         "body2": "No existing members were removed. Reduce your team size or keep your current plan, then schedule the downgrade again if you still need it.",
         "closing": "If you have any questions, feel free to reply to this email anytime.",
     },

--- a/backend/app/services/email_copy.py
+++ b/backend/app/services/email_copy.py
@@ -159,3 +159,46 @@ AU_WARN_COPY: dict[str, dict[str, str]] = {
         ),
     },
 }
+
+# story #3207 — 3205 그라운딩 중 발견한 잔여 2통(dunning·하향취소 자동취소, 둘 다 빌링
+# 어드민/오너向). ko는 기존 발송 문구 그대로(무회귀). en은 이 스토리에서 신규 —
+# TRANSACTIONAL_COPY와 동형으로 유나 검수 대기 초안이다.
+#
+# org_subscription_downgrade.py의 en 카피는 과거 PR#3308에서 유나가 "로케일별 분기
+# 정책이 아직 없다"는 이유로 반려하고 ko 단일로 남긴 이력이 있다 — #3205가 그 전제
+# (정책 부재)를 채웠으므로 이번엔 그 반려의 근거 자체가 해소된 상태에서 다시 제안한다.
+DUNNING_COPY: dict[str, dict[str, str]] = {
+    "ko": {
+        "subject": "[Sprintable] 결제가 처리되지 않았습니다 — 확인해 주세요",
+        "greeting": "안녕하세요, Sprintable입니다.",
+        "intro": "정기결제 시도가 처리되지 않았습니다. 저희 쪽에서 매일 자동으로 재시도하고 있으니, 등록하신 카드 정보를 확인해 주시면 감사하겠습니다.",
+        "grace_note": "<b>{grace_date}</b>까지 결제가 완료되지 않으면 조직의 플랜이 자동으로 Free로 전환됩니다. Free로 전환되어도 <b>기존 데이터는 삭제되지 않으며</b>, 신규 업로드만 제한됩니다. 이후 결제를 완료하시면 즉시 원래 플랜({tier_display})으로 복귀합니다.",
+        "cta_label": "결제 정보 확인하러 가기",
+        "closing": "문의사항이 있으시면 언제든 회신해 주세요.",
+    },
+    "en": {
+        "subject": "[Sprintable] Your payment couldn't be processed — please check",
+        "greeting": "Hello, this is Sprintable.",
+        "intro": "Your recurring payment attempt couldn't be processed. We'll retry automatically once a day, so please check your registered card details.",
+        "grace_note": "If payment isn't completed by <b>{grace_date}</b>, your organization's plan will automatically switch to Free. Even after switching, <b>your existing data won't be deleted</b> — only new uploads will be restricted. Once payment is completed, you'll immediately return to your original plan ({tier_display}).",
+        "cta_label": "Check payment details",
+        "closing": "If you have any questions, feel free to reply to this email anytime.",
+    },
+}
+
+DOWNGRADE_AUTO_CANCEL_COPY: dict[str, dict[str, str]] = {
+    "ko": {
+        "subject": "[Sprintable] 예약된 하향 전환이 취소되었습니다 — 좌석 한도 초과",
+        "greeting": "안녕하세요, Sprintable입니다.",
+        "body1": "예약하신 {tier} 플랜으로의 하향 전환이 자동으로 취소되었습니다. 현재 조직 멤버가 {seat_count}명으로, 해당 플랜의 포함 좌석({included_seats}석)을 초과하기 때문입니다.",
+        "body2": "기존 멤버는 제거되지 않았습니다. 팀 규모를 줄이거나 현재 플랜을 유지하신 뒤, 하향 전환이 여전히 필요하시면 다시 예약해 주세요.",
+        "closing": "문의사항이 있으시면 언제든 회신해 주세요.",
+    },
+    "en": {
+        "subject": "[Sprintable] Your scheduled downgrade was cancelled — seat limit exceeded",
+        "greeting": "Hello, this is Sprintable.",
+        "body1": "Your scheduled downgrade to the {tier} plan was automatically cancelled. Your organization currently has {seat_count} members, which exceeds that plan's included seats ({included_seats}).",
+        "body2": "No existing members were removed. Reduce your team size or keep your current plan, then schedule the downgrade again if you still need it.",
+        "closing": "If you have any questions, feel free to reply to this email anytime.",
+    },
+}

--- a/backend/app/services/org_subscription_downgrade.py
+++ b/backend/app/services/org_subscription_downgrade.py
@@ -162,32 +162,40 @@ async def cancel_pending_downgrade(session: AsyncSession, *, org_id: uuid.UUID) 
 
 async def _notify_downgrade_auto_cancelled(session: AsyncSession, *, org_id: uuid.UUID, tier: str, seat_count: int, included_seats: int) -> None:
     """③ — 좌석초과로 하향이 자동 취소됐음을 owner/admin에게 통지(storage-usage-warn과
-    동형 best-effort 이메일 패턴, 재구현 0)."""
-    emails = [
-        r[0] for r in (
+    동형 best-effort 이메일 패턴, 재구현 0).
+
+    story #3207 — 과거 PR#3308에서 유나가 "로케일별 분기 정책이 아직 없다"는 이유로
+    en 카피를 반려하고 ko 단일로 남긴 자리(그 코멘트 원문은 아래 보존). #3205가 그
+    전제(정책 부재)를 채웠으므로 이제 email_copy.DOWNGRADE_AUTO_CANCEL_COPY+
+    resolve_locale 경유로 편입, 수신자별 locale 분기(storage/AU 임계와 동형)."""
+    from app.services.agent_onboarding_config import resolve_locale
+    from app.services.email import render_email_shell
+    from app.services.email_copy import DOWNGRADE_AUTO_CANCEL_COPY
+
+    recipients = [
+        r for r in (
             await session.execute(
-                select(User.email)
+                select(User.email, User.locale)
                 .join(OrgMember, User.id == OrgMember.user_id)
                 .where(OrgMember.org_id == org_id, OrgMember.role.in_(["owner", "admin"]), OrgMember.deleted_at.is_(None))
             )
         ).all()
     ]
-    # 유나양 design 반려(PR#3308, 2026-08-21) — 영문 메일이 제품의 기존 한국어 메일
-    # (초대·#3316 dunning)과 보이스가 갈렸다. 로케일별 분기 정책은 아직 없음(PO 확認) —
+    # 유나양 design 반려(PR#3308, 2026-08-21, 이력 보존) — 영문 메일이 제품의 기존 한국어
+    # 메일(초대·#3316 dunning)과 보이스가 갈렸다. 로케일별 분기 정책은 아직 없음(PO 확認) —
     # 기존 메일 관례대로 한국어 단일. 문안은 design이 첨부한 원문 그대로(#3316 톤 매칭).
-    subject = "[Sprintable] 예약된 하향 전환이 취소되었습니다 — 좌석 한도 초과"
-    html = (
-        f"<p>안녕하세요, Sprintable입니다.</p>"
-        f"<p>예약하신 {tier} 플랜으로의 하향 전환이 자동으로 취소되었습니다. 현재 조직 "
-        f"멤버가 {seat_count}명으로, 해당 플랜의 포함 좌석({included_seats}석)을 초과하기 "
-        f"때문입니다.</p>"
-        f"<p>기존 멤버는 제거되지 않았습니다. 팀 규모를 줄이거나 현재 플랜을 유지하신 뒤, "
-        f"하향 전환이 여전히 필요하시면 다시 예약해 주세요.</p>"
-        f"<p>문의사항이 있으시면 언제든 회신해 주세요.</p>"
-    )
-    for em in emails:
+    for em, locale_value in recipients:
+        recipient_locale = resolve_locale(locale_value)
+        copy = DOWNGRADE_AUTO_CANCEL_COPY[recipient_locale]
+        content = (
+            f"<p>{copy['greeting']}</p>"
+            f"<p>{copy['body1'].format(tier=tier, seat_count=seat_count, included_seats=included_seats)}</p>"
+            f"<p>{copy['body2']}</p>"
+            f"<p>{copy['closing']}</p>"
+        )
+        html = render_email_shell(content, locale=recipient_locale)
         try:
-            send_email(em, subject, html)
+            send_email(em, copy["subject"], html)
         except Exception:
             logger.warning("downgrade auto-cancel notify 실패 org=%s", org_id, exc_info=True)
 

--- a/backend/tests/test_3207_dunning_downgrade_locale.py
+++ b/backend/tests/test_3207_dunning_downgrade_locale.py
@@ -1,0 +1,104 @@
+"""story #3207 — dunning(빌링 재시도)·구독 하향취소 자동취소 알림 2종의 locale 분기 pin.
+#3205와 동형(email_copy.py 사전+resolve_locale), 순수 dict/DB 불요 부분과 mock 세션
+부분을 나눠 검증한다."""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def test_dunning_copy_has_both_locales_and_required_fields():
+    from app.services.email_copy import DUNNING_COPY
+
+    for locale in ("ko", "en"):
+        copy = DUNNING_COPY[locale]
+        assert copy["subject"] and copy["greeting"] and copy["intro"]
+        assert copy["grace_note"] and copy["cta_label"] and copy["closing"]
+        # 동적 값 포맷 안 깨지는지.
+        formatted = copy["grace_note"].format(grace_date="2026-09-01", tier_display="Team")
+        assert "2026-09-01" in formatted and "Team" in formatted
+
+
+def test_downgrade_auto_cancel_copy_has_both_locales_and_required_fields():
+    from app.services.email_copy import DOWNGRADE_AUTO_CANCEL_COPY
+
+    for locale in ("ko", "en"):
+        copy = DOWNGRADE_AUTO_CANCEL_COPY[locale]
+        assert copy["subject"] and copy["greeting"] and copy["body1"] and copy["body2"] and copy["closing"]
+        formatted = copy["body1"].format(tier="team", seat_count=12, included_seats=10)
+        assert "team" in formatted and "12" in formatted and "10" in formatted
+
+
+def test_dunning_email_content_locale_branch_and_shell_wrapped():
+    from app.services.billing_scheduler import _dunning_email_content
+
+    ko_subject, ko_html = _dunning_email_content(tier="team", grace_expires_at=date(2026, 9, 1), locale="ko")
+    en_subject, en_html = _dunning_email_content(tier="team", grace_expires_at=date(2026, 9, 1), locale="en")
+
+    assert ko_subject == "[Sprintable] 결제가 처리되지 않았습니다 — 확인해 주세요"
+    assert "안녕하세요, Sprintable입니다." in ko_html
+    assert en_subject == "[Sprintable] Your payment couldn't be processed — please check"
+    assert "Hello, this is Sprintable." in en_html
+    # story #3206 공용 셸 경유 확認(회사정보 푸터 존재).
+    assert "주식회사 뭉클랩" in ko_html
+    assert "주식회사 뭉클랩" in en_html
+    assert 'lang="en"' in en_html
+
+
+@pytest.mark.anyio
+async def test_notify_dunning_failure_sends_locale_matched_copy_per_recipient(monkeypatch):
+    import app.services.billing_scheduler as sched
+
+    sent = []
+
+    def _fake_send_email(to, subject, html):
+        sent.append({"to": to, "subject": subject, "html": html})
+        return True
+
+    monkeypatch.setattr(sched, "send_email", _fake_send_email)
+
+    result = MagicMock()
+    result.all.return_value = [("ko@example.com", "ko"), ("en@example.com", "en")]
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+
+    await sched._notify_dunning_failure(session, uuid.uuid4(), tier="team", grace_expires_at=date(2026, 9, 1))
+
+    assert len(sent) == 2
+    ko_sent = next(s for s in sent if s["to"] == "ko@example.com")
+    en_sent = next(s for s in sent if s["to"] == "en@example.com")
+    assert "결제가 처리되지 않았습니다" in ko_sent["subject"]
+    assert "couldn't be processed" in en_sent["subject"]
+
+
+@pytest.mark.anyio
+async def test_notify_downgrade_auto_cancelled_sends_locale_matched_copy_per_recipient(monkeypatch):
+    import app.services.org_subscription_downgrade as mod
+
+    sent = []
+
+    def _fake_send_email(to, subject, html):
+        sent.append({"to": to, "subject": subject, "html": html})
+        return True
+
+    monkeypatch.setattr(mod, "send_email", _fake_send_email)
+
+    result = MagicMock()
+    result.all.return_value = [("ko@example.com", "ko"), ("en@example.com", None)]
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+
+    await mod._notify_downgrade_auto_cancelled(
+        session, org_id=uuid.uuid4(), tier="team", seat_count=12, included_seats=10,
+    )
+
+    assert len(sent) == 2
+    ko_sent = next(s for s in sent if s["to"] == "ko@example.com")
+    en_sent = next(s for s in sent if s["to"] == "en@example.com")
+    # locale=None → resolve_locale이 DEFAULT_LOCALE(ko)로 폴백.
+    assert "취소되었습니다" in ko_sent["subject"]
+    assert "취소되었습니다" in en_sent["subject"]
+    assert "주식회사 뭉클랩" in ko_sent["html"]

--- a/backend/tests/test_3207_dunning_downgrade_locale.py
+++ b/backend/tests/test_3207_dunning_downgrade_locale.py
@@ -76,6 +76,10 @@ async def test_notify_dunning_failure_sends_locale_matched_copy_per_recipient(mo
 
 @pytest.mark.anyio
 async def test_notify_downgrade_auto_cancelled_sends_locale_matched_copy_per_recipient(monkeypatch):
+    """까디르 QA 지적(2026-08-29, PR#3608 qa:changes) — 이전 fixture가 ("en@example.com",
+    None)이라 None→ko 폴백 때문에 두 수신자 다 실제로는 ko 카피를 받았다(«틀릴 수 없는
+    무효 오라클» — locale 분기가 깨져도 GREEN). en 수신자는 실제 "en" 값으로 넣고 en
+    고유 문구로 판별한다."""
     import app.services.org_subscription_downgrade as mod
 
     sent = []
@@ -87,7 +91,7 @@ async def test_notify_downgrade_auto_cancelled_sends_locale_matched_copy_per_rec
     monkeypatch.setattr(mod, "send_email", _fake_send_email)
 
     result = MagicMock()
-    result.all.return_value = [("ko@example.com", "ko"), ("en@example.com", None)]
+    result.all.return_value = [("ko@example.com", "ko"), ("en@example.com", "en")]
     session = AsyncMock()
     session.execute = AsyncMock(return_value=result)
 
@@ -98,7 +102,35 @@ async def test_notify_downgrade_auto_cancelled_sends_locale_matched_copy_per_rec
     assert len(sent) == 2
     ko_sent = next(s for s in sent if s["to"] == "ko@example.com")
     en_sent = next(s for s in sent if s["to"] == "en@example.com")
-    # locale=None → resolve_locale이 DEFAULT_LOCALE(ko)로 폴백.
     assert "취소되었습니다" in ko_sent["subject"]
-    assert "취소되었습니다" in en_sent["subject"]
+    assert "취소되었습니다" not in en_sent["subject"]
+    assert "seat limit exceeded" in en_sent["subject"]
     assert "주식회사 뭉클랩" in ko_sent["html"]
+    assert "주식회사 뭉클랩" in en_sent["html"]  # 회사정보 푸터는 locale 무관 고정.
+
+
+@pytest.mark.anyio
+async def test_notify_downgrade_auto_cancelled_none_locale_falls_back_to_ko(monkeypatch):
+    """locale=None(판별원 없는 기존 유저)인 수신자는 DEFAULT_LOCALE(ko)로 폴백 — 위
+    locale 분기 테스트와 분리된 별도 케이스(둘을 합치면 위 케이스처럼 무효 오라클이 된다)."""
+    import app.services.org_subscription_downgrade as mod
+
+    sent = []
+
+    def _fake_send_email(to, subject, html):
+        sent.append({"to": to, "subject": subject, "html": html})
+        return True
+
+    monkeypatch.setattr(mod, "send_email", _fake_send_email)
+
+    result = MagicMock()
+    result.all.return_value = [("noloc@example.com", None)]
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+
+    await mod._notify_downgrade_auto_cancelled(
+        session, org_id=uuid.uuid4(), tier="team", seat_count=12, included_seats=10,
+    )
+
+    assert len(sent) == 1
+    assert "취소되었습니다" in sent[0]["subject"]


### PR DESCRIPTION
[SID:3207]

## 배경
#3205(발송 메일 언어를 유저 로케일로 분기) 그라운딩 중 발견한 잔여 2통 —
`billing_scheduler.py`(dunning 재시도 안내)·`org_subscription_downgrade.py`
(구독 하향취소 자동취소, 좌석 한도 초과)가 #3205의 7종 범위 밖에 있었다.

**PR#3308 맥락 해소**: `org_subscription_downgrade.py`엔 과거 PR#3308에서 유나가
"영문 메일이 제품의 기존 한국어 메일과 보이스가 갈렸다. 로케일별 분기 정책은
아직 없음"을 이유로 en 카피를 반려하고 ko 단일로 남긴 코멘트가 실재한다 —
**#3205가 그 전제(정책 부재)를 채웠으므로**, 이 PR은 그 반려의 근거 자체가
해소된 상태에서 다시 제안한다(코멘트 원문은 코드에 그대로 보존, 해소 맥락만 추가).

## 변경
- `_dunning_email_content()`(billing_scheduler.py) — `locale` 파라미터 추가,
  `email_copy.DUNNING_COPY` 사전 편입.
- `_notify_dunning_failure()` — storage/AU 임계 알림(#3205)과 동형으로 수신자별
  (`users.locale`) 개별 분기.
- `_notify_downgrade_auto_cancelled()`(org_subscription_downgrade.py) —
  `email_copy.DOWNGRADE_AUTO_CANCEL_COPY` 편입 + 수신자별 분기.
- 둘 다 `render_email_shell()`(#3206) 경유로 공용 브랜드 셸 자동 적용.
- 새 메커니즘 발명 없음 — #3205/#3206이 이미 만든 `email_copy.py`+`resolve_locale`+
  `render_email_shell()`을 그대로 재사용.

## en 카피 검수
유나 검수 요청 넣음(doc `email-locale-copy-proposal-3207`) — #3205와 동형으로
구현은 병행, 검수 결과 오면 필요 시 반영 재push.

## Test plan
- [x] `test_3207_dunning_downgrade_locale.py`(신규 5종) — 사전 형태·포맷·
      locale 분기(mock 세션, 수신자별)
- [x] `test_e_2494_c3_scheduler.py`·`test_e_2493_c2_charge_ledger.py` — 회귀 없음(44개)
- [x] `uv run pytest tests/ -m "not destructive_schema" -k "billing or dunning or downgrade or email or 2494 or 2493"` — 195 passed, 0 failed
- [x] `scripts/lint_dependency_override_get_read_db.py` 로컬 직접 실행 — 신규 위반 0건