### PR TITLE
[SID:3254] S3 create-only+required_write_headers+local PUT 실구현

### DIFF
--- a/apps/web/src/app/api/storage/local/[...path]/route.test.ts
+++ b/apps/web/src/app/api/storage/local/[...path]/route.test.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { signLocalObject } from '@/lib/storage/local-sign';
+
+// story dc3d62f4(BE·스토리지·self-host, 부수 MEDIUM 처방) — local PUT 수신 핸들러 신설.
+// GET은 이미 살아 있었으나(story #2193 계열) 이 파일 자체에 테스트가 없었다 — PUT 신설과
+// 함께 GET도 최소 커버.
+
+const SECRET = 'test-secret';
+const CONTAINER = 'sprintable-memo-attachments';
+const OBJECT_PATH = 'chat/p1/c1/hello.txt';
+
+describe('/api/storage/local/[...path]', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'sp-storage-route-'));
+    vi.resetModules();
+    vi.stubEnv('STORAGE_PROVIDER', 'local');
+    vi.stubEnv('STORAGE_LOCAL_ROOT', root);
+    vi.stubEnv('STORAGE_LOCAL_SIGNING_SECRET', SECRET);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  function url(path: string, qs: Record<string, string>) {
+    const q = new URLSearchParams(qs).toString();
+    return `http://localhost/api/storage/local/${path}?${q}`;
+  }
+
+  it('PUT: 유효한 write 서명 → 200 + 파일이 실제로 디스크에 쓰인다', async () => {
+    const { PUT } = await import('./route');
+    const exp = Date.now() + 60_000;
+    const sig = signLocalObject(SECRET, CONTAINER, OBJECT_PATH, exp, 'PUT');
+
+    const req = new Request(url(`${CONTAINER}/${OBJECT_PATH}`, { exp: String(exp), sig }), {
+      method: 'PUT',
+      body: 'hello from PUT',
+    });
+    const res = await PUT(req as never, { params: Promise.resolve({ path: [CONTAINER, ...OBJECT_PATH.split('/')] }) });
+    expect(res.status).toBe(200);
+
+    const written = await readFile(join(root, CONTAINER, OBJECT_PATH), 'utf8');
+    expect(written).toBe('hello from PUT');
+  });
+
+  it('PUT: read(GET) 서명으로는 거부된다(서명 공간 분리 — read capability로 write 불가)', async () => {
+    const { PUT } = await import('./route');
+    const exp = Date.now() + 60_000;
+    const readSig = signLocalObject(SECRET, CONTAINER, OBJECT_PATH, exp); // method 기본값 GET
+
+    const req = new Request(
+      url(`${CONTAINER}/${OBJECT_PATH}`, { exp: String(exp), sig: readSig }),
+      { method: 'PUT', body: 'malicious overwrite attempt' },
+    );
+    const res = await PUT(req as never, { params: Promise.resolve({ path: [CONTAINER, ...OBJECT_PATH.split('/')] }) });
+    expect(res.status).toBe(403);
+
+    await expect(readFile(join(root, CONTAINER, OBJECT_PATH), 'utf8')).rejects.toThrow();
+  });
+
+  it('PUT: 만료된 서명 → 403', async () => {
+    const { PUT } = await import('./route');
+    const exp = Date.now() - 1_000;
+    const sig = signLocalObject(SECRET, CONTAINER, OBJECT_PATH, exp, 'PUT');
+
+    const req = new Request(url(`${CONTAINER}/${OBJECT_PATH}`, { exp: String(exp), sig }), {
+      method: 'PUT',
+      body: 'x',
+    });
+    const res = await PUT(req as never, { params: Promise.resolve({ path: [CONTAINER, ...OBJECT_PATH.split('/')] }) });
+    expect(res.status).toBe(403);
+  });
+
+  it('PUT: STORAGE_PROVIDER != local → 404(표면 비노출)', async () => {
+    vi.stubEnv('STORAGE_PROVIDER', 'gcs');
+    vi.resetModules();
+    const { PUT } = await import('./route');
+    const exp = Date.now() + 60_000;
+    const sig = signLocalObject(SECRET, CONTAINER, OBJECT_PATH, exp, 'PUT');
+
+    const req = new Request(url(`${CONTAINER}/${OBJECT_PATH}`, { exp: String(exp), sig }), {
+      method: 'PUT',
+      body: 'x',
+    });
+    const res = await PUT(req as never, { params: Promise.resolve({ path: [CONTAINER, ...OBJECT_PATH.split('/')] }) });
+    expect(res.status).toBe(404);
+  });
+
+  it('GET: write(PUT) 서명으로는 거부된다(역방향도 분리 확認)', async () => {
+    const { GET } = await import('./route');
+    const exp = Date.now() + 60_000;
+    const writeSig = signLocalObject(SECRET, CONTAINER, OBJECT_PATH, exp, 'PUT');
+
+    const req = new Request(url(`${CONTAINER}/${OBJECT_PATH}`, { exp: String(exp), sig: writeSig }));
+    const res = await GET(req as never, { params: Promise.resolve({ path: [CONTAINER, ...OBJECT_PATH.split('/')] }) });
+    expect(res.status).toBe(403);
+  });
+
+  it('GET → PUT → GET 왕복: 쓴 걸 그대로 읽는다', async () => {
+    const { GET, PUT } = await import('./route');
+    const exp = Date.now() + 60_000;
+    const writeSig = signLocalObject(SECRET, CONTAINER, OBJECT_PATH, exp, 'PUT');
+    const putReq = new Request(url(`${CONTAINER}/${OBJECT_PATH}`, { exp: String(exp), sig: writeSig }), {
+      method: 'PUT',
+      body: 'roundtrip content',
+    });
+    const putRes = await PUT(putReq as never, { params: Promise.resolve({ path: [CONTAINER, ...OBJECT_PATH.split('/')] }) });
+    expect(putRes.status).toBe(200);
+
+    const readSig = signLocalObject(SECRET, CONTAINER, OBJECT_PATH, exp);
+    const getReq = new Request(url(`${CONTAINER}/${OBJECT_PATH}`, { exp: String(exp), sig: readSig }));
+    const getRes = await GET(getReq as never, { params: Promise.resolve({ path: [CONTAINER, ...OBJECT_PATH.split('/')] }) });
+    expect(getRes.status).toBe(200);
+    const body = Buffer.from(await getRes.arrayBuffer()).toString('utf8');
+    expect(body).toBe('roundtrip content');
+  });
+});

--- a/apps/web/src/app/api/storage/local/[...path]/route.ts
+++ b/apps/web/src/app/api/storage/local/[...path]/route.ts
@@ -56,3 +56,48 @@ export async function GET(
   };
   return new NextResponse(new Uint8Array(body), { status: 200, headers });
 }
+
+// story dc3d62f4(BE·스토리지·self-host, 부수 MEDIUM 처방) — BE `local.py::signed_write_url`가
+// PUT 서명 URL을 이미 발급하고 있었는데(`method=PUT` 쿼리·payload에 `PUT:` 접두어) 이 라우트엔
+// PUT 수신 핸들러 자체가 없어 self-host local 배포에서 업로드가 100% 실패했다. GET과 동일한
+// authz 원칙(신규 결정 0, 단기 HMAC 토큰만 검증) — method='PUT'로 검증해 GET 서명 재사용을
+// 차단한다(별개 시그니처 공간이라야 read capability로 write를 못 함).
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  if (STORAGE_PROVIDER !== 'local') {
+    return NextResponse.json({ error: { message: 'not found' } }, { status: 404 });
+  }
+
+  const { path } = await params;
+  if (!path || path.length < 2) {
+    return NextResponse.json({ error: { message: 'invalid path' } }, { status: 400 });
+  }
+  const container = path[0]!;
+  const objectPath = path.slice(1).join('/');
+
+  const { searchParams } = new URL(request.url);
+  const exp = Number(searchParams.get('exp'));
+  const sig = searchParams.get('sig') ?? '';
+
+  let secret: string;
+  try {
+    secret = resolveLocalSigningSecret();
+  } catch {
+    return NextResponse.json(
+      { error: { message: 'local storage signing not configured' } },
+      { status: 503 },
+    );
+  }
+
+  if (!verifyLocalObject(secret, container, objectPath, exp, sig, 'PUT')) {
+    return NextResponse.json({ error: { message: 'invalid or expired signature' } }, { status: 403 });
+  }
+
+  const body = Buffer.from(await request.arrayBuffer());
+  const contentType = request.headers.get('content-type') ?? undefined;
+  await new LocalDiskStorageService().putObject(container, objectPath, body, contentType);
+
+  return new NextResponse(null, { status: 200 });
+}

--- a/apps/web/src/lib/storage/local-sign.ts
+++ b/apps/web/src/lib/storage/local-sign.ts
@@ -6,31 +6,40 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 // authorize 게이트를 통과한 뒤에만 이 HMAC 토큰을 발급한다 → serve 라우트는 토큰 검증만 한다
 // (신규 authz surface 0·scope 우회 0). GCS V4 signed URL 과 동치(짧은 만료 capability URL).
 
-function payload(container: string, objectPath: string, exp: number): string {
-  return `${container}/${objectPath}:${exp}`;
+// story dc3d62f4(BE·스토리지·self-host, local PUT 부재 처방) — BE `local.py::signed_write_url`가
+// write 서명 payload에 `PUT:` 접두어를 이미 묶고 있었다(read와 같은 시그니처를 write에 재사용하지
+// 못하게). 그런데 이 FE 파일의 payload()는 method를 아예 몰라 GET/PUT을 구분 못 했다 — BE가
+// 발급한 write 서명은 여기서 절대 검증을 통과할 수 없는 상태였다(payload 문자열 자체가
+// 다르므로). method를 명시 인자로 받아 BE와 동일한 접두어 규칙을 따르게 한다.
+function payload(container: string, objectPath: string, exp: number, method: 'GET' | 'PUT' = 'GET'): string {
+  const base = `${container}/${objectPath}:${exp}`;
+  return method === 'PUT' ? `PUT:${base}` : base;
 }
 
-/** authorize 통과 후 발급되는 단기 서명. */
+/** authorize 통과 후 발급되는 단기 서명. method 기본값 GET(기존 read 호출부 무회귀). */
 export function signLocalObject(
   secret: string,
   container: string,
   objectPath: string,
   exp: number,
+  method: 'GET' | 'PUT' = 'GET',
 ): string {
-  return createHmac('sha256', secret).update(payload(container, objectPath, exp)).digest('hex');
+  return createHmac('sha256', secret).update(payload(container, objectPath, exp, method)).digest('hex');
 }
 
-/** serve 라우트의 토큰 검증(만료·서명 일치). 타이밍 세이프 비교. */
+/** serve 라우트의 토큰 검증(만료·서명 일치). 타이밍 세이프 비교. method 기본값 GET —
+ * write(PUT) 서명을 검증하려면 method='PUT'을 명시해야 한다(GET 서명으로 PUT 인가 금지). */
 export function verifyLocalObject(
   secret: string,
   container: string,
   objectPath: string,
   exp: number,
   sig: string,
+  method: 'GET' | 'PUT' = 'GET',
 ): boolean {
   if (!secret || !sig) return false;
   if (!Number.isFinite(exp) || exp < Date.now()) return false;
-  const expected = signLocalObject(secret, container, objectPath, exp);
+  const expected = signLocalObject(secret, container, objectPath, exp, method);
   const a = Buffer.from(expected, 'utf8');
   const b = Buffer.from(sig, 'utf8');
   if (a.length !== b.length) return false;

--- a/apps/web/src/lib/storage/storage.test.ts
+++ b/apps/web/src/lib/storage/storage.test.ts
@@ -34,6 +34,24 @@ describe('local-sign HMAC', () => {
     const sig = signLocalObject(secret, container, path, exp);
     expect(verifyLocalObject(secret, container, 'chat/p1/c1/other.png', exp, sig)).toBe(false);
   });
+
+  // story dc3d62f4 — BE local.py::signed_write_url이 write payload에 PUT: 접두어를 이미
+  // 묶고 있었는데(read와 시그니처 공간을 분리하려는 의도) 이 FE 파일이 method를 몰라 그
+  // 의도가 실제로는 전혀 구현이 안 돼 있었다(read 서명 payload와 완전히 같은 문자열이었다면
+  // read 토큰으로 write도 통과했을 것). method 인자 도입 후 read/write 시그니처가 실제로
+  // 갈리는지 고정.
+  it('method=PUT 서명은 method=GET(기본값)으로 검증 실패(시그니처 공간 분리)', () => {
+    const exp = Date.now() + 60_000;
+    const writeSig = signLocalObject(secret, container, path, exp, 'PUT');
+    expect(verifyLocalObject(secret, container, path, exp, writeSig)).toBe(false);
+    expect(verifyLocalObject(secret, container, path, exp, writeSig, 'PUT')).toBe(true);
+  });
+
+  it('method=GET 서명은 method=PUT으로 검증 실패(역방향도 분리)', () => {
+    const exp = Date.now() + 60_000;
+    const readSig = signLocalObject(secret, container, path, exp, 'GET');
+    expect(verifyLocalObject(secret, container, path, exp, readSig, 'PUT')).toBe(false);
+  });
 });
 
 describe('LocalDiskStorageService roundtrip', () => {

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -574,9 +574,11 @@ class AssetUploadUrlResponse(BaseModel):
     upload_url: str
     object_path: str
     expires_at: datetime
-    # story #3249(카디르/codex HIGH 후속) — create-only 서명(x-goog-if-generation-match: 0)이
-    # PUT 요청에도 정확히 실려야 서명이 valid함(GCS가 헤더를 서명 바인딩에 포함) — FE는 이 헤더를
-    # 그대로 PUT에 붙여야 한다(안 붙이면 403). 응답에 명시해 FE가 하드코딩 대신 서버 계약을 따르게.
+    # story #3249/dc3d62f4 — create-only 서명(GCS: x-goog-if-generation-match·S3/MinIO:
+    # If-None-Match)이 PUT 요청에도 정확히 실려야 서명이 valid함(provider가 헤더를 서명
+    # 바인딩에 포함) — FE는 이 헤더를 그대로 PUT에 붙여야 한다(안 붙이면 서명 불일치).
+    # provider별로 이름이 다르므로 여기 하드코딩하지 않고 provider.required_write_headers()가
+    # 채운다(아래 호출부).
     required_put_headers: dict[str, str] = {}
 
 
@@ -622,7 +624,8 @@ async def create_asset_upload_url(
 
     from app.services.storage import get_storage_provider
 
-    upload_url = await get_storage_provider().signed_write_url(
+    provider = get_storage_provider()
+    upload_url = await provider.signed_write_url(
         DEFAULT_CONTAINER, object_path, ttl=_ASSET_UPLOAD_URL_TTL, content_type=body.content_type,
         create_only=True,
     )
@@ -631,7 +634,10 @@ async def create_asset_upload_url(
     return AssetUploadUrlResponse(
         upload_url=upload_url, object_path=object_path,
         expires_at=datetime.now(timezone.utc) + _ASSET_UPLOAD_URL_TTL,
-        required_put_headers={"x-goog-if-generation-match": "0"},
+        # story dc3d62f4 — provider별 조건부 헤더 이름이 다르다(GCS: x-goog-if-generation-match·
+        # S3/MinIO: If-None-Match). 하드코딩하면 self-host가 S3/MinIO로 배포됐을 때 FE에 틀린
+        # 헤더 계약을 내려줘 서명 불일치로 PUT 자체가 깨진다 — provider에게 직접 물어본다.
+        required_put_headers=provider.required_write_headers(create_only=True),
     )
 
 

--- a/backend/app/services/storage/base.py
+++ b/backend/app/services/storage/base.py
@@ -43,6 +43,15 @@ class StorageProvider(abc.ABC):
         유지 — avatar/canvas 등 기존 호출부는 인자 안 넘기면 기존 동작 그대로(무회귀)."""
 
     @abc.abstractmethod
+    def required_write_headers(self, *, create_only: bool = False) -> dict[str, str]:
+        """create_only=True인 signed_write_url의 PUT에 클라이언트가 반드시 실어야 하는 헤더 —
+        조건부 쓰기를 서명에 바인딩하는 방식이 provider마다 이름이 다르다(GCS는
+        `x-goog-if-generation-match`, S3/MinIO는 `If-None-Match`). story dc3d62f4 — 호출부
+        (assets.py 등)가 이 헤더를 하드코딩하면 provider가 바뀌어도 응답이 안 바뀌어 실제완
+        다른 provider로 배포된 self-host가 FE에 틀린 헤더 계약을 내려준다(서명 불일치로
+        PUT 자체가 깨짐). 순수함수(I/O 없음) — provider 인스턴스의 정적 속성일 뿐이라 sync."""
+
+    @abc.abstractmethod
     async def delete_object(self, container: str, object_path: str) -> bool:
         """객체 hard-delete(S8 grace cron). 이미 없으면 True(멱등)·실패 시 False(best-effort·호출부 계속)."""
 

--- a/backend/app/services/storage/gcs.py
+++ b/backend/app/services/storage/gcs.py
@@ -91,6 +91,9 @@ class GcsStorageProvider(StorageProvider):
             logger.warning("gcs storage: signed write url 생성 실패 path=%s", object_path, exc_info=True)
             return None
 
+    def required_write_headers(self, *, create_only: bool = False) -> dict[str, str]:
+        return {"x-goog-if-generation-match": "0"} if create_only else {}
+
     async def delete_object(self, container: str, object_path: str) -> bool:
         def _blocking() -> bool:
             from google.cloud import storage

--- a/backend/app/services/storage/local.py
+++ b/backend/app/services/storage/local.py
@@ -112,6 +112,9 @@ class LocalStorageProvider(StorageProvider):
             logger.warning("local storage: signed write url 생성 실패 path=%s", object_path, exc_info=True)
             return None
 
+    def required_write_headers(self, *, create_only: bool = False) -> dict[str, str]:
+        return {}  # local PUT 수신 자체가 미구현(story dc3d62f4 부수 MEDIUM, 별도 후속) — 헤더 계약 없음.
+
     async def delete_object(self, container: str, object_path: str) -> bool:
         def _blocking() -> bool:
             _resolve_safe(container, object_path).unlink(missing_ok=True)  # 없어도 OK = 멱등

--- a/backend/app/services/storage/s3.py
+++ b/backend/app/services/storage/s3.py
@@ -1,6 +1,7 @@
 """S3(및 minio 호환) storage provider. `boto3` 는 이 모듈에서만 lazy import
-(STORAGE_PROVIDER=s3 일 때만 로드). minio = S3_ENDPOINT override. 범위 = AC2 "동작"(prod 미가동).
-env 는 호출 시점 read(테스트 setenv 정합).
+(STORAGE_PROVIDER=s3 일 때만 로드). minio = S3_ENDPOINT override. self-host(OSS) 배포의 정식
+1급 provider — 우리 SaaS(dev/prod)는 GCS를 쓰므로 이 provider 자체는 여기서 미가동이지만
+dead code 아님(story dc3d62f4, #3254 재확認). env 는 호출 시점 read(테스트 setenv 정합).
 """
 from __future__ import annotations
 
@@ -16,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 def _client():
     import boto3  # 지연 import(provider=s3 일 때만)
+    from botocore.config import Config
 
     kwargs: dict = {}
     region = os.environ.get("S3_REGION")
@@ -29,6 +31,11 @@ def _client():
     if access_key and secret_key:
         kwargs["aws_access_key_id"] = access_key
         kwargs["aws_secret_access_key"] = secret_key
+    # story dc3d62f4 — SigV4 명시 강제. boto3가 리전(특히 us-east-1)에 따라 SigV2로 조용히
+    # 떨어지면 아래 signed_write_url의 IfNoneMatch가 서명에 안 묶인다(직접 실측: SigV2
+    # 프리사인 URL엔 조건부 헤더가 아예 안 실림 — "서명은 됐는데 조건은 서버가 검증 안 함"이
+    # 되어 create_only=True가 조용히 무력화된다). MinIO도 SigV4 전제라 이 강제가 둘 다 해결.
+    kwargs["config"] = Config(signature_version="s3v4")
     return boto3.client("s3", **kwargs)
 
 
@@ -60,21 +67,25 @@ class S3StorageProvider(StorageProvider):
         self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None,
         create_only: bool = False,
     ) -> str | None:
-        """create_only: 카디르/codex 재발견(story #3249 2라운드) — S3/MinIO는 self-host 배포의
-        정식 1급 provider(factory.py, dead code 아님)라 create_only=True를 조용히 no-op하면
-        "create-only 보호가 있다"는 거짓 보장이 된다(cap 우회 재현 가능). 실제 조건부-쓰기
-        (If-None-Match) 구현 전까지는 **fail-closed** — URL을 아예 미발급(None, 호출부가 502로
-        거부)한다. 진짜 구현은 story dc3d62f4 별건."""
-        if create_only:
-            logger.warning(
-                "s3 storage: create_only 미지원 — URL 미발급(fail-closed) path=%s", object_path
-            )
-            return None
+        """create_only: story #3249(카디르/codex HIGH) 처방을 GCS와 동형으로 실구현(story
+        dc3d62f4) — gcs.py가 `x-goog-if-generation-match: 0`을 서명에 묶는 것과 동형으로,
+        여기선 `If-None-Match: *`(AWS S3 조건부 쓰기, PutObject 표준 파라미터 — boto3
+        operation model에 `IfNoneMatch`→헤더 `If-None-Match`로 실측 확認)를 서명에 묶는다.
+        "객체가 아직 없을 때만 생성" 조건이 presigned URL 자체에 바인딩돼, 같은 URL로 재PUT하면
+        412 Precondition Failed로 거부된다(cap 우회 재PUT 체인 차단, GCS와 동일 방어).
+
+        ⚠️SigV4 강제가 전제(위 `_client()`) — SigV2로 서명하면 `IfNoneMatch`가 조용히
+        시그니처 밖으로 빠져(직접 실측: SigV2 프리사인 URL의 쿼리스트링엔 조건부 헤더 흔적이
+        아예 없음) "서명은 유효한데 조건은 서버가 검증 안 하는" 무력화된 create_only가 된다
+        — 이게 원래 no-op 결함과 같은 결과를 조용히 재현하는 자리라 SigV4 강제 없이 이 분기만
+        추가하면 안 됨."""
 
         def _blocking() -> str:
             params: dict = {"Bucket": container, "Key": object_path}
             if content_type:
                 params["ContentType"] = content_type
+            if create_only:
+                params["IfNoneMatch"] = "*"
             return _client().generate_presigned_url(
                 "put_object", Params=params, ExpiresIn=int(ttl.total_seconds()),
             )
@@ -84,6 +95,9 @@ class S3StorageProvider(StorageProvider):
         except Exception:
             logger.warning("s3 storage: signed write url 생성 실패 path=%s", object_path, exc_info=True)
             return None
+
+    def required_write_headers(self, *, create_only: bool = False) -> dict[str, str]:
+        return {"If-None-Match": "*"} if create_only else {}
 
     async def delete_object(self, container: str, object_path: str) -> bool:
         def _blocking() -> bool:

--- a/backend/tests/test_3249_asset_upload_endpoints.py
+++ b/backend/tests/test_3249_asset_upload_endpoints.py
@@ -56,6 +56,10 @@ def _mock_storage(monkeypatch):
     prov = MagicMock()
     prov.head_object = AsyncMock(side_effect=_head)
     prov.signed_write_url = AsyncMock(side_effect=_signed_write)
+    # story dc3d62f4 — required_write_headers는 provider별 실 반환값이 있어야 한다(MagicMock
+    # 기본값은 Mock 객체라 Pydantic dict[str,str] 검증에 안 맞음). 이 파일은 GCS 배포를
+    # 가정하고 작성됐으니 GCS 실제 반환값과 동일하게 고정.
+    prov.required_write_headers = MagicMock(return_value={"x-goog-if-generation-match": "0"})
     monkeypatch.setattr(_storage_mod, "get_storage_provider", lambda: prov)
     yield
 

--- a/backend/tests/test_storage_provider.py
+++ b/backend/tests/test_storage_provider.py
@@ -149,16 +149,86 @@ async def test_gcs_signed_write_url_binds_create_only_header(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_s3_signed_write_url_create_only_fails_closed():
-    """story #3249 2라운드(카디르/codex) — S3는 self-host 1급 provider(dead code 아님)인데
-    create_only=True를 실제로 강제 못 하면서 조용히 URL을 내주면 "create-only 보호가 있다"는
-    거짓 보장이 된다(cap 우회 재현). 진짜 구현(If-None-Match) 전까진 URL 자체를 미발급해야
-    한다(호출부가 502로 거부 — silent 성공 금지). create_only=False(기본)는 기존 동작 무회귀."""
+async def test_s3_client_forces_sigv4(monkeypatch):
+    """story dc3d62f4 — SigV4 강제가 IfNoneMatch 바인딩의 전제(실측: SigV2 프리사인 URL은
+    조건부 헤더가 서명 밖으로 조용히 빠짐 — signature_version 미지정이면 리전에 따라 SigV2로
+    떨어질 수 있어 이 강제가 없으면 아래 테스트가 우연히 통과해도 실 배포에서 재발할 수
+    있다)."""
+    import boto3
+
+    from app.services.storage.s3 import _client
+
+    captured: dict = {}
+    real_client = boto3.client
+
+    def _spy(*args, **kwargs):
+        captured.update(kwargs)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(boto3, "client", _spy)
+    _client()
+    assert captured["config"].signature_version == "s3v4"
+
+
+@pytest.mark.anyio
+async def test_s3_signed_write_url_binds_create_only_if_none_match(monkeypatch):
+    """story dc3d62f4 — create_only=True면 `IfNoneMatch: "*"`(→ `If-None-Match` 헤더)가
+    generate_presigned_url의 Params에 실제로 실려야 한다(boto3 PutObject operation model
+    실측 확認: IfNoneMatch→header `If-None-Match`, SigV4 서명에 바인딩됨 — GCS의
+    x-goog-if-generation-match:0과 동형 방어). create_only=False(기본, 무회귀)면 실리지
+    않아야 한다."""
+    captured: list[dict] = []
+
+    class _FakeClient:
+        def generate_presigned_url(self, operation, *, Params, ExpiresIn):
+            captured.append(Params)
+            return "https://signed.example/fake"
+
+    from app.services.storage import s3 as s3_module
+
+    monkeypatch.setattr(s3_module, "_client", lambda: _FakeClient())
+
     provider = S3StorageProvider()
+
     url = await provider.signed_write_url(
         "bucket", "obj/path", ttl=timedelta(minutes=10), content_type="image/png", create_only=True,
     )
-    assert url is None
+    assert url == "https://signed.example/fake"
+    assert captured[-1].get("IfNoneMatch") == "*"
+
+    captured.clear()
+    await provider.signed_write_url(
+        "bucket", "obj/path", ttl=timedelta(minutes=10), content_type="image/png",
+    )
+    assert "IfNoneMatch" not in captured[-1]  # 기본값(무회귀) — 조건 바인딩 없음.
+
+
+@pytest.mark.anyio
+async def test_s3_signed_write_url_create_only_actually_rejects_replay(monkeypatch):
+    """story dc3d62f4 통합 pin — 실 boto3(fake 자격증명, 오프라인 서명만)로 프리사인 URL을
+    실제로 생성해 `X-Amz-SignedHeaders`에 `if-none-match`가 포함되는지 확認한다(단위 mock이
+    아니라 boto3 자체의 서명 동작 — «서명은 됐는데 조건이 실제로 안 실린» 무력화 재발을
+    가장 직접적으로 잡는 층). `_client()`가 실제로 읽는 env var(S3_ACCESS_KEY_ID 계열)로
+    스코프 한정 — AWS_* 표준 env를 오염시키지 않는다."""
+    monkeypatch.setenv("S3_ACCESS_KEY_ID", "AKIAFAKE")
+    monkeypatch.setenv("S3_SECRET_ACCESS_KEY", "fakefakefakefakefakefakefakefakefakefake")
+    monkeypatch.setenv("S3_REGION", "us-east-1")
+
+    provider = S3StorageProvider()
+    url = await provider.signed_write_url(
+        "bucket", "obj/path", ttl=timedelta(minutes=10), create_only=True,
+    )
+    assert url is not None
+    assert "X-Amz-SignedHeaders=" in url
+    signed_headers = url.split("X-Amz-SignedHeaders=")[1].split("&")[0]
+    assert "if-none-match" in signed_headers.lower()
+
+    url_no_create_only = await provider.signed_write_url(
+        "bucket", "obj/path", ttl=timedelta(minutes=10),
+    )
+    assert url_no_create_only is not None
+    signed_headers_2 = url_no_create_only.split("X-Amz-SignedHeaders=")[1].split("&")[0]
+    assert "if-none-match" not in signed_headers_2.lower()
 
 
 @pytest.mark.anyio
@@ -175,6 +245,19 @@ async def test_local_signed_write_url_create_only_fails_closed(monkeypatch):
         "bucket", "obj/path", ttl=timedelta(minutes=10), content_type="image/png",
     )
     assert url2 is not None
+
+
+def test_required_write_headers_are_provider_specific_not_hardcoded():
+    """story dc3d62f4 — assets.py가 GCS 헤더를 하드코딩했었다(응답이 provider 무관하게
+    항상 x-goog-if-generation-match). provider가 바뀌면 응답도 바뀌어야 한다 — 그래야
+    self-host가 S3/MinIO로 배포됐을 때 FE가 맞는 헤더를 PUT에 실을 수 있다."""
+    assert GcsStorageProvider().required_write_headers(create_only=True) == {
+        "x-goog-if-generation-match": "0"
+    }
+    assert GcsStorageProvider().required_write_headers(create_only=False) == {}
+    assert S3StorageProvider().required_write_headers(create_only=True) == {"If-None-Match": "*"}
+    assert S3StorageProvider().required_write_headers(create_only=False) == {}
+    assert LocalStorageProvider().required_write_headers(create_only=True) == {}
 
 
 async def test_local_download_blocks_path_traversal(monkeypatch, tmp_path):


### PR DESCRIPTION
story #3254(dc3d62f4, BE·스토리지·self-host). PR#3637(story #3249) 2라운드 QA에서 발견 — S3/MinIO는 self-host 정식 1급 provider인데 create_only가 조용히 no-op(거짓 create-only 보장, cap 우회 100% 재현). 이 PR이 3갈래 처방 전부(HIGH+LOW+MEDIUM) 완결.

## HIGH — S3/MinIO create-only 실구현
- `s3.py::signed_write_url`: `create_only=True`면 `IfNoneMatch: "*"`를 presigned URL에 바인딩(boto3 PutObject operation model 실측 확認) — GCS의 `x-goog-if-generation-match: 0`과 동형 방어.
- `_client()`: `Config(signature_version="s3v4")` 명시 강제. **실측으로 잡은 숨은 함정**: SigV4 미지정 시 boto3가 리전 따라 SigV2로 조용히 떨어질 수 있고, SigV2 프리사인 URL은 조건부 헤더가 서명 밖으로 완전히 빠진다 — 이거 없이 IfNoneMatch만 추가했으면 "서명은 유효한데 조건은 서버가 검증 안 하는" 방식으로 원래 사고가 조용히 재발했을 것.

## LOW — required_put_headers 일반화
`assets.py`가 provider 무관하게 항상 GCS 전용 헤더를 하드코딩 — `StorageProvider.required_write_headers(create_only)` 추상 메서드 신설(3개 provider 각자 구현), 라우터가 하드코딩 대신 provider에게 물어보게 교체.

## MEDIUM — local provider PUT 실구현
BE `local.py::signed_write_url`은 이미 PUT 서명 URL을 발급하고 있었는데 FE `route.ts`에 PUT 수신 핸들러 자체가 없어 self-host local 배포 업로드가 100% 실패. **부수 발견** — BE/FE 서명 계약 자체가 어긋나 있었다: BE의 write payload(`PUT:{container}/{path}:{exp}`)는 read와 다른 문자열인데 FE `local-sign.ts`는 method를 몰라 항상 같은 문자열로 서명 계산 — PUT 핸들러를 그냥 기존 verify로 만들었으면 BE 발급 write 서명은 영원히 검증 실패했을 것. `signLocalObject`/`verifyLocalObject`에 `method` 인자 추가해 BE와 동형 규칙으로 정정 후 PUT 핸들러 신설(GET과 동일 authz 원칙, method='PUT' 검증으로 GET 서명 재사용 차단).

## 검증
- BE: 신규/재작성 pin 5건 + 뮤테이션 자가검증 2회(SigV4 강제·IfNoneMatch 바인딩 각각 제거 → 정확한 대상 RED) + 관련 realdb 66건 PASS
- FE: 신규 pin 8건 + 뮤테이션 자가검증(method 접두어 분리 제거 → 양방향 서명 재사용 취약점 4건 정확히 RED) + apps/web 전체 551 files/5151 tests PASS + tsc --noEmit 클린

## 경계
self-host(OSS) 배포 옵션 한정 — 우리 SaaS(dev/prod=GCS)는 무영향.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_019rkXVqy2DF1aAN7szuqp44