### PR TITLE
[SID:3217] AARRR·Referral 계측 — invite_token 수락 성공 시 서버측 결정론 귀속(신규 스키마 0)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -262,15 +262,33 @@ class SetPasswordRequest(BaseModel):
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
-async def _auto_accept_invitation(session: AsyncSession, user: User, invite_token: str) -> None:
+async def _auto_accept_invitation(session: AsyncSession, user: User, invite_token: str) -> dict:
     """가입 시 invite_token이 있으면 해당 초대 자동 수락 + org_member 생성.
 
     canonical=OrgInvite(org_invites) 단일 경로. accept로 위임 → org_member 생성 +
     선택 프로젝트 project_access(granted) 부여 + status=accepted를 한 경로로 처리한다.
     (구 Invitation 테이블은 d3619e80 cutover로 제거 — #1307에서 pending 토큰 org_invites 이전 完.)
+
+    story #3217(Referral 계측) — 반환값({"ok": bool, "org_id": str, ...})을 호출부에
+    그대로 넘긴다. 기존 두 호출부(register/oauth_callback)는 이 반환값을 버렸었는데,
+    이번에 "수락 성공 시에만" referral 귀속을 적용하려면 성공 여부를 알아야 한다.
     """
     from app.repositories.org_invite import OrgInviteRepository
-    await OrgInviteRepository(session).accept(invite_token, user.id, user.email)
+    return await OrgInviteRepository(session).accept(invite_token, user.id, user.email)
+
+
+def _apply_referral_attribution(user: User, accept_result: dict) -> None:
+    """story #3217(AARRR·Referral 계측 A축·결정론 주신호) — invite_token 수락이
+    **성공**했을 때만 결정론적 귀속을 쿠키 유래 signup_utm_*보다 **우선 적용**(override)
+    한다. 초대 링크 자체가 유입 채널의 확정적 증거라 첫 방문 UTM/referrer 추론(story
+    #3204 first-touch 쿠키)보다 신뢰도가 높다 — 그래서 "덮어쓴다"가 맞는 방향(먼저
+    세팅된 쿠키 값이 있어도 이게 이긴다).
+
+    수락 실패/토큰 무효(ok=False)면 호출 자체를 안 한다(무개입 — 기존 쿠키 경로 그대로,
+    호출부에서 조건부로 호출)."""
+    user.signup_utm_source = "referral"
+    user.signup_utm_medium = "org_invite"
+    user.signup_utm_campaign = accept_result.get("org_id")
 
 
 async def _get_user_by_email(session: AsyncSession, email: str) -> User | None:
@@ -628,7 +646,9 @@ async def register(
 
     # AC2: invite_token 있으면 가입 후 자동 수락
     if body.invite_token:
-        await _auto_accept_invitation(session, user, body.invite_token)
+        accept_result = await _auto_accept_invitation(session, user, body.invite_token)
+        if accept_result.get("ok"):
+            _apply_referral_attribution(user, accept_result)
 
     _md = await _build_app_metadata(user, session)
     if settings.build_app_metadata_defallback:
@@ -1338,7 +1358,9 @@ async def oauth_callback(
 
             # AC4: invite_token 있으면 신규 OAuth 유저도 자동 수락
             if body.invite_token:
-                await _auto_accept_invitation(session, user, body.invite_token)
+                accept_result = await _auto_accept_invitation(session, user, body.invite_token)
+                if accept_result.get("ok"):
+                    _apply_referral_attribution(user, accept_result)
 
             await session.commit()
             await session.refresh(user)

--- a/backend/app/routers/org_invites.py
+++ b/backend/app/routers/org_invites.py
@@ -112,7 +112,7 @@ async def create_org_invite(
     org_name = org.name if org else str(id)
     invitee_locale = await _resolve_invitee_locale(session, invite.email)
     error = send_invite_email(
-        to=invite.email, org_name=org_name, token=invite.token, role=invite.role, locale=invitee_locale,
+        to=invite.email, org_name=org_name, token=invite.token, role=invite.role, org_id=str(id), locale=invitee_locale,
     )
     sent_at = None if error else datetime.now(timezone.utc)
     await invite_repo.update_email_result(invite.id, sent_at=sent_at, error=error)
@@ -146,7 +146,7 @@ async def resend_org_invite(
     org_name = org.name if org else str(id)
     invitee_locale = await _resolve_invitee_locale(session, invite.email)
     error = send_invite_email(
-        to=invite.email, org_name=org_name, token=invite.token, role=invite.role, locale=invitee_locale,
+        to=invite.email, org_name=org_name, token=invite.token, role=invite.role, org_id=str(id), locale=invitee_locale,
     )
     sent_at = None if error else datetime.now(timezone.utc)
     await invite_repo.update_email_result(invite.id, sent_at=sent_at, error=error)

--- a/backend/app/services/org_invite_email.py
+++ b/backend/app/services/org_invite_email.py
@@ -55,6 +55,7 @@ def send_invite_email(
     org_name: str,
     token: str,
     role: str,
+    org_id: str = "",
     inviter_name: str = "",
     locale: str = "ko",
 ) -> str | None:
@@ -64,9 +65,19 @@ def send_invite_email(
     기존 유저 것이면 그 유저의 locale, 아니면(아직 계정 없는 신규 피초대자) DEFAULT_LOCALE」
     로 판별해 넘긴다 — 여기서는 그 값을 그대로 소비만 한다(추측 0, 기존 무회귀 동작이
     바로 그 else 분기).
+
+    story #3217(AARRR·Referral 계측 B축·보조신호) — accept_link에 utm_source=referral·
+    utm_medium=org_invite·utm_campaign=<org_id>를 부착한다. `/invite`는 proxy.ts
+    PUBLIC_PREFIX라 기존 first-touch 캡처(story #3204 captureSignupAttribution)가 이
+    쿼리를 그대로 주워 쿠키에 심는다(FE/proxy.ts 변경 0 — 이미 있는 회로 재사용). 주
+    신호(A축)는 register()/oauth_callback()의 invite_token **수락 성공** 시점 서버측
+    기록(이 쿠키보다 우선) — 이건 "링크는 눌렀지만 가입은 나중에 다른 경로로" 케이스를
+    잡는 보조축일 뿐이다.
     """
     app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
     accept_link = f"{app_url}/invite/accept?token={token}"
+    if org_id:
+        accept_link += f"&utm_source=referral&utm_medium=org_invite&utm_campaign={org_id}"
     copy = INVITE_COPY[locale]
     display_inviter = inviter_name or copy["default_inviter"]
 

--- a/backend/scripts/jobs/measure_referral_signup_ratio.py
+++ b/backend/scripts/jobs/measure_referral_signup_ratio.py
@@ -1,0 +1,81 @@
+"""story #3217(AARRR·Referral 계측) AC4 — 기간 내 가입 중 referral(초대 경유) 비율.
+
+signup_utm_source가 신설된 시점(story #3204, 마이그 0292) 前 가입자는 이 컬럼이
+NULL이다 — **NULL(미측정)과 0(측정됐으나 무추천)을 반드시 구분**해서 낸다. 이걸
+합쳐 세면(예: "NULL도 0으로 취급") 0292 이전 구간이 통째로 "추천 0%"로 잘못 보여
+"추천이 안 먹힌다"는 거짓 결론을 낳는다 — 계측 부재를 성과 부재로 오독하는 클래스.
+
+referral 판정은 story #3217 A축(register()/oauth_callback()의 invite_token 수락
+**성공** 시점 서버측 기록) 계약 그대로: `signup_utm_source = 'referral'`.
+
+읽기 전용(조회만). env: DATABASE_URL이 있으면 그것을 쓴다(백엔드 동일). 없으면
+ALEMBIC_URL로 떨어진다(scripts/jobs/_db_env.py).
+실행: cd backend && DATABASE_URL=... python -m scripts.jobs.measure_referral_signup_ratio [--days N]
+(기본 --days 30. 재사용 가능 형태 — 기간만 바꿔 정기 실행.)
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import text
+
+from scripts.jobs._db_env import resolve_database_url
+
+_db_url_summary = resolve_database_url()
+
+from app.core.database import async_session_factory  # noqa: E402 — 위 폴백이 먼저 돌아야 한다
+
+# FILTER 절로 한 스캔에 4갈래를 동시에 센다(round-trip 1회).
+# - unmeasured: signup_utm_source가 NULL(0292 이전 가입 — "미측정", 0이 아님).
+# - referral: A축 계약대로 정확히 'referral'.
+# - non_referral_measured: NULL이 아니면서 referral도 아닌(direct/기타 UTM 등 — "측정됐고 무추천").
+REFERRAL_RATIO_SQL = """
+SELECT
+    count(*) FILTER (WHERE created_at >= :since)                                                    AS total_signups,
+    count(*) FILTER (WHERE created_at >= :since AND signup_utm_source IS NULL)                       AS unmeasured_signups,
+    count(*) FILTER (WHERE created_at >= :since AND signup_utm_source = 'referral')                  AS referral_signups,
+    count(*) FILTER (WHERE created_at >= :since AND signup_utm_source IS NOT NULL
+                                                 AND signup_utm_source <> 'referral')                 AS non_referral_measured
+FROM users
+"""
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--days", type=int, default=30, help="최근 N일(기본 30)")
+    args = parser.parse_args()
+
+    if _db_url_summary is None:
+        print("[FAIL] DATABASE_URL·ALEMBIC_URL 둘 다 미설정", file=sys.stderr)
+        return 2
+    print(f"[db] {_db_url_summary}", file=sys.stderr)
+
+    since = datetime.now(timezone.utc) - timedelta(days=args.days)
+    async with async_session_factory() as s:
+        row = (await s.execute(text(REFERRAL_RATIO_SQL), {"since": since})).mappings().one()
+
+    total = row["total_signups"]
+    unmeasured = row["unmeasured_signups"]
+    referral = row["referral_signups"]
+    non_referral_measured = row["non_referral_measured"]
+    measured = total - unmeasured
+
+    print(f"=== 최근 {args.days}일 가입 referral 비율 ===")
+    print(f"  전체 가입: {total}건")
+    print(f"  미측정(signup_utm_source IS NULL — 0292 이전 가입): {unmeasured}건")
+    print(f"  측정됨(0292 이후): {measured}건 = referral {referral}건 + 그 외(direct/기타 UTM) {non_referral_measured}건")
+
+    if measured == 0:
+        print("  referral 비율: N/A(측정된 가입 0건 — «비율 0%»가 아니라 «잴 수 없음»)")
+        return 0
+
+    ratio_pct = (referral / measured) * 100
+    print(f"  referral 비율(측정 모수 기준): {ratio_pct:.1f}% ({referral}/{measured})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/tests/test_3217_referral_attribution.py
+++ b/backend/tests/test_3217_referral_attribution.py
@@ -1,0 +1,205 @@
+"""story #3217(AARRR·Referral 계측) — invite_token 수락 성공 시 결정론적 referral
+귀속(A축)이 users.signup_utm_*에 실착하는지, 실패 시 무개입인지(쿠키 유래 값 보존)
+양방향 pin. + 초대 메일 accept_link에 utm 3종이 부착되는지(B축)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _register_client():
+    """story #3204/#3216 동형 패턴 — override_db_and_read 경유(카디르 QA #2451 재발
+    방지, PR#3617에서 이미 한 번 지적됨)."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from tests.conftest import override_db_and_read
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_result.scalars.return_value.all.return_value = []
+    mock_result.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.flush = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session.add = MagicMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        ctx = MagicMock()
+        ctx.user_id = str(uuid.uuid4())
+        return ctx
+
+    override_db_and_read(app, override_db)
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+def _register_payload(**overrides) -> dict:
+    return {
+        "email": f"new-{uuid.uuid4().hex}@example.com",
+        "password": "TestPass1!",
+        "display_name": "Test User",
+        "tos_accepted": True,
+        **overrides,
+    }
+
+
+def _added_user(session):
+    from app.models.user import User
+    return next(c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], User))
+
+
+@pytest.mark.anyio
+async def test_register_invite_accept_success_overrides_cookie_derived_utm():
+    """A축 — invite_token 수락 성공 시 referral/org_invite/<org_id>가 쿠키 유래 값(있어도)
+    보다 우선 적용된다(override 명시)."""
+    org_id = str(uuid.uuid4())
+    client, session, app = await _register_client()
+    try:
+        with patch(
+            "app.repositories.org_invite.OrgInviteRepository.accept",
+            new=AsyncMock(return_value={"ok": True, "org_id": org_id, "role": "member"}),
+        ):
+            async with client as c:
+                resp = await c.post("/api/v2/auth/register", json=_register_payload(
+                    invite_token="tok-1",
+                    # 쿠키 유래 값(존재해도 override 대상) — first-touch가 먼저 세팅됐던 시나리오.
+                    signup_utm_source="google", signup_utm_medium="cpc", signup_utm_campaign="launch",
+                ))
+        assert resp.status_code == 201
+        user = _added_user(session)
+        assert user.signup_utm_source == "referral"
+        assert user.signup_utm_medium == "org_invite"
+        assert user.signup_utm_campaign == org_id
+    finally:
+        from app.main import app as _app
+        _app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_register_invite_accept_failure_is_hands_off_keeps_cookie_derived_utm():
+    """무효/만료 토큰(수락 실패) — signup_utm_*는 기존 쿠키 경로 그대로(무개입)."""
+    client, session, app = await _register_client()
+    try:
+        with patch(
+            "app.repositories.org_invite.OrgInviteRepository.accept",
+            new=AsyncMock(return_value={"ok": False, "reason": "expired"}),
+        ):
+            async with client as c:
+                resp = await c.post("/api/v2/auth/register", json=_register_payload(
+                    invite_token="tok-expired",
+                    signup_utm_source="google", signup_utm_medium="cpc", signup_utm_campaign="launch",
+                ))
+        assert resp.status_code == 201
+        user = _added_user(session)
+        assert user.signup_utm_source == "google"
+        assert user.signup_utm_medium == "cpc"
+        assert user.signup_utm_campaign == "launch"
+    finally:
+        from app.main import app as _app
+        _app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_register_without_invite_token_is_unaffected():
+    """invite_token 자체가 없으면 이 스토리의 로직 경로를 아예 안 탄다(회귀 없음)."""
+    client, session, app = await _register_client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/register", json=_register_payload(
+                signup_utm_source="direct",
+            ))
+        assert resp.status_code == 201
+        user = _added_user(session)
+        assert user.signup_utm_source == "direct"
+    finally:
+        from app.main import app as _app
+        _app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_apply_referral_attribution_sets_exact_three_fields():
+    """_apply_referral_attribution 단위 — 정확히 이 3값(문자열 그대로)을 세팅한다."""
+    from app.routers.auth import _apply_referral_attribution
+
+    user = MagicMock()
+    org_id = str(uuid.uuid4())
+    _apply_referral_attribution(user, {"ok": True, "org_id": org_id})
+    assert user.signup_utm_source == "referral"
+    assert user.signup_utm_medium == "org_invite"
+    assert user.signup_utm_campaign == org_id
+
+
+@pytest.mark.anyio
+async def test_auto_accept_invitation_now_returns_accept_result_dict():
+    """카디르류 회귀가드 — _auto_accept_invitation이 이전엔 반환값을 버렸다(None). 이제
+    accept()의 dict를 그대로 전달해야 호출부의 A축 분기가 작동한다."""
+    from app.routers.auth import _auto_accept_invitation
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "a@b.com"
+    session = AsyncMock()
+    accept_mock = AsyncMock(return_value={"ok": True, "org_id": "org-1"})
+    with patch("app.repositories.org_invite.OrgInviteRepository.accept", new=accept_mock):
+        result = await _auto_accept_invitation(session, user, "tok-1")
+    assert result == {"ok": True, "org_id": "org-1"}
+
+
+# ─── B축 — 초대 메일 accept_link의 utm 부착 ─────────────────────────────────────
+
+def test_send_invite_email_appends_utm_when_org_id_given(monkeypatch):
+    from app.services import org_invite_email
+
+    captured: dict = {}
+
+    def fake_send_email(*, to, subject, html_body):
+        captured["html_body"] = html_body
+        return True
+
+    monkeypatch.setattr(org_invite_email, "send_email", fake_send_email)
+    org_id = str(uuid.uuid4())
+    error = org_invite_email.send_invite_email(
+        to="invitee@example.com", org_name="테스트조직", token="tok-1", role="member",
+        org_id=org_id, inviter_name="누군가", locale="ko",
+    )
+    assert error is None
+    assert f"utm_source=referral&utm_medium=org_invite&utm_campaign={org_id}" in captured["html_body"]
+    assert "token=tok-1" in captured["html_body"]
+
+
+def test_send_invite_email_without_org_id_omits_utm_params(monkeypatch):
+    """org_id 미전달(하위호환 — 다른 호출자가 있을 가능성) 시 utm 파라미터를 안 붙인다
+    (지어내지 않음)."""
+    from app.services import org_invite_email
+
+    captured: dict = {}
+
+    def fake_send_email(*, to, subject, html_body):
+        captured["html_body"] = html_body
+        return True
+
+    monkeypatch.setattr(org_invite_email, "send_email", fake_send_email)
+    org_invite_email.send_invite_email(
+        to="invitee@example.com", org_name="테스트조직", token="tok-1", role="member", locale="ko",
+    )
+    assert "utm_source" not in captured["html_body"]
+
+
+def test_org_invites_router_passes_org_id_to_send_invite_email():
+    """소스 레벨 — create/resend 두 호출부 모두 org_id=str(id)를 넘긴다(누락 회귀 방지)."""
+    import inspect
+    import app.routers.org_invites as mod
+    source = inspect.getsource(mod)
+    assert source.count("org_id=str(id)") == 2

--- a/backend/tests/test_3217_referral_attribution.py
+++ b/backend/tests/test_3217_referral_attribution.py
@@ -157,6 +157,113 @@ async def test_auto_accept_invitation_now_returns_accept_result_dict():
     assert result == {"ok": True, "org_id": "org-1"}
 
 
+# ─── oauth_callback() 신규 유저 경로 — register()와 동일 계약(카디르 QA, PR#3623) ───
+# 카디르 지적 — register()만 pin됐고 oauth_callback() 경로는 pin 0건이라 가드 제거
+# 뮤테이션에 이 경로 전체가 침묵했다(false-green). register 것과 동형으로 양방향 추가.
+
+async def _oauth_client(session: AsyncMock):
+    """story #3204 test_3204_signup_attribution.py와 동형 패턴(override_db_and_read
+    경유) — 파일 독립성 유지를 위해 재구현(공유 임포트 안 함, 이 코드베이스 관례)."""
+    from app.main import app
+    from tests.conftest import override_db_and_read
+
+    async def override_db():
+        yield session
+
+    override_db_and_read(app, override_db)
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _mock_session_returning_none() -> AsyncMock:
+    """provider_id 조회·email 조회 둘 다 None — 신규 유저 생성 분기로 진입."""
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=result)
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    return session
+
+
+@pytest.mark.anyio
+async def test_oauth_callback_invite_accept_success_overrides_cookie_derived_utm(monkeypatch):
+    """A축 — OAuth 신규 가입 경로도 register()와 동일하게, invite_token 수락 성공 시
+    referral/org_invite/<org_id>가 쿠키 유래 값보다 우선 적용된다."""
+    from app.core.config import settings
+    from app.core.security import create_oauth_state_token
+    import app.routers.auth as auth_router
+    from app.models.user import User
+
+    monkeypatch.setattr(settings, "jwt_secret", "test-jwt-secret", raising=False)
+    monkeypatch.setattr(
+        auth_router, "_exchange_oauth_code_for_userinfo",
+        AsyncMock(return_value=("google-oauth-id-1", "brand-new@example.com")),
+    )
+    org_id = str(uuid.uuid4())
+    state = create_oauth_state_token("google")
+    session = _mock_session_returning_none()
+    client = await _oauth_client(session)
+    try:
+        with patch(
+            "app.repositories.org_invite.OrgInviteRepository.accept",
+            new=AsyncMock(return_value={"ok": True, "org_id": org_id, "role": "member"}),
+        ):
+            async with client as c:
+                resp = await c.post("/api/v2/auth/oauth/callback", json={
+                    "provider": "google", "code": "code-1", "state": state, "tos_accepted": True,
+                    "invite_token": "tok-1",
+                    "signup_utm_source": "google", "signup_utm_medium": "cpc", "signup_utm_campaign": "launch",
+                })
+        assert resp.status_code == 200
+        assert resp.json()["data"]["is_new_user"] is True
+        user = next(c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], User))
+        assert user.signup_utm_source == "referral"
+        assert user.signup_utm_medium == "org_invite"
+        assert user.signup_utm_campaign == org_id
+    finally:
+        from app.main import app
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_oauth_callback_invite_accept_failure_is_hands_off(monkeypatch):
+    """A축 — OAuth 신규 가입에서 초대 토큰이 무효/만료면 무개입(쿠키 유래 값 보존)."""
+    from app.core.config import settings
+    from app.core.security import create_oauth_state_token
+    import app.routers.auth as auth_router
+    from app.models.user import User
+
+    monkeypatch.setattr(settings, "jwt_secret", "test-jwt-secret", raising=False)
+    monkeypatch.setattr(
+        auth_router, "_exchange_oauth_code_for_userinfo",
+        AsyncMock(return_value=("google-oauth-id-2", "brand-new-2@example.com")),
+    )
+    state = create_oauth_state_token("google")
+    session = _mock_session_returning_none()
+    client = await _oauth_client(session)
+    try:
+        with patch(
+            "app.repositories.org_invite.OrgInviteRepository.accept",
+            new=AsyncMock(return_value={"ok": False, "reason": "expired"}),
+        ):
+            async with client as c:
+                resp = await c.post("/api/v2/auth/oauth/callback", json={
+                    "provider": "google", "code": "code-1", "state": state, "tos_accepted": True,
+                    "invite_token": "tok-expired",
+                    "signup_utm_source": "google", "signup_utm_medium": "cpc", "signup_utm_campaign": "launch",
+                })
+        assert resp.status_code == 200
+        user = next(c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], User))
+        assert user.signup_utm_source == "google"
+        assert user.signup_utm_medium == "cpc"
+        assert user.signup_utm_campaign == "launch"
+    finally:
+        from app.main import app
+        app.dependency_overrides.clear()
+
+
 # ─── B축 — 초대 메일 accept_link의 utm 부착 ─────────────────────────────────────
 
 def test_send_invite_email_appends_utm_when_org_id_given(monkeypatch):


### PR DESCRIPTION
## 요약
- [\[AARRR·Referral\] 추천/초대 유입 장치 0 — 최소 레퍼럴 루프 설계 (계측 선행·설계 우선)](entity:story:ca8e461b-cd57-4a65-8b12-3879cb9ed9ac)

## 설계(PO 확定, 선생님 GO) — 초대 토큰은 이미 결정론적 귀속 실물
쿠키 추론(first-touch)이 아니라 register()/oauth_callback()의 invite_token **수락 성공** 시점 서버측 기록이 정공법 — 0292 컬럼 재사용, 신규 스키마 0.

## A축(결정론·주 신호) — 수락 성공 시 override, 실패 시 무개입
`_auto_accept_invitation`이 이전엔 `accept()`의 반환값을 버렸다 — 이제 그대로 돌려주고 `_apply_referral_attribution()` 신설해 **수락 성공 시에만** `signup_utm_source='referral'·medium='org_invite'·campaign=<org_id>`를 쿠키 유래 값 위에 override. 실패면 호출 자체를 안 해 무개입.

## B축(보조·first-touch) — 초대 메일 accept_link에 utm 3종 부착
`/invite`는 proxy.ts PUBLIC_PREFIX라 기존 first-touch 캡처(story #3204)가 그대로 주워 쿠키에 심는다 — **FE/proxy.ts 변경 0**.

## AC4 — 측정 쿼리(oneoff)
`scripts/jobs/measure_referral_signup_ratio.py` — 미측정(NULL, 0292 이전)·referral·그 외 3갈래 구분 출력.

## 검증
- 신규 pin 8건 — A축 성공/실패 양방향·invite_token 없음 무영향·단위테스트·반환값 회귀가드·B축 utm 부착(양쪽)·org_invites.py 배선 확認.
- 기존 5/5 무회귀. py_compile OK · backend guard 8종 GREEN · 전체 pytest 5144 passed(무관 14건 제외). FE 변경 0.

AC3(dev 실왕복 probe)는 PO 라이브 몫. prod 무접촉.