### PR TITLE
[SID:3217] Referral 계측 후속 라운드 — authenticated accept 결정론 귀속 훅

### DIFF
--- a/backend/app/repositories/org_invite.py
+++ b/backend/app/repositories/org_invite.py
@@ -220,6 +220,10 @@ class OrgInviteRepository:
                     "org_id": str(invite.organization_id),
                     "role": invite.role,
                     "already_member": True,
+                    # story #3217(Referral 계측) — 호출부(invite_accept.py)가
+                    # user.created_at >= invite_created_at로 "이 초대가 신규 가입을
+                    # 유발했는지"를 판정하는 데 쓴다.
+                    "invite_created_at": invite.created_at,
                 }
             return {"ok": False, "reason": "already_accepted"}
         if invite.status != "pending":
@@ -266,7 +270,8 @@ class OrgInviteRepository:
         invite.accepted_at = datetime.now(timezone.utc)
         await self.session.flush()
 
-        return {"ok": True, "org_id": str(invite.organization_id), "role": invite.role}
+        # story #3217(Referral 계측) — invite_created_at도 함께(위 idempotent 분기와 동일 계약).
+        return {"ok": True, "org_id": str(invite.organization_id), "role": invite.role, "invite_created_at": invite.created_at}
 
     async def _ensure_member_anchor(self, org_id: uuid.UUID, user_id: uuid.UUID) -> None:
         """수락자(휴먼)의 canonical members 앵커(type='human', id=org_member.id)를 멱등 보장.

--- a/backend/app/routers/invite_accept.py
+++ b/backend/app/routers/invite_accept.py
@@ -69,5 +69,18 @@ async def accept_invite(
             raise HTTPException(status_code=403, detail="Email does not match invite")
         raise HTTPException(status_code=400, detail="Cannot accept invite")
 
+    # story #3217(Referral 계측, 착지 후 PO 라이브 probe 발견) — 이메일 가입 경로 실
+    # 여정은 register()가 invite_token을 받는 게 아니라: 비로그인 수락 → /login?
+    # returnUrl → 가입 → **이 authenticated accept**로 흐른다(OAuth 경로만 register()
+    # 훅이 유효). register()/oauth_callback()의 A축 훅은 그대로 두고(OAuth·API 클라
+    # 유효), 여기에 결정론 규칙으로 귀속을 보강한다: 계정 생성이 이 초대 생성 **이후**
+    # (invite→signup 인과, `user.created_at >= invite_created_at`)면 이 초대가 유발한
+    # 신규 가입 — referral 기록. 계정이 초대보다 오래면(기존 유저의 통상 수락) 그
+    # 계정의 기존 귀속(가입 시점 값)을 건드리지 않는다(무기록).
+    invite_created_at = result.get("invite_created_at")
+    if invite_created_at is not None and user.created_at >= invite_created_at:
+        from app.routers.auth import _apply_referral_attribution
+        _apply_referral_attribution(user, result)
+
     await session.commit()
     return AcceptInviteResponse(ok=True, org_id=result["org_id"], role=result["role"])

--- a/backend/tests/test_3217_referral_attribution.py
+++ b/backend/tests/test_3217_referral_attribution.py
@@ -264,6 +264,135 @@ async def test_oauth_callback_invite_accept_failure_is_hands_off(monkeypatch):
         app.dependency_overrides.clear()
 
 
+# ─── authenticated accept(/api/v2/invites/accept) — 실 이메일 가입 여정의 진짜 A축 ──
+# PO 착지 후 라이브 probe 발견(2026-08-30) — 이메일 가입은 register()가 invite_token을
+# 받는 게 아니라: 비로그인 수락 → /login?returnUrl → 가입(invite_token 없이) →
+# **이 authenticated accept**로 흘러 register() 훅이 무의미했다(OAuth 경로만 유효).
+# 결정론 규칙: user.created_at >= invite_created_at(초대가 먼저·계정이 뒤=초대 유발
+# 가입)이면 귀속, 계정이 초대보다 오래면(기존 유저 통상 수락) 무기록.
+
+async def _invite_accept_client(user_created_at):
+    """test_e_org_multi_s3_3_invite_accept.py와 동형 패턴(_get_repo 오버라이드)이되,
+    get_db만 걸고 get_read_db를 놓치는 회귀 클래스(story #2451, PR#3617에서도 재발)를
+    피해 override_db_and_read 경유로 교체 — 이 파일의 다른 헬퍼들과 동일 원칙."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from tests.conftest import override_db_and_read
+
+    user_id = uuid.uuid4()
+    mock_user = MagicMock()
+    mock_user.id = user_id
+    mock_user.email = "invitee@example.com"
+    mock_user.is_active = True
+    mock_user.created_at = user_created_at
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_user
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.commit = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        ctx = MagicMock()
+        ctx.user_id = str(user_id)
+        return ctx
+
+    override_db_and_read(app, override_db)
+    app.dependency_overrides[get_current_user] = override_auth
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_user, app
+
+
+@pytest.mark.anyio
+async def test_invite_accept_new_signup_after_invite_gets_referral_attribution():
+    """계정 생성이 초대 생성 이후(초대가 유발한 신규 가입) — referral/org_invite/<org_id>
+    가 실착한다."""
+    from datetime import datetime, timedelta, timezone
+    from app.routers.invite_accept import _get_repo
+
+    invite_created_at = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    user_created_at = invite_created_at + timedelta(hours=1)  # 초대 後 가입
+    org_id = str(uuid.uuid4())
+
+    client, user, app = await _invite_accept_client(user_created_at)
+    try:
+        mock_repo = MagicMock()
+        mock_repo.accept = AsyncMock(return_value={
+            "ok": True, "org_id": org_id, "role": "member", "invite_created_at": invite_created_at,
+        })
+        app.dependency_overrides[_get_repo] = lambda: mock_repo
+
+        async with client as c:
+            resp = await c.post("/api/v2/invites/accept", json={"token": "tok-1"})
+
+        assert resp.status_code == 200
+        assert user.signup_utm_source == "referral"
+        assert user.signup_utm_medium == "org_invite"
+        assert user.signup_utm_campaign == org_id
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_invite_accept_existing_user_before_invite_is_hands_off():
+    """계정이 초대보다 오래됐다(기존 유저의 통상 수락) — 귀속을 안 건드린다(무기록,
+    가입 시점 기존 값 보존 — 여기선 override 호출 자체가 없었음을 signup_utm_source
+    미변경 MagicMock 기본 sentinel로 확認)."""
+    from datetime import datetime, timedelta, timezone
+    from app.routers.invite_accept import _get_repo
+
+    invite_created_at = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    user_created_at = invite_created_at - timedelta(days=30)  # 계정이 초대보다 훨씬 오래됨
+    org_id = str(uuid.uuid4())
+
+    client, user, app = await _invite_accept_client(user_created_at)
+    # 가입 시점 기존 귀속값(예: 이 유저는 예전에 direct로 가입) — 무기록이면 그대로 남아야 한다.
+    user.signup_utm_source = "direct"
+    user.signup_utm_medium = None
+    user.signup_utm_campaign = None
+    try:
+        mock_repo = MagicMock()
+        mock_repo.accept = AsyncMock(return_value={
+            "ok": True, "org_id": org_id, "role": "member", "invite_created_at": invite_created_at,
+        })
+        app.dependency_overrides[_get_repo] = lambda: mock_repo
+
+        async with client as c:
+            resp = await c.post("/api/v2/invites/accept", json={"token": "tok-1"})
+
+        assert resp.status_code == 200
+        assert user.signup_utm_source == "direct"
+        assert user.signup_utm_medium is None
+        assert user.signup_utm_campaign is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_invite_accept_without_invite_created_at_key_is_hands_off():
+    """기존 accept() 성공 응답(invite_created_at 키 자체가 없는 이전 계약 — 회귀 시나리오
+    시뮬레이션)에서도 크래시 없이 무기록으로 안전하게 저하한다."""
+    from app.routers.invite_accept import _get_repo
+
+    client, user, app = await _invite_accept_client(user_created_at=None)
+    user.signup_utm_source = "direct"
+    try:
+        mock_repo = MagicMock()
+        mock_repo.accept = AsyncMock(return_value={"ok": True, "org_id": str(uuid.uuid4()), "role": "member"})
+        app.dependency_overrides[_get_repo] = lambda: mock_repo
+
+        async with client as c:
+            resp = await c.post("/api/v2/invites/accept", json={"token": "tok-1"})
+
+        assert resp.status_code == 200
+        assert user.signup_utm_source == "direct"
+    finally:
+        app.dependency_overrides.clear()
+
+
 # ─── B축 — 초대 메일 accept_link의 utm 부착 ─────────────────────────────────────
 
 def test_send_invite_email_appends_utm_when_org_id_given(monkeypatch):


### PR DESCRIPTION
## 계보
PR#3623([SID:3217] AARRR·Referral 계측 A축/B축/AC4)이 이미 머지·클로즈됐다(01:09:38Z). 이 PR은 착지 후 PO 라이브 probe가 발견한 실 갭에 대한 **후속 라운드** — 같은 브랜치(feat/3217-referral-attribution)에 이어 커밋했으나 머지된 PR엔 재붙지 않아 새로 연다.

- [\[AARRR·Referral\] 추천/초대 유입 장치 0 — 최소 레퍼럴 루프 설계 (계측 선행·설계 우선)](entity:story:ca8e461b-cd57-4a65-8b12-3879cb9ed9ac)

## 착지 후 실 갭(PO 라이브 probe, 2026-08-30)
AC2(메일 utm)는 PASS(3종 실물 확認)였으나, **A축이 web 이메일 가입 경로에서 발화 불가**였다 — register 페이지에 invite 처리가 아예 없고(grep 0), 실 여정은 비로그인 수락→/login?returnUrl→(가입 시 invite_token 없이) 가입→인증 후 **authenticated accept**(POST /api/v2/invites/accept)로 흘러 register()/oauth_callback()의 A축 훅은 OAuth 경로에서만 실제로 탔다. 이메일 초대 가입자는 전원 무귀속(경로 하나 false-capability)이었다.

## 처방(PO 확定) — authenticated accept 성공 지점에 결정론 규칙으로 귀속 훅 추가
`OrgInviteRepository.accept()`의 두 성공 반환(신규 수락·idempotent 재수락) 모두에 `invite_created_at` 추가. `invite_accept.py`의 accept_invite()가 `user.created_at >= invite_created_at`(초대가 먼저·계정이 뒤=이 초대가 유발한 신규 가입)일 때만 auth.py의 `_apply_referral_attribution()`을 재사용 호출. 계정이 초대보다 오래면(기존 유저의 통상 수락) 무기록 — 가입 시점 기존 귀속값 보존. register()/oauth_callback() 훅은 OAuth·API 클라 경로용으로 그대로 유지.

## 검증
- 신규 pin 3건 — 신규가입(초대 後 계정)→referral 실착·기존유저(계정이 초대보다 오래됨)→무기록·invite_created_at 키 부재(구 계약)에서도 안전 저하.
- 작업 중 자체 발견 — 신규 헬퍼가 raw get_db override만 걸 뻔한 걸 push 前 로컬 가드로 직접 잡아 override_db_and_read로 교체(셀프캐치, 카디르 대기 없음).
- 관련 스위트 85 passed+2 skipped(realdb) GREEN · py_compile OK · backend guard 8종 GREEN · 전체 pytest 5148 passed(무관 14건+ref-신선도 아티팩트 1건, story #3195에서 이미 확認한 동일 클래스 제외).

부수 발견(PO가 별도 등재 예정, 이 라운드 스코프 밖) — 비로그인 수락→회원가입 링크가 returnUrl을 떨궈 가입 후 accept 복귀가 끊기는 UX 결함. prod 무접촉.