### PR TITLE
[SID:3242] /storage 다운로드 실동작 빌드 — sign 경로 재사용·no-op 소멸·실패 신호

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -188,6 +188,8 @@
     "typeConversation": "Conversation",
     "typeManual": "Manual",
     "download": "Download",
+    "downloadErrorTitle": "Couldn't download",
+    "downloadErrorDesc": "The file could not be downloaded. Please try again.",
     "delete": "Delete",
     "cancel": "Cancel",
     "deleteTitle": "Delete this asset?",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -188,6 +188,8 @@
     "typeConversation": "대화",
     "typeManual": "직접 첨부",
     "download": "다운로드",
+    "downloadErrorTitle": "다운로드하지 못했습니다",
+    "downloadErrorDesc": "파일을 받지 못했습니다. 다시 시도해 주세요.",
     "delete": "삭제",
     "cancel": "취소",
     "deleteTitle": "자산을 삭제할까요?",

--- a/apps/web/src/components/storage/storage-view.tsx
+++ b/apps/web/src/components/storage/storage-view.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { Badge } from '@/components/ui/badge';
+import { ToastContainer, useToast } from '@/components/ui/toast';
 import { useContextualPanelState } from '@/components/ui/contextual-panel-layout';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
@@ -57,6 +58,7 @@ export function resolveAssetDeepLinkAction(params: {
 // projectName 은 순수 표시용(폴더 트리 헤더)이라 전역 컨텍스트 그대로 유지(artifacts와 동형).
 export function StorageView({ projectId }: { projectId: string }) {
   const t = useTranslations('storage');
+  const { toasts, addToast, dismissToast } = useToast();
   const { projectName } = useDashboardContext();
   const searchParams = useSearchParams();
 
@@ -301,8 +303,34 @@ export function StorageView({ projectId }: { projectId: string }) {
     [],
   );
 
-  // 다운로드/업로드 = 어포던스 (S3/S7 미착지 → 컨트롤만 렌더, no-op)
-  const noopAsset = useCallback((_asset: Asset) => {}, []);
+  // 다운로드 = 실동작 (story #886d996f). 기존 sign 경로(/api/attachments/sign?asset_id) 재사용 —
+  // BE가 asset_id로 container/object_path를 서버측 재도출·storage.signRead(SSOT, 자체 서명 0).
+  // asset.id만 넘기고, 실패 경로는 무신호 금지(toast). disposition=attachment로 인라인 아닌 저장.
+  const handleDownloadAsset = useCallback(
+    async (asset: Asset) => {
+      try {
+        const res = await fetchWithAuth(
+          `/api/attachments/sign?asset_id=${encodeURIComponent(asset.id)}&disposition=attachment`,
+        );
+        if (!res.ok) throw new Error(`sign failed: ${res.status}`);
+        const { data } = (await res.json()) as { data?: { url?: string } };
+        if (!data?.url) throw new Error('sign returned no url');
+        const a = document.createElement('a');
+        a.href = data.url;
+        a.rel = 'noopener';
+        a.download = asset.name;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+      } catch {
+        addToast({ title: t('downloadErrorTitle'), body: t('downloadErrorDesc'), type: 'error' });
+      }
+    },
+    [addToast, t],
+  );
+
+  // 업로드 = BE 선행 대기 (story #d4b371be: POST /assets/upload-url + /upload-confirm 착지 전까지
+  // 배선 불가). 착지 후 이 no-op을 실 업로드(hidden file input→프리사인드 PUT→confirm)로 대체한다.
   const noopUpload = useCallback(() => {}, []);
 
   const folderMap = useMemo(() => new Map(folders.map((f) => [f.id, f])), [folders]);
@@ -387,7 +415,7 @@ export function StorageView({ projectId }: { projectId: string }) {
           selectedAssetId={selectedAssetId}
           onSelectAsset={handleSelectAsset}
           onDeleteAsset={handleRequestDelete}
-          onDownloadAsset={noopAsset}
+          onDownloadAsset={handleDownloadAsset}
           onUpload={noopUpload}
           resolveFolderLabel={resolveFolderLabel}
           loading={loading}
@@ -403,7 +431,7 @@ export function StorageView({ projectId }: { projectId: string }) {
           <StorageDetailPanel
             asset={selectedAsset}
             folderLabel={resolveFolderLabel(selectedAsset?.folder_id ?? null)}
-            onDownload={noopAsset}
+            onDownload={handleDownloadAsset}
             onRequestDelete={handleRequestDelete}
           />
         ) : null}
@@ -429,7 +457,7 @@ export function StorageView({ projectId }: { projectId: string }) {
             <StorageDetailPanel
               asset={selectedAsset}
               folderLabel={resolveFolderLabel(selectedAsset?.folder_id ?? null)}
-              onDownload={noopAsset}
+              onDownload={handleDownloadAsset}
               onRequestDelete={handleRequestDelete}
               onClose={() => detailPanel.setDrawerOpen(false)}
             />
@@ -443,6 +471,8 @@ export function StorageView({ projectId }: { projectId: string }) {
         onOpenChange={setDeleteOpen}
         onDeleted={handleDeleted}
       />
+
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </div>
   );
 }


### PR DESCRIPTION
## /storage 다운로드 실동작 빌드 — sign 경로 재사용·no-op 소멸·실패 신호 (#886d996f 다운로드 축)

`/storage` 「다운로드」가 빈 함수(`noopAsset`)라 클릭해도 무반응·에러 신호조차 0이던 걸 **실동작으로 빌드**. PO 판정에 따른 **다운로드 축만**(업로드 축은 BE 선행 대기·아래 잔여 참조).

### 다운로드 (실동작·SSOT 준수)
기존 sign 경로를 재사용 — 자체 서명/putObject 신설 0(#39a05c5a IStorageService SSOT 규칙 준수):
```
GET /api/attachments/sign?asset_id=<asset.id>&disposition=attachment
```
- BE `attachments.py`가 **asset_id로 container/object_path를 서버측 재도출**(FE 제공 path 무시)한 뒤 `storage.signRead(container, object_path, {disposition})` → `{ data: { url } }`. 인가·좌표 도출이 전부 서버 권위.
- FE는 `asset.id`만 넘기고, 반환된 단기 서명 URL을 `<a download>`로 트리거. `disposition=attachment`가 Content-Disposition을 attachment로 세팅(인라인 미리보기 아닌 저장).
- 배선: `onDownloadAsset`(리스트)·`onDownload`(상세 패널·드로어) 3자리 전부 `handleDownloadAsset`.

### 실패 무신호 금지 (AC③)
sign 비-2xx·URL 부재·예외는 전부 catch → **toast**(`downloadErrorTitle`/`downloadErrorDesc`, type=error) — storage 화면 기존 toast 기전(`useToast`+`ToastContainer`, delete-dialog와 동형) 재사용. 조용한 실패 0.

### 잔여 (PO 명시 — 이 PR 범위 밖)
- **업로드 no-op은 남는다**: 재사용할 스토리지 업로드 엔드포인트가 부재(assets.py=read+폴더+삭제뿐). BE 선행 story **#d4b371be**(POST /assets/upload-url + /upload-confirm·SSOT signed_write_url·source_type=manual) 착지 후, 그 FE 계약(AC5)을 소비해 별 PR로 업로드 FE(hidden file input→프리사인드 PUT→confirm)를 배선한다. `noopUpload`에 그 대기 사유 주석.
- **«no-op 전부 소멸» 검산은 #886d996f 완주(업로드 FE 배선까지) 시점 기준** — 이 PR은 다운로드 축의 no-op만 소멸.

### 디디 조율
삭제 PR **#3635는 OPEN**(QA 대기·미머지). storage-view.tsx를 안 건드려(assets.py+storage-delete-dialog.tsx 뿐) **무충돌** 확認. (초기 「이미 머지」는 실물 재확認 후 OPEN으로 정정.)

### 검증
- `tsc --noEmit` 소스 에러 0.
- **vitest 20 통과**(storage 전체·기존 delete-dialog/capacity toast 회귀 없음). storage-view 전용 유닛 하네스는 없어(마운트 시 폴더/자산 fetch 다수) 다운로드 핸들러 단위테스트는 미추가 — **실 다운로드 픽셀은 배포 후 검증**.
- dev까지만·prod 착지 금지.

리뷰어 카디르 대행(유나 author FE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)