### PR TITLE
[SID:3319] 머지 게이트 기본 지정 승인자 org 정책 — QA 前 org owner 서명 가능 결함 처방

### DIFF
--- a/backend/alembic/versions/0302_org_gate_policy_merge_default_approver.py
+++ b/backend/alembic/versions/0302_org_gate_policy_merge_default_approver.py
@@ -1,0 +1,35 @@
+"""story #3319(2026-09-02, 선생님 처방 확定) — 머지 게이트 기본 지정 승인자 org 정책.
+
+머지 게이트가 designated_approver_id=None으로 생성돼 rule B(gates.py::
+_non_doc_gate_approvable)가 project owner/admin 전원(org owner 포함)에게 «승인 가능»으로
+노출했다(실사고: PR#3706 머지 게이트를 QA 前에 선생님이 서명). org_gate_policy에
+merge_gate_default_approver_member_id(nullable UUID)를 추가 — 값이 있으면 신규 생성되는
+머지 게이트의 designated_approver_id로 채워져 그 멤버 1인에게만 승인 자격이 좁혀진다.
+미설정(None, 기본값)은 현행 무변경(회귀 0). 0276(gate.designated_approver_id 신설)과 동형
+패턴 — 데이터 마이그 없음.
+
+Revision ID: 0302
+Revises: 0301
+Create Date: 2026-09-02
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0302"
+down_revision = "0301"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "org_gate_policy",
+        sa.Column("merge_gate_default_approver_member_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("org_gate_policy", "merge_gate_default_approver_member_id")

--- a/backend/app/models/hitl_config.py
+++ b/backend/app/models/hitl_config.py
@@ -49,6 +49,17 @@ class OrgGatePolicy(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, unique=True, index=True)
     posture: Mapped[str] = mapped_column(String(20), nullable=False, server_default="balanced")
+    # story #3319(2026-09-02, 선생님 처방 확定) — 머지 게이트가 designated_approver_id=None으로
+    # 생성돼 rule B(gates.py::_non_doc_gate_approvable)가 project owner/admin 전원(org owner
+    # 포함)에게 «승인 가능»으로 노출했다(실사고: PR#3706 머지 게이트를 QA 前에 선생님이 서명).
+    # 이 값(org 멤버·nullable)을 설정하면 머지 게이트 생성 시 designated_approver_id로 채워져
+    # rule B가 그 멤버 1인에게만 승인 자격을 좁힌다(gates.py::_non_doc_can_approve 변경 참조).
+    # 미설정(None, 기본값)은 현행 무변경(회귀 0). 사람 멤버만 허용(에이전트는 requires_human
+    # 게이트에 구조적으로 서명 불가) — 쓰기 시점(routers/hitl_config.py::upsert_org_policy)에서
+    # is_org_owner_or_admin과 동형 NOT EXISTS 패턴으로 검증(422).
+    merge_gate_default_approver_member_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -520,8 +520,28 @@ async def _non_doc_can_approve(
     user_id: uuid.UUID,
     org_id: uuid.UUID,
     project_id: uuid.UUID | None,
+    designated_approver_id: uuid.UUID | None = None,
+    caller_member_id: uuid.UUID | None = None,
 ) -> bool:
     """gate_type 별 규칙 dispatch.
+
+    story #3319(2026-09-02, 선생님 처방 확定) — ``designated_approver_id``가 있으면 gate_type을
+    안 가리고 그 1인에게만 승인 자격을 좁힌다(최우선 단락 — 아래 gate_type별 규칙보다 먼저
+    적용). 실사고: 머지 게이트에 org policy로 지정 승인자를 넣어도(create_gate 호출부만
+    고치면) 이 함수가 그 값을 안 봐서 project/org owner 전원이 여전히 승인 가능했다 —
+    designated_approver_id 배선과는 **별개**의 인가 로직이 필요했다. 영향 범위는 머지뿐 아니라
+    designated_approver_id가 설정된 **모든** gate_type(레시피 external_publish 등)에 미친다 —
+    "지정 승인자만 결정"이 gate_type 무관 단일 규칙이 되는 것이 맞는 의미(PO 확定). 미지정
+    (None, 기본값)은 아래 기존 규칙 그대로 — 회귀 0.
+
+    ⚠️``user_id``는 이 함수 아래쪽 규칙(``is_org_owner_or_admin``/``get_project_role``)이
+    쓰는 **user 축**(org_members.user_id)인 반면, ``Gate.designated_approver_id``는 **member
+    축**(org_members.id/team_members.id, story #2985)이다 — 두 공간이 다르므로
+    ``user_id == designated_approver_id`` 비교는 항상 거짓(다른 uuid 공간)이 되는 조용한
+    버그였다(첫 구현에서 실측으로 발견 — 지정 승인자 본인도 403이 남). 그래서 caller의
+    **member id**(호출부가 이미 ``resolve_member()``로 갖고 있는 ``resolved.id``)를 별도
+    인자로 받는다 — user_id를 여기서 다시 member_id로 해소하는 신규 쿼리를 만들지 않는다
+    (호출부 재사용, N+1 없음).
 
     - artifact_canonicalize: **휴먼 전용**(추가 role 제약 없음). E-CANVAS C4-S8(story a5118cb0)
       설계 주석(visual_artifacts.py propose_canonical_version 바로 위) — "승인/반려는 기존
@@ -532,6 +552,8 @@ async def _non_doc_can_approve(
     - 그 외(merge/pr_review/qa/deploy 등): rule B(``_non_doc_gate_approvable``, story #1974) —
       project owner/admin, project-무관 work_item 은 org owner/admin.
     """
+    if designated_approver_id is not None:
+        return caller_member_id is not None and caller_member_id == designated_approver_id
     if gate_type == "artifact_canonicalize":
         return True
     return await _non_doc_gate_approvable(session, user_id, org_id, project_id)
@@ -571,7 +593,10 @@ async def _authorize_gate_approve_equivalent(
         _project_id = await resolve_work_item_project_id(
             session, org_id, gate.work_item_type, gate.work_item_id,
         )
-        if not await _non_doc_can_approve(session, gate.gate_type, uuid.UUID(auth.user_id), org_id, _project_id):
+        if not await _non_doc_can_approve(
+            session, gate.gate_type, uuid.UUID(auth.user_id), org_id, _project_id,
+            designated_approver_id=gate.designated_approver_id, caller_member_id=resolved.id,
+        ):
             raise HTTPException(
                 status_code=403,
                 detail=(
@@ -848,16 +873,24 @@ async def list_gates(
     # #2198(PO 판정): 캐시 키가 project_id 단독에서 (gate_type, project_id) 로 바뀌었다 — 승인
     # 자격이 이제 gate_type 에도 의존한다(_non_doc_can_approve 표 참조. artifact_canonicalize
     # 는 project_id 무관 항상 True).
-    approvable_cache: dict[tuple[str, uuid.UUID | None], bool] = {}
+    # story #3319 — designated_approver_id도 키에 편입해야 한다: 같은 (gate_type, project_id)
+    # 조합이라도 게이트마다 designated_approver_id가 다를 수 있어(예: 머지 게이트 A는 정책
+    # 적용 前 생성=None, B는 적용 後 생성=특정 멤버) 이걸 빼면 먼저 계산된 캐시값을 서로 다른
+    # 게이트가 잘못 공유한다(둘 다 project owner인데 A는 승인 가능·B는 designated 아니라
+    # 불가여야 하는데, 캐시가 A의 True를 B에도 돌려주는 사고).
+    approvable_cache: dict[tuple[str, uuid.UUID | None, uuid.UUID | None], bool] = {}
     eligible_ids: set[uuid.UUID] = set()
     if non_doc_gates and resolved is not None and resolved.type == "human":
-        # N+1 방지: gate 여러 건이 같은 (gate_type, project_id) 를 가리켜도 _non_doc_can_approve 는
-        # **고유 조합당 1회**만 호출(캐시) — gate 개수와 무관.
+        # N+1 방지: gate 여러 건이 같은 (gate_type, project_id, designated_approver_id) 를
+        # 가리켜도 _non_doc_can_approve 는 **고유 조합당 1회**만 호출(캐시) — gate 개수와 무관.
         for _resp, g in non_doc_gates:
             pid = project_id_by_work_item.get(g.work_item_id)
-            key = (g.gate_type, pid)
+            key = (g.gate_type, pid, g.designated_approver_id)
             if key not in approvable_cache:
-                approvable_cache[key] = await _non_doc_can_approve(session, g.gate_type, _uid, org_id, pid)
+                approvable_cache[key] = await _non_doc_can_approve(
+                    session, g.gate_type, _uid, org_id, pid,
+                    designated_approver_id=g.designated_approver_id, caller_member_id=resolved.id,
+                )
             if approvable_cache[key]:
                 eligible_ids.add(g.id)
 
@@ -1233,7 +1266,10 @@ async def get_gate_endpoint(
             )
             resp.can_approve = _reason is None and is_valid_transition(gate.status, "approved")
         elif resolved.type == "human":  # rule B 는 human 체크가 없어 여기서 fail-closed(list_gates 와 동형).
-            _approvable = await _non_doc_can_approve(session, gate.gate_type, _uid, org_id, project_id)
+            _approvable = await _non_doc_can_approve(
+                session, gate.gate_type, _uid, org_id, project_id,
+                designated_approver_id=gate.designated_approver_id, caller_member_id=resolved.id,
+            )
             resp.can_approve = _approvable and is_valid_transition(gate.status, "approved")
     return resp
 

--- a/backend/app/routers/hitl_config.py
+++ b/backend/app/routers/hitl_config.py
@@ -3,7 +3,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -25,6 +25,37 @@ from app.services.disposition_advisor import DEFAULT_MIN_VERDICTS, get_dispositi
 from app.services.gate_resolver import resolve_disposition
 
 router = APIRouter(prefix="/api/v2/gate-config", tags=["gate-config", "Trust"])
+
+
+async def _is_eligible_merge_gate_default_approver(
+    session: AsyncSession, org_id: uuid.UUID, member_id: uuid.UUID,
+) -> bool:
+    """story #3319 — merge_gate_default_approver_member_id 값 검증. is_org_owner_or_admin
+    (project_auth.py:424-461)의 NOT EXISTS 패턴을 그대로 재사용하되, 그 함수는 user_id 축으로
+    조회하는데 이 필드는 org_members.id(member_id) 축이라 여기서 member_id 키로 다시 짠다
+    (member_id→user_id 해소 후 재호출하는 간접보다, 같은 쿼리를 member_id로 직접 겨냥하는
+    쪽이 원자적 — 해소·검증 사이 레이스 없음). owner/admin role + 미삭제 + agent 미연동
+    (story #2058 AC5②와 동일 불변식) 전부 만족해야 True."""
+    row = await session.execute(
+        text(
+            """
+            SELECT 1 FROM org_members
+            WHERE id = :member_id
+              AND org_id = :org_id
+              AND deleted_at IS NULL
+              AND role IN ('owner', 'admin')
+              AND NOT EXISTS (
+                SELECT 1 FROM members m
+                WHERE m.user_id = org_members.user_id
+                  AND m.org_id = org_members.org_id
+                  AND m.type = 'agent'
+              )
+            LIMIT 1
+            """
+        ),
+        {"member_id": member_id, "org_id": org_id},
+    )
+    return row.scalar_one_or_none() is not None
 
 
 # ── org posture ───────────────────────────────────────────────────────────────
@@ -55,15 +86,33 @@ async def upsert_org_policy(
     전무해 org 내 임의 멤버가 org 전체 HITL gate posture를 바꿀 수 있었다."""
     if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
         raise HTTPException(status_code=403, detail="org admin/owner required")
+    # story #3319 — 값이 있으면(지우는 게 아니라 채우는 PUT) 사람 owner/admin 멤버인지 검증.
+    # None(미설정 또는 명시 해제)은 검증 대상 없음 — 현행 무변경(회귀 0)으로 그대로 통과.
+    if body.merge_gate_default_approver_member_id is not None and not (
+        await _is_eligible_merge_gate_default_approver(
+            session, org_id, body.merge_gate_default_approver_member_id,
+        )
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "merge_gate_default_approver_member_id는 이 조직의 human owner/admin 멤버여야 "
+                "합니다(에이전트는 requires_human 게이트에 서명할 수 없습니다)."
+            ),
+        )
     r = await session.execute(
         select(OrgGatePolicy).where(OrgGatePolicy.org_id == org_id).limit(1)
     )
     policy = r.scalar_one_or_none()
     if policy is None:
-        policy = OrgGatePolicy(id=uuid.uuid4(), org_id=org_id, posture=body.posture)
+        policy = OrgGatePolicy(
+            id=uuid.uuid4(), org_id=org_id, posture=body.posture,
+            merge_gate_default_approver_member_id=body.merge_gate_default_approver_member_id,
+        )
         session.add(policy)
     else:
         policy.posture = body.posture
+        policy.merge_gate_default_approver_member_id = body.merge_gate_default_approver_member_id
     await session.flush()
     await session.refresh(policy)
     return OrgGatePolicyResponse.model_validate(policy)

--- a/backend/app/schemas/hitl_config.py
+++ b/backend/app/schemas/hitl_config.py
@@ -8,6 +8,9 @@ from app.models.hitl_config import DISPOSITIONS, GATE_TYPES, POSTURES
 
 class OrgGatePolicyCreate(BaseModel):
     posture: str = "balanced"
+    # story #3319 — 미지정(None, 기본값)은 현행 무변경(회귀 0). 사람 멤버만 허용(422) — 검증은
+    # routers/hitl_config.py::upsert_org_policy가 is_org_owner_or_admin과 동형 NOT EXISTS로.
+    merge_gate_default_approver_member_id: uuid.UUID | None = None
 
     @field_validator("posture")
     @classmethod
@@ -23,6 +26,7 @@ class OrgGatePolicyResponse(BaseModel):
     id: uuid.UUID
     org_id: uuid.UUID
     posture: str
+    merge_gate_default_approver_member_id: uuid.UUID | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.models.gate import Gate, set_gate_evidence_status, set_gate_status
+from app.models.hitl_config import OrgGatePolicy
 from app.models.participation import ParticipationRole
 from app.services.gate_resolver import (
     SOURCE_MEMBER_OVERRIDE,
@@ -520,6 +521,15 @@ async def evaluate_merge_gate(
         gate_type=MERGE_GATE_TYPE, pr_number=db_pr_number, repo_full_name=db_repo_full_name,
     )
     _prior_status = _prior_gate.status if _prior_gate is not None else None
+    # story #3319(2026-09-02, 선생님 처방 확定) — org가 merge_gate_default_approver_member_id를
+    # 설정해 뒀으면 그 멤버로 designated_approver_id를 채운다(gates.py::_non_doc_can_approve의
+    # 새 분기가 이 값이 있으면 project/org owner 전원이 아니라 그 1인에게만 승인 자격을
+    # 좁힌다 — 실사고: QA 前 머지 게이트를 org owner가 승인 가능 상태로 봄). 미설정(기본값)이면
+    # None 그대로 — 현행 무변경(회귀 0).
+    _org_policy = (await session.execute(
+        select(OrgGatePolicy.merge_gate_default_approver_member_id)
+        .where(OrgGatePolicy.org_id == org_id)
+    )).scalar_one_or_none()
     gate = await create_gate(
         session,
         org_id,
@@ -532,6 +542,7 @@ async def evaluate_merge_gate(
         neutral_facts=facts,
         pr_number=db_pr_number,
         repo_full_name=db_repo_full_name,
+        designated_approver_id=_org_policy,
     )
 
     # 재제출 re-open(doc-gate 48f064e5 선례 이식): uq(work_item,gate_type)=1행 + terminal=immutable

--- a/backend/tests/test_1974_gate_assigned_to_me.py
+++ b/backend/tests/test_1974_gate_assigned_to_me.py
@@ -32,6 +32,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.gate_mock_factory import make_gate
+
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
 # realdb 섹션이 Base.metadata.create_all 을 호출한다 — conftest.py AST 가드(story 8236bbc3) 대응.
@@ -144,7 +146,10 @@ def _resp(g):
 
 
 def _doc_gate(requester_id, *, gate_id=None, status="pending"):
-    return SimpleNamespace(
+    # story #3319 — SimpleNamespace 대신 make_gate()(tests/gate_mock_factory.py, story #2837
+    # "건드릴 때 이관" 관례): 이 파일을 새로 고치는 김에, Gate에 새 필드(designated_approver_id)가
+    # 늘 때마다 SimpleNamespace가 AttributeError로 재발하던 걸 구조적으로 차단한다.
+    return make_gate(
         id=gate_id or uuid.uuid4(), gate_type="doc_approval", work_item_type="doc",
         work_item_id=uuid.uuid4(),
         neutral_facts={"requested_by_member_id": str(requester_id)} if requester_id else {},
@@ -153,7 +158,7 @@ def _doc_gate(requester_id, *, gate_id=None, status="pending"):
 
 
 def _story_gate(*, gate_type="merge", gate_id=None, status="pending", work_item_id=None):
-    return SimpleNamespace(
+    return make_gate(
         id=gate_id or uuid.uuid4(), gate_type=gate_type, work_item_type="story",
         work_item_id=work_item_id or uuid.uuid4(), neutral_facts={}, status=status,
     )
@@ -161,7 +166,7 @@ def _story_gate(*, gate_type="merge", gate_id=None, status="pending", work_item_
 
 def _org_level_gate(*, gate_id=None, status="pending"):
     """project_id=None 케이스(구조적 project-무관 work_item — wf_line_version 류)."""
-    return SimpleNamespace(
+    return make_gate(
         id=gate_id or uuid.uuid4(), gate_type="workflow_config_publish", work_item_type="wf_line_version",
         work_item_id=uuid.uuid4(), neutral_facts={}, status=status,
     )

--- a/backend/tests/test_2631_gate_undo_discuss.py
+++ b/backend/tests/test_2631_gate_undo_discuss.py
@@ -445,8 +445,11 @@ async def test_discuss_endpoint_non_approver_403_service_not_called():
     from app.routers.gates import request_gate_discussion_endpoint, GateDiscussionRequest
     from fastapi import HTTPException
     caller = _resolved_human()
+    # story #3319 — designated_approver_id: _authorize_gate_approve_equivalent가 이제 이 필드를
+    # _non_doc_can_approve 호출부 kwarg로 읽는다(그 함수 자체는 아래서 mock돼도 kwarg 평가는
+    # mock 이전에 일어나 AttributeError로 터진다) — None(정책 미설정)으로 명시.
     fake_gate = SimpleNamespace(id=uuid.uuid4(), gate_type="merge", work_item_type="story",
-                                work_item_id=uuid.uuid4())
+                                work_item_id=uuid.uuid4(), designated_approver_id=None)
     result = AsyncMock()
     result.scalar_one_or_none = lambda: fake_gate
     discussfn = AsyncMock()
@@ -491,7 +494,7 @@ async def test_discuss_endpoint_forces_actor_from_auth():
     from app.routers.gates import request_gate_discussion_endpoint, GateDiscussionRequest
     caller = _resolved_human()
     fake_gate = SimpleNamespace(id=uuid.uuid4(), gate_type="artifact_canonicalize", work_item_type="visual_artifact",
-                                work_item_id=uuid.uuid4())
+                                work_item_id=uuid.uuid4(), designated_approver_id=None)
     result = SimpleNamespace(scalar_one_or_none=lambda: fake_gate)
     discussfn = AsyncMock(return_value=SimpleNamespace())
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \

--- a/backend/tests/test_3319_merge_gate_designated_approver_policy.py
+++ b/backend/tests/test_3319_merge_gate_designated_approver_policy.py
@@ -1,0 +1,573 @@
+"""story #3319(40030054) — 머지 게이트가 designated_approver_id=None으로 생성돼 rule B
+(gates.py::_non_doc_gate_approvable)가 project/org owner·admin 전원에게 «승인 가능»으로
+노출하던 결함 처방(실사고: PR#3706 머지 게이트를 QA 前에 org owner가 서명).
+
+처방 B(선생님 확定): OrgGatePolicy.merge_gate_default_approver_member_id(nullable) 설정 시
+①evaluate_merge_gate가 그 값을 designated_approver_id로 채우고 ②_non_doc_can_approve의
+새 최우선 분기가 «designated_approver_id가 있으면 그 1인만 승인 가능»을 gate_type 무관
+강제한다(두 변경이 다 있어야 실제로 owner inbox의 승인 버튼이 비활성화됨 — 그라운딩에서
+확認한 "designated만 채우면 반쪽" 갭)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session, *, slug="org3319"):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org3319", slug=f"{slug}-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_human_member(session, org_id, *, user_id=None, role="member"):
+    from app.core.security import hash_password
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    uid = user_id or uuid.uuid4()
+    session.add(User(
+        id=uid, email=f"u-{uid.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    member_id = uuid.uuid4()
+    session.add(OrgMember(id=member_id, org_id=org_id, user_id=uid, role=role))
+    await session.commit()
+    return member_id
+
+
+async def _seed_agent_member(session, org_id, project_id, *, role="admin"):
+    """사람 아닌 org owner/admin — merge_gate_default_approver_member_id 422 검증용. org_members
+    엔 type 컬럼이 없어(사람 전용 구조) 통합 신원 테이블 `members`(app/models/member.py::Member,
+    team_members는 이 테이블 위 VIEW — 실 alembic 스키마에선 view라 직접 INSERT 불가)에 같은
+    user_id로 type='agent' 행을 얹어 is_org_owner_or_admin의 NOT EXISTS 패턴이 실제로 걸리는
+    조건을 재현한다."""
+    from app.core.security import hash_password
+    from app.models.member import Member
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    uid = uuid.uuid4()
+    # members.user_id → users.id FK — agent라도 이 테이블은 human user row를 참조한다
+    # (봇 소유주 개념, org_members와 동형 관례).
+    session.add(User(
+        id=uid, email=f"bot-{uid.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    member_id = uuid.uuid4()
+    session.add(OrgMember(id=member_id, org_id=org_id, user_id=uid, role=role))
+    await session.commit()
+    session.add(Member(id=uuid.uuid4(), org_id=org_id, type="agent", user_id=uid, name="bot"))
+    await session.commit()
+    return member_id
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_jwt(app, Session, org_id, project_id, caller_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(caller_id), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ─── ① rule B 매트릭스(순수 함수) ───────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_non_doc_can_approve_designated_matches_caller_true():
+    """⚠️user_id 축(org_members.user_id)과 designated_approver_id 축(member_id)이 달라
+    caller_member_id를 별도로 넘겨야 한다(첫 구현에서 user_id로 직접 비교해 지정 승인자
+    본인도 403이 나던 실측 버그 — 회귀가드 겸함)."""
+    from app.routers.gates import _non_doc_can_approve
+
+    caller_member = uuid.uuid4()
+    assert await _non_doc_can_approve(
+        session=None, gate_type="merge", user_id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(),
+        designated_approver_id=caller_member, caller_member_id=caller_member,
+    ) is True
+
+
+@pytest.mark.anyio
+async def test_non_doc_can_approve_designated_mismatch_false_even_for_owner():
+    """⭐핵심 — designated가 있으면 caller가 project owner/admin이어도(rule B가 원래 True를
+    줬을 자리) False. session=None이라 _non_doc_gate_approvable로 폴백하면 즉시 크래시할
+    것 — 최우선 단락이 실제로 먼저 걸려 폴백 자체를 안 탄다는 것도 같이 증명."""
+    from app.routers.gates import _non_doc_can_approve
+
+    caller_member = uuid.uuid4()
+    designated = uuid.uuid4()
+    assert await _non_doc_can_approve(
+        session=None, gate_type="merge", user_id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(),
+        designated_approver_id=designated, caller_member_id=caller_member,
+    ) is False
+
+
+@pytest.mark.anyio
+async def test_non_doc_can_approve_designated_caller_member_id_missing_fails_closed():
+    """caller_member_id를 안 넘긴 호출(레거시 호출부가 있다면)도 fail-closed(False) — 지정
+    승인자가 있는데 caller 축을 모르면 조용히 통과가 아니라 거부."""
+    from app.routers.gates import _non_doc_can_approve
+
+    designated = uuid.uuid4()
+    assert await _non_doc_can_approve(
+        session=None, gate_type="merge", user_id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(),
+        designated_approver_id=designated,
+    ) is False
+
+
+@pytest.mark.anyio
+async def test_non_doc_can_approve_designated_none_is_current_behavior_regression():
+    """designated_approver_id 생략(기존 호출부 스타일)도 None과 동일 — 회귀 0."""
+    from sqlalchemy import select
+
+    from app.models.project import OrgMember
+    from app.routers.gates import _non_doc_can_approve
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="org3319rb")
+            owner_id = await _seed_human_member(s, org_id, role="owner")
+            member_id = await _seed_human_member(s, org_id, role="member")
+
+            owner_user_id = (await s.execute(
+                select(OrgMember.user_id).where(OrgMember.id == owner_id)
+            )).scalar_one()
+            member_user_id = (await s.execute(
+                select(OrgMember.user_id).where(OrgMember.id == member_id)
+            )).scalar_one()
+
+            assert await _non_doc_can_approve(
+                s, "merge", owner_user_id, org_id, project_id,
+            ) is True
+            assert await _non_doc_can_approve(
+                s, "merge", member_user_id, org_id, project_id,
+            ) is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_non_doc_can_approve_designated_applies_across_gate_types_not_just_merge():
+    """⭐PO 확定 — designated 분기는 gate_type을 안 가린다(레시피 external_publish 등에도
+    적용). qa 게이트로 재현 — merge 전용 로직이 아님을 명시 고정."""
+    from app.routers.gates import _non_doc_can_approve
+
+    caller_member = uuid.uuid4()
+    designated = uuid.uuid4()
+    assert await _non_doc_can_approve(
+        session=None, gate_type="qa", user_id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(),
+        designated_approver_id=designated, caller_member_id=caller_member,
+    ) is False
+    assert await _non_doc_can_approve(
+        session=None, gate_type="external_publish", user_id=uuid.uuid4(), org_id=uuid.uuid4(),
+        project_id=uuid.uuid4(), designated_approver_id=designated, caller_member_id=designated,
+    ) is True
+
+
+# ─── ② 정책값 → 머지 게이트 designated_approver_id 실주입(실 왕복) ────────────────
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_stamps_designated_approver_from_org_policy():
+    """⭐AC 핵심 — OrgGatePolicy.merge_gate_default_approver_member_id를 설정해 두면
+    evaluate_merge_gate가 생성하는 머지 게이트의 designated_approver_id가 그 값으로
+    채워진다."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.models.hitl_config import OrgGatePolicy
+    from app.models.pm import Story
+    from app.models.participation import Participation, ParticipationRole
+    from app.services.merge_verdict_gate import evaluate_merge_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="org3319stamp")
+            po_member_id = await _seed_human_member(s, org_id, role="admin")
+
+            s.add(OrgGatePolicy(
+                id=uuid.uuid4(), org_id=org_id, posture="balanced",
+                merge_gate_default_approver_member_id=po_member_id,
+            ))
+            await s.commit()
+
+            implementer_id = await _seed_human_member(s, org_id, role="member")
+            role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="implementation", label="Implementation", is_default=True)
+            s.add(role)
+            await s.commit()
+            story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="S")
+            s.add(story)
+            await s.commit()
+            s.add(Participation(
+                id=uuid.uuid4(), org_id=org_id, story_id=story.id,
+                member_id=implementer_id, role_id=role.id,
+            ))
+            await s.commit()
+
+            decision = await evaluate_merge_gate(
+                s, org_id, story.id, pr_number=101, repo="acme/repo",
+                ci_result="pass", head_sha="a" * 40,
+            )
+            await s.commit()
+
+            assert decision.gate_id is not None
+            gate = (await s.execute(
+                select(Gate).where(Gate.id == decision.gate_id)
+            )).scalar_one()
+            assert gate.designated_approver_id == po_member_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_evaluate_merge_gate_designated_approver_none_when_policy_unset():
+    """회귀 0 — OrgGatePolicy 행 자체가 없으면(미설정 조직) 머지 게이트는 여전히
+    designated_approver_id=None으로 생성된다(현행 무변경)."""
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.models.pm import Story
+    from app.models.participation import Participation, ParticipationRole
+    from app.services.merge_verdict_gate import evaluate_merge_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="org3319nopolicy")
+            implementer_id = await _seed_human_member(s, org_id, role="member")
+            role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="implementation", label="Implementation", is_default=True)
+            s.add(role)
+            await s.commit()
+            story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="S")
+            s.add(story)
+            await s.commit()
+            s.add(Participation(
+                id=uuid.uuid4(), org_id=org_id, story_id=story.id,
+                member_id=implementer_id, role_id=role.id,
+            ))
+            await s.commit()
+
+            decision = await evaluate_merge_gate(
+                s, org_id, story.id, pr_number=102, repo="acme/repo",
+                ci_result="pass", head_sha="b" * 40,
+            )
+            await s.commit()
+
+            gate = (await s.execute(
+                select(Gate).where(Gate.id == decision.gate_id)
+            )).scalar_one()
+            assert gate.designated_approver_id is None
+    finally:
+        await engine.dispose()
+
+
+# ─── ③ 정책 PUT — 사람 owner/admin만(422) ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_upsert_org_policy_rejects_agent_member_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="org3319agent")
+            admin_user_id = uuid.uuid4()
+            await _seed_human_member(s, org_id, user_id=admin_user_id, role="admin")
+            agent_member_id = await _seed_agent_member(s, org_id, project_id)
+        await _setup_app_jwt(app, Session, org_id, project_id, admin_user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.put(
+                "/api/v2/gate-config/policy",
+                json={"posture": "balanced", "merge_gate_default_approver_member_id": str(agent_member_id)},
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_upsert_org_policy_rejects_non_owner_admin_member_422():
+    """member role(owner/admin 아님)도 거부 — 사람이어도 자격 부족."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="org3319member")
+            admin_user_id = uuid.uuid4()
+            await _seed_human_member(s, org_id, user_id=admin_user_id, role="admin")
+            plain_member_id = await _seed_human_member(s, org_id, role="member")
+        await _setup_app_jwt(app, Session, org_id, project_id, admin_user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.put(
+                "/api/v2/gate-config/policy",
+                json={"posture": "balanced", "merge_gate_default_approver_member_id": str(plain_member_id)},
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_upsert_org_policy_accepts_human_admin_member_200_round_trip():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="org3319ok")
+            admin_user_id = uuid.uuid4()
+            await _seed_human_member(s, org_id, user_id=admin_user_id, role="admin")
+            po_member_id = await _seed_human_member(s, org_id, role="owner")
+        await _setup_app_jwt(app, Session, org_id, project_id, admin_user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.put(
+                "/api/v2/gate-config/policy",
+                json={"posture": "balanced", "merge_gate_default_approver_member_id": str(po_member_id)},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["merge_gate_default_approver_member_id"] == str(po_member_id)
+
+            # GET도 값을 그대로 되돌려준다.
+            resp2 = await client.get("/api/v2/gate-config/policy")
+            assert resp2.json()["merge_gate_default_approver_member_id"] == str(po_member_id)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_upsert_org_policy_unset_value_still_200_regression():
+    """미지정(None, 기본값)은 검증 대상 자체가 없어 그대로 통과(회귀 0)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="org3319unset")
+            admin_user_id = uuid.uuid4()
+            await _seed_human_member(s, org_id, user_id=admin_user_id, role="admin")
+        await _setup_app_jwt(app, Session, org_id, project_id, admin_user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.put("/api/v2/gate-config/policy", json={"posture": "conservative"})
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["merge_gate_default_approver_member_id"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ④ HTTP 승인 왕복 — designated만 성공·비지정 project owner는 403 ──────────────
+
+
+@pytest.mark.anyio
+async def test_transition_endpoint_designated_approver_succeeds_others_403():
+    """실 HTTP 왕복 — designated_approver_id가 찍힌 non-doc 게이트(gate_type=qa로 재현,
+    머지 SHA 프레시니스 기계장치는 이 테스트의 관심사가 아니라 배제)를 project owner가
+    아닌 비지정 admin이 승인 시도하면 403, 지정된 본인은 200."""
+    from app.main import app
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="org3319tx")
+            designated_user_id = uuid.uuid4()
+            designated_member_id = await _seed_human_member(
+                s, org_id, user_id=designated_user_id, role="admin",
+            )
+            other_admin_user_id = uuid.uuid4()
+            await _seed_human_member(s, org_id, user_id=other_admin_user_id, role="admin")
+
+            from app.models.pm import Story
+            story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="S")
+            s.add(story)
+            await s.commit()
+
+            gate = await create_gate(
+                s, org_id, story.id, "story", "qa",
+                designated_member_id, uuid.uuid4(),
+                project_id=project_id, neutral_facts={},
+                designated_approver_id=designated_member_id, notify=False,
+            )
+            await s.commit()
+            gate_id = gate.id
+
+        # 비지정 admin — project owner/admin이면 옛 rule B론 통과했을 자리, 지금은 403.
+        await _setup_app_jwt(app, Session, org_id, project_id, other_admin_user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition", json={"status": "approved"},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        # 지정된 본인 — 200.
+        await _setup_app_jwt(app, Session, org_id, project_id, designated_user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition", json={"status": "approved"},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── ⑤ delegate 후 새 지정자 허용(예외 경로) ─────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_delegate_then_new_designee_can_approve_old_designee_403():
+    """예외 경로는 기존 delegate API뿐(PO 확定) — 위임 後 새 지정자는 승인 가능, 원 지정자는
+    더 이상 불가."""
+    from app.main import app
+    from app.services.gate_service import create_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, slug="org3319delegate")
+            original_user_id = uuid.uuid4()
+            original_member_id = await _seed_human_member(
+                s, org_id, user_id=original_user_id, role="admin",
+            )
+            new_user_id = uuid.uuid4()
+            new_member_id = await _seed_human_member(s, org_id, user_id=new_user_id, role="admin")
+
+            from app.models.pm import Story
+            story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="S")
+            s.add(story)
+            await s.commit()
+
+            gate = await create_gate(
+                s, org_id, story.id, "story", "qa",
+                original_member_id, uuid.uuid4(),
+                project_id=project_id, neutral_facts={},
+                designated_approver_id=original_member_id, notify=False,
+            )
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app_jwt(app, Session, org_id, project_id, original_user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/delegate",
+                json={"new_approver_member_id": str(new_member_id)},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        # 원 지정자 — 이제 403(위임으로 자격 이전됨).
+        await _setup_app_jwt(app, Session, org_id, project_id, original_user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition", json={"status": "approved"},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        # 새 지정자 — 200.
+        await _setup_app_jwt(app, Session, org_id, project_id, new_user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition", json={"status": "approved"},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -59,6 +59,12 @@ async def test_gate_transition_forces_resolver_id_to_caller(monkeypatch):
     # story #2982 — 이미해소 가드(status!='pending'이면 409)도 MagicMock 오토속성(항상
     # not-None)을 "이미 해소됨"으로 오독한다. "pending"으로 명시해 그 가드도 대상 밖임을 밝힌다.
     _g.status = "pending"
+    # story #3319 — designated_approver_id도 MagicMock 오토속성 함정(바로 위 #2975/#2982와 동형):
+    # None이 아니면 _non_doc_can_approve가 「캐스팅된 담당자만」분기로 먼저 판정해버려, 이 테스트가
+    # 몽키패치한 _non_doc_gate_approvable(항상 True)이 아예 호출되지 않고 403으로 실패한다. 이
+    # 테스트의 관심사(resolver_id 강제)는 designated_approver_id 축과 무관하므로 명시적으로
+    # None(정책 미설정) 고정해 기존 org-role 폴백 경로 그대로 대상 밖임을 밝힌다.
+    _g.designated_approver_id = None
     _gr.scalar_one_or_none.return_value = _g
     _sess.execute = AsyncMock(return_value=_gr)
     from fastapi import BackgroundTasks

--- a/backend/tests/test_gate_decider_can_approve_89484c8c.py
+++ b/backend/tests/test_gate_decider_can_approve_89484c8c.py
@@ -203,7 +203,7 @@ async def _run_non_doc_can_approve(project_role):
     org = uuid.uuid4()
     merge = SimpleNamespace(
         id=uuid.uuid4(), gate_type="merge", work_item_type="story", work_item_id=uuid.uuid4(),
-        neutral_facts={}, status="pending",
+        neutral_facts={}, status="pending", designated_approver_id=None,
     )
     gates_result = MagicMock()
     gates_result.scalars.return_value.all.return_value = [merge]

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -45,6 +45,11 @@ def _non_doc_gate_session():
         # story #2982 — 이미해소 가드(status!='pending'이면 409)도 이 값을 읽는다. SimpleNamespace는
         # 미선언 속성이 AttributeError라 명시 필요 — "pending"으로 그 가드가 대상 밖임을 분명히 한다.
         status="pending", resolver_id=None, resolved_at=None,
+        # story #3319 — _authorize_gate_approve_equivalent(비-doc 분기)가 이제 이 필드를
+        # _non_doc_can_approve 호출부 kwarg로 읽는다(위 다른 None 필드들과 동일 이유로 명시
+        # 필요 — 이 파일의 관심사는 resolver_id 강제이지 designated 정책 판정이 아니므로
+        # None="정책 미설정"으로 그 축을 대상 밖임을 분명히 한다).
+        designated_approver_id=None,
     )
     s.execute = AsyncMock(return_value=gr)
     return s


### PR DESCRIPTION
## 요약
머지 게이트가 `designated_approver_id=None`으로 생성돼 rule B(`gates.py::_non_doc_gate_approvable`)가 project/org owner·admin 전원(org owner 포함)에게 "승인 가능"으로 노출하던 결함 처방(story #40030054). 실사고: PR#3706 머지 게이트를 QA 前(PO AC 리뷰 조건부 단계)에 선생님이 서명하는 일이 있었음 — 우리 사슬은 PO 리뷰→QA→PO 서명인데 카드가 owner에게 "지금 승인 가능"으로 보여 손이 갔다.

## 처방 B(선생님 확定 — 처방 A "QA 前 비활성 배지"는 후속 별개 축)

1. `OrgGatePolicy.merge_gate_default_approver_member_id`(nullable UUID) 신설 — 마이그 0302, story #2985의 `Gate.designated_approver_id` 추가(0276)와 동형 패턴(데이터 마이그 없음, 단순 up/downgrade).
2. `evaluate_merge_gate`(merge_verdict_gate.py)가 이 정책값을 조회해 생성하는 머지 게이트의 `designated_approver_id`로 채운다. 미설정(기본값)이면 현행 그대로 `None`(회귀 0).
3. **`_non_doc_can_approve`에 최우선 분기 신설** — `designated_approver_id`가 있으면 gate_type 무관 그 1인에게만 승인 자격을 좁힌다. ⚠️그라운딩의 핵심 발견: `designated_approver_id`만 배선하고 이 분기가 없으면 owner inbox의 승인 버튼은 그대로 눌린다(카드 배달 대상만 좁아질 뿐, 인가 로직은 안 봄) — 두 변경이 함께 있어야 실제로 닫힌다.
4. **영향 범위 명시(PO 확定)**: 이 분기는 gate_type을 안 가리므로 `designated_approver_id`가 설정된 **모든** gate_type(레시피 external_publish 등 story #3312/#3325 포함)에 동일 적용된다 — "지정 승인자만 결정"이 gate_type 무관 단일 규칙이 되는 것이 맞는 의미. 예외 경로는 기존 `/delegate`(재지정) API만.
5. 정책 PUT은 새 엔드포인트 없이 기존 `GET/PUT /api/v2/gate-config/policy` 확장 — 값은 사람 owner/admin 멤버만 허용(`is_org_owner_or_admin`과 동형 NOT EXISTS 패턴 재사용, 위반 시 422).

## 구현 중 실측으로 발견·수정한 부수 버그 2건

- **user_id ↔ member_id 축 혼동**: `Gate.designated_approver_id`는 member_id 축(org_members.id/team_members.id, story #2985)인데 caller 식별에 쓰이던 `user_id`(org_members.user_id)와 직접 비교하면 지정 승인자 **본인도 403**이 나는 조용한 버그였다(첫 구현에서 자체 테스트로 즉시 잡음). 호출부가 이미 갖고 있는 `resolved.id`(caller_member_id)를 새 인자로 스레딩해 해결 — 신규 쿼리 0.
- **`list_gates`의 can_approve 캐시 키 누락**: 캐시 키가 `(gate_type, project_id)`뿐이라, 같은 조합이라도 게이트마다 `designated_approver_id`가 다르면(정책 적용 前/後 생성 등) 먼저 계산된 캐시값을 서로 다른 게이트가 잘못 공유하는 사고가 날 자리였다 — `designated_approver_id`를 키에 편입.

## 테스트
`backend/tests/test_3319_merge_gate_designated_approver_policy.py` 13케이스:
- rule B 매트릭스: designated==caller_member 허용 · ≠caller 거부(project owner여도) · caller_member_id 미제공 fail-closed · gate_type 무관 적용(merge 아닌 qa/external_publish로 재현).
- 정책값 → 실제 머지 게이트 `designated_approver_id` 실주입(왕복) · 미설정 시 None 회귀.
- 정책 PUT: agent 멤버 422 · non-owner/admin 사람도 422 · human owner/admin 200 왕복(GET도 재확인) · 미지정 값 200 회귀.
- HTTP 승인 왕복: 지정자 200 · 비지정 admin(옛 rule B론 통과했을 자리) 403.
- delegate 후 새 지정자 200 · 원 지정자 403(예외 경로 검증).

`test_gate_decider_can_approve_89484c8c.py`의 `SimpleNamespace` merge 게이트 mock fixture에 `designated_approver_id=None` 명시 추가(신규 컬럼 참조로 인한 `AttributeError` — 기존 mock fixture 갱신 필요 케이스).

마이그 up/down 수동 검증(빈 DB `alembic upgrade head`/`downgrade -1`/재-upgrade 전부 클린). 기존 gate/merge-gate 회귀 스위트 — non-destructive 30건 + destructive realdb 133건(#3325/#3312/#3001/#2709 등 designated_approver_id 관련 전체 포함) 전부 그린.

뮤테이션 셀프체크 2회 — ①rule B 분기 제거 → 관련 6케이스 정확히 그 자리서 RED(나머지 7케이스는 무관하게 그린) ②정책→designated_approver_id 배선 제거 → 스탬핑 테스트 1건 정확히 RED. 둘 다 원복.

## 범위 밖
- 처방 A(QA 前 카드에 "확인 필요" 배지+서명 비활성)는 별개 후속.
- 기존 pending 머지 게이트 일괄 재지정은 스코프 밖(게이트 단위 `/delegate` API로).
- 우리 조직의 실제 값 세팅(sellerking/2fd14616)은 머지 후 PO가 dev에서 직접 PUT(코드에 상수 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfPLRWqGNvcf58NWYrYKba