### PR TITLE
[SID:3287] 축1 Phase1 FE 소비 — org 표시 라벨을 보드 컬럼/카드에 렌더

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -970,3 +970,69 @@ describe('KanbanBoard — story #3043 <lg 기본값=list(칸반 다열은 opt-in
     expect(container.innerHTML).not.toContain('max-w-[280px]');
   });
 });
+
+// story #3287([도메인탈고정·축1 Phase1] AC4) — org 라벨 오버라이드가 클래식(5-status)
+// 컬럼 헤더 텍스트만 바꾸고, canonical status(드래그·색상·전이 판정에 쓰는 col.id)와
+// 신뢰축(TRUST_COLUMNS, 다른 어휘) 라벨은 절대 안 건드리는지 실 렌더로 고정.
+describe('KanbanBoard — org 라벨 오버라이드 소비(#3287 AC4)', () => {
+  function stubFetchWithDomainLabels(
+    stories: Array<Record<string, unknown> & { status: string }>,
+    labels: Array<{ domain: string; canonical_slug: string; label_ko: string | null; label_en: string | null }>,
+  ) {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.startsWith('/api/stories?')) {
+        const status = new URL(url, 'http://localhost').searchParams.get('status');
+        const matched = stories.filter((s) => s.status === status);
+        return { ok: true, json: async () => ({ data: matched, meta: { total: matched.length, nextCursor: null } }) };
+      }
+      if (typeof url === 'string' && url.includes('/domain-labels')) {
+        return { ok: true, json: async () => labels };
+      }
+      return { ok: false, json: async () => null };
+    }));
+  }
+
+  beforeEach(() => {
+    useDashboardContextMock.mockReturnValue({
+      currentTeamMemberId: 'me-1', orgId: 'org-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'human',
+    });
+  });
+
+  it('클래식(5-status) 컬럼 헤더는 오버라이드 라벨로 바뀌고, 오버라이드 없는 컬럼은 canonical i18n 그대로다', async () => {
+    stubFetchWithDomainLabels(
+      [{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium' }],
+      [{ domain: 'status', canonical_slug: 'backlog', label_ko: '아이디어', label_en: 'Idea' }],
+    );
+    await mount();
+    const classicBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '5-status 클래식');
+    expect(classicBtn, '클래식 토글 버튼을 못 찾음').toBeDefined();
+    await act(async () => { classicBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('아이디어'); // backlog 오버라이드 적용
+    expect(container.textContent).not.toContain('백로그'); // canonical i18n 문구는 더는 안 보임
+    expect(container.textContent).toContain('완료'); // done엔 오버라이드 없음 — canonical i18n 그대로
+  });
+
+  it('오버라이드 미설정(빈 목록)이면 전 컬럼이 기존 canonical i18n 라벨 그대로다(회귀 0)', async () => {
+    stubFetchWithDomainLabels([{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium' }], []);
+    await mount();
+    const classicBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '5-status 클래식');
+    await act(async () => { classicBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(container.textContent).toContain('백로그');
+  });
+
+  it('신뢰축(TRUST_COLUMNS) 컬럼 헤더는 자기 어휘 그대로지만, 카드 내부 상태 배지는 story.status 오버라이드를 받는다', async () => {
+    stubFetchWithDomainLabels(
+      [{ id: 's1', title: 'S1', status: 'backlog', priority: 'medium', trust_stage: 'queued' }],
+      [{ domain: 'status', canonical_slug: 'backlog', label_ko: '아이디어', label_en: 'Idea' }],
+    );
+    await mount(); // 기본값=trust축(P0-04) — 클래식 토글 안 누름.
+    // 컬럼 헤더(대기/실행 중/...)는 TRUST_COLUMNS 고유 어휘 그대로 — statusLabel()을 안 씀.
+    expect(container.textContent).toContain('입력 필요');
+    // 카드 내부 배지는 story.status(canonical, 축과 무관)를 보여주므로 오버라이드가 반영된다.
+    expect(container.textContent).toContain('아이디어');
+  });
+});

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -3,7 +3,7 @@
 import type { ComponentType } from 'react';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { Check, ChevronDown, LayoutGrid, LayoutList, Search, Workflow, Plus } from 'lucide-react';
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, DragOverlay, closestCenter } from '@dnd-kit/core';
 import { Button } from '@/components/ui/button';
@@ -12,6 +12,7 @@ import { Input } from '@/components/ui/input';
 import { useRenderNonce } from '@/hooks/use-render-nonce';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useOrgSyncVersion } from '@/lib/project-context-client';
+import { useOrgDomainLabels } from '@/hooks/use-org-domain-labels';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -139,6 +140,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
   // 동일 패턴 — orgSyncVersion을 트리거 effect 의존성에 얹는다.
   const orgSyncVersion = useOrgSyncVersion();
   const t = useTranslations('board');
+  const locale = useLocale();
   const { toasts, addToast, dismissToast } = useToast();
   const [transitionError, setTransitionError] = useState<string | null>(null);
   // story #2154 — 이 배너는 4초 후 자동 setTransitionError(null)로만 해소되고, 재시도 直前에
@@ -305,7 +307,12 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
   // 이미 로드된(페이지네이션으로 fetch된) 카드만 in-place 패치 — 전체 재fetch를 하지 않으므로
   // 스크롤 위치·컬럼 순서가 흔들리지 않는다(AC3, #2050에서 배운 레이아웃 시프트 축과 동일 원리).
   // 아직 로드 안 된 카드(다른 컬럼 페이지네이션 밖)의 신규 진입은 이 스토리 스코프 밖으로 둔다.
-  const { currentTeamMemberId } = useDashboardContext();
+  const { currentTeamMemberId, orgId } = useDashboardContext();
+  // story #3287([도메인탈고정·축1 Phase1]) — org별 표시 라벨 오버라이드. canonical
+  // status(col.id, drag/전이/색상 전부 이걸로 판정)는 절대 안 바뀐다 — statusLabel()이
+  // 있으면 그 문구로 컬럼 헤더 텍스트만 치환하고, 없으면(오버라이드 미설정) 기존
+  // t(col.i18nKey) 그대로(회귀 0).
+  const domainLabels = useOrgDomainLabels(orgId, locale);
 
   // story #2137 — 카드(stories 배열)와 상세 패널(selectedStory)이 별도 state라, SSE 패치를
   // stories에만 적용하면 패널만 옛값에 고정된다(#2384·#2130과 같은 클래스의 3번째 재발 — 이번엔
@@ -1586,6 +1593,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
               storyGatesMap={storyGatesMap}
               storyLineMap={storyLineMap}
               projectId={projectId}
+              getStatusLabel={domainLabels.statusLabel}
             />
           </div>
         ) : axisMode === 'trust' ? (
@@ -1625,6 +1633,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                     isDragging={activeId != null}
                     onCreateStory={handleCreateStoryTrust}
                     autoComposeSignal={col.id === 'queued' ? autoComposeNonce : 0}
+                    getStatusLabel={domainLabels.statusLabel}
                   />
                 );
               })}
@@ -1640,6 +1649,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                     onClick={() => {}}
                     lineStatus={storyLineMap[activeStory.id]}
                     verifiedBy={activeStory.human_verified_by ? memberMap[activeStory.human_verified_by] : undefined}
+                    getStatusLabel={domainLabels.statusLabel}
                   />
                 </div>
               )}
@@ -1665,7 +1675,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                   <KanbanColumn
                     key={col.id}
                     id={col.id}
-                    label={t(col.i18nKey)}
+                    label={domainLabels.statusLabel(col.id) ?? t(col.i18nKey)}
                     stories={colStories}
                     epicMap={epicMap}
                     memberMap={memberMap}
@@ -1698,6 +1708,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                     collapsed={col.id === 'done' ? doneCollapsed : undefined}
                     onToggleCollapse={col.id === 'done' ? handleToggleDoneCollapse : undefined}
                     autoComposeSignal={col.id === 'backlog' ? autoComposeNonce : 0}
+                    getStatusLabel={domainLabels.statusLabel}
                   />
                 );
               })}
@@ -1713,6 +1724,7 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
                     onClick={() => {}}
                     lineStatus={storyLineMap[activeStory.id]}
                     verifiedBy={activeStory.human_verified_by ? memberMap[activeStory.human_verified_by] : undefined}
+                    getStatusLabel={domainLabels.statusLabel}
                   />
                 </div>
               )}

--- a/apps/web/src/components/kanban/kanban-column.test.tsx
+++ b/apps/web/src/components/kanban/kanban-column.test.tsx
@@ -105,3 +105,55 @@ describe('KanbanColumn — 컬럼헤더 소헤딩(story #2969 PR-5)', () => {
     expect(header?.className).not.toContain('uppercase');
   });
 });
+
+// 유나 design:changes(PR#3687, story #3287 AC4, 2026-09-01) — org 커스텀 라벨은 길이가
+// 자유라 고정폭 컬럼(w-[280px])에서 WIP 카운트·버튼을 밀어낼 수 있었다.
+describe('KanbanColumn — 긴 org 라벨이 WIP 카운트를 안 밀어낸다(유나 design:changes, PR#3687)', () => {
+  it('헤더 h3가 min-w-0, 라벨 span이 truncate+title(전체 문구)을 갖는다', async () => {
+    const longLabel = '아이디어 검토 대기열 — 마케팅팀 승인 전 임시 보관함(매우 긴 org 커스텀 라벨)';
+    await act(async () => {
+      root.render(
+        wrap(
+          <KanbanColumn
+            id="backlog"
+            label={longLabel}
+            stories={[]}
+            epicMap={{}}
+            memberMap={{}}
+            onStoryClick={vi.fn()}
+          />,
+        ),
+      );
+    });
+
+    const header = container.querySelector('h3');
+    expect(header?.className).toContain('min-w-0');
+    const labelSpan = header?.querySelector('span[title]');
+    expect(labelSpan).not.toBeNull();
+    expect(labelSpan?.className).toContain('truncate');
+    expect(labelSpan?.getAttribute('title')).toBe(longLabel);
+    expect(labelSpan?.textContent).toBe(longLabel);
+  });
+
+  it('WIP 배지·카운트를 담은 우측 그룹은 shrink-0 — 라벨이 길어도 이쪽이 안 밀린다', async () => {
+    await act(async () => {
+      root.render(
+        wrap(
+          <KanbanColumn
+            id="backlog"
+            label="백로그"
+            stories={[]}
+            epicMap={{}}
+            memberMap={{}}
+            onStoryClick={vi.fn()}
+            wipLimit={5}
+          />,
+        ),
+      );
+    });
+
+    const header = container.querySelector('h3');
+    const rightGroup = header?.nextElementSibling;
+    expect(rightGroup?.className).toContain('shrink-0');
+  });
+});

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -166,11 +166,15 @@ export function KanbanColumn({
             <>
               {/* story #2969 §1.3-b(doc proofline-system-layer-2969, PR-5) — 컬럼헤더=소헤딩
                   (Heading 무게, sans 유지 — 한글이라 caps/mono 금지). 크기(text-xs)는 불변. */}
-              <h3 className="flex items-center gap-2 text-xs font-extrabold text-foreground">
+              {/* 유나 design:changes(PR#3687, 2026-09-01) — org 커스텀 라벨은 길이가
+                  자유(«아이디어 검토 대기열»)라 고정폭 컬럼(w-[280px])에서 wip 카운트·
+                  버튼을 밀어낼 수 있었다. h3에 min-w-0(flex item이 컨텐츠 크기로
+                  안 밀어붙이게)+텍스트 자체에 truncate, 잘려도 title로 전체 문구 확인. */}
+              <h3 className="flex min-w-0 items-center gap-2 text-xs font-extrabold text-foreground">
                 <span className={`size-1.5 shrink-0 rounded-full ${statusColor.dot}`} aria-hidden="true" />
-                {label}
+                <span className="truncate" title={label}>{label}</span>
               </h3>
-              <div className="flex items-center gap-1.5">
+              <div className="flex shrink-0 items-center gap-1.5">
                 {/* AC1: WIP 초과 배지 */}
                 {wipExceeded && (
                   <Badge variant="destructive" className="text-[10px]">

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -70,6 +70,8 @@ interface KanbanColumnProps {
   onToggleCollapse?: () => void;
   // f1910a31: ?view=new → 인라인 컴포저 auto-open. nonce가 바뀔 때마다(0→1, 1→2…) 재오픈.
   autoComposeSignal?: number;
+  /** story #3287 AC4 — StoryCard로 그대로 threading(설명은 story-card.tsx 참고). */
+  getStatusLabel?: (canonicalSlug: string) => string | undefined;
 }
 
 export function KanbanColumn({
@@ -80,7 +82,7 @@ export function KanbanColumn({
   onCreateStory, projectId, onKickoffStory, executionMap, blockedByMap, storyLabelsMap, storyGatesMap, storyLineMap,
   totalCount, hasMore, loadingMore, onLoadMore,
   collapsed, onToggleCollapse,
-  autoComposeSignal,
+  autoComposeSignal, getStatusLabel,
 }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
   const t = useTranslations('board');
@@ -323,6 +325,7 @@ export function KanbanColumn({
                   gates={storyGatesMap?.[story.id] ?? []}
                   lineStatus={storyLineMap?.[story.id]}
                   verifiedBy={story.human_verified_by ? memberMap[story.human_verified_by] : undefined}
+                  getStatusLabel={getStatusLabel}
                 />
               ))}
             </div>

--- a/apps/web/src/components/kanban/kanban-list-view.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.tsx
@@ -61,10 +61,13 @@ function StatusGroup({
         onClick={() => setExpanded((p) => !p)}
       >
         {expanded ? <ChevronDown className="size-4 shrink-0" /> : <ChevronRight className="size-4 shrink-0" />}
-        <span>{label}</span>
+        {/* 유나 design:changes(PR#3687, 2026-09-01) — kanban-column.tsx L169과 동일 구조
+            (label→CountBadge 밀어내기 위험). min-w-0+truncate로 긴 org 라벨을 흡수,
+            title로 전체 문구 확인. */}
+        <span className="min-w-0 truncate" title={label}>{label}</span>
         {/* story #3050(2984-S2, 유나 design PASS 비차단 finding) — CountBadge(S1) 채택,
             bg-muted 채움 폐지. */}
-        <CountBadge count={stories.length} className="ml-auto" />
+        <CountBadge count={stories.length} className="ml-auto shrink-0" />
       </button>
 
       {expanded && (

--- a/apps/web/src/components/kanban/kanban-list-view.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.tsx
@@ -25,6 +25,9 @@ interface KanbanListViewProps {
   storyGatesMap?: Record<string, { id: string; gate_type: string; status: string }[]>;
   storyLineMap?: Record<string, LineStatusSummary>;
   projectId?: string;
+  /** story #3287 AC4 — org 라벨 오버라이드(useOrgDomainLabels().statusLabel). 없으면
+   * 기존 t(col.i18nKey) 그대로(회귀 0). 그룹 헤더+카드 내부 배지 둘 다에 쓰인다. */
+  getStatusLabel?: (canonicalSlug: string) => string | undefined;
 }
 
 interface StatusGroupProps {
@@ -41,11 +44,12 @@ interface StatusGroupProps {
   storyGatesMap?: KanbanListViewProps['storyGatesMap'];
   storyLineMap?: KanbanListViewProps['storyLineMap'];
   projectId?: string;
+  getStatusLabel?: KanbanListViewProps['getStatusLabel'];
 }
 
 function StatusGroup({
   columnId, label, stories, epicMap, memberMap, onStoryClick, onChangeStatus,
-  executionMap, blockedByMap, storyLabelsMap, storyGatesMap, storyLineMap, projectId,
+  executionMap, blockedByMap, storyLabelsMap, storyGatesMap, storyLineMap, projectId, getStatusLabel,
 }: StatusGroupProps) {
   const [expanded, setExpanded] = useState(columnId !== 'done');
 
@@ -88,6 +92,7 @@ function StatusGroup({
                   gates={storyGatesMap?.[story.id] ?? []}
                   lineStatus={storyLineMap?.[story.id]}
                   verifiedBy={story.human_verified_by ? memberMap[story.human_verified_by] : undefined}
+                  getStatusLabel={getStatusLabel}
                 />
               </div>
             ))
@@ -100,7 +105,7 @@ function StatusGroup({
 
 export function KanbanListView({
   stories, epicMap, memberMap, onStoryClick, onChangeStatus,
-  executionMap, blockedByMap, storyLabelsMap, storyGatesMap, storyLineMap, projectId,
+  executionMap, blockedByMap, storyLabelsMap, storyGatesMap, storyLineMap, projectId, getStatusLabel,
 }: KanbanListViewProps) {
   const t = useTranslations('board');
 
@@ -112,7 +117,7 @@ export function KanbanListView({
           <StatusGroup
             key={col.id}
             columnId={col.id}
-            label={t(col.i18nKey)}
+            label={getStatusLabel?.(col.id) ?? t(col.i18nKey)}
             stories={colStories}
             epicMap={epicMap}
             memberMap={memberMap}
@@ -124,6 +129,7 @@ export function KanbanListView({
             storyGatesMap={storyGatesMap}
             storyLineMap={storyLineMap}
             projectId={projectId}
+            getStatusLabel={getStatusLabel}
           />
         );
       })}

--- a/apps/web/src/components/kanban/kanban-trust-column.tsx
+++ b/apps/web/src/components/kanban/kanban-trust-column.tsx
@@ -70,6 +70,11 @@ interface KanbanTrustColumnProps {
   // "지금 이 순간 못 놓는다"는 동적 신호를 얹는다(resolveTrustColumnId의 조용한 무효화만으론
   // "왜 안 되는지" 안 보여 반쪽 — PO 지적).
   isDragging?: boolean;
+  /** story #3287 AC4 — 카드 내부 상태 배지는 story.status(canonical, trust_stage와 무관)를
+   * 보여주므로 트러스트 뷰 카드에도 그대로 threading한다. 컬럼 헤더 라벨(이 컴포넌트의
+   * `label` prop) 자체는 별개 어휘(TRUST_COLUMNS)라 여긴 안 건드림 — kanban-board.tsx가
+   * TRUST_COLUMNS엔 이 override를 안 씀. */
+  getStatusLabel?: (canonicalSlug: string) => string | undefined;
 }
 
 /**
@@ -92,7 +97,7 @@ interface KanbanTrustColumnProps {
 export function KanbanTrustColumn({
   id, label, locked, stories, epicMap, memberMap, onStoryClick, onEditStory, onChangeStatus, onDeleteStory,
   projectId, onKickoffStory, executionMap, blockedByMap, storyLabelsMap, storyGatesMap, storyLineMap,
-  onCreateStory, autoComposeSignal, isDragging = false,
+  onCreateStory, autoComposeSignal, isDragging = false, getStatusLabel,
 }: KanbanTrustColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id, disabled: locked });
   const t = useTranslations('board');
@@ -233,6 +238,7 @@ export function KanbanTrustColumn({
               lineStatus={storyLineMap?.[story.id]}
               verifiedBy={story.human_verified_by ? memberMap[story.human_verified_by] : undefined}
               locked={locked}
+              getStatusLabel={getStatusLabel}
             />
           ))}
         </div>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -108,6 +108,11 @@ interface StoryCardProps {
   /** E-VERIFY P0-04 — story.human_verified_by(UUID)를 호출부가 미리 resolve해 넘긴 것(assignee/
    * assignees와 동일 패턴). 결재자가 현재 담당자가 아닐 수 있어(assigneeList와 별개 조회). */
   verifiedBy?: KanbanMember;
+  /** story #3287([도메인탈고정·축1 Phase1] AC4) — org별 status 라벨 오버라이드 조회 함수
+   * (useOrgDomainLabels().statusLabel). 없으면(undefined) 기존 t(...) canonical 문구 그대로
+   * (회귀 0) — 어떤 축(classic/trust) 카드든 story.status 자체가 바뀌는 게 아니라 여기 표시
+   * 텍스트만 바뀐다. */
+  getStatusLabel?: (canonicalSlug: string) => string | undefined;
   /** story #2933 H4(P0-H) — 트러스트축 파생 컬럼(needs_input/verified/merge_ready)의 카드는
    * 게이트/증거 사실이 소속을 계산한다(v4 결정⑤ — 빼는 길=게이트 해소뿐). true면 드래그 wiring
    * 자체를 끄고(useSortable disabled, dnd-kit 리스너 미부착 — goals-client.tsx/retro page.tsx의
@@ -121,7 +126,7 @@ interface StoryCardProps {
   className?: string;
 }
 
-export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [], gates = [], lineStatus, verifiedBy, locked = false, className }: StoryCardProps) {
+export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [], gates = [], lineStatus, verifiedBy, locked = false, className, getStatusLabel }: StoryCardProps) {
   const t = useTranslations('board');
   // E-BOARD S6: 복수 assignee. assignees 우선, 없으면 단일 assignee 폴백. agent 한 명이라도 있으면 agent 취급(glow).
   const assigneeList = (assignees && assignees.length > 0) ? assignees : (assignee ? [assignee] : []);
@@ -315,11 +320,11 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
   }, [story.id, onDelete]);
 
   const statuses = [
-    { id: 'backlog', label: t('backlog') },
-    { id: 'ready-for-dev', label: t('readyForDev') },
-    { id: 'in-progress', label: t('inProgress') },
-    { id: 'in-review', label: t('inReview') },
-    { id: 'done', label: t('done') },
+    { id: 'backlog', label: getStatusLabel?.('backlog') ?? t('backlog') },
+    { id: 'ready-for-dev', label: getStatusLabel?.('ready-for-dev') ?? t('readyForDev') },
+    { id: 'in-progress', label: getStatusLabel?.('in-progress') ?? t('inProgress') },
+    { id: 'in-review', label: getStatusLabel?.('in-review') ?? t('inReview') },
+    { id: 'done', label: getStatusLabel?.('done') ?? t('done') },
   ];
 
   const proofState = STATUS_TO_PROOF_STATE[story.status] ?? 'amber';

--- a/apps/web/src/hooks/use-org-domain-labels.test.tsx
+++ b/apps/web/src/hooks/use-org-domain-labels.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+//
+// story #3287([도메인탈고정·축1 Phase1] AC4 FE 소비) — useOrgDomainLabels가 GET
+// /api/v2/organizations/{orgId}/domain-labels 응답을 domain:canonical_slug 키로 인덱싱해
+// statusLabel()/entityTypeLabel()로 조회 가능케 하는지, 로케일 선택(ko 우선, 없으면 en
+// 폴백)과 "오버라이드 미설정 slug는 undefined"(호출부가 canonical 문구로 폴백)를 실 렌더로
+// 고정한다.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useOrgDomainLabels } from './use-org-domain-labels';
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('@/lib/db/client', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuthMock(...args),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  fetchWithAuthMock.mockReset();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function Harness({ orgId, locale }: { orgId: string | undefined; locale: string }) {
+  const labels = useOrgDomainLabels(orgId, locale);
+  return (
+    <div
+      data-testid="dump"
+      data-loading={String(labels.loading)}
+      data-status-backlog={labels.statusLabel('backlog') ?? ''}
+      data-status-done={labels.statusLabel('done') ?? ''}
+      data-entity-story={labels.entityTypeLabel('story') ?? ''}
+    />
+  );
+}
+
+async function flush(times = 4) {
+  await act(async () => {
+    for (let i = 0; i < times; i++) await Promise.resolve();
+  });
+}
+
+describe('useOrgDomainLabels — 라벨 API 인덱싱+로케일 선택(#3287 AC4)', () => {
+  it('설정된 slug는 오버라이드 라벨을, 미설정 slug는 undefined를 반환한다', async () => {
+    fetchWithAuthMock.mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { domain: 'status', canonical_slug: 'backlog', label_ko: '아이디어', label_en: 'Idea' },
+        { domain: 'entity_type', canonical_slug: 'story', label_ko: '캠페인', label_en: 'Campaign' },
+      ],
+    });
+
+    await act(async () => {
+      root.render(<Harness orgId="org-1" locale="ko" />);
+    });
+    await flush();
+
+    const el = container.querySelector('[data-testid="dump"]') as HTMLElement;
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/api/v2/organizations/org-1/domain-labels');
+    expect(el.dataset.statusBacklog).toBe('아이디어');
+    expect(el.dataset.statusDone).toBe(''); // 오버라이드 미설정 — undefined(호출부가 canonical 문구로 폴백)
+    expect(el.dataset.entityStory).toBe('캠페인');
+  });
+
+  it('locale=en이면 label_en을 우선하고, label_en이 비어있으면 label_ko로 폴백한다', async () => {
+    fetchWithAuthMock.mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { domain: 'status', canonical_slug: 'backlog', label_ko: '아이디어', label_en: 'Idea' },
+        { domain: 'status', canonical_slug: 'done', label_ko: '완료', label_en: null },
+      ],
+    });
+
+    await act(async () => {
+      root.render(<Harness orgId="org-1" locale="en" />);
+    });
+    await flush();
+
+    const el = container.querySelector('[data-testid="dump"]') as HTMLElement;
+    expect(el.dataset.statusBacklog).toBe('Idea');
+    expect(el.dataset.statusDone).toBe('완료'); // en 없음 → ko 폴백
+  });
+
+  it('orgId가 없으면 fetch 자체를 호출하지 않고(불필요 네트워크 0) 전부 undefined다', async () => {
+    await act(async () => {
+      root.render(<Harness orgId={undefined} locale="ko" />);
+    });
+    await flush();
+
+    expect(fetchWithAuthMock).not.toHaveBeenCalled();
+    const el = container.querySelector('[data-testid="dump"]') as HTMLElement;
+    expect(el.dataset.statusBacklog).toBe('');
+    expect(el.dataset.loading).toBe('false');
+  });
+
+  it('응답 !ok면 조용히 빈 목록으로 처리한다(캔버스 렌더 자체는 안 깨짐)', async () => {
+    fetchWithAuthMock.mockResolvedValue({ ok: false, json: async () => { throw new Error('unused'); } });
+
+    await act(async () => {
+      root.render(<Harness orgId="org-1" locale="ko" />);
+    });
+    await flush();
+
+    const el = container.querySelector('[data-testid="dump"]') as HTMLElement;
+    expect(el.dataset.statusBacklog).toBe('');
+  });
+});

--- a/apps/web/src/hooks/use-org-domain-labels.test.tsx
+++ b/apps/web/src/hooks/use-org-domain-labels.test.tsx
@@ -95,6 +95,31 @@ describe('useOrgDomainLabels — 라벨 API 인덱싱+로케일 선택(#3287 AC4
     expect(el.dataset.statusDone).toBe('완료'); // en 없음 → ko 폴백
   });
 
+  // 유나 design:changes(PR#3687, 2026-09-01) — 빈 문자열("")은 null이 아니라서 예전
+  // `preferred ?? entry.label_ko ?? entry.label_en`이 그대로 반환해 소비처의
+  // `statusLabel(...) ?? t(...)` 폴백도 안 타 헤더/배지가 빈칸으로 렌더될 뻔했다.
+  it('빈 문자열 라벨("")은 값이 아니라 undefined로 취급된다(canonical 폴백 트리거)', async () => {
+    fetchWithAuthMock.mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { domain: 'status', canonical_slug: 'backlog', label_ko: '', label_en: 'Idea' },
+        { domain: 'status', canonical_slug: 'done', label_ko: '   ', label_en: null },
+      ],
+    });
+
+    await act(async () => {
+      root.render(<Harness orgId="org-1" locale="ko" />);
+    });
+    await flush();
+
+    const el = container.querySelector('[data-testid="dump"]') as HTMLElement;
+    // ko 우선인데 label_ko=""(빈 값) — label_en('Idea')로 폴백해야 한다(빈 문자열을
+    // "설정된 라벨"로 오인해 그대로 반환하면 안 됨).
+    expect(el.dataset.statusBacklog).toBe('Idea');
+    // label_ko가 공백뿐이고 label_en도 없음 — 둘 다 무효라 완전히 undefined(canonical 폴백).
+    expect(el.dataset.statusDone).toBe('');
+  });
+
   it('orgId가 없으면 fetch 자체를 호출하지 않고(불필요 네트워크 0) 전부 undefined다', async () => {
     await act(async () => {
       root.render(<Harness orgId={undefined} locale="ko" />);

--- a/apps/web/src/hooks/use-org-domain-labels.ts
+++ b/apps/web/src/hooks/use-org-domain-labels.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { fetchWithAuth } from '@/lib/db/client';
+
+/**
+ * story #3287([도메인탈고정·축1 Phase1] org 표시 라벨 레이어) FE 소비 — BE
+ * `GET /api/v2/organizations/{org_id}/domain-labels`(canonical slug 불변, org별 표시
+ * 라벨만) 조회+캐시. canonical_slug는 이 훅이 절대 안 바꾼다 — 호출부(kanban-board 등)가
+ * 기존 하드코딩 라벨(t(col.i18nKey) 등)을 그대로 fallback으로 쓰고, 이 훅이 반환하는
+ * override가 있을 때만 그 위에 얹는다("미설정=시스템 기본값" 원칙, BE 설계 doc
+ * entity:doc:1fa7e2a9-c8c2-4a8e-a9da-35bce52a5012 §Phase 1 그대로).
+ */
+
+type DomainLabelEntry = {
+  domain: 'entity_type' | 'status';
+  canonical_slug: string;
+  label_ko: string | null;
+  label_en: string | null;
+};
+
+export interface OrgDomainLabels {
+  /** (domain, canonical_slug) → label. 현재 locale의 label_ko/label_en 중 값이 있는
+   *쪽만 채워진다 — 없으면 호출부가 자기 기본 라벨(i18n)로 폴백. */
+  statusLabel(canonicalSlug: string): string | undefined;
+  entityTypeLabel(canonicalSlug: string): string | undefined;
+  loading: boolean;
+}
+
+function pickLocaleLabel(entry: DomainLabelEntry, locale: string): string | undefined {
+  const preferred = locale.startsWith('ko') ? entry.label_ko : entry.label_en;
+  return preferred ?? entry.label_ko ?? entry.label_en ?? undefined;
+}
+
+/** orgId가 없으면(아직 로딩 중 등) 빈 오버라이드 — 전부 폴백(회귀 0). locale은 next-intl의
+ * useLocale()을 호출부가 넘긴다(이 훅 자체는 next-intl 의존을 안 늘리려고 순수 string으로 받음). */
+export function useOrgDomainLabels(orgId: string | undefined, locale: string): OrgDomainLabels {
+  const [entries, setEntries] = useState<DomainLabelEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!orgId) {
+      setEntries([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    void (async () => {
+      try {
+        const res = await fetchWithAuth(`/api/v2/organizations/${orgId}/domain-labels`);
+        if (!res.ok) {
+          if (!cancelled) setEntries([]);
+          return;
+        }
+        const data = (await res.json()) as DomainLabelEntry[];
+        if (!cancelled) setEntries(data);
+      } catch {
+        // 네트워크 실패 등 — 조용히 폴백(라벨 오버라이드는 장식 계층, 실패가 보드 자체를
+        // 막으면 안 된다·설계 doc의 "무설정=기본값" 원칙과 동일 정신).
+        if (!cancelled) setEntries([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId]);
+
+  const byKey = new Map<string, DomainLabelEntry>();
+  for (const e of entries) byKey.set(`${e.domain}:${e.canonical_slug}`, e);
+
+  return {
+    statusLabel: (slug) => {
+      const entry = byKey.get(`status:${slug}`);
+      return entry ? pickLocaleLabel(entry, locale) : undefined;
+    },
+    entityTypeLabel: (slug) => {
+      const entry = byKey.get(`entity_type:${slug}`);
+      return entry ? pickLocaleLabel(entry, locale) : undefined;
+    },
+    loading,
+  };
+}

--- a/apps/web/src/hooks/use-org-domain-labels.ts
+++ b/apps/web/src/hooks/use-org-domain-labels.ts
@@ -27,9 +27,18 @@ export interface OrgDomainLabels {
   loading: boolean;
 }
 
+// 유나 design:changes(PR#3687, 2026-09-01) — 빈 문자열("")은 null이 아니라 값이 있는
+// 것으로 취급돼 그대로 반환됐다(?? 는 null/undefined만 거름). 소비처(kanban-board 등)의
+// `statusLabel(...) ?? t(...)` 폴백도 ""는 값으로 보고 폴백 안 타 헤더/배지가 빈칸으로
+// 렌더됐을 것 — trim 후 빈 값이면 undefined로 정규화해 canonical 폴백이 항상 뜨게 한다.
+function normalizeLabel(value: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 function pickLocaleLabel(entry: DomainLabelEntry, locale: string): string | undefined {
-  const preferred = locale.startsWith('ko') ? entry.label_ko : entry.label_en;
-  return preferred ?? entry.label_ko ?? entry.label_en ?? undefined;
+  const preferred = normalizeLabel(locale.startsWith('ko') ? entry.label_ko : entry.label_en);
+  return preferred ?? normalizeLabel(entry.label_ko) ?? normalizeLabel(entry.label_en);
 }
 
 /** orgId가 없으면(아직 로딩 중 등) 빈 오버라이드 — 전부 폴백(회귀 0). locale은 next-intl의


### PR DESCRIPTION
## Summary
- story #3287([도메인탈고정·축1 Phase1] org 표시 라벨 레이어) AC4 — BE(PR #3685, merged)가 만든 `org_domain_label` API를 FE가 실제로 소비하도록 이어붙였다.
- 신규 `useOrgDomainLabels(orgId, locale)` 훅: `GET /api/v2/organizations/{orgId}/domain-labels`를 조회해 `statusLabel(canonicalSlug)`/`entityTypeLabel(canonicalSlug)`로 오버라이드를 노출(locale=ko면 label_ko 우선·en 폴백, 그 반대도 동일; 미설정 slug는 `undefined` — 호출부가 canonical 문구로 폴백).
- 소비 지점(전부 `getStatusLabel?.(canonicalSlug) ?? t(...)` 패턴, 오버라이드 미설정 시 100% 기존 렌더 그대로):
  - 클래식(5-status) 보드 컬럼 헤더(`kanban-board.tsx` COLUMNS 블록)
  - 카드 내부 상태 배지(`story-card.tsx`의 `statuses`/`proofStateLabel`) — `KanbanColumn`·`KanbanTrustColumn`·`KanbanListView`(모바일 리스트) 전부 경유, DragOverlay 카드 포함
- **의도적으로 안 건드린 것**: canonical `status`(col.id — 드래그/전이 판정·`STATUS_COLOR` 축) 자체, TRUST_COLUMNS 자체 컬럼 헤더 어휘(대기/실행 중/입력 필요/... — status 도메인과 다른 별개 어휘라 오버라이드 대상 아님). 카드 내부 배지는 `story.status`(canonical, trust_stage와 무관)를 보여주므로 trust축 카드에도 오버라이드가 반영되는 게 맞다 — 테스트로 이 구분을 고정.

## 알려진 잔여 스코프(이번 PR에 미포함, PO 보고 예정)
- "네비"(PO가 언급) — 구체적 렌더 지점 미확定. 그라운딩 필요.
- `story-detail-panel.tsx`(카드 클릭 시 열리는 상세 패널의 상태 배지+드롭다운)도 같은 `t(statusKey)` 패턴으로 라벨이 안 바뀜 — 여러 호출부(플로우뷰 포함)에 걸쳐 있어 이번 패스 스코프 밖으로 판단, 발견만 보고.
- `entityTypeLabel()`(entity_type 도메인, 예: «스토리»→«캠페인») — 이번 패스는 PO의 구체 예시(보드 컬럼)인 status 도메인만. 소비할 구체 렌더 지점 미확定.

## Test plan
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm lint` — 0 errors(기존 무관 파일 5개 warning만)
- [x] `pnpm vitest run src/components/kanban/ src/hooks/use-org-domain-labels.test.tsx` — 148/148 pass
  - 기존 `kanban-board.test.tsx` 42건 전부 무변경 통과(orgId 없는 기존 테스트 하네스 → hook no-op → 회귀 0 실증)
  - 신규: `use-org-domain-labels.test.tsx`(locale 선택·미설정 slug undefined·orgId 없으면 fetch 0회·응답 !ok graceful) + `kanban-board.test.tsx` 3건(클래식 헤더 오버라이드 적용/미설정 컬럼 무변경/트러스트축 헤더 불변+카드배지 반영)
- [ ] AC4 "실 UI 확認"(선생님/PO 라이브 검증 몫) — dev org에 오버라이드 PUT 후 보드 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016f7RbuzR1Mc5cXkJLWbggn