### PR TITLE
[SID:3222] 기본 알림 레벨 저장 무반영 — BFF 이중래핑 정정

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/notification-default-level.test.tsx
+++ b/apps/web/src/app/(authenticated)/settings/notification-default-level.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+//
+// story #3222 — 기본 알림 레벨 저장이 화면에 반영 안 되던 결함(BE notification-preferences가
+// {"data": [...]}로 이중래핑 반환 → FE 프록시가 그 위에 다시 감싸 {data: {data: [...]}}가
+// 됨 → 화면 파서가 배열을 못 찾아 조용히 무반영)의 UI측 라이브 pin. route.test.ts(같은
+// story)가 프록시 실경로의 단일래핑을 증명하고, 이 파일은 "그 정합된 응답이 왔을 때 화면이
+// 실제로 즉시 반영하는지"를 증명한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../messages/ko.json';
+import { RefreshProvider } from '@/contexts/refresh-context';
+
+const { useDashboardContextMock } = vi.hoisted(() => ({
+  useDashboardContextMock: vi.fn(),
+}));
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), refresh: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams('tab=notifications'),
+  usePathname: () => '/settings',
+}));
+
+// GET 계열은 fetchWithAuth 경유 — /api/current-project·/api/notification-preferences만
+// 의미있는 값을 주고 나머지는 기존 page.test.tsx와 동형으로 ok:false 기본값.
+let preferenceLevel: 'all' | 'mentions' | 'mute' = 'all';
+
+vi.mock('@/lib/db/client', () => ({
+  fetchWithAuth: vi.fn(async (url: string) => {
+    if (url === '/api/current-project') {
+      return { ok: true, json: async () => ({ data: { project_id: 'proj-1', org_id: 'org-1' } }) };
+    }
+    if (url === '/api/notification-preferences') {
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ scope_type: 'global', channel: 'in_app', level: preferenceLevel }],
+        }),
+      };
+    }
+    return { ok: false, json: async () => ({ data: null }) };
+  }),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <RefreshProvider>{node}</RefreshProvider>
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  preferenceLevel = 'all';
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useDashboardContextMock.mockReturnValue({ orgId: 'org-1', orgMemberships: [] });
+  // RefreshProvider가 마운트 시 localStorage.getItem을 읽는다 — jsdom 환경설정에
+  // storage 백엔드가 없어 인메모리 스텁으로 대체(이 테스트의 관심사가 아님).
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+  });
+  // PUT은 handleSetGlobalPreferenceLevel이 raw fetch로 직접 호출(fetchWithAuth 아님).
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ data: [{ scope_type: 'global', channel: 'in_app', level: 'mentions' }] }),
+  })));
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  // vi.resetModules()는 호출하지 않는다 — RefreshProvider를 이 파일 상단에서 정적
+  // import하는데, resetModules 후 SettingsPage를 동적 재-import하면 RefreshContext
+  // 모듈 인스턴스가 갈라져(Provider≠Consumer 심볼) "must be used within
+  // RefreshProvider"가 오탐으로 뜬다.
+});
+
+async function mount(node: React.ReactNode) {
+  await act(async () => { root.render(wrap(node)); });
+  // loadContext의 GET 체인(현재-프로젝트→org목록→notification-settings→notification-preferences
+  // →webhooks)이 여러 await를 거치므로 microtask flush를 한 번 더 준다.
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+function levelButton(text: string): HTMLButtonElement {
+  const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === text);
+  if (!btn) throw new Error(`button not found: ${text}`);
+  return btn;
+}
+
+describe('SettingsPage — 기본 알림 레벨 즉시 반영(story #3222)', () => {
+  it('GET(서버=mentions)이면 마운트 직후 화면도 «멘션만»이 선택 표시된다(리로드=재마운트와 동형)', async () => {
+    preferenceLevel = 'mentions';
+    const { default: SettingsPage } = await import('./page');
+    await mount(<SettingsPage />);
+
+    const mentionsBtn = levelButton('멘션만');
+    // 선택된 버튼엔 bg-primary가 붙는다(원 컴포넌트 조건부 className).
+    expect(mentionsBtn.className).toContain('bg-primary');
+  });
+
+  it('«멘션만» 클릭 → PUT 응답 반영해 화면이 즉시 «멘션만»으로 갱신된다(무반영 회귀가드)', async () => {
+    const { default: SettingsPage } = await import('./page');
+    await mount(<SettingsPage />);
+
+    // 초기값은 all이 선택 표시.
+    expect(levelButton('전체').className).toContain('bg-primary');
+
+    await act(async () => {
+      levelButton('멘션만').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(levelButton('멘션만').className).toContain('bg-primary');
+    expect(levelButton('전체').className).not.toContain('bg-primary');
+  });
+});

--- a/apps/web/src/app/api/notification-preferences/route.test.ts
+++ b/apps/web/src/app/api/notification-preferences/route.test.ts
@@ -1,0 +1,62 @@
+// story #3222 — 이중래핑 회귀가드. BE(notification_preferences.py)가 예전엔 {"data": [...]}로
+// 반환했는데, 이 route(→ proxyToFastapi → apiSuccess)가 그 응답 바디를 그대로 다시
+// {data: raw, ...}로 감싸 최종 FE 응답이 {data: {data: [...]}}로 이중래핑됐다(설정>알림 화면이
+// 레벨 저장해도 조용히 반영 안 되는 실사고 — PR#3605 billing/orders와 동일 클래스).
+// fastapi-proxy.test.ts/billing orders route.test.ts와 동형 — global.fetch mock으로 BE 응답을
+// 흉내내고 GET/PUT을 직접 호출해 실경로(route → proxyToFastapi → apiSuccess)를 지난다.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getAuthContextMock, getServerSessionMock } = vi.hoisted(() => ({
+  getAuthContextMock: vi.fn(),
+  getServerSessionMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth-helpers', () => ({ getAuthContext: getAuthContextMock }));
+vi.mock('@/lib/db/server', () => ({ getServerSession: getServerSessionMock }));
+
+import { GET, PUT } from './route';
+
+describe('/api/notification-preferences — 이중래핑 회귀가드(story #3222)', () => {
+  beforeEach(() => {
+    getAuthContextMock.mockReset();
+    getServerSessionMock.mockReset();
+    getAuthContextMock.mockResolvedValue({ id: 'member-1', type: 'human' });
+    getServerSessionMock.mockResolvedValue({ access_token: 'token-1' });
+  });
+
+  it('GET: BE가 flat list를 반환하면 FE 최종 응답은 단일래핑 {data: [...]}이다(이중래핑 금지)', async () => {
+    const bePrefs = [{
+      id: 'pref-1', member_id: 'member-1', scope_type: 'global', scope_id: null,
+      event_key: null, channel: 'in_app', level: 'mentions', updated_at: '2026-08-30T00:00:00Z',
+    }];
+    // BE 라우터(get_preferences)가 실제로 반환하는 형상 — flat list(dict로 감싸지 않음).
+    global.fetch = vi.fn(async () => new Response(JSON.stringify(bePrefs), { status: 200 }));
+
+    const res = await GET(new Request('http://localhost/api/notification-preferences'));
+    const json = await res.json();
+
+    // 이중래핑이었다면 json.data가 {data: [...]}(object)였을 것 — 배열 자체여야 한다.
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data).toEqual(bePrefs);
+    expect(json.error).toBeNull();
+  });
+
+  it('PUT: BE가 flat list를 반환하면 FE 최종 응답은 단일래핑 {data: [...]}이다(이중래핑 금지)', async () => {
+    const bePrefs = [{
+      id: 'pref-1', member_id: 'member-1', scope_type: 'global', scope_id: null,
+      event_key: null, channel: 'in_app', level: 'mentions', updated_at: '2026-08-30T00:00:00Z',
+    }];
+    global.fetch = vi.fn(async () => new Response(JSON.stringify(bePrefs), { status: 200 }));
+
+    const res = await PUT(new Request('http://localhost/api/notification-preferences', {
+      method: 'PUT',
+      body: JSON.stringify({ preferences: [{ scope_type: 'global', scope_id: null, channel: 'in_app', level: 'mentions' }] }),
+    }));
+    const json = await res.json();
+
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data).toEqual(bePrefs);
+    expect(json.data[0].level).toBe('mentions');
+    expect(json.error).toBeNull();
+  });
+});

--- a/backend/app/routers/notification_preferences.py
+++ b/backend/app/routers/notification_preferences.py
@@ -95,9 +95,15 @@ async def get_preferences(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-) -> dict:
+) -> list[dict]:
     """GET /api/v2/notification-preferences — 현재 멤버(또는 admin override 대상)의 전체
     preference 조회.
+
+    story #3222 — flat list로 반환한다(**{"data": [...]}로 감싸지 않음**). FE 프록시
+    (notification-preferences/route.ts의 apiSuccess)가 이 BE 응답 바디를 그대로
+    `{data: raw, ...}`로 감싸므로, 여기서 이미 {"data": [...]}를 반환하면 FE 최종
+    모양이 {data: {data: [...]}}로 이중래핑된다(설정 화면이 저장해도 조용히 반영
+    안 되는 실사고 — PR#3605의 billing/orders와 동일 계약 정정).
 
     story #2623(2026-08-14) — webhooks.py story 933248fa의 「제1 경고」 그대로 준수: PUT만
     admin override를 넣고 GET을 빠뜨리면 「저장은 되는데 목록에 안 보임」으로 재오픈된다 —
@@ -121,7 +127,7 @@ async def get_preferences(
     rows = (await db.execute(
         select(NotificationPreference).where(NotificationPreference.member_id == scope_member_id)
     )).scalars().all()
-    return {"data": [_pref_to_dict(p) for p in rows]}
+    return [_pref_to_dict(p) for p in rows]
 
 
 @router.put("")
@@ -130,7 +136,7 @@ async def upsert_preferences(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-) -> dict:
+) -> list[dict]:
     """PUT /api/v2/notification-preferences — upsert (INSERT ON CONFLICT UPDATE).
 
     story #2623(2026-08-14) — webhooks.py story 933248fa와 동형 admin override: 산티아고의
@@ -138,7 +144,9 @@ async def upsert_preferences(
     (기존 self-service 무회귀). `body.member_id` 지정 시 caller org 스코프로 서버측 재해소
     (`_resolve_target_member_id` 재사용 — body-claimed org 신뢰 금지) 후, 해소된 target이
     caller 자신과 다르면 admin/owner role 필수(JWT app_metadata.role, 서버 검증된 클레임) —
-    아니면 명시 403(침묵 caller-scope 강제 저장 금지)."""
+    아니면 명시 403(침묵 caller-scope 강제 저장 금지).
+
+    story #3222 — GET과 동일하게 flat list 반환(이중래핑 방지, 위 GET 참고)."""
     member = await _get_member(auth, org_id, db)
 
     target_member_id = member.id
@@ -232,4 +240,4 @@ async def upsert_preferences(
         results.append(_pref_to_dict(row))
 
     await db.commit()
-    return {"data": results}
+    return results

--- a/backend/tests/test_2623_notification_preferences_admin_override.py
+++ b/backend/tests/test_2623_notification_preferences_admin_override.py
@@ -140,11 +140,11 @@ async def test_self_service_put_and_get_unaffected_no_member_id():
                 s, None, org.id, _agent_auth(agent_id, org.id),
                 [{"scope_type": "global", "channel": "sse", "level": "mentions"}],
             )
-            assert put_result["data"][0]["member_id"] == str(agent_id)
+            assert put_result[0]["member_id"] == str(agent_id)
 
             get_result = await _call_get(s, None, org.id, _agent_auth(agent_id, org.id))
-            assert len(get_result["data"]) == 1
-            assert get_result["data"][0]["level"] == "mentions"
+            assert len(get_result) == 1
+            assert get_result[0]["level"] == "mentions"
     finally:
         await engine.dispose()
 
@@ -168,9 +168,9 @@ async def test_admin_put_then_get_parity_no_reopen_regression():
             get_result = await _call_get(
                 s, agent_id, org.id, _human_auth(admin_user_id, org.id, role="admin"),
             )
-            assert len(get_result["data"]) == 1
-            assert get_result["data"][0]["member_id"] == str(agent_id)
-            assert get_result["data"][0]["level"] == "mute"
+            assert len(get_result) == 1
+            assert get_result[0]["member_id"] == str(agent_id)
+            assert get_result[0]["level"] == "mute"
     finally:
         await engine.dispose()
 
@@ -234,7 +234,7 @@ async def test_owner_role_also_allowed():
                 s, agent_id, org.id, _human_auth(owner_user_id, org.id, role="owner"),
                 [{"scope_type": "global", "channel": "sse", "level": "mentions"}],
             )
-            assert result["data"][0]["member_id"] == str(agent_id)
+            assert result[0]["member_id"] == str(agent_id)
     finally:
         await engine.dispose()
 
@@ -249,7 +249,7 @@ async def test_get_self_via_explicit_member_id_no_admin_check_needed():
 
         async with Session() as s:
             result = await _call_get(s, agent_id, org.id, _agent_auth(agent_id, org.id))
-            assert result["data"] == []  # 403 없이 정상 통과(그냥 자기 것 0건)
+            assert result == []  # 403 없이 정상 통과(그냥 자기 것 0건)
     finally:
         await engine.dispose()
 
@@ -309,6 +309,6 @@ async def test_admin_override_human_target_mute_conversation_allowed():
                 s, target_member_id, org.id, _human_auth(admin_user_id, org.id, role="admin"),
                 [{"scope_type": "conversation", "scope_id": str(uuid.uuid4()), "channel": "sse", "level": "mute"}],
             )
-            assert result["data"][0]["level"] == "mute"
+            assert result[0]["level"] == "mute"
     finally:
         await engine.dispose()

--- a/backend/tests/test_2637_notification_preference_router_event_key.py
+++ b/backend/tests/test_2637_notification_preference_router_event_key.py
@@ -88,9 +88,9 @@ async def test_upsert_event_key_scope_succeeds():
                 ]),
                 db=s, auth=_auth(agent_id, org_id), org_id=org_id,
             )
-            assert resp["data"][0]["event_key"] == "org.acme.widget.made"
-            assert resp["data"][0]["scope_id"] is None
-            assert resp["data"][0]["level"] == "mute"
+            assert resp[0]["event_key"] == "org.acme.widget.made"
+            assert resp[0]["scope_id"] is None
+            assert resp[0]["level"] == "mute"
     finally:
         await engine.dispose()
 
@@ -172,8 +172,8 @@ async def test_upsert_event_key_scope_is_idempotent_update():
                 ]),
                 db=s, auth=_auth(agent_id, org_id), org_id=org_id,
             )
-            assert first["data"][0]["id"] == second["data"][0]["id"]
-            assert second["data"][0]["level"] == "all"
+            assert first[0]["id"] == second[0]["id"]
+            assert second[0]["level"] == "all"
 
             from app.models.notification_preference import NotificationPreference
             from sqlalchemy import select
@@ -213,11 +213,11 @@ async def test_distinct_event_keys_do_not_collide():
                 ]),
                 db=s, auth=_auth(agent_id, org_id), org_id=org_id,
             )
-            assert resp["data"][0]["event_key"] == "org.acme.thing.done"
+            assert resp[0]["event_key"] == "org.acme.thing.done"
 
             from app.routers.notification_preferences import get_preferences
 
             all_prefs = await get_preferences(db=s, auth=_auth(agent_id, org_id), org_id=org_id)
-            assert len(all_prefs["data"]) == 2
+            assert len(all_prefs) == 2
     finally:
         await engine.dispose()


### PR DESCRIPTION
## 배경
- [\[설정·알림\] 기본 알림 레벨 저장이 화면에 전혀 반영 안 됨 — BFF 이중래핑({data:{data}})으로 쓰기 성공이 실패처럼·읽기는 항상 기본값·원복 불능 함정까지](entity:story:fbb224f4-97ed-4655-84ed-cb67ad080476)

## 원인
notification_preferences.py GET/PUT이 `{"data": [...]}`로 반환 → FE 프록시(apiSuccess)가
그 응답을 그대로 다시 `{data: raw, ...}`로 감싸 최종 `{data: {data: [...]}}` 이중래핑.
화면 파서(`json.data.find(...)`)는 배열을 기대하는데 실제론 object라 조용히 무반영 —
PUT은 200 실저장되지만 화면·리로드 반영 전부 깨지고, «전체» 재클릭은 PUT 자체가
스킵돼 원복도 막히는 함정이었다.

## 처방
PR#3605(billing/orders)과 동일 계약 — BE가 flat list를 그대로 반환하도록 정정
(webhooks/config 등 자매 엔드포인트 관례와 통일). FE는 그대로 두고(파서 무수정)
apiSuccess가 한 번만 감싸는 정상 경로로 복귀.

## 검증
- 신규 route.test.ts(2건) — 프록시 실경로(global.fetch mock) 단일래핑 증명.
- 신규 notification-default-level.test.tsx(2건) — 실컴포넌트 마운트, 서버값 즉시
  반영+클릭 시 갱신 라이브 pin.
- 기존 BE pinned 테스트(test_2623/test_2637) 16곳 계약 정정(`resp["data"][...]`→
  `resp[...]`) — 이중래핑을 그대로 pin하고 있던 것.
- tsc 0·lint 0(무관 5건)·전체 vitest 539/5038 GREEN·build GREEN·backend
  py_compile OK·guard 8/8 GREEN·전체 pytest 5150 passed(무관 14건 제외).