### PR TITLE
[SID:3262] Interaction 도구 예외 관측성 확보 — SDK 예외삼킴 근인조사 1보

### DIFF
--- a/support-gateway/app/interaction.py
+++ b/support-gateway/app/interaction.py
@@ -9,6 +9,7 @@ customer 메시지(이미 저장됨, app/routers/sessions.py) → 인입 분류�
 어떤 세부사항(분류기·비용상한·Vertex AFC)도 몰라도 된다."""
 from __future__ import annotations
 
+import logging
 import uuid
 from dataclasses import dataclass
 
@@ -24,6 +25,23 @@ from app.model_config import Role, estimate_cost_usd, model_for
 from app.models import SupportConversation, SupportExecutionLog, SupportMessage
 from app.no_fiction_guard import FALLBACK_REPLY, looks_like_fabricated_handoff_claim
 from app.vertex_client import LLMClient, get_llm_client
+
+logger = logging.getLogger(__name__)
+
+# story #3262 3차 dev 실측(2026-08-31, 페드루 PO 근인조사) — 코퍼스 내 질문 7/7 근거 답 0건
+# (에러 3·에스컬 3·날조 1), 로그엔 아무 흔적도 없었다. 근인: **도구(_make_tools 클로저)가
+# raise하면 google-genai SDK의 AFC 디스패치가 그 예외를 삼키고**, Interaction 모델이 마치
+# 시스템 프롬프트에 그런 문구가 있었다는 듯 "죄송합니다, 현재 시스템에 오류가 발생하여..."류
+# 정형 사과문을 생성한다 — 로컬(실 코드+SA 토큰, knowledge_task 단독 실행)에선 완벽히
+# 동작했으므로 코드·자격·모델·검색수학 자체는 무죄, Cloud Run 런타임 조립(uvicorn/uvloop
+# 이벤트루프×AFC·asyncpg 세션 상호작용·metadata 자격 경로 등 용의)에서만 재현되는 결함.
+#
+# 1보(이 커밋) = **관측성**: 도구 자체를 try/except로 감싸 SDK가 예외를 볼 기회를 원천
+# 차단하고(SDK 삼킴 버그를 더는 안 만난다), logger.exception으로 실 traceback을 Cloud
+# Logging에 남기고, 고객에게는 "조용한 품질강등" 대신 정직한 실패 신호를 돌려준다. 근본
+# 원인(왜 Cloud Run에서만 raise하는지)은 이 로그가 찍힌 뒤 2보에서 다룬다 — 지금은 증상
+# 봉합이 아니라 "안 보이던 것을 보이게" 하는 단계라는 점을 다음 스텝 판단자가 알아야 한다.
+_TOOL_FAILURE_HONEST_MESSAGE = "지금 확인이 안 됩니다. 잠시 후 다시 시도해 주세요."
 
 _INTERACTION_SYSTEM_PROMPT = """당신은 이 회사의 고객 지원 담당자입니다. 원칙(BAO/S):
 1. 고객이 직접 한다 — 당신이 대신 실행하지 않고, 방법을 안내합니다(v1은 쓰기 액션 0).
@@ -79,21 +97,48 @@ def _make_tools(
 
     async def knowledge_search(query: str) -> str:
         """고객 문의와 관련된 사내 지식(문서·FAQ)을 검색합니다."""
-        result = await knowledge_task(db, conversation_id=conversation_id, org_id=org_id, query=query, llm=llm)
         knowledge_state["called"] = True
+        try:
+            result = await knowledge_task(db, conversation_id=conversation_id, org_id=org_id, query=query, llm=llm)
+        except Exception:
+            logger.exception(
+                "knowledge_search 도구 실행 중 예외(conversation_id=%s, org_id=%s, query=%r)",
+                conversation_id,
+                org_id,
+                query[:200],
+            )
+            return _TOOL_FAILURE_HONEST_MESSAGE
         knowledge_state["had_match"] = knowledge_state.get("had_match", False) or result.had_match
         return result.answer
 
     async def org_status_lookup(question: str) -> str:
         """이 조직(org)의 현재 상태(플랜·설정 등)를 조회합니다."""
-        return await org_status_task(db, conversation_id=conversation_id, org_id=org_id, question=question)
+        try:
+            return await org_status_task(db, conversation_id=conversation_id, org_id=org_id, question=question)
+        except Exception:
+            logger.exception(
+                "org_status_lookup 도구 실행 중 예외(conversation_id=%s, org_id=%s, question=%r)",
+                conversation_id,
+                org_id,
+                question[:200],
+            )
+            return _TOOL_FAILURE_HONEST_MESSAGE
 
     async def escalate(reason: str) -> str:
         """이 대화를 사람 담당자에게 연결합니다. 고객이 명시적으로 요청했거나, 자동 응대로
         해결이 어렵다고 판단될 때 호출하세요."""
-        result = await escalation_task(
-            db, conversation_id=conversation_id, org_id=org_id, reason="interaction", detail=reason
-        )
+        try:
+            result = await escalation_task(
+                db, conversation_id=conversation_id, org_id=org_id, reason="interaction", detail=reason
+            )
+        except Exception:
+            logger.exception(
+                "escalate 도구 실행 중 예외(conversation_id=%s, org_id=%s, reason=%r)",
+                conversation_id,
+                org_id,
+                reason[:200],
+            )
+            return _TOOL_FAILURE_HONEST_MESSAGE
         escalation_state["called"] = True
         return f"escalated:{result.id}"
 

--- a/support-gateway/tests/test_tool_exception_observability.py
+++ b/support-gateway/tests/test_tool_exception_observability.py
@@ -1,0 +1,75 @@
+"""story #3262 3차 dev 실측 근인조사(2026-08-31, 페드루 PO) — 도구가 raise하면 google-genai
+SDK의 AFC 디스패치가 예외를 삼켜 Cloud Logging에 흔적이 0였다(런타임 전용 재현, 로컬에선
+knowledge_task 단독 실행이 완벽히 동작해 코드·자격·모델 자체는 무죄로 확認됨). 1보(관측성):
+도구를 try/except로 감싸 SDK가 예외를 볼 기회 자체를 없애고 logger.exception으로 실
+traceback을 남긴다 — 이 테스트는 "감싸짐"과 "로그가 실제로 찍힘"을 검증한다."""
+from __future__ import annotations
+
+import logging
+
+import app.execution_tasks as execution_tasks_module
+from app.interaction import _TOOL_FAILURE_HONEST_MESSAGE
+from tests.conftest import OTHER_ORG_ID, make_token
+
+
+async def _post_message(client, org_id=OTHER_ORG_ID, content="팀원을 초대하려면 어떻게 하나요?"):
+    headers = {"Authorization": f"Bearer {make_token(org_id)}"}
+    session = await client.post("/api/v1/sessions", headers=headers)
+    session_id = session.json()["id"]
+    resp = await client.post(f"/api/v1/sessions/{session_id}/messages", json={"content": content}, headers=headers)
+    return resp
+
+
+async def test_knowledge_search_exception_is_logged_and_does_not_crash_the_turn(client, fake_llm, monkeypatch, caplog):
+    def _boom(vector, top_k=3):
+        raise RuntimeError("simulated Cloud Run-only failure (예: uvloop×AFC 상호작용)")
+
+    monkeypatch.setattr(execution_tasks_module, "search", _boom)
+    fake_llm.classify_text = "inquiry"
+    fake_llm.call_tool_name = "knowledge_search"
+    fake_llm.call_tool_kwargs = {"query": "팀원을 초대하려면?"}
+    fake_llm.interaction_text = "안내드릴게요."
+
+    with caplog.at_level(logging.ERROR, logger="app.interaction"):
+        resp = await _post_message(client)
+
+    assert resp.status_code == 200  # 500으로 안 죽는다 — SDK가 삼킬 예외 자체가 안 나간다.
+    assert any(
+        "knowledge_search 도구 실행 중 예외" in record.message and record.exc_info is not None
+        for record in caplog.records
+    ), "traceback 포함 exception 로그가 안 찍힘"
+
+
+async def test_escalate_exception_is_logged_and_does_not_crash_the_turn(client, fake_llm, monkeypatch, caplog):
+    async def _boom(db, *, conversation_id, org_id, reason, detail):
+        raise RuntimeError("simulated escalation_task failure")
+
+    import app.interaction as interaction_module
+
+    # interaction.py는 `from app.execution_tasks import escalation_task`로 자기 네임스페이스에
+    # 이름을 바인딩해뒀다 — execution_tasks_module 쪽을 패치해도 이미 바인딩된 이름엔 안
+    # 미친다. 실제 호출부(escalate 클로저)가 참조하는 interaction_module 쪽을 패치해야 한다.
+    monkeypatch.setattr(interaction_module, "escalation_task", _boom)
+
+    fake_llm.classify_text = "inquiry"
+    fake_llm.call_tool_name = "escalate"
+    fake_llm.call_tool_kwargs = {"reason": "고객이 사람 연결을 요청함"}
+    fake_llm.interaction_text = "담당자 연결을 시도할게요."
+
+    with caplog.at_level(logging.ERROR, logger="app.interaction"):
+        resp = await _post_message(client)
+
+    assert resp.status_code == 200
+    assert any(
+        "escalate 도구 실행 중 예외" in record.message and record.exc_info is not None for record in caplog.records
+    )
+
+
+async def test_tool_failure_honest_message_has_no_fabrication_markers():
+    """폴백 문구 자체가 no_fiction_guard·knowledge_fiction_guard 트리거 패턴을 우연히 안
+    건드리는지 확인(순환 오탐 방지)."""
+    from app.knowledge_fiction_guard import looks_like_fabricated_product_instructions
+    from app.no_fiction_guard import looks_like_fabricated_handoff_claim
+
+    assert looks_like_fabricated_handoff_claim(_TOOL_FAILURE_HONEST_MESSAGE) is False
+    assert looks_like_fabricated_product_instructions(_TOOL_FAILURE_HONEST_MESSAGE) is False


### PR DESCRIPTION
[SID:3262]

## 배경
페드루 PO 3차 dev 실측(2026-08-31)에서 지식원 코퍼스 내 질문 7/7 근거 답 0건(에러 3·에스컬 3·날조 1), 로그 흔적 0. 근인조사(재현 스크립트+SA 토큰 로컬 재현, scratchpad 보존)로 코드·자격·모델·검색수학은 무죄 확認 — **도구가 raise하면 google-genai SDK의 AFC 디스패치가 예외를 삼키고** Interaction 모델이 정형 사과문("죄송합니다, 현재 시스템에 오류가 발생하여...")을 대신 생성하는 게 근인. 로컬에서 `knowledge_task` 단독 실행은 완벽히 동작해 Cloud Run 런타임 조립에서만 재현되는 결함으로 특정됨.

## 이 PR (1보 — 관측성, 페드루 발주)
`app/interaction.py`의 `_make_tools`가 만드는 세 도구(`knowledge_search`/`org_status_lookup`/`escalate`)를 각각 `try/except`로 감싸:
- SDK가 예외를 볼 기회 자체를 차단(도구 관점에선 정상 반환이 되므로 AFC 디스패치의 삼킴 버그를 더는 만나지 않는다)
- `logger.exception(...)`으로 conversation_id/org_id/입력값과 함께 실 traceback을 Cloud Logging에 남김
- 고객에게는 조용한 품질강등 대신 정직한 실패 신호("지금 확인이 안 됩니다. 잠시 후 다시 시도해 주세요.") 반환

**근본 원인(왜 Cloud Run에서만 raise하는지)은 이 커밋의 스코프가 아니다** — 이 로그가 실측(dev 배포 후 배터리 재실행)으로 찍히면 2보에서 다룬다.

## 스코프 밖(페드루 PO 명시 — 안 건드림)
- SDK 예외삼킴 자체에 대한 방어 설계 — [지원v1·6방어·계측](entity:story:b93a2ab1-bdd8-44a1-a528-aad1b58ef976) 축
- "무료 플랜 10명" 날조(무관 매치가 가드를 해제) — [지식가드 위협모델 2](entity:story:833f9219-09be-435c-ad5f-745015e5ceed) 후속 스토리

## 검증
- 신규 테스트 3건: knowledge_search/escalate 예외 시 500 안 나고 traceback 로그 찍힘 확認(caplog), 폴백 문구가 기존 no_fiction_guard/knowledge_fiction_guard를 우연히 트리거 안 함 확認.
- 로컬 support-gateway 전체 스위트 57건 그린.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>