### PR TITLE
[SID:3312] approve stage → external_publish 게이트 자동생성 배선

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1193,6 +1193,15 @@ async def _publish_registry_event_core(
             detail={"code": "invalid_payload", "message": str(e), "errors": [str(e)]},
         ) from e
 
+    # story #3312(M1→M3·마케팅자동화) — routing 해석 직후, 메시지 발송 이전에 게이트 부수효과를
+    # 먼저 정착시킨다(routing_resolver 호출과 동일 컴포지션 스타일 — 인라인 분기 아님).
+    # definition에 이 stage의 gate 선언이 없으면 완전 no-op(AC3 회귀 0).
+    from app.services.recipe_gate_hooks import maybe_create_stage_gate
+
+    await maybe_create_stage_gate(
+        db, org_id=org_id, definition=definition, payload=payload, requester_member_id=sender.id,
+    )
+
     if extra_broadcast_member_ids:
         # story #2693(AC2): payload_field routing과 동일 검증 — 예전엔 filter_org_member_ids로
         # 비회원 id를 조용히 걸러내고(silent drop) 발행을 그대로 진행했다. AC1의 원자성

--- a/backend/app/services/event_definition_registry.py
+++ b/backend/app/services/event_definition_registry.py
@@ -31,6 +31,13 @@ _SEGMENT_CHARSET_RE = re.compile(r"^[a-z0-9_]+$")
 # 하므로, 여기 없는 target을 server_derived로 등록하면 해석기가 절대 못 푸는 정의가 만들어진다
 # — validate_event_routing이 등록 시점에 막는다(발행 시점에야 발견되는 것보다 이르게).
 SERVER_DERIVED_TARGETS = frozenset({"none", "work_item_stakeholders", "goal_owner"})
+# story #3312(M1→M3·마케팅자동화) — stage_metadata[stage].gate.approver의 닫힌 어휘.
+# SERVER_DERIVED_TARGETS와 동형 설계: PO 확定(페드루, 2026-09-02) "approver는 역할 참조로만
+# 선언(조직 상수 0) — 다른 org가 같은 정의를 apply해도 그 org 자신의 owner가 승인자". 실제
+# member_id 해석은 recipe_gate_hooks.py(발행 시점)의 몫 — 그 모듈이 이 어휘 전체를 커버하는
+# resolver를 갖는지 모듈 로드 시점에 assert로 고정한다(event_routing_resolver.py의
+# _SERVER_DERIVED_RESOLVERS 완결성 assert와 동일 패턴).
+APPROVER_ROLE_REFERENCES = frozenset({"org_owner"})
 # story #3288(축2-ⓐ) — "recipe_role_binding": 사이클형 정의의 stage를 recipe_role_bindings
 # 테이블(org/project 스코프 role→agent 바인딩)로 조회해 푸는 3번째 kind. payload_field처럼
 # payload의 필드를 직접 읽지도, server_derived처럼 고정 닫힌 어휘로 파생하지도 않는다 —
@@ -327,6 +334,26 @@ def validate_stage_metadata(payload_schema: dict, stage_metadata: dict) -> None:
             if not isinstance(meta.get(field), str) or not meta[field]:
                 raise InvalidStageMetadataError(
                     f"stage_metadata[{slug!r}].{field}는 비어있지 않은 문자열이어야 합니다."
+                )
+        # story #3312(M1→M3·마케팅자동화, PO 확定 2026-09-02②) — gate는 선택 필드지만, «막지
+        # 않는다고 검증 안 하면 오타가 조용히 무시»되는 자리라(recipe_gate_hooks.py가 gate
+        # 키가 없으면 그냥 no-op하므로, 오타 난 gate 선언은 "게이트가 영원히 안 생기는" 채로
+        # 조용히 죽는다 — story #2793류 실버그와 동일 클래스) 있으면 shape을 명시 강제한다.
+        if "gate" in meta:
+            gate = meta["gate"]
+            if not isinstance(gate, dict):
+                raise InvalidStageMetadataError(
+                    f"stage_metadata[{slug!r}].gate는 object({{type, approver}})여야 합니다 — "
+                    f"{type(gate).__name__} 아님."
+                )
+            if not isinstance(gate.get("type"), str) or not gate["type"]:
+                raise InvalidStageMetadataError(
+                    f"stage_metadata[{slug!r}].gate.type은 비어있지 않은 문자열이어야 합니다."
+                )
+            if gate.get("approver") not in APPROVER_ROLE_REFERENCES:
+                raise InvalidStageMetadataError(
+                    f"stage_metadata[{slug!r}].gate.approver는 {sorted(APPROVER_ROLE_REFERENCES)} "
+                    f"중 하나여야 합니다 — {gate.get('approver')!r}은 닫힌 어휘 밖입니다."
                 )
 
 

--- a/backend/app/services/recipe_gate_hooks.py
+++ b/backend/app/services/recipe_gate_hooks.py
@@ -1,0 +1,102 @@
+"""story #3312(M1→M3·마케팅자동화) — recipe(사이클형 EventDefinition)의 stage 이벤트 발행이
+`stage_metadata[stage].gate` 선언을 가지고 있으면, 그 work item에 게이트를 자동 생성한다.
+
+event_routing_resolver.py와 동형 설계 — `_publish_registry_event_core`(routers/events.py,
+#2633 AC2 단일파이프)가 routing 해석 직후 이 모듈을 호출하는 별도 단일목적 서비스(인라인
+stage=="approve" 분기 대신). PO 판단(페드루, 2026-09-02) — 이 코드베이스 기존 관례(단일
+core + 단일목적 서비스 호출 컴포지션)와 정합, 테스트도 격리됨.
+
+`gate` 선언 shape은 event_definition_registry.validate_stage_metadata가 등록/수정 시점에
+이미 강제한다({type: str, approver: APPROVER_ROLE_REFERENCES 소속}) — 이 모듈은 그 계약을
+신뢰하고 값 해석만 한다(routing_resolver가 validate_event_routing의 계약을 신뢰하는 것과
+동일 원칙, resolve_routing_leg 참조)."""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project import OrgMember
+from app.services.event_definition_registry import APPROVER_ROLE_REFERENCES
+
+
+class UnknownApproverRoleError(ValueError):
+    """approver 역할참조를 실 member_id로 못 풀었음 — 어휘는 등록 시점에 이미 검증됐으므로,
+    여기서 나오면 "그 org에 role=owner인 org_member가 없다"류의 실제 데이터 결함이다(오타
+    클래스 아님 — 조용히 넘기면 게이트가 승인자 없이 붕 떠버리므로 발행 시점에 명시 거부)."""
+
+
+async def _resolve_org_owner(db: AsyncSession, *, org_id: uuid.UUID) -> uuid.UUID:
+    member_id = (await db.execute(
+        select(OrgMember.id)
+        .where(OrgMember.org_id == org_id, OrgMember.role == "owner", OrgMember.deleted_at.is_(None))
+        .order_by(OrgMember.created_at.asc())
+        .limit(1)
+    )).scalar_one_or_none()
+    if member_id is None:
+        raise UnknownApproverRoleError(f"org {org_id}에 role=owner인 org_member가 없습니다.")
+    return member_id
+
+
+# APPROVER_ROLE_REFERENCES(event_definition_registry.py, 등록 시점 강제 어휘) 전체를 이
+# 모듈이 실제로 풀 수 있는지 로드 시점에 고정 — event_routing_resolver.py의
+# _SERVER_DERIVED_RESOLVERS 완결성 assert와 동일 패턴(등록은 통과했는데 발행이 조용히
+# 못 푸는 정의가 만들어지는 것을 막는다).
+_APPROVER_ROLE_RESOLVERS = {"org_owner": _resolve_org_owner}
+assert set(_APPROVER_ROLE_RESOLVERS) == set(APPROVER_ROLE_REFERENCES), (
+    "recipe_gate_hooks의 approver role resolver 어휘가 "
+    "event_definition_registry.APPROVER_ROLE_REFERENCES와 어긋남"
+)
+
+
+def _parse_work_item_uuid(value: str) -> uuid.UUID | None:
+    try:
+        return uuid.UUID(value)
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+async def maybe_create_stage_gate(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    definition,
+    payload: dict,
+    requester_member_id: uuid.UUID,
+) -> None:
+    """definition.stage_metadata[payload['stage']].gate 선언이 있으면 그 work item에
+    pending 게이트를 멱등 생성한다(create_gate 자체가 (work_item_id, work_item_type,
+    gate_type) 키로 멱등 — AC2가 이 재사용만으로 충족된다, 신규 멱등 로직 불요).
+
+    stage/work_item 정보가 payload에 없거나, 그 stage에 gate 선언이 없으면 완전 no-op —
+    선언 없는 정의(다른 레시피)의 stage 이벤트는 이 함수를 거쳐도 아무 부수효과가 없다
+    (AC3 회귀 0)."""
+    stage = payload.get("stage")
+    work_item_type = payload.get("work_item_type")
+    work_item_id_raw = payload.get("work_item_id")
+    if not stage or not work_item_type or not work_item_id_raw:
+        return
+
+    stage_meta = (definition.stage_metadata or {}).get(stage) or {}
+    gate_decl = stage_meta.get("gate")
+    if not gate_decl:
+        return
+
+    work_item_id = _parse_work_item_uuid(work_item_id_raw)
+    if work_item_id is None:
+        return
+
+    resolver = _APPROVER_ROLE_RESOLVERS[gate_decl["approver"]]
+    approver_id = await resolver(db, org_id=org_id)
+
+    from app.services.gate_service import create_gate
+    from app.services.workflow_line_config import _default_role_id
+
+    role_id = await _default_role_id(db, org_id) or uuid.uuid4()
+    await create_gate(
+        db, org_id, work_item_id, work_item_type, gate_decl["type"],
+        requester_member_id, role_id,
+        neutral_facts={"triggered_by_event": definition.key, "stage": stage},
+        designated_approver_id=approver_id,
+    )

--- a/backend/app/services/recipe_gate_hooks.py
+++ b/backend/app/services/recipe_gate_hooks.py
@@ -14,11 +14,17 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.project import OrgMember
 from app.services.event_definition_registry import APPROVER_ROLE_REFERENCES
+from app.services.reference_token import build_reference_token
+
+# PO 확定(페드루, 2026-09-02, 변경요청①) — 값을 지어내지 않는다: 못 찾은 필드는 이 sentinel로
+# 명시한다("가서 보라" 금지 — story #3312 처방 3과 동형, 결재 카드에 실물이 안 보이면 그
+# 사실 자체를 정직하게 드러낸다).
+_UNCONFIRMED = "미확認"
 
 
 class UnknownApproverRoleError(ValueError):
@@ -57,6 +63,102 @@ def _parse_work_item_uuid(value: str) -> uuid.UUID | None:
         return None
 
 
+async def _work_item_title(
+    db: AsyncSession, *, org_id: uuid.UUID, work_item_type: str, work_item_id: uuid.UUID,
+) -> str | None:
+    """event_routing_resolver._resolve_work_item_stakeholders와 동형 타입별 분기(그 함수와
+    나란히 둘 범용 헬퍼가 이 코드베이스에 없다는 것도 같은 그라운딩에서 확認됨) — 지원하는
+    타입만 조회, 그 외는 None(지어내지 않음)."""
+    if work_item_type == "story":
+        from app.models.pm import Story
+
+        return (await db.execute(
+            select(Story.title).where(Story.id == work_item_id, Story.org_id == org_id)
+        )).scalar_one_or_none()
+    if work_item_type == "task":
+        from app.models.pm import Task
+
+        return (await db.execute(
+            select(Task.title).where(Task.id == work_item_id, Task.org_id == org_id)
+        )).scalar_one_or_none()
+    return None
+
+
+async def _latest_linked_draft_doc(
+    db: AsyncSession, *, org_id: uuid.UUID, work_item_type: str, work_item_id: uuid.UUID,
+) -> tuple[uuid.UUID, str, str] | None:
+    """이 work item과 doc 사이의 가장 최근 entity_references 행(어느 방향이든 — 산출물 doc이
+    work item을 참조했을 수도, work item쪽 텍스트가 doc을 참조했을 수도 있다)을 찾아 그 doc의
+    (id, title, content)를 반환. 없으면 None(지어내지 않음)."""
+    from app.models.reference import Reference
+
+    row = (await db.execute(
+        select(Reference.source_type, Reference.source_id, Reference.target_type, Reference.target_id)
+        .where(
+            Reference.org_id == org_id,
+            or_(
+                and_(
+                    Reference.target_type == work_item_type, Reference.target_id == work_item_id,
+                    Reference.source_type == "doc",
+                ),
+                and_(
+                    Reference.source_type == work_item_type, Reference.source_id == work_item_id,
+                    Reference.target_type == "doc",
+                ),
+            ),
+        )
+        .order_by(Reference.created_at.desc())
+        .limit(1)
+    )).first()
+    if row is None:
+        return None
+    source_type, source_id, _target_type, target_id = row
+    doc_id = source_id if source_type == "doc" else target_id
+
+    from app.models.doc import Doc
+
+    doc_row = (await db.execute(
+        select(Doc.title, Doc.content).where(Doc.id == doc_id, Doc.org_id == org_id)
+    )).first()
+    if doc_row is None:
+        return None
+    doc_title, doc_content = doc_row
+    return doc_id, doc_title, doc_content or ""
+
+
+async def _build_approval_neutral_facts(
+    db: AsyncSession, *, org_id: uuid.UUID, definition, stage: str, work_item_type: str,
+    work_item_id: uuid.UUID, payload: dict,
+) -> dict:
+    """PO 변경요청①(페드루, 2026-09-02) — 결재함 카드가 승인자에게 «무엇을 승인하는지»를
+    실물로 보여줘야 한다(story 처방 3, "가서 보라" 금지). work item 제목+참조 토큰·payload
+    채널·그 work item에 링크된 최신 산출물 doc(직전 draft) 참조+텍스트 요약(첫 300자)을
+    채운다 — 못 찾은 값은 _UNCONFIRMED로 명시(침묵도 지어냄도 아님)."""
+    facts: dict = {"triggered_by_event": definition.key, "stage": stage}
+
+    title = await _work_item_title(db, org_id=org_id, work_item_type=work_item_type, work_item_id=work_item_id)
+    facts["work_item_title"] = title or _UNCONFIRMED
+    facts["work_item_reference_token"] = (
+        (build_reference_token(work_item_type, work_item_id, title) if title else None) or _UNCONFIRMED
+    )
+
+    channel = payload.get("channel")
+    facts["channel"] = channel if isinstance(channel, str) and channel else _UNCONFIRMED
+
+    draft = await _latest_linked_draft_doc(
+        db, org_id=org_id, work_item_type=work_item_type, work_item_id=work_item_id,
+    )
+    if draft is None:
+        facts["draft_doc_reference_token"] = _UNCONFIRMED
+        facts["draft_doc_summary"] = _UNCONFIRMED
+    else:
+        doc_id, doc_title, doc_content = draft
+        facts["draft_doc_reference_token"] = build_reference_token("doc", doc_id, doc_title) or _UNCONFIRMED
+        facts["draft_doc_summary"] = doc_content[:300] or _UNCONFIRMED
+
+    return facts
+
+
 async def maybe_create_stage_gate(
     db: AsyncSession,
     *,
@@ -90,6 +192,11 @@ async def maybe_create_stage_gate(
     resolver = _APPROVER_ROLE_RESOLVERS[gate_decl["approver"]]
     approver_id = await resolver(db, org_id=org_id)
 
+    neutral_facts = await _build_approval_neutral_facts(
+        db, org_id=org_id, definition=definition, stage=stage,
+        work_item_type=work_item_type, work_item_id=work_item_id, payload=payload,
+    )
+
     from app.services.gate_service import create_gate
     from app.services.workflow_line_config import _default_role_id
 
@@ -97,6 +204,6 @@ async def maybe_create_stage_gate(
     await create_gate(
         db, org_id, work_item_id, work_item_type, gate_decl["type"],
         requester_member_id, role_id,
-        neutral_facts={"triggered_by_event": definition.key, "stage": stage},
+        neutral_facts=neutral_facts,
         designated_approver_id=approver_id,
     )

--- a/backend/tests/test_3312_approve_stage_gate_auto_creation.py
+++ b/backend/tests/test_3312_approve_stage_gate_auto_creation.py
@@ -1,0 +1,289 @@
+"""story #3312(M1→M3·마케팅자동화) — recipe의 approve stage 이벤트 발행이 external_publish
+게이트를 자동 생성하는지(AC1) 실왕복 검증. 멱등(AC2)·무선언 회귀 0(AC3)·approver 역할참조
+어휘 강제(등록 시점)도 같이 고정한다.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── 단위 축 — validate_stage_metadata의 gate shape 강제(DB 불요) ──────────────────
+
+
+def test_validate_stage_metadata_accepts_valid_gate_declaration():
+    from app.services.event_definition_registry import validate_stage_metadata
+
+    schema = {"properties": {"stage": {"enum": ["draft", "approve", "publish"]}}}
+    validate_stage_metadata(schema, {
+        "approve": {"role": "Approver", "action": "승인", "gate": {"type": "external_publish", "approver": "org_owner"}},
+    })  # raise 없으면 통과
+
+
+def test_validate_stage_metadata_rejects_gate_not_object():
+    from app.services.event_definition_registry import InvalidStageMetadataError, validate_stage_metadata
+
+    schema = {"properties": {"stage": {"enum": ["approve"]}}}
+    with pytest.raises(InvalidStageMetadataError):
+        validate_stage_metadata(schema, {"approve": {"role": "R", "action": "A", "gate": "external_publish"}})
+
+
+def test_validate_stage_metadata_rejects_empty_gate_type():
+    from app.services.event_definition_registry import InvalidStageMetadataError, validate_stage_metadata
+
+    schema = {"properties": {"stage": {"enum": ["approve"]}}}
+    with pytest.raises(InvalidStageMetadataError):
+        validate_stage_metadata(schema, {
+            "approve": {"role": "R", "action": "A", "gate": {"type": "", "approver": "org_owner"}},
+        })
+
+
+def test_validate_stage_metadata_rejects_unknown_approver_role():
+    """오타(예: "org-owner", "owner") 재현 — 닫힌 어휘 밖은 등록 시점에 거부돼야 나중에
+    recipe_gate_hooks가 조용히 no-op(게이트가 영원히 안 생김)하는 사고를 막는다."""
+    from app.services.event_definition_registry import InvalidStageMetadataError, validate_stage_metadata
+
+    schema = {"properties": {"stage": {"enum": ["approve"]}}}
+    with pytest.raises(InvalidStageMetadataError):
+        validate_stage_metadata(schema, {
+            "approve": {"role": "R", "action": "A", "gate": {"type": "external_publish", "approver": "owner"}},
+        })
+
+
+def test_recipe_gate_hooks_resolver_vocabulary_matches_registry():
+    """recipe_gate_hooks._APPROVER_ROLE_RESOLVERS 완결성 assert가 모듈 로드 시점에 이미
+    돌지만(import 자체가 실패하면 이 테스트 파일 전체가 collection 단계에서 죽는다), 어휘가
+    실제로 비어있지 않은지도 한 번 더 pin — 어휘를 실수로 빈 집합으로 되돌리면 이 테스트가
+    (import는 통과해도) 잡는다."""
+    from app.services.event_definition_registry import APPROVER_ROLE_REFERENCES
+    from app.services.recipe_gate_hooks import _APPROVER_ROLE_RESOLVERS
+
+    assert APPROVER_ROLE_REFERENCES == {"org_owner"}
+    assert set(_APPROVER_ROLE_RESOLVERS) == APPROVER_ROLE_REFERENCES
+
+
+# ─── 실행 축(realdb) — AC1/AC2/AC3 실왕복 ──────────────────────────────────────
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_with_owner(session, *, slug="acme3312"):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+
+    org = Organization(id=uuid.uuid4(), name="Org3312", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    owner_user_id = uuid.uuid4()
+    owner_member = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=owner_user_id, role="owner")
+    session.add(owner_member)
+    await session.commit()
+    return org.id, project.id, owner_member.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="레시피 산출물")
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+_CYCLE_SCHEMA = {
+    "type": "object", "additionalProperties": False,
+    "required": ["stage", "work_item_type", "work_item_id"],
+    "properties": {
+        "stage": {"type": "string", "enum": ["draft", "approve", "publish"]},
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+    },
+}
+_CYCLE_ROUTING = {
+    "escalation": {"kind": "server_derived", "target": "none"},
+    "broadcast": {"kind": "server_derived", "target": "none"},
+}
+
+
+async def _seed_recipe_definition(session, org_id, *, slug, stage_metadata):
+    from app.models.event_definition import EventDefinition
+
+    d = EventDefinition(
+        id=uuid.uuid4(), key=f"org.{slug}.recipe_cycle", org_id=org_id, name="테스트 레시피",
+        payload_schema=_CYCLE_SCHEMA, routing=_CYCLE_ROUTING, stage_metadata=stage_metadata,
+    )
+    session.add(d)
+    await session.commit()
+    return d.key
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+def _fake_request() -> "StarletteRequest":
+    from starlette.requests import Request as StarletteRequest
+    return StarletteRequest(scope={"type": "http", "headers": []})
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_approve_stage_event_auto_creates_external_publish_gate():
+    """⭐AC1 핵심 — stage_metadata.approve.gate 선언이 있는 정의의 approve stage 이벤트를
+    발행하면, 그 work item에 pending external_publish 게이트가 designated_approver=org owner로
+    자동 생성된다."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_member_id = await _seed_org_with_owner(s)
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_recipe_definition(
+                s, org_id, slug="acme3312a",
+                stage_metadata={
+                    "draft": {"role": "Writer", "action": "초안 작성"},
+                    "approve": {
+                        "role": "Approver", "action": "승인",
+                        "gate": {"type": "external_publish", "approver": "org_owner"},
+                    },
+                    "publish": {"role": "Publisher", "action": "게시"},
+                },
+            )
+
+            body = EventPublishRequest(
+                definition_key=definition_key,
+                payload={"stage": "approve", "work_item_type": "story", "work_item_id": str(story_id)},
+            )
+            await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+
+            gates = (await s.execute(
+                select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "external_publish")
+            )).scalars().all()
+            assert len(gates) == 1
+            gate = gates[0]
+            assert gate.status == "pending"
+            assert gate.designated_approver_id == owner_member_id
+            assert gate.org_id == org_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_approve_stage_event_republish_is_idempotent():
+    """AC2 — 같은 work item에 approve stage 이벤트가 다시 발행돼도(재시도·재발행류) pending
+    게이트가 1건으로 유지된다(create_gate의 기존 멱등 재사용)."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner_member_id = await _seed_org_with_owner(s, slug="acme3312b")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_recipe_definition(
+                s, org_id, slug="acme3312b",
+                stage_metadata={
+                    "approve": {
+                        "role": "Approver", "action": "승인",
+                        "gate": {"type": "external_publish", "approver": "org_owner"},
+                    },
+                },
+            )
+            body = EventPublishRequest(
+                definition_key=definition_key,
+                payload={"stage": "approve", "work_item_type": "story", "work_item_id": str(story_id)},
+            )
+            for _ in range(2):
+                await publish_registry_event(
+                    body, BackgroundTasks(), _fake_request(), db=s,
+                    auth=_auth(publisher_id, org_id), org_id=org_id,
+                )
+
+            gates = (await s.execute(
+                select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "external_publish")
+            )).scalars().all()
+            assert len(gates) == 1, f"멱등 깨짐 — {len(gates)}건 생성됨"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_stage_event_without_gate_declaration_creates_no_gate():
+    """AC3 — gate 선언이 없는 stage(다른 레시피류) 이벤트를 발행해도 게이트가 전혀 안 생긴다
+    (회귀 0 — 이 훅이 무선언 정의에 완전 무영향임을 실증)."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner_member_id = await _seed_org_with_owner(s, slug="acme3312c")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_recipe_definition(
+                s, org_id, slug="acme3312c",
+                stage_metadata={"draft": {"role": "Writer", "action": "초안 작성"}},
+            )
+            body = EventPublishRequest(
+                definition_key=definition_key,
+                payload={"stage": "draft", "work_item_type": "story", "work_item_id": str(story_id)},
+            )
+            await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+
+            gates = (await s.execute(select(Gate).where(Gate.work_item_id == story_id))).scalars().all()
+            assert gates == []
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3312_approve_stage_gate_auto_creation.py
+++ b/backend/tests/test_3312_approve_stage_gate_auto_creation.py
@@ -133,6 +133,7 @@ _CYCLE_SCHEMA = {
         "stage": {"type": "string", "enum": ["draft", "approve", "publish"]},
         "work_item_type": {"type": "string"},
         "work_item_id": {"type": "string", "format": "uuid"},
+        "channel": {"type": "string"},
     },
 }
 _CYCLE_ROUTING = {
@@ -210,6 +211,81 @@ async def test_approve_stage_event_auto_creates_external_publish_gate():
             assert gate.status == "pending"
             assert gate.designated_approver_id == owner_member_id
             assert gate.org_id == org_id
+
+            # PO 변경요청①(2026-09-02) — neutral_facts가 카드에서 «무엇을 승인하는지» 보이게.
+            # 이 케이스는 channel/링크된 draft doc이 없으므로 그 둘은 «미확認»이어야 한다
+            # (지어내지 않음 — 다음 테스트가 값 있는 happy-path를 커버).
+            facts = gate.neutral_facts
+            assert facts["work_item_title"] == "레시피 산출물"
+            assert facts["work_item_reference_token"] == f"[레시피 산출물](entity:story:{story_id})"
+            assert facts["channel"] == "미확認"
+            assert facts["draft_doc_reference_token"] == "미확認"
+            assert facts["draft_doc_summary"] == "미확認"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_approve_stage_event_neutral_facts_surface_channel_and_linked_draft_doc():
+    """PO 변경요청① happy-path — payload에 channel이 있고 그 story에 draft doc이(entity_references
+    로) 링크돼 있으면 카드가 실 채널·doc 참조 토큰·본문 첫 300자를 담는다."""
+    import datetime as dt
+
+    from app.routers.events import EventPublishRequest, publish_registry_event
+    from app.models.doc import Doc
+    from app.models.gate import Gate
+    from app.models.reference import Reference
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner_member_id = await _seed_org_with_owner(s, slug="acme3312d")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+            doc = Doc(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="9월 캠페인 초안",
+                slug=f"campaign-draft-{uuid.uuid4().hex[:8]}", content="X" * 400,  # 300자 잘림 확인용
+            )
+            s.add(doc)
+            await s.commit()
+            s.add(Reference(
+                id=uuid.uuid4(), org_id=org_id,
+                source_type="doc", source_field="body", source_id=doc.id,
+                target_type="story", target_id=story_id,
+                form="mention", relation="none", created_at=dt.datetime.now(dt.timezone.utc),
+            ))
+            await s.commit()
+
+            definition_key = await _seed_recipe_definition(
+                s, org_id, slug="acme3312d",
+                stage_metadata={
+                    "approve": {
+                        "role": "Approver", "action": "승인",
+                        "gate": {"type": "external_publish", "approver": "org_owner"},
+                    },
+                },
+            )
+            body = EventPublishRequest(
+                definition_key=definition_key,
+                payload={
+                    "stage": "approve", "work_item_type": "story", "work_item_id": str(story_id),
+                    "channel": "twitter",
+                },
+            )
+            await publish_registry_event(
+                body, BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_id, org_id), org_id=org_id,
+            )
+
+            gate = (await s.execute(
+                select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "external_publish")
+            )).scalar_one()
+            facts = gate.neutral_facts
+            assert facts["channel"] == "twitter"
+            assert facts["draft_doc_reference_token"] == f"[9월 캠페인 초안](entity:doc:{doc.id})"
+            assert facts["draft_doc_summary"] == "X" * 300
     finally:
         await engine.dispose()
 
@@ -285,5 +361,62 @@ async def test_stage_event_without_gate_declaration_creates_no_gate():
 
             gates = (await s.execute(select(Gate).where(Gate.work_item_id == story_id))).scalars().all()
             assert gates == []
+    finally:
+        await engine.dispose()
+
+
+# ─── AC5 — 커넥터용 조회 계약 = 기존 GET /api/v2/gates(필터: work_item_id·work_item_type·
+#     gate_type·status·sort). 새 라우트 없음(PO 확定, 2026-09-02) — 아래는 그 계약이 org
+#     스코프 밖 요청에서 0건을 낸다는 실증(카디르 QA 커버리지 요구 반영). ─────────────────
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_list_gates_returns_zero_for_work_item_outside_caller_org_scope():
+    """⭐AC5 — 에이전트 키 caller가 자기 org로 인증했지만 조회 필터(work_item_id)가 **다른
+    org**의 story/게이트를 가리키면 그 게이트가 새지 않는다(설령 그 story_id를 정확히 안다
+    해도). 실측: `list_gates`는 이 경우 빈 리스트가 아니라 `HTTPException(404)`를 낸다
+    (gates.py:673, "존재-비노출" 관례 — get_gate_endpoint 단건조회와 동일 판정축, 모듈
+    docstring 참조) — 그래서 이 테스트는 404를 단언한다(다른 org의 게이트 내용이 응답에
+    한 조각도 안 실림)."""
+    from fastapi import HTTPException
+
+    from app.routers.gates import list_gates
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_a_id, project_a_id, _owner_a = await _seed_org_with_owner(s, slug="acme3312e-a")
+            caller_id = await _seed_agent(s, org_a_id, project_a_id, name="caller")
+
+            org_b_id, project_b_id, owner_b_id = await _seed_org_with_owner(s, slug="acme3312e-b")
+            story_b_id = await _seed_story(s, org_b_id, project_b_id)
+            definition_key_b = await _seed_recipe_definition(
+                s, org_b_id, slug="acme3312eb",
+                stage_metadata={
+                    "approve": {
+                        "role": "Approver", "action": "승인",
+                        "gate": {"type": "external_publish", "approver": "org_owner"},
+                    },
+                },
+            )
+            publisher_b_id = await _seed_agent(s, org_b_id, project_b_id, name="publisher-b")
+            from app.routers.events import EventPublishRequest, publish_registry_event
+
+            await publish_registry_event(
+                EventPublishRequest(
+                    definition_key=definition_key_b,
+                    payload={"stage": "approve", "work_item_type": "story", "work_item_id": str(story_b_id)},
+                ),
+                BackgroundTasks(), _fake_request(), db=s, auth=_auth(publisher_b_id, org_b_id), org_id=org_b_id,
+            )
+
+            with pytest.raises(HTTPException) as exc:
+                await list_gates(
+                    work_item_id=story_b_id, work_item_type="story", status=None, sort=None,
+                    gate_type="external_publish", assigned_to_me=False,
+                    session=s, org_id=org_a_id, auth=_auth(caller_id, org_a_id),
+                )
+            assert exc.value.status_code == 404, f"org 스코프 밖 게이트가 샜다 — {exc.value!r}"
     finally:
         await engine.dispose()


### PR DESCRIPTION
## 배경
[[M1→M3·마케팅자동화] approve 단계 → external_publish 게이트 «자동 생성» 배선](entity:story:761a0f7b-f939-4839-a797-680e04057876)(#3312) — 자동화 루프가 사람 개입 없이 「승인 카드까지」 서려면, recipe의 approve stage 이벤트가 external_publish 게이트를 자동 생성해야 한다.

## 그라운딩(PO 승인 2026-09-02)
- 훅 지점 = `event_routing_resolver.py`와 동형인 별도 서비스 모듈(`recipe_gate_hooks.py`) — `_publish_registry_event_core`가 routing 해석 직후 호출(인라인 stage=="approve" 분기 아님, #2633 AC2 단일파이프 원칙 유지).
- `stage_metadata[stage].gate = {type, approver}` 선언 — `validate_stage_metadata`가 기존 role/action 검증에 이어 shape을 강제(막지 않으면 오타가 조용히 무시되는 자리이므로 명시 검증, story #2793류 실버그와 동일 클래스 방지).
- approver = **역할 참조**로만 선언(조직 상수 0) — 현재 `org_owner` 하나, `APPROVER_ROLE_REFERENCES` 닫힌 어휘. 실 member는 발행 시점에 그 org에서 해석(다른 org가 같은 정의를 apply해도 그 org 자신의 owner가 승인자).
- `create_gate()`의 기존 `(work_item_id, work_item_type, gate_type)` 멱등을 그대로 재사용 — AC2(멱등)가 신규 로직 없이 충족.

## AC 커버리지
- AC1(자동 생성) — `test_approve_stage_event_auto_creates_external_publish_gate`
- AC2(멱등) — `test_approve_stage_event_republish_is_idempotent`
- AC3(무선언 회귀 0) — `test_stage_event_without_gate_declaration_creates_no_gate`
- AC4(뮤테이션: 생성 훅 호출 제거 시 AC1 RED) — AC1 테스트 자체가 그 훅 호출에 의존(별도 뮤테이션 케이스 불요)
- AC6(기존 Gate FSM 무변경) — `external_publish`는 이미 `_ALWAYS_MANUAL_GATE_TYPES`(story #3291) 등재 済이라 이 PR이 그 성질을 안 건드림(새 상태기계 0)
- AC5(work item 기준 최신 external_publish 게이트 조회 API) — 새 라우트 없음(PO 확定), 기존 GET /api/v2/gates 필터 조합이 계약(아래 §커넥터용 조회 계약 참고). org 스코프 밖 0건(404) 실증 — test_list_gates_returns_zero_for_work_item_outside_caller_org_scope.
- AC7(QA→PO 머지·라이브 실증) — 이번 커밋 스코프 밖, 후속.

## 검증
로컬 realdb(전용 throwaway DB): 신규 10개 전부 PASS(neutral_facts 실물 노출 2건·AC5 org스코프 1건 추가) + 기존 `test_2633_event_publish.py`/`test_2665_event_publish_history.py`(destructive) 27개 전부 PASS(회귀 0), 총 39개.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DfPLRWqGNvcf58NWYrYKba

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 커넥터용 조회 계약(AC5, PO 확定 2026-09-02 — 새 라우트 없음)

publish stage 실행부(Threads 커넥터 chokepoint)가 gate_id 없이 「이 work item의 최신
external_publish 게이트」를 알아야 할 때, 기존 `GET /api/v2/gates`를 다음 필터 조합으로 쓴다.

**쿼리 예시**
```
GET /api/v2/gates?work_item_id={work_item_id}&work_item_type=story&gate_type=external_publish
```

**응답**: `GateResponse` 배열(`app/routers/gates.py:143`). 이 접합에서 실제로 쓰는 필드만 추림:
| 필드 | 의미 |
|---|---|
| `id` | gate_id — 이후 승인/반려 조회·assertGateApproved에 씀 |
| `status` | `"pending"` \| `"approved"` \| `"rejected"` \| `"auto_passed"` \| `"voided"` \| `"held"` — external_publish는 `_ALWAYS_MANUAL_GATE_TYPES`라 posture 무관 항상 `"pending"`으로 생성 |
| `designated_approver_id` | 지정 승인자(org owner) member_id |
| `neutral_facts` | 결재 카드 실물(work_item_title/work_item_reference_token/channel/draft_doc_reference_token/draft_doc_summary) — 못 찾은 값은 `"미확認"` 문자열 |
| `work_item_id`/`work_item_type` | 에코 |

**0건 처리**: 응답이 빈 배열 `[]`이면 "아직 approve 이벤트가 발행 안 됐다"(게이트 생성 전) — 에러 아님, 커넥터는 publish를 보류.

**복수건 처리**: 실제로는 안 생긴다 — `create_gate()`의 기존 `(work_item_id, work_item_type, gate_type)` 멱등이 같은 work item에 이 조합으로 게이트를 1건으로 강제한다(이 PR의 AC2 테스트가 실증). 커넥터는 방어적으로 "가장 최근 1건"만 신뢰하면 되지만, 정상 흐름에서 2건 이상은 버그 신호.

**org 스코프 밖 요청**: work_item_id가 caller의 org 소속이 아니면 `404 Gate not found`(존재-비노출 관례) — 이 PR의 `test_list_gates_returns_zero_for_work_item_outside_caller_org_scope`가 실증.

@미르코군 — 이 계약으로 접합 가능한지 확인 부탁하는.

