### PR TITLE
[SID:3389] e2e global-setup — /inbox 웜업으로 콜드 컴파일 30초 타임아웃 제거

### DIFF
--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -24,10 +24,36 @@ async function globalSetup() {
     throw new Error(`Login failed (${resp.status()}): ${body}`);
   }
 
+  // story #3389(CI 플래키, 2026-09-03) — Next dev는 라우트를 요청 시점에 처음
+  // 컴파일한다(on-demand compile). playwright의 webServer.url 체크는 "포트가 응답하는가"
+  // 만 확인할 뿐 /inbox 라우트 자체가 컴파일됐는지는 모른다 — 그래서 아래 로그인 확인용
+  // goto가 이 프로세스에서 /inbox의 «첫 요청»이 되면 컴파일 시간이 기본 30초 goto
+  // 예산을 넘길 수 있다. 실측(PR #3736·#3740·#3746 CI 3회 재현, run 33741248327·
+  // 33750372064·job 100668189880): 매번 대비 위반 0건인데 정확히 이 줄에서 51~53초
+  // 만에 TimeoutError — 러너 경합이면 실패 시각이 들쭉날쭉해야 하는데 세 번 다 같은
+  // 좁은 구간에 몰린 것이 콜드 컴파일 신호와 일치한다(자원 경합·느린 API라면 이렇게
+  // 좁게 몰리지 않는다). 처방(AC2): goto 타임아웃 값을 올리는 지름길 대신, 판정 대상이
+  // 아닌 별도 웜업 요청으로 컴파일 비용을 먼저 치른다 — 아래 진짜 goto는 이미 컴파일된
+  // (warm) 라우트를 받으므로 기본 30초 예산 그대로 둔다(이 웜업 자체가 "처방이 통했다"는
+  // 증거다: 웜업 없이 되돌리면 이 결함이 재현돼야 한다).
+  await context.request.get('/inbox', { timeout: 90_000 }).catch(() => {
+    // 웜업의 목적은 컴파일 트리거뿐 — 응답 상태/성패는 판정하지 않는다(아래 진짜 goto가
+    // 판정한다). 웜업 자체가 실패해도(예: 아직 서버가 완전히 안정화되지 않음) 무시하고
+    // 진짜 goto로 넘어간다 — 웜업 실패가 이 함수 전체를 죽이면 안 된다.
+  });
+
   // Navigate to /inbox once to confirm the session works server-side
   const page = await context.newPage();
-  await page.goto('/inbox');
-  await page.waitForURL(/\/inbox/, { timeout: 15000 });
+  try {
+    await page.goto('/inbox');
+    await page.waitForURL(/\/inbox/, { timeout: 15000 });
+  } catch (err) {
+    // story #3389(AC3) — 이 실패는 대비(color-contrast) 판정과 무관하다. axe 위반
+    // 리포트와 다른 문장으로 내야 PO가 로그를 열자마자 "플래키/기동 실패"와 "실 대비
+    // 위반"을 가른다(이전엔 둘 다 그냥 "Contrast guard 빨강"으로만 보였다).
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`⚠ 페이지 도달 실패(타임아웃) — not a contrast verdict(대비 판정 아님, story #3389). 원인: ${detail}`);
+  }
 
   await context.storageState({ path: path.join(authDir, 'owner.json') });
   await browser.close();


### PR DESCRIPTION
## 요지
Contrast guard(axe runtime) 잡이 대비 위반 0건인데 `page.goto: Timeout 30000ms exceeded`로 빨간 것 — 오늘 하루 4회 재현(PR #3736·#3740·#3746·#3747). PO가 매번 로그를 열어 플래키/실 위반을 손으로 갈랐다.

## 원인 실측(AC1)

| PR | run/job | 시각 | 실패 줄 | goto 시작→실패 gap |
|---|---|---|---|---|
| #3736 attempt 2 | run 33741248327 | 10:21:07Z | `global-setup.ts:29`, `page.goto('/inbox')` | ~52s |
| #3740 | run 33750372064 | 11:36:11Z | 같은 줄 | ~53s |
| #3746 | job 100668189880 | 13:30:35Z | 같은 줄 | ~51s |
| #3747 | job 100680778790 | 14:10:29Z | 같은 줄 | (동일 패턴, 페드루 실측 보고) |

네 번 다 정확히 같은 자리(`global-setup.ts:29`)에서, 정확히 30초 goto 타임아웃을 넘긴 좁은 시간대(51~53초 — pnpm 기동+서버 바인딩 후 goto 시작부터 카운트)에 실패했고, 대비 위반은 매번 0건이었다. **자원 경합**(원인 후보 2)이었다면 실패 시각이 들쭉날쭉했을 것이고, **느린 API**(원인 후보 3)였다면 이 정도로 좁게 몰리지 않는다 — **콜드 스타트/온디맨드 컴파일**(원인 후보 1)이 남는 유일한 설명이다.

**로컬 재현으로 확증**: 이 워크트리에서 Next dev 서버를 새로 띄우고 `/inbox`를 연속으로 curl — 첫 히트(콜드 컴파일) **7.74초** → 둘째 히트(warm) **0.032초**, 약 240배 차이. Next dev가 라우트를 요청 시점에 처음 컴파일한다는 것을 직접 재현했다(CI가 로컬보다 ~6배 느리다는 이 저장소의 기존 실측대로면 CI에서 40~50초대로 번역되고, 이는 관측된 51~53초 gap과 정합한다).

## 처방(AC2)
**goto 타임아웃 값을 올리는 지름길은 쓰지 않았다.** 대신 로그인 성공 뒤·진짜 `page.goto('/inbox')` 전에 `context.request.get('/inbox', { timeout: 90_000 })` 웜업 요청을 추가했다 — 컴파일 비용을 이 별도(판정 대상 아닌) 예산에서 먼저 치르고, 뒤이은 진짜 goto는 이미 컴파일된 라우트를 받아 **기본 30초 예산 그대로** 통과한다. 웜업 자체의 성패는 판정하지 않는다(`.catch()`로 무시 — 목적은 컴파일 트리거뿐, 실패해도 본 함수를 죽이지 않는다).

`global-setup.ts`는 `playwright.config.ts`의 모든 e2e 프로젝트가 공유하므로, 이 수정은 contrast-guard뿐 아니라 전체 e2e 스위트의 같은 콜드스타트 위험을 함께 없앤다.

## 실패 메시지 분리(AC3)
진짜 goto를 `try/catch`로 감싸 실패 시 `⚠ 페이지 도달 실패(타임아웃) — not a contrast verdict` 접두로 재던진다. webServer 자체의 기동 실패는 이미 Playwright가 `[WebServer] Error: ...`로 완전히 다른 문장을 내므로(PR#3745 Next 슬러그 충돌 실사고에서 실측 확인됨) 별도 처리가 필요 없었다 — 이 PR은 남아 있던 애매한 한 자리(페이지 도달 실패)만 명시적으로 가른다.

## AC4 — develop CI 5회 연속 초록
머지 후 관측 필요. 이 PR 코멘트로 추적하겠음(현재는 웜업 부재 상태의 4회 실패만 확보).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lbwgf71pVGzZ6NPntw5JCC