### PR TITLE
[SID:3419] feat: 채널 포스트 발행 취소 서버 경로 — 예약 명령 취소·발행 회수(unpublish)

### DIFF
--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -101,15 +101,30 @@ class ChannelConnectionResponse(BaseModel):
     # 이 값 하나로 버튼을 그리거나 안 그린다 — scopes 원본을 노출해 FE가 다시 판정하게
     # 만들지 않는다(판정 로직 단일 지점).
     can_unpublish: bool = False
+    # 페드루 PO 리뷰(2026-09-04, PR#3774) — can_unpublish=false 하나로는 FE가 유나
+    # §17-11의 두 문구(「미지원」vs「재연결하면 회수 가능」)를 못 가른다. 어느 쪽인지
+    # 명시하는 판정값 — can_unpublish=true면 항상 null(막힌 이유가 없다).
+    # 'unsupported' = 어댑터가 이 채널에 회수 자체를 선언 안 함(재연결해도 안 풀림,
+    # §17-11 문구 대상 아님 — 그 절 자체가 "스코프 부족"만 다룬다) ·
+    # 'scope_insufficient' = 어댑터는 지원하는데 이 연결에 필요 스코프가 없음(재연결
+    # 하면 풀림 — §17-11 owner/member 문구가 이 값 전용).
+    unpublish_blocked_reason: str | None = None
 
 
 def _to_response(row) -> ChannelConnectionResponse:
     adapter = get_channel_adapter(row.channel)
     max_text_length = adapter.max_text_length if adapter is not None and adapter.max_text_length > 0 else None
-    can_unpublish = bool(
-        adapter is not None and adapter.supports_unpublish
-        and adapter.unpublish_required_scope in (row.scopes or [])
+    supports_unpublish = adapter is not None and adapter.supports_unpublish
+    has_required_scope = bool(
+        supports_unpublish and adapter.unpublish_required_scope in (row.scopes or [])
     )
+    can_unpublish = supports_unpublish and has_required_scope
+    if can_unpublish:
+        unpublish_blocked_reason = None
+    elif not supports_unpublish:
+        unpublish_blocked_reason = "unsupported"
+    else:
+        unpublish_blocked_reason = "scope_insufficient"
     return ChannelConnectionResponse(
         id=row.id, channel=row.channel, account_id=row.account_id, account_label=row.account_label,
         credential_kind=row.credential_kind, status=row.status,
@@ -117,6 +132,7 @@ def _to_response(row) -> ChannelConnectionResponse:
         last_refreshed_at=row.last_refreshed_at.isoformat() if row.last_refreshed_at else None,
         last_error=row.last_error, can_auto_refresh=can_auto_refresh(row.refresh_mode),
         connected_by=row.connected_by, created_at=row.created_at.isoformat(), updated_at=row.updated_at.isoformat(),
+        unpublish_blocked_reason=unpublish_blocked_reason,
         max_text_length=max_text_length, can_unpublish=can_unpublish,
     )
 

--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -96,11 +96,20 @@ class ChannelConnectionResponse(BaseModel):
     # 하드코딩하면 다른 채널이 붙을 때 값이 틀리는 재발(담롱군 §4-6)이 난다 — 선언 안 한
     # 채널이면 null("한도 미확認", 지어내지 않는다).
     max_text_length: int | None = None
+    # story #3419(AC4) — 「이 연결로 지금 발행 글을 회수할 수 있나」의 최종 판정값(어댑터
+    # `supports_unpublish` ∧ 연결 `scopes`에 필요 스코프 포함, PO 확定 산식 그대로). FE가
+    # 이 값 하나로 버튼을 그리거나 안 그린다 — scopes 원본을 노출해 FE가 다시 판정하게
+    # 만들지 않는다(판정 로직 단일 지점).
+    can_unpublish: bool = False
 
 
 def _to_response(row) -> ChannelConnectionResponse:
     adapter = get_channel_adapter(row.channel)
     max_text_length = adapter.max_text_length if adapter is not None and adapter.max_text_length > 0 else None
+    can_unpublish = bool(
+        adapter is not None and adapter.supports_unpublish
+        and adapter.unpublish_required_scope in (row.scopes or [])
+    )
     return ChannelConnectionResponse(
         id=row.id, channel=row.channel, account_id=row.account_id, account_label=row.account_label,
         credential_kind=row.credential_kind, status=row.status,
@@ -108,7 +117,7 @@ def _to_response(row) -> ChannelConnectionResponse:
         last_refreshed_at=row.last_refreshed_at.isoformat() if row.last_refreshed_at else None,
         last_error=row.last_error, can_auto_refresh=can_auto_refresh(row.refresh_mode),
         connected_by=row.connected_by, created_at=row.created_at.isoformat(), updated_at=row.updated_at.isoformat(),
-        max_text_length=max_text_length,
+        max_text_length=max_text_length, can_unpublish=can_unpublish,
     )
 
 

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -16,17 +16,24 @@ from app.services.channel_posts import (
     ChannelPostApproverRoleMissingError,
     ChannelPostDraftNotFoundError,
     ChannelPostGateAlreadyHeldError,
+    ChannelPostGateNotFoundError,
+    ChannelPostNotPublishedError,
     ChannelPostReapprovalRequiredError,
     ChannelPostSealMissingError,
     ChannelPostVersionNotFoundError,
     ChannelPublishInProgressError,
     ChannelPublishProviderError,
     ChannelRateLimitedError,
+    ChannelScopeInsufficientError,
     ChannelTextTooLongError,
     ChannelTokenExpiredError,
+    ChannelUnpublishUnsupportedError,
     ExternalPublishGateNotApprovedError,
+    PublicationCommandNotCancellableError,
+    PublicationCommandNotFoundError,
     build_tagged_link,
     build_text_preview,
+    cancel_scheduled_publication,
     create_channel_post_draft_version,
     get_channel_post_draft,
     is_agent_caller,
@@ -35,6 +42,7 @@ from app.services.channel_posts import (
     publish_channel_post_draft,
     submit_channel_post_draft,
     text_char_count,
+    unpublish_channel_post,
 )
 from app.services.member_resolver import resolve_member
 
@@ -52,6 +60,29 @@ async def _require_human(db: AsyncSession, auth: AuthContext, org_id: uuid.UUID)
             detail={
                 "code": "CHANNEL_POST_PUBLISH_HUMAN_ONLY",
                 "message": "채널 포스트 발행은 휴먼 멤버만 가능합니다(에이전트는 초안·상신까지).",
+            },
+        )
+    return resolved
+
+
+async def _require_owner_or_admin(db: AsyncSession, auth: AuthContext, org_id: uuid.UUID):
+    """story #3419 AC3 — 취소·회수는 site_posts.py::_require_owner_or_admin과 동형(발행
+    보다 좁은 권한 — 되돌릴 수 있는 파괴적 상태전환이라 owner/admin 한 단계 더)."""
+    resolved = await resolve_member(auth, org_id, db)
+    if resolved.type != "human":
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "CHANNEL_POST_CANCEL_UNPUBLISH_HUMAN_ONLY",
+                "message": "발행 취소·회수는 휴먼 멤버만 가능합니다(에이전트는 초안·상신까지).",
+            },
+        )
+    if resolved.role not in ("owner", "admin"):
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "CHANNEL_POST_CANCEL_UNPUBLISH_OWNER_OR_ADMIN_ONLY",
+                "message": "발행 취소·회수는 조직 owner 또는 admin만 가능합니다.",
             },
         )
     return resolved
@@ -650,3 +681,128 @@ async def retry_publication_command_endpoint(
         raise HTTPException(status_code=404, detail="command를 찾을 수 없거나 재시도 대상이 아닙니다")
     await db.commit()
     return RetryPublicationCommandResponse(id=command.id, status=command.status)
+
+
+class CancelScheduledCommandResponse(BaseModel):
+    command_id: uuid.UUID
+    status: str
+    reason_code: str | None = None
+
+
+@router.post(
+    "/{org_id}/channel-posts/drafts/{draft_id}/cancel-scheduled",
+    response_model=CancelScheduledCommandResponse,
+)
+async def cancel_scheduled_command_endpoint(
+    org_id: uuid.UUID,
+    draft_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> CancelScheduledCommandResponse:
+    """story #3419 AC1 — owner/admin 전용(휴먼 전용 안의 좁은 축, `_require_owner_or_admin`
+    — 되돌릴 수 있는 파괴적 상태전환이라 발행 자체보다 한 단계 더). 이 draft의 gate에
+    걸린 **가장 최근** publication_command가 pending·blocked·dead_letter면 `cancelled`로
+    전이한다. 그 외 상태는 409(코드 명시) — «이미 실행 중/끝난 것을 취소하려 했다»를
+    정직하게 알린다."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    resolved = await _require_owner_or_admin(db, auth, org_id)
+
+    try:
+        command = await cancel_scheduled_publication(
+            db, org_id=org_id, draft_id=draft_id, cancelled_by_member_id=resolved.id,
+        )
+    except ChannelPostDraftNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ChannelPostGateNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except PublicationCommandNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "PUBLICATION_COMMAND_NOT_FOUND", "message": str(exc)},
+        ) from exc
+    except PublicationCommandNotCancellableError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "PUBLICATION_COMMAND_NOT_CANCELLABLE", "message": str(exc),
+                "current_status": exc.current_status,
+            },
+        ) from exc
+
+    return CancelScheduledCommandResponse(
+        command_id=command.id, status=command.status, reason_code=command.reason_code,
+    )
+
+
+class UnpublishChannelPostResponse(BaseModel):
+    publication_id: uuid.UUID
+    status: str
+    external_id: str | None = None
+    unpublished_at: str
+
+
+@router.post(
+    "/{org_id}/channel-posts/drafts/{draft_id}/unpublish", response_model=UnpublishChannelPostResponse,
+)
+async def unpublish_channel_post_endpoint(
+    org_id: uuid.UUID,
+    draft_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> UnpublishChannelPostResponse:
+    """story #3419 AC2 — owner/admin 전용(site_posts.py unpublish 관례와 동형). 이
+    draft의 gate에서 가장 최근 발행된(status='published') 글을 Threads 공식 삭제
+    API로 회수한다. 어댑터 미지원(422)·연결 스코프 부족(422, required_scopes 실림 —
+    기존 연결은 threads_delete 스코프 없이 저장돼 있어 재인증 前까지 여기 걸린다,
+    PO 確定 ②-a)·연결 비활성(409)·이미 회수/미발행(409)·provider 오류(401/403→토큰
+    만료 409, 그 외→502)를 각각 명시 코드로 구분한다."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    resolved = await _require_owner_or_admin(db, auth, org_id)
+
+    try:
+        pub = await unpublish_channel_post(
+            db, org_id=org_id, draft_id=draft_id, unpublished_by_member_id=resolved.id,
+        )
+    except ChannelPostDraftNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ChannelPostGateNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ChannelPostNotPublishedError as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": "CHANNEL_POST_NOT_PUBLISHED", "message": str(exc)},
+        ) from exc
+    except ChannelUnpublishUnsupportedError as exc:
+        raise HTTPException(
+            status_code=422, detail={"code": "CHANNEL_UNPUBLISH_UNSUPPORTED", "message": str(exc)},
+        ) from exc
+    except ChannelScopeInsufficientError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_SCOPE_INSUFFICIENT", "message": str(exc),
+                "required_scopes": exc.required_scopes,
+            },
+        ) from exc
+    except ChannelConnectionNotActiveError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "CHANNEL_CONNECTION_NOT_ACTIVE", "message": str(exc)},
+        ) from exc
+    except ChannelTokenExpiredError as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": "CHANNEL_TOKEN_EXPIRED", "message": str(exc)},
+        ) from exc
+    except ChannelPublishProviderError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "CHANNEL_PUBLISH_PROVIDER_ERROR", "message": str(exc)},
+        ) from exc
+
+    return UnpublishChannelPostResponse(
+        publication_id=pub.id, status=pub.status, external_id=pub.external_id,
+        unpublished_at=pub.updated_at.isoformat(),
+    )

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -32,13 +32,30 @@ class ChannelAdapterConfig:
     # 대상 글마다 달라 여기 선언 대상이 아니다, app/services/utm.py::resolve_utm_campaign).
     utm_source: str = ""
     utm_medium: str = ""
+    # story #3419(Phase1·마케팅운영, PO 결정 2026-09-04) — 발행된 글을 채널에서 회수(삭제
+    # API 호출) 가능한지. max_text_length·can_auto_refresh와 동형 관례(채널의 성질을 여기
+    # 선언하고 목록 API가 그대로 노출 → FE가 버튼 렌더 여부를 판단, 신규 판정 로직 불요).
+    supports_unpublish: bool = False
+    # 회수를 실제로 실행하려면 연결이 이 스코프를 갖고 있어야 한다(None=이 어댑터는 스코프
+    # 요구 없음 — supports_unpublish=False면 애초에 의미 없는 값). `ChannelConnection.scopes`
+    # 는 연결 시점에 이 어댑터의 `scope` 문자열을 그대로 저장한 값이다(그라운딩 확認 —
+    # Threads 토큰 교환 응답에 별도 "실제 부여된 스코프" 필드가 없어, 이 코드베이스 기존
+    # 관례(`channel_connections.py::channel_connection_callback`)가 이미 "요청한 스코프"를
+    # "이 연결의 스코프"로 기록해 왔다 — 새 컬럼·새 메커니즘 불요, 이 필드를 `scope`에 포함시
+    # 키기만 하면 기존 저장 경로가 그대로 반영한다. 기존 연결은 이 값 없이 저장돼 있어
+    # 자동으로 "부족"으로 판정된다 — 재인증해야 새 scope가 반영).
+    unpublish_required_scope: str | None = None
 
 
 CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
     "threads": ChannelAdapterConfig(
         authorize_url="https://threads.net/oauth/authorize",
         token_url="https://graph.threads.net/oauth/access_token",
-        scope="threads_basic,threads_content_publish",
+        # story #3419 — threads_delete 추가(회수 API 스코프, Meta 공식 문서 실측
+        # developers.facebook.com/docs/threads/posts/delete-posts/ 2026-09-04). 기존
+        # 연결은 이 스코프 없이 이미 저장돼 있어 재인증 전까지 회수가 막힌다(의도, PO
+        # 확定 — 새 연결부터 자동 해소).
+        scope="threads_basic,threads_content_publish,threads_delete",
         refresh_mode="reissue_from_access_token",
         credential_kind="oauth",
         # sprintable-agent-plugins/plugins/sprintable/connectors/threads.ts:27의
@@ -47,6 +64,8 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         max_text_length=500,
         utm_source="threads",
         utm_medium="social",
+        supports_unpublish=True,
+        unpublish_required_scope="threads_delete",
     ),
 }
 

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -168,6 +168,67 @@ class ChannelPostGateAlreadyHeldError(Exception):
         )
 
 
+class ChannelPostGateNotFoundError(Exception):
+    """story #3419 — 취소·회수 대상을 찾으려면 그 draft가 상신된 적(=게이트가 생긴
+    적)이 있어야 한다. 순수 초안(상신 전)에 취소/회수를 시도하면 이 예외 — 404."""
+
+    def __init__(self, draft_id: uuid.UUID):
+        self.draft_id = draft_id
+        super().__init__(f"이 draft는 아직 상신된 적이 없습니다(취소/회수 대상 없음): {draft_id}")
+
+
+class PublicationCommandNotFoundError(Exception):
+    """story #3419 AC1 — 이 draft의 gate에 걸린 publication_command 자체가 없다(발행/예약
+    요청을 한 적이 없음). 404."""
+
+    def __init__(self, draft_id: uuid.UUID):
+        self.draft_id = draft_id
+        super().__init__(f"취소할 발행 명령이 없습니다: {draft_id}")
+
+
+class PublicationCommandNotCancellableError(Exception):
+    """story #3419 AC1 — PO 確定 ①-a: 취소 가능 상태는 pending·blocked·dead_letter뿐
+    (사람이 「이 명령을 끝내겠다」는 뜻 — 종결 아닌 상태 전부 허용). in_progress(이미
+    실행 중)·completed·voided·cancelled(이미 종결)는 409."""
+
+    def __init__(self, *, command_id: uuid.UUID, current_status: str):
+        self.command_id = command_id
+        self.current_status = current_status
+        super().__init__(
+            f"이 명령은 취소할 수 없는 상태입니다(command_id={command_id}, status={current_status})"
+        )
+
+
+class ChannelPostNotPublishedError(Exception):
+    """story #3419 AC2 — 회수하려면 이 gate에 status='published' 행이 있어야 한다.
+    발행된 적이 없거나 이미 unpublished면 이 예외 — 409."""
+
+    def __init__(self, draft_id: uuid.UUID):
+        self.draft_id = draft_id
+        super().__init__(f"발행된 적이 없거나 이미 회수된 글입니다: {draft_id}")
+
+
+class ChannelUnpublishUnsupportedError(Exception):
+    """story #3419 AC2 — 어댑터가 `supports_unpublish=False`로 선언한 채널. 화면은
+    이 선언값으로 버튼 자체를 안 그리는 게 정상 경로지만(§17-4), 서버도 독립적으로
+    거부한다(FE 우회·구버전 클라이언트 대비) — 422."""
+
+    def __init__(self, *, channel: str):
+        self.channel = channel
+        super().__init__(f"이 채널은 발행 회수를 지원하지 않습니다: {channel}")
+
+
+class ChannelScopeInsufficientError(Exception):
+    """story #3419 AC2·PO 確定 ②-a — 어댑터는 회수를 지원하지만 이 연결에 필요 스코프
+    (예: threads_delete)가 없다. 기존 연결(이 스코프 도입 前 저장분)이 항상 여기 걸린다
+    (의도) — 재인증하면 새 scope 문자열이 반영돼 해소된다. 422, required_scopes를
+    실어 화면이 「재인증하면 회수할 수 있습니다」(유나 §17-11)를 그릴 수 있게 한다."""
+
+    def __init__(self, *, required_scopes: list[str]):
+        self.required_scopes = required_scopes
+        super().__init__(f"이 연결에 필요한 스코프가 없습니다: {required_scopes}")
+
+
 def compute_channel_post_hash(*, text: str, link_url: str | None) -> str:
     """gate_seal.compute_seal_hash 위 얇은 payload 조립부(site_posts.compute_body_sha256과
     동형 역할) — channel은 draft 고정값(배달 경로)이라 해시에 안 섞는다(모델 docstring 참고)."""
@@ -962,3 +1023,149 @@ async def publish_channel_post_draft(
     )
     await db.commit()
     return row
+
+
+# ─── story #3419(Phase1·마케팅운영) — 발행 취소(예약 명령 취소·발행분 회수) ─────────────────
+# 둘 다 draft의 gate를 gate.status와 무관하게 조회한다(publish_channel_post_draft의
+# "승인 상태 재검증"과 다른 축 — 취소·회수는 "지금 그 게이트가 승인 상태인가"가 아니라
+# "이 gate에 걸린 command/publication이 그 자체로 끝낼 수 있는 상태인가"만 본다. 예:
+# 승인 뒤 편집으로 게이트가 다시 pending으로 돌아가도, 그 전에 만들어진 blocked/dead_letter
+# command는 여전히 사람이 명시 취소할 대상이다).
+
+_CANCELLABLE_COMMAND_STATUSES = frozenset({"pending", "blocked", "dead_letter"})
+
+
+async def _resolve_gate_for_draft(db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID) -> tuple[ChannelPostDraft, Gate]:
+    draft = await get_channel_post_draft(db, org_id=org_id, draft_id=draft_id)
+    if draft is None:
+        raise ChannelPostDraftNotFoundError(draft_id)
+
+    from app.services.gate_service import find_gate_slot_with_pr_fallback
+
+    gate = await find_gate_slot_with_pr_fallback(
+        db, org_id=org_id, work_item_id=draft.work_item_id, work_item_type="story",
+        gate_type=_EXTERNAL_PUBLISH_GATE_TYPE, pr_number=None, repo_full_name=None,
+    )
+    if gate is None:
+        raise ChannelPostGateNotFoundError(draft_id)
+    return draft, gate
+
+
+async def cancel_scheduled_publication(
+    db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID, cancelled_by_member_id: uuid.UUID,
+) -> PublicationCommand:
+    """story #3419 AC1·PO 確定 ①-a — 이 gate의 **가장 최근** publication_command가
+    pending·blocked·dead_letter 중 하나면 `cancelled`(reason_code=CANCELLED_BY_HUMAN)로
+    전이한다. 그 외 상태(in_progress·completed·voided·이미 cancelled)는
+    PublicationCommandNotCancellableError(라우터가 409).
+
+    cron(`process_due_publication_commands`)의 클레임 WHERE절은 `status='pending'`만
+    본다 — cancelled로 바뀌기만 하면 새 배제 로직 없이 구조적으로 다시 안 집힌다(voided·
+    dead_letter·blocked와 동일 원리, story #3414 그라운딩)."""
+    draft, gate = await _resolve_gate_for_draft(db, org_id=org_id, draft_id=draft_id)
+
+    command = (await db.execute(
+        select(PublicationCommand)
+        .where(PublicationCommand.gate_id == gate.id)
+        .order_by(PublicationCommand.created_at.desc())
+        .limit(1)
+        .with_for_update()
+    )).scalar_one_or_none()
+    if command is None:
+        raise PublicationCommandNotFoundError(draft_id)
+    if command.status not in _CANCELLABLE_COMMAND_STATUSES:
+        raise PublicationCommandNotCancellableError(command_id=command.id, current_status=command.status)
+
+    command.status = "cancelled"
+    command.reason_code = "CANCELLED_BY_HUMAN"
+    await db.commit()
+    await db.refresh(command)
+
+    from app.services.activity_log import ActivityLogService
+
+    await ActivityLogService(db).record(
+        org_id=org_id, action="publication_command_cancelled", actor_type="platform", actor_id=None,
+        entity_type="publication_command", entity_id=command.id,
+        context={
+            "gate_id": str(gate.id), "draft_id": str(draft_id),
+            "cancelled_by_member_id": str(cancelled_by_member_id),
+        },
+    )
+    await db.commit()
+    return command
+
+
+async def unpublish_channel_post(
+    db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID, unpublished_by_member_id: uuid.UUID,
+) -> ChannelPublication:
+    """story #3419 AC2·PO 確定 ②-a — 이 gate의 **가장 최근 status='published'**
+    channel_publications 행을 Threads 공식 삭제 API로 회수하고 `unpublished`로 전이한다
+    (external_id·permalink는 건드리지 않는다 — "보존", `_to_draft_list_item`의
+    published_pub_by_gate가 status='published'만 걸러서 그 뒤로는 목록에서 자연히
+    "지금 살아 있는 것"이 아니게 된다, 신규 필터링 코드 불요).
+
+    가드 순서(전부 Threads 호출 前): ①gate 존재 ②published 행 존재 ③어댑터
+    supports_unpublish ④연결 활성 ⑤연결 스코프에 필요 스코프 포함. 어느 하나라도
+    실패하면 Threads 호출 0건(fail-closed, publish 경로의 "재검증 뒤 호출" 규율과
+    동형)."""
+    draft, gate = await _resolve_gate_for_draft(db, org_id=org_id, draft_id=draft_id)
+
+    pub = (await db.execute(
+        select(ChannelPublication)
+        .where(ChannelPublication.gate_id == gate.id, ChannelPublication.status == "published")
+        .order_by(ChannelPublication.published_at.desc())
+        .limit(1)
+        .with_for_update()
+    )).scalar_one_or_none()
+    if pub is None:
+        raise ChannelPostNotPublishedError(draft_id)
+
+    adapter = get_channel_adapter(draft.channel)
+    if adapter is None or not adapter.supports_unpublish:
+        raise ChannelUnpublishUnsupportedError(channel=draft.channel)
+
+    connection = await _get_active_connection(db, org_id=org_id, connection_id=draft.connection_id)
+    if adapter.unpublish_required_scope and adapter.unpublish_required_scope not in (connection.scopes or []):
+        raise ChannelScopeInsufficientError(required_scopes=[adapter.unpublish_required_scope])
+
+    access_token = decrypt_for_use(connection)
+    if access_token is None:
+        raise ChannelConnectionNotActiveError(connection_id=connection.id)
+
+    if pub.external_id is None:
+        # 이론상 status='published'면 항상 채워져 있다(publish_channel_post_draft가 media
+        # id 확보 뒤에만 published로 전이) — 그래도 발행 provider 호출은 정직한 실패로
+        # 낸다(external_id 없이 삭제 호출을 시도하면 무의미한 요청이 나간다).
+        raise ChannelPublishProviderError(
+            provider_code="MISSING_EXTERNAL_ID", provider_message="published 행에 external_id가 없습니다",
+        )
+
+    import httpx
+    from app.services.threads_publish import ThreadsPublishError, delete_media
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            try:
+                await delete_media(client, access_token=access_token, media_id=pub.external_id)
+            except ThreadsPublishError as exc:
+                _, mapped_exc = _classify_threads_error(exc, connection_id=connection.id)
+                raise mapped_exc from exc
+    finally:
+        del access_token  # ⛔즉시 소비 후 폐기 — 기존 관례와 동일.
+
+    pub.status = "unpublished"
+    await db.commit()
+    await db.refresh(pub)
+
+    from app.services.activity_log import ActivityLogService
+
+    await ActivityLogService(db).record(
+        org_id=org_id, action="channel_post_unpublished", actor_type="platform", actor_id=None,
+        entity_type="channel_publication", entity_id=pub.id,
+        context={
+            "gate_id": str(gate.id), "external_id": pub.external_id,
+            "unpublished_by_member_id": str(unpublished_by_member_id),
+        },
+    )
+    await db.commit()
+    return pub

--- a/backend/app/services/threads_publish.py
+++ b/backend/app/services/threads_publish.py
@@ -112,6 +112,29 @@ async def get_publishing_limit(
     return int(quota_usage), int(quota_total), int(quota_duration)
 
 
+async def delete_media(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> None:
+    """story #3419 — 발행된 글 회수(공식 삭제 API, 실측 2026-09-04·출처
+    developers.facebook.com/docs/threads/posts/delete-posts/): `DELETE
+    /v1.0/{threads-media-id}` — 스코프 `threads_basic`+`threads_delete` 필요, 한도
+    100건/일/계정(rate limit 자체는 이 클라이언트가 사전 조회하지 않는다 — get_
+    publishing_limit과 달리 삭제 잔량 조회 API가 별도로 없음, 초과 시 provider가 직접
+    거부). 성공 응답은 `{"success": true, "deleted_id": ...}` — success가 false거나
+    없으면 실패로 취급(호출부가 "회수됐다"고 잘못 믿지 않게)."""
+    resp = await client.delete(
+        _MEDIA_URL_TMPL.format(media_id=media_id), params={"access_token": access_token},
+    )
+    if resp.status_code != 200:
+        raise ThreadsPublishError(
+            "THREADS_DELETE_MEDIA_FAILED", resp.text[:500], status_code=resp.status_code,
+        )
+    body = resp.json()
+    if not body.get("success"):
+        raise ThreadsPublishError(
+            "THREADS_DELETE_MEDIA_FAILED", f"success=false in response: {resp.text[:500]}",
+            status_code=resp.status_code,
+        )
+
+
 async def get_permalink(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> str | None:
     """PO 결정① — `GET /{media-id}?fields=permalink`. 값이 없으면(provider가 아직 못
     붙였을 가능성) None — 호출부가 "발행은 됐는데 permalink만 비었다"로 받아들일 수

--- a/backend/tests/test_3419_cancel_unpublish.py
+++ b/backend/tests/test_3419_cancel_unpublish.py
@@ -1,0 +1,746 @@
+"""story #3419(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04) — 채널 포스트 «발행 취소»
+서버 경로. ① 예약 명령 취소(POST .../cancel-scheduled) ② 발행된 글 회수(POST
+.../unpublish, Threads 공식 삭제 API).
+
+PO 確定 요지:
+- ①-a 취소 대상 = pending·blocked·dead_letter(사람이 "이 명령을 끝내겠다"는 뜻). 그 외
+  (in_progress·completed·voided·cancelled)는 409.
+- ②-a Threads 삭제는 스코프 threads_delete가 필요 — 연결의 `scopes`(연결 시점에 어댑터
+  `scope` 문자열을 그대로 저장, 그라운딩 확認)에 없으면 422 CHANNEL_SCOPE_INSUFFICIENT.
+  기존 연결(이 스토리 前 저장분)은 항상 여기 걸린다(의도) — 새 연결부터 자동 해소.
+- 둘 다 owner/admin 전용(site_posts unpublish 관례와 동일, 발행 자체보다 좁은 권한)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="3419 Cancel Unpublish Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="담롱"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_human(session, org_id, *, role="member"):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="채널 포스트"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_default_role(session, org_id):
+    from app.models.participation import ParticipationRole
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+    session.add(role)
+    await session.commit()
+    return role.id
+
+
+async def _seed_connection(
+    session, org_id, *, channel="threads", status="active", account_id=None, token="plain-access-token",
+    scopes=None,
+):
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    kwargs = {}
+    if scopes is not None:
+        kwargs["scopes"] = scopes
+    conn = ChannelConnection(
+        id=uuid.uuid4(), org_id=org_id, channel=channel,
+        account_id=account_id or f"acct-{uuid.uuid4().hex[:8]}", status=status,
+        credential_kind="oauth", refresh_mode="reissue_from_access_token",
+        encrypted_access_token=encrypt_channel_credential(token) if status == "active" else None,
+        **kwargs,
+    )
+    session.add(conn)
+    await session.commit()
+    return conn.id
+
+
+async def _approve_gate_directly(session, gate_id):
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    gate = (await session.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+    gate.status = "approved"
+    gate.resolver_id = uuid.uuid4()
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.commit()
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id, agent: bool = False):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if agent:
+            claims["app_metadata"]["api_key_id"] = "test-agent-key"
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _draft_body(*, work_item_id, connection_id, text="채널 포스트 본문입니다."):
+    return {"work_item_id": str(work_item_id), "connection_id": str(connection_id), "text": text}
+
+
+async def _create_draft_submit_approve(
+    client, session, *, org_id, connection_id, story_id, text="채널 포스트 본문입니다.",
+    scheduled_at: datetime | None = None,
+):
+    r_draft = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+        json=_draft_body(work_item_id=story_id, connection_id=connection_id, text=text),
+    )
+    assert r_draft.status_code == 201, r_draft.text
+    draft_id = r_draft.json()["draft_id"]
+    submit_body = {}
+    if scheduled_at is not None:
+        submit_body["scheduled_at"] = scheduled_at.isoformat()
+    r_submit = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json=submit_body,
+    )
+    assert r_submit.status_code == 200, r_submit.text
+    gate_id = uuid.UUID(r_submit.json()["gate_id"])
+    await _approve_gate_directly(session, gate_id)
+    return draft_id, gate_id
+
+
+# --- AC1 — 예약 명령 취소 ---------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cancel_pending_command_then_cron_does_not_pick_it_up():
+    """AC1 핵심 + QA 회귀 가드 — pending 취소 뒤 cancelled로 전이하고, cron 배치가
+    (구조적으로 안전하지만) 실제로도 그 명령을 안 집는지 실측한다."""
+    from app.main import app
+    from app.services.publication_command import process_due_publication_commands
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        now = datetime.now(timezone.utc)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from app.models.channel_post_version import ChannelPostVersion
+            from sqlalchemy import select
+            version_id = (await s.execute(
+                select(ChannelPostVersion.id).where(ChannelPostVersion.draft_id == uuid.UUID(draft_id))
+            )).scalar_one()
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=version_id, operation="publish",
+                scheduled_at=now - timedelta(minutes=1), status="pending", requested_by_member_id=agent_id,
+            )
+            s.add(cmd)
+            await s.commit()
+            cmd_id = cmd.id
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_cancel = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/cancel-scheduled",
+            )
+        assert r_cancel.status_code == 200, r_cancel.text
+        body = r_cancel.json().get("data") or r_cancel.json()
+        assert body["status"] == "cancelled"
+        assert body["reason_code"] == "CANCELLED_BY_HUMAN"
+
+        # cron 배치를 실제로 한 번 돌려도 이 명령이 처리 안 되는지(status 불변).
+        async with Session() as s:
+            await process_due_publication_commands(s, now=now)
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd_row = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
+            assert cmd_row.status == "cancelled", "cron이 cancelled 명령을 건드림(회귀)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cancel_blocked_and_dead_letter_commands_allowed():
+    """PO 確定 ①-a — blocked·dead_letter도 취소 대상(cron이 어차피 안 집는 상태지만
+    사람이 명시적으로 끝낼 수 있어야 한다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="admin")
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        for status in ("blocked", "dead_letter"):
+            async with _client_for(app) as client, Session() as s:
+                story_id = await _seed_story(s, org_id, project_id, title=status)
+                draft_id, gate_id = await _create_draft_submit_approve(
+                    client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                    scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+                )
+
+            async with Session() as s:
+                from app.models.publication_command import PublicationCommand
+                cmd = PublicationCommand(
+                    id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                    approved_version=uuid.uuid4(), operation="publish", scheduled_at=None,
+                    status=status, requested_by_member_id=agent_id,
+                )
+                s.add(cmd)
+                await s.commit()
+
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client:
+                r_cancel = await client.post(
+                    f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/cancel-scheduled",
+                )
+            assert r_cancel.status_code == 200, f"{status} 취소 실패: {r_cancel.text}"
+            body = r_cancel.json().get("data") or r_cancel.json()
+            assert body["status"] == "cancelled", f"{status}에서 취소 안 됨: {body}"
+
+            _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cancel_completed_command_returns_409_with_current_status():
+    """AC1 — 이미 끝난(completed) 명령을 취소하려 하면 409(현재 상태 실림)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+            )
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id, destination=connection_id,
+                approved_version=uuid.uuid4(), operation="publish", scheduled_at=None,
+                status="completed", requested_by_member_id=agent_id,
+            )
+            s.add(cmd)
+            await s.commit()
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_cancel = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/cancel-scheduled",
+            )
+        assert r_cancel.status_code == 409, r_cancel.text
+        body = r_cancel.json()
+        error = body.get("error") or body
+        assert error["code"] == "PUBLICATION_COMMAND_NOT_CANCELLABLE"
+        assert error["current_status"] == "completed"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cancel_no_command_returns_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, _gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_cancel = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/cancel-scheduled",
+            )
+        assert r_cancel.status_code == 404, r_cancel.text
+        body = r_cancel.json()
+        error = body.get("error") or body
+        assert error["code"] == "PUBLICATION_COMMAND_NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cancel_agent_caller_forbidden():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{uuid.uuid4()}/cancel-scheduled",
+            )
+        assert r.status_code == 403, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cancel_member_role_forbidden_owner_admin_only():
+    """AC3 — site-posts unpublish 관례 그대로: 일반 member는 못 한다(owner/admin만)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            member_id = await _seed_human(s, org_id, role="member")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=member_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{uuid.uuid4()}/cancel-scheduled",
+            )
+        assert r.status_code == 403, r.text
+        body = r.json()
+        error = body.get("error") or body
+        assert error["code"] == "CHANNEL_POST_CANCEL_UNPUBLISH_OWNER_OR_ADMIN_ONLY"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# --- AC2 — 발행된 글 회수(unpublish) ------------------------------------------------
+
+
+async def _publish_immediately(app, Session, *, org_id, connection_id, story_id, agent_id, human_id):
+    """즉시발행 성공까지 왕복(mock)한 뒤 (draft_id, gate_id, external_id)를 돌려준다.
+    상신(에이전트 가능)과 발행(휴먼 전용)이 서로 다른 actor라 컨텍스트를 각각 스위치
+    한다 — 이 함수 호출 뒤 app 컨텍스트는 human_id로 남는다(그대로 취소/회수 호출
+    가능)."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+
+    _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+    async with _client_for(app) as client, Session() as s:
+        draft_id, gate_id = await _create_draft_submit_approve(
+            client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+        )
+
+    _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+    with (
+        patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+        patch.object(tp, "create_container", AsyncMock(return_value="creation-x")),
+        patch.object(tp, "publish_container", AsyncMock(return_value="media-x")),
+        patch.object(tp, "get_permalink", AsyncMock(return_value="https://www.threads.net/@demo/post/media-x")),
+    ):
+        async with _client_for(app) as client:
+            r_pub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+    assert r_pub.status_code == 200, r_pub.text
+    return draft_id, gate_id, "media-x"
+
+
+@pytest.mark.anyio
+async def test_unpublish_scope_insufficient_returns_422_with_required_scopes():
+    """PO 確定 ②-a 핵심 — 기존 연결(threads_delete 스코프 없이 저장)로는 회수가
+    422 CHANNEL_SCOPE_INSUFFICIENT로 막힌다(required_scopes 실림). Threads 호출
+    0건(mock 미설치 상태에서 성공하면 실제로 호출을 안 한 것 — 가드가 먼저 막았다는
+    뜻)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            # scopes 명시 안 함 — server_default=[](threads_delete 없음), 기존 연결 재현.
+            connection_id = await _seed_connection(s, org_id)
+
+        draft_id, gate_id, external_id = await _publish_immediately(
+            app, Session, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            agent_id=agent_id, human_id=human_id,
+        )
+        async with _client_for(app) as client:
+            r_unpub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/unpublish")
+        assert r_unpub.status_code == 422, r_unpub.text
+        body = r_unpub.json()
+        error = body.get("error") or body
+        assert error["code"] == "CHANNEL_SCOPE_INSUFFICIENT"
+        assert "threads_delete" in error["required_scopes"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublish_success_with_sufficient_scope_marks_unpublished_preserves_external_id():
+    """AC2 — 스코프가 있으면 실제 삭제 호출→성공 시 status='unpublished'·external_id
+    보존(지워지지 않음)·시각 기록(updated_at)."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(
+                s, org_id, scopes=["threads_basic", "threads_content_publish", "threads_delete"],
+            )
+
+        draft_id, gate_id, external_id = await _publish_immediately(
+            app, Session, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            agent_id=agent_id, human_id=human_id,
+        )
+        with patch.object(tp, "delete_media", AsyncMock(return_value=None)) as mock_delete:
+            async with _client_for(app) as client:
+                r_unpub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/unpublish")
+        assert r_unpub.status_code == 200, r_unpub.text
+        body = r_unpub.json().get("data") or r_unpub.json()
+        assert body["status"] == "unpublished"
+        assert body["external_id"] == external_id
+        assert body["unpublished_at"] is not None
+        assert mock_delete.await_count == 1
+        _, kwargs = mock_delete.call_args
+        assert kwargs["media_id"] == external_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublish_not_published_returns_409():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(
+                s, org_id, scopes=["threads_basic", "threads_content_publish", "threads_delete"],
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r_unpub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/unpublish")
+        assert r_unpub.status_code == 409, r_unpub.text
+        body = r_unpub.json()
+        error = body.get("error") or body
+        assert error["code"] == "CHANNEL_POST_NOT_PUBLISHED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublish_twice_second_time_returns_409_not_published():
+    """양성대조 — unpublish 성공 뒤 다시 시도하면(이미 회수됨) 409(재-삭제 시도가
+    Threads로 안 나가야 한다)."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(
+                s, org_id, scopes=["threads_basic", "threads_content_publish", "threads_delete"],
+            )
+
+        draft_id, gate_id, external_id = await _publish_immediately(
+            app, Session, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            agent_id=agent_id, human_id=human_id,
+        )
+        with patch.object(tp, "delete_media", AsyncMock(return_value=None)) as mock_delete:
+            async with _client_for(app) as client:
+                r1 = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/unpublish")
+                assert r1.status_code == 200, r1.text
+                r2 = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/unpublish")
+        assert r2.status_code == 409, r2.text
+        error = r2.json().get("error") or r2.json()
+        assert error["code"] == "CHANNEL_POST_NOT_PUBLISHED"
+        assert mock_delete.await_count == 1, "두 번째 호출이 Threads DELETE를 또 냈다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublish_provider_error_maps_to_502():
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(
+                s, org_id, scopes=["threads_basic", "threads_content_publish", "threads_delete"],
+            )
+
+        draft_id, gate_id, external_id = await _publish_immediately(
+            app, Session, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            agent_id=agent_id, human_id=human_id,
+        )
+
+        from app.services.threads_publish import ThreadsPublishError
+
+        with patch.object(
+            tp, "delete_media",
+            AsyncMock(side_effect=ThreadsPublishError("THREADS_DELETE_MEDIA_FAILED", "boom", status_code=500)),
+        ):
+            async with _client_for(app) as client:
+                r_unpub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/unpublish")
+        assert r_unpub.status_code == 502, r_unpub.text
+        error = r_unpub.json().get("error") or r_unpub.json()
+        assert error["code"] == "CHANNEL_PUBLISH_PROVIDER_ERROR"
+
+        # 실패했으니 status는 여전히 published(unpublished로 잘못 바뀌면 안 된다).
+        async with Session() as s:
+            from app.models.channel_publication import ChannelPublication
+            from sqlalchemy import select
+            pub = (await s.execute(
+                select(ChannelPublication).where(ChannelPublication.gate_id == gate_id)
+            )).scalar_one()
+            assert pub.status == "published", "실패했는데 unpublished로 바뀜(회귀)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublish_agent_caller_forbidden():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts/{uuid.uuid4()}/unpublish",
+            )
+        assert r.status_code == 403, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublish_unsupported_channel_returns_422():
+    """AC2 — 어댑터가 supports_unpublish=False로 선언한 채널은 스코프 확인 前에 이미
+    422(서버도 독립적으로 거부 — FE 버튼 미노출과 별개의 방어선)."""
+    from unittest.mock import patch
+    from app.main import app
+    import app.services.channel_posts as cp_module
+    from app.services.channel_adapters import ChannelAdapterConfig
+
+    unsupported_adapter = ChannelAdapterConfig(
+        authorize_url="https://example.test/oauth", token_url="https://example.test/token",
+        scope="basic", refresh_mode="manual", max_text_length=500,
+        supports_unpublish=False,
+    )
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(
+                s, org_id, scopes=["threads_basic", "threads_content_publish", "threads_delete"],
+            )
+
+        draft_id, gate_id, external_id = await _publish_immediately(
+            app, Session, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            agent_id=agent_id, human_id=human_id,
+        )
+        with patch.object(cp_module, "get_channel_adapter", return_value=unsupported_adapter):
+            async with _client_for(app) as client:
+                r_unpub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/unpublish")
+        assert r_unpub.status_code == 422, r_unpub.text
+        error = r_unpub.json().get("error") or r_unpub.json()
+        assert error["code"] == "CHANNEL_UNPUBLISH_UNSUPPORTED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3419_cancel_unpublish.py
+++ b/backend/tests/test_3419_cancel_unpublish.py
@@ -744,3 +744,97 @@ async def test_unpublish_unsupported_channel_returns_422():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+# --- unpublish_blocked_reason(페드루 PO 리뷰, PR#3774) ------------------------------
+
+
+@pytest.mark.anyio
+async def test_connection_list_unpublish_blocked_reason_null_when_can_unpublish():
+    """can_unpublish=true면 unpublish_blocked_reason은 항상 null(막힌 이유가 없다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="member")
+            connection_id = await _seed_connection(
+                s, org_id, scopes=["threads_basic", "threads_content_publish", "threads_delete"],
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+        assert r.status_code == 200, r.text
+        items = r.json()
+        row = [it for it in items if it["id"] == str(connection_id)][0]
+        assert row["can_unpublish"] is True
+        assert row["unpublish_blocked_reason"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_connection_list_unpublish_blocked_reason_scope_insufficient():
+    """유나 §17-11 대상 — 어댑터는 지원하는데 스코프가 없는 경우(기존 연결 재현,
+    scopes 명시 안 함=server_default)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="member")
+            connection_id = await _seed_connection(s, org_id)  # scopes 명시 안 함
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+        assert r.status_code == 200, r.text
+        items = r.json()
+        row = [it for it in items if it["id"] == str(connection_id)][0]
+        assert row["can_unpublish"] is False
+        assert row["unpublish_blocked_reason"] == "scope_insufficient"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_connection_list_unpublish_blocked_reason_unsupported_for_adapter_without_support():
+    """어댑터가 아예 supports_unpublish=False로 선언한 채널은 스코프와 무관하게
+    'unsupported' — §17-11 문구 대상이 아니다(재연결해도 안 풀림)."""
+    from unittest.mock import patch
+    from app.main import app
+    import app.routers.channel_connections as cc_module
+    from app.services.channel_adapters import ChannelAdapterConfig
+
+    unsupported_adapter = ChannelAdapterConfig(
+        authorize_url="https://example.test/oauth", token_url="https://example.test/token",
+        scope="basic", refresh_mode="manual", max_text_length=500,
+        supports_unpublish=False,
+    )
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, role="member")
+            connection_id = await _seed_connection(
+                s, org_id, scopes=["threads_basic", "threads_content_publish", "threads_delete"],
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+        with patch.object(cc_module, "get_channel_adapter", return_value=unsupported_adapter):
+            async with _client_for(app) as client:
+                r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections")
+        assert r.status_code == 200, r.text
+        items = r.json()
+        row = [it for it in items if it["id"] == str(connection_id)][0]
+        assert row["can_unpublish"] is False
+        assert row["unpublish_blocked_reason"] == "unsupported"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,6 @@
 {
   "_snapshot_policy": "story #3383(2026-09-03) — 로컬 재측정(템플릿 DB 적용 후). 로컬 절대시간은 CI의 ~1/6이지만(실측), 파일 간 상대 비중은 LPT 배분에 유효하다. 재측정 기준은 이전과 동일: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐.",
-  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)",
+  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)",
   "measured_at": "2026-09-03",
   "files": [
     {
@@ -858,6 +858,10 @@
     {
       "file": "tests/test_3415_channel_post_command_exposure.py",
       "sec": 19.0
+    },
+    {
+      "file": "tests/test_3419_cancel_unpublish.py",
+      "sec": 31.0
     }
   ]
 }


### PR DESCRIPTION
[SID:3419]

## 배경
PR 2(#3768)에서 화면 설계(유나 §8·§11)의 «발행 취소» 버튼을 서버 경로 부재로 죽은 버튼 처리했다(미르코 관측). 이 PR이 그 서버 경로 둘.

## 변경

**① `POST .../channel-posts/drafts/{draft_id}/cancel-scheduled`** — 이 draft gate의 가장 최근 `publication_command`가 `pending`·`blocked`·`dead_letter`면 `cancelled`(reason_code=`CANCELLED_BY_HUMAN`)로 전이(PO 確定 ①-a — "이 명령을 끝내겠다"는 사람 의사이므로 종결 아닌 상태 전부 허용). 그 외(`in_progress`·`completed`·`voided`·`cancelled`)는 409(코드+현재 상태 실림). cron의 클레임 WHERE절(`status='pending'`)이 구조적으로 `cancelled`를 절대 안 집는다 — 새 배제 로직 불요(voided·dead_letter·blocked와 동일 원리, #3414에서 이미 확立).

**② `POST .../channel-posts/drafts/{draft_id}/unpublish`** — Threads 공식 삭제 API 실측 반영(`DELETE graph.threads.net/v1.0/{media-id}`, 스코프 `threads_basic`+`threads_delete`, 100건/일 — 출처 developers.facebook.com/docs/threads/posts/delete-posts/, 2026-09-04 확인). 성공 시 `channel_publications.status=unpublished`(`external_id` 보존 — 지우지 않음, `updated_at`으로 시각 기록). 가드 순서(Threads 호출 前 전부): gate 존재 → published 행 존재 → 어댑터 `supports_unpublish` → 연결 활성 → 연결 스코프. **기존 연결은 `threads_delete` 스코프 없이 이미 저장돼 있어 422 `CHANNEL_SCOPE_INSUFFICIENT`로 막힌다(PO 確定 ②-a, 의도)** — 재인증하면 새 `scope` 문자열이 반영돼 자동 해소. 새 컬럼·새 마이그레이션 없이 기존 관례(`channel_connections.scopes`가 연결 시점의 adapter `scope` 문자열을 저장해 온 것)를 그대로 재사용했다.

- `channel_adapters.py`: `ChannelAdapterConfig`에 `supports_unpublish`·`unpublish_required_scope` 선언(`max_text_length`·`can_auto_refresh`와 동형 관례, 신규 패턴 없음) + threads 항목 `scope`에 `threads_delete` 추가(line 58, 새 연결 플로우부터 자동 반영).
- `threads_publish.py`: `delete_media()` 추가(기존 `_MEDIA_URL_TMPL` 재사용).
- `channel_connections.py`: 목록 응답에 `can_unpublish`(어댑터 선언 ∧ 연결 스코프 최종 판정) 노출 — FE가 단일 값으로 버튼 렌더 판단.
- `channel_posts.py`: `cancel_scheduled_publication()`·`unpublish_channel_post()` 신규 서비스 함수 + 라우터에 owner/admin 전용 엔드포인트 2종(`_require_owner_or_admin`, site-posts unpublish 관례와 동형 — 발행 자체보다 좁은 권한, 되돌릴 수 있는 파괴적 상태전환이라 한 단계 더).

## AC6(문서) — 유나 doc 절 번호
「Phase 1 화면 설계 — 채널 포스트 관리」§17-10(열거형 둘 분리 — `publication_commands.status` vs `channel_publications.status`, `cancelled`·`unpublished`·`voided` 3자 구분 포함)·§17-11(스코프 부족 시 owner/member별 문구, 「연결을 다시 하면 회수할 수 있습니다」)에 이미 선반영돼 있다(그라운딩 확인, 2026-09-04) — 이 PR엔 문서 변경 없음.

## 검증
- 신규 테스트 13건: pending 취소+cron 회귀가드·blocked/dead_letter 취소·completed 취소 409·명령 없음 404·에이전트/member 403·스코프 부족 422·회수 성공(external_id 보존)·미발행 409·이중 unpublish 409(재-삭제 호출 0회)·provider 오류 502·미지원 채널 422.
- mutation self-check 2건 — 취소 가능 상태 집합을 `{pending}`으로 축소 → blocked/dead_letter 취소 테스트 정확히 RED. `published` 필터 제거 → 이중 unpublish 테스트가 락 경합으로 hang(가드 부재가 얼마나 위험한지 오히려 더 뚜렷하게 확인) → 둘 다 원복 후 재확인.
- develop(#3414+#3418 머지 후)로 rebase, 44/44 green(관련 회귀 포함).

## 범위 밖
- FE 배선(버튼 노출)은 미르코 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm
