### PR TITLE
[SID:3313] block_template 없는 recipe stage 알림 온보딩 결함 처방

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1112,10 +1112,20 @@ async def _render_event_message_content(
         # stage가 payload에 없거나 stage_metadata에 등재 안 됨 — 지어내지 않고 기존 폴백.
         return "\n".join(_generic_event_message_lines(definition.key, payload))
 
+    # PO 리뷰(페드루, 2026-09-02) — validate_stage_metadata의 role/action 필수 검증은
+    # 2026-08-19 이후 "쓰기 시점" 가드라, 그 전에 저장된 정의는 role/action이 누락된 채
+    # DB에 있을 수 있다. 직접 인덱싱(stage_meta['role'])하면 그 정의의 publish 자체가
+    # KeyError로 죽는다(알림 개선이 발행 회귀가 되는 자리) — .get()으로 방어, 하나라도
+    # 없으면 지어내지 않고 기존 제네릭 폴백.
+    role = stage_meta.get("role")
+    action = stage_meta.get("action")
+    if not role or not action:
+        return "\n".join(_generic_event_message_lines(definition.key, payload))
+
     lines = [
         f"[이벤트] {definition.key}",
-        f"- stage: {stage} ({stage_meta['role']})",
-        f"- 할 일: {stage_meta['action']}",
+        f"- stage: {stage} ({role})",
+        f"- 할 일: {action}",
     ]
 
     enum = ((definition.payload_schema.get("properties") or {}).get("stage") or {}).get("enum") or []

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1054,12 +1054,112 @@ async def _get_or_create_event_conversation(
     )
 
 
-def _render_event_message_content(definition_key: str, payload: dict) -> str:
+def _generic_event_message_lines(definition_key: str, payload: dict) -> list[str]:
     """P2(story #2637)의 block_template 렌더러가 상륙하기 전 제네릭 폴백 — model.py docstring의
     "템플릿 없으면 제네릭 카드"와 동형 원칙을 메시지 본문 레벨에서 지금 구현. 필드 순서는
     payload dict 삽입 순서(파이썬 3.7+ 보장) 그대로 — 임의 정렬로 무의미하게 흔들지 않는다."""
     lines = [f"[이벤트] {definition_key}"]
     lines += [f"- {k}: {v}" for k, v in payload.items()]
+    return lines
+
+
+async def _render_event_notification_work_item_ref(
+    db: AsyncSession, *, org_id: uuid.UUID, work_item_type: str, work_item_id: uuid.UUID,
+) -> str | None:
+    """work_item을 클릭되는 참조 토큰으로(story #3313 AC2) — 지원 타입만, 못 찾으면 None
+    (지어내지 않음, 호출부가 raw id 폴백으로 이어받는다)."""
+    from app.services.reference_token import build_reference_token
+
+    title: str | None = None
+    if work_item_type == "story":
+        from app.models.pm import Story
+
+        title = (await db.execute(
+            select(Story.title).where(Story.id == work_item_id, Story.org_id == org_id)
+        )).scalar_one_or_none()
+    elif work_item_type == "task":
+        from app.models.pm import Task
+
+        title = (await db.execute(
+            select(Task.title).where(Task.id == work_item_id, Task.org_id == org_id)
+        )).scalar_one_or_none()
+    if not title:
+        return None
+    return build_reference_token(work_item_type, work_item_id, title)
+
+
+async def _render_event_message_content(
+    db: AsyncSession, *, org_id: uuid.UUID, definition, payload: dict,
+) -> str:
+    """story #3313(마케팅자동화·온보딩 결함) — `block_template`가 없는 사이클형 정의(stage
+    이벤트)의 알림 본문이 "stage/work_item_id뿐"이라 수신 에이전트가 `list_event_definitions`
+    조회+스토리 정독 없이는 못 움직였다(담롱 실측, "최저 지능 LLM도 이벤트만 보고 척척" 온보딩
+    철학 미달). `stage_metadata[stage]`에 이미 있는 role/action과 `payload_schema.stage.enum`
+    순서로 뽑은 다음 stage+발행 예시를 본문에 싣는다.
+
+    ⚠️PO 확定(2026-09-02) — 조직 규칙/우리 문구를 기본값으로 박지 않는다: role/action은
+    정의(stage_metadata)에 이미 적힌 값을 그대로 옮길 뿐 새 문구를 짓지 않고, 발행 예시도
+    definition_key+payload 골격만(값 없이 구조만). 회귀 0인 두 갈래(둘 다 기존 제네릭
+    그대로): ①block_template가 있는 정의(P2 렌더러가 그 정의는 이미 담당) ②stage_metadata가
+    비어있는 비사이클형 정의("담당자 없는 stage는 모르면 안 준다" 원칙과 동일 — 지어낼
+    stage_metadata 자체가 없다)."""
+    if definition.block_template is not None or not definition.stage_metadata:
+        return "\n".join(_generic_event_message_lines(definition.key, payload))
+
+    stage = payload.get("stage")
+    stage_meta = definition.stage_metadata.get(stage) if stage else None
+    if stage_meta is None:
+        # stage가 payload에 없거나 stage_metadata에 등재 안 됨 — 지어내지 않고 기존 폴백.
+        return "\n".join(_generic_event_message_lines(definition.key, payload))
+
+    lines = [
+        f"[이벤트] {definition.key}",
+        f"- stage: {stage} ({stage_meta['role']})",
+        f"- 할 일: {stage_meta['action']}",
+    ]
+
+    enum = ((definition.payload_schema.get("properties") or {}).get("stage") or {}).get("enum") or []
+    next_stage = None
+    if stage in enum:
+        idx = enum.index(stage)
+        if idx + 1 < len(enum):
+            next_stage = enum[idx + 1]
+    if next_stage is not None:
+        next_role = (definition.stage_metadata.get(next_stage) or {}).get("role")
+        lines.append(f"- 다음 단계: {next_stage}" + (f" ({next_role})" if next_role else ""))
+        next_payload = {k: v for k, v in payload.items() if k != "stage"}
+        next_payload["stage"] = next_stage
+        example = json.dumps(
+            {"definition_key": definition.key, "payload": next_payload}, ensure_ascii=False,
+        )
+        lines.append(f"- 다음 단계로 넘기는 발행 예시: publish_event({example})")
+    else:
+        lines.append("- 다음 단계: 없음(마지막 stage)")
+
+    work_item_type = payload.get("work_item_type")
+    work_item_id_raw = payload.get("work_item_id")
+    work_item_ref: str | None = None
+    if work_item_type and work_item_id_raw:
+        try:
+            work_item_id = uuid.UUID(str(work_item_id_raw))
+        except (ValueError, AttributeError, TypeError):
+            work_item_id = None
+        if work_item_id is not None:
+            work_item_ref = await _render_event_notification_work_item_ref(
+                db, org_id=org_id, work_item_type=work_item_type, work_item_id=work_item_id,
+            )
+    if work_item_ref:
+        lines.append(f"- work item: {work_item_ref}")
+    else:
+        # 참조 토큰을 못 만들었으면(타입 미지원·존재 안 함 등) raw 값을 그대로 남긴다 —
+        # 기존 폴백이 주던 정보(원시 id)를 잃지 않는다(지어내지 않음).
+        for k in ("work_item_type", "work_item_id"):
+            if k in payload:
+                lines.append(f"- {k}: {payload[k]}")
+
+    shown_keys = {"stage", "work_item_type", "work_item_id"}
+    lines += [f"- {k}: {v}" for k, v in payload.items() if k not in shown_keys]
+
     return "\n".join(lines)
 
 
@@ -1306,7 +1406,7 @@ async def _publish_registry_event_core(
     # "이벤트 발행분"으로 인지하고 event_key로 event_definitions를 조회해 block_template
     # 렌더러를 태울 근거. 렌더러 자체는 #2637 FE 레인(이 커밋은 스키마 배선만).
     send_body = SendMessageRequest(
-        content=_render_event_message_content(definition.key, payload),
+        content=await _render_event_message_content(db, org_id=org_id, definition=definition, payload=payload),
         mentioned_ids=list(escalation_ids),
         event_context={"event_key": definition.key, "payload": payload},
     )

--- a/backend/tests/test_3313_recipe_notification_render.py
+++ b/backend/tests/test_3313_recipe_notification_render.py
@@ -1,0 +1,341 @@
+"""story #3313(마케팅자동화·온보딩 결함) — block_template 없는 사이클형 정의의 stage 이벤트
+알림이 role/action·다음 stage·발행 예시·work item 참조 토큰을 싣는지(AC1/AC2) 실왕복 검증.
+block_template 있는 정의·stage_metadata 없는 비사이클형 정의는 바이트 동일 렌더(AC3, PO
+확定②로 두 갈래 다 커버)."""
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session, *, slug="e3313"):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org3313", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="캠페인 아이디어 후보"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+_CYCLE_SCHEMA = {
+    "type": "object", "additionalProperties": False,
+    "required": ["stage", "work_item_type", "work_item_id"],
+    "properties": {
+        "stage": {"type": "string", "enum": ["monitor", "research", "draft"]},
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+    },
+}
+_ROUTING = {
+    "escalation": {"kind": "server_derived", "target": "none"},
+    "broadcast": {"kind": "server_derived", "target": "none"},
+}
+
+
+async def _seed_definition(
+    session, org_id, *, slug, stage_metadata=None, block_template=None, payload_schema=None,
+):
+    from app.models.event_definition import EventDefinition
+
+    d = EventDefinition(
+        id=uuid.uuid4(), key=f"org.{slug}.recipe_cycle", org_id=org_id, name="테스트 레시피",
+        payload_schema=payload_schema or _CYCLE_SCHEMA, routing=_ROUTING,
+        stage_metadata=stage_metadata or {}, block_template=block_template,
+    )
+    session.add(d)
+    await session.commit()
+    return d.key
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+def _fake_request(*, project_id_header: uuid.UUID | None = None) -> "StarletteRequest":
+    """story #2674 — publish_registry_event의 X-Project-Id 헤더 폴백(work_item 참조가 다른
+    project를 가리키거나 애초에 못 풀 때 대비, test_2633_event_publish.py와 동형 패턴)."""
+    from starlette.requests import Request as StarletteRequest
+
+    headers = []
+    if project_id_header is not None:
+        headers.append((b"x-project-id", str(project_id_header).encode()))
+    return StarletteRequest(scope={"type": "http", "headers": headers})
+
+
+async def _publish_and_get_content(
+    session, *, definition_key, payload, publisher_id, org_id, project_id_header=None,
+):
+    from app.routers.events import EventPublishRequest, publish_registry_event
+    from app.models.conversation import ConversationMessage
+
+    resp = await publish_registry_event(
+        EventPublishRequest(definition_key=definition_key, payload=payload),
+        BackgroundTasks(), _fake_request(project_id_header=project_id_header),
+        db=session, auth=_auth(publisher_id, org_id), org_id=org_id,
+    )
+    from sqlalchemy import select
+
+    msg = (await session.execute(
+        select(ConversationMessage).where(ConversationMessage.id == uuid.UUID(resp["message_id"]))
+    )).scalar_one()
+    return msg.content, resp
+
+
+def _generic_expected(definition_key: str, payload: dict) -> str:
+    lines = [f"[이벤트] {definition_key}"]
+    lines += [f"- {k}: {v}" for k, v in payload.items()]
+    return "\n".join(lines)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_stage_event_without_block_template_renders_role_action_next_stage_and_example():
+    """⭐AC1 핵심 — block_template=null인 사이클형 정의의 stage 이벤트 알림에 role·action·
+    다음 stage·다음 발행 예시가 실린다."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="e3313a")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_definition(
+                s, org_id, slug="e3313a",
+                stage_metadata={
+                    "monitor": {"role": "Scout", "action": "주제·신호 감지, 후보 콘텐츠 아이디어 수집"},
+                    "research": {"role": "Researcher", "action": "근거 자료 수집"},
+                    "draft": {"role": "Writer", "action": "초안 작성"},
+                },
+            )
+            content, _resp = await _publish_and_get_content(
+                s, definition_key=definition_key,
+                payload={"stage": "monitor", "work_item_type": "story", "work_item_id": str(story_id)},
+                publisher_id=publisher_id, org_id=org_id,
+            )
+
+            assert "- stage: monitor (Scout)" in content
+            assert "- 할 일: 주제·신호 감지, 후보 콘텐츠 아이디어 수집" in content
+            assert "- 다음 단계: research (Researcher)" in content
+            example_line = next(
+                line for line in content.splitlines()
+                if line.startswith("- 다음 단계로 넘기는 발행 예시: publish_event(")
+            )
+            example_json = example_line.removeprefix(
+                "- 다음 단계로 넘기는 발행 예시: publish_event("
+            ).removesuffix(")")
+            example = json.loads(example_json)
+            assert example["definition_key"] == definition_key
+            assert example["payload"]["stage"] == "research"
+            assert example["payload"]["work_item_id"] == str(story_id)
+            assert f"[캠페인 아이디어 후보](entity:story:{story_id})" in content
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_last_stage_has_no_next_stage_line():
+    """마지막 stage(다음 stage 없음)는 "없음(마지막 stage)"으로 명시 — 지어내지 않음."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="e3313b")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_definition(
+                s, org_id, slug="e3313b",
+                stage_metadata={
+                    "monitor": {"role": "Scout", "action": "감지"},
+                    "research": {"role": "Researcher", "action": "조사"},
+                    "draft": {"role": "Writer", "action": "작성"},
+                },
+            )
+            content, _resp = await _publish_and_get_content(
+                s, definition_key=definition_key,
+                payload={"stage": "draft", "work_item_type": "story", "work_item_id": str(story_id)},
+                publisher_id=publisher_id, org_id=org_id,
+            )
+            assert "- 다음 단계: 없음(마지막 stage)" in content
+            assert "publish_event(" not in content
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_unresolvable_work_item_falls_back_to_raw_id():
+    """work item title을 못 찾으면(작업 자체는 실존하지만 work_item_type이 이 렌더러가
+    지원하는 story/task가 아님 — 예: doc) 참조 토큰 대신 원시 work_item_type/work_item_id를
+    그대로 남긴다(정보 손실 없음, 지어내지 않음). 실존하지 않는 id 대신 실 Doc을 써서 "project
+    해소 실패"(별개 관심사, #2674)와 "title lookup 미지원 타입"을 섞지 않는다."""
+    from app.models.doc import Doc
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="e3313c")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            doc = Doc(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="어떤 문서",
+                slug=f"doc-{uuid.uuid4().hex[:8]}",
+            )
+            s.add(doc)
+            await s.commit()
+
+            schema = {
+                "type": "object", "additionalProperties": False,
+                "required": ["stage", "work_item_type", "work_item_id"],
+                "properties": {
+                    "stage": {"type": "string", "enum": ["monitor"]},
+                    "work_item_type": {"type": "string"},
+                    "work_item_id": {"type": "string", "format": "uuid"},
+                },
+            }
+            definition_key = await _seed_definition(
+                s, org_id, slug="e3313c",
+                stage_metadata={"monitor": {"role": "Scout", "action": "감지"}},
+                payload_schema=schema,
+            )
+            content, _resp = await _publish_and_get_content(
+                s, definition_key=definition_key,
+                payload={"stage": "monitor", "work_item_type": "doc", "work_item_id": str(doc.id)},
+                publisher_id=publisher_id, org_id=org_id,
+            )
+            assert "- work_item_type: doc" in content
+            assert f"- work_item_id: {doc.id}" in content
+            assert "entity:doc:" not in content
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_definition_with_block_template_renders_byte_identical_to_old_generic():
+    """⭐AC3-① — block_template이 있는 정의는 이 스토리 이전과 바이트 동일(회귀 0). P2(#2637)
+    FE 렌더러가 그 정의를 이미 담당하므로 이 plain body는 손대지 않는다."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="e3313d")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_definition(
+                s, org_id, slug="e3313d",
+                stage_metadata={"monitor": {"role": "Scout", "action": "감지"}},
+                block_template={"title": "템플릿 있음"},
+            )
+            payload = {"stage": "monitor", "work_item_type": "story", "work_item_id": str(story_id)}
+            content, _resp = await _publish_and_get_content(
+                s, definition_key=definition_key, payload=payload, publisher_id=publisher_id, org_id=org_id,
+            )
+            assert content == _generic_expected(definition_key, payload)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_non_cyclic_definition_without_stage_metadata_renders_byte_identical():
+    """⭐AC3-② — PO 확定(2026-09-02): block_template 없는 정의라도 stage_metadata 자체가
+    빈(비사이클형) 정의는 바이트 동일(회귀 0) — 지어낼 role/action이 애초에 없다("담당자
+    없는 stage는 모르면 안 준다" 원칙과 동일)."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="e3313e")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            schema = {
+                "type": "object", "additionalProperties": False,
+                "required": ["work_item_type", "work_item_id"],
+                "properties": {"work_item_type": {"type": "string"}, "work_item_id": {"type": "string", "format": "uuid"}},
+            }
+            definition_key = await _seed_definition(
+                s, org_id, slug="e3313e", stage_metadata={}, payload_schema=schema,
+            )
+            payload = {"work_item_type": "story", "work_item_id": str(story_id)}
+            content, _resp = await _publish_and_get_content(
+                s, definition_key=definition_key, payload=payload, publisher_id=publisher_id, org_id=org_id,
+            )
+            assert content == _generic_expected(definition_key, payload)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_stage_not_registered_in_stage_metadata_falls_back_to_generic():
+    """stage가 payload_schema.enum엔 있는데 stage_metadata에는 등재 안 됐으면(누락) 지어내지
+    않고 기존 폴백으로 — 이 케이스는 validate_stage_metadata가 등록 시점에 이미 stage_metadata
+    ⊆ enum만 강제하지 enum ⊆ stage_metadata까진 강제 안 하므로(부분 정의 허용) 실제로 있을 수
+    있는 조합."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="e3313f")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_definition(
+                s, org_id, slug="e3313f",
+                stage_metadata={"monitor": {"role": "Scout", "action": "감지"}},  # "research" 누락
+            )
+            payload = {"stage": "research", "work_item_type": "story", "work_item_id": str(story_id)}
+            content, _resp = await _publish_and_get_content(
+                s, definition_key=definition_key, payload=payload, publisher_id=publisher_id, org_id=org_id,
+            )
+            assert content == _generic_expected(definition_key, payload)
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_3313_recipe_notification_render.py
+++ b/backend/tests/test_3313_recipe_notification_render.py
@@ -339,3 +339,31 @@ async def test_stage_not_registered_in_stage_metadata_falls_back_to_generic():
             assert content == _generic_expected(definition_key, payload)
     finally:
         await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_legacy_stage_metadata_missing_action_falls_back_without_crashing_publish():
+    """⭐PO 리뷰(페드루, 2026-09-02) — validate_stage_metadata의 role/action 필수 검증은
+    2026-08-19 이후 "쓰기 시점" 가드라, 그 전에 저장된 정의는 role/action이 누락된 채 DB에
+    남아있을 수 있다(이 테스트가 그 레거시 shape을 직접 재현). 직접 인덱싱이면 publish 자체가
+    KeyError로 죽어 "알림 개선이 발행 회귀"가 됐을 자리 — .get() 방어로 발행은 성공하고
+    본문은 기존 제네릭으로 안전 폴백해야 한다."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="e3313g")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_definition(
+                s, org_id, slug="e3313g",
+                # action 누락(레거시) — validate_stage_metadata 신설 前 저장됐을 법한 shape.
+                stage_metadata={"monitor": {"role": "Scout"}},
+            )
+            payload = {"stage": "monitor", "work_item_type": "story", "work_item_id": str(story_id)}
+            content, _resp = await _publish_and_get_content(
+                s, definition_key=definition_key, payload=payload, publisher_id=publisher_id, org_id=org_id,
+            )  # KeyError 없이 여기까지 도달하는 것 자체가 핵심 단언.
+            assert content == _generic_expected(definition_key, payload)
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 배경
[[마케팅자동화·온보딩 결함] 레시피 stage 이벤트 알림이 «뭘 하라»(stage_metadata.action)와 «다음 단계» 힌트를 싣지 않는다](entity:story:92c23382-03f8-4dec-afd1-e33466850d8d)(#3313) — `block_template=null`인 사이클형 정의(마케팅 레시피 등)의 stage 이벤트 알림이 `"[이벤트] key\n- stage: X\n- work_item_id: Y"`뿐이라, 수신 에이전트가 `list_event_definitions` 조회+스토리 정독 없이는 다음 행동을 몰랐다(담롱 실측 — 온보딩 철학 "최저 지능 LLM도 이벤트만 보고 척척" 미달).

## 처방
`_render_event_message_content`(routers/events.py, 유일 호출부)를 `definition` 전체+`db`/`org_id`를 받게 확장 — `block_template`가 없고 `stage_metadata`가 있는 정의만 새 렌더로 분기:
- `stage_metadata[stage].role/action`을 본문에 그대로 옮김(문구 새로 안 지음)
- `payload_schema.stage.enum`에서 다음 stage 도출 + `publish_event(definition_key+payload 골격)` 발행 예시(값 없이 구조만)
- work item을 `build_reference_token`(기존 SSOT, story #2282)으로 클릭 참조 토큰화 — 지원 타입(story/task) 밖이거나 못 찾으면 원시 id 폴백(정보 손실 없음)

**PO 확定 두 못박음(2026-09-02)**: ①조직 규칙/우리 문구 하드코딩 0 — role/action/발행예시 전부 정의·payload에서만 파생 ②AC3 회귀 0 범위는 block_template 있는 정의뿐 아니라 stage_metadata가 빈 비사이클형 정의도 포함(둘 다 손 안 댐).

## AC 커버리지
- AC1(role/action/다음단계/발행예시 렌더) — `test_stage_event_without_block_template_renders_role_action_next_stage_and_example`, `test_last_stage_has_no_next_stage_line`
- AC2(work item 클릭 참조 토큰) — 위 테스트에 포함(`entity:story:` 토큰 단언). 미지원 타입 폴백 — `test_unresolvable_work_item_falls_back_to_raw_id`
- AC3(회귀 0, 두 갈래) — `test_definition_with_block_template_renders_byte_identical_to_old_generic`(①) / `test_non_cyclic_definition_without_stage_metadata_renders_byte_identical`(②) — 둘 다 바이트 동일 단언
- 부가: stage가 payload_schema.enum엔 있는데 stage_metadata에 등재 안 된 부분정의 케이스도 기존 폴백 유지 — `test_stage_not_registered_in_stage_metadata_falls_back_to_generic`
- ⛔AC4(라이브 실증 — 담롱 온보딩 측정 YES) — dev 배포 후 확認 필요, 이 PR 스코프 밖(PO 지침대로 done 前 명시)
- AC5(조직 상수 0) — 위 처방 참고, 코드 리뷰로 실증

## 검증
로컬 realdb(전용 throwaway DB): 신규 6개 전부 PASS + 기존 `test_2633_event_publish.py`/`test_2665_event_publish_history.py`(destructive) 19개 전부 PASS(회귀 0), 총 25개.

develop 기준 별 브랜치(#3704와 독립, PO 지침).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DfPLRWqGNvcf58NWYrYKba

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 실물 전/후 대조(정의 `org.moonklabs.marketing_content_pipeline`, 11344a2a, version 2, 페드루 제공 원문)

로컬에서 실제 stage_metadata로 `_render_event_message_content`를 직접 돌린 결과(work_item_id가 로컬 DB엔 없는 story라 참조 토큰은 raw id로 폴백 — 실 dev에서는 그 story 제목이 실려 클릭 참조 토큰이 나온다).

**stage=monitor — BEFORE**
```
[이벤트] org.moonklabs.marketing_content_pipeline
- stage: monitor
- work_item_id: af821d06-bc93-4279-9c64-7d0a1738caf0
- work_item_type: story
```
**stage=monitor — AFTER**
```
[이벤트] org.moonklabs.marketing_content_pipeline
- stage: monitor (Agent)
- 할 일: 주제·신호 감지, 후보 콘텐츠 아이디어 수집 → 후보 3+선정 1을 doc으로 남기고 다음 stage(research) 발행
- 다음 단계: research (Agent)
- 다음 단계로 넘기는 발행 예시: publish_event({"definition_key": "org.moonklabs.marketing_content_pipeline", "payload": {"work_item_id": "af821d06-bc93-4279-9c64-7d0a1738caf0", "work_item_type": "story", "stage": "research"}})
- work_item_type: story
- work_item_id: af821d06-bc93-4279-9c64-7d0a1738caf0
```

**stage=approve — BEFORE**
```
[이벤트] org.moonklabs.marketing_content_pipeline
- stage: approve
- work_item_id: af821d06-bc93-4279-9c64-7d0a1738caf0
- work_item_type: story
```
**stage=approve — AFTER**
```
[이벤트] org.moonklabs.marketing_content_pipeline
- stage: approve (Human)
- 할 일: 초안 검토 후 external_publish 게이트 승인/반려 — 이 stage 바인딩은 알림 대상이고 실 승인은 Gate 전이가 한다(승인자=조직 owner)
- 다음 단계: publish (Agent)
- 다음 단계로 넘기는 발행 예시: publish_event({"definition_key": "org.moonklabs.marketing_content_pipeline", "payload": {"work_item_id": "af821d06-bc93-4279-9c64-7d0a1738caf0", "work_item_type": "story", "stage": "publish"}})
- work_item_type: story
- work_item_id: af821d06-bc93-4279-9c64-7d0a1738caf0
```

role/action 문구는 전부 `org.moonklabs.marketing_content_pipeline` 정의 자신의 stage_metadata 값 — 렌더러 코드엔 이 문구가 한 글자도 없다(다른 org가 다른 문구로 같은 구조를 등록해도 동일 메커니즘으로 그 org 자신의 문구가 실린다).
