### PR TITLE
[SID:3377] 시각 산출물 뷰어 html_blob iframe sandbox=""→allow-scripts + 「크게 보기」 상호작용 토글

### DIFF
--- a/apps/web/e2e/artifact-viewer-sandbox.spec.ts
+++ b/apps/web/e2e/artifact-viewer-sandbox.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * story #3377(결함·customer-zero) — 시각 산출물 뷰어 html_blob iframe이 `sandbox=""`라
+ * 스크립트가 전부 차단돼 인터랙티브 프로토타입이 정지 화면으로 보이던 결함.
+ *
+ * 이 파일은 앱(로그인·백엔드) 전체를 왕복하지 않고 브라우저 sandbox 계약 자체를
+ * `page.setContent()`로 직접 재현해 검증한다 — AC가 실제로 묻는 건 "이 iframe 속성
+ * 조합이 브라우저에서 어떻게 동작하는가"이지 우리 React 배선이 아니다(그 배선은
+ * artifact-stage.test.tsx/artifact-expand-dialog.test.tsx가 jsdom으로 덮는다). 크리덴셜
+ * 불요·백엔드 불요 — 항상 실행된다(default-off 아님).
+ *
+ * 실행: pnpm exec playwright test e2e/artifact-viewer-sandbox.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+// ArtifactStage(artifact-stage.tsx)가 실제로 렌더하는 형태 그대로 재현 — sandbox 값과
+// pointer-events 클래스만 시나리오별로 바꾼다(props htmlInteractive와 1:1 대응).
+function harnessHtml(opts: { sandbox: string; pointerEventsAuto: boolean }): string {
+  const iframeClass = opts.pointerEventsAuto ? '' : 'pointer-events-none';
+  return `<!doctype html><html><body>
+    <div id="stage" style="width:400px;height:300px;position:relative">
+      <iframe id="target" title="artifact" sandbox="${opts.sandbox}" class="${iframeClass}"
+        style="width:400px;height:300px;border:0;${opts.pointerEventsAuto ? '' : 'pointer-events:none;'}"
+        srcdoc="&lt;!doctype html&gt;&lt;body style='margin:0'&gt;
+          &lt;a id='link' href='#next' onclick=&quot;document.body.dataset.clicked='1'&quot;
+             style='display:block;width:400px;height:300px;'&gt;다음 화면&lt;/a&gt;
+          &lt;script&gt;
+            window.__ran = true;
+            try { window.parent.document; window.__parentAccess = 'ok'; }
+            catch (e) { window.__parentAccess = 'blocked:' + e.name; }
+          &lt;/script&gt;
+        &lt;/body&gt;"
+      ></iframe>
+    </div>
+  </body></html>`;
+}
+
+test.describe('artifact viewer iframe sandbox (story #3377)', () => {
+  test('allow-scripts runs the artifact\'s JS but blocks parent DOM access (no allow-same-origin)', async ({ page }) => {
+    await page.setContent(harnessHtml({ sandbox: 'allow-scripts', pointerEventsAuto: true }));
+    const frame = page.frameLocator('#target');
+    await expect(frame.locator('#link')).toBeVisible();
+
+    const frameHandle = await page.$('#target');
+    const contentFrame = await frameHandle!.contentFrame();
+    const ran = await contentFrame!.evaluate(() => (window as unknown as { __ran?: boolean }).__ran);
+    expect(ran).toBe(true); // 결함 재현 — 예전 sandbox=""였으면 스크립트가 전혀 안 돌아 이게 undefined였다
+
+    const parentAccess = await contentFrame!.evaluate(() => (window as unknown as { __parentAccess?: string }).__parentAccess);
+    expect(parentAccess).toMatch(/^blocked:/); // 뮤테이션 대상 — allow-same-origin을 더하면 'ok'가 되어 RED
+  });
+
+  test('interactive(pointer-events:auto) lets a real click reach the iframe and change its DOM (hash 라우팅 전제)', async ({ page }) => {
+    await page.setContent(harnessHtml({ sandbox: 'allow-scripts', pointerEventsAuto: true }));
+    const frameHandle = await page.$('#target');
+    // test 3(비상호작용)과 동일한 실좌표 클릭 방식이라야 pointer-events 차이만 대조된다.
+    // 클릭이 실제로 앵커 href(#next)를 발화시켜 iframe 자신의 URL 프래그먼트가 바뀌는지로
+    // 판별한다(hash 라우팅 전제 그 자체) — onclick의 JS부수효과는 같은 클릭이 hash 네비를
+    // 동반해 실행 컨텍스트가 갈리므로(정상 동작) 그 값을 읽으려 들지 않는다.
+    const bounds = (await frameHandle!.boundingBox())!;
+    await page.mouse.click(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
+    await expect.poll(() => frameHandle!.contentFrame().then((f) => f?.url())).toMatch(/#next$/);
+  });
+
+  test('non-interactive(pointer-events:none) — a click at the iframe\'s coordinates never reaches its DOM (캔버스 pan 설계 보존, 회귀 0)', async ({ page }) => {
+    await page.setContent(harnessHtml({ sandbox: 'allow-scripts', pointerEventsAuto: false }));
+    const box = (await page.$('#target'))!;
+    const bounds = (await box.boundingBox())!;
+    // pointer-events:none이면 이 좌표 클릭은 iframe 아래(부모 div)로 그대로 통과한다 —
+    // 실제 브라우저 히트테스트 계약을 검증(className 문자열 존재 확인이 아니라 진짜 클릭).
+    await page.mouse.click(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
+    const frameHandle = await page.$('#target');
+    const contentFrame = await frameHandle!.contentFrame();
+    const clicked = await contentFrame!.evaluate(() => document.body.dataset['clicked']);
+    expect(clicked).toBeUndefined();
+  });
+});

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4509,7 +4509,11 @@
     "viewerActualSizeAction": "Actual size",
     "responsivePreviewDesktop": "Desktop",
     "responsivePreviewTablet": "Tablet",
-    "responsivePreviewMobile": "Mobile"
+    "responsivePreviewMobile": "Mobile",
+    "artifactInteractiveOn": "Interactive on",
+    "artifactInteractiveOff": "Interactive off",
+    "artifactInteractiveOnHint": "Clicks reach the artifact's own buttons · turn off to pan the canvas instead",
+    "artifactInteractiveOffHint": "The artifact isn't clickable right now · turn on to press its buttons"
   },
   "releaseNotes": {
     "whatsNew": "What's new",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4513,7 +4513,8 @@
     "artifactInteractiveOn": "Interactive on",
     "artifactInteractiveOff": "Interactive off",
     "artifactInteractiveOnHint": "Clicks reach the artifact's own buttons · turn off to pan the canvas instead",
-    "artifactInteractiveOffHint": "The artifact isn't clickable right now · turn on to press its buttons"
+    "artifactInteractiveOffHint": "The artifact isn't clickable right now · turn on to press its buttons",
+    "artifactStageInteractiveHint": "To click through the flow, open Expand → Interactive"
   },
   "releaseNotes": {
     "whatsNew": "What's new",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4513,7 +4513,8 @@
     "artifactInteractiveOn": "상호작용 켬",
     "artifactInteractiveOff": "상호작용 끔",
     "artifactInteractiveOnHint": "클릭하면 산출물 안 버튼이 눌립니다 · 끄면 캔버스 이동으로 바뀝니다",
-    "artifactInteractiveOffHint": "지금은 산출물이 눌리지 않습니다 · 켜면 안 버튼을 누를 수 있습니다"
+    "artifactInteractiveOffHint": "지금은 산출물이 눌리지 않습니다 · 켜면 안 버튼을 누를 수 있습니다",
+    "artifactStageInteractiveHint": "클릭해서 흐름을 따라가려면 크게 보기 → 상호작용"
   },
   "releaseNotes": {
     "whatsNew": "What's new",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4509,7 +4509,11 @@
     "viewerActualSizeAction": "실제 크기",
     "responsivePreviewDesktop": "데스크톱",
     "responsivePreviewTablet": "태블릿",
-    "responsivePreviewMobile": "모바일"
+    "responsivePreviewMobile": "모바일",
+    "artifactInteractiveOn": "상호작용 켬",
+    "artifactInteractiveOff": "상호작용 끔",
+    "artifactInteractiveOnHint": "클릭하면 산출물 안 버튼이 눌립니다 · 끄면 캔버스 이동으로 바뀝니다",
+    "artifactInteractiveOffHint": "지금은 산출물이 눌리지 않습니다 · 켜면 안 버튼을 누를 수 있습니다"
   },
   "releaseNotes": {
     "whatsNew": "What's new",

--- a/apps/web/src/components/canvas/artifact-expand-dialog.test.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.test.tsx
@@ -94,6 +94,48 @@ describe('ArtifactExpandDialog — 반응형 미리보기 브레이크포인트 
   });
 });
 
+// story #3377(결함·customer-zero) — 「크게 보기」는 pan 캔버스로 안 쓰이는 컨텍스트라
+// html_blob이면 기본으로 클릭을 받는다(인라인 스테이지는 그대로 pointer-events:none 유지 —
+// artifact-stage.test.tsx/artifact-viewer.test.tsx가 그쪽을 덮는다).
+describe('ArtifactExpandDialog — 「상호작용」 토글(story #3377)', () => {
+  it('defaults to ON for html format — iframe is clickable and scripted, but never allow-same-origin', async () => {
+    await mount();
+    const iframe = document.body.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe.className).not.toContain('pointer-events-none');
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
+    expect(iframe.getAttribute('sandbox')).not.toContain('allow-same-origin');
+    expect([...document.body.querySelectorAll('button')].map((b) => b.textContent)).toContain('상호작용 켬');
+  });
+
+  it('toggling off restores pointer-events:none (pan/zoom 회귀 0 — 캔버스로 되돌아간다)', async () => {
+    await mount();
+    const toggle = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '상호작용 켬')!;
+    await act(async () => { toggle.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const iframe = document.body.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe.className).toContain('pointer-events-none');
+    expect([...document.body.querySelectorAll('button')].map((b) => b.textContent)).toContain('상호작용 끔');
+  });
+
+  it('does not render the toggle for non-html formats', async () => {
+    await mount({ format: 'tree', content: '[]' });
+    expect([...document.body.querySelectorAll('button')].map((b) => b.textContent)).not.toContain('상호작용 켬');
+  });
+
+  it('switching to a different artifact resets the toggle to the new format default (같은 원칙 — 브레이크포인트 리셋과 동일 블록)', async () => {
+    await mount();
+    const offBtn = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '상호작용 켬')!;
+    await act(async () => { offBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect([...document.body.querySelectorAll('button')].map((b) => b.textContent)).toContain('상호작용 끔');
+
+    await act(async () => {
+      root.render(wrap(
+        <ArtifactExpandDialog open onOpenChange={vi.fn()} title="t2" format="html" content={FIXED_HTML} canvasBounds={{ w: 1280, h: 800 }} />,
+      ));
+    });
+    expect([...document.body.querySelectorAll('button')].map((b) => b.textContent)).toContain('상호작용 켬');
+  });
+});
+
 // story #3007(로드맵 P2·PR-E, L1) — 다이얼로그는 floating이라 --elev-overlay.
 describe('ArtifactExpandDialog — 로드맵 P2·PR-E L1(다이얼로그 elevation 토큰)', () => {
   it('팝업이 shadow-[var(--elev-overlay)]를 쓰고 shadow-lg는 안 쓴다', async () => {

--- a/apps/web/src/components/canvas/artifact-expand-dialog.test.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.test.tsx
@@ -121,6 +121,24 @@ describe('ArtifactExpandDialog — 「상호작용」 토글(story #3377)', () =
     expect([...document.body.querySelectorAll('button')].map((b) => b.textContent)).not.toContain('상호작용 켬');
   });
 
+  // 유나 design verdict(41e70eee7) — 토글·Close가 둘 다 ml-auto면 flex auto 마진이 반씩
+  // 나뉘어 토글이 헤더 가운데로 뜬다. ml-auto는 언제나 정확히 하나만 갖는다.
+  it('exactly one of [toggle, Close] carries ml-auto — never both, never neither (헤더 레이아웃 회귀 가드)', async () => {
+    await mount(); // html — 토글 노출
+    const toggleBtn = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '상호작용 켬')!;
+    const closeBtn = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '닫기')!;
+    expect(toggleBtn.className).toContain('ml-auto');
+    expect(closeBtn.className).not.toContain('ml-auto');
+
+    await act(async () => {
+      root.render(wrap(
+        <ArtifactExpandDialog open onOpenChange={vi.fn()} title="t" format="tree" content="[]" canvasBounds={{ w: 1280, h: 800 }} />,
+      ));
+    });
+    const closeBtnNoToggle = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '닫기')!;
+    expect(closeBtnNoToggle.className).toContain('ml-auto');
+  });
+
   it('switching to a different artifact resets the toggle to the new format default (같은 원칙 — 브레이크포인트 리셋과 동일 블록)', async () => {
     await mount();
     const offBtn = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '상호작용 켬')!;

--- a/apps/web/src/components/canvas/artifact-expand-dialog.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.tsx
@@ -95,7 +95,14 @@ export function ArtifactExpandDialog({
               </button>
             ) : null}
             <DialogPrimitive.Close
-              className="ml-auto rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+              className={cn(
+                'rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground',
+                // 유나 design verdict(41e70eee7) — 토글과 Close가 둘 다 ml-auto면 flex auto
+                // 마진이 남은 공간을 반씩 나눠 토글이 헤더 가운데로 뜬다. ml-auto는 항상
+                // 정확히 하나(가장 왼쪽의 오른쪽-정렬 요소)만 갖는다 — html이면 토글이,
+                // 아니면(토글 부재) Close 자신이 그 자리를 맡는다.
+                format === 'html' ? '' : 'ml-auto',
+              )}
             >
               {t('closeAction')}
             </DialogPrimitive.Close>

--- a/apps/web/src/components/canvas/artifact-expand-dialog.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
+import { MousePointerClick } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ArtifactStage, isResponsiveHtml, RESPONSIVE_PREVIEW_BREAKPOINTS, type ResponsivePreviewBreakpoint } from './artifact-stage';
 import { ArtifactGalleryTimeline, type GalleryTimelineVersion } from './artifact-gallery-timeline';
@@ -46,9 +47,16 @@ export function ArtifactExpandDialog({
   // 이유가 없다 — 매번 데스크톱(=원본 canvas_bounds)으로 리셋. effect가 아니라 렌더 중 조정
   // (React 공식 "prop 변경 시 state 리셋" 패턴) — set-state-in-effect lint 대상이 아니다.
   const [prevContent, setPrevContent] = useState(content);
+  // story #3377(결함·customer-zero) — 캔버스 인라인 스테이지는 pan/드래그 설계 보존을 위해
+  // 항상 클릭을 안 받지만(ArtifactStage htmlInteractive 기본 false), 이 다이얼로그는 pan
+  // 캔버스로 안 쓰이므로(overlay 미사용) html_blob에서 기본 ON — PO 확定(2026-09-03).
+  const [htmlInteractive, setHtmlInteractive] = useState(format === 'html');
   if (content !== prevContent) {
     setPrevContent(content);
     setBreakpoint('desktop');
+    // 다른 아티팩트로 전환되면 이전 상호작용 토글이 새 콘텐츠에 새지 않도록 기본값(해당
+    // 포맷이 html이면 ON)으로 되돌린다 — 위 브레이크포인트 리셋과 동일 원칙, 같은 블록.
+    setHtmlInteractive(format === 'html');
   }
   const previewWidth = breakpoint === 'desktop' ? undefined : RESPONSIVE_PREVIEW_BREAKPOINTS[breakpoint];
 
@@ -69,6 +77,23 @@ export function ArtifactExpandDialog({
             <DialogPrimitive.Title className="truncate text-sm font-semibold text-foreground">
               {title}
             </DialogPrimitive.Title>
+            {format === 'html' ? (
+              <button
+                type="button"
+                onClick={() => setHtmlInteractive((v) => !v)}
+                aria-pressed={htmlInteractive}
+                title={t(htmlInteractive ? 'artifactInteractiveOnHint' : 'artifactInteractiveOffHint')}
+                className={cn(
+                  'ml-auto flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium',
+                  htmlInteractive
+                    ? 'border-primary/40 bg-primary/10 text-primary'
+                    : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground',
+                )}
+              >
+                <MousePointerClick className="size-3" aria-hidden />
+                {t(htmlInteractive ? 'artifactInteractiveOn' : 'artifactInteractiveOff')}
+              </button>
+            ) : null}
             <DialogPrimitive.Close
               className="ml-auto rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
             >
@@ -101,7 +126,10 @@ export function ArtifactExpandDialog({
             />
           ) : null}
           <div className="min-h-0 flex-1 overflow-hidden p-4">
-            <ArtifactStage format={format} content={content} title={title} canvasBounds={canvasBounds} previewWidth={previewWidth} />
+            <ArtifactStage
+              format={format} content={content} title={title} canvasBounds={canvasBounds} previewWidth={previewWidth}
+              htmlInteractive={format === 'html' && htmlInteractive}
+            />
           </div>
         </DialogPrimitive.Popup>
       </DialogPrimitive.Portal>

--- a/apps/web/src/components/canvas/artifact-stage.test.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.test.tsx
@@ -52,12 +52,32 @@ function readTransform(el: HTMLElement) {
 }
 
 describe('ArtifactStage — 캔버스 뷰포트(story 1948d19d)', () => {
-  it('locks down the html sandbox and marks content pointer-events:none (crux — 상시 캡처 오버레이 폐기)', async () => {
+  it('runs scripts (allow-scripts) but keeps content pointer-events:none by default (story #3377 — 결함: sandbox=""가 스크립트까지 막아 정지 화면으로 보이던 것 수정, pan/드래그 설계는 그대로)', async () => {
     await mount();
     const iframe = container.querySelector('iframe') as HTMLIFrameElement;
     expect(iframe).not.toBeNull();
-    expect(iframe.getAttribute('sandbox')).toBe('');
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
     expect(iframe.className).toContain('pointer-events-none');
+  });
+
+  // story #3377 — 뮤테이션 대상 축: allow-same-origin을 주면 부모 DOM·쿠키·스토리지에
+  // 닿을 수 있어 반드시 없어야 한다(iframe 내부 script는 여전히 cross-origin 격리).
+  it('never grants allow-same-origin regardless of htmlInteractive (보안 표면 — 부모 접근 차단 유지)', async () => {
+    await mount({ htmlInteractive: true });
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
+    expect(iframe.getAttribute('sandbox')).not.toContain('allow-same-origin');
+  });
+
+  it('htmlInteractive=true makes the iframe clickable (pointer-events:auto) — only where the caller opts in (ArtifactExpandDialog)', async () => {
+    await mount({ htmlInteractive: true });
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe.className).not.toContain('pointer-events-none');
+  });
+
+  it('non-html formats are unaffected by htmlInteractive (이미지/tree 포맷엔 iframe 자체가 없음)', async () => {
+    await mount({ format: 'image', content: 'https://example.com/x.png', htmlInteractive: true });
+    expect(container.querySelector('iframe')).toBeNull();
   });
 
   it('never renders the v1~v2.1 scroll/overlay remnants (data-artifact-stage-scroll·data-pan-overlay)', async () => {

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -15,11 +15,14 @@ import type { ArtifactFormat } from '@/services/canvas';
  * - 뷰포트 = `transform: translate(tx,ty) scale(s)` 하나 — pan은 전방향(가로/세로 구분 없음)·
  *   "잘림" 상태 자체가 없다(콘텐츠는 항상 캔버스 위 어딘가에 있고, 안 보이면 이동하면 그만).
  * - 휠=pan·⌘/Ctrl+휠(트랙패드 핀치와 동일 신호)=커서 중심 줌.
- * - **crux(v2.1 오류 교정)**: 상시 전면 캡처 오버레이를 폐기 — iframe/img/tree 콘텐츠는 항상
- *   `pointer-events:none`(렌더된 오브젝트일 뿐, 상호작용 대상이 아님). 핀 등 우리 DOM 오버레이만
- *   `pointer-events:auto`로 상호작용 가능 — 이동-임계값(4px) 초과 드래그 중엔 오버레이도
- *   pointer-events:none으로 전환해 "핀 위에서 시작한 드래그가 pan으로 해석"을 순수 CSS로
- *   구현한다(핀 자체의 onClick은 무변경 — 임계 미달=일반 클릭이 그대로 발화).
+ * - **crux(v2.1 오류 교정)**: 상시 전면 캡처 오버레이를 폐기 — iframe/img/tree 콘텐츠는 기본
+ *   `pointer-events:none`(렌더된 오브젝트일 뿐, 상호작용 대상이 아님 — 이 스테이지 자체의 pan/
+ *   드래그 설계는 그대로다). 핀 등 우리 DOM 오버레이만 `pointer-events:auto`로 상호작용
+ *   가능 — 이동-임계값(4px) 초과 드래그 중엔 오버레이도 pointer-events:none으로 전환해
+ *   "핀 위에서 시작한 드래그가 pan으로 해석"을 순수 CSS로 구현한다(핀 자체의 onClick은
+ *   무변경 — 임계 미달=일반 클릭이 그대로 발화). story #3377 — html_blob만 `htmlInteractive`
+ *   prop으로 이 기본을 뒤집을 수 있다(`ArtifactExpandDialog`의 「상호작용」 토글 전용, 이
+ *   스테이지가 pan 캔버스로 안 쓰이는 그 컨텍스트에서만).
  *
  * story 74d6047e — 모바일 터치(2-finger 핀치 줌·더블탭 fit/100% 토글) 추가. 1-finger는 이미
  * 제네릭 Pointer Events pan 경로가 그대로 작동해 신규 로직 불필요(선생님 실사용 지적으로
@@ -104,6 +107,14 @@ interface ArtifactStageProps {
   format: ArtifactFormat;
   content: string;
   title: string;
+  /** story #3377(결함·customer-zero) — html_blob iframe이 pointer-events:auto가 되고
+   * `sandbox="allow-scripts"`(allow-same-origin 없음)로 실제 클릭을 받는지 여부. 기본
+   * false(캔버스 pan/드래그 설계 보존 — 인라인 스테이지는 항상 false). true는 지금
+   * `ArtifactExpandDialog`의 「상호작용」 토글(html_blob 기본 ON)에서만 넘어온다 — 그
+   * 컨텍스트엔 pan 캔버스가 없어(overlay 미사용) iframe이 클릭을 받아도 드래그 제스처와
+   * 충돌할 자리가 없다. false여도 스크립트 자체는 항상 돈다(아래 sandbox 참고) — 막히는
+   * 건 클릭이 iframe에 닿는 것 하나뿐이라 정적 렌더는 인라인에서도 정상이다. */
+  htmlInteractive?: boolean;
   /** story 1948d19d §4(BE #2135) — 선언된 아트보드 크기(그 버전의 불변 스냅샷). null/undefined
    * (레거시·미선언·#2135 착지 전)면 포맷별 기본 아트보드로 폴백(가짜 추정 0 — 측정이 아니라
    * 선언된 규약). image 포맷은 이 값과 무관하게 로드 후 실측 자연 크기를 우선한다. */
@@ -130,6 +141,8 @@ interface ArtifactStageProps {
    * 원인 회피 — 그라운딩 결론 그대로). 높이는 canvas_bounds.h 유지(iframe이 sandbox=""라
    * 리플로우 후 실제 콘텐츠 높이를 부모가 측정할 방법이 없음 — cross-origin 격리, 정직 단순화).
    * 저작 시점 canvasBounds 자체는 건드리지 않는다(핀 좌표·썸네일 등 다른 소비처와 무관).
+   * story #3377 — sandbox가 allow-scripts인 지금도 cross-origin 격리 자체는 안 풀렸으니
+   * 이 높이 미측정 제약은 그대로 유효하다.
    */
   previewWidth?: number;
   /** story #2725 — 좌표 픽 모드. true면 커서가 crosshair로 바뀌고, pan-드래그가 아닌 순수
@@ -144,12 +157,14 @@ interface ArtifactStageProps {
 /**
  * story 1948d19d — transform 캔버스 뷰포트 엔진. 3포맷(html/image/tree) 공유 — "전 표면 통일"의
  * 핵심은 이 하나의 pan/zoom/선택 계약이지 포맷별 렌더 방식이 아니다(포맷은 콘텐츠 레이어
- * 안쪽만 다름). sandbox 무완화 유지(iframe은 여전히 `sandbox=""`) — pointer-events:none이라
- * 상호작용 레이어와 물리적으로 분리되므로 완화할 필요 자체가 없다.
+ * 안쪽만 다름). sandbox는 `allow-scripts`(story #3377, allow-same-origin 없음 — 부모
+ * DOM·쿠키·스토리지는 여전히 못 닿는다)로 스크립트는 항상 돈다. 클릭이 iframe에 닿는지는
+ * `htmlInteractive`로 별도 게이팅(기본 false=pointer-events:none, 상호작용 레이어와
+ * 물리적으로 분리 — pan/드래그 설계 보존).
  */
 function CanvasViewport({
   format, content, title, canvasBounds, overlay, mode = 'view', contentRef, previewWidth,
-  pinAddMode, onPickCoordinate,
+  pinAddMode, onPickCoordinate, htmlInteractive = false,
 }: {
   format: ArtifactFormat; content: string; title: string;
   canvasBounds?: { w: number; h: number } | null; overlay?: React.ReactNode; mode?: 'view' | 'edit';
@@ -157,6 +172,7 @@ function CanvasViewport({
   previewWidth?: number;
   pinAddMode?: boolean;
   onPickCoordinate?: (xPercent: number, yPercent: number) => void;
+  htmlInteractive?: boolean;
 }) {
   const t = useTranslations('canvas');
   // story 70a06b22 — 어제(74d6047e) 만든 터치 핀치/더블탭이 힌트 카피에 반영 안 된 발견성 갭
@@ -472,8 +488,8 @@ function CanvasViewport({
             <iframe
               title={title}
               srcDoc={content}
-              sandbox=""
-              className="pointer-events-none rounded-lg bg-background"
+              sandbox="allow-scripts"
+              className={htmlInteractive ? 'rounded-lg bg-background' : 'pointer-events-none rounded-lg bg-background'}
               style={{ width: bounds.w, height: bounds.h }}
             />
           ) : format === 'image' ? (
@@ -540,17 +556,22 @@ function TreeStageContent(
 
 /**
  * 포맷별 렌더 스테이지 — 이제 3포맷 전부 같은 `CanvasViewport` 엔진(transform pan/zoom)을
- * 공유한다(story 1948d19d §1~§3). 완전 잠금 샌드박스 iframe(`sandbox=""` — allow-scripts·
- * allow-same-origin 둘 다 없음, 핸드오프 §3-1 + 유나 디자인 가디언 보안 지적 반영) 유지 —
- * pointer-events:none이 상호작용 레이어와 물리적으로 분리해 완화가 애초에 불필요.
+ * 공유한다(story 1948d19d §1~§3). html_blob iframe은 `sandbox="allow-scripts"`(allow-same-origin
+ * 없음, 핸드오프 §3-1 + 유나 디자인 가디언 보안 지적 유지 — 부모 DOM·쿠키·스토리지엔 여전히
+ * 못 닿는다)로 스크립트는 항상 돈다(story #3377 — 예전엔 `sandbox=""`라 스크립트까지 막혀
+ * 인터랙티브 프로토타입이 정지 화면으로 보였다). 클릭이 iframe에 닿는지(pointer-events)는
+ * `htmlInteractive`로 별도 게이팅 — 기본 false(캔버스 pan/드래그 설계 보존), true는
+ * `ArtifactExpandDialog`의 「상호작용」 토글에서만.
  */
 export function ArtifactStage({
   format, content, title, canvasBounds, overlay, mode, contentRef, previewWidth, pinAddMode, onPickCoordinate,
+  htmlInteractive,
 }: ArtifactStageProps) {
   return (
     <CanvasViewport
       format={format} content={content} title={title} canvasBounds={canvasBounds} overlay={overlay} mode={mode}
       contentRef={contentRef} previewWidth={previewWidth} pinAddMode={pinAddMode} onPickCoordinate={onPickCoordinate}
+      htmlInteractive={htmlInteractive}
     />
   );
 }

--- a/apps/web/src/components/canvas/artifact-viewer.test.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.test.tsx
@@ -42,6 +42,18 @@ describe('ArtifactViewer (SSR snapshot)', () => {
     expect(markup).not.toContain('allow-same-origin');
   });
 
+  it('shows the 「크게 보기 → 상호작용」 hint for html format only (story #3377 — 인라인 스테이지는 클릭을 안 받는다는 안내)', () => {
+    const htmlMarkup = renderToStaticMarkup(
+      wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+    );
+    expect(htmlMarkup).toContain('클릭해서 흐름을 따라가려면 크게 보기 → 상호작용');
+
+    const treeMarkup = renderToStaticMarkup(
+      wrap(<ArtifactViewer artifact={{ ...MOCK_ARTIFACT, format: 'tree' }} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+    );
+    expect(treeMarkup).not.toContain('클릭해서 흐름을 따라가려면');
+  });
+
   it('omits the anchor badge entirely when the artifact has no anchor version yet (초안 중립·낙인 금지)', () => {
     const draftArtifact = { ...MOCK_ARTIFACT, anchor_version: null };
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/canvas/artifact-viewer.test.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.test.tsx
@@ -34,12 +34,11 @@ describe('ArtifactViewer (SSR snapshot)', () => {
     expect(markup).toContain('정본 v3');
   });
 
-  it('fully locks down the html stage sandbox (no allow-scripts, no allow-same-origin — 유나 디자인 가디언 보안 지적 반영)', () => {
+  it('runs scripts but never grants allow-same-origin on the inline stage (story #3377 — sandbox=""가 스크립트까지 막던 결함 수정, 유나 디자인 가디언 보안 지적은 same-origin 미부여로 유지)', () => {
     const markup = renderToStaticMarkup(
       wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
     );
-    expect(markup).toContain('sandbox=""');
-    expect(markup).not.toContain('allow-scripts');
+    expect(markup).toContain('sandbox="allow-scripts"');
     expect(markup).not.toContain('allow-same-origin');
   });
 

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -279,6 +279,14 @@ export function ArtifactViewer({
                 />
               </div>
             ) : null}
+            {/* story #3377 — 인라인 스테이지는 pan/드래그 설계 보존을 위해 클릭을 안 받는다
+             * (htmlInteractive 기본 false). html_blob이 실제로 상호작용(버튼 클릭 등)을
+             * 요구하는 산출물일 수 있어, 그 경로가 「크게 보기」임을 명시한다. */}
+            {artifact.format === 'html' ? (
+              <p className="mt-1.5 text-[11px] text-muted-foreground">
+                {t('artifactStageInteractiveHint')}
+              </p>
+            ) : null}
           </div>
           <ArtifactVersionRail
             artifact={artifact}


### PR DESCRIPTION
## 결함
`ArtifactStage`의 html_blob iframe이 `sandbox=""`(빈 값)라 스크립트가 전부 차단돼, 인터랙티브 프로토타입(hash 라우팅+inline JS)이 뷰어 안에서 로그인 카드 한 장으로만 렌더됨(PO·유나 실측, customer-zero 결함). story #3377.

## 변경
- `artifact-stage.tsx`: iframe `sandbox=""` → `sandbox="allow-scripts"`(allow-same-origin은 주지 않음 — 부모 DOM·쿠키·스토리지 격리 유지). 클릭이 iframe에 닿는지는 신규 `htmlInteractive` prop으로 별도 게이팅, 기본 `false`(캔버스 인라인 스테이지는 pan/드래그 설계 그대로 `pointer-events:none` 유지 — 회귀 0).
- `artifact-expand-dialog.tsx`(「크게 보기」): html_blob이면 기본 ON인 「상호작용」 토글 추가. ON=`pointer-events:auto`+`sandbox=allow-scripts`(클릭 가능), OFF=기존 pan/줌 전용. 이 컨텍스트는 pan 캔버스로 안 쓰여(overlay 미사용) 드래그 충돌 자리가 없음(PO 확定).
- `e2e/artifact-viewer-sandbox.spec.ts`(신규): 앱/백엔드 왕복 없이 `page.setContent()`로 브라우저 sandbox 계약 자체를 검증 — allow-scripts가 스크립트를 돌리되 allow-same-origin 없이 부모 접근을 막는지(SecurityError류), 상호작용 ON/OFF에서 실좌표 클릭이 iframe에 닿는지/안 닿는지.
- 기존 vitest 2건 갱신(`sandbox=""` 단정 → `allow-scripts` 단정) + 신규 vitest 7건(mutation 대비 포함).

## 뮤테이션 검증
sandbox에 `allow-same-origin`을 추가 → 관련 vitest 4건이 실제로 RED됨을 확인 후 원복(GREEN).

## 범위 밖
외부 네트워크 허용(CSP는 그대로 차단) · 아티팩트 안 폼 제출 · 갤러리 썸네일(`artifact-thumbnail.tsx`)의 별도 `sandbox=""`는 무변경(작은 정적 미리보기, 상호작용 불필요).

## Test plan
- [x] `pnpm --filter web exec vitest run` — 5345 passed
- [x] `pnpm --filter web exec eslint src/components/canvas e2e/artifact-viewer-sandbox.spec.ts` — clean
- [x] `pnpm --filter web exec tsc --noEmit` — clean
- [x] `pnpm --filter web build` — success
- [x] `npx playwright test` (standalone config, 백엔드 불요) — 3 passed, 실 Chromium에서 sandbox 계약 확인
- [x] 뮤테이션: allow-same-origin 추가 → 4 tests RED → 원복 → GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lbwgf71pVGzZ6NPntw5JCC