### PR TITLE
[SID:2476] legacy subscriptions/subscription_checkout_sessions — OSS死·SaaS-only 라이브 명시

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,22 @@ jobs:
   # story #2330 AC6 — env.py(PR#2661)의 "autocommit_block()은 이 프로젝트에서 원리적으로
   # 못 쓴다" 주석은 «읽어야» 서는 것이었다(주석만으로는 다음 사람이 또 쓸 수 있다). grep
   # 가드로 승격한다 — 마이그레이션 파일에 그 호출이 들어오면 CI가 빨개진다.
+  # story #2476(결제②-A1후속 재그라운딩, 2026-09-01) — legacy `subscriptions`·
+  # `subscription_checkout_sessions` 테이블은 OSS(이 레포)에서 참조 0건이지만 死 테이블은
+  # 아니다(docs/pk-triage-orm-unmodeled.md, story a74bdc84 — 별도 SaaS 제품이 같은 물리
+  # DB를 라이브로 쓰는 중). OSS 정본은 org_subscriptions뿐 — 이 lint는 「참조 0」을 계수
+  # 가능하게 유지한다(새 코드가 legacy 테이블을 다시 끌어오면 즉시 빨강).
+  legacy-subscriptions-reuse-lint:
+    name: legacy subscriptions reuse lint (guard, story #2476)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Scan backend/app for legacy subscriptions table reuse
+        working-directory: backend
+        run: python3 scripts/lint_legacy_subscriptions_reuse.py
+
   alembic-no-autocommit-block:
     name: Alembic migrations — no autocommit_block() (guard)
     runs-on: ubuntu-latest

--- a/backend/alembic/versions/0298_legacy_subscriptions_dead_comment.py
+++ b/backend/alembic/versions/0298_legacy_subscriptions_dead_comment.py
@@ -1,0 +1,43 @@
+"""legacy subscriptions/subscription_checkout_sessions — OSS死·SaaS-only 라이브 선언 주석.
+
+story #2476(결제②-A1후속) 재그라운딩(2026-09-01, 페드루 PO 판정) — 이 두 테이블은 OSS
+레포(이 backend)에서 실사용 0건(전수 grep 확認: app/ 어디서도 ORM 모델·raw SQL 소비 없음)
+이라 스토리 원 AC 「참조 0이면 drop 또는 死선언」 갈래 중 **死선언** 쪽이 정답이다 — drop은
+아니다.
+
+⛔drop 절대 금지: `docs/pk-triage-orm-unmodeled.md`(story a74bdc84, 기존 전수 감사)가 이미
+이 두 테이블을 «(보류) SaaS-only 라이브»로 분류해 뒀다 — `subscriptions`는 SaaS 라이브
+206 refs, `subscription_checkout_sessions`는 35 refs(둘 다 별도 SaaS 제품/오버레이가
+Supabase로 직접 침 — dead 아님). sprintable(OSS)과 SaaS가 같은 물리 Postgres를 공유하는
+구조라 여기서 DROP하면 SaaS 프로덕션 데이터가 지워진다. drop 가능 여부는 이 트랙·이 org
+밖(SaaS 트랙 판단) — 손 안 댄다.
+
+이 마이그는 순수 `COMMENT ON TABLE`만 한다 — 스키마/데이터 무변경, idempotent(같은 값
+재실행 안전), downgrade는 comment를 NULL로 되돌린다(원래 comment 없던 상태). 목적은 차기
+감사자가 psql `\\d+ subscriptions`만 봐도 "이거 OSS에서 안 쓴다·SaaS 거다·지우지 마라"를
+즉시 알 수 있게 — 코드 주석(app/models/org_subscription.py)과 짝.
+
+OSS 정본은 `org_subscriptions`(app/models/org_subscription.py::OrgSubscription) 하나뿐이다.
+"""
+from alembic import op
+
+revision = "0298"
+down_revision = "0297"
+branch_labels = None
+depends_on = None
+
+_COMMENT = (
+    "OSS-dead / SaaS-only live (story #2476 재그라운딩, docs/pk-triage-orm-unmodeled.md "
+    "story a74bdc84). sprintable(OSS) backend는 이 테이블을 안 쓴다 — org_subscriptions가 "
+    "OSS 유일 정본. 이 물리 DB를 공유하는 별도 SaaS 제품이 라이브로 쓰는 중이라 DROP 금지."
+)
+
+
+def upgrade() -> None:
+    op.execute(f"COMMENT ON TABLE subscriptions IS '{_COMMENT}'")
+    op.execute(f"COMMENT ON TABLE subscription_checkout_sessions IS '{_COMMENT}'")
+
+
+def downgrade() -> None:
+    op.execute("COMMENT ON TABLE subscriptions IS NULL")
+    op.execute("COMMENT ON TABLE subscription_checkout_sessions IS NULL")

--- a/backend/app/models/org_subscription.py
+++ b/backend/app/models/org_subscription.py
@@ -9,6 +9,18 @@ from app.core.database import Base
 
 
 class OrgSubscription(Base):
+    """OSS(sprintable backend)의 **유일한** 구독 정본 모델(story #2476, 2026-09-01 재그라운딩).
+
+    ⛔ legacy `subscriptions`·`subscription_checkout_sessions` 테이블은 여기서 안 쓴다 — OSS
+    레포 전수 grep 확認 참조 0건. 그렇다고 死 테이블은 아니다: `docs/pk-triage-orm-unmodeled.md`
+    (story a74bdc84)가 이미 그 둘을 «(보류) SaaS-only 라이브»로 분류해 뒀다(별도 SaaS 제품이
+    같은 물리 DB를 Supabase로 직접 침 — subscriptions 206 refs·subscription_checkout_sessions
+    35 refs). 그래서 DROP은 금지(SaaS prod 데이터 파괴 위험) — 대신 마이그 0298이 `COMMENT ON
+    TABLE`로 그 두 테이블에 같은 사실을 DB 메타데이터 레벨에도 못박아 뒀다. 새 코드가 이
+    ORM 모델 대신 그 legacy 테이블을 다시 참조하려 하면 그게 회귀다(스코프 밖 SaaS 얘기가
+    아닌 한).
+    """
+
     __tablename__ = "org_subscriptions"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/backend/scripts/lint_legacy_subscriptions_reuse.py
+++ b/backend/scripts/lint_legacy_subscriptions_reuse.py
@@ -1,0 +1,76 @@
+"""story #2476(결제②-A1후속 재그라운딩, 2026-09-01) — legacy `subscriptions`·
+`subscription_checkout_sessions` 테이블이 OSS backend 코드에 다시 참조되면 CI를 빨갛게 한다.
+
+배경: 두 테이블은 OSS(이 레포)에서 참조 0건(재그라운딩 시점 전수 grep 확認)이지만, 死
+테이블은 아니다 — `docs/pk-triage-orm-unmodeled.md`(story a74bdc84)가 이미 별도 SaaS 제품이
+같은 물리 DB를 라이브로 쓰는 중임을 확認해 뒀다(subscriptions 206 refs·subscription_
+checkout_sessions 35 refs). OSS 정본은 `org_subscriptions`(app/models/org_subscription.py::
+OrgSubscription) 하나뿐 — 누군가 실수로(또는 예전 설계문서를 그대로 베껴) 이 legacy 테이블을
+ORM 모델이나 raw SQL로 다시 끌어오면, 그 코드는 SaaS가 실제로 쓰는 스키마를 OSS 배포가
+건드리게 될 위험이 있다. 「참조 0」을 계수 가능하게 유지하는 가드.
+
+⛔이 lint가 잡는 것(패턴 3종, backend/app/ 전수):
+  ① `__tablename__ = "subscriptions"` / `"subscription_checkout_sessions"` (ORM 모델 재도입)
+  ② raw SQL: FROM/INTO/UPDATE/JOIN 뒤에 그 테이블명이 오는 경우(대소문자 무관)
+  ③ `sa.Table("subscriptions", ...)` / `Table("subscription_checkout_sessions", ...)` 리플렉션
+
+⛔이 lint가 «못 잡는» 것: 동적으로 조립된 테이블명(f-string·변수 결합), ORM 관계 문자열이
+아닌 완전히 별도 표현으로 우회한 raw SQL. 오탐 방지 우선(다른 lint_*.py와 동일 원칙) — 걸리면
+그건 이 스크립트가 못 잡던 새 우회 경로이지, 안전하다는 뜻이 아니다.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_TABLES = ("subscriptions", "subscription_checkout_sessions")
+
+_PATTERNS = [
+    re.compile(rf'__tablename__\s*=\s*["\']({"|".join(_TABLES)})["\']'),
+    re.compile(
+        rf'\b(FROM|INTO|UPDATE|JOIN)\s+({"|".join(_TABLES)})\b', re.IGNORECASE
+    ),
+    re.compile(rf'\bTable\(\s*["\']({"|".join(_TABLES)})["\']'),
+]
+
+SCAN_ROOT = "app"
+
+
+def find_violations(path: Path, label: str | None = None) -> list[str]:
+    """단일 파일 스캔 — 위반 라인을 `{label}:{lineno}: {line}` 형태로 반환(label 생략 시 path 그대로)."""
+    text = path.read_text(encoding="utf-8")
+    label = label or str(path)
+    violations: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for pattern in _PATTERNS:
+            if pattern.search(line):
+                violations.append(f"{label}:{lineno}: {line.strip()}")
+    return violations
+
+
+def scan(backend_root: Path) -> list[str]:
+    violations: list[str] = []
+    for f in sorted((backend_root / SCAN_ROOT).rglob("*.py")):
+        violations.extend(find_violations(f, label=str(f.relative_to(backend_root))))
+    return violations
+
+
+def main() -> int:
+    backend_root = Path(__file__).resolve().parent.parent
+    violations = scan(backend_root)
+    if violations:
+        print(
+            "FAIL: legacy subscriptions/subscription_checkout_sessions 테이블이 OSS backend "
+            "코드에 재도입됐다 (story #2476 — OSS 정본은 org_subscriptions뿐, legacy는 SaaS "
+            "전용 라이브 스키마라 OSS가 건드리면 안 된다):"
+        )
+        for v in violations:
+            print(f"  {v}")
+        return 1
+    print("OK: legacy subscriptions 테이블 참조 0건 유지")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
+++ b/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
@@ -35,6 +35,7 @@ _CI_OR_LOCAL_ONLY_ALLOWLIST = frozenset({
     "lint_commit_before_validate.py",             # story #2459 — CI lint 게이트(AST 정적분석, 운영 DB 무접속)
     "lint_dependency_override_get_read_db.py",    # story #2451 — CI lint 게이트(tests/ override 스캔, 운영 DB 무접속)
     "lint_destructive_test_sql.py",               # story #2786 — CI lint 게이트(tests/ 재귀 AST 스캔, 운영 DB 무접속)
+    "lint_legacy_subscriptions_reuse.py",         # story #2476 — CI lint 게이트(app/ 재귀 정적 스캔, 운영 DB 무접속)
     "lint_project_access_403.py",                 # story #2342 AC7 — CI lint 게이트
     "lint_query_sentinel_direct_calls.py",        # story #2335 — CI lint 게이트
     "lint_no_script_output_artifacts.py",         # story #3008 — CI lint 게이트(scripts/ 파일명·내용 정적 스캔, 운영 DB 무접속)

--- a/backend/tests/test_2476_legacy_subscriptions_reuse_lint.py
+++ b/backend/tests/test_2476_legacy_subscriptions_reuse_lint.py
@@ -1,0 +1,105 @@
+"""story #2476(결제②-A1후속 재그라운딩) — lint_legacy_subscriptions_reuse.py의 정탐/오탐 회귀
+가드. 합성 fixture로 짓는다(실물이 고쳐져도 이 테스트는 안 사라진다, story #2335/#2342 lint와
+동형)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from lint_legacy_subscriptions_reuse import find_violations, scan  # noqa: E402
+
+
+def _write(tmp_path: Path, name: str, source: str) -> Path:
+    p = tmp_path / name
+    p.write_text(source)
+    return p
+
+
+def test_detects_tablename_reintroduction(tmp_path):
+    src = '''
+class Subscription(Base):
+    __tablename__ = "subscriptions"
+'''
+    path = _write(tmp_path, "bad_model.py", src)
+    assert len(find_violations(path)) == 1
+
+
+def test_detects_checkout_sessions_tablename(tmp_path):
+    src = '''
+class SubscriptionCheckoutSession(Base):
+    __tablename__ = "subscription_checkout_sessions"
+'''
+    path = _write(tmp_path, "bad_checkout_model.py", src)
+    assert len(find_violations(path)) == 1
+
+
+def test_detects_raw_sql_from_clause(tmp_path):
+    src = '''
+async def legacy_lookup(session):
+    return await session.execute(text("SELECT * FROM subscriptions WHERE org_id = :org_id"))
+'''
+    path = _write(tmp_path, "bad_raw_sql.py", src)
+    assert len(find_violations(path)) == 1
+
+
+def test_detects_table_reflection(tmp_path):
+    src = '''
+legacy = sa.Table("subscriptions", metadata, autoload_with=engine)
+'''
+    path = _write(tmp_path, "bad_reflection.py", src)
+    assert len(find_violations(path)) == 1
+
+
+def test_org_subscriptions_canonical_not_flagged(tmp_path):
+    """정본 org_subscriptions는 legacy 테이블명과 다른 문자열이라 안 걸려야 한다."""
+    src = '''
+class OrgSubscription(Base):
+    __tablename__ = "org_subscriptions"
+
+async def get_org_subscription(session, org_id):
+    return await session.execute(text("SELECT * FROM org_subscriptions WHERE org_id = :org_id"))
+'''
+    path = _write(tmp_path, "good_canonical.py", src)
+    assert find_violations(path) == []
+
+
+def test_prose_mention_in_docstring_not_flagged(tmp_path):
+    """死선언 주석 자체(이 스토리가 새로 추가한 것과 동형)는 SQL 절/__tablename__ 패턴이 아니라
+    안 걸려야 한다 — 걸리면 이 lint가 자기 자신의 문서화 커밋을 매번 빨갛게 만드는 셈이라
+    오탐 방지 실패."""
+    src = '''
+class OrgSubscription(Base):
+    """OSS 유일 정본. legacy subscriptions·subscription_checkout_sessions는 SaaS 전용 라이브라
+    OSS에서 안 쓴다 — docs/pk-triage-orm-unmodeled.md 참고."""
+
+    __tablename__ = "org_subscriptions"
+'''
+    path = _write(tmp_path, "good_docstring.py", src)
+    assert find_violations(path) == []
+
+
+def test_mutation_disabling_patterns_causes_zero_detections():
+    """뮤테이션: 패턴 리스트를 비우면 위 양성 테스트가 깨져야 한다 — 이 lint의 핵심 로직이
+    실제로 테스트에 의해 지켜지는지 자가 검증(story #2342 lint와 동일 관례)."""
+    import lint_legacy_subscriptions_reuse as mod
+
+    original = mod._PATTERNS
+    try:
+        mod._PATTERNS = []
+        src = 'class Subscription(Base):\n    __tablename__ = "subscriptions"\n'
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "bad.py"
+            path.write_text(src)
+            violations = find_violations(path)
+        assert violations == [], "뮤테이션 후에는 탐지가 0이어야 정상(로직이 실제로 패턴에 의존함을 증명)"
+    finally:
+        mod._PATTERNS = original
+
+
+def test_current_repo_has_zero_violations():
+    """실물 backend/app/ 전수 스캔 — 재그라운딩 시점(2026-09-01) 확認한 참조 0건이 유지되는지
+    CI가 도는 그 검사 자체를 pytest로도 한 번 더 고정한다."""
+    backend_root = Path(__file__).parent.parent
+    assert scan(backend_root) == []


### PR DESCRIPTION
## 배경 — 재그라운딩 (2026-09-01, 페드루 PO 판정)
[[결제②-A1후속] 두 구독 스키마 통합 — org_subscriptions(정본) ↔ legacy subscriptions(死스키마) 정리](entity:story:5348afbf-d77d-433d-8a4c-ed99f2f926c5)

원 AC: 「참조 0이면 마이그로 정리(**drop**) 또는 명시적 «死 스키마» 선언」. 착수 前 재그라운딩(전제 재검증)에서 drop 갈래는 조건 미발동으로 확認됐다:

- OSS(이 레포) 코드: `backend/app/` 전수 grep 참조 **0건**(스토리 원 전제와 일치).
- 그러나 `docs/pk-triage-orm-unmodeled.md`(기존 전수 감사, story a74bdc84)가 이미 이 두 테이블을 「(보류) SaaS-only 라이브」로 분류해 뒀다 — `subscriptions` SaaS 라이브 **206 refs**, `subscription_checkout_sessions` **35 refs**. 별도 SaaS 제품/오버레이가 같은 물리 Postgres를 Supabase로 직접 침 — **dead 아님**.
- ⇒ sprintable(OSS)에서 DROP하면 SaaS prod 데이터 파괴 위험 — **死선언 갈래만 진행**(PO 확定, drop 정책은 그 doc에 이미 결정돼 있어 재상신 불요).

## 변경
1. `backend/app/models/org_subscription.py` — `OrgSubscription`을 OSS 유일 정본으로 클래스 docstring에 명시, legacy 2테이블 死·SaaS-only 사실 + pk-triage doc(a74bdc84) 링크.
2. `backend/alembic/versions/0298_legacy_subscriptions_dead_comment.py` — 순수 `COMMENT ON TABLE`(idempotent, 스키마/데이터 무변경). 로컬 disposable PG(fresh, baseline→0298 전체 체인)로 `alembic upgrade head` 실측 — 에러 0, `obj_description()` 양쪽 정상 반영 확認.
3. `backend/scripts/lint_legacy_subscriptions_reuse.py` + `tests/test_2476_legacy_subscriptions_reuse_lint.py` — OSS 재유입 가드(③). `__tablename__` 재도입·raw SQL FROM/INTO/UPDATE/JOIN·`Table()` 리플렉션 3종 패턴을 `backend/app/` 전수 스캔, 「참조 0」을 계수 가능하게 유지. 정탐 4종 + 오탐 2종(org_subscriptions 정본·死선언 docstring 자체가 안 걸리는지) + 뮤테이션 셀프체크 + 실물 0건 확認, 8 passed. `ci.yml`에 guard job 배선(기존 `lint_*.py` 관례 그대로).

## 검증
- 새 lint pytest 8 passed.
- 관련 스위트(`org_subscription`/`subscription` 매칭 57개) 무회귀.
- actionlint: ci.yml 새 job 오류 0.
- 마이그레이션 로컬 실PG 왕복 검증(위 ②).

## 스코프 경계
- ⛔ **drop 절대 금지**(SaaS prod 데이터 파괴 위험) — 이 PR은 어떤 데이터/스키마도 변경하지 않는다(COMMENT만).
- SaaS 쪽 legacy 정리 여부는 이 트랙·이 org 밖 — 손 안 댐.
- develop 착지까지, prod 반영 없음.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01LYrGWC6cqBE37oteHUtHyT