### PR TITLE
[SID:3295] workflow_templates HTTP 라우터 은퇴 — 모델/리포지토리/테이블은 존치

### DIFF
--- a/apps/web/scripts/verify-no-new-raw-fetch-api.test.ts
+++ b/apps/web/scripts/verify-no-new-raw-fetch-api.test.ts
@@ -47,8 +47,8 @@ describe('extractRawFetchApiCalls — 순수 판정 함수(AC4)', () => {
 // story #2691 — 선언된 baseline 크기를 고정해 조용한 증감(리뷰 없는 추가/삭제)을 막는다
 // (verify-no-i18n-phrase-collision.ts의 GRANDFATHER_BASELINE_COUNT_TEST와 동일 관례).
 describe('GRANDFATHER_BASELINE_COUNT_TEST — 41번째부터는 review 없이 조용히 못 늘어난다(관례 재사용)', () => {
-  it('PR#3558 — profile-menu.tsx→use-account-switcher.ts 추출로 4건이 3건으로 재등재(accounts는 fetchWithAuth 전환)돼 162건으로 줄었다', () => {
-    expect(GRANDFATHER_BASELINE.size).toBe(162);
+  it('story #3295 — workflow-template-gallery-section.tsx의 죽은 grandfather 항목 제거(축2-ⓒ가 신세대 이전+fetchWithAuth 전환해 실제로 안 걸림)로 161건으로 줄었다', () => {
+    expect(GRANDFATHER_BASELINE.size).toBe(161);
   });
 
   it('EXEMPT_FILES는 10개 파일(pre-auth·공개 라우트·primitive 구현) 그대로다(story #ab2a503f — app/set-password/confirm/page.tsx 추가, 카디르 QA 처방)', () => {

--- a/apps/web/scripts/verify-no-new-raw-fetch-api.ts
+++ b/apps/web/scripts/verify-no-new-raw-fetch-api.ts
@@ -233,7 +233,10 @@ export const GRANDFATHER_BASELINE = new Set<string>([
   'components/settings/workflow-line-editor-section.tsx::/api/workflow-line-config/versions',
   'components/settings/workflow-line-editor-section.tsx::/api/workflow-line-config/versions/',
   'components/settings/workflow-policy-simulator-section.tsx::/api/workflow-line-config/resolve-preview',
-  'components/settings/workflow-template-gallery-section.tsx::/api/workflow-templates/',
+  // story #3295 — workflow-template-gallery-section.tsx의 grandfather 항목 제거: 축2-ⓒ
+  // (PR#3690)가 이 컴포넌트를 신세대(/api/events/definitions/...)로 이전+fetchWithAuth로
+  // 교체하며 이 raw fetch 자체가 없어졌다(재확인 grep: 0건). 죽은 채무를 목록에 남겨두지
+  // 않는다.
   'components/settings/workflow-trigger-types-section.tsx::/api/workflow-trigger-types/',
   'components/shared/rejected-relations-section.tsx::/api/stories/',
   'components/sprints/hypothesis-declaration-card.tsx::/api/context-pack/search?project_id=',

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -218,7 +218,7 @@ async def lifespan(app: FastAPI):
             await worker_engine.dispose()
 
 
-from app.routers import a2a, account, activation, activity_logs, admin_billing, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, billing_keys, toss_webhooks, org_subscription_checkout, billing_packs, context_pack, deeplink_manifest, domain_labels, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, legal, loop_measure_due, loops, mcp, me, meetings, members, merge_gate, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, platform_settings, policy_documents, project_access, project_settings, projects, public_docs, reference_candidates, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, session_context, sprints, standups, stories, subscription, support_gateway_token, tasks, team_members, team_presence, trust_scores, usage, user_blocks, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activation, activity_logs, admin_billing, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, billing_keys, toss_webhooks, org_subscription_checkout, billing_packs, context_pack, deeplink_manifest, domain_labels, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, legal, loop_measure_due, loops, mcp, me, meetings, members, merge_gate, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, platform_settings, policy_documents, project_access, project_settings, projects, public_docs, reference_candidates, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, session_context, sprints, standups, stories, subscription, support_gateway_token, tasks, team_members, team_presence, trust_scores, usage, user_blocks, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_report, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 # 도메인 축 B(org-1st-class-surface-ia-design-b §3): OpenAPI 태그 조직-우선 위계.
 # 개별 라우터는 기존 세부 tag(예 "stories")를 그대로 유지하고 이 4축 태그를 추가로 보유(다중
@@ -467,7 +467,12 @@ app.include_router(integrations.router)
 app.include_router(workflow_versions.router)
 app.include_router(workflow_trigger_types.router)
 app.include_router(workflow_executions.router)
-app.include_router(workflow_templates.router)
+# story #3295(도메인탈고정 축2 후속) — workflow_templates HTTP 라우터 은퇴(FE 소비처 0건,
+# 축2-ⓒ에서 settings 갤러리가 신세대 recipe_role_bindings apply로 이전 完). 모델/
+# 리포지토리/테이블은 존치 — deployment_lifecycle.py가 WorkflowTemplateRepository를
+# fleet 배포 자동 라우팅 규칙 생성의 기본 경로로 여전히 실사용(별개 도메인, 이전 대상
+# 아님). 라우터 파일 자체는 안 지움 — SEC-S8 IDOR 회귀가드가 apply_template 함수를
+# 직접 호출(HTTP 대신)로 이관해 계속 재사용.
 app.include_router(file_locks.router)
 app.include_router(workflow_report.router)
 app.include_router(workflow_trigger.router)

--- a/backend/tests/test_e_security_sec_s8_bb_workflow_templates_executions_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_bb_workflow_templates_executions_project_scope_realdb.py
@@ -1,10 +1,19 @@
 """E-SECURITY SEC-S8(story 83ea3d6a) BB: workflow_templates apply + workflow_executions
-story-summary project-scope 미검증 봉쇄 실증(까심 전수스윕, 실HTTP 확定).
+story-summary project-scope 미검증 봉쇄 실증(까심 전수스윕).
 
 - apply_template: body.project_id에 has_project_access 검증 자체가 없어, project_a만
   grant된 caller가 project_b로 template apply 시 실제로 AgentRoutingRule이 생성됐다(201).
 - story_execution_summary: project_id에 project 접근권 검증이 없어 남의 project 워크플로
-  실행 상태(story-level status/rule_name)가 노출됐다(200)."""
+  실행 상태(story-level status/rule_name)가 노출됐다(200).
+
+story #3295(도메인탈고정 축2 후속) — apply_template 축(아래 두 테스트)은 이 스토리에서
+HTTP 왕복 대신 **함수 직접호출**로 이관했다(라우터 은퇴로 HTTP 표면 자체가 사라짐 —
+`app/routers/workflow_templates.py`는 FE 소비처 0건 확認 후 이 스토리에서 제거, 모델/
+리포지토리/테이블은 deployment_lifecycle.py가 여전히 실사용해 존치). SEC 커버리지
+손실 0 — 같은 검증 체인(has_project_access 실 호출·AgentRoutingRule 생성 여부)을 그대로
+실증하되, 라우팅 계층(HTTPException 변환) 대신 함수를 직접 불러 assert. story_execution_
+summary 축(아래 나머지 두 테스트)은 별개 라우터(workflow_executions.py, 은퇴 대상 아님)라
+HTTP 왕복 그대로 무변경."""
 from __future__ import annotations
 
 import os
@@ -109,12 +118,20 @@ async def _setup_app(app, Session, user_id, org_id):
 
 # ── apply_template ───────────────────────────────────────────────────────────
 
+def _auth_ctx(user_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+
 @pytest.mark.anyio
 async def test_apply_template_cross_project_blocked_no_rule_created():
-    """BB 재현: project_a만 grant된 caller가 project_b로 template apply → 404·룰 생성 0."""
-    from app.main import app
+    """BB 재현(story #3295 — 함수 직접호출로 이관, SEC 커버리지 손실 0): project_a만
+    grant된 caller가 project_b로 template apply → HTTPException(404)·룰 생성 0."""
+    from fastapi import HTTPException
+
     from app.models.agent_routing_rule import AgentRoutingRule
     from app.models.member import Member
+    from app.routers.workflow_templates import ApplyTemplateRequest, apply_template
 
     engine, Session = await _session_factory()
     try:
@@ -125,36 +142,29 @@ async def test_apply_template_cross_project_blocked_no_rule_created():
             await s.commit()
             agent_id = agent.id
 
-        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
-        client = _client_for(app)
-        try:
-            resp = await client.post(
-                "/api/v2/workflow-templates/solo/apply",
-                json={
-                    "project_id": str(seeded["project_b_id"]),
-                    "role_mapping": {"step_1": str(agent_id)},
-                },
-            )
-            assert resp.status_code == 404, resp.text
-        finally:
-            await client.aclose()
+            with pytest.raises(HTTPException) as ei:
+                await apply_template(
+                    "solo",
+                    ApplyTemplateRequest(project_id=seeded["project_b_id"], role_mapping={"step_1": str(agent_id)}),
+                    db=s, auth=_auth_ctx(seeded["human_user_id"], seeded["org_id"]), org_id=seeded["org_id"],
+                )
+            assert ei.value.status_code == 404
 
-        async with Session() as s:
             from sqlalchemy import select
             rules = (await s.execute(
                 select(AgentRoutingRule).where(AgentRoutingRule.project_id == seeded["project_b_id"])
             )).scalars().all()
             assert rules == [], "무권한 project에 AgentRoutingRule이 생성되면 안 됨"
     finally:
-        app.dependency_overrides.clear()
         await engine.dispose()
 
 
 @pytest.mark.anyio
 async def test_apply_template_same_project_still_works():
-    from app.main import app
+    """story #3295 — 함수 직접호출로 이관(음성대조: 권한 있는 project는 무회귀로 계속 됨)."""
     from app.models.member import Member
     from app.models.project_access import ProjectAccess
+    from app.routers.workflow_templates import ApplyTemplateRequest, apply_template
 
     engine, Session = await _session_factory()
     try:
@@ -170,22 +180,13 @@ async def test_apply_template_same_project_still_works():
             await s.commit()
             agent_id = agent.id
 
-        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
-        client = _client_for(app)
-        try:
-            resp = await client.post(
-                "/api/v2/workflow-templates/solo/apply",
-                json={
-                    "project_id": str(seeded["project_a_id"]),
-                    "role_mapping": {"step_1": str(agent_id)},
-                },
+            resp = await apply_template(
+                "solo",
+                ApplyTemplateRequest(project_id=seeded["project_a_id"], role_mapping={"step_1": str(agent_id)}),
+                db=s, auth=_auth_ctx(seeded["human_user_id"], seeded["org_id"]), org_id=seeded["org_id"],
             )
-            assert resp.status_code == 201, resp.text
-            assert resp.json()["rules_created"] == 1
-        finally:
-            await client.aclose()
+            assert resp.rules_created == 1
     finally:
-        app.dependency_overrides.clear()
         await engine.dispose()
 
 
@@ -257,3 +258,34 @@ async def test_story_execution_summary_same_project_still_works():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+# ── story #3295: 라우터 은퇴 실증(retired-concept-live-surface = 0) ──────────
+
+@pytest.mark.anyio
+async def test_workflow_templates_http_routes_are_unreachable():
+    """story #3295 — main.py에서 workflow_templates.router 등록을 뺐다. 실 app 인스턴스에
+    HTTP로 왕복해 3개 엔드포인트 전부 도달 불가(404 — FastAPI가 매칭되는 라우트 자체가
+    없을 때 내는 값)임을 실증한다. 모델/리포지토리는 그대로라 import 자체는 여전히
+    되므로(위 apply_template 직접호출 테스트들이 그 증거), "코드가 없다"가 아니라
+    "그 주소로 나가는 라우터가 없다"는 걸 실 HTTP로 가른다."""
+    from app.main import app
+
+    async def _auth():
+        from app.dependencies.auth import AuthContext
+        return AuthContext(user_id=str(uuid.uuid4()), email=None, claims={"app_metadata": {"org_id": str(uuid.uuid4())}})
+
+    from app.dependencies.auth import get_current_user
+    app.dependency_overrides[get_current_user] = _auth
+    client = _client_for(app)
+    try:
+        for method, path in [
+            ("GET", "/api/v2/workflow-templates"),
+            ("GET", "/api/v2/workflow-templates/solo"),
+            ("POST", "/api/v2/workflow-templates/solo/apply"),
+        ]:
+            resp = await client.request(method, path, json={} if method == "POST" else None)
+            assert resp.status_code == 404, f"{method} {path} → {resp.status_code}(라우터 은퇴 후에도 도달 가능하면 안 됨)"
+    finally:
+        app.dependency_overrides.clear()
+        await client.aclose()


### PR DESCRIPTION
story #3295(도메인탈고정 축2 후속). 축2-ⓒ(PR#3690)에서 분리한 트랙 — 그라운딩으로 PO 초안보다 스코프가 좁혀짐.

## 스코프 정정 근거
`deployment_lifecycle.py::_build_routing_template_from_db`가 `WorkflowTemplateRepository`를 **기본 경로**로 실사용 중(fleet 배포 시 역할조합→자동 라우팅규칙, 구세대 memo_type 어휘) — 설정갤러리와 완전 별개인 살아있는 기능이라 "이전할" 이유 자체가 없었다. 모델/리포지토리/테이블 무변경.

## 구현
- `main.py`: `app.include_router(workflow_templates.router)` + import 제거 — HTTP 표면 완전 은퇴. 라우터 파일 자체는 유지(함수 직접호출로 SEC 테스트가 계속 재사용).
- SEC-S8 IDOR 회귀가드 이관: `apply_template` 관련 2개 테스트를 HTTP 왕복→함수 직접호출로 전환(커버리지 손실 0, 뮤테이션 자가검증 완료). `story_execution_summary` 축(별개 라우터)은 무변경.
- 신규 pin: 3개 경로 전부 실 HTTP 404 확認(retired-concept-live-surface = 0).
- (겸사) FE raw-fetch 가드의 죽은 grandfather 항목 정리.

## 검증
- SEC-S8 5/5 passed(뮤테이션 포함) · deployment_lifecycle 관련 회귀 52/52 passed · workflow_template 나머지 29/29 passed · 앱 import 클린 · FE 가드 green.

## 스코프 밖
모델·리포지토리·테이블 은퇴 안 함(deployment_lifecycle 실사용).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_019rkXVqy2DF1aAN7szuqp44