### PR TITLE
[SID:3195] 온보딩 1/4 입력값 이메일 인증 왕복 소실 fix + 미인증 선제 고지

### DIFF
--- a/apps/web/src/app/api/auth/me/route.test.ts
+++ b/apps/web/src/app/api/auth/me/route.test.ts
@@ -1,0 +1,70 @@
+// story #3195 — 카디르 QA 치명(PR#3617): 이전엔 onboarding-form.tsx/verify-email/page.tsx가
+// `/api/me`(BE me.py::get_me, TeamMember 필수)를 불렀는데, 그 회로가 겨냥하는 "무 org"
+// 상태에선 BE가 404를 내 email_verified/org_id를 전혀 못 읽었다 — FE 테스트는 fetch를
+// 모듈째 mock해 이 실경로(route.ts → proxyToFastapi → BE) 자체를 안 지나가서 못 잡혔다
+// (PR#3605와 동형 "실경로 미도달" 클래스). 이 파일은 fastapi-proxy.test.ts/PR#3605
+// route.test.ts와 동형 패턴 — getServerSession+global.fetch만 mock하고 route의 GET을
+// 직접 호출해 실제 프록시 코드 경로(→ /api/v2/auth/me)를 지나며 "실경로 도달"을 증명한다.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getServerSessionMock } = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+}));
+vi.mock('@/lib/db/server', () => ({ getServerSession: getServerSessionMock }));
+
+import { GET } from './route';
+
+describe('/api/auth/me — 실경로 계약(story #3195, 카디르 QA)', () => {
+  beforeEach(() => {
+    getServerSessionMock.mockReset();
+    getServerSessionMock.mockResolvedValue({ access_token: 'token-1' });
+  });
+
+  it('BE(/api/v2/auth/me)를 호출하고 응답을 단일래핑 {data: ...}로 반환한다', async () => {
+    const beBody = { member_id: 'm-1', org_id: null, project_id: null, email_verified: false };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toContain('/api/v2/auth/me');
+      return new Response(JSON.stringify(beBody), { status: 200 });
+    });
+    global.fetch = fetchMock;
+
+    const res = await GET(new Request('http://localhost/api/auth/me'));
+    const json = await res.json();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(json.data).toEqual(beBody);
+    expect(json.error).toBeNull();
+  });
+
+  it('무 org(=이 스토리가 겨냥하는 온보딩 1/4 상태) — BE가 org_id:null·email_verified 실값으로 200 낸다(404 아님)', async () => {
+    // BE app.routers.auth.get_auth_me는 JWT claims만 읽어 TeamMember/org 유무와 무관하게
+    // 항상 200을 낸다(me.py::get_me와 달리) — 여기서는 그 계약을 FE 라우트가 그대로
+    // 통과시키는지만 증명한다(BE 자체 핸들러 로직은 backend/tests/test_3195_*.py 소관).
+    global.fetch = vi.fn(async () => new Response(
+      JSON.stringify({ member_id: 'm-1', org_id: null, project_id: null, email_verified: true }),
+      { status: 200 },
+    ));
+
+    const res = await GET(new Request('http://localhost/api/auth/me'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.org_id).toBeNull();
+    expect(json.data.email_verified).toBe(true);
+  });
+
+  it('세션 없음 — BE 호출 없이 401', async () => {
+    getServerSessionMock.mockResolvedValue(null);
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock;
+
+    const res = await GET(new Request('http://localhost/api/auth/me'));
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('BE 에러(500)를 그대로 전달한다(삼키지 않음)', async () => {
+    global.fetch = vi.fn(async () => new Response('boom', { status: 500 }));
+    const res = await GET(new Request('http://localhost/api/auth/me'));
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/src/app/api/auth/me/route.ts
+++ b/apps/web/src/app/api/auth/me/route.ts
@@ -1,0 +1,19 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+/** story #3195 — BE app.routers.auth.get_auth_me(AuthMeResponse)를 서빙. `/api/me`
+ * (BE `me.py::get_me`, TeamMember 필수)와 달리 JWT claims만으로 응답해 org/TeamMember가
+ * 없어도(=온보딩 1/4 진행 중인 유저) 200을 낸다 — email_verified·org_id를 org-less
+ * 컨텍스트에서도 신뢰성 있게 읽어야 하는 소비처(onboarding-form.tsx·verify-email/page.tsx)
+ * 전용 경로. `/api/me`는 그대로(다른 소비처들의 org/project-scoped 계약 무변경). */
+export async function GET(request: Request) {
+  try {
+    const res = await proxyToFastapi(request, '/api/v2/auth/me');
+    if (!res.ok) return res;
+    const data: unknown = await res.json();
+    return apiSuccess(data);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/app/onboarding/onboarding-form.org-step-persist.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.org-step-persist.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+//
+// story #3195(온보딩·FE) — 이메일 인증 왕복(가입 → 1/4 입력 → EMAIL_VERIFICATION_REQUIRED
+// 400 → 메일함 링크 → verify-email → 「시작하기」 복귀)이 풀 페이지 네비게이션이라
+// OnboardingForm이 통째로 리마운트돼 orgName/orgSlug가 사라졌다(재입력 강요). AC1: 왕복
+// 후 복귀 시 1/4 입력값이 sessionStorage draft로 보존돼 있다. AC2: 미인증 상태 안내가
+// 제출 전에(마운트 시 /api/me.email_verified===false로) 보인다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { OnboardingForm } from './onboarding-form';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const DRAFT_KEY = 'sp_onboarding_org_draft';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap() {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <OnboardingForm />
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  sessionStorage.clear();
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  sessionStorage.clear();
+});
+
+function mockFetchDefault(overrides: Record<string, () => Promise<unknown>> = {}) {
+  return vi.fn(async (url: string) => {
+    if (url in overrides) return overrides[url]!();
+    if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) } as Response;
+    if (url === '/api/me') return { ok: true, json: async () => ({ data: {} }) } as Response;
+    throw new Error('unexpected fetch: ' + url);
+  });
+}
+
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+function setNativeValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('OnboardingForm — 1/4 입력값 sessionStorage draft 영속(story #3195 AC1)', () => {
+  it('조직명 입력 시 draft가 sessionStorage에 저장된다', async () => {
+    vi.stubGlobal('fetch', mockFetchDefault());
+    await act(async () => { root.render(wrap()); });
+    await flush();
+
+    const nameInput = container.querySelector('input') as HTMLInputElement;
+    await act(async () => { setNativeValue(nameInput, '새싹상회'); });
+
+    const raw = sessionStorage.getItem(DRAFT_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!) as { orgName: string; orgSlug: string };
+    expect(parsed.orgName).toBe('새싹상회');
+  });
+
+  it('재마운트(=인증 왕복 시뮬레이션) 시 draft가 복원돼 재입력을 요구하지 않는다', async () => {
+    sessionStorage.setItem(DRAFT_KEY, JSON.stringify({ orgName: '새싹상회', orgSlug: 'saessak-shop' }));
+    vi.stubGlobal('fetch', mockFetchDefault());
+    await act(async () => { root.render(wrap()); });
+    await flush();
+
+    const nameInput = container.querySelector('input') as HTMLInputElement;
+    expect(nameInput.value).toBe('새싹상회');
+    const inputs = container.querySelectorAll('input');
+    expect((inputs[1] as HTMLInputElement).value).toBe('saessak-shop');
+  });
+
+  it('조직 생성 성공 시 draft를 지운다(더는 필요 없어짐)', async () => {
+    vi.stubGlobal('fetch', mockFetchDefault({
+      '/api/organizations': async () => ({ ok: true, json: async () => ({ data: { id: 'org-1' } }) }),
+      '/api/auth/refresh': async () => ({ ok: true, json: async () => ({}) }),
+    }));
+    await act(async () => { root.render(wrap()); });
+    await flush();
+
+    const inputs = container.querySelectorAll('input');
+    await act(async () => { setNativeValue(inputs[0] as HTMLInputElement, 'New Org'); });
+    expect(sessionStorage.getItem(DRAFT_KEY)).toBeTruthy();
+
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => /조직 만들기/.test(b.textContent ?? '')) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(false);
+    await act(async () => { submitBtn.click(); });
+    await flush();
+
+    expect(sessionStorage.getItem(DRAFT_KEY)).toBeNull();
+  });
+
+  it('EMAIL_VERIFICATION_REQUIRED로 실패해도 draft는 그대로 남는다(왕복 중 소실 금지)', async () => {
+    vi.stubGlobal('fetch', mockFetchDefault({
+      '/api/organizations': async () => ({
+        ok: false, status: 403,
+        json: async () => ({ error: { code: 'EMAIL_VERIFICATION_REQUIRED', message: 'x' } }),
+      }),
+    }));
+    await act(async () => { root.render(wrap()); });
+    await flush();
+
+    const inputs = container.querySelectorAll('input');
+    await act(async () => { setNativeValue(inputs[0] as HTMLInputElement, 'New Org'); });
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => /조직 만들기/.test(b.textContent ?? '')) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(false);
+    await act(async () => { submitBtn.click(); });
+    await flush();
+
+    expect(sessionStorage.getItem(DRAFT_KEY)).toBeTruthy();
+  });
+});
+
+describe('OnboardingForm — 미인증 선제 고지(story #3195 AC2)', () => {
+  it('/api/me.email_verified===false면 제출 前(마운트 시)부터 안내+재전송 버튼이 보인다', async () => {
+    vi.stubGlobal('fetch', mockFetchDefault({
+      '/api/me': async () => ({ ok: true, json: async () => ({ data: { email_verified: false } }) }),
+    }));
+    await act(async () => { root.render(wrap()); });
+    await flush();
+
+    const resendBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '인증 메일 재전송');
+    expect(resendBtn).toBeTruthy();
+    // 아직 제출(조직 만들기)을 누르지 않았다 — 배너가 마운트 시점부터 선제로 떴다는 증거.
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => /조직 만들기/.test(b.textContent ?? ''));
+    expect(submitBtn).toBeTruthy();
+  });
+
+  it('/api/me.email_verified===true면 선제 고지가 안 뜬다(회귀 없음)', async () => {
+    vi.stubGlobal('fetch', mockFetchDefault({
+      '/api/me': async () => ({ ok: true, json: async () => ({ data: { email_verified: true } }) }),
+    }));
+    await act(async () => { root.render(wrap()); });
+    await flush();
+
+    const resendBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '인증 메일 재전송');
+    expect(resendBtn).toBeUndefined();
+  });
+
+  it('/api/me.email_verified===null(판정 불가)이면 안내가 안 뜬다 — 제출 시 400 분기가 안전망으로 남는다', async () => {
+    vi.stubGlobal('fetch', mockFetchDefault({
+      '/api/me': async () => ({ ok: true, json: async () => ({ data: { email_verified: null } }) }),
+    }));
+    await act(async () => { root.render(wrap()); });
+    await flush();
+
+    const resendBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '인증 메일 재전송');
+    expect(resendBtn).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/onboarding/onboarding-form.org-step-persist.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.org-step-persist.test.tsx
@@ -4,7 +4,17 @@
 // 400 → 메일함 링크 → verify-email → 「시작하기」 복귀)이 풀 페이지 네비게이션이라
 // OnboardingForm이 통째로 리마운트돼 orgName/orgSlug가 사라졌다(재입력 강요). AC1: 왕복
 // 후 복귀 시 1/4 입력값이 sessionStorage draft로 보존돼 있다. AC2: 미인증 상태 안내가
-// 제출 전에(마운트 시 /api/me.email_verified===false로) 보인다.
+// 제출 전에(마운트 시 /api/auth/me.email_verified===false로) 보인다.
+//
+// 카디르 QA(PR#3617) 치명 — `/api/me`가 실제로 서빙하는 BE(me.py::get_me, TeamMember
+// 필수)는 이 스토리가 겨냥하는 "무 org" 상태에서 404라 email_verified/org_id를 못 읽는다
+// (mock 테스트는 실경로를 안 지나 이 갭을 못 잡았음 — PR#3605와 동형 클래스). `/api/auth/
+// me`(BFF 신설, BE app.routers.auth.get_auth_me — JWT claims만 읽어 org 유무 무관 항상
+// 200)로 교체 — 이 파일의 모든 mock도 그 응답 shape(member_id 포함)로 갱신한다.
+//
+// codex MED(같은 QA 라운드) — draft 키가 계정-무관 고정 문자열이면 같은 탭 계정 전환 시
+// 前 계정 입력이 새 계정 화면에 샌다. member_id로 키잉(uid 확定 後 별도 effect에서
+// 복원/저장)해 계정마다 분리한다 — 아래 "계정간 격리" describe가 그 pin.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
@@ -14,7 +24,9 @@ import koMessages from '../../../messages/ko.json';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-const DRAFT_KEY = 'sp_onboarding_org_draft';
+const DRAFT_PREFIX = 'sp_onboarding_org_draft:';
+const UID_A = 'user-aaa';
+const UID_B = 'user-bbb';
 
 let container: HTMLDivElement;
 let root: Root;
@@ -41,11 +53,13 @@ afterEach(async () => {
   sessionStorage.clear();
 });
 
-function mockFetchDefault(overrides: Record<string, () => Promise<unknown>> = {}) {
+function mockFetchDefault(uid: string, overrides: Record<string, () => Promise<unknown>> = {}) {
   return vi.fn(async (url: string) => {
     if (url in overrides) return overrides[url]!();
     if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) } as Response;
-    if (url === '/api/me') return { ok: true, json: async () => ({ data: {} }) } as Response;
+    if (url === '/api/auth/me') {
+      return { ok: true, json: async () => ({ data: { member_id: uid, org_id: null, email_verified: true } }) } as Response;
+    }
     throw new Error('unexpected fetch: ' + url);
   });
 }
@@ -61,23 +75,24 @@ function setNativeValue(el: HTMLInputElement, value: string) {
 }
 
 describe('OnboardingForm — 1/4 입력값 sessionStorage draft 영속(story #3195 AC1)', () => {
-  it('조직명 입력 시 draft가 sessionStorage에 저장된다', async () => {
-    vi.stubGlobal('fetch', mockFetchDefault());
+  it('조직명 입력 시 draft가 uid 키로 sessionStorage에 저장된다', async () => {
+    vi.stubGlobal('fetch', mockFetchDefault(UID_A));
     await act(async () => { root.render(wrap()); });
     await flush();
 
     const nameInput = container.querySelector('input') as HTMLInputElement;
     await act(async () => { setNativeValue(nameInput, '새싹상회'); });
+    await flush();
 
-    const raw = sessionStorage.getItem(DRAFT_KEY);
+    const raw = sessionStorage.getItem(DRAFT_PREFIX + UID_A);
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!) as { orgName: string; orgSlug: string };
     expect(parsed.orgName).toBe('새싹상회');
   });
 
-  it('재마운트(=인증 왕복 시뮬레이션) 시 draft가 복원돼 재입력을 요구하지 않는다', async () => {
-    sessionStorage.setItem(DRAFT_KEY, JSON.stringify({ orgName: '새싹상회', orgSlug: 'saessak-shop' }));
-    vi.stubGlobal('fetch', mockFetchDefault());
+  it('재마운트(=인증 왕복 시뮬레이션) 시 같은 uid의 draft가 복원돼 재입력을 요구하지 않는다', async () => {
+    sessionStorage.setItem(DRAFT_PREFIX + UID_A, JSON.stringify({ orgName: '새싹상회', orgSlug: 'saessak-shop' }));
+    vi.stubGlobal('fetch', mockFetchDefault(UID_A));
     await act(async () => { root.render(wrap()); });
     await flush();
 
@@ -88,7 +103,7 @@ describe('OnboardingForm — 1/4 입력값 sessionStorage draft 영속(story #31
   });
 
   it('조직 생성 성공 시 draft를 지운다(더는 필요 없어짐)', async () => {
-    vi.stubGlobal('fetch', mockFetchDefault({
+    vi.stubGlobal('fetch', mockFetchDefault(UID_A, {
       '/api/organizations': async () => ({ ok: true, json: async () => ({ data: { id: 'org-1' } }) }),
       '/api/auth/refresh': async () => ({ ok: true, json: async () => ({}) }),
     }));
@@ -97,18 +112,19 @@ describe('OnboardingForm — 1/4 입력값 sessionStorage draft 영속(story #31
 
     const inputs = container.querySelectorAll('input');
     await act(async () => { setNativeValue(inputs[0] as HTMLInputElement, 'New Org'); });
-    expect(sessionStorage.getItem(DRAFT_KEY)).toBeTruthy();
+    await flush();
+    expect(sessionStorage.getItem(DRAFT_PREFIX + UID_A)).toBeTruthy();
 
     const submitBtn = [...container.querySelectorAll('button')].find((b) => /조직 만들기/.test(b.textContent ?? '')) as HTMLButtonElement;
     expect(submitBtn.disabled).toBe(false);
     await act(async () => { submitBtn.click(); });
     await flush();
 
-    expect(sessionStorage.getItem(DRAFT_KEY)).toBeNull();
+    expect(sessionStorage.getItem(DRAFT_PREFIX + UID_A)).toBeNull();
   });
 
   it('EMAIL_VERIFICATION_REQUIRED로 실패해도 draft는 그대로 남는다(왕복 중 소실 금지)', async () => {
-    vi.stubGlobal('fetch', mockFetchDefault({
+    vi.stubGlobal('fetch', mockFetchDefault(UID_A, {
       '/api/organizations': async () => ({
         ok: false, status: 403,
         json: async () => ({ error: { code: 'EMAIL_VERIFICATION_REQUIRED', message: 'x' } }),
@@ -119,19 +135,51 @@ describe('OnboardingForm — 1/4 입력값 sessionStorage draft 영속(story #31
 
     const inputs = container.querySelectorAll('input');
     await act(async () => { setNativeValue(inputs[0] as HTMLInputElement, 'New Org'); });
+    await flush();
     const submitBtn = [...container.querySelectorAll('button')].find((b) => /조직 만들기/.test(b.textContent ?? '')) as HTMLButtonElement;
     expect(submitBtn.disabled).toBe(false);
     await act(async () => { submitBtn.click(); });
     await flush();
 
-    expect(sessionStorage.getItem(DRAFT_KEY)).toBeTruthy();
+    expect(sessionStorage.getItem(DRAFT_PREFIX + UID_A)).toBeTruthy();
+  });
+});
+
+describe('OnboardingForm — 계정간 draft 격리(codex MED, PR#3617)', () => {
+  it('A 계정의 draft가 sessionStorage에 있어도, B 계정으로 마운트하면 B 화면엔 안 새 나간다', async () => {
+    sessionStorage.setItem(DRAFT_PREFIX + UID_A, JSON.stringify({ orgName: '유출되면안됨', orgSlug: 'leak' }));
+    vi.stubGlobal('fetch', mockFetchDefault(UID_B));
+    await act(async () => { root.render(wrap()); });
+    await flush();
+
+    const nameInput = container.querySelector('input') as HTMLInputElement;
+    expect(nameInput.value).toBe('');
+    expect(container.textContent).not.toContain('유출되면안됨');
+    // A의 draft 자체는 훼손 없이 그대로 남아있다(B 세션이 A 슬롯을 안 건드림).
+    expect(sessionStorage.getItem(DRAFT_PREFIX + UID_A)).toBeTruthy();
+  });
+
+  it('B 계정이 타이핑하면 B 전용 키(uid 분리)로 저장되고 A 슬롯은 안 바뀐다', async () => {
+    sessionStorage.setItem(DRAFT_PREFIX + UID_A, JSON.stringify({ orgName: 'A의 값', orgSlug: 'a-org' }));
+    vi.stubGlobal('fetch', mockFetchDefault(UID_B));
+    await act(async () => { root.render(wrap()); });
+    await flush();
+
+    const nameInput = container.querySelector('input') as HTMLInputElement;
+    await act(async () => { setNativeValue(nameInput, 'B의 값'); });
+    await flush();
+
+    const draftA = JSON.parse(sessionStorage.getItem(DRAFT_PREFIX + UID_A)!) as { orgName: string };
+    expect(draftA.orgName).toBe('A의 값');
+    const draftB = JSON.parse(sessionStorage.getItem(DRAFT_PREFIX + UID_B)!) as { orgName: string };
+    expect(draftB.orgName).toBe('B의 값');
   });
 });
 
 describe('OnboardingForm — 미인증 선제 고지(story #3195 AC2)', () => {
-  it('/api/me.email_verified===false면 제출 前(마운트 시)부터 안내+재전송 버튼이 보인다', async () => {
-    vi.stubGlobal('fetch', mockFetchDefault({
-      '/api/me': async () => ({ ok: true, json: async () => ({ data: { email_verified: false } }) }),
+  it('/api/auth/me.email_verified===false면 제출 前(마운트 시)부터 안내+재전송 버튼이 보인다', async () => {
+    vi.stubGlobal('fetch', mockFetchDefault(UID_A, {
+      '/api/auth/me': async () => ({ ok: true, json: async () => ({ data: { member_id: UID_A, org_id: null, email_verified: false } }) }),
     }));
     await act(async () => { root.render(wrap()); });
     await flush();
@@ -143,9 +191,18 @@ describe('OnboardingForm — 미인증 선제 고지(story #3195 AC2)', () => {
     expect(submitBtn).toBeTruthy();
   });
 
-  it('/api/me.email_verified===true면 선제 고지가 안 뜬다(회귀 없음)', async () => {
-    vi.stubGlobal('fetch', mockFetchDefault({
-      '/api/me': async () => ({ ok: true, json: async () => ({ data: { email_verified: true } }) }),
+  it('/api/auth/me.email_verified===true면 선제 고지가 안 뜬다(회귀 없음)', async () => {
+    vi.stubGlobal('fetch', mockFetchDefault(UID_A));
+    await act(async () => { root.render(wrap()); });
+    await flush();
+
+    const resendBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '인증 메일 재전송');
+    expect(resendBtn).toBeUndefined();
+  });
+
+  it('/api/auth/me.email_verified===null(판정 불가)이면 안내가 안 뜬다 — 제출 시 400 분기가 안전망으로 남는다', async () => {
+    vi.stubGlobal('fetch', mockFetchDefault(UID_A, {
+      '/api/auth/me': async () => ({ ok: true, json: async () => ({ data: { member_id: UID_A, org_id: null, email_verified: null } }) }),
     }));
     await act(async () => { root.render(wrap()); });
     await flush();
@@ -154,14 +211,16 @@ describe('OnboardingForm — 미인증 선제 고지(story #3195 AC2)', () => {
     expect(resendBtn).toBeUndefined();
   });
 
-  it('/api/me.email_verified===null(판정 불가)이면 안내가 안 뜬다 — 제출 시 400 분기가 안전망으로 남는다', async () => {
-    vi.stubGlobal('fetch', mockFetchDefault({
-      '/api/me': async () => ({ ok: true, json: async () => ({ data: { email_verified: null } }) }),
+  it('/api/auth/me가 404여도(구 /api/me였다면 무 org에서 이랬을 상황) 크래시 없이 조용히 폴백한다', async () => {
+    vi.stubGlobal('fetch', mockFetchDefault(UID_A, {
+      '/api/auth/me': async () => ({ ok: false, status: 404, json: async () => ({ error: { code: 'NOT_FOUND' } }) }),
     }));
     await act(async () => { root.render(wrap()); });
     await flush();
 
     const resendBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '인증 메일 재전송');
     expect(resendBtn).toBeUndefined();
+    // 폼 자체는 정상 — 크래시 없음(조직명 입력창이 여전히 존재).
+    expect(container.querySelector('input')).toBeTruthy();
   });
 });

--- a/apps/web/src/app/onboarding/onboarding-form.org-step-persist.test.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.org-step-persist.test.tsx
@@ -145,6 +145,42 @@ describe('OnboardingForm — 1/4 입력값 sessionStorage draft 영속(story #31
   });
 });
 
+describe('OnboardingForm — identityResolved 前 입력 게이팅(유나 design:changes, PR#3617)', () => {
+  it('/api/auth/me 미해소 동안 조직명·슬러그 입력이 disabled — 빈 값이 순간이라도 안 채워지는 깜빡임 방지', async () => {
+    let resolveMe!: (v: { ok: true; json: () => Promise<unknown> }) => void;
+    const mePromise = new Promise<{ ok: true; json: () => Promise<unknown> }>((r) => { resolveMe = r; });
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/auth/me') return mePromise;
+      if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) } as Response;
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap()); });
+
+    const inputs = container.querySelectorAll('input');
+    expect((inputs[0] as HTMLInputElement).disabled).toBe(true);
+    expect((inputs[1] as HTMLInputElement).disabled).toBe(true);
+
+    await act(async () => {
+      resolveMe({ ok: true, json: async () => ({ data: { member_id: UID_A, org_id: null, email_verified: true } }) });
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+
+    expect((container.querySelectorAll('input')[0] as HTMLInputElement).disabled).toBe(false);
+  });
+
+  it('/api/auth/me 조회 실패해도 게이팅이 영영 안 풀리는 게 아니라 해제된다(폼 영구 잠김 방지)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/auth/me') throw new Error('network down');
+      if (url === '/api/onboarding/events') return { ok: true, json: async () => ({}) } as Response;
+      throw new Error('unexpected fetch: ' + url);
+    }));
+    await act(async () => { root.render(wrap()); });
+    await flush();
+
+    expect((container.querySelectorAll('input')[0] as HTMLInputElement).disabled).toBe(false);
+  });
+});
+
 describe('OnboardingForm — 계정간 draft 격리(codex MED, PR#3617)', () => {
   it('A 계정의 draft가 sessionStorage에 있어도, B 계정으로 마운트하면 B 화면엔 안 새 나간다', async () => {
     sessionStorage.setItem(DRAFT_PREFIX + UID_A, JSON.stringify({ orgName: '유출되면안됨', orgSlug: 'leak' }));

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -15,12 +15,18 @@ import { emitOnboardingEvent } from './onboarding-telemetry';
 // 같은 탭 내 네비게이션 전체에서 살아남는다(탭을 아예 새로 열면 못 살리는 게 정상 — 메일
 // 클라이언트가 링크를 새 탭에서 열어도 verify-email 자체 접근엔 로그인 세션만 있으면 되고,
 // 왕복 자체가 "같은 탭"이어야 이 값이 필요한 시나리오라 sessionStorage로 충분하다).
-const ORG_DRAFT_STORAGE_KEY = 'sp_onboarding_org_draft';
+//
+// 카디르 QA(PR#3617) codex MED — 키가 고정 문자열이면 같은 탭에서 계정 전환(로그아웃→
+// 다른 계정 로그인) 시 前 계정이 타이핑한 값이 새 계정 온보딩 화면에 그대로 새 나간다.
+// member_id(uid)로 키잉해 계정마다 별도 슬롯을 쓴다 — uid는 /api/auth/me 응답이 와야
+// 알 수 있어(비동기) 초기 렌더 시점엔 아직 복원 못 하고, uid 확정 後 별도 effect에서
+// 복원한다(아래 참고).
+const ORG_DRAFT_STORAGE_PREFIX = 'sp_onboarding_org_draft:';
 
-function loadOrgDraft(): { orgName: string; orgSlug: string } | null {
-  if (typeof window === 'undefined') return null; // SSR — 이 lazy initializer가 서버에서도 한 번 돈다.
+function loadOrgDraft(uid: string): { orgName: string; orgSlug: string } | null {
+  if (typeof window === 'undefined') return null;
   try {
-    const raw = sessionStorage.getItem(ORG_DRAFT_STORAGE_KEY);
+    const raw = sessionStorage.getItem(ORG_DRAFT_STORAGE_PREFIX + uid);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as { orgName?: unknown; orgSlug?: unknown };
     if (typeof parsed.orgName !== 'string' || typeof parsed.orgSlug !== 'string') return null;
@@ -30,17 +36,18 @@ function loadOrgDraft(): { orgName: string; orgSlug: string } | null {
   }
 }
 
-function saveOrgDraft(orgName: string, orgSlug: string): void {
+function saveOrgDraft(uid: string, orgName: string, orgSlug: string): void {
   try {
-    if (!orgName && !orgSlug) { sessionStorage.removeItem(ORG_DRAFT_STORAGE_KEY); return; }
-    sessionStorage.setItem(ORG_DRAFT_STORAGE_KEY, JSON.stringify({ orgName, orgSlug }));
+    const key = ORG_DRAFT_STORAGE_PREFIX + uid;
+    if (!orgName && !orgSlug) { sessionStorage.removeItem(key); return; }
+    sessionStorage.setItem(key, JSON.stringify({ orgName, orgSlug }));
   } catch {
     // 시크릿 모드 등 sessionStorage 차단 — 이 스토리 前과 동일(비영속) 동작으로 조용히 저하.
   }
 }
 
-function clearOrgDraft(): void {
-  try { sessionStorage.removeItem(ORG_DRAFT_STORAGE_KEY); } catch { /* no-op */ }
+function clearOrgDraft(uid: string): void {
+  try { sessionStorage.removeItem(ORG_DRAFT_STORAGE_PREFIX + uid); } catch { /* no-op */ }
 }
 
 const AGENT_ROLES = ['developer', 'designer', 'pm', 'qa', 'devops'];
@@ -67,8 +74,10 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
   const t = useTranslations('onboarding');
 
   const [step, setStep] = useState<Step>(initialStep ?? 'org');
-  const [orgName, setOrgName] = useState(() => loadOrgDraft()?.orgName ?? '');
-  const [orgSlug, setOrgSlug] = useState(() => loadOrgDraft()?.orgSlug ?? '');
+  const [orgName, setOrgName] = useState('');
+  const [orgSlug, setOrgSlug] = useState('');
+  // story #3195 — draft 저장/복원 키는 uid가 확정돼야(=/api/auth/me 응답 後) 정해진다.
+  const [draftUid, setDraftUid] = useState<string | null>(null);
   const [projectName, setProjectName] = useState('');
   const [projectDesc, setProjectDesc] = useState('');
   const [orgId, setOrgId] = useState<string | null>(initialOrgId ?? null);
@@ -98,29 +107,45 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
     emitOnboardingEvent('onboarding_started');
   }, []);
 
-  // story #3195 — 매 키입력마다 draft 저장(디바운스 불요 — sessionStorage 쓰기는 로컬·저비용).
-  // org 단계를 이미 지났으면(step advance 후 재입력 없음) 더 쓸 이유가 없어 스킵.
-  useEffect(() => {
-    if (step !== 'org') return;
-    saveOrgDraft(orgName, orgSlug);
-  }, [step, orgName, orgSlug]);
-
-  // story #3195 AC2 — «이메일 인증 필요»를 제출(400) 前에 선제 고지. /api/me가 신설한
-  // email_verified가 명시 false일 때만 배너를 띄운다(true·null 둘 다 무표시 — null은 조회
-  // 실패/API키 컨텍스트로 판정 불가란 뜻이라, 이전처럼 "제출해봐야 아는" 폴백으로 자연스럽게
-  // 저하할 뿐 새로운 오탐을 만들지 않는다).
+  // story #3195 — org 단계 마운트 시 딱 1회, 신원(uid) + 미인증 여부를 함께 조회한다.
+  // 카디르 QA(PR#3617) 치명 — FE `/api/me`가 실제로 서빙하는 BE는 TeamMember 필수인
+  // `me.py::get_me()`라, 이 스토리가 겨냥하는 바로 그 "무 org" 상태에서 404가 나 email_
+  // verified·org_id 둘 다 못 읽었다(테스트는 mock이라 안 잡힘 — 3605와 동형 "실경로
+  // 미도달" 클래스). 대신 `/api/auth/me`(BFF 신설, BE app.routers.auth.get_auth_me)를
+  // 쓴다 — JWT claims만으로 응답해 TeamMember/무 org 여부와 무관하게 항상 200.
   useEffect(() => {
     if (step !== 'org') return;
     let cancelled = false;
-    fetchWithAuth('/api/me')
+    fetchWithAuth('/api/auth/me')
       .then((res) => (res.ok ? res.json() : null))
-      .then((json: { data?: { email_verified?: boolean | null } } | null) => {
+      .then((json: { data?: { member_id?: string; email_verified?: boolean | null } } | null) => {
         if (cancelled) return;
+        // AC2 — email_verified가 명시 false일 때만 배너를 띄운다(true·null 둘 다 무표시 —
+        // null은 조회 실패/판정 불가란 뜻이라, 이전처럼 "제출해봐야 아는" 폴백으로 자연스럽게
+        // 저하할 뿐 새로운 오탐을 만들지 않는다).
         if (json?.data?.email_verified === false) setEmailVerifyBlocked(true);
+
+        const uid = json?.data?.member_id;
+        if (!uid) return;
+        setDraftUid(uid);
+        // 유저가 이 응답을 기다리는 동안 이미 타이핑을 시작했으면(레이스) 덮어쓰지 않는다
+        // — 함수형 업데이트로 "지금 이 순간의" 실제 값을 보고 판단(클로저 stale 없음).
+        const draft = loadOrgDraft(uid);
+        if (!draft) return;
+        setOrgName((prev) => prev || draft.orgName);
+        setOrgSlug((prev) => prev || draft.orgSlug);
       })
-      .catch(() => { /* 조용히 폴백 — 제출 시 400 분기가 그대로 안전망 */ });
+      .catch(() => { /* 조용히 폴백 — 제출 시 400 분기가 그대로 안전망, draft 복원도 스킵 */ });
     return () => { cancelled = true; };
   }, [step]);
+
+  // story #3195 — 매 키입력마다 draft 저장(디바운스 불요 — sessionStorage 쓰기는 로컬·저비용).
+  // uid가 아직 안 잡혔으면(위 fetch 응답 前 짧은 창) 저장을 건너뛴다 — 계정-무관 키로 쓰면
+  // codex MED가 지적한 계정간 누수가 재발한다.
+  useEffect(() => {
+    if (step !== 'org' || !draftUid) return;
+    saveOrgDraft(draftUid, orgName, orgSlug);
+  }, [step, draftUid, orgName, orgSlug]);
 
   const handleOrgNameChange = (name: string) => {
     setOrgName(name);
@@ -189,7 +214,7 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
       setOrgId(json.data.id);
       // story #3195 — 조직 생성 성공(=이 값들이 이제 쓸모 없어짐) 시점에만 draft를 지운다.
       // 실패(EMAIL_VERIFICATION_REQUIRED 포함) 시엔 절대 안 지운다 — 왕복 중 그대로 살아야 함.
-      clearOrgDraft();
+      if (draftUid) clearOrgDraft(draftUid);
       // E-ONB S5 FINAL: org 생성 시 org_member가 최초 생성됨 → 즉시 토큰 refresh로
       // 새 JWT에 org_id(BE auth Path4 org_member fallback) 반영. 이래야 다음 단계 project 생성의
       // getAuthContext(/api/v2/me)가 통과한다(미refresh 시 fresh JWT엔 team_member 없어 me null → 401).

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -5,8 +5,43 @@ import { UpgradeModal } from '@/components/ui/upgrade-modal';
 import { Button } from '@/components/ui/button';
 import { OperatorInput, OperatorTextarea, OperatorSelect } from '@/components/ui/operator-control';
 import { useTranslations } from 'next-intl';
+import { fetchWithAuth } from '@/lib/db/client';
 import { ConnectStep } from './connect-step';
 import { emitOnboardingEvent } from './onboarding-telemetry';
+
+// story #3195 — 이메일 인증 왕복(가입 → 1/4 입력 → EMAIL_VERIFICATION_REQUIRED 400 →
+// 메일함에서 링크 클릭 → verify-email 페이지 → 「시작하기」로 복귀)이 풀 페이지 네비게이션이라
+// 이 컴포넌트가 통째로 리마운트돼 React state(orgName/orgSlug)가 사라졌다. sessionStorage는
+// 같은 탭 내 네비게이션 전체에서 살아남는다(탭을 아예 새로 열면 못 살리는 게 정상 — 메일
+// 클라이언트가 링크를 새 탭에서 열어도 verify-email 자체 접근엔 로그인 세션만 있으면 되고,
+// 왕복 자체가 "같은 탭"이어야 이 값이 필요한 시나리오라 sessionStorage로 충분하다).
+const ORG_DRAFT_STORAGE_KEY = 'sp_onboarding_org_draft';
+
+function loadOrgDraft(): { orgName: string; orgSlug: string } | null {
+  if (typeof window === 'undefined') return null; // SSR — 이 lazy initializer가 서버에서도 한 번 돈다.
+  try {
+    const raw = sessionStorage.getItem(ORG_DRAFT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { orgName?: unknown; orgSlug?: unknown };
+    if (typeof parsed.orgName !== 'string' || typeof parsed.orgSlug !== 'string') return null;
+    return { orgName: parsed.orgName, orgSlug: parsed.orgSlug };
+  } catch {
+    return null;
+  }
+}
+
+function saveOrgDraft(orgName: string, orgSlug: string): void {
+  try {
+    if (!orgName && !orgSlug) { sessionStorage.removeItem(ORG_DRAFT_STORAGE_KEY); return; }
+    sessionStorage.setItem(ORG_DRAFT_STORAGE_KEY, JSON.stringify({ orgName, orgSlug }));
+  } catch {
+    // 시크릿 모드 등 sessionStorage 차단 — 이 스토리 前과 동일(비영속) 동작으로 조용히 저하.
+  }
+}
+
+function clearOrgDraft(): void {
+  try { sessionStorage.removeItem(ORG_DRAFT_STORAGE_KEY); } catch { /* no-op */ }
+}
 
 const AGENT_ROLES = ['developer', 'designer', 'pm', 'qa', 'devops'];
 // story #3196 ⑥ — 값(BE role 필드, 영문 enum 그대로 무변경)과 표시 라벨을 분리. 예전엔
@@ -32,8 +67,8 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
   const t = useTranslations('onboarding');
 
   const [step, setStep] = useState<Step>(initialStep ?? 'org');
-  const [orgName, setOrgName] = useState('');
-  const [orgSlug, setOrgSlug] = useState('');
+  const [orgName, setOrgName] = useState(() => loadOrgDraft()?.orgName ?? '');
+  const [orgSlug, setOrgSlug] = useState(() => loadOrgDraft()?.orgSlug ?? '');
   const [projectName, setProjectName] = useState('');
   const [projectDesc, setProjectDesc] = useState('');
   const [orgId, setOrgId] = useState<string | null>(initialOrgId ?? null);
@@ -62,6 +97,30 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
   useEffect(() => {
     emitOnboardingEvent('onboarding_started');
   }, []);
+
+  // story #3195 — 매 키입력마다 draft 저장(디바운스 불요 — sessionStorage 쓰기는 로컬·저비용).
+  // org 단계를 이미 지났으면(step advance 후 재입력 없음) 더 쓸 이유가 없어 스킵.
+  useEffect(() => {
+    if (step !== 'org') return;
+    saveOrgDraft(orgName, orgSlug);
+  }, [step, orgName, orgSlug]);
+
+  // story #3195 AC2 — «이메일 인증 필요»를 제출(400) 前에 선제 고지. /api/me가 신설한
+  // email_verified가 명시 false일 때만 배너를 띄운다(true·null 둘 다 무표시 — null은 조회
+  // 실패/API키 컨텍스트로 판정 불가란 뜻이라, 이전처럼 "제출해봐야 아는" 폴백으로 자연스럽게
+  // 저하할 뿐 새로운 오탐을 만들지 않는다).
+  useEffect(() => {
+    if (step !== 'org') return;
+    let cancelled = false;
+    fetchWithAuth('/api/me')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json: { data?: { email_verified?: boolean | null } } | null) => {
+        if (cancelled) return;
+        if (json?.data?.email_verified === false) setEmailVerifyBlocked(true);
+      })
+      .catch(() => { /* 조용히 폴백 — 제출 시 400 분기가 그대로 안전망 */ });
+    return () => { cancelled = true; };
+  }, [step]);
 
   const handleOrgNameChange = (name: string) => {
     setOrgName(name);
@@ -128,6 +187,9 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
       }
 
       setOrgId(json.data.id);
+      // story #3195 — 조직 생성 성공(=이 값들이 이제 쓸모 없어짐) 시점에만 draft를 지운다.
+      // 실패(EMAIL_VERIFICATION_REQUIRED 포함) 시엔 절대 안 지운다 — 왕복 중 그대로 살아야 함.
+      clearOrgDraft();
       // E-ONB S5 FINAL: org 생성 시 org_member가 최초 생성됨 → 즉시 토큰 refresh로
       // 새 JWT에 org_id(BE auth Path4 org_member fallback) 반영. 이래야 다음 단계 project 생성의
       // getAuthContext(/api/v2/me)가 통과한다(미refresh 시 fresh JWT엔 team_member 없어 me null → 401).

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -78,6 +78,12 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
   const [orgSlug, setOrgSlug] = useState('');
   // story #3195 — draft 저장/복원 키는 uid가 확정돼야(=/api/auth/me 응답 後) 정해진다.
   const [draftUid, setDraftUid] = useState<string | null>(null);
+  // 유나 design:changes(PR#3617) — draft 복원이 post-mount effect라 응답 前엔 입력창이
+  // 항상 empty로 뜬 뒤 draft로 채워지는 깜빡임이 실측됐다("입력이 그대로 있다"는 인상이
+  // 이 스토리의 AC 자체). uid 해소(성공·실패 무관) 前까지 org 입력 2개를 게이팅해 빈
+  // 화면이 찍히는 순간 자체를 없앤다(PO 선택 ⓐ — lazy-init 무키 폴백(ⓑ)은 前 계정 draft가
+  // 잠깐 보일 위험이 있어 계정격리 축과 상충).
+  const [identityResolved, setIdentityResolved] = useState(false);
   const [projectName, setProjectName] = useState('');
   const [projectDesc, setProjectDesc] = useState('');
   const [orgId, setOrgId] = useState<string | null>(initialOrgId ?? null);
@@ -126,16 +132,22 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
         if (json?.data?.email_verified === false) setEmailVerifyBlocked(true);
 
         const uid = json?.data?.member_id;
-        if (!uid) return;
+        if (!uid) { setIdentityResolved(true); return; }
         setDraftUid(uid);
         // 유저가 이 응답을 기다리는 동안 이미 타이핑을 시작했으면(레이스) 덮어쓰지 않는다
         // — 함수형 업데이트로 "지금 이 순간의" 실제 값을 보고 판단(클로저 stale 없음).
         const draft = loadOrgDraft(uid);
-        if (!draft) return;
-        setOrgName((prev) => prev || draft.orgName);
-        setOrgSlug((prev) => prev || draft.orgSlug);
+        if (draft) {
+          setOrgName((prev) => prev || draft.orgName);
+          setOrgSlug((prev) => prev || draft.orgSlug);
+        }
+        setIdentityResolved(true);
       })
-      .catch(() => { /* 조용히 폴백 — 제출 시 400 분기가 그대로 안전망, draft 복원도 스킵 */ });
+      .catch(() => {
+        // 조용히 폴백 — 제출 시 400 분기가 그대로 안전망, draft 복원도 스킵. 실패해도
+        // 게이팅을 영영 풀지 않으면 폼 자체가 막히므로 반드시 resolved 처리한다.
+        if (!cancelled) setIdentityResolved(true);
+      });
     return () => { cancelled = true; };
   }, [step]);
 
@@ -443,6 +455,10 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
 
         {step === 'org' && (
           <div className="space-y-4">
+            {/* 유나 design:changes(PR#3617) — draft 복원(uid 확定 後 별도 effect)이 응답
+                前엔 항상 empty로 뜬 뒤 채워지는 깜빡임을 만들었다("입력이 그대로 있다"는
+                인상이 AC 자체). identityResolved 前까지 두 입력을 disabled로 게이팅해 그
+                순간 자체를 없앤다. */}
             <div className="space-y-1.5">
               <label className="text-sm font-medium text-foreground">{t('orgName')}</label>
               <OperatorInput
@@ -450,6 +466,7 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
                 value={orgName}
                 onChange={(e) => handleOrgNameChange(e.target.value)}
                 placeholder={t('orgNamePlaceholder')}
+                disabled={!identityResolved}
               />
             </div>
             <div className="space-y-1.5">
@@ -459,6 +476,7 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
                 value={orgSlug}
                 onChange={(e) => handleOrgSlugChange(e.target.value)}
                 placeholder={t('slugPlaceholder')}
+                disabled={!identityResolved}
               />
               {orgSlug && !slugValid ? (
                 // ⚠️Phase2 i18n·#2485 — 클라 측 정규식 검증 문구가 하드코딩 한국어다(t() 아님,

--- a/apps/web/src/app/verify-email/page.test.tsx
+++ b/apps/web/src/app/verify-email/page.test.tsx
@@ -8,8 +8,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
+const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn() }));
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: pushMock }),
   useSearchParams: () => new URLSearchParams('token=tok-1'),
 }));
 
@@ -29,6 +30,7 @@ afterEach(async () => {
   container.remove();
   vi.unstubAllGlobals();
   vi.resetModules();
+  pushMock.mockClear();
 });
 
 async function mountAndWait() {
@@ -81,5 +83,32 @@ describe('VerifyEmailPage — error.code 분기 (story #2484)', () => {
     await mountAndWait();
     expect(container.textContent).not.toContain('brand new raw string');
     expect(container.textContent).toContain('인증에 실패했습니다.');
+  });
+});
+
+// story #3195 — «시작하기»가 org 유무와 무관하게 항상 /inbox로 갔다. 온보딩 도중(org
+// 미생성) 이메일 인증 벽에 걸린 유저는 org가 없어 /inbox가 막다른 곳이었다.
+describe('VerifyEmailPage — 「시작하기」 목적지가 org_id 유무로 갈린다(story #3195)', () => {
+  function mockFetchByUrl(orgId: string | null) {
+    return vi.fn(async (url: string) => {
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: { org_id: orgId } }) };
+      return { json: async () => ({ data: { message: 'Email verified successfully' } }) };
+    });
+  }
+
+  it('org_id 있음 — 「시작하기」가 /inbox로 이동', async () => {
+    vi.stubGlobal('fetch', mockFetchByUrl('org-1'));
+    await mountAndWait();
+    const startBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '시작하기');
+    await act(async () => { startBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(pushMock).toHaveBeenCalledWith('/inbox');
+  });
+
+  it('org_id 없음(온보딩 미완주) — 「시작하기」가 /onboarding으로 이동(전엔 /inbox 막다른 곳)', async () => {
+    vi.stubGlobal('fetch', mockFetchByUrl(null));
+    await mountAndWait();
+    const startBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '시작하기');
+    await act(async () => { startBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(pushMock).toHaveBeenCalledWith('/onboarding');
   });
 });

--- a/apps/web/src/app/verify-email/page.test.tsx
+++ b/apps/web/src/app/verify-email/page.test.tsx
@@ -111,4 +111,28 @@ describe('VerifyEmailPage — 「시작하기」 목적지가 org_id 유무로 �
     await act(async () => { startBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(pushMock).toHaveBeenCalledWith('/onboarding');
   });
+
+  // 유나 design:pass 비차단 ①(2026-08-29) — /api/me 응답 前 빠른 클릭 레이스. 이전엔
+  // useState 기본값(/inbox)이 그대로 나가 no-org 유저가 막다른 곳으로 갔다. 지금은 클릭이
+  // 판정을 "기다렸다" 라우팅해야 한다.
+  it('/api/me 응답 前 클릭해도(레이스) — 응답 도착 후 올바른 목적지(/onboarding)로 이동한다', async () => {
+    let resolveMe!: (v: { ok: true; json: () => Promise<unknown> }) => void;
+    const mePromise = new Promise<{ ok: true; json: () => Promise<unknown> }>((r) => { resolveMe = r; });
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/me') return mePromise;
+      return { json: async () => ({ data: { message: 'Email verified successfully' } }) };
+    }));
+    await mountAndWait();
+
+    const startBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '시작하기');
+    // /api/me가 아직 안 끝난 시점에 클릭 — 예전엔 여기서 이미 /inbox로 나갔다.
+    await act(async () => { startBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(pushMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveMe({ ok: true, json: async () => ({ data: { org_id: null } }) });
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    });
+    expect(pushMock).toHaveBeenCalledWith('/onboarding');
+  });
 });

--- a/apps/web/src/app/verify-email/page.test.tsx
+++ b/apps/web/src/app/verify-email/page.test.tsx
@@ -91,7 +91,7 @@ describe('VerifyEmailPage — error.code 분기 (story #2484)', () => {
 describe('VerifyEmailPage — 「시작하기」 목적지가 org_id 유무로 갈린다(story #3195)', () => {
   function mockFetchByUrl(orgId: string | null) {
     return vi.fn(async (url: string) => {
-      if (url === '/api/me') return { ok: true, json: async () => ({ data: { org_id: orgId } }) };
+      if (url === '/api/auth/me') return { ok: true, json: async () => ({ data: { org_id: orgId } }) };
       return { json: async () => ({ data: { message: 'Email verified successfully' } }) };
     });
   }
@@ -119,7 +119,7 @@ describe('VerifyEmailPage — 「시작하기」 목적지가 org_id 유무로 �
     let resolveMe!: (v: { ok: true; json: () => Promise<unknown> }) => void;
     const mePromise = new Promise<{ ok: true; json: () => Promise<unknown> }>((r) => { resolveMe = r; });
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (url === '/api/me') return mePromise;
+      if (url === '/api/auth/me') return mePromise;
       return { json: async () => ({ data: { message: 'Email verified successfully' } }) };
     }));
     await mountAndWait();

--- a/apps/web/src/app/verify-email/page.tsx
+++ b/apps/web/src/app/verify-email/page.tsx
@@ -17,6 +17,21 @@ export default function VerifyEmailPage() {
     () => (token ? '' : '유효하지 않은 인증 링크입니다.')
   );
 
+  // story #3195 — «시작하기»가 org 유무와 무관하게 항상 /inbox로 갔다. 온보딩 도중(org
+  // 미생성) 이메일 인증 벽에 걸린 유저는 org가 없어 /inbox가 막다른 곳이었다(온보딩
+  // 1/4로 돌아가야 sessionStorage draft도 복원된다) — register/page.tsx와 동일 패턴
+  // (org_id 유무로 목적지 분기)으로 통일.
+  const [destination, setDestination] = useState('/inbox');
+  useEffect(() => {
+    fetch('/api/me')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json: { data?: { org_id?: string | null } } | null) => {
+        if (json?.data?.org_id) setDestination('/inbox');
+        else setDestination('/onboarding');
+      })
+      .catch(() => { /* 기본값 /inbox 유지 — 조회 실패는 이전 동작으로 저하 */ });
+  }, []);
+
   useEffect(() => {
     if (!token) return;
 
@@ -71,7 +86,7 @@ export default function VerifyEmailPage() {
           <div className="space-y-4">
             <p className="text-sm font-medium text-success" role="status" aria-live="polite" aria-atomic="true">{message}</p>
             <button
-              onClick={() => router.push('/inbox')}
+              onClick={() => router.push(destination)}
               className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-brand px-4 py-3 text-sm font-medium text-brand-foreground transition hover:bg-brand/90"
             >
               시작하기

--- a/apps/web/src/app/verify-email/page.tsx
+++ b/apps/web/src/app/verify-email/page.tsx
@@ -22,14 +22,19 @@ export default function VerifyEmailPage() {
   // 1/4로 돌아가야 sessionStorage draft도 복원된다) — register/page.tsx와 동일 패턴
   // (org_id 유무로 목적지 분기)으로 통일.
   //
-  // 유나 design:pass 비차단 ①(2026-08-29) — /api/me 응답 前 빠른 클릭이면 no-org 유저가
-  // 여전히 막다른 /inbox로 갈 수 있었다(useState 기본값 레이스). ref에 Promise를 캐시해
-  // effect든 클릭이든 «같은 promise»를 공유·await하게 해 판정 前 클릭도 정확한 목적지를
-  // 기다렸다 라우팅한다(중복 fetch도 안 남).
+  // 카디르 QA(PR#3617) 치명 — `/api/me`는 BE `me.py::get_me()`(TeamMember 필수)를 서빙해
+  // 무 org(정확히 이 유저 상태)면 404 → org_id를 못 읽어 `/inbox` 폴백으로 떨어지며 막다른
+  // 길이 재생산됐다. `/api/auth/me`(BFF 신설, BE app.routers.auth.get_auth_me)로 교체 —
+  // JWT claims만 읽어 org 유무와 무관하게 항상 200.
+  //
+  // 유나 design:pass 비차단 ①(2026-08-29) — 응답 前 빠른 클릭이면 no-org 유저가 여전히
+  // 막다른 /inbox로 갈 수 있었다(useState 기본값 레이스). ref에 Promise를 캐시해 effect든
+  // 클릭이든 «같은 promise»를 공유·await하게 해 판정 前 클릭도 정확한 목적지를 기다렸다
+  // 라우팅한다(중복 fetch도 안 남).
   const destinationRef = useRef<Promise<string> | null>(null);
   function resolveDestination(): Promise<string> {
     if (!destinationRef.current) {
-      destinationRef.current = fetch('/api/me')
+      destinationRef.current = fetch('/api/auth/me')
         .then((res) => (res.ok ? res.json() : null))
         .then((json: { data?: { org_id?: string | null } } | null) => (json?.data?.org_id ? '/inbox' : '/onboarding'))
         .catch(() => '/inbox'); // 조회 실패는 이전 동작(/inbox)으로 저하

--- a/apps/web/src/app/verify-email/page.tsx
+++ b/apps/web/src/app/verify-email/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
@@ -21,16 +21,26 @@ export default function VerifyEmailPage() {
   // 미생성) 이메일 인증 벽에 걸린 유저는 org가 없어 /inbox가 막다른 곳이었다(온보딩
   // 1/4로 돌아가야 sessionStorage draft도 복원된다) — register/page.tsx와 동일 패턴
   // (org_id 유무로 목적지 분기)으로 통일.
-  const [destination, setDestination] = useState('/inbox');
-  useEffect(() => {
-    fetch('/api/me')
-      .then((res) => (res.ok ? res.json() : null))
-      .then((json: { data?: { org_id?: string | null } } | null) => {
-        if (json?.data?.org_id) setDestination('/inbox');
-        else setDestination('/onboarding');
-      })
-      .catch(() => { /* 기본값 /inbox 유지 — 조회 실패는 이전 동작으로 저하 */ });
-  }, []);
+  //
+  // 유나 design:pass 비차단 ①(2026-08-29) — /api/me 응답 前 빠른 클릭이면 no-org 유저가
+  // 여전히 막다른 /inbox로 갈 수 있었다(useState 기본값 레이스). ref에 Promise를 캐시해
+  // effect든 클릭이든 «같은 promise»를 공유·await하게 해 판정 前 클릭도 정확한 목적지를
+  // 기다렸다 라우팅한다(중복 fetch도 안 남).
+  const destinationRef = useRef<Promise<string> | null>(null);
+  function resolveDestination(): Promise<string> {
+    if (!destinationRef.current) {
+      destinationRef.current = fetch('/api/me')
+        .then((res) => (res.ok ? res.json() : null))
+        .then((json: { data?: { org_id?: string | null } } | null) => (json?.data?.org_id ? '/inbox' : '/onboarding'))
+        .catch(() => '/inbox'); // 조회 실패는 이전 동작(/inbox)으로 저하
+    }
+    return destinationRef.current;
+  }
+  useEffect(() => { void resolveDestination(); }, []);
+
+  const handleStart = () => {
+    void resolveDestination().then((destination) => router.push(destination));
+  };
 
   useEffect(() => {
     if (!token) return;
@@ -86,7 +96,7 @@ export default function VerifyEmailPage() {
           <div className="space-y-4">
             <p className="text-sm font-medium text-success" role="status" aria-live="polite" aria-atomic="true">{message}</p>
             <button
-              onClick={() => router.push(destination)}
+              onClick={handleStart}
               className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-brand px-4 py-3 text-sm font-medium text-brand-foreground transition hover:bg-brand/90"
             >
               시작하기

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1832,6 +1832,10 @@ class AuthMeResponse(BaseModel):
     resolved_default_project_id: str | None = None
     is_project_ambiguous: bool = False
     accessible_project_ids: list[str] = []
+    # story #3195(온보딩·FE) — 온보딩 1/4가 "이메일 인증 필요"를 제출(400) 前에 선제 고지하려면
+    # 이 신호가 필요했다. api_key 컨텍스트(에이전트)는 User 행이 없어 None(무의미 — 온보딩 게이트
+    # 자체가 인간 전용이라 agent 소비처는 이 필드를 참조하지 않는다).
+    email_verified: bool | None = None
 
 
 async def _resolve_project_default(
@@ -1870,6 +1874,7 @@ async def get_auth_me(
     resolved: str | None = None
     ambiguous = False
     accessible_ids: list[str] = []
+    email_verified: bool | None = None
     if meta.get("api_key_id"):
         try:
             member_id = uuid.UUID(auth.user_id)
@@ -1877,6 +1882,15 @@ async def get_auth_me(
             resolved, ambiguous, accessible_ids = await _resolve_project_default(db, member_id, org_id)
         except Exception:
             logger.warning("get_auth_me: 신규 project default 판정 실패 — 레거시 필드만 반환", exc_info=True)
+    else:
+        # story #3195 — human JWT 세션(auth.user_id == User.id)에 한해서만 조회. api_key
+        # 컨텍스트는 위 분기라 여기 안 온다(불필요 쿼리 회피).
+        try:
+            email_verified = (
+                await db.execute(select(User.email_verified).where(User.id == uuid.UUID(auth.user_id)))
+            ).scalar_one_or_none()
+        except Exception:
+            logger.warning("get_auth_me: email_verified 조회 실패 — None으로 반환", exc_info=True)
     return AuthMeResponse(
         member_id=auth.user_id,
         org_id=auth.org_id or meta.get("org_id"),
@@ -1884,6 +1898,7 @@ async def get_auth_me(
         resolved_default_project_id=resolved,
         is_project_ambiguous=ambiguous,
         accessible_project_ids=accessible_ids,
+        email_verified=email_verified,
     )
 
 

--- a/backend/tests/test_3195_me_email_verified.py
+++ b/backend/tests/test_3195_me_email_verified.py
@@ -1,6 +1,13 @@
-"""story #3195(온보딩·FE) — GET /api/v2/me가 email_verified를 반환해야 온보딩 1/4가
-제출(400) 前에 «인증 필요» 안내를 선제 고지할 수 있다(AC2). 신규 DB 쿼리는 human JWT
-세션(api_key 컨텍스트가 아닐 때)에만 도는지, api_key 컨텍스트는 무영향(None)인지 고정."""
+"""story #3195(온보딩·FE) — GET /api/v2/auth/me(get_auth_me)가 email_verified를 반환해야
+온보딩 1/4가 제출(400) 前에 «인증 필요» 안내를 선제 고지할 수 있다(AC2). 신규 DB 쿼리는
+human JWT 세션(api_key 컨텍스트가 아닐 때)에만 도는지, api_key 컨텍스트는 무영향(None)
+인지 고정.
+
+카디르 QA(PR#3617) 치명 — 이 필드를 처음엔 이 함수(auth.py::get_auth_me)에 붙였는데
+FE가 실제로 부르던 건 `/api/me`(BE me.py::get_me, TeamMember 필수)였다. 이 스토리가
+겨냥하는 "무 org"(온보딩 1/4 진행 중) 상태에서 me.py::get_me는 404를 낸다 — 즉 FE를
+`/api/auth/me`로 옮긴 지금, **이 엔드포인트가 무 org에서도 200을 내는지**가 이 fix
+전체의 성패를 가른다. 아래 무org 200 pin이 그 계약을 고정한다."""
 from __future__ import annotations
 
 import uuid
@@ -29,6 +36,19 @@ def _mock_db(email_verified: bool | None) -> AsyncMock:
 async def test_human_jwt_session_returns_email_verified_false():
     auth = AuthContext(user_id=str(uuid.uuid4()), email="new@example.com", claims={"app_metadata": {}})
     resp = await get_auth_me(auth=auth, db=_mock_db(False))
+    assert resp.email_verified is False
+
+
+@pytest.mark.anyio
+async def test_no_org_human_session_returns_200_with_org_id_none_not_404():
+    """카디르 QA(PR#3617) 필수 pin — 무 org(=이 스토리가 겨냥하는 온보딩 1/4 진행 중)
+    human 세션은 org_id/project_id 클레임 자체가 없다(claims에 org_id 키 없음). 이
+    함수가 me.py::get_me와 달리 TeamMember를 전혀 조회하지 않아 404가 날 수 없고,
+    org_id=None으로 정직하게 200을 낸다는 계약을 고정한다 — verify-email/onboarding
+    두 소비처 모두 이 계약에 기대고 있다."""
+    auth = AuthContext(user_id=str(uuid.uuid4()), email="new@example.com", claims={"app_metadata": {}})
+    resp = await get_auth_me(auth=auth, db=_mock_db(False))
+    assert resp.org_id is None
     assert resp.email_verified is False
 
 

--- a/backend/tests/test_3195_me_email_verified.py
+++ b/backend/tests/test_3195_me_email_verified.py
@@ -1,0 +1,65 @@
+"""story #3195(온보딩·FE) — GET /api/v2/me가 email_verified를 반환해야 온보딩 1/4가
+제출(400) 前에 «인증 필요» 안내를 선제 고지할 수 있다(AC2). 신규 DB 쿼리는 human JWT
+세션(api_key 컨텍스트가 아닐 때)에만 도는지, api_key 컨텍스트는 무영향(None)인지 고정."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.dependencies.auth import AuthContext
+from app.routers.auth import get_auth_me
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _mock_db(email_verified: bool | None) -> AsyncMock:
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = email_verified
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+@pytest.mark.anyio
+async def test_human_jwt_session_returns_email_verified_false():
+    auth = AuthContext(user_id=str(uuid.uuid4()), email="new@example.com", claims={"app_metadata": {}})
+    resp = await get_auth_me(auth=auth, db=_mock_db(False))
+    assert resp.email_verified is False
+
+
+@pytest.mark.anyio
+async def test_human_jwt_session_returns_email_verified_true():
+    auth = AuthContext(user_id=str(uuid.uuid4()), email="verified@example.com", claims={"app_metadata": {}})
+    resp = await get_auth_me(auth=auth, db=_mock_db(True))
+    assert resp.email_verified is True
+
+
+@pytest.mark.anyio
+async def test_api_key_agent_context_email_verified_stays_none_no_query():
+    """api_key 컨텍스트는 User 행이 없다 — 조회 자체를 안 타서 None(무의미)으로 남아야
+    하고, DB round-trip을 낭비하지 않는다(호출 안 됨을 직접 확인)."""
+    member_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    auth = AuthContext(
+        user_id=str(member_id), email=None,
+        claims={"app_metadata": {"api_key_id": "key-1", "org_id": str(org_id)}},
+        org_id=str(org_id),
+    )
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=[])))
+    resp = await get_auth_me(auth=auth, db=session)
+    assert resp.email_verified is None
+
+
+@pytest.mark.anyio
+async def test_email_verified_lookup_failure_degrades_to_none_not_crash():
+    auth = AuthContext(user_id=str(uuid.uuid4()), email="a@b.com", claims={"app_metadata": {}})
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=RuntimeError("db down"))
+    resp = await get_auth_me(auth=auth, db=session)
+    assert resp.email_verified is None


### PR DESCRIPTION
## 요약
- [\[온보딩·FE\] 이메일 인증 왕복이 온보딩 1/4 입력값(조직명·슬러그)을 소실 — 재입력 강요](entity:story:679ff2fc-bd77-47d7-a95f-c4d41c84f576)

## 발견(PO 신규 회원 친절도 실 워크스루, 2026-08-28 dev)
가입 → 온보딩 1/4 조직명·슬러그 입력 → «조직 만들기» 클릭 시점에 EMAIL_VERIFICATION_REQUIRED(사후 고지) → 메일 인증 → verify-email 페이지 «시작하기» 복귀 → 1/4 폼이 빈 채 재시작. 근본원인 둘:
1. 인증 왕복이 풀 페이지 네비게이션(이메일 링크 클릭)이라 OnboardingForm이 통째로 리마운트돼 React state가 사라짐.
2. verify-email의 «시작하기»가 org 유무와 무관하게 항상 `/inbox`로 갔다 — 이 시점엔 org가 아직 없어 막다른 곳이었다(register/page.tsx가 이미 쓰는 "org_id 유무로 목적지 분기" 패턴과 불일치했던 별개 결함).

## ①1/4 입력값 영속 — sessionStorage draft(AC1)
같은 탭 내 네비게이션 전체에서 살아남는 sessionStorage로 orgName/orgSlug를 매 입력마다 저장, org 단계 마운트 시 복원. 조직 생성 **성공** 시에만 clear(실패 EMAIL_VERIFICATION_REQUIRED 포함 — 왕복 중엔 항상 보존).

## ②「시작하기」 목적지 — org_id 유무 분기
verify-email/page.tsx가 register/page.tsx와 동일 패턴(GET /api/me → org_id 유무로 /inbox vs /onboarding)으로 통일.

## ③미인증 선제 고지(AC2) — BE `/me` 신설 email_verified
`AuthMeResponse`에 `email_verified: bool | None` 추가(human JWT 세션에서만 조회, api_key 컨텍스트는 스킵). onboarding-form.tsx가 마운트 시 이 값을 확인해 false면 제출(400) 前부터 기존 재전송 UI(story #2441)를 재사용해 선제 노출.

## 검증
- 신규 pin 13건 — FE 9건(draft 저장/복원/clear/보존·미인증 선제고지·목적지 분기)+BE 4건(email_verified true/false/api_key무쿼리/조회실패 폴백).
- tsc 0 · lint 0(무관 기존 5건) · verify:no-new-raw-fetch-api(fetchWithAuth 전환)/no-new-raw-button/no-duplicate-i18n-keys 전부 GREEN · 전체 vitest 538파일/5047건 GREEN · build GREEN.
- backend: py_compile OK · alembic heads 단일(무변경) · guard 7종 GREEN · 전체 pytest 5130 passed(14 failed는 기존 환경 갭).

prod 무접촉(develop 대상).