### PR TITLE
[SID:3278] 활성 상담 최대 1개 — partial unique index 보강+레이스 우아한 처리

### DIFF
--- a/support-gateway/alembic/versions/0005_active_conversation_unique_index.py
+++ b/support-gateway/alembic/versions/0005_active_conversation_unique_index.py
@@ -1,0 +1,62 @@
+"""story #3278(지원v1·후속) — (org_id, external_user_id)당 활성 상담(ended_at IS NULL)
+최대 1개를 DB 제약으로 강제.
+
+출처: PR#3667 카디르 QA 참고사항(2026-09-01, 비차단) — story #3276이 만든 "활성 최대 1개"
+불변식이 앱 로직(`_get_or_create_active_conversation`)에만 있고 DB 제약이 없어, 동시 start
+요청 레이스에서 이론상 활성 2개가 생길 수 있다.
+
+partial unique index `(org_id, external_user_id) WHERE ended_at IS NULL`. `external_user_id`
+IS NULL인 레거시 봉인 행(story #3276 이전, "org당 1스레드" 시절)은 이 인덱스 대상에서
+자연히 제외된다 — Postgres 유니크 인덱스는 NULL끼리 서로 다른 값으로 취급하므로, NULL
+external_user_id 행이 여러 개 있어도(레거시) 위반이 안 된다. WHERE 절에 명시로 제외하지
+않아도 되지만, 아래 선-정리 UPDATE에서는 명시로 건너뛴다(레거시 행은 새 불변식 적용
+대상이 아니므로 손대지 않는다 — story #3276 "봉인" 원칙 그대로).
+
+마이그레이션 전 기존 데이터 정리(스토리 처방 그대로) — 인덱스 생성 전, 같은
+(org_id, external_user_id)에 활성 상담이 2개 이상이면 가장 최근 것만 남기고 나머지는
+`ended_at=now()`로 종료 처리한다(정리 정책: "가장 최근 활성 유지" — 위젯이 재오픈 시
+사용자가 마지막으로 보고 있던 대화가 이어지는 게 가장 자연스럽다). v1은 단일 위젯
+클라이언트라 실제로 이 분기를 탈 데이터는 거의 없을 것으로 예상(스토리 자체 서술)이지만,
+있어도 마이그레이션이 죽지 않고 스스로 정리한다.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+_INDEX_NAME = "ux_support_conversations_org_user_active"
+
+_CLEANUP_SQL = """
+WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY org_id, external_user_id
+               ORDER BY created_at DESC, id DESC
+           ) AS rn
+    FROM support_conversations
+    WHERE ended_at IS NULL AND external_user_id IS NOT NULL
+)
+UPDATE support_conversations
+SET ended_at = now()
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1)
+"""
+
+
+def upgrade() -> None:
+    op.execute(_CLEANUP_SQL)
+    op.create_index(
+        _INDEX_NAME,
+        "support_conversations",
+        ["org_id", "external_user_id"],
+        unique=True,
+        postgresql_where=sa.text("ended_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_INDEX_NAME, table_name="support_conversations")

--- a/support-gateway/app/routers/sessions.py
+++ b/support-gateway/app/routers/sessions.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -112,6 +113,31 @@ async def _get_active_conversation(
     ).scalar_one_or_none()
 
 
+async def _create_active_conversation_racesafe(
+    db: AsyncSession, *, session: SupportSession, org_id: uuid.UUID, external_user_id: uuid.UUID
+) -> SupportConversation:
+    """story #3278 — check-then-insert(호출부가 먼저 "활성 없음"을 확인한 뒤 여기로 옴)는
+    동시 요청 레이스에서 둘 다 "없음"을 보고 둘 다 insert를 시도할 수 있다. 이제
+    `ux_support_conversations_org_user_active`(partial unique index, migration 0005)가
+    그 레이스의 패자를 DB 레벨에서 실제로 막는다 — 패자는 여기서 IntegrityError를 500으로
+    흘려보내지 않고, 승자의 행을 조용히 재사용한다(스토리 처방 "위반 시 앱 레벨 우아한
+    처리" 그대로). 사용자 입장에선 "내가 만들었나 남이 만들었나"가 무관하고, 활성 상담이
+    정확히 1개만 존재하면 된다."""
+    conv = SupportConversation(org_id=org_id, session_id=session.id, external_user_id=external_user_id)
+    db.add(conv)
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        winner = await _get_active_conversation(db, org_id=org_id, external_user_id=external_user_id)
+        if winner is None:
+            # 이론상 도달 불가(우리가 진 경쟁이면 승자 행이 반드시 있어야 한다) — 방어적
+            # 재-raise(조용히 삼켜 원인불명 500/무한루프보다 원래 에러가 낫다).
+            raise
+        return winner
+    return conv
+
+
 async def _get_or_create_active_conversation(
     db: AsyncSession, *, session: SupportSession, org_id: uuid.UUID, external_user_id: uuid.UUID
 ) -> SupportConversation:
@@ -122,10 +148,9 @@ async def _get_or_create_active_conversation(
     existing = await _get_active_conversation(db, org_id=org_id, external_user_id=external_user_id)
     if existing is not None:
         return existing
-    conv = SupportConversation(org_id=org_id, session_id=session.id, external_user_id=external_user_id)
-    db.add(conv)
-    await db.flush()
-    return conv
+    return await _create_active_conversation_racesafe(
+        db, session=session, org_id=org_id, external_user_id=external_user_id
+    )
 
 
 async def _get_owned_conversation_or_404(
@@ -323,8 +348,12 @@ async def start_new_conversation(
     if active is not None:
         active.ended_at = datetime.now(timezone.utc)
 
-    conv = SupportConversation(org_id=identity.org_id, session_id=session.id, external_user_id=identity.user_id)
-    db.add(conv)
+    # story #3278 — 동시 "새 상담 시작" 레이스도 같은 partial unique index에 걸린다(위
+    # _create_active_conversation_racesafe docstring 참고). 패자는 승자가 만든 상담을
+    # 그대로 돌려받는다 — "새 상담 시작"을 두 번 눌러도 활성 상담은 항상 정확히 1개.
+    conv = await _create_active_conversation_racesafe(
+        db, session=session, org_id=identity.org_id, external_user_id=identity.user_id
+    )
     await db.commit()
     await db.refresh(conv)
     return _to_conversation_response(conv, escalation_status=None)

--- a/support-gateway/tests/test_3278_active_conversation_race.py
+++ b/support-gateway/tests/test_3278_active_conversation_race.py
@@ -1,0 +1,122 @@
+"""story #3278(지원v1·후속) — (org_id, external_user_id)당 활성 상담 최대 1개를
+partial unique index(alembic/versions/0005_active_conversation_unique_index.py)로 강제 +
+레이스 패자의 앱 레벨 우아한 처리(app/routers/sessions.py::_create_active_conversation_racesafe).
+
+migration 0005 자체(실 PG에서 중복 INSERT가 실제로 막히는가·기존 중복 데이터 선-정리
+UPDATE가 옳게 동작하는가·레거시 NULL external_user_id 행은 안 건드리는가)는 로컬 실
+Postgres로 별도 수동 검증 완료(PR 본문 참고) — 이 스위트는 다른 gateway 테스트와 동일하게
+sqlite 인메모리라 partial unique index 자체를 못 태운다(`Base.metadata.create_all`이
+모델 정의만 보고, 이 인덱스는 마이그레이션 전용이라 모델엔 없음 — 0003의 기존 비-unique
+인덱스와 동일한 이 코드베이스 관례). 그래서 여기는 IntegrityError를 monkeypatch로 주입해
+"레이스에서 졌을 때 앱 코드가 올바르게 반응하는가"(우아한 처리 로직 자체)만 겨냥한다.
+
+⚠️`app.routers.sessions`/`app.models`는 이 파일 **함수 안에서만** import한다(모듈 최상단
+import는 collection 시점에 `app.db`(모듈 로드 시 즉시 엔진 생성)를 끌고 들어와
+`_configure_settings` autouse 픽스처가 아직 안 걸린 상태의 실 `settings.database_url`
+(빈 문자열)로 실패한다 — story #3279 test_3279_operator_reply.py 등 기존 파일들이 전부
+이 지연 import 관례를 쓰는 이유와 동일)."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_session(db, *, org_id, external_user_id):
+    from app.models import SupportSession
+
+    session = SupportSession(id=uuid.uuid4(), org_id=org_id, external_user_id=external_user_id)
+    db.add(session)
+    await db.flush()
+    return session
+
+
+@pytest.mark.anyio
+async def test_no_race_creates_new_conversation(db_engine):
+    """양성대조 — 경쟁이 없으면(flush가 정상 성공) 그냥 새 상담을 만든다(기존 동작 무회귀)."""
+    from app.routers.sessions import _create_active_conversation_racesafe
+
+    Session = async_sessionmaker(db_engine, expire_on_commit=False)
+    async with Session() as db:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        session = await _seed_session(db, org_id=org_id, external_user_id=user_id)
+
+        result = await _create_active_conversation_racesafe(
+            db, session=session, org_id=org_id, external_user_id=user_id
+        )
+        await db.commit()
+
+        assert result.org_id == org_id
+        assert result.external_user_id == user_id
+
+
+@pytest.mark.anyio
+async def test_race_loser_reuses_winner_conversation_instead_of_500(db_engine):
+    """⭐AC pin — flush()가 IntegrityError(unique 위반, 레이스 패배 시뮬레이션)를 던지면
+    500을 흘려보내지 않고 이미 존재하는(=승자가 만든) 활성 상담을 그대로 돌려받는다."""
+    from app.models import SupportConversation
+    from app.routers.sessions import _create_active_conversation_racesafe, _get_active_conversation
+
+    Session = async_sessionmaker(db_engine, expire_on_commit=False)
+    async with Session() as db:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        session = await _seed_session(db, org_id=org_id, external_user_id=user_id)
+        # "승자"가 이미 커밋해 둔 활성 상담을 미리 심어둔다(레이스 결과를 흉내).
+        winner = SupportConversation(org_id=org_id, session_id=session.id, external_user_id=user_id)
+        db.add(winner)
+        await db.commit()
+
+        real_flush = db.flush
+        call_count = {"n": 0}
+
+        async def _flush_raise_once():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise IntegrityError("insert into support_conversations", {}, Exception("duplicate key"))
+            return await real_flush()
+
+        db.flush = _flush_raise_once
+
+        result = await _create_active_conversation_racesafe(
+            db, session=session, org_id=org_id, external_user_id=user_id
+        )
+
+        assert result.id == winner.id  # 승자 재사용 — 새 행을 또 만들지 않음.
+        assert call_count["n"] == 1  # flush는 정확히 한 번(실패한 그 한 번)만 시도됨.
+
+    # 별도 세션으로 재조회 — DB 실측(같은 트랜잭션 안 self-confirm이 아니라).
+    async with Session() as verify_db:
+        active = await _get_active_conversation(verify_db, org_id=org_id, external_user_id=user_id)
+        assert active is not None
+        assert active.id == winner.id
+
+
+@pytest.mark.anyio
+async def test_race_loser_with_no_winner_found_reraises(db_engine):
+    """방어적 재-raise pin — IntegrityError는 났는데(이론상 불가능해야 함) 재조회해도
+    승자 행이 없으면, 조용히 삼켜 원인불명 500/무한루프를 만들지 않고 원래 에러를 그대로
+    다시 던진다."""
+    from app.routers.sessions import _create_active_conversation_racesafe
+
+    Session = async_sessionmaker(db_engine, expire_on_commit=False)
+    async with Session() as db:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        session = await _seed_session(db, org_id=org_id, external_user_id=user_id)
+        await db.commit()
+
+        async def _flush_always_raise():
+            raise IntegrityError("insert into support_conversations", {}, Exception("duplicate key"))
+
+        db.flush = _flush_always_raise
+
+        with pytest.raises(IntegrityError):
+            await _create_active_conversation_racesafe(
+                db, session=session, org_id=org_id, external_user_id=user_id
+            )


### PR DESCRIPTION
[SID:3278]

story: entity:story:accf5575-c12e-4275-bc83-a186c9dd567a
출처: PR#3667 카디르 QA 참고사항(비차단) — 지원 스프린트 마무리 결로 당김.

## 결함
(org_id, external_user_id)당 활성 상담(ended_at IS NULL) 최대 1개가
`_get_or_create_active_conversation`의 check-then-insert(앱 로직)에만 있고 DB 제약이
없어, 동시 start 요청 레이스에서 이론상 활성 2개가 생길 수 있었다. v1은 단일 위젯
클라이언트라 실확률은 낮음(스토리 자체 서술) — 그래도 DB가 보장 못 하는 불변식은
불변식이 아니다.

## 변경
- **`alembic/versions/0005`** — partial unique index
  `ux_support_conversations_org_user_active(org_id, external_user_id) WHERE ended_at IS
  NULL`. 마이그레이션 전 기존 중복 활성 상담을 자동 선-정리(가장 최근 것만 유지, 나머지
  `ended_at=now()`) — "마이그레이션 전 기존 데이터 선실측" 요구를, 환경에 의존하는 수동
  확인 대신 마이그레이션 자체의 자기-치유 UPDATE로 충족(어느 환경에서 돌아도 안전).
  `external_user_id IS NULL`인 레거시 봉인 행(story #3276 이전, "org당 1스레드" 시절)은
  정리 대상에서 명시 제외.
- **`app/routers/sessions.py`** — `_create_active_conversation_racesafe()` 신설(insert
  로직 추출) + `start_new_conversation`에도 동일 패턴 적용(두 endpoint 다 이 unique
  index에 걸릴 수 있는 write 경로임을 `SupportConversation(` 생성 지점 전수 grep으로
  확인). unique 위반(IntegrityError) 시 500이 아니라 rollback 후 승자의 활성 상담을
  그대로 재사용(스토리 처방 "위반 시 앱 레벨 우아한 처리" 그대로 채택).

## 검증
마이그레이션 자체는 sqlite 테스트 스위트가 못 태우는 영역이라(partial unique index는
마이그레이션 전용 — 이 코드베이스가 0003의 기존 인덱스도 모델에 안 실어두는 것과 동일
관례) **로컬 실 Postgres로 직접 검증**:
1. 인덱스 생성 후 동일 (org_id, external_user_id) 활성 행 2번째 INSERT가 실제로
   `duplicate key value violates unique constraint` 로 거부됨.
2. 마이그레이션 前 상태에 중복 활성 2개 + 레거시 NULL 행 2개를 직접 시딩 후 upgrade —
   오래된 활성 1개만 자동 `ended` 처리(최신 유지), 레거시 NULL 행 2개는 안 건드림을 실측.

앱 레벨 우아한 처리(`_create_active_conversation_racesafe`)는 IntegrityError를
monkeypatch로 주입한 sqlite 테스트 3건(정상 경로 양성대조·레이스 패자 승자 재사용·
승자 없음 방어적 재-raise)으로 검증. 뮤테이션 테스트: try/except 제거 → 관련 테스트
정확히 RED 확인 후 원복.

전체 스위트 176/176 통과(신규 3건 포함, 회귀 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)