### PR TITLE
[SID:3360] 자사 사이트 글을 Sprintable 백엔드에 저장 — 공개 site-posts API

### DIFF
--- a/backend/alembic/versions/0307_site_posts.py
+++ b/backend/alembic/versions/0307_site_posts.py
@@ -1,0 +1,53 @@
+"""story #3360(발행 구조·서버, 선생님 확定 2026-09-03 00:53Z·00:55Z) — 자사 사이트 글을
+Sprintable 백엔드에 저장(site_posts). 발행 = 승인 게이트(external_publish) 통과한 글 1행 —
+코드 저장소 커밋(#3352 site_git)은 «오늘 실물»용 지름길이었고 제품 구조가 아니다(선생님
+명시). unique(org_id, lang, slug) — 재발행은 같은 행 upsert.
+
+⚠️번호 의존성 — story #3354(PR#3728, `0306_pageview_counter.py`)의 `org_metering_keys`를
+공개 읽기 API의 «org 공개키»로 그대로 재사용한다(새 키 개념 발명 0, 페드루 확定). 그래서 이
+브랜치는 feat/3354-pageview-counter 위에서 시작했고, 0306은 이미 실존해 down_revision을
+바로 정확한 값으로 잡을 수 있었다(#3337/#3340류의 "임시 번호 뒤 rebase" 우회가 불필요 —
+#3728이 develop에 머지되면 이 브랜치를 그 위로 다시 rebase하는 것만으로 충돌 없이 이어진다).
+
+Revision ID: 0307
+Revises: 0306
+Create Date: 2026-09-03
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0307"
+down_revision = "0306"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "site_posts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("lang", sa.Text(), nullable=False),
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("tags", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default="[]"),
+        sa.Column("body_md", sa.Text(), nullable=False),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("source_story_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("gate_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_by_member_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("unpublished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.UniqueConstraint("org_id", "lang", "slug", name="uq_site_posts_org_lang_slug"),
+    )
+    op.create_index("ix_site_posts_org_id", "site_posts", ["org_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_site_posts_org_id", table_name="site_posts")
+    op.drop_table("site_posts")

--- a/backend/app/core/public_api_cors.py
+++ b/backend/app/core/public_api_cors.py
@@ -1,0 +1,48 @@
+"""공개(무인증) API 라우트 전용 CORS — 전역 CORSMiddleware(main.py)의 allow_origins는 인증
+API 표면 보호용 고정 allowlist라, 여기 등록된 공개 경로만 따로 완전 개방한다(쿠키 0·무인증
+라우트뿐이라 allow_credentials 없이 origin "*"과 궁합 문제 없음). main.py에서 전역
+CORSMiddleware보다 나중에 add_middleware해 바깥쪽(요청을 먼저 통과)에 둬야 preflight
+OPTIONS가 전역 allowlist 판정에 걸리기 전에 여기서 가로채진다.
+
+story #3354(PR#3728)가 `/pageview` 하나로 처음 만들었고, story #3360(페드루 확定 — "새
+미들웨어 신설 금지, #3728 미들웨어 경로에 추가")이 `/site-posts` 계열을 여기로 얹었다. 새
+공개 라우트가 CORS 개방이 필요하면 `_ROUTES`에 (path 판별, 허용 methods)만 추가."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+def _is_pageview(path: str) -> bool:
+    return path == "/api/v2/public/pageview"
+
+
+def _is_site_posts(path: str) -> bool:
+    return path == "/api/v2/public/site-posts" or path.startswith("/api/v2/public/site-posts/")
+
+
+_ROUTES: list[tuple[Callable[[str], bool], str]] = [
+    (_is_pageview, "POST, OPTIONS"),
+    (_is_site_posts, "GET, OPTIONS"),
+]
+
+
+class PublicApiCorsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+        allowed_methods = next((methods for matcher, methods in _ROUTES if matcher(path)), None)
+        if allowed_methods is None:
+            return await call_next(request)
+        if request.method == "OPTIONS":
+            return Response(status_code=204, headers={
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": allowed_methods,
+                "Access-Control-Allow-Headers": "Content-Type",
+                "Access-Control-Max-Age": "86400",
+            })
+        response = await call_next(request)
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        return response

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -218,7 +218,7 @@ async def lifespan(app: FastAPI):
             await worker_engine.dispose()
 
 
-from app.routers import a2a, account, activation, activity_logs, admin_billing, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, billing_keys, toss_webhooks, org_subscription_checkout, billing_packs, context_pack, connectors, deeplink_manifest, domain_labels, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, legal, loop_measure_due, loops, mcp, me, meetings, members, merge_gate, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, pageview_metering, participation, plan_features, platform_settings, policy_documents, project_access, project_settings, projects, public_docs, public_pageview, recipe_repeat_schedules, reference_candidates, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, session_context, sprints, standups, stories, subscription, support_gateway_token, tasks, team_members, team_presence, trust_scores, usage, user_blocks, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_report, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activation, activity_logs, admin_billing, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, billing_keys, toss_webhooks, org_subscription_checkout, billing_packs, context_pack, connectors, deeplink_manifest, domain_labels, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, judgments, labels, legal, loop_measure_due, loops, mcp, me, meetings, members, merge_gate, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, pageview_metering, participation, plan_features, platform_settings, policy_documents, project_access, project_settings, projects, public_docs, public_pageview, public_site_posts, recipe_repeat_schedules, reference_candidates, references, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, session_context, site_posts, sprints, standups, stories, subscription, support_gateway_token, tasks, team_members, team_presence, trust_scores, usage, user_blocks, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_report, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 # 도메인 축 B(org-1st-class-surface-ia-design-b §3): OpenAPI 태그 조직-우선 위계.
 # 개별 라우터는 기존 세부 tag(예 "stories")를 그대로 유지하고 이 4축 태그를 추가로 보유(다중
@@ -348,12 +348,12 @@ app.add_middleware(
     ],
 )
 
-# story #3354(마케팅자동화·측정) — 공개 beacon 라우트 하나만 CORS 완전 개방(app 전체
-# allowlist는 안 건드림). 전역 CORSMiddleware보다 나중에 add_middleware해 바깥쪽(요청을
-# 먼저 가로챔)에 둬야 preflight OPTIONS가 전역 allowlist 판정에 안 걸린다.
-from app.routers.public_pageview import PublicPageviewCorsMiddleware  # noqa: E402
+# story #3354(공개 beacon)·#3360(공개 site-posts) — 공개(무인증) 라우트만 CORS 완전 개방
+# (app 전체 allowlist는 안 건드림). 전역 CORSMiddleware보다 나중에 add_middleware해 바깥쪽
+# (요청을 먼저 가로챔)에 둬야 preflight OPTIONS가 전역 allowlist 판정에 안 걸린다.
+from app.core.public_api_cors import PublicApiCorsMiddleware  # noqa: E402
 
-app.add_middleware(PublicPageviewCorsMiddleware)
+app.add_middleware(PublicApiCorsMiddleware)
 
 # story #3173(결제②-B) — AU(automation_units) 계측. app/dependencies/auth.py의
 # get_current_user()가 request.state.au_actor/au_org_id를 심어두면 여기서 응답 완료 후
@@ -407,6 +407,7 @@ app.include_router(tasks.router)
 app.include_router(docs.router)
 app.include_router(public_docs.router)
 app.include_router(public_pageview.router)
+app.include_router(public_site_posts.router)
 app.include_router(meetings.router)
 app.include_router(stories.router)
 app.include_router(projects.router)
@@ -442,6 +443,7 @@ app.include_router(members.router)
 app.include_router(merge_gate.router)
 app.include_router(organizations.router)
 app.include_router(pageview_metering.router)
+app.include_router(site_posts.router)
 app.include_router(resolve.router)
 app.include_router(org_invites.router)
 app.include_router(invite_accept.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -131,6 +131,7 @@ from app.models.recipe_role_binding import RecipeRoleBinding
 from app.models.recipe_repeat_schedule import RecipeRepeatSchedule
 from app.models.org_metering_key import OrgMeteringKey
 from app.models.org_pageview_daily import OrgPageviewDaily
+from app.models.site_post import SitePost
 
 __all__ = [
     "RoleTemplate",

--- a/backend/app/models/site_post.py
+++ b/backend/app/models/site_post.py
@@ -1,0 +1,43 @@
+"""story #3360(발행 구조·서버, 선생님 확定 2026-09-03) — 자사(및 다른 조직) 사이트 글을 코드
+저장소 커밋이 아니라 서버 행 1개로 저장한다. 발행 = 승인 게이트(external_publish) 통과한 글
+1행 — 배포 0·커밋 0. unique(org_id, lang, slug) — 재발행은 같은 행 upsert(githubcommit
+이력 대신 이 행 자체의 created_at/gate_id가 승인 증거가 된다, story 본문 §3)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class SitePost(Base):
+    __tablename__ = "site_posts"
+    __table_args__ = (
+        UniqueConstraint("org_id", "lang", "slug", name="uq_site_posts_org_lang_slug"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    lang: Mapped[str] = mapped_column(Text, nullable=False)
+    slug: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    tags: Mapped[list] = mapped_column(JSONB, nullable=False, server_default="[]")
+    body_md: Mapped[str] = mapped_column(Text, nullable=False)
+    published_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # work_item_id로 body에 받지만 이 스토리의 발행 대상은 항상 story라 컬럼명은 명세 그대로
+    # source_story_id(다른 work_item_type이 생기면 그때 컬럼을 넓힌다 — 지금 지어내지 않음).
+    source_story_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    gate_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_by_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    unpublished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/routers/public_pageview.py
+++ b/backend/app/routers/public_pageview.py
@@ -5,7 +5,9 @@
 `public_key`(비밀 아닌 공개 식별자, org_metering_keys 참고) — 모르는 키는 침묵 204(존재
 유출 안 함, public_docs.py의 unknown→에러 노출과 달리 이쪽은 beacon이라 클라이언트가 응답을
 안 읽으므로 오히려 구분 없는 204가 더 안전한 선택).
-"""
+
+CORS는 `app/core/public_api_cors.py::PublicApiCorsMiddleware`(공개 API 공용, story #3360이
+`/site-posts` 추가하며 일반화)가 담당 — 이 파일엔 CORS 로직 없음."""
 from __future__ import annotations
 
 import hashlib
@@ -15,7 +17,6 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, Request, Response
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.dependencies.database import get_db
 from app.services.pageview_counter import record_pageview, resolve_org_by_public_key
@@ -66,29 +67,3 @@ async def post_pageview(
     today = datetime.now(timezone.utc).date()
     await record_pageview(db, org_id=org_id, path=body.path, day=today)
     return Response(status_code=204)
-
-
-_PUBLIC_PAGEVIEW_PATH = "/api/v2/public/pageview"
-
-
-class PublicPageviewCorsMiddleware(BaseHTTPMiddleware):
-    """beacon은 blog 정적 사이트(app 도메인과 다른 origin)에서 호출된다. 전역 CORSMiddleware
-    (main.py)의 allow_origins는 인증 API 표면 보호용 고정 allowlist라 이 경로만 완전 개방
-    (PO "CORS는 이 라우트만" 확定) — 쿠키 0·무인증이라 allow_credentials 없이 origin "*"과
-    궁합 문제 없음. main.py에서 전역 CORSMiddleware보다 나중에 add_middleware해 바깥쪽(요청
-    먼저 통과)에 두면, preflight OPTIONS를 전역 CORSMiddleware의 allowlist 판정 전에 여기서
-    가로챈다."""
-
-    async def dispatch(self, request: Request, call_next):
-        if request.url.path != _PUBLIC_PAGEVIEW_PATH:
-            return await call_next(request)
-        if request.method == "OPTIONS":
-            return Response(status_code=204, headers={
-                "Access-Control-Allow-Origin": "*",
-                "Access-Control-Allow-Methods": "POST, OPTIONS",
-                "Access-Control-Allow-Headers": "Content-Type",
-                "Access-Control-Max-Age": "86400",
-            })
-        response = await call_next(request)
-        response.headers["Access-Control-Allow-Origin"] = "*"
-        return response

--- a/backend/app/routers/public_site_posts.py
+++ b/backend/app/routers/public_site_posts.py
@@ -10,19 +10,16 @@ public_key = story #3354(PR#3728)의 org_metering_keys.public_key 그대로 재�
 CORS·Cache-Control은 이 파일 책임 밖(전자는 app/core/public_api_cors.py, 후자는 각 핸들러가
 직접 Response 헤더로).
 
-⚠️에러 응답 형상 — 이 앱의 전역 `@app.exception_handler(HTTPException)`(main.py)은 모든
-HTTPException을 `{"data": None, "error": {"code", "message"}, "meta": None}` 봉투로
-재포장한다(내부 API 전역 관례). 그런데 정본 계약(story 15a18511)은 raw FastAPI 기본형
-`{"detail": "not found"}`을 명시했다 — 이 파일은 다른 조직 사이트가 소비하는 외부 공개
-계약이라 내부 봉투를 강제할 이유가 없고, 계약이 이미 그렇게 pin됐으므로 `HTTPException`
-대신 `JSONResponse`를 직접 반환해 전역 핸들러를 우회한다(다른 공개 라우트에 이 방식을
-퍼뜨리자는 게 아니라, 이미 파트너와 문자 그대로 합의된 이 계약만의 예외)."""
+에러 응답 형상 — 페드루 PO 판정(2026-09-03, 미르코군 랜딩 lib/site-posts.ts 실측: `res.ok`만
+보고 본문은 안 읽음, PR#34 diff): 오류 본문은 계약 밖 — 다른 공개 라우트와 동일하게
+`HTTPException`을 그대로 던져 앱 전역 `@app.exception_handler(HTTPException)`(main.py) 봉투
+({"data","error","meta"})로 나가게 둔다(특수 케이스 하나 줄이는 쪽이 맞는 판단). 정본 계약도
+"오류 본문 형상=앱 전역 봉투·소비자는 status만 본다"로 갱신됨."""
 from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, Query, Response
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -63,57 +60,50 @@ def _iso(dt) -> str:
     return dt.isoformat()
 
 
-def _not_found() -> JSONResponse:
-    return JSONResponse(status_code=404, content={"detail": "not found"})
-
-
-def _lang_required() -> JSONResponse:
-    return JSONResponse(status_code=400, content={"detail": "lang is required"})
+async def _resolve_org_or_404(db: AsyncSession, public_key: str) -> uuid.UUID:
+    org_id = await resolve_org_by_public_key(db, public_key)
+    if org_id is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return org_id
 
 
 @router.get("", response_model=SitePostListResponse)
 async def list_site_posts_public(
+    response: Response,
     public_key: str = Query(default=""),
     lang: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
-) -> Response:
+) -> SitePostListResponse:
     if not lang:
-        return _lang_required()
-    org_id = await resolve_org_by_public_key(db, public_key)
-    if org_id is None:
-        return _not_found()
+        raise HTTPException(status_code=400, detail="lang is required")
+    org_id = await _resolve_org_or_404(db, public_key)
+    response.headers["Cache-Control"] = _CACHE_CONTROL
     rows = await list_published_site_posts(db, org_id=org_id, lang=lang)
-    body = SitePostListResponse(posts=[
+    return SitePostListResponse(posts=[
         SitePostListItem(
             slug=r.slug, title=r.title, summary=r.summary, tags=r.tags, lang=r.lang,
             published_at=_iso(r.published_at),
         )
         for r in rows
     ])
-    return JSONResponse(
-        status_code=200, content=body.model_dump(), headers={"Cache-Control": _CACHE_CONTROL},
-    )
 
 
 @router.get("/{slug}", response_model=SitePostDetailResponse)
 async def get_site_post_public(
     slug: str,
+    response: Response,
     public_key: str = Query(default=""),
     lang: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
-) -> Response:
+) -> SitePostDetailResponse:
     if not lang:
-        return _lang_required()
-    org_id = await resolve_org_by_public_key(db, public_key)
-    if org_id is None:
-        return _not_found()
+        raise HTTPException(status_code=400, detail="lang is required")
+    org_id = await _resolve_org_or_404(db, public_key)
     post = await get_published_site_post(db, org_id=org_id, lang=lang, slug=slug)
     if post is None:
-        return _not_found()
-    body = SitePostDetailResponse(
+        raise HTTPException(status_code=404, detail="not found")
+    response.headers["Cache-Control"] = _CACHE_CONTROL
+    return SitePostDetailResponse(
         slug=post.slug, title=post.title, summary=post.summary, tags=post.tags, lang=post.lang,
         published_at=_iso(post.published_at), body_md=post.body_md, source_story_id=str(post.source_story_id),
-    )
-    return JSONResponse(
-        status_code=200, content=body.model_dump(), headers={"Cache-Control": _CACHE_CONTROL},
     )

--- a/backend/app/routers/public_site_posts.py
+++ b/backend/app/routers/public_site_posts.py
@@ -1,0 +1,119 @@
+"""story #3360(발행 구조·서버, 선생님 확定 2026-09-03) — 공개 site-posts 읽기 API.
+
+**비인증** 라우트(public_pageview.py/public_docs.py와 동형). 공개 API 계약은 story
+15a18511(랜딩·미르코) 본문 "공개 API 계약" 절이 정본 — 이 파일은 그 절의 필드명·상태코드를
+문자 그대로 따른다(필드명 하나라도 다르면 랜딩이 조용히 빈 화면을 낸다, PO 명시).
+
+public_key = story #3354(PR#3728)의 org_metering_keys.public_key 그대로 재사용(새 키 개념
+발명 0) — 조회수 beacon과 같은 값 하나로 두 API를 다 식별한다.
+
+CORS·Cache-Control은 이 파일 책임 밖(전자는 app/core/public_api_cors.py, 후자는 각 핸들러가
+직접 Response 헤더로).
+
+⚠️에러 응답 형상 — 이 앱의 전역 `@app.exception_handler(HTTPException)`(main.py)은 모든
+HTTPException을 `{"data": None, "error": {"code", "message"}, "meta": None}` 봉투로
+재포장한다(내부 API 전역 관례). 그런데 정본 계약(story 15a18511)은 raw FastAPI 기본형
+`{"detail": "not found"}`을 명시했다 — 이 파일은 다른 조직 사이트가 소비하는 외부 공개
+계약이라 내부 봉투를 강제할 이유가 없고, 계약이 이미 그렇게 pin됐으므로 `HTTPException`
+대신 `JSONResponse`를 직접 반환해 전역 핸들러를 우회한다(다른 공개 라우트에 이 방식을
+퍼뜨리자는 게 아니라, 이미 파트너와 문자 그대로 합의된 이 계약만의 예외)."""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, Query, Response
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.database import get_db
+from app.services.pageview_counter import resolve_org_by_public_key
+from app.services.site_posts import get_published_site_post, list_published_site_posts
+
+router = APIRouter(prefix="/api/v2/public/site-posts", tags=["public-site-posts"])
+
+_CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300"
+
+
+class SitePostListItem(BaseModel):
+    slug: str
+    title: str
+    summary: str | None
+    tags: list
+    lang: str
+    published_at: str
+
+
+class SitePostListResponse(BaseModel):
+    posts: list[SitePostListItem]
+
+
+class SitePostDetailResponse(BaseModel):
+    slug: str
+    title: str
+    summary: str
+    tags: list
+    lang: str
+    published_at: str
+    body_md: str
+    source_story_id: str
+
+
+def _iso(dt) -> str:
+    return dt.isoformat()
+
+
+def _not_found() -> JSONResponse:
+    return JSONResponse(status_code=404, content={"detail": "not found"})
+
+
+def _lang_required() -> JSONResponse:
+    return JSONResponse(status_code=400, content={"detail": "lang is required"})
+
+
+@router.get("", response_model=SitePostListResponse)
+async def list_site_posts_public(
+    public_key: str = Query(default=""),
+    lang: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    if not lang:
+        return _lang_required()
+    org_id = await resolve_org_by_public_key(db, public_key)
+    if org_id is None:
+        return _not_found()
+    rows = await list_published_site_posts(db, org_id=org_id, lang=lang)
+    body = SitePostListResponse(posts=[
+        SitePostListItem(
+            slug=r.slug, title=r.title, summary=r.summary, tags=r.tags, lang=r.lang,
+            published_at=_iso(r.published_at),
+        )
+        for r in rows
+    ])
+    return JSONResponse(
+        status_code=200, content=body.model_dump(), headers={"Cache-Control": _CACHE_CONTROL},
+    )
+
+
+@router.get("/{slug}", response_model=SitePostDetailResponse)
+async def get_site_post_public(
+    slug: str,
+    public_key: str = Query(default=""),
+    lang: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    if not lang:
+        return _lang_required()
+    org_id = await resolve_org_by_public_key(db, public_key)
+    if org_id is None:
+        return _not_found()
+    post = await get_published_site_post(db, org_id=org_id, lang=lang, slug=slug)
+    if post is None:
+        return _not_found()
+    body = SitePostDetailResponse(
+        slug=post.slug, title=post.title, summary=post.summary, tags=post.tags, lang=post.lang,
+        published_at=_iso(post.published_at), body_md=post.body_md, source_story_id=str(post.source_story_id),
+    )
+    return JSONResponse(
+        status_code=200, content=body.model_dump(), headers={"Cache-Control": _CACHE_CONTROL},
+    )

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -1,0 +1,72 @@
+"""story #3360(발행 구조·서버, 선생님 확定 2026-09-03) — 자사 사이트 글 발행 API(org 인증).
+
+POST /api/v2/organizations/{org_id}/site-posts — org 멤버(에이전트 키 포함) write. **서버
+chokepoint**: work item의 external_publish 게이트가 approved/auto_passed가 아니면 403 —
+connectors.py::post_connector_schema와 동일 권한 축(스키마 등록처럼 "그 org 소속이면 누구나"
+— owner/admin 전용 아님, 발행 스킬을 실행하는 게 에이전트라 owner/admin이면 그 흐름이 첫
+호출에서 403으로 죽는다)."""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.services.site_posts import (
+    ExternalPublishGateNotApprovedError,
+    InvalidSitePostInputError,
+    publish_site_post,
+)
+
+router = APIRouter(prefix="/api/v2/organizations", tags=["site-posts"])
+
+
+class PublishSitePostRequest(BaseModel):
+    work_item_id: uuid.UUID
+    gate_id: uuid.UUID | None = None
+    title: str = Field(..., min_length=1, max_length=300)
+    slug: str = Field(..., min_length=1, max_length=200)
+    lang: str = Field(..., min_length=2, max_length=5)
+    summary: str = Field(..., min_length=1, max_length=1000)
+    tags: list[str] = Field(default_factory=list)
+    body_md: str = Field(..., min_length=1)
+
+
+class SitePostResponse(BaseModel):
+    id: uuid.UUID
+    slug: str
+    title: str
+    lang: str
+    published_at: str
+    gate_id: uuid.UUID
+
+
+@router.post("/{org_id}/site-posts", response_model=SitePostResponse, status_code=201)
+async def post_site_post(
+    org_id: uuid.UUID,
+    body: PublishSitePostRequest,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> SitePostResponse:
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    try:
+        post = await publish_site_post(
+            db, org_id=org_id, work_item_id=body.work_item_id, gate_id=body.gate_id,
+            title=body.title, slug=body.slug, lang=body.lang, summary=body.summary,
+            tags=body.tags, body_md=body.body_md, created_by_member_id=uuid.UUID(auth.user_id),
+        )
+    except InvalidSitePostInputError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except ExternalPublishGateNotApprovedError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+    return SitePostResponse(
+        id=post.id, slug=post.slug, title=post.title, lang=post.lang,
+        published_at=post.published_at.isoformat(), gate_id=post.gate_id,
+    )

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -1,0 +1,143 @@
+"""story #3360(발행 구조·서버, 선생님 확定 2026-09-03) — 자사 사이트 글 저장/조회.
+
+**서버 chokepoint**(story 본문 §2): work item의 external_publish 게이트가 approved/
+auto_passed가 아니면 발행 자체가 안 된다 — git 커밋이 승인 증거였던 자리를, 이 SitePost 행의
+gate_id·created_at이 그대로 대신한다."""
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate
+from app.models.site_post import SitePost
+
+_SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+_LANG_RE = re.compile(r"^[a-z]{2}(-[A-Z]{2})?$")
+
+_APPROVED_STATUSES = ("approved", "auto_passed")
+
+
+class InvalidSitePostInputError(ValueError):
+    """slug/lang이 서버 형식 규칙을 어김(422)."""
+
+
+class ExternalPublishGateNotApprovedError(Exception):
+    """work item의 external_publish 게이트가 approved/auto_passed가 아님(403). gate_id·
+    status를 담아 사유 문구에 그대로 노출한다(story 본문 §2 명시)."""
+
+    def __init__(self, *, gate_id: uuid.UUID | None, status: str | None):
+        self.gate_id = gate_id
+        self.status = status
+        detail = (
+            f"external_publish 게이트가 승인되지 않았습니다(gate_id={gate_id}, status={status})"
+            if gate_id is not None
+            else "이 work item에 승인된 external_publish 게이트가 없습니다"
+        )
+        super().__init__(detail)
+
+
+def _validate_slug(slug: str) -> None:
+    if not _SLUG_RE.match(slug):
+        raise InvalidSitePostInputError(f"slug 형식이 올바르지 않습니다: {slug!r}")
+
+
+def _validate_lang(lang: str) -> None:
+    if not _LANG_RE.match(lang):
+        raise InvalidSitePostInputError(f"lang 형식이 올바르지 않습니다: {lang!r}")
+
+
+async def _resolve_approved_gate(
+    db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID, gate_id: uuid.UUID | None,
+) -> Gate:
+    """gate_id가 주어지면 그 게이트 자체를 검증(work_item/타입 일치 + 승인 상태). 없으면 이
+    work item의 external_publish 게이트를 찾아 검증(가장 최근 것 — story #2150 재제출 리셋
+    관례상 같은 (work_item, gate_type)엔 사실상 행 1개만 산다)."""
+    if gate_id is not None:
+        gate = (await db.execute(
+            select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
+        )).scalar_one_or_none()
+        if (
+            gate is None
+            or gate.work_item_id != work_item_id
+            or gate.gate_type != "external_publish"
+            or gate.status not in _APPROVED_STATUSES
+        ):
+            raise ExternalPublishGateNotApprovedError(
+                gate_id=gate_id, status=gate.status if gate is not None else None,
+            )
+        return gate
+
+    gate = (await db.execute(
+        select(Gate)
+        .where(
+            Gate.org_id == org_id, Gate.work_item_id == work_item_id, Gate.gate_type == "external_publish",
+        )
+        .order_by(Gate.created_at.desc())
+        .limit(1)
+    )).scalar_one_or_none()
+    if gate is None or gate.status not in _APPROVED_STATUSES:
+        raise ExternalPublishGateNotApprovedError(
+            gate_id=gate.id if gate is not None else None, status=gate.status if gate is not None else None,
+        )
+    return gate
+
+
+async def publish_site_post(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    work_item_id: uuid.UUID,
+    gate_id: uuid.UUID | None,
+    title: str,
+    slug: str,
+    lang: str,
+    summary: str,
+    tags: list,
+    body_md: str,
+    created_by_member_id: uuid.UUID,
+) -> SitePost:
+    _validate_slug(slug)
+    _validate_lang(lang)
+    gate = await _resolve_approved_gate(db, org_id=org_id, work_item_id=work_item_id, gate_id=gate_id)
+
+    now = datetime.now(timezone.utc)
+    stmt = pg_insert(SitePost).values(
+        id=uuid.uuid4(), org_id=org_id, lang=lang, slug=slug, title=title, summary=summary,
+        tags=tags, body_md=body_md, published_at=now, source_story_id=work_item_id,
+        gate_id=gate.id, created_by_member_id=created_by_member_id, unpublished_at=None,
+    )
+    stmt = stmt.on_conflict_do_update(
+        constraint="uq_site_posts_org_lang_slug",
+        set_={
+            "title": title, "summary": summary, "tags": tags, "body_md": body_md,
+            "published_at": now, "source_story_id": work_item_id, "gate_id": gate.id,
+            "unpublished_at": None, "updated_at": now,
+            # created_by_member_id는 최초 발행자 그대로 — 재발행이 저자를 안 바꾼다.
+        },
+    ).returning(SitePost)
+    row = (await db.execute(stmt)).scalar_one()
+    await db.commit()
+    return row
+
+
+async def get_published_site_post(db: AsyncSession, *, org_id: uuid.UUID, lang: str, slug: str) -> SitePost | None:
+    return (await db.execute(
+        select(SitePost).where(
+            SitePost.org_id == org_id, SitePost.lang == lang, SitePost.slug == slug,
+            SitePost.unpublished_at.is_(None),
+        )
+    )).scalar_one_or_none()
+
+
+async def list_published_site_posts(db: AsyncSession, *, org_id: uuid.UUID, lang: str) -> list[SitePost]:
+    stmt = (
+        select(SitePost)
+        .where(SitePost.org_id == org_id, SitePost.lang == lang, SitePost.unpublished_at.is_(None))
+        .order_by(SitePost.published_at.desc())
+    )
+    return list((await db.execute(stmt)).scalars().all())

--- a/backend/tests/test_3360_site_posts.py
+++ b/backend/tests/test_3360_site_posts.py
@@ -3,7 +3,8 @@
 공개 API 계약은 story 15a18511(랜딩) 본문이 정본 — 이 테스트는 그 절의 필드명·상태코드를
 그대로 assert한다(list `{"posts":[{slug,title,summary,tags,lang,published_at}]}`, detail
 `{slug,title,summary,tags,lang,published_at,body_md,source_story_id}`, unknown public_key/slug
-→404 `{"detail":"not found"}`, lang 누락 →400).
+→404, lang 누락 →400). 오류 본문 형상은 계약 밖(PO 판정 2026-09-03 — 미르코군 랜딩은
+res.ok만 보고 본문은 안 읽음) — 앱 전역 HTTPException 봉투 그대로 검증한다.
 
 seed 하네스는 test_3354_pageview_counter.py 패턴(httpx ASGITransport+override_db_and_read+
 claims에 org_id 직접 주입) 재사용."""
@@ -332,9 +333,9 @@ async def test_unknown_public_key_returns_404_not_found():
                 "/api/v2/public/site-posts/hello-world", params={"public_key": "garbage", "lang": "ko"},
             )
         assert r_list.status_code == 404
-        assert r_list.json() == {"detail": "not found"}
+        assert r_list.json() == {"data": None, "error": {"code": "NOT_FOUND", "message": "not found"}, "meta": None}
         assert r_detail.status_code == 404
-        assert r_detail.json() == {"detail": "not found"}
+        assert r_detail.json() == {"data": None, "error": {"code": "NOT_FOUND", "message": "not found"}, "meta": None}
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -356,7 +357,7 @@ async def test_unknown_slug_returns_404():
                 "/api/v2/public/site-posts/does-not-exist", params={"public_key": public_key, "lang": "ko"},
             )
         assert r.status_code == 404
-        assert r.json() == {"detail": "not found"}
+        assert r.json() == {"data": None, "error": {"code": "NOT_FOUND", "message": "not found"}, "meta": None}
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_3360_site_posts.py
+++ b/backend/tests/test_3360_site_posts.py
@@ -1,0 +1,444 @@
+"""story #3360(발행 구조·서버, 선생님 확定 2026-09-03) — 자사 사이트 글 저장·공개 API.
+
+공개 API 계약은 story 15a18511(랜딩) 본문이 정본 — 이 테스트는 그 절의 필드명·상태코드를
+그대로 assert한다(list `{"posts":[{slug,title,summary,tags,lang,published_at}]}`, detail
+`{slug,title,summary,tags,lang,published_at,body_md,source_story_id}`, unknown public_key/slug
+→404 `{"detail":"not found"}`, lang 누락 →400).
+
+seed 하네스는 test_3354_pageview_counter.py 패턴(httpx ASGITransport+override_db_and_read+
+claims에 org_id 직접 주입) 재사용."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Site Posts Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="publisher"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="1호 글"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_gate(session, org_id, work_item_id, *, status="pending", gate_type="external_publish"):
+    from app.models.gate import Gate
+
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, work_item_type="story",
+        gate_type=gate_type, status=status,
+    )
+    session.add(gate)
+    await session.commit()
+    return gate.id
+
+
+async def _seed_metering_key(session, org_id):
+    from app.services.pageview_counter import get_or_create_active_key
+
+    return await get_or_create_active_key(session, org_id=org_id)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _setup_public_app(app, Session):
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+
+
+def _publish_body(*, work_item_id, gate_id=None, slug="hello-world", lang="ko"):
+    return {
+        "work_item_id": str(work_item_id), "gate_id": str(gate_id) if gate_id else None,
+        "title": "AI가 «몰라요»라고 말할 때", "slug": slug, "lang": lang,
+        "summary": "요약입니다", "tags": ["ai", "product"], "body_md": "# 제목\n\n본문입니다.",
+    }
+
+
+@pytest.mark.anyio
+async def test_post_with_unapproved_gate_returns_403_and_creates_zero_rows():
+    from app.main import app
+    from app.models.site_post import SitePost
+    from sqlalchemy import func, select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            await _seed_gate(s, org_id, story_id, status="pending")
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts", json=_publish_body(work_item_id=story_id),
+            )
+        assert r.status_code == 403, r.text
+
+        async with Session() as s:
+            count = (await s.execute(select(func.count()).select_from(SitePost))).scalar_one()
+        assert count == 0, "게이트 미승인인데 행이 생겼다(서버 chokepoint 회귀)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_post_with_approved_gate_returns_201_and_public_api_reflects():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            gate_id = await _seed_gate(s, org_id, story_id, status="approved")
+            public_key = await _seed_metering_key(s, org_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts",
+                json=_publish_body(work_item_id=story_id, gate_id=gate_id),
+            )
+        assert r.status_code == 201, r.text
+        assert r.json()["gate_id"] == str(gate_id)
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as public_client:
+            r_list = await public_client.get(
+                "/api/v2/public/site-posts", params={"public_key": public_key, "lang": "ko"},
+            )
+            r_detail = await public_client.get(
+                "/api/v2/public/site-posts/hello-world", params={"public_key": public_key, "lang": "ko"},
+            )
+
+        assert r_list.status_code == 200, r_list.text
+        posts = r_list.json()["posts"]
+        assert len(posts) == 1
+        assert set(posts[0].keys()) == {"slug", "title", "summary", "tags", "lang", "published_at"}, \
+            "list 응답 필드가 정본 계약과 다르다(랜딩이 조용히 빈 화면)"
+        assert posts[0]["slug"] == "hello-world"
+        assert r_list.headers.get("cache-control") == "public, s-maxage=60, stale-while-revalidate=300"
+
+        assert r_detail.status_code == 200, r_detail.text
+        detail = r_detail.json()
+        assert set(detail.keys()) == {
+            "slug", "title", "summary", "tags", "lang", "published_at", "body_md", "source_story_id",
+        }, "detail 응답 필드가 정본 계약과 다르다"
+        assert detail["body_md"] == "# 제목\n\n본문입니다."
+        assert detail["source_story_id"] == str(story_id)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_auto_passed_gate_also_counts_as_approved():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            await _seed_gate(s, org_id, story_id, status="auto_passed")
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts", json=_publish_body(work_item_id=story_id),
+            )
+        assert r.status_code == 201, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_invalid_slug_rejected_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            await _seed_gate(s, org_id, story_id, status="approved")
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts",
+                json=_publish_body(work_item_id=story_id, slug="../x"),
+            )
+        assert r.status_code == 422, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_republish_same_org_lang_slug_upserts_single_row():
+    from app.main import app
+    from app.models.site_post import SitePost
+    from sqlalchemy import func, select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            gate_id = await _seed_gate(s, org_id, story_id, status="approved")
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+
+        async with _client_for(app) as client:
+            await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts",
+                json=_publish_body(work_item_id=story_id, gate_id=gate_id),
+            )
+            body2 = _publish_body(work_item_id=story_id, gate_id=gate_id)
+            body2["title"] = "제목 수정판"
+            r2 = await client.post(f"/api/v2/organizations/{org_id}/site-posts", json=body2)
+        assert r2.status_code == 201, r2.text
+
+        async with Session() as s:
+            count = (await s.execute(select(func.count()).select_from(SitePost))).scalar_one()
+            row = (await s.execute(select(SitePost).where(SitePost.slug == "hello-world"))).scalar_one()
+        assert count == 1, "재발행인데 행이 늘었다(upsert 회귀)"
+        assert row.title == "제목 수정판"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unknown_public_key_returns_404_not_found():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        _setup_public_app(app, Session)
+        async with _client_for(app) as client:
+            r_list = await client.get("/api/v2/public/site-posts", params={"public_key": "garbage", "lang": "ko"})
+            r_detail = await client.get(
+                "/api/v2/public/site-posts/hello-world", params={"public_key": "garbage", "lang": "ko"},
+            )
+        assert r_list.status_code == 404
+        assert r_list.json() == {"detail": "not found"}
+        assert r_detail.status_code == 404
+        assert r_detail.json() == {"detail": "not found"}
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unknown_slug_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            public_key = await _seed_metering_key(s, org_id)
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as client:
+            r = await client.get(
+                "/api/v2/public/site-posts/does-not-exist", params={"public_key": public_key, "lang": "ko"},
+            )
+        assert r.status_code == 404
+        assert r.json() == {"detail": "not found"}
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_missing_lang_returns_400():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            public_key = await _seed_metering_key(s, org_id)
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as client:
+            r = await client.get("/api/v2/public/site-posts", params={"public_key": public_key})
+        assert r.status_code == 400, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublished_post_excluded_from_public_reads():
+    from app.main import app
+    from app.models.site_post import SitePost
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            gate_id = await _seed_gate(s, org_id, story_id, status="approved")
+            public_key = await _seed_metering_key(s, org_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+
+        async with _client_for(app) as client:
+            await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts",
+                json=_publish_body(work_item_id=story_id, gate_id=gate_id),
+            )
+
+        from datetime import datetime, timezone
+        async with Session() as s:
+            row = (await s.execute(select(SitePost).where(SitePost.slug == "hello-world"))).scalar_one()
+            row.unpublished_at = datetime.now(timezone.utc)
+            await s.commit()
+
+        _setup_public_app(app, Session)
+        async with _client_for(app) as public_client:
+            r_list = await public_client.get(
+                "/api/v2/public/site-posts", params={"public_key": public_key, "lang": "ko"},
+            )
+            r_detail = await public_client.get(
+                "/api/v2/public/site-posts/hello-world", params={"public_key": public_key, "lang": "ko"},
+            )
+        assert r_list.json()["posts"] == [], "unpublished 글이 목록에 남아있다(회귀)"
+        assert r_detail.status_code == 404, "unpublished 글의 본문이 여전히 공개 조회된다(회귀)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_site_posts_cors_preflight_open():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        _setup_public_app(app, Session)
+        async with _client_for(app) as client:
+            r = await client.options(
+                "/api/v2/public/site-posts",
+                headers={"Origin": "https://sprintable.ai", "Access-Control-Request-Method": "GET"},
+            )
+        assert r.status_code == 204
+        assert r.headers.get("access-control-allow-origin") == "*"
+        assert "GET" in r.headers.get("access-control-allow-methods", "")
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## ⚠️ 스택 의존성
이 브랜치는 `feat/3354-pageview-counter`(**PR#3728, 아직 미머지**) 위에서 시작했다 — 공개 `public_key`(org_metering_keys)를 그대로 재사용하기 위함(story #3360 처방 §3, 새 키 개념 발명 0). **#3728이 머지되기 전까지 이 PR의 diff에는 #3728의 변경분도 함께 보인다.** #3728이 먼저 머지되면 이 브랜치를 origin/develop 위로 rebase — 그때 diff가 이 스토리분만으로 줄어든다.

## 배경
선생님 확定(2026-09-03 00:53Z·00:55Z): 글은 콘텐츠다 — 코드 저장소에 커밋하는 구조(#3352 site_git·1호 01d6cda)는 "오늘 실물"용 지름길이었고 제품 구조가 아니다. 2호부터: 글은 서버에 저장, 랜딩(및 다른 조직의 사이트)은 공개 API로 읽어 즉시 게시.

## 구현
- `POST /api/v2/organizations/{org_id}/site-posts` — org 멤버(에이전트 키 포함) write. **서버 chokepoint**: work item의 `external_publish` 게이트가 `approved`/`auto_passed`가 아니면 403(gate_id·status 포함 사유). slug `^[a-z0-9]+(-[a-z0-9]+)*$`·lang `^[a-z]{2}(-[A-Z]{2})?$` 서버 검증(422). 재발행=같은 (org,lang,slug) upsert(저자는 최초 발행자 유지, upsert가 안 덮음).
- `GET /api/v2/public/site-posts?public_key=&lang=` (목록) · `GET /api/v2/public/site-posts/{slug}?public_key=&lang=` (본문) — 무인증. public_key = #3728 `org_metering_keys.public_key` 그대로.
- CORS: `app/core/public_api_cors.py`로 일반화 — #3728이 `/pageview` 하나만 열던 단일-경로 미들웨어를 경로 목록 방식(`_ROUTES`)으로 확장해 `/site-posts` 계열도 얹었다(새 미들웨어 신설 0, PO 확定 "미들웨어 경로에 추가" 그대로).
- `Cache-Control: public, s-maxage=60, stale-while-revalidate=300`.

## 공개 API 계약 — story 15a18511(랜딩·미르코) 본문이 정본, 문자 그대로 구현
- 목록 200: `{"posts":[{slug,title,summary|null,tags,lang,published_at}]}`
- 본문 200: `{slug,title,summary,tags,lang,published_at,body_md,source_story_id}`
- 모르는 public_key/slug → 404 `{"detail":"not found"}` · lang 미지정 → 400

## ⚠️ PO 확인 요청 — 에러 응답 형상 우회
이 앱 전역 `@app.exception_handler(HTTPException)`(main.py)이 모든 HTTPException을 `{"data":null,"error":{"code","message"},"meta":null}` 봉투로 재포장한다(내부 API 전역 관례) — 그런데 정본 계약은 raw `{"detail":...}`을 명시했다. site-posts의 공개 GET 2개만 `HTTPException` 대신 `JSONResponse`를 직접 반환해 이 전역 봉투를 우회했다(다른 라우트로 퍼뜨리지 않음, 파일 docstring에 근거 기록). 계약 문자 그대로는 맞췄으나 **이 우회 자체가 맞는 판단인지 확인 부탁** — Mirko 랜딩이 실제로 `.detail`을 읽는지 사전에 맞춰본 것이면 문제 없고, 혹시 이미 봉투 형상을 전제했다면 내가 반대로 고쳐야 한다.

## 테스트
`test_3360_site_posts.py` 신규, realdb 10건 — AC 그대로:
- 게이트 미승인 → 403·행 0[관측] / 승인 후 → 201·공개 API 즉시 반영[관측]
- auto_passed 게이트도 승인으로 인정
- slug `../x` → 422
- 재발행 → 행 1개 유지(upsert), 내용은 최신으로
- 모르는 public_key/slug → 404 `{"detail":"not found"}` 정확 매치
- lang 누락 → 400
- unpublished_at 세팅된 글은 목록/본문 둘 다 공개 조회에서 제외
- site-posts CORS preflight 개방

뮤테이션 자체검증: chokepoint(게이트 승인 상태 체크)를 제거하고 재실행 → 403이 나와야 할 요청이 201로 새는 것을 확認(가드가 실제로 잡는다는 증명) 후 원복.

기존 `test_3354_pageview_counter.py` 회귀 없음(CORS 미들웨어 일반화 포함, 로컬 realdb 19/19 pass).

## 스코프 밖(story 본문 명시)
- 처방 4항(플러그인 `publish_site_post` 커넥터 전환) — 미르코군 플러그인 쪽 후속.
- 처방 5항(1호 글 이관) — PO가 직접 POST 1회 실행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfPLRWqGNvcf58NWYrYKba