### PR TITLE
[SID:3325] 레시피 승인 게이트 채팅카드 발송 + rejected 재오픈 카드 재발송 (PR C)

### DIFF
--- a/backend/app/services/recipe_gate_hooks.py
+++ b/backend/app/services/recipe_gate_hooks.py
@@ -12,6 +12,7 @@ core + 단일목적 서비스 호출 컴포지션)와 정합, 테스트도 격�
 동일 원칙, resolve_routing_leg 참조)."""
 from __future__ import annotations
 
+import logging
 import uuid
 
 from sqlalchemy import and_, or_, select
@@ -20,6 +21,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.project import OrgMember
 from app.services.event_definition_registry import APPROVER_ROLE_REFERENCES
 from app.services.reference_token import build_reference_token
+
+logger = logging.getLogger(__name__)
 
 # PO 확定(페드루, 2026-09-02, 변경요청①) — 값을 지어내지 않는다: 못 찾은 필드는 이 sentinel로
 # 명시한다("가서 보라" 금지 — story #3312 처방 3과 동형, 결재 카드에 실물이 안 보이면 그
@@ -173,7 +176,20 @@ async def maybe_create_stage_gate(
 
     stage/work_item 정보가 payload에 없거나, 그 stage에 gate 선언이 없으면 완전 no-op —
     선언 없는 정의(다른 레시피)의 stage 이벤트는 이 함수를 거쳐도 아무 부수효과가 없다
-    (AC3 회귀 0)."""
+    (AC3 회귀 0).
+
+    story #3325/#0e3abfaf(PO 확定, 2026-09-02, PR C) — create_gate 뒤 채팅 결재 카드까지
+    이어 보낸다(결재함 탭에만 서고 채팅 알림이 0이던 결함). 범용 create_gate()/
+    _reopen_rejected_gate()는 무변경 — 이 훅(caller) 쪽에서만 기존 게이트 status를
+    호출 전에 먼저 조회해 세 갈래로 가른다:
+      - 기존 없음(신규) 또는 rejected(→ create_gate가 _reopen_rejected_gate로 pending
+        재오픈) → 카드 발송(best-effort, 실패해도 게이트 생성/재오픈 자체는 되돌리지
+        않음 — create_gate의 gate.pending_approval 알림과 동일 관례).
+      - voided(admin이 명시 무효화, #04e69c5f/#2150 AC5 — 자동 재오픈 대상 아님) →
+        create_gate는 그대로 voided 반환(부수효과 0), 이 훅은 명시 로그만 남긴다
+        ("왜 카드가 안 서는지"가 완전 침묵이던 것을 관측 가능하게).
+      - 이미 pending(재발행 반복) → create_gate 그대로 멱등 반환, 카드 재발송 없음
+        (같은 승인 요청을 반복 스팸하지 않는다)."""
     stage = payload.get("stage")
     work_item_type = payload.get("work_item_type")
     work_item_id_raw = payload.get("work_item_id")
@@ -197,13 +213,54 @@ async def maybe_create_stage_gate(
         work_item_type=work_item_type, work_item_id=work_item_id, payload=payload,
     )
 
-    from app.services.gate_service import create_gate
+    from app.services.approval_delivery import dispatch_approval_request_cards
+    from app.services.gate_service import (
+        create_gate,
+        find_gate_slot_with_pr_fallback,
+        resolve_work_item_project_id,
+    )
     from app.services.workflow_line_config import _default_role_id
 
+    gate_type = gate_decl["type"]
+
+    # 카드 발송 여부 판단은 create_gate() 호출 *전* status로만 가능하다 — 호출 후에는
+    # "신규 pending"과 "이미 pending이던 슬롯"이 똑같이 status=="pending"으로 구분이
+    # 안 된다(post-call 값만으론 전이를 모른다).
+    existing = await find_gate_slot_with_pr_fallback(
+        db, org_id=org_id, work_item_id=work_item_id, work_item_type=work_item_type,
+        gate_type=gate_type, pr_number=None, repo_full_name=None,
+    )
+    previous_status = existing.status if existing is not None else None
+
     role_id = await _default_role_id(db, org_id) or uuid.uuid4()
-    await create_gate(
-        db, org_id, work_item_id, work_item_type, gate_decl["type"],
+    gate = await create_gate(
+        db, org_id, work_item_id, work_item_type, gate_type,
         requester_member_id, role_id,
         neutral_facts=neutral_facts,
         designated_approver_id=approver_id,
     )
+
+    if gate.status == "voided":
+        logger.info(
+            "recipe stage gate stays voided — admin 판단 필요(자동 재오픈 대상 아님) "
+            "gate_id=%s org_id=%s work_item_type=%s work_item_id=%s stage=%s",
+            gate.id, org_id, work_item_type, work_item_id, stage,
+        )
+        return
+
+    if gate.status != "pending" or previous_status not in (None, "rejected"):
+        return
+
+    project_id = await resolve_work_item_project_id(db, org_id, work_item_type, work_item_id)
+    try:
+        await dispatch_approval_request_cards(
+            db, org_id=org_id, work_item_type=work_item_type, work_item_id=work_item_id,
+            project_id=project_id, title=neutral_facts["work_item_title"], gate_id=gate.id,
+            requester_id=requester_member_id, approver_ids=[approver_id],
+            designated_approver_id=approver_id,
+        )
+    except Exception:
+        logger.warning(
+            "recipe stage gate approval card dispatch failed gate_id=%s (best-effort, swallowed)",
+            gate.id, exc_info=True,
+        )

--- a/backend/tests/test_3325_recipe_gate_card_reopen.py
+++ b/backend/tests/test_3325_recipe_gate_card_reopen.py
@@ -1,0 +1,369 @@
+"""story #3325(4a016f5a)/#3326(0e3abfaf) — PR C. PO 확定(페드루, 2026-09-02):
+
+①recipe_gate_hooks.maybe_create_stage_gate가 create_gate() 뒤 채팅 결재 카드까지 이어
+보낸다(결재함 탭에만 서고 채팅 알림 0이던 결함 — #4a016f5a).
+②기존 게이트 status별 처리(#0e3abfaf 재프레임) — rejected는 `_reopen_rejected_gate`
+재사용으로 pending 복귀+카드 재발송, voided는 admin 판단 유지(#04e69c5f/#2150 AC5,
+자동 재오픈 대상 아님)로 0건+명시 로그, pending은 멱등(카드 재발송 없음).
+
+범용 create_gate()/_reopen_rejected_gate()는 무변경 — 전부 recipe_gate_hooks.py의
+호출부(caller) 쪽에서만 처리한다(PO 지시, 최소 blast radius)."""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_with_owner(session, *, slug="acme3325"):
+    """#3312의 동명 헬퍼와 달리, 승인자(owner)를 채팅 카드 수신자로도 쓰므로 TeamMember 행을
+    같이 심는다 — ConversationParticipant.member_id는 team_members.id FK(NOT NULL)라, 카드
+    dispatch(신규 축, ①)가 실제로 도달하려면 owner가 team_members에도 있어야 한다
+    (test_3001_gate_delegate_realdb.py::_seed_org_member와 동일 이유)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.team import TeamMember
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org3325", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    owner_user = User(id=uuid.uuid4(), email=f"owner-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(owner_user)
+    await session.commit()
+    owner_member = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=owner_user.id, role="owner")
+    session.add(owner_member)
+    await session.commit()
+    session.add(TeamMember(
+        id=owner_member.id, org_id=org.id, project_id=project.id, type="human", name="owner", is_active=True,
+    ))
+    await session.commit()
+    return org.id, project.id, owner_member.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="레시피 산출물")
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+_CYCLE_SCHEMA = {
+    "type": "object", "additionalProperties": False,
+    "required": ["stage", "work_item_type", "work_item_id"],
+    "properties": {
+        "stage": {"type": "string", "enum": ["draft", "approve", "publish"]},
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+        "channel": {"type": "string"},
+    },
+}
+_CYCLE_ROUTING = {
+    "escalation": {"kind": "server_derived", "target": "none"},
+    "broadcast": {"kind": "server_derived", "target": "none"},
+}
+
+
+async def _seed_recipe_definition(session, org_id, *, slug, stage_metadata):
+    from app.models.event_definition import EventDefinition
+
+    d = EventDefinition(
+        id=uuid.uuid4(), key=f"org.{slug}.recipe_cycle", org_id=org_id, name="테스트 레시피",
+        payload_schema=_CYCLE_SCHEMA, routing=_CYCLE_ROUTING, stage_metadata=stage_metadata,
+    )
+    session.add(d)
+    await session.commit()
+    return d.key
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+def _fake_request() -> "StarletteRequest":
+    from starlette.requests import Request as StarletteRequest
+    return StarletteRequest(scope={"type": "http", "headers": []})
+
+
+async def _publish_approve(session, org_id, publisher_id, definition_key, story_id):
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    body = EventPublishRequest(
+        definition_key=definition_key,
+        payload={"stage": "approve", "work_item_type": "story", "work_item_id": str(story_id)},
+    )
+    await publish_registry_event(
+        body, BackgroundTasks(), _fake_request(), db=session, auth=_auth(publisher_id, org_id), org_id=org_id,
+    )
+
+
+async def _card_messages_for_gate(session, gate_id, approver_id):
+    from app.models.conversation import ConversationMessage
+    from sqlalchemy import select
+
+    return (await session.execute(
+        select(ConversationMessage).where(
+            ConversationMessage.msg_metadata["approval_target"]["gate_id"].astext == str(gate_id),
+            ConversationMessage.mentioned_ids.contains([approver_id]),
+        )
+    )).scalars().all()
+
+
+_STAGE_METADATA = {
+    "approve": {
+        "role": "Approver", "action": "승인",
+        "gate": {"type": "external_publish", "approver": "org_owner"},
+    },
+}
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_fresh_pending_gate_dispatches_approval_card():
+    """①⭐신규 pending 게이트가 생성되면 지정 승인자(org owner) DM에 카드 1건이 실제로
+    선다(approval_target.gate_id=이 게이트, mentioned_ids에 owner 포함) — 결재함에만 서고
+    채팅 알림 0이던 결함의 근본수정."""
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_id = await _seed_org_with_owner(s, slug="acme3325a")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_recipe_definition(
+                s, org_id, slug="acme3325a", stage_metadata=_STAGE_METADATA,
+            )
+
+            await _publish_approve(s, org_id, publisher_id, definition_key, story_id)
+
+            gate = (await s.execute(
+                select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "external_publish")
+            )).scalar_one()
+            assert gate.status == "pending"
+
+            msgs = await _card_messages_for_gate(s, gate.id, owner_id)
+            assert len(msgs) == 1, f"카드가 정확히 1건 서야 함 — {len(msgs)}건"
+            assert msgs[0].msg_metadata["approval_target"]["designated"] is True
+            assert msgs[0].msg_metadata["activation"]["kind"] == "request"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_pending_gate_republish_is_idempotent_no_duplicate_card():
+    """③이미 pending인 슬롯에 approve가 다시 발행돼도(재시도류) 게이트는 여전히 1건이고
+    (기존 AC2), 카드도 반복 재발송되지 않는다(같은 승인 요청 스팸 방지, PO 확定)."""
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_id = await _seed_org_with_owner(s, slug="acme3325b")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_recipe_definition(
+                s, org_id, slug="acme3325b", stage_metadata=_STAGE_METADATA,
+            )
+
+            await _publish_approve(s, org_id, publisher_id, definition_key, story_id)
+            await _publish_approve(s, org_id, publisher_id, definition_key, story_id)
+
+            gates = (await s.execute(
+                select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "external_publish")
+            )).scalars().all()
+            assert len(gates) == 1
+
+            msgs = await _card_messages_for_gate(s, gates[0].id, owner_id)
+            assert len(msgs) == 1, f"멱등 pending 재발행에서 카드가 중복 발송됨 — {len(msgs)}건"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_rejected_gate_reopens_to_pending_and_resends_card_on_republish():
+    """②-a 진짜 제품 경로 — rejected 게이트가 있는 work item에 approve가 재발행되면
+    `_reopen_rejected_gate`(#04e69c5f 재제출 경로) 재사용으로 pending 복귀(신규 row
+    0건 — 감사이력 보존) + 지정 승인자에게 카드가 새로 1건 더 선다(최초 카드 이후 두
+    번째 카드, 합계 2건)."""
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_id = await _seed_org_with_owner(s, slug="acme3325c")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_recipe_definition(
+                s, org_id, slug="acme3325c", stage_metadata=_STAGE_METADATA,
+            )
+
+            await _publish_approve(s, org_id, publisher_id, definition_key, story_id)
+
+            gate = (await s.execute(
+                select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "external_publish")
+            )).scalar_one()
+            gate_id_before = gate.id
+            gate.status = "rejected"
+            gate.resolver_id = owner_id
+            gate.resolved_at = dt.datetime.now(dt.timezone.utc)
+            gate.resolution_note = "부적합"
+            await s.commit()
+
+            await _publish_approve(s, org_id, publisher_id, definition_key, story_id)
+
+            gates = (await s.execute(
+                select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "external_publish")
+            )).scalars().all()
+            assert len(gates) == 1, "신규 row가 생기면 안 됨(재오픈=같은 row 재사용)"
+            assert gates[0].id == gate_id_before
+            assert gates[0].status == "pending", "rejected → 재발행 시 pending으로 재오픈돼야"
+            assert gates[0].resolver_id is None
+
+            msgs = await _card_messages_for_gate(s, gates[0].id, owner_id)
+            assert len(msgs) == 2, f"최초 카드+재오픈 카드=2건이어야 — {len(msgs)}건"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_voided_gate_stays_voided_zero_new_gate_and_logs_explicitly(caplog):
+    """②-b voided는 admin의 명시 무효화(#04e69c5f/#2150 AC5) — 자동 재오픈 대상이 아니다.
+    approve 재발행해도 새 게이트 0건(회귀 없음, 기존 voided row 그대로)·카드도 0건, 대신
+    "왜 안 갔는지"가 침묵이 아니라 명시 로그로 관측 가능해야 한다."""
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_id = await _seed_org_with_owner(s, slug="acme3325d")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_recipe_definition(
+                s, org_id, slug="acme3325d", stage_metadata=_STAGE_METADATA,
+            )
+
+            # admin이 직접 void한 게이트를 재현(hook을 거치지 않고 미리 심는다 — void_gate_
+            # endpoint 자체는 story #S30 범위, 여기선 그 사후 상태만 재현).
+            voided_gate = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="external_publish", status="voided", designated_approver_id=owner_id,
+                resolver_id=owner_id, resolved_at=dt.datetime.now(dt.timezone.utc),
+                resolution_note="admin_void: 좀비 방지",
+            )
+            s.add(voided_gate)
+            await s.commit()
+            voided_gate_id = voided_gate.id
+
+            with caplog.at_level(logging.INFO, logger="app.services.recipe_gate_hooks"):
+                await _publish_approve(s, org_id, publisher_id, definition_key, story_id)
+
+            gates = (await s.execute(
+                select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "external_publish")
+            )).scalars().all()
+            assert len(gates) == 1, f"voided에서 새 게이트가 생기면 안 됨 — {len(gates)}건"
+            assert gates[0].id == voided_gate_id
+            assert gates[0].status == "voided"
+
+            msgs = await _card_messages_for_gate(s, voided_gate_id, owner_id)
+            assert msgs == [], "voided 상태에서 카드가 새면 안 됨"
+
+            assert any(
+                "voided" in rec.message and str(voided_gate_id) in rec.message
+                for rec in caplog.records
+            ), "voided no-op이 명시 로그로 관측 가능해야 함(완전 침묵 금지)"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_card_dispatch_failure_does_not_roll_back_gate_creation():
+    """카드 배달은 best-effort — dispatch_approval_request_cards가 실패해도 게이트
+    생성/재오픈 자체는 되돌아가지 않는다(create_gate()의 gate.pending_approval 알림과
+    동일 관례, monkeypatch로 강제 실패 재현)."""
+    from app.models.gate import Gate
+    from sqlalchemy import select
+    import app.services.recipe_gate_hooks as hooks_module
+
+    async def _boom(*_a, **_kw):
+        raise RuntimeError("card delivery boom")
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_id = await _seed_org_with_owner(s, slug="acme3325e")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            definition_key = await _seed_recipe_definition(
+                s, org_id, slug="acme3325e", stage_metadata=_STAGE_METADATA,
+            )
+
+            import app.services.approval_delivery as approval_delivery_module
+            original = approval_delivery_module.dispatch_approval_request_cards
+            approval_delivery_module.dispatch_approval_request_cards = _boom
+            try:
+                await _publish_approve(s, org_id, publisher_id, definition_key, story_id)
+            finally:
+                approval_delivery_module.dispatch_approval_request_cards = original
+
+            gate = (await s.execute(
+                select(Gate).where(Gate.work_item_id == story_id, Gate.gate_type == "external_publish")
+            )).scalar_one()
+            assert gate.status == "pending", "카드 배달 실패가 게이트 생성 자체를 되돌리면 안 됨"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 요약
- approve stage 게이트 자동생성(#3312)이 결재함 탭에만 서고 채팅 카드가 0건이던 결함 처방(story #4a016f5a).
- 기존 게이트 status별 재발행 처리 명확화(story #0e3abfaf, PO 재프레임 2026-09-02):
  - 없음/`rejected` → `create_gate()`가 기존 `_reopen_rejected_gate` 경로로 pending 생성/재오픈 → 훅이 `dispatch_approval_request_cards()`를 best-effort로 이어 호출(신규 생성이든 재오픈이든 동일 배선, 카드 실패가 게이트 생성/재오픈 자체를 되돌리지 않음).
  - `voided` → admin의 명시 무효화(#04e69c5f/#2150 AC5, "자동 재오픈 대상 아님" 설계 그대로 유효) — 새 게이트 0건 유지, 대신 `logger.info`로 명시 관측 가능(이전엔 완전 침묵).
  - `pending`(이미 대기 중) → 멱등, 카드 재발송 없음(스팸 방지).
- 범용 `gate_service.py::create_gate()`/`_reopen_rejected_gate()`는 **완전 무변경** — 전부 `recipe_gate_hooks.py::maybe_create_stage_gate`(호출부) 쪽에서만 처리해 blast radius를 이 훅 하나로 좁혔다(PO 지시).

## 근거
- [\[결재·결함\] 카드 미도달](https://app.sprintable.ai) — story #4a016f5a(3325)
- [\[결재·정리\] 게이트 상태별 처리 명확화](https://app.sprintable.ai) — story #0e3abfaf(3326)
- develop 최신(#3706/#3707 포함) 기준.

## 테스트
`backend/tests/test_3325_recipe_gate_card_reopen.py` — 실 Postgres 왕복(create_all), 5케이스:
1. 신규 pending → 카드 1건(approval_target.gate_id + mentioned_ids 실 왕복).
2. pending 재발행 → 게이트 1건·카드 1건 유지(멱등, 중복 발송 없음).
3. `rejected` → 재발행 → 같은 row가 pending으로 재오픈(신규 row 0)·카드 2건째 발송.
4. `voided` → 재발행 → 새 게이트 0건·카드 0건·명시 로그 1건(caplog로 검증).
5. 카드 배달 실패(monkeypatch)에도 게이트 생성 자체는 롤백되지 않음.

뮤테이션 셀프체크: 카드 발송 호출부를 제거하고 재실행 → fresh/idempotent/rejected 3케이스가 정확히 그 자리(`assert len(msgs) == 1`)에서 RED로 실패함을 확인 후 원복.

회귀: `test_3312_approve_stage_gate_auto_creation.py`·`test_3313_recipe_notification_render.py`·`test_2524_gate_reopen_requires_human.py`(범용 재오픈 pin) 전부 그린 — `gate_service.py` 무변경이라 merge/doc 등 다른 gate_type은 완전 무영향.

## 다음
- 3번째 바퀴: [previous_output_doc_id 체인·doc id 참조 토큰화](https://app.sprintable.ai) — story #e62a02de, 별 PR.
- dev 배포는 이 PR+위 스토리 묶어 배치 1회(PO 방침).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfPLRWqGNvcf58NWYrYKba