### PR TITLE
[3199] disposable PG 로컬 반복기동 — SysV shm 정리 루틴(root 불요)

### DIFF
--- a/backend/scripts/disposable_pg.sh
+++ b/backend/scripts/disposable_pg.sh
@@ -139,6 +139,12 @@ fi
 # unix_socket_directories는 짧은 고정 경로로 — scratchpad 등 긴 경로는 유닉스 소켓 경로
 # 103바이트 상한(macOS)을 넘겨 기동 자체가 실패한다(story #3199 재현 시 실제로 걸림).
 _start_pg() {
+  # 카디르 QA 3라운드 지적(PR#3616) — pg_ctl -l은 append라, data-dir를 재사용하는 이전
+  # 시도의 shmget 흔적이 로그에 영구히 남으면 「이번 시도가 shm 실패인가」가 아니라
+  # 「이 파일에 그런 적 있었나」를 재게 된다(포트 충돌 등 무관한 실패에도 파괴적 스윕이
+  # 잘못 발동). PG가 아직 안 떠 있는 시점이라 truncate에 경합이 없다 — 시도 직전 항상
+  # 비운다.
+  : > "$DATA_DIR/log.txt"
   pg_ctl -D "$DATA_DIR" -o "-p $PORT -c unix_socket_directories=/tmp" -l "$DATA_DIR/log.txt" start
 }
 

--- a/backend/scripts/disposable_pg.sh
+++ b/backend/scripts/disposable_pg.sh
@@ -101,8 +101,11 @@ sweep_orphan_shm() {
   local err rc
   for id in "${candidates[@]}"; do
     _id_in "$id" "$live_ids" && continue
-    if ! err="$(ipcrm -m "$id" 2>&1 >/dev/null)"; then
-      rc=$?
+    # 페드루 코스메틱 지적(PR#3616 재QA) — `if ! err=$(...); then rc=$?` 형태는 `!`가 이미
+    # 조건을 부정한 뒤라 그 안의 `$?`는 항상 0(부정 자체의 성공)을 찍는다. 실제 종료코드는
+    # `&&`/`||`로 조건 밖에서 따로 잡아야 한다.
+    err="$(ipcrm -m "$id" 2>&1 >/dev/null)" && rc=0 || rc=$?
+    if [ "$rc" -ne 0 ]; then
       if ! grep -qiE 'not permitted|permission denied' <<<"$err"; then
         echo "ipcrm -m $id 실패(rc=$rc, EPERM 아님): $err" >&2
       fi

--- a/backend/scripts/disposable_pg.sh
+++ b/backend/scripts/disposable_pg.sh
@@ -21,6 +21,8 @@
 # 못 잡는 것(선언): ⓐ다른 uid가 띄운 PG — 그 postmaster.pid를 못 읽지만, 같은 이유로
 # 커널이 그 uid의 shm을 ipcrm으로부터도 막아주므로 안전(EPERM, 스윕에서 조용히 스킵).
 # ⓑ같은 uid의 PG 아닌 SysV 사용자(다른 도구가 shm을 쓰는 경우) — 이건 진짜 미탐지 리스크.
+# ⓒ data-dir 경로에 공백이 들어가면 `-D` 파싱(sed)이 그 지점에서 끊긴다 — disposable
+# 리그 관례상 실경로엔 공백이 없어 지금은 무해하나, 공백 포함 경로를 쓰게 되면 재점검 필요.
 #
 # 사용:
 #   backend/scripts/disposable_pg.sh <data-dir> <port>              # 세션 모드(Ctrl-C까지 유지)

--- a/backend/scripts/disposable_pg.sh
+++ b/backend/scripts/disposable_pg.sh
@@ -9,10 +9,18 @@
 # 기동 전 이 호스트의 "죽은 disposable PG 잔재" shm 세그를 non-root ipcrm으로 스윕한다.
 # 판별은 추정이 아니라 실물 대조: PG postmaster는 자기 SysV 세그의 key/shmid를
 # postmaster.pid 7번째 줄에 스스로 기록하므로(PG≥10 표준 포맷, 같은 uid라 읽기 가능),
-# 살아있는 모든 PG 클러스터(이 스크립트가 관리하는 데이터 디렉터리 + 호스트에 이미 떠
-# 있는 다른 PG들, 예: brew services 상시구동 클러스터)의 shmid를 실물로 모아 제외하고
-# 나머지만 지운다. IPC_RMID는 마지막 detach 후 파괴라(POSIX 표준 동작) 혹시 살아있는
-# 세그를 잘못 걸어도 attach 중인 프로세스는 안 죽는다 — 죽는 건 nattch=0 고아뿐.
+# 그걸로 살아있는 클러스터를 실물 확認해 제외하고 나머지만 지운다. IPC_RMID는 마지막
+# detach 후 파괴라(POSIX 표준 동작) 혹시 살아있는 세그를 잘못 걸어도 attach 중인
+# 프로세스는 안 죽는다 — 죽는 건 nattch=0 고아뿐.
+#
+# live 클러스터 탐색은 well-known 경로 추정(brew 경로 등)이 아니라 **실행 중인 postmaster
+# 전수**로 한다 — 이 스토리의 발단 자체가 «두 저자 동형 재현»(병행 세션)이라, 다른 세션이
+# 임의 data-dir에서 띄운 disposable PG도 실사용 경로다(페드루 QA 지적, PR#3616). `ps`로
+# `postgres -D <dir>` 커맨드라인 전부를 찾아 그 dir들의 postmaster.pid를 전부 읽는다 —
+# brew 경로는 이 일반 스캔에 자연히 흡수되어 더 이상 특례가 아니다.
+# 못 잡는 것(선언): ⓐ다른 uid가 띄운 PG — 그 postmaster.pid를 못 읽지만, 같은 이유로
+# 커널이 그 uid의 shm을 ipcrm으로부터도 막아주므로 안전(EPERM, 스윕에서 조용히 스킵).
+# ⓑ같은 uid의 PG 아닌 SysV 사용자(다른 도구가 shm을 쓰는 경우) — 이건 진짜 미탐지 리스크.
 #
 # 사용:
 #   backend/scripts/disposable_pg.sh <data-dir> <port>              # 세션 모드(Ctrl-C까지 유지)
@@ -38,13 +46,16 @@ PG_BIN_DIR="$(dirname "$(command -v postgres 2>/dev/null || echo /opt/homebrew/o
 export PATH="$PG_BIN_DIR:$PATH"
 
 _live_shmids() {
-  local pidfile line7
-  for pidfile in /opt/homebrew/var/postgresql@*/postmaster.pid "$DATA_DIR/postmaster.pid"; do
+  local line dir pidfile line7
+  while IFS= read -r line; do
+    dir="$(sed -n 's/.* -D  *\([^ ]*\).*/\1/p' <<<"$line")"
+    [ -n "$dir" ] || continue
+    pidfile="$dir/postmaster.pid"
     [ -f "$pidfile" ] || continue
     line7="$(sed -n '7p' "$pidfile" 2>/dev/null || true)"
     [ -n "$line7" ] || continue
     awk '{print $2}' <<<"$line7"
-  done
+  done < <(ps -axwwo command 2>/dev/null | grep -E '/postgres( |$)' | grep -F ' -D ')
 }
 
 sweep_orphan_shm() {

--- a/backend/scripts/disposable_pg.sh
+++ b/backend/scripts/disposable_pg.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# story #3199 — macOS 호스트 SysV shm(kern.sysv.shmmni=32, 로컬 기본값·시스템 전체 상한)이
+# disposable PG initdb의 shmget으로 쉽게 saturate돼(우리 disposable PG들이 종료 trap 없이
+# 죽으면서 세그를 반납 못 하고 누적) 반복 기동이 막히던 문제(미르코·저자 동형 재현)의 정리
+# 루틴. `-c shared_memory_type=mmap`을 써도 안 풀렸던 이유: PG≥9.3은 shared_memory_type과
+# 무관하게 클러스터당 SysV 세그 1개(소형 인터록용)를 항상 추가로 잡기 때문 — 그 1개가
+# 32/32 saturation에 걸리면 mmap 여부와 무관하게 ENOSPC.
+#
+# 기동 전 이 호스트의 "죽은 disposable PG 잔재" shm 세그를 non-root ipcrm으로 스윕한다.
+# 판별은 추정이 아니라 실물 대조: PG postmaster는 자기 SysV 세그의 key/shmid를
+# postmaster.pid 7번째 줄에 스스로 기록하므로(PG≥10 표준 포맷, 같은 uid라 읽기 가능),
+# 살아있는 모든 PG 클러스터(이 스크립트가 관리하는 데이터 디렉터리 + 호스트에 이미 떠
+# 있는 다른 PG들, 예: brew services 상시구동 클러스터)의 shmid를 실물로 모아 제외하고
+# 나머지만 지운다. IPC_RMID는 마지막 detach 후 파괴라(POSIX 표준 동작) 혹시 살아있는
+# 세그를 잘못 걸어도 attach 중인 프로세스는 안 죽는다 — 죽는 건 nattch=0 고아뿐.
+#
+# 사용:
+#   backend/scripts/disposable_pg.sh <data-dir> <port>              # 세션 모드(Ctrl-C까지 유지)
+#   backend/scripts/disposable_pg.sh <data-dir> <port> -- <command>  # 원샷(명령 실행 후 자동 stop, 그 종료코드로 exit)
+#   - data-dir가 없으면 initdb로 새로 만든다(진짜 disposable — 매번 신선한 클러스터).
+#   - 종료(EXIT/INT/TERM 무엇이든) trap이 pg_ctl stop -m fast로 항상 shm을 반납한다 —
+#     다음 실행이 오늘 이걸 다시 겪지 않도록.
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <data-dir> <port> [-- <command...>]" >&2
+  exit 2
+fi
+
+DATA_DIR="$1"
+PORT="$2"
+shift 2
+if [ "${1:-}" = "--" ]; then
+  shift
+fi
+
+PG_BIN_DIR="$(dirname "$(command -v postgres 2>/dev/null || echo /opt/homebrew/opt/postgresql@16/bin/postgres)")"
+export PATH="$PG_BIN_DIR:$PATH"
+
+_live_shmids() {
+  local pidfile line7
+  for pidfile in /opt/homebrew/var/postgresql@*/postmaster.pid "$DATA_DIR/postmaster.pid"; do
+    [ -f "$pidfile" ] || continue
+    line7="$(sed -n '7p' "$pidfile" 2>/dev/null || true)"
+    [ -n "$line7" ] || continue
+    awk '{print $2}' <<<"$line7"
+  done
+}
+
+sweep_orphan_shm() {
+  local live_ids id skip found
+  live_ids="$(_live_shmids)"
+  ipcs -m 2>/dev/null | awk '/^m/ {print $2}' | while read -r id; do
+    skip=0
+    while read -r found; do
+      [ -n "$found" ] && [ "$id" = "$found" ] && skip=1 && break
+    done <<<"$live_ids"
+    [ "$skip" = 1 ] && continue
+    ipcrm -m "$id" >/dev/null 2>&1 || true
+  done
+}
+
+sweep_orphan_shm
+
+if [ ! -d "$DATA_DIR" ]; then
+  initdb -D "$DATA_DIR" -U postgres --auth=trust -E UTF8 >/dev/null
+fi
+
+trap 'pg_ctl -D "$DATA_DIR" -m fast stop >/dev/null 2>&1 || true' EXIT INT TERM
+
+# unix_socket_directories는 짧은 고정 경로로 — scratchpad 등 긴 경로는 유닉스 소켓 경로
+# 103바이트 상한(macOS)을 넘겨 기동 자체가 실패한다(story #3199 재현 시 실제로 걸림).
+pg_ctl -D "$DATA_DIR" -o "-p $PORT -c unix_socket_directories=/tmp" -l "$DATA_DIR/log.txt" start
+
+echo "disposable PG ready — postgresql://postgres@127.0.0.1:$PORT/postgres (data=$DATA_DIR)"
+
+if [ $# -gt 0 ]; then
+  set +e
+  "$@"
+  code=$?
+  set -e
+  exit "$code"
+fi
+
+echo "Ctrl-C 또는 SIGTERM으로 종료하면 자동 stop(shm 반납)."
+while true; do sleep 3600; done

--- a/backend/scripts/disposable_pg.sh
+++ b/backend/scripts/disposable_pg.sh
@@ -6,23 +6,38 @@
 # 무관하게 클러스터당 SysV 세그 1개(소형 인터록용)를 항상 추가로 잡기 때문 — 그 1개가
 # 32/32 saturation에 걸리면 mmap 여부와 무관하게 ENOSPC.
 #
-# 기동 전 이 호스트의 "죽은 disposable PG 잔재" shm 세그를 non-root ipcrm으로 스윕한다.
-# 판별은 추정이 아니라 실물 대조: PG postmaster는 자기 SysV 세그의 key/shmid를
-# postmaster.pid 7번째 줄에 스스로 기록하므로(PG≥10 표준 포맷, 같은 uid라 읽기 가능),
-# 그걸로 살아있는 클러스터를 실물 확認해 제외하고 나머지만 지운다. IPC_RMID는 마지막
-# detach 후 파괴라(POSIX 표준 동작) 혹시 살아있는 세그를 잘못 걸어도 attach 중인
-# 프로세스는 안 죽는다 — 죽는 건 nattch=0 고아뿐.
+# 카디르 QA(PR#3616 head cd21e1794) HIGH 2건 반영:
+#   ①세션 모드가 foreground `sleep 3600`으로 signal을 최악 1시간 잡아두던 것 — 이 스크립트가
+#     막으려는 바로 그 "종료 trap 지연" 결함을 자기가 재생산하고 있었다. 백그라운드 sleep+
+#     `wait`(bash에서 트랩된 시그널에 즉시 인터럽트됨)+INT/TERM 트랩이 명시 exit하는 구조로
+#     교체 — EXIT 트랩(cleanup)이 그 exit로 인해 정확히 한 번만 실행된다.
+#   ②이전 주석 "attach 중인 프로세스는 안 죽는다"는 절반만 정직했다 — IPC_RMID는 이미
+#     attach된 프로세스는 안 죽이지만, **그 순간부터 그 세그에 대한 신규 attach를 전부
+#     막는다.** 즉 무고한 live 세그를 잘못 걸면 "죽지는 않되 새 커넥션(새 backend attach)이
+#     그때부터 실패하기 시작"하는 실질 피해가 있다 — 그래서 스윕을 **평시엔 절대 안 돈다**로
+#     좁혔다: 먼저 정상 기동을 시도하고, initdb/pg_ctl start가 shm 관련 사유로 실패했을
+#     때만(로그에서 shmget/ENOSPC 시그니처 확인) 스윕 후 1회 재시도한다 — 무고한 세그를
+#     건드리는 창 자체가 "포화로 실제 실패했을 때"로만 좁혀진다.
+#
+# 기동 전이 아니라 **실패 시에만** 이 호스트의 "죽은 disposable PG 잔재" shm 세그를
+# non-root ipcrm으로 스윕한다. 판별은 추정이 아니라 실물 대조: PG postmaster는 자기 SysV
+# 세그의 key/shmid를 postmaster.pid 7번째 줄에 스스로 기록하므로(PG≥10 표준 포맷, 같은
+# uid라 읽기 가능), 그걸로 살아있는 클러스터를 실물 확認해 제외하고 나머지만 지운다.
 #
 # live 클러스터 탐색은 well-known 경로 추정(brew 경로 등)이 아니라 **실행 중인 postmaster
 # 전수**로 한다 — 이 스토리의 발단 자체가 «두 저자 동형 재현»(병행 세션)이라, 다른 세션이
 # 임의 data-dir에서 띄운 disposable PG도 실사용 경로다(페드루 QA 지적, PR#3616). `ps`로
 # `postgres -D <dir>` 커맨드라인 전부를 찾아 그 dir들의 postmaster.pid를 전부 읽는다 —
-# brew 경로는 이 일반 스캔에 자연히 흡수되어 더 이상 특례가 아니다.
+# brew 경로는 이 일반 스캔에 자연히 흡수되어 더 이상 특례가 아니다. 실제 제거 직전에도 이
+# live 목록을 한 번 더 재수집해(1차 스냅샷~제거 사이 TOCTOU 창을 좁힘) 그 사이 새로 뜬
+# 병행 세션까지 반영한다.
+#
 # 못 잡는 것(선언): ⓐ다른 uid가 띄운 PG — 그 postmaster.pid를 못 읽지만, 같은 이유로
-# 커널이 그 uid의 shm을 ipcrm으로부터도 막아주므로 안전(EPERM, 스윕에서 조용히 스킵).
-# ⓑ같은 uid의 PG 아닌 SysV 사용자(다른 도구가 shm을 쓰는 경우) — 이건 진짜 미탐지 리스크.
-# ⓒ data-dir 경로에 공백이 들어가면 `-D` 파싱(sed)이 그 지점에서 끊긴다 — disposable
-# 리그 관례상 실경로엔 공백이 없어 지금은 무해하나, 공백 포함 경로를 쓰게 되면 재점검 필요.
+# 커널이 그 uid의 shm을 ipcrm으로부터도 막아주므로 안전(EPERM, 스윕에서 조용히 스킵 —
+# EPERM 외의 ipcrm 실패는 조용히 삼키지 않고 stderr로 낸다). ⓑ같은 uid의 PG 아닌 SysV
+# 사용자(다른 도구가 shm을 쓰는 경우) — 이건 진짜 미탐지 리스크. ⓒ data-dir 경로에
+# 공백이 들어가면 `-D` 파싱(sed)이 그 지점에서 끊긴다 — disposable 리그 관례상 실경로엔
+# 공백이 없어 지금은 무해하나, 공백 포함 경로를 쓰게 되면 재점검 필요.
 #
 # 사용:
 #   backend/scripts/disposable_pg.sh <data-dir> <port>              # 세션 모드(Ctrl-C까지 유지)
@@ -60,30 +75,79 @@ _live_shmids() {
   done < <(ps -axwwo command 2>/dev/null | grep -E '/postgres( |$)' | grep -F ' -D ')
 }
 
+_id_in() {
+  # $1=id, $2=목록(개행 구분 문자열 하나)
+  local id="$1" list="$2" found
+  while read -r found; do
+    [ -n "$found" ] && [ "$id" = "$found" ] && return 0
+  done <<<"$list"
+  return 1
+}
+
 sweep_orphan_shm() {
-  local live_ids id skip found
+  local live_ids id candidates=()
+  # 1차 스냅샷으로 후보(비-live로 보이는 세그)만 추린다 — 아직 아무것도 안 지움.
   live_ids="$(_live_shmids)"
-  ipcs -m 2>/dev/null | awk '/^m/ {print $2}' | while read -r id; do
-    skip=0
-    while read -r found; do
-      [ -n "$found" ] && [ "$id" = "$found" ] && skip=1 && break
-    done <<<"$live_ids"
-    [ "$skip" = 1 ] && continue
-    ipcrm -m "$id" >/dev/null 2>&1 || true
+  while read -r id; do
+    [ -n "$id" ] || continue
+    _id_in "$id" "$live_ids" || candidates+=("$id")
+  done < <(ipcs -m 2>/dev/null | awk '/^m/ {print $2}')
+
+  [ "${#candidates[@]}" -eq 0 ] && return 0
+
+  # 실 제거 직전 live 목록을 한 번 더 재수집 — 1차 스냅샷~지금 사이 새로 뜬 병행 세션(다른
+  # 저자 세션 등)을 반영해 TOCTOU 창을 좁힌다.
+  live_ids="$(_live_shmids)"
+  local err rc
+  for id in "${candidates[@]}"; do
+    _id_in "$id" "$live_ids" && continue
+    if ! err="$(ipcrm -m "$id" 2>&1 >/dev/null)"; then
+      rc=$?
+      if ! grep -qiE 'not permitted|permission denied' <<<"$err"; then
+        echo "ipcrm -m $id 실패(rc=$rc, EPERM 아님): $err" >&2
+      fi
+    fi
   done
 }
 
-sweep_orphan_shm
+cleanup() {
+  pg_ctl -D "$DATA_DIR" -m fast stop >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+_shm_failure_signature() {
+  grep -qiE 'shmget|no space left on device' "$1" 2>/dev/null
+}
 
 if [ ! -d "$DATA_DIR" ]; then
-  initdb -D "$DATA_DIR" -U postgres --auth=trust -E UTF8 >/dev/null
+  if ! _initdb_out="$(initdb -D "$DATA_DIR" -U postgres --auth=trust -E UTF8 2>&1)"; then
+    if grep -qiE 'shmget|no space left on device' <<<"$_initdb_out"; then
+      sweep_orphan_shm
+      initdb -D "$DATA_DIR" -U postgres --auth=trust -E UTF8 >/dev/null
+    else
+      echo "$_initdb_out" >&2
+      exit 1
+    fi
+  fi
 fi
-
-trap 'pg_ctl -D "$DATA_DIR" -m fast stop >/dev/null 2>&1 || true' EXIT INT TERM
 
 # unix_socket_directories는 짧은 고정 경로로 — scratchpad 등 긴 경로는 유닉스 소켓 경로
 # 103바이트 상한(macOS)을 넘겨 기동 자체가 실패한다(story #3199 재현 시 실제로 걸림).
-pg_ctl -D "$DATA_DIR" -o "-p $PORT -c unix_socket_directories=/tmp" -l "$DATA_DIR/log.txt" start
+_start_pg() {
+  pg_ctl -D "$DATA_DIR" -o "-p $PORT -c unix_socket_directories=/tmp" -l "$DATA_DIR/log.txt" start
+}
+
+if ! _start_pg; then
+  if _shm_failure_signature "$DATA_DIR/log.txt"; then
+    sweep_orphan_shm
+    _start_pg
+  else
+    echo "disposable PG 기동 실패(shm 무관 사유) — $DATA_DIR/log.txt 확認하는" >&2
+    exit 1
+  fi
+fi
 
 echo "disposable PG ready — postgresql://postgres@127.0.0.1:$PORT/postgres (data=$DATA_DIR)"
 
@@ -96,4 +160,7 @@ if [ $# -gt 0 ]; then
 fi
 
 echo "Ctrl-C 또는 SIGTERM으로 종료하면 자동 stop(shm 반납)."
-while true; do sleep 3600; done
+while true; do
+  sleep 3600 &
+  wait $!
+done

--- a/backend/tests/test_3199_disposable_pg_shm_sweep.py
+++ b/backend/tests/test_3199_disposable_pg_shm_sweep.py
@@ -195,6 +195,36 @@ def test_start_failure_unrelated_to_shm_does_not_trigger_sweep(fake_env):
     assert not fake_env["log"].exists() or fake_env["log"].read_text().strip() == ""
 
 
+def test_stale_shmget_line_from_prior_attempt_does_not_permanently_trigger_sweep(fake_env):
+    """카디르 QA 3라운드 지적(PR#3616 head eeb2f6926) — `pg_ctl -l`은 append라, data-dir를
+    재사용하는 이전 시도의 shmget 흔적이 로그에 영구히 남으면 「이번 시도가 shm 실패인가」가
+    아니라 「이 파일에 그런 적 있었나」를 재게 된다. 옛 흔적을 미리 심어두고, 이번 실패는
+    완전히 무관한 사유(포트 충돌)로 만들어 스윕이 잘못 발동하지 않아야 함을 고정 —
+    카디르 재현 시나리오 그대로."""
+    (fake_env["data_dir"] / "log.txt").write_text(
+        "FATAL:  could not create shared memory segment: shmget(...) failed: "
+        "No space left on device\n"
+    )
+    _make_stub(fake_env["tmp_path"] / "bin" / "pg_ctl", """
+args=("$@")
+for a in "${args[@]}"; do [ "$a" = "stop" ] && exit 0; done
+logfile=""
+prev=""
+for a in "${args[@]}"; do
+  if [ "$prev" = "-l" ]; then logfile="$a"; fi
+  prev="$a"
+done
+echo "FATAL:  could not bind IPv4 address: Address already in use" >> "$logfile"
+exit 1
+""")
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999", "--", "true"],
+        env=fake_env["env"], capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode != 0
+    assert not fake_env["log"].exists() or fake_env["log"].read_text().strip() == ""
+
+
 def test_one_shot_mode_runs_command_and_propagates_exit_code(fake_env):
     """`-- <command>` 원샷 모드 — 명령의 종료코드를 그대로 반환한다."""
     result = subprocess.run(

--- a/backend/tests/test_3199_disposable_pg_shm_sweep.py
+++ b/backend/tests/test_3199_disposable_pg_shm_sweep.py
@@ -27,8 +27,10 @@ def _make_stub(path: Path, body: str) -> None:
 
 @pytest.fixture
 def fake_env(tmp_path):
-    """ipcs -m이 live(1001)+orphan(2002,3003) 3개 세그를 보고하는 가짜 호스트.
-    live postmaster.pid는 1001을 자기 shmid로 자체 기록(7번째 줄, PG 실물 포맷)."""
+    """ipcs -m이 live(1001, 자기 data-dir)+병행 세션 live(4004, **다른** data-dir·PR#3616
+    카디르 QA 지적 축)+orphan(2002,3003) 4개 세그를 보고하는 가짜 호스트. 각 live
+    postmaster.pid는 자기 shmid를 7번째 줄에 자체 기록(PG 실물 포맷). ps -axwwo command도
+    스텁해 "well-known 경로 추정이 아니라 실행 중인 postmaster 전수 스캔"을 그대로 태운다."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log = tmp_path / "ipcrm_calls.log"
@@ -39,6 +41,7 @@ if [ "$1" = "-m" ]; then
   echo "T     ID     KEY        MODE       OWNER    GROUP"
   echo "Shared Memory:"
   echo "m 1001 0x00000000 --rw------- fakeuser  fakeuser"
+  echo "m 4004 0x33333333 --rw------- fakeuser  fakeuser"
   echo "m 2002 0x11111111 --rw------- fakeuser  fakeuser"
   echo "m 3003 0x22222222 --rw------- fakeuser  fakeuser"
 fi
@@ -61,13 +64,33 @@ exit 0
         "12345\n/fake/data\n1700000000\n55999\n/tmp\nlocalhost\n 999999     1001\nready\n"
     )
 
+    # 병행 저자 세션(예: 미르코 리그·다른 data-dir) 시뮬레이션 — well-known 경로가 아닌
+    # 임의 위치, 다른 shmid(4004).
+    other_data_dir = tmp_path / "other-session-data"
+    other_data_dir.mkdir()
+    (other_data_dir / "postmaster.pid").write_text(
+        "22222\n/fake/other\n1700000001\n55440\n/tmp\nlocalhost\n 888888     4004\nready\n"
+    )
+
+    # ps -axwwo command 스텁 — 두 live 클러스터의 postmaster 커맨드라인만 보고한다
+    # (checkpointer 등 워커 프로세스는 -D가 없어 실제로도 이 grep에 안 걸림 — 재현 안 함).
+    _make_stub(bin_dir / "ps", f"""
+if [ "$1" = "-axwwo" ]; then
+  echo "/usr/local/bin/postgres -D {data_dir}"
+  echo "/usr/local/bin/postgres -D {other_data_dir}"
+fi
+""")
+
     env = dict(os.environ)
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
-    return {"env": env, "data_dir": data_dir, "log": log, "tmp_path": tmp_path}
+    return {
+        "env": env, "data_dir": data_dir, "other_data_dir": other_data_dir,
+        "log": log, "tmp_path": tmp_path,
+    }
 
 
 def test_sweep_removes_orphans_but_excludes_live_shmid(fake_env):
-    """live(1001, postmaster.pid 실물 기록)는 ipcrm 대상에서 빠지고 orphan(2002·3003)만
+    """live(1001, 자기 postmaster.pid 실물 기록)는 ipcrm 대상에서 빠지고 orphan(2002·3003)만
     지워진다 — postmaster.pid 판별이 실제로 작동함을 고정."""
     result = subprocess.run(
         ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999", "--", "true"],
@@ -76,6 +99,24 @@ def test_sweep_removes_orphans_but_excludes_live_shmid(fake_env):
     assert result.returncode == 0, result.stderr
 
     removed_ids = fake_env["log"].read_text().split()
+    assert "1001" not in removed_ids
+    assert "2002" in removed_ids
+    assert "3003" in removed_ids
+
+
+def test_sweep_excludes_concurrent_session_in_unrelated_data_dir(fake_env):
+    """PR#3616 카디르 QA 지적(진짜 블로커) — 병행 저자 세션이 well-known 경로가 아닌
+    임의 data-dir(4004)에서 띄운 live PG도 실행 중인 postmaster 전수 스캔(ps)으로 잡혀
+    스윕에서 제외돼야 한다. 이 스토리의 발단 자체가 «두 저자 동형 재현»이라 병행은
+    실사용 경로 — well-known 경로 추정으로 회귀하면 다른 세션의 DB를 침범한다."""
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999", "--", "true"],
+        env=fake_env["env"], capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+
+    removed_ids = fake_env["log"].read_text().split()
+    assert "4004" not in removed_ids
     assert "1001" not in removed_ids
     assert "2002" in removed_ids
     assert "3003" in removed_ids

--- a/backend/tests/test_3199_disposable_pg_shm_sweep.py
+++ b/backend/tests/test_3199_disposable_pg_shm_sweep.py
@@ -1,18 +1,27 @@
 """story #3199 — macOS 호스트 SysV shm(kern.sysv.shmmni=32 기본값) saturation으로 disposable
 PG 반복 기동이 막히던 문제(미르코·저자 세션 동형 재현, ipcs -m 32/32). 정리 루틴
 scripts/disposable_pg.sh의 스윕 로직 pin — 실 SysV IPC/실 PG는 건드리지 않는다(macOS
-전용·호스트 상태 의존이라 CI 러너에서 그대로 못 돌림). ipcs/ipcrm/pg_ctl/postgres를 전부
-가짜 실행파일로 스텁해 "살아있는 클러스터(postmaster.pid 7번째 줄 실물 대조)만 제외하고
-나머지 shm만 ipcrm된다"는 로직 자체를 고정한다.
+전용·호스트 상태 의존이라 CI 러너에서 그대로 못 돌림). ipcs/ipcrm/pg_ctl/postgres/ps를
+전부 가짜 실행파일로 스텁한다.
 
-판별(story 본문): 저자 세션에서 disposable PG 1회 기동+realdb 1건 실행 재현 —
-이건 이 스크립트로 실물 재현 완료(수동 검증, 이 pytest는 로직 회귀가드).
+카디르 QA(PR#3616 head cd21e1794) HIGH 2건 반영 후의 pin:
+  ① 세션 모드 signal 프롬프트니스 — foreground `sleep 3600`이 SIGTERM을 1시간 잡아두던
+    결함을 백그라운드 sleep+wait+명시 exit 트랩으로 고쳤다. 실 하위프로세스로 스크립트를
+    띄우고 SIGTERM을 보내 초 단위로 종료됨을 시간으로 잰다.
+  ② lazy-sweep — 스윕은 이제 "평시"엔 절대 안 돌고, pg_ctl start/initdb가 shm 관련
+    사유로 실패했을 때만(로그 시그니처) 돈다. pg_ctl 스텁을 "1차 실패(shmget 로그)+2차
+    성공"으로 만들어 이 재시도 경로를 정확히 태운다 — 정상 기동(1차 성공)일 땐 ipcrm이
+    한 번도 안 불림을 별도로 pin.
+
+판별(story 본문): 저자 세션에서 disposable PG 1회 기동+realdb 1건 실행 재현 — 이건 이
+스크립트로 실물 재현 완료(수동 검증, 이 pytest는 로직 회귀가드).
 """
 from __future__ import annotations
 
 import os
 import stat
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -25,17 +34,50 @@ def _make_stub(path: Path, body: str) -> None:
     path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
 
+def _pg_ctl_stub_body(fail_marker: Path, extra_shm_error: bool) -> str:
+    """pg_ctl 스텁 — start는 fail_marker 파일이 없으면 1회 "shmget 실패"로 로그를 남기고
+    실패, 있으면(=재시도) 성공. stop은 항상 성공(no-op)."""
+    shm_line = (
+        'echo "FATAL:  could not create shared memory segment: shmget(...) failed: '
+        'No space left on device" >> "$logfile"' if extra_shm_error else 'true'
+    )
+    return f"""
+args=("$@")
+is_stop=0
+for a in "${{args[@]}}"; do [ "$a" = "stop" ] && is_stop=1; done
+if [ "$is_stop" = 1 ]; then
+  exit 0
+fi
+logfile=""
+prev=""
+for a in "${{args[@]}}"; do
+  if [ "$prev" = "-l" ]; then logfile="$a"; fi
+  prev="$a"
+done
+if [ ! -f "{fail_marker}" ]; then
+  touch "{fail_marker}"
+  {shm_line}
+  exit 1
+fi
+echo "server started"
+exit 0
+"""
+
+
 @pytest.fixture
-def fake_env(tmp_path):
-    """ipcs -m이 live(1001, 자기 data-dir)+병행 세션 live(4004, **다른** data-dir·PR#3616
-    카디르 QA 지적 축)+orphan(2002,3003) 4개 세그를 보고하는 가짜 호스트. 각 live
-    postmaster.pid는 자기 shmid를 7번째 줄에 자체 기록(PG 실물 포맷). ps -axwwo command도
-    스텁해 "well-known 경로 추정이 아니라 실행 중인 postmaster 전수 스캔"을 그대로 태운다."""
+def fake_env(tmp_path, request):
+    """ipcs -m이 live(1001, 자기 data-dir)+병행 세션 live(4004, 다른 data-dir)+
+    orphan(2002,3003) 4개 세그를 보고하는 가짜 호스트. pg_ctl start는 기본적으로 1차
+    "shmget 실패" 후 2차 성공(재시도 경로가 항상 태워짐) — `always_succeed` 마커로 1차부터
+    바로 성공하는 변형도 만든다(평시=스윕 0회 확인용)."""
+    always_succeed = getattr(request, "param", False)
+
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log = tmp_path / "ipcrm_calls.log"
+    fail_marker = tmp_path / "pg_ctl_attempted"
 
-    _make_stub(bin_dir / "ipcs", f"""
+    _make_stub(bin_dir / "ipcs", """
 if [ "$1" = "-m" ]; then
   echo "IPC status from <fake> as of now"
   echo "T     ID     KEY        MODE       OWNER    GROUP"
@@ -50,32 +92,34 @@ fi
 echo "$@" >> {log}
 exit 0
 """)
-    # pg_ctl start/stop 둘 다 no-op — 이 테스트는 스윕 로직만 pin.
-    _make_stub(bin_dir / "pg_ctl", """
-echo "pg_ctl $@ (stub, no-op)"
+    if always_succeed:
+        _make_stub(bin_dir / "pg_ctl", """
+args=("$@")
+for a in "${args[@]}"; do [ "$a" = "stop" ] && exit 0; done
+echo "server started"
 exit 0
 """)
+    else:
+        _make_stub(bin_dir / "pg_ctl", _pg_ctl_stub_body(fail_marker, extra_shm_error=True))
     _make_stub(bin_dir / "postgres", "exit 0")
+    _make_stub(bin_dir / "initdb", "exit 0")
 
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    # PG postmaster.pid 실물 포맷(7줄) — 7번째 줄이 "key shmid", shmid=1001이 live.
     (data_dir / "postmaster.pid").write_text(
         "12345\n/fake/data\n1700000000\n55999\n/tmp\nlocalhost\n 999999     1001\nready\n"
     )
 
-    # 병행 저자 세션(예: 미르코 리그·다른 data-dir) 시뮬레이션 — well-known 경로가 아닌
-    # 임의 위치, 다른 shmid(4004).
     other_data_dir = tmp_path / "other-session-data"
     other_data_dir.mkdir()
     (other_data_dir / "postmaster.pid").write_text(
         "22222\n/fake/other\n1700000001\n55440\n/tmp\nlocalhost\n 888888     4004\nready\n"
     )
 
-    # ps -axwwo command 스텁 — 두 live 클러스터의 postmaster 커맨드라인만 보고한다
-    # (checkpointer 등 워커 프로세스는 -D가 없어 실제로도 이 grep에 안 걸림 — 재현 안 함).
+    ps_calls = tmp_path / "ps_calls.log"
     _make_stub(bin_dir / "ps", f"""
 if [ "$1" = "-axwwo" ]; then
+  echo x >> {ps_calls}
   echo "/usr/local/bin/postgres -D {data_dir}"
   echo "/usr/local/bin/postgres -D {other_data_dir}"
 fi
@@ -85,30 +129,13 @@ fi
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
     return {
         "env": env, "data_dir": data_dir, "other_data_dir": other_data_dir,
-        "log": log, "tmp_path": tmp_path,
+        "log": log, "ps_calls": ps_calls, "tmp_path": tmp_path,
     }
 
 
-def test_sweep_removes_orphans_but_excludes_live_shmid(fake_env):
-    """live(1001, 자기 postmaster.pid 실물 기록)는 ipcrm 대상에서 빠지고 orphan(2002·3003)만
-    지워진다 — postmaster.pid 판별이 실제로 작동함을 고정."""
-    result = subprocess.run(
-        ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999", "--", "true"],
-        env=fake_env["env"], capture_output=True, text=True, timeout=10,
-    )
-    assert result.returncode == 0, result.stderr
-
-    removed_ids = fake_env["log"].read_text().split()
-    assert "1001" not in removed_ids
-    assert "2002" in removed_ids
-    assert "3003" in removed_ids
-
-
-def test_sweep_excludes_concurrent_session_in_unrelated_data_dir(fake_env):
-    """PR#3616 카디르 QA 지적(진짜 블로커) — 병행 저자 세션이 well-known 경로가 아닌
-    임의 data-dir(4004)에서 띄운 live PG도 실행 중인 postmaster 전수 스캔(ps)으로 잡혀
-    스윕에서 제외돼야 한다. 이 스토리의 발단 자체가 «두 저자 동형 재현»이라 병행은
-    실사용 경로 — well-known 경로 추정으로 회귀하면 다른 세션의 DB를 침범한다."""
+def test_sweep_excludes_live_and_concurrent_session_removes_only_orphans(fake_env):
+    """재시도(1차 shmget 실패→스윕→2차 성공) 경로에서 live(1001)와 병행 세션 live(4004,
+    PR#3616 카디르 QA 지적 축)는 빠지고 orphan(2002·3003)만 지워진다."""
     result = subprocess.run(
         ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999", "--", "true"],
         env=fake_env["env"], capture_output=True, text=True, timeout=10,
@@ -122,9 +149,37 @@ def test_sweep_excludes_concurrent_session_in_unrelated_data_dir(fake_env):
     assert "3003" in removed_ids
 
 
+@pytest.mark.parametrize("fake_env", [True], indirect=True)
+def test_lazy_sweep_never_runs_when_start_succeeds_on_first_try(fake_env):
+    """카디르 QA HIGH② — 평시(첫 시도 성공)엔 스윕이 아예 안 돈다. 무고한 세그를 건드리는
+    창이 «포화로 실제 실패했을 때»로만 좁혀졌음을 고정."""
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999", "--", "true"],
+        env=fake_env["env"], capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    assert not fake_env["log"].exists() or fake_env["log"].read_text().strip() == ""
+
+
+def test_start_failure_unrelated_to_shm_does_not_trigger_sweep(fake_env):
+    """shm 시그니처가 없는 실패(예: 권한 문제)는 스윕을 트리거하지 않고 그대로 에러
+    전파한다 — shm 무관 실패까지 스윕으로 덮어 진짜 원인을 가리지 않는다."""
+    non_shm_fail = _pg_ctl_stub_body(fake_env["tmp_path"] / "never-touched", extra_shm_error=False)
+    _make_stub(fake_env["tmp_path"] / "bin" / "pg_ctl", non_shm_fail.replace(
+        "No space left on device", "").replace(
+        'echo "FATAL:  could not create shared memory segment: shmget(...) failed: " >> "$logfile"',
+        'echo "FATAL:  data directory has invalid permissions" >> "$logfile"',
+    ))
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999", "--", "true"],
+        env=fake_env["env"], capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode != 0
+    assert not fake_env["log"].exists() or fake_env["log"].read_text().strip() == ""
+
+
 def test_one_shot_mode_runs_command_and_propagates_exit_code(fake_env):
-    """`-- <command>` 원샷 모드 — 명령의 종료코드를 그대로 반환한다(트랩이 그 값을 삼키지
-    않음, story 본문 «disposable PG 1회 기동+realdb 1건 실행» 판별의 배선 축)."""
+    """`-- <command>` 원샷 모드 — 명령의 종료코드를 그대로 반환한다."""
     result = subprocess.run(
         ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999", "--", "bash", "-c", "exit 7"],
         env=fake_env["env"], capture_output=True, text=True, timeout=10,
@@ -136,3 +191,35 @@ def test_missing_args_usage_error():
     result = subprocess.run(["bash", str(SCRIPT)], capture_output=True, text=True, timeout=10)
     assert result.returncode == 2
     assert "usage" in result.stderr
+
+
+@pytest.mark.parametrize("fake_env", [True], indirect=True)
+def test_session_mode_terminates_promptly_on_sigterm_not_after_full_sleep(fake_env):
+    """카디르 QA HIGH① — 세션 모드(원샷 아님)에서 SIGTERM을 보내면 foreground
+    `sleep 3600` 전체를 기다리지 않고 수 초 내로 종료돼야 한다(백그라운드 sleep+wait는
+    트랩된 시그널에 즉시 인터럽트됨). 이 스크립트 자신이 막으려는 "종료 trap 지연"
+    결함을 재생산하지 않는지가 핵심."""
+    proc = subprocess.Popen(
+        ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999"],
+        env=fake_env["env"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    try:
+        # "disposable PG ready" 라인이 뜰 때까지(세션 모드 진입 확認) 짧게 폴링.
+        deadline = time.monotonic() + 5
+        ready = False
+        while time.monotonic() < deadline:
+            line = proc.stdout.readline()
+            if "ready" in line:
+                ready = True
+                break
+        assert ready, "session mode did not report ready in time"
+
+        start = time.monotonic()
+        proc.terminate()  # SIGTERM
+        proc.wait(timeout=5)
+        elapsed = time.monotonic() - start
+        assert elapsed < 5, f"SIGTERM took {elapsed:.2f}s — sleep 3600이 여전히 signal을 막는 중"
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)

--- a/backend/tests/test_3199_disposable_pg_shm_sweep.py
+++ b/backend/tests/test_3199_disposable_pg_shm_sweep.py
@@ -149,6 +149,23 @@ def test_sweep_excludes_live_and_concurrent_session_removes_only_orphans(fake_en
     assert "3003" in removed_ids
 
 
+def test_ipcrm_failure_reports_real_exit_code_not_zero(fake_env):
+    """페드루 코스메틱 지적(PR#3616 재QA) — `if ! err=$(...); then rc=$?`는 `!`가 이미
+    부정한 뒤라 그 안의 $?가 항상 0을 찍던 버그. ipcrm이 EPERM 아닌 사유(예: 42)로
+    실패하면 stderr의 «rc=»가 실제 종료코드를 찍어야 한다(0 아님)."""
+    _make_stub(fake_env["tmp_path"] / "bin" / "ipcrm", """
+echo "device or resource busy (fake non-EPERM failure)" >&2
+exit 42
+""")
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999", "--", "true"],
+        env=fake_env["env"], capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "rc=42" in result.stderr, result.stderr
+    assert "rc=0" not in result.stderr
+
+
 @pytest.mark.parametrize("fake_env", [True], indirect=True)
 def test_lazy_sweep_never_runs_when_start_succeeds_on_first_try(fake_env):
     """카디르 QA HIGH② — 평시(첫 시도 성공)엔 스윕이 아예 안 돈다. 무고한 세그를 건드리는

--- a/backend/tests/test_3199_disposable_pg_shm_sweep.py
+++ b/backend/tests/test_3199_disposable_pg_shm_sweep.py
@@ -1,0 +1,97 @@
+"""story #3199 — macOS 호스트 SysV shm(kern.sysv.shmmni=32 기본값) saturation으로 disposable
+PG 반복 기동이 막히던 문제(미르코·저자 세션 동형 재현, ipcs -m 32/32). 정리 루틴
+scripts/disposable_pg.sh의 스윕 로직 pin — 실 SysV IPC/실 PG는 건드리지 않는다(macOS
+전용·호스트 상태 의존이라 CI 러너에서 그대로 못 돌림). ipcs/ipcrm/pg_ctl/postgres를 전부
+가짜 실행파일로 스텁해 "살아있는 클러스터(postmaster.pid 7번째 줄 실물 대조)만 제외하고
+나머지 shm만 ipcrm된다"는 로직 자체를 고정한다.
+
+판별(story 본문): 저자 세션에서 disposable PG 1회 기동+realdb 1건 실행 재현 —
+이건 이 스크립트로 실물 재현 완료(수동 검증, 이 pytest는 로직 회귀가드).
+"""
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "disposable_pg.sh"
+
+
+def _make_stub(path: Path, body: str) -> None:
+    path.write_text(f"#!/usr/bin/env bash\n{body}\n")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+@pytest.fixture
+def fake_env(tmp_path):
+    """ipcs -m이 live(1001)+orphan(2002,3003) 3개 세그를 보고하는 가짜 호스트.
+    live postmaster.pid는 1001을 자기 shmid로 자체 기록(7번째 줄, PG 실물 포맷)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "ipcrm_calls.log"
+
+    _make_stub(bin_dir / "ipcs", f"""
+if [ "$1" = "-m" ]; then
+  echo "IPC status from <fake> as of now"
+  echo "T     ID     KEY        MODE       OWNER    GROUP"
+  echo "Shared Memory:"
+  echo "m 1001 0x00000000 --rw------- fakeuser  fakeuser"
+  echo "m 2002 0x11111111 --rw------- fakeuser  fakeuser"
+  echo "m 3003 0x22222222 --rw------- fakeuser  fakeuser"
+fi
+""")
+    _make_stub(bin_dir / "ipcrm", f"""
+echo "$@" >> {log}
+exit 0
+""")
+    # pg_ctl start/stop 둘 다 no-op — 이 테스트는 스윕 로직만 pin.
+    _make_stub(bin_dir / "pg_ctl", """
+echo "pg_ctl $@ (stub, no-op)"
+exit 0
+""")
+    _make_stub(bin_dir / "postgres", "exit 0")
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    # PG postmaster.pid 실물 포맷(7줄) — 7번째 줄이 "key shmid", shmid=1001이 live.
+    (data_dir / "postmaster.pid").write_text(
+        "12345\n/fake/data\n1700000000\n55999\n/tmp\nlocalhost\n 999999     1001\nready\n"
+    )
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    return {"env": env, "data_dir": data_dir, "log": log, "tmp_path": tmp_path}
+
+
+def test_sweep_removes_orphans_but_excludes_live_shmid(fake_env):
+    """live(1001, postmaster.pid 실물 기록)는 ipcrm 대상에서 빠지고 orphan(2002·3003)만
+    지워진다 — postmaster.pid 판별이 실제로 작동함을 고정."""
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999", "--", "true"],
+        env=fake_env["env"], capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+
+    removed_ids = fake_env["log"].read_text().split()
+    assert "1001" not in removed_ids
+    assert "2002" in removed_ids
+    assert "3003" in removed_ids
+
+
+def test_one_shot_mode_runs_command_and_propagates_exit_code(fake_env):
+    """`-- <command>` 원샷 모드 — 명령의 종료코드를 그대로 반환한다(트랩이 그 값을 삼키지
+    않음, story 본문 «disposable PG 1회 기동+realdb 1건 실행» 판별의 배선 축)."""
+    result = subprocess.run(
+        ["bash", str(SCRIPT), str(fake_env["data_dir"]), "55999", "--", "bash", "-c", "exit 7"],
+        env=fake_env["env"], capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 7
+
+
+def test_missing_args_usage_error():
+    result = subprocess.run(["bash", str(SCRIPT)], capture_output=True, text=True, timeout=10)
+    assert result.returncode == 2
+    assert "usage" in result.stderr


### PR DESCRIPTION
[SID:3199]

## 원인
macOS 호스트 SysV shm(`kern.sysv.shmmni=32`, 시스템 전체 상한)이 종료 trap
없이 죽은 disposable PG들의 인터록 세그 누적으로 saturate — 저자 세션에서
정확히 32/32로 재현(`ipcs -m`). `-c shared_memory_type=mmap`으로도 안
풀리는 이유: PG≥9.3은 그 설정과 무관하게 클러스터당 소형 SysV 세그 1개를
항상 잡는다(메인 shared buffers는 mmap이어도, 인터록용 1개는 SysV 고정).

## 처방 — root 불요 정리 루틴(페드루 제안 설계)
`ipcrm`은 uid 소유 세그면 non-root로 제거 가능. "죽은 잔재 vs 살아있는
클러스터"를 추정이 아니라 실물로 가른다 — PG postmaster는 자기 SysV
세그의 key/shmid를 `postmaster.pid` 7번째 줄에 스스로 기록(PG≥10 표준
포맷, 같은 uid라 non-root로 읽힘). `scripts/disposable_pg.sh`는 기동 전
이 실물 대조로 live만 제외하고 나머지 orphan을 스윕, 종료(EXIT/INT/TERM)
trap으로 자기 세그도 항상 반납.

안전 근거: `IPC_RMID`는 마지막 detach 후 파괴(POSIX 표준)라 혹시 살아있는
세그를 잘못 걸어도 attach 중인 프로세스는 안 죽는다 — 즉시 죽는 건
nattch=0 고아뿐.

## 판별(story 본문 그대로 실측)
저자 세션: 32/32 saturated → 스윕 → 1/32(live 홈브류 PG@16만 잔존) →
disposable PG 정상 기동(`initdb`/`pg_ctl start` ENOSPC 없음) → `alembic
upgrade head`(0292) → realdb 테스트(`test_3208_artifact_preview_cross_project_realdb.py`)
3건 통과 → 정상 stop으로 shm 반납, live PG는 전 구간 건강(`select 1` 계속
성공). 재발 시나리오도 검증: 새 disposable PG를 `SIGKILL`로 강제로 죽여
orphan 세그를 인위 생성 → 다음 실행이 정확히 그 orphan만 스윕하고 live는
그대로 보존함을 확인.

## Test plan
- [x] `pytest tests/test_3199_disposable_pg_shm_sweep.py` — ipcs/ipcrm/pg_ctl
  스텁으로 스윕 로직(live 제외·orphan만 제거) 및 원샷 모드 종료코드 전파 pin
  (3 passed)
- [x] 뮤테이션 주입(live-제외 분기 제거) → RED 확인 후 정확히 원복
- [x] `lint_no_script_output_artifacts.py` / `lint_dependency_override_get_read_db.py` 신규 위반 0건
- [x] 저자 세션 실물 재현(위 판별) — macOS 로컬 전용이라 CI는 로직만 pin