### PR TITLE
[SID:3228] Activity Log action 필터 debounce — 무한루프 크래시 근본 처방

### DIFF
--- a/apps/web/src/components/activity/activity-log-view.test.tsx
+++ b/apps/web/src/components/activity/activity-log-view.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+// story #3228(버그사냥, 카디르 발견 → 착수) — Activity Log의 action 필터 입력창이
+// debounce 없이 buildParams/fetchLogs의 useCallback 의존값이었다. 타이핑 1글자당
+// 네트워크 재조회 이펙트가 재실행돼(실측: 50자 타이핑 → /api/activity-logs 요청
+// 정확히 50건, 1:1) 긴 문자열을 빠르게 입력하면 수백~수천 건이 몰려 브라우저
+// 커넥션풀 고갈(ERR_INSUFFICIENT_RESOURCES) → 비동기 응답들이 거의 동시 귀환하며
+// 겹쳐 부르는 setState 폭주가 React #185(Maximum update depth exceeded)로 이어져
+// 페이지 전체가 크래시했다. 처방: actionFilter를 300ms debounce한 값으로만
+// buildParams가 재계산되도록 분리 + maxLength=200 방어선.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { ActivityLogView } from './activity-log-view';
+import { TopBarProvider } from '@/components/nav/top-bar-context';
+import enMessages from '../../../messages/en.json';
+
+const fetchWithAuthMock = vi.fn();
+
+vi.mock('@/lib/db/client', () => ({
+  fetchWithAuth: (...args: Parameters<typeof fetchWithAuthMock>) => fetchWithAuthMock(...args),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+async function mount() {
+  await act(async () => {
+    root.render(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <TopBarProvider>
+          <ActivityLogView projectId="p1" />
+        </TopBarProvider>
+      </NextIntlClientProvider>,
+    );
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchWithAuthMock.mockReset();
+  fetchWithAuthMock.mockImplementation(async (url: string) => {
+    if (url.includes('/api/members')) return { ok: true, status: 200, json: async () => ({ data: [] }) };
+    return { ok: true, status: 200, json: async () => ({ data: { items: [], total: 0, limit: 30, offset: 0 } }) };
+  });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  container.remove();
+});
+
+describe('ActivityLogView — action 필터 debounce(story #3228)', () => {
+  it('길게 연타 입력해도 activity-logs 요청은 debounce 창 1개로 뭉친다(요청 폭주 방지)', async () => {
+    await mount();
+    fetchWithAuthMock.mockClear();
+
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+    // 뮤테이션 전이면 이만큼 타이핑 시 activity-logs 요청도 그만큼(1:1) 나갔다 —
+    // debounce가 살아있으면 실제 fetchLogs 호출은 debounce 창이 만료된 뒤 1건뿐이어야 한다.
+    await act(async () => {
+      for (let i = 0; i < 50; i++) {
+        setInputValue(input, 'A'.repeat(i + 1));
+        vi.advanceTimersByTime(10); // 각 keystroke 사이 10ms — 300ms debounce 창보다 훨씬 짧음
+      }
+    });
+
+    const activityLogCallsDuringTyping = fetchWithAuthMock.mock.calls.filter(([u]: [string]) => u.includes('/api/activity-logs')).length;
+    expect(activityLogCallsDuringTyping).toBe(0); // 타이핑 도중엔 아직 debounce 창 안 — 0건이어야 함
+
+    await act(async () => { vi.advanceTimersByTime(350); }); // debounce 창 만료
+
+    const activityLogCallsAfterSettle = fetchWithAuthMock.mock.calls.filter(([u]: [string]) => u.includes('/api/activity-logs')).length;
+    expect(activityLogCallsAfterSettle).toBe(1); // 정확히 1건만 — 요청 폭주 재발 시 이 값이 커진다
+  });
+
+  it('debounce 만료 후 실제 action 쿼리파라미터가 최종 입력값으로 정확히 나간다(무회귀 — 필터 기능 자체는 정상)', async () => {
+    await mount();
+    fetchWithAuthMock.mockClear();
+
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+    await act(async () => { setInputValue(input, 'deploy'); });
+    await act(async () => { vi.advanceTimersByTime(350); });
+
+    const call = fetchWithAuthMock.mock.calls.find(([u]: [string]) => u.includes('/api/activity-logs'));
+    expect(call).toBeDefined();
+    const url = new URL(call![0] as string, 'http://x');
+    expect(url.searchParams.get('action')).toBe('deploy');
+  });
+
+  it('입력값을 지우면(빈 문자열) debounce 후 action 파라미터가 다시 빠진다(무회귀)', async () => {
+    await mount();
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+    await act(async () => { setInputValue(input, 'deploy'); });
+    await act(async () => { vi.advanceTimersByTime(350); });
+    fetchWithAuthMock.mockClear();
+
+    await act(async () => { setInputValue(input, ''); });
+    await act(async () => { vi.advanceTimersByTime(350); });
+
+    const call = fetchWithAuthMock.mock.calls.find(([u]: [string]) => u.includes('/api/activity-logs'));
+    expect(call).toBeDefined();
+    const url = new URL(call![0] as string, 'http://x');
+    expect(url.searchParams.has('action')).toBe(false);
+  });
+
+  it('maxLength=200 방어선 — 입력창이 그 이상은 애초에 못 받도록 정직하게 제한한다(잘라내기 아님, 입력차단)', async () => {
+    await mount();
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+    expect(input.maxLength).toBe(200);
+  });
+});

--- a/apps/web/src/components/activity/activity-log-view.tsx
+++ b/apps/web/src/components/activity/activity-log-view.tsx
@@ -46,6 +46,18 @@ const ALL = '__all__';
 const PAGE_SIZE = 30;
 
 const ENTITY_TYPES = ['story', 'epic', 'sprint', 'memo', 'task', 'agent_run', 'doc', 'meeting'];
+// story #3228(버그사냥, 카디르) — actionFilter가 debounce 없이 buildParams/fetchLogs의
+// useCallback 의존값이라, 타이핑 1글자당 이펙트가 재실행돼 네트워크 요청이 그대로
+// 발사됐다(실측: 50자 타이핑 → /api/activity-logs 요청 정확히 50건, 1:1). 긴 문자열을
+// 빠르게 입력하면(예: 2000자+) 수백~수천 건이 짧은 시간에 몰려 브라우저 커넥션풀이
+// 고갈(ERR_INSUFFICIENT_RESOURCES)되고, 그 요청들이 비동기로 거의 동시에 귀환하며
+// 겹쳐 부르는 setState 폭주가 React #185(Maximum update depth exceeded)로 이어져
+// 페이지 전체가 크래시했다. 근본 처방은 "왜 렌더가 자기를 다시 트리거하는가"를 끊는
+// 디바운스 — 300ms는 이 코드베이스의 다른 텍스트필터(예: 검색창) 관례와 동일 값.
+const ACTION_FILTER_DEBOUNCE_MS = 300;
+// 방어선(2중) — 이 필드는 활동 로그의 action 문자열 필터일 뿐 자유 텍스트 입력이 아니다.
+// 실제 action 값들(예: "created", "updated_status")보다 압도적으로 넉넉한 상한.
+const ACTION_FILTER_MAX_LENGTH = 200;
 
 function getDefaultDates() {
   const to = new Date();
@@ -83,6 +95,14 @@ export function ActivityLogView({ projectId }: ActivityLogViewProps) {
 
   const [actorFilter, setActorFilter] = useState(ALL);
   const [actionFilter, setActionFilter] = useState(ALL);
+  // story #3228 — buildParams/fetchLogs는 이 debounce된 값을 쓴다(원본 actionFilter는
+  // input의 controlled value로만 쓰여 타이핑이 시각적으로는 즉시 반영됨 — 지연되는 건
+  // 네트워크 재조회뿐).
+  const [debouncedActionFilter, setDebouncedActionFilter] = useState(ALL);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedActionFilter(actionFilter), ACTION_FILTER_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [actionFilter]);
   const [entityTypeFilter, setEntityTypeFilter] = useState(ALL);
   const [{ from: initFrom, to: initTo }] = useState(getDefaultDates);
   const [fromDate, setFromDate] = useState(initFrom);
@@ -104,13 +124,13 @@ export function ActivityLogView({ projectId }: ActivityLogViewProps) {
     (nextOffset = 0) => {
       const p = new URLSearchParams({ project_id: projectId, limit: String(PAGE_SIZE), offset: String(nextOffset) });
       if (actorFilter !== ALL) p.set('actor_id', actorFilter);
-      if (actionFilter !== ALL) p.set('action', actionFilter);
+      if (debouncedActionFilter !== ALL) p.set('action', debouncedActionFilter);
       if (entityTypeFilter !== ALL) p.set('entity_type', entityTypeFilter);
       if (fromDate) p.set('from', `${fromDate}T00:00:00`);
       if (toDate) p.set('to', `${toDate}T23:59:59`);
       return p;
     },
-    [projectId, actorFilter, actionFilter, entityTypeFilter, fromDate, toDate],
+    [projectId, actorFilter, debouncedActionFilter, entityTypeFilter, fromDate, toDate],
   );
 
   const fetchLogs = useCallback(
@@ -226,6 +246,7 @@ export function ActivityLogView({ projectId }: ActivityLogViewProps) {
                 value={actionFilter === ALL ? '' : actionFilter}
                 onChange={(e) => setActionFilter(e.target.value || ALL)}
                 placeholder={t('filterAction')}
+                maxLength={ACTION_FILTER_MAX_LENGTH}
                 className="rounded-md border border-input bg-background px-3 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground"
               />
             </div>


### PR DESCRIPTION
## 요약
- [[버그사냥] Activity Log 필터 입력창에 2000자+ 입력 시 React 무한루프 크래시(전체 페이지 다운)](entity:story:5099b9a4-3323-4198-bb3e-d39d7ce2fb25)

## 근본 원인
`actionFilter`가 debounce 없이 `buildParams`/`fetchLogs`의 `useCallback` 의존값이라, 타이핑 1글자당 이펙트가 재실행돼 네트워크 요청이 그대로 발사됐다. 실측(라이브 dev-app.sprintable.ai, sellerking 계정): 50자 타이핑 → `/api/activity-logs` 요청 정확히 50건, 1:1 비율.

긴 문자열을 빠르게 입력하면(2000자+) 수백~수천 건이 짧은 시간에 몰려 브라우저 커넥션풀이 고갈(`ERR_INSUFFICIENT_RESOURCES`)되고, 그 요청들이 비동기로 거의 동시에 귀환하며 겹쳐 부르는 setState 폭주가 React #185(Maximum update depth exceeded)로 이어져 페이지 전체가 크래시했다.

## 처방
- `actionFilter`를 300ms debounce한 값(`debouncedActionFilter`)으로만 `buildParams`가 재계산되도록 분리 — input 자체의 controlled value는 즉시 반영(타이핑 체감은 그대로), 지연되는 건 네트워크 재조회뿐.
- `maxLength={200}` 방어선 추가 — 이 필드는 활동 로그 action 문자열 필터일 뿐 자유 텍스트 입력이 아니다(실제 action 값들보다 압도적으로 넉넉한 상한). 브라우저 네이티브 `maxLength`라 입력 자체를 정직하게 차단(잘라내기 아님).

## 검증
- 신규 pin 4건(`activity-log-view.test.tsx`):
  - 요청 폭주 방지 — 50회 타이핑 시뮬레이션 중 `activity-logs` 요청 0건(debounce 창 안), 창 만료 후 정확히 1건.
  - 정상 필터링 무회귀 — debounce 후 `action` 쿼리파라미터가 최종 입력값으로 정확히 전달, 값 지우면 파라미터도 다시 빠짐.
  - `maxLength=200` 속성 확認.
- 뮤테이션 검증 — debounce 의존성 배열을 원복(우회)하는 뮤테이션 → 정확히 1건 RED(요청폭주방지 pin만 — 필터기능 pin 2건은 debounce 트리거타이밍만 우회한 이 단일뮤테이션에서는 최종 action 파라미터 값 자체는 여전히 정확히 나가 안 깨짐, 핵심 방어선 반응은 정확 — 미르코 재현 정정), 원복 후 4/4.
- `tsc --noEmit` 0. `vitest run`(전체) — 540 files/5042 tests 전부 PASS(기존 539/5038+신규 1파일/4건).

## 참고
- Playwright 라이브 재현(원 발견 세션)에서 임계값 1500~2000자 사이로 크래시 발생을 이진탐색 특定했음 — 이번 fix는 그 트리거(요청 폭주) 자체를 근본에서 제거.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
