### PR TITLE
[SID:3182] 「지금」 스트립 대량-N expand cap — severity 그룹당 3건+더보기 (S3a 후속 2차 조항)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3512,6 +3512,7 @@
     "nowStripGroupDanger": "Action needed",
     "nowStripGroupWarn": "Attention",
     "nowStripGroupInfo": "Observe · Learn",
+    "nowStripGroupMore": "+{count} more",
     "pulseLabel": "Project pulse",
     "pulseEpicEmpty": "No active epic",
     "pulseCostTrendLabel": "Cost trend",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3512,6 +3512,7 @@
     "nowStripGroupDanger": "행동 필요",
     "nowStripGroupWarn": "주의",
     "nowStripGroupInfo": "관찰 · 학습",
+    "nowStripGroupMore": "+{count} 더보기",
     "pulseLabel": "프로젝트 맥박",
     "pulseEpicEmpty": "활성 에픽 없음",
     "pulseCostTrendLabel": "비용 추이",

--- a/apps/web/src/components/chat/now-strip.test.tsx
+++ b/apps/web/src/components/chat/now-strip.test.tsx
@@ -197,3 +197,68 @@ describe('NowStrip — story #3180 attention.changed 신호(AC2 즉시 재조회
     expect(fetchWithAuthMock.mock.calls.length).toBe(callsAfterMount + 1);
   });
 });
+
+// story #3182(S3a 후속) — expanded 상태에서 severity 그룹별 대량-N일 때 스크롤 폭탄 방지.
+// S2c③④(embed-group.tsx ConciseList) 선례 그대로 그룹당 기본 3건 + 「+N 더보기」.
+describe('NowStrip — story #3182 그룹별 expand cap(2차 조항, S2c 선례 재사용)', () => {
+  function makeAgentStuckItems(n: number): AttentionItem[] {
+    return Array.from({ length: n }, (_, i) => ({
+      type: 'agent_stuck' as const, severity: 'warn' as const, auto_detected: true,
+      entity_type: 'story' as const, entity_id: `s-${i}`, gate_type: 'merge' as const, stuck_since: null,
+    }));
+  }
+
+  it('실측 38건 시나리오 — 한 그룹(warn) 38건이어도 펼친 직후엔 3건만 렌더되고 「+35 더보기」가 뜬다', async () => {
+    mockAttention(makeAgentStuckItems(38));
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    const header = container.querySelector('button[aria-expanded]')!;
+    await act(async () => { header.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    const cards = container.querySelectorAll('a[href^="/board?story="]');
+    expect(cards.length).toBe(3);
+    expect(container.textContent).toContain('+35 더보기');
+  });
+
+  it('「더보기」를 누르면 그룹 전체(38건)가 펼쳐지고, 카드는 여전히 원탭 도달 링크를 유지한다(AC2)', async () => {
+    mockAttention(makeAgentStuckItems(38));
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    const header = container.querySelector('button[aria-expanded]')!;
+    await act(async () => { header.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    const moreBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === '+35 더보기')!;
+    await act(async () => { moreBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    const cards = container.querySelectorAll('a[href^="/board?story="]');
+    expect(cards.length).toBe(38);
+    expect(container.querySelector('a[href="/board?story=s-0"]')).toBeTruthy();
+    expect(container.querySelector('a[href="/board?story=s-37"]')).toBeTruthy();
+  });
+
+  it('회귀(AC3) — 소량(그룹당 3건 이하)에서는 「더보기」가 안 뜬다(불필요 UI 0)', async () => {
+    mockAttention(makeAgentStuckItems(3));
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    const header = container.querySelector('button[aria-expanded]')!;
+    await act(async () => { header.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(container.querySelectorAll('a[href^="/board?story="]').length).toBe(3);
+    expect(container.textContent).not.toContain('더보기');
+  });
+
+  it('그룹별 독립 — danger 그룹이 대량이어도 warn 그룹(소량)엔 영향 없다(각 그룹 자체 cap)', async () => {
+    const danger: AttentionItem[] = Array.from({ length: 10 }, (_, i) => ({
+      type: 'agent_auth_failure' as const, severity: 'danger' as const, auto_detected: true,
+      member_id: `m-${i}`, reason: 'revoked' as const, failure_count: 1, first_failed_at: null, last_failed_at: null,
+    }));
+    mockAttention([...danger, AGENT_STUCK]);
+    await act(async () => { root.render(wrap(<NowStrip />)); });
+    await flush();
+    const header = container.querySelector('button[aria-expanded]')!;
+    await act(async () => { header.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(container.textContent).toContain('+7 더보기'); // danger 10건 → 3+더보기7
+    expect(container.querySelector('a[href="/board?story=s-1"]')).toBeTruthy(); // warn 1건은 cap 미적용(3건 미만)
+  });
+});

--- a/apps/web/src/components/chat/now-strip.tsx
+++ b/apps/web/src/components/chat/now-strip.tsx
@@ -100,6 +100,38 @@ function groupBySeverity(items: NowStripItem[]): { severity: NowStripSeverity; i
     .filter((g) => g.items.length > 0);
 }
 
+// story #3182(S3a 후속) — embed-group.tsx ConciseList(S2c③④)의 「default N + 더보기」
+// 값·기전을 그대로 재사용(PO 지시: 신규 패턴 0). collapsed-default(1차 조항, S2c 불변식)는
+// 이미 groups 자체를 안 그리는 상위 `expanded &&` 가드가 지킨다 — 이건 «펼친 뒤» 그룹당
+// 대량-N일 때의 2차 조항(스크롤 폭탄 방지).
+const GROUP_DEFAULT_VISIBLE = 3;
+
+function NowStripSeverityGroup({ severity, items }: { severity: NowStripSeverity; items: NowStripItem[] }) {
+  const t = useTranslations('chats');
+  const [groupExpanded, setGroupExpanded] = useState(false);
+  const visible = groupExpanded ? items : items.slice(0, GROUP_DEFAULT_VISIBLE);
+  const hiddenCount = items.length - GROUP_DEFAULT_VISIBLE;
+
+  return (
+    <div className="space-y-1">
+      <p className={cn('px-1 pt-1 text-[10.5px] font-semibold tracking-wide uppercase', SEVERITY_GROUP_TEXT[severity])}>
+        {t(SEVERITY_GROUP_LABEL_KEY[severity])}
+      </p>
+      {visible.map((item) => <NowStripCard key={item.key} item={item} />)}
+      {hiddenCount > 0 && (
+        <Button
+          type="button"
+          variant="link"
+          onClick={() => setGroupExpanded((v) => !v)}
+          className="h-auto p-0 px-1 text-[11px] font-medium"
+        >
+          {groupExpanded ? t('nowStripCollapse') : t('nowStripGroupMore', { count: hiddenCount })}
+        </Button>
+      )}
+    </div>
+  );
+}
+
 export interface NowStripProps {
   /** agent_stuck 라벨용(action-zone.tsx와 동일 계약) — 없으면 attentionEntityLabel 자체의
    * entity_type 폴백(no-fiction)으로 떨어진다, 필수 아님. */
@@ -198,14 +230,7 @@ export function NowStrip({ resolveName, expanded: expandedProp, onExpandedChange
       </Button>
       {expanded && (
         <div className="space-y-2 border-t border-border p-2 pt-1.5">
-          {groups.map((g) => (
-            <div key={g.severity} className="space-y-1">
-              <p className={cn('px-1 pt-1 text-[10.5px] font-semibold tracking-wide uppercase', SEVERITY_GROUP_TEXT[g.severity])}>
-                {t(SEVERITY_GROUP_LABEL_KEY[g.severity])}
-              </p>
-              {g.items.map((item) => <NowStripCard key={item.key} item={item} />)}
-            </div>
-          ))}
+          {groups.map((g) => <NowStripSeverityGroup key={g.severity} severity={g.severity} items={g.items} />)}
         </div>
       )}
     </div>


### PR DESCRIPTION
## 요약
- [\[S3a 후속·refinement\] 「지금」 스트립 대량-N expand cap — severity 그룹 접힘+더보기 (카드 홍수 방지 2차 조항)](entity:story:860b6c04-182c-4b94-bf80-293a47f1c614)

## 발단(2026-08-28 유나 S3a 실픽셀 스팟체크·PR#3582 착지 후)
now-strip expanded 상태가 attention 전건을 그대로 나열(cap/slice/더보기 grep 0) — 실측 38건 환경에서 expand 시 스크롤 폭탄. collapsed 기본값이 첫 화면 밀도는 보존하므로 1차 조항(S2c 불변식)은 충족 상태였으나, wire doc §1의 «건수 늘면 severity 그룹 접힘+더보기» 2차 조항이 미집행이었다.

## 처방 — S2c③④(embed-group.tsx ConciseList) 값·기전 그대로 재사용(PO 지시: 신규 패턴 0)
severity 그룹(danger/warn/info)마다 독립된 접힘 상태(NowStripSeverityGroup 신규 컴포넌트)로 기본 3건 노출 + 「+N 더보기」. 클릭 시 그 그룹만 전체 펼침·「접기」로 재수렴. 카드 자체와 원탭 도달 href는 무변경.

verify:no-new-raw-button 가드가 최초 raw `<button>` 구현(S2c 원 코드 그대로 베낌)을 신규 위반으로 적출 — Button(variant="link")으로 교체해 통과시켰다.

## 검증
- 신규 pin 4건 — 38건 그룹 펼침 시 3건만+«+35 더보기»·더보기 클릭 시 38건 전체+원탭 도달 유지(AC2)·소량(≤3)에서 더보기 미노출(AC3 회귀)·그룹별 독립 cap.
- tsc 0 · lint 0(무관 기존 5건) · verify:no-duplicate-i18n-keys/no-i18n-phrase-collision/no-new-raw-button 전부 GREEN · 전체 vitest 537파일/5036건 GREEN · build GREEN.

prod 무접촉(develop 대상).