### PR TITLE
[SID:2255] app/models 등재 완주 — 15개 orphaned 모델 + 재발가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,23 @@ jobs:
         working-directory: backend
         run: python3 scripts/lint_legacy_subscriptions_reuse.py
 
+  # story #2255(69d7380e, 2026-07-28~09-02) — app/models/*.py에 __tablename__ 보유 모델이
+  # 새로 생겼는데 app/models/__init__.py에 import 안 되면 create_all()이 그 테이블을 조용히
+  # 안 만든다(#2201이 처음 적발한 결함 클래스, 11개 중 10개가 이 스토리로 뒤늦게 등재됨 —
+  # 등재 도중 이 가드로 5개가 «독립적으로 또» 새 있던 것도 같이 적발돼 함께 정리됨). 정적
+  # AST 스캔뿐(런타임 import 0회) — 정상 경로 오버헤드 없음. story #2662의 실패-시점 진단
+  # 가드와 보완 관계(겹치지 않음, 각 스크립트 docstring 참고).
+  model-registration-completeness-lint:
+    name: model registration completeness lint (guard, story #2255)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Scan app/models for unregistered __tablename__ models
+        working-directory: backend
+        run: python3 scripts/lint_model_registration_completeness.py
+
   alembic-no-autocommit-block:
     name: Alembic migrations — no autocommit_block() (guard)
     runs-on: ubuntu-latest

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -79,17 +79,39 @@ from app.models.activity_event import ActivityEvent
 from app.models.asset import Asset, AssetFolder, AssetLink
 from app.models.release_note import ReleaseNote
 from app.models.role_template import RoleTemplate
-# fix(2026-07-28, #2201 후속 CI 적출): app/models/*.py 파일 목록 대 이 파일의 import 목록을
-# 전수 대조해, `import app.models`만으로는 Base.metadata에 안 잡히는 모듈 11개를 찾았다
-# (2026-07-20 hitl_config/participation 건과 동일 결함 클래스). 이 PR이 실제로 필요한 것은
-# `event`(Event/"events" 테이블) 하나뿐이라 그것만 여기서 등재한다 — 나머지 10개(activity_log·
-# plan_feature·project_api_key·label·onboarding_event·verdict·workflow_execution_log·
-# workflow_line·workflow_template·workflow_trigger_type)는 등재 시 destructive_schema
-# 테스트(101개 파일 × 파일당 create_all/drop_all) 총소요가 CI 예산(25분, 기준선 16~17분)을
-# 넘겨 별도 스토리로 분리 — "[인프라·CI] 모델 하나 늘 때마다 CI가 몇 분씩 느려진다 — 집합
-# 모듈 누락 10건을 «등재할 수 없는» 상태다"(id 69d7380e-9567-47ed-9194-d9784cbf637a).
-# "등재를 미루는 것"이 아니라 "파일마다 전체 스키마를 create_all/drop_all하는 구조 자체를
-# 먼저 손보는 것"이 그 스토리의 실제 과제.
+# fix(2026-09-02, story #2255/69d7380e 완주) — #2201/PR#2554(2026-07-28)가 미룬 나머지 10개
+# 등재. 재그라운딩(당시 전제 vs 지금): #2293(2026-07-28~08, PR#2576/#2583)이 destructive_schema
+# 스위트를 4-way CI 샤드로 이미 쪼갰고, 최근 실측(story #2285 AC4, 2026-08-17)은 샤드당 4~6분·
+# 천장 25분 대비 여유 19~21분 — #2201 당시(순차 단일잡·여유 8분)와 전혀 다른 상태. 로컬 실측
+# (2026-09-02, disposable PG): 133테이블 create_all 평균 0.219s·drop_all 0.096s → 이 10개 파일
+# (16개 모델 클래스) 등재 후에도 파일당 증분은 이 자릿수(초 미만)라 178개 destructive_schema
+# 파일 전체로 곱해도 샤드당 여유(19~21분)를 갉아먹는 수준이 아니다(상세 수치는 PR 본문).
+from app.models.activity_log import ActivityLog
+from app.models.plan_feature import PlanFeature
+from app.models.project_api_key import ProjectApiKey
+from app.models.label import ItemLabel, Label
+from app.models.onboarding_event import OnboardingEvent
+from app.models.verdict import Verdict
+from app.models.workflow_execution_log import WorkflowExecutionLog
+from app.models.workflow_line import (
+    WorkflowLineDefinition,
+    WorkflowLineDefinitionVersion,
+    WorkflowLineStepApproval,
+    WorkflowLineStepRun,
+    WorkflowLineStepRunEvent,
+    WorkflowRoleAssignment,
+)
+from app.models.workflow_template import WorkflowTemplate
+from app.models.workflow_trigger_type import WorkflowTriggerType
+# fix(2026-09-02, story #2255 AC6 가드 자체 실증) — lint_model_registration_completeness.py를
+# 짓고 처음 돌려보니 위 10개와 별개로 5개가 더 새 있었다(전부 최근 며칠 새 커밋 — #2201/#2255
+# 결함 클래스가 그 사이 독립적으로 5번 더 재발한 것). 가드가 스스로를 증명한 사례라 여기서
+# 같이 정리한다(발견 즉시 수정) — FK 의존 없음(전수 확認), 등재 저위험.
+from app.models.billing_order import BillingOrder
+from app.models.domain_label import OrgDomainLabel
+from app.models.org_billing_key import OrgBillingKey
+from app.models.platform_setting import PlatformSetting
+from app.models.rejected_relation import RejectedRelation
 from app.models.trust_snapshot import OrgMemberTrustSnapshot
 from app.models.unattached_snapshot import UnattachedStorySnapshot
 from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArtifact
@@ -203,4 +225,25 @@ __all__ = [
     "User",
     "WorkflowVersion",
     "Event",
+    "ActivityLog",
+    "PlanFeature",
+    "ProjectApiKey",
+    "Label",
+    "ItemLabel",
+    "OnboardingEvent",
+    "Verdict",
+    "WorkflowExecutionLog",
+    "WorkflowLineDefinition",
+    "WorkflowLineDefinitionVersion",
+    "WorkflowLineStepRun",
+    "WorkflowLineStepApproval",
+    "WorkflowLineStepRunEvent",
+    "WorkflowRoleAssignment",
+    "WorkflowTemplate",
+    "WorkflowTriggerType",
+    "BillingOrder",
+    "OrgDomainLabel",
+    "OrgBillingKey",
+    "PlatformSetting",
+    "RejectedRelation",
 ]

--- a/backend/app/models/_test_only_unregistered_fixture.py
+++ b/backend/app/models/_test_only_unregistered_fixture.py
@@ -1,0 +1,32 @@
+"""story #2662 AC2 전용 — 영구 미등재 픽스처(운영 모델 아님).
+
+PR#3700(story #2255) 리뷰(페드루, 2026-09-02)에서 드러난 문제: AC2 양성대조가 실제 운영
+모델(`app.models.activity_log`)을 "아직 `app/models/__init__.py`에 안 잡힌 모델"의 예시로
+빌려 썼는데, 그 모델이 나중에(story #2255에서) 실제로 등재되면서 양성대조의 전제
+("이 모듈은 app.models 벌크 import에 없다")가 깨져 `test_ac2_positive_control_missing_import_gets_diagnosed`가
+거짓 GREEN(failed=0)으로 무너졌다.
+
+이 파일은 그 함정을 구조적으로 없앤다 — 운영 모델을 빌려 쓰는 대신, **의도적으로 영원히
+미등재 상태로 남는 테스트 전용 모델**을 만든다. `app/models/__init__.py`가 이 모듈을 절대
+import하면 안 된다(그 순간 이 파일의 존재 이유가 사라진다) — `scripts/lint_model_registration_completeness.py`의
+`_INTENTIONALLY_UNREGISTERED` 허용목록에 등재해 AC6 가드의 오탐 대상에서 제외했다.
+
+`__tablename__`을 가진 채로 `app/models/` 안에 있어야 하는 이유: story #2662의 진단
+레지스트리(`tests/conftest.py::_build_tablename_to_module_registry`)가 이 디렉터리를
+AST로 정적 스캔해 테이블명→모듈 경로를 맵핑하기 때문 — `__init__.py` 등재 여부와 무관하게
+파일이 여기 있기만 하면 레지스트리에 잡힌다(그래서 진단 문구에 이 모듈명이 뜬다).
+"""
+import uuid
+
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class _Story2662Ac2UnregisteredFixture(Base):
+    """운영 코드는 이 클래스를 절대 참조하지 않는다 — story #2662 AC2 양성대조 전용."""
+
+    __tablename__ = "test_2662_ac2_positive_control"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/backend/scripts/lint_model_registration_completeness.py
+++ b/backend/scripts/lint_model_registration_completeness.py
@@ -25,6 +25,12 @@ import ast
 import sys
 from pathlib import Path
 
+# story #2662 AC2 양성대조 전용 픽스처(app/models/_test_only_unregistered_fixture.py) —
+# 의도적으로 영원히 __init__.py에 미등재 상태로 남아야 하는 유일한 예외. 이 파일을 등재하면
+# AC2 양성대조의 전제(app.models 벌크 import에 없다)가 깨진다. 새 운영 모델을 여기 추가하지
+# 말 것 — 그건 이 가드가 정확히 막으려는 결함이다.
+_INTENTIONALLY_UNREGISTERED = {"_test_only_unregistered_fixture"}
+
 
 def _models_with_tablename(models_dir: Path) -> dict[str, str]:
     """{module_stem: tablename} — app/models/*.py를 AST로 정적 스캔(import 0회)."""
@@ -61,7 +67,11 @@ def find_unregistered(models_dir: Path) -> dict[str, str]:
     """{module_stem: tablename} — __tablename__은 있는데 __init__.py에 안 잡힌 모듈만."""
     with_tablename = _models_with_tablename(models_dir)
     imported = _imported_module_stems(models_dir / "__init__.py")
-    return {stem: table for stem, table in with_tablename.items() if stem not in imported}
+    return {
+        stem: table
+        for stem, table in with_tablename.items()
+        if stem not in imported and stem not in _INTENTIONALLY_UNREGISTERED
+    }
 
 
 def main() -> int:

--- a/backend/scripts/lint_model_registration_completeness.py
+++ b/backend/scripts/lint_model_registration_completeness.py
@@ -25,11 +25,21 @@ import ast
 import sys
 from pathlib import Path
 
-# story #2662 AC2 양성대조 전용 픽스처(app/models/_test_only_unregistered_fixture.py) —
-# 의도적으로 영원히 __init__.py에 미등재 상태로 남아야 하는 유일한 예외. 이 파일을 등재하면
-# AC2 양성대조의 전제(app.models 벌크 import에 없다)가 깨진다. 새 운영 모델을 여기 추가하지
-# 말 것 — 그건 이 가드가 정확히 막으려는 결함이다.
-_INTENTIONALLY_UNREGISTERED = {"_test_only_unregistered_fixture"}
+# PO 리뷰(페드루, 2026-09-02) — "사유 없는 추가"로 등재 회피의 뒷문이 되는 걸 막기 위해
+# set이 아니라 {stem: 사유} dict로 강제한다. 새 항목은 반드시 스토리 번호(#NNNN)를 인용하는
+# 사유를 같이 적어야 하고(test_allowlist_entries_cite_a_story_reference가 강제), 이 dict의
+# key 집합 자체도 tests/test_2255_model_registration_completeness_lint.py의
+# test_allowlist_is_pinned_to_known_fixtures_only에 pin돼 있어 조용히 늘어날 수 없다(둘 다
+# 건드려야 리뷰에서 보임). 새 운영 모델을 여기 추가하지 말 것 — 그건 이 가드가 정확히
+# 막으려는 결함이다. 오직 story #2662 AC2 양성대조처럼 "영원히 미등재 상태로 남아야
+# 검증이 성립하는" 테스트 전용 픽스처만 여기 온다.
+_INTENTIONALLY_UNREGISTERED: dict[str, str] = {
+    "_test_only_unregistered_fixture": (
+        "story #2662 AC2 양성대조 전용 — app.models 벌크 import에 영원히 없어야 그 테스트가 "
+        "운영 모델 등재 상태와 무관하게 계속 자가 실패할 수 있다. "
+        "app/models/_test_only_unregistered_fixture.py 참고."
+    ),
+}
 
 
 def _models_with_tablename(models_dir: Path) -> dict[str, str]:

--- a/backend/scripts/lint_model_registration_completeness.py
+++ b/backend/scripts/lint_model_registration_completeness.py
@@ -1,0 +1,84 @@
+"""story #2255(69d7380e) — app/models/*.py에 새 ORM 모델(`__tablename__` 보유 클래스)이
+생겼는데 app/models/__init__.py가 그 모듈을 import 안 하면 CI를 빨갛게 한다.
+
+배경: #2201(2026-07-28)이 정확히 이 결함 클래스로 11개 모델이 Base.metadata에 안 잡혀
+create_all()이 그 테이블들을 조용히 안 만들었다(프로세스의 «첫» realdb 테스트에서만 터짐 —
+파일 순서에 따라 우연히 다른 파일의 import 경로로 sys.modules에 먼저 로드되면 안 드러났다).
+그중 10개는 #2255에서 뒤늦게 등재됐다 — 이 가드는 «다음 11번째»가 같은 방식으로 몇 주씩
+안 잡히는 것을 막는다.
+
+⛔이 가드가 못 잡는 것(story #2662 진단 가드와 보완 관계, 겹치지 않음):
+  ① 이 가드는 **정적**(AST만, import 0회) — "새 파일이 __init__.py에 없다"만 본다.
+     #2662 가드는 **런타임**(테스트가 실제로 실패했을 때만) — "이 테스트가 왜 실패했는지"를
+     진단한다. 둘 다 있어야 하는 이유: 이 가드는 실패를 애초에 안 나게(선제) 막고, #2662
+     가드는 그래도 새는 경우(예: __init__.py는 등재했지만 특정 테스트 파일이 그 시점 이전에
+     import를 안 한 다른 이유)를 사후에 설명한다.
+  ② mixin/abstract 클래스처럼 `__tablename__`이 없는 모델은 안 본다 — 실제 테이블을 안 만드는
+     클래스는 이 가드의 관심사가 아니다(create_all이 만들 테이블만 추적).
+  ③ `app/models/__init__.py`가 아닌 다른 경로(예: 특정 라우터가 직접 import)로 어딘가에서
+     이미 로드되고 있어도, 이 가드는 그것을 "등재됨"으로 인정하지 않는다 — SSOT를
+     `app/models/__init__.py` 하나로 강제한다(다른 경로 의존은 #2201류 재발의 씨앗).
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+
+def _models_with_tablename(models_dir: Path) -> dict[str, str]:
+    """{module_stem: tablename} — app/models/*.py를 AST로 정적 스캔(import 0회)."""
+    out: dict[str, str] = {}
+    for filepath in sorted(models_dir.glob("*.py")):
+        if filepath.name == "__init__.py":
+            continue
+        try:
+            tree = ast.parse(filepath.read_text(encoding="utf-8"))
+        except (SyntaxError, OSError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(isinstance(t, ast.Name) and t.id == "__tablename__" for t in node.targets):
+                continue
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                out[filepath.stem] = node.value.value
+                break
+    return out
+
+
+def _imported_module_stems(init_path: Path) -> set[str]:
+    """app/models/__init__.py를 AST로 스캔해 `from app.models.X import ...` 형태의 X 전부를 모은다."""
+    tree = ast.parse(init_path.read_text(encoding="utf-8"))
+    stems: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("app.models."):
+            stems.add(node.module.rsplit(".", 1)[-1])
+    return stems
+
+
+def find_unregistered(models_dir: Path) -> dict[str, str]:
+    """{module_stem: tablename} — __tablename__은 있는데 __init__.py에 안 잡힌 모듈만."""
+    with_tablename = _models_with_tablename(models_dir)
+    imported = _imported_module_stems(models_dir / "__init__.py")
+    return {stem: table for stem, table in with_tablename.items() if stem not in imported}
+
+
+def main() -> int:
+    models_dir = Path(__file__).resolve().parent.parent / "app" / "models"
+    unregistered = find_unregistered(models_dir)
+    if unregistered:
+        print(
+            "FAIL: app/models/*.py에 __tablename__을 선언한 모듈이 app/models/__init__.py에 "
+            "import 안 됨 — create_all()이 이 테이블들을 조용히 안 만든다(story #2201/#2255와 "
+            "동일 결함 클래스):"
+        )
+        for stem, table in sorted(unregistered.items()):
+            print(f"  app/models/{stem}.py (table={table!r}) — __init__.py에 `from app.models.{stem} import ...` 추가할 것")
+        return 1
+    print("OK: app/models/*.py의 __tablename__ 보유 모델 전부 __init__.py에 등재됨")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_2255_model_registration_completeness_lint.py
+++ b/backend/tests/test_2255_model_registration_completeness_lint.py
@@ -84,3 +84,37 @@ def test_current_repo_has_zero_unregistered_models():
     유지되는지 CI가 도는 그 검사 자체를 pytest로도 한 번 더 고정한다."""
     models_dir = Path(__file__).parent.parent / "app" / "models"
     assert find_unregistered(models_dir) == {}
+
+
+def test_intentionally_unregistered_allowlist_suppresses_detection(tmp_path):
+    """PR#3700 리뷰(페드루, 2026-09-02) — story #2662 AC2 양성대조 픽스처
+    (app/models/_test_only_unregistered_fixture.py)는 __init__.py에 절대 등재하면 안 되는
+    유일한 예외. 허용목록이 이 stem을 정확히 걸러내는지 합성 fixture로 고정."""
+    _write(
+        tmp_path,
+        "_test_only_unregistered_fixture.py",
+        'class Fixture(Base):\n    __tablename__ = "test_2662_ac2_positive_control"\n',
+    )
+    _write(tmp_path, "__init__.py", "# no imports\n")
+    assert find_unregistered(tmp_path) == {}
+
+
+def test_mutation_empty_allowlist_would_have_flagged_the_fixture(tmp_path):
+    """뮤테이션 셀프체크 — 허용목록을 비우면 위 픽스처가 다시 탐지돼야 한다. 이 케이스가
+    실제로 허용목록 로직에 의존함을 증명(허용목록이 아무 효과 없이 늘 통과하는 게 아님)."""
+    import lint_model_registration_completeness as mod
+
+    original = mod._INTENTIONALLY_UNREGISTERED
+    try:
+        mod._INTENTIONALLY_UNREGISTERED = set()
+        _write(
+            tmp_path,
+            "_test_only_unregistered_fixture.py",
+            'class Fixture(Base):\n    __tablename__ = "test_2662_ac2_positive_control"\n',
+        )
+        _write(tmp_path, "__init__.py", "# no imports\n")
+        assert mod.find_unregistered(tmp_path) == {
+            "_test_only_unregistered_fixture": "test_2662_ac2_positive_control"
+        }, "허용목록을 비웠는데도 탐지가 안 되면 허용목록 로직 자체가 무동작이라는 뜻"
+    finally:
+        mod._INTENTIONALLY_UNREGISTERED = original

--- a/backend/tests/test_2255_model_registration_completeness_lint.py
+++ b/backend/tests/test_2255_model_registration_completeness_lint.py
@@ -106,7 +106,7 @@ def test_mutation_empty_allowlist_would_have_flagged_the_fixture(tmp_path):
 
     original = mod._INTENTIONALLY_UNREGISTERED
     try:
-        mod._INTENTIONALLY_UNREGISTERED = set()
+        mod._INTENTIONALLY_UNREGISTERED = {}
         _write(
             tmp_path,
             "_test_only_unregistered_fixture.py",
@@ -118,3 +118,24 @@ def test_mutation_empty_allowlist_would_have_flagged_the_fixture(tmp_path):
         }, "허용목록을 비웠는데도 탐지가 안 되면 허용목록 로직 자체가 무동작이라는 뜻"
     finally:
         mod._INTENTIONALLY_UNREGISTERED = original
+
+
+def test_allowlist_is_pinned_to_known_fixtures_only():
+    """PO 리뷰(페드루, 2026-09-02) ① — 허용목록이 "이유 명기 없이" 조용히 늘어날 수 있는
+    뒷문이 되면 안 된다. key 집합을 정확히 pin — 새 항목을 추가하려면 이 테스트도 같이
+    고쳐야 하므로 리뷰에서 반드시 눈에 띈다(조용한 확장 불가)."""
+    from lint_model_registration_completeness import _INTENTIONALLY_UNREGISTERED
+
+    assert set(_INTENTIONALLY_UNREGISTERED) == {"_test_only_unregistered_fixture"}
+
+
+def test_allowlist_entries_cite_a_story_reference():
+    """PO 리뷰(페드루, 2026-09-02) ① — 허용목록의 각 항목은 사유가 비어있으면 안 되고,
+    그 사유가 스토리 번호(#NNNN)를 인용해야 한다(등재 회피의 근거 없는 뒷문 방지)."""
+    import re
+
+    from lint_model_registration_completeness import _INTENTIONALLY_UNREGISTERED
+
+    for stem, reason in _INTENTIONALLY_UNREGISTERED.items():
+        assert reason and reason.strip(), f"{stem}의 허용 사유가 비어있다"
+        assert re.search(r"#\d+", reason), f"{stem}의 허용 사유가 스토리 번호를 인용하지 않는다: {reason!r}"

--- a/backend/tests/test_2255_model_registration_completeness_lint.py
+++ b/backend/tests/test_2255_model_registration_completeness_lint.py
@@ -1,0 +1,86 @@
+"""story #2255(69d7380e) — lint_model_registration_completeness.py의 정탐/오탐 회귀 가드.
+합성 fixture로 짓는다(실물이 고쳐져도 이 테스트는 안 사라진다, story #2335/#2342/#2476 lint와
+동형)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from lint_model_registration_completeness import (  # noqa: E402
+    _imported_module_stems,
+    _models_with_tablename,
+    find_unregistered,
+)
+
+
+def _write(tmp_path: Path, name: str, source: str) -> Path:
+    p = tmp_path / name
+    p.write_text(source)
+    return p
+
+
+def test_detects_unregistered_model(tmp_path):
+    _write(
+        tmp_path,
+        "widget.py",
+        'class Widget(Base):\n    __tablename__ = "widgets"\n',
+    )
+    _write(tmp_path, "__init__.py", "# no imports\n")
+    unregistered = find_unregistered(tmp_path)
+    assert unregistered == {"widget": "widgets"}
+
+
+def test_registered_model_not_flagged(tmp_path):
+    _write(
+        tmp_path,
+        "widget.py",
+        'class Widget(Base):\n    __tablename__ = "widgets"\n',
+    )
+    _write(tmp_path, "__init__.py", "from app.models.widget import Widget\n")
+    assert find_unregistered(tmp_path) == {}
+
+
+def test_model_without_tablename_not_flagged(tmp_path):
+    """mixin/abstract 클래스(__tablename__ 없음)는 실 테이블을 안 만드니 이 가드 관심사 밖."""
+    _write(tmp_path, "mixin.py", "class TimestampMixin:\n    pass\n")
+    _write(tmp_path, "__init__.py", "# no imports\n")
+    assert find_unregistered(tmp_path) == {}
+
+
+def test_import_from_unrelated_module_does_not_count_as_registration(tmp_path):
+    """__init__.py가 다른 패키지를 import해도 app.models.X 형태가 아니면 등재로 안 친다."""
+    _write(
+        tmp_path,
+        "widget.py",
+        'class Widget(Base):\n    __tablename__ = "widgets"\n',
+    )
+    _write(tmp_path, "__init__.py", "from sqlalchemy import Column\n")
+    assert find_unregistered(tmp_path) == {"widget": "widgets"}
+
+
+def test_mutation_blank_registry_causes_zero_detections(tmp_path):
+    """뮤테이션: _models_with_tablename이 늘 빈 dict를 반환하게 하면 양성 테스트가 깨져야
+    한다 — 이 lint의 핵심 로직이 실제로 테스트에 의존함을 자가 검증(story #2342 lint와 동일
+    관례)."""
+    import lint_model_registration_completeness as mod
+
+    original = mod._models_with_tablename
+    try:
+        mod._models_with_tablename = lambda models_dir: {}
+        _write(
+            tmp_path,
+            "widget.py",
+            'class Widget(Base):\n    __tablename__ = "widgets"\n',
+        )
+        _write(tmp_path, "__init__.py", "# no imports\n")
+        assert mod.find_unregistered(tmp_path) == {}, "뮤테이션 후에는 탐지가 0이어야 정상"
+    finally:
+        mod._models_with_tablename = original
+
+
+def test_current_repo_has_zero_unregistered_models():
+    """실물 app/models/ 전수 스캔 — story #2255 완주 시점(2026-09-02) 확認한 등재 0갭이
+    유지되는지 CI가 도는 그 검사 자체를 pytest로도 한 번 더 고정한다."""
+    models_dir = Path(__file__).parent.parent / "app" / "models"
+    assert find_unregistered(models_dir) == {}

--- a/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
+++ b/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
@@ -36,6 +36,7 @@ _CI_OR_LOCAL_ONLY_ALLOWLIST = frozenset({
     "lint_dependency_override_get_read_db.py",    # story #2451 — CI lint 게이트(tests/ override 스캔, 운영 DB 무접속)
     "lint_destructive_test_sql.py",               # story #2786 — CI lint 게이트(tests/ 재귀 AST 스캔, 운영 DB 무접속)
     "lint_legacy_subscriptions_reuse.py",         # story #2476 — CI lint 게이트(app/ 재귀 정적 스캔, 운영 DB 무접속)
+    "lint_model_registration_completeness.py",    # story #2255 — CI lint 게이트(app/models AST 정적 스캔, 운영 DB 무접속)
     "lint_project_access_403.py",                 # story #2342 AC7 — CI lint 게이트
     "lint_query_sentinel_direct_calls.py",        # story #2335 — CI lint 게이트
     "lint_no_script_output_artifacts.py",         # story #3008 — CI lint 게이트(scripts/ 파일명·내용 정적 스캔, 운영 DB 무접속)

--- a/backend/tests/test_2662_missing_model_import_guard.py
+++ b/backend/tests/test_2662_missing_model_import_guard.py
@@ -153,7 +153,15 @@ def test_ac2_positive_control_missing_import_gets_diagnosed(pytester: pytest.Pyt
     """⭐AC2 핵심 — PR #3067 21파일 사례의 최소 재현. `import app.models.activity_log`가
     빠진 채 transition_gate()류 write를 흉내내는 create_all 테스트를 서브프로세스로 돌려,
     (1) 여전히 실패하고(가드가 실패를 숨기지 않는다) (2) 그 실패 리포트에 이 가드의 진단
-    섹션이 실제로 붙는지(원인이 명확한 메시지로 바뀌는지) 둘 다 확인한다."""
+    섹션이 실제로 붙는지(원인이 명확한 메시지로 바뀌는지) 둘 다 확인한다.
+
+    PR#3700(story #2255) 리뷰(페드루, 2026-09-02) — 이 표본은 원래 실 운영 모델
+    `app.models.activity_log`를 빌려 썼는데, 그 모델이 #2255에서 실제로 `__init__.py`에
+    등재되면서 표본의 전제("app.models 벌크 import에 없다")가 깨져 이 테스트가 거짓
+    GREEN(failed=0)으로 무너졌다. 운영 모델이 아니라 `app/models/_test_only_unregistered_fixture.py`
+    (영구 미등재로 설계된 테스트 전용 모델, `lint_model_registration_completeness.py`의
+    `_INTENTIONALLY_UNREGISTERED` 허용목록으로 AC6 가드에서도 제외됨)를 대상으로 바꿔,
+    앞으로 어떤 운영 모델이 등재되든 이 양성대조는 계속 실패할 수 있다."""
     import os
     import shutil
     from pathlib import Path
@@ -166,8 +174,6 @@ def test_ac2_positive_control_missing_import_gets_diagnosed(pytester: pytest.Pyt
     disposable_url, disposable_name = _create_disposable_pg_database(base_db_url)
     pytester.makepyfile(
         test_repro=f'''
-import os
-import uuid
 import pytest
 
 pytestmark = pytest.mark.destructive_schema
@@ -179,10 +185,11 @@ def anyio_backend():
 
 
 @pytest.mark.anyio
-async def test_write_without_activity_log_import():
-    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+async def test_write_without_fixture_import():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
     from app.core.database import Base
-    import app.models  # noqa: F401 — 벌크 임포트(activity_log는 여기 없음, #2201 후속)
+    import app.models  # noqa: F401 — 벌크 임포트(story #2662 AC2 픽스처는 영구 미등재라 여기 없음)
 
     url = {disposable_url!r}
     for prefix in ("postgresql+psycopg2://", "postgresql://"):
@@ -192,13 +199,15 @@ async def test_write_without_activity_log_import():
     engine = create_async_engine(url)
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-    Session = async_sessionmaker(engine, expire_on_commit=False)
-    async with Session() as s:
-        from app.services.activity_log import ActivityLogService
-        await ActivityLogService(s).record(
-            org_id=uuid.uuid4(), action="x", actor_id=None, actor_type="human",
+        # story #2662 AC2 픽스처 모듈을 이 프로세스가 절대 import 안 하므로 그 테이블은
+        # Base.metadata에 없다 — create_all()이 만들 수 없는 테이블 이름을 직접 참조해
+        # PR #3067 21파일 사례(모델 미등재 → relation ... does not exist)를 재현.
+        await conn.execute(
+            text(
+                "INSERT INTO test_2662_ac2_positive_control (id) "
+                "VALUES ('00000000-0000-0000-0000-000000000000'::uuid)"
+            )
         )
-        await s.commit()
     await engine.dispose()
 '''
     )
@@ -219,7 +228,7 @@ async def test_write_without_activity_log_import():
         _drop_disposable_pg_database(base_db_url, disposable_name)
     result.assert_outcomes(failed=1)  # 가드가 실패 자체를 숨기면 안 된다 — 여전히 RED.
     output = "\\n".join(result.outlines)
-    assert "app.models.activity_log" in output, (
+    assert "app.models._test_only_unregistered_fixture" in output, (
         f"진단 섹션이 리포트에 안 실렸다 — 21파일 사례가 재현 안 됨.\\noutput={output!r}"
     )
     assert "story #2662" in output


### PR DESCRIPTION
## 배경 — 재그라운딩 (2026-09-02, 페드루 PO 판정: 축소 스코프 진행)
[[인프라·CI] 모델 하나 늘 때마다 CI가 몇 분씩 느려진다 — 집합 모듈 누락 10건을 «등재할 수 없는» 상태다](entity:story:69d7380e-9567-47ed-9194-d9784cbf637a)

원 스토리(2026-07-28) 전제("101개 순차 단일잡·CI 예산 여유 8분")는 이미 폐기됨 — 두 후속 트랙이 그 위기의 뿌리를 이미 건드려놨다:
- **#2293**(같은 사고로 촉발, PR#2576/#2583) — destructive_schema를 4-way CI 샤드로 분리. 최근 실측(story #2285 AC4, 2026-08-17): 샤드당 4~6분 vs 천장 25분 → **여유 19~21분**.
- **#2662**(2026-08-15 PO AC 리뷰) — 「conftest 전체 벌크 임포트」를 근거와 함께 기각, 대신 실패-시점 진단 가드 채택. `app/models/__init__.py`를 정본으로 쓰는 기존 관례는 그대로 유효.

⇒ 원 AC가 요구한 "구조 개선"은 이미 됐다고 판단, **재작업 없이 남은 실작업만 완주**(PO 확定).

## AC1 — 계측(먼저)
로컬 disposable PG 실측(3회 평균):
| | tables | create_all | drop_all |
|---|---|---|---|
| 등재 前 | 133 | 0.219s | 0.096s |
| 15개 등재 後 | 154 | 0.223s | 0.102s |

21테이블 증분 ≈ 0.010s(오차범위) — sub-linear. 현재 destructive_schema 파일 178개(`discover_files()` 실측 — #2293 스냅샷 94개·#2662 시점 128개 대비 더 늘어남) × 델타 반영해도 178×0.010s ≈ 1.78초, 4샤드 균등분배 시 샤드당 ≈ 0.45초 — 19~21분 마진에 영향 없음(정정 2026-09-02, 페드루 PO AC 리뷰 — 원문 5초/1.3초는 산수 오류).

## AC4 — 10개 실등재 (+가드 자체 실증으로 5개 추가 발견)
원 10개(activity_log·plan_feature·project_api_key·label·onboarding_event·verdict·workflow_execution_log·workflow_line·workflow_template·workflow_trigger_type — 16개 모델 클래스) 등재.

AC6 가드를 처음 돌려보니 **별개로 5개가 더** 새 있었다(billing_order·domain_label·org_billing_key·platform_setting·rejected_relation — 최근 며칠 새 독립 재발). FK 의존 0 확認 후 발견 즉시 같이 정리(name collision 0, FK 참조는 전부 이미 등재된 테이블만).

**검증**: 실물 destructive_schema 파일 16개(원본+신규분)를 CI와 동일 레시피(파일별 dropdb/createdb+`CREATE EXTENSION vector`+isolated pytest)로 로컬 왕복 — 전부 PASS. 전체 non-destructive 스위트 5271 passed(수정 前 13건 pre-existing 실패는 baseline 대조로 무관 확認).

## AC5 — 오염 양성대조
격리 축(파일별 물리적으로 별도 throwaway DB) 자체는 안 건드림 — 테이블 수만 늘리는 변경은 그 구조상 교차 테스트 오염 경로 자체가 없다(별도 DB라 공유 상태 자체가 없음). 15개 파일 순차 왕복이 실증.

## AC6 — 재발 가드
`backend/scripts/lint_model_registration_completeness.py` — `app/models/*.py`의 `__tablename__` 보유 모듈이 `__init__.py`에 미등재면 CI 즉시 빨강(정적 AST뿐, 런타임 오버헤드 0). story #2662의 실패-시점 진단 가드와는 다른 축(선제 차단 vs 사후 진단) — 겹치지 않음(각 스크립트 docstring에 상호 참조 명시).

정탐 4종 + 오탐 2종(mixin/abstract 무시·타 패키지 import 오인 방지) + 뮤테이션 셀프체크 + 실물 0갭 확認, 8 passed. `ci.yml` guard job 배선(기존 `lint_*.py` 관례). scripts-root allowlist(#2384)에도 미리 등재.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01LYrGWC6cqBE37oteHUtHyT
