### PR TITLE
[SID:3279] gateway 마이그 0004 — ck_support_messages_role에 'operator' 편입(핫픽스)

### DIFF
--- a/support-gateway/alembic/versions/0004_operator_role_check_widen.py
+++ b/support-gateway/alembic/versions/0004_operator_role_check_widen.py
@@ -1,0 +1,39 @@
+"""story #3279(지원v1·후속) 핫픽스 — ck_support_messages_role에 'operator' 편입.
+
+⚠️2026-09-01 페드루 PO 라이브 실왕복 실측 발견 — PR#3672(gateway 측 운영자 회신 착지점,
+app/routers/operator_replies.py)가 `SupportMessage(role="operator", ...)`를 INSERT하도록
+모델·라우터 코드는 넓혔지만, 0001에서 만든 DB CHECK 제약(`role IN ('customer', 'agent',
+'system')`)은 그대로 뒀다 — 실 PG에서 'operator' INSERT가 500(check violation)으로 죽는다.
+gateway 테스트 스위트는 항상 sqlite 인메모리(tests/conftest.py `_configure_settings`)라
+PG 전용 CHECK 제약 위반을 구조적으로 못 잡는다(sqlite는 이 제약 자체를 안 검사) — 이번
+실사고의 근인 층. 재발 방지(별도 systemic 등재)는 PO 담당, 이 마이그레이션은 그 증상의
+직접 원인만 닫는다.
+
+Postgres는 CHECK 제약을 직접 ALTER 못 한다 — drop 후 새 정의로 재생성.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-09-01
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("ck_support_messages_role", "support_messages", type_="check")
+    op.create_check_constraint(
+        "ck_support_messages_role", "support_messages", "role IN ('customer', 'agent', 'system', 'operator')"
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_support_messages_role", "support_messages", type_="check")
+    op.create_check_constraint(
+        "ck_support_messages_role", "support_messages", "role IN ('customer', 'agent', 'system')"
+    )

--- a/support-gateway/app/models.py
+++ b/support-gateway/app/models.py
@@ -82,7 +82,10 @@ class SupportMessage(Base):
         UUID(as_uuid=True), ForeignKey("support_conversations.id"), nullable=False, index=True
     )
     org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
-    role: Mapped[str] = mapped_column(Text, nullable=False)  # 'customer' | 'agent' | 'system'
+    # story #3279 핫픽스(2026-09-01, 마이그 0004) — 'operator' 편입 전엔 DB CHECK 제약이
+    # 이 role을 몰라 실 PG에서 500이었다(app/routers/operator_replies.py가 이미 쓰고
+    # 있었음에도). 이 주석과 alembic/versions/0004의 CHECK을 항상 같이 갱신할 것.
+    role: Mapped[str] = mapped_column(Text, nullable=False)  # 'customer' | 'agent' | 'system' | 'operator'
     content: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 


### PR DESCRIPTION
[SID:3279]

story: entity:story:1016b5c0-2a0d-4951-9919-4d1f434700ff (운영자 회신 표면 부재)

## 급행 사유
2026-09-01 페드루 PO의 라이브 실왕복(선생님 실 에스컬 카드에 스레드 답신)에서 실 결함
발견: backend 훅은 정상 발화·권한 통과까지 갔으나 **gateway가 500**을 반환.

## 근본원인
- PR#3672(gateway 측 운영자 회신 착지점, `app/routers/operator_replies.py`)가
  `SupportMessage(role="operator", ...)`를 INSERT하도록 모델·라우터 코드는 넓혔음.
- 하지만 `alembic/versions/0001`이 만든 DB CHECK 제약(`ck_support_messages_role`,
  `role IN ('customer', 'agent', 'system')`)은 그대로 방치 — 실 PG에서 'operator'
  INSERT가 check violation(500)으로 죽음.
- gateway 테스트 스위트는 항상 sqlite 인메모리(`tests/conftest.py`)라 PG 전용 CHECK
  제약 위반을 구조적으로 못 잡는다 — 이번 실사고의 근인 층(재발 방지 systemic 등재는
  페드루 PO 별도 담당).

## 변경
- `alembic/versions/0004_operator_role_check_widen.py` — `ck_support_messages_role`
  drop 후 `'operator'` 포함해 재생성(Postgres는 CHECK 직접 ALTER 불가). 다운그레이드는
  원 3값으로 복귀.
- `app/models.py` — `role` 컬럼 주석에 `'operator'` 추가, "이 주석과 0004의 CHECK을
  항상 같이 갱신할 것" 코멘트 첨부(코드-제약 drift 재발 방지).

## 검증
- **실 로컬 Postgres(brew postgresql@16)로 양방향 실측**(mock 아님):
  1. `alembic upgrade head` → `role='operator'` INSERT 성공.
  2. `alembic downgrade -1` → 같은 INSERT가 `check constraint "ck_support_messages_role"`
     위반으로 정확히 거부됨(에러 메시지 확인).
  3. 재-upgrade로 원복.
- sqlite 스위트 164/164 통과(회귀 없음) — 단, 위 실측이 보여주듯 이 스위트 자체는 이
  결함 계열을 잡을 수 없다는 게 근인이므로 실 PG 검증이 실질적 증거.
- dev 배포는 수동 마이그 실행 컨벤션(`feedback_migration_run_manual`) — 머지 후 dev
  마이그 수동 실행 필요(페드루 PO 재발신·재실측용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)