### PR TITLE
[SID:3267] Support Gateway VPC egress 수선 — Cloud SQL Private IP timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -535,6 +535,7 @@ steps:
           exit 0
         fi
         GCP_PROJECT="${PROJECT_ID}" GCP_REGION="${_AR_REGION}" AR_REPO="${_AR_REPO}" COMMIT_SHA="${COMMIT_SHA}" \
+          SUPPORT_GATEWAY_SERVICE_ACCOUNT="${_SUPPORT_GATEWAY_SERVICE_ACCOUNT}" \
           bash support-gateway/scripts/provision_migrate_job.sh ${_DEPLOY_ENV}
     waitFor: [push-support-gateway]
 
@@ -958,6 +959,9 @@ steps:
           echo "skip deploy-support-gateway: _SUPPORT_GATEWAY_DEPLOY_ENABLED != true (story #3259, PO 프로비저닝 대기)"
           exit 0
         fi
+        # story #b96151da(voided 대체) 수선 — 페드루 PO 실측(gcloud describe diff): migrate
+        # job과 동일 사유로 서비스도 VPC egress 없이는 Cloud SQL Private IP에 "dial tcp
+        # 10.110.0.3:3307: i/o timeout"으로 죽는다(--add-cloudsql-instances 소켓만으론 부족).
         gcloud run deploy support-gateway-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/support-gateway:${COMMIT_SHA} \
           --region=${_AR_REGION} \
@@ -966,6 +970,9 @@ steps:
           --max-instances=${_SUPPORT_GATEWAY_MAX_INSTANCES} \
           --allow-unauthenticated \
           --add-cloudsql-instances=${PROJECT_ID}:${_AR_REGION}:sprintable-${_DEPLOY_ENV} \
+          --network=default \
+          --subnet=default \
+          --vpc-egress=private-ranges-only \
           --update-secrets="SUPPORT_GATEWAY_DATABASE_URL=SUPPORT_GATEWAY_DATABASE_URL_${_DEPLOY_ENV}:latest,SUPPORT_GATEWAY_TOKEN_SECRET=SUPPORT_GATEWAY_TOKEN_SECRET_${_DEPLOY_ENV}:latest" \
           --quiet
     waitFor: [run-support-gateway-migrate-job]

--- a/support-gateway/scripts/provision_migrate_job.sh
+++ b/support-gateway/scripts/provision_migrate_job.sh
@@ -34,6 +34,17 @@ if [ -z "${COMMIT_SHA:-}" ] && [ "${DRY_RUN}" != "1" ]; then
     exit 1
 fi
 
+# story #b96151da(voided 대체) 수선 — 페드루 PO 실측(gcloud describe diff, 2026-08-31):
+# 이 잡이 최초 배포 시 VPC 어노테이션·전용 SA 둘 다 없어 "dial tcp 10.110.0.3:3307:
+# i/o timeout"으로 죽었다. Cloud SQL Auth Proxy(--set-cloudsql-instances)가 unix socket을
+# 앱에 내주더라도, 그 프록시 자신이 인스턴스의 Private IP에 닿으려면 이 프로젝트 네트워킹
+# 구성상 VPC egress가 별도로 필요하다(성공하는 sprintable-migrate-dev도 cloudsql-instances +
+# network-interfaces + vpc-access-egress 셋 다 갖춤 — 소켓만으론 부족, 실측 확認).
+if [ -z "${SUPPORT_GATEWAY_SERVICE_ACCOUNT:-}" ] && [ "${DRY_RUN}" != "1" ]; then
+    echo "ERROR: SUPPORT_GATEWAY_SERVICE_ACCOUNT is not set — fleet 자격 0 경계 위반 방지(기본 compute SA로 조용히 fallback 금지)." >&2
+    exit 1
+fi
+
 JOB_NAME="sprintable-support-gateway-migrate-${ENV}"
 IMAGE_TAG="${COMMIT_SHA:-latest-${ENV}}"
 IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/support-gateway:${IMAGE_TAG}"
@@ -58,6 +69,8 @@ JOB_NAME=${JOB_NAME}
 IMAGE=${IMAGE}
 CLOUD_SQL_INSTANCE=${CLOUD_SQL_INSTANCE}
 DB_SECRET_NAME=${DB_SECRET_NAME}
+SERVICE_ACCOUNT=${SUPPORT_GATEWAY_SERVICE_ACCOUNT:-<unset>}
+VPC=network=default,subnet=default,egress=private-ranges-only
 COMMAND=/app/scripts/migrate.sh
 EOF
     exit 0
@@ -68,8 +81,12 @@ gcloud run jobs deploy "${JOB_NAME}" \
     --region="${GCP_REGION}" \
     --project="${GCP_PROJECT}" \
     --command="/app/scripts/migrate.sh" \
+    --service-account="${SUPPORT_GATEWAY_SERVICE_ACCOUNT}" \
     --set-secrets="SUPPORT_GATEWAY_DATABASE_URL=${DB_SECRET_NAME}:latest" \
     --set-cloudsql-instances="${CLOUD_SQL_INSTANCE}" \
+    --network=default \
+    --subnet=default \
+    --vpc-egress=private-ranges-only \
     --execution-environment=gen2 \
     --max-retries=1 \
     --task-timeout=300


### PR DESCRIPTION
[SID:3267]

## 배경
story #b96151da(voided 대체, #3259 Gateway 배포 flip 집행)의 실 배포에서 Cloud Build step 11(run-support-gateway-migrate-job)이 죽었다. 페드루 PO가 로그+`gcloud run jobs describe`/`gcloud run services describe` diff로 근본 확인.

## 근본원인 (Pedro 실측)
```
ERROR: dial tcp 10.110.0.3:3307: i/o timeout
```
`--set-cloudsql-instances`(Cloud SQL Auth Proxy 소켓)만으론 부족 — 이 프로젝트 네트워킹 구성상 프록시 자신이 인스턴스 Private IP에 닿으려면 VPC egress가 별도 필요하다. 성공하는 `sprintable-migrate-dev`(backend) 잡과 대조:
- **있음(성공)**: `cloudsql-instances` + `network-interfaces=[{default/default}]` + `vpc-access-egress=private-ranges-only` + 전용 런타임 SA
- **없음(우리 잡)**: VPC 어노테이션 2종 전무 + **서비스계정이 기본 compute SA**(전용 SA 미지정 — fleet 자격 0 경계 위반이기도 함, `--service-account` 플래그를 처음부터 안 넘겼던 내 실수)

## 수정
1. `support-gateway/scripts/provision_migrate_job.sh` — `--network=default --subnet=default --vpc-egress=private-ranges-only` + `--service-account=${SUPPORT_GATEWAY_SERVICE_ACCOUNT}`(신규 필수 env, 미지정 시 fail-closed 에러) 추가.
2. `deploy-support-gateway`(cloudbuild.yaml) — 서비스도 첫 DB 접속에서 동일 timeout을 맞을 것이라 같은 3개 VPC 플래그 선제 추가.

## 검증
- `provision_migrate_job.sh --dry-run` — SA env var 유무 양쪽 케이스 확인(미지정 시 실행 경로는 fail-closed, DRY_RUN은 관례대로 `<unset>` 표시만).
- cloudbuild.yaml YAML 파싱 green.
- `test_3140_cloudbuild_secret_manifest_guard.py`(실 GCP 왕복 포함)·`test_cloudbuild_migrate_wiring.py`·`test_deploy_backend_redis_secret_conflict.py` 45건 green — 이번 수정이 시크릿/마이그 배선 계약을 안 건드림 확인.
- step 14(backend 배포, 위임토큰 시크릿 발급 측)는 이전 배포에서 이미 성공 — 이번 PR 스코프 밖.

## Test plan
- [ ] CI green
- [ ] 머지 후 재배포 → migrate job 실제 성공(테이블 실재) → support-gateway-dev 기동 → health 200(PO 실측) — 이게 story #b96151da/#3259 done 조건

🤖 Generated with [Claude Code](https://claude.com/claude-code)