### PR TITLE
[SID:3423] feat: channel-posts 목록 필터 — scheduled_from/scheduled_to·unscheduled

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -311,7 +311,8 @@ async def list_channel_post_drafts_endpoint(
     unscheduled: bool = Query(
         default=False,
         description="true면 gate.sealed_scheduled_at이 null인 draft만(캘린더 「날짜 미정」 "
-        "레인). scheduled_from/scheduled_to와 상호 배타.",
+        "레인). scheduled_from/scheduled_to와 상호 배타. 게이트 자체가 없는(아직 상신 "
+        "안 한) 순수 초안도 포함한다 — 둘 다 「날짜 미정」이라는 점에서 같은 부류다(유나 §11-1).",
     ),
     db: AsyncSession = Depends(get_db),
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -298,16 +298,65 @@ async def list_channel_post_drafts_endpoint(
     org_id: uuid.UUID,
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
+    scheduled_from: datetime | None = Query(
+        default=None,
+        description="예약 시각 범위 시작(tz-aware ISO, gate.sealed_scheduled_at 기준 — "
+        "publication_command의 스냅샷 값이 아니다). unscheduled와 함께 줄 수 없다.",
+    ),
+    scheduled_to: datetime | None = Query(
+        default=None,
+        description="예약 시각 범위 끝(tz-aware ISO, gate.sealed_scheduled_at 기준). "
+        "unscheduled와 함께 줄 수 없다.",
+    ),
+    unscheduled: bool = Query(
+        default=False,
+        description="true면 gate.sealed_scheduled_at이 null인 draft만(캘린더 「날짜 미정」 "
+        "레인). scheduled_from/scheduled_to와 상호 배타.",
+    ),
     db: AsyncSession = Depends(get_db),
     verified_org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> list[ChannelPostDraftListItem]:
     """조직 멤버(휴먼·에이전트 모두) 읽기 가능 — site_posts 목록과 동형(승인·발행 경계
-    밖이라 human-only 제약 없음)."""
+    밖이라 human-only 제약 없음).
+
+    story #3423(캘린더 #3422 선행) — 날짜 필터 셋(scheduled_from/scheduled_to/
+    unscheduled)이 없으면 기존 응답과 완전히 동일(회귀 0). 있으면 tz-aware를
+    강제(naive는 비교 결과가 항상 어긋나는 #3414 nit J와 동일 함정)하고, unscheduled는
+    범위 파라미터와 상호 배타(둘 다 주면 "무엇을 원하는지" 모호해진다)."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
 
-    rows = await list_channel_post_drafts(db, org_id=org_id, limit=limit, offset=offset)
+    if unscheduled and (scheduled_from is not None or scheduled_to is not None):
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_POST_LIST_FILTER_CONFLICT",
+                "message": "unscheduled는 scheduled_from/scheduled_to와 함께 줄 수 없습니다.",
+            },
+        )
+    for _label, _value in (("scheduled_from", scheduled_from), ("scheduled_to", scheduled_to)):
+        if _value is not None and _value.tzinfo is None:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "CHANNEL_POST_LIST_FILTER_NAIVE_DATETIME",
+                    "message": f"{_label}은 timezone 정보가 있어야 합니다(예: Z 또는 +09:00).",
+                },
+            )
+    if scheduled_from is not None and scheduled_to is not None and scheduled_from > scheduled_to:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "CHANNEL_POST_LIST_FILTER_RANGE_INVALID",
+                "message": "scheduled_from은 scheduled_to보다 늦을 수 없습니다.",
+            },
+        )
+
+    rows = await list_channel_post_drafts(
+        db, org_id=org_id, limit=limit, offset=offset,
+        scheduled_from=scheduled_from, scheduled_to=scheduled_to, unscheduled=unscheduled,
+    )
     return [_to_draft_list_item(row) for row in rows]
 
 

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -451,6 +451,9 @@ async def list_channel_post_draft_versions(
 async def list_channel_post_drafts(
     db: AsyncSession, *, org_id: uuid.UUID, limit: int = 50, offset: int = 0,
     draft_id: uuid.UUID | None = None,
+    scheduled_from: datetime | None = None,
+    scheduled_to: datetime | None = None,
+    unscheduled: bool = False,
 ) -> list[
     tuple[
         ChannelPostDraft, ChannelPostVersion, ChannelPostVersion,
@@ -492,7 +495,15 @@ async def list_channel_post_drafts(
 
     반환: (draft, latest_version, origin_version, gate, published_publication,
     latest_version_publication, published_body_sha256, latest_command) — gate·publication·
-    command 계열은 없으면 None(지어내지 않는다, "모른다≠다르다")."""
+    command 계열은 없으면 None(지어내지 않는다, "모른다≠다르다").
+
+    story #3423(캘린더 #3422 선행) — `scheduled_from`/`scheduled_to`/`unscheduled`.
+    기준 컬럼은 **`gate.sealed_scheduled_at`**(승인된 예약 시각) — `publication_command.
+    scheduled_at`이 아니다(그 값은 요청 시점 스냅샷, story #3414). "그 게이트"의 정의는
+    배치②와 동일(work_item당 가장 최근 생성된 external_publish 게이트) — 필터가
+    사후 필터링이 아니라 **페이지 쿼리 자체**에 들어가야 LIMIT/OFFSET이 필터링된
+    결과 위에서 동작한다(안 그러면 페이지가 좁아지거나 빈 페이지가 나온다). 필터가
+    하나도 없으면 이 조인·정렬 변경 자체를 안 탄다(기존 응답 완전 불변, 회귀 0)."""
     latest_version_ids = (
         select(
             ChannelPostVersion.draft_id,
@@ -526,10 +537,40 @@ async def list_channel_post_drafts(
             & (origin.version == origin_version_ids.c.min_version),
         )
         .where(ChannelPostDraft.org_id == org_id)
-        .order_by(latest.created_at.desc())
-        .limit(limit)
-        .offset(offset)
     )
+
+    schedule_filter_active = unscheduled or scheduled_from is not None or scheduled_to is not None
+    if schedule_filter_active:
+        latest_gate_ids = (
+            select(Gate.work_item_id, func.max(Gate.created_at).label("max_created_at"))
+            .where(Gate.org_id == org_id, Gate.gate_type == _EXTERNAL_PUBLISH_GATE_TYPE)
+            .group_by(Gate.work_item_id)
+            .subquery()
+        )
+        filter_gate = aliased(Gate)
+        stmt = stmt.outerjoin(
+            latest_gate_ids, latest_gate_ids.c.work_item_id == ChannelPostDraft.work_item_id,
+        ).outerjoin(
+            filter_gate,
+            (filter_gate.work_item_id == latest_gate_ids.c.work_item_id)
+            & (filter_gate.created_at == latest_gate_ids.c.max_created_at)
+            & (filter_gate.gate_type == _EXTERNAL_PUBLISH_GATE_TYPE)
+            & (filter_gate.org_id == org_id),
+        )
+        if unscheduled:
+            stmt = stmt.where(filter_gate.sealed_scheduled_at.is_(None))
+        else:
+            if scheduled_from is not None:
+                stmt = stmt.where(filter_gate.sealed_scheduled_at >= scheduled_from)
+            if scheduled_to is not None:
+                stmt = stmt.where(filter_gate.sealed_scheduled_at <= scheduled_to)
+        # AC2 — 필터가 활성일 때만 정렬을 예약 시각 기준으로 바꾼다(미정은 NULLS LAST
+        # 뒤 created_at으로 2차 정렬). 필터 없는 기본 목록의 정렬(최근 편집순)은 안 건드린다.
+        stmt = stmt.order_by(filter_gate.sealed_scheduled_at.asc().nulls_last(), latest.created_at.desc())
+    else:
+        stmt = stmt.order_by(latest.created_at.desc())
+
+    stmt = stmt.limit(limit).offset(offset)
     if draft_id is not None:
         stmt = stmt.where(ChannelPostDraft.id == draft_id)
     page_rows = [(row[0], row[1], row[2]) for row in (await db.execute(stmt)).all()]

--- a/backend/tests/test_3423_channel_post_scheduled_filter.py
+++ b/backend/tests/test_3423_channel_post_scheduled_filter.py
@@ -1,0 +1,535 @@
+"""story #3423(Phase1·마케팅운영·소형, 페드루 PO 確定 2026-09-04) — channel-posts 목록에
+예약 시각 날짜 범위 필터(`scheduled_from`/`scheduled_to`)와 「날짜 미정」 필터
+(`unscheduled=true`) 추가. 캘린더 화면(#3422) 선행 — 클라이언트 전량 조회 금지.
+
+AC 요지:
+- 기준 컬럼은 `gate.sealed_scheduled_at`(승인된 예약 시각) — `publication_command.
+  scheduled_at`(요청 시점 스냅샷, #3414)이 아니다.
+- `unscheduled`와 범위 파라미터는 상호 배타(422).
+- `scheduled_from > scheduled_to`면 422. naive datetime(tz 정보 없음)도 422.
+- 필터가 하나도 없으면 기존 응답과 완전히 동일해야 한다(회귀 0).
+- 기존 6쿼리 구조 유지(N+1 금지) — 필터는 페이지 쿼리 자체에 gate 조인으로 들어간다."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="3423 Scheduled Filter Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="담롱"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="채널 포스트"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_default_role(session, org_id):
+    from app.models.participation import ParticipationRole
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+    session.add(role)
+    await session.commit()
+    return role.id
+
+
+async def _seed_connection(session, org_id, *, channel="threads", status="active", account_id=None, token="plain-access-token"):
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    conn = ChannelConnection(
+        id=uuid.uuid4(), org_id=org_id, channel=channel,
+        account_id=account_id or f"acct-{uuid.uuid4().hex[:8]}", status=status,
+        credential_kind="oauth", refresh_mode="reissue_from_access_token",
+        encrypted_access_token=encrypt_channel_credential(token) if status == "active" else None,
+    )
+    session.add(conn)
+    await session.commit()
+    return conn.id
+
+
+async def _approve_gate_directly(session, gate_id):
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    gate = (await session.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+    gate.status = "approved"
+    gate.resolver_id = uuid.uuid4()
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.commit()
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id, agent: bool = False):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if agent:
+            claims["app_metadata"]["api_key_id"] = "test-agent-key"
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+def _draft_body(*, work_item_id, connection_id, text="채널 포스트 본문입니다."):
+    return {"work_item_id": str(work_item_id), "connection_id": str(connection_id), "text": text}
+
+
+async def _create_draft_submit_approve(
+    client, session, *, org_id, connection_id, story_id, text="채널 포스트 본문입니다.",
+    scheduled_at: datetime | None = None,
+):
+    r_draft = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+        json=_draft_body(work_item_id=story_id, connection_id=connection_id, text=text),
+    )
+    assert r_draft.status_code == 201, r_draft.text
+    draft_id = r_draft.json()["draft_id"]
+    submit_body = {}
+    if scheduled_at is not None:
+        submit_body["scheduled_at"] = scheduled_at.isoformat()
+    r_submit = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json=submit_body,
+    )
+    assert r_submit.status_code == 200, r_submit.text
+    gate_id = uuid.UUID(r_submit.json()["gate_id"])
+    await _approve_gate_directly(session, gate_id)
+    return draft_id, gate_id
+
+
+def _ids(items):
+    return {it["draft_id"] for it in items}
+
+
+@pytest.mark.anyio
+async def test_no_filter_response_unchanged():
+    """AC3 회귀 — 필터 파라미터를 아예 안 주면 기존 응답과 완전히 동일(정렬·전체 목록)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_a, _ = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id,
+                story_id=await _seed_story(s, org_id, project_id, title="A"),
+                scheduled_at=datetime.now(timezone.utc) + timedelta(days=1),
+            )
+            draft_b, _ = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id,
+                story_id=await _seed_story(s, org_id, project_id, title="B"),
+            )
+
+            r_no_filter = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+            r_explicit_none = await client.get(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                params={"limit": 50, "offset": 0},
+            )
+        assert r_no_filter.status_code == 200, r_no_filter.text
+        assert r_no_filter.json() == r_explicit_none.json()
+        assert _ids(r_no_filter.json()) == {draft_a, draft_b}
+        # 기본 정렬(최근 편집순 = created_at desc) — draft_b가 나중에 만들어졌으니 먼저.
+        order = [it["draft_id"] for it in r_no_filter.json()]
+        assert order.index(draft_b) < order.index(draft_a)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_scheduled_range_filters_by_gate_sealed_scheduled_at():
+    """AC1 핵심 — 범위 안의 gate.sealed_scheduled_at만 걸린다(다른 draft·미정 draft 제외)."""
+    from app.main import app
+
+    now = datetime.now(timezone.utc)
+    in_range = now + timedelta(days=3)
+    out_of_range = now + timedelta(days=30)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_in, _ = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id,
+                story_id=await _seed_story(s, org_id, project_id, title="in-range"),
+                scheduled_at=in_range,
+            )
+            draft_out, _ = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id,
+                story_id=await _seed_story(s, org_id, project_id, title="out-of-range"),
+                scheduled_at=out_of_range,
+            )
+            draft_unset, _ = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id,
+                story_id=await _seed_story(s, org_id, project_id, title="unset"),
+            )
+
+            r = await client.get(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                params={
+                    "scheduled_from": (now + timedelta(days=1)).isoformat(),
+                    "scheduled_to": (now + timedelta(days=7)).isoformat(),
+                },
+            )
+        assert r.status_code == 200, r.text
+        assert _ids(r.json()) == {draft_in}, (
+            f"범위 필터가 정확하지 않다: {_ids(r.json())} (기대: {{draft_in}}, "
+            f"out={draft_out}, unset={draft_unset})"
+        )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_scheduled_from_equals_to_matches_exact_instant():
+    """AC3 경계 — from=to(같은 시각)면 정확히 그 시각인 draft만(포함 양끝)."""
+    from app.main import app
+
+    pinned = datetime.now(timezone.utc) + timedelta(days=2)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_pinned, _ = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id,
+                story_id=await _seed_story(s, org_id, project_id, title="pinned"),
+                scheduled_at=pinned,
+            )
+            draft_off_by_one_sec, _ = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id,
+                story_id=await _seed_story(s, org_id, project_id, title="off-by-1s"),
+                scheduled_at=pinned + timedelta(seconds=1),
+            )
+
+            r = await client.get(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                params={"scheduled_from": pinned.isoformat(), "scheduled_to": pinned.isoformat()},
+            )
+        assert r.status_code == 200, r.text
+        assert _ids(r.json()) == {draft_pinned}
+        assert draft_off_by_one_sec not in _ids(r.json())
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unscheduled_filter_matches_null_sealed_scheduled_at_including_no_gate():
+    """AC1 — unscheduled=true는 sealed_scheduled_at IS NULL인 draft만: 예약 없이 상신된
+    것뿐 아니라 **게이트조차 없는 순수 초안**도 포함(둘 다 「날짜 미정」, 유나 §11-1)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_scheduled, _ = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id,
+                story_id=await _seed_story(s, org_id, project_id, title="scheduled"),
+                scheduled_at=datetime.now(timezone.utc) + timedelta(days=1),
+            )
+            draft_submitted_unset, _ = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id,
+                story_id=await _seed_story(s, org_id, project_id, title="submitted-unset"),
+            )
+            # 순수 초안(상신조차 안 함 — 게이트 자체가 없다).
+            r_pure_draft = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json=_draft_body(
+                    work_item_id=await _seed_story(s, org_id, project_id, title="pure-draft"),
+                    connection_id=connection_id,
+                ),
+            )
+            assert r_pure_draft.status_code == 201, r_pure_draft.text
+            draft_pure = r_pure_draft.json()["draft_id"]
+
+            r = await client.get(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                params={"unscheduled": "true"},
+            )
+        assert r.status_code == 200, r.text
+        assert _ids(r.json()) == {draft_submitted_unset, draft_pure}, (
+            f"unscheduled 필터 결과가 어긋남: {_ids(r.json())}"
+        )
+        assert draft_scheduled not in _ids(r.json())
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unscheduled_and_range_together_returns_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, _project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                params={
+                    "unscheduled": "true",
+                    "scheduled_from": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+        assert r.status_code == 422, r.text
+        error = r.json().get("error") or r.json()
+        assert error["code"] == "CHANNEL_POST_LIST_FILTER_CONFLICT"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_scheduled_from_after_to_returns_422():
+    from app.main import app
+
+    now = datetime.now(timezone.utc)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, _project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                params={
+                    "scheduled_from": (now + timedelta(days=5)).isoformat(),
+                    "scheduled_to": now.isoformat(),
+                },
+            )
+        assert r.status_code == 422, r.text
+        error = r.json().get("error") or r.json()
+        assert error["code"] == "CHANNEL_POST_LIST_FILTER_RANGE_INVALID"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_naive_datetime_returns_422():
+    """AC1 — tz 정보 없는 scheduled_from은 422(naive/aware 비교가 항상 어긋나는 함정,
+    #3414 nit J와 동일 사상)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, _project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                params={"scheduled_from": "2026-09-10T00:00:00"},
+            )
+        assert r.status_code == 422, r.text
+        error = r.json().get("error") or r.json()
+        assert error["code"] == "CHANNEL_POST_LIST_FILTER_NAIVE_DATETIME"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def _count_selects_for_filtered_list(client, engine, org_id, *, params):
+    from sqlalchemy import event
+
+    statements: list[str] = []
+
+    def _listener(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _listener)
+    try:
+        r = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts", params=params)
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _listener)
+    assert r.status_code == 200, r.text
+    select_count = len([st for st in statements if st.strip().upper().startswith("SELECT")])
+    return r.json(), select_count
+
+
+@pytest.mark.anyio
+async def test_filtered_query_count_flat_no_n_plus_one():
+    """AC2 — 필터가 활성일 때 SELECT 수가 draft 개수와 무관하게 고정(N+1 금지).
+    doc상 "총 6쿼리"는 published 상태 draft가 있을 때의 상한(배치⑤ published_publication
+    본문해시 조회가 published_version_ids가 비면 조건부로 스킵된다 — 배치 수 자체가
+    draft 수에 비례해 늘지 않는다는 것이 진짜 불변식이므로, 1건 vs 3건 draft를 필터
+    활성 상태로 같이 재고 쿼리 수가 같은지로 검증한다(매직넘버 6 고정 대신)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        filter_params = {
+            "scheduled_from": (datetime.now(timezone.utc)).isoformat(),
+            "scheduled_to": (datetime.now(timezone.utc) + timedelta(days=7)).isoformat(),
+        }
+
+        async with _client_for(app) as client, Session() as s:
+            await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id,
+                story_id=await _seed_story(s, org_id, project_id, title="one-draft"),
+                scheduled_at=datetime.now(timezone.utc) + timedelta(days=1),
+            )
+            items_1, select_count_1 = await _count_selects_for_filtered_list(
+                client, engine, org_id, params=filter_params,
+            )
+            assert len(items_1) == 1
+
+            for n in range(3):
+                await _create_draft_submit_approve(
+                    client, s, org_id=org_id, connection_id=connection_id,
+                    story_id=await _seed_story(s, org_id, project_id, title=f"more-{n}"),
+                    scheduled_at=datetime.now(timezone.utc) + timedelta(days=1),
+                )
+            items_4, select_count_4 = await _count_selects_for_filtered_list(
+                client, engine, org_id, params=filter_params,
+            )
+            assert len(items_4) == 4
+
+        print(f"\n=== N+1 실측(필터 활성): 1건 SELECT={select_count_1}, 4건 SELECT={select_count_4}")
+        assert select_count_1 == select_count_4, (
+            f"draft 수가 늘자 쿼리 수도 늘었다(N+1 의심): 1건={select_count_1}, 4건={select_count_4}"
+        )
+        assert select_count_1 >= 3, "쿼리가 너무 적다 — listener가 아무것도 못 잡았을 가능성"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,6 @@
 {
   "_snapshot_policy": "story #3383(2026-09-03) — 로컬 재측정(템플릿 DB 적용 후). 로컬 절대시간은 CI의 ~1/6이지만(실측), 파일 간 상대 비중은 LPT 배분에 유효하다. 재측정 기준은 이전과 동일: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐.",
-  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)",
+  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)+story-3423-scheduled-filter(CI shard(2) unweighted-guard 실측 23s, run 33849386492/job 100950217041, 2026-09-04 — PR#3775)",
   "measured_at": "2026-09-03",
   "files": [
     {
@@ -862,6 +862,10 @@
     {
       "file": "tests/test_3419_cancel_unpublish.py",
       "sec": 31.0
+    },
+    {
+      "file": "tests/test_3423_channel_post_scheduled_filter.py",
+      "sec": 23.0
     }
   ]
 }


### PR DESCRIPTION
[SID:3423]

## 요지
`GET .../channel-posts/drafts` 목록에 예약 시각 날짜 범위(`scheduled_from`/`scheduled_to`)와 「날짜 미정」(`unscheduled=true`) 필터를 추가한다. 캘린더 화면(#3422)이 클라이언트 전량 조회 없이 필터된 페이지만 받을 수 있게 하는 선행 작업 — PR#3769(#3414) 추가③ 미이행분.

## 기준 컬럼
**`gates.sealed_scheduled_at`**(승인된 예약 시각) — `publication_command.scheduled_at`(요청 시점 스냅샷, #3414)이 아니다. "그 게이트"의 정의는 목록 서비스의 기존 배치②(work_item당 가장 최근 생성된 external_publish 게이트)와 동일하다.

## 설계
- 필터는 사후 필터링이 아니라 **페이지 쿼리 자체**(조건부 outerjoin)에 들어간다 — LIMIT/OFFSET이 필터된 결과 위에서 동작해야 하므로.
- 필터 파라미터가 하나도 없으면 이 조인·정렬 변경 자체를 안 탄다 — 기존 응답과 완전히 동일(회귀 0, 테스트로 고정).
- 라우터 단 검증 3종(422): `unscheduled`+범위 동시 지정(`CHANNEL_POST_LIST_FILTER_CONFLICT`), naive datetime(`CHANNEL_POST_LIST_FILTER_NAIVE_DATETIME`), `scheduled_from > scheduled_to`(`CHANNEL_POST_LIST_FILTER_RANGE_INVALID`).

## 테스트
신규 8건(`test_3423_channel_post_scheduled_filter.py`): 범위 필터·경계(from=to 동일시각)·unscheduled(게이트 없는 순수 초안 포함)·422 3종·필터 없을 때 응답 완전 불변(회귀)·N+1 미발생(1건 vs 4건 draft SELECT 수 비교). `test_3415_channel_post_command_exposure.py` 회귀 8건도 재확인 PASS.

필터링 로직 2종 뮤테이션 자가검증 완료(`schedule_filter_active` 강제 비활성·`unscheduled` 조건 반전) — 둘 다 예측된 대상 테스트만 정확히 RED, 원복 후 byte-identical 재확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm