### PR TITLE
[SID:3260] 지원 위젯 라이브 재검 FAIL 3축 처방 — CSP·재시도 스톰·모바일 겹침

### DIFF
--- a/apps/web/next.config.test.ts
+++ b/apps/web/next.config.test.ts
@@ -5,7 +5,7 @@
 // (story #2050) — media-src만 빠져 있었던 것을 여기서 고정한다.
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const CONFIG_SOURCE = readFileSync(path.resolve(__dirname, 'next.config.ts'), 'utf-8');
 
@@ -48,5 +48,48 @@ describe('CSP frame-src (story #2809 regression guard)', () => {
 
   it('does not blanket-open storage.googleapis.com (GCS는 임의 콘텐츠를 끼울 수 있어 exact-origin allowlist 부적합 — toss-checkout 선례)', () => {
     expect(extractDirective('frame-src')).not.toContain('storage.googleapis.com');
+  });
+});
+
+// story #3260 2차(유나 design 라이브 실측 FAIL, 2026-08-31) — CORS(서버측 허용)는 이미
+// 열려있었는데 이 앱 자체의 CSP connect-src(문서측 outbound 제한)가 별개 층이라 위젯의
+// 브라우저 직접 fetch가 fetch를 보내기도 전에 막혔다. 위 파일의 static-source-regex
+// 방식(extractDirective)은 connect-src가 이제 env 기반 계산식이라 못 잡는다 — 실제로
+// 다른 env로 모듈을 재평가해 결과 헤더값을 대조한다.
+describe('CSP connect-src — Support Gateway origin (story #3260 2차 회귀가드)', () => {
+  const ENV_KEY = 'NEXT_PUBLIC_SUPPORT_GATEWAY_URL';
+  const original = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = original;
+  });
+
+  async function cspHeaderValue(): Promise<string> {
+    vi.resetModules();
+    const mod = await import('./next.config');
+    const config = mod.default as { headers?: () => Promise<Array<{ headers: Array<{ key: string; value: string }> }>> };
+    const groups = await config.headers!();
+    return groups[0]!.headers.find((h) => h.key === 'Content-Security-Policy')!.value;
+  }
+
+  it('NEXT_PUBLIC_SUPPORT_GATEWAY_URL이 설정되면 그 origin이 connect-src에 실린다(위젯 fetch가 CSP에 막히던 실사고 회귀가드)', async () => {
+    process.env[ENV_KEY] = 'https://support-gateway-dev-57iommnikq-du.a.run.app';
+    const csp = await cspHeaderValue();
+    expect(csp).toContain('https://support-gateway-dev-57iommnikq-du.a.run.app');
+  });
+
+  it('미설정(prod류 — 위젯 자체가 안 뜨는 빌드)이면 하드코딩 origin 없이 connect-src가 원래 값 그대로다', async () => {
+    delete process.env[ENV_KEY];
+    const csp = await cspHeaderValue();
+    expect(csp).not.toContain('run.app');
+    expect(csp).toContain("connect-src 'self' https://*.googleapis.com https://*.tosspayments.com");
+  });
+
+  it('URL로 파싱 안 되는 값이면 CSP 문법을 깨지 않고 안전하게 무시한다(정직한 부재 취급)', async () => {
+    process.env[ENV_KEY] = 'not-a-valid-url';
+    const csp = await cspHeaderValue();
+    expect(csp).toContain("connect-src 'self' https://*.googleapis.com https://*.tosspayments.com");
+    expect(csp).not.toContain('not-a-valid-url');
   });
 });

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,6 +4,24 @@ import path from 'path';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
+// story #3260 2차(유나 design 라이브 실측 FAIL, 2026-08-31) — 지원 위젯이 Support
+// Gateway를 브라우저에서 직접 호출(BFF 프록시 없음, gateway-client.ts)하는데, CORS(story
+// #3242/#3649·서버측 "누구를 받아줄지" 허용)를 열어도 이 앱 자체의 CSP connect-src("우리
+// 문서가 어디로 나갈 수 있는지" 허용)가 별개 층이라 브라우저가 fetch 자체를 보내기도
+// 전에 차단했다(콘솔 실측: "violates CSP directive: connect-src"). NEXT_PUBLIC_
+// SUPPORT_GATEWAY_URL(cloudbuild.yaml·Dockerfile 배선, story #3260 1차)이 이미 진실원
+// (dev만 실 URL·prod는 빈 문자열)이라 그대로 파생한다 — dev/prod origin을 여기 하드코딩
+// 하지 않는다(그 값 자체가 두 번째 SSOT가 되는 함정 회피).
+const _SUPPORT_GATEWAY_CSP_ORIGIN = (() => {
+  const raw = process.env['NEXT_PUBLIC_SUPPORT_GATEWAY_URL'];
+  if (!raw) return null; // 미설정(prod·위젯 미노출 빌드)이면 CSP도 그대로 안 연다.
+  try {
+    return new URL(raw).origin;
+  } catch {
+    return null; // 정직한 값 부재 취급 — CSP 문법을 깨느니 안 여는 쪽이 안전측.
+  }
+})();
+
 const _CSP = [
   "default-src 'self'",
   // story #2510 — Toss 결제위젯 SDK(js.tosspayments.com)가 script-src에 없으면 카드
@@ -15,8 +33,13 @@ const _CSP = [
   "img-src 'self' data: blob: https://storage.googleapis.com https://*.googleusercontent.com https://avatars.githubusercontent.com",
   "font-src 'self' data:",
   // API 호출 (self = Next.js rewrites 경유, googleapis = Cloud KMS/AI, tosspayments = 결제
-  // 위젯 SDK 자체 통신 — story #2510)
-  "connect-src 'self' https://*.googleapis.com https://*.tosspayments.com",
+  // 위젯 SDK 자체 통신 — story #2510). Support Gateway origin은 위 상수 참고 — 브라우저가
+  // 직접 호출하는 유일한 비-self API 오리진(다른 모든 데이터 fetch는 Next.js BFF 프록시
+  // 경유라 'self'로 충분, 위젯만 예외).
+  [
+    "connect-src 'self' https://*.googleapis.com https://*.tosspayments.com",
+    _SUPPORT_GATEWAY_CSP_ORIGIN,
+  ].filter(Boolean).join(' '),
   // story #2083 — 채팅 첨부 영상(GCS 서명 URL)이 <video>로 로드될 때 media-src에
   // storage.googleapis.com이 없어 CSP가 통째로 차단하고 있었다(콘솔 실측). img-src에는
   // 이미 같은 호스트가 허용돼 있다(story #2050, 서명 URL·노출 축 동일) — 새 origin을

--- a/apps/web/src/components/support-widget/support-widget-launcher.effect-deps.test.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.effect-deps.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+//
+// story #3260 2차 finding(2026-08-31, 유나 라이브 실측 FAIL — 재시도 스톰) — 근본원인은
+// launcher의 mount effect가 `[open, session]` deps였던 것: session(useSupportWidgetSession()
+// 반환 객체)이 status 변화마다 새 참조가 되므로, session 참조가 바뀔 때마다 effect가
+// 재발화해 connect()를 다시 불렀다. support-widget-launcher.test.tsx의 호출횟수 pin은 이걸
+// 실 훅+1초 백오프 조합으로 검증하는데, 백오프가 "session이 바뀌어도 재호출이 실제
+// side-effect(state 변화)를 안 내면 추가 재발화가 없다"는 우연한 상호작용으로 재시도를
+// 가려버려(리버트해서 직접 확認 — 효과 deps를 되돌려도 백오프만으로 이 테스트는 green이었다),
+// 이 fix 자체를 단독으로 겨냥하는 회귀가드가 못 된다. 이 파일은 그 갭을 닫는다 — 훅을
+// 통째로 목해 매 렌더 새 session 객체를 강제로 만들어내고(백오프 로직 자체가 실행되지
+// 않음), 그 상태에서 connect가 몇 번 불리는지를 직접 잰다. deps가 [open, session]으로
+// 되돌아가면 이 테스트가 렌더 횟수만큼 connect가 불려 반드시 red가 된다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { SidebarProvider } from '@/components/ui/sidebar';
+import type { SupportWidgetSession } from '@/hooks/use-support-widget-session';
+import { SupportWidgetLauncher } from './support-widget-launcher';
+
+const connectMock = vi.fn();
+let renderCount = 0;
+
+vi.mock('@/hooks/use-support-widget-session', () => ({
+  // 매 호출마다 새 객체 리터럴 — 실 훅이 status 변화 시 하던 것과 동일한 "참조 불안정"을
+  // 무조건 재현한다(백오프·async 타이밍 전부 우회, effect deps 자체만 겨냥). vi.mock은
+  // vitest가 파일 최상단으로 호이스트하므로 이 아래의 static import보다 먼저 적용된다.
+  useSupportWidgetSession: (): SupportWidgetSession => {
+    renderCount += 1;
+    return {
+      status: 'error',
+      messages: [],
+      sending: false,
+      sendError: null,
+      connect: connectMock,
+      sendMessage: vi.fn(async () => {}),
+      retryLastMessage: vi.fn(),
+    };
+  },
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  connectMock.mockReset();
+  renderCount = 0;
+  vi.stubGlobal('localStorage', {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+    clear: () => {},
+  });
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+async function mount() {
+  await act(async () => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <SidebarProvider>
+          <SupportWidgetLauncher />
+        </SidebarProvider>
+      </NextIntlClientProvider>,
+    );
+  });
+}
+
+describe('SupportWidgetLauncher — mount effect는 session 참조 변경에 반응하지 않는다(회귀가드)', () => {
+  it('open 그대로인 채 session이 매 렌더 새 참조여도(훅을 통째로 목해 강제 재현) connect는 딱 1번만 불린다', async () => {
+    await mount();
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); }); // open
+    const rendersAfterOpen = renderCount;
+    expect(rendersAfterOpen).toBeGreaterThan(0);
+
+    // open을 그대로 둔 채 강제로 여러 번 더 렌더시킨다(부모 재렌더 시뮬레이션) — 매번
+    // useSupportWidgetSession()이 다시 불려 새 session 객체가 나온다(목의 설계 그대로).
+    for (let i = 0; i < 5; i++) {
+      await act(async () => {
+        root.render(
+          <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+            <SidebarProvider>
+              <SupportWidgetLauncher />
+            </SidebarProvider>
+          </NextIntlClientProvider>,
+        );
+      });
+    }
+    expect(renderCount).toBeGreaterThan(rendersAfterOpen); // 실제로 더 렌더됐다(테스트 유효성 확認)
+    expect(connectMock).toHaveBeenCalledTimes(1); // effect deps가 [open]이라 재발화 없음
+  });
+});

--- a/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
@@ -13,6 +13,26 @@ import koMessages from '../../../messages/ko.json';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { SupportWidgetLauncher } from './support-widget-launcher';
 
+// story #3260 2차 finding(유나 라이브 실측 FAIL — 재시도 스톰, 2026-08-31) 회귀가드용 —
+// isSupportGatewayConfiguredMock 기본값은 false(기존 테스트 전부가 'unavailable'을 가정
+// — 이 목이 파일 전체에 적용돼도 회귀 0). 스톰 테스트 describe만 true로 뒤집는다.
+const isSupportGatewayConfiguredMock = vi.fn(() => false);
+const createOrResumeGatewaySessionMock = vi.fn();
+vi.mock('@/lib/support-widget/gateway-client', () => ({
+  isSupportGatewayConfigured: () => isSupportGatewayConfiguredMock(),
+  createOrResumeGatewaySession: (...args: unknown[]) => createOrResumeGatewaySessionMock(...args),
+  listGatewayMessages: vi.fn(),
+  sendGatewayMessage: vi.fn(),
+}));
+
+// story #3260 3차 finding(선생님 실기기 적발→유나 design 확定, 2026-08-31) — 모바일 채팅-상세
+// (/chats/{id})에서만 런처를 숨긴다. 기본값은 chats/layout.test.tsx의 isListRoute 판정과
+// 무관한 일반 라우트로 둬서(기존 테스트 전부가 "런처는 언제나 뜬다"를 가정) 회귀 0.
+const usePathnameMock = vi.fn(() => '/board');
+vi.mock('next/navigation', () => ({
+  usePathname: () => usePathnameMock(),
+}));
+
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 let container: HTMLDivElement;
@@ -38,6 +58,9 @@ beforeEach(() => {
   root = createRoot(container);
   stubLocalStorage();
   setInnerWidth(1280); // 데스크톱 기본값(각 데스크톱 테스트가 이 값을 가정)
+  isSupportGatewayConfiguredMock.mockReset().mockReturnValue(false);
+  createOrResumeGatewaySessionMock.mockReset();
+  usePathnameMock.mockReset().mockReturnValue('/board');
 });
 
 afterEach(async () => {
@@ -151,5 +174,100 @@ describe('SupportWidgetLauncher — story #3260 2차: 사이드바 실 폭 기�
     await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     const panel = container.querySelector('[role="dialog"]') as HTMLElement;
     expect(panel.style.left).toBe('272px');
+  });
+});
+
+// story #3260 2차 finding(2026-08-31, 유나 라이브 실측 FAIL) — CSP가 Gateway fetch를
+// 막는 상황(즉시·동기에 가깝게 실패)에서 connect()가 4초에 87회(~22/s) 발화했다. 원인은
+// launcher의 mount effect가 [open, session] deps라 session(훅 반환 객체, status 변경마다
+// 새 참조)이 바뀔 때마다 재발화했던 것 — deps를 [open]으로 좁혀 open 전이 1회만 부르게
+// 고쳤다(+훅 쪽 1초 백오프는 2차 방어). 여기서는 실패가 반복돼도 시도 자체가 1회로
+// 그치는지를 호출 횟수로 직접 고정한다(회귀 시 이 숫자가 바로 커진다 — 재발이 red가 되는
+// 구조).
+describe('SupportWidgetLauncher — story #3260 2차: 재시도 스톰 회귀가드', () => {
+  it('connect()가 계속 실패해도(예: CSP 차단) 열려있는 동안 세션 발급 시도는 1회로 그친다', async () => {
+    isSupportGatewayConfiguredMock.mockReturnValue(true);
+    createOrResumeGatewaySessionMock.mockRejectedValue(new Error('Refused to connect: violates CSP directive'));
+    await mount();
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    // 실패 후 status가 'error'로 바뀌며 훅 반환 객체가 새 참조가 되는 렌더가 몇 차례
+    // 더 도는데, 그 렌더들 자체가 재시도를 유발하지 않아야 한다.
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain(koMessages.supportWidget.errorTitle);
+    expect(createOrResumeGatewaySessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('닫았다 곧바로 다시 열어도(1초 백오프 안) — 훅의 2차 방어가 여전히 막아 1회 그대로다', async () => {
+    isSupportGatewayConfiguredMock.mockReturnValue(true);
+    createOrResumeGatewaySessionMock.mockRejectedValue(new Error('network down'));
+    await mount();
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); }); // open
+    await act(async () => { await Promise.resolve(); });
+    await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); }); // close
+    await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); }); // reopen(즉시)
+    await act(async () => { await Promise.resolve(); });
+    expect(createOrResumeGatewaySessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('백오프 창(1초)이 지난 뒤 다시 열면(정당한 사용자 재시도) — 2번째 호출이 나온다', async () => {
+    vi.useFakeTimers();
+    try {
+      isSupportGatewayConfiguredMock.mockReturnValue(true);
+      createOrResumeGatewaySessionMock.mockRejectedValue(new Error('network down'));
+      await mount();
+      const btn = container.querySelector('button') as HTMLButtonElement;
+      await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); }); // open
+      await act(async () => { await Promise.resolve(); });
+      await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); }); // close
+      await act(async () => { vi.advanceTimersByTime(1100); }); // 백오프 창 경과
+      await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); }); // reopen
+      await act(async () => { await Promise.resolve(); });
+      expect(createOrResumeGatewaySessionMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// story #3260 3차 finding(2026-08-31, 선생님 실기기 적발→유나 design 확定) — 모바일 채팅
+// 상세(/chats/{id})는 자체 하단 첨부/전송 아이콘 열이 있어 런처(bottom-20 left-5)가 그 위에
+// 그대로 겹쳤다(실기기 스크린샷 실증, entity:artifact:13c9e4cb). 리스트(/chats, id 없음)는
+// 그 열이 없어 무관 — chats/layout.tsx의 isListRoute = pathname === '/chats' 판정과 대칭.
+// 페드루 PO 발주 pin 3종: 모바일 상세=DOM 0 / 모바일 리스트·보드=기존 그대로 / 데스크톱=라우트
+// 무관 불변.
+describe('SupportWidgetLauncher — story #3260 3차: 모바일 채팅-상세 숨김', () => {
+  it('모바일 + 채팅-상세(/chats/conv-123) — 런처 DOM 자체가 없다(겹침 원천 차단)', async () => {
+    setInnerWidth(500);
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    await mount();
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('모바일 + 채팅-리스트(/chats, id 없음) — 기존처럼 bottom-20에 그대로 뜬다', async () => {
+    setInnerWidth(500);
+    usePathnameMock.mockReturnValue('/chats');
+    await mount();
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    expect(btn.className).toContain('bottom-20');
+  });
+
+  it('모바일 + 채팅과 무관한 라우트(/board) — 기존처럼 그대로 뜬다(채팅-상세만 예외)', async () => {
+    setInnerWidth(500);
+    usePathnameMock.mockReturnValue('/board');
+    await mount();
+    expect(container.querySelector('button')).toBeTruthy();
+  });
+
+  it('데스크톱 — 채팅-상세 라우트여도 사이드바 폭+16px 배치가 그대로다(데스크톱은 스플릿뷰라 무관)', async () => {
+    setInnerWidth(1280);
+    usePathnameMock.mockReturnValue('/chats/conv-123');
+    await mount();
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    expect(btn.style.left).toBe('272px'); // 256(기본 사이드바 폭)+16
   });
 });

--- a/apps/web/src/components/support-widget/support-widget-launcher.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { LifeBuoy, X } from 'lucide-react';
 import { useSidebar } from '@/components/ui/sidebar';
@@ -45,16 +46,41 @@ const DESKTOP_SIDEBAR_GAP_PX = 16;
  * 다시 겹치는 "폭 가변" 함정) — `useSidebar()`가 그 실시간 폭을 그대로 노출하므로 정적 추정
  * 대신 이 값을 직접 소비한다. `collapsible="offcanvas"`(app-sidebar.tsx)라 collapsed 상태는
  * 사이드바가 화면 밖으로 완전히 밀려나(가시 폭 0) 별도 처리 불요 — left-5 그대로 안전.
+ *
+ * ⚠️story #3260 3차 finding(2026-08-31, 선생님 실기기 적발→유나 design 확定) — 모바일
+ * 채팅-상세 화면(`/chats/{id}`)은 자체 하단 첨부/전송 아이콘 열이 있어, 이 런처(bottom-20
+ * left-5)가 그 위에 그대로 겹쳤다(실기기 스크린샷 실증). `/chats`(id 없는 리스트)는 그런
+ * 하단 열이 없어 겹치지 않는다 — 그래서 "모바일 전체 숨김"이 아니라 **채팅-상세 라우트에서만**
+ * render null 한다(데스크톱은 스플릿뷰라 리스트+상세가 항상 같이 보여 무관, chats/layout.tsx의
+ * `isListRoute = pathname === '/chats'` 판정과 대칭 — 상세는 그 나머지 `/chats/*`).
  */
 export function SupportWidgetLauncher() {
   const t = useTranslations('supportWidget');
   const [open, setOpen] = useState(false);
   const session = useSupportWidgetSession();
   const { isMobile, state: sidebarState, width: sidebarWidth } = useSidebar();
+  const pathname = usePathname();
+  const isMobileChatDetailRoute = isMobile && pathname !== '/chats' && pathname.startsWith('/chats/');
 
+  // ⚠️story #3260 2차 finding(2026-08-31, 유나 라이브 실측 FAIL — 재시도 스톰) — 이 effect가
+  // 예전엔 [open, session] deps였다. session은 status가 바뀔 때마다(connect()가 실패해
+  // 'error'로 떨어질 때 포함) useSupportWidgetSession()의 useMemo가 새 객체를 반환하므로,
+  // session 참조 변경 자체가 이 effect를 재발화시켜 connect()를 다시 불렀다 — CSP가 Gateway
+  // fetch를 막는 상황에서는 그 실패가 즉시(네트워크 왕복 없이) 나므로 "실패→재발화→재시도"가
+  // 사실상 동기 루프로 돌아 4초에 87회(~22/s)를 쳤다(POST /api/support/session-token 실측).
+  // 처방: deps를 `open` 하나로 좁히고, connect의 "최신 함수"는 ref로 우회 참조한다 — 이러면
+  // open이 실제로 false→true로 바뀔 때만 1회 호출되고, 내부 상태(status) 변화로는 절대
+  // 재발화하지 않는다('error' 이후 재시도는 패널의 명시 "다시 연결하기" 버튼(session.connect()
+  // 직접 호출)으로만 — 사용자 행동 1회=시도 1회, 자동 루프 0). 훅 쪽에도 최소시도간격(1초)
+  // 백오프를 별도로 걸어둔다(use-support-widget-session.ts) — 이 effect 밖의 다른 호출
+  // 경로가 생겨도 스톰이 구조적으로 재발 못 하게 하는 2중 방어.
+  const connectRef = useRef(session.connect);
   useEffect(() => {
-    if (open) session.connect();
-  }, [open, session]);
+    connectRef.current = session.connect;
+  });
+  useEffect(() => {
+    if (open) connectRef.current();
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -64,6 +90,11 @@ export function SupportWidgetLauncher() {
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [open]);
+
+  // 모든 hook 호출 뒤에만 조건부 반환한다(hook 호출 순서는 렌더마다 불변이어야 하는 React
+  // 규칙) — 모바일 채팅-상세에서는 통째로 숨긴다(패널이 열려있었다면 그것도 함께 사라짐,
+  // 겹치는 화면 자체를 안 그리는 게 옳다).
+  if (isMobileChatDetailRoute) return null;
 
   // 모바일: 사이드바가 화면 폭을 안 먹어 기본 left-5(className) 그대로 — style override 없음.
   // 데스크톱·사이드바 열림: 실 폭(리사이즈 반영) + 여백만큼 오른쪽으로.

--- a/apps/web/src/hooks/use-support-widget-session.ts
+++ b/apps/web/src/hooks/use-support-widget-session.ts
@@ -78,11 +78,21 @@ export function useSupportWidgetSession(): SupportWidgetSession {
   const sessionIdRef = useRef<string | null>(null);
   const connectingRef = useRef(false);
   const lastFailedContentRef = useRef<string | null>(null);
+  // story #3260 2차 finding(유나 라이브 실측 FAIL — 재시도 스톰, 2026-08-31) — 호출부
+  // (support-widget-launcher.tsx)의 effect deps 축소가 1차 방어. 이건 2차 방어(백오프) —
+  // connect()를 부르는 다른 경로가 미래에 또 생겨도, 최근 시도로부터 이 시간 안이면
+  // 무조건 no-op(네트워크를 새로 안 태움). CSP 차단처럼 즉시 실패하는 케이스는 재시도
+  // 간격이 사실상 0이 될 수 있어(왕복 지연 없음) 이 가드가 없으면 순수 동기 루프가 된다.
+  const lastAttemptAtRef = useRef(0);
+  const MIN_RETRY_INTERVAL_MS = 1000;
 
   const connect = useCallback(() => {
     // Gateway 자체가 이 빌드에 안 붙어있음 — 정직한 'unavailable' 유지, 재시도할 대상이 없다.
     if (!isSupportGatewayConfigured()) return;
     if (connectingRef.current || status === 'ready') return;
+    const now = Date.now();
+    if (now - lastAttemptAtRef.current < MIN_RETRY_INTERVAL_MS) return;
+    lastAttemptAtRef.current = now;
     connectingRef.current = true;
     setStatus('connecting');
     setSendError(null);


### PR DESCRIPTION
## 배경
[\[지원v1·2위젯\] 인앱 문의 위젯 셸](entity:story:263f3414-edbc-4d65-8d56-3c8b301ab9d2) — 통합 PR#3652 머지 후 유나 design 최종 라이브 왕복 **FAIL**(entity:artifact:9e4a87a1) + 선생님 실기기 적발 후속(entity:artifact:13c9e4cb). 페드루 PO 발주대로 세 축 전부 한 PR로 묶어 라이브 재검을 한 번에 닫는다.

## 축1(블로커) CSP connect-src 차단
CORS(#3242/#3649 — 서버측 "누구를 받아줄지" 허용)를 열어도 이 앱 자체의 CSP `connect-src`(`next.config.ts`, "우리 문서가 어디로 나갈 수 있는지")가 별개 층이라 위젯의 브라우저 직접 fetch가 나가기도 전에 막혔다(콘솔 실측: `violates CSP directive: connect-src`).

처방: `NEXT_PUBLIC_SUPPORT_GATEWAY_URL`(story #3260 1차에서 이미 진실원 — dev만 실 URL·prod는 빈 문자열)에서 origin을 파생해 `connect-src`에 주입. dev/prod를 여기 하드코딩하지 않는다. URL이 없거나 파싱 불가면 그대로 미개방(정직한 부재 취급). `next.config.test.ts` 3케이스 추가 — 모듈을 실제로 다른 env로 재평가해 결과 헤더값을 대조(static-source-regex로는 env 기반 계산식을 못 잡음).

## 축2(FE 결함) 재시도 스톰
`connect()`가 `'error'` 재진입을 안 막아 launcher의 mount effect(`[open, session]` deps)가 session 참조 변경(status 바뀔 때마다 새 객체)마다 재발화 → `POST /api/support/session-token` 4초에 87회(~22/s).

처방(2중): ① launcher effect deps를 `[open]`으로 좁히고 connect의 "최신 함수"는 ref로 우회 참조 — open 전이 1회만 자동 호출, 내부 상태 변화로는 재발화 없음. ② 훅에 1초 백오프(2차 방어).

테스트: 호출횟수 pin + 신설 `support-widget-launcher.effect-deps.test.tsx`(훅을 통째로 목해 매 렌더 새 session 참조를 강제 재현 — 백오프/async 타이밍을 우회해 effect deps 자체만 겨냥). **자체 리버트 뮤테이션으로 확認**: 기존 pin 테스트는 백오프와 상호작용해 effect deps를 되돌려도 green이었던 걸 직접 발견했고, 이 신설 테스트가 그 갭을 닫는다(되돌리면 6회 호출로 red).

## 축3(디자인) 모바일 채팅-상세 겹침
선생님 실기기 적발 — 모바일 `/chats/{id}`는 자체 하단 첨부/전송 아이콘 열이 있어 런처(`bottom-20 left-5`)가 겹쳤다. `/chats`(리스트)는 그 열이 없어 무관.

처방: `usePathname()`으로 `/chats/*`(리스트 제외) + `isMobile`일 때만 render null. `chats/layout.tsx`의 기존 `isListRoute = pathname === '/chats'` 판정과 대칭. 데스크톱은 스플릿뷰라 라우트 무관 항상 렌더.

테스트 pin 3종(페드루 PO 발주): 모바일 상세=DOM 0 / 모바일 리스트·기타=기존처럼 렌더 / 데스크톱=라우트 무관 불변. 리버트 뮤테이션으로 확認(가드 제거 시 즉시 red).

## 검증
- FE 전체 `pnpm exec vitest run` → 549 files / 5099 tests passed(신규 8건).
- eslint 경고 0. `pnpm build` 성공.
- 축2·축3 둘 다 자체 리버트 뮤테이션 킬 확認(카디르 QA 방법론 선제 적용 — 재왕복 최소화 목적).

🤖 Generated with [Claude Code](https://claude.com/claude-code)