### PR TITLE
[SID:3390] 채널 자격 시크릿 2종 dev Cloud Run 바인딩 — deploy SSOT

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -766,9 +766,15 @@ steps:
         # 이미 live인 backend prod 배포 자체가 "secret not found"로 깨진다. backend
         # 코드 쪽은 이미 이 값 미설정 시 fail-closed 503(support_gateway_token.py)이라
         # 시크릿을 아예 안 실어도 안전 — prod가 그 상태다.
+        # story f56bd418(#3390, Phase1·인프라) — CHANNEL_CREDENTIAL_ENCRYPTION_KEY·
+        # CHANNEL_OAUTH_STATE_SECRET(story #3373 채널 연결 골격, config.py의
+        # channel_credential_encryption_key·channel_oauth_state_secret)을 **dev
+        # 분기에만** 추가한다. prod는 별도 결정(prod 시크릿 미생성 — SUPPORT_GATEWAY_
+        # TOKEN_SECRET과 동일 선례: 값 미설정 시 fail-closed라 시크릿을 아예 안 실어도
+        # 안전, prod SECRETS_FLAG에 넣으면 존재하지 않는 시크릿으로 배포 자체가 깨진다).
         SECRETS_FLAG=""
         if [ "${_DEPLOY_ENV}" == "dev" ]; then
-          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER_SPRINTABLE:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV_SPRINTABLE:latest,APPLE_PRIVATE_KEY=APPLE_SIWA_PRIVATE_KEY:latest,SUPPORT_GATEWAY_TOKEN_SECRET=SUPPORT_GATEWAY_TOKEN_SECRET_dev:latest"
+          SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_DEV_PGBOUNCER_SPRINTABLE:latest,DATABASE_URL_DIRECT=DATABASE_URL_DIRECT_DEV_SPRINTABLE:latest,APPLE_PRIVATE_KEY=APPLE_SIWA_PRIVATE_KEY:latest,SUPPORT_GATEWAY_TOKEN_SECRET=SUPPORT_GATEWAY_TOKEN_SECRET_dev:latest,CHANNEL_CREDENTIAL_ENCRYPTION_KEY=CHANNEL_CREDENTIAL_ENCRYPTION_KEY_DEV:latest,CHANNEL_OAUTH_STATE_SECRET=CHANNEL_OAUTH_STATE_SECRET_DEV:latest"
         elif [ "${_DEPLOY_ENV}" == "prod" ]; then
           SECRETS_FLAG="--update-secrets=DATABASE_URL=DATABASE_URL_PROD_PGBOUNCER:latest,DATABASE_URL_DIRECT=DATABASE_URL_PROD:latest,DATABASE_URL_READ=DATABASE_URL_READ:latest,APPLE_PRIVATE_KEY=APPLE_SIWA_PRIVATE_KEY:latest"
         fi


### PR DESCRIPTION
[SID:3390]

## 배경
PR #3736(#3373 채널 연결 서비스 골격) develop 머지 뒤 — `CHANNEL_CREDENTIAL_ENCRYPTION_KEY_DEV`·
`CHANNEL_OAUTH_STATE_SECRET_DEV`는 Secret Manager에 이미 있고 매니페스트에도 등재돼
있지만, Cloud Run 바인딩이 없어 dev에 배포하면 채널 연결 API가 "키 없음"으로 거부된다.

## 변경
`cloudbuild.yaml` deploy-backend 스텝의 `SECRETS_FLAG` **dev 분기에만** 두 시크릿 추가
(`SUPPORT_GATEWAY_TOKEN_SECRET`과 동일 선례 — prod는 시크릿 자체가 없고, 코드가 미설정
시 fail-closed라 prod SECRETS_FLAG는 손대지 않는다).

## env var ↔ pydantic 필드 대응 확認
`Settings.model_config`(`backend/app/core/config.py:11`)에 `case_sensitive` 지정이
없다 — pydantic-settings 기본은 대소문자 무관 매핑. `CHANNEL_CREDENTIAL_ENCRYPTION_KEY`
→ `channel_credential_encryption_key`, `CHANNEL_OAUTH_STATE_SECRET` →
`channel_oauth_state_secret` 그대로 매핑된다(코드 확인, 이름 불일치 없음).

## 검증
- `python3 infra/check_cloudbuild_secret_manifest.py` — `OK`(두 이름 모두 매니페스트
  등재 완료, 새로 추가할 필요 없음).
- `yaml.safe_load(open('cloudbuild.yaml'))` — 파싱 성공.
- 값은 어디에도 출력하지 않았다(이름만).

## 범위 밖
Cloud Scheduler `refresh-channel-tokens` 등록은 PO가 gcloud로 손 등록(관례).
dev 배포 뒤 실측(`gcloud run services describe`의 secret env 목록·`GET .../channel-app-credentials`
200)은 PO 확認 몫.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm