### PR TITLE
[SID:3329] stage_metadata.action 문구 안에 박힌 doc/story id 자동 참조 토큰화

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import logging
 import random
+import re
 import time
 import uuid
 from collections import defaultdict
@@ -26,7 +27,7 @@ from typing import Any
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import and_, delete, func, or_, select, update
+from sqlalchemy import String, and_, cast, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import (
@@ -1114,6 +1115,126 @@ async def _render_event_notification_doc_ref(
 _DOC_ID_PAYLOAD_LABELS: dict[str, str] = {"previous_output_doc_id": "앞 단계 산출물"}
 
 
+# story #3329 — stage_metadata.action 같은 자유 문구 안에 "박힌" UUID/8자 prefix를 찾는다.
+# ⚠️`\b`(Python re 기본 Unicode 워드 경계)는 한글을 워드 문자로 쳐서 "20808e14의"처럼
+# hex 뒤에 한글 조사가 바로 붙으면 경계가 안 생겨 매치 자체가 실패한다(실측 확인, 이
+# 스토리의 정확히 그 실패 사례) — 그래서 ASCII 영숫자만 보는 lookaround로 직접 짠다.
+# 전체 UUID를 8자 alt보다 먼저 두어, 8자 alt가 UUID의 첫 세그먼트만 따로 집어가지
+# 않게 한다(추가로 8자 alt는 뒤에 `-`가 오면 자체적으로 제외 — 이중 방어).
+_EMBEDDED_FULL_UUID_RE = re.compile(
+    r"(?<![0-9a-zA-Z])[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?![0-9a-zA-Z])",
+    re.IGNORECASE,
+)
+_EMBEDDED_HEX8_RE = re.compile(
+    r"(?<![0-9a-zA-Z])[0-9a-f]{8}(?![0-9a-zA-Z-])",
+    re.IGNORECASE,
+)
+
+
+async def _resolve_doc_or_story_by_id(
+    db: AsyncSession, *, org_id: uuid.UUID, entity_id: uuid.UUID,
+) -> tuple[str, str] | None:
+    """entity_id가 이 org의 doc 또는 story로 실재하면 (entity_type, title). doc을 먼저 본다
+    (story #3329 실사례가 doc뿐이나 AC 문구가 doc/story 둘 다 명시 — doc/story id가 서로
+    겹칠 확률은 사실상 0이라 우선순위 자체는 결과에 영향 없음)."""
+    from app.models.doc import Doc
+
+    doc_title = (await db.execute(
+        select(Doc.title).where(Doc.id == entity_id, Doc.org_id == org_id, Doc.deleted_at.is_(None))
+    )).scalar_one_or_none()
+    if doc_title:
+        return ("doc", doc_title)
+
+    from app.models.pm import Story
+
+    story_title = (await db.execute(
+        select(Story.title).where(Story.id == entity_id, Story.org_id == org_id, Story.deleted_at.is_(None))
+    )).scalar_one_or_none()
+    if story_title:
+        return ("story", story_title)
+    return None
+
+
+async def _resolve_doc_or_story_by_hex8_prefix(
+    db: AsyncSession, *, org_id: uuid.UUID, prefix: str,
+) -> tuple[str, uuid.UUID, str] | None:
+    """story #3329 AC2 — 8자 hex prefix는 그 자체로 유일하지 않을 수 있다. doc+story를 합쳐
+    이 org에서 그 prefix로 시작하는 id가 **정확히 1건**일 때만 치환 대상으로 인정한다
+    (0건="그런 거 없음"·2건 이상="어느 쪽인지 모름" — 둘 다 원문 유지가 안전하다, AC1
+    "오탐 0"의 직접 구현). 대소문자 무관 매칭(id는 소문자로 저장되지만 문구엔 대문자로
+    적혔을 가능성 방어)."""
+    from app.models.doc import Doc
+    from app.models.pm import Story
+
+    like_pattern = f"{prefix.lower()}%"
+    doc_rows = (await db.execute(
+        select(Doc.id, Doc.title).where(
+            Doc.org_id == org_id, Doc.deleted_at.is_(None),
+            cast(Doc.id, String).like(like_pattern),
+        )
+    )).all()
+    story_rows = (await db.execute(
+        select(Story.id, Story.title).where(
+            Story.org_id == org_id, Story.deleted_at.is_(None),
+            cast(Story.id, String).like(like_pattern),
+        )
+    )).all()
+    candidates: list[tuple[str, uuid.UUID, str]] = (
+        [("doc", r.id, r.title) for r in doc_rows] + [("story", r.id, r.title) for r in story_rows]
+    )
+    if len(candidates) != 1:
+        return None
+    return candidates[0]
+
+
+async def _async_regex_sub(pattern: "re.Pattern[str]", async_replacer, text: str) -> str:
+    """`re.sub`의 async 버전 — stdlib엔 없다(콜백이 동기 함수만 허용). 매치를 순서대로
+    돌며 각 자리를 `await async_replacer(match)`의 결과로 채운다(non-overlapping은
+    `finditer`가 이미 보장)."""
+    parts: list[str] = []
+    last_end = 0
+    for m in pattern.finditer(text):
+        parts.append(text[last_end:m.start()])
+        parts.append(await async_replacer(m))
+        last_end = m.end()
+    parts.append(text[last_end:])
+    return "".join(parts)
+
+
+async def _tokenize_embedded_entity_refs(db: AsyncSession, *, org_id: uuid.UUID, text: str) -> str:
+    """story #3329 — stage_metadata.action 같은 자유 문구 안에 박힌 org 내 doc/story
+    UUID(전체 또는 8자 prefix)를 클릭 참조 토큰으로 치환한다. 실재하는 엔티티로 해소될
+    때만 바꾸고(없으면·모호하면 원문 그대로 둔다) — AC1 "오탐 0"의 직접 구현. 전체 UUID
+    패스를 먼저 끝내고 나서 8자 prefix 패스를 돈다 — 전체 UUID가 이미 토큰(`entity:doc:
+    XXXXXXXX-...`)으로 바뀐 뒤라 그 안의 첫 8자가 하이픈 바로 앞이라 8자 정규식 자체가
+    스스로 제외한다(이중 치환 없음, 별도 마스킹 불요)."""
+    from app.services.reference_token import build_reference_token
+
+    async def _replace_full(match: re.Match) -> str:
+        raw = match.group(0)
+        try:
+            entity_id = uuid.UUID(raw)
+        except ValueError:
+            return raw
+        resolved = await _resolve_doc_or_story_by_id(db, org_id=org_id, entity_id=entity_id)
+        if resolved is None:
+            return raw
+        entity_type, title = resolved
+        return build_reference_token(entity_type, entity_id, title) or raw
+
+    text = await _async_regex_sub(_EMBEDDED_FULL_UUID_RE, _replace_full, text)
+
+    async def _replace_prefix(match: re.Match) -> str:
+        raw = match.group(0)
+        resolved = await _resolve_doc_or_story_by_hex8_prefix(db, org_id=org_id, prefix=raw)
+        if resolved is None:
+            return raw
+        entity_type, entity_id, title = resolved
+        return build_reference_token(entity_type, entity_id, title) or raw
+
+    return await _async_regex_sub(_EMBEDDED_HEX8_RE, _replace_prefix, text)
+
+
 async def _render_event_message_content(
     db: AsyncSession, *, org_id: uuid.UUID, definition, payload: dict,
 ) -> str:
@@ -1148,10 +1269,14 @@ async def _render_event_message_content(
     if not role or not action:
         return "\n".join(_generic_event_message_lines(definition.key, payload))
 
+    # story #3329 — action 문구 안에 박힌 doc/story UUID(전체 또는 8자 prefix)를 참조
+    # 토큰으로. work_item_ref/*_doc_id와 같은 "실재하는 것만" 원칙(없으면 원문 그대로).
+    rendered_action = await _tokenize_embedded_entity_refs(db, org_id=org_id, text=action)
+
     lines = [
         f"[이벤트] {definition.key}",
         f"- stage: {stage} ({role})",
-        f"- 할 일: {action}",
+        f"- 할 일: {rendered_action}",
     ]
 
     enum = ((definition.payload_schema.get("properties") or {}).get("stage") or {}).get("enum") or []

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1201,17 +1201,45 @@ async def _async_regex_sub(pattern: "re.Pattern[str]", async_replacer, text: str
     return "".join(parts)
 
 
+def _protected_reference_token_spans(text: str) -> list[tuple[int, int]]:
+    """PO 리뷰(PR#3713, 2026-09-02) — 이미 참조 토큰인 구간(`[제목](entity:type:id)`)의
+    **제목 부분**엔 커밋 sha·다른 엔티티의 8자 prefix·전체 UUID가 우연히 들어있을 수 있다
+    (정의 문구·스토리 제목에 sha 언급이 흔함). 그 구간까지 훑으면 "토큰 속 토큰"(중첩 마크다운
+    링크로 구조가 깨짐)을 만든다 — 기존 하이픈 제외 방어(`(?![0-9a-zA-Z-])`)는 `entity:
+    doc:XXXXXXXX-...`의 **첫 세그먼트만** 막지, 토큰 앞쪽 제목 텍스트는 못 막는다.
+
+    파싱은 이 조직의 기존 SSOT(`mention_parser.py::_CHAT_TOKEN_RE` — FE `applyEntity`가
+    만드는 정확한 토큰 모양, escape된 대괄호까지 인식하도록 여러 사고를 거쳐 다듬어진 정규식)를
+    그대로 재사용한다(새 정규식 발명 0). 호출부가 이 span 안에서 시작하는 매치를 스킵한다."""
+    from app.services.mention_parser import _CHAT_TOKEN_RE
+
+    return [(m.start(), m.end()) for m in _CHAT_TOKEN_RE.finditer(text)]
+
+
+def _starts_within_spans(pos: int, spans: list[tuple[int, int]]) -> bool:
+    return any(start <= pos < end for start, end in spans)
+
+
 async def _tokenize_embedded_entity_refs(db: AsyncSession, *, org_id: uuid.UUID, text: str) -> str:
     """story #3329 — stage_metadata.action 같은 자유 문구 안에 박힌 org 내 doc/story
     UUID(전체 또는 8자 prefix)를 클릭 참조 토큰으로 치환한다. 실재하는 엔티티로 해소될
     때만 바꾸고(없으면·모호하면 원문 그대로 둔다) — AC1 "오탐 0"의 직접 구현. 전체 UUID
-    패스를 먼저 끝내고 나서 8자 prefix 패스를 돈다 — 전체 UUID가 이미 토큰(`entity:doc:
-    XXXXXXXX-...`)으로 바뀐 뒤라 그 안의 첫 8자가 하이픈 바로 앞이라 8자 정규식 자체가
-    스스로 제외한다(이중 치환 없음, 별도 마스킹 불요)."""
+    패스를 먼저 끝내고 나서 8자 prefix 패스를 돈다.
+
+    PO 리뷰(PR#3713) — 각 패스 직전에 `_protected_reference_token_spans`로 "이미 토큰인
+    구간"을 다시 계산해, 그 구간 **안에서 시작하는** 매치는 건드리지 않는다. 전체 UUID
+    패스는 원문 기준 보호구간(원문에 이미 있던 토큰의 제목 안 UUID 방어) — 8자 prefix
+    패스는 **전체 UUID 패스가 끝난 뒤의 텍스트** 기준으로 보호구간을 다시 계산한다(방금
+    만든 새 토큰의 제목 안 8자 hex까지 함께 방어 — 재계산이 핵심, 원문 기준 보호구간을
+    재사용하면 새로 생긴 토큰은 못 막는다)."""
     from app.services.reference_token import build_reference_token
+
+    protected = _protected_reference_token_spans(text)
 
     async def _replace_full(match: re.Match) -> str:
         raw = match.group(0)
+        if _starts_within_spans(match.start(), protected):
+            return raw
         try:
             entity_id = uuid.UUID(raw)
         except ValueError:
@@ -1224,8 +1252,12 @@ async def _tokenize_embedded_entity_refs(db: AsyncSession, *, org_id: uuid.UUID,
 
     text = await _async_regex_sub(_EMBEDDED_FULL_UUID_RE, _replace_full, text)
 
+    protected = _protected_reference_token_spans(text)
+
     async def _replace_prefix(match: re.Match) -> str:
         raw = match.group(0)
+        if _starts_within_spans(match.start(), protected):
+            return raw
         resolved = await _resolve_doc_or_story_by_hex8_prefix(db, org_id=org_id, prefix=raw)
         if resolved is None:
             return raw

--- a/backend/tests/test_3329_embedded_entity_ref_tokenization.py
+++ b/backend/tests/test_3329_embedded_entity_ref_tokenization.py
@@ -355,6 +355,63 @@ async def test_multiple_embedded_refs_in_one_action_both_tokenized():
 
 @_REAL_DB_SKIP
 @pytest.mark.anyio
+async def test_existing_token_title_hex8_untouched():
+    """⭐PO 리뷰(PR#3713, 2026-09-02) — action 문구에 **이미** 참조 토큰이 박혀 있고, 그
+    토큰의 제목 안에 다른(실재하는) doc의 8자 prefix와 우연히 같은 hex8 문자열이 들어있어도
+    건드리지 않는다("토큰 속 토큰" 금지). trap 문서(E1)가 실재해 그 prefix로 해소 가능한데도
+    보호구간이 막아야 한다 — trap이 없으면 이 테스트는 아무것도 증명하지 못한다."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner = await _seed_org_with_owner(s, slug="e3329j")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            outer_doc_id = uuid.UUID("aaaa1111-0000-4000-8000-000000000001")
+            await _seed_doc(s, org_id, project_id, doc_id=outer_doc_id, title="커밋 bbbb2222 반영본")
+            trap_doc_id = uuid.UUID("bbbb2222-0000-4000-8000-000000000001")
+            await _seed_doc(s, org_id, project_id, doc_id=trap_doc_id, title="함정 문서")
+
+            existing_token = f"[커밋 bbbb2222 반영본](entity:doc:{outer_doc_id})"
+            content = await _publish_draft_and_get_content(
+                s, org_id, project_id, publisher_id, slug="e3329j",
+                action_text=f"{existing_token} 확인 요망",
+            )
+            assert existing_token in content
+            assert f"entity:doc:{trap_doc_id}" not in content
+            assert content.count("entity:doc:") == 1
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_new_token_title_hex8_prefix_no_nested_substitution():
+    """⭐PO 리뷰(PR#3713, 2026-09-02) — 전체 UUID 패스가 **방금 만든** 새 토큰의 제목 안에
+    다른(실재하는) doc의 8자 prefix와 같은 hex8 문자열이 들어있어도, 뒤이은 8자 prefix 패스가
+    그 안까지 훑어 중첩 치환하지 않는다. trap 문서(E2)가 실재해 그 prefix로 해소 가능한데도
+    막아야 한다."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner = await _seed_org_with_owner(s, slug="e3329k")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            outer_doc_id = uuid.UUID("cccc3333-0000-4000-8000-000000000001")
+            await _seed_doc(s, org_id, project_id, doc_id=outer_doc_id, title="커밋 dddd4444 반영")
+            trap_doc_id = uuid.UUID("dddd4444-0000-4000-8000-000000000001")
+            await _seed_doc(s, org_id, project_id, doc_id=trap_doc_id, title="함정 문서2")
+
+            content = await _publish_draft_and_get_content(
+                s, org_id, project_id, publisher_id, slug="e3329k",
+                action_text=f"doc {outer_doc_id}를 참고하세요",
+            )
+            assert f"[커밋 dddd4444 반영](entity:doc:{outer_doc_id})" in content
+            assert f"entity:doc:{trap_doc_id}" not in content
+            assert content.count("entity:doc:") == 1
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
 async def test_cross_org_doc_prefix_does_not_leak():
     """AC1 경계 — 다른 org에만 존재하는 8자 prefix는 이 org에선 0건이라(존재판정 org
     스코프) 원문 그대로 — IDOR류 누수 없음(#3323의 org 경계 원칙과 동형)."""

--- a/backend/tests/test_3329_embedded_entity_ref_tokenization.py
+++ b/backend/tests/test_3329_embedded_entity_ref_tokenization.py
@@ -1,0 +1,377 @@
+"""story #3329(febb8a4a) — stage_metadata.action 자유 문구 안에 박힌 doc/story
+UUID(전체 또는 8자 prefix)를 알림 렌더(events.py::_render_event_message_content,
+_tokenize_embedded_entity_refs)가 클릭 참조 토큰으로 바꾸는지 검증.
+
+실사례 재현(담롱 3바퀴 draft 알림): action 문구에 "doc 20808e14의 해당 행"처럼 8자 hex가
+한글 조사 바로 뒤에 붙는다 — Python 기본 `\\b`(Unicode 워드 경계)는 한글을 워드 문자로 쳐서
+이 경계가 안 생기므로(직접 실측 확인), 이 회귀를 실제로 잡는 테스트를 포함한다.
+
+AC1 — 실재하는 엔티티만 토큰화(오탐 0): 존재하는 UUID/유일 prefix는 바뀌고, 존재하지 않거나
+모호한 것은 원문 그대로.
+AC2 — 8자 prefix 유일성 보장 방침: doc+story 합쳐 정확히 1건일 때만 치환, 2건 이상(모호)이면
+원문 유지."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_with_owner(session, *, slug="e3329"):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.team import TeamMember
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org3329", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    owner_user = User(id=uuid.uuid4(), email=f"owner-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(owner_user)
+    await session.commit()
+    owner_member = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=owner_user.id, role="owner")
+    session.add(owner_member)
+    await session.commit()
+    session.add(TeamMember(
+        id=owner_member.id, org_id=org.id, project_id=project.id, type="human", name="owner", is_active=True,
+    ))
+    await session.commit()
+    return org.id, project.id, owner_member.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, story_id=None, title="레시피 산출물"):
+    from app.models.pm import Story
+
+    story = Story(id=story_id or uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_doc(session, org_id, project_id, *, doc_id=None, title):
+    from app.models.doc import Doc
+
+    doc = Doc(
+        id=doc_id or uuid.uuid4(), org_id=org_id, project_id=project_id, title=title,
+        slug=f"doc-{uuid.uuid4().hex[:8]}", content=f"{title} 본문",
+    )
+    session.add(doc)
+    await session.commit()
+    return doc.id
+
+
+_RECIPE_SCHEMA = {
+    "type": "object", "additionalProperties": False,
+    "required": ["stage", "work_item_type", "work_item_id"],
+    "properties": {
+        "stage": {"type": "string", "enum": ["draft", "approve", "publish"]},
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+    },
+}
+_ROUTING = {
+    "escalation": {"kind": "server_derived", "target": "none"},
+    "broadcast": {"kind": "server_derived", "target": "none"},
+}
+
+
+async def _seed_definition(session, org_id, *, slug, action_text):
+    from app.models.event_definition import EventDefinition
+
+    d = EventDefinition(
+        id=uuid.uuid4(), key=f"org.{slug}.recipe_cycle", org_id=org_id, name="테스트 레시피",
+        payload_schema=_RECIPE_SCHEMA, routing=_ROUTING,
+        stage_metadata={"draft": {"role": "Writer", "action": action_text}},
+    )
+    session.add(d)
+    await session.commit()
+    return d.key
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+    )
+
+
+def _fake_request() -> "StarletteRequest":
+    from starlette.requests import Request as StarletteRequest
+    return StarletteRequest(scope={"type": "http", "headers": []})
+
+
+async def _publish(session, *, definition_key, payload, publisher_id, org_id):
+    from app.routers.events import EventPublishRequest, publish_registry_event
+
+    return await publish_registry_event(
+        EventPublishRequest(definition_key=definition_key, payload=payload),
+        BackgroundTasks(), _fake_request(), db=session, auth=_auth(publisher_id, org_id), org_id=org_id,
+    )
+
+
+async def _content_of(session, resp):
+    from app.models.conversation import ConversationMessage
+    from sqlalchemy import select
+
+    msg = (await session.execute(
+        select(ConversationMessage).where(ConversationMessage.id == uuid.UUID(resp["message_id"]))
+    )).scalar_one()
+    return msg.content
+
+
+async def _publish_draft_and_get_content(s, org_id, project_id, publisher_id, *, slug, action_text):
+    story_id = await _seed_story(s, org_id, project_id)
+    definition_key = await _seed_definition(s, org_id, slug=slug, action_text=action_text)
+    resp = await _publish(
+        s, definition_key=definition_key, publisher_id=publisher_id, org_id=org_id,
+        payload={"stage": "draft", "work_item_type": "story", "work_item_id": str(story_id)},
+    )
+    return await _content_of(s, resp)
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_hex8_prefix_unique_in_org_becomes_reference_token():
+    """⭐AC1/AC2 핵심 — 실사례 그대로: action 문구 안 8자 prefix가 org 내 유일한 doc과
+    매치되면 클릭 토큰으로 바뀐다."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner = await _seed_org_with_owner(s, slug="e3329a")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            doc_id = uuid.UUID("20808e14-0000-4000-8000-000000000001")
+            await _seed_doc(s, org_id, project_id, doc_id=doc_id, title="채널별 산출물 규격 표")
+
+            content = await _publish_draft_and_get_content(
+                s, org_id, project_id, publisher_id, slug="e3329a",
+                action_text="채널별 산출물 규격 표 doc 20808e14의 해당 행을 참고해 초안 작성",
+            )
+            assert f"[채널별 산출물 규격 표](entity:doc:{doc_id})" in content
+            assert "20808e14의" not in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_hex8_prefix_immediately_followed_by_korean_particle_still_matches():
+    """⭐한글 조사 바로 붙는 실측 재현(회귀 방지) — Python 기본 `\\b`는 한글을 워드 문자로
+    쳐서 "20808e14의"에서 경계가 안 생겨 매치가 실패했었다(직접 실측 확인). 이 테스트가
+    그 정확한 실패 형태를 pin한다."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner = await _seed_org_with_owner(s, slug="e3329b")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            doc_id = uuid.UUID("a11c3813-0000-4000-8000-000000000001")
+            await _seed_doc(s, org_id, project_id, doc_id=doc_id, title="톤 가이드")
+
+            content = await _publish_draft_and_get_content(
+                s, org_id, project_id, publisher_id, slug="e3329b",
+                action_text="톤 가이드 a11c3813을 따라 작성하고 마침표로 끝내세요",
+            )
+            assert f"[톤 가이드](entity:doc:{doc_id})" in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_hex8_prefix_no_match_stays_raw():
+    """AC1 음성 대조 — 존재하지 않는 8자 prefix는 원문 그대로 남는다(오탐 0)."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner = await _seed_org_with_owner(s, slug="e3329c")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+
+            content = await _publish_draft_and_get_content(
+                s, org_id, project_id, publisher_id, slug="e3329c",
+                action_text="doc deadbeef를 참고하세요",
+            )
+            assert "deadbeef를 참고하세요" in content
+            assert "entity:doc:" not in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_hex8_prefix_ambiguous_multiple_matches_stays_raw():
+    """⭐AC2 핵심 — 같은 8자 prefix로 시작하는 doc이 org 안에 2건이면(모호) 치환하지
+    않는다(«실재하는 엔티티만», 그러나 유일하지 않으면 위험 — 안전하게 원문 유지)."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner = await _seed_org_with_owner(s, slug="e3329d")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            await _seed_doc(
+                s, org_id, project_id,
+                doc_id=uuid.UUID("cafe1234-0000-4000-8000-000000000001"), title="문서 A",
+            )
+            await _seed_doc(
+                s, org_id, project_id,
+                doc_id=uuid.UUID("cafe1234-0000-4000-8000-000000000002"), title="문서 B",
+            )
+
+            content = await _publish_draft_and_get_content(
+                s, org_id, project_id, publisher_id, slug="e3329d",
+                action_text="doc cafe1234를 참고하세요",
+            )
+            assert "cafe1234를 참고하세요" in content
+            assert "entity:doc:" not in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_full_uuid_embedded_becomes_reference_token():
+    """AC1 — 문구에 8자 prefix 대신 전체 UUID가 박혀 있어도 동일하게 토큰화된다."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner = await _seed_org_with_owner(s, slug="e3329e")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            doc_id = uuid.uuid4()
+            await _seed_doc(s, org_id, project_id, doc_id=doc_id, title="규격 표 전체")
+
+            content = await _publish_draft_and_get_content(
+                s, org_id, project_id, publisher_id, slug="e3329e",
+                action_text=f"doc {doc_id}를 참고하세요",
+            )
+            assert f"[규격 표 전체](entity:doc:{doc_id})" in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_full_uuid_nonexistent_stays_raw():
+    """AC1 음성 대조 — 존재하지 않는 전체 UUID는 원문 그대로."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner = await _seed_org_with_owner(s, slug="e3329f")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            ghost_id = uuid.uuid4()
+
+            content = await _publish_draft_and_get_content(
+                s, org_id, project_id, publisher_id, slug="e3329f",
+                action_text=f"doc {ghost_id}를 참고하세요",
+            )
+            assert f"{ghost_id}를 참고하세요" in content
+            assert "entity:doc:" not in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_story_prefix_also_tokenized_not_just_doc():
+    """AC1 — story #3329 문구가 "doc/story UUID"라고 명시한 대로, story id 8자 prefix도
+    doc과 동일하게 토큰화된다."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner = await _seed_org_with_owner(s, slug="e3329g")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            ref_story_id = uuid.UUID("beef0001-0000-4000-8000-000000000001")
+            await _seed_story(s, org_id, project_id, story_id=ref_story_id, title="참고 스토리")
+
+            content = await _publish_draft_and_get_content(
+                s, org_id, project_id, publisher_id, slug="e3329g",
+                action_text="story beef0001의 AC를 그대로 따르세요",
+            )
+            assert f"[참고 스토리](entity:story:{ref_story_id})" in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_multiple_embedded_refs_in_one_action_both_tokenized():
+    """AC1 — 문구 하나에 서로 다른 두 참조가 박혀 있어도 둘 다 정확한 자리에 토큰화된다
+    (위치 보존 pin — _async_regex_sub의 순서 처리 검증)."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner = await _seed_org_with_owner(s, slug="e3329h")
+            publisher_id = await _seed_agent(s, org_id, project_id)
+            doc1_id = uuid.UUID("11110001-0000-4000-8000-000000000001")
+            doc2_id = uuid.UUID("22220002-0000-4000-8000-000000000001")
+            await _seed_doc(s, org_id, project_id, doc_id=doc1_id, title="규격 표")
+            await _seed_doc(s, org_id, project_id, doc_id=doc2_id, title="톤 가이드")
+
+            content = await _publish_draft_and_get_content(
+                s, org_id, project_id, publisher_id, slug="e3329h",
+                action_text="doc 11110001과 doc 22220002를 함께 참고하세요",
+            )
+            assert f"[규격 표](entity:doc:{doc1_id})" in content
+            assert f"[톤 가이드](entity:doc:{doc2_id})" in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_cross_org_doc_prefix_does_not_leak():
+    """AC1 경계 — 다른 org에만 존재하는 8자 prefix는 이 org에선 0건이라(존재판정 org
+    스코프) 원문 그대로 — IDOR류 누수 없음(#3323의 org 경계 원칙과 동형)."""
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_a_id, project_a_id, _owner_a = await _seed_org_with_owner(s, slug="e3329i-a")
+            org_b_id, project_b_id, _owner_b = await _seed_org_with_owner(s, slug="e3329i-b")
+            other_doc_id = uuid.UUID("beefbeef-0000-4000-8000-000000000001")
+            await _seed_doc(s, org_b_id, project_b_id, doc_id=other_doc_id, title="다른 org 문서")
+
+            publisher_id = await _seed_agent(s, org_a_id, project_a_id)
+            content = await _publish_draft_and_get_content(
+                s, org_a_id, project_a_id, publisher_id, slug="e3329i",
+                action_text="doc beefbeef를 참고하세요",
+            )
+            assert "beefbeef를 참고하세요" in content
+            assert "entity:doc:" not in content
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story #3329(febb8a4a). payload 필드(`previous_output_doc_id` 등, #3323)는 이미 토큰화되지만, `action` 자유 문구 안에 "박힌" UUID/8자 prefix(예: "규격 표 20808e14 문서를 참고해 톤 가이드 a11c3813에 맞춰 초안 작성")는 생 문자열로 남아 수신 에이전트가 클릭해 갈 수 없었다.
- `events.py::_tokenize_embedded_entity_refs()` — 전체 UUID 패스를 먼저(8자 prefix가 UUID 첫 세그먼트를 가로채지 않게), 이어서 8자 prefix 패스. 실재하는 org 내 doc/story로 해소될 때만 치환, 못 찾으면/모호하면 원문 유지("오탐 0").
- **AC2 — 8자 prefix 고유성 방침**: doc+story를 합쳐 이 org에서 그 prefix로 시작하는 id가 **정확히 1건**일 때만 치환 대상. 0건("그런 거 없음")·2건 이상("어느 쪽인지 모름") 둘 다 원문 유지.
- **정규식 버그 실측 확인 후 수정**: Python 기본 `\b`(Unicode 워드 경계)는 한글을 워드 문자로 쳐서 "20808e14의"처럼 hex 바로 뒤에 한글 조사가 붙으면 경계가 안 생겨 매치 자체가 실패한다(이 스토리의 정확히 그 실패 사례로 실측 확인). ASCII 영숫자만 보는 lookaround로 직접 구현.
- `_render_event_message_content`의 사이클 렌더 분기에서 `action`을 토큰화 결과로 교체 — 기존 work_item_ref/*_doc_id 토큰화와 동일한 "실재하는 것만" 원칙.

## PO 리뷰 반영(head 1b84a92a4)
"이미 토큰인 구간(제목 안)은 건드리지 말 것" — 기존 하이픈 제외 방어는 새 토큰의 `entity:doc:XXXXXXXX-...` 첫 세그먼트만 막았지, 토큰 **제목** 안의 커밋 sha·다른 doc prefix·전체 UUID까지는 못 막아 "토큰 속 토큰" 중첩 위험이 있었다. `_protected_reference_token_spans()` 신설 — `mention_parser.py::_CHAT_TOKEN_RE`(기존 SSOT, 새 정규식 발명 0) 재사용해 각 패스 직전 보호구간을 계산(전체 UUID 패스=원문 기준·8자 prefix 패스=전체 UUID 패스 출력 기준 재계산), 그 안에서 시작하는 매치는 스킵.

## Test plan
- [x] 신규 `test_3329_embedded_entity_ref_tokenization.py` 11건: 고유 8자 prefix 토큰화, **한글 조사 직접 인접 케이스(회귀 pin)**, 미매치/모호 매칭 원문유지, 전체 UUID 토큰화, 존재하지 않는 UUID 원문유지, story도 doc과 동일 토큰화, 한 문구 내 다중 참조 동시 토큰화, 타 org prefix 미유출, **원문에 이미 있던 토큰 제목 안 8자 hex 무변경(trap 문서 실재)**, **새로 만든 토큰 제목 안 8자 prefix 중첩 0(trap 문서 실재)**.
- [x] **뮤테이션 RED**: 토큰화 호출 bypass → 의존 5건 RED(1차) / 보호구간 체크만 제거 → 신규 2건만 RED(2차, 나머지 9건은 그대로 green) → 각각 원복 → 11/11 green.
- [x] 회귀 무관: `test_3323_prev_output_doc_chain`(9건)·`test_3258_doc_gate_card_content_realdb`(2건) 전부 무회귀(로컬 postgres, 20/20 pass).
- [ ] 카디르 QA → PO 머지.

## 참고 — backlog(이 PR 스코프 밖)
`_resolve_doc_or_story_by_hex8_prefix`의 `cast(id, String).like(...)`는 인덱스를 못 타는 전량 스캔이다(prefix 매칭이라 btree 인덱스 활용 불가) — 지금 규모에선 무해하나, doc/story 테이블이 커지면 별도 최적화 검토 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pN7nEKmenxEugBXV1oVQS