### PR TITLE
[SID:3332] block_template↔payload_schema 계약 정합 검증 + {{ref.X}} 참조 토큰 신설

### DIFF
--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -19,6 +19,7 @@ import { renderStaticEventBlock } from '@/components/chat/event-block-card';
 import { ProofCapsule } from '@/components/proof-capsule/proof-capsule';
 import { useSseMultiplexerContext } from '@/components/realtime-provider';
 
+import { escapeMarkdownLinkText } from '@/components/chat/chat-input-entity-tokens';
 import { fetchWithAuth } from '@/lib/db/client';
 import { buildApproverPickerOptions } from '@/lib/approver-picker-options';
 import { useToast, ToastContainer } from '@/components/ui/toast';
@@ -484,8 +485,17 @@ function ApprovalRequestBody({
     const payload: Record<string, unknown> = {
       gate_type: gate.gate_type,
       verdict: verdictLabel,
-      work_item_title: title,
       resolution_note: gate.resolution_note ?? null,
+    };
+    // story #3332 — 0301 마이그가 preset.gate.verdict의 "대상" 필드를 {{payload.
+    // work_item_title}}(생 텍스트, payload_schema엔 있었으나 아무 발행처도 채운 적 없어
+    // 항상 ⟨missing⟩이었다)에서 {{ref.work_item}}(클릭 토큰)로 바꿨다. 이 카드는 서버가
+    // 계산해 주는 refs를 못 받으므로(자체 fetchGate() 데이터로 합성하는 카드) 여기서
+    // 직접 만든다 — title은 이 컴포넌트가 이미 쓰는 값(work_item_summary?.title 폴백
+    // 포함) 그대로, escapeMarkdownLinkText는 BE build_reference_token과 동일 escape
+    // 규칙(reference_token.py)의 FE 미러(chat-input-entity-tokens.ts) 재사용.
+    const refs: Record<string, string | null> = {
+      work_item: `[${escapeMarkdownLinkText(title)}](entity:${toEntityType(gate.work_item_type)}:${gate.work_item_id})`,
     };
     // PO 리뷰(head 81f7e4a7e) — resolution_note 없음은 템플릿 저자 실수(⟨missing⟩ 마커
     // 대상)가 아니라 정상적인 「선택값 부재」다(기존 카드도 사유 없으면 그 줄 자체를 안
@@ -497,7 +507,7 @@ function ApprovalRequestBody({
       : parsed.blocks.map((b) => (
         b.type === 'fields' ? { ...b, fields: b.fields.filter((f) => f.value !== '{{payload.resolution_note}}') } : b
       ));
-    return renderBlockTemplate({ blocks: blocksToRender }, payload).filter((b) => b.type === 'text' || b.type === 'fields');
+    return renderBlockTemplate({ blocks: blocksToRender }, payload, refs).filter((b) => b.type === 'text' || b.type === 'fields');
   })() : null;
   const riskLevel = deriveRiskLevel(gate);
   const needsFullFlow = usesSignatureFlow(riskLevel);

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -982,17 +982,18 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
       expect(container.textContent).toContain('제안서.md');
     });
 
-    it('story #3332 — {{ref.work_item}}이 UUID 없는 클릭 가능 링크(<a href>)로 렌더된다(Q2 UUID 노출 금지를 실제 링크로 만족)', async () => {
+    it('story #3332 — {{ref.work_item}}이 EntityChip(공유 SSOT)으로 렌더된다 — 칩 클릭 버튼·UUID 텍스트 0(PO 리뷰 PR#3714)', async () => {
       stubGate({ status: 'approved', title: '제안서.md', resolution_note: '근거가 충분합니다' });
       await act(async () => {
         root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} eventDefinitionsByKey={withGateVerdictCatalog} />));
       });
-      const links = Array.from(container.querySelectorAll('a')).filter((a) => a.textContent === '제안서.md');
-      expect(links.length).toBeGreaterThan(0);
-      expect(links[0]?.getAttribute('href')).toBe(`/docs?id=${DOC_ID}`);
-      // 링크의 href 속성 안에는 UUID가 있는 게 정상(내비게이션 경로)이다 — textContent에만
-      // 없어야 한다(사람이 읽는 화면에 안 보이는 것이 Q2의 실제 요구, href 자체는 대상 아님).
-      expect(links[0]?.textContent).not.toContain(DOC_ID);
+      // EntityChip은 <a href>가 아니라 클릭 트리거 <button type="button">으로 렌더된다
+      // (embed-card.tsx — readingPanel.open 또는 모달을 여는 JS 핸들러, href는 내비게이션
+      // DOM 속성이 아니라 내부 상태로만 쓰인다). "링크"가 아니라 "칩(버튼)"이 도달 기준.
+      const chipButtons = Array.from(container.querySelectorAll('button')).filter((b) => b.textContent?.includes('제안서.md'));
+      expect(chipButtons.length).toBeGreaterThan(0);
+      // Q2의 실제 요구: 화면 텍스트 어디에도 UUID가 없어야 한다(href 유무와 무관).
+      expect(container.textContent).not.toContain(DOC_ID);
     });
 
     it('PO 리뷰(head 81f7e4a7e) — resolved + 템플릿 있음 + resolution_note 없음(승인·사유 미기재) — 사유 행 자체가 안 뜬다(⟨missing⟩ 마커 노출 금지, 기존 카드와 동형 비회귀)', async () => {
@@ -1125,7 +1126,7 @@ describe('ChatBubble — story #2637 event_definitions block_template 카드', (
     };
     const catalog = { 'preset.gate.verdict': { key: 'preset.gate.verdict', org_id: null, payload_schema: {}, routing: {}, block_template: REF_TEMPLATE, enabled: true, version: 1 } };
 
-    it('event.refs에 값이 있으면 UUID 없는 클릭 가능 링크로 렌더된다(실제 배포 경로 — #3330 통지 카드)', async () => {
+    it('event.refs에 값이 있으면 EntityChip(공유 SSOT)으로 렌더된다 — 칩 클릭 버튼·UUID 텍스트 0(실제 배포 경로 — #3330 통지 카드)', async () => {
       const message: ChatMessage = {
         ...baseMessage,
         content: '[이벤트] preset.gate.verdict',
@@ -1140,9 +1141,8 @@ describe('ChatBubble — story #2637 event_definitions block_template 카드', (
         root.render(wrap(<ChatBubble message={message} isMine={false} eventDefinitionsByKey={catalog} />));
       });
       expect(container.textContent).not.toContain(DOC_ID);
-      const link = Array.from(container.querySelectorAll('a')).find((a) => a.textContent === 'Threads 포스트 초안');
-      expect(link).not.toBeUndefined();
-      expect(link?.getAttribute('href')).toBe(`/board?story=${DOC_ID}`);
+      const chipButtons = Array.from(container.querySelectorAll('button')).filter((b) => b.textContent?.includes('Threads 포스트 초안'));
+      expect(chipButtons.length).toBeGreaterThan(0);
     });
 
     it('event.refs 자체가 없으면(구서버·work_item 페어 없는 payload) {{ref.work_item}}이 명시 플레이스홀더로 정직하게 드러난다(지어내지 않음)', async () => {

--- a/apps/web/src/components/chat/chat-bubble.test.tsx
+++ b/apps/web/src/components/chat/chat-bubble.test.tsx
@@ -947,13 +947,16 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
   });
 
   describe('story #2637 AC4(PO 08-14 확定) — resolved 분기 preset.gate.verdict block_template 부분 소비', () => {
-    // 0251 마이그(develop 상륙) 실물 그대로 — 대상 필드 value가 work_item_title로 정정된 것.
+    // 0301 마이그(story #3332, develop 상륙) 실물 그대로 — 대상 필드 value가 {{ref.work_item}}
+    // (클릭 토큰)로 정정된 것. 0251의 {{payload.work_item_title}}은 payload_schema엔 있었으나
+    // 어떤 발행처도 채운 적이 없어 항상 ⟨missing⟩이었다(PR#3711 리뷰 실측) — approval-request-
+    // card.tsx가 이제 title로 직접 참조 토큰을 합성해 refs로 넘긴다.
     const GATE_VERDICT_TEMPLATE = {
       blocks: [
         { type: 'header', text: '게이트 판정' },
         { type: 'text', text: '**{{payload.gate_type}}** 게이트 — **{{payload.verdict}}**' },
         { type: 'fields', fields: [
-          { label: '대상', value: '{{payload.work_item_title}}' },
+          { label: '대상', value: '{{ref.work_item}}' },
           { label: '사유', value: '{{payload.resolution_note}}' },
         ] },
       ],
@@ -977,6 +980,19 @@ describe('ChatBubble — story #2604 P2 결재 요청(approval_target) 카드', 
       // '제안서.md'는 카드 상단 제목(기존)과 fields 대상 값(신규) 둘 다에 나타난다 — 중복 등장 자체가
       // 정상(같은 개념 두 자리 표시), 최소 1회 이상만 확認.
       expect(container.textContent).toContain('제안서.md');
+    });
+
+    it('story #3332 — {{ref.work_item}}이 UUID 없는 클릭 가능 링크(<a href>)로 렌더된다(Q2 UUID 노출 금지를 실제 링크로 만족)', async () => {
+      stubGate({ status: 'approved', title: '제안서.md', resolution_note: '근거가 충분합니다' });
+      await act(async () => {
+        root.render(wrap(<ChatBubble message={approvalMessage} isMine={false} eventDefinitionsByKey={withGateVerdictCatalog} />));
+      });
+      const links = Array.from(container.querySelectorAll('a')).filter((a) => a.textContent === '제안서.md');
+      expect(links.length).toBeGreaterThan(0);
+      expect(links[0]?.getAttribute('href')).toBe(`/docs?id=${DOC_ID}`);
+      // 링크의 href 속성 안에는 UUID가 있는 게 정상(내비게이션 경로)이다 — textContent에만
+      // 없어야 한다(사람이 읽는 화면에 안 보이는 것이 Q2의 실제 요구, href 자체는 대상 아님).
+      expect(links[0]?.textContent).not.toContain(DOC_ID);
     });
 
     it('PO 리뷰(head 81f7e4a7e) — resolved + 템플릿 있음 + resolution_note 없음(승인·사유 미기재) — 사유 행 자체가 안 뜬다(⟨missing⟩ 마커 노출 금지, 기존 카드와 동형 비회귀)', async () => {
@@ -1094,6 +1110,56 @@ describe('ChatBubble — story #2637 event_definitions block_template 카드', (
     expect(container.textContent).toContain('S-42');
     // note는 payload에 없다 — 명시 플레이스홀더(조용한 공백 금지, AC0-b).
     expect(container.textContent).toContain('⟨missing: payload.note⟩');
+  });
+
+  describe('story #3332 — {{ref.X}} 네임스페이스(event.refs, publish_registry_event이 계산해 준 참조 토큰)', () => {
+    const REF_TEMPLATE = {
+      blocks: [
+        { type: 'header', text: '게이트 판정' },
+        { type: 'text', text: '**{{payload.gate_type}}** 게이트 — **{{payload.verdict}}**' },
+        { type: 'fields', fields: [
+          { label: '대상', value: '{{ref.work_item}}' },
+          { label: '사유', value: '{{payload.resolution_note}}' },
+        ] },
+      ],
+    };
+    const catalog = { 'preset.gate.verdict': { key: 'preset.gate.verdict', org_id: null, payload_schema: {}, routing: {}, block_template: REF_TEMPLATE, enabled: true, version: 1 } };
+
+    it('event.refs에 값이 있으면 UUID 없는 클릭 가능 링크로 렌더된다(실제 배포 경로 — #3330 통지 카드)', async () => {
+      const message: ChatMessage = {
+        ...baseMessage,
+        content: '[이벤트] preset.gate.verdict',
+        sender_type: 'agent',
+        event: {
+          event_key: 'preset.gate.verdict',
+          payload: { gate_type: 'external_publish', verdict: 'rejected', resolution_note: '어투 정정' },
+          refs: { work_item: `[Threads 포스트 초안](entity:story:${DOC_ID})` },
+        },
+      };
+      await act(async () => {
+        root.render(wrap(<ChatBubble message={message} isMine={false} eventDefinitionsByKey={catalog} />));
+      });
+      expect(container.textContent).not.toContain(DOC_ID);
+      const link = Array.from(container.querySelectorAll('a')).find((a) => a.textContent === 'Threads 포스트 초안');
+      expect(link).not.toBeUndefined();
+      expect(link?.getAttribute('href')).toBe(`/board?story=${DOC_ID}`);
+    });
+
+    it('event.refs 자체가 없으면(구서버·work_item 페어 없는 payload) {{ref.work_item}}이 명시 플레이스홀더로 정직하게 드러난다(지어내지 않음)', async () => {
+      const message: ChatMessage = {
+        ...baseMessage,
+        content: '[이벤트] preset.gate.verdict',
+        sender_type: 'agent',
+        event: {
+          event_key: 'preset.gate.verdict',
+          payload: { gate_type: 'external_publish', verdict: 'approved' },
+        },
+      };
+      await act(async () => {
+        root.render(wrap(<ChatBubble message={message} isMine={false} eventDefinitionsByKey={catalog} />));
+      });
+      expect(container.textContent).toContain('⟨missing: ref.work_item⟩');
+    });
   });
 
   it('유나 design 스티어 2차 — text 블록의 AC0-b 인라인 마크다운(**굵게**·`코드`)이 별표/백틱 리터럴이 아니라 실제 <strong>/<code>로 렌더된다', async () => {

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -598,6 +598,7 @@ export function ChatBubble({
             <EventBlockCard
               template={eventBlockTemplate}
               payload={eventTarget.payload}
+              refs={eventTarget.refs}
             />
           ) : serverCommand ? (
             <ServerCommandResultCard

--- a/apps/web/src/components/chat/event-block-card.tsx
+++ b/apps/web/src/components/chat/event-block-card.tsx
@@ -7,7 +7,8 @@ import { Button } from '@/components/ui/button';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { renderBlockTemplate, type BlockTemplate, type BlockTemplateBlock } from '@/lib/block-template';
 import { extractBackendErrorMessage } from '@/lib/api-error-message';
-import { getEntityHref } from '@/components/chat/embed-card';
+import { EntityChip, getEntityHref } from '@/components/chat/embed-card';
+import { parseEntityRef, unescapeReferenceLabel } from '@/components/chat/entity-ref';
 
 interface EventBlockCardProps {
   /** story #2637 AC2/PO 리뷰(head 80319636c ①) — 파싱은 chat-bubble.tsx가 미리 끝낸다. 이
@@ -41,29 +42,38 @@ const INLINE_MD_RE = /(\*\*[^*]+\*\*|`[^`]+`)/g;
 // (`[제목](entity:type:id)`, escape 규칙까지 동일 — reference_token.py/mention_parser.py의
 // FE 미러). 이 카드의 인라인 렌더러는 원래 **bold**/`code`만 알아서, 이 토큰을 그대로 두면
 // 「대상: [제목](entity:doc:UUID)」처럼 UUID가 그대로 텍스트에 노출된다(story #2637 Q2
-// "UUID 노출 금지" 위반, 실측 — chat-bubble.test.tsx 회귀로 발견). 여기서 제목만 뽑아
-// getEntityHref로 얻은 href가 있으면 클릭 가능한 링크로, 없으면(예: task — 부모 조회가
-// 필요해 동기 해소 불가) 제목 텍스트만 보여준다(UUID는 어느 쪽이든 안 보인다).
-const ENTITY_TOKEN_RE = /\[((?:[^\]\\]|\\.)*)\]\(entity:([a-z_]+):([0-9a-fA-F-]+)\)/g;
-
-function unescapeTokenTitle(title: string): string {
-  return title.replace(/\\(.)/g, '$1');
-}
+// "UUID 노출 금지" 위반, 실측 — chat-bubble.test.tsx 회귀로 발견).
+//
+// PO 리뷰(PR#3714) — 채팅·결재 dialog(#3710)·문서·스토리 패널이 전부 같은 토큰 클래스를
+// `EntityChip`(embed-card.tsx SSOT)으로 그린다. 여기만 자체 `<a>`/`<span>`을 새로 짓지
+// 않는다(두 벌 금지) — 토큰 span 자체를 찾는 정규식만 이 파일 몫으로 남기고(ReactMarkdown
+// 없이 직접 정규식으로 훑는 소비부라 span 탐지 자체는 대체할 게 없다 — chat-bubble.tsx 등은
+// ReactMarkdown이 이미 `[title](href)`를 `<a>`로 갈라 주지만 이 렌더러는 그 파서가 없다),
+// href 파싱은 `parseEntityRef`(entity-ref.ts SSOT, 비-UUID는 null → 폴백)·제목 unescape는
+// `unescapeReferenceLabel`(같은 SSOT 파일 — ReactMarkdown이 없는 소비부 전용)·렌더는
+// `EntityChip` 그대로 재사용한다. `references` 사이드밴드가 없는 소비부라(서버가 발행
+// 시점에 계산한 합성 토큰 — 유령 판정 대상 아님) `resolveEmbedDecision` 없이 embed-card.tsx
+// `MdBody`의 references-less 패턴과 동형으로 ghost/referenceMeta 생략 기본값을 그대로 쓴다.
+const ENTITY_TOKEN_SPAN_RE = /\[((?:[^\]\\]|\\.)*)\]\(([^)]*)\)/g;
 
 function renderTextWithEntityTokens(text: string): React.ReactNode {
   const parts: React.ReactNode[] = [];
   let lastEnd = 0;
   let i = 0;
-  for (const m of text.matchAll(ENTITY_TOKEN_RE)) {
-    const [full, rawTitle, entityType, entityId] = m;
+  for (const m of text.matchAll(ENTITY_TOKEN_SPAN_RE)) {
+    const [full, rawTitle, href] = m;
+    const ref = parseEntityRef(href);
+    if (!ref) continue;
     const start = m.index ?? 0;
     if (start > lastEnd) parts.push(<span key={i++}>{renderInlineMarkdown(text.slice(lastEnd, start))}</span>);
-    const title = unescapeTokenTitle(rawTitle);
-    const href = getEntityHref(entityType, entityId);
     parts.push(
-      href
-        ? <a key={i++} href={href} className="font-medium text-primary underline underline-offset-2">{title}</a>
-        : <span key={i++} className="font-medium text-foreground">{title}</span>,
+      <EntityChip
+        key={i++}
+        entityType={ref.entityType}
+        entityId={ref.entityId}
+        label={unescapeReferenceLabel(rawTitle)}
+        href={getEntityHref(ref.entityType, ref.entityId)}
+      />,
     );
     lastEnd = start + full.length;
   }

--- a/apps/web/src/components/chat/event-block-card.tsx
+++ b/apps/web/src/components/chat/event-block-card.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { renderBlockTemplate, type BlockTemplate, type BlockTemplateBlock } from '@/lib/block-template';
 import { extractBackendErrorMessage } from '@/lib/api-error-message';
+import { getEntityHref } from '@/components/chat/embed-card';
 
 interface EventBlockCardProps {
   /** story #2637 AC2/PO 리뷰(head 80319636c ①) — 파싱은 chat-bubble.tsx가 미리 끝낸다. 이
@@ -16,6 +17,9 @@ interface EventBlockCardProps {
    * 갖지 않는 이유). */
   template: BlockTemplate;
   payload: Record<string, unknown>;
+  /** story #3332 — 서버가 발행 시점에 계산한 참조 토큰({{ref.X}} 해소용). 생략(구버전 캐시
+   * 등)은 undefined→{} 폴백(block-template.ts renderBlockTemplate 기본값)과 동형. */
+  refs?: Record<string, string | null>;
 }
 
 // story #2637 — 유나 design 스티어 2차(08-14, 재작업 방식까지 PR 前 확定).
@@ -26,10 +30,47 @@ interface EventBlockCardProps {
 // 오파싱될 위험이 있다(마커는 항상 리터럴 텍스트로 유지). renderBlockTemplate은 완성된
 // 문자열을 주므로 여기서 정규식으로 다시 갈라 부분 스타일만 입힌다(block-template.ts 파서
 // 자체는 순수 문자열 계약 그대로 유지 — 세그먼트 구조로 바꾸지 않는다).
-const MISSING_MARKER_RE = /(⟨missing: payload\.[a-zA-Z0-9_]+⟩)/g;
+// story #3332 — {{ref.X}}도 같은 "미해소=명시 마커" 원칙이라 시각적으로 동일하게 구분돼야
+// 한다(payload.와 ref. 두 네임스페이스를 하나의 alternation으로).
+const MISSING_MARKER_RE = /(⟨missing: (?:payload|ref)\.[a-zA-Z0-9_]+⟩)/g;
 // AC0-b 스펙 의도(굵게 `**…**`·코드 `` `…` ``)만 지원하는 최소 인라인 마크다운 — 그 밖의
 // 마크다운 문법(링크·이탤릭 등)은 AC0-b 예시에 없어 v1 범위 밖으로 다루지 않는다.
 const INLINE_MD_RE = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+
+// story #3332 — {{ref.X}}가 치환하는 값은 BE `build_reference_token`과 정확히 같은 모양
+// (`[제목](entity:type:id)`, escape 규칙까지 동일 — reference_token.py/mention_parser.py의
+// FE 미러). 이 카드의 인라인 렌더러는 원래 **bold**/`code`만 알아서, 이 토큰을 그대로 두면
+// 「대상: [제목](entity:doc:UUID)」처럼 UUID가 그대로 텍스트에 노출된다(story #2637 Q2
+// "UUID 노출 금지" 위반, 실측 — chat-bubble.test.tsx 회귀로 발견). 여기서 제목만 뽑아
+// getEntityHref로 얻은 href가 있으면 클릭 가능한 링크로, 없으면(예: task — 부모 조회가
+// 필요해 동기 해소 불가) 제목 텍스트만 보여준다(UUID는 어느 쪽이든 안 보인다).
+const ENTITY_TOKEN_RE = /\[((?:[^\]\\]|\\.)*)\]\(entity:([a-z_]+):([0-9a-fA-F-]+)\)/g;
+
+function unescapeTokenTitle(title: string): string {
+  return title.replace(/\\(.)/g, '$1');
+}
+
+function renderTextWithEntityTokens(text: string): React.ReactNode {
+  const parts: React.ReactNode[] = [];
+  let lastEnd = 0;
+  let i = 0;
+  for (const m of text.matchAll(ENTITY_TOKEN_RE)) {
+    const [full, rawTitle, entityType, entityId] = m;
+    const start = m.index ?? 0;
+    if (start > lastEnd) parts.push(<span key={i++}>{renderInlineMarkdown(text.slice(lastEnd, start))}</span>);
+    const title = unescapeTokenTitle(rawTitle);
+    const href = getEntityHref(entityType, entityId);
+    parts.push(
+      href
+        ? <a key={i++} href={href} className="font-medium text-primary underline underline-offset-2">{title}</a>
+        : <span key={i++} className="font-medium text-foreground">{title}</span>,
+    );
+    lastEnd = start + full.length;
+  }
+  if (lastEnd === 0) return renderInlineMarkdown(text);
+  if (lastEnd < text.length) parts.push(<span key={i++}>{renderInlineMarkdown(text.slice(lastEnd))}</span>);
+  return parts;
+}
 
 // PO 리뷰(head 57316d4e7, node 재현 첨부) — 예전엔 여기 "전체가 단일 토큰"일 때 렌더를
 // 건너뛰는 fast-path가 있었는데, 그 판별에 모듈 전역 /g 정규식의 .test()를 썼다. /g는
@@ -56,11 +97,11 @@ function renderInlineMarkdown(text: string): React.ReactNode {
 // (홀수 인덱스=캡처된 매치) 공유 정규식 객체의 lastIndex 상태와 완전히 무관하다.
 function renderTextWithMissingMarkers(text: string): React.ReactNode {
   const parts = text.split(MISSING_MARKER_RE);
-  if (parts.length === 1) return renderInlineMarkdown(text);
+  if (parts.length === 1) return renderTextWithEntityTokens(text);
   return parts.map((part, i) =>
     i % 2 === 1
       ? <em key={i} className="italic text-warning-strong">{part}</em>
-      : <span key={i}>{renderInlineMarkdown(part)}</span>,
+      : <span key={i}>{renderTextWithEntityTokens(part)}</span>,
   );
 }
 
@@ -80,11 +121,11 @@ function renderTextWithMissingMarkers(text: string): React.ReactNode {
  * admin/owner — team_members.role, `/api/me`가 내려주는 그 값)이다. 직무 템플릿 slug(예:
  * "backend-engineer")가 아니다 — 이름이 비슷해 헷갈리기 쉬운 축이라 명시한다.
  */
-export function EventBlockCard({ template, payload }: EventBlockCardProps) {
+export function EventBlockCard({ template, payload, refs }: EventBlockCardProps) {
   const t = useTranslations('chats');
   const { currentMemberType, role } = useDashboardContext();
 
-  const blocks = renderBlockTemplate(template, payload);
+  const blocks = renderBlockTemplate(template, payload, refs);
 
   return (
     <div className="min-w-0 max-w-full space-y-3 rounded-xl rounded-tl-sm border border-border bg-card px-3.5 py-3">

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -83,7 +83,13 @@ export interface ChatMessage {
    * 발행분이다 — event_key로 event_definitions를 조회해 block_template이 있으면 그걸로,
    * 없으면 content(BE의 제네릭 폴백 텍스트, #2633 _render_event_message_content)를 그대로
    * 렌더한다(비회귀). 구서버/일반 메시지는 `?? null`로 통일(approval_target과 같은 이유). */
-  event?: { event_key: string; payload: Record<string, unknown> } | null;
+  event?: {
+    event_key: string;
+    payload: Record<string, unknown>;
+    /** story #3332 — 서버가 발행 시점에 계산한 참조 토큰(block_template의 {{ref.X}}용).
+     * 구서버는 이 키 자체가 없다 — EventBlockCard가 undefined를 {}로 폴백한다(비회귀). */
+    refs?: Record<string, string | null>;
+  } | null;
   /** story #2985 — 'request'(액션 카드)/'result'(회신 카드) 판별(BE msg_metadata.activation.kind
    * → _activation_payload가 top-level로 노출). story #3001부터 'request_info'는 BE가 더
    * 이상 발행하지 않는다(정보성 카드 폐기 — 카드 자체가 지정자에게만 간다). 구서버(undefined/

--- a/apps/web/src/lib/block-template.test.ts
+++ b/apps/web/src/lib/block-template.test.ts
@@ -67,6 +67,27 @@ describe('substituteMustache — story #2637 AC0-b', () => {
   });
 });
 
+describe('substituteMustache — story #3332 {{ref.X}} 네임스페이스', () => {
+  it('ref 값이 있으면 그대로 치환(클릭 토큰 문자열)', () => {
+    expect(substituteMustache('대상: {{ref.work_item}}', {}, { work_item: '[제목](entity:story:abc)' }))
+      .toBe('대상: [제목](entity:story:abc)');
+  });
+
+  it('refs 인자를 생략하면(기존 2-인자 호출부) ref 머스태시는 명시 플레이스홀더', () => {
+    expect(substituteMustache('{{ref.work_item}}', {})).toBe('⟨missing: ref.work_item⟩');
+  });
+
+  it('refs에 키가 없거나 값이 null이면 명시 플레이스홀더(payload와 동일 원칙)', () => {
+    expect(substituteMustache('{{ref.work_item}}', {}, {})).toBe('⟨missing: ref.work_item⟩');
+    expect(substituteMustache('{{ref.work_item}}', {}, { work_item: null })).toBe('⟨missing: ref.work_item⟩');
+  });
+
+  it('payload와 ref 두 네임스페이스가 한 문자열에 섞여도 각자 정확히 치환', () => {
+    expect(substituteMustache('{{payload.verdict}} · {{ref.work_item}}', { verdict: 'approved' }, { work_item: '[제목](entity:story:abc)' }))
+      .toBe('approved · [제목](entity:story:abc)');
+  });
+});
+
 describe('parseBlockTemplate — story #2637 AC0-b 실물', () => {
   it('AC0-b 실 예시를 그대로 파싱한다', () => {
     const parsed = parseBlockTemplate(AC0B_EXAMPLE);
@@ -141,5 +162,38 @@ describe('renderBlockTemplate — story #2637 AC0-b', () => {
     const template = { blocks: [{ type: 'header', text: 'ok' }, { type: 'unknown' }] } as unknown as Parameters<typeof renderBlockTemplate>[0];
     const rendered = renderBlockTemplate(template, {});
     expect(rendered).toEqual([{ type: 'header', text: 'ok' }]);
+  });
+
+  it('story #3332 — preset.gate.verdict 0301 마이그 실 예시: {{ref.work_item}}이 fields에서 클릭 토큰으로 치환된다', () => {
+    const template = parseBlockTemplate({
+      blocks: [
+        { type: 'header', text: '게이트 판정' },
+        { type: 'text', text: '**{{payload.gate_type}}** 게이트 — **{{payload.verdict}}**' },
+        {
+          type: 'fields',
+          fields: [
+            { label: '대상', value: '{{ref.work_item}}' },
+            { label: '사유', value: '{{payload.resolution_note}}' },
+          ],
+        },
+      ],
+    })!;
+    const payload = { gate_type: 'external_publish', verdict: 'rejected', resolution_note: '어투 정정' };
+    const refs = { work_item: '[Threads 포스트 초안](entity:story:abc123)' };
+    const rendered = renderBlockTemplate(template, payload, refs);
+
+    expect(rendered[2]).toEqual({
+      type: 'fields',
+      fields: [
+        { label: '대상', value: '[Threads 포스트 초안](entity:story:abc123)' },
+        { label: '사유', value: '어투 정정' },
+      ],
+    });
+  });
+
+  it('refs 인자를 생략해도(구버전 호출부) payload 전용 템플릿은 그대로 회귀 0', () => {
+    const template = parseBlockTemplate(AC0B_EXAMPLE)!;
+    const payload = { work_item_type: 'story', from_status: 'in-progress', to_status: 'in-review', work_item_id: 'S-123' };
+    expect(renderBlockTemplate(template, payload)).toEqual(renderBlockTemplate(template, payload, {}));
   });
 });

--- a/apps/web/src/lib/block-template.ts
+++ b/apps/web/src/lib/block-template.ts
@@ -69,16 +69,30 @@ export function isKnownBlockType(type: string): type is BlockTemplateBlock['type
   return (BLOCK_TEMPLATE_TYPES as readonly string[]).includes(type);
 }
 
-const MUSTACHE_RE = /\{\{payload\.([a-zA-Z0-9_]+)\}\}/g;
+// story #3332 — `{{ref.X}}`(2번째 머스태시 네임스페이스, `{{payload.X}}`와 병렬) 신설. payload는
+// 발행자가 직접 준 값이지만, ref는 **서버가 발행 시점에 계산한 참조 토큰**(클릭 가능한
+// `[제목](entity:type:id)`, events.py::_publish_registry_event_core의 `refs` — BE
+// event_definition_registry.py::BLOCK_TEMPLATE_REF_VOCAB과 짝인 어휘, 지금은 work_item 1종).
+const MUSTACHE_RE = /\{\{(payload|ref)\.([a-zA-Z0-9_]+)\}\}/g;
 
 /**
- * `{{payload.field}}` 머스태시를 payload 값으로 치환한다. 치환 실패(payload에 그 키가 없거나
- * 값이 null/undefined)는 빈 문자열로 조용히 지우지 않고 `⟨missing: payload.field⟩`를 그대로
- * 남긴다(AC0-b 명시 — 조용한 공백 금지). 값이 문자열이 아니면(숫자·불리언 등) String()으로
- * 직렬화한다 — payload는 JSON이라 임의 타입이 올 수 있다.
+ * `{{payload.field}}`/`{{ref.field}}` 머스태시를 치환한다. `payload`는 payload 값(없거나
+ * null/undefined면 `⟨missing: payload.field⟩`), `ref`는 `refs` 인자의 값(없거나 null이면
+ * `⟨missing: ref.field⟩`) — 둘 다 조용히 공백으로 지우지 않고 실패를 명시한다(AC0-b 원칙의
+ * ref 네임스페이스 확장). 값이 문자열이 아니면(숫자·불리언 등) String()으로 직렬화한다 —
+ * payload는 JSON이라 임의 타입이 올 수 있다(refs는 항상 string | null이라 해당 없음).
  */
-export function substituteMustache(template: string, payload: Record<string, unknown>): string {
-  return template.replace(MUSTACHE_RE, (_match, field: string) => {
+export function substituteMustache(
+  template: string,
+  payload: Record<string, unknown>,
+  refs: Record<string, string | null> = {},
+): string {
+  return template.replace(MUSTACHE_RE, (_match, namespace: string, field: string) => {
+    if (namespace === 'ref') {
+      const value = refs[field];
+      if (value === undefined || value === null) return `⟨missing: ref.${field}⟩`;
+      return value;
+    }
     if (!(field in payload) || payload[field] === null || payload[field] === undefined) {
       return `⟨missing: payload.${field}⟩`;
     }
@@ -87,24 +101,34 @@ export function substituteMustache(template: string, payload: Record<string, unk
 }
 
 /** BlockTemplateFields 하나의 각 field.value에 머스태시 치환을 적용한 새 배열을 만든다. */
-function substituteFieldEntries(fields: BlockTemplateFieldEntry[], payload: Record<string, unknown>): BlockTemplateFieldEntry[] {
-  return fields.map((f) => ({ label: f.label, value: substituteMustache(f.value, payload) }));
+function substituteFieldEntries(
+  fields: BlockTemplateFieldEntry[],
+  payload: Record<string, unknown>,
+  refs: Record<string, string | null>,
+): BlockTemplateFieldEntry[] {
+  return fields.map((f) => ({ label: f.label, value: substituteMustache(f.value, payload, refs) }));
 }
 
 /**
- * 블록 배열 전체에 payload를 치환해 "렌더 준비된" 블록 배열을 만든다(아직 JSX 아님 — 순수
- * 데이터 변환). header/text의 `text`, fields의 각 `value`가 치환 대상이다. actions는 라벨/
- * definition_key가 정적 텍스트라 치환 대상이 아니다(AC0-b 예시에 머스태시가 없음).
+ * 블록 배열 전체에 payload/refs를 치환해 "렌더 준비된" 블록 배열을 만든다(아직 JSX 아님 —
+ * 순수 데이터 변환). header/text의 `text`, fields의 각 `value`가 치환 대상이다. actions는
+ * 라벨/definition_key가 정적 텍스트라 치환 대상이 아니다(AC0-b 예시에 머스태시가 없음).
  * 알 수 없는 type은 스킵한다(등록 게이트를 통과한 template이라면 원래 없어야 하지만, 방어적
- * — 조용히 죽지 않고 렌더 결과에서 빠지는 것으로 정직하게 처리).
+ * — 조용히 죽지 않고 렌더 결과에서 빠지는 것으로 정직하게 처리). `refs` 생략(기존 호출부)은
+ * 완전 additive — `{{ref.X}}`가 없는 템플릿은 그대로, 있는데 refs를 안 주면 명시 플레이스홀더로
+ * 정직하게 드러난다(지어내지 않음).
  */
-export function renderBlockTemplate(template: BlockTemplate, payload: Record<string, unknown>): BlockTemplateBlock[] {
+export function renderBlockTemplate(
+  template: BlockTemplate,
+  payload: Record<string, unknown>,
+  refs: Record<string, string | null> = {},
+): BlockTemplateBlock[] {
   const out: BlockTemplateBlock[] = [];
   for (const block of template.blocks) {
     if (block.type === 'header' || block.type === 'text') {
-      out.push({ type: block.type, text: substituteMustache(block.text, payload) });
+      out.push({ type: block.type, text: substituteMustache(block.text, payload, refs) });
     } else if (block.type === 'fields') {
-      out.push({ type: 'fields', fields: substituteFieldEntries(block.fields, payload) });
+      out.push({ type: 'fields', fields: substituteFieldEntries(block.fields, payload, refs) });
     } else if (block.type === 'actions') {
       out.push(block);
     }

--- a/backend/alembic/versions/0301_preset_gate_verdict_ref_work_item.py
+++ b/backend/alembic/versions/0301_preset_gate_verdict_ref_work_item.py
@@ -1,0 +1,81 @@
+"""story #3332(PO 확定 2026-09-02) — preset.gate.verdict block_template의 "대상" 필드를
+work item 참조 토큰으로 교체.
+
+Revision ID: 0301
+Revises: 0300
+Create Date: 2026-09-02
+
+[[no-pr-for-data]] 게이트 — 프리셋 표현 콘텐츠 변경(0166/0167/0240/0249/0251 선례와 동일 규칙,
+병합 전 선생님 확認 필요할 수 있음).
+
+정정 근거: 0251이 "대상" 값을 `{{payload.work_item_id}}`(원시 UUID)에서
+`{{payload.work_item_title}}`로 바꿨는데, 이 필드는 payload_schema에 optional로만
+추가됐을 뿐(0251) 실제 발행처(`_publish_gate_verdict_notification`, #3330) 어디서도
+채워진 적이 없어 렌더 시 항상 `⟨missing: payload.work_item_title⟩`로 떴다(PR#3711
+리뷰, 페드루 실측). 이번 정정(#3332)이 새로 연 `{{ref.X}}` 네임스페이스(서버가 발행
+시점에 계산하는 클릭 가능한 참조 토큰, events.py::_publish_registry_event_core)로
+"대상"을 `{{ref.work_item}}`으로 바꾼다 — 생 텍스트가 아니라 실제 클릭 토큰이 뜬다.
+
+payload_schema는 이번엔 안 건드린다(0251이 추가한 work_item_title 필드는 그대로
+남겨둔다 — 파괴적 스키마 변경 불필요, 그저 아무도 안 채우는 optional 필드로 남을 뿐
+무해하다).
+"""
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0301"
+down_revision = "0300"
+branch_labels = None
+depends_on = None
+
+_KEY = "preset.gate.verdict"
+
+_OLD_BLOCK_TEMPLATE = {
+    "blocks": [
+        {"type": "header", "text": "게이트 판정"},
+        {"type": "text", "text": "**{{payload.gate_type}}** 게이트 — **{{payload.verdict}}**"},
+        {"type": "fields", "fields": [
+            {"label": "대상", "value": "{{payload.work_item_title}}"},
+            {"label": "사유", "value": "{{payload.resolution_note}}"},
+        ]},
+    ],
+}
+
+_NEW_BLOCK_TEMPLATE = {
+    "blocks": [
+        {"type": "header", "text": "게이트 판정"},
+        {"type": "text", "text": "**{{payload.gate_type}}** 게이트 — **{{payload.verdict}}**"},
+        {"type": "fields", "fields": [
+            {"label": "대상", "value": "{{ref.work_item}}"},
+            {"label": "사유", "value": "{{payload.resolution_note}}"},
+        ]},
+    ],
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE event_definitions "
+            "SET block_template = :block_template, version = version + 1 "
+            "WHERE org_id IS NULL AND key = :key"
+        ),
+        {"block_template": json.dumps(_NEW_BLOCK_TEMPLATE), "key": _KEY},
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE event_definitions "
+            "SET block_template = :block_template, version = version - 1 "
+            "WHERE org_id IS NULL AND key = :key"
+        ),
+        {"block_template": json.dumps(_OLD_BLOCK_TEMPLATE), "key": _KEY},
+    )

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -642,7 +642,9 @@ def _activation_meta(req: "SendMessageRequest") -> dict | None:
 
 def _event_meta(req: "SendMessageRequest") -> dict | None:
     """story #2637 AC 0-a: req.event_context({"event_key","payload"}) → msg_metadata['event'].
-    없으면 None(완전 additive) — publish_registry_event만 이 필드를 채운다."""
+    story #3332 — "refs"(발행 시점에 서버가 계산한 참조 토큰, block_template의 {{ref.X}}용)도
+    같은 dict에 additive로 실린다. 없으면 None(완전 additive) — publish_registry_event만
+    이 필드를 채운다."""
     return {"event": req.event_context} if isinstance(req.event_context, dict) else None
 
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1612,13 +1612,31 @@ async def _publish_registry_event_core(
 
     from app.routers.conversations import SendMessageRequest, send_message
 
+    # story #3332 — block_template의 `{{ref.X}}` 머스태시가 FE에서 해소할 값. `{{payload.X}}`
+    # 와 달리 발행자가 직접 준 값이 아니라 **서버가 발행 시점에 계산**하는 참조 토큰이다 —
+    # 지금은 work_item 1종만(payload에 work_item_type/work_item_id 둘 다 있을 때만 계산,
+    # 기존 함수 재사용 — 새 로직 0). BLOCK_TEMPLATE_REF_VOCAB(event_definition_registry.py)
+    # 과 짝인 어휘라 새 종류를 추가하려면 둘 다 넓혀야 한다.
+    refs: dict[str, str | None] = {}
+    _refs_work_item_type = payload.get("work_item_type")
+    _refs_work_item_id_raw = payload.get("work_item_id")
+    if _refs_work_item_type and _refs_work_item_id_raw:
+        try:
+            _refs_work_item_id = uuid.UUID(str(_refs_work_item_id_raw))
+        except (ValueError, AttributeError, TypeError):
+            _refs_work_item_id = None
+        if _refs_work_item_id is not None:
+            refs["work_item"] = await _render_event_notification_work_item_ref(
+                db, org_id=org_id, work_item_type=_refs_work_item_type, work_item_id=_refs_work_item_id,
+            )
+
     # story #2637 AC 0-a: event_context → msg_metadata['event'](additive) — FE가 이 메시지를
     # "이벤트 발행분"으로 인지하고 event_key로 event_definitions를 조회해 block_template
     # 렌더러를 태울 근거. 렌더러 자체는 #2637 FE 레인(이 커밋은 스키마 배선만).
     send_body = SendMessageRequest(
         content=await _render_event_message_content(db, org_id=org_id, definition=definition, payload=payload),
         mentioned_ids=list(escalation_ids),
-        event_context={"event_key": definition.key, "payload": payload},
+        event_context={"event_key": definition.key, "payload": payload, "refs": refs},
     )
     msg_response = await send_message(
         conv.id, send_body, background_tasks, db=db, auth=auth, org_id=org_id,
@@ -2066,6 +2084,7 @@ async def create_event_definition(
         InvalidStageMetadataError,
         validate_action_auth,
         validate_block_template,
+        validate_block_template_refs,
         validate_event_definition_key,
         validate_event_payload_schema_shape,
         validate_event_routing,
@@ -2083,6 +2102,10 @@ async def create_event_definition(
         validate_event_routing(body.routing, allow_server_derived=False)
         if body.block_template is not None:
             validate_block_template(body.block_template)
+            # story #3332 — 구조 게이트(validate_block_template) 통과 뒤, block_template이
+            # 참조하는 {{payload.X}}/{{ref.X}}가 실제로 해소 가능한지 내용 교차검증(오타를
+            # 등록 시점에 막는다 — 이전엔 이 검증이 전혀 없었다, PR#3711 리뷰 실측).
+            validate_block_template_refs(body.payload_schema, body.block_template)
         if body.action_auth is not None:
             validate_action_auth(body.action_auth)
         validate_stage_metadata(body.payload_schema, body.stage_metadata)
@@ -2142,6 +2165,7 @@ async def update_event_definition(
         InvalidStageMetadataError,
         validate_action_auth,
         validate_block_template,
+        validate_block_template_refs,
         validate_event_payload_schema_shape,
         validate_event_routing,
         validate_stage_metadata,
@@ -2180,6 +2204,26 @@ async def update_event_definition(
             raise HTTPException(
                 status_code=400, detail={"code": "invalid_definition", "message": str(e)},
             ) from e
+
+    # story #3332 — block_template↔payload_schema 교차검증도 위 stage_metadata와 동일
+    # 규율: 둘 중 하나만 바뀌어도 **유효 조합**(새 값 있으면 새 값·없으면 기존 값)으로
+    # 재검증한다 — payload_schema만 줄어들고 block_template을 안 건드리면 그 템플릿이
+    # 참조하던 필드가 조용히 사라질 수 있다. 유효 block_template이 없으면(둘 다 None)
+    # 검증 대상 자체가 없어 스킵.
+    if body.payload_schema is not None or body.block_template is not None:
+        effective_schema_for_template = (
+            body.payload_schema if body.payload_schema is not None else definition.payload_schema
+        )
+        effective_block_template = (
+            body.block_template if body.block_template is not None else definition.block_template
+        )
+        if effective_block_template is not None:
+            try:
+                validate_block_template_refs(effective_schema_for_template, effective_block_template)
+            except InvalidBlockTemplateError as e:
+                raise HTTPException(
+                    status_code=400, detail={"code": "invalid_definition", "message": str(e)},
+                ) from e
 
     content_changed = False
     if body.name is not None:

--- a/backend/app/services/event_definition_registry.py
+++ b/backend/app/services/event_definition_registry.py
@@ -275,6 +275,75 @@ def validate_block_template(template: dict) -> None:
                         raise InvalidBlockTemplateError(f"blocks[{i}].actions[{j}].auth: {e}") from e
 
 
+_TEMPLATE_MUSTACHE_RE = re.compile(r"\{\{(payload|ref)\.([a-zA-Z0-9_]+)\}\}")
+
+# story #3332(PO 확定 2026-09-02) — `{{ref.X}}`의 닫힌 어휘. `{{payload.X}}`(발행자가 직접
+# 준 값)와 병렬인 두 번째 머스태시 네임스페이스로, 서버가 발행 시점에 계산해 event_context.
+# refs에 싣는 "참조 토큰"(클릭 가능한 `[제목](entity:type:id)`) 전용이다 — 지금은 work_item
+# 1종만(work_item_type/work_item_id 페어를 갖는 payload_schema 전제, events.py::
+# _render_event_notification_work_item_ref 재사용 계산). 새 종류를 열려면 이 어휘 +
+# events.py의 실 계산 로직 둘 다 넓혀야 한다(SERVER_DERIVED_TARGETS와 동형 이중 게이트).
+BLOCK_TEMPLATE_REF_VOCAB = frozenset({"work_item"})
+
+
+def _iter_block_template_texts(template: dict):
+    """block_template.blocks 안에서 머스태시 치환 대상인 문자열만 순서대로 낸다 — FE
+    substituteMustache/renderBlockTemplate이 실제로 치환하는 자리와 정확히 같은 범위
+    (header/text의 text, fields[].value). actions는 라벨/definition_key가 정적 텍스트라
+    치환 대상이 아니다(block-template.ts 주석과 동형 — 여기서 검사 범위를 넓히면 FE가
+    실제로 안 보는 자리까지 검증해 거짓양성을 낸다)."""
+    for block in template.get("blocks") or []:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type in ("header", "text"):
+            text = block.get("text")
+            if isinstance(text, str):
+                yield text
+        elif block_type == "fields":
+            for f in block.get("fields") or []:
+                if isinstance(f, dict) and isinstance(f.get("value"), str):
+                    yield f["value"]
+
+
+def validate_block_template_refs(payload_schema: dict, template: dict) -> None:
+    """story #3332 — block_template이 참조하는 머스태시가 실제로 해소 가능한지 등록/PATCH
+    시점에 강제한다(이전엔 이 교차검증이 전혀 없어 `{{payload.work_item_title}}`처럼
+    payload_schema에 없는 키를 참조해도 등록이 통과했다 — 렌더 시점에야 FE가 `⟨missing:
+    payload.x⟩`로 조용히 드러내는 게 유일한 신호였다, PR#3711 리뷰에서 실측 발견).
+
+    두 네임스페이스를 각자 다른 기준으로 검사한다:
+    - `{{payload.X}}` — X가 `payload_schema.properties`에 실재해야 한다(오타를 등록
+      시점에 막는다 — "오타로 써도 통과하나"가 "아니오"가 되게).
+    - `{{ref.X}}` — X가 `BLOCK_TEMPLATE_REF_VOCAB`(서버가 실제로 계산해 줄 수 있는 종류)
+      안에 있어야 한다.
+
+    `validate_block_template`(구조 게이트)이 이미 통과한 template을 전제로 한다 — 이 함수는
+    그 뒤에 이어서 부르는 두 번째 게이트(내용 교차검증)다."""
+    properties = (payload_schema.get("properties") or {}) if isinstance(payload_schema, dict) else {}
+    unknown_payload_keys: set[str] = set()
+    unknown_ref_keys: set[str] = set()
+    for text in _iter_block_template_texts(template):
+        for namespace, key in _TEMPLATE_MUSTACHE_RE.findall(text):
+            if namespace == "payload" and key not in properties:
+                unknown_payload_keys.add(key)
+            elif namespace == "ref" and key not in BLOCK_TEMPLATE_REF_VOCAB:
+                unknown_ref_keys.add(key)
+    errors: list[str] = []
+    if unknown_payload_keys:
+        errors.append(
+            f"block_template이 payload_schema.properties에 없는 payload 키를 참조합니다: "
+            f"{sorted(unknown_payload_keys)}."
+        )
+    if unknown_ref_keys:
+        errors.append(
+            f"block_template이 지원하지 않는 ref 종류를 참조합니다: {sorted(unknown_ref_keys)} "
+            f"(허용: {sorted(BLOCK_TEMPLATE_REF_VOCAB)})."
+        )
+    if errors:
+        raise InvalidBlockTemplateError(" ".join(errors))
+
+
 def validate_event_payload_schema_shape(payload_schema: dict) -> None:
     """story #2636 AC1: org 커스텀 등록 시점에 payload_schema 자체가 유효한 JSON Schema이고
     top-level `additionalProperties: false`를 명시했는지 강제. 미선언 스키마는 JSON Schema

--- a/backend/tests/test_3332_block_template_payload_ref_contract.py
+++ b/backend/tests/test_3332_block_template_payload_ref_contract.py
@@ -47,6 +47,20 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """PR#3711 CI flake(RuntimeError: Event loop is closed) 조사에서 발견 — 실제로 메시지를
+    발행하는 realdb 테스트(publish_registry_event 경유)는 `send_message`의 background task
+    (`mark_agent_replied`)가 이 테스트의 throwaway 엔진이 아니라 `app.core.database.
+    async_session_factory`(전역·프로세스 수명)를 쓴다. pytest-anyio가 테스트마다 새 이벤트
+    루프를 만들어 dispose 없이 두면 다음 테스트가 "이전 루프에 묶인" 커넥션을 재사용하려다
+    누수 경고/`Event loop is closed`로 이어진다(test_3330_gate_verdict_notification.py에서
+    실측 재현·정정). 이 realdb 하네스 246개 파일이 이미 쓰는 표준 방어 fixture 재사용."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 # ============================================================================
 # 1부 — validate_block_template_refs 순수 단위 테스트(DB 불요, test_2637_block_template_
 # validation.py와 동형 패턴).

--- a/backend/tests/test_3332_block_template_payload_ref_contract.py
+++ b/backend/tests/test_3332_block_template_payload_ref_contract.py
@@ -1,0 +1,583 @@
+"""story #3332(68b43066) — block_template↔payload_schema 계약 정합 검증 + {{ref.X}} 참조
+토큰 신설.
+
+근본원인(소스 확認): `validate_block_template`(구조 게이트, story #2637)은 어휘 4종·필수
+필드만 검사하고, `{{payload.X}}`가 참조하는 X가 `payload_schema.properties`에 실재하는지는
+전혀 검사하지 않았다 — preset.gate.verdict의 대상 필드가 `{{payload.work_item_title}}`을
+참조했지만(0251) 그 필드를 채우는 발행처가 없어 항상 `⟨missing: payload.work_item_title⟩`
+로 렌더됐다(PR#3711 리뷰, 페드루 실측).
+
+## 처방
+1. `validate_block_template_refs(payload_schema, template)` 신설 — `{{payload.X}}`는
+   payload_schema.properties ⊆, `{{ref.X}}`는 BLOCK_TEMPLATE_REF_VOCAB(닫힌 어휘, 지금은
+   work_item 1종) 안이어야 한다. 위반 시 InvalidBlockTemplateError(등록 엔드포인트에서
+   기존 규약대로 400 — 이 파일의 sibling test_2637_block_template_registration.py가
+   이미 이 400 규약을 pin해 둠, 스토리 AC 문구의 "422"는 실제 코드 규약과 다름 —
+   PR 본문에 명시 보고).
+2. `events.py::_publish_registry_event_core`가 발행 시점에 work_item_type/work_item_id
+   페어가 있으면 `_render_event_notification_work_item_ref`(기존 함수 재사용)로 참조 토큰을
+   계산해 `event_context.refs.work_item`에 싣는다.
+3. POST/PATCH /api/v2/events/definitions에 새 검증기 배선(등록 시점에 오타를 막는다).
+4. migration 0301 — preset.gate.verdict의 "대상" 필드를 {{payload.work_item_title}}에서
+   {{ref.work_item}}로 교체(생 텍스트가 아니라 클릭 토큰).
+
+AC(스토리 acceptance_criteria 원문 기준):
+- 반려 통지 카드의 "대상"이 클릭 토큰으로 실린다(라이브 검증은 이 PR 스코프 밖 — 배포 후
+  가능. 이 테스트 파일은 발행 시점 refs 계산 + FE 치환 로직까지 각 레이어에서 검증).
+- 존재하지 않는 payload 키를 참조하는 block_template PATCH → 400(양성대조, 이 레포 규약)·
+  정상 템플릿은 통과(음성대조).
+- 회귀 0(기존 프리셋 전부 검증 통과 — 이 파일의 풀 마이그레이션 감사 테스트가 pin).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ============================================================================
+# 1부 — validate_block_template_refs 순수 단위 테스트(DB 불요, test_2637_block_template_
+# validation.py와 동형 패턴).
+# ============================================================================
+
+_GATE_VERDICT_PAYLOAD_SCHEMA = {
+    "type": "object", "additionalProperties": False,
+    "required": ["work_item_type", "work_item_id", "gate_type", "verdict"],
+    "properties": {
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+        "gate_type": {"type": "string"},
+        "verdict": {"type": "string", "enum": ["approved", "rejected"]},
+        "resolver_member_id": {"type": "string", "format": "uuid"},
+        "resolution_note": {"type": ["string", "null"]},
+    },
+}
+
+
+def test_valid_payload_and_ref_references_pass():
+    from app.services.event_definition_registry import validate_block_template_refs
+
+    template = {
+        "blocks": [
+            {"type": "header", "text": "게이트 판정"},
+            {"type": "text", "text": "**{{payload.gate_type}}** — **{{payload.verdict}}**"},
+            {"type": "fields", "fields": [
+                {"label": "대상", "value": "{{ref.work_item}}"},
+                {"label": "사유", "value": "{{payload.resolution_note}}"},
+            ]},
+        ],
+    }
+    validate_block_template_refs(_GATE_VERDICT_PAYLOAD_SCHEMA, template)  # no raise
+
+
+def test_unknown_payload_key_rejected():
+    """⭐근본원인 직접 재현 — 0251이 실제로 저질렀던 실수(payload_schema에 없는
+    work_item_title 참조)가 이제 등록 시점에 막힌다."""
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template_refs
+
+    template = {
+        "blocks": [
+            {"type": "fields", "fields": [
+                {"label": "대상", "value": "{{payload.work_item_title}}"},
+            ]},
+        ],
+    }
+    with pytest.raises(InvalidBlockTemplateError) as ei:
+        validate_block_template_refs(_GATE_VERDICT_PAYLOAD_SCHEMA, template)
+    assert "work_item_title" in str(ei.value)
+
+
+def test_unknown_ref_vocab_rejected():
+    from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template_refs
+
+    template = {
+        "blocks": [
+            {"type": "fields", "fields": [
+                {"label": "대상", "value": "{{ref.totally_unsupported_kind}}"},
+            ]},
+        ],
+    }
+    with pytest.raises(InvalidBlockTemplateError) as ei:
+        validate_block_template_refs(_GATE_VERDICT_PAYLOAD_SCHEMA, template)
+    assert "totally_unsupported_kind" in str(ei.value)
+
+
+def test_actions_block_not_scanned():
+    """actions[].label/definition_key는 정적 텍스트라 검증 대상이 아니다(FE
+    block-template.ts의 치환 범위와 정확히 동형 — 안 그러면 FE가 안 보는 자리까지
+    검증해 거짓양성을 낸다)."""
+    from app.services.event_definition_registry import validate_block_template_refs
+
+    template = {
+        "blocks": [
+            {"type": "actions", "actions": [
+                {"label": "{{payload.nonexistent}}", "action": "publish", "definition_key": "x"},
+            ]},
+        ],
+    }
+    validate_block_template_refs(_GATE_VERDICT_PAYLOAD_SCHEMA, template)  # no raise
+
+
+def test_no_mustache_at_all_passes():
+    from app.services.event_definition_registry import validate_block_template_refs
+
+    template = {"blocks": [{"type": "header", "text": "정적 문구"}]}
+    validate_block_template_refs(_GATE_VERDICT_PAYLOAD_SCHEMA, template)  # no raise
+
+
+# ============================================================================
+# 2부 — POST/PATCH 엔드포인트 배선 확인(test_2637_block_template_registration.py와
+# 동형 realdb 패턴 — 400 규약도 그대로 재사용).
+# ============================================================================
+
+async def _realdb_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug="acme3332"):
+    from app.models.organization import Organization
+
+    org = Organization(id=uuid.uuid4(), name=f"Org-{slug}", slug=slug)
+    session.add(org)
+    await session.commit()
+    return org.id
+
+
+async def _seed_org_member(session, org_id, *, role="admin"):
+    from app.models.project import OrgMember
+
+    user_id = uuid.uuid4()
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role=role))
+    await session.commit()
+    return user_id
+
+
+def _human_auth(user_id: uuid.UUID, org_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(user_id), email="admin@example.com",
+        claims={"app_metadata": {"org_id": str(org_id)}}, org_id=str(org_id),
+    )
+
+
+_SCHEMA_WITH_TITLE = {
+    "type": "object", "additionalProperties": False,
+    "properties": {"title": {"type": "string"}},
+}
+_NONE_ROUTING = {
+    "escalation": {"kind": "server_derived", "target": "none"},
+    "broadcast": {"kind": "server_derived", "target": "none"},
+}
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_register_rejects_block_template_referencing_unknown_payload_key():
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            with pytest.raises(HTTPException) as ei:
+                await create_event_definition(
+                    CreateEventDefinitionRequest(
+                        key="org.acme3332.widget.made", payload_schema=_SCHEMA_WITH_TITLE,
+                        routing=_NONE_ROUTING,
+                        block_template={"blocks": [{"type": "fields", "fields": [
+                            {"label": "오타", "value": "{{payload.titel}}"},
+                        ]}]},
+                    ),
+                    db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_register_accepts_valid_payload_reference():
+    from app.routers.events import CreateEventDefinitionRequest, create_event_definition
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+
+            resp = await create_event_definition(
+                CreateEventDefinitionRequest(
+                    key="org.acme3332.widget.made", payload_schema=_SCHEMA_WITH_TITLE,
+                    routing=_NONE_ROUTING,
+                    block_template={"blocks": [{"type": "fields", "fields": [
+                        {"label": "제목", "value": "{{payload.title}}"},
+                    ]}]},
+                ),
+                db=s, auth=_human_auth(user_id, org_id), org_id=org_id,
+            )
+            assert resp.block_template is not None
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_patch_rejects_when_new_payload_schema_orphans_existing_block_template():
+    """PO 리뷰와 동형 규율(stage_metadata 케이스) — block_template은 안 건드리고
+    payload_schema만 줄여도, 그 조합이 유효한지(effective 값 기준) 재검증한다."""
+    from app.routers.events import (
+        CreateEventDefinitionRequest, UpdateEventDefinitionRequest,
+        create_event_definition, update_event_definition,
+    )
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            user_id = await _seed_org_member(s, org_id, role="admin")
+            auth = _human_auth(user_id, org_id)
+
+            created = await create_event_definition(
+                CreateEventDefinitionRequest(
+                    key="org.acme3332.widget.made", payload_schema=_SCHEMA_WITH_TITLE,
+                    routing=_NONE_ROUTING,
+                    block_template={"blocks": [{"type": "fields", "fields": [
+                        {"label": "제목", "value": "{{payload.title}}"},
+                    ]}]},
+                ),
+                db=s, auth=auth, org_id=org_id,
+            )
+
+            with pytest.raises(HTTPException) as ei:
+                await update_event_definition(
+                    created.id,
+                    UpdateEventDefinitionRequest(
+                        payload_schema={"type": "object", "additionalProperties": False, "properties": {}},
+                    ),
+                    db=s, auth=auth, org_id=org_id,
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+# ============================================================================
+# 3부 — 발행 시점 refs 계산(realdb, work_item_stakeholders 라우팅 재사용 검증과 동형
+# 패턴 — test_3330의 _publish 헬퍼 재사용).
+# ============================================================================
+
+async def _seed_org_with_owner(session, *, slug="e3332"):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.team import TeamMember
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org3332", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    owner_user = User(id=uuid.uuid4(), email=f"owner-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(owner_user)
+    await session.commit()
+    owner_member = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=owner_user.id, role="owner")
+    session.add(owner_member)
+    await session.commit()
+    session.add(TeamMember(
+        id=owner_member.id, org_id=org.id, project_id=project.id, type="human", name="owner", is_active=True,
+    ))
+    await session.commit()
+    return org.id, project.id, owner_member.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="executor"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, assignee_id, title="Threads 포스트 초안"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, assignee_id=assignee_id)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_system_publisher(session, org_id, project_id):
+    """test_3330_gate_verdict_notification.py와 동형 우회 — Base.metadata.create_all
+    스키마엔 team_members가(프로덕션의 members/project_access 위 VIEW와 달리) 독립
+    테이블이라 미리 심어야 _get_or_create_system_publisher가 있는 걸 찾는다."""
+    from app.models.member import Member
+    from app.models.team import TeamMember
+
+    publisher_id = uuid.uuid4()
+    session.add(Member(
+        id=publisher_id, org_id=org_id, type="agent", name="시스템 발행",
+        runtime_type="system-publisher", is_active=True,
+    ))
+    session.add(TeamMember(
+        id=publisher_id, org_id=org_id, project_id=project_id, type="agent",
+        name="시스템 발행", runtime_type="system-publisher", is_active=True,
+    ))
+    await session.commit()
+    return publisher_id
+
+
+async def _seed_preset_gate_verdict_definition(session):
+    from app.models.event_definition import EventDefinition
+    from sqlalchemy import select
+
+    existing = (await session.execute(
+        select(EventDefinition).where(
+            EventDefinition.key == "preset.gate.verdict", EventDefinition.org_id.is_(None),
+        )
+    )).scalar_one_or_none()
+    if existing is not None:
+        return
+    session.add(EventDefinition(
+        id=uuid.uuid4(), key="preset.gate.verdict", org_id=None,
+        payload_schema=_GATE_VERDICT_PAYLOAD_SCHEMA,
+        routing={
+            "escalation": {"kind": "server_derived", "target": "none"},
+            "broadcast": {
+                "kind": "server_derived", "target": "work_item_stakeholders",
+                "inherit_conversation_scope": True,
+            },
+        },
+        enabled=True, version=1,
+    ))
+    await session.commit()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_publish_computes_work_item_ref_when_payload_has_work_item_pair():
+    """refs 계산은 `publish_registry_event`(→`_publish_registry_event_core`)에 있다 —
+    `transition_gate`를 거치지 않고 직접 발행해 이 계산 로직 자체만 검증한다(story #3330의
+    "언제 발행하는가" 게이팅과는 독립된 축 — 이 worktree는 #3330 착지 前 origin/develop
+    기준이라 transition_gate로 external_publish 타입을 거치면 그 미착지 게이팅에 걸려
+    발행 자체가 스킵된다, 실측 확인)."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+    from fastapi import BackgroundTasks
+    from starlette.requests import Request as StarletteRequest
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_id = await _seed_org_with_owner(s, slug="e3332a")
+            await _seed_preset_gate_verdict_definition(s)
+            await _seed_system_publisher(s, org_id, project_id)
+            executor_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=executor_id)
+
+            def _auth(agent_id, org_id):
+                from app.dependencies.auth import AuthContext
+                return AuthContext(
+                    user_id=str(agent_id), email=None,
+                    claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+                )
+
+            resp = await publish_registry_event(
+                EventPublishRequest(
+                    definition_key="preset.gate.verdict",
+                    payload={
+                        "work_item_type": "story", "work_item_id": str(story_id),
+                        "gate_type": "external_publish", "verdict": "approved",
+                        "resolver_member_id": str(owner_id),
+                    },
+                ),
+                BackgroundTasks(), StarletteRequest(scope={"type": "http", "headers": []}),
+                db=s, auth=_auth(executor_id, org_id), org_id=org_id,
+            )
+            await s.commit()
+
+            from app.models.conversation import ConversationMessage
+            from sqlalchemy import select
+
+            msg = (await s.execute(
+                select(ConversationMessage).where(ConversationMessage.id == uuid.UUID(resp["message_id"]))
+            )).scalar_one()
+            refs = (msg.msg_metadata or {}).get("event", {}).get("refs") or {}
+            assert refs.get("work_item") == f"[Threads 포스트 초안](entity:story:{story_id})"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_publish_refs_empty_when_payload_lacks_work_item_pair():
+    """preset.goal.measured처럼 work_item_type/id가 없는 payload는 refs가 빈 dict —
+    지어내지 않는다."""
+    from app.routers.events import EventPublishRequest, publish_registry_event
+    from fastapi import BackgroundTasks
+    from starlette.requests import Request as StarletteRequest
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_id = await _seed_org_with_owner(s, slug="e3332b")
+            await _seed_system_publisher(s, org_id, project_id)
+
+            from app.models.event_definition import EventDefinition
+
+            s.add(EventDefinition(
+                id=uuid.uuid4(), key="preset.goal.measured", org_id=None,
+                payload_schema={
+                    "type": "object", "additionalProperties": False,
+                    "required": ["goal_id", "metric_value"],
+                    "properties": {
+                        "goal_id": {"type": "string", "format": "uuid"},
+                        "metric_value": {"type": "number"},
+                    },
+                },
+                routing={
+                    "escalation": {"kind": "server_derived", "target": "none"},
+                    "broadcast": {"kind": "server_derived", "target": "goal_owner", "inherit_conversation_scope": False},
+                },
+                enabled=True, version=1,
+            ))
+            await s.commit()
+
+            from app.models.pm import Goal
+
+            goal = Goal(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="측정 목표")
+            s.add(goal)
+            await s.commit()
+
+            def _auth(agent_id, org_id):
+                from app.dependencies.auth import AuthContext
+                return AuthContext(
+                    user_id=str(agent_id), email=None,
+                    claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(org_id),
+                )
+
+            resp = await publish_registry_event(
+                EventPublishRequest(
+                    definition_key="preset.goal.measured",
+                    payload={"goal_id": str(goal.id), "metric_value": 3},
+                ),
+                BackgroundTasks(), StarletteRequest(scope={"type": "http", "headers": []}),
+                db=s, auth=_auth(owner_id, org_id), org_id=org_id,
+            )
+            from app.models.conversation import ConversationMessage
+            from sqlalchemy import select
+
+            msg = (await s.execute(
+                select(ConversationMessage).where(ConversationMessage.id == uuid.UUID(resp["message_id"]))
+            )).scalar_one()
+            assert (msg.msg_metadata or {}).get("event", {}).get("refs") == {}
+    finally:
+        await engine.dispose()
+
+
+# ============================================================================
+# 4부 — 풀 마이그레이션 감사(회귀 가드) — PO 리뷰 조건 "기존 프리셋 전부가 새 검증기를
+# 통과하는지" 를 이후 마이그레이션에도 계속 지키게 한다. alembic upgrade head를 실제로
+# 돌려 org_id IS NULL block_template 보유 정의 전부를 새 검증기에 통과시킨다.
+# ============================================================================
+
+def _to_asyncpg_url(url: str) -> str:
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+def _to_plain_postgres_url(url: str) -> str:
+    return url.replace("postgresql+asyncpg://", "postgresql://").replace("postgresql+psycopg2://", "postgresql://")
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_all_seeded_preset_block_templates_pass_new_validator():
+    """실측(2026-09-02, 이 스토리 작업 중 직접 실행): 이 감사를 alembic upgrade head로
+    실행하면 preset 4종 + preset.workflow.* 8종 + preset.steer.instruct 1종, 합계 13건
+    전부 PASS(0301 포함). 향후 새 프리셋이 이 검증을 놓치면 여기서 잡힌다."""
+    import asyncio
+    import subprocess
+    import sys
+
+    db_name = f"backend_e3332_audit_{uuid.uuid4().hex[:8]}"
+    base_url = _to_plain_postgres_url(_REAL_DB_URL).rsplit("/", 1)[0]
+    admin_url = _to_asyncpg_url(base_url + "/postgres")
+
+    import asyncpg
+
+    admin_dsn = admin_url.replace("postgresql+asyncpg://", "postgresql://")
+    admin_conn = await asyncpg.connect(admin_dsn)
+    try:
+        await admin_conn.execute(f'CREATE DATABASE "{db_name}"')
+    finally:
+        await admin_conn.close()
+
+    audit_db_url = _to_plain_postgres_url(f"{base_url}/{db_name}")
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "alembic", "upgrade", "head"],
+            cwd=str(__import__("pathlib").Path(__file__).parent.parent),
+            env={**__import__("os").environ, "ALEMBIC_DATABASE_URL": audit_db_url},
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"alembic upgrade head 실패:\n{result.stdout}\n{result.stderr}"
+
+        from sqlalchemy.ext.asyncio import create_async_engine
+        from app.services.event_definition_registry import InvalidBlockTemplateError, validate_block_template_refs
+
+        engine = create_async_engine(_to_asyncpg_url(audit_db_url))
+        try:
+            async with engine.connect() as conn:
+                result_rows = await conn.exec_driver_sql(
+                    "SELECT key, payload_schema, block_template FROM event_definitions "
+                    "WHERE block_template IS NOT NULL AND org_id IS NULL ORDER BY key"
+                )
+                rows = result_rows.fetchall()
+        finally:
+            await engine.dispose()
+
+        failures = []
+        for key, payload_schema, block_template in rows:
+            try:
+                validate_block_template_refs(payload_schema, block_template)
+            except InvalidBlockTemplateError as e:
+                failures.append((key, str(e)))
+
+        assert len(rows) >= 13, f"프리셋 정의 수가 예상(13건 이상)보다 적음 — 마이그레이션 실행 누락 의심: {len(rows)}"
+        assert failures == [], f"기존 프리셋이 새 검증기를 통과 못 함(회귀): {failures}"
+    finally:
+        admin_conn = await asyncpg.connect(admin_dsn)
+        try:
+            await admin_conn.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
+        finally:
+            await admin_conn.close()


### PR DESCRIPTION
## Summary
- story #3332(68b43066). PR#3711 리뷰 중 PO 실측 발견: dev `preset.gate.verdict`의 block_template "대상" 필드가 `{{payload.work_item_title}}`을 참조하는데(0251), 어떤 발행처도 그 필드를 채운 적이 없어 항상 `⟨missing: payload.work_item_title⟩`로 렌더됐다.
- **근본원인**: `validate_block_template`(구조 게이트, #2637)은 어휘 4종·필수 필드만 검사하고, `{{payload.X}}`가 참조하는 X가 `payload_schema.properties`에 실재하는지는 전혀 검사하지 않았다.
- BE `validate_block_template_refs(payload_schema, template)` 신설, POST/PATCH에 배선(PATCH는 stage_metadata와 동형 "effective 값" 재검증).
  - ⚠️스토리 AC 문구는 "422"였으나 이 레포 기존 규약(`test_2637_block_template_registration.py`가 이미 pin)은 400 — 일관성 우선으로 400 유지, 전체 전환은 스코프 밖.
- BE `events.py` — 발행 시점에 work_item_type/id 페어가 있으면 기존 `_render_event_notification_work_item_ref`(#3313, 새 로직 0)로 참조 토큰 계산해 `event_context.refs.work_item`에 실음.
- migration 0301 — `preset.gate.verdict`의 "대상"을 `{{payload.work_item_title}}` → `{{ref.work_item}}`로 교체.
- FE `block-template.ts` — `{{ref.X}}` 신설(payload와 병렬, 완전 additive).
- FE `event-block-card.tsx` — **회귀 발견 즉시 수정**: `{{ref.X}}` 값(`[제목](entity:type:id)`)을 그대로 텍스트로 두면 story #2637 Q2("UUID 노출 금지") 위반(기존 테스트 회귀로 직접 발견) — `getEntityHref` 재사용해 클릭 가능한 `<a>` 링크로 교체, UUID는 href 속성 안에만.
- FE `approval-request-card.tsx` — resolved 게이트 카드도 refs.work_item 직접 합성(`escapeMarkdownLinkText` 재사용).

## Test plan
- [x] BE 신규 11건(단위 5·등록/PATCH 배선 3·발행시점 refs 2·**풀 마이그레이션 감사 1** — alembic upgrade head 후 org_id IS NULL block_template 보유 정의 13건 전부 새 검증기 통과, 향후 회귀 가드).
- [x] **뮤테이션 BE**: 검증기 배선 제거→2건 RED / refs 계산 제거→1건 RED → 각각 원복 → 11/11 green.
- [x] BE 회귀 74/74 pass(로컬 postgres) — `test_2637_block_template_registration/validation/preset_block_template_seed`·`test_2632_event_definitions`·`test_2634_event_definitions_list`.
- [x] FE 신규 8건 — **뮤테이션 FE**: ref 치환 제거→5건 RED / entity-token→링크 변환 제거→3건 RED(Q2 회귀 재현 포함) → 각각 원복 → green.
- [x] FE 회귀 191/191 pass — `chat-bubble.test.tsx`(gate-verdict 픽스처를 0301 실물로 갱신)·`approval-request-card.test.tsx`·`block-template.test.ts`.
- [x] `tsc --noEmit` 클린.
- [x] 전역 엔진 dispose 방어 fixture 선제 추가(PR#3711 CI flake 조사에서 발견한 클래스 — 이 파일도 publish_registry_event 경유 실 발행 테스트라 같은 위험, 기존 246개 realdb 파일 표준 fixture 재사용). BE 11/11+회귀 60/60 재확認, 누수 경고 0.
- [ ] 카디르 QA → PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pN7nEKmenxEugBXV1oVQS
