### PR TITLE
[SID:3341] org 게이트 정책 BFF+설정 UI 신설 — posture·머지 게이트 기본 승인자

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3904,6 +3904,23 @@
     "reverted": "Reverted to org default.",
     "noProjectForOrgEdit": "At least one project is required to set organization defaults."
   },
+  "orgGatePolicy": {
+    "title": "Approval Posture & Default Approver",
+    "description": "Set the organization-wide gate judgment posture, and the default approver used when a merge gate has none assigned.",
+    "postureLabel": "Posture",
+    "postureConservative": "Conservative",
+    "postureBalanced": "Balanced",
+    "posturePermissive": "Permissive",
+    "approverLabel": "Merge Gate Default Approver",
+    "approverUnset": "Unset (current)",
+    "approverPickPlaceholder": "Select an approver",
+    "approverLoading": "Loading…",
+    "save": "Save",
+    "saving": "Saving…",
+    "saved": "Saved.",
+    "saveFailed": "Failed to save.",
+    "loadFailed": "Failed to load policy."
+  },
   "githubLinks": {
     "sectionLabel": "PR links",
     "loading": "Loading…",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3904,6 +3904,23 @@
     "reverted": "조직 기본값으로 되돌렸습니다.",
     "noProjectForOrgEdit": "조직 기본값을 설정하려면 프로젝트가 하나 이상 필요합니다."
   },
+  "orgGatePolicy": {
+    "title": "결재 태세 및 기본 승인자",
+    "description": "조직 전체의 게이트 판정 태세와, 머지 게이트에 승인자가 지정되지 않았을 때 쓰일 기본 승인자를 설정합니다.",
+    "postureLabel": "결재 태세",
+    "postureConservative": "보수적",
+    "postureBalanced": "균형",
+    "posturePermissive": "관대",
+    "approverLabel": "머지 게이트 기본 승인자",
+    "approverUnset": "미지정 (현행)",
+    "approverPickPlaceholder": "승인자를 선택하세요",
+    "approverLoading": "불러오는 중…",
+    "save": "저장",
+    "saving": "저장 중…",
+    "saved": "저장됐습니다.",
+    "saveFailed": "저장에 실패했습니다.",
+    "loadFailed": "정책을 불러오지 못했습니다."
+  },
   "githubLinks": {
     "sectionLabel": "PR 연결",
     "loading": "불러오는 중…",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -25,6 +25,7 @@ import { ThemeSettings } from '@/components/settings/theme-settings';
 import { RefreshSettings } from '@/components/settings/refresh-settings';
 import { StandupDeadlineSection } from '@/components/settings/standup-deadline-section';
 import { GateLevelMatrix } from '@/components/settings/gate-level-matrix';
+import { OrgGatePolicySection } from '@/components/settings/org-gate-policy-section';
 import { TwoFactorSection } from '@/components/settings/two-factor-section';
 import { SetPasswordSection } from '@/components/settings/set-password-section';
 import { LinkedAccountsSection } from '@/components/settings/linked-accounts-section';
@@ -1082,6 +1083,14 @@ export default function SettingsPage() {
                     orgId={orgInfo.id}
                     canEdit={currentOrgRole === 'owner' || currentOrgRole === 'admin'}
                   />
+                </div>
+              ) : null}
+              {/* story e0c1b24c — org 게이트 정책(posture·머지 게이트 기본 승인자). #3319/PR#3716로
+                  백엔드(GET/PUT /api/v2/gate-config/policy)는 착지했으나 값 넣을 화면이 없었다 —
+                  GateLevelMatrix(work_type×actor_type 매트릭스, 별개 개념)와 나란히 둔다. */}
+              {orgInfo ? (
+                <div className="mt-6">
+                  <OrgGatePolicySection canEdit={currentOrgRole === 'owner' || currentOrgRole === 'admin'} />
                 </div>
               ) : null}
               {currentOrgRole === 'owner' && (

--- a/apps/web/src/app/api/gate-config/policy/route.test.ts
+++ b/apps/web/src/app/api/gate-config/policy/route.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { proxyToFastapiWrapped } = vi.hoisted(() => ({ proxyToFastapiWrapped: vi.fn() }));
+
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWrapped }));
+
+import { GET, PUT } from './route';
+
+function fastapiOk(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('/api/gate-config/policy', () => {
+  it('GET — FastAPI GET /api/v2/gate-config/policy로 위임(파라미터 없음)', async () => {
+    proxyToFastapiWrapped.mockResolvedValue(fastapiOk({ data: null, error: null, meta: null }));
+    const request = new Request('http://test/api/gate-config/policy');
+
+    const resp = await GET(request);
+
+    expect(proxyToFastapiWrapped).toHaveBeenCalledWith(request, '/api/v2/gate-config/policy');
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toEqual({ data: null, error: null, meta: null });
+  });
+
+  it('GET — 정책 미설정 시 data:null을 그대로 통과(지어내지 않음)', async () => {
+    proxyToFastapiWrapped.mockResolvedValue(fastapiOk({ data: null, error: null, meta: null }));
+    const resp = await GET(new Request('http://test/api/gate-config/policy'));
+    await expect(resp.json()).resolves.toEqual({ data: null, error: null, meta: null });
+  });
+
+  it('PUT — FastAPI PUT /api/v2/gate-config/policy로 위임', async () => {
+    proxyToFastapiWrapped.mockResolvedValue(
+      fastapiOk({
+        data: {
+          id: 'policy-1', org_id: 'org-1', posture: 'balanced',
+          merge_gate_default_approver_member_id: 'member-1',
+          created_at: '2026-09-02T00:00:00Z', updated_at: '2026-09-02T00:00:00Z',
+        },
+        error: null, meta: null,
+      }),
+    );
+    const request = new Request('http://test/api/gate-config/policy', {
+      method: 'PUT',
+      body: JSON.stringify({ posture: 'balanced', merge_gate_default_approver_member_id: 'member-1' }),
+    });
+
+    const resp = await PUT(request);
+
+    expect(proxyToFastapiWrapped).toHaveBeenCalledWith(request, '/api/v2/gate-config/policy');
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.data.posture).toBe('balanced');
+  });
+
+  it('PUT — 422(에이전트 멤버 지정 등)는 그대로 pass-through', async () => {
+    proxyToFastapiWrapped.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: 'merge_gate_default_approver_member_id는 이 조직의 human owner/admin 멤버여야 합니다(에이전트는 requires_human 게이트에 서명할 수 없습니다).',
+        }),
+        { status: 422, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const resp = await PUT(new Request('http://test/api/gate-config/policy', { method: 'PUT', body: '{}' }));
+    expect(resp.status).toBe(422);
+    const body = await resp.json();
+    expect(body.detail).toContain('human owner/admin');
+  });
+
+  it('PUT — 403(org admin/owner 아님)은 그대로 pass-through', async () => {
+    proxyToFastapiWrapped.mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'org admin/owner required' }), {
+        status: 403, headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const resp = await PUT(new Request('http://test/api/gate-config/policy', { method: 'PUT', body: '{}' }));
+    expect(resp.status).toBe(403);
+  });
+});

--- a/apps/web/src/app/api/gate-config/policy/route.ts
+++ b/apps/web/src/app/api/gate-config/policy/route.ts
@@ -1,0 +1,13 @@
+import { proxyToFastapiWrapped } from '@/lib/fastapi-proxy';
+
+// story e0c1b24c — org 게이트 정책(posture·merge_gate_default_approver_member_id) BFF.
+// 백엔드 GET/PUT /api/v2/gate-config/policy(backend/app/routers/hitl_config.py)는 org를
+// 헤더(X-Org-Id)/JWT로 해소하므로 동적 [id] 파라미터가 없다(gates/route.ts와 동형, org
+// 하위 [id]/gate-config와는 다름). GET은 정책 미설정 시 null을 그대로 반환(지어내지 않음).
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapiWrapped(request, '/api/v2/gate-config/policy');
+}
+
+export async function PUT(request: Request): Promise<Response> {
+  return proxyToFastapiWrapped(request, '/api/v2/gate-config/policy');
+}

--- a/apps/web/src/components/settings/org-gate-policy-section.test.tsx
+++ b/apps/web/src/components/settings/org-gate-policy-section.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+//
+// story e0c1b24c — org 게이트 정책(posture·merge_gate_default_approver_member_id) 설정 UI.
+// two-factor-section.test.tsx와 동형 harness(NextIntlClientProvider+createRoot+jsdom,
+// global fetch stub — fetchWithAuth는 내부에서 fetch를 그대로 위임하므로 이 방식으로 충분).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { OrgGatePolicySection } from './org-gate-policy-section';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+const ELIGIBLE_APPROVERS = {
+  data: [
+    { id: 'member-1', user_id: 'u1', name: '송윤재', email: 'iamyoonjae@moonklabs.com', role: 'owner' },
+    { id: 'member-2', user_id: 'u2', name: '페드루', email: 'pedro@moonklabs.com', role: 'admin' },
+  ],
+};
+
+function stubFetch(policyData: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/gate-config/policy' && (!init || init.method === undefined)) {
+        return { ok: true, status: 200, json: async () => ({ data: policyData, error: null, meta: null }) };
+      }
+      if (url === '/api/org-members/eligible-approvers') {
+        return { ok: true, status: 200, json: async () => ELIGIBLE_APPROVERS };
+      }
+      throw new Error('unexpected fetch: ' + url + ' ' + (init?.method ?? 'GET'));
+    }),
+  );
+}
+
+describe('OrgGatePolicySection — 조회(story e0c1b24c)', () => {
+  it('정책 미설정(null) — posture는 기본값 balanced·승인자는 미지정으로 표시(읽기전용)', async () => {
+    stubFetch(null);
+    await act(async () => {
+      root.render(wrap(<OrgGatePolicySection canEdit={false} />));
+    });
+    await flush();
+
+    expect(container.textContent).toContain(koMessages.orgGatePolicy.postureBalanced);
+    expect(container.textContent).toContain(koMessages.orgGatePolicy.approverUnset);
+    expect(container.querySelectorAll('button').length).toBe(0);
+  });
+
+  it('정책 설정됨 — posture·승인자 표시이름(이메일 병기)이 정확히 반영된다', async () => {
+    stubFetch({
+      id: 'p1', org_id: 'o1', posture: 'conservative',
+      merge_gate_default_approver_member_id: 'member-1',
+      created_at: '2026-09-02T00:00:00Z', updated_at: '2026-09-02T00:00:00Z',
+    });
+    await act(async () => {
+      root.render(wrap(<OrgGatePolicySection canEdit={false} />));
+    });
+    await flush();
+
+    expect(container.textContent).toContain(koMessages.orgGatePolicy.postureConservative);
+    expect(container.textContent).toContain('송윤재 (iamyoonjae@moonklabs.com)');
+  });
+
+  it('canEdit=true — 승인자 드롭다운 트리거가 현재 지정된 승인자 표시이름을 초기값으로 보여준다', async () => {
+    stubFetch({
+      id: 'p1', org_id: 'o1', posture: 'balanced',
+      merge_gate_default_approver_member_id: 'member-2',
+      created_at: '2026-09-02T00:00:00Z', updated_at: '2026-09-02T00:00:00Z',
+    });
+    await act(async () => {
+      root.render(wrap(<OrgGatePolicySection canEdit />));
+    });
+    await flush();
+
+    const triggerBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('페드루'),
+    );
+    expect(triggerBtn).toBeDefined();
+  });
+});
+
+describe('OrgGatePolicySection — 저장(story e0c1b24c)', () => {
+  it('⭐posture 버튼 클릭 → 저장 → PUT body가 새 posture를 정확히 싣는다', async () => {
+    stubFetch(null);
+    let putBody: unknown;
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url === '/api/gate-config/policy' && init?.method === 'PUT') {
+          putBody = JSON.parse(String(init.body));
+          return { ok: true, status: 200, json: async () => ({ data: { posture: 'permissive' }, error: null, meta: null }) };
+        }
+        if (url === '/api/gate-config/policy') {
+          return { ok: true, status: 200, json: async () => ({ data: null, error: null, meta: null }) };
+        }
+        if (url === '/api/org-members/eligible-approvers') {
+          return { ok: true, status: 200, json: async () => ELIGIBLE_APPROVERS };
+        }
+        throw new Error('unexpected fetch: ' + url);
+      },
+    );
+    await act(async () => {
+      root.render(wrap(<OrgGatePolicySection canEdit />));
+    });
+    await flush();
+
+    const permissiveBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === koMessages.orgGatePolicy.posturePermissive,
+    );
+    expect(permissiveBtn).toBeDefined();
+    await act(async () => {
+      permissiveBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    const saveBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === koMessages.orgGatePolicy.save,
+    );
+    expect(saveBtn).toBeDefined();
+    await act(async () => {
+      saveBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    expect(putBody).toEqual({ posture: 'permissive', merge_gate_default_approver_member_id: null });
+    expect(container.textContent).toContain(koMessages.orgGatePolicy.saved);
+  });
+
+  it('⭐422(에이전트 멤버 지정 등) — 백엔드 detail 문구가 화면에 그대로 나온다(지어내지 않음)', async () => {
+    stubFetch(null);
+    const detailMsg =
+      'merge_gate_default_approver_member_id는 이 조직의 human owner/admin 멤버여야 합니다(에이전트는 requires_human 게이트에 서명할 수 없습니다).';
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url === '/api/gate-config/policy' && init?.method === 'PUT') {
+          return { ok: false, status: 422, json: async () => ({ detail: detailMsg }) };
+        }
+        if (url === '/api/gate-config/policy') {
+          return { ok: true, status: 200, json: async () => ({ data: null, error: null, meta: null }) };
+        }
+        if (url === '/api/org-members/eligible-approvers') {
+          return { ok: true, status: 200, json: async () => ELIGIBLE_APPROVERS };
+        }
+        throw new Error('unexpected fetch: ' + url);
+      },
+    );
+    await act(async () => {
+      root.render(wrap(<OrgGatePolicySection canEdit />));
+    });
+    await flush();
+
+    const saveBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === koMessages.orgGatePolicy.save,
+    );
+    await act(async () => {
+      saveBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    expect(container.textContent).toContain(detailMsg);
+  });
+});

--- a/apps/web/src/components/settings/org-gate-policy-section.tsx
+++ b/apps/web/src/components/settings/org-gate-policy-section.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { OperatorDropdownSelect, type SelectOption } from '@/components/ui/operator-dropdown-select';
+import { buildApproverPickerOptions } from '@/lib/approver-picker-options';
+import { fetchWithAuth } from '@/lib/db/client';
+import { cn } from '@/lib/utils';
+
+/**
+ * story e0c1b24c — org 게이트 정책(posture·merge_gate_default_approver_member_id) 설정
+ * UI. 백엔드(backend/app/routers/hitl_config.py GET/PUT /api/v2/gate-config/policy)는
+ * #3319/PR#3716로 이미 착지했으나, 이 값을 넣을 화면/BFF 경로가 0이었다 — 이 컴포넌트가
+ * 그 자리(BFF는 app/api/gate-config/policy/route.ts). GateLevelMatrix(S-GATE-4, work_type
+ * ×actor_type 매트릭스)와는 별개 개념(posture=전역 판정 태세·기본 승인자=merge 게이트
+ * 미지정 시 폴백)이라 별도 SectionCard로 둔다 — 같은 canEdit 규약(org owner/admin)만 공유.
+ *
+ * 승인자 픽커는 approval-request-card.tsx::DelegateApprovalControl과 동일 소스
+ * (/api/org-members/eligible-approvers + buildApproverPickerOptions + OperatorDropdownSelect,
+ * story #3040 v3 단일 소스 원칙 재사용 — 새 픽커 로직 발명 0).
+ */
+
+type Posture = 'conservative' | 'balanced' | 'permissive';
+const POSTURES: Posture[] = ['conservative', 'balanced', 'permissive'];
+const POSTURE_LABEL_KEY: Record<Posture, 'postureConservative' | 'postureBalanced' | 'posturePermissive'> = {
+  conservative: 'postureConservative',
+  balanced: 'postureBalanced',
+  permissive: 'posturePermissive',
+};
+
+interface OrgGatePolicyResponse {
+  id: string;
+  org_id: string;
+  posture: string;
+  merge_gate_default_approver_member_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface EligibleApprover {
+  id: string;
+  user_id: string | null;
+  name?: string | null;
+  email?: string | null;
+  role: 'owner' | 'admin' | 'member';
+}
+
+interface OrgGatePolicySectionProps {
+  canEdit: boolean;
+}
+
+export function OrgGatePolicySection({ canEdit }: OrgGatePolicySectionProps) {
+  const t = useTranslations('orgGatePolicy');
+  const [loading, setLoading] = useState(true);
+  const [posture, setPosture] = useState<Posture>('balanced');
+  const [approverId, setApproverId] = useState<string>(''); // '' = 미지정(현행)
+  const [approverOptions, setApproverOptions] = useState<SelectOption[]>([]);
+  const [loadingApprovers, setLoadingApprovers] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const res = await fetchWithAuth('/api/gate-config/policy');
+        if (cancelled) return;
+        if (res.ok) {
+          const json = (await res.json().catch(() => null)) as { data?: OrgGatePolicyResponse | null } | null;
+          const policy = json?.data;
+          if (policy) {
+            if ((POSTURES as string[]).includes(policy.posture)) setPosture(policy.posture as Posture);
+            setApproverId(policy.merge_gate_default_approver_member_id ?? '');
+          }
+        } else {
+          setMessage({ type: 'error', text: t('loadFailed') });
+        }
+      } catch {
+        if (!cancelled) setMessage({ type: 'error', text: t('loadFailed') });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    // canEdit 여부와 무관하게 조회한다 — 읽기전용 뷰에서도 지정된 승인자의 표시이름을
+    // 풀어야 한다(id만 보여주면 admin이 아닌 owner도 못 알아본다). eligible-approvers는
+    // org 멤버 누구나 호출 가능(관리자 전용 아님, backend/app/routers/org_members.py 실측).
+    let cancelled = false;
+    async function loadApprovers() {
+      setLoadingApprovers(true);
+      try {
+        const res = await fetchWithAuth('/api/org-members/eligible-approvers');
+        if (cancelled) return;
+        if (res.ok) {
+          const json = (await res.json().catch(() => null)) as { data?: EligibleApprover[] } | null;
+          const { options } = buildApproverPickerOptions(json?.data ?? []);
+          setApproverOptions(options);
+        }
+      } finally {
+        if (!cancelled) setLoadingApprovers(false);
+      }
+    }
+    void loadApprovers();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setMessage(null);
+    try {
+      const res = await fetchWithAuth('/api/gate-config/policy', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          posture,
+          merge_gate_default_approver_member_id: approverId || null,
+        }),
+      });
+      if (res.ok) {
+        setMessage({ type: 'success', text: t('saved') });
+      } else {
+        // story e0c1b24c AC — 에이전트 멤버 지정 시 422 문구가 화면에 그대로 나와야 한다
+        // (backend/app/routers/hitl_config.py의 human-only 검증 메시지, HTTPException.detail).
+        const body = (await res.json().catch(() => null)) as { detail?: string; error?: { message?: string } } | null;
+        setMessage({ type: 'error', text: body?.detail ?? body?.error?.message ?? t('saveFailed') });
+      }
+    } catch {
+      setMessage({ type: 'error', text: t('saveFailed') });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const approverSelectOptions: SelectOption[] = [{ value: '', label: t('approverUnset') }, ...approverOptions];
+  const currentApproverLabel = approverId
+    ? (approverOptions.find((o) => o.value === approverId)?.label ?? approverId)
+    : t('approverUnset');
+
+  return (
+    <SectionCard>
+      <SectionCardHeader>
+        <div className="space-y-1">
+          <h2 className="text-base font-semibold text-foreground">{t('title')}</h2>
+          <p className="text-sm text-muted-foreground">{t('description')}</p>
+        </div>
+      </SectionCardHeader>
+      <SectionCardBody className="space-y-4">
+        {message && (
+          <Alert
+            variant={message.type === 'success' ? 'success' : 'destructive'}
+            role={message.type === 'success' ? 'status' : 'alert'}
+            aria-live={message.type === 'success' ? 'polite' : 'assertive'}
+            aria-atomic="true"
+          >
+            <AlertDescription>{message.text}</AlertDescription>
+          </Alert>
+        )}
+
+        {loading ? (
+          <div className="space-y-2">
+            <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+            <div className="h-7 w-64 animate-pulse rounded bg-muted" />
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">{t('postureLabel')}</p>
+              {canEdit ? (
+                <div className="flex gap-1" role="group" aria-label={t('postureLabel')}>
+                  {POSTURES.map((p) => (
+                    <Button
+                      key={p}
+                      type="button"
+                      variant="glass"
+                      size="sm"
+                      disabled={saving}
+                      onClick={() => setPosture(p)}
+                      className={cn(
+                        'min-w-[80px]',
+                        posture === p
+                          ? 'border-primary bg-primary-tint text-foreground'
+                          : 'border-border text-muted-foreground hover:bg-muted/40',
+                      )}
+                    >
+                      {t(POSTURE_LABEL_KEY[p])}
+                    </Button>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">{t(POSTURE_LABEL_KEY[posture])}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">{t('approverLabel')}</p>
+              {canEdit ? (
+                <OperatorDropdownSelect
+                  value={approverId}
+                  onValueChange={setApproverId}
+                  options={approverSelectOptions}
+                  placeholder={loadingApprovers ? t('approverLoading') : t('approverPickPlaceholder')}
+                  disabled={loadingApprovers || saving}
+                />
+              ) : (
+                <p className="text-sm text-muted-foreground">{currentApproverLabel}</p>
+              )}
+            </div>
+
+            {canEdit ? (
+              <Button type="button" size="sm" onClick={() => void handleSave()} disabled={saving}>
+                {saving ? t('saving') : t('save')}
+              </Button>
+            ) : null}
+          </>
+        )}
+      </SectionCardBody>
+    </SectionCard>
+  );
+}


### PR DESCRIPTION
## Summary
story e0c1b24c. #3319(PR#3716)로 `OrgGatePolicy.merge_gate_default_approver_member_id`와 `PUT /api/v2/gate-config/policy`(사람 멤버만·422)가 dev에 착지했으나, 그 값을 넣을 화면/BFF 경로가 0이었다(레포 전수 grep: 백엔드 주석 1건뿐, 에이전트 키는 403 정상 설계). 사람 어드민도 브라우저/API로 값을 못 넣던 상태.

## 처방
1. **BFF** `apps/web/src/app/api/gate-config/policy/route.ts` — GET/PUT `proxyToFastapiWrapped('/api/v2/gate-config/policy')`(org는 헤더/JWT로 해소돼 `[id]` 파라미터 불요, `gates/route.ts`와 동형).
2. **설정 UI** `OrgGatePolicySection` — posture 3택 버튼그룹 + 머지 게이트 기본 승인자 드롭다운 + 저장. `GateLevelMatrix`(work_type×actor_type 매트릭스, 별개 개념) 바로 아래 조직 설정 탭에 배치, 같은 `canEdit`(org owner/admin) 규약 공유. 승인자 픽커는 `approval-request-card.tsx::DelegateApprovalControl`과 **동일 소스**(`eligible-approvers` + `buildApproverPickerOptions` + `OperatorDropdownSelect`, story #3040 v3 단일 소스 원칙 — 새 픽커 로직 발명 0).
3. 422 문구(에이전트 멤버 지정 시 human-only 검증 메시지)는 백엔드 `HTTPException.detail`을 그대로 노출(지어낸 일반 메시지로 덮지 않음).

## Test plan
- [x] BFF 라우트 테스트 5/5 pass(GET/PUT 위임·null 정책 통과·422/403 pass-through).
- [x] 컴포넌트 테스트 5/5 pass(미설정 읽기전용·설정된 값 표시(이름+이메일 병기)·canEdit 드롭다운 초기값·posture 변경+저장 PUT body 정확성·422 문구 화면 그대로).
- [x] **뮤테이션**: 422 detail 추출 로직 제거 → 그 pin 테스트만 정확히 RED → 원복 → 5/5 green.
- [x] 회귀: `components/settings/` + `app/api/gate-config/` 전체 53/53 pass.
- [x] `tsc --noEmit` 0 에러 · `eslint`(변경 파일 5종) 0 경고 · `pnpm --filter web build` 성공(`/api/gate-config/policy` 라우트 매니페스트 확認).
- [ ] 카디르군 라이브 픽셀 QA(모바일/데스크톱) — sellerking(어드민) 계정으로 실제 저장→머지 게이트 카드 `can_approve=false` 실측(#3319 AC 재확認 포함).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pN7nEKmenxEugBXV1oVQS