### PR TITLE
[SID:3407] fix(oauth-channel): Meta 거부를 파라미터 누락으로 오진단하던 결함

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2094,6 +2094,7 @@
     "channelConnectErrorStateInvalid": "The connection request expired or is invalid — please try again.",
     "channelConnectErrorOwnerOnly": "Only owners can do this.",
     "channelConnectErrorSessionExpired": "Your session expired — please sign in again.",
+    "channelConnectErrorProviderDenied": "Permission was denied — please reconnect.",
     "appCredentialsTitle": "{channel} app credentials",
     "appCredentialsOrgActive": "Connecting with this organization's app · ID ends in {suffix}",
     "appCredentialsPlatformActive": "Connecting with Sprintable's shared app (default)",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2095,6 +2095,7 @@
     "channelConnectErrorOwnerOnly": "Only owners can do this.",
     "channelConnectErrorSessionExpired": "Your session expired — please sign in again.",
     "channelConnectErrorProviderDenied": "Permission was denied — please reconnect.",
+    "channelConnectErrorProviderError": "The channel provider had an error — please try reconnecting shortly.",
     "appCredentialsTitle": "{channel} app credentials",
     "appCredentialsOrgActive": "Connecting with this organization's app · ID ends in {suffix}",
     "appCredentialsPlatformActive": "Connecting with Sprintable's shared app (default)",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2095,6 +2095,7 @@
     "channelConnectErrorOwnerOnly": "이 작업은 owner만 할 수 있습니다.",
     "channelConnectErrorSessionExpired": "세션이 만료되었습니다 — 다시 로그인해 주세요.",
     "channelConnectErrorProviderDenied": "권한 승인이 취소되었습니다 — 다시 연결해 주세요.",
+    "channelConnectErrorProviderError": "채널 제공자 쪽 오류입니다 — 잠시 후 다시 연결해 주세요.",
     "appCredentialsTitle": "{channel} 앱 자격",
     "appCredentialsOrgActive": "이 조직의 앱으로 연결합니다 · 앱 ID 끝 4자리 {suffix}",
     "appCredentialsPlatformActive": "Sprintable 공용 앱으로 연결합니다(기본)",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2094,6 +2094,7 @@
     "channelConnectErrorStateInvalid": "연결 요청이 만료되었거나 유효하지 않습니다 — 다시 시도해 주세요.",
     "channelConnectErrorOwnerOnly": "이 작업은 owner만 할 수 있습니다.",
     "channelConnectErrorSessionExpired": "세션이 만료되었습니다 — 다시 로그인해 주세요.",
+    "channelConnectErrorProviderDenied": "권한 승인이 취소되었습니다 — 다시 연결해 주세요.",
     "appCredentialsTitle": "{channel} 앱 자격",
     "appCredentialsOrgActive": "이 조직의 앱으로 연결합니다 · 앱 ID 끝 4자리 {suffix}",
     "appCredentialsPlatformActive": "Sprintable 공용 앱으로 연결합니다(기본)",

--- a/apps/web/src/app/api/oauth-channel/callback/[channel]/route.test.ts
+++ b/apps/web/src/app/api/oauth-channel/callback/[channel]/route.test.ts
@@ -47,6 +47,14 @@ describe('GET /api/oauth-channel/callback/[channel] (story #3376)', () => {
     expect(res.headers.get('location')).not.toContain('user_denied');
   });
 
+  it('⭐story #3407 페드루 리뷰 — error=server_error(제공자 오류)는 거부가 아니라 OAUTH_PROVIDER_ERROR로 가른다', async () => {
+    stubCookies();
+    const res = await GET(makeRequest({ error: 'server_error', state: 's' }), routeParams());
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(res.headers.get('location')).toContain('connect_error=OAUTH_PROVIDER_ERROR');
+    expect(res.headers.get('location')).not.toContain('server_error');
+  });
+
   it('code·state·org_id 쿠키 중 org_id가 없으면 BE를 부르지 않고 에러 리다이렉트', async () => {
     h.cookiesGetMock.mockReturnValue(undefined); // oauth_channel_org_threads 없음
     const res = await GET(makeRequest({ code: 'c', state: 's' }), routeParams());

--- a/apps/web/src/app/api/oauth-channel/callback/[channel]/route.test.ts
+++ b/apps/web/src/app/api/oauth-channel/callback/[channel]/route.test.ts
@@ -38,6 +38,15 @@ describe('GET /api/oauth-channel/callback/[channel] (story #3376)', () => {
     h.cookiesGetMock.mockImplementation((name: string) => (name in defaults ? { value: defaults[name] } : undefined));
   }
 
+  it('⭐story #3407 — error 파라미터(Meta 거부)가 있으면 code/state 유무와 무관하게 즉시 OAUTH_PROVIDER_DENIED로, BE는 안 부른다', async () => {
+    stubCookies();
+    const res = await GET(makeRequest({ error: 'access_denied', error_reason: 'user_denied', state: 's' }), routeParams());
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(res.headers.get('location')).toContain('connect_error=OAUTH_PROVIDER_DENIED');
+    expect(res.headers.get('location')).not.toContain('access_denied');
+    expect(res.headers.get('location')).not.toContain('user_denied');
+  });
+
   it('code·state·org_id 쿠키 중 org_id가 없으면 BE를 부르지 않고 에러 리다이렉트', async () => {
     h.cookiesGetMock.mockReturnValue(undefined); // oauth_channel_org_threads 없음
     const res = await GET(makeRequest({ code: 'c', state: 's' }), routeParams());

--- a/apps/web/src/app/api/oauth-channel/callback/[channel]/route.ts
+++ b/apps/web/src/app/api/oauth-channel/callback/[channel]/route.ts
@@ -23,6 +23,22 @@ export async function GET(request: Request, { params }: RouteParams) {
   const orgId = cookieStore.get(`oauth_channel_org_${channel}`)?.value;
   cookieStore.delete(`oauth_channel_org_${channel}`);
 
+  // story #3407 — Meta가 사용자 거부 시 code 없이 `?error=access_denied&state=...`로
+  // 돌려준다. 아래 code/state/orgId 체크보다 먼저 봐야 한다 — 안 그러면 "파라미터
+  // 누락"(OAUTH_MISSING_PARAMS, 일반 실패 문구)으로 오진단돼, 사용자가 명시적으로 거부한
+  // 것이 마치 시스템 오류처럼 보인다(페드루 PO 라이브 실측). error_description/
+  // error_reason은 서버 로그에만 — URL 쿼리에는 Meta 원문을 절대 안 싣는다.
+  const providerError = searchParams.get('error');
+  if (providerError) {
+    console.error('[oauth-channel/callback] provider denied', {
+      channel,
+      error: providerError,
+      error_description: searchParams.get('error_description'),
+      error_reason: searchParams.get('error_reason'),
+    });
+    return NextResponse.redirect(`${origin}/organization/channels?connect_error=OAUTH_PROVIDER_DENIED`);
+  }
+
   if (!code || !state || !orgId) {
     return NextResponse.redirect(`${origin}/organization/channels?connect_error=OAUTH_MISSING_PARAMS`);
   }

--- a/apps/web/src/app/api/oauth-channel/callback/[channel]/route.ts
+++ b/apps/web/src/app/api/oauth-channel/callback/[channel]/route.ts
@@ -28,15 +28,23 @@ export async function GET(request: Request, { params }: RouteParams) {
   // 누락"(OAUTH_MISSING_PARAMS, 일반 실패 문구)으로 오진단돼, 사용자가 명시적으로 거부한
   // 것이 마치 시스템 오류처럼 보인다(페드루 PO 라이브 실측). error_description/
   // error_reason은 서버 로그에만 — URL 쿼리에는 Meta 원문을 절대 안 싣는다.
+  //
+  // 페드루 리뷰 후속 — Meta는 같은 `error` 파라미터로 access_denied(사용자 거부) 외에
+  // server_error·temporarily_unavailable류(제공자 쪽 오류)도 보낸다. 전부 "거부"로
+  // 뭉치면 그 자체가 또 다른 오진단이라, access_denied/user_denied만 OAUTH_PROVIDER_DENIED,
+  // 나머지는 OAUTH_PROVIDER_ERROR로 가른다.
   const providerError = searchParams.get('error');
   if (providerError) {
-    console.error('[oauth-channel/callback] provider denied', {
+    const errorReason = searchParams.get('error_reason');
+    console.error('[oauth-channel/callback] provider error', {
       channel,
       error: providerError,
       error_description: searchParams.get('error_description'),
-      error_reason: searchParams.get('error_reason'),
+      error_reason: errorReason,
     });
-    return NextResponse.redirect(`${origin}/organization/channels?connect_error=OAUTH_PROVIDER_DENIED`);
+    const isUserDenied = providerError === 'access_denied' || errorReason === 'user_denied';
+    const connectError = isUserDenied ? 'OAUTH_PROVIDER_DENIED' : 'OAUTH_PROVIDER_ERROR';
+    return NextResponse.redirect(`${origin}/organization/channels?connect_error=${connectError}`);
   }
 
   if (!code || !state || !orgId) {

--- a/apps/web/src/components/channel-connect/connect-error.ts
+++ b/apps/web/src/components/channel-connect/connect-error.ts
@@ -6,9 +6,14 @@ const KNOWN_CONNECT_ERROR_KEYS: Record<string, string> = {
   CHANNEL_OAUTH_STATE_INVALID: 'channelConnectErrorStateInvalid',
   CHANNEL_CONNECTION_OWNER_ONLY: 'channelConnectErrorOwnerOnly',
   OAUTH_MISSING_PARAMS: 'channelConnectErrorGeneric',
-  // story #3407 — 사용자가 Meta 권한 화면에서 명시적으로 거부(error=access_denied 등)한
-  // 경우 전용 문구. OAUTH_MISSING_PARAMS(일반 실패)로 오진단되던 자리를 분리한다.
+  // story #3407 — 사용자가 Meta 권한 화면에서 명시적으로 거부(error=access_denied,
+  // error_reason=user_denied)한 경우 전용 문구. OAUTH_MISSING_PARAMS(일반 실패)로
+  // 오진단되던 자리를 분리한다.
   OAUTH_PROVIDER_DENIED: 'channelConnectErrorProviderDenied',
+  // story #3407 페드루 리뷰 — Meta가 같은 `error` 파라미터로 server_error·
+  // temporarily_unavailable류도 보낸다. 그건 "사용자 거부"가 아니라 제공자 쪽 오류라
+  // OAUTH_PROVIDER_DENIED로 뭉치면 그 자체가 또 다른 오진단이 된다 — 별도 코드로 가른다.
+  OAUTH_PROVIDER_ERROR: 'channelConnectErrorProviderError',
   SESSION_EXPIRED: 'channelConnectErrorSessionExpired',
   INVALID_REQUEST: 'channelConnectErrorGeneric',
   CHANNEL_AUTHORIZE_FAILED: 'channelConnectErrorGeneric',

--- a/apps/web/src/components/channel-connect/connect-error.ts
+++ b/apps/web/src/components/channel-connect/connect-error.ts
@@ -6,6 +6,9 @@ const KNOWN_CONNECT_ERROR_KEYS: Record<string, string> = {
   CHANNEL_OAUTH_STATE_INVALID: 'channelConnectErrorStateInvalid',
   CHANNEL_CONNECTION_OWNER_ONLY: 'channelConnectErrorOwnerOnly',
   OAUTH_MISSING_PARAMS: 'channelConnectErrorGeneric',
+  // story #3407 — 사용자가 Meta 권한 화면에서 명시적으로 거부(error=access_denied 등)한
+  // 경우 전용 문구. OAUTH_MISSING_PARAMS(일반 실패)로 오진단되던 자리를 분리한다.
+  OAUTH_PROVIDER_DENIED: 'channelConnectErrorProviderDenied',
   SESSION_EXPIRED: 'channelConnectErrorSessionExpired',
   INVALID_REQUEST: 'channelConnectErrorGeneric',
   CHANNEL_AUTHORIZE_FAILED: 'channelConnectErrorGeneric',


### PR DESCRIPTION
[SID:3407]

## 배경
페드루 PO가 dev 라이브에서 실측(307 확인): Meta가 사용자의 명시적 권한 거부 시 `code` 없이 `?error=access_denied&state=...`로 콜백을 리다이렉트하는데, 콜백 라우트(`apps/web/src/app/api/oauth-channel/callback/[channel]/route.ts`)가 `error` 파라미터를 전혀 보지 않고 `code`/`state`/`orgId` 존재 체크만 하고 있어 `connect_error=OAUTH_MISSING_PARAMS`(일반 실패 문구)로 떨어졌다. 사용자가 명시적으로 거부한 상황이 시스템 오류처럼 보이는 오진단.

## 변경
- `route.ts`: `error` 파라미터를 기존 `code`/`state`/`orgId` 체크보다 **먼저** 분기 — 있으면 BE 호출 없이 즉시 `connect_error=OAUTH_PROVIDER_DENIED`로 리다이렉트. `error_description`/`error_reason`은 서버 로그(`console.error`)에만 남기고, URL 쿼리에는 Meta 원문을 절대 싣지 않는다(개인정보/보안 제약).
- `connect-error.ts`: `OAUTH_PROVIDER_DENIED` → `channelConnectErrorProviderDenied` 매핑 추가.
- `messages/ko.json` / `messages/en.json`: 라벨 1행씩 추가.
- `route.test.ts`: 신규 케이스 1건 — error 파라미터 존재 시 BE 미호출 + `OAUTH_PROVIDER_DENIED`로 리다이렉트 + URL에 Meta 원문 미노출 검증.

**BE 변경 0건.** FE 전용 — 유나군 디자인 verdict 대상.

## 검증
- 타겟 파일: 6/6 pass
- 관련 스위트(`oauth-channel/` + `channel-connect/`, 3개 파일): 28/28 pass
- ko/en JSON 유효성 확인(`json.load`)
- mutation self-check: `if (providerError)` 분기를 `if (false && providerError)`로 무력화 → 신규 테스트만 정확히 RED(`OAUTH_MISSING_PARAMS`로 떨어짐), 원복 후 byte-identical 확인 + 전부 green 재확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm