### PR TITLE
[SID:3284] SupportEscalation resolved 전환 콜백 동기화 — 게이트 해소→gateway 상태 반영

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -98,6 +98,13 @@ class Settings(BaseSettings):
     # 정직하게 skip한다(app/services/operator_reply_delivery.py).
     support_gateway_operator_reply_url: str = ""
 
+    # story #183fe7a5(지원v1·후속) — 게이트 해소(approve/reject) → gateway
+    # SupportEscalation.status 동기화(콜백, backend→support-gateway, operator_reply_url과
+    # 같은 방향·다른 aud). support-gateway/app/routers/escalation_resolution.py의 절대 URL.
+    # 미설정 시 동기화를 정직하게 skip(app/services/escalation_resolution_delivery.py) — 이
+    # 자체가 approve/reject 자체를 막지 않는다(best-effort, AC3).
+    support_gateway_escalation_resolution_url: str = ""
+
     # story #3263(지원v1·5에스컬레이션) — 트랜잭셔널 메일의 "즉시 고객센터로 문의" 문구가
     # 실재하지 않는 표면(고객센터)을 가리키던 fiction 정정. 위젯(story #3260)이 dev에만 떠
     # 있고 prod는 아직 미노출(NEXT_PUBLIC_SUPPORT_WIDGET_ENABLED)이라, 메일 카피가 위젯

--- a/backend/app/services/escalation_resolution_delivery.py
+++ b/backend/app/services/escalation_resolution_delivery.py
@@ -1,0 +1,109 @@
+"""story #183fe7a5(지원v1·후속) — 게이트 해소(approve/reject) → gateway
+SupportEscalation.status 동기화. support-gateway/app/escalation_delivery.py(gateway→backend,
+게이트 생성 방향)의 반대 방향 — operator_reply_delivery.py(backend→gateway, 운영자 회신)와
+같은 SUPPORT_GATEWAY_TOKEN_SECRET을 aud="support-gateway:escalation-resolution"으로 서명한다
+(gateway 쪽 검증: support-gateway/app/token_verify.py::verify_escalation_resolution_token).
+
+트리거: gate_service.py::transition_gate()가 work_item_type=="support_escalation" 게이트를
+approved|rejected로 전이시킬 때마다 이 배달을 부른다(background task 아님 — 커밋 前 호출이지만,
+이 함수 자체가 실패를 삼켜 approve/reject 자체를 절대 안 깨뜨린다, AC3).
+
+⚠️설계 결정(디디, 2026-09-01) — reject 의미론(AC2): approve와 reject **둘 다** gateway에
+resolved=True(gateway 쪽 상태값은 'resolved' 하나뿐)로 동기화한다. 근거: 위젯 배너("담당자에게
+전달되었습니다")가 전달하는 사실은 "사람이 이 문의를 처리 대상으로 받아 갔는가"이지 "그 사람이
+어떤 판정을 내렸는가"가 아니다 — Gate FSM에서 approved/rejected는 둘 다 **종결 상태**(재상신
+없이는 pending으로 안 돌아옴)이므로, reject만 미동기화로 남기면 이 스토리가 고치려는 버그
+(«게이트만 닫히고 배너는 영구 고정»)가 reject 경로에서 똑같이 재발한다. resolution(실제
+approved|rejected 값)은 그대로 실어 보내 gateway가 필요하면 세분화할 수 있게 열어둔다(현재
+gateway 응답 스키마는 그 필드를 안 쓴다 — 정직하게 안 쓰는 것뿐, 못 보내는 게 아니다)."""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import httpx
+from jose import jwt as jose_jwt
+
+from app.core.config import settings
+from app.models.gate import Gate
+
+logger = logging.getLogger(__name__)
+
+# gateway 쪽(support-gateway/app/token_verify.py::ESCALATION_RESOLUTION_AUD)과 문자열이 정확히
+# 같아야 한다 — 프로세스가 분리돼 있어 상수 공유 불가, 값만 계약으로 고정.
+ESCALATION_RESOLUTION_AUD = "support-gateway:escalation-resolution"
+_DELIVERY_TOKEN_TTL_SECONDS = 60
+
+
+async def deliver_escalation_resolution_for_gate(*, gate: Gate, new_status: str) -> bool:
+    """gate.neutral_facts에서 support_escalation_id를 역참조해 배달한다. 호출부
+    (gate_service.py::transition_gate)가 이미 검증·전이 완료한 Gate 객체를 그대로 넘긴다 —
+    이 함수는 그 신뢰를 재검증하지 않는다(operator_reply_delivery.py와 달리, 여기는 사용자
+    입력이 아니라 이미 커밋 경로 안의 신뢰된 호출)."""
+    if gate.work_item_type != "support_escalation":
+        logger.warning(
+            "escalation resolution sync skip — gate_id=%s not a support_escalation gate", gate.id
+        )
+        return False
+
+    escalation_id_raw = (gate.neutral_facts or {}).get("support_escalation_id")
+    if not escalation_id_raw:
+        logger.warning(
+            "escalation resolution sync skip — gate_id=%s missing support_escalation_id in neutral_facts",
+            gate.id,
+        )
+        return False
+    try:
+        escalation_id = uuid.UUID(str(escalation_id_raw))
+    except ValueError:
+        logger.warning(
+            "escalation resolution sync skip — gate_id=%s malformed support_escalation_id=%r",
+            gate.id, escalation_id_raw,
+        )
+        return False
+
+    return await deliver_escalation_resolution(escalation_id=escalation_id, resolution=new_status)
+
+
+async def deliver_escalation_resolution(*, escalation_id: uuid.UUID, resolution: str) -> bool:
+    """반환값은 순수 관측용(테스트 편의) — 실패해도 예외를 밖으로 던지지 않는다(위
+    docstring 참고). True=gateway가 2xx로 접수, False=미설정·네트워크 실패·비2xx 전부 포함."""
+    if not settings.support_gateway_token_secret:
+        logger.warning(
+            "escalation resolution sync skip — SUPPORT_GATEWAY_TOKEN_SECRET not configured escalation_id=%s",
+            escalation_id,
+        )
+        return False
+    if not settings.support_gateway_escalation_resolution_url:
+        logger.warning(
+            "escalation resolution sync skip — support_gateway_escalation_resolution_url not configured "
+            "escalation_id=%s",
+            escalation_id,
+        )
+        return False
+
+    now = datetime.now(timezone.utc)
+    claims = {
+        "aud": ESCALATION_RESOLUTION_AUD,
+        "escalation_id": str(escalation_id),
+        "resolution": resolution,
+        "exp": now + timedelta(seconds=_DELIVERY_TOKEN_TTL_SECONDS),
+        "iat": now,
+    }
+    try:
+        token = jose_jwt.encode(claims, settings.support_gateway_token_secret, algorithm="HS256")
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                settings.support_gateway_escalation_resolution_url,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            resp.raise_for_status()
+    except Exception:
+        logger.exception(
+            "escalation resolution sync POST failed escalation_id=%s resolution=%s "
+            "(swallowed — 위젯 배너는 다음 성공한 동기화까지 정체될 뿐, 데이터 유실 아님)",
+            escalation_id, resolution,
+        )
+        return False
+    return True

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -859,6 +859,22 @@ async def transition_gate(
         except Exception:  # noqa: BLE001 — best-effort, 실시간 반영 실패가 게이트 해소를 막지 않음.
             logger.warning("gate_resolved 카드 실시간 반영 배선 실패 gate=%s", gate.id, exc_info=True)
 
+        # story #183fe7a5(지원v1·후속) — support_escalation 게이트 해소를 gateway
+        # SupportEscalation.status에 동기화(콜백, AC1/AC2). approve/reject 둘 다 gateway
+        # 쪽엔 'resolved'로 도착한다(escalation_resolution_delivery.py 모듈 docstring의
+        # reject 의미론 판단 참고) — best-effort(AC3, 위 카드 알림과 동일 관례).
+        if gate.work_item_type == "support_escalation":
+            try:
+                from app.services.escalation_resolution_delivery import (
+                    deliver_escalation_resolution_for_gate,
+                )
+                await deliver_escalation_resolution_for_gate(gate=gate, new_status=new_status)
+            except Exception:  # noqa: BLE001 — best-effort, 동기화 실패가 게이트 해소를 막지 않음.
+                logger.warning(
+                    "escalation resolution sync 배선 실패 gate=%s status=%s", gate.id, new_status,
+                    exc_info=True,
+                )
+
     # story #1715(PO 판정 2026-08-24) — 상신자(requested_by_member_id) 회신은 gate_type/
     # line-bound 분기와 무관하게 **이 한 자리에서만** 부른다(아래 if/else 갈리기 전) — 두
     # 경로 양쪽에 각자 호출을 심으면 "구조적으로 배타적"이라는 주장이 코드 두 곳의 일치에

--- a/backend/tests/test_183fe7a5_escalation_resolution.py
+++ b/backend/tests/test_183fe7a5_escalation_resolution.py
@@ -1,0 +1,211 @@
+"""story #183fe7a5(지원v1·후속) — 게이트 해소(approve/reject) → gateway
+SupportEscalation.status 동기화. 두 층:
+①`deliver_escalation_resolution_for_gate` — 순수 Gate 객체 역참조(DB 조회 없음 — 호출부
+  gate_service.py가 이미 검증된 Gate를 넘긴다, operator_reply_delivery.py와의 설계 차이는
+  모듈 docstring 참고).
+②`deliver_escalation_resolution` — httpx mock(story #3279 test_3279_operator_reply.py와
+  동형 관례, `patch("httpx.AsyncClient.post", ...)`)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.gate import Gate
+
+# --- ① deliver_escalation_resolution_for_gate — Gate 역참조(DB 0) ------------------------
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _gate(*, work_item_type="support_escalation", escalation_id: uuid.UUID | None = None) -> Gate:
+    gate_id = uuid.uuid4()
+    neutral_facts = {"support_escalation_id": str(escalation_id)} if escalation_id is not None else {}
+    return Gate(
+        id=gate_id, org_id=uuid.uuid4(), work_item_id=gate_id,
+        work_item_type=work_item_type, gate_type="support_escalation_review",
+        status="approved", neutral_facts=neutral_facts,
+    )
+
+
+@pytest.mark.anyio
+async def test_delegates_with_resolved_escalation_id(monkeypatch):
+    from app.services import escalation_resolution_delivery as mod
+
+    escalation_id = uuid.uuid4()
+    gate = _gate(escalation_id=escalation_id)
+    delegate = AsyncMock(return_value=True)
+    monkeypatch.setattr(mod, "deliver_escalation_resolution", delegate)
+
+    result = await mod.deliver_escalation_resolution_for_gate(gate=gate, new_status="approved")
+
+    assert result is True
+    delegate.assert_awaited_once_with(escalation_id=escalation_id, resolution="approved")
+
+
+@pytest.mark.anyio
+async def test_reject_also_delegates_pin(monkeypatch):
+    """⭐AC2 pin — reject도 approve와 동일하게 배달한다(모듈 docstring 설계 결정: gateway
+    쪽 상태는 둘 다 'resolved'). resolution 값 자체는 실제 'rejected'를 정직하게 실어
+    보낸다(gateway가 세분화하고 싶어지면 못 하게 막지 않는다)."""
+    from app.services import escalation_resolution_delivery as mod
+
+    escalation_id = uuid.uuid4()
+    gate = _gate(escalation_id=escalation_id)
+    delegate = AsyncMock(return_value=True)
+    monkeypatch.setattr(mod, "deliver_escalation_resolution", delegate)
+
+    result = await mod.deliver_escalation_resolution_for_gate(gate=gate, new_status="rejected")
+
+    assert result is True
+    delegate.assert_awaited_once_with(escalation_id=escalation_id, resolution="rejected")
+
+
+@pytest.mark.anyio
+async def test_non_support_escalation_gate_skips(monkeypatch):
+    """오배달 방지 pin — work_item_type이 다르면(예: doc 결재) gate_id가 우연히 맞아도
+    절대 배달하면 안 된다."""
+    from app.services import escalation_resolution_delivery as mod
+
+    gate = _gate(work_item_type="doc", escalation_id=uuid.uuid4())
+    delegate = AsyncMock(return_value=True)
+    monkeypatch.setattr(mod, "deliver_escalation_resolution", delegate)
+
+    result = await mod.deliver_escalation_resolution_for_gate(gate=gate, new_status="approved")
+
+    assert result is False
+    delegate.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_missing_escalation_id_skips(monkeypatch):
+    from app.services import escalation_resolution_delivery as mod
+
+    gate = _gate(escalation_id=None)
+    delegate = AsyncMock(return_value=True)
+    monkeypatch.setattr(mod, "deliver_escalation_resolution", delegate)
+
+    result = await mod.deliver_escalation_resolution_for_gate(gate=gate, new_status="approved")
+
+    assert result is False
+    delegate.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_malformed_escalation_id_skips(monkeypatch):
+    from app.services import escalation_resolution_delivery as mod
+
+    gate_id = uuid.uuid4()
+    gate = Gate(
+        id=gate_id, org_id=uuid.uuid4(), work_item_id=gate_id,
+        work_item_type="support_escalation", gate_type="support_escalation_review",
+        status="approved", neutral_facts={"support_escalation_id": "not-a-uuid"},
+    )
+    delegate = AsyncMock(return_value=True)
+    monkeypatch.setattr(mod, "deliver_escalation_resolution", delegate)
+
+    result = await mod.deliver_escalation_resolution_for_gate(gate=gate, new_status="approved")
+
+    assert result is False
+    delegate.assert_not_awaited()
+
+
+# --- ② deliver_escalation_resolution — httpx mock ------------------------------------------
+
+
+def _resp(status_code: int):
+    class R:
+        def raise_for_status(self):
+            if status_code >= 400:
+                import httpx
+                raise httpx.HTTPStatusError("boom", request=None, response=self)  # type: ignore[arg-type]
+    r = R()
+    r.status_code = status_code
+    return r
+
+
+@pytest.mark.anyio
+async def test_deliver_escalation_resolution_success(monkeypatch):
+    from app.core.config import settings
+    from app.services.escalation_resolution_delivery import ESCALATION_RESOLUTION_AUD, deliver_escalation_resolution
+
+    monkeypatch.setattr(settings, "support_gateway_token_secret", "test-secret-padded-to-32-bytes-min")
+    monkeypatch.setattr(
+        settings, "support_gateway_escalation_resolution_url",
+        "https://gateway.example/api/v1/internal/escalation-resolution",
+    )
+
+    captured = {}
+
+    async def _post(self, url, headers=None, **kwargs):
+        captured["url"] = url
+        captured["headers"] = headers
+        return _resp(200)
+
+    escalation_id = uuid.uuid4()
+    with patch("httpx.AsyncClient.post", new=_post):
+        ok = await deliver_escalation_resolution(escalation_id=escalation_id, resolution="approved")
+
+    assert ok is True
+    assert captured["url"] == "https://gateway.example/api/v1/internal/escalation-resolution"
+
+    from jose import jwt as jose_jwt
+    claims = jose_jwt.get_unverified_claims(captured["headers"]["Authorization"].removeprefix("Bearer "))
+    assert claims["aud"] == ESCALATION_RESOLUTION_AUD
+    assert claims["escalation_id"] == str(escalation_id)
+    assert claims["resolution"] == "approved"
+
+
+@pytest.mark.anyio
+async def test_deliver_escalation_resolution_5xx_returns_false_not_raises(monkeypatch):
+    from app.core.config import settings
+    from app.services.escalation_resolution_delivery import deliver_escalation_resolution
+
+    monkeypatch.setattr(settings, "support_gateway_token_secret", "test-secret-padded-to-32-bytes-min")
+    monkeypatch.setattr(settings, "support_gateway_escalation_resolution_url", "https://gateway.example/x")
+
+    with patch("httpx.AsyncClient.post", new=AsyncMock(return_value=_resp(500))):
+        ok = await deliver_escalation_resolution(escalation_id=uuid.uuid4(), resolution="approved")
+    assert ok is False
+
+
+@pytest.mark.anyio
+async def test_deliver_escalation_resolution_network_error_returns_false_not_raises(monkeypatch):
+    from app.core.config import settings
+    from app.services.escalation_resolution_delivery import deliver_escalation_resolution
+
+    monkeypatch.setattr(settings, "support_gateway_token_secret", "test-secret-padded-to-32-bytes-min")
+    monkeypatch.setattr(settings, "support_gateway_escalation_resolution_url", "https://gateway.example/x")
+
+    async def _post(self, url, headers=None, **kwargs):
+        raise ConnectionError("network down")
+
+    with patch("httpx.AsyncClient.post", new=_post):
+        ok = await deliver_escalation_resolution(escalation_id=uuid.uuid4(), resolution="rejected")
+    assert ok is False
+
+
+@pytest.mark.anyio
+async def test_deliver_escalation_resolution_skips_when_secret_unconfigured(monkeypatch):
+    from app.core.config import settings
+    from app.services.escalation_resolution_delivery import deliver_escalation_resolution
+
+    monkeypatch.setattr(settings, "support_gateway_token_secret", "")
+    monkeypatch.setattr(settings, "support_gateway_escalation_resolution_url", "https://gateway.example/x")
+    ok = await deliver_escalation_resolution(escalation_id=uuid.uuid4(), resolution="approved")
+    assert ok is False
+
+
+@pytest.mark.anyio
+async def test_deliver_escalation_resolution_skips_when_url_unconfigured(monkeypatch):
+    from app.core.config import settings
+    from app.services.escalation_resolution_delivery import deliver_escalation_resolution
+
+    monkeypatch.setattr(settings, "support_gateway_token_secret", "test-secret-padded-to-32-bytes-min")
+    monkeypatch.setattr(settings, "support_gateway_escalation_resolution_url", "")
+    ok = await deliver_escalation_resolution(escalation_id=uuid.uuid4(), resolution="approved")
+    assert ok is False

--- a/backend/tests/test_183fe7a5_gate_service_wiring.py
+++ b/backend/tests/test_183fe7a5_gate_service_wiring.py
@@ -1,0 +1,124 @@
+"""story #183fe7a5(지원v1·후속) — gate_service.py::transition_gate()가 support_escalation
+게이트를 approve/reject할 때마다 escalation_resolution_delivery를 실제로 부르는지(배선
+자체)를 겨냥한다. AsyncMock 세션 패턴은 tests/test_e_cage_referee_p3_gate_object.py의
+test_transition_valid_pending_to_approved와 동형(session 전체를 AsyncMock으로 흉내 —
+transition_gate 내부 다른 부작용 호출들은 이미 그 파일에서 이 패턴으로 검증돼 안전이
+확인됨, 배달 함수만 monkeypatch로 관측)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+GATE_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _mock_session_for_gate(gate):
+    session = AsyncMock()
+    gate_r = MagicMock()
+    gate_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=gate_r)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    return session
+
+
+def _support_escalation_gate(*, escalation_id: uuid.UUID) -> MagicMock:
+    gate = MagicMock()
+    gate.id = GATE_ID
+    gate.org_id = ORG_ID
+    gate.status = "pending"
+    gate.work_item_type = "support_escalation"
+    gate.neutral_facts = {"support_escalation_id": str(escalation_id)}
+    return gate
+
+
+@pytest.mark.anyio
+async def test_approve_triggers_escalation_resolution_delivery():
+    from app.services.gate_service import transition_gate
+
+    escalation_id = uuid.uuid4()
+    gate = _support_escalation_gate(escalation_id=escalation_id)
+    session = _mock_session_for_gate(gate)
+
+    with patch(
+        "app.services.escalation_resolution_delivery.deliver_escalation_resolution_for_gate",
+        new_callable=AsyncMock,
+    ) as delegate:
+        await transition_gate(session, ORG_ID, GATE_ID, "approved", MEMBER_ID)
+
+    delegate.assert_awaited_once()
+    _, kwargs = delegate.call_args
+    assert kwargs["gate"] is gate
+    assert kwargs["new_status"] == "approved"
+
+
+@pytest.mark.anyio
+async def test_reject_also_triggers_escalation_resolution_delivery():
+    """⭐AC2 pin — reject도 approve와 동일하게 동기화 훅이 발화한다(위젯 배너 영구 고정
+    버그가 reject 경로에서 재발하지 않게)."""
+    from app.services.gate_service import transition_gate
+
+    escalation_id = uuid.uuid4()
+    gate = _support_escalation_gate(escalation_id=escalation_id)
+    session = _mock_session_for_gate(gate)
+
+    with patch(
+        "app.services.escalation_resolution_delivery.deliver_escalation_resolution_for_gate",
+        new_callable=AsyncMock,
+    ) as delegate:
+        await transition_gate(session, ORG_ID, GATE_ID, "rejected", MEMBER_ID)
+
+    delegate.assert_awaited_once()
+    _, kwargs = delegate.call_args
+    assert kwargs["new_status"] == "rejected"
+
+
+@pytest.mark.anyio
+async def test_non_support_escalation_gate_does_not_trigger_delivery():
+    """오배선 방지 pin — 다른 gate_type(예: story merge 게이트) approve는 이 새 훅을 절대
+    안 태운다(work_item_type 분기가 정확히 지켜지는지)."""
+    from app.services.gate_service import transition_gate
+
+    gate = MagicMock()
+    gate.id = GATE_ID
+    gate.org_id = ORG_ID
+    gate.status = "pending"
+    gate.work_item_type = "story"
+    session = _mock_session_for_gate(gate)
+
+    with patch(
+        "app.services.escalation_resolution_delivery.deliver_escalation_resolution_for_gate",
+        new_callable=AsyncMock,
+    ) as delegate:
+        await transition_gate(session, ORG_ID, GATE_ID, "approved", MEMBER_ID)
+
+    delegate.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_delivery_failure_does_not_break_the_transition():
+    """AC3 pin — 동기화 배달이 예외를 던져도 게이트 전이(approve) 자체는 성공한다
+    (gate_service.py의 기존 try/except 관례, notify_gate_card_recipients_resolved와 동형)."""
+    from app.services.gate_service import transition_gate
+
+    escalation_id = uuid.uuid4()
+    gate = _support_escalation_gate(escalation_id=escalation_id)
+    session = _mock_session_for_gate(gate)
+
+    with patch(
+        "app.services.escalation_resolution_delivery.deliver_escalation_resolution_for_gate",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("gateway unreachable"),
+    ):
+        result = await transition_gate(session, ORG_ID, GATE_ID, "approved", MEMBER_ID)
+
+    assert result.status == "approved"  # 전이 자체는 정상 완료 — 배달 실패가 안 깨뜨림.

--- a/backend/tests/test_check_env_drift_settings_coverage.py
+++ b/backend/tests/test_check_env_drift_settings_coverage.py
@@ -222,4 +222,8 @@ def test_settings_field_env_keys_works_without_pydantic_settings_importable(monk
     # substitution을 재사용해 배선, 시크릿은 이미 바인딩된 SUPPORT_GATEWAY_TOKEN_SECRET
     # 재사용이라 신규 시크릿 불요)로 114→115. 가드가 신규 필드를 설계대로 잡은 것.
     assert "SUPPORT_GATEWAY_OPERATOR_REPLY_URL" in keys
-    assert len(keys) == 115
+    # story #183fe7a5(지원v1·후속, 2026-09-01): support_gateway_escalation_resolution_url
+    # 1필드 신설(게이트 해소→gateway SupportEscalation.status 동기화 콜백 착지 URL —
+    # operator_reply_url과 동일 게이팅 원칙·같은 시크릿 재사용, aud만 분리)로 115→116.
+    assert "SUPPORT_GATEWAY_ESCALATION_RESOLUTION_URL" in keys
+    assert len(keys) == 116

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -490,6 +490,29 @@ def test_deploy_backend_prod_excludes_support_gateway_operator_reply_url_even_wh
     assert "SUPPORT_GATEWAY_OPERATOR_REPLY_URL" not in result
 
 
+def test_deploy_backend_includes_support_gateway_escalation_resolution_url_when_set():
+    """story #183fe7a5 — operator-reply URL과 같은 게이트(위 세 테스트와 동형 트리플릿)."""
+    result = _run_env_vars_assembly(
+        "dev", "redis://10.164.120.243:6379", support_gateway_url="https://support-gateway-dev.example.run.app"
+    )
+    assert (
+        "SUPPORT_GATEWAY_ESCALATION_RESOLUTION_URL="
+        "https://support-gateway-dev.example.run.app/api/v1/internal/escalation-resolution"
+    ) in result
+
+
+def test_deploy_backend_excludes_support_gateway_escalation_resolution_url_when_unset():
+    result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379", support_gateway_url="")
+    assert "SUPPORT_GATEWAY_ESCALATION_RESOLUTION_URL" not in result
+
+
+def test_deploy_backend_prod_excludes_support_gateway_escalation_resolution_url_even_when_set():
+    result = _run_env_vars_assembly(
+        "prod", "", support_gateway_url="https://support-gateway-dev.example.run.app"
+    )
+    assert "SUPPORT_GATEWAY_ESCALATION_RESOLUTION_URL" not in result
+
+
 def test_deploy_backend_dev_env_vars_unchanged_by_prod_branch():
     """dev 경로 무회귀 — prod 분기 추가가 dev의 다른 필드에 영향을 주지 않는다."""
     result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379")

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -747,6 +747,14 @@ steps:
         if [ "${_DEPLOY_ENV}" != "prod" ] && [ -n "${_NEXT_PUBLIC_SUPPORT_GATEWAY_URL}" ]; then
           ENV_VARS="$${ENV_VARS},SUPPORT_GATEWAY_OPERATOR_REPLY_URL=${_NEXT_PUBLIC_SUPPORT_GATEWAY_URL}/api/v1/internal/operator-replies"
         fi
+        # story #183fe7a5(지원v1·후속) — 게이트 해소(approve/reject)→gateway
+        # SupportEscalation.status 동기화 착지 URL. 위 operator-reply URL과 완전히 같은
+        # 게이팅 원칙(dev 전용, 빈 값이면 안 싣는다 — GOTENBERG_SERVICE_URL 선례 재사용)
+        # 재사용 — 같은 SUPPORT_GATEWAY_TOKEN_SECRET, aud만 다름(escalation_resolution_
+        # delivery.py 모듈 docstring 참고).
+        if [ "${_DEPLOY_ENV}" != "prod" ] && [ -n "${_NEXT_PUBLIC_SUPPORT_GATEWAY_URL}" ]; then
+          ENV_VARS="$${ENV_VARS},SUPPORT_GATEWAY_ESCALATION_RESOLUTION_URL=${_NEXT_PUBLIC_SUPPORT_GATEWAY_URL}/api/v1/internal/escalation-resolution"
+        fi
         # story #2445/#3110/#3118 — DATABASE_URL(PgBouncer, dev/prod 둘 다 sprintable 앱유저)·
         # DATABASE_URL_DIRECT(dev=sprintable 앱유저·prod=postgres 직결)·DATABASE_URL_READ(prod만)·
         # APPLE_PRIVATE_KEY 시크릿 바인딩. dev pgbouncer 경유분은 #3110 2보(userlist에 sprintable

--- a/support-gateway/app/main.py
+++ b/support-gateway/app/main.py
@@ -8,6 +8,7 @@ from slowapi.middleware import SlowAPIMiddleware
 from app.config import settings
 from app.rate_limit import limiter
 from app.routers.admin import router as admin_router
+from app.routers.escalation_resolution import router as escalation_resolution_router
 from app.routers.operator_replies import router as operator_replies_router
 from app.routers.sessions import router as sessions_router
 
@@ -39,6 +40,7 @@ app.add_middleware(
 app.include_router(sessions_router)
 app.include_router(admin_router)
 app.include_router(operator_replies_router)
+app.include_router(escalation_resolution_router)
 
 
 @app.get("/healthz")

--- a/support-gateway/app/routers/escalation_resolution.py
+++ b/support-gateway/app/routers/escalation_resolution.py
@@ -1,0 +1,45 @@
+"""story #183fe7a5(지원v1·후속) — 게이트 해소(approve/reject) 동기화 착지점. backend가
+gate_service.py::transition_gate()에서 SUPPORT_GATEWAY_TOKEN_SECRET을 aud="support-gateway:
+escalation-resolution"으로 서명해 배달한다(app/token_verify.py::
+require_escalation_resolution_claims — escalation_delivery.py의 반대 방향, operator_replies.py
+와 같은 방향·다른 aud).
+
+⚠️설계 결정(backend/app/services/escalation_resolution_delivery.py 모듈 docstring 그대로) —
+approve·reject 둘 다 여기선 status='resolved' 하나로 수렴한다(gateway 쪽 상태값이 애초에
+'open'|'resolved' 이분법뿐 — SupportEscalation.status 정의, app/models.py). resolution
+클레임 값(실제 'approved'|'rejected')은 받아서 로그에만 남긴다(현재 스키마가 세분화를 안
+씀 — 정직하게 안 쓰는 것뿐, 못 받는 게 아니다).
+
+fleet 자격 0 불변식 그대로 — org_id를 클레임에서 안 받는다(escalation_id 존재 자체가
+유일한 근거, operator_replies.py와 동일 원칙)."""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_db
+from app.models import SupportEscalation
+from app.token_verify import EscalationResolutionClaims, require_escalation_resolution_claims
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/internal", tags=["operator"])
+
+
+@router.post("/escalation-resolution", status_code=204)
+async def receive_escalation_resolution(
+    claims: EscalationResolutionClaims = Depends(require_escalation_resolution_claims),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    escalation = await db.get(SupportEscalation, claims.escalation_id)
+    if escalation is None:
+        raise HTTPException(status_code=404, detail="escalation not found")
+
+    escalation.status = "resolved"
+    await db.commit()
+    logger.info(
+        "escalation resolution synced escalation_id=%s resolution=%s status=resolved",
+        claims.escalation_id, claims.resolution,
+    )

--- a/support-gateway/app/token_verify.py
+++ b/support-gateway/app/token_verify.py
@@ -119,6 +119,60 @@ async def require_operator_reply_claims(authorization: str = Header(default=""))
         raise HTTPException(status_code=401, detail=f"invalid operator reply token: {exc}") from exc
 
 
+# story #183fe7a5(지원v1·후속) — 게이트 해소(approve/reject)→gateway SupportEscalation.status
+# 동기화 콜백(backend→gateway, escalation_delivery.py의 반대 방향 — OPERATOR_REPLY_AUD와
+# 같은 방향, 같은 대칭키, aud만 다름). backend/app/services/escalation_resolution_delivery.py
+# 발급 계약.
+ESCALATION_RESOLUTION_AUD = "support-gateway:escalation-resolution"
+
+
+class EscalationResolutionTokenError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class EscalationResolutionClaims:
+    escalation_id: uuid.UUID
+    resolution: str
+
+
+def verify_escalation_resolution_token(token: str) -> EscalationResolutionClaims:
+    if not settings.token_secret:
+        raise EscalationResolutionTokenError("SUPPORT_GATEWAY_TOKEN_SECRET not configured")
+    try:
+        # audience= 명시 — PyJWT가 이 시점에 이미 aud 부재/불일치 둘 다 거부(OPERATOR_REPLY_AUD
+        # 검증과 동일 실측 근거).
+        claims = jwt.decode(
+            token, settings.token_secret, algorithms=["HS256"], audience=ESCALATION_RESOLUTION_AUD
+        )
+    except jwt.PyJWTError as exc:
+        raise EscalationResolutionTokenError(str(exc)) from exc
+    # story #3661/#3279 선례 재사용(2026-09-01) — "라이브러리 기본 동작 하나에만 의존하지
+    # 않는다"는 확立된 관례대로 독립 2차 방어를 명시로 남긴다.
+    if claims.get("aud") != ESCALATION_RESOLUTION_AUD:
+        raise EscalationResolutionTokenError(f"missing or mismatched aud claim: {claims.get('aud')!r}")
+    try:
+        escalation_id = uuid.UUID(claims["escalation_id"])
+        resolution = str(claims["resolution"])
+    except (KeyError, ValueError) as exc:
+        raise EscalationResolutionTokenError(f"malformed claims: {exc}") from exc
+    if not resolution.strip():
+        raise EscalationResolutionTokenError("empty resolution")
+    return EscalationResolutionClaims(escalation_id=escalation_id, resolution=resolution)
+
+
+async def require_escalation_resolution_claims(
+    authorization: str = Header(default=""),
+) -> EscalationResolutionClaims:
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="missing bearer token")
+    token = authorization[len("Bearer "):]
+    try:
+        return verify_escalation_resolution_token(token)
+    except EscalationResolutionTokenError as exc:
+        raise HTTPException(status_code=401, detail=f"invalid escalation resolution token: {exc}") from exc
+
+
 async def require_admin(authorization: str = Header(default="")) -> None:
     """story #3264 AC3/AC4 — 어드민 계측 조회(app/routers/admin.py) 전용. 고객 위임 토큰과
     완전히 다른 신뢰 재료(settings.admin_token, 정적 비교) — org 클레임이 없으므로 이 경로는

--- a/support-gateway/tests/test_escalation_resolution.py
+++ b/support-gateway/tests/test_escalation_resolution.py
@@ -1,0 +1,130 @@
+"""story #183fe7a5(지원v1·후속) — 게이트 해소 동기화 착지점
+(POST /api/v1/internal/escalation-resolution) 엔드투엔드. test_operator_replies.py와 동형
+스캐폴딩 — 실 에스컬레이션(고객 턴→SupportEscalation 생성)을 먼저 만들고, 그 escalation_id로
+동기화 토큰을 보내 status가 'open'→'resolved'로 실제 바뀌는지 확認한다."""
+from __future__ import annotations
+
+import uuid
+
+import jwt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.models import SupportEscalation
+from app.token_verify import ESCALATION_RESOLUTION_AUD
+from tests.conftest import OTHER_ORG_ID, TEST_TOKEN_SECRET, make_token
+
+
+def _resolution_token(escalation_id: uuid.UUID, resolution: str, *, secret: str = TEST_TOKEN_SECRET) -> str:
+    return jwt.encode(
+        {"aud": ESCALATION_RESOLUTION_AUD, "escalation_id": str(escalation_id), "resolution": resolution},
+        secret,
+        algorithm="HS256",
+    )
+
+
+async def _create_escalation(client, fake_llm, db_engine) -> uuid.UUID:
+    fake_llm.classify_text = "needs_human"
+    headers = {"Authorization": f"Bearer {make_token(OTHER_ORG_ID)}"}
+    session = await client.post("/api/v1/sessions", headers=headers)
+    session_id = session.json()["id"]
+    resp = await client.post(
+        f"/api/v1/sessions/{session_id}/messages", json={"content": "사람 필요해요"}, headers=headers
+    )
+    conversation_id = uuid.UUID(resp.json()["customer_message"]["conversation_id"])
+
+    async with async_sessionmaker(db_engine, expire_on_commit=False)() as db_session:
+        escalation = (
+            await db_session.execute(
+                select(SupportEscalation).where(SupportEscalation.conversation_id == conversation_id)
+            )
+        ).scalars().one()
+        assert escalation.status == "open"  # 양성대조 — 착수 전 실제로 open인지 먼저 확認.
+        return escalation.id
+
+
+async def _escalation_status(db_engine, escalation_id: uuid.UUID) -> str:
+    async with async_sessionmaker(db_engine, expire_on_commit=False)() as db_session:
+        escalation = await db_session.get(SupportEscalation, escalation_id)
+        return escalation.status
+
+
+async def test_approve_resolution_marks_escalation_resolved(client, fake_llm, db_engine):
+    """⭐AC1 pin — 이 스토리의 핵심 계약. 착수 전엔 실측상 이 값이 절대 'resolved'가 될
+    방법이 없었다(코드 전수: status='resolved' 기록 자리 0건, 스토리 발견 사실)."""
+    escalation_id = await _create_escalation(client, fake_llm, db_engine)
+
+    token = _resolution_token(escalation_id, "approved")
+    resp = await client.post(
+        "/api/v1/internal/escalation-resolution", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 204, resp.text
+
+    assert await _escalation_status(db_engine, escalation_id) == "resolved"
+
+
+async def test_reject_resolution_also_marks_escalation_resolved(client, fake_llm, db_engine):
+    """⭐AC2 pin — reject도 approve와 동일하게 위젯 배너를 정리한다(설계 결정, 모듈
+    docstring 참고: 두 판정 다 "사람이 이 문의를 처리 대상으로 받아 갔다"는 동일 사실)."""
+    escalation_id = await _create_escalation(client, fake_llm, db_engine)
+
+    token = _resolution_token(escalation_id, "rejected")
+    resp = await client.post(
+        "/api/v1/internal/escalation-resolution", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 204, resp.text
+
+    assert await _escalation_status(db_engine, escalation_id) == "resolved"
+
+
+async def test_resolution_unknown_escalation_id_returns_404(client):
+    token = _resolution_token(uuid.uuid4(), "approved")
+    resp = await client.post(
+        "/api/v1/internal/escalation-resolution", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 404
+
+
+async def test_resolution_invalid_token_rejected(client):
+    resp = await client.post(
+        "/api/v1/internal/escalation-resolution", headers={"Authorization": "Bearer garbage"}
+    )
+    assert resp.status_code == 401
+
+
+async def test_resolution_wrong_secret_rejected(client):
+    token = _resolution_token(uuid.uuid4(), "approved", secret="not-the-real-secret-padded-32-bytes")
+    resp = await client.post(
+        "/api/v1/internal/escalation-resolution", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 401
+
+
+async def test_resolution_operator_reply_token_cross_kind_rejected(client):
+    """교차토큰 방어 — operator-reply용 토큰(aud 다름)을 이 엔드포인트에 보내면 401."""
+    from app.token_verify import OPERATOR_REPLY_AUD
+
+    token = jwt.encode(
+        {"aud": OPERATOR_REPLY_AUD, "escalation_id": str(uuid.uuid4()), "content": "wrong endpoint"},
+        TEST_TOKEN_SECRET,
+        algorithm="HS256",
+    )
+    resp = await client.post(
+        "/api/v1/internal/escalation-resolution", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 401
+
+
+async def test_resolution_is_idempotent_on_repeat_delivery(client, fake_llm, db_engine):
+    """재시도/중복 배달(operator_reply_delivery.py 계약의 "재시도" 여지와 동형) — 두 번
+    보내도 에러 없이 그대로 resolved 유지."""
+    escalation_id = await _create_escalation(client, fake_llm, db_engine)
+    token = _resolution_token(escalation_id, "approved")
+
+    for _ in range(2):
+        resp = await client.post(
+            "/api/v1/internal/escalation-resolution", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 204
+
+    assert await _escalation_status(db_engine, escalation_id) == "resolved"

--- a/support-gateway/tests/test_token_verify.py
+++ b/support-gateway/tests/test_token_verify.py
@@ -7,10 +7,13 @@ import pytest
 
 from app.config import settings
 from app.token_verify import (
+    ESCALATION_RESOLUTION_AUD,
     OPERATOR_REPLY_AUD,
     DelegatedTokenError,
+    EscalationResolutionTokenError,
     OperatorReplyTokenError,
     verify_delegated_token,
+    verify_escalation_resolution_token,
     verify_operator_reply_token,
 )
 from tests.conftest import TEST_TOKEN_SECRET
@@ -157,3 +160,88 @@ def test_operator_reply_token_unconfigured_secret_fails_closed(monkeypatch):
     )
     with pytest.raises(OperatorReplyTokenError):
         verify_operator_reply_token(token)
+
+
+# --- story #183fe7a5 — 에스컬레이션 해소 동기화 토큰(backend→gateway, escalation_delivery.py
+# 반대 방향, operator-reply와 같은 방향·다른 aud) -------------------------------------------
+
+
+def test_escalation_resolution_token_valid_roundtrip():
+    escalation_id = uuid.uuid4()
+    token = jwt.encode(
+        {"aud": ESCALATION_RESOLUTION_AUD, "escalation_id": str(escalation_id), "resolution": "approved"},
+        TEST_TOKEN_SECRET,
+        algorithm="HS256",
+    )
+    claims = verify_escalation_resolution_token(token)
+    assert claims.escalation_id == escalation_id
+    assert claims.resolution == "approved"
+
+
+def test_escalation_resolution_token_missing_aud_rejected():
+    token = jwt.encode(
+        {"escalation_id": str(uuid.uuid4()), "resolution": "approved"}, TEST_TOKEN_SECRET, algorithm="HS256"
+    )
+    with pytest.raises(EscalationResolutionTokenError):
+        verify_escalation_resolution_token(token)
+
+
+def test_escalation_resolution_token_wrong_aud_rejected():
+    """교차토큰 방어 — operator-reply aud가 실린 토큰을 이 검증기에 던지면 거부."""
+    token = jwt.encode(
+        {"aud": OPERATOR_REPLY_AUD, "escalation_id": str(uuid.uuid4()), "resolution": "approved"},
+        TEST_TOKEN_SECRET,
+        algorithm="HS256",
+    )
+    with pytest.raises(EscalationResolutionTokenError):
+        verify_escalation_resolution_token(token)
+
+
+def test_escalation_resolution_token_delegated_token_rejected_here_cross_kind_defense():
+    """위임 토큰(aud 없음)을 이 검증기에 잘못 던져도 거부돼야 한다."""
+    token = jwt.encode(
+        {"org_id": str(uuid.uuid4()), "user_id": str(uuid.uuid4())}, TEST_TOKEN_SECRET, algorithm="HS256"
+    )
+    with pytest.raises(EscalationResolutionTokenError):
+        verify_escalation_resolution_token(token)
+
+
+def test_operator_reply_token_rejected_by_escalation_resolution_verifier_cross_kind_defense():
+    """반대 방향 교차 — operator-reply 검증기가 이 토큰을 받아도 안 되고(위에서 확인),
+    이 검증기가 operator-reply 토큰을 받아도 안 된다(양방향 pin)."""
+    token = jwt.encode(
+        {"aud": ESCALATION_RESOLUTION_AUD, "escalation_id": str(uuid.uuid4()), "resolution": "rejected"},
+        TEST_TOKEN_SECRET,
+        algorithm="HS256",
+    )
+    with pytest.raises(OperatorReplyTokenError):
+        verify_operator_reply_token(token)
+
+
+def test_escalation_resolution_token_missing_resolution_rejected():
+    token = jwt.encode(
+        {"aud": ESCALATION_RESOLUTION_AUD, "escalation_id": str(uuid.uuid4())}, TEST_TOKEN_SECRET, algorithm="HS256"
+    )
+    with pytest.raises(EscalationResolutionTokenError):
+        verify_escalation_resolution_token(token)
+
+
+def test_escalation_resolution_token_empty_resolution_rejected():
+    token = jwt.encode(
+        {"aud": ESCALATION_RESOLUTION_AUD, "escalation_id": str(uuid.uuid4()), "resolution": "   "},
+        TEST_TOKEN_SECRET,
+        algorithm="HS256",
+    )
+    with pytest.raises(EscalationResolutionTokenError):
+        verify_escalation_resolution_token(token)
+
+
+def test_escalation_resolution_token_unconfigured_secret_fails_closed(monkeypatch):
+    monkeypatch.setattr(settings, "token_secret", "")
+    token = jwt.encode(
+        {"aud": ESCALATION_RESOLUTION_AUD, "escalation_id": str(uuid.uuid4()), "resolution": "approved"},
+        TEST_TOKEN_SECRET,
+        algorithm="HS256",
+    )
+    with pytest.raises(EscalationResolutionTokenError):
+        verify_escalation_resolution_token(token)


### PR DESCRIPTION
[SID:3284]

story: entity:story:183fe7a5-08cd-4a75-88f6-8c386ff23bd9
관련: #3279 사슬(entity:story:1016b5c0-2a0d-4951-9919-4d1f434700ff)의 미착지 조각
(설계 ③ "approve 시점에 resolved 전환"이 실측 확인 결과 구현에서 빠져 있었음).

## 결함
카드 approve는 backend Gate만 해소하고 gateway의 `SupportEscalation.status`는 영구
`'open'` — 고객 위젯 배너("담당자에게 전달되었습니다", story #3263 AC4)가 실제 해결
후에도 영구 표시된다(코드 전수 확인: `status='resolved'` 기록 자리 0건).

## 처방: (a) 콜백 동기화(스토리 권장안 채택)
`operator_reply_delivery.py`(#3279, backend→gateway)와 대칭 채널 — 같은
`SUPPORT_GATEWAY_TOKEN_SECRET`을 다른 `aud`로 재사용, escalation_id 키.

## 설계 결정 — AC2(reject 의미론, 스토리가 명시 요구)
**approve·reject 둘 다 gateway에 `resolved`로 동기화한다.** 근거(모듈 docstring에도
명시): 위젯 배너가 전달하는 사실은 "사람이 이 문의를 처리 대상으로 받아 갔는가"이지
판정 방향이 아니다. Gate FSM에서 `approved`/`rejected`는 둘 다 종결 상태라, reject만
미동기화로 두면 이 스토리가 고치려는 버그가 reject 경로에서 그대로 재발한다.
`resolution`(실제 approved|rejected) 값은 그대로 실어 보내 gateway가 필요하면 세분화
할 수 있게 열어둔다.

## 변경
**backend** — `gate_service.py::transition_gate()`에 `work_item_type=="support_escalation"`
분기 추가(기존 approve/reject 블록 안, `notify_gate_card_recipients_resolved`와 동일
try/except best-effort 관례 — AC3: 배달 실패가 게이트 해소 자체를 절대 안 깨뜨림).
신설 `services/escalation_resolution_delivery.py`는 이미 검증된 Gate 객체를 그대로
받는다(operator_reply_delivery.py와 달리 별도 DB 재조회 없음 — 호출부가 이미 커밋
경로 안의 신뢰된 호출). `SUPPORT_GATEWAY_ESCALATION_RESOLUTION_URL` 설정은 기존
`_NEXT_PUBLIC_SUPPORT_GATEWAY_URL` substitution 재사용(dev 전용 게이트, 신규 시크릿 0).

**support-gateway** — `token_verify.py`에 `ESCALATION_RESOLUTION_AUD` 검증기(operator-reply
와 동일한 PyJWT `audience=` 1차 + 명시 aud 2차 방어, story #3661 선례 재사용). 신설
`routers/escalation_resolution.py` — `POST /api/v1/internal/escalation-resolution`,
escalation_id로 조회 후 `status='resolved'` 기록(멱등, 재시도 안전).

**FE 변경 불요** — 위젯의 `_conversation_escalation_status()`(sessions.py, 기존 코드)가
이미 `SupportEscalation.status`를 읽고 있어, 이 수정만으로 재오픈 시 배너가 자동 소멸.

## 검증
- 뮤테이션 테스트 2건: transition_gate 훅 제거 → 배선 테스트 정확히 RED, gateway 라우터
  status 대입 제거 → AC1/AC2/멱등 테스트 3건 정확히 RED. 둘 다 원복 후 재확인.
- backend: 신규 14건 + 관련 기존 87건(gate_service·operator_reply·deploy 게이팅·env
  drift coverage) 전부 통과, 회귀 0.
- support-gateway: 신규 20건 포함 188/188 전부 통과(교차토큰 방어 3종: wrong-aud·
  delegated-token·operator-reply-token 전부 이 엔드포인트에서 거부 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)