### PR TITLE
[SID:3242] GCS memo-attachments CORS PUT 프리플라이트 차단 해소

### DIFF
--- a/backend/tests/test_2806_gcs_attachments_cors_ssot.py
+++ b/backend/tests/test_2806_gcs_attachments_cors_ssot.py
@@ -64,6 +64,30 @@ def test_cors_file_allows_get_for_signed_url_fetch():
     assert "GET" in all_methods
 
 
+def test_cors_file_allows_put_for_signed_upload_and_excludes_options():
+    """story #3242(2026-08-31, 유나 실측·페드루 PO 발주) — #886d996f 업로드가 이 버킷에 서명
+    PUT을 직접 쏘는데 method가 GET/HEAD뿐이라 프리플라이트가 Access-Control-Allow-Origin
+    부재로 net::ERR_FAILED. OPTIONS는 GCS가 Access-Control-Request-Method 매칭으로 자동
+    처리하므로 명시하면 안 된다(공식문서: "you shouldn't specify OPTIONS in your CORS
+    configuration")."""
+    rules = _load_cors_rules()
+    all_methods = {m for rule in rules for m in rule.get("method", [])}
+    assert "PUT" in all_methods
+    assert "OPTIONS" not in all_methods
+
+
+def test_cors_file_allows_required_put_headers():
+    """assets.py create_asset_upload_url이 signed_write_url(create_only=True, content_type=...)
+    로 서명해 모든 업로드 PUT에 Content-Type과 x-goog-if-generation-match를 항상 바인딩한다
+    (안 보내면 403 SignatureDoesNotMatch). GCS responseHeader는 preflight의
+    Access-Control-Allow-Headers에 대응(Expose-Headers 아님) — 여기 없으면 프리플라이트 자체가
+    막힌다. Content-Type은 #2806부터 이미 있었으나 x-goog-if-generation-match는 없었다."""
+    rules = _load_cors_rules()
+    all_headers = {h for rule in rules for h in rule.get("responseHeader", [])}
+    assert "Content-Type" in all_headers
+    assert "x-goog-if-generation-match" in all_headers
+
+
 def test_cloudbuild_apply_step_references_the_cors_file_exactly():
     """⭐선언 정합성 — cloudbuild.yaml의 apply-gcs-attachments-cors 스텝이 참조하는
     --cors-file 경로가 실제 이 파일과 정확히 일치하는지(파일명 드리프트 방지)."""

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -311,6 +311,14 @@ steps:
   # iframe이라 무영향)가 origin 불문 전부 차단돼 있었다. `gcloud storage buckets update
   # --cors-file=`은 **전체 교체**라 매 배포 재실행에도 멱등(파일 내용이 그대로면 결과도
   # 그대로) — build/push와 무관해 초반부터 병행 실행.
+  #
+  # 갱신(story #3242, 2026-08-31, 페드루 PO 발주·유나 실측 근거): #886d996f 업로드 기능이
+  # 이 버킷에 서명 PUT을 직접 쏘게 되며 GET/HEAD만 있던 method가 뚫렸다 — PUT 프리플라이트가
+  # Access-Control-Allow-Origin 부재로 net::ERR_FAILED. method에 PUT 추가(OPTIONS는 GCS가
+  # Access-Control-Request-Method 매칭으로 자동 처리 — 명시 금지, 공식문서 확認 완료). PUT은
+  # 항상 create_only=True로 서명(x-goog-if-generation-match: 0 바인딩)·content_type 바인딩이라
+  # responseHeader(=GCS의 Access-Control-Allow-Headers 대응 필드)에 x-goog-if-generation-match를
+  # 추가(Content-Type은 기존에 이미 있었음) — 둘 중 하나라도 빠지면 프리플라이트가 여전히 막힌다.
   - id: apply-gcs-attachments-cors
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
     entrypoint: bash
@@ -330,8 +338,7 @@ steps:
         echo "OK: dev Cloud Run regional origin confirmed in applied CORS"
     waitFor: ['-']
 
-  # story #2887 — avatar 전용 버킷 CORS. PUT까지 필요(memo-attachments는 GET/HEAD뿐 — 아바타는
-  # FE가 서명 URL로 직접 PUT하는 업로드 흐름이라 다름). CORS json(infra/gcs-avatars-cors.json)
+  # story #2887 — avatar 전용 버킷 CORS. CORS json(infra/gcs-avatars-cors.json)
   # 자체는 dev/prod origin을 이미 다 실은 공용 파일(memo-attachments와 동일 관례) — 버킷명만
   # env별로 갈린다.
   # story #3117(2026-08-26, prod 실사고 후속) — 여태 dev 전용 게이트(prod 버킷 미프로비저닝)

--- a/infra/gcs-attachments-cors.json
+++ b/infra/gcs-attachments-cors.json
@@ -7,8 +7,8 @@
       "https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app",
       "http://localhost:3108"
     ],
-    "method": ["GET", "HEAD"],
-    "responseHeader": ["Content-Type", "Content-Length", "Content-Disposition", "Range"],
+    "method": ["GET", "HEAD", "PUT"],
+    "responseHeader": ["Content-Type", "Content-Length", "Content-Disposition", "Range", "x-goog-if-generation-match"],
     "maxAgeSeconds": 3600
   }
 ]


### PR DESCRIPTION
## 배경
페드루 PO 발주(story #886d996f 완결 블로커) — 유나 실측: `/storage` 업로드가 서명 PUT을 `sprintable-memo-attachments`에 직접 쏘는데, 버킷 CORS `method`가 `GET/HEAD`뿐이라 프리플라이트가 `Access-Control-Allow-Origin` 부재로 `net::ERR_FAILED`.

## SSOT 위치 (기존 확인)
story #2806에서 이미 `infra/gcs-attachments-cors.json` + `cloudbuild.yaml`의 `apply-gcs-attachments-cors` 스텝으로 durable화돼 있음(`gcloud storage buckets update --cors-file=` 전체교체·`waitFor: ['-']`로 build/push와 무관 병행 실행). 손 gsutil 일회 적용 아님 — 이 SSOT를 고쳐 다음 dev 배포에 자동 재적용되게 함.

## 변경
- `infra/gcs-attachments-cors.json`: `method`에 `PUT` 추가(OPTIONS는 GCS가 `Access-Control-Request-Method` 매칭으로 자동 처리하므로 명시 금지 — [공식문서](https://cloud.google.com/storage/docs/cross-origin) 확인). `responseHeader`(GCS의 preflight `Access-Control-Allow-Headers` 대응 필드, Expose-Headers 아님)에 `x-goog-if-generation-match` 추가.
  - 근거: `assets.py` `create_asset_upload_url`이 `signed_write_url(create_only=True, content_type=...)`로 서명해 모든 업로드 PUT에 `Content-Type`(기존 보유)과 `x-goog-if-generation-match: 0`(신규 추가)을 항상 바인딩 — 안 보내면 403, CORS에 없으면 프리플라이트 자체가 막힘.
  - 기존 origin·GET 계약은 그대로 유지(superset) — story #2806의 chat 첨부(docx-preview 등 GET 기반) 흐름은 무영향, 같은 버킷이지만 이번 변경은 순수 추가이므로 그 경로 회귀 없음.
- `cloudbuild.yaml`: 위 변경 근거를 주석으로 남기고, 이제 stale해진 "avatar만 PUT 필요" 주석 정정.
- `backend/tests/test_2806_gcs_attachments_cors_ssot.py`: PUT 존재+OPTIONS 부재, 필요 responseHeader 2종 존재를 pin하는 정적 테스트 2개 추가.

## 검증
- `uv run pytest backend/tests/test_2806_gcs_attachments_cors_ssot.py -q` → 9 passed (기존 7 + 신규 2)
- `cloudbuild.yaml` YAML 파싱 확인

## 조사 결과 (PO 질문 회신)
- **prod FE origin 필요 여부**: 이미 필요 없음 확인 아님 — `sprintable-memo-attachments`는 cloudbuild.yaml 주석(디디군 2026-08-19 실측)에 따라 **dev/prod 공유 버킷**(`GCS_MEMO_ATTACHMENTS_BUCKET` override가 배포 SSOT 어디에도 없음)이고, JSON에 `app.sprintable.ai`(prod FE)가 이미 등재돼 있음. 별도 추가 불필요.
- **docx 첨부 CORS 차단과 동일 뿌리인지**: 같은 버킷 맞음. 다만 그 이슈는 GET 기반(story #2806, origin 부재)이라 이미 해소됐고, 이번 PUT 부재는 별개 결함 표면 — 이번 변경은 기존 GET 계약에 순수 추가라 그 경로는 무영향.
- **반영 확인 실측**: 이 PR은 SSOT만 변경. 실측(`gcloud storage buckets describe --format='value(cors_config)')`·preflight OPTIONS 응답의 `Access-Control-Allow-Origin`)은 develop 머지 후 dev Cloud Build 배포가 `apply-gcs-attachments-cors` 스텝을 실행한 뒤 회신에 첨부 예정.

## 못 잡는 것
- 실 브라우저 프리플라이트 왕복(OPTIONS→Allow-Origin 확인)은 dev 배포 후에만 가능 — 이 PR 자체로는 정적 선언 정합성만 보증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)