### PR TITLE
[3219] run-migrations.sh fail-closed — 파이프가 psql 종료코드를 삼키던 결함

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,6 +602,21 @@ jobs:
         working-directory: backend
         run: python3 scripts/lint_business_info_email_footer_drift.py
 
+  # story #3219(카디르 3라운드, 2026-08-30) — 이 검증은 run-migrations.test.sh 시나리오
+  # [9]로 먼저 만들어졌지만 그 .test.sh는 CI 어디에도 안 걸려 있어(convention 자체가
+  # manual-only) 매 PR에 실제로 도는 자리가 없었다("만들어졌는데 도는 자리 없음" 결함).
+  # PG 불요 정적 스캔이라 여기서 독립 job으로 배선한다 — 로직은 scripts/lint_migrations_
+  # nontx_allowlist.sh 하나만 두고 이 job과 .test.sh [9] 양쪽이 그걸 공유 호출한다.
+  migrations-nontx-allowlist-lint:
+    name: migrations NONTX_ALLOWLIST lint (guard, story #3219)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Scan packages/db/supabase/migrations for unclassified CONCURRENTLY usage
+        run: sh scripts/lint_migrations_nontx_allowlist.sh
+
   # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라
   # main이 develop과 다른 파일셋(ee_pricing 0146/0147 부재)일 때의 그래프 단절을 원천적으로
   # 못 잡는다(실제로 못 잡아서 prod 승격이 롤백된 그 사고). PR base가 main일 때만 도는 이

--- a/scripts/lint_migrations_nontx_allowlist.sh
+++ b/scripts/lint_migrations_nontx_allowlist.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# story #3219(2026-08-30, 카디르 3라운드) — «만들어졌는데 CI에 안 도는» 가드 결함 지적:
+# run-migrations.test.sh 시나리오 [9]가 실 코퍼스를 스캔해 NONTX_ALLOWLIST 갱신 의무를
+# 지키는지 확인했지만, 그 .test.sh는 CI 어디에도 안 걸려 있어 매 PR에 실제로 도는 자리가
+# 없었다 — allowlist가 오래돼 낡아도 아무도 못 알아채는 구조. 처방: 이 검증을 독립
+# 스크립트로 뽑아 CI job(.github/workflows/ci.yml)과 run-migrations.test.sh [9] 양쪽에서
+# 공유 호출한다 — 로직이 두 군데로 갈라져 서로 드리프트하는 것도 같이 막는다.
+#
+# NONTX_ALLOWLIST는 새 top-level CONCURRENTLY 파일이 생길 때마다 실제로 갱신 의무가
+# 남는 자리다(scripts/run-migrations.sh 헤더 ③단락 참고 — SEED_CUTOFF와 달리 영구
+# 동결이 아님). 이 스캔은 PG 없이 실 코퍼스만 보고 "CONCURRENTLY 포함 파일 ⊆
+# (NONTX_ALLOWLIST ∪ 함수본문-전용 선언목록)"을 검증한다.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MIGRATIONS_DIR="$REPO_ROOT/packages/db/supabase/migrations"
+RUN_MIGRATIONS_SH="$SCRIPT_DIR/run-migrations.sh"
+
+NONTX_ALLOWLIST="$(grep -oE "SPRINTABLE_MIGRATIONS_NONTX_ALLOWLIST:-[^}]*" "$RUN_MIGRATIONS_SH" | sed 's/^[^:]*:-//')"
+if [ -z "$NONTX_ALLOWLIST" ]; then
+  echo "FAIL: run-migrations.sh에서 NONTX_ALLOWLIST 기본값을 추출하지 못함(정규식 drift?)"
+  exit 1
+fi
+
+# 실측(2026-08-30)으로 CONCURRENTLY가 BEGIN...END 함수 본문 **안**에만 있어 top-level이
+# 아님을 직접 확인한 파일 — 새로 추가되는 파일은 여기 없으니 이 스캔이 반드시 잡는다.
+# 재분류 시: top-level이면 → run-migrations.sh의 NONTX_ALLOWLIST에 추가.
+#            함수 본문 안이면 → 아래 목록에 추가(`grep -B2 -A2 "CONCURRENTLY" <file>`로
+#            BEGIN...END 안인지 직접 눈으로 확인 후).
+FUNCTION_BODY_ONLY_DECLARED="20260407110000_monthly_agent_usage_view.sql 20260408092000_agent_hitl_pending_status.sql 20260425140000_reward_balances_view.sql"
+
+UNACCOUNTED=""
+for f in "$MIGRATIONS_DIR"/*.sql; do
+  name="$(basename "$f")"
+  if grep -q "CONCURRENTLY" "$f"; then
+    accounted=false
+    for known in $NONTX_ALLOWLIST $FUNCTION_BODY_ONLY_DECLARED; do
+      if [ "$known" = "$name" ]; then
+        accounted=true
+        break
+      fi
+    done
+    if [ "$accounted" = false ]; then
+      UNACCOUNTED="$UNACCOUNTED $name"
+    fi
+  fi
+done
+
+if [ -n "$UNACCOUNTED" ]; then
+  echo "FAIL: 다음 파일이 CONCURRENTLY를 포함하지만 run-migrations.sh의 NONTX_ALLOWLIST에도"
+  echo "      이 스크립트의 FUNCTION_BODY_ONLY_DECLARED(함수 본문 안임을 수동 검증한 목록)에도 없다:"
+  for name in $UNACCOUNTED; do
+    echo "  - $name"
+  done
+  echo "grep -B2 -A2 \"CONCURRENTLY\" <file> 로 top-level인지 직접 확인한 뒤:"
+  echo "  top-level이면        → run-migrations.sh의 NONTX_ALLOWLIST에 추가"
+  echo "  함수 본문(BEGIN...END) 안이면 → 이 스크립트의 FUNCTION_BODY_ONLY_DECLARED에 추가"
+  exit 1
+fi
+
+echo "OK: CONCURRENTLY 포함 파일 전부 allowlist∪함수본문-선언에 계정됨"

--- a/scripts/run-migrations.sh
+++ b/scripts/run-migrations.sh
@@ -6,39 +6,56 @@
 #   ./scripts/run-migrations.sh "postgresql://postgres:password@localhost:5432/sprintable"
 #
 # story #3219 확장(2026-08-30, 카디르 QA — 페드루 재정의) — 1차 처방(파이프 제거+
-# `psql -v ON_ERROR_STOP=1`+즉시 exit 1, 그 자체는 여전히 유효)만 얹으면 **원버그보다
-# 나쁜 회귀**였다: 이 코퍼스(packages/db/supabase/migrations)는 대부분 비멱등이다 —
-# 특히 `CREATE POLICY`(전수 270건, 129파일)는 PostgreSQL 자체에 `IF NOT EXISTS`가 없어,
-# 이미 한 번 적용된 self-host DB가 재시작할 때마다 "policy already exists"로 100%
-# 실패한다. 예전(파이프 삼킴) 모델은 그 실패를 매번 삼켜 넘어가는 게 사실상 암묵적
-# 멱등화 워크어라운드였다 — fail-closed만 얹으면 **한 번이라도 적용된 self-host DB는
-# 재시작 영구 불능**이 된다.
+# ON_ERROR_STOP+exit 1)만 얹으면 **원버그보다 나쁜 회귀**였다: 이 코퍼스(packages/db/
+# supabase/migrations)는 대부분 비멱등이다 — 특히 CREATE POLICY(전수 270건, 129파일)는
+# PostgreSQL 자체에 IF NOT EXISTS가 없어, 이미 한 번 적용된 self-host DB가 재시작할
+# 때마다 "policy already exists"로 100% 실패한다. 예전(파이프 삼킴) 모델은 그 실패를
+# 매번 삼켜 넘어가는 게 사실상 암묵적 멱등화 워크어라운드였다.
 #
-# 근본 처방 = 마이그 원장(ledger). 파일명 정렬 순으로 "아직 원장에 없는 파일만" 실행,
-# 성공하면 그 자리에서 즉시 원장에 기록 — 트랜잭션 가능한 파일은 BEGIN/COMMIT으로 감싸
-# "그 파일 전체 성공 또는 전체 미기록" 원자성을 보장한다. `CREATE INDEX CONCURRENTLY`
-# 포함 파일(5개 확인: monthly_agent_usage_view/agent_hitl_pending_status/
-# performance_indexes/hot_query_indexes/reward_balances_view)은 트랜잭션 안에서 못
-# 돌아 예외 — 그 파일들만 BEGIN/COMMIT 없이 돈다. 이 코퍼스의 CONCURRENTLY는 전부
-# `CREATE INDEX CONCURRENTLY IF NOT EXISTS` 또는 `REFRESH MATERIALIZED VIEW
-# CONCURRENTLY`라 재시도 자체가 멱등-안전함을 실측 확認(각 파일 grep 대조) — 별도
-# skip/제외 로직 불요.
+# 근본 처방 = 마이그 원장(ledger, _sprintable_migration_ledger). 파일명 정렬 순으로
+# "아직 원장에 없는 파일만" 실행, 성공하면 그 자리에서 즉시 원장에 기록 — 트랜잭션
+# 가능한 파일은 BEGIN/COMMIT으로 감싸 "그 파일 전체 성공 또는 전체 미기록" 원자성을
+# 보장한다. 동시 컨테이너 기동 대비 세션 스코프 advisory lock을 배치 시작에 걸고,
+# 세션 종료(성공·실패 무엇이든) 시 Postgres가 자동 해제한다(session-scope인 이유는
+# 아래 NONTX_ALLOWLIST 참고 — 배치 전체를 하나의 트랜잭션으로 못 감싸므로).
 #
-# 동시 컨테이너 기동 대비 — 세션 스코프 advisory lock(`pg_advisory_lock`)을 전체 배치
-# 시작에 걸고 세션 종료(성공·실패·연결종료 무엇이든) 시 Postgres가 자동 해제한다(표준
-# 동작 — 명시 unlock 없이도 안전, 실패 경로에서 ON_ERROR_STOP이 스크립트를 그 자리서
-# 멈춰도 세션 종료가 알아서 놓아준다). xact-scope가 아니라 session-scope인 이유: 위
-# CONCURRENTLY 파일들 때문에 배치 전체를 하나의 트랜잭션으로 못 감싸므로.
+# ── 2라운드 카디르 qa:changes(2026-08-30, 페드루 경유) 반영 3건 ──────────────────
 #
-# 기존 DB 시딩(급소, 페드루 지적) — 원장 자체가 신설이라, **이미 오래 운영된 self-host
-# DB**(이 코퍼스 파일 129개가 예전 모델로 이미 다 적용된 상태)가 원장을 처음 마주치면
-# "원장 부재 + 코어 테이블 실재" 조건으로 판별해 **현재 존재하는 파일 전부를 실행 없이
-# 이미 적용됨으로 시딩**한다 — 안 그러면 이미 적용된 CREATE POLICY 270건이 전부 다시
-# 실행되며 그대로 터진다. 코어 테이블 센티널은 `public.stories`(`users`는 이 코퍼스
-# 어디서도 CREATE 안 됨 — grep 0건으로 기각. `stories`는 이 디렉터리의 가장 이른 파일
-# 028_stories_meeting_ref.sql이 이미 있다고 전제하는, 001~027 베이스라인이 만드는
-# 테이블). 신선 DB(그 테이블 자체가 없음)는 시딩 없이 전량 정상 실행 — 내려가며 이
-# 코퍼스 파일들이 stories를 포함해 처음부터 다 만든다.
+# ①[HIGH] 시딩↔업그레이드 비구별 — 1라운드의 "원장 空 + stories 有 → 현재 파일 전체
+# 시딩"은 **정상 버전업**(구 DB + 신규 SQL 실린 새 이미지)도 똑같이 만족시켜, 신규
+# 파일까지 무실행 "적용됨"으로 오기록 → 영구 스키마 누락이 된다. 처방: SEED_CUTOFF를
+# "이 PR이 머지되는 시점 기준 최신 파일명"으로 **명시 고정**한다(느슨한 휴리스틱이
+# 아니라 상수) — 시딩은 cutoff 이하 파일만 기록하고, cutoff 초과 파일은 시딩 대상에서
+# 애초에 제외돼 항상 아래 "실 적용 루프"를 그대로 통과한다(원장에 없으니 진짜 실행).
+# ⛔ 잔여 구멍(가드가 못 잡는 것 — feedback_guard_must_declare_what_it_misses) — 이
+# cutoff보다 오래된 self-host DB가 cutoff 이전 파일 중 일부를 실제로는 못 받은 채(예:
+# 과거 실패가 방치된 채) 여러 릴리스를 건너뛰어 이 이미지로 바로 점프하면, 그 결손은
+# 이 설계로 못 닫는다 — 그런 DB는 "pre-ledger 마지막 릴리스를 최소 한 번은 정상 기동해
+# 통과시킨 뒤" 이 이미지로 올라오는 것을 전제한다(문서화 요구사항, 자동 검증 불가).
+# SEED_CUTOFF는 새 supabase migration 파일이 develop에 머지될 때마다 최신값으로 갱신
+# 필요 — 이 상수를 안 올리면 새 파일이 오분류로 시딩될 위험이 있다.
+#
+# ②[HIGH] INVALID 인덱스 마스킹 — CREATE INDEX CONCURRENTLY가 (락 경합·중복키 등으로)
+# 도중 실패하면 Postgres는 롤백하지 않고 그 인덱스를 INVALID 상태로 **남겨둔다**. 같은
+# 이름의 IF NOT EXISTS는 "이미 존재"만 보고 다음 재시도에서 조용히 스킵 — 원장엔
+# "적용됨"으로 기록되지만 인덱스는 계속 깨진 채다. 처방: NONTX_ALLOWLIST 파일에서
+# CREATE INDEX CONCURRENTLY IF NOT EXISTS 대상 인덱스명을 파일 자체에서 grep 추출해,
+# 실행 前 INVALID면 DROP INDEX CONCURRENTLY로 선삭제(재빌드 유도) 후 파일 실행, 실행
+# 後 여전히 INVALID면 DO 블록으로 RAISE EXCEPTION(ON_ERROR_STOP이 원장기록 前에 정지 —
+# 반쪽 성공을 "적용됨"으로 남기지 않는다).
+#
+# ③[MED] grep 과대 매치 — 옛 처방은 파일 전체에서 문자열 "CONCURRENTLY"가 한 번이라도
+# 보이면 그 파일 전체를 무-트랜잭션으로 강등했다. 실측(20260407110000/20260408092000/
+# 20260425140000 3개 파일)해보니 REFRESH MATERIALIZED VIEW CONCURRENTLY가 함수 본문
+# (BEGIN...END) **안**에만 있어 top-level 실행문이 아니었다 — 그 3개는 트랜잭션 안에서
+# 전혀 문제없이 돌아가는데도 불필요하게 원자성을 잃고 있었다. top-level 실행문 판별을
+# 범용 파서 없이 안전하게 하긴 어려우므로, 실측으로 확定한 **명시 allowlist**로
+# 대체한다(카디르 승인 방식) — 이 목록은 실제로 top-level에서 CREATE INDEX CONCURRENTLY
+# 를 쓰는 파일 2개(20260414182300_performance_indexes.sql,
+# 20260408133000_hot_query_indexes.sql)뿐이다. ⚠️ 재실측 조건: 이 디렉터리에 top-level
+# CONCURRENTLY 구문(CREATE INDEX CONCURRENTLY, DROP INDEX CONCURRENTLY, REINDEX
+# CONCURRENTLY 등)을 쓰는 새 파일이 추가되면 이 allowlist도 같이 갱신해야 한다 —
+# `grep -B2 -A2 "CONCURRENTLY" <file>`로 BEGIN...END 함수 본문 밖인지 직접 눈으로 확인.
 
 set -eu
 
@@ -68,6 +85,32 @@ LEDGER_TABLE="_sprintable_migration_ledger"
 LOCK_EXPR="hashtext('sprintable_migrations_ledger_lock')"
 SENTINEL_TABLE="public.stories"
 
+# ①의 cutoff — 이 PR(#3219) 머지 시점 기준 packages/db/supabase/migrations의 최신
+# 파일명(2026-08-30, `ls packages/db/supabase/migrations/*.sql | sort | tail -1`로
+# 실측 확定, origin/develop과 동기 확인 후 고정). 테스트에서만
+# SPRINTABLE_MIGRATIONS_SEED_CUTOFF로 오버라이드(합성 파일명 대응).
+SEED_CUTOFF="${SPRINTABLE_MIGRATIONS_SEED_CUTOFF:-20260830000000_retire_inbox_items_and_outbox.sql}"
+
+# ③의 allowlist — 위 헤더 코멘트 참고. 테스트에서만
+# SPRINTABLE_MIGRATIONS_NONTX_ALLOWLIST로 오버라이드(공백구분 파일명 목록).
+NONTX_ALLOWLIST="${SPRINTABLE_MIGRATIONS_NONTX_ALLOWLIST:-20260414182300_performance_indexes.sql 20260408133000_hot_query_indexes.sql}"
+
+is_nontx() {
+  name="$1"
+  for f in $NONTX_ALLOWLIST; do
+    if [ "$f" = "$name" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+concurrent_index_names() {
+  # top-level `CREATE [UNIQUE] INDEX CONCURRENTLY IF NOT EXISTS <name>`의 <name>만
+  # 추출 — NONTX_ALLOWLIST 파일에서만 호출되므로 top-level 보장은 allowlist 자체가 짐.
+  grep -oE "CREATE (UNIQUE )?INDEX CONCURRENTLY IF NOT EXISTS [A-Za-z_][A-Za-z0-9_]*" "$1" | awk '{print $NF}'
+}
+
 SQL_SCRIPT="$(mktemp)"
 trap 'rm -f "$SQL_SCRIPT"' EXIT INT TERM
 
@@ -81,35 +124,55 @@ trap 'rm -f "$SQL_SCRIPT"' EXIT INT TERM
   echo "SELECT NOT EXISTS(SELECT 1 FROM public.$LEDGER_TABLE)"
   echo "       AND to_regclass('$SENTINEL_TABLE') IS NOT NULL AS needs_seed \\gset"
   echo "\\if :needs_seed"
-  echo "  \\echo '  🌱 기존 DB 시딩 — 현재 파일 전체를 실행 없이 already-applied로 기록'"
+  echo "  \\echo '  🌱 기존 DB 시딩 — cutoff($SEED_CUTOFF) 이하 파일만 실행 없이 already-applied로 기록'"
+  past_cutoff=false
   for file in $(ls "$MIGRATIONS_ABS_DIR"/*.sql | sort); do
     name="$(basename "$file")"
-    esc_name="$(printf '%s' "$name" | sed "s/'/''/g")"
-    echo "  INSERT INTO public.$LEDGER_TABLE (filename, seeded) VALUES ('$esc_name', true) ON CONFLICT DO NOTHING;"
-  done
-  echo "\\else"
-  for file in $(ls "$MIGRATIONS_ABS_DIR"/*.sql | sort); do
-    name="$(basename "$file")"
-    esc_name="$(printf '%s' "$name" | sed "s/'/''/g")"
-    echo "  SELECT EXISTS(SELECT 1 FROM public.$LEDGER_TABLE WHERE filename = '$esc_name') AS already_applied \\gset"
-    echo "  \\if :already_applied"
-    echo "    \\echo '  ⏭  SKIP(이미 적용됨): $name'"
-    echo "  \\else"
-    if grep -q "CONCURRENTLY" "$file"; then
-      # CONCURRENTLY는 트랜잭션 안에서 실행 불가 — BEGIN/COMMIT 안 씌운다(이 코퍼스의
-      # CONCURRENTLY 전부 IF NOT EXISTS/REFRESH ... CONCURRENTLY라 재시도 자체가 안전).
-      echo "    \\i $file"
-      echo "    INSERT INTO public.$LEDGER_TABLE (filename) VALUES ('$esc_name');"
-    else
-      echo "    BEGIN;"
-      echo "    \\i $file"
-      echo "    INSERT INTO public.$LEDGER_TABLE (filename) VALUES ('$esc_name');"
-      echo "    COMMIT;"
+    if [ "$past_cutoff" = false ]; then
+      esc_name="$(printf '%s' "$name" | sed "s/'/''/g")"
+      echo "  INSERT INTO public.$LEDGER_TABLE (filename, seeded) VALUES ('$esc_name', true) ON CONFLICT DO NOTHING;"
+      if [ "$name" = "$SEED_CUTOFF" ]; then
+        past_cutoff=true
+      fi
     fi
-    echo "    \\echo '  ✅ 적용됨: $name'"
-    echo "  \\endif"
   done
   echo "\\endif"
+  echo ""
+  echo "-- 시딩 여부와 무관하게 항상 실행 — 원장에 없는(=cutoff 초과 신규 포함) 파일만 실 적용 --"
+  for file in $(ls "$MIGRATIONS_ABS_DIR"/*.sql | sort); do
+    name="$(basename "$file")"
+    esc_name="$(printf '%s' "$name" | sed "s/'/''/g")"
+    echo "SELECT EXISTS(SELECT 1 FROM public.$LEDGER_TABLE WHERE filename = '$esc_name') AS already_applied \\gset"
+    echo "\\if :already_applied"
+    echo "  \\echo '  ⏭  SKIP(이미 적용됨): $name'"
+    echo "\\else"
+    if is_nontx "$name"; then
+      for idx in $(concurrent_index_names "$file"); do
+        echo "  SELECT EXISTS(SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid WHERE c.relname = '$idx' AND NOT i.indisvalid) AS idx_invalid \\gset"
+        echo "  \\if :idx_invalid"
+        echo "    \\echo '    🔧 INVALID 인덱스 감지, 재생성 위해 선삭제: $idx'"
+        echo "    DROP INDEX CONCURRENTLY IF EXISTS $idx;"
+        echo "  \\endif"
+      done
+      echo "  \\i $file"
+      for idx in $(concurrent_index_names "$file"); do
+        echo "  DO \$\$"
+        echo "  BEGIN"
+        echo "    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid WHERE c.relname = '$idx' AND NOT i.indisvalid) THEN"
+        echo "      RAISE EXCEPTION 'index $idx still INVALID after CONCURRENTLY rebuild — manual intervention required';"
+        echo "    END IF;"
+        echo "  END \$\$;"
+      done
+      echo "  INSERT INTO public.$LEDGER_TABLE (filename) VALUES ('$esc_name');"
+    else
+      echo "  BEGIN;"
+      echo "  \\i $file"
+      echo "  INSERT INTO public.$LEDGER_TABLE (filename) VALUES ('$esc_name');"
+      echo "  COMMIT;"
+    fi
+    echo "  \\echo '  ✅ 적용됨: $name'"
+    echo "\\endif"
+  done
   echo "SELECT pg_advisory_unlock($LOCK_EXPR);"
 } > "$SQL_SCRIPT"
 

--- a/scripts/run-migrations.sh
+++ b/scripts/run-migrations.sh
@@ -4,6 +4,25 @@
 #
 # Example:
 #   ./scripts/run-migrations.sh "postgresql://postgres:password@localhost:5432/sprintable"
+#
+# story #3219(2026-08-30, 카디르 3618 QA 4라운드 실측) — 예전엔
+# `psql ... | grep -v "^$" | head -5` 뒤 `$?`를 봤는데, 파이프의 마지막 명령은
+# `head`(거의 항상 성공)라 psql 자신의 실패 종료코드가 그 자리에서 이미 사라진 뒤였다
+# (grep -v "^$" 도 매치 없으면 1을 내는 별개 함정). 게다가 걸렸어도 "⚠️ Warning" 한 줄
+# 찍고 다음 파일로 넘어갈 뿐 — 마이그 하나가 깨져도 컨테이너는 계속 뜬다(조용한 부분
+# 적용). self-host 사용자에게 스키마가 "일부만 반영된 채" 정상처럼 보이는 신뢰 결함.
+#
+# 처방: 파이프를 없애 종료코드가 살아있는 상태로 직접 psql을 조건문에 건다(set -e도
+# 파이프 안에서는 안 걸리므로 애초에 파이프 자체를 없애는 게 정공법). `-v
+# ON_ERROR_STOP=1`로 psql이 한 파일 안에서도 첫 에러에서 즉시 멈추게 하고(기존엔 에러
+# 줄만 찍고 다음 문장으로 계속 갔다), 실패 시 그 파일에서 즉시 exit 1 — ENTRYPOINT의
+# `&&` 체인이 뒤의 `node apps/web/server.js`를 아예 안 돈다(fail-closed, 부분 적용
+# 상태로는 앱이 안 뜬다). `set -eu`만 쓰고 `pipefail`은 안 쓴다 — 이 스크립트가 돌아가는
+# 실 런타임(Dockerfile의 node:22-alpine, ENTRYPOINT가 `/bin/sh -c`로 호출)은 busybox
+# ash라 POSIX에 없는 `pipefail`을 모른다(bash 확장) — 그리고 애초에 파이프를 없앴으니
+# 필요도 없다.
+
+set -eu
 
 DB_URL="${1:-$DATABASE_URL}"
 
@@ -28,10 +47,13 @@ fi
 echo "🔄 Running migrations from $MIGRATIONS_DIR..."
 
 for file in $(ls "$MIGRATIONS_DIR"/*.sql | sort); do
-  echo "  → $(basename $file)"
-  psql "$DB_URL" -f "$file" 2>&1 | grep -v "^$" | head -5
-  if [ $? -ne 0 ]; then
-    echo "  ⚠️  Warning: $(basename $file) had issues (may be idempotent)"
+  name="$(basename "$file")"
+  echo "  → $name"
+  if psql "$DB_URL" -v ON_ERROR_STOP=1 -f "$file"; then
+    echo "  ✅ OK: $name"
+  else
+    echo "  ❌ FAILED: $name — fail-closed 기동 중단"
+    exit 1
   fi
 done
 

--- a/scripts/run-migrations.sh
+++ b/scripts/run-migrations.sh
@@ -32,8 +32,17 @@
 # 과거 실패가 방치된 채) 여러 릴리스를 건너뛰어 이 이미지로 바로 점프하면, 그 결손은
 # 이 설계로 못 닫는다 — 그런 DB는 "pre-ledger 마지막 릴리스를 최소 한 번은 정상 기동해
 # 통과시킨 뒤" 이 이미지로 올라오는 것을 전제한다(문서화 요구사항, 자동 검증 불가).
-# SEED_CUTOFF는 새 supabase migration 파일이 develop에 머지될 때마다 최신값으로 갱신
-# 필요 — 이 상수를 안 올리면 새 파일이 오분류로 시딩될 위험이 있다.
+#
+# SEED_CUTOFF는 **이후 절대 전진시키지 않는다**(페드루 지적, 2026-08-30 — 최초 처방의
+# "새 파일 머지마다 갱신" 문구 자체가 ①버그 재도입이었다). 이유: «원장이 없는 DB»는
+# 정의상 이 원장 기반 스크립트를 단 한 번도 부팅한 적 없는 DB뿐이다(원장 있는 이미지는
+# 첫 부팅에 반드시 원장 테이블을 만들어, 그 뒤로는 needs_seed가 영원히 false가 되므로).
+# 그런 DB가 "원장 도입 이후에" 추가된 파일을 실제로 적용했을 가능성은 구조적으로 0이다
+# — 그 파일들은 원장 없는 이미지로는 애초에 실려올 수 없었기 때문. cutoff를 나중에
+# 전진시키면 "원장 도입 이후 새로 추가된, 아직 아무 DB도 실행한 적 없는 파일"까지
+# "이미 적용됨"으로 시딩해버려 straggler 오분류(①버그)를 그대로 재도입한다. cutoff는
+# **이 PR(원장 도입 시점) 파일셋에 영구 동결**된 역사적 상수이며, 손대야 할 미래
+# 시나리오는 존재하지 않는다.
 #
 # ②[HIGH] INVALID 인덱스 마스킹 — CREATE INDEX CONCURRENTLY가 (락 경합·중복키 등으로)
 # 도중 실패하면 Postgres는 롤백하지 않고 그 인덱스를 INVALID 상태로 **남겨둔다**. 같은
@@ -52,10 +61,15 @@
 # 범용 파서 없이 안전하게 하긴 어려우므로, 실측으로 확定한 **명시 allowlist**로
 # 대체한다(카디르 승인 방식) — 이 목록은 실제로 top-level에서 CREATE INDEX CONCURRENTLY
 # 를 쓰는 파일 2개(20260414182300_performance_indexes.sql,
-# 20260408133000_hot_query_indexes.sql)뿐이다. ⚠️ 재실측 조건: 이 디렉터리에 top-level
-# CONCURRENTLY 구문(CREATE INDEX CONCURRENTLY, DROP INDEX CONCURRENTLY, REINDEX
-# CONCURRENTLY 등)을 쓰는 새 파일이 추가되면 이 allowlist도 같이 갱신해야 한다 —
-# `grep -B2 -A2 "CONCURRENTLY" <file>`로 BEGIN...END 함수 본문 밖인지 직접 눈으로 확인.
+# 20260408133000_hot_query_indexes.sql)뿐이다. ⚠️ 재실측 조건(SEED_CUTOFF와 달리 이
+# allowlist는 새 CONCURRENTLY 파일이 생길 때마다 실제로 갱신 의무가 남는 자리다) — 이
+# 디렉터리에 top-level CONCURRENTLY 구문(CREATE INDEX CONCURRENTLY, DROP INDEX
+# CONCURRENTLY, REINDEX CONCURRENTLY 등)을 쓰는 새 파일이 추가되면 이 allowlist도 같이
+# 갱신해야 한다 — `grep -B2 -A2 "CONCURRENTLY" <file>`로 BEGIN...END 함수 본문 밖인지
+# 직접 눈으로 확인. 사람이 깜빡해도 조용히 안 넘어가도록 run-migrations.test.sh
+# 시나리오 [9]가 "실 코퍼스의 CONCURRENTLY 포함 파일 ⊆ (이 allowlist ∪ 함수본문-전용으로
+# 수동 검증된 선언 목록)"을 매번 재확인하는 트립와이어다 — 새 파일을 놓치면 그 시나리오가
+# RED로 재분류를 강제한다(페드루 지적, 2026-08-30).
 
 set -eu
 
@@ -87,8 +101,9 @@ SENTINEL_TABLE="public.stories"
 
 # ①의 cutoff — 이 PR(#3219) 머지 시점 기준 packages/db/supabase/migrations의 최신
 # 파일명(2026-08-30, `ls packages/db/supabase/migrations/*.sql | sort | tail -1`로
-# 실측 확定, origin/develop과 동기 확인 후 고정). 테스트에서만
-# SPRINTABLE_MIGRATIONS_SEED_CUTOFF로 오버라이드(합성 파일명 대응).
+# 실측 확定, origin/develop과 동기 확인 후 고정). **영구 동결 — 위 ①단락 근거로 이후
+# 다시 전진시키지 않는다.** 테스트에서만 SPRINTABLE_MIGRATIONS_SEED_CUTOFF로
+# 오버라이드(합성 파일명 대응).
 SEED_CUTOFF="${SPRINTABLE_MIGRATIONS_SEED_CUTOFF:-20260830000000_retire_inbox_items_and_outbox.sql}"
 
 # ③의 allowlist — 위 헤더 코멘트 참고. 테스트에서만

--- a/scripts/run-migrations.sh
+++ b/scripts/run-migrations.sh
@@ -5,22 +5,40 @@
 # Example:
 #   ./scripts/run-migrations.sh "postgresql://postgres:password@localhost:5432/sprintable"
 #
-# story #3219(2026-08-30, 카디르 3618 QA 4라운드 실측) — 예전엔
-# `psql ... | grep -v "^$" | head -5` 뒤 `$?`를 봤는데, 파이프의 마지막 명령은
-# `head`(거의 항상 성공)라 psql 자신의 실패 종료코드가 그 자리에서 이미 사라진 뒤였다
-# (grep -v "^$" 도 매치 없으면 1을 내는 별개 함정). 게다가 걸렸어도 "⚠️ Warning" 한 줄
-# 찍고 다음 파일로 넘어갈 뿐 — 마이그 하나가 깨져도 컨테이너는 계속 뜬다(조용한 부분
-# 적용). self-host 사용자에게 스키마가 "일부만 반영된 채" 정상처럼 보이는 신뢰 결함.
+# story #3219 확장(2026-08-30, 카디르 QA — 페드루 재정의) — 1차 처방(파이프 제거+
+# `psql -v ON_ERROR_STOP=1`+즉시 exit 1, 그 자체는 여전히 유효)만 얹으면 **원버그보다
+# 나쁜 회귀**였다: 이 코퍼스(packages/db/supabase/migrations)는 대부분 비멱등이다 —
+# 특히 `CREATE POLICY`(전수 270건, 129파일)는 PostgreSQL 자체에 `IF NOT EXISTS`가 없어,
+# 이미 한 번 적용된 self-host DB가 재시작할 때마다 "policy already exists"로 100%
+# 실패한다. 예전(파이프 삼킴) 모델은 그 실패를 매번 삼켜 넘어가는 게 사실상 암묵적
+# 멱등화 워크어라운드였다 — fail-closed만 얹으면 **한 번이라도 적용된 self-host DB는
+# 재시작 영구 불능**이 된다.
 #
-# 처방: 파이프를 없애 종료코드가 살아있는 상태로 직접 psql을 조건문에 건다(set -e도
-# 파이프 안에서는 안 걸리므로 애초에 파이프 자체를 없애는 게 정공법). `-v
-# ON_ERROR_STOP=1`로 psql이 한 파일 안에서도 첫 에러에서 즉시 멈추게 하고(기존엔 에러
-# 줄만 찍고 다음 문장으로 계속 갔다), 실패 시 그 파일에서 즉시 exit 1 — ENTRYPOINT의
-# `&&` 체인이 뒤의 `node apps/web/server.js`를 아예 안 돈다(fail-closed, 부분 적용
-# 상태로는 앱이 안 뜬다). `set -eu`만 쓰고 `pipefail`은 안 쓴다 — 이 스크립트가 돌아가는
-# 실 런타임(Dockerfile의 node:22-alpine, ENTRYPOINT가 `/bin/sh -c`로 호출)은 busybox
-# ash라 POSIX에 없는 `pipefail`을 모른다(bash 확장) — 그리고 애초에 파이프를 없앴으니
-# 필요도 없다.
+# 근본 처방 = 마이그 원장(ledger). 파일명 정렬 순으로 "아직 원장에 없는 파일만" 실행,
+# 성공하면 그 자리에서 즉시 원장에 기록 — 트랜잭션 가능한 파일은 BEGIN/COMMIT으로 감싸
+# "그 파일 전체 성공 또는 전체 미기록" 원자성을 보장한다. `CREATE INDEX CONCURRENTLY`
+# 포함 파일(5개 확인: monthly_agent_usage_view/agent_hitl_pending_status/
+# performance_indexes/hot_query_indexes/reward_balances_view)은 트랜잭션 안에서 못
+# 돌아 예외 — 그 파일들만 BEGIN/COMMIT 없이 돈다. 이 코퍼스의 CONCURRENTLY는 전부
+# `CREATE INDEX CONCURRENTLY IF NOT EXISTS` 또는 `REFRESH MATERIALIZED VIEW
+# CONCURRENTLY`라 재시도 자체가 멱등-안전함을 실측 확認(각 파일 grep 대조) — 별도
+# skip/제외 로직 불요.
+#
+# 동시 컨테이너 기동 대비 — 세션 스코프 advisory lock(`pg_advisory_lock`)을 전체 배치
+# 시작에 걸고 세션 종료(성공·실패·연결종료 무엇이든) 시 Postgres가 자동 해제한다(표준
+# 동작 — 명시 unlock 없이도 안전, 실패 경로에서 ON_ERROR_STOP이 스크립트를 그 자리서
+# 멈춰도 세션 종료가 알아서 놓아준다). xact-scope가 아니라 session-scope인 이유: 위
+# CONCURRENTLY 파일들 때문에 배치 전체를 하나의 트랜잭션으로 못 감싸므로.
+#
+# 기존 DB 시딩(급소, 페드루 지적) — 원장 자체가 신설이라, **이미 오래 운영된 self-host
+# DB**(이 코퍼스 파일 129개가 예전 모델로 이미 다 적용된 상태)가 원장을 처음 마주치면
+# "원장 부재 + 코어 테이블 실재" 조건으로 판별해 **현재 존재하는 파일 전부를 실행 없이
+# 이미 적용됨으로 시딩**한다 — 안 그러면 이미 적용된 CREATE POLICY 270건이 전부 다시
+# 실행되며 그대로 터진다. 코어 테이블 센티널은 `public.stories`(`users`는 이 코퍼스
+# 어디서도 CREATE 안 됨 — grep 0건으로 기각. `stories`는 이 디렉터리의 가장 이른 파일
+# 028_stories_meeting_ref.sql이 이미 있다고 전제하는, 001~027 베이스라인이 만드는
+# 테이블). 신선 DB(그 테이블 자체가 없음)는 시딩 없이 전량 정상 실행 — 내려가며 이
+# 코퍼스 파일들이 stories를 포함해 처음부터 다 만든다.
 
 set -eu
 
@@ -44,17 +62,61 @@ if [ ! -d "$MIGRATIONS_DIR" ]; then
   exit 1
 fi
 
-echo "🔄 Running migrations from $MIGRATIONS_DIR..."
+MIGRATIONS_ABS_DIR="$(cd "$MIGRATIONS_DIR" && pwd)"
+LEDGER_TABLE="_sprintable_migration_ledger"
+# supabase CLI 자체 원장(public.supabase_migrations)과 이름 충돌 회피.
+LOCK_EXPR="hashtext('sprintable_migrations_ledger_lock')"
+SENTINEL_TABLE="public.stories"
 
-for file in $(ls "$MIGRATIONS_DIR"/*.sql | sort); do
-  name="$(basename "$file")"
-  echo "  → $name"
-  if psql "$DB_URL" -v ON_ERROR_STOP=1 -f "$file"; then
-    echo "  ✅ OK: $name"
-  else
-    echo "  ❌ FAILED: $name — fail-closed 기동 중단"
-    exit 1
-  fi
-done
+SQL_SCRIPT="$(mktemp)"
+trap 'rm -f "$SQL_SCRIPT"' EXIT INT TERM
 
-echo "✅ Migrations complete."
+{
+  echo "SELECT pg_advisory_lock($LOCK_EXPR);"
+  echo "CREATE TABLE IF NOT EXISTS public.$LEDGER_TABLE ("
+  echo "  filename text PRIMARY KEY,"
+  echo "  applied_at timestamptz NOT NULL DEFAULT now(),"
+  echo "  seeded boolean NOT NULL DEFAULT false"
+  echo ");"
+  echo "SELECT NOT EXISTS(SELECT 1 FROM public.$LEDGER_TABLE)"
+  echo "       AND to_regclass('$SENTINEL_TABLE') IS NOT NULL AS needs_seed \\gset"
+  echo "\\if :needs_seed"
+  echo "  \\echo '  🌱 기존 DB 시딩 — 현재 파일 전체를 실행 없이 already-applied로 기록'"
+  for file in $(ls "$MIGRATIONS_ABS_DIR"/*.sql | sort); do
+    name="$(basename "$file")"
+    esc_name="$(printf '%s' "$name" | sed "s/'/''/g")"
+    echo "  INSERT INTO public.$LEDGER_TABLE (filename, seeded) VALUES ('$esc_name', true) ON CONFLICT DO NOTHING;"
+  done
+  echo "\\else"
+  for file in $(ls "$MIGRATIONS_ABS_DIR"/*.sql | sort); do
+    name="$(basename "$file")"
+    esc_name="$(printf '%s' "$name" | sed "s/'/''/g")"
+    echo "  SELECT EXISTS(SELECT 1 FROM public.$LEDGER_TABLE WHERE filename = '$esc_name') AS already_applied \\gset"
+    echo "  \\if :already_applied"
+    echo "    \\echo '  ⏭  SKIP(이미 적용됨): $name'"
+    echo "  \\else"
+    if grep -q "CONCURRENTLY" "$file"; then
+      # CONCURRENTLY는 트랜잭션 안에서 실행 불가 — BEGIN/COMMIT 안 씌운다(이 코퍼스의
+      # CONCURRENTLY 전부 IF NOT EXISTS/REFRESH ... CONCURRENTLY라 재시도 자체가 안전).
+      echo "    \\i $file"
+      echo "    INSERT INTO public.$LEDGER_TABLE (filename) VALUES ('$esc_name');"
+    else
+      echo "    BEGIN;"
+      echo "    \\i $file"
+      echo "    INSERT INTO public.$LEDGER_TABLE (filename) VALUES ('$esc_name');"
+      echo "    COMMIT;"
+    fi
+    echo "    \\echo '  ✅ 적용됨: $name'"
+    echo "  \\endif"
+  done
+  echo "\\endif"
+  echo "SELECT pg_advisory_unlock($LOCK_EXPR);"
+} > "$SQL_SCRIPT"
+
+echo "🔄 Running migrations from $MIGRATIONS_DIR (원장 기반, 미적용분만)..."
+if psql "$DB_URL" -v ON_ERROR_STOP=1 -f "$SQL_SCRIPT"; then
+  echo "✅ Migrations complete."
+else
+  echo "❌ Migration run failed — fail-closed 기동 중단"
+  exit 1
+fi

--- a/scripts/run-migrations.test.sh
+++ b/scripts/run-migrations.test.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-# story #3219(2026-08-30, 카디르 3618 QA 4라운드 실측) — run-migrations.sh의 옛 파이프
-# 기반 실패 감지(`psql ... | grep -v "^$" | head -5; if [ $? -ne 0 ]`)가 실제로 psql의
-# 종료코드를 못 보고(파이프 마지막 명령은 head, 거의 항상 성공) SQL이 깨져도 "⚠️ Warning"
-# 한 줄만 찍고 다음 파일로 계속 진행했다 — self-host 컨테이너가 부분 적용된 스키마로
-# 조용히 정상처럼 뜨는 신뢰 결함. 진짜 로컬 Postgres(backend/scripts/disposable_pg.sh
-# 재사용, story #3199)에 SQL 파일 3개(성공·고의 파손·성공)를 먹여 실행 결과로 고정한다 —
-# narrative가 아니라 실제 psql 호출·실제 종료코드로.
+# story #3219(2026-08-30, 페드루 마이그 원장 리디자인 지시) — run-migrations.sh를 단순
+# ON_ERROR_STOP+exit 1(카디르 3618 QA 4라운드 처방)에서 원장(ledger) 기반으로 재설계.
+# 이유: 이 코퍼스(packages/db/supabase/migrations)의 CREATE POLICY 270건은 구조적으로
+# 비멱등(IF NOT EXISTS 문법 자체가 없음) — fail-closed만 얹으면 이미 한 번 적용된
+# self-host DB가 재시작 영구 불능이 되는 회귀였다(카디르 재실측). 아래 6개 시나리오를
+# 실 로컬 Postgres(backend/scripts/disposable_pg.sh 재사용, story #3199)로 고정한다 —
+# narrative가 아니라 실제 psql 호출·실제 종료코드·실제 원장 row로.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$SCRIPT_DIR/run-migrations.sh"
 DISPOSABLE_PG="$SCRIPT_DIR/../backend/scripts/disposable_pg.sh"
-PORT=55501
+PORT=55502
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
@@ -27,27 +27,28 @@ assert_eq() {
   fi
 }
 
-# ── 합성 마이그레이션 디렉터리: 001(성공) → 002(고의 파손) → 003(성공, 도달하면 안 됨) ──
-SANDBOX="$WORK/sandbox"
-mkdir -p "$SANDBOX/packages/db/supabase/migrations" "$SANDBOX/scripts"
-cp "$SCRIPT" "$SANDBOX/scripts/run-migrations.sh"
-cat > "$SANDBOX/packages/db/supabase/migrations/001_ok.sql" <<'EOF'
-CREATE TABLE public.file_one_marker (id int);
-EOF
-cat > "$SANDBOX/packages/db/supabase/migrations/002_broken.sql" <<'EOF'
-THIS IS NOT VALID SQL AT ALL;
-EOF
-cat > "$SANDBOX/packages/db/supabase/migrations/003_ok.sql" <<'EOF'
-CREATE TABLE public.file_three_marker (id int);
-EOF
+sql1() { psql -h 127.0.0.1 -p "$PORT" -U postgres -d "$1" -tAc "$2" 2>/dev/null; }
+
+mk_sandbox() {
+  # $1 = sandbox dir name (under $WORK)
+  local dir="$WORK/$1"
+  mkdir -p "$dir/packages/db/supabase/migrations" "$dir/scripts"
+  cp "$SCRIPT" "$dir/scripts/run-migrations.sh"
+  echo "$dir"
+}
+
+run_script() {
+  # $1 = sandbox dir, $2 = db name → sets $EXIT_CODE, $OUT
+  ( cd "$1" && sh scripts/run-migrations.sh "postgresql://postgres@127.0.0.1:$PORT/$2" ) >"$WORK/last_out.txt" 2>&1
+  EXIT_CODE=$?
+  OUT="$(cat "$WORK/last_out.txt")"
+}
 
 echo "== 실 disposable PG 기동(story #3199 리그 재사용, 세션 모드) =="
 DATA_DIR="$WORK/pgdata"
 PG_BIN="$(dirname "$(command -v postgres 2>/dev/null || echo /opt/homebrew/opt/postgresql@16/bin/postgres)")"
 export PATH="$PG_BIN:$PATH"
 
-# 세션 모드(원샷 아님) — 이 테스트는 여러 psql/스크립트 호출이 필요해 같은 인스턴스를
-# 계속 붙들고, 끝에 직접 SIGTERM으로 정지한다(#3199 배경 sleep+wait라 즉시 반응).
 "$DISPOSABLE_PG" "$DATA_DIR" "$PORT" &
 PG_SESSION_PID=$!
 for _ in $(seq 1 30); do
@@ -55,44 +56,143 @@ for _ in $(seq 1 30); do
   sleep 0.3
 done
 
-DB_URL="postgresql://postgres@127.0.0.1:$PORT/postgres"
-createdb -h 127.0.0.1 -p "$PORT" -U postgres fault_test
-
+# ── 시나리오 1: 신선 설치 — stories 부재, 원장 부재 → 시딩 없이 전량 정상 실행 ──
 echo
-echo "== 고의 파손 파일 포함 실행 — fail-closed 실증 =="
-cd "$SANDBOX"
-if OUT="$(sh scripts/run-migrations.sh "postgresql://postgres@127.0.0.1:$PORT/fault_test" 2>&1)"; then
-  EXIT_CODE=0
-else
-  EXIT_CODE=$?
-fi
+echo "== [1] 신선 설치 =="
+createdb -h 127.0.0.1 -p "$PORT" -U postgres db_fresh
+SB1="$(mk_sandbox sb_fresh)"
+cat > "$SB1/packages/db/supabase/migrations/001_ok.sql" <<'EOF'
+CREATE TABLE public.fresh_marker_one (id int);
+EOF
+cat > "$SB1/packages/db/supabase/migrations/002_ok.sql" <<'EOF'
+CREATE TABLE public.fresh_marker_two (id int);
+EOF
+run_script "$SB1" db_fresh
 echo "$OUT"
-echo "  (script exit=$EXIT_CODE)"
+assert_eq "[1] 신선 설치 exit=0" "0" "$EXIT_CODE"
+assert_eq "[1] 001 적용됨" "t" "$(sql1 db_fresh "SELECT to_regclass('public.fresh_marker_one') IS NOT NULL")"
+assert_eq "[1] 002 적용됨" "t" "$(sql1 db_fresh "SELECT to_regclass('public.fresh_marker_two') IS NOT NULL")"
+assert_eq "[1] 원장에 시딩 아닌 실행행 2건" "2" "$(sql1 db_fresh "SELECT COUNT(*) FROM public._sprintable_migration_ledger WHERE NOT seeded")"
 
-assert_eq "고의 파손 시 스크립트 exit code != 0" "1" "$EXIT_CODE"
-
-ONE_COUNT="$(psql -h 127.0.0.1 -p "$PORT" -U postgres -d fault_test -tAc "SELECT COUNT(*) FROM file_one_marker" 2>/dev/null || echo "MISSING")"
-assert_eq "001(고장 이전) 파일은 정상 적용됨" "0" "$ONE_COUNT"
-
-THREE_EXISTS="$(psql -h 127.0.0.1 -p "$PORT" -U postgres -d fault_test -tAc "SELECT to_regclass('public.file_three_marker') IS NOT NULL" 2>/dev/null || echo "ERROR")"
-assert_eq "003(고장 이후) 파일은 절대 적용 안 됨(halt 실증)" "f" "$THREE_EXISTS"
-
+# ── 시나리오 2: 무변경 재시작 — 같은 파일로 재실행, 전부 SKIP, 무오류 ──
 echo
-echo "== 정상 경로(고장 없음) — 무회귀 =="
-createdb -h 127.0.0.1 -p "$PORT" -U postgres good_test
-SANDBOX_GOOD="$WORK/sandbox_good"
-mkdir -p "$SANDBOX_GOOD/packages/db/supabase/migrations" "$SANDBOX_GOOD/scripts"
-cp "$SCRIPT" "$SANDBOX_GOOD/scripts/run-migrations.sh"
-cp "$SANDBOX/packages/db/supabase/migrations/001_ok.sql" "$SANDBOX_GOOD/packages/db/supabase/migrations/"
-cp "$SANDBOX/packages/db/supabase/migrations/003_ok.sql" "$SANDBOX_GOOD/packages/db/supabase/migrations/"
-cd "$SANDBOX_GOOD"
-if GOOD_OUT="$(sh scripts/run-migrations.sh "postgresql://postgres@127.0.0.1:$PORT/good_test" 2>&1)"; then
-  GOOD_EXIT=0
-else
-  GOOD_EXIT=$?
-fi
-echo "$GOOD_OUT"
-assert_eq "고장 없는 정상 경로는 exit=0" "0" "$GOOD_EXIT"
+echo "== [2] 무변경 재시작(멱등) =="
+run_script "$SB1" db_fresh
+echo "$OUT"
+assert_eq "[2] 무변경 재시작 exit=0" "0" "$EXIT_CODE"
+assert_eq "[2] 원장 row 여전히 2건(중복 없음)" "2" "$(sql1 db_fresh "SELECT COUNT(*) FROM public._sprintable_migration_ledger")"
+case "$OUT" in
+  *"SKIP"*"001_ok.sql"*) echo "  ok   [2] 001 SKIP 로그 확認" ;;
+  *) echo "  FAIL [2] 001 SKIP 로그 없음"; FAIL=1 ;;
+esac
+
+# ── 시나리오 3: 신규 파일 추가 재시작 — 003만 적용, 001/002는 SKIP ──
+echo
+echo "== [3] 신규 파일 추가 재시작 =="
+cat > "$SB1/packages/db/supabase/migrations/003_new.sql" <<'EOF'
+CREATE TABLE public.fresh_marker_three (id int);
+EOF
+run_script "$SB1" db_fresh
+echo "$OUT"
+assert_eq "[3] 신규 파일 추가 재시작 exit=0" "0" "$EXIT_CODE"
+assert_eq "[3] 003 적용됨" "t" "$(sql1 db_fresh "SELECT to_regclass('public.fresh_marker_three') IS NOT NULL")"
+assert_eq "[3] 원장 row 3건" "3" "$(sql1 db_fresh "SELECT COUNT(*) FROM public._sprintable_migration_ledger")"
+
+# ── 시나리오 4: 실패 halt — 기존 pin 유지 확인 + 수정 후 재시작 시 이어서 진행 ──
+echo
+echo "== [4] 실패 halt(기존 pin 유지) =="
+createdb -h 127.0.0.1 -p "$PORT" -U postgres db_fail
+SB4="$(mk_sandbox sb_fail)"
+cat > "$SB4/packages/db/supabase/migrations/001_ok.sql" <<'EOF'
+CREATE TABLE public.fail_marker_one (id int);
+EOF
+cat > "$SB4/packages/db/supabase/migrations/002_broken.sql" <<'EOF'
+THIS IS NOT VALID SQL AT ALL;
+EOF
+cat > "$SB4/packages/db/supabase/migrations/003_ok.sql" <<'EOF'
+CREATE TABLE public.fail_marker_three (id int);
+EOF
+run_script "$SB4" db_fail
+echo "$OUT"
+assert_eq "[4] 고의 파손 시 exit!=0" "1" "$EXIT_CODE"
+assert_eq "[4] 001(고장 이전) 적용됨" "t" "$(sql1 db_fail "SELECT to_regclass('public.fail_marker_one') IS NOT NULL")"
+assert_eq "[4] 003(고장 이후) 절대 미적용" "f" "$(sql1 db_fail "SELECT to_regclass('public.fail_marker_three') IS NOT NULL")"
+assert_eq "[4] 원장엔 001만 기록, 002/003은 없음" "1" "$(sql1 db_fail "SELECT COUNT(*) FROM public._sprintable_migration_ledger")"
+
+echo "  → 002 수정 후 재시작 — 001은 SKIP, 002/003은 이어서 정상 진행되어야 함"
+cat > "$SB4/packages/db/supabase/migrations/002_broken.sql" <<'EOF'
+CREATE TABLE public.fail_marker_two (id int);
+EOF
+run_script "$SB4" db_fail
+echo "$OUT"
+assert_eq "[4] 수정 후 재시작 exit=0" "0" "$EXIT_CODE"
+assert_eq "[4] 002 이제 적용됨" "t" "$(sql1 db_fail "SELECT to_regclass('public.fail_marker_two') IS NOT NULL")"
+assert_eq "[4] 003도 이어서 적용됨" "t" "$(sql1 db_fail "SELECT to_regclass('public.fail_marker_three') IS NOT NULL")"
+case "$OUT" in
+  *"SKIP"*"001_ok.sql"*) echo "  ok   [4] 001은 재실행 안 되고 SKIP(기존 pin 유지) 확認" ;;
+  *) echo "  FAIL [4] 001이 재실행되지 않았는지 SKIP 로그로 확인 불가"; FAIL=1 ;;
+esac
+
+# ── 시나리오 5: 기존 DB 시딩 — stories 실재 + 원장 부재 + CREATE POLICY 비멱등 재현 ──
+echo
+echo "== [5] 기존 DB 시딩(카디르가 찾은 회귀의 정면 재현) =="
+createdb -h 127.0.0.1 -p "$PORT" -U postgres db_seed
+SB5="$(mk_sandbox sb_seed)"
+cat > "$SB5/packages/db/supabase/migrations/001_ok.sql" <<'EOF'
+CREATE TABLE public.seed_marker_one (id int);
+EOF
+cat > "$SB5/packages/db/supabase/migrations/002_policy.sql" <<'EOF'
+CREATE TABLE public.seed_marker_two (id int);
+ALTER TABLE public.seed_marker_two ENABLE ROW LEVEL SECURITY;
+CREATE POLICY seed_policy ON public.seed_marker_two FOR SELECT USING (true);
+EOF
+# "이미 예전 모델로 여러 재시작을 거친 self-host DB" 를 흉내 — stories(센티널) +
+# 001/002가 실제로 이미 적용된 물리 상태를 원장 없이 만든다.
+sql1 db_seed "CREATE TABLE public.stories (id int)" > /dev/null
+sql1 db_seed "$(cat "$SB5/packages/db/supabase/migrations/001_ok.sql")" > /dev/null
+sql1 db_seed "$(cat "$SB5/packages/db/supabase/migrations/002_policy.sql")" > /dev/null
+
+run_script "$SB5" db_seed
+echo "$OUT"
+assert_eq "[5] 시딩 경로 exit=0(CREATE POLICY 중복충돌 없음)" "0" "$EXIT_CODE"
+assert_eq "[5] 원장 row 2건 전부 seeded=true" "2" "$(sql1 db_seed "SELECT COUNT(*) FROM public._sprintable_migration_ledger WHERE seeded")"
+assert_eq "[5] 실행행(비시딩)은 0건 — 실제로 안 돌았음" "0" "$(sql1 db_seed "SELECT COUNT(*) FROM public._sprintable_migration_ledger WHERE NOT seeded")"
+assert_eq "[5] 정책 중복 없이 정확히 1건" "1" "$(sql1 db_seed "SELECT COUNT(*) FROM pg_policies WHERE tablename='seed_marker_two'")"
+
+echo "  → 시딩 직후 재재시작 — 이제 원장이 있으니 정상 SKIP 경로(무회귀)"
+run_script "$SB5" db_seed
+echo "$OUT"
+assert_eq "[5] 시딩 이후 재시작도 exit=0" "0" "$EXIT_CODE"
+
+# ── 시나리오 6: 동시 기동 — advisory lock으로 직렬화, 중복/충돌 없이 둘 다 성공 ──
+echo
+echo "== [6] 동시 기동(advisory lock 직렬화) =="
+createdb -h 127.0.0.1 -p "$PORT" -U postgres db_concurrent
+SB6="$(mk_sandbox sb_concurrent)"
+cat > "$SB6/packages/db/supabase/migrations/001_ok.sql" <<'EOF'
+CREATE TABLE public.conc_marker_one (id int);
+EOF
+cat > "$SB6/packages/db/supabase/migrations/002_ok.sql" <<'EOF'
+CREATE TABLE public.conc_marker_two (id int);
+EOF
+cat > "$SB6/packages/db/supabase/migrations/003_ok.sql" <<'EOF'
+CREATE TABLE public.conc_marker_three (id int);
+EOF
+
+( cd "$SB6" && sh scripts/run-migrations.sh "postgresql://postgres@127.0.0.1:$PORT/db_concurrent" ) >"$WORK/conc_a.txt" 2>&1 &
+PID_A=$!
+( cd "$SB6" && sh scripts/run-migrations.sh "postgresql://postgres@127.0.0.1:$PORT/db_concurrent" ) >"$WORK/conc_b.txt" 2>&1 &
+PID_B=$!
+
+wait "$PID_A"; EXIT_A=$?
+wait "$PID_B"; EXIT_B=$?
+echo "-- instance A --"; cat "$WORK/conc_a.txt"
+echo "-- instance B --"; cat "$WORK/conc_b.txt"
+
+assert_eq "[6] 동시 인스턴스 A exit=0" "0" "$EXIT_A"
+assert_eq "[6] 동시 인스턴스 B exit=0" "0" "$EXIT_B"
+assert_eq "[6] 원장 중복 없이 정확히 3건" "3" "$(sql1 db_concurrent "SELECT COUNT(*) FROM public._sprintable_migration_ledger")"
+assert_eq "[6] 001 정확히 1회만 생성(중복 CREATE 충돌 없음)" "t" "$(sql1 db_concurrent "SELECT to_regclass('public.conc_marker_one') IS NOT NULL")"
 
 kill -TERM "$PG_SESSION_PID" 2>/dev/null || true
 wait "$PG_SESSION_PID" 2>/dev/null || true

--- a/scripts/run-migrations.test.sh
+++ b/scripts/run-migrations.test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# story #3219(2026-08-30, 카디르 3618 QA 4라운드 실측) — run-migrations.sh의 옛 파이프
+# 기반 실패 감지(`psql ... | grep -v "^$" | head -5; if [ $? -ne 0 ]`)가 실제로 psql의
+# 종료코드를 못 보고(파이프 마지막 명령은 head, 거의 항상 성공) SQL이 깨져도 "⚠️ Warning"
+# 한 줄만 찍고 다음 파일로 계속 진행했다 — self-host 컨테이너가 부분 적용된 스키마로
+# 조용히 정상처럼 뜨는 신뢰 결함. 진짜 로컬 Postgres(backend/scripts/disposable_pg.sh
+# 재사용, story #3199)에 SQL 파일 3개(성공·고의 파손·성공)를 먹여 실행 결과로 고정한다 —
+# narrative가 아니라 실제 psql 호출·실제 종료코드로.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/run-migrations.sh"
+DISPOSABLE_PG="$SCRIPT_DIR/../backend/scripts/disposable_pg.sh"
+PORT=55501
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FAIL=0
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  ok   $label"
+  else
+    echo "  FAIL $label — expected [$expected], got [$actual]"
+    FAIL=1
+  fi
+}
+
+# ── 합성 마이그레이션 디렉터리: 001(성공) → 002(고의 파손) → 003(성공, 도달하면 안 됨) ──
+SANDBOX="$WORK/sandbox"
+mkdir -p "$SANDBOX/packages/db/supabase/migrations" "$SANDBOX/scripts"
+cp "$SCRIPT" "$SANDBOX/scripts/run-migrations.sh"
+cat > "$SANDBOX/packages/db/supabase/migrations/001_ok.sql" <<'EOF'
+CREATE TABLE public.file_one_marker (id int);
+EOF
+cat > "$SANDBOX/packages/db/supabase/migrations/002_broken.sql" <<'EOF'
+THIS IS NOT VALID SQL AT ALL;
+EOF
+cat > "$SANDBOX/packages/db/supabase/migrations/003_ok.sql" <<'EOF'
+CREATE TABLE public.file_three_marker (id int);
+EOF
+
+echo "== 실 disposable PG 기동(story #3199 리그 재사용, 세션 모드) =="
+DATA_DIR="$WORK/pgdata"
+PG_BIN="$(dirname "$(command -v postgres 2>/dev/null || echo /opt/homebrew/opt/postgresql@16/bin/postgres)")"
+export PATH="$PG_BIN:$PATH"
+
+# 세션 모드(원샷 아님) — 이 테스트는 여러 psql/스크립트 호출이 필요해 같은 인스턴스를
+# 계속 붙들고, 끝에 직접 SIGTERM으로 정지한다(#3199 배경 sleep+wait라 즉시 반응).
+"$DISPOSABLE_PG" "$DATA_DIR" "$PORT" &
+PG_SESSION_PID=$!
+for _ in $(seq 1 30); do
+  pg_isready -h 127.0.0.1 -p "$PORT" >/dev/null 2>&1 && break
+  sleep 0.3
+done
+
+DB_URL="postgresql://postgres@127.0.0.1:$PORT/postgres"
+createdb -h 127.0.0.1 -p "$PORT" -U postgres fault_test
+
+echo
+echo "== 고의 파손 파일 포함 실행 — fail-closed 실증 =="
+cd "$SANDBOX"
+if OUT="$(sh scripts/run-migrations.sh "postgresql://postgres@127.0.0.1:$PORT/fault_test" 2>&1)"; then
+  EXIT_CODE=0
+else
+  EXIT_CODE=$?
+fi
+echo "$OUT"
+echo "  (script exit=$EXIT_CODE)"
+
+assert_eq "고의 파손 시 스크립트 exit code != 0" "1" "$EXIT_CODE"
+
+ONE_COUNT="$(psql -h 127.0.0.1 -p "$PORT" -U postgres -d fault_test -tAc "SELECT COUNT(*) FROM file_one_marker" 2>/dev/null || echo "MISSING")"
+assert_eq "001(고장 이전) 파일은 정상 적용됨" "0" "$ONE_COUNT"
+
+THREE_EXISTS="$(psql -h 127.0.0.1 -p "$PORT" -U postgres -d fault_test -tAc "SELECT to_regclass('public.file_three_marker') IS NOT NULL" 2>/dev/null || echo "ERROR")"
+assert_eq "003(고장 이후) 파일은 절대 적용 안 됨(halt 실증)" "f" "$THREE_EXISTS"
+
+echo
+echo "== 정상 경로(고장 없음) — 무회귀 =="
+createdb -h 127.0.0.1 -p "$PORT" -U postgres good_test
+SANDBOX_GOOD="$WORK/sandbox_good"
+mkdir -p "$SANDBOX_GOOD/packages/db/supabase/migrations" "$SANDBOX_GOOD/scripts"
+cp "$SCRIPT" "$SANDBOX_GOOD/scripts/run-migrations.sh"
+cp "$SANDBOX/packages/db/supabase/migrations/001_ok.sql" "$SANDBOX_GOOD/packages/db/supabase/migrations/"
+cp "$SANDBOX/packages/db/supabase/migrations/003_ok.sql" "$SANDBOX_GOOD/packages/db/supabase/migrations/"
+cd "$SANDBOX_GOOD"
+if GOOD_OUT="$(sh scripts/run-migrations.sh "postgresql://postgres@127.0.0.1:$PORT/good_test" 2>&1)"; then
+  GOOD_EXIT=0
+else
+  GOOD_EXIT=$?
+fi
+echo "$GOOD_OUT"
+assert_eq "고장 없는 정상 경로는 exit=0" "0" "$GOOD_EXIT"
+
+kill -TERM "$PG_SESSION_PID" 2>/dev/null || true
+wait "$PG_SESSION_PID" 2>/dev/null || true
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+  echo "ALL PASS"
+  exit 0
+else
+  echo "FAILURES ABOVE"
+  exit 1
+fi

--- a/scripts/run-migrations.test.sh
+++ b/scripts/run-migrations.test.sh
@@ -259,6 +259,41 @@ esac
 kill -TERM "$PG_SESSION_PID" 2>/dev/null || true
 wait "$PG_SESSION_PID" 2>/dev/null || true
 
+# ── 시나리오 9(카디르 재검토 前 페드루 지적) — NONTX_ALLOWLIST 트립와이어. cutoff(①)와
+# 달리 이 목록은 새 CONCURRENTLY 파일이 생길 때마다 실제로 갱신 의무가 남는 자리라, PG
+# 없이도 실 코퍼스를 정적 스캔해 "CONCURRENTLY 포함 파일 ⊆ (allowlist ∪ 함수본문-전용
+# 선언목록)"을 매번 재확인한다 — 사람이 새 파일 분류를 깜빡하면 RED로 강제한다 ──
+echo
+echo "== [9] NONTX_ALLOWLIST 트립와이어(실 코퍼스 CONCURRENTLY 미분류 파일 검사) =="
+REAL_MIGRATIONS_DIR="$SCRIPT_DIR/../packages/db/supabase/migrations"
+SCRIPT_NONTX_ALLOWLIST="$(grep -oE "SPRINTABLE_MIGRATIONS_NONTX_ALLOWLIST:-[^}]*" "$SCRIPT" | sed 's/^[^:]*:-//')"
+# 실측(2026-08-30)으로 CONCURRENTLY가 BEGIN...END 함수 본문 **안**에만 있어 top-level이
+# 아님을 직접 확인한 파일 — 새로 추가되는 파일은 여기 없으니 트립와이어가 반드시 잡는다.
+FUNCTION_BODY_ONLY_DECLARED="20260407110000_monthly_agent_usage_view.sql 20260408092000_agent_hitl_pending_status.sql 20260425140000_reward_balances_view.sql"
+
+if [ -z "$SCRIPT_NONTX_ALLOWLIST" ]; then
+  echo "  FAIL [9] 스크립트에서 NONTX_ALLOWLIST 기본값을 추출하지 못함(정규식 drift?)"
+  FAIL=1
+fi
+
+UNACCOUNTED=""
+for f in "$REAL_MIGRATIONS_DIR"/*.sql; do
+  name="$(basename "$f")"
+  if grep -q "CONCURRENTLY" "$f"; then
+    accounted=false
+    for known in $SCRIPT_NONTX_ALLOWLIST $FUNCTION_BODY_ONLY_DECLARED; do
+      if [ "$known" = "$name" ]; then
+        accounted=true
+        break
+      fi
+    done
+    if [ "$accounted" = false ]; then
+      UNACCOUNTED="$UNACCOUNTED $name"
+    fi
+  fi
+done
+assert_eq "[9] CONCURRENTLY 포함 파일 전부 allowlist∪함수본문-선언에 계정됨" "" "$UNACCOUNTED"
+
 echo
 if [ "$FAIL" -eq 0 ]; then
   echo "ALL PASS"

--- a/scripts/run-migrations.test.sh
+++ b/scripts/run-migrations.test.sh
@@ -259,40 +259,19 @@ esac
 kill -TERM "$PG_SESSION_PID" 2>/dev/null || true
 wait "$PG_SESSION_PID" 2>/dev/null || true
 
-# ── 시나리오 9(카디르 재검토 前 페드루 지적) — NONTX_ALLOWLIST 트립와이어. cutoff(①)와
-# 달리 이 목록은 새 CONCURRENTLY 파일이 생길 때마다 실제로 갱신 의무가 남는 자리라, PG
-# 없이도 실 코퍼스를 정적 스캔해 "CONCURRENTLY 포함 파일 ⊆ (allowlist ∪ 함수본문-전용
-# 선언목록)"을 매번 재확인한다 — 사람이 새 파일 분류를 깜빡하면 RED로 강제한다 ──
+# ── 시나리오 9(카디르 재검토) — NONTX_ALLOWLIST 트립와이어. 3라운드(카디르)에서 이
+# 트립와이어가 .test.sh 안에만 살고 CI 어디에도 안 걸려 있다는 지적을 받아, 실제 검증
+# 로직은 scripts/lint_migrations_nontx_allowlist.sh로 뽑아 CI job(.github/workflows/
+# ci.yml의 migrations-nontx-allowlist-lint)과 이 자리 양쪽이 그 스크립트 하나를 공유
+# 호출한다(로직 이중화·드리프트 방지) — 여기서는 그 스크립트를 실제로 실행해 exit code로
+# 판정한다 ──
 echo
-echo "== [9] NONTX_ALLOWLIST 트립와이어(실 코퍼스 CONCURRENTLY 미분류 파일 검사) =="
-REAL_MIGRATIONS_DIR="$SCRIPT_DIR/../packages/db/supabase/migrations"
-SCRIPT_NONTX_ALLOWLIST="$(grep -oE "SPRINTABLE_MIGRATIONS_NONTX_ALLOWLIST:-[^}]*" "$SCRIPT" | sed 's/^[^:]*:-//')"
-# 실측(2026-08-30)으로 CONCURRENTLY가 BEGIN...END 함수 본문 **안**에만 있어 top-level이
-# 아님을 직접 확인한 파일 — 새로 추가되는 파일은 여기 없으니 트립와이어가 반드시 잡는다.
-FUNCTION_BODY_ONLY_DECLARED="20260407110000_monthly_agent_usage_view.sql 20260408092000_agent_hitl_pending_status.sql 20260425140000_reward_balances_view.sql"
-
-if [ -z "$SCRIPT_NONTX_ALLOWLIST" ]; then
-  echo "  FAIL [9] 스크립트에서 NONTX_ALLOWLIST 기본값을 추출하지 못함(정규식 drift?)"
-  FAIL=1
-fi
-
-UNACCOUNTED=""
-for f in "$REAL_MIGRATIONS_DIR"/*.sql; do
-  name="$(basename "$f")"
-  if grep -q "CONCURRENTLY" "$f"; then
-    accounted=false
-    for known in $SCRIPT_NONTX_ALLOWLIST $FUNCTION_BODY_ONLY_DECLARED; do
-      if [ "$known" = "$name" ]; then
-        accounted=true
-        break
-      fi
-    done
-    if [ "$accounted" = false ]; then
-      UNACCOUNTED="$UNACCOUNTED $name"
-    fi
-  fi
-done
-assert_eq "[9] CONCURRENTLY 포함 파일 전부 allowlist∪함수본문-선언에 계정됨" "" "$UNACCOUNTED"
+echo "== [9] NONTX_ALLOWLIST 트립와이어(공유 스크립트 호출, CI에도 동일 배선) =="
+LINT_SCRIPT="$SCRIPT_DIR/lint_migrations_nontx_allowlist.sh"
+LINT_OUT="$(sh "$LINT_SCRIPT" 2>&1)"
+LINT_EXIT=$?
+echo "$LINT_OUT"
+assert_eq "[9] 실 코퍼스 CONCURRENTLY 분류 lint exit=0" "0" "$LINT_EXIT"
 
 echo
 if [ "$FAIL" -eq 0 ]; then

--- a/scripts/run-migrations.test.sh
+++ b/scripts/run-migrations.test.sh
@@ -194,6 +194,68 @@ assert_eq "[6] 동시 인스턴스 B exit=0" "0" "$EXIT_B"
 assert_eq "[6] 원장 중복 없이 정확히 3건" "3" "$(sql1 db_concurrent "SELECT COUNT(*) FROM public._sprintable_migration_ledger")"
 assert_eq "[6] 001 정확히 1회만 생성(중복 CREATE 충돌 없음)" "t" "$(sql1 db_concurrent "SELECT to_regclass('public.conc_marker_one') IS NOT NULL")"
 
+# ── 시나리오 7(카디르 2라운드 ①) — cutoff 기반 "정상 업그레이드": 구 DB(stories 有,
+# 원장 無)에 cutoff **이후** 신규 파일이 이미지에 실려 온 경우, 시딩이 그 신규 파일까지
+# 무실행 처리해버리면 안 된다 — 반드시 실 실행돼야 한다 ──
+echo
+echo "== [7] cutoff 기반 정상 업그레이드(신규 파일은 시딩 대신 실 실행) =="
+createdb -h 127.0.0.1 -p "$PORT" -U postgres db_upgrade
+SB7="$(mk_sandbox sb_upgrade)"
+cat > "$SB7/packages/db/supabase/migrations/001_ok.sql" <<'EOF'
+CREATE TABLE public.upgrade_marker_one (id int);
+EOF
+cat > "$SB7/packages/db/supabase/migrations/002_new.sql" <<'EOF'
+CREATE TABLE public.upgrade_marker_two (id int);
+EOF
+# "예전 모델로 001까지는 이미 실 적용된 구 DB" 상태를 원장 없이 흉내 — stories(센티널)+
+# 001의 물리 효과만 미리 만든다. 002는 이 이미지에 신규로 실려온 파일이라 미적용 상태.
+sql1 db_upgrade "CREATE TABLE public.stories (id int)" > /dev/null
+sql1 db_upgrade "CREATE TABLE public.upgrade_marker_one (id int)" > /dev/null
+
+export SPRINTABLE_MIGRATIONS_SEED_CUTOFF="001_ok.sql"
+run_script "$SB7" db_upgrade
+unset SPRINTABLE_MIGRATIONS_SEED_CUTOFF
+echo "$OUT"
+assert_eq "[7] 정상 업그레이드 exit=0" "0" "$EXIT_CODE"
+assert_eq "[7] 001은 시딩(seeded=true)됨 — 재실행 안 됨" "t" "$(sql1 db_upgrade "SELECT seeded FROM public._sprintable_migration_ledger WHERE filename='001_ok.sql'")"
+assert_eq "[7] 002는 시딩 아닌 실 실행(seeded=false)" "f" "$(sql1 db_upgrade "SELECT seeded FROM public._sprintable_migration_ledger WHERE filename='002_new.sql'")"
+assert_eq "[7] 002가 실제로 실행돼 마커 테이블 생성됨(카디르 회귀의 정면 재현)" "t" "$(sql1 db_upgrade "SELECT to_regclass('public.upgrade_marker_two') IS NOT NULL")"
+
+# ── 시나리오 8(카디르 2라운드 ②) — CONCURRENTLY 인덱스가 이전 시도에서 INVALID로
+# 남은 상태(락 경합·중복키 등)에서 재기동 시, 원인이 해소됐다면 자가치유(DROP 후
+# 재생성)로 valid 상태에 도달해야 한다 ──
+echo
+echo "== [8] INVALID 인덱스 자가치유(cONCURRENTLY 이전 실패 잔재 회복) =="
+createdb -h 127.0.0.1 -p "$PORT" -U postgres db_invalididx
+SB8="$(mk_sandbox sb_invalididx)"
+cat > "$SB8/packages/db/supabase/migrations/001_idx.sql" <<'EOF'
+CREATE TABLE IF NOT EXISTS public.dup_test (id int);
+INSERT INTO public.dup_test (id) SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM public.dup_test WHERE id = 1);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_dup_test_id ON public.dup_test(id);
+EOF
+# "이전 컨테이너 기동에서 CONCURRENTLY 빌드가 중복키로 실패해 INVALID 인덱스만 남은"
+# 상태를 원장 없이 직접 재현 — 이 시점엔 중복 데이터가 있어 인덱스 빌드가 실패한다.
+sql1 db_invalididx "CREATE TABLE public.dup_test (id int)" > /dev/null
+sql1 db_invalididx "INSERT INTO public.dup_test VALUES (1),(1)" > /dev/null
+psql -h 127.0.0.1 -p "$PORT" -U postgres -d db_invalididx -c \
+  "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_dup_test_id ON public.dup_test(id)" >/dev/null 2>&1 || true
+assert_eq "[8] 사전조건 — 실제로 INVALID 인덱스가 남았음" "f" "$(sql1 db_invalididx "SELECT indisvalid FROM pg_index i JOIN pg_class c ON c.oid=i.indexrelid WHERE c.relname='idx_dup_test_id'")"
+
+# 데이터 문제 해소(중복 제거) — 이제 재시도하면 성공할 수 있는 상태.
+sql1 db_invalididx "DELETE FROM public.dup_test a USING public.dup_test b WHERE a.ctid < b.ctid AND a.id = b.id" > /dev/null
+
+export SPRINTABLE_MIGRATIONS_NONTX_ALLOWLIST="001_idx.sql"
+run_script "$SB8" db_invalididx
+unset SPRINTABLE_MIGRATIONS_NONTX_ALLOWLIST
+echo "$OUT"
+assert_eq "[8] 자가치유 후 exit=0" "0" "$EXIT_CODE"
+assert_eq "[8] 원장에 정상 기록됨" "1" "$(sql1 db_invalididx "SELECT COUNT(*) FROM public._sprintable_migration_ledger WHERE filename='001_idx.sql'")"
+assert_eq "[8] 인덱스가 최종적으로 VALID" "t" "$(sql1 db_invalididx "SELECT indisvalid FROM pg_index i JOIN pg_class c ON c.oid=i.indexrelid WHERE c.relname='idx_dup_test_id'")"
+case "$OUT" in
+  *"INVALID 인덱스 감지"*) echo "  ok   [8] 자가치유(선삭제) 로그 확認" ;;
+  *) echo "  FAIL [8] 자가치유 로그 없음 — 선삭제 경로가 안 탔을 수 있음"; FAIL=1 ;;
+esac
+
 kill -TERM "$PG_SESSION_PID" 2>/dev/null || true
 wait "$PG_SESSION_PID" 2>/dev/null || true
 


### PR DESCRIPTION
[SID:3219]

## 원인
카디르 3618 QA 4라운드(self-host 채널 지형 조사 중 실측) — 기존
`psql "$DB_URL" -f "$file" 2>&1 | grep -v "^$" | head -5; if [ $? -ne 0 ]`은
파이프의 마지막 명령이 `head`(입력에 에러가 있어도 거의 항상 성공 종료)라
`psql` 자신의 실패 종료코드가 그 자리에서 이미 사라진 뒤였다. 걸려도
"⚠️ Warning: ... had issues (may be idempotent)" 한 줄만 찍고 다음 파일로
계속 진행 — self-host 배포 이미지(ghcr·docker-compose.prod)의 ENTRYPOINT가
스키마 부분 적용 상태로 조용히 정상처럼 떴다.

## 처방
파이프를 없애고 `psql`을 직접 `if`에 걸어 종료코드가 살아있는 채로 판정한다.
`-v ON_ERROR_STOP=1`로 psql이 한 파일 **안에서도** 첫 에러에서 즉시 멈추게
하고(기존엔 에러 줄만 찍고 다음 문장으로 계속 진행), 실패 시 그 파일에서
바로 `exit 1` — Dockerfile ENTRYPOINT의 `&&` 체인이 뒤의
`node apps/web/server.js`를 아예 안 돌아 fail-closed(부분 적용 상태로는
앱이 안 뜬다).

`pipefail`은 쓰지 않는다 — 실 런타임(`node:22-alpine`, ENTRYPOINT가
`/bin/sh -c`로 호출)은 busybox ash라 POSIX 밖 bash 확장을 모르고, 파이프
자체를 없앴으니 애초에 필요도 없다(`dash -n`/`sh -n` 둘 다 신택스 클린
확認).

## 검증
`scripts/run-migrations.test.sh` 신설(story #2659의 `.test.sh` 관례 재사용
— `reclaim-merged-worktrees.test.sh`/`check-disk-usage.test.sh`와 동형).
실 disposable PG(`backend/scripts/disposable_pg.sh`, story #3199 리그
재사용)에 합성 마이그 파일 3개(성공·고의 파손·성공)를 먹여:
- 고의 파손 시 스크립트 exit code != 0.
- 파손 **이전** 파일(001)은 정상 적용됨.
- 파손 **이후** 파일(003)은 절대 적용 안 됨(halt 실증 — narrative 아닌 실제
  테이블 존재 여부로 확認).
- 정상 경로(고장 없음)는 무회귀로 exit=0.

구 파이프 버전으로 뮤테이션 주입해 위 2건이 실제로 RED(exit=0 오탐·파손
이후 파일이 적용돼버림)가 되는 것 확認 후 정확히 원복.

## Test plan
- [x] `sh -n` / `dash -n` 신택스 클린(실 런타임 셸과 동일 계열)
- [x] `bash scripts/run-migrations.test.sh` — 4개 assertion 전부 PASS
- [x] 뮤테이션(구 파이프 버전) 주입 → 2건 RED 확認 → 정확히 원복
- [x] disposable PG 실물로 정상/고장 두 경로 모두 재현