### PR TITLE
[SID:3260] 지원 위젯 ↔ Support Gateway 실연동

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4435,6 +4435,7 @@
     "escalatedBadge": "Connected to a human",
     "messageFailedLabel": "Couldn't send",
     "sendErrorRetry": "Retry",
+    "sendErrorFallback": "We couldn't get a response right now. Please try again shortly, or contact us directly.",
     "inputPlaceholder": "Type a message",
     "sendLabel": "Send"
   }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4428,6 +4428,13 @@
     "closeLabel": "Close",
     "unavailableTitle": "Support chat is coming soon",
     "unavailableBody": "We're connecting this — you can't send a message yet.",
+    "errorTitle": "Couldn't connect",
+    "errorBody": "We couldn't connect to support chat. Please try again.",
+    "retryConnect": "Reconnect",
+    "thinkingLabel": "Thinking… ({seconds}s)",
+    "escalatedBadge": "Connected to a human",
+    "messageFailedLabel": "Couldn't send",
+    "sendErrorRetry": "Retry",
     "inputPlaceholder": "Type a message",
     "sendLabel": "Send"
   }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4428,6 +4428,13 @@
     "closeLabel": "닫기",
     "unavailableTitle": "지원 채팅 준비 중입니다",
     "unavailableBody": "곧 연결됩니다 — 지금은 문의를 접수할 수 없습니다.",
+    "errorTitle": "연결에 실패했습니다",
+    "errorBody": "지원 채팅에 연결하지 못했습니다. 다시 시도해 주세요.",
+    "retryConnect": "다시 연결하기",
+    "thinkingLabel": "생각 중… ({seconds}초)",
+    "escalatedBadge": "담당자에게 연결됨",
+    "messageFailedLabel": "전송하지 못했습니다",
+    "sendErrorRetry": "다시 시도",
     "inputPlaceholder": "메시지를 입력하세요",
     "sendLabel": "보내기"
   }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4435,6 +4435,7 @@
     "escalatedBadge": "담당자에게 연결됨",
     "messageFailedLabel": "전송하지 못했습니다",
     "sendErrorRetry": "다시 시도",
+    "sendErrorFallback": "지금 응답을 받지 못했습니다. 잠시 후 다시 시도하시거나, 담당자에게 직접 문의해 주세요.",
     "inputPlaceholder": "메시지를 입력하세요",
     "sendLabel": "보내기"
   }

--- a/apps/web/src/app/api/support/session-token/route.ts
+++ b/apps/web/src/app/api/support/session-token/route.ts
@@ -1,0 +1,14 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// story #3260 Phase 2 — 위젯이 Support Gateway(별도 Cloud Run 서비스)를 직접 호출하기
+// 전에 필요한 org-스코프 위임 토큰 발급. 본체 backend POST /api/v2/support/session-token
+// (backend/app/routers/support_gateway_token.py) → { token, expires_in }. 그 이후의 실제
+// Gateway 호출(POST /api/v1/sessions 등)은 이 라우트를 거치지 않고 브라우저가 Gateway
+// origin으로 직접 나간다(apps/web/src/lib/support-widget/gateway-client.ts) — 이 라우트는
+// "이 앱 세션(쿠키) → Gateway가 신뢰하는 위임 토큰" 교환 지점 하나뿐.
+export async function POST(request: Request) {
+  const _r = await proxyToFastapi(request, '/api/v2/support/session-token');
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json(), undefined, _r.status);
+}

--- a/apps/web/src/components/support-widget/support-widget-panel.test.tsx
+++ b/apps/web/src/components/support-widget/support-widget-panel.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+//
+// story #3260 Phase 2 — 패널 body의 status별 렌더(error 재시도·sending 지속신호·escalated
+// 배지·sendError 폴백+재시도)를 useSupportWidgetSession을 직접 모킹해 검증한다(네트워크
+// 계약 자체는 use-support-widget-session.test.tsx가 이미 커버).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { SupportWidgetPanelBody } from './support-widget-panel';
+import type { SupportWidgetSession } from '@/hooks/use-support-widget-session';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+function baseSession(overrides: Partial<SupportWidgetSession> = {}): SupportWidgetSession {
+  return {
+    status: 'ready',
+    messages: [],
+    sending: false,
+    sendError: null,
+    connect: vi.fn(),
+    sendMessage: vi.fn(async () => {}),
+    retryLastMessage: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function mount(session: SupportWidgetSession) {
+  await act(async () => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <SupportWidgetPanelBody session={session} />
+      </NextIntlClientProvider>,
+    );
+  });
+}
+
+describe('SupportWidgetPanelBody — story #3260 Phase 2', () => {
+  it('error 상태 — unavailable과 다른 문구+재시도 버튼을 보이고, 클릭하면 connect()를 다시 부른다', async () => {
+    const connect = vi.fn();
+    await mount(baseSession({ status: 'error', connect }));
+    expect(container.textContent).toContain(koMessages.supportWidget.errorTitle);
+    expect(container.textContent).not.toContain(koMessages.supportWidget.unavailableTitle);
+    const retryBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.supportWidget.retryConnect)!;
+    await act(async () => { retryBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('sending 중엔 "생각 중" 지속 신호가 뜨고, 입력창·전송버튼이 막힌다(무신호 금지)', async () => {
+    await mount(baseSession({ sending: true }));
+    expect(container.textContent).toContain('생각 중');
+    const input = container.querySelector('input') as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+  });
+
+  it('escalated 메시지는 "담당자에게 연결됨" 배지를 함께 보인다', async () => {
+    await mount(baseSession({
+      messages: [{ id: 'a1', role: 'agent', content: '담당자를 연결해 드릴게요.', createdAt: 't', escalated: true }],
+    }));
+    expect(container.textContent).toContain(koMessages.supportWidget.escalatedBadge);
+  });
+
+  it('sendError가 있으면 폴백 배너+재시도 버튼이 뜨고, 클릭하면 retryLastMessage()를 부른다(카디르 지적 승계 — 무신호 금지 필수요건)', async () => {
+    const retryLastMessage = vi.fn();
+    await mount(baseSession({
+      sendError: '지금 응답을 받지 못했습니다. 잠시 후 다시 시도하시거나, 담당자에게 직접 문의해 주세요.',
+      retryLastMessage,
+    }));
+    expect(container.textContent).toContain('담당자에게 직접 문의');
+    const retryBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === koMessages.supportWidget.sendErrorRetry)!;
+    await act(async () => { retryBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(retryLastMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('failed 메시지는 실패 마커를 보이고 조용히 사라지지 않는다(no-fiction)', async () => {
+    await mount(baseSession({
+      messages: [{ id: 'local-1', role: 'user', content: '안 보내진 메시지', createdAt: 't', failed: true }],
+    }));
+    expect(container.textContent).toContain('안 보내진 메시지');
+    expect(container.textContent).toContain(koMessages.supportWidget.messageFailedLabel);
+  });
+});

--- a/apps/web/src/components/support-widget/support-widget-panel.tsx
+++ b/apps/web/src/components/support-widget/support-widget-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Send, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -33,15 +33,45 @@ export function SupportWidgetPanelHeader({ onClose }: { onClose: () => void }) {
 }
 
 /**
- * story #3260 — status는 항상 'unavailable'(Support Gateway 계약 착지 전, use-support-widget-
- * session.ts 참고) — 그래도 'connecting'/'ready' 분기를 지금 갖춰두는 이유: 계약 착지 후
- * 훅 내부만 교체되면 이 컴포넌트는 무변경으로 실 데이터를 그대로 그린다(호출부 재작업 0).
+ * story #3260 Phase 2(2026-08-31, 페드루 PO 실 왕복 실측 지적) — support-gateway의
+ * Interaction/Execution 루프는 동기 처리라 ~12초까지 걸린다(story #3261). 정적 스피너는
+ * "멈춘 건지 도는 건지" 구분이 안 돼 무신호와 다를 바 없다 — 경과 초를 1초마다 갱신해
+ * 살아있다는 신호를 지속적으로 준다.
+ */
+function ThinkingIndicator() {
+  const t = useTranslations('supportWidget');
+  // 이 컴포넌트는 sending===true인 동안만 마운트되므로(호출부의 조건부 렌더) 매 등장이
+  // 곧 새 왕복의 시작 — 0에서 다시 세는 것이 초기 useState(0)만으로 이미 정확하다.
+  const [seconds, setSeconds] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setSeconds((s) => s + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="flex items-center gap-1.5 rounded-xl bg-muted px-3 py-2 text-sm text-muted-foreground">
+      <span className="flex gap-0.5" aria-hidden>
+        <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.3s]" />
+        <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.15s]" />
+        <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/60" />
+      </span>
+      {t('thinkingLabel', { seconds })}
+    </div>
+  );
+}
+
+/**
+ * story #3260 Phase 2 — status 4종을 각각 다른 화면으로 그린다:
+ * - 'unavailable': Gateway가 이 빌드에 아예 안 붙어있음(재시도 대상 없음, 정직한 "준비 중").
+ * - 'error': 붙어있는데 연결 자체가 실패(재시도 버튼 — connect() 재호출로 의미 있음).
+ * - 'connecting': 세션+이력 로딩 중.
+ * - 'ready': 실 대화. sending 중엔 ThinkingIndicator, sendError면 «사람 연결» 폴백 배너
+ *   (카디르 지적 승계 — 500/무신호 금지 필수 요건).
  */
 export function SupportWidgetPanelBody({ session }: { session: SupportWidgetSession }) {
   const t = useTranslations('supportWidget');
   const [draft, setDraft] = useState('');
 
-  if (session.status === 'unavailable' || session.status === 'error') {
+  if (session.status === 'unavailable') {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-1.5 px-6 text-center">
         <p className="text-sm font-medium text-foreground">{t('unavailableTitle')}</p>
@@ -50,7 +80,19 @@ export function SupportWidgetPanelBody({ session }: { session: SupportWidgetSess
     );
   }
 
-  const canSend = draft.trim().length > 0 && session.status === 'ready';
+  if (session.status === 'error') {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
+        <p className="text-sm font-medium text-foreground">{t('errorTitle')}</p>
+        <p className="text-xs text-muted-foreground">{t('errorBody')}</p>
+        <Button type="button" size="sm" variant="secondary" onClick={() => session.connect()}>
+          {t('retryConnect')}
+        </Button>
+      </div>
+    );
+  }
+
+  const canSend = draft.trim().length > 0 && session.status === 'ready' && !session.sending;
 
   return (
     <>
@@ -63,13 +105,28 @@ export function SupportWidgetPanelBody({ session }: { session: SupportWidgetSess
               key={m.id}
               className={`max-w-[85%] rounded-xl px-3 py-2 text-sm leading-relaxed [overflow-wrap:anywhere] ${
                 m.role === 'user' ? 'ml-auto bg-proof-blue-soft text-foreground' : 'bg-muted text-foreground'
-              }`}
+              } ${m.pending ? 'opacity-60' : ''} ${m.failed ? 'border border-destructive/50' : ''}`}
             >
               {m.content}
+              {m.escalated ? (
+                <p className="mt-1 text-[10px] font-medium text-muted-foreground">{t('escalatedBadge')}</p>
+              ) : null}
+              {m.failed ? (
+                <p role="alert" className="mt-1 text-[10px] font-medium text-destructive">{t('messageFailedLabel')}</p>
+              ) : null}
             </div>
           ))
         )}
+        {session.sending ? <ThinkingIndicator /> : null}
       </div>
+      {session.sendError ? (
+        <div className="flex shrink-0 items-center justify-between gap-2 border-t border-border bg-destructive/10 px-3 py-2">
+          <p role="alert" aria-live="assertive" className="text-xs text-foreground">{session.sendError}</p>
+          <Button type="button" size="sm" variant="outline" onClick={() => session.retryLastMessage()}>
+            {t('sendErrorRetry')}
+          </Button>
+        </div>
+      ) : null}
       <form
         className="flex shrink-0 items-center gap-1.5 border-t border-border p-2"
         onSubmit={(e) => {
@@ -84,7 +141,7 @@ export function SupportWidgetPanelBody({ session }: { session: SupportWidgetSess
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           placeholder={t('inputPlaceholder')}
-          disabled={session.status !== 'ready'}
+          disabled={session.status !== 'ready' || session.sending}
           className="min-w-0 flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50"
         />
         <Button type="submit" size="sm" disabled={!canSend} aria-label={t('sendLabel')}>

--- a/apps/web/src/hooks/use-support-widget-session.test.tsx
+++ b/apps/web/src/hooks/use-support-widget-session.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+//
+// story #3260 Phase 2(2026-08-31) — Support Gateway 계약(디디 PR#3648)이 착지한 뒤 이 훅이
+// 실 fetch 계층(gateway-client.ts)을 올바르게 소비하는지 검증한다. 훅 자체는 @testing-
+// library/react-hooks 없이(use-render-nonce.test.tsx 등 이 레포 관례) 작은 하니스
+// 컴포넌트로 마운트해 DOM 텍스트/속성으로 상태를 읽는다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useSupportWidgetSession } from './use-support-widget-session';
+
+const isSupportGatewayConfiguredMock = vi.fn();
+const createOrResumeGatewaySessionMock = vi.fn();
+const listGatewayMessagesMock = vi.fn();
+const sendGatewayMessageMock = vi.fn();
+
+vi.mock('@/lib/support-widget/gateway-client', () => ({
+  isSupportGatewayConfigured: () => isSupportGatewayConfiguredMock(),
+  createOrResumeGatewaySession: (...args: unknown[]) => createOrResumeGatewaySessionMock(...args),
+  listGatewayMessages: (...args: unknown[]) => listGatewayMessagesMock(...args),
+  sendGatewayMessage: (...args: unknown[]) => sendGatewayMessageMock(...args),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  isSupportGatewayConfiguredMock.mockReset().mockReturnValue(true);
+  createOrResumeGatewaySessionMock.mockReset();
+  listGatewayMessagesMock.mockReset();
+  sendGatewayMessageMock.mockReset();
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+function Harness() {
+  const session = useSupportWidgetSession();
+  return (
+    <div>
+      <span data-testid="status">{session.status}</span>
+      <span data-testid="sending">{String(session.sending)}</span>
+      <span data-testid="send-error">{session.sendError ?? ''}</span>
+      <ul>
+        {session.messages.map((m) => (
+          <li key={m.id} data-role={m.role} data-pending={m.pending} data-failed={m.failed} data-escalated={m.escalated}>
+            {m.content}
+          </li>
+        ))}
+      </ul>
+      <button type="button" onClick={() => session.connect()}>connect</button>
+      <button type="button" onClick={() => void session.sendMessage('안녕하세요')}>send</button>
+      <button type="button" onClick={() => session.retryLastMessage()}>retry</button>
+    </div>
+  );
+}
+
+async function mount() {
+  await act(async () => { root.render(<Harness />); });
+}
+
+function statusText() { return container.querySelector('[data-testid="status"]')!.textContent; }
+function click(label: string) {
+  const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === label)!;
+  return act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+}
+
+describe('useSupportWidgetSession — story #3260 Phase 2', () => {
+  it('Gateway가 이 빌드에 안 붙어있으면(isSupportGatewayConfigured=false) connect()해도 unavailable 그대로다', async () => {
+    isSupportGatewayConfiguredMock.mockReturnValue(false);
+    await mount();
+    await click('connect');
+    expect(statusText()).toBe('unavailable');
+    expect(createOrResumeGatewaySessionMock).not.toHaveBeenCalled();
+  });
+
+  it('connect() 성공 — 세션 생성+이력 조회 후 ready로 전환되고 이력이 그대로 렌더된다', async () => {
+    createOrResumeGatewaySessionMock.mockResolvedValue({ id: 'sess-1', org_id: 'org-1', created_at: 'now' });
+    listGatewayMessagesMock.mockResolvedValue([
+      { id: 'm1', conversation_id: 'c1', role: 'customer', content: '이전 문의', created_at: 't1' },
+      { id: 'm2', conversation_id: 'c1', role: 'agent', content: '이전 응답', created_at: 't2' },
+    ]);
+    await mount();
+    await click('connect');
+    expect(statusText()).toBe('ready');
+    expect(container.textContent).toContain('이전 문의');
+    expect(container.textContent).toContain('이전 응답');
+  });
+
+  it('connect() 실패 — error 상태로 전환된다(unavailable과 구분)', async () => {
+    createOrResumeGatewaySessionMock.mockRejectedValue(new Error('network down'));
+    await mount();
+    await click('connect');
+    expect(statusText()).toBe('error');
+  });
+
+  it('sendMessage 성공 — 낙관적 echo가 실 메시지(+escalated 플래그)로 교체된다', async () => {
+    createOrResumeGatewaySessionMock.mockResolvedValue({ id: 'sess-1', org_id: 'org-1', created_at: 'now' });
+    listGatewayMessagesMock.mockResolvedValue([]);
+    sendGatewayMessageMock.mockResolvedValue({
+      customer_message: { id: 'c1', conversation_id: 'conv-1', role: 'customer', content: '안녕하세요', created_at: 't1' },
+      agent_message: { id: 'a1', conversation_id: 'conv-1', role: 'agent', content: '무엇을 도와드릴까요?', created_at: 't2' },
+      escalated: false,
+    });
+    await mount();
+    await click('connect');
+    await click('send');
+    expect(container.textContent).toContain('무엇을 도와드릴까요?');
+    expect(container.querySelector('[data-testid="sending"]')!.textContent).toBe('false');
+    // 낙관적 local-* id가 실 서버 id로 교체돼 pending 마커가 안 남는다.
+    expect(container.querySelector('[data-pending="true"]')).toBeNull();
+  });
+
+  it('sendMessage 실패 — 카디르 지적 승계(필수): 500/무신호 대신 sendError 정직 문구+실패 마커가 남는다', async () => {
+    createOrResumeGatewaySessionMock.mockResolvedValue({ id: 'sess-1', org_id: 'org-1', created_at: 'now' });
+    listGatewayMessagesMock.mockResolvedValue([]);
+    sendGatewayMessageMock.mockRejectedValue(new Error('HTTP 500'));
+    await mount();
+    await click('connect');
+    await click('send');
+    expect(container.querySelector('[data-testid="send-error"]')!.textContent).not.toBe('');
+    expect(container.querySelector('[data-failed="true"]')).not.toBeNull();
+  });
+
+  it('retryLastMessage — 실패한 메시지를 같은 내용으로 재전송하고 성공하면 실패 마커가 지워진다', async () => {
+    createOrResumeGatewaySessionMock.mockResolvedValue({ id: 'sess-1', org_id: 'org-1', created_at: 'now' });
+    listGatewayMessagesMock.mockResolvedValue([]);
+    sendGatewayMessageMock.mockRejectedValueOnce(new Error('HTTP 500'));
+    sendGatewayMessageMock.mockResolvedValueOnce({
+      customer_message: { id: 'c1', conversation_id: 'conv-1', role: 'customer', content: '안녕하세요', created_at: 't1' },
+      agent_message: { id: 'a1', conversation_id: 'conv-1', role: 'agent', content: '재시도 성공', created_at: 't2' },
+      escalated: false,
+    });
+    await mount();
+    await click('connect');
+    await click('send');
+    expect(container.querySelector('[data-failed="true"]')).not.toBeNull();
+    await click('retry');
+    expect(container.querySelector('[data-failed="true"]')).toBeNull();
+    expect(container.textContent).toContain('재시도 성공');
+  });
+});

--- a/apps/web/src/hooks/use-support-widget-session.test.tsx
+++ b/apps/web/src/hooks/use-support-widget-session.test.tsx
@@ -9,6 +9,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../messages/ko.json';
+import enMessages from '../../messages/en.json';
 import { useSupportWidgetSession } from './use-support-widget-session';
 
 const isSupportGatewayConfiguredMock = vi.fn();
@@ -64,10 +65,11 @@ function Harness() {
   );
 }
 
-async function mount() {
+async function mount(locale: 'ko' | 'en' = 'ko') {
+  const messages = locale === 'ko' ? koMessages : enMessages;
   await act(async () => {
     root.render(
-      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      <NextIntlClientProvider locale={locale} messages={messages} timeZone="Asia/Seoul">
         <Harness />
       </NextIntlClientProvider>,
     );
@@ -137,6 +139,18 @@ describe('useSupportWidgetSession — story #3260 Phase 2', () => {
     // (supportWidget.sendErrorFallback)로 렌더된 실 값과 정확히 일치해야 한다.
     expect(container.querySelector('[data-testid="send-error"]')!.textContent).toBe(koMessages.supportWidget.sendErrorFallback);
     expect(container.querySelector('[data-failed="true"]')).not.toBeNull();
+  });
+
+  it('EN 로케일 크로스체크(카디르 QA 뮤테이션 실증 반영) — ko/en 양쪽이 같은 값을 참조해 동어반복이던 갭을 닫는다. locale=en으로 마운트하면 영문 문구가 뜬다 — 하드코딩 한글로 되돌리는 회귀는 이 테스트에서 반드시 red가 된다(ko 대조 테스트만으론 t() 걷어내도 green이었던 뮤테이션 갭).', async () => {
+    createOrResumeGatewaySessionMock.mockResolvedValue({ id: 'sess-1', org_id: 'org-1', created_at: 'now' });
+    listGatewayMessagesMock.mockResolvedValue([]);
+    sendGatewayMessageMock.mockRejectedValue(new Error('HTTP 500'));
+    await mount('en');
+    await click('connect');
+    await click('send');
+    const rendered = container.querySelector('[data-testid="send-error"]')!.textContent;
+    expect(rendered).toBe(enMessages.supportWidget.sendErrorFallback);
+    expect(rendered).not.toBe(koMessages.supportWidget.sendErrorFallback);
   });
 
   it('retryLastMessage — 실패한 메시지를 같은 내용으로 재전송하고 성공하면 실패 마커가 지워진다', async () => {

--- a/apps/web/src/hooks/use-support-widget-session.test.tsx
+++ b/apps/web/src/hooks/use-support-widget-session.test.tsx
@@ -7,6 +7,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../messages/ko.json';
 import { useSupportWidgetSession } from './use-support-widget-session';
 
 const isSupportGatewayConfiguredMock = vi.fn();
@@ -63,7 +65,13 @@ function Harness() {
 }
 
 async function mount() {
-  await act(async () => { root.render(<Harness />); });
+  await act(async () => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <Harness />
+      </NextIntlClientProvider>,
+    );
+  });
 }
 
 function statusText() { return container.querySelector('[data-testid="status"]')!.textContent; }
@@ -125,7 +133,9 @@ describe('useSupportWidgetSession — story #3260 Phase 2', () => {
     await mount();
     await click('connect');
     await click('send');
-    expect(container.querySelector('[data-testid="send-error"]')!.textContent).not.toBe('');
+    // story #3260 2차(유나 design 판정) — 하드코딩 한글 문구 leak 회귀가드. i18n 키
+    // (supportWidget.sendErrorFallback)로 렌더된 실 값과 정확히 일치해야 한다.
+    expect(container.querySelector('[data-testid="send-error"]')!.textContent).toBe(koMessages.supportWidget.sendErrorFallback);
     expect(container.querySelector('[data-failed="true"]')).not.toBeNull();
   });
 

--- a/apps/web/src/hooks/use-support-widget-session.ts
+++ b/apps/web/src/hooks/use-support-widget-session.ts
@@ -9,6 +9,7 @@
 'use client';
 
 import { useCallback, useMemo, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import {
   createOrResumeGatewaySession,
   isSupportGatewayConfigured,
@@ -65,6 +66,11 @@ function toWidgetMessage(m: GatewayMessage): SupportWidgetMessage {
 }
 
 export function useSupportWidgetSession(): SupportWidgetSession {
+  // story #3260 2차(유나 design 판정, 2026-08-31) — 이 문구가 하드코딩 한글이라 i18n
+  // leak이었다(en 빌드에서도 한글이 그대로 뜨는 결함). 훅이 next-intl useTranslations()를
+  // 직접 불러 'chats'류 다른 훅과 동일하게 t()로 렌더한다(패널이 아니라 훅이 소유 —
+  // sendError는 이미 "완성된 표시용 문구" 계약이라 패널에 원인 코드를 별도로 안 넘긴다).
+  const t = useTranslations('supportWidget');
   const [status, setStatus] = useState<SupportWidgetStatus>('unavailable');
   const [messages, setMessages] = useState<SupportWidgetMessage[]>([]);
   const [sending, setSending] = useState(false);
@@ -120,11 +126,11 @@ export function useSupportWidgetSession(): SupportWidgetSession {
       setMessages((prev) => prev.map((m) => (m.id === optimisticId ? { ...m, pending: false, failed: true } : m)));
       // 카디르 지적 승계(필수) — 500/무신호 금지. 서버가 무슨 이유로 죽었든(타임아웃·5xx)
       // 위젯은 항상 이 정직한 «사람 연결» 폴백 문구를 보여준다.
-      setSendError('지금 응답을 받지 못했습니다. 잠시 후 다시 시도하시거나, 담당자에게 직접 문의해 주세요.');
+      setSendError(t('sendErrorFallback'));
     } finally {
       setSending(false);
     }
-  }, [sending]);
+  }, [sending, t]);
 
   const retryLastMessage = useCallback(() => {
     const content = lastFailedContentRef.current;

--- a/apps/web/src/hooks/use-support-widget-session.ts
+++ b/apps/web/src/hooks/use-support-widget-session.ts
@@ -1,13 +1,26 @@
-// story #3260(지원v1 v1·2위젯) — Support Gateway(story #f2a27d2a, 디디) 세션/메시지 계약이
-// 아직 없다(2026-08-31 착수 시점 grep 확認 — backend/infra 어디에도 support_gateway 자체가
-// 없음). 그 계약이 실 API로 착지하기 전까지 이 훅은 «연결을 흉내내지 않는다» — 페드루
-// 발주(디디와 API 셰이프 선합의 후 코딩)에 따라 정직한 'unavailable' 상태만 반환한다.
-// AC5(§5-3 착지 전 병합 시 서버 정직 응답 — 에코/대기 응답 스텁 무신호 금지)의 정신을
-// 그대로 셸 단계에도 적용: 가짜로 열려있는 척하지 않는다.
+// story #3260 Phase 2(2026-08-31) — Support Gateway(support-gateway/, 디디) 계약이 착지했다
+// (schemas.py/routers/sessions.py, PR#3648 — MessageResponse.content·GET 이력 둘 다 확定).
+// 이 훅이 실 fetch 계층(apps/web/src/lib/support-widget/gateway-client.ts)을 소비한다.
+//
+// ⚠️본체 chat 실시간(realtime-provider.tsx `useSseMultiplexerContext()`)은 절대 구독하지
+// 않는다 — Gateway는 SSE/스트리밍이 아예 없다(동기 왕복 단일 계약, schemas.py
+// MessageExchangeResponse 문서 참고 — "v1: 동기 왕복"). 이중소비·고아 슬롯 결함 클래스가
+// 애초에 재발할 표면 자체가 없다(story #2102급 원칙을 셸 설계 단계에서 이미 충족).
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  createOrResumeGatewaySession,
+  isSupportGatewayConfigured,
+  listGatewayMessages,
+  sendGatewayMessage,
+  type GatewayMessage,
+} from '@/lib/support-widget/gateway-client';
 
+// story #3260 2차(페드루 PO) — unavailable은 «Gateway 미도달(이 빌드에 아예 안 붙어있음)»
+// 딱 하나로 좁힌다. 붙어있는데 연결이 실패한 경우('error')와 뜻이 다르다 — 전자는 재시도
+// 자체가 무의미(설정이 없다)하고 후자는 connect() 재시도가 의미 있다(패널이 이 구분으로
+// 다른 UI를 그린다).
 export type SupportWidgetStatus = 'unavailable' | 'connecting' | 'ready' | 'error';
 
 export interface SupportWidgetMessage {
@@ -15,39 +28,115 @@ export interface SupportWidgetMessage {
   role: 'user' | 'agent';
   content: string;
   createdAt: string;
+  /** agent 메시지 전용 — Gateway가 사람에게 연결했다는 뜻(무신호 아님, 항상 진짜 안내
+   * 텍스트를 동반 — support-gateway/app/no_fiction_guard.py가 지어낸 서술을 구조적으로
+   * 차단하므로 이 플래그가 true여도 content는 항상 정직한 문구다). */
+  escalated?: boolean;
+  /** 낙관적 echo(서버 확認 전) — 실패하지 않았다면 응답 도착 즉시 실 메시지로 교체된다. */
+  pending?: boolean;
+  /** 왕복 자체가 실패(네트워크·5xx)해 서버가 이 메시지를 못 받았을 수 있는 상태 —
+   * "성공한 척" 지우지 않고 실패를 그대로 보여준다(no-fiction). */
+  failed?: boolean;
 }
 
 export interface SupportWidgetSession {
   status: SupportWidgetStatus;
   messages: SupportWidgetMessage[];
-  /** 위젯이 열릴 때만 호출(lazy — 모든 인증 화면에 상주하는 런처가 매 페이지 진입마다
-   * 네트워크를 태우지 않도록). Gateway 계약 착지 전까지는 no-op(status가 이미
-   * 'unavailable'로 고정돼 있어 실질적 의미는 없음 — 인터페이스만 안정화). */
+  /** POST /messages 왕복이 진행 중 — story #3261 실측(~12초)이라 패널이 이 값으로
+   * "생각 중" 지속 신호(경과 초 등)를 그린다(무신호 금지, 페드루 지시). */
+  sending: boolean;
+  /** 가장 최근 실패의 사람 문구 — «사람 연결» 폴백 안내(카디르 지적 승계, 필수 요건). */
+  sendError: string | null;
+  /** 위젯이 열릴 때만 호출(lazy). status가 'connecting'|'ready'면 재호출은 no-op —
+   * 'error'에서는 재시도로 동작한다(사용자가 다시 열거나 재시도 트리거 시). */
   connect: () => void;
   sendMessage: (content: string) => Promise<void>;
+  /** sendError가 있을 때만 의미 있음 — 실패한 마지막 메시지를 같은 내용으로 재전송. */
+  retryLastMessage: () => void;
 }
 
-/**
- * story #3260 — Support Gateway(§5-1) 세션/스트림 계약이 착지하면 이 훅 내부만 교체된다
- * (실 fetch+독립 SSE 연결 — 본체 realtime-provider.tsx의 useSseMultiplexerContext()는
- * 절대 재사용하지 않는다, story #2102급 이중소비/고아 슬롯 결함 클래스 재발 방지 원칙).
- * 호출부(support-widget-panel.tsx)는 이 인터페이스만 알면 되므로 그 교체가 호출부
- * 무변경으로 끝난다.
- */
+function toWidgetMessage(m: GatewayMessage): SupportWidgetMessage {
+  return {
+    id: m.id,
+    role: m.role === 'customer' ? 'user' : 'agent',
+    content: m.content,
+    createdAt: m.created_at,
+  };
+}
+
 export function useSupportWidgetSession(): SupportWidgetSession {
-  const [status] = useState<SupportWidgetStatus>('unavailable');
-  const messages = useMemo<SupportWidgetMessage[]>(() => [], []);
+  const [status, setStatus] = useState<SupportWidgetStatus>('unavailable');
+  const [messages, setMessages] = useState<SupportWidgetMessage[]>([]);
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  const connectingRef = useRef(false);
+  const lastFailedContentRef = useRef<string | null>(null);
 
   const connect = useCallback(() => {
-    // Gateway 계약 착지 전 — 의도적 no-op.
-  }, []);
+    // Gateway 자체가 이 빌드에 안 붙어있음 — 정직한 'unavailable' 유지, 재시도할 대상이 없다.
+    if (!isSupportGatewayConfigured()) return;
+    if (connectingRef.current || status === 'ready') return;
+    connectingRef.current = true;
+    setStatus('connecting');
+    setSendError(null);
+    void (async () => {
+      try {
+        const session = await createOrResumeGatewaySession();
+        sessionIdRef.current = session.id;
+        const history = await listGatewayMessages(session.id);
+        setMessages(history.map(toWidgetMessage));
+        setStatus('ready');
+      } catch {
+        setStatus('error');
+      } finally {
+        connectingRef.current = false;
+      }
+    })();
+  }, [status]);
 
-  const sendMessage = useCallback(async (_content: string) => {
-    // Gateway 계약 착지 전 — 의도적 no-op(성공한 척 큐잉하지 않음, panel이 status로 막는다).
-  }, []);
+  const sendMessage = useCallback(async (content: string) => {
+    const sessionId = sessionIdRef.current;
+    if (!sessionId || sending) return;
+    const optimisticId = `local-${Date.now()}`;
+    // 낙관적 echo — 실제로 입력한 내용을 그대로 보여줄 뿐(지어낸 응답 아님), ~12초 왕복
+    // 동안 "내가 보낸 게 맞나" 불안을 없앤다. pending 플래그로 서버 확認 전임을 구분.
+    setMessages((prev) => [
+      ...prev,
+      { id: optimisticId, role: 'user', content, createdAt: new Date().toISOString(), pending: true },
+    ]);
+    setSending(true);
+    setSendError(null);
+    lastFailedContentRef.current = null;
+    try {
+      const exchange = await sendGatewayMessage(sessionId, content);
+      setMessages((prev) => [
+        ...prev.filter((m) => m.id !== optimisticId),
+        toWidgetMessage(exchange.customer_message),
+        { ...toWidgetMessage(exchange.agent_message), escalated: exchange.escalated },
+      ]);
+    } catch {
+      lastFailedContentRef.current = content;
+      setMessages((prev) => prev.map((m) => (m.id === optimisticId ? { ...m, pending: false, failed: true } : m)));
+      // 카디르 지적 승계(필수) — 500/무신호 금지. 서버가 무슨 이유로 죽었든(타임아웃·5xx)
+      // 위젯은 항상 이 정직한 «사람 연결» 폴백 문구를 보여준다.
+      setSendError('지금 응답을 받지 못했습니다. 잠시 후 다시 시도하시거나, 담당자에게 직접 문의해 주세요.');
+    } finally {
+      setSending(false);
+    }
+  }, [sending]);
+
+  const retryLastMessage = useCallback(() => {
+    const content = lastFailedContentRef.current;
+    if (!content) return;
+    setMessages((prev) => prev.filter((m) => !(m.failed && m.content === content)));
+    void sendMessage(content);
+  }, [sendMessage]);
 
   // 반환 객체 자체를 안정화 — 호출부(support-widget-launcher.tsx)가 이 객체를 effect
-  // deps에 그대로 넣는다. 매 렌더 새 객체 리터럴이면 status/messages가 안 바뀌어도 매번
-  // effect가 재발화한다(불필요한 connect() 재호출 — 실 연결이 붙으면 낭비가 아니라 버그가 된다).
-  return useMemo(() => ({ status, messages, connect, sendMessage }), [status, messages, connect, sendMessage]);
+  // deps에 그대로 넣는다(값이 안 바뀌면 재렌더가 connect()를 불필요하게 재호출하지 않게).
+  return useMemo(
+    () => ({ status, messages, sending, sendError, connect, sendMessage, retryLastMessage }),
+    [status, messages, sending, sendError, connect, sendMessage, retryLastMessage],
+  );
 }

--- a/apps/web/src/lib/support-widget/gateway-client.test.ts
+++ b/apps/web/src/lib/support-widget/gateway-client.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+//
+// story #3260 2차(카디르 QA 축① 지적, 2026-08-31) — use-support-widget-session.test.tsx는
+// gateway-client 모듈 전체를 vi.mock으로 통째로 갈아치워서, 이 파일 안의 실 !res.ok→throw
+// 매핑 로직 자체는 어디서도 실행되지 않았다(그 매핑 코드가 통째로 삭제돼도 CI는 계속
+// green이었을 자리). 이 파일은 그 갭을 겨냥 — fetchWithAuth(세션-token 발급)만 목하고
+// Gateway 응답(global fetch)은 실 코드 경로로 태운다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('@/lib/db/client', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuthMock(...args),
+}));
+
+// gatewayBaseUrl()이 process.env를 매 호출 시점에 읽으므로(모듈 로드 시점이 아님) 정적
+// import로 충분 — env는 각 테스트의 beforeEach가 설정한다.
+import { sendGatewayMessage } from './gateway-client';
+
+const ENV_KEY = 'NEXT_PUBLIC_SUPPORT_GATEWAY_URL';
+const GATEWAY_URL = 'https://support-gateway-dev.example';
+
+beforeEach(() => {
+  process.env[ENV_KEY] = GATEWAY_URL;
+  fetchWithAuthMock.mockReset().mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: { token: 'delegated-token', expires_in: 300 } }),
+  });
+});
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+  vi.unstubAllGlobals();
+});
+
+describe('sendGatewayMessage — story #3260 2차 카디르 QA 축① 회귀가드', () => {
+  it('Gateway가 5xx를 돌려주면 HTTP 상태를 담아 throw한다(no-fiction — 조용히 삼키지 않음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500 })));
+    await expect(sendGatewayMessage('sess-1', '안녕하세요')).rejects.toThrow('HTTP 500');
+  });
+
+  it('네트워크 자체가 죽으면(fetch reject) 그대로 전파한다(가짜 성공으로 삼키지 않음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('Failed to fetch'); }));
+    await expect(sendGatewayMessage('sess-1', '안녕하세요')).rejects.toThrow('Failed to fetch');
+  });
+});

--- a/apps/web/src/lib/support-widget/gateway-client.ts
+++ b/apps/web/src/lib/support-widget/gateway-client.ts
@@ -1,0 +1,91 @@
+// story #3260 Phase 2 — Support Gateway(support-gateway/, story #f2a27d2a)를 브라우저가
+// **직접** 호출한다(이 앱의 다른 모든 데이터 fetch와 달리 Next.js BFF 프록시를 거치지
+// 않는다 — Gateway는 물리적으로 다른 Cloud Run 서비스라 fetchWithAuth의 쿠키 기반 인증이
+// 애초에 안 먹는다, Bearer 위임 토큰 스킴). 계약은 support-gateway/app/schemas.py·
+// routers/sessions.py(2026-08-31, 디디 PR#3648)를 그대로 따른다.
+import { fetchWithAuth } from '@/lib/db/client';
+
+export interface GatewaySession {
+  id: string;
+  org_id: string;
+  created_at: string;
+}
+
+export interface GatewayMessage {
+  id: string;
+  conversation_id: string;
+  role: 'customer' | 'agent';
+  content: string;
+  created_at: string;
+}
+
+export interface GatewayMessageExchange {
+  customer_message: GatewayMessage;
+  agent_message: GatewayMessage;
+  escalated: boolean;
+}
+
+function gatewayBaseUrl(): string | null {
+  const url = process.env['NEXT_PUBLIC_SUPPORT_GATEWAY_URL'];
+  return url && url.length > 0 ? url : null;
+}
+
+export function isSupportGatewayConfigured(): boolean {
+  return gatewayBaseUrl() !== null;
+}
+
+/** 본체 backend(POST /api/v2/support/session-token, backend/app/routers/
+ * support_gateway_token.py)가 발급하는 org-스코프 위임 토큰 — 이 앱 자체 인증(쿠키)은
+ * 여기까지만 쓰인다(Next.js 프록시 경유, fetchWithAuth). 이후 Gateway 호출은 전부 이
+ * 토큰을 Bearer로 붙인 직접 fetch. */
+async function issueDelegatedToken(): Promise<string> {
+  const res = await fetchWithAuth('/api/support/session-token', { method: 'POST' });
+  if (!res.ok) throw new Error(`session-token failed: HTTP ${res.status}`);
+  const json = await res.json().catch(() => null) as { data?: { token?: string } } | { token?: string } | null;
+  const token = (json && 'data' in json ? json.data?.token : (json as { token?: string } | null)?.token);
+  if (!token) throw new Error('session-token response missing token');
+  return token;
+}
+
+/** 세션 발급(멱등 — org+user당 1개, 기존 세션 재사용). 매 왕복 직전 새 위임 토큰을 발급해
+ * 붙인다(token_ttl_seconds=300 만료 추적 대신 "쓸 때마다 새로 발급"으로 단순화 — 발급
+ * 자체가 가벼운 본체 backend 호출이라 이 트레이드오프가 낫다, 별도 만료 타이머 불필요). */
+export async function createOrResumeGatewaySession(): Promise<GatewaySession> {
+  const base = gatewayBaseUrl();
+  if (!base) throw new Error('Support Gateway not configured');
+  const token = await issueDelegatedToken();
+  const res = await fetch(`${base}/api/v1/sessions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`gateway session failed: HTTP ${res.status}`);
+  return (await res.json()) as GatewaySession;
+}
+
+export async function listGatewayMessages(sessionId: string): Promise<GatewayMessage[]> {
+  const base = gatewayBaseUrl();
+  if (!base) throw new Error('Support Gateway not configured');
+  const token = await issueDelegatedToken();
+  const res = await fetch(`${base}/api/v1/sessions/${sessionId}/messages`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`gateway history failed: HTTP ${res.status}`);
+  const json = (await res.json()) as { messages: GatewayMessage[] };
+  return json.messages;
+}
+
+/** story #3261(오케스트레이션) 실측(Pedro, 2026-08-31) — 이 왕복은 동기 처리라 ~12초까지
+ * 걸릴 수 있다(분류→비용상한 확인→Vertex 대화 루프). 호출부(use-support-widget-session.ts)가
+ * 이 지연 동안 "생각 중" 지속 신호를 책임진다 — 여기는 순수 네트워크 계약만. */
+export async function sendGatewayMessage(sessionId: string, content: string): Promise<GatewayMessageExchange> {
+  const base = gatewayBaseUrl();
+  if (!base) throw new Error('Support Gateway not configured');
+  const token = await issueDelegatedToken();
+  const res = await fetch(`${base}/api/v1/sessions/${sessionId}/messages`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) throw new Error(`gateway message failed: HTTP ${res.status}`);
+  return (await res.json()) as GatewayMessageExchange;
+}


### PR DESCRIPTION
## 배경
[\[지원v1·2위젯\] 인앱 문의 위젯 셸](entity:story:263f3414-edbc-4d65-8d56-3c8b301ab9d2) 잔여 AC(2/3/5) 착지 — Support Gateway 계약이 디디군 쪽에서 확定됐다([\[지원v1·1경계\] Support Gateway 서비스 신설](entity:story:f2a27d2a-73b2-4c14-9c74-b6dc61bfe026), `content` 노출+GET 이력 PR#3648·no-fiction 가드 PR#3650). Phase 1(PR#3643/#3646)의 항상-`unavailable` 스텁 훅을 실 fetch 계층으로 교체한다.

## 신설
- `apps/web/src/lib/support-widget/gateway-client.ts` — 브라우저→Support Gateway **직접** fetch(BFF 프록시 없음, 물리적으로 다른 Cloud Run 서비스). `createOrResumeGatewaySession`·`listGatewayMessages`·`sendGatewayMessage`. 매 왕복 직전 본체 backend에서 새 위임 토큰을 발급(만료 타이머 추적 대신 "쓸 때마다 새로 발급" — `token_ttl_seconds=300` 만료 버그 클래스를 구조적으로 제거).
- `apps/web/src/app/api/support/session-token/route.ts` — 이 앱 세션(쿠키)→Gateway 위임 토큰 교환 지점(`proxyToFastapi` 표준 패턴). 이 라우트 하나만 거치고 그 이후 Gateway 호출은 전부 브라우저 직접(AC2 — 본체 conversation API 미사용 그대로 유지).

## `use-support-widget-session.ts` 재작성
- `status`: `unavailable`(Gateway가 이 빌드에 아예 없음 — 재시도 대상 자체가 없음) / `connecting` / `ready` / `error`(붙어있는데 연결 실패 — `connect()` 재시도가 의미 있음, 패널이 별도 화면+재시도 버튼으로 구분). 페드루 PO 지시("`unavailable`은 Gateway 미도달일 때만") 충족.
- `sendMessage` — 낙관적 echo(`pending`)로 즉시 내 메시지를 보여주고, 성공하면 실 메시지(+`escalated` 플래그)로 교체. 실패하면 조용히 사라지지 않고 `failed` 마커+`sendError` 정직 문구로 남는다(no-fiction — **카디르 지적 승계 필수요건**: 500/무신호 금지).
- `retryLastMessage` — 마지막 실패 메시지를 같은 내용으로 재전송.

## 패널 UI
- `ThinkingIndicator` — story #3261 실측(~12초 동기 왕복)에 맞춘 지속 신호(1초마다 경과초 갱신).
- `error` 상태 전용 화면(`unavailable`과 문구 분리)+재시도 버튼.
- `escalated` 배지 — Gateway no-fiction 가드(PR#3650)가 지어낸 서술을 구조적으로 차단해두므로 content는 항상 정직한 안내 텍스트, 배지는 시각 강조만.
- `sendError` 폴백 배너+재시도 — 「사람 연결」 안내(필수요건 4).

## SSE 분리(AC3) — 설계로 이미 충족
Gateway는 SSE/스트리밍이 없다(`schemas.py` `MessageExchangeResponse`: "v1: 동기 왕복"). 본체 `realtime-provider.tsx`의 `useSseMultiplexerContext()`는 이 훅·컴포넌트 어디서도 구독하지 않는다 — 이중소비·고아 슬롯 결함 클래스가 재발할 표면 자체가 없다.

## 검증
- FE 전체: `pnpm exec vitest run` → 547 files / 5085 tests passed(신규 21건 — 훅 6건+패널 5건+기존 launcher 10건).
- `eslint` 경고 0. `pnpm build` 성공.
- 컴파일된 실 CSS로 ready+escalated+failed+sending+error 5개 상태 동시 렌더 스크린샷으로 대비·레이아웃 육안 확인.

## 스코프 밖
- AC5 "실브라우저 왕복"의 최종 확인은 dev 배포 후 유나군 라이브 검증 — 이 PR은 단위/컴포넌트 테스트+정적 렌더까지.
- prod 플래그는 여전히 off(`NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED` — 이 PR 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)