### PR TITLE
[SID:3212] 구독 취소·하향 «예약/적용» 확인 메일 신설

### DIFF
--- a/backend/app/services/email_copy.py
+++ b/backend/app/services/email_copy.py
@@ -94,6 +94,59 @@ TRANSACTIONAL_COPY: dict[str, dict[str, dict]] = {
             "fallback_label": "If the button doesn't work, paste this address into your browser:",
         },
     },
+    # story #3212(구독 라이프사이클 메일 공백, 2026-08-29) — 하향/취소 «예약 확인» 2종.
+    # payment_receipt와 동일 골격(render_action_email 그대로, 발명 0). {tier}/{apply_date}
+    # 자리표시자는 org_subscription_downgrade.py가 .format()으로 채운다. cta_url은
+    # 빌링 설정 페이지(기존 예약 철회 UI가 이미 거기 있다 — 새 공개 원클릭 철회 엔드포인트
+    # 발명 안 함, 로그인 후 기존 버튼 그대로 사용).
+    "subscription_downgrade_reserved": {
+        "ko": {
+            "subject": "[Sprintable] {tier} 플랜으로 변경이 예약됐습니다",
+            "intro_lines": [
+                "플랜 변경이 예약됐습니다.",
+                "{apply_date}부터 {tier} 플랜으로 전환됩니다.",
+            ],
+            "cta_label": "예약 확인·철회하기",
+            "expiry_note": "적용 전까지 언제든 예약을 철회하고 현재 플랜을 유지하실 수 있습니다.",
+            "security_note": "본인이 요청하지 않으셨다면 즉시 고객센터로 문의해 주세요.",
+            "fallback_label": "버튼이 열리지 않으면 아래 주소를 브라우저에 붙여넣어 주세요:",
+        },
+        "en": {
+            "subject": "[Sprintable] Your plan change to {tier} is scheduled",
+            "intro_lines": [
+                "A plan change has been scheduled.",
+                "You'll switch to the {tier} plan on {apply_date}.",
+            ],
+            "cta_label": "Review or cancel",
+            "expiry_note": "You can cancel this scheduled change and keep your current plan anytime before it takes effect.",
+            "security_note": "If you didn't request this, please contact support immediately.",
+            "fallback_label": "If the button doesn't work, paste this address into your browser:",
+        },
+    },
+    "subscription_cancel_reserved": {
+        "ko": {
+            "subject": "[Sprintable] 구독 해지가 예약됐습니다",
+            "intro_lines": [
+                "구독 해지가 예약됐습니다.",
+                "{apply_date}까지는 현재 플랜을 그대로 이용하실 수 있고, 그 이후 Free 플랜으로 전환됩니다.",
+            ],
+            "cta_label": "예약 확인·철회하기",
+            "expiry_note": "적용 전까지 언제든 예약을 철회하고 구독을 유지하실 수 있습니다.",
+            "security_note": "본인이 요청하지 않으셨다면 즉시 고객센터로 문의해 주세요.",
+            "fallback_label": "버튼이 열리지 않으면 아래 주소를 브라우저에 붙여넣어 주세요:",
+        },
+        "en": {
+            "subject": "[Sprintable] Your subscription cancellation is scheduled",
+            "intro_lines": [
+                "Your subscription cancellation has been scheduled.",
+                "You'll keep your current plan until {apply_date}, then switch to the Free plan.",
+            ],
+            "cta_label": "Review or cancel",
+            "expiry_note": "You can cancel this scheduled cancellation and keep your subscription anytime before it takes effect.",
+            "security_note": "If you didn't request this, please contact support immediately.",
+            "fallback_label": "If the button doesn't work, paste this address into your browser:",
+        },
+    },
 }
 
 REMINDER_COPY: dict[str, dict[str, str]] = {
@@ -234,6 +287,42 @@ DOWNGRADE_AUTO_CANCEL_COPY: dict[str, dict[str, str]] = {
         "greeting": "Hello, this is Sprintable.",
         "body1": "Your scheduled downgrade to the {tier} plan was automatically canceled. Your organization currently has {seat_count} members, which exceeds that plan's included seats ({included_seats}).",
         "body2": "No existing members were removed. Reduce your team size or keep your current plan, then schedule the downgrade again if you still need it.",
+        "closing": "If you have any questions, feel free to reply to this email anytime.",
+    },
+}
+
+# story #3212 — 하향/취소 «적용 완료» 2종. 액션 불요(정보성)라 DOWNGRADE_AUTO_CANCEL_COPY와
+# 동형(greeting/body1/body2/closing, render_email_shell 직접 사용 — CTA 버튼 없음).
+SUBSCRIPTION_DOWNGRADE_APPLIED_COPY: dict[str, dict[str, str]] = {
+    "ko": {
+        "subject": "[Sprintable] {tier} 플랜으로 전환이 완료됐습니다",
+        "greeting": "안녕하세요, Sprintable입니다.",
+        "body1": "예약하신 {tier} 플랜으로 전환이 완료됐습니다.",
+        "body2": "기존 데이터는 삭제되지 않고 그대로 보존되며, 변경된 플랜 한도 내에서 계속 이용하실 수 있습니다.",
+        "closing": "문의사항이 있으시면 언제든 회신해 주세요.",
+    },
+    "en": {
+        "subject": "[Sprintable] Your plan change to {tier} is complete",
+        "greeting": "Hello, this is Sprintable.",
+        "body1": "Your scheduled plan change to {tier} is now complete.",
+        "body2": "Your existing data hasn't been deleted and remains available, within the limits of your new plan.",
+        "closing": "If you have any questions, feel free to reply to this email anytime.",
+    },
+}
+
+SUBSCRIPTION_CANCEL_APPLIED_COPY: dict[str, dict[str, str]] = {
+    "ko": {
+        "subject": "[Sprintable] 구독이 해지되어 Free 플랜으로 전환됐습니다",
+        "greeting": "안녕하세요, Sprintable입니다.",
+        "body1": "예약하신 구독 해지가 적용되어 Free 플랜으로 전환됐습니다.",
+        "body2": "기존 데이터와 콘텐츠는 삭제되지 않고 그대로 보존됩니다 — 언제든 다시 업그레이드해 이어서 이용하실 수 있습니다.",
+        "closing": "문의사항이 있으시면 언제든 회신해 주세요.",
+    },
+    "en": {
+        "subject": "[Sprintable] Your subscription has ended — you're now on the Free plan",
+        "greeting": "Hello, this is Sprintable.",
+        "body1": "Your scheduled cancellation is now complete and you've been switched to the Free plan.",
+        "body2": "Your existing data and content haven't been deleted and remain available — you can upgrade again anytime to pick up where you left off.",
         "closing": "If you have any questions, feel free to reply to this email anytime.",
     },
 }

--- a/backend/app/services/org_subscription_downgrade.py
+++ b/backend/app/services/org_subscription_downgrade.py
@@ -32,6 +32,7 @@ checkout.py`/`org_subscription_tier_change.py`는 애초에 이 함정을 안 �
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 from datetime import datetime, timezone
 
@@ -89,6 +90,9 @@ async def _offering_or_raise(session: AsyncSession, *, tier: str, currency: str)
 
 
 async def _reserve_pending_change(session: AsyncSession, *, sub: OrgSubscription, new_tier: str, offering_id: uuid.UUID) -> OrgSubscription:
+    """story #3212 — reserve_downgrade/cancel_subscription 공통 단일 지점(SSOT)이라
+    예약 확인 메일도 여기서 한 번만 쏜다(호출자별 개별 배선 불요, #3209 _confirm_with_ledger와
+    동형 원칙). 메일 실패는 예약 자체를 되돌리지 않는다."""
     await session.execute(
         update(OrgSubscription)
         .where(OrgSubscription.org_id == sub.org_id)
@@ -98,7 +102,90 @@ async def _reserve_pending_change(session: AsyncSession, *, sub: OrgSubscription
         )
     )
     await session.commit()
+    try:
+        await _notify_downgrade_reserved(
+            session, org_id=sub.org_id, new_tier=new_tier,
+            apply_at=sub.current_period_end, is_cancellation=(new_tier == "free"),
+        )
+    except Exception:
+        logger.warning("downgrade reserved notify 실패 org=%s", sub.org_id, exc_info=True)
     return await _refetch_subscription(session, sub.org_id)
+
+
+async def _notify_downgrade_reserved(
+    session: AsyncSession, *, org_id: uuid.UUID, new_tier: str, apply_at: datetime, is_cancellation: bool,
+) -> None:
+    """story #3212 AC1 — 하향/취소 예약 즉시 확인 메일. TRANSACTIONAL_COPY(payment_receipt와
+    동일 골격, render_action_email 그대로) + 수신자별 locale(storage/AU 경고·auto-cancel과
+    동형 owner/admin 전원 조회). CTA는 새 공개 원클릭 철회 엔드포인트를 발명하지 않고
+    빌링 설정 페이지(기존 예약 철회 UI가 이미 거기 있다)로 보낸다."""
+    from app.services.agent_onboarding_config import resolve_locale
+    from app.services.email import render_action_email
+    from app.services.email_copy import TRANSACTIONAL_COPY
+
+    copy_key = "subscription_cancel_reserved" if is_cancellation else "subscription_downgrade_reserved"
+    app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
+    billing_url = f"{app_url}/settings?tab=billing"
+    apply_date_display = apply_at.strftime("%Y-%m-%d")
+    tier_display = new_tier.capitalize()
+
+    recipients = [
+        r for r in (
+            await session.execute(
+                select(User.email, User.locale)
+                .join(OrgMember, User.id == OrgMember.user_id)
+                .where(OrgMember.org_id == org_id, OrgMember.role.in_(["owner", "admin"]), OrgMember.deleted_at.is_(None))
+            )
+        ).all()
+    ]
+    for em, locale_value in recipients:
+        recipient_locale = resolve_locale(locale_value)
+        copy = TRANSACTIONAL_COPY[copy_key][recipient_locale]
+        intro_lines = [line.format(tier=tier_display, apply_date=apply_date_display) for line in copy["intro_lines"]]
+        html = render_action_email(
+            intro_lines=intro_lines, cta_label=copy["cta_label"], cta_url=billing_url,
+            expiry_note=copy["expiry_note"], security_note=copy["security_note"],
+            fallback_label=copy["fallback_label"], locale=recipient_locale,
+        )
+        try:
+            send_email(em, copy["subject"].format(tier=tier_display), html)
+        except Exception:
+            logger.warning("downgrade reserved email 개별 발송 실패 org=%s to=%s", org_id, em, exc_info=True)
+
+
+async def _notify_downgrade_applied(session: AsyncSession, *, org_id: uuid.UUID, new_tier: str, is_cancellation: bool) -> None:
+    """story #3212 AC2 — sweep 적용(갱신일 도래) 시 완료 통지. 액션 불요(정보성)라
+    DOWNGRADE_AUTO_CANCEL_COPY와 동형(greeting/body/closing, render_email_shell 직접)."""
+    from app.services.agent_onboarding_config import resolve_locale
+    from app.services.email import render_email_shell
+    from app.services.email_copy import SUBSCRIPTION_CANCEL_APPLIED_COPY, SUBSCRIPTION_DOWNGRADE_APPLIED_COPY
+
+    copy_dict = SUBSCRIPTION_CANCEL_APPLIED_COPY if is_cancellation else SUBSCRIPTION_DOWNGRADE_APPLIED_COPY
+    tier_display = new_tier.capitalize()
+
+    recipients = [
+        r for r in (
+            await session.execute(
+                select(User.email, User.locale)
+                .join(OrgMember, User.id == OrgMember.user_id)
+                .where(OrgMember.org_id == org_id, OrgMember.role.in_(["owner", "admin"]), OrgMember.deleted_at.is_(None))
+            )
+        ).all()
+    ]
+    for em, locale_value in recipients:
+        recipient_locale = resolve_locale(locale_value)
+        copy = copy_dict[recipient_locale]
+        content = (
+            f"<p>{copy['greeting']}</p>"
+            f"<p>{copy['body1'].format(tier=tier_display)}</p>"
+            f"<p>{copy['body2']}</p>"
+            f"<p>{copy['closing']}</p>"
+        )
+        html = render_email_shell(content, locale=recipient_locale)
+        try:
+            send_email(em, copy["subject"].format(tier=tier_display), html)
+        except Exception:
+            logger.warning("downgrade applied email 개별 발송 실패 org=%s to=%s", org_id, em, exc_info=True)
 
 
 async def reserve_downgrade(session: AsyncSession, *, org_id: uuid.UUID, new_tier: str) -> OrgSubscription:
@@ -255,6 +342,10 @@ async def sweep_pending_tier_downgrades(session: AsyncSession, *, now: datetime 
             cancelled_seat_overage += 1
             continue
 
+        # story #3212 — 아래 UPDATE 직후 identity-map evaluate 동기화로 sub.pending_tier가
+        # None으로 덮인다(위 seat-overage 분기와 동일 함정, 카디르 확定 버그 PR#3308 QA
+        # 참고) — 메일에 넘길 목표 tier를 UPDATE 前에 스냅샷한다.
+        target_tier_snapshot = "free" if is_cancellation else sub.pending_tier
         if is_cancellation:
             # free는 Toss 결제 주기가 없다 — downgrade_to_free(dunning 강제전환)의 free
             # upsert 관례와 동형으로 billing_cycle/period를 비운다(재구현 0).
@@ -274,6 +365,12 @@ async def sweep_pending_tier_downgrades(session: AsyncSession, *, now: datetime 
             update(OrgSubscription).where(OrgSubscription.id == sub.id).values(**update_values)
         )
         await session.commit()
+        try:
+            await _notify_downgrade_applied(
+                session, org_id=sub.org_id, new_tier=target_tier_snapshot, is_cancellation=is_cancellation,
+            )
+        except Exception:
+            logger.warning("downgrade applied notify 실패 org=%s", sub.org_id, exc_info=True)
         applied += 1
 
     return {"pending_seen": len(pending), "applied": applied, "cancelled_seat_overage": cancelled_seat_overage, "skipped": skipped}

--- a/backend/tests/test_3212_subscription_lifecycle_email.py
+++ b/backend/tests/test_3212_subscription_lifecycle_email.py
@@ -1,0 +1,269 @@
+"""story #3212 — 구독 취소/하향 «예약 확인»+«적용 완료» 메일. #3207(dunning/auto-cancel
+locale)과 동형 mocking 관례 — 무효 오라클 방지 위해 ko/en 수신자를 실제로 다른 값으로 넣는다."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _locale_result(rows: list[tuple[str, str | None]]) -> MagicMock:
+    r = MagicMock()
+    r.all.return_value = rows
+    return r
+
+
+# ── _notify_downgrade_reserved — 카피/locale 내용 ────────────────────────────
+
+@pytest.mark.anyio
+async def test_notify_downgrade_reserved_downgrade_variant_locale_matched(monkeypatch):
+    import app.services.org_subscription_downgrade as mod
+
+    sent = []
+    monkeypatch.setattr(mod, "send_email", lambda to, subject, html: sent.append({"to": to, "subject": subject, "html": html}))
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_locale_result([("ko@example.com", "ko"), ("en@example.com", "en")]))
+
+    await mod._notify_downgrade_reserved(
+        session, org_id=uuid.uuid4(), new_tier="starter",
+        apply_at=datetime(2026, 9, 29, tzinfo=timezone.utc), is_cancellation=False,
+    )
+
+    assert len(sent) == 2
+    ko_sent = next(s for s in sent if s["to"] == "ko@example.com")
+    en_sent = next(s for s in sent if s["to"] == "en@example.com")
+    assert ko_sent["subject"] == "[Sprintable] Starter 플랜으로 변경이 예약됐습니다"
+    assert "2026-09-29" in ko_sent["html"]
+    assert "plan change to Starter is scheduled" in en_sent["subject"]
+    # CTA(철회 링크)가 빌링 설정 페이지를 가리킨다 — 새 원클릭 엔드포인트 발명 없음.
+    assert "/settings?tab=billing" in ko_sent["html"]
+
+
+@pytest.mark.anyio
+async def test_notify_downgrade_reserved_cancellation_variant_uses_cancel_copy(monkeypatch):
+    import app.services.org_subscription_downgrade as mod
+
+    sent = []
+    monkeypatch.setattr(mod, "send_email", lambda to, subject, html: sent.append({"to": to, "subject": subject, "html": html}))
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_locale_result([("owner@example.com", "ko")]))
+
+    await mod._notify_downgrade_reserved(
+        session, org_id=uuid.uuid4(), new_tier="free",
+        apply_at=datetime(2026, 9, 29, tzinfo=timezone.utc), is_cancellation=True,
+    )
+
+    assert len(sent) == 1
+    assert sent[0]["subject"] == "[Sprintable] 구독 해지가 예약됐습니다"
+    assert "Free 플랜으로 전환됩니다" in sent[0]["html"]
+
+
+@pytest.mark.anyio
+async def test_notify_downgrade_reserved_one_recipient_failure_does_not_block_others(monkeypatch):
+    import app.services.org_subscription_downgrade as mod
+
+    sent = []
+
+    def _send(to, subject, html):
+        if to == "fails@example.com":
+            raise RuntimeError("smtp down")
+        sent.append(to)
+
+    monkeypatch.setattr(mod, "send_email", _send)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_locale_result([("fails@example.com", "ko"), ("ok@example.com", "ko")]))
+
+    await mod._notify_downgrade_reserved(
+        session, org_id=uuid.uuid4(), new_tier="starter",
+        apply_at=datetime(2026, 9, 29, tzinfo=timezone.utc), is_cancellation=False,
+    )
+
+    assert sent == ["ok@example.com"]
+
+
+# ── _notify_downgrade_applied — 카피/locale 내용 ─────────────────────────────
+
+@pytest.mark.anyio
+async def test_notify_downgrade_applied_downgrade_variant(monkeypatch):
+    import app.services.org_subscription_downgrade as mod
+
+    sent = []
+    monkeypatch.setattr(mod, "send_email", lambda to, subject, html: sent.append({"to": to, "subject": subject, "html": html}))
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_locale_result([("en@example.com", "en")]))
+
+    await mod._notify_downgrade_applied(session, org_id=uuid.uuid4(), new_tier="starter", is_cancellation=False)
+
+    assert len(sent) == 1
+    assert "plan change to Starter is complete" in sent[0]["subject"]
+    assert "hasn't been deleted" in sent[0]["html"]
+
+
+@pytest.mark.anyio
+async def test_notify_downgrade_applied_cancellation_variant(monkeypatch):
+    import app.services.org_subscription_downgrade as mod
+
+    sent = []
+    monkeypatch.setattr(mod, "send_email", lambda to, subject, html: sent.append({"to": to, "subject": subject, "html": html}))
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_locale_result([("ko@example.com", "ko")]))
+
+    await mod._notify_downgrade_applied(session, org_id=uuid.uuid4(), new_tier="free", is_cancellation=True)
+
+    assert len(sent) == 1
+    assert sent[0]["subject"] == "[Sprintable] 구독이 해지되어 Free 플랜으로 전환됐습니다"
+    assert "삭제되지 않고 그대로 보존" in sent[0]["html"]
+
+
+# ── SSOT 배선 — _reserve_pending_change ──────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_reserve_pending_change_dispatches_reserved_email_with_correct_flags(monkeypatch):
+    """reserve_downgrade/cancel_subscription 공통 단일 지점 — is_cancellation과 apply_at이
+    정확히 넘어가는지 고정(호출자별 개별 배선 불요 원칙의 실제 증거)."""
+    import app.services.org_subscription_downgrade as mod
+    from app.models.org_subscription import OrgSubscription
+
+    sub = MagicMock(spec=OrgSubscription)
+    sub.org_id = uuid.uuid4()
+    sub.current_period_end = datetime(2026, 9, 29, tzinfo=timezone.utc)
+    refetched = MagicMock()
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=MagicMock(scalar_one=MagicMock(return_value=refetched)))
+
+    notify_mock = AsyncMock()
+    monkeypatch.setattr(mod, "_notify_downgrade_reserved", notify_mock)
+
+    result = await mod._reserve_pending_change(session, sub=sub, new_tier="starter", offering_id=uuid.uuid4())
+
+    assert result is refetched
+    notify_mock.assert_awaited_once_with(
+        session, org_id=sub.org_id, new_tier="starter",
+        apply_at=sub.current_period_end, is_cancellation=False,
+    )
+
+
+@pytest.mark.anyio
+async def test_reserve_pending_change_cancellation_sets_is_cancellation_true(monkeypatch):
+    import app.services.org_subscription_downgrade as mod
+    from app.models.org_subscription import OrgSubscription
+
+    sub = MagicMock(spec=OrgSubscription)
+    sub.org_id = uuid.uuid4()
+    sub.current_period_end = datetime(2026, 9, 29, tzinfo=timezone.utc)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=MagicMock(scalar_one=MagicMock(return_value=MagicMock())))
+
+    notify_mock = AsyncMock()
+    monkeypatch.setattr(mod, "_notify_downgrade_reserved", notify_mock)
+
+    await mod._reserve_pending_change(session, sub=sub, new_tier="free", offering_id=uuid.uuid4())
+
+    notify_mock.assert_awaited_once_with(
+        session, org_id=sub.org_id, new_tier="free",
+        apply_at=sub.current_period_end, is_cancellation=True,
+    )
+
+
+@pytest.mark.anyio
+async def test_reserve_pending_change_notify_failure_does_not_break_reservation(monkeypatch):
+    import app.services.org_subscription_downgrade as mod
+    from app.models.org_subscription import OrgSubscription
+
+    sub = MagicMock(spec=OrgSubscription)
+    sub.org_id = uuid.uuid4()
+    sub.current_period_end = datetime(2026, 9, 29, tzinfo=timezone.utc)
+    refetched = MagicMock()
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=MagicMock(scalar_one=MagicMock(return_value=refetched)))
+    monkeypatch.setattr(mod, "_notify_downgrade_reserved", AsyncMock(side_effect=RuntimeError("smtp down")))
+
+    result = await mod._reserve_pending_change(session, sub=sub, new_tier="starter", offering_id=uuid.uuid4())
+
+    assert result is refetched
+
+
+# ── SSOT 배선 — sweep_pending_tier_downgrades(적용 시점) ─────────────────────
+
+@pytest.mark.anyio
+async def test_sweep_applied_downgrade_notifies_with_pre_update_tier_snapshot(monkeypatch):
+    """카디르 확定 버그(PR#3308 QA)와 동일 함정 — UPDATE 後 sub.pending_tier를 그대로
+    넘기면 identity-map evaluate 동기화로 이미 None이라 메일에 None이 실린다(#3207/§③
+    seat-overage 분기가 이미 스냅샷으로 막은 것과 동일 클래스). ②(적용) 경로도 스냅샷
+    으로 막혔는지 고정."""
+    import app.services.org_subscription_downgrade as mod
+    from app.models.org_subscription import OrgSubscription
+    from app.models.offering_version import OfferingVersion
+
+    now = datetime(2026, 9, 29, tzinfo=timezone.utc)
+    sub = MagicMock(spec=OrgSubscription)
+    sub.id = uuid.uuid4()
+    sub.org_id = uuid.uuid4()
+    sub.pending_tier = "starter"
+    sub.pending_offering_version_id = uuid.uuid4()
+    sub.billing_cycle = "monthly"
+
+    pending_result = MagicMock()
+    pending_result.scalars.return_value.all.return_value = [sub]
+    session = AsyncMock()
+
+    offering = MagicMock(spec=OfferingVersion)
+    offering.included_seats = 100
+    session.get = AsyncMock(return_value=offering)
+
+    monkeypatch.setattr(mod, "count_human_seats", AsyncMock(return_value=3))
+    monkeypatch.setattr(mod, "compute_period_end", MagicMock(return_value=now))
+    notify_mock = AsyncMock()
+    monkeypatch.setattr(mod, "_notify_downgrade_applied", notify_mock)
+
+    # UPDATE 호출 시점에 evaluate 동기화를 흉내내 pending_tier를 None으로 되돌린다 —
+    # 스냅샷 없이 넘겼다면 아래 assert가 new_tier=None으로 실패한다.
+    async def _execute_side_effect(*a, **kw):
+        if not hasattr(_execute_side_effect, "called"):
+            _execute_side_effect.called = True
+            return pending_result
+        sub.pending_tier = None
+        return MagicMock()
+    session.execute = AsyncMock(side_effect=_execute_side_effect)
+
+    await mod.sweep_pending_tier_downgrades(session, now=now)
+
+    notify_mock.assert_awaited_once_with(session, org_id=sub.org_id, new_tier="starter", is_cancellation=False)
+
+
+@pytest.mark.anyio
+async def test_sweep_applied_cancellation_notifies_with_free_tier(monkeypatch):
+    import app.services.org_subscription_downgrade as mod
+    from app.models.org_subscription import OrgSubscription
+    from app.models.offering_version import OfferingVersion
+
+    now = datetime(2026, 9, 29, tzinfo=timezone.utc)
+    sub = MagicMock(spec=OrgSubscription)
+    sub.id = uuid.uuid4()
+    sub.org_id = uuid.uuid4()
+    sub.pending_tier = "free"
+    sub.pending_offering_version_id = uuid.uuid4()
+    sub.billing_cycle = "monthly"
+
+    pending_result = MagicMock()
+    pending_result.scalars.return_value.all.return_value = [sub]
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[pending_result, MagicMock()])
+
+    offering = MagicMock(spec=OfferingVersion)
+    offering.included_seats = 100
+    session.get = AsyncMock(return_value=offering)
+
+    notify_mock = AsyncMock()
+    monkeypatch.setattr(mod, "_notify_downgrade_applied", notify_mock)
+
+    await mod.sweep_pending_tier_downgrades(session, now=now)
+
+    notify_mock.assert_awaited_once_with(session, org_id=sub.org_id, new_tier="free", is_cancellation=True)


### PR DESCRIPTION
## 요약
- [\[빌링·메일\] 구독 취소·하향 «예약/적용» 확인 메일 부재 — 라이프사이클 통지 공백(현재는 자동 철회 때만 발송)](entity:story:7676a73d-3127-4e4c-ac28-c609639147da)

## 발견(선생님 실측, 2026-08-29)
취소/하향을 예약해도, 실제로 적용돼도 메일이 0건이었다 — 자동 철회(좌석초과) 시에만 통지 메일이 실재(#3207). 「내가 취소한 게 맞나」를 확인할 길이 화면뿐이고, 갱신일에 조용히 Free로 떨어졌다.

## ①예약 확認 메일 — `_reserve_pending_change` 단일 지점(SSOT)
`reserve_downgrade`/`cancel_subscription` 공통 호출부에서 한 번만 쏜다(호출자별 개별 배선 불요, #3209 `_confirm_with_ledger`와 동형 원칙). `TRANSACTIONAL_COPY`(payment_receipt와 동일 골격, `render_action_email` 재사용) 신규 2종. CTA "예약 확인·철회하기"는 빌링 설정 페이지로(새 공개 원클릭 철회 엔드포인트 발명 없음 — 기존 로그인 후 철회 버튼 그대로 재사용).

## ②적용 완료 메일 — `sweep_pending_tier_downgrades` 적용 분기
갱신일 도래해 실제 적용될 때(하향·해지 둘 다) 통지. 액션 불요(정보성)라 `DOWNGRADE_AUTO_CANCEL_COPY`와 동형(greeting/body/closing) 신규 2종. 데이터 보존 안내 포함.

⚠️카디르 확定 버그(PR#3308 QA)와 동일 함정 재확인 — UPDATE 後 `sub.pending_tier`를 그대로 메일에 넘기면 SQLAlchemy evaluate 동기화로 이미 None이라 메일에 None이 실린다. UPDATE 前에 로컬 변수로 스냅샷해 넘긴다(기존 seat-overage 분기가 이미 쓰던 방어와 동일 패턴).

## ③자동 철회 기존 메일 무회귀
`_notify_downgrade_auto_cancelled`는 무수정 — 기존 test_3207 21건 재확認 GREEN.

## 검증
- 신규 pin 10건 — 예약메일 카피/locale 3건 + 적용메일 카피/locale 2건 + SSOT 배선 3건(reserve→is_cancellation=False·cancel→True·발송실패가 예약을 안 깨뜨림) + sweep 적용 배선 2건(snapshot 회귀가드 포함).
- py_compile OK · 관련 181 passed · 전체 pytest(-m "not destructive_schema") 5114 passed(14 failed는 기존 환경 갭, 이번 변경과 무관).

## AC1/2 라이브 검증 안내
Sprout Two org가 현재 Starter라(#3209 검증 부산물) 취소 예약→확인 메일→철회 플로우를 실제로 돌릴 수 있음(예약 철회까지 하면 org 상태도 원복). sweep 적용(②)은 story #2896(Cloud Scheduler 착지) 대기 中이라 org_subscription_downgrade.py 자체 문서화된 기존 제약 그대로(라이브 자동 집행은 그 스케줄러 착지 後) — 함수 호출은 dev에서 직접 트리거해 검증 가능.

prod 무접촉(develop 대상).