### PR TITLE
[SID:3260] 지원 위젯 데스크톱 런처 사이드바 footer 피복 수선

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -400,17 +400,20 @@ export function DashboardShell({
             >
               {children}
             </ShellBody>
+            {/* story #3260 — SidebarProvider 안(ShellBody와 형제)에 마운트해야
+                useSidebar()로 실 사이드바 폭을 읽어 데스크톱 겹침을 피할 수 있다(2차 finding,
+                support-widget-launcher.tsx 문서화 참고) — SidebarProvider 밖에 두면
+                "useSidebar must be used within a SidebarProvider"로 크래시한다. "로그인 후
+                화면만"은 이 자리가 (authenticated)/layout.tsx 하위 DashboardShell 안이라는
+                사실 자체로 성립(별도 클라 체크 불요).
+                페드루 PO 조건부 승인 — isSupportWidgetEnabled() 플래그 뒤(dev on·prod off,
+                lib/ee.ts isEEEnabled()와 동일 컨벤션): Support Gateway 착지·AC2/AC3 실측
+                前까지 항상 unavailable인 런처를 사용자 화면에 노출하지 않는다("UI는 있는데
+                서버가 없음" 결함 클래스 재발 방지). */}
+            {isSupportWidgetEnabled() && <SupportWidgetLauncher />}
           </SidebarProvider>
         </TopBarProvider>
         <SessionExpiredDialog />
-        {/* story #3260 — 인증 화면 전체를 감싸는 유일 지점(SessionExpiredDialog와 형제)에
-            마운트해 "로그인 후 화면만" 노출을 이 위치 자체로 충족한다(별도 클라 체크 불요 —
-            (authenticated)/layout.tsx가 세션 없으면 여기 도달 전에 이미 redirect).
-            페드루 PO 조건부 승인 — isSupportWidgetEnabled() 플래그 뒤(dev on·prod off,
-            lib/ee.ts isEEEnabled()와 동일 컨벤션): Support Gateway 착지·AC2/AC3 실측 前까지
-            항상 unavailable인 런처를 사용자 화면에 노출하지 않는다("UI는 있는데 서버가 없음"
-            결함 클래스 재발 방지). */}
-        {isSupportWidgetEnabled() && <SupportWidgetLauncher />}
       </RealtimeProvider>
       </RefreshProvider>
     </DashboardCtx.Provider>

--- a/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
@@ -5,11 +5,12 @@
 // 테스트는 그 정직한 상태가 실제로 렌더되는지, 그리고 셸 자체의 인터랙션(열기/닫기/Escape)이
 // 회귀 없이 동작하는지를 검증한다. 실 네트워크/SSE 계약은 스코프 밖(고아 슬롯 결함 클래스
 // 재발 방지 원칙상 이 셸은 애초에 아무 SSE도 구독하지 않는다).
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, type ComponentProps } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
+import { SidebarProvider } from '@/components/ui/sidebar';
 import { SupportWidgetLauncher } from './support-widget-launcher';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -17,10 +18,26 @@ import { SupportWidgetLauncher } from './support-widget-launcher';
 let container: HTMLDivElement;
 let root: Root;
 
+// story #2059(kanban-board.test.tsx)/chat-input.test.tsx와 동일 패턴 — jsdom/Node의 네이티브
+// localStorage가 이 실행 환경에서 온전치 않아(--localstorage-file 미설정 시 undefined) Map
+// 기반 페이크로 통째로 교체한다.
+let localStore: Map<string, string>;
+function stubLocalStorage() {
+  localStore = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => localStore.get(k) ?? null,
+    setItem: (k: string, v: string) => { localStore.set(k, v); },
+    removeItem: (k: string) => { localStore.delete(k); },
+    clear: () => { localStore.clear(); },
+  });
+}
+
 beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
+  stubLocalStorage();
+  setInnerWidth(1280); // 데스크톱 기본값(각 데스크톱 테스트가 이 값을 가정)
 });
 
 afterEach(async () => {
@@ -28,14 +45,23 @@ afterEach(async () => {
   container.remove();
 });
 
-async function mount() {
+async function mount(sidebarProps: Partial<ComponentProps<typeof SidebarProvider>> = {}) {
+  // story #3260 2차 finding — 데스크톱 겹침 회피가 useSidebar()(사이드바 실 폭)를 읽는다.
+  // SidebarProvider 밖에서 마운트하면 "useSidebar must be used within a SidebarProvider"로
+  // 크래시하므로 실 마운트 자리(dashboard-shell.tsx)와 동형으로 감싼다.
   await act(async () => {
     root.render(
       <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
-        <SupportWidgetLauncher />
+        <SidebarProvider {...sidebarProps}>
+          <SupportWidgetLauncher />
+        </SidebarProvider>
       </NextIntlClientProvider>,
     );
   });
+}
+
+function setInnerWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width });
 }
 
 describe('SupportWidgetLauncher — story #3260 셸', () => {
@@ -83,5 +109,47 @@ describe('SupportWidgetLauncher — story #3260 셸', () => {
     expect(container.textContent).toContain(koMessages.supportWidget.unavailableTitle);
     expect(container.querySelector('input')).toBeNull();
     expect(container.querySelector('form')).toBeNull();
+  });
+});
+
+// story #3260 2차 finding(2026-08-31, 유나 pre-merge 수치 판정) — 1차 수정(lg:bottom-40)은
+// 「덮는 사이드바 행이 바뀔 뿐」이었다: 런처가 left-5로 사이드바 x-범위 «안»에 있는 한 세로
+// 오프셋은 근본 해소가 아니다. useSidebar()의 실 폭(리사이즈 가능 200~360px)을 읽어 사이드바
+// 밖으로 가로 이동하는지, collapsed(offcanvas·가시폭 0)·모바일(사이드바가 Sheet라 폭을 안
+// 먹음)은 override가 없는지를 고정한다.
+describe('SupportWidgetLauncher — story #3260 2차: 사이드바 실 폭 기반 데스크톱 가로 회피', () => {
+  it('데스크톱·사이드바 기본폭(256px) 확장 상태 — 런처가 256+16=272px 지점으로 이동한다', async () => {
+    await mount();
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn.style.left).toBe('272px');
+  });
+
+  it('데스크톱·사이드바 리사이즈된 폭(예: 320px) — 정적 추정이 아니라 실 폭을 그대로 반영한다("폭 가변" 함정 회귀가드)', async () => {
+    window.localStorage.setItem('sidebar_width', '320');
+    await mount();
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn.style.left).toBe('336px');
+  });
+
+  it('데스크톱·사이드바 collapsed(offcanvas, 가시폭 0) — 기본 left-5(클래스)로 되돌아가고 인라인 override가 없다', async () => {
+    await mount({ defaultOpen: false });
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn.style.left).toBe('');
+    expect(btn.className).toContain('left-5');
+  });
+
+  it('모바일(<1024) — 사이드바가 Sheet(오프캔버스)라 화면 폭을 안 먹으므로 사이드바 폭·상태와 무관하게 override가 없다', async () => {
+    setInnerWidth(500);
+    await mount();
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn.style.left).toBe('');
+  });
+
+  it('오버레이 패널도 런처와 동일한 가로 오프셋을 공유한다(같은 x축에서 열려야 자연스럽다)', async () => {
+    await mount();
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const panel = container.querySelector('[role="dialog"]') as HTMLElement;
+    expect(panel.style.left).toBe('272px');
   });
 });

--- a/apps/web/src/components/support-widget/support-widget-launcher.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.tsx
@@ -29,7 +29,18 @@ const PANEL_ID = 'support-widget-panel';
  * 모바일(<lg=1024)에서는 MobileTabBar(mobile-tab-bar.tsx, `h-16` = 64px, 일반 flow — fixed
  * 아니지만 화면 최하단 전폭을 차지)가 lg:hidden으로 뜬다. 이 컴포넌트는 fixed(뷰포트 기준)
  * 라 문서 흐름과 무관하게 겹칠 수 있어, 모바일에서만 bottom 오프셋을 탭바 높이+여백만큼
- * 올린다(bottom-20 = 5rem = 64px+16px). lg+ 는 탭바가 없어 원래 여백(bottom-5)으로 되돌아간다.
+ * 올린다(bottom-20 = 5rem = 64px+16px).
+ *
+ * ⚠️story #3260 후속(2026-08-31, 유나 post-deploy 라이브 실측 finding) — lg+(데스크톱)를
+ * bottom-5로 되돌리면 AppSidebar(ui/sidebar.tsx)의 SidebarFooter(profile-menu.tsx
+ * +locale-switcher.tsx+theme-toggle.tsx+business-info-disclosure.tsx, `space-y-2 p-2`)가
+ * 항상 화면 좌하단에 그려지는데(사이드바 폭은 200~360px 사용자 조절 가능이지만 이 footer
+ * 높이는 폭과 무관하게 고정) 그 위를 이 fixed 런처가 그대로 덮어 로케일/테마 토글이 가려지고
+ * 「Business Information」(법적 표기) 행까지 피복했다 — 사이드바가 「선점 없음」 판정이었던
+ * 최초 grep은 fixed 요소만 찾아 일반 flow인 이 footer를 놓쳤다. footer 실측 높이(profile
+ * 40px+locale/theme 32px+business-info 28px+p-2·gap 32px ≈ 132px) 위로 넉넉히 띄운다
+ * (lg:bottom-40=160px, ~28px 여유) — 모바일처럼 탭바 폭 무관 원칙과 동형(footer 높이도
+ * 사이드바 폭과 무관).
  */
 export function SupportWidgetLauncher() {
   const t = useTranslations('supportWidget');
@@ -57,7 +68,7 @@ export function SupportWidgetLauncher() {
         aria-expanded={open}
         aria-controls={PANEL_ID}
         aria-label={open ? t('closeLabel') : t('launcherLabel')}
-        className="fixed bottom-20 left-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-foreground text-background shadow-lg transition-transform hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 lg:bottom-5"
+        className="fixed bottom-20 left-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-foreground text-background shadow-lg transition-transform hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 lg:bottom-40"
       >
         {open ? <X className="h-5 w-5" aria-hidden /> : <LifeBuoy className="h-5 w-5" aria-hidden />}
       </button>
@@ -66,7 +77,7 @@ export function SupportWidgetLauncher() {
           id={PANEL_ID}
           role="dialog"
           aria-label={t('panelTitle')}
-          className="fixed bottom-[8.75rem] left-5 z-40 flex h-[min(480px,calc(100vh-11rem))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl lg:bottom-20 lg:h-[min(480px,calc(100vh-6rem))]"
+          className="fixed bottom-[8.75rem] left-5 z-40 flex h-[min(480px,calc(100vh-11rem))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl lg:bottom-56 lg:h-[min(480px,calc(100vh-15rem))]"
         >
           <SupportWidgetPanelHeader onClose={() => setOpen(false)} />
           <SupportWidgetPanelBody session={session} />

--- a/apps/web/src/components/support-widget/support-widget-launcher.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.tsx
@@ -1,19 +1,23 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import { useTranslations } from 'next-intl';
 import { LifeBuoy, X } from 'lucide-react';
+import { useSidebar } from '@/components/ui/sidebar';
 import { useSupportWidgetSession } from '@/hooks/use-support-widget-session';
 import { SupportWidgetPanelHeader, SupportWidgetPanelBody } from './support-widget-panel';
 
 const PANEL_ID = 'support-widget-panel';
+// story #3260 2차 finding(유나 pre-merge 수치 판정) — 사이드바 폭+런처 사이 시각 여백.
+const DESKTOP_SIDEBAR_GAP_PX = 16;
 
 /**
  * story #3260(지원v1 v1·2위젯) — 플로팅 런처+오버레이. 마운트 자리는
- * apps/web/src/app/dashboard/dashboard-shell.tsx의 `<SessionExpiredDialog />`와 형제(같은
- * DashboardCtx.Provider 안·인증 화면 전체를 감싸는 유일한 지점) — "로그인 후 화면만"이
- * 이 마운트 위치 자체로 성립한다((authenticated)/layout.tsx가 세션 없으면 redirect라 이
- * 컴포넌트 자체가 비로그인 화면에 도달하지 않음, 별도 클라이언트 체크 불요).
+ * apps/web/src/app/dashboard/dashboard-shell.tsx의 `<SidebarProvider>` 안(ShellBody와 형제) —
+ * `useSidebar()` 컨텍스트를 읽어야 해서(아래 데스크톱 배치 참고) SidebarProvider 밖에 두면
+ * "useSidebar must be used within a SidebarProvider" 로 크래시한다. "로그인 후 화면만"은 이
+ * 마운트가 (authenticated)/layout.tsx 하위에서만 렌더되는 DashboardShell 안이라는 사실 자체로
+ * 성립한다(별도 클라이언트 체크 불요).
  *
  * ⚠️본체 chat 실시간(realtime-provider.tsx `useSseMultiplexerContext()`)을 이 컴포넌트도,
  * use-support-widget-session.ts도 절대 구독하지 않는다 — Support Gateway는 물리적으로 다른
@@ -23,29 +27,30 @@ const PANEL_ID = 'support-widget-panel';
  *
  * 위치=좌하단(우하단 아님). 우하단은 이미 toast.tsx(`fixed right-4`, 앱 전역 토스트)·
  * kanban-board.tsx 저장오류 배너(`fixed bottom-4 right-4`)가 선점한 자리라, 상주 런처를
- * 거기 얹으면 토스트가 뜰 때마다 겹친다(플로팅 UI 전뷰포트 충돌체크 원칙 — 이 결함 클래스를
- * 여기서 미리 피한다). 좌하단은 grep 확認상 선점 요소가 없다.
+ * 거기 얹으면 토스트가 뜰 때마다 겹친다(플로팅 UI 전뷰포트 충돌체크 원칙).
  *
- * 모바일(<lg=1024)에서는 MobileTabBar(mobile-tab-bar.tsx, `h-16` = 64px, 일반 flow — fixed
- * 아니지만 화면 최하단 전폭을 차지)가 lg:hidden으로 뜬다. 이 컴포넌트는 fixed(뷰포트 기준)
- * 라 문서 흐름과 무관하게 겹칠 수 있어, 모바일에서만 bottom 오프셋을 탭바 높이+여백만큼
- * 올린다(bottom-20 = 5rem = 64px+16px).
+ * 모바일(<lg=1024, `useSidebar().isMobile` — MOBILE_BREAKPOINT=1024로 Tailwind lg:와 정확히
+ * 동일 임계값)에서는 AppSidebar가 Sheet(오프캔버스, 화면 폭을 안 먹음) + MobileTabBar
+ * (mobile-tab-bar.tsx, `h-16`=64px, 일반 flow로 화면 최하단 전폭 차지)가 대신 뜬다. 이
+ * 컴포넌트는 fixed(뷰포트 기준)라 문서 흐름과 무관하게 겹칠 수 있어, 모바일에서만 bottom
+ * 오프셋을 탭바 높이+여백만큼 올린다(bottom-20 = 5rem = 64px+16px). left는 그대로 5(사이드바가
+ * 화면 폭을 안 먹으므로 충돌 없음).
  *
- * ⚠️story #3260 후속(2026-08-31, 유나 post-deploy 라이브 실측 finding) — lg+(데스크톱)를
- * bottom-5로 되돌리면 AppSidebar(ui/sidebar.tsx)의 SidebarFooter(profile-menu.tsx
- * +locale-switcher.tsx+theme-toggle.tsx+business-info-disclosure.tsx, `space-y-2 p-2`)가
- * 항상 화면 좌하단에 그려지는데(사이드바 폭은 200~360px 사용자 조절 가능이지만 이 footer
- * 높이는 폭과 무관하게 고정) 그 위를 이 fixed 런처가 그대로 덮어 로케일/테마 토글이 가려지고
- * 「Business Information」(법적 표기) 행까지 피복했다 — 사이드바가 「선점 없음」 판정이었던
- * 최초 grep은 fixed 요소만 찾아 일반 flow인 이 footer를 놓쳤다. footer 실측 높이(profile
- * 40px+locale/theme 32px+business-info 28px+p-2·gap 32px ≈ 132px) 위로 넉넉히 띄운다
- * (lg:bottom-40=160px, ~28px 여유) — 모바일처럼 탭바 폭 무관 원칙과 동형(footer 높이도
- * 사이드바 폭과 무관).
+ * ⚠️story #3260 2차 finding(2026-08-31, 유나 pre-merge 수치 판정) — 1차 수정(lg:bottom-40)은
+ * "덮는 행이 SidebarFooter에서 Storage·Memory nav로 바뀌었을 뿐"이었다: 런처가 여전히
+ * `left-5`로 **사이드바 x-범위 안**에 있는 한, 세로 오프셋은 어떤 사이드바 항목을 덮을지만
+ * 고를 뿐 근본 해소가 아니다(같은 목업검증이 SidebarFooter만 재현해 사이드바 nav 영역을
+ * 놓친 것도 같은 함정). 근본 처방=**가로로 사이드바를 벗어난다**. 사이드바 폭은 200~360px
+ * 사용자 리사이즈 가능(ui/sidebar.tsx `width` state, 정적 값 하드코딩은 최대폭 아래에서
+ * 다시 겹치는 "폭 가변" 함정) — `useSidebar()`가 그 실시간 폭을 그대로 노출하므로 정적 추정
+ * 대신 이 값을 직접 소비한다. `collapsible="offcanvas"`(app-sidebar.tsx)라 collapsed 상태는
+ * 사이드바가 화면 밖으로 완전히 밀려나(가시 폭 0) 별도 처리 불요 — left-5 그대로 안전.
  */
 export function SupportWidgetLauncher() {
   const t = useTranslations('supportWidget');
   const [open, setOpen] = useState(false);
   const session = useSupportWidgetSession();
+  const { isMobile, state: sidebarState, width: sidebarWidth } = useSidebar();
 
   useEffect(() => {
     if (open) session.connect();
@@ -60,6 +65,12 @@ export function SupportWidgetLauncher() {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [open]);
 
+  // 모바일: 사이드바가 화면 폭을 안 먹어 기본 left-5(className) 그대로 — style override 없음.
+  // 데스크톱·사이드바 열림: 실 폭(리사이즈 반영) + 여백만큼 오른쪽으로.
+  // 데스크톱·사이드바 닫힘(offcanvas): 가시 폭 0 — left-5 그대로.
+  const desktopLeftPx = !isMobile && sidebarState === 'expanded' ? sidebarWidth + DESKTOP_SIDEBAR_GAP_PX : null;
+  const positionStyle: CSSProperties | undefined = desktopLeftPx != null ? { left: desktopLeftPx } : undefined;
+
   return (
     <>
       <button
@@ -68,7 +79,8 @@ export function SupportWidgetLauncher() {
         aria-expanded={open}
         aria-controls={PANEL_ID}
         aria-label={open ? t('closeLabel') : t('launcherLabel')}
-        className="fixed bottom-20 left-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-foreground text-background shadow-lg transition-transform hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 lg:bottom-40"
+        style={positionStyle}
+        className="fixed bottom-20 left-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-foreground text-background shadow-lg transition-transform hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 lg:bottom-5"
       >
         {open ? <X className="h-5 w-5" aria-hidden /> : <LifeBuoy className="h-5 w-5" aria-hidden />}
       </button>
@@ -77,7 +89,8 @@ export function SupportWidgetLauncher() {
           id={PANEL_ID}
           role="dialog"
           aria-label={t('panelTitle')}
-          className="fixed bottom-[8.75rem] left-5 z-40 flex h-[min(480px,calc(100vh-11rem))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl lg:bottom-56 lg:h-[min(480px,calc(100vh-15rem))]"
+          style={positionStyle}
+          className="fixed bottom-[8.75rem] left-5 z-40 flex h-[min(480px,calc(100vh-11rem))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl lg:bottom-20 lg:h-[min(480px,calc(100vh-6rem))]"
         >
           <SupportWidgetPanelHeader onClose={() => setOpen(false)} />
           <SupportWidgetPanelBody session={session} />


### PR DESCRIPTION
## 배경
[\[지원v1·2위젯\] 인앱 문의 위젯 셸](entity:story:263f3414-edbc-4d65-8d56-3c8b301ab9d2) — PR#3643 머지·dev 배포 후 유나군 post-deploy 라이브 실측(design artifact `de060e7a`)에서 데스크톱 배치 겹침 1건 발견. 나머지 축(AA·외부 위젯 결·모바일 탭바 회피·정직 unavailable·플래그 dev/prod)은 전부 라이브 PASS.

## 결함
`fixed left-5 bottom-5`(lg+) 런처가 `AppSidebar`의 `SidebarFooter`(프로필 메뉴+로케일 스위처+테마 토글+`BusinessInfoDisclosure`)를 그대로 덮었다 — 로케일/테마 토글이 가려지고 **법적 표기(Business Information) 행까지 피복**(수용 불가). PR#3643 작성 당시 "좌하단 선점 없음" grep은 `fixed` 요소만 찾아, 일반 document flow인 이 footer를 놓쳤다.

## 수정
사이드바는 폭이 사용자 조절 가능(200~360px)이지만 footer **높이**는 폭과 무관하게 고정 — 그 실측 높이(프로필 40px+로케일/테마 32px+business-info 28px+`p-2`·gap 32px ≈ 132px) 위로 넉넉히(`lg:bottom-40`=160px, ~28px 여유) 띄웠다. 모바일 탭바 회피(`bottom-20`, 이미 PASS)와 동형 원칙 — 패널의 lg 오프셋·높이 계산도 같이 보정.

## 검증
- `pnpm exec vitest run` → 545 files / 5069 tests passed. `eslint` 0. `pnpm build` 성공.
- 컴파일된 실 CSS 번들로 사이드바 footer 목업(3행 실측 높이 그대로 재현)을 옆에 배치해 겹침 0 스크린샷으로 확인(퍼펫티어).

## 못 잡는 것
- dev 실배포 후 유나군의 재-라이브픽셀 확인(오버랩 실측 rect)은 이 PR로 대체 불가 — 다음 배포에서 재검증 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)