### PR TITLE
[SID:3349] 반복 스케줄 행 갱신을 같은 회차(work_item==last_story_id)로 가드

### DIFF
--- a/backend/app/services/recipe_repeat_schedule.py
+++ b/backend/app/services/recipe_repeat_schedule.py
@@ -166,6 +166,19 @@ async def maybe_upsert_repeat_schedule(
     )).scalar_one_or_none()
     if existing is None:
         return
+    # story #3349(실사고 2026-09-02 14:56Z) — 같은 정의를 다른 work item이 병렬로 발행하면
+    # (예: QA 테스트 스토리의 approve 발행) 이 유니크 키만으로는 "같은 회차"인지 구분이 안 돼
+    # last_story_id/snapshot이 그 work item으로 덮인다. 진행 中인 회차의 정체성은
+    # last_story_id로 이미 고정돼 있으므로, 이번 발행의 work_item이 그것과 다르면 무시한다
+    # (last_story_id가 아직 없는 스케줄엔 비교 축이 없으니 통과 — work_item_type != "story"로
+    # 생성된 케이스의 기존 동작 보존).
+    if existing.last_story_id is not None and existing.last_story_id != work_item_id:
+        logger.info(
+            "recipe_repeat_schedule: work_item=%s는 이 정의의 진행 中인 회차(last_story_id=%s)와 "
+            "다름 — 스냅샷/last_story_id 갱신 skip(정의=%s org=%s)",
+            work_item_id, existing.last_story_id, definition.key, org_id,
+        )
+        return
     snapshot = _snapshot_from_payload(payload)
     if snapshot:
         existing.last_payload_snapshot = {**existing.last_payload_snapshot, **snapshot}

--- a/backend/tests/test_3349_repeat_schedule_cycle_guard.py
+++ b/backend/tests/test_3349_repeat_schedule_cycle_guard.py
@@ -1,0 +1,272 @@
+"""story #3349(실사고 2026-09-02 14:56Z, 배포 4회차 직후 라이브) — 사이클형 레시피 정의를
+«다른 work item»이 병렬로 발행하면(예: QA 테스트 스토리의 approve 발행) recipe_repeat_schedules
+행이 (org, project, definition_key) 유니크 키만으로 그 work item을 "같은 회차"로 착각해
+last_story_id/snapshot을 덮어쓴다 — 다음 회차가 엉뚱한 스토리의 assignee·산출물을 승계한다.
+
+처방(페드루 확定, story 본문 그대로):
+1. 첫 stage 아닌 발행은 payload.work_item_id == schedule.last_story_id일 때만 스냅샷 갱신
+   (같은 회차). 다른 work item이면 무시(로그 1줄).
+2. 첫 stage 발행(repeat 포함)은 현행(새 회차 시작 = 덮어쓰기가 맞음) 유지.
+
+회귀 (a)(b)(c) — story 본문 그대로:
+(a) 병렬 work item의 중간 stage 발행 → 행 무변
+(b) 같은 회차 measure 발행 → snapshot 갱신
+(c) 새 회차 collect+repeat → last_story_id 교체
+
+seed 하네스는 test_3337_recipe_repeat_scheduler.py와 동일 패턴(파일별 로컬 중복이 이 스위트의
+기존 관례)."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+_REAL_DB_URL = __import__("os").getenv("PARITY_TEST_DATABASE_URL") or __import__("os").getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+_REAL_DB_SKIP = pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """test_3337와 동일 이유 — publish_preset_event()가 send_message()의 background task를
+    태우고, 그 task는 전역 엔진(app.core.database.async_session_factory)을 쓴다."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _realdb_session():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_owner(session, *, slug="e3349"):
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.team import TeamMember
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org3349", slug=slug)
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    owner_user = User(id=uuid.uuid4(), email=f"owner-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(owner_user)
+    await session.commit()
+    owner_member = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=owner_user.id, role="owner")
+    session.add(owner_member)
+    await session.commit()
+    session.add(TeamMember(
+        id=owner_member.id, org_id=org.id, project_id=project.id, type="human", name="owner", is_active=True,
+    ))
+    await session.commit()
+    return org.id, project.id, owner_member.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="executor"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+_CYCLIC_SCHEMA = {
+    "type": "object", "additionalProperties": False,
+    "required": ["work_item_type", "work_item_id", "stage"],
+    "properties": {
+        "work_item_type": {"type": "string"},
+        "work_item_id": {"type": "string", "format": "uuid"},
+        "stage": {"type": "string", "enum": ["collect", "measure"]},
+        "repeat": {"type": "string"},
+        "channel": {"type": "string"},
+        "previous_output_doc_id": {"type": "string"},
+    },
+}
+_STAGE_METADATA = {
+    "collect": {"role": "Collector", "action": "수집"},
+    "measure": {"role": "Measurer", "action": "측정"},
+}
+_NONE_ROUTING = {
+    "escalation": {"kind": "server_derived", "target": "none"},
+    "broadcast": {"kind": "server_derived", "target": "none"},
+}
+
+
+async def _seed_cyclic_definition(session, *, org_id, key="org.e3349.cyclic"):
+    from app.models.event_definition import EventDefinition
+
+    d = EventDefinition(
+        id=uuid.uuid4(), key=key, org_id=org_id, name="반복 테스트 정의",
+        payload_schema=_CYCLIC_SCHEMA, routing=_NONE_ROUTING, stage_metadata=_STAGE_METADATA,
+        enabled=True, version=1,
+    )
+    session.add(d)
+    await session.commit()
+    return d
+
+
+async def _seed_story(session, org_id, project_id, *, assignee_id=None, title="회차"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, assignee_id=assignee_id)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _publish_stage(session, *, org_id, story_id, definition_key, stage, requester_id, repeat=None, channel=None):
+    from app.dependencies.auth import AuthContext
+    from app.routers.events import _publish_registry_event_core
+    from fastapi import BackgroundTasks
+
+    payload = {"work_item_type": "story", "work_item_id": str(story_id), "stage": stage}
+    if repeat is not None:
+        payload["repeat"] = repeat
+    if channel is not None:
+        payload["channel"] = channel
+    auth = AuthContext(
+        user_id=str(requester_id), email=None,
+        claims={"app_metadata": {"api_key_id": "test-agent"}}, org_id=str(org_id),
+    )
+    return await _publish_registry_event_core(session, org_id, auth, definition_key, payload, BackgroundTasks())
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_a_parallel_work_item_mid_stage_publish_leaves_row_unchanged():
+    from app.models.recipe_repeat_schedule import RecipeRepeatSchedule
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner_id = await _seed_org_project_owner(s, slug="e3349a")
+            executor_id = await _seed_agent(s, org_id, project_id)
+            definition = await _seed_cyclic_definition(s, org_id=org_id)
+            story1_id = await _seed_story(s, org_id, project_id, assignee_id=executor_id, title="회차 1")
+            other_story_id = await _seed_story(s, org_id, project_id, title="QA 테스트 스토리")
+
+            await _publish_stage(
+                s, org_id=org_id, story_id=story1_id, definition_key=definition.key,
+                stage="collect", requester_id=executor_id, repeat="P7D", channel="slack:#launch",
+            )
+            await s.commit()
+
+            schedule = (await s.execute(
+                select(RecipeRepeatSchedule).where(RecipeRepeatSchedule.definition_key == definition.key)
+            )).scalar_one()
+            assert schedule.last_story_id == story1_id
+            snapshot_before = dict(schedule.last_payload_snapshot)
+
+            # 실사고 재현 — 무관한 다른 work item(QA 테스트 스토리)이 같은 정의의 non-first
+            # stage를 발행.
+            await _publish_stage(
+                s, org_id=org_id, story_id=other_story_id, definition_key=definition.key,
+                stage="measure", requester_id=executor_id, channel="slack:#qa-noise",
+            )
+            await s.commit()
+
+            await s.refresh(schedule)
+            assert schedule.last_story_id == story1_id, "다른 work item의 발행이 last_story_id를 덮었다(회귀)"
+            assert schedule.last_payload_snapshot == snapshot_before, "다른 work item의 발행이 snapshot을 덮었다(회귀)"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_b_same_cycle_measure_publish_updates_snapshot():
+    from app.models.recipe_repeat_schedule import RecipeRepeatSchedule
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner_id = await _seed_org_project_owner(s, slug="e3349b")
+            executor_id = await _seed_agent(s, org_id, project_id)
+            definition = await _seed_cyclic_definition(s, org_id=org_id)
+            story1_id = await _seed_story(s, org_id, project_id, assignee_id=executor_id, title="회차 1")
+
+            await _publish_stage(
+                s, org_id=org_id, story_id=story1_id, definition_key=definition.key,
+                stage="collect", requester_id=executor_id, repeat="P7D", channel="slack:#launch",
+            )
+            await s.commit()
+
+            # 같은 회차(story1)의 measure 발행 — snapshot이 최신 channel로 갱신돼야 한다.
+            await _publish_stage(
+                s, org_id=org_id, story_id=story1_id, definition_key=definition.key,
+                stage="measure", requester_id=executor_id, channel="slack:#measure-result",
+            )
+            await s.commit()
+
+            schedule = (await s.execute(
+                select(RecipeRepeatSchedule).where(RecipeRepeatSchedule.definition_key == definition.key)
+            )).scalar_one()
+            assert schedule.last_story_id == story1_id
+            assert schedule.last_payload_snapshot["channel"] == "slack:#measure-result", "같은 회차 재발행인데 snapshot이 최신화 안 됐다(회귀)"
+    finally:
+        await engine.dispose()
+
+
+@_REAL_DB_SKIP
+@pytest.mark.anyio
+async def test_c_new_cycle_collect_with_repeat_replaces_last_story_id():
+    from app.models.recipe_repeat_schedule import RecipeRepeatSchedule
+    from sqlalchemy import select
+
+    engine, Session = await _realdb_session()
+    try:
+        async with Session() as s:
+            org_id, project_id, _owner_id = await _seed_org_project_owner(s, slug="e3349c")
+            executor_id = await _seed_agent(s, org_id, project_id)
+            definition = await _seed_cyclic_definition(s, org_id=org_id)
+            story1_id = await _seed_story(s, org_id, project_id, assignee_id=executor_id, title="회차 1")
+            story2_id = await _seed_story(s, org_id, project_id, assignee_id=executor_id, title="회차 2")
+
+            await _publish_stage(
+                s, org_id=org_id, story_id=story1_id, definition_key=definition.key,
+                stage="collect", requester_id=executor_id, repeat="P7D",
+            )
+            await s.commit()
+
+            # 새 회차 — 다른 work item(story2)이 collect+repeat로 발행하면 이건 진짜 새 회차
+            # 시작이므로 last_story_id가 교체돼야 한다(guard가 이 경로를 막으면 안 됨).
+            await _publish_stage(
+                s, org_id=org_id, story_id=story2_id, definition_key=definition.key,
+                stage="collect", requester_id=executor_id, repeat="P7D",
+            )
+            await s.commit()
+
+            schedule = (await s.execute(
+                select(RecipeRepeatSchedule).where(RecipeRepeatSchedule.definition_key == definition.key)
+            )).scalar_one()
+            assert schedule.last_story_id == story2_id, "새 회차 collect+repeat 발행인데 last_story_id가 교체 안 됐다(guard 과잉적용)"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 배경 — 실사고(2026-09-02 14:56Z, 배포 4회차 직후 라이브)
- 14:56:04Z PO가 5바퀴 collect(repeat P7D·work_item #3347 df3f7a59) 발행 → 행 569b3576 생성(정상).
- 14:56:40Z 카디르가 QA 테스트 스토리(#3348 8858046b·미배정)로 같은 정의의 stage를 발행 → 행의 `last_story_id`가 8858046b로 덮임(«매 stage 발행마다 스냅샷 최신화» 훅이 work item을 구분하지 않음).
- 7일 뒤 tick이 "직전 회차 스토리"로 QA 스토리를 보고 assignee(없음)를 승계했을 것 — fleet이 customer-zero로 첫날에 밟은 케이스.

## 원인
`recipe_repeat_schedule.py::maybe_upsert_repeat_schedule` — 첫 stage 아닌 발행도 (org, project, definition_key) 유니크 키로 행을 찾아 무조건 last_story_id/snapshot 갱신 (다른 work_item인지 구분 안 함).

## 처방
non-first-stage(또는 repeat 없는 first-stage) 갱신 분기에 guard 추가: `payload.work_item_id == schedule.last_story_id`일 때만 스냅샷/last_story_id 갱신. 다른 work item이면 무시(로그 1줄). 새 회차 collect+repeat 발행(진짜 회차 교체) 분기는 기존 upsert 그대로 — guard 미적용.

## 테스트
`test_3349_repeat_schedule_cycle_guard.py` 신규, realdb 3건 (story 본문 회귀 (a)(b)(c) 그대로):
- (a) 병렬 work item의 중간 stage 발행 → 행 무변
- (b) 같은 회차 measure 발행 → snapshot 갱신
- (c) 새 회차 collect+repeat → last_story_id 교체

뮤테이션 자체검증: guard를 임시로 제거하고 재실행 → test_a가 실제로 fail함을 확認(가드가 실제로 잡는다는 증명) 후 원복.

기존 `test_3337_recipe_repeat_scheduler.py` 4건도 회귀 없음(로컬 realdb 7/7 pass).

## 오염 데이터
오늘 오염된 행 569b3576은 이 PR과 별개로 PO가 5호 스토리 id로 직접 정정 예정(마이그 없음, story 본문 AC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfPLRWqGNvcf58NWYrYKba