### PR TITLE
[SID:3272] cloudbuild-secret-manifest-guard — main+develop 매니페스트 합집합으로 대조

### DIFF
--- a/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
+++ b/backend/tests/test_3140_cloudbuild_secret_manifest_guard.py
@@ -277,3 +277,56 @@ def test_sync_against_real_manifest_and_real_gcp_if_available():
     manifest = pr_gate.load_manifest()
     ok, lines = sync_gate.check(manifest, live)
     assert ok, f"manifest가 GCP 실물과 어긋남(정기 갱신 필요) — {lines}"
+
+
+# ── story #3272 — main+develop manifest 합집합(스케줄 가드 배경음화 방지) ────────────────
+
+
+def test_parse_manifest_text_strips_blank_lines_and_comments():
+    text = "A\n# comment\n\nB\n  C  \n"
+    assert sync_gate.parse_manifest_text(text) == {"A", "B", "C"}
+
+
+def test_load_manifest_union_adds_develop_only_names():
+    """⭐핵심 pin — main 매니페스트엔 없고 develop에만 있는(=아직 승격 전) 이름이 union에
+    들어가면, 그 이름이 GCP에 있어도 더 이상 "GCP엔 있는데 manifest에 없음" 드리프트로
+    안 잡힌다(story #3272 실사고: SUPPORT_GATEWAY_*_dev 3종, run 33458117504)."""
+    with patch.object(sync_gate, "load_manifest", return_value={"A"}), \
+         patch.object(sync_gate, "fetch_develop_manifest_text", return_value="A\nSUPPORT_GATEWAY_TOKEN_SECRET_dev\n"):
+        union = sync_gate.load_manifest_union()
+    assert union == {"A", "SUPPORT_GATEWAY_TOKEN_SECRET_dev"}
+
+    ok, lines = sync_gate.check(manifest=union, live={"A", "SUPPORT_GATEWAY_TOKEN_SECRET_dev"})
+    assert ok is True  # union 적용 전이었다면 main={"A"} 단독 대조로 이 케이스가 FAIL이었다.
+
+
+def test_load_manifest_union_falls_back_to_main_only_when_develop_fetch_fails():
+    """develop을 못 읽으면(네트워크 실패 등) 조용히 main 단독으로 폴백 — 완화가 안 걸릴
+    뿐, 이 스크립트 자체가 죽거나 예외를 삼켜 원인불명 성공을 내지는 않는다."""
+    with patch.object(sync_gate, "load_manifest", return_value={"A"}), \
+         patch.object(sync_gate, "fetch_develop_manifest_text", return_value=None):
+        union = sync_gate.load_manifest_union()
+    assert union == {"A"}
+
+
+def test_load_manifest_union_still_catches_true_orphan_secret():
+    """⭐선언 검증 — main·develop 어느 쪽 manifest에도 없는 이름(진짜 고아)은 union
+    적용 후에도 여전히 "GCP엔 있는데 manifest에 없음"으로 잡힌다(이 처방이 넓히는 "정상"
+    범위는 develop이 아는 이름으로 한정된다는 모듈 docstring의 선언 그대로)."""
+    with patch.object(sync_gate, "load_manifest", return_value={"A"}), \
+         patch.object(sync_gate, "fetch_develop_manifest_text", return_value="A\n"):
+        union = sync_gate.load_manifest_union()
+    ok, lines = sync_gate.check(manifest=union, live={"A", "TRULY_ORPHANED_SECRET"})
+    assert ok is False
+    assert any("TRULY_ORPHANED_SECRET" in line for line in lines)
+
+
+def test_load_manifest_union_still_catches_dangerous_axis_deleted_from_gcp():
+    """위험 축(manifest엔 있는데 GCP엔 없음)은 union 적용 후에도 그대로 잡힌다 — 이
+    처방이 손대는 건 저위험 축(GCP엔 있는데 manifest에 없음)뿐이다."""
+    with patch.object(sync_gate, "load_manifest", return_value={"A", "GHOST"}), \
+         patch.object(sync_gate, "fetch_develop_manifest_text", return_value="A\n"):
+        union = sync_gate.load_manifest_union()
+    ok, lines = sync_gate.check(manifest=union, live={"A"})
+    assert ok is False
+    assert any("GHOST" in line for line in lines)

--- a/infra/sync_cloudbuild_secret_manifest.py
+++ b/infra/sync_cloudbuild_secret_manifest.py
@@ -11,6 +11,22 @@
 - manifest에 있는데 GCP에 없음 = **위험** — 시크릿이 실제로 삭제/이름변경됐는데 manifest는
   그걸 여전히 "존재"로 승인하고 있어 PR 게이트가 그 이름에 대해 거짓 안전(false green)을 낸다.
 
+story #3272(2026-09-01) — 스케줄 워크플로우(cloudbuild-secret-manifest-guard.yml)는 schedule
+트리거라 기본적으로 **main**을 checkout한다. dev 전용 시크릿(SUPPORT_GATEWAY_*_dev 3종 등,
+story #3140 후속 추가분)은 develop 매니페스트가 정본이고 main엔 승격 시점에야 도착한다 —
+그 사이 이 스크립트가 main만 보면 매번 "GCP엔 있는데 manifest에 없음"으로 FAIL을 쏘는
+«빨강=배경음» 클래스가 된다(실측: run 33458117504, develop 매니페스트엔 3/3 존재·main엔
+0/3). 처방: **main+develop 매니페스트의 합집합**을 GCP 실물과 대조한다 — `check()` 자체의
+2방향 판정(위험 축/저위험 축)은 그대로 유지하면서, "아직 승격 전"이라는 정상 상태를 더 이상
+드리프트로 오판하지 않는다.
+
+**이 처방이 새로 못 잡게 되는 것**(선언): main엔 아예 없고 develop 매니페스트에만 적힌
+이름이 GCP에도 존재하면(예: 실험 브랜치가 등록했지만 결국 main에 승격 안 시킨 시크릿), 이
+가드는 이제 그걸 "정상"(승격 대기 중)으로 봐준다 — 실제로는 그냥 만들어두고 잊은 고아
+시크릿일 수 있다. main·GCP 어느 쪽에도 없는 이름(진짜 고아)은 여전히 잡는다(develop에도
+없으면 union에서 빠지므로 `only_in_gcp`로 그대로 걸린다) — 이 처방이 넓히는 "정상" 범위는
+정확히 "develop 매니페스트가 이미 알고 있는 이름"으로 제한된다.
+
 **이 스크립트가 못 잡는 것**(선언, AC3): 이름이 존재하고 manifest·GCP 둘 다 일치해도 그
 시크릿의 **내용**(값)이 낡았는지는 안 본다(예: 로테이션 기한이 지난 API 키) — 이름 존재 축과
 내용 신선도 축은 별개 문제.
@@ -29,6 +45,47 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from check_cloudbuild_secret_manifest import _MANIFEST_PATH, load_manifest  # noqa: E402
 from cloudbuild_secret_refs import _REPO_ROOT  # noqa: E402
+
+_MANIFEST_RELATIVE_PATH = "infra/cloudbuild-secret-manifest.txt"
+
+
+def parse_manifest_text(text: str) -> set[str]:
+    """load_manifest()와 동일한 파싱 규칙(빈 줄·주석 제외) — git show로 얻은 develop 쪽
+    텍스트에 재사용하는 순수 함수(테스트가 git/subprocess 없이 검증)."""
+    return {
+        line.strip() for line in text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    }
+
+
+def fetch_develop_manifest_text() -> str | None:
+    """origin/develop의 manifest 파일 내용을 로컬 clone 안에서 직접 읽는다(git show — 추가
+    GCP 권한 불요, 이미 checkout된 로컬 저장소만 씀). 실패(fetch 안 됨·develop에 파일이
+    없음 등)하면 조용히 None — 그 경우 main 단독으로 대조(구 동작으로 안전측 폴백, 회귀는
+    아니고 "완화가 적용 안 됨"일 뿐)."""
+    try:
+        subprocess.run(
+            ["git", "fetch", "--depth=1", "origin", "develop"],
+            cwd=_REPO_ROOT, capture_output=True, text=True, check=True, timeout=30,
+        )
+        proc = subprocess.run(
+            ["git", "show", f"origin/develop:{_MANIFEST_RELATIVE_PATH}"],
+            cwd=_REPO_ROOT, capture_output=True, text=True, check=True, timeout=30,
+        )
+        return proc.stdout
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def load_manifest_union() -> set[str]:
+    """story #3272 — 현재 checkout(스케줄 워크플로우=main)의 manifest + develop 브랜치의
+    manifest 합집합. develop 텍스트를 못 읽으면(위 fetch_develop_manifest_text 참고)
+    main 단독으로 폴백한다."""
+    manifest = load_manifest()
+    develop_text = fetch_develop_manifest_text()
+    if develop_text is not None:
+        manifest |= parse_manifest_text(develop_text)
+    return manifest
 
 
 def _live_gcp_secret_names() -> set[str]:
@@ -65,13 +122,13 @@ def check(manifest: set[str], live: set[str]) -> tuple[bool, list[str]]:
 
 
 def main() -> int:
-    manifest = load_manifest()
+    manifest = load_manifest_union()
     live = _live_gcp_secret_names()
     ok, lines = check(manifest, live)
     for line in lines:
         print(line)
     if ok:
-        print(f"OK — manifest({len(manifest)}건)가 GCP 실물과 정확히 일치.")
+        print(f"OK — manifest(main+develop 합집합 {len(manifest)}건)가 GCP 실물과 정확히 일치.")
     return 0 if ok else 1
 
 


### PR DESCRIPTION
[SID:3272]

story: entity:story:35cd6638-0569-48f2-8705-ad0d35642645
발견: run 33458117504(2026-09-01, schedule)

## 결함
`cloudbuild-secret-manifest-guard.yml`은 schedule 트리거라 기본 `main`을 checkout —
`sync_cloudbuild_secret_manifest.py`가 그 checkout의 `infra/cloudbuild-secret-
manifest.txt`만 GCP 실물과 대조한다. dev 전용 시크릿(`SUPPORT_GATEWAY_*_dev` 3종,
story #3140 후속 추가분)은 develop 매니페스트가 정본이고 main엔 승격 시점에야 도착 —
그 사이 이 가드가 매번 "GCP엔 있는데 manifest에 없음"으로 FAIL을 쏜다(실측:
develop 매니페스트엔 3/3 존재·main엔 0/3). 승격 전이라는 정상 상태가 매일 빨강을 내면
«빨강=배경음»화되어 진짜 드리프트를 놓치는 위험이 커진다.

## 처방(스토리 후보 ① 채택)
`load_manifest_union()` 신설 — 현재 checkout(main)의 manifest + `git show origin/
develop:...`로 읽은 develop 매니페스트의 **합집합**을 GCP 실물과 대조. `check()` 자체의
2방향 판정(위험 축: manifest에만 있음 / 저위험 축: GCP에만 있음)은 그대로 유지 — "아직
승격 전"이라는 정상 상태만 더 이상 드리프트로 오판하지 않는다. develop fetch가 실패하면
(네트워크 등) 조용히 main 단독으로 폴백한다(스크립트가 죽거나 예외를 삼켜 원인불명
성공을 내지 않음).

## 선언(스토리 요구 — "가드가 못 잡게 되는 것" 명시)
main·develop 어느 쪽 manifest에도 없는 **진짜 고아 시크릿은 여전히 잡힌다**(develop에도
없으면 union에서 빠지므로). 이 처방이 새로 못 잡게 되는 건: main엔 없고 develop
매니페스트에만 등록된 채 결국 main에 승격 안 시킨 이름이 GCP에 존재하면(예: 실험
브랜치가 만들고 잊은 시크릿) "정상(승격 대기 중)"으로 오판할 수 있음 — 넓어지는 "정상"
범위가 정확히 "develop이 이미 아는 이름"으로 한정된다는 것까지 모듈 docstring에 명시.

## 검증
- 신규 테스트 5건 — union이 develop-only 이름을 실제로 흡수해 story의 실사고(오탐
  FAIL)를 해소함을 pin, fetch 실패 시 main 폴백, 진짜 고아 시크릿은 여전히 잡힘, 위험
  축(manifest에만 있음)은 그대로 잡힘.
- **로컬에서 실제 git fetch 왕복으로 검증**(mock 아님) — `origin/main`·`origin/develop`
  의 실제 manifest 텍스트를 직접 diff해 `SUPPORT_GATEWAY_ADMIN_TOKEN_dev`·
  `SUPPORT_GATEWAY_DATABASE_URL_dev`·`SUPPORT_GATEWAY_TOKEN_SECRET_dev` 3건이 정확히
  union에 흡수됨을 확인 — 스토리가 보고한 실사고와 정확히 같은 3건.
- 뮤테이션 테스트: union 병합 라인 제거 → 핵심 pin 테스트 정확히 RED 확인 후 원복.
- 기존 30건(`check()` 등) 전부 무회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)