### PR TITLE
[SID:3333] [테스트·위생] realdb 전역 엔진 dispose — test_3329 정정 + 17건 추가 발견·정리 + 가드 lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,26 @@ jobs:
         working-directory: backend
         run: python3 scripts/lint_destructive_test_sql.py
 
+  # story a05da51b(2026-09-02, story #3330/PR#3711 CI flake 후속) — destructive_schema
+  # 마커 파일이 publish_registry_event/publish_preset_event/transition_gate/send_message
+  # (전역 엔진 app.core.database.engine의 background task 경로를 실제로 태우는 진입점)를
+  # 호출하면서 `_dispose_global_engine_after_test` 표준 fixture가 없으면 커밋 시점에 잡는다.
+  # 스크립트 docstring(scripts/lint_destructive_publish_path_dispose_fixture.py) 참조 —
+  # baseline 없음(도입 시점 위반 17건 전부 이 스토리에서 정리 후 켰다, grandfather 목록
+  # 없음 — PO 판정: "썩는 목록"). non-destructive 파일은 이 가드 대상이 아니다(story #3330의
+  # conftest.py 전역 autouse가 이미 구조적으로 커버 — test_a05da51b_dispose_fixture_
+  # guards.py가 그 메커니즘 자체의 회귀가드).
+  destructive-publish-path-dispose-fixture-lint:
+    name: destructive publish-path dispose fixture lint (guard, story a05da51b)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Scan tests/ for destructive files that publish without the global-engine dispose fixture
+        working-directory: backend
+        run: python3 scripts/lint_destructive_publish_path_dispose_fixture.py
+
   no-script-output-artifacts-lint:
     name: no script output artifacts lint (guard, story #3008)
     runs-on: ubuntu-latest

--- a/backend/scripts/lint_destructive_publish_path_dispose_fixture.py
+++ b/backend/scripts/lint_destructive_publish_path_dispose_fixture.py
@@ -1,0 +1,179 @@
+"""story a05da51b — 「발행 경로를 타는 destructive realdb 테스트는 전역 엔진 dispose
+fixture 필수」 정적 가드. CI가 커밋 시점에 잡는다.
+
+배경(2026-09-02 — story #3330/PR#3711 CI 2회 flake): `test_3330_gate_verdict_
+notification.py`가 실제로 메시지를 발행해 `send_message`의 background task
+(`mark_agent_replied`)를 태우는데, 그 task는 이 테스트의 throwaway 엔진이 아니라
+`app.core.database.async_session_factory`(전역·프로세스 수명 엔진)를 쓴다.
+pytest-anyio가 테스트마다 새 이벤트 루프를 만드는데 dispose 없이 두면, 이 전역
+엔진의 커넥션 풀이 "이전 루프에 묶인" 커넥션을 다음 테스트(같은 파일의 다음
+테스트도 포함)에 재사용시키려다 `Event loop is closed`류로 죽는다.
+
+⛔이 가드가 다루는 건 **destructive_schema 마커 파일만**이다 — non-destructive
+파일은 story #3330(PR#3711)이 conftest.py의 `pytest_collection_modifyitems`에
+심은 collection-시점 자동 주입(non-destructive **async** 테스트에만
+`_dispose_global_engine_for_non_destructive_tests`를 자동으로 끼워 넣는다)이
+이미 구조적으로 커버한다 — "그 파일 작성자가 이 위험을 알고 있었는가"에 기대지
+않는다. destructive 파일은 그 자동 주입의 스코프 밖(파일별 완전 격리 프로세스라
+**다른 파일**로는 안 새지만, **같은 파일 안의** 여러 테스트끼리는 여전히 같은
+전역 엔진 풀을 공유하므로 위험이 남는다 — test_3329_embedded_entity_ref_
+tokenization.py(PR#3713)가 정확히 이 클래스로 실측 재현됨, story a05da51b).
+
+⛔무엇을 잡는가: destructive_schema 마커가 있는 파일이 "실 발행/HTTP 경로"
+신호 함수(아래 `_TRIGGER_CALL_NAMES` — 전역 엔진의 background task 체인을
+실제로 태우는 것으로 소스에서 확認된 것들, story #3330 그라운딩 근거)를 호출
+하면서 `_dispose_global_engine_after_test`(246개 파일이 이미 쓰는 표준 fixture
+이름) 문자열이 파일 안에 전혀 없으면 위반.
+
+⛔판별 방식 — 이름 기반(호출 대상 함수가 실제로 그 경로를 타는지 타입 추적은
+안 한다, `lint_destructive_test_sql.py`와 같은 비용/이득 판단): `ast.Call`의
+함수명이 `_TRIGGER_CALL_NAMES`에 있으면 트리거로 센다. fixture 존재 여부는
+파일 전체에서 `_dispose_global_engine_after_test` 문자열 출현으로 판별(정의든
+호출이든 상관없이 — 오탐보다 미탐 방지를 우선, «있는데 못 찾음»보다 «있다고
+쳐줌»이 이 가드의 목적에 안전).
+
+⛔예외(마커) — 정말 이 fixture가 필요 없는 게 확실한 자리(예: 발행이 항상
+mock/patch되어 전역 엔진에 절대 안 닿는 경우)는 같은 줄 또는 바로 윗줄에
+`# dispose-fixture-not-needed: <사유>` 주석이 있으면 통과.
+
+⛔이 가드가 **못 잡는 것**(선언, `lint_destructive_test_sql.py` docstring과
+동일 원칙):
+  · 트리거 함수를 **간접 호출**(다른 헬퍼 함수 안에서 한 단계 이상 건너 호출)하는
+    경우 — 이 스캐너는 파일 안의 직접 `ast.Call` 이름만 본다, 호출 그래프 추적
+    없음.
+  · 트리거 함수를 동적으로(문자열 리플렉션·`getattr` 등) 호출하는 경우.
+  · fixture 이름이 파일에 "문자열로만" 있고 실제로 `@pytest.fixture`로 등록/
+    사용되지 않는 경우(예: 주석 안에만 언급) — 존재 여부만 보고 등록 여부는
+    검증하지 않는다.
+  다음에 이 사각을 밟는 사람이 있다면 그게 이 판단이 틀렸다는 신호이니 그때
+  확장한다.
+
+⛔baseline — 이 가드 도입 시점(2026-09-02) 스윕으로 기존 위반 전부 정리(test_3329
+포함, story a05da51b이 이 커밋에서 함께 고침) 후 켰다. "봐주는 게 없다" 원칙은
+`lint_destructive_test_sql.py`(#2786)와 동형.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).parent.parent / "tests"
+
+# story #3330 그라운딩(gate_service.py::_publish_gate_verdict_notification·
+# events.py::_publish_registry_event_core) 근거 — 실제로 send_message의
+# background task(mark_agent_replied, 전역 엔진 소비처)를 태우는 것으로 소스에서
+# 확認된 진입점만 담는다(추측 0).
+_TRIGGER_CALL_NAMES = {
+    "publish_registry_event",  # events.py 라우터 함수 — 직접 호출 realdb 테스트가 흔함.
+    "publish_preset_event",  # 서버 자동발행 진입점(#2791) — 위와 같은 core를 태움.
+    "transition_gate",  # story #3330 이후 approved/rejected 전이마다 무조건 알림 발행 시도.
+    "send_message",  # conversations.py — 발행 경로의 최종 메시지 생성 지점.
+}
+_FIXTURE_NAME = "_dispose_global_engine_after_test"
+_ALLOW_MARKER_RE = re.compile(r"#\s*dispose-fixture-not-needed\s*:")
+
+
+def _call_func_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _is_destructive_schema_mark(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "destructive_schema"
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "mark"
+    )
+
+
+def _has_destructive_schema_marker(tree: ast.AST) -> bool:
+    """lint_destructive_test_sql.py::_has_destructive_schema_marker와 동일 판별(재사용
+    — 두 벌 유지 대신 같은 시그널을 각 스크립트가 독립적으로 같은 규칙으로 재현, story
+    #2643/conftest.py의 판별축과도 동형)."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and _is_destructive_schema_mark(node.value):
+            return True
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for deco in node.decorator_list:
+                target = deco.func if isinstance(deco, ast.Call) else deco
+                if _is_destructive_schema_mark(target):
+                    return True
+    return False
+
+
+def _has_allow_marker(source: str) -> bool:
+    return bool(_ALLOW_MARKER_RE.search(source))
+
+
+def _find_trigger_calls(tree: ast.AST) -> list[tuple[int, str]]:
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            name = _call_func_name(node)
+            if name in _TRIGGER_CALL_NAMES:
+                hits.append((node.lineno, name))
+    return hits
+
+
+def find_violation(path: Path) -> tuple[str, list[str]] | None:
+    """destructive 마커 파일이 트리거 호출을 갖는데 fixture 문자열이 파일에 없으면
+    (파일, [트리거명 목록]) 반환, 아니면 None."""
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return None
+    if not _has_destructive_schema_marker(tree):
+        return None
+    triggers = _find_trigger_calls(tree)
+    if not triggers:
+        return None
+    if _FIXTURE_NAME in source:
+        return None
+    if _has_allow_marker(source):
+        return None
+    trigger_names = sorted({name for _, name in triggers})
+    return str(path), trigger_names
+
+
+def scan_dir(root: Path) -> tuple[list[tuple[str, list[str]]], int]:
+    violations: list[tuple[str, list[str]]] = []
+    files = sorted(root.rglob("*.py"))
+    for path in files:
+        v = find_violation(path)
+        if v is not None:
+            violations.append(v)
+    return violations, len(files)
+
+
+def scan_repo() -> tuple[list[tuple[str, list[str]]], int]:
+    return scan_dir(TESTS_DIR)
+
+
+def main() -> int:
+    violations, scanned = scan_repo()
+    print(f"스캔 파일 {scanned}개(tests/ 재귀)")
+    if violations:
+        print(f"FAIL: 발행 경로를 타는데 dispose fixture가 없는 destructive 테스트 파일 {len(violations)}건")
+        print("story a05da51b 판정: 이 파일들은 publish_registry_event/publish_preset_event/")
+        print("transition_gate/send_message를 호출해 전역 엔진(app.core.database.engine)의")
+        print("background task 경로를 태우는데, `_dispose_global_engine_after_test` fixture가")
+        print("없다 — 같은 파일 안 여러 테스트 사이에서 커넥션 누수/Event loop is closed로")
+        print("이어질 수 있다(story #3330/PR#3711 실사고).")
+        print("정말 필요 없으면 `# dispose-fixture-not-needed: <사유>` 마커를 파일에 다세요.")
+        for file, trigger_names in violations:
+            print(f"  {file} — 트리거: {', '.join(trigger_names)}")
+        return 1
+    print("OK: 발행 경로 타는 destructive 파일 전부 dispose fixture 보유")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_1715_merge_gate_requester_notify_realdb.py
+++ b/backend/tests/test_1715_merge_gate_requester_notify_realdb.py
@@ -27,6 +27,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
+++ b/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
@@ -35,6 +35,7 @@ _CI_OR_LOCAL_ONLY_ALLOWLIST = frozenset({
     "lint_commit_before_validate.py",             # story #2459 — CI lint 게이트(AST 정적분석, 운영 DB 무접속)
     "lint_dependency_override_get_read_db.py",    # story #2451 — CI lint 게이트(tests/ override 스캔, 운영 DB 무접속)
     "lint_destructive_test_sql.py",               # story #2786 — CI lint 게이트(tests/ 재귀 AST 스캔, 운영 DB 무접속)
+    "lint_destructive_publish_path_dispose_fixture.py",  # story a05da51b — CI lint 게이트(tests/ 재귀 AST 스캔, 운영 DB 무접속)
     "lint_legacy_subscriptions_reuse.py",         # story #2476 — CI lint 게이트(app/ 재귀 정적 스캔, 운영 DB 무접속)
     "lint_model_registration_completeness.py",    # story #2255 — CI lint 게이트(app/models AST 정적 스캔, 운영 DB 무접속)
     "lint_project_access_403.py",                 # story #2342 AC7 — CI lint 게이트

--- a/backend/tests/test_2630_circuit_breaker.py
+++ b/backend/tests/test_2630_circuit_breaker.py
@@ -34,6 +34,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_2633_event_publish.py
+++ b/backend/tests/test_2633_event_publish.py
@@ -26,6 +26,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_2636_publish_zero_reach_warning.py
+++ b/backend/tests/test_2636_publish_zero_reach_warning.py
@@ -21,6 +21,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_2637_action_auth_enforcement.py
+++ b/backend/tests/test_2637_action_auth_enforcement.py
@@ -22,6 +22,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_2637_event_msg_metadata_tagging.py
+++ b/backend/tests/test_2637_event_msg_metadata_tagging.py
@@ -22,6 +22,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_2675_publish_event_malformed_uuid_400.py
+++ b/backend/tests/test_2675_publish_event_malformed_uuid_400.py
@@ -39,6 +39,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_2693_publish_event_unknown_member_400.py
+++ b/backend/tests/test_2693_publish_event_unknown_member_400.py
@@ -38,6 +38,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_2935_steer_conversation_override.py
+++ b/backend/tests/test_2935_steer_conversation_override.py
@@ -31,6 +31,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 def _load_steer_definition():
     """0274 마이그의 시드 데이터를 실 코드에서 동적 로드 — test_2633의 `_load_seed_definitions`
     (0245 로드)와 동일 패턴, 신규 헬퍼 발명 금지. (원래 0272로 작성됐으나 develop #3359와

--- a/backend/tests/test_3288_recipe_role_bindings.py
+++ b/backend/tests/test_3288_recipe_role_bindings.py
@@ -32,6 +32,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_3312_approve_stage_gate_auto_creation.py
+++ b/backend/tests/test_3312_approve_stage_gate_auto_creation.py
@@ -19,6 +19,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 # ─── 단위 축 — validate_stage_metadata의 gate shape 강제(DB 불요) ──────────────────
 
 

--- a/backend/tests/test_3313_recipe_notification_render.py
+++ b/backend/tests/test_3313_recipe_notification_render.py
@@ -20,6 +20,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_3323_prev_output_doc_chain.py
+++ b/backend/tests/test_3323_prev_output_doc_chain.py
@@ -28,6 +28,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_3325_recipe_gate_card_reopen.py
+++ b/backend/tests/test_3325_recipe_gate_card_reopen.py
@@ -29,6 +29,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_3329_embedded_entity_ref_tokenization.py
+++ b/backend/tests/test_3329_embedded_entity_ref_tokenization.py
@@ -29,6 +29,24 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일의 테스트는 실제로 메시지를 발행해(`_publish` →
+    `publish_registry_event`) `send_message`의 background task(`mark_agent_replied`)를
+    태운다. 그 task는 이 파일의 throwaway 엔진이 아니라 `app.core.database.
+    async_session_factory`(전역·프로세스 수명)를 쓴다. destructive_schema 마커 파일이라
+    story #3330의 conftest.py 전역 autouse(non-destructive 전용, 프로세스 격리로 이미
+    안전한 destructive는 스코프 밖)의 적용 대상이 아니다 — 이 파일 자신의 여러 테스트가
+    **한 pytest 세션 안에서** 순차 실행되며 같은 전역 엔진을 반복 사용하므로, dispose
+    없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션 누수/`Event loop is
+    closed`로 이어질 수 있다(실측 확인 — test_3330_gate_verdict_notification.py에서
+    최초 재현, 이 파일도 같은 위험을 이미 갖고 있었음이 회귀 재확認 중 발견됨). 이
+    realdb 하네스가 destructive 파일에 이미 쓰는 표준 방어 fixture 재사용(새 로직 0)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _realdb_session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_a05da51b_dispose_fixture_guards.py
+++ b/backend/tests/test_a05da51b_dispose_fixture_guards.py
@@ -1,0 +1,194 @@
+"""story a05da51b — realdb 테스트 전역 엔진 dispose 하네스의 두 가드를 양성/음성 대조로
+고정한다.
+
+배경: story #3330(PR#3711)이 conftest.py의 `pytest_collection_modifyitems`에 「non-
+destructive **async** 테스트에만 `_dispose_global_engine_for_non_destructive_tests`를
+collection 시점에 자동 주입」을 심었다(파일별 opt-in fixture의 구조적 구멍을 막기 위해
+— "그 파일 작성자가 전역 엔진 위험을 알고 있었는가"에 기대지 않는다). 이 자동 주입
+메커니즘이 조용히 깨지면(예: 누군가 `pytest_collection_modifyitems`의 그 블록을 실수로
+지우거나 조건을 바꾸면) CI가 다시 #3330 flake급으로 빨개지는데, 그걸 알아챌 회귀가드가
+지금까지 없었다 — 이 파일이 그 가드다.
+
+1부(async 자동 주입 회귀가드) — `test_3186_mixed_collection_guard.py`와 동일한 subprocess
++ tmp_path + conftest.py 복사 관례(pytest 내장 `--setup-plan`으로 실제 fixture 주입 여부를
+실행 없이 확인 — story #2662/#3186이 이미 쓰는 검증 방식과 동형).
+2부(destructive publish-path lint 가드) — `scripts/lint_destructive_publish_path_dispose_
+fixture.py`를 직접 import해 단위 검증(파일 I/O 없이 순수 함수 축)."""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def _copy_conftest(tmp_path: Path) -> None:
+    conftest_src = (Path(__file__).parent / "conftest.py").read_text(encoding="utf-8")
+    (tmp_path / "conftest.py").write_text(conftest_src, encoding="utf-8")
+
+
+_ASYNC_NON_DESTRUCTIVE_VICTIM = """
+    import pytest
+
+    @pytest.fixture
+    def anyio_backend():
+        return "asyncio"
+
+    @pytest.mark.anyio
+    async def test_ordinary_async():
+        assert 1 + 1 == 2
+"""
+
+_SYNC_NON_DESTRUCTIVE_VICTIM = """
+    def test_ordinary_sync():
+        assert 1 + 1 == 2
+"""
+
+_ASYNC_DESTRUCTIVE_VICTIM = """
+    import pytest
+
+    pytestmark = pytest.mark.destructive_schema
+
+    @pytest.fixture
+    def anyio_backend():
+        return "asyncio"
+
+    @pytest.mark.anyio
+    async def test_destructive_async():
+        assert 1 + 1 == 2
+"""
+
+_FIXTURE_NAME = "_dispose_global_engine_for_non_destructive_tests"
+
+
+def _run_setup_plan(tmp_path: Path, extra_args: list[str]) -> str:
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(tmp_path), "--setup-plan", "-q", *extra_args],
+        capture_output=True, text=True, cwd=tmp_path,
+        env={"PARITY_TEST_DATABASE_URL": "", "ALEMBIC_DATABASE_URL": "", "PATH": __import__("os").environ["PATH"]},
+    )
+    return result.stdout + result.stderr
+
+
+def test_positive_control_async_non_destructive_test_gets_dispose_fixture_injected(tmp_path: Path):
+    """⭐AC — 이 fixture가 collection 시점에 실제로 주입되는지(뮤테이션 대상: conftest.py의
+    주입 루프를 지우면 이 테스트가 RED가 된다 — 아래 뮤테이션 절 참조)."""
+    (tmp_path / "test_async_victim.py").write_text(textwrap.dedent(_ASYNC_NON_DESTRUCTIVE_VICTIM))
+    _copy_conftest(tmp_path)
+
+    output = _run_setup_plan(tmp_path, [])
+    assert f"SETUP    F {_FIXTURE_NAME}" in output, f"async non-destructive 테스트에 dispose fixture가 주입되지 않음\n{output}"
+
+
+def test_sync_non_destructive_test_does_not_get_dispose_fixture_injected(tmp_path: Path):
+    """음성대조 — sync 테스트는 이 fixture를 몰라야 한다(story #2662 회귀 방지 —
+    async fixture가 sync 테스트에 autouse로 걸리면 PytestRemovedIn9Warning으로
+    서브프로세스 메타테스트 출력이 깨진다, PR#3711 카디르 QA 실측)."""
+    (tmp_path / "test_sync_victim.py").write_text(textwrap.dedent(_SYNC_NON_DESTRUCTIVE_VICTIM))
+    _copy_conftest(tmp_path)
+
+    output = _run_setup_plan(tmp_path, [])
+    assert _FIXTURE_NAME not in output, f"sync 테스트에 dispose fixture가 주입됨(회귀)\n{output}"
+    assert "PytestRemovedIn9Warning" not in output, f"sync 테스트에서 async fixture 경고 발생(회귀)\n{output}"
+
+
+def test_destructive_async_test_does_not_get_dispose_fixture_injected(tmp_path: Path):
+    """음성대조 — destructive_schema 마커 async 테스트도 이 fixture를 몰라야 한다(스코프=
+    non-destructive만, story #3330 PO 확定). destructive 파일은 파일별 완전 격리
+    프로세스라 이 conftest-레벨 자동 방어가 애초에 불필요 — 발행 경로를 타는 destructive
+    파일은 대신 개별 `_dispose_global_engine_after_test`(scripts/lint_destructive_
+    publish_path_dispose_fixture.py 가드 대상)를 쓴다."""
+    (tmp_path / "test_destructive_victim.py").write_text(textwrap.dedent(_ASYNC_DESTRUCTIVE_VICTIM))
+    _copy_conftest(tmp_path)
+
+    output = _run_setup_plan(tmp_path, ["-m", "destructive_schema"])
+    assert _FIXTURE_NAME not in output, f"destructive 마커 테스트에 dispose fixture가 주입됨(스코프 위반)\n{output}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2부 — lint_destructive_publish_path_dispose_fixture.py 단위 검증(순수 함수, 파일 I/O 없이
+# ast.parse 대상 소스만 직접 구성 — lint_destructive_test_sql.py에 대응하는 단위 테스트가
+# 이 조직에 아직 없어 이 파일이 그 축까지 함께 고정한다).
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _lint_module():
+    import importlib.util
+
+    path = Path(__file__).parent.parent / "scripts" / "lint_destructive_publish_path_dispose_fixture.py"
+    spec = importlib.util.spec_from_file_location("lint_destructive_publish_path_dispose_fixture", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_and_check(tmp_path: Path, filename: str, source: str):
+    p = tmp_path / filename
+    p.write_text(textwrap.dedent(source), encoding="utf-8")
+    return _lint_module().find_violation(p)
+
+
+def test_lint_flags_destructive_file_with_trigger_call_and_no_fixture(tmp_path: Path):
+    """⭐AC — 발행 경로 트리거 + destructive 마커 + fixture 없음 → 위반 검출."""
+    violation = _write_and_check(tmp_path, "test_victim.py", """
+        import pytest
+        pytestmark = pytest.mark.destructive_schema
+
+        async def test_x():
+            await publish_registry_event(x, y)
+    """)
+    assert violation is not None
+    file, triggers = violation
+    assert "publish_registry_event" in triggers
+
+
+def test_lint_passes_when_fixture_present(tmp_path: Path):
+    """음성대조 — 같은 트리거가 있어도 fixture 문자열이 파일에 있으면 통과."""
+    violation = _write_and_check(tmp_path, "test_victim.py", """
+        import pytest
+        pytestmark = pytest.mark.destructive_schema
+
+        @pytest.fixture(autouse=True)
+        async def _dispose_global_engine_after_test():
+            yield
+
+        async def test_x():
+            await publish_registry_event(x, y)
+    """)
+    assert violation is None
+
+
+def test_lint_passes_when_no_trigger_call(tmp_path: Path):
+    """음성대조 — destructive 마커만 있고 트리거 호출이 없으면 fixture 없어도 통과
+    (이 가드는 "발행 경로를 타는" 파일만 요구한다 — 모든 destructive 파일에 강제하지
+    않는다)."""
+    violation = _write_and_check(tmp_path, "test_victim.py", """
+        import pytest
+        pytestmark = pytest.mark.destructive_schema
+
+        def test_x():
+            assert 1 == 1
+    """)
+    assert violation is None
+
+
+def test_lint_passes_when_not_destructive_marked(tmp_path: Path):
+    """음성대조 — 마커 자체가 없으면(non-destructive 파일) 이 가드의 대상이 아니다
+    (그쪽은 conftest.py 자동 주입이 이미 커버 — 1부 테스트들)."""
+    violation = _write_and_check(tmp_path, "test_victim.py", """
+        async def test_x():
+            await publish_registry_event(x, y)
+    """)
+    assert violation is None
+
+
+def test_lint_respects_allow_marker(tmp_path: Path):
+    """양성대조 — `# dispose-fixture-not-needed:` 마커가 파일에 있으면 통과."""
+    violation = _write_and_check(tmp_path, "test_victim.py", """
+        import pytest
+        pytestmark = pytest.mark.destructive_schema
+
+        # dispose-fixture-not-needed: 이 테스트는 publish_registry_event를 항상 mock한다.
+        async def test_x():
+            await publish_registry_event(x, y)
+    """)
+    assert violation is None

--- a/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
+++ b/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
@@ -30,6 +30,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_h1_s10_e2e.py
+++ b/backend/tests/test_h1_s10_e2e.py
@@ -26,6 +26,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
 async def test_h1_end_to_end_ready_to_done():

--- a/backend/tests/test_h1_s7_gate_verdict.py
+++ b/backend/tests/test_h1_s7_gate_verdict.py
@@ -29,6 +29,25 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """story a05da51b — 이 파일은 publish_registry_event/publish_preset_event/
+    transition_gate/send_message 중 하나를 호출해 실제로 메시지를 발행하거나 게이트를
+    전이시킨다 — `send_message`의 background task(`mark_agent_replied`)가 이 파일의
+    throwaway 엔진이 아니라 `app.core.database.async_session_factory`(전역·프로세스
+    수명 엔진)를 쓴다. destructive_schema 마커 파일이라 story #3330(PR#3711)이 conftest.py
+    에 심은 전역 autouse(non-destructive 전용 스코프)의 적용 대상이 아니다 — 이 파일
+    자신의 여러 테스트가 한 pytest 세션 안에서 순차 실행되며 같은 전역 엔진을 반복
+    사용하므로, dispose 없이 두면 pytest-anyio의 테스트별 새 이벤트 루프 사이에서 커넥션
+    누수/`Event loop is closed`로 이어질 수 있다(story #3330/PR#3711 실사고 — test_3330_
+    gate_verdict_notification.py에서 최초 재현). 이 realdb 하네스의 표준 방어 fixture
+    재사용(새 로직 0, story a05da51b — scripts/lint_destructive_publish_path_dispose_
+    fixture.py 가드 대상)."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
 def _gate(gate_type="merge", work_item_type="story", created=None, resolved=None, facts=None):
     now = datetime(2026, 6, 12, 12, 0, tzinfo=timezone.utc)
     return SimpleNamespace(


### PR DESCRIPTION
## Summary
story a05da51b(entity:story:a05da51b-ae5c-4dd1-bca2-17fce860ad6c). story #3330/PR#3711 CI flake 후속.

- **1커밋** — `test_3329_embedded_entity_ref_tokenization.py`(PR#3713, 머지 済)에 표준 dispose fixture 추가. 이 파일도 destructive_schema 마커라 PR#3711의 conftest.py 전역 autouse(non-destructive 전용 스코프) 밖이고, 실제로 여러 테스트가 같은 파일 안에서 순차 발행하며 전역 엔진을 공유해 누수 위험이 있었다(실측 확認).
- **2커밋** — 신설 lint로 전체 스캔한 결과 test_3329 외에 **17개 파일**이 같은 클래스 위반(발행 경로 트리거 + destructive 마커 + fixture 없음). `lint_destructive_test_sql.py`(#2786) 선례 규율 그대로 **baseline 없이 전부 이 스토리에서 정리**(PO 판정 — grandfather 목록은 썩는다).
- **3커밋** — `scripts/lint_destructive_publish_path_dispose_fixture.py` 신설(`lint_destructive_test_sql.py`와 동형 구조) + CI job 배선 + `test_a05da51b_dispose_fixture_guards.py`(conftest.py의 collection-시점 async 자동 주입 메커니즘 자체의 회귀가드 + 이 lint 스크립트의 단위 검증).

## Test plan
- [x] 정정 전(lint 스캔): 위반 17건(1715·2630·2633·2636·2637×2·2675·2693·2935·3288·3312·3313·3323·3325·ccbcd9da·h1_s10·h1_s7) — test_3329는 1커밋에서 이미 정리해 목록 밖.
- [x] 정정 후: 스캔 1094개 파일, 위반 0건.
- [x] **뮤테이션(lint 자체, 실 파일)**: test_h1_s7_gate_verdict.py에서 fixture 블록을 실제로 지움 → lint 정확히 1건 FAIL(그 파일·`transition_gate` 트리거 보고) → 원복 → OK.
- [x] **뮤테이션(1부 conftest 자동 주입 회귀가드)**: conftest.py의 collection-injection 루프를 제거 → `test_positive_control_async_non_destructive_test_gets_dispose_fixture_injected`만 정확히 RED(나머지 7건 green) → 원복 → 8/8 green.
- [x] **destructive 파일별 개별 실행**(CI `backend-test-destructive` job과 동일한 "파일마다 신선 격리 DB" 방식으로 로컬 재현) — 정정 대상 18개 파일(17건 + test_3329) 전부 개별 실행, 122건 pass·누수 경고 0건. (참고: GH Actions 4-way 샤딩 자체는 로컬 재현 안 함 — 파일별 완전 격리가 핵심 불변량이라 개별 실행이 동등한 신호.)
- [ ] 카디르 QA → PO 머지.

## 참고 — 가드가 못 잡는 것(스크립트 docstring에 명시)
트리거 함수(`publish_registry_event`/`publish_preset_event`/`transition_gate`/`send_message`)의 간접 호출(다른 헬퍼 경유)·동적 호출(getattr/리플렉션)·fixture 이름이 파일에 문자열로만 있고 실제 `@pytest.fixture`로 등록/사용되지 않는 경우.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pN7nEKmenxEugBXV1oVQS