### PR TITLE
[SID:3270] hotfix — PR#3663/#3659 squash-merge race로 test_injection_defense_contract.py 깨짐

### DIFF
--- a/support-gateway/tests/test_injection_defense_contract.py
+++ b/support-gateway/tests/test_injection_defense_contract.py
@@ -116,6 +116,7 @@ def test_tool_signature_has_no_org_override_parameter(tool_name, allowed_params)
         user_id=uuid.uuid4(),
         escalation_state={"called": False},
         knowledge_state={"called": False, "had_match": False},
+        tool_reply_state={"called": False, "answers": []},
         llm=None,
     )
     tool = next(t for t in tools if t.__name__ == tool_name)
@@ -137,6 +138,7 @@ def test_v1_tool_surface_is_exactly_the_known_read_or_log_only_set():
         user_id=uuid.uuid4(),
         escalation_state={"called": False},
         knowledge_state={"called": False, "had_match": False},
+        tool_reply_state={"called": False, "answers": []},
         llm=None,
     )
     assert {t.__name__ for t in tools} == {"knowledge_search", "org_status_lookup", "escalate"}


### PR DESCRIPTION
[SID:3270]

## 발견 경로
[SID:3273](support-gateway pytest CI사각 봉쇄, PR#3665)의 신설 `gateway-test` 잡의 **첫 실주행**에서 즉시 잡힌 develop의 실 회귀. 이 잡이 없었다면 계속 무검출이었을 것 — 정확히 #3273 스토리가 막으려던 그 클래스.

## 근인
`feat/3270-history-citation-fixes`(PR#3663) 브랜치는 `origin/develop` `877ad2744`(PR#3659 머지 *前*)에서 분기됐다 — PR#3659가 그 이후 도입한 `support-gateway/tests/test_injection_defense_contract.py`를 이 브랜치는 한 번도 본 적이 없다(로컬 테스트 스위트에 그 파일 자체가 없었다 — 제가 PR#3663에서 보고한 "87 passed"는 정직한 숫자였지만 이 파일을 아예 커버 못 한 표본이었다).

PR#3663이 `_make_tools()`에 `tool_reply_state`를 신규 필수 kwarg로 추가했는데, git의 squash-merge는 그 파일을 diff에서 안 건드려 **충돌 없이 조용히 통과**했다 — develop에서 두 PR의 결과가 처음 만났을 때야 시맨틱 드리프트로 드러났다. PR#3659 리베이스 때 겪은 것과 정확히 동형 클래스(git이 line-level conflict로 못 잡는 인터페이스 드리프트).

## 변경
`test_injection_defense_contract.py`의 `_make_tools()` 호출 2곳(`test_tool_signature_has_no_org_override_parameter`·`test_v1_tool_surface_is_exactly_the_known_read_or_log_only_set`)에 `tool_reply_state={"called": False, "answers": []}` 추가. **프로덕션 코드(`interaction.py`) 무변경** — 순수 테스트 픽스처 동기화, 동작 변경 없음.

## 검증
`uv run pytest` — 123 passed(develop 현재 4 failed → 0).