### PR TITLE
[SID:3283] ANY 강제 턴 종결 설계 — AFC 호출 상한 축소+무매치 종결 시 코드 에스컬

### DIFF
--- a/support-gateway/app/interaction.py
+++ b/support-gateway/app/interaction.py
@@ -409,6 +409,34 @@ async def handle_turn(
         deduped_answers = [a for a in tool_reply_state["answers"] if not (a in seen or seen.add(a))]
         reply_text = "\n\n".join(deduped_answers)
 
+    # story #3283(지원v1·후속, 2026-09-01 PO 라이브 실증) — force_tool_names(강제 그라운딩)
+    # 턴이 (상한 축소 이후에도) 전 호출 무매치로 끝나면, escalate는 mode=ANY(allowed=
+    # knowledge_search만)에 의해 이번 턴 내내 호출 자체가 봉쇄돼 있었다 — 모델에게 "정직
+    # 무매치 시 사람 연결"을 맡길 재량 자체가 없었다는 뜻. 조립 답변이 이미 "담당자에게
+    # 연결해 드리는 게 정확합니다"라고 말하는데 실제로는 아무도 연결 안 된 채로 끝나는 걸
+    # 막기 위해, 이 경우엔 모델 재량을 거치지 않고 코드가 직접 에스컬레이션을 실행한다
+    # (근접 사다리 #3281의 "재무매치=에스컬" ③단을 강제 턴에서도 구조적으로 이행시키는
+    # 마지막 조각 — AUTO 턴 일반화는 스코프 밖으로 유보, PO 확定).
+    if force_tool_names and not escalated and not knowledge_state["had_match"]:
+        await escalation_task(
+            db,
+            conversation_id=conversation.id,
+            org_id=org_id,
+            user_id=user_id,
+            reason="forced_grounding_no_match",
+            detail=f"강제 knowledge_search가 전 호출 무매치로 종결 — 코드가 직접 에스컬: {customer_text[:120]!r}",
+        )
+        db.add(
+            SupportExecutionLog(
+                conversation_id=conversation.id,
+                org_id=org_id,
+                task_type="forced_grounding_escalation",
+                model=model,
+                summary="forced grounding turn ended with no match — code-escalated",
+            )
+        )
+        escalated = True
+
     _store_agent_message(db, conversation=conversation, org_id=org_id, text=reply_text, cost_usd=cost)
     await maybe_summarize(db, conversation=conversation, llm=llm)
     return TurnResult(reply_text=reply_text, escalated=escalated)

--- a/support-gateway/app/vertex_client.py
+++ b/support-gateway/app/vertex_client.py
@@ -105,10 +105,23 @@ class VertexLLMClient:
             if force_tool_names
             else None
         )
+        # story #3283(지원v1·후속, 2026-09-01 PO 라이브 실증) — mode=ANY는 AFC 루프의 매
+        # 스텝에 적용되는 제약이라, 도구가 계속 무매치를 돌려주면 모델은 텍스트도 escalate도
+        # 절대 못 내고 SDK 기본 상한(maximum_remote_calls=10, 실측과 정확히 일치)까지
+        # 반복한다 — 실측 10회·117초. 강제 그라운딩 턴에 한해 이 상한을 2로 좁혀 질의 변주
+        # 1회 재시도의 가치는 보존하되 10x 지연·비용은 차단한다(PO 확定, 1은 과잉 축소로
+        # 기각). force_tool_names가 없는 일반 AUTO 턴은 SDK 기본값(10) 그대로 — 이 스토리
+        # 스코프 밖(PO 확定).
+        automatic_function_calling = (
+            types.AutomaticFunctionCallingConfig(maximum_remote_calls=2) if force_tool_names else None
+        )
         chat = self._client.aio.chats.create(
             model=model,
             config=types.GenerateContentConfig(
-                system_instruction=system_prompt, tools=tools, tool_config=tool_config
+                system_instruction=system_prompt,
+                tools=tools,
+                tool_config=tool_config,
+                automatic_function_calling=automatic_function_calling,
             ),
         )
         resp = await chat.send_message(user_text)

--- a/support-gateway/tests/test_orchestration.py
+++ b/support-gateway/tests/test_orchestration.py
@@ -183,3 +183,66 @@ async def test_needs_grounding_reverse_mutation_pin(client, fake_llm):
     assert forced == ["knowledge_search"]
     assert not_forced is None
     assert forced != not_forced
+
+
+# story #3283(지원v1·후속, 2026-09-01 PO 라이브 실증) — 강제 그라운딩 턴이 전 호출 무매치로
+# 끝나면 escalate 자체가 mode=ANY(allowed=knowledge_search만)에 의해 봉쇄돼 모델 재량으로는
+# 절대 못 부른다 — 조립 문구("연결해 드리는 게 정확합니다")가 실제 행동과 어긋나지 않도록
+# 코드가 직접 에스컬레이션을 실행해야 한다.
+async def test_forced_grounding_turn_ending_no_match_code_escalates(client, fake_llm, db_engine, monkeypatch):
+    import app.execution_tasks as execution_tasks_module
+
+    monkeypatch.setattr(execution_tasks_module, "search", lambda vector, top_k=3, min_score=None: [])
+
+    fake_llm.classify_text = "inquiry"
+    fake_llm.classify_needs_grounding = True
+    fake_llm.call_tool_name = "knowledge_search"
+    fake_llm.call_tool_kwargs = {"query": "에이전트 로컬 설정 방법"}
+    resp = await _post_message(client, OTHER_ORG_ID, content="에이전트 로컬 설정 방법")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["escalated"] is True
+    from app.execution_tasks import NO_MATCH_MESSAGE
+
+    assert body["agent_message"]["content"] == NO_MATCH_MESSAGE  # 문구는 그대로, 실동작만 이행.
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    async with async_sessionmaker(db_engine, expire_on_commit=False)() as session:
+        escalations = (await session.execute(select(SupportEscalation))).scalars().all()
+        assert len(escalations) == 1
+        assert escalations[0].reason == "forced_grounding_no_match"
+        logs = (await session.execute(select(SupportExecutionLog))).scalars().all()
+        assert any(log.task_type == "forced_grounding_escalation" for log in logs)
+
+
+async def test_forced_grounding_turn_with_near_miss_does_not_code_escalate(client, fake_llm, db_engine, monkeypatch):
+    """근접 매치(had_match=True)가 있으면 코드 강제 에스컬이 안 걸려야 한다 — #3281 근접
+    사다리 ②단이 강제 턴에서도 여전히 정상 착지하는지 회귀 방지."""
+    import app.execution_tasks as execution_tasks_module
+    from app.knowledge.corpus import KnowledgeChunk
+    from app.knowledge_search import SearchMatch
+
+    chunk = KnowledgeChunk(id="near-x", title="근접문서", content="근접 내용", source_note="test")
+    monkeypatch.setattr(
+        execution_tasks_module, "search", lambda vector, top_k=3, min_score=None: [SearchMatch(chunk=chunk, score=0.65)]
+    )
+
+    fake_llm.classify_text = "inquiry"
+    fake_llm.classify_needs_grounding = True
+    fake_llm.knowledge_text = "NONE"  # 관련성 판정 LLM이 거부 — 정확 매치가 아니라 근접으로 착지.
+    fake_llm.call_tool_name = "knowledge_search"
+    fake_llm.call_tool_kwargs = {"query": "질문"}
+    resp = await _post_message(client, OTHER_ORG_ID, content="질문")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["escalated"] is False
+    assert "근접 내용" in body["agent_message"]["content"]
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    async with async_sessionmaker(db_engine, expire_on_commit=False)() as session:
+        escalations = (await session.execute(select(SupportEscalation))).scalars().all()
+        assert escalations == []

--- a/support-gateway/tests/test_vertex_client.py
+++ b/support-gateway/tests/test_vertex_client.py
@@ -1,0 +1,65 @@
+"""story #3283(지원v1·후속, 2026-09-01 PO 라이브 실증) — VertexLLMClient.generate_with_tools의
+실 SDK 설정 배선 pin. genai.Client 자체를 몽키패치해 실 Vertex 호출 0 — force_tool_names에
+따라 tool_config(mode=ANY)와 automatic_function_calling(maximum_remote_calls=2)이 정확히
+조립되는지만 검증한다. 실 AFC 루프 동작(모델이 진짜 몇 번 반복 호출하는지)은 페이크로
+재현 불가 — 수동 SDK 스모크 테스트 영역(기존 관례, conftest.py FakeLLMClient 문서 참고)."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class _FakeChats:
+    def __init__(self, captured: dict) -> None:
+        self._captured = captured
+
+    def create(self, *, model: str, config):
+        self._captured["model"] = model
+        self._captured["config"] = config
+        chat = SimpleNamespace()
+        chat.send_message = AsyncMock(
+            return_value=SimpleNamespace(
+                text="ok",
+                usage_metadata=SimpleNamespace(prompt_token_count=1, candidates_token_count=1),
+                automatic_function_calling_history=[],
+            )
+        )
+        return chat
+
+
+@pytest.fixture
+def vertex_client(monkeypatch):
+    from app import vertex_client as vertex_client_module
+
+    captured: dict = {}
+    fake_genai_client = SimpleNamespace(aio=SimpleNamespace(chats=_FakeChats(captured)))
+    monkeypatch.setattr("google.genai.Client", lambda **kwargs: fake_genai_client)
+
+    client = vertex_client_module.VertexLLMClient()
+    return client, captured
+
+
+async def test_force_tool_names_sets_any_mode_and_reduces_call_cap(vertex_client):
+    client, captured = vertex_client
+    await client.generate_with_tools(
+        model="gemini-x", system_prompt="sp", user_text="hi", tools=[], force_tool_names=["knowledge_search"]
+    )
+    config = captured["config"]
+    assert config.tool_config.function_calling_config.mode == "ANY"
+    assert config.tool_config.function_calling_config.allowed_function_names == ["knowledge_search"]
+    assert config.automatic_function_calling is not None
+    assert config.automatic_function_calling.maximum_remote_calls == 2
+
+
+async def test_no_force_tool_names_leaves_auto_mode_and_sdk_default_cap(vertex_client):
+    """force_tool_names가 없는 일반 AUTO 턴은 SDK 기본 상한(10, 실측 재현과 일치)을 그대로
+    쓴다 — story #3283 스코프는 강제 턴 한정(PO 확定)."""
+    client, captured = vertex_client
+    await client.generate_with_tools(
+        model="gemini-x", system_prompt="sp", user_text="hi", tools=[], force_tool_names=None
+    )
+    config = captured["config"]
+    assert config.tool_config is None
+    assert config.automatic_function_calling is None


### PR DESCRIPTION
story #3283(지원v1·후속). 2026-09-01 PO 근접 표본 라이브 실증(gateway 00029·conv 97adfe55) — story #3277(강제 knowledge_search) AC 리뷰 때 예견한 최악 케이스가 실물로 나옴.

## 실측
«에이전트 로컬 설정 방법»(needs_grounding=true·코퍼스 무매치 표본): ANY 강제 하 모델이 knowledge_search를 **10회 연속 호출**(질의 변주 포함, 전부 무매치), **117초** 후 AFC 상한 종결. 최종 표면=정직 무매치 조립문(#3270 조립이 받쳐 날조·크래시 0) — 단:
1. **지연·비용**: 고객 117초 대기·임베딩+관련성 LLM 10x
2. **«담당자에게 연결해 드리는 게 정확합니다» 문구 미이행**: mode=ANY(allowed=knowledge_search만)가 escalate 호출 자체를 봉쇄 → escalated=False. #3281 근접 사다리 ③단(재무매치=에스컬)이 "모델 재량"에 걸려 있어 강제 턴에선 절대 못 탄다.

## 근인(SDK 실측 확認)
`AutomaticFunctionCallingConfig.maximum_remote_calls` 기본값이 정확히 **10**(SDK 필드 직접 조회 확認) — 라이브 실측 "10연발"과 정확히 일치. mode=ANY는 AFC 루프의 매 스텝에 적용되는 제약이라, 도구가 계속 무매치를 돌려주는 한 모델은 텍스트도 escalate도 절대 못 내고 이 상한까지 반복한다.

## 처방(PO 승인)
- `vertex_client.py`: `force_tool_names` 켜진 턴에 한해 `AutomaticFunctionCallingConfig(maximum_remote_calls=2)` 명시 — 질의 변주 1회 재시도 가치는 보존, 10x는 차단(1은 과잉 축소로 기각). 일반 AUTO 턴은 SDK 기본값(10) 그대로(스코프 밖, PO 확定).
- `interaction.py`: 강제 그라운딩 턴이 전 호출 무매치로 끝나면 모델 재량 없이 코드가 직접 `escalation_task(...)` 실행 — 조립 문구의 "연결" 약속이 실제 행동과 일치하게 만드는 유일한 경로. AUTO 턴 일반화는 스코프 밖 유보(PO 확定 — 분류기+가드+사다리가 이미 그물, 전 무매치 강제 에스컬은 과에스컬 방향).

## 검증
- 신규 pin 4건: SDK 배선 2건(force_tool_names→ANY+cap=2 / 없으면 AUTO+기본값) + orchestration 2건(무매치 종결→코드 에스컬 · 근접 매치 있으면 회귀 없이 정상 착지)
- 뮤테이션 자가검증 2회(cap 반영 제거·에스컬 블록 비활성화) — 정확한 대상만 RED 확認 후 원복
- support-gateway 전체 164 passed(무회귀)

## 남은 것
⚠️ 실 AFC 루프가 cap=2에서 진짜 2회로 끊기는지는 페이크로 재현 불가 — 기존 관례대로 수동 SDK 스모크/라이브 재검 영역(PO 레인 — 같은 표본으로 "수 초 내·정직 문구+실 에스컬" 재확인 예고). #3268/#3281 done 판정도 이 재검 완료까지 보류.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_019rkXVqy2DF1aAN7szuqp44