### PR TITLE
[SID:3378] 산출물 갤러리 카드→상세 페이지 진입로 신설

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4500,6 +4500,7 @@
     "galleryFormatImage": "Image",
     "galleryFormatTree": "Layout",
     "galleryOpenArtifactAction": "Open artifact",
+    "galleryOpenDetailAction": "Open detail page",
     "detailLoading": "Loading",
     "detailNotFound": "Artifact not found",
     "galleryBackAction": "Back to gallery",
@@ -4514,7 +4515,9 @@
     "artifactInteractiveOff": "Interactive off",
     "artifactInteractiveOnHint": "Clicks reach the artifact's own buttons · turn off to pan the canvas instead",
     "artifactInteractiveOffHint": "The artifact isn't clickable right now · turn on to press its buttons",
-    "artifactStageInteractiveHint": "To click through the flow, open Expand → Interactive"
+    "artifactStageInteractiveHint": "To click through the flow, open Expand → Interactive",
+    "artifactDetailPageLink": "Open detail page",
+    "artifactDetailPageLinkHint": "Export, propose canonical, comments, and version lineage live on the detail page"
   },
   "releaseNotes": {
     "whatsNew": "What's new",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4516,7 +4516,6 @@
     "artifactInteractiveOnHint": "Clicks reach the artifact's own buttons · turn off to pan the canvas instead",
     "artifactInteractiveOffHint": "The artifact isn't clickable right now · turn on to press its buttons",
     "artifactStageInteractiveHint": "To click through the flow, open Expand → Interactive",
-    "artifactDetailPageLink": "Open detail page",
     "artifactDetailPageLinkHint": "Export, propose canonical, comments, and version lineage live on the detail page"
   },
   "releaseNotes": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4516,7 +4516,6 @@
     "artifactInteractiveOnHint": "클릭하면 산출물 안 버튼이 눌립니다 · 끄면 캔버스 이동으로 바뀝니다",
     "artifactInteractiveOffHint": "지금은 산출물이 눌리지 않습니다 · 켜면 안 버튼을 누를 수 있습니다",
     "artifactStageInteractiveHint": "클릭해서 흐름을 따라가려면 크게 보기 → 상호작용",
-    "artifactDetailPageLink": "상세 페이지로",
     "artifactDetailPageLinkHint": "내보내기·정본 제안·코멘트·버전 lineage는 상세 페이지에 있습니다"
   },
   "releaseNotes": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4500,6 +4500,7 @@
     "galleryFormatImage": "이미지",
     "galleryFormatTree": "레이아웃",
     "galleryOpenArtifactAction": "산출물 열기",
+    "galleryOpenDetailAction": "상세 페이지로",
     "detailLoading": "불러오는 중",
     "detailNotFound": "산출물을 찾을 수 없습니다",
     "galleryBackAction": "갤러리로 돌아가기",
@@ -4514,7 +4515,9 @@
     "artifactInteractiveOff": "상호작용 끔",
     "artifactInteractiveOnHint": "클릭하면 산출물 안 버튼이 눌립니다 · 끄면 캔버스 이동으로 바뀝니다",
     "artifactInteractiveOffHint": "지금은 산출물이 눌리지 않습니다 · 켜면 안 버튼을 누를 수 있습니다",
-    "artifactStageInteractiveHint": "클릭해서 흐름을 따라가려면 크게 보기 → 상호작용"
+    "artifactStageInteractiveHint": "클릭해서 흐름을 따라가려면 크게 보기 → 상호작용",
+    "artifactDetailPageLink": "상세 페이지로",
+    "artifactDetailPageLinkHint": "내보내기·정본 제안·코멘트·버전 lineage는 상세 페이지에 있습니다"
   },
   "releaseNotes": {
     "whatsNew": "What's new",

--- a/apps/web/src/components/canvas/artifact-expand-dialog.test.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.test.tsx
@@ -121,22 +121,35 @@ describe('ArtifactExpandDialog — 「상호작용」 토글(story #3377)', () =
     expect([...document.body.querySelectorAll('button')].map((b) => b.textContent)).not.toContain('상호작용 켬');
   });
 
-  // 유나 design verdict(41e70eee7) — 토글·Close가 둘 다 ml-auto면 flex auto 마진이 반씩
-  // 나뉘어 토글이 헤더 가운데로 뜬다. ml-auto는 언제나 정확히 하나만 갖는다.
-  it('exactly one of [toggle, Close] carries ml-auto — never both, never neither (헤더 레이아웃 회귀 가드)', async () => {
-    await mount(); // html — 토글 노출
+  // 유나 design verdict(41e70eee7) — 오른쪽 정렬 액션이 각자 ml-auto를 가지면 flex auto
+  // 마진이 여럿으로 나뉘어 가운데로 뜬다(story #3378에서 상세 링크가 셋째 액션으로 늘며
+  // 재발 위험 — 그룹 wrapper 하나에만 ml-auto를 두는 구조로 전환). ml-auto는 그 wrapper
+  // 딱 하나만 갖고, 안의 개별 버튼/링크는 전부 갖지 않는다.
+  it('exactly the action-group wrapper carries ml-auto — individual actions never do (헤더 레이아웃 회귀 가드)', async () => {
+    await mount({ artifactId: 'art-1' }); // html — 상세 링크+토글+Close 셋 다 노출
     const toggleBtn = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '상호작용 켬')!;
     const closeBtn = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '닫기')!;
-    expect(toggleBtn.className).toContain('ml-auto');
+    const detailLink = document.body.querySelector('a[href="/artifacts/art-1"]')!;
+    expect(toggleBtn.className).not.toContain('ml-auto');
     expect(closeBtn.className).not.toContain('ml-auto');
+    expect(detailLink.className).not.toContain('ml-auto');
+    // 셋의 공통 조상(액션 그룹 wrapper)이 정확히 하나의 ml-auto를 진다.
+    const wrapper = closeBtn.parentElement!;
+    expect(wrapper).toBe(toggleBtn.parentElement);
+    expect(wrapper).toBe(detailLink.parentElement);
+    expect(wrapper.className).toContain('ml-auto');
+  });
 
-    await act(async () => {
-      root.render(wrap(
-        <ArtifactExpandDialog open onOpenChange={vi.fn()} title="t" format="tree" content="[]" canvasBounds={{ w: 1280, h: 800 }} />,
-      ));
-    });
-    const closeBtnNoToggle = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '닫기')!;
-    expect(closeBtnNoToggle.className).toContain('ml-auto');
+  it('does not render the detail-page link when artifactId is omitted (story-detail 뷰어 자기참조 방지)', async () => {
+    await mount(); // artifactId 없음
+    expect(document.body.querySelector('a[href^="/artifacts/"]')).toBeNull();
+  });
+
+  it('renders the detail-page link via the bare /artifacts/{id} legacy-redirect path (proxy.ts가 실 project로 해소, story #3208과 동일 메커니즘)', async () => {
+    await mount({ artifactId: 'art-42', format: 'tree' }); // non-html에서도 링크는 뜬다
+    const link = document.body.querySelector('a[href="/artifacts/art-42"]');
+    expect(link).not.toBeNull();
+    expect(link!.textContent).toBe('상세 페이지로');
   });
 
   it('switching to a different artifact resets the toggle to the new format default (같은 원칙 — 브레이크포인트 리셋과 동일 블록)', async () => {

--- a/apps/web/src/components/canvas/artifact-expand-dialog.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.tsx
@@ -96,7 +96,7 @@ export function ArtifactExpandDialog({
                   className="flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
                 >
                   <ExternalLink className="size-3" aria-hidden />
-                  {t('artifactDetailPageLink')}
+                  {t('galleryOpenDetailAction')}
                 </Link>
               ) : null}
               {format === 'html' ? (

--- a/apps/web/src/components/canvas/artifact-expand-dialog.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
-import { MousePointerClick } from 'lucide-react';
+import { ExternalLink, MousePointerClick } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ArtifactStage, isResponsiveHtml, RESPONSIVE_PREVIEW_BREAKPOINTS, type ResponsivePreviewBreakpoint } from './artifact-stage';
 import { ArtifactGalleryTimeline, type GalleryTimelineVersion } from './artifact-gallery-timeline';
@@ -26,6 +27,13 @@ interface ArtifactExpandDialogProps {
   versions?: GalleryTimelineVersion[];
   selectedVersion?: number;
   onSelectVersion?: (versionNumber: number) => void;
+  /** story #3378(결함·customer-zero) — 이 다이얼로그가 막다른 길이었다(닫기·버전 점·전체
+   * 보기/실제 크기만, 내보내기·정본 제안·코멘트가 있는 상세로 갈 길 0). 갤러리에서 열 때만
+   * 넘긴다 — 이미 상세 페이지 안(artifact-viewer.tsx)에서 열린 다이얼로그는 그 자리로
+   * 다시 링크할 이유가 없어 생략(prop 부재=미노출, no-fiction). `/artifacts/{id}`(ws/proj
+   * 없는 bare 경로)로 링크하면 proxy.ts의 레거시 리다이렉트(story #3208과 동일 메커니즘)가
+   * 이 아티팩트의 실제 소속 project로 직접 해소한다 — 클라에서 ws/proj를 추측하지 않는다. */
+  artifactId?: string;
 }
 
 /**
@@ -36,7 +44,7 @@ interface ArtifactExpandDialogProps {
  * 큰 뷰포트다(인라인 카드도 동일 컴포넌트, 크기만 다름). 신규 뷰어 0 — 기존 컴포넌트 재사용.
  */
 export function ArtifactExpandDialog({
-  open, onOpenChange, title, format, content, canvasBounds, versions, selectedVersion, onSelectVersion,
+  open, onOpenChange, title, format, content, canvasBounds, versions, selectedVersion, onSelectVersion, artifactId,
 }: ArtifactExpandDialogProps) {
   const t = useTranslations('canvas');
   // story 3d0d60a3 — 반응형 미리보기. @media 판정=html 포맷에서만(유나 1순위·값싼 소스 파싱,
@@ -77,35 +85,43 @@ export function ArtifactExpandDialog({
             <DialogPrimitive.Title className="truncate text-sm font-semibold text-foreground">
               {title}
             </DialogPrimitive.Title>
-            {format === 'html' ? (
-              <button
-                type="button"
-                onClick={() => setHtmlInteractive((v) => !v)}
-                aria-pressed={htmlInteractive}
-                title={t(htmlInteractive ? 'artifactInteractiveOnHint' : 'artifactInteractiveOffHint')}
-                className={cn(
-                  'ml-auto flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium',
-                  htmlInteractive
-                    ? 'border-primary/40 bg-primary/10 text-primary'
-                    : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground',
-                )}
+            {/* 유나 design verdict(41e70eee7) — 오른쪽 정렬 액션들이 각자 ml-auto를 가지면
+             * flex auto 마진이 남은 공간을 나눠 가져 가운데로 뜬다. ml-auto는 이 그룹
+             * 컨테이너 하나에만 두고, 안의 형제들은 gap으로만 벌린다(항목이 늘어도 안전). */}
+            <div className="ml-auto flex items-center gap-2">
+              {artifactId ? (
+                <Link
+                  href={`/artifacts/${artifactId}`}
+                  title={t('artifactDetailPageLinkHint')}
+                  className="flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  <ExternalLink className="size-3" aria-hidden />
+                  {t('artifactDetailPageLink')}
+                </Link>
+              ) : null}
+              {format === 'html' ? (
+                <button
+                  type="button"
+                  onClick={() => setHtmlInteractive((v) => !v)}
+                  aria-pressed={htmlInteractive}
+                  title={t(htmlInteractive ? 'artifactInteractiveOnHint' : 'artifactInteractiveOffHint')}
+                  className={cn(
+                    'flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium',
+                    htmlInteractive
+                      ? 'border-primary/40 bg-primary/10 text-primary'
+                      : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground',
+                  )}
+                >
+                  <MousePointerClick className="size-3" aria-hidden />
+                  {t(htmlInteractive ? 'artifactInteractiveOn' : 'artifactInteractiveOff')}
+                </button>
+              ) : null}
+              <DialogPrimitive.Close
+                className="rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
               >
-                <MousePointerClick className="size-3" aria-hidden />
-                {t(htmlInteractive ? 'artifactInteractiveOn' : 'artifactInteractiveOff')}
-              </button>
-            ) : null}
-            <DialogPrimitive.Close
-              className={cn(
-                'rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground',
-                // 유나 design verdict(41e70eee7) — 토글과 Close가 둘 다 ml-auto면 flex auto
-                // 마진이 남은 공간을 반씩 나눠 토글이 헤더 가운데로 뜬다. ml-auto는 항상
-                // 정확히 하나(가장 왼쪽의 오른쪽-정렬 요소)만 갖는다 — html이면 토글이,
-                // 아니면(토글 부재) Close 자신이 그 자리를 맡는다.
-                format === 'html' ? '' : 'ml-auto',
-              )}
-            >
-              {t('closeAction')}
-            </DialogPrimitive.Close>
+                {t('closeAction')}
+              </DialogPrimitive.Close>
+            </div>
           </div>
           {showBreakpointSelector ? (
             <div className="flex shrink-0 items-center gap-0.5 border-b border-border px-4 py-2">

--- a/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
@@ -307,7 +307,16 @@ describe('ArtifactGalleryView — 상세 페이지 진입(story #3378)', () => {
     await mount();
     const titleLink = container.querySelector('a[href="/artifacts/a1"]');
     expect(titleLink).not.toBeNull();
-    expect(titleLink!.textContent).toBe('웰컴 이메일 시안');
+    expect(titleLink!.textContent).toContain('웰컴 이메일 시안');
+  });
+
+  // 유나 design verdict(ad31d9449) — 배지행이 제목 Link 밖에 있으면 카드 하단이 hover:border로
+  // «눌린다»는 인상을 주면서 실제로는 아무 데도 안 이어지는 죽은 면적이 된다. 배지도 이제
+  // 같은 Link 안에 있어야 한다(제목+메타 전체가 상세로 가는 클릭 가능 영역).
+  it('the badge row (anchor/latest chips) sits inside the same detail link — no dead-click area below the title (design verdict)', async () => {
+    await mount();
+    const titleLink = container.querySelector('a[href="/artifacts/a1"]');
+    expect(titleLink?.textContent).toContain('v3까지'); // galleryLatestChip
   });
 
   it('the expand dialog carries a 「상세 페이지로」 link so it is no longer a dead end', async () => {

--- a/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
@@ -300,6 +300,32 @@ describe('ArtifactGalleryView — story 3d888ba2 (실물 열람 + 그리드 시�
   });
 });
 
+// story #3378(결함·customer-zero, 선생님 실사용) — 카드가 «크게 보기» 다이얼로그로만
+// 이어지고 상세 페이지(내보내기·정본 제안·코멘트·버전)로 갈 길이 없던 결함.
+describe('ArtifactGalleryView — 상세 페이지 진입(story #3378)', () => {
+  it('the card title is a real link to /artifacts/{id} — a click reaches the detail route in ≤2 clicks from the gallery', async () => {
+    await mount();
+    const titleLink = container.querySelector('a[href="/artifacts/a1"]');
+    expect(titleLink).not.toBeNull();
+    expect(titleLink!.textContent).toBe('웰컴 이메일 시안');
+  });
+
+  it('the expand dialog carries a 「상세 페이지로」 link so it is no longer a dead end', async () => {
+    vi.stubGlobal('fetch', stubFetch({
+      versionDetailByArtifact: { a1: versionDetail('a1', 3) },
+    }));
+    await mount();
+    const thumbBtn = container.querySelector('[title="산출물 열기"]') as HTMLButtonElement;
+    await act(async () => { thumbBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    // 카드 제목 링크(container 안)와 다이얼로그 링크(base-ui Portal, container 밖)가 둘 다
+    // href="/artifacts/a1"이라 container 밖 것만 골라야 다이얼로그 쪽을 잡는다.
+    const detailLink = [...document.body.querySelectorAll('a[href="/artifacts/a1"]')].find((el) => !container.contains(el));
+    expect(detailLink).not.toBeUndefined();
+    expect(detailLink!.textContent).toBe('상세 페이지로');
+  });
+});
+
 describe('ArtifactGalleryView 빈상태 — 그리기|임포트 co-located 진입점(story 64010b05)', () => {
   it('shows both entry points, and "임포트" routes the shared story picker to the import dialog', async () => {
     vi.stubGlobal('fetch', stubFetch({ artifacts: [], stories: [{ id: 's1', title: '온보딩 개선' }] }));

--- a/apps/web/src/components/canvas/artifact-gallery-view.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { Frame } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -92,21 +93,27 @@ function ArtifactCard({
   onOpen: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onOpen}
-      title={axisT('galleryOpenArtifactAction')}
-      className="group flex flex-col overflow-hidden rounded-xl border border-border bg-card text-left transition-colors hover:border-primary/40"
-    >
-      <ArtifactThumbnail
-        artifactId={artifact.id}
-        latestVersionNumber={artifact.latestVersionNumber}
-        anchorVersion={artifact.anchorVersion}
-        className="aspect-[8/5] w-full rounded-none border-0 border-b border-border"
-      />
-      <span className="min-w-0 truncate px-3 pt-2.5 text-[13px] font-semibold text-foreground">
+    // story #3378(결함·customer-zero, 선생님 실사용) — 카드 전체가 <button>이라 크게 보기
+    // 다이얼로그 말고는 갈 곳이 없었다(다이얼로그 자체도 막다른 길이었다). <a>는 <button>
+    // 안에 못 들어가(중첩 상호작용 콘텐츠, 무효 HTML)라 바깥 컨테이너를 button에서 div로
+    // 내리고, 썸네일만 여전히 다이얼로그를 여는 button, 제목은 실제 <Link>로 상세 페이지에
+    // 간다(스토리 문구 "카드 제목 링크" 그대로).
+    <div className="group flex flex-col overflow-hidden rounded-xl border border-border bg-card transition-colors hover:border-primary/40">
+      <button type="button" onClick={onOpen} title={axisT('galleryOpenArtifactAction')} className="block w-full text-left">
+        <ArtifactThumbnail
+          artifactId={artifact.id}
+          latestVersionNumber={artifact.latestVersionNumber}
+          anchorVersion={artifact.anchorVersion}
+          className="aspect-[8/5] w-full rounded-none border-0 border-b border-border"
+        />
+      </button>
+      <Link
+        href={`/artifacts/${artifact.id}`}
+        title={axisT('galleryOpenDetailAction')}
+        className="min-w-0 truncate px-3 pt-2.5 text-[13px] font-semibold text-foreground hover:underline"
+      >
         {artifact.title}
-      </span>
+      </Link>
       <div className="flex items-center gap-1.5 px-3 pb-3 pt-1.5">
         {artifact.anchorVersion != null ? (
           <span className="shrink-0 rounded border border-success px-1.5 py-0.5 text-[9px] font-extrabold text-success">
@@ -126,7 +133,7 @@ function ArtifactCard({
           </span>
         ) : null}
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -405,6 +412,7 @@ export function ArtifactGalleryView({ projectId }: { projectId: string }) {
           versions={expandTarget.versions}
           selectedVersion={expandTarget.versionNumber}
           onSelectVersion={(versionNumber) => void handleOpenArtifact(expandTarget.artifactId, versionNumber, expandTarget.title)}
+          artifactId={expandTarget.artifactId}
         />
       ) : null}
       {projectId ? (

--- a/apps/web/src/components/canvas/artifact-gallery-view.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.tsx
@@ -98,6 +98,10 @@ function ArtifactCard({
     // 안에 못 들어가(중첩 상호작용 콘텐츠, 무효 HTML)라 바깥 컨테이너를 button에서 div로
     // 내리고, 썸네일만 여전히 다이얼로그를 여는 button, 제목은 실제 <Link>로 상세 페이지에
     // 간다(스토리 문구 "카드 제목 링크" 그대로).
+    // 유나 design verdict(ad31d9449) — 배지행을 별도 div로 두면 hover:border(카드 전체)가
+    // "눌린다"는 인상을 주면서 실제로는 아무 데도 안 이어지는 죽은 36px 면적(카드의 16.4%)이
+    // 된다. 배지는 전부 span이라 중첩 문제가 없으므로 제목 Link 안으로 옮겨 "제목+메타=상세
+    // 링크 영역" 전체가 실제로 클릭 가능하게 한다(죽은 면적 0).
     <div className="group flex flex-col overflow-hidden rounded-xl border border-border bg-card transition-colors hover:border-primary/40">
       <button type="button" onClick={onOpen} title={axisT('galleryOpenArtifactAction')} className="block w-full text-left">
         <ArtifactThumbnail
@@ -110,29 +114,29 @@ function ArtifactCard({
       <Link
         href={`/artifacts/${artifact.id}`}
         title={axisT('galleryOpenDetailAction')}
-        className="min-w-0 truncate px-3 pt-2.5 text-[13px] font-semibold text-foreground hover:underline"
+        className="flex flex-col gap-1.5 px-3 pt-2.5 pb-3 hover:underline"
       >
-        {artifact.title}
-      </Link>
-      <div className="flex items-center gap-1.5 px-3 pb-3 pt-1.5">
-        {artifact.anchorVersion != null ? (
-          <span className="shrink-0 rounded border border-success px-1.5 py-0.5 text-[9px] font-extrabold text-success">
-            {axisT('galleryAnchorPill', { version: artifact.anchorVersion })}
+        <span className="min-w-0 truncate text-[13px] font-semibold text-foreground">{artifact.title}</span>
+        <span className="flex items-center gap-1.5 no-underline">
+          {artifact.anchorVersion != null ? (
+            <span className="shrink-0 rounded border border-success px-1.5 py-0.5 text-[9px] font-extrabold text-success">
+              {axisT('galleryAnchorPill', { version: artifact.anchorVersion })}
+            </span>
+          ) : null}
+          <span className="shrink-0 rounded border border-border bg-muted/60 px-1.5 py-0.5 text-[11px] font-bold tabular-nums text-muted-foreground">
+            {axisT('galleryLatestChip', { version: artifact.latestVersionNumber })}
           </span>
-        ) : null}
-        <span className="shrink-0 rounded border border-border bg-muted/60 px-1.5 py-0.5 text-[11px] font-bold tabular-nums text-muted-foreground">
-          {axisT('galleryLatestChip', { version: artifact.latestVersionNumber })}
+          {/* story #2724(2026-08-17, 페드루 PO 판정) — 카드 레벨 미연결 배지. 사이드바 "무소속"
+           * 그룹 라벨(축 기준)과는 다른 축의 정보(story_id·doc_id 원자값 기준, 위 GalleryArtifact
+           * Summary 주석 참조)라 중복 아님 — 그리드 스크롤만으로 바로 보이는 게 목적(발견성).
+           * ⚠️표현(색·아이콘·문구 톤)은 스케치 — 유나 design 게이트에서 다듬어짐 전제. */}
+          {artifact.unlinked ? (
+            <span className="ml-auto shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] font-medium italic text-muted-foreground">
+              {axisT('galleryUnlinkedBadge')}
+            </span>
+          ) : null}
         </span>
-        {/* story #2724(2026-08-17, 페드루 PO 판정) — 카드 레벨 미연결 배지. 사이드바 "무소속"
-         * 그룹 라벨(축 기준)과는 다른 축의 정보(story_id·doc_id 원자값 기준, 위 GalleryArtifact
-         * Summary 주석 참조)라 중복 아님 — 그리드 스크롤만으로 바로 보이는 게 목적(발견성).
-         * ⚠️표현(색·아이콘·문구 톤)은 스케치 — 유나 design 게이트에서 다듬어짐 전제. */}
-        {artifact.unlinked ? (
-          <span className="ml-auto shrink-0 rounded border border-border px-1.5 py-0.5 text-[10px] font-medium italic text-muted-foreground">
-            {axisT('galleryUnlinkedBadge')}
-          </span>
-        ) : null}
-      </div>
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -185,13 +185,16 @@ export function ArtifactViewer({
                 {isViewingAnchor ? t('editAsNewVersionAction') : t('editAction')}
               </button>
             ) : null}
+            {/* story #3378(결함·customer-zero, 선생님 실사용) — 아이콘 단독이라 못 찾았다는
+             * 지적. title(호버 툴팁)만으론 발견성이 부족해 라벨 텍스트를 상시 노출한다. */}
             <button
               type="button"
               onClick={() => setExportOpen(true)}
               title={t('exportDialogTitle')}
-              className="flex items-center gap-1 text-xs hover:text-foreground"
+              className="flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
             >
               <Download className="h-3.5 w-3.5" aria-hidden />
+              {t('exportDialogTitle')}
             </button>
             {/* story #2725 — commentsComingSoon 자리표시자 폐기(미착지 트랙이 착지). onCreateThread
              * 없으면(호출부 미배선) 토글 불가한 순수 카운트 표시로 폴백 — onResolveThread/onReplyThread와


### PR DESCRIPTION
## 결함
갤러리 카드 클릭이 「크게 보기」 다이얼로그만 열고, 내보내기·정본 제안·코멘트·버전 lineage가 있는 상세 페이지(`/{ws}/{proj}/artifacts/{id}`)로 갈 링크가 없었음(선생님 실사용: "산출물 갤러리에서 상세페이지로 이동을 못하는 건 진짜 정신병인"). story #3378.

**base가 #3737(story #3377)인 이유**: 이 PR이 건드리는 `artifact-expand-dialog.tsx`/`artifact-viewer.tsx`가 #3377이 이미 바꾼 파일이라 그 위에 쌓았습니다. #3377이 develop에 머지되면 이 PR도 재베이스해서 base를 develop으로 옮기겠습니다.

## 변경
- `artifact-gallery-view.tsx`: `ArtifactCard`의 바깥 컨테이너를 `button`→`div`로 내리고(`<a>`가 `<button>` 안에 못 들어감 — 무효 HTML), 썸네일만 여전히 다이얼로그를 여는 button, 제목은 실제 `<Link href="/artifacts/{id}">`로 — 갤러리→상세 1클릭.
- `artifact-expand-dialog.tsx`: 신규 `artifactId` prop, 헤더에 「상세 페이지로」 링크 추가(format 무관 — 다이얼로그→상세 1클릭, 막다른 길 제거). 오른쪽 정렬 액션(상세링크·상호작용토글·닫기) 전부를 wrapper 하나의 `ml-auto`로 묶어 #3377이 겪은 ml-auto 이중부여를 액션이 늘어도 구조적으로 재발 못 하게 함.
- `artifact-viewer.tsx`: 내보내기 버튼에 라벨 텍스트 상시 노출(아이콘+title 툴팁만으론 실사용에서 발견 못함).
- 링크는 ws/proj 없는 bare `/artifacts/{id}`로 — `proxy.ts`의 레거시 리다이렉트(story #3208과 동일 메커니즘)가 아티팩트의 실제 소속 project로 직접 해소. 클라이언트가 ws/proj를 추측하지 않아, 현재 보는 project와 다른 project 소속 아티팩트에서도 정확히 동작.

## 범위 밖
갤러리 레이아웃 재설계 · 다이얼로그에 내보내기 기능 자체 추가.

## 뮤테이션 검증
카드 제목 링크(`<Link>`)를 `<span>`으로 되돌림 → 관련 vitest가 실제로 RED됨을 확인 후 원복(GREEN).

## Test plan
- [x] `pnpm --filter web exec vitest run` — 5351 passed
- [x] `pnpm --filter web exec eslint src/components/canvas` — clean
- [x] `pnpm --filter web exec tsc --noEmit` — clean
- [x] `pnpm --filter web build` — success
- [x] i18n phrase-collision 검사 — clean
- [x] 뮤테이션: 카드 제목 링크 제거 → RED → 원복 → GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lbwgf71pVGzZ6NPntw5JCC