### PR TITLE
[SID:3345] 게이트 판정 사유가 승인(approved)엔 안 실리던 결함 정정

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1307,8 +1307,13 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
 
     lines.append(f"- 게이트: {gate_type} → {verdict}")
 
-    if verdict == "rejected" and resolution_note:
-        lines.append(f"- 반려 사유: {resolution_note}")
+    # story 1cd72bfc(2026-09-02, 담롱 4바퀴 승인 실측·PO 확定) — 이전엔 verdict=="rejected"
+    # 게이트가 있어 승인(approved) 판정에 사유가 있어도(예: "Ddddd") 원천 차단됐다.
+    # 에이전트 표면(MCP message.content)에서는 이 함수가 사유 노출의 전부다(사람 표면인
+    # block_template의 "사유" 필드는 별개 — chat-bubble.tsx event-block-card, 이 스토리
+    # 스코프 밖). 값 없으면 줄 자체를 생략(승인·반려 공통 — 지어내지 않는다).
+    if resolution_note:
+        lines.append(f"- 사유: {resolution_note}")
 
     draft_doc_ref: str | None = None
     if work_item_type and work_item_id is not None and gate_type:

--- a/backend/tests/test_3330_gate_verdict_notification.py
+++ b/backend/tests/test_3330_gate_verdict_notification.py
@@ -263,7 +263,9 @@ async def test_rejected_gate_reaches_work_item_assignee_with_reason_and_next_act
             content = await _latest_message_content_for(s, executor_id, org_id)
             assert content is not None, "executor에게 도달한 메시지가 없다(AC1 실패)"
             assert "- 게이트: external_publish → rejected" in content
-            assert "- 반려 사유: 어투가 너무 딱딱함 — 다시" in content
+            # story 1cd72bfc — 라벨을 verdict 무관 "사유"로 통일(이전 "반려 사유"는 approved에
+            # 사유가 있어도 원천 차단하던 게이트의 부산물이었다, 아래 테스트가 그 정정을 pin).
+            assert "- 사유: 어투가 너무 딱딱함 — 다시" in content
             assert f"[Threads 포스트 초안 v1](entity:doc:{doc_id})" in content
             assert "approve stage 이벤트를 다시 발행하세요" in content
     finally:
@@ -293,6 +295,37 @@ async def test_approved_gate_also_reaches_work_item_assignee():
             assert content is not None
             assert "- 게이트: external_publish → approved" in content
             assert "다음 stage 이벤트를 발행하세요" in content
+            # story 1cd72bfc AC(음성대조) — 사유 없이 승인하면 사유 줄 자체가 없다(지어내지 않음).
+            assert "- 사유:" not in content
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_approved_gate_with_note_shows_reason_line():
+    """⭐story 1cd72bfc — 담롱 4바퀴 승인 실측 재현: approved 판정에도 note가 있으면 사유
+    줄이 실행자에게 도달한 메시지에 실린다(이전엔 verdict=="rejected" 게이트가 승인 사유를
+    원천 차단했다 — 이게 그 실 결함의 재현+정정 pin)."""
+    from app.services.gate_service import transition_gate
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, owner_id = await _seed_org_with_owner(s, slug="e3330c")
+            await _seed_preset_gate_verdict_definition(s)
+            await _seed_system_publisher(s, org_id, project_id)
+            executor_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=executor_id)
+            gate = await _seed_gate(s, org_id, work_item_id=story_id)
+
+            await transition_gate(s, org_id, gate.id, "approved", resolver_id=owner_id, note="Ddddd")
+            await s.commit()
+
+            content = await _latest_message_content_for(s, executor_id, org_id)
+            assert content is not None
+            assert "- 게이트: external_publish → approved" in content
+            assert "- 사유: Ddddd" in content
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
## Summary
story 1cd72bfc. 담롱 4바퀴 승인 실측(2026-09-02 13:40Z) — 선생님 승인(resolution_note="Ddddd")이 실행자 방에 도달·payload에도 값이 실렸으나, message.content(에이전트가 MCP로 읽는 텍스트)엔 사유 줄이 없었다.

## 그라운딩 — 스토리 원 전제 정정
"block_template이 resolution_note를 참조 안 함"은 소스 확認 결과 부정확했다 — `preset.gate.verdict`의 block_template(0251부터)은 이미 "사유" 필드를 갖고 있다(사람이 보는 카드 표면). 실 결함은 `events.py::_render_gate_verdict_message`(#3330, 에이전트 표면 message.content의 전부)의 `if verdict == "rejected" and resolution_note` 게이트가 **승인 사유를 원천 차단**하던 것. PO 판정: 카드(사람 표면) 렌더 여부는 이 스토리 스코프 밖(유나 design이 실픽셀 별도 확認) — 이 PR은 에이전트 표면만.

## 처방
`verdict == "rejected"` 조건 제거 — resolution_note가 있으면 승인·반려 공통 "- 사유: {note}" 줄(값 없으면 생략). 라벨도 "반려 사유"→"사유"(block_template 필드 라벨과 통일). 마이그레이션 불요(순수 텍스트 렌더러).

## Test plan
- [x] 기존 테스트 라벨 갱신 + 신규 2건: approved+note→사유 줄(실사고 재현+정정) / approved 無note→줄 없음(음성대조). 5/5 pass.
- [x] **뮤테이션**: `verdict == "rejected"` 게이트 복원 → 신규 테스트만 정확히 RED → 원복 → 5/5 green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pN7nEKmenxEugBXV1oVQS