### PR TITLE
[SID:3289] story-detail-panel·chat 멘션피커 org 라벨 오버라이드 확산

### DIFF
--- a/apps/web/src/components/chat/chat-input.test.tsx
+++ b/apps/web/src/components/chat/chat-input.test.tsx
@@ -10,6 +10,13 @@ import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { ChatInput } from './chat-input';
 
+// story #3289(도메인탈고정·축1 Phase1 FE잔여, AC2) — kanban-board.test.tsx와 동형 mock.
+// orgId를 안 주면(기본 beforeEach) useOrgDomainLabels가 no-op이라 기존 44개 테스트는 무회귀.
+const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 function withIntl(node: React.ReactNode) {
@@ -44,6 +51,7 @@ let root: Root;
 beforeEach(() => {
   stubLocalStorage();
   stubMatchMedia(false); // 기본은 데스크톱(포인터 정밀) — AC1 대상
+  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'human' });
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
@@ -238,6 +246,77 @@ describe('ChatInput — `#` 엔티티 피커 종류별 그룹화(story #2263 ㉠
     const listbox = container.querySelector('[role="listbox"]');
     expect(listbox!.textContent).toContain('검토 중');
     expect(listbox!.textContent).not.toContain('in-review');
+  });
+});
+
+// story #3289(도메인탈고정·축1 Phase1 FE잔여, AC2) — 「네비」 실측 결과 사이드바/브레드크럼엔
+// entity_type 렌더지점이 없고, 실제 렌더처가 이 `#` 엔티티 피커였다(kanban-board.test.tsx
+// #3287 AC4와 동형 처방 — 참조 코어 chat-input-entity-tokens.ts는 diff 0, 여기서만 얹는다).
+describe('ChatInput — org 엔티티명 라벨 오버라이드(story #3289 AC2)', () => {
+  function stubFetchWithDomainLabels(
+    entities: Array<{ entity_type: string; entity_id: string; title: string; status: string | null }>,
+    labels: Array<{ domain: string; canonical_slug: string; label_ko: string | null; label_en: string | null }>,
+  ) {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/api/entities/search')) {
+        return new Response(JSON.stringify({ data: entities }));
+      }
+      if (typeof url === 'string' && url.includes('/domain-labels')) {
+        return new Response(JSON.stringify(labels));
+      }
+      return new Response(JSON.stringify({ data: [] }));
+    }));
+  }
+
+  it('오버라이드 없는 org(빈 목록)면 canonical entityTypeLabel() 그대로("스토리", 회귀 0)', async () => {
+    stubFetchWithDomainLabels(
+      [{ entity_type: 'story', entity_id: 's1', title: '스토리 하나', status: null }],
+      [],
+    );
+    useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', orgId: 'org-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'human' });
+
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" projectId="p1" onSend={vi.fn()} />));
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '#');
+      el.selectionStart = 1;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox!.textContent).toContain('스토리');
+  });
+
+  it('org가 story 라벨을 오버라이드하면 `#` 피커 그룹 헤더가 그 문구로 바뀐다', async () => {
+    // 제목 자체에 "스토리" 문자열이 없어야 group-header 텍스트만 정확히 잰다(entity.title은
+    // 자유 텍스트라 우연히 겹치면 assertion이 오염된다).
+    stubFetchWithDomainLabels(
+      [{ entity_type: 'story', entity_id: 's1', title: '표시용 제목', status: null }],
+      [{ domain: 'entity_type', canonical_slug: 'story', label_ko: '작업건', label_en: null }],
+    );
+    useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', orgId: 'org-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'human' });
+
+    await act(async () => {
+      root.render(withIntl(<ChatInput threadId="c1" projectId="p1" onSend={vi.fn()} />));
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '#');
+      el.selectionStart = 1;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    // domain-labels 조회(useOrgDomainLabels)와 entity 검색(useEntityPicker, 200ms 디바운스)이
+    // 둘 다 흐를 시간을 준다.
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox!.textContent).toContain('작업건');
+    expect(listbox!.textContent).not.toContain('스토리');
   });
 });
 

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -3,7 +3,9 @@
 import { useEffect, useRef, useState, type ClipboardEvent, type KeyboardEvent } from 'react';
 import Link from 'next/link';
 import { AlertTriangle, Compass, FolderOpen, Loader2, Paperclip, Send, Terminal, Type, Upload, X, Hash } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { useOrgDomainLabels } from '@/hooks/use-org-domain-labels';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -170,6 +172,13 @@ interface ChatInputProps {
 
 export function ChatInput({ onSend, onUploadFile, disabled, placeholder, projectId, onMentionIdsChange, commandTargets, threadId, onEscape, currentTeamMemberId, participants, prefillCommand }: ChatInputProps) {
   const t = useTranslations('chats');
+  // story #3289(도메인탈고정·축1 Phase1 FE잔여, AC2) — 「네비」 실측 결과 사이드바/브레드크럼엔
+  // entity_type 렌더지점이 없고, 실제 렌더처는 이 `#` 엔티티 피커(chat-input-entity-tokens.ts
+  // entityTypeLabel())였다. 그 코어 파일은 AC3 판정 대상(diff 0 규율, #2264)이라 손대지
+  // 않고, 소비처인 여기서 kanban-board.tsx와 동형으로 org 오버라이드를 얹는다.
+  const { orgId } = useDashboardContext();
+  const locale = useLocale();
+  const domainLabels = useOrgDomainLabels(orgId, locale);
   // story 1946(PO 실기기 발견): 터치(가상 키보드)엔 Cmd/Shift 조합이 없어 Enter=발송이면 장문
   // 지시 중 오발송이 잦다. 뷰포트가 아니라 입력 capability로 분기(물리 키보드 연결 태블릿은
   // 데스크톱 거동이 자연스러움) — artifact-stage.tsx와 동형 패턴(`(pointer: coarse)` 1회 판정,
@@ -710,7 +719,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
                         }}
                         className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs text-foreground hover:bg-muted"
                       >
-                        <span className="shrink-0 text-muted-foreground">{entityTypeLabel(ent.entity_type)}</span>
+                        <span className="shrink-0 text-muted-foreground">{domainLabels.entityTypeLabel(ent.entity_type) ?? entityTypeLabel(ent.entity_type)}</span>
                         <span className="truncate">{ent.title}</span>
                       </button>
                     </li>
@@ -787,7 +796,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
               <li key={`${entity.entity_type}:${entity.entity_id}`}>
                 {isNewGroup && (
                   <div className="sticky top-0 bg-popover px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    {entityTypeLabel(entity.entity_type)}
+                    {domainLabels.entityTypeLabel(entity.entity_type) ?? entityTypeLabel(entity.entity_type)}
                   </div>
                 )}
                 <button

--- a/apps/web/src/components/epics/epic-swimlane-board.tsx
+++ b/apps/web/src/components/epics/epic-swimlane-board.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { ChevronDown, ChevronRight, Lock } from 'lucide-react';
 import {
   DndContext, type DragEndEvent, PointerSensor, useDroppable, useSensor, useSensors,
@@ -11,6 +11,8 @@ import { parseCursorMeta } from '@/lib/pagination';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { StoryCard } from '@/components/kanban/story-card';
 import { StoryDetailPanel, type Task } from '@/components/kanban/story-detail-panel';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { useOrgDomainLabels } from '@/hooks/use-org-domain-labels';
 import { useToast, ToastContainer } from '@/components/ui/toast';
 import { WorkspaceFrameTabs } from '@/components/workspace/workspace-frame-tabs';
 import {
@@ -240,6 +242,12 @@ function SwimlaneRow({ laneId, title, subtitle, columns, stories, axisMode, memb
 
 export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
   const t = useTranslations('board');
+  // story #3289 — kanban-board.tsx와 동형(useOrgDomainLabels 배선). 이 화면의 StoryDetailPanel
+  // 호출부(아래)에만 소비시킨다 — StoryCard(라인 163 부근) 배지는 이 스토리 AC 밖(3687이
+  // 커버한 건 kanban-board.tsx뿐, 이 스윔레인 카드는 별도 갭 — 별도 스토리로 남긴다).
+  const { orgId } = useDashboardContext();
+  const locale = useLocale();
+  const domainLabels = useOrgDomainLabels(orgId, locale);
   const [stories, setStories] = useState<KanbanStory[]>([]);
   const [epics, setEpics] = useState<KanbanEpic[]>([]);
   const [members, setMembers] = useState<KanbanMember[]>([]);
@@ -619,6 +627,8 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
               <StoryDetailPanel
                 story={selectedStory}
                 tasks={storyTasks}
+                getStatusLabel={domainLabels.statusLabel}
+                getEntityTypeLabel={domainLabels.entityTypeLabel}
                 nextTasksCursor={storyTasksNextCursor}
                 loadingMoreTasks={loadingMoreStoryTasks}
                 onLoadMoreTasks={async () => {

--- a/apps/web/src/components/flow/flow-node-story-panel.tsx
+++ b/apps/web/src/components/flow/flow-node-story-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { StoryDetailPanel, type Task } from '@/components/kanban/story-detail-panel';
 import type { KanbanStory } from '@/components/kanban/types';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -11,6 +11,8 @@ import { selectUnconfirmedCandidates } from './flow-relation-review';
 import { FlowRelationReviewQueue } from './flow-relation-review-queue';
 import { useOrgSyncVersion } from '@/lib/project-context-client';
 import { fetchWithAuth } from '@/lib/db/client';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { useOrgDomainLabels } from '@/hooks/use-org-domain-labels';
 
 const OVERLAY_GAP = 8; // 노드와 패널 사이 여백(px)
 const OVERLAY_EDGE_MARGIN = 16; // 뷰포트 가장자리 여백(px)
@@ -77,6 +79,12 @@ function computeOverlayPosition(rect: DOMRect | null, viewportHeight: number): {
 export function FlowNodeStoryPanel({ storyId, onClose, onDeleteSuccess }: FlowNodeStoryPanelProps) {
   const t = useTranslations('flow');
   const isMobile = useIsMobile();
+  // story #3289 — kanban-board.tsx와 동형(useOrgDomainLabels 배선). 이 컴포넌트는 자체
+  // fetch로 자립하는 얇은 래퍼(#2354 관례)라 여기서 직접 훅을 붙인다(flow-client.tsx 경유
+  // props threading 대신).
+  const { orgId } = useDashboardContext();
+  const locale = useLocale();
+  const domainLabels = useOrgDomainLabels(orgId, locale);
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   const [overlayPosition, setOverlayPosition] = useState<{ top: number; heightPx: number } | null>(null);
   // story #2358 — 「확認하기」 훑기 큐 진입점. 이 story가 source인 미확認 후보 건수(별도
@@ -201,7 +209,7 @@ export function FlowNodeStoryPanel({ storyId, onClose, onDeleteSuccess }: FlowNo
     // StoryDetailPanel이 이미 갖고 있는 전체화면 드로어 모드로 뜬다(KanbanBoard와 동일 경로).
     return (
       <>
-        <StoryDetailPanel story={state.story} tasks={state.tasks} onClose={onClose} onDeleteSuccess={onDeleteSuccess} />
+        <StoryDetailPanel story={state.story} tasks={state.tasks} onClose={onClose} onDeleteSuccess={onDeleteSuccess} getStatusLabel={domainLabels.statusLabel} getEntityTypeLabel={domainLabels.entityTypeLabel} />
         {reviewEntry}
         {reviewDialog}
       </>
@@ -216,6 +224,8 @@ export function FlowNodeStoryPanel({ storyId, onClose, onDeleteSuccess }: FlowNo
         onClose={onClose}
         onDeleteSuccess={onDeleteSuccess}
         overlayPosition={{ top: overlayPosition!.top, heightPx: overlayPosition!.heightPx }}
+        getStatusLabel={domainLabels.statusLabel}
+        getEntityTypeLabel={domainLabels.entityTypeLabel}
       />
       {reviewEntry}
       {reviewDialog}

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1798,6 +1798,8 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
           tasks={storyTasks}
           memberMap={memberMap}
           members={members}
+          getStatusLabel={domainLabels.statusLabel}
+          getEntityTypeLabel={domainLabels.entityTypeLabel}
           nextTasksCursor={storyTasksNextCursor}
           loadingMoreTasks={loadingMoreStoryTasks}
           onLoadMoreTasks={async () => {

--- a/apps/web/src/components/kanban/story-detail-panel.test.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.test.tsx
@@ -129,6 +129,45 @@ describe('StoryDetailPanel — overlayPosition (story #2354, 지도 위에 겹�
   });
 });
 
+// story #3289(도메인탈고정·축1 Phase1 FE잔여, AC1) — getStatusLabel 없으면(undefined) 기존
+// canonical t(...) 그대로(회귀 0, 3687과 동형 폴백), 있으면 그 오버라이드가 배지 텍스트를
+// 대체한다(localStatus 자체·색상 판정은 story-card.tsx와 동일하게 무변경).
+describe('StoryDetailPanel — org 상태 라벨 오버라이드(story #3289 AC1)', () => {
+  it('getStatusLabel 없으면 canonical t(...) 문구 그대로(회귀 0)', async () => {
+    await act(async () => {
+      root.render(wrap(<StoryDetailPanel story={makeStory({ status: 'backlog' })} tasks={[]} onClose={() => {}} />));
+    });
+    const badgeButton = container.querySelector('[aria-label="상태"]');
+    expect(badgeButton?.textContent).toContain('백로그');
+  });
+
+  it('getStatusLabel이 undefined를 돌려주면(org 미설정) canonical 그대로 폴백', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel story={makeStory({ status: 'backlog' })} tasks={[]} onClose={() => {}} getStatusLabel={() => undefined} />,
+      ));
+    });
+    const badgeButton = container.querySelector('[aria-label="상태"]');
+    expect(badgeButton?.textContent).toContain('백로그');
+  });
+
+  it('getStatusLabel이 값을 돌려주면 배지 텍스트가 그 오버라이드로 바뀐다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <StoryDetailPanel
+          story={makeStory({ status: 'backlog' })}
+          tasks={[]}
+          onClose={() => {}}
+          getStatusLabel={(slug) => (slug === 'backlog' ? '대기열' : undefined)}
+        />,
+      ));
+    });
+    const badgeButton = container.querySelector('[aria-label="상태"]');
+    expect(badgeButton?.textContent).toContain('대기열');
+    expect(badgeButton?.textContent).not.toContain('백로그');
+  });
+});
+
 // story #2528 — 전역 스크롤바 숨김(#2165) 하에 상세패널 본문 스크롤 컨테이너가 예외 목록에
 // 없어 스크롤바가 안 보이던 결함. globals.css 범용 옵트인 `.scrollbar-visible` 클래스 적용
 // 계약을 고정한다. jsdom은 실 스크롤바 렌더를 계산하지 않으므로 실제 가시성은 라이브 QA 몫

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -92,6 +92,14 @@ interface StoryDetailPanelProps {
   sprintMap?: Record<string, string>;
   onNavigate?: (storyId: string) => void;
   projectId?: string;
+  /** story #3289(도메인탈고정·축1 Phase1 FE잔여) — org별 status 라벨 오버라이드 조회 함수
+   * (useOrgDomainLabels().statusLabel), story-card.tsx의 getStatusLabel과 동형. 없으면
+   * (undefined) 기존 t(...) canonical 문구 그대로(회귀 0) — localStatus 자체(판정/색상)는
+   * 안 바뀐다, 표시 텍스트만. */
+  getStatusLabel?: (canonicalSlug: string) => string | undefined;
+  /** story #3289 AC2 — org 엔티티명 라벨 오버라이드(useOrgDomainLabels().entityTypeLabel).
+   * description/AC 편집기의 `#` 피커(EntityAwareTextarea)로 그대로 물려준다. */
+  getEntityTypeLabel?: (canonicalSlug: string) => string | undefined;
   /** story #2354 — 갈래 보기의 «지도 위에 겹치는» 소형 팝오버 모드. 생략하면 기존 전체화면
    * 드로어(칸반 그대로, 회귀 없음). 값을 주면 배경 딤을 없애고(지도를 «가리지» 않는다),
    * «top+height 확정값»만 받아 그대로 스타일에 적용한다 — 위/아래 반전 판단(클릭한 노드가
@@ -331,7 +339,7 @@ export function DescriptionViewer({
   );
 }
 
-export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loadingMoreTasks = false, onLoadMoreTasks, onClose, onStoryUpdate, onDeleteSuccess, memberMap = {}, members = [], storyMap = {}, epicMap = {}, sprintMap = {}, onNavigate, projectId, overlayPosition }: StoryDetailPanelProps) {
+export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loadingMoreTasks = false, onLoadMoreTasks, onClose, onStoryUpdate, onDeleteSuccess, memberMap = {}, members = [], storyMap = {}, epicMap = {}, sprintMap = {}, onNavigate, projectId, overlayPosition, getStatusLabel, getEntityTypeLabel }: StoryDetailPanelProps) {
   const t = useTranslations('board');
   // story #1959(P2-S3): 딥링크 매니페스트(story_detail→parentTab=all) — 콜드 진입 시 "전체"
   // 탭 루트를 BACK 대상으로 선주입. 카드 클릭으로 연 경우(history.length>1)는 no-op.
@@ -823,7 +831,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     done: 'done',
   };
   const statusKey = statusKeyMap[localStatus];
-  const statusLabel = statusKey ? t(statusKey) : localStatus;
+  // story #3289 — org 라벨 오버라이드 우선(story-card.tsx와 동형 `?? t(...)` 폴백), 아래
+  // Workcell run.now/stage/nextNeed·배지가 전부 이 값 하나로 수렴하므로 여기 한 곳만 바꾸면
+  // 표시 텍스트가 전체 소비처에 퍼진다(localStatus 자체·판정/색상은 무변경).
+  const statusLabel = getStatusLabel?.(localStatus) ?? (statusKey ? t(statusKey) : localStatus);
 
   // E-UI-DAEGBYEON P0 — Workcell 최소 실화면 배선(story `e5310d1b`, dead-path 방지).
   // 정직한 최소 표면: 실 필드(title/status/assignee/description/acceptance_criteria/
@@ -1367,7 +1378,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                         onClick={() => { if (!isCurrent) void handleChangeStatus(col.id); }}
                       >
                         <Check className={`size-4 ${isCurrent ? '' : 'opacity-0'}`} />
-                        {t(statusKeyMap[col.id] ?? col.i18nKey)}
+                        {getStatusLabel?.(col.id) ?? t(statusKeyMap[col.id] ?? col.i18nKey)}
                       </DropdownMenuItem>
                     );
                   })}
@@ -1609,6 +1620,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                     placeholder="Markdown 형식으로 작성하세요..."
                     className="flex field-sizing-content min-h-[160px] w-full resize-y rounded-lg border border-input bg-transparent px-2.5 py-2 font-mono text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                     autoFocus
+                    getEntityTypeLabel={getEntityTypeLabel}
                   />
                   <div className="flex gap-2">
                     <Button size="sm" onClick={handleSaveDescription} disabled={savingDescription}>
@@ -1667,6 +1679,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                     placeholder="Markdown 형식으로 작성하세요..."
                     className="flex field-sizing-content min-h-[160px] w-full resize-y rounded-lg border border-input bg-transparent px-2.5 py-2 font-mono text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                     autoFocus
+                    getEntityTypeLabel={getEntityTypeLabel}
                   />
                   <div className="flex gap-2">
                     <Button size="sm" onClick={handleSaveAC} disabled={savingAC}>

--- a/apps/web/src/components/shared/entity-aware-textarea.test.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.test.tsx
@@ -10,13 +10,14 @@ import { EntityAwareTextarea } from './entity-aware-textarea';
 
 // 실제 controlled input처럼 동작해야 e.target.value/selectionStart가 이어지는 입력에서
 // 최신값을 반영한다 — 바깥 let 변수만 갱신하면 리렌더가 없어 DOM value가 안 바뀐다.
-function ControlledHarness({ initial, projectId, onValueChange }: { initial: string; projectId?: string; onValueChange: (v: string) => void }) {
+function ControlledHarness({ initial, projectId, onValueChange, getEntityTypeLabel }: { initial: string; projectId?: string; onValueChange: (v: string) => void; getEntityTypeLabel?: (canonicalSlug: string) => string | undefined }) {
   const [value, setValue] = useState(initial);
   return (
     <EntityAwareTextarea
       value={value}
       onChange={(v) => { setValue(v); onValueChange(v); }}
       projectId={projectId}
+      getEntityTypeLabel={getEntityTypeLabel}
     />
   );
 }
@@ -134,6 +135,55 @@ describe('EntityAwareTextarea — story #2264', () => {
 
     expect(container.textContent).toContain('검토 중');
     expect(container.textContent).not.toContain('in-review');
+  });
+});
+
+// story #3289(도메인탈고정·축1 Phase1 FE잔여, AC2) — 참조 코어(chat-input-entity-tokens.ts)의
+// entityTypeLabel()은 diff 0 규율(#2264 AC3) 대상이라 손대지 않고, 이 소비처에서만 org
+// 오버라이드를 얹는다. getEntityTypeLabel 없으면(undefined) canonical 그대로(회귀 0).
+describe('EntityAwareTextarea — org 엔티티명 라벨 오버라이드(story #3289 AC2)', () => {
+  it('getEntityTypeLabel 없으면 canonical entityTypeLabel() 그대로("스토리")', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ entity_type: 'story', entity_id: '11111111-1111-1111-1111-111111111111', title: '제목', status: null }],
+    }))));
+    await act(async () => {
+      root.render(<ControlledHarness initial="" projectId="p1" onValueChange={() => {}} />);
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '#');
+      el.selectionStart = 1;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+    expect(container.textContent).toContain('스토리');
+  });
+
+  it('getEntityTypeLabel이 값을 돌려주면 그룹 헤더가 그 오버라이드로 바뀐다', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      data: [{ entity_type: 'story', entity_id: '11111111-1111-1111-1111-111111111111', title: '제목', status: null }],
+    }))));
+    await act(async () => {
+      root.render(
+        <ControlledHarness
+          initial=""
+          projectId="p1"
+          onValueChange={() => {}}
+          getEntityTypeLabel={(slug) => (slug === 'story' ? '작업건' : undefined)}
+        />,
+      );
+    });
+    const el = textarea();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(el, '#');
+      el.selectionStart = 1;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => { await new Promise((r) => setTimeout(r, 260)); });
+    expect(container.textContent).toContain('작업건');
+    expect(container.textContent).not.toContain('스토리');
   });
 });
 

--- a/apps/web/src/components/shared/entity-aware-textarea.tsx
+++ b/apps/web/src/components/shared/entity-aware-textarea.tsx
@@ -17,6 +17,11 @@ interface EntityAwareTextareaProps {
   className?: string;
   autoFocus?: boolean;
   onPaste?: (e: ClipboardEvent<HTMLTextAreaElement>) => void;
+  /** story #3289(도메인탈고정·축1 Phase1 FE잔여, AC2) — org 엔티티명 라벨 오버라이드
+   * (useOrgDomainLabels().entityTypeLabel), story-card.tsx의 getStatusLabel과 동형. 없으면
+   * chat-input-entity-tokens.ts의 canonical entityTypeLabel() 그대로(회귀 0). 참조 코어
+   * 파일(chat-input-entity-tokens.ts) 자체는 diff 0 규율(#2264 AC3)이라 여기 소비처에서만 얹는다. */
+  getEntityTypeLabel?: (canonicalSlug: string) => string | undefined;
 }
 
 /**
@@ -25,7 +30,7 @@ interface EntityAwareTextareaProps {
  * use-entity-picker.ts, 이 파일은 그 위의 얇은 렌더 래퍼 — chat-input.tsx의 entity dropdown
  * JSX를 그대로 재사용). story description/AC(story-detail-panel.tsx)가 첫 소비자.
  */
-export function EntityAwareTextarea({ value, onChange, projectId, placeholder, className, autoFocus, onPaste }: EntityAwareTextareaProps) {
+export function EntityAwareTextarea({ value, onChange, projectId, placeholder, className, autoFocus, onPaste, getEntityTypeLabel }: EntityAwareTextareaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const entityPicker = useEntityPicker(projectId);
 
@@ -88,7 +93,7 @@ export function EntityAwareTextarea({ value, onChange, projectId, placeholder, c
               <li key={`${entity.entity_type}:${entity.entity_id}`}>
                 {isNewGroup && (
                   <div className="sticky top-0 bg-popover px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    {entityTypeLabel(entity.entity_type)}
+                    {getEntityTypeLabel?.(entity.entity_type) ?? entityTypeLabel(entity.entity_type)}
                   </div>
                 )}
                 {/* ⛔focus-outset을 일부러 안 붙인다(PO 확認, 2026-07-28) — 이 하이라이트(bg-accent)는


### PR DESCRIPTION
## Summary
- AC1: `story-detail-panel.tsx`의 status 배지·전환메뉴·Workcell 표시가 `useOrgDomainLabels().statusLabel` 오버라이드를 소비(3687과 동형 `?? t(...)` 폴백, 회귀 0). 호출부 3곳 배선 — `kanban-board.tsx`(기존 domainLabels 재사용)·`epic-swimlane-board.tsx`·`flow-node-story-panel.tsx`(신규 훅 배선).
- AC2: 실측 결과 사이드바(app-sidebar.tsx)·브레드크럼(doc-breadcrumb.tsx)엔 entity_type 렌더지점이 **없음**. 실제 렌더처는 `chat-input-entity-tokens.ts`의 `entityTypeLabel()`(소비처: chat `#` 멘션피커 `chat-input.tsx` + `entity-aware-textarea.tsx`)였다 — 참조 코어 파일 자체는 diff-0 규율(#2264 AC3)이라 손대지 않고 두 소비처에서만 org 오버라이드를 얹었다.
- AC3: 오버라이드 미설정 org는 canonical 그대로.
- ⛔범위 밖(별도 갭으로 남김, 스코프 발산 금지): `epic-swimlane-board.tsx`의 `StoryCard` 배지는 3687이 커버 안 한 별도 표면 — 이번 스토리 AC 밖이라 손 안 댐.

## Test plan
- [x] `pnpm vitest run` (해당 7개 파일) — 165 passed
- [x] `pnpm type-check`(tsc --noEmit) — clean
- [x] `pnpm lint`(eslint, 해당 파일) — clean
- [x] `pnpm build`(next build) — 성공
- [x] 로컬 dev server 부팅 확인(크래시 없음)
- [ ] 인증 필요 라이브 화면(칸반 상세패널·에픽 스윔레인·플로우 노드·챗 멘션피커) 픽셀 확인 — dev 배포 후 카디르군 QA 몫

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrXtyieXmkonMVwuCWr9c3