### PR TITLE
[SID:3215] DS 순감소 리팩터 2호 — context-switcher-chip 11건+kanban-board 10건 raw <button> → Button 이관

### DIFF
--- a/apps/web/scripts/raw-button-baseline.json
+++ b/apps/web/scripts/raw-button-baseline.json
@@ -5,7 +5,10 @@
     "story #3177(S3a) AC5 순감소 — chat-list-view.tsx 4건→0건(<Button> 전환, 이 스토리가 그 파일을",
     "건드리며 실측 제거). 186f/511occ → 185f/507occ.",
     "story #3183(DS 순감소 리팩터 1호) — story-detail-panel.tsx 37건→0건(<Button variant=\"ghost\">",
-    "전량 전환, baseline 단일 파일 최다 채무 소거). 185f/507occ → 184f/470occ."
+    "전량 전환, baseline 단일 파일 최다 채무 소거). 185f/507occ → 184f/470occ.",
+    "story #3215(DS 순감소 리팩터 2호) — context-switcher-chip.tsx 11건+kanban-board.tsx 10건",
+    "→ 0건(<Button variant=\"ghost\"> 전량 전환, h-auto/min-h-0/min-w-0/font-normal/rounded-none",
+    "개별 보정은 1호와 동형 패턴). 184f/470occ → 182f/449occ."
   ],
   "counts": {
     "app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx": 3,
@@ -139,7 +142,6 @@
     "components/hypotheses/story-hypotheses-section.tsx": 4,
     "components/inbox/approvals-queue.tsx": 5,
     "components/integrations/pr-link-section.tsx": 1,
-    "components/kanban/kanban-board.tsx": 10,
     "components/kanban/kanban-column.tsx": 5,
     "components/kanban/kanban-list-view.tsx": 1,
     "components/kanban/kanban-trust-column.tsx": 1,
@@ -152,7 +154,6 @@
     "components/meetings/audio-recorder.tsx": 2,
     "components/nav/app-sidebar.tsx": 1,
     "components/nav/business-info-disclosure.tsx": 1,
-    "components/nav/context-switcher-chip.tsx": 11,
     "components/nav/notification-bell.tsx": 7,
     "components/nav/theme-toggle.tsx": 1,
     "components/nav/unified-switcher.tsx": 1,

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1479,7 +1479,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
               onClick={() => setViewMode('board')}
               title="Board view"
               className={`size-7 min-h-0 min-w-0 rounded-none ${
-                viewMode === 'board' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/50'
+                viewMode === 'board' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/50 hover:text-muted-foreground'
               }`}
             >
               <LayoutGrid className="size-3.5" />
@@ -1490,7 +1490,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
               onClick={() => setViewMode('list')}
               title="List view"
               className={`size-7 min-h-0 min-w-0 rounded-none ${
-                viewMode === 'list' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/50'
+                viewMode === 'list' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/50 hover:text-muted-foreground'
               }`}
             >
               <LayoutList className="size-3.5" />

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1151,18 +1151,19 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
             { id: 'human' as const, label: t('filterMembers') },
             { id: 'agent' as const, label: t('filterAgents') },
           ]).map(({ id, label }) => (
-            <button
+            <Button
               key={id || 'all'}
               type="button"
+              variant="ghost"
               onClick={() => setAssigneeTypeFilter(id)}
-              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              className={`h-auto min-h-0 min-w-0 rounded-md px-3 py-1.5 text-xs font-medium ${
                 assigneeTypeFilter === id
                   ? 'bg-foreground/10 text-foreground'
                   : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
               }`}
             >
               {label}
-            </button>
+            </Button>
           ))}
 
           <div className="mx-1 h-4 w-px bg-border/60" />
@@ -1171,9 +1172,10 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           <DropdownMenu onOpenChange={(open) => { if (!open) setSprintSearch(''); }}>
             <DropdownMenuTrigger
               render={
-                <button
+                <Button
                   type="button"
-                  className={`flex h-7 items-center gap-1 rounded-md border px-2 text-xs font-medium transition-colors ${
+                  variant="ghost"
+                  className={`h-7 min-h-0 min-w-0 gap-1 rounded-md border px-2 text-xs font-medium ${
                     selectedSprintId
                       ? 'border-primary/40 bg-primary/10 text-primary'
                       : 'border-border/60 text-muted-foreground hover:border-border hover:text-foreground'
@@ -1183,7 +1185,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                     {selectedSprintId ? (sprints.find((s) => s.id === selectedSprintId)?.title ?? t('allSprints')) : t('allSprints')}
                   </span>
                   <ChevronDown className="size-3 shrink-0" />
-                </button>
+                </Button>
               }
             />
             <DropdownMenuContent align="start" className="w-56">
@@ -1231,9 +1233,10 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           <DropdownMenu onOpenChange={(open) => { if (!open) setEpicSearch(''); }}>
             <DropdownMenuTrigger
               render={
-                <button
+                <Button
                   type="button"
-                  className={`flex h-7 items-center gap-1 rounded-md border px-2 text-xs font-medium transition-colors ${
+                  variant="ghost"
+                  className={`h-7 min-h-0 min-w-0 gap-1 rounded-md border px-2 text-xs font-medium ${
                     selectedEpicId
                       ? 'border-primary/40 bg-primary/10 text-primary'
                       : 'border-border/60 text-muted-foreground hover:border-border hover:text-foreground'
@@ -1243,7 +1246,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                     {selectedEpicId ? (epics.find((e) => e.id === selectedEpicId)?.title ?? t('allEpics')) : t('allEpics')}
                   </span>
                   <ChevronDown className="size-3 shrink-0" />
-                </button>
+                </Button>
               }
             />
             <DropdownMenuContent align="start" className="w-56">
@@ -1291,9 +1294,10 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           <DropdownMenu onOpenChange={(open) => { if (!open) setAssigneeSearch(''); }}>
             <DropdownMenuTrigger
               render={
-                <button
+                <Button
                   type="button"
-                  className={`flex h-7 items-center gap-1 rounded-md border px-2 text-xs font-medium transition-colors ${
+                  variant="ghost"
+                  className={`h-7 min-h-0 min-w-0 gap-1 rounded-md border px-2 text-xs font-medium ${
                     selectedAssigneeId
                       ? 'border-primary/40 bg-primary/10 text-primary'
                       : 'border-border/60 text-muted-foreground hover:border-border hover:text-foreground'
@@ -1303,7 +1307,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                     {selectedAssigneeId ? (members.find((m) => m.id === selectedAssigneeId)?.name ?? t('allAssignees')) : t('allAssignees')}
                   </span>
                   <ChevronDown className="size-3 shrink-0" />
-                </button>
+                </Button>
               }
             />
             <DropdownMenuContent align="start" className="w-56">
@@ -1371,9 +1375,10 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
             <DropdownMenu onOpenChange={(open) => { if (!open) setLabelSearch(''); }}>
               <DropdownMenuTrigger
                 render={
-                  <button
+                  <Button
                     type="button"
-                    className={`flex h-7 items-center gap-1 rounded-md border px-2 text-xs font-medium transition-colors ${
+                    variant="ghost"
+                    className={`h-7 min-h-0 min-w-0 gap-1 rounded-md border px-2 text-xs font-medium ${
                       selectedLabelIds.length > 0
                         ? 'border-primary/40 bg-primary/10 text-primary'
                         : 'border-border/60 text-muted-foreground hover:border-border hover:text-foreground'
@@ -1383,7 +1388,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                       {selectedLabelIds.length > 0 ? t('labelsActive', { count: selectedLabelIds.length }) : t('allLabels')}
                     </span>
                     <ChevronDown className="size-3 shrink-0" />
-                  </button>
+                  </Button>
                 }
               />
               <DropdownMenuContent align="start" className="w-56">
@@ -1453,40 +1458,43 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
               className="h-7 w-36 text-xs"
             />
           ) : (
-            <button
+            <Button
               type="button"
+              variant="ghost"
               title={t('searchPlaceholder')}
               onClick={() => setShowSearch(true)}
-              className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
+              className={`size-7 min-h-0 min-w-0 rounded-md ${
                 searchQuery ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
               }`}
             >
               <Search className="size-3.5" />
-            </button>
+            </Button>
           )}
 
           {/* Board/List toggle */}
           <div className="flex items-center overflow-hidden rounded-md border border-border/60">
-            <button
+            <Button
               type="button"
+              variant="ghost"
               onClick={() => setViewMode('board')}
               title="Board view"
-              className={`flex h-7 w-7 items-center justify-center transition-colors ${
+              className={`size-7 min-h-0 min-w-0 rounded-none ${
                 viewMode === 'board' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/50'
               }`}
             >
               <LayoutGrid className="size-3.5" />
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant="ghost"
               onClick={() => setViewMode('list')}
               title="List view"
-              className={`flex h-7 w-7 items-center justify-center transition-colors ${
+              className={`size-7 min-h-0 min-w-0 rounded-none ${
                 viewMode === 'list' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/50'
               }`}
             >
               <LayoutList className="size-3.5" />
-            </button>
+            </Button>
           </div>
 
           {/* story #2933 H4(P0-H, 유나 판정 2026-08-22) — 5-status/6단계 신뢰축 컬럼 축 토글.
@@ -1501,28 +1509,30 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
               렌더 전용, 이번 슬라이스 스코프). */}
           {viewMode === 'board' && (
             <div className="flex items-center gap-3 border-b border-border/60" role="tablist" aria-label={t('trustAxisView')}>
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 role="tab"
                 aria-selected={axisMode === 'status'}
                 onClick={() => handleSetAxisMode('status')}
-                className={`-mb-px whitespace-nowrap border-b-2 px-0.5 pb-1.5 text-[11px] font-semibold transition ${
+                className={`h-auto min-h-0 min-w-0 -mb-px whitespace-nowrap rounded-none border-x-0 border-t-0 border-b-2 px-0.5 pb-1.5 text-[11px] font-semibold ${
                   axisMode === 'status' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'
                 }`}
               >
                 {t('trustClassicView')}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                variant="ghost"
                 role="tab"
                 aria-selected={axisMode === 'trust'}
                 onClick={() => handleSetAxisMode('trust')}
-                className={`-mb-px whitespace-nowrap border-b-2 px-0.5 pb-1.5 text-[11px] font-semibold transition ${
+                className={`h-auto min-h-0 min-w-0 -mb-px whitespace-nowrap rounded-none border-x-0 border-t-0 border-b-2 px-0.5 pb-1.5 text-[11px] font-semibold ${
                   axisMode === 'trust' ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'
                 }`}
               >
                 {t('trustAxisView')}
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/apps/web/src/components/nav/context-switcher-chip.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.tsx
@@ -178,7 +178,7 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
               type="button"
               variant="ghost"
               onClick={() => s.setCreateProjectOpen(true)}
-              className="min-h-11 w-full justify-start gap-2 rounded-lg px-3.5 py-2.5 text-left font-normal text-brand hover:bg-accent"
+              className="min-h-11 w-full justify-start gap-2 rounded-lg px-3.5 py-2.5 text-left font-normal text-brand hover:bg-accent hover:text-brand"
             >
               <Plus className="h-4 w-4 shrink-0" />
               <span className="text-sm">{t('switcherNewProject')}</span>
@@ -225,7 +225,7 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
                       variant="ghost"
                       disabled={s.pending}
                       onClick={() => void s.switchOrg(org.orgId)}
-                      className="min-h-11 w-full justify-start gap-2.5 rounded-lg px-3.5 py-2.5 text-left font-normal text-muted-foreground hover:bg-accent disabled:opacity-60"
+                      className="min-h-11 w-full justify-start gap-2.5 rounded-lg px-3.5 py-2.5 text-left font-normal text-muted-foreground hover:bg-accent hover:text-muted-foreground disabled:opacity-60"
                     >
                       <span className="flex-1 text-[13.5px]">{t('switcherSwitchToOrg')}</span>
                       <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
@@ -294,7 +294,7 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
                   variant="ghost"
                   disabled={acc.atCap || acc.busy !== null}
                   onClick={() => void acc.handleAdd()}
-                  className="min-h-11 w-full justify-start gap-2 rounded-lg px-3.5 py-2.5 text-left font-normal text-brand hover:bg-accent disabled:opacity-60"
+                  className="min-h-11 w-full justify-start gap-2 rounded-lg px-3.5 py-2.5 text-left font-normal text-brand hover:bg-accent hover:text-brand disabled:opacity-60"
                 >
                   {acc.busy === 'add' ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
                   <span className="flex-1 text-sm">{acc.t('addAccount')}</span>

--- a/apps/web/src/components/nav/context-switcher-chip.tsx
+++ b/apps/web/src/components/nav/context-switcher-chip.tsx
@@ -94,11 +94,12 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
             2~3x 폰트부스트 조건에선 2~3 device px 절단으로 관측). `leading-tight`로
             교체 — 버튼 자체는 이미 h-11+overflow-hidden이 하드캡이므로 라벨은 안전하게
             느슨해질 수 있다(2단 실높이 leading-tight 기준 ~30.75px < 예산 32px, 안착). */}
-        <button
+        <Button
           type="button"
+          variant="ghost"
           onClick={() => s.setOpen(true)}
           disabled={s.pending}
-          className="flex h-11 min-w-0 max-w-[190px] shrink-0 items-center gap-2 overflow-hidden rounded-xl border border-border bg-card px-2 py-1.5 text-left transition hover:bg-muted disabled:opacity-60 lg:hidden"
+          className="h-11 min-h-0 min-w-0 max-w-[190px] shrink-0 justify-start gap-2 overflow-hidden rounded-xl border border-border bg-card px-2 py-1.5 text-left font-normal hover:bg-muted disabled:opacity-60 lg:hidden"
           aria-label={t('switcherMobileTriggerAria')}
         >
           <OrgInitial name={s.displayOrg} className="flex size-7 shrink-0 items-center justify-center rounded-[7px] bg-brand text-xs font-semibold text-brand-foreground" />
@@ -107,19 +108,20 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
             <span className="w-full truncate text-[13px] font-bold leading-tight text-foreground">{chipLabel}</span>
           </span>
           <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
-        </button>
+        </Button>
 
         <SheetContent side="bottom" className="max-h-[80vh] rounded-t-2xl p-0">
           <SheetHeader className="flex-row items-center justify-between border-b pb-3">
             <SheetTitle>{t('switcherMobileSheetTitle')}</SheetTitle>
-            <button
+            <Button
               type="button"
+              variant="ghost"
               onClick={() => { window.location.href = '/settings?tab=organization'; }}
-              className="flex size-11 items-center justify-center rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              className="size-11 min-h-0 min-w-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
               aria-label={t('switcherOrgSettingsAria')}
             >
               <Settings className="h-3.5 w-3.5" />
-            </button>
+            </Button>
           </SheetHeader>
 
           <div className="focus-inset flex-1 overflow-y-auto px-2 pb-4">
@@ -153,12 +155,13 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
               s.filteredCurrentOrgProjects.map((project) => {
                 const isCurrent = project.projectId === s.currentProjectId;
                 return (
-                  <button
+                  <Button
                     key={project.projectId}
                     type="button"
+                    variant="ghost"
                     disabled={s.pending}
                     onClick={() => void s.switchProject(project.projectId)}
-                    className={`flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3.5 py-2.5 text-left transition hover:bg-accent disabled:opacity-60 ${isCurrent ? 'bg-brand/10' : ''}`}
+                    className={`min-h-11 w-full justify-start gap-2.5 rounded-lg px-3.5 py-2.5 text-left font-normal hover:bg-accent disabled:opacity-60 ${isCurrent ? 'bg-brand/10' : ''}`}
                   >
                     <OrgInitial
                       name={project.projectName}
@@ -167,18 +170,19 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
                     <span className="min-w-0 flex-1 truncate text-[13.5px] text-foreground">{project.projectName}</span>
                     {/* 유나 규격 — 색만 의존 금지(브랜드 배경+글리프 이중 표식). */}
                     {isCurrent && <Check className="h-4 w-4 shrink-0 text-brand" />}
-                  </button>
+                  </Button>
                 );
               })
             )}
-            <button
+            <Button
               type="button"
+              variant="ghost"
               onClick={() => s.setCreateProjectOpen(true)}
-              className="flex min-h-11 w-full items-center gap-2 rounded-lg px-3.5 py-2.5 text-left text-brand transition hover:bg-accent"
+              className="min-h-11 w-full justify-start gap-2 rounded-lg px-3.5 py-2.5 text-left font-normal text-brand hover:bg-accent"
             >
               <Plus className="h-4 w-4 shrink-0" />
               <span className="text-sm">{t('switcherNewProject')}</span>
-            </button>
+            </Button>
 
             {/* 다른 조직들 — 섹션 라벨 신설(§③). */}
             {s.otherOrgs.length > 0 && (
@@ -203,41 +207,44 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
                     </div>
                   ) : orgProjects && orgProjects.length > 0 ? (
                     orgProjects.map((project) => (
-                      <button
+                      <Button
                         key={project.projectId}
                         type="button"
+                        variant="ghost"
                         disabled={s.pending}
                         onClick={() => void s.switchOrgAndProject(org.orgId, project.projectId)}
-                        className="flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3.5 py-2.5 text-left transition hover:bg-accent disabled:opacity-60"
+                        className="min-h-11 w-full justify-start gap-2.5 rounded-lg px-3.5 py-2.5 text-left font-normal hover:bg-accent disabled:opacity-60"
                       >
                         <span className="min-w-0 flex-1 truncate text-[13.5px]">{project.projectName}</span>
                         <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-                      </button>
+                      </Button>
                     ))
                   ) : (
-                    <button
+                    <Button
                       type="button"
+                      variant="ghost"
                       disabled={s.pending}
                       onClick={() => void s.switchOrg(org.orgId)}
-                      className="flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3.5 py-2.5 text-left text-muted-foreground transition hover:bg-accent disabled:opacity-60"
+                      className="min-h-11 w-full justify-start gap-2.5 rounded-lg px-3.5 py-2.5 text-left font-normal text-muted-foreground hover:bg-accent disabled:opacity-60"
                     >
                       <span className="flex-1 text-[13.5px]">{t('switcherSwitchToOrg')}</span>
                       <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-                    </button>
+                    </Button>
                   )}
                 </div>
               );
             })}
 
             <div className="mt-2 border-t pt-2">
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 onClick={() => s.setCreateOrgOpen(true)}
-                className="flex min-h-11 w-full items-center gap-2 rounded-lg px-3.5 py-2.5 text-left transition hover:bg-accent"
+                className="min-h-11 w-full justify-start gap-2 rounded-lg px-3.5 py-2.5 text-left font-normal hover:bg-accent"
               >
                 <Plus className="h-4 w-4 shrink-0" />
                 <span className="text-sm">{t('switcherNewOrganization')}</span>
-              </button>
+              </Button>
             </div>
 
             {/* story #3146 §③ 계정층(신규) — divider로 시각 분리(무거운 조작·우발 탭 방지,
@@ -256,12 +263,13 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
                   const isExpired = account.status === 'expired';
                   const label = account.name ?? account.email ?? acc.tc('unknown');
                   return (
-                    <button
+                    <Button
                       key={account.account_id}
                       type="button"
+                      variant="ghost"
                       disabled={acc.busy !== null || isActive}
                       onClick={() => void acc.handleSwitch(account)}
-                      className={`flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3.5 py-2.5 text-left transition hover:bg-accent disabled:opacity-60 ${isActive ? 'bg-brand/10' : ''}`}
+                      className={`min-h-11 w-full justify-start gap-2.5 rounded-lg px-3.5 py-2.5 text-left font-normal hover:bg-accent disabled:opacity-60 ${isActive ? 'bg-brand/10' : ''}`}
                     >
                       <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
                         {label.charAt(0).toUpperCase()}
@@ -278,38 +286,41 @@ export function ContextSwitcherChip({ orgs, currentOrgId, projects, currentProje
                       </span>
                       {isActive && <Check className="h-4 w-4 shrink-0 text-brand" />}
                       {acc.busy === account.account_id && <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />}
-                    </button>
+                    </Button>
                   );
                 })}
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   disabled={acc.atCap || acc.busy !== null}
                   onClick={() => void acc.handleAdd()}
-                  className="flex min-h-11 w-full items-center gap-2 rounded-lg px-3.5 py-2.5 text-left text-brand transition hover:bg-accent disabled:opacity-60"
+                  className="min-h-11 w-full justify-start gap-2 rounded-lg px-3.5 py-2.5 text-left font-normal text-brand hover:bg-accent disabled:opacity-60"
                 >
                   {acc.busy === 'add' ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
                   <span className="flex-1 text-sm">{acc.t('addAccount')}</span>
                   {acc.atCap && <span className="text-xs text-muted-foreground">{acc.t('capReached')}</span>}
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
+                  variant="ghost"
                   disabled={acc.busy !== null}
                   onClick={() => void acc.handleSignOut('this')}
-                  className="flex min-h-11 w-full items-center gap-2 rounded-lg px-3.5 py-2.5 text-left text-destructive transition hover:bg-muted"
+                  className="min-h-11 w-full justify-start gap-2 rounded-lg px-3.5 py-2.5 text-left font-normal text-destructive hover:bg-muted"
                 >
                   <LogOut className="size-4" />
                   <span className="text-sm">{acc.others.length > 0 ? acc.t('signOutThis') : acc.tc('logout')}</span>
-                </button>
+                </Button>
                 {acc.others.length > 0 && (
-                  <button
+                  <Button
                     type="button"
+                    variant="ghost"
                     disabled={acc.busy !== null}
                     onClick={() => void acc.handleSignOut('all')}
-                    className="flex min-h-11 w-full items-center gap-2 rounded-lg px-3.5 py-2.5 text-left text-destructive transition hover:bg-muted"
+                    className="min-h-11 w-full justify-start gap-2 rounded-lg px-3.5 py-2.5 text-left font-normal text-destructive hover:bg-muted"
                   >
                     <LogOut className="size-4" />
                     <span className="text-sm">{acc.t('signOutAll')}</span>
-                  </button>
+                  </Button>
                 )}
               </>
             )}


### PR DESCRIPTION
## 요약
- [\[DS 순감소 리팩터 2호\] context-switcher-chip 11건 + kanban-board 10건 raw <button> → Button 이관 (baseline 차순위 2파일)](entity:story:35b88efa-356a-4e0c-ac58-b9b6650c3b7d)

키스톤(#3164) baseline 차순위 2파일을 1호(#3183·story-detail-panel)와 동형 패턴으로 순수 리팩터. 동작 변경 0 — 전량 `<Button variant="ghost">`로 전환, Button 기본 클래스가 원본 레이아웃/타이포를 덮어쓰지 않도록 개별 보정.

## 회귀 방지(변환 중 발견·직접 보정)
- **의도된 min-h-11 보존**: 시트 리스트 행들은 원래부터 자체 min-h-11(44px 터치타깃, story #3147 AC2)을 갖고 있었다 — 최초 커밋에서 Button 기본값과 "충돌"로 오인해 지워버리는 실수를 했고, 기존 pin이 즉시 잡아냈다 — 복원.
- **justify-center → justify-start**: 원본은 flex 기본값(flex-start)이었는데 Button 기본이 justify-center를 강제 — flex-1 필러 없는 행은 justify-start 없이 중앙쏠림.
- **font-medium 강제 굵기**: 자체 font-weight 없이 부모 상속에 기대던 span들에 font-normal 명시.
- **rounded-none**: kanban-board 토글쌍·axis 탭은 부모/자체 테두리 구조상 Button 기본 rounded-md/border가 시각 잡음이 되어 중립화.

## 검증
- context-switcher-chip.test.tsx+kanban-board.test.tsx 55건 전부 PASS(min-h-11 pin이 위 실수를 실제로 잡아낸 근거).
- tsc 0 · lint 0(무관 기존 5건) · 전체 vitest 539파일/5057건 PASS · build 성공.

## 순감소 실측
raw-button-baseline.json: 184f/470occ → 182f/449occ(예측치 정확히 일치). 가드 재실행 0 신규위반.

## 잔여
라이트/다크·hover/active 실 픽셀 대조는 유나양 design 게이트 몫(AC4 명시). prod 무접촉.