### PR TITLE
[SID:3262] 근인 확定 & 수정(2보-b) — future-import가 AFC 도구 디스패치 붕괴

### DIFF
--- a/support-gateway/app/interaction.py
+++ b/support-gateway/app/interaction.py
@@ -6,8 +6,21 @@ customer 메시지(이미 저장됨, app/routers/sessions.py) → 인입 분류�
 스폰·지휘, Blueprint §1.1/§1.2) → 응답 저장 → 메모리 압축 트리거(AC3).
 
 이 함수는 라우터(app/routers/sessions.py)가 호출하는 유일한 진입점 — 라우터는 이 안의
-어떤 세부사항(분류기·비용상한·Vertex AFC)도 몰라도 된다."""
-from __future__ import annotations
+어떤 세부사항(분류기·비용상한·Vertex AFC)도 몰라도 된다.
+
+⛔`from __future__ import annotations`(PEP 563)를 이 파일에 절대 넣지 않는다 — story #3262
+2보-b 근인 확定(2026-08-31, 페드루 PO+디디 교차실측): PEP 563이 이 모듈의 함수 어노테이션을
+전부 지연 평가 문자열로 바꾸면, `_make_tools`가 만드는 도구 클로저(knowledge_search 등)의
+`inspect.signature(...).parameters[...].annotation`도 문자열이 된다. google-genai SDK
+2.20.0의 실제 인자변환 경로(`google.genai._extra_utils.convert_argument_from_function` →
+`convert_if_exist_pydantic_model`)는 그 값을 `typing.get_type_hints()`로 재해석하지 않고
+그대로 `isinstance(value, annotation)`에 넘겨 `TypeError`를 던진다 — **선언(스키마 생성)은
+멀쩡히 성공하지만(FunctionDeclaration.from_callable_with_api_option은 무사), 실 호출
+디스패치 단계에서만 조용히 깨진다**(SDK가 그 TypeError를 삼키고 도구를 아예 호출 안 한
+채 모델이 정형 사과문을 대신 생성 — 실사고 그대로). 로컬 A/B 실측(같은 클로저를
+future-import 있는/없는 모듈에 각각 심어 실 Vertex AFC 라운드트립)으로 재현·반증 완료 —
+tests/test_afc_argument_conversion_regression.py가 이 정확한 실패 클래스를 SDK 내부
+함수로 직접 고정한다(스키마 non-empty 검사로는 이 결함이 안 잡힌다 — 그 접근은 기각됨)."""
 
 import logging
 import sys

--- a/support-gateway/tests/test_afc_argument_conversion_regression.py
+++ b/support-gateway/tests/test_afc_argument_conversion_regression.py
@@ -1,0 +1,75 @@
+"""story #3262 2보-b — 근인 확定 회귀 가드(2026-08-31, 페드루 PO+디디 교차실측).
+
+**정확한 결함 클래스**: `app/interaction.py`에 `from __future__ import annotations`(PEP 563)가
+있으면 `_make_tools`가 만드는 도구 클로저의 파라미터 어노테이션이 지연평가 문자열이 된다.
+google-genai SDK 2.20.0의 실 인자변환 경로(`google.genai._extra_utils.
+convert_argument_from_function`)는 `inspect.signature(...).parameters[...].annotation`을
+그대로(문자열이어도 재해석 없이) `isinstance(value, annotation)`에 넘겨 `TypeError: isinstance()
+arg 2 must be a type...`를 던진다 — **선언(스키마 생성, `FunctionDeclaration.
+from_callable_with_api_option`)은 이 결함에서 멀쩡히 성공한다**(직접 실측 확認 — 그래서 "도구
+파라미터 스키마가 비어있지 않음"류 검사로는 이 결함이 안 잡힌다). 실 디스패치 단계에서만
+조용히 깨지고, SDK가 그 TypeError를 삼켜 도구가 아예 안 불리며 모델이 정형 사과문을 대신
+생성한다(2026-08-31 dev 3차 실측 실사고와 동일 서명).
+
+이 테스트는 SDK가 실제로 쓰는 그 변환 함수를 `app/interaction.py::_make_tools`가 만든 진짜
+클로저에 직접 태워, "인자가 정상 변환되는가"를 단언한다 — future-import가 이 파일에 재도입되면
+정확히 이 테스트가 RED로 떨어진다(실측으로 확認한 유일한 신뢰할 수 있는 회귀선)."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from google.genai._extra_utils import convert_argument_from_function
+
+from app.interaction import _make_tools
+
+
+class _NoopDB:
+    def add(self, *args, **kwargs):
+        pass
+
+
+def _build_tools():
+    return _make_tools(
+        _NoopDB(),
+        conversation_id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        escalation_state={"called": False},
+        knowledge_state={"called": False, "had_match": False},
+        llm=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "tool_name,args",
+    [
+        ("knowledge_search", {"query": "팀원을 초대하려면 어떻게 하나요?"}),
+        ("org_status_lookup", {"question": "우리 조직 플랜이 뭔가요?"}),
+        ("escalate", {"reason": "고객이 사람 연결을 요청함"}),
+    ],
+)
+def test_sdk_can_convert_tool_call_arguments_without_typeerror(tool_name, args):
+    """SDK가 모델의 function_call 인자를 실제로 도구에 전달하기 직전 단계 — 여기서
+    TypeError가 나면 도구가 절대 안 불린다(2026-08-31 실사고의 정확한 메커니즘)."""
+    tools = _build_tools()
+    tool = next(t for t in tools if t.__name__ == tool_name)
+
+    converted = convert_argument_from_function(args, tool)
+
+    assert converted == args
+
+
+def test_tool_parameter_annotations_are_real_types_not_deferred_strings():
+    """근인 그 자체를 직접 단언 — `from __future__ import annotations`가 이 파일에 재도입되면
+    `inspect.signature(...).annotation`이 문자열이 된다(str 타입 객체가 아니라 리터럴 "str").
+    위 SDK 변환 테스트보다 한 단계 더 근본적인 신호라 같이 고정해둔다."""
+    import inspect
+
+    tools = _build_tools()
+    for tool in tools:
+        for name, param in inspect.signature(tool).parameters.items():
+            assert isinstance(param.annotation, type), (
+                f"{tool.__name__}의 파라미터 {name!r} 어노테이션이 실 타입이 아니라 "
+                f"{param.annotation!r}({type(param.annotation).__name__}) — "
+                "app/interaction.py에 `from __future__ import annotations`가 있는지 확인하세요."
+            )


### PR DESCRIPTION
[SID:3262]

## 근인
페드루 PO 실측으로 갈래②(SDK가 도구를 디스패치조차 못 함) 확정, 범인=`app/interaction.py`의 `from __future__ import annotations`. 정확한 메커니즘을 교차실측으로 특정했다.

## 정밀화(페드루 PO 원 발주 대비 한 단계 더 파고든 부분)
**선언(스키마 생성)은 이 결함에서 멀쩡히 성공한다** — `FunctionDeclaration.from_callable_with_api_option`을 실 `_make_tools` 클로저에 직접 태워 확認. 즉 PO가 제안한 "도구 파라미터 스키마 non-empty" 회귀 테스트 설계는 **이 결함을 못 잡는다**(실측으로 반증 — WITH/WITHOUT future-import 둘 다 동일한 non-empty schema를 만든다).

실제 붕괴 지점은 인자 **변환/디스패치** 단계: google-genai 2.20.0의 `_extra_utils.convert_argument_from_function`이 `inspect.signature(...).annotation`을 `typing.get_type_hints()`로 재해석하지 않고 그대로 `isinstance(value, annotation)`에 넘긴다 — PEP 563이 annotation을 문자열(`"str"`)로 만들면 `TypeError: isinstance() arg 2 must be a type...`가 나고, SDK가 이 예외를 삼켜 도구를 아예 호출 안 한다.

실 Vertex A/B 라운드트립(같은 클로저를 future-import 있는/없는 모듈에 각각 심음)으로 재현·반증 완료 — WITH만 정확히 실사고와 동일한 "죄송합니다, 현재 시스템에 오류가 발생하여..." 정형 사과문을 생성, WITHOUT은 도구가 정상 호출돼 근거 답변을 냄.

## 수정
`app/interaction.py`에서 future-import 제거(파일 내 다른 어노테이션은 forward-ref 불요 — Python 3.12 네이티브 `X | None` 문법이라 안전). 재도입 절대 금지 주석 신설(정확한 메커니즘 설명 포함).

## 회귀 가드
`tests/test_afc_argument_conversion_regression.py` — SDK가 실제로 쓰는 `convert_argument_from_function`을 `_make_tools`의 진짜 클로저에 직접 태워 인자 변환이 TypeError 없이 성공하는지 단언. **RED→GREEN 자체검증 완료**: future-import를 일부러 재도입해 4건 전부 정확히 실 프로덕션 TypeError로 RED 떨어지는 것 확認 후 되돌림 — "이 회귀가 실제로 잡는다"를 스스로 증명.

## 검증
전체 support-gateway 스위트 63건 그린(신규 4건 포함).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>