### PR TITLE
[SID:3427] feat: destructive_schema 신규 파일 shard-weights 미등재 조기 가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,31 @@ jobs:
         working-directory: backend
         run: python3 scripts/lint_destructive_test_sql.py
 
+  # story 23bf1913(CI 후속, 2026-09-04) — 오늘 4 PR(#3769·#3773·#3774·#3775)이 신규
+  # destructive_schema 파일을 shard-weights.json에 안 넣은 채 열려, story #3392의
+  # unweighted 가드가 **샤드 완주 뒤(~20분)**에야 그 사실을 알렸다(4×20분 낭비, 기능
+  # 결함 0건 — 전부 등재 누락). 이 job은 shard 분배 前 별도로 즉시 판정한다(discover
+  # +load_weights+unweighted_files_in을 shard_destructive_tests.py에서 그대로 재사용,
+  # 신규 로직 발명 0). Postgres 불요(--collect-only는 DB 연결 없음, 스크립트 docstring
+  # 실측 확認) — uv 설치+더미 JWT_SECRET/SECRET_KEY만으로 끝난다.
+  destructive-schema-weights-registered-lint:
+    name: destructive schema weights registered (guard, story 23bf1913)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      JWT_SECRET: ci-test-secret-at-least-32-chars-long
+      SECRET_KEY: ci-test-secret-at-least-32-chars-long
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: 'latest'
+      - name: Check every destructive_schema test file is registered in shard-weights.json
+        working-directory: backend
+        run: python3 scripts/lint_destructive_schema_weights_registered.py
+
   # story a05da51b(2026-09-02, story #3330/PR#3711 CI flake 후속) — destructive_schema
   # 마커 파일이 publish_registry_event/publish_preset_event/transition_gate/send_message
   # (전역 엔진 app.core.database.engine의 background task 경로를 실제로 태우는 진입점)를

--- a/backend/scripts/lint_destructive_schema_weights_registered.py
+++ b/backend/scripts/lint_destructive_schema_weights_registered.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""story 23bf1913(CI 후속, 페드루 PO 착수 2026-09-04) — 신규 destructive_schema 테스트
+파일이 `infra/destructive-schema-shard-weights.json`에 미등재면 샤드 분배 **前** 별도
+정적 체크에서 즉시 실패한다.
+
+오늘(2026-09-04) 4건 PR(#3769·#3773·#3774·#3775) 전부 같은 사고를 반복했다 — 새
+destructive 파일을 weights.json에 안 넣은 채 PR을 열면, story #3392의 unweighted 초과
+가드(AC1, `shard_destructive_tests.py`)가 그 사실을 알려 주긴 하는데 **그 샤드가 파일을
+전부 완주한 뒤에야**(~20분) 로그에 나타난다. 4 PR × 재커밋 1회 × 완주 대기 = 4×20분 낭비 —
+전부 기능 결함 0건, 등재 누락뿐이었다.
+
+이 가드는 그 20분을 기다리지 않는다 — `shard_destructive_tests.py`가 이미 갖고 있는
+`discover_files()`(pytest --collect-only, ⛔discover가 항상 SSOT — 그 모듈 docstring
+그대로)·`load_weights()`·`unweighted_files_in()`·`average_weight()`를 그대로 재사용해
+(신규 판정 로직 발명 0) 별도 CI job에서 즉시 판정한다.
+
+Postgres 불요 — `--collect-only`는 DB 연결이 없다(실측 확認, 로컬 `JWT_SECRET=x
+SECRET_KEY=x pytest -m destructive_schema --collect-only` 14초 완주). 더미
+JWT_SECRET/SECRET_KEY(설정값 검증 통과용, 실제 인증에는 안 쓰임)+uv sync만으로 끝난다 —
+`backend-test-destructive`(8-way 매트릭스+Postgres+템플릿 DB 빌드) 전체를 기다릴 필요가
+없다.
+
+⛔이 가드가 못 잡는 것(story #3392의 다른 가드와 축이 다르다 — 명시 선언, 다른 lint
+스크립트들의 관례 그대로):
+  · 이미 등재는 됐지만 실측치가 크게 틀린(낡은) 파일 — 그건 story #3392의 unweighted
+    초과 가드(AC1, shard 완주 후 실측 대조)와 `check_staleness()`(파일 수 +20%) 몫이다.
+    이 가드는 **존재 자체**만 본다("이 파일이 weights.json에 한 줄이라도 있나") — 그
+    줄의 값이 맞는지는 검증하지 않는다.
+  · weights.json에 등재된 파일이 나중에 destructive_schema 마커를 잃거나 파일명이
+    바뀌는 경우 — `discover()`가 SSOT라 그 파일은 애초에 "신규 미등재" 목록에 안 잡히고,
+    반대로 weights.json에 남은 죽은 항목은 이 가드가 지적하지 않는다(무해 —
+    `partition()`이 그 항목을 그냥 안 쓸 뿐, story #3397이 이미 이 경로를 정리했다).
+
+사용법: `python3 scripts/lint_destructive_schema_weights_registered.py`(backend/ cwd)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+from shard_destructive_tests import (  # noqa: E402
+    average_weight,
+    discover_files,
+    load_weights,
+    unweighted_files_in,
+)
+
+
+def main() -> int:
+    files = discover_files()
+    weights = load_weights()
+    missing = unweighted_files_in(files, weights)
+
+    print(f"discover: destructive_schema 파일 {len(files)}개 · weights.json 등재 {len(weights)}개")
+
+    if not missing:
+        print("OK: 신규 미등재 destructive_schema 파일 0건")
+        return 0
+
+    avg = average_weight(weights)
+    print(f"FAIL: shard-weights.json에 없는 destructive_schema 파일 {len(missing)}개(story 23bf1913)")
+    print(
+        "이대로 두면 샤드가 이 파일을 「평균 가중치」로만 배정하고, 실측이 평균의 3배를 "
+        "넘으면(story #3392 AC1) 샤드 완주 뒤(~20분)에야 CI가 빨강이 됩니다."
+    )
+    print()
+    print(
+        "아래 조각을 infra/destructive-schema-shard-weights.json의 \"files\" 배열 끝에 "
+        f"추가하세요(sec 값은 평균 가중치 {avg:.1f}s로 채웠습니다 — 실측치로 바꾸는 편이 "
+        "낫습니다, scripts/measure_destructive_durations_local.py 참고):"
+    )
+    print()
+    for f in missing:
+        print(json.dumps({"file": f, "sec": round(avg, 1)}, ensure_ascii=False) + ",")
+        print(f"::error::destructive_schema 파일이 shard-weights.json에 없습니다(story 23bf1913): {f}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
+++ b/backend/tests/test_2384_scripts_root_image_exclusion_lint.py
@@ -41,6 +41,10 @@ _CI_OR_LOCAL_ONLY_ALLOWLIST = frozenset({
     "lint_project_access_403.py",                 # story #2342 AC7 — CI lint 게이트
     "lint_query_sentinel_direct_calls.py",        # story #2335 — CI lint 게이트
     "lint_no_script_output_artifacts.py",         # story #3008 — CI lint 게이트(scripts/ 파일명·내용 정적 스캔, 운영 DB 무접속)
+    "lint_destructive_schema_weights_registered.py",  # story 23bf1913 — CI lint 게이트(pytest
+                                                   # --collect-only + infra/destructive-schema-shard-
+                                                   # weights.json 정적 대조, Postgres·운영 DB 무접속 —
+                                                   # 그 자신의 docstring에 실측 확認 명시).
     "model_db_drift_audit.py",                    # story #2181 — 로컬 1회성 감사(읽기 전용)
     "shard_destructive_tests.py",                 # story #2293 — CI 매트릭스 샤딩 유틸
     "build_destructive_schema_template.py",       # story #3383 — CI 전용, backend-test-destructive

--- a/backend/tests/test_23bf1913_shard_weights_registered_lint.py
+++ b/backend/tests/test_23bf1913_shard_weights_registered_lint.py
@@ -1,0 +1,89 @@
+"""story 23bf1913 — lint_destructive_schema_weights_registered.py의 정탐/오탐 회귀 가드.
+`unweighted_files_in()`/`average_weight()` 자체의 정확성은 이미
+tests/test_shard_destructive_tests.py가 고정한다(재검증 안 함, 신규 로직 발명 0인
+스크립트라 그쪽 커버리지를 그대로 물려받는다) — 여기서는 이 스크립트 고유의 glue
+(exit code·JSON 조각 출력)만 검증한다. `discover_files()`(실제 `uv run pytest
+--collect-only` 서브프로세스)는 매번 몇 초가 걸려 monkeypatch로 대체한다(합성 fixture,
+story #2786/#2335 lint 테스트와 동형 관례)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import lint_destructive_schema_weights_registered as lint_mod  # noqa: E402
+
+
+def test_positive_control_missing_file_returns_1_and_prints_pasteable_json(monkeypatch, capsys):
+    """story 23bf1913 원 사고(오늘 4 PR) 재현 — discover된 파일 중 하나가 weights.json에
+    없으면 exit 1 + 그 파일명이 붙여넣기 가능한 JSON 조각으로 나온다."""
+    monkeypatch.setattr(
+        lint_mod, "discover_files", lambda: ["tests/test_a.py", "tests/test_new_3900.py"]
+    )
+    monkeypatch.setattr(lint_mod, "load_weights", lambda: {"tests/test_a.py": 10.0})
+
+    exit_code = lint_mod.main()
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "test_new_3900.py" in out
+    assert '"file": "tests/test_new_3900.py"' in out
+    assert '"sec": 10.0' in out  # 평균 가중치(등재 1건뿐이라 그 값 그대로)로 채워짐
+    assert "::error::" in out
+
+
+def test_negative_control_all_registered_returns_0(monkeypatch, capsys):
+    """음성대조 — discover된 파일이 전부 weights.json에 있으면 통과(story 23bf1913)."""
+    monkeypatch.setattr(lint_mod, "discover_files", lambda: ["tests/test_a.py", "tests/test_b.py"])
+    monkeypatch.setattr(
+        lint_mod, "load_weights", lambda: {"tests/test_a.py": 10.0, "tests/test_b.py": 5.0}
+    )
+
+    exit_code = lint_mod.main()
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "OK" in out
+    assert "0건" in out
+
+
+def test_multiple_missing_files_all_listed_in_output(monkeypatch, capsys):
+    """여러 건이 동시에 미등재면 전부 각자 한 줄씩(누락 없이) 나온다."""
+    monkeypatch.setattr(
+        lint_mod, "discover_files",
+        lambda: ["tests/test_a.py", "tests/test_new1.py", "tests/test_new2.py"],
+    )
+    monkeypatch.setattr(lint_mod, "load_weights", lambda: {"tests/test_a.py": 20.0})
+
+    exit_code = lint_mod.main()
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "2개" in out
+    assert "test_new1.py" in out
+    assert "test_new2.py" in out
+
+
+def test_empty_weights_json_still_averages_to_fallback_one(monkeypatch, capsys):
+    """weights.json이 텅 비어 있으면(신규 레포·최초 세팅류) average_weight()의 1.0 폴백
+    (shard_destructive_tests.py 기존 계약, 재검증 안 함)이 그대로 JSON 조각에 실린다 —
+    이 스크립트가 그 폴백을 자기 나름대로 다시 계산하지 않는지 확인."""
+    monkeypatch.setattr(lint_mod, "discover_files", lambda: ["tests/test_only.py"])
+    monkeypatch.setattr(lint_mod, "load_weights", lambda: {})
+
+    exit_code = lint_mod.main()
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert '"sec": 1.0' in out
+
+
+def test_real_repo_state_smoke(capsys):
+    """합성 fixture가 아니라 실물 repo 상태로 한 번 — discover_files()가 실제
+    subprocess를 태워 217개(2026-09-04 실측)를 찾고, 그 시점 weights.json이 전부
+    등재돼 있으면 0을 반환한다(story 23bf1913 PR 스스로가 이 가드를 통과해야 하므로
+    이 테스트 자체가 「가드가 자기 재료를 못 찾으면 빨강」 원칙의 실물 확認)."""
+    exit_code = lint_mod.main()
+    out = capsys.readouterr().out
+    assert exit_code == 0, out
+    assert "OK" in out


### PR DESCRIPTION
[SID:3427]

## 요지
새 `destructive_schema` 테스트 파일이 `infra/destructive-schema-shard-weights.json`에 없으면, 지금까지는 shard가 그 파일을 완주한 뒤(~20분)에야 story #3392의 unweighted 초과 가드가 알려줬다. 오늘 하루 4개 PR(#3769·#3773·#3774·#3775)이 전부 같은 패턴으로 20분씩 낭비했다 — 매번 기능 결함은 0건, 순수 등재 누락이었다.

## 구현
`backend/scripts/lint_destructive_schema_weights_registered.py` 신설 — `shard_destructive_tests.py`의 `discover_files()`(pytest `--collect-only`, discover가 SSOT)·`load_weights()`·`unweighted_files_in()`·`average_weight()`를 그대로 재사용(신규 판정 로직 0)해 shard 분배 전에 즉시 판정한다. 미등재 파일이 있으면 `weights.json`에 그대로 붙여넣을 수 있는 JSON 조각(`{"file": ..., "sec": <평균가중치>}`)을 출력한다.

`--collect-only`는 DB 연결이 필요 없음을 실측 확인(`JWT_SECRET=x SECRET_KEY=x pytest -m destructive_schema --collect-only` 로컬 14초 완주) — `ci.yml`에 Postgres 없는 별도 5분 job으로 추가(`destructive-test-sql-lint`와 동형 관례: uv 설치 + 더미 `JWT_SECRET`/`SECRET_KEY`만).

## 이 가드가 못 잡는 것(docstring 명시)
- 이미 등재는 됐지만 실측치가 낡은/틀린 파일 — 그건 기존 story #3392 unweighted 초과 가드(shard 완주 후 실측 대조)와 `check_staleness()` 몫. 이 가드는 "존재 자체"만 본다.
- weights.json에 남은 죽은 항목(파일명 변경·마커 제거) — `discover()`가 SSOT라 무해(파일이 애초에 대상에서 빠짐).

## 양성대조(AC3)
새 테스트 파일 5건: 미등재 1건 → exit 1 + 붙여넣기 가능한 JSON 조각 출력 확인, 여러 건 동시 미등재도 전부 나열 확인, 음성대조(전부 등재 시 exit 0), weights.json이 비었을 때의 폴백값(1.0) 확인, 실물 repo 상태 스모크(현재 216개 전부 등재 확인 — 이 PR 자신이 가드를 통과해야 한다).

뮤테이션 자가검증(FAIL 분기를 강제로 OK 처리) — 예측된 3건 정확히 RED 확인 후 원복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm