### PR TITLE
[SID:3274] 상담 진입 모델 재설계 — 상시 플로팅 폐기, 온보딩 한정+설정>문의

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1478,6 +1478,7 @@
     "tabAppearance": "Appearance",
     "tabApiKeys": "API Keys",
     "tabNotifications": "Notifications",
+    "tabSupport": "Contact & Support",
     "tabAiAgents": "AI & Agents",
     "tabProjects": "Projects",
     "tabMembers": "Access",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1478,6 +1478,7 @@
     "tabAppearance": "테마",
     "tabApiKeys": "API 키",
     "tabNotifications": "알림",
+    "tabSupport": "문의·고객지원",
     "tabAiAgents": "AI & 에이전트",
     "tabProjects": "프로젝트",
     "tabMembers": "접근 권한",

--- a/apps/web/src/app/(authenticated)/settings/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.test.tsx
@@ -87,3 +87,60 @@ describe('SettingsPage — 전역 법적 고지 푸터 (story #2865)', () => {
     expect(termsLinks).toHaveLength(1);
   });
 });
+
+// story #3274(지원v1·후속, 선생님 확定 2026-09-01) — 상시 플로팅 폐기 후 "일반 상황" 유일
+// 진입점. isSupportWidgetEnabled() 뒤 게이팅(dev on·prod off, EE_ENABLED와 동일 컨벤션)과
+// ?tab=support 딥링크 폴백 둘 다 고정한다.
+describe('SettingsPage — story #3274: 설정 > 문의 탭', () => {
+  const ORIGINAL_FLAG = process.env['NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED'];
+
+  afterEach(() => {
+    if (ORIGINAL_FLAG === undefined) delete process.env['NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED'];
+    else process.env['NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED'] = ORIGINAL_FLAG;
+  });
+
+  it('flag off(prod 기본값) — 문의 탭 트리거 자체가 없다', async () => {
+    delete process.env['NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED'];
+    const { default: SettingsPage } = await import('./page');
+    await mount(<SettingsPage />);
+    expect(container.textContent).not.toContain(koMessages.settings.tabSupport);
+  });
+
+  it('flag on — 문의 탭 트리거가 뜨고, 클릭하면 위젯 패널(panelTitle)이 인라인 렌더된다', async () => {
+    process.env['NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED'] = 'true';
+    // 파일 최상단 hoisted mock의 useSearchParams()는 호출마다 `new URLSearchParams(...)`를
+    // 새로 만들어 참조가 매 렌더 달라진다 — 실 Next.js useSearchParams()는 네비게이션이
+    // 실제로 안 바뀌면 안정적인 참조를 주는데, 이 목은 그렇지 않아 페이지의
+    // `useEffect(() => setActiveTab(...), [searchParamsHook])`가 매 렌더 재발화해 클릭으로
+    // 바꾼 activeTab을 url의 tab=appearance로 즉시 되돌려버린다(목 아티팩트 — 실 프로덕션
+    // 동작이 아님). 이 테스트만 안정 참조로 override.
+    const stableParams = new URLSearchParams('tab=appearance');
+    vi.doMock('next/navigation', () => ({
+      useRouter: () => ({ replace: vi.fn(), refresh: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+      useSearchParams: () => stableParams,
+      usePathname: () => '/settings',
+    }));
+    const { default: SettingsPage } = await import('./page');
+    await mount(<SettingsPage />);
+
+    const trigger = Array.from(container.querySelectorAll('[role="tab"]')).find(
+      (el) => el.textContent?.includes(koMessages.settings.tabSupport),
+    ) as HTMLElement;
+    expect(trigger).not.toBeUndefined();
+    await act(async () => { trigger.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    expect(container.textContent).toContain(koMessages.supportWidget.panelTitle);
+  });
+
+  it('flag off인데 ?tab=support로 직접 진입해도 기본 탭(profile)으로 폴백한다(빈 화면 방지)', async () => {
+    delete process.env['NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED'];
+    vi.doMock('next/navigation', () => ({
+      useRouter: () => ({ replace: vi.fn(), refresh: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+      useSearchParams: () => new URLSearchParams('tab=support'),
+      usePathname: () => '/settings',
+    }));
+    const { default: SettingsPage } = await import('./page');
+    await mount(<SettingsPage />);
+    expect(container.textContent).not.toContain(koMessages.supportWidget.panelTitle);
+  });
+});

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -5,7 +5,7 @@ import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { BarChart2, Bell, Bot, CreditCard, FolderKanban, GitBranch, Menu, Palette, Plus, ShieldCheck, Trash2, User, Users, Webhook, X } from 'lucide-react';
+import { BarChart2, Bell, Bot, CreditCard, FolderKanban, GitBranch, LifeBuoy, Menu, Palette, Plus, ShieldCheck, Trash2, User, Users, Webhook, X } from 'lucide-react';
 import { UsageDashboard } from '@/components/settings/usage-dashboard';
 import { OrgMembersSection } from '@/components/settings/org-members-section';
 import { AddMemberModal } from '@/components/settings/add-member-modal';
@@ -40,6 +40,8 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { NOTIFICATION_TYPES } from '@/lib/notification-types';
 import { isEEEnabled } from '@/lib/ee';
+import { isSupportWidgetEnabled } from '@/lib/support-widget-flag';
+import { SupportSettingsTabPanel } from '@/components/settings/support-tab-panel';
 import { HumanOnlyAction } from '@/components/ui/human-only-action';
 import dynamic from 'next/dynamic';
 import { fetchWithAuth } from '@/lib/db/client';
@@ -109,8 +111,12 @@ const HIDDEN_SETTINGS_TABS = new Set<string>(['ai', 'workflow', 'org-members']);
 const DEFAULT_SETTINGS_TAB = 'profile';
 
 // ?tab= 딥링크가 숨김 탭을 가리키면 기본 탭으로 폴백 (빈 화면 방지).
+// story #3274 — support 탭은 isSupportWidgetEnabled() 뒤(prod는 아직 false)라 flag off일
+// 때 ?tab=support로 직접 들어오면 트리거/콘텐츠가 아예 안 그려져 빈 화면이 된다 — 그
+// 경우도 기본 탭으로 폴백.
 function resolveSettingsTab(tab: string | null): string {
   if (!tab || HIDDEN_SETTINGS_TABS.has(tab)) return DEFAULT_SETTINGS_TAB;
+  if (tab === 'support' && !isSupportWidgetEnabled()) return DEFAULT_SETTINGS_TAB;
   return tab;
 }
 
@@ -690,6 +696,12 @@ export default function SettingsPage() {
               <Bell className="h-4 w-4" />
               {t('tabNotifications')}
             </TabsTrigger>
+            {isSupportWidgetEnabled() && (
+              <TabsTrigger value="support">
+                <LifeBuoy className="h-4 w-4" />
+                {t('tabSupport')}
+              </TabsTrigger>
+            )}
 
             <span className="px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground">{t('projectSettings')}</span>
             {currentProjectId && !HIDDEN_SETTINGS_TABS.has('ai') ? (
@@ -810,6 +822,12 @@ export default function SettingsPage() {
             <TabsContent value="appearance">
               <ThemeSettings />
             </TabsContent>
+
+            {isSupportWidgetEnabled() && (
+              <TabsContent value="support">
+                <SupportSettingsTabPanel />
+              </TabsContent>
+            )}
 
             <TabsContent value="api-keys">
               <SectionCard>

--- a/apps/web/src/components/dashboard/activation-checklist-banner.test.tsx
+++ b/apps/web/src/components/dashboard/activation-checklist-banner.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { ActivationChecklistBanner } from './activation-checklist-banner';
+import { _resetActivationStatusCacheForTests } from '@/hooks/use-activation-status';
 
 // story #3201 — useDashboardContext(projectId)·useRouter 신규 의존성. storage-capacity-
 // banner.test.tsx와 동일 패턴(실 dashboard-shell.tsx 전체 모듈 그래프를 끌어들이지 않음).
@@ -50,6 +51,7 @@ beforeEach(() => {
   stubStorages();
   routerPushMock.mockClear();
   createFirstInstructionConversationMock.mockReset();
+  _resetActivationStatusCacheForTests();
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);

--- a/apps/web/src/components/dashboard/activation-checklist-banner.tsx
+++ b/apps/web/src/components/dashboard/activation-checklist-banner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -8,53 +8,26 @@ import { ChevronDown, ChevronUp, Circle, CircleCheck, Loader2 } from 'lucide-rea
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
-import { fetchWithAuth } from '@/lib/db/client';
+import { useActivationStatus, type ActivationState } from '@/hooks/use-activation-status';
 import { createFirstInstructionConversation } from '@/lib/onboarding/first-instruction';
 import { cn } from '@/lib/utils';
 
 /**
  * story #3159(retention·최소층) — 가입 후 남은 activation 단계를 상시 노출(완주 유도).
- * `/api/activation/checklist` 마운트 1회 조회(storage-capacity-banner.tsx와 동형 no-polling
- * 패턴). PO 지시(2026-08-27): 완전 소멸은 완주(all_complete) 시만 — 접기(collapse)는
- * 허용하되 접힌 상태에서도 진행률 칩은 남는다(수동 dismiss로 완전히 숨길 순 없음).
+ * PO 지시(2026-08-27): 완전 소멸은 완주(all_complete) 시만 — 접기(collapse)는 허용하되
+ * 접힌 상태에서도 진행률 칩은 남는다(수동 dismiss로 완전히 숨길 순 없음).
  *
- * 완주를 한 번 관측하면 localStorage에 영구 기록해 이후 세션은 fetch 자체를 건너뛴다
- * (activation은 단조 증가 — 한 번 다 채우면 되돌아가지 않는다. 활성 사용자 전원이 매
- * 세션 이 엔드포인트를 다시 때리는 낭비 방지).
+ * story #3274 — fetch/skip(COMPLETE_KEY) 로직은 `useActivationStatus()`(hooks/use-
+ * activation-status.ts)로 분리했다 — support-widget-launcher.tsx의 온보딩 단계 게이팅과
+ * 같은 조회를 공유한다(두 벌 판별자·중복 네트워크 호출 금지, AC①).
  */
-const COMPLETE_KEY = 'sprintable_activation_checklist_complete';
 const COLLAPSE_KEY = 'sprintable_activation_checklist_collapsed';
-
-interface ActivationState {
-  steps: {
-    signed_up: boolean;
-    email_verified: boolean;
-    org_created: boolean;
-    agent_connected: boolean;
-    first_roundtrip: boolean;
-  };
-  completed: number;
-  total: number;
-  all_complete: boolean;
-  // story #3201 — 왕복 성사된 대화(또는 org 최초 agent DM) id, 없으면 null.
-  first_instruction_conversation_id: string | null;
-}
-
-function readLocalFlag(key: string): boolean {
-  if (typeof window === 'undefined') return false;
-  try {
-    return window.localStorage.getItem(key) === '1';
-  } catch {
-    return false;
-  }
-}
 
 export function ActivationChecklistBanner() {
   const t = useTranslations('activation');
   const router = useRouter();
   const { projectId } = useDashboardContext();
-  const [state, setState] = useState<ActivationState | null>(null);
-  const [skip] = useState<boolean>(() => readLocalFlag(COMPLETE_KEY));
+  const { state, allComplete } = useActivationStatus();
   const [navigatingToInstruction, setNavigatingToInstruction] = useState(false);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
@@ -65,33 +38,7 @@ export function ActivationChecklistBanner() {
     }
   });
 
-  useEffect(() => {
-    if (skip) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const res = await fetchWithAuth('/api/activation/checklist');
-        if (!res.ok) return;
-        const json = (await res.json()) as { data?: ActivationState };
-        if (cancelled || !json.data) return;
-        setState(json.data);
-        if (json.data.all_complete) {
-          try {
-            window.localStorage.setItem(COMPLETE_KEY, '1');
-          } catch {
-            // 영속 실패해도 이번 렌더는 정상 동작(단지 다음 세션에 한 번 더 조회할 뿐)
-          }
-        }
-      } catch {
-        // 조회 실패는 치명적이지 않음 — 배너 미노출
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [skip]);
-
-  if (skip || !state || state.all_complete) return null;
+  if (allComplete || !state) return null;
 
   const toggleCollapse = () => {
     const next = !collapsed;

--- a/apps/web/src/components/settings/support-tab-panel.tsx
+++ b/apps/web/src/components/settings/support-tab-panel.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+import { useSupportWidgetSession } from '@/hooks/use-support-widget-session';
+import { SupportWidgetPanelBody } from '@/components/support-widget/support-widget-panel';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+
+/**
+ * story #3274(지원v1·후속, 선생님 확定 2026-09-01) — 상시 플로팅 폐기 후 "일반 상황"의
+ * 유일한 상담 진입점. 설정 > 문의 탭(settings/page.tsx `support` 탭 콘텐츠)에 위젯 세션
+ * 훅+패널 body를 그대로 인라인 임베드한다(#3260 자산 재사용 — 발명 0, support-widget-
+ * launcher.tsx의 오버레이 chrome/닫기 버튼만 빼고 body는 완전히 동일 컴포넌트).
+ *
+ * 탭이 활성화될 때만 마운트된다(TabsContent의 base-ui Tabs.Panel 기본값 keepMounted=false
+ * — 비활성 탭은 아예 언마운트) — 그래서 이 컴포넌트의 mount effect 1회 connect()가 곧
+ * "탭을 열 때만 세션 발급"과 정확히 대응한다(런처의 open→connect 패턴과 동형, 사용자가
+ * 안 연 탭에서 미리 토큰을 발급하지 않는다).
+ */
+export function SupportSettingsTabPanel() {
+  const t = useTranslations('supportWidget');
+  const session = useSupportWidgetSession();
+
+  useEffect(() => {
+    session.connect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- 마운트 1회만(런처의 [open] 패턴과 동형, session 참조 변경에 재발화 금지 — story #3260 2차 재시도 스톰 교훈 그대로 적용)
+  }, []);
+
+  return (
+    <SectionCard>
+      <SectionCardHeader>
+        <h2 className="text-sm font-semibold text-foreground">{t('panelTitle')}</h2>
+        <p className="text-xs text-muted-foreground">{t('panelSubtitle')}</p>
+      </SectionCardHeader>
+      <SectionCardBody className="p-0">
+        <div className="flex h-[32rem] flex-col overflow-hidden rounded-b-[inherit] border-t border-border">
+          <SupportWidgetPanelBody session={session} />
+        </div>
+      </SectionCardBody>
+    </SectionCard>
+  );
+}

--- a/apps/web/src/components/support-widget/support-widget-launcher.effect-deps.test.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.effect-deps.test.tsx
@@ -17,6 +17,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { SidebarProvider } from '@/components/ui/sidebar';
+import { _resetActivationStatusCacheForTests } from '@/hooks/use-activation-status';
 import type { SupportWidgetSession } from '@/hooks/use-support-widget-session';
 import { SupportWidgetLauncher } from './support-widget-launcher';
 
@@ -59,11 +60,23 @@ beforeEach(() => {
     removeItem: () => {},
     clear: () => {},
   });
+  // story #3274 — 런처가 이제 useActivationStatus()도 부른다(온보딩 단계 게이팅). 이 파일의
+  // 관심사는 effect deps 회귀 하나뿐이라, activation 조회는 "미완주"(런처가 뜨는 쪽)로
+  // 고정해 무관 변수로 만든다 — 캐시도 파일 간/테스트 간 새지 않게 리셋.
+  _resetActivationStatusCacheForTests();
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ data: {
+      steps: { signed_up: true, email_verified: false, org_created: false, agent_connected: false, first_roundtrip: false },
+      completed: 1, total: 5, all_complete: false, first_instruction_conversation_id: null,
+    } }),
+  })));
 });
 
 afterEach(async () => {
   await act(async () => { root.unmount(); });
   container.remove();
+  vi.unstubAllGlobals();
 });
 
 async function mount() {

--- a/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
@@ -334,3 +334,27 @@ describe('SupportWidgetLauncher — story #3274: 온보딩 단계 게이팅(핵�
     expect(container.querySelector('button')).toBeTruthy();
   });
 });
+
+// 유나 design 리뷰 🟡(PR#3668 2차, 2026-09-01) — 설정 > 문의 탭(패널A, 마운트 시 connect)과
+// 이 플로팅(패널B, 클릭 시 connect)이 같은 화면에서 동시에 열리면 세션 훅 인스턴스 2개가
+// 서로 안 보이는 로컬 messages state를 각자 가져 뷰 불일치가 생긴다. isMobileChatDetailRoute와
+// 동형으로 설정 라우트에서 원천 차단(설정 페이지의 상담 진입점은 문의 탭 하나로 충분).
+describe('SupportWidgetLauncher — story #3274 2차: 설정 라우트 숨김(세션 이중 원천 차단)', () => {
+  it('/settings — 플로팅이 안 뜬다(문의 탭과의 이중 세션 방지)', async () => {
+    usePathnameMock.mockReturnValue('/settings');
+    await mount();
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('/settings/integrations(설정 하위 라우트) — 마찬가지로 안 뜬다', async () => {
+    usePathnameMock.mockReturnValue('/settings/integrations');
+    await mount();
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('설정과 무관한 라우트(/board) — 영향 없이 그대로 뜬다(무회귀)', async () => {
+    usePathnameMock.mockReturnValue('/board');
+    await mount();
+    expect(container.querySelector('button')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
@@ -11,7 +11,10 @@ import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { SidebarProvider } from '@/components/ui/sidebar';
+import { _resetActivationStatusCacheForTests } from '@/hooks/use-activation-status';
 import { SupportWidgetLauncher } from './support-widget-launcher';
+
+const ACTIVATION_COMPLETE_KEY = 'sprintable_activation_checklist_complete';
 
 // story #3260 2차 finding(유나 라이브 실측 FAIL — 재시도 스톰, 2026-08-31) 회귀가드용 —
 // isSupportGatewayConfiguredMock 기본값은 false(기존 테스트 전부가 'unavailable'을 가정
@@ -61,6 +64,11 @@ beforeEach(() => {
   isSupportGatewayConfiguredMock.mockReset().mockReturnValue(false);
   createOrResumeGatewaySessionMock.mockReset();
   usePathnameMock.mockReset().mockReturnValue('/board');
+  // story #3274 — 런처가 이제 useActivationStatus()도 부른다(온보딩 단계 게이팅). 이
+  // 파일의 기존 테스트 전부는 "런처가 뜬다"를 전제하므로 기본값=미완주(fetch 미설정 시
+  // 실 fetch가 실패해 allComplete=false로 남는 것과 동형, use-activation-status.ts의
+  // fail-closed와 일치) — 게이팅 자체를 겨냥하는 describe만 별도로 완주 상태를 만든다.
+  _resetActivationStatusCacheForTests();
 });
 
 afterEach(async () => {
@@ -135,47 +143,12 @@ describe('SupportWidgetLauncher — story #3260 셸', () => {
   });
 });
 
-// story #3260 2차 finding(2026-08-31, 유나 pre-merge 수치 판정) — 1차 수정(lg:bottom-40)은
-// 「덮는 사이드바 행이 바뀔 뿐」이었다: 런처가 left-5로 사이드바 x-범위 «안»에 있는 한 세로
-// 오프셋은 근본 해소가 아니다. useSidebar()의 실 폭(리사이즈 가능 200~360px)을 읽어 사이드바
-// 밖으로 가로 이동하는지, collapsed(offcanvas·가시폭 0)·모바일(사이드바가 Sheet라 폭을 안
-// 먹음)은 override가 없는지를 고정한다.
-describe('SupportWidgetLauncher — story #3260 2차: 사이드바 실 폭 기반 데스크톱 가로 회피', () => {
-  it('데스크톱·사이드바 기본폭(256px) 확장 상태 — 런처가 256+16=272px 지점으로 이동한다', async () => {
-    await mount();
-    const btn = container.querySelector('button') as HTMLButtonElement;
-    expect(btn.style.left).toBe('272px');
-  });
-
-  it('데스크톱·사이드바 리사이즈된 폭(예: 320px) — 정적 추정이 아니라 실 폭을 그대로 반영한다("폭 가변" 함정 회귀가드)', async () => {
-    window.localStorage.setItem('sidebar_width', '320');
-    await mount();
-    const btn = container.querySelector('button') as HTMLButtonElement;
-    expect(btn.style.left).toBe('336px');
-  });
-
-  it('데스크톱·사이드바 collapsed(offcanvas, 가시폭 0) — 기본 left-5(클래스)로 되돌아가고 인라인 override가 없다', async () => {
-    await mount({ defaultOpen: false });
-    const btn = container.querySelector('button') as HTMLButtonElement;
-    expect(btn.style.left).toBe('');
-    expect(btn.className).toContain('left-5');
-  });
-
-  it('모바일(<1024) — 사이드바가 Sheet(오프캔버스)라 화면 폭을 안 먹으므로 사이드바 폭·상태와 무관하게 override가 없다', async () => {
-    setInnerWidth(500);
-    await mount();
-    const btn = container.querySelector('button') as HTMLButtonElement;
-    expect(btn.style.left).toBe('');
-  });
-
-  it('오버레이 패널도 런처와 동일한 가로 오프셋을 공유한다(같은 x축에서 열려야 자연스럽다)', async () => {
-    await mount();
-    const btn = container.querySelector('button') as HTMLButtonElement;
-    await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
-    const panel = container.querySelector('[role="dialog"]') as HTMLElement;
-    expect(panel.style.left).toBe('272px');
-  });
-});
+// story #3274(선생님 확定 2026-09-01) — 좌하단 배치+사이드바 실 폭 회피 로직(위 5건짜리
+// describe, story #3260 2차 finding)을 통째로 걷었다. 걷는 이유: 런처가 우하단으로
+// 옮겨가 좌측 고정 사이드바와 애초에 안 겹치므로 그 회피 자체가 무의미해졌다(사이드바가
+// 없어진 게 아니라 이 컴포넌트가 반대편으로 이동해 그 충돌축이 통째로 사라짐) — 새
+// 충돌축(우하단 toast/저장오류 배너)은 아래 "우하단 배치+토스트 corner 회피" describe가
+// 대신 고정한다.
 
 // story #3260 2차 finding(2026-08-31, 유나 라이브 실측 FAIL) — CSP가 Gateway fetch를
 // 막는 상황(즉시·동기에 가깝게 실패)에서 connect()가 4초에 87회(~22/s) 발화했다. 원인은
@@ -231,13 +204,13 @@ describe('SupportWidgetLauncher — story #3260 2차: 재시도 스톰 회귀가
   });
 });
 
-// story #3260 3차 finding(2026-08-31, 선생님 실기기 적발→유나 design 확定) — 모바일 채팅
-// 상세(/chats/{id})는 자체 하단 첨부/전송 아이콘 열이 있어 런처(bottom-20 left-5)가 그 위에
-// 그대로 겹쳤다(실기기 스크린샷 실증, entity:artifact:13c9e4cb). 리스트(/chats, id 없음)는
-// 그 열이 없어 무관 — chats/layout.tsx의 isListRoute = pathname === '/chats' 판정과 대칭.
-// 페드루 PO 발주 pin 3종: 모바일 상세=DOM 0 / 모바일 리스트·보드=기존 그대로 / 데스크톱=라우트
-// 무관 불변.
-describe('SupportWidgetLauncher — story #3260 3차: 모바일 채팅-상세 숨김', () => {
+// story #3260 3차 finding(2026-08-31, 선생님 실기기 적발→유나 design 확定), story #3274로
+// 위치만 우측 이전 — 모바일 채팅 상세(/chats/{id})는 자체 하단 첨부/전송 아이콘 열이 있어
+// 겹친다는 사실 자체는 좌→우 이동과 무관하게 그대로다(실기기 스크린샷 실증,
+// entity:artifact:13c9e4cb). 리스트(/chats, id 없음)는 그 열이 없어 무관 — chats/layout.tsx의
+// isListRoute = pathname === '/chats' 판정과 대칭. 페드루 PO 발주 pin 3종: 모바일 상세=DOM 0 /
+// 모바일 리스트·보드=기존 그대로 / 데스크톱=라우트 무관 불변.
+describe('SupportWidgetLauncher — story #3260 3차(3274로 우측 이전): 모바일 채팅-상세 숨김', () => {
   it('모바일 + 채팅-상세(/chats/conv-123) — 런처 DOM 자체가 없다(겹침 원천 차단)', async () => {
     setInnerWidth(500);
     usePathnameMock.mockReturnValue('/chats/conv-123');
@@ -262,12 +235,65 @@ describe('SupportWidgetLauncher — story #3260 3차: 모바일 채팅-상세 �
     expect(container.querySelector('button')).toBeTruthy();
   });
 
-  it('데스크톱 — 채팅-상세 라우트여도 사이드바 폭+16px 배치가 그대로다(데스크톱은 스플릿뷰라 무관)', async () => {
+  it('데스크톱 — 채팅-상세 라우트여도 그대로 뜬다(데스크톱은 스플릿뷰라 무관, isMobile 분기 자체를 안 탐)', async () => {
     setInnerWidth(1280);
     usePathnameMock.mockReturnValue('/chats/conv-123');
     await mount();
     const btn = container.querySelector('button') as HTMLButtonElement;
     expect(btn).toBeTruthy();
-    expect(btn.style.left).toBe('272px'); // 256(기본 사이드바 폭)+16
+  });
+});
+
+// story #3274(선생님 확定 2026-09-01) — 우하단 배치+토스트/저장오류 배너 corner 회피.
+// 사이드바 회피 로직을 걷은 대신 새 충돌축(toast.tsx·kanban-board.tsx 둘 다
+// `fixed bottom-4 right-4`)을 bottom-20으로 넘어선다 — 반응형 분기 없이 모바일/데스크톱
+// 동일 값(모바일=탭바 회피와 우연히 같은 값을 재사용).
+describe('SupportWidgetLauncher — story #3274: 우하단 배치+토스트 corner 회피', () => {
+  it('데스크톱 — right-5·bottom-20 클래스로 뜬다(사이드바 관련 인라인 style 없음)', async () => {
+    await mount();
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn.className).toContain('right-5');
+    expect(btn.className).toContain('bottom-20');
+    expect(btn.style.left).toBe('');
+    expect(btn.style.right).toBe('');
+  });
+
+  it('오버레이 패널도 런처와 같은 우측 오프셋(right-5)을 공유한다', async () => {
+    await mount();
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const panel = container.querySelector('[role="dialog"]') as HTMLElement;
+    expect(panel.className).toContain('right-5');
+  });
+});
+
+// story #3274(선생님 확定 2026-09-01) — 상시 플로팅 폐기 핵심 불변식 2건.
+// ① "배너 ⟺ 플로팅": 둘 다 같은 판별자(useActivationStatus().allComplete)를 공유하므로
+//    온보딩 미완주(allComplete=false) 동안엔 항상 같이 뜨고, 완주 즉시 항상 같이 사라진다
+//    (두 벌 판별자 금지 원칙의 실제 증거 — 하나가 뜨는데 하나만 안 뜨는 상태가 없다).
+// ② 완주 후 플로팅 DOM 자체가 0(마운트는 되지만 렌더 결과가 없다 — 조건부 hidden이 아니라
+//    통째로 render null, PR 리뷰 시 "그냥 숨겨져 있을 뿐"과 구분하기 위한 명시 pin).
+describe('SupportWidgetLauncher — story #3274: 온보딩 단계 게이팅(핵심 불변식)', () => {
+  it('activation 미완주(기본값) — 플로팅이 뜬다(온보딩 단계)', async () => {
+    await mount();
+    expect(container.querySelector('button')).toBeTruthy();
+  });
+
+  it('activation 완주(localStorage 플래그) — 플로팅 DOM 자체가 없다(AC④, 조용히 숨김이 아니라 render null)', async () => {
+    window.localStorage.setItem(ACTIVATION_COMPLETE_KEY, '1');
+    await mount();
+    // mount()가 감싸는 SidebarProvider 자체의 wrapper div는 남지만(하니스), 런처가 그리는
+    // 요소(button/dialog)는 정말로 0개여야 한다 — hidden 스타일이 아니라 render null.
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(container.querySelectorAll('[aria-label]').length).toBe(0);
+  });
+
+  it('완주 상태에서는 모바일이든 데스크톱이든, 어떤 라우트든 플로팅이 뜨지 않는다(라우트/뷰포트보다 게이팅이 우선)', async () => {
+    window.localStorage.setItem(ACTIVATION_COMPLETE_KEY, '1');
+    setInnerWidth(500);
+    usePathnameMock.mockReturnValue('/board');
+    await mount();
+    expect(container.querySelector('button')).toBeNull();
   });
 });

--- a/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.test.tsx
@@ -64,11 +64,19 @@ beforeEach(() => {
   isSupportGatewayConfiguredMock.mockReset().mockReturnValue(false);
   createOrResumeGatewaySessionMock.mockReset();
   usePathnameMock.mockReset().mockReturnValue('/board');
-  // story #3274 — 런처가 이제 useActivationStatus()도 부른다(온보딩 단계 게이팅). 이
-  // 파일의 기존 테스트 전부는 "런처가 뜬다"를 전제하므로 기본값=미완주(fetch 미설정 시
-  // 실 fetch가 실패해 allComplete=false로 남는 것과 동형, use-activation-status.ts의
-  // fail-closed와 일치) — 게이팅 자체를 겨냥하는 describe만 별도로 완주 상태를 만든다.
+  // story #3274(유나 design 리뷰 실블로커 반영, 2026-09-01) — 런처가 이제
+  // useActivationStatus()도 부르는데, `!activationState`(fetch 미해결/실패)도 숨김
+  // 조건이라(배너와 대칭) fetch를 아예 안 갈아치우면 state가 영원히 null로 남아 이
+  // 파일의 기존 테스트 전부(런처가 뜬다는 전제)가 깨진다. 기본값=조회 성공+미완주로
+  // 고정 — 게이팅 자체를 겨냥하는 describe만 완주/로딩-중 상태를 개별적으로 만든다.
   _resetActivationStatusCacheForTests();
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ data: {
+      steps: { signed_up: true, email_verified: false, org_created: false, agent_connected: false, first_roundtrip: false },
+      completed: 1, total: 5, all_complete: false, first_instruction_conversation_id: null,
+    } }),
+  })));
 });
 
 afterEach(async () => {
@@ -295,5 +303,34 @@ describe('SupportWidgetLauncher — story #3274: 온보딩 단계 게이팅(핵�
     usePathnameMock.mockReturnValue('/board');
     await mount();
     expect(container.querySelector('button')).toBeNull();
+  });
+
+  // 유나 design 리뷰 실블로커(PR#3668 1차, 2026-09-01) — `!activationState` 가드가 빠져
+  // fetch 실패/로딩 중(allComplete=false, state=null)에 배너는 숨는데 런처만 fail-open으로
+  // 뜨는 비대칭이 있었다. 배너와 정확히 대칭(둘 다 보수적으로 숨김)임을 pin한다.
+  it('activation 조회 실패(fetch reject) — allComplete=false여도 배너처럼 보수적으로 숨는다(fail-open 회귀가드)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network'); }));
+    await mount();
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('activation 조회가 아직 안 끝난 순간(마운트 직후, 응답 전) — 배너처럼 잠깐 숨어있다', async () => {
+    let resolveFetch: (v: unknown) => void = () => {};
+    vi.stubGlobal('fetch', vi.fn(() => new Promise((resolve) => { resolveFetch = resolve; })));
+    await mount();
+    // 아직 fetch가 안 끝난 시점 — state=null이라 런처가 없어야 한다.
+    expect(container.querySelector('button')).toBeNull();
+    await act(async () => {
+      resolveFetch({
+        ok: true,
+        json: async () => ({ data: {
+          steps: { signed_up: true, email_verified: false, org_created: false, agent_connected: false, first_roundtrip: false },
+          completed: 1, total: 5, all_complete: false, first_instruction_conversation_id: null,
+        } }),
+      });
+      await Promise.resolve(); await Promise.resolve();
+    });
+    // 응답 도착 후엔 정상적으로 뜬다(무한 숨김이 아님을 함께 확認).
+    expect(container.querySelector('button')).toBeTruthy();
   });
 });

--- a/apps/web/src/components/support-widget/support-widget-launcher.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.tsx
@@ -53,6 +53,13 @@ export function SupportWidgetLauncher() {
   const pathname = usePathname();
   const { state: activationState, allComplete } = useActivationStatus();
   const isMobileChatDetailRoute = isMobile && pathname !== '/chats' && pathname.startsWith('/chats/');
+  // story #3274(유나 design 리뷰 🟡, 2026-09-01) — 설정 > 문의 탭(support-tab-panel.tsx)이
+  // 마운트 시 자체 세션을 연다. 같은 화면에 이 플로팅까지 열려있으면 세션 훅 인스턴스
+  // 2개가 각자 로컬 messages state를 가져 서로 안 보이는 뷰 불일치가 생긴다(서버는 org+
+  // user당 세션 1개로 멱등이라 데이터 위험은 없지만, 같은 기능의 진입점이 한 화면에 둘
+  // 있는 것 자체도 산만하다). isMobileChatDetailRoute와 동형으로 라우트 게이팅해 원천
+  // 차단 — 설정 페이지의 상담 진입점은 문의 탭 하나로 충분(진입점 0 아님).
+  const isSettingsRoute = pathname != null && (pathname === '/settings' || pathname.startsWith('/settings/'));
 
   // ⚠️story #3260 2차 finding(2026-08-31, 유나 라이브 실측 FAIL — 재시도 스톰) — 이 effect가
   // 예전엔 [open, session] deps였다. session은 status가 바뀔 때마다(connect()가 실패해
@@ -92,7 +99,7 @@ export function SupportWidgetLauncher() {
   // 빠져 있어 fetch 실패/로딩 중(allComplete=false, state=null)에 배너는 숨는데 런처만
   // fail-open으로 뜨는 비대칭이 있었다("배너 ⟺ 플로팅" 불변식 위반). banner와 정확히
   // 대칭시킨다 — 로딩/실패 중엔 둘 다 보수적으로 숨는다(PO 확認 정책).
-  if (allComplete || !activationState || isMobileChatDetailRoute) return null;
+  if (allComplete || !activationState || isMobileChatDetailRoute || isSettingsRoute) return null;
 
   return (
     <>

--- a/apps/web/src/components/support-widget/support-widget-launcher.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.tsx
@@ -51,7 +51,7 @@ export function SupportWidgetLauncher() {
   const session = useSupportWidgetSession();
   const { isMobile } = useSidebar();
   const pathname = usePathname();
-  const { allComplete } = useActivationStatus();
+  const { state: activationState, allComplete } = useActivationStatus();
   const isMobileChatDetailRoute = isMobile && pathname !== '/chats' && pathname.startsWith('/chats/');
 
   // ⚠️story #3260 2차 finding(2026-08-31, 유나 라이브 실측 FAIL — 재시도 스톰) — 이 effect가
@@ -87,7 +87,12 @@ export function SupportWidgetLauncher() {
   // 규칙) — 온보딩 완주 후엔 이 컴포넌트 자체가 통째로 사라진다(story #3274 새 모델, AC④).
   // 모바일 채팅-상세에서도 통째로 숨긴다(패널이 열려있었다면 그것도 함께 사라짐 — 겹치는
   // 화면 자체를 안 그리는 게 옳다, story #3260 3차 finding 그대로 유효).
-  if (allComplete || isMobileChatDetailRoute) return null;
+  //
+  // ⚠️유나 design 리뷰 실블로커(PR#3668 1차, 2026-09-01) — `!activationState` 가드가
+  // 빠져 있어 fetch 실패/로딩 중(allComplete=false, state=null)에 배너는 숨는데 런처만
+  // fail-open으로 뜨는 비대칭이 있었다("배너 ⟺ 플로팅" 불변식 위반). banner와 정확히
+  // 대칭시킨다 — 로딩/실패 중엔 둘 다 보수적으로 숨는다(PO 확認 정책).
+  if (allComplete || !activationState || isMobileChatDetailRoute) return null;
 
   return (
     <>

--- a/apps/web/src/components/support-widget/support-widget-launcher.tsx
+++ b/apps/web/src/components/support-widget/support-widget-launcher.tsx
@@ -1,65 +1,57 @@
 'use client';
 
-import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { LifeBuoy, X } from 'lucide-react';
 import { useSidebar } from '@/components/ui/sidebar';
+import { useActivationStatus } from '@/hooks/use-activation-status';
 import { useSupportWidgetSession } from '@/hooks/use-support-widget-session';
 import { SupportWidgetPanelHeader, SupportWidgetPanelBody } from './support-widget-panel';
 
 const PANEL_ID = 'support-widget-panel';
-// story #3260 2차 finding(유나 pre-merge 수치 판정) — 사이드바 폭+런처 사이 시각 여백.
-const DESKTOP_SIDEBAR_GAP_PX = 16;
 
 /**
- * story #3260(지원v1 v1·2위젯) — 플로팅 런처+오버레이. 마운트 자리는
- * apps/web/src/app/dashboard/dashboard-shell.tsx의 `<SidebarProvider>` 안(ShellBody와 형제) —
- * `useSidebar()` 컨텍스트를 읽어야 해서(아래 데스크톱 배치 참고) SidebarProvider 밖에 두면
- * "useSidebar must be used within a SidebarProvider" 로 크래시한다. "로그인 후 화면만"은 이
- * 마운트가 (authenticated)/layout.tsx 하위에서만 렌더되는 DashboardShell 안이라는 사실 자체로
- * 성립한다(별도 클라이언트 체크 불요).
+ * story #3274(지원v1·후속, 선생님 확定 2026-09-01 — "좌하단은 말이 안 됨"·"상시 플로팅
+ * 자체가 방해") — 상시 노출 폐기. 새 모델: **온보딩 단계(activation 미완주)에서만** 이
+ * 플로팅이 뜬다. 완주 후 일반 진입은 설정 > 문의 탭(settings/page.tsx `support` 탭 —
+ * 이 컴포넌트가 쓰는 패널/세션 훅을 그대로 인라인 임베드해 재사용, 발명 0)뿐이다. "온보딩
+ * 단계"의 실물 판정은 두 벌을 만들지 않고 activation-checklist-banner.tsx와 같은 판별자
+ * (`useActivationStatus()`, `!allComplete`)를 공유한다(PO 확定 — checklist all_complete가
+ * 이미 있는 5단계 판별의 재사용).
+ *
+ * 자리는 우하단(좌하단 폐기 — 우하단이 표준 UX). 이전 좌하단 시절 "사이드바 실 폭 회피"
+ * 로직(useSidebar 폭 읽기+동적 left 오프셋, story #3260 2차 finding)은 전부 걷었다 — 걷는
+ * 이유는 우측으로 옮기면 좌측 고정 사이드바와 애초에 안 겹쳐 그 회피 자체가 무의미해졌기
+ * 때문(사이드바가 사라진 게 아니라 이 컴포넌트가 반대편으로 이동해 그 축이 통째로 안 걸리게
+ * 됨). 새 충돌축은 우하단을 이미 쓰는 toast.tsx(`fixed right-4`)·kanban-board.tsx 저장오류
+ * 배너(`fixed bottom-4 right-4`) — `bottom-20`(5rem)로 그 corner를 넘어 뜬다. 이 값은 모바일
+ * MobileTabBar(h-16=64px) 회피에 쓰이던 것과 같은 값을 재사용한다(모바일=탭바, 데스크톱=
+ * 토스트/배너 — 우연히 같은 오프셋이 둘 다 만족시켜 반응형 분기 자체가 불필요해졌다).
+ *
+ * 마운트 자리는 apps/web/src/app/dashboard/dashboard-shell.tsx의 `<SidebarProvider>` 안
+ * (ShellBody와 형제) — `useSidebar().isMobile`(모바일 채팅-상세 판정에 여전히 필요)을
+ * 읽어야 해서 SidebarProvider 밖에 두면 크래시한다. "로그인 후 화면만"은 이 마운트가
+ * (authenticated)/layout.tsx 하위 DashboardShell 안이라는 사실 자체로 성립.
  *
  * ⚠️본체 chat 실시간(realtime-provider.tsx `useSseMultiplexerContext()`)을 이 컴포넌트도,
  * use-support-widget-session.ts도 절대 구독하지 않는다 — Support Gateway는 물리적으로 다른
  * 서비스라 같은 EventSource/구독 레지스트리를 타면 안 된다(이중소비·고아 슬롯 결함 클래스,
- * story #2102급 dedup 강제 스캔 대상이기도 함 — 그 훅이 실 SSE를 열게 되면 그때
- * sse-dedup-enforcement 쪽 EXEMPTIONS/가드 적용 여부를 재검토할 것).
+ * story #2102급 dedup 강제 스캔 대상이기도 함).
  *
- * 위치=좌하단(우하단 아님). 우하단은 이미 toast.tsx(`fixed right-4`, 앱 전역 토스트)·
- * kanban-board.tsx 저장오류 배너(`fixed bottom-4 right-4`)가 선점한 자리라, 상주 런처를
- * 거기 얹으면 토스트가 뜰 때마다 겹친다(플로팅 UI 전뷰포트 충돌체크 원칙).
- *
- * 모바일(<lg=1024, `useSidebar().isMobile` — MOBILE_BREAKPOINT=1024로 Tailwind lg:와 정확히
- * 동일 임계값)에서는 AppSidebar가 Sheet(오프캔버스, 화면 폭을 안 먹음) + MobileTabBar
- * (mobile-tab-bar.tsx, `h-16`=64px, 일반 flow로 화면 최하단 전폭 차지)가 대신 뜬다. 이
- * 컴포넌트는 fixed(뷰포트 기준)라 문서 흐름과 무관하게 겹칠 수 있어, 모바일에서만 bottom
- * 오프셋을 탭바 높이+여백만큼 올린다(bottom-20 = 5rem = 64px+16px). left는 그대로 5(사이드바가
- * 화면 폭을 안 먹으므로 충돌 없음).
- *
- * ⚠️story #3260 2차 finding(2026-08-31, 유나 pre-merge 수치 판정) — 1차 수정(lg:bottom-40)은
- * "덮는 행이 SidebarFooter에서 Storage·Memory nav로 바뀌었을 뿐"이었다: 런처가 여전히
- * `left-5`로 **사이드바 x-범위 안**에 있는 한, 세로 오프셋은 어떤 사이드바 항목을 덮을지만
- * 고를 뿐 근본 해소가 아니다(같은 목업검증이 SidebarFooter만 재현해 사이드바 nav 영역을
- * 놓친 것도 같은 함정). 근본 처방=**가로로 사이드바를 벗어난다**. 사이드바 폭은 200~360px
- * 사용자 리사이즈 가능(ui/sidebar.tsx `width` state, 정적 값 하드코딩은 최대폭 아래에서
- * 다시 겹치는 "폭 가변" 함정) — `useSidebar()`가 그 실시간 폭을 그대로 노출하므로 정적 추정
- * 대신 이 값을 직접 소비한다. `collapsible="offcanvas"`(app-sidebar.tsx)라 collapsed 상태는
- * 사이드바가 화면 밖으로 완전히 밀려나(가시 폭 0) 별도 처리 불요 — left-5 그대로 안전.
- *
- * ⚠️story #3260 3차 finding(2026-08-31, 선생님 실기기 적발→유나 design 확定) — 모바일
- * 채팅-상세 화면(`/chats/{id}`)은 자체 하단 첨부/전송 아이콘 열이 있어, 이 런처(bottom-20
- * left-5)가 그 위에 그대로 겹쳤다(실기기 스크린샷 실증). `/chats`(id 없는 리스트)는 그런
- * 하단 열이 없어 겹치지 않는다 — 그래서 "모바일 전체 숨김"이 아니라 **채팅-상세 라우트에서만**
- * render null 한다(데스크톱은 스플릿뷰라 리스트+상세가 항상 같이 보여 무관, chats/layout.tsx의
- * `isListRoute = pathname === '/chats'` 판정과 대칭 — 상세는 그 나머지 `/chats/*`).
+ * ⚠️story #3260 3차 finding(2026-08-31, 선생님 실기기 적발→유나 design 확定)은 그대로
+ * 유효 — 모바일 채팅-상세 화면(`/chats/{id}`)은 자체 하단 첨부/전송 아이콘 열이 있어
+ * 겹친다. 위치가 우측으로 바뀌어도 그 화면 하단 열과 겹치는 문제 자체는 사라지지 않으므로
+ * `isMobileChatDetailRoute` 판정은 그대로 유지한다(`/chats`는 리스트라 무관, 그 나머지
+ * `/chats/*`만 상세).
  */
 export function SupportWidgetLauncher() {
   const t = useTranslations('supportWidget');
   const [open, setOpen] = useState(false);
   const session = useSupportWidgetSession();
-  const { isMobile, state: sidebarState, width: sidebarWidth } = useSidebar();
+  const { isMobile } = useSidebar();
   const pathname = usePathname();
+  const { allComplete } = useActivationStatus();
   const isMobileChatDetailRoute = isMobile && pathname !== '/chats' && pathname.startsWith('/chats/');
 
   // ⚠️story #3260 2차 finding(2026-08-31, 유나 라이브 실측 FAIL — 재시도 스톰) — 이 effect가
@@ -92,15 +84,10 @@ export function SupportWidgetLauncher() {
   }, [open]);
 
   // 모든 hook 호출 뒤에만 조건부 반환한다(hook 호출 순서는 렌더마다 불변이어야 하는 React
-  // 규칙) — 모바일 채팅-상세에서는 통째로 숨긴다(패널이 열려있었다면 그것도 함께 사라짐,
-  // 겹치는 화면 자체를 안 그리는 게 옳다).
-  if (isMobileChatDetailRoute) return null;
-
-  // 모바일: 사이드바가 화면 폭을 안 먹어 기본 left-5(className) 그대로 — style override 없음.
-  // 데스크톱·사이드바 열림: 실 폭(리사이즈 반영) + 여백만큼 오른쪽으로.
-  // 데스크톱·사이드바 닫힘(offcanvas): 가시 폭 0 — left-5 그대로.
-  const desktopLeftPx = !isMobile && sidebarState === 'expanded' ? sidebarWidth + DESKTOP_SIDEBAR_GAP_PX : null;
-  const positionStyle: CSSProperties | undefined = desktopLeftPx != null ? { left: desktopLeftPx } : undefined;
+  // 규칙) — 온보딩 완주 후엔 이 컴포넌트 자체가 통째로 사라진다(story #3274 새 모델, AC④).
+  // 모바일 채팅-상세에서도 통째로 숨긴다(패널이 열려있었다면 그것도 함께 사라짐 — 겹치는
+  // 화면 자체를 안 그리는 게 옳다, story #3260 3차 finding 그대로 유효).
+  if (allComplete || isMobileChatDetailRoute) return null;
 
   return (
     <>
@@ -110,8 +97,7 @@ export function SupportWidgetLauncher() {
         aria-expanded={open}
         aria-controls={PANEL_ID}
         aria-label={open ? t('closeLabel') : t('launcherLabel')}
-        style={positionStyle}
-        className="fixed bottom-20 left-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-foreground text-background shadow-lg transition-transform hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 lg:bottom-5"
+        className="fixed bottom-20 right-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-foreground text-background shadow-lg transition-transform hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
       >
         {open ? <X className="h-5 w-5" aria-hidden /> : <LifeBuoy className="h-5 w-5" aria-hidden />}
       </button>
@@ -120,8 +106,7 @@ export function SupportWidgetLauncher() {
           id={PANEL_ID}
           role="dialog"
           aria-label={t('panelTitle')}
-          style={positionStyle}
-          className="fixed bottom-[8.75rem] left-5 z-40 flex h-[min(480px,calc(100vh-11rem))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl lg:bottom-20 lg:h-[min(480px,calc(100vh-6rem))]"
+          className="fixed bottom-[8.75rem] right-5 z-40 flex h-[min(480px,calc(100vh-11rem))] w-[360px] max-w-[calc(100vw-2.5rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl"
         >
           <SupportWidgetPanelHeader onClose={() => setOpen(false)} />
           <SupportWidgetPanelBody session={session} />

--- a/apps/web/src/hooks/use-activation-status.test.tsx
+++ b/apps/web/src/hooks/use-activation-status.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+//
+// story #3274(지원v1·후속) — activation-checklist-banner.tsx에서 뽑아낸 공유 hook. 핵심
+// 계약(AC①) — 배너와 support-widget-launcher.tsx 둘 다 이 훅을 부르는데, 둘이 같은 렌더
+// 사이클에 마운트돼도 실 fetch는 세션당 1회로 수렴해야 한다("배너와 단일 fetch·COMPLETE_KEY
+// 공유"). 이 파일은 그 dedup 자체와, 기존 banner 테스트가 이미 커버하는 skip/기록 계약을
+// 훅 레벨에서 직접 고정한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { _resetActivationStatusCacheForTests, useActivationStatus } from './use-activation-status';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const COMPLETE_KEY = 'sprintable_activation_checklist_complete';
+
+let localStore: Map<string, string>;
+function stubLocalStorage() {
+  localStore = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => localStore.get(k) ?? null,
+    setItem: (k: string, v: string) => { localStore.set(k, v); },
+    removeItem: (k: string) => { localStore.delete(k); },
+    clear: () => { localStore.clear(); },
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  stubLocalStorage();
+  _resetActivationStatusCacheForTests();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+function stubChecklistFetch(data: object) {
+  return vi.fn(async () => ({ ok: true, json: async () => ({ data }) }));
+}
+
+const PARTIAL = {
+  steps: { signed_up: true, email_verified: false, org_created: true, agent_connected: false, first_roundtrip: false },
+  completed: 2,
+  total: 5,
+  all_complete: false,
+  first_instruction_conversation_id: null,
+};
+
+function Probe({ testid }: { testid: string }) {
+  const { allComplete } = useActivationStatus();
+  return <span data-testid={testid}>{String(allComplete)}</span>;
+}
+
+describe('useActivationStatus — story #3274 AC① 단일 fetch 공유', () => {
+  it('두 소비처(배너 형태·런처 형태)가 같은 렌더에 동시 마운트돼도 실 fetch는 1회만 나간다', async () => {
+    const fetchSpy = stubChecklistFetch(PARTIAL);
+    vi.stubGlobal('fetch', fetchSpy);
+    await act(async () => {
+      root.render(
+        <>
+          <Probe testid="banner" />
+          <Probe testid="launcher" />
+        </>,
+      );
+    });
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="banner"]')!.textContent).toBe('false');
+    expect(container.querySelector('[data-testid="launcher"]')!.textContent).toBe('false');
+  });
+
+  it('localStorage에 완주 플래그가 있으면 fetch 자체를 건너뛰고 allComplete=true를 즉시 반환한다', async () => {
+    window.localStorage.setItem(COMPLETE_KEY, '1');
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    await act(async () => { root.render(<Probe testid="probe" />); });
+    await flush();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="probe"]')!.textContent).toBe('true');
+  });
+
+  it('all_complete=true 응답을 받으면 localStorage에 영구 기록한다(다음 세션 재조회 방지)', async () => {
+    vi.stubGlobal('fetch', stubChecklistFetch({ ...PARTIAL, all_complete: true, completed: 5 }));
+    await act(async () => { root.render(<Probe testid="probe" />); });
+    await flush();
+    expect(container.querySelector('[data-testid="probe"]')!.textContent).toBe('true');
+    expect(window.localStorage.getItem(COMPLETE_KEY)).toBe('1');
+  });
+
+  it('fetch 실패는 조용히 삼키고 allComplete=false로 남는다(에러 표면 없음)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network'); }));
+    await act(async () => { root.render(<Probe testid="probe" />); });
+    await flush();
+    expect(container.querySelector('[data-testid="probe"]')!.textContent).toBe('false');
+  });
+});

--- a/apps/web/src/hooks/use-activation-status.ts
+++ b/apps/web/src/hooks/use-activation-status.ts
@@ -1,0 +1,101 @@
+// story #3274(지원v1·후속, 선생님 확定 2026-09-01) — activation checklist 조회를
+// activation-checklist-banner.tsx 밖으로 뽑아 공유 hook화(AC① "배너와 단일 fetch·
+// COMPLETE_KEY 공유"). 두 소비처(배너 + support-widget-launcher.tsx의 온보딩 단계 게이팅)가
+// 같은 트리 안에서 부모-자식 관계가 아니라(dashboard-shell.tsx에서 형제 위치) 각자
+// useActivationStatus()를 부르는데, 모듈 스코프 in-flight promise로 캐싱해 실 네트워크
+// 호출은 세션당 1회만 나간다(둘 다 마운트돼도 fetchWithAuth가 두 번 안 나감).
+'use client';
+
+import { useEffect, useState } from 'react';
+import { fetchWithAuth } from '@/lib/db/client';
+
+const COMPLETE_KEY = 'sprintable_activation_checklist_complete';
+
+export interface ActivationState {
+  steps: {
+    signed_up: boolean;
+    email_verified: boolean;
+    org_created: boolean;
+    agent_connected: boolean;
+    first_roundtrip: boolean;
+  };
+  completed: number;
+  total: number;
+  all_complete: boolean;
+  // story #3201 — 왕복 성사된 대화(또는 org 최초 agent DM) id, 없으면 null.
+  first_instruction_conversation_id: string | null;
+}
+
+function readLocalFlag(key: string): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(key) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writeLocalFlag(key: string): void {
+  try {
+    window.localStorage.setItem(key, '1');
+  } catch {
+    // 영속 실패해도 이번 렌더는 정상 동작(단지 다음 세션에 한 번 더 조회할 뿐)
+  }
+}
+
+// 모듈 스코프 in-flight 캐시 — 여러 컴포넌트가 같은 렌더 사이클에 훅을 호출해도 실
+// fetchWithAuth 호출은 1회로 수렴한다(React 컴포넌트 트리와 무관한 공유, 페이지 세션
+// 동안 유지 — activation은 단조 증가라 재조회할 이유가 없다).
+let sharedFetchPromise: Promise<ActivationState | null> | null = null;
+
+// firebase-session.ts::_resetKeyCacheForTests()와 동일 컨벤션 — 모듈 스코프 캐시는 테스트
+// 파일 간(그리고 한 파일의 it() 블록 간) 격리가 필요하다, 안 그러면 앞 테스트의 stub된
+// fetch 응답이 캐시로 남아 뒤 테스트에 새지 않도록 test setup에서 명시 호출한다.
+export function _resetActivationStatusCacheForTests(): void {
+  sharedFetchPromise = null;
+}
+
+async function fetchActivationState(): Promise<ActivationState | null> {
+  if (!sharedFetchPromise) {
+    sharedFetchPromise = (async () => {
+      try {
+        const res = await fetchWithAuth('/api/activation/checklist');
+        if (!res.ok) return null;
+        const json = (await res.json()) as { data?: ActivationState };
+        return json.data ?? null;
+      } catch {
+        return null;
+      }
+    })();
+  }
+  return sharedFetchPromise;
+}
+
+export interface UseActivationStatusResult {
+  /** 조회 완료 전이거나 조회 실패면 null. */
+  state: ActivationState | null;
+  /** 완주 여부 — localStorage에 이미 기록된 경우(과거 세션에 완주 관측)도 true(fetch 자체를
+   * 건너뛰므로 state는 null로 남지만 "온보딩 단계 아님"은 확定적으로 참이다). */
+  allComplete: boolean;
+}
+
+export function useActivationStatus(): UseActivationStatusResult {
+  const [skip] = useState<boolean>(() => readLocalFlag(COMPLETE_KEY));
+  const [state, setState] = useState<ActivationState | null>(null);
+
+  useEffect(() => {
+    if (skip) return;
+    let cancelled = false;
+    void (async () => {
+      const data = await fetchActivationState();
+      if (cancelled || !data) return;
+      setState(data);
+      if (data.all_complete) writeLocalFlag(COMPLETE_KEY);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [skip]);
+
+  return { state, allComplete: skip || state?.all_complete === true };
+}


### PR DESCRIPTION
story #3274(지원v1·후속). 선생님 확定(2026-09-01) — 좌하단 플로팅 폐기(우하단이 표준 UX), 상시 플로팅 자체도 걷는다.

## 새 모델
- **온보딩 단계**(activation checklist 미완주): 우하단 플로팅 노출
- **일반 상황**: 설정 > 문의 탭 진입(상시 표면은 이것만)

## 변경
**① `useActivationStatus()` 공유 훅** — `activation-checklist-banner.tsx`의 fetch/skip 로직을 `hooks/use-activation-status.ts`로 추출. 배너와 런처가 dashboard-shell.tsx에서 형제 위치(부모-자식 아님)라 각자 훅을 부르지만, 모듈 스코프 in-flight promise 캐시로 실 네트워크 호출은 세션당 1회로 수렴(두 벌 판별자·중복 호출 금지). `_resetActivationStatusCacheForTests()`는 `firebase-session.ts`의 기존 `_resetKeyCacheForTests()` 컨벤션을 그대로 따름.

**② 런처 우하단 이전 + 온보딩 게이팅** — 좌하단 시절 "사이드바 실 폭 회피" 로직(`useSidebar` 폭 읽기+동적 `left` 오프셋, story #3260 2차 finding)을 전부 걷었다. 걷는 이유: 우측으로 옮기면 좌측 고정 사이드바와 애초에 안 겹쳐 그 회피 자체가 무의미해졌다(사이드바가 사라진 게 아니라 컴포넌트가 반대편으로 이동해 그 축이 안 걸림). 새 충돌축은 `toast.tsx`·`kanban-board.tsx` 저장오류 배너(둘 다 `fixed bottom-4 right-4`) — `bottom-20`으로 그 corner를 넘어선다(모바일 탭바 회피에 쓰던 값과 우연히 같아 반응형 분기가 통째로 사라짐). 게이팅은 `!allComplete && !isMobileChatDetailRoute` — 완주 시 통째로 `render null`(AC④), 모바일 채팅-상세 숨김(story #3260 3차 finding)은 위치 이전과 무관한 별개 결함이라 그대로 유지.

**③ 설정 > 문의 탭** — `settings/page.tsx`에 `support` 탭 신설(`isSupportWidgetEnabled()` 뒤 게이팅, `EE_ENABLED`와 동일 컨벤션). 신규 `SupportSettingsTabPanel`이 `support-widget-panel.tsx`의 `SupportWidgetPanelBody`를 그대로 인라인 임베드(#3260 자산 재사용, 발명 0). `?tab=support` 딥링크 지원, flag off일 때는 기본 탭(profile)으로 폴백(빈 화면 방지).

## 불변식 pin(선생님 지시)
- "배너 ⟺ 플로팅": 같은 판별자 공유 — 단일 fetch dedup을 `use-activation-status.test.tsx`가 직접 pin
- 완주 후 플로팅 DOM 0(hidden 스타일 아닌 render null) — `support-widget-launcher.test.tsx`

## 걷은 pin — "왜 걷는지"
사이드바 실 폭 회피 5건(story #3260 2차)은 런처가 우측 이동으로 그 충돌축 자체를 잃어 통째로 제거. 모바일 채팅-상세 숨김(story #3260 3차)은 별개 결함(그 화면 하단 열과의 겹침)이라 그대로 유지 — 데스크톱 전용 사이드바-폭 assertion 1건만 제거(인라인 style 자체가 없어짐).

## 검증
- apps/web 전체 550 files/5114 tests 그린(신규 43건), eslint 0, build 성공, i18n coverage 통과

## 남은 것
⚠️ 로컬 Docker 데몬이 이 세션에서 기동 안 돼(PR#3664와 동일 이슈) 실 브라우저 라이브 픽셀 검증은 못 했다 — jsdom 렌더 테스트(className/게이팅/조건부 렌더)로 대체. dev 배포 후 실 픽셀로 토스트/kanban 배너와의 실제 겹침 여부 최종 확定 필요.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_019rkXVqy2DF1aAN7szuqp44