### PR TITLE
[SID:3414] feat: 발행 명령·예약 스케줄러 — publication_commands 원장+cron 워커

### DIFF
--- a/backend/alembic/versions/0317_gate_sealed_scheduled_at.py
+++ b/backend/alembic/versions/0317_gate_sealed_scheduled_at.py
@@ -1,0 +1,32 @@
+"""story #3414(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04) — Gate.sealed_scheduled_at.
+
+블루프린트 v3 §3 원문 재독(정정 2): external_publish 게이트가 봉인하는 것은 본문
+해시뿐 아니라 "예약 시각"도 포함한다("목적지·불변 버전·예약 시각·예산을 참조 — 승인 후
+변경 시 무효화"). site_posts 등 다른 gate_type은 예약 개념이 없어 이 컬럼을 영원히
+null로 둔다 — 기존 sealed_content_version/sha256/body와 같은 공유-nullable 관례
+그대로(신규 테이블을 안 판다, gate 하나가 이미 이 "봉인" 역할을 도맡고 있음).
+
+Revision ID: 0317
+Revises: 0316
+Create Date: 2026-09-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0317"
+down_revision = "0316"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "gate",
+        sa.Column("sealed_scheduled_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("gate", "sealed_scheduled_at")

--- a/backend/alembic/versions/0318_publication_commands.py
+++ b/backend/alembic/versions/0318_publication_commands.py
@@ -1,0 +1,69 @@
+"""story #3414(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04) — publication_commands.
+
+발행 명령 원장. 블루프린트 v3 §3 멱등키(org_id+destination+approved_version+
+operation) 그대로 UNIQUE. 휴먼의 발행/예약 요청(POST .../publish)이 이 행을
+만든다(승인 자체는 트리거가 아니다 — "승인 없는 명령이 없다"일 뿐, PO 確定 (B)
+2026-09-04). gate_id는 FK 없음(channel_connections·channel_post_drafts와 동일
+관례) — 승인 뒤 편집 시 이 gate에 걸린 pending 명령을 voided로 무효화하는
+조회(void_pending_commands_for_gate)의 유일한 키.
+
+failure_kind/dead_letter_at은 유나 T9 계약(화면이 실패를 조립하지 않게 서버가
+값으로 준다) — 이 PR은 저장까지, 목록/단건 노출은 후속 story #3415.
+
+Revision ID: 0318
+Revises: 0317
+Create Date: 2026-09-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0318"
+down_revision = "0317"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "publication_commands",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("gate_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("destination", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("approved_version", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("operation", sa.Text(), nullable=False, server_default="publish"),
+        sa.Column("scheduled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False, server_default="pending"),
+        sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("reason_code", sa.Text(), nullable=True),
+        sa.Column("failure_kind", sa.Text(), nullable=True),
+        sa.Column("dead_letter_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("requested_by_member_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "org_id", "destination", "approved_version", "operation",
+            name="uq_publication_commands_idempotency",
+        ),
+    )
+    op.create_index("ix_publication_commands_org_id", "publication_commands", ["org_id"])
+    op.create_index("ix_publication_commands_gate_id", "publication_commands", ["gate_id"])
+    # cron 워커 클레임 쿼리(status='pending' AND scheduled_at<=now())의 인덱스 축.
+    op.create_index(
+        "ix_publication_commands_status_scheduled_at",
+        "publication_commands", ["status", "scheduled_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_publication_commands_status_scheduled_at", table_name="publication_commands")
+    op.drop_index("ix_publication_commands_gate_id", table_name="publication_commands")
+    op.drop_index("ix_publication_commands_org_id", table_name="publication_commands")
+    op.drop_table("publication_commands")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -139,6 +139,7 @@ from app.models.site_post_version import SitePostVersion
 from app.models.channel_post_draft import ChannelPostDraft
 from app.models.channel_post_version import ChannelPostVersion
 from app.models.channel_publication import ChannelPublication
+from app.models.publication_command import PublicationCommand
 
 __all__ = [
     "RoleTemplate",

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -126,6 +126,11 @@ class Gate(Base):
     sealed_content_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
     sealed_content_sha256: Mapped[str | None] = mapped_column(Text, nullable=True)
     sealed_content_body: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story #3414(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 정정2) — external_publish
+    # 전용 두 번째 봉인 축(위 sealed_content_*와 같은 관례, 공유-nullable — 예약 개념이
+    # 없는 다른 gate_type은 항상 null). "승인 후 예약 시각 변경=재승인"(블루프린트 §3)의
+    # 비교 기준값. site_posts 등은 이 컬럼을 절대 안 씀.
+    sealed_scheduled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # 승인 후 수정으로 시스템이 되돌린 pending인지(사람이 처음 상신한 pending과 구분 — S4가
     # "재승인 필요" 배지를 그릴 신호) — 새 명시 submit()이 재봉인하면 False로 복귀한다.
     reapproval_required: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))

--- a/backend/app/models/publication_command.py
+++ b/backend/app/models/publication_command.py
@@ -1,0 +1,62 @@
+"""story #3414(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04) — 발행 명령 원장.
+
+블루프린트 v3 §3 그대로: 휴먼의 발행/예약 요청(POST .../publish)이 이 행을
+만든다(PO 確定 (B) — 승인 자체는 트리거가 아니다, "승인 없는 명령이 없다"일
+뿐). `UNIQUE(org_id, destination, approved_version, operation)` — 블루프린트
+멱등키. `scheduled_at`은 요청 시점 gate.sealed_scheduled_at을 그대로 옮긴
+값(null=즉시) — command 자체는 그 뒤 gate가 재봉인돼도 안 따라간다(불변,
+`approved_version` 고정과 같은 사상 — "그 순간 승인된 것"의 스냅샷).
+
+`gate_id`는 FK 없음(channel_connections·channel_post_drafts와 동일 관례,
+그라운딩 §9) — 승인 뒤 편집으로 이 gate가 pending 복귀할 때 이 gate에 걸린
+pending 명령을 voided로 무효화하는 조회(`void_pending_commands_for_gate`)의
+유일한 키.
+
+`failure_kind`는 유나 design §11-5 정본 3값(`connection`/`needs_check`/
+`transient`) — 화면이 실패를 조립하지 않도록 서버가 값으로 낸다. 매핑을 모르는
+error_code는 `needs_check`로 fail-closed(임의로 transient=재시도 가능이라
+단정하지 않는다)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class PublicationCommand(Base):
+    __tablename__ = "publication_commands"
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id", "destination", "approved_version", "operation",
+            name="uq_publication_commands_idempotency",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    gate_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    destination: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    approved_version: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    operation: Mapped[str] = mapped_column(Text, nullable=False, server_default="publish")
+    scheduled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # 'pending'|'in_progress'|'completed'|'failed'|'dead_letter'|'voided'|'blocked'
+    # (blocked=connection 복구 대기, PO 정정2 추가② — 일반 재시도 큐 밖).
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="pending")
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    next_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # voided 전이 사유('CONTENT_CHANGED'|'SCHEDULE_CHANGED') — PO 確定3.
+    reason_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # 'connection'|'needs_check'|'transient' — 유나 design §11-5.
+    failure_kind: Mapped[str | None] = mapped_column(Text, nullable=True)
+    dead_letter_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    requested_by_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False,
+    )

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -125,6 +125,25 @@ class SubmitChannelPostDraftRequest(BaseModel):
     # v3 §3). 생략/null=즉시. 승인 뒤 이 값만 바꿔도(본문은 그대로) 재승인이 필요하다 —
     # submit_channel_post_draft가 그 판정을 한다(신규 엔드포인트 없음).
     scheduled_at: datetime | None = None
+
+    @field_validator("scheduled_at")
+    @classmethod
+    def _scheduled_at_must_be_tz_aware_future(cls, v: datetime | None) -> datetime | None:
+        """페드루 리뷰 nit J — naive datetime을 그대로 받으면
+        `submit_channel_post_draft`의 `existing.sealed_scheduled_at != scheduled_at`
+        비교가 aware(기존 봉인값)와 naive(이번 요청) 사이에서 값이 실제로 같아도 항상
+        "다르다"로 나온다(Python은 naive/aware `!=` 비교를 예외 없이 그냥 다르다고
+        본다 — 순서 비교(`<`)만 TypeError) → 헛 재승인·대기 명령 誤void. 422로 앞단에서
+        막는다. 과거 시각도 거부(예약이 즉시 도래해 버려 "예약"이라는 사용자 의도와
+        어긋난다 — cron이 자가치유로 집기야 하겠지만 애초에 요청을 받지 않는 편이
+        정직하다)."""
+        if v is None:
+            return v
+        if v.tzinfo is None:
+            raise ValueError("scheduled_at은 timezone 정보가 있어야 합니다(예: Z 또는 +09:00)")
+        if v <= datetime.now(timezone.utc):
+            raise ValueError("scheduled_at은 현재 시각 이후여야 합니다")
+        return v
 
 
 class SubmitChannelPostDraftResponse(BaseModel):
@@ -376,10 +395,19 @@ async def publish_channel_post_draft_endpoint(
     반환 — 실제 발행은 cron 워커(AC3)가 그 시각에 처리한다.
 
     두 경로 다 `publication_command`를 감사·재시도 원장으로 upsert한다(멱등 —
-    같은 draft/version 재요청은 새 행을 안 만든다). command upsert가 **3중
-    재검증(게이트approved·seal일치·connection활성) 뒤**에 오도록 순서를 지킨다
-    (카디르 QA⑥) — 재검증 실패로 요청이 거부되면 command 행 자체가 안 생긴다(고아
-    pending 행이 남아 워커가 엉뚱하게 재시도하는 것을 원천 차단)."""
+    같은 draft/version 재요청은 새 행을 안 만든다).
+
+    페드루 리뷰 F(제품 의미 확定) — command upsert는 **3중 재검증 앞이 아니라**
+    `resolve_command_target`의 게이트-승인 확인 **뒤**에 온다(카디르 QA⑥, 재검증
+    실패로 요청 자체가 거부되면 command 행이 안 생겨 고아 pending을 막는다). 다만
+    나머지 두 재검증(seal 일치·connection 활성)은 `publish_channel_post_draft` 호출
+    **안에서** 일어난다 — 즉 command가 이미 만들어진 뒤에 그 두 검증이 실패할 수
+    있다는 뜻이고, 그러면 이 command는 (고아가 아니라) "사람이 실제로 요청한
+    명령"으로 pending에 남는다. 그 실패가 결정적(needs_check — 예:
+    SITE_POST_REAPPROVAL_REQUIRED류)이면 즉시 dead_letter로 멈추고(자동 재시도
+    없음), 일시적(transient/quota)이면 백오프 재시도, connection이면 blocked로
+    넘어간다 — 사람이 모르게 방치되지 않도록 실패 응답 body에 `command_status`·
+    `next_attempt_at`을 함께 낸다(화면 문구는 후속)."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
@@ -419,6 +447,17 @@ async def publish_channel_post_draft_endpoint(
     await db.commit()
     now = datetime.now(timezone.utc)
 
+    def _with_command_state(detail: dict) -> dict:
+        # 페드루 리뷰 F(제품 의미 확定) — 즉시 발행 실패로 command가 pending(자동
+        # 재시도 대기)/dead_letter(재시도 없음)/blocked(연결 복구 대기)/voided로 남을
+        # 수 있다. 사람이 요청한 명령이 사람 모르게 방치되지 않도록 실패 응답에 그
+        # 상태와 다음 자동 재시도 시각을 함께 낸다(화면 문구는 후속 스토리).
+        return {
+            **detail,
+            "command_status": command.status,
+            "next_attempt_at": command.next_attempt_at.isoformat() if command.next_attempt_at else None,
+        }
+
     try:
         row = await publish_channel_post_draft(
             db, org_id=org_id, draft_id=draft_id, published_by_member_id=resolved.id,
@@ -428,7 +467,10 @@ async def publish_channel_post_draft_endpoint(
             db, command, error_code="CHANNEL_POST_DRAFT_NOT_FOUND", last_error=str(exc), now=now,
         )
         await db.commit()
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=404,
+            detail=_with_command_state({"code": "CHANNEL_POST_DRAFT_NOT_FOUND", "message": str(exc)}),
+        ) from exc
     except ExternalPublishGateNotApprovedError as exc:
         await apply_command_failure(
             db, command, error_code="EXTERNAL_PUBLISH_APPROVAL_REQUIRED", last_error=str(exc), now=now,
@@ -436,7 +478,7 @@ async def publish_channel_post_draft_endpoint(
         await db.commit()
         raise HTTPException(
             status_code=403,
-            detail={"code": "EXTERNAL_PUBLISH_APPROVAL_REQUIRED", "message": str(exc)},
+            detail=_with_command_state({"code": "EXTERNAL_PUBLISH_APPROVAL_REQUIRED", "message": str(exc)}),
         ) from exc
     except ChannelTextTooLongError as exc:
         # 페드루 PO 확定(2026-09-03) — 발행 시점 재검사(UTM 태그된 링크가 붙은 실제 전송
@@ -448,10 +490,10 @@ async def publish_channel_post_draft_endpoint(
         await db.commit()
         raise HTTPException(
             status_code=422,
-            detail={
+            detail=_with_command_state({
                 "code": "CHANNEL_TEXT_TOO_LONG", "message": str(exc),
                 "max_length": exc.max_length, "current_length": exc.current_length,
-            },
+            }),
         ) from exc
     except ChannelPostSealMissingError as exc:
         await apply_command_failure(
@@ -459,7 +501,8 @@ async def publish_channel_post_draft_endpoint(
         )
         await db.commit()
         raise HTTPException(
-            status_code=409, detail={"code": "SITE_POST_SEAL_MISSING", "message": str(exc)},
+            status_code=409,
+            detail=_with_command_state({"code": "SITE_POST_SEAL_MISSING", "message": str(exc)}),
         ) from exc
     except ChannelPostReapprovalRequiredError as exc:
         # story #3414 — 추가② 훅이 대개 이 상황 전에 command를 이미 voided로 무효화해
@@ -470,7 +513,7 @@ async def publish_channel_post_draft_endpoint(
         await db.commit()
         raise HTTPException(
             status_code=409,
-            detail={"code": "SITE_POST_REAPPROVAL_REQUIRED", "message": str(exc)},
+            detail=_with_command_state({"code": "SITE_POST_REAPPROVAL_REQUIRED", "message": str(exc)}),
         ) from exc
     except ChannelConnectionNotActiveError as exc:
         await apply_command_failure(
@@ -479,7 +522,7 @@ async def publish_channel_post_draft_endpoint(
         await db.commit()
         raise HTTPException(
             status_code=409,
-            detail={"code": "CHANNEL_CONNECTION_NOT_ACTIVE", "message": str(exc)},
+            detail=_with_command_state({"code": "CHANNEL_CONNECTION_NOT_ACTIVE", "message": str(exc)}),
         ) from exc
     except ChannelTokenExpiredError as exc:
         await apply_command_failure(
@@ -488,7 +531,7 @@ async def publish_channel_post_draft_endpoint(
         await db.commit()
         raise HTTPException(
             status_code=409,
-            detail={"code": "CHANNEL_TOKEN_EXPIRED", "message": str(exc)},
+            detail=_with_command_state({"code": "CHANNEL_TOKEN_EXPIRED", "message": str(exc)}),
         ) from exc
     except ChannelRateLimitedError as exc:
         retry_after_seconds = max(0, int((exc.reset_at - now).total_seconds()))
@@ -499,7 +542,13 @@ async def publish_channel_post_draft_endpoint(
         await db.commit()
         raise HTTPException(
             status_code=429,
-            detail={"code": "CHANNEL_RATE_LIMITED", "message": str(exc), "reset_at": exc.reset_at.isoformat()},
+            detail=_with_command_state({
+                "code": "CHANNEL_RATE_LIMITED", "message": str(exc), "reset_at": exc.reset_at.isoformat(),
+            }),
+            # 페드루 리뷰 블로커E — Retry-After 헤더가 빠져 있었다(main.py의 헤더
+            # 처리기는 slowapi 429 경로만 커버, 이 429는 그 경로가 아니다). 실값
+            # (retry_after_seconds)은 바로 위에서 이미 계산했다 — 그대로 싣는다.
+            headers={"Retry-After": str(retry_after_seconds)},
         ) from exc
     except ChannelPublishProviderError as exc:
         await apply_command_failure(
@@ -508,17 +557,20 @@ async def publish_channel_post_draft_endpoint(
         await db.commit()
         raise HTTPException(
             status_code=502,
-            detail={"code": "CHANNEL_PUBLISH_PROVIDER_ERROR", "message": str(exc)},
+            detail=_with_command_state({"code": "CHANNEL_PUBLISH_PROVIDER_ERROR", "message": str(exc)}),
         ) from exc
     except ChannelPublishInProgressError as exc:
         # story #3395 — 같은 (gate_id, version_id) 동시 요청 경합에서 진 쪽이 이긴 쪽의
         # 완료를 기다렸는데도 못 끝났다(약 3초). 거짓 200도 무단 500도 아닌 정직한
         # "잠시 후 다시" — 클라이언트 재시도는 그때 남은 container_created 행으로 기존
-        # 부분성공 재시도 경로를 그대로 탄다. command는 아직 in_progress로 남겨둔다
-        # (실패로 단정 안 함 — 이긴 쪽이 곧 끝낼 것이므로).
+        # 부분성공 재시도 경로를 그대로 탄다. 페드루 리뷰 nit I — command는 여기서
+        # 손대지 않는다(apply_command_failure를 안 부른다) — 생성 시점 그대로
+        # `pending`이다("in_progress로 남긴다"던 원래 주석이 틀렸다 — in_progress는
+        # 워커·이 함수의 성공 직전에만 대입되는 값이지 여기선 대입한 적이 없다). 다음
+        # 요청(재시도)이 같은 멱등키로 이 pending command를 그대로 재사용한다.
         raise HTTPException(
             status_code=409,
-            detail={"code": "CHANNEL_PUBLISH_IN_PROGRESS", "message": str(exc)},
+            detail=_with_command_state({"code": "CHANNEL_PUBLISH_IN_PROGRESS", "message": str(exc)}),
         ) from exc
 
     command.status = "completed"
@@ -550,8 +602,10 @@ async def retry_publication_command_endpoint(
     auth: AuthContext = Depends(get_current_user),
 ) -> RetryPublicationCommandResponse:
     """story #3414 AC5 — 휴먼 전용(발행 자체가 human-only인 것과 동형). `dead_letter`
-    상태인 command만 다시 큐(`pending`)에 올린다 — 다른 상태(completed·voided·blocked
-    등)는 404로 존재 비노출(카디르 QA와 동형 관례, 상태를 굳이 구별해 알려주지 않는다).
+    **또는 `blocked`**(연결 복구 대기 — 페드루 리뷰 블로커B: 원래 dead_letter만
+    받아 owner 재인증 뒤 blocked 예약 명령이 갈 길이 없었다) 상태인 command만 다시
+    큐(`pending`)에 올린다 — 그 외 상태(completed·voided 등)는 404로 존재 비노출
+    (카디르 QA와 동형 관례, 상태를 굳이 구별해 알려주지 않는다).
     `next_attempt_at`을 null로 되돌려야 다음 cron tick이 이 행을 실제로 다시 집는다
     (status만 바뀌고 next_attempt_at이 미래에 멈춰 있으면 WHERE절에서 계속 빠지는
     결함 — 카디르 QA⑤ 지적 그대로 반영)."""

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -3,6 +3,7 @@ API. `app/routers/site_posts.py`(story #3365) 형태를 그대로 미러 — 새
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -120,6 +121,10 @@ class ChannelPostVersionHistoryItem(BaseModel):
 
 class SubmitChannelPostDraftRequest(BaseModel):
     version_id: uuid.UUID | None = None
+    # story #3414(PO 確定, 2026-09-04) — 예약 발행 시각도 게이트 봉인 범위(블루프린트
+    # v3 §3). 생략/null=즉시. 승인 뒤 이 값만 바꿔도(본문은 그대로) 재승인이 필요하다 —
+    # submit_channel_post_draft가 그 판정을 한다(신규 엔드포인트 없음).
+    scheduled_at: datetime | None = None
 
 
 class SubmitChannelPostDraftResponse(BaseModel):
@@ -127,6 +132,7 @@ class SubmitChannelPostDraftResponse(BaseModel):
     version_id: uuid.UUID
     content_sha256: str
     status: str
+    scheduled_at: str | None = None
 
 
 @router.post(
@@ -301,7 +307,7 @@ async def submit_channel_post_draft_endpoint(
     try:
         gate, version_id = await submit_channel_post_draft(
             db, org_id=org_id, draft_id=draft_id, version_id=body.version_id,
-            requester_member_id=uuid.UUID(auth.user_id),
+            requester_member_id=uuid.UUID(auth.user_id), scheduled_at=body.scheduled_at,
         )
     except ChannelPostDraftNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -336,14 +342,21 @@ async def submit_channel_post_draft_endpoint(
     return SubmitChannelPostDraftResponse(
         gate_id=gate.id, version_id=version_id, content_sha256=gate.sealed_content_sha256,
         status=gate.status,
+        scheduled_at=gate.sealed_scheduled_at.isoformat() if gate.sealed_scheduled_at else None,
     )
 
 
 class PublishChannelPostResponse(BaseModel):
-    permalink: str | None
-    external_id: str | None
-    published_at: str
+    permalink: str | None = None
+    external_id: str | None = None
+    published_at: str | None = None
     version_id: uuid.UUID
+    # story #3414 — 예약(scheduled_at 봉인됨)이면 이 요청은 command만 만들고 실제
+    # 발행은 워커가 나중에 한다. 기존 필드(permalink 등)는 즉시 경로에서만 채워진다
+    # (회귀 0 — 기존 FE는 이 셋을 그대로 읽는다, scheduled 필드는 새로 봐야 안다).
+    scheduled: bool = False
+    command_id: uuid.UUID | None = None
+    scheduled_at: str | None = None
 
 
 @router.post(
@@ -356,21 +369,71 @@ async def publish_channel_post_draft_endpoint(
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> PublishChannelPostResponse:
-    """story #f8f7cb0f — 휴먼 전용(AC1). 발행 직전 게이트 approved·봉인 일치·connection
-    active 셋을 재검증(fail-closed)한 뒤 연결 토큰으로 Threads에 2-호출 발행한다. 같은
-    (gate, version) 재요청은 멱등(새 POST 없이 기존 완료 행 반환)."""
+    """story #f8f7cb0f·#3414 — 휴먼 전용(AC1). 발행/예약 요청 둘 다 이 엔드포인트 하나
+    (블루프린트 §3 "즉시 발행=scheduled_at 없음인 같은 명령", PO 確定). 게이트가 승인한
+    scheduled_at(gate.sealed_scheduled_at)이 없으면 즉시 — 기존처럼 3중 재검증 뒤
+    동기로 Threads 2-호출까지 완료한다. 있으면 `publication_commands` 행만 만들고
+    반환 — 실제 발행은 cron 워커(AC3)가 그 시각에 처리한다.
+
+    두 경로 다 `publication_command`를 감사·재시도 원장으로 upsert한다(멱등 —
+    같은 draft/version 재요청은 새 행을 안 만든다). command upsert가 **3중
+    재검증(게이트approved·seal일치·connection활성) 뒤**에 오도록 순서를 지킨다
+    (카디르 QA⑥) — 재검증 실패로 요청이 거부되면 command 행 자체가 안 생긴다(고아
+    pending 행이 남아 워커가 엉뚱하게 재시도하는 것을 원천 차단)."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
     resolved = await _require_human(db, auth, org_id)
+
+    from app.services.channel_posts import resolve_command_target
+    from app.services.publication_command import apply_command_failure, create_or_get_publication_command
+
+    try:
+        draft, latest, gate = await resolve_command_target(db, org_id=org_id, draft_id=draft_id)
+    except ChannelPostDraftNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ExternalPublishGateNotApprovedError as exc:
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "EXTERNAL_PUBLISH_APPROVAL_REQUIRED", "message": str(exc)},
+        ) from exc
+
+    if gate.sealed_scheduled_at is not None:
+        # 예약 — command만 만들고 여기서 끝(워커가 나중에 처리, AC3).
+        command, _ = await create_or_get_publication_command(
+            db, org_id=org_id, gate_id=gate.id, destination=draft.connection_id,
+            approved_version=latest.id, requested_by_member_id=resolved.id,
+            scheduled_at=gate.sealed_scheduled_at,
+        )
+        await db.commit()
+        return PublishChannelPostResponse(
+            version_id=latest.id, scheduled=True, command_id=command.id,
+            scheduled_at=gate.sealed_scheduled_at.isoformat(),
+        )
+
+    # 즉시 — command를 pending으로 upsert한 뒤 기존처럼 동기 실행(AC2, 동기 유지).
+    command, _ = await create_or_get_publication_command(
+        db, org_id=org_id, gate_id=gate.id, destination=draft.connection_id,
+        approved_version=latest.id, requested_by_member_id=resolved.id, scheduled_at=None,
+    )
+    await db.commit()
+    now = datetime.now(timezone.utc)
 
     try:
         row = await publish_channel_post_draft(
             db, org_id=org_id, draft_id=draft_id, published_by_member_id=resolved.id,
         )
     except ChannelPostDraftNotFoundError as exc:
+        await apply_command_failure(
+            db, command, error_code="CHANNEL_POST_DRAFT_NOT_FOUND", last_error=str(exc), now=now,
+        )
+        await db.commit()
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ExternalPublishGateNotApprovedError as exc:
+        await apply_command_failure(
+            db, command, error_code="EXTERNAL_PUBLISH_APPROVAL_REQUIRED", last_error=str(exc), now=now,
+        )
+        await db.commit()
         raise HTTPException(
             status_code=403,
             detail={"code": "EXTERNAL_PUBLISH_APPROVAL_REQUIRED", "message": str(exc)},
@@ -379,6 +442,10 @@ async def publish_channel_post_draft_endpoint(
         # 페드루 PO 확定(2026-09-03) — 발행 시점 재검사(UTM 태그된 링크가 붙은 실제 전송
         # 문자열 기준). draft 생성 시점의 매핑(422·max_length·current_length)과 동형 —
         # 코드 하나가 두 HTTP status를 갖지 않게 유지.
+        await apply_command_failure(
+            db, command, error_code="CHANNEL_TEXT_TOO_LONG", last_error=str(exc), now=now,
+        )
+        await db.commit()
         raise HTTPException(
             status_code=422,
             detail={
@@ -387,30 +454,58 @@ async def publish_channel_post_draft_endpoint(
             },
         ) from exc
     except ChannelPostSealMissingError as exc:
+        await apply_command_failure(
+            db, command, error_code="SITE_POST_SEAL_MISSING", last_error=str(exc), now=now,
+        )
+        await db.commit()
         raise HTTPException(
             status_code=409, detail={"code": "SITE_POST_SEAL_MISSING", "message": str(exc)},
         ) from exc
     except ChannelPostReapprovalRequiredError as exc:
+        # story #3414 — 추가② 훅이 대개 이 상황 전에 command를 이미 voided로 무효화해
+        # 두지만, 놓친 경합 창은 여기서도 잡는다(이중 방어).
+        command.status = "voided"
+        command.reason_code = "CONTENT_CHANGED"
+        command.last_error = str(exc)[:2000]
+        await db.commit()
         raise HTTPException(
             status_code=409,
             detail={"code": "SITE_POST_REAPPROVAL_REQUIRED", "message": str(exc)},
         ) from exc
     except ChannelConnectionNotActiveError as exc:
+        await apply_command_failure(
+            db, command, error_code="CHANNEL_CONNECTION_NOT_ACTIVE", last_error=str(exc), now=now,
+        )
+        await db.commit()
         raise HTTPException(
             status_code=409,
             detail={"code": "CHANNEL_CONNECTION_NOT_ACTIVE", "message": str(exc)},
         ) from exc
     except ChannelTokenExpiredError as exc:
+        await apply_command_failure(
+            db, command, error_code="CHANNEL_TOKEN_EXPIRED", last_error=str(exc), now=now,
+        )
+        await db.commit()
         raise HTTPException(
             status_code=409,
             detail={"code": "CHANNEL_TOKEN_EXPIRED", "message": str(exc)},
         ) from exc
     except ChannelRateLimitedError as exc:
+        retry_after_seconds = max(0, int((exc.reset_at - now).total_seconds()))
+        await apply_command_failure(
+            db, command, error_code="CHANNEL_RATE_LIMITED", last_error=str(exc), now=now,
+            retry_after_seconds=retry_after_seconds,
+        )
+        await db.commit()
         raise HTTPException(
             status_code=429,
             detail={"code": "CHANNEL_RATE_LIMITED", "message": str(exc), "reset_at": exc.reset_at.isoformat()},
         ) from exc
     except ChannelPublishProviderError as exc:
+        await apply_command_failure(
+            db, command, error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", last_error=str(exc), now=now,
+        )
+        await db.commit()
         raise HTTPException(
             status_code=502,
             detail={"code": "CHANNEL_PUBLISH_PROVIDER_ERROR", "message": str(exc)},
@@ -419,13 +514,55 @@ async def publish_channel_post_draft_endpoint(
         # story #3395 — 같은 (gate_id, version_id) 동시 요청 경합에서 진 쪽이 이긴 쪽의
         # 완료를 기다렸는데도 못 끝났다(약 3초). 거짓 200도 무단 500도 아닌 정직한
         # "잠시 후 다시" — 클라이언트 재시도는 그때 남은 container_created 행으로 기존
-        # 부분성공 재시도 경로를 그대로 탄다.
+        # 부분성공 재시도 경로를 그대로 탄다. command는 아직 in_progress로 남겨둔다
+        # (실패로 단정 안 함 — 이긴 쪽이 곧 끝낼 것이므로).
         raise HTTPException(
             status_code=409,
             detail={"code": "CHANNEL_PUBLISH_IN_PROGRESS", "message": str(exc)},
         ) from exc
 
+    command.status = "completed"
+    command.last_error = None
+    command.failure_kind = None
+    await db.commit()
+
     return PublishChannelPostResponse(
         permalink=row.permalink, external_id=row.external_id,
         published_at=row.published_at.isoformat(), version_id=row.version_id,
+        scheduled=False, command_id=command.id,
     )
+
+
+class RetryPublicationCommandResponse(BaseModel):
+    id: uuid.UUID
+    status: str
+
+
+@router.post(
+    "/{org_id}/channel-posts/publication-commands/{command_id}/retry",
+    response_model=RetryPublicationCommandResponse,
+)
+async def retry_publication_command_endpoint(
+    org_id: uuid.UUID,
+    command_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> RetryPublicationCommandResponse:
+    """story #3414 AC5 — 휴먼 전용(발행 자체가 human-only인 것과 동형). `dead_letter`
+    상태인 command만 다시 큐(`pending`)에 올린다 — 다른 상태(completed·voided·blocked
+    등)는 404로 존재 비노출(카디르 QA와 동형 관례, 상태를 굳이 구별해 알려주지 않는다).
+    `next_attempt_at`을 null로 되돌려야 다음 cron tick이 이 행을 실제로 다시 집는다
+    (status만 바뀌고 next_attempt_at이 미래에 멈춰 있으면 WHERE절에서 계속 빠지는
+    결함 — 카디르 QA⑤ 지적 그대로 반영)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    await _require_human(db, auth, org_id)
+
+    from app.services.publication_command import retry_dead_letter_command
+
+    command = await retry_dead_letter_command(db, org_id=org_id, command_id=command_id)
+    if command is None:
+        raise HTTPException(status_code=404, detail="command를 찾을 수 없거나 재시도 대상이 아닙니다")
+    await db.commit()
+    return RetryPublicationCommandResponse(id=command.id, status=command.status)

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -1265,3 +1265,26 @@ async def refresh_channel_tokens(
     except Exception as exc:
         logger.exception("refresh-channel-tokens cron error: %s", exc)
         return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
+# ─── POST /api/v2/internal/cron/publication-commands ──────────────────────────
+# story #3414(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04) — 발행 명령 워커. 예약(scheduled_
+# at)이 도래했거나 재시도 대기(next_attempt_at)가 도래한 pending publication_commands를
+# SKIP LOCKED 배치로 집어 처리한다. 즉시 발행(scheduled_at 없음)은 보통 그 요청 안에서
+# 동기로 이미 끝나 있어야 하고, 이 워커가 그런 행을 집는다면 그 동기 경로가 중간에
+# 죽은 경우의 자가치유다. workflow_sla_processor.py::process_sla와 동형(상한 있는 배치·
+# cron 겹침 시 중복 처리 방지).
+
+@router.post("/publication-commands")
+async def publication_commands_tick(
+    request: Request,
+    session: AsyncSession = Depends(get_worker_db),
+) -> JSONResponse:
+    verify_cron(request)
+    try:
+        from app.services.publication_command import process_due_publication_commands
+        counts = await process_due_publication_commands(session)
+        return _ok(counts)
+    except Exception as exc:
+        logger.exception("publication-commands cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -356,6 +356,11 @@ async def _reseal_gate_on_new_version(
         gate.resolution_note = None
         gate.resolved_at = None
         gate.reapproval_required = True
+        # story #3414 추가② — 조용한 무효화 경로(명시적 재상신이 아니라 새 draft 버전
+        # 생성만으로 approved→pending으로 되돌아간 경우)도 대기 중 명령을 즉시
+        # 무효화한다. submit_channel_post_draft의 명시적 재상신 경로와 동형 처방.
+        from app.services.publication_command import void_pending_commands_for_gate
+        await void_pending_commands_for_gate(db, gate_id=gate.id, reason_code="CONTENT_CHANGED")
         return
     gate.sealed_content_version = version.version
     gate.sealed_content_sha256 = version.body_sha256
@@ -534,11 +539,20 @@ async def submit_channel_post_draft(
     draft_id: uuid.UUID,
     version_id: uuid.UUID | None,
     requester_member_id: uuid.UUID,
+    scheduled_at: datetime | None = None,
 ) -> tuple[Gate, uuid.UUID]:
     """초안 버전을 external_publish 게이트에 상신 — site_posts.submit_site_post_draft와
     1:1 대응(AC3). **에이전트도 호출 가능**(AC1, 2026-09-03 dev 실측 정정 — site S2와 동일
     실동작: submit은 게이트 생성까지만, 승인·발행이 human-only다. 이 함수 자체엔 actor_type
-    가드가 없다 — 신규 코드 불요)."""
+    가드가 없다 — 신규 코드 불요).
+
+    story #3414(PO 確定 (B), 2026-09-04) — 재승인 판정 지점은 이 함수 하나다. 판정축은
+    본문 해시 **또는** scheduled_at 중 하나라도 봉인값과 다르면 재승인(destination
+    축은 이 도메인에서 draft당 connection_id가 구조적으로 불변이라 실질 검사 대상이
+    아니다). 즉 "본문은 그대로, 예약 시각만 바꾼다"도 이 함수를 다시 불러 처리한다
+    (신규 엔드포인트를 따로 안 만든다 — 판정 지점을 하나로 유지). site_posts는 예약
+    개념이 없어 판정축이 하나뿐이라 이 함수와 대칭이 깨지는데, 대칭보다 판정 단일
+    지점이 우선이라는 게 PO 확定."""
     draft = await get_channel_post_draft(db, org_id=org_id, draft_id=draft_id)
     if draft is None:
         raise ChannelPostDraftNotFoundError(draft_id)
@@ -575,12 +589,19 @@ async def submit_channel_post_draft(
                 holding_connection_id=holder.connection_id,
             )
 
+    # story #3414 — 무엇이 바뀌었는지(본문 또는 scheduled_at)를 재봉인 前에 먼저
+    # 판정한다. 둘 다 안 바뀌었으면 기존처럼 완전 no-op(short-circuit).
+    content_changed = existing is None or existing.sealed_content_sha256 != target.body_sha256
+    schedule_changed = existing is None or existing.sealed_scheduled_at != scheduled_at
     if (
         existing is not None
-        and existing.sealed_content_sha256 == target.body_sha256
+        and not content_changed
+        and not schedule_changed
         and existing.status in ("pending", "approved")
     ):
         return existing, target.id
+
+    was_approved = existing is not None and existing.status == "approved"
 
     neutral_facts = {
         "destination": draft.channel,
@@ -608,7 +629,19 @@ async def submit_channel_post_draft(
     gate.sealed_content_version = target.version
     gate.sealed_content_sha256 = target.body_sha256
     gate.sealed_content_body = target.text
+    gate.sealed_scheduled_at = scheduled_at
     gate.reapproval_required = False
+
+    if was_approved:
+        # story #3414 추가② — 이 재상신이 이미 승인된 게이트를 되돌린 경우(위에서
+        # pending으로 되돌렸다), 그 게이트에 걸린 대기 중 명령을 즉시 무효화한다
+        # (워커 tick을 기다리지 않고 화면이 바로 "이 예약은 더 이상 유효하지 않다"를
+        # 보일 수 있게). 사유 코드는 실제 무엇이 바뀌었는지 그대로 — 본문이 바뀌었으면
+        # CONTENT_CHANGED, 본문은 그대로고 시각만 바뀌었으면 SCHEDULE_CHANGED.
+        from app.services.publication_command import void_pending_commands_for_gate
+        reason_code = "CONTENT_CHANGED" if content_changed else "SCHEDULE_CHANGED"
+        await void_pending_commands_for_gate(db, gate_id=gate.id, reason_code=reason_code)
+
     await db.commit()
     await db.refresh(gate)
     return gate, target.id
@@ -634,6 +667,35 @@ def _classify_threads_error(
     return "CHANNEL_PUBLISH_PROVIDER_ERROR", ChannelPublishProviderError(
         provider_code=exc.code, provider_message=exc.message,
     )
+
+
+async def resolve_command_target(
+    db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID,
+) -> tuple[ChannelPostDraft, ChannelPostVersion, Gate]:
+    """story #3414 — `publication_command` 키 조립에 필요한 (draft, latest_version, gate)
+    조회 전용. **`publish_channel_post_draft()`의 재검증(봉인 일치·connection 활성)을
+    재구현하지 않는다** — 그 함수가 실제 발행(즉시든 워커든) 시점에 이미 한다. 여기선
+    "게이트가 이 work_item에 존재하고 approved인지"만 본다(근거 없는 command 생성을
+    막는 최소선)."""
+    draft = await get_channel_post_draft(db, org_id=org_id, draft_id=draft_id)
+    if draft is None:
+        raise ChannelPostDraftNotFoundError(draft_id)
+
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    gate = await find_gate_slot_with_pr_fallback(
+        db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
+        gate_type=_EXTERNAL_PUBLISH_GATE_TYPE, pr_number=None, repo_full_name=None,
+    )
+    if gate is None or gate.status != "approved":
+        raise ExternalPublishGateNotApprovedError(
+            gate_id=gate.id if gate is not None else None,
+            status=gate.status if gate is not None else None,
+        )
+    versions = await list_channel_post_draft_versions(db, draft_id=draft_id)
+    if not versions:
+        raise ChannelPostDraftNotFoundError(draft_id)
+    return draft, versions[-1], gate
 
 
 async def publish_channel_post_draft(

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -1,0 +1,329 @@
+"""story #3414(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04) — 발행 명령 원장 서비스.
+
+블루프린트 v3 §3 「발행 명령」·「예약 스케줄러」·「서버 발행 워커」 그대로: 휴먼의
+발행/예약 요청이 `publication_commands` 행을 만들고(PO 確定 (B) — 승인 자체는
+트리거가 아니다, "승인 없는 명령이 없다"일 뿐), cron 워커가 예약분을 집어 기존
+`publish_channel_post_draft()`를 그대로 호출한다(3중 재검증 재구현 금지 — 그
+함수가 이미 함).
+
+재사용 패턴 3종(신규 발명 금지):
+- SKIP LOCKED 배치 클레임 — `workflow_sla_processor.py::process_sla`와 동형.
+- 동시 upsert 경합 방지(SAVEPOINT+IntegrityError constraint명 확인+재조회) —
+  story #3395(PR#3757, `channel_posts.py::publish_channel_post_draft`)와 동형
+  관용구. 그쪽은 이긴 쪽의 "완료"를 폴링하지만, 여기는 command 자체가 감사
+  원장일 뿐이라 진 쪽은 재조회한 기존 행을 그대로 반환하면 된다(완료 대기 불요).
+- dead_letter 어휘 — `workflow_line_metrics.py`의 `delivery_status`와 같은 문자열.
+
+`failure_kind`는 유나 design §11-5 정본 3값(`connection`/`needs_check`/
+`transient`) — 매핑을 모르는 error_code는 `needs_check`로 fail-closed(임의로
+transient=재시도 가능이라 단정하지 않는다)."""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.publication_command import PublicationCommand
+
+logger = logging.getLogger(__name__)
+
+# story #3414 — cron 1회 tick이 집는 상한(workflow_sla_processor.py::_SLA_BATCH_SIZE와
+# 동형 사상 — 상한 없는 SKIP LOCKED 배치는 그 자체가 위험, story #2461 finding #5).
+BATCH_SIZE = 50
+MAX_RETRIES = 5
+_BACKOFF_BASE_SECONDS = 60  # 1분→2분→4분→8분→16분(마지막 실패면 dead_letter).
+
+# story #3414 PO 정정3 — 유나 design §11-5 정본. 매핑 안 되는 error_code는 반드시
+# 'needs_check'로 떨어진다(아래 _UNMAPPED_FAILURE_KIND) — "재시도해도 되는지 모른다"를
+# "재시도해도 된다(transient)"로 지어내지 않는다.
+FAILURE_KIND_CONNECTION = "connection"
+FAILURE_KIND_NEEDS_CHECK = "needs_check"
+FAILURE_KIND_TRANSIENT = "transient"
+
+# story #3414 — 어떤 서버 error code가 어느 failure_kind인지의 유일한 매핑 표. 새 코드가
+# 추가되면 여기 등재하지 않는 한 자동으로 needs_check(fail-closed)로 떨어진다 — "일단
+# transient로"류 추측 금지(story #3405/#3406 "미지 code는 추측 안 함" 원칙과 동일 사상).
+_CONNECTION_BLOCKED_CODES = frozenset({"CHANNEL_TOKEN_EXPIRED", "CHANNEL_CONNECTION_NOT_ACTIVE"})
+_NEEDS_CHECK_CODES = frozenset({"CHANNEL_PUBLISH_IN_PROGRESS"})
+_TRANSIENT_CODES = frozenset({"CHANNEL_PUBLISH_PROVIDER_ERROR", "CHANNEL_RATE_LIMITED"})
+
+
+def classify_failure_kind(error_code: str | None) -> str:
+    """story #3414 — error_code 하나를 유나 design §11-5의 3값 중 하나로 분류한다.
+    매핑표 밖의(또는 None) error_code는 전부 needs_check(재시도 가능 여부를 서버가
+    모른다는 뜻 — transient로 지어내면 화면이 안전하지 않은 자동 재시도를 약속하게
+    된다)."""
+    if error_code in _CONNECTION_BLOCKED_CODES:
+        return FAILURE_KIND_CONNECTION
+    if error_code in _TRANSIENT_CODES:
+        return FAILURE_KIND_TRANSIENT
+    if error_code in _NEEDS_CHECK_CODES:
+        return FAILURE_KIND_NEEDS_CHECK
+    return FAILURE_KIND_NEEDS_CHECK
+
+
+async def create_or_get_publication_command(
+    db: AsyncSession, *, org_id: uuid.UUID, gate_id: uuid.UUID, destination: uuid.UUID,
+    approved_version: uuid.UUID, requested_by_member_id: uuid.UUID,
+    scheduled_at: datetime | None, operation: str = "publish",
+) -> tuple[PublicationCommand, bool]:
+    """멱등 upsert(블루프린트 §3 키: org_id+destination+approved_version+operation) —
+    기존 행이 있으면 그대로 반환(재생성 0, Threads 이중 POST 방지의 근원 축 하나).
+    반환값 둘째 원소는 "새로 만들었는지"(호출부 분기·테스트 편의).
+
+    story #3395(PR#3757)와 동형 동시성 방어 — 진짜 동시 요청 2건이 둘 다 아래 select에서
+    None을 보고 각자 INSERT하면 UNIQUE 위반이 난다. SAVEPOINT로 감싸 위반 시 이 INSERT만
+    롤백하고(바깥 트랜잭션은 오염 안 됨), constraint 이름을 확인한 뒤(다른 원인까지
+    "경합"으로 오판하지 않도록 — approval_delivery.py QA 교훈) 진 쪽은 이긴 쪽이 커밋한
+    행을 재조회해 그대로 반환한다(완료 대기 불요 — #3757과 다른 점, 여기 command는
+    "완결된 발행 결과"가 아니라 감사 원장이라 어느 상태든 반환해도 무방)."""
+    existing = (await db.execute(
+        select(PublicationCommand).where(
+            PublicationCommand.org_id == org_id,
+            PublicationCommand.destination == destination,
+            PublicationCommand.approved_version == approved_version,
+            PublicationCommand.operation == operation,
+        )
+    )).scalar_one_or_none()
+    if existing is not None:
+        return existing, False
+
+    command = PublicationCommand(
+        id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=destination,
+        approved_version=approved_version, operation=operation, scheduled_at=scheduled_at,
+        status="pending", requested_by_member_id=requested_by_member_id,
+    )
+    try:
+        async with db.begin_nested():
+            db.add(command)
+            await db.flush()
+    except IntegrityError as exc:
+        _orig = getattr(exc, "orig", None)
+        constraint = getattr(_orig, "constraint_name", None) or getattr(
+            getattr(_orig, "__cause__", None), "constraint_name", None,
+        )
+        if constraint != "uq_publication_commands_idempotency":
+            raise
+        winner = (await db.execute(
+            select(PublicationCommand).where(
+                PublicationCommand.org_id == org_id,
+                PublicationCommand.destination == destination,
+                PublicationCommand.approved_version == approved_version,
+                PublicationCommand.operation == operation,
+            )
+        )).scalar_one()
+        return winner, False
+    return command, True
+
+
+async def void_pending_commands_for_gate(db: AsyncSession, *, gate_id: uuid.UUID, reason_code: str) -> int:
+    """story #3414 추가② — 승인된 게이트가 재편집/재예약으로 pending(reapproval_required)
+    으로 되돌아갈 때, 그 게이트에 걸린 **pending 상태의 command만** voided로 전이한다
+    (워커 tick을 기다리지 않고 화면이 "이 예약은 더 이상 유효하지 않다"를 즉시 보일 수
+    있게). completed·dead_letter·voided 등 이미 종결된 command는 절대 건드리지 않는다
+    (그 자체 이력 보존 — "이 게이트의 아무 행이나"가 아니라 "이 게이트의 대기 중인
+    행"만, 카디르 QA③ 지적 그대로)."""
+    rows = (await db.execute(
+        select(PublicationCommand).where(
+            PublicationCommand.gate_id == gate_id, PublicationCommand.status == "pending",
+        ).with_for_update()
+    )).scalars().all()
+    for row in rows:
+        row.status = "voided"
+        row.reason_code = reason_code
+    return len(rows)
+
+
+def compute_next_attempt_at(
+    *, attempt_count: int, now: datetime, retry_after_seconds: int | None = None,
+) -> datetime:
+    """story #3414 — dispatch_router.py::_post_with_retry와 동형 사상의 지수 백오프
+    (1분→2분→4분→8분→16분). `Retry-After` 헤더가 있으면 그 값을 그대로 쓴다(기본
+    백오프보다 우선 — 카디르 QA④: 헤더를 실제로 읽었는지 증명하려면 기본값과 다른
+    값으로 검증해야 한다는 지적 반영, 여기서 헤더값을 무조건 우선)."""
+    if retry_after_seconds is not None and retry_after_seconds > 0:
+        return now + timedelta(seconds=retry_after_seconds)
+    delay = _BACKOFF_BASE_SECONDS * (2 ** attempt_count)
+    return now + timedelta(seconds=delay)
+
+
+async def retry_dead_letter_command(db: AsyncSession, *, org_id: uuid.UUID, command_id: uuid.UUID) -> PublicationCommand | None:
+    """story #3414 AC5 — dead_letter 상태인 command를 사람이 다시 큐에 올린다.
+    attempt_count는 리셋하지 않는다(이력 보존, PO 권장 그대로) — next_attempt_at을
+    now로 되돌려야 cron이 이 행을 다시 집는다(status만 pending으로 바꾸고 next_attempt_at
+    이 미래에 멈춰 있으면 WHERE절에서 계속 빠진다 — 카디르 QA⑤ 지적)."""
+    command = (await db.execute(
+        select(PublicationCommand).where(
+            PublicationCommand.id == command_id, PublicationCommand.org_id == org_id,
+        ).with_for_update()
+    )).scalar_one_or_none()
+    if command is None or command.status != "dead_letter":
+        return None
+    command.status = "pending"
+    command.next_attempt_at = None
+    command.dead_letter_at = None
+    command.last_error = None
+    command.failure_kind = None
+    return command
+
+
+async def _process_one_command(db: AsyncSession, command: PublicationCommand, *, now: datetime) -> None:
+    """단건 처리 — 알려진 실패는 여기서 전부 잡아 `command`에 결과를 남기고 정상
+    반환한다(예외를 밖으로 던지지 않는다). 호출부(`process_due_publication_commands`)가
+    그래도 한 번 더 try/except로 감싸는 건 진짜 미분류 버그에 대한 2중 방어(AC4
+    격리 — 이 command 하나의 실패가 배치의 나머지를 막으면 안 된다)."""
+    from app.models.channel_post_version import ChannelPostVersion
+    from app.services.channel_posts import (
+        ChannelConnectionNotActiveError,
+        ChannelPostDraftNotFoundError,
+        ChannelPostReapprovalRequiredError,
+        ChannelPostSealMissingError,
+        ChannelPublishInProgressError,
+        ChannelPublishProviderError,
+        ChannelRateLimitedError,
+        ChannelTextTooLongError,
+        ChannelTokenExpiredError,
+        ExternalPublishGateNotApprovedError,
+        get_channel_post_draft,
+        publish_channel_post_draft,
+    )
+
+    command.status = "in_progress"
+    await db.flush()
+
+    error_code: str | None = None
+    last_error: str | None = None
+    retry_after_seconds: int | None = None
+    try:
+        version_row = (await db.execute(
+            select(ChannelPostVersion).where(ChannelPostVersion.id == command.approved_version)
+        )).scalar_one_or_none()
+        if version_row is None:
+            raise ChannelPostDraftNotFoundError(command.approved_version)
+        draft = await get_channel_post_draft(db, org_id=command.org_id, draft_id=version_row.draft_id)
+        if draft is None:
+            raise ChannelPostDraftNotFoundError(version_row.draft_id)
+
+        await publish_channel_post_draft(
+            db, org_id=command.org_id, draft_id=draft.id,
+            published_by_member_id=command.requested_by_member_id,
+        )
+        command.status = "completed"
+        command.last_error = None
+        command.failure_kind = None
+        return
+    except ChannelPostReapprovalRequiredError as exc:
+        # story #3414 추가② 이중 방어 — void_pending_commands_for_gate가 보통 이 상황을
+        # 이미 선제 처리하지만(제출 시점 즉시), 놓친 경우를 워커가 마지막으로 잡는다.
+        command.status = "voided"
+        command.reason_code = "CONTENT_CHANGED"
+        command.last_error = str(exc)[:2000]
+        return
+    except ChannelPostDraftNotFoundError as exc:
+        error_code, last_error = "CHANNEL_POST_DRAFT_NOT_FOUND", str(exc)
+    except ExternalPublishGateNotApprovedError as exc:
+        error_code, last_error = "EXTERNAL_PUBLISH_APPROVAL_REQUIRED", str(exc)
+    except ChannelPostSealMissingError as exc:
+        error_code, last_error = "SITE_POST_SEAL_MISSING", str(exc)
+    except ChannelTextTooLongError as exc:
+        error_code, last_error = "CHANNEL_TEXT_TOO_LONG", str(exc)
+    except ChannelConnectionNotActiveError as exc:
+        error_code, last_error = "CHANNEL_CONNECTION_NOT_ACTIVE", str(exc)
+    except ChannelTokenExpiredError as exc:
+        error_code, last_error = "CHANNEL_TOKEN_EXPIRED", str(exc)
+    except ChannelRateLimitedError as exc:
+        error_code, last_error = "CHANNEL_RATE_LIMITED", str(exc)
+        retry_after_seconds = max(0, int((exc.reset_at - now).total_seconds()))
+    except ChannelPublishProviderError as exc:
+        error_code, last_error = "CHANNEL_PUBLISH_PROVIDER_ERROR", str(exc)
+    except ChannelPublishInProgressError as exc:
+        error_code, last_error = "CHANNEL_PUBLISH_IN_PROGRESS", str(exc)
+    except Exception as exc:  # noqa: BLE001 — 미분류 실패도 이 command 하나만 막는다.
+        last_error = str(exc)
+        logger.exception("publication_command 처리 중 미분류 예외 command_id=%s", command.id)
+
+    await apply_command_failure(
+        db, command, error_code=error_code, last_error=last_error, now=now,
+        retry_after_seconds=retry_after_seconds,
+    )
+
+
+async def apply_command_failure(
+    db: AsyncSession, command: PublicationCommand, *,
+    error_code: str | None, last_error: str | None, now: datetime, retry_after_seconds: int | None = None,
+) -> None:
+    """story #3414 — 실패 한 건을 command(+필요하면 connection) 상태에 반영하는 유일한
+    지점. 워커(`_process_one_command`)와 즉시-발행 라우터(`publish_channel_post_draft_
+    endpoint`) 둘 다 이 함수를 쓴다 — 실패 분류·백오프·connection 승격 로직을 두 곳에
+    각자 짜지 않는다(드리프트 원천 차단, story #3405/#3406과 동일 사상)."""
+    command.last_error = last_error[:2000] if last_error else None
+    failure_kind = classify_failure_kind(error_code)
+    command.failure_kind = failure_kind
+
+    if failure_kind == FAILURE_KIND_CONNECTION:
+        # story #3414 PO 정정2 추가② — 재시도 백오프 큐가 아니라 연결 상태를 승격하고
+        # 이 command는 "연결 복구 대기"(blocked)로 멈춘다. 연결이 다시 active가 되는
+        # 것(owner 재인증 등)은 이 스토리 스코프 밖 — 그 뒤 사람이 수동 재시도(AC5)로
+        # 이어간다. apply_refresh_failure()를 직접 부르지 않는 이유 — 그 함수가
+        # 내부에서 즉시 commit해 호출부의 커밋 경계와 어긋난다(같은 필드 대입만 여기서
+        # 직접 한다, 새 로직 발명 아님).
+        from app.models.channel_connection import ChannelConnection
+
+        connection = await db.get(ChannelConnection, command.destination)
+        if connection is not None:
+            connection.status = "quota_exceeded" if error_code == "CHANNEL_RATE_LIMITED" else "expired"
+            connection.last_error = (last_error or "")[:2000]
+        command.status = "blocked"
+        return
+
+    command.attempt_count += 1
+    if command.attempt_count >= MAX_RETRIES:
+        command.status = "dead_letter"
+        command.dead_letter_at = now
+        command.next_attempt_at = None
+        return
+    command.status = "pending"
+    command.next_attempt_at = compute_next_attempt_at(
+        attempt_count=command.attempt_count, now=now, retry_after_seconds=retry_after_seconds,
+    )
+
+
+async def process_due_publication_commands(db: AsyncSession, *, now: datetime | None = None) -> dict[str, int]:
+    """story #3414 AC3 — cron 워커의 유일한 진입점. `scheduled_at`(예약 시각, null=즉시라
+    이미 동기 경로가 처리했어야 함 — 여기 남아 있다면 그 동기 경로가 중간에 죽은
+    것이라 자가치유 대상)이 도래했고, 재시도 대기 중(`next_attempt_at`)이면 그것도
+    도래한 `status='pending'` command를 SKIP LOCKED 배치로 클레임한다
+    (`workflow_sla_processor.py::process_sla`와 동형 — 상한 있는 배치, cron 겹침 시
+    중복 처리 방지).
+
+    각 command는 개별 트랜잭션(커밋 경계)으로 처리 — 한 건의 실패(또는 진짜 미분류
+    버그)가 배치의 나머지 org·command를 막지 않는다(AC4 격리)."""
+    now = now or datetime.now(timezone.utc)
+    rows = (await db.execute(
+        select(PublicationCommand).where(
+            PublicationCommand.status == "pending",
+            (PublicationCommand.scheduled_at.is_(None)) | (PublicationCommand.scheduled_at <= now),
+            (PublicationCommand.next_attempt_at.is_(None)) | (PublicationCommand.next_attempt_at <= now),
+        ).order_by(PublicationCommand.created_at.asc())
+        .limit(BATCH_SIZE)
+        .with_for_update(skip_locked=True)
+    )).scalars().all()
+
+    counts = {
+        "completed": 0, "pending_retry": 0, "dead_letter": 0, "blocked": 0, "voided": 0, "error": 0,
+    }
+    for command in rows:
+        try:
+            await _process_one_command(db, command, now=now)
+            await db.commit()
+            key = command.status if command.status in ("completed", "dead_letter", "blocked", "voided") else "pending_retry"
+            counts[key] += 1
+        except Exception:  # noqa: BLE001 — 2중 방어(AC4): 진짜 미분류 예외도 이 건만 격리.
+            await db.rollback()
+            counts["error"] += 1
+            logger.exception("publication command batch item 처리 실패 command_id=%s", command.id)
+    return counts

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -35,7 +35,11 @@ logger = logging.getLogger(__name__)
 # 동형 사상 — 상한 없는 SKIP LOCKED 배치는 그 자체가 위험, story #2461 finding #5).
 BATCH_SIZE = 50
 MAX_RETRIES = 5
-_BACKOFF_BASE_SECONDS = 60  # 1분→2분→4분→8분→16분(마지막 실패면 dead_letter).
+# attempt_count는 실패마다 먼저 증가한 뒤 백오프를 계산한다(1부터 시작) — 그래서 실제
+# 지연 순서는 2분(2^1)→4분→8분→16분이다(다음 겹증가인 5번째 실패에서 MAX_RETRIES
+# 도달·dead_letter, 그 시점엔 next_attempt_at을 아예 안 만든다). 페드루 리뷰 nit H —
+# 이전 주석의 "1분→..."은 attempt_count가 0부터 쓰인다고 잘못 적은 것.
+_BACKOFF_BASE_SECONDS = 60
 
 # story #3414 PO 정정3 — 유나 design §11-5 정본. 매핑 안 되는 error_code는 반드시
 # 'needs_check'로 떨어진다(아래 _UNMAPPED_FAILURE_KIND) — "재시도해도 되는지 모른다"를
@@ -142,9 +146,10 @@ def compute_next_attempt_at(
     *, attempt_count: int, now: datetime, retry_after_seconds: int | None = None,
 ) -> datetime:
     """story #3414 — dispatch_router.py::_post_with_retry와 동형 사상의 지수 백오프
-    (1분→2분→4분→8분→16분). `Retry-After` 헤더가 있으면 그 값을 그대로 쓴다(기본
-    백오프보다 우선 — 카디르 QA④: 헤더를 실제로 읽었는지 증명하려면 기본값과 다른
-    값으로 검증해야 한다는 지적 반영, 여기서 헤더값을 무조건 우선)."""
+    (2분→4분→8분→16분, attempt_count가 1부터 들어오므로 — 위 _BACKOFF_BASE_SECONDS
+    주석 참고). `Retry-After` 헤더가 있으면 그 값을 그대로 쓴다(기본 백오프보다 우선 —
+    카디르 QA④: 헤더를 실제로 읽었는지 증명하려면 기본값과 다른 값으로 검증해야
+    한다는 지적 반영, 여기서 헤더값을 무조건 우선)."""
     if retry_after_seconds is not None and retry_after_seconds > 0:
         return now + timedelta(seconds=retry_after_seconds)
     delay = _BACKOFF_BASE_SECONDS * (2 ** attempt_count)
@@ -152,16 +157,24 @@ def compute_next_attempt_at(
 
 
 async def retry_dead_letter_command(db: AsyncSession, *, org_id: uuid.UUID, command_id: uuid.UUID) -> PublicationCommand | None:
-    """story #3414 AC5 — dead_letter 상태인 command를 사람이 다시 큐에 올린다.
+    """story #3414 AC5 — `dead_letter` **또는 `blocked`**(연결 복구 대기) 상태인 command를
+    사람이 다시 큐에 올린다. 페드루 리뷰 블로커B — 원래 `dead_letter`만 받았는데,
+    토큰 만료로 `blocked`된 **예약** 명령은 owner가 재인증한 뒤에도 갈 길이 없었다
+    (이 함수가 거부·같은 gate로 재-publish 요청해도 멱등이라 같은 blocked 행을 그대로
+    반환할 뿐 — 막다른 길). 연결이 실제로 복구됐는지는 이 함수가 판단하지 않는다 —
+    pending으로 되돌리기만 하면 다음 cron tick(또는 즉시 재-publish)의
+    `publish_channel_post_draft` 3중 재검증이 그대로 판정한다(안 고쳐졌으면 다시
+    같은 실패로 돌아올 뿐이라 안전).
+
     attempt_count는 리셋하지 않는다(이력 보존, PO 권장 그대로) — next_attempt_at을
-    now로 되돌려야 cron이 이 행을 다시 집는다(status만 pending으로 바꾸고 next_attempt_at
+    null로 되돌려야 cron이 이 행을 다시 집는다(status만 pending으로 바꾸고 next_attempt_at
     이 미래에 멈춰 있으면 WHERE절에서 계속 빠진다 — 카디르 QA⑤ 지적)."""
     command = (await db.execute(
         select(PublicationCommand).where(
             PublicationCommand.id == command_id, PublicationCommand.org_id == org_id,
         ).with_for_update()
     )).scalar_one_or_none()
-    if command is None or command.status != "dead_letter":
+    if command is None or command.status not in ("dead_letter", "blocked"):
         return None
     command.status = "pending"
     command.next_attempt_at = None
@@ -175,7 +188,11 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
     """단건 처리 — 알려진 실패는 여기서 전부 잡아 `command`에 결과를 남기고 정상
     반환한다(예외를 밖으로 던지지 않는다). 호출부(`process_due_publication_commands`)가
     그래도 한 번 더 try/except로 감싸는 건 진짜 미분류 버그에 대한 2중 방어(AC4
-    격리 — 이 command 하나의 실패가 배치의 나머지를 막으면 안 된다)."""
+    격리 — 이 command 하나의 실패가 배치의 나머지를 막으면 안 된다).
+
+    `command.status`는 이미 `in_progress`다 — 호출부가 배치 클레임 단계에서 이미
+    표시·commit했다(블로커A, 아래 `process_due_publication_commands` 참고). 여기서
+    다시 대입하지 않는다(중복)."""
     from app.models.channel_post_version import ChannelPostVersion
     from app.services.channel_posts import (
         ChannelConnectionNotActiveError,
@@ -191,9 +208,6 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
         get_channel_post_draft,
         publish_channel_post_draft,
     )
-
-    command.status = "in_progress"
-    await db.flush()
 
     error_code: str | None = None
     last_error: str | None = None
@@ -267,19 +281,42 @@ async def apply_command_failure(
     if failure_kind == FAILURE_KIND_CONNECTION:
         # story #3414 PO 정정2 추가② — 재시도 백오프 큐가 아니라 연결 상태를 승격하고
         # 이 command는 "연결 복구 대기"(blocked)로 멈춘다. 연결이 다시 active가 되는
-        # 것(owner 재인증 등)은 이 스토리 스코프 밖 — 그 뒤 사람이 수동 재시도(AC5)로
-        # 이어간다. apply_refresh_failure()를 직접 부르지 않는 이유 — 그 함수가
-        # 내부에서 즉시 commit해 호출부의 커밋 경계와 어긋난다(같은 필드 대입만 여기서
-        # 직접 한다, 새 로직 발명 아님).
+        # 것(owner 재인증 등)은 이 스토리 스코프 밖 — 그 뒤 사람이 수동 재시도(AC5,
+        # 블로커B로 blocked도 받는다)로 이어간다. apply_refresh_failure()를 직접
+        # 부르지 않는 이유 — 그 함수가 내부에서 즉시 commit해 호출부의 커밋 경계와
+        # 어긋난다(같은 필드 대입만 여기서 직접 한다, 새 로직 발명 아님).
+        #
+        # 페드루 리뷰 nit G — `error_code == "CHANNEL_RATE_LIMITED"`분기로 만든
+        # "quota_exceeded" 상태값은 죽은 코드였다(CHANNEL_RATE_LIMITED는 _TRANSIENT_
+        # CODES라 애초에 이 분기(connection)에 못 옴 — 아래처럼 백오프 재시도로 간다).
+        # ChannelConnection.status enum(active|expired|revoked|error)에도 없는 값이라
+        # 제거. 이미 revoked/error로 더 구체적인 종결 상태면 그걸 expired로 덮어쓰지
+        # 않는다(더 약한 정보로 되돌리지 않기).
         from app.models.channel_connection import ChannelConnection
 
         connection = await db.get(ChannelConnection, command.destination)
         if connection is not None:
-            connection.status = "quota_exceeded" if error_code == "CHANNEL_RATE_LIMITED" else "expired"
             connection.last_error = (last_error or "")[:2000]
+            if connection.status not in ("revoked", "error"):
+                connection.status = "expired"
         command.status = "blocked"
         return
 
+    if failure_kind == FAILURE_KIND_NEEDS_CHECK:
+        # story #3414 페드루 리뷰 블로커C — 결정적 실패(입력 형태 오류·승인 필요·초안
+        # 없음 등, 매핑표 밖이라 fail-closed로 여기 떨어진 것들 포함 — 예:
+        # CHANNEL_TEXT_TOO_LONG·SITE_POST_SEAL_MISSING·EXTERNAL_PUBLISH_APPROVAL_
+        # REQUIRED·CHANNEL_POST_DRAFT_NOT_FOUND)는 재시도해도 그대로 다시 실패한다.
+        # transient와 같은 백오프 큐에 넣으면(원래 버그) 모듈 docstring의 fail-closed
+        # 취지와 반대로 "모른다"를 "재시도해도 된다"로 지어낸 것이 된다 — 즉시
+        # dead_letter로 보내 사람 재시도(AC5)만 받는다.
+        command.attempt_count += 1
+        command.status = "dead_letter"
+        command.dead_letter_at = now
+        command.next_attempt_at = None
+        return
+
+    # transient만 지수 백오프 재시도 큐로.
     command.attempt_count += 1
     if command.attempt_count >= MAX_RETRIES:
         command.status = "dead_letter"
@@ -296,12 +333,20 @@ async def process_due_publication_commands(db: AsyncSession, *, now: datetime | 
     """story #3414 AC3 — cron 워커의 유일한 진입점. `scheduled_at`(예약 시각, null=즉시라
     이미 동기 경로가 처리했어야 함 — 여기 남아 있다면 그 동기 경로가 중간에 죽은
     것이라 자가치유 대상)이 도래했고, 재시도 대기 중(`next_attempt_at`)이면 그것도
-    도래한 `status='pending'` command를 SKIP LOCKED 배치로 클레임한다
-    (`workflow_sla_processor.py::process_sla`와 동형 — 상한 있는 배치, cron 겹침 시
-    중복 처리 방지).
+    도래한 `status='pending'` command를 SKIP LOCKED 배치로 클레임한다.
 
-    각 command는 개별 트랜잭션(커밋 경계)으로 처리 — 한 건의 실패(또는 진짜 미분류
-    버그)가 배치의 나머지 org·command를 막지 않는다(AC4 격리)."""
+    페드루 리뷰 블로커A — 클레임(집기)과 처리(commit)를 분리한 2단계다. `SELECT ...
+    FOR UPDATE SKIP LOCKED`의 행 락은 **그 SELECT를 실행한 트랜잭션이 끝나야**
+    풀린다(commit/rollback). 원래 구조는 건마다 `db.commit()`을 해 첫 건이 끝나는
+    순간 트랜잭션이 종료되면서 나머지 클레임 행의 락까지 전부 풀렸다 — 그 행들은
+    여전히 `status='pending'`이라, 그 사이 겹쳐 도는 다른 tick이 같은 행을 다시
+    클레임해 이중 처리할 수 있었다(`workflow_sla_processor.py::process_sla`가 "루프
+    *뒤* 1회 commit"으로 겹침을 막는 것과 이 지점이 정확히 달랐다 — "동형"이라던
+    원래 주석이 틀렸다). 아래처럼 클레임한 행 전부를 `in_progress`로 표시하고 **그
+    표시만** 한 번에 commit해 락을 여기서 놓는다 — 그 뒤로는 이 행들이 `status=
+    'pending'` 조건에 안 걸려 겹친 tick이 아예 못 다시 집는다. 그 다음에야 건별로
+    개별 트랜잭션(커밋 경계)으로 처리 — 한 건의 실패(또는 진짜 미분류 버그)가 배치의
+    나머지 org·command를 막지 않는다(AC4 격리, 이 축은 원래 구조 그대로)."""
     now = now or datetime.now(timezone.utc)
     rows = (await db.execute(
         select(PublicationCommand).where(
@@ -312,6 +357,10 @@ async def process_due_publication_commands(db: AsyncSession, *, now: datetime | 
         .limit(BATCH_SIZE)
         .with_for_update(skip_locked=True)
     )).scalars().all()
+
+    for command in rows:
+        command.status = "in_progress"
+    await db.commit()
 
     counts = {
         "completed": 0, "pending_retry": 0, "dead_letter": 0, "blocked": 0, "voided": 0, "error": 0,

--- a/backend/tests/test_3414_publication_command.py
+++ b/backend/tests/test_3414_publication_command.py
@@ -524,9 +524,12 @@ async def test_resubmit_identical_content_and_schedule_is_noop():
 @pytest.mark.anyio
 async def test_resubmit_schedule_change_after_approval_triggers_reapproval_and_voids_only_pending_command():
     """PO 정정3 (B) + 카디르 QA③ — 본문은 그대로, scheduled_at만 바뀐 재상신도 승인을
-    되돌리고(reapproval_required=True) 대기 중 command를 voided(SCHEDULE_CHANGED)로
-    무효화한다. 양성대조: 같은 gate에 이미 completed 상태인 옛 행이 하나 더 있어도
-    그 행은 안 건드리는지(gate_id만으로 뭉개면 다른 행까지 오염되는 결함을 잡는다)."""
+    되돌리고(gate.status를 pending으로) 대기 중 command를 voided(SCHEDULE_CHANGED)로
+    무효화한다. 페드루 리뷰 nit K — reapproval_required 자체는 False로 남는다(Gate
+    모델 문서화 계약: 그건 "시스템이 조용히 되돌렸다"는 신호고, 이건 사람이 방금
+    명시적으로 재상신한 경로라 True가 될 이유가 없다 — 아래 assert 참고). 양성대조:
+    같은 gate에 이미 completed 상태인 옛 행이 하나 더 있어도 그 행은 안 건드리는지
+    (gate_id만으로 뭉개면 다른 행까지 오염되는 결함을 잡는다)."""
     from unittest.mock import AsyncMock, patch
     import app.services.threads_publish as tp
     from app.main import app
@@ -594,7 +597,9 @@ async def test_resubmit_schedule_change_after_approval_triggers_reapproval_and_v
             # 계약) — 이건 사람이 방금 명시적으로 재상신한 경로라 False로 복귀하는 게
             # 기존 설계 그대로(submit_channel_post_draft 재상신은 항상 False로 리셋).
             assert gate.reapproval_required is False
-            assert gate.sealed_scheduled_at is not None
+            # 페드루 리뷰 nit K — "not None"만으론 값 자체가 새 요청(scheduled_at_2)로
+            # 갱신됐는지 증명 못 한다(옛 값이 그대로 남아도 통과). 정확한 값 대조.
+            assert gate.sealed_scheduled_at == scheduled_at_2
 
             voided = (await s.execute(
                 select(PublicationCommand).where(PublicationCommand.id == pending_command_id)
@@ -857,8 +862,12 @@ async def test_cron_rate_limited_uses_retry_after_value_not_default_backoff():
             cmd_id = cmd.id
 
         # get_publishing_limit이 quota_usage>=quota_total로 보이게 해 ChannelRateLimitedError
-        # 를 유도(reset_at 확정값으로 — quota_duration=120초).
-        with patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(250, 250, 120))):
+        # 를 유도(reset_at 확정값으로 — quota_duration=300초). 페드루 리뷰 블로커D —
+        # 원래 120초는 attempt_count=1의 기본 백오프(60*2^1=120)와 **같은 값**이라
+        # 헤더를 무시해도 이 테스트가 통과했다(우연히 안 틀릴 수 없는 값). 기본
+        # 백오프 어느 attempt_count와도 안 겹치는 300초로 바꿔 헤더가 실제로 읽혔을
+        # 때만 통과하게 한다.
+        with patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(250, 250, 300))):
             async with Session() as s:
                 await process_due_publication_commands(s, now=now)
 
@@ -867,9 +876,9 @@ async def test_cron_rate_limited_uses_retry_after_value_not_default_backoff():
             from sqlalchemy import select
             cmd = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
             assert cmd.failure_kind == "transient"
-            expected = now + timedelta(seconds=120)
+            expected = now + timedelta(seconds=300)
             delta = abs((cmd.next_attempt_at - expected).total_seconds())
-            assert delta < 5, f"next_attempt_at이 Retry-After(120s) 값을 안 썼다: {cmd.next_attempt_at} vs {expected}"
+            assert delta < 5, f"next_attempt_at이 Retry-After(300s) 값을 안 썼다: {cmd.next_attempt_at} vs {expected}"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -1101,6 +1110,351 @@ async def test_retry_non_dead_letter_command_returns_404():
         async with _client_for(app) as client:
             r = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/publication-commands/{cmd_id}/retry")
         assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_batch_claim_holds_lock_until_whole_batch_marked_in_progress_no_double_processing():
+    """페드루 리뷰 블로커A — 겹친 두 tick이 같은 배치의 뒷 순번 행을 이중 처리하지
+    않는지, 실제 두 세션의 동시 호출로 검증한다(순차 호출로는 이 결함이 재현되지
+    않는다 — 첫 tick이 완전히 끝난 뒤 둘째 tick이 시작되면 첫 tick이 이미 다 처리해
+    버려 겹칠 여지가 없다).
+
+    시나리오: 배치에 cmd_1(먼저 처리됨)·cmd_2(나중 처리됨) 두 건. tick_a가 cmd_1을
+    처리·commit한 직후 — 배치 클레임이 통짜 commit으로 이미 끝났다면 이 시점에 cmd_2는
+    이미 DB에 in_progress로 박혀 있다 — 바로 그 순간 tick_b를 동시에 돌린다. 클레임이
+    건별 commit이던 원래 구조라면 cmd_1의 per-item commit이 트랜잭션을 끝내며 cmd_2의
+    락도 함께 풀려버려(cmd_2는 아직 손 안 댄 채 'pending'), tick_b가 cmd_2를 마저 집어
+    이중 처리한다."""
+    from unittest.mock import AsyncMock, patch
+    import asyncio
+    import app.services.threads_publish as tp
+    import app.services.publication_command as pc_module
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_1 = await _seed_story(s, org_id, project_id, title="배치1")
+            story_2 = await _seed_story(s, org_id, project_id, title="배치2")
+            draft_1, gate_1 = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_1,
+                text="배치1 본문", scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+            draft_2, gate_2 = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_2,
+                text="배치2 본문", scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+
+            async def _version_id_for(draft_id):
+                return (await s.execute(
+                    select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+                )).scalar_one()
+
+            # created_at을 명시적으로 벌려 order_by(created_at.asc())가 cmd_1을 먼저
+            # 집도록 고정한다(사람 눈에도 결정적인 순서로 재현 가능하게).
+            cmd_1 = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_1, destination=connection_id,
+                approved_version=await _version_id_for(draft_1), operation="publish",
+                scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+                created_at=now - timedelta(seconds=2),
+            )
+            cmd_2 = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_2, destination=connection_id,
+                approved_version=await _version_id_for(draft_2), operation="publish",
+                scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+                created_at=now - timedelta(seconds=1),
+            )
+            s.add_all([cmd_1, cmd_2])
+            await s.commit()
+            cmd_1_id, cmd_2_id = cmd_1.id, cmd_2.id
+
+        cmd2_about_to_process = asyncio.Event()
+        release_tick_b_result = asyncio.Event()
+        process_calls: list[uuid.UUID] = []
+        real_process_one = pc_module._process_one_command
+        paused_once = False
+
+        async def _tracking_process_one(db, command, *, now):
+            nonlocal paused_once
+            if command.id == cmd_2_id and not paused_once:
+                paused_once = True
+                cmd2_about_to_process.set()
+                await asyncio.wait_for(release_tick_b_result.wait(), timeout=10)
+            process_calls.append(command.id)
+            await real_process_one(db, command, now=now)
+
+        async def _tick_a():
+            async with Session() as s:
+                return await pc_module.process_due_publication_commands(s, now=now)
+
+        async def _tick_b():
+            await asyncio.wait_for(cmd2_about_to_process.wait(), timeout=10)
+            async with Session() as s:
+                result = await pc_module.process_due_publication_commands(s, now=now)
+            release_tick_b_result.set()
+            return result
+
+        with (
+            patch.object(tp, "create_container", AsyncMock(return_value="creation-batch")),
+            patch.object(tp, "publish_container", AsyncMock(return_value="media-batch")),
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "get_permalink", AsyncMock(return_value="https://www.threads.net/@demo/post/media-batch")),
+            patch.object(pc_module, "_process_one_command", _tracking_process_one),
+        ):
+            await asyncio.wait_for(asyncio.gather(_tick_a(), _tick_b()), timeout=20)
+
+        assert process_calls.count(cmd_2_id) == 1, (
+            f"cmd_2가 겹친 tick에 이중 처리됐다(배치 클레임 commit이 건별로 쪼개져 있었다는 뜻): {process_calls}"
+        )
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd_1_row = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_1_id))).scalar_one()
+            cmd_2_row = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_2_id))).scalar_one()
+            assert cmd_1_row.status == "completed"
+            assert cmd_2_row.status == "completed"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_deterministic_failure_goes_straight_to_dead_letter_no_auto_retry():
+    """페드루 리뷰 블로커C — 결정적 실패(매핑표 밖 error_code라 fail-closed로
+    needs_check로 떨어진 것들 포함)는 transient처럼 지수 백오프 재시도 큐에 들어가지
+    않고 즉시 dead_letter로 멈춘다(자동 재시도 0회 — attempt_count는 1에서 멈춘다).
+    양성대조: 두 번째 cron tick을 더 돌려도 재시도 시도조차 없어야 한다(next_attempt_at
+    이 애초에 None이라 WHERE절에서 안 잡히는지)."""
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from app.models.gate import Gate
+            from sqlalchemy import select
+
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=version_id, operation="publish",
+                scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+            )
+            s.add(cmd)
+            # 결정적 실패 유도 — 게이트가 승인 상태를 잃었다(void_pending_commands_for_gate
+            # 훅이 보통 이 경합을 선점하지만, 놓친 경우를 워커가 마지막으로 만나는
+            # 시나리오를 직접 DB 조작으로 재현한다). publish_channel_post_draft가 자체
+            # 재검증에서 ExternalPublishGateNotApprovedError를 던진다 — 그 error_code
+            # (EXTERNAL_PUBLISH_APPROVAL_REQUIRED)는 매핑표 밖이라 needs_check.
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            gate.status = "pending"
+            await s.commit()
+            cmd_id = cmd.id
+
+        async with Session() as s:
+            await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd_row = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd_row.status == "dead_letter"
+            assert cmd_row.failure_kind == "needs_check"
+            assert cmd_row.attempt_count == 1
+            assert cmd_row.dead_letter_at is not None
+            assert cmd_row.next_attempt_at is None
+
+        # 양성대조 — 두 번째 tick을 더 돌려도(자동으로는) 아무 것도 안 바뀐다.
+        async with Session() as s:
+            await process_due_publication_commands(s, now=now + timedelta(hours=1))
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd_row = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd_row.status == "dead_letter", "결정적 실패가 두 번째 tick에서 조용히 재시도됐다"
+            assert cmd_row.attempt_count == 1
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_retry_endpoint_accepts_blocked_command_then_next_cron_tick_reprocesses():
+    """페드루 리뷰 블로커B — dead_letter만 받던 수동 재시도가 blocked(연결 복구 대기)도
+    받는지, 카디르 QA⑤와 동형으로 status만 바뀌는 게 아니라 다음 cron tick이 실제로
+    재처리하는지까지 본다(토큰 재인증 등으로 연결이 복구됐다고 가정한 시나리오)."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=version_id, operation="publish",
+                scheduled_at=now - timedelta(hours=1), status="blocked", failure_kind="connection",
+                last_error="token expired(seed)", attempt_count=1, requested_by_member_id=agent_id,
+            )
+            s.add(cmd)
+            await s.commit()
+            cmd_id = cmd.id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_retry = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/publication-commands/{cmd_id}/retry",
+            )
+            assert r_retry.status_code == 200, r_retry.text
+            body = r_retry.json().get("data") or r_retry.json()
+            assert body["status"] == "pending"
+
+        with (
+            patch.object(tp, "create_container", AsyncMock(return_value="creation-z")),
+            patch.object(tp, "publish_container", AsyncMock(return_value="media-z")),
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "get_permalink", AsyncMock(return_value="https://www.threads.net/@demo/post/media-z")),
+        ):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=datetime.now(timezone.utc))
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd_row = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd_row.status == "completed", "retry 뒤 status만 pending이 됐을 뿐 다음 cron tick에서 실제로 재처리되지 않았다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_immediate_rate_limited_returns_retry_after_header_and_command_state():
+    """페드루 리뷰 블로커E·F — 즉시 발행이 429(quota)로 실패하면 응답에 Retry-After
+    헤더(실값)가 실리고, body(error 객체)에도 command_status·next_attempt_at이 함께
+    나가 사람이 "언제 자동 재시도되는지" 알 수 있는지."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app as _app
+        _setup_org_scoped_app(_app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(_app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+
+        with patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(250, 250, 300))):
+            _setup_org_scoped_app(_app, Session, org_id, user_id=human_id)
+            async with _client_for(_app) as client:
+                r_pub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+
+        assert r_pub.status_code == 429, r_pub.text
+        assert r_pub.headers.get("retry-after") == "300", dict(r_pub.headers)
+        body = r_pub.json()
+        error = body.get("error") or body
+        assert error["command_status"] == "pending"
+        assert error["next_attempt_at"] is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_retry_command_endpoint_agent_caller_forbidden():
+    """페드루 리뷰 nit L — 발행 엔드포인트처럼 retry도 human-only(_require_human)인지
+    에이전트 키 호출로 확인(기존엔 발행 human-only 테스트만 있고 retry는 없었다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=uuid.uuid4(), destination=uuid.uuid4(),
+                approved_version=uuid.uuid4(), operation="publish", status="dead_letter",
+                requested_by_member_id=uuid.uuid4(),
+            )
+            s.add(cmd)
+            await s.commit()
+            cmd_id = cmd.id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/publication-commands/{cmd_id}/retry")
+        assert r.status_code == 403, r.text
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_3414_publication_command.py
+++ b/backend/tests/test_3414_publication_command.py
@@ -1,0 +1,1144 @@
+"""story #3414(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04) — 발행 명령·예약 스케줄러.
+
+블루프린트 v3 §3 「발행 명령」·「예약 스케줄러」·「서버 발행 워커」 구현. PO 確定 (B):
+재승인 판정 지점은 `submit_channel_post_draft` 하나(본문 해시 또는 scheduled_at 중
+하나라도 봉인값과 다르면 재승인). 즉시 발행=scheduled_at 없음인 같은 명령(같은
+`/publish` 엔드포인트가 둘 다 처리).
+
+카디르 QA(스토리 본문 6항) 반영:
+① 멱등키 동시성 — 진짜 동시 HTTP 요청(순차 아님)으로 검증.
+② scheduled_at 경계 — sleep 대신 과거/미래 행을 심고 cron 1회 호출로 대조.
+③ voided — 같은 gate에 completed 행+pending 행을 같이 심어 pending만 voided되는지.
+④ Retry-After — 기본 백오프와 다른 값으로 헤더가 실제로 반영됐는지.
+⑤ dead_letter 수동재시도 — retry 뒤 cron을 한 번 더 돌려 실제 재처리되는지.
+⑥ 즉시발행 순서 — 재검증 실패 시 command 행 자체가 안 생기는지."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Publication Command Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="담롱"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_human(session, org_id, *, role="member"):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="채널 포스트"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_default_role(session, org_id):
+    from app.models.participation import ParticipationRole
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+    session.add(role)
+    await session.commit()
+    return role.id
+
+
+async def _seed_connection(session, org_id, *, channel="threads", status="active", account_id=None, token="plain-access-token"):
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    conn = ChannelConnection(
+        id=uuid.uuid4(), org_id=org_id, channel=channel,
+        account_id=account_id or f"acct-{uuid.uuid4().hex[:8]}", status=status,
+        credential_kind="oauth", refresh_mode="reissue_from_access_token",
+        encrypted_access_token=encrypt_channel_credential(token) if status == "active" else None,
+    )
+    session.add(conn)
+    await session.commit()
+    return conn.id
+
+
+async def _approve_gate_directly(session, gate_id):
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    gate = (await session.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+    gate.status = "approved"
+    gate.resolver_id = uuid.uuid4()
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.commit()
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id, agent: bool = False):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if agent:
+            claims["app_metadata"]["api_key_id"] = "test-agent-key"
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _draft_body(*, work_item_id, connection_id, text="채널 포스트 본문입니다."):
+    return {"work_item_id": str(work_item_id), "connection_id": str(connection_id), "text": text}
+
+
+async def _create_draft_submit_approve(
+    client, session, *, org_id, connection_id, story_id, text="채널 포스트 본문입니다.",
+    scheduled_at: datetime | None = None,
+):
+    r_draft = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+        json=_draft_body(work_item_id=story_id, connection_id=connection_id, text=text),
+    )
+    assert r_draft.status_code == 201, r_draft.text
+    draft_id = r_draft.json()["draft_id"]
+    submit_body = {}
+    if scheduled_at is not None:
+        submit_body["scheduled_at"] = scheduled_at.isoformat()
+    r_submit = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json=submit_body,
+    )
+    assert r_submit.status_code == 200, r_submit.text
+    gate_id = uuid.UUID(r_submit.json()["gate_id"])
+    await _approve_gate_directly(session, gate_id)
+    return draft_id, gate_id
+
+
+# --- AC1/AC2 — 봉인+명령 생성 -------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_submit_with_scheduled_at_seals_it_and_publish_returns_scheduled_command():
+    """AC1·AC2 — scheduled_at을 실어 상신하면 gate.sealed_scheduled_at에 봉인되고,
+    승인 뒤 발행 요청은 command만 만들고 Threads는 안 부른다."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    scheduled_at = datetime.now(timezone.utc) + timedelta(days=1)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=scheduled_at,
+            )
+
+        with (
+            patch.object(tp, "create_container", AsyncMock()) as mock_create,
+            patch.object(tp, "publish_container", AsyncMock()) as mock_publish,
+        ):
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client:
+                r = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+            assert r.status_code == 200, r.text
+            body = r.json()["data"] if "data" in r.json() else r.json()
+            assert body["scheduled"] is True
+            assert body["command_id"] is not None
+            assert body["scheduled_at"] is not None
+            mock_create.assert_not_called()
+            mock_publish.assert_not_called()
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from sqlalchemy import select
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert gate.sealed_scheduled_at is not None
+
+            from app.models.publication_command import PublicationCommand
+            cmd = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.gate_id == gate_id)
+            )).scalar_one()
+            assert cmd.status == "pending"
+            assert cmd.scheduled_at is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_immediate_no_scheduled_at_completes_synchronously_and_marks_command_completed():
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+
+        with (
+            patch.object(tp, "create_container", AsyncMock(return_value="creation-1")),
+            patch.object(tp, "publish_container", AsyncMock(return_value="media-1")),
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "get_permalink", AsyncMock(return_value="https://www.threads.net/@demo/post/media-1")),
+        ):
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client:
+                r = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+            assert r.status_code == 200, r.text
+            body = r.json()["data"] if "data" in r.json() else r.json()
+            assert body["scheduled"] is False
+            assert body["permalink"] == "https://www.threads.net/@demo/post/media-1"
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.gate_id == gate_id)
+            )).scalar_one()
+            assert cmd.status == "completed"
+            assert cmd.scheduled_at is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_denied_when_gate_not_approved_creates_no_orphan_command():
+    """카디르 QA⑥ — 재검증 실패(게이트 미승인)로 요청이 거부되면 command 행 자체가
+    안 생겨야 한다(고아 pending 행이 남아 워커가 엉뚱하게 재시도하는 것을 방지)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id),
+            )
+            draft_id = r_draft.json()["draft_id"]
+            r_submit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+            )
+            assert r_submit.status_code == 200, r_submit.text
+            # 승인 안 함 — pending 그대로.
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+        assert r.status_code == 403, r.text
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            rows = (await s.execute(select(PublicationCommand))).scalars().all()
+            assert len(rows) == 0, "게이트 미승인으로 거부됐는데 command 행이 생겼다(고아 행)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_immediate_idempotent_no_duplicate_command_sequential():
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+
+        with (
+            patch.object(tp, "create_container", AsyncMock(return_value="creation-1")),
+            patch.object(tp, "publish_container", AsyncMock(return_value="media-1")),
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "get_permalink", AsyncMock(return_value="https://www.threads.net/@demo/post/media-1")),
+        ):
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client:
+                r1 = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+                assert r1.status_code == 200, r1.text
+                r2 = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+                assert r2.status_code == 200, r2.text
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            rows = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.gate_id == gate_id)
+            )).scalars().all()
+            assert len(rows) == 1, "같은 (org,destination,approved_version,operation) 재요청이 새 행을 만들었다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_immediate_true_concurrent_requests_single_command_row():
+    """카디르 QA① — 순차 호출이 아니라 진짜 동시 두 요청(asyncio.gather)으로 검증한다.
+    story #3395(PR#3757)와 동형 클래스(UNIQUE 위반 500 위험) — SAVEPOINT+재조회 방어가
+    실제로 동작하는지. #3757의 barrier 기법 그대로 재사용 — asyncio.Event로 두 요청을
+    `resolve_command_target` 반환 직전(=command upsert 직전 지점)에서 강제로 겹치게
+    한다. 이게 없으면 로컬 실행 순서가 우연히 순차가 돼 버려 레이스 자체가 재현 안 될
+    수 있다(실측: barrier 없이 먼저 시도했을 때 실제로 재현이 안 됐다)."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+    import app.services.channel_posts as channel_posts_service
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+
+        arrived = asyncio.Event()
+        arrived_count = 0
+        real_resolve_command_target = channel_posts_service.resolve_command_target
+
+        async def _barrier_resolve_command_target(*args, **kwargs):
+            nonlocal arrived_count
+            result = await real_resolve_command_target(*args, **kwargs)
+            arrived_count += 1
+            if arrived_count >= 2:
+                arrived.set()
+            await arrived.wait()  # 둘 다 여기 도착해야 통과 — upsert 직전 지점을 겹치게 한다.
+            return result
+
+        with (
+            patch.object(channel_posts_service, "resolve_command_target", side_effect=_barrier_resolve_command_target),
+            patch.object(tp, "create_container", AsyncMock(return_value="creation-1")),
+            patch.object(tp, "publish_container", AsyncMock(return_value="media-1")),
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "get_permalink", AsyncMock(return_value="https://www.threads.net/@demo/post/media-1")),
+        ):
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client_a, _client_for(app) as client_b:
+                r_a, r_b = await asyncio.gather(
+                    client_a.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish"),
+                    client_b.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish"),
+                )
+            assert r_a.status_code == 200, r_a.text
+            assert r_b.status_code == 200, r_b.text
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            rows = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.gate_id == gate_id)
+            )).scalars().all()
+            assert len(rows) == 1, "진짜 동시 요청 2건이 publication_commands에 서로 다른 행을 만들었다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# --- 재승인 판정(PO 確定 B) — submit_channel_post_draft 단일 지점 -------------------
+
+
+@pytest.mark.anyio
+async def test_resubmit_identical_content_and_schedule_is_noop():
+    from app.main import app
+
+    scheduled_at = datetime.now(timezone.utc) + timedelta(days=1)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=scheduled_at,
+            )
+            r_resubmit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit",
+                json={"scheduled_at": scheduled_at.isoformat()},
+            )
+            assert r_resubmit.status_code == 200, r_resubmit.text
+
+            from app.models.gate import Gate
+            from sqlalchemy import select
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert gate.status == "approved", "무변경 재상신이 승인을 되돌렸다(no-op이어야 함)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resubmit_schedule_change_after_approval_triggers_reapproval_and_voids_only_pending_command():
+    """PO 정정3 (B) + 카디르 QA③ — 본문은 그대로, scheduled_at만 바뀐 재상신도 승인을
+    되돌리고(reapproval_required=True) 대기 중 command를 voided(SCHEDULE_CHANGED)로
+    무효화한다. 양성대조: 같은 gate에 이미 completed 상태인 옛 행이 하나 더 있어도
+    그 행은 안 건드리는지(gate_id만으로 뭉개면 다른 행까지 오염되는 결함을 잡는다)."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    scheduled_at_1 = datetime.now(timezone.utc) + timedelta(days=1)
+    scheduled_at_2 = datetime.now(timezone.utc) + timedelta(days=2)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=scheduled_at_1,
+            )
+
+        # 양성대조 표본 — 같은 gate에 이미 종결된(completed) command 행 하나를 직접 심는다
+        # (다른 approved_version — UNIQUE 키가 달라야 별개 행으로 들어간다).
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            old_completed = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=uuid.uuid4(), operation="publish", scheduled_at=None,
+                status="completed", requested_by_member_id=uuid.uuid4(),
+            )
+            s.add(old_completed)
+            await s.commit()
+            old_completed_id = old_completed.id
+
+        # scheduled_at_1로 예약 발행 요청 — pending command 1건 생성.
+        with (
+            patch.object(tp, "create_container", AsyncMock()),
+            patch.object(tp, "publish_container", AsyncMock()),
+        ):
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client:
+                r_pub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+                assert r_pub.status_code == 200, r_pub.text
+                pending_command_id = uuid.UUID((r_pub.json().get("data") or r_pub.json())["command_id"])
+
+        # 본문은 그대로, scheduled_at만 바꿔 재상신 — 재승인 트리거돼야 한다.
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_resubmit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit",
+                json={"scheduled_at": scheduled_at_2.isoformat()},
+            )
+            assert r_resubmit.status_code == 200, r_resubmit.text
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            assert gate.status == "pending"
+            # reapproval_required는 "시스템이 조용히 되돌렸다"는 신호(Gate 모델 문서화된
+            # 계약) — 이건 사람이 방금 명시적으로 재상신한 경로라 False로 복귀하는 게
+            # 기존 설계 그대로(submit_channel_post_draft 재상신은 항상 False로 리셋).
+            assert gate.reapproval_required is False
+            assert gate.sealed_scheduled_at is not None
+
+            voided = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.id == pending_command_id)
+            )).scalar_one()
+            assert voided.status == "voided"
+            assert voided.reason_code == "SCHEDULE_CHANGED"
+
+            # 양성대조 — 옛 completed 행은 절대 안 건드려졌는지.
+            untouched = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.id == old_completed_id)
+            )).scalar_one()
+            assert untouched.status == "completed", "gate_id만으로 뭉개져 종결된 다른 행까지 오염됐다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resubmit_content_change_after_approval_voids_with_content_changed_reason():
+    """새 draft 버전(본문 편집)이 approved→pending을 되돌리는 조용한 경로
+    (_reseal_gate_on_new_version)도 대기 중 command를 voided(CONTENT_CHANGED)로
+    무효화하는지."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(days=1),
+            )
+
+        with (
+            patch.object(tp, "create_container", AsyncMock()),
+            patch.object(tp, "publish_container", AsyncMock()),
+        ):
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client:
+                r_pub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+                assert r_pub.status_code == 200, r_pub.text
+                pending_command_id = uuid.UUID((r_pub.json().get("data") or r_pub.json())["command_id"])
+
+        # 본문 편집(새 버전) — 명시적 재상신 없이 _reseal_gate_on_new_version 훅만 탄다.
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r_edit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(work_item_id=story_id, connection_id=connection_id, text="수정된 본문입니다."),
+            )
+            assert r_edit.status_code == 201, r_edit.text
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            voided = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.id == pending_command_id)
+            )).scalar_one()
+            assert voided.status == "voided"
+            assert voided.reason_code == "CONTENT_CHANGED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# --- cron 워커(AC3) — 카디르 QA② 비-sleep 시각경계 ----------------------------------
+
+
+@pytest.mark.anyio
+async def test_cron_claims_only_due_scheduled_commands_not_future_ones():
+    """카디르 QA② — sleep 대신 과거/미래로 정확히 고정한 두 행을 심고 cron을 그 자리에서
+    1회 호출해 대조한다."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_past = await _seed_story(s, org_id, project_id, title="과거분")
+            story_future = await _seed_story(s, org_id, project_id, title="미래분")
+            draft_past, gate_past = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_past,
+                text="과거 예약", scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+            draft_future, gate_future = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_future,
+                text="미래 예약", scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+
+            async def _version_id_for(draft_id):
+                return (await s.execute(
+                    select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+                )).scalar_one()
+
+            past_cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_past, destination=connection_id,
+                approved_version=await _version_id_for(draft_past), operation="publish",
+                scheduled_at=now - timedelta(hours=1), status="pending", requested_by_member_id=agent_id,
+            )
+            future_cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_future, destination=connection_id,
+                approved_version=await _version_id_for(draft_future), operation="publish",
+                scheduled_at=now + timedelta(hours=1), status="pending", requested_by_member_id=agent_id,
+            )
+            s.add_all([past_cmd, future_cmd])
+            await s.commit()
+            past_cmd_id, future_cmd_id = past_cmd.id, future_cmd.id
+
+        with (
+            patch.object(tp, "create_container", AsyncMock(return_value="creation-x")),
+            patch.object(tp, "publish_container", AsyncMock(return_value="media-x")),
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "get_permalink", AsyncMock(return_value="https://www.threads.net/@demo/post/media-x")),
+        ):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            past = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == past_cmd_id))).scalar_one()
+            future = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == future_cmd_id))).scalar_one()
+            assert past.status == "completed", "도래한(과거) scheduled_at 행을 cron이 안 집었다"
+            assert future.status == "pending", "미도래(미래) scheduled_at 행을 cron이 잘못 집었다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_retryable_failure_backs_off_with_attempt_count():
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=version_id, operation="publish",
+                scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+            )
+            s.add(cmd)
+            await s.commit()
+            cmd_id = cmd.id
+
+        from app.services.threads_publish import ThreadsPublishError
+        with (
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "create_container", AsyncMock(side_effect=ThreadsPublishError(
+                status_code=500, code="SERVER_ERROR", message="boom",
+            ))),
+        ):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd.status == "pending"
+            assert cmd.attempt_count == 1
+            assert cmd.failure_kind == "transient"
+            assert cmd.next_attempt_at is not None
+            assert cmd.next_attempt_at > now
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_rate_limited_uses_retry_after_value_not_default_backoff():
+    """카디르 QA④ — 기본 백오프와 다른 값(Retry-After: 120)을 mock에 실어, next_attempt_at
+    이 그 값(now+120s, 허용오차 수 초)인지 계산한다. "미래인지"만 보면 헤더 무시해도
+    통과하므로 정확한 값을 assert한다."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=version_id, operation="publish",
+                scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+            )
+            s.add(cmd)
+            await s.commit()
+            cmd_id = cmd.id
+
+        # get_publishing_limit이 quota_usage>=quota_total로 보이게 해 ChannelRateLimitedError
+        # 를 유도(reset_at 확정값으로 — quota_duration=120초).
+        with patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(250, 250, 120))):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd.failure_kind == "transient"
+            expected = now + timedelta(seconds=120)
+            delta = abs((cmd.next_attempt_at - expected).total_seconds())
+            assert delta < 5, f"next_attempt_at이 Retry-After(120s) 값을 안 썼다: {cmd.next_attempt_at} vs {expected}"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_max_retries_reaches_dead_letter():
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.services.publication_command import MAX_RETRIES, process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=version_id, operation="publish",
+                scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+                attempt_count=MAX_RETRIES - 1,
+            )
+            s.add(cmd)
+            await s.commit()
+            cmd_id = cmd.id
+
+        from app.services.threads_publish import ThreadsPublishError
+        with (
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "create_container", AsyncMock(side_effect=ThreadsPublishError(
+                status_code=500, code="SERVER_ERROR", message="boom",
+            ))),
+        ):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd.status == "dead_letter"
+            assert cmd.dead_letter_at is not None
+            assert cmd.next_attempt_at is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_token_expired_blocks_command_and_escalates_connection_status():
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=version_id, operation="publish",
+                scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+            )
+            s.add(cmd)
+            await s.commit()
+            cmd_id = cmd.id
+
+        from app.services.threads_publish import ThreadsPublishError
+        with (
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "create_container", AsyncMock(side_effect=ThreadsPublishError(
+                status_code=401, code="TOKEN_EXPIRED", message="expired token",
+            ))),
+        ):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=now)
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_connection import ChannelConnection
+            from sqlalchemy import select
+            cmd = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd.status == "blocked"
+            assert cmd.failure_kind == "connection"
+            conn = (await s.execute(select(ChannelConnection).where(ChannelConnection.id == connection_id))).scalar_one()
+            assert conn.status == "expired"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_dead_letter_retry_endpoint_then_next_cron_tick_reprocesses():
+    """카디르 QA⑤ — retry 뒤 status만 확인하고 끝내지 않는다. 그 다음 cron tick을
+    실제로 한 번 더 돌려서 진짜 재처리되는지까지 본다(next_attempt_at이 안 풀리는
+    결함을 잡는다)."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            connection_id = await _seed_connection(s, org_id)
+
+        from app.main import app
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            story_id = await _seed_story(s, org_id, project_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=version_id, operation="publish",
+                scheduled_at=now - timedelta(hours=1), status="dead_letter",
+                dead_letter_at=now - timedelta(minutes=10), next_attempt_at=now + timedelta(hours=999),
+                attempt_count=5, requested_by_member_id=agent_id,
+            )
+            s.add(cmd)
+            await s.commit()
+            cmd_id = cmd.id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_retry = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/publication-commands/{cmd_id}/retry",
+            )
+            assert r_retry.status_code == 200, r_retry.text
+            body = r_retry.json().get("data") or r_retry.json()
+            assert body["status"] == "pending"
+
+        with (
+            patch.object(tp, "create_container", AsyncMock(return_value="creation-y")),
+            patch.object(tp, "publish_container", AsyncMock(return_value="media-y")),
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "get_permalink", AsyncMock(return_value="https://www.threads.net/@demo/post/media-y")),
+        ):
+            async with Session() as s:
+                await process_due_publication_commands(s, now=datetime.now(timezone.utc))
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd.status == "completed", "retry 뒤 status만 pending이 됐을 뿐 다음 cron tick에서 실제로 재처리되지 않았다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_retry_non_dead_letter_command_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="owner")
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=uuid.uuid4(), destination=uuid.uuid4(),
+                approved_version=uuid.uuid4(), operation="publish", status="completed",
+                requested_by_member_id=uuid.uuid4(),
+            )
+            s.add(cmd)
+            await s.commit()
+            cmd_id = cmd.id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/publication-commands/{cmd_id}/retry")
+        assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cron_endpoint_requires_cron_secret(monkeypatch):
+    """기존 cron.py 다른 엔드포인트와 동일 가드(CRON_SECRET Bearer) 재사용 확認 — DB
+    세션(`get_worker_db`)까지 스캐폴딩(override_db_and_read가 안 거는 별도 dependency
+    key)해서 진짜로 verify_cron()이 거부하는지 본다(연결 실패로 500이 나면 이 테스트가
+    실제로 뭘 검증했는지 알 수 없다)."""
+    import app.routers.cron as cron_module
+    from app.dependencies.database import get_worker_db
+    from app.main import app
+    from httpx import AsyncClient, ASGITransport
+
+    monkeypatch.setattr(cron_module, "CRON_SECRET", "test-cron-secret")
+
+    engine, Session = await _session_factory()
+    try:
+        async def _worker_db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_worker_db] = _worker_db
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r_no_auth = await client.post("/api/v2/internal/cron/publication-commands")
+            assert r_no_auth.status_code == 401, r_no_auth.text
+            r_wrong_auth = await client.post(
+                "/api/v2/internal/cron/publication-commands",
+                headers={"Authorization": "Bearer wrong-secret"},
+            )
+            assert r_wrong_auth.status_code == 401, r_wrong_auth.text
+            r_right_auth = await client.post(
+                "/api/v2/internal/cron/publication-commands",
+                headers={"Authorization": "Bearer test-cron-secret"},
+            )
+            assert r_right_auth.status_code == 200, r_right_auth.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -850,6 +850,10 @@
     {
       "file": "tests/test_3411_channel_post_text_preview.py",
       "sec": 6.0
+    },
+    {
+      "file": "tests/test_3414_publication_command.py",
+      "sec": 18.0
     }
   ]
 }

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,6 @@
 {
   "_snapshot_policy": "story #3383(2026-09-03) — 로컬 재측정(템플릿 DB 적용 후). 로컬 절대시간은 CI의 ~1/6이지만(실측), 파일 간 상대 비중은 LPT 배분에 유효하다. 재측정 기준은 이전과 동일: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐.",
-  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held",
+  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)",
   "measured_at": "2026-09-03",
   "files": [
     {
@@ -853,7 +853,7 @@
     },
     {
       "file": "tests/test_3414_publication_command.py",
-      "sec": 18.0
+      "sec": 25.9
     }
   ]
 }


### PR DESCRIPTION
[SID:3414]

## 배경
블루프린트 v3 §3(발행 명령·예약 스케줄러·서버 발행 워커). PO 세션 중 3회 방향 정정을 거쳐 최종 확定된 설계 — 스토리 본문(#3414)에 전체 논의 경과가 남아 있음.

## 핵심 설계
- **명령 생성 트리거 = 발행/예약 요청**(PO 確定 (B), 승인 자체는 트리거 아님). `POST .../publish` 하나가 즉시·예약 둘 다 처리 — `scheduled_at`이 게이트에 봉인돼 있으면(null=즉시) 그 값을 그대로 command에 옮긴다.
- `scheduled_at`은 게이트 봉인 범위(`Gate.sealed_scheduled_at` 신규 컬럼, 다른 gate_type엔 항상 null). 재승인 판정 지점은 `submit_channel_post_draft` 하나 — 본문 해시 또는 scheduled_at 중 하나라도 다르면 재승인.
- 승인 뒤 편집/재예약 두 경로 모두 대기 중 command를 즉시 `voided`(reason_code 포함)로 무효화.
- cron 워커는 기존 `publish_channel_post_draft()`를 그대로 호출(3중 재검증 재구현 금지). SKIP LOCKED 배치, `failure_kind`(connection/needs_check/transient, 유나 design §11-5) 분류, connection 실패는 연결 상태 승격+blocked, 그 외는 지수 백오프+dead_letter+수동 재시도.
- command upsert는 3중 재검증 **뒤**(고아 pending 행 방지). 진짜 동시 요청은 SAVEPOINT+재조회(story #3395/PR#3757과 동형).

## 검증
- 신규 테스트 16건(카디르 QA 6항 전부 반영 — 실제 asyncio.Event barrier 동시성, sleep 없는 시각경계, voided 정밀 타깃, Retry-After 실값, dead_letter end-to-end 재처리, 즉시발행 고아 command 방지).
- 기존 회귀 87/87 green(#3374/#3394/#3403/#3404/#f8f7cb0f/#3411).
- mutation self-check 2건(voided 범위 필터·SAVEPOINT 가드 각각 제거 → 정확히 대상 테스트 RED, 원복 후 재확인).
- Alembic 마이그레이션(0317/0318) fresh DB에 실제 `upgrade head`로 검증(create_all 아님).

## 범위 밖(명시, 후속 스토리)
- `failure_kind`/`next_attempt_at`/`dead_letter_at`의 목록/단건 응답 노출 — 저장은 이 PR, 노출은 #3415(backlog).
- 캘린더 화면/예약 목록 UI — FE, 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm