### PR TITLE
[SID:3276] 상담 대화 사용자 단위 분리+수명주기 — BE 1차(org=절대 격리 경계 유지)

### DIFF
--- a/support-gateway/alembic/versions/0003_conversation_user_scope.py
+++ b/support-gateway/alembic/versions/0003_conversation_user_scope.py
@@ -1,0 +1,46 @@
+"""story #3276(지원v1·후속) — 상담 대화 사용자 단위 분리+수명주기.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-09-01
+
+⚠️레거시 데이터 처분(AC4, 페드루 PO 승인 2026-09-01) — 이 마이그레이션은 기존
+support_conversations 행의 external_user_id를 **backfill하지 않는다**(NULL로 남긴다).
+새 조회 경로(app/routers/sessions.py)는 (org_id, external_user_id) exact match만 보므로
+NULL 행은 누구의 조회에도 안 걸린다 — "봉인"(삭제는 안 함, 감사 목적 DB엔 그대로 남음).
+backfill(원 생성 세션의 external_user_id로 귀속)도 검토했으나, 그러면 org당 대화가
+여러 사용자에게 섞여 쌓인 오염 이력이 "원 생성자" 화면에 그대로 남는다 — 봉인이 증상
+자체(선생님이 자기 위젯에서 타 계정 흔적을 본 것)를 완전히 지운다.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "support_conversations",
+        sa.Column("external_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column(
+        "support_conversations",
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_support_conversations_org_user_active",
+        "support_conversations",
+        ["org_id", "external_user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_support_conversations_org_user_active", table_name="support_conversations")
+    op.drop_column("support_conversations", "ended_at")
+    op.drop_column("support_conversations", "external_user_id")

--- a/support-gateway/app/models.py
+++ b/support-gateway/app/models.py
@@ -39,8 +39,14 @@ class SupportSession(Base):
 
 
 class SupportConversation(Base):
-    """org당 1스레드 계승(Blueprint v0.3 §1.1) — org_id별 유니크 제약은 마이그레이션에서
-    건다(story #3259는 저장소 골격까지, 스레드 재사용 정책 자체는 story #3 오케스트레이션 스코프)."""
+    """story #3276(지원v1·후속) — org는 절대 격리 경계(불변)지만, 상담 자체는 **사용자 단위로
+    분리**된다: (org_id, external_user_id)당 활성(ended_at IS NULL) 상담 최대 1개(통례 —
+    인터컴류). external_user_id가 NULL인 행은 이 마이그레이션 *이전* 생성분("org당 1스레드"
+    시절, Blueprint v0.3 §1.1 원 설계) — 봉인(backfill 안 함, 삭제도 안 함): 새 조회 경로는
+    exact (org_id, external_user_id) 매치만 보므로 그 행들은 이제 누구의 조회에도 안 걸린다
+    (감사 목적으로 DB엔 남는다). ended_at이 채워지면 읽기 전용 이력(app/routers/sessions.py
+    ".../conversations/{id}/end") — SupportEscalation.status(사람 연결 완료 여부)와는 완전히
+    별개 축이다(상담을 종료해도 열린 에스컬레이션은 안 건드린다, 그 반대도 마찬가지)."""
 
     __tablename__ = "support_conversations"
 
@@ -49,6 +55,10 @@ class SupportConversation(Base):
     session_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("support_sessions.id"), nullable=False
     )
+    # NULL=레거시 봉인 행(위 docstring). 신규 생성 경로(_get_or_create_active_conversation 등)는
+    # 항상 값을 채운다 — 코드 레벨 불변식, DB NOT NULL 제약은 아니다(레거시 행 공존 때문).
+    external_user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     # story #3261 AC3 — org별 대화 메모리(요약 압축). app/memory.py가

--- a/support-gateway/app/routers/sessions.py
+++ b/support-gateway/app/routers/sessions.py
@@ -1,11 +1,16 @@
-"""story #3259 AC3 — 위젯용 세션 API. 모든 쿼리는 위임 토큰의 org_id로 스코프된다(요청
-바디/경로 파라미터의 org_id는 신뢰하지 않는다 — 애초에 받지도 않는다). org 소속 불일치는
-404로 판정한다(존재 자체를 노출하지 않는 것이 403보다 안전측 — backend CI의
+"""story #3259 AC3 — 위젯용 세션 API. 모든 쿼리는 위임 토큰의 org_id/external_user_id로
+스코프된다(요청 바디/경로 파라미터는 신뢰하지 않는다 — 애초에 받지도 않는다). org 소속
+불일치는 404로 판정한다(존재 자체를 노출하지 않는 것이 403보다 안전측 — backend CI의
 `has_project_access 403 lint` 관례와 동일 철학, story #2342 참고, 이 서비스는 별도 코드베이스라
-그 lint 대상은 아니지만 규율은 따른다)."""
+그 lint 대상은 아니지만 규율은 따른다).
+
+story #3276(지원v1·후속) — 상담 대화 사용자 단위 분리. org는 절대 격리 경계(불변)지만,
+같은 org 안에서도 대화는 (org_id, external_user_id) 단위로 갈린다 — 자세한 설계 근거는
+app/models.py::SupportConversation 참고."""
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import select
@@ -18,6 +23,8 @@ from app.interaction import handle_turn
 from app.models import SupportConversation, SupportEscalation, SupportMessage, SupportSession
 from app.rate_limit import limiter
 from app.schemas import (
+    ConversationListResponse,
+    ConversationResponse,
     MessageCreateRequest,
     MessageExchangeResponse,
     MessageListResponse,
@@ -39,12 +46,25 @@ def _to_message_response(message: SupportMessage) -> MessageResponse:
     )
 
 
+def _to_conversation_response(conv: SupportConversation, escalation_status: str | None) -> ConversationResponse:
+    return ConversationResponse(
+        id=conv.id,
+        created_at=conv.created_at,
+        ended_at=conv.ended_at,
+        escalation_status=escalation_status,
+    )
+
+
 async def _conversation_escalation_status(db: AsyncSession, conversation_id: uuid.UUID) -> str | None:
     """story #3263 AC4 — 대화 레벨 에스컬레이션 상태. "가장 최근 1건"이 아니라 "지금 열려있는
     게 하나라도 있는가"로 판정한다 — created_at 정렬(초 단위 해상도, SQLite CURRENT_TIMESTAMP)
     로는 근접 시각에 생긴 두 행의 선후를 신뢰할 수 없고, 무엇보다 고객이 실제로 궁금한 건
     "지금 사람이 아직 보고 있는가"이지 "가장 최근 사건이 뭐였는가"가 아니다 — 열린 게
-    하나라도 있으면 과거에 resolved된 게 더 최근에 안 걸려도 open이 맞다."""
+    하나라도 있으면 과거에 resolved된 게 더 최근에 안 걸려도 open이 맞다.
+
+    story #3276 — conversation_id 단위 그대로다. (org_id, external_user_id) 스코프 분리는
+    호출부(conversation을 어떻게 찾았는지)의 책임이지 이 함수는 손대지 않는다 — 스코프가
+    올바르게 좁혀지면 이 함수는 코드 변경 없이 자동으로 per-user가 된다."""
     statuses = (
         await db.execute(
             select(SupportEscalation.status).where(SupportEscalation.conversation_id == conversation_id)
@@ -55,24 +75,73 @@ async def _conversation_escalation_status(db: AsyncSession, conversation_id: uui
     return "open" if "open" in statuses else "resolved"
 
 
-async def _get_or_create_conversation(
-    db: AsyncSession, session: SupportSession, org_id: uuid.UUID
-) -> SupportConversation:
-    """org당 1스레드 계승(Blueprint v0.3 §1.1) — 재사용/만료 정책 자체는 story #3(오케스트레이션)
-    스코프. 여기서는 "org_id로 스코프된 최신 conversation을 찾거나 만든다"까지만."""
-    existing = (
+async def _get_session_or_404(db: AsyncSession, *, session_id: uuid.UUID, identity: DelegatedIdentity) -> SupportSession:
+    """story #3276 보강 — org_id뿐 아니라 external_user_id까지 일치해야 한다(위임 토큰
+    소유자가 자기 세션만 조작 가능). 이전엔 org_id만 봐서, 같은 org의 타 사용자 session_id를
+    안다면(추측·유출) 자기 토큰으로 그 세션을 조작할 수 있는 통로가 이론상 있었다 — 대화
+    자체는 identity.user_id로 스코프돼 데이터 유출로 이어지진 않았지만(구 코드가 conversation을
+    org_id로만 찾았으므로), 이 스토리로 조회 축을 조여둔 김에 세션 소유권도 같이 조인다."""
+    session = (
+        await db.execute(
+            select(SupportSession).where(
+                SupportSession.id == session_id,
+                SupportSession.org_id == identity.org_id,
+                SupportSession.external_user_id == identity.user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if session is None:
+        raise HTTPException(status_code=404, detail="session not found")
+    return session
+
+
+async def _get_active_conversation(
+    db: AsyncSession, *, org_id: uuid.UUID, external_user_id: uuid.UUID
+) -> SupportConversation | None:
+    return (
         await db.execute(
             select(SupportConversation)
-            .where(SupportConversation.org_id == org_id)
+            .where(
+                SupportConversation.org_id == org_id,
+                SupportConversation.external_user_id == external_user_id,
+                SupportConversation.ended_at.is_(None),
+            )
             .order_by(SupportConversation.created_at.desc())
             .limit(1)
         )
     ).scalar_one_or_none()
+
+
+async def _get_or_create_active_conversation(
+    db: AsyncSession, *, session: SupportSession, org_id: uuid.UUID, external_user_id: uuid.UUID
+) -> SupportConversation:
+    """story #3276 AC1 — (org_id, external_user_id)당 활성 상담 최대 1개(통례, 인터컴류).
+    org_id만으로 찾던 구 _get_or_create_conversation을 대체 — 이제 같은 org 안에서도 남의
+    대화에 절대 안 닿는다. ended_at IS NULL 필터가 핵심(종료된 상담은 여기서 안 잡히고
+    자동으로 새 상담이 열린다 — "종료 후 재문의"의 자연스러운 통례 동작)."""
+    existing = await _get_active_conversation(db, org_id=org_id, external_user_id=external_user_id)
     if existing is not None:
         return existing
-    conv = SupportConversation(org_id=org_id, session_id=session.id)
+    conv = SupportConversation(org_id=org_id, session_id=session.id, external_user_id=external_user_id)
     db.add(conv)
     await db.flush()
+    return conv
+
+
+async def _get_owned_conversation_or_404(
+    db: AsyncSession, *, org_id: uuid.UUID, external_user_id: uuid.UUID, conversation_id: uuid.UUID
+) -> SupportConversation:
+    conv = (
+        await db.execute(
+            select(SupportConversation).where(
+                SupportConversation.id == conversation_id,
+                SupportConversation.org_id == org_id,
+                SupportConversation.external_user_id == external_user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if conv is None:
+        raise HTTPException(status_code=404, detail="conversation not found")
     return conv
 
 
@@ -114,19 +183,15 @@ async def post_message(
     db: AsyncSession = Depends(get_db),
 ) -> MessageExchangeResponse:
     request.state.delegated_org_id = str(identity.org_id)
-    # org_id를 WHERE에 태워 스코프 — 타 org의 session_id를 넣어도 0행(404), 존재 노출 없음.
-    session = (
-        await db.execute(
-            select(SupportSession).where(
-                SupportSession.id == session_id,
-                SupportSession.org_id == identity.org_id,
-            )
-        )
-    ).scalar_one_or_none()
-    if session is None:
-        raise HTTPException(status_code=404, detail="session not found")
+    session = await _get_session_or_404(db, session_id=session_id, identity=identity)
 
-    conv = await _get_or_create_conversation(db, session, identity.org_id)
+    # story #3276 — 항상 "현재 활성 상담"(없거나 종료됐으면 자동 신규)에 붙인다. 종료된
+    # 상담에 굳이 conversation_id로 계속 쓰려는 시도 자체가 없다 — 이 엔드포인트는 conversation_id를
+    # 받지 않는다(항상 활성 상담이 대상, 명시적 재개는 지원 안 함 — 종료=읽기전용이 곧
+    # "다시 쓰려면 새 상담" 통례).
+    conv = await _get_or_create_active_conversation(
+        db, session=session, org_id=identity.org_id, external_user_id=identity.user_id
+    )
 
     customer_message = SupportMessage(
         conversation_id=conv.id,
@@ -175,32 +240,24 @@ async def list_messages(
     session_id: uuid.UUID,
     identity: DelegatedIdentity = Depends(require_delegated_identity),
     db: AsyncSession = Depends(get_db),
+    conversation_id: uuid.UUID | None = None,
 ) -> MessageListResponse:
-    """story #3261 보완(2026-08-31, 페드루 PO 실 왕복 실측 지적) — 위젯 재오픈 시 대화 이력
-    복원용. org 스코프는 위와 동형(session 자체를 org_id로 먼저 스코프 — 존재하지 않는
-    session_id/타 org session_id 둘 다 404, 구분 안 됨)."""
-    request.state.delegated_org_id = str(identity.org_id)
-    session = (
-        await db.execute(
-            select(SupportSession).where(
-                SupportSession.id == session_id,
-                SupportSession.org_id == identity.org_id,
-            )
-        )
-    ).scalar_one_or_none()
-    if session is None:
-        raise HTTPException(status_code=404, detail="session not found")
+    """story #3261 보완(2026-08-31) — 위젯 재오픈 시 대화 이력 복원용.
 
-    conv = (
-        await db.execute(
-            select(SupportConversation)
-            .where(SupportConversation.org_id == identity.org_id)
-            .order_by(SupportConversation.created_at.desc())
-            .limit(1)
+    story #3276 — `conversation_id` 쿼리 파라미터 추가: 지정하면 그 특정 상담(자기 것만,
+    종료된 것 포함 — 읽기 전용 이력 열람)을 본다. 생략하면 "현재 활성 상담"을 본다(없으면
+    빈 목록 — GET에서 새 상담을 만들지 않는다, 부작용 없는 조회가 원칙)."""
+    request.state.delegated_org_id = str(identity.org_id)
+    await _get_session_or_404(db, session_id=session_id, identity=identity)
+
+    if conversation_id is not None:
+        conv = await _get_owned_conversation_or_404(
+            db, org_id=identity.org_id, external_user_id=identity.user_id, conversation_id=conversation_id
         )
-    ).scalar_one_or_none()
+    else:
+        conv = await _get_active_conversation(db, org_id=identity.org_id, external_user_id=identity.user_id)
     if conv is None:
-        return MessageListResponse(messages=[], escalation_status=None)
+        return MessageListResponse(conversation_id=None, ended_at=None, messages=[], escalation_status=None)
 
     messages = (
         await db.execute(
@@ -211,5 +268,90 @@ async def list_messages(
     ).scalars().all()
     escalation_status = await _conversation_escalation_status(db, conv.id)
     return MessageListResponse(
-        messages=[_to_message_response(m) for m in messages], escalation_status=escalation_status
+        conversation_id=conv.id,
+        ended_at=conv.ended_at,
+        messages=[_to_message_response(m) for m in messages],
+        escalation_status=escalation_status,
     )
+
+
+@router.get("/sessions/{session_id}/conversations", response_model=ConversationListResponse)
+@limiter.limit(lambda: settings.session_rate_limit)
+async def list_conversations(
+    request: Request,
+    session_id: uuid.UUID,
+    identity: DelegatedIdentity = Depends(require_delegated_identity),
+    db: AsyncSession = Depends(get_db),
+) -> ConversationListResponse:
+    """story #3276 AC3 — 위젯 대화 목록(자기 것만, 통례 수준 — 미리보기 텍스트 등은 v1
+    스코프 밖). created_at 최신순."""
+    request.state.delegated_org_id = str(identity.org_id)
+    await _get_session_or_404(db, session_id=session_id, identity=identity)
+
+    conversations = (
+        await db.execute(
+            select(SupportConversation)
+            .where(
+                SupportConversation.org_id == identity.org_id,
+                SupportConversation.external_user_id == identity.user_id,
+            )
+            .order_by(SupportConversation.created_at.desc())
+        )
+    ).scalars().all()
+    items = [
+        _to_conversation_response(conv, await _conversation_escalation_status(db, conv.id))
+        for conv in conversations
+    ]
+    return ConversationListResponse(conversations=items)
+
+
+@router.post("/sessions/{session_id}/conversations/start", response_model=ConversationResponse)
+@limiter.limit(lambda: settings.session_rate_limit)
+async def start_new_conversation(
+    request: Request,
+    session_id: uuid.UUID,
+    identity: DelegatedIdentity = Depends(require_delegated_identity),
+    db: AsyncSession = Depends(get_db),
+) -> ConversationResponse:
+    """story #3276 AC2 — 위젯 "새 상담 시작". 현재 활성 상담이 있으면 먼저 종료하고(명시
+    액션이 곧 "이전 건 그만"이라는 의사표시 — 굳이 별도 end 호출을 먼저 강제하지 않는다),
+    빈 새 상담을 만들어 돌려준다."""
+    request.state.delegated_org_id = str(identity.org_id)
+    session = await _get_session_or_404(db, session_id=session_id, identity=identity)
+
+    active = await _get_active_conversation(db, org_id=identity.org_id, external_user_id=identity.user_id)
+    if active is not None:
+        active.ended_at = datetime.now(timezone.utc)
+
+    conv = SupportConversation(org_id=identity.org_id, session_id=session.id, external_user_id=identity.user_id)
+    db.add(conv)
+    await db.commit()
+    await db.refresh(conv)
+    return _to_conversation_response(conv, escalation_status=None)
+
+
+@router.post("/sessions/{session_id}/conversations/{conversation_id}/end", response_model=ConversationResponse)
+@limiter.limit(lambda: settings.session_rate_limit)
+async def end_conversation(
+    request: Request,
+    session_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    identity: DelegatedIdentity = Depends(require_delegated_identity),
+    db: AsyncSession = Depends(get_db),
+) -> ConversationResponse:
+    """story #3276 AC2 — 위젯 "상담 종료". 종료된 상담=읽기 전용 이력(다음 메시지는 자동으로
+    새 상담을 연다, post_message 참고). SupportEscalation.status는 손대지 않는다 — 종료는
+    "이 대화창을 닫는다"는 뜻이지 "사람 연결이 해소됐다"는 뜻이 아니다(완전히 별개 축).
+    이미 종료된 상담을 다시 종료해도 멱등하게 200(재시도 안전) — ended_at을 덮어쓰지 않는다
+    (최초 종료 시각을 보존)."""
+    request.state.delegated_org_id = str(identity.org_id)
+    await _get_session_or_404(db, session_id=session_id, identity=identity)
+    conv = await _get_owned_conversation_or_404(
+        db, org_id=identity.org_id, external_user_id=identity.user_id, conversation_id=conversation_id
+    )
+    if conv.ended_at is None:
+        conv.ended_at = datetime.now(timezone.utc)
+        await db.commit()
+        await db.refresh(conv)
+    escalation_status = await _conversation_escalation_status(db, conv.id)
+    return _to_conversation_response(conv, escalation_status)

--- a/support-gateway/app/schemas.py
+++ b/support-gateway/app/schemas.py
@@ -47,10 +47,33 @@ class MessageListResponse(BaseModel):
 
     story #3263 AC4 — 재오픈 시에도 escalation_status가 살아있어야 한다(무신호 금지). 턴
     단위 `escalated` 배지는 그 순간이 지나면 화면에서 사라지지만, 사람에게 넘어간 사실
-    자체는 위젯을 닫았다 열어도 조용히 사라지면 안 된다."""
+    자체는 위젯을 닫았다 열어도 조용히 사라지면 안 된다.
 
+    story #3276 — `conversation_id`/`ended_at` 추가: 위젯이 지금 보는 상담이 어느 것인지·
+    종료됐는지(=읽기 전용, 입력창 비활성화해야 함)를 알 수 있어야 한다. 상담이 아예 없으면
+    (신규 사용자) 셋 다 None/빈 리스트."""
+
+    conversation_id: uuid.UUID | None
+    ended_at: datetime | None
     messages: list[MessageResponse]
     escalation_status: str | None
+
+
+class ConversationResponse(BaseModel):
+    """story #3276 — 상담 1건의 요약(목록·시작·종료 엔드포인트 공통 응답 shape). 고객 메시지
+    원문은 안 싣는다(AdminMetricsResponse와 같은 절제 원칙 — 필요하면 GET .../messages로
+    별도 조회)."""
+
+    id: uuid.UUID
+    created_at: datetime
+    ended_at: datetime | None
+    escalation_status: str | None
+
+
+class ConversationListResponse(BaseModel):
+    """story #3276 AC3 — GET .../conversations(위젯 대화 목록, 자기 것만). created_at 최신순."""
+
+    conversations: list[ConversationResponse]
 
 
 class AdminMetricsResponse(BaseModel):

--- a/support-gateway/tests/test_conversation_user_scope.py
+++ b/support-gateway/tests/test_conversation_user_scope.py
@@ -1,0 +1,249 @@
+"""story #3276(지원v1·후속) — 상담 대화 사용자 단위 분리+수명주기. 「의미론 선택 문장마다
+반대 구현을 red로 만드는 pin」 규율(story #3662/#3663 클래스) — AC 다섯 축을 각각 직접
+겨냥한다."""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+
+import app.execution_tasks as execution_tasks_module
+from app.metrics import compute_resolution_metrics
+from app.models import SupportConversation
+from tests.conftest import OTHER_ORG_ID, make_token
+
+
+async def _create_session(client, org_id, user_id):
+    headers = {"Authorization": f"Bearer {make_token(org_id, user_id=user_id)}"}
+    resp = await client.post("/api/v1/sessions", headers=headers)
+    return headers, resp.json()["id"]
+
+
+# --- AC1: 대화 스코프=(org_id, external_user_id) --------------------------------------
+
+
+async def test_same_org_different_users_get_independent_conversations(client, fake_llm):
+    """핵심 회귀 — 선생님이 실측한 그 증상 그대로: 같은 org 안 서로 다른 external_user_id는
+    절대 같은 대화를 공유하지 않는다(구 코드는 org_id만 봐서 공유했다)."""
+    user_a, user_b = uuid.uuid4(), uuid.uuid4()
+    headers_a, session_a = await _create_session(client, OTHER_ORG_ID, user_a)
+    headers_b, session_b = await _create_session(client, OTHER_ORG_ID, user_b)
+
+    await client.post(f"/api/v1/sessions/{session_a}/messages", json={"content": "A만의 비밀 문의"}, headers=headers_a)
+
+    resp_b = await client.get(f"/api/v1/sessions/{session_b}/messages", headers=headers_b)
+    assert resp_b.status_code == 200
+    assert resp_b.json()["messages"] == []  # B는 A의 흔적을 절대 못 본다.
+
+    resp_a = await client.get(f"/api/v1/sessions/{session_a}/messages", headers=headers_a)
+    assert any(m["content"] == "A만의 비밀 문의" for m in resp_a.json()["messages"])
+
+
+async def test_session_id_scoped_to_owning_user_not_just_org(client, fake_llm):
+    """story #3276 보강 pin — 같은 org의 타 사용자 session_id를 안다고 해도(추측·유출)
+    자기 토큰으로는 그 세션을 조작할 수 없다(404 — 존재 노출 없음)."""
+    user_a, user_b = uuid.uuid4(), uuid.uuid4()
+    _, session_a = await _create_session(client, OTHER_ORG_ID, user_a)
+    headers_b, _ = await _create_session(client, OTHER_ORG_ID, user_b)
+
+    resp = await client.post(
+        f"/api/v1/sessions/{session_a}/messages", json={"content": "hijack 시도"}, headers=headers_b
+    )
+    assert resp.status_code == 404
+
+
+async def test_cross_org_isolation_still_holds(client, fake_llm):
+    """#3264 자산(교차 org 격리 pin) 불변 확認 — story #3276이 사용자 축을 추가했다고 org
+    축이 느슨해지면 안 된다."""
+    from tests.conftest import MOONKLABS_ORG_ID
+
+    user = uuid.uuid4()
+    headers_a, session_a = await _create_session(client, OTHER_ORG_ID, user)
+    await client.post(f"/api/v1/sessions/{session_a}/messages", json={"content": "org A 비밀"}, headers=headers_a)
+
+    # 같은 external_user_id라도 org가 다르면 완전 별개(우연 일치조차 없어야 함).
+    headers_b, session_b = await _create_session(client, MOONKLABS_ORG_ID, user)
+    resp = await client.get(f"/api/v1/sessions/{session_b}/messages", headers=headers_b)
+    assert resp.json()["messages"] == []
+
+
+# --- AC2: 수명주기(새 상담·종료) --------------------------------------------------------
+
+
+async def test_start_new_conversation_ends_previous_and_isolates_messages(client, fake_llm):
+    user = uuid.uuid4()
+    headers, session_id = await _create_session(client, OTHER_ORG_ID, user)
+
+    await client.post(f"/api/v1/sessions/{session_id}/messages", json={"content": "첫 상담"}, headers=headers)
+
+    start_resp = await client.post(f"/api/v1/sessions/{session_id}/conversations/start", headers=headers)
+    assert start_resp.status_code == 200
+    new_conv = start_resp.json()
+    assert new_conv["ended_at"] is None
+
+    await client.post(f"/api/v1/sessions/{session_id}/messages", json={"content": "둘째 상담"}, headers=headers)
+
+    active = await client.get(f"/api/v1/sessions/{session_id}/messages", headers=headers)
+    contents = [m["content"] for m in active.json()["messages"] if m["role"] == "customer"]
+    assert contents == ["둘째 상담"]  # 첫 상담 메시지는 새 활성 대화에 안 섞인다.
+    assert active.json()["conversation_id"] == new_conv["id"]
+
+
+async def test_end_conversation_makes_it_read_only_history_next_message_opens_fresh_one(client, fake_llm):
+    user = uuid.uuid4()
+    headers, session_id = await _create_session(client, OTHER_ORG_ID, user)
+
+    post1 = await client.post(f"/api/v1/sessions/{session_id}/messages", json={"content": "종료 전"}, headers=headers)
+    conv_id = post1.json()["customer_message"]["conversation_id"]
+
+    end_resp = await client.post(f"/api/v1/sessions/{session_id}/conversations/{conv_id}/end", headers=headers)
+    assert end_resp.status_code == 200
+    assert end_resp.json()["ended_at"] is not None
+
+    # 종료된 대화를 굳이 재활용하지 않는다 — 다음 메시지는 자동으로 새 상담을 연다.
+    post2 = await client.post(f"/api/v1/sessions/{session_id}/messages", json={"content": "종료 후"}, headers=headers)
+    assert post2.json()["customer_message"]["conversation_id"] != conv_id
+
+    # 종료된 대화는 conversation_id로 명시 조회하면 그대로 읽힌다(읽기 전용 이력).
+    history = await client.get(
+        f"/api/v1/sessions/{session_id}/messages", params={"conversation_id": conv_id}, headers=headers
+    )
+    assert history.status_code == 200
+    assert history.json()["ended_at"] is not None
+    assert any(m["content"] == "종료 전" for m in history.json()["messages"])
+
+
+async def test_ending_conversation_does_not_touch_open_escalation_status(client, fake_llm):
+    """종료≠에스컬 해소 — 별개 축(AC2 명시 요구사항) pin."""
+    user = uuid.uuid4()
+    headers, session_id = await _create_session(client, OTHER_ORG_ID, user)
+
+    fake_llm.classify_text = "needs_human"
+    post1 = await client.post(f"/api/v1/sessions/{session_id}/messages", json={"content": "사람 필요"}, headers=headers)
+    assert post1.json()["escalation_status"] == "open"
+    conv_id = post1.json()["customer_message"]["conversation_id"]
+
+    end_resp = await client.post(f"/api/v1/sessions/{session_id}/conversations/{conv_id}/end", headers=headers)
+    assert end_resp.status_code == 200
+    assert end_resp.json()["escalation_status"] == "open"  # 종료가 에스컬 상태를 안 건드림.
+
+
+async def test_end_conversation_is_idempotent(client, fake_llm):
+    user = uuid.uuid4()
+    headers, session_id = await _create_session(client, OTHER_ORG_ID, user)
+    post1 = await client.post(f"/api/v1/sessions/{session_id}/messages", json={"content": "hi"}, headers=headers)
+    conv_id = post1.json()["customer_message"]["conversation_id"]
+
+    r1 = await client.post(f"/api/v1/sessions/{session_id}/conversations/{conv_id}/end", headers=headers)
+    r2 = await client.post(f"/api/v1/sessions/{session_id}/conversations/{conv_id}/end", headers=headers)
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert r1.json()["ended_at"] == r2.json()["ended_at"]  # 최초 종료 시각 보존, 재호출로 안 밀림.
+
+
+async def test_cannot_end_another_users_conversation(client, fake_llm):
+    user_a, user_b = uuid.uuid4(), uuid.uuid4()
+    headers_a, session_a = await _create_session(client, OTHER_ORG_ID, user_a)
+    headers_b, session_b = await _create_session(client, OTHER_ORG_ID, user_b)
+
+    post1 = await client.post(f"/api/v1/sessions/{session_a}/messages", json={"content": "A의 상담"}, headers=headers_a)
+    conv_a = post1.json()["customer_message"]["conversation_id"]
+
+    resp = await client.post(f"/api/v1/sessions/{session_b}/conversations/{conv_a}/end", headers=headers_b)
+    assert resp.status_code == 404
+
+
+# --- AC3: 위젯 대화 목록(자기 것만) ------------------------------------------------------
+
+
+async def test_list_conversations_returns_only_own_conversations(client, fake_llm):
+    user_a, user_b = uuid.uuid4(), uuid.uuid4()
+    headers_a, session_a = await _create_session(client, OTHER_ORG_ID, user_a)
+    headers_b, session_b = await _create_session(client, OTHER_ORG_ID, user_b)
+
+    await client.post(f"/api/v1/sessions/{session_a}/messages", json={"content": "A"}, headers=headers_a)
+    await client.post(f"/api/v1/sessions/{session_a}/conversations/start", headers=headers_a)
+    await client.post(f"/api/v1/sessions/{session_b}/messages", json={"content": "B"}, headers=headers_b)
+
+    list_a = await client.get(f"/api/v1/sessions/{session_a}/conversations", headers=headers_a)
+    assert list_a.status_code == 200
+    assert len(list_a.json()["conversations"]) == 2  # A의 상담 2개(원본+새로 시작한 것)
+
+    list_b = await client.get(f"/api/v1/sessions/{session_b}/conversations", headers=headers_b)
+    assert len(list_b.json()["conversations"]) == 1
+    assert list_b.json()["conversations"][0]["id"] != list_a.json()["conversations"][0]["id"]
+
+
+# --- AC4: 기존 데이터 처분(레거시 봉인) ---------------------------------------------------
+
+
+async def test_legacy_org_scoped_conversation_is_sealed_unreachable_by_any_user(client, fake_llm, db_engine):
+    """레거시 행(external_user_id=NULL, 마이그 前 생성분 시뮬레이션)은 신규 조회 경로 어디서도
+    안 걸린다 — backfill 안 함(봉인), 삭제도 안 함(DB엔 남아 감사 가능)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    legacy_id = uuid.uuid4()
+    async with async_sessionmaker(db_engine, expire_on_commit=False)() as session:
+        legacy = SupportConversation(id=legacy_id, org_id=OTHER_ORG_ID, session_id=uuid.uuid4(), external_user_id=None)
+        session.add(legacy)
+        await session.commit()
+
+    user = uuid.uuid4()
+    headers, session_id = await _create_session(client, OTHER_ORG_ID, user)
+
+    # 활성 상담 조회(자동 get-or-create)는 레거시 행을 절대 재사용하지 않는다 — 새 것을 만든다.
+    resp = await client.post(f"/api/v1/sessions/{session_id}/messages", json={"content": "hi"}, headers=headers)
+    assert resp.json()["customer_message"]["conversation_id"] != legacy_id
+
+    # 목록에도 안 뜬다.
+    listing = await client.get(f"/api/v1/sessions/{session_id}/conversations", headers=headers)
+    assert legacy_id not in {c["id"] for c in listing.json()["conversations"]}
+
+    # 명시 conversation_id로 찔러봐도 404(소유권 없음 — external_user_id 불일치).
+    peek = await client.get(
+        f"/api/v1/sessions/{session_id}/messages", params={"conversation_id": str(legacy_id)}, headers=headers
+    )
+    assert peek.status_code == 404
+
+    # 데이터 자체는 DB에 그대로 남아있다(삭제 아님, 감사 가능).
+    async with async_sessionmaker(db_engine, expire_on_commit=False)() as session:
+        still_there = await session.get(SupportConversation, legacy_id)
+        assert still_there is not None
+        assert still_there.external_user_id is None
+
+
+# --- AC5: 계측 정합 ---------------------------------------------------------------------
+
+
+async def test_metrics_total_turns_unaffected_by_per_user_conversation_split(client, fake_llm, db_engine):
+    """story #3264 metrics는 SupportMessage/SupportEscalation row count 기반(org_id만
+    필터, conversation 무관) — 대화가 org당 1개든 사용자별로 N개로 쪼개지든 turn 카운트는
+    똑같아야 한다. 이 반례가 깨지면(예: 미래에 누군가 conversation 단위로 잘못 재집계하면)
+    이 pin이 red가 된다."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    user_a, user_b = uuid.uuid4(), uuid.uuid4()
+    headers_a, session_a = await _create_session(client, OTHER_ORG_ID, user_a)
+    headers_b, session_b = await _create_session(client, OTHER_ORG_ID, user_b)
+
+    await client.post(f"/api/v1/sessions/{session_a}/messages", json={"content": "A1"}, headers=headers_a)
+    await client.post(f"/api/v1/sessions/{session_a}/messages", json={"content": "A2"}, headers=headers_a)
+    await client.post(f"/api/v1/sessions/{session_b}/messages", json={"content": "B1"}, headers=headers_b)
+
+    async with async_sessionmaker(db_engine, expire_on_commit=False)() as session:
+        metrics = await compute_resolution_metrics(session, org_id=OTHER_ORG_ID)
+    assert metrics.total_turns == 3  # 대화 2개(사용자별)에 걸쳐 있어도 agent 메시지 3건 그대로.
+
+
+async def test_escalation_status_is_per_conversation_not_leaked_across_users_in_same_org(client, fake_llm):
+    """#3263 AC4 escalation_status 함수 자체는 무변경이지만, 스코프가 올바르게 좁혀졌으니
+    자동으로 per-user가 되어야 한다 — B의 에스컬레이션이 A의 escalation_status에 안 새는지."""
+    user_a, user_b = uuid.uuid4(), uuid.uuid4()
+    headers_a, session_a = await _create_session(client, OTHER_ORG_ID, user_a)
+    headers_b, session_b = await _create_session(client, OTHER_ORG_ID, user_b)
+
+    fake_llm.classify_text = "needs_human"
+    await client.post(f"/api/v1/sessions/{session_b}/messages", json={"content": "B가 사람 필요"}, headers=headers_b)
+
+    fake_llm.classify_text = "inquiry"
+    resp_a = await client.post(f"/api/v1/sessions/{session_a}/messages", json={"content": "A는 그냥 문의"}, headers=headers_a)
+    assert resp_a.json()["escalation_status"] is None  # B의 에스컬레이션이 A에게 안 보임.


### PR DESCRIPTION
[SID:3276]

## 배경
선생님 customer-zero 실사용 중 타 계정 테스트 흔적이 자기 위젯에 보임 — `sessions.py`의 `_get_or_create_conversation`·`list_messages` 둘 다 conversation을 **org_id만**으로 조회해(`session.external_user_id`는 아예 안 봄) 같은 org의 모든 사용자가 org당 1개뿐인 최신 대화를 공유하고 있었다.

## 방향(선생님 확定 2026-09-01, 페드루 PO 승인)
Blueprint §1.1 "org당 1스레드"의 원 의도=org는 최소(절대) 격리 단위 — 그 격리는 그대로 두고, **상담 자체는 사용자 단위로 분리**한다.

## 스키마(migration 0003)
- `support_conversations`에 `external_user_id`(nullable)·`ended_at`(nullable) 추가.
- **레거시 처분(AC4)**: 기존 행은 backfill 안 함 — `external_user_id=NULL`로 **봉인**. 원 생성 세션으로 귀속시키는 대안도 검토했으나, 그러면 오염 이력이 원 생성자 화면에 그대로 남아 증상이 안 지워진다(반례) — 봉인이 증상 자체를 완전히 지운다. 삭제는 안 함(감사 목적으로 DB엔 남는다).
- 로컬 real Postgres(pgvector/pg16)로 `0001→0003` upgrade + `0003→0002` downgrade 왕복 검증 완료.

## API 변경(`app/routers/sessions.py`)
- **AC1**: `(org_id, external_user_id)`당 활성(`ended_at IS NULL`) 상담 최대 1개(통례, 인터컴류) — 같은 org 안에서도 남의 대화에 절대 안 닿는다.
- **AC2**: `POST .../conversations/start`(현재 활성 종료+신규 생성) · `POST .../conversations/{id}/end`(명시 종료, 멱등, 최초 종료 시각 보존). `SupportEscalation.status`는 완전히 별개 축 — 종료해도 안 건드린다(pin).
- **AC3**: `GET .../conversations` — 자기 것만 목록(통례 수준, 과설계 안 함).
- `GET .../messages`에 `conversation_id` 쿼리 파라미터 추가 — 특정(종료 포함) 상담 읽기 전용 조회. 생략 시 현재 활성 상담(GET은 부작용 없음 — 새 상담을 만들지 않는다).
- 보강: 세션 조회도 `org_id`뿐 아니라 `external_user_id`까지 확인(위임 토큰 소유자만 자기 세션 조작 가능 — 이전엔 org_id만 봐서 이론상 통로가 있었다, 이 스토리로 조회 축을 조이는 김에 같이 닫음).

## 계측 정합(AC5)
- `metrics.py`(#3264)는 이미 `SupportMessage`/`SupportEscalation` row count 기반(conversation 무관, org_id만 필터) — **변경 불요**, pin 테스트로 확認.
- `_conversation_escalation_status`(#3263 AC4)는 `conversation_id` 단위 그대로 — 스코프가 올바르게 좁혀지니 **코드 변경 없이 자동으로 per-user화**, pin 테스트로 확認.

## 검증
- 신규 `tests/test_conversation_user_scope.py` 12건(AC1~5 각 축 직접 겨냥) + 기존 123건 = **135 passed**.
- 핵심 격리 가드 직접 뮤테이션(`_get_active_conversation`에서 `external_user_id` 필터 제거) 적용 → 신규 pin 3건(AC1 핵심 격리·목록 누출·에스컬 상태 누출)이 확실히 red로 죽는 것 확認 → 원복 → green 재확인.

## 스코프 밖(페드루 PO 지시)
FE(위젯 새상담/종료 버튼·목록 UI)는 같은 스토리의 **2차 PR** — [\[지원v1·후속\] 상담 진입 모델 재설계](entity:story:cba6b3ea-58d8-4b83-a1a3-fda4bc88c0d4)(미르코군 진입 모델) 착지 후 순서(위젯 표면 겹침). 스토리 `done`은 FE 실픽셀+라이브 실측까지, 단 이 BE PR만 착지해도 **"타인 흔적 보임" 증상 자체는 즉시 소멸**(list가 per-user로 좁혀지므로).