### PR TITLE
[3210] 발송 메일 QP «=hex» 오해석 손상 — 발송 직전 전수 엔티티화 가드

### DIFF
--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -2,6 +2,7 @@
 import html
 import logging
 import os
+import re
 import smtplib
 from datetime import datetime, timezone
 from email.mime.multipart import MIMEMultipart
@@ -115,6 +116,23 @@ def render_action_email(
     return render_email_shell(content, locale=locale)
 
 
+# story #3210 — 발송 경로 어느 홉이든(Resend/SES/구글그룹스 재배포 등, 정확히 어느
+# 홉인지는 우리 쪽에서 확인 불가) HTML 본문의 리터럴 「=[hex][hex]」를 quoted-printable
+# 이스케이프로 오해석해 그 두 글자를 삼킨다 — 실기기 재현으로 확인(viewport meta
+# 「width=device-width」 중 「=de」가 손상, 「=1"」은 유효 hex쌍이 아니라 무사).
+# `&#61;`는 QP 디코딩(전송 단계) 이전엔 평문이라 오해석되지 않고, 브라우저의 HTML
+# 파싱(렌더 단계, href 속성값 포함)에서 `=`로 복원돼 시각·기능 영향이 없다. 구조적
+# `=`(속성 대입, 예: name="viewport")는 항상 따옴표가 뒤따라 hex와 매치되지 않으므로
+# 안전 — 즉 이 치환은 항상 텍스트/속성값 안의 리터럴 `=hex`만 잡는다. 정적 viewport
+# meta뿐 아니라 향후 동적 콘텐츠(쿠폰 코드·해시 등)에도 동일 클래스가 재발할 수 있어
+# 발송 직전 이 한 지점에서 전수 방어한다(개별 호출부마다 알아서 피하게 하지 않음).
+_QP_HEX_COLLISION_RE = re.compile(r"=(?=[0-9a-fA-F]{2})")
+
+
+def _neutralize_qp_hex_collisions(html_body: str) -> str:
+    return _QP_HEX_COLLISION_RE.sub("&#61;", html_body)
+
+
 def send_email(to: str, subject: str, html_body: str) -> bool:
     """이메일 발송.
 
@@ -123,6 +141,7 @@ def send_email(to: str, subject: str, html_body: str) -> bool:
     provider 발송 실패 시 예외를 re-raise — 호출자가 오류 처리 책임.
     (E-ONBOARDING S4: False/예외를 호출자가 '미발송'으로 surface해 무음 성공을 차단.)
     """
+    html_body = _neutralize_qp_hex_collisions(html_body)
     resend_key = os.getenv("RESEND_API_KEY", "")
     if resend_key:
         _send_via_resend(to=to, subject=subject, html_body=html_body, api_key=resend_key)

--- a/backend/tests/test_3210_email_qp_hex_collision_guard.py
+++ b/backend/tests/test_3210_email_qp_hex_collision_guard.py
@@ -1,0 +1,81 @@
+"""story #3210 — 발송 경로(Resend→SES 추정, 정확한 홉은 우리 쪽에서 재현 불가)가
+리터럴 「=[hex][hex]」를 quoted-printable 이스케이프로 오해석해 그 두 글자를 삼킨다.
+실착 확인: 셸 viewport meta의 「width=device-width」 중 「=de」가 「width�vice-width」로
+손상(=de → 0xDE 단일바이트), 「initial-scale=1」은 「=1"」이 유효 hex쌍이 아니라 무사.
+
+`send_email()`이 발송 직전 html_body의 모든 「=hex」를 `&#61;`로 엔티티화해 전수 방어한다
+— 정적 viewport meta뿐 아니라 향후 동적 콘텐츠(쿠폰 코드·해시 등)에도 같은 클래스가
+재발하지 않도록. AC2(«=hex» 포함 본문 표본 1건 무손상)의 단위 pin.
+"""
+from __future__ import annotations
+
+from app.services.email import _neutralize_qp_hex_collisions, render_email_shell
+
+
+def test_viewport_meta_de_sequence_neutralized():
+    """실착 재현분과 정확히 같은 시퀀스 — width=device-width의 «=de».
+    가드는 render_email_shell()이 아니라 send_email() 발송 직전 단일 지점에 있다
+    (호출부마다 알아서 피하게 하지 않는다는 설계 — 여기선 그 지점을 직접 호출해 고정)."""
+    shell = render_email_shell("<p>본문</p>")
+    assert "width=device-width" in shell  # 셸 자체는 원문 그대로(가드 적용 전)
+    guarded = _neutralize_qp_hex_collisions(shell)
+    assert "width&#61;device-width" in guarded
+    assert "width=device-width" not in guarded
+
+
+def test_non_hex_following_equals_left_untouched():
+    """실착에서 무사했던 자리(=1", ="600" 등) — =뒤 2글자가 hex가 아니면 그대로 둔다."""
+    result = _neutralize_qp_hex_collisions('initial-scale=1" width="600"')
+    assert 'initial-scale=1"' in result
+    assert 'width="600"' in result
+
+
+def test_dynamic_content_hex_looking_sequence_neutralized_and_recoverable():
+    """AC2 양성대조 — 쿠폰 코드/해시류 동적 콘텐츠에 우연히 «=AB» 모양이 섞여도
+    엔티티화되고, HTML 엔티티 디코딩(브라우저 렌더 단계)으로 원문이 그대로 복원된다."""
+    import html as html_module
+
+    content = "<p>쿠폰 코드: SAVE=de20</p>"
+    result = _neutralize_qp_hex_collisions(content)
+    assert "SAVE&#61;de20" in result
+    assert "SAVE=de20" not in result
+    assert html_module.unescape(result) == content
+
+
+def test_structural_attribute_equals_never_matched():
+    """구조적 `=`(속성 대입)는 항상 따옴표가 뒤따라 hex와 매치되지 않는다 — 가드를 셸
+    전체(실 발송 페이로드)에 적용해도 HTML 파싱을 깨뜨리지 않음을 확認."""
+    guarded = _neutralize_qp_hex_collisions(render_email_shell("<p>본문</p>"))
+    assert 'name="viewport"' in guarded
+    assert 'charset="utf-8"' in guarded
+    assert 'lang="ko"' in guarded
+
+
+def test_href_query_value_hex_sequence_neutralized_and_link_still_resolves_after_decode():
+    """href 속성값 안의 =hex도 동일 보호 — 엔티티 디코딩 후 URL 자체는 원문 그대로라
+    링크 기능에 영향이 없다."""
+    import html as html_module
+
+    href = '<a href="https://x.example/verify?token=ab12cd">go</a>'
+    result = _neutralize_qp_hex_collisions(href)
+    assert "token&#61;ab12cd" in result
+    assert html_module.unescape(result) == href
+
+
+def test_send_email_actually_applies_guard_before_dispatch(monkeypatch):
+    """단위 helper가 옳아도 send_email()이 실제로 호출 안 하면 무의미 — 배선 자체를 고정.
+    resend 발송 함수로 실제 전달되는 html_body가 가드 통과분인지 직접 확認."""
+    from app import services
+
+    captured: dict[str, str] = {}
+
+    def _fake_send_via_resend(*, to, subject, html_body, api_key):
+        captured["html_body"] = html_body
+
+    monkeypatch.setenv("RESEND_API_KEY", "fake-key-for-test")
+    monkeypatch.setattr(services.email, "_send_via_resend", _fake_send_via_resend)
+
+    services.email.send_email("to@example.com", "제목", "<p>width=device-width</p>")
+
+    assert "width&#61;device-width" in captured["html_body"]
+    assert "width=device-width" not in captured["html_body"]


### PR DESCRIPTION
[SID:3210]

## 원인
셸 viewport meta의 `width=device-width` 중 `=de`가 quoted-printable 유효 hex
이스케이프로 오해석돼 실착 손상(`width�vice-width`). `=1"`은 유효 hex쌍이
아니라 무사 — 클래스가 정확히 `=`+유효hex 2자 시퀀스.

정확한 홉(Resend API 자체/SES 재인코딩/구글그룹스 재배포)은 재현 환경상
확인 불가(비-그룹 수신 주소 없음). Resend Python SDK는 순수 JSON REST라
CTE 관련 로직이 클라이언트 쪽에 전혀 없음을 소스로 확인, 공개 문서에서도
CTE 제어 파라미터를 찾지 못함(ⓑ 근본 경로는 인프라 밖에서 실측 불가).

## 처방(ⓐ+가드)
`send_email()` 발송 직전, html_body의 모든 `=[hex][hex]`를 `&#61;`로
엔티티화 — 어느 홉이 원인이든 원천 차단(홉 특정에 의존하지 않음). HTML
파싱(렌더 단계)에서 `=`로 복원되어 시각·기능 영향 0(href 속성값도 동일 —
엔티티 디코딩 후 URL 사용). 구조적 `=`(속성 대입)는 항상 따옴표가 뒤따라
hex와 매치되지 않아 안전.

정적 viewport meta 인스턴스 하나만 패치하지 않고 발송 단일 지점에 건 이유:
향후 동적 콘텐츠(쿠폰 코드·해시 등)에서 같은 클래스가 "보이는 자리"서
재발할 수 있다는 게 스토리 자체의 지적이라, 클래스째 막음.

## AC 대조
1. 실착 메일 raw에서 viewport meta 원문 무손상 — PO 재실착 확인 필요(가드 적용 후).
2. «=hex» 포함 본문 표본 1건 무손상 실착(양성대조) — 단위 pin으로 커버
   (`test_dynamic_content_hex_looking_sequence_neutralized_and_recoverable`),
   실착 양성대조는 PO 재테스트 요청.

## 자기검증
`test_send_email_actually_applies_guard_before_dispatch` — 가드 호출 라인을
직접 제거하는 뮤테이션 주입 → RED 확인 후 정확히 원복.

## Test plan
- [x] `pytest tests/test_3210_email_qp_hex_collision_guard.py` (6 passed)
- [x] `pytest tests/ -k email` 회귀 0 (93 passed, 6 skipped)
- [x] `scripts/lint_dependency_override_get_read_db.py` 신규 위반 0건
- [ ] PO 실착 재검증(AC1·AC2 raw 대조)