### PR TITLE
[SID:3279] 운영자 회신 발신자 구분 렌더(FE 3/3) — role='operator' "상담원" 라벨

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4449,6 +4449,7 @@
     "conversationListEmpty": "No past conversations yet",
     "conversationActiveBadge": "Active",
     "conversationEndedBanner": "This conversation has ended. Start a new one to keep chatting.",
-    "endConversation": "End conversation"
+    "endConversation": "End conversation",
+    "operatorSenderLabel": "Support team"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4449,6 +4449,7 @@
     "conversationListEmpty": "아직 이전 상담이 없습니다",
     "conversationActiveBadge": "진행 중",
     "conversationEndedBanner": "이 상담은 종료되었습니다. 계속하려면 새 상담을 시작해 주세요.",
-    "endConversation": "상담 종료"
+    "endConversation": "상담 종료",
+    "operatorSenderLabel": "상담원"
   }
 }

--- a/apps/web/src/components/support-widget/support-widget-panel.test.tsx
+++ b/apps/web/src/components/support-widget/support-widget-panel.test.tsx
@@ -170,4 +170,36 @@ describe('SupportWidgetPanelBody — story #3260 Phase 2', () => {
       expect(btn).toBeUndefined();
     });
   });
+
+  describe('story #3279 — 운영자 회신 발신자 구분 렌더', () => {
+    it('role="operator" 메시지는 "상담원" 라벨을 보인다', async () => {
+      await mount(baseSession({
+        messages: [{ id: 'op1', role: 'operator', content: '확인했습니다, 답변드릴게요.', createdAt: 't' }],
+      }));
+      expect(container.textContent).toContain(koMessages.supportWidget.operatorSenderLabel);
+      expect(container.textContent).toContain('확인했습니다, 답변드릴게요.');
+    });
+
+    it('role="agent"(AI 자동응대) 메시지는 "상담원" 라벨을 안 보인다(발신자 축이 다르다는 것을 실측)', async () => {
+      await mount(baseSession({
+        messages: [{ id: 'ag1', role: 'agent', content: 'AI 자동 응답입니다.', createdAt: 't' }],
+      }));
+      expect(container.textContent).not.toContain(koMessages.supportWidget.operatorSenderLabel);
+    });
+
+    it('한 대화 안에 operator·agent 메시지가 섞여도 각자 정확히 자기 라벨만 보인다', async () => {
+      await mount(baseSession({
+        messages: [
+          { id: 'ag1', role: 'agent', content: 'AI가 먼저 응대', createdAt: 't1' },
+          { id: 'op1', role: 'operator', content: '운영자가 이어서 답변', createdAt: 't2' },
+        ],
+      }));
+      const opBubble = container.querySelector('[data-role="operator"]');
+      const agBubble = container.querySelector('[data-role="agent"]');
+      expect(opBubble?.textContent).toContain(koMessages.supportWidget.operatorSenderLabel);
+      expect(opBubble?.textContent).toContain('운영자가 이어서 답변');
+      expect(agBubble?.textContent).not.toContain(koMessages.supportWidget.operatorSenderLabel);
+      expect(agBubble?.textContent).toContain('AI가 먼저 응대');
+    });
+  });
 });

--- a/apps/web/src/components/support-widget/support-widget-panel.tsx
+++ b/apps/web/src/components/support-widget/support-widget-panel.tsx
@@ -226,7 +226,7 @@ export function SupportWidgetPanelBody({ session }: { session: SupportWidgetSess
               } ${m.pending ? 'opacity-60' : ''} ${m.failed ? 'border border-destructive/50' : ''}`}
             >
               {m.role === 'operator' ? (
-                <p className="mb-1 flex items-center gap-1 text-[11px] font-semibold text-muted-foreground">
+                <p className="mb-1 flex items-center gap-1 text-[11px] font-semibold text-foreground">
                   <UserRound className="h-3 w-3" aria-hidden />
                   {t('operatorSenderLabel')}
                 </p>

--- a/apps/web/src/components/support-widget/support-widget-panel.tsx
+++ b/apps/web/src/components/support-widget/support-widget-panel.tsx
@@ -212,10 +212,25 @@ export function SupportWidgetPanelBody({ session }: { session: SupportWidgetSess
           session.messages.map((m) => (
             <div
               key={m.id}
+              data-role={m.role}
               className={`max-w-[85%] rounded-xl px-3 py-2 text-sm leading-relaxed [overflow-wrap:anywhere] ${
-                m.role === 'user' ? 'ml-auto bg-proof-blue-soft text-foreground' : 'bg-muted text-foreground'
+                m.role === 'user'
+                  ? 'ml-auto bg-proof-blue-soft text-foreground'
+                  // story #3279 — operator(사람 운영자 실 회신)는 agent(AI 자동응대)와 같은
+                  // bg-muted를 쓰되 좌측 강조 보더로 시각 축을 분리한다(발신자가 다르다는
+                  // 신호 — no-fiction 원칙의 렌더 축 대응물: "누가 답했는지"도 지어내면
+                  // 안 된다).
+                  : m.role === 'operator'
+                    ? 'border-l-2 border-l-primary bg-muted text-foreground'
+                    : 'bg-muted text-foreground'
               } ${m.pending ? 'opacity-60' : ''} ${m.failed ? 'border border-destructive/50' : ''}`}
             >
+              {m.role === 'operator' ? (
+                <p className="mb-1 flex items-center gap-1 text-[11px] font-semibold text-muted-foreground">
+                  <UserRound className="h-3 w-3" aria-hidden />
+                  {t('operatorSenderLabel')}
+                </p>
+              ) : null}
               {m.content}
               {m.escalated ? (
                 <p className="mt-1 text-[10px] font-medium text-muted-foreground">{t('escalatedBadge')}</p>

--- a/apps/web/src/hooks/use-support-widget-session.test.tsx
+++ b/apps/web/src/hooks/use-support-widget-session.test.tsx
@@ -136,6 +136,24 @@ describe('useSupportWidgetSession — story #3260 Phase 2', () => {
     expect(container.querySelector('[data-testid="escalation-status"]')!.textContent).toBe('open');
   });
 
+  it('story #3279 — role="operator" 메시지는 "agent"로 안 뭉개지고 그대로 재오픈 복원된다', async () => {
+    createOrResumeGatewaySessionMock.mockResolvedValue({ id: 'sess-1', org_id: 'org-1', created_at: 'now' });
+    listGatewayMessagesMock.mockResolvedValue({
+      messages: [
+        { id: 'm1', conversation_id: 'c1', role: 'operator', content: '확인했습니다, 답변드릴게요.', created_at: 't1' },
+        { id: 'm2', conversation_id: 'c1', role: 'agent', content: 'AI 자동 응답', created_at: 't2' },
+      ],
+      escalationStatus: 'open',
+    });
+    await mount();
+    await click('connect');
+    const items = Array.from(container.querySelectorAll('li'));
+    const operatorItem = items.find((li) => li.textContent === '확인했습니다, 답변드릴게요.');
+    const agentItem = items.find((li) => li.textContent === 'AI 자동 응답');
+    expect(operatorItem?.getAttribute('data-role')).toBe('operator');
+    expect(agentItem?.getAttribute('data-role')).toBe('agent'); // operator 매핑이 agent 쪽을 오염시키지 않는다.
+  });
+
   it('connect() 실패 — error 상태로 전환된다(unavailable과 구분)', async () => {
     createOrResumeGatewaySessionMock.mockRejectedValue(new Error('network down'));
     await mount();

--- a/apps/web/src/hooks/use-support-widget-session.ts
+++ b/apps/web/src/hooks/use-support-widget-session.ts
@@ -31,7 +31,10 @@ export type SupportWidgetStatus = 'unavailable' | 'connecting' | 'ready' | 'erro
 
 export interface SupportWidgetMessage {
   id: string;
-  role: 'user' | 'agent';
+  // story #3279(지원v1·후속) — 'operator'는 사람 운영자의 실 회신(GatewayMessage.role
+  // 'operator' 그대로 통과, agent와 값을 안 합친다 — 패널이 이 값으로 "상담원" 라벨을
+  // 구분 렌더한다).
+  role: 'user' | 'agent' | 'operator';
   content: string;
   createdAt: string;
   /** agent 메시지 전용 — Gateway가 사람에게 연결했다는 뜻(무신호 아님, 항상 진짜 안내
@@ -83,9 +86,13 @@ export interface SupportWidgetSession {
 }
 
 function toWidgetMessage(m: GatewayMessage): SupportWidgetMessage {
+  // story #3279 — 'operator'는 'agent'로 뭉개지 않고 그대로 통과시킨다(예전엔 role !==
+  // 'customer'면 전부 'agent'였다 — 이 map을 안 고쳤으면 operator 회신이 조용히 AI 응답
+  // 행세를 했을 것, 페드루 PO가 명시로 짚은 자리).
+  const role = m.role === 'customer' ? 'user' : m.role === 'operator' ? 'operator' : 'agent';
   return {
     id: m.id,
-    role: m.role === 'customer' ? 'user' : 'agent',
+    role,
     content: m.content,
     createdAt: m.created_at,
   };

--- a/apps/web/src/lib/support-widget/gateway-client.ts
+++ b/apps/web/src/lib/support-widget/gateway-client.ts
@@ -14,7 +14,10 @@ export interface GatewaySession {
 export interface GatewayMessage {
   id: string;
   conversation_id: string;
-  role: 'customer' | 'agent';
+  // story #3279(지원v1·후속) — 'operator'는 사람 운영자가 결재 카드 스레드 답장으로 보낸
+  // 회신(support-gateway PR#3672 착지점, backend PR#3673 배달 훅). AI 'agent' 응답과
+  // 발신자 축 자체가 다르다(자동 응대 vs 사람 개입) — 위젯이 구분 렌더해야 한다.
+  role: 'customer' | 'agent' | 'operator';
   content: string;
   created_at: string;
 }


### PR DESCRIPTION
[SID:3279]

## 배경
gateway 측(PR#3672, 머지 完)이 `role='operator'` 메시지를 적재하고, backend 측(PR#3673)이 배달 훅을 낸다. 이 PR은 마지막 조각 — 위젯이 그 `role`을 실제로 구분 렌더한다.

이전 코드는 `role !== 'customer'`면 전부 `'agent'`로 뭉갰다 — 그대로 두면 사람 운영자가 쓴 회신이 AI 자동 응답 행세를 하게 된다(no-fiction 원칙의 렌더 축 위반, 페드루 PO가 PR#3673 리뷰에서 명시로 짚음).

## 변경
1. **`gateway-client.ts`/`use-support-widget-session.ts`** — `GatewayMessage.role`·`SupportWidgetMessage.role`에 `'operator'` 추가, `toWidgetMessage`가 그대로 통과(agent로 안 합침).
2. **`support-widget-panel.tsx`** — operator 메시지 버블에 "상담원" 라벨(`UserRound` 아이콘+좌측 강조 보더로 agent와 시각 축 분리) — 위젯 런처·설정탭 둘 다 `SupportWidgetPanelBody`를 공유해 발명 0으로 동시 적용(#3260 자산 재사용 관례). 메시지 div에 `data-role` 속성 추가.

## 검증
- 훅 레벨: `role='operator'` 메시지가 재오픈(`connect()`) 복원 시에도 agent와 안 섞이는 것 pin.
- 패널 레벨: operator만 라벨 보임·agent는 안 보임·혼재 시 각자 정확히 자기 라벨만 보이는 것 3건.
- **뮤테이션 검증**(`toWidgetMessage`를 구 매핑으로 되돌림) — 훅 레벨 pin이 확실히 red로 죽는 것 확認(패널 레벨은 목 세션이라 무관 — 계층 분리 확인) → 원복.
- 전체 **64 passed**, `tsc --noEmit` 클린, lint 0 error, `pnpm build` 성공, i18n dup-key 가드 green.

## 스코프 밖
답장 권한(카드 audience 밖 참가자의 스레드 답장 실물 가능 여부) — 페드루 PO가 카디르군 QA 축으로 이관(PR#3673 리뷰 코멘트).

## 스택
PR#3672(gateway) → PR#3673(backend) → 이 PR(FE). 셋 다 머지+배포돼야 실제 왕복이 완주한다(도달 가능한 표면은 실픽셀 라이브 검증 대상, 페드루 PO 확定 — story done 게이트).