### PR TITLE
[SID:3387] 게이트 판정 에이전트 알림 — external_publish 다음행동 오도 정정

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1279,6 +1279,7 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
     이미 계산해 둔 `neutral_facts`를 게이트 행 재조회로 그대로 재사용한다(새로 계산
     안 함)."""
     from app.models.gate import Gate
+    from app.services.gate_reason_signal import has_discontinue_signal
 
     work_item_type = payload.get("work_item_type")
     work_item_id_raw = payload.get("work_item_id")
@@ -1316,6 +1317,7 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
         lines.append(f"- 사유: {resolution_note}")
 
     draft_doc_ref: str | None = None
+    draft_id: str | None = None
     if work_item_type and work_item_id is not None and gate_type:
         gate_row = (await db.execute(
             select(Gate).where(
@@ -1325,18 +1327,48 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
             ).order_by(Gate.resolved_at.desc()).limit(1)
         )).scalar_one_or_none()
         if gate_row is not None:
-            token = (gate_row.neutral_facts or {}).get("draft_doc_reference_token")
+            facts = gate_row.neutral_facts or {}
+            token = facts.get("draft_doc_reference_token")
             if token and token != "미확認":
                 draft_doc_ref = token
+            # story #3387 — site_posts.py 흐름(external_publish)이 stamp한 draft_id.
+            # 레시피 흐름의 draft_doc_reference_token과는 상호배타(한 게이트가 두 흐름
+            # 모두에서 만들어지지 않는다) — 링크가 아니라 참조로만 싣는다(PO 2026-09-03
+            # 13:33Z, 실행 권유 아님).
+            draft_id = facts.get("draft_id")
     if draft_doc_ref:
         lines.append(f"- 대상 산출물: {draft_doc_ref}")
+    if draft_id:
+        lines.append(f"- draft_id: {draft_id}")
 
+    # story #3387(결함·오도 문구, PO 2026-09-03 13:33Z 스코프 확定) — gate_type=
+    # external_publish는 이 아래 레시피 전용 문구(다른 gate_type용, 변경 없음)를 타지
+    # 않는다. 담롱 실사례 5건(온찬 eb9e797d) 전부 이 분기의 옛 문구와 문자 그대로
+    # 일치했다 — verdict만 보고 gate_type을 안 봐 "발행 도구"(제품에 없음)를 approved에
+    # 권하고, rejected엔 사유 무관 재상신을 권해 «폐기 대상» 반려와 정면으로 모순됐다.
+    #
+    # 유나 8칸 표(2026-09-03) 중 에이전트 칸(3·4·6·8)만 여기서 구현한다 — 휴먼 칸
+    # (1·2·5·7)은 이 함수의 스코프 밖(agent-only MCP 표면, 휴먼 3표면엔 다음 행동 문구를
+    # 신설하지 않기로 PO가 확定, 화면 실 버튼이 있는데 문구를 더하면 새 오도 자리가 된다).
+    # 실행 동사 0건 규율: "할 일 없음"으로 시작 — 이 표면 수신자는 항상 에이전트라
+    # "누르세요/쓰세요/발행하세요"류를 전부 금지한다(사람 표면 버튼과 헷갈릴 여지 자체를
+    # 없앤다).
+    if gate_type == "external_publish":
+        if verdict == "approved":
+            lines.append("- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다.")
+        elif verdict == "rejected":
+            # AC3 — 사유에 «폐기/중단» 신호가 있으면 다음 행동 자체를 비운다(침묵도
+            # 문구다). 재상신을 권하면 카드가 사람의 결정과 정면으로 반대되는 행동을
+            # 시킨다(스토리 관측 사례 5).
+            if not has_discontinue_signal(resolution_note):
+                lines.append("- 다음 행동: 할 일 없음 — 다시 올릴지는 작성자가 정합니다.")
     # 페드루 리뷰(PR#3711) — "approve 게이트를 다시 발행"은 실재하지 않는 동작(게이트는
     # 발행 대상이 아니라 이벤트 발행의 부산물)이라 최저 지능 에이전트가 그대로 따라도
     # 실패하지 않을 실제 동작으로 정정: rejected는 「산출물 수정→같은 정의의 approve
     # stage 이벤트 재발행(게이트는 그 발행에 자동 재오픈됨)」, approved는 「이 정의의
-    # 다음 stage 이벤트 발행」.
-    if verdict == "rejected":
+    # 다음 stage 이벤트 발행」. ⚠️story #3387 — 이 갈래는 external_publish 이외
+    # gate_type 전용이다(회귀 0, 위에서 이미 갈라냈다).
+    elif verdict == "rejected":
         lines.append(
             "- 다음 행동: 산출물을 수정한 뒤, 같은 레시피 정의의 approve stage 이벤트를 "
             "다시 발행하세요(payload.previous_output_doc_id=수정본 id) — 게이트는 그 "

--- a/backend/app/services/gate_reason_signal.py
+++ b/backend/app/services/gate_reason_signal.py
@@ -1,0 +1,23 @@
+"""story #3387 — 반려 사유 텍스트에서 «폐기/중단» 신호를 가리는 공용 판정 함수.
+
+⛔단일 SSOT — story 5b00f0bc(넛지 억제, 아직 코드 없음)가 나중에 이 함수를 그대로
+재사용한다(PO 2026-09-03 13:33Z). 두 벌로 나뉘면 같은 사유가 한쪽에서만 신호로 잡히는
+순간이 온다 — 새로 짤 때 이 함수를 import하고, 여기 없는 새 판정을 그쪽에서 따로 만들지
+않는다.
+
+키워드 목록은 의도적으로 좁다(과탐 방지) — "폐기 대상"·"중단"·"금지"·"삭제" 계열만.
+"수정 후 재상신 바랍니다" 같은 정상 반려 사유를 이 신호로 오분류하면 정반대 결함(침묵해야
+할 곳에서 재상신을 권함)이 된다."""
+from __future__ import annotations
+
+import re
+
+_DISCONTINUE_SIGNAL_RE = re.compile(r"폐기|중단|금지|삭제")
+
+
+def has_discontinue_signal(reason_text: str | None) -> bool:
+    """반려 사유에 «끝내라»는 신호가 있는가. None/빈 문자열은 신호 없음(False) — 사유가
+    없으면 판정할 근거도 없다(지어내지 않는다)."""
+    if not reason_text:
+        return False
+    return bool(_DISCONTINUE_SIGNAL_RE.search(reason_text))

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -472,6 +472,11 @@ async def submit_site_post_draft(
         "media_manifest_hash": _EMPTY_MEDIA_MANIFEST_HASH,
         "draft_author_member_id": str(origin_author_member_id),
         "requested_by_member_id": str(requester_member_id),
+        # story #3387 — 이 게이트가 가리키는 글 관리 화면(apps/web /content/{draft_id})을
+        # 에이전트 알림(_render_gate_verdict_message)이 참조로 실을 수 있도록. 게이트 자체엔
+        # draft_id 컬럼이 없어(그라운딩 완료) 기존 필드들과 동형으로 neutral_facts에 얹는다
+        # — 링크가 아니라 참조 정보다(PO 2026-09-03 13:33Z, 에이전트에겐 실행 권유 아님).
+        "draft_id": str(draft.id),
     }
 
     # 페드루 PO 리뷰(2026-09-03 05:59Z) — 기본 역할이 없으면 가짜 uuid로 게이트를 만드는

--- a/backend/tests/test_3330_gate_verdict_notification.py
+++ b/backend/tests/test_3330_gate_verdict_notification.py
@@ -267,7 +267,12 @@ async def test_rejected_gate_reaches_work_item_assignee_with_reason_and_next_act
             # 사유가 있어도 원천 차단하던 게이트의 부산물이었다, 아래 테스트가 그 정정을 pin).
             assert "- 사유: 어투가 너무 딱딱함 — 다시" in content
             assert f"[Threads 포스트 초안 v1](entity:doc:{doc_id})" in content
-            assert "approve stage 이벤트를 다시 발행하세요" in content
+            # story #3387 — "어투가 너무 딱딱함 — 다시"엔 폐기/중단 신호가 없다. 옛 문구
+            # ("approve stage 이벤트를 다시 발행하세요")는 gate_type=merge 등 external_publish
+            # 이외 전용으로 갈라졌다(test_gate_type_outside_verdict_capture_mapping_still_notifies
+            # 가 그쪽을 그대로 pin) — 여기는 external_publish 신 문구를 pin한다.
+            assert "- 다음 행동: 할 일 없음 — 다시 올릴지는 작성자가 정합니다." in content
+            assert "approve stage 이벤트를 다시 발행하세요" not in content
     finally:
         await engine.dispose()
 
@@ -294,7 +299,10 @@ async def test_approved_gate_also_reaches_work_item_assignee():
             content = await _latest_message_content_for(s, executor_id, org_id)
             assert content is not None
             assert "- 게이트: external_publish → approved" in content
-            assert "다음 stage 이벤트를 발행하세요" in content
+            # story #3387 — external_publish approved는 신 문구(실행 동사 0, 화면 실 버튼과
+            # 헷갈릴 여지 자체를 없앤다). 옛 문구는 이제 다른 gate_type 전용이다.
+            assert "- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다." in content
+            assert "다음 stage 이벤트를 발행하세요" not in content
             # story 1cd72bfc AC(음성대조) — 사유 없이 승인하면 사유 줄 자체가 없다(지어내지 않음).
             assert "- 사유:" not in content
     finally:

--- a/backend/tests/test_3387_gate_reason_signal.py
+++ b/backend/tests/test_3387_gate_reason_signal.py
@@ -1,0 +1,32 @@
+"""story #3387 — has_discontinue_signal 단위 검증. story 5b00f0bc(넛지 억제, 아직 코드
+없음)이 나중에 이 함수를 그대로 재사용하므로 여기서 계약을 고정해 둔다."""
+from __future__ import annotations
+
+import pytest
+
+from app.services.gate_reason_signal import has_discontinue_signal
+
+
+@pytest.mark.parametrize("text", [
+    "발행 금지·폐기 대상",
+    "폐기 대상입니다",
+    "당분간 중단합니다",
+    "이 계정은 사용 금지",
+    "산출물 삭제 요청",
+])
+def test_discontinue_keywords_detected(text: str) -> None:
+    assert has_discontinue_signal(text) is True
+
+
+@pytest.mark.parametrize("text", [
+    "제목 오타 수정 필요",
+    "본문 형식이 가이드와 다릅니다",
+    "요약이 너무 깁니다, 3줄로 줄여주세요",
+])
+def test_normal_reasons_not_flagged(text: str) -> None:
+    assert has_discontinue_signal(text) is False
+
+
+@pytest.mark.parametrize("text", [None, ""])
+def test_missing_reason_is_no_signal(text) -> None:
+    assert has_discontinue_signal(text) is False

--- a/backend/tests/test_3387_gate_verdict_agent_next_action.py
+++ b/backend/tests/test_3387_gate_verdict_agent_next_action.py
@@ -1,0 +1,137 @@
+"""story #3387(결함·오도 문구, PO 2026-09-03 13:33Z 스코프 확定) — 담롱 온찬 실사례 5건
+(2026-09-03) 전부 `_render_gate_verdict_message`(agent-only MCP 표면)의 옛 문구와 문자
+그대로 일치했다: verdict만 보고 gate_type을 안 봐 approved에 제품에 없는 «발행 도구»를
+권했고(사례 1~4), «폐기 대상» rejected에 재상신을 권해 결정과 정반대 행동을 시켰다(사례 5).
+
+여기서는 `_render_gate_verdict_message`를 mock db(실 Postgres 없이)로 직접 호출해 새
+gate_type=external_publish 분기만 좁게 잰다 — 실전 통합 경로(발행→work item assignee
+도달)는 test_3330_gate_verdict_notification.py가 이미 realdb로 덮는다.
+
+AC5 — 뮤테이션: has_discontinue_signal 호출을 지우면 "사례 5" 테스트가 RED로 바뀐다."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _FakeGateRow:
+    def __init__(self, neutral_facts: dict | None):
+        self.neutral_facts = neutral_facts
+
+
+class _FakeResult:
+    def __init__(self, row):
+        self._row = row
+
+    def scalar_one_or_none(self):
+        return self._row
+
+
+def _fake_db(gate_row=None):
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_FakeResult(gate_row))
+    return db
+
+
+def _payload(*, gate_type: str, verdict: str, resolution_note: str | None = None) -> dict:
+    return {
+        "work_item_type": "story",
+        "work_item_id": str(uuid.uuid4()),
+        "gate_type": gate_type,
+        "verdict": verdict,
+        "resolution_note": resolution_note,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _stub_work_item_ref(monkeypatch):
+    from app.routers import events as events_module
+
+    async def _fake_ref(*_args, **_kwargs):
+        return "[제목](entity:story:11111111-1111-1111-1111-111111111111)"
+
+    monkeypatch.setattr(events_module, "_render_event_notification_work_item_ref", _fake_ref)
+
+
+async def _render(payload: dict, gate_row=None) -> str:
+    from app.routers.events import _render_gate_verdict_message
+
+    return await _render_gate_verdict_message(_fake_db(gate_row), org_id=uuid.uuid4(), payload=payload)
+
+
+class TestExternalPublishAgentNextAction:
+    async def test_approved_gives_no_task_text_not_publish_tool(self):
+        # 사례 1~4 — 승인 카드가 제품에 없는 «발행 도구»를 더 이상 권하지 않는다.
+        text = await _render(_payload(gate_type="external_publish", verdict="approved"))
+        assert "발행 도구" not in text
+        assert "- 다음 행동: 할 일 없음 — 발행은 휴먼이 화면에서 합니다." in text
+
+    async def test_rejected_with_discontinue_signal_has_no_next_action_line_at_all(self):
+        # 사례 5 — 「발행 금지·폐기 대상」으로 반려했는데 재상신을 권하던 모순을 없앤다.
+        # 침묵도 문구다: "다음 행동" 줄 자체가 없어야 한다(빈 값이 아니라 렌더 자체 없음).
+        text = await _render(_payload(
+            gate_type="external_publish", verdict="rejected", resolution_note="발행 금지·폐기 대상",
+        ))
+        assert "다음 행동" not in text
+        assert "자동 재오픈" not in text
+        assert "다시 발행하세요" not in text
+
+    async def test_rejected_without_signal_gives_no_task_text_not_a_directive(self):
+        text = await _render(_payload(
+            gate_type="external_publish", verdict="rejected", resolution_note="제목 오타 수정 필요",
+        ))
+        assert "- 다음 행동: 할 일 없음 — 다시 올릴지는 작성자가 정합니다." in text
+
+    async def test_rejected_signal_is_keyword_based_not_a_blanket_reason_suppression(self):
+        # "제목 오타 수정 필요"는 신호가 없어 문구가 뜬다(위 테스트) — "중단"이 들어간
+        # 사유만 신호로 잡혀야 한다(과탐 방지, gate_reason_signal.py 자체 규율).
+        text = await _render(_payload(
+            gate_type="external_publish", verdict="rejected", resolution_note="당분간 중단합니다",
+        ))
+        assert "다음 행동" not in text
+
+    async def test_execution_verbs_are_absent_from_both_agent_branches(self):
+        approved_text = await _render(_payload(gate_type="external_publish", verdict="approved"))
+        rejected_text = await _render(_payload(
+            gate_type="external_publish", verdict="rejected", resolution_note="사유 없이 반려",
+        ))
+        for verb in ("누르세요", "쓰세요", "발행하세요", "재상신하세요"):
+            assert verb not in approved_text
+            assert verb not in rejected_text
+
+    async def test_draft_id_surfaces_as_plain_reference_not_a_link(self):
+        draft_id = str(uuid.uuid4())
+        gate_row = _FakeGateRow({"draft_id": draft_id})
+        text = await _render(
+            _payload(gate_type="external_publish", verdict="approved"), gate_row=gate_row,
+        )
+        assert f"- draft_id: {draft_id}" in text
+        assert "http" not in text  # 참조이지 링크가 아니다.
+
+    async def test_no_neutral_facts_omits_draft_id_line_without_erroring(self):
+        text = await _render(_payload(gate_type="external_publish", verdict="approved"), gate_row=None)
+        assert "draft_id" not in text
+
+
+class TestOtherGateTypesUnchanged:
+    """story #3387 회귀 0 — external_publish 이외 gate_type(예: qa/deploy/merge/pr_review·
+    레시피 파이프라인)은 옛 문구를 그대로 유지한다."""
+
+    async def test_non_external_publish_approved_keeps_old_publish_tool_text(self):
+        text = await _render(_payload(gate_type="qa", verdict="approved"))
+        assert "발행 도구" in text
+        assert "할 일 없음" not in text
+
+    async def test_non_external_publish_rejected_keeps_old_resubmit_text(self):
+        text = await _render(_payload(gate_type="qa", verdict="rejected", resolution_note="폐기 대상"))
+        assert "다시 발행하세요" in text
+        assert "자동 재오픈됩니다" in text


### PR DESCRIPTION
## 요지
`external_publish` 게이트 카드의 «다음 행동» 안내가 결정 종류·사유를 무시하던 결함(담롱 온찬 5사례, 2026-09-03). approved 판정에 제품에 없는 «발행 도구»를 권하고, «폐기 대상» 반려에 재상신을 권해 결정과 정반대 행동을 시켰다.

## 조사 결과 — 스코프 정정(착수 전 PO 확認 받음)
"다음 행동:" 리터럴 텍스트는 코드 전체에서 `backend/app/routers/events.py::_render_gate_verdict_message` 단 한 곳뿐이다. 이 함수는 **MCP `poll_events` 전용 agent 알림 표면**이라고 함수 자신의 docstring이 명시한다("사람 표면인 block_template의 '사유' 필드는 별개, 이 함수 스코프 밖"). 결재함(`approvals-queue.tsx`)·게이트상세(`gates/[id]/page.tsx`)·채팅카드(`approval-request-card.tsx`)는 오늘 «다음 행동» 문구를 아예 렌더하지 않는다.

**PO 스코프 확定(2026-09-03 13:33Z)**: (a) 에이전트향 백엔드 함수만 수정한다. (b) 휴먼 3표면엔 «다음 행동» 문구를 신설하지 않는다 — 휴먼은 이미 화면의 실 버튼(«발행»·«다시 승인 요청»)을 보고 있어 문구를 더하면 그게 새 오도 자리가 된다.

## 변경
- `_render_gate_verdict_message`에 `gate_type == "external_publish"` 가드 추가. 다른 gate_type(레시피 파이프라인 등)은 옛 문구 완전 무변화(회귀 0, 별도 테스트로 고정).
- `approved` → 「할 일 없음 — 발행은 휴먼이 화면에서 합니다」(실행동사 0, 유나 표의 에이전트 칸 규율 그대로).
- `rejected` + 폐기/중단 신호 → 다음 행동 줄 자체를 렌더하지 않음(침묵도 문구다 — 사례 5의 모순 제거).
- `rejected` + 신호 없음 → 「할 일 없음 — 다시 올릴지는 작성자가 정합니다」.
- `app/services/gate_reason_signal.py`(신규) — `has_discontinue_signal` 순수 함수로 분리. story 5b00f0bc(넛지 억제, 아직 코드 없음)가 이후 이 함수를 그대로 재사용한다(PO 지시, 두 벌 금지).
- `site_posts.py::submit_site_post_draft` — 게이트 `neutral_facts`에 `draft_id` stamp(1줄, 기존 필드들과 동형 패턴). 에이전트 메시지엔 참조 정보로만 노출(링크 아님, 실행 권유 아님 — PO 명시).

## 확인한 것 (AC4/AC6 — "구현자가 확認해 PR 본문에 적는다")
- Gate ORM/스키마에 `audience`·`draft_id` 컬럼 자체가 없다(모델·스키마 전문 확認). 이 표면(MCP `_render_gate_verdict_message`)은 애초에 항상 에이전트 수신 전용이라 `audience` 분기 자체가 불필요 — 결재함/게이트상세/채팅카드(휴먼 화면)에 별도 신설도 없어 그쪽의 audience 필요성도 없다.
- `draft_id`는 Gate에 직접 컬럼이 없어 `neutral_facts`에 얹었다(위 변경사항).
- 세 표면(①②③)은 오늘 각자 문구를 만들지 않으며(신설 안 함), 유일한 문구 소스는 이 PR이 고친 `events.py`의 단일 함수다 — "세 표면이 서로 다른 소스를 쓴다"는 결함은 존재하지 않는다(있던 게 아니라 애초에 하나뿐이었다).

## 테스트
- 신규 19건 — mock db로 실 Postgres 없이: agent 분기(approved/rejected×신호유무) 6건, 실행동사 0건 검증 1건, draft_id 참조 노출 2건, 회귀가드(비external_publish 무변화) 2건, `has_discontinue_signal` 단위 9건.
- 뮤테이션 — `has_discontinue_signal` 가드 제거 → 2건 RED 확인 후 원복.
- 관련 backend 스위트(`gate`/`site_post`/`event` 키워드, 626건) 전건 통과. 실패 3건은 무관 사전결함(`test_eventbus_s2/s3.py`, 이 PR과 무관, develop에도 존재).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lbwgf71pVGzZ6NPntw5JCC