### PR TITLE
[SID:3388] fix: shard-weights.json에 test_f6d14476_gate_already_held.py 실측값 등재

### DIFF
--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,6 @@
 {
   "_snapshot_policy": "story #3383(2026-09-03) — 로컬 재측정(템플릿 DB 적용 후). 로컬 절대시간은 CI의 ~1/6이지만(실측), 파일 간 상대 비중은 LPT 배분에 유효하다. 재측정 기준은 이전과 동일: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐.",
-  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections",
+  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard",
   "measured_at": "2026-09-03",
   "files": [
     {
@@ -834,6 +834,10 @@
     {
       "file": "tests/test_3399_agent_visible_channel_connections.py",
       "sec": 5.64
+    },
+    {
+      "file": "tests/test_f6d14476_gate_already_held.py",
+      "sec": 23.0
     }
   ]
 }


### PR DESCRIPTION
## 요약

#3751(story #3388/f6d14476, 「gate already held」)에서 신설된
`backend/tests/test_f6d14476_gate_already_held.py`가 `infra/destructive-schema-shard-weights.json`
에 미등재라, story #9440113a(#3392)의 unweighted 가드가 develop 위 모든 PR CI에서 발화 중
(#3760 shard 7: 23s > 16s 판정선). CI 실측값(23s)을 weights.json에 등재해 가드를 잠재운다.

## 변경

- `infra/destructive-schema-shard-weights.json`에 `{"file": "tests/test_f6d14476_gate_already_held.py", "sec": 23.0}` 추가.
- 헤더(`total_files`/`total_sec`)는 story #3397/#3398에 따라 이미 파생 제거된 상태 — 항목만 추가, 헤더는 건드리지 않음.

## 검증

로컬 `python3 -c "json.load(...)"`로 well-formedness·dedup 확認(209건, 중복 0). 로컬 pytest 환경(실PG) 없어 `test_shard_destructive_tests.py` 로컬 실행은 못했음 — CI가 판정자.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm