### PR TITLE
[SID:3213] 참조 임베드 «대상이 없습니다» 오표기 제거 — 미등록≠비존재

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -105,9 +105,11 @@ describe('ChatBubble — story #2263 AC6 유령 칩(stored 참조 대조)', () =
     await act(async () => {
       root.render(wrap(<ChatBubble message={{ ...baseMessage, references: [] }} isMine={false} />));
     });
-    // 유령 칩은 버튼(클릭·모달)이 아니라 행동 0의 span이어야 한다.
-    expect(container.querySelector('button')).toBeNull();
-    expect(container.textContent).toContain('대상이 없습니다');
+    // story #3213 — 유령이라도 미등록≠비존재라 "대상이 없습니다"를 더 이상 단정하지 않는다.
+    // 클릭(EntityPreviewModal의 실 fetch)으로 진짜 존재판정을 위임 — 그래서 버튼은 있어야 한다.
+    expect(container.querySelector('button')).not.toBeNull();
+    expect(container.textContent).not.toContain('대상이 없습니다');
+    expect(container.textContent).toContain('제안서.md');
   });
 
   it('음성대조 — references에 본문 토큰과 정확히 일치하는 항목이 있으면 정상 칩 그대로다', async () => {
@@ -1486,7 +1488,7 @@ describe('ChatBubble — story #2671 EmbedCard 단독 참조 문단 카드 렌�
     expect(container.querySelector('button[aria-label="미리보기"]')).toBeNull(); // EmbedCard doc 전용 마커 아님
   });
 
-  it('참조가 유령(stored 참조에 없음)이면 단독 문단이어도 카드가 아니라 유령 칩(행동 0)이다', async () => {
+  it('참조가 유령(stored 참조에 없음)이면 단독 문단이어도 카드가 아니라 유령 칩이다(story #3213 — 클릭은 가능, 정적 "대상이 없습니다" 단정은 없음)', async () => {
     await act(async () => {
       root.render(wrap(
         <ChatBubble
@@ -1496,8 +1498,9 @@ describe('ChatBubble — story #2671 EmbedCard 단독 참조 문단 카드 렌�
       ));
     });
     expect(container.querySelector('.rounded-md')).toBeNull();
-    expect(container.querySelector('button')).toBeNull();
-    expect(container.textContent).toContain('대상이 없습니다');
+    expect(container.querySelector('button')).not.toBeNull();
+    expect(container.textContent).not.toContain('대상이 없습니다');
+    expect(container.textContent).toContain('제안서.md');
   });
 
   it('asset 토큰은 단독 문단이어도 기존 AssetEmbedCard 그대로다(EmbedCard로 안 새어간다)', async () => {

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -980,10 +980,18 @@ export function EntityChip({
   const inner = (
     <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>
       <EntityGlyph Icon={resolveEntityIcon(entityType)} label={label} className="size-3 shrink-0" />
-      {/* AC3 — truncate된 라벨의 전체 텍스트를 title(native)로도 보장(가장 낮은 공통분모
-          접근성 폴백 — 아래 커스텀 tooltip과 별개, JS 없이도 동작). */}
-      <span className={entityChipLabelVariants({ variant })} title={ghost ? undefined : label}>
-        {ghost ? '대상이 없습니다' : label}
+      {/* story #3213 — ghost 두 하위축을 가른다: entityId가 있으면(=본문 토큰이 UUID까지
+          파싱됐는데 이번 메시지의 stored 참조와만 매칭 안 됨 — 예: 손으로 친 토큰이 backend
+          파서 한계로 등록 실패) "대상이 없습니다"를 더 이상 안 쓴다. #2263 AC6 당시엔 #2302
+          AC4(진짜 존재하지 않는 대상)의 문구를 그대로 재사용했지만, 미등록≠비존재라는 걸 이
+          스토리의 실측(PO 발신 메시지, 대상 story 실재 확認)이 보였다 — 실제로 파싱된 라벨
+          (대체로 진짜 제목)을 그대로 보여준다(회색으로만 "미확認" 표시, 아래 클릭 가능
+          분기가 진짜 존재판정을 진다). entityId가 없으면(예: bare #<번호>가 아예 해소 안 된
+          story-detail-panel.tsx 케이스 — 가리킬 UUID 자체가 없다) 이 스토리의 대상이 아니다
+          — 클릭할 것도 없으므로 기존 "대상이 없습니다"(시제 중립 문구, 발명 0) 그대로 유지.
+          AC3 — truncate된 라벨의 전체 텍스트를 title(native)로도 보장. */}
+      <span className={entityChipLabelVariants({ variant })} title={ghost && !entityId ? undefined : label}>
+        {ghost && !entityId ? '대상이 없습니다' : label}
       </span>
       {/* AC1 — 사실성(상수 "관찰됨": entity_references 자체가 관찰됨 tier) · 표면 · 지점.
           ⛔색으로만 구분하지 않고 글자로 적는다(가디언 규율 재사용). inline-meta 변형에서만
@@ -997,9 +1005,11 @@ export function EntityChip({
     </span>
   );
 
-  if (ghost) {
-    return <span className="inline-flex cursor-default no-underline">{inner}</span>;
-  }
+  // story #3213 — ghost도 이제 클릭 가능(예전 "행동 0" 정책 철회). #2302 AC4의 실
+  // not-found 판정(EntityPreviewModal의 실 fetch)이 이미 정직한 존재판정을 갖고 있으니,
+  // 그걸 재사용하는 게 "모른다"를 그대로 미확認 상태로 두는 것보다 정직하다(모르면
+  // 확인해 본다 — 지어내지 않는다는 이 코드베이스의 반복 원칙과 동형). entityId가 UUID
+  // 모양으로 파싱됐다는 것 자체가 이미 "클릭해서 확인해 볼 가치"의 최소 근거.
 
   // story #2886(S2b) AC2 — 격납 메타(관찰됨·form·point·status)를 hover/focus tooltip으로.
   // base-ui Tooltip은 hover+focus 둘 다 기본 지원(키보드 Tab으로 트리거에 도달 가능) — 별도

--- a/apps/web/src/components/chat/entity-chip.test.tsx
+++ b/apps/web/src/components/chat/entity-chip.test.tsx
@@ -96,13 +96,20 @@ describe('EntityChip variant=inline-meta — 기존 전개 그대로(escape hatc
   });
 });
 
-describe('EntityChip ghost — variant 무관 무동작 유지', () => {
-  it('ghost는 inline이든 inline-meta든 항상 "대상이 없습니다"·클릭 없음', async () => {
+describe('EntityChip ghost — story #3213(미등록≠비존재, "대상이 없습니다" 정적 단정 제거)', () => {
+  it('ghost는 "대상이 없습니다"를 더 이상 안 쓰고 실 라벨을 보인다', async () => {
     await act(async () => {
       root.render(<EntityChip entityType="story" entityId="s-1" label={LONG_LABEL} href={null} ghost referenceMeta={META} />);
     });
-    expect(container.textContent).toContain('대상이 없습니다');
-    expect(container.querySelector('button')).toBeNull();
+    expect(container.textContent).not.toContain('대상이 없습니다');
+    expect(container.textContent).toContain(LONG_LABEL);
+  });
+
+  it('ghost도 클릭 가능(EntityPreviewModal의 실 fetch로 진짜 존재판정 위임)', async () => {
+    await act(async () => {
+      root.render(<EntityChip entityType="story" entityId="s-1" label="스토리 제목" href={null} ghost />);
+    });
+    expect(container.querySelector('button')).not.toBeNull();
   });
 });
 

--- a/apps/web/src/components/kanban/description-viewer.test.tsx
+++ b/apps/web/src/components/kanban/description-viewer.test.tsx
@@ -91,7 +91,7 @@ describe('DescriptionViewer — entity: 링크가 EntityChip으로 그려지는�
     expect(container.querySelector('button')).toBeTruthy();
   });
 
-  it('references에 없는 대상이면 유령 칩(회색·클릭 불가)으로 그린다', async () => {
+  it('references에 없는 대상이면 유령 칩(회색)으로 그린다 — story #3213: entityId가 있으므로 클릭 가능·실 라벨 유지', async () => {
     await act(async () => {
       root.render(
         <DescriptionViewer
@@ -101,9 +101,11 @@ describe('DescriptionViewer — entity: 링크가 EntityChip으로 그려지는�
       );
     });
 
-    expect(container.textContent).toContain('대상이 없습니다');
-    // 유령 칩은 button(모달 진입)이 없다 — embed-card.tsx EntityChip의 ghost 분기.
-    expect(container.querySelector('button')).toBeFalsy();
+    // entityId가 UUID까지 파싱됐다 — 미등록≠비존재라 "대상이 없습니다" 단정 없이 실 라벨을
+    // 보이고, 클릭(EntityChip→EntityPreviewModal 실 fetch)으로 진짜 존재판정을 위임한다.
+    expect(container.textContent).not.toContain('대상이 없습니다');
+    expect(container.textContent).toContain('스토리 제목');
+    expect(container.querySelector('button')).toBeTruthy();
   });
 
   it('references가 undefined(미로드)면 유령 판정을 보류하고 정상 칩으로 그린다(#2622와 동형 폴백)', async () => {

--- a/backend/tests/test_1993_mention_parser.py
+++ b/backend/tests/test_1993_mention_parser.py
@@ -97,6 +97,27 @@ def test_extract_chat_title_with_escaped_paren_and_backslash_still_matches():
     assert extract_chat_entity_mentions(content) == [("doc", doc_id)]
 
 
+def test_extract_chat_hand_typed_unescaped_bracket_title_intentionally_fails():
+    """story #3213 그라운딩(2026-08-29) — 위 두 테스트가 고정한 «escape된» 토큰과 대조군.
+    사람이 `build_reference_token`/FE `applyEntity`를 거치지 않고 **원문 그대로**(백슬래시
+    escape 없이) 손으로 토큰을 짓거나 붙여넣으면(이 조직의 실제 명명 관례 `[TAG] 제목`이
+    정확히 이 모양) 여전히 매치 실패한다 — 이건 #2282 미해결이 아니라 **설계 그대로**다.
+
+    이 정규식을 완전한 bracket-balancing 파서로 바꾸면(원문 그대로도 파싱되게) #2282가
+    막은 바로 그 phishing 위험(escape 안 된 `]`/`(` 조합으로 링크 구조를 변조)이 다시
+    열린다(reference_token.py 모듈 docstring 참조) — 그래서 백엔드는 고치지 않는다.
+
+    실제 처방(story #3213 AC2)은 FE 쪽이다: 등록 실패(references 미저장)가 "대상이
+    없습니다"로 오표기되던 걸 정직한 폴백(클릭 시 실 fetch로 존재판정)으로 바꿨다 —
+    `apps/web/src/components/chat/embed-card.tsx`의 EntityChip ghost 분기 참조."""
+    from app.services.mention_parser import extract_chat_entity_mentions
+
+    story_id = uuid.uuid4()
+    unescaped_title = "[빌링·메일] 구독 취소 확인 메일 부재"
+    content = f"[{unescaped_title}](entity:story:{story_id})"
+    assert extract_chat_entity_mentions(content) == []
+
+
 @pytest.mark.parametrize("raw_title", [
     "🚀 Launch Plan [Q3] 🎯",
     "Say \"Hello\" and 'Bye'",


### PR DESCRIPTION
[SID:3213]

## 발견 (선생님 제보+실물 대조)
PO가 선생님 채널에 보낸 #3212 안내 메시지의 스토리 임베드가 «대상이 없습니다»로
렌더(대상은 실재, 스크린샷 실재). 재현 데이터: 실패 메시지 id=`0c1ff112-efaa-49bc-b0ec-09d139207078`
(`references: []`)·동형 성공 메시지 다수(`stored>0`).

## 재현 (실물 왕복)
테스트 대화에서 직접 재현: `[[빌링·메일] 구독 취소...](entity:story:<real-id>)`처럼
title 자체에 미이스케이프 `[`/`]`가 있는 토큰을 손으로 붙여넣으면 `references: []`
(대조군으로 `mentions` 파라미터 경유 시 동일 대상이 `stored: 1`로 정상 등록 — 확인 완료).

## 판별 축 3개 결론
1. **escape 경계(①) — 확認, 원인**. `mention_parser.py::_CHAT_TOKEN_RE`는 `build_reference_token`/
   FE `applyEntity`가 만드는 escape된 토큰만 파싱하도록 설계됐다(#2282). 손으로 친 원문
   그대로의 토큰은 여전히 매치 실패 — 이건 미해결 버그가 아니라 **설계 그대로**다(regex를
   bracket-balancing으로 바꾸면 #2282가 막은 phishing 위험이 재발한다, `reference_token.py`
   모듈 docstring 참조). 그래서 백엔드는 고치지 않고, 신규 pin 테스트로 이 사실을 명문화했다.
2. **race(②) — 기각**. 즉시 재현(지연 0)에서도 동일 결과라 타이밍과 무관.
3. **FE 폴백 오표기(③) — 확認, 이 PR의 실제 처방**. `#2263 AC6`가 `#2302 AC4`("진짜 존재하지
   않는 대상")의 문구를 그대로 재사용했는데, "등록 안 됨(ghost)"과 "존재 안 함"은 다른 사실이다.

## 변경
`EntityChip`의 ghost 렌더링을 `entityId` 유무로 가른다:
- **entityId 있음**(=UUID까지 파싱됐는데 stored 참조와만 불일치 — 이번 버그의 실제 케이스):
  "대상이 없습니다" 단정 제거, 실 라벨 표시 + 클릭 가능(예전 "행동 0" 정책 철회) —
  `EntityPreviewModal`의 기존 fetch 기반 존재판정에 진짜 여부를 위임한다(새 메커니즘 발명
  0, 이미 있는 정직한 판정을 재사용).
- **entityId 없음**(예: bare `#<번호>`가 아예 해소 안 된 케이스 — 가리킬 UUID 자체가 없음):
  기존 "대상이 없습니다"·클릭 불가 그대로 무회귀(이 스토리의 대상이 아님).

영향 범위: `chat-bubble.tsx`(채팅 본문)·`description-viewer.tsx`(칸반 스토리 설명) 둘 다
`EntityChip` 공용 컴포넌트라 자동으로 같이 반영된다.

## Test plan
- [x] `backend/tests/test_1993_mention_parser.py` — 신규 pin(`test_extract_chat_hand_typed_unescaped_bracket_title_intentionally_fails`, 왜 백엔드를 안 고치는지 문서화), 42개 재통과
- [x] `entity-chip.test.tsx`·`chat-bubble.test.tsx`·`description-viewer.test.tsx` — 4곳 갱신(entityId 유무 두 축 모두 커버), 무관 케이스(backlinks/rejected-relations/still_exists류·bare-number-미해소)는 무변경 확認
- [x] `npx vitest run apps/web/src/components/chat/ apps/web/src/components/kanban/ apps/web/src/components/shared/` — 71 files / 834 tests passed
- [x] `npx tsc --noEmit` — clean