### PR TITLE
[SID:3302] 웹→네이티브 셸 session-changed 브릿지 발신부 신설

### DIFF
--- a/apps/web/src/lib/db/client.test.ts
+++ b/apps/web/src/lib/db/client.test.ts
@@ -4,7 +4,7 @@
 // 이게 없으면 401 폴링/SSE 재연결 루프가 세션이 죽은 뒤에도 매 tick마다 refresh를 재시도해
 // "401에는 재시도하지 않는다"는 처방이 무력화된다.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchWithAuth } from './client';
+import { fetchWithAuth, loginWithPassword, refreshAuthTokens, registerUser } from './client';
 import { resetSessionExpired, signalSessionExpired } from '@/lib/auth/session-expired-signal';
 
 beforeEach(() => {
@@ -14,6 +14,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   resetSessionExpired();
+  delete window.ReactNativeWebView;
 });
 
 describe('fetchWithAuth — 세션만료 신호 후 단락(#2160)', () => {
@@ -75,5 +76,62 @@ describe('fetchWithAuth — 동시 401 N건 → refresh single-flight(story #268
     expect(a.status).toBe(200);
     expect(b.status).toBe(200);
     expect(c.status).toBe(200);
+  });
+});
+
+// story #3302(#2459 진단 (c) 갈래, AC1/AC3) — login/register/refresh 공통 choke point
+// (callAuthRoute)의 성공 분기가 네이티브 셸에 session-changed를 정확히 1회 알리는지,
+// 실패 분기는 0회인지 pin한다. 뮤테이션 자가검증(AC3) — callAuthRoute의 notifySessionChanged()
+// 호출 한 줄을 지우면 아래 세 성공 케이스가 전부 RED로 떨어져야 한다(직접 지워서 확認).
+function okAuthResponse() {
+  return new Response(
+    JSON.stringify({ data: { access_token: 'at', refresh_token: 'rt', token_type: 'bearer' } }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+function failAuthResponse() {
+  return new Response(
+    JSON.stringify({ error: { code: 'INVALID_CREDENTIALS', message: 'bad' } }),
+    { status: 401, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+describe('callAuthRoute → notifySessionChanged 브릿지(story #3302 AC1/AC3)', () => {
+  it('loginWithPassword 성공 시 셸에 session-changed가 정확히 1회 간다', async () => {
+    const postMessage = vi.fn();
+    window.ReactNativeWebView = { postMessage };
+    vi.stubGlobal('fetch', vi.fn(async () => okAuthResponse()));
+    await loginWithPassword('a@b.com', 'pw');
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(JSON.stringify({ type: 'session-changed' }));
+  });
+
+  it('registerUser 성공 시 셸에 session-changed가 정확히 1회 간다', async () => {
+    const postMessage = vi.fn();
+    window.ReactNativeWebView = { postMessage };
+    vi.stubGlobal('fetch', vi.fn(async () => okAuthResponse()));
+    await registerUser('a@b.com', 'pw');
+    expect(postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshAuthTokens 성공 시 셸에 session-changed가 정확히 1회 간다(가장 빈번한 경로 — #2459 진단 (c)의 핵심 창)', async () => {
+    const postMessage = vi.fn();
+    window.ReactNativeWebView = { postMessage };
+    vi.stubGlobal('fetch', vi.fn(async () => okAuthResponse()));
+    await refreshAuthTokens();
+    expect(postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('실패(401 등) 응답이면 셸에 아무것도 안 보낸다', async () => {
+    const postMessage = vi.fn();
+    window.ReactNativeWebView = { postMessage };
+    vi.stubGlobal('fetch', vi.fn(async () => failAuthResponse()));
+    await loginWithPassword('a@b.com', 'wrong');
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('셸 밖(브라우저)에서 로그인 성공해도 예외 없이 조용하다(AC2)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okAuthResponse()));
+    await expect(loginWithPassword('a@b.com', 'pw')).resolves.toMatchObject({ error: null });
   });
 });

--- a/apps/web/src/lib/db/client.ts
+++ b/apps/web/src/lib/db/client.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { isSessionExpiredSignaled, signalSessionExpired } from '@/lib/auth/session-expired-signal';
+import { notifySessionChanged } from '@/lib/native-shell-bridge';
 
 // ─── FastAPI Auth Utilities ───────────────────────────────────────────────────
 
@@ -25,6 +26,10 @@ async function callAuthRoute(path: string, body: object): Promise<AuthResult> {
   if (!res.ok) {
     return { data: null, error: json.error ?? { code: 'UNKNOWN', message: 'Unknown error' } };
   }
+  // story #3302(#2459 진단 (c)) — login/register/refresh 공통 choke point. 성공은 항상
+  // sp_at/sp_rt 쿠키가 새로 세워졌다는 뜻(각 route.ts가 Set-Cookie) — 네이티브 셸에 즉시
+  // 알려 디스크로 내리게 한다(강제종료 시 갱신 쿠키 유실 방지, AC1).
+  notifySessionChanged();
   return { data: json.data as AuthTokens, error: null };
 }
 

--- a/apps/web/src/lib/native-shell-bridge.test.ts
+++ b/apps/web/src/lib/native-shell-bridge.test.ts
@@ -4,11 +4,12 @@
 // 셸에서만 노출, 웹·안드로이드는 없어야 한다. 이 테스트는 isAppleLoginEligible()의
 // fail-closed 계약(신호 부재·위조는 전부 비노출)을 값으로 고정한다 — 이 함수 하나가
 // 틀리면 웹/안드로이드에 Apple 버튼이 새거나(4.8 무관 노출) iOS/macOS에서 못 뜬다.
-import { afterEach, describe, expect, it } from 'vitest';
-import { isAppleLoginEligible } from './native-shell-bridge';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isAppleLoginEligible, notifySessionChanged } from './native-shell-bridge';
 
 afterEach(() => {
   delete window.__SPRINTABLE_SHELL__;
+  delete window.ReactNativeWebView;
 });
 
 describe('isAppleLoginEligible — story #3118 AC0 fail-closed 계약', () => {
@@ -41,5 +42,23 @@ describe('isAppleLoginEligible — story #3118 AC0 fail-closed 계약', () => {
     // @ts-expect-error — 오배선(필드 누락) 시나리오.
     window.__SPRINTABLE_SHELL__ = {};
     expect(isAppleLoginEligible()).toBe(false);
+  });
+});
+
+// story #3302(#2459 진단 (c) 갈래, AC4) — 셸 수신 계약(sprintable-mobile App.js:798
+// `JSON.parse(msg)?.type === 'session-changed'`)과 바이트 일치해야 한다. 셸이 `type` 필드만
+// 보고 다른 필드는 안 본다(App.js 주석 — "값은 안 받는다, type만 본다")고 명시돼 있어 최소
+// payload({type:'session-changed'})가 계약 전체다.
+describe('notifySessionChanged — 웹→셸 브릿지 발신(story #3302, #2459 진단 (c))', () => {
+  it('셸 안이면 정확히 {type:"session-changed"}를 1회 postMessage한다', () => {
+    const postMessage = vi.fn();
+    window.ReactNativeWebView = { postMessage };
+    notifySessionChanged();
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(JSON.stringify({ type: 'session-changed' }));
+  });
+
+  it('셸 밖(window.ReactNativeWebView 부재)이면 예외 없이 조용히 아무 일도 안 한다', () => {
+    expect(() => notifySessionChanged()).not.toThrow();
   });
 });

--- a/apps/web/src/lib/native-shell-bridge.ts
+++ b/apps/web/src/lib/native-shell-bridge.ts
@@ -22,6 +22,16 @@ export function notifyContentPainted() {
   window.ReactNativeWebView?.postMessage(JSON.stringify({ type: 'content-painted' }));
 }
 
+// story #3302(#2459 진단 (c) 갈래) — 브릿지 계약의 발신 절반. 셸(sprintable-mobile App.js:370
+// AppState 백그라운드 flush + :798 session-changed flush)은 2026-07-21 P0 대응으로 이미
+// 배선됐으나, 웹이 이 신호를 한 번도 보낸 적이 없었다(그 사이 grep 0건). 로그인·세션 회전·
+// 갱신 직후 호출하면 셸이 즉시 쿠키를 디스크로 내려(그 전엔 백그라운드 진입 때까지 대기 —
+// "포그라운드 유지한 채 바로 강제종료"하는 경우를 못 잡던 그 창을 닫는다). content-painted와
+// 동일 관례 — 네이티브 셸 밖에서는 조용히 아무 일도 안 한다.
+export function notifySessionChanged() {
+  window.ReactNativeWebView?.postMessage(JSON.stringify({ type: 'session-changed' }));
+}
+
 // story #2766(레인 A) §A5 — 다운로드 버튼 환경 분기의 판별 신호. 서버사이드(SSR)에서
 // 호출하면 항상 false(window 없음).
 export function isNativeShell(): boolean {


### PR DESCRIPTION
## Summary
- sprintable-mobile `App.js:789-798`가 명시한 브릿지 계약 — 웹이 로그인·세션 회전·갱신 직후 `window.ReactNativeWebView?.postMessage(JSON.stringify({type:'session-changed'}))`를 보낸다 — 의 **수신부는 2026-07-21 P0 대응으로 이미 배선됐으나(App.js:370 AppState 백그라운드 flush + :798 session-changed flush), 발신부(apps/web)는 한 번도 구현된 적이 없었다**(#2459 진단 (c) 갈래, grep 0건).
- 영향: 셸의 AppState 백그라운드 flush만으로는 "포그라운드 유지한 채 바로 강제종료"하는 경우를 못 잡는다(App.js 자체 주석이 명시한 한계). refresh가 조용히 `sp_at`을 갱신해도 셸에 안 알려지니 그 쿠키가 디스크에 안 내려간 채 강제종료되면 다음 실행이 이미 rotate된 refresh_token으로 시작 → single-use 회전 → 401/로그아웃. 선생님 실사용 "완전 종료 후 재실행 시 로그아웃 왕왕" 진술과 정합하는 후보(#2459 가설 (a)와 겹치는 지점).
- 수정: `native-shell-bridge.ts`에 `notifyContentPainted()`와 동형으로 `notifySessionChanged()` 신설 + `client.ts`의 `callAuthRoute()`(login/register/refresh 공통 choke point) 성공 분기에서 호출.

## AC 대조
- ①login/register/refresh 성공 각 1회 발신·실패 0회 — `client.test.ts`로 pin.
- ②셸 아닌 환경(`window.ReactNativeWebView` 부재) no-op·예외 0 — `native-shell-bridge.test.ts`.
- ③뮤테이션: `callAuthRoute`의 `notifySessionChanged();` 한 줄을 직접 지워서 재실행 → 3개 성공 테스트가 전부 RED로 떨어지는 것 확認(로컬 재현, 커밋엔 물론 정상 라인만 포함).
- ④메시지 shape 바이트 일치 — 수신 코드: `sprintable-mobile/App.js:798` `if (JSON.parse(msg)?.type === 'session-changed') flushCookies();`(주석: "값은 안 받는다, type만 본다"). 발신 payload는 정확히 `{type:'session-changed'}` 하나뿐.
- ⑤이 가드가 못 잡는 것(선언):
  - 셸 측 flush 자체의 실패(디스크 쓰기 실패·OS 타이밍) — 웹은 postMessage를 "보냈다"까지만 알고, 셸이 실제로 받아 내렸는지는 셸 쪽 계측이 별도로 필요.
  - iOS(WKWebView) 동형 여부 — `sprintable-mobile/modules/webview-cookies/index.ts:13`가 자체적으로 "미확認"이라 명시. 이 PR은 웹 발신부만 고치며 iOS 저장 기전 차이는 다루지 않는다.
  - 실기기 "강제종료 후 재실행 시 세션 유지" 확認은 배포 후 실기기 몫 — 미확認 상태로 남김.

## Test plan
- [x] `pnpm vitest run`(native-shell-bridge.test.ts 신규 2건 + client.test.ts 신규 5건, login/onboarding 소비처 회귀 포함) — 54 passed
- [x] `pnpm type-check`(tsc --noEmit) — clean
- [x] `pnpm lint`(eslint, 해당 파일) — clean
- [x] `pnpm build`(next build) — 성공
- [x] 뮤테이션 자가검증 — 호출 한 줄 제거 시 3개 테스트 RED 확認(로컬)
- [ ] 실기기 "강제종료 후 재실행 세션 유지" 라이브 확認 — 배포 후 선생님/실기기 몫(AC⑤ 명시)

⛔ dev까지(케이던스 배치). prod 승격은 결함 수정이므로 선생님 명시 허가 후 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrXtyieXmkonMVwuCWr9c3