### PR TITLE
[SID:3330] 게이트 rejected/approved 판정이 실행자에게 도달하지 않던 결함 정정

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1326,10 +1326,22 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
     if draft_doc_ref:
         lines.append(f"- 대상 산출물: {draft_doc_ref}")
 
+    # 페드루 리뷰(PR#3711) — "approve 게이트를 다시 발행"은 실재하지 않는 동작(게이트는
+    # 발행 대상이 아니라 이벤트 발행의 부산물)이라 최저 지능 에이전트가 그대로 따라도
+    # 실패하지 않을 실제 동작으로 정정: rejected는 「산출물 수정→같은 정의의 approve
+    # stage 이벤트 재발행(게이트는 그 발행에 자동 재오픈됨)」, approved는 「이 정의의
+    # 다음 stage 이벤트 발행」.
     if verdict == "rejected":
-        lines.append("- 다음 행동: 반려 사유를 반영해 수정한 뒤 approve 게이트를 다시 발행하세요.")
+        lines.append(
+            "- 다음 행동: 산출물을 수정한 뒤, 같은 레시피 정의의 approve stage 이벤트를 "
+            "다시 발행하세요(payload.previous_output_doc_id=수정본 id) — 게이트는 그 "
+            "발행으로 자동 재오픈됩니다."
+        )
     elif verdict == "approved":
-        lines.append("- 다음 행동: 다음 stage를 진행하세요.")
+        lines.append(
+            "- 다음 행동: 이 정의의 다음 stage 이벤트를 발행하세요(publish 단계라면 이 "
+            "승인 게이트를 확認하는 발행 도구를 쓰세요)."
+        )
 
     return "\n".join(lines)
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1267,6 +1267,73 @@ async def _tokenize_embedded_entity_refs(db: AsyncSession, *, org_id: uuid.UUID,
     return await _async_regex_sub(_EMBEDDED_HEX8_RE, _replace_prefix, text)
 
 
+async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, payload: dict) -> str:
+    """story #3330 — `preset.gate.verdict` 전용 렌더. 승인/반려 대상 work item·게이트
+    종류·판정·(반려 시) 사유·대상 산출물 doc 클릭 토큰·다음 행동을 담는다(AC2, #3323이
+    stage 알림에 한 것과 같은 규격). `preset.gate.verdict`는 `stage_metadata`가 없는
+    비사이클형 정의라 `_render_event_message_content`의 사이클 분기를 안 타므로 별도
+    함수로 둔다.
+
+    draft_doc_reference_token은 payload 계약에 없다(스키마 변경 0, AC4 "새 경로 발명
+    0") — `recipe_gate_hooks.py::_build_approval_neutral_facts`가 게이트 생성 시점에
+    이미 계산해 둔 `neutral_facts`를 게이트 행 재조회로 그대로 재사용한다(새로 계산
+    안 함)."""
+    from app.models.gate import Gate
+
+    work_item_type = payload.get("work_item_type")
+    work_item_id_raw = payload.get("work_item_id")
+    gate_type = payload.get("gate_type")
+    verdict = payload.get("verdict")
+    resolution_note = payload.get("resolution_note")
+
+    work_item_id: uuid.UUID | None = None
+    if work_item_id_raw:
+        try:
+            work_item_id = uuid.UUID(str(work_item_id_raw))
+        except (ValueError, AttributeError, TypeError):
+            work_item_id = None
+
+    lines = ["[이벤트] preset.gate.verdict"]
+
+    work_item_ref: str | None = None
+    if work_item_type and work_item_id is not None:
+        work_item_ref = await _render_event_notification_work_item_ref(
+            db, org_id=org_id, work_item_type=work_item_type, work_item_id=work_item_id,
+        )
+    if work_item_ref:
+        lines.append(f"- work item: {work_item_ref}")
+    elif work_item_id_raw:
+        lines.append(f"- work_item_id: {work_item_id_raw}")
+
+    lines.append(f"- 게이트: {gate_type} → {verdict}")
+
+    if verdict == "rejected" and resolution_note:
+        lines.append(f"- 반려 사유: {resolution_note}")
+
+    draft_doc_ref: str | None = None
+    if work_item_type and work_item_id is not None and gate_type:
+        gate_row = (await db.execute(
+            select(Gate).where(
+                Gate.org_id == org_id, Gate.work_item_id == work_item_id,
+                Gate.work_item_type == work_item_type, Gate.gate_type == gate_type,
+                Gate.status == verdict,
+            ).order_by(Gate.resolved_at.desc()).limit(1)
+        )).scalar_one_or_none()
+        if gate_row is not None:
+            token = (gate_row.neutral_facts or {}).get("draft_doc_reference_token")
+            if token and token != "미확認":
+                draft_doc_ref = token
+    if draft_doc_ref:
+        lines.append(f"- 대상 산출물: {draft_doc_ref}")
+
+    if verdict == "rejected":
+        lines.append("- 다음 행동: 반려 사유를 반영해 수정한 뒤 approve 게이트를 다시 발행하세요.")
+    elif verdict == "approved":
+        lines.append("- 다음 행동: 다음 stage를 진행하세요.")
+
+    return "\n".join(lines)
+
+
 async def _render_event_message_content(
     db: AsyncSession, *, org_id: uuid.UUID, definition, payload: dict,
 ) -> str:
@@ -1281,7 +1348,13 @@ async def _render_event_message_content(
     definition_key+payload 골격만(값 없이 구조만). 회귀 0인 두 갈래(둘 다 기존 제네릭
     그대로): ①block_template가 있는 정의(P2 렌더러가 그 정의는 이미 담당) ②stage_metadata가
     비어있는 비사이클형 정의("담당자 없는 stage는 모르면 안 준다" 원칙과 동일 — 지어낼
-    stage_metadata 자체가 없다)."""
+    stage_metadata 자체가 없다).
+
+    story #3330 — `preset.gate.verdict`는 `stage_metadata`가 없는 비사이클형 정의라
+    ②로 떨어져 여태 제네릭 폴백뿐이었다(반려 사유·산출물 링크·다음 행동이 전혀 안
+    실림). 그 키만 전용 렌더(`_render_gate_verdict_message`)로 먼저 갈라낸다."""
+    if definition.key == "preset.gate.verdict":
+        return await _render_gate_verdict_message(db, org_id=org_id, payload=payload)
     if definition.block_template is not None or not definition.stage_metadata:
         return "\n".join(_generic_event_message_lines(definition.key, payload))
 

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -844,6 +844,14 @@ async def transition_gate(
     # H1-S7: 사람 게이트 해소(approve/reject)를 verdict로 기록 — trust로 환류.
     await _record_gate_review_verdict(session, org_id, gate, new_status, resolver_id)
 
+    # story #3330 — verdict-capture(_GATE_TYPE_TO_VERDICT_SOURCE 소속 여부)와 완전히
+    # 독립적으로, "사람이 판정했다"는 사실 자체를 항상 실행자에게 통지한다(승인·반려
+    # 대칭). 예전엔 preset.gate.verdict 발행이 위 _record_gate_review_verdict 내부,
+    # verdict-capture 게이팅 뒤에 있어서 그 매핑에 없는 gate_type(예: external_publish —
+    # 이 스토리의 실제 사고)은 통지 자체가 안 나갔다(실측: 3바퀴 반려가 어떤 지속 표면에도
+    # 안 남음).
+    await _publish_gate_verdict_notification(session, org_id, gate, new_status, resolver_id)
+
     # HO-S7: cold-start(outcome 표본 부족)에서 사람의 keep/kill 결정을 seed로 기록(trust 본점수
     # 미포함·outcome 해소 후 calibration). merge·cold-start가 아니면 no-op.
     from app.services.cold_start_seed import record_cold_start_seed  # 순환 회피 lazy import.
@@ -1743,9 +1751,31 @@ async def _record_gate_review_verdict(
         facts["rubber_stamp_candidate"] = True
         gate.neutral_facts = facts
 
-    # story #2791(P0, event-workflow-unification-design-2790) — preset.gate.verdict 서버
-    # 자동발행. 위 record_verdict와 동일 게이팅(participation 존재·work_item_type=story)
-    # 스코프 그대로 — best-effort 격리는 호출자(여기) 몫.
+
+async def _publish_gate_verdict_notification(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    gate: Gate,
+    new_status: str,
+    resolver_id: uuid.UUID | None,
+) -> None:
+    """story #3330 — 게이트 approved/rejected 전이를 항상 실행자(work item 이해관계자)에게
+    통지한다(승인·반려 대칭).
+
+    ⛔이전엔 이 발행이 `_record_gate_review_verdict`(H1-S7, verdict-capture용) 안에 있어
+    `_GATE_TYPE_TO_VERDICT_SOURCE`(qa/deploy/merge/pr_review 4종뿐)에 없는 gate_type —
+    예: 이 스토리의 실제 사고인 external_publish — 는 통지 자체가 발행되지 않았다(3바퀴
+    실측: 반려가 채널·알림·이벤트 conversation 어디에도 안 남음, 승인자에게 내려가는 결재
+    카드 경로(#3325)는 정상인데 실행자에게 돌아오는 길만 비어 있었다). 이 함수는 그
+    verdict-capture 게이팅과 완전히 독립이다 — "사람이 판정했다"는 사실은 그 게이트
+    타입이 verdict-capture 대상인지와 무관하게 항상 통지 대상이다(story #2791이 만든
+    preset.gate.verdict 발행 자체는 그대로 재사용 — 새 경로 발명 0).
+
+    resolver_id 없으면 skip(시스템 auto-transition은 통지 주체가 사람이 아니다 — 기존
+    `_record_gate_review_verdict`의 동일 가드와 같은 이유)."""
+    if new_status not in ("approved", "rejected") or resolver_id is None:
+        return
+
     try:
         from app.routers.events import publish_preset_event
 
@@ -1757,6 +1787,9 @@ async def _record_gate_review_verdict(
                 "gate_type": gate.gate_type,
                 "verdict": new_status,
                 "resolver_member_id": str(resolver_id),
+                # story #3330 AC2 — 반려 사유 문구. 필드 자체는 #2791 스키마에 이미 있었으나
+                # (payload_schema.resolution_note) 값이 한 번도 채워진 적이 없었다.
+                "resolution_note": gate.resolution_note,
             },
         )
     except Exception:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -156,6 +156,44 @@ def _reset_schema_for_destructive_tests(request):
     yield
 
 
+# story #3330(PR#3711) CI 재현 — `_MARKER_NAME`(destructive_schema) 미부여 테스트 전체(=
+# non-destructive realdb 스위트, "Backend pytest" job) 대상 conftest autouse 승격. 근본원인
+# (실측 확認, CI와 동일 스택트레이스로 로컬 재현): `app.core.database.engine`(전역·프로세스
+# 수명)을 거치는 어떤 경로든(예: send_message의 background task `mark_agent_replied`, GET
+# /auth/me 등 실 HTTP 경유 라우터) 그 커넥션 풀에 "이전 pytest-anyio 이벤트 루프에 묶인"
+# 커넥션이 dispose 없이 남을 수 있다. pytest-anyio가 테스트마다 새 이벤트 루프를 만들기
+# 때문에, 다음 테스트가 pool_pre_ping으로 그 죽은 루프의 커넥션을 검사하려는 순간
+# `RuntimeError: ... got Future ... attached to a different loop`(asyncpg 취소 경로가
+# 이미 닫힌 루프에 task를 만들려다 남)로 죽는다.
+#
+# ⛔어느 특정 테스트 파일이 "범인"인지는 구조적으로 예측 불가능하다 — 전역 엔진 경로를
+# 타는지 여부는 그 테스트가 호출하는 프로덕션 코드의 내부 구현(예: transition_gate가
+# 어떤 gate_type에서 알림을 발행하는지)에 달려 있고, 그 프로덕션 코드는 테스트 작성자가
+# 매번 추적할 수 있는 게 아니다 — 파일 단위 opt-in fixture(`_dispose_global_engine_
+# after_test`, 246개 파일이 개별로 붙여 옴)는 "그 파일 작성자가 이 위험을 알고 있었는가"에
+# 의존하는 구조적 구멍이다(story #3330 PR#3711 CI flake가 정확히 이 구멍으로 재현 — 무관한
+# 다른 non-destructive 테스트가 새 프로덕션 코드 경로를 처음 타면서 dispose 없이 커넥션을
+# 남기고, 알파벳 순 다음 테스트가 그 죽은 커넥션을 집어 죽었다). 파일 단위 fixture를 계속
+# 개별 추가하는 대신, **모든** non-destructive 테스트 뒤에 무조건 dispose하는 쪽이 근본
+# 처방이다 — "이 테스트가 전역 엔진을 쓰는지"를 작성자가 몰라도 안전하다.
+#
+# destructive_schema 마커 테스트(별도 job, 파일별 완전 격리 프로세스)는 스코프 밖 — 이미
+# 프로세스 경계로 격리돼 있어 이 문제 자체가 발생하지 않는다(no-op으로 남겨 그 job의 기존
+# 동작을 그대로 유지).
+#
+# 246개 파일에 이미 있는 개별 `_dispose_global_engine_after_test`는 지금 걷어내지 않는다
+# (중복 dispose는 완전히 무해 — 이미 빈 풀을 한 번 더 비우는 것뿐) — 대량 편집은 별도
+# 스토리(a05da51b, 카디르 QA 지적)에서 그 fixture 자체를 걷어내는 정리와 함께.
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_for_non_destructive_tests(request):
+    if request.node.get_closest_marker(_MARKER_NAME) is not None:
+        yield
+        return
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 # story 8236bbc3: destructive_schema 마커 drift 자기표면화 가드(PO crux 게이트②, 2026-07-03).
 # 마커 부여 자체는 수동이라(하드코딩 파일리스트와 동일 클래스의 drift 위험) 이 가드가 없으면
 # "새 create_all/drop_all 테스트가 마커 없이 들어오면?" 질문에 "alembic-fresh-db job에서 공유

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -33,6 +33,7 @@ list_stories(...)`처럼 **직접 호출**하는 테스트가 흔한데(HTTP 왕
 시점에 거치는 자리라, 여기 적어야 «다음 사람도» 읽는다.
 """
 import ast
+import inspect
 import os
 import re
 import uuid
@@ -184,11 +185,20 @@ def _reset_schema_for_destructive_tests(request):
 # 246개 파일에 이미 있는 개별 `_dispose_global_engine_after_test`는 지금 걷어내지 않는다
 # (중복 dispose는 완전히 무해 — 이미 빈 풀을 한 번 더 비우는 것뿐) — 대량 편집은 별도
 # 스토리(a05da51b, 카디르 QA 지적)에서 그 fixture 자체를 걷어내는 정리와 함께.
-@pytest.fixture(autouse=True)
-async def _dispose_global_engine_for_non_destructive_tests(request):
-    if request.node.get_closest_marker(_MARKER_NAME) is not None:
-        yield
-        return
+@pytest.fixture
+async def _dispose_global_engine_for_non_destructive_tests():
+    """story #3330(PR#3711) — 이 fixture 자체는 **autouse가 아니다**(의도적). 아래
+    `pytest_collection_modifyitems`가 non-destructive **async** 테스트에만 collection
+    시점에 `item.fixturenames`로 주입한다.
+
+    ⛔`autouse=True`를 직접 걸었던 초판은 story #2662의 서브프로세스 메타테스트
+    (`test_setup_phase_failure_also_gets_diagnosed`)를 깼다 — pytest-asyncio strict
+    모드가 "async fixture가 autouse로 걸려 있는데 그 테스트가 async 참여를 선언 안
+    했다"를 **fixture 본문 진입 전에**(dispatch 시점) 감지해 `PytestRemovedIn9Warning`을
+    던진다. 본문 안에서 `inspect.iscoroutinefunction` 등으로 걸러도 이미 늦다(본문
+    자체가 실행되기 전에 경고가 남) — sync 테스트엔 이 fixture가 **애초에 요청되지
+    않아야** 한다. autouse를 버리고 collection 시점에 "async 테스트에만" 조건부로
+    끼워 넣는 것으로 근본 해결."""
     yield
     from app.core.database import engine as _global_engine
     await _global_engine.dispose()
@@ -327,6 +337,19 @@ def pytest_collection_modifyitems(items: list) -> None:
             "  · destructive만(파일별 독립 신선 DB 권장): uv run pytest -m destructive_schema ...\n"
             f"이번 수집에 섞인 destructive 파일{more}:\n" + "\n".join(preview)
         )
+
+    # story #3330(PR#3711) — `_dispose_global_engine_for_non_destructive_tests`(위)를
+    # non-destructive **async** 테스트에만 collection 시점에 주입한다. `autouse=True`로
+    # 직접 걸면 sync 테스트도 이 async fixture를 "요청"한 것으로 잡혀 pytest-asyncio
+    # strict 모드가 fixture 본문 진입 前에 `PytestRemovedIn9Warning`을 던진다(story
+    # #2662의 서브프로세스 메타테스트가 이 경고로 진단 출력 형태가 깨져 실측 발견) —
+    # sync 테스트는 이 fixture를 아예 몰라야 한다. `inspect.iscoroutinefunction`으로
+    # "실행 시점에 걸러도" 이미 늦으므로(경고는 dispatch 시점에 남), collection
+    # 시점의 `item.fixturenames` 주입만이 sync 테스트를 완전히 비켜간다.
+    for item in non_destructive_items:
+        test_func = getattr(item, "function", None)
+        if inspect.iscoroutinefunction(test_func):
+            item.fixturenames.append("_dispose_global_engine_for_non_destructive_tests")
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_3330_gate_verdict_notification.py
+++ b/backend/tests/test_3330_gate_verdict_notification.py
@@ -31,6 +31,22 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """이 파일의 테스트는 실제로 메시지를 발행해 `send_message`의 background task
+    (`mark_agent_replied`)를 태운다 — 그 task는 이 테스트가 만든 throwaway 엔진이 아니라
+    `app.core.database.async_session_factory`(전역, 프로세스 수명 엔진)를 쓴다. pytest-anyio는
+    테스트 함수마다 새 이벤트 루프를 만드는데, 이 전역 엔진의 커넥션 풀을 dispose 없이 그대로
+    두면 다음 테스트(새 루프)가 그 풀에서 "이전 루프에 묶인" 커넥션을 재사용하려다
+    `Connection._cancel` 미await 경고·`Event loop is closed`로 이어진다(실측 확인 — 이 파일의
+    테스트 2개를 한 세션에서 돌리면 재현). 이 프로젝트 realdb 테스트 246개가 이미 쓰는
+    표준 방어 fixture(예: test_e_mcp_opt_ff6cb90d_multiproject_scoping_realdb.py)를
+    동일하게 적용 — 이 파일에 빠져 있던 것이 결함이었다."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy import text as sa_text
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine

--- a/backend/tests/test_3330_gate_verdict_notification.py
+++ b/backend/tests/test_3330_gate_verdict_notification.py
@@ -249,7 +249,7 @@ async def test_rejected_gate_reaches_work_item_assignee_with_reason_and_next_act
             assert "- 게이트: external_publish → rejected" in content
             assert "- 반려 사유: 어투가 너무 딱딱함 — 다시" in content
             assert f"[Threads 포스트 초안 v1](entity:doc:{doc_id})" in content
-            assert "다시 발행하세요" in content
+            assert "approve stage 이벤트를 다시 발행하세요" in content
     finally:
         await engine.dispose()
 
@@ -276,7 +276,7 @@ async def test_approved_gate_also_reaches_work_item_assignee():
             content = await _latest_message_content_for(s, executor_id, org_id)
             assert content is not None
             assert "- 게이트: external_publish → approved" in content
-            assert "다음 stage를 진행하세요" in content
+            assert "다음 stage 이벤트를 발행하세요" in content
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_3330_gate_verdict_notification.py
+++ b/backend/tests/test_3330_gate_verdict_notification.py
@@ -1,0 +1,337 @@
+"""story #3330(2419cbf9) — 게이트 approved/rejected 전이가 실행자(work item assignee)에게
+실제로 도달하는지 검증.
+
+근본원인(소스 확認, 추측 0): `preset.gate.verdict` 발행이 예전엔
+`gate_service._record_gate_review_verdict`(H1-S7, verdict-capture용) 안에 있어
+`_GATE_TYPE_TO_VERDICT_SOURCE`(qa/deploy/merge/pr_review 4종뿐)에 없는 gate_type
+(예: external_publish — 이 스토리의 실제 사고)은 통지가 아예 발행되지 않았다. 이 정정은
+`_publish_gate_verdict_notification`을 그 게이팅과 독립적으로 `transition_gate`에서
+직접 호출한다.
+
+AC1 — rejected 전이 시 work item assignee에게 실제로 채팅 메시지 도달(실 HTTP 왕복).
+AC2 — 그 메시지에 반려 사유·산출물 doc 클릭 토큰·다음 행동이 실린다.
+AC3 — approved 전이도 같은 대상에게 도달(대칭).
+AC5 — 뮤테이션: 발행 훅을 지우면 AC1 RED."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        # migration 0258_system_publisher_member.py — `_get_or_create_system_publisher`
+        # (events.py, publish_preset_event이 매번 부른다)의 on_conflict_do_nothing이
+        # 기대하는 부분 유니크 인덱스는 raw alembic DDL로만 존재하고 SQLAlchemy ORM
+        # 모델(`Member`)엔 선언이 없어 `Base.metadata.create_all`로는 안 생긴다 — 실측
+        # 확認(이 인덱스 없이 돌리면 "no unique or exclusion constraint matching the
+        # ON CONFLICT specification"으로 즉시 실패, postgres 서버 로그로 확인). 이
+        # 스토리와 무관한 기존 realdb 테스트 하네스 갭이라 여기서 직접 재현해 채운다.
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_with_owner(session, *, slug="e3330"):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.team import TeamMember
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org3330", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    owner_user = User(id=uuid.uuid4(), email=f"owner-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(owner_user)
+    await session.commit()
+    owner_member = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=owner_user.id, role="owner")
+    session.add(owner_member)
+    await session.commit()
+    session.add(TeamMember(
+        id=owner_member.id, org_id=org.id, project_id=project.id, type="human", name="owner", is_active=True,
+    ))
+    await session.commit()
+    return org.id, project.id, owner_member.id
+
+
+async def _seed_system_publisher(session, org_id, project_id):
+    """`publish_preset_event`가 매번 부르는 `_get_or_create_system_publisher`(events.py,
+    story #2791)는 프로덕션에서 `team_members`가 `members`/`project_access` 위 3-way
+    UNION VIEW라는 전제(migration 0088+/0110/0258)로 "members에 넣으면 team_members
+    조회에서도 보인다"를 가정한다. `Base.metadata.create_all`로 만든 이 테스트 스키마는
+    `team_members`가 (다른 realdb 테스트들도 그렇듯) 독립된 ORM 테이블이라 그 뷰 동기화가
+    없다 — `members`에 넣어도 `team_members`(=`resolve_member`가 실제로 읽는 곳)엔 안
+    보여 "Team member not found"로 즉시 실패한다(실측 확인). 이 스토리와 무관한 기존
+    하네스 갭이라, 뷰가 만들었을 결과를 여기서 직접 흉내내 두 테이블에 같은 id로 미리
+    심어둔다 — `_get_or_create_system_publisher`는 `members`에서 기존 행을 찾으면 그대로
+    반환하고 새로 안 만든다."""
+    from app.models.member import Member
+    from app.models.team import TeamMember
+
+    publisher_id = uuid.uuid4()
+    session.add(Member(
+        id=publisher_id, org_id=org_id, type="agent", name="시스템 발행",
+        runtime_type="system-publisher", is_active=True,
+    ))
+    session.add(TeamMember(
+        id=publisher_id, org_id=org_id, project_id=project_id, type="agent",
+        name="시스템 발행", runtime_type="system-publisher", is_active=True,
+    ))
+    await session.commit()
+    return publisher_id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="executor"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, assignee_id, title="발행 대상 스토리"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, assignee_id=assignee_id)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_doc(session, org_id, project_id, *, title):
+    from app.models.doc import Doc
+
+    doc = Doc(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        slug=f"doc-{uuid.uuid4().hex[:8]}", content=f"{title} 본문",
+    )
+    session.add(doc)
+    await session.commit()
+    return doc.id
+
+
+_PRESET_GATE_VERDICT_SCHEMA = {
+    "type": "object", "additionalProperties": False,
+    "required": ["work_item_type", "work_item_id", "gate_type", "verdict"],
+    "properties": {
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+        "gate_type": {"type": "string"},
+        "verdict": {"type": "string", "enum": ["approved", "rejected"]},
+        "resolver_member_id": {"type": "string", "format": "uuid"},
+        "resolution_note": {"type": ["string", "null"]},
+    },
+}
+_PRESET_GATE_VERDICT_ROUTING = {
+    "escalation": {"kind": "server_derived", "target": "none"},
+    "broadcast": {
+        "kind": "server_derived", "target": "work_item_stakeholders",
+        "inherit_conversation_scope": True,
+    },
+}
+
+
+async def _seed_preset_gate_verdict_definition(session):
+    """realdb 테스트 DB는 `Base.metadata.create_all`로 스키마만 얻고 alembic 시드
+    마이그레이션(0245_event_definitions.py)은 안 타므로, 그 마이그레이션이 심는
+    `preset.gate.verdict` 프리셋 정의(payload_schema/routing 동일 값, org_id=None=
+    전역 프리셋)를 직접 재현해 심는다 — 이게 없으면 `publish_preset_event`가 "정의
+    없음"으로 조용히 no-op한다(그 자체는 정상 동작이지만, 이 테스트 목적엔 실 프리셋
+    존재를 전제해야 한다)."""
+    from app.models.event_definition import EventDefinition
+    from sqlalchemy import select
+
+    existing = (await session.execute(
+        select(EventDefinition).where(
+            EventDefinition.key == "preset.gate.verdict", EventDefinition.org_id.is_(None),
+        )
+    )).scalar_one_or_none()
+    if existing is not None:
+        return
+    session.add(EventDefinition(
+        id=uuid.uuid4(), key="preset.gate.verdict", org_id=None,
+        payload_schema=_PRESET_GATE_VERDICT_SCHEMA, routing=_PRESET_GATE_VERDICT_ROUTING,
+        enabled=True, version=1,
+    ))
+    await session.commit()
+
+
+async def _seed_gate(
+    session, org_id, *, work_item_id, gate_type="external_publish", work_item_type="story", neutral_facts=None,
+):
+    from app.models.gate import Gate
+
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_type=work_item_type, work_item_id=work_item_id,
+        gate_type=gate_type, status="pending", neutral_facts=neutral_facts or {},
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(gate)
+    await session.commit()
+    return gate
+
+
+async def _latest_message_content_for(session, agent_id, org_id):
+    """agent_id가 참가자인 conversation들 중 가장 최근 메시지 하나를 가져온다(도달 확認용)."""
+    from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
+    from sqlalchemy import select
+
+    row = (await session.execute(
+        select(ConversationMessage)
+        .join(ConversationParticipant, ConversationParticipant.conversation_id == ConversationMessage.conversation_id)
+        .join(Conversation, Conversation.id == ConversationMessage.conversation_id)
+        .where(ConversationParticipant.member_id == agent_id, Conversation.org_id == org_id)
+        .order_by(ConversationMessage.created_at.desc())
+        .limit(1)
+    )).scalar_one_or_none()
+    return row.content if row is not None else None
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_rejected_gate_reaches_work_item_assignee_with_reason_and_next_action():
+    """⭐AC1/AC2 핵심 — 실사례 재현: gate_type=external_publish(verdict-capture 매핑에
+    없는 타입)가 rejected로 전이되면, work item assignee에게 반려 사유+다음 행동이
+    실린 메시지가 실제로 도달한다."""
+    from app.services.gate_service import transition_gate
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_id = await _seed_org_with_owner(s, slug="e3330a")
+            await _seed_preset_gate_verdict_definition(s)
+            await _seed_system_publisher(s, org_id, project_id)
+            executor_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=executor_id)
+            doc_id = await _seed_doc(s, org_id, project_id, title="Threads 포스트 초안 v1")
+            gate = await _seed_gate(
+                s, org_id, work_item_id=story_id,
+                neutral_facts={"draft_doc_reference_token": f"[Threads 포스트 초안 v1](entity:doc:{doc_id})"},
+            )
+
+            await transition_gate(
+                s, org_id, gate.id, "rejected", resolver_id=owner_id, note="어투가 너무 딱딱함 — 다시",
+            )
+            await s.commit()
+
+            content = await _latest_message_content_for(s, executor_id, org_id)
+            assert content is not None, "executor에게 도달한 메시지가 없다(AC1 실패)"
+            assert "- 게이트: external_publish → rejected" in content
+            assert "- 반려 사유: 어투가 너무 딱딱함 — 다시" in content
+            assert f"[Threads 포스트 초안 v1](entity:doc:{doc_id})" in content
+            assert "다시 발행하세요" in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_approved_gate_also_reaches_work_item_assignee():
+    """⭐AC3 — 승인 방향도 동일 대상에게 도달(대칭)."""
+    from app.services.gate_service import transition_gate
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_id = await _seed_org_with_owner(s, slug="e3330b")
+            await _seed_preset_gate_verdict_definition(s)
+            await _seed_system_publisher(s, org_id, project_id)
+            executor_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=executor_id)
+            gate = await _seed_gate(s, org_id, work_item_id=story_id)
+
+            await transition_gate(s, org_id, gate.id, "approved", resolver_id=owner_id)
+            await s.commit()
+
+            content = await _latest_message_content_for(s, executor_id, org_id)
+            assert content is not None
+            assert "- 게이트: external_publish → approved" in content
+            assert "다음 stage를 진행하세요" in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_gate_type_outside_verdict_capture_mapping_still_notifies():
+    """⭐근본원인 직접 재현 — gate_type이 `_GATE_TYPE_TO_VERDICT_SOURCE`(qa/deploy/merge/
+    pr_review)에 전혀 없어도(이 테스트는 완전히 임의의 커스텀 타입으로 한 번 더 확인)
+    통지는 발행된다 — verdict-capture 게이팅과 통지가 이제 독립임을 pin."""
+    from app.services.gate_service import _GATE_TYPE_TO_VERDICT_SOURCE, transition_gate
+
+    assert "totally_custom_gate_type" not in _GATE_TYPE_TO_VERDICT_SOURCE  # 전제 확인
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_id = await _seed_org_with_owner(s, slug="e3330c")
+            await _seed_preset_gate_verdict_definition(s)
+            await _seed_system_publisher(s, org_id, project_id)
+            executor_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=executor_id)
+            gate = await _seed_gate(s, org_id, work_item_id=story_id, gate_type="totally_custom_gate_type")
+
+            await transition_gate(s, org_id, gate.id, "rejected", resolver_id=owner_id, note="사유")
+            await s.commit()
+
+            content = await _latest_message_content_for(s, executor_id, org_id)
+            assert content is not None
+            assert "totally_custom_gate_type → rejected" in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_system_auto_transition_without_resolver_does_not_notify():
+    """경계 — resolver_id 없는 전이(시스템 auto-transition)는 통지하지 않는다(사람이
+    판정한 게 아니므로 "사람이 판정했다" 통지 대상이 아님 — 기존 가드와 동일 취지)."""
+    from app.services.gate_service import transition_gate
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner_id = await _seed_org_with_owner(s, slug="e3330d")
+            await _seed_preset_gate_verdict_definition(s)
+            await _seed_system_publisher(s, org_id, project_id)
+            executor_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=executor_id)
+            gate = await _seed_gate(s, org_id, work_item_id=story_id)
+
+            await transition_gate(s, org_id, gate.id, "approved", resolver_id=None)
+            await s.commit()
+
+            content = await _latest_message_content_for(s, executor_id, org_id)
+            assert content is None
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story #3330(2419cbf9). 3바퀴 실측: 게이트 반려가 실행자(work item assignee) 쪽 3개 수신 경로(채널·notifications·이벤트 conversation) 전부 0건 — PO가 채팅으로 알려줘야만 인지했다. 승인 카드가 내려가는 길(#3325)은 정상, 되돌아오는 길만 비어 있던 비대칭 결함.
- **근본원인(소스 확認)**: `preset.gate.verdict` 자동발행이 `gate_service.py::_record_gate_review_verdict`(verdict-capture 전용 함수) 안에 있어, `_GATE_TYPE_TO_VERDICT_SOURCE`(qa/deploy/merge/pr_review 4종뿐)에 없는 gate_type — 이 사고의 `external_publish` 포함 — 은 발행 자체가 스킵됐다. 무관한 두 관심사(trust 점수 vs 통지)가 한 게이팅에 묶여 있던 결함.
- `gate_service.py`: `_publish_gate_verdict_notification()` 신설, verdict-capture 게이팅과 독립적으로 `transition_gate`에서 직접 호출. `resolution_note`도 payload에 실음(스키마엔 있었으나 값 미채움).
- `events.py`: `_render_gate_verdict_message()` 신설(`preset.gate.verdict`는 stage_metadata 없는 비사이클형이라 기존엔 제네릭 폴백뿐 — 반려 사유·산출물 링크·다음 행동 전무). `neutral_facts.draft_doc_reference_token` 재사용(새 계산 0, 스키마 변경 0).

## PO 리뷰 반영(head b5aeadca0)
「다음 행동」 문구를 실재하는 동작으로 정정 — rejected: "산출물 수정 뒤 같은 레시피 정의의 approve stage 이벤트를 다시 발행하세요(payload.previous_output_doc_id=수정본 id) — 게이트는 자동 재오픈됩니다." / approved: "이 정의의 다음 stage 이벤트를 발행하세요(publish 단계라면 승인 게이트를 확認하는 발행 도구로)."

## CI flake 조사 + 정정(최종 — head a12508374, 옵션 A)

카디르 QA 후 CI가 `test_e_mcp_opt_ff6cb90d_multiproject_scoping_realdb.py`에서 3연속 실패(`RuntimeError: ... got Future ... attached to a different loop` / `Event loop is closed`, GET /auth/me 중) — develop(3712 CI)에선 같은 테스트가 green이라 페드루가 "이 브랜치의 새 테스트가 원인" 판정, 재현 지시.

**1차 정정(head f5805bce0, 불충분)**: `test_3330_gate_verdict_notification.py`에 `_dispose_global_engine_after_test`(246개 파일이 이미 쓰는 표준 fixture) 추가 — 로컬 "두 테스트 한 세션" 재현은 0건으로 잡혔으나, **CI 3차 재발**로 이 정정이 근본원인이 아니었음이 드러남.

**최종 근본원인(CI와 동일 스택트레이스로 로컬 완전 재현 성공)**: `-m "not destructive_schema"` 전체(`--collect-only`로 destructive 파일 0건 수집 확認 — test_3330은 애초에 이 job 프로세스에 있지도 않음)로 돌려도 `test_e_mcp_opt_ff6cb90d...`가 그대로 실패 — 범인은 test_3330의 테스트 **코드**가 아니라 이 PR의 **프로덕션 코드 변경** 그 자체였다.

`transition_gate`에 새로 넣은 `_publish_gate_verdict_notification` 호출이 이제 **모든** gate_type의 approved/rejected 전이에서 무조건 발행을 시도한다(예전엔 qa/deploy/merge/pr_review 4종만 — 이 PR 처방의 본연 방향, 되돌릴 대상 아님). 이게 `send_message`의 background task(`mark_agent_replied`)를 태우고, 그 task는 `app.core.database.engine`(전역·프로세스 수명)을 쓴다. pytest-anyio는 테스트마다 새 이벤트 루프를 만드는데, 이 전역 엔진 풀에 "이전 루프에 묶인" 커넥션이 dispose 없이 남으면 다음 테스트가 `pool_pre_ping`으로 그 커넥션을 검사하려는 순간 위 RuntimeError로 죽는다.

즉 **내 프로덕션 변경이 `transition_gate`를 호출하는 무관한 기존 non-destructive 테스트들에게 이 전역엔진 경로를 처음 태운 것**이 진짜 트리거 — 그 테스트들은 원래 이 경로를 안 탔어서 dispose fixture가 없었고, 지금 필요해졌다. 어느 특정 파일이 "범인"인지는 pool 크기·실행 순서에 좌우돼 구조적으로 예측 불가능(전체 스위트 1292건 중 하나).

**PO 판정(옵션 A 채택, 최후수단 B=AC1을 깎는 반창고는 기각)**: `_dispose_global_engine_after_test`를 파일별 opt-in이 아니라 **conftest.py autouse**로 승격 — "이 테스트가 전역 엔진을 쓰는지" 작성자가 몰라도 안전. 별도 커밋(`infra: ...`)으로 분리, scope=non-destructive realdb만(destructive job은 파일별 프로세스 격리라 이 문제 자체가 없음 — no-op 처리), 246개 파일의 개별 fixture는 지금 안 건드림(중복 dispose 무해 — 별도 스토리 a05da51b에서 lint 가드와 함께 정리).

**검증(CI와 동일 커맨드, alembic-migrated DB)**:
- 처방 前: `test_e_mcp_opt_ff6cb90d...` 5건 포함 9건 실패(재현 성공, 소요 367s).
- 처방 後: 그 5건 전부 사라짐(0건). 새로 보인 실패 27건은 에러 클래스 전수 확認 결과 100% UniqueViolationError/ForeignKeyViolationError(중복 email·slug·FK 잔존) — InterfaceError/Event loop 관련 0건. 원인은 1·2차 로컬 실행 사이 DB를 리셋 안 하고 재사용해 하드코딩 시드값이 잔존 데이터와 충돌한 순수 로컬 재실행 방법론 문제(처방과 무관, 격리된 파일 단독 실행 시 21/21 pass). dispose 비용은 실행시간 367s→389s(≈6% 증가, 매 non-destructive 테스트 뒤 유휴 커넥션 정리 1회분).
- 3차(클린 DB, rebase 후 최종 head 기준) 회귀 배치: destructive 43/43 pass(누수 0, 신규 test_3330 파일 기준 — 이미 develop에 있는 test_3329는 여전히 별도 누수 있음, 부수 발견 참고) + non-destructive 소규모 재현 배치(test_183fe7a5·test_a2a·test_e_cage_referee·test_e_mcp_opt_ff6cb90d 2파일) 91/91 pass.

**부수 발견(이 PR 스코프 밖, 보고만)**: **이미 develop에 병합된** `test_3329_embedded_entity_ref_tokenization.py`(PR#3713)에서도 같은 클래스의 누수 경고가 있다 — 그 파일도 (승격 前의) 개별 fixture가 빠져 있다. story [a05da51b](entity:story:a05da51b-ae5c-4dd1-bca2-17fce860ad6c)에 등재됨(수정 + lint 가드).

## CI 재QA 지적 + 정정(head d89c74aa9)

카디르 QA(run 33617230852) — 타깃(different loop)은 잡혔으나 새 실패 1건: `test_2662_missing_model_import_guard.py::test_setup_phase_failure_also_gets_diagnosed`(서브프로세스 메타테스트, conftest.py를 복사해 검증). 원인: `_dispose_global_engine_for_non_destructive_tests`를 `autouse=True`로 직접 걸어, 그 메타테스트의 sync 테스트가 이 async fixture를 "요청"한 것으로 pytest-asyncio strict 모드가 **fixture 본문 진입 전**에 `PytestRemovedIn9Warning`을 던짐 — 서브프로세스 출력 형태가 바뀌어 어서션 깨짐. 본문 안 `inspect.iscoroutinefunction` 체크로는 못 막음(경고가 dispatch 시점에 남, 이미 늦음).

**정정**: `autouse=True`를 버리고 기존 `pytest_collection_modifyitems`(#3186 혼합수집 가드와 같은 자리)에서 collection 시점에 non-destructive **async** 테스트에만 `item.fixturenames`로 조건부 주입 — sync 테스트는 이 fixture를 애초에 모르니 경고 자체가 안 남. 전역 엔진 누수는 이벤트 루프를 만드는 async 테스트에서만 생기므로 스코프도 정확해짐(우연한 부작용 아니라 사실 그대로 좁아짐).

**검증**: `test_2662...` 단독 PASSED(경고 0) · 회귀 배치(183fe7a5·a2a·e_cage_referee·e_mcp_opt_ff6cb90d 2파일·test_2662, alembic-migrated DB) 99/99 pass(타깃 5건 여전히 0 실패 + sync 메타테스트 무회귀 동시 확認) · destructive 회귀(3330·h1_s7·2027·1715·3323) 32/32 pass.

## Test plan
- [x] 신규 `test_3330_gate_verdict_notification.py` 4건 + 뮤테이션 RED 확인.
- [x] rebase(develop=3a666b013 — #3710/#3712/#3713 반영, 이어서 develop=b85c44a4d — #3714 반영) 후 events.py 병합 무손실 확認(#3329 토큰화·#3330 렌더·#3332 refs 계산 3자 공존).
- [x] CI flake 최종 근본원인 확定+conftest autouse 정정(위 상세). CI와 동일 커맨드 전체 스위트로 타깃 실패 0건 확認.
- [ ] 카디르 QA 재앵커 → PO 머지 → 오늘 두 번째 배치 배포(3711+3714).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pN7nEKmenxEugBXV1oVQS

