### PR TITLE
[SID:3208] 아티팩트 직URL/채팅 임베드 크로스프로젝트 404 수정

### DIFF
--- a/apps/web/src/app/api/visual-artifacts/preview/route.ts
+++ b/apps/web/src/app/api/visual-artifacts/preview/route.ts
@@ -1,0 +1,41 @@
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { handleApiError } from '@/lib/api-error';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+/**
+ * GET /api/visual-artifacts/preview?id=<uuid>
+ *
+ * story #3208 — `apps/web/src/app/api/docs/preview/route.ts`(#2168)와 동형. 아티팩트
+ * 직URL·채팅 임베드가 호출자의 «현재» project로만 스코프된 `GET /api/visual-artifacts/{id}`
+ * (BE SEC-S8 project_id 필터)에 막혀 다른 프로젝트를 보던 중이면 대상이 실재해도 404였다 —
+ * 이 프리뷰는 org 스코프로 먼저 찾고 실 접근권을 검증해 위치정보(project_id/org_slug/
+ * project_slug)만 낸다(본문은 여전히 project_id를 안 뒤에 `GET /{id}`가 낸다).
+ */
+export async function GET(request: Request) {
+  try {
+    const me = await getOrgProjectAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded)
+      return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get('id')?.trim();
+    if (!id) return ApiErrors.badRequest('id is required');
+
+    const _r = await proxyToFastapi(request, '/api/v2/visual-artifacts/preview');
+    if (!_r.ok) return _r;
+    const json = await _r.json() as {
+      data?: { id: string; project_id: string; org_slug: string; project_slug: string | null };
+    };
+    if (!json.data) return ApiErrors.notFound('Artifact not found');
+    return apiSuccess({
+      id: json.data.id,
+      projectId: json.data.project_id,
+      orgSlug: json.data.org_slug,
+      projectSlug: json.data.project_slug ?? null,
+    });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/chat/embed-card.artifact-form.test.tsx
+++ b/apps/web/src/components/chat/embed-card.artifact-form.test.tsx
@@ -42,7 +42,12 @@ async function flush() {
 
 describe('EmbedCard artifact 실 렌더 인라인 — story #2905 S2c①', () => {
   it('artifact detail fetch 성공(latest_version_number 있음) → ArtifactThumbnail 렌더', async () => {
+    // story #3208 — preview(project_id 해소)→detail(X-Project-Id 명시) 2단 왕복이다
+    // (#2168 doc own-href와 동형 근본원인·처방).
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/visual-artifacts/preview?id=art-1') {
+        return { ok: true, json: async () => ({ data: { projectId: 'p-current' } }) };
+      }
       expect(url).toBe('/api/visual-artifacts/art-1');
       return { ok: true, json: async () => ({ data: { latest_version_number: 3, anchor_version: 2 } }) };
     }));

--- a/apps/web/src/components/chat/embed-card.link-states.test.tsx
+++ b/apps/web/src/components/chat/embed-card.link-states.test.tsx
@@ -157,9 +157,24 @@ describe('AC3/AC4 — task는 부모 story로("담긴 곳으로 갑니다")', ()
   });
 });
 
+// story #3208 — 위 own-href(story/epic/asset)와 별개로, artifact의 detail fetch는 이제
+// preview(project_id 해소)→detail(X-Project-Id 명시) 2단 왕복이다(#2168 doc own-href와
+// 동형 근본원인·처방). 이 describe 블록의 모든 stubFetch는 `/preview` 요청에 먼저 응답해야
+// detail fetch까지 도달한다 — 이 헬퍼가 그 반복을 한 곳으로 모은다.
+function stubArtifactPreviewThenDetail(
+  detailImpl: (url: string) => Promise<{ ok: boolean; json: () => Promise<unknown> }>,
+) {
+  stubFetch(async (url) => {
+    if (url.includes('/api/visual-artifacts/preview')) {
+      return { ok: true, json: async () => ({ data: { projectId: 'p-current' } }) };
+    }
+    return detailImpl(url);
+  });
+}
+
 describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, 전부 없으면 ③)', () => {
   it('story_id가 있는 artifact는 "담긴 곳으로 갑니다"로 그 story로 간다', async () => {
-    stubFetch(async () => ({
+    stubArtifactPreviewThenDetail(async () => ({
       ok: true,
       json: async () => ({ data: { story_id: 's-1', epic_id: null, doc_id: null } }),
     }));
@@ -173,8 +188,30 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
     expect(link!.textContent).toContain('담긴 곳으로 갑니다');
   });
 
+  it('story #3208 핵심 처방 — 뷰어가 다른 project를 보던 중이어도 preview가 해소한 project_id를 detail fetch에 X-Project-Id로 명시 실어 보낸다(«현재 project»로 스코프되지 않음)', async () => {
+    const calls: { url: string; headers: Record<string, string> }[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      const headers: Record<string, string> = {};
+      new Headers(init?.headers).forEach((v, k) => { headers[k] = v; });
+      calls.push({ url, headers });
+      if (url.includes('/api/visual-artifacts/preview')) {
+        return { ok: true, json: async () => ({ data: { projectId: 'p-owning' } }) };
+      }
+      return { ok: true, json: async () => ({ data: { story_id: null, epic_id: null, doc_id: null } }) };
+    }));
+    await act(async () => {
+      root.render(<EmbedCard entity_type="artifact" entity_id="a-cross" title="크로스 목업" status={null} />);
+    });
+    await openCard();
+    await flush();
+    const detailCall = calls.find((c) => c.url === '/api/visual-artifacts/a-cross');
+    expect(detailCall).toBeDefined();
+    // Headers는 이름을 소문자로 정규화한다.
+    expect(detailCall!.headers['x-project-id']).toBe('p-owning');
+  });
+
   it('epic_id만 있으면 그 epic(/goals/)으로 간다', async () => {
-    stubFetch(async () => ({
+    stubArtifactPreviewThenDetail(async () => ({
       ok: true,
       json: async () => ({ data: { story_id: null, epic_id: 'e-9', doc_id: null } }),
     }));
@@ -189,7 +226,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
   // story #2642(BE #3044) — ArtifactResponse는 artifact 자기 행의 org_id/project_id를
   // 직접 싣는다(부모 hop 불필요) — story_id/epic_id 분기 둘 다 이 값을 그대로 쓴다.
   it('story_id + org_slug/project_slug가 있는 artifact는 크로스프로젝트 부모 story로 직행한다', async () => {
-    stubFetch(async () => ({
+    stubArtifactPreviewThenDetail(async () => ({
       ok: true,
       json: async () => ({ data: { story_id: 's-1', epic_id: null, doc_id: null, org_slug: 'acme', project_slug: 'content' } }),
     }));
@@ -203,7 +240,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
   });
 
   it('epic_id + org_slug/project_slug가 있는 artifact는 크로스프로젝트 부모 epic으로 직행한다', async () => {
-    stubFetch(async () => ({
+    stubArtifactPreviewThenDetail(async () => ({
       ok: true,
       json: async () => ({ data: { story_id: null, epic_id: 'e-9', doc_id: null, org_slug: 'acme', project_slug: 'content' } }),
     }));
@@ -222,6 +259,9 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
   // 이 처방이 그 사각도 같이 없앤다).
   it('doc_id가 있는 artifact — 그 doc이 속한 project로 직행한다(#2168 재사용, 새 BE 없음)', async () => {
     stubFetch(async (url) => {
+      if (url.includes('/api/visual-artifacts/preview')) {
+        return { ok: true, json: async () => ({ data: { projectId: 'p-current' } }) };
+      }
       if (url.includes('/api/visual-artifacts/')) {
         if (url.includes('/exports')) return { ok: true, json: async () => ({ data: [] }) };
         if (url.includes('/versions/')) return { ok: false, json: async () => ({}) };
@@ -247,6 +287,9 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
 
   it('doc_id가 있는 artifact — doc preview 조회 실패 시 기존 bare `/docs?id=`로 우아하게 폴백한다(회귀 아님, ④ 원칙)', async () => {
     stubFetch(async (url) => {
+      if (url.includes('/api/visual-artifacts/preview')) {
+        return { ok: true, json: async () => ({ data: { projectId: 'p-current' } }) };
+      }
       if (url.includes('/api/visual-artifacts/')) {
         if (url.includes('/exports')) return { ok: true, json: async () => ({ data: [] }) };
         if (url.includes('/versions/')) return { ok: false, json: async () => ({}) };
@@ -265,7 +308,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
   });
 
   it('전부 null(독립 artifact)이면 회색·행동0 "열 수 있는 화면이 없습니다"(거짓 링크 금지)', async () => {
-    stubFetch(async () => ({
+    stubArtifactPreviewThenDetail(async () => ({
       ok: true,
       json: async () => ({ data: { story_id: null, epic_id: null, doc_id: null } }),
     }));
@@ -318,6 +361,9 @@ describe('story #2614 AC1/AC3 — artifact(부모 없는 독립 목업)는 몸�
     // 내용물이 아니다)로 응답해 ArtifactThumbnail이 안전하게 placeholder로 정착하게 한다.
     stubFetch(async (url) => {
       expect(url).toContain('/api/visual-artifacts/');
+      // story #3208 — EntityPreviewModal의 detail fetch·EmbedCard 자신의 썸네일 fetch 둘 다
+      // 이제 preview(project_id 해소)를 먼저 부른다(#2168 doc own-href와 동형).
+      if (url.includes('/preview')) return { ok: true, json: async () => ({ data: { projectId: 'p-current' } }) };
       if (url.includes('/exports')) return { ok: true, json: async () => ({ data: [] }) };
       if (url.includes('/versions/')) return { ok: false, json: async () => ({}) };
       return {

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -445,6 +445,36 @@ export function EntityPreviewModal({
       return () => { cancelled = true; };
     }
 
+    if (entityType === 'artifact') {
+      // story #3208(PO customer-zero) — GET /api/visual-artifacts/{id}는 «현재 탭이 보고
+      // 있는» project로 스코프된다(fetch 인터셉터가 X-Project-Id를 그걸로 채움) — 아티팩트가
+      // 다른 project 소속이면(채팅에서 흔함, doc #2168과 동형) 대상이 실재해도 404였다.
+      // preview(org 스코프 조회+has_project_access 검증, BE 신설)로 실제 project_id를 먼저
+      // 알아낸 뒤 그 값을 X-Project-Id로 명시 실어 detail을 정확한 project로 조회한다 —
+      // project-context-client.ts의 fetch 인터셉터는 이미 명시된 X-Project-Id를 안 덮는다
+      // (switcher의 cross-org 로드가 쓰는 것과 동일한 기존 escape hatch, 새 메커니즘 0).
+      void (async () => {
+        try {
+          const previewRes = await fetchWithAuth(`/api/visual-artifacts/preview?id=${encodeURIComponent(entityId)}`);
+          if (!previewRes.ok) throw new Error();
+          const previewJson = (await previewRes.json()) as { data?: { projectId?: string } };
+          const resolvedProjectId = previewJson.data?.projectId;
+          if (!resolvedProjectId) throw new Error();
+          const detailRes = await fetchWithAuth(`/api/visual-artifacts/${entityId}`, {
+            headers: { 'X-Project-Id': resolvedProjectId },
+          });
+          if (!detailRes.ok) throw new Error();
+          const detailJson = (await detailRes.json()) as { data?: Record<string, unknown> };
+          if (!cancelled) setDetail(detailJson.data ?? null);
+        } catch {
+          if (!cancelled) setNotFound(true);
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
+      })();
+      return () => { cancelled = true; };
+    }
+
     const url = ENTITY_API[entityType]?.(entityId);
     if (!url) return; // hypothesis 등 — fetch 전략 자체가 없다(loading도 이미 false로 시작).
     fetch(url)
@@ -720,10 +750,24 @@ export function EmbedCard({
     let cancelled = false;
     const url = ENTITY_API.artifact?.(entity_id);
     if (!url) return;
-    void fetchWithAuth(url)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((json: { data?: Record<string, unknown> } | null) => { if (!cancelled) setArtifactDetail((json?.data ?? null) as typeof artifactDetail); })
-      .catch(() => { if (!cancelled) setArtifactDetail(null); });
+    // story #3208 — EntityPreviewModal의 detail fetch와 동형 처방(preview로 실제 project_id를
+    // 먼저 알아내 X-Project-Id로 명시). 이 썸네일 fetch는 원래도 실패 시 조용히 폴백(plain
+    // 라벨 폼)이라 하드 실패는 아니었지만, 같은 근본원인(현재 project로만 스코프)이라 같이 고친다.
+    void (async () => {
+      try {
+        const previewRes = await fetchWithAuth(`/api/visual-artifacts/preview?id=${encodeURIComponent(entity_id)}`);
+        if (!previewRes.ok) throw new Error();
+        const previewJson = (await previewRes.json()) as { data?: { projectId?: string } };
+        const resolvedProjectId = previewJson.data?.projectId;
+        if (!resolvedProjectId) throw new Error();
+        const detailRes = await fetchWithAuth(url, { headers: { 'X-Project-Id': resolvedProjectId } });
+        if (!detailRes.ok) throw new Error();
+        const json = (await detailRes.json()) as { data?: Record<string, unknown> };
+        if (!cancelled) setArtifactDetail((json.data ?? null) as typeof artifactDetail);
+      } catch {
+        if (!cancelled) setArtifactDetail(null);
+      }
+    })();
     return () => { cancelled = true; };
   }, [entity_type, entity_id]);
 

--- a/apps/web/src/components/chat/embed-card.tsx
+++ b/apps/web/src/components/chat/embed-card.tsx
@@ -89,6 +89,32 @@ const ENTITY_API: Record<string, (id: string) => string> = {
   hypothesis: (id) => `/api/hypotheses/${id}`,
 };
 
+// story #3208(PO customer-zero) — GET /api/visual-artifacts/{id}는 «현재 탭이 보고 있는»
+// project로 스코프된다(fetch 인터셉터가 X-Project-Id를 그걸로 채움) — 아티팩트가 다른
+// project 소속이면(채팅에서 흔함, doc #2168과 동형) 대상이 실재해도 404였다. preview
+// (org 스코프 조회+has_project_access 검증, BE 신설)로 실제 project_id를 먼저 알아낸 뒤
+// 그 값을 X-Project-Id로 명시 실어 detail을 정확한 project로 조회한다 —
+// project-context-client.ts의 fetch 인터셉터는 이미 명시된 X-Project-Id를 안 덮는다
+// (switcher의 cross-org 로드가 쓰는 것과 동일한 기존 escape hatch, 새 메커니즘 0).
+//
+// ⛔까디르 QA 지적(2026-08-29, PR#3611 qa:changes) — 이 로직이 EntityPreviewModal
+// (모달 detail fetch)·EmbedCard(인라인 썸네일 fetch) 두 곳에 독립 구현으로 처음 들어갔다가
+// 한쪽(EntityChip 클릭→모달 경로, 스토리 원 시나리오)이 pin 없이 방치될 뻔했다 — 공용
+// 함수 하나로 모아 "두 곳이 각자 옳게 짜는" 대신 "한 곳이 옳으면 둘 다 옳다"로 만든다.
+async function fetchArtifactCrossProjectDetail(artifactId: string): Promise<Record<string, unknown> | null> {
+  const previewRes = await fetchWithAuth(`/api/visual-artifacts/preview?id=${encodeURIComponent(artifactId)}`);
+  if (!previewRes.ok) throw new Error('artifact preview fetch failed');
+  const previewJson = (await previewRes.json()) as { data?: { projectId?: string } };
+  const resolvedProjectId = previewJson.data?.projectId;
+  if (!resolvedProjectId) throw new Error('artifact preview missing projectId');
+  const detailRes = await fetchWithAuth(`/api/visual-artifacts/${artifactId}`, {
+    headers: { 'X-Project-Id': resolvedProjectId },
+  });
+  if (!detailRes.ok) throw new Error('artifact detail fetch failed');
+  const detailJson = (await detailRes.json()) as { data?: Record<string, unknown> };
+  return detailJson.data ?? null;
+}
+
 // story #2614 AC2 — 멘션 합성 가능 8타입(story/doc/epic/task/sprint/artifact/hypothesis/
 // evidence) 전수표. 이 Set에 없는 타입은 "이 엔티티는 별도 미리보기가 없습니다"로 떨어진다 —
 // 그게 이 스토리가 고친 결함(만들 수는 있는데 몸통에서 아무것도 못 얻는 반쪽)이었다. sprint는
@@ -446,26 +472,13 @@ export function EntityPreviewModal({
     }
 
     if (entityType === 'artifact') {
-      // story #3208(PO customer-zero) — GET /api/visual-artifacts/{id}는 «현재 탭이 보고
-      // 있는» project로 스코프된다(fetch 인터셉터가 X-Project-Id를 그걸로 채움) — 아티팩트가
-      // 다른 project 소속이면(채팅에서 흔함, doc #2168과 동형) 대상이 실재해도 404였다.
-      // preview(org 스코프 조회+has_project_access 검증, BE 신설)로 실제 project_id를 먼저
-      // 알아낸 뒤 그 값을 X-Project-Id로 명시 실어 detail을 정확한 project로 조회한다 —
-      // project-context-client.ts의 fetch 인터셉터는 이미 명시된 X-Project-Id를 안 덮는다
-      // (switcher의 cross-org 로드가 쓰는 것과 동일한 기존 escape hatch, 새 메커니즘 0).
+      // story #3208 — 공용 헬퍼(위 fetchArtifactCrossProjectDetail) 경유. EmbedCard의
+      // 인라인 썸네일 fetch와 동일 로직을 공유한다(까디르 QA 지적, 두 곳 독립구현이던
+      // 것을 한 곳으로 수렴).
       void (async () => {
         try {
-          const previewRes = await fetchWithAuth(`/api/visual-artifacts/preview?id=${encodeURIComponent(entityId)}`);
-          if (!previewRes.ok) throw new Error();
-          const previewJson = (await previewRes.json()) as { data?: { projectId?: string } };
-          const resolvedProjectId = previewJson.data?.projectId;
-          if (!resolvedProjectId) throw new Error();
-          const detailRes = await fetchWithAuth(`/api/visual-artifacts/${entityId}`, {
-            headers: { 'X-Project-Id': resolvedProjectId },
-          });
-          if (!detailRes.ok) throw new Error();
-          const detailJson = (await detailRes.json()) as { data?: Record<string, unknown> };
-          if (!cancelled) setDetail(detailJson.data ?? null);
+          const data = await fetchArtifactCrossProjectDetail(entityId);
+          if (!cancelled) setDetail(data);
         } catch {
           if (!cancelled) setNotFound(true);
         } finally {
@@ -748,22 +761,13 @@ export function EmbedCard({
   useEffect(() => {
     if (entity_type !== 'artifact') return;
     let cancelled = false;
-    const url = ENTITY_API.artifact?.(entity_id);
-    if (!url) return;
-    // story #3208 — EntityPreviewModal의 detail fetch와 동형 처방(preview로 실제 project_id를
-    // 먼저 알아내 X-Project-Id로 명시). 이 썸네일 fetch는 원래도 실패 시 조용히 폴백(plain
-    // 라벨 폼)이라 하드 실패는 아니었지만, 같은 근본원인(현재 project로만 스코프)이라 같이 고친다.
+    // story #3208 — 공용 헬퍼(fetchArtifactCrossProjectDetail) 경유, EntityPreviewModal의
+    // detail fetch와 동일 로직 공유(까디르 QA 지적). 이 썸네일 fetch는 원래도 실패 시
+    // 조용히 폴백(plain 라벨 폼)이라 하드 실패는 아니었지만, 같은 근본원인이라 같이 고친다.
     void (async () => {
       try {
-        const previewRes = await fetchWithAuth(`/api/visual-artifacts/preview?id=${encodeURIComponent(entity_id)}`);
-        if (!previewRes.ok) throw new Error();
-        const previewJson = (await previewRes.json()) as { data?: { projectId?: string } };
-        const resolvedProjectId = previewJson.data?.projectId;
-        if (!resolvedProjectId) throw new Error();
-        const detailRes = await fetchWithAuth(url, { headers: { 'X-Project-Id': resolvedProjectId } });
-        if (!detailRes.ok) throw new Error();
-        const json = (await detailRes.json()) as { data?: Record<string, unknown> };
-        if (!cancelled) setArtifactDetail((json.data ?? null) as typeof artifactDetail);
+        const data = await fetchArtifactCrossProjectDetail(entity_id);
+        if (!cancelled) setArtifactDetail(data as typeof artifactDetail);
       } catch {
         if (!cancelled) setArtifactDetail(null);
       }

--- a/apps/web/src/components/chat/entity-chip.test.tsx
+++ b/apps/web/src/components/chat/entity-chip.test.tsx
@@ -113,6 +113,34 @@ describe('EntityChip ghost — story #3213(미등록≠비존재, "대상이 없
   });
 });
 
+describe('EntityChip — story #3208(PO customer-zero, 카디르 QA #3611 지적) — 클릭→모달의 detail fetch는 아티팩트 자기 project로 스코프된다', () => {
+  it('클릭 시 EntityPreviewModal이 preview로 해소한 project_id를 X-Project-Id로 명시 실어 detail을 조회한다 — «채팅 공유받은 사람이 클릭」한 원 시나리오', async () => {
+    // 까디르 QA(PR#3611) — embed-card.link-states.test.tsx의 X-Project-Id pin은 EmbedCard의
+    // 독립 썸네일 fetch(마운트 시점에 먼저 도착)에 가려 EntityChip 클릭→모달 경로(스토리 원
+    // 사건: 채팅으로 공유받은 사람이 다른 project를 보다가 클릭) 자체는 pin 없이 방치될
+    // 뻔했다 — 이 테스트는 EntityChip 단독(EmbedCard 썸네일 효과가 없는 컴포넌트)이라 그
+    // 혼선이 구조적으로 없다.
+    const calls: { url: string; headers: Record<string, string> }[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      const headers: Record<string, string> = {};
+      new Headers(init?.headers).forEach((v, k) => { headers[k] = v; });
+      calls.push({ url, headers });
+      if (url.includes('/api/visual-artifacts/preview')) {
+        return { ok: true, json: async () => ({ data: { projectId: 'p-owning' } }) };
+      }
+      return { ok: true, json: async () => ({ data: {} }) };
+    }));
+    await act(async () => {
+      root.render(<EntityChip entityType="artifact" entityId="art-cross" label="크로스 목업" href={null} />);
+    });
+    await act(async () => { container.querySelector('button')!.click(); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    const detailCall = calls.find((c) => c.url === '/api/visual-artifacts/art-cross');
+    expect(detailCall).toBeDefined();
+    expect(detailCall!.headers['x-project-id']).toBe('p-owning');
+  });
+});
+
 // story #461e9a54(P0) — 채팅 임베드는 전부 우측 ReadingPanel로(모달 0). ReadingPanelProvider
 // 유무로 갈리는 두 경로를 각각 고정한다.
 describe('EntityChip — story #461e9a54 ReadingPanel 라우팅', () => {

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -864,6 +864,89 @@ describe('proxy — legacy resource redirect generalized to non-docs resources (
   });
 });
 
+describe('proxy — bare /artifacts/{id}는 «현재 project 추측»이 아니라 자기 project로 해소(story #3208, customer-zero)', () => {
+  beforeEach(() => {
+    process.env['JWT_SECRET'] = JWT_SECRET;
+    process.env['NEXT_PUBLIC_FASTAPI_URL'] = 'http://localhost:8000';
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env['JWT_SECRET'];
+  });
+
+  const ARTIFACT_ID = 'a1b2c3d4-e5f6-4789-a0b1-c2d3e4f5a6b7';
+
+  it('현재 project(쿠키)와 아티팩트의 실제 project가 다르면, «현재»가 아니라 아티팩트 자기 project로 301(핵심 처방)', async () => {
+    const token = await makeAccessToken({ orgId: 'org-1' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/me')) {
+        return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+      }
+      if (url.includes(`/api/v2/visual-artifacts/preview?id=${ARTIFACT_ID}`)) {
+        // 아티팩트는 실제로 'sprintable' project 소속 — «현재» 쿠키(zerogo)와 다르다.
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ data: { id: ARTIFACT_ID, project_id: 'proj-sprintable', org_slug: 'moonklabs', project_slug: 'sprintable' } }),
+        });
+      }
+      // 일반 경로(projects/{id} 등)가 불렸다면 그건 폴백 경로를 탄 것 — 이 테스트에선 안 불려야 함.
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    const response = await middleware(makeRequest(`/artifacts/${ARTIFACT_ID}`, {
+      sp_at: token, sprintable_current_project_id: 'proj-zerogo',
+    }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe(`https://app.example.com/moonklabs/sprintable/artifacts/${ARTIFACT_ID}`);
+    // «현재» project(zerogo)를 조회하는 일반 경로(projects/proj-zerogo)는 안 탔어야 한다.
+    expect(mockFetch).not.toHaveBeenCalledWith(expect.stringContaining('/projects/proj-zerogo'), expect.anything());
+  });
+
+  it('아티팩트 preview가 실패(대상 없음·접근권 없음)하면 기존 «현재 project 추측» 경로로 폴백(회귀 0)', async () => {
+    const token = await makeAccessToken({ orgId: 'org-1' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/me')) {
+        return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+      }
+      if (url.includes('/api/v2/visual-artifacts/preview')) {
+        return Promise.resolve({ ok: false, status: 404 });
+      }
+      if (url.includes('/api/v2/organizations/org-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
+      }
+      if (url.includes('/api/v2/projects/proj-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'proj-1', slug: 'sprintable' }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    const response = await middleware(makeRequest(`/artifacts/${ARTIFACT_ID}`, {
+      sp_at: token, sprintable_current_project_id: 'proj-1',
+    }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe(`https://app.example.com/moonklabs/sprintable/artifacts/${ARTIFACT_ID}`);
+  });
+
+  it('id가 UUID 모양이 아니면(목록 페이지 /artifacts 등) preview를 안 부르고 기존 경로 그대로', async () => {
+    const token = await makeAccessToken({ orgId: 'org-1', projectId: 'proj-1' });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/api/v2/me')) {
+        return Promise.resolve({ ok: true, json: async () => ({ org_id: 'org-1' }) });
+      }
+      if (url.includes('/api/v2/organizations/org-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'org-1', slug: 'moonklabs' }) });
+      }
+      if (url.includes('/api/v2/projects/proj-1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'proj-1', slug: 'sprintable' }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    const response = await middleware(makeRequest('/artifacts', { sp_at: token }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/moonklabs/sprintable/artifacts');
+    expect(mockFetch).not.toHaveBeenCalledWith(expect.stringContaining('/visual-artifacts/preview'), expect.anything());
+  });
+});
+
 describe('proxy — 경로 리터럴 rename 301(story 8fc51517): [ws]/[proj]/board/* → [ws]/[proj]/flow/*', () => {
   beforeEach(() => {
     process.env['JWT_SECRET'] = JWT_SECRET;

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -149,6 +149,32 @@ async function getVerifiedOrgId(fastapiUrl: string, accessToken: string): Promis
   }
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// story #3208(PO customer-zero, 2026-08-29) — bare `/artifacts/{id}` 레거시 리다이렉트가
+// 아래 일반 경로(쿠키/JWT로 «현재» projectId를 추측 → 그 project에서 리소스를 찾는 꼴)를
+// 그대로 타면, 아티팩트가 **다른** project 소속일 때 항상 실패한다(아티팩트는 정확히 하나의
+// project에 속하지 «현재 보고 있는» project에 속하는 게 아니다 — doc의 #2168과 동형 클래스).
+// 아티팩트 자신의 실제 project를 `GET /api/v2/visual-artifacts/preview`(BE 신설, org 스코프
+// 조회 + has_project_access 검증)로 직접 물어 해소한다 — 추측 0, 진짜 위치.
+async function resolveArtifactOwnProject(
+  fastapiUrl: string, orgId: string, artifactId: string, accessToken: string,
+): Promise<{ orgSlug: string; projectSlug: string } | null> {
+  try {
+    const res = await fetch(`${fastapiUrl}/api/v2/visual-artifacts/preview?id=${artifactId}`, {
+      headers: { Authorization: `Bearer ${accessToken}`, 'X-Org-Id': orgId },
+    });
+    if (!res.ok) return null;
+    const json = await res.json() as { data?: { org_slug?: string; project_slug?: string | null } };
+    const orgSlug = json.data?.org_slug;
+    const projectSlug = json.data?.project_slug;
+    if (!orgSlug || !projectSlug) return null;
+    return { orgSlug, projectSlug };
+  } catch {
+    return null;
+  }
+}
+
 // story #1998(급, 선생님 실사용 "보드가 404") — access token의 app_metadata.project_id를
 // CURRENT_PROJECT_COOKIE 부재 시 fallback으로 쓴다. 근본원인: 이 쿠키는 onboarding-form.tsx·
 // switch-project·switch-org 명시 액션에서만 SET되고 평범한 로그인(POST /api/auth/login)에서는
@@ -194,13 +220,29 @@ async function redirectLegacyResourcePath(
 
   const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
   const orgId = await getVerifiedOrgId(fastapiUrl, accessToken);
-  // story #1998: 쿠키 우선(명시 switch-project 결과) — 없으면 JWT app_metadata.project_id로 fallback.
-  const projectId = request.cookies.get(CURRENT_PROJECT_COOKIE)?.value
-    ?? await getProjectIdFromAccessToken(accessToken);
   // orgId조차 없으면(토큰 자체가 org_id를 못 실은 예외적 경우) 개입할 근거가 없어 그대로 통과
   // (Next 자체 404) — verifyAccessToken 통과 후 이론상 가능하나 실사용 재현 없음, story #2212
   // 스코프 밖(그 경우엔 org조차 모르니 org-briefing으로도 못 보낸다).
   if (!orgId) return null;
+
+  // story #3208 — artifacts는 «현재 project 추측»이 아니라 «자기 자신이 속한 project»로
+  // 해소한다(doc #2168과 동형). id가 UUID 모양일 때만 시도하고, 실패하면(대상 없음·접근권
+  // 없음·백엔드 오류) 아래 일반 경로로 자연히 폴백한다(회귀 0 — 기존 동작을 대체하는 게
+  // 아니라 artifacts에 한해 우선순위가 더 높은 해소 경로를 추가하는 것).
+  if (resourceName === 'artifacts' && segments[1] && UUID_RE.test(segments[1])) {
+    const ownSlugs = await resolveArtifactOwnProject(fastapiUrl, orgId, segments[1], accessToken);
+    if (ownSlugs) {
+      const rest = pathname.slice(`/${resourceName}`.length);
+      const url = request.nextUrl.clone();
+      url.pathname = `/${ownSlugs.orgSlug}/${ownSlugs.projectSlug}/${resourceName}${rest}`;
+      url.searchParams.delete(RESOLVE_RETRY_PARAM);
+      return NextResponse.redirect(url, 301);
+    }
+  }
+
+  // story #1998: 쿠키 우선(명시 switch-project 결과) — 없으면 JWT app_metadata.project_id로 fallback.
+  const projectId = request.cookies.get(CURRENT_PROJECT_COOKIE)?.value
+    ?? await getProjectIdFromAccessToken(accessToken);
   // story #2212 — 여기서 그냥 null(→ Next 404)을 주던 것이 결함이었다. "프로젝트를 못 정했다"는
   // 사고가 아니라 코드 주석에 그대로 선언된 설계였지만("해소 불가면 null"), 그 선택 자체가
   // dead-end라 처방 대상이다. org는 확定됐으니 org-briefing(프로젝트 불필요 페이지)으로 보내고

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -328,6 +328,55 @@ async def _load_detail(session: AsyncSession, artifact: VisualArtifact, version_
     )
 
 
+@router.get("/preview")
+async def get_artifact_preview(
+    id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    scope: dict = Depends(get_scope_context_no_key_scope_check),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """story #3208 — 아티팩트 직URL/채팅 임베드가 호출자의 «현재» project_id로만
+    스코프된 `GET /{id}`(SEC-S8, project_id 필수 필터)에 의존하다 보니, 다른 프로젝트를
+    보던 중 링크를 열면 대상이 실재해도 project_id 불일치로 404였다(`docs.py::
+    get_doc_preview`와 동형 갭 — #2168이 doc에서 이미 고친 그 문제).
+
+    처방도 doc과 동형: **org 스코프로만** 먼저 찾고, 그 artifact가 실제로 속한
+    project에 대해 `has_project_access`로 **진짜 접근권**을 검증한 뒤에만 위치정보
+    (project_id·org_slug·project_slug)를 내준다 — org 멤버라고 무조건 열어주면
+    SEC-S8이 막은 것과 같은 계열의 IDOR이 되므로, project_id 필터를 없애는 게 아니라
+    "어느 project인지 먼저 알아낸 뒤 그 project 접근권을 확認"으로 순서를 바꾼 것뿐이다
+    (본문은 안 실어 나른다 — 위치만, 실제 상세는 여전히 `GET /{id}`가 그 project_id로
+    스코프해 낸다).
+
+    무권한/미존재는 404로 통일(존재 비노출 규율, doc과 동일 — story #2322/#2342)."""
+    from app.services.entity_slug import resolve_org_slug, resolve_project_slugs
+    from app.services.project_auth import has_project_access
+
+    org_id = scope["org_id"]
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    artifact = (await session.execute(
+        select(VisualArtifact).where(
+            VisualArtifact.id == id, VisualArtifact.org_id == org_id,
+            VisualArtifact.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+    if not await has_project_access(session, uuid.UUID(auth.user_id), artifact.project_id, org_id):
+        return _err("NOT_FOUND", "Artifact not found", 404)
+
+    org_slug = await resolve_org_slug(session, artifact.org_id)
+    project_slug_map = await resolve_project_slugs(session, {artifact.project_id})
+    return _ok({
+        "id": str(artifact.id),
+        "project_id": str(artifact.project_id),
+        "org_slug": org_slug,
+        "project_slug": project_slug_map.get(artifact.project_id),
+    })
+
+
 @router.get("/{id}")
 async def get_artifact(
     id: uuid.UUID,

--- a/backend/tests/test_3208_artifact_preview_cross_project_realdb.py
+++ b/backend/tests/test_3208_artifact_preview_cross_project_realdb.py
@@ -1,0 +1,214 @@
+"""story #3208 — 아티팩트 직URL/채팅 임베드가 «현재» 프로젝트로만 스코프된 GET /{id}
+(SEC-S8, project_id 필수 필터)에 막혀, 다른 프로젝트를 보던 중 링크를 열면 대상이 실재해도
+404였다. `GET /api/v2/visual-artifacts/preview`(신설, `docs.py::get_doc_preview`와 동형)가
+org 스코프로 먼저 찾고 `has_project_access`로 실제 접근권을 검증해 위치정보만 낸다.
+
+realdb 필수 — has_project_access SSOT(team_member∪grant∪owner/admin) 실측 + slug 컬럼 실조회.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(slug 有) + project_a(grant O)·project_b(grant X, slug 有) + artifact_b(project_b)."""
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.visual_artifact import ArtifactVersion, VisualArtifact
+    from sqlalchemy import text
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="A", slug=f"proj-a-{uuid.uuid4().hex[:8]}")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="B", slug=f"proj-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    user_id = uuid.uuid4()
+    await session.execute(text(
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        "login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{user_id}','u-{uuid.uuid4().hex[:8]}@test.local','x','U',true,true,0,false,0)"
+    ))
+    om_id = uuid.uuid4()
+    await session.execute(text(
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{om_id}','{org.id}','{user_id}','member')"
+    ))
+    # user는 project_a에만 grant(project_b는 접근 없음 — cross-project 축).
+    await session.execute(text(
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{project_a.id}','{om_id}','granted')"
+    ))
+    await session.commit()
+
+    creator_id = uuid.uuid4()
+    artifact_b = VisualArtifact(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Artifact B",
+        source="created", latest_version_number=1, created_by=creator_id,
+    )
+    session.add(artifact_b)
+    await session.commit()
+    version_b = ArtifactVersion(id=uuid.uuid4(), artifact_id=artifact_b.id, version_number=1, created_by=creator_id)
+    session.add(version_b)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "org_slug": org.slug,
+        "project_a_id": project_a.id, "project_b_id": project_b.id, "project_b_slug": project_b.slug,
+        "artifact_b_id": artifact_b.id, "user_id": user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id, project_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    # story #2451(§6 Phase3) — get_db만 걸고 get_read_db를 잊는 회귀 방지, 공용 헬퍼 경유.
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_preview_cross_project_returns_real_location_when_access_granted():
+    """근본 재현: user는 «현재» project_a를 보고 있지만 artifact_b(project_b 소속)를 열람할
+    권한은 있다(team_member) — preview가 GET /{id}처럼 project_id 불일치로 막지 않고
+    실제 위치(project_id·org_slug·project_slug)를 내야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        # user에게 project_b에도 team_member 권한을 준다(접근 있음 축).
+        async with Session() as s:
+            from sqlalchemy import text
+            await s.execute(text(
+                f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+                f"SELECT gen_random_uuid(),'{seeded['project_b_id']}',id,'granted' "
+                f"FROM org_members WHERE org_id='{seeded['org_id']}' AND user_id='{seeded['user_id']}'"
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/visual-artifacts/preview", params={"id": str(seeded["artifact_b_id"])},
+            )
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert data["project_id"] == str(seeded["project_b_id"])
+            assert data["org_slug"] == seeded["org_slug"]
+            assert data["project_slug"] == seeded["project_b_slug"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_preview_no_access_to_owning_project_returns_404():
+    """대상은 실재하지만(org 안) 그 project에 접근권이 없으면 여전히 404 — SEC-S8과 동형
+    가드(project_id 필터를 없앤 게 아니라 순서를 바꾼 것뿐임을 확認)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/visual-artifacts/preview", params={"id": str(seeded["artifact_b_id"])},
+            )
+            assert resp.status_code == 404
+            assert resp.json()["error"]["code"] == "NOT_FOUND"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_preview_nonexistent_artifact_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/visual-artifacts/preview", params={"id": str(uuid.uuid4())},
+            )
+            assert resp.status_code == 404
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
[SID:3208]

## 발견 (PO customer-zero, 2026-08-29)
sellerking(admin) 세션·현재 프로젝트=제로고 상태에서 sprintable 프로젝트의 아티팩트
직URL(`/artifacts/{id}`)이 «산출물을 찾을 수 없습니다». `?p={projectId}` 쿼리를
붙여도 동일 — 유나도 동일 증상 언급.

## 근본원인
아티팩트는 정확히 하나의 project에 속하지 "현재 보고 있는" project에 속하는 게
아닌데, 두 경로 다 «현재 project»로만 스코프해 조회한다 — doc의 #2168과 동형 클래스:
1. bare `/artifacts/{id}` 레거시 리다이렉트(`proxy.ts::redirectLegacyResourcePath`)가
   쿠키/JWT로 추측한 projectId로 목적지를 조립(`?p=`는 애초에 이 단계에서 안 읽힘 —
   `project-context-client.ts` SSOT 규칙상 flat 라우트 전용).
2. 채팅 임베드 클릭(`embed-card.tsx`)도 `GET /api/visual-artifacts/{id}`(SEC-S8,
   project_id 필수 필터)를 «현재 탭 project»로 스코프 — 다른 project를 보던 중
   클릭하면 대상이 실재해도 404.

## 처방 (doc #2168과 동형 — 새 메커니즘 발명 0)
- BE: `GET /api/v2/visual-artifacts/preview?id=`(신설, `docs.py::get_doc_preview`와
  동형) — org 스코프로 먼저 찾고 `has_project_access`로 실제 접근권을 검증한 뒤
  위치정보만 낸다. SEC-S8의 project_id 필터는 안 없앤다 — "먼저 project를 알아낸
  뒤 그 project 접근권 확認"으로 순서만 바꿈.
- FE `proxy.ts`: artifacts는 쿠키/JWT 추측 대신 preview로 자기 project를 먼저
  해소, 실패 시 기존 경로로 폴백(회귀 0).
- FE `embed-card.tsx`: detail fetch·썸네일 fetch 둘 다 preview→detail
  (X-Project-Id 명시) 2단 왕복 — `project-context-client.ts`의 기존 escape hatch
  (명시 헤더는 fetch 인터셉터가 안 덮음, switcher cross-org 로드와 동일 패턴) 재사용.

## Test plan
- [x] `test_3208_artifact_preview_cross_project_realdb.py`(신규 3종) — 접근권
      있음/없음/미존재
- [x] `proxy.test.ts`(신규 3종) — 크로스프로젝트 301·preview 실패 폴백·비-UUID
      스킵, 기존 75개 회귀 없음
- [x] `embed-card.link-states.test.tsx`(8개 갱신+신규 X-Project-Id 검증 1개)·
      `embed-card.artifact-form.test.tsx`(1개 갱신) — 관련 스코프 899개 전체 재통과
- [x] `npx tsc --noEmit`·eslint clean
- [x] `scripts/lint_dependency_override_get_read_db.py` 로컬 직접 실행 — 신규 위반 0건