### PR TITLE
[SID:3204] acquisition 계측 — sign_up GA4 전환 이벤트 + 가입 출처 UTM/referrer 영속화

### DIFF
--- a/apps/web/src/app/api/auth/callback/[provider]/route.test.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.test.ts
@@ -340,4 +340,28 @@ describe('GET /api/auth/callback/[provider] — sign_up 전환 신호 + 귀속 �
     expect(body).not.toHaveProperty('signup_utm_source');
     expect(body).not.toHaveProperty('signup_referrer');
   });
+
+  it('카디르 QA(PR#3612) — is_new_user=true(신규 가입)면 귀속 쿠키 4개를 지운다(maxAge=0)', async () => {
+    stubCookies({ sp_attr_src: 'google', sp_attr_ref: 'https://twitter.com/x' });
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => ({ data: { access_token: 'at', refresh_token: 'rt', is_new_user: true } }),
+    });
+    const res = await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+
+    for (const name of ['sp_attr_src', 'sp_attr_medium', 'sp_attr_campaign', 'sp_attr_ref']) {
+      const cookie = res.cookies.get(name);
+      expect(cookie?.value).toBe('');
+      expect(cookie?.maxAge).toBe(0);
+    }
+  });
+
+  it('is_new_user=false(기존 유저 로그인)면 귀속 쿠키를 안 건드린다 — 아직 소비 안 됨', async () => {
+    stubCookies({ sp_attr_src: 'google' });
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => ({ data: { access_token: 'at', refresh_token: 'rt', is_new_user: false } }),
+    });
+    const res = await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+
+    expect(res.cookies.get('sp_attr_src')).toBeUndefined();
+  });
 });

--- a/apps/web/src/app/api/auth/callback/[provider]/route.test.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.test.ts
@@ -274,3 +274,70 @@ describe('GET /api/auth/callback/[provider] — state 검증 분기 로그(2026-
     expect(allLoggedText).not.toContain(secretStored);
   });
 });
+
+// story #3204(acquisition 계측) — sign_up 전환 이벤트 발화 신호(?signup=1)+first-touch
+// 귀속 쿠키 relay. register/page.tsx(email 경로)와 동일 파라미터로 발화 지점을 하나로
+// 모으는 SSOT 계약의 OAuth 쪽 절반.
+describe('GET /api/auth/callback/[provider] — sign_up 전환 신호 + 귀속 쿠키 relay(story #3204)', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    h.cookiesGetMock.mockReset();
+    h.cookiesDeleteMock.mockReset();
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  function stubCookies(overrides: Record<string, string> = {}) {
+    const defaults: Record<string, string> = { oauth_state_google: 'matching-state', ...overrides };
+    h.cookiesGetMock.mockImplementation((name: string) =>
+      name in defaults ? { value: defaults[name] } : undefined,
+    );
+  }
+
+  it('is_new_user=true — 목적지 URL에 ?signup=1이 붙는다', async () => {
+    stubCookies();
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => ({ data: { access_token: 'at', refresh_token: 'rt', is_new_user: true } }),
+    });
+    const res = await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+    expect(res.headers.get('location')).toBe('http://localhost:3108/chats?signup=1');
+  });
+
+  it('is_new_user=false(기존 유저 로그인) — signup 파라미터가 안 붙는다(재로그인마다 중복 발화 금지)', async () => {
+    stubCookies();
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => ({ data: { access_token: 'at', refresh_token: 'rt', is_new_user: false } }),
+    });
+    const res = await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+    expect(res.headers.get('location')).toBe('http://localhost:3108/chats');
+  });
+
+  it('first-touch 귀속 쿠키가 있으면 BE oauth/callback 요청 바디에 그대로 실려 간다', async () => {
+    stubCookies({
+      sp_attr_src: 'google', sp_attr_medium: 'cpc', sp_attr_campaign: 'launch', sp_attr_ref: 'https://twitter.com/x',
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => ({ data: { access_token: 'at', refresh_token: 'rt', is_new_user: true } }),
+    });
+    await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+
+    const call = mockFetch.mock.calls.find((c) => String(c[0]).includes('/api/v2/auth/oauth/callback'));
+    const body = JSON.parse((call?.[1] as { body: string }).body);
+    expect(body).toMatchObject({
+      signup_utm_source: 'google', signup_utm_medium: 'cpc',
+      signup_utm_campaign: 'launch', signup_referrer: 'https://twitter.com/x',
+    });
+  });
+
+  it('귀속 쿠키가 없으면 요청 바디에 그 필드들 자체가 없다(빈 문자열을 지어내지 않음)', async () => {
+    stubCookies();
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => ({ data: { access_token: 'at', refresh_token: 'rt', is_new_user: true } }),
+    });
+    await GET(makeRequest({ code: 'c', state: 'matching-state' }), routeParams());
+
+    const call = mockFetch.mock.calls.find((c) => String(c[0]).includes('/api/v2/auth/oauth/callback'));
+    const body = JSON.parse((call?.[1] as { body: string }).body);
+    expect(body).not.toHaveProperty('signup_utm_source');
+    expect(body).not.toHaveProperty('signup_referrer');
+  });
+});

--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
-import { SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
+import { SIGNUP_ATTRIBUTION_COOKIE_NAMES, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 import { safeNextPath } from '@/lib/auth/session-redirect';
 import { resolveAppUrl } from '@/services/app-url';
 import { isOAuthCallbackMode, expectedReturnUri } from '@/lib/auth/oauth-callback-mode';
@@ -221,6 +221,15 @@ async function handleCallback(request: Request, provider: string, code: string |
   const res = NextResponse.redirect(destination);
   res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
+  // 카디르 QA(PR#3612) — register route.ts와 동일 이유. is_new_user일 때만(신규 계정이
+  // 실제로 이 귀속을 소비했을 때만) 지운다 — 기존 유저 로그인은 애초에 이 값을 안 썼으니
+  // 지울 이유가 없다(다음 진짜 첫 방문 신호를 위해 남겨 둔다는 의미는 아니고, 그냥 소비
+  // 안 한 값을 건드릴 이유가 없다는 뜻 — 어느 쪽이든 이후 실제 가입 시점에 갱신/소비됨).
+  if (isNewUser) {
+    for (const name of SIGNUP_ATTRIBUTION_COOKIE_NAMES) {
+      res.cookies.set(name, '', { ...cookieBase(), maxAge: 0 });
+    }
+  }
   return res;
 }
 

--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -133,11 +133,24 @@ async function handleCallback(request: Request, provider: string, code: string |
     return NextResponse.redirect(`${origin}/settings?linked=${provider}`);
   }
 
+  // story #3204 — proxy.ts가 랜딩 시점에 심어둔 first-touch 귀속 쿠키를 그대로 BE로 relay
+  // (register route.ts와 동일 계약). 신규 유저 생성 분기에서만 BE가 실제로 사용한다.
+  const utmSource = cookieStore.get('sp_attr_src')?.value;
+  const utmMedium = cookieStore.get('sp_attr_medium')?.value;
+  const utmCampaign = cookieStore.get('sp_attr_campaign')?.value;
+  const attrReferrer = cookieStore.get('sp_attr_ref')?.value;
+
   // FastAPI OAuth callback
   const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/oauth/callback`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ provider, code, state, tos_accepted: tosAccepted, invite_token: inviteToken }),
+    body: JSON.stringify({
+      provider, code, state, tos_accepted: tosAccepted, invite_token: inviteToken,
+      ...(utmSource ? { signup_utm_source: utmSource } : {}),
+      ...(utmMedium ? { signup_utm_medium: utmMedium } : {}),
+      ...(utmCampaign ? { signup_utm_campaign: utmCampaign } : {}),
+      ...(attrReferrer ? { signup_referrer: attrReferrer } : {}),
+    }),
   }).catch(() => null);
 
   if (!fastapiRes?.ok) {
@@ -146,8 +159,8 @@ async function handleCallback(request: Request, provider: string, code: string |
     return NextResponse.redirect(`${origin}/login?error=${errCode}`);
   }
 
-  const json = await fastapiRes.json() as { data?: { access_token: string; refresh_token: string } };
-  const { access_token, refresh_token } = json.data ?? {};
+  const json = await fastapiRes.json() as { data?: { access_token: string; refresh_token: string; is_new_user?: boolean } };
+  const { access_token, refresh_token, is_new_user: isNewUser } = json.data ?? {};
 
   if (!access_token || !refresh_token) {
     return NextResponse.redirect(`${origin}/login?error=oauth_no_token`);
@@ -197,7 +210,14 @@ async function handleCallback(request: Request, provider: string, code: string |
 
   // AC3: 세션 만료로 OAuth 재로그인한 경우 작업 경로 복귀(safeNextPath 가드)·없으면 홈(chat).
   // story #3179(S3c) 후속(추가 실측 발견) — /dashboard 폐합, 홈=chat 재조준.
-  const destination = inviteToken ? `${origin}/chats` : `${origin}${safeNextPath(nextCookie)}`;
+  const destinationUrl = new URL(
+    inviteToken ? `${origin}/chats` : `${origin}${safeNextPath(nextCookie)}`,
+  );
+  // story #3204 — register/page.tsx(email 경로)와 동일 파라미터로 발화 지점을 하나로
+  // 모은다(google-analytics.tsx route-change effect가 소비). is_new_user=false(로그인)면
+  // 안 붙인다 — 재로그인마다 가입 이벤트가 중복 잡히면 안 됨.
+  if (isNewUser) destinationUrl.searchParams.set('signup', '1');
+  const destination = destinationUrl.toString();
   const res = NextResponse.redirect(destination);
   res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });

--- a/apps/web/src/app/api/auth/register/route.test.ts
+++ b/apps/web/src/app/api/auth/register/route.test.ts
@@ -1,0 +1,76 @@
+// story #3204(acquisition 계측) — POST /api/auth/register가 proxy.ts의 first-touch
+// 귀속 쿠키를 BE로 relay하고, 가입 성공 後 그 쿠키를 지우는지(카디르 QA, PR#3612 — 안
+// 지우면 같은 브라우저 재가입 시 前 계정 귀속이 새 계정에 오염) 고정.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ cookiesGetMock: vi.fn() }));
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({ get: h.cookiesGetMock })),
+}));
+vi.mock('@/lib/db/server', () => ({ SP_AT_COOKIE: 'sp_at', SP_RT_COOKIE: 'sp_rt' }));
+vi.mock('@/lib/auth/csrf', () => ({ verifyCsrfOrigin: () => null }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { POST } from './route';
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/auth/register — first-touch 귀속 relay + 소비(story #3204)', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    h.cookiesGetMock.mockReset();
+  });
+  afterEach(() => { vi.unstubAllEnvs(); });
+
+  function stubAttrCookies(overrides: Record<string, string> = {}) {
+    h.cookiesGetMock.mockImplementation((name: string) =>
+      name in overrides ? { value: overrides[name] } : undefined,
+    );
+  }
+
+  it('귀속 쿠키가 있으면 BE 요청 바디에 그대로 실려 간다', async () => {
+    stubAttrCookies({ sp_attr_src: 'google', sp_attr_medium: 'cpc' });
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => ({ data: { access_token: 'at', refresh_token: 'rt' } }),
+    });
+    await POST(makeRequest({ email: 'a@b.com', password: 'Abc123!!', display_name: 'A', tos_accepted: true }));
+
+    const body = JSON.parse((mockFetch.mock.calls[0]?.[1] as { body: string }).body);
+    expect(body.signup_utm_source).toBe('google');
+    expect(body.signup_utm_medium).toBe('cpc');
+  });
+
+  it('가입 성공(201) 응답에서 귀속 쿠키 4개를 전부 지운다(maxAge=0)', async () => {
+    stubAttrCookies({ sp_attr_src: 'google', sp_attr_ref: 'https://twitter.com/x' });
+    mockFetch.mockResolvedValueOnce({
+      ok: true, json: async () => ({ data: { access_token: 'at', refresh_token: 'rt' } }),
+    });
+    const res = await POST(makeRequest({ email: 'a@b.com', password: 'Abc123!!', display_name: 'A', tos_accepted: true }));
+
+    expect(res.status).toBe(201);
+    for (const name of ['sp_attr_src', 'sp_attr_medium', 'sp_attr_campaign', 'sp_attr_ref']) {
+      const cookie = res.cookies.get(name);
+      expect(cookie?.value).toBe('');
+      expect(cookie?.maxAge).toBe(0);
+    }
+  });
+
+  it('가입 실패면 귀속 쿠키를 지우지 않는다(아직 소비된 게 아님 — 재시도 때 다시 쓴다)', async () => {
+    stubAttrCookies({ sp_attr_src: 'google' });
+    mockFetch.mockResolvedValueOnce({
+      ok: false, status: 409, json: async () => ({ error: { code: 'EMAIL_TAKEN', message: 'x' } }),
+    });
+    const res = await POST(makeRequest({ email: 'a@b.com', password: 'Abc123!!', display_name: 'A', tos_accepted: true }));
+
+    expect(res.status).toBe(409);
+    expect(res.cookies.get('sp_attr_src')).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
+import { cookieBase, SIGNUP_ATTRIBUTION_COOKIE_NAMES, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -45,5 +45,11 @@ export async function POST(request: Request) {
   const res = NextResponse.json({ data: { ok: true } }, { status: 201 });
   res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
+  // 카디르 QA(PR#3612) — register()는 항상 신규 계정 생성이라(200/201 = 가입 성공,
+  // 재로그인 개념이 없음) 여기 도달하면 예외 없이 소비된 것. 안 지우면 같은 브라우저에서
+  // 재가입(로그아웃 후 다른 이메일 등) 시 이 계정의 옛 귀속이 새 계정에 오염된다.
+  for (const name of SIGNUP_ATTRIBUTION_COOKIE_NAMES) {
+    res.cookies.set(name, '', { ...cookieBase(), maxAge: 0 });
+  }
   return res;
 }

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
 import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
@@ -12,6 +13,13 @@ export async function POST(request: Request) {
 
   const body = await request.json() as { email: string; password: string; display_name?: string; tos_accepted?: boolean; invite_token?: string };
 
+  // story #3204 — proxy.ts가 랜딩 시점에 심어둔 first-touch 귀속 쿠키를 그대로 BE로 relay.
+  const cookieStore = await cookies();
+  const utmSource = cookieStore.get('sp_attr_src')?.value;
+  const utmMedium = cookieStore.get('sp_attr_medium')?.value;
+  const utmCampaign = cookieStore.get('sp_attr_campaign')?.value;
+  const referrer = cookieStore.get('sp_attr_ref')?.value;
+
   const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -21,6 +29,10 @@ export async function POST(request: Request) {
       display_name: body.display_name ?? body.email.split('@')[0],
       tos_accepted: body.tos_accepted ?? false,
       ...(body.invite_token ? { invite_token: body.invite_token } : {}),
+      ...(utmSource ? { signup_utm_source: utmSource } : {}),
+      ...(utmMedium ? { signup_utm_medium: utmMedium } : {}),
+      ...(utmCampaign ? { signup_utm_campaign: utmCampaign } : {}),
+      ...(referrer ? { signup_referrer: referrer } : {}),
     }),
   });
 

--- a/apps/web/src/app/register/page.test.tsx
+++ b/apps/web/src/app/register/page.test.tsx
@@ -13,8 +13,9 @@ import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import enMessages from '../../../messages/en.json';
 
+const { pushMock, refreshMock } = vi.hoisted(() => ({ pushMock: vi.fn(), refreshMock: vi.fn() }));
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
 }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -144,5 +145,54 @@ describe('RegisterPage — error.code 분기 (story #2484)', () => {
     const alertEl = container.querySelector('[role="alert"]');
     expect(alertEl?.textContent).not.toContain('brand new raw string');
     expect(alertEl?.textContent).toBe(koMessages.register.registrationFailed);
+  });
+});
+
+// story #3204(acquisition 계측) — 가입 완료 시 목적지 URL에 sign_up 이벤트 발화 신호
+// (?signup=1)를 붙인다. OAuth 경로(api/auth/callback/[provider]/route.ts)와 동일
+// 파라미터로 통일해 google-analytics.tsx 한 곳에서만 발화하는 SSOT 계약.
+describe('RegisterPage — sign_up 이벤트 발화 신호(story #3204)', () => {
+  afterEach(() => { vi.unstubAllGlobals(); pushMock.mockClear(); });
+
+  async function fillAndSubmit() {
+    const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement;
+    const pwInput = container.querySelector('input[type="password"]') as HTMLInputElement;
+    const tosCheckbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await act(async () => {
+      setNativeValue(nameInput, 'Test User');
+      setNativeValue(emailInput, 'a@b.com');
+      setNativeValue(pwInput, 'Abc123!!');
+      tosCheckbox.click();
+    });
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.register.submit);
+    await act(async () => {
+      submitBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('가입 성공 → org_id 있으면 /inbox?signup=1로 이동', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/auth/register') return { ok: true, json: async () => ({ data: { ok: true } }) };
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: { org_id: 'org-1' } }) };
+      return { ok: false, json: async () => ({}) };
+    }));
+    await mount('ko');
+    await fillAndSubmit();
+    expect(pushMock).toHaveBeenCalledWith('/inbox?signup=1');
+  });
+
+  it('가입 성공 → org_id 없으면 /onboarding?signup=1로 이동', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/auth/register') return { ok: true, json: async () => ({ data: { ok: true } }) };
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: {} }) };
+      return { ok: false, json: async () => ({}) };
+    }));
+    await mount('ko');
+    await fillAndSubmit();
+    expect(pushMock).toHaveBeenCalledWith('/onboarding?signup=1');
   });
 });

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -66,7 +66,11 @@ export default function RegisterPage() {
       }
       const meRes = await fetch('/api/me');
       const meJson = await meRes.json() as { data?: { org_id?: string } };
-      router.push(meJson.data?.org_id ? '/inbox' : '/onboarding');
+      // story #3204 — sign_up 전환 이벤트 발화 신호(google-analytics.tsx의 route-change
+      // effect가 소비). OAuth 경로(api/auth/callback/[provider]/route.ts)와 동일 파라미터로
+      // 통일해 발화 지점을 하나로 모은다(SSOT).
+      const destination = meJson.data?.org_id ? '/inbox' : '/onboarding';
+      router.push(`${destination}?signup=1`);
       router.refresh();
     } catch {
       setError(t('registrationFailed'));

--- a/apps/web/src/components/google-analytics.test.tsx
+++ b/apps/web/src/components/google-analytics.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+//
+// story #3204(acquisition 계측) — sign_up 전환 이벤트 발화 SSOT. 가입 경로 2개(email/pw는
+// register/page.tsx, OAuth는 서버 리다이렉트)가 둘 다 같은 `?signup=1` 파라미터로 수렴하고,
+// 여기 한 곳에서만 gtag('event','sign_up')을 쏜다(billing-tab.tsx의 Toss checkout 성공
+// 쿼리파라미터 소비 패턴과 동형). 처리 直後 파라미터를 제거해 새로고침 시 재발화되지 않는지도 고정.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const { pushMock, replaceMock, usePathnameMock, useSearchParamsMock } = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  replaceMock: vi.fn(),
+  usePathnameMock: vi.fn(),
+  useSearchParamsMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: usePathnameMock,
+  useSearchParams: useSearchParamsMock,
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+}));
+
+vi.mock('next/script', () => ({
+  default: () => null,
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.resetModules(); // GA_ID는 모듈 최상단 const라 env를 바꾼 뒤엔 재-import가 필요.
+  process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID = 'G-TEST123';
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  (window as unknown as { gtag: (...args: unknown[]) => void }).gtag = vi.fn();
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.clearAllMocks();
+  delete (window as { gtag?: unknown }).gtag;
+  delete process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;
+});
+
+async function mount() {
+  const { GoogleAnalytics } = await import('./google-analytics');
+  await act(async () => { root.render(<GoogleAnalytics />); });
+}
+
+describe('GoogleAnalytics — sign_up 전환 이벤트(story #3204)', () => {
+  it('?signup=1이 있으면 gtag(event, sign_up)을 발화하고 파라미터를 제거한다', async () => {
+    usePathnameMock.mockReturnValue('/onboarding');
+    useSearchParamsMock.mockReturnValue(new URLSearchParams('signup=1'));
+    await mount();
+
+    const gtag = window.gtag as ReturnType<typeof vi.fn>;
+    expect(gtag).toHaveBeenCalledWith('event', 'sign_up');
+    expect(replaceMock).toHaveBeenCalledWith('/onboarding');
+  });
+
+  it('다른 쿼리파라미터가 같이 있으면 signup만 지우고 나머지는 보존한다', async () => {
+    usePathnameMock.mockReturnValue('/inbox');
+    useSearchParamsMock.mockReturnValue(new URLSearchParams('signup=1&from=proj-1'));
+    await mount();
+
+    expect(replaceMock).toHaveBeenCalledWith('/inbox?from=proj-1');
+  });
+
+  it('signup 파라미터가 없으면 sign_up 이벤트를 발화하지 않는다', async () => {
+    usePathnameMock.mockReturnValue('/inbox');
+    useSearchParamsMock.mockReturnValue(new URLSearchParams(''));
+    await mount();
+
+    const gtag = window.gtag as ReturnType<typeof vi.fn>;
+    const signUpCalls = gtag.mock.calls.filter((c) => c[0] === 'event' && c[1] === 'sign_up');
+    expect(signUpCalls.length).toBe(0);
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('GA_ID 미설정(dev 음성대조)이면 signup=1이 있어도 이벤트를 발화하지 않는다', async () => {
+    delete process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;
+    usePathnameMock.mockReturnValue('/onboarding');
+    useSearchParamsMock.mockReturnValue(new URLSearchParams('signup=1'));
+    await mount();
+
+    const gtag = window.gtag as ReturnType<typeof vi.fn>;
+    expect(gtag).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/google-analytics.tsx
+++ b/apps/web/src/components/google-analytics.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Script from 'next/script';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, Suspense } from 'react';
 
 const GA_ID = process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;
@@ -16,12 +16,29 @@ declare global {
 function GoogleAnalyticsInner() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const router = useRouter();
 
   useEffect(() => {
     if (!GA_ID || typeof window === 'undefined' || !window.gtag) return;
     const url = pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : '');
     window.gtag('config', GA_ID, { page_path: url });
   }, [pathname, searchParams]);
+
+  // story #3204 — 전환 이벤트 발화 SSOT. 가입 경로 2개(email/pw는 register/page.tsx,
+  // OAuth는 api/auth/callback/[provider]/route.ts 서버 리다이렉트라 클라 JS 컨텍스트가
+  // 없음) 둘 다 목적지 URL에 같은 `?signup=1`을 붙이고, 여기 한 곳에서만 발화한다
+  // (billing-tab.tsx의 Toss checkout 성공 쿼리파라미터 소비 패턴과 동형 — 처리 直後
+  // router.replace로 파라미터를 제거해 새로고침 시 재발화되지 않게 한다).
+  useEffect(() => {
+    if (!GA_ID || typeof window === 'undefined' || !window.gtag) return;
+    if (searchParams?.get('signup') !== '1') return;
+    window.gtag('event', 'sign_up');
+    const next = new URLSearchParams(searchParams);
+    next.delete('signup');
+    const query = next.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
 
   if (!GA_ID) return null;
 

--- a/apps/web/src/lib/auth/cookies.ts
+++ b/apps/web/src/lib/auth/cookies.ts
@@ -14,6 +14,15 @@ function isSecureScheme(): boolean {
   return appUrl.startsWith('https://');
 }
 
+/** story #3204 — 가입 출처 first-touch 쿠키 이름(proxy.ts가 세팅·register/oauth 콜백
+ * route.ts가 읽고 BE로 relay). 카디르 QA(PR#3612) — 가입 성공 직후 반드시 지워야 한다
+ * (안 지우면 같은 브라우저에서 재가입 시 前 계정의 옛 귀속이 새 계정에 오염된다). 이름을
+ * 한 곳에 두어 세팅(proxy.ts)·소비+삭제(register/oauth route.ts) 세 자리가 드리프트하지
+ * 않게 한다. */
+export const SIGNUP_ATTRIBUTION_COOKIE_NAMES = [
+  'sp_attr_src', 'sp_attr_medium', 'sp_attr_campaign', 'sp_attr_ref',
+] as const;
+
 export function cookieBase(): {
   httpOnly: boolean;
   secure: boolean;

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1004,3 +1004,46 @@ describe('proxy — story #2595 connect-guide locale rewrite', () => {
     }
   });
 });
+
+// story #3204(acquisition 계측) — 가입 출처 first-touch 캡처. public path에서만 도는
+// 독립 분기(기존 인증/세션 흐름과 무관) — makeRequest에 headers 옵션이 없어 이 describe
+// 안에서만 쓰는 로컬 헬퍼로 referer 헤더를 얹는다.
+function makeRequestWithReferer(path: string, referer: string, cookies: Record<string, string> = {}): NextRequest {
+  const req = new NextRequest(`https://app.example.com${path}`, { headers: { referer } });
+  for (const [name, value] of Object.entries(cookies)) {
+    req.cookies.set(name, value);
+  }
+  return req;
+}
+
+describe('proxy — 가입 출처 first-touch 캡처(story #3204)', () => {
+  it('utm_source/medium/campaign 쿼리가 있으면 각각 쿠키로 저장한다', async () => {
+    const response = await middleware(makeRequest('/?utm_source=google&utm_medium=cpc&utm_campaign=launch'));
+    expect(response.cookies.get('sp_attr_src')?.value).toBe('google');
+    expect(response.cookies.get('sp_attr_medium')?.value).toBe('cpc');
+    expect(response.cookies.get('sp_attr_campaign')?.value).toBe('launch');
+  });
+
+  it('외부 referer는 저장하지만 동일 출처 referer는 저장하지 않는다', async () => {
+    const external = await middleware(makeRequestWithReferer('/', 'https://twitter.com/some/post'));
+    expect(external.cookies.get('sp_attr_ref')?.value).toBe('https://twitter.com/some/post');
+
+    const internal = await middleware(makeRequestWithReferer('/register', 'https://app.example.com/login'));
+    expect(internal.cookies.get('sp_attr_ref')?.value).toBeUndefined();
+  });
+
+  it('utm도 referer도 없으면(direct) 쿠키를 남기지 않는다', async () => {
+    const response = await middleware(makeRequest('/'));
+    expect(response.cookies.get('sp_attr_src')?.value).toBeUndefined();
+    expect(response.cookies.get('sp_attr_ref')?.value).toBeUndefined();
+  });
+
+  it('first-touch — 이미 귀속 쿠키가 있으면 재방문 시 새 utm으로 덮어쓰지 않는다', async () => {
+    const response = await middleware(
+      makeRequest('/?utm_source=facebook&utm_medium=social', { sp_attr_src: 'google' }),
+    );
+    // 응답에 이 쿠키를 새로 set하지 않았어야 한다(요청에 이미 있던 값이 그대로 유지 —
+    // set-cookie 자체가 없으므로 get()이 undefined).
+    expect(response.cookies.get('sp_attr_medium')?.value).toBeUndefined();
+  });
+});

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -569,6 +569,48 @@ async function resolveAndRespond(
   return response;
 }
 
+// story #3204(acquisition 계측) — 가입 출처 first-touch 캡처. 기존 oauth_state_*/
+// oauth_tos_* 등과 동형 관례(별개 단순 쿠키 4개, JSON blob 발명 없음). 30일(=sp_rt와
+// 동일 윈도우) — 그 안에 가입하면 register()/oauth_callback()이 이 값을 users 컬럼에
+// 1회 옮겨 담는다. **first-touch**: 이미 하나라도 세팅돼 있으면 재방문에 덮어쓰지
+// 않는다(첫 유입 채널만 귀속). httpOnly(FE JS가 아니라 register/oauth 콜백 route.ts만
+// 읽는다) — 클라 조작 표면을 줄인다.
+const SIGNUP_ATTRIBUTION_COOKIES = {
+  source: 'sp_attr_src', medium: 'sp_attr_medium', campaign: 'sp_attr_campaign', referrer: 'sp_attr_ref',
+} as const;
+const SIGNUP_ATTRIBUTION_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+
+function captureSignupAttribution(request: NextRequest, response: NextResponse): void {
+  const alreadyCaptured = Object.values(SIGNUP_ATTRIBUTION_COOKIES).some(
+    (name) => request.cookies.get(name)?.value,
+  );
+  if (alreadyCaptured) return; // first-touch만 — 재방문 덮어쓰기 안 함.
+
+  const params = request.nextUrl.searchParams;
+  const utmSource = params.get('utm_source');
+  const utmMedium = params.get('utm_medium');
+  const utmCampaign = params.get('utm_campaign');
+
+  // 동일 출처 내부 이동은 "출처"가 아니다(예: 로그인→가입 링크 클릭) — 외부 referer만.
+  let externalReferrer: string | null = null;
+  const referer = request.headers.get('referer');
+  if (referer) {
+    try {
+      externalReferrer = new URL(referer).origin === request.nextUrl.origin ? null : referer;
+    } catch {
+      externalReferrer = null;
+    }
+  }
+
+  if (!utmSource && !utmMedium && !utmCampaign && !externalReferrer) return; // 신호 없음(direct) — 쿠키 안 남김.
+
+  const base = { ...cookieBase(), maxAge: SIGNUP_ATTRIBUTION_MAX_AGE_SECONDS };
+  if (utmSource) response.cookies.set(SIGNUP_ATTRIBUTION_COOKIES.source, utmSource, base);
+  if (utmMedium) response.cookies.set(SIGNUP_ATTRIBUTION_COOKIES.medium, utmMedium, base);
+  if (utmCampaign) response.cookies.set(SIGNUP_ATTRIBUTION_COOKIES.campaign, utmCampaign, base);
+  if (externalReferrer) response.cookies.set(SIGNUP_ATTRIBUTION_COOKIES.referrer, externalReferrer, base);
+}
+
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
@@ -588,7 +630,9 @@ export async function proxy(request: NextRequest) {
     PUBLIC_PREFIX.some((prefix) => pathname.startsWith(prefix));
 
   if (isPublicPath) {
-    return NextResponse.next({ request });
+    const response = NextResponse.next({ request });
+    captureSignupAttribution(request, response);
+    return response;
   }
 
   // Authenticated API routes — try token refresh but never redirect to /login

--- a/backend/alembic/versions/0292_users_signup_attribution.py
+++ b/backend/alembic/versions/0292_users_signup_attribution.py
@@ -1,0 +1,35 @@
+"""story #3204(acquisition 계측) — users에 가입 출처 귀속 컬럼 4종 신설.
+
+proxy.ts의 first-touch 쿠키(첫 랜딩의 utm_source/medium/campaign·referrer, 재방문
+덮어쓰기 안 함)를 register()/oauth_callback() 신규 유저 생성 시점에 1회 포착한다
+(locale 컬럼과 동형 패턴). 전부 nullable — 기존 행/캠페인 링크 없는 direct 가입은
+NULL로 남는다(소급 채움 없음).
+
+Revision ID: 0292
+Revises: 0291
+Create Date: 2026-08-29
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0292"
+down_revision = "0291"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("signup_utm_source", sa.Text(), nullable=True))
+    op.add_column("users", sa.Column("signup_utm_medium", sa.Text(), nullable=True))
+    op.add_column("users", sa.Column("signup_utm_campaign", sa.Text(), nullable=True))
+    op.add_column("users", sa.Column("signup_referrer", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "signup_referrer")
+    op.drop_column("users", "signup_utm_campaign")
+    op.drop_column("users", "signup_utm_medium")
+    op.drop_column("users", "signup_utm_source")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -30,6 +30,15 @@ class User(Base):
     # 발송 전용 신호. nullable, 가입 시 Accept-Language로 1회 포착. None이면
     # resolve_locale()이 DEFAULT_LOCALE("ko")로 폴백한다(추측 백필 없음).
     locale: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #3204(acquisition 계측) — 가입 시점 1회 포착(locale과 동형 패턴, 재작성 없음).
+    # proxy.ts의 first-touch 쿠키(첫 랜딩의 utm_*/referrer, 재방문 덮어쓰기 안 함)를
+    # register()/oauth_callback() 신규 유저 생성 시점에 그대로 옮겨 담는다. 코호트별
+    # 채널 분석이 목적이라 반복 이벤트가 아닌 1회성 불변 속성 — event meta가 아니라
+    # 이 테이블의 직접 컬럼으로 둔다(PO 확定, doc story #3204).
+    signup_utm_source: Mapped[str | None] = mapped_column(Text, nullable=True)
+    signup_utm_medium: Mapped[str | None] = mapped_column(Text, nullable=True)
+    signup_utm_campaign: Mapped[str | None] = mapped_column(Text, nullable=True)
+    signup_referrer: Mapped[str | None] = mapped_column(Text, nullable=True)
     google_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
     # story #2155(2026-07-23): GitHub 로그인 자체를 제거했다(app/routers/auth.py — provider
     # dispatch에서 "github" 삭제). 이 컬럼은 로그인 외 용도가 0곳(PO grep 확認 — 커밋 귀속·

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -117,6 +117,12 @@ class RegisterRequest(BaseModel):
     display_name: str  # AC3: 필수
     tos_accepted: bool = False
     invite_token: str | None = None  # AC2: 초대 토큰 (가입 후 자동 수락)
+    # story #3204(acquisition 계측) — proxy.ts의 first-touch 쿠키를 FE route.ts가 그대로
+    # 실어 보낸다(신뢰 경계 밖 값, 자유 텍스트로만 취급 — 인가/조회 키로 안 씀).
+    signup_utm_source: str | None = None
+    signup_utm_medium: str | None = None
+    signup_utm_campaign: str | None = None
+    signup_referrer: str | None = None
 
     @field_validator("email")
     @classmethod
@@ -580,6 +586,11 @@ async def register(
         # 동일 헬퍼 재사용, 새 파서 발명 없음). FE 명시 전달값은 없음(가입 폼에 locale
         # 필드가 없다) — 브라우저가 항상 보내는 헤더뿐이라 FE 변경 불요.
         locale=resolve_locale_from_request(None, request.headers.get("accept-language")),
+        # story #3204 — 1회 포착(locale과 동형), 소급 없음.
+        signup_utm_source=body.signup_utm_source,
+        signup_utm_medium=body.signup_utm_medium,
+        signup_utm_campaign=body.signup_utm_campaign,
+        signup_referrer=body.signup_referrer,
     )
     session.add(user)
     try:
@@ -1170,6 +1181,12 @@ class OAuthCallbackRequest(BaseModel):
     state: str
     tos_accepted: bool = False
     invite_token: str | None = None  # AC4: OAuth 가입 시 초대 자동 수락
+    # story #3204 — register()와 동일 계약(신뢰 경계 밖 자유 텍스트, 신규 유저 생성
+    # 분기에서만 사용 — 기존 유저 매칭/링크 분기는 무시한다, 재가입이 아니므로).
+    signup_utm_source: str | None = None
+    signup_utm_medium: str | None = None
+    signup_utm_campaign: str | None = None
+    signup_referrer: str | None = None
 
 
 @router.get("/oauth/{provider}/authorize")
@@ -1232,6 +1249,10 @@ async def oauth_callback(
     id_col = getattr(User, f"{provider}_id")
     result = await session.execute(select(User).where(id_col == oauth_id, User.is_active.is_(True)))
     user = result.scalar_one_or_none()
+    # story #3204 — sign_up 전환 이벤트 발화 신호. "신규 유저 생성" 분기(아래)에서만
+    # true — 기존 유저를 provider_id/email로 찾아 링크만 한 경우는 로그인이지 가입이
+    # 아니다(재가입 아님).
+    is_new_user = False
 
     if not user:
         # story #3118(PO 확定 2026-08-26, private relay 이메일 특성) — Apple은 이메일 자동
@@ -1263,6 +1284,11 @@ async def oauth_callback(
                 tos_accepted_at=datetime.now(timezone.utc),
                 # story #3205 — register()와 동일 포착(발명 0).
                 locale=resolve_locale_from_request(None, request.headers.get("accept-language")),
+                # story #3204 — register()와 동일 포착(발명 0).
+                signup_utm_source=body.signup_utm_source,
+                signup_utm_medium=body.signup_utm_medium,
+                signup_utm_campaign=body.signup_utm_campaign,
+                signup_referrer=body.signup_referrer,
                 **{f"{provider}_id": oauth_id},
             )
             session.add(user)
@@ -1271,6 +1297,7 @@ async def oauth_callback(
             except IntegrityError:
                 await session.rollback()
                 return _err("EMAIL_CONFLICT", "Email already registered", 409)
+            is_new_user = True
 
             # AC4: invite_token 있으면 신규 OAuth 유저도 자동 수락
             if body.invite_token:
@@ -1296,6 +1323,10 @@ async def oauth_callback(
         "refresh_token": raw_refresh,
         "token_type": "bearer",
         "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        # story #3204 — FE route.ts가 이 값으로 목적지 URL에 sign_up 이벤트 발화 신호를
+        # 붙인다(?signup=1). 본인 인증 응답 안이라 계정 존재 여부를 타인에게 누출하지
+        # 않는다(PO 확認 2026-08-29).
+        "is_new_user": is_new_user,
     })
 
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -100,6 +100,23 @@ def _err(code: str, message: str, status_code: int = 400) -> JSONResponse:
 
 # ─── Schemas ──────────────────────────────────────────────────────────────────
 
+# story #3204(카디르 QA, PR#3612) — UTM/referrer는 유저(브라우저)가 URL 쿼리로 완전히
+# 통제하는 값이라 무제한 저장 금지. 422 거부가 아니라 **클램프**(잘라서 저장) — 이상한
+# UTM 값 하나로 가입 자체가 막히면(422) 신규 유저 유입 경로를 스스로 차단하는 꼴이라
+# 서비스 목적에 반한다. 값 상한은 PO 확定(2026-08-29): utm 3종 각 256자, referrer는
+# URL이라 더 길 수 있어 1024자.
+_ATTRIBUTION_UTM_MAX_LEN = 256
+_ATTRIBUTION_REFERRER_MAX_LEN = 1024
+
+
+def _clamp_attribution_utm(v: str | None) -> str | None:
+    return v[:_ATTRIBUTION_UTM_MAX_LEN] if v else v
+
+
+def _clamp_attribution_referrer(v: str | None) -> str | None:
+    return v[:_ATTRIBUTION_REFERRER_MAX_LEN] if v else v
+
+
 class LoginRequest(BaseModel):
     email: str
     password: str
@@ -123,6 +140,16 @@ class RegisterRequest(BaseModel):
     signup_utm_medium: str | None = None
     signup_utm_campaign: str | None = None
     signup_referrer: str | None = None
+
+    @field_validator("signup_utm_source", "signup_utm_medium", "signup_utm_campaign")
+    @classmethod
+    def clamp_utm(cls, v: str | None) -> str | None:
+        return _clamp_attribution_utm(v)
+
+    @field_validator("signup_referrer")
+    @classmethod
+    def clamp_referrer(cls, v: str | None) -> str | None:
+        return _clamp_attribution_referrer(v)
 
     @field_validator("email")
     @classmethod
@@ -1187,6 +1214,16 @@ class OAuthCallbackRequest(BaseModel):
     signup_utm_medium: str | None = None
     signup_utm_campaign: str | None = None
     signup_referrer: str | None = None
+
+    @field_validator("signup_utm_source", "signup_utm_medium", "signup_utm_campaign")
+    @classmethod
+    def clamp_utm(cls, v: str | None) -> str | None:
+        return _clamp_attribution_utm(v)
+
+    @field_validator("signup_referrer")
+    @classmethod
+    def clamp_referrer(cls, v: str | None) -> str | None:
+        return _clamp_attribution_referrer(v)
 
 
 @router.get("/oauth/{provider}/authorize")

--- a/backend/tests/test_3204_signup_attribution.py
+++ b/backend/tests/test_3204_signup_attribution.py
@@ -17,9 +17,12 @@ def anyio_backend():
 # ─── register() — signup_utm_*/signup_referrer 영속화 ──────────────────────────
 
 async def _register_client():
+    """카디르 QA(PR#3612) — raw get_db 오버라이드는 get_read_db를 놓치는 회귀 클래스
+    (story #2451 §6 Phase3, 4차 재발). override_db_and_read 경유로 두 dependency key를
+    구조적으로 함께 건다."""
     from app.main import app
     from app.dependencies.auth import get_current_user
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     mock_session = AsyncMock()
     mock_result = MagicMock()
@@ -39,7 +42,7 @@ async def _register_client():
         ctx.user_id = str(uuid.uuid4())
         return ctx
 
-    app.dependency_overrides[get_db] = override_db
+    override_db_and_read(app, override_db)
     app.dependency_overrides[get_current_user] = override_auth
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
 
@@ -93,16 +96,38 @@ async def test_register_without_attribution_fields_leaves_them_none():
         app.dependency_overrides.clear()
 
 
+@pytest.mark.anyio
+async def test_register_clamps_oversized_attribution_fields():
+    """카디르 QA(PR#3612) — UTM/referrer는 유저(브라우저)가 URL 쿼리로 완전히 통제하는
+    값이라 무제한 저장 금지. 422 거부가 아니라 클램프(가입 자체는 막지 않는다)."""
+    import app.routers.auth as auth_router
+
+    client, session, app = await _register_client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/register", json=_register_payload(
+                signup_utm_source="x" * 500,
+                signup_referrer="https://example.com/" + ("y" * 2000),
+            ))
+        assert resp.status_code == 201
+        user = _added_user(session)
+        assert len(user.signup_utm_source) == auth_router._ATTRIBUTION_UTM_MAX_LEN
+        assert len(user.signup_referrer) == auth_router._ATTRIBUTION_REFERRER_MAX_LEN
+    finally:
+        app.dependency_overrides.clear()
+
+
 # ─── oauth_callback() — is_new_user + signup_utm_*/signup_referrer 영속화 ──────
 
 async def _oauth_client(session: AsyncMock):
+    """카디르 QA(PR#3612) — _register_client와 동일 fix(override_db_and_read 경유)."""
     from app.main import app
-    from app.dependencies.database import get_db
+    from tests.conftest import override_db_and_read
 
     async def override_db():
         yield session
 
-    app.dependency_overrides[get_db] = override_db
+    override_db_and_read(app, override_db)
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 

--- a/backend/tests/test_3204_signup_attribution.py
+++ b/backend/tests/test_3204_signup_attribution.py
@@ -1,0 +1,216 @@
+"""story #3204(acquisition 계측) — 가입 시점 utm/referrer 영속화(register()/oauth_callback())
++ oauth_callback() 응답의 is_new_user 플래그(FE sign_up 전환 이벤트 발화 신호)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── register() — signup_utm_*/signup_referrer 영속화 ──────────────────────────
+
+async def _register_client():
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_result.scalars.return_value.all.return_value = []
+    mock_result.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.flush = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session.add = MagicMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        ctx = MagicMock()
+        ctx.user_id = str(uuid.uuid4())
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+def _register_payload(**overrides) -> dict:
+    return {
+        "email": f"new-{uuid.uuid4().hex}@example.com",
+        "password": "TestPass1!",
+        "display_name": "Test User",
+        "tos_accepted": True,
+        **overrides,
+    }
+
+
+def _added_user(session):
+    from app.models.user import User
+    return next(c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], User))
+
+
+@pytest.mark.anyio
+async def test_register_persists_signup_attribution_fields():
+    client, session, app = await _register_client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/register", json=_register_payload(
+                signup_utm_source="google", signup_utm_medium="cpc",
+                signup_utm_campaign="launch", signup_referrer="https://twitter.com/x",
+            ))
+        assert resp.status_code == 201
+        user = _added_user(session)
+        assert user.signup_utm_source == "google"
+        assert user.signup_utm_medium == "cpc"
+        assert user.signup_utm_campaign == "launch"
+        assert user.signup_referrer == "https://twitter.com/x"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_register_without_attribution_fields_leaves_them_none():
+    """direct 가입(캠페인 링크 없음) — 지어내지 않고 None으로 남는다."""
+    client, session, app = await _register_client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/register", json=_register_payload())
+        assert resp.status_code == 201
+        user = _added_user(session)
+        assert user.signup_utm_source is None
+        assert user.signup_referrer is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── oauth_callback() — is_new_user + signup_utm_*/signup_referrer 영속화 ──────
+
+async def _oauth_client(session: AsyncMock):
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    async def override_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_db
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _mock_session_returning_none() -> AsyncMock:
+    """provider_id 조회·email 조회 둘 다 None — 신규 유저 생성 분기로 진입."""
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=result)
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    return session
+
+
+def _mock_session_returning_existing_user() -> AsyncMock:
+    """provider_id 조회에서 기존 유저가 바로 잡힘 — 로그인(신규 아님). spec 없는 순수
+    MagicMock — _build_app_metadata의 후속 member 조회도 같은 mock 결과를 재사용하므로
+    (session.execute가 단일 return_value) 임의 속성 접근(member.user_id 등)이 모두
+    통과해야 한다(spec을 걸면 User에 없는 속성에서 AttributeError)."""
+    existing = MagicMock()
+    existing.id = uuid.uuid4()
+    existing.email = "existing@example.com"
+    existing.locale = None
+    # MagicMock은 getattr(user, "last_org_id", None)의 default가 절대 안 먹는다(속성이
+    # "항상 존재"하니 Mock을 돌려줌) — 명시로 None을 박아야 _build_app_metadata가 실제
+    # None 분기(org_id 미지정)를 탄다. 안 박으면 Mock이 JWT payload까지 새 나가
+    # "Object of type MagicMock is not JSON serializable"로 죽는다.
+    existing.last_org_id = None
+    existing.last_project_id = None
+
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = existing
+    # _build_app_metadata의 후속 member/org 조회가 리스트류(scalars().all())를 읽는
+    # 경로면 빈 리스트로 떨어뜨려 org_id/project_id 등 미확定 상태로 메타데이터가
+    # 안전(JSON 직렬화 가능)하게 비게 한다 — 이 테스트의 관심사는 is_new_user뿐이라
+    # 메타데이터 내용 자체는 검증 대상이 아니다.
+    result.scalars.return_value.all.return_value = []
+    result.all.return_value = []
+    session.execute = AsyncMock(return_value=result)
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    return session
+
+
+@pytest.mark.anyio
+async def test_oauth_callback_new_user_returns_is_new_user_true_and_persists_attribution(monkeypatch):
+    from app.core.config import settings
+    from app.core.security import create_oauth_state_token
+    import app.routers.auth as auth_router
+
+    monkeypatch.setattr(settings, "jwt_secret", "test-jwt-secret", raising=False)
+    monkeypatch.setattr(
+        auth_router, "_exchange_oauth_code_for_userinfo",
+        AsyncMock(return_value=("google-oauth-id-1", "brand-new@example.com")),
+    )
+    state = create_oauth_state_token("google")
+    session = _mock_session_returning_none()
+    client = await _oauth_client(session)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/oauth/callback", json={
+                "provider": "google", "code": "code-1", "state": state, "tos_accepted": True,
+                "signup_utm_source": "google", "signup_referrer": "https://twitter.com/x",
+            })
+        assert resp.status_code == 200
+        assert resp.json()["data"]["is_new_user"] is True
+
+        from app.models.user import User
+        user = next(c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], User))
+        assert user.signup_utm_source == "google"
+        assert user.signup_referrer == "https://twitter.com/x"
+    finally:
+        from app.main import app
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_oauth_callback_existing_user_login_returns_is_new_user_false(monkeypatch):
+    """카디르류 검산 포인트 — provider_id로 기존 유저를 바로 찾은 로그인은 신규 가입이
+    아니다. is_new_user=False라 FE가 재로그인마다 sign_up 이벤트를 중복 발화하지 않는다.
+
+    _build_app_metadata는 org/project 해소 체인이 깊어(member/invite/first_accessible
+    등 다단 폴백) 이 테스트의 관심사(is_new_user) 밖이라 고정 dict로 대체한다 — 메타데이터
+    내용 자체는 이 테스트가 검증할 축이 아니다(다른 기존 테스트들의 몫)."""
+    from app.core.config import settings
+    from app.core.security import create_oauth_state_token
+    import app.routers.auth as auth_router
+
+    monkeypatch.setattr(settings, "jwt_secret", "test-jwt-secret", raising=False)
+    monkeypatch.setattr(
+        auth_router, "_exchange_oauth_code_for_userinfo",
+        AsyncMock(return_value=("google-oauth-id-1", "existing@example.com")),
+    )
+    monkeypatch.setattr(auth_router, "_build_app_metadata", AsyncMock(return_value={}))
+    state = create_oauth_state_token("google")
+    session = _mock_session_returning_existing_user()
+    client = await _oauth_client(session)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/oauth/callback", json={
+                "provider": "google", "code": "code-1", "state": state,
+            })
+        assert resp.status_code == 200
+        assert resp.json()["data"]["is_new_user"] is False
+    finally:
+        from app.main import app
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## 요약
- [\[acquisition·계측\] 가입 «출처 귀속» 장치 부재 — GA4는 페이지뷰만(전환 이벤트 0)·가입 시점 UTM/referrer 영속화 0](entity:story:c6d21981-145c-48a6-9cc1-5855d497c8a2)

## 발견(PO 실측, 2026-08-29)
prod 페이지뷰 계측(gtag)은 실재하나 ①전환 이벤트 0 ②가입 시점 UTM/referrer 영속화 0 ③GA 프로퍼티 접근 불가로 실데이터 검증은 이번 스코프 밖(PO 확定).

## ①sign_up 전환 이벤트 — 발화 지점 SSOT
가입 경로 2개(email/pw는 클라측 즉시 확定, OAuth는 서버 리다이렉트라 클라 JS 컨텍스트 자체가 없고 로그인/가입 구분 신호도 BE 응답에 없었음)를 `?signup=1` 쿼리파라미터 하나로 수렴시켜 `google-analytics.tsx`의 route-change effect 한 곳에서만 발화(Toss checkout 성공 쿼리파라미터 소비 패턴과 동형).

BE `oauth_callback()` 응답에 `is_new_user` 신설(신규 유저 생성 분기에서만 true — 기존 유저 로그인은 false라 재로그인마다 중복 발화 안 됨). 본인 인증 응답 안이라 계정 존재 누출 아님(PO 확認).

## ②UTM/referrer 영속화 — proxy.ts first-touch 쿠키 + users 컬럼 4개(마이그 0292)
`proxy.ts`에 **완전 독립** 분기 하나만 삽입 — utm_source/medium/campaign 쿼리나 외부 referer가 있고 기존 귀속 쿠키가 없으면(first-touch) 쿠키 4개로 기록. 동일 출처 내부 이동은 referer로 안 침. 기존 인증/세션 로직과 무관.

register 시점(email POST route.ts + oauth callback route.ts) 둘 다 쿠키를 읽어 BE로 relay, `users.signup_utm_source/medium/campaign/referrer`(nullable)로 1회 저장 — locale/tos_accepted_at과 동일한 "가입 시 1회 포착" 컬럼 패턴.

## ③prod-only 원칙 무회귀
`GA_ID`가 dev cloudbuild 빌드 인자에 없어 sign_up 이벤트 발화도 동일 가드로 dev 0 유지. UTM/referrer 쿠키·컬럼 저장은 GA와 무관해 환경 무관 항상 동작(dev QA도 귀속값 확認 가능하게 의도).

## 검증
- 신규 pin 18건 — proxy.test.ts 4 + google-analytics.test.tsx(신규) 4 + register/page.test.tsx 2 + oauth callback route.test.ts 4 + BE test_3204_signup_attribution.py 4.
- tsc 0 · lint 0(무관 기존 5건) · verify:raw-fetch/raw-button GREEN · 전체 vitest 536파일/5022건 GREEN · build GREEN.
- backend: py_compile OK · alembic heads 단일(0292) · 전체 pytest(-m "not destructive_schema") 5119 passed(14 failed는 기존 환경 갭, 무관 파일).

prod 무접촉(develop 대상). AC1(prod sign_up 실측)·AC2 실데이터 확認은 GA 프로퍼티 접근 열리면 후속(스토리 명시 스코프 밖).