### PR TITLE
[SID:3293] 축2-ⓒ settings 갤러리 신세대 이전 — recipe_role_bindings apply로 교체

### DIFF
--- a/apps/web/src/app/api/events/definitions/[id]/apply/route.ts
+++ b/apps/web/src/app/api/events/definitions/[id]/apply/route.ts
@@ -1,0 +1,12 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// story #3288(축2-ⓐ) — POST /api/v2/events/definitions/{id}/apply 프록시. body =
+// {project_id?, role_mapping}. recipe_role_bindings upsert(BE 검증체인 그대로 통과 —
+// has_project_access·stage_metadata 키·org 스코프 agent 검증).
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/events/definitions/${id}/apply`);
+}

--- a/apps/web/src/app/api/events/definitions/[id]/bindings/route.ts
+++ b/apps/web/src/app/api/events/definitions/[id]/bindings/route.ts
@@ -1,0 +1,11 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// story #3293(축2-ⓒ §B) — GET /api/v2/events/definitions/{id}/bindings 프록시. query
+// project_id(선택) 그대로 전달(url.search 자동 forward). 응답 {bindings: {stage: agent_id}}.
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/events/definitions/${id}/bindings`);
+}

--- a/apps/web/src/app/api/workflow-templates/[slug]/apply/route.ts
+++ b/apps/web/src/app/api/workflow-templates/[slug]/apply/route.ts
@@ -1,6 +1,0 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
-
-export async function POST(request: Request, { params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params;
-  return proxyToFastapi(request, `/api/v2/workflow-templates/${slug}/apply`);
-}

--- a/apps/web/src/app/api/workflow-templates/[slug]/route.ts
+++ b/apps/web/src/app/api/workflow-templates/[slug]/route.ts
@@ -1,6 +1,0 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
-
-export async function GET(request: Request, { params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params;
-  return proxyToFastapi(request, `/api/v2/workflow-templates/${slug}`);
-}

--- a/apps/web/src/app/api/workflow-templates/route.ts
+++ b/apps/web/src/app/api/workflow-templates/route.ts
@@ -1,5 +1,0 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
-
-export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/workflow-templates');
-}

--- a/apps/web/src/components/settings/workflow-template-gallery-section.test.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 //
-// story #2501 — `data.detail`은 실 envelope({data,error,meta})에 없는 필드라 이 분기는
-// 항상 죽어있었다(그라운딩 확認 — backend apply_template()은 generic HTTP상태 코드만
-// 낸다) — 적용 실패 사유가 한 번도 화면에 안 뜨고 항상 '적용 실패'만 보여줬다.
-// `error.message`로 교정한 회귀가드.
+// story #3293(도메인탈고정 축2-ⓒ) — 구세대 workflow_templates 소비를 신세대
+// (EventDefinition/recipe_role_bindings, 축2-ⓐ story #3288) 이전에 맞춰 전면 재작성.
+// story #2501(error.message 분기)·#3010(elev-card 토큰) 회귀가드는 새 fetch 표면
+// (/api/events/definitions 계열)에 맞춰 그대로 보존.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
@@ -41,50 +41,55 @@ async function flush() {
   await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
 }
 
-// role_ref가 있는 step이 하나도 없어 requiredSteps가 비고, "적용하기" 버튼이 role
-// 매핑 없이 바로 활성화된다 — 이 테스트가 검증하려는 건 apply 실패 응답 처리이지
-// 역할매핑 UI가 아니므로 최소 fixture로 그 표면만 자른다.
-const TEMPLATE = {
-  slug: 'tmpl-1',
-  name: '테스트 템플릿',
+const DEFINITION = {
+  id: 'def-1',
+  key: 'preset.test.recipe',
+  org_id: null,
+  name: '테스트 레시피',
   description: '설명',
-  chain_length: 1,
-  steps: [],
-  presets: {},
-  rules_template: [],
-  is_system: true,
+  payload_schema: { properties: { stage: { enum: ['step_1'] } } },
+  stage_metadata: {},
+  enabled: true,
 };
 
-describe('WorkflowTemplateGallerySection — error.code 분기 (story #2501)', () => {
+function stubFetch(overrides: Record<string, unknown> = {}) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+    if (url === '/api/events/definitions' && !init) return { ok: true, json: async () => [DEFINITION] };
+    if (url.includes('/api/team-members')) return { ok: true, json: async () => ({ data: [] }) };
+    if (url.includes('/api/events/definitions/def-1/bindings')) {
+      // step_1이 이미 배정돼 있어야 requiredStages 검증(빈 매핑 차단)을 통과하고
+      // 실제 apply fetch까지 도달한다 — 이 describe 블록의 관심사는 apply 실패
+      // 응답 렌더링이지 역할매핑 완결성 검증이 아니므로 최소 fixture로 그 표면만 자른다.
+      return { ok: true, json: async () => ({ bindings: { step_1: 'agent-1' } }) };
+    }
+    if (url === '/api/events/definitions/def-1/apply' && overrides['apply']) {
+      return overrides['apply'];
+    }
+    throw new Error('unexpected fetch: ' + url);
+  }));
+}
+
+describe('WorkflowTemplateGallerySection — error.message 분기 (story #2501 계승)', () => {
   it('적용 실패 사유가 raw "적용 실패" 폴백 대신 실 서버 메시지로 뜬다(핵심 회귀가드)', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === '/api/workflow-templates' && !init) return { ok: true, json: async () => [TEMPLATE] };
-      if (url.includes('/api/team-members')) return { ok: true, json: async () => ({ data: [] }) };
-      if (url.includes('/api/v1/agent-routing-rules')) return { ok: true, json: async () => ({ data: [] }) };
-      if (url === '/api/workflow-templates/tmpl-1' && (!init || init.method === undefined)) {
-        return { ok: true, json: async () => TEMPLATE };
-      }
-      if (url === '/api/workflow-templates/tmpl-1/apply') {
-        return {
-          ok: false,
-          json: async () => ({
-            data: null,
-            error: { code: 'UNPROCESSABLE_ENTITY', message: 'agent(s) not found in this org: abc' },
-            meta: null,
-          }),
-        };
-      }
-      throw new Error('unexpected fetch: ' + url);
-    }));
+    stubFetch({
+      apply: {
+        ok: false,
+        json: async () => ({
+          data: null,
+          error: { code: 'UNPROCESSABLE_ENTITY', message: 'agent(s) not found in this org: abc' },
+          meta: null,
+        }),
+      },
+    });
 
     await act(async () => { root.render(wrap(<WorkflowTemplateGallerySection projectId="proj-1" />)); });
     await flush();
 
-    const tmplBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('테스트 템플릿'));
+    const tmplBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('테스트 레시피'));
     await act(async () => { tmplBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
 
-    const applyBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '적용하기');
+    const applyBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '재적용(덮어쓰기)');
     expect(applyBtn).not.toBeUndefined();
     await act(async () => { applyBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
@@ -94,27 +99,18 @@ describe('WorkflowTemplateGallerySection — error.code 분기 (story #2501)', (
   });
 
   it('backend가 error.message를 안 주면(네트워크 계층 등) 안전 폴백 "적용 실패"로 간다(회귀 없음)', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === '/api/workflow-templates' && !init) return { ok: true, json: async () => [TEMPLATE] };
-      if (url.includes('/api/team-members')) return { ok: true, json: async () => ({ data: [] }) };
-      if (url.includes('/api/v1/agent-routing-rules')) return { ok: true, json: async () => ({ data: [] }) };
-      if (url === '/api/workflow-templates/tmpl-1' && (!init || init.method === undefined)) {
-        return { ok: true, json: async () => TEMPLATE };
-      }
-      if (url === '/api/workflow-templates/tmpl-1/apply') {
-        return { ok: false, json: async () => ({ data: null, error: {}, meta: null }) };
-      }
-      throw new Error('unexpected fetch: ' + url);
-    }));
+    stubFetch({
+      apply: { ok: false, json: async () => ({ data: null, error: {}, meta: null }) },
+    });
 
     await act(async () => { root.render(wrap(<WorkflowTemplateGallerySection projectId="proj-1" />)); });
     await flush();
 
-    const tmplBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('테스트 템플릿'));
+    const tmplBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('테스트 레시피'));
     await act(async () => { tmplBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
 
-    const applyBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '적용하기');
+    const applyBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '재적용(덮어쓰기)');
     await act(async () => { applyBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await flush();
 
@@ -125,18 +121,49 @@ describe('WorkflowTemplateGallerySection — error.code 분기 (story #2501)', (
 // story #3010(로드맵 P3, L1) — 선택 가능한 템플릿 카드는 인라인 카드라 --elev-card.
 describe('WorkflowTemplateGallerySection — 로드맵 P3 L1(템플릿 카드 elevation 토큰)', () => {
   it('템플릿 카드가 hover:shadow-[var(--elev-card)]를 쓰고 hover:shadow-sm은 안 쓴다', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === '/api/workflow-templates' && !init) return { ok: true, json: async () => [TEMPLATE] };
-      if (url.includes('/api/team-members')) return { ok: true, json: async () => ({ data: [] }) };
-      if (url.includes('/api/v1/agent-routing-rules')) return { ok: true, json: async () => ({ data: [] }) };
-      throw new Error('unexpected fetch: ' + url);
-    }));
+    stubFetch();
     await act(async () => { root.render(wrap(<WorkflowTemplateGallerySection projectId="proj-1" />)); });
     await flush();
 
-    const tmplBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('테스트 템플릿'));
+    const tmplBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('테스트 레시피'));
     expect(tmplBtn).not.toBeUndefined();
     expect(tmplBtn?.className).toContain('hover:shadow-[var(--elev-card)]');
     expect(tmplBtn?.className).not.toMatch(/hover:shadow-sm(\s|$)/);
+  });
+});
+
+// story #3293(축2-ⓒ) 신규 — PO 확定 A: overwrite 확認 다이얼로그 없이 기존 배정값 프리필.
+describe('WorkflowTemplateGallerySection — 축2-ⓒ 프리필(PO 확定 A)', () => {
+  it('기존 배정이 있으면 확認 다이얼로그 없이 드롭다운에 프리필된다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/events/definitions' && !init) {
+        return { ok: true, json: async () => [{ ...DEFINITION, stage_metadata: { step_1: { role: 'Developer', action: 'do it' } } }] };
+      }
+      if (url.includes('/api/team-members')) {
+        return { ok: true, json: async () => ({ data: [{ id: 'agent-1', name: '디디군', type: 'agent' }] }) };
+      }
+      if (url.includes('/api/events/definitions/def-1/bindings')) {
+        return { ok: true, json: async () => ({ bindings: { step_1: 'agent-1' } }) };
+      }
+      throw new Error('unexpected fetch: ' + url);
+    }));
+
+    await act(async () => { root.render(wrap(<WorkflowTemplateGallerySection projectId="proj-1" />)); });
+    await flush();
+
+    // "적용됨" 배지가 이미 떠 있어야 한다(bindings 비어있지 않음).
+    expect(container.textContent).toContain('적용됨');
+
+    const tmplBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('테스트 레시피'));
+    await act(async () => { tmplBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await flush();
+
+    // 확認 다이얼로그 텍스트가 없어야 한다(PO 확定 A — 다이얼로그 자체를 없앰).
+    expect(container.textContent).not.toContain('교체됩니다');
+    // 대신 select가 기존 배정값으로 프리필돼 있어야 한다.
+    const select = container.querySelector('select');
+    expect(select?.value).toBe('agent-1');
+    // 버튼 라벨도 "재적용" 문구로 이미 적용됨을 알린다.
+    expect(container.textContent).toContain('재적용');
   });
 });

--- a/apps/web/src/components/settings/workflow-template-gallery-section.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.tsx
@@ -120,7 +120,7 @@ export function WorkflowTemplateGallerySection({
     setApplying(true);
     setApplyResult(null);
     try {
-      const res = await fetch(`/api/events/definitions/${selected.id}/apply`, {
+      const res = await fetchWithAuth(`/api/events/definitions/${selected.id}/apply`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project_id: projectId, role_mapping: roleMapping }),

--- a/apps/web/src/components/settings/workflow-template-gallery-section.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.tsx
@@ -6,23 +6,14 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { fetchWithAuth } from '@/lib/db/client';
+import { cyclicStages, isCyclicDefinition, type EventDefinitionResponse } from '@/components/loops/loop-create-dialog';
 
-interface TemplateStep {
-  pattern: string;
-  role_ref: string;
-  default_label?: string;
-}
-
-interface WorkflowTemplate {
-  slug: string;
-  name: string;
-  description: string;
-  chain_length: number;
-  steps: TemplateStep[];
-  presets: Record<string, Record<string, string>>;
-  rules_template: Record<string, unknown>[];
-  is_system: boolean;
-}
+// story #3293(도메인탈고정 축2-ⓒ) — 구세대 workflow_templates(story #3010 P3 등) 소비를
+// 신세대(EventDefinition/recipe_role_bindings, 축2-ⓐ story #3288)로 이전. doc
+// axis2c-gallery-migration-map-and-design §2/§3 매핑+PO 확定(A/B/C) 그대로:
+// - A: overwrite 확認 다이얼로그 대신 기존 배정값을 드롭다운에 프리필(§B read로 조회).
+// - B: 신규 GET .../bindings 로 "적용됨" 판정+프리필(구세대 agent-routing-rules 스캔 대체).
+// - C: presets(역할명 프리셋) 드롭다운은 스킵 — 저장 로직 무영향, 순수 FE 편의였음.
 
 interface TeamMember {
   id: string;
@@ -31,15 +22,11 @@ interface TeamMember {
   role?: string;
 }
 
-interface AppliedRule {
-  rule_metadata?: { template_slug?: string };
-}
-
-function ChainBadge({ length }: { length: number }) {
+function StageCountBadge({ count }: { count: number }) {
   const labels: Record<number, string> = { 0: 'Kanban', 1: '1-step', 2: '2-step', 3: '3-step' };
   return (
     <Badge variant="secondary" className="text-[10px]">
-      {labels[length] ?? `${length}-step`}
+      {labels[count] ?? `${count}-step`}
     </Badge>
   );
 }
@@ -53,44 +40,46 @@ export function WorkflowTemplateGallerySection({
 }) {
   const _t = useTranslations('settings');
 
-  const [templates, setTemplates] = useState<WorkflowTemplate[]>([]);
+  const [definitions, setDefinitions] = useState<EventDefinitionResponse[]>([]);
   const [agents, setAgents] = useState<TeamMember[]>([]);
   const [loading, setLoading] = useState(true);
-  const [selected, setSelected] = useState<WorkflowTemplate | null>(null);
-  const [loadingDetail, setLoadingDetail] = useState(false);
-  const [appliedSlug, setAppliedSlug] = useState<string | null>(null);
+  const [selected, setSelected] = useState<EventDefinitionResponse | null>(null);
+  const [loadingBindings, setLoadingBindings] = useState(false);
+  const [appliedKeys, setAppliedKeys] = useState<Set<string>>(new Set());
 
   const [roleMapping, setRoleMapping] = useState<Record<string, string>>({});
   const [applying, setApplying] = useState(false);
   const [applyResult, setApplyResult] = useState<{ ok: boolean; message: string } | null>(null);
-  const [overwriteConfirm, setOverwriteConfirm] = useState(false);
 
-  const requiredSteps = selected
-    ? [...new Set(selected.steps.filter(s => s.role_ref).map(s => s.role_ref))]
-    : [];
+  const cyclicDefinitions = definitions.filter(isCyclicDefinition);
 
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
-      const [tmplRes, memberRes, rulesRes] = await Promise.all([
-        fetchWithAuth('/api/workflow-templates'),
+      const [defRes, memberRes] = await Promise.all([
+        fetchWithAuth('/api/events/definitions'),
         fetchWithAuth(`/api/team-members?project_id=${projectId}&type=agent`),
-        fetchWithAuth(`/api/v1/agent-routing-rules?project_id=${projectId}`),
       ]);
-      if (tmplRes.ok) {
-        const data: unknown = await tmplRes.json();
-        setTemplates(Array.isArray(data) ? (data as WorkflowTemplate[]) : []);
+      if (defRes.ok) {
+        const data: unknown = await defRes.json();
+        const defs = Array.isArray(data) ? (data as EventDefinitionResponse[]) : [];
+        setDefinitions(defs);
+        // "적용됨" 배지 — cyclic 정의마다 이 project에 바인딩이 하나라도 있는지 조회.
+        const cyclic = defs.filter(isCyclicDefinition);
+        const applied = new Set<string>();
+        await Promise.all(cyclic.map(async d => {
+          const r = await fetchWithAuth(`/api/events/definitions/${d.id}/bindings?project_id=${projectId}`);
+          if (r.ok) {
+            const j = await r.json() as { bindings?: Record<string, string> };
+            if (Object.keys(j.bindings ?? {}).length > 0) applied.add(d.key);
+          }
+        }));
+        setAppliedKeys(applied);
       }
       if (memberRes.ok) {
         const json = await memberRes.json() as { data?: TeamMember[] } | TeamMember[];
         const members = Array.isArray(json) ? json : ((json as { data?: TeamMember[] }).data ?? []);
         setAgents(members);
-      }
-      if (rulesRes.ok) {
-        const json = await rulesRes.json() as { data?: AppliedRule[] } | AppliedRule[];
-        const rules = Array.isArray(json) ? json : ((json as { data?: AppliedRule[] }).data ?? []);
-        const slug = rules.find(r => r.rule_metadata?.template_slug)?.rule_metadata?.template_slug ?? null;
-        setAppliedSlug(slug);
       }
     } finally {
       setLoading(false);
@@ -99,58 +88,47 @@ export function WorkflowTemplateGallerySection({
 
   useEffect(() => { void loadData(); }, [loadData]);
 
-  const handleSelectTemplate = async (tmpl: WorkflowTemplate) => {
-    setSelected(null);
-    setRoleMapping({});
+  const handleSelectDefinition = async (def: EventDefinitionResponse) => {
+    setSelected(def);
     setApplyResult(null);
-    setOverwriteConfirm(false);
-    setLoadingDetail(true);
+    setLoadingBindings(true);
     try {
-      const res = await fetchWithAuth(`/api/workflow-templates/${tmpl.slug}`);
+      // PO 확定 A — 기존 배정값을 프리필해 "뭘 덮어쓰는지" 보이게(확認 다이얼로그 대체).
+      const res = await fetchWithAuth(`/api/events/definitions/${def.id}/bindings?project_id=${projectId}`);
       if (res.ok) {
-        const full = await res.json() as WorkflowTemplate;
-        setSelected(full);
+        const j = await res.json() as { bindings?: Record<string, string> };
+        setRoleMapping(j.bindings ?? {});
+      } else {
+        setRoleMapping({});
       }
     } finally {
-      setLoadingDetail(false);
+      setLoadingBindings(false);
     }
   };
 
-  const handleApply = async (overwrite = false) => {
+  const requiredStages = selected ? cyclicStages(selected) : [];
+
+  const handleApply = async () => {
     if (!selected) return;
 
-    const missing = requiredSteps.filter(ref => !roleMapping[ref]);
+    const missing = requiredStages.filter(stage => !roleMapping[stage]);
     if (missing.length > 0) {
       setApplyResult({ ok: false, message: `역할 매핑 필요: ${missing.join(', ')}` });
-      return;
-    }
-
-    if (appliedSlug && !overwrite) {
-      setOverwriteConfirm(true);
       return;
     }
 
     setApplying(true);
     setApplyResult(null);
     try {
-      const res = await fetch(`/api/workflow-templates/${selected.slug}/apply`, {
+      const res = await fetch(`/api/events/definitions/${selected.id}/apply`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          project_id: projectId,
-          role_mapping: roleMapping,
-          overwrite_existing: overwrite || !!appliedSlug,
-        }),
+        body: JSON.stringify({ project_id: projectId, role_mapping: roleMapping }),
       });
-      // story #2500 — `data.detail`은 실 envelope({data,error,meta})에 없는 필드라 이
-      // 분기는 항상 죽어있었다(그라운딩 확認 — backend apply_template()은 generic
-      // HTTP상태 코드만 낸다, dict-coded 아님) — 실패 사유가 한 번도 화면에 안 뜨고
-      // 항상 '적용 실패'만 보여줬다. 올바른 필드(error.message)로 교정.
-      const data = await res.json() as { ok?: boolean; rules_created?: number; error?: { message?: string } };
+      const data = await res.json() as { ok?: boolean; bindings_upserted?: number; error?: { message?: string } };
       if (res.ok && data.ok) {
-        setApplyResult({ ok: true, message: `규칙 ${String(data.rules_created ?? 0)}개 생성 완료` });
-        setAppliedSlug(selected.slug);
-        setOverwriteConfirm(false);
+        setApplyResult({ ok: true, message: `배정 ${String(data.bindings_upserted ?? 0)}건 저장 완료` });
+        setAppliedKeys(prev => new Set(prev).add(selected.key));
       } else {
         setApplyResult({ ok: false, message: data.error?.message ?? '적용 실패' });
       }
@@ -179,76 +157,61 @@ export function WorkflowTemplateGallerySection({
       <SectionCardHeader>
         <div className="space-y-1">
           <h2 className="text-base font-semibold text-foreground">워크플로우 템플릿 갤러리</h2>
-          <p className="text-sm text-muted-foreground">템플릿을 선택해 라우팅 규칙을 자동 생성합니다.</p>
+          <p className="text-sm text-muted-foreground">템플릿을 선택해 단계별 담당 에이전트를 배정합니다.</p>
         </div>
       </SectionCardHeader>
       <SectionCardBody>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          {templates.map(tmpl => (
+          {cyclicDefinitions.map(def => (
             <button
-              key={tmpl.slug}
-              onClick={() => void handleSelectTemplate(tmpl)}
-              disabled={loadingDetail}
+              key={def.id}
+              onClick={() => void handleSelectDefinition(def)}
+              disabled={loadingBindings}
               // story #3010(로드맵 P3, L1) — 선택 가능한 인라인 카드는 --elev-card.
               className={`rounded-lg border p-4 text-left transition hover:border-primary/60 hover:shadow-[var(--elev-card)] disabled:opacity-60 ${
-                selected?.slug === tmpl.slug ? 'border-primary bg-primary/5' : 'border-border bg-background'
+                selected?.id === def.id ? 'border-primary bg-primary/5' : 'border-border bg-background'
               }`}
             >
               <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0">
-                  <p className="font-medium text-sm text-foreground truncate">{tmpl.name}</p>
-                  <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">{tmpl.description}</p>
+                  <p className="font-medium text-sm text-foreground truncate">{def.name || def.key}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">{def.description}</p>
                 </div>
                 <div className="flex shrink-0 flex-col items-end gap-1">
-                  <ChainBadge length={tmpl.chain_length} />
-                  {appliedSlug === tmpl.slug && (
+                  <StageCountBadge count={cyclicStages(def).length} />
+                  {appliedKeys.has(def.key) && (
                     <Badge variant="success" className="text-[10px]">적용됨</Badge>
                   )}
                 </div>
               </div>
-              <p className="mt-2 text-[10px] text-muted-foreground">
-                프리셋 {Object.keys(tmpl.presets ?? {}).length}종
-              </p>
             </button>
           ))}
         </div>
 
-        {loadingDetail && (
-          <p className="mt-4 text-xs text-muted-foreground">템플릿 로딩 중...</p>
+        {loadingBindings && (
+          <p className="mt-4 text-xs text-muted-foreground">배정 정보 로딩 중...</p>
         )}
 
-        {selected && (
+        {selected && !loadingBindings && (
           <div className="mt-6 rounded-lg border border-border bg-muted/30 p-4 space-y-4">
             <div>
-              <h3 className="font-semibold text-sm text-foreground">{selected.name} — 역할 매핑</h3>
-              <p className="mt-0.5 text-xs text-muted-foreground">각 역할에 프로젝트 에이전트를 연결하세요.</p>
+              <h3 className="font-semibold text-sm text-foreground">{selected.name || selected.key} — 역할 매핑</h3>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                각 단계에 프로젝트 에이전트를 연결하세요. 기존 배정이 있으면 아래에 표시됩니다.
+              </p>
             </div>
 
-            {selected.rules_template && selected.rules_template.length > 0 && (
-              <div>
-                <p className="text-xs font-medium text-foreground mb-1">생성될 규칙 ({selected.rules_template.length}개)</p>
-                <ul className="space-y-0.5">
-                  {(selected.rules_template as Array<{ name?: string; priority?: number }>).map((r, i) => (
-                    <li key={i} className="flex items-center gap-2 text-[11px] text-muted-foreground">
-                      <span className="font-mono text-[10px] w-5 text-right shrink-0">{r.priority ?? i + 1}</span>
-                      <span className="truncate">{r.name ?? `규칙 ${i + 1}`}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            {requiredSteps.map(ref => {
-              const step = selected.steps.find(s => s.role_ref === ref);
+            {requiredStages.map(stage => {
+              const meta = selected.stage_metadata[stage];
               return (
-                <div key={ref} className="flex items-center gap-3">
+                <div key={stage} className="flex items-center gap-3">
                   <span className="w-32 shrink-0 text-xs font-medium text-foreground">
-                    {step?.default_label ?? ref}
+                    {meta?.role ?? stage}
                   </span>
                   <select
                     className="flex-1 rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                    value={roleMapping[ref] ?? ''}
-                    onChange={e => setRoleMapping(prev => ({ ...prev, [ref]: e.target.value }))}
+                    value={roleMapping[stage] ?? ''}
+                    onChange={e => setRoleMapping(prev => ({ ...prev, [stage]: e.target.value }))}
                   >
                     <option value="">에이전트 선택...</option>
                     {agents.map(a => (
@@ -270,23 +233,13 @@ export function WorkflowTemplateGallerySection({
               </p>
             )}
 
-            {overwriteConfirm ? (
-              <div className="flex items-center gap-2">
-                <p className="text-xs text-muted-foreground">기존 템플릿 규칙이 교체됩니다. 계속하시겠습니까?</p>
-                <Button size="sm" variant="destructive" disabled={applying} onClick={() => void handleApply(true)}>
-                  교체 적용
-                </Button>
-                <Button size="sm" variant="outline" onClick={() => setOverwriteConfirm(false)}>취소</Button>
-              </div>
-            ) : (
-              <Button
-                size="sm"
-                disabled={applying || requiredSteps.some(r => !roleMapping[r])}
-                onClick={() => void handleApply(false)}
-              >
-                {applying ? '적용 중...' : '적용하기'}
-              </Button>
-            )}
+            <Button
+              size="sm"
+              disabled={applying || requiredStages.some(s => !roleMapping[s])}
+              onClick={() => void handleApply()}
+            >
+              {applying ? '적용 중...' : (appliedKeys.has(selected.key) ? '재적용(덮어쓰기)' : '적용하기')}
+            </Button>
           </div>
         )}
       </SectionCardBody>

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -2034,6 +2034,68 @@ async def apply_recipe_role_bindings(
     return ApplyRecipeRoleBindingsResponse(ok=True, bindings_upserted=upserted)
 
 
+class RecipeRoleBindingsResponse(BaseModel):
+    bindings: dict[str, str]
+
+
+@router.get("/definitions/{definition_id}/bindings", response_model=RecipeRoleBindingsResponse)
+async def get_recipe_role_bindings(
+    definition_id: uuid.UUID,
+    project_id: uuid.UUID | None = None,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> RecipeRoleBindingsResponse:
+    """GET /api/v2/events/definitions/{id}/bindings — story #3293(축2-ⓒ §B).
+
+    축2-ⓐ(apply, story #3288)는 쓰기(upsert)만 만들었다 — 갤러리 FE가 "이미 배정됨"
+    배지·기존 role_mapping 프리필을 하려면 이 read가 필요(doc
+    axis2c-gallery-migration-map-and-design §3-B). project_id 지정 시 그 project
+    특이성 바인딩이 org 전역보다 우선(event_routing_resolver.py의 조회 우선순위와
+    동형 — 여기도 그대로 병합해 "실제로 발행 시 어느 값이 쓰일지"와 일치하는 뷰를
+    보여준다). project_id 미지정 시 org 전역 바인딩만.
+    """
+    from app.models.event_definition import EventDefinition
+    from app.models.recipe_role_binding import RecipeRoleBinding
+    from app.services.project_auth import require_project_access
+
+    if project_id is not None:
+        await require_project_access(db, uuid.UUID(auth.user_id), project_id, org_id, not_found_detail="Project not found")
+
+    definition = (await db.execute(
+        select(EventDefinition).where(
+            EventDefinition.id == definition_id,
+            or_(EventDefinition.org_id == org_id, EventDefinition.org_id.is_(None)),
+        )
+    )).scalar_one_or_none()
+    if definition is None:
+        raise HTTPException(status_code=404, detail="event definition not found")
+
+    # org 전역(project_id IS NULL) 먼저 채우고, project 특이성으로 덮어써 우선순위를
+    # 정확히 반영(project_scope_clause와 동형 우선순위, resolver의 실 조회 순서와 일치).
+    org_wide = (await db.execute(
+        select(RecipeRoleBinding.stage, RecipeRoleBinding.agent_member_id).where(
+            RecipeRoleBinding.org_id == org_id,
+            RecipeRoleBinding.project_id.is_(None),
+            RecipeRoleBinding.event_definition_key == definition.key,
+        )
+    )).all()
+    bindings: dict[str, str] = {stage: str(agent_id) for stage, agent_id in org_wide}
+
+    if project_id is not None:
+        project_scoped = (await db.execute(
+            select(RecipeRoleBinding.stage, RecipeRoleBinding.agent_member_id).where(
+                RecipeRoleBinding.org_id == org_id,
+                RecipeRoleBinding.project_id == project_id,
+                RecipeRoleBinding.event_definition_key == definition.key,
+            )
+        )).all()
+        for stage, agent_id in project_scoped:
+            bindings[stage] = str(agent_id)
+
+    return RecipeRoleBindingsResponse(bindings=bindings)
+
+
 class EventPublishHistoryItem(BaseModel):
     id: str
     conversation_id: str

--- a/backend/tests/test_3293_recipe_role_bindings_read.py
+++ b/backend/tests/test_3293_recipe_role_bindings_read.py
@@ -1,0 +1,235 @@
+"""story #3293(도메인탈고정 축2-ⓒ §B) — GET /api/v2/events/definitions/{id}/bindings.
+
+축2-ⓐ(story #3288, PR#3686 MERGED)는 apply(쓰기)만 만들었다 — 갤러리 FE가 "이미
+배정됨" 배지·기존 role_mapping 프리필을 하려면 이 read가 필요(doc
+axis2c-gallery-migration-map-and-design §3-B). 검증 축:
+- project_id 지정 시 그 project 바인딩이 org 전역보다 우선(병합 뷰).
+- project_id 미지정 시 org 전역 바인딩만.
+- 미배정 stage는 응답에 아예 안 실림(빈 dict 항목 아님).
+- has_project_access 없는 project_id 조회는 404(SSOT require_project_access 재사용).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+_CYCLIC_PAYLOAD_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["stage", "work_item_type", "work_item_id"],
+    "properties": {
+        "stage": {"type": "string", "enum": ["step_1", "step_2"]},
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+    },
+}
+_ROUTING = {
+    "escalation": {"kind": "recipe_role_binding"},
+    "broadcast": {"kind": "server_derived", "target": "none"},
+}
+
+
+async def _seed_org_project(session, *, slug="axis2c"):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org3293", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_human_caller(session, org_id, project_id, *, name="caller"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="human", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_cyclic_definition(session, *, key="preset.axis2c.recipe_test"):
+    from app.models.event_definition import EventDefinition
+
+    d = EventDefinition(
+        id=uuid.uuid4(), key=key, org_id=None, payload_schema=_CYCLIC_PAYLOAD_SCHEMA, routing=_ROUTING,
+        stage_metadata={"step_1": {"role": "Developer", "action": "do the thing"},
+                        "step_2": {"role": "Reviewer", "action": "review the thing"}},
+    )
+    session.add(d)
+    await session.commit()
+    return d
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_project_binding_wins_over_org_wide_in_read_view():
+    from app.routers.events import (
+        ApplyRecipeRoleBindingsRequest, apply_recipe_role_bindings, get_recipe_role_bindings,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            definition = await _seed_cyclic_definition(s)
+            caller_id = await _seed_human_caller(s, org_id, project_id)
+            org_wide_agent = await _seed_agent(s, org_id, project_id, name="org-wide")
+            project_agent = await _seed_agent(s, org_id, project_id, name="project-specific")
+
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=None, role_mapping={"step_1": str(org_wide_agent)}),
+                db=s, auth=_auth(caller_id, org_id), org_id=org_id,
+            )
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=project_id, role_mapping={"step_1": str(project_agent)}),
+                db=s, auth=_auth(caller_id, org_id), org_id=org_id,
+            )
+
+            resp = await get_recipe_role_bindings(
+                definition.id, project_id, db=s, auth=_auth(caller_id, org_id), org_id=org_id,
+            )
+            assert resp.bindings == {"step_1": str(project_agent)}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_no_project_id_returns_org_wide_only():
+    from app.routers.events import (
+        ApplyRecipeRoleBindingsRequest, apply_recipe_role_bindings, get_recipe_role_bindings,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            definition = await _seed_cyclic_definition(s)
+            caller_id = await _seed_human_caller(s, org_id, project_id)
+            org_wide_agent = await _seed_agent(s, org_id, project_id, name="org-wide")
+            project_agent = await _seed_agent(s, org_id, project_id, name="project-specific")
+
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=None, role_mapping={"step_1": str(org_wide_agent)}),
+                db=s, auth=_auth(caller_id, org_id), org_id=org_id,
+            )
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=project_id, role_mapping={"step_2": str(project_agent)}),
+                db=s, auth=_auth(caller_id, org_id), org_id=org_id,
+            )
+
+            resp = await get_recipe_role_bindings(
+                definition.id, None, db=s, auth=_auth(caller_id, org_id), org_id=org_id,
+            )
+            assert resp.bindings == {"step_1": str(org_wide_agent)}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_unassigned_stage_absent_from_response():
+    from app.routers.events import (
+        ApplyRecipeRoleBindingsRequest, apply_recipe_role_bindings, get_recipe_role_bindings,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s)
+            definition = await _seed_cyclic_definition(s)
+            caller_id = await _seed_human_caller(s, org_id, project_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+            await apply_recipe_role_bindings(
+                definition.id,
+                ApplyRecipeRoleBindingsRequest(project_id=project_id, role_mapping={"step_1": str(agent_id)}),
+                db=s, auth=_auth(caller_id, org_id), org_id=org_id,
+            )
+
+            resp = await get_recipe_role_bindings(
+                definition.id, project_id, db=s, auth=_auth(caller_id, org_id), org_id=org_id,
+            )
+            assert "step_2" not in resp.bindings
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_no_project_access_rejected_404():
+    from fastapi import HTTPException
+
+    from app.routers.events import get_recipe_role_bindings
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_a = await _seed_org_project(s, slug="axis2c-sec-a")
+            from app.models.project import Project
+            project_b = Project(id=uuid.uuid4(), org_id=org_id, name="P-B")
+            s.add(project_b)
+            await s.commit()
+
+            definition = await _seed_cyclic_definition(s)
+            outsider_id = await _seed_agent(s, org_id, project_a, name="outsider")
+
+            with pytest.raises(HTTPException) as ei:
+                await get_recipe_role_bindings(
+                    definition.id, project_b.id, db=s, auth=_auth(outsider_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 404
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
story #3293(도메인탈고정 축2-ⓒ, doc axis2c-gallery-migration-map-and-design). 축2-ⓐ(PR#3686, MERGED) 착지 후 PO 확定(A/B/C) 그대로 착수.

## 구현
- **B(신규 read, 첫 조각)**: `GET /api/v2/events/definitions/{id}/bindings?project_id=` — recipe_role_bindings를 project 특이성 우선으로 병합해 유효 바인딩 뷰 반환.
- **A(overwrite UX 절충)**: 확認 다이얼로그 제거, 기존 배정값을 역할 드롭다운에 프리필.
- **C(presets 스킵)**: 프리셋 드롭다운 생략(수동 선택만) — 저장 로직 무영향.
- 갤러리 전면 재작성: `GET /api/events/definitions`(loop-create-dialog.tsx의 `isCyclicDefinition`/`cyclicStages` 재사용, 발명 0)+신규 §B read+`POST /definitions/{id}/apply`로 fetch 대상 교체.
- FE 소비처(`/api/workflow-templates` Next 프록시 3개) 은퇴 — grep으로 살아있는 주소 0건 확認 후 삭제.

## ⚠️ 발견 — BE `workflow_templates.py` 은퇴는 스코프 밖으로 보류
`app/services/deployment_lifecycle.py`가 `WorkflowTemplateRepository`를 **여전히 직접 사용**(fleet 배포 시 역할 조합→라우팅 템플릿 자동 선택, 설정 갤러리와 무관한 별개 기능) — 놓쳤으면 모델/테이블까지 은퇴하다 그 기능이 조용히 깨졌을 것. HTTP 라우터는 FE 소비처가 없어 dead지만, `test_e_security_sec_s8_bb_workflow_templates_executions_project_scope_realdb.py`(그 라우터를 실 HTTP로 때리는 SEC 회귀가드)가 있어 라우터/모델/테이블 은퇴는 이 두 자리를 먼저 정리하는 별도 후속 스토리로 분리.

## 검증
- 신규 BE pin 4건 + 뮤테이션 자가검증(project-scope 병합 제거 → 정확한 pin만 RED)
- FE 컴포넌트 테스트 재작성(회귀가드 계승+신규 프리필 pin) 4/4 passed
- FE 전체 553 files/5177 tests PASS + tsc 클린
- BE 관련 회귀 14건 PASS + SEC-S8 가드(clean alembic DB로 재검증) 4/4 PASS + 앱 import 클린

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_019rkXVqy2DF1aAN7szuqp44