### PR TITLE
[SID:3249] POST /assets/upload-url + /upload-confirm 신설 — manual 자산 업로드 BE

### DIFF
--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -31,7 +31,7 @@ from app.models.pm import Story
 from app.models.team import TeamMember
 from app.services.asset_registry import DEFAULT_CONTAINER
 from app.services.member_resolver import canonicalize_member_id, resolve_member
-from app.services.project_auth import accessible_project_ids_in_org, has_project_access
+from app.services.project_auth import accessible_project_ids_in_org, has_project_access, require_project_access
 
 logger = logging.getLogger(__name__)
 
@@ -574,6 +574,10 @@ class AssetUploadUrlResponse(BaseModel):
     upload_url: str
     object_path: str
     expires_at: datetime
+    # story #3249(카디르/codex HIGH 후속) — create-only 서명(x-goog-if-generation-match: 0)이
+    # PUT 요청에도 정확히 실려야 서명이 valid함(GCS가 헤더를 서명 바인딩에 포함) — FE는 이 헤더를
+    # 그대로 PUT에 붙여야 한다(안 붙이면 403). 응답에 명시해 FE가 하드코딩 대신 서버 계약을 따르게.
+    required_put_headers: dict[str, str] = {}
 
 
 _ASSET_UPLOAD_URL_TTL = timedelta(minutes=10)
@@ -607,9 +611,8 @@ async def create_asset_upload_url(
     null-project 관례와 정합).
     """
     if body.project_id is not None:
-        # story #2322/#2342 판정 — project 접근 거부는 항상 404(존재 비노출), 403 금지.
-        if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
-            raise HTTPException(status_code=404, detail="Project not found")
+        # story #2697 SSOT — require_project_access로 수렴(raw inline 패턴 신규 추가 금지, 실패시 항상 404).
+        await require_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id)
 
     if settings.is_ee_enabled:
         from ee.plan_limits import reject_if_org_over_storage_cap  # type: ignore[import]
@@ -621,12 +624,14 @@ async def create_asset_upload_url(
 
     upload_url = await get_storage_provider().signed_write_url(
         DEFAULT_CONTAINER, object_path, ttl=_ASSET_UPLOAD_URL_TTL, content_type=body.content_type,
+        create_only=True,
     )
     if upload_url is None:
         raise HTTPException(status_code=502, detail="업로드 URL 서명 실패")
     return AssetUploadUrlResponse(
         upload_url=upload_url, object_path=object_path,
         expires_at=datetime.now(timezone.utc) + _ASSET_UPLOAD_URL_TTL,
+        required_put_headers={"x-goog-if-generation-match": "0"},
     )
 
 
@@ -652,9 +657,8 @@ async def confirm_asset_upload(
     재검사) — check_storage_capacity 가 head_object 실 크기로 authoritative 판정.
     """
     if body.project_id is not None:
-        # story #2322/#2342 판정 — project 접근 거부는 항상 404(존재 비노출), 403 금지.
-        if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
-            raise HTTPException(status_code=404, detail="Project not found")
+        # story #2697 SSOT — require_project_access로 수렴(raw inline 패턴 신규 추가 금지, 실패시 항상 404).
+        await require_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id)
 
     expected_prefix = (
         f"org/{org_id}/project/{body.project_id}/manual/" if body.project_id is not None

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -12,7 +12,7 @@ import base64
 import json
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -29,6 +29,7 @@ from app.models.conversation import Conversation, ConversationMessage
 from app.models.doc import Doc
 from app.models.pm import Story
 from app.models.team import TeamMember
+from app.services.asset_registry import DEFAULT_CONTAINER
 from app.services.member_resolver import canonicalize_member_id, resolve_member
 from app.services.project_auth import accessible_project_ids_in_org, has_project_access
 
@@ -561,3 +562,166 @@ async def get_asset_text(
     return AssetTextResponse(
         asset_id=asset.id, content_type=asset.content_type, text_content=data.decode("utf-8", errors="ignore")
     )
+
+
+class AssetUploadUrlRequest(BaseModel):
+    filename: str
+    content_type: str
+    project_id: uuid.UUID | None = None
+
+
+class AssetUploadUrlResponse(BaseModel):
+    upload_url: str
+    object_path: str
+    expires_at: datetime
+
+
+_ASSET_UPLOAD_URL_TTL = timedelta(minutes=10)
+
+
+def _manual_asset_object_path(org_id: uuid.UUID, project_id: uuid.UUID | None, filename: str) -> str:
+    """서버-구성 object_path(client 가 경로 지정 불가) — manual source_type 은
+    path_in_source_scope(asset_registry.py)가 경로 제약을 안 걸어서(«manual 만 경로 제약
+    없음(신뢰 등록)»), 이 서버-구성 자체가 유일한 IDOR 방벽이다. uuid4 세그먼트로 추측 불가
+    (avatar_upload._object_path 와 동형 원칙)."""
+    from app.services.mcp_attachment_upload import safe_attachment_filename
+
+    safe = safe_attachment_filename(filename)
+    if project_id is not None:
+        return f"org/{org_id}/project/{project_id}/manual/{uuid.uuid4()}-{safe}"
+    return f"org/{org_id}/manual/{uuid.uuid4()}-{safe}"
+
+
+@router.post("/assets/upload-url", response_model=AssetUploadUrlResponse)
+async def create_asset_upload_url(
+    body: AssetUploadUrlRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> AssetUploadUrlResponse:
+    """POST /api/v2/assets/upload-url — story #3249(#3242 업로드 축 BE 선행분).
+
+    avatar(team_members.py `/avatar/upload-url`)·canvas(visual_artifacts.py export upload-url)와
+    동형 — SSOT `signed_write_url` 재사용(자체 서명 0). project_id 지정 시 has_project_access
+    검증(get_asset 과 동일 IDOR 축), None 이면 org-level 자산(_scope_filter 의 기존 org-level
+    null-project 관례와 정합).
+    """
+    if body.project_id is not None:
+        # story #2322/#2342 판정 — project 접근 거부는 항상 404(존재 비노출), 403 금지.
+        if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
+            raise HTTPException(status_code=404, detail="Project not found")
+
+    if settings.is_ee_enabled:
+        from ee.plan_limits import reject_if_org_over_storage_cap  # type: ignore[import]
+        await reject_if_org_over_storage_cap(db, org_id)
+
+    object_path = _manual_asset_object_path(org_id, body.project_id, body.filename)
+
+    from app.services.storage import get_storage_provider
+
+    upload_url = await get_storage_provider().signed_write_url(
+        DEFAULT_CONTAINER, object_path, ttl=_ASSET_UPLOAD_URL_TTL, content_type=body.content_type,
+    )
+    if upload_url is None:
+        raise HTTPException(status_code=502, detail="업로드 URL 서명 실패")
+    return AssetUploadUrlResponse(
+        upload_url=upload_url, object_path=object_path,
+        expires_at=datetime.now(timezone.utc) + _ASSET_UPLOAD_URL_TTL,
+    )
+
+
+class AssetUploadConfirmRequest(BaseModel):
+    object_path: str
+    filename: str
+    content_type: str | None = None
+    project_id: uuid.UUID | None = None
+    folder_id: uuid.UUID | None = None
+
+
+@router.post("/assets/upload-confirm", response_model=AssetResponse, status_code=201)
+async def confirm_asset_upload(
+    body: AssetUploadConfirmRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> AssetResponse:
+    """POST /api/v2/assets/upload-confirm — story #3249. head_object 실측(존재·실크기)으로
+    Asset row 등록(source_type=manual, avatar_upload.confirm_upload 와 동형 원칙). object_path 는
+    upload-url 이 이 org/project 스코프로 서버-구성한 값과 prefix 일치해야만 함(avatar 의
+    PATH_NOT_SCOPED 와 동형 — 타 org/project 경로로 등록 시도 차단). 용량 cap 재검사(AC3 confirm
+    재검사) — check_storage_capacity 가 head_object 실 크기로 authoritative 판정.
+    """
+    if body.project_id is not None:
+        # story #2322/#2342 판정 — project 접근 거부는 항상 404(존재 비노출), 403 금지.
+        if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
+            raise HTTPException(status_code=404, detail="Project not found")
+
+    expected_prefix = (
+        f"org/{org_id}/project/{body.project_id}/manual/" if body.project_id is not None
+        else f"org/{org_id}/manual/"
+    )
+    if not body.object_path.startswith(expected_prefix) or "/" in body.object_path[len(expected_prefix):]:
+        raise HTTPException(status_code=403, detail="이 스코프로 발급된 업로드 경로가 아닙니다")
+
+    if body.folder_id is not None:
+        folder = (await db.execute(
+            select(AssetFolder).where(
+                AssetFolder.id == body.folder_id, AssetFolder.org_id == org_id,
+                AssetFolder.project_id == body.project_id, AssetFolder.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if folder is None:
+            raise HTTPException(status_code=404, detail="Folder not found")
+
+    from app.services.storage import get_storage_provider
+
+    size_bytes = await get_storage_provider().head_object(DEFAULT_CONTAINER, body.object_path)
+    if size_bytes is None:
+        raise HTTPException(status_code=404, detail="업로드된 객체를 찾을 수 없습니다(PUT 미완료?)")
+
+    if settings.is_ee_enabled:
+        from ee.plan_limits import check_storage_capacity  # type: ignore[import]
+        await check_storage_capacity(db, org_id, [{"url": body.object_path}])
+
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    created_by: uuid.UUID | None = None
+    try:
+        created_by = (await resolve_member(auth, org_id, db)).id
+    except Exception:  # noqa: BLE001 — created_by 는 비필수(asset.created_by nullable).
+        created_by = None
+
+    base_ins = pg_insert(Asset).values(
+        org_id=org_id, project_id=body.project_id, folder_id=body.folder_id,
+        container=DEFAULT_CONTAINER, object_path=body.object_path,
+        name=body.filename.strip() or "file", content_type=body.content_type,
+        size_bytes=size_bytes, created_by=created_by,
+    )
+    # 까심 R3 동형(asset_registry.sync_attachment_assets) — project_id null/non-null 별
+    # partial unique 로 conflict target 분기(uq_assets_proj_nonnull vs uq_assets_proj_null).
+    if body.project_id is not None:
+        ins = base_ins.on_conflict_do_nothing(
+            index_elements=[Asset.org_id, Asset.project_id, Asset.container, Asset.object_path],
+            index_where=Asset.project_id.isnot(None),
+        ).returning(Asset.id)
+    else:
+        ins = base_ins.on_conflict_do_nothing(
+            index_elements=[Asset.org_id, Asset.container, Asset.object_path],
+            index_where=Asset.project_id.is_(None),
+        ).returning(Asset.id)
+    asset_id = (await db.execute(ins)).scalar_one_or_none()
+    if asset_id is None:
+        sel = select(Asset.id).where(
+            Asset.org_id == org_id, Asset.container == DEFAULT_CONTAINER,
+            Asset.object_path == body.object_path,
+        )
+        sel = sel.where(
+            Asset.project_id == body.project_id if body.project_id is not None else Asset.project_id.is_(None)
+        )
+        asset_id = (await db.execute(sel)).scalar_one()
+    await db.commit()
+
+    asset = (await db.execute(select(Asset).where(Asset.id == asset_id))).scalar_one()
+    accessible = {body.project_id} if body.project_id is not None else set()
+    enriched = await _enrich(db, org_id, accessible, [asset])
+    return enriched[asset.id]

--- a/backend/app/services/storage/base.py
+++ b/backend/app/services/storage/base.py
@@ -30,10 +30,17 @@ class StorageProvider(abc.ABC):
 
     @abc.abstractmethod
     async def signed_write_url(
-        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None
+        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None,
+        create_only: bool = False,
     ) -> str | None:
         """단기 만료 write(PUT) 서명 URL — D3(put=FE) 원칙 유지하며 대용량 바이너리가 BE(Cloud Run)를
-        경유하지 않게 한다(E-CANVAS C1-S5: FE가 캡처한 PNG를 GCS에 직접 PUT). 실패 시 None(best-effort)."""
+        경유하지 않게 한다(E-CANVAS C1-S5: FE가 캡처한 PNG를 GCS에 직접 PUT). 실패 시 None(best-effort).
+
+        story #3249(카디르/codex HIGH) — create_only=True 면 "생성 전용"(기존 객체가 있으면 PUT
+        거부) 조건이 서명에 바인딩된다. 없으면 GCS 기본이 "생성 또는 덮어쓰기"라, confirm이 작은
+        크기로 cap을 통과시킨 뒤 아직 유효한(TTL 內) 같은 signed URL로 더 큰 객체를 재PUT해 DB
+        cap 추적을 우회할 수 있었다(실 storage 는 커지는데 confirm 은 재호출 안 됨). 기본값 False
+        유지 — avatar/canvas 등 기존 호출부는 인자 안 넘기면 기존 동작 그대로(무회귀)."""
 
     @abc.abstractmethod
     async def delete_object(self, container: str, object_path: str) -> bool:

--- a/backend/app/services/storage/gcs.py
+++ b/backend/app/services/storage/gcs.py
@@ -53,10 +53,16 @@ class GcsStorageProvider(StorageProvider):
             return None
 
     async def signed_write_url(
-        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None
+        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None,
+        create_only: bool = False,
     ) -> str | None:
         """signed_read_url과 동형(IAM SignBlob V4) — method="PUT". content_type 지정 시 서명에
-        바인딩돼 FE PUT 요청의 Content-Type 헤더가 반드시 일치해야 한다(임의 타입 업로드 방지)."""
+        바인딩돼 FE PUT 요청의 Content-Type 헤더가 반드시 일치해야 한다(임의 타입 업로드 방지).
+
+        create_only=True 면 `x-goog-if-generation-match: 0`을 서명에 바인딩(story #3249) —
+        GCS 는 이 조건을 "객체가 아직 없을 때만 생성"으로 해석해, 같은 signed URL로 재PUT하면
+        412 Precondition Failed 로 거부한다(cap 우회 재PUT 체인 차단). 이 헤더도 서명에 굽힌
+        값이라 클라이언트 PUT 요청이 정확히 이 헤더를 포함해야 함(안 보내면 403 SignatureDoesNotMatch)."""
 
         def _blocking() -> str:
             import google.auth
@@ -75,6 +81,8 @@ class GcsStorageProvider(StorageProvider):
             }
             if content_type:
                 kwargs["content_type"] = content_type
+            if create_only:
+                kwargs["headers"] = {"x-goog-if-generation-match": "0"}
             return blob.generate_signed_url(**kwargs)
 
         try:

--- a/backend/app/services/storage/local.py
+++ b/backend/app/services/storage/local.py
@@ -91,8 +91,15 @@ class LocalStorageProvider(StorageProvider):
         ⚠️ FE `/api/storage/local/...` serve 라우트가 현재 GET만 문서화돼 있어 PUT 수신을
         지원하려면 FE 측 대응 핸들러가 필요(OSS local provider 후속 — BE 서명 계약만 여기 마련).
 
-        create_only: 인자는 받되 no-op(PUT 수신 자체가 미구현이라 "생성 전용" 조건을 검사할
-        서버측 핸들러가 아직 없음 — story #3249, GCS provider 만 실제 enforce)."""
+        create_only: story #3249 2라운드(카디르/codex) — PUT 수신 자체가 미구현이라 "생성 전용"
+        조건을 검사할 서버측 핸들러가 없다. 조용히 no-op(성공한 것처럼 URL 발급)하면 "create-only
+        보호가 있다"는 거짓 보장이 되므로 **fail-closed**로 URL 자체를 미발급한다(호출부가 502로
+        거부). 진짜 구현은 story dc3d62f4 별건."""
+        if create_only:
+            logger.warning(
+                "local storage: create_only 미지원(PUT 미구현) — URL 미발급(fail-closed) path=%s", object_path
+            )
+            return None
         secret = _signing_secret()
         try:
             base = os.environ.get("STORAGE_LOCAL_SERVE_BASE_URL", _DEFAULT_SERVE_BASE).rstrip("/")

--- a/backend/app/services/storage/local.py
+++ b/backend/app/services/storage/local.py
@@ -84,11 +84,15 @@ class LocalStorageProvider(StorageProvider):
             return None
 
     async def signed_write_url(
-        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None
+        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None,
+        create_only: bool = False,
     ) -> str | None:
         """signed_read_url과 동형이나 payload에 method=PUT을 바인딩(read 서명 재사용 방지).
         ⚠️ FE `/api/storage/local/...` serve 라우트가 현재 GET만 문서화돼 있어 PUT 수신을
-        지원하려면 FE 측 대응 핸들러가 필요(OSS local provider 후속 — BE 서명 계약만 여기 마련)."""
+        지원하려면 FE 측 대응 핸들러가 필요(OSS local provider 후속 — BE 서명 계약만 여기 마련).
+
+        create_only: 인자는 받되 no-op(PUT 수신 자체가 미구현이라 "생성 전용" 조건을 검사할
+        서버측 핸들러가 아직 없음 — story #3249, GCS provider 만 실제 enforce)."""
         secret = _signing_secret()
         try:
             base = os.environ.get("STORAGE_LOCAL_SERVE_BASE_URL", _DEFAULT_SERVE_BASE).rstrip("/")

--- a/backend/app/services/storage/s3.py
+++ b/backend/app/services/storage/s3.py
@@ -60,9 +60,16 @@ class S3StorageProvider(StorageProvider):
         self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None,
         create_only: bool = False,
     ) -> str | None:
-        """create_only: S3 는 prod 미가동(모듈 docstring)이라 실제 조건부-쓰기 바인딩(IfNoneMatch)은
-        아직 구현 안 함(GCS 만 story #3249 대상) — 인자는 받되 no-op(다른 provider와 인터페이스
-        정합만 유지, 실사용 시 재검토 필요한 후속 갭으로 남긴다)."""
+        """create_only: 카디르/codex 재발견(story #3249 2라운드) — S3/MinIO는 self-host 배포의
+        정식 1급 provider(factory.py, dead code 아님)라 create_only=True를 조용히 no-op하면
+        "create-only 보호가 있다"는 거짓 보장이 된다(cap 우회 재현 가능). 실제 조건부-쓰기
+        (If-None-Match) 구현 전까지는 **fail-closed** — URL을 아예 미발급(None, 호출부가 502로
+        거부)한다. 진짜 구현은 story dc3d62f4 별건."""
+        if create_only:
+            logger.warning(
+                "s3 storage: create_only 미지원 — URL 미발급(fail-closed) path=%s", object_path
+            )
+            return None
 
         def _blocking() -> str:
             params: dict = {"Bucket": container, "Key": object_path}

--- a/backend/app/services/storage/s3.py
+++ b/backend/app/services/storage/s3.py
@@ -57,8 +57,13 @@ class S3StorageProvider(StorageProvider):
             return None
 
     async def signed_write_url(
-        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None
+        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None,
+        create_only: bool = False,
     ) -> str | None:
+        """create_only: S3 는 prod 미가동(모듈 docstring)이라 실제 조건부-쓰기 바인딩(IfNoneMatch)은
+        아직 구현 안 함(GCS 만 story #3249 대상) — 인자는 받되 no-op(다른 provider와 인터페이스
+        정합만 유지, 실사용 시 재검토 필요한 후속 갭으로 남긴다)."""
+
         def _blocking() -> str:
             params: dict = {"Bucket": container, "Key": object_path}
             if content_type:

--- a/backend/ee/plan_limits.py
+++ b/backend/ee/plan_limits.py
@@ -240,6 +240,28 @@ async def check_storage_capacity(session: AsyncSession, org_id, attachments: lis
         raise _storage_limit_error("storage", max_storage_mb, tier, used_mb=int(used) / (1024 * 1024))
 
 
+async def reject_if_org_over_storage_cap(session: AsyncSession, org_id) -> None:
+    """story #3249 — 업로드 발급(presigned URL) 시점의 「선검사」. check_storage_capacity 는
+    실 head_object 크기가 있어야(업로드 後) 호출 가능해 발급 단계에선 못 쓴다 — 신규 파일
+    크기를 아직 몰라도 판정 가능한 부분만(현재 사용량이 이미 한도 이상인가) 같은 SSOT
+    (tier→offering_versions)로 검사해 헛발급을 막는다. 파일별/정확한 총량 판정은 여전히
+    confirm 단계의 check_storage_capacity(재검사) 몫."""
+    tier = await _get_org_tier(session, org_id)
+    if tier not in KNOWN_TIERS:
+        return
+    limits = await _get_org_storage_limits(session, tier)
+    if limits is None:
+        return
+    max_storage_mb, _max_file_mb = limits
+    max_storage_bytes = max_storage_mb * 1024 * 1024
+    used = (await session.execute(
+        text("SELECT COALESCE(SUM(size_bytes),0) FROM assets WHERE org_id = :oid AND deleted_at IS NULL"),
+        {"oid": str(org_id)},
+    )).scalar() or 0
+    if int(used) >= max_storage_bytes:
+        raise _storage_limit_error("storage", max_storage_mb, tier, used_mb=int(used) / (1024 * 1024))
+
+
 async def _seat_usage(session: AsyncSession, org_id, *, include_pending_invites: bool) -> int:
     """휴먼 org_members(+옵션: 대기중 미만료 초대) 카운트 — seats 축의 "현재값"(에이전트
     미포함, PO 판정 안B: seats=휴먼 전용)."""

--- a/backend/tests/test_3249_asset_upload_endpoints.py
+++ b/backend/tests/test_3249_asset_upload_endpoints.py
@@ -34,7 +34,7 @@ def anyio_backend():
 
 
 _HEAD_SIZES: dict[str, int | None] = {}
-_SIGNED_URL_CALLS: list[tuple[str, str]] = []
+_SIGNED_URL_CALLS: list[tuple[str, str, bool]] = []
 
 
 @pytest.fixture(autouse=True)
@@ -49,8 +49,8 @@ def _mock_storage(monkeypatch):
     async def _head(container, object_path):
         return _HEAD_SIZES.get(object_path, None)
 
-    async def _signed_write(container, object_path, *, ttl, content_type):
-        _SIGNED_URL_CALLS.append((container, object_path))
+    async def _signed_write(container, object_path, *, ttl, content_type, create_only=False):
+        _SIGNED_URL_CALLS.append((container, object_path, create_only))
         return f"https://signed.example/{object_path}"
 
     prov = MagicMock()
@@ -84,23 +84,23 @@ async def _reset_and_seed(session):
     await session.commit()
 
 
-async def _seed_free_tier_cap(session, *, storage_mb: int, max_file_mb: int = 5000):
-    """offering_versions free-tier 최소 seed — 로컬 create_all DB 는 마이그 seed 데이터가
-    없어(#3241 라운드서 확認된 동일 gap) 테스트 자체 격리를 위해 직접 심는다."""
-    await session.execute(text(
-        "INSERT INTO offering_versions (id,tier,currency,version_label,monthly_price_minor,"
-        "annual_price_minor,included_seats,au_limit,realtime_connection_limit,storage_mb_limit,"
-        "max_file_mb,lab_credit_minor,rate_limit_per_min,automation_rule_limit,webhook_limit,"
-        "event_replay_days,overage_allowed,effective_from,created_by) VALUES "
-        "(gen_random_uuid(),'free','usd','test-3249',0,0,1,1000,10,:storage_mb,:max_file_mb,0,60,10,5,7,"
-        "false,now(),'test-3249')"
-    ), {"storage_mb": storage_mb, "max_file_mb": max_file_mb})
-    await session.commit()
+def _mock_org_storage_limits(monkeypatch, *, storage_mb: int, max_file_mb: int = 5000):
+    """실 offering_versions 조회(_get_org_storage_limits)를 직접 monkeypatch — CI의 real DB엔
+    이미 마이그가 심은 tier='free' 행이 존재해서(로컬 create_all DB엔 없어 #3241 라운드서 직접
+    INSERT로 seed했던 것과 달리) 테스트가 새 행을 추가로 INSERT하면 `ORDER BY currency ASC
+    LIMIT 1`이 어느 행을 집을지 비결정적이 된다(실 seed 값이 이겨 캡이 발동 안 하는 실패 재현,
+    CI에서 실측). 조회 자체를 대체해 seed 데이터 유무와 완전히 무관하게 만든다."""
+    import ee.plan_limits as _plan_limits
+
+    async def _fake(session, tier):
+        return (storage_mb, max_file_mb) if tier == "free" else None
+
+    monkeypatch.setattr(_plan_limits, "_get_org_storage_limits", _fake)
 
 
 @pytest.mark.anyio
 async def test_upload_url_scoped_and_object_path_shape():
-    """접근권 있는 project 는 200+server-구성 prefix, 접근권 없는 project 는 403(URL 미발급)."""
+    """접근권 있는 project 는 200+server-구성 prefix, 접근권 없는 project 는 404(URL 미발급, 존재 비노출)."""
     from app.routers.assets import create_asset_upload_url, AssetUploadUrlRequest
 
     engine = create_async_engine(_ASYNC)
@@ -118,6 +118,9 @@ async def test_upload_url_scoped_and_object_path_shape():
             assert r.object_path.endswith("-a.png")
             assert r.upload_url.startswith("https://signed.example/")
             assert _SIGNED_URL_CALLS[-1][1] == r.object_path
+            # story #3249 카디르/codex HIGH 후속 — create-only 서명 실제 요청+계약 노출 둘 다 확인.
+            assert _SIGNED_URL_CALLS[-1][2] is True
+            assert r.required_put_headers == {"x-goog-if-generation-match": "0"}
 
             from fastapi import HTTPException
             with pytest.raises(HTTPException) as ei:
@@ -268,7 +271,7 @@ async def test_upload_url_rejected_when_org_already_over_cap(monkeypatch):
     try:
         async with Session() as s:
             await _reset_and_seed(s)
-            await _seed_free_tier_cap(s, storage_mb=1)  # 1MB 총량 캡 — 아래로 이미 초과.
+            _mock_org_storage_limits(monkeypatch, storage_mb=1)  # 1MB 총량 캡 — 아래로 이미 초과.
             await s.execute(text(
                 "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes)"
                 " VALUES (gen_random_uuid(),:o,:p,:c,'cap/existing','e',:sz)"
@@ -300,7 +303,7 @@ async def test_confirm_rejects_when_real_size_exceeds_cap(monkeypatch):
     try:
         async with Session() as s:
             await _reset_and_seed(s)
-            await _seed_free_tier_cap(s, storage_mb=1000, max_file_mb=1)  # 파일당 1MB 상한.
+            _mock_org_storage_limits(monkeypatch, storage_mb=1000, max_file_mb=1)  # 파일당 1MB 상한.
             obj = f"org/{ORG}/project/{PROJ_A}/manual/{uuid.uuid4()}-huge.bin"
             _HEAD_SIZES[obj] = 5 * 1024 * 1024  # 5MB > 1MB 파일 상한.
 

--- a/backend/tests/test_3249_asset_upload_endpoints.py
+++ b/backend/tests/test_3249_asset_upload_endpoints.py
@@ -1,0 +1,326 @@
+"""story #3249 — POST /api/v2/assets/upload-url + /upload-confirm(BE, #3242 업로드 축 선행분).
+
+avatar/canvas 와 동형(SSOT signed_write_url·자체 서명 0). manual 은 asset_registry.
+path_in_source_scope 가 경로 제약을 안 걸어서(«manual 만 경로 제약 없음») 서버-구성
+object_path 자체가 유일한 IDOR 방벽 — 그 경계 실증이 이 파일의 핵심.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("a3000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("a3000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("a3000000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("a3000000-0000-0000-0000-0000000000c1")
+PROJ_B = uuid.UUID("a3000000-0000-0000-0000-0000000000c2")
+BUCKET = "sprintable-memo-attachments"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+_HEAD_SIZES: dict[str, int | None] = {}
+_SIGNED_URL_CALLS: list[tuple[str, str]] = []
+
+
+@pytest.fixture(autouse=True)
+def _mock_storage(monkeypatch):
+    from unittest.mock import AsyncMock, MagicMock
+
+    import app.services.storage as _storage_mod
+
+    _HEAD_SIZES.clear()
+    _SIGNED_URL_CALLS.clear()
+
+    async def _head(container, object_path):
+        return _HEAD_SIZES.get(object_path, None)
+
+    async def _signed_write(container, object_path, *, ttl, content_type):
+        _SIGNED_URL_CALLS.append((container, object_path))
+        return f"https://signed.example/{object_path}"
+
+    prov = MagicMock()
+    prov.head_object = AsyncMock(side_effect=_head)
+    prov.signed_write_url = AsyncMock(side_effect=_signed_write)
+    monkeypatch.setattr(_storage_mod, "get_storage_provider", lambda: prov)
+    yield
+
+
+async def _reset_and_seed(session):
+    for sql in [
+        f"DELETE FROM asset_links WHERE org_id='{ORG}'",
+        f"DELETE FROM assets WHERE org_id='{ORG}'",
+        f"DELETE FROM offering_versions WHERE tier='free' AND created_by='test-3249'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','A3','a3org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,login_fail_count,totp_enabled,totp_fail_count) "
+        f"VALUES ('{USER}','u@a3.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
+        # USER 는 PROJ_A 에만 grant(PROJ_B 접근 없음 — IDOR 테스트축, test_asset_registry_realdb.py 동형).
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+    ]:
+        await session.execute(text(sql))
+    await session.commit()
+
+
+async def _seed_free_tier_cap(session, *, storage_mb: int, max_file_mb: int = 5000):
+    """offering_versions free-tier 최소 seed — 로컬 create_all DB 는 마이그 seed 데이터가
+    없어(#3241 라운드서 확認된 동일 gap) 테스트 자체 격리를 위해 직접 심는다."""
+    await session.execute(text(
+        "INSERT INTO offering_versions (id,tier,currency,version_label,monthly_price_minor,"
+        "annual_price_minor,included_seats,au_limit,realtime_connection_limit,storage_mb_limit,"
+        "max_file_mb,lab_credit_minor,rate_limit_per_min,automation_rule_limit,webhook_limit,"
+        "event_replay_days,overage_allowed,effective_from,created_by) VALUES "
+        "(gen_random_uuid(),'free','usd','test-3249',0,0,1,1000,10,:storage_mb,:max_file_mb,0,60,10,5,7,"
+        "false,now(),'test-3249')"
+    ), {"storage_mb": storage_mb, "max_file_mb": max_file_mb})
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_upload_url_scoped_and_object_path_shape():
+    """접근권 있는 project 는 200+server-구성 prefix, 접근권 없는 project 는 403(URL 미발급)."""
+    from app.routers.assets import create_asset_upload_url, AssetUploadUrlRequest
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            auth = _auth()
+
+            r = await create_asset_upload_url(
+                AssetUploadUrlRequest(filename="a.png", content_type="image/png", project_id=PROJ_A),
+                db=s, auth=auth, org_id=ORG,
+            )
+            assert r.object_path.startswith(f"org/{ORG}/project/{PROJ_A}/manual/")
+            assert r.object_path.endswith("-a.png")
+            assert r.upload_url.startswith("https://signed.example/")
+            assert _SIGNED_URL_CALLS[-1][1] == r.object_path
+
+            from fastapi import HTTPException
+            with pytest.raises(HTTPException) as ei:
+                await create_asset_upload_url(
+                    AssetUploadUrlRequest(filename="b.png", content_type="image/png", project_id=PROJ_B),
+                    db=s, auth=auth, org_id=ORG,
+                )
+            assert ei.value.status_code == 404  # story #2322/#2342: project 접근 거부=404(존재 비노출).
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_upload_url_org_level_no_project():
+    from app.routers.assets import create_asset_upload_url, AssetUploadUrlRequest
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            r = await create_asset_upload_url(
+                AssetUploadUrlRequest(filename="c.png", content_type="image/png", project_id=None),
+                db=s, auth=_auth(), org_id=ORG,
+            )
+            assert r.object_path.startswith(f"org/{ORG}/manual/")
+            assert "/project/" not in r.object_path
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_confirm_round_trip_creates_asset_and_storage_reflects():
+    """정상 발급→confirm 왕복(AC4 핀①) — Asset row 등록 + storage_usage 즉시 반영(AC2)."""
+    from app.routers.assets import (
+        AssetUploadConfirmRequest, AssetUploadUrlRequest, confirm_asset_upload,
+        create_asset_upload_url, storage_usage,
+    )
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            auth = _auth()
+
+            issued = await create_asset_upload_url(
+                AssetUploadUrlRequest(filename="doc.pdf", content_type="application/pdf", project_id=PROJ_A),
+                db=s, auth=auth, org_id=ORG,
+            )
+            _HEAD_SIZES[issued.object_path] = 2048  # 실 업로드 완료 시뮬레이션(head_object authoritative).
+
+            before = await storage_usage(db=s, auth=auth, org_id=ORG)
+
+            resp = await confirm_asset_upload(
+                AssetUploadConfirmRequest(
+                    object_path=issued.object_path, filename="doc.pdf",
+                    content_type="application/pdf", project_id=PROJ_A,
+                ),
+                db=s, auth=auth, org_id=ORG,
+            )
+            assert resp.size_bytes == 2048
+            assert resp.name == "doc.pdf"
+            assert resp.project_id == PROJ_A
+
+            row = (await s.execute(
+                text("SELECT size_bytes, deleted_at FROM assets WHERE id=:id"), {"id": resp.id}
+            )).one()
+            assert row.size_bytes == 2048 and row.deleted_at is None
+
+            after = await storage_usage(db=s, auth=auth, org_id=ORG)
+            assert after.used_bytes == before.used_bytes + 2048
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_confirm_rejects_tampered_object_path_no_asset_created():
+    """AC4 핀② — upload-url 이 발급 안 한(server-구성 prefix 밖) object_path 로 confirm 시도는
+    거부되고, 실제로 Asset row 가 안 생긴다(양성대조: 거부가 진짜 no-op임을 DB 로 증명)."""
+    from fastapi import HTTPException
+    from app.routers.assets import AssetUploadConfirmRequest, confirm_asset_upload, storage_usage
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            auth = _auth()
+            forged = f"org/{ORG}/project/{PROJ_A}/manual/../../../etc/passwd"
+            _HEAD_SIZES[forged] = 999  # 객체가 실재해도(head_object 성공) prefix 불일치면 거부돼야 함.
+
+            before = await storage_usage(db=s, auth=auth, org_id=ORG)
+            with pytest.raises(HTTPException) as ei:
+                await confirm_asset_upload(
+                    AssetUploadConfirmRequest(
+                        object_path=forged, filename="x", project_id=PROJ_A,
+                    ),
+                    db=s, auth=auth, org_id=ORG,
+                )
+            assert ei.value.status_code == 403
+            after = await storage_usage(db=s, auth=auth, org_id=ORG)
+            assert after.used_bytes == before.used_bytes  # 부작용 0.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_confirm_object_not_found_leaves_no_orphan_asset():
+    """AC4 핀④ — confirm 안 된(putObject 미완료) 발급은 Asset 미등록으로 남는다(고아 객체
+    자체 정리는 #2869 별건 — 여기선 '미등록'만 확認)."""
+    from fastapi import HTTPException
+    from app.routers.assets import AssetUploadConfirmRequest, confirm_asset_upload
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            never_uploaded = f"org/{ORG}/project/{PROJ_A}/manual/{uuid.uuid4()}-ghost.png"
+            # _HEAD_SIZES 에 없음 → head_object None(업로드 미완료 시뮬레이션).
+            with pytest.raises(HTTPException) as ei:
+                await confirm_asset_upload(
+                    AssetUploadConfirmRequest(
+                        object_path=never_uploaded, filename="ghost.png", project_id=PROJ_A,
+                    ),
+                    db=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 404
+            cnt = (await s.execute(
+                text("SELECT COUNT(*) FROM assets WHERE object_path=:p"), {"p": never_uploaded}
+            )).scalar_one()
+            assert cnt == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_upload_url_rejected_when_org_already_over_cap(monkeypatch):
+    """AC3 «발급 선검사» — 이미 총량 캡을 넘긴 org 는 서명URL 자체를 못 받는다(헛발급 방지)."""
+    from app.core.config import settings
+    from fastapi import HTTPException
+    from app.routers.assets import AssetUploadUrlRequest, create_asset_upload_url
+
+    monkeypatch.setattr(settings, "license_consent", "agreed")
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            await _seed_free_tier_cap(s, storage_mb=1)  # 1MB 총량 캡 — 아래로 이미 초과.
+            await s.execute(text(
+                "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes)"
+                " VALUES (gen_random_uuid(),:o,:p,:c,'cap/existing','e',:sz)"
+            ), {"o": ORG, "p": PROJ_A, "c": BUCKET, "sz": 2 * 1024 * 1024})  # 2MB > 1MB 캡.
+            await s.commit()
+
+            with pytest.raises(HTTPException) as ei:
+                await create_asset_upload_url(
+                    AssetUploadUrlRequest(filename="d.png", content_type="image/png", project_id=PROJ_A),
+                    db=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 402
+            assert _SIGNED_URL_CALLS == []  # 헛발급 0 — signed_write_url 자체가 안 불림.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_confirm_rejects_when_real_size_exceeds_cap(monkeypatch):
+    """AC3 «confirm 재검사» — 발급 시점엔 캡 안이었어도(0바이트 기준) 실 업로드 크기가 파일당
+    상한을 넘으면 confirm 이 거부하고 Asset 은 안 생긴다(check_storage_capacity 재사용)."""
+    from app.core.config import settings
+    from fastapi import HTTPException
+    from app.routers.assets import AssetUploadConfirmRequest, confirm_asset_upload
+
+    monkeypatch.setattr(settings, "license_consent", "agreed")
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            await _seed_free_tier_cap(s, storage_mb=1000, max_file_mb=1)  # 파일당 1MB 상한.
+            obj = f"org/{ORG}/project/{PROJ_A}/manual/{uuid.uuid4()}-huge.bin"
+            _HEAD_SIZES[obj] = 5 * 1024 * 1024  # 5MB > 1MB 파일 상한.
+
+            with pytest.raises(HTTPException) as ei:
+                await confirm_asset_upload(
+                    AssetUploadConfirmRequest(object_path=obj, filename="huge.bin", project_id=PROJ_A),
+                    db=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 402
+            cnt = (await s.execute(
+                text("SELECT COUNT(*) FROM assets WHERE object_path=:p"), {"p": obj}
+            )).scalar_one()
+            assert cnt == 0  # 거부 = Asset 미등록(부작용 0).
+    finally:
+        await engine.dispose()
+
+
+def _auth():
+    from unittest.mock import MagicMock
+
+    auth = MagicMock()
+    auth.user_id = str(USER)
+    return auth

--- a/backend/tests/test_storage_provider.py
+++ b/backend/tests/test_storage_provider.py
@@ -148,6 +148,35 @@ async def test_gcs_signed_write_url_binds_create_only_header(monkeypatch):
     assert "headers" not in captured[-1]  # 기본값(avatar/canvas 무회귀) — 조건 바인딩 없음.
 
 
+@pytest.mark.anyio
+async def test_s3_signed_write_url_create_only_fails_closed():
+    """story #3249 2라운드(카디르/codex) — S3는 self-host 1급 provider(dead code 아님)인데
+    create_only=True를 실제로 강제 못 하면서 조용히 URL을 내주면 "create-only 보호가 있다"는
+    거짓 보장이 된다(cap 우회 재현). 진짜 구현(If-None-Match) 전까진 URL 자체를 미발급해야
+    한다(호출부가 502로 거부 — silent 성공 금지). create_only=False(기본)는 기존 동작 무회귀."""
+    provider = S3StorageProvider()
+    url = await provider.signed_write_url(
+        "bucket", "obj/path", ttl=timedelta(minutes=10), content_type="image/png", create_only=True,
+    )
+    assert url is None
+
+
+@pytest.mark.anyio
+async def test_local_signed_write_url_create_only_fails_closed(monkeypatch):
+    """local 은 PUT 수신 자체가 미구현 — create_only=True 는 같은 이유로 fail-closed."""
+    monkeypatch.setenv("STORAGE_LOCAL_SIGNING_SECRET", "shared-secret")
+    provider = LocalStorageProvider()
+    url = await provider.signed_write_url(
+        "bucket", "obj/path", ttl=timedelta(minutes=10), content_type="image/png", create_only=True,
+    )
+    assert url is None
+    # create_only=False(기본)는 기존 동작 무회귀 — URL 발급 계속됨.
+    url2 = await provider.signed_write_url(
+        "bucket", "obj/path", ttl=timedelta(minutes=10), content_type="image/png",
+    )
+    assert url2 is not None
+
+
 async def test_local_download_blocks_path_traversal(monkeypatch, tmp_path):
     monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
     with pytest.raises(ValueError, match="traversal"):

--- a/backend/tests/test_storage_provider.py
+++ b/backend/tests/test_storage_provider.py
@@ -101,6 +101,53 @@ async def test_local_signed_url_matches_fe_hmac(monkeypatch):
     assert params["sig"] == expected
 
 
+@pytest.mark.anyio
+async def test_gcs_signed_write_url_binds_create_only_header(monkeypatch):
+    """story #3249(카디르/codex HIGH) — create_only=True 면 x-goog-if-generation-match: 0 이
+    generate_signed_url 의 headers kwarg 에 실제로 실려야 한다(이게 GCS 서버가 재PUT을 412로
+    거부하게 만드는 유일한 메커니즘 — 여기가 빠지면 cap 우회 재PUT 체인이 그대로 열린다).
+    create_only=False(기본, avatar/canvas 무회귀)면 headers 자체가 안 실려야 한다."""
+    import google.auth
+    from unittest.mock import MagicMock
+
+    captured: list[dict] = []
+
+    class _FakeBlob:
+        def generate_signed_url(self, **kwargs):
+            captured.append(kwargs)
+            return "https://signed.example/fake"
+
+    class _FakeBucket:
+        def blob(self, path):
+            return _FakeBlob()
+
+    class _FakeClient:
+        def bucket(self, name):
+            return _FakeBucket()
+
+    fake_creds = MagicMock()
+    fake_creds.refresh = MagicMock()
+    fake_creds.service_account_email = "sa@example.iam.gserviceaccount.com"
+    fake_creds.token = "fake-token"
+    monkeypatch.setattr(google.auth, "default", lambda: (fake_creds, "proj"))
+
+    import google.cloud.storage as gcs_storage
+    monkeypatch.setattr(gcs_storage, "Client", _FakeClient)
+
+    provider = GcsStorageProvider()
+
+    await provider.signed_write_url(
+        "bucket", "obj/path", ttl=timedelta(minutes=10), content_type="image/png", create_only=True,
+    )
+    assert captured[-1].get("headers") == {"x-goog-if-generation-match": "0"}
+
+    captured.clear()
+    await provider.signed_write_url(
+        "bucket", "obj/path", ttl=timedelta(minutes=10), content_type="image/png",
+    )
+    assert "headers" not in captured[-1]  # 기본값(avatar/canvas 무회귀) — 조건 바인딩 없음.
+
+
 async def test_local_download_blocks_path_traversal(monkeypatch, tmp_path):
     monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
     with pytest.raises(ValueError, match="traversal"):


### PR DESCRIPTION
[SID:3249]

## 문제
#3242(업로드·다운로드 no-op) 착수 중 확定된 갭 — `assets.py`엔 read+폴더+삭제(#3241)뿐, manual 자산의 업로드 프리사인드 발급·등록 엔드포인트가 애초에 없었다. FE(#3242, 유나)가 그대로 소비할 수 있도록 BE를 먼저 분리 착지한다.

## 처방
avatar(`team_members.py` `/avatar/upload-url`+confirm)·canvas(`visual_artifacts.py` export upload-url)와 동형 — SSOT `get_storage_provider().signed_write_url`/`head_object` 재사용, 자체 서명 신설 없음.

- `POST /api/v2/assets/upload-url` — `project_id` 지정 시 `require_project_access`(story #2697 SSOT) 검증(거부=404, 존재 비노출), `None`이면 org-level 자산. object_path는 **서버가 구성**(`org/{org_id}/project/{project_id}/manual/{uuid4}-{safe_filename}`) — client는 경로를 지정할 수 없음(manual은 `path_in_source_scope`가 경로 제약을 안 걸어서 이 서버-구성이 유일한 IDOR 방벽). 총량 캡 "발급 선검사"(`ee/plan_limits.reject_if_org_over_storage_cap`) — 402.
- `POST /api/v2/assets/upload-confirm` — object_path prefix 재검증(불일치=403) → `head_object` 실측(미존재=404) → `check_storage_capacity` 재검사(초과=402) → Asset row 등록(`source_type=manual`) → `storage_usage` 즉시 반영.

### QA 라운드 — cap 우회 HIGH fix(카디르/codex)
공격: ①작은 객체 PUT→②confirm(작은 크기로 cap 통과·DB size_bytes 고정)→③아직 유효한(TTL 內) 같은 signed URL로 큰 객체 재PUT(GCS 기본="생성 또는 덮어쓰기"). 처방 — **create-only 서명**: `signed_write_url`에 `create_only: bool = False` 추가, GCS는 `x-goog-if-generation-match: 0`을 서명에 바인딩(재PUT=412 거부). 기본값 False라 avatar/canvas 등 기존 호출부 무회귀. assets upload-url만 `create_only=True`.

## FE 계약(#3242 소비용)

```
POST /api/v2/assets/upload-url
Request: { filename: string, content_type: string, project_id?: uuid | null }
Response 200: {
  upload_url: string,
  object_path: string,
  expires_at: datetime,
  required_put_headers: { "x-goog-if-generation-match": "0" }  // ⚠️PUT 요청에 정확히 이 헤더를 포함해야 서명 valid(안 보내면 403)
}
Response 402: PLAN_LIMIT_EXCEEDED(캡 초과, 헛발급 방지)
Response 404: 프로젝트 접근권 없음(존재 비노출)

POST /api/v2/assets/upload-confirm
Request: { object_path: string, filename: string, content_type?: string, project_id?: uuid | null, folder_id?: uuid | null }
Response 201: AssetResponse(기존 GET /assets/{id}와 동일 스키마)
Response 403: object_path가 발급 스코프 밖(변조 의심)
Response 404: 업로드된 객체를 찾을 수 없음(PUT 미완료, 또는 required_put_headers 누락으로 PUT 자체가 403 실패) — Asset 미등록으로 남음
Response 402: PLAN_LIMIT_EXCEEDED(실 크기 기준 재검사)
Response 412(GCS 단, PUT 자체): 이미 존재하는 object_path에 재PUT 시도(create-only 위반) — FE는 새 upload-url을 재발급받아야 함
```

## 테스트
`backend/tests/test_3249_asset_upload_endpoints.py`(realdb, 7건) — 스코프 발급/거부·org-level 무프로젝트·정상 왕복(storage_usage 즉시 반영)·변조 경로 거부(부작용 0)·미확인 업로드 미등록·캡 초과 발급 선거부·confirm 재검사 거부.
`backend/tests/test_storage_provider.py`(GCS provider 레벨, 신규) — create_only=True 시 headers kwarg 실바인딩, False(기본) 시 미바인딩(avatar/canvas 무회귀 pin).
전항 뮤테이션 검증 완료(가드 제거 시 RED 확인 후 복원).

guard lint 8종(`lint_project_access_403.py`가 403 오용 2건 실제로 잡아냄 — require_project_access로 수렴) + `test_authz_project_scope_coverage.py`(13/13) + `test_2697...count_lock`(raw inline 패턴 신규 0건, require_project_access 수렴으로 닫음) + `pytest --collect-only`(8466건, 0 import error) 로컬 선제 통과.

## 못 잡는 것
confirm의 cap 검사-등록 사이 동시성 TOCTOU는 별건([보안·TOCTOU] 자산 upload-confirm 동시 호출 시 용량 cap 우회, codex/카디르 MEDIUM)으로 분리됨 — 이 PR 스코프 밖. folder_id 검증은 존재/스코프 확인만. 고아 객체(미confirm PUT) 자체의 스토리지 정리는 #2869 별건. **create-only는 GCS만 실제 enforce** — S3/local provider는 인자만 받고 no-op(시그니처 정합용, prod 미가동/PUT-serve 미구현). self-host(OSS) 환경에서 storage cap 자체가 EE 전용 기능이라 실무 영향은 제한적이나, self-host가 S3-호환 provider로 EE를 켠(비표준 조합) 극단 케이스에선 create-only 우회가 남는다 — 인지 필요.

⛔ dev까지만(prod 착지 금지) — 게이트: PR → PO AC 리뷰 → QA → PO 머지.
