### PR TITLE
[SID:3262] 도구 예외 계측 확장(2보-a) — BaseException 재전파+stderr 트레이스+AFC 원장 로그

### DIFF
--- a/support-gateway/app/interaction.py
+++ b/support-gateway/app/interaction.py
@@ -10,6 +10,7 @@ customer 메시지(이미 저장됨, app/routers/sessions.py) → 인입 분류�
 from __future__ import annotations
 
 import logging
+import sys
 import uuid
 from dataclasses import dataclass
 
@@ -36,11 +37,21 @@ logger = logging.getLogger(__name__)
 # 동작했으므로 코드·자격·모델·검색수학 자체는 무죄, Cloud Run 런타임 조립(uvicorn/uvloop
 # 이벤트루프×AFC·asyncpg 세션 상호작용·metadata 자격 경로 등 용의)에서만 재현되는 결함.
 #
-# 1보(이 커밋) = **관측성**: 도구 자체를 try/except로 감싸 SDK가 예외를 볼 기회를 원천
-# 차단하고(SDK 삼킴 버그를 더는 안 만난다), logger.exception으로 실 traceback을 Cloud
-# Logging에 남기고, 고객에게는 "조용한 품질강등" 대신 정직한 실패 신호를 돌려준다. 근본
-# 원인(왜 Cloud Run에서만 raise하는지)은 이 로그가 찍힌 뒤 2보에서 다룬다 — 지금은 증상
-# 봉합이 아니라 "안 보이던 것을 보이게" 하는 단계라는 점을 다음 스텝 판단자가 알아야 한다.
+# 1보(2026-08-31 배포·리비전 00009) = 관측성 시도 — 그런데 **재실측 결과 로그가 0였다**
+# (logger.exception 출력 없이 도구 실패가 그대로 재현). 그 "무발화" 자체가 2보의 1급 단서 —
+# 페드루 PO가 세 갈래로 좁힘: ①CancelledError류(BaseException)가 `except Exception`을
+# 통과했을 가능성 ②SDK가 도구를 디스패치조차 못 해 도구 코드 자체가 안 돌았을 가능성
+# ③logging 설정이 실제로 stderr/Cloud Logging에 안 닿았을 가능성.
+#
+# 2보-a(이 커밋) = **계측 확장**, 아직 근본수정 아님:
+# - `except Exception` 외에 `except BaseException`을 추가해 CancelledError류도 로그로
+#   잡는다 — 단, BaseException은 삼키지 않고 로그 후 **re-raise**한다(취소 시맨틱을 죽이면
+#   안 된다는 표준 원칙 — Exception 하위 실패만 정직 폴백으로 삼킨다).
+# - `logging` 설정 불확실성을 우회하려고 각 도구 진입/성공/예외 지점에 `print(...,
+#   file=sys.stderr, flush=True)`를 직접 심는다("[tool-trace]" 접두 — grep 대상).
+# - `app/vertex_client.py::generate_with_tools`가 SDK 자체의
+#   `resp.automatic_function_calling_history`(SDK가 "도구에 무슨 일이 있었다고 믿는지"의
+#   원장)를 통째로 로그+stderr에 남긴다 — 세 갈래를 한 번의 배포로 가른다.
 _TOOL_FAILURE_HONEST_MESSAGE = "지금 확인이 안 됩니다. 잠시 후 다시 시도해 주세요."
 
 _INTERACTION_SYSTEM_PROMPT = """당신은 이 회사의 고객 지원 담당자입니다. 원칙(BAO/S):
@@ -97,6 +108,7 @@ def _make_tools(
 
     async def knowledge_search(query: str) -> str:
         """고객 문의와 관련된 사내 지식(문서·FAQ)을 검색합니다."""
+        print(f"[tool-trace] knowledge_search 진입 conv={conversation_id} query={query[:80]!r}", file=sys.stderr, flush=True)
         knowledge_state["called"] = True
         try:
             result = await knowledge_task(db, conversation_id=conversation_id, org_id=org_id, query=query, llm=llm)
@@ -107,14 +119,31 @@ def _make_tools(
                 org_id,
                 query[:200],
             )
+            print(f"[tool-trace] knowledge_search Exception — 정직 폴백 반환 conv={conversation_id}", file=sys.stderr, flush=True)
             return _TOOL_FAILURE_HONEST_MESSAGE
+        except BaseException:
+            logger.exception(
+                "knowledge_search 도구 실행 중 BaseException(CancelledError류 추정, re-raise) "
+                "(conversation_id=%s, org_id=%s, query=%r)",
+                conversation_id,
+                org_id,
+                query[:200],
+            )
+            print(f"[tool-trace] knowledge_search BaseException — re-raise conv={conversation_id}", file=sys.stderr, flush=True)
+            raise
         knowledge_state["had_match"] = knowledge_state.get("had_match", False) or result.had_match
+        print(
+            f"[tool-trace] knowledge_search 정상 반환 conv={conversation_id} had_match={result.had_match}",
+            file=sys.stderr,
+            flush=True,
+        )
         return result.answer
 
     async def org_status_lookup(question: str) -> str:
         """이 조직(org)의 현재 상태(플랜·설정 등)를 조회합니다."""
+        print(f"[tool-trace] org_status_lookup 진입 conv={conversation_id} question={question[:80]!r}", file=sys.stderr, flush=True)
         try:
-            return await org_status_task(db, conversation_id=conversation_id, org_id=org_id, question=question)
+            result = await org_status_task(db, conversation_id=conversation_id, org_id=org_id, question=question)
         except Exception:
             logger.exception(
                 "org_status_lookup 도구 실행 중 예외(conversation_id=%s, org_id=%s, question=%r)",
@@ -122,11 +151,25 @@ def _make_tools(
                 org_id,
                 question[:200],
             )
+            print(f"[tool-trace] org_status_lookup Exception — 정직 폴백 반환 conv={conversation_id}", file=sys.stderr, flush=True)
             return _TOOL_FAILURE_HONEST_MESSAGE
+        except BaseException:
+            logger.exception(
+                "org_status_lookup 도구 실행 중 BaseException(CancelledError류 추정, re-raise) "
+                "(conversation_id=%s, org_id=%s, question=%r)",
+                conversation_id,
+                org_id,
+                question[:200],
+            )
+            print(f"[tool-trace] org_status_lookup BaseException — re-raise conv={conversation_id}", file=sys.stderr, flush=True)
+            raise
+        print(f"[tool-trace] org_status_lookup 정상 반환 conv={conversation_id}", file=sys.stderr, flush=True)
+        return result
 
     async def escalate(reason: str) -> str:
         """이 대화를 사람 담당자에게 연결합니다. 고객이 명시적으로 요청했거나, 자동 응대로
         해결이 어렵다고 판단될 때 호출하세요."""
+        print(f"[tool-trace] escalate 진입 conv={conversation_id} reason={reason[:80]!r}", file=sys.stderr, flush=True)
         try:
             result = await escalation_task(
                 db, conversation_id=conversation_id, org_id=org_id, reason="interaction", detail=reason
@@ -138,8 +181,20 @@ def _make_tools(
                 org_id,
                 reason[:200],
             )
+            print(f"[tool-trace] escalate Exception — 정직 폴백 반환 conv={conversation_id}", file=sys.stderr, flush=True)
             return _TOOL_FAILURE_HONEST_MESSAGE
+        except BaseException:
+            logger.exception(
+                "escalate 도구 실행 중 BaseException(CancelledError류 추정, re-raise) "
+                "(conversation_id=%s, org_id=%s, reason=%r)",
+                conversation_id,
+                org_id,
+                reason[:200],
+            )
+            print(f"[tool-trace] escalate BaseException — re-raise conv={conversation_id}", file=sys.stderr, flush=True)
+            raise
         escalation_state["called"] = True
+        print(f"[tool-trace] escalate 정상 반환 conv={conversation_id} escalation_id={result.id}", file=sys.stderr, flush=True)
         return f"escalated:{result.id}"
 
     return [knowledge_search, org_status_lookup, escalate]

--- a/support-gateway/app/vertex_client.py
+++ b/support-gateway/app/vertex_client.py
@@ -8,11 +8,16 @@ location="global" 고정 — Blueprint v0.4 §4.3 AC④ 실측: Pro·Flash-Lite 
 """
 from __future__ import annotations
 
+import json
+import logging
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
 
 from app.config import settings
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -87,6 +92,22 @@ class VertexLLMClient:
             model=model, config=types.GenerateContentConfig(system_instruction=system_prompt, tools=tools)
         )
         resp = await chat.send_message(user_text)
+
+        # story #3262 2보-a(2026-08-31) — SDK 자체의 "도구에 무슨 일이 있었다고 믿는지" 원장.
+        # 1보(try/except+logger.exception)가 배포됐는데도 재실측에서 로그가 0였다 — 도구
+        # 코드가 아예 안 돌았는지(SDK가 디스패치 자체를 실패), 아니면 다른 이유로 로그가 안
+        # 찍혔는지를 이걸로 가른다. 임시 계측(근본원인 확定 후 걷어낼 코드) — 항상 남기지 않음.
+        afc_history = resp.automatic_function_calling_history
+        afc_summary = (
+            [c.model_dump(mode="json", exclude_none=True) for c in afc_history] if afc_history else []
+        )
+        logger.info("automatic_function_calling_history: %s", json.dumps(afc_summary, ensure_ascii=False))
+        print(
+            f"[tool-trace] automatic_function_calling_history: {json.dumps(afc_summary, ensure_ascii=False)}",
+            file=sys.stderr,
+            flush=True,
+        )
+
         usage = resp.usage_metadata
         return GenerateResult(
             text=resp.text or "",

--- a/support-gateway/tests/test_tool_exception_observability.py
+++ b/support-gateway/tests/test_tool_exception_observability.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import logging
 
+import pytest
+
 import app.execution_tasks as execution_tasks_module
 from app.interaction import _TOOL_FAILURE_HONEST_MESSAGE
 from tests.conftest import OTHER_ORG_ID, make_token
@@ -63,6 +65,64 @@ async def test_escalate_exception_is_logged_and_does_not_crash_the_turn(client, 
     assert any(
         "escalate 도구 실행 중 예외" in record.message and record.exc_info is not None for record in caplog.records
     )
+
+
+class _SimulatedNonExceptionFailure(BaseException):
+    """story #3262 2보-a — Exception이 아닌 BaseException(CancelledError류) 시뮬레이션 전용
+    더미. 실제 asyncio.CancelledError를 테스트에서 직접 던지면 pytest-asyncio 자체의 태스크
+    취소 메커니즘과 얽힐 위험이 있어, 같은 계층(BaseException 서브클래스·Exception 아님)의
+    독립 클래스로 대체한다."""
+
+
+async def test_knowledge_search_base_exception_is_logged_and_reraised_not_swallowed(
+    client, fake_llm, monkeypatch, caplog
+):
+    """2보-a 핵심 회귀 — CancelledError류(BaseException, Exception 아님)는 `except
+    Exception`을 통과해 1보 래퍼가 조용히 놓쳤을 수 있다(1보 배포 후 재실측 무발화의 1급
+    단서). 이제는 로그로 잡되, 삼키지 않고 재전파해야 한다(취소 시맨틱 보존)."""
+
+    def _boom(vector, top_k=3):
+        raise _SimulatedNonExceptionFailure("simulated CancelledError-class failure")
+
+    monkeypatch.setattr(execution_tasks_module, "search", _boom)
+    fake_llm.classify_text = "inquiry"
+    fake_llm.call_tool_name = "knowledge_search"
+    fake_llm.call_tool_kwargs = {"query": "팀원을 초대하려면?"}
+    fake_llm.interaction_text = "안내드릴게요."
+
+    # starlette/anyio가 ASGI 호출 경로 어딘가에서 구조적 동시성(TaskGroup)을 쓰면 우리 예외가
+    # BaseExceptionGroup으로 포장될 수 있다 — 어느 쪽이든 "삼켜지지 않고 나갔다"만 확인한다.
+    with caplog.at_level(logging.ERROR, logger="app.interaction"), pytest.raises(BaseException) as exc_info:
+        await _post_message(client)
+
+    raised = exc_info.value
+    if isinstance(raised, BaseExceptionGroup):
+        assert any(isinstance(e, _SimulatedNonExceptionFailure) for e in raised.exceptions)
+    else:
+        assert isinstance(raised, _SimulatedNonExceptionFailure)
+
+    assert any(
+        "BaseException" in record.message and record.exc_info is not None for record in caplog.records
+    ), "BaseException 로그가 재전파 前에 안 찍힘"
+
+
+async def test_knowledge_search_emits_stderr_tool_trace_lines(client, fake_llm, monkeypatch, capsys):
+    """logging 설정 불확실성 우회용 stderr 직접 print — 진입/정상반환 두 지점 다 찍히는지.
+    search()는 명시적으로 빈 매치로 몽키패치 — FakeLLMClient.embed()가 돌려주는 3차원 더미
+    벡터([0.1,0.2,0.3])는 실 gemini-embedding-001 3072차원 embeddings.json과 안 맞아 그대로
+    두면 이 테스트가 "정상 반환"이 아니라 우연히 예외 경로를 타 버린다(실측 중 발견)."""
+    monkeypatch.setattr(execution_tasks_module, "search", lambda vector, top_k=3: [])
+    fake_llm.classify_text = "inquiry"
+    fake_llm.call_tool_name = "knowledge_search"
+    fake_llm.call_tool_kwargs = {"query": "팀원을 초대하려면?"}
+    fake_llm.interaction_text = "안내드릴게요."
+
+    resp = await _post_message(client)
+    assert resp.status_code == 200
+
+    captured = capsys.readouterr()
+    assert "[tool-trace] knowledge_search 진입" in captured.err
+    assert "[tool-trace] knowledge_search 정상 반환" in captured.err
 
 
 async def test_tool_failure_honest_message_has_no_fabrication_markers():


### PR DESCRIPTION
[SID:3262]

## 배경
1보(PR#3653, logger.exception 래핑) 배포 후(리비전 00009) 페드루 PO 재실측 — **로그 흔적 0인 채 도구 실패가 그대로 재현**됐다(Q1 팀원초대=번호목록 형식 날조로 브레드크럼 정규식 회피, Q2 무료플랜인원=여전히 SDK 삼킴 문구). 로컬 제거 행렬(SDK 2.20.0·SA 토큰·uvloop·py3.12+uvloop 전부)은 완주 — 실패는 실 Cloud Run 프로세스에서만 재현.

이 "무발화" 자체가 2보의 1급 단서. 페드루 PO가 세 갈래로 좁힘:
1. CancelledError류(BaseException, Exception 아님)가 `except Exception`을 통과
2. SDK가 도구를 디스패치조차 못 함(예외가 도구 밖 SDK 층)
3. logging이 실제로 stderr/Cloud Logging에 안 닿음

## 이 PR (2보-a — 계측 확장, 아직 근본수정 아님)
세 갈래를 한 번의 배포로 가르는 계측:

- `app/interaction.py`: 세 도구(`knowledge_search`/`org_status_lookup`/`escalate`) 전부 `except Exception` 뒤에 `except BaseException`을 추가 — CancelledError류는 삼키지 않고 로그 후 **re-raise**(취소 시맨틱 보존, Exception 하위만 정직 폴백으로 삼킴). 각 도구 진입/성공/예외 지점에 `print(..., file=sys.stderr, flush=True)` 직접 삽입("[tool-trace]" 접두 — logging 설정 불확실성을 완전히 우회).
- `app/vertex_client.py::generate_with_tools`: SDK 자체의 `resp.automatic_function_calling_history`(SDK가 "도구에 무슨 일이 있었다고 믿는지"의 원장 — 함수콜/응답/에러가 그대로 담김)를 통째로 `logger.info`+stderr에 남김.

## 검증
- 신규 테스트: BaseException이 삼켜지지 않고 재전파되는지(로그 찍힌 후) 회귀, stderr 트레이스 라인 존재 확인.
- 전체 스위트 59건 그린(신규 테스트 작성 중 `FakeLLMClient.embed()`의 3차원 더미벡터가 실 embeddings.json(3072차원)과 안 맞아 우연히 예외 경로를 타던 것도 발견·수정 — 결정론화).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>