### PR TITLE
[SID:3253] sprintable/gate 자기참조 순환 처방 — REST check-runs 직접 집계

### DIFF
--- a/backend/app/services/verdict_capture.py
+++ b/backend/app/services/verdict_capture.py
@@ -131,51 +131,62 @@ async def fetch_pr_review_rounds(repo: str, pr_number: int) -> int:
         return 0
 
 
+_GATE_CHECK_NAME = "sprintable/gate"
+_FAILURE_CONCLUSIONS = {"failure", "timed_out", "cancelled", "action_required", "stale"}
+
+
 async def fetch_status_check_rollup(repo: str, head_sha: str, token: str) -> tuple[str | None, str]:
-    """E-GHAPP Bot-M.1: PR head commit의 집계 CI 상태를 GitHub GraphQL statusCheckRollup으로 조회.
+    """E-GHAPP Bot-M.1: PR head commit의 집계 CI 상태를 REST check-runs 목록에서 직접 계산.
 
     반환 **(ci, reason)** — ci ∈ 'success'|'failure'|None, reason은 unknown(ci=None) 사유 진단용:
       ('success', 'resolved') · ('failure', 'resolved') · (None, 'pending') · (None, 'api_error') ·
       (None, 'not_found') · (None, 'no_token'/'bad_input').
     **token(installation access token)**으로 호출. ⚠️**PAT fallback 없음**(Bot-M.1 게이트). reason은 라이브
     App/권한 진단 + 'unknown 0' 검증용(success 승격 절대 금지). 토큰은 호출자가 org→installation 해소해 전달.
-    """
+
+    story #3253(2026-08-30/31 진단, 2026-09-01 재확認 후 처방) — GitHub GraphQL의 집계
+    `statusCheckRollup{state}`(구현, 아래 기록만 남김)은 커밋에 달린 **모든** 체크런을 합산하는데,
+    그 안에 `sprintable/gate`(이 함수의 호출자 자신이 발행한 체크런)까지 포함돼 있었다. 즉
+    sprintable/gate가 아직 자기 판정을 못 끝내 `in_progress`인 동안은 롤업 자체가 SUCCESS가
+    될 수 없는 **자기참조 순환**이었다 — reevaluate가 `ci_result`를 pass→null로 후퇴시키던
+    진짜 원인(다른 모든 하위 게이트가 success여도 gate 자신의 in_progress가 계속 rollup을
+    오염). 처방: REST `GET /repos/{repo}/commits/{sha}/check-runs`(list_check_runs_for_ref와
+    동일 API축, github_app.py)로 개별 체크런 목록을 직접 받아 `sprintable/gate` 자기 자신을
+    제외하고 이 함수가 직접 집계한다 — 집계 규칙은 원래 GraphQL rollup 의미론과 최대한
+    동형(미완료 체크 존재=pending, 실패류 conclusion 존재=failure, 그 외 전부=success)."""
     if not token:
         return None, "no_token"
     if not repo or "/" not in repo or not head_sha:
         return None, "bad_input"
-    owner, name = repo.split("/", 1)
-    query = (
-        "query($owner:String!,$name:String!,$oid:GitObjectID!){"
-        "repository(owner:$owner,name:$name){object(oid:$oid){"
-        "... on Commit{statusCheckRollup{state}}}}}"
-    )
     try:
         import httpx
         async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                "https://api.github.com/graphql",
+            resp = await client.get(
+                f"https://api.github.com/repos/{repo}/commits/{head_sha}/check-runs",
                 headers={
                     "Authorization": f"Bearer {token}",
                     "Accept": "application/vnd.github+json",
                 },
-                json={"query": query, "variables": {"owner": owner, "name": name, "oid": head_sha}},
+                params={"per_page": 100},
             )
         if resp.status_code != 200:
             return None, "api_error"
         data = resp.json()
-        obj = (((data.get("data") or {}).get("repository") or {}).get("object")) or {}
-        rollup = (obj.get("statusCheckRollup") if isinstance(obj, dict) else None) or {}
-        state = rollup.get("state")
-        if state == "SUCCESS":
-            return "success", "resolved"
-        if state in ("FAILURE", "ERROR"):
-            return "failure", "resolved"
-        if state in ("PENDING", "EXPECTED"):
+        runs = data.get("check_runs") if isinstance(data, dict) else None
+        if not isinstance(runs, list):
+            return None, "not_found"
+        # 자기 자신(sprintable/gate) 제외 — 자기참조 순환의 근인 처방.
+        relevant = [r for r in runs if isinstance(r, dict) and r.get("name") != _GATE_CHECK_NAME]
+        if not relevant:
+            return None, "not_found"
+        if any(r.get("status") != "completed" for r in relevant):
             return None, "pending"          # 미완료 — 채우지 않음(success 승격 금지).
-        return None, "not_found"            # rollup 없음(체크 미설정/SHA 불일치 등).
+        conclusions = {r.get("conclusion") for r in relevant}
+        if conclusions & _FAILURE_CONCLUSIONS:
+            return "failure", "resolved"
+        return "success", "resolved"        # success/neutral/skipped 전부 통과(원 rollup 의미론과 동형).
     except Exception as exc:  # noqa: BLE001
-        logger.warning("statusCheckRollup fetch failed repo=%s sha=%s: %s", repo, head_sha, exc)
+        logger.warning("check-runs fetch failed repo=%s sha=%s: %s", repo, head_sha, exc)
         return None, "api_error"
 
 

--- a/backend/tests/test_h1_s6_github_webhook.py
+++ b/backend/tests/test_h1_s6_github_webhook.py
@@ -338,26 +338,59 @@ async def test_native_ci_not_pulled_when_event_has_conclusion():
 
 @pytest.mark.anyio
 async def test_fetch_status_check_rollup_returns_ci_and_reason():
-    """statusCheckRollup → (ci, reason). token 없음=(None,no_token)·state별 매핑·PAT 인자 없음."""
+    """story #3253 — REST check-runs 목록에서 직접 집계 → (ci, reason). token 없음=(None,no_token)·
+    conclusion별 매핑·sprintable/gate 자기 자신은 항상 집계에서 제외됨."""
     assert await _svc.fetch_status_check_rollup("o/r", "sha", "") == (None, "no_token")
     assert await _svc.fetch_status_check_rollup("badrepo", "sha", "tok") == (None, "bad_input")
 
-    def _resp(status, state):
+    def _run(name, status, conclusion):
+        return {"name": name, "status": status, "conclusion": conclusion}
+
+    def _resp(status_code, check_runs):
         r = MagicMock()
-        r.status_code = status
-        r.json.return_value = {"data": {"repository": {"object": {"statusCheckRollup": ({"state": state} if state else None)}}}}
+        r.status_code = status_code
+        r.json.return_value = {"check_runs": check_runs} if check_runs is not None else {}
         return r
 
     import httpx
+
     cases = [
-        (200, "SUCCESS", ("success", "resolved")),
-        (200, "FAILURE", ("failure", "resolved")),
-        (200, "ERROR", ("failure", "resolved")),
-        (200, "PENDING", (None, "pending")),
-        (200, "EXPECTED", (None, "pending")),
+        (200, [_run("CI", "completed", "success")], ("success", "resolved")),
+        (200, [_run("CI", "completed", "failure")], ("failure", "resolved")),
+        (200, [_run("CI", "completed", "timed_out")], ("failure", "resolved")),
+        (200, [_run("CI", "in_progress", None)], (None, "pending")),
+        (200, [], (None, "not_found")),
         (200, None, (None, "not_found")),
-        (500, "SUCCESS", (None, "api_error")),
+        (500, [_run("CI", "completed", "success")], (None, "api_error")),
     ]
-    for status, state, expected in cases:
-        with patch.object(httpx.AsyncClient, "post", new=AsyncMock(return_value=_resp(status, state))):
+    for status_code, check_runs, expected in cases:
+        with patch.object(httpx.AsyncClient, "get", new=AsyncMock(return_value=_resp(status_code, check_runs))):
             assert await _svc.fetch_status_check_rollup("moonklabs/sprintable", "abc", "inst-tok") == expected
+
+
+@pytest.mark.anyio
+async def test_fetch_status_check_rollup_excludes_gate_self_reference():
+    """story #3253 핵심 회귀 pin — 자기참조 순환 재현·처방 검증. sprintable/gate 자기 자신이
+    아직 in_progress인데 나머지 하위 체크(CI 등)는 전부 success면, 예전 GraphQL rollup
+    집계식으로는 (None,'pending')이었을 상황(gate 포함 전체가 완료돼야 SUCCESS)을 이 함수는
+    gate 자신을 제외하고 계산해 ('success','resolved')로 정확히 판정해야 한다 — CI가 100%
+    green인데도 gate가 영구히 자기 자신을 기다리는 사고가 이 pin으로 구조적으로 막힌다."""
+
+    def _resp(check_runs):
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {"check_runs": check_runs}
+        return r
+
+    import httpx
+
+    check_runs = [
+        {"name": "sprintable/gate", "status": "in_progress", "conclusion": None},
+        {"name": "CI", "status": "completed", "conclusion": "success"},
+        {"name": "QA review gate", "status": "completed", "conclusion": "success"},
+    ]
+    with patch.object(httpx.AsyncClient, "get", new=AsyncMock(return_value=_resp(check_runs))):
+        assert await _svc.fetch_status_check_rollup("moonklabs/sprintable", "abc", "inst-tok") == (
+            "success",
+            "resolved",
+        )


### PR DESCRIPTION
story #3253(5874e215, 제품·결함·머지게이트). 2026-08-30/31 그라운딩 + 2026-09-01 전제 재실측(PO 지시).

## 재검 결과 — 스코프 재분류(PO 승인)
- **ⓑ(자기참조 순환)는 지금도 그대로 실재·미수정** 확認 — 이 PR이 처방
- **"PR 재오픈이 통과 게이트를 리셋"**은 재오픈 전용 결함이 아니라 08-20 PO 확定 정책("pending 전이 후 사람 재승인 없인 자동 복구 안 함")의 정상 발현으로 재분류(reopen 웹훅을 opened/synchronize와 다르게 처리하는 코드를 못 찾음) — 관측 자체는 정직하게 보존, 별개 처방은 불요로 판정

## 근인
`fetch_status_check_rollup()`이 GitHub GraphQL 집계 `statusCheckRollup{state}`(커밋의 모든 체크런 합산)를 신뢰하는데, 그 안에 `sprintable/gate` 자기 자신의 체크런까지 포함된다 — gate가 아직 in_progress인 동안은 롤업 자체가 SUCCESS가 될 수 없는 자기참조 순환. 다른 모든 하위 게이트가 success여도 gate 자신이 계속 rollup을 오염해 `ci_result`가 pass→null로 후퇴하고, outcome 표본이 cold-start를 벗어나도 AUTO_MERGE 경로를 영구히 막을 잠재 결함이었다.

## 처방
REST `GET /repos/{repo}/commits/{sha}/check-runs`(`list_check_runs_for_ref`와 동일 API축, `github_app.py`)로 교체 — 개별 체크런 목록을 직접 받아 `sprintable/gate` 자기 자신을 이름으로 제외하고 이 함수가 직접 집계(원 rollup 의미론과 동형: 미완료 존재=pending·실패류=failure·그 외=success).

## 검증
- 기존 GraphQL mock 테스트를 REST mock으로 전면 재작성 — 동일 케이스 커버
- **신규 핵심 회귀 pin**: sprintable/gate 자신이 in_progress인데 나머지 체크가 전부 success인 시나리오 → success/resolved로 정확히 판정(자기참조 순환 처방의 직접 증거)
- 관련 gate/verdict 테스트 전체(realdb 포함, 로컬 postgres@16 실측) 166건 PASS(무회귀)

## 남은 것
라이브 확認 표본(전 하위 게이트 success인데 gate만 in_progress로 안 끝나는 실 PR)은 PO가 `/api/gates` 계측 권한으로 before/after JSON을 잡아 재현 pin에 별도 앵커 예정.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_019rkXVqy2DF1aAN7szuqp44