### PR TITLE
[SID:3401] test_sse_lease.py — 시간 임계 assert가 러너 속도에 종속되던 플레이키 fix

### DIFF
--- a/backend/tests/test_sse_lease.py
+++ b/backend/tests/test_sse_lease.py
@@ -112,20 +112,28 @@ async def test_earliest_expiry_returns_soonest_score(_flag_on_fakeredis):
     await sse_lease.acquire("g", 3, "c1")
     await sse_lease.acquire("g", 3, "c2")
     key = sse_lease._key("g")
-    # c1이 c2보다 먼저 만료하도록 score를 직접 당겨둔다(둘 다 acquire 직후 score는 거의 같음).
-    await _flag_on_fakeredis.zadd(key, {"c1": time.time() + 10, "c2": time.time() + 80})
+    # story #3401 — 기대값을 zadd 시점에 한 번만 캡처한다. 예전엔 assert 쪽에서 time.time()을
+    # 다시 불러 "지금 기준 +10"과 비교했는데, earliest_expiry()는 그 사이 실제 Redis
+    # 라운드트립(비동기 await)을 거친다 — 느린 러너에서 이 간격이 늘어나면 두 time.time()
+    # 호출값이 갈라져(±2s 여유를 실측으로 넘긴 사례: 2.47s) 순전히 타이밍만으로 실패했다
+    # (develop run 33786510969). earliest_expiry()는 저장된 score를 그대로 반환하므로(재계산
+    # 없음), 같은 값과 정확히 비교하면 이 시계열 자체가 사라진다.
+    c1_expiry = time.time() + 10
+    await _flag_on_fakeredis.zadd(key, {"c1": c1_expiry, "c2": time.time() + 80})
     earliest = await sse_lease.earliest_expiry("g")
-    assert earliest is not None
-    assert abs(earliest - (time.time() + 10)) < 2  # c1(가장 이른 것)의 score
+    assert earliest == c1_expiry  # c1(가장 이른 것)의 score — 저장한 값과 정확히 같아야 한다
 
 
 async def test_earliest_expiry_skips_already_expired(_flag_on_fakeredis):
     """이미 만료(score<=now)된 건 evict된 뒤 계산 — 산 것 중 가장 이른 것만 본다."""
     key = sse_lease._key("g")
-    await _flag_on_fakeredis.zadd(key, {"zombie": time.time() - 5, "alive": time.time() + 50})
+    # story #3401 — 위 test_earliest_expiry_returns_soonest_score와 동일한 이유로 기대값을
+    # zadd 시점에 캡처해 정확 비교(assert 쪽 time.time() 재호출 제거 — 느린 러너에서 실측
+    # 2.47s 갈라짐으로 flaky, develop run 33786510969).
+    alive_expiry = time.time() + 50
+    await _flag_on_fakeredis.zadd(key, {"zombie": time.time() - 5, "alive": alive_expiry})
     earliest = await sse_lease.earliest_expiry("g")
-    assert earliest is not None
-    assert abs(earliest - (time.time() + 50)) < 2
+    assert earliest == alive_expiry
 
 
 async def test_earliest_expiry_none_when_live_full(_flag_on_fakeredis):


### PR DESCRIPTION
## 요지
story #3401(develop run 33786510969 실사고 — 7455 중 1건, `assert 2.47 < 2`). `test_earliest_expiry_returns_soonest_score`·`test_earliest_expiry_skips_already_expired` 두 테스트가 zadd에 쓴 score를 검증할 때 "지금 기준 `time.time() + N`"을 assert 쪽에서 **다시 계산**해 ±2초 관용치로 비교했다. `earliest_expiry()`는 저장된 score를 그대로 반환할 뿐 재계산하지 않으므로(`app/services/sse_lease.py` 확인), zadd 시점과 assert 시점 사이 실제 경과한 wall-clock(await 라운드트립 + 느린 러너의 스케줄링 지연)만큼 두 `time.time()` 호출값이 갈라진다 — **코드 회귀가 아니라 순전히 이 시계열 자체가 원인**.

story #3393이 정식화한 "느린 러너 표본"(median 4.45x~max 12.18x)과 같은 반(班) — 벽시계 절대값에 기대는 판정이 러너 속도가 그날그날 다르면 흔들린다는 동일 구조(#3396의 60초 가드 정규화와 같은 계열).

## 처방
시계 mock/freezegun 도입 대신 더 작은 수술 — 기대값을 zadd 시점에 "한 번만" 변수로 캡처해 두고 그 값과 **정확히(==) 비교**한다. `earliest_expiry()`가 저장값을 그대로 반환하는 이상 재-`time.time()` 호출 자체가 불필요했다 — 시계열이 아예 사라져 어떤 러너 속도에서도 흔들리지 않는다.

## 검증
`asyncio.sleep(3)`으로 느린 러너를 시뮬레이션하는 임시 회귀 스크립트(커밋 안 함)로:
- (a) 구 스타일이 실제로 **3.01s** 갈라져 `assert <2`를 못 통과함을 재현.
- (b) 신 스타일(정확 비교)은 같은 3초 지연에서도 항상 참임을 확인.

`test_sse_lease.py` 16건 전체 통과(회귀 없음 — SSE lease 만료 판정 로직 자체는 무변화, 테스트 견고성만 개선).

## 참고
- 근거 스토리: #3401(entity:story:abe70d83-a95a-4c30-9509-29f5761551b6)
- 관련 선례: story #3396(entity:story:2089b772-daca-43f4-9f0a-eaef2d76bcd7) — CI 60초 가드를 러너 정규화 배율로 고친 같은 계열의 처방.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lbwgf71pVGzZ6NPntw5JCC