### PR TITLE
[SID:3291] M1·마케팅자동화 — external_publish 항상-수동 게이트 신설

### DIFF
--- a/backend/app/models/hitl_config.py
+++ b/backend/app/models/hitl_config.py
@@ -24,6 +24,10 @@ DISPOSITIONS = frozenset({"allow_auto", "ask", "deny"})
 # 안 준다 — 순수히 「generic POST /api/v2/gates로 생성 허용」 관문 통과 목적.
 GATE_TYPES = frozenset({
     "pr_review", "qa", "merge", "deploy", "workflow_config_publish", "agent_decision_request",
+    # story #3291(M1·마케팅자동화) — 불가역 외부 발신(SNS/광고 게시). gate_service.py의
+    # _ALWAYS_MANUAL_GATE_TYPES에도 등재해 org posture 무관 항상 pending 강제(순수히
+    # 여기 등재만으론 disposition 자동판정에 영향 없음 — 위 agent_decision_request 주석 참고).
+    "external_publish",
 })
 
 _POSTURE_DEFAULT: dict[str, str] = {

--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -1181,7 +1181,11 @@ async def a2a_rpc(
     return JsonRpcResponse(id=body.id, result=result)
 
 
-_VALID_LINK_GATE_REASONS = frozenset({"auth"})
+# story #3291(M1·마케팅자동화) — "external_publish": 불가역 외부 발신 게이트 link. _advance_
+# task_state의 분기는 "auth"만 특수(TASK_STATE_AUTH_REQUIRED) — 그 외 선언값(이것 포함)은
+# 이미 기존 else 분기(TASK_STATE_INPUT_REQUIRED)로 정확히 처리되므로 그쪽 로직 변경 불요,
+# 이 검증 세트에만 추가하면 된다.
+_VALID_LINK_GATE_REASONS = frozenset({"auth", "external_publish"})
 
 
 class LinkGateBody(BaseModel):

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -66,7 +66,11 @@ RiskGrade = Literal["low", "high"]
 # 5a34ef7f)가 정확히 이 간극에서 났다 — FE가 note/evidence_viewed를 안 보내는 채로 배선돼
 # 있었는데 그 사실을 아무 코드도 "doc_approval=high"라고 선언하지 않고 있었다. low로
 # 등재하지 않는다(신중 결재 취지 훼손, PO 명시 판단) — high로 명시.
-_HIGH_RISK_GATE_TYPES: frozenset[str] = frozenset({"merge", "deploy", "workflow_config_publish", DOC_GATE_TYPE})
+# story #3291(M1·마케팅자동화, 2026-09-01) — external_publish(불가역 외부 발신) 명시 high
+# 등재. doc_approval 미등재 실사고(위 코멘트) 선례를 그대로 따라 폴백 의존 대신 명시.
+_HIGH_RISK_GATE_TYPES: frozenset[str] = frozenset(
+    {"merge", "deploy", "workflow_config_publish", DOC_GATE_TYPE, "external_publish"}
+)
 #
 # story #2709(2026-08-17, PO 판정) — agent_decision_request를 명시 low 등재. 미등재=폴백(§2.3
 # 보수적 high)에 기대는 게 안전한 기본값이 아니라는 것을 story #6c89e40d(doc_approval 미등재
@@ -326,6 +330,13 @@ _ALWAYS_MANUAL_GATE_TYPES: frozenset[str] = frozenset(
         # 와 동형 근거 — 판단이 존재 이유인 게이트가 permissive posture로 자동 승인되면 애초에
         # 만든 이유가 없어진다).
         "support_escalation_review",
+        # story #3291(M1·마케팅자동화, 2026-09-01, PO 확定) — 불가역 외부 발신(SNS/광고 게시).
+        # 마케팅 레시피가 role→agent 바인딩까지는 자유롭게 자동화해도(축2-ⓐ), 실제 외부로
+        # 나가는 마지막 발걸음만은 org posture(permissive 포함) 무관 항상 사람이 승인해야
+        # 한다 — doc_approval/agent_decision_request와 동형 근거(판단이 존재 이유인 게이트가
+        # 자동 승인되면 만든 이유가 없어진다). ⚠️이 스토리는 게이트 타입 자체가 항상-수동임을
+        # 강제할 뿐 — 실제 발행 직전 gate.status 확인(chokepoint)은 발행 커넥터 스토리 몫.
+        "external_publish",
     }
 )
 # ⚠️story #2709 — agent_decision_request가 항상 manual(=posture 무관 항상 pending)인 이유:

--- a/backend/tests/test_1972_gate_risk_grade.py
+++ b/backend/tests/test_1972_gate_risk_grade.py
@@ -70,6 +70,7 @@ _RISK_GRADE_MATRIX: list[tuple[str | None, str, str]] = [
     ("conservative", "workflow_config_publish", "high"),
     ("conservative", "doc_approval", "high"),
     ("conservative", "agent_decision_request", "high"),  # story #2709
+    ("conservative", "external_publish", "high"),  # story #3291
     ("conservative", _UNCLASSIFIED_GATE_TYPE, "high"),
     # posture=permissive → 항상 low(gate_type 무관, §2.1)
     ("permissive", "pr_review", "low"),
@@ -79,6 +80,7 @@ _RISK_GRADE_MATRIX: list[tuple[str | None, str, str]] = [
     ("permissive", "workflow_config_publish", "low"),
     ("permissive", "doc_approval", "low"),
     ("permissive", "agent_decision_request", "low"),  # story #2709
+    ("permissive", "external_publish", "low"),  # story #3291 — §2.1 1차 축은 gate_type 무관
     ("permissive", _UNCLASSIFIED_GATE_TYPE, "low"),
     # posture=balanced → 2차 축(gate_type, §2.2) + 폴백(§2.3)
     ("balanced", "pr_review", "low"),
@@ -87,6 +89,7 @@ _RISK_GRADE_MATRIX: list[tuple[str | None, str, str]] = [
     ("balanced", "deploy", "high"),
     ("balanced", "workflow_config_publish", "high"),
     ("balanced", "doc_approval", "high"),  # 2차 축 명시 등재(더 이상 폴백 아님, ⓐ')
+    ("balanced", "external_publish", "high"),  # story #3291 — _HIGH_RISK_GATE_TYPES 명시 등재
     # story #2709 — agent_decision_request는 _LOW_RISK_GATE_TYPES에 명시 등재(gate_service.py) —
     # doc_approval과 반대로 low(2차 축에서 직접, 폴백 아님). 근거: 이 gate는 되돌릴 수 없는
     # 액션을 그 자신이 트리거하지 않는다(에이전트가 이미 자기 가정대로 진행 중인 결정의
@@ -100,6 +103,7 @@ _RISK_GRADE_MATRIX: list[tuple[str | None, str, str]] = [
     (None, "deploy", "high"),
     (None, "workflow_config_publish", "high"),
     (None, "doc_approval", "high"),  # 2차 축 명시 등재(더 이상 폴백 아님, ⓐ')
+    (None, "external_publish", "high"),  # story #3291 — balanced와 동일(§2.2 2차 축)
     (None, "agent_decision_request", "low"),  # story #2709 — balanced와 동일(§2.2 2차 축)
     (None, _UNCLASSIFIED_GATE_TYPE, "high"),  # 폴백: 진짜 미분류 gate_type → 보수적 고위험
 ]

--- a/backend/tests/test_3291_external_publish_gate.py
+++ b/backend/tests/test_3291_external_publish_gate.py
@@ -1,0 +1,182 @@
+"""story #3291(M1·마케팅자동화) — external_publish 게이트: 불가역 외부 발신(SNS/광고 게시)은
+org posture(permissive 포함) 무관 항상 사람 승인을 거쳐야 한다.
+
+⚠️이 스토리는 "게이트 타입이 항상-수동"임을 강제할 뿐 — 실제 발행 직전 gate.status 확인
+(chokepoint)은 발행 커넥터 스토리 몫(doc axis2-recipe-mechanism-event-definitions-design §E
+경계 그대로).
+
+검증 축:
+- AC1: org posture=permissive(allow_auto)여도 create_gate가 status="pending"·
+  requires_human=True를 강제(뮤테이션: _ALWAYS_MANUAL_GATE_TYPES에서 external_publish를
+  빼면 이 pin이 RED — "진짜 항상-수동"의 증거).
+- AC2: rejected 후 재상신(create_gate 재호출)도 pending으로 재오픈.
+- AC3: hitl_config.GATE_TYPES에 등재 — generic POST /api/v2/gates 스키마 검증 통과.
+- AC4: a2a.py LinkGateBody가 reason="external_publish"를 거부하지 않음.
+- AC5: _HIGH_RISK_GATE_TYPES 명시 등재(doc_approval 미등재 실사고 선례 반복 방지).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org3291", slug=f"org3291-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _set_permissive_posture(session, org_id):
+    from app.models.hitl_config import OrgGatePolicy
+
+    session.add(OrgGatePolicy(id=uuid.uuid4(), org_id=org_id, posture="permissive"))
+    await session.commit()
+
+
+# ─── AC1: 핵심 pin — permissive posture여도 external_publish는 항상 pending ──────
+
+@pytest.mark.anyio
+async def test_external_publish_always_pending_even_with_permissive_posture():
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _set_permissive_posture(s, org_id)
+            caller_id = uuid.uuid4()
+            work_item_id = uuid.uuid4()
+
+            gate = await create_gate(
+                session=s, org_id=org_id, work_item_id=work_item_id,
+                work_item_type="marketing_publish", gate_type="external_publish",
+                member_id=caller_id, role_id=caller_id,
+                neutral_facts={"channel": "linkedin", "content": "draft post"},
+                project_id=project_id, notify=False,
+            )
+            await s.commit()
+
+            assert gate.status == "pending", (
+                "external_publish는 _ALWAYS_MANUAL — org posture(permissive)와 무관하게 항상 pending"
+            )
+            assert gate.requires_human is True
+    finally:
+        await engine.dispose()
+
+
+# ─── AC2: rejected 후 재상신 → pending 재오픈 ────────────────────────────────
+
+@pytest.mark.anyio
+async def test_external_publish_rejected_reopens_to_pending():
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            await _set_permissive_posture(s, org_id)
+            caller_id = uuid.uuid4()
+            work_item_id = uuid.uuid4()
+
+            gate = await create_gate(
+                session=s, org_id=org_id, work_item_id=work_item_id,
+                work_item_type="marketing_publish", gate_type="external_publish",
+                member_id=caller_id, role_id=caller_id,
+                neutral_facts={"channel": "linkedin"}, project_id=project_id, notify=False,
+            )
+            await s.commit()
+
+            # 반려 상태로 직접 전이(사람이 거부했다고 가정) — 재상신 시나리오 세팅.
+            gate.status = "rejected"
+            gate.resolved_at = None
+            await s.commit()
+
+            reopened = await create_gate(
+                session=s, org_id=org_id, work_item_id=work_item_id,
+                work_item_type="marketing_publish", gate_type="external_publish",
+                member_id=caller_id, role_id=caller_id,
+                neutral_facts={"channel": "linkedin", "content": "revised post"},
+                project_id=project_id, notify=False,
+            )
+            await s.commit()
+
+            assert reopened.id == gate.id
+            assert reopened.status == "pending"
+            assert reopened.requires_human is True
+    finally:
+        await engine.dispose()
+
+
+# ─── AC3: hitl_config.GATE_TYPES 등재 — schema validator 통과 ────────────────
+
+def test_gate_types_includes_external_publish():
+    from app.models.hitl_config import GATE_TYPES
+
+    assert "external_publish" in GATE_TYPES
+
+
+def test_schema_validator_accepts_external_publish():
+    from app.schemas.hitl_config import OrgGateOverrideCreate
+
+    # gate_type 필드 검증기가 GATE_TYPES를 그대로 참조 — 미등재였다면 ValueError.
+    override = OrgGateOverrideCreate(
+        role_id=uuid.uuid4(), gate_type="external_publish", disposition="ask",
+    )
+    assert override.gate_type == "external_publish"
+
+
+# ─── AC4: a2a.py LinkGateBody reason 허용 ────────────────────────────────────
+
+def test_a2a_link_gate_accepts_external_publish_reason():
+    from app.routers.a2a import _VALID_LINK_GATE_REASONS
+
+    assert "external_publish" in _VALID_LINK_GATE_REASONS
+
+
+# ─── AC5: high-risk 명시 등재(doc_approval 미등재 실사고 재발 방지) ──────────
+
+def test_high_risk_gate_types_includes_external_publish():
+    from app.services.gate_service import _HIGH_RISK_GATE_TYPES
+
+    assert "external_publish" in _HIGH_RISK_GATE_TYPES


### PR DESCRIPTION
story #3291(M1·마케팅자동화 서버측 조각). 「불가역 외부 발신(SNS/광고 게시)은 사람 승인 게이트를 통과해야만 실행」을 강제 — org posture(permissive 포함) 무관 항상 pending.

PO가 Explore로 develop 실측한 정확한 4개 지점 그대로 반영:
1. `gate_service.py::_ALWAYS_MANUAL_GATE_TYPES`에 등재 — `create_gate`/`_reopen_rejected_gate` 둘 다 이 프로즌셋을 참조해 disposition 결과(auto_passed 포함)를 강제로 pending 덮어씀.
2. `hitl_config.py::GATE_TYPES`에 등재 — generic `POST /api/v2/gates` 스키마 검증(schemas/hitl_config.py는 이 상수를 직접 import하므로 별도 수정 불요).
3. `a2a.py::_VALID_LINK_GATE_REASONS`에 추가 — 발행 task를 이 게이트에 link해 승인 전 진행 봉쇄(reason="auth"만 AUTH_REQUIRED로 분기, 그 외는 기존 else 분기가 이미 INPUT_REQUIRED로 정확히 처리 — `_advance_task_state` 로직 변경 불요).
4. `_HIGH_RISK_GATE_TYPES`에도 명시 등재(doc_approval 미등재 실사고 선례 반복 방지).

## 검증
- 신규 pin 6건: **핵심** — org posture=permissive로 설정해도 `create_gate`가 status=pending·requires_human=true 강제(뮤테이션: external_publish를 `_ALWAYS_MANUAL_GATE_TYPES`에서 빼면 정확히 이 2건만 RED — "진짜 항상-수동"의 증거) + rejected 재상신 시 pending 재오픈 + GATE_TYPES/schema validator/a2a reason/_HIGH_RISK 등재 확認.
- 관련 회귀(agent_decision_request·gate reopen·support_escalation·hitl_config·a2a link_gate 계열) 전부 PASS.

## 스코프 밖(스토리 명시)
실제 발행 직전 gate.status 확認(chokepoint)은 발행 커넥터(LinkedIn 등) 스토리 몫 — 이 스토리는 게이트 타입 자체가 항상-수동임을 서버에 심는 것까지.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_019rkXVqy2DF1aAN7szuqp44