### PR TITLE
[SID:3365] 고객 에이전트가 공개 권한 없이 블로그 초안과 불변 버전을 등록한다

### DIFF
--- a/backend/alembic/versions/0308_site_post_drafts.py
+++ b/backend/alembic/versions/0308_site_post_drafts.py
@@ -1,0 +1,61 @@
+"""story #3365(Phase0 S1·마케팅 운영 블루프린트 v3, 선생님 확定 2026-09-03) — 초안·불변 버전
+원장. 고객 에이전트가 넣는 초안과 휴먼 개정본을 `site_posts`(공개 projection)와 분리된 별도
+테이블에 쌓는다 — 승인·발행 전에는 공개 행이 절대 생기지 않는다.
+
+Revision ID: 0308
+Revises: 0307
+Create Date: 2026-09-03
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0308"
+down_revision = "0307"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "site_post_drafts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("work_item_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default="draft"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.UniqueConstraint("org_id", "work_item_id", "slug", name="uq_site_post_drafts_org_work_item_slug"),
+    )
+    op.create_index("ix_site_post_drafts_org_id", "site_post_drafts", ["org_id"])
+
+    op.create_table(
+        "site_post_versions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "draft_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("site_post_drafts.id"), nullable=False,
+        ),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("lang", sa.Text(), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("tags", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default="[]"),
+        sa.Column("body_md", sa.Text(), nullable=False),
+        sa.Column("body_sha256", sa.Text(), nullable=False),
+        sa.Column("author_member_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("author_kind", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.UniqueConstraint("draft_id", "version", name="uq_site_post_versions_draft_version"),
+    )
+    op.create_index("ix_site_post_versions_draft_id", "site_post_versions", ["draft_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_site_post_versions_draft_id", table_name="site_post_versions")
+    op.drop_table("site_post_versions")
+    op.drop_index("ix_site_post_drafts_org_id", table_name="site_post_drafts")
+    op.drop_table("site_post_drafts")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -132,6 +132,8 @@ from app.models.recipe_repeat_schedule import RecipeRepeatSchedule
 from app.models.org_metering_key import OrgMeteringKey
 from app.models.org_pageview_daily import OrgPageviewDaily
 from app.models.site_post import SitePost
+from app.models.site_post_draft import SitePostDraft
+from app.models.site_post_version import SitePostVersion
 
 __all__ = [
     "RoleTemplate",

--- a/backend/app/models/site_post_draft.py
+++ b/backend/app/models/site_post_draft.py
@@ -1,0 +1,36 @@
+"""story #3365(Phase0 S1, 선생님 확定 2026-09-03) — 초안 원장. 고객 에이전트가 넣는 초안과
+휴먼이 고친 개정판을 같은 work item·slug 아래 불변 버전으로 쌓는다. `SitePost`(공개 projection,
+site_post.py)와 분리 — 승인·발행 전에는 이 테이블에만 존재하고 공개 행은 절대 안 생긴다.
+
+버전 원문·주체는 SitePostVersion(아래)이 SSOT — 이 draft 행 자체엔 원작성 주체를 중복 저장하지
+않는다(version_number=1이 원작성 버전).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class SitePostDraft(Base):
+    __tablename__ = "site_post_drafts"
+    __table_args__ = (
+        UniqueConstraint("org_id", "work_item_id", "slug", name="uq_site_post_drafts_org_work_item_slug"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    work_item_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    slug: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="draft")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/models/site_post_version.py
+++ b/backend/app/models/site_post_version.py
@@ -1,0 +1,42 @@
+"""story #3365(Phase0 S1) — 초안의 불변 버전 원장. 휴먼이 본문을 고치면 기존 행을 덮지 않고
+새 버전을 추가한다(``version`` 오름차순, draft당 유일) — 에이전트 원안과 휴먼 개정본이
+별도 행으로 남아 이력 조회가 항상 가능하다(AC6). `body_sha256`은 S2(승인 봉인)가 "승인한
+버전=공개될 버전"을 증명하는 데 재사용할 canonical 해시 — 여기선 그냥 계산해 둔다.
+
+필드명은 유나군 S4 화면 설계(문서 62fc03ee §4-3, 페드루 PO 확定 2026-09-03)가 요구하는
+Phase 1 원장 어휘(content_version 승격 예정)에 맞춘다: ``version``·``body_sha256``·
+``author_kind``·``author_member_id`` — 여기서 굳혀 두면 S2·S4가 이름을 다시 안 맞춰도 된다."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class SitePostVersion(Base):
+    __tablename__ = "site_post_versions"
+    __table_args__ = (
+        UniqueConstraint("draft_id", "version", name="uq_site_post_versions_draft_version"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    draft_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("site_post_drafts.id"), nullable=False, index=True
+    )
+    version: Mapped[int] = mapped_column(nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    lang: Mapped[str] = mapped_column(Text, nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    tags: Mapped[list] = mapped_column(JSONB, nullable=False, server_default="[]")
+    body_md: Mapped[str] = mapped_column(Text, nullable=False)
+    body_sha256: Mapped[str] = mapped_column(Text, nullable=False)
+    author_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    author_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,6 +23,7 @@ from app.services.site_posts import (
     get_site_post_draft,
     is_agent_caller,
     list_site_post_draft_versions,
+    list_site_post_drafts,
     publish_site_post,
 )
 
@@ -44,6 +45,17 @@ class SitePostDraftVersionResponse(BaseModel):
     draft_id: uuid.UUID
     version_id: uuid.UUID
     version: int
+
+
+class SitePostDraftListItem(BaseModel):
+    draft_id: uuid.UUID
+    work_item_id: uuid.UUID
+    slug: str
+    lang: str
+    title: str
+    current_version: int
+    latest_author_kind: str
+    updated_at: str
 
 
 class SitePostVersionHistoryItem(BaseModel):
@@ -158,6 +170,32 @@ async def post_site_post_draft_version(
     return SitePostDraftVersionResponse(
         draft_id=version.draft_id, version_id=version.id, version=version.version,
     )
+
+
+@router.get("/{org_id}/site-posts/drafts", response_model=list[SitePostDraftListItem])
+async def list_site_post_drafts_endpoint(
+    org_id: uuid.UUID,
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[SitePostDraftListItem]:
+    """story #3365 후속(S4 계약 갭, 페드루 PO 확定 2026-09-03) — S4 글 관리 화면이 열릴 때
+    draft_id를 미리 알 방법이 없어 신설. 조직 멤버(휴먼·에이전트 모두) 읽기 가능 — 목록 조회는
+    승인·발행 경계 밖이라 human-only 제약 없음."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    rows = await list_site_post_drafts(db, org_id=org_id, limit=limit, offset=offset)
+    return [
+        SitePostDraftListItem(
+            draft_id=draft.id, work_item_id=draft.work_item_id, slug=draft.slug,
+            lang=version.lang, title=version.title, current_version=version.version,
+            latest_author_kind=version.author_kind, updated_at=version.created_at.isoformat(),
+        )
+        for draft, version in rows
+    ]
 
 
 @router.get(

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -18,10 +18,48 @@ from app.dependencies.database import get_db
 from app.services.site_posts import (
     ExternalPublishGateNotApprovedError,
     InvalidSitePostInputError,
+    MediaNotSupportedPhase0Error,
+    create_site_post_draft_version,
+    get_site_post_draft,
+    is_agent_caller,
+    list_site_post_draft_versions,
     publish_site_post,
 )
 
 router = APIRouter(prefix="/api/v2/organizations", tags=["site-posts"])
+
+
+class CreateSitePostDraftVersionRequest(BaseModel):
+    work_item_id: uuid.UUID
+    title: str = Field(..., min_length=1, max_length=300)
+    slug: str = Field(..., min_length=1, max_length=200)
+    lang: str = Field(..., min_length=2, max_length=5)
+    summary: str = Field(..., min_length=1, max_length=1000)
+    tags: list[str] = Field(default_factory=list)
+    body_md: str = Field(..., min_length=1)
+    media_manifest: list = Field(default_factory=list)
+
+
+class SitePostDraftVersionResponse(BaseModel):
+    draft_id: uuid.UUID
+    version_id: uuid.UUID
+    version: int
+
+
+class SitePostVersionHistoryItem(BaseModel):
+    version_id: uuid.UUID
+    version: int
+    slug: str
+    source_story_id: uuid.UUID
+    title: str
+    lang: str
+    summary: str
+    tags: list[str]
+    body_md: str
+    body_sha256: str
+    author_member_id: uuid.UUID
+    author_kind: str
+    created_at: str
 
 
 class PublishSitePostRequest(BaseModel):
@@ -55,6 +93,18 @@ async def post_site_post(
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
+    # story #3365(Phase0 S1) AC4 — 공개 API는 휴먼 전용. 초안 제출자(고객 에이전트)와 발행자(휴먼)
+    # 경계가 이 체크 하나로 갈린다 — 가드가 먼저(게이트 조회보다 앞) 서야 mutation("이 조건을
+    # 제거하면 반드시 201로 실패")이 성립한다.
+    if await is_agent_caller(db, org_id=org_id, member_id=uuid.UUID(auth.user_id)):
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "SITE_POST_PUBLISH_HUMAN_ONLY",
+                "message": "글 공개는 휴먼 멤버만 가능합니다 (에이전트는 초안만 제출).",
+            },
+        )
+
     try:
         post = await publish_site_post(
             db, org_id=org_id, work_item_id=body.work_item_id, gate_id=body.gate_id,
@@ -70,3 +120,72 @@ async def post_site_post(
         id=post.id, slug=post.slug, title=post.title, lang=post.lang,
         published_at=post.published_at.isoformat(), gate_id=post.gate_id,
     )
+
+
+@router.post(
+    "/{org_id}/site-posts/drafts", response_model=SitePostDraftVersionResponse, status_code=201,
+)
+async def post_site_post_draft_version(
+    org_id: uuid.UUID,
+    body: CreateSitePostDraftVersionRequest,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> SitePostDraftVersionResponse:
+    """story #3365(Phase0 S1) — 고객 에이전트·휴먼 공용 초안 제출 API. 공개 권한이 없어도(agent
+    키만으로도) 호출 가능 — 공개 `SitePost` 행은 만들지 않는다(AC1). 작성 주체는 요청 body가
+    아니라 인증 컨텍스트에서 서버가 판정해 위조를 원천 차단한다(AC2 — body에 author 필드
+    자체가 없다)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    member_id = uuid.UUID(auth.user_id)
+    actor_type = "agent" if await is_agent_caller(db, org_id=org_id, member_id=member_id) else "human"
+
+    try:
+        version = await create_site_post_draft_version(
+            db, org_id=org_id, work_item_id=body.work_item_id, slug=body.slug, lang=body.lang,
+            title=body.title, summary=body.summary, tags=body.tags, body_md=body.body_md,
+            media_manifest=body.media_manifest, author_member_id=member_id, author_kind=actor_type,
+        )
+    except MediaNotSupportedPhase0Error as exc:
+        raise HTTPException(
+            status_code=422, detail={"code": "MEDIA_NOT_SUPPORTED_PHASE0", "message": str(exc)},
+        ) from exc
+    except InvalidSitePostInputError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    return SitePostDraftVersionResponse(
+        draft_id=version.draft_id, version_id=version.id, version=version.version,
+    )
+
+
+@router.get(
+    "/{org_id}/site-posts/drafts/{draft_id}/versions", response_model=list[SitePostVersionHistoryItem],
+)
+async def list_site_post_draft_version_history(
+    org_id: uuid.UUID,
+    draft_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[SitePostVersionHistoryItem]:
+    """story #3365 AC6 — 조직 멤버가 버전 이력을 조회하면 에이전트 원안(v1)과 휴먼 개정본(v2+)이
+    별도 버전으로 관측된다."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    draft = await get_site_post_draft(db, org_id=org_id, draft_id=draft_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail="draft not found")
+
+    versions = await list_site_post_draft_versions(db, draft_id=draft_id)
+    return [
+        SitePostVersionHistoryItem(
+            version_id=v.id, version=v.version, slug=draft.slug, source_story_id=draft.work_item_id,
+            title=v.title, lang=v.lang, summary=v.summary, tags=v.tags, body_md=v.body_md,
+            body_sha256=v.body_sha256, author_member_id=v.author_member_id, author_kind=v.author_kind,
+            created_at=v.created_at.isoformat(),
+        )
+        for v in versions
+    ]

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -5,16 +5,21 @@ auto_passed가 아니면 발행 자체가 안 된다 — git 커밋이 승인 �
 gate_id·created_at이 그대로 대신한다."""
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.gate import Gate
 from app.models.site_post import SitePost
+from app.models.site_post_draft import SitePostDraft
+from app.models.site_post_version import SitePostVersion
+from app.models.team import TeamMember
 
 _SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 _LANG_RE = re.compile(r"^[a-z]{2}(-[A-Z]{2})?$")
@@ -24,6 +29,10 @@ _APPROVED_STATUSES = ("approved", "auto_passed")
 
 class InvalidSitePostInputError(ValueError):
     """slug/lang이 서버 형식 규칙을 어김(422)."""
+
+
+class MediaNotSupportedPhase0Error(ValueError):
+    """Phase 0엔 미디어 입력이 없다 — manifest가 비어 있지 않으면 422(story #3365 AC5)."""
 
 
 class ExternalPublishGateNotApprovedError(Exception):
@@ -139,5 +148,101 @@ async def list_published_site_posts(db: AsyncSession, *, org_id: uuid.UUID, lang
         select(SitePost)
         .where(SitePost.org_id == org_id, SitePost.lang == lang, SitePost.unpublished_at.is_(None))
         .order_by(SitePost.published_at.desc())
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+# ─── story #3365(Phase0 S1) — 초안·불변 버전 ────────────────────────────────────
+
+async def is_agent_caller(db: AsyncSession, *, org_id: uuid.UUID, member_id: uuid.UUID) -> bool:
+    """이 caller가 이 org의 agent TeamMember인지 — auth.py `_verify_org_membership`의 OrgMember∪
+    TeamMember 재확인 축(story f84227b5, PR#3730)과 동형: 클레임(``api_key_id``)을 신뢰하지 않고
+    DB의 실제 멤버 타입으로 판정한다(actor_type fail-closed — 클레임 위조·테스트 하네스의 클레임
+    누락 둘 다에 안전)."""
+    result = await db.execute(
+        select(TeamMember.id).where(
+            TeamMember.org_id == org_id, TeamMember.id == member_id, TeamMember.type == "agent",
+            TeamMember.is_active.is_(True),
+        ).limit(1)
+    )
+    return result.first() is not None
+
+
+def compute_body_sha256(*, title: str, lang: str, summary: str, tags: list, body_md: str) -> str:
+    """canonical payload hash — S2가 승인 대상 버전을 봉인할 때(gate neutral_facts) 재사용할
+    같은 계산(페드루 PO 확定, 문서 62fc03ee §4-3: "content_sha256"이 이 값 그대로)."""
+    canonical = json.dumps(
+        {"title": title, "lang": lang, "summary": summary, "tags": tags, "body_md": body_md},
+        sort_keys=True, ensure_ascii=False, separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+async def create_site_post_draft_version(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    work_item_id: uuid.UUID,
+    slug: str,
+    lang: str,
+    title: str,
+    summary: str,
+    tags: list,
+    body_md: str,
+    media_manifest: list,
+    author_member_id: uuid.UUID,
+    author_kind: str,
+) -> SitePostVersion:
+    """초안을 (org, work_item, slug)로 upsert하고 새 불변 버전을 추가한다. 기존 버전은 절대
+    덮어쓰지 않는다(AC3) — 에이전트 원안·휴먼 개정본이 별도 행으로 남는다(AC6). 공개 `SitePost`
+    행은 여기서 절대 만들지 않는다(AC1) — 승인·발행은 별개 게이트·엔드포인트(S2·S3) 몫."""
+    _validate_slug(slug)
+    _validate_lang(lang)
+    if media_manifest:
+        raise MediaNotSupportedPhase0Error("Phase 0은 미디어 입력을 지원하지 않습니다")
+
+    draft = (await db.execute(
+        select(SitePostDraft)
+        .where(
+            SitePostDraft.org_id == org_id, SitePostDraft.work_item_id == work_item_id,
+            SitePostDraft.slug == slug,
+        )
+        .with_for_update()
+    )).scalar_one_or_none()
+    if draft is None:
+        draft = SitePostDraft(id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, slug=slug)
+        db.add(draft)
+        await db.flush()
+        next_version = 1
+    else:
+        next_version = (await db.execute(
+            select(func.coalesce(func.max(SitePostVersion.version), 0)).where(
+                SitePostVersion.draft_id == draft.id
+            )
+        )).scalar_one() + 1
+
+    version = SitePostVersion(
+        id=uuid.uuid4(), draft_id=draft.id, version=next_version,
+        title=title, lang=lang, summary=summary, tags=tags, body_md=body_md,
+        body_sha256=compute_body_sha256(title=title, lang=lang, summary=summary, tags=tags, body_md=body_md),
+        author_member_id=author_member_id, author_kind=author_kind,
+    )
+    db.add(version)
+    await db.commit()
+    await db.refresh(version)
+    return version
+
+
+async def get_site_post_draft(db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID) -> SitePostDraft | None:
+    return (await db.execute(
+        select(SitePostDraft).where(SitePostDraft.id == draft_id, SitePostDraft.org_id == org_id)
+    )).scalar_one_or_none()
+
+
+async def list_site_post_draft_versions(db: AsyncSession, *, draft_id: uuid.UUID) -> list[SitePostVersion]:
+    stmt = (
+        select(SitePostVersion)
+        .where(SitePostVersion.draft_id == draft_id)
+        .order_by(SitePostVersion.version.asc())
     )
     return list((await db.execute(stmt)).scalars().all())

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.models.gate import Gate
 from app.models.site_post import SitePost
@@ -246,3 +247,36 @@ async def list_site_post_draft_versions(db: AsyncSession, *, draft_id: uuid.UUID
         .order_by(SitePostVersion.version.asc())
     )
     return list((await db.execute(stmt)).scalars().all())
+
+
+async def list_site_post_drafts(
+    db: AsyncSession, *, org_id: uuid.UUID, limit: int = 50, offset: int = 0,
+) -> list[tuple[SitePostDraft, SitePostVersion]]:
+    """story #3365 후속(S4 계약 갭, 페드루 PO 확定 2026-09-03) — 조직 스코프 초안 목록. S4
+    화면이 열릴 때 draft_id를 미리 알 방법이 없어 만든 자리 — 항목마다 최신 버전(title·lang·
+    version·author_kind)을 붙인다. "최신"은 draft.updated_at이 아니라 최신 버전의
+    created_at으로 정렬한다 — draft 행 자체는 버전 추가 시 갱신되지 않아(SSOT는 버전 쪽)
+    이 값이 실제 최근 활동을 반영한다. 게이트 상태·봉인 필드는 S2 몫 — 여기서 지어내지 않는다."""
+    latest_version_ids = (
+        select(
+            SitePostVersion.draft_id,
+            func.max(SitePostVersion.version).label("max_version"),
+        )
+        .group_by(SitePostVersion.draft_id)
+        .subquery()
+    )
+    latest = aliased(SitePostVersion)
+    stmt = (
+        select(SitePostDraft, latest)
+        .join(latest_version_ids, latest_version_ids.c.draft_id == SitePostDraft.id)
+        .join(
+            latest,
+            (latest.draft_id == latest_version_ids.c.draft_id)
+            & (latest.version == latest_version_ids.c.max_version),
+        )
+        .where(SitePostDraft.org_id == org_id)
+        .order_by(latest.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    return [(row[0], row[1]) for row in (await db.execute(stmt)).all()]

--- a/backend/tests/test_3360_site_posts.py
+++ b/backend/tests/test_3360_site_posts.py
@@ -7,7 +7,14 @@
 res.ok만 보고 본문은 안 읽음) — 앱 전역 HTTPException 봉투 그대로 검증한다.
 
 seed 하네스는 test_3354_pageview_counter.py 패턴(httpx ASGITransport+override_db_and_read+
-claims에 org_id 직접 주입) 재사용."""
+claims에 org_id 직접 주입) 재사용.
+
+⚠️story #3365(Phase0 S1, 2026-09-03) 회귀 — 이 POST 엔드포인트는 이제 휴먼 전용이다(agent
+호출은 403 SITE_POST_PUBLISH_HUMAN_ONLY, 신규 test_3365_site_post_drafts.py 참고). 이 파일의
+기존 "성공 발행" 테스트들은 그 경계가 생기기 전 작성돼 caller로 agent를 썼던 것 — 이제
+휴먼(`_seed_human`)으로 바꿔 각 테스트가 원래 의도(게이트/slug/upsert/공개 조회 chokepoint)를
+계속 정확히 검증하게 한다(안 바꾸면 새 agent-차단이 먼저 걸려 원래 검증하려던 경로를 더 이상
+안 타면서도 같은 403으로 조용히 통과해버린다)."""
 from __future__ import annotations
 
 import os
@@ -79,6 +86,23 @@ async def _seed_agent(session, org_id, project_id, *, name="publisher"):
     session.add(m)
     await session.commit()
     return m.id
+
+
+async def _seed_human(session, org_id, *, role="member"):
+    """story #3365 — POST site-posts는 이제 휴먼 전용. 실제 JWT 휴먼과 동형인 User+OrgMember
+    조합(TeamMember 없음 → is_agent_caller()가 False로 판정)."""
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(
+        id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x",
+    )
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id
 
 
 async def _seed_story(session, org_id, project_id, *, title="1호 글"):
@@ -168,10 +192,10 @@ async def test_post_with_unapproved_gate_returns_403_and_creates_zero_rows():
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org(s)
-            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
             await _seed_gate(s, org_id, story_id, status="pending")
-        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
 
         async with _client_for(app) as client:
             r = await client.post(
@@ -188,8 +212,12 @@ async def test_post_with_unapproved_gate_returns_403_and_creates_zero_rows():
 
 
 @pytest.mark.anyio
-async def test_post_with_approved_gate_returns_201_and_public_api_reflects():
+async def test_agent_publish_returns_403_site_post_publish_human_only_even_with_approved_gate():
+    """story #3365(Phase0 S1) AC4 — 게이트가 approved여도 agent 호출은 공개를 못 만든다.
+    뮤테이션 대상: 이 체크를 제거하면 아래 assert가 201로 반드시 실패한다."""
     from app.main import app
+    from app.models.site_post import SitePost
+    from sqlalchemy import func, select
 
     engine, Session = await _session_factory()
     try:
@@ -198,8 +226,37 @@ async def test_post_with_approved_gate_returns_201_and_public_api_reflects():
             agent_id = await _seed_agent(s, org_id, project_id)
             story_id = await _seed_story(s, org_id, project_id)
             gate_id = await _seed_gate(s, org_id, story_id, status="approved")
-            public_key = await _seed_metering_key(s, org_id)
         _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts",
+                json=_publish_body(work_item_id=story_id, gate_id=gate_id),
+            )
+        assert r.status_code == 403, r.text
+        assert r.json()["error"]["code"] == "SITE_POST_PUBLISH_HUMAN_ONLY", r.text
+
+        async with Session() as s:
+            count = (await s.execute(select(func.count()).select_from(SitePost))).scalar_one()
+        assert count == 0, "agent 호출인데 공개 행이 생겼다(휴먼 전용 경계 회귀)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_post_with_approved_gate_returns_201_and_public_api_reflects():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            gate_id = await _seed_gate(s, org_id, story_id, status="approved")
+            public_key = await _seed_metering_key(s, org_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
 
         async with _client_for(app) as client:
             r = await client.post(
@@ -246,10 +303,10 @@ async def test_auto_passed_gate_also_counts_as_approved():
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org(s)
-            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
             await _seed_gate(s, org_id, story_id, status="auto_passed")
-        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
 
         async with _client_for(app) as client:
             r = await client.post(
@@ -269,10 +326,10 @@ async def test_invalid_slug_rejected_422():
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org(s)
-            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
             await _seed_gate(s, org_id, story_id, status="approved")
-        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
 
         async with _client_for(app) as client:
             r = await client.post(
@@ -295,10 +352,10 @@ async def test_republish_same_org_lang_slug_upserts_single_row():
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org(s)
-            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
             gate_id = await _seed_gate(s, org_id, story_id, status="approved")
-        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
 
         async with _client_for(app) as client:
             await client.post(
@@ -392,11 +449,11 @@ async def test_unpublished_post_excluded_from_public_reads():
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org(s)
-            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
             gate_id = await _seed_gate(s, org_id, story_id, status="approved")
             public_key = await _seed_metering_key(s, org_id)
-        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
 
         async with _client_for(app) as client:
             await client.post(

--- a/backend/tests/test_3365_external_publish_gate_human_only.py
+++ b/backend/tests/test_3365_external_publish_gate_human_only.py
@@ -1,0 +1,48 @@
+"""story #3365(Phase0 S1) AC4(승인 절반) — 페드루 PO 확定(2026-09-03): «승인 API» 403은
+신규 엔드포인트·신규 코드가 아니라 기존 gates.py `transition_gate_endpoint`
+(`_authorize_gate_approve_equivalent`, `resolved.type != "human"` → 403)가 이미 전 gate_type에
+걸쳐 강제한다. 이 테스트는 그 기존 가드를 `external_publish` gate_type에 회귀로 고정한다
+(신규 동작 없음 — 기존 가드 재확인).
+
+real Postgres 불요 — test_rc1_body_trust_actor.py와 동형 mock 단위 테스트."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_agent_cannot_approve_external_publish_gate_existing_guard_pinned():
+    from fastapi import BackgroundTasks, HTTPException
+
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.services.member_resolver import ResolvedMember
+
+    agent = ResolvedMember(
+        id=uuid.uuid4(), user_id=None, name="담롱", type="agent", role="member", org_id=uuid.uuid4(),
+    )
+
+    class _FakeAuth:
+        user_id = str(uuid.uuid4())
+        claims: dict = {}
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=agent)):
+        with pytest.raises(HTTPException) as exc_info:
+            await transition_gate_endpoint(
+                id=uuid.uuid4(),
+                body=GateTransitionRequest(status="approved"),
+                background_tasks=BackgroundTasks(),
+                session=AsyncMock(),
+                org_id=agent.org_id,
+                auth=_FakeAuth(),
+            )
+    assert exc_info.value.status_code == 403
+    assert "에이전트 승인 불가" in str(exc_info.value.detail)

--- a/backend/tests/test_3365_site_post_drafts.py
+++ b/backend/tests/test_3365_site_post_drafts.py
@@ -274,3 +274,59 @@ async def test_unknown_draft_id_versions_returns_404():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_drafts_scoped_to_org_and_ordered_by_latest_activity():
+    """페드루 PO 후속 요청(2026-09-03, S4 계약 갭) — 조직 스코프 목록 엔드포인트. 타 org 초안이
+    새어 들어오면 안 되고(cross-org 격리), 최근에 버전이 붙은 초안이 먼저 와야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a_id, project_a_id = await _seed_org(s, slug="org-a")
+            org_b_id, project_b_id = await _seed_org(s, slug="org-b")
+            agent_a_id = await _seed_agent(s, org_a_id, project_a_id)
+            agent_b_id = await _seed_agent(s, org_b_id, project_b_id)
+            story_a1 = await _seed_story(s, org_a_id, project_a_id, title="A-1호 글")
+            story_a2 = await _seed_story(s, org_a_id, project_a_id, title="A-2호 글")
+            story_b1 = await _seed_story(s, org_b_id, project_b_id, title="B-1호 글")
+
+        _setup_org_scoped_app(app, Session, org_a_id, user_id=agent_a_id)
+        async with _client_for(app) as client:
+            await client.post(
+                f"/api/v2/organizations/{org_a_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_a1, slug="a-one", title="A 글 1"),
+            )
+            r_first = await client.post(
+                f"/api/v2/organizations/{org_a_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_a2, slug="a-two", title="A 글 2"),
+            )
+            # a-one에 버전을 하나 더 붙여 "최근 활동"을 a-one 쪽으로 옮긴다.
+            await client.post(
+                f"/api/v2/organizations/{org_a_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_a1, slug="a-one", title="A 글 1(개정)"),
+            )
+        assert r_first.status_code == 201, r_first.text
+
+        _setup_org_scoped_app(app, Session, org_b_id, user_id=agent_b_id)
+        async with _client_for(app) as client:
+            await client.post(
+                f"/api/v2/organizations/{org_b_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_b1, slug="b-one", title="B 글 1"),
+            )
+
+        _setup_org_scoped_app(app, Session, org_a_id, user_id=agent_a_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_a_id}/site-posts/drafts")
+        assert r.status_code == 200, r.text
+        items = r.json()
+        assert {item["slug"] for item in items} == {"a-one", "a-two"}, "타 org(org-b) 초안이 새어 들어왔다"
+        assert items[0]["slug"] == "a-one", "최근 버전이 붙은 초안이 먼저 와야 한다(updated_at desc)"
+        assert items[0]["title"] == "A 글 1(개정)"
+        assert items[0]["current_version"] == 2
+        assert items[0]["latest_author_kind"] == "agent"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3365_site_post_drafts.py
+++ b/backend/tests/test_3365_site_post_drafts.py
@@ -1,0 +1,276 @@
+"""story #3365(Phase0 S1·마케팅 운영 블루프린트 v3, 선생님 확定 2026-09-03) — 고객 에이전트가
+공개 권한 없이 블로그 초안·불변 버전을 등록한다.
+
+AC 매핑:
+- AC1: 고객 에이전트가 초안 생성 API에 제출 → 201, 공개 `SitePost` 행 0.
+- AC2: 원작성 주체 서버 판정(agent) — body엔 author 필드 자체가 없어 위조 표면이 없다.
+- AC3: 동일 초안을 휴먼이 수정 → 새 불변 버전(기존 버전 보존).
+- AC4(공개 절반): 에이전트가 공개 API(POST /site-posts)를 부르면 403 SITE_POST_PUBLISH_HUMAN_ONLY
+  — 테스트는 test_3360_site_posts.py에 있다(그 파일의 사이드카).
+- AC5: media_manifest 비어있지 않으면 422 MEDIA_NOT_SUPPORTED_PHASE0.
+- AC6: 버전 이력 조회 시 에이전트 원안·휴먼 개정본이 별도 버전으로 관측.
+  AC4(승인 절반)의 기존 가드 회귀 고정은 test_3365_external_publish_gate_human_only.py(real
+  Postgres 불요 — mock 단위 테스트라 이 파일과 분리했다).
+
+뮤테이션 1건(스토리 본문 명시) — 에이전트 공개 차단 조건 제거는 test_3360_site_posts.py의
+전용 테스트가 검증한다(자체검증 완료).
+
+seed 하네스는 test_3360_site_posts.py 패턴 그대로 재사용."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Draft Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="담롱"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_human(session, org_id, *, role="member"):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="2호 글"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _draft_body(*, work_item_id, slug="2ho-blog", lang="ko", title="2호 글", media_manifest=None):
+    return {
+        "work_item_id": str(work_item_id), "slug": slug, "lang": lang, "title": title,
+        "summary": "요약입니다", "tags": ["ai"], "body_md": "# 제목\n\n본문입니다.",
+        "media_manifest": media_manifest if media_manifest is not None else [],
+    }
+
+
+@pytest.mark.anyio
+async def test_agent_creates_draft_returns_201_and_zero_public_rows():
+    from app.main import app
+    from app.models.site_post import SitePost
+    from sqlalchemy import func, select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts", json=_draft_body(work_item_id=story_id),
+            )
+        assert r.status_code == 201, r.text
+        payload = r.json()
+        assert payload["version"] == 1
+        assert uuid.UUID(payload["draft_id"])
+        assert uuid.UUID(payload["version_id"])
+
+        async with Session() as s:
+            from app.models.site_post_version import SitePostVersion
+            version = (await s.execute(
+                select(SitePostVersion).where(SitePostVersion.id == uuid.UUID(payload["version_id"]))
+            )).scalar_one()
+            public_count = (await s.execute(select(func.count()).select_from(SitePost))).scalar_one()
+        assert version.author_kind == "agent"
+        assert version.author_member_id == agent_id
+        assert public_count == 0, "초안 제출만으로 공개 SitePost 행이 생겼다(경계 회귀)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_edit_creates_new_version_and_preserves_original():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r1 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, title="에이전트 원안"),
+            )
+        assert r1.status_code == 201, r1.text
+        draft_id = r1.json()["draft_id"]
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r2 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, title="휴먼 개정판"),
+            )
+        assert r2.status_code == 201, r2.text
+        assert r2.json()["version"] == 2
+        assert r2.json()["draft_id"] == draft_id, "같은 (org,work_item,slug)인데 새 draft가 생겼다"
+
+        async with _client_for(app) as client:
+            r_hist = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/versions")
+        assert r_hist.status_code == 200, r_hist.text
+        versions = r_hist.json()
+        assert len(versions) == 2
+        assert versions[0]["version"] == 1
+        assert versions[0]["title"] == "에이전트 원안"
+        assert versions[0]["author_kind"] == "agent"
+        assert versions[1]["version"] == 2
+        assert versions[1]["title"] == "휴먼 개정판"
+        assert versions[1]["author_kind"] == "human"
+        assert versions[0]["body_sha256"] != versions[1]["body_sha256"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonempty_media_manifest_returns_422_media_not_supported_phase0():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, media_manifest=[{"url": "https://x/y.png"}]),
+            )
+        assert r.status_code == 422, r.text
+        assert r.json()["error"]["code"] == "MEDIA_NOT_SUPPORTED_PHASE0", r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unknown_draft_id_versions_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts/{uuid.uuid4()}/versions")
+        assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
[SID:3365]

## 요약
Phase0·마케팅운영 블루프린트 v3 S1(선생님 승인 2026-09-03) — 기존 `POST /site-posts`가
게이트만 승인되면 에이전트 키도 호출해 곧바로 공개할 수 있어, 초안 제출자(고객 에이전트)와
발행자(휴먼)의 경계가 없었다. 이 PR은 그 경계를 서버에 만든다.

- 신규 `site_post_drafts`/`site_post_versions` 원장(마이그레이션 0308) — 고객 에이전트가
  `POST /api/v2/organizations/{org}/site-posts/drafts`로 제목·slug·본문·work_item을 제출하면
  `201`과 `draft_id`/`version_id`/`version`을 반환하고 공개 `SitePost` 행은 만들지 않는다.
  작성 주체(`author_kind`/`author_member_id`)는 인증 컨텍스트에서 서버가 판정 — body에
  author 필드 자체가 없어 위조 표면이 없다.
- 동일 draft를 다시 제출(휴먼 수정 포함)하면 기존 버전을 덮지 않고 새 불변 버전을 추가 —
  `GET .../drafts/{id}/versions`로 에이전트 원안·휴먼 개정본을 별도 버전으로 조회 가능.
- (후속 커밋) `GET /site-posts/drafts` — 조직 스코프 초안 목록(S4 화면이 draft_id를 미리 몰라도
  열 수 있게 함, 페드루 PO 확定 2026-09-03). 항목마다 최신 버전을 붙이고 최근 활동순 정렬.
- 비어있지 않은 `media_manifest`는 `422 MEDIA_NOT_SUPPORTED_PHASE0`(Phase 0엔 미디어 없음).
- 기존 공개 API(`POST /site-posts`)에 휴먼 전용 가드 추가 — 에이전트 호출은 게이트 승인
  여부와 무관하게 `403 SITE_POST_PUBLISH_HUMAN_ONLY`.
- AC4 승인 축은 페드루 PO 확定대로 신규 코드 없음 — 기존 `gates.py` `transition_gate_endpoint`의
  human-only 가드가 이미 전 gate_type에 걸려 있어, `external_publish`에 대한 회귀 테스트만
  추가해 고정(`test_3365_external_publish_gate_human_only.py`).
- 필드명(`version`/`body_sha256`/`author_kind`/`author_member_id`/`source_story_id`)은 S4
  화면 설계(유나·문서 62fc03ee §4-3, 페드루 확定)와 미리 맞췄다.

## API 계약

⚠️휴먼 개정본은 **`draft_id`를 body에 싣지 않는다** — 서버가 `(org_id, work_item_id, slug)`로
기존 draft를 찾아 새 버전을 얹는다(같은 엔드포인트·같은 요청 모양, `work_item_id`+`slug`만
최초 제출과 동일하면 자동으로 upsert). S4가 "버전 추가"를 별도 호출로 구현하지 않아도 된다.

### 1) 신규 초안 생성(고객 에이전트, agent API key)
```
POST /api/v2/organizations/{org_id}/site-posts/drafts
```
```json
{
  "work_item_id": "3f9a1c2e-...",
  "slug": "2ho-blog",
  "lang": "ko",
  "title": "2호 글",
  "summary": "요약입니다",
  "tags": ["ai", "product"],
  "body_md": "# 제목\n\n본문입니다.",
  "media_manifest": []
}
```
→ `201`
```json
{"draft_id": "b1e2...", "version_id": "c3f4...", "version": 1}
```
DB: `SitePostVersion.author_kind="agent"`, `author_member_id`=인증 캐릭터의 member id(body 무관).
공개 `SitePost` 행 0.

### 2) 조직 스코프 초안 목록(S4 계약 갭, 후속 커밋·페드루 PO 확定)
```
GET /api/v2/organizations/{org_id}/site-posts/drafts?limit=50&offset=0
```
→ `200` — 항목마다 최신 버전(title/lang/version/author_kind)을 붙인다. 정렬은 `updated_at`
desc(최신 버전의 `created_at`) — draft 행 자체의 `updated_at`이 아니다(버전 추가 시 draft 행은
갱신하지 않는다·SSOT는 버전 쪽). 게이트 상태·봉인 필드는 S2가 나중에 붙인다.
```json
[
  {
    "draft_id": "b1e2...", "work_item_id": "3f9a1c2e-...", "slug": "2ho-blog",
    "lang": "ko", "title": "2호 글(휴먼 개정)", "current_version": 2,
    "latest_author_kind": "human", "updated_at": "2026-09-03T03:52:00+00:00"
  }
]
```
휴먼·에이전트 모두 읽기 가능(승인·발행 경계 밖) — 조직 멤버십만 확인.

### 3) 같은 초안에 버전 추가(휴먼 개정 — 동일 엔드포인트, `work_item_id`+`slug` 동일)
```
POST /api/v2/organizations/{org_id}/site-posts/drafts
```
```json
{
  "work_item_id": "3f9a1c2e-...",
  "slug": "2ho-blog",
  "lang": "ko",
  "title": "2호 글(휴먼 개정)",
  "summary": "수정된 요약",
  "tags": ["ai", "product"],
  "body_md": "# 제목\n\n수정된 본문입니다.",
  "media_manifest": []
}
```
→ `201`
```json
{"draft_id": "b1e2...", "version_id": "d5a6...", "version": 2}
```
`draft_id`는 1)과 동일 — 새 draft가 생기지 않는다. 버전 1은 그대로 보존.

### 4) 버전 이력 조회
```
GET /api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/versions
```
→ `200`
```json
[
  {
    "version_id": "c3f4...", "version": 1, "slug": "2ho-blog",
    "source_story_id": "3f9a1c2e-...", "title": "2호 글", "lang": "ko",
    "summary": "요약입니다", "tags": ["ai", "product"], "body_md": "# 제목\n\n본문입니다.",
    "body_sha256": "…", "author_member_id": "…", "author_kind": "agent",
    "created_at": "2026-09-03T03:50:00+00:00"
  },
  {
    "version_id": "d5a6...", "version": 2, "slug": "2ho-blog",
    "source_story_id": "3f9a1c2e-...", "title": "2호 글(휴먼 개정)", "lang": "ko",
    "summary": "수정된 요약", "tags": ["ai", "product"], "body_md": "# 제목\n\n수정된 본문입니다.",
    "body_sha256": "…", "author_member_id": "…", "author_kind": "human",
    "created_at": "2026-09-03T03:52:00+00:00"
  }
]
```

### 5) 에이전트가 기존 공개 API를 부르면(게이트 approved여도)
```
POST /api/v2/organizations/{org_id}/site-posts
```
→ `403`
```json
{"data": null, "error": {"code": "SITE_POST_PUBLISH_HUMAN_ONLY", "message": "글 공개는 휴먼 멤버만 가능합니다 (에이전트는 초안만 제출)."}, "meta": null}
```

### 6) 미디어 manifest가 비어있지 않으면
→ `422`
```json
{"data": null, "error": {"code": "MEDIA_NOT_SUPPORTED_PHASE0", "message": "Phase 0은 미디어 입력을 지원하지 않습니다"}, "meta": null}
```

## 뮤테이션 자체검증
공개 API의 에이전트 차단 조건을 임시 제거 → `test_agent_publish_returns_403_site_post_publish_human_only_even_with_approved_gate`가 403 대신 201을 받아 실패함을 확인 → 원복.

## 테스트
- `tests/test_3365_site_post_drafts.py`(신규, realdb 5건 — cross-org 격리·최근순 정렬 포함)
- `tests/test_3365_external_publish_gate_human_only.py`(신규, mock 1건 — AC4 승인 축 회귀 고정)
- `tests/test_3360_site_posts.py`(caller를 human으로 교정 + agent 차단 신규 1건, realdb 6건)
- `tests/test_f84227b5_agent_org_header_membership.py`(회귀 확인, realdb 2건)
- `tests/test_rc1_body_trust_actor.py`(회귀 확인, mock 5건)
- 마이그레이션 0308 upgrade/downgrade/re-upgrade 로컬 실PG 왕복 확인.

## 범위 밖
문안 생성·리서치·자동교정·미디어 저장·에셋 계보·채널 변주·캘린더·예약(스토리 명시).
승인 봉인(S2)·서버 공개(S3)는 후속 스토리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm
