### PR TITLE
[SID:3220] 비로그인 초대수락→회원가입 returnUrl 소실 — 파라미터명 불일치가 근본원인

### DIFF
--- a/apps/web/src/app/invite/accept/page.tsx
+++ b/apps/web/src/app/invite/accept/page.tsx
@@ -12,7 +12,11 @@ export default async function InviteAcceptPage({ searchParams }: Props) {
 
   const session = await getServerSession().catch(() => null);
   if (!session) {
-    redirect(`/login?returnUrl=${encodeURIComponent(`/invite/accept?token=${token}`)}`);
+    // story #3220 — 예전엔 `returnUrl`로 실었는데 login/page.tsx는 `next`만 읽는다(양쪽이
+    // 애초에 다른 파라미터명으로 각자 짜여 한 번도 안 이어져 있었음 — 비로그인 사용자는
+    // 로그인해도 여기로 못 돌아왔다). 세션-만료 redirect(session-redirect.ts)와 동일한
+    // `next` 컨벤션으로 통일.
+    redirect(`/login?next=${encodeURIComponent(`/invite/accept?token=${token}`)}`);
   }
 
   const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';

--- a/apps/web/src/app/login/page.test.tsx
+++ b/apps/web/src/app/login/page.test.tsx
@@ -11,11 +11,17 @@ import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 
-const { loginWithPasswordMock } = vi.hoisted(() => ({ loginWithPasswordMock: vi.fn() }));
+// story #3220 — searchParamsRef를 vi.hoisted로 노출해 테스트별로 next 파라미터를
+// 갈아끼울 수 있게 한다(기존엔 매 호출 새 빈 URLSearchParams라 next 유무를 테스트할
+// 방법이 없었음). beforeEach에서 빈 값으로 리셋 — 다른 기존 테스트엔 무회귀.
+const { loginWithPasswordMock, searchParamsRef } = vi.hoisted(() => ({
+  loginWithPasswordMock: vi.fn(),
+  searchParamsRef: { current: new URLSearchParams() },
+}));
 vi.mock('@/lib/db/client', () => ({ loginWithPassword: loginWithPasswordMock }));
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: vi.fn(), refresh: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => searchParamsRef.current,
 }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -36,6 +42,7 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   loginWithPasswordMock.mockReset();
+  searchParamsRef.current = new URLSearchParams();
 });
 
 afterEach(async () => {
@@ -142,4 +149,29 @@ describe('LoginPage — error.code 분기 (story #2484)', () => {
 
   // 양성대조(AC) — 가드 없이 raw message를 그대로 쓰면 이 테스트가 RED여야 한다.
   // (수동 mutation self-check로 확認 — 아래 PR 설명 참고. 이 테스트 자체가 그 반례 역할.)
+});
+
+// story #3220 — 비로그인 초대수락→회원가입 경로가 여기서 끊겼다: login 페이지 자체는
+// next를 이미 들고 있는데 "회원가입" 링크가 그걸 안 실어 register로 못 넘겼다.
+describe('LoginPage — 회원가입 링크 next 전파(story #3220, 초대수락 여정 단절 fix)', () => {
+  it('next 파라미터가 있으면 회원가입 링크가 그대로 실어 나른다', async () => {
+    searchParamsRef.current = new URLSearchParams(
+      `next=${encodeURIComponent('/invite/accept?token=abc123')}`
+    );
+    await mount();
+    const signUpLink = [...container.querySelectorAll('a')].find(
+      (a) => a.textContent === koMessages.login.signUp
+    );
+    expect(signUpLink?.getAttribute('href')).toBe(
+      `/register?next=${encodeURIComponent('/invite/accept?token=abc123')}`
+    );
+  });
+
+  it('next가 없으면 예전처럼 맨몸 /register — 회귀 없음', async () => {
+    await mount();
+    const signUpLink = [...container.querySelectorAll('a')].find(
+      (a) => a.textContent === koMessages.login.signUp
+    );
+    expect(signUpLink?.getAttribute('href')).toBe('/register');
+  });
 });

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -256,7 +256,13 @@ export default function LoginPage() {
         </p>
         <p className="text-center text-sm text-muted-foreground">
           {t('noAccount')}{' '}
-          <Link href="/register" className="font-medium text-brand hover:text-brand/80">
+          {/* story #3220 — 이 링크가 nextParam을 안 실어 비로그인 초대수락→회원가입 경로에서
+              복귀 목적지가 여기서 끊겼다(로그인 페이지 자체는 next를 이미 들고 있었는데
+              "회원가입"으로 넘어가는 순간 버려짐). OAuth 버튼들(위)과 동일 패턴으로 전파. */}
+          <Link
+            href={nextParam ? `/register?next=${encodeURIComponent(nextParam)}` : '/register'}
+            className="font-medium text-brand hover:text-brand/80"
+          >
             {t('signUp')}
           </Link>
         </p>

--- a/apps/web/src/app/register/page.test.tsx
+++ b/apps/web/src/app/register/page.test.tsx
@@ -13,9 +13,16 @@ import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import enMessages from '../../../messages/en.json';
 
-const { pushMock, refreshMock } = vi.hoisted(() => ({ pushMock: vi.fn(), refreshMock: vi.fn() }));
+// story #3220 — searchParamsRef를 vi.hoisted로 노출해 next 파라미터를 테스트별로
+// 갈아끼운다(login/page.test.tsx와 동일 패턴). beforeEach에서 빈 값으로 리셋.
+const { pushMock, refreshMock, searchParamsRef } = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  refreshMock: vi.fn(),
+  searchParamsRef: { current: new URLSearchParams() },
+}));
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+  useSearchParams: () => searchParamsRef.current,
 }));
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -36,6 +43,7 @@ beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
+  searchParamsRef.current = new URLSearchParams();
 });
 
 afterEach(async () => {
@@ -194,5 +202,92 @@ describe('RegisterPage — sign_up 이벤트 발화 신호(story #3204)', () => 
     await mount('ko');
     await fillAndSubmit();
     expect(pushMock).toHaveBeenCalledWith('/onboarding?signup=1');
+  });
+});
+
+// story #3220 — 비로그인 초대수락→가입 여정: register 완료 후 org_id 유무만 보고
+// /inbox·/onboarding으로 무조건 미는 대신, next(예: /invite/accept?token=…)가 있으면
+// 그쪽을 우선 복귀시켜야 초대받은 사람이 자기 조직을 만드는 대신 초대받은 조직에
+// 합류할 수 있다.
+describe('RegisterPage — next 우선 복귀(story #3220, 초대수락 여정 단절 fix)', () => {
+  afterEach(() => { vi.unstubAllGlobals(); pushMock.mockClear(); });
+
+  async function fillAndSubmit() {
+    const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement;
+    const pwInput = container.querySelector('input[type="password"]') as HTMLInputElement;
+    const tosCheckbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await act(async () => {
+      setNativeValue(nameInput, 'Test User');
+      setNativeValue(emailInput, 'a@b.com');
+      setNativeValue(pwInput, 'Abc123!!');
+      tosCheckbox.click();
+    });
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.register.submit);
+    await act(async () => {
+      submitBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('next가 있으면 org_id 유무와 무관하게 next로 복귀 — 쿼리스트링 구분자(&)도 정확히 붙는다', async () => {
+    searchParamsRef.current = new URLSearchParams(
+      `next=${encodeURIComponent('/invite/accept?token=abc123')}`
+    );
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/auth/register') return { ok: true, json: async () => ({ data: { ok: true } }) };
+      // org_id가 있어도(재가입 엣지케이스와 무관 — 이 값과 무관하게 next 우선) next가 이긴다.
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: { org_id: 'org-1' } }) };
+      return { ok: false, json: async () => ({}) };
+    }));
+    await mount('ko');
+    await fillAndSubmit();
+    expect(pushMock).toHaveBeenCalledWith('/invite/accept?token=abc123&signup=1');
+  });
+
+  it('next가 오픈 리다이렉트 가드에 걸리면(외부 도메인) safeNextPath 폴백(/chats)으로 안전 하강', async () => {
+    searchParamsRef.current = new URLSearchParams(`next=${encodeURIComponent('//evil.com')}`);
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/auth/register') return { ok: true, json: async () => ({ data: { ok: true } }) };
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: {} }) };
+      return { ok: false, json: async () => ({}) };
+    }));
+    await mount('ko');
+    await fillAndSubmit();
+    expect(pushMock).toHaveBeenCalledWith('/chats?signup=1');
+  });
+
+  it('next가 없으면 예전처럼 org_id 분기만 적용 — 회귀 없음', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/api/auth/register') return { ok: true, json: async () => ({ data: { ok: true } }) };
+      if (url === '/api/me') return { ok: true, json: async () => ({ data: {} }) };
+      return { ok: false, json: async () => ({}) };
+    }));
+    await mount('ko');
+    await fillAndSubmit();
+    expect(pushMock).toHaveBeenCalledWith('/onboarding?signup=1');
+  });
+});
+
+// story #3220(fix-on-sight) — Google OAuth 버튼도 login 페이지의 OAuth 버튼들과 같은
+// 결함(next 미전파)이 있었다. NEXT_PUBLIC_OAUTH_ENABLED가 있어야 버튼 자체가 렌더된다.
+describe('RegisterPage — Google OAuth 링크 next 전파(story #3220)', () => {
+  const originalOauthEnabled = process.env['NEXT_PUBLIC_OAUTH_ENABLED'];
+  beforeEach(() => { process.env['NEXT_PUBLIC_OAUTH_ENABLED'] = 'true'; });
+  afterEach(() => { process.env['NEXT_PUBLIC_OAUTH_ENABLED'] = originalOauthEnabled; });
+
+  it('next가 있고 ToS 동의 상태면 Google 링크가 next를 실어 나른다', async () => {
+    searchParamsRef.current = new URLSearchParams(
+      `next=${encodeURIComponent('/invite/accept?token=abc123')}`
+    );
+    await mount('ko');
+    const tosCheckbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await act(async () => { tosCheckbox.click(); });
+    const googleLink = [...container.querySelectorAll('a')].find((a) => a.href.includes('provider=google'));
+    expect(googleLink?.getAttribute('href')).toBe(
+      `/auth/login?provider=google&tos_accepted=true&next=${encodeURIComponent('/invite/accept?token=abc123')}`
+    );
   });
 });

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { LegalFooter } from '@/components/legal/legal-footer';
+import { safeNextPath } from '@/lib/auth/session-redirect';
 
 function checkPasswordRules(pw: string) {
   return {
@@ -24,6 +25,8 @@ function countCategories(rules: ReturnType<typeof checkPasswordRules>) {
 export default function RegisterPage() {
   const t = useTranslations('register');
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const nextParam = searchParams.get('next');
   const [displayName, setDisplayName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -69,8 +72,16 @@ export default function RegisterPage() {
       // story #3204 — sign_up 전환 이벤트 발화 신호(google-analytics.tsx의 route-change
       // effect가 소비). OAuth 경로(api/auth/callback/[provider]/route.ts)와 동일 파라미터로
       // 통일해 발화 지점을 하나로 모은다(SSOT).
-      const destination = meJson.data?.org_id ? '/inbox' : '/onboarding';
-      router.push(`${destination}?signup=1`);
+      //
+      // story #3220 — 비로그인 초대수락→가입 여정에서 여기가 org_id 유무만 보고 무조건
+      // /inbox·/onboarding으로 밀어내 accept 복귀가 끊겼다(초대받은 사람이 자기 조직을
+      // 만들게 됨). next가 있으면(오픈 리다이렉트 가드 safeNextPath 통과분만) 그쪽을
+      // 최우선으로 — invite_accept.py 주석(story #3217)이 문서화한 의도된 여정
+      // (login→가입→authenticated accept)과 일치. 목적지가 이미 자체 쿼리스트링을 갖고
+      // 있을 수 있어(예: /invite/accept?token=…) `?signup=1` 고정 대신 구분자를 판별한다.
+      const destination = nextParam ? safeNextPath(nextParam) : (meJson.data?.org_id ? '/inbox' : '/onboarding');
+      const separator = destination.includes('?') ? '&' : '?';
+      router.push(`${destination}${separator}signup=1`);
       router.refresh();
     } catch {
       setError(t('registrationFailed'));
@@ -179,8 +190,11 @@ export default function RegisterPage() {
               <div className="flex-grow border-t border-border/50" />
             </div>
 
+            {/* story #3220 — login/page.tsx의 OAuth 버튼들과 동일 패턴으로 next 전파
+                (/auth/login/route.ts가 이미 next를 읽어 콜백까지 이어준다 — 이 버튼만
+                빠져 있었음, fix-on-sight). */}
             <a
-              href={tosAccepted ? '/auth/login?provider=google&tos_accepted=true' : undefined}
+              href={tosAccepted ? `/auth/login?provider=google&tos_accepted=true${nextParam ? `&next=${encodeURIComponent(nextParam)}` : ''}` : undefined}
               onClick={!tosAccepted ? (e) => { e.preventDefault(); setError(t('tosRequiredError')); } : undefined}
               className={`flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-background px-4 py-3 text-sm font-medium text-foreground/80 transition hover:bg-muted/50 ${!tosAccepted ? 'opacity-50 cursor-not-allowed' : ''}`}
             >


### PR DESCRIPTION
[SID:3220]

## 요약
비로그인 사용자가 초대 accept 링크를 밟으면 `/login?returnUrl=...`로 리다이렉트되는데, login 페이지는 `next`만 읽는다 — `returnUrl`은 코드베이스 어디서도 읽히지 않는 죽은 파라미터명(grep 0건). session-redirect.ts의 SSOT 컨벤션(`next`)과 애초에 다른 이름으로 각자 짜여 한 번도 안 이어져 있었다. 그 결과 가입 완료 후 초대 accept 복귀 대신 `/onboarding`(자기 조직 생성)으로 새서, 초대받은 사용자가 자기 조직을 만들게 되는 여정 단절이었다.

invite_accept.py의 기존 주석(story #3217)이 이미 문서화한 의도된 여정(비로그인 수락→login→가입→authenticated accept)과 정확히 일치하도록 세 지점을 `next`로 통일했다.

## 변경
1. **invite/accept/page.tsx** — `returnUrl` → `next`로 파라미터명 정정(root cause).
2. **login/page.tsx** — "회원가입" 링크가 `nextParam`을 안 실었다. OAuth 버튼들과 동일 패턴으로 전파.
3. **register/page.tsx** — 가입 완료 후 org_id 유무만으로 `/inbox`·`/onboarding`에 무조건 떠밀던 목적지 로직에 `next` 우선순위 추가(`safeNextPath` 오픈 리다이렉트 가드 적용). 목적지가 이미 쿼리스트링을 가질 수 있어(`/invite/accept?token=…`) `?signup=1` 고정 대신 구분자 판별. Google OAuth 링크도 같은 결함 패턴이라 fix-on-sight.

## 검증
- **로컬 next dev 서버로 서버-관측 가능한 두 홉을 실 HTTP로 확인**(curl, 백엔드 불요 — `getServerSession()`이 쿠키만 봄):
  - `GET /invite/accept?token=X` (무쿠키) → `307 Location: /login?next=%2Finvite%2Faccept%3Ftoken%3DX`
  - `GET /login?next=...` → 렌더된 "회원가입" 링크 `href`에 `next`가 정확히 실림
- 클라이언트 쪽(③ post-register 목적지 우선순위)은 유닛테스트 7건 신설 + 뮤테이션 검증(구 로직으로 되돌려 정확히 그 3건만 RED 재현 확認).
- 광역 회귀 스윕(invite/onboarding/verify-email) 88건 ALL PASS.
- typecheck·eslint 클린.

## 테스트 계획
- [x] 로컬 dev 서버 실 HTTP 검증(서버 리다이렉트 홉 2개)
- [x] 신규 유닛테스트 7건 + 뮤테이션 검증
- [x] 광역 회귀 스윕 88건
- [x] typecheck/lint

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>