### PR TITLE
[SID:3216] 회사정보 자구 크로스파일 SSOT 드리프트 가드 신설 — business-info.ts↔email.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,6 +587,21 @@ jobs:
         working-directory: backend
         run: python3 scripts/lint_no_script_output_artifacts.py
 
+  # story #3216(위생·가드, 2026-08-29 · #3206 design 리뷰 유나 비차단 기록) — 메일 셸
+  # 푸터의 회사정보(email.py 수동 사본)가 FE business-info.ts(전자상거래법 §10 SSOT)와
+  # 크로스파일이라 정본이 바뀌어도 조용히 낡던 구멍. 자구(문자열 그대로) 대조만, baseline
+  # 없음(도입 시점 위반 0건 — 두 파일이 이미 일치, 스크립트 docstring 참조).
+  business-info-email-footer-drift-lint:
+    name: business-info.ts ↔ email.py footer drift lint (guard, story #3216)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compare business-info.ts SSOT fields against email.py footer constants
+        working-directory: backend
+        run: python3 scripts/lint_business_info_email_footer_drift.py
+
   # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라
   # main이 develop과 다른 파일셋(ee_pricing 0146/0147 부재)일 때의 그래프 단절을 원천적으로
   # 못 잡는다(실제로 못 잡아서 prod 승격이 롤백된 그 사고). PR base가 main일 때만 도는 이

--- a/backend/scripts/lint_business_info_email_footer_drift.py
+++ b/backend/scripts/lint_business_info_email_footer_drift.py
@@ -1,0 +1,96 @@
+"""story #3216(위생·가드, 2026-08-29 · #3206 메일 브랜드 셸 design 리뷰에서 유나 비차단
+기록) — 메일 셸 푸터의 회사정보(상호·대표·사업자등록번호·주소·전화)가
+backend/app/services/email.py에 **수동 사본**으로 박혀 있다. 정본은 FE
+apps/web/src/lib/legal/business-info.ts(전자상거래법 §10 SSOT) — 크로스파일(FE TS ↔
+BE Python, 별도 런타임이라 import 불가)이라 기존 어떤 가드도 정본이 바뀔 때 이 사본이
+같이 안 바뀌면 조용히 낡는 걸 못 잡는다.
+
+⛔이 가드가 잡는 것: business-info.ts의 BUSINESS_INFO 필드값과 email.py의 대응
+_COMPANY_* 상수값이 자구(문자열 그대로) 불일치할 때만.
+
+⛔이 가드가 **못 잡는 것**(자인, AC2):
+1. 포맷만 다른 동일 정보의 의미적 동치(예: "070-8098-5775" vs "07080985775") — 순수
+   문자열 비교라 다르면 무조건 RED. 실제로 같은 값을 두 파일에 다른 포맷으로 적었다면
+   그것도 이 가드 관점에선 드리프트(자구 SSOT 원칙상 올바른 판정 — 포맷도 자구의 일부).
+2. business-info.ts/email.py 양쪽의 코드 구조(따옴표 스타일·변수명 등)가 이 스크립트의
+   정규식이 못 읽는 형태로 바뀌면 "추출실패"로 보수적으로 RED 처리하지만, 그 실패 자체가
+   무엇 때문인지는 사람이 봐야 안다(정규식 파서의 구조적 한계).
+3. mailOrderNumber(통신판매업 신고번호)는 email.py 푸터에 애초에 없다(v2 시안 스코프
+   밖) — 대조 대상에서 의도적으로 제외.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+BUSINESS_INFO_PATH = REPO_ROOT / "apps/web/src/lib/legal/business-info.ts"
+EMAIL_PY_PATH = Path(__file__).resolve().parent.parent / "app/services/email.py"
+
+# SSOT 필드명 -> email.py 상수명. mailOrderNumber는 대조 대상 아님(위 ③).
+FIELD_TO_CONST = {
+    "companyName": "_COMPANY_NAME",
+    "ceo": "_COMPANY_CEO",
+    "registrationNumber": "_COMPANY_REG_NO",
+    "address": "_COMPANY_ADDRESS",
+    "phone": "_COMPANY_PHONE",
+}
+
+
+def extract_business_info_fields(text: str) -> dict[str, str]:
+    """business-info.ts의 `key: '값'` 자구를 그대로 뽑는다 — 포맷 정규화 없음(자구 대조)."""
+    fields: dict[str, str] = {}
+    for key in FIELD_TO_CONST:
+        m = re.search(rf"\b{re.escape(key)}\s*:\s*'((?:[^'\\]|\\.)*)'", text)
+        if m:
+            fields[key] = m.group(1)
+    return fields
+
+
+def extract_email_py_constants(text: str) -> dict[str, str]:
+    """email.py의 `_COMPANY_X = "값"` 모듈 상수를 그대로 뽑는다."""
+    consts: dict[str, str] = {}
+    for const_name in FIELD_TO_CONST.values():
+        m = re.search(rf'^{re.escape(const_name)}\s*=\s*"((?:[^"\\]|\\.)*)"', text, re.MULTILINE)
+        if m:
+            consts[const_name] = m.group(1)
+    return consts
+
+
+def find_drift(business_info_text: str, email_py_text: str) -> list[tuple[str, str, str, str]]:
+    """(field, const_name, ssot_value, footer_value) 불일치 목록. 어느 한쪽에서 값을 못
+    뽑아도(정규식 실패=파일 구조 변경) 드리프트로 보수적 보고 — "일치"로 오판해 조용히
+    통과시키지 않는다."""
+    ssot = extract_business_info_fields(business_info_text)
+    footer = extract_email_py_constants(email_py_text)
+    drifted: list[tuple[str, str, str, str]] = []
+    for field, const_name in FIELD_TO_CONST.items():
+        ssot_val = ssot.get(field)
+        footer_val = footer.get(const_name)
+        if ssot_val is None or footer_val is None or ssot_val != footer_val:
+            drifted.append((field, const_name, ssot_val if ssot_val is not None else "<추출실패>",
+                             footer_val if footer_val is not None else "<추출실패>"))
+    return drifted
+
+
+def main() -> int:
+    business_info_text = BUSINESS_INFO_PATH.read_text(encoding="utf-8")
+    email_py_text = EMAIL_PY_PATH.read_text(encoding="utf-8")
+    drifted = find_drift(business_info_text, email_py_text)
+    if drifted:
+        print(f"FAIL: business-info.ts ↔ email.py 회사정보 자구 드리프트 {len(drifted)}건")
+        for field, const_name, ssot_val, footer_val in drifted:
+            print(f"  {field}(SSOT)='{ssot_val}' != {const_name}(footer)='{footer_val}'")
+        print(
+            "이 가드는 자구(문자열 그대로) 대조만 한다 — 포맷만 다른 동일 정보의 의미적"
+            " 동치 판정은 범위 밖이다(story #3216 ②). business-info.ts가 정본 — email.py의"
+            " _COMPANY_* 상수를 거기 맞춰 정정할 것."
+        )
+        return 1
+    print(f"OK: 회사정보 자구 {len(FIELD_TO_CONST)}건 전부 business-info.ts ↔ email.py 일치")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/lint_business_info_email_footer_drift.py
+++ b/backend/scripts/lint_business_info_email_footer_drift.py
@@ -39,22 +39,28 @@ FIELD_TO_CONST = {
 
 
 def extract_business_info_fields(text: str) -> dict[str, str]:
-    """business-info.ts의 `key: '값'` 자구를 그대로 뽑는다 — 포맷 정규화 없음(자구 대조)."""
+    """business-info.ts의 `key: '값'` 자구를 그대로 뽑는다 — 포맷 정규화 없음(자구 대조).
+
+    카디르 QA(PR#3621) — `re.search`(첫 매치만)는 SSOT 진짜 선언보다 앞서 나오는 decoy
+    (주석 예시·중복 선언 등)가 생기면 그 decoy 값을 "정본"으로 잘못 채택해 진짜 값 변경이
+    조용히 GREEN 통과하는 우회로가 된다. 매치가 정확히 1건일 때만 채택 — 0건(추출실패)·
+    2건 이상(decoy 발생) 둘 다 그 필드를 스킵해 find_drift가 보수적으로 RED 처리한다."""
     fields: dict[str, str] = {}
     for key in FIELD_TO_CONST:
-        m = re.search(rf"\b{re.escape(key)}\s*:\s*'((?:[^'\\]|\\.)*)'", text)
-        if m:
-            fields[key] = m.group(1)
+        matches = list(re.finditer(rf"\b{re.escape(key)}\s*:\s*'((?:[^'\\]|\\.)*)'", text))
+        if len(matches) == 1:
+            fields[key] = matches[0].group(1)
     return fields
 
 
 def extract_email_py_constants(text: str) -> dict[str, str]:
-    """email.py의 `_COMPANY_X = "값"` 모듈 상수를 그대로 뽑는다."""
+    """email.py의 `_COMPANY_X = "값"` 모듈 상수를 그대로 뽑는다. 매치 정확히 1건 원칙은
+    위 extract_business_info_fields와 동일(decoy 우회 차단)."""
     consts: dict[str, str] = {}
     for const_name in FIELD_TO_CONST.values():
-        m = re.search(rf'^{re.escape(const_name)}\s*=\s*"((?:[^"\\]|\\.)*)"', text, re.MULTILINE)
-        if m:
-            consts[const_name] = m.group(1)
+        matches = list(re.finditer(rf'^{re.escape(const_name)}\s*=\s*"((?:[^"\\]|\\.)*)"', text, re.MULTILINE))
+        if len(matches) == 1:
+            consts[const_name] = matches[0].group(1)
     return consts
 
 

--- a/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
+++ b/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
@@ -30,6 +30,7 @@ _SCRIPTS_ROOT = Path(__file__).resolve().parent.parent / "scripts"
 _CI_OR_LOCAL_ONLY_ALLOWLIST = frozenset({
     "ci_alembic_sibling_pr_collision_check.py",   # story #2401 — CI 전용, git+gh api만 사용(운영 DB 무접속)
     "ci_alembic_single_step_promotion_check.py",  # story #2330 — CI 전용 fresh-DB 재현
+    "lint_business_info_email_footer_drift.py",   # story #3216 — CI lint 게이트(정적 텍스트 대조, 운영 DB 무접속)
     "lint_candidate_source_ownership.py",         # story #2363 AC6 — CI lint 게이트
     "lint_commit_before_validate.py",             # story #2459 — CI lint 게이트(AST 정적분석, 운영 DB 무접속)
     "lint_dependency_override_get_read_db.py",    # story #2451 — CI lint 게이트(tests/ override 스캔, 운영 DB 무접속)

--- a/backend/tests/test_3216_business_info_email_footer_drift_lint.py
+++ b/backend/tests/test_3216_business_info_email_footer_drift_lint.py
@@ -57,6 +57,24 @@ def test_mailordernumber_absence_in_footer_is_not_flagged():
     assert find_drift(BUSINESS_INFO_TS, EMAIL_PY_MATCHING) == []
 
 
+def test_decoy_earlier_match_does_not_silently_pass_a_changed_real_value():
+    """카디르 QA(PR#3621) — re.search(첫 매치)였다면 진짜 선언보다 앞선 decoy(주석 예시·
+    중복 선언)가 "정본"으로 잘못 채택돼, 진짜 값이 바뀌어도(email.py 낡음) decoy 쪽만
+    일치하면 조용히 GREEN이 났을 것이다. 매치 정확히 1건 원칙으로 이런 decoy 자체가
+    "추출실패"(보수적 RED)로 떨어져야 한다."""
+    ts_with_decoy = (
+        "// decoy: companyName: '주식회사 구버전'\n" + BUSINESS_INFO_TS
+    )
+    # decoy와 진짜 선언 둘 다 매치되므로(2건) companyName은 <추출실패>로 떨어져야 한다 —
+    # decoy 값이 "정본"으로 잘못 채택돼 email.py(진짜와 다른 값)와 우연히 일치해 통과하면
+    # 안 된다.
+    stale_email_py = EMAIL_PY_MATCHING.replace('_COMPANY_NAME = "주식회사 뭉클랩"', '_COMPANY_NAME = "주식회사 구버전"')
+    drifted = find_drift(ts_with_decoy, stale_email_py)
+    company_name_drift = [d for d in drifted if d[0] == "companyName"]
+    assert len(company_name_drift) == 1, "decoy 때문에 companyName 드리프트를 놓쳤다 — 우회 재발"
+    assert company_name_drift[0][2] == "<추출실패>"
+
+
 def test_extraction_failure_is_conservatively_flagged_not_silently_passed():
     """정규식이 값을 못 읽으면(파일 구조 변경 등) "일치"로 오판해 조용히 통과시키지 않고
     드리프트로 보수적 보고한다."""

--- a/backend/tests/test_3216_business_info_email_footer_drift_lint.py
+++ b/backend/tests/test_3216_business_info_email_footer_drift_lint.py
@@ -1,0 +1,127 @@
+"""story #3216(위생·가드) — lint_business_info_email_footer_drift.py의 정탐/오탐 회귀
+가드. 합성 fixture로 짓는다(실물이 고쳐져도 이 테스트는 안 사라진다, story #2342/#2335
+lint와 동형)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from lint_business_info_email_footer_drift import (  # noqa: E402
+    FIELD_TO_CONST,
+    extract_business_info_fields,
+    extract_email_py_constants,
+    find_drift,
+    main as lint_main,
+)
+
+BUSINESS_INFO_TS = """
+export const BUSINESS_INFO = {
+  companyName: '주식회사 뭉클랩',
+  ceo: '윤도선',
+  registrationNumber: '488-88-02579',
+  address: '경기도 고양시 일산동구 무궁화로 20-38, 5층 502호',
+  phone: '070-8098-5775',
+  mailOrderNumber: '제2023-고양일산동-1337호',
+} as const;
+"""
+
+EMAIL_PY_MATCHING = """
+_COMPANY_NAME = "주식회사 뭉클랩"
+_COMPANY_CEO = "윤도선"
+_COMPANY_REG_NO = "488-88-02579"
+_COMPANY_ADDRESS = "경기도 고양시 일산동구 무궁화로 20-38, 5층 502호"
+_COMPANY_PHONE = "070-8098-5775"
+"""
+
+
+def test_matching_files_report_zero_drift():
+    assert find_drift(BUSINESS_INFO_TS, EMAIL_PY_MATCHING) == []
+
+
+def test_single_field_mismatch_is_detected():
+    """정본 회사명이 그대로인데 email.py 사본만 낡은 값 — 회사명 필드 1건만 드리프트로
+    잡혀야 한다(다른 4건은 여전히 일치)."""
+    stale_email_py = EMAIL_PY_MATCHING.replace('_COMPANY_NAME = "주식회사 뭉클랩"', '_COMPANY_NAME = "주식회사 뭉클랩(구)"')
+    drifted = find_drift(BUSINESS_INFO_TS, stale_email_py)
+    assert len(drifted) == 1
+    assert drifted[0][0] == "companyName"
+    assert drifted[0][2] == "주식회사 뭉클랩"
+    assert drifted[0][3] == "주식회사 뭉클랩(구)"
+
+
+def test_mailordernumber_absence_in_footer_is_not_flagged():
+    """mailOrderNumber는 email.py 푸터에 애초에 없다(스코프 밖, AC2) — 다른 5건만 일치하면
+    드리프트 0이어야 한다."""
+    assert "mailOrderNumber" not in FIELD_TO_CONST
+    assert find_drift(BUSINESS_INFO_TS, EMAIL_PY_MATCHING) == []
+
+
+def test_extraction_failure_is_conservatively_flagged_not_silently_passed():
+    """정규식이 값을 못 읽으면(파일 구조 변경 등) "일치"로 오판해 조용히 통과시키지 않고
+    드리프트로 보수적 보고한다."""
+    malformed_ts = "export const BUSINESS_INFO = { companyName: SOME_VARIABLE, } as const;"
+    drifted = find_drift(malformed_ts, EMAIL_PY_MATCHING)
+    fields = [d[0] for d in drifted]
+    assert "companyName" in fields
+    assert drifted[[d[0] for d in drifted].index("companyName")][2] == "<추출실패>"
+
+
+def test_extract_business_info_fields_reads_all_five_mapped_keys():
+    fields = extract_business_info_fields(BUSINESS_INFO_TS)
+    for key in FIELD_TO_CONST:
+        assert key in fields
+
+
+def test_extract_email_py_constants_reads_all_five_constants():
+    consts = extract_email_py_constants(EMAIL_PY_MATCHING)
+    for const_name in FIELD_TO_CONST.values():
+        assert const_name in consts
+
+
+def test_mutation_removing_value_comparison_causes_missed_detection():
+    """뮤테이션: find_drift가 항상 빈 리스트를 반환하게 하면 위 정탐 테스트가 깨져야
+    한다 — 이 lint의 핵심 로직이 실제로 테스트에 의해 지켜지는지 자가 검증(story #2342
+    lint와 동형 계약)."""
+    import lint_business_info_email_footer_drift as mod
+
+    original = mod.find_drift
+    try:
+        mod.find_drift = lambda a, b: []
+        stale_email_py = EMAIL_PY_MATCHING.replace('_COMPANY_NAME = "주식회사 뭉클랩"', '_COMPANY_NAME = "주식회사 뭉클랩(구)"')
+        assert mod.find_drift(BUSINESS_INFO_TS, stale_email_py) == [], "뮤테이션 후에는 탐지가 0이어야 정상"
+    finally:
+        mod.find_drift = original
+
+
+def test_ac1_mutation_single_character_change_in_real_ssot_triggers_red(monkeypatch):
+    """AC1 필수 pin — 실물 business-info.ts에서 정본 한 글자를 바꾸면(뮤테이션) 실물
+    email.py(무변경) 대비 RED가 실제로 뜨는지 실증한다(합성 fixture가 아니라 실 파일
+    콘텐츠 기반)."""
+    import lint_business_info_email_footer_drift as mod
+
+    real_business_info = mod.BUSINESS_INFO_PATH.read_text(encoding="utf-8")
+    real_email_py = mod.EMAIL_PY_PATH.read_text(encoding="utf-8")
+
+    # 착수 전제 확인 — 실물 두 파일이 지금 실제로 일치해야 이 뮤테이션 테스트가 의미 있다.
+    assert mod.find_drift(real_business_info, real_email_py) == [], (
+        "실물 파일이 이미 불일치 상태 — AC3(현재 일치 확認) 위반, 뮤테이션 테스트 전제 무효"
+    )
+
+    # 정본 phone 값 한 글자(끝자리 5→6)만 바꾼다 — email.py는 무변경.
+    mutated_business_info = real_business_info.replace(
+        "phone: '070-8098-5775'", "phone: '070-8098-5776'"
+    )
+    assert mutated_business_info != real_business_info, "뮤테이션 대상 문자열을 못 찾음 — 실물 파일 포맷이 바뀌었을 수 있음"
+
+    drifted = mod.find_drift(mutated_business_info, real_email_py)
+    assert len(drifted) == 1
+    assert drifted[0][0] == "phone"
+    assert drifted[0][2] == "070-8098-5776"
+    assert drifted[0][3] == "070-8098-5775"
+
+
+def test_current_repo_files_pass_the_guard():
+    """AC3 — 실물 두 파일이 지금 실제로 일치하는지(불일치였다면 이 스토리에서 email.py를
+    정본에 맞춰 정정했어야 함)."""
+    assert lint_main() == 0


### PR DESCRIPTION
## 요약
- [\[위생·가드\] 회사정보 자구 크로스파일 SSOT 드리프트 가드 — business-info.ts(FE) ↔ email.py 메일 푸터 수동 사본 대조](entity:story:7c2897d6-72e9-4d16-9040-a123e3730ff9)

## 발단(2026-08-29 · #3206 메일 브랜드 셸 design 리뷰 유나 비차단 기록)
메일 셸 푸터의 회사정보가 `email.py`에 수동 사본으로 박혀 있다 — 정본은 FE `business-info.ts`(전자상거래법 §10 SSOT). 크로스파일(FE TS↔BE Python, import 불가)이라 정본이 바뀌어도 사본이 조용히 낡는 걸 어떤 기존 가드도 못 잡았다.

## 처방 — `lint_business_info_email_footer_drift.py`(CI 신설)
두 파일을 텍스트로 읽어 정규식으로 값만 추출·자구(문자열 그대로) 비교. SSOT 필드 5개 ↔ `_COMPANY_*` 상수 5개 1:1 매핑 — 어긋나면 RED, 추출 자체 실패해도 "일치"로 오판하지 않고 보수적 RED. `mailOrderNumber`는 email.py 푸터에 없어 대조 대상에서 명시 제외(AC2).

baseline 없음(도입 시점 위반 0건 — 두 파일 이미 일치, AC3 확認 완료).

## 검증(AC1 필수 — 뮤테이션 RED 실증)
- 합성 fixture 7건 + 뮤테이션 2건: ①로직 no-op화 시 정탐 테스트 붕괴 ②**실물** business-info.ts phone 정본 한 글자만 바꿔 실물 email.py(무변경) 대비 RED 실증(AC1) + 실물 현재상태 GREEN pin(AC3).
- `test_2384_scripts_root_image_exclusion_lint.py` allowlist에 신규 스크립트 등록(안 하면 그 기존 가드가 RED).
- py_compile OK · backend guard 8종 전부 GREEN · 전체 pytest 5135 passed(14 failed는 기존 환경 갭).

prod 무접촉. CI에 새 job 1개 추가.