### PR TITLE
[SID:3241] DELETE /api/v2/assets/{id} 핸들러 신설 — soft-delete 100% 실패 해소

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -193,6 +193,8 @@
     "deleteTitle": "Delete this asset?",
     "deleteBody": "Deleting <b>{name}</b> can't be undone.",
     "deleteImpact": "This asset is currently used in {count} place(s) — deleting it will break the links below.",
+    "deleteErrorTitle": "Couldn't delete asset",
+    "deleteErrorDesc": "Something went wrong. Try again.",
     "selectPrompt": "Select an asset to see its details.",
     "emptyTitle": "No assets yet",
     "emptyDesc": "Files uploaded or attached to this project show up here.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -193,6 +193,8 @@
     "deleteTitle": "자산을 삭제할까요?",
     "deleteBody": "<b>{name}</b>을(를) 삭제하면 되돌릴 수 없습니다.",
     "deleteImpact": "이 자산은 현재 {count}곳에서 사용 중입니다 — 삭제하면 아래 항목의 링크가 끊어집니다.",
+    "deleteErrorTitle": "자산을 삭제하지 못했습니다",
+    "deleteErrorDesc": "문제가 발생했습니다. 다시 시도해 주세요.",
     "selectPrompt": "자산을 선택하면 상세 정보가 표시됩니다.",
     "emptyTitle": "아직 자산이 없습니다",
     "emptyDesc": "이 프로젝트에 업로드하거나 첨부한 파일이 여기에 표시됩니다.",

--- a/apps/web/src/components/storage/storage-delete-dialog.test.tsx
+++ b/apps/web/src/components/storage/storage-delete-dialog.test.tsx
@@ -94,3 +94,42 @@ describe('StorageDeleteDialog — #2525 footer sticky', () => {
     expect(document.body.textContent).not.toContain('곳에서 사용 중');
   });
 });
+
+// story #3241 — BE DELETE 핸들러 신설(S7 착지) 회귀 pin + AC4(에러 토스트 카피 분리, 로드-실패
+// 문구 오용 제거) 고정. 성공 시 onDeleted/onOpenChange 호출, 실패 시 삭제 전용 카피(deleteErrorTitle)
+// 노출 — 구 errorTitle(「자산을 불러오지 못했습니다」, 로드-실패 문구)이 아님을 명시적으로 확인.
+describe('StorageDeleteDialog — #3241 삭제 왕복 + 에러 카피', () => {
+  it('DELETE 200 시 onDeleted+onOpenChange(false) 호출된다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: { ok: true } }) })));
+    const onDeleted = vi.fn();
+    const onOpenChange = vi.fn();
+    act(() => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages}>
+          <StorageDeleteDialog asset={makeAsset(0)} open onOpenChange={onOpenChange} onDeleted={onDeleted} />
+        </NextIntlClientProvider>,
+      );
+    });
+    const deleteButton = Array.from(document.querySelectorAll('button')).find((b) => b.textContent === '삭제');
+    await act(async () => { deleteButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onDeleted).toHaveBeenCalledWith('asset-1');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('DELETE 비-2xx 시 삭제 실패 전용 카피가 뜨고(로드-실패 문구 아님) 다이얼로그는 안 닫힌다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({}) })));
+    const onOpenChange = vi.fn();
+    act(() => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages}>
+          <StorageDeleteDialog asset={makeAsset(0)} open onOpenChange={onOpenChange} onDeleted={() => {}} />
+        </NextIntlClientProvider>,
+      );
+    });
+    const deleteButton = Array.from(document.querySelectorAll('button')).find((b) => b.textContent === '삭제');
+    await act(async () => { deleteButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(document.body.textContent).toContain('자산을 삭제하지 못했습니다');
+    expect(document.body.textContent).not.toContain('자산을 불러오지 못했습니다');
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/components/storage/storage-delete-dialog.tsx
+++ b/apps/web/src/components/storage/storage-delete-dialog.tsx
@@ -27,16 +27,17 @@ export function StorageDeleteDialog({ asset, open, onOpenChange, onDeleted }: St
     if (!asset) return;
     setDeleting(true);
     try {
-      // S7(서버 delete) 미착지 가능 → 비-2xx/예외는 toast 후 graceful 유지.
+      // story #3241: 서버 DELETE 핸들러 신설됨(S7 착지) — 비-2xx/예외는 삭제 실패 전용 카피로
+      // toast(구 errorTitle/errorDesc는 «자산을 불러오지 못했습니다» 로드-실패 문구라 오용이었음).
       const res = await fetch(`/api/assets/${asset.id}`, { method: 'DELETE' });
       if (!res.ok) {
-        addToast({ title: t('errorTitle'), body: t('errorDesc'), type: 'error' });
+        addToast({ title: t('deleteErrorTitle'), body: t('deleteErrorDesc'), type: 'error' });
         return;
       }
       onDeleted(asset.id);
       onOpenChange(false);
     } catch {
-      addToast({ title: t('errorTitle'), body: t('errorDesc'), type: 'error' });
+      addToast({ title: t('deleteErrorTitle'), body: t('deleteErrorDesc'), type: 'error' });
     } finally {
       setDeleting(false);
     }

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -12,7 +12,7 @@ import base64
 import json
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -485,6 +485,35 @@ async def get_asset(
         raise HTTPException(status_code=404, detail="Asset not found")
     enriched = await _enrich(db, org_id, accessible, [asset])
     return enriched[asset.id]
+
+
+@router.delete("/assets/{asset_id}", status_code=200)
+async def delete_asset(
+    asset_id: str,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """DELETE /api/v2/assets/{id} — story #3241(핸들러 부재로 100% 실패 fix).
+
+    soft-delete만(`deleted_at` 세팅, 하드삭제 금지) — storage_usage()가 이미 그 필드를 전제하고
+    복구 7일 grace(cron.py storage_usage_warn 인접 잡)까지 문서화돼 있던 설계를 실제로 발동시킨다.
+    authz는 get_asset과 동일 _scope_filter 재사용(IDOR 일관 — 스코프 밖/이미 삭제됨/malformed uuid
+    전부 graceful 404, 존재여부 비노출).
+    """
+    try:
+        aid = uuid.UUID(asset_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Asset not found") from None
+    clauses, _accessible = await _scope_filter(db, auth, org_id, None)
+    asset = (await db.execute(
+        select(Asset).where(Asset.id == aid, and_(*clauses))
+    )).scalar_one_or_none()
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    asset.deleted_at = datetime.now(timezone.utc)
+    await db.commit()
+    return {"ok": True}
 
 
 class AssetTextResponse(BaseModel):

--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -105,6 +105,11 @@ PATH_ID_PARAM_RE = re.compile(r"^(?:id|[a-z][a-z0-9]*_id)$")
 # **project_id= 키워드로 호출됐을 때만** 가드로 인정(sprints.delete 등 정당 사용 보존).
 ID_MUTATION_PROJECT_GUARDS: frozenset[str] = frozenset(PROJECT_GUARD_FUNCTIONS - {"resolve_member"}) | {
     "assert_target_in_caller_org",
+    # story #3241 — assets.py 모듈-로컬 헬퍼(has_id_mutation_guard 는 has_guard 와 달리 1-hop 바디
+    # 헬퍼를 안 들여다봄 — 이 축은 이름을 직접 알아야 함). get_asset(GET, 기존)이 이미 이 헬퍼로
+    # project 접근권을 검증하던 동일 IDOR 경계를 delete_asset(신규 DELETE)이 재사용한다 — 이름이
+    # assets.py 에만 있음을 확인 후 편입(grep 0건, 타 모듈 동명 함수와 충돌 리스크 없음).
+    "_scope_filter",
 }
 
 # Depends(...) 콜러블 — 결과 id가 caller auth에서 서버-파생돼 클라이언트가 스푸핑할 여지가

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -883,6 +883,66 @@ async def test_get_single_asset_scoped():
 
 
 @pytest.mark.anyio
+async def test_delete_asset_scoped_soft_delete_and_storage_reflects():
+    """story #3241 — DELETE /assets/{id} 신설. 핵심: 핸들러 부재로 100% 실패하던 걸 soft-delete로
+    실동작화 + get_asset과 동일 _scope_filter 재사용(cross-project=거부 자체가 성립하는지) +
+    storage_usage 즉시 반영(AC2 실증) + 하드삭제 금지(row 존속·deleted_at만 세팅) 4개를 한 번에 편다.
+    """
+    from unittest.mock import MagicMock
+
+    from fastapi import HTTPException
+
+    from app.routers.assets import delete_asset, storage_usage
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            ins = ("INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes)"
+                   " VALUES (:id,:o,:p,:c,:path,:n,:sz)")
+            aid_a = uuid.uuid4()  # PROJ_A: USER granted — 삭제 대상
+            await s.execute(text(ins), {"id": aid_a, "o": ORG, "p": PROJ_A, "c": BUCKET, "path": "da/a", "n": "a.png", "sz": 1000})
+            aid_b = uuid.uuid4()  # PROJ_B: USER 미접근 — 거부 대조군
+            await s.execute(text(ins), {"id": aid_b, "o": ORG, "p": PROJ_B, "c": BUCKET, "path": "da/b", "n": "b.png", "sz": 500})
+            await s.commit()
+
+            auth = MagicMock()
+            auth.user_id = str(USER)
+
+            # 삭제 前 storage_usage = 두 asset 합.
+            before = await storage_usage(db=s, auth=auth, org_id=ORG)
+            assert before.used_bytes == 1500
+
+            # ①양성: 접근권 있는 asset 삭제 성공.
+            r = await delete_asset(str(aid_a), db=s, auth=auth, org_id=ORG)
+            assert r == {"ok": True}
+
+            row = (await s.execute(text("SELECT deleted_at FROM assets WHERE id=:id"), {"id": aid_a})).scalar_one()
+            assert row is not None  # soft-delete = deleted_at 세팅.
+            row_exists = (await s.execute(text("SELECT 1 FROM assets WHERE id=:id"), {"id": aid_a})).scalar_one_or_none()
+            assert row_exists == 1  # 하드삭제 금지 — row 자체는 존속.
+
+            # storage_usage 즉시 반영(AC2) — 삭제분 제외.
+            after = await storage_usage(db=s, auth=auth, org_id=ORG)
+            assert after.used_bytes == 500
+
+            # ②음성(양성대조, story #3241 AC1): 스코프 밖 asset 삭제 시도는 거부되고 실제로
+            # 안 지워진다 — 이 asset이 여전히 storage_usage 합산에 남아있는지로 부작용 0 증명.
+            with pytest.raises(HTTPException) as ei:
+                await delete_asset(str(aid_b), db=s, auth=auth, org_id=ORG)
+            assert ei.value.status_code == 404
+            still = (await s.execute(text("SELECT deleted_at FROM assets WHERE id=:id"), {"id": aid_b})).scalar_one()
+            assert still is None
+            # storage_usage 는 org 전체 합(project 접근권 무관) — aid_b 는 거부됐을 뿐 살아있으므로
+            # 여전히 합산된다(500 그대로, aid_a 삭제분만 빠짐). 이걸로 거부가 "진짜 no-op"임을 증명.
+            unchanged = await storage_usage(db=s, auth=auth, org_id=ORG)
+            assert unchanged.used_bytes == 500
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_grace_cron_hard_deletes_expired_softdeleted(monkeypatch):
     """S8 Phase 2: grace cron — soft-delete 7일 경과만 hard-delete(row+link CASCADE). 최근/live 보존.
     blob delete 성공 시에만 row 삭제(mock provider)."""


### PR DESCRIPTION
[SID:3241]

## 문제
`backend/app/routers/assets.py`에 DELETE 라우트 자체가 존재한 적이 없었다(핸들러 부재, 라우팅 누락 아님). FE는 확인 다이얼로그에서 "되돌릴 수 없습니다"까지 경고하지만 실제로는 서버가 요청을 아예 받지 않아 삭제가 전 사용자·전 자산에 대해 100% 실패했다. `storage_usage()`는 이미 `deleted_at IS NULL` soft-delete를 전제하고 있었으나 그걸 발동시키는 API가 없는 상태.

## 처방
- `DELETE /api/v2/assets/{asset_id}` 신설 — soft-delete만(`deleted_at` 세팅, 하드삭제 금지).
- authz는 기존 `get_asset`과 동일한 `_scope_filter` 재사용(IDOR 일관 — cross-project/cross-org/malformed uuid 전부 graceful 404).
- FE 에러 토스트 카피 분리 — 기존 `errorTitle`/`errorDesc`(로드 실패 문구)를 삭제 실패에 오용하던 것을 `deleteErrorTitle`/`deleteErrorDesc`로 분리(ko/en 둘 다).
- `tests/authz_coverage_lib.py`의 `ID_MUTATION_PROJECT_GUARDS`에 `_scope_filter` 편입 — 이 축(`has_id_mutation_guard`)은 `has_guard`와 달리 1-hop 바디 헬퍼를 안 들여다봐 이름 등록이 필요(assets.py 로컬 헬퍼, grep으로 타 모듈 동명 충돌 없음 확인 후 추가).

## 테스트
- `backend/tests/test_asset_registry_realdb.py::test_delete_asset_scoped_soft_delete_and_storage_reflects`(신규, realdb) — 접근권 있는 asset 삭제 성공(soft-delete·하드삭제 아님)+storage_usage 즉시 반영(AC2)+cross-project 거부 시 부작용 0(양성대조). 뮤테이션 검증 완료(fix 되돌리면 RED).
- `apps/web/.../storage-delete-dialog.test.tsx`(신규 2건) — DELETE 200 시 onDeleted/onOpenChange 호출, 비-2xx 시 삭제 전용 카피 노출(로드-실패 문구 아님을 명시 확인).
- `test_authz_project_scope_coverage.py` — 신규 mutation 라우트 가드 인식 확인(뮤테이션 검증 완료, 편입 전 RED).
- guard lint 8종 + `pytest --collect-only`(8459건, 0 import error) 로컬 선제 통과.

⛔ dev까지만(prod 착지 금지) — 게이트: PR → PO AC 리뷰 → QA → PO 머지.