### PR TITLE
[SID:3282] 지원운영 어드민 관제 뷰 — gateway 신규 엔드포인트(1/4)

### DIFF
--- a/support-gateway/app/routers/admin.py
+++ b/support-gateway/app/routers/admin.py
@@ -1,21 +1,43 @@
 """story #3264(지원v1·6방어·계측) AC3/AC4 — 어드민 계측 조회. 고객 위임 토큰 축과 완전히
 분리된 인증(app/token_verify.py::require_admin) — org 스코프 개념이 없는 내부 운영
-엔드포인트다. 고객 대화 원문(SupportMessage.content)은 절대 반환하지 않는다(집계 숫자만
-— org 격리 원칙이 "고객 데이터"에 적용되는 것이지, 우리 자신의 운영 지표 열람에는 안
-적용된다는 점을 명확히 한다)."""
+엔드포인트다. /metrics의 고객 대화 원문(SupportMessage.content) 절대 미반환 원칙은 그
+엔드포인트 전용(집계 API 경계) — org 격리 원칙이 "고객 데이터"에 적용되는 것이지, 우리
+자신의 운영 지표 열람에는 안 적용된다는 점을 명확히 한다.
+
+story #3282(지원운영 어드민 관제, 2026-09-01 PO 판정 반영) — /conversations·
+/conversations/{id}/messages는 위 원칙이 적용 안 되는 별개 엔드포인트군이다: sprintable-admin
+운영 콘솔(IAP 게이트)이 고객 문의 원문을 항시 열람(에스컬 여부 무관, 선생님 확定 방향①)하는
+것 자체가 업무인 별개 신뢰 표면이라는 게 PO 판정(설계 doc §2-b, entity:doc:
+e8aa483d-bff6-4d78-ac7f-dacc86d615f5). 그 대가로 두 조건이 이 파일 안에 강제된다:
+(1) 호출 시마다 operator_identity를 로그로 남긴다(durable 감사 로그 자체는 internal-api
+쪽 책임 — 설계 doc §5, gateway는 "누가 봤는지"까지 저장할 fleet 자격을 새로 안 받는다),
+(2) org 격리는 internal-api의 require_operator 층에서 통제한다는 전제 — 이 라우터 자체는
+require_admin(정적 토큰, org 스코프 없음) 그대로라 org_id는 순수 필터일 뿐 인가 경계가
+아니다."""
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.db import get_db
 from app.metrics import compute_resolution_metrics
-from app.schemas import AdminMetricsResponse
+from app.models import SupportConversation, SupportEscalation, SupportMessage
+from app.schemas import (
+    AdminConversationListResponse,
+    AdminConversationMessagesResponse,
+    AdminConversationSummary,
+    AdminMetricsResponse,
+    MessageResponse,
+)
 from app.token_verify import require_admin
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/admin", tags=["admin"], dependencies=[Depends(require_admin)])
 
@@ -38,4 +60,92 @@ async def get_metrics(
         escalation_rate=metrics.escalation_rate,
         cost_cap_org_daily_usd=settings.cost_cap_org_daily_usd,
         cost_cap_org_session_usd=settings.cost_cap_org_session_usd,
+    )
+
+
+@router.get("/conversations", response_model=AdminConversationListResponse)
+async def list_conversations(
+    db: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    x_operator_identity: str = Header(default="unknown"),
+) -> AdminConversationListResponse:
+    """story #3282 — 방향① 확定(선생님 13:45): 에스컬 여부 무관, org 전체 지원 대화를 항시
+    열람 가능해야 한다. org_id 생략 시 전 org 대상(전체 관제 뷰).
+
+    x_operator_identity는 internal-api가 실은 "그 호출을 시킨 운영자"의 신원을 실은 것이다
+    — 이 함수는 인가 판단에 안 쓴다(gateway가 fleet 자격을 새로 받는 게 아니다, require_admin
+    통과 여부만 본다) — 로그 문자열로만 소비한다(모듈 docstring 참고, durable 기록은
+    internal-api 책임)."""
+    logger.info("admin conversation list access operator=%s org_id=%s", x_operator_identity, org_id)
+
+    stmt = select(SupportConversation).order_by(SupportConversation.created_at.desc()).limit(limit)
+    if org_id is not None:
+        stmt = stmt.where(SupportConversation.org_id == org_id)
+    conversations = (await db.execute(stmt)).scalars().all()
+
+    conv_ids = [c.id for c in conversations]
+    escalation_map: dict[uuid.UUID, list[uuid.UUID]] = {cid: [] for cid in conv_ids}
+    if conv_ids:
+        rows = (
+            await db.execute(
+                select(SupportEscalation.conversation_id, SupportEscalation.id).where(
+                    SupportEscalation.conversation_id.in_(conv_ids)
+                )
+            )
+        ).all()
+        for conversation_id, escalation_id in rows:
+            escalation_map[conversation_id].append(escalation_id)
+
+    return AdminConversationListResponse(
+        conversations=[
+            AdminConversationSummary(
+                id=c.id,
+                org_id=c.org_id,
+                external_user_id=c.external_user_id,
+                created_at=c.created_at,
+                ended_at=c.ended_at,
+                escalation_ids=escalation_map[c.id],
+            )
+            for c in conversations
+        ]
+    )
+
+
+@router.get("/conversations/{conversation_id}/messages", response_model=AdminConversationMessagesResponse)
+async def get_conversation_messages(
+    conversation_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    x_operator_identity: str = Header(default="unknown"),
+) -> AdminConversationMessagesResponse:
+    """story #3282 — 원문 전체 반환(에스컬 필터 없음). 모듈 docstring의 "원문 절대 반환
+    안 함" 원칙은 /metrics 전용이라 이 엔드포인트엔 적용되지 않는다(별개 신뢰 표면, PO 판정)."""
+    conv = (
+        await db.execute(select(SupportConversation).where(SupportConversation.id == conversation_id))
+    ).scalar_one_or_none()
+    if conv is None:
+        raise HTTPException(status_code=404, detail="conversation not found")
+
+    logger.info(
+        "admin conversation transcript access operator=%s conversation_id=%s org_id=%s",
+        x_operator_identity, conversation_id, conv.org_id,
+    )
+
+    messages = (
+        await db.execute(
+            select(SupportMessage)
+            .where(SupportMessage.conversation_id == conversation_id)
+            .order_by(SupportMessage.created_at.asc())
+        )
+    ).scalars().all()
+
+    return AdminConversationMessagesResponse(
+        conversation_id=conversation_id,
+        org_id=conv.org_id,
+        messages=[
+            MessageResponse(
+                id=m.id, conversation_id=m.conversation_id, role=m.role, content=m.content, created_at=m.created_at
+            )
+            for m in messages
+        ],
     )

--- a/support-gateway/app/schemas.py
+++ b/support-gateway/app/schemas.py
@@ -88,3 +88,37 @@ class AdminMetricsResponse(BaseModel):
     escalation_rate: float | None
     cost_cap_org_daily_usd: float
     cost_cap_org_session_usd: float
+
+
+class AdminConversationSummary(BaseModel):
+    """story #3282(지원운영 어드민 관제) — 어드민 콘솔 대화 목록 1건. 고객 원문은 안 싣는다
+    (목록 레벨에선 ConversationResponse와 같은 절제 원칙 — 원문은 .../messages로 별도 조회).
+    escalation_status(문자열)는 일부러 안 담는다: SupportEscalation.status는 영구 'open'
+    결함(story 183fe7a5-08cd-4a75-88f6-8c386ff23bd9)이 있어, 어드민 콘솔의 "에스컬 상태"는
+    internal-api 쪽에서 Gate.status 기준으로 계산한다(설계 doc §3/§4) — escalation_ids만
+    실어 그 Gate 역참조(Gate.neutral_facts.support_escalation_id)를 가능케 한다."""
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    external_user_id: uuid.UUID | None
+    created_at: datetime
+    ended_at: datetime | None
+    escalation_ids: list[uuid.UUID]
+
+
+class AdminConversationListResponse(BaseModel):
+    """story #3282 — GET /admin/conversations(어드민 전용, 전 org 대상 가능 — org_id 생략
+    시 전체). created_at 최신순."""
+
+    conversations: list[AdminConversationSummary]
+
+
+class AdminConversationMessagesResponse(BaseModel):
+    """story #3282 — GET /admin/conversations/{id}/messages. 원문 전체 반환(에스컬 필터
+    없음 — 선생님 확定 방향①). admin.py 모듈 docstring의 "원문 절대 반환 안 함" 원칙은
+    /metrics(계측 API) 전용이고 이 엔드포인트는 별개 신뢰 표면이라 적용 안 된다(PO 판정,
+    설계 doc §2-b)."""
+
+    conversation_id: uuid.UUID
+    org_id: uuid.UUID
+    messages: list[MessageResponse]

--- a/support-gateway/tests/test_admin_conversations.py
+++ b/support-gateway/tests/test_admin_conversations.py
@@ -1,0 +1,136 @@
+"""story #3282(지원운영 어드민 관제, 2026-09-01 PO 판정 확定판) — 어드민 신규
+/conversations·/conversations/{id}/messages. 핵심 pin은 "방향① 확定": 에스컬레이트 안 한
+대화도 전부 열람 가능해야 한다(에스컬만 보이면 실패) — test_admin_metrics.py의 인증 스캐폴딩
+(require_admin, MOONKLABS_ORG_ID/OTHER_ORG_ID)을 그대로 재사용한다."""
+from __future__ import annotations
+
+import uuid
+
+from app.config import settings
+from tests.conftest import MOONKLABS_ORG_ID, OTHER_ORG_ID, make_token
+
+
+async def _post_message(client, org_id, content="hello"):
+    headers = {"Authorization": f"Bearer {make_token(org_id)}"}
+    session = await client.post("/api/v1/sessions", headers=headers)
+    session_id = session.json()["id"]
+    resp = await client.post(f"/api/v1/sessions/{session_id}/messages", json={"content": content}, headers=headers)
+    return resp.json()
+
+
+# --- 인증(신규 엔드포인트도 기존 require_admin 재사용 — 별도 인가 경계를 새로 안 만든다) ------
+
+
+async def test_list_conversations_rejects_missing_admin_token(client):
+    resp = await client.get("/api/v1/admin/conversations")
+    assert resp.status_code == 401
+
+
+async def test_get_messages_rejects_missing_admin_token(client):
+    resp = await client.get(f"/api/v1/admin/conversations/{uuid.uuid4()}/messages")
+    assert resp.status_code == 401
+
+
+# --- 방향① pin — 에스컬 여부 무관 전 대화 항시 열람(선생님 13:45 확定) --------------------
+
+
+async def test_list_conversations_includes_non_escalated_conversation(client, fake_llm, monkeypatch):
+    """핵심 pin — 에스컬레이트된 적 없는(=SupportEscalation 행이 0인) 대화도 목록에 뜬다.
+    구 설계안(방향②, 에스컬만 노출)이 부활하면 이 테스트가 즉시 깨진다."""
+    monkeypatch.setattr(settings, "admin_token", "the-real-admin-token")
+    fake_llm.classify_text = "inquiry"  # 에스컬 트리거 없음
+    exchange = await _post_message(client, OTHER_ORG_ID, content="평범한 문의(에스컬 아님)")
+    conversation_id = exchange["customer_message"]["conversation_id"]
+
+    resp = await client.get(
+        "/api/v1/admin/conversations", headers={"Authorization": "Bearer the-real-admin-token"}
+    )
+    assert resp.status_code == 200
+    ids = [c["id"] for c in resp.json()["conversations"]]
+    assert conversation_id in ids
+
+
+async def test_list_conversations_spans_all_orgs_when_org_id_omitted(client, fake_llm, monkeypatch):
+    """org_id 생략 시 전 org 대상(어드민 콘솔의 "전 org 관제" 요건 — 방향① 재확認)."""
+    monkeypatch.setattr(settings, "admin_token", "the-real-admin-token")
+    fake_llm.classify_text = "inquiry"
+    a = await _post_message(client, OTHER_ORG_ID, content="org A 문의")
+    b = await _post_message(client, MOONKLABS_ORG_ID, content="org B(moonklabs) 문의")
+
+    resp = await client.get(
+        "/api/v1/admin/conversations", headers={"Authorization": "Bearer the-real-admin-token"}
+    )
+    ids = {c["id"] for c in resp.json()["conversations"]}
+    assert a["customer_message"]["conversation_id"] in ids
+    assert b["customer_message"]["conversation_id"] in ids
+
+
+async def test_list_conversations_org_id_filters(client, fake_llm, monkeypatch):
+    monkeypatch.setattr(settings, "admin_token", "the-real-admin-token")
+    fake_llm.classify_text = "inquiry"
+    await _post_message(client, OTHER_ORG_ID, content="org A 문의")
+    await _post_message(client, MOONKLABS_ORG_ID, content="org B(moonklabs) 문의")
+
+    resp = await client.get(
+        "/api/v1/admin/conversations",
+        params={"org_id": str(OTHER_ORG_ID)},
+        headers={"Authorization": "Bearer the-real-admin-token"},
+    )
+    orgs = {c["org_id"] for c in resp.json()["conversations"]}
+    assert orgs == {str(OTHER_ORG_ID)}
+
+
+async def test_list_conversations_exposes_escalation_ids_for_gate_crossref(client, fake_llm, monkeypatch):
+    """escalation_ids는 status 문자열이 아니다(SupportEscalation.status 영구 'open' 결함,
+    story 183fe7a5) — id만 실어 internal-api가 Gate.neutral_facts.support_escalation_id로
+    역참조할 수 있게 한다(설계 doc §3/§4)."""
+    monkeypatch.setattr(settings, "admin_token", "the-real-admin-token")
+    fake_llm.classify_text = "needs_human"
+    exchange = await _post_message(client, OTHER_ORG_ID, content="화가 났어요")
+    conversation_id = exchange["customer_message"]["conversation_id"]
+    assert exchange["escalated"] is True
+
+    resp = await client.get(
+        "/api/v1/admin/conversations", headers={"Authorization": "Bearer the-real-admin-token"}
+    )
+    row = next(c for c in resp.json()["conversations"] if c["id"] == conversation_id)
+    assert len(row["escalation_ids"]) == 1
+
+
+async def test_get_messages_returns_full_transcript_without_escalation_filter(client, fake_llm, monkeypatch):
+    """방향① pin(메시지 축) — 에스컬 안 된 대화의 원문도 그대로 반환한다. admin.py 모듈의
+    "원문 절대 반환 안 함" 원칙은 /metrics 전용이라 이 엔드포인트엔 적용 안 된다(PO 판정)."""
+    monkeypatch.setattr(settings, "admin_token", "the-real-admin-token")
+    fake_llm.classify_text = "inquiry"
+    marker = "매우-특이한-어드민-열람-마커-a7c1"
+    exchange = await _post_message(client, OTHER_ORG_ID, content=marker)
+    conversation_id = exchange["customer_message"]["conversation_id"]
+
+    resp = await client.get(
+        f"/api/v1/admin/conversations/{conversation_id}/messages",
+        headers={"Authorization": "Bearer the-real-admin-token"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["conversation_id"] == conversation_id
+    contents = [m["content"] for m in body["messages"]]
+    assert marker in contents  # 원문 그대로 — /metrics와 반대 원칙
+
+
+async def test_get_messages_unknown_conversation_id_404s(client, monkeypatch):
+    monkeypatch.setattr(settings, "admin_token", "the-real-admin-token")
+    resp = await client.get(
+        f"/api/v1/admin/conversations/{uuid.uuid4()}/messages",
+        headers={"Authorization": "Bearer the-real-admin-token"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_operator_identity_header_is_audit_only_not_authorization(client, fake_llm, monkeypatch):
+    """x_operator_identity 미전송(기본값 "unknown")이어도 require_admin만 통과하면 200 —
+    이 헤더는 인가 판단에 안 쓴다는 계약을 고정한다(모듈 docstring 참고)."""
+    monkeypatch.setattr(settings, "admin_token", "the-real-admin-token")
+    resp = await client.get(
+        "/api/v1/admin/conversations", headers={"Authorization": "Bearer the-real-admin-token"}
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
[SID:3282]

story: entity:story:18f01889-89e4-4165-b799-5b96c4c81310
design doc(확定판): entity:doc:e8aa483d-bff6-4d78-ac7f-dacc86d615f5

## 요약
설계 슬라이스 §6 구현 순서 1단계 — support-gateway `admin.py`에 어드민 콘솔 전용
신규 엔드포인트 2종 신설.

- `GET /api/v1/admin/conversations?org_id=` — 전 org(생략 시 전체) 지원 대화 목록.
  방향① 확定(선생님 13:45)에 따라 **에스컬 여부와 무관하게 항시 열람** — 에스컬만
  노출하던 구 설계안(방향②)은 PO 판정으로 기각됨.
- `GET /api/v1/admin/conversations/{id}/messages` — 원문 전체 반환. `admin.py` 모듈의
  "원문 절대 반환 안 함" 원칙은 `/metrics`(계측 API) 전용이고, 이 엔드포인트군은
  운영자가 문의를 읽는 게 업무인 별개 신뢰 표면이라 그 원칙이 적용되지 않는다는 게
  PO 판정(설계 doc §2-b) — 두 라우터 docstring에 그대로 명시.

## 감사·인가
- 인증은 기존 `require_admin`(정적 토큰) 그대로 재사용 — 새 인가 경계를 만들지 않음.
- `x_operator_identity` 헤더는 internal-api가 실을 "호출한 운영자 신원"이지만 **인가
  판단에는 안 쓴다** — 로그 문자열로만 소비(durable 감사 로그는 internal-api 쪽 책임,
  설계 doc §5 — gateway는 fleet 자격을 새로 안 받는다).
- `escalation_ids`만 실음(상태 문자열 아님) — `SupportEscalation.status` 영구 `'open'`
  결함(story 183fe7a5-08cd-4a75-88f6-8c386ff23bd9, 분리 등재)을 우회. 어드민 콘솔의
  "에스컬 상태"는 후속 PR(internal-api)에서 `Gate.status` 기준으로 계산.

## 검증
- 신규 테스트 9건(`tests/test_admin_conversations.py`) — 인증 재사용 2건, 방향① pin
  3건(비에스컬 대화 노출·전 org 스팬·org 필터), escalation_ids 역참조 1건, 원문
  무필터 반환 1건, 404 1건, operator_identity 비인가성 1건.
- 방향① pin은 뮤테이션 테스트로 검증 — `list_conversations`를 escalation-only join으로
  일부러 되돌려 관련 3개 테스트가 정확히 RED로 떨어지는 것 확인 후 원복.
- 로컬 전체 스위트 169/169 통과(회귀 없음).

## 다음 PR
internal-api HTTP 클라이언트 + 열람 감사 로그(설계 doc §5, §6 2단계) — 착수 전 internal-api
기존 audit 패턴 재사용 여부 1차 그라운딩 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)