### PR TITLE
[SID:3400] CI 워크플로 run 완주 대조를 공유 컴포지트 액션으로 추출 — design-review-gate.yml도 story #3346 처방 적용

### DIFF
--- a/.github/actions/ci-run-completion-check/action.yml
+++ b/.github/actions/ci-run-completion-check/action.yml
@@ -1,0 +1,71 @@
+name: CI workflow run completion check
+description: >
+  qa/design review gate 공용 — head SHA에 대한 CI 워크플로 run 자체가 completed+success인지
+  직접 대조한다(체크런 목록만 보는 기존 판정이 "체크런 자체가 아직 안 생긴" 워크플로를 못
+  잡는 구멍을 메운다). story #3346(qa-review-gate.yml 최초 적용)·#3400(design-review-gate.yml
+  로 확장하며 컴포지트 액션으로 추출) 참고.
+
+# story #3346(2026-09-02 실사고, PR#3725 head a9c9322eb) — "qa:pass인데 안 끝난 비-advisory
+# 체크가 있으면 fail" 판정이 commits/{sha}/check-runs 목록만 봐서, force-push 직후
+# concurrency로 queued 상태이던 CI(잡이 아직 안 시작해 체크런 자체가 없음)를 «미완 0건»으로
+# 오판했다 — "미완인 체크런을 찾는" 로직은 "체크런 자체가 없다"는 신호를 원리적으로 못
+# 잡는다(없는 것과 통과한 것을 구별 못 함).
+#
+# 처방 — 이 리포의 필수 체크 넷(Backend pytest·Lint·Alembic·Support Gateway)이 전부 «CI»라는
+# 단일 워크플로(ci.yml) 안의 잡이라는 실측 사실에 기대, "체크런 목록"이 아니라 "그 워크플로
+# 자체의 run 상태"를 head에 대해 직접 물어 fail-closed로 판정한다: run이 하나도 없으면(아직
+# 큐잉조차 안 됐거나 조회 실패) «미완»으로 실패, 있으면 최신 run의 status가 completed이고
+# conclusion이 success인지를 요구한다.
+#
+# ⛔branch protection의 required_status_checks를 직접 읽는 방법(더 근본적인 SSOT)도
+# 검토했으나 GITHUB_TOKEN에는 그 API 자체에 대한 권한 스코프가 없다(actionlint가
+# "administration"을 유효하지 않은 permission으로 거부 — GitHub REST "Get branch
+# protection"은 애초에 GITHUB_TOKEN으로 접근 불가한 엔드포인트다). 이 액션을 쓰는 워크플로는
+# `permissions.actions: read`를 선언해야 한다(호출부 책임 — 컴포지트 액션은 자신의
+# permissions를 선언할 수 없다).
+#
+# story #3400 — qa-review-gate.yml(#3346)·design-review-gate.yml 둘 다 이 판정이 그대로
+# 필요해 verdict-head-check와 같은 자리(공유 컴포지트 액션)로 추출했다. label-name만 소비자별
+# 에러 메시지 표기용으로 받고, 판정 로직 자체(워크플로 파일명 "ci.yml"·필수 잡 이름)는
+# 공유한다 — 두 게이트가 같은 CI를 같은 기준으로 재는 것이 맞다(verdict-head-check가
+# header/head-extract 정규식을 소비자별로 다르게 «유지»한 것과는 반대 판단 — 그쪽은 리뷰어별
+# 실제 코멘트 관행이 갈려서 통일하면 진짜 회귀가 났지만, 이쪽은 "같은 CI를 재는 것"이라
+# 갈릴 이유가 없다).
+
+inputs:
+  label-name:
+    description: 판정 라벨 이름(예 qa:pass·design:pass) — 에러 메시지 표기용.
+    required: true
+  gh-token:
+    description: gh api 호출용 토큰.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        LABEL_NAME: ${{ inputs.label-name }}
+      run: |
+        set -euo pipefail
+        RUNS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${HEAD_SHA}&per_page=20" --paginate --slurp \
+          | jq '[.[].workflow_runs[]]')"
+        LATEST="$(echo "${RUNS_JSON}" | jq 'sort_by(.run_started_at) | last')"
+        if [ "${LATEST}" = "null" ]; then
+          echo "::error title=CI workflow run not found::${LABEL_NAME}가 붙어 있지만 head(${HEAD_SHA})에 대한 CI 워크플로 run이 하나도 없다 — 아직 큐잉조차 안 됐을 수 있다(체크런 부재와 같은 증상). 모르면 통과가 아니라 실패다(fail-closed)."
+          exit 1
+        fi
+        STATUS="$(echo "${LATEST}" | jq -r '.status')"
+        CONCLUSION="$(echo "${LATEST}" | jq -r '.conclusion')"
+        RUN_URL="$(echo "${LATEST}" | jq -r '.html_url')"
+        if [ "${STATUS}" != "completed" ]; then
+          echo "::error title=CI workflow run not completed::${LABEL_NAME}가 붙어 있지만 head(${HEAD_SHA})의 CI 워크플로 run이 아직 «${STATUS}»다(예: queued — force-push 직후 이전 head의 run과 concurrency 대기 중일 수 있다, 실사고 story #3346). 체크런이 없는 상태라 체크런 목록 기반 판정이 못 잡는다 — 이 스텝이 그 자리를 메운다. ${RUN_URL}"
+          exit 1
+        fi
+        if [ "${CONCLUSION}" != "success" ]; then
+          echo "::error title=CI workflow run not success::${LABEL_NAME}가 붙어 있지만 head(${HEAD_SHA})의 CI 워크플로 run이 completed지만 conclusion이 «${CONCLUSION}»(success 아님). ${RUN_URL}"
+          exit 1
+        fi
+        echo "CI workflow run completed+success for ${HEAD_SHA}: ${RUN_URL}"

--- a/.github/workflows/design-review-gate.yml
+++ b/.github/workflows/design-review-gate.yml
@@ -57,6 +57,12 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read  # AC7 개정분 — labeled 타임라인 이벤트 조회(issues/events)에 필요
+  # story #3400 — CI 워크플로 run 상태(queued/in_progress/completed)를
+  # actions/workflows/{id}/runs로 직접 읽는다(qa-review-gate.yml #3346과 공유하는
+  # .github/actions/ci-run-completion-check). branch protection required_status_checks
+  # 직접 읽기는 GITHUB_TOKEN에 권한 스코프 자체가 없어(actionlint: "administration"은
+  # 무효 permission) 채택 안 함 — 근거는 그 액션 파일 주석 참고.
+  actions: read
 
 jobs:
   design-review-gate:
@@ -274,3 +280,17 @@ jobs:
             exit 1
           fi
           echo "no incomplete non-advisory checks for ${HEAD_SHA}."
+
+      # story #3346(qa-review-gate.yml에서 최초 발견·수정, 2026-09-02 실사고 PR#3725)·
+      # #3400(이 워크플로로 확장) — 위 스텝은 "존재하는 check-runs 목록"만 본다.
+      # force-push 직후 concurrency로 큐 대기(pending) 중이던 CI는 잡이 아직 시작도 안
+      # 해 체크런 자체가 하나도 없었다 — "미완인 체크런"이 아니라 "체크런 자체가 없는"
+      # 경우라 위 스텝의 필터를 그냥 통과해(0건 매치) «미완 0건»으로 오판한다. 판정
+      # 로직·근거는 qa-review-gate.yml과 공유하는
+      # .github/actions/ci-run-completion-check/action.yml 참고.
+      - name: Enforce the CI workflow run itself is completed+success at head (not just its check-runs)
+        if: steps.scope.outputs.in_scope == 'true'
+        uses: ./.github/actions/ci-run-completion-check
+        with:
+          label-name: design:pass
+          gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/qa-review-gate.yml
+++ b/.github/workflows/qa-review-gate.yml
@@ -257,38 +257,12 @@ jobs:
       # 워크플로의 잡이 실제로 시작돼야 생긴다 — «존재 자체가 없다»는 신호는 check-runs
       # API로는 원리적으로 못 잡는다(없는 것과 통과한 것을 구별 못 함).
       #
-      # 처방 — 이 넷은 전부 «CI»라는 단일 워크플로(ci.yml) 안의 잡이다(실측: 이 파일
-      # 이름 넷 전부가 ci.yml에서 나온다 — 다른 워크플로가 이 이름들을 내는 자리는
-      # 없다). 그래서 "체크런 목록"이 아니라 "그 워크플로 자체의 run 상태"를 head에
-      # 대해 직접 물어 fail-closed로 판정한다: run이 하나도 없으면(아직 큐잉조차 안
-      # 됐거나 조회 실패) «미완»으로 실패, 있으면 그 중 최신 run의 status가
-      # completed이고 conclusion이 success인지를 요구한다. ⛔branch protection의
-      # required_status_checks를 직접 읽는 방법(더 근본적인 SSOT)도 검토했으나
-      # GITHUB_TOKEN에는 그 API 자체에 대한 권한 스코프가 없다(actionlint가
-      # "administration"을 유효하지 않은 permission으로 거부 — GitHub REST "Get branch
-      # protection"은 애초에 GITHUB_TOKEN으로 접근 불가한 엔드포인트다).
+      # story #3400 — 이 판정을 design-review-gate.yml도 그대로 필요로 해(동일 구조의
+      # 취약 스텝을 갖고 있었다) 공유 컴포지트 액션(verdict-head-check와 같은 자리)으로
+      # 추출했다. 판정 로직·근거는 .github/actions/ci-run-completion-check/action.yml
+      # 참고.
       - name: Enforce the CI workflow run itself is completed+success at head (not just its check-runs)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          RUNS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${HEAD_SHA}&per_page=20" --paginate --slurp \
-            | jq '[.[].workflow_runs[]]')"
-          LATEST="$(echo "${RUNS_JSON}" | jq 'sort_by(.run_started_at) | last')"
-          if [ "${LATEST}" = "null" ]; then
-            echo "::error title=CI workflow run not found::head(${HEAD_SHA})에 대한 CI 워크플로 run이 하나도 없다 — 아직 큐잉조차 안 됐을 수 있다(체크런 부재와 같은 증상). 모르면 통과가 아니라 실패다(fail-closed)."
-            exit 1
-          fi
-          STATUS="$(echo "${LATEST}" | jq -r '.status')"
-          CONCLUSION="$(echo "${LATEST}" | jq -r '.conclusion')"
-          RUN_URL="$(echo "${LATEST}" | jq -r '.html_url')"
-          if [ "${STATUS}" != "completed" ]; then
-            echo "::error title=CI workflow run not completed::head(${HEAD_SHA})의 CI 워크플로 run이 아직 «${STATUS}»다(예: queued — force-push 직후 이전 head의 run과 concurrency 대기 중일 수 있다, 실사고 PR#3725). 체크런이 없는 상태라 위 스텝이 못 잡는다 — 이 스텝이 그 자리를 메운다. ${RUN_URL}"
-            exit 1
-          fi
-          if [ "${CONCLUSION}" != "success" ]; then
-            echo "::error title=CI workflow run not success::head(${HEAD_SHA})의 CI 워크플로 run이 completed지만 conclusion이 «${CONCLUSION}»(success 아님). ${RUN_URL}"
-            exit 1
-          fi
-          echo "CI workflow run completed+success for ${HEAD_SHA}: ${RUN_URL}"
+        uses: ./.github/actions/ci-run-completion-check
+        with:
+          label-name: qa:pass
+          gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 요지
story #3346(PR#3759)이 qa-review-gate.yml에만 고친 "체크런 목록이 아니라 CI 워크플로 run 자체의 상태를 head에 직접 대조"하는 스텝이 design-review-gate.yml에도 그대로 필요했다. 확인해 보니 design-review-gate.yml의 "Enforce no incomplete non-advisory checks when design:pass is claimed" 스텝이 **qa-review-gate.yml의 고쳐지기 전 버전과 동일한 로직**(check-runs 목록 기반)을 갖고 있었고, 같은 빈 check-runs 픽스처로 재현하면 동일하게 오판(exit 0)함을 확인했다.

## 처방
로직이 두 게이트에 동일하게 필요하므로(둘 다 같은 CI를 같은 기준으로 재는 것이 맞다) story #2912 선례(공유 컴포지트 액션으로 수렴)를 따라 `.github/actions/ci-run-completion-check`로 추출했다.
- 신설 컴포지트 액션 — PR#3759의 판정 로직 그대로(run 없음=fail-closed, 최신 run status=completed·conclusion=success 요구), `label-name`만 소비자별 에러 메시지 표기용 입력으로 받음.
- `qa-review-gate.yml` — 인라인 스텝을 액션 호출로 교체(로직 무변화).
- `design-review-gate.yml` — 새 스텝 추가(`steps.scope.outputs.in_scope` 조건 유지, 이 워크플로만의 경로 스코핑 관례를 그대로 따름) + `permissions.actions: read` 추가.

**참고**: `verdict-head-check`가 header/head-extract 정규식을 소비자별로 다르게 «유지»한 것과는 반대 판단 — 그쪽은 리뷰어별 실제 코멘트 관행이 갈려서 통일하면 진짜 회귀가 났었지만, 이번엔 "같은 CI를 재는 것"이라 갈릴 이유가 없다.

## 검증
- `actionlint`(YAML+shellcheck) — 무관 기존 경고만 재확인. `action.yml`을 직접 대상 지정하면 "jobs/on 섹션 없음" 오탐이 뜨는데(actionlint가 모든 파일을 workflow로 취급) 기존 `verdict-head-check/action.yml`도 동일 오탐이 남을 확인(사전 존재하는 정상 현상). 인자 없는 전체스캔은 무관 경고 외 0.
- 로컬 bash+jq 픽스처 4종×2라벨(qa:pass·design:pass)로 새 액션의 판정 로직을 재현 — queued/run없음/completed+failure는 fail, completed+success만 pass.
- **대조**: design-review-gate.yml 구 스텝을 같은 빈 check-runs 픽스처로 돌리면 wrongly pass(exit 0) — 이 PR이 고치는 정확한 구멍이 design 쪽에도 있었음을 재확인.

## 참고
- 근거 스토리: #3400(entity:story:7f066a4c-2f9d-449a-ab5a-277580251d4d), 원 스토리 #3346, PR#3759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lbwgf71pVGzZ6NPntw5JCC