### PR TITLE
[SID:3260] Support Gateway CORS+위젯 URL 배선

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -173,6 +173,10 @@ jobs:
             # 결함 클래스 재발 방지) — Support Gateway(#f2a27d2a) 착지·AC2/AC3(Gateway
             # 경유·본체 SSE와 분리) 실측 통과 前까지 prod는 명시 false(무접촉).
             echo "support_widget_enabled=false" >> "$GITHUB_OUTPUT"
+            # story #3260 Phase 2(2026-08-31) — Support Gateway prod 미배포(아래
+            # support_gateway_deploy_enabled=false) 상태라 CORS·widget URL 둘 다 무접촉.
+            echo "support_gateway_cors_origins=" >> "$GITHUB_OUTPUT"
+            echo "next_public_support_gateway_url=" >> "$GITHUB_OUTPUT"
             # story #f2a27d2a(지원v1·1경계, 2026-08-31 페드루 PO — Gateway flip PR) — prod
             # 자원(전용 SA·전용 DB·시크릿) 미프로비저닝 상태라 명시 false(무접촉). dev만
             # 프로비저닝 완료(support-gateway-dev@sprintable-494803.iam.gserviceaccount.com·
@@ -393,6 +397,15 @@ jobs:
             # 급 결재 UI가 아니라 지원v1 문의 위젯)이 항상 unavailable 상태만 반환하는 동안은
             # dev에서만 켜서 검증한다(prod는 위 main 분기에서 명시 false).
             echo "support_widget_enabled=true" >> "$GITHUB_OUTPUT"
+            # story #3260 Phase 2(2026-08-31) — 위젯이 Support Gateway를 브라우저에서 직접
+            # 호출하는 데 필요한 CORS allowlist+base URL. origin 목록은 infra/gcs-attachments-
+            # cors.json(story #3242, 같은 dev FE origin 집합 — 이 값들이 이미 검증된 dev FE
+            # 표면 SSOT)과 동일 값 재사용(새 값 지어내지 않음) — `|`-구분(cloudbuild.yaml
+            # deploy-support-gateway 스텝에서 `,`로 변환, MCP_ALLOWED_HOSTS와 동형). Gateway
+            # URL은 실측(`gcloud run services describe support-gateway-dev --region=
+            # asia-northeast3 --format='value(status.url)'`, 2026-08-31).
+            echo "support_gateway_cors_origins=https://dev-app.sprintable.ai|https://sprintable-frontend-dev-57iommnikq-du.a.run.app|https://sprintable-frontend-dev-787818285179.asia-northeast3.run.app|http://localhost:3108" >> "$GITHUB_OUTPUT"
+            echo "next_public_support_gateway_url=https://support-gateway-dev-57iommnikq-du.a.run.app" >> "$GITHUB_OUTPUT"
             # story #f2a27d2a(지원v1·1경계, 2026-08-31 페드루 PO — Gateway flip PR) — dev 전용
             # 자원 프로비저닝 완료(SA·전용 DB·Secret Manager 2종, 사부님 보고 済) — dev만 켠다.
             echo "support_gateway_deploy_enabled=true" >> "$GITHUB_OUTPUT"
@@ -595,6 +608,8 @@ jobs:
           V_SSE_MULTIPLEX_ENABLED: ${{ steps.env.outputs.sse_multiplex_enabled }}
           V_EE_ENABLED: ${{ steps.env.outputs.ee_enabled }}
           V_SUPPORT_WIDGET_ENABLED: ${{ steps.env.outputs.support_widget_enabled }}
+          V_SUPPORT_GATEWAY_CORS_ORIGINS: ${{ steps.env.outputs.support_gateway_cors_origins }}
+          V_NEXT_PUBLIC_SUPPORT_GATEWAY_URL: ${{ steps.env.outputs.next_public_support_gateway_url }}
           V_SUPPORT_GATEWAY_DEPLOY_ENABLED: ${{ steps.env.outputs.support_gateway_deploy_enabled }}
           V_SUPPORT_GATEWAY_SERVICE_ACCOUNT: ${{ steps.env.outputs.support_gateway_service_account }}
           V_LICENSE_CONSENT: ${{ steps.env.outputs.license_consent }}
@@ -619,7 +634,7 @@ jobs:
           # 쪽은 정확히 "true" 문자열만 스킵으로 취급하므로 다른 값은 전부 안전측(배포)이다.
           V_REALTIME_GCE_SKIP="${V_REALTIME_GCE_SKIP:-false}"
           V_REALTIME_CLOUDRUN_SKIP="${V_REALTIME_CLOUDRUN_SKIP:-false}"
-          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\",_MCP_ALLOWED_HOSTS=\"${V_MCP_ALLOWED_HOSTS}\",_EE_ENABLED=\"${V_EE_ENABLED}\",_SUPPORT_WIDGET_ENABLED=\"${V_SUPPORT_WIDGET_ENABLED}\",_SUPPORT_GATEWAY_DEPLOY_ENABLED=\"${V_SUPPORT_GATEWAY_DEPLOY_ENABLED}\",_SUPPORT_GATEWAY_SERVICE_ACCOUNT=\"${V_SUPPORT_GATEWAY_SERVICE_ACCOUNT}\",_LICENSE_CONSENT=\"${V_LICENSE_CONSENT}\",_TOSS_CLIENT_KEY=\"${V_TOSS_CLIENT_KEY}\",_NEXT_PUBLIC_APP_URL=\"${V_NEXT_PUBLIC_APP_URL}\",_REALTIME_GCE_SKIP=\"${V_REALTIME_GCE_SKIP}\",_REALTIME_CLOUDRUN_SKIP=\"${V_REALTIME_CLOUDRUN_SKIP}\",_APPLE_TEAM_ID=\"${V_APPLE_TEAM_ID}\",_MOBILE_APP_LINK_ORIGIN=\"${V_MOBILE_APP_LINK_ORIGIN}\",_FIREBASE_OAUTH_HANDOFF_ENABLED=\"${V_FIREBASE_OAUTH_HANDOFF_ENABLED}\""
+          SUBST="_DEPLOY_ENV=\"${V_DEPLOY_ENV}\",_FASTAPI_URL=\"${V_FASTAPI_URL}\",_BACKEND_MIN_INSTANCES=\"${V_BACKEND_MIN_INSTANCES}\",_BACKEND_MAX_INSTANCES=\"${V_BACKEND_MAX_INSTANCES}\",_DB_POOL_SIZE=\"${V_DB_POOL_SIZE}\",_DB_MAX_OVERFLOW=\"${V_DB_MAX_OVERFLOW}\",_BACKEND_DB_PGBOUNCER=\"${V_BACKEND_DB_PGBOUNCER}\",_BACKEND_TIMEOUT=\"${V_BACKEND_TIMEOUT}\",_GA4_MEASUREMENT_ID=\"${V_GA4_MEASUREMENT_ID}\",_REALTIME_MIN_INSTANCES=\"${V_REALTIME_MIN_INSTANCES}\",_REALTIME_MAX_INSTANCES=\"${V_REALTIME_MAX_INSTANCES}\",_REALTIME_TIMEOUT=\"${V_REALTIME_TIMEOUT}\",_REALTIME_URL=\"${V_REALTIME_URL}\",_BACKEND_PG_LISTEN_ENABLED=\"${V_BACKEND_PG_LISTEN_ENABLED}\",_BACKEND_REDIS_CONSUME_ENABLED=\"${V_BACKEND_REDIS_CONSUME_ENABLED}\",_BACKEND_REDIS_DISPATCH_ENABLED=\"${V_BACKEND_REDIS_DISPATCH_ENABLED}\",_REDIS_URL=\"${V_REDIS_URL}\",_BACKEND_REDIS_DUAL_PUBLISH_ENABLED=\"${V_BACKEND_REDIS_DUAL_PUBLISH_ENABLED}\",_BACKEND_FANOUT_WAKE_REDIS_ENABLED=\"${V_BACKEND_FANOUT_WAKE_REDIS_ENABLED}\",_SSE_MULTIPLEX_ENABLED=\"${V_SSE_MULTIPLEX_ENABLED}\",_BACKEND_PRESENCE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_REDIS_ENABLED}\",_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED=\"${V_BACKEND_PRESENCE_ONLINE_REDIS_ENABLED}\",_BACKEND_SSE_LEASE_REDIS_ENABLED=\"${V_BACKEND_SSE_LEASE_REDIS_ENABLED}\",_FRONTEND_MIN_INSTANCES=\"${V_FRONTEND_MIN_INSTANCES}\",_FRONTEND_MAX_INSTANCES=\"${V_FRONTEND_MAX_INSTANCES}\",_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED=\"${V_BACKEND_SSE_TRANSIENT_REPLAY_ENABLED}\",_MCP_ALLOWED_HOSTS=\"${V_MCP_ALLOWED_HOSTS}\",_EE_ENABLED=\"${V_EE_ENABLED}\",_SUPPORT_WIDGET_ENABLED=\"${V_SUPPORT_WIDGET_ENABLED}\",_SUPPORT_GATEWAY_DEPLOY_ENABLED=\"${V_SUPPORT_GATEWAY_DEPLOY_ENABLED}\",_SUPPORT_GATEWAY_SERVICE_ACCOUNT=\"${V_SUPPORT_GATEWAY_SERVICE_ACCOUNT}\",_SUPPORT_GATEWAY_CORS_ORIGINS=\"${V_SUPPORT_GATEWAY_CORS_ORIGINS}\",_NEXT_PUBLIC_SUPPORT_GATEWAY_URL=\"${V_NEXT_PUBLIC_SUPPORT_GATEWAY_URL}\",_LICENSE_CONSENT=\"${V_LICENSE_CONSENT}\",_TOSS_CLIENT_KEY=\"${V_TOSS_CLIENT_KEY}\",_NEXT_PUBLIC_APP_URL=\"${V_NEXT_PUBLIC_APP_URL}\",_REALTIME_GCE_SKIP=\"${V_REALTIME_GCE_SKIP}\",_REALTIME_CLOUDRUN_SKIP=\"${V_REALTIME_CLOUDRUN_SKIP}\",_APPLE_TEAM_ID=\"${V_APPLE_TEAM_ID}\",_MOBILE_APP_LINK_ORIGIN=\"${V_MOBILE_APP_LINK_ORIGIN}\",_FIREBASE_OAUTH_HANDOFF_ENABLED=\"${V_FIREBASE_OAUTH_HANDOFF_ENABLED}\""
           echo "substitutions=${SUBST}" >> "$GITHUB_OUTPUT"
 
       - name: Submit Cloud Build

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -55,6 +55,10 @@ ENV NEXT_PUBLIC_EE_ENABLED=${NEXT_PUBLIC_EE_ENABLED}
 # 항상 unavailable인 런처를 화면에 노출하지 않기 위한 게이트.
 ARG NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED=false
 ENV NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED=${NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED}
+# story #3260 Phase 2 — 위젯이 Support Gateway를 브라우저에서 직접 호출(BFF 프록시 없음)하는
+# 데 필요한 그 서비스의 base URL. 기본값 빈 문자열(dev-safe fallback, 위 컨벤션과 동일).
+ARG NEXT_PUBLIC_SUPPORT_GATEWAY_URL=""
+ENV NEXT_PUBLIC_SUPPORT_GATEWAY_URL=${NEXT_PUBLIC_SUPPORT_GATEWAY_URL}
 # story #2758(2026-08-18) — apps/web/src/ee/components/billing/toss-checkout.ts(story #2510)가
 # 읽는 Toss 결제위젯 clientKey. manual-env-allowlist.yml에 declared_by:PO로 「등재」만 되고
 # ARG/ENV 어디에도 배선된 적이 없어(EE_ENABLED·LICENSE_CONSENT와 동형 「등재≠배선」 3번째)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -95,6 +95,11 @@ substitutions:
   # 재발 방지: Support Gateway(#f2a27d2a) 착지·AC2/AC3 실측 前까지 위젯 런처를 prod에
   # 노출하지 않는다. EE_ENABLED와 동일 컨벤션 — dev-safe 기본값 false, GHA가 dev만 true 주입.
   _SUPPORT_WIDGET_ENABLED: "false"
+  # story #3260 Phase 2 — 위젯이 Support Gateway를 직접 호출(BFF 프록시 없음)하려면 FE
+  # 빌드가 그 서비스 origin을 알아야 한다. 빈 문자열 기본값(dev-safe — GHA가 dev 분기에서만
+  # 실 Gateway URL 주입, prod는 위젯 자체가 아직 안 뜨므로(SUPPORT_WIDGET_ENABLED=false)
+  # 무접촉).
+  _NEXT_PUBLIC_SUPPORT_GATEWAY_URL: ""
   # story #2758(2026-08-18, 페드루 PO 지시 — EE_ENABLED·LICENSE_CONSENT와 동형 「등재≠배선」
   # 3번째, 미르코 2754 라이브 실증이 이 마디에서 잡음) — apps/web/src/ee/components/billing/
   # toss-checkout.ts(story #2510)가 읽는 Toss 결제위젯 clientKey가 manual-env-allowlist.yml에
@@ -168,6 +173,10 @@ substitutions:
   _SUPPORT_GATEWAY_SERVICE_ACCOUNT: ''
   _SUPPORT_GATEWAY_MIN_INSTANCES: '0'
   _SUPPORT_GATEWAY_MAX_INSTANCES: '2'
+  # story #3260(위젯 셸) — 브라우저가 이 서비스를 직접 호출(BFF 프록시 없음)하므로 실
+  # CORS preflight가 돈다. `|`-구분 기본값(빈 문자열=미설정) — deploy-support-gateway
+  # 스텝에서 `,`로 변환(cloudbuild.yaml MCP_ALLOWED_HOSTS 선례와 동일 2-layer 콤마 함정 회피).
+  _SUPPORT_GATEWAY_CORS_ORIGINS: ''
 
   # E-ARCH 1단계(story #2078·PR #2358 PG_LISTEN_ENABLED 배선): SSE/LISTEN 전용
   # `sprintable-realtime-${_DEPLOY_ENV}` 서비스 — REST(`sprintable-backend-*`)와 같은 이미지,
@@ -416,6 +425,8 @@ steps:
       - NEXT_PUBLIC_EE_ENABLED=${_EE_ENABLED}
       - --build-arg
       - NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED=${_SUPPORT_WIDGET_ENABLED}
+      - --build-arg
+      - NEXT_PUBLIC_SUPPORT_GATEWAY_URL=${_NEXT_PUBLIC_SUPPORT_GATEWAY_URL}
       - --build-arg
       - NEXT_PUBLIC_TOSS_CLIENT_KEY=${_TOSS_CLIENT_KEY}
       - .
@@ -968,6 +979,15 @@ steps:
         # SA(${_SUPPORT_GATEWAY_SERVICE_ACCOUNT})에 `roles/aiplatform.user` IAM 바인딩이
         # 아직 없으면 Vertex 호출이 403으로 죽는다 — 코드/배포 스텝은 여기까지만 하고 그
         # IAM 부여는 backend/support-gateway 최초 프로비저닝과 동형으로 PO가 gcloud로 한다.
+        # story #3260 — CORS_ORIGINS 값(콤마 구분 origin 목록)이 이 --update-env-vars 자체의
+        # ArgDict 구분자(,)와 충돌한다(cloudbuild.yaml MCP_ALLOWED_HOSTS 선례와 동일 함정) —
+        # `^;^` 커스텀 구분자 이스케이프로 이 플래그의 구분자를 ,에서 ;로 바꾼다(gcloud topic
+        # escaping). GHA는 `|`-구분으로 여기까지 값을 나르므로(위 GHA 주석) 먼저 ,로 되돌린다.
+        ENV_VARS="SUPPORT_GATEWAY_VERTEX_PROJECT=${PROJECT_ID}"
+        if [ -n "${_SUPPORT_GATEWAY_CORS_ORIGINS}" ]; then
+          CORS_ORIGINS_COMMA=$(printf '%s' "${_SUPPORT_GATEWAY_CORS_ORIGINS}" | tr '|' ',')
+          ENV_VARS="$${ENV_VARS};SUPPORT_GATEWAY_CORS_ORIGINS=$${CORS_ORIGINS_COMMA}"
+        fi
         gcloud run deploy support-gateway-${_DEPLOY_ENV} \
           --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/support-gateway:${COMMIT_SHA} \
           --region=${_AR_REGION} \
@@ -979,7 +999,7 @@ steps:
           --network=default \
           --subnet=default \
           --vpc-egress=private-ranges-only \
-          --update-env-vars="SUPPORT_GATEWAY_VERTEX_PROJECT=${PROJECT_ID}" \
+          --update-env-vars="^;^$${ENV_VARS}" \
           --update-secrets="SUPPORT_GATEWAY_DATABASE_URL=SUPPORT_GATEWAY_DATABASE_URL_${_DEPLOY_ENV}:latest,SUPPORT_GATEWAY_TOKEN_SECRET=SUPPORT_GATEWAY_TOKEN_SECRET_${_DEPLOY_ENV}:latest" \
           --quiet
     waitFor: [run-support-gateway-migrate-job]

--- a/support-gateway/app/config.py
+++ b/support-gateway/app/config.py
@@ -31,7 +31,14 @@ class Settings(BaseSettings):
     # 위임 토큰 만료(초) — 짧게: 유출돼도 피해 창을 최소화.
     token_ttl_seconds: int = 300
 
-    cors_allow_origins: list[str] = []
+    # story #3260(위젯 셸) — 브라우저가 이 서비스를 **직접** 호출한다(Next.js BFF 프록시
+    # 경유 아님, 별도 Cloud Run 오리진이라 실제 CORS preflight가 돈다 — backend/app/core/
+    # config.py의 cors_origins는 대부분 서버사이드 프록시 경유라 사실상 미사용인 것과 다름).
+    # list[str] 대신 backend와 동일하게 comma-구분 문자열로 받는다 — pydantic-settings의
+    # list[str] env 파싱은 JSON을 기대해, 값 안의 콤마가 gcloud --update-env-vars의 comma-
+    # 구분 ArgDict 파싱과 이중으로 충돌한다(cloudbuild.yaml MCP_ALLOWED_HOSTS 선례와 동일
+    # 함정 — 이 필드 자체를 그 함정 밖으로 뺀다).
+    cors_origins: str = ""
 
     # story #3261(지원v1·3오케스트레이션) — Vertex AI SDK 접속 좌표. GCP credit 경계
     # 안(Blueprint §4.1) — Claude 등 파트너 모델은 이 서비스가 아예 모른다(SDK가 vertexai=True

--- a/support-gateway/app/main.py
+++ b/support-gateway/app/main.py
@@ -22,14 +22,17 @@ async def _rate_limit_handler(request, exc):  # noqa: ANN001 — slowapi 시그�
     return JSONResponse(status_code=429, content={"detail": "rate limit exceeded"})
 
 
-if settings.cors_allow_origins:
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=settings.cors_allow_origins,
-        allow_credentials=True,
-        allow_methods=["GET", "POST"],
-        allow_headers=["Authorization", "Content-Type"],
-    )
+# story #3260 — backend/app/main.py의 CORSMiddleware 배선과 동형(항상 마운트, 빈
+# origins면 실질적으로 전부 거부 — "설정 자체가 없다"와 "빈 배열"을 다르게 다루려던 옛
+# 분기(`if settings.cors_allow_origins:`)를 걷어낸다, 이 서비스는 브라우저 직접 호출이라
+# CORSMiddleware가 실제로 매 요청 경로에 있다).
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[o.strip() for o in settings.cors_origins.split(",") if o.strip()],
+    allow_credentials=True,
+    allow_methods=["GET", "POST"],
+    allow_headers=["Authorization", "Content-Type"],
+)
 
 app.include_router(sessions_router)
 

--- a/support-gateway/tests/test_cors_wiring.py
+++ b/support-gateway/tests/test_cors_wiring.py
@@ -1,0 +1,15 @@
+"""story #3260(위젯 셸) — 이 서비스는 브라우저가 직접 호출한다(Next.js BFF 프록시 경유
+아님) — 실제 CORS preflight가 매 요청 경로에 돈다. 이전 코드(`if settings.cors_allow_origins:`
+분기)는 미설정 시 CORSMiddleware 자체를 안 붙였는데, 지금은 항상 붙이되 빈 origins면 실질
+전부 거부(backend/app/main.py와 동형 컨벤션) — 이 fail-closed 기본값을 pin한다."""
+from __future__ import annotations
+
+
+async def test_options_preflight_gets_no_allow_origin_when_unconfigured(client):
+    """SUPPORT_GATEWAY_CORS_ORIGINS 미설정(테스트 기본값 "")이면 어떤 origin도 preflight를
+    통과하지 못한다 — 미설정=거부(허용 아님)가 fail-closed 원칙과 일치한다."""
+    res = await client.options(
+        "/api/v1/sessions",
+        headers={"Origin": "https://dev-app.sprintable.ai", "Access-Control-Request-Method": "POST"},
+    )
+    assert "access-control-allow-origin" not in {k.lower() for k in res.headers.keys()}


### PR DESCRIPTION
## 배경
[\[지원v1·2위젯\] 인앱 문의 위젯 셸](entity:story:263f3414-edbc-4d65-8d56-3c8b301ab9d2) Phase 2(위젯↔Gateway 연동) 착수 grep — `support-gateway`는 브라우저가 **직접** 호출(Next.js BFF 프록시 경유 아님)이라 실 CORS preflight가 도는데, 배포 파이프라인 어디에도 `CORS_ORIGINS`가 배선돼 있지 않았고(`config.py` 기본값 `[]`) `NEXT_PUBLIC_SUPPORT_GATEWAY_URL`도 FE 빌드에 노출된 적이 없었다 — 이대로면 dev 배포에서 위젯이 Gateway를 호출하는 순간 preflight가 죽는다.

## 변경
- `support-gateway/app/config.py`: `cors_allow_origins: list[str]` → `cors_origins: str`(`backend/app/core/config.py`와 동일 컨벤션, comma-구분). `list[str]`는 pydantic-settings가 env 값을 JSON으로 기대해서, 값 안의 콤마가 `gcloud --update-env-vars`의 comma-구분 ArgDict 파싱과 이중 충돌한다(`cloudbuild.yaml`의 `MCP_ALLOWED_HOSTS` 선례와 동일 함정).
- `support-gateway/app/main.py`: `CORSMiddleware`를 `backend/app/main.py`와 동형으로 **항상** 마운트(빈 origins=사실상 전부 거부 — 이전 `if settings.cors_allow_origins:` 조건부 마운트 제거, backend 컨벤션과 통일).
- `cloudbuild.yaml`: `_SUPPORT_GATEWAY_CORS_ORIGINS`·`_NEXT_PUBLIC_SUPPORT_GATEWAY_URL` substitution 신설(기본 빈 문자열) + `deploy-support-gateway` 스텝에 `^;^` 커스텀 ArgDict 구분자로 안전 배선(`MCP_ALLOWED_HOSTS` 선례 재사용, 값 안의 콤마 안전) + `build-frontend` 스텝 build-arg 추가.
- `.github/workflows/cloud-build.yml`: dev 분기는 `infra/gcs-attachments-cors.json`(story #3242, 이미 검증된 dev FE origin SSOT)과 동일 origin 집합 재사용(새 값 안 지어냄) + 실측 Gateway dev URL(`gcloud run services describe support-gateway-dev --region=asia-northeast3`). prod 분기는 Gateway 미배포(`_SUPPORT_GATEWAY_DEPLOY_ENABLED=false`) 상태라 둘 다 명시 빈 값(무접촉).
- `apps/web/Dockerfile`: `NEXT_PUBLIC_SUPPORT_GATEWAY_URL` ARG/ENV 배선(`NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED`와 동형).

## 검증
- `support-gateway`: `uv run pytest tests/ -q` → 21 passed(신규 CORS fail-closed pin 1건 포함).
- FE: `pnpm build` 성공.
- GHA/cloudbuild YAML 파싱 확인(`python3 -c "import yaml; ..."`).

## 스코프 밖 / 관련 진행 중
`MessageResponse.content` 누락·GET 이력 엔드포인트 부재(디디군 [\[지원v1·1경계\] Support Gateway 서비스 신설](entity:story:f2a27d2a-73b2-4c14-9c74-b6dc61bfe026) 소관)는 별도로 API 셰이프 합의 중이라 이 PR엔 포함하지 않았다 — `support-gateway/app/config.py`·`main.py`를 이 PR과 다른 관심사(CORS만)로 건드리니, 병합 순서 신경 써 주는(디디군 쪽 작업이 겹치면 리베이스).

🤖 Generated with [Claude Code](https://claude.com/claude-code)