### PR TITLE
[SID:3334] 게이트 반려(변경 요청) 사유 필수 — 서버 422 + FE 게이팅

### DIFF
--- a/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/gates/[id]/page.tsx
@@ -168,6 +168,13 @@ export default function GateDetailPage() {
   const decisionFacts = gate && isDecisionGate(gate) ? deriveDecisionFacts(gate) : null;
   const requiresOptionChoice = decisionFacts !== null && decisionFacts.options.length > 0;
   const isSigFlowGate = !!gate && usesSignatureFlow(deriveRiskLevel(gate));
+  // story #3334 — 저위험 게이트의 반려(변경 요청)는 예전엔 사유 입력창 자체가 없는 인라인
+  // 버튼이라 클릭 즉시 빈 사유로 제출됐다(선생님 4바퀴 T1' 실사고 재현 그 자체). 근거열람
+  // 없이도 반려 자체는 가능해야 하므로(승인만 evidence 축) 저위험 게이트를 통째로 서명
+  // 플로우로 밀어넣지 않고, "반려하려는 의도"일 때만 이 토글로 같은 GateSignatureApproval
+  // 패널을 연다 — 승인은 기존처럼 원탭 그대로(이 스토리는 반려 축만 다룬다).
+  const [rejectPanelOpen, setRejectPanelOpen] = useState(false);
+  useEffect(() => { setRejectPanelOpen(false); }, [gate?.id]);
 
   const transition = useCallback(async (status: 'approved' | 'rejected', note?: string, evidenceViewed?: boolean) => {
     if (!gate) return;
@@ -404,7 +411,7 @@ export default function GateDetailPage() {
                         : t('gateReadonlyNotAuthorized')}
                     </p>
                   </div>
-                ) : isSigFlowGate ? (
+                ) : isSigFlowGate || rejectPanelOpen ? (
                   // story #2975(유나양 design 판정 2026-08-24, PO 확定) — 409(gate_head_changed)
                   // 후 fetchGate() 재조회로 gate.github_check_run_sha가 바뀌어도, key 없이는 이
                   // 컴포넌트가 그대로 살아있어 evidenceViewed/reason state가 안 리셋된다 —
@@ -413,15 +420,26 @@ export default function GateDetailPage() {
                   // key={SHA}로 SHA가 바뀔 때마다 강제 remount — 세밀한 useEffect 리셋 목록은
                   // 미래 state 추가마다 리셋 누락 사각을 만드는 구조(이번 사고와 동형 클래스)라
                   // PO가 명시 기각, remount가 미래 state까지 구조적으로 안전(최소안 채택).
-                  <GateSignatureApproval
-                    key={gate.github_check_run_sha}
-                    gate={gate}
-                    resolving={resolving}
-                    error={transitionError}
-                    onApprove={(reason) => void transition('approved', reason, true)}
-                    onReject={(reason) => void transition('rejected', reason)}
-                    onDiscuss={(reason) => void discuss(reason)}
-                  />
+                  <div className="space-y-2">
+                    <GateSignatureApproval
+                      key={gate.github_check_run_sha}
+                      gate={gate}
+                      resolving={resolving}
+                      error={transitionError}
+                      onApprove={(reason) => void transition('approved', reason, true)}
+                      onReject={(reason) => void transition('rejected', reason)}
+                      onDiscuss={(reason) => void discuss(reason)}
+                    />
+                    {/* story #3334 — 저위험 게이트는 «변경 요청» 클릭으로만 이 패널에 들어온다
+                        (원래 근거열람+사유 요구가 없는 등급) — 잘못 눌렀을 때 원탭 승인 화면으로
+                        되돌아갈 길을 남긴다. 고위험(isSigFlowGate) 게이트는 이 패널이 유일한
+                        경로라 취소 버튼 자체가 무의미(숨김).*/}
+                    {!isSigFlowGate ? (
+                      <Button type="button" variant="ghost" size="sm" className="w-full text-muted-foreground" disabled={resolving} onClick={() => setRejectPanelOpen(false)}>
+                        {t('cancel')}
+                      </Button>
+                    ) : null}
+                  </div>
                 ) : (
                   <div className="space-y-3">
                     <GateEvidence gate={gate} />
@@ -440,7 +458,7 @@ export default function GateDetailPage() {
                         variant="outline"
                         className="min-h-12 flex-1 gap-1.5"
                         disabled={resolving}
-                        onClick={() => void transition('rejected')}
+                        onClick={() => setRejectPanelOpen(true)}
                       >
                         <XCircle className="size-4" />
                         {t('gateReject')}

--- a/apps/web/src/components/cage/gate-signature-approval.tsx
+++ b/apps/web/src/components/cage/gate-signature-approval.tsx
@@ -47,6 +47,10 @@ export function GateSignatureApproval({
   const canSign = evidenceViewed && reason.trim().length > 0 && !resolving;
   // discuss는 근거 열람 불필요(승인이 아니므로) — 사유만 있으면 된다.
   const canDiscuss = reason.trim().length > 0 && !resolving;
+  // story #3334(선생님 실사용 4바퀴 T1' 적출) — 반려(변경 요청)는 근거 열람과 무관하게(승인이
+  // 아니므로 canSign과 다른 축) 사유만 필수. 예전엔 이 버튼이 resolving만 봐서 사유 빈 채로도
+  // 즉시 제출됐다(서버도 무검증이라 그대로 저장 — 반려 통지가 사유 없이 나감, #3330 AC2 무력화).
+  const canReject = reason.trim().length > 0 && !resolving;
 
   return (
     <div className="space-y-4">
@@ -95,7 +99,7 @@ export function GateSignatureApproval({
           <Button
             variant="outline"
             className={compact ? 'min-h-12 w-full gap-1.5' : 'min-h-12 flex-1 gap-1.5'}
-            disabled={resolving}
+            disabled={!canReject}
             onClick={() => onReject(reason)}
           >
             <Pencil className="size-4" />

--- a/apps/web/src/components/chat/approval-request-card.test.tsx
+++ b/apps/web/src/components/chat/approval-request-card.test.tsx
@@ -954,3 +954,55 @@ describe('ApprovalRequestCard — story #3258 doc 요약/diff+논의요청 지�
     expect(container.textContent).toContain('기한 조정 논의');
   });
 });
+
+// story #3334(페드루 PO 리뷰 적출) — 이 카드의 저위험 반려 버튼(gateReject)이 예전엔
+// onReject()를 사유 없이 즉시 호출했다(gates/[id]/page.tsx·approvals-queue.tsx에 이미 적용한
+// "반려는 사유 필수" 처방이 이 세 번째 표면엔 빠져 있었다 — 채팅 결재 카드는 선생님이 가장
+// 많이 쓰는 표면). 클릭은 이제 서명 패널(GateSignatureApproval, 사유 textarea 보유)을 열
+// 뿐이고, 사유를 채워야만 그 안의 「변경 요청」이 풀린다.
+describe('ApprovalRequestCard — 저위험 반려는 사유 패널을 거친다(story #3334)', () => {
+  it('저위험 반려 클릭 → 즉시 POST 0 → 사유 입력 後에만 POST 1(status=rejected)', async () => {
+    const calls: { url: string; method?: string; body?: string }[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method, body: init?.body as string | undefined });
+      if (init?.method === 'POST' && url.includes('/transition')) return { ok: true, json: async () => ({}) };
+      if (url.includes('/api/gates/')) {
+        return { ok: true, json: async () => ({ data: gate({ id: 'g-low-reject', can_approve: true, risk_grade: 'low' }) }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }));
+
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+          <ApprovalRequestCard target={{ work_item_type: 'story', work_item_id: 'w-1', gate_id: 'g-low-reject', actions: ['approve', 'reject'] }} />
+        </NextIntlClientProvider>,
+      );
+    });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.gateReject)) as HTMLButtonElement;
+    expect(rejectBtn).toBeTruthy();
+    await act(async () => { rejectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    // 클릭 직후 — 패널만 열렸다, 아직 POST 0건. 이 패널은 다이얼로그가 아니라 카드 안
+    // 인라인 렌더(container 안)라 document.body 포탈 스코프가 불요.
+    expect(calls.filter((c) => c.method === 'POST')).toHaveLength(0);
+    const panelRejectBtn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.sigRequestChanges)) as HTMLButtonElement;
+    expect(panelRejectBtn).toBeTruthy();
+    expect(panelRejectBtn.disabled).toBe(true); // AC — 사유 입력 前 비활성.
+
+    const textarea = document.getElementById('gate-sig-reason') as HTMLTextAreaElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+      setter.call(textarea, '스키마 필드명이 기존 컨벤션과 다릅니다');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(panelRejectBtn.disabled).toBe(false);
+
+    await act(async () => { panelRejectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const postCall = calls.find((c) => c.method === 'POST');
+    expect(postCall?.url).toBe('/api/gates/g-low-reject/transition');
+    expect(JSON.parse(postCall?.body ?? '{}')).toMatchObject({ status: 'rejected', note: '스키마 필드명이 기존 컨벤션과 다릅니다' });
+  });
+});

--- a/apps/web/src/components/chat/approval-request-card.tsx
+++ b/apps/web/src/components/chat/approval-request-card.tsx
@@ -511,6 +511,15 @@ function ApprovalRequestBody({
   })() : null;
   const riskLevel = deriveRiskLevel(gate);
   const needsFullFlow = usesSignatureFlow(riskLevel);
+  // story #3334(페드루 PO 리뷰 적출) — 저위험 게이트의 반려(변경 요청)는 예전엔 이 카드가
+  // onReject()를 사유 없이 즉시 호출했다(gates/[id]/page.tsx·approvals-queue.tsx에 적용한
+  // 동형 처방을 이 세 번째 표면엔 빠뜨렸던 것 — 채팅 결재 카드는 선생님이 가장 많이 쓰는
+  // 표면이라 실사용에서 바로 걸림돌이 됐을 자리). 근거열람 없이도 반려 자체는 가능해야
+  // 하므로(승인만 evidence 축) 저위험 게이트를 통째로 서명 플로우로 밀어넣지 않고, "반려
+  // 하려는 의도"일 때만 이 토글로 같은 GateSignatureApproval 패널을 연다.
+  // gate.id는 이 카드 인스턴스의 수명 동안 고정(target.gate_id로 매 폴링/재조회를 같은
+  // 게이트에 거는 구조라 다른 게이트로 안 바뀐다) — 리셋 이펙트 불요.
+  const [rejectPanelOpen, setRejectPanelOpen] = useState(false);
   const canAct = gate.status === 'pending' && gate.can_approve === true;
   // story #3001 — 지정이 걸린 게이트인데 지금 이 카드를 보는 나는 더 이상 그 지정자가
   // 아니다(위임됨). 미지정(broadcast) 게이트는 gate.designated_approver_id가 애초 null이라
@@ -719,23 +728,34 @@ function ApprovalRequestBody({
         // 렌더하지 않는다. 고위험도 이제 챗 안에서 완결되므로(#2625) 여기 남는 유일한
         // "액션 불가" 사유는 무권한뿐이다.
         <p className="text-[11px] text-muted-foreground">{tCage('gateReadonlyNotAuthorized')}</p>
-      ) : needsFullFlow ? (
+      ) : needsFullFlow || rejectPanelOpen ? (
         // story #2975(유나양 design 판정 2026-08-24) 갭 자체발견(#2982 작업 중) — 그 블로커
         // 처방(key={SHA}로 재조회 後 evidenceViewed/reason 강제 리셋)이 gates/[id]/page.tsx
         // 에만 적용되고 이 챗 카드는 빠져 있었다. 같은 컴포넌트·같은 취약(SHA 바뀐 뒤에도
         // 열람체크가 살아있어 재확認 없이 재승인 가능)이라 동형 처방.
-        <GateSignatureApproval
-          key={gate.github_check_run_sha}
-          gate={gate}
-          resolving={resolving}
-          error={transitionError}
-          // story #2027 AC2: GateSignatureApproval의 canSign이 evidenceViewed&&reason로 버튼을
-          // 막아서 이 콜백에 닿았다는 사실 자체가 열람 확인 — gates/[id]/page.tsx와 동일 계약.
-          onApprove={(reason) => onApprove(reason, true)}
-          onReject={onReject}
-          onDiscuss={onDiscuss}
-          compact
-        />
+        <div className="space-y-1.5">
+          <GateSignatureApproval
+            key={gate.github_check_run_sha}
+            gate={gate}
+            resolving={resolving}
+            error={transitionError}
+            // story #2027 AC2: GateSignatureApproval의 canSign이 evidenceViewed&&reason로 버튼을
+            // 막아서 이 콜백에 닿았다는 사실 자체가 열람 확인 — gates/[id]/page.tsx와 동일 계약.
+            onApprove={(reason) => onApprove(reason, true)}
+            onReject={onReject}
+            onDiscuss={onDiscuss}
+            compact
+          />
+          {/* story #3334 — 저위험 게이트는 «변경 요청» 클릭으로만 이 패널에 들어온다(원래
+              근거열람+사유 요구가 없는 등급) — 잘못 눌렀을 때 원탭 승인 화면으로 되돌아갈
+              길을 남긴다. 고위험(needsFullFlow) 게이트는 이 패널이 유일한 경로라 취소
+              버튼이 무의미(숨김). */}
+          {!needsFullFlow ? (
+            <Button type="button" variant="ghost" size="sm" className="w-full text-muted-foreground" disabled={resolving} onClick={() => setRejectPanelOpen(false)}>
+              {tCage('cancel')}
+            </Button>
+          ) : null}
+        </div>
       ) : (
         <>
           {transitionError ? (
@@ -748,7 +768,7 @@ function ApprovalRequestBody({
               <Check className="h-3.5 w-3.5" aria-hidden />
               {tCage('gateApprove')}
             </Button>
-            <Button type="button" size="sm" variant="destructive" onClick={() => onReject()} disabled={resolving} className="flex-1">
+            <Button type="button" size="sm" variant="destructive" onClick={() => setRejectPanelOpen(true)} disabled={resolving} className="flex-1">
               <X className="h-3.5 w-3.5" aria-hidden />
               {tCage('gateReject')}
             </Button>

--- a/apps/web/src/components/docs/doc-gate-section.tsx
+++ b/apps/web/src/components/docs/doc-gate-section.tsx
@@ -464,7 +464,9 @@ export function DocGateSection({
                 variant="ghost"
                 size="sm"
                 className="gap-1 text-destructive hover:text-destructive hover:ring-1 hover:ring-inset hover:ring-destructive/60"
-                disabled={busy}
+                // story #3334 — 반려 사유(note) 서버측 필수 강제(gates.py 422)와 짝 — 예전엔
+                // busy만 봐서 빈 textarea로도 즉시 제출됐다(서버 무검증이던 시절 그대로 방치).
+                disabled={busy || !note.trim()}
                 onClick={() => void submitReject()}
               >
                 <ShieldX className="size-3.5" />

--- a/apps/web/src/components/docs/doc-status-rail.tsx
+++ b/apps/web/src/components/docs/doc-status-rail.tsx
@@ -185,10 +185,15 @@ export function DocStatusHeader({ docId, status, editHref, onTransitioned }: { d
         </Button>
       ) : isApprover ? (
         <div className="flex shrink-0 gap-2">
-          <Button size="sm" variant="ghost" disabled={busy} className="gap-1 text-destructive hover:ring-1 hover:ring-inset hover:ring-destructive/60"
-            onClick={() => currentTeamMemberId && void gateTransition({ status: 'rejected', resolver_id: currentTeamMemberId }, onTransitioned)}
-          >
-            <XCircle className="size-3.5" />{t('docGateReject')}
+          {/* story #3334 — 반려(변경 요청)는 gate_type 무관 사유 필수(서버 422). 저위험이라도
+              이 리더 헤더엔 사유 입력창이 없으므로, 반려는 사유 모달을 가진 에디터
+              (doc-gate-section.tsx의 rejectOpen 다이얼로그)로 유도한다 — 위 고위험 분기와
+              같은 원칙("여기서 직행 처리 안 함, 반려는 비대칭 예외 없이 동일 취급"). 승인은
+              사유가 필요 없으므로 기존처럼 원탭 그대로. */}
+          <Button asChild size="sm" variant="ghost" className="gap-1 text-destructive hover:ring-1 hover:ring-inset hover:ring-destructive/60">
+            <Link href={editHref}>
+              <XCircle className="size-3.5" />{t('docGateReject')}
+            </Link>
           </Button>
           <Button size="sm" variant="ghost" disabled={busy} className="gap-1 text-success hover:ring-1 hover:ring-inset hover:ring-success/60"
             onClick={() => currentTeamMemberId && void gateTransition({ status: 'approved', resolver_id: currentTeamMemberId }, onTransitioned)}

--- a/apps/web/src/components/hypotheses/hypothesis-gate-badge.tsx
+++ b/apps/web/src/components/hypotheses/hypothesis-gate-badge.tsx
@@ -145,7 +145,9 @@ export function HypothesisGateBadge({ hypothesis, gate, resolveName = (id) => id
             size="sm"
             variant="ghost"
             className="h-7 text-destructive hover:text-destructive hover:ring-1 hover:ring-inset hover:ring-destructive/60"
-            disabled={resolving}
+            // story #3334 — 반려 사유(note) 서버측 필수 강제(gates.py 422)와 짝. 예전엔
+            // resolving만 봐서 빈 입력으로도 즉시 제출됐다.
+            disabled={resolving || !rejectNote.trim()}
             onClick={() => void transition('rejected', rejectNote)}
           >
             {resolving ? '…' : t('gateRejectConfirm')}

--- a/apps/web/src/components/inbox/approvals-queue.test.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.test.tsx
@@ -561,13 +561,35 @@ describe('ApprovalsQueue', () => {
     expect(calls.filter((c) => c.method === 'POST')).toHaveLength(1);
   });
 
-  it('변경 요청 클릭 시(저위험) status=rejected로 호출하고 반려됨 배지를 보인다', async () => {
+  // story #3334(선생님 실사용 4바퀴 T1' 적출, 처방 확定) — 저위험이라도 반려는 이제 사유
+  // 필수(서버 gate_type 무관 422 강제). 예전엔 이 카드의 "변경 요청" 클릭이 사유 없이 즉시
+  // POST했다(이 테스트가 그 낡은 계약을 pin하고 있었다) — 지금은 클릭 즉시 제출 대신 서명
+  // 다이얼로그(GateSignatureApproval, document.body 포탈)를 열고, 사유를 채워야만 그 안의
+  // "변경 요청" 버튼이 풀린다.
+  it('변경 요청 클릭 시(저위험) 사유 다이얼로그를 열고, 사유 입력 後에만 status=rejected로 호출한다', async () => {
     const calls = mockFetches([lowRiskActionable({ id: 'g-rej' })], []);
     await mount();
     const rejectButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.sigRequestChanges));
     await act(async () => { rejectButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+
+    // 다이얼로그가 열렸다 — 즉시 POST는 아직 안 나갔다.
+    expect(calls.filter((c) => c.method === 'POST')).toHaveLength(0);
+    const dialogRejectBtn = [...document.body.querySelectorAll('[data-slot="dialog-content"] button')].find((b) => b.textContent?.includes(koMessages.cage.sigRequestChanges)) as HTMLButtonElement;
+    expect(dialogRejectBtn.disabled).toBe(true); // AC — 사유 입력 前 비활성.
+
+    const textarea = document.body.querySelector('#gate-sig-reason') as HTMLTextAreaElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+      setter.call(textarea, '스키마 필드명이 기존 컨벤션과 다릅니다');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(dialogRejectBtn.disabled).toBe(false);
+
+    await act(async () => { dialogRejectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     const postCall = calls.find((c) => c.method === 'POST');
-    expect(JSON.parse(postCall?.body ?? '{}')).toEqual({ status: 'rejected', note: null, evidence_viewed: false, reviewed_head_sha: null });
+    expect(JSON.parse(postCall?.body ?? '{}')).toEqual({
+      status: 'rejected', note: '스키마 필드명이 기존 컨벤션과 다릅니다', evidence_viewed: false, reviewed_head_sha: null,
+    });
     expect(container.textContent).toContain(koMessages.cage.queueResolvedRejected);
   });
 
@@ -707,12 +729,25 @@ describe('ApprovalsQueue', () => {
     expect(buttonsAfter.some((t) => t?.includes(koMessages.cage.gateApprove))).toBe(true);
   });
 
-  it('AC 음성대조 — 반려 직후(아직 승인/취소 안 됨)엔 취소 버튼이 즉시 뜨지 않다가, 반려 완료 후엔 뜬다', async () => {
+  // story #3334 — "반려 직후"의 의미가 바뀌었다: 클릭은 이제 다이얼로그를 열 뿐(즉시 반려
+  // 아님) — 취소 버튼은 사유 입력 後 다이얼로그 안에서 실제로 제출해야만 뜬다.
+  it('AC 음성대조 — 반려 클릭은 다이얼로그만 열고(취소 버튼 안 뜸), 사유 입력 後 제출해야 취소 버튼이 뜬다', async () => {
     mockFetches([lowRiskActionable({ id: 'g-reject-undo' })], []);
     await mount();
     const rejectButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes(koMessages.cage.sigRequestChanges));
     expect([...container.querySelectorAll('button')].some((b) => b.textContent?.includes(koMessages.cage.gateUndo))).toBe(false);
     await act(async () => { rejectButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    // 다이얼로그만 열렸다 — 아직 반려되지 않았으므로 취소 버튼은 여전히 없다.
+    expect([...container.querySelectorAll('button')].some((b) => b.textContent?.includes(koMessages.cage.gateUndo))).toBe(false);
+
+    const textarea = document.body.querySelector('#gate-sig-reason') as HTMLTextAreaElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+      setter.call(textarea, '재작업 필요');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const dialogRejectBtn = [...document.body.querySelectorAll('[data-slot="dialog-content"] button')].find((b) => b.textContent?.includes(koMessages.cage.sigRequestChanges)) as HTMLButtonElement;
+    await act(async () => { dialogRejectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect([...container.querySelectorAll('button')].some((b) => b.textContent?.includes(koMessages.cage.gateUndo))).toBe(true);
   });
 
@@ -1153,14 +1188,29 @@ describe('ApprovalsQueue — story #3113 결정 게이트(agent_decision_request
     expect(approveBtn.disabled).toBe(false);
   });
 
-  it('거절은 안 선택 없이도 즉시 가능하다(반려는 안을 고르는 행위가 아님)', async () => {
+  // story #3334 — 반려는 여전히 "안 선택" 없이 가능하다(옵션 축과 무관, 그 AC는 안 바뀜). 다만
+  // 반려 자체가 이제 사유 없이 "즉시"는 아니다(gate_type 무관 사유 필수) — 클릭은 다이얼로그를
+  // 열 뿐이고, 옵션을 고르지 않은 채로도 그 다이얼로그에 진입할 수 있음(=안 선택 무관)만 남는다.
+  it('거절 버튼은 안 선택 없이도 눌리지만(반려는 안을 고르는 행위가 아님), 사유 다이얼로그를 거쳐야 제출된다', async () => {
     const calls = mockFetches([decisionGate()], []);
     await mount();
     const rejectBtn = Array.from(container.querySelectorAll('button')).find(
       (b) => b.textContent?.includes(koMessages.cage.sigRequestChanges),
     ) as HTMLButtonElement;
-    expect(rejectBtn.disabled).toBe(false);
+    expect(rejectBtn.disabled).toBe(false); // 옵션 미선택 상태에서도 클릭 자체는 가능.
     await act(async () => { rejectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(calls.filter((c) => c.method === 'POST')).toHaveLength(0); // 즉시 제출은 안 됨.
+
+    const textarea = document.body.querySelector('#gate-sig-reason') as HTMLTextAreaElement;
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')!.set!;
+      setter.call(textarea, '보류(C안)로 다시 검토 요청');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const dialogRejectBtn = [...document.body.querySelectorAll('[data-slot="dialog-content"] button')].find(
+      (b) => b.textContent?.includes(koMessages.cage.sigRequestChanges),
+    ) as HTMLButtonElement;
+    await act(async () => { dialogRejectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     const postCall = calls.find((c) => c.method === 'POST' && c.url.includes('/transition'));
     expect(JSON.parse(postCall?.body ?? '{}').status).toBe('rejected');
   });

--- a/apps/web/src/components/inbox/approvals-queue.tsx
+++ b/apps/web/src/components/inbox/approvals-queue.tsx
@@ -609,10 +609,12 @@ export function ApprovalsQueue() {
           // 필드 없이 기존 자유텍스트 필드 재사용 — 결과 조회 시 "어느 안"이었는지 그대로 읽힌다).
           else void resolveGate(gate.id, 'approved', requiresOptionChoice ? t('decisionSelectedNote', { option: selectedOption }) : null);
         };
-        const rejectOnClick = () => {
-          if (isSigFlow) setSignatureTargetId(gate.id);
-          else void resolveGate(gate.id, 'rejected');
-        };
+        // story #3334(선생님 실사용 4바퀴 T1' 적출) — 반려(변경 요청)는 이제 gate_type/위험도
+        // 무관 사유 필수(서버 422, gates.py transition_gate_endpoint). 예전엔 저위험 게이트만
+        // 이 else 분기로 사유 없이 즉시 반려됐다 — 그 즉시제출 경로를 없애고 반려는 항상 이미
+        // 있는 서명 다이얼로그(GateSignatureApproval, 사유 textarea 보유)로 통일한다. 승인은
+        // 기존처럼 저위험 원탭 그대로(primaryOnClick, 변경 없음 — 이 스토리는 반려 축만 다룬다).
+        const rejectOnClick = () => setSignatureTargetId(gate.id);
 
         return (
           <div key={gate.id} className="rounded-xl border border-border bg-card px-4 py-3">

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1488,6 +1488,16 @@ async def transition_gate_endpoint(
                 "resolved_at": _gate.resolved_at.isoformat() if _gate.resolved_at else None,
             },
         )
+    # story #3334(선생님 실사용 4바퀴 T1' 적출) — rejected(변경 요청) 전이는 gate_type 무관 사유
+    # (note) 서버측 강제. 반려는 실행자에게 «무엇을 고칠지»를 주는 게 목적(#3330 AC2 반려 통지가
+    # 그 사유를 싣는다) — 사유 없는 반려는 「승인 대기와 구분되는 멈춤」만 만들고 실행자를 그대로
+    # 막아세운다. 아래 approved+고위험 강제(#2027)와 결을 맞추되, 그쪽은 risk_grade=="high"에서만
+    # 도는 반면 이건 **항상**(위험도 무관) — 처방 문서 원문 "모든 gate_type" 그대로.
+    if body.status == "rejected" and not (body.note or "").strip():
+        raise HTTPException(
+            status_code=422,
+            detail="반려(변경 요청) 사유(note) 입력이 필수입니다.",
+        )
     # story #2027(까심 QA 적출): 고위험(risk_grade=high) 게이트의 approved 전이는 사유(note) 서버측
     # 강제 — void_gate/override_gate 기존 관례(reason 없으면 ValueError→422, void_gate 참고)에
     # 맞추는 작업이다(신규 규칙 아님). 이전엔 FE 버튼 disable(evidenceViewed && reason.trim())만

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1488,16 +1488,6 @@ async def transition_gate_endpoint(
                 "resolved_at": _gate.resolved_at.isoformat() if _gate.resolved_at else None,
             },
         )
-    # story #3334(선생님 실사용 4바퀴 T1' 적출) — rejected(변경 요청) 전이는 gate_type 무관 사유
-    # (note) 서버측 강제. 반려는 실행자에게 «무엇을 고칠지»를 주는 게 목적(#3330 AC2 반려 통지가
-    # 그 사유를 싣는다) — 사유 없는 반려는 「승인 대기와 구분되는 멈춤」만 만들고 실행자를 그대로
-    # 막아세운다. 아래 approved+고위험 강제(#2027)와 결을 맞추되, 그쪽은 risk_grade=="high"에서만
-    # 도는 반면 이건 **항상**(위험도 무관) — 처방 문서 원문 "모든 gate_type" 그대로.
-    if body.status == "rejected" and not (body.note or "").strip():
-        raise HTTPException(
-            status_code=422,
-            detail="반려(변경 요청) 사유(note) 입력이 필수입니다.",
-        )
     # story #2027(까심 QA 적출): 고위험(risk_grade=high) 게이트의 approved 전이는 사유(note) 서버측
     # 강제 — void_gate/override_gate 기존 관례(reason 없으면 ValueError→422, void_gate 참고)에
     # 맞추는 작업이다(신규 규칙 아님). 이전엔 FE 버튼 disable(evidenceViewed && reason.trim())만

--- a/backend/app/routers/workflow_line_config.py
+++ b/backend/app/routers/workflow_line_config.py
@@ -276,9 +276,26 @@ async def approve_publish(
     return VersionResponse.model_validate(version)
 
 
+class RejectPublishRequest(BaseModel):
+    # story #3334(페드루 PO 처방, 서버 강제 위치 정정) — transition_gate() 서비스층이 이제
+    # rejected 전이에 사유를 gate_type 무관 강제한다. 이 엔드포인트가 note 없이 호출하면
+    # 그 ValueError가 아래 `except ValueError: pass`("gate already resolved")에 조용히
+    # 삼켜져 — version만 rejected로 보이고 gate는 영원히 pending인 채 남는 사고가 났을
+    # 것이다. 여기서 먼저 필수로 막아 그 경로 자체를 없앤다.
+    reason: str
+
+    @field_validator("reason")
+    @classmethod
+    def _reason_not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("반려 사유(reason)는 비어있지 않아야 합니다.")
+        return v
+
+
 @router.post("/versions/{version_id}/reject", response_model=VersionResponse)
 async def reject_publish(
     version_id: uuid.UUID,
+    body: RejectPublishRequest,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
@@ -288,9 +305,12 @@ async def reject_publish(
     version = await _load_version(session, org_id, version_id)
     if version.review_gate_id is not None:
         try:
-            await transition_gate(session, org_id, version.review_gate_id, "rejected", resolver_id=actor)
+            await transition_gate(
+                session, org_id, version.review_gate_id, "rejected",
+                resolver_id=actor, note=body.reason,
+            )
         except ValueError:
-            pass  # gate already resolved — version 전이만 반영
+            pass  # gate already resolved — version 전이만 반영(body.reason은 위에서 이미 비어있지 않음이 보장됨)
     version = await transition_version(session, version, "rejected")
     await session.commit()
     # story #2459 회귀 동형 방어(2026-08-05): commit 後 model_validate 前 명시 refresh.

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -796,6 +796,14 @@ async def transition_gate(
             f"불법 전이: {gate.status} → {new_status}. "
             f"pending에서만 approved|rejected로 전이 가능."
         )
+    # story #3334(선생님 실사용 4바퀴 T1' 적출, 페드루 PO 처방 — 서버 강제 위치 정정) —
+    # rejected 전이는 gate_type 무관 사유(note) 서버측 강제. void_gate(바로 아래 참조)와
+    # 동일 관례(reason 없으면 ValueError→라우터가 422로 재포장)를 여기 서비스층에 둔다 —
+    # 처음엔 router(transition_gate_endpoint)에만 걸었다가, transition_gate()를 직접 부르는
+    # 내부 호출자(workflow_line_config.py::reject_publish 등)가 그 우회로였음을 PO 리뷰가
+    # 잡았다 — "모든 gate_type 서버 거부"라면 모든 호출 경로를 통과하는 이 지점이 맞다.
+    if new_status == "rejected" and not (note or "").strip():
+        raise ValueError("반려(변경 요청) 사유(note) 입력이 필수입니다.")
 
     # P0-04(doc trust-pipeline-be-design §4 훅①): trust_stage mutation 전 스냅샷(story 대상 게이트만).
     _trust_before = None

--- a/backend/app/services/workflow_parallel_approval.py
+++ b/backend/app/services/workflow_parallel_approval.py
@@ -174,13 +174,19 @@ def _quorum_met(approved: int, total_blocking: int, qtype: str, qcount: int | No
 
 async def record_parallel_decision(
     session: AsyncSession, approval_id: uuid.UUID, decision: str, resolver_id: uuid.UUID | None,
+    note: str | None = None,
 ) -> dict[str, Any]:
     """approver row 1건 결정을 기록하고 그룹 quorum 을 재평가한다.
 
     blocking approver-kind row 만 집계(consult/non-blocking 제외). any reject(any_reject_blocks)→
     ``transition_gate(rejected)`` / quorum 충족→``transition_gate(approved)`` / else pending.
     gate 가 이미 terminal 이면 멱등 skip(중복 해소 무시).
-    """
+
+    story #3334(페드루 PO 처방, 전수 grep 대상) — 이 함수는 아직 HTTP 엔드포인트가 없다(라우터
+    미배선, 이 파일의 유일한 호출자는 자기 테스트뿐 — 실 프로덕션 경로 아님). 그래도
+    transition_gate("rejected")에 도달하는 자리라 note 를 받아 그대로 넘긴다 + 이 row 자체의
+    decision_note(모델 컬럼, 지금까지 아무도 안 채우던 미사용 필드)에도 기록 — 엔드포인트가
+    나중에 배선될 때 "reject엔 사유가 필수"라는 계약이 이미 여기 박혀 있게 한다."""
     if decision not in _VALID_DECISIONS:
         raise ValueError(f"invalid decision: {decision}")
     appr = (await session.execute(
@@ -215,6 +221,8 @@ async def record_parallel_decision(
 
     appr.status = decision
     appr.resolved_at = _now()
+    if note:
+        appr.decision_note = note
     await session.flush()
 
     # 그룹의 blocking approver-kind row 로 quorum 재계산(consult/non-blocking 제외·AC④).
@@ -237,7 +245,7 @@ async def record_parallel_decision(
     # target 도달 시 transition_gate 단일 rail 로 해소(gate 는 위에서 non-terminal 확인됨).
     if target is not None and gate is not None:
         from app.services.gate_service import transition_gate
-        await transition_gate(session, appr.org_id, appr.gate_id, target, resolver_id=resolver_id)
+        await transition_gate(session, appr.org_id, appr.gate_id, target, resolver_id=resolver_id, note=note)
         outcome = target
 
     return {"outcome": outcome, "skipped": False, **tally}

--- a/backend/tests/test_183fe7a5_gate_service_wiring.py
+++ b/backend/tests/test_183fe7a5_gate_service_wiring.py
@@ -75,7 +75,9 @@ async def test_reject_also_triggers_escalation_resolution_delivery():
         "app.services.escalation_resolution_delivery.deliver_escalation_resolution_for_gate",
         new_callable=AsyncMock,
     ) as delegate:
-        await transition_gate(session, ORG_ID, GATE_ID, "rejected", MEMBER_ID)
+        # story #3334 — transition_gate("rejected")가 이제 사유 필수(서비스층 강제). 이
+        # 테스트의 관심사(escalation 동기화 훅 발화)와 무관하므로 명시로 실어 대상 밖임을 밝힌다.
+        await transition_gate(session, ORG_ID, GATE_ID, "rejected", MEMBER_ID, "에스컬레이션 재현 사유")
 
     delegate.assert_awaited_once()
     _, kwargs = delegate.call_args

--- a/backend/tests/test_3334_gate_reject_reason_enforce.py
+++ b/backend/tests/test_3334_gate_reject_reason_enforce.py
@@ -1,0 +1,256 @@
+"""story #3334(선생님 실사용 4바퀴 T1' 적출, 페드루 PO 처방): 게이트 rejected(변경 요청) 전이의
+사유(resolution_note) 서버측 강제.
+
+배경: `/gates/{id}` 상세 페이지 저위험 인라인 반려 버튼은 사유 입력창 자체가 없었다 — 클릭 즉시
+`resolution_note=""`로 rejected 저장. 서버도 무검증이라 그대로 통과했다 — 반려 통지(#3330 AC2가
+사유+다음 행동을 싣는다)가 빈 사유로 나가, 실행자가 "무엇을 고칠지" 못 받았다.
+
+story #2027(고위험 approved의 note 서버측 강제)과 결이 같은 처방이되, 핵심 차이: #2027은
+risk_grade=="high"에서만 돈다(저위험은 과도 강제 금지가 PO AC) — 이 스토리는 처방 원문
+"모든 gate_type" 그대로, risk_grade/gate_type 무관 항상 강제한다. 아래 테스트가 그 차이를
+직접 고정한다(저위험 gate_type=merge 조합으로 422를 실증 — #2027이라면 이 조합은 그냥
+통과했을 것).
+
+seed/client 헬퍼는 test_2027_gate_approval_reason_enforce.py와 동일 패턴(파일별 로컬 중복이
+이 스위트의 기존 관례).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# realdb 섹션이 Base.metadata.create_all을 호출한다 — conftest.py AST 가드(story 8236bbc3) 대응.
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import app.models  # noqa: F401 — 전 모델 메타데이터 로드
+    import app.models.activity_log  # noqa: F401 — transition_gate()가 ActivityLog를 씀(#2201 후속 미등재 갭).
+    from app.core.database import Base
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from tests.conftest import override_db_and_read
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _seed_common(session):
+    """org + project + caller(project owner grant — rule B 승인/반려 자격)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    caller = User(id=uuid.uuid4(), email=f"caller-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller.id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=caller_om.id,
+        permission="granted", role="owner",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "caller_id": caller.id}
+
+
+async def _seed_gate(session, *, posture: str, gate_type: str, story_title: str):
+    from app.models.gate import Gate
+    from app.models.hitl_config import OrgGatePolicy
+    from app.models.pm import Story
+
+    seeded = await _seed_common(session)
+    session.add(OrgGatePolicy(org_id=seeded["org_id"], posture=posture))
+    await session.commit()
+    story = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                  title=story_title)
+    session.add(story)
+    await session.commit()
+    gate = Gate(id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=story.id,
+                work_item_type="story", gate_type=gate_type, status="pending")
+    session.add(gate)
+    await session.commit()
+    return seeded, gate.id
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_low_risk_reject_without_note_422_and_no_mutation():
+    """핵심 차이 실증(#2027 대칭 대조): permissive posture가 gate_type=merge를 저위험으로
+    오버라이드한 조합(#2027이라면 approve는 note 없이 통과) — 그런데도 **reject는 여전히
+    422**다. risk_grade 무관, gate_type 무관 처방 원문("모든 gate_type") 그대로."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded, gate_id = await _seed_gate(
+                s, posture="permissive", gate_type="merge", story_title="저위험 반려 대상(사유 無)",
+            )
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition", json={"status": "rejected"},
+            )
+            assert resp.status_code == 422, resp.text
+            # app.main.http_exception_handler — HTTPException.detail(str)을
+            # {"error":{"message":...}} 봉투로 재포장(story #2003 REST 엔벨로프).
+            assert "사유" in resp.json()["error"]["message"], resp.json()
+
+            # 뮤테이션 0 확인 — 재조회(feedback_verify_commit_race: 직후 상태를 API 재조회로 입증).
+            recheck = await client.get(f"/api/v2/gates/{gate_id}")
+            assert recheck.status_code == 200, recheck.text
+            body = recheck.json()
+            assert body["status"] == "pending", body
+            assert body["resolution_note"] is None, body
+            assert body["resolved_at"] is None, body
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_reject_with_note_persists_resolution_note_and_dispatches_notification():
+    """같은 저위험 조합에 note를 실어 보내면 200·resolution_note가 실제로 저장된다(재조회로
+    확인) — #3330 AC2(반려 통지가 이 사유를 싣는다)가 의존하는 바로 그 데이터."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded, gate_id = await _seed_gate(
+                s, posture="permissive", gate_type="merge", story_title="저위험 반려 대상(사유 有)",
+            )
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            note = "스키마 필드명이 기존 컨벤션과 다릅니다 — snake_case로 통일해주세요"
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "rejected", "note": note},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] == "rejected", resp.json()
+            assert resp.json()["resolution_note"] == note, resp.json()
+
+            recheck = await client.get(f"/api/v2/gates/{gate_id}")
+            assert recheck.status_code == 200, recheck.text
+            body = recheck.json()
+            assert body["status"] == "rejected", body
+            assert body["resolution_note"] == note, body
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_realdb_doc_gate_reject_without_note_422():
+    """gate_type=doc_approval(고위험 축이 다른 종류 — #2027 강제와 무관한 gate_type)도 reject
+    사유 강제 대상임을 고정 — "gate_type 무관"이 특정 축 하나에 우연히 걸린 결과가 아님을
+    다른 gate_type으로도 확인한다."""
+    from app.main import app
+    from app.models.doc import Doc
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_common(s)
+            doc = Doc(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="반려 대상 문서", slug=f"doc-{uuid.uuid4().hex[:6]}", status="pending",
+            )
+            s.add(doc)
+            await s.flush()
+            from app.models.gate import Gate
+            gate = Gate(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=doc.id, work_item_type="doc",
+                gate_type="doc_approval", status="pending",
+                neutral_facts={"requested_by_member_id": str(uuid.uuid4())},
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["caller_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition", json={"status": "rejected"},
+            )
+            assert resp.status_code == 422, resp.text
+            assert "사유" in resp.json()["error"]["message"], resp.json()
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_a2a_sa5_auth_required_realdb.py
+++ b/backend/tests/test_a2a_sa5_auth_required_realdb.py
@@ -276,7 +276,9 @@ async def test_reject_from_auth_required_transitions_to_rejected():
             app.dependency_overrides.clear()
 
         async with Session() as s:
-            await transition_gate(s, org_id, gate_id, "rejected", resolver_id=uuid.uuid4())
+            # story #3334 — transition_gate("rejected")가 이제 사유 필수. 이 테스트의
+            # 관심사(A2ATask 상태 동기화)와 무관하므로 명시로 실어 대상 밖임을 밝힌다.
+            await transition_gate(s, org_id, gate_id, "rejected", resolver_id=uuid.uuid4(), note="a2a 인가 거부")
             await s.commit()
 
         async with Session() as s:

--- a/backend/tests/test_e_cage_referee_p3_gate_object.py
+++ b/backend/tests/test_e_cage_referee_p3_gate_object.py
@@ -542,8 +542,12 @@ async def test_transition_approved_saves_note():
 
 
 @pytest.mark.anyio
-async def test_transition_rejected_empty_note_graceful():
-    """rejected 전이 시 note=None이면 resolution_note 건드리지 않음."""
+async def test_transition_rejected_empty_note_now_rejected_by_server():
+    """story #3334(선생님 4바퀴 실사고) — 이 테스트는 예전엔 "note=None이면 graceful하게
+    통과·resolution_note 안 건드림"을 고정했었다. 그 전제 자체가 이 스토리의 처방(반려는
+    gate_type 무관 사유 필수)과 정면 충돌 — 사유 없는 반려가 «무엇을 고칠지» 없이 조용히
+    통과하던 그 정확한 경로다. 낡은 계약을 지우는 대신 새 계약(ValueError→422)으로 뒤집어
+    같은 자리를 계속 지킨다(gate mutate 0도 함께 확인)."""
     from app.services.gate_service import transition_gate
 
     gate = MagicMock()
@@ -559,8 +563,9 @@ async def test_transition_rejected_empty_note_graceful():
     session.flush = AsyncMock()
     session.refresh = AsyncMock()
 
-    await transition_gate(session, ORG_ID, GATE_ID, "rejected", MEMBER_ID, None)
-    assert gate.status == "rejected"
+    with pytest.raises(ValueError, match="사유"):
+        await transition_gate(session, ORG_ID, GATE_ID, "rejected", MEMBER_ID, None)
+    assert gate.status == "pending"  # 뮤테이션 0 — status가 여전히 원래 값.
     assert gate.resolution_note is None
 
 

--- a/backend/tests/test_edg_s9_parallel_quorum.py
+++ b/backend/tests/test_edg_s9_parallel_quorum.py
@@ -217,10 +217,12 @@ async def test_any_reject_blocks_rejects_gate():
         rid = (await s.execute(select(WorkflowLineStepApproval.id).where(
             WorkflowLineStepApproval.approver_member_id == a1["member_id"]))).scalar_one()
         # 1명 reject → any_reject_blocks → 즉시 rejected(나머지 대기 안 함)
-        r = await record_parallel_decision(s, rid, "rejected", a1["member_id"])
+        # story #3334 — transition_gate("rejected")가 이제 사유 필수라 note를 실어 보낸다.
+        r = await record_parallel_decision(s, rid, "rejected", a1["member_id"], note="블로커 이슈 확인 필요")
         assert r["outcome"] == "rejected" and r["rejected"] == 1
         g = (await s.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
         assert g.status == "rejected"
+        assert g.resolution_note == "블로커 이슈 확인 필요"
     await engine.dispose()
 
 

--- a/backend/tests/test_h1_fix2_approve_advances_done.py
+++ b/backend/tests/test_h1_fix2_approve_advances_done.py
@@ -125,7 +125,9 @@ async def test_transition_reject_does_not_advance_story_either():
 
         async with Session() as s:
             await s.execute(_text("SET session_replication_role = replica"))
-            await transition_gate(s, org, gate_id, "rejected", resolver_id=resolver)
+            # story #3334 — transition_gate("rejected")가 이제 사유 필수. 이 테스트의
+            # 관심사(story.status 미전진 확인)와 무관하므로 명시로 실어 대상 밖임을 밝힌다.
+            await transition_gate(s, org, gate_id, "rejected", resolver_id=resolver, note="양성대조용 반려")
             await s.commit()
 
         async with Session() as s:


### PR DESCRIPTION
## Summary
[SID:3334] 선생님 실사용 4바퀴 T1' 적출 — `/gates/{id}` 상세 페이지의 저위험 인라인 «변경 요청» 버튼이 사유 입력 없이 즉시 `resolution_note=""`로 반려를 제출했다(서버도 무검증). 반려 통지(#3330 AC2가 사유+다음 행동을 싣는다)가 빈 사유로 나가 실행자가 "무엇을 고칠지" 못 받는 결함.

## Fix
**서버**: `transition_gate_endpoint`가 `status="rejected"`에 빈/누락 사유(note)면 422 — **gate_type·risk_grade 무관 항상**(처방 원문 "모든 gate_type" 그대로 — #2027의 approved+고위험 전용 규칙과 다름).

**FE**: 이 엔드포인트로 rejected를 보내는 모든 호출부를 감사했다(스토리가 명시한 "두 표면"보다 넓음 — 서버 강제가 무조건이라, 감사 안 했으면 아래 다른 경로들이 그냥 깨졌을 것):
- `GateSignatureApproval`(gates/[id]·inbox 다이얼로그·챗 결재카드 공유) — 반려 버튼이 이제 `reason.trim()` 필수(예전엔 `resolving`만 봄).
- `gates/[id]/page.tsx`·`approvals-queue.tsx` — 저위험 게이트의 원클릭/무다이얼로그 반려 경로를 없애고 같은 서명 패널로 통일(승인은 저위험 원탭 그대로, 변경 없음).
- `doc-gate-section.tsx` — 자체 반려 모달의 제출 버튼도 사유 필수.
- `doc-status-rail.tsx` — permissive posture의 저위험 doc gate 반려 버튼(희귀 케이스)도 고위험과 동형으로 에디터 유도.
- `hypothesis-gate-badge.tsx` — 인라인 반려 확認 버튼도 사유 필수.

## PO 리뷰 2건 반영(head f2db19ff4 → 44863f3ac)

**① 회귀(필수) — 챗 결재카드 세 번째 표면 누락**: `approval-request-card.tsx:751`(저위험
`needsFullFlow=false` 분기)도 `onReject()`를 사유 없이 즉시 호출하고 있었다(357행 서명 플로우만
보고 이 분기를 놓침). gates/[id]/page.tsx·approvals-queue.tsx와 동형 처방 — 클릭은 이제
GateSignatureApproval 패널을 열 뿐, 테스트로 "즉시 POST 0 → 사유 입력 後 POST 1" 고정.

**② 근본(서버 강제 위치) — service 층으로 이동**: 422를 `transition_gate_endpoint`(router)에만
걸어 `transition_gate()`를 직접 부르는 경로가 우회됐다. `void_gate` 관례(reason 없으면
ValueError→라우터가 422로 재포장)대로 서비스층(`gate_service.py::transition_gate()`)으로 옮기고
router의 중복 체크는 제거. `"rejected"`로 backend 전수 grep한 `transition_gate(...)` 호출부 판정:

| 호출부 | 판정 |
|---|---|
| `routers/gates.py`(HTTP `/transition`) | 사용자 note 그대로 — 위 FE 5+1표면이 게이팅 |
| `routers/workflow_line_config.py::reject_publish` | **수정** — `except ValueError: pass`("이미 해소됨"용)가 신규 ValueError까지 조용히 삼켜 gate가 영원히 pending으로 남을 뻔함. `RejectPublishRequest.reason` 필수 필드 추가(Pydantic 검증) |
| `services/workflow_parallel_approval.py::record_parallel_decision`(quorum any-reject) | **수정** — 아직 HTTP 엔드포인트 미배선(자기 테스트만 호출, 실서비스 무영향)이지만 배선되면 바로 깨질 자리라 `note` 파라미터 추가 + row의 기존 미사용 컬럼 `decision_note`에도 기록 |
| `services/gate_service.py` force-resolve | 이미 `note=reason` 전달 중(기존) — 무영향 |
| `workflow_sla_processor.py`·`workflow_line_config.py::approve_publish`·`loop.py` | approved 전용 — 해당 없음 |


## 카디르 QA 적출 2건 반영(head 44863f3ac → 520a19c6b)

QA가 destructive-schema 2샤드에서 잡음 — `test_a2a_sa5_auth_required_realdb.py`·
`test_h1_fix2_approve_advances_done.py`가 `transition_gate(..., "rejected")`를 router가
아니라 **서비스 함수를 직접** 호출(그래서 이전 CI엔 안 걸렸다가, 이번 서비스층 이전으로
걸림). PO 지시대로 "rejected" 문자열 grep이 아니라 **`transition_gate(` 호출부 전수**(tests
포함)로 다시 표를 만들었다:

| 파일:라인 | 판정 |
|---|---|
| `app/routers/gates.py`(HTTP) | 사용자 note — FE 6표면이 게이팅(위 표) |
| `app/routers/workflow_line_config.py::reject_publish` | reason 필수 바디(위 fix) |
| `app/services/workflow_parallel_approval.py::record_parallel_decision` | note 파라미터 추가(위 fix, 미배선) |
| `app/services/gate_service.py` force-resolve(~1908행) | 기존 `note=reason` — 무영향 |
| `tests/test_2027_gate_approval_reason_enforce.py` | 이미 note 포함 — 무영향 |
| `tests/test_2857_hypothesis_outcome_confirm_realdb.py` | 이미 note="근거 부족" — 무영향 |
| `tests/test_e_verify_v0_s2_evidence_signal_realdb.py` | 이미 note="no" — 무영향 |
| `tests/test_edg_s9_parallel_quorum.py` | **수정** — note 추가(위 커밋) |
| `tests/test_a2a_sa5_auth_required_realdb.py` | **수정**(QA 적출) — A2ATask 상태동기화 테스트, 프로덕션 우회 아님 확인 후 note 추가 |
| `tests/test_h1_fix2_approve_advances_done.py` | **수정**(QA 적출) — story.status 미전진 양성대조, 프로덕션 우회 아님 확인 후 note 추가 |
| `tests/test_183fe7a5_gate_service_wiring.py` | **수정**(재감사 중 추가 발견) — escalation 동기화 훅 테스트, note 추가 |
| `tests/test_e_cage_referee_p3_gate_object.py::test_transition_rejected_empty_note_graceful` | **수정**(재감사 중 추가 발견) — 이 테스트 자체가 "사유 없어도 통과" 낡은 계약을 pin하고 있었다. ValueError 기대로 뒤집어 새 계약을 계속 지킴 |
| `app/services/workflow_sla_processor.py`·`workflow_line_config.py::approve_publish`·`services/loop.py`·나머지 gate/transition 테스트 전부 | approved 전용 또는 이미 note 포함 — 해당 없음 |

a2a.py 프로덕션 코드 자체엔 `transition_gate(` 호출이 없음(주석 인용 1건뿐) — 두 QA 적출
모두 테스트가 서비스 함수를 직접 부르는 자리였지 실 우회 경로는 아니었음을 확인.

로컬 재검증: 위 표의 수정 4파일 + story #3334/#2027/#3330 관련 destructive_schema 8파일
(78 테스트) 전부 green. non-destructive 전체 스위트는 로컬 alembic 마이그 DB가 없어 재현
못 함(CI가 그 축의 최종 판정자).
## Test plan
- [x] 신규 백엔드 realdb 3건: 저위험(gate_type=merge, permissive) 조합에서 사유 없으면 422+뮤테이션 0(#2027의 "저위험은 과도강제 금지"와 정반대임을 대조 실증) · 사유 있으면 200+resolution_note 저장 · gate_type=doc_approval도 동형 422(gate_type 무관 확認)
- [x] 뮤테이션 셀프체크 — 가드 되돌리면 두 positive 테스트가 실제로 red로 떨어짐을 확인 후 복원
- [x] FE 회귀 스위트(approvals-queue 62건·doc-gate-section·doc-status-rail·gates/[id] page·chat-bubble) 전부 로컬 green(233건) — 낡은 계약 3건은 새 다이얼로그 흐름으로 갱신
- [x] `tsc --noEmit` clean
- [x] `eslint` clean(터치 파일 전부)
- [ ] 카디르군 QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfPLRWqGNvcf58NWYrYKba

