### PR TITLE
[SID:3260] 4차 finding — 전역 X-Project-Id/X-Org-Id 인터셉터 cross-origin 경계 누수

### DIFF
--- a/apps/web/src/lib/project-context-client.test.ts
+++ b/apps/web/src/lib/project-context-client.test.ts
@@ -158,6 +158,36 @@ describe('installProjectHeaderInterceptor — X-Project-Id 옆에 X-Org-Id가 �
     const [, init] = baseFetch.mock.calls[0] as [string, RequestInit | undefined];
     expect(init?.headers).toBeUndefined();
   });
+
+  // story #3260 4차 finding(2026-08-31, 유나 5축 라이브 재검) — 절대 URL이 path만 `/api/`로
+  // 시작하면 origin/host를 안 보고 same-origin 취급했다. Support Gateway(별도 Cloud Run,
+  // Bearer 위임토큰만 신뢰하는 경계 서비스)의 `https://support-gateway-dev-.../api/v1/
+  // sessions`가 정확히 이 모양이라, cross-origin인데도 X-Project-Id/X-Org-Id가 실려 나가
+  // Gateway CORS 프리플라이트(ACAH에 없는 헤더)가 400으로 거부했다.
+  it('회귀가드(4차) — cross-origin 절대 URL(path가 /api/로 시작해도)에는 컨텍스트 헤더를 안 싣는다(Gateway 경계 보존)', async () => {
+    setEffectiveProjectId('proj-1');
+    setEffectiveOrgId('org-1');
+    await window.fetch('https://support-gateway-dev-57iommnikq-du.a.run.app/api/v1/sessions', {
+      headers: { Authorization: 'Bearer delegated-token' },
+    });
+
+    const [, init] = baseFetch.mock.calls[0] as [string, RequestInit];
+    const headers = new Headers(init.headers);
+    expect(headers.has('X-Project-Id')).toBe(false);
+    expect(headers.has('X-Org-Id')).toBe(false);
+    expect(headers.get('Authorization')).toBe('Bearer delegated-token'); // 명시 헤더는 그대로 통과
+  });
+
+  it('양성대조 — 이 앱 자신을 절대 URL(같은 origin)로 명시해 불러도 여전히 주입된다(과교정 아님)', async () => {
+    setEffectiveProjectId('proj-1');
+    setEffectiveOrgId('org-1');
+    await window.fetch(`${window.location.origin}/api/projects`);
+
+    const [, init] = baseFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Headers;
+    expect(headers.get('X-Project-Id')).toBe('proj-1');
+    expect(headers.get('X-Org-Id')).toBe('org-1');
+  });
 });
 
 describe('resolveEffectiveOrgId (story #2873 — 0-프로젝트 org 전환 후 침묵 오배달 재발방지)', () => {

--- a/apps/web/src/lib/project-context-client.ts
+++ b/apps/web/src/lib/project-context-client.ts
@@ -87,6 +87,18 @@ let interceptorInstalled = false;
  *   스킵 — 명시 스코프를 덮지 않는다.
  * - story #2497 — 둘을 항상 «함께» 싣는다(하나만 실으면 멀티-org 유저에서 org_id가
  *   JWT stale org로 새는 이 fire의 정확한 재발 형태다).
+ *
+ * ⚠️story #3260 4차 finding(2026-08-31, 유나 5축 라이브 재검 — CSP 뚫린 뒤 드러난 층) — 이
+ * "same-origin" 전제가 실제로는 **path 모양만** 봤다: 절대 URL(`http...`)이면 `new
+ * URL(url).pathname`만 뽑아 `/api/`로 시작하는지만 확認하고, 그 URL의 **origin/host는
+ * 아예 확認하지 않았다**. Support Gateway(`https://support-gateway-dev-...run.app/api/v1/
+ * sessions`, gateway-client.ts가 raw fetch로 부름)의 pathname이 하필 `/api/`로 시작해
+ * 이 "same-origin" 인터셉터가 **cross-origin 요청에도** X-Project-Id/X-Org-Id를 실어
+ * 버렸다 — Gateway는 Bearer 위임토큰만 신뢰하는 경계 서비스라 그 헤더들을 CORS
+ * Access-Control-Allow-Headers에 안 뒀고(경계를 무르게 해서 통과시키는 처방은 페드루 PO가
+ * 명시 기각), 그래서 OPTIONS 프리플라이트가 400으로 거부돼 POST 자체가 ERR_FAILED 났다.
+ * 처방: origin도 함께 확認해 실제 **동일 출처**일 때만 주입한다(cross-origin 절대 URL은
+ * path가 뭘 닮았든 스킵).
  */
 export function installProjectHeaderInterceptor(): void {
   if (interceptorInstalled || typeof window === 'undefined') return;
@@ -97,11 +109,15 @@ export function installProjectHeaderInterceptor(): void {
     try {
       if (typeof input === 'string' || input instanceof URL) {
         const url = typeof input === 'string' ? input : input.href;
-        const path = url.startsWith('http') ? new URL(url).pathname : url.split('?')[0];
+        const isAbsolute = /^https?:\/\//.test(url);
+        // 절대 URL이면 origin까지 파싱해 실제 동일 출처인지 확認한다 — path 모양(`/api/...`)만
+        // 보고 판단하면 cross-origin 서비스(예: Support Gateway)에도 새 나간다(위 finding).
+        const sameOrigin = !isAbsolute || new URL(url).origin === window.location.origin;
+        const path = isAbsolute ? new URL(url).pathname : url.split('?')[0];
         const projectId = effectiveProjectIdRef.current;
         const orgId = effectiveOrgIdRef.current;
         // 컨텍스트 제어 엔드포인트(`/api/switch-*`)는 자체 컨텍스트를 관리하므로 주입 제외.
-        const isApi = path.startsWith('/api/') && !path.startsWith('/api/switch-');
+        const isApi = sameOrigin && path.startsWith('/api/') && !path.startsWith('/api/switch-');
         if (isApi && projectId) {
           const headers = new Headers(init?.headers);
           if (!headers.has('X-Project-Id') && !headers.has('X-Org-Id')) {


### PR DESCRIPTION
## 배경
[\[지원v1·2위젯\] 인앱 문의 위젯 셸](entity:story:263f3414-edbc-4d65-8d56-3c8b301ab9d2) — PR#3655(3축 처방) 머지 후 유나 5축 라이브 재검에서 CSP가 뚫리자 다음 층이 드러났다: Support Gateway로 나가는 POST가 OPTIONS 프리플라이트에서 400으로 거부.

## 근본원인
`gateway-client.ts`는 raw fetch인데도 요청에 `X-Project-Id`/`X-Org-Id`가 실려 있었다. `project-context-client.ts`의 전역 `window.fetch` 인터셉터(`installProjectHeaderInterceptor`)가 "same-origin `/api/*`" 판정을 **path 모양만** 봤다: 절대 URL이면 `new URL(url).pathname`만 뽑아 `/api/`로 시작하는지만 확認하고, **origin/host는 아예 안 봤다**. Support Gateway URL(`https://support-gateway-dev-.../api/v1/sessions`)의 pathname이 하필 `/api/`로 시작해, cross-origin 요청인데도 컨텍스트 헤더가 실렸다. Gateway는 Bearer 위임토큰만 신뢰하는 경계 서비스라 그 헤더들을 CORS `Access-Control-Allow-Headers`에 안 뒀고(의도된 경계), 그래서 프리플라이트가 거부됐다.

## 처방(페드루 PO 확定)
ⓐ FE 클린 fetch로 확정 — Gateway 쪽 allow-headers 확장(ⓑ)은 경계를 무르게 해서 기각. 절대 URL이면 origin까지 파싱해 `window.location.origin`과 실제로 같을 때만 same-origin 취급한다. cross-origin 절대 URL은 path가 무엇을 닮았든 스킵.

## 영향 범위 주의
이 인터셉터는 전역 `window.fetch` 패치(앱 전체 fetch가 통과) — 회귀 위험이 커서 FE 전체 스위트(549 files/5101 tests)를 재통과시켰다. 기존 5건 무회귀, 신규 2건 추가.

## 테스트(페드루 PO 발주 pin 2종)
① cross-origin 절대 URL(path가 `/api/`를 닮아도) — 컨텍스트 헤더 부재, 명시 `Authorization`은 그대로 통과. ② 양성대조 — 이 앱 자신을 절대 URL(같은 origin)로 불러도 여전히 주입(과교정 아님). 둘 다 리버트 뮤테이션으로 직접 확認(되돌리면 ①이 red).

## 검증
- FE 전체 `pnpm exec vitest run` → 549 files / 5101 tests passed.
- eslint 경고 0. `pnpm build` 성공.

🤖 Generated with [Claude Code](https://claude.com/claude-code)