### PR TITLE
[SID:3279] 운영자 회신 배달 훅(backend 측 2/2) — 카드 스레드 답장→gateway 배달

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -92,6 +92,12 @@ class Settings(BaseSettings):
     support_gateway_token_secret: str = ""
     support_gateway_token_ttl_seconds: int = 300
 
+    # story #3279(지원v1·후속) — 운영자 회신 배달(backend→support-gateway). escalation_events
+    # 배달(gateway→backend, backend_escalation_events_url은 support-gateway 쪽 설정)의 반대
+    # 방향 — support-gateway/app/routers/operator_replies.py의 절대 URL. 미설정 시 배달을
+    # 정직하게 skip한다(app/services/operator_reply_delivery.py).
+    support_gateway_operator_reply_url: str = ""
+
     # story #3263(지원v1·5에스컬레이션) — 트랜잭셔널 메일의 "즉시 고객센터로 문의" 문구가
     # 실재하지 않는 표면(고객센터)을 가리키던 fiction 정정. 위젯(story #3260)이 dev에만 떠
     # 있고 prod는 아직 미노출(NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED)이라, 메일 카피가 위젯

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -684,6 +684,28 @@ def _approval_payload(msg: "ConversationMessage") -> dict:
     return {"approval_target": target if isinstance(target, dict) else None}
 
 
+def _operator_reply_target_gate_id(root_msg: "ConversationMessage | None") -> uuid.UUID | None:
+    """story #3279(지원v1·후속) — root_msg(스레드 답장의 부모, 이미 explicit SELECT로 로드된
+    값)가 support 에스컬레이션 카드(approval_delivery.py가 만드는 approval_target.work_item_type
+    =="support_escalation")면 그 gate_id를 돌려준다. 카드가 아니거나 gate_id가 없거나
+    malformed면 None(=배달 대상 아님) — send_message()가 이 값이 있을 때만 background task를
+    큐잉한다. _approval_payload와 달리 root_msg는 이 요청 안에서 방금 로드한 값이라
+    msg_metadata가 이미 채워져 있음이 보장된다(__dict__ 우회 불필요, 직접 속성 접근 안전)."""
+    if root_msg is None or not root_msg.msg_metadata:
+        return None
+    approval_target = root_msg.msg_metadata.get("approval_target")
+    if not isinstance(approval_target, dict) or approval_target.get("work_item_type") != "support_escalation":
+        return None
+    gate_id_raw = approval_target.get("gate_id")
+    if not gate_id_raw:
+        return None
+    try:
+        return uuid.UUID(str(gate_id_raw))
+    except ValueError:
+        logger.warning("operator reply skip — malformed gate_id in approval_target=%r", gate_id_raw)
+        return None
+
+
 def _event_payload(msg: "ConversationMessage") -> dict:
     """story #2637 AC 0-a: msg_metadata['event'] → payload top-level(없으면 None).
     _approval_payload와 동형(additive·__dict__ 전용 read — 동일 greenlet_spawn 회피 이유).
@@ -3055,6 +3077,18 @@ async def send_message(
         message_id=msg.id,
         org_id=org_id,
     )
+
+    # story #3279(지원v1·후속) — 운영자 회신 배달 훅. 이 메시지가 support 에스컬레이션 카드에
+    # 대한 **스레드 답장**이면, 그 내용을 support-gateway의 해당 대화로 배달한다(background
+    # task — 배달 실패가 이 챗 전송 자체를 절대 안 깨뜨린다). ⛔카드 최상위(스레드 아닌)
+    # 텍스트 답은 이 분기를 안 탄다 — approval_delivery.py의 기존 정책("챗 텍스트는 게이트를
+    # 해소하지 않는다 — 카드 액션만 유효")과 별개 트리거라 그 정책을 안 건드린다.
+    operator_reply_gate_id = _operator_reply_target_gate_id(root_msg)
+    if operator_reply_gate_id is not None:
+        from app.services.operator_reply_delivery import deliver_operator_reply_for_gate
+        background_tasks.add_task(
+            deliver_operator_reply_for_gate, gate_id=operator_reply_gate_id, content=body.content
+        )
 
     # S-COMM-12 AC1: agent 답신 시 해당 conversation의 최근 gateway_accepted delivery → agent_replied
     if sender.type == "agent":

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -3083,11 +3083,18 @@ async def send_message(
     # task — 배달 실패가 이 챗 전송 자체를 절대 안 깨뜨린다). ⛔카드 최상위(스레드 아닌)
     # 텍스트 답은 이 분기를 안 탄다 — approval_delivery.py의 기존 정책("챗 텍스트는 게이트를
     # 해소하지 않는다 — 카드 액션만 유효")과 별개 트리거라 그 정책을 안 건드린다.
+    # ⚠️카디르 QA ⑥축(2026-09-01) — sender_id를 반드시 넘긴다. deliver_operator_reply_for_gate가
+    # Gate.designated_approver_id와 대조해 비승인자 답장을 소리내며 거부한다(조용한 드롭 금지
+    # — "카드가 audience 한정이라 비승인자는 애초에 답장을 못 쓴다"는 가정이 배달 층에선
+    # 틀렸었다, 프로젝트 접근권 있는 아무 휴먼이 이 DM에 스레드 답장을 쓸 수 있었다).
     operator_reply_gate_id = _operator_reply_target_gate_id(root_msg)
     if operator_reply_gate_id is not None:
         from app.services.operator_reply_delivery import deliver_operator_reply_for_gate
         background_tasks.add_task(
-            deliver_operator_reply_for_gate, gate_id=operator_reply_gate_id, content=body.content
+            deliver_operator_reply_for_gate,
+            gate_id=operator_reply_gate_id,
+            content=body.content,
+            sender_id=sender.id,
         )
 
     # S-COMM-12 AC1: agent 답신 시 해당 conversation의 최근 gateway_accepted delivery → agent_replied

--- a/backend/app/services/operator_reply_delivery.py
+++ b/backend/app/services/operator_reply_delivery.py
@@ -1,0 +1,106 @@
+"""story #3279(지원v1·후속) — 운영자 회신 배달(backend→support-gateway).
+support-gateway/app/escalation_delivery.py(gateway→backend)의 반대 방향 — 같은
+SUPPORT_GATEWAY_TOKEN_SECRET을 aud="support-gateway:operator-reply"로 서명한다(gateway
+쪽 검증: support-gateway/app/token_verify.py::verify_operator_reply_token, PR#3672).
+
+트리거: 결재 카드 메시지(msg_metadata.approval_target.work_item_type=="support_escalation")에
+**스레드 답장**이 달리면 send_message()(conversations.py)가 이 배달을 background task로
+큐잉한다. 카드 최상위(스레드 아닌) 텍스트 답은 여전히 아무 것도 안 한다 —
+approval_delivery.py의 기존 정책("챗 텍스트는 게이트를 해소하지 않는다 — 카드 액션만
+유효")과 별개 트리거라 그 정책을 안 건드린다.
+
+배달 실패는 정직 로그로만 남기고 예외를 전파하지 않는다(escalation_delivery.py와 동일
+계약)."""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import httpx
+from jose import jwt as jose_jwt
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# gateway 쪽(support-gateway/app/token_verify.py::OPERATOR_REPLY_AUD)과 문자열이 정확히
+# 같아야 한다 — 프로세스가 분리돼 있어 상수 공유 불가, 값만 계약으로 고정.
+OPERATOR_REPLY_AUD = "support-gateway:operator-reply"
+_DELIVERY_TOKEN_TTL_SECONDS = 60
+
+
+async def deliver_operator_reply_for_gate(*, gate_id: uuid.UUID, content: str) -> bool:
+    """카드가 가리키는 gate의 neutral_facts에서 support_escalation_id를 역참조해 배달한다.
+
+    호출부(conversations.py::send_message)는 "이 스레드 답장의 부모 메시지가 support
+    카드"까지만 확認하고 gate_id를 넘긴다 — 그 게이트가 실제로 지금도 유효한
+    support_escalation 게이트인지는 여기서 정본(Gate 행)을 다시 읽어 확定한다(부모 메시지의
+    msg_metadata는 카드 배달 시점의 스냅샷이라, 그 사이 게이트가 삭제/변조됐을 가능성까지
+    이 함수가 한 번 더 닫는다)."""
+    from sqlalchemy import select
+
+    from app.core.database import async_session_factory
+    from app.models.gate import Gate
+
+    async with async_session_factory() as db:
+        gate = (await db.execute(select(Gate).where(Gate.id == gate_id))).scalar_one_or_none()
+        if gate is None or gate.work_item_type != "support_escalation":
+            logger.warning("operator reply skip — gate_id=%s not a support_escalation gate", gate_id)
+            return False
+        escalation_id_raw = (gate.neutral_facts or {}).get("support_escalation_id")
+        if not escalation_id_raw:
+            logger.warning(
+                "operator reply skip — gate_id=%s missing support_escalation_id in neutral_facts", gate_id
+            )
+            return False
+        try:
+            escalation_id = uuid.UUID(str(escalation_id_raw))
+        except ValueError:
+            logger.warning(
+                "operator reply skip — gate_id=%s malformed support_escalation_id=%r", gate_id, escalation_id_raw
+            )
+            return False
+
+    return await deliver_operator_reply(escalation_id=escalation_id, content=content)
+
+
+async def deliver_operator_reply(*, escalation_id: uuid.UUID, content: str) -> bool:
+    """반환값은 순수 관측용(테스트 편의) — 실패해도 예외를 밖으로 던지지 않는다(위
+    docstring 참고). True=gateway가 2xx로 접수, False=미설정·네트워크 실패·비2xx 전부 포함."""
+    if not settings.support_gateway_token_secret:
+        logger.warning(
+            "operator reply delivery skip — SUPPORT_GATEWAY_TOKEN_SECRET not configured escalation_id=%s",
+            escalation_id,
+        )
+        return False
+    if not settings.support_gateway_operator_reply_url:
+        logger.warning(
+            "operator reply delivery skip — support_gateway_operator_reply_url not configured escalation_id=%s",
+            escalation_id,
+        )
+        return False
+
+    now = datetime.now(timezone.utc)
+    claims = {
+        "aud": OPERATOR_REPLY_AUD,
+        "escalation_id": str(escalation_id),
+        "content": content[:4000],
+        "exp": now + timedelta(seconds=_DELIVERY_TOKEN_TTL_SECONDS),
+        "iat": now,
+    }
+    try:
+        token = jose_jwt.encode(claims, settings.support_gateway_token_secret, algorithm="HS256")
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                settings.support_gateway_operator_reply_url,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            resp.raise_for_status()
+    except Exception:
+        logger.exception(
+            "operator reply delivery POST failed escalation_id=%s (swallowed — retryable via new reply)",
+            escalation_id,
+        )
+        return False
+    return True

--- a/backend/app/services/operator_reply_delivery.py
+++ b/backend/app/services/operator_reply_delivery.py
@@ -30,14 +30,22 @@ OPERATOR_REPLY_AUD = "support-gateway:operator-reply"
 _DELIVERY_TOKEN_TTL_SECONDS = 60
 
 
-async def deliver_operator_reply_for_gate(*, gate_id: uuid.UUID, content: str) -> bool:
+async def deliver_operator_reply_for_gate(*, gate_id: uuid.UUID, content: str, sender_id: uuid.UUID) -> bool:
     """카드가 가리키는 gate의 neutral_facts에서 support_escalation_id를 역참조해 배달한다.
 
     호출부(conversations.py::send_message)는 "이 스레드 답장의 부모 메시지가 support
-    카드"까지만 확認하고 gate_id를 넘긴다 — 그 게이트가 실제로 지금도 유효한
-    support_escalation 게이트인지는 여기서 정본(Gate 행)을 다시 읽어 확定한다(부모 메시지의
-    msg_metadata는 카드 배달 시점의 스냅샷이라, 그 사이 게이트가 삭제/변조됐을 가능성까지
-    이 함수가 한 번 더 닫는다)."""
+    카드"까지만 확認하고 gate_id·sender_id를 넘긴다 — 그 게이트가 실제로 지금도 유효한
+    support_escalation 게이트인지·**이 답장을 쓴 사람이 실제로 그 게이트의 지정 승인자인지**
+    는 여기서 정본(Gate 행)을 다시 읽어 확定한다(부모 메시지의 msg_metadata는 카드 배달
+    시점의 스냅샷이라, 그 사이 게이트가 삭제/변조됐을 가능성까지 이 함수가 한 번 더 닫는다).
+
+    ⚠️story #3279 카디르 QA ⑥축 실 finding(2026-09-01, 페드루 PO 자인) — 최초 구현은
+    sender를 전혀 안 봐서, 프로젝트 접근권 있는 아무 휴먼의 스레드 답장이 고객에게
+    "운영자 회신"으로 배달됐다("카드가 audience 한정이라 비승인자는 답장 자체가 안 된다"는
+    가정이 배달 층에선 틀렸다 — non-DM 자동 join까지 겹치면 도달 표면이 넓다). v1은 단일
+    승인자 모델(story #2985 designated_approver_id) 그대로 유지 — 대조 실패는 조용한 드롭이
+    아니라 **소리내는** 스킵(경고 로그, reason 명시)이어야 나중에 "왜 답장이 고객한테
+    안 갔지"를 진단할 수 있다."""
     from sqlalchemy import select
 
     from app.core.database import async_session_factory
@@ -47,6 +55,13 @@ async def deliver_operator_reply_for_gate(*, gate_id: uuid.UUID, content: str) -
         gate = (await db.execute(select(Gate).where(Gate.id == gate_id))).scalar_one_or_none()
         if gate is None or gate.work_item_type != "support_escalation":
             logger.warning("operator reply skip — gate_id=%s not a support_escalation gate", gate_id)
+            return False
+        if gate.designated_approver_id is None or gate.designated_approver_id != sender_id:
+            logger.warning(
+                "operator reply skip — gate_id=%s sender_id=%s is not the designated approver "
+                "(designated_approver_id=%s) — unauthorized reply attempt, dropped loudly not silently",
+                gate_id, sender_id, gate.designated_approver_id,
+            )
             return False
         escalation_id_raw = (gate.neutral_facts or {}).get("support_escalation_id")
         if not escalation_id_raw:

--- a/backend/tests/test_3279_operator_reply.py
+++ b/backend/tests/test_3279_operator_reply.py
@@ -1,0 +1,165 @@
+"""story #3279(지원v1·후속) — 운영자 회신 배달. 세 층을 각각 겨냥한다:
+①`_operator_reply_target_gate_id`(conversations.py) — 순수 함수, DB/HTTP 0.
+②`deliver_operator_reply`(operator_reply_delivery.py) — httpx mock, DB 0(story #2813
+  github_checks_api 관례와 동형 — `patch("httpx.AsyncClient.post", ...)`).
+③`deliver_operator_reply_for_gate` — 실 PG Gate 행 조회(story #3263 realdb 관례와 동형).
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.routers.conversations import _operator_reply_target_gate_id
+
+# --- ① _operator_reply_target_gate_id — 순수 함수 ---------------------------------------
+
+
+def _root_msg(msg_metadata: dict | None):
+    return SimpleNamespace(msg_metadata=msg_metadata)
+
+
+def test_no_thread_root_returns_none():
+    """스레드 답장이 아닌 최상위 메시지 — approval_delivery.py의 "챗 텍스트는 게이트를
+    해소하지 않는다" 정책과 별개 트리거이므로, 애초에 이 훅 자체가 안 켜져야 한다."""
+    assert _operator_reply_target_gate_id(None) is None
+
+
+def test_reply_to_support_escalation_card_returns_gate_id():
+    gate_id = uuid.uuid4()
+    root_msg = _root_msg({
+        "approval_target": {"work_item_type": "support_escalation", "gate_id": str(gate_id), "actions": ["approve", "reject"]},
+    })
+    assert _operator_reply_target_gate_id(root_msg) == gate_id
+
+
+def test_reply_to_non_support_escalation_card_returns_none():
+    """카드는 카드지만 다른 work_item_type(예: doc 결재) — 절대 오배달되면 안 된다."""
+    root_msg = _root_msg({
+        "approval_target": {"work_item_type": "doc", "gate_id": str(uuid.uuid4())},
+    })
+    assert _operator_reply_target_gate_id(root_msg) is None
+
+
+def test_reply_to_plain_message_without_approval_target_returns_none():
+    """일반 스레드 답장(카드가 아닌 평범한 메시지에 대한 답장) — approval_target 자체가 없음."""
+    root_msg = _root_msg({"activation": {"kind": "request"}})
+    assert _operator_reply_target_gate_id(root_msg) is None
+
+
+def test_no_msg_metadata_at_all_returns_none():
+    assert _operator_reply_target_gate_id(_root_msg(None)) is None
+    assert _operator_reply_target_gate_id(_root_msg({})) is None
+
+
+def test_missing_gate_id_returns_none():
+    root_msg = _root_msg({"approval_target": {"work_item_type": "support_escalation"}})
+    assert _operator_reply_target_gate_id(root_msg) is None
+
+
+def test_malformed_gate_id_returns_none_not_raises():
+    """실 DB 조회 없이도 여기서 안전하게 걸러야 한다 — 다음 층(deliver_operator_reply_for_gate)
+    으로 malformed 값이 넘어가지 않는다."""
+    root_msg = _root_msg({"approval_target": {"work_item_type": "support_escalation", "gate_id": "not-a-uuid"}})
+    assert _operator_reply_target_gate_id(root_msg) is None
+
+
+# --- ② deliver_operator_reply — httpx mock ------------------------------------------------
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _resp(status_code: int):
+    class R:
+        def raise_for_status(self):
+            if status_code >= 400:
+                import httpx
+                raise httpx.HTTPStatusError("boom", request=None, response=self)  # type: ignore[arg-type]
+    r = R()
+    r.status_code = status_code
+    return r
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_success(monkeypatch):
+    from app.core.config import settings
+    from app.services.operator_reply_delivery import OPERATOR_REPLY_AUD, deliver_operator_reply
+
+    monkeypatch.setattr(settings, "support_gateway_token_secret", "test-secret-padded-to-32-bytes-min")
+    monkeypatch.setattr(settings, "support_gateway_operator_reply_url", "https://gateway.example/api/v1/internal/operator-replies")
+
+    captured = {}
+
+    async def _post(self, url, headers=None, **kwargs):
+        captured["url"] = url
+        captured["headers"] = headers
+        return _resp(201)
+
+    escalation_id = uuid.uuid4()
+    with patch("httpx.AsyncClient.post", new=_post):
+        ok = await deliver_operator_reply(escalation_id=escalation_id, content="확인했습니다.")
+
+    assert ok is True
+    assert captured["url"] == "https://gateway.example/api/v1/internal/operator-replies"
+
+    from jose import jwt as jose_jwt
+    claims = jose_jwt.get_unverified_claims(captured["headers"]["Authorization"].removeprefix("Bearer "))
+    assert claims["aud"] == OPERATOR_REPLY_AUD
+    assert claims["escalation_id"] == str(escalation_id)
+    assert claims["content"] == "확인했습니다."
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_5xx_returns_false_not_raises(monkeypatch):
+    from app.core.config import settings
+    from app.services.operator_reply_delivery import deliver_operator_reply
+
+    monkeypatch.setattr(settings, "support_gateway_token_secret", "test-secret-padded-to-32-bytes-min")
+    monkeypatch.setattr(settings, "support_gateway_operator_reply_url", "https://gateway.example/x")
+
+    with patch("httpx.AsyncClient.post", new=AsyncMock(return_value=_resp(500))):
+        ok = await deliver_operator_reply(escalation_id=uuid.uuid4(), content="x")
+    assert ok is False
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_network_error_returns_false_not_raises(monkeypatch):
+    from app.core.config import settings
+    from app.services.operator_reply_delivery import deliver_operator_reply
+
+    monkeypatch.setattr(settings, "support_gateway_token_secret", "test-secret-padded-to-32-bytes-min")
+    monkeypatch.setattr(settings, "support_gateway_operator_reply_url", "https://gateway.example/x")
+
+    async def _post(self, url, headers=None, **kwargs):
+        raise ConnectionError("network down")
+
+    with patch("httpx.AsyncClient.post", new=_post):
+        ok = await deliver_operator_reply(escalation_id=uuid.uuid4(), content="x")
+    assert ok is False
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_skips_when_secret_unconfigured(monkeypatch):
+    from app.core.config import settings
+    from app.services.operator_reply_delivery import deliver_operator_reply
+
+    monkeypatch.setattr(settings, "support_gateway_token_secret", "")
+    monkeypatch.setattr(settings, "support_gateway_operator_reply_url", "https://gateway.example/x")
+    ok = await deliver_operator_reply(escalation_id=uuid.uuid4(), content="x")
+    assert ok is False
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_skips_when_url_unconfigured(monkeypatch):
+    from app.core.config import settings
+    from app.services.operator_reply_delivery import deliver_operator_reply
+
+    monkeypatch.setattr(settings, "support_gateway_token_secret", "test-secret-padded-to-32-bytes-min")
+    monkeypatch.setattr(settings, "support_gateway_operator_reply_url", "")
+    ok = await deliver_operator_reply(escalation_id=uuid.uuid4(), content="x")
+    assert ok is False

--- a/backend/tests/test_3279_operator_reply_realdb.py
+++ b/backend/tests/test_3279_operator_reply_realdb.py
@@ -1,0 +1,176 @@
+"""story #3279(지원v1·후속) — deliver_operator_reply_for_gate의 Gate 역참조를 실 PG로
+검증한다(story #3263 test_3263_support_escalation_events_realdb.py와 동형 스캐폴딩).
+deliver_operator_reply 자체(HTTP 배달)는 test_3279_operator_reply.py가 이미 mock으로
+커버 — 여기는 그 함수를 monkeypatch로 갈아치우고 "올바른 escalation_id로 호출됐는가"만
+본다."""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug: str, name: str):
+    from app.models.organization import Organization
+    org = Organization(id=uuid.uuid4(), name=name, slug=slug)
+    session.add(org)
+    await session.commit()
+    return org.id
+
+
+async def _seed_support_escalation_gate(session, *, org_id, escalation_id: uuid.UUID | None):
+    """create_gate()를 직접 부르지 않고 Gate 행 자체의 실 컬럼만 심는다(member_id/role_id/
+    project_id는 Gate 모델의 컬럼이 아니다 — create_gate() 서비스 함수의 파라미터일 뿐,
+    다른 테이블/관계로 해소된다). 이 테스트는 게이트 *생성* 경로(test_3263가 이미 커버)가
+    아니라 *역참조 조회* 경로만 겨냥한다."""
+    from app.models.gate import Gate
+
+    gate_id = uuid.uuid4()
+    neutral_facts: dict = {}
+    if escalation_id is not None:
+        neutral_facts["support_escalation_id"] = str(escalation_id)
+    gate = Gate(
+        id=gate_id,
+        org_id=org_id,
+        work_item_id=gate_id,
+        work_item_type="support_escalation",
+        gate_type="support_escalation_review",
+        status="pending",
+        neutral_facts=neutral_facts,
+    )
+    session.add(gate)
+    await session.commit()
+    return gate_id
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_for_gate_resolves_escalation_id_and_delegates(monkeypatch):
+    from app.services import operator_reply_delivery as mod
+
+    engine, Session = await _session_factory()
+    try:
+        org_slug = f"org-{uuid.uuid4().hex[:8]}"
+        async with Session() as s:
+            org_id = await _seed_org(s, slug=org_slug, name="테스트 조직")
+            escalation_id = uuid.uuid4()
+            gate_id = await _seed_support_escalation_gate(s, org_id=org_id, escalation_id=escalation_id)
+
+        monkeypatch.setattr("app.core.database.async_session_factory", Session)
+        delegate = AsyncMock(return_value=True)
+        monkeypatch.setattr(mod, "deliver_operator_reply", delegate)
+
+        result = await mod.deliver_operator_reply_for_gate(gate_id=gate_id, content="답변 내용입니다.")
+
+        assert result is True
+        delegate.assert_awaited_once_with(escalation_id=escalation_id, content="답변 내용입니다.")
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_for_gate_missing_escalation_id_skips(monkeypatch):
+    """neutral_facts에 support_escalation_id가 없는(예: 다른 사유로 변조된) 게이트 —
+    정직하게 스킵(False), 배달 함수는 아예 안 부른다."""
+    from app.services import operator_reply_delivery as mod
+
+    engine, Session = await _session_factory()
+    try:
+        org_slug = f"org-{uuid.uuid4().hex[:8]}"
+        async with Session() as s:
+            org_id = await _seed_org(s, slug=org_slug, name="테스트 조직")
+            gate_id = await _seed_support_escalation_gate(s, org_id=org_id, escalation_id=None)
+
+        monkeypatch.setattr("app.core.database.async_session_factory", Session)
+        delegate = AsyncMock(return_value=True)
+        monkeypatch.setattr(mod, "deliver_operator_reply", delegate)
+
+        result = await mod.deliver_operator_reply_for_gate(gate_id=gate_id, content="x")
+
+        assert result is False
+        delegate.assert_not_awaited()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_for_gate_unknown_gate_id_skips(monkeypatch):
+    from app.services import operator_reply_delivery as mod
+
+    engine, Session = await _session_factory()
+    try:
+        monkeypatch.setattr("app.core.database.async_session_factory", Session)
+        delegate = AsyncMock(return_value=True)
+        monkeypatch.setattr(mod, "deliver_operator_reply", delegate)
+
+        result = await mod.deliver_operator_reply_for_gate(gate_id=uuid.uuid4(), content="x")
+
+        assert result is False
+        delegate.assert_not_awaited()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_for_gate_non_support_escalation_gate_skips(monkeypatch):
+    """work_item_type이 support_escalation이 아닌 게이트(예: doc 결재) — gate_id가 우연히
+    맞아도 절대 배달하면 안 된다(오배달 방지 pin)."""
+    from app.models.gate import Gate
+    from app.services import operator_reply_delivery as mod
+
+    engine, Session = await _session_factory()
+    try:
+        org_slug = f"org-{uuid.uuid4().hex[:8]}"
+        async with Session() as s:
+            org_id = await _seed_org(s, slug=org_slug, name="테스트 조직")
+            gate_id = uuid.uuid4()
+            s.add(Gate(
+                id=gate_id, org_id=org_id, work_item_id=gate_id,
+                work_item_type="doc", gate_type="doc_review", status="pending",
+                neutral_facts={"support_escalation_id": str(uuid.uuid4())},
+            ))
+            await s.commit()
+
+        monkeypatch.setattr("app.core.database.async_session_factory", Session)
+        delegate = AsyncMock(return_value=True)
+        monkeypatch.setattr(mod, "deliver_operator_reply", delegate)
+
+        result = await mod.deliver_operator_reply_for_gate(gate_id=gate_id, content="x")
+
+        assert result is False
+        delegate.assert_not_awaited()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3279_operator_reply_realdb.py
+++ b/backend/tests/test_3279_operator_reply_realdb.py
@@ -52,7 +52,9 @@ async def _seed_org(session, *, slug: str, name: str):
     return org.id
 
 
-async def _seed_support_escalation_gate(session, *, org_id, escalation_id: uuid.UUID | None):
+async def _seed_support_escalation_gate(
+    session, *, org_id, escalation_id: uuid.UUID | None, designated_approver_id: uuid.UUID | None
+):
     """create_gate()를 직접 부르지 않고 Gate 행 자체의 실 컬럼만 심는다(member_id/role_id/
     project_id는 Gate 모델의 컬럼이 아니다 — create_gate() 서비스 함수의 파라미터일 뿐,
     다른 테이블/관계로 해소된다). 이 테스트는 게이트 *생성* 경로(test_3263가 이미 커버)가
@@ -71,6 +73,7 @@ async def _seed_support_escalation_gate(session, *, org_id, escalation_id: uuid.
         gate_type="support_escalation_review",
         status="pending",
         neutral_facts=neutral_facts,
+        designated_approver_id=designated_approver_id,
     )
     session.add(gate)
     await session.commit()
@@ -84,16 +87,21 @@ async def test_deliver_operator_reply_for_gate_resolves_escalation_id_and_delega
     engine, Session = await _session_factory()
     try:
         org_slug = f"org-{uuid.uuid4().hex[:8]}"
+        approver_id = uuid.uuid4()
         async with Session() as s:
             org_id = await _seed_org(s, slug=org_slug, name="테스트 조직")
             escalation_id = uuid.uuid4()
-            gate_id = await _seed_support_escalation_gate(s, org_id=org_id, escalation_id=escalation_id)
+            gate_id = await _seed_support_escalation_gate(
+                s, org_id=org_id, escalation_id=escalation_id, designated_approver_id=approver_id
+            )
 
         monkeypatch.setattr("app.core.database.async_session_factory", Session)
         delegate = AsyncMock(return_value=True)
         monkeypatch.setattr(mod, "deliver_operator_reply", delegate)
 
-        result = await mod.deliver_operator_reply_for_gate(gate_id=gate_id, content="답변 내용입니다.")
+        result = await mod.deliver_operator_reply_for_gate(
+            gate_id=gate_id, content="답변 내용입니다.", sender_id=approver_id
+        )
 
         assert result is True
         delegate.assert_awaited_once_with(escalation_id=escalation_id, content="답변 내용입니다.")
@@ -110,15 +118,18 @@ async def test_deliver_operator_reply_for_gate_missing_escalation_id_skips(monke
     engine, Session = await _session_factory()
     try:
         org_slug = f"org-{uuid.uuid4().hex[:8]}"
+        approver_id = uuid.uuid4()
         async with Session() as s:
             org_id = await _seed_org(s, slug=org_slug, name="테스트 조직")
-            gate_id = await _seed_support_escalation_gate(s, org_id=org_id, escalation_id=None)
+            gate_id = await _seed_support_escalation_gate(
+                s, org_id=org_id, escalation_id=None, designated_approver_id=approver_id
+            )
 
         monkeypatch.setattr("app.core.database.async_session_factory", Session)
         delegate = AsyncMock(return_value=True)
         monkeypatch.setattr(mod, "deliver_operator_reply", delegate)
 
-        result = await mod.deliver_operator_reply_for_gate(gate_id=gate_id, content="x")
+        result = await mod.deliver_operator_reply_for_gate(gate_id=gate_id, content="x", sender_id=approver_id)
 
         assert result is False
         delegate.assert_not_awaited()
@@ -136,7 +147,9 @@ async def test_deliver_operator_reply_for_gate_unknown_gate_id_skips(monkeypatch
         delegate = AsyncMock(return_value=True)
         monkeypatch.setattr(mod, "deliver_operator_reply", delegate)
 
-        result = await mod.deliver_operator_reply_for_gate(gate_id=uuid.uuid4(), content="x")
+        result = await mod.deliver_operator_reply_for_gate(
+            gate_id=uuid.uuid4(), content="x", sender_id=uuid.uuid4()
+        )
 
         assert result is False
         delegate.assert_not_awaited()
@@ -154,6 +167,7 @@ async def test_deliver_operator_reply_for_gate_non_support_escalation_gate_skips
     engine, Session = await _session_factory()
     try:
         org_slug = f"org-{uuid.uuid4().hex[:8]}"
+        approver_id = uuid.uuid4()
         async with Session() as s:
             org_id = await _seed_org(s, slug=org_slug, name="테스트 조직")
             gate_id = uuid.uuid4()
@@ -161,6 +175,7 @@ async def test_deliver_operator_reply_for_gate_non_support_escalation_gate_skips
                 id=gate_id, org_id=org_id, work_item_id=gate_id,
                 work_item_type="doc", gate_type="doc_review", status="pending",
                 neutral_facts={"support_escalation_id": str(uuid.uuid4())},
+                designated_approver_id=approver_id,
             ))
             await s.commit()
 
@@ -168,7 +183,100 @@ async def test_deliver_operator_reply_for_gate_non_support_escalation_gate_skips
         delegate = AsyncMock(return_value=True)
         monkeypatch.setattr(mod, "deliver_operator_reply", delegate)
 
-        result = await mod.deliver_operator_reply_for_gate(gate_id=gate_id, content="x")
+        result = await mod.deliver_operator_reply_for_gate(gate_id=gate_id, content="x", sender_id=approver_id)
+
+        assert result is False
+        delegate.assert_not_awaited()
+    finally:
+        await engine.dispose()
+
+
+# --- 카디르 QA ⑥축(2026-09-01) — sender_id ↔ designated_approver_id 대조 -------------------
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_for_gate_authorized_sender_delivers(monkeypatch):
+    """지정 승인자 본인의 답장 — 정상 배달(회귀 확認, 위 성공 케이스와 별개로 "권한 대조를
+    통과한 정상 경로"라는 관점에서 한 번 더 고정)."""
+    from app.services import operator_reply_delivery as mod
+
+    engine, Session = await _session_factory()
+    try:
+        approver_id = uuid.uuid4()
+        async with Session() as s:
+            org_id = await _seed_org(s, slug=f"org-{uuid.uuid4().hex[:8]}", name="테스트 조직")
+            escalation_id = uuid.uuid4()
+            gate_id = await _seed_support_escalation_gate(
+                s, org_id=org_id, escalation_id=escalation_id, designated_approver_id=approver_id
+            )
+
+        monkeypatch.setattr("app.core.database.async_session_factory", Session)
+        delegate = AsyncMock(return_value=True)
+        monkeypatch.setattr(mod, "deliver_operator_reply", delegate)
+
+        result = await mod.deliver_operator_reply_for_gate(gate_id=gate_id, content="본인 답장", sender_id=approver_id)
+
+        assert result is True
+        delegate.assert_awaited_once()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_for_gate_unauthorized_sender_skips_loudly(monkeypatch, caplog):
+    """⭐카디르 QA ⑥축 실 finding pin(2026-09-01) — 프로젝트 접근권 있는 아무 휴먼(지정
+    승인자가 아닌 사람)의 스레드 답장은 고객에게 절대 배달되면 안 된다. 조용한 드롭이
+    아니라 경고 로그로 소리내야 한다(진단 가능성 — "왜 답장이 고객한테 안 갔지")."""
+    import logging
+
+    from app.services import operator_reply_delivery as mod
+
+    engine, Session = await _session_factory()
+    try:
+        approver_id = uuid.uuid4()
+        random_project_member_id = uuid.uuid4()  # 지정 승인자가 아닌 제3자.
+        async with Session() as s:
+            org_id = await _seed_org(s, slug=f"org-{uuid.uuid4().hex[:8]}", name="테스트 조직")
+            gate_id = await _seed_support_escalation_gate(
+                s, org_id=org_id, escalation_id=uuid.uuid4(), designated_approver_id=approver_id
+            )
+
+        monkeypatch.setattr("app.core.database.async_session_factory", Session)
+        delegate = AsyncMock(return_value=True)
+        monkeypatch.setattr(mod, "deliver_operator_reply", delegate)
+
+        with caplog.at_level(logging.WARNING, logger="app.services.operator_reply_delivery"):
+            result = await mod.deliver_operator_reply_for_gate(
+                gate_id=gate_id, content="비승인자가 쓴 답장", sender_id=random_project_member_id
+            )
+
+        assert result is False
+        delegate.assert_not_awaited()  # 고객에게 절대 안 나간다 — 핵심 단언.
+        assert any("not the designated approver" in r.message for r in caplog.records)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_deliver_operator_reply_for_gate_no_designated_approver_fails_closed(monkeypatch):
+    """designated_approver_id 자체가 None(v1 예상 밖 상태 — support_gateway_token.py 발급
+    경로는 항상 채우지만, 방어적으로) — "아무나 허용"이 아니라 "전부 거부"(feedback_
+    actor_type_failclosed와 동형 원칙)."""
+    from app.services import operator_reply_delivery as mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s, slug=f"org-{uuid.uuid4().hex[:8]}", name="테스트 조직")
+            gate_id = await _seed_support_escalation_gate(
+                s, org_id=org_id, escalation_id=uuid.uuid4(), designated_approver_id=None
+            )
+
+        monkeypatch.setattr("app.core.database.async_session_factory", Session)
+        delegate = AsyncMock(return_value=True)
+        monkeypatch.setattr(mod, "deliver_operator_reply", delegate)
+
+        result = await mod.deliver_operator_reply_for_gate(gate_id=gate_id, content="x", sender_id=uuid.uuid4())
 
         assert result is False
         delegate.assert_not_awaited()

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -216,4 +216,10 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # DM 배선 — 이 파일 상단 config.py 주석 참고)로 110→114. 가드가 신규 필드를 설계대로 잡은 것.
     assert "SUPPORT_ESCALATION_REQUESTER_MEMBER_ID" in keys and "SUPPORT_ESCALATION_APPROVER_MEMBER_ID" in keys
     assert "SUPPORT_ESCALATION_TARGET_ORG_SLUG" in keys and "SUPPORT_ESCALATION_TARGET_PROJECT_SLUG" in keys
-    assert len(keys) == 114
+    # story #3279(지원v1·후속, 2026-09-01): support_gateway_operator_reply_url 1필드 신설
+    # (운영자 회신 배달 — backend→support-gateway, escalation_delivery.py 반대 방향의
+    # 착지 URL. cloudbuild.yaml deploy-backend 스텝에서 기존 _NEXT_PUBLIC_SUPPORT_GATEWAY_URL
+    # substitution을 재사용해 배선, 시크릿은 이미 바인딩된 SUPPORT_GATEWAY_TOKEN_SECRET
+    # 재사용이라 신규 시크릿 불요)로 114→115. 가드가 신규 필드를 설계대로 잡은 것.
+    assert "SUPPORT_GATEWAY_OPERATOR_REPLY_URL" in keys
+    assert len(keys) == 115

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -156,6 +156,11 @@ _DECLARED_SUBSTITUTIONS = {
     # 직접 참조.
     "_SUPPORT_ESCALATION_REQUESTER_MEMBER_ID", "_SUPPORT_ESCALATION_APPROVER_MEMBER_ID",
     "_SUPPORT_ESCALATION_TARGET_ORG_SLUG", "_SUPPORT_ESCALATION_TARGET_PROJECT_SLUG",
+    # story #3279(지원v1·후속) — 운영자 회신 배달 착지 URL. _NEXT_PUBLIC_SUPPORT_GATEWAY_URL은
+    # 이전엔 deploy-frontend(순수 gcloud args 리스트 — 이 가드가 스캔하는 4개 bash 스텝 밖)
+    # 에서만 쓰여 이 목록에 없어도 무해했으나(_APPLE_TEAM_ID와 동형 선례), deploy-backend
+    # 쪽으로도 재사용하며 처음 걸린다.
+    "_NEXT_PUBLIC_SUPPORT_GATEWAY_URL",
     "PROJECT_ID", "PROJECT_NUMBER", "BUILD_ID", "COMMIT_SHA", "SHORT_SHA",
     "REPO_NAME", "BRANCH_NAME", "TAG_NAME", "REVISION_ID", "LOCATION",
 }
@@ -196,7 +201,9 @@ def _apply_cloudbuild_escaping(script: str) -> str:
     return script.replace("$$", "$")
 
 
-def _run_env_vars_assembly(deploy_env: str, redis_url: str, gotenberg_url: str = "") -> str:
+def _run_env_vars_assembly(
+    deploy_env: str, redis_url: str, gotenberg_url: str = "", support_gateway_url: str = ""
+) -> str:
     """실제 gcloud 호출부만 잘라내고 ENV_VARS 조립 로직까지만 실행 — 실제 배포 없이 결과 문자열만 얻는다."""
     script = _apply_cloudbuild_escaping(_extract_deploy_backend_script())
     # 실제 gcloud run deploy 호출 라인 이후는 잘라내고 ENV_VARS를 echo하도록 붙인다.
@@ -248,6 +255,10 @@ def _run_env_vars_assembly(deploy_env: str, redis_url: str, gotenberg_url: str =
         "_SUPPORT_ESCALATION_APPROVER_MEMBER_ID": "",
         "_SUPPORT_ESCALATION_TARGET_ORG_SLUG": "moonklabs",
         "_SUPPORT_ESCALATION_TARGET_PROJECT_SLUG": "sprintable",
+        # story #3279 — GOTENBERG_SERVICE_URL과 동일 이유(set -u라 미설정이면 스크립트가
+        # 죽는다). 기본 빈 문자열(substitutions 기본값과 정합 — gateway 자체가 아직
+        # dev 전용 프로비저닝이라 prod엔 이 값이 없다).
+        "_NEXT_PUBLIC_SUPPORT_GATEWAY_URL": support_gateway_url,
     }
     proc = subprocess.run(
         ["bash", "-c", assembly_only],
@@ -448,6 +459,35 @@ def test_deploy_backend_prod_excludes_gotenberg_service_url_even_when_set():
         "prod", "", gotenberg_url="https://office-converter-dev.example.run.app"
     )
     assert "GOTENBERG_SERVICE_URL" not in result
+
+
+def test_deploy_backend_includes_support_gateway_operator_reply_url_when_set():
+    """story #3279 — support-gateway가 프로비저닝된 뒤(_NEXT_PUBLIC_SUPPORT_GATEWAY_URL
+    채워짐) 운영자 회신 착지 URL이 실린다(기존 값에 경로만 이어붙임)."""
+    result = _run_env_vars_assembly(
+        "dev", "redis://10.164.120.243:6379", support_gateway_url="https://support-gateway-dev.example.run.app"
+    )
+    assert (
+        "SUPPORT_GATEWAY_OPERATOR_REPLY_URL="
+        "https://support-gateway-dev.example.run.app/api/v1/internal/operator-replies"
+    ) in result
+
+
+def test_deploy_backend_excludes_support_gateway_operator_reply_url_when_unset():
+    """빈 값이면 키 자체를 안 싣는다(operator_reply_delivery.py가 미설정을 fail-closed로
+    처리하므로 이게 안전한 기본 상태 — GOTENBERG_SERVICE_URL과 동일 원칙)."""
+    result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379", support_gateway_url="")
+    assert "SUPPORT_GATEWAY_OPERATOR_REPLY_URL" not in result
+
+
+def test_deploy_backend_prod_excludes_support_gateway_operator_reply_url_even_when_set():
+    """GOTENBERG_SERVICE_URL의 prod 게이트 회귀(카디르 QA 2026-08-19)와 동일 클래스를
+    처음부터 막는다 — 값이 채워져 있어도 prod에서는 키 자체가 없어야 한다(support-gateway
+    자체가 아직 dev 전용 프로비저닝)."""
+    result = _run_env_vars_assembly(
+        "prod", "", support_gateway_url="https://support-gateway-dev.example.run.app"
+    )
+    assert "SUPPORT_GATEWAY_OPERATOR_REPLY_URL" not in result
 
 
 def test_deploy_backend_dev_env_vars_unchanged_by_prod_branch():

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -736,6 +736,17 @@ steps:
         if [ "${_DEPLOY_ENV}" != "prod" ] && [ -n "${_GOTENBERG_SERVICE_URL}" ]; then
           ENV_VARS="$${ENV_VARS},GOTENBERG_SERVICE_URL=${_GOTENBERG_SERVICE_URL}"
         fi
+        # story #3279(지원v1·후속) — 운영자 회신 배달(backend→support-gateway) 착지 URL.
+        # support-gateway 자체가 아직 dev 전용 프로비저닝(_NEXT_PUBLIC_SUPPORT_GATEWAY_URL이
+        # prod엔 빈 문자열, deploy-frontend 스텝 주석 참고)이라 같은 조건으로 게이트 — 빈
+        # 값이면 아예 안 싣는다(GOTENBERG_SERVICE_URL과 동일 원칙, 안 실으면 코드 쪽
+        # settings.support_gateway_operator_reply_url=""가 fail-closed로 배달을 정직하게
+        # skip한다 — operator_reply_delivery.py). SUPPORT_GATEWAY_TOKEN_SECRET은 이미 이
+        # 스텝의 SECRETS_FLAG(dev 분기)에 바인딩돼 있어 별도 시크릿 추가 불요(같은 대칭키
+        # 재사용 — aud로만 구조적 분리, escalation_delivery.py 반대 방향과 동형).
+        if [ "${_DEPLOY_ENV}" != "prod" ] && [ -n "${_NEXT_PUBLIC_SUPPORT_GATEWAY_URL}" ]; then
+          ENV_VARS="$${ENV_VARS},SUPPORT_GATEWAY_OPERATOR_REPLY_URL=${_NEXT_PUBLIC_SUPPORT_GATEWAY_URL}/api/v1/internal/operator-replies"
+        fi
         # story #2445/#3110/#3118 — DATABASE_URL(PgBouncer, dev/prod 둘 다 sprintable 앱유저)·
         # DATABASE_URL_DIRECT(dev=sprintable 앱유저·prod=postgres 직결)·DATABASE_URL_READ(prod만)·
         # APPLE_PRIVATE_KEY 시크릿 바인딩. dev pgbouncer 경유분은 #3110 2보(userlist에 sprintable


### PR DESCRIPTION
[SID:3279]

## 배경
gateway 측(PR#3672, 머지 完)이 착지점을 냈다. 이 PR은 발신 측 — 카드 메시지(approval_delivery.py가 만드는 `approval_target.work_item_type=="support_escalation"`)에 **스레드 답장**이 달리면 그 내용을 support-gateway의 해당 대화로 배달한다.

⛔카드 최상위(스레드 아닌) 텍스트 답은 이 분기를 안 탄다 — `approval_delivery.py`의 기존 정책("챗 텍스트는 게이트를 해소하지 않는다 — 카드 액션만 유효")과 별개 트리거라 그 정책을 안 건드린다.

## 변경
1. **`app/services/operator_reply_delivery.py`** — `escalation_delivery.py`(gateway→backend)의 반대 방향. 같은 `SUPPORT_GATEWAY_TOKEN_SECRET`을 `aud="support-gateway:operator-reply"`로 서명(PR#3672가 gateway 측 검증기를 이미 냄). `deliver_operator_reply_for_gate`가 `gate_id`→`Gate.neutral_facts.support_escalation_id` 역참조(정본 재확인 — 부모 메시지 스냅샷만 믿지 않음)→`deliver_operator_reply`가 실 배달(escalation_delivery.py와 동형 fire-and-forget, 실패해도 예외 전파 안 함).
2. **`app/routers/conversations.py`** — `_operator_reply_target_gate_id` 순수 헬퍼 신설(`_approval_payload`류와 동형 패턴) — `send_message()`가 이미 로드해둔 `root_msg`(thread_id 유효성 검증 재사용, 추가 쿼리 0)에서 gate_id를 뽑는다. `background_tasks`로 큐잉 — 배달 실패가 챗 전송 자체를 절대 안 깨뜨린다.
3. **`config.py` + `cloudbuild.yaml`** — `support_gateway_operator_reply_url` 신설(빈 값=fail-closed skip). `deploy-backend` ENV_VARS에 기존 `_NEXT_PUBLIC_SUPPORT_GATEWAY_URL` substitution 재사용 배선(dev만, `GOTENBERG_SERVICE_URL`과 동일 prod 게이트 원칙) — 신규 시크릿 불요(`SUPPORT_GATEWAY_TOKEN_SECRET` 기존 바인딩 재사용).

## 검증
- `_operator_reply_target_gate_id` 순수 단위 테스트 7건(no-thread·정상 라우팅·오배달 방지·malformed 방어).
- `deliver_operator_reply` httpx mock 5건(성공/5xx/네트워크실패/시크릿·URL 미설정).
- `deliver_operator_reply_for_gate` 실 PG Gate 조회 4건(정상 역참조·escalation_id 부재·미지 gate_id·work_item_type 불일치 오배달 방지).
- **뮤테이션 검증**(work_item_type 체크 제거) — pin이 확실히 red로 죽는 것 확認 후 원복.
- 전체 **59 passed**(신규+인접 회귀 전부, `test_conversations.py` 포함).
- cloudbuild 가드 3종(substitution 미선언·byte 한도·ENV_VARS 조립 실행)·env-drift Settings 커버리지 카운트(114→115) 전부 기존 관례대로 동반 갱신.

## 스코프 밖(후속 PR, 페드루 PO 명시 AC)
위젯 FE — `role="operator"` 렌더("상담원" 라벨+재오픈 복원까지가 2부 AC, 도달 가능한 표면은 실픽셀로).