### PR TITLE
[SID:3297] dev 배포 케이던스 전환 — develop push 자동배포 제거

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -5,8 +5,15 @@ name: Cloud Build (GCP)
 # Submit 스텝에 인라인 나열 금지. 주석에도 리터럴 표현식 토큰 쓰지 말 것.
 
 on:
+  # story #3297(2026-09-01, 선생님 지시 — 배포 케이던스가 워크플로우 병목) — develop을 push
+  # 트리거에서 뺀다. 실측: develop 머지 31건 = Cloud Build 31회(머지마다 dev 전체 배포).
+  # dev 배포는 이제 workflow_dispatch로 PO가 「머지 묶음 완주+CI green+정정 0」일 때 1회
+  # (운용 규칙, 코드 밖). main(prod 승격 경로)은 무변 — push 트리거 그대로 유지.
+  # env 도출은 "Set deploy environment" 스텝이 github.ref_name만 보고 분기한다(아래
+  # inputs.env는 참조되지 않음 — dispatch 시에도 대상 ref가 dev/prod를 가른다는 뜻이라,
+  # develop ref로 dispatch하면 이 로직이 그대로 target=dev를 도출한다. 별도 배선 불요).
   push:
-    branches: [main, develop]
+    branches: [main]
   workflow_dispatch:
     inputs:
       env:


### PR DESCRIPTION
## 배경
[[인프라] dev 배포 케이던스 전환 — develop push 자동배포 제거·안정 threshold에서 PO 수동 1회](entity:story:114fb396-fd94-455d-b83b-93cb59733349)

선생님 지시(2026-09-01): 「dev 배포도 threshold가 안정적일 때 한 번만 — 배포가 너무 잦아 워크플로우 자체가 병목·dev 정정 사건으로 격차 확대」. 실측: 오늘 develop 머지 31건 = Cloud Build (GCP) 31회.

## 변경
`.github/workflows/cloud-build.yml` `on.push.branches`에서 `develop` 제거. `main`(prod 승격 경로)은 무변.

## AC별 실측
- **develop 머지 시 Cloud Build 미실행**: 트리거 자체를 제거했으므로 구조적으로 보장 (`branches: [main]`만 남음).
- **workflow_dispatch → dev env 도출**: `Set deploy environment` 스텝은 `github.ref_name`만 보고 분기(`main`이면 prod, 아니면 dev) — push든 dispatch든 트리거 종류와 무관하게 동작. `develop` ref로 dispatch하면 그대로 `target=dev`가 나옴(코드 정적 확認 — 실제 dispatch 실행은 아래 참조). `workflow_dispatch.inputs.env`는 원래도 어디서도 참조 안 되는 dead input이라 그대로 둠(스토리에서도 "기존 env input 그대로" 명시).
- **Deploy Digest Guard·Serving Reality Guard green 유지**: 코드 변경 불요 — 실측 근거:
  - Deploy Digest Guard(`deploy-digest-guard.yml`): `workflow_dispatch`/`workflow_call`만 있고 `push` 트리거 자체가 없다. 배포 워크플로우가 방금 배포한 정확한 commit_sha를 들고 온디맨드로 호출하는 설계 — cadence와 무관.
  - Serving Reality Guard(`serving-reality-guard.yml` → `infra/check_serving_reality.py`): docstring에 "지금 서빙되는 것이 최신 머지인가는 안 본다(주기 실행이라 기대 리비전을 모른다) — 구조적 건강(axis A 트래픽 고정·axis B 정체)만 본다"고 명시돼 있다. **"머지=배포" 전제 자체가 이 가드엔 없다** — 배치 배포 체제에서도 상주 빨강 없음.
- **DB Migrations 트리거 연동**: `migrate.yml`은 `cloud-build.yml`과 완전히 별개 워크플로우(자체 `push: [develop, main]` + `paths: packages/db/supabase/migrations/**` 필터) — 공유 트리거·상호 호출 없음, 이 변경과 연동 자체가 없다.
- **develop 브랜치 보호 영향 없음**: `gh api repos/moonklabs/sprintable/branches/develop/protection` 확認 — `required_status_checks.contexts`에 "Cloud Build (GCP)" 없음.
- **actionlint**: 변경분에 새 오류 0(기존 shellcheck SC2129 style 경고는 무관한 사전 존재분).

## 미검증(인프라 lane 필요)
`workflow_dispatch`로 실제 dev 배포 1회 트리거 + 서빙 확認(배포 success≠서빙, `Serving Reality Guard` on-demand 겸 확認)은 실제 gcloud 배포 액션이라 PO 승인·집행 몫으로 남겨둠. 머지 후 dispatch 부탁하는.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01LYrGWC6cqBE37oteHUtHyT