### PR TITLE
[SID:3275] agent_project_profiles 행 부재 시 first_connected_at 무음 미기록 — self-heal

### DIFF
--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -304,7 +304,16 @@ async def sync_agent_profile_presence(session: AsyncSession, member_id: uuid.UUI
     `create_org_level_agent`가 생성 시 항상 세팅해 이 경로에서 NULL을 만날 수 없다)로
     `ensure_agent_project_profile`을 멱등 호출한 뒤 UPDATE를 1회만 재시도한다. 콜사이트 7곳
     (agent_gateway.py×3·team_members.py×3·agent_auth_failure.py×1) 전부를 고치는 대신 이 함수
-    내부에서 닫는 쪽이 더 좁은 경계(PO 확定)."""
+    내부에서 닫는 쪽이 더 좁은 경계(PO 확定).
+
+    ⛔카디르 QA 실사고(2026-09-01, PR#3664 1차) — `agent_project_profiles.member_id`의 실 FK
+    부모는 `team_members`가 아니라 `members`다. `team_members` 행은 있는데 `members` 행이
+    없는 에이전트(정상 생성 경로라면 안 생기지만, 기존 테스트 2개가 정확히 이 모양으로
+    실 SSE 경로 agent_gateway.py를 태운다)에서 위 team_member-존재 체크만으론 못 걸러
+    `ensure_agent_project_profile`의 INSERT가 FK 위반으로 그대로 크래시했다("무해한 0-row"를
+    "즉시 500"으로 악화). `members` 존재를 먼저 확認해 그 경우도 team_member 부재와 동형으로
+    로그만 남기고 조용히 반환한다 — "무음보다 시끄러운 실패가 낫다"는 로그로 시끄럽다는
+    뜻이지 엔드포인트가 죽어도 된다는 뜻이 아니다."""
     allowed = {"last_seen_at", "active_story_id", "agent_status"}
     upd = {k: v for k, v in fields.items() if k in allowed}
     if not upd:
@@ -328,6 +337,19 @@ async def sync_agent_profile_presence(session: AsyncSession, member_id: uuid.UUI
         # team_members 행 자체가 없다(고아 member_id) — self-heal 대상 밖, 소리내어 남긴다.
         logger.warning(
             "sync_agent_profile_presence: no team_member row for member_id=%s — presence write skipped",
+            member_id,
+        )
+        return
+
+    member_exists = (await session.execute(select(Member.id).where(Member.id == member_id))).scalar_one_or_none()
+    if member_exists is None:
+        # agent_project_profiles.member_id의 실 FK 부모(members)가 없다 — team_members는
+        # 있는데 members가 없는 상태(정상 생성 경로에선 안 생김, 데이터 스멜 가능성은 story
+        # #3275 코멘트로 별도 기록). ensure INSERT를 시도하면 FK 위반으로 크래시하므로 먼저
+        # 걸러 조용히 반환(로그로 시끄럽게, 크래시로 시끄럽지 않게).
+        logger.warning(
+            "sync_agent_profile_presence: team_member exists but members row missing for member_id=%s "
+            "— self-heal skipped (FK parent absent)",
             member_id,
         )
         return

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -13,6 +13,7 @@ owner_member_id=생성 휴먼 member, agent_project_profiles는 team_member 런�
 """
 from __future__ import annotations
 
+import logging
 import uuid
 
 from sqlalchemy import func, select
@@ -23,6 +24,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.member import AgentProjectProfile, Member
 from app.models.project import OrgMember
 from app.models.user import User
+
+logger = logging.getLogger(__name__)
 
 
 async def sync_agent_anchor_on_create(
@@ -282,7 +285,7 @@ async def sync_agent_profile_presence(session: AsyncSession, member_id: uuid.UUI
     """AC3-4 2-1 dual-write: 에이전트 presence를 agent_project_profiles에도 반영(team_members UPDATE와 동시).
 
     AC3-4 뷰가 last_seen_at/active_story_id/agent_status를 agent_project_profiles서 읽으므로 cutover 전
-    동기 유지. member_id(=agent team_member.id, 1:1)로 단일 profile 행 UPDATE. 행 없으면 0건(무해).
+    동기 유지. member_id(=agent team_member.id, 1:1)로 단일 profile 행 UPDATE.
     cutover(2-2) 후 레거시 team_members UPDATE 제거 시 이 경로가 유일 write가 된다.
 
     story #3197 — 이 함수가 "agent가 online으로 관측됐다"(last_seen_at=NOW 세팅)를 쓰는
@@ -290,7 +293,18 @@ async def sync_agent_profile_presence(session: AsyncSession, member_id: uuid.UUI
     non-None 값으로 오면(=online write, offline인 last_seen_at=None과 구분) 같은 UPDATE에
     `first_connected_at = COALESCE(first_connected_at, :그 값)`을 얹는다 — 별도 write 0,
     한 번 채워지면 이후 online 갱신에 덮이지 않는다(COALESCE가 기존 값 우선).
-    """
+
+    story #3275(2026-09-01, 선생님 prod customer-zero 실사고 그라운딩) — "행 없으면 0건(무해)"
+    가정이 실은 무해하지 않았다: profile 부재(S4급 grant-only 클래스 — `ensure_agent_project_profile`
+    이 project_access grant 경로 한 곳에만 배선돼, heartbeat 등 나머지 콜사이트는 무음 스킵)면
+    `first_connected_at`이 영원히 안 써지는데, heartbeat 엔드포인트 자체는 `team_members` 뷰의
+    grant-only 분기(런타임 컬럼 NULL)로 200 OK를 반환해 "연결은 됐는데 체크리스트만 영구
+    위음성"이 재현됐다. rowcount==0이면 self-heal: `TeamMember.project_id`(anchor project —
+    `team_members.project_id`는 DB NOT NULL 제약, `write_agent_project_placement`/
+    `create_org_level_agent`가 생성 시 항상 세팅해 이 경로에서 NULL을 만날 수 없다)로
+    `ensure_agent_project_profile`을 멱등 호출한 뒤 UPDATE를 1회만 재시도한다. 콜사이트 7곳
+    (agent_gateway.py×3·team_members.py×3·agent_auth_failure.py×1) 전부를 고치는 대신 이 함수
+    내부에서 닫는 쪽이 더 좁은 경계(PO 확定)."""
     allowed = {"last_seen_at", "active_story_id", "agent_status"}
     upd = {k: v for k, v in fields.items() if k in allowed}
     if not upd:
@@ -299,8 +313,35 @@ async def sync_agent_profile_presence(session: AsyncSession, member_id: uuid.UUI
         upd["first_connected_at"] = func.coalesce(
             AgentProjectProfile.__table__.c.first_connected_at, upd["last_seen_at"]
         )
-    await session.execute(
+    result = await session.execute(
         sa_update(AgentProjectProfile.__table__)
         .where(AgentProjectProfile.__table__.c.member_id == member_id)
         .values(**upd)
     )
+    if result.rowcount != 0:
+        return
+
+    from app.models.team import TeamMember
+
+    team_member = await session.get(TeamMember, member_id)
+    if team_member is None:
+        # team_members 행 자체가 없다(고아 member_id) — self-heal 대상 밖, 소리내어 남긴다.
+        logger.warning(
+            "sync_agent_profile_presence: no team_member row for member_id=%s — presence write skipped",
+            member_id,
+        )
+        return
+
+    await ensure_agent_project_profile(session, member_id=member_id, project_id=team_member.project_id)
+    retry = await session.execute(
+        sa_update(AgentProjectProfile.__table__)
+        .where(AgentProjectProfile.__table__.c.member_id == member_id)
+        .values(**upd)
+    )
+    if retry.rowcount == 0:
+        # ensure 직후인데도 0행 — 이론상 불가(project_id NOT NULL·ensure는 멱등 INSERT)이나
+        # 무음보다 시끄러운 실패가 낫다(no-fiction 원칙).
+        logger.error(
+            "sync_agent_profile_presence: self-heal failed to produce a writable profile row for member_id=%s",
+            member_id,
+        )

--- a/backend/tests/test_3275_presence_profile_selfheal_realdb.py
+++ b/backend/tests/test_3275_presence_profile_selfheal_realdb.py
@@ -171,18 +171,78 @@ async def test_existing_profile_path_unaffected_no_duplicate_row():
 
 
 @pytest.mark.anyio
-async def test_orphan_member_id_logs_and_does_not_raise():
+async def test_orphan_member_id_logs_and_does_not_raise(caplog):
     """team_members 행 자체가 없는 member_id(고아) — self-heal 대상 밖. 예외 없이 조용히
-    반환(무음이 아니라 로그로 신호, 회귀 시 크래시로 드러난다)."""
+    반환(무음이 아니라 로그로 신호, 회귀 시 크래시로 드러난다). 카디르 QA 보강(PR#3664 1차) —
+    "예외 없음"만이 아니라 경고 로그가 실제로 발화하는지까지 assert한다."""
+    import logging
+
     from app.services.agent_anchor_sync import sync_agent_profile_presence
 
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
             from datetime import datetime, timezone
-            await sync_agent_profile_presence(
-                s, uuid.uuid4(), last_seen_at=datetime.now(timezone.utc), agent_status="online"
-            )
+            with caplog.at_level(logging.WARNING, logger="app.services.agent_anchor_sync"):
+                await sync_agent_profile_presence(
+                    s, uuid.uuid4(), last_seen_at=datetime.now(timezone.utc), agent_status="online"
+                )
             await s.commit()  # 예외 없이 끝나야 한다.
+            assert any("presence write skipped" in r.message for r in caplog.records)
+    finally:
+        await engine.dispose()
+
+
+async def _seed_team_member_only_no_member_row(session):
+    """카디르 QA 실사고(PR#3664 1차) 재현 — `agent_project_profiles.member_id`의 실 FK
+    부모는 `members`인데, `team_members`는 있고 `members`는 없는 상태(정상 생성 경로에선
+    안 생기지만 test_2602_sse_lease_lifespan_reclaim.py::_seed_org_project_agent와 동형 —
+    실 SSE 경로 agent_gateway.py:561이 이 상태의 에이전트로도 호출될 수 있음이 실측됨)."""
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    member_id = uuid.uuid4()
+    session.add(TeamMember(id=member_id, org_id=org.id, project_id=project.id, type="agent", name="Agent"))
+    await session.commit()
+    return {"org_id": org.id, "project_id": project.id, "member_id": member_id}
+
+
+@pytest.mark.anyio
+async def test_members_row_missing_skips_self_heal_without_fk_crash(caplog):
+    """핵심 pin(카디르 QA 지적, PR#3664 1차 회귀 재발 방지) — team_members는 있는데 FK 실부모인
+    members가 없으면, self-heal이 `ensure_agent_project_profile` INSERT를 시도해 FK 위반으로
+    크래시하는 대신 조용히(로그로) 스킵해야 한다. 이 가드를 제거하는 뮤테이션 시 이 테스트가
+    IntegrityError로 정확히 RED가 된다."""
+    import logging
+    from datetime import datetime, timezone
+
+    from sqlalchemy import select
+
+    from app.models.member import AgentProjectProfile
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_team_member_only_no_member_row(s)
+
+            with caplog.at_level(logging.WARNING, logger="app.services.agent_anchor_sync"):
+                await sync_agent_profile_presence(
+                    s, seeded["member_id"], last_seen_at=datetime.now(timezone.utc), agent_status="online"
+                )
+            await s.commit()  # FK 위반 없이 끝나야 한다(과거 회귀: IntegrityError 그대로 전파).
+
+            assert any("members row missing" in r.message for r in caplog.records)
+            rows = (await s.execute(
+                select(AgentProjectProfile).where(AgentProjectProfile.member_id == seeded["member_id"])
+            )).scalars().all()
+            assert rows == []  # self-heal이 스킵됐으니 profile 행도 안 생겨야 한다.
     finally:
         await engine.dispose()

--- a/backend/tests/test_3275_presence_profile_selfheal_realdb.py
+++ b/backend/tests/test_3275_presence_profile_selfheal_realdb.py
@@ -1,0 +1,188 @@
+"""story #3275([연결·판별자] 프로필 행 부재 self-heal, 2026-09-01 — 선생님 prod customer-zero
+실사고 그라운딩) — `sync_agent_profile_presence`의 UPDATE가 `agent_project_profiles` 행 부재
+시 조용히 0건이던 결함. heartbeat는 `team_members` 뷰의 grant-only 분기(런타임 컬럼 NULL)로
+200 OK를 반환하는데 `first_connected_at`은 영원히 안 써져 "연결은 됐는데 체크리스트/CTA만
+영구 위음성"이 재현됐다(발단 story #3197 — 그 스토리 본체의 `get_verified_map` OR 판별 로직은
+불변, 이 결함은 그 판별자가 읽는 원천 write 한 층 위)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.destructive_schema,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    import app.models  # noqa: F401
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_agent_without_profile(session):
+    """team_members(agent, project_id 세팅) 만 만들고 agent_project_profiles 행은 **의도적으로
+    안 만든다** — S4급 grant-only 갭(profile 없이 team_members 뷰에만 존재)의 실제 모양."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.team import TeamMember
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    member_id = uuid.uuid4()
+    session.add(Member(id=member_id, org_id=org.id, type="agent", name="Agent", is_active=True))
+    await session.commit()
+    session.add(TeamMember(id=member_id, org_id=org.id, project_id=project.id, type="agent", name="Agent"))
+    await session.commit()
+    return {"org_id": org.id, "project_id": project.id, "member_id": member_id}
+
+
+@pytest.mark.anyio
+async def test_heartbeat_self_heals_missing_profile_and_stamps_first_connected_at():
+    """핵심 pin — profile 행 없는 에이전트가 presence를 쓰면(heartbeat 동형) profile이
+    self-heal로 만들어지고 first_connected_at이 즉시 채워진다. self-heal 제거 뮤테이션 시
+    이 assert가 정확히 RED(테스트 자체가 profile row not found)가 된다."""
+    from sqlalchemy import select
+
+    from app.models.member import AgentProjectProfile
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_without_profile(s)
+
+            # self-heal 전 — profile 행이 정말 0개인지 먼저 확認(전제 검증, 거짓양성 방지).
+            pre = (await s.execute(
+                select(AgentProjectProfile).where(AgentProjectProfile.member_id == seeded["member_id"])
+            )).scalar_one_or_none()
+            assert pre is None
+
+            from datetime import datetime, timezone
+            now = datetime.now(timezone.utc)
+            await sync_agent_profile_presence(s, seeded["member_id"], last_seen_at=now, agent_status="online")
+            await s.commit()
+
+            prof = (await s.execute(
+                select(AgentProjectProfile).where(AgentProjectProfile.member_id == seeded["member_id"])
+            )).scalar_one()
+            assert prof.project_id == seeded["project_id"]
+            assert prof.agent_status == "online"
+            assert prof.first_connected_at is not None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_second_heartbeat_does_not_move_first_connected_at():
+    """COALESCE 불변식 무회귀 — self-heal로 만들어진 뒤에도 재기록 시 first_connected_at이
+    최초 값 그대로 유지된다(재연결마다 갱신되면 "최초 연결" 의미가 무너진다)."""
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import select
+
+    from app.models.member import AgentProjectProfile
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_without_profile(s)
+
+            first_seen = datetime.now(timezone.utc)
+            await sync_agent_profile_presence(s, seeded["member_id"], last_seen_at=first_seen, agent_status="online")
+            await s.commit()
+
+            second_seen = first_seen + timedelta(minutes=10)
+            await sync_agent_profile_presence(s, seeded["member_id"], last_seen_at=second_seen, agent_status="online")
+            await s.commit()
+
+            prof = (await s.execute(
+                select(AgentProjectProfile).where(AgentProjectProfile.member_id == seeded["member_id"])
+            )).scalar_one()
+            assert prof.first_connected_at.replace(tzinfo=timezone.utc) == first_seen
+            assert prof.last_seen_at.replace(tzinfo=timezone.utc) == second_seen
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_existing_profile_path_unaffected_no_duplicate_row():
+    """무회귀 — profile이 이미 있는 정상 케이스(기존 동작)는 self-heal 분기를 안 타고, 중복
+    행도 안 생긴다(정상 경로가 이 변경으로 흔들리지 않음을 고정)."""
+    from datetime import datetime, timezone
+
+    from sqlalchemy import select
+
+    from app.models.member import AgentProjectProfile
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_without_profile(s)
+            s.add(AgentProjectProfile(
+                id=uuid.uuid4(), member_id=seeded["member_id"], project_id=seeded["project_id"],
+            ))
+            await s.commit()
+
+            now = datetime.now(timezone.utc)
+            await sync_agent_profile_presence(s, seeded["member_id"], last_seen_at=now, agent_status="online")
+            await s.commit()
+
+            rows = (await s.execute(
+                select(AgentProjectProfile).where(AgentProjectProfile.member_id == seeded["member_id"])
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].first_connected_at is not None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_orphan_member_id_logs_and_does_not_raise():
+    """team_members 행 자체가 없는 member_id(고아) — self-heal 대상 밖. 예외 없이 조용히
+    반환(무음이 아니라 로그로 신호, 회귀 시 크래시로 드러난다)."""
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from datetime import datetime, timezone
+            await sync_agent_profile_presence(
+                s, uuid.uuid4(), last_seen_at=datetime.now(timezone.utc), agent_status="online"
+            )
+            await s.commit()  # 예외 없이 끝나야 한다.
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
story #3275([연결·판별자] 프로필 행 부재 self-heal). 2026-09-01 그라운딩 — 발단은 story #3197 재점검(선생님 prod customer-zero: 온보딩 체크리스트 3/5 org "에이전트 연결하기" 미체크 보고).

## 그라운딩 결론
#3197 본체(`get_verified_map`의 `first_connected_at` OR 판별 로직)는 develop/main 양쪽에 배포 완료 상태이고 **진짜 done**이 맞다(git log 확認, d3d4756ad). 이 스토리는 그 판별자가 읽는 **원천 write가 가끔 아예 안 만들어지는** 한 층 위의 별개 결함.

## 근인
`sync_agent_profile_presence`(agent_anchor_sync.py)의 UPDATE가 `WHERE member_id=`만 걸고 존재 확認이 없다 — `agent_project_profiles` 행이 0개면 조용히 0-row UPDATE(주석이 "행 없으면 0건(무해)"로 자인). 같은 클래스를 이미 한 번 찾아 고친 자리(`ensure_agent_project_profile`, S4)가 있지만 **딱 한 콜사이트**(`project_access.py:195`, grant 경로)에만 배선돼 있었다. heartbeat 엔드포인트(`team_members.py:655`)는 `team_members` 뷰(grant-only 분기, 런타임 컬럼 NULL)로 200 OK를 반환하므로 "연결은 됐는데 `first_connected_at`은 영원히 미기록"이라는 정확한 위음성 조합이 구조적으로 가능했다.

## 처방
`sync_agent_profile_presence` 자체를 self-healing으로: UPDATE `rowcount==0`이면 `TeamMember.project_id`(anchor project)로 `ensure_agent_project_profile`을 1회 호출 후 UPDATE 재시도. 콜사이트 7곳(agent_gateway.py×3·team_members.py×3·agent_auth_failure.py×1) 전파보다 이 함수 내부에서 닫는 쪽이 좁고 안전(PO 확定).

**PO 단서① 검증**: `team_members.project_id`는 DB `NOT NULL` 제약(model 확認) — `write_agent_project_placement`/`create_org_level_agent`가 생성 시 항상 세팅해 이 self-heal 경로에서 project_id NULL을 만날 수 없다(스키마 레벨로 확認, 실데이터 조회 불요). team_member 행 자체가 없는 고아 case만 별도로 로그 신호.

**verify_seq/acked_seq 축(PO 단서③)**: 무변경 — `get_verified_map`/`agent_verify.py`는 손 안 댐. 이 fix는 그 판별자가 읽는 원천 write 신뢰성만 다룬다.

## 검증
- 신규 realdb 테스트 4건(`test_2836_agent_auth_failure_realdb.py`류와 동형 패턴, `PARITY_TEST_DATABASE_URL`/`ALEMBIC_DATABASE_URL` 필요 — 로컬 PG 미가용이라 로컬은 skip, CI에서 실행): profile 없는 에이전트 presence write → self-heal(PO 단서②, 핵심 pin) / 재기록 시 first_connected_at 불변(COALESCE 무회귀) / 정상 경로(profile 기존) 무회귀 / 고아 member_id 예외 없이 로그만
- 관련 기존 mock 테스트 65 passed(무회귀)
- 커스텀 static lint 가드 5종(query-sentinel·403·get_read_db·candidate-ownership·commit-before-validate) 전부 새 위반 0건

## 남은 것
- PO 단서④ — 착지 후 dev 재현 검산(선생님 3/5 org 유형이 heartbeat 1회로 뒤집히는지)은 병합 후 별도 진행
- 로컬 Docker 데몬이 이 세션에서 기동 안 돼(4분 대기 후 포기) realdb 테스트를 로컬에서 직접 GREEN 확認은 못 했음 — CI 실행 결과로 확認 필요

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_019rkXVqy2DF1aAN7szuqp44