### PR TITLE
[SID:3285] gateway realdb 드리프트 게이트 — sqlite로 못 잡는 PG 제약 드리프트 클래스 봉쇄

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,6 +941,28 @@ jobs:
     # 17~23분+)에 비하면 러너 비용은 무시할 수준 — 그래도 첫 CI 실주행 미지수 여유로 10분.
     timeout-minutes: 10
 
+    # story #3285(지원v1·후속, 2026-09-01) — gateway 스위트는 SQLite 인메모리(conftest.py)라
+    # 실 Postgres 마이그레이션 제약(CHECK/FK) 드리프트를 구조적으로 못 잡는 클래스였다(실증:
+    # #3672가 role을 코드로만 넓혀 dev PG서 500). backend와 같은 pgvector 서비스 패턴을
+    # 재사용 — 비용은 미미(gateway 마이그레이션 3~4개뿐, 수 초).
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: sprintable
+          POSTGRES_PASSWORD: sprintable
+          POSTGRES_DB: sprintable_gateway_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      GATEWAY_REALDB_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5433/sprintable_gateway_test
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -951,7 +973,7 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Run pytest (support-gateway — sqlite in-memory, no external services)
+      - name: Run pytest (support-gateway — sqlite in-memory + realdb 드리프트 게이트)
         if: needs.detect-changed-scope.outputs.gateway_relevant != 'false'
         working-directory: support-gateway
         run: |

--- a/support-gateway/app/models.py
+++ b/support-gateway/app/models.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Float, ForeignKey, Text, Uuid, func
+from sqlalchemy import CheckConstraint, DateTime, Float, ForeignKey, Index, Text, Uuid, func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 # SQLAlchemy 2.0 제네릭 Uuid — PG는 native UUID로, SQLite(테스트 전용, aiosqlite)는 CHAR(32)로
@@ -49,6 +49,14 @@ class SupportConversation(Base):
     별개 축이다(상담을 종료해도 열린 에스컬레이션은 안 건드린다, 그 반대도 마찬가지)."""
 
     __tablename__ = "support_conversations"
+    # story #3285(지원v1·후속, 2026-09-01) — realdb 드리프트 게이트가 처음 실행되며 발견한
+    # 별개 사전 존재 드리프트(operator role과 무관). migration 0003이 실제로 만든 건
+    # (org_id, external_user_id) 복합 인덱스 하나(그 조합으로 "활성 상담" 조회, 위 docstring)
+    # 인데, 모델은 external_user_id에 `index=True`만 붙여 실제 배포엔 없는 단일 컬럼 인덱스를
+    # 따로 선언하고 있었다(compare_metadata 실측으로 적발). 실 배포 스키마에 맞춰 정정.
+    __table_args__ = (
+        Index("ix_support_conversations_org_user_active", "org_id", "external_user_id"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
@@ -57,7 +65,7 @@ class SupportConversation(Base):
     )
     # NULL=레거시 봉인 행(위 docstring). 신규 생성 경로(_get_or_create_active_conversation 등)는
     # 항상 값을 채운다 — 코드 레벨 불변식, DB NOT NULL 제약은 아니다(레거시 행 공존 때문).
-    external_user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    external_user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
@@ -71,11 +79,32 @@ class SupportConversation(Base):
     )
 
 
+# story #3285(지원v1·후속, 2026-09-01) — #3672가 이 값 목록을 코드(app/routers/operator_replies.py
+# role="operator")에서 먼저 넓혔는데 마이그레이션(ck_support_messages_role, migration 0001)은
+# 그대로였다 — dev PG에서 실제로 IntegrityError 500(#3279 실왕복). 이 상수가 "코드가 믿는
+# 유효 role 집합"의 유일한 출처다 — CheckConstraint도, 아래 realdb 드리프트 프로브
+# (tests/test_gateway_schema_drift_realdb.py)도 전부 이 상수 하나를 순회/참조한다. 새 role을
+# 추가할 땐 여기만 고치면 되고, 그 순간 프로브가 자동으로 그 값을 실제 INSERT해 마이그레이션
+# 누락을 구조적으로 잡는다(하드코딩된 별도 목록을 테스트에 두면 갱신을 잊는 바로 그 실수가
+# 재발한다 — PO 확定).
+#
+# ⚠️migration 0004(story #3279 핫픽스, PR#3678)가 실 제약을 이 4개 값으로 넓히기 전까지는
+# 이 선언과 dev/prod 배포 상태가 불일치한다 — 그동안은 realdb 드리프트 테스트가 **의도적으로
+# RED**다(정확히 이 사고를 재현·증명하는 것). #3678 머지 전까지 이 PR은 머지 보류.
+ALLOWED_ROLES: tuple[str, ...] = ("customer", "agent", "system", "operator")
+
+
 class SupportMessage(Base):
     """고객 텍스트 저장 — role='customer'인 행은 항상 injection_defense.sanitize_customer_text()를
     거친 *이후* 값이어야 한다(app/injection_defense.py·story #3259 AC5 골격, 본 방어는 story #6)."""
 
     __tablename__ = "support_messages"
+    __table_args__ = (
+        CheckConstraint(
+            "role IN (" + ", ".join(f"'{r}'" for r in ALLOWED_ROLES) + ")",
+            name="ck_support_messages_role",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     conversation_id: Mapped[uuid.UUID] = mapped_column(
@@ -83,9 +112,11 @@ class SupportMessage(Base):
     )
     org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     # story #3279 핫픽스(2026-09-01, 마이그 0004) — 'operator' 편입 전엔 DB CHECK 제약이
-    # 이 role을 몰라 실 PG에서 500이었다(app/routers/operator_replies.py가 이미 쓰고
-    # 있었음에도). 이 주석과 alembic/versions/0004의 CHECK을 항상 같이 갱신할 것.
-    role: Mapped[str] = mapped_column(Text, nullable=False)  # 'customer' | 'agent' | 'system' | 'operator'
+    # 이 role을 몰라 실 PG에서 500이었다. story #3285가 "주석과 마이그레이션을 항상 같이
+    # 갱신할 것"이라는 수동 규율을 구조로 대체 — 이제 이 컬럼의 유효값은 ALLOWED_ROLES
+    # 상수(위)가 유일한 출처이고, CheckConstraint도 realdb 드리프트 프로브도 전부 거기서
+    # 도출된다. 새 role 추가 시 여기(주석 아님, ALLOWED_ROLES)만 고칠 것.
+    role: Mapped[str] = mapped_column(Text, nullable=False)  # ALLOWED_ROLES 중 하나 — 위 상수 참고.
     content: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 

--- a/support-gateway/tests/test_gateway_schema_drift_realdb.py
+++ b/support-gateway/tests/test_gateway_schema_drift_realdb.py
@@ -1,0 +1,112 @@
+"""story #3285(지원v1·후속, 2026-09-01) — gateway 스위트가 SQLite 인메모리(conftest.py의
+`Base.metadata.create_all()`)라 실 Postgres 마이그레이션 제약(CHECK/FK)과의 드리프트를
+구조적으로 못 잡는 클래스. 실증: story #3672가 `role="operator"`를 코드로만 허용하고
+`ck_support_messages_role`(migration 0001, 'customer'|'agent'|'system'만) 확장을 안 해
+dev PG서 IntegrityError 500(#3279 실왕복) — SQLite는 이 제약 자체를 모델에서 안 봐서
+어떤 테스트도 이걸 못 잡았다.
+
+이 파일은 disposable Postgres(CI: gateway-test 잡의 postgres 서비스, 로컬: GATEWAY_REALDB_URL
+설정 시)에 실 alembic 마이그레이션을 태워 두 층으로 검증한다:
+
+① `compare_metadata()` — 테이블·컬럼·인덱스·FK·제약 유무(add/remove)류 구조 드리프트 일반
+   봉쇄. 로컬 실측(2026-09-01, postgres@16) — 모델에서 제약을 통째로 빼면 diff 1건 정확히
+   뜬다.
+② ①의 사각(로컬 실측으로 직접 확認) — **같은 이름의 제약인데 조건식(허용 값 목록)만 바뀐
+   경우는 `compare_metadata()`가 diff=0으로 못 잡는다**(Postgres가 `IN (...)`을
+   `= ANY(ARRAY[...])`로 canonicalize해 텍스트 비교도 못 씀). 이 사각을 별도 삽입 프로브로
+   보완 — `app.models.ALLOWED_ROLES`(모델 상수, 이 테스트에 별도 하드코딩하지 않음 — PO
+   확定: 새 role이 그 상수에 추가되는 순간 이 프로브가 자동으로 그 값을 실제 INSERT해
+   마이그레이션 누락을 구조적으로 잡는다)를 순회하며 실 제약을 통과하는지 확認한다.
+
+⚠️2026-09-01 시점 — migration 0004(story #3279 핫픽스, PR#3678)가 아직 develop에 없어
+ALLOWED_ROLES('operator' 포함)와 실 배포 제약(0001, 3개 값)이 불일치한다. 이 파일의 ②는
+그래서 **지금 시점 의도적으로 RED**(정확히 이 사고를 재현·증명) — #3678 머지 전까지 이 PR은
+머지 보류(PO 확定 사슬)."""
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+from alembic.autogenerate import compare_metadata
+from alembic.migration import MigrationContext
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models import ALLOWED_ROLES, Base, SupportConversation, SupportMessage, SupportSession
+
+_ENV_VAR = "GATEWAY_REALDB_URL"
+_ROOT = Path(__file__).parent.parent
+
+pytestmark = pytest.mark.skipif(
+    _ENV_VAR not in os.environ,
+    reason=f"{_ENV_VAR} 미설정 — disposable Postgres 필요(CI gateway-test 잡은 항상 설정, 로컬은 선택 실행).",
+)
+
+
+def _sync_url() -> str:
+    return os.environ[_ENV_VAR]
+
+
+def _async_url() -> str:
+    url = _sync_url()
+    if "+asyncpg" in url:
+        return url
+    return url.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+
+
+@pytest.fixture(scope="module")
+def migrated_engine():
+    env = {**os.environ, "SUPPORT_GATEWAY_DATABASE_URL": _async_url()}
+    subprocess.run(["uv", "run", "alembic", "upgrade", "head"], cwd=_ROOT, env=env, check=True)
+    engine = create_engine(_sync_url())
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+        subprocess.run(["uv", "run", "alembic", "downgrade", "base"], cwd=_ROOT, env=env, check=True)
+
+
+def test_model_metadata_matches_migrated_schema_no_structural_drift(migrated_engine):
+    """① add/remove류 구조 드리프트(테이블·컬럼·인덱스·FK·제약 유무) 일반 봉쇄."""
+    with migrated_engine.connect() as conn:
+        ctx = MigrationContext.configure(conn)
+        diff = compare_metadata(ctx, Base.metadata)
+    assert diff == [], f"모델↔실 마이그레이션 스키마 드리프트: {diff}"
+
+
+def test_every_allowed_role_actually_persists_against_real_constraint(migrated_engine):
+    """② ①의 사각(같은 이름·조건 변경) 보완 pin. ALLOWED_ROLES를 그대로 순회 —
+    이 테스트 자체는 role 목록을 하드코딩하지 않는다(PO 확定, app/models.py 주석 참고)."""
+    with Session(migrated_engine) as session:
+        sess_row = SupportSession(org_id=uuid.uuid4(), external_user_id=uuid.uuid4())
+        session.add(sess_row)
+        session.flush()
+        conv = SupportConversation(org_id=sess_row.org_id, session_id=sess_row.id)
+        session.add(conv)
+        session.flush()
+
+        failed_roles: list[str] = []
+        for role in ALLOWED_ROLES:
+            try:
+                with session.begin_nested():
+                    session.add(
+                        SupportMessage(
+                            conversation_id=conv.id, org_id=sess_row.org_id, role=role, content="probe"
+                        )
+                    )
+                    session.flush()
+            except IntegrityError:
+                failed_roles.append(role)
+
+        session.rollback()
+
+    assert failed_roles == [], (
+        f"ALLOWED_ROLES에 있는 값이 실 CHECK 제약(ck_support_messages_role)을 못 넘었습니다: "
+        f"{failed_roles} — 마이그레이션이 이 값을 반영 못 했다는 뜻(모델이 코드보다 먼저 넓어짐)."
+    )


### PR DESCRIPTION
story #3285(지원v1·후속). 2026-09-01 실증(#3279 라이브 왕복) — story #3672가 `role="operator"`를 코드로만 허용하고 마이그레이션(`ck_support_messages_role`, 3개 값만)은 그대로라 dev PG서 IntegrityError 500. gateway 스위트(SQLite 인메모리)는 이 제약 자체를 모델에서 안 봐서 못 잡았다.

## 그라운딩 핵심 발견(로컬 postgres@16 직접 실측)
alembic `compare_metadata()`는 제약 add/remove는 정확히 잡지만, **"같은 이름의 제약인데 조건식(허용 값)만 바뀐" 경우는 diff=0으로 못 잡는다**(Postgres가 canonicalize해 텍스트 비교도 안 됨) — 정확히 이번 사고의 모양. 이 사각을 밝히지 않고 진행했으면 "닫았다고 착각하는 가드"가 될 뻔했다.

## 처방(PO 승인)
- `ALLOWED_ROLES` 모델 상수 신설(코드가 믿는 유효 role의 유일한 출처) + `CheckConstraint` 명시 선언
- `test_gateway_schema_drift_realdb.py`: ①`compare_metadata()` diff=0(구조 드리프트 일반) ②`ALLOWED_ROLES` 순회 삽입 프로브(①의 사각 보완 — 새 role 추가 즉시 자동 검증)
- CI: gateway-test 잡(#3273로 이미 required)에 backend와 동일한 `pgvector/pgvector:pg16` 서비스 추가

## 부수 발견 즉시 수정
게이트 첫 실행에서 별개 사전 드리프트 발견(`SupportConversation.external_user_id` 단일 인덱스가 실 배포엔 없음, 실제론 `(org_id, external_user_id)` 복합 인덱스) — 모델을 실 스키마에 맞춰 정정.

## 검증
- realdb ①: 인덱스 드리프트 mutation(원복)에 정확히 RED, 수정 후 PASS
- realdb ②: **현재 의도적으로 RED**(`['operator']`) — PR#3678(migration 0004) 머지 즉시 자동 GREEN
- sqlite 스위트 173 passed, 2 skipped(realdb, env 미설정 로컬 기본) 무회귀

## ⚠️머지 보류
PR#3678이 develop에 먼저 머지돼야 이 PR의 realdb ②가 GREEN — gateway-test가 이미 required라 자연히 강제되는 순서. #3678 머지 확認 후 머지.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_019rkXVqy2DF1aAN7szuqp44