### PR TITLE
[SID:3261] agent 응답 content 노출 + GET 대화 이력 — 위젯 읽기 경로 0 해소

### DIFF
--- a/support-gateway/app/routers/sessions.py
+++ b/support-gateway/app/routers/sessions.py
@@ -17,10 +17,26 @@ from app.injection_defense import sanitize_customer_text
 from app.interaction import handle_turn
 from app.models import SupportConversation, SupportMessage, SupportSession
 from app.rate_limit import limiter
-from app.schemas import MessageCreateRequest, MessageExchangeResponse, MessageResponse, SessionResponse
+from app.schemas import (
+    MessageCreateRequest,
+    MessageExchangeResponse,
+    MessageListResponse,
+    MessageResponse,
+    SessionResponse,
+)
 from app.token_verify import DelegatedIdentity, require_delegated_identity
 
 router = APIRouter(prefix="/api/v1", tags=["sessions"])
+
+
+def _to_message_response(message: SupportMessage) -> MessageResponse:
+    return MessageResponse(
+        id=message.id,
+        conversation_id=message.conversation_id,
+        role=message.role,
+        content=message.content,
+        created_at=message.created_at,
+    )
 
 
 async def _get_or_create_conversation(
@@ -126,17 +142,51 @@ async def post_message(
     ).scalar_one()
 
     return MessageExchangeResponse(
-        customer_message=MessageResponse(
-            id=customer_message.id,
-            conversation_id=customer_message.conversation_id,
-            role=customer_message.role,
-            created_at=customer_message.created_at,
-        ),
-        agent_message=MessageResponse(
-            id=agent_message.id,
-            conversation_id=agent_message.conversation_id,
-            role=agent_message.role,
-            created_at=agent_message.created_at,
-        ),
+        customer_message=_to_message_response(customer_message),
+        agent_message=_to_message_response(agent_message),
         escalated=turn.escalated,
     )
+
+
+@router.get("/sessions/{session_id}/messages", response_model=MessageListResponse)
+@limiter.limit(lambda: settings.session_rate_limit)
+async def list_messages(
+    request: Request,
+    session_id: uuid.UUID,
+    identity: DelegatedIdentity = Depends(require_delegated_identity),
+    db: AsyncSession = Depends(get_db),
+) -> MessageListResponse:
+    """story #3261 보완(2026-08-31, 페드루 PO 실 왕복 실측 지적) — 위젯 재오픈 시 대화 이력
+    복원용. org 스코프는 위와 동형(session 자체를 org_id로 먼저 스코프 — 존재하지 않는
+    session_id/타 org session_id 둘 다 404, 구분 안 됨)."""
+    request.state.delegated_org_id = str(identity.org_id)
+    session = (
+        await db.execute(
+            select(SupportSession).where(
+                SupportSession.id == session_id,
+                SupportSession.org_id == identity.org_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if session is None:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    conv = (
+        await db.execute(
+            select(SupportConversation)
+            .where(SupportConversation.org_id == identity.org_id)
+            .order_by(SupportConversation.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if conv is None:
+        return MessageListResponse(messages=[])
+
+    messages = (
+        await db.execute(
+            select(SupportMessage)
+            .where(SupportMessage.conversation_id == conv.id)
+            .order_by(SupportMessage.created_at.asc())
+        )
+    ).scalars().all()
+    return MessageListResponse(messages=[_to_message_response(m) for m in messages])

--- a/support-gateway/app/schemas.py
+++ b/support-gateway/app/schemas.py
@@ -20,13 +20,24 @@ class MessageResponse(BaseModel):
     id: uuid.UUID
     conversation_id: uuid.UUID
     role: str
+    content: str
     created_at: datetime
 
 
 class MessageExchangeResponse(BaseModel):
     """story #3261 — customer 메시지 저장 + 그 턴의 agent 응답을 한 번에 준다(v1: 동기 왕복,
-    스트리밍/SSE는 story #2 위젯 셸 스코프 — 이 계약 위에서 소비한다)."""
+    스트리밍/SSE는 story #2 위젯 셸 스코프 — 이 계약 위에서 소비한다).
+
+    ⚠️story #3261 보완(2026-08-31, 페드루 PO 실 왕복 실측 지적) — 최초 릴리즈는 agent_message에
+    content가 없어 위젯이 답을 볼 방법이 0이었다(응답은 DB엔 저장되는데 클라이언트가 읽을
+    경로가 없는 계약 구멍). MessageResponse에 content를 추가해 해소."""
 
     customer_message: MessageResponse
     agent_message: MessageResponse
     escalated: bool
+
+
+class MessageListResponse(BaseModel):
+    """story #3261 보완 — GET /sessions/{id}/messages(대화 이력, 위젯 재오픈 시 복원용)."""
+
+    messages: list[MessageResponse]

--- a/support-gateway/tests/test_message_history.py
+++ b/support-gateway/tests/test_message_history.py
@@ -1,0 +1,59 @@
+"""story #3261 보완(2026-08-31, 페드루 PO 실 왕복 실측 지적) — agent_message.content 계약
+구멍 + GET /messages(대화 이력) 신설."""
+from __future__ import annotations
+
+from tests.conftest import MOONKLABS_ORG_ID, OTHER_ORG_ID, make_token
+
+
+async def test_message_exchange_response_includes_reply_content(client, fake_llm):
+    fake_llm.interaction_text = "안녕하세요! 무엇을 도와드릴까요?"
+    headers = {"Authorization": f"Bearer {make_token(OTHER_ORG_ID)}"}
+    session = await client.post("/api/v1/sessions", headers=headers)
+    session_id = session.json()["id"]
+
+    resp = await client.post(
+        f"/api/v1/sessions/{session_id}/messages", json={"content": "hi"}, headers=headers
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["customer_message"]["content"] == "hi"
+    assert body["agent_message"]["content"] == "안녕하세요! 무엇을 도와드릴까요?"
+
+
+async def test_get_messages_returns_history_in_order(client, fake_llm):
+    headers = {"Authorization": f"Bearer {make_token(OTHER_ORG_ID)}"}
+    session = await client.post("/api/v1/sessions", headers=headers)
+    session_id = session.json()["id"]
+
+    await client.post(f"/api/v1/sessions/{session_id}/messages", json={"content": "first"}, headers=headers)
+    await client.post(f"/api/v1/sessions/{session_id}/messages", json={"content": "second"}, headers=headers)
+
+    resp = await client.get(f"/api/v1/sessions/{session_id}/messages", headers=headers)
+    assert resp.status_code == 200
+    messages = resp.json()["messages"]
+    assert [m["content"] for m in messages if m["role"] == "customer"] == ["first", "second"]
+    assert all("content" in m for m in messages)
+    # 시간순 오름차순(위젯 재오픈 시 위→아래 렌더 가정)
+    assert messages == sorted(messages, key=lambda m: m["created_at"])
+
+
+async def test_get_messages_empty_conversation_returns_empty_list(client, fake_llm):
+    headers = {"Authorization": f"Bearer {make_token(OTHER_ORG_ID)}"}
+    session = await client.post("/api/v1/sessions", headers=headers)
+    session_id = session.json()["id"]
+
+    resp = await client.get(f"/api/v1/sessions/{session_id}/messages", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["messages"] == []
+
+
+async def test_get_messages_cross_org_404(client, fake_llm):
+    token_a = make_token(OTHER_ORG_ID)
+    session = await client.post("/api/v1/sessions", headers={"Authorization": f"Bearer {token_a}"})
+    session_id = session.json()["id"]
+
+    token_moonklabs = make_token(MOONKLABS_ORG_ID)
+    resp = await client.get(
+        f"/api/v1/sessions/{session_id}/messages", headers={"Authorization": f"Bearer {token_moonklabs}"}
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
[SID:3261]

## 배경
PR#3647 머지 후 첫 실 LLM 왕복(Pedro dev live 실측, POST /messages 200·11.7초·실 Vertex 왕복)에서 계약 구멍 발견 — agent의 답이 DB엔 저장되는데 `MessageResponse`에 `content` 필드가 없고 `GET /messages`도 405라 클라이언트가 그 답을 읽을 경로가 0이었다. 위젯 연동(미르코 착수 中)의 하드 블로커라 story #3261 done 보류 사유가 됐음.

## 수정 2건
1. `MessageResponse.content` 추가 — `customer_message`·`agent_message` 둘 다 실제 텍스트 노출.
2. `GET /api/v1/sessions/{id}/messages` 신설 — 대화 이력 조회(위젯 재오픈 시 복원용). org 스코프는 기존 POST와 동형(session을 org_id로 먼저 스코프, 존재하지 않는 session_id/타 org session_id 둘 다 404).

## 검증
- 기존 20건 + 신규 4건(`test_message_history.py`: content 노출·이력 시간순·빈 대화 목록·cross-org 404) 전부 green.
- org 특례 없음 grep 가드 재확인(신규 코드 무접촉이라 당연 green이지만 명시 재확인).

## Test plan
- [ ] CI green
- [ ] QA/design 게이트
- [ ] 머지 후 dev 재배포 → Pedro가 위젯 없이 curl로 왕복 재실측(POST로 답 저장 → GET으로 조회) → 그 결과로 story #3261 done 판정

🤖 Generated with [Claude Code](https://claude.com/claude-code)