### PR TITLE
[SID:3331] MCP sprintable_list_conversations 신설 — 내 참여 방 자가발견 백스톱

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -356,7 +356,7 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_get_velocity", "sprintable_get_wallet", "sprintable_get_workflow_guide",
     "sprintable_give_reward", "sprintable_list_audit_logs", "sprintable_list_backlog",
     "sprintable_get_chat_message",
-    "sprintable_list_chat_messages", "sprintable_list_docs", "sprintable_list_epics",
+    "sprintable_list_chat_messages", "sprintable_list_conversations", "sprintable_list_docs", "sprintable_list_epics",
     "sprintable_list_goals",
     "sprintable_list_meetings", "sprintable_list_my_tasks", "sprintable_list_retro_sessions",
     "sprintable_list_sprints", "sprintable_list_standup_entries", "sprintable_list_stories",

--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -354,6 +354,14 @@ class SprintableClient:
         (대소문자 무관 접근)."""
         return await self.request("GET", path, params=params, return_headers=True)
 
+    async def get_full(self, path: str, *, params: dict | None = None) -> Any:
+        """story #3331 — get()과 동일하되 `{data: T, ...sibling}` 래핑을 풀지 않고 그대로
+        반환한다(post_full()의 GET 짝 — sibling 키(total·limit·offset 등 body 기반
+        페이지네이션 메타)가 필요한 소수 호출부(list_conversations)용). X-Total-Count 같은
+        헤더 기반 페이지네이션은 get_with_headers()가 이미 담당 — 이건 body-embedded 메타
+        전용."""
+        return await self.request("GET", path, params=params, unwrap=False)
+
     async def post(self, path: str, *, json: dict | None = None) -> Any:
         return await self.request("POST", path, json=json or {})
 

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -799,7 +799,9 @@ _TOOL_DEFS: list[tuple] = [
     # Chat (5)
     ("sprintable_list_conversations",
      "[조직] 내가 참여한 방 목록 — 알림이 안 왔어도 스스로 점검하는 백스톱(story #3331)."
-     " id를 몰라도 되는 유일한 대화 발견 경로 — send/list_chat_messages/get_chat_message는"
+     " id를 몰라도 되는 유일한 대화 발견 경로다(단, project_id 단위 목록 — API 자체가"
+     " project_id 필수라 «기본 프로젝트 안의 내 방»만 보인다, 여러 프로젝트를 훑으려면"
+     " project_id를 바꿔 반복 호출할 것) — send/list_chat_messages/get_chat_message는"
      " conversation_id를 이미 알아야 하는데, 그 id를 얻을 방법이 이 도구뿐이었다(채널로"
      " 밀려오지 않은 방은 존재 자체를 몰랐다). 세션 시작 시·긴 정지 후 재기동 시 «내 앞으로"
      " 뭐가 왔는지» 먼저 이걸로 훑을 것. id·type·title·participants·last_read_at·"

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -97,8 +97,9 @@ from .tools.meetings import (
     trigger_ai_summary, update_meeting,
 )
 from .tools.chat import (
-    CreateConversationInput, GetChatMessageInput, ListChatMessagesInput, SendChatInput,
-    create_conversation, get_chat_message, list_chat_messages, send_chat_message,
+    CreateConversationInput, GetChatMessageInput, ListChatMessagesInput, ListConversationsInput,
+    SendChatInput, create_conversation, get_chat_message, list_chat_messages,
+    list_conversations, send_chat_message,
 )
 from .tools.notifications import (
     CheckNotificationsInput, MarkAllNotificationsReadInput, MarkNotificationReadInput,
@@ -795,7 +796,17 @@ _TOOL_DEFS: list[tuple] = [
      "[신뢰] 이 버전을 정본으로 제안(게이트 생성) — 제안만, 승인/반려는 항상 휴먼. ⭐이 버전이 확定될"
      " 준비가 됐다고 판단될 때 휴먼 승인을 요청.",
      ProposeCanonicalInput, propose_canonical_version),
-    # Chat (4)
+    # Chat (5)
+    ("sprintable_list_conversations",
+     "[조직] 내가 참여한 방 목록 — 알림이 안 왔어도 스스로 점검하는 백스톱(story #3331)."
+     " id를 몰라도 되는 유일한 대화 발견 경로 — send/list_chat_messages/get_chat_message는"
+     " conversation_id를 이미 알아야 하는데, 그 id를 얻을 방법이 이 도구뿐이었다(채널로"
+     " 밀려오지 않은 방은 존재 자체를 몰랐다). 세션 시작 시·긴 정지 후 재기동 시 «내 앞으로"
+     " 뭐가 왔는지» 먼저 이걸로 훑을 것. id·type·title·participants·last_read_at·"
+     " unread_count·latest_message를 준다. ⛔`create_conversation`은 조회가 아니라 매번"
+     " 새 방을 만드는 도구다(dedup 없음) — 기존 방이 있는지 확인할 땐 이걸 먼저 쓸 것,"
+     " create_conversation을 조회 우회로 쓰면 빈 방만 하나 더 생긴다.",
+     ListConversationsInput, list_conversations),
     ("sprintable_send_chat_message",
      "[조직] conversation thread에 채팅 메시지 발송. conversation_id로 대화를 지정(thread_id는"
      " 폐기 예정 별칭 — story #2427: 이 도구들의 «응답» thread_id는 대화 ID가 아니라 회신 스레드"
@@ -807,7 +818,9 @@ _TOOL_DEFS: list[tuple] = [
      " 메시지에서도 링크/backlink가 동작하게 한다.",
      SendChatInput, send_chat_message),
     ("sprintable_create_conversation",
-     "[조직] 새 conversation thread 생성.",
+     "[조직] 새 conversation thread **생성**(조회 아님 — dedup 없이 매 호출 신규 방을 만든다,"
+     " story #3331). 이 방이 이미 있는지 확인하고 싶으면 먼저 `sprintable_list_conversations`를"
+     " 쓸 것 — 이 도구를 조회 우회로 쓰면 빈 방만 하나 더 생긴다.",
      CreateConversationInput, create_conversation),
     ("sprintable_list_chat_messages",
      "[조직] conversation thread 메시지 목록 조회. conversation_id로 대화를 지정(thread_id는"

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -1,4 +1,4 @@
-"""채팅 MCP 도구 (3개)."""
+"""채팅 MCP 도구 (5개)."""
 from __future__ import annotations
 
 import logging
@@ -207,6 +207,28 @@ class ListChatMessagesInput(ConversationScopedInput):
     before: str | None = None
 
 
+class ListConversationsInput(SprintableInput):
+    """story #3331 — 에이전트가 자기 conversation 목록을 조회할 도구가 없어(id를 이미 알아야
+    읽히는 send/list_chat_messages/get_chat_message뿐) «채널로 밀려온 방」 밖의 존재를 아예
+    몰랐다(실사고: 담롱↔선생님 DM 896235be에 담롱 앞 결재 카드 2장이 있었는데도 세션 내내
+    발견 못 함). `GET /api/v2/conversations`(agent 키 호환 확認 完 — 이 라우터의 다른
+    엔드포인트와 동일 `get_current_user` 의존성)를 그대로 노출 — 새 REST·새 인증 0.
+
+    ⚠️이 REST가 받는 파라미터는 project_id(필수)·include_agent_conversations·limit·offset
+    뿐이다(conversations.py::list_conversations 실측) — `since`나 참여자 필터는 API 자체에
+    없어 지어내지 않는다(story 처방 2/3은 이 PR 스코프 밖, API 확장이 별도 필요)."""
+
+    include_agent_conversations: bool = Field(
+        default=False,
+        description=(
+            "org owner/admin 키에서만 유효 — agent끼리만 있는(휴먼 미참여) 대화까지 포함한다. "
+            "그 외 role은 서버가 403을 낸다."
+        ),
+    )
+    limit: int | None = None
+    offset: int | None = None
+
+
 class GetChatMessageInput(ConversationScopedInput):
     message_id: str
 
@@ -327,8 +349,29 @@ async def send_chat_message(args: SendChatInput) -> list[TextContent]:
         return err(str(exc))
 
 
+async def list_conversations(args: ListConversationsInput) -> list[TextContent]:
+    """내가 참여 중인 conversation 목록 — id·제목·참여자·마지막 메시지·미읽음 수. 알림이 안
+    왔어도(채널 미도달·이벤트 conversation 부재 등) 스스로 «내 앞으로 뭐가 왔는지» 점검하는
+    백스톱(story #3331) — id를 몰라도 되는 유일한 대화 발견 경로. `create_conversation`은
+    조회가 아니라 매번 새 방을 만드는 도구이니(dedup 없음) 기존 방이 있는지 먼저 이걸로
+    확인할 것."""
+    try:
+        params: dict = {"project_id": client.require_project_id()}
+        if args.include_agent_conversations:
+            params["include_agent_conversations"] = "true"
+        if args.limit is not None:
+            params["limit"] = str(args.limit)
+        if args.offset is not None:
+            params["offset"] = str(args.offset)
+        return ok(await client.get_full("/api/v2/conversations", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
 async def create_conversation(args: CreateConversationInput) -> list[TextContent]:
-    """새 conversation thread 생성."""
+    """새 conversation thread **생성**(조회 아님 — dedup 없이 매 호출 신규 방을 만든다, story
+    #3331). 이 방이 이미 있는지 확인하고 싶으면 먼저 `list_conversations`를 쓸 것 — 이 도구를
+    조회 우회로 쓰면 빈 방만 하나 더 생긴다."""
     try:
         body: dict = {
             "type": "group",

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -216,7 +216,14 @@ class ListConversationsInput(SprintableInput):
 
     ⚠️이 REST가 받는 파라미터는 project_id(필수)·include_agent_conversations·limit·offset
     뿐이다(conversations.py::list_conversations 실측) — `since`나 참여자 필터는 API 자체에
-    없어 지어내지 않는다(story 처방 2/3은 이 PR 스코프 밖, API 확장이 별도 필요)."""
+    없어 지어내지 않는다(story 처방 2/3은 이 PR 스코프 밖, API 확장이 별도 필요).
+
+    ⚠️PO 변경요청①(2026-09-02, PR#3712 리뷰) — project_id가 REST 필수라(미지정 시 422, PO
+    실측) 이 목록은 «내가 참여한 방 전부»가 아니라 **«기본 프로젝트 안의 내 방»**이다 —
+    다중 프로젝트 org에선 조용히 좁아질 수 있다. `project_id`는 (베이스 클래스 `SprintableInput`
+    상속 필드) 다른 chat 도구와 동형인 선택적 per-call override(E-MCP-OPT ff6cb90d 관례,
+    미지정 시 client.require_project_id() 현행) — 여러 프로젝트를 훑으려면 project_id를
+    바꿔가며 반복 호출할 것."""
 
     include_agent_conversations: bool = Field(
         default=False,

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -56,7 +56,9 @@ EXPECTED_TOOLS = {
     # core (4) — E-MCP-OPT(story ff6cb90d): list_projects/set_default_project 2종 추가.
     "sprintable_list_team_members", "sprintable_my_dashboard",
     "sprintable_list_projects", "sprintable_set_default_project",
-    # chat (4) — story 3cf50d90: get_chat_message(단건 원문 조회) 추가.
+    # chat (5) — story 3cf50d90: get_chat_message(단건 원문 조회) 추가. story #3331:
+    # list_conversations(내 참여 방 목록 — 알림 미도달 백스톱) 추가.
+    "sprintable_list_conversations",
     "sprintable_send_chat_message", "sprintable_create_conversation", "sprintable_list_chat_messages",
     "sprintable_get_chat_message",
     # meetings (6)
@@ -139,7 +141,8 @@ def test_total_tool_count():
     # 119→121. story #2668(B3): sprintable_submit_for_approval 1종 신설(문서 결재 상신
     # REST를 MCP로 노출 — 도구 목록에 없어 에이전트가 발견 못 하던 것) — 121→122.
     # story #2709: sprintable_request_decision 1종 신설(AskUserQuestion 블로킹 대체) — 122→123.
-    assert len(_TOOLS) == 124  # story b6b9c52d(#2707 부수): sprintable_import_image_artifact 신설 123→124
+    # story #3331: sprintable_list_conversations 1종 신설(내 참여 방 목록 — 알림 미도달 백스톱) — 124→125.
+    assert len(_TOOLS) == 125  # story b6b9c52d(#2707 부수): sprintable_import_image_artifact 신설 123→124
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_2412_mcp_unknown_arg_rejection.py
+++ b/backend/tests/test_2412_mcp_unknown_arg_rejection.py
@@ -76,17 +76,17 @@ async def test_registered_standup_history_tool_still_accepts_known_args():
 
 
 def test_all_registered_tools_share_the_same_lockdown():
-    """AC2 카운트 — `_TOOL_DEFS` 123개 + ping 1개 = 124개(story #2634: sprintable_publish_event/
+    """AC2 카운트 — `_TOOL_DEFS` 124개 + ping 1개 = 125개(story #2634: sprintable_publish_event/
     sprintable_list_event_definitions 추가로 117→119. story #2636: sprintable_register_
     event_definition/sprintable_update_event_definition 추가로 119→121. story #2668:
     sprintable_submit_for_approval 추가로 121→122. story #2709: sprintable_request_decision
     추가로 122→123. story b6b9c52d(#2707 부수): sprintable_import_image_artifact 추가로
-    123→124) 전부 arg_model이
+    123→124. story #3331: sprintable_list_conversations 추가로 124→125) 전부 arg_model이
     extra=forbid로 잠겨 있어야 한다(상속 갈래 SprintableInput/BaseModel 안 가리고 전부)."""
     from sprintable_mcp import server as srv
 
     tools = srv.mcp._tool_manager.list_tools()
-    assert len(tools) == 124
+    assert len(tools) == 125
     unlocked = [
         t.name for t in tools
         if t.fn_metadata.arg_model.model_config.get("extra") != "forbid"

--- a/backend/tests/test_3331_mcp_list_conversations.py
+++ b/backend/tests/test_3331_mcp_list_conversations.py
@@ -125,6 +125,37 @@ async def test_list_conversations_limit_offset_stringified_and_passed():
 
 
 @pytest.mark.anyio
+async def test_list_conversations_project_id_override_reaches_query_string():
+    """⭐PO 변경요청①(2026-09-02, PR#3712 리뷰) — API가 project_id 필수(422·PO 실측)라 이
+    도구는 «내가 참여한 방 전부»가 아니라 «기본 프로젝트 안의 내 방»이다(다중 프로젝트
+    org에선 조용히 좁아짐). per-call project_id override(SprintableInput 상속 필드,
+    E-MCP-OPT ff6cb90d 관례 — server.py wrapper가 kwargs["project_id"]를 contextvar로
+    태운다)가 실제로 쿼리스트링에 반영되는지 실증. client를 통째로 mock하면 진짜
+    require_project_id()의 override-우선 로직을 타지 않으므로, 여기선 get_full만 patch하고
+    나머지는 실 client 싱글턴을 그대로 쓴다."""
+    from sprintable_mcp.api_client import reset_project_override, set_project_override
+    from sprintable_mcp.tools import chat as chat_mod
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_get_full(path, params=None):
+        calls.append((path, params))
+        return _LIST_RESP
+
+    original_project_id = chat_mod.client._project_id
+    chat_mod.client._project_id = "default-project"
+    tok = set_project_override("override-project")
+    try:
+        with patch.object(chat_mod.client, "get_full", new=AsyncMock(side_effect=fake_get_full)):
+            await chat_mod.list_conversations(chat_mod.ListConversationsInput())
+    finally:
+        reset_project_override(tok)
+        chat_mod.client._project_id = original_project_id
+
+    assert calls[0][1]["project_id"] == "override-project"
+
+
+@pytest.mark.anyio
 async def test_list_conversations_error_surfaces():
     """project_id ambiguous 등 client.require_project_id()가 던지는 SprintableApiError도
     다른 도구와 동형으로 err()에 담겨 나간다(create_conversation과 동일 관례)."""

--- a/backend/tests/test_3331_mcp_list_conversations.py
+++ b/backend/tests/test_3331_mcp_list_conversations.py
@@ -1,0 +1,185 @@
+"""story #3331(74be44d1) — MCP `sprintable_list_conversations` 신설. 에이전트가 «자기
+conversation 목록»을 조회할 수단이 없어(id를 이미 알아야 읽히는 send/list_chat_messages/
+get_chat_message뿐) 채널로 밀려오지 않은 방의 존재 자체를 몰랐던 결함(실사고: 담롱↔선생님
+DM 896235be에 담롱 앞 결재 카드 2장이 있었는데도 세션 내내 발견 못 함) 처방.
+
+신규 REST 없음 — 기존 `GET /api/v2/conversations`(conversations.py::list_conversations)를
+그대로 노출한다. 지어내지 않음 축: 이 REST가 실제로 받는 파라미터(project_id·
+include_agent_conversations·limit·offset)만 노출하고 since/참여자 필터는 API 자체에 없어
+추가하지 않았다(별도 API 확장 스토리)."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+_LIST_RESP = {
+    "data": [
+        {
+            "id": "896235be-0000-0000-0000-000000000001", "type": "dm", "title": None,
+            "status": "open", "participants": [{"id": "p1", "name": "담롱"}, {"id": "p2", "name": "선생님"}],
+            "muted": False, "last_read_at": None, "unread_count": 2,
+            "latest_message": {"content": "결재 요청", "created_at": "2026-09-02T07:06:21.065Z"},
+            "updated_at": "2026-09-02T07:06:21.065Z",
+        },
+    ],
+    "total": 1, "limit": 30, "offset": 0,
+}
+
+
+@pytest.mark.anyio
+async def test_list_conversations_calls_existing_rest_endpoint_with_resolved_project_id():
+    """⭐AC1/AC4 핵심 — 신규 REST 0, 기존 GET /api/v2/conversations를 그대로 호출한다.
+    project_id는 client.require_project_id()로 해소(create_conversation과 동형 관례)."""
+    from sprintable_mcp.tools.chat import ListConversationsInput, list_conversations
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_get_full(path, params=None):
+        calls.append((path, params))
+        return _LIST_RESP
+
+    with patch("sprintable_mcp.tools.chat.client") as mock_client:
+        mock_client.require_project_id.return_value = "proj-1"
+        mock_client.get_full = AsyncMock(side_effect=fake_get_full)
+        out = await list_conversations(ListConversationsInput())
+
+    assert calls == [("/api/v2/conversations", {"project_id": "proj-1"})]
+    parsed = json.loads(out[0].text)
+    # AC1 — 목록 항목이 id·제목·참여자·마지막 메시지 시각·미읽음 수를 담고 있다(REST가 이미
+    # 주는 값을 그대로 통과·지어내지 않음).
+    assert parsed["data"][0]["id"] == "896235be-0000-0000-0000-000000000001"
+    assert parsed["data"][0]["unread_count"] == 2
+    assert parsed["data"][0]["latest_message"]["content"] == "결재 요청"
+    # ⭐total/limit/offset sibling이 살아있어야 한다(get_full — unwrap=False 확認, data만
+    # 남기고 페이지네이션 메타를 버리면 안 됨).
+    assert parsed["total"] == 1
+    assert parsed["limit"] == 30
+
+
+@pytest.mark.anyio
+async def test_list_conversations_include_agent_conversations_flag_passed_as_string_true():
+    """include_agent_conversations=True면 쿼리 파라미터로 실려 간다(owner/admin 전용은 서버가
+    403으로 강제 — 도구 쪽에서 role을 미리 판단하지 않는다, 지어내지 않음)."""
+    from sprintable_mcp.tools.chat import ListConversationsInput, list_conversations
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_get_full(path, params=None):
+        calls.append((path, params))
+        return _LIST_RESP
+
+    with patch("sprintable_mcp.tools.chat.client") as mock_client:
+        mock_client.require_project_id.return_value = "proj-1"
+        mock_client.get_full = AsyncMock(side_effect=fake_get_full)
+        await list_conversations(ListConversationsInput(include_agent_conversations=True))
+
+    assert calls[0][1] == {"project_id": "proj-1", "include_agent_conversations": "true"}
+
+
+@pytest.mark.anyio
+async def test_list_conversations_omits_absent_optional_params():
+    """limit/offset 미지정이면 쿼리에 안 실린다(REST 자체 기본값에 위임 — 지어낸 기본값을
+    도구가 강제하지 않음)."""
+    from sprintable_mcp.tools.chat import ListConversationsInput, list_conversations
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_get_full(path, params=None):
+        calls.append((path, params))
+        return _LIST_RESP
+
+    with patch("sprintable_mcp.tools.chat.client") as mock_client:
+        mock_client.require_project_id.return_value = "proj-1"
+        mock_client.get_full = AsyncMock(side_effect=fake_get_full)
+        await list_conversations(ListConversationsInput())
+
+    assert "limit" not in calls[0][1]
+    assert "offset" not in calls[0][1]
+    assert "include_agent_conversations" not in calls[0][1]
+
+
+@pytest.mark.anyio
+async def test_list_conversations_limit_offset_stringified_and_passed():
+    from sprintable_mcp.tools.chat import ListConversationsInput, list_conversations
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_get_full(path, params=None):
+        calls.append((path, params))
+        return _LIST_RESP
+
+    with patch("sprintable_mcp.tools.chat.client") as mock_client:
+        mock_client.require_project_id.return_value = "proj-1"
+        mock_client.get_full = AsyncMock(side_effect=fake_get_full)
+        await list_conversations(ListConversationsInput(limit=10, offset=20))
+
+    assert calls[0][1] == {"project_id": "proj-1", "limit": "10", "offset": "20"}
+
+
+@pytest.mark.anyio
+async def test_list_conversations_error_surfaces():
+    """project_id ambiguous 등 client.require_project_id()가 던지는 SprintableApiError도
+    다른 도구와 동형으로 err()에 담겨 나간다(create_conversation과 동일 관례)."""
+    from sprintable_mcp.tools.chat import ListConversationsInput, list_conversations
+
+    with patch("sprintable_mcp.tools.chat.client") as mock_client:
+        mock_client.require_project_id.side_effect = Exception("여러 프로젝트에 접근 가능한 키입니다.")
+        out = await list_conversations(ListConversationsInput())
+
+    assert "error" in out[0].text.lower()
+
+
+@pytest.mark.anyio
+async def test_create_conversation_unaffected_still_posts_new_room_every_call():
+    """회귀 0 — create_conversation은 여전히 «만드는» 도구다(dedup 없음, 문서 문구만 갱신했지
+    동작은 무변경). 이 PR이 create_conversation의 실제 생성 동작을 바꾸지 않았음을 고정."""
+    from sprintable_mcp.tools.chat import CreateConversationInput, create_conversation
+
+    calls: list[str] = []
+
+    async def fake_post(path, json=None):
+        calls.append(path)
+        return {"id": "new-conv", "type": "group", "title": None, "existing": False}
+
+    with patch("sprintable_mcp.tools.chat.client") as mock_client:
+        mock_client.require_project_id.return_value = "proj-1"
+        mock_client.post = AsyncMock(side_effect=fake_post)
+        out = await create_conversation(CreateConversationInput(participant_ids=["p1", "p2"]))
+
+    assert calls == ["/api/v2/conversations"]
+    parsed = json.loads(out[0].text)
+    assert parsed["conversation_id"] == "new-conv"
+
+
+def test_list_conversations_registered_in_tool_registry():
+    """⭐AC — server.py TOOLS에 등재돼 있고, 설명 첫 문장이 PO가 지시한 백스톱 문구를 담는다."""
+    from sprintable_mcp.server import _TOOL_DEFS as TOOLS
+
+    matches = [t for t in TOOLS if t[0] == "sprintable_list_conversations"]
+    assert len(matches) == 1, "sprintable_list_conversations가 TOOLS에 정확히 1건 등재돼야 함"
+    _name, description, input_model, fn = matches[0]
+    assert "내가 참여한 방 목록" in description
+    assert "백스톱" in description
+    from sprintable_mcp.tools.chat import ListConversationsInput, list_conversations
+    assert input_model is ListConversationsInput
+    assert fn is list_conversations
+
+
+def test_create_conversation_description_warns_against_lookup_misuse():
+    """⭐AC5 회귀 — create_conversation 도구 설명이 "조회 아님·list_conversations를 쓸 것"을
+    명시(처방4 우려의 문서측 처방 — 백엔드 dedup 동작 자체는 EF-S2 기존 설계라 무변경)."""
+    from sprintable_mcp.server import _TOOL_DEFS as TOOLS
+
+    matches = [t for t in TOOLS if t[0] == "sprintable_create_conversation"]
+    assert len(matches) == 1
+    _name, description, _input_model, _fn = matches[0]
+    assert "list_conversations" in description
+    assert "조회" in description

--- a/backend/tests/test_mcp_axis_prefix_b_surface.py
+++ b/backend/tests/test_mcp_axis_prefix_b_surface.py
@@ -80,6 +80,8 @@ def test_tool_names_and_param_models_untouched():
     2종 신설(org 커스텀 이벤트 등록/수정) — 118→120. story #2668(B3): sprintable_submit_
     for_approval 1종 신설(문서 결재 상신 MCP 발견 경로) — 120→121. story #2709: sprintable_
     request_decision 1종 신설(AskUserQuestion 블로킹 대체) — 121→122. story b6b9c52d(#2707
-    부수): sprintable_import_image_artifact 1종 신설(base64 원콜 이미지 임포트) — 122→123."""
-    assert len(_TOOL_DEFS) == 123
+    부수): sprintable_import_image_artifact 1종 신설(base64 원콜 이미지 임포트) — 122→123.
+    story #3331: sprintable_list_conversations 1종 신설(내 참여 방 목록 — 알림 미도달
+    백스톱) — 123→124."""
+    assert len(_TOOL_DEFS) == 124
     assert all(name.startswith("sprintable_") for name in _TOOLS)


### PR DESCRIPTION
## 요약
에이전트가 자기 conversation 목록을 조회할 도구가 없어(id를 이미 알아야 읽히는 `send_chat_message`/`list_chat_messages`/`get_chat_message`뿐) 채널로 밀려오지 않은 방의 존재 자체를 몰랐던 결함 처방(story #74be44d1).

**실사고**: 담롱↔선생님 1:1 DM `896235be`(2026-07-21부터 존재)에 담롱 앞 결재 카드 2장(`6201c75c`·`7869a155`)이 있었는데도, 담롱은 세션 내내 그 방의 존재를 알 수 없었다 — 방이 채널로 밀려오지 않았고 목록 조회 도구가 없었기 때문. 목록 도구가 있었다면 「내 전 conversation에 0건」으로 한 단계 강한 판정이 가능했을 자리.

## 처방
그라운딩(코드 읽기)으로 확인한 대로 **신규 REST 불요** — `GET /api/v2/conversations`(`conversations.py::list_conversations`)가 이미 정확히 "내가 참여 중인 conversation" 조회를 하고 있고, `Depends(get_current_user)`라 agent 키도 그대로 호환된다. MCP 도구 노출만 빠져 있었다.

- `sprintable_list_conversations` 신설(`sprintable_mcp/tools/chat.py`) — 그 REST를 그대로 노출. 이 REST가 실제로 받는 파라미터(`project_id`·`include_agent_conversations`·`limit`·`offset`)만 노출하고, `since`/참여자 필터는 API 자체에 없어 지어내지 않았다(별도 API 확장이 필요 — 범위 밖으로 명시).
- `api_client.py::get_full()` 신설(`post_full()`의 GET 짝) — `{data, total, limit, offset}` body-embedded 페이지네이션 메타를 기본 `unwrap=True`로 잃지 않게.
- `create_conversation` 도구 설명·docstring 갱신 — "조회 아님, dedup 없이 매번 새 방을 만든다 — 기존 방 확인은 `list_conversations`로 먼저" 명시(처방4: 조회 우회로 쓰면 빈 방만 하나 더 생기는 사고를 문서로 방지. 백엔드 dedup-off 동작 자체는 EF-S2 기존 설계라 무변경).

## 테스트
`backend/tests/test_3331_mcp_list_conversations.py` — 8케이스: 기존 REST 호출 계약 pin(신규 REST 0 확인)·`include_agent_conversations` 플래그 전달·limit/offset 생략 시 미전송·limit/offset 문자열화 전달·에러 전파·`create_conversation` 무회귀(여전히 매번 새 방)·`sprintable_list_conversations` 레지스트리 등재+설명 문구(PO 지시 "내가 참여한 방 목록"·"백스톱")·`create_conversation` 설명에 조회 경고 문구.

기존 tool-count 완결성 가드 4곳 갱신(신규 도구 추가 시 항상 걸리는 관례적 카운터, 코드 버그 아님): `test_contract.py::test_total_tool_count`(124→125)·`test_all_expected_tools_registered`(EXPECTED_TOOLS에 추가)·`test_mcp_axis_prefix_b_surface.py`(123→124)·`app/services/mcp_toolset.py::ALL_TOOL_NAMES`(양방향 완결성 가드 대상 목록에 추가).

뮤테이션 셀프체크: `get_full`→`get`로, 필터 파라미터 구성을 제거 → 신규 4케이스가 정확히 그 자리서 RED(등재/문구 테스트는 안 건드렸으니 그대로 그린) — 원복.

전체 MCP 테스트 스위트 `pytest -k mcp` 502 passed(이전 498 + 신규 8 − 4 fixed net). 남은 7 실패는 로컬 `.mcp.json`이 hosted HTTP transport를 가리켜서 나는 환경 의존 실패로, **`develop` 베이스라인에서 동일하게 실패함을 직접 확認**(내 변경과 무관).

## 범위 밖(별도 스토리)
- `since`/참여자 필터 — REST 자체에 없어 API 확장 필요(story 처방 2/3, 이 PR 범위 아님).
- 처방4의 백엔드 dedup 정책 변경(같은 참여자 집합 재사용 여부) — EF-S2 기존 설계 결정이라 PO가 별도 판정.

## 라이브 확인
담롱군 재기동 후(M3) `896235be`가 목록에 실제로 뜨는지가 양성 대조 — PR 본문에 남기는 대로, dev 배포 뒤 실측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfPLRWqGNvcf58NWYrYKba