### PR TITLE
[SID:3404] fix(channel-posts): 다른 초안이 쥔 게이트를 조용히 되돌리는 결함 — site_posts f6d14476 미러

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -14,6 +14,7 @@ from app.services.channel_posts import (
     ChannelConnectionNotActiveError,
     ChannelPostApproverRoleMissingError,
     ChannelPostDraftNotFoundError,
+    ChannelPostGateAlreadyHeldError,
     ChannelPostReapprovalRequiredError,
     ChannelPostSealMissingError,
     ChannelPostVersionNotFoundError,
@@ -279,6 +280,18 @@ async def submit_channel_post_draft_endpoint(
         raise HTTPException(
             status_code=409,
             detail={"code": "CHANNEL_POST_APPROVER_ROLE_MISSING", "message": str(exc)},
+        ) from exc
+    except ChannelPostGateAlreadyHeldError as exc:
+        # story #3404 — site_posts.py의 SITE_POST_GATE_ALREADY_HELD와 동형 상태코드·모양.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "CHANNEL_POST_GATE_ALREADY_HELD",
+                "message": str(exc),
+                "holding_draft_id": str(exc.holding_draft_id),
+                "holding_channel": exc.holding_channel,
+                "holding_connection_id": str(exc.holding_connection_id),
+            },
         ) from exc
 
     return SubmitChannelPostDraftResponse(

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -146,6 +146,26 @@ class ChannelPostVersionNotFoundError(Exception):
         super().__init__(f"버전을 찾을 수 없습니다: {version_id}")
 
 
+class ChannelPostGateAlreadyHeldError(Exception):
+    """story #3404(Phase1 결함, site_posts.py::SitePostGateAlreadyHeldError·story f6d14476
+    미러) — external_publish 게이트 슬롯은 work_item 단위(draft 단위가 아니다). 같은
+    work_item에 채널 포스트 초안이 둘 이상(예: 서로 다른 connection_id) 있을 때, 이미 다른
+    초안이 그 게이트를 쥐고(pending/approved) 있으면 이 초안의 상신을 명시 거부한다 —
+    조용히 되밟아 먼저 승인된 게이트를 pending으로 되돌리는 사고를 서버가 원천 차단한다.
+    어느 초안이 쥐고 있는지(draft_id·channel·connection_id)를 실어 화면이 "다른 초안이
+    승인 절차 중" 문구+링크를 그릴 수 있게 한다."""
+
+    def __init__(self, *, holding_draft_id: uuid.UUID, holding_channel: str, holding_connection_id: uuid.UUID):
+        self.holding_draft_id = holding_draft_id
+        self.holding_channel = holding_channel
+        self.holding_connection_id = holding_connection_id
+        super().__init__(
+            f"이 work item은 다른 초안이 이미 승인 절차 중입니다"
+            f"(holding_draft_id={holding_draft_id}, channel={holding_channel}, "
+            f"connection_id={holding_connection_id})"
+        )
+
+
 def compute_channel_post_hash(*, text: str, link_url: str | None) -> str:
     """gate_seal.compute_seal_hash 위 얇은 payload 조립부(site_posts.compute_body_sha256과
     동형 역할) — channel은 draft 고정값(배달 경로)이라 해시에 안 섞는다(모델 docstring 참고)."""
@@ -251,7 +271,17 @@ async def _reseal_gate_on_new_version(
 ) -> None:
     """site_posts.py::_reseal_gate_on_new_version과 동형 규칙(§3-1-2), 봉인 본문만 이
     도메인의 `text`를 쓴다: pending 中 편집 → 즉시 재봉인, approved 뒤 편집 → pending
-    재오픈+reapproval_required=True(옛 봉인은 그대로 보존)."""
+    재오픈+reapproval_required=True(옛 봉인은 그대로 보존).
+
+    story #3404(디디 코드 확認 2026-09-03·페드루 PO 지시 2026-09-04) — 이 훅은
+    work_item_id만으로 게이트를 찾는다(draft 무관). 승인 대상이 아닌 다른 초안을
+    편집(새 버전 생성 — 새 draft 최초 생성 포함, 그 자체가 버전 1 생성)했을 뿐인데
+    여기서 그 게이트를 되돌리거나(approved→pending) 조용히 재봉인하면 submit()의
+    가드(resolve_gate_holder_draft_id)를 거치지 않고도 동일한 파괴가 일어난다 —
+    site_posts.py가 f6d14476에서 이미 막은 것과 정확히 같은 결함 클래스가 이 파일에
+    그대로 남아 있었다(직접 재현 확認). submit()과 같은 판정 함수를 그대로 쓴다."""
+    from app.services.gate_service import resolve_gate_holder_draft_id
+
     gate = (await db.execute(
         select(Gate)
         .where(
@@ -261,6 +291,8 @@ async def _reseal_gate_on_new_version(
         .with_for_update()
     )).scalar_one_or_none()
     if gate is None:
+        return
+    if resolve_gate_holder_draft_id(gate, this_draft_id=version.draft_id) is not None:
         return
     if gate.status == "approved":
         set_gate_status(gate, "pending", now=datetime.now(timezone.utc))
@@ -459,13 +491,26 @@ async def submit_channel_post_draft(
         raise ChannelPostVersionNotFoundError(version_id)
     origin_author_member_id = versions[0].author_member_id
 
-    from app.services.gate_service import create_gate, find_gate_slot_with_pr_fallback
+    from app.services.gate_service import create_gate, find_gate_slot_with_pr_fallback, resolve_gate_holder_draft_id
     from app.services.workflow_line_config import _default_role_id
 
     existing = await find_gate_slot_with_pr_fallback(
         db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
         gate_type=_EXTERNAL_PUBLISH_GATE_TYPE, pr_number=None, repo_full_name=None,
     )
+
+    # story #3404(site_posts.py f6d14476 미러, 판정 로직은 gate_service.py::
+    # resolve_gate_holder_draft_id로 공유) — 게이트 슬롯은 work_item 단위라, 이미 다른
+    # 초안이 그 게이트를 쥐고(pending/approved) 있으면 이 초안의 상신을 막는다.
+    holding_draft_id = resolve_gate_holder_draft_id(existing, this_draft_id=draft.id)
+    if holding_draft_id is not None:
+        holder = await get_channel_post_draft(db, org_id=org_id, draft_id=holding_draft_id)
+        if holder is not None:
+            raise ChannelPostGateAlreadyHeldError(
+                holding_draft_id=holder.id, holding_channel=holder.channel,
+                holding_connection_id=holder.connection_id,
+            )
+
     if (
         existing is not None
         and existing.sealed_content_sha256 == target.body_sha256
@@ -477,6 +522,9 @@ async def submit_channel_post_draft(
         "destination": draft.channel,
         "draft_author_member_id": str(origin_author_member_id),
         "requested_by_member_id": str(requester_member_id),
+        # story #3404 — 이 게이트 슬롯을 "쥔" 초안 식별(위 차단 판정의 유일한 근거).
+        # 재상신·재승인 요청도 매번 같은 값을 다시 써 넣는다(no-op이지만 명시).
+        "draft_id": str(draft.id),
     }
 
     role_id = await _default_role_id(db, org_id)

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -594,13 +594,25 @@ def resolve_gate_holder_draft_id(
     None을 반환하는 경우 전부 "막지 않는다"는 뜻이다: 게이트가 없음(신규) · pending/
     approved가 아님(rejected/voided 등 — 걱정할 보유자가 없다) · neutral_facts에
     draft_id가 아예 없음(이 판정이 생기기 前의 레거시 게이트, "모른다≠다르다" — 모르면
-    막지 않는다) · this_draft_id와 같음(자기 자신, 재상신은 언제나 허용)."""
+    막지 않는다) · this_draft_id와 같음(자기 자신, 재상신은 언제나 허용) · neutral_facts.
+    draft_id 값이 유효한 UUID가 아님(페드루 PO 리뷰, PR#3764 — 옛 코드(리팩터 前)는
+    문자열 그대로 비교해 이 자리서 절대 안 터졌는데, `uuid.UUID(...)` 파싱을 여기로
+    끌어오며 생긴 신규 실패 축이었다: 이 함수는 가드다 — 가드가 깨진 데이터 때문에
+    500을 내면 안 된다. 못 읽으면 "모른다"로 취급해 막지 않고 warning만 남긴다)."""
     if existing_gate is None or existing_gate.status not in ("pending", "approved"):
         return None
     holding_raw = (existing_gate.neutral_facts or {}).get("draft_id")
     if holding_raw is None:
         return None
-    holding_id = uuid.UUID(holding_raw)
+    try:
+        holding_id = uuid.UUID(holding_raw)
+    except (ValueError, TypeError, AttributeError):
+        logger.warning(
+            "gate.neutral_facts.draft_id is not a valid UUID (gate_id=%s, value=%r) — "
+            "treating as unknown holder, not blocking",
+            existing_gate.id, holding_raw,
+        )
+        return None
     if holding_id == this_draft_id:
         return None
     return holding_id

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -578,6 +578,34 @@ async def find_gate_slot_with_pr_fallback(
     ).scalar_one_or_none()
 
 
+def resolve_gate_holder_draft_id(
+    existing_gate: Gate | None, *, this_draft_id: uuid.UUID,
+) -> uuid.UUID | None:
+    """story #3404(site_posts.py의 story f6d14476 처방을 channel_posts.py로도 미러하며
+    추출) — 「이 게이트를 이미 다른 초안이 쥐고 있는가」 판정을 한 곳에 모은다. site_posts.py
+    ·channel_posts.py 둘 다 external_publish 게이트 슬롯이 work_item 단위(draft 단위가
+    아니다)라 같은 work_item에 초안이 둘 이상이면 뒤늦은 상신이 앞선 승인을 조용히
+    pending으로 되돌릴 수 있다 — 그 판정 로직 자체(neutral_facts.draft_id 대조)는 두 도메인
+    이 완전히 동일해 두 벌로 유지하면 드리프트 표면이 된다(한쪽만 고치고 잊는 사고). 던지는
+    에러(SitePostGateAlreadyHeldError/ChannelPostGateAlreadyHeldError)는 도메인마다
+    필드가 달라(lang/slug vs channel/connection_id) 여기서 만들지 않는다 — 호출부가 이
+    함수의 반환값(막고 있는 draft_id, 또는 없으면 None)만 받아 자기 도메인 에러를 짓는다.
+
+    None을 반환하는 경우 전부 "막지 않는다"는 뜻이다: 게이트가 없음(신규) · pending/
+    approved가 아님(rejected/voided 등 — 걱정할 보유자가 없다) · neutral_facts에
+    draft_id가 아예 없음(이 판정이 생기기 前의 레거시 게이트, "모른다≠다르다" — 모르면
+    막지 않는다) · this_draft_id와 같음(자기 자신, 재상신은 언제나 허용)."""
+    if existing_gate is None or existing_gate.status not in ("pending", "approved"):
+        return None
+    holding_raw = (existing_gate.neutral_facts or {}).get("draft_id")
+    if holding_raw is None:
+        return None
+    holding_id = uuid.UUID(holding_raw)
+    if holding_id == this_draft_id:
+        return None
+    return holding_id
+
+
 async def find_pending_merge_gates_by_head_sha(
     session: AsyncSession, *, org_id: uuid.UUID, head_sha: str,
 ) -> list[Gate]:

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -362,11 +362,12 @@ async def _reseal_gate_on_new_version(
     # work_item_id만으로 게이트를 찾는다(draft 무관). 승인 대상이 아닌 다른 초안을
     # 편집(새 버전 생성)했을 뿐인데 여기서 그 게이트를 되돌리거나(approved→pending)
     # 조용히 재봉인하면(pending 유지) submit()을 거치지 않고도 동일한 파괴가 일어난다.
-    # neutral_facts.draft_id로 "이 게이트를 쥔 초안"을 확인해, 값이 있고 이 버전의
-    # draft와 다르면 건드리지 않는다(레거시·draft_id 미기록 게이트는 §3-1-1
-    # "모른다≠다르다"에 따라 그대로 통과 — submit() 경로와 동일한 판단 기준).
-    holding_draft_id_raw = (gate.neutral_facts or {}).get("draft_id")
-    if holding_draft_id_raw is not None and holding_draft_id_raw != str(version.draft_id):
+    # 판정은 submit()과 같은 함수로 한다(story #3404에서 gate_service.py::
+    # resolve_gate_holder_draft_id로 추출 — channel_posts.py가 이 함수의 동형 훅에서도
+    # 같은 결함 클래스를 갖고 있어 공유하게 됐다).
+    from app.services.gate_service import resolve_gate_holder_draft_id
+
+    if resolve_gate_holder_draft_id(gate, this_draft_id=version.draft_id) is not None:
         return
     if gate.status == "approved":
         # 승인된 뒤 편집 — pending으로 되돌리기만 한다. sealed_content_*는 절대 안 건드린다
@@ -521,7 +522,7 @@ async def submit_site_post_draft(
         raise SitePostVersionNotFoundError(version_id)
     origin_author_member_id = versions[0].author_member_id
 
-    from app.services.gate_service import create_gate, find_gate_slot_with_pr_fallback
+    from app.services.gate_service import create_gate, find_gate_slot_with_pr_fallback, resolve_gate_holder_draft_id
     from app.services.workflow_line_config import _default_role_id
 
     existing = await find_gate_slot_with_pr_fallback(
@@ -529,22 +530,20 @@ async def submit_site_post_draft(
         gate_type="external_publish", pr_number=None, repo_full_name=None,
     )
 
-    # story f6d14476(PO 결정②) — 게이트 슬롯은 work_item 단위라, 이미 다른 초안이 그
-    # 게이트를 쥐고(pending/approved) 있으면 이 초안의 상신을 막는다(AC1). 「다른 초안」
-    # 판정은 neutral_facts.draft_id로 한다 — 이 값이 없는(이 스토리 착지 前에 만들어진)
-    # 레거시 게이트는 누가 쥐고 있는지 알 수 없어 차단하지 않는다(§3-1-1 "모른다≠다르다"
-    # — 모르면 막지 않는다, AC2가 요구하는 "같은 초안 재상신은 그대로 허용"을 레거시
-    # 게이트에서도 조용히 깨뜨리지 않기 위한 안전장치).
-    if existing is not None and existing.status in ("pending", "approved"):
-        holding_draft_id_raw = (existing.neutral_facts or {}).get("draft_id")
-        if holding_draft_id_raw is not None and holding_draft_id_raw != str(draft.id):
-            holder = await get_site_post_draft(db, org_id=org_id, draft_id=uuid.UUID(holding_draft_id_raw))
-            if holder is not None:
-                holder_versions = await list_site_post_draft_versions(db, draft_id=holder.id)
-                holder_lang = holder_versions[-1].lang if holder_versions else None
-                raise SitePostGateAlreadyHeldError(
-                    holding_draft_id=holder.id, holding_lang=holder_lang, holding_slug=holder.slug,
-                )
+    # story f6d14476(PO 결정②, AC1) — 게이트 슬롯은 work_item 단위라, 이미 다른 초안이 그
+    # 게이트를 쥐고(pending/approved) 있으면 이 초안의 상신을 막는다. 판정 로직 자체는
+    # story #3404에서 gate_service.py::resolve_gate_holder_draft_id로 뽑아 channel_
+    # posts.py와 공유한다("모른다≠다르다"·자기 자신 재상신 허용 규칙 포함, 그 함수
+    # docstring 참고) — 여기선 그 판정 결과로 이 도메인 전용 에러(lang/slug)만 짓는다.
+    holding_draft_id = resolve_gate_holder_draft_id(existing, this_draft_id=draft.id)
+    if holding_draft_id is not None:
+        holder = await get_site_post_draft(db, org_id=org_id, draft_id=holding_draft_id)
+        if holder is not None:
+            holder_versions = await list_site_post_draft_versions(db, draft_id=holder.id)
+            holder_lang = holder_versions[-1].lang if holder_versions else None
+            raise SitePostGateAlreadyHeldError(
+                holding_draft_id=holder.id, holding_lang=holder_lang, holding_slug=holder.slug,
+            )
 
     if (
         existing is not None

--- a/backend/tests/test_3404_channel_post_gate_already_held.py
+++ b/backend/tests/test_3404_channel_post_gate_already_held.py
@@ -388,3 +388,61 @@ async def test_legacy_gate_without_draft_id_in_neutral_facts_does_not_block():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_corrupted_draft_id_in_neutral_facts_does_not_block_or_500():
+    """⭐페드루 PO 리뷰(PR#3764) — neutral_facts.draft_id가 유효한 UUID가 아니면(데이터
+    손상) resolve_gate_holder_draft_id가 500을 내지 않는다 — "모른다"로 취급해 막지 않고
+    상신은 그대로 200이어야 한다(가드가 깨진 데이터로 서비스를 죽이면 안 된다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_a = await _seed_connection(s, org_id, account_id="acct-a")
+            connection_b = await _seed_connection(s, org_id, account_id="acct-b")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_draft_a = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_a),
+            )
+            assert r_draft_a.status_code == 201, r_draft_a.text
+
+            r_submit_a = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{r_draft_a.json()['draft_id']}/submit",
+                json={},
+            )
+            assert r_submit_a.status_code == 200, r_submit_a.text
+            gate_id = uuid.UUID(r_submit_a.json()["gate_id"])
+
+        # 손상 재현 — draft_id 값을 유효하지 않은 문자열로 덮어쓴다.
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            gate.neutral_facts = {**gate.neutral_facts, "draft_id": "not-a-uuid"}
+            await s.commit()
+
+        async with _client_for(app) as client:
+            r_draft_b = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_b),
+            )
+            assert r_draft_b.status_code == 201, r_draft_b.text
+
+            r_submit_b = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{r_draft_b.json()['draft_id']}/submit",
+                json={},
+            )
+            assert r_submit_b.status_code == 200, r_submit_b.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3404_channel_post_gate_already_held.py
+++ b/backend/tests/test_3404_channel_post_gate_already_held.py
@@ -1,0 +1,390 @@
+"""story #3404(Phase1 결함, site_posts.py::submit_site_post_draft의 story f6d14476 처방을
+channel_posts로 미러, 페드루 PO 확定 2026-09-04) — external_publish 게이트 슬롯은 work_item
+단위(draft 단위가 아니다). 같은 work_item에 채널 포스트 초안이 둘(예: 서로 다른
+connection_id) 있으면, 이미 다른 초안이 그 게이트를 쥐고(pending/approved) 있는데 뒤늦게
+다른 초안이 상신하면 조용히 그 게이트를 재봉인·pending으로 되돌리던 결함 — site_posts에서
+이미 고친 클래스 그대로 재현 가능했다(디디 코드 확認, 2026-09-03).
+
+이 파일의 핵심 pin: 「가드 없으면 빨강」 — draft B 상신이 draft A의 승인을 실제로 되돌리지
+않는지, 그리고 같은 draft 재상신은 여전히(회귀 없이) 허용되는지."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Gate Already Held Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="담롱"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="채널 포스트"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_default_role(session, org_id):
+    from app.models.participation import ParticipationRole
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+    session.add(role)
+    await session.commit()
+    return role.id
+
+
+async def _seed_connection(session, org_id, *, channel="threads", status="active", account_id=None, token="plain-access-token"):
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    conn = ChannelConnection(
+        id=uuid.uuid4(), org_id=org_id, channel=channel,
+        account_id=account_id or f"acct-{uuid.uuid4().hex[:8]}", status=status,
+        credential_kind="oauth", refresh_mode="reissue_from_access_token",
+        encrypted_access_token=encrypt_channel_credential(token) if status == "active" else None,
+    )
+    session.add(conn)
+    await session.commit()
+    return conn.id
+
+
+async def _approve_gate_directly(session, gate_id):
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    gate = (await session.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+    gate.status = "approved"
+    gate.resolver_id = uuid.uuid4()
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.commit()
+
+
+async def _get_gate_status(session, gate_id):
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    return (await session.execute(select(Gate.status).where(Gate.id == gate_id))).scalar_one()
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id, agent: bool = False):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if agent:
+            claims["app_metadata"]["api_key_id"] = "test-agent-key"
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _draft_body(*, work_item_id, connection_id, text="채널 포스트 본문입니다."):
+    return {"work_item_id": str(work_item_id), "connection_id": str(connection_id), "text": text}
+
+
+@pytest.mark.anyio
+async def test_second_draft_submit_blocked_while_first_holds_approved_gate():
+    """⭐핵심 pin — draft A(연결 1) 상신·승인 뒤, 같은 work_item의 draft B(연결 2)를
+    상신하면 409 CHANNEL_POST_GATE_ALREADY_HELD로 거부되고, A의 gate.status는 approved
+    그대로 남는다(가드 없으면: B의 상신이 같은 게이트를 B의 내용으로 재봉인+pending으로
+    되돌려 이 assert가 실패한다 — 그게 이 pin의 존재 이유)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_a = await _seed_connection(s, org_id, account_id="acct-a")
+            connection_b = await _seed_connection(s, org_id, account_id="acct-b")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            r_draft_a = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_a, text="A안"),
+            )
+            assert r_draft_a.status_code == 201, r_draft_a.text
+            draft_a_id = r_draft_a.json()["draft_id"]
+
+            r_submit_a = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_a_id}/submit", json={},
+            )
+            assert r_submit_a.status_code == 200, r_submit_a.text
+            gate_a_id = uuid.UUID(r_submit_a.json()["gate_id"])
+            await _approve_gate_directly(s, gate_a_id)
+
+            r_draft_b = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_b, text="B안"),
+            )
+            assert r_draft_b.status_code == 201, r_draft_b.text
+            draft_b_id = r_draft_b.json()["draft_id"]
+
+            r_submit_b = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_b_id}/submit", json={},
+            )
+            assert r_submit_b.status_code == 409, r_submit_b.text
+            body = r_submit_b.json()["error"]
+            assert body["code"] == "CHANNEL_POST_GATE_ALREADY_HELD"
+            assert body["holding_draft_id"] == draft_a_id
+            assert body["holding_channel"] == "threads"
+            assert body["holding_connection_id"] == str(connection_a)
+
+        async with Session() as s:
+            assert await _get_gate_status(s, gate_a_id) == "approved", (
+                "draft B의 상신 시도가 draft A의 승인을 pending으로 되돌렸다 — 가드가 안 걸린 것"
+            )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_draft_resubmit_still_allowed_no_regression():
+    """AC3(회귀 없음) — 같은 draft를 다시 상신(예: 재승인 요청)하는 것은 그대로 허용된다
+    (자기 자신은 "다른 초안"이 아니다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id),
+            )
+            assert r_draft.status_code == 201, r_draft.text
+            draft_id = r_draft.json()["draft_id"]
+
+            r_submit_1 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+            )
+            assert r_submit_1.status_code == 200, r_submit_1.text
+
+            # 재상신(같은 버전, no-op) — 여전히 200이어야 한다.
+            r_submit_2 = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+            )
+            assert r_submit_2.status_code == 200, r_submit_2.text
+            assert r_submit_2.json()["gate_id"] == r_submit_1.json()["gate_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_creating_non_holding_draft_does_not_reopen_or_reseal_other_gate():
+    """⭐발견 즉시 수정 회귀가드 — draft A 승인 뒤, draft B(다른 연결)를 그냥 '생성'만
+    해도(상신 없이) `_reseal_gate_on_new_version` 훅이 work_item_id만으로 A의 게이트를
+    찾아 조용히 reopen/재봉인하던 경로(디디가 실제로 재현한 그 버그, submit() 가드보다
+    앞선 시점)를 막는다. B 생성 후 A 게이트는 완전 불변이어야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_a = await _seed_connection(s, org_id, account_id="acct-a")
+            connection_b = await _seed_connection(s, org_id, account_id="acct-b")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_a_id, gate_a_id = await _seed_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_a, story_id=story_id, text="A안",
+            )
+
+            r_draft_b = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_b, text="B안"),
+            )
+            assert r_draft_b.status_code == 201, r_draft_b.text
+
+        async with Session() as s:
+            assert await _get_gate_status(s, gate_a_id) == "approved", (
+                "draft B의 생성(상신도 아님)이 draft A의 승인을 pending으로 되돌렸다"
+            )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def _seed_submit_approve(client, session, *, org_id, connection_id, story_id, text):
+    r_draft = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+        json=_draft_body(work_item_id=story_id, connection_id=connection_id, text=text),
+    )
+    assert r_draft.status_code == 201, r_draft.text
+    draft_id = r_draft.json()["draft_id"]
+    r_submit = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={})
+    assert r_submit.status_code == 200, r_submit.text
+    gate_id = uuid.UUID(r_submit.json()["gate_id"])
+    await _approve_gate_directly(session, gate_id)
+    return draft_id, gate_id
+
+
+@pytest.mark.anyio
+async def test_legacy_gate_without_draft_id_in_neutral_facts_does_not_block():
+    """"모른다≠다르다" — neutral_facts에 draft_id가 없는(이 판정이 생기기 前에 만들어진)
+    레거시 게이트는 누가 쥐고 있는지 모르므로 차단하지 않는다. 레거시 상태는 정상 경로로
+    만든 뒤(draft A 상신 → neutral_facts.draft_id가 채워짐) 그 키만 직접 제거해 재현한다
+    (Gate 모델을 손으로 다시 짓지 않는다 — 실제 컬럼 스키마와 어긋날 위험)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_a = await _seed_connection(s, org_id, account_id="acct-a")
+            connection_b = await _seed_connection(s, org_id, account_id="acct-b")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_draft_a = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_a),
+            )
+            assert r_draft_a.status_code == 201, r_draft_a.text
+
+            r_submit_a = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{r_draft_a.json()['draft_id']}/submit",
+                json={},
+            )
+            assert r_submit_a.status_code == 200, r_submit_a.text
+            gate_id = uuid.UUID(r_submit_a.json()["gate_id"])
+
+        # 레거시 재현 — draft_id 키만 제거(그 외 필드는 정상 경로가 채운 그대로 유지).
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            gate.neutral_facts = {k: v for k, v in gate.neutral_facts.items() if k != "draft_id"}
+            await s.commit()
+
+        async with _client_for(app) as client:
+            r_draft_b = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_b),
+            )
+            assert r_draft_b.status_code == 201, r_draft_b.text
+
+            r_submit_b = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{r_draft_b.json()['draft_id']}/submit",
+                json={},
+            )
+            assert r_submit_b.status_code == 200, r_submit_b.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,6 @@
 {
   "_snapshot_policy": "story #3383(2026-09-03) — 로컬 재측정(템플릿 DB 적용 후). 로컬 절대시간은 CI의 ~1/6이지만(실측), 파일 간 상대 비중은 LPT 배분에 유효하다. 재측정 기준은 이전과 동일: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐.",
-  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard",
+  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3404-channel-post-gate-already-held",
   "measured_at": "2026-09-03",
   "files": [
     {
@@ -838,6 +838,10 @@
     {
       "file": "tests/test_f6d14476_gate_already_held.py",
       "sec": 23.0
+    },
+    {
+      "file": "tests/test_3404_channel_post_gate_already_held.py",
+      "sec": 6.0
     }
   ]
 }


### PR DESCRIPTION
## 요약

같은 work_item에 채널 포스트 초안이 둘(서로 다른 connection_id) 있으면 external_publish
게이트 슬롯이 work_item 단위라, 뒤늦은 초안의 활동이 앞서 승인된 게이트를 조용히 pending
으로 되돌릴 수 있었다 — site_posts.py가 story f6d14476(#3388)에서 이미 고친 것과 정확히
같은 결함 클래스가 `channel_posts.py`엔 그대로 남아 있었다(디디 코드 대조로 확認, 페드루
PO 지시로 이 PR로 이어 착수).

## 결함 지점 — 실제로는 둘

로컬 실PG로 직접 재현하며 확인 — **하나만 고치면 안 됐다**:

1. `submit_channel_post_draft` — draft A 상신·승인 뒤 draft B(다른 connection) 상신 →
   같은 게이트를 B의 내용으로 재봉인+pending 되돌림.
2. `_reseal_gate_on_new_version`(편집/생성 훅) — **submit()을 거치지 않고도** draft B를
   그냥 *생성*만 해도(그 자체가 버전 1 생성) 같은 훅이 work_item_id만으로 A의 게이트를
   찾아 조용히 reopen — 1번을 고치고도 이 경로가 남아 있어 재현 테스트가 여전히 빨강이었다
   (이 PR을 쓰는 동안 실제로 겪음). site_posts.py도 f6d14476에서 이 훅을 함께 고쳤었다.

## 설계 — 판정 로직 공유(페드루 PO 지시, "두 벌 금지")

「이 게이트를 다른 초안이 쥐고 있는가」 판정(neutral_facts.draft_id 대조 — pending/
approved만 대상, 값 없으면 "모른다≠다르다"로 막지 않음, 자기 자신 재상신은 항상 허용)은
두 도메인에 완전히 동일한 로직이라 `gate_service.py::resolve_gate_holder_draft_id`로
추출했다. **`site_posts.py`의 기존 인라인 판정(f6d14476)도 이 함수로 교체**했다(로직
변경 없음, 순수 추출 — 아래 회귀 테스트로 확인). 던지는 에러(`SitePostGateAlreadyHeldError`
/`ChannelPostGateAlreadyHeldError`)는 도메인마다 필드가 달라(lang/slug vs channel/
connection_id) 그대로 두 벌 — 그건 진짜 도메인 차이라 합치지 않았다.

## QA — 「두 연결×같은 work_item」 재현이 가드 없으면 실제로 빨강

Mutation self-check: `channel_posts.py`의 `resolve_gate_holder_draft_id` 호출(reseal
훅 쪽)을 지웠더니 `test_second_draft_submit_blocked_while_first_holds_approved_gate`·
`test_creating_non_holding_draft_does_not_reopen_or_reseal_other_gate` **정확히 2건만**
RED(나머지 2건은 green 유지), 원복 후 4건 전부 green.

로컬 실 Postgres(pg@16)로:
- 신규 `test_3404_channel_post_gate_already_held.py` 4건 — 두 연결 상신 차단·같은 draft
  재상신 회귀 없음·초안 생성만으로도 되돌리지 않음·레거시 게이트(draft_id 미기록)는
  "모른다≠다르다"로 안 막음.
- 기존 `test_f6d14476_gate_already_held.py`(site_posts) 6건 — 리팩터 후 전부 그대로 통과
  (로직 변경 없음 확인).
- `site_post`·`channel_post`·`gate_service` 관련 destructive_schema 테스트 전체 98건 —
  회귀 없음.

## 관련

- story f6d14476/#3388(선례, site_posts 원 처방) · story #3404(이 PR) · story #3374(채널
  포스트 초안/상신 API 원 스토리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm