### PR TITLE
[SID:3299] epic-swimlane 인라인 StoryCard 배지 org 라벨 오버라이드 확산

### DIFF
--- a/apps/web/src/components/epics/epic-swimlane-board.test.tsx
+++ b/apps/web/src/components/epics/epic-swimlane-board.test.tsx
@@ -55,8 +55,12 @@ vi.mock('next/navigation', () => ({
 // HumanOnlyAction(useDashboardContext().currentMemberType==='human')로 감싸여 있다
 // (kanban-board.test.tsx와 동형 관례). Provider 없이는 기본 컨텍스트값에 currentMemberType이
 // 아예 없어(fail-closed) 버튼이 항상 숨는다 — onDeleteSuccess 배선을 실제로 증명하려면 human으로 스텁.
+// story #3299(3687/3694 후속) — org statusLabel 오버라이드 테스트가 orgId를 바꿔 넣어야
+// 해서 정적 객체 리터럴 mock을 kanban-board.test.tsx와 동형의 vi.hoisted 모킹 함수로 바꾼다.
+// 기본 반환값(orgId 없음)은 기존 동작과 동일 — 다른 describe 블록은 무회귀.
+const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
-  useDashboardContext: () => ({ currentTeamMemberId: 'me-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'human' }),
+  useDashboardContext: () => useDashboardContextMock(),
 }));
 
 const { capturedDragEndHandlers, capturedDragStartHandlers } = vi.hoisted(() => ({
@@ -89,6 +93,7 @@ let container: HTMLDivElement;
 let root: Root;
 
 beforeEach(() => {
+  useDashboardContextMock.mockReturnValue({ currentTeamMemberId: 'me-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'human' });
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
@@ -151,6 +156,8 @@ type FetchStub = {
   // 실 fetch·delete 성공 시 카드 제거). story_id별 태스크 목록.
   tasksByStoryId?: Record<string, Array<Record<string, unknown>>>;
   deleteStorySpy?: (id: string) => void;
+  // story #3299 — kanban-board.test.tsx #3287 AC4와 동형(domain-labels 응답 스텁).
+  domainLabels?: Array<{ domain: string; canonical_slug: string; label_ko: string | null; label_en: string | null }>;
 };
 
 // ⚠️QA changes 4R(PR#3377, 카디르+codex, 2026-08-22) — CI 실행 명령까지 정확 재현해 8+1회
@@ -177,12 +184,15 @@ function withDefaultTrustStage(list: Array<Record<string, unknown>>): Array<Reco
   return list.map((s) => ('trust_stage' in s ? s : { ...s, trust_stage: deriveDefaultTrustStage(String(s['status'])) }));
 }
 
-function stubFetch({ stories = [], epics = [], members = [], bulkPatchSpy, singlePatchSpy, singlePatchOk = true, bulkPatchOk = true, storiesGetSpy, storyPages, epicPages, singlePatchResponseData, bulkPatchResponseData, storiesFetchFails = false, storiesAlwaysHasMore = false, tasksByStoryId = {}, deleteStorySpy }: FetchStub) {
+function stubFetch({ stories = [], epics = [], members = [], bulkPatchSpy, singlePatchSpy, singlePatchOk = true, bulkPatchOk = true, storiesGetSpy, storyPages, epicPages, singlePatchResponseData, bulkPatchResponseData, storiesFetchFails = false, storiesAlwaysHasMore = false, tasksByStoryId = {}, deleteStorySpy, domainLabels }: FetchStub) {
   stories = withDefaultTrustStage(stories);
   storyPages = storyPages?.map((page) => ({ ...page, stories: withDefaultTrustStage(page.stories) }));
   callLog = [];
   vi.stubGlobal('fetch', vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
     callLog.push(`${init?.method ?? 'GET'} ${url}`);
+    if (typeof url === 'string' && url.includes('/domain-labels')) {
+      return { ok: true, json: async () => domainLabels ?? [] };
+    }
     if (typeof url === 'string' && url.startsWith('/api/stories/bulk') && init?.method === 'PATCH') {
       bulkPatchSpy?.(JSON.parse(init.body ?? '{}'));
       if (!bulkPatchOk) return { ok: false, status: 500, json: async () => ({ error: { message: 'boom' } }) };
@@ -900,5 +910,33 @@ describe('EpicSwimlaneBoard — 스코프 축소(story #3019)', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// story #3299(3687/3694 후속) — 인라인 StoryCard 배지(ProofCapsule stateLabel, 카드 클릭 전
+// 항상 보이는 텍스트라 axisMode 토글과 무관)가 org statusLabel 오버라이드를 소비하는지.
+// kanban-board.test.tsx #3287 AC4와 동형 처방 — canonical status(색·판정)는 절대 무변경.
+describe('EpicSwimlaneBoard — 인라인 StoryCard 배지 org 라벨 오버라이드(story #3299)', () => {
+  beforeEach(() => {
+    useDashboardContextMock.mockReturnValue({
+      currentTeamMemberId: 'me-1', orgId: 'org-1', projectMemberships: [], orgMemberships: [], currentMemberType: 'human',
+    });
+  });
+
+  it('오버라이드 미설정(빈 목록)이면 카드 배지가 canonical i18n 그대로다(회귀 0)', async () => {
+    await mount({
+      stories: [{ id: 's1', title: '주인없는카드', status: 'backlog', priority: 'medium', epic_id: null }],
+      domainLabels: [],
+    });
+    expect(container.textContent).toContain('백로그');
+  });
+
+  it('org가 backlog 라벨을 오버라이드하면 스윔레인 인라인 카드 배지가 그 문구로 바뀐다', async () => {
+    await mount({
+      stories: [{ id: 's1', title: '주인없는카드', status: 'backlog', priority: 'medium', epic_id: null }],
+      domainLabels: [{ domain: 'status', canonical_slug: 'backlog', label_ko: '아이디어', label_en: 'Idea' }],
+    });
+    expect(container.textContent).toContain('아이디어');
+    expect(container.textContent).not.toContain('백로그');
   });
 });

--- a/apps/web/src/components/epics/epic-swimlane-board.tsx
+++ b/apps/web/src/components/epics/epic-swimlane-board.tsx
@@ -143,13 +143,16 @@ interface SwimlaneCellProps {
   memberMap: Record<string, KanbanMember>;
   onStoryClick: (story: KanbanStory) => void;
   isDragging: boolean;
+  /** story #3299(3687/3694 후속) — org status 라벨 오버라이드(useOrgDomainLabels().statusLabel),
+   * kanban-board.tsx의 StoryCard prop threading과 동형. 없으면 canonical t(...) 그대로. */
+  getStatusLabel?: (canonicalSlug: string) => string | undefined;
 }
 
 // story #2954(유나 처방·H4 kanban-trust-column.tsx:86,92 문법 이식) — 드래그 中엔 잠긴
 // (파생) 열이 "지금 못 놓는다"는 게 정적 상태만으론 안 드러났다(handleDragEnd:333의
 // targetLocked 방어는 침묵 실패 — 드롭해도 조용히 무효화). opacity-45로 드래그 중에만
 // 어둡게 해 시각이 그 침묵을 메운다.
-function SwimlaneCell({ laneId, columnId, locked, stories, memberMap, onStoryClick, isDragging }: SwimlaneCellProps) {
+function SwimlaneCell({ laneId, columnId, locked, stories, memberMap, onStoryClick, isDragging, getStatusLabel }: SwimlaneCellProps) {
   const { setNodeRef, isOver } = useDroppable({ id: `${laneId}::${columnId}`, disabled: locked });
   const closedDuringDrag = locked && isDragging;
   return (
@@ -167,6 +170,7 @@ function SwimlaneCell({ laneId, columnId, locked, stories, memberMap, onStoryCli
           assignees={(story.assignee_ids ?? []).flatMap((id) => memberMap[id] ? [memberMap[id]] : [])}
           onClick={() => onStoryClick(story)}
           locked={locked}
+          getStatusLabel={getStatusLabel}
         />
       ))}
     </div>
@@ -202,9 +206,11 @@ interface SwimlaneRowProps {
   memberMap: Record<string, KanbanMember>;
   onStoryClick: (story: KanbanStory) => void;
   isDragging: boolean;
+  /** story #3299 — SwimlaneCell로 그대로 물려준다(위 주석과 동형). */
+  getStatusLabel?: (canonicalSlug: string) => string | undefined;
 }
 
-function SwimlaneRow({ laneId, title, subtitle, columns, stories, axisMode, memberMap, onStoryClick, isDragging }: SwimlaneRowProps) {
+function SwimlaneRow({ laneId, title, subtitle, columns, stories, axisMode, memberMap, onStoryClick, isDragging, getStatusLabel }: SwimlaneRowProps) {
   const byColumn = useMemo(() => {
     const map: Record<string, KanbanStory[]> = {};
     for (const col of columns) map[col.id] = [];
@@ -233,6 +239,7 @@ function SwimlaneRow({ laneId, title, subtitle, columns, stories, axisMode, memb
             memberMap={memberMap}
             onStoryClick={onStoryClick}
             isDragging={isDragging}
+            getStatusLabel={getStatusLabel}
           />
         ))}
       </div>
@@ -242,9 +249,9 @@ function SwimlaneRow({ laneId, title, subtitle, columns, stories, axisMode, memb
 
 export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
   const t = useTranslations('board');
-  // story #3289 — kanban-board.tsx와 동형(useOrgDomainLabels 배선). 이 화면의 StoryDetailPanel
-  // 호출부(아래)에만 소비시킨다 — StoryCard(라인 163 부근) 배지는 이 스토리 AC 밖(3687이
-  // 커버한 건 kanban-board.tsx뿐, 이 스윔레인 카드는 별도 갭 — 별도 스토리로 남긴다).
+  // story #3289 — kanban-board.tsx와 동형(useOrgDomainLabels 배선). story #3299(3687/3694
+  // 후속) — 그때 StoryDetailPanel에만 물렸던 domainLabels를 이제 인라인 StoryCard 배지
+  // (SwimlaneRow→SwimlaneCell→StoryCard prop threading)에도 물린다. 새 훅 배선 없음(재사용).
   const { orgId } = useDashboardContext();
   const locale = useLocale();
   const domainLabels = useOrgDomainLabels(orgId, locale);
@@ -581,6 +588,7 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
                     memberMap={memberMap}
                     onStoryClick={(s) => setSelectedStoryId(s.id)}
                     isDragging={draggingActive}
+                    getStatusLabel={domainLabels.statusLabel}
                   />
                 ))}
 
@@ -605,6 +613,7 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
                         memberMap={memberMap}
                         onStoryClick={(s) => setSelectedStoryId(s.id)}
                         isDragging={draggingActive}
+                        getStatusLabel={domainLabels.statusLabel}
                       />
                     ))}
                   </div>
@@ -619,6 +628,7 @@ export function EpicSwimlaneBoard({ projectId }: { projectId: string }) {
                   memberMap={memberMap}
                   onStoryClick={(s) => setSelectedStoryId(s.id)}
                   isDragging={draggingActive}
+                  getStatusLabel={domainLabels.statusLabel}
                 />
               </div>
             </DndContext>


### PR DESCRIPTION
## Summary
- 3687(kanban-board StoryCard)·3694(StoryDetailPanel 3곳: kanban·epic-swimlane·flow-node)가 안 커버한 별도 표면 — `EpicSwimlaneBoard`가 인라인으로 그리는 `StoryCard`(`SwimlaneRow`→`SwimlaneCell`) 배지가 여전히 canonical 하드코딩이었다.
- 새 훅 배선 없음(⛔중복 금지 — 3694에서 이미 배선된 `domainLabels` 재사용). `getStatusLabel` prop을 `EpicSwimlaneBoard` → `SwimlaneRow` → `SwimlaneCell` → `StoryCard`로 그대로 물렸다(kanban-board.tsx 3687 패턴과 동형).
- 오버라이드 미설정 org는 canonical 그대로(회귀 0). 색·판정(story.status 자체)·레이아웃 무변경 — 표시 텍스트만.

## Test plan
- [x] `pnpm vitest run`(epic-swimlane-board.test.tsx 신규 2건 포함 33 passed·관련 파일 합산 92 passed)
- [x] `pnpm type-check`(tsc --noEmit) — clean
- [x] `pnpm lint`(eslint, 해당 파일) — clean
- [x] `pnpm build`(next build) — 성공
- [ ] 라이브 픽셀(에픽 스윔레인 뷰) 확認 — dev 배포 후 카디르군 QA 몫

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrXtyieXmkonMVwuCWr9c3