### PR TITLE
[SID:3298] fix(gateway): support_conversations 모델↔마이그 드리프트 — fleet CI blocker

### DIFF
--- a/support-gateway/app/models.py
+++ b/support-gateway/app/models.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, DateTime, Float, ForeignKey, Index, Text, Uuid, func
+from sqlalchemy import CheckConstraint, DateTime, Float, ForeignKey, Index, Text, Uuid, func, text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 # SQLAlchemy 2.0 제네릭 Uuid — PG는 native UUID로, SQLite(테스트 전용, aiosqlite)는 CHAR(32)로
@@ -54,8 +54,27 @@ class SupportConversation(Base):
     # (org_id, external_user_id) 복합 인덱스 하나(그 조합으로 "활성 상담" 조회, 위 docstring)
     # 인데, 모델은 external_user_id에 `index=True`만 붙여 실제 배포엔 없는 단일 컬럼 인덱스를
     # 따로 선언하고 있었다(compare_metadata 실측으로 적발). 실 배포 스키마에 맞춰 정정.
+    #
+    # story #3298(2026-09-02, fleet CI blocker 정정) — migration 0005(story #3278, PR#3681)가
+    # (org_id, external_user_id) WHERE ended_at IS NULL 부분 유니크 인덱스
+    # ux_support_conversations_org_user_active를 실 DB에 추가했으나, 이 모델은 그때 갱신 안
+    # 됨(compare_metadata 실측: DB엔 있고 metadata엔 없어 'remove_index'로 잡힘 — 정본은
+    # migration 쪽, 모델이 뒤처졌던 것). 위 ix_(0003, 비유니크·전체행) 인덱스는 0005가 안
+    # 지웠으므로 DB에 그대로 남아 있다 — 둘 다 선언해야 실 스키마와 일치.
+    # ⛔postgresql_where만 주면 SQLite(테스트 dialect)는 그 kwarg를 무시하고 **전체행** 유니크
+    # 인덱스를 만든다(부분 조건 없이) — 실측으로 걸림: test_conversation_user_scope.py 3건이
+    # "새 상담 시작이 이전 걸 종료 처리"하는 흐름에서 ended_at 무관 유니크 위반으로 깨졌다.
+    # sqlite_where를 나란히 줘야 SQLite에서도 진짜 부분 인덱스(ended_at IS NULL만 대상)가 된다.
     __table_args__ = (
         Index("ix_support_conversations_org_user_active", "org_id", "external_user_id"),
+        Index(
+            "ux_support_conversations_org_user_active",
+            "org_id",
+            "external_user_id",
+            unique=True,
+            postgresql_where=text("ended_at IS NULL"),
+            sqlite_where=text("ended_at IS NULL"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)


### PR DESCRIPTION
## 배경 — fleet-wide blocker
[[버그·CI blocker] support_conversations 모델↔마이그레이션 스키마 드리프트 — ux_support_conversations_org_user_active 유니크 인덱스](entity:story:aac7334a-e606-4da8-b320-221a6769b8db)

`develop` required 체크 «Support Gateway pytest»가 `test_gateway_schema_drift_realdb.py::test_model_metadata_matches_migrated_schema_no_structural_drift`에서 FAIL — 이후 모든 dev PR이 이 required로 막히는 상태였다.

## 근본원인 (드리프트 유발 커밋 특정)
`9e205f621` ([SID:3278] 활성 상담 최대 1개, PR#3681)가 alembic migration `0005_active_conversation_unique_index.py`로 실 DB에 `(org_id, external_user_id) WHERE ended_at IS NULL` 부분 유니크 인덱스 `ux_support_conversations_org_user_active`를 추가했지만, `app/models.py::SupportConversation.__table_args__`는 그 커밋에서 갱신되지 않았다.

**정본 판정**: migration(DB에 실재) 쪽이 정본, **모델이 뒤처졌다** — 스토리 AC가 예상한 "모델 기준일 가능성"과 반대. `compare_metadata()`가 `('remove_index', Index('ux_...', unique=True))`로 정확히 이 갭(DB엔 있고 metadata엔 없음)을 잡았다.

## 변경
`app/models.py`에 누락된 인덱스 선언 추가(마이그레이션 신규 추가 없음 — 스키마/데이터 무변경, 모델을 실 스키마에 맞춤):
```python
Index(
    "ux_support_conversations_org_user_active",
    "org_id", "external_user_id",
    unique=True,
    postgresql_where=text("ended_at IS NULL"),
    sqlite_where=text("ended_at IS NULL"),
)
```
(기존 `ix_support_conversations_org_user_active` 비유니크 인덱스는 0005가 안 지워 DB에 그대로 남아 있어 유지.)

⚠️ **도중 발견한 함정**: `postgresql_where`만 주면 SQLite(단위테스트 dialect)가 그 kwarg를 무시하고 **전체행** 유니크 인덱스를 만든다 — 실측으로 `test_conversation_user_scope.py` 3건("새 상담 시작이 이전 걸 종료 처리")이 ended_at 무관 유니크 위반으로 깨지는 걸 확認했다. `sqlite_where`를 나란히 줘야 두 dialect 모두 진짜 부분 인덱스가 된다.

## 검증
- 로컬 disposable Postgres(fresh) + `GATEWAY_REALDB_URL` 실왕복: 수정 前 drift 재현(FAIL) → 수정 後 PASS 전환 확認.
- 전체 support-gateway 스위트: **191 passed, 2 skipped**(수정 前엔 3 failed).
- 마이그레이션 신규 추가 없음 — idempotent/rollback 우려 자체가 없음(모델 선언만 정정).

⛔ skip 반창고 아님 — 근본(모델↔마이그 일치) 정정. develop 착지까지, prod 무관.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01LYrGWC6cqBE37oteHUtHyT