### PR TITLE
[SID:3367] external_publish 승인이 본 버전을 봉인하고 수정 즉시 재승인 상태로 바꾼다

### DIFF
--- a/backend/alembic/versions/0310_gate_site_post_seal.py
+++ b/backend/alembic/versions/0310_gate_site_post_seal.py
@@ -1,0 +1,39 @@
+"""story #3365(Phase0 S2·마케팅 운영 블루프린트 v3, 선생님 확定 2026-09-03) — gate에
+external_publish 전용 sealing 컬럼 4종 신설. github_check_run_sha/approved_head_sha(merge
+gate)와 동형 축 — "이 승인이 귀속된 대상"을 상신 시점에 한 번 기록하고 이후 비교만 한다.
+전부 nullable/기본값 안전 — 기존 gate_type은 전혀 안 건드린다(additive).
+
+번호 의존성 — story #3365 S1(PR#3731, 머지 c12c03f0e→647b8fe43)이 이미 0308을 썼고, PR#3732
+(미르코, S5)가 developing 中 같은 0308 위에서 시작해 이 PR 머지 뒤 0309로 리베이스한다(페드루
+PO 확定 2026-09-03). 이 revision은 그 자리를 피해 0310부터 잡는다.
+
+Revision ID: 0310
+Revises: 0308
+Create Date: 2026-09-03
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0310"
+down_revision = "0308"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("gate", sa.Column("sealed_content_version", sa.Integer(), nullable=True))
+    op.add_column("gate", sa.Column("sealed_content_sha256", sa.Text(), nullable=True))
+    op.add_column("gate", sa.Column("sealed_content_body", sa.Text(), nullable=True))
+    op.add_column(
+        "gate",
+        sa.Column("reapproval_required", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("gate", "reapproval_required")
+    op.drop_column("gate", "sealed_content_body")
+    op.drop_column("gate", "sealed_content_sha256")
+    op.drop_column("gate", "sealed_content_version")

--- a/backend/alembic/versions/0310_gate_site_post_seal.py
+++ b/backend/alembic/versions/0310_gate_site_post_seal.py
@@ -4,11 +4,12 @@ gate)와 동형 축 — "이 승인이 귀속된 대상"을 상신 시점에 한
 전부 nullable/기본값 안전 — 기존 gate_type은 전혀 안 건드린다(additive).
 
 번호 의존성 — story #3365 S1(PR#3731, 머지 c12c03f0e→647b8fe43)이 이미 0308을 썼고, PR#3732
-(미르코, S5)가 developing 中 같은 0308 위에서 시작해 이 PR 머지 뒤 0309로 리베이스한다(페드루
-PO 확定 2026-09-03). 이 revision은 그 자리를 피해 0310부터 잡는다.
+(미르코, S5, story #3370)가 0309로 먼저 develop에 머지됐다(2e5a4b515, 페드루 PO 확定
+2026-09-03 06:39Z). 이 revision은 그 위(0310)에 그대로 얹는다 — down_revision을 0308에서
+0309로 rebase 후 갱신.
 
 Revision ID: 0310
-Revises: 0308
+Revises: 0309
 Create Date: 2026-09-03
 """
 from __future__ import annotations
@@ -17,7 +18,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "0310"
-down_revision = "0308"
+down_revision = "0309"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -118,6 +118,17 @@ class Gate(Base):
     # 단조증가) 워터마크. reopen_gate_if_new_sha가 이걸로 stale/순서역전 웹훅 배달을
     # 걸러 이미 최신 SHA로 승인된 게이트를 옛 배달로 부당 재-pending시키지 않는다.
     pr_head_observed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # story #3365(Phase0 S2, 마케팅운영) — external_publish 전용 sealing. approved_head_sha
+    # (위, merge gate)와 동형 축: "이 승인이 귀속된 대상"을 서버가 상신 시점에 한 번 기록하고
+    # 그 뒤로는 **비교만** 한다(어떤 갱신 경로도 열지 않는다 — story 본문 «봉인 값 불변» AC).
+    # 최신 site_post_versions 행과 다르면(즉 승인 뒤 수정) 공개 서비스가 409로 거부하고,
+    # 그 새 버전을 만든 트랜잭션이 이 gate를 pending으로 되돌린다(site_posts.py 참고).
+    sealed_content_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sealed_content_sha256: Mapped[str | None] = mapped_column(Text, nullable=True)
+    sealed_content_body: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # 승인 후 수정으로 시스템이 되돌린 pending인지(사람이 처음 상신한 pending과 구분 — S4가
+    # "재승인 필요" 배지를 그릴 신호) — 새 명시 submit()이 재봉인하면 False로 복귀한다.
+    reapproval_required: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -216,6 +216,14 @@ class GateResponse(BaseModel):
     # 등 타 엔드포인트는 PR 링크 N+1 조회 비용 때문에 스코프 밖, risk_grade/can_approve와 동일
     # 선례 — Gate ORM에 이 속성이 없어 from_attributes 기본값으로 조용히 통과).
     github_check_enforced: bool | None = None
+    # story #3367(Phase0 S2, 페드루 PO 리뷰 2026-09-03 05:59Z) — external_publish 전용 sealing.
+    # S4 승인 카드(본문 전문·버전·해시)·재승인 배지(봉인 해시 vs 현재 해시 파생)가 이걸 읽는다.
+    # github_check_run_sha/approved_head_sha와 동일 선례 — Gate ORM 컬럼명과 일치라
+    # from_attributes로 자동 채워짐(다른 gate_type은 전부 None, additive·하위호환).
+    sealed_content_version: int | None = None
+    sealed_content_sha256: str | None = None
+    sealed_content_body: str | None = None
+    reapproval_required: bool = False
     created_at: datetime
     updated_at: datetime
 
@@ -1486,6 +1494,21 @@ async def transition_gate_endpoint(
                 "current_status": _gate.status,
                 "resolver_id": str(_gate.resolver_id) if _gate.resolver_id else None,
                 "resolved_at": _gate.resolved_at.isoformat() if _gate.resolved_at else None,
+            },
+        )
+    # story #3365(Phase0 S2, 페드루 PO 재정정 2026-09-03 06:06Z) — external_publish 전용 막다른
+    # 길 차단. 승인 뒤 편집으로 pending 재오픈된 게이트는 sealed_content_*가 옛 버전 그대로다
+    # (site_posts.py `_reseal_gate_on_new_version` 참고 — 승인 기록을 조용히 덮지 않는다). 이
+    # 옛 봉인을 그대로 승인하면 site_posts.py의 409 비교 기준점만 갱신될 뿐 실제로는 아무 새
+    # 내용도 승인받지 못한 채 "승인됨"으로 보이는 막다른 길이 열린다 — 재봉인(submit() 재호출)
+    # 없이는 approve 전이 자체를 막는다. reapproval_required는 다른 gate_type엔 항상 False라
+    # 이 체크는 site-post 게이트 밖에서 무해(additive).
+    if body.status == "approved" and _gate is not None and _gate.reapproval_required:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "SITE_POST_RESUBMIT_REQUIRED",
+                "message": "승인 뒤 내용이 바뀌었습니다. 재상신(submit)한 뒤 다시 승인해주세요.",
             },
         )
     # story #2027(까심 QA 적출): 고위험(risk_grade=high) 게이트의 approved 전이는 사유(note) 서버측

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1501,9 +1501,17 @@ async def transition_gate_endpoint(
     # (site_posts.py `_reseal_gate_on_new_version` 참고 — 승인 기록을 조용히 덮지 않는다). 이
     # 옛 봉인을 그대로 승인하면 site_posts.py의 409 비교 기준점만 갱신될 뿐 실제로는 아무 새
     # 내용도 승인받지 못한 채 "승인됨"으로 보이는 막다른 길이 열린다 — 재봉인(submit() 재호출)
-    # 없이는 approve 전이 자체를 막는다. reapproval_required는 다른 gate_type엔 항상 False라
-    # 이 체크는 site-post 게이트 밖에서 무해(additive).
-    if body.status == "approved" and _gate is not None and _gate.reapproval_required:
+    # 없이는 approve 전이 자체를 막는다.
+    # ⚠️페드루 PO 실측(2026-09-03 07:11Z, CI shard 3 실패) — gate_type 스코프 없이
+    # `_gate.reapproval_required`만 보면 bare MagicMock 기반 테스트(예:
+    # test_edg_s23_hypothesis_overlay.py — gate_type="merge"만 명시하고 이 필드는 안 건드림)의
+    # auto-attribute가 항상 truthy MagicMock이라 site-post와 무관한 gate_type까지 이 가드에
+    # 걸린다(#2975/#2982/#3319와 동형 MagicMock 함정 재발). gate_type=="external_publish"로
+    # 명시 스코프해 그 클래스의 오탐을 원천 차단한다 — 다른 gate_type은 이 필드를 절대 안 본다.
+    if (
+        body.status == "approved" and _gate is not None
+        and _gate.gate_type == "external_publish" and _gate.reapproval_required
+    ):
         raise HTTPException(
             status_code=409,
             detail={

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -19,8 +19,10 @@ from app.services.site_posts import (
     ExternalPublishGateNotApprovedError,
     InvalidSitePostInputError,
     MediaNotSupportedPhase0Error,
+    SitePostApproverRoleMissingError,
     SitePostDraftNotFoundError,
     SitePostReapprovalRequiredError,
+    SitePostSealMissingError,
     SitePostVersionNotFoundError,
     create_site_post_draft_version,
     get_site_post_draft,
@@ -149,6 +151,11 @@ async def post_site_post(
         raise HTTPException(
             status_code=409,
             detail={"code": "SITE_POST_REAPPROVAL_REQUIRED", "message": str(exc)},
+        ) from exc
+    except SitePostSealMissingError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "SITE_POST_SEAL_MISSING", "message": str(exc)},
         ) from exc
 
     return SitePostResponse(
@@ -281,6 +288,11 @@ async def submit_site_post_draft_endpoint(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except SitePostVersionNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except SitePostApproverRoleMissingError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "SITE_POST_APPROVER_ROLE_MISSING", "message": str(exc)},
+        ) from exc
 
     return SubmitSitePostDraftResponse(
         gate_id=gate.id, version_id=version_id, content_sha256=gate.sealed_content_sha256,

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -19,12 +19,16 @@ from app.services.site_posts import (
     ExternalPublishGateNotApprovedError,
     InvalidSitePostInputError,
     MediaNotSupportedPhase0Error,
+    SitePostDraftNotFoundError,
+    SitePostReapprovalRequiredError,
+    SitePostVersionNotFoundError,
     create_site_post_draft_version,
     get_site_post_draft,
     is_agent_caller,
     list_site_post_draft_versions,
     list_site_post_drafts,
     publish_site_post,
+    submit_site_post_draft,
 )
 
 router = APIRouter(prefix="/api/v2/organizations", tags=["site-posts"])
@@ -45,6 +49,8 @@ class SitePostDraftVersionResponse(BaseModel):
     draft_id: uuid.UUID
     version_id: uuid.UUID
     version: int
+    author_kind: str
+    body_sha256: str
 
 
 class SitePostDraftListItem(BaseModel):
@@ -55,7 +61,19 @@ class SitePostDraftListItem(BaseModel):
     title: str
     current_version: int
     latest_author_kind: str
+    origin_author_kind: str
     updated_at: str
+
+
+class SubmitSitePostDraftRequest(BaseModel):
+    version_id: uuid.UUID | None = None
+
+
+class SubmitSitePostDraftResponse(BaseModel):
+    gate_id: uuid.UUID
+    version_id: uuid.UUID
+    content_sha256: str
+    status: str
 
 
 class SitePostVersionHistoryItem(BaseModel):
@@ -127,6 +145,11 @@ async def post_site_post(
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except ExternalPublishGateNotApprovedError as exc:
         raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except SitePostReapprovalRequiredError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "SITE_POST_REAPPROVAL_REQUIRED", "message": str(exc)},
+        ) from exc
 
     return SitePostResponse(
         id=post.id, slug=post.slug, title=post.title, lang=post.lang,
@@ -169,6 +192,7 @@ async def post_site_post_draft_version(
 
     return SitePostDraftVersionResponse(
         draft_id=version.draft_id, version_id=version.id, version=version.version,
+        author_kind=version.author_kind, body_sha256=version.body_sha256,
     )
 
 
@@ -191,10 +215,11 @@ async def list_site_post_drafts_endpoint(
     return [
         SitePostDraftListItem(
             draft_id=draft.id, work_item_id=draft.work_item_id, slug=draft.slug,
-            lang=version.lang, title=version.title, current_version=version.version,
-            latest_author_kind=version.author_kind, updated_at=version.created_at.isoformat(),
+            lang=latest.lang, title=latest.title, current_version=latest.version,
+            latest_author_kind=latest.author_kind, origin_author_kind=origin.author_kind,
+            updated_at=latest.created_at.isoformat(),
         )
-        for draft, version in rows
+        for draft, latest, origin in rows
     ]
 
 
@@ -227,3 +252,37 @@ async def list_site_post_draft_version_history(
         )
         for v in versions
     ]
+
+
+@router.post(
+    "/{org_id}/site-posts/drafts/{draft_id}/submit", response_model=SubmitSitePostDraftResponse,
+)
+async def submit_site_post_draft_endpoint(
+    org_id: uuid.UUID,
+    draft_id: uuid.UUID,
+    body: SubmitSitePostDraftRequest,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> SubmitSitePostDraftResponse:
+    """story #3365(Phase0 S2) — 초안 버전을 external_publish 게이트에 상신(PO 계약 확定
+    2026-09-03 04:26Z). body.version_id 생략 시 최신 버전. 에이전트 키도 호출 가능 — 게이트
+    생성까지만 허용되고(AC2), external_publish는 항상 human-only 승인 대상(기존 gates.py
+    transition_gate_endpoint의 human-only 가드가 그대로 적용, 신규 코드 없음)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    try:
+        gate, version_id = await submit_site_post_draft(
+            db, org_id=org_id, draft_id=draft_id, version_id=body.version_id,
+            requester_member_id=uuid.UUID(auth.user_id),
+        )
+    except SitePostDraftNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except SitePostVersionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return SubmitSitePostDraftResponse(
+        gate_id=gate.id, version_id=version_id, content_sha256=gate.sealed_content_sha256,
+        status=gate.status,
+    )

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -16,7 +16,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from app.models.gate import Gate
+from app.models.gate import Gate, set_gate_status
 from app.models.site_post import SitePost
 from app.models.site_post_draft import SitePostDraft
 from app.models.site_post_version import SitePostVersion
@@ -49,6 +49,28 @@ class ExternalPublishGateNotApprovedError(Exception):
             else "이 work item에 승인된 external_publish 게이트가 없습니다"
         )
         super().__init__(detail)
+
+
+class SitePostReapprovalRequiredError(Exception):
+    """story #3365(Phase0 S2) AC6 — 승인된 버전(gate.sealed_content_sha256)과 지금 공개하려는
+    내용의 해시가 다르다. gate.sealed_content_sha256이 None(구식/미봉인 게이트)이면 이 검사
+    자체를 건너뛴다 — S1 이전에 만들어진 승인 게이트를 소급 차단하지 않는다."""
+
+    def __init__(self, *, gate_id: uuid.UUID):
+        self.gate_id = gate_id
+        super().__init__(f"승인된 버전과 현재 내용이 다릅니다(gate_id={gate_id}) — 재승인이 필요합니다")
+
+
+class SitePostDraftNotFoundError(Exception):
+    def __init__(self, draft_id: uuid.UUID):
+        self.draft_id = draft_id
+        super().__init__(f"draft를 찾을 수 없습니다: {draft_id}")
+
+
+class SitePostVersionNotFoundError(Exception):
+    def __init__(self, version_id: uuid.UUID | None):
+        self.version_id = version_id
+        super().__init__(f"버전을 찾을 수 없습니다: {version_id}")
 
 
 def _validate_slug(slug: str) -> None:
@@ -115,6 +137,13 @@ async def publish_site_post(
     _validate_lang(lang)
     gate = await _resolve_approved_gate(db, org_id=org_id, work_item_id=work_item_id, gate_id=gate_id)
 
+    # story #3365(Phase0 S2) AC6 — 승인 뒤 본문이 바뀌었으면 공개하지 않는다. 뮤테이션 대상:
+    # 이 비교를 제거하면 승인 후 바뀐 본문이 그대로 공개돼 회귀 테스트가 반드시 실패해야 한다.
+    if gate.sealed_content_sha256 is not None:
+        current_hash = compute_body_sha256(title=title, lang=lang, summary=summary, tags=tags, body_md=body_md)
+        if current_hash != gate.sealed_content_sha256:
+            raise SitePostReapprovalRequiredError(gate_id=gate.id)
+
     now = datetime.now(timezone.utc)
     stmt = pg_insert(SitePost).values(
         id=uuid.uuid4(), org_id=org_id, lang=lang, slug=slug, title=title, summary=summary,
@@ -170,13 +199,19 @@ async def is_agent_caller(db: AsyncSession, *, org_id: uuid.UUID, member_id: uui
 
 
 def compute_body_sha256(*, title: str, lang: str, summary: str, tags: list, body_md: str) -> str:
-    """canonical payload hash — S2가 승인 대상 버전을 봉인할 때(gate neutral_facts) 재사용할
-    같은 계산(페드루 PO 확定, 문서 62fc03ee §4-3: "content_sha256"이 이 값 그대로)."""
+    """canonical payload hash — S2가 승인 대상 버전을 봉인할 때(gate.sealed_content_sha256)
+    재사용할 같은 계산(페드루 PO 확定, 문서 62fc03ee §4-3: "content_sha256"이 이 값 그대로)."""
     canonical = json.dumps(
         {"title": title, "lang": lang, "summary": summary, "tags": tags, "body_md": body_md},
         sort_keys=True, ensure_ascii=False, separators=(",", ":"),
     )
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# story #3365(Phase0 S2) — Phase 0엔 미디어가 없어(S1) manifest는 항상 빈 배열 → 이 해시는
+# 상수. AC1이 "빈 media manifest hash"를 봉인 값으로 명시해서 지어내지 않고 실제로 계산해 둔다.
+_EMPTY_MEDIA_MANIFEST_HASH = hashlib.sha256(json.dumps([], separators=(",", ":")).encode("utf-8")).hexdigest()
+_SITE_POST_DESTINATION = "hosted_site"
 
 
 async def create_site_post_draft_version(
@@ -229,9 +264,37 @@ async def create_site_post_draft_version(
         author_member_id=author_member_id, author_kind=author_kind,
     )
     db.add(version)
+    await db.flush()
+
+    # story #3365(Phase0 S2) AC4·AC5 — 이 새 버전이 이미 approved된 external_publish 게이트를
+    # 무효화한다면(승인 후 수정), 그 게이트를 같은 트랜잭션 안에서 원자적으로 pending으로
+    # 되돌린다 — 버전은 새로 생겼는데 게이트는 옛 승인 그대로인 상태가 존재하면 안 된다(AC5).
+    # sealed_content_*는 여기서 절대 안 건드린다 — publish_site_post의 409 비교 anchor로
+    # 그대로 남아야 "봉인 값 불변" 요건이 성립한다.
+    await _reopen_approved_gate_after_edit(db, org_id=org_id, work_item_id=work_item_id)
+
     await db.commit()
     await db.refresh(version)
     return version
+
+
+async def _reopen_approved_gate_after_edit(db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID) -> None:
+    gate = (await db.execute(
+        select(Gate)
+        .where(
+            Gate.org_id == org_id, Gate.work_item_id == work_item_id, Gate.gate_type == "external_publish",
+            Gate.status == "approved",
+        )
+        .with_for_update()
+    )).scalar_one_or_none()
+    if gate is None:
+        return
+    set_gate_status(gate, "pending", now=datetime.now(timezone.utc))
+    gate.requires_human = True
+    gate.resolver_id = None
+    gate.resolution_note = None
+    gate.resolved_at = None
+    gate.reapproval_required = True
 
 
 async def get_site_post_draft(db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID) -> SitePostDraft | None:
@@ -251,12 +314,16 @@ async def list_site_post_draft_versions(db: AsyncSession, *, draft_id: uuid.UUID
 
 async def list_site_post_drafts(
     db: AsyncSession, *, org_id: uuid.UUID, limit: int = 50, offset: int = 0,
-) -> list[tuple[SitePostDraft, SitePostVersion]]:
+) -> list[tuple[SitePostDraft, SitePostVersion, SitePostVersion]]:
     """story #3365 후속(S4 계약 갭, 페드루 PO 확定 2026-09-03) — 조직 스코프 초안 목록. S4
     화면이 열릴 때 draft_id를 미리 알 방법이 없어 만든 자리 — 항목마다 최신 버전(title·lang·
-    version·author_kind)을 붙인다. "최신"은 draft.updated_at이 아니라 최신 버전의
-    created_at으로 정렬한다 — draft 행 자체는 버전 추가 시 갱신되지 않아(SSOT는 버전 쪽)
-    이 값이 실제 최근 활동을 반영한다. 게이트 상태·봉인 필드는 S2 몫 — 여기서 지어내지 않는다."""
+    version·author_kind)과 원안 버전(version 1, origin_author_kind — «에이전트가 쓰고 사람이
+    고친 글» vs «사람이 쓴 글» 구별용, 페드루 PO 후속 2026-09-03 05:33Z)을 붙인다. "최신"은
+    draft.updated_at이 아니라 최신 버전의 created_at으로 정렬한다 — draft 행 자체는 버전 추가
+    시 갱신되지 않아(SSOT는 버전 쪽) 이 값이 실제 최근 활동을 반영한다. 게이트 상태·봉인
+    필드는 여기서 지어내지 않는다(라우터가 별도로 필요하면 gate를 따로 조회).
+
+    반환: (draft, latest_version, origin_version) 튜플 리스트."""
     latest_version_ids = (
         select(
             SitePostVersion.draft_id,
@@ -265,18 +332,107 @@ async def list_site_post_drafts(
         .group_by(SitePostVersion.draft_id)
         .subquery()
     )
+    origin_version_ids = (
+        select(
+            SitePostVersion.draft_id,
+            func.min(SitePostVersion.version).label("min_version"),
+        )
+        .group_by(SitePostVersion.draft_id)
+        .subquery()
+    )
     latest = aliased(SitePostVersion)
+    origin = aliased(SitePostVersion)
     stmt = (
-        select(SitePostDraft, latest)
+        select(SitePostDraft, latest, origin)
         .join(latest_version_ids, latest_version_ids.c.draft_id == SitePostDraft.id)
         .join(
             latest,
             (latest.draft_id == latest_version_ids.c.draft_id)
             & (latest.version == latest_version_ids.c.max_version),
         )
+        .join(origin_version_ids, origin_version_ids.c.draft_id == SitePostDraft.id)
+        .join(
+            origin,
+            (origin.draft_id == origin_version_ids.c.draft_id)
+            & (origin.version == origin_version_ids.c.min_version),
+        )
         .where(SitePostDraft.org_id == org_id)
         .order_by(latest.created_at.desc())
         .limit(limit)
         .offset(offset)
     )
-    return [(row[0], row[1]) for row in (await db.execute(stmt)).all()]
+    return [(row[0], row[1], row[2]) for row in (await db.execute(stmt)).all()]
+
+
+async def submit_site_post_draft(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    draft_id: uuid.UUID,
+    version_id: uuid.UUID | None,
+    requester_member_id: uuid.UUID,
+) -> tuple[Gate, uuid.UUID]:
+    """story #3365(Phase0 S2) — 초안 버전을 external_publish 게이트에 상신. 대상 버전(생략 시
+    최신)의 content_sha256·content_version·본문 스냅샷을 게이트에 봉인(sealed_content_*)한다
+    — 이후 어떤 경로도 이 값을 조용히 갱신하지 않는다(불변 — 뮤테이션 대상: 이 값을 갱신하는
+    코드 경로를 하나 열면 승인 후 변경→409 테스트가 반드시 실패해야 한다). 같은 봉인 대상으로
+    재상신하면(내용 무변경) 기존 게이트를 그대로 반환한다(멱등 — 재봉인 없음).
+
+    에이전트 키도 호출 가능(AC2) — external_publish는 `_ALWAYS_MANUAL_GATE_TYPES`라 create_gate가
+    호출자 무관 항상 pending을 강제한다(gate_service.py 참고, 신규 코드 불요)."""
+    draft = await get_site_post_draft(db, org_id=org_id, draft_id=draft_id)
+    if draft is None:
+        raise SitePostDraftNotFoundError(draft_id)
+
+    versions = await list_site_post_draft_versions(db, draft_id=draft_id)
+    if not versions:
+        raise SitePostDraftNotFoundError(draft_id)
+    target = versions[-1] if version_id is None else next((v for v in versions if v.id == version_id), None)
+    if target is None:
+        raise SitePostVersionNotFoundError(version_id)
+    origin_author_member_id = versions[0].author_member_id
+
+    from app.services.gate_service import create_gate, find_gate_slot_with_pr_fallback
+    from app.services.workflow_line_config import _default_role_id
+
+    existing = await find_gate_slot_with_pr_fallback(
+        db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
+        gate_type="external_publish", pr_number=None, repo_full_name=None,
+    )
+    if (
+        existing is not None
+        and existing.sealed_content_sha256 == target.body_sha256
+        and existing.status in ("pending", "approved")
+    ):
+        return existing, target.id  # 이미 이 정확한 내용으로 봉인돼 있다 — 재봉인하지 않는다(불변).
+
+    neutral_facts = {
+        "destination": _SITE_POST_DESTINATION,
+        "media_manifest_hash": _EMPTY_MEDIA_MANIFEST_HASH,
+        "draft_author_member_id": str(origin_author_member_id),
+        "requested_by_member_id": str(requester_member_id),
+    }
+
+    role_id = await _default_role_id(db, org_id) or uuid.uuid4()
+    gate = await create_gate(
+        db, org_id, draft.work_item_id, "story", "external_publish",
+        requester_member_id, role_id, neutral_facts=neutral_facts,
+    )
+    # create_gate()의 기존-pending/approved 멱등 반환 분기는 neutral_facts 인자를 무시한다
+    # (신규 생성·rejected 재오픈 경로에서만 반영) — 위 sha 동일성 조기 return을 안 탔다는 건
+    # 내용이 달라졌거나 신규라는 뜻이라, 여기서 명시적으로 (재)봉인하는 것이 바로 이번
+    # submit() 호출이 의도한 행위다("조용한 갱신"이 아니다).
+    gate.neutral_facts = neutral_facts
+    if gate.status != "pending":
+        set_gate_status(gate, "pending", now=datetime.now(timezone.utc))
+        gate.requires_human = True
+        gate.resolver_id = None
+        gate.resolution_note = None
+        gate.resolved_at = None
+    gate.sealed_content_version = target.version
+    gate.sealed_content_sha256 = target.body_sha256
+    gate.sealed_content_body = target.body_md
+    gate.reapproval_required = False
+    await db.commit()
+    await db.refresh(gate)
+    return gate, target.id

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -53,12 +53,37 @@ class ExternalPublishGateNotApprovedError(Exception):
 
 class SitePostReapprovalRequiredError(Exception):
     """story #3365(Phase0 S2) AC6 — 승인된 버전(gate.sealed_content_sha256)과 지금 공개하려는
-    내용의 해시가 다르다. gate.sealed_content_sha256이 None(구식/미봉인 게이트)이면 이 검사
-    자체를 건너뛴다 — S1 이전에 만들어진 승인 게이트를 소급 차단하지 않는다."""
+    내용의 해시가 다르다."""
 
     def __init__(self, *, gate_id: uuid.UUID):
         self.gate_id = gate_id
         super().__init__(f"승인된 버전과 현재 내용이 다릅니다(gate_id={gate_id}) — 재승인이 필요합니다")
+
+
+class SitePostSealMissingError(Exception):
+    """story #3365(Phase0 S2, 페드루 PO 리뷰 2026-09-03 05:59Z) — fail-closed. gate.status가
+    approved/auto_passed인데 sealed_content_sha256이 None(제출→봉인 없이 승인된 구식/우회
+    게이트)이면, "무엇이 승인됐는지 서버가 모른다"는 뜻이라 REAPPROVAL_REQUIRED(내용이
+    다르다는 걸 안다)와는 다른 별개 코드로 거부한다(유나 설계 §3-1-1 "모른다≠다르다").
+    S2 이전 이미 공개된 SitePost 행은 이 검사와 무관(projection 자체는 안 건드림) — 이
+    게이트로 다시 발행을 시도할 때만 막힌다(재발행은 submit()으로 재상신해 봉인부터)."""
+
+    def __init__(self, *, gate_id: uuid.UUID):
+        self.gate_id = gate_id
+        super().__init__(f"이 게이트는 봉인된 버전이 없습니다(gate_id={gate_id}) — 재상신 후 다시 승인받아야 합니다")
+
+
+class SitePostApproverRoleMissingError(Exception):
+    """story #3365(Phase0 S2, 페드루 PO 리뷰) — 조직에 기본 결재 역할(ParticipationRole.
+    is_default)이 없으면 상신을 명시적으로 거부한다. 예전엔 `uuid.uuid4()`로 존재하지 않는
+    role_id를 만들어 게이트를 생성했다(조용한 폴백 — green을 만드는 자리)."""
+
+    def __init__(self, *, org_id: uuid.UUID):
+        self.org_id = org_id
+        super().__init__(
+            f"조직에 기본 결재 역할이 설정되지 않았습니다(org_id={org_id}) — "
+            "조직 설정에서 기본 역할을 지정한 뒤 다시 상신하세요"
+        )
 
 
 class SitePostDraftNotFoundError(Exception):
@@ -137,12 +162,16 @@ async def publish_site_post(
     _validate_lang(lang)
     gate = await _resolve_approved_gate(db, org_id=org_id, work_item_id=work_item_id, gate_id=gate_id)
 
-    # story #3365(Phase0 S2) AC6 — 승인 뒤 본문이 바뀌었으면 공개하지 않는다. 뮤테이션 대상:
-    # 이 비교를 제거하면 승인 후 바뀐 본문이 그대로 공개돼 회귀 테스트가 반드시 실패해야 한다.
-    if gate.sealed_content_sha256 is not None:
-        current_hash = compute_body_sha256(title=title, lang=lang, summary=summary, tags=tags, body_md=body_md)
-        if current_hash != gate.sealed_content_sha256:
-            raise SitePostReapprovalRequiredError(gate_id=gate.id)
+    # story #3365(Phase0 S2) AC6 — 승인 뒤 본문이 바뀌었으면 공개하지 않는다. fail-closed
+    # (페드루 PO 리뷰 2026-09-03 05:59Z) — 봉인 자체가 없는 승인 게이트(제출→봉인 경로를 안
+    # 거친 구식/우회 게이트)는 "무엇이 승인됐는지 모른다"는 뜻이라 통과가 아니라 거부한다.
+    # 뮤테이션 대상: 이 블록을 제거하면 승인 후 바뀐 본문이 그대로 공개돼 회귀 테스트가
+    # 반드시 실패해야 한다.
+    if gate.sealed_content_sha256 is None:
+        raise SitePostSealMissingError(gate_id=gate.id)
+    current_hash = compute_body_sha256(title=title, lang=lang, summary=summary, tags=tags, body_md=body_md)
+    if current_hash != gate.sealed_content_sha256:
+        raise SitePostReapprovalRequiredError(gate_id=gate.id)
 
     now = datetime.now(timezone.utc)
     stmt = pg_insert(SitePost).values(
@@ -266,35 +295,50 @@ async def create_site_post_draft_version(
     db.add(version)
     await db.flush()
 
-    # story #3365(Phase0 S2) AC4·AC5 — 이 새 버전이 이미 approved된 external_publish 게이트를
-    # 무효화한다면(승인 후 수정), 그 게이트를 같은 트랜잭션 안에서 원자적으로 pending으로
-    # 되돌린다 — 버전은 새로 생겼는데 게이트는 옛 승인 그대로인 상태가 존재하면 안 된다(AC5).
-    # sealed_content_*는 여기서 절대 안 건드린다 — publish_site_post의 409 비교 anchor로
-    # 그대로 남아야 "봉인 값 불변" 요건이 성립한다.
-    await _reopen_approved_gate_after_edit(db, org_id=org_id, work_item_id=work_item_id)
+    # story #3365(Phase0 S2) AC4·AC5, 페드루 PO 재정정(2026-09-03 06:06Z, 앞선 06:03Z 정정을
+    # 유나군 코드 대조로 재철회) — 승인 뒤 봉인은 "무엇이 승인됐었나"의 유일한 기록이라 편집
+    # 훅이 조용히 덮으면 안 된다(publish_site_post의 409 비교 기준점이 죽는다). 확定 규칙:
+    #   · pending 中 편집  → 같은 트랜잭션에서 즉시 재봉인(결재자가 볼 것=승인할 것, 아직
+    #     파괴할 승인 기록이 없다).
+    #   · approved 뒤 편집 → pending 재오픈 + reapproval_required=True, **봉인은 옛 버전
+    #     그대로 유지**(재봉인은 submit_site_post_draft의 명시 재호출만이 한다 — gates.py의
+    #     approve 전이가 reapproval_required=True인 동안 409로 막혀 "옛 봉인을 승인하는" 막다른
+    #     길 자체를 차단한다).
+    await _reseal_gate_on_new_version(db, org_id=org_id, work_item_id=work_item_id, version=version)
 
     await db.commit()
     await db.refresh(version)
     return version
 
 
-async def _reopen_approved_gate_after_edit(db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID) -> None:
+async def _reseal_gate_on_new_version(
+    db: AsyncSession, *, org_id: uuid.UUID, work_item_id: uuid.UUID, version: SitePostVersion,
+) -> None:
     gate = (await db.execute(
         select(Gate)
         .where(
             Gate.org_id == org_id, Gate.work_item_id == work_item_id, Gate.gate_type == "external_publish",
-            Gate.status == "approved",
+            Gate.status.in_(("pending", "approved")),
         )
         .with_for_update()
     )).scalar_one_or_none()
     if gate is None:
         return
-    set_gate_status(gate, "pending", now=datetime.now(timezone.utc))
-    gate.requires_human = True
-    gate.resolver_id = None
-    gate.resolution_note = None
-    gate.resolved_at = None
-    gate.reapproval_required = True
+    if gate.status == "approved":
+        # 승인된 뒤 편집 — pending으로 되돌리기만 한다. sealed_content_*는 절대 안 건드린다
+        # (여기서 건드리면 "무엇이 승인됐었나" 기록이 사라진다 — 재봉인은 submit() 재호출 몫).
+        set_gate_status(gate, "pending", now=datetime.now(timezone.utc))
+        gate.requires_human = True
+        gate.resolver_id = None
+        gate.resolution_note = None
+        gate.resolved_at = None
+        gate.reapproval_required = True
+        return
+    # 아직 한 번도 승인된 적 없는 pending — 결재자가 볼 대상 자체가 그냥 최신본이면 되므로
+    # 편집마다 즉시 재봉인(재상신 왕복 불요).
+    gate.sealed_content_version = version.version
+    gate.sealed_content_sha256 = version.body_sha256
+    gate.sealed_content_body = version.body_md
 
 
 async def get_site_post_draft(db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID) -> SitePostDraft | None:
@@ -373,10 +417,13 @@ async def submit_site_post_draft(
     requester_member_id: uuid.UUID,
 ) -> tuple[Gate, uuid.UUID]:
     """story #3365(Phase0 S2) — 초안 버전을 external_publish 게이트에 상신. 대상 버전(생략 시
-    최신)의 content_sha256·content_version·본문 스냅샷을 게이트에 봉인(sealed_content_*)한다
-    — 이후 어떤 경로도 이 값을 조용히 갱신하지 않는다(불변 — 뮤테이션 대상: 이 값을 갱신하는
-    코드 경로를 하나 열면 승인 후 변경→409 테스트가 반드시 실패해야 한다). 같은 봉인 대상으로
-    재상신하면(내용 무변경) 기존 게이트를 그대로 반환한다(멱등 — 재봉인 없음).
+    최신)의 content_sha256·content_version·본문 스냅샷을 게이트에 봉인(sealed_content_*)한다.
+
+    페드루 PO 정정(2026-09-03 06:03Z) — 봉인은 "승인된 뒤"에만 불변이다. pending/approved인
+    한 `_reseal_gate_on_new_version`(버전 생성 훅)이 매 편집마다 이미 최신 버전으로 계속
+    동기화해 두므로, 이 함수는 대부분 그 동기화된 상태를 그대로 반환하는 idempotent 조회다
+    (아래 sha 동일성 분기). 값이 다를 때만(예: 명시적으로 과거 버전을 상신 요청) 여기서
+    직접 재봉인한다 — 그것도 submit() 호출 자체가 그 재봉인의 명시적 트리거다.
 
     에이전트 키도 호출 가능(AC2) — external_publish는 `_ALWAYS_MANUAL_GATE_TYPES`라 create_gate가
     호출자 무관 항상 pending을 강제한다(gate_service.py 참고, 신규 코드 불요)."""
@@ -413,7 +460,11 @@ async def submit_site_post_draft(
         "requested_by_member_id": str(requester_member_id),
     }
 
-    role_id = await _default_role_id(db, org_id) or uuid.uuid4()
+    # 페드루 PO 리뷰(2026-09-03 05:59Z) — 기본 역할이 없으면 가짜 uuid로 게이트를 만드는
+    # 조용한 폴백 대신 명시 실패한다(SITE_POST_APPROVER_ROLE_MISSING).
+    role_id = await _default_role_id(db, org_id)
+    if role_id is None:
+        raise SitePostApproverRoleMissingError(org_id=org_id)
     gate = await create_gate(
         db, org_id, draft.work_item_id, "story", "external_publish",
         requester_member_id, role_id, neutral_facts=neutral_facts,

--- a/backend/tests/gate_mock_factory.py
+++ b/backend/tests/gate_mock_factory.py
@@ -58,6 +58,12 @@ def make_gate(**overrides) -> Gate:
         github_check_run_id=None,
         github_check_run_sha=None,
         approved_head_sha=None,
+        # story #3365(Phase0 S2) — reapproval_required는 requires_human과 동형(server_default
+        # false·nullable=False 컬럼): transient 인스턴스는 서버 기본값이 아직 안 채워져 None으로
+        # 읽히는데, GateResponse가 `bool`(Optional 아님)로 선언돼 있어 그대로 두면 422로 죽는다
+        # (실제로 test_rc1_body_trust_actor.py에서 재현). sealed_content_*는 진짜 nullable이라
+        # GateResponse도 Optional로 받으므로 기본값 불요.
+        reapproval_required=False,
         created_at=now,
         updated_at=now,
     )

--- a/backend/tests/test_3360_site_posts.py
+++ b/backend/tests/test_3360_site_posts.py
@@ -14,7 +14,17 @@ claims에 org_id 직접 주입) 재사용.
 기존 "성공 발행" 테스트들은 그 경계가 생기기 전 작성돼 caller로 agent를 썼던 것 — 이제
 휴먼(`_seed_human`)으로 바꿔 각 테스트가 원래 의도(게이트/slug/upsert/공개 조회 chokepoint)를
 계속 정확히 검증하게 한다(안 바꾸면 새 agent-차단이 먼저 걸려 원래 검증하려던 경로를 더 이상
-안 타면서도 같은 403으로 조용히 통과해버린다)."""
+안 타면서도 같은 403으로 조용히 통과해버린다).
+
+⚠️story #3367(Phase0 S2, 2026-09-03) 회귀 — 페드루 PO 리뷰(fail-closed)로 승인된 게이트도
+`sealed_content_sha256`이 없으면(S2 이전 방식으로 직접 approved 시드) 공개가 409
+SITE_POST_SEAL_MISSING으로 막힌다. 이 파일의 "성공 발행" 테스트는 `_seed_gate`에
+`seal_for=_publish_body(...)`를 넘겨 봉인까지 시드한다 — 이 파일의 관심사는 seal 자체가
+아니라 게이트/slug/upsert/공개 조회 chokepoint이므로, seal은 "이미 submit()을 거친 정상
+게이트"를 흉내 내는 전제 조건일 뿐이다(seal 자체의 회귀는 test_3367_site_post_submit_gate_
+seal.py 관할). `test_republish_...`는 재발행 시 본문을 바꾸지 않는다 — 승인 후 다른 본문
+publish는 이제 그 자체가 회귀 대상(같은 파일의 새 테스트가 별도로 검증)이라 원래 이 테스트가
+검증하려던 "upsert가 행을 안 늘린다"만 그대로 남긴다."""
 from __future__ import annotations
 
 import os
@@ -114,12 +124,25 @@ async def _seed_story(session, org_id, project_id, *, title="1호 글"):
     return story.id
 
 
-async def _seed_gate(session, org_id, work_item_id, *, status="pending", gate_type="external_publish"):
+async def _seed_gate(
+    session, org_id, work_item_id, *, status="pending", gate_type="external_publish", seal_for=None,
+):
+    """seal_for: story #3367(Phase0 S2) — 넘기면 그 `_publish_body(...)` dict의 canonical
+    해시로 `sealed_content_sha256`을 채운다(fail-closed 회귀 — 승인 게이트도 봉인 없인 공개
+    안 됨). None(기본)이면 예전처럼 미봉인 — pending/미승인 케이스는 seal 자체가 무관하다."""
     from app.models.gate import Gate
+
+    sealed_content_sha256 = None
+    if seal_for is not None:
+        from app.services.site_posts import compute_body_sha256
+        sealed_content_sha256 = compute_body_sha256(
+            title=seal_for["title"], lang=seal_for["lang"], summary=seal_for["summary"],
+            tags=seal_for["tags"], body_md=seal_for["body_md"],
+        )
 
     gate = Gate(
         id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id, work_item_type="story",
-        gate_type=gate_type, status=status,
+        gate_type=gate_type, status=status, sealed_content_sha256=sealed_content_sha256,
     )
     session.add(gate)
     await session.commit()
@@ -254,7 +277,8 @@ async def test_post_with_approved_gate_returns_201_and_public_api_reflects():
             org_id, project_id = await _seed_org(s)
             human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
-            gate_id = await _seed_gate(s, org_id, story_id, status="approved")
+            _body = _publish_body(work_item_id=story_id)
+            gate_id = await _seed_gate(s, org_id, story_id, status="approved", seal_for=_body)
             public_key = await _seed_metering_key(s, org_id)
         _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
 
@@ -305,7 +329,8 @@ async def test_auto_passed_gate_also_counts_as_approved():
             org_id, project_id = await _seed_org(s)
             human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
-            await _seed_gate(s, org_id, story_id, status="auto_passed")
+            _body = _publish_body(work_item_id=story_id)
+            await _seed_gate(s, org_id, story_id, status="auto_passed", seal_for=_body)
         _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
 
         async with _client_for(app) as client:
@@ -344,6 +369,10 @@ async def test_invalid_slug_rejected_422():
 
 @pytest.mark.anyio
 async def test_republish_same_org_lang_slug_upserts_single_row():
+    """story #3367(Phase0 S2) 후속 정정 — 재발행은 봉인된 것과 **같은** 내용으로만 성공한다
+    (다른 본문 재발행은 이제 409 SITE_POST_REAPPROVAL_REQUIRED/SEAL_MISSING이 정상 동작 —
+    별도 테스트가 그걸 검증한다). 이 테스트의 관심사는 그대로 upsert 자체(같은 슬러그 재호출이
+    행을 안 늘리는 것)다."""
     from app.main import app
     from app.models.site_post import SitePost
     from sqlalchemy import func, select
@@ -354,7 +383,8 @@ async def test_republish_same_org_lang_slug_upserts_single_row():
             org_id, project_id = await _seed_org(s)
             human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
-            gate_id = await _seed_gate(s, org_id, story_id, status="approved")
+            _body = _publish_body(work_item_id=story_id)
+            gate_id = await _seed_gate(s, org_id, story_id, status="approved", seal_for=_body)
         _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
 
         async with _client_for(app) as client:
@@ -362,16 +392,17 @@ async def test_republish_same_org_lang_slug_upserts_single_row():
                 f"/api/v2/organizations/{org_id}/site-posts",
                 json=_publish_body(work_item_id=story_id, gate_id=gate_id),
             )
-            body2 = _publish_body(work_item_id=story_id, gate_id=gate_id)
-            body2["title"] = "제목 수정판"
-            r2 = await client.post(f"/api/v2/organizations/{org_id}/site-posts", json=body2)
+            r2 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts",
+                json=_publish_body(work_item_id=story_id, gate_id=gate_id),
+            )
         assert r2.status_code == 201, r2.text
 
         async with Session() as s:
             count = (await s.execute(select(func.count()).select_from(SitePost))).scalar_one()
             row = (await s.execute(select(SitePost).where(SitePost.slug == "hello-world"))).scalar_one()
         assert count == 1, "재발행인데 행이 늘었다(upsert 회귀)"
-        assert row.title == "제목 수정판"
+        assert row.title == "AI가 «몰라요»라고 말할 때"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -451,7 +482,8 @@ async def test_unpublished_post_excluded_from_public_reads():
             org_id, project_id = await _seed_org(s)
             human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
-            gate_id = await _seed_gate(s, org_id, story_id, status="approved")
+            _body = _publish_body(work_item_id=story_id)
+            gate_id = await _seed_gate(s, org_id, story_id, status="approved", seal_for=_body)
             public_key = await _seed_metering_key(s, org_id)
         _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
 

--- a/backend/tests/test_3365_external_publish_gate_human_only.py
+++ b/backend/tests/test_3365_external_publish_gate_human_only.py
@@ -46,3 +46,62 @@ async def test_agent_cannot_approve_external_publish_gate_existing_guard_pinned(
             )
     assert exc_info.value.status_code == 403
     assert "에이전트 승인 불가" in str(exc_info.value.detail)
+
+
+@pytest.mark.anyio
+async def test_resubmit_required_guard_does_not_fire_for_non_site_post_gate_types():
+    """story #3367 후속(페드루 PO 실측 2026-09-03 07:11Z, CI shard 3 실패) — SITE_POST_
+    RESUBMIT_REQUIRED 가드는 gate_type=="external_publish"로 명시 스코프돼야 한다. 여기선
+    merge 게이트에 reapproval_required=True를 **명시로 세워** 그 경계가 실제로 gate_type
+    분기 때문이지 우연히 통과하는 게 아님을 고정한다(예전 버그: gate_type 체크 없이
+    reapproval_required만 봐서 MagicMock auto-attribute 오탐까지 겹쳐 merge 게이트도
+    409로 막혔었다)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi import BackgroundTasks, HTTPException
+
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.services.member_resolver import ResolvedMember
+
+    human = ResolvedMember(
+        id=uuid.uuid4(), user_id=uuid.uuid4(), name="h", type="human", role="owner", org_id=uuid.uuid4(),
+    )
+
+    async def _fake_transition(session, org_id, gid, status, resolver_id, note, *, pending_deliveries=None):
+        return MagicMock(id=gid, status="approved")
+
+    gate = MagicMock()
+    gate.gate_type = "merge"
+    gate.github_check_run_sha = None
+    gate.status = "pending"
+    gate.designated_approver_id = None
+    # 이 필드가 True인데도 merge 게이트라 가드가 안 걸려야 한다(핵심 assert).
+    gate.reapproval_required = True
+
+    session = AsyncMock()
+    gate_result = MagicMock()
+    gate_result.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=gate_result)
+
+    class _FakeAuth:
+        user_id = str(human.user_id)
+        claims: dict = {"app_metadata": {"org_id": str(human.org_id)}}
+
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=human)), \
+         patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)), \
+         patch.object(gates_mod, "transition_gate", _fake_transition), \
+         patch.object(gates_mod.GateResponse, "model_validate", staticmethod(lambda g: g)):
+        try:
+            await transition_gate_endpoint(
+                id=uuid.uuid4(),
+                body=GateTransitionRequest(status="approved", note="테스트 사유", evidence_viewed=True),
+                background_tasks=BackgroundTasks(),
+                session=session,
+                org_id=human.org_id,
+                auth=_FakeAuth(),
+            )
+        except HTTPException as exc:
+            assert exc.detail.get("code") != "SITE_POST_RESUBMIT_REQUIRED" if isinstance(exc.detail, dict) else True, (
+                "merge 게이트인데 SITE_POST_RESUBMIT_REQUIRED로 막혔다(gate_type 스코프 회귀)"
+            )

--- a/backend/tests/test_3367_site_post_submit_gate_seal.py
+++ b/backend/tests/test_3367_site_post_submit_gate_seal.py
@@ -7,8 +7,10 @@ AC 매핑:
 - AC2: 에이전트도 상신은 허용(게이트 생성까지) — external_publish는 _ALWAYS_MANUAL_GATE_TYPES라
   create_gate가 호출자 무관 항상 pending을 강제한다(신규 코드 없음, 기존 가드 그대로).
 - AC4·AC5: 승인 뒤 새 버전이 생기면(휴먼 수정) 그 버전 생성과 같은 트랜잭션 안에서 게이트가
-  원자적으로 pending+reapproval_required=True로 되돌아간다. 봉인 값(sealed_content_*)은
-  이 시점에 안 바뀐다 — 다음 명시 submit()이 재봉인할 때까지 "예전 승인 대상"으로 남는다.
+  원자적으로 pending+reapproval_required=True로 되돌아가고, **동시에 그 새 버전으로
+  재봉인**된다(페드루 PO 정정 2026-09-03 06:03Z — 봉인은 "결재자가 승인할 대상"이므로 재오픈
+  시점에 최신화돼야 그 pending을 승인했을 때 막다른 409가 안 난다). 승인 전(pending) 상태의
+  편집도 같은 방식으로 항상 최신 버전에 재봉인된다.
 - AC6: 봉인된 해시와 지금 공개하려는 내용의 해시가 다르면 공개 서비스는 409
   SITE_POST_REAPPROVAL_REQUIRED — 기존 공개 본문은 그대로 유지된다.
 - 봉인 값 불변: 재상신해도 내용이 같으면(같은 버전) 게이트·봉인 값이 그대로 재사용된다(멱등).
@@ -16,12 +18,17 @@ AC 매핑:
 - neutral_facts에 draft_author_member_id(버전 1 작성자)·requested_by_member_id(상신자) —
   S5(통지 수신자)가 읽는 키 이름 그대로(recipe_gate_hooks._build_approval_neutral_facts 관례).
 
-뮤테이션 2건(스토리 본문 + AC 인라인 명시):
-① 공개 직전 hash 비교를 제거 — 승인 후 바뀐 본문이 공개돼 test_publish_after_edit_...가
-   반드시 실패해야 한다.
-② 봉인 값을 갱신하는 코드 경로를 편집-훅에 하나 더 열면(사실상 조용한 재봉인) 같은 테스트가
-   반드시 실패해야 한다(더 이상 mismatch가 안 생겨 409를 못 본다).
-둘 다 이 파일 맨 아래 주석에 자체검증 절차를 남긴다(실행은 세션 로그 참고, 커밋엔 포함 안 함)."""
+뮤테이션 3건(스토리 본문 + AC 인라인 명시 + 페드루 PO 정정 06:03Z):
+① 공개 직전 hash 비교를 제거 — 승인 후 바뀐 본문이 공개돼
+   test_publish_with_content_diverged_...가 반드시 실패해야 한다.
+② 봉인이 아예 없는(fail-closed) 승인 게이트로 공개되는 코드 경로를 열면(SEAL_MISSING 검사
+   제거) test_publish_with_approved_but_unsealed_gate_...가 반드시 실패해야 한다.
+③ 편집-훅(`_reseal_gate_on_new_version`)에서 approved→pending "상태 전이"만 제거하고
+   재봉인은 남기면(즉 승인된 게이트가 새 본문으로 조용히 재봉인되면서도 approved로 남으면)
+   test_edit_after_approval_atomically_reopens_and_reseals_gate_to_new_version의
+   `gate.status == "pending"` assert가 반드시 실패해야 한다 — 이게 "재검토 없이 새 본문이
+   승인된 것처럼 새는" 진짜 보안 축이다.
+전부 세션 중 실행·RED 확인·원복 완료(커밋엔 포함 안 함)."""
 from __future__ import annotations
 
 import os
@@ -117,6 +124,17 @@ async def _seed_story(session, org_id, project_id, *, title="2호 글"):
     return story.id
 
 
+async def _seed_default_role(session, org_id):
+    """story #3367 — submit()이 이제 기본 역할 없으면 명시 거부한다(SITE_POST_APPROVER_ROLE_
+    MISSING, 페드루 PO 리뷰) — 이 파일의 submit() 성공 경로 테스트는 모두 이 시드가 필요."""
+    from app.models.participation import ParticipationRole
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+    session.add(role)
+    await session.commit()
+    return role.id
+
+
 async def _seed_metering_key(session, org_id):
     from app.services.pageview_counter import get_or_create_active_key
     return await get_or_create_active_key(session, org_id=org_id)
@@ -181,6 +199,7 @@ async def test_submit_seals_pending_gate_with_target_version():
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
             agent_id = await _seed_agent(s, org_id, project_id)
             human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
@@ -233,6 +252,7 @@ async def test_agent_can_submit_but_gate_stays_pending_not_approved():
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
             agent_id = await _seed_agent(s, org_id, project_id)
             story_id = await _seed_story(s, org_id, project_id)
 
@@ -261,6 +281,7 @@ async def test_resubmit_same_content_is_idempotent():
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
             agent_id = await _seed_agent(s, org_id, project_id)
             story_id = await _seed_story(s, org_id, project_id)
 
@@ -285,13 +306,73 @@ async def test_resubmit_same_content_is_idempotent():
 
 
 @pytest.mark.anyio
-async def test_edit_after_approval_atomically_reopens_gate_to_pending():
+async def test_pending_edit_reseals_immediately_same_transaction():
+    """페드루 PO 확定(2026-09-03 06:06Z) — 아직 한 번도 승인된 적 없는 pending 게이트는
+    편집마다 즉시 재봉인된다(결재자가 볼 대상=최신본이면 되고, 아직 덮으면 안 될 승인 기록이
+    없다 — 재상신 왕복 불요)."""
     from app.main import app
 
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+        gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+        # 아직 승인 전 — 편집하면 같은 게이트가 즉시 새 버전으로 재봉인돼야 한다.
+        async with _client_for(app) as client:
+            r_edit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, title="2호 글(승인 전 수정)"),
+            )
+        assert r_edit.status_code == 201, r_edit.text
+        new_sha256 = r_edit.json()["body_sha256"]
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+        assert gate.status == "pending"
+        assert gate.reapproval_required is False, "승인된 적 없는 pending인데 재승인 플래그가 섰다"
+        assert gate.sealed_content_version == 2
+        assert gate.sealed_content_sha256 == new_sha256
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_approve_after_edit_is_blocked_until_resubmit_seals_new_version():
+    """페드루 PO 확定(2026-09-03 06:06Z) — 승인 뒤 편집은 게이트를 pending으로 되돌리되 봉인은
+    옛 버전 그대로 둔다("무엇이 승인됐었나" 기록 보존). 그 옛 봉인을 그대로 승인하는 막다른
+    길은 gates.py가 409 SITE_POST_RESUBMIT_REQUIRED로 막는다 — 빠져나가는 길은 submit()
+    재호출(새 버전으로 재봉인+플래그 해제) 뿐이다."""
+    from app.main import app
+    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.services.member_resolver import ResolvedMember
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
             agent_id = await _seed_agent(s, org_id, project_id)
             human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
@@ -315,23 +396,75 @@ async def test_edit_after_approval_atomically_reopens_gate_to_pending():
         async with Session() as s:
             await _approve_gate_directly(s, gate_id)
 
-        # 승인 뒤 휴먼이 본문을 고친다 — 새 버전 생성과 같은 트랜잭션에서 게이트가 되돌아가야 한다.
+        # 승인 뒤 편집 — pending 재오픈, 봉인은 옛 버전 그대로.
         async with _client_for(app) as client:
             r_edit = await client.post(
                 f"/api/v2/organizations/{org_id}/site-posts/drafts",
                 json=_draft_body(work_item_id=story_id, title="2호 글(승인 후 수정)"),
             )
         assert r_edit.status_code == 201, r_edit.text
-        assert r_edit.json()["version"] == 2
+        new_sha256 = r_edit.json()["body_sha256"]
 
         async with Session() as s:
             from app.models.gate import Gate
             from sqlalchemy import select
             gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
-        assert gate.status == "pending", "승인 후 수정인데 게이트가 approved로 남아있다(AC4 회귀)"
+        assert gate.status == "pending"
         assert gate.reapproval_required is True
-        assert gate.resolver_id is None
-        assert gate.sealed_content_sha256 == sealed_before, "봉인 값이 편집 훅에서 조용히 갱신됐다(불변 위반)"
+        assert gate.sealed_content_sha256 == sealed_before, "봉인이 편집 훅에서 조용히 갱신됐다(승인 기록 훼손)"
+
+        # 막다른 길 — 옛 봉인 그대로 승인 시도 → 409.
+        from fastapi import BackgroundTasks, HTTPException
+        from unittest.mock import AsyncMock, patch
+        import app.routers.gates as gates_mod
+
+        approver = ResolvedMember(
+            id=uuid.uuid4(), user_id=uuid.uuid4(), name="approver", type="human",
+            role="owner", org_id=org_id,
+        )
+
+        class _FakeAuth:
+            user_id = str(approver.user_id)
+            claims: dict = {"app_metadata": {"org_id": str(org_id)}}
+
+        async with Session() as s:
+            with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=approver)), \
+                 patch.object(gates_mod, "_non_doc_gate_approvable", AsyncMock(return_value=True)):
+                with pytest.raises(HTTPException) as exc_info:
+                    await transition_gate_endpoint(
+                        id=gate_id, body=GateTransitionRequest(status="approved"),
+                        background_tasks=BackgroundTasks(), session=s, org_id=org_id, auth=_FakeAuth(),
+                    )
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["code"] == "SITE_POST_RESUBMIT_REQUIRED"
+
+        # 빠져나가는 길 — submit() 재호출: 새 버전으로 재봉인 + 플래그 해제.
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_resubmit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+        assert r_resubmit.status_code == 200, r_resubmit.text
+        assert r_resubmit.json()["content_sha256"] == new_sha256
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+        assert gate.sealed_content_sha256 == new_sha256
+        assert gate.reapproval_required is False
+
+        # 이제 승인 → 공개하면 새 본문이 나간다.
+        async with Session() as s:
+            await _approve_gate_directly(s, gate_id)
+        async with _client_for(app) as client:
+            r_publish = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts",
+                json={
+                    "work_item_id": str(story_id), "gate_id": str(gate_id),
+                    "title": "2호 글(승인 후 수정)", "slug": "2ho-blog", "lang": "ko",
+                    "summary": "요약입니다", "tags": ["ai"], "body_md": "# 제목\n\n본문입니다.",
+                },
+            )
+        assert r_publish.status_code == 201, r_publish.text
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -350,6 +483,7 @@ async def test_publish_with_content_diverged_from_sealed_hash_returns_409_and_ke
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
             agent_id = await _seed_agent(s, org_id, project_id)
             human_id = await _seed_human(s, org_id)
             story_id = await _seed_story(s, org_id, project_id)
@@ -418,6 +552,7 @@ async def test_submit_unknown_draft_returns_404():
     try:
         async with Session() as s:
             org_id, _project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
             human_id = await _seed_human(s, org_id)
         _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
 
@@ -439,6 +574,7 @@ async def test_submit_unknown_version_id_returns_404():
     try:
         async with Session() as s:
             org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
             agent_id = await _seed_agent(s, org_id, project_id)
             story_id = await _seed_story(s, org_id, project_id)
 
@@ -490,6 +626,91 @@ async def test_list_drafts_origin_author_kind_distinguishes_agent_origin_human_l
         assert item["origin_author_kind"] == "agent"
         assert item["latest_author_kind"] == "human"
         assert item["current_version"] == 2
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_with_approved_but_unsealed_gate_fails_closed_409_seal_missing():
+    """페드루 PO 리뷰(2026-09-03 05:59Z) — S2 이전/우회 경로로 만들어진 승인 게이트(submit()을
+    한 번도 안 거쳐 sealed_content_sha256이 없음)로는 어떤 본문도 공개되면 안 된다(fail-closed
+    — "봉인 없음"과 "봉인과 다름"은 서로 다른 실패, 코드도 다르다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+            from app.models.gate import Gate
+            from datetime import datetime, timezone
+            gate = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="external_publish", status="approved",
+                resolver_id=uuid.uuid4(), resolved_at=datetime.now(timezone.utc),
+            )
+            s.add(gate)
+            await s.commit()
+            gate_id = gate.id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts",
+                json={
+                    "work_item_id": str(story_id), "gate_id": str(gate_id),
+                    "title": "글", "slug": "unsealed-post", "lang": "ko",
+                    "summary": "요약", "tags": [], "body_md": "본문",
+                },
+            )
+        assert r.status_code == 409, r.text
+        assert r.json()["error"]["code"] == "SITE_POST_SEAL_MISSING", r.text
+
+        async with Session() as s:
+            from app.models.site_post import SitePost
+            from sqlalchemy import func, select
+            count = (await s.execute(select(func.count()).select_from(SitePost))).scalar_one()
+        assert count == 0, "봉인 없는 승인 게이트로 공개 행이 생겼다(fail-closed 회귀)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_submit_without_default_role_returns_409_approver_role_missing():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            # 의도적으로 _seed_default_role을 안 부른다 — 이 org엔 기본 결재 역할이 없다.
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+        assert r_submit.status_code == 409, r_submit.text
+        assert r_submit.json()["error"]["code"] == "SITE_POST_APPROVER_ROLE_MISSING", r_submit.text
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import func, select
+            count = (await s.execute(
+                select(func.count()).select_from(Gate).where(Gate.org_id == org_id)
+            )).scalar_one()
+        assert count == 0, "역할 미설정인데 게이트가 생성됐다(조용한 폴백 회귀)"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_3367_site_post_submit_gate_seal.py
+++ b/backend/tests/test_3367_site_post_submit_gate_seal.py
@@ -1,0 +1,495 @@
+"""story #3367(Phase0 S2·마케팅 운영 블루프린트 v3, 선생님 확定 2026-09-03) — external_publish
+승인이 본 버전을 봉인하고 수정 즉시 재승인 상태로 바꾼다.
+
+AC 매핑:
+- AC1: 휴먼(또는 에이전트)이 상신하면 external_publish 게이트가 pending으로 서고 대상
+  version·content_sha256·빈 media manifest hash·목적지(hosted_site)가 봉인된다.
+- AC2: 에이전트도 상신은 허용(게이트 생성까지) — external_publish는 _ALWAYS_MANUAL_GATE_TYPES라
+  create_gate가 호출자 무관 항상 pending을 강제한다(신규 코드 없음, 기존 가드 그대로).
+- AC4·AC5: 승인 뒤 새 버전이 생기면(휴먼 수정) 그 버전 생성과 같은 트랜잭션 안에서 게이트가
+  원자적으로 pending+reapproval_required=True로 되돌아간다. 봉인 값(sealed_content_*)은
+  이 시점에 안 바뀐다 — 다음 명시 submit()이 재봉인할 때까지 "예전 승인 대상"으로 남는다.
+- AC6: 봉인된 해시와 지금 공개하려는 내용의 해시가 다르면 공개 서비스는 409
+  SITE_POST_REAPPROVAL_REQUIRED — 기존 공개 본문은 그대로 유지된다.
+- 봉인 값 불변: 재상신해도 내용이 같으면(같은 버전) 게이트·봉인 값이 그대로 재사용된다(멱등).
+- S1 후속(페드루 PO 2026-09-03 05:33Z): 목록 GET에 origin_author_kind(버전 1의 author_kind).
+- neutral_facts에 draft_author_member_id(버전 1 작성자)·requested_by_member_id(상신자) —
+  S5(통지 수신자)가 읽는 키 이름 그대로(recipe_gate_hooks._build_approval_neutral_facts 관례).
+
+뮤테이션 2건(스토리 본문 + AC 인라인 명시):
+① 공개 직전 hash 비교를 제거 — 승인 후 바뀐 본문이 공개돼 test_publish_after_edit_...가
+   반드시 실패해야 한다.
+② 봉인 값을 갱신하는 코드 경로를 편집-훅에 하나 더 열면(사실상 조용한 재봉인) 같은 테스트가
+   반드시 실패해야 한다(더 이상 mismatch가 안 생겨 409를 못 본다).
+둘 다 이 파일 맨 아래 주석에 자체검증 절차를 남긴다(실행은 세션 로그 참고, 커밋엔 포함 안 함)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Submit Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="담롱"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_human(session, org_id, *, role="member"):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="2호 글"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_metering_key(session, org_id):
+    from app.services.pageview_counter import get_or_create_active_key
+    return await get_or_create_active_key(session, org_id=org_id)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _draft_body(*, work_item_id, slug="2ho-blog", lang="ko", title="2호 글"):
+    return {
+        "work_item_id": str(work_item_id), "slug": slug, "lang": lang, "title": title,
+        "summary": "요약입니다", "tags": ["ai"], "body_md": "# 제목\n\n본문입니다.",
+        "media_manifest": [],
+    }
+
+
+async def _approve_gate_directly(session, gate_id):
+    """휴먼 결재 UI 왕복(gates.py) 없이 승인 상태만 만든다 — 이 테스트의 관심사는 site_posts.py
+    쪽 상태(sealed_content_*·reapproval_required·409)지 gates.py의 승인 authz가 아니다
+    (그건 test_rc1_body_trust_actor.py·test_3365_external_publish_gate_human_only.py 관할)."""
+    from datetime import datetime, timezone
+    from app.models.gate import Gate
+
+    from sqlalchemy import select
+    gate = (await session.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+    gate.status = "approved"
+    gate.resolver_id = uuid.uuid4()
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_submit_seals_pending_gate_with_target_version():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id),
+            )
+        assert r_draft.status_code == 201, r_draft.text
+        draft_id = r_draft.json()["draft_id"]
+        version_id = r_draft.json()["version_id"]
+        content_sha256 = r_draft.json()["body_sha256"]
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+        assert r_submit.status_code == 200, r_submit.text
+        payload = r_submit.json()
+        assert payload["version_id"] == version_id
+        assert payload["content_sha256"] == content_sha256
+        assert payload["status"] == "pending"
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+            gate = (await s.execute(select(Gate).where(Gate.id == uuid.UUID(payload["gate_id"])))).scalar_one()
+        assert gate.status == "pending"
+        assert gate.gate_type == "external_publish"
+        assert gate.work_item_id == story_id
+        assert gate.sealed_content_version == 1
+        assert gate.sealed_content_sha256 == content_sha256
+        assert gate.sealed_content_body == "# 제목\n\n본문입니다."
+        assert gate.neutral_facts["destination"] == "hosted_site"
+        assert gate.neutral_facts["draft_author_member_id"] == str(agent_id)
+        assert gate.neutral_facts["requested_by_member_id"] == str(human_id)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_can_submit_but_gate_stays_pending_not_approved():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+        assert r_submit.status_code == 200, r_submit.text
+        assert r_submit.json()["status"] == "pending", "에이전트 상신인데 approved/auto_passed로 생성됐다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resubmit_same_content_is_idempotent():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            r1 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+            r2 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+        assert r1.json()["gate_id"] == r2.json()["gate_id"], "같은 내용 재상신인데 다른 게이트가 생겼다"
+        assert r1.json()["content_sha256"] == r2.json()["content_sha256"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_edit_after_approval_atomically_reopens_gate_to_pending():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+        gate_id = uuid.UUID(r_submit.json()["gate_id"])
+        sealed_before = r_submit.json()["content_sha256"]
+
+        async with Session() as s:
+            await _approve_gate_directly(s, gate_id)
+
+        # 승인 뒤 휴먼이 본문을 고친다 — 새 버전 생성과 같은 트랜잭션에서 게이트가 되돌아가야 한다.
+        async with _client_for(app) as client:
+            r_edit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, title="2호 글(승인 후 수정)"),
+            )
+        assert r_edit.status_code == 201, r_edit.text
+        assert r_edit.json()["version"] == 2
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+        assert gate.status == "pending", "승인 후 수정인데 게이트가 approved로 남아있다(AC4 회귀)"
+        assert gate.reapproval_required is True
+        assert gate.resolver_id is None
+        assert gate.sealed_content_sha256 == sealed_before, "봉인 값이 편집 훅에서 조용히 갱신됐다(불변 위반)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_with_content_diverged_from_sealed_hash_returns_409_and_keeps_old_public_body():
+    """AC6의 실제 갭 — 기존 POST /site-posts는 임의 body(title/slug/body_md 등)를 그대로
+    받는다(초안/버전 시스템과 무관하게 호출 가능, S1 이전부터 있던 계약). 게이트가 approved인
+    동안 그 body만 다른 내용으로 바꿔 다시 호출하면(초안은 안 건드림 — AC4 훅이 아예 안 탄다),
+    승인된 해시와 달라 서버가 막아야 한다는 것이 이 스토리의 핵심 실사고("승인된 같은 게이트로
+    달라진 본문도 upsert한다") — AC4(초안 편집 시 재-pending)와는 별개 경로다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+        gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+        async with Session() as s:
+            await _approve_gate_directly(s, gate_id)
+
+        # 최초 발행 — 승인된 그 내용 그대로.
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_publish1 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts",
+                json={
+                    "work_item_id": str(story_id), "gate_id": str(gate_id),
+                    "title": "2호 글", "slug": "2ho-blog", "lang": "ko",
+                    "summary": "요약입니다", "tags": ["ai"], "body_md": "# 제목\n\n본문입니다.",
+                },
+            )
+        assert r_publish1.status_code == 201, r_publish1.text
+
+        # 초안은 안 건드리고, 같은(여전히 approved인) 게이트로 다른 본문을 직접 공개 시도.
+        async with _client_for(app) as client:
+            r_publish2 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts",
+                json={
+                    "work_item_id": str(story_id), "gate_id": str(gate_id),
+                    "title": "2호 글", "slug": "2ho-blog", "lang": "ko",
+                    "summary": "요약입니다", "tags": ["ai"], "body_md": "# 제목\n\n승인 안 받은 본문입니다.",
+                },
+            )
+        assert r_publish2.status_code == 409, r_publish2.text
+        assert r_publish2.json()["error"]["code"] == "SITE_POST_REAPPROVAL_REQUIRED", r_publish2.text
+
+        async with Session() as s:
+            from app.models.site_post import SitePost
+            from sqlalchemy import select
+            row = (await s.execute(
+                select(SitePost).where(SitePost.org_id == org_id, SitePost.slug == "2ho-blog")
+            )).scalar_one()
+        assert row.body_md == "# 제목\n\n본문입니다.", "409 거부인데 기존 공개 본문이 바뀌었다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_submit_unknown_draft_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{uuid.uuid4()}/submit", json={},
+            )
+        assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_submit_unknown_version_id_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit",
+                json={"version_id": str(uuid.uuid4())},
+            )
+        assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_drafts_origin_author_kind_distinguishes_agent_origin_human_latest():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, title="에이전트 원안"),
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, title="휴먼 개정판"),
+            )
+            r_list = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts")
+        assert r_list.status_code == 200, r_list.text
+        item = r_list.json()[0]
+        assert item["origin_author_kind"] == "agent"
+        assert item["latest_author_kind"] == "human"
+        assert item["current_version"] == 2
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -50,6 +50,10 @@ def _non_doc_gate_session():
         # 필요 — 이 파일의 관심사는 resolver_id 강제이지 designated 정책 판정이 아니므로
         # None="정책 미설정"으로 그 축을 대상 밖임을 분명히 한다).
         designated_approver_id=None,
+        # story #3365(Phase0 S2) — external_publish 전용 막다른 길 가드(gates.py)가 이제 이
+        # 필드를 읽는다(위 다른 None 필드들과 동일 이유 — 이 파일의 관심사는 resolver_id 강제,
+        # site-post 재승인 판정이 아니므로 False="일반 게이트, 그 축 대상 밖"으로 명시한다).
+        reapproval_required=False,
     )
     s.execute = AsyncMock(return_value=gr)
     return s


### PR DESCRIPTION
[SID:3367]

## 요약
Phase0·마케팅운영 블루프린트 v3 S2(선생님 승인 2026-09-03) — S1이 만든 초안·버전을
external_publish 게이트에 봉인해 "승인한 버전 = 공개될 버전"을 서버가 증명한다.

- `POST /api/v2/organizations/{org}/site-posts/drafts/{draft_id}/submit`(PO 계약 확定
  2026-09-03 04:26Z) — body 선택 `{version_id}`(생략 시 최신). 서버가 role_id 내부 해소
  (`workflow_line_config._default_role_id` 재사용)·`external_publish` 게이트 pending 생성·
  대상 버전을 봉인 → `200 {gate_id, version_id, content_sha256, status}`.
- 에이전트 키도 호출 가능(게이트 생성까지만, AC2) — `external_publish`는 이미
  `_ALWAYS_MANUAL_GATE_TYPES`(story #3291)라 신규 코드 없이 항상 `pending`.
- **pending 상태(승인 전) 편집**은 같은 트랜잭션에서 즉시 재봉인(재상신 왕복 불요 — 아직
  덮을 승인 기록이 없다). **승인 뒤 편집**은 게이트를 `pending`+`reapproval_required=True`로
  되돌리되 **봉인은 옛 버전 그대로 유지**한다("무엇이 승인됐었나" 기록 보존, AC4·AC5).
- 막다른 길 차단(페드루 PO 정정 06:06Z) — `reapproval_required=true`인 게이트는 기존 게이트
  전이(`POST /gates/{id}/transition`)의 `approved` 전이 자체를 `409
  SITE_POST_RESUBMIT_REQUIRED`로 거부한다. 빠져나가는 길은 `submit()` 재호출(새 버전으로
  재봉인 + 플래그 해제) 뿐.
- 기존 공개 API(`POST /site-posts`)에 fail-closed 해시 비교 추가 — 봉인된 해시와 다른 본문
  공개 시도는 `409 SITE_POST_REAPPROVAL_REQUIRED`, 봉인 자체가 없는(S2 이전/우회) 승인
  게이트는 `409 SITE_POST_SEAL_MISSING`("모른다≠다르다", 페드루 PO 리뷰).
- `submit()`에 조직 기본 결재 역할이 없으면 `409 SITE_POST_APPROVER_ROLE_MISSING`(예전엔
  가짜 role_id로 게이트를 만드는 조용한 폴백이었다 — 명시 실패로 교정).
- `GET /gates`·`GET /gates/{id}` 응답에 `sealed_content_version`/`sealed_content_sha256`/
  `sealed_content_body`/`reapproval_required` 노출(S4 승인 카드·재승인 배지가 읽음).
- 목록 GET에 `origin_author_kind`(버전 1의 author_kind) 추가.

## ⚠️봉인 필드 — S3(미르코)가 읽을 정확한 위치

**neutral_facts가 아니라 `Gate` 전용 컬럼 4종이다** — merge gate의 `approved_head_sha`/
`github_check_run_sha`와 동형 축(전례 재사용, 신규 패턴 발명 0). content_version/
content_sha256/content_body는 neutral_facts JSON이 아니라 아래 컬럼에 있다:

| 필드 | 위치 | 타입 |
|---|---|---|
| `content_version` | `Gate.sealed_content_version` | int |
| `content_sha256` | `Gate.sealed_content_sha256` | text |
| `content_body` | `Gate.sealed_content_body` | text |
| `reapproval_required` | `Gate.reapproval_required` | bool |
| `destination` | `Gate.neutral_facts["destination"]` | `"hosted_site"` 고정 |
| `media_manifest_hash` | `Gate.neutral_facts["media_manifest_hash"]` | 빈 배열의 sha256(상수) |
| `draft_author_member_id` | `Gate.neutral_facts["draft_author_member_id"]` | uuid 문자열(버전 1 작성자) |
| `requested_by_member_id` | `Gate.neutral_facts["requested_by_member_id"]` | uuid 문자열(상신자) |

이렇게 나눈 이유: content_sha256 비교가 공개 요청마다(핫 패스) 도는데, JSONB 키 접근보다
컬럼이 인덱싱·타입 안전 양쪽에서 낫고, 이미 Gate 테이블에 있는 SHA-비교 전례
(`approved_head_sha`)와 정확히 같은 모양이라 재사용했다. `neutral_facts`는 나머지(감사·
통지용 서술 사실)만 담는다 — 이 테이블 나머지 값 전부의 기존 관례 그대로.

## API 계약

### 1) 상신(고객 에이전트 또는 휴먼)
```
POST /api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit
```
```json
{"version_id": null}
```
→ `200`
```json
{
  "gate_id": "5aa5e29d-...", "version_id": "35952de8-...",
  "content_sha256": "35cd1e8a3312...", "status": "pending"
}
```
같은 draft에 같은 내용(버전)으로 다시 호출하면 같은 `gate_id`·같은 `content_sha256`을
반환한다(멱등 — 재봉인하지 않는다).

### 2) pending 편집 vs 승인 후 편집 — 재봉인 시점이 다르다
`POST .../drafts`(S1의 버전 생성 엔드포인트)로 같은 draft에 새 버전을 추가할 때, 기존
external_publish 게이트가 있으면 그 트랜잭션 안에서:

| 게이트 현재 상태 | 결과 |
|---|---|
| `pending`(승인 전) | 즉시 그 새 버전으로 재봉인(`sealed_content_*` 갱신). 상태·플래그 불변. |
| `approved` | `pending`+`reapproval_required=true`로 되돌아가되, **`sealed_content_*`는 옛 버전 그대로**(재봉인 없음 — "무엇이 승인됐었나" 기록을 보존해야 다음 3)의 막다른 길 차단이 성립한다). |

### 3) 막다른 길 — 재승인 필요 게이트를 그대로 승인 시도
```
POST /api/v2/organizations/{org_id}/gates/{gate_id}/transition
```
```json
{"status": "approved"}
```
게이트가 `reapproval_required=true`인 동안은(위 표의 두 번째 행) → `409`
```json
{"data": null, "error": {"code": "SITE_POST_RESUBMIT_REQUIRED", "message": "..."}, "meta": null}
```
빠져나가는 길: `submit()`을 다시 호출 → 최신 버전으로 재봉인 + `reapproval_required=false` →
그 뒤에야 승인 가능.

### 4) 봉인된 해시와 다른 내용으로 공개 시도
```
POST /api/v2/organizations/{org_id}/site-posts
```
(gate가 여전히 `approved`인 상태에서 승인 안 받은 본문으로 호출 — 초안을 안 건드리고 이
엔드포인트만 직접 다른 body로 부르는 것도 포함, S1 이전부터 있던 계약이라 이 경로가 진짜
실사고 지점이었다.)
→ `409`
```json
{"data": null, "error": {"code": "SITE_POST_REAPPROVAL_REQUIRED", "message": "..."}, "meta": null}
```
`gate.sealed_content_sha256`이 `None`(S2 이전/우회로 만들어진 승인 게이트 — submit()을
한 번도 안 거침)이면 fail-closed로 별도 코드 → `409`
```json
{"data": null, "error": {"code": "SITE_POST_SEAL_MISSING", "message": "..."}, "meta": null}
```
두 경우 다 기존 공개 `SitePost` 행(본문)은 그대로 유지된다.

### 5) 상신 시 조직에 기본 결재 역할이 없으면
```
POST /api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit
```
→ `409`
```json
{"data": null, "error": {"code": "SITE_POST_APPROVER_ROLE_MISSING", "message": "..."}, "meta": null}
```
게이트 자체가 생성되지 않는다(예전엔 가짜 `role_id`로 만드는 조용한 폴백이었다).

### 6) 목록 GET origin_author_kind
```
GET /api/v2/organizations/{org_id}/site-posts/drafts
```
→ 항목에 `origin_author_kind`(버전 1) 추가 — `latest_author_kind`(최신 버전)와 짝.

## 뮤테이션 자체검증(로컬, 커밋엔 미포함) — 전부 실행·RED 확인·원복 완료
① `publish_site_post`의 hash/seal 비교 블록을 통째로 제거 → 409 테스트 2건(REAPPROVAL_
REQUIRED·SEAL_MISSING) 모두 201로 반드시 실패.
② 편집-훅(`_reseal_gate_on_new_version`)의 `approved` 분기에서 status-flip만 제거하고
재봉인 시도를 남기면(=조용히 새 본문으로 재봉인하면서도 approved로 남으면) 막다른 길 차단
테스트의 `gate.status == "pending"` assert가 반드시 실패 — 이게 "재검토 없이 새 본문이
승인된 것처럼 새는" 진짜 보안 축이다.

## 테스트
- `tests/test_3367_site_post_submit_gate_seal.py`(신규, realdb 11건 — 상신 봉인·에이전트
  pending 유지·멱등 재상신·pending 즉시재봉인·승인후편집 막다른길+resubmit 탈출·fail-closed
  2종·기본역할 누락·origin_author_kind)
- `tests/test_3365_site_post_drafts.py`·`tests/test_3360_site_posts.py`(seal_for로 정상
  봉인 시드하도록 갱신)·`tests/test_3291_external_publish_gate.py`(회귀 확인, 총 27건)
- gate 관련 mock 테스트 20파일(92건, `_authorize_gate_approve_equivalent`·can_approve·
  risk_grade·withdraw·hold·override 등) 전수 재확인 — `GateResponse`에 신규 non-Optional
  `reapproval_required` 필드 추가로 `gate_mock_factory.make_gate()`가 낡은 필드셋이 되며
  터진 실회귀 1건 발견·수정(`make_gate()` 기본값 보강 + `test_rc1_body_trust_actor.py`의
  손수 SimpleNamespace도 동일 보강).
- 마이그레이션 0310(down_revision=0308) upgrade/downgrade/re-upgrade 로컬 실PG 왕복 확인
  (스키마 자체는 이번 라운드 변경 없음 — 로직만).

## 범위 밖
다단계 결재 정책·예약 시각 봉인·예산 게이트·실제 미디어 해시 계산·댓글/광고 승인(스토리 명시).
승인본 서버 공개·URL·platform 감사(S3, 미르코 병렬 진행)는 이 PR의 sealed 필드를 그대로 읽는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm

