### PR TITLE
[SID:3354] 자체 조회수 카운터 — 공개 beacon + measure stage 조회 API

### DIFF
--- a/backend/alembic/versions/0306_pageview_counter.py
+++ b/backend/alembic/versions/0306_pageview_counter.py
@@ -1,0 +1,57 @@
+"""story #3354(마케팅자동화·측정, 페드루 PO 확定 2026-09-03) — 자체 조회수 카운터.
+GA4 속성을 우리 계정이 못 읽어(담롱·PO 실측 2026-09-03) 발행 재개 즉시 «유입→활성화» 첫
+열을 세려면 우리 서버가 직접 세는 수단이 필요하다.
+
+두 테이블:
+- org_metering_keys — 공개 글 페이지 beacon이 자신을 식별할 비밀 아닌 공개 키(랜딩 JS에
+  박힘, revoked_at으로만 재발급).
+- org_pageview_daily — (org_id, path, day) 일별 집계(standup.py의 (member, date) unique와
+  동형 골격).
+
+Revision ID: 0306
+Revises: 0305
+Create Date: 2026-09-03
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0306"
+down_revision = "0305"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "org_metering_keys",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("public_key", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("public_key", name="uq_org_metering_keys_public_key"),
+    )
+    op.create_index("ix_org_metering_keys_org_id", "org_metering_keys", ["org_id"])
+
+    op.create_table(
+        "org_pageview_daily",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("path", sa.Text(), nullable=False),
+        sa.Column("day", sa.Date(), nullable=False),
+        sa.Column("count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.UniqueConstraint("org_id", "path", "day", name="uq_org_pageview_daily_org_path_day"),
+    )
+    op.create_index("ix_org_pageview_daily_org_path", "org_pageview_daily", ["org_id", "path"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_org_pageview_daily_org_path", table_name="org_pageview_daily")
+    op.drop_table("org_pageview_daily")
+    op.drop_index("ix_org_metering_keys_org_id", table_name="org_metering_keys")
+    op.drop_table("org_metering_keys")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -218,7 +218,7 @@ async def lifespan(app: FastAPI):
             await worker_engine.dispose()
 
 
-from app.routers import a2a, account, activation, activity_logs, admin_billing, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, billing_keys, toss_webhooks, org_subscription_checkout, billing_packs, context_pack, connectors, deeplink_manifest, domain_labels, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, legal, loop_measure_due, loops, mcp, me, meetings, members, merge_gate, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, platform_settings, policy_documents, project_access, project_settings, projects, public_docs, recipe_repeat_schedules, reference_candidates, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, session_context, sprints, standups, stories, subscription, support_gateway_token, tasks, team_members, team_presence, trust_scores, usage, user_blocks, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_report, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activation, activity_logs, admin_billing, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, billing_keys, toss_webhooks, org_subscription_checkout, billing_packs, context_pack, connectors, deeplink_manifest, domain_labels, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, legal, loop_measure_due, loops, mcp, me, meetings, members, merge_gate, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, pageview_metering, participation, plan_features, platform_settings, policy_documents, project_access, project_settings, projects, public_docs, public_pageview, recipe_repeat_schedules, reference_candidates, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, session_context, sprints, standups, stories, subscription, support_gateway_token, tasks, team_members, team_presence, trust_scores, usage, user_blocks, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_report, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 # 도메인 축 B(org-1st-class-surface-ia-design-b §3): OpenAPI 태그 조직-우선 위계.
 # 개별 라우터는 기존 세부 tag(예 "stories")를 그대로 유지하고 이 4축 태그를 추가로 보유(다중
@@ -348,6 +348,13 @@ app.add_middleware(
     ],
 )
 
+# story #3354(마케팅자동화·측정) — 공개 beacon 라우트 하나만 CORS 완전 개방(app 전체
+# allowlist는 안 건드림). 전역 CORSMiddleware보다 나중에 add_middleware해 바깥쪽(요청을
+# 먼저 가로챔)에 둬야 preflight OPTIONS가 전역 allowlist 판정에 안 걸린다.
+from app.routers.public_pageview import PublicPageviewCorsMiddleware  # noqa: E402
+
+app.add_middleware(PublicPageviewCorsMiddleware)
+
 # story #3173(결제②-B) — AU(automation_units) 계측. app/dependencies/auth.py의
 # get_current_user()가 request.state.au_actor/au_org_id를 심어두면 여기서 응답 완료 후
 # 읽어 usage_meters에 쌓는다. 전체 fail-open(계측 예외가 요청에 영향 0) — 모듈 docstring 참고.
@@ -399,6 +406,7 @@ app.include_router(workflow_line_config.router)
 app.include_router(tasks.router)
 app.include_router(docs.router)
 app.include_router(public_docs.router)
+app.include_router(public_pageview.router)
 app.include_router(meetings.router)
 app.include_router(stories.router)
 app.include_router(projects.router)
@@ -433,6 +441,7 @@ app.include_router(runtime_capabilities.router)
 app.include_router(members.router)
 app.include_router(merge_gate.router)
 app.include_router(organizations.router)
+app.include_router(pageview_metering.router)
 app.include_router(resolve.router)
 app.include_router(org_invites.router)
 app.include_router(invite_accept.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -129,6 +129,8 @@ from app.models.chain_circuit_breaker import ChainCircuitBreaker
 from app.models.event_definition import EventDefinition
 from app.models.recipe_role_binding import RecipeRoleBinding
 from app.models.recipe_repeat_schedule import RecipeRepeatSchedule
+from app.models.org_metering_key import OrgMeteringKey
+from app.models.org_pageview_daily import OrgPageviewDaily
 
 __all__ = [
     "RoleTemplate",

--- a/backend/app/models/org_metering_key.py
+++ b/backend/app/models/org_metering_key.py
@@ -1,0 +1,33 @@
+"""story #3354(마케팅자동화·측정, 페드루 PO 확定 2026-09-03) — org 조회수 beacon용 공개
+식별자. GA4 속성을 우리 계정이 못 읽어(담롱·PO 실측) 자사 서버가 직접 세는 수단이 필요하다.
+
+이 키는 **비밀이 아니다** — 랜딩 JS(정적 페이지 소스)에 그대로 박히는 공개 식별자다(PO
+확定, Q1 답변). 그래서 시크릿처럼 hash해 저장하지 않고 평문으로 둔다 — value가 새도 할 수
+있는 일은 그 org 앞으로 pageview count를 늘리는 것뿐(쓰기 폭이 애초에 낮다). revoked_at으로
+재발급(rotate)만 지원 — 옛 값은 즉시 무효화되고 새 값이 그 자리를 대신한다(행은 이력으로
+남김, 물리삭제 안 함)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class OrgMeteringKey(Base):
+    __tablename__ = "org_metering_keys"
+    __table_args__ = (
+        Index("ix_org_metering_keys_org_id", "org_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    public_key: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/org_pageview_daily.py
+++ b/backend/app/models/org_pageview_daily.py
@@ -1,0 +1,35 @@
+"""story #3354(마케팅자동화·측정, 페드루 PO 확定 2026-09-03) — 공개 글 페이지 조회수 일별
+집계. (org_id, path, day) 축으로 upsert(standup.py의 (member, date) unique와 동형 골격) —
+UA/IP/쿠키는 여기 안 온다(dedup은 순수 in-memory/redis 레이트리밋 키로만, 영속 저장 0 —
+개인정보 0 원칙, PO AC)."""
+from __future__ import annotations
+
+import uuid
+from datetime import date as date_type
+from datetime import datetime
+
+from sqlalchemy import Date, DateTime, Index, Integer, Text, UniqueConstraint, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class OrgPageviewDaily(Base):
+    __tablename__ = "org_pageview_daily"
+    __table_args__ = (
+        UniqueConstraint("org_id", "path", "day", name="uq_org_pageview_daily_org_path_day"),
+        Index("ix_org_pageview_daily_org_path", "org_id", "path"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    path: Mapped[str] = mapped_column(Text, nullable=False)
+    day: Mapped[date_type] = mapped_column(Date, nullable=False)
+    count: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/routers/pageview_metering.py
+++ b/backend/app/routers/pageview_metering.py
@@ -1,0 +1,76 @@
+"""story #3354(마케팅자동화·측정, 페드루 PO 확定 2026-09-03) — org 조회수 카운터 관리 API.
+
+GET  /api/v2/organizations/{org_id}/metering-key   — 활성 공개 키 조회(없으면 최초 발급, org 멤버 read).
+POST /api/v2/organizations/{org_id}/metering-key/rotate — 재발급(owner/admin write, connectors.py PUT config와 동형 권한 축).
+GET  /api/v2/organizations/{org_id}/pageviews       — measure stage/커넥터가 읽는 집계(org 멤버 read).
+
+설정 화면(키 노출 UI)은 story 4180f67f 후속 — 이번 PR은 API만(PO 확定 Q1 답변)."""
+from __future__ import annotations
+
+import uuid
+from datetime import date as date_type
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.services.pageview_counter import get_or_create_active_key, get_pageviews, rotate_key
+from app.services.project_auth import is_org_owner_or_admin
+
+router = APIRouter(prefix="/api/v2/organizations", tags=["pageview-metering"])
+
+
+class MeteringKeyResponse(BaseModel):
+    public_key: str
+
+
+class PageviewDayEntry(BaseModel):
+    path: str
+    day: date_type
+    count: int
+
+
+@router.get("/{org_id}/metering-key", response_model=MeteringKeyResponse)
+async def get_metering_key(
+    org_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> MeteringKeyResponse:
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    public_key = await get_or_create_active_key(db, org_id=org_id)
+    return MeteringKeyResponse(public_key=public_key)
+
+
+@router.post("/{org_id}/metering-key/rotate", response_model=MeteringKeyResponse)
+async def rotate_metering_key(
+    org_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> MeteringKeyResponse:
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    if not await is_org_owner_or_admin(db, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="org owner/admin required to rotate metering key")
+    public_key = await rotate_key(db, org_id=org_id)
+    return MeteringKeyResponse(public_key=public_key)
+
+
+@router.get("/{org_id}/pageviews", response_model=list[PageviewDayEntry])
+async def list_pageviews(
+    org_id: uuid.UUID,
+    path: str | None = Query(default=None),
+    date_from: date_type | None = Query(default=None, alias="from"),
+    date_to: date_type | None = Query(default=None, alias="to"),
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[PageviewDayEntry]:
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    rows = await get_pageviews(db, org_id=org_id, path=path, date_from=date_from, date_to=date_to)
+    return [PageviewDayEntry(path=r.path, day=r.day, count=r.count) for r in rows]

--- a/backend/app/routers/public_pageview.py
+++ b/backend/app/routers/public_pageview.py
@@ -1,0 +1,94 @@
+"""story #3354(마케팅자동화·측정, 페드루 PO 확定 2026-09-03) — 공개 글 페이지 beacon.
+
+**비인증** 라우트(public_docs.py와 동형 — 인증 Depends 의도적 생략). 개인정보 0(PO AC): UA는
+해시해 레이트리밋 키로만 쓰고 어디에도 영속 저장 안 함, IP·쿠키 저장 0. org 식별은 body의
+`public_key`(비밀 아닌 공개 식별자, org_metering_keys 참고) — 모르는 키는 침묵 204(존재
+유출 안 함, public_docs.py의 unknown→에러 노출과 달리 이쪽은 beacon이라 클라이언트가 응답을
+안 읽으므로 오히려 구분 없는 204가 더 안전한 선택).
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Request, Response
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.dependencies.database import get_db
+from app.services.pageview_counter import record_pageview, resolve_org_by_public_key
+from app.services.rate_limiter import get_rate_limiter
+
+router = APIRouter(prefix="/api/v2/public", tags=["public-pageview"])
+
+# 최소 봇 필터(처방 3항) — UA 문자열 규칙만, 정교한 탐지는 스코프 밖(PO 확定 "최소").
+_BOT_UA_RE = re.compile(r"bot|spider|crawl|slurp|headless", re.IGNORECASE)
+
+_DEDUP_WINDOW_LIMIT = 1  # 레이트리밋 윈도우(rate_limiter.WINDOW_SECS=60s)당 같은 (org,path,ua) 1회만 — AC "1분 내 재요청 억제"
+
+
+class PageviewBeaconRequest(BaseModel):
+    public_key: str = Field(..., min_length=1, max_length=128)
+    path: str = Field(..., min_length=1, max_length=512)
+    referrer: str | None = Field(default=None, max_length=1024)
+
+
+@router.post("/pageview", status_code=204)
+async def post_pageview(
+    body: PageviewBeaconRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    # referrer는 받되 저장하지 않는다 — 페이지 querystring에 개인식별 정보가 실릴 수 있어
+    # (개인정보 0 원칙) 집계 축(org, path, day)에 없는 차원은 지금 스코프에서 버린다(PO
+    # 처방 1항이 body 필드로만 나열했지, 영속 컬럼으로 못박지 않았다 — 향후 "유입경로별"
+    # 분석이 필요해지면 별도 스토리로 컬럼을 연다).
+    _ = body.referrer
+
+    org_id = await resolve_org_by_public_key(db, body.public_key)
+    if org_id is None:
+        return Response(status_code=204)
+
+    ua = request.headers.get("user-agent", "")
+    if not ua or _BOT_UA_RE.search(ua):
+        return Response(status_code=204)
+    ua_hash = hashlib.sha256(ua.encode()).hexdigest()
+
+    limiter = get_rate_limiter()
+    allowed, _remaining, _retry_after = await limiter.check(
+        f"pv:{org_id}:{body.path}:{ua_hash}", _DEDUP_WINDOW_LIMIT,
+    )
+    if not allowed:
+        return Response(status_code=204)  # 1분 내 같은 UA 재요청 — 중복으로 간주, 집계 안 늘림
+
+    today = datetime.now(timezone.utc).date()
+    await record_pageview(db, org_id=org_id, path=body.path, day=today)
+    return Response(status_code=204)
+
+
+_PUBLIC_PAGEVIEW_PATH = "/api/v2/public/pageview"
+
+
+class PublicPageviewCorsMiddleware(BaseHTTPMiddleware):
+    """beacon은 blog 정적 사이트(app 도메인과 다른 origin)에서 호출된다. 전역 CORSMiddleware
+    (main.py)의 allow_origins는 인증 API 표면 보호용 고정 allowlist라 이 경로만 완전 개방
+    (PO "CORS는 이 라우트만" 확定) — 쿠키 0·무인증이라 allow_credentials 없이 origin "*"과
+    궁합 문제 없음. main.py에서 전역 CORSMiddleware보다 나중에 add_middleware해 바깥쪽(요청
+    먼저 통과)에 두면, preflight OPTIONS를 전역 CORSMiddleware의 allowlist 판정 전에 여기서
+    가로챈다."""
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path != _PUBLIC_PAGEVIEW_PATH:
+            return await call_next(request)
+        if request.method == "OPTIONS":
+            return Response(status_code=204, headers={
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "POST, OPTIONS",
+                "Access-Control-Allow-Headers": "Content-Type",
+                "Access-Control-Max-Age": "86400",
+            })
+        response = await call_next(request)
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        return response

--- a/backend/app/services/pageview_counter.py
+++ b/backend/app/services/pageview_counter.py
@@ -1,0 +1,93 @@
+"""story #3354(마케팅자동화·측정, 페드루 PO 확定 2026-09-03) — 자체 조회수 카운터 서비스.
+
+org_metering_keys: 공개 키(비밀 아님, 랜딩 JS에 박힘) → org_id 해소.
+org_pageview_daily: (org_id, path, day) upsert 집계 — recipe_repeat_schedule.py의 pg_insert
+on_conflict_do_update 패턴 재사용(SKIP LOCKED 배치와 별개 축, 여기선 동시 beacon 두 개가
+같은 (org, path, day) 행을 만들 때 원자적으로 count+1이 되게 하는 것만 목적)."""
+from __future__ import annotations
+
+import secrets
+import uuid
+from datetime import date as date_type
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.org_metering_key import OrgMeteringKey
+from app.models.org_pageview_daily import OrgPageviewDaily
+
+_KEY_BYTES = 32  # doc_share.py의 secrets.token_urlsafe(32)와 동일 관례
+
+
+def _generate_public_key() -> str:
+    return secrets.token_urlsafe(_KEY_BYTES)
+
+
+async def get_or_create_active_key(db: AsyncSession, *, org_id: uuid.UUID) -> str:
+    """현재 활성 키가 있으면 그대로, 없으면(최초 발급) 새로 만든다. GET(멤버 read)."""
+    existing = (await db.execute(
+        select(OrgMeteringKey).where(
+            OrgMeteringKey.org_id == org_id, OrgMeteringKey.revoked_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if existing is not None:
+        return existing.public_key
+
+    key = OrgMeteringKey(id=uuid.uuid4(), org_id=org_id, public_key=_generate_public_key())
+    db.add(key)
+    await db.commit()
+    return key.public_key
+
+
+async def rotate_key(db: AsyncSession, *, org_id: uuid.UUID) -> str:
+    """옛 활성 키를 즉시 무효화(revoked_at)하고 새 키를 발급한다(owner/admin write)."""
+    now = datetime.now(timezone.utc)
+    existing = (await db.execute(
+        select(OrgMeteringKey).where(
+            OrgMeteringKey.org_id == org_id, OrgMeteringKey.revoked_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if existing is not None:
+        existing.revoked_at = now
+
+    key = OrgMeteringKey(id=uuid.uuid4(), org_id=org_id, public_key=_generate_public_key())
+    db.add(key)
+    await db.commit()
+    return key.public_key
+
+
+async def resolve_org_by_public_key(db: AsyncSession, public_key: str) -> uuid.UUID | None:
+    row = (await db.execute(
+        select(OrgMeteringKey.org_id).where(
+            OrgMeteringKey.public_key == public_key, OrgMeteringKey.revoked_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    return row
+
+
+async def record_pageview(db: AsyncSession, *, org_id: uuid.UUID, path: str, day: date_type) -> None:
+    stmt = pg_insert(OrgPageviewDaily).values(
+        id=uuid.uuid4(), org_id=org_id, path=path, day=day, count=1,
+    )
+    stmt = stmt.on_conflict_do_update(
+        constraint="uq_org_pageview_daily_org_path_day",
+        set_={"count": OrgPageviewDaily.count + 1, "updated_at": datetime.now(timezone.utc)},
+    )
+    await db.execute(stmt)
+    await db.commit()
+
+
+async def get_pageviews(
+    db: AsyncSession, *, org_id: uuid.UUID, path: str | None, date_from: date_type | None, date_to: date_type | None,
+) -> list[OrgPageviewDaily]:
+    stmt = select(OrgPageviewDaily).where(OrgPageviewDaily.org_id == org_id)
+    if path is not None:
+        stmt = stmt.where(OrgPageviewDaily.path == path)
+    if date_from is not None:
+        stmt = stmt.where(OrgPageviewDaily.day >= date_from)
+    if date_to is not None:
+        stmt = stmt.where(OrgPageviewDaily.day <= date_to)
+    stmt = stmt.order_by(OrgPageviewDaily.day.asc())
+    return list((await db.execute(stmt)).scalars().all())

--- a/backend/tests/test_3354_pageview_counter.py
+++ b/backend/tests/test_3354_pageview_counter.py
@@ -1,0 +1,363 @@
+"""story #3354(마케팅자동화·측정, 페드루 PO 확定 2026-09-03) — 자체 조회수 카운터.
+
+GA4 속성을 우리 계정이 못 읽어(담롱·PO 실측) 자사 서버가 직접 세는 수단. AC 그대로:
+beacon 1회 → 집계 1 증가[관측]·GET 반영·같은 UA 1분 내 재요청 억제.
+
+seed 하네스는 test_139d2405_slug_infra_realdb.py 패턴(httpx ASGITransport+override_db_and_read
++claims에 org_id 직접 주입해 get_verified_org_id의 X-Org-Id membership DB 왕복을 우회)을
+따른다 — 공개 beacon 라우트는 인증 자체가 없어 이 패턴이 불필요, org-scoped 라우트에만 적용."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+
+    org = Organization(id=uuid.uuid4(), name="Pageview Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org.id
+
+
+async def _seed_owner(session, org_id):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"owner-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await session.commit()
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role="owner"))
+    await session.commit()
+    return user_id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id=None):
+    """org-scoped 라우트(GET/POST metering-key·pageviews)용 — public beacon엔 인증이 없어
+    이 오버라이드가 불필요(별도 client로 호출). user_id 미지정 시 owner/admin write가
+    필요한 엔드포인트(rotate)는 403 — read 전용 테스트는 그래도 무방(랜덤 user_id로 충분,
+    get_verified_org_id는 claims의 org_id로 membership DB 왕복 자체를 생략한다)."""
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _setup_public_app(app, Session):
+    """공개 beacon 라우트 — 인증 오버라이드 없이 get_db만."""
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+
+
+@pytest.mark.anyio
+async def test_metering_key_lazy_issue_is_idempotent():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+        _setup_org_scoped_app(app, Session, org_id)
+
+        async with _client_for(app) as client:
+            r1 = await client.get(f"/api/v2/organizations/{org_id}/metering-key")
+            r2 = await client.get(f"/api/v2/organizations/{org_id}/metering-key")
+        assert r1.status_code == 200, r1.text
+        assert r1.json()["public_key"] == r2.json()["public_key"]
+        assert len(r1.json()["public_key"]) > 20
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_rotate_invalidates_old_key():
+    from app.main import app
+    from app.services.pageview_counter import resolve_org_by_public_key
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_owner(s, org_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=owner_id)
+
+        async with _client_for(app) as client:
+            r1 = await client.get(f"/api/v2/organizations/{org_id}/metering-key")
+            old_key = r1.json()["public_key"]
+            r2 = await client.post(f"/api/v2/organizations/{org_id}/metering-key/rotate")
+            assert r2.status_code == 200, r2.text
+            new_key = r2.json()["public_key"]
+
+        assert new_key != old_key
+        async with Session() as s:
+            assert await resolve_org_by_public_key(s, old_key) is None, "회전된 옛 키가 여전히 org를 해소한다(회귀)"
+            assert await resolve_org_by_public_key(s, new_key) == org_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_rotate_requires_org_owner_or_admin():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+        _setup_org_scoped_app(app, Session, org_id)  # 랜덤 user_id — org 멤버조차 아님
+
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/metering-key/rotate")
+        assert r.status_code == 403, "owner/admin 아닌데 rotate가 허용됐다(권한 가드 회귀)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_beacon_once_increments_and_get_reflects():
+    from app.main import app
+    from app.services.pageview_counter import get_or_create_active_key
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            public_key = await get_or_create_active_key(s, org_id=org_id)
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as public_client:
+            r = await public_client.post(
+                "/api/v2/public/pageview",
+                json={"public_key": public_key, "path": "/ko/blog/hello-world"},
+                headers={"user-agent": "Mozilla/5.0 test-browser-A"},
+            )
+        assert r.status_code == 204
+
+        _setup_org_scoped_app(app, Session, org_id)
+        async with _client_for(app) as client:
+            r2 = await client.get(f"/api/v2/organizations/{org_id}/pageviews", params={"path": "/ko/blog/hello-world"})
+        rows = r2.json()
+        assert len(rows) == 1, rows
+        assert rows[0]["count"] == 1, "beacon 1회인데 집계가 1이 아니다(AC 실패)"
+        assert rows[0]["path"] == "/ko/blog/hello-world"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_ua_within_one_minute_is_suppressed():
+    from app.main import app
+    from app.services.pageview_counter import get_or_create_active_key
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            public_key = await get_or_create_active_key(s, org_id=org_id)
+
+        _setup_public_app(app, Session)
+        ua = {"user-agent": "Mozilla/5.0 test-browser-B"}
+        async with _client_for(app) as public_client:
+            r1 = await public_client.post(
+                "/api/v2/public/pageview", json={"public_key": public_key, "path": "/ko/blog/dup-test"}, headers=ua,
+            )
+            r2 = await public_client.post(
+                "/api/v2/public/pageview", json={"public_key": public_key, "path": "/ko/blog/dup-test"}, headers=ua,
+            )
+        assert r1.status_code == 204 and r2.status_code == 204
+
+        _setup_org_scoped_app(app, Session, org_id)
+        async with _client_for(app) as client:
+            r3 = await client.get(f"/api/v2/organizations/{org_id}/pageviews", params={"path": "/ko/blog/dup-test"})
+        rows = r3.json()
+        assert len(rows) == 1
+        assert rows[0]["count"] == 1, "같은 UA 1분 내 재요청인데 집계가 늘었다(AC 실패 — dedup 미작동)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_different_ua_each_counts_independently():
+    from app.main import app
+    from app.services.pageview_counter import get_or_create_active_key
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            public_key = await get_or_create_active_key(s, org_id=org_id)
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as public_client:
+            await public_client.post(
+                "/api/v2/public/pageview", json={"public_key": public_key, "path": "/ko/blog/multi-visitor"},
+                headers={"user-agent": "Mozilla/5.0 visitor-1"},
+            )
+            await public_client.post(
+                "/api/v2/public/pageview", json={"public_key": public_key, "path": "/ko/blog/multi-visitor"},
+                headers={"user-agent": "Mozilla/5.0 visitor-2"},
+            )
+
+        _setup_org_scoped_app(app, Session, org_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/pageviews", params={"path": "/ko/blog/multi-visitor"})
+        rows = r.json()
+        assert rows[0]["count"] == 2, "dedup이 UA별이 아니라 path 전체를 막았다(과잉적용 회귀)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unknown_public_key_is_silent_noop():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as public_client:
+            r = await public_client.post(
+                "/api/v2/public/pageview",
+                json={"public_key": "not-a-real-key", "path": "/ko/blog/hello-world"},
+                headers={"user-agent": "Mozilla/5.0 test-browser-C"},
+            )
+        assert r.status_code == 204, "모르는 public_key가 침묵 204가 아니라 에러/다른 코드를 냈다(존재 유출 위험)"
+
+        _setup_org_scoped_app(app, Session, org_id)
+        async with _client_for(app) as client:
+            r2 = await client.get(f"/api/v2/organizations/{org_id}/pageviews")
+        assert r2.json() == [], "모르는 키의 beacon이 실제로 어느 org에 집계됐다(회귀)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_bot_ua_is_filtered_out():
+    from app.main import app
+    from app.services.pageview_counter import get_or_create_active_key
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            public_key = await get_or_create_active_key(s, org_id=org_id)
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as public_client:
+            r = await public_client.post(
+                "/api/v2/public/pageview", json={"public_key": public_key, "path": "/ko/blog/bot-hit"},
+                headers={"user-agent": "Googlebot/2.1 (+http://www.google.com/bot.html)"},
+            )
+        assert r.status_code == 204
+
+        _setup_org_scoped_app(app, Session, org_id)
+        async with _client_for(app) as client:
+            r2 = await client.get(f"/api/v2/organizations/{org_id}/pageviews", params={"path": "/ko/blog/bot-hit"})
+        assert r2.json() == [], "봇 UA인데 집계가 잡혔다(최소 봇 필터 미작동)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_beacon_route_cors_preflight_open():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        _setup_public_app(app, Session)
+        async with _client_for(app) as client:
+            r = await client.options(
+                "/api/v2/public/pageview",
+                headers={"Origin": "https://sprintable.ai", "Access-Control-Request-Method": "POST"},
+            )
+        assert r.status_code == 204
+        assert r.headers.get("access-control-allow-origin") == "*", "beacon 라우트 preflight가 개방 CORS가 아니다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## 배경
sprintable.ai GA4(G-LKTVN5RVYY) 속성을 우리 계정이 읽을 수 없다(담롱·PO 실측 2026-09-03). 발행 재개 즉시 «유입→활성화» 첫 열을 세려면 우리 서버가 직접 세는 수단이 필요하다 — 다른 조직도 자기 사이트에 같은 beacon을 붙이면 measure stage가 그대로 돈다(제품 능력).

## 구현
- `POST /api/v2/public/pageview` — 무인증(public_docs.py 선례 그대로), body: `public_key`(org 공개 식별자)·`path`·`referrer?`. 모르는 키는 침묵 204(존재 유출 안 함). UA를 해시해 `rate_limiter.check()`의 raw key로 직접 재사용(WINDOW_SECS=60이 AC "1분 내 재요청 억제"와 이미 일치, limit=1) — 레이트리밋과 dedup을 같은 메커니즘으로 해결, 영속 저장은 0(쿠키·IP·UA 어디에도 안 남음). 최소 봇 필터(UA 문자열 규칙).
- `GET /api/v2/organizations/{org}/pageviews?path=&from=&to=` — org 멤버 read, (org_id, path, day) 일별 집계.
- `GET /api/v2/organizations/{org}/metering-key` — 활성 공개 키 조회(없으면 최초 발급, lazy).
- `POST /api/v2/organizations/{org}/metering-key/rotate` — 재발급(owner/admin write, connectors.py의 PUT config와 동형 권한 축 — `is_org_owner_or_admin` 재사용).
- CORS: `PublicPageviewCorsMiddleware` — beacon 라우트 하나만 완전 개방(전역 CORSMiddleware allowlist는 그대로).

## PO 그라운딩 답변 반영
- Q1(org public_key 저장 위치) → 새 최소 테이블 `org_metering_keys`(팀 결합 0). 설정 화면 노출은 story 4180f67f 후속.
- Q2(정의 v7 문구·커넥터 measure kind 노출) → 이번 PR 밖. PO가 직접 PATCH, 커넥터 kind는 미르코군 플러그인 쪽.

## 테스트
`test_3354_pageview_counter.py` 신규, realdb 10건 — AC 그대로:
- beacon 1회 → 집계 1 증가 · GET 반영
- 같은 UA 1분 내 재요청 억제(dedup) / 다른 UA는 독립 카운트
- 모르는 public_key → 침묵 204, 어느 org에도 안 잡힘
- 봇 UA(Googlebot 등) → 필터링
- metering-key lazy 발급 멱등 / rotate가 옛 키 무효화 / rotate는 owner·admin만
- beacon 라우트 CORS preflight 개방

뮤테이션 자체검증: dedup·봇필터·unknown-key guard를 각각 제거하고 재실행 → 해당 테스트가 실제로 fail함을 확認(가드가 실제로 잡는다는 증명) 후 원복.

기존 `test_3317_org_connector_registry.py` 회귀 없음(로컬 realdb 24/24 pass).

## PO 리뷰 메모(코드 변경 불요 — QA/미르코군 랜딩 참고)
1. 봇 필터 정규식에 `headless`가 있어 puppeteer 기본 UA(`HeadlessChrome`)는 집계 안 됨 — 카디르군 라이브 QA는 UA 헤더를 직접 지정한 curl로.
2. **beacon 계약은 「fetch + JSON body」**(`Content-Type: application/json`) — preflight는 `PublicPageviewCorsMiddleware`가 받는다. `navigator.sendBeacon`은 `Content-Type: text/plain`으로 고정돼 있어 이 계약과 안 맞고(pydantic이 JSON 파싱 실패로 422) 못 쓴다. 미르코군 랜딩 beacon 스크립트가 읽어야 할 계약.
3. dedup(1분 내 같은 UA 억제)이 **인스턴스 메모리 기준**(`InMemoryRateLimiter`, `REDIS`가 아닌 dev 기본 백엔드) — Cloud Run 다중 인스턴스 환경에서는 인스턴스마다 별도 윈도우라 새는(under-suppress) 방향으로만 어긋난다(과다-집계는 가능·과소-집계는 불가). "최소" 스코프로 수용(PO 확定) — Redis 백엔드(`RedisRateLimiter`, 이미 코드 존재)로 전환하면 인스턴스 간에도 정확해지지만 이번 스토리 스코프 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfPLRWqGNvcf58NWYrYKba
