### PR TITLE
[SID:3300] [P0 핫픽스] domain-labels BFF route 신설 — 로그인 직후 세션만료 팝업

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "verify:reserved-first-segments-sync": "tsx scripts/verify-reserved-first-segments-sync.ts",
     "verify:migrated-resources-sync": "tsx scripts/verify-migrated-resources-sync.ts",
     "verify:no-new-raw-fetch-api": "tsx scripts/verify-no-new-raw-fetch-api.ts",
+    "verify:no-direct-backend-v2-call": "tsx scripts/verify-no-direct-backend-v2-call.ts",
     "verify:tint-foreground-contrast": "tsx scripts/verify-tint-foreground-contrast.ts",
     "verify:no-new-tint-color-text": "tsx scripts/verify-no-new-tint-color-text.ts",
     "verify:cross-element-tint-text": "tsx scripts/verify-cross-element-tint-text.ts",

--- a/apps/web/scripts/verify-no-direct-backend-v2-call.test.ts
+++ b/apps/web/scripts/verify-no-direct-backend-v2-call.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { extractDirectV2Calls } from './verify-no-direct-backend-v2-call';
+
+describe('extractDirectV2Calls — 순수 판정 함수(story #3300/#3701 재발 가드)', () => {
+  it('fetchWithAuth(`/api/v2/...`)를 잡는다', () => {
+    const hits = extractDirectV2Calls(
+      'fetchWithAuth(`/api/v2/organizations/${orgId}/domain-labels`)',
+      'hooks/use-org-domain-labels.ts',
+    );
+    expect(hits).toEqual([{
+      file: 'hooks/use-org-domain-labels.ts',
+      urlPrefix: '/api/v2/organizations/',
+      key: 'hooks/use-org-domain-labels.ts::/api/v2/organizations/',
+    }]);
+  });
+
+  // ⭐양성대조 — 이 스토리(#3300)의 실사고를 그대로 재현한 픽스처. 수정 前 코드가 정확히 이
+  // 패턴이었다(이 테스트가 RED였다면 회귀가드가 실제로 그 버그를 잡았을 것을 증명).
+  it('#3300 실사고 픽스처 — 고치기 前 use-org-domain-labels.ts 원문을 그대로 놓치지 않는다', () => {
+    const hits = extractDirectV2Calls(
+      "const res = await fetchWithAuth(`/api/v2/organizations/${orgId}/domain-labels`);",
+      'hooks/use-org-domain-labels.ts',
+    );
+    expect(hits).toHaveLength(1);
+  });
+
+  it('BFF 경로(/api/organizations/...)로 고친 뒤에는 안 잡는다(회귀 0)', () => {
+    const hits = extractDirectV2Calls(
+      'fetchWithAuth(`/api/organizations/${orgId}/domain-labels`)',
+      'hooks/use-org-domain-labels.ts',
+    );
+    expect(hits).toEqual([]);
+  });
+
+  it('raw fetch(v2)는 이 가드의 대상이 아니다(별도 관심사 — 서버사이드 파일이 정당하게 씀)', () => {
+    const hits = extractDirectV2Calls(
+      "fetch(`${FASTAPI_URL()}/api/v2/me`)",
+      'lib/db/server.ts',
+    );
+    expect(hits).toEqual([]);
+  });
+
+  it('/api/v2/가 아닌 BFF 경로는 안 잡는다', () => {
+    const hits = extractDirectV2Calls(`fetchWithAuth('/api/stories')`, 'f.ts');
+    expect(hits).toEqual([]);
+  });
+
+  it('템플릿 리터럴의 ${} 보간 이전 고정 접두사만 키로 남긴다', () => {
+    const hits = extractDirectV2Calls('fetchWithAuth(`/api/v2/team-members/${agentId}`)', 'f.ts');
+    expect(hits[0]!.urlPrefix).toBe('/api/v2/team-members/');
+  });
+});

--- a/apps/web/scripts/verify-no-direct-backend-v2-call.ts
+++ b/apps/web/scripts/verify-no-direct-backend-v2-call.ts
@@ -1,0 +1,89 @@
+/**
+ * story #3305(P0 핫픽스 #3701 재발 가드, AC3) — `fetchWithAuth('/api/v2/...')`처럼 BFF
+ * route(`/api/...`) 없이 백엔드 `/api/v2/*`를 직접 겨냥하는 클라이언트 호출을 막는다.
+ *
+ * verify-no-new-raw-fetch-api.ts(story #2689/#2691)와는 다른 결함 클래스다 — 그 가드는
+ * "raw fetch() vs fetchWithAuth()"(401 재시도 유무)를 잡고, 이건 "fetchWithAuth()가
+ * 맞는 유틸을 쓰고도 URL 자체가 BFF를 건너뛰는" 자리를 잡는다(#3300 실사고 — domain-labels
+ * 훅이 `/api/v2/organizations/{org}/domain-labels`를 직접 호출해 Next.js에 미등록 라우트로
+ * 새서(500) fetchWithAuth의 401→refresh→재시도 경로가 SessionExpiredDialog를 반복
+ * 트리거했다 — dev 앱 「로그인하자마자 세션 만료」의 근본원인).
+ *
+ * `fetchWithAuth`는 `@/lib/db/client`의 브라우저 전용 유틸(서버사이드 파일은 절대 안 씀 —
+ * 서버는 이미 자기 프로세스 안에서 backend를 직접 부를 이유가 없다·route-resolve.ts/
+ * db/server.ts/agent-routing-rule.ts 등은 전부 raw `fetch`를 쓴다) — 그래서 이 판정은
+ * `fetch(` 전체가 아니라 `fetchWithAuth(` 호출 하나만 봐도 false positive가 없다.
+ *
+ * grandfather baseline 없음(의도적) — 이 글을 쓰는 시점 codebase 전수 grep으로 기존 위반
+ * 0건을 확認했다(story #3705 조사). 새로 생기는 모든 위반을 즉시 막는다.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+const EXT_RE = /\.(tsx?|ts)$/;
+const TEST_RE = /\.test\.[tj]sx?$/;
+
+const RAW_FETCH_WITH_AUTH_RE = /\bfetchWithAuth\(\s*([`'"])((?:(?!\1).)*)/g;
+
+export interface DirectV2CallHit {
+  file: string;
+  urlPrefix: string;
+  key: string;
+}
+
+function stablePrefix(url: string): string {
+  const idx = url.indexOf('${');
+  return idx === -1 ? url : url.slice(0, idx);
+}
+
+export function extractDirectV2Calls(content: string, file: string): DirectV2CallHit[] {
+  const hits: DirectV2CallHit[] = [];
+  for (const m of content.matchAll(RAW_FETCH_WITH_AUTH_RE)) {
+    const url = m[2] ?? '';
+    if (!url.startsWith('/api/v2/')) continue;
+    const prefix = stablePrefix(url);
+    hits.push({ file, urlPrefix: prefix, key: `${file}::${prefix}` });
+  }
+  return hits;
+}
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (path.relative(SRC_ROOT, full) === 'app/api') continue; // BFF 프록시 라우트 자신 제외(정당하게 /api/v2/*를 부른다).
+      walk(full, out);
+    } else if (EXT_RE.test(entry) && !TEST_RE.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+function main(): void {
+  const files: string[] = [];
+  walk(SRC_ROOT, files);
+
+  const hits: DirectV2CallHit[] = [];
+  for (const abs of files) {
+    const content = readFileSync(abs, 'utf8');
+    const rel = path.relative(SRC_ROOT, abs).split(path.sep).join('/');
+    hits.push(...extractDirectV2Calls(content, rel));
+  }
+
+  if (hits.length > 0) {
+    console.log(`\n❌ fetchWithAuth('/api/v2/*') 직접호출 ${hits.length}건 — BFF route(/api/...)를 만들고 그쪽을 부를 것(story #3300/#3701 재발):`);
+    for (const h of hits.sort((a, b) => a.key.localeCompare(b.key))) {
+      console.log(`  - ${h.file} → "${h.urlPrefix}"`);
+    }
+    process.exit(1);
+  }
+
+  console.log('OK: fetchWithAuth(\'/api/v2/*\') 직접호출 0건');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/apps/web/src/app/api/organizations/[id]/domain-labels/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/domain-labels/route.ts
@@ -1,0 +1,24 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// story #3705(P0 핫픽스) — org별 표시 라벨 오버라이드 BFF 프록시 신설. 이 라우트가 없어서
+// useOrgDomainLabels 훅이 BE `/api/v2/organizations/{org}/domain-labels`를 직접 호출했고,
+// fetchWithAuth의 401→refresh→재시도 경로가 그 직접 호출에도 그대로 걸려 refresh 후에도
+// 401이 반복 → SessionExpiredDialog(세션 만료 팝업)가 로그인 직후 뜨는 원인이었다.
+// 다른 organizations/[id]/* 형제 라우트(gate-config 등)와 달리 apiSuccess({data}) 재래핑을
+// 안 하고 raw passthrough를 쓴다 — 훅(use-org-domain-labels.ts)이 `res.json()`을 이미
+// BE 원본 shape(GET=배열·PUT=단일 객체) 그대로 파싱하고 있어, 여기서 감싸면 그 파싱이
+// 깨진다(fastapi-proxy 봉투 경계 gotcha — 소비부 shape 먼저 확認 후 결정).
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/organizations/${id}/domain-labels`);
+}
+
+export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/organizations/${id}/domain-labels`);
+}
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/organizations/${id}/domain-labels`);
+}

--- a/apps/web/src/hooks/use-org-domain-labels.test.tsx
+++ b/apps/web/src/hooks/use-org-domain-labels.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 //
 // story #3287([도메인탈고정·축1 Phase1] AC4 FE 소비) — useOrgDomainLabels가 GET
-// /api/v2/organizations/{orgId}/domain-labels 응답을 domain:canonical_slug 키로 인덱싱해
-// statusLabel()/entityTypeLabel()로 조회 가능케 하는지, 로케일 선택(ko 우선, 없으면 en
-// 폴백)과 "오버라이드 미설정 slug는 undefined"(호출부가 canonical 문구로 폴백)를 실 렌더로
-// 고정한다.
+// /api/organizations/{orgId}/domain-labels(BFF, story #3705 P0 핫픽스로 전환) 응답을
+// domain:canonical_slug 키로 인덱싱해 statusLabel()/entityTypeLabel()로 조회 가능케 하는지,
+// 로케일 선택(ko 우선, 없으면 en 폴백)과 "오버라이드 미설정 slug는 undefined"(호출부가
+// canonical 문구로 폴백)를 실 렌더로 고정한다.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
@@ -70,7 +70,7 @@ describe('useOrgDomainLabels — 라벨 API 인덱싱+로케일 선택(#3287 AC4
     await flush();
 
     const el = container.querySelector('[data-testid="dump"]') as HTMLElement;
-    expect(fetchWithAuthMock).toHaveBeenCalledWith('/api/v2/organizations/org-1/domain-labels');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/api/organizations/org-1/domain-labels');
     expect(el.dataset.statusBacklog).toBe('아이디어');
     expect(el.dataset.statusDone).toBe(''); // 오버라이드 미설정 — undefined(호출부가 canonical 문구로 폴백)
     expect(el.dataset.entityStory).toBe('캠페인');

--- a/apps/web/src/hooks/use-org-domain-labels.ts
+++ b/apps/web/src/hooks/use-org-domain-labels.ts
@@ -4,12 +4,19 @@ import { useEffect, useState } from 'react';
 import { fetchWithAuth } from '@/lib/db/client';
 
 /**
- * story #3287([도메인탈고정·축1 Phase1] org 표시 라벨 레이어) FE 소비 — BE
- * `GET /api/v2/organizations/{org_id}/domain-labels`(canonical slug 불변, org별 표시
+ * story #3287([도메인탈고정·축1 Phase1] org 표시 라벨 레이어) FE 소비 — BFF
+ * `GET /api/organizations/{org_id}/domain-labels`(canonical slug 불변, org별 표시
  * 라벨만) 조회+캐시. canonical_slug는 이 훅이 절대 안 바꾼다 — 호출부(kanban-board 등)가
  * 기존 하드코딩 라벨(t(col.i18nKey) 등)을 그대로 fallback으로 쓰고, 이 훅이 반환하는
  * override가 있을 때만 그 위에 얹는다("미설정=시스템 기본값" 원칙, BE 설계 doc
  * entity:doc:1fa7e2a9-c8c2-4a8e-a9da-35bce52a5012 §Phase 1 그대로).
+ *
+ * story #3705(P0 핫픽스) — 이 훅이 BFF route 없이 BE `/api/v2/...`를 직접 호출하고
+ * 있었다(다른 모든 엔드포인트는 `/api/...` BFF proxy 경유). fetchWithAuth의
+ * 401→refresh→재시도 경로가 직접 호출에도 그대로 걸려, refresh 성공 후에도 domain-labels
+ * 재시도가 또 401(같은 이유로 BFF 인증 forwarding을 안 탐)이 되어 SessionExpiredDialog가
+ * 로그인 직후 뜨는 원인이었다 — BFF route 신설(app/api/organizations/[id]/domain-labels/
+ * route.ts) + 이 URL을 그 경로로 전환해 다른 엔드포인트와 동형화한다.
  */
 
 type DomainLabelEntry = {
@@ -56,7 +63,7 @@ export function useOrgDomainLabels(orgId: string | undefined, locale: string): O
     setLoading(true);
     void (async () => {
       try {
-        const res = await fetchWithAuth(`/api/v2/organizations/${orgId}/domain-labels`);
+        const res = await fetchWithAuth(`/api/organizations/${orgId}/domain-labels`);
         if (!res.ok) {
           if (!cancelled) setEntries([]);
           return;


### PR DESCRIPTION
## Summary
- 근본원인: `useOrgDomainLabels`(apps/web/src/hooks/use-org-domain-labels.ts)가 BFF 프록시 없이 BE `/api/v2/organizations/{org}/domain-labels`를 **직접 호출**하고 있었다. 다른 모든 엔드포인트는 `/api/...` BFF route(`proxyToFastapi`)를 경유하는데 이 경로만 BFF route가 없어(search 0건) Next.js에 등록되지 않은 경로로 샜다.
- 로컬 재현: 수정 전 구경로(`/api/v2/organizations/org-1/domain-labels`)를 로컬 dev 서버에 직접 호출하면 **500**(라우트 미등록 — 프레임워크 처리 실패). `fetchWithAuth`의 401→refresh→재시도 경로가 이 깨진 응답에도 걸려 refresh 성공 후에도 재시도가 또 실패 → `SessionExpiredDialog`(세션 만료 팝업) 반복 트리거 — dev 실사용자가 로그인 직후 겪은 증상과 일치.
- 수정(다른 `organizations/[id]/*` 형제 라우트와 동형 패턴):
  1. BFF route 신설 `apps/web/src/app/api/organizations/[id]/domain-labels/route.ts` — GET/PUT/DELETE, `proxyToFastapi` **raw passthrough**(훅이 이미 BE 원본 shape을 그대로 파싱하므로 `apiSuccess({data})` 재래핑은 안 함 — fastapi-proxy 봉투 경계를 소비부 shape 확認 후 결정).
  2. 훅 URL을 `/api/v2/...` → `/api/organizations/${orgId}/domain-labels`(BFF)로 전환.
- 이 훅을 쓰는 6개 파일(kanban-board·epic-swimlane-board·flow-node-story-panel·chat-input·story-detail-panel·훅 자체 테스트) 전부 무회귀 확認.

## Test plan
- [x] 로컬 `next dev`로 직접 재현: 수정 前 구경로 → 500(라우트 없음) / 수정 後 신경로 → 정상 401(UNAUTHORIZED 구조화 응답, `proxyToFastapi`까지 정상 도달 확認)
- [x] `pnpm vitest run`(도메인라벨 소비 6개 파일) — 160 passed
- [x] `pnpm type-check`(tsc --noEmit) — clean
- [x] `pnpm lint`(eslint, 해당 파일) — clean
- [x] `pnpm build`(next build) — 성공, `/api/organizations/[id]/domain-labels` 라우트 등록 확認
- [ ] 실 로그인 세션 지속(로그인→보드→세션 유지) 라이브 확認 — 로컬은 백엔드 미기동으로 자격증명 기반 재현 불가, dev 배포 후 필요(급행 배포 시 최우선 확認 요청)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrXtyieXmkonMVwuCWr9c3