### PR TITLE
[SID:3418] fix: rate_limit_backend dev를 redis로 배선 + memory 폴백 가시화

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,6 +50,7 @@ async def lifespan(app: FastAPI):
     from app.services.event_broker import check_outbox_dual_publish_config
     from app.services.firebase_verifier import check_mobile_app_check_config
     from app.services.pg_pubsub import check_listen_config, listen_loop
+    from app.services.rate_limiter import warn_if_rate_limit_backend_is_memory
 
     # story c4c72eb1(E-ARCH GCE 이전) PR-A: asyncio.Event는 최초 .wait()/.set() 시점의 실행
     # 루프에 바인딩된다 — 테스트가 TestClient(app)로 lifespan을 여러 번(서로 다른 루프로) 태우는
@@ -86,6 +87,7 @@ async def lifespan(app: FastAPI):
     check_cron_secret_config()  # story #2072: non-local + CRON_SECRET 미설정 fail-closed.
     check_outbox_dual_publish_config()  # story #2138: outbox + dual_publish/dispatch 동시 fail-closed.
     check_mobile_app_check_config()  # 산티아고 §9 finding 1: mobile 발급 on + App Check 미필수 fail-closed.
+    warn_if_rate_limit_backend_is_memory()  # story #3418: 인스턴스 다중+memory=레이트리밋 인스턴스별 분리, 경고만(fail-closed 아님).
     # story bea25062: cutover 존재-캐시는 의도적으로 startup에서 warm 안 함(자체 발견 —
     # TestClient(app)로 lifespan을 태우는 기존 SSE 테스트들이 라우트 전용으로 짜둔 유한한
     # mock db.execute() 순서-큐를 startup 시점의 이 캐시 조회가 몰래 하나 소비해 실패시켰다).

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.dependencies.database import get_db
 from app.services import realtime_readiness
 
@@ -32,11 +33,15 @@ async def health_check(response: Response, db: AsyncSession = Depends(get_db)):
     except Exception as exc:
         db_status = f"error: {type(exc).__name__}"
 
+    # story #3418(AC2) — rate_limit_backend를 이 사람이 보는 표면에 노출한다. 앱은 인스턴스가
+    # 몇 개인지 모르므로 이 값만으로 "여러 인스턴스+memory"를 스스로 판정할 수는 없다(그건
+    # startup 경고, `warn_if_rate_limit_backend_is_memory()`의 몫) — 여기서는 있는 그대로의
+    # 설정값을 실어 사람이 인스턴스 수와 대조할 수 있게만 한다.
     if db_status != "ok":
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
-        return {"status": "error", "version": "v2", "db": db_status}
+        return {"status": "error", "version": "v2", "db": db_status, "rate_limit_backend": settings.rate_limit_backend}
 
-    return {"status": "ok", "version": "v2", "db": db_status}
+    return {"status": "ok", "version": "v2", "db": db_status, "rate_limit_backend": settings.rate_limit_backend}
 
 
 @router.get("/ready")

--- a/backend/app/services/rate_limiter.py
+++ b/backend/app/services/rate_limiter.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import logging
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
+
+logger = logging.getLogger(__name__)
 
 TIER_LIMITS: dict[str, int] = {
     "free": 60,
@@ -85,3 +88,27 @@ def get_rate_limiter() -> RateLimiter:
 
 def hash_api_key(plaintext: str) -> str:
     return hashlib.sha256(plaintext.encode()).hexdigest()
+
+
+def warn_if_rate_limit_backend_is_memory(s=None) -> None:
+    """story #3418 AC2 — 카디르 실측(dev, 2026-09-04): 백엔드 인스턴스가 최소 3개인데
+    `rate_limit_backend` 기본값이 `"memory"`라 `get_rate_limiter()`가 만드는
+    `InMemoryRateLimiter`가 프로세스 로컬 상태다 — beacon dedup(1분 내 재요청 억제)을
+    포함해 이 서비스를 쓰는 모든 레이트리밋이 인스턴스마다 따로 세게 된다(한도가 사실상
+    「인스턴스 수 배」로 느슨해짐).
+
+    ⚠️이 가드가 못 잡는 것(docstring 선언, 카디르 QA 관례) — 앱 프로세스는 자기가 몇 개의
+    인스턴스로 떠 있는지 모른다. 그래서 "정말 여러 인스턴스인데 memory"를 직접 검증하지
+    못하고, "memory인데 로컬이 아니다"(=Cloud Run 등 배포 환경, 통상 min-instances 여러
+    개로 뜬다)까지만 판정한다 — 로컬 단일 프로세스 개발(`is_really_local`)은 그 자체로
+    무해해 조용히 넘긴다."""
+    if s is None:
+        from app.core.config import settings as s
+
+    if s.rate_limit_backend != "redis" and not s.is_really_local:
+        logger.warning(
+            "[startup] rate_limit_backend=%s(기본값) — 인스턴스가 여러 개면 레이트리밋·"
+            "beacon dedup이 인스턴스별로 갈라진다(story #3418, dev 실측 1→2). "
+            "RATE_LIMIT_BACKEND=redis 배선 권장.",
+            s.rate_limit_backend,
+        )

--- a/backend/tests/test_3418_rate_limit_backend.py
+++ b/backend/tests/test_3418_rate_limit_backend.py
@@ -1,0 +1,246 @@
+"""story #3418(카디르 실측 2026-09-04 · 페드루 PO 確定) — 백엔드 인스턴스가 최소 3개인데
+`rate_limit_backend` 기본값이 `"memory"`라 dedup·레이트리밋이 인스턴스마다 따로 세던 결함.
+
+AC4 — `RedisRateLimiter` 경로 단위 테스트(기존엔 없었다, 이 파일이 그 기준선). `get_rate_
+limiter()`의 분기·`InMemoryRateLimiter`의 기존 동작(윈도우 슬라이딩·독립 키)도 같은 파일에서
+커버해 「기존 memory 테스트 불변」의 기준선 자체를 세운다."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import rate_limiter as rl_module
+from app.services.rate_limiter import (
+    WINDOW_SECS,
+    InMemoryRateLimiter,
+    RedisRateLimiter,
+    get_rate_limiter,
+    warn_if_rate_limit_backend_is_memory,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """get_rate_limiter()의 모듈 전역 싱글턴(`_limiter`)이 테스트 간 새 나가지 않게 리셋—
+    안 하면 앞선 테스트가 만든 InMemoryRateLimiter/RedisRateLimiter가 뒤 테스트의 settings
+    변경과 무관하게 그대로 재사용돼(첫 호출만 실제로 분기) 이 파일의 분기 테스트 자체가
+    순서에 취약해진다."""
+    rl_module._limiter = None
+    yield
+    rl_module._limiter = None
+
+
+# --- get_rate_limiter() 분기 ---------------------------------------------------
+
+
+def test_get_rate_limiter_defaults_to_in_memory(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "rate_limit_backend", "memory")
+    assert isinstance(get_rate_limiter(), InMemoryRateLimiter)
+
+
+def test_get_rate_limiter_redis_backend_returns_redis_rate_limiter(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "rate_limit_backend", "redis")
+    monkeypatch.setattr(settings, "redis_url", "redis://fake-host:6379/0")
+
+    class _StubRedisClient:
+        pass
+
+    def _fake_from_url(url, decode_responses=True):
+        assert url == "redis://fake-host:6379/0", "settings.redis_url이 그대로 안 전달됨"
+        return _StubRedisClient()
+
+    import redis.asyncio as aioredis
+
+    monkeypatch.setattr(aioredis, "from_url", _fake_from_url)
+    assert isinstance(get_rate_limiter(), RedisRateLimiter)
+
+
+def test_get_rate_limiter_is_singleton_within_process(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "rate_limit_backend", "memory")
+    a = get_rate_limiter()
+    b = get_rate_limiter()
+    assert a is b, "모듈 전역 싱글턴이 호출마다 새 인스턴스를 만듦(불필요한 상태 유실)"
+
+
+# --- InMemoryRateLimiter --------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_in_memory_allows_up_to_limit_then_blocks():
+    limiter = InMemoryRateLimiter()
+    key = "test-key"
+    results = [await limiter.check(key, 3) for _ in range(4)]
+    assert [r[0] for r in results] == [True, True, True, False]
+
+
+@pytest.mark.anyio
+async def test_in_memory_different_keys_independent():
+    limiter = InMemoryRateLimiter()
+    for _ in range(3):
+        await limiter.check("key-a", 3)
+    allowed, _, _ = await limiter.check("key-b", 3)
+    assert allowed is True
+
+
+# --- RedisRateLimiter(fakeredis) ------------------------------------------------
+
+
+@pytest.fixture
+def _fake_redis_limiter(monkeypatch):
+    """RedisRateLimiter를 fakeredis 백엔드로 왕복시킨다 — SSE lease(test_sse_lease.py)와
+    달리 이 클래스의 명령(zremrangebyscore/zadd/zcard/expire/zrange/zrem)은 순수 ZSET
+    명령뿐이라 Lua EVAL이 필요 없다(lupa 불요, 실측 확認)."""
+    aioredis_fake = pytest.importorskip("fakeredis.aioredis")
+    server = aioredis_fake.FakeServer()
+    client = aioredis_fake.FakeRedis(server=server, decode_responses=True)
+
+    import redis.asyncio as aioredis
+
+    monkeypatch.setattr(aioredis, "from_url", lambda url, decode_responses=True: client)
+    return RedisRateLimiter("redis://fake/0"), client
+
+
+@pytest.mark.anyio
+async def test_redis_limiter_key_format(_fake_redis_limiter):
+    """AC4 — 실제 Redis 키가 `rl:{key}` 형식으로 쌓이는지(운영 조회·TTL 확인이 이 형식에
+    의존한다)."""
+    limiter, client = _fake_redis_limiter
+    await limiter.check("beacon:org1:/p:ua-x", 5)
+    assert await client.keys("rl:*") == ["rl:beacon:org1:/p:ua-x"]
+
+
+@pytest.mark.anyio
+async def test_redis_limiter_sets_ttl_window_plus_5(_fake_redis_limiter):
+    """AC4 — TTL이 WINDOW_SECS+5로 설정되는지(무기한 축적 방지 — story #2461류 「상한 없는
+    누적」 finding과 동일 클래스 재발 방지)."""
+    limiter, client = _fake_redis_limiter
+    await limiter.check("ttl-key", 5)
+    ttl = await client.ttl("rl:ttl-key")
+    assert WINDOW_SECS < ttl <= WINDOW_SECS + 5, f"TTL={ttl}, 기대범위=({WINDOW_SECS}, {WINDOW_SECS + 5}]"
+
+
+@pytest.mark.anyio
+async def test_redis_limiter_allows_up_to_limit_then_blocks(_fake_redis_limiter):
+    limiter, _ = _fake_redis_limiter
+    key = "enforce-key"
+    results = [await limiter.check(key, 3) for _ in range(4)]
+    assert [r[0] for r in results] == [True, True, True, False]
+
+
+@pytest.mark.anyio
+async def test_redis_limiter_different_keys_independent(_fake_redis_limiter):
+    limiter, _ = _fake_redis_limiter
+    for _ in range(3):
+        await limiter.check("key-a", 3)
+    allowed, _, _ = await limiter.check("key-b", 3)
+    assert allowed is True
+
+
+@pytest.mark.anyio
+async def test_redis_limiter_removes_own_entry_when_blocked_no_unbounded_growth(_fake_redis_limiter):
+    """양성대조 — check()가 초과 판정 시 방금 추가한 자기 entry를 zrem으로 되돌리는지.
+    안 그러면 거부된 요청마다 ZSET이 계속 자라 count가 절대 limit 아래로 안 줄어드는
+    결함(뮤테이션: 이 zrem 라인을 지우면 5회 호출 뒤 count가 2가 아니라 5가 돼 RED)."""
+    limiter, client = _fake_redis_limiter
+    key = "no-growth-key"
+    for _ in range(5):
+        await limiter.check(key, 2)
+    assert await client.zcard(f"rl:{key}") == 2
+
+
+# --- warn_if_rate_limit_backend_is_memory() (AC2) -------------------------------
+
+
+def _s(**overrides):
+    base = {"rate_limit_backend": "memory", "is_really_local": True}
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_warn_fires_when_memory_and_not_local(caplog):
+    """AC2 — 배포 환경(로컬 아님)인데 memory면 경고 1줄."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger=rl_module.__name__):
+        warn_if_rate_limit_backend_is_memory(_s(rate_limit_backend="memory", is_really_local=False))
+    assert any("rate_limit_backend" in r.message for r in caplog.records)
+
+
+def test_warn_silent_when_redis(caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger=rl_module.__name__):
+        warn_if_rate_limit_backend_is_memory(_s(rate_limit_backend="redis", is_really_local=False))
+    assert caplog.records == []
+
+
+def test_warn_silent_when_memory_but_truly_local(caplog):
+    """가드가 못 잡는 축(docstring 선언) — 로컬 단일 프로세스는 memory가 그 자체로 무해해
+    조용히 넘긴다(매 로컬 기동마다 경고 스팸 방지)."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger=rl_module.__name__):
+        warn_if_rate_limit_backend_is_memory(_s(rate_limit_backend="memory", is_really_local=True))
+    assert caplog.records == []
+
+
+def test_warn_reads_real_settings_by_default(monkeypatch, caplog):
+    """s=None 기본 인자가 실제 app.core.config.settings를 읽는지(스텁만 통과하고 실제
+    배선은 안 되는 회귀 방지 — check_internal_secret_config 등과 동일 관례).
+
+    `is_really_local`은 읽기전용 프로퍼티(K_SERVICE/PYTEST_CURRENT_TEST/SPRINTABLE_
+    LOCAL_DEV 신호 파생, config.py)라 인스턴스 setattr로는 못 덮는다 — 클래스 속성을
+    통째로 다른 property로 교체(monkeypatch가 테스트 뒤 원복)."""
+    import logging
+
+    from app.core.config import Settings, settings
+
+    monkeypatch.setattr(settings, "rate_limit_backend", "memory")
+    monkeypatch.setattr(Settings, "is_really_local", property(lambda self: False))
+    with caplog.at_level(logging.WARNING, logger=rl_module.__name__):
+        warn_if_rate_limit_backend_is_memory()
+    assert any("rate_limit_backend" in r.message for r in caplog.records)
+
+
+# --- /api/v2/health rate_limit_backend 노출(AC2) ---------------------------------
+
+
+@pytest.mark.anyio
+async def test_health_endpoint_exposes_rate_limit_backend_value(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from httpx import ASGITransport, AsyncClient
+
+    from app.core.config import settings
+    from app.main import app
+    from tests.conftest import override_db_and_read
+
+    monkeypatch.setattr(settings, "rate_limit_backend", "redis")
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=None)
+
+    async def _override():
+        yield mock_session
+
+    override_db_and_read(app, _override)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/api/v2/health")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["rate_limit_backend"] == "redis"

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -409,6 +409,21 @@ def test_deploy_backend_prod_excludes_plain_redis_url():
     assert "REDIS_URL" not in result
 
 
+def test_deploy_backend_dev_includes_rate_limit_backend_redis():
+    """story #3418(카디르 실측 2026-09-04) — dev는 REDIS_URL과 같은 분기로
+    RATE_LIMIT_BACKEND=redis도 싣는다(REDIS_URL만 있고 이게 없으면 rate_limiter.py::
+    get_rate_limiter가 기본값 memory로 계속 남는다)."""
+    result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379")
+    assert "RATE_LIMIT_BACKEND=redis" in result
+
+
+def test_deploy_backend_prod_excludes_rate_limit_backend():
+    """AC1 — prod는 선생님 결재 전까지 손대지 않는다(REDIS_URL과 동일 게이트에 묶었으니
+    자동으로 같이 빠진다 — 그 사실을 이 테스트가 고정)."""
+    result = _run_env_vars_assembly("prod", "")
+    assert "RATE_LIMIT_BACKEND" not in result
+
+
 def test_deploy_backend_dev_includes_admin_operator_env_vars():
     """story #2777 — dev는 ADMIN_OPERATOR_AUDIENCE/ALLOWLIST를 plain env로 넘긴다."""
     result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379")
@@ -555,7 +570,7 @@ def test_deploy_backend_dev_env_vars_unchanged_by_prod_branch():
         # story 194acb63 — 베이스 문자열 맨 끝(SUPPORT_ESCALATION_TARGET_PROJECT_SLUG 다음)에
         # 이어붙는다 — REDIS_URL 등 조건부 append는 그 뒤.
         "PUBLIC_SITE_BASE_URL=https://sprintable.ai,"
-        "REDIS_URL=redis://10.164.120.243:6379,"
+        "REDIS_URL=redis://10.164.120.243:6379,RATE_LIMIT_BACKEND=redis,"
         "ADMIN_OPERATOR_AUDIENCE=https://example-audience.run.app,"
         "ADMIN_OPERATOR_ALLOWLIST=operator@example.iam.gserviceaccount.com,"
         "GCS_AVATARS_BUCKET=sprintable-avatars-dev"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -722,8 +722,12 @@ steps:
         # story #2141 — REDIS_URL: prod는 Secret Manager 바인딩과 동명 키 충돌 방지로 여기서 안 넘김.
         # ⛔story #2423 — 셸 변수는 반드시 $$로 이스케이프(단일 $는 Cloud Build 자신의 substitution
         # 파서가 args 전체를 먼저 훑어 build submit 자체를 INVALID_ARGUMENT로 거부 — 예시로도 금지).
+        # story #3418(카디르 실측 2026-09-04) — RATE_LIMIT_BACKEND=redis를 REDIS_URL과 같은 dev
+        # 분기에 묶는다(rate_limiter.py::get_rate_limiter가 이 값 있어야 RedisRateLimiter로 감 —
+        # REDIS_URL만 있고 이게 없으면 기본값 memory라 인스턴스별로 계속 갈라진다). prod는 PO가
+        # 선생님 결재 뒤 별도로.
         if [ "${_DEPLOY_ENV}" != "prod" ]; then
-          ENV_VARS="$${ENV_VARS},REDIS_URL=${_REDIS_URL}"
+          ENV_VARS="$${ENV_VARS},REDIS_URL=${_REDIS_URL},RATE_LIMIT_BACKEND=redis"
         fi
         # story #2777 — ADMIN_OPERATOR_*: prod는 키 자체가 없어야 안전(require_admin_operator
         # fail-closed 503, 대표승인 前 prod 결제개입 전면금지 태세와 정합).


### PR DESCRIPTION
[SID:3418]

## 배경(카디르 실측, dev, 2026-09-04)
공개 글 beacon 1분 dedup이 억제 안 됨(1→2). 원인: `rate_limit_backend` 기본값이 `"memory"`인데 dev/prod 둘 다 env가 안 실려 있었고, 백엔드 인스턴스는 최소 3개(dev min=3) — `get_rate_limiter()`의 `InMemoryRateLimiter`가 프로세스 로컬이라 dedup·레이트리밋 전부 인스턴스별로 갈라진다.

## 변경
- **cloudbuild.yaml**: `RATE_LIMIT_BACKEND=redis`를 기존 REDIS_URL과 같은 dev-only 조건분기에 배선(`_DEPLOY_ENV != prod`). **prod는 이 PR에 없음** — 선생님 결재 뒤 PO가 같은 SSOT로 별도 진행.
- **app/services/rate_limiter.py**: `warn_if_rate_limit_backend_is_memory()` 신설 — memory인데 로컬이 아니면(Cloud Run 등) startup 경고 1줄. fail-closed 아님(레이트리밋 저하는 가용성보다 안전 쪽 실패). 기존 `check_internal_secret_config()` 등과 동형 `s=None` 테스트 훅 패턴. 앱은 인스턴스 수를 모르므로 "여러 인스턴스인지"는 직접 못 잡는다는 한계를 docstring에 명시.
- **app/main.py**: lifespan에서 위 가드를 다른 startup 가드들과 같은 자리에서 호출.
- **app/routers/health.py**: `GET /api/v2/health` 응답에 `rate_limit_backend` 값 노출(사람이 인스턴스 수와 대조 가능하게).

## 검증
- 신규 20테스트: `get_rate_limiter()` 분기(redis/memory)·싱글턴·`InMemoryRateLimiter`/`RedisRateLimiter` 단위 동작(fakeredis 실왕복 — 키 형식 `rl:{key}`·TTL(WINDOW_SECS+5)·한도 강제·거부 시 zrem no-growth)·startup 경고 4종(로컬/비로컬×memory/redis)·health 노출·cloudbuild dev/prod 배선.
- 기존 `test_deploy_backend_redis_secret_conflict.py`의 exact-match 하드코딩 테스트(story #3124 가드 관례)를 새 env var에 맞게 동기화.
- mutation self-check 4건(경고 조건 무효화·RedisRateLimiter zrem 제거·`get_rate_limiter` redis 분기 무효화·cloudbuild env var 제거) 전부 정확한 대상 테스트 RED 확인 → 원복 → 재확認 green.
- `app.main:app` 실 lifespan 기동(ASGITransport) 스모크 확認 — 크래시 없음.

## 범위 밖
- prod `RATE_LIMIT_BACKEND` 배선(선생님 결재 필요, PO lane).
- `app/core/rate_limit.py`(slowapi 기반, login/refresh 등 auth-critical 라우트 공유 limiter) — story #2444 PO 결정으로 이미 별도 스코프(가용성 우선, in-memory 유지). 이 스토리가 건드리는 건 `app/services/rate_limiter.py`(beacon dedup·API-key tier 레이트리밋)뿐.
- 라이브 재실측(dev 배포 뒤 카디르 QA)·fbcc07b5(#3354) done 전이는 그 통과 뒤.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm