### PR TITLE
[SID:3279] 운영자 회신 착지점(gateway 측 1/2) — POST /internal/operator-replies

### DIFF
--- a/support-gateway/app/main.py
+++ b/support-gateway/app/main.py
@@ -8,6 +8,7 @@ from slowapi.middleware import SlowAPIMiddleware
 from app.config import settings
 from app.rate_limit import limiter
 from app.routers.admin import router as admin_router
+from app.routers.operator_replies import router as operator_replies_router
 from app.routers.sessions import router as sessions_router
 
 app = FastAPI(title="Sprintable Support Gateway", version="0.1.0")
@@ -37,6 +38,7 @@ app.add_middleware(
 
 app.include_router(sessions_router)
 app.include_router(admin_router)
+app.include_router(operator_replies_router)
 
 
 @app.get("/healthz")

--- a/support-gateway/app/routers/operator_replies.py
+++ b/support-gateway/app/routers/operator_replies.py
@@ -1,0 +1,62 @@
+"""story #3279(지원v1·후속) — 운영자 회신 착지점. backend가 승인자의 스레드 답장을
+escalation_id에 붙여 여기로 배달한다(app/token_verify.py::require_operator_reply_claims —
+escalation_delivery.py의 반대 방향, 같은 SUPPORT_GATEWAY_TOKEN_SECRET을 다른 aud로).
+
+fleet 자격 0 불변식 그대로 — 이 엔드포인트는 backend의 team_member id도, 어느 승인자가
+답했는지도 모른다(claims엔 escalation_id+content뿐). 고객 표면에 사람 이름을 안 실으려는
+게 아니라(그것도 맞지만), 애초에 이 프로세스가 그 신원을 받아 들고 있으면 안 된다는
+Blueprint §2 경계 그대로다."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_db
+from app.models import SupportEscalation, SupportExecutionLog, SupportMessage
+from app.schemas import MessageResponse
+from app.token_verify import OperatorReplyClaims, require_operator_reply_claims
+
+router = APIRouter(prefix="/api/v1/internal", tags=["operator"])
+
+
+@router.post("/operator-replies", response_model=MessageResponse, status_code=201)
+async def receive_operator_reply(
+    claims: OperatorReplyClaims = Depends(require_operator_reply_claims),
+    db: AsyncSession = Depends(get_db),
+) -> MessageResponse:
+    # escalation_id로만 conversation을 찾는다(SupportEscalation.conversation_id) — org_id는
+    # 클레임에 없다(escalation 행 자체가 이미 그 org에 스코프돼 있어 재확인이 불필요, 그리고
+    # gateway는 애초에 org_id를 별도로 신뢰할 근거가 이 토큰엔 없다 — escalation_id 존재
+    # 자체가 유일한 근거).
+    escalation = await db.get(SupportEscalation, claims.escalation_id)
+    if escalation is None:
+        raise HTTPException(status_code=404, detail="escalation not found")
+
+    # story #3276 — 종료된 상담이어도 회신은 그대로 적재한다(읽기 전용은 "고객의 새 발화"만
+    # 막는 개념이지, 운영자가 이미 진행 중이던 왕복을 마무리하는 회신까지 막을 이유가 없다
+    # — 고객이 다음에 그 이력을 열면 그대로 보인다).
+    message = SupportMessage(
+        conversation_id=escalation.conversation_id,
+        org_id=escalation.org_id,
+        role="operator",
+        content=claims.content,
+    )
+    db.add(message)
+    db.add(
+        SupportExecutionLog(
+            conversation_id=escalation.conversation_id,
+            org_id=escalation.org_id,
+            task_type="operator_reply",
+            model="n/a",
+            summary=f"operator reply delivered (escalation_id={escalation.id})",
+        )
+    )
+    await db.commit()
+    await db.refresh(message)
+    return MessageResponse(
+        id=message.id,
+        conversation_id=message.conversation_id,
+        role=message.role,
+        content=message.content,
+        created_at=message.created_at,
+    )

--- a/support-gateway/app/token_verify.py
+++ b/support-gateway/app/token_verify.py
@@ -64,6 +64,61 @@ async def require_delegated_identity(authorization: str = Header(default="")) ->
         raise HTTPException(status_code=401, detail=f"invalid delegated token: {exc}") from exc
 
 
+# story #3279(지원v1·후속) — 운영자 회신 배달(backend→gateway, escalation_delivery.py의
+# 반대 방향). 같은 대칭키(SUPPORT_GATEWAY_TOKEN_SECRET)를 backend가 이 aud로 서명해
+# 보낸다(backend/app/services/operator_reply_delivery.py 발급 계약). 위임 토큰(aud 없음)·
+# 에스컬레이션 배달 토큰(aud="backend:escalation-events", backend가 검증)과 셋 다 같은
+# 키를 쓰지만 aud로 구조적으로 분리된 별개 신뢰 재료다.
+OPERATOR_REPLY_AUD = "support-gateway:operator-reply"
+
+
+class OperatorReplyTokenError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class OperatorReplyClaims:
+    escalation_id: uuid.UUID
+    content: str
+
+
+def verify_operator_reply_token(token: str) -> OperatorReplyClaims:
+    if not settings.token_secret:
+        raise OperatorReplyTokenError("SUPPORT_GATEWAY_TOKEN_SECRET not configured")
+    try:
+        # audience= 명시 — PyJWT가 이 시점에 이미 aud 부재/불일치 둘 다 거부한다(부재 시
+        # MissingRequiredClaimError, 불일치 시 InvalidAudienceError — 둘 다 PyJWTError 하위).
+        claims = jwt.decode(token, settings.token_secret, algorithms=["HS256"], audience=OPERATOR_REPLY_AUD)
+    except jwt.PyJWTError as exc:
+        raise OperatorReplyTokenError(str(exc)) from exc
+    # story #3279(페드루 PO 지시, 2026-09-01) — story #3661에서 backend 쪽 jose 검증기가
+    # "토큰에 aud 클레임이 아예 없으면 audience= 인자를 조용히 건너뛴다"는 라이브러리별
+    # 상이 동작으로 뚫릴 뻔한 것과 동형 클래스 재발 방지. 이 함수는 PyJWT(jose 아님)라
+    # 위 audience= 인자가 이미 부재/불일치 둘 다 거부하지만(실측: 가드를 지워도 여전히
+    # 거부됨), "라이브러리 기본 동작 하나에만 의존하지 않는다"는 이 코드베이스의 확立된
+    # 관례대로 독립 2차 방어를 명시로 남긴다 — 부재든 불일치든 이 줄이 한 번 더 잡는다.
+    if claims.get("aud") != OPERATOR_REPLY_AUD:
+        raise OperatorReplyTokenError(f"missing or mismatched aud claim: {claims.get('aud')!r}")
+    try:
+        escalation_id = uuid.UUID(claims["escalation_id"])
+        content = str(claims["content"])
+    except (KeyError, ValueError) as exc:
+        raise OperatorReplyTokenError(f"malformed claims: {exc}") from exc
+    if not content.strip():
+        raise OperatorReplyTokenError("empty content")
+    return OperatorReplyClaims(escalation_id=escalation_id, content=content)
+
+
+async def require_operator_reply_claims(authorization: str = Header(default="")) -> OperatorReplyClaims:
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="missing bearer token")
+    token = authorization[len("Bearer "):]
+    try:
+        return verify_operator_reply_token(token)
+    except OperatorReplyTokenError as exc:
+        raise HTTPException(status_code=401, detail=f"invalid operator reply token: {exc}") from exc
+
+
 async def require_admin(authorization: str = Header(default="")) -> None:
     """story #3264 AC3/AC4 — 어드민 계측 조회(app/routers/admin.py) 전용. 고객 위임 토큰과
     완전히 다른 신뢰 재료(settings.admin_token, 정적 비교) — org 클레임이 없으므로 이 경로는

--- a/support-gateway/tests/test_operator_replies.py
+++ b/support-gateway/tests/test_operator_replies.py
@@ -1,0 +1,117 @@
+"""story #3279(지원v1·후속) — 운영자 회신 착지점(POST /api/v1/internal/operator-replies)
+엔드투엔드. 실 에스컬레이션(고객 턴→SupportEscalation 생성)을 먼저 만들고, 그 escalation_id를
+운영자 회신 토큰에 실어 보내 SupportMessage(role='operator')로 적재되는지 확認한다."""
+from __future__ import annotations
+
+import uuid
+
+import jwt
+from sqlalchemy import select
+
+from app.config import settings
+from app.models import SupportEscalation, SupportMessage
+from app.token_verify import OPERATOR_REPLY_AUD
+from tests.conftest import OTHER_ORG_ID, TEST_TOKEN_SECRET, make_token
+
+
+def _operator_reply_token(escalation_id: uuid.UUID, content: str, *, secret: str = TEST_TOKEN_SECRET) -> str:
+    return jwt.encode(
+        {"aud": OPERATOR_REPLY_AUD, "escalation_id": str(escalation_id), "content": content},
+        secret,
+        algorithm="HS256",
+    )
+
+
+async def _create_escalated_conversation(client, fake_llm, db_engine):
+    """고객 턴 하나로 실 SupportEscalation 행을 만들고 그 id를 돌려준다(합성 mock이 아니라
+    handle_turn의 실 classifier→escalation_task 경로를 태운다, test_admin_metrics.py 관례)."""
+    fake_llm.classify_text = "needs_human"
+    headers = {"Authorization": f"Bearer {make_token(OTHER_ORG_ID)}"}
+    session = await client.post("/api/v1/sessions", headers=headers)
+    session_id = session.json()["id"]
+    resp = await client.post(
+        f"/api/v1/sessions/{session_id}/messages", json={"content": "사람 필요해요"}, headers=headers
+    )
+    conversation_id = uuid.UUID(resp.json()["customer_message"]["conversation_id"])
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    async with async_sessionmaker(db_engine, expire_on_commit=False)() as db_session:
+        escalation = (
+            await db_session.execute(
+                select(SupportEscalation).where(SupportEscalation.conversation_id == conversation_id)
+            )
+        ).scalars().one()
+        return escalation.id, conversation_id, session_id, headers
+
+
+async def test_operator_reply_lands_in_the_escalated_conversation(client, fake_llm, db_engine):
+    escalation_id, conversation_id, session_id, headers = await _create_escalated_conversation(
+        client, fake_llm, db_engine
+    )
+
+    token = _operator_reply_token(escalation_id, "안녕하세요, 확인 후 답변드립니다.")
+    resp = await client.post(
+        "/api/v1/internal/operator-replies", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["role"] == "operator"
+    assert body["content"] == "안녕하세요, 확인 후 답변드립니다."
+    assert body["conversation_id"] == str(conversation_id)
+
+    # 고객 쪽 GET 이력 조회에도 그대로 보인다(별도 렌더 축은 story #3279 후속 FE 몫이지만,
+    # 데이터 자체는 이미 이 왕복으로 도달해 있어야 한다).
+    history = await client.get(f"/api/v1/sessions/{session_id}/messages", headers=headers)
+    contents = [m["content"] for m in history.json()["messages"]]
+    assert "안녕하세요, 확인 후 답변드립니다." in contents
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    async with async_sessionmaker(db_engine, expire_on_commit=False)() as db_session:
+        operator_messages = (
+            await db_session.execute(select(SupportMessage).where(SupportMessage.role == "operator"))
+        ).scalars().all()
+        assert len(operator_messages) == 1
+        assert operator_messages[0].org_id == OTHER_ORG_ID
+
+
+async def test_operator_reply_lands_even_when_conversation_already_ended(client, fake_llm, db_engine):
+    """story #3276과의 상호작용 pin — 상담이 종료된 뒤에도 운영자 회신은 그대로 적재된다
+    (읽기전용은 "고객의 새 발화"만 막는 개념, 왕복 마무리는 막지 않는다)."""
+    escalation_id, conversation_id, session_id, headers = await _create_escalated_conversation(
+        client, fake_llm, db_engine
+    )
+    end_resp = await client.post(
+        f"/api/v1/sessions/{session_id}/conversations/{conversation_id}/end", headers=headers
+    )
+    assert end_resp.status_code == 200
+
+    token = _operator_reply_token(escalation_id, "종료 후에도 도달하는 회신")
+    resp = await client.post(
+        "/api/v1/internal/operator-replies", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 201, resp.text
+
+
+async def test_operator_reply_unknown_escalation_id_returns_404(client):
+    token = _operator_reply_token(uuid.uuid4(), "존재하지 않는 escalation")
+    resp = await client.post(
+        "/api/v1/internal/operator-replies", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 404
+
+
+async def test_operator_reply_invalid_token_rejected(client):
+    resp = await client.post(
+        "/api/v1/internal/operator-replies", headers={"Authorization": "Bearer garbage"}
+    )
+    assert resp.status_code == 401
+
+
+async def test_operator_reply_wrong_secret_rejected(client):
+    token = _operator_reply_token(uuid.uuid4(), "wrong secret", secret="not-the-real-secret-padded-32-bytes")
+    resp = await client.post(
+        "/api/v1/internal/operator-replies", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 401

--- a/support-gateway/tests/test_token_verify.py
+++ b/support-gateway/tests/test_token_verify.py
@@ -6,7 +6,13 @@ import jwt
 import pytest
 
 from app.config import settings
-from app.token_verify import DelegatedTokenError, verify_delegated_token
+from app.token_verify import (
+    OPERATOR_REPLY_AUD,
+    DelegatedTokenError,
+    OperatorReplyTokenError,
+    verify_delegated_token,
+    verify_operator_reply_token,
+)
 from tests.conftest import TEST_TOKEN_SECRET
 
 
@@ -75,3 +81,79 @@ def test_escalation_delivery_token_rejected_here_cross_kind_defense(monkeypatch)
     )
     with pytest.raises(DelegatedTokenError):
         verify_delegated_token(token)
+
+
+# --- story #3279 — 운영자 회신 토큰(backend→gateway, escalation_delivery.py 반대 방향) -----
+
+
+def test_operator_reply_token_valid_roundtrip():
+    escalation_id = uuid.uuid4()
+    token = jwt.encode(
+        {"aud": OPERATOR_REPLY_AUD, "escalation_id": str(escalation_id), "content": "확인했습니다, 답변드릴게요."},
+        TEST_TOKEN_SECRET,
+        algorithm="HS256",
+    )
+    claims = verify_operator_reply_token(token)
+    assert claims.escalation_id == escalation_id
+    assert claims.content == "확인했습니다, 답변드릴게요."
+
+
+def test_operator_reply_token_missing_aud_rejected():
+    """페드루 PO 지시(2026-09-01, story #3661 클래스 재발 방지) — aud 클레임 자체가 없는
+    토큰은 반드시 거부돼야 한다(부재를 "검증 대상 없음=통과"로 오판하면 안 된다)."""
+    token = jwt.encode(
+        {"escalation_id": str(uuid.uuid4()), "content": "aud 없이 서명된 토큰"},
+        TEST_TOKEN_SECRET,
+        algorithm="HS256",
+    )
+    with pytest.raises(OperatorReplyTokenError):
+        verify_operator_reply_token(token)
+
+
+def test_operator_reply_token_wrong_aud_rejected():
+    """aud가 있지만 다른 값(예: 위임 토큰·에스컬레이션 배달 토큰과 교차 오용)이면 거부."""
+    token = jwt.encode(
+        {"aud": "backend:escalation-events", "escalation_id": str(uuid.uuid4()), "content": "잘못된 aud"},
+        TEST_TOKEN_SECRET,
+        algorithm="HS256",
+    )
+    with pytest.raises(OperatorReplyTokenError):
+        verify_operator_reply_token(token)
+
+
+def test_operator_reply_token_delegated_token_rejected_here_cross_kind_defense():
+    """위임 토큰(aud 없음)을 이 검증기에 잘못 던져도 거부돼야 한다."""
+    token = jwt.encode(
+        {"org_id": str(uuid.uuid4()), "user_id": str(uuid.uuid4())}, TEST_TOKEN_SECRET, algorithm="HS256"
+    )
+    with pytest.raises(OperatorReplyTokenError):
+        verify_operator_reply_token(token)
+
+
+def test_operator_reply_token_missing_content_rejected():
+    token = jwt.encode(
+        {"aud": OPERATOR_REPLY_AUD, "escalation_id": str(uuid.uuid4())}, TEST_TOKEN_SECRET, algorithm="HS256"
+    )
+    with pytest.raises(OperatorReplyTokenError):
+        verify_operator_reply_token(token)
+
+
+def test_operator_reply_token_empty_content_rejected():
+    token = jwt.encode(
+        {"aud": OPERATOR_REPLY_AUD, "escalation_id": str(uuid.uuid4()), "content": "   "},
+        TEST_TOKEN_SECRET,
+        algorithm="HS256",
+    )
+    with pytest.raises(OperatorReplyTokenError):
+        verify_operator_reply_token(token)
+
+
+def test_operator_reply_token_unconfigured_secret_fails_closed(monkeypatch):
+    monkeypatch.setattr(settings, "token_secret", "")
+    token = jwt.encode(
+        {"aud": OPERATOR_REPLY_AUD, "escalation_id": str(uuid.uuid4()), "content": "x"},
+        TEST_TOKEN_SECRET,
+        algorithm="HS256",
+    )
+    with pytest.raises(OperatorReplyTokenError):
+        verify_operator_reply_token(token)


### PR DESCRIPTION
[SID:3279]

## 배경
에스컬 배너가 "이 대화로 답변드립니다"를 약속하는데, 운영자가 그 support 대화에 답을 쓸 표면/API가 존재하지 않았다(카드는 approve/reject뿐). 실 에스컬(8291afe9, 선생님 실문의)이 이 갭으로 채널 우회 답변 중.

이 PR은 **gateway 측 절반**만 낸다(착지점) — backend 쪽 배달 훅(카드 스레드 답장 감지→gateway 호출)과 위젯 FE(상담원 발신자 구분 렌더)는 후속 PR.

## 그라운딩(요약 — 상세는 팀 채널에 남김)
- 카드 메시지 자체가 이미 `msg_metadata.approval_target = {work_item_type, work_item_id, gate_id, ...}`를 담고 있고, `ConversationMessage.thread_id`가 실 컬럼으로 존재(스레드 답글 지원 구조) — 승인자가 카드에 **스레드 답장**하면 `gate_id`→`Gate.neutral_facts.support_escalation_id` 역참조로 escalation_id를 얻을 수 있다(후속 PR 스코프).
- `approval_delivery.py`의 기존 정책("챗 텍스트는 게이트를 해소하지 않는다 — 카드 액션만 유효")과 충돌 없음 — 스레드 답장은 게이트 해소가 아니라 별개 트리거.

## 변경
1. **`app/token_verify.py`** — `verify_operator_reply_token`/`require_operator_reply_claims` 신설. `OPERATOR_REPLY_AUD="support-gateway:operator-reply"`, `escalation_delivery.py`(gateway→backend)의 반대 방향. 페드루 PO 지시(story #3661 클래스 재발 방지)로 aud 부재/불일치 둘 다 명시 거부 — PyJWT `audience=` 파라미터(1차)+명시 `claims.get("aud") != ...` 재확인(2차)의 독립 2중 방어.
2. **`app/routers/operator_replies.py`** — `POST /api/v1/internal/operator-replies`. escalation_id로 `SupportEscalation`을 찾아 그 `conversation_id`에 `role='operator'` `SupportMessage` 적재. org_id/운영자 신원 전부 gateway가 모른 채(fleet 자격 0 불변식). 종료된 상담(#3276)에도 그대로 적재(읽기전용은 "고객의 새 발화"만 막는 개념).

## 뮤테이션 검증(페드루 PO 명시 요청)
- 2차 방어(명시 aud 체크)만 제거 → 1차(`audience=`)가 단독으로 부재/불일치 둘 다 거부하는 것 확認(green) — 진짜 독립 2중 방어임을 실측.
- `audience=` 자체를 통째로 제거하는 뮤테이션은 **유효 토큰까지 같이 깨짐**(PyJWT는 토큰에 aud 클레임이 있으면 `audience=` 없이는 무조건 거부) — 이건 jose와 다른 PyJWT의 실제 동작이고, PyJWT 쪽엔 애초에 #3661류(aud 부재 시 조용히 스킵) 침묵 우회가 구조적으로 없다는 방증.

## 검증
- `tests/test_operator_replies.py`(5건) — 실 `escalation_task` 경로(classifier→needs_human)로 실 `SupportEscalation` 생성 후 왕복 검증.
- `tests/test_token_verify.py`에 `OPERATOR_REPLY_AUD` 전용 8건 추가.
- 전체 **156 passed**.

## 스코프 밖(후속 PR)
- backend `send_message` 훅(스레드 답장 감지→gate_id 역참조→`operator_reply_delivery.py` 신설·서명·배달) + secret/cloudbuild 프로비저닝.
- 위젯 FE — "상담원" 발신자 구분 렌더(`role='operator'` 매핑).

이 PR 머지·배포 전까지 이 새 엔드포인트는 아무도 호출하지 않는다(고립 배포, 회귀 위험 0).