### PR TITLE
[SID:3273] support-gateway pytest 자동 실행 잡 신설 — GHA CI사각 봉쇄

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     timeout-minutes: 3
     outputs:
       backend_relevant: ${{ steps.scope.outputs.backend_relevant }}
+      gateway_relevant: ${{ steps.scope.outputs.gateway_relevant }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,7 +56,8 @@ jobs:
           # 컨텍스트에서만 돈다(design-review-gate.yml의 AC8과 같은 fail-closed 원칙).
           if [ -z "${BASE_SHA}" ] || [ -z "${HEAD_SHA}" ]; then
             echo "backend_relevant=true" >> "$GITHUB_OUTPUT"
-            echo "PR 컨텍스트 아님(push 이벤트 등) — fail-closed로 백엔드 전량 실행."
+            echo "gateway_relevant=true" >> "$GITHUB_OUTPUT"
+            echo "PR 컨텍스트 아님(push 이벤트 등) — fail-closed로 백엔드·gateway 전량 실행."
             exit 0
           fi
           CHANGED="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
@@ -79,6 +81,22 @@ jobs:
               echo "allowlist 밖 파일:"
               echo "${NON_SAFE}"
             fi
+          fi
+
+          # story #3273(CI사각) — support-gateway는 backend와 반대 방향 필터가 안전하다.
+          # backend는 packages/ 등 넓은 코드베이스에 걸쳐 있어 "안전 확定" allowlist(스킵 대상)를
+          # 좁게 잡는 게 맞지만, support-gateway는 그 자체가 "0 fleet 자격"(app/config.py 상단
+          # 주석) — 자기 디렉토리 밖 어떤 코드도 import하지 않는 게 설계 불변식이다. 그래서
+          # 여기는 "관련 확定" allowlist(실행 대상)를 좁게 잡는 쪽이 더 안전하다 — 이 워크플로
+          # 파일 자체가 바뀔 때도 돈다(자기 안전).
+          GATEWAY_CHANGED="$(printf '%s\n' "${CHANGED}" \
+            | grep -E '^support-gateway/|^\.github/workflows/ci\.yml$' || true)"
+          if [ -n "${GATEWAY_CHANGED}" ] || [ -z "${CHANGED}" ]; then
+            echo "gateway_relevant=true" >> "$GITHUB_OUTPUT"
+            echo "support-gateway/ 변경 있음(또는 변경 0건) — gateway pytest 실행."
+          else
+            echo "gateway_relevant=false" >> "$GITHUB_OUTPUT"
+            echo "support-gateway/ 밖 변경만 있음 — gateway pytest skip 대상."
           fi
 
   alembic-fresh-db:
@@ -893,6 +911,60 @@ jobs:
             echo "## Backend pytest — slowest 20 (여유: 천장 25분, 08-17 실측 본체 7~8분)"
             echo '```'
             awk '/slowest 20 durations/,0' /tmp/pytest_output.log 2>/dev/null || echo "(durations 출력 없음 — 타임아웃-취소로 이 스텝 자체가 못 돌았을 가능성)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # story #3273(CI사각, 2026-09-01 카디르 QA 발견) — support-gateway/ 디렉토리엔 pytest
+  # 스위트(86건 시점 발견, 이 잡 도입 시점 87건)가 있었지만 GHA 어느 워크플로에도 실행 잡이
+  # 없었다 — backend-test와 달리 그동안 이 서비스를 건드린 PR도 "required CI green"이 스위트
+  # 0건 실행으로 통과했고, 검증은 QA의 codex exec 수동 실행에만 의존했다(«CI green≠관문 전부»
+  # 클래스). support-gateway는 story #3259(지원v1·1경계)의 "0 fleet 자격" 설계로 자기
+  # 디렉토리 밖 어떤 코드도 import하지 않는다(app/config.py 상단 주석) — 그래서 이 서비스
+  # 테스트는 backend-test처럼 실PG 서비스가 필요 없다(tests/conftest.py가 sqlite+aiosqlite
+  # 인메모리로 매 테스트를 격리) — 로컬 실측(2026-09-01) 87 passed, 0.94초.
+  #
+  # ⚠️아직 develop 필수 상태 체크가 아니다(페드루 PO 지시, 2026-09-01) — 신설 잡을 곧장
+  # required에 태우면 이 잡 자체의 미지 플레이크가 전 머지를 막는 자리가 된다("게이트에
+  # 머지 뒤에만 아는 것 금지"의 사촌 원칙). develop에서 몇 사이클 돌아 플레이크 0을 확認한
+  # 뒤에만 PO가 branch protection에 수동으로 등재한다(`gh api --method PUT
+  # repos/moonklabs/sprintable/branches/develop/protection/required_status_checks/contexts`
+  # 로 "Support Gateway pytest" 추가 — 관리자 권한 필요, 이 PR이 하는 일 아님).
+  gateway-test:
+    name: Support Gateway pytest
+    needs: [detect-changed-scope]
+    # backend-test·alembic-fresh-db와 동형 이유(위 주석 반복 안 함) — 잡 자체는 항상 돌고
+    # 스텝만 조건부 스킵해 "미실행=스킵"이 "통과"로 잡히는 모호함을 피한다.
+    if: always()
+    runs-on: ubuntu-latest
+    # 실측(2026-09-01, 로컬 87 passed 0.94초) — postgres 서비스 불요·CI 콜드 uv sync 포함해도
+    # 수 분 이내로 예상. backend-test(7~8분, 실PG)·backend-test-destructive(#3269 실측
+    # 17~23분+)에 비하면 러너 비용은 무시할 수준 — 그래도 첫 CI 실주행 미지수 여유로 10분.
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        if: needs.detect-changed-scope.outputs.gateway_relevant != 'false'
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: 'latest'
+
+      - name: Run pytest (support-gateway — sqlite in-memory, no external services)
+        if: needs.detect-changed-scope.outputs.gateway_relevant != 'false'
+        working-directory: support-gateway
+        run: |
+          set -o pipefail
+          uv run pytest -q --durations=20 2>&1 | tee /tmp/gateway_pytest_output.log
+
+      - name: Slowest tests summary
+        if: always()
+        run: |
+          {
+            echo "## Support Gateway pytest — slowest 20"
+            echo '```'
+            awk '/slowest 20 durations/,0' /tmp/gateway_pytest_output.log 2>/dev/null || echo "(durations 출력 없음 — skip됐거나 타임아웃)"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
[SID:3273]

## 배경
카디르 QA가 PR#3663 검수 중 부수 발견: `support-gateway/`에 pytest 스위트(발견 시점 86건, 현재 87건)가 있지만 GHA 어느 워크플로에도 자동 실행 잡이 없었다. `backend/`의 "Backend pytest"에 대응하는 게 없어, gateway만 건드린 PR의 required CI 체크는 스위트를 단 한 번도 안 돌리고 통과했다 — 검증은 QA의 codex exec 수동 실행에만 의존.

## 그라운딩
- `ci.yml` 전체 grep — support-gateway는 `cloud-build.yml`의 배포 env 배선에만 등장, pytest 실행 잡은 0건.
- `detect-changed-scope`의 `backend_relevant` 필터(docs/·*.md·apps/web/·packages/만 백엔드-무관 allowlist)는 gateway-only 변경을 못 걸러 `backend-test` 잡의 스텝 자체는 돌지만, 그 잡은 `working-directory: backend`뿐이라 gateway/ 테스트를 애초에 안 건드림 — "잡은 도는데 실제 검증은 0건"인 조용한 갭.

## 변경
1. `detect-changed-scope`에 `gateway_relevant` 출력 추가 — support-gateway는 story #3259의 "0 fleet 자격" 설계로 자기 디렉토리 밖 어떤 코드도 import하지 않는다(물리적 격리, `app/config.py` 상단 주석) → backend의 "안전 확定 allowlist(스킵 대상)"와 반대로 "관련 확定 allowlist(실행 대상)"가 더 안전 — `support-gateway/` 또는 이 워크플로 파일 자체가 바뀔 때만 실행, 그 외 skip.
2. `gateway-test` 잡 신설(backend-test와 동형 — 잡은 항상 돌고 스텝만 조건부 스킵, "미실행=스킵"이 "통과"로 안 잡히게). postgres 서비스 불요 — `tests/conftest.py`가 sqlite+aiosqlite 인메모리로 매 테스트 격리.

## 러너 예산 근거(required 등재 판단용)
- 로컬 실측(2026-09-01): `uv run pytest` → **87 passed, 0.94초**.
- 비교: `backend-test`(실PG, 7~8분) · `backend-test-destructive`(#3269 최근 관측 17~23분+, 러너 경합 이슈 진행 중).
- CI 콜드 `uv sync` 포함해도 gateway 잡은 분 단위 이내로 예상 — 기존 무거운 잡들 대비 러너 비용은 무시할 수준.

## required 등재 — 이 PR 스코프 밖(페드루 PO 지시)
신설 잡을 곧장 required에 태우면 이 잡 자체의 미지 플레이크가 전 머지를 막는 자리가 된다("게이트에 머지 뒤에만 아는 것 금지"의 사촌 원칙). **제안**: develop에서 몇 사이클 돌아 플레이크 0을 확認한 뒤 PO가 branch protection에 수동 등재(`gh api --method PUT repos/moonklabs/sprintable/branches/develop/protection/required_status_checks/contexts`로 "Support Gateway pytest" 추가 — 관리자 권한 필요). 현재 required 체크 6개(확認됨): Backend pytest·Lint,Type Check,Test,Build·Alembic upgrade head (fresh DB)·Design review gate·QA review gate·sprintable/gate.

## 검증
- `actionlint .github/workflows/ci.yml` — 신설 잡 범위 0 이슈(파일 전체 기존 1건 무관 warning만).
- `python3 -c "import yaml; yaml.safe_load(...)"` — 구문 유효, 잡 등록 확認.
- 이 PR 자체가 gateway-only 변경이 아니라 `ci.yml`만 건드리므로 backend_relevant=true 경로도 같이 실측된다(fail-closed 확認).