### PR TITLE
[SID:3324] MCP sprintable_get_doc — doc_id 인자 추가(slug와 택1)

### DIFF
--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -573,8 +573,11 @@ _TOOL_DEFS: list[tuple] = [
      " 생긴다(story #2282).",
      ListDocsInput, list_docs),
     ("sprintable_get_doc",
-     "[지식] slug로 문서 단건 조회. 응답 reference_token 필드가 이 문서를 가리키는 참조 토큰"
-     "([제목](entity:doc:id))을 준다 — 채팅 등에 그대로 쓰면 참조가 생긴다(story #2282).",
+     "[지식] slug 또는 doc_id로 문서 단건 조회(둘 중 하나 필수, story #3324) — 이벤트 payload·"
+     "참조 토큰(entity:doc:id)·게이트 neutral_facts가 주는 id를 doc_id에 그대로 넣으면 열린다"
+     "(예전엔 slug만 받아 그 id들로 «Doc not found»가 났다). 응답 reference_token 필드가 이"
+     " 문서를 가리키는 참조 토큰([제목](entity:doc:id))을 준다 — 채팅 등에 그대로 쓰면 참조가"
+     " 생긴다(story #2282).",
      GetDocInput, get_doc),
     ("sprintable_search_docs",
      "[지식] 문서 제목/본문 검색.",

--- a/backend/sprintable_mcp/tools/docs.py
+++ b/backend/sprintable_mcp/tools/docs.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Literal
 
 from mcp.types import TextContent
+from pydantic import model_validator
 
 from ..api_client import client
 from ..response import err, ok
@@ -19,7 +20,21 @@ class ListDocsInput(SprintableInput):
 
 
 class GetDocInput(SprintableInput):
-    slug: str
+    """story #3324 — 이벤트 payload·참조 토큰(`entity:doc:id`)·게이트 neutral_facts는 전부
+    doc id를 주는데, 이 도구는 slug만 받아 «Doc not found»로 막혔다(담롱·PO 둘 다 오늘 같은
+    자리에서 걸림 — PO는 search_docs로 slug를 되짚어야 했다). `doc_id`(uuid)를 주면 slug
+    해소 단계 자체를 건너뛰고 `GET /api/v2/docs/{doc_id}`로 직행 — REST는 이미 있어 MCP
+    인자 배선만(신규 REST 0). slug/doc_id는 택1(ConversationScopedInput의 conversation_id/
+    thread_id 검증과 동형 관례) — 둘 다 없으면 조용히 통과시키지 않고 명시 에러."""
+
+    slug: str | None = None
+    doc_id: str | None = None
+
+    @model_validator(mode="after")
+    def _require_slug_or_doc_id(self) -> "GetDocInput":
+        if not self.slug and not self.doc_id:
+            raise ValueError("slug 또는 doc_id 중 하나가 필요합니다.")
+        return self
 
 
 class SearchDocsInput(SprintableInput):
@@ -101,7 +116,7 @@ async def list_docs(args: ListDocsInput) -> list[TextContent]:
 
 
 async def get_doc(args: GetDocInput) -> list[TextContent]:
-    """slug로 문서 단건 조회 — 본문(content) 포함.
+    """slug 또는 doc_id로 문서 단건 조회 — 본문(content) 포함.
 
     8a8e881a: list 엔드포인트(/api/v2/docs?slug=)는 DocSummary(메타·snippet만·content 미포함)를
     반환해 에이전트가 서로의 doc 본문을 못 읽었다. slug→id 해소 후 GET /{id}(DocResponse·content
@@ -110,8 +125,14 @@ async def get_doc(args: GetDocInput) -> list[TextContent]:
 
     story #2191: slug 조회 자체는 BE에서도 항상 {data,meta} 봉투로 오므로(단건이라도) 여기서
     같은 방식으로 언랩한다 — 안 하면 summaries[0]이 dict를 정수 인덱싱하려다 터진다.
+
+    story #3324: `doc_id`가 오면 slug 해소 단계(list+필터) 자체를 건너뛰고 `GET /{id}`로
+    직행한다 — 이벤트 payload·참조 토큰이 주는 id를 그대로 열 수 있게. `doc_id`가 없으면
+    (기존 계약대로) slug로 해소.
     """
     try:
+        if args.doc_id:
+            return ok(await client.get(f"/api/v2/docs/{args.doc_id}"))
         result = await client.get(
             "/api/v2/docs", params={"project_id": client.require_project_id(), "slug": args.slug}
         )

--- a/backend/tests/test_3324_mcp_get_doc_by_id.py
+++ b/backend/tests/test_3324_mcp_get_doc_by_id.py
@@ -1,0 +1,108 @@
+"""story #3324(d37d1f09) — MCP `sprintable_get_doc`가 slug만 받아, 이벤트 payload·참조
+토큰(entity:doc:id)·게이트 neutral_facts가 주는 doc id로는 «Doc not found»가 나던 결함
+처방. 담롱·PO 둘 다 3바퀴 같은 자리에서 걸림(PO는 search_docs로 slug를 되짚어야 했다).
+
+처방: `doc_id`(uuid) 인자 추가 — slug와 택1. `doc_id`가 오면 slug 해소(list+필터) 단계
+자체를 건너뛰고 GET /api/v2/docs/{doc_id}로 직행(신규 REST 0, 기존 배선 재사용). slug
+경로는 완전 무변경(회귀 0). 둘 다 없으면 조용히 통과시키지 않고 pydantic ValidationError로
+명시 거부(ConversationScopedInput의 conversation_id/thread_id 검증과 동형 관례)."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+_DOC_ID = "11111111-1111-1111-1111-111111111111"
+_DOC_RESP = {
+    "id": _DOC_ID, "title": "Handoff", "slug": "handoff", "tags": [],
+    "content": "FULL BODY — 핸드오프 계약 내용", "content_format": "markdown",
+    "updated_at": "2026-06-15T00:00:00Z",
+}
+
+
+@pytest.mark.anyio
+async def test_get_doc_by_doc_id_skips_slug_resolution_and_hits_id_endpoint_directly():
+    """⭐AC1 핵심 — doc_id를 주면 slug 해소(list+필터) 호출 없이 곧장 GET /{id}로 간다(이벤트
+    payload가 주는 id 그대로 열림)."""
+    from sprintable_mcp.tools.docs import GetDocInput, get_doc
+
+    calls: list[tuple] = []
+
+    async def fake_get(path, params=None):
+        calls.append((path, params))
+        return _DOC_RESP
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.project_id = "proj"
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        out = await get_doc(GetDocInput(doc_id=_DOC_ID))
+
+    parsed = json.loads(out[0].text)
+    assert parsed["content"] == "FULL BODY — 핸드오프 계약 내용"
+    assert parsed["id"] == _DOC_ID
+    # slug 해소용 list 엔드포인트(/api/v2/docs)를 전혀 호출하지 않았다 — 단일 호출로 직행.
+    assert calls == [(f"/api/v2/docs/{_DOC_ID}", None)]
+
+
+@pytest.mark.anyio
+async def test_get_doc_slug_path_unchanged_regression():
+    """AC1 회귀 0 — slug만 준 기존 경로는 완전 무변경(list+필터 후 GET /{id})."""
+    from sprintable_mcp.tools.docs import GetDocInput, get_doc
+
+    list_resp = [{"id": _DOC_ID, "title": "Handoff", "slug": "handoff", "snippet": "intro..."}]
+    calls: list[tuple] = []
+
+    async def fake_get(path, params=None):
+        calls.append((path, params))
+        return list_resp if path == "/api/v2/docs" else _DOC_RESP
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.project_id = "proj"
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        out = await get_doc(GetDocInput(slug="handoff"))
+
+    parsed = json.loads(out[0].text)
+    assert parsed["content"] == "FULL BODY — 핸드오프 계약 내용"
+    assert calls[0][0] == "/api/v2/docs"
+    assert calls[1][0] == f"/api/v2/docs/{_DOC_ID}"
+
+
+@pytest.mark.anyio
+async def test_get_doc_neither_slug_nor_doc_id_raises_explicit_error():
+    """AC1 — 둘 다 없으면 명시 에러(조용히 통과·조용히 실패 둘 다 아님)."""
+    from sprintable_mcp.tools.docs import GetDocInput
+
+    with pytest.raises(ValidationError, match="slug 또는 doc_id"):
+        GetDocInput()
+
+
+@pytest.mark.anyio
+async def test_get_doc_by_doc_id_not_found_surfaces_error():
+    """doc_id 경로도 존재하지 않는 id면 err()로 에러가 뜬다(BE 404가 client.get에서 예외로
+    전파되는 기존 관용구 재사용 — get_chat_message 등과 동형)."""
+    from sprintable_mcp.tools.docs import GetDocInput, get_doc
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.project_id = "proj"
+        mock_client.get = AsyncMock(side_effect=Exception("404 Not Found"))
+        out = await get_doc(GetDocInput(doc_id="99999999-9999-9999-9999-999999999999"))
+
+    assert "error" in out[0].text.lower()
+
+
+def test_get_doc_registered_description_documents_doc_id():
+    """도구 설명이 doc_id 지원을 명시한다(온보딩 표면 — 도구 발견 시점에 알 수 있어야 함)."""
+    from sprintable_mcp.server import _TOOL_DEFS
+
+    matches = [t for t in _TOOL_DEFS if t[0] == "sprintable_get_doc"]
+    assert len(matches) == 1
+    _name, description, _input_model, _fn = matches[0]
+    assert "doc_id" in description


### PR DESCRIPTION
## 요약
이벤트 payload·참조 토큰(`entity:doc:id`)·게이트 neutral_facts는 전부 doc id를 주는데, `sprintable_get_doc`은 slug만 받아 「Doc not found」로 막혔다(story #d37d1f09). 담롱·PO 둘 다 오늘 같은 자리에서 걸림 — PO는 `search_docs`로 slug를 되짚어야 했다.

## 처방
- `GetDocInput`에 `doc_id`(uuid) 필드 추가 — `slug`와 택1(`ConversationScopedInput`의 `conversation_id`/`thread_id` 검증과 동형 관례, pydantic `model_validator`로 둘 다 없으면 명시 거부).
- `doc_id`가 오면 slug 해소 단계(list+필터 왕복) 자체를 건너뛰고 기존 `GET /api/v2/docs/{id}`로 직행 — 신규 REST 0.
- `slug`만 준 기존 경로는 완전 무변경(회귀 0).
- 도구 설명(server.py)에 `doc_id` 지원 명시(온보딩 표면 — 발견 시점에 알 수 있어야 함).

새 도구 등록이 아니라 기존 도구 스키마 확장이라 tool-count 완결성 가드(4곳, PR#3712에서 매번 갱신하던 그것)는 대상 아님 — 확認 完.

## 테스트
`backend/tests/test_3324_mcp_get_doc_by_id.py` 5케이스 + 기존 `test_mcp_get_doc_8a8e881a.py` 2케이스 그린:
- doc_id 경로가 slug 해소 호출 없이 단일 `GET /{id}` 호출로 직행(AC1 핵심).
- slug 경로 완전 무변경(회귀 0).
- slug/doc_id 둘 다 없으면 `ValidationError`.
- doc_id 경로도 404 등 에러가 정상 전파.
- 도구 설명에 `doc_id` 문구 등재.

뮤테이션 셀프체크: doc_id 직행 분기 제거 → 그 자리 1케이스가 정확히 RED("Doc not found: None"), slug 회귀 테스트는 무관하게 그린 — 원복.

전체 MCP 테스트 스위트 508 passed(신규 5·전체 무회귀) — 남은 7 실패는 로컬 `.mcp.json`이 hosted transport를 가리켜서 나는 환경 의존 실패로 develop 베이스라인에서도 동일(PR#3712에서 이미 확認한 것과 동일 클래스).

## 「id로 못 여는 도구」 후보(별건 — 코드 변경 없음, 목록만)
- **`sprintable_get_story` 부재 확認**(server.py에 `sprintable_get_story` grep 0건) — 스토리 단건은 `search_stories`로만 되짚을 수 있다. story #3324 처방 문구가 지목한 그대로, 별도 스토리로 등재 권장.
- `sprintable_get_chat_message`는 `conversation_id`(부모 스코프 id)가 필수 — 이건 doc처럼 「slug만 받고 id를 거부」하는 클래스가 아니라 「부모 컨텍스트를 이미 알아야」하는 다른 축이라 이 스토리 범위 밖(원 인지 상태 그대로 열려 있음, 별건 판단은 PO 몫).
- 가볍게 표본 확인한 `get_task`/`get_artifact`는 이미 순수 id 필드(`task_id`/`artifact_id`)를 받는다 — doc이 유별났던 자리였을 가능성. 전수 감사는 이 PR 스코프 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfPLRWqGNvcf58NWYrYKba