### PR TITLE
[SID:3369] 휴먼이 승인한 정확한 버전만 서버가 공개 — URL·platform 감사

### DIFF
--- a/backend/alembic/versions/0311_activity_logs_actor_type_platform.py
+++ b/backend/alembic/versions/0311_activity_logs_actor_type_platform.py
@@ -1,0 +1,47 @@
+"""story #3369(Phase0 S3·마케팅 운영 플랫폼 v3, 페드루 PO 확定 2026-09-03) —
+activity_logs.actor_type CHECK를 'platform'까지 넓힌다.
+
+승인은 human이 결정하지만 승인본을 공개 projection(site_posts)에 반영하는 실행 자체는
+서버(platform)가 한다 — "누가 결정했나"와 "누가 실행했나"를 같은 actor_type 값으로
+뭉치면 감사 로그에서 그 구분이 사라진다(story 4b580094 AC5). 순수 확장(기존 두 값은
+그대로 유지)이라 기존 row는 옛 값 그대로 새 CHECK를 통과한다 — 0287
+(usage_meters.meter_type)과 같은 관례.
+
+번호 의존성 — S2(story #3367, PR#3733)가 0310을 이미 썼다(gate.sealed_content_*).
+그 PR이 develop에 먼저 머지되면 이 리비전은 그대로 0310 위에 선다(순서 무관, 도메인이
+완전히 다르다 — activity_logs vs gate).
+
+Revision ID: 0311
+Revises: 0310
+Create Date: 2026-09-03
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0311"
+down_revision = "0310"
+branch_labels = None
+depends_on = None
+
+_NEW_TYPES = ("agent", "human", "platform")
+_OLD_TYPES = ("agent", "human")
+
+
+def _check_sql(values: tuple[str, ...]) -> str:
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"actor_type IN ({quoted})"
+
+
+def upgrade() -> None:
+    op.drop_constraint("ck_activity_logs_actor_type", "activity_logs", type_="check")
+    op.create_check_constraint(
+        "ck_activity_logs_actor_type", "activity_logs", _check_sql(_NEW_TYPES),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_activity_logs_actor_type", "activity_logs", type_="check")
+    op.create_check_constraint(
+        "ck_activity_logs_actor_type", "activity_logs", _check_sql(_OLD_TYPES),
+    )

--- a/backend/app/models/activity_log.py
+++ b/backend/app/models/activity_log.py
@@ -11,7 +11,8 @@ from app.core.database import Base
 class ActivityLog(Base):
     __tablename__ = "activity_logs"
     __table_args__ = (
-        CheckConstraint("actor_type IN ('agent', 'human')", name="ck_activity_logs_actor_type"),
+        # story #3369(Phase0 S3, migration 0311) — 'platform'(서버 자신의 기계적 실행) 추가.
+        CheckConstraint("actor_type IN ('agent', 'human', 'platform')", name="ck_activity_logs_actor_type"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -30,6 +30,7 @@ from app.services.site_posts import (
     list_site_post_draft_versions,
     list_site_post_drafts,
     publish_site_post,
+    publish_site_post_from_draft,
     submit_site_post_draft,
 )
 
@@ -297,4 +298,66 @@ async def submit_site_post_draft_endpoint(
     return SubmitSitePostDraftResponse(
         gate_id=gate.id, version_id=version_id, content_sha256=gate.sealed_content_sha256,
         status=gate.status,
+    )
+
+
+class PublishSitePostFromDraftResponse(BaseModel):
+    url: str
+    published_at: str
+    version_id: uuid.UUID
+
+
+@router.post(
+    "/{org_id}/site-posts/drafts/{draft_id}/publish", response_model=PublishSitePostFromDraftResponse,
+)
+async def publish_site_post_from_draft_endpoint(
+    org_id: uuid.UUID,
+    draft_id: uuid.UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> PublishSitePostFromDraftResponse:
+    """story #3369(Phase0 S3) — 휴먼이 승인된 최신 버전을 공개한다. draft_id 하나로 서버가
+    직접 최신 버전·게이트를 읽는다(발행 화면이 본문을 다시 보낼 필요 없음 — S4 계약).
+
+    가드 순서(AC2·AC3): ①에이전트 호출자 차단(SITE_POST_PUBLISH_HUMAN_ONLY) → ②게이트
+    approved 재검증(EXTERNAL_PUBLISH_APPROVAL_REQUIRED, auto_passed도 거부) → ③봉인
+    재검증(SEAL_MISSING/REAPPROVAL_REQUIRED)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    if await is_agent_caller(db, org_id=org_id, member_id=uuid.UUID(auth.user_id)):
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "SITE_POST_PUBLISH_HUMAN_ONLY",
+                "message": "글 공개는 휴먼 멤버만 가능합니다 (에이전트는 초안만 제출).",
+            },
+        )
+
+    try:
+        post, url, version_id = await publish_site_post_from_draft(
+            db, org_id=org_id, draft_id=draft_id, published_by_member_id=uuid.UUID(auth.user_id),
+            backend_base_url=str(request.base_url),
+        )
+    except SitePostDraftNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ExternalPublishGateNotApprovedError as exc:
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "EXTERNAL_PUBLISH_APPROVAL_REQUIRED", "message": str(exc)},
+        ) from exc
+    except SitePostSealMissingError as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": "SITE_POST_SEAL_MISSING", "message": str(exc)},
+        ) from exc
+    except SitePostReapprovalRequiredError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "SITE_POST_REAPPROVAL_REQUIRED", "message": str(exc)},
+        ) from exc
+
+    return PublishSitePostFromDraftResponse(
+        url=url, published_at=post.published_at.isoformat(), version_id=version_id,
     )

--- a/backend/app/services/activity_log.py
+++ b/backend/app/services/activity_log.py
@@ -16,7 +16,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-ActorType = Literal["agent", "human"]
+# story #3369(Phase0 S3, 마케팅운영) — "platform"은 서버 자신이 기계적으로 실행한 행위
+# (승인은 human이 결정했지만 공개 projection 반영 자체는 platform이 한다, 도크 4b580094
+# AC5)를 human/agent 어느 쪽도 아닌 제3의 행위자로 구분하기 위한 신규 값. 마이그레이션
+# 0311이 activity_logs.actor_type CHECK 제약을 이 값까지 넓힌다.
+ActorType = Literal["agent", "human", "platform"]
 
 
 async def record_activity_bg(
@@ -111,8 +115,8 @@ class ActivityLogService:
         context: dict | None = None,
     ) -> ActivityLog:
         """activity_logs row 생성. immutable — update/delete 없음. (AC2, AC3, AC4, AC5)"""
-        if actor_type not in ("agent", "human"):
-            raise ValueError(f"actor_type must be 'agent' or 'human', got {actor_type!r}")
+        if actor_type not in ("agent", "human", "platform"):
+            raise ValueError(f"actor_type must be 'agent', 'human', or 'platform', got {actor_type!r}")
 
         log = ActivityLog(
             org_id=org_id,

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -173,24 +173,47 @@ async def publish_site_post(
     if current_hash != gate.sealed_content_sha256:
         raise SitePostReapprovalRequiredError(gate_id=gate.id)
 
+    row = await _upsert_site_post_row(
+        db, org_id=org_id, work_item_id=work_item_id, gate_id=gate.id, title=title, slug=slug,
+        lang=lang, summary=summary, tags=tags, body_md=body_md, created_by_member_id=created_by_member_id,
+    )
+    await db.commit()
+    return row
+
+
+async def _upsert_site_post_row(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    work_item_id: uuid.UUID,
+    gate_id: uuid.UUID,
+    title: str,
+    slug: str,
+    lang: str,
+    summary: str,
+    tags: list,
+    body_md: str,
+    created_by_member_id: uuid.UUID,
+) -> SitePost:
+    """story #3369(Phase0 S3) 추출 — publish_site_post(레거시 endpoint)와
+    publish_site_post_from_draft(신규 draft 기반 endpoint) 둘 다 같은 upsert가 필요해
+    갈랐다. commit은 호출자 몫(신규 경로는 같은 트랜잭션에 activity_log를 얹는다)."""
     now = datetime.now(timezone.utc)
     stmt = pg_insert(SitePost).values(
         id=uuid.uuid4(), org_id=org_id, lang=lang, slug=slug, title=title, summary=summary,
         tags=tags, body_md=body_md, published_at=now, source_story_id=work_item_id,
-        gate_id=gate.id, created_by_member_id=created_by_member_id, unpublished_at=None,
+        gate_id=gate_id, created_by_member_id=created_by_member_id, unpublished_at=None,
     )
     stmt = stmt.on_conflict_do_update(
         constraint="uq_site_posts_org_lang_slug",
         set_={
             "title": title, "summary": summary, "tags": tags, "body_md": body_md,
-            "published_at": now, "source_story_id": work_item_id, "gate_id": gate.id,
+            "published_at": now, "source_story_id": work_item_id, "gate_id": gate_id,
             "unpublished_at": None, "updated_at": now,
             # created_by_member_id는 최초 발행자 그대로 — 재발행이 저자를 안 바꾼다.
         },
     ).returning(SitePost)
-    row = (await db.execute(stmt)).scalar_one()
-    await db.commit()
-    return row
+    return (await db.execute(stmt)).scalar_one()
 
 
 async def get_published_site_post(db: AsyncSession, *, org_id: uuid.UUID, lang: str, slug: str) -> SitePost | None:
@@ -487,3 +510,110 @@ async def submit_site_post_draft(
     await db.commit()
     await db.refresh(gate)
     return gate, target.id
+
+
+# ─── story #3369(Phase0 S3) — 승인본만 서버가 공개, URL, platform 감사 ─────────────
+
+async def _resolve_public_url(
+    db: AsyncSession, *, org_id: uuid.UUID, lang: str, slug: str, backend_base_url: str,
+) -> str:
+    """사람용 URL 조립 — 조직 설정 `site` 커넥터의 org_config.site_base_url이 있으면
+    그것 + `/{lang}/blog/{slug}`(PO 보정, doc 62fc03ee §4). 없으면(오늘은 어느 org도
+    `site` 커넥터를 등록하지 않았다 — 실측 확認) 공개 API URL로 fallback한다(AC4: "설정이
+    없으면 공개 API URL을 반환"). 새 env 상수를 만들지 않는다 — 공개 API가 이 백엔드
+    자신이 서빙하는 라우트라 호출 시점의 `request.base_url`(backend_base_url)로 충분하다."""
+    from app.services.connector_registry import get_org_connector
+
+    connector = await get_org_connector(db, org_id=org_id, connector_key="site")
+    site_base_url = None
+    if connector is not None:
+        raw = connector.org_config.get("site_base_url")
+        if isinstance(raw, str) and raw.strip():
+            site_base_url = raw.rstrip("/")
+
+    if site_base_url is not None:
+        return f"{site_base_url}/{lang}/blog/{slug}"
+
+    from app.services.pageview_counter import get_or_create_active_key
+
+    public_key = await get_or_create_active_key(db, org_id=org_id)
+    return f"{backend_base_url.rstrip('/')}/api/v2/public/site-posts/{slug}?public_key={public_key}&lang={lang}"
+
+
+async def publish_site_post_from_draft(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    draft_id: uuid.UUID,
+    published_by_member_id: uuid.UUID,
+    backend_base_url: str,
+) -> tuple[SitePost, str, uuid.UUID]:
+    """story #3369(Phase0 S3) AC1~AC5 — draft의 최신 버전을, 그 버전을 봉인한
+    external_publish 게이트가 실제로 `approved`일 때만 공개 projection에 반영한다.
+
+    레거시 `publish_site_post`(POST /site-posts, 호출자가 본문 전체를 다시 보낸다)와
+    달리 이 경로는 draft_id 하나로 최신 버전을 서버가 직접 읽는다(위조 불가). 게이트
+    상태는 `approved` **정확히 일치**로만 인정한다(`auto_passed`도 거부 — 뮤테이션
+    대상: 이 검사를 `_APPROVED_STATUSES` 세트로 완화하면 회귀 테스트가 반드시 실패해야
+    한다. 레거시 경로가 auto_passed를 허용하는 것과 의도적으로 다르다 — Phase 0
+    external_publish는 항상-수동 게이트라 auto_passed 분기가 원래 도달 불가능하지만
+    (S1 doc 62fc03ee §3-1 각주), 이 새 endpoint 자신의 계약으로 한 번 더 못박는다).
+
+    봉인 재검증(SitePostSealMissingError/SitePostReapprovalRequiredError)은 레거시
+    publish_site_post와 이제 완전히 같은 규칙이다(페드루 PO 리뷰 2026-09-03 05:59Z로
+    레거시도 fail-closed가 됐다 — 최초 구현 당시엔 레거시가 더 관대했으나 그 차이는
+    리뷰로 없어졌다). gates.py의 approve 전이 가드(SITE_POST_RESUBMIT_REQUIRED, 페드루
+    PO 06:06Z)가 이미 "옛 봉인을 승인"하는 경로 자체를 막아, approved인데 해시가 다른
+    행은 정상 경로로 이중으로 도달 불가능하다 — 그래도 방어망으로 남긴다."""
+    draft = await get_site_post_draft(db, org_id=org_id, draft_id=draft_id)
+    if draft is None:
+        raise SitePostDraftNotFoundError(draft_id)
+
+    versions = await list_site_post_draft_versions(db, draft_id=draft_id)
+    if not versions:
+        raise SitePostDraftNotFoundError(draft_id)
+    latest = versions[-1]
+
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    gate = await find_gate_slot_with_pr_fallback(
+        db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
+        gate_type="external_publish", pr_number=None, repo_full_name=None,
+    )
+    if gate is None or gate.status != "approved":
+        raise ExternalPublishGateNotApprovedError(
+            gate_id=gate.id if gate is not None else None,
+            status=gate.status if gate is not None else None,
+        )
+
+    if gate.sealed_content_sha256 is None:
+        raise SitePostSealMissingError(gate_id=gate.id)
+    if gate.sealed_content_sha256 != latest.body_sha256:
+        raise SitePostReapprovalRequiredError(gate_id=gate.id)
+
+    post = await _upsert_site_post_row(
+        db, org_id=org_id, work_item_id=draft.work_item_id, gate_id=gate.id,
+        title=latest.title, slug=draft.slug, lang=latest.lang, summary=latest.summary,
+        tags=latest.tags, body_md=latest.body_md, created_by_member_id=published_by_member_id,
+    )
+    url = await _resolve_public_url(
+        db, org_id=org_id, lang=latest.lang, slug=draft.slug, backend_base_url=backend_base_url,
+    )
+
+    # AC5 — 승인 actor(human)는 게이트 승인 시점에 이미 별도로 기록된다(gate_service.py 몫,
+    # 이 함수가 새로 만들지 않는다). 여기서 기록하는 것은 "공개 projection 반영"이라는
+    # platform의 기계적 실행 그 자체 — actor_type=platform·actor_id=None(사람이 아니라
+    # 플랫폼이 한 일이라는 구분이 AC의 핵심), 누가 눌렀는지는 context에 보존한다.
+    from app.services.activity_log import ActivityLogService
+
+    await ActivityLogService(db).record(
+        org_id=org_id, action="site_post_published", actor_type="platform", actor_id=None,
+        entity_type="site_post", entity_id=post.id,
+        context={
+            "gate_id": str(gate.id), "version_id": str(latest.id), "url": url,
+            "published_by_member_id": str(published_by_member_id),
+        },
+    )
+    await db.commit()
+    await db.refresh(post)
+    return post, url, latest.id

--- a/backend/tests/test_3369_publish_site_post_from_draft.py
+++ b/backend/tests/test_3369_publish_site_post_from_draft.py
@@ -1,0 +1,668 @@
+"""story #3369(Phase0 S3·마케팅 운영 플랫폼 v3, 페드루 PO 확定 2026-09-03) — 휴먼이 승인한
+정확한 버전만 서버가 공개하고 URL과 platform 감사를 남긴다.
+
+AC 매핑:
+- AC1: 인증된 조직 휴먼이 승인된 최신 버전에 "발행"을 요청하면 서버가 봉인을 재검증한 뒤
+  그 버전만 SitePost 공개 projection에 반영한다.
+- AC2: 게이트가 없거나 pending/rejected/auto_passed면 403 EXTERNAL_PUBLISH_APPROVAL_
+  REQUIRED — Phase 0 external_publish는 실제 휴먼 approved만 인정한다(auto_passed 포함
+  거부 — 뮤테이션 대상).
+- AC3: 고객 에이전트가 같은 endpoint를 호출하면 승인 유무와 무관하게 403 SITE_POST_
+  PUBLISH_HUMAN_ONLY.
+- AC4: 성공 응답은 공개 URL을 반환하고, 그 URL을 익명 GET하면 승인된 제목·본문과 200이
+  관측된다. site 커넥터 org_config.site_base_url이 있으면 그것 기반, 없으면 공개 API URL.
+- AC5: 성공 시 감사 로그에 공개 실행 actor=platform, gate_id·version_id·URL이 연결된다.
+- AC6: 승인 후 수정된 버전의 발행 요청이 거부되면(SEAL_MISSING/REAPPROVAL_REQUIRED) 이전에
+  공개된 URL과 본문은 그대로 유지된다.
+- AC7: 재승인 후 다시 발행하면 같은 글의 공개 projection이 새 버전으로 갱신되고, 감사
+  로그에는 두 발행의 version ID가 구분되어 남는다.
+
+뮤테이션 1건(스토리 본문 명시) — auto_passed를 공개 가능 상태에 다시 포함한다:
+publish_site_post_from_draft()의 `gate.status != "approved"`를
+`gate.status not in ("approved", "auto_passed")`로 완화하면
+test_auto_passed_gate_is_rejected_not_approved가 반드시 실패해야 한다(403 대신 200).
+로컬 자체검증 절차는 파일 맨 아래 주석 — 실행은 세션 로그 참고, 커밋엔 미포함."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Publish Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="담롱"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_human(session, org_id, *, role="member"):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="2호 글"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_default_role(session, org_id):
+    """story #3367(PR#3733 리뷰 반영) — submit()이 기본 역할 없으면 명시 거부한다
+    (SITE_POST_APPROVER_ROLE_MISSING). 이 파일의 submit() 경유 테스트는 모두 이 시드가
+    필요하다(test_3367의 동일 헬퍼 그대로 재사용)."""
+    from app.models.participation import ParticipationRole
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+    session.add(role)
+    await session.commit()
+    return role.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _draft_body(*, work_item_id, slug="2ho-blog", lang="ko", title="2호 글", body_md="# 제목\n\n본문입니다."):
+    return {
+        "work_item_id": str(work_item_id), "slug": slug, "lang": lang, "title": title,
+        "summary": "요약입니다", "tags": ["ai"], "body_md": body_md, "media_manifest": [],
+    }
+
+
+async def _approve_gate_directly(session, gate_id, *, status="approved"):
+    """휴먼 결재 UI 왕복(gates.py) 없이 상태만 만든다(test_3367과 동형 관례) — 이 테스트의
+    관심사는 site_posts.py의 재검증 로직이지 gates.py의 승인 authz가 아니다."""
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    gate = (await session.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+    gate.status = status
+    gate.resolver_id = uuid.uuid4()
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.commit()
+
+
+async def _submit_and_approve(client, session, *, org_id, draft_id, status="approved"):
+    """draft를 상신(봉인)하고 곧바로 승인 상태로 만든다 — 이 파일 전체가 재사용하는 조합."""
+    r = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={})
+    assert r.status_code == 200, r.text
+    gate_id = uuid.UUID(r.json()["gate_id"])
+    await _approve_gate_directly(session, gate_id, status=status)
+    return gate_id
+
+
+@pytest.mark.anyio
+async def test_publish_success_matching_seal_creates_public_projection_and_platform_audit():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id),
+            )
+            assert r_draft.status_code == 201, r_draft.text
+            draft_id = r_draft.json()["draft_id"]
+            version_id = r_draft.json()["version_id"]
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client, Session() as s:
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+            assert r_submit.status_code == 200, r_submit.text
+            gate_id = uuid.UUID(r_submit.json()["gate_id"])
+            await _approve_gate_directly(s, gate_id)
+
+            r_pub = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub.status_code == 200, r_pub.text
+        payload = r_pub.json()
+        assert payload["version_id"] == version_id
+        assert payload["url"]
+        assert payload["published_at"]
+
+        # AC4 — 공개 URL을 익명 GET하면 승인된 제목·본문과 200.
+        from urllib.parse import urlparse
+        parsed = urlparse(payload["url"])
+        async with _client_for(app) as anon_client:
+            r_public = await anon_client.get(parsed.path + "?" + parsed.query)
+        assert r_public.status_code == 200, r_public.text
+        assert r_public.json()["title"] == "2호 글"
+        assert r_public.json()["body_md"] == "# 제목\n\n본문입니다."
+
+        # AC5 — activity_log에 platform actor로 gate_id·version_id·url이 연결된다.
+        async with Session() as s:
+            from app.models.activity_log import ActivityLog
+            from sqlalchemy import select
+            logs = (await s.execute(
+                select(ActivityLog).where(
+                    ActivityLog.org_id == org_id, ActivityLog.action == "site_post_published",
+                )
+            )).scalars().all()
+        assert len(logs) == 1
+        log = logs[0]
+        assert log.actor_type == "platform"
+        assert log.actor_id is None
+        assert log.context["gate_id"] == str(gate_id)
+        assert log.context["version_id"] == version_id
+        assert log.context["url"] == payload["url"]
+        assert log.context["published_by_member_id"] == str(human_id)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_caller_gets_human_only_403_and_no_projection_written():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client, Session() as s:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts", json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            await _submit_and_approve(client, s, org_id=org_id, draft_id=draft_id)
+
+            r_pub = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub.status_code == 403, r_pub.text
+        assert r_pub.json()["error"]["code"] == "SITE_POST_PUBLISH_HUMAN_ONLY"
+
+        async with Session() as s:
+            from app.models.site_post import SitePost
+            from sqlalchemy import select
+            rows = (await s.execute(select(SitePost).where(SitePost.org_id == org_id))).scalars().all()
+        assert rows == []
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_pending_gate_returns_approval_required_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts", json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+        assert r_submit.json()["status"] == "pending"  # 승인 안 함 — 그대로 pending
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_pub = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub.status_code == 403, r_pub.text
+        assert r_pub.json()["error"]["code"] == "EXTERNAL_PUBLISH_APPROVAL_REQUIRED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_gate_at_all_returns_approval_required_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts", json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+        # submit()을 아예 안 함 — 게이트 자체가 없다.
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_pub = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub.status_code == 403, r_pub.text
+        assert r_pub.json()["error"]["code"] == "EXTERNAL_PUBLISH_APPROVAL_REQUIRED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_auto_passed_gate_is_rejected_not_approved():
+    """AC2 핵심 — 뮤테이션 대상 라인이 지키는 바로 그 테스트. auto_passed는 이 endpoint에서
+    성공으로 치지 않는다(레거시 publish_site_post는 허용하지만 이 draft 기반 endpoint는 더
+    엄격하다 — 페드루 PO 명시)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client, Session() as s:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts", json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            await _submit_and_approve(client, s, org_id=org_id, draft_id=draft_id, status="auto_passed")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_pub = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub.status_code == 403, r_pub.text
+        assert r_pub.json()["error"]["code"] == "EXTERNAL_PUBLISH_APPROVAL_REQUIRED"
+
+        async with Session() as s:
+            from app.models.site_post import SitePost
+            from sqlalchemy import select
+            rows = (await s.execute(select(SitePost).where(SitePost.org_id == org_id))).scalars().all()
+        assert rows == [], "auto_passed로 공개 projection이 만들어지면 안 된다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_seal_missing_returns_409_and_writes_nothing():
+    """AC1·설계 정정(페드루 2026-09-03) — submit()을 거치지 않고 승인만 만들면
+    sealed_content_sha256이 None이다. 레거시 publish_site_post는 이 경우 검사를 skip하지만,
+    이 draft 기반 endpoint는 fail-closed로 409 SITE_POST_SEAL_MISSING을 낸다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts", json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/submit", json={},
+            )
+            gate_id = uuid.UUID(r_submit.json()["gate_id"])
+
+        # submit()이 만든 게이트를 안 쓰고, 다른 경로로(예: 구식 마이그레이션 이전 게이트를
+        # 흉내) sealed_content_*를 직접 지워 "봉인 없이 승인됨" 상태를 재현한다.
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select, update
+            await s.execute(
+                update(Gate).where(Gate.id == gate_id).values(
+                    status="approved", sealed_content_sha256=None, sealed_content_version=None,
+                    sealed_content_body=None, resolver_id=uuid.uuid4(), resolved_at=datetime.now(timezone.utc),
+                )
+            )
+            await s.commit()
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_pub = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub.status_code == 409, r_pub.text
+        assert r_pub.json()["error"]["code"] == "SITE_POST_SEAL_MISSING"
+
+        async with Session() as s:
+            from app.models.site_post import SitePost
+            from sqlalchemy import select
+            rows = (await s.execute(select(SitePost).where(SitePost.org_id == org_id))).scalars().all()
+        assert rows == []
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_hash_mismatch_defense_in_depth_returns_409_reapproval_required():
+    """AC6 방어망 — 정상 경로로는 승인 후 편집이 게이트를 pending으로 되돌려(_reopen_
+    approved_gate_after_edit) 이 분기가 도달 불가능하다(페드루 PO 확인 2026-09-03). 그래도
+    "approved인데 해시가 다른" 행이 다른 경로로 생기는 경우를 막는 방어망이 실제로 작동하는지
+    직접 그 상태를 만들어 확인한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client, Session() as s:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts", json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            gate_id = await _submit_and_approve(client, s, org_id=org_id, draft_id=draft_id)
+
+        # 방어망 재현 — approved 유지한 채 봉인 해시만 강제로 다른 값으로 바꾼다(정상 경로로는
+        # 절대 안 생기는 조합, 위 파일독 주석 그대로).
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import update
+            await s.execute(update(Gate).where(Gate.id == gate_id).values(sealed_content_sha256="다른-해시"))
+            await s.commit()
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_pub = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub.status_code == 409, r_pub.text
+        assert r_pub.json()["error"]["code"] == "SITE_POST_REAPPROVAL_REQUIRED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_rejected_publish_keeps_previously_published_body_unchanged():
+    """AC6 — 최초 발행 성공 후, 편집(v2)이 게이트를 pending으로 되돌린 상태에서 재상신 없이
+    발행을 재시도하면 403(승인 필요)이고, 기존 공개본(v1)은 그대로 유지된다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client, Session() as s:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts", json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            await _submit_and_approve(client, s, org_id=org_id, draft_id=draft_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_pub1 = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub1.status_code == 200, r_pub1.text
+        url_v1 = r_pub1.json()["url"]
+
+        # 승인 후 편집 — 게이트가 자동으로 pending+reapproval_required=True로 되돌아간다.
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r_v2 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, body_md="# 제목\n\n수정된 본문."),
+            )
+        assert r_v2.status_code == 201, r_v2.text
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_pub2 = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub2.status_code == 403, r_pub2.text
+        assert r_pub2.json()["error"]["code"] == "EXTERNAL_PUBLISH_APPROVAL_REQUIRED"
+
+        from urllib.parse import urlparse
+        parsed = urlparse(url_v1)
+        async with _client_for(app) as anon_client:
+            r_public = await anon_client.get(parsed.path + "?" + parsed.query)
+        assert r_public.status_code == 200
+        assert r_public.json()["body_md"] == "# 제목\n\n본문입니다.", "거부된 재발행이 기존 공개본을 건드리면 안 된다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_republish_after_reapproval_updates_projection_and_logs_distinct_versions():
+    """AC7 — 재승인 후 다시 발행하면 같은 글의 공개 projection이 새 버전으로 갱신되고,
+    감사 로그에는 두 발행의 version ID가 구분되어 남는다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client, Session() as s:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts", json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            v1_id = r_draft.json()["version_id"]
+            await _submit_and_approve(client, s, org_id=org_id, draft_id=draft_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_pub1 = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub1.status_code == 200, r_pub1.text
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client, Session() as s:
+            r_v2 = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json=_draft_body(work_item_id=story_id, body_md="# 제목\n\n재승인된 본문."),
+            )
+            v2_id = r_v2.json()["version_id"]
+            await _submit_and_approve(client, s, org_id=org_id, draft_id=draft_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_pub2 = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub2.status_code == 200, r_pub2.text
+        assert r_pub2.json()["version_id"] == v2_id
+        assert r_pub2.json()["version_id"] != v1_id
+
+        async with Session() as s:
+            from app.models.site_post import SitePost
+            from sqlalchemy import select
+            posts = (await s.execute(select(SitePost).where(SitePost.org_id == org_id))).scalars().all()
+        assert len(posts) == 1, "같은 (org,lang,slug) — 새 행이 아니라 upsert여야 한다"
+        assert posts[0].body_md == "# 제목\n\n재승인된 본문."
+
+        async with Session() as s:
+            from app.models.activity_log import ActivityLog
+            from sqlalchemy import select
+            logs = (await s.execute(
+                select(ActivityLog)
+                .where(ActivityLog.org_id == org_id, ActivityLog.action == "site_post_published")
+                .order_by(ActivityLog.created_at.asc())
+            )).scalars().all()
+        assert len(logs) == 2
+        assert {log.context["version_id"] for log in logs} == {v1_id, v2_id}
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_url_uses_configured_site_base_url_over_public_api_fallback():
+    """AC4 — 조직 설정 site 커넥터의 org_config.site_base_url이 있으면 그것 기반
+    (+/{lang}/blog/{slug}), 없으면(다른 모든 테스트) 공개 API URL로 fallback한다."""
+    from app.main import app
+    from app.services.connector_registry import set_org_connector_config, set_org_connector_schema
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            await set_org_connector_schema(
+                s, org_id=org_id, connector_key="site", version="0.1.0", channel="stable",
+                fields=[{"name": "site_base_url", "source": "org_config", "type": "string", "required": False}],
+                requires_env=[], created_by=None,
+            )
+            await set_org_connector_config(
+                s, org_id=org_id, connector_key="site", config={"site_base_url": "https://sprintable.ai"},
+            )
+            await s.commit()  # 두 함수 다 flush만 한다 — 세션 종료 전 커밋 안 하면 롤백된다
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id)
+        async with _client_for(app) as client, Session() as s:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts", json=_draft_body(work_item_id=story_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            await _submit_and_approve(client, s, org_id=org_id, draft_id=draft_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_pub = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub.status_code == 200, r_pub.text
+        assert r_pub.json()["url"] == "https://sprintable.ai/ko/blog/2ho-blog"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── 뮤테이션 자체검증(로컬, 커밋엔 미포함) ─────────────────────────────────────
+# ① app/services/site_posts.py::publish_site_post_from_draft의
+#    `if gate is None or gate.status != "approved":`를
+#    `if gate is None or gate.status not in ("approved", "auto_passed"):`로 완화 →
+#    test_auto_passed_gate_is_rejected_not_approved 실행 → 403 대신 200으로 RED 확인 →
+#    원복 → GREEN 재확인.


### PR DESCRIPTION
## 요약
Phase0·마케팅운영 블루프린트 v3 S3(페드루 PO 재배분 2026-09-03 05:56Z — 디디→미르코, S4가 S2 대기로 손이 빔). S2(#3733, story #3367)의 `Gate.sealed_content_*` 컬럼을 재검증해 승인된 정확한 버전만 서버가 공개 projection에 반영한다.

**base는 임시로 S2(PR#3733) 브랜치** — S2가 develop에 머지되면 GitHub이 base를 자동으로 develop으로 전환한다(페드루 지시). 그 사이 리뷰·QA 병렬 진행.

## 변경
- `POST /organizations/{org}/site-posts/drafts/{draft_id}/publish`(신규, 휴먼 전용) — draft_id 하나로 서버가 직접 최신 버전을 읽는다.
  - 가드: 에이전트 차단(`SITE_POST_PUBLISH_HUMAN_ONLY`) → 게이트 `status=='approved'` 정확 일치(`auto_passed`도 거부 — `EXTERNAL_PUBLISH_APPROVAL_REQUIRED`, 뮤테이션 대상) → 봉인 재검증(S2의 기존 `SitePostSealMissingError`/`SitePostReapprovalRequiredError` 재사용 — 409 `SEAL_MISSING`/`REAPPROVAL_REQUIRED`).
  - S2의 `gates.py` approve 전이 가드(`reapproval_required=True`면 409 `SITE_POST_RESUBMIT_REQUIRED`)가 "옛 봉인을 승인"하는 경로를 이미 막아, "approved인데 해시 다름"은 정상 경로로 도달 불가 — 방어망으로 유지.
  - 성공 시 `SitePost` upsert(`_upsert_site_post_row`로 레거시 `publish_site_post`와 공유 추출) + 공개 URL 조립(조직 `site` 커넥터 `org_config.site_base_url`, 없으면 백엔드 자신의 공개 API URL) + `activity_log`(`actor_type=platform`·`actor_id=None`, `context`에 `gate_id`·`version_id`·`url`·`published_by_member_id`).
- 마이그레이션 0311 — `activity_logs.actor_type` CHECK를 `platform`까지 확장(순수 확장).

## 테스트
`tests/test_3369_publish_site_post_from_draft.py`(신규, realdb 10건) — 성공+URL+platform 감사·에이전트 차단·pending/게이트없음/`auto_passed` 403·`SEAL_MISSING`/해시불일치 409·거부된 재발행이 기존 공개본 보존(AC6)·재승인 후 재발행이 projection 갱신+감사 2건 구분(AC7)·`site_base_url` 우선순위(AC4).

뮤테이션 1건(로컬 자체검증, 커밋 미포함) — `approved` 정확일치 체크를 `(approved, auto_passed)` 세트로 완화 → RED(403 대신 200) 확인 후 원복 → GREEN 재확인.

회귀: `test_3360`/`test_3365`/`test_3367`/`test_3291`/`test_rc1_body_trust_actor` 전부(37건) 재확인. ruff 신규 위반 0.

## 범위 밖
gates.py의 `SITE_POST_RESUBMIT_REQUIRED` 가드는 S2(#3733) 몫(이미 포함) — 이 PR이 새로 만들지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lbwgf71pVGzZ6NPntw5JCC