### PR TITLE
[SID:3403] feat(channel-posts): 초안 단건 조회 GET .../drafts/{draft_id}

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -173,6 +173,31 @@ async def post_channel_post_draft_version(
     )
 
 
+def _to_draft_list_item(
+    row: tuple,
+) -> ChannelPostDraftListItem:
+    """story #3403 — 목록·단건 두 엔드포인트가 공유하는 유일한 직렬화 지점. 손으로 두
+    번 짜지 않는다(드리프트 원천 차단, list_channel_post_drafts()가 draft_id 필터를
+    똑같이 지원하는 것과 동형 사상)."""
+    draft, latest, origin, gate, published_pub, latest_pub, published_body_sha256 = row
+    return ChannelPostDraftListItem(
+        draft_id=draft.id, work_item_id=draft.work_item_id, channel=draft.channel,
+        connection_id=draft.connection_id, current_version=latest.version,
+        latest_author_kind=latest.author_kind, origin_author_kind=origin.author_kind,
+        updated_at=latest.created_at.isoformat(),
+        body_sha256=latest.body_sha256,
+        gate_status=gate.status if gate else None,
+        reapproval_required=gate.reapproval_required if gate else None,
+        sealed_content_sha256=gate.sealed_content_sha256 if gate else None,
+        published_at=published_pub.published_at.isoformat() if published_pub else None,
+        published_body_sha256=published_body_sha256,
+        publication_status=latest_pub.status if latest_pub else None,
+        permalink=published_pub.permalink if published_pub else None,
+        external_id=published_pub.external_id if published_pub else None,
+        error_code=latest_pub.error_code if latest_pub else None,
+    )
+
+
 @router.get("/{org_id}/channel-posts/drafts", response_model=list[ChannelPostDraftListItem])
 async def list_channel_post_drafts_endpoint(
     org_id: uuid.UUID,
@@ -188,25 +213,31 @@ async def list_channel_post_drafts_endpoint(
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
     rows = await list_channel_post_drafts(db, org_id=org_id, limit=limit, offset=offset)
-    return [
-        ChannelPostDraftListItem(
-            draft_id=draft.id, work_item_id=draft.work_item_id, channel=draft.channel,
-            connection_id=draft.connection_id, current_version=latest.version,
-            latest_author_kind=latest.author_kind, origin_author_kind=origin.author_kind,
-            updated_at=latest.created_at.isoformat(),
-            body_sha256=latest.body_sha256,
-            gate_status=gate.status if gate else None,
-            reapproval_required=gate.reapproval_required if gate else None,
-            sealed_content_sha256=gate.sealed_content_sha256 if gate else None,
-            published_at=published_pub.published_at.isoformat() if published_pub else None,
-            published_body_sha256=published_body_sha256,
-            publication_status=latest_pub.status if latest_pub else None,
-            permalink=published_pub.permalink if published_pub else None,
-            external_id=published_pub.external_id if published_pub else None,
-            error_code=latest_pub.error_code if latest_pub else None,
-        )
-        for draft, latest, origin, gate, published_pub, latest_pub, published_body_sha256 in rows
-    ]
+    return [_to_draft_list_item(row) for row in rows]
+
+
+@router.get(
+    "/{org_id}/channel-posts/drafts/{draft_id}", response_model=ChannelPostDraftListItem,
+)
+async def get_channel_post_draft_detail_endpoint(
+    org_id: uuid.UUID,
+    draft_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> ChannelPostDraftListItem:
+    """story #3403 — 단건 조회. 목록 항목(`ChannelPostDraftListItem`)과 완전히 같은
+    shape·같은 직렬화 경로(`_to_draft_list_item`) — `list_channel_post_drafts()`를
+    draft_id 필터로 그대로 재사용해 조인 축 드리프트가 구조적으로 없다. 권한도 목록과
+    동일(휴먼·에이전트 둘 다, `_require_human()` 안 부름). org 스코프 밖이거나 존재하지
+    않으면 404("존재 비노출" 관례, site_posts detail과 동형)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+
+    rows = await list_channel_post_drafts(db, org_id=org_id, draft_id=draft_id, limit=1)
+    if not rows:
+        raise HTTPException(status_code=404, detail=f"draft를 찾을 수 없습니다: {draft_id}")
+    return _to_draft_list_item(rows[0])
 
 
 @router.get(

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -296,6 +296,7 @@ async def list_channel_post_draft_versions(
 
 async def list_channel_post_drafts(
     db: AsyncSession, *, org_id: uuid.UUID, limit: int = 50, offset: int = 0,
+    draft_id: uuid.UUID | None = None,
 ) -> list[
     tuple[
         ChannelPostDraft, ChannelPostVersion, ChannelPostVersion,
@@ -304,6 +305,12 @@ async def list_channel_post_drafts(
 ]:
     """site_posts.list_site_post_drafts와 동형(latest+origin 버전 조인, "최신"은 최신
     버전의 created_at 기준) — API 경로 제안 §③ "site S4 후속과 동형".
+
+    story #3403 — `draft_id`를 주면 페이지 쿼리에 단건 필터가 추가될 뿐, 그 아래 배치
+    ②~⑤(gate·publication·버전해시 조회)는 손대지 않는다 — 이미 work_item_id/gate_id
+    키로 동작해 draft 수와 무관하다. 단건 조회(`GET .../drafts/{draft_id}`)가 이 함수를
+    그대로 재사용하는 이유 — 두 번째 쿼리 경로를 새로 짜면 목록과 단건이 다른 값을
+    낼 드리프트 표면이 생긴다.
 
     story #3394(S2c BE 선행, 페드루 PO 확定 2026-09-04) — 상태 파생·발행 상태 필드를 여기서
     배치 조회해 붙인다(site_posts.list_site_post_drafts의 #3384 확장과 동형 패턴, N+1 금지 —
@@ -362,6 +369,8 @@ async def list_channel_post_drafts(
         .limit(limit)
         .offset(offset)
     )
+    if draft_id is not None:
+        stmt = stmt.where(ChannelPostDraft.id == draft_id)
     page_rows = [(row[0], row[1], row[2]) for row in (await db.execute(stmt)).all()]
     if not page_rows:
         return []

--- a/backend/tests/test_3403_channel_post_draft_detail.py
+++ b/backend/tests/test_3403_channel_post_draft_detail.py
@@ -1,0 +1,498 @@
+"""story #3403(Phase1·마케팅운영, S2c BE 선행 2, 페드루 PO 확定 2026-09-04) — 채널 포스트
+초안 단건 조회 `GET /organizations/{org_id}/channel-posts/drafts/{draft_id}`.
+
+핵심 계약: 목록 엔드포인트(`GET .../channel-posts/drafts`, story #3394)의 항목과
+**완전히 같은 shape·같은 조인 축**이어야 한다 — `list_channel_post_drafts()`를 draft_id
+필터로 재사용하므로 구조적으로 같다(두 번째 쿼리 경로 없음). 이 파일의 각 상태 테스트는
+목록 응답의 동등 항목과 단건 응답을 **필드 단위로 대조**한다(값이 우연히 같은 게 아니라
+같은 코드 경로임을 pin)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="S2c Draft Detail Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="담롱"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_human(session, org_id, *, role="member"):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="채널 포스트"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_default_role(session, org_id):
+    from app.models.participation import ParticipationRole
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+    session.add(role)
+    await session.commit()
+    return role.id
+
+
+async def _seed_connection(session, org_id, *, channel="threads", status="active", account_id=None, token="plain-access-token"):
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    conn = ChannelConnection(
+        id=uuid.uuid4(), org_id=org_id, channel=channel,
+        account_id=account_id or f"acct-{uuid.uuid4().hex[:8]}", status=status,
+        credential_kind="oauth", refresh_mode="reissue_from_access_token",
+        encrypted_access_token=encrypt_channel_credential(token) if status == "active" else None,
+    )
+    session.add(conn)
+    await session.commit()
+    return conn.id
+
+
+async def _approve_gate_directly(session, gate_id):
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    gate = (await session.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+    gate.status = "approved"
+    gate.resolver_id = uuid.uuid4()
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.commit()
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id, agent: bool = False):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if agent:
+            claims["app_metadata"]["api_key_id"] = "test-agent-key"
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _draft_body(*, work_item_id, connection_id, text="채널 포스트 본문입니다.", link_url=None):
+    body = {"work_item_id": str(work_item_id), "connection_id": str(connection_id), "text": text}
+    if link_url is not None:
+        body["link_url"] = link_url
+    return body
+
+
+async def _seed_submit_approve(client, session, *, org_id, connection_id, story_id, text="채널 포스트 본문입니다."):
+    r_draft = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+        json=_draft_body(work_item_id=story_id, connection_id=connection_id, text=text),
+    )
+    assert r_draft.status_code == 201, r_draft.text
+    draft_id = r_draft.json()["draft_id"]
+    r_submit = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={})
+    assert r_submit.status_code == 200, r_submit.text
+    gate_id = uuid.UUID(r_submit.json()["gate_id"])
+    await _approve_gate_directly(session, gate_id)
+    return draft_id, gate_id
+
+
+@pytest.mark.anyio
+async def test_detail_draft_only_matches_list_item_exactly():
+    """AC3(a) — 게이트조차 없는 순수 초안: 단건 응답이 목록의 동등 항목과 필드까지 정확히
+    같다(같은 코드 경로 pin)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id),
+            )
+            assert r_draft.status_code == 201, r_draft.text
+            draft_id = r_draft.json()["draft_id"]
+
+            r_list = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+            r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+
+        assert r_detail.status_code == 200, r_detail.text
+        list_row = [it for it in r_list.json() if it["draft_id"] == draft_id]
+        assert len(list_row) == 1
+        assert r_detail.json() == list_row[0]
+        assert r_detail.json()["gate_status"] is None
+        assert r_detail.json()["publication_status"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_detail_published_matches_list_item_exactly():
+    """AC3(b) — 승인+발행됨: publication_status=published, permalink/external_id/
+    published_at 채워짐. 단건과 목록이 필드까지 정확히 같다."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _seed_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+
+        with (
+            patch.object(tp, "create_container", AsyncMock(return_value="creation-1")),
+            patch.object(tp, "publish_container", AsyncMock(return_value="media-1")),
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "get_permalink", AsyncMock(return_value="https://www.threads.net/@demo/post/media-1")),
+        ):
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client:
+                r_publish = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+                assert r_publish.status_code == 200, r_publish.text
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_list = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+            r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+
+        assert r_detail.status_code == 200, r_detail.text
+        list_row = [it for it in r_list.json() if it["draft_id"] == draft_id]
+        assert len(list_row) == 1
+        assert r_detail.json() == list_row[0]
+        body = r_detail.json()
+        assert body["publication_status"] == "published"
+        assert body["permalink"] == "https://www.threads.net/@demo/post/media-1"
+        assert body["external_id"] == "media-1"
+        assert body["published_at"] is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_detail_partial_success_matches_list_item_exactly():
+    """AC3(c) — 부분 성공(publication_status=container_created): 단건과 목록이 필드까지
+    정확히 같다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _seed_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+
+        async with Session() as s:
+            from app.models.channel_publication import ChannelPublication
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            s.add(ChannelPublication(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, version_id=version_id,
+                connection_id=connection_id, channel="threads",
+                external_container_id="creation-mid-flight", status="container_created",
+            ))
+            await s.commit()
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_list = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+            r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+
+        assert r_detail.status_code == 200, r_detail.text
+        list_row = [it for it in r_list.json() if it["draft_id"] == draft_id]
+        assert len(list_row) == 1
+        assert r_detail.json() == list_row[0]
+        assert r_detail.json()["publication_status"] == "container_created"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_detail_unknown_draft_id_404():
+    """AC3(d) — 존재하지 않는 draft_id → 404(존재 비노출 관례)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{uuid.uuid4()}")
+        assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_detail_org_scope_mismatch_404():
+    """다른 org의 draft_id → 404(org_id로 스코프 안 벗어남 — 존재는 알지만 다른 조직 소유라는
+    구별조차 노출하지 않는다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id_a, project_id_a = await _seed_org(s)
+            org_id_b, project_id_b = await _seed_org(s)
+            agent_id_a = await _seed_agent(s, org_id_a, project_id_a)
+            story_id = await _seed_story(s, org_id_a, project_id_a)
+            connection_id = await _seed_connection(s, org_id_a)
+
+        _setup_org_scoped_app(app, Session, org_id_a, user_id=agent_id_a, agent=True)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id_a}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id),
+            )
+            assert r_draft.status_code == 201, r_draft.text
+            draft_id = r_draft.json()["draft_id"]
+
+        async with Session() as s:
+            agent_id_b = await _seed_agent(s, org_id_b, project_id_b)
+        _setup_org_scoped_app(app, Session, org_id_b, user_id=agent_id_b, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id_b}/channel-posts/drafts/{draft_id}")
+        assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_can_also_read_detail():
+    """목록과 동일 권한 — 휴먼도 단건 조회 가능(human-only 아님, publish와 대조)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="member")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id),
+            )
+            assert r_draft.status_code == 201, r_draft.text
+            draft_id = r_draft.json()["draft_id"]
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+        assert r.status_code == 200, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_detail_query_count_does_not_scale_with_other_drafts_in_org():
+    """AC4(N+1 비회귀) — org에 다른 draft가 여럿 있어도 단건 조회의 SELECT 수는 그
+    draft 하나뿐일 때와 같다(구조적으로 list_channel_post_drafts()의 draft_id 필터를
+    타므로 자동 보장 — 실측으로 pin)."""
+    from sqlalchemy import event
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id),
+            )
+            assert r_draft.status_code == 201, r_draft.text
+            draft_id = r_draft.json()["draft_id"]
+
+            def _capture(stmts):
+                def _listener(conn, cursor, statement, parameters, context, executemany):
+                    stmts.append(statement)
+                return _listener
+
+            statements_solo: list[str] = []
+            listener_solo = _capture(statements_solo)
+            event.listen(engine.sync_engine, "before_cursor_execute", listener_solo)
+            try:
+                r_solo = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+                assert r_solo.status_code == 200, r_solo.text
+            finally:
+                event.remove(engine.sync_engine, "before_cursor_execute", listener_solo)
+            select_count_solo = len([st for st in statements_solo if st.strip().upper().startswith("SELECT")])
+
+            # 서로 다른 work_item(=서로 다른 게이트)을 가리키는 draft 3건 추가(같은 org).
+            async with Session() as s:
+                extra_story_ids = [await _seed_story(s, org_id, project_id) for _ in range(3)]
+            for story_n in extra_story_ids:
+                await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                    json=_draft_body(work_item_id=story_n, connection_id=connection_id),
+                )
+
+            statements_crowded: list[str] = []
+            listener_crowded = _capture(statements_crowded)
+            event.listen(engine.sync_engine, "before_cursor_execute", listener_crowded)
+            try:
+                r_crowded = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+                assert r_crowded.status_code == 200, r_crowded.text
+                assert r_crowded.json()["draft_id"] == draft_id
+            finally:
+                event.remove(engine.sync_engine, "before_cursor_execute", listener_crowded)
+            select_count_crowded = len([st for st in statements_crowded if st.strip().upper().startswith("SELECT")])
+
+        assert select_count_crowded == select_count_solo, (
+            f"org에 다른 draft가 늘어도 단건 조회 SELECT 수가 늘면 안 된다 — "
+            f"solo={select_count_solo}, crowded={select_count_crowded}"
+        )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,6 @@
 {
   "_snapshot_policy": "story #3383(2026-09-03) — 로컬 재측정(템플릿 DB 적용 후). 로컬 절대시간은 CI의 ~1/6이지만(실측), 파일 간 상대 비중은 LPT 배분에 유효하다. 재측정 기준은 이전과 동일: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐.",
-  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard",
+  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail",
   "measured_at": "2026-09-03",
   "files": [
     {
@@ -838,6 +838,10 @@
     {
       "file": "tests/test_f6d14476_gate_already_held.py",
       "sec": 23.0
+    },
+    {
+      "file": "tests/test_3403_channel_post_draft_detail.py",
+      "sec": 8.0
     }
   ]
 }


### PR DESCRIPTION
## 요약

미르코군 FE 상세 페이지가 목록 전체를 스캔하지 않고 draft_id로 바로 조회할 수 있게 —
`GET /organizations/{org_id}/channel-posts/drafts/{draft_id}` 신설.

## 설계

- 목록 항목(`ChannelPostDraftListItem`, story #3394/#3742)과 **완전히 같은 shape·같은
  직렬화 경로**. `list_channel_post_drafts()`에 `draft_id: uuid.UUID | None = None` 필터를
  추가해 페이지 쿼리에만 `.where(ChannelPostDraft.id == draft_id)`를 얹는다 — 그 아래
  gate/publication/version-hash 배치 조회는 손대지 않는다(이미 work_item_id/gate_id 키라
  draft 수와 무관, N+1 없음이 구조적으로 보장됨).
- 직렬화는 `_to_draft_list_item()` 헬퍼 하나로 목록·단건 공유 — 두 번째 쿼리/직렬화
  경로를 손으로 새로 짜지 않는다(조인 축 드리프트 원천 차단).
- 권한은 목록과 동일(휴먼·에이전트 둘 다, `_require_human()` 없음). org 스코프 밖이거나
  존재하지 않으면 404("존재 비노출" 관례, site_posts detail과 동형).

## 테스트

`test_3403_channel_post_draft_detail.py`(신규, 7건) — 3상태(초안만·발행됨·부분성공) 각각
목록 응답의 동등 항목과 단건 응답을 **필드 단위로 대조**(같은 코드 경로임을 pin) +
404(존재하지 않는 draft_id·다른 org 소유) + 휴먼도 접근 가능 + N+1 비회귀(org에 다른
draft가 늘어도 단건 조회 SELECT 수 불변).

404 가드는 뮤테이션 자가검증 완료 — 가드를 제거하고 돌리면 대상 2건(`test_detail_unknown_
draft_id_404`·`test_detail_org_scope_mismatch_404`)만 RED, 나머지 5건은 그대로 green.

로컬 실 Postgres(pg@16, 이 테스트 클래스의 `create_all` 스크래치 DB 관례)로 신규 7건 +
기존 channel_posts/channel_connections 관련 77건 전부 통과, 회귀 없음.

## 관련

- story #3403(이 PR) · story #3394/#3742(목록 계약 선례) · story #3374(초안/상신 API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm