### PR TITLE
[SID:3288] 축2-ⓐ 레시피 apply 계층 — recipe_role_bindings + routing kind 신설

### DIFF
--- a/backend/alembic/versions/0296_recipe_role_bindings.py
+++ b/backend/alembic/versions/0296_recipe_role_bindings.py
@@ -1,0 +1,64 @@
+"""story #3288(도메인탈고정 축2-ⓐ) — recipe_role_bindings 신설: EventDefinition.stage_metadata
+의 role(현재 표시 텍스트뿐)을 실제 org/project의 TeamMember(에이전트)에 바인딩해, routing
+해석기(event_routing_resolver.py)가 발행 시점에 "이 stage는 실제로 누구인가"를 조회할 수 있게
+한다. AgentRoutingRule 재사용은 폐기(doc axis2-recipe-mechanism-event-definitions-design 참고
+— rule_evaluator.py가 구세대 trigger 어휘 전용이라 신세대 트리거를 아예 못 읽음).
+
+project_id nullable — NULL은 org 전역 바인딩(모든 project 적용), NOT NULL은 그 project 전용
+(조회 시 project 특이성이 org 전역보다 우선 — WebhookConfig의 project_id-nullable-scope
+패턴과 동형).
+
+Revision ID: 0296
+Revises: 0295
+Create Date: 2026-09-01
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0296"
+down_revision = "0295"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "recipe_role_bindings",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("event_definition_key", sa.Text, nullable=False),
+        sa.Column("stage", sa.Text, nullable=False),
+        sa.Column("agent_member_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("created_by", UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_recipe_role_bindings_org_id", "recipe_role_bindings", ["org_id"])
+    op.create_index("ix_recipe_role_bindings_project_id", "recipe_role_bindings", ["project_id"])
+    op.create_index(
+        "ix_recipe_role_bindings_lookup", "recipe_role_bindings",
+        ["org_id", "event_definition_key", "stage"],
+    )
+    # NULLS NOT DISTINCT 미지원(PG16 이하 호환) — project_id NULL(org 전역)은 org당 1개만
+    # 허용하려는 의도지만, 표준 UNIQUE 제약은 NULL끼리 서로 다르다고 봐 여러 org-전역 행이
+    # 통과해버린다(재적용 시 upsert가 새 행을 또 만듦). 부분 unique index 2개로 분리해
+    # "NULL(org 전역)은 org당 1개"와 "NOT NULL(project 특이성)은 (org,project,key,stage)당
+    # 1개"를 각각 강제한다.
+    op.create_index(
+        "uq_recipe_role_bindings_org_scope", "recipe_role_bindings",
+        ["org_id", "event_definition_key", "stage"],
+        unique=True, postgresql_where=sa.text("project_id IS NULL"),
+    )
+    op.create_index(
+        "uq_recipe_role_bindings_project_scope", "recipe_role_bindings",
+        ["org_id", "project_id", "event_definition_key", "stage"],
+        unique=True, postgresql_where=sa.text("project_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("recipe_role_bindings")

--- a/backend/alembic/versions/0297_recipe_role_bindings.py
+++ b/backend/alembic/versions/0297_recipe_role_bindings.py
@@ -8,9 +8,14 @@ project_id nullable — NULL은 org 전역 바인딩(모든 project 적용), NOT
 (조회 시 project 특이성이 org 전역보다 우선 — WebhookConfig의 project_id-nullable-scope
 패턴과 동형).
 
-Revision ID: 0296
-Revises: 0295
+Revision ID: 0297
+Revises: 0296
 Create Date: 2026-09-01
+
+⚠️ 마이그 번호 조정(2026-09-01, PO 조율) — 원래 0296으로 작성했으나 PR#3685(축1·
+0296_org_domain_label)가 먼저 그 번호를 썼다(둘 다 develop 최신 0295에서 분기한 형제
+충돌). 3685가 먼저 develop에 착지하므로 이쪽을 0297로 밀고 down_revision을 0296(3685의
+번호)으로 체인.
 """
 from __future__ import annotations
 
@@ -18,8 +23,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects.postgresql import UUID
 
-revision = "0296"
-down_revision = "0295"
+revision = "0297"
+down_revision = "0296"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -104,6 +104,7 @@ from app.models.participation import Participation, ParticipationRole
 from app.models.chain_escalation_org_config import ChainEscalationOrgConfig
 from app.models.chain_circuit_breaker import ChainCircuitBreaker
 from app.models.event_definition import EventDefinition
+from app.models.recipe_role_binding import RecipeRoleBinding
 
 __all__ = [
     "RoleTemplate",

--- a/backend/app/models/recipe_role_binding.py
+++ b/backend/app/models/recipe_role_binding.py
@@ -1,0 +1,54 @@
+"""story #3288(축2-ⓐ) — 레시피 apply 계층. `EventDefinition.stage_metadata[stage].role`은
+순수 표시 텍스트라(온보딩 가이드 렌더러 전용), 실제로 "이 org/project에서 이 stage는 누구인가"를
+routing 해석기(event_routing_resolver.py)가 조회할 자리가 없었다 — 이 얇은 바인딩 테이블이 그
+자리다.
+
+⚠️ AgentRoutingRule 재사용은 폐기된 설계(doc axis2-recipe-mechanism-event-definitions-design
+§설계정정 참고) — rule_evaluator.py가 trigger_type_slugs/memo_type/event_params(구세대 어휘)만
+읽어 EventDefinition.key/stage를 조건에 넣어도 절대 안 읽는다. 신세대 "자동화"는 side-effect
+자동집행이 아니라 "알림→에이전트가 action을 지시로 읽고 스스로 행동"이므로, 필요한 건 라우팅
+해석기가 참조할 이 바인딩 테이블뿐(자동화 엔진 이식 불요).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class RecipeRoleBinding(Base):
+    __tablename__ = "recipe_role_bindings"
+    __table_args__ = (
+        # 표준 UNIQUE는 NULL끼리 서로 다르다고 봐(NULLS DISTINCT 기본), project_id=NULL(org
+        # 전역) 행이 여러 개 통과해버린다 — 부분 unique index 2개로 분리(EventDefinition의
+        # uq_event_definitions_preset_key/org_key와 동형 패턴).
+        Index(
+            "uq_recipe_role_bindings_org_scope", "org_id", "event_definition_key", "stage",
+            unique=True, postgresql_where=text("project_id IS NULL"),
+        ),
+        Index(
+            "uq_recipe_role_bindings_project_scope", "org_id", "project_id", "event_definition_key", "stage",
+            unique=True, postgresql_where=text("project_id IS NOT NULL"),
+        ),
+        Index("ix_recipe_role_bindings_lookup", "org_id", "event_definition_key", "stage"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    # NULL = org 전역 바인딩(모든 project에 적용). NOT NULL = 그 project 전용(우선순위 高).
+    project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    event_definition_key: Mapped[str] = mapped_column(Text, nullable=False)
+    stage: Mapped[str] = mapped_column(Text, nullable=False)
+    agent_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1181,9 +1181,11 @@ async def _publish_registry_event_core(
     try:
         escalation_ids = await resolve_routing_leg(
             definition.routing["escalation"], payload=payload, org_id=org_id, db=db,
+            definition_key=definition.key,
         )
         broadcast_ids = await resolve_routing_leg(
             definition.routing["broadcast"], payload=payload, org_id=org_id, db=db,
+            definition_key=definition.key,
         )
     except (MissingRoutingPayloadFieldError, InvalidWorkItemReferenceError, UnknownRoutingMemberError) as e:
         raise HTTPException(
@@ -1924,6 +1926,111 @@ async def update_event_definition(
     await db.commit()
     await db.refresh(definition)
     return _event_definition_detail(definition)
+
+
+class ApplyRecipeRoleBindingsRequest(BaseModel):
+    project_id: uuid.UUID | None = None
+    # story #3288(축2-ⓐ) — stage_slug → TeamMember.id(str). None project_id = org 전역
+    # 바인딩(모든 project 적용, 특정 project 바인딩이 있으면 그쪽이 우선 — 조회는
+    # event_routing_resolver.py의 project-먼저 순서로 이미 강제).
+    role_mapping: dict[str, str]
+
+
+class ApplyRecipeRoleBindingsResponse(BaseModel):
+    ok: bool
+    bindings_upserted: int
+
+
+@router.post(
+    "/definitions/{definition_id}/apply", response_model=ApplyRecipeRoleBindingsResponse, status_code=201,
+)
+async def apply_recipe_role_bindings(
+    definition_id: uuid.UUID,
+    body: ApplyRecipeRoleBindingsRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> ApplyRecipeRoleBindingsResponse:
+    """POST /api/v2/events/definitions/{id}/apply — story #3288(축2-ⓐ).
+
+    구 `workflow_templates.py::apply_template`의 검증 체인을 이식(생성 로직 자체는 폐기 —
+    doc axis2-recipe-mechanism-event-definitions-design §설계정정 참고, AgentRoutingRule을
+    만들지 않고 recipe_role_bindings에 upsert만 한다):
+    ①project_id 지정 시 has_project_access 선검증(SEC-S8 CRITICAL 재발 방지 — 이 사고가 난
+    그 자리) ②role_mapping 키 집합이 정의의 stage_metadata.keys()(=사실상 stage enum) ⊇
+    하는지 검증 ③agent_id가 실제로 이 org의 TeamMember인지 검증.
+    """
+    from app.models.event_definition import EventDefinition
+    from app.models.recipe_role_binding import RecipeRoleBinding
+    from app.models.team import TeamMember
+    from app.services.project_auth import has_project_access
+
+    if body.project_id is not None:
+        if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
+            raise HTTPException(status_code=404, detail="Project not found")
+
+    definition = (await db.execute(
+        select(EventDefinition).where(
+            EventDefinition.id == definition_id,
+            or_(EventDefinition.org_id == org_id, EventDefinition.org_id.is_(None)),
+        )
+    )).scalar_one_or_none()
+    if definition is None:
+        raise HTTPException(status_code=404, detail="event definition not found")
+
+    valid_stages = set(definition.stage_metadata.keys())
+    unknown_stages = sorted(set(body.role_mapping.keys()) - valid_stages)
+    if unknown_stages:
+        raise HTTPException(
+            status_code=422,
+            detail=f"role_mapping에 이 정의의 stage_metadata에 없는 stage가 있습니다: {unknown_stages}",
+        )
+
+    agent_ids = {uuid.UUID(v) for v in body.role_mapping.values()}
+    valid_agents = set((await db.execute(
+        select(TeamMember.id).where(TeamMember.id.in_(agent_ids), TeamMember.org_id == org_id)
+    )).scalars().all())
+    missing_agents = [v for v in body.role_mapping.values() if uuid.UUID(v) not in valid_agents]
+    if missing_agents:
+        raise HTTPException(
+            status_code=422,
+            detail=f"agent(s) not found in this org: {missing_agents}",
+        )
+
+    actor_id: uuid.UUID | None = None
+    try:
+        actor_id = uuid.UUID(str(auth.user_id))
+    except Exception:
+        pass
+
+    # SQL NULL은 `= NULL`로 안 잡힌다(IS NULL 필요) — project_id 스코프 절을 조건부로 구성.
+    project_scope_clause = (
+        RecipeRoleBinding.project_id.is_(None) if body.project_id is None
+        else RecipeRoleBinding.project_id == body.project_id
+    )
+
+    upserted = 0
+    for stage, agent_id_str in body.role_mapping.items():
+        agent_id = uuid.UUID(agent_id_str)
+        existing = (await db.execute(
+            select(RecipeRoleBinding).where(
+                RecipeRoleBinding.org_id == org_id,
+                project_scope_clause,
+                RecipeRoleBinding.event_definition_key == definition.key,
+                RecipeRoleBinding.stage == stage,
+            )
+        )).scalar_one_or_none()
+        if existing is not None:
+            existing.agent_member_id = agent_id
+        else:
+            db.add(RecipeRoleBinding(
+                org_id=org_id, project_id=body.project_id, event_definition_key=definition.key,
+                stage=stage, agent_member_id=agent_id, created_by=actor_id,
+            ))
+        upserted += 1
+
+    await db.commit()
+    return ApplyRecipeRoleBindingsResponse(ok=True, bindings_upserted=upserted)
 
 
 class EventPublishHistoryItem(BaseModel):

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1963,11 +1963,12 @@ async def apply_recipe_role_bindings(
     from app.models.event_definition import EventDefinition
     from app.models.recipe_role_binding import RecipeRoleBinding
     from app.models.team import TeamMember
-    from app.services.project_auth import has_project_access
+    from app.services.project_auth import require_project_access
 
     if body.project_id is not None:
-        if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
-            raise HTTPException(status_code=404, detail="Project not found")
+        # story #2697 SSOT — require_project_access로 수렴(raw inline has_project_access+raise
+        # 패턴 신규 추가 금지, 카디르 QA #3686 적발). 실패 시 항상 404(존재 비노출).
+        await require_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id, not_found_detail="Project not found")
 
     definition = (await db.execute(
         select(EventDefinition).where(

--- a/backend/app/services/event_definition_registry.py
+++ b/backend/app/services/event_definition_registry.py
@@ -31,7 +31,12 @@ _SEGMENT_CHARSET_RE = re.compile(r"^[a-z0-9_]+$")
 # 하므로, 여기 없는 target을 server_derived로 등록하면 해석기가 절대 못 푸는 정의가 만들어진다
 # — validate_event_routing이 등록 시점에 막는다(발행 시점에야 발견되는 것보다 이르게).
 SERVER_DERIVED_TARGETS = frozenset({"none", "work_item_stakeholders", "goal_owner"})
-_ROUTING_KINDS = frozenset({"payload_field", "server_derived"})
+# story #3288(축2-ⓐ) — "recipe_role_binding": 사이클형 정의의 stage를 recipe_role_bindings
+# 테이블(org/project 스코프 role→agent 바인딩)로 조회해 푸는 3번째 kind. payload_field처럼
+# payload의 필드를 직접 읽지도, server_derived처럼 고정 닫힌 어휘로 파생하지도 않는다 —
+# stage 자체가 payload에 있고(사이클형 정의 표준 필드) 그 stage로 org/project 스코프
+# 바인딩 테이블을 찾는 3번째 해석 방식(event_routing_resolver.py가 실 구현).
+_ROUTING_KINDS = frozenset({"payload_field", "server_derived", "recipe_role_binding"})
 
 
 class InvalidEventDefinitionKeyError(ValueError):
@@ -126,6 +131,18 @@ def _validate_routing_leg(leg: dict, *, leg_name: str, allow_server_derived: boo
         if not leg.get("member_id_field"):
             raise InvalidEventRoutingError(
                 f"routing.{leg_name}.kind='payload_field'는 member_id_field가 필수입니다."
+            )
+        return
+
+    if kind == "recipe_role_binding":
+        # story #3288 — member_id_field/target 둘 다 불요(payload의 stage로 org/project
+        # 스코프 바인딩 테이블을 조회하는 게 해석 방식 전체). org 커스텀 정의도 등록 가능
+        # (자기 org의 바인딩 테이블만 조회하므로 payload_field와 동형 위험도 — server_derived의
+        # "서버가 모르는 파생 역할" 우려와 다른 클래스).
+        if leg.get("member_id_field") or leg.get("target"):
+            raise InvalidEventRoutingError(
+                f"routing.{leg_name}.kind='recipe_role_binding'은 member_id_field/target을 "
+                "가질 수 없습니다(stage 기반 바인딩 조회이므로 추가 파라미터 불요)."
             )
         return
 

--- a/backend/app/services/event_routing_resolver.py
+++ b/backend/app/services/event_routing_resolver.py
@@ -123,6 +123,86 @@ async def _resolve_none(db: AsyncSession, *, org_id: uuid.UUID, payload: dict) -
     return set()
 
 
+async def _resolve_work_item_project_id(
+    db: AsyncSession, *, org_id: uuid.UUID, payload: dict,
+) -> uuid.UUID | None:
+    """story #3288 — recipe_role_binding이 project 스코프 바인딩을 찾으려면 work_item의
+    project_id가 필요하다. _resolve_work_item_stakeholders와 동일 타입 분기(중복이지만 그
+    함수는 담당자 id를, 이건 project_id를 뽑아 반환 shape이 달라 별도 함수로 유지 — 이후
+    공통화는 후속 리팩터, 이 스토리 스코프 밖)."""
+    work_item_type = payload.get("work_item_type")
+    work_item_id_raw = payload.get("work_item_id")
+    if not work_item_type or not work_item_id_raw:
+        return None
+    work_item_id = _parse_uuid(work_item_id_raw, field_name="work_item_id")
+
+    if work_item_type == "story":
+        from app.models.pm import Story
+
+        return (await db.execute(
+            select(Story.project_id).where(Story.id == work_item_id, Story.org_id == org_id)
+        )).scalar_one_or_none()
+    if work_item_type == "task":
+        from app.models.pm import Task
+
+        return (await db.execute(
+            select(Task.project_id).where(Task.id == work_item_id, Task.org_id == org_id)
+        )).scalar_one_or_none()
+    if work_item_type in ("goal", "epic"):
+        from app.models.pm import Goal
+
+        return (await db.execute(
+            select(Goal.project_id).where(Goal.id == work_item_id, Goal.org_id == org_id)
+        )).scalar_one_or_none()
+
+    logger.warning(
+        "event_routing_resolver: unsupported work_item_type=%s for recipe_role_binding project lookup",
+        work_item_type,
+    )
+    return None
+
+
+async def _resolve_recipe_role_binding(
+    db: AsyncSession, *, org_id: uuid.UUID, payload: dict, definition_key: str,
+) -> set[uuid.UUID]:
+    """story #3288(축2-ⓐ) — stage_metadata.role은 표시 텍스트뿐이라, 발행 시점에 "이 stage는
+    실제로 누구인가"를 recipe_role_bindings에서 조회한다. project 스코프 바인딩이 org 전역
+    바인딩보다 우선(project_id IS NOT NULL 행을 먼저 찾고 없으면 project_id IS NULL로 폴백).
+
+    ⛔PO 확定(2026-09-01) 「모르면 안 준다」 — 바인딩이 없으면 빈 집합을 반환한다(다른
+    server_derived류 폴백으로 조용히 대체하지 않음 — 미배정 stage가 엉뚱한 이해관계자에게
+    새는 것 자체가 방지 대상)."""
+    stage = payload.get("stage")
+    if not stage:
+        return set()
+
+    from app.models.recipe_role_binding import RecipeRoleBinding
+
+    project_id = await _resolve_work_item_project_id(db, org_id=org_id, payload=payload)
+
+    if project_id is not None:
+        agent_id = (await db.execute(
+            select(RecipeRoleBinding.agent_member_id).where(
+                RecipeRoleBinding.org_id == org_id,
+                RecipeRoleBinding.project_id == project_id,
+                RecipeRoleBinding.event_definition_key == definition_key,
+                RecipeRoleBinding.stage == stage,
+            )
+        )).scalar_one_or_none()
+        if agent_id is not None:
+            return {agent_id}
+
+    agent_id = (await db.execute(
+        select(RecipeRoleBinding.agent_member_id).where(
+            RecipeRoleBinding.org_id == org_id,
+            RecipeRoleBinding.project_id.is_(None),
+            RecipeRoleBinding.event_definition_key == definition_key,
+            RecipeRoleBinding.stage == stage,
+        )
+    )).scalar_one_or_none()
+    return {agent_id} if agent_id is not None else set()
+
+
 # SERVER_DERIVED_TARGETS(event_definition_registry.py) 전체를 커버해야 한다 — 모듈 로드
 # 시점에 어긋나면 즉시 ImportError로 드러나게(운영 중 조용한 미해석 대신).
 _SERVER_DERIVED_RESOLVERS = {
@@ -138,10 +218,21 @@ assert set(_SERVER_DERIVED_RESOLVERS) == set(SERVER_DERIVED_TARGETS), (
 
 async def resolve_routing_leg(
     leg: dict, *, payload: dict, org_id: uuid.UUID, db: AsyncSession,
+    definition_key: str | None = None,
 ) -> set[uuid.UUID]:
     """routing.escalation 또는 routing.broadcast 한 leg를 실제 member_id 집합으로. leg는
     이미 validate_event_routing()을 통과한 정의에서 온 것을 전제(등록 시점 계약 검증 완료 —
-    여기서 kind/target 모양을 다시 의심하지 않는다, 값 해석만)."""
+    여기서 kind/target 모양을 다시 의심하지 않는다, 값 해석만).
+
+    definition_key: kind="recipe_role_binding"일 때만 필수(story #3288) — 그 외 kind는 안 씀,
+    기존 호출부(#2633) 무회귀 위해 기본값 None."""
+    if leg["kind"] == "recipe_role_binding":
+        if not definition_key:
+            raise ValueError("recipe_role_binding 해석에는 definition_key가 필요합니다.")
+        return await _resolve_recipe_role_binding(
+            db, org_id=org_id, payload=payload, definition_key=definition_key,
+        )
+
     if leg["kind"] == "payload_field":
         field = leg["member_id_field"]
         value = payload.get(field)

--- a/backend/tests/test_3288_recipe_role_bindings.py
+++ b/backend/tests/test_3288_recipe_role_bindings.py
@@ -1,0 +1,431 @@
+"""story #3288(도메인탈고정 축2-ⓐ) — 레시피 apply 계층: EventDefinition.stage_metadata.role
+(표시 텍스트뿐)을 실제 org/project TeamMember에 바인딩해, routing 해석기가 발행 시점에 그
+stage의 실제 담당 에이전트를 조회할 수 있게 한다.
+
+doc axis2-recipe-mechanism-event-definitions-design §설계정정 — AgentRoutingRule 재사용은
+폐기(rule_evaluator.py가 구세대 trigger 어휘 전용이라 신세대 트리거를 절대 못 읽음). 신세대
+"자동화" = 알림→에이전트가 action을 지시로 읽고 스스로 행동. 이 스토리는 그 알림의 수신자를
+정확히 만드는 recipe_role_bindings+routing kind만 다룬다(side-effect 자동집행 아님).
+
+검증 축:
+- AC1: 테이블/모델 — org 전역 vs project 특이성 스코프 분리(부분 unique index).
+- AC2: routing kind="recipe_role_binding" — 실 발행으로 바인딩된 에이전트가 route_message
+  수신자에 포함되는지 실증.
+- AC3: apply 엔드포인트 — 구 apply_template 검증체인(has_project_access·stage 검증·org
+  스코프 agent 검증) 이식 확인.
+- AC4: 「모르면 안 준다」 — 바인딩 없는 stage는 빈 집합(다른 이해관계자로 새지 않음).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+_CYCLIC_PAYLOAD_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["stage", "work_item_type", "work_item_id"],
+    "properties": {
+        "stage": {"type": "string", "enum": ["step_1", "step_2"]},
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+    },
+}
+_RECIPE_ROLE_BINDING_ROUTING = {
+    "escalation": {"kind": "recipe_role_binding"},
+    "broadcast": {"kind": "server_derived", "target": "none"},
+}
+
+
+async def _seed_org_project(session, *, slug="axis2a"):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org3288", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_human_caller(session, org_id, project_id, *, name="caller"):
+    """has_project_access의 team_member_branch는 type='human'만 통과시킨다(project_auth.py
+    _project_access_predicate 실측) — apply 엔드포인트 호출자는 이 타입으로 seed."""
+    from app.models.team import TeamMember
+
+    m = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="human", name=name, is_active=True,
+    )
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="S")
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_cyclic_definition(session, *, key="preset.axis2a.recipe_test"):
+    from app.models.event_definition import EventDefinition
+
+    d = EventDefinition(
+        id=uuid.uuid4(), key=key, org_id=None, payload_schema=_CYCLIC_PAYLOAD_SCHEMA,
+        routing=_RECIPE_ROLE_BINDING_ROUTING,
+        stage_metadata={"step_1": {"role": "Developer", "action": "do the thing"},
+                        "step_2": {"role": "Reviewer", "action": "review the thing"}},
+    )
+    session.add(d)
+    await session.commit()
+    return d
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+def _fake_request():
+    from starlette.requests import Request as StarletteRequest
+    return StarletteRequest(scope={"type": "http", "headers": []})
+
+
+# ─── registry: routing kind validation ─────────────────────────────────────
+
+def test_registry_accepts_recipe_role_binding_kind_bare():
+    from app.services.event_definition_registry import validate_event_routing
+
+    validate_event_routing({
+        "escalation": {"kind": "recipe_role_binding"},
+        "broadcast": {"kind": "server_derived", "target": "none"},
+    })
+
+
+def test_registry_rejects_recipe_role_binding_with_extra_params():
+    from app.services.event_definition_registry import InvalidEventRoutingError, validate_event_routing
+
+    with pytest.raises(InvalidEventRoutingError):
+        validate_event_routing({
+            "escalation": {"kind": "recipe_role_binding", "target": "none"},
+            "broadcast": {"kind": "server_derived", "target": "none"},
+        })
+
+
+# ─── AC2/AC4: 해석기 — 바인딩 있으면 그 에이전트, 없으면 빈 집합(모르면 안 준다) ──────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_routes_to_bound_agent_via_apply_endpoint():
+    from app.routers.events import (
+        ApplyRecipeRoleBindingsRequest, EventPublishRequest,
+        apply_recipe_role_bindings, publish_registry_event,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            definition = await _seed_cyclic_definition(s)
+            publisher_id = await _seed_human_caller(s, org_id, project_id, name="publisher")
+            developer_id = await _seed_agent(s, org_id, project_id, name="dev")
+            story_id = await _seed_story(s, org_id, project_id)
+
+            apply_resp = await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=project_id, role_mapping={"step_1": str(developer_id)}),
+                db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert apply_resp.ok and apply_resp.bindings_upserted == 1
+
+            body = EventPublishRequest(
+                definition_key=definition.key,
+                payload={"stage": "step_1", "work_item_type": "story", "work_item_id": str(story_id)},
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert resp["escalation_member_ids"] == [str(developer_id)]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_publish_unassigned_stage_yields_no_escalation_no_leak():
+    """PO 확定 「모르면 안 준다」 — step_2에 바인딩이 없으면 escalation은 빈 채로 나가야
+    한다. **타 org의 같은 (definition_key, stage) 바인딩이 존재해도** 새지 않아야 한다 —
+    org_id 필터가 빠지면 이 테스트가 정확히 그 누출을 잡는다(단순 "바인딩 0건" 케이스보다
+    엄격: 리졸버가 org 스코프 없이 아무 매치나 집어오는 뮤테이션을 여기서 실제로 RED)."""
+    from app.routers.events import (
+        ApplyRecipeRoleBindingsRequest, EventPublishRequest,
+        apply_recipe_role_bindings, publish_registry_event,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="axis2a-leak-a")
+            other_org_id, other_project_id = await _seed_org_project(s, slug="axis2a-leak-b")
+            definition = await _seed_cyclic_definition(s)
+            publisher_id = await _seed_human_caller(s, org_id, project_id, name="publisher")
+            developer_id = await _seed_agent(s, org_id, project_id, name="dev")
+            story_id = await _seed_story(s, org_id, project_id)
+
+            # step_1만 바인딩, step_2는 미배정으로 남긴다(이 org 안에서는).
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=project_id, role_mapping={"step_1": str(developer_id)}),
+                db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+
+            # 타 org가 같은 definition_key+stage="step_2"를 바인딩해둔다 — org 스코프가 실제로
+            # 지켜지는지의 진짜 대조군(리졸버가 org_id를 빼먹으면 이게 새어 들어온다).
+            other_publisher = await _seed_human_caller(s, other_org_id, other_project_id, name="other-publisher")
+            other_agent = await _seed_agent(s, other_org_id, other_project_id, name="other-dev")
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(
+                    project_id=other_project_id, role_mapping={"step_2": str(other_agent)},
+                ),
+                db=s, auth=_auth(other_publisher, other_org_id), org_id=other_org_id,
+            )
+
+            body = EventPublishRequest(
+                definition_key=definition.key,
+                payload={"stage": "step_2", "work_item_type": "story", "work_item_id": str(story_id)},
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert resp["escalation_member_ids"] == []
+            assert str(developer_id) not in resp["escalation_member_ids"]
+            assert str(other_agent) not in resp["escalation_member_ids"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_project_scope_binding_wins_over_org_wide_binding():
+    from app.routers.events import (
+        ApplyRecipeRoleBindingsRequest, EventPublishRequest,
+        apply_recipe_role_bindings, publish_registry_event,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            definition = await _seed_cyclic_definition(s)
+            publisher_id = await _seed_human_caller(s, org_id, project_id, name="publisher")
+            org_wide_agent = await _seed_agent(s, org_id, project_id, name="org-wide")
+            project_agent = await _seed_agent(s, org_id, project_id, name="project-specific")
+            story_id = await _seed_story(s, org_id, project_id)
+
+            # org 전역 바인딩 먼저(project_id=None).
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=None, role_mapping={"step_1": str(org_wide_agent)}),
+                db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            # 이 project 전용 바인딩(우선해야 함).
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=project_id, role_mapping={"step_1": str(project_agent)}),
+                db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+
+            body = EventPublishRequest(
+                definition_key=definition.key,
+                payload={"stage": "step_1", "work_item_type": "story", "work_item_id": str(story_id)},
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert resp["escalation_member_ids"] == [str(project_agent)]
+    finally:
+        await engine.dispose()
+
+
+# ─── AC3: apply 엔드포인트 검증체인 ──────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_rejects_unknown_stage():
+    from app.routers.events import ApplyRecipeRoleBindingsRequest, apply_recipe_role_bindings
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            definition = await _seed_cyclic_definition(s)
+            publisher_id = await _seed_human_caller(s, org_id, project_id, name="publisher")
+
+            with pytest.raises(HTTPException) as ei:
+                await apply_recipe_role_bindings(
+                    definition.id,
+                    ApplyRecipeRoleBindingsRequest(
+                        project_id=project_id, role_mapping={"nonexistent_stage": str(publisher_id)},
+                    ),
+                    db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 422
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_rejects_cross_org_agent():
+    from app.routers.events import ApplyRecipeRoleBindingsRequest, apply_recipe_role_bindings
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="axis2a-a")
+            other_org_id, other_project_id = await _seed_org_project(s, slug="axis2a-b")
+            definition = await _seed_cyclic_definition(s)
+            publisher_id = await _seed_human_caller(s, org_id, project_id, name="publisher")
+            foreign_agent = await _seed_agent(s, other_org_id, other_project_id, name="foreign")
+
+            with pytest.raises(HTTPException) as ei:
+                await apply_recipe_role_bindings(
+                    definition.id,
+                    ApplyRecipeRoleBindingsRequest(
+                        project_id=project_id, role_mapping={"step_1": str(foreign_agent)},
+                    ),
+                    db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 422
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_rejects_caller_without_project_access():
+    """SEC-S8 CRITICAL 재발 방지(구 apply_template 사고 자리) — project 접근권 없는
+    caller가 그 project에 바인딩을 심을 수 없어야 한다."""
+    from app.routers.events import ApplyRecipeRoleBindingsRequest, apply_recipe_role_bindings
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_a = await _seed_org_project(s, slug="axis2a-sec")
+            from app.models.project import Project
+            project_b = Project(id=uuid.uuid4(), org_id=org_id, name="P-B")
+            s.add(project_b)
+            await s.commit()
+
+            # publisher는 project_a에만 소속(project_b엔 미소속·미권한).
+            outsider_id = await _seed_agent(s, org_id, project_a, name="outsider")
+            definition = await _seed_cyclic_definition(s)
+            target_agent = await _seed_agent(s, org_id, project_b.id, name="target")
+
+            with pytest.raises(HTTPException) as ei:
+                await apply_recipe_role_bindings(
+                    definition.id,
+                    ApplyRecipeRoleBindingsRequest(
+                        project_id=project_b.id, role_mapping={"step_1": str(target_agent)},
+                    ),
+                    db=s, auth=_auth(outsider_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 404
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_reapply_upserts_not_duplicates():
+    """재적용(같은 stage, 다른 agent)은 새 행 추가가 아니라 갱신이어야 한다 — 부분 unique
+    index가 실제로 이걸 강제하는지 확인(모델/마이그 정합성)."""
+    from sqlalchemy import func, select
+
+    from app.models.recipe_role_binding import RecipeRoleBinding
+    from app.routers.events import ApplyRecipeRoleBindingsRequest, apply_recipe_role_bindings
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            definition = await _seed_cyclic_definition(s)
+            publisher_id = await _seed_human_caller(s, org_id, project_id, name="publisher")
+            agent_1 = await _seed_agent(s, org_id, project_id, name="agent-1")
+            agent_2 = await _seed_agent(s, org_id, project_id, name="agent-2")
+
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=project_id, role_mapping={"step_1": str(agent_1)}),
+                db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=project_id, role_mapping={"step_1": str(agent_2)}),
+                db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+
+            count = (await s.execute(
+                select(func.count()).select_from(RecipeRoleBinding).where(
+                    RecipeRoleBinding.org_id == org_id, RecipeRoleBinding.project_id == project_id,
+                    RecipeRoleBinding.event_definition_key == definition.key, RecipeRoleBinding.stage == "step_1",
+                )
+            )).scalar_one()
+            assert count == 1
+
+            bound = (await s.execute(
+                select(RecipeRoleBinding.agent_member_id).where(
+                    RecipeRoleBinding.org_id == org_id, RecipeRoleBinding.project_id == project_id,
+                    RecipeRoleBinding.event_definition_key == definition.key, RecipeRoleBinding.stage == "step_1",
+                )
+            )).scalar_one()
+            assert bound == agent_2
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3288_recipe_role_bindings.py
+++ b/backend/tests/test_3288_recipe_role_bindings.py
@@ -198,11 +198,58 @@ async def test_publish_routes_to_bound_agent_via_apply_endpoint():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+async def test_org_wide_fallback_does_not_leak_across_org():
+    """카디르 QA(PR#3686) 지적 — 기존 leak 테스트(아래 test_publish_unassigned_stage_
+    yields_no_escalation_no_leak)의 "타 org 바인딩"이 project-scope였던 탓에 org_id 필터를
+    통째로 제거해도 project_id 자체가 안 맞아 우연히 통과했다(리졸버의 두 쿼리 중
+    org-wide(project_id IS NULL) 폴백 쪽을 실제로는 못 겨냥). 이 테스트는 **타 org가 org-wide
+    바인딩**(project_id=None)을 걸어 정밀 겨냥 — org_id 필터가 org-wide 폴백 쿼리에서
+    빠지면 이게 정확히 새어 들어온다."""
+    from app.routers.events import (
+        ApplyRecipeRoleBindingsRequest, EventPublishRequest,
+        apply_recipe_role_bindings, publish_registry_event,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="axis2a-orgwide-a")
+            other_org_id, other_project_id = await _seed_org_project(s, slug="axis2a-orgwide-b")
+            definition = await _seed_cyclic_definition(s)
+            publisher_id = await _seed_human_caller(s, org_id, project_id, name="publisher")
+            story_id = await _seed_story(s, org_id, project_id)
+
+            # 이 org(org_id)는 step_2에 아무 바인딩도 안 건다(project든 org-wide든).
+            # 타 org가 org-wide(project_id=None) 바인딩을 건다 — 정밀 대조군.
+            other_publisher = await _seed_human_caller(s, other_org_id, other_project_id, name="other-publisher")
+            other_agent = await _seed_agent(s, other_org_id, other_project_id, name="other-dev")
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=None, role_mapping={"step_2": str(other_agent)}),
+                db=s, auth=_auth(other_publisher, other_org_id), org_id=other_org_id,
+            )
+
+            body = EventPublishRequest(
+                definition_key=definition.key,
+                payload={"stage": "step_2", "work_item_type": "story", "work_item_id": str(story_id)},
+            )
+            resp = await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+            assert resp["escalation_member_ids"] == []
+            assert str(other_agent) not in resp["escalation_member_ids"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
 async def test_publish_unassigned_stage_yields_no_escalation_no_leak():
     """PO 확定 「모르면 안 준다」 — step_2에 바인딩이 없으면 escalation은 빈 채로 나가야
-    한다. **타 org의 같은 (definition_key, stage) 바인딩이 존재해도** 새지 않아야 한다 —
-    org_id 필터가 빠지면 이 테스트가 정확히 그 누출을 잡는다(단순 "바인딩 0건" 케이스보다
-    엄격: 리졸버가 org 스코프 없이 아무 매치나 집어오는 뮤테이션을 여기서 실제로 RED)."""
+    한다. 타 org의 같은 (definition_key, stage) **project-scope** 바인딩이 존재해도 새지
+    않아야 한다(project_id 자체가 안 맞으므로 이 시나리오는 project_id 매칭이 실제
+    방어선 — org-wide 폴백 쿼리의 org_id 누락은 별도 위 test_org_wide_fallback_does_not_
+    leak_across_org가 정밀 겨냥, 카디르 QA #3686 적발로 분리)."""
     from app.routers.events import (
         ApplyRecipeRoleBindingsRequest, EventPublishRequest,
         apply_recipe_role_bindings, publish_registry_event,


### PR DESCRIPTION
story #3288(도메인탈고정 축2-ⓐ, doc axis2-recipe-mechanism-event-definitions-design). 이번주 목표 「도메인 탈고정+레시피」 축2 핵심.

## 배경
`EventDefinition.stage_metadata[stage].role`은 지금 순수 표시 텍스트(온보딩 가이드 렌더러 전용)뿐 — "이 org/project에서 이 stage는 실제로 누구인가"를 routing 해석기가 조회할 자리가 없었다.

## ⚠️ 설계 정정(구현 착수 전 자체 발견)
당초 구세대 `AgentRoutingRule` 재사용을 계획했으나, `rule_evaluator.py`의 매칭 로직이 `trigger_type_slugs`/`memo_type`/`event_params`(구세대 memo 트리거 어휘)만 읽어 `EventDefinition.key`/`stage`를 조건에 넣어도 절대 안 읽는다 — 만들어도 영원히 안 발동하는 죽은 규칙이 될 뻔했다. 실측 결과 신세대 "자동화"의 실체는 `_publish_registry_event_core`가 routing을 route_message로 풀어 관련자에게 **알리는** 것 — side-effect 자동집행이 아니라 "알림받은 에이전트가 action을 지시로 읽고 스스로 행동"하는 구조. 이 발견으로 AgentRoutingRule 생성 자체를 폐기하고 훨씬 얇은 바인딩 테이블로 설계를 바꿨다.

## 구현
- `recipe_role_bindings` 신규 테이블 — project_id NULL=org 전역, NOT NULL=project 특이성(조회 시 우선). 부분 unique index 2개(EventDefinition의 기존 preset/org key 패턴과 동형).
- routing kind `recipe_role_binding` 신규 추가(payload_field/server_derived 옆). 해석기가 payload.stage+work_item으로 역산한 project_id로 바인딩 조회 — project 스코프가 org 전역보다 우선, 바인딩 없으면 **빈 집합**(PO 확定 「모르면 안 준다」).
- `POST /api/v2/events/definitions/{id}/apply` — 구 `apply_template`의 검증 체인 이식(has_project_access·stage 검증·org 스코프 agent 검증) + upsert만(AgentRoutingRule 생성 없음).

## 검증
- 신규 pin 9건(kind 검증·실 발행 라우팅 실증·project-scope 우선순위·미배정=빈 집합[타 org 동일 바인딩 존재해도 안 샘]·검증체인 3종·재적용 upsert)
- 뮤테이션 자가검증 3회(우선순위 제거·폴백 제거·org_id 필터 누락) — 정확한 대상만 RED 확認 후 원복
- 관련 회귀 스위트(destructive 82건+non-destructive 39건) 전부 PASS

## 스코프 밖
external_publish 승인 게이트(축2-ⓑ)는 PO 별도 설계 중. settings 갤러리 신세대 이전(축2-ⓒ)·생성시 자동적용 훅(축2-ⓓ)은 후속 스토리.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_019rkXVqy2DF1aAN7szuqp44