### PR TITLE
[SID:3346] QA Review Gate — 체크런 부재를 CI워크플로 run 상태로 직접 대조

### DIFF
--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -81,6 +81,14 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  # story #3346 — 아래 신규 스텝이 CI 워크플로 run 상태(queued/in_progress/completed)를
+  # `actions/workflows/{id}/runs`로 직접 읽는다. 참고: branch protection의
+  # required_status_checks(더 근본적인 SSOT)를 읽는 방법도 검토했으나 GITHUB_TOKEN에는
+  # 그 권한 스코프 자체가 없다(actionlint: "administration"은 유효 permission이 아님 —
+  # GitHub REST "Get branch protection"은 GITHUB_TOKEN으로 애초에 접근 불가) — 그래서
+  # "이 리포의 필수 체크 넷이 전부 ci.yml 한 워크플로에서 나온다"는 실측 사실(아래 스텝
+  # 주석 참고)에 기대 "CI 워크플로 자체의 run 상태"로 대체한다.
+  actions: read
 
 jobs:
   qa-review-gate:
@@ -240,3 +248,47 @@ jobs:
             exit 1
           fi
           echo "no incomplete non-advisory checks for ${HEAD_SHA}."
+
+      # story #3346(2026-09-02 실사고, PR#3725 head a9c9322eb) — 위 스텝은 "존재하는
+      # check-runs 목록"만 본다. force-push 직후 concurrency로 큐 대기(pending) 중이던
+      # CI는 잡이 아직 «시작도 안 해» Backend pytest·Lint·Alembic·Support Gateway
+      # 체크런이 하나도 없었다 — "미완인 체크런"이 아니라 "체크런 자체가 없는" 경우라
+      # 위 스텝의 필터를 그냥 통과해(0건 매치) «미완 0건»으로 오판했다. 체크런은 그
+      # 워크플로의 잡이 실제로 시작돼야 생긴다 — «존재 자체가 없다»는 신호는 check-runs
+      # API로는 원리적으로 못 잡는다(없는 것과 통과한 것을 구별 못 함).
+      #
+      # 처방 — 이 넷은 전부 «CI»라는 단일 워크플로(ci.yml) 안의 잡이다(실측: 이 파일
+      # 이름 넷 전부가 ci.yml에서 나온다 — 다른 워크플로가 이 이름들을 내는 자리는
+      # 없다). 그래서 "체크런 목록"이 아니라 "그 워크플로 자체의 run 상태"를 head에
+      # 대해 직접 물어 fail-closed로 판정한다: run이 하나도 없으면(아직 큐잉조차 안
+      # 됐거나 조회 실패) «미완»으로 실패, 있으면 그 중 최신 run의 status가
+      # completed이고 conclusion이 success인지를 요구한다. ⛔branch protection의
+      # required_status_checks를 직접 읽는 방법(더 근본적인 SSOT)도 검토했으나
+      # GITHUB_TOKEN에는 그 API 자체에 대한 권한 스코프가 없다(actionlint가
+      # "administration"을 유효하지 않은 permission으로 거부 — GitHub REST "Get branch
+      # protection"은 애초에 GITHUB_TOKEN으로 접근 불가한 엔드포인트다).
+      - name: Enforce the CI workflow run itself is completed+success at head (not just its check-runs)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          RUNS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${HEAD_SHA}&per_page=20" --paginate --slurp \
+            | jq '[.[].workflow_runs[]]')"
+          LATEST="$(echo "${RUNS_JSON}" | jq 'sort_by(.run_started_at) | last')"
+          if [ "${LATEST}" = "null" ]; then
+            echo "::error title=CI workflow run not found::head(${HEAD_SHA})에 대한 CI 워크플로 run이 하나도 없다 — 아직 큐잉조차 안 됐을 수 있다(체크런 부재와 같은 증상). 모르면 통과가 아니라 실패다(fail-closed)."
+            exit 1
+          fi
+          STATUS="$(echo "${LATEST}" | jq -r '.status')"
+          CONCLUSION="$(echo "${LATEST}" | jq -r '.conclusion')"
+          RUN_URL="$(echo "${LATEST}" | jq -r '.html_url')"
+          if [ "${STATUS}" != "completed" ]; then
+            echo "::error title=CI workflow run not completed::head(${HEAD_SHA})의 CI 워크플로 run이 아직 «${STATUS}»다(예: queued — force-push 직후 이전 head의 run과 concurrency 대기 중일 수 있다, 실사고 PR#3725). 체크런이 없는 상태라 위 스텝이 못 잡는다 — 이 스텝이 그 자리를 메운다. ${RUN_URL}"
+            exit 1
+          fi
+          if [ "${CONCLUSION}" != "success" ]; then
+            echo "::error title=CI workflow run not success::head(${HEAD_SHA})의 CI 워크플로 run이 completed지만 conclusion이 «${CONCLUSION}»(success 아님). ${RUN_URL}"
+            exit 1
+          fi
+          echo "CI workflow run completed+success for ${HEAD_SHA}: ${RUN_URL}"


### PR DESCRIPTION
## 요지
실사고(2026-09-02, PR#3725 head a9c9322eb) — force-push 직후 CI run이 concurrency로 6분+ **queued(큐 대기)** 상태였다. "qa:pass인데 안 끝난 비-advisory 체크가 있으면 fail" 판정이 `commits/{sha}/check-runs` 목록만 봐서, 체크런 자체가 아직 안 생긴(잡이 시작 안 함) 상태를 **«미완 0건»으로 오판**했다. "미완인 체크런을 찾는" 로직은 "체크런 자체가 없다"는 신호를 원리적으로 못 잡는다(없는 것과 통과한 것을 구별 못 함). 실 머지는 branch protection required contexts 부재로 막혔다(마지막 방어선은 살아 있었음).

## 처방
이 리포의 필수 체크 넷(Backend pytest·Lint·Alembic·Support Gateway)이 전부 `ci.yml`이라는 **단일 워크플로**의 잡이라는 실측 사실에 기대, "체크런 목록"이 아니라 **"CI 워크플로 run 자체의 상태"**를 head에 대해 직접 질의하는 새 스텝을 추가했다(기존 체크런 기반 스텝은 그대로 유지 — 방어 계층 하나 더).
- run이 하나도 없으면(아직 큐잉조차 안 됐거나 조회 실패) fail-closed.
- 있으면 최신 run의 `status == completed` && `conclusion == success`를 요구.

**branch protection의 `required_status_checks`(더 근본적인 SSOT)를 직접 읽는 방법도 검토**했으나 `GITHUB_TOKEN`에는 그 API 권한 스코프 자체가 없다(`actionlint`가 `administration`을 유효하지 않은 permission으로 거부 — GitHub REST "Get branch protection"은 `GITHUB_TOKEN`으로 애초에 접근 불가한 엔드포인트). `actions: read`만 추가해 `actions/workflows/{id}/runs`로 대체했다.

## 검증
- `actionlint` 통과(YAML+shellcheck 번들, 무관 기존 경고 1건만 — ci.yml:1449 SC2034, 재확인).
- `gh api repos/moonklabs/sprintable/branches/develop/protection`으로 실 필수 컨텍스트 넷이 전부 `ci.yml` 잡임을 실측 확인.
- 로컬 bash+jq 픽스처 4종(PR#3725 실사고 값 그대로 재현)으로 새 스텝의 판정 로직을 재현:
  - queued(실사고 재현) → **fail**(status=queued로 정확히 잡음)
  - run 자체 없음 → fail(fail-closed)
  - completed+failure → fail
  - completed+success → **pass**
  - **대조**: 같은 실사고 데이터(빈 check-runs 배열)로 기존 스텝을 재현하면 exit 0(잘못 통과) — 이 PR이 고치는 정확한 구멍임을 재확인.

## 스코프 밖 — 플래그만
- `design-review-gate.yml`에 동일 구조의 취약 스텝이 하나 더 있다(같은 check-runs-목록 기반 로직). 이 스토리 스코프(QA Review Gate) 밖이라 손대지 않음 — 별도 스토리로 플래그 필요.
- story AC2(QA verdict 코멘트 템플릿의 "CI green" 문구 교체)는 카디르(QA 에이전트) 자신의 운영 프롬프트 영역 — 이 레포 코드가 아니라 이 PR로 반영 불가, PO/카디르 경유 별도 처리 필요.

## 참고
- 근거 스토리: #3346(entity:story:f872a75b-013e-45fc-8206-688fb7ad7bf0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lbwgf71pVGzZ6NPntw5JCC