### PR TITLE
[SID:2890] delete_avatar 버킷 미설정 시 silent no-op → 503 fail-closed 통일

### DIFF
--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -610,7 +610,14 @@ async def delete_avatar_endpoint(
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
     await _assert_can_edit_avatar(id, member, session, org_id, auth)
-    await delete_avatar(current_avatar_url=member.avatar_url)
+    # story #2890 — delete_avatar가 이제 버킷 미설정 시 AvatarUploadError(503)를 던진다
+    # (예전엔 조용히 no-op했다). 위 upload-url/confirm 엔드포인트와 동일 패턴으로 잡아
+    # HTTP 503으로 변환 — 안 잡으면 avatar_url을 null化해버려 fail-closed 계약이
+    # 라우터 층에서 다시 새는 걸 막는다.
+    try:
+        await delete_avatar(current_avatar_url=member.avatar_url)
+    except AvatarUploadError as e:
+        raise HTTPException(status_code=e.status_code, detail={"code": e.code, "message": e.message}) from e
     await repo.apply_anchor_update(member, {"avatar_url": None})
     session.expire(member)
     updated = await repo.get(id)

--- a/backend/app/services/avatar_upload.py
+++ b/backend/app/services/avatar_upload.py
@@ -121,8 +121,13 @@ async def confirm_upload(
 
 
 async def delete_avatar(*, current_avatar_url: str | None) -> None:
-    if not AVATARS_BUCKET:
-        return
+    # story #2890(카디르 QA MEDIUM, PR #3297) — 이 함수만 버킷 미설정 시 예외 없이 no-op해
+    # 모듈 docstring의 계약("GCS_AVATARS_BUCKET 미설정 시 전 함수 503 fail-closed")을
+    # 어겼다 — 라우터(team_members.py delete_avatar_endpoint)는 그 침묵을 "삭제 성공"과
+    # 구별 못 하고 avatar_url을 그대로 null化해, 미설정 환경(운영 드리프트 시나리오)에서
+    # storage 객체가 orphan으로 남을 수 있었다. create_upload_url/confirm_upload와 동일한
+    # _require_bucket()로 통일 — 계약대로 fail-closed.
+    bucket = _require_bucket()
     old_path = canonical_avatar_object_path(current_avatar_url)
     if old_path:
-        await get_storage_provider().delete_object(AVATARS_BUCKET, old_path)
+        await get_storage_provider().delete_object(bucket, old_path)

--- a/backend/tests/test_2887_avatar_upload_service.py
+++ b/backend/tests/test_2887_avatar_upload_service.py
@@ -213,4 +213,20 @@ async def test_delete_avatar_ignores_external_url(avatar_service):
     """우리 버킷이 아닌 avatar_url(레거시/외부값)은 delete_object 호출 없이 그냥 통과 —
     canonical_avatar_object_path가 None을 반환하는 값에 대해 예외 없이 조용히 no-op."""
     await avatar_service.delete_avatar(current_avatar_url="https://example.com/someone-elses-avatar.png")
+
+
+@pytest.mark.asyncio
+async def test_delete_avatar_unconfigured_bucket_is_503(avatar_service_unconfigured):
+    """story #2890(카디르 QA MEDIUM, PR #3297) — delete_avatar만 create_upload_url/
+    confirm_upload와 달리 버킷 미설정 시 예외 없이 조용히 return해 모듈 docstring의
+    계약(⑤미설정 시 503 fail-closed)을 어기고 있었다. 라우터(team_members.py
+    delete_avatar_endpoint)는 그 침묵을 성공과 구별 못 하고 avatar_url을 그대로
+    null化해, storage 객체가 orphan으로 남을 수 있었다(원 재현). 이제 다른 두 함수와
+    동일하게 503+AVATAR_UPLOAD_NOT_CONFIGURED를 던진다."""
+    with pytest.raises(avatar_service_unconfigured.AvatarUploadError) as exc_info:
+        await avatar_service_unconfigured.delete_avatar(
+            current_avatar_url="https://storage.googleapis.com/some-bucket/avatar/x/y/z.png",
+        )
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.code == "AVATAR_UPLOAD_NOT_CONFIGURED"
     # no exception = pass


### PR DESCRIPTION
[SID:2890]

## 요약
카디르 QA(PR #3297) MEDIUM 상신 — `avatar_upload.py` 모듈 docstring의 계약("GCS_AVATARS_BUCKET 미설정 시 전 함수 503 fail-closed")을 `delete_avatar()`만 어기고 있었다. `create_upload_url`/`confirm_upload`는 이미 `_require_bucket()`로 503을 던지는데 `delete_avatar`만 `if not AVATARS_BUCKET: return`으로 예외 없이 조용히 no-op — 라우터(`team_members.py` `delete_avatar_endpoint`)는 그 침묵을 삭제 성공과 구별 못 하고 `avatar_url`을 그대로 null化해, 운영 드리프트(버킷 미설정) 시나리오에서 실 storage 객체가 orphan으로 남을 수 있었다.

dev는 버킷 구성済(카디르 gcloud 실측 — CORS·IAM 전부 확인)라 현재 도달 불가한 경로 — 비차단 판정으로 fast-follow.

## 변경
1. **avatar_upload.py**: `delete_avatar()`도 다른 두 함수와 동일하게 `_require_bucket()` 사용.
2. **team_members.py**: `delete_avatar_endpoint`에 그 503을 HTTP 응답으로 변환하는 try/except 추가(위 upload-url/confirm 엔드포인트와 동일 패턴 — 안 잡으면 `avatar_url`을 null化해버려 fail-closed 계약이 라우터 층에서 다시 샌다).

## 검증
- 신규 테스트(미설정→503) + 기존 테스트(정상삭제·외부URL no-op) 무회귀.
- 뮤테이션 검증 — 구 코드로 되돌려 정확히 신규 테스트만 RED.
- 8종 backend guard lint + 전체 스위트 collect-only(8458건, import 오류 0) 로컬 선제 통과.

## 테스트 계획
- [x] 신규 유닛테스트(미설정→503) + 뮤테이션 검증
- [x] 기존 delete_avatar 테스트 무회귀
- [x] guard lint 8종 + collect-only 전수

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>