### PR TITLE
[SID:3430] dev 전용 «샌드박스 채널 어댑터» — 발행 명령/cron/취소/회수/429/dead_letter를 dev 라이브로 재는 가짜 provider

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -88,6 +88,8 @@ async def lifespan(app: FastAPI):
     check_outbox_dual_publish_config()  # story #2138: outbox + dual_publish/dispatch 동시 fail-closed.
     check_mobile_app_check_config()  # 산티아고 §9 finding 1: mobile 발급 on + App Check 미필수 fail-closed.
     warn_if_rate_limit_backend_is_memory()  # story #3418: 인스턴스 다중+memory=레이트리밋 인스턴스별 분리, 경고만(fail-closed 아님).
+    from app.services.channel_adapters import assert_sandbox_channel_not_registered_in_prod
+    assert_sandbox_channel_not_registered_in_prod()  # story 5b27b32f AC5: prod에 sandbox 채널 등재=기동 실패(fail-closed).
     # story bea25062: cutover 존재-캐시는 의도적으로 startup에서 warm 안 함(자체 발견 —
     # TestClient(app)로 lifespan을 태우는 기존 SSE 테스트들이 라우트 전용으로 짜둔 유한한
     # mock db.execute() 순서-큐를 startup 시점의 이 캐시 조회가 몰래 하나 소비해 실패시켰다).

--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -73,6 +73,23 @@ async def _require_owner(db: AsyncSession, auth: AuthContext, org_id: uuid.UUID)
     return resolved
 
 
+async def _require_owner_or_admin(db: AsyncSession, auth: AuthContext, org_id: uuid.UUID):
+    """story 5b27b32f(AC2) — 샌드박스 연결 생성은 실 OAuth 연결(_require_owner, owner
+    전용)보다 넓은 owner/admin(channel_posts.py::_require_owner_or_admin·site_posts.py와
+    동형 폭 — 테스트 인프라라 취소·회수와 같은 급으로 취급, 실제 외부 계정 자격을
+    다루는 실채널 연결보다는 덜 민감하다는 판단)."""
+    resolved = await _require_human(db, auth, org_id)
+    if resolved.role not in ("owner", "admin"):
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "CHANNEL_CONNECTION_OWNER_OR_ADMIN_ONLY",
+                "message": "샌드박스 채널 연결은 조직 owner 또는 admin만 가능합니다.",
+            },
+        )
+    return resolved
+
+
 def _redirect_uri(org_id: uuid.UUID, channel: str) -> str:
     from app.core.config import settings
     return f"{settings.app_url}/api/oauth-channel/callback/{channel}"
@@ -377,6 +394,47 @@ async def channel_connection_callback(
     return _to_response(row)
 
 
+@router.post("/{org_id}/channel-connections/sandbox", response_model=ChannelConnectionResponse, status_code=201)
+async def create_sandbox_channel_connection(
+    org_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> ChannelConnectionResponse:
+    """story 5b27b32f(AC2) — OAuth 없는 샌드박스 연결 생성. dev org에 실 Meta 자격이
+    없어(채널 연결 0건) 발행 명령·cron tick·cancel·unpublish·429·컨테이너 폴링 경로를
+    dev에서 라이브로 못 밟던 병목을 푼다. `upsert_channel_connection`(story #3373 AC8
+    기존 함수, 신규 로직 0)을 그대로 재사용 — 같은 (org, "sandbox", account_id) 재호출은
+    새 행이 아니라 기존 행 갱신(멱등, 실 OAuth 콜백과 동일 계약).
+
+    이 채널 자체가 `SANDBOX_CHANNEL_ENABLED=true`일 때만 CHANNEL_ADAPTERS에 등재되므로
+    (channel_adapters.py) prod에선 이 엔드포인트를 호출해도 404(어댑터 없음)로 막힌다 —
+    라우트 자체를 조건부로 등록하지 않는 이유는 fail-closed 축을 어댑터 레지스트리 하나로
+    모으기 위함(AC5의 기동 시점 가드와 같은 SSOT)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    resolved = await _require_owner_or_admin(db, auth, org_id)
+
+    adapter = get_channel_adapter("sandbox")
+    if adapter is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "CHANNEL_SANDBOX_DISABLED",
+                "message": "이 환경에서 샌드박스 채널이 비활성화돼 있습니다(SANDBOX_CHANNEL_ENABLED).",
+            },
+        )
+
+    row = await upsert_channel_connection(
+        db, org_id=org_id, channel="sandbox", account_id=f"sandbox-{org_id}",
+        account_label="Sandbox", credential_kind=adapter.credential_kind,
+        access_token="sandbox-dummy-access-token", refresh_token=None,
+        token_expires_at=None, refresh_mode=adapter.refresh_mode,
+        scopes=adapter.scope.split(","), connected_by=resolved.id,
+    )
+    return _to_response(row)
+
+
 @router.post("/{org_id}/channel-connections/{connection_id}/disconnect", response_model=ChannelConnectionResponse)
 async def disconnect_channel_connection(
     org_id: uuid.UUID,
@@ -513,7 +571,11 @@ async def get_channel_publishing_limit(
             detail={"code": "CHANNEL_CONNECTION_NOT_ACTIVE", "message": "연결에 저장된 토큰이 없습니다."},
         )
 
-    from app.services.threads_publish import ThreadsPublishError, get_publishing_limit
+    from app.services.channel_adapters import get_publish_client_module
+    from app.services.threads_publish import ThreadsPublishError
+
+    # story 5b27b32f — sandbox 연결이면 sandbox_publish로 우회(publish 경로와 동일 디스패치).
+    get_publishing_limit = get_publish_client_module(row.channel).get_publishing_limit
 
     try:
         async with httpx.AsyncClient(timeout=10) as client:

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -1137,6 +1137,19 @@ async def unpublish_channel_post_endpoint(
         raise HTTPException(
             status_code=409, detail={"code": "CHANNEL_TOKEN_EXPIRED", "message": str(exc)},
         ) from exc
+    except ChannelRateLimitedError as exc:
+        # story 5b27b32f — 이 핸들러가 원래 빠져 있었다(gap 발견: _classify_threads_error에
+        # 429 분기를 추가하니 delete_media 실패도 이제 이 예외를 낼 수 있는데 unpublish
+        # 엔드포인트만 못 잡고 있었다 — 발행(publish) 엔드포인트의 기존 핸들러와 동형,
+        # 다만 unpublish엔 publication_command가 없어 apply_command_failure 호출은 없다).
+        retry_after_seconds = max(0, int((exc.reset_at - datetime.now(timezone.utc)).total_seconds()))
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "code": "CHANNEL_RATE_LIMITED", "message": str(exc), "reset_at": exc.reset_at.isoformat(),
+            },
+            headers={"Retry-After": str(retry_after_seconds)},
+        ) from exc
     except ChannelPublishProviderError as exc:
         raise HTTPException(
             status_code=502,

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -12,6 +12,7 @@ Phase1은 Threads 1개만 구현한다(범위 밖: Instagram/Facebook/X/WordPres
 암호화 로직은 채널 무관 공용)."""
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 
@@ -92,6 +93,42 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
     ),
 }
 
+# story 5b27b32f(Phase1·BE·테스트 인프라, 페드루 PO 확定 2026-09-04) — dev 전용 샌드박스
+# 채널. dev org에 실 Meta 자격이 없어(채널 연결 0건) publication_command·cron tick·
+# cancel-scheduled·unpublish·429·컨테이너 폴링 경로를 라이브로 한 번도 못 밟던 문제
+# (카디르 배포17 관측) — Threads 어댑터 코드(threads_publish.py)는 그대로 두고, 별도
+# 결정적 가짜 provider(sandbox_publish.py)로 같은 오케스트레이션 경로를 태운다.
+#
+# **fail-closed 이중 방어**(AC1·AC5): ①이 아래 블록 자체가 `SANDBOX_CHANNEL_ENABLED=true`
+# 일 때만 등재한다(cloudbuild.yaml이 dev에만 이 값을 싣고 prod엔 키 자체가 없다 —
+# GCS_CHANNEL_MEDIA_BUCKET 이전의 ADMIN_OPERATOR_* 관례 그대로) ②그래도 잘못 켜졌을 경우
+# (수동 오조작 등)를 대비해 `assert_sandbox_channel_not_registered_in_prod()`가 기동
+# 시점에 `settings.is_prod_deploy`와 대조해 있으면 안 되는데 있으면 즉시 RuntimeError로
+# 기동 자체를 죽인다(app/main.py lifespan에서 호출).
+if os.environ.get("SANDBOX_CHANNEL_ENABLED", "").strip().lower() == "true":
+    CHANNEL_ADAPTERS["sandbox"] = ChannelAdapterConfig(
+        authorize_url="",  # OAuth 없음(AC2) — 연결은 POST .../channel-connections/sandbox 전용.
+        token_url="",
+        scope="sandbox_publish,sandbox_delete",
+        refresh_mode="manual",  # 더미 토큰이라 자동 갱신 개념 자체가 없음.
+        credential_kind="none",
+        max_text_length=500,  # Threads와 동형(그라운딩 §1 실측 재사용, 새 한도를 지어내지 않는다).
+        utm_source="sandbox",
+        utm_medium="test",
+        supports_unpublish=True,
+        unpublish_required_scope="sandbox_delete",
+        # Threads와 동일 이미지 규격(AC1 "Threads와 같은 모양") — sandbox_publish.py가
+        # 실제로 Pillow 변환 파이프라인을 거치므로(channel_post_images.py는 채널 무관 공용)
+        # 같은 한도가 그대로 의미를 가진다.
+        image_formats=("image/jpeg", "image/png"),
+        image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=10.0,
+        image_width_min=320,
+        image_width_max=1440,
+        image_color_space="sRGB",
+        image_max_count=1,
+    )
+
 
 def get_channel_adapter(channel: str) -> ChannelAdapterConfig | None:
     return CHANNEL_ADAPTERS.get(channel)
@@ -99,3 +136,31 @@ def get_channel_adapter(channel: str) -> ChannelAdapterConfig | None:
 
 def can_auto_refresh(refresh_mode: str) -> bool:
     return refresh_mode in ("refresh_token", "reissue_from_access_token")
+
+
+def get_publish_client_module(channel: str):
+    """story 5b27b32f — 발행 클라이언트 모듈 디스패치. `sandbox`만 `threads_publish`
+    대신 `sandbox_publish`로 우회한다(같은 함수 시그니처·같은 `ThreadsPublishError`
+    클래스를 그대로 재사용 — sandbox_publish.py가 신규 예외 타입을 만들지 않으므로
+    channel_posts.py의 기존 except절이 그대로 먹힌다, 신규 판정 로직 0). 실 배포 채널
+    (threads 등)은 전부 threads_publish 그대로 — 이 함수가 sandbox 개입의 유일한
+    지점이다(Threads 어댑터 코드 자체는 무변경)."""
+    if channel == "sandbox":
+        from app.services import sandbox_publish
+        return sandbox_publish
+    from app.services import threads_publish
+    return threads_publish
+
+
+def assert_sandbox_channel_not_registered_in_prod() -> None:
+    """story 5b27b32f(AC5) — 기동 시점 fail-closed 방어. env 플래그 게이트(위)가 이미
+    prod cloudbuild.yaml에 `SANDBOX_CHANNEL_ENABLED` 키 자체를 안 실어 정상 배포에서는
+    이 함수가 항상 no-op이다 — 그래도 수동 오조작(예: gcloud run services update로 누가
+    직접 env를 붙임)까지 방어하는 두 번째 층. `app/main.py` lifespan이 기동마다 호출."""
+    from app.core.config import settings
+
+    if settings.is_prod_deploy and "sandbox" in CHANNEL_ADAPTERS:
+        raise RuntimeError(
+            "fail-closed: prod 배포에 sandbox 채널 어댑터가 등재돼 있습니다"
+            "(SANDBOX_CHANNEL_ENABLED가 prod에 잘못 설정됐을 가능성 — story 5b27b32f AC5)."
+        )

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -895,12 +895,22 @@ async def submit_channel_post_draft(
 def _classify_threads_error(
     exc: "ThreadsPublishError", *, connection_id: uuid.UUID,
 ) -> tuple[str, Exception]:
-    """provider 실패를 안정 코드+예외로 분류. 401/403은 토큰 만료(재인증 유도), 그 외는
-    미분류 provider 오류(502) — 담롱 요구 "«막혔다»와 «막는 장치를 쟀다»는 다르다"
-    그대로(그라운딩 §③)."""
+    """provider 실패를 안정 코드+예외로 분류. 401/403은 토큰 만료(재인증 유도), 429는
+    한도 초과(그라운딩 §③), 그 외는 미분류 provider 오류(502) — 담롱 요구 "«막혔다»와
+    «막는 장치를 쟀다»는 다르다" 그대로.
+
+    story 5b27b32f — 429 분기는 이 스토리에서 처음 추가(샌드박스 [sandbox:429] 마커가
+    create_container 단계에서 429를 내는 걸 정확히 분류하려고 필요해졌다). 기존
+    get_publishing_limit 사전조회가 놓친 경우(예: 조회와 실제 생성 호출 사이 경합)에도
+    이 분기가 동작해 Threads 실 provider가 create_container에서 직접 429를 낼 가능성
+    까지 함께 커버한다 — sandbox 전용 로직이 아니라 일반 강건성 개선."""
     if exc.status_code in (401, 403):
         return "CHANNEL_TOKEN_EXPIRED", ChannelTokenExpiredError(
             connection_id=connection_id, provider_message=exc.message,
+        )
+    if exc.status_code == 429:
+        return "CHANNEL_RATE_LIMITED", ChannelRateLimitedError(
+            reset_at=datetime.now(timezone.utc) + timedelta(seconds=60),
         )
     return "CHANNEL_PUBLISH_PROVIDER_ERROR", ChannelPublishProviderError(
         provider_code=exc.code, provider_message=exc.message,
@@ -1008,15 +1018,19 @@ async def publish_channel_post_draft(
         raise ChannelConnectionNotActiveError(connection_id=connection.id)
 
     import httpx
+    from app.services.channel_adapters import get_publish_client_module
     from app.services.channel_connection import apply_refresh_failure
-    from app.services.threads_publish import (
-        ThreadsPublishError,
-        create_container,
-        get_container_status,
-        get_permalink,
-        get_publishing_limit,
-        publish_container,
-    )
+    from app.services.threads_publish import ThreadsPublishError
+
+    # story 5b27b32f — sandbox 채널이면 threads_publish 대신 sandbox_publish(같은
+    # 함수 시그니처)로 우회. 이 한 줄이 sandbox 개입의 유일한 지점 — 아래 로직은 어느
+    # 쪽이 골렸는지 모른다.
+    _publish_client = get_publish_client_module(draft.channel)
+    create_container = _publish_client.create_container
+    get_container_status = _publish_client.get_container_status
+    get_permalink = _publish_client.get_permalink
+    get_publishing_limit = _publish_client.get_publishing_limit
+    publish_container = _publish_client.publish_container
 
     tagged_link = (
         build_tagged_link(channel=draft.channel, link_url=latest.link_url, draft_id=draft.id)
@@ -1370,7 +1384,11 @@ async def unpublish_channel_post(
         )
 
     import httpx
-    from app.services.threads_publish import ThreadsPublishError, delete_media
+    from app.services.channel_adapters import get_publish_client_module
+    from app.services.threads_publish import ThreadsPublishError
+
+    # story 5b27b32f — publish 경로와 동일 디스패치(pub.channel 기준).
+    delete_media = get_publish_client_module(pub.channel).delete_media
 
     try:
         async with httpx.AsyncClient(timeout=15) as client:

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -891,6 +891,13 @@ async def submit_channel_post_draft(
 # latest.link_url은 절대 바꾸지 않는다(봉인 해시가 이미 그 원본 쌍으로 계산돼 있다, #3374).
 # UTM은 발행 시점에만 조립되는 배달 계층 부가물이지 승인 대상 내용이 아니다.
 
+# story 5b27b32f(페드루 리뷰 N1) — Threads 429 응답 자체엔 reset 시각이 실려오지 않는다
+# (Meta 문서에 Retry-After류 필드 없음, 그라운딩 §③) — provider가 알려주지 않을 때 쓰는
+# 기본 유예값. 60초는 임의값이 아니라 story #3414 백오프 최소 단위(_BACKOFF_BASE_SECONDS,
+# publication_command.py)와 맞춘 것 — 이보다 짧으면 재시도가 백오프보다 먼저 도래해
+# 의미가 없다.
+_RATE_LIMIT_DEFAULT_RESET_SECONDS = 60
+
 
 def _classify_threads_error(
     exc: "ThreadsPublishError", *, connection_id: uuid.UUID,
@@ -910,7 +917,7 @@ def _classify_threads_error(
         )
     if exc.status_code == 429:
         return "CHANNEL_RATE_LIMITED", ChannelRateLimitedError(
-            reset_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+            reset_at=datetime.now(timezone.utc) + timedelta(seconds=_RATE_LIMIT_DEFAULT_RESET_SECONDS),
         )
     return "CHANNEL_PUBLISH_PROVIDER_ERROR", ChannelPublishProviderError(
         provider_code=exc.code, provider_message=exc.message,

--- a/backend/app/services/sandbox_publish.py
+++ b/backend/app/services/sandbox_publish.py
@@ -1,0 +1,132 @@
+"""story 5b27b32f(Phase1·BE·테스트 인프라, 페드루 PO 확定 2026-09-04) — dev 전용 샌드박스
+채널 발행 클라이언트. `threads_publish.py`(Threads 실 provider)와 **정확히 같은 함수
+시그니처**를 가진 결정적 가짜 provider — `channel_adapters.py::get_publish_client_module`
+이 `draft.channel == "sandbox"`일 때만 threads_publish 대신 이 모듈을 골라 쓴다(오케스트
+레이션(channel_posts.py)은 어느 쪽이 골렸는지 모른다, 신규 판정 로직 0). Threads 어댑터
+코드는 이 스토리에서 한 글자도 안 건드린다.
+
+**결정적·상태 없음(stateless)** — 이 클라이언트는 실 HTTP 호출을 전혀 하지 않는다
+(`client`/`access_token` 인자는 시그니처 정합을 위해서만 받고 안 쓴다). 여러 Cloud Run
+인스턴스가 같은 creation_id를 나중에 다시 물어봐도(폴링 tick마다 다른 인스턴스가 받을 수
+있다) 같은 답을 내야 하므로, 필요한 모든 상태(폴링 완료 시각·에러 모드)를 서버 메모리가
+아니라 **`creation_id` 문자열 자체**에 인코딩한다(`sandbox:{mode}:{ready_at_epoch}:
+{uuid}` — 방식은 story #3383류 stateless-encoding 관례와 동형).
+
+## 본문 마커(story 본문 AC3, 정본) — `create_container`가 받는 `text`에서만 읽는다
+(publish_container/get_container_status/delete_media는 원문을 다시 안 받으므로, 이
+마커들이 결정하는 행동은 전부 `create_container`가 만드는 creation_id 인코딩 또는
+`create_container` 자신의 즉시 예외로 표현된다):
+
+- (마커 없음) — 기본 성공. 컨테이너는 즉시 FINISHED, permalink는
+  `https://sandbox.invalid/{media_id}`.
+- `[sandbox:429]` — `create_container`가 즉시 429로 실패(Threads 한도 초과 시뮬레이션).
+  channel_posts.py::_classify_threads_error의 신규 429 분기(이 스토리에서 추가, Threads
+  실 provider가 create_container 단계에서 429를 낼 가능성에도 마찬가지로 유효한 일반
+  개선)가 `ChannelRateLimitedError`로 승격한다.
+- `[sandbox:provider-error]` — `create_container`가 502로 실패(미분류 provider 오류
+  시뮬레이션, 기존 _classify_threads_error가 이미 CHANNEL_PUBLISH_PROVIDER_ERROR로
+  분류).
+- `[sandbox:expired-token]` — `create_container`가 401로 실패(기존 _classify_threads_
+  error가 이미 CHANNEL_TOKEN_EXPIRED로 분류).
+- `[sandbox:container-error]` — 컨테이너 생성 자체는 성공하지만, 폴링(get_container_
+  status)이 ERROR를 낸다(AC3 "컨테이너 ERROR").
+- `[sandbox:container-slow]` — 컨테이너가 즉시 안 끝나고 `_CONTAINER_SLOW_DELAY_SECONDS`
+  뒤에야 FINISHED로 전환된다(AC3 "container IN_PROGRESS→FINISHED 2 tick" — 발행 오케스트
+  레이션의 최초 30초 대기+이후 폴링 주기를 감안해 첫 poll엔 아직 IN_PROGRESS, 두 번째
+  poll에서 FINISHED가 나오게 지연을 잡았다).
+
+마커는 서로 배타적으로 다루지 않는다(먼저 매치되는 것을 그대로 적용) — 실패 마커 3종은
+텍스트 안 어디에든, 컨테이너 마커 2종과 자유롭게 조합 가능."""
+from __future__ import annotations
+
+import time
+import uuid
+
+import httpx
+
+from app.services.threads_publish import ThreadsPublishError
+
+_MARKER_429 = "[sandbox:429]"
+_MARKER_PROVIDER_ERROR = "[sandbox:provider-error]"
+_MARKER_EXPIRED_TOKEN = "[sandbox:expired-token]"
+_MARKER_CONTAINER_ERROR = "[sandbox:container-error]"
+_MARKER_CONTAINER_SLOW = "[sandbox:container-slow]"
+
+# story 5b27b32f — cron 워커의 발행 오케스트레이션(channel_posts.py)은 컨테이너 생성 직후
+# 곧바로 폴링하지 않고(Meta 권장 30초 대기, story 620beefc B3) 그 다음 tick부터 폴링한다.
+# 40초로 잡으면: 최초 폴링(≈30초 후)엔 아직 IN_PROGRESS, 두 번째 폴링(≈60초 후)엔 FINISHED
+# — AC3 "2 tick"을 실측 오케스트레이션 타이밍과 어긋나지 않게 재현한다.
+_CONTAINER_SLOW_DELAY_SECONDS = 40
+
+
+def _encode_creation_id(*, mode: str, ready_at_epoch: int) -> str:
+    return f"sandbox:{mode}:{ready_at_epoch}:{uuid.uuid4().hex}"
+
+
+def _decode_creation_id(creation_id: str) -> tuple[str, int]:
+    """(mode, ready_at_epoch). 형식이 어긋나면(외부에서 만든 값 등) 방어적으로 즉시
+    FINISHED 취급 — 샌드박스가 알 수 없는 입력에 영원히 멈춰 있는 것보다 낫다."""
+    parts = creation_id.split(":")
+    if len(parts) != 4 or parts[0] != "sandbox" or parts[1] not in ("ok", "error"):
+        return "ok", 0
+    try:
+        return parts[1], int(parts[2])
+    except ValueError:
+        return "ok", 0
+
+
+async def create_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, text: str,
+    image_url: str | None = None,
+) -> str:
+    if _MARKER_429 in text:
+        raise ThreadsPublishError("SANDBOX_RATE_LIMITED", "sandbox: [sandbox:429] 마커 시뮬레이션", status_code=429)
+    if _MARKER_PROVIDER_ERROR in text:
+        raise ThreadsPublishError(
+            "SANDBOX_PROVIDER_ERROR", "sandbox: [sandbox:provider-error] 마커 시뮬레이션", status_code=502,
+        )
+    if _MARKER_EXPIRED_TOKEN in text:
+        raise ThreadsPublishError(
+            "SANDBOX_TOKEN_EXPIRED", "sandbox: [sandbox:expired-token] 마커 시뮬레이션", status_code=401,
+        )
+
+    mode = "error" if _MARKER_CONTAINER_ERROR in text else "ok"
+    delay = _CONTAINER_SLOW_DELAY_SECONDS if _MARKER_CONTAINER_SLOW in text else 0
+    return _encode_creation_id(mode=mode, ready_at_epoch=int(time.time()) + delay)
+
+
+async def get_container_status(
+    client: httpx.AsyncClient, *, access_token: str, creation_id: str,
+) -> tuple[str, str | None]:
+    mode, ready_at_epoch = _decode_creation_id(creation_id)
+    if time.time() < ready_at_epoch:
+        return "IN_PROGRESS", None
+    if mode == "error":
+        return "ERROR", "SANDBOX_SIMULATED_CONTAINER_ERROR"
+    return "FINISHED", None
+
+
+async def publish_container(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str, creation_id: str,
+) -> str:
+    # 여기 도달했다는 것 자체가 오케스트레이션이 이미 FINISHED를 확인했다는 뜻(AC3
+    # "기본 성공") — media_id는 새 uuid4(진짜 미디어처럼 creation_id와 다른 값).
+    return f"sandbox-media-{uuid.uuid4().hex}"
+
+
+async def get_publishing_limit(
+    client: httpx.AsyncClient, *, access_token: str, threads_user_id: str,
+) -> tuple[int, int, int]:
+    # 항상 넉넉한 잔량 — 429 시뮬레이션은 create_container 마커로만 유발한다(모듈 상단
+    # docstring 참고 — 이 함수는 text를 못 받아 마커를 볼 수 없다).
+    return 0, 100, 3600
+
+
+async def get_permalink(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> str | None:
+    return f"https://sandbox.invalid/{media_id}"
+
+
+async def delete_media(client: httpx.AsyncClient, *, access_token: str, media_id: str) -> None:
+    # AC3 "기본 성공" — 회수(unpublish) 실패 시뮬레이션은 이 스토리 스코프 밖으로 명시
+    # 배제(story 본문 마커 목록에 unpublish용 마커가 없다).
+    return None

--- a/backend/app/services/sandbox_publish.py
+++ b/backend/app/services/sandbox_publish.py
@@ -29,14 +29,19 @@
 - `[sandbox:expired-token]` — `create_container`가 401로 실패(기존 _classify_threads_
   error가 이미 CHANNEL_TOKEN_EXPIRED로 분류).
 - `[sandbox:container-error]` — 컨테이너 생성 자체는 성공하지만, 폴링(get_container_
-  status)이 ERROR를 낸다(AC3 "컨테이너 ERROR").
+  status)이 ERROR를 낸다(AC3 "컨테이너 ERROR"). ⚠️**이미지 첨부 초안 전용** — 오케스트
+  레이션(channel_posts.py::publish_channel_post_draft)이 `has_image`일 때만 폴링을
+  타므로(story 620beefc AC5), 이미지 없는 TEXT 초안에서는 create_container가 이 마커를
+  creation_id에 인코딩해도 아무도 안 읽어 즉시 published로 끝난다(마커가 조용히
+  inert — 결함 아님, 발행 오케스트레이션의 기존 분기 구조).
 - `[sandbox:container-slow]` — 컨테이너가 즉시 안 끝나고 `_CONTAINER_SLOW_DELAY_SECONDS`
   뒤에야 FINISHED로 전환된다(AC3 "container IN_PROGRESS→FINISHED 2 tick" — 발행 오케스트
   레이션의 최초 30초 대기+이후 폴링 주기를 감안해 첫 poll엔 아직 IN_PROGRESS, 두 번째
-  poll에서 FINISHED가 나오게 지연을 잡았다).
+  poll에서 FINISHED가 나오게 지연을 잡았다). ⚠️위와 동일하게 **이미지 첨부 초안 전용**.
 
 마커는 서로 배타적으로 다루지 않는다(먼저 매치되는 것을 그대로 적용) — 실패 마커 3종은
-텍스트 안 어디에든, 컨테이너 마커 2종과 자유롭게 조합 가능."""
+텍스트 안 어디에든, 컨테이너 마커 2종과 자유롭게 조합 가능(단, 컨테이너 마커 2종은
+이미지 첨부 초안에서만 의미 있음, 위 참고)."""
 from __future__ import annotations
 
 import time

--- a/backend/tests/test_5b27b32f_sandbox_channel.py
+++ b/backend/tests/test_5b27b32f_sandbox_channel.py
@@ -120,6 +120,16 @@ async def _seed_human(session, org_id, project_id, *, role="owner"):
     return user.id
 
 
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    """페드루 리뷰 B1 — test_3373_channel_connections.py::_seed_agent와 동형."""
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
 async def _seed_story(session, org_id, project_id, *, title="채널 포스트"):
     from app.models.pm import Story
 
@@ -326,6 +336,32 @@ async def test_create_sandbox_connection_as_member_forbidden():
         assert r.status_code == 403, r.text
         error = r.json().get("error") or r.json()
         assert error["code"] == "CHANNEL_CONNECTION_OWNER_OR_ADMIN_ONLY"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_sandbox_connection_as_agent_returns_403():
+    """페드루 리뷰 B1 — 샌드박스 연결은 "OAuth 없이 agent-callable"이 아니다. 실제로는
+    `_require_owner_or_admin`이 `_require_human`을 거치므로(channel_connections.py:76,51)
+    에이전트 키는 사람과 똑같이 403(CHANNEL_CONNECTION_HUMAN_ONLY) — 실 OAuth 연결
+    (test_3373_channel_connections.py::test_agent_gets_403_on_every_endpoint)과 동일
+    가드가 이 신규 endpoint에도 그대로 적용됨을 고정."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/sandbox")
+        assert r.status_code == 403, r.text
+        error = r.json().get("error") or r.json()
+        assert error["code"] == "CHANNEL_CONNECTION_HUMAN_ONLY"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -579,6 +615,39 @@ async def test_publish_via_sandbox_container_error_marker_inert_on_text_path():
             draft_id, gate_id = await _create_draft_submit_approve(
                 client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
                 text="TEXT 발행은 폴링이 없다 [sandbox:container-error]",
+            )
+            publication = await publish_channel_post_draft(
+                s, org_id=org_id, draft_id=draft_id, published_by_member_id=human_id,
+            )
+        assert publication.status == "published"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_via_sandbox_container_slow_marker_inert_on_text_path():
+    """페드루 리뷰 B2 — `[sandbox:container-error]`와 동일 이유로 `[sandbox:container-
+    slow]`도 TEXT 경로에서는 폴링 자체가 없어(has_image=False면 get_container_status
+    호출 안 함, story 620beefc B3) 즉시 published여야 한다 — 지연이 전혀 관측되면 안
+    된다(관측되면 TEXT/IMAGE 분기 자체가 깨진 것)."""
+    from app.main import app
+    from app.services.channel_posts import publish_channel_post_draft
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id, project_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client, Session() as s:
+            connection_id = await _create_sandbox_connection(client, org_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                text="TEXT 발행은 폴링이 없다 [sandbox:container-slow]",
             )
             publication = await publish_channel_post_draft(
                 s, org_id=org_id, draft_id=draft_id, published_by_member_id=human_id,

--- a/backend/tests/test_5b27b32f_sandbox_channel.py
+++ b/backend/tests/test_5b27b32f_sandbox_channel.py
@@ -1,0 +1,657 @@
+"""story 5b27b32f(Phase1·BE·테스트 인프라, 페드루 PO 확定 2026-09-04) — dev 전용
+샌드박스 채널 어댑터. AC1~5 QA: 어댑터 등재 게이트(env 실측)·연결 생성 endpoint(owner/
+admin)·마커 5종(단위+통합)·prod fail-closed·발행/취소/회수 경로 라이브 재현.
+
+`CHANNEL_ADAPTERS["sandbox"]`는 모듈 import 시점에 `SANDBOX_CHANNEL_ENABLED` env를
+1회 읽어 등재하므로(channel_adapters.py), 개별 테스트는 `monkeypatch.setitem`으로
+그 dict에 직접 항목을 넣고 뺀다(reload 불요 — channel_adapters.py엔 예외 클래스가
+없어 애초에 그 함정도 없지만, dict 직접 조작이 더 단순·명확하다). env 게이트 자체가
+실제로 동작하는지는 별도 subprocess 테스트로 독립 검증."""
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.fixture(autouse=True)
+def _enable_sandbox_adapter(monkeypatch):
+    """dict 항목 직접 주입 — SANDBOX_CHANNEL_ENABLED env 파싱 자체는 별도
+    test_sandbox_env_flag_gates_registration_via_subprocess가 독립 검증한다."""
+    import app.services.channel_adapters as adapters_mod
+
+    sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete",
+        refresh_mode="manual", credential_kind="none", max_text_length=500,
+        utm_source="sandbox", utm_medium="test", supports_unpublish=True,
+        unpublish_required_scope="sandbox_delete",
+        image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,
+        image_aspect_max=10.0, image_width_min=320, image_width_max=1440,
+        image_color_space="sRGB", image_max_count=1,
+    )
+    monkeypatch.setitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", sandbox_config)
+    yield
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="5b27b32f Sandbox Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_human(session, org_id, project_id, *, role="owner"):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="채널 포스트"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_default_role(session, org_id):
+    from app.models.participation import ParticipationRole
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+    session.add(role)
+    await session.commit()
+    return role.id
+
+
+async def _approve_gate_directly(session, gate_id):
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    gate = (await session.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+    gate.status = "approved"
+    gate.resolver_id = uuid.uuid4()
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.commit()
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id, agent: bool = False):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if agent:
+            claims["app_metadata"]["api_key_id"] = "test-agent-key"
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _create_sandbox_connection(client, org_id) -> uuid.UUID:
+    r = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/sandbox")
+    assert r.status_code == 201, r.text
+    return uuid.UUID(r.json()["id"])
+
+
+async def _create_draft_submit_approve(client, s, *, org_id, connection_id, story_id, text="샌드박스 포스트"):
+    r_draft = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+        json={"work_item_id": str(story_id), "connection_id": str(connection_id), "text": text},
+    )
+    assert r_draft.status_code == 201, r_draft.text
+    draft_id = r_draft.json()["draft_id"]
+    r_submit = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json={},
+    )
+    assert r_submit.status_code == 200, r_submit.text
+    gate_id = uuid.UUID(r_submit.json()["gate_id"])
+    await _approve_gate_directly(s, gate_id)
+    return draft_id, gate_id
+
+
+# ─── AC1 — env 게이트 실측(subprocess, monkeypatch 아님) ─────────────────────
+
+def test_sandbox_env_flag_gates_registration_via_subprocess():
+    """subprocess로 실제 프로세스 기동+import 순서를 그대로 재현 — dict 직접주입이
+    아니라 진짜 env var 파싱 경로 자체를 검증한다(AC1)."""
+    import subprocess
+    import sys
+
+    backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    script = (
+        "from app.services.channel_adapters import CHANNEL_ADAPTERS\n"
+        "assert 'sandbox' in CHANNEL_ADAPTERS, 'enabled인데 미등재'\n"
+    )
+    r_on = subprocess.run(
+        [sys.executable, "-c", script], cwd=backend_dir, capture_output=True, text=True,
+        env={**os.environ, "SANDBOX_CHANNEL_ENABLED": "true"},
+    )
+    assert r_on.returncode == 0, r_on.stderr
+
+    script_off = (
+        "from app.services.channel_adapters import CHANNEL_ADAPTERS\n"
+        "assert 'sandbox' not in CHANNEL_ADAPTERS, 'unset인데 등재됨(prod 사고 위험)'\n"
+    )
+    env_off = {k: v for k, v in os.environ.items() if k != "SANDBOX_CHANNEL_ENABLED"}
+    r_off = subprocess.run(
+        [sys.executable, "-c", script_off], cwd=backend_dir, capture_output=True, text=True, env=env_off,
+    )
+    assert r_off.returncode == 0, r_off.stderr
+
+
+def test_get_publish_client_module_dispatches_by_channel():
+    from app.services import sandbox_publish, threads_publish
+    from app.services.channel_adapters import get_publish_client_module
+
+    assert get_publish_client_module("sandbox") is sandbox_publish
+    assert get_publish_client_module("threads") is threads_publish
+    assert get_publish_client_module("unknown-channel") is threads_publish  # 기본값(회귀 축)
+
+
+# ─── AC5 — prod fail-closed ───────────────────────────────────────────────
+
+def test_prod_with_sandbox_registered_raises(monkeypatch):
+    from app.core.config import settings
+    from app.services.channel_adapters import assert_sandbox_channel_not_registered_in_prod
+
+    monkeypatch.setattr(settings, "deploy_env", "prod")
+    with pytest.raises(RuntimeError, match="fail-closed"):
+        assert_sandbox_channel_not_registered_in_prod()
+
+
+def test_dev_with_sandbox_registered_does_not_raise(monkeypatch):
+    from app.core.config import settings
+    from app.services.channel_adapters import assert_sandbox_channel_not_registered_in_prod
+
+    monkeypatch.setattr(settings, "deploy_env", "dev")
+    assert_sandbox_channel_not_registered_in_prod()  # no raise
+
+
+def test_prod_without_sandbox_registered_does_not_raise(monkeypatch):
+    import app.services.channel_adapters as adapters_mod
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "deploy_env", "prod")
+    monkeypatch.delitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", raising=False)
+    adapters_mod.assert_sandbox_channel_not_registered_in_prod()  # no raise
+
+
+# ─── AC2 — 연결 생성 endpoint ─────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_sandbox_connection_as_owner_succeeds():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/sandbox")
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["channel"] == "sandbox"
+        assert body["status"] == "active"
+        assert body["account_label"] == "Sandbox"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_sandbox_connection_as_admin_succeeds():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id, role="admin")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/sandbox")
+        assert r.status_code == 201, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_sandbox_connection_as_member_forbidden():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id, role="member")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/sandbox")
+        assert r.status_code == 403, r.text
+        error = r.json().get("error") or r.json()
+        assert error["code"] == "CHANNEL_CONNECTION_OWNER_OR_ADMIN_ONLY"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_sandbox_connection_disabled_returns_404(monkeypatch):
+    """어댑터가 등재 안 돼 있으면(prod 정상 상태) 엔드포인트 자체는 살아있되 404 —
+    fail-closed 축이 어댑터 레지스트리 하나로 모여 있는지 확인."""
+    from app.main import app
+    import app.services.channel_adapters as adapters_mod
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id, role="owner")
+
+        monkeypatch.delitem(adapters_mod.CHANNEL_ADAPTERS, "sandbox", raising=False)
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/sandbox")
+        assert r.status_code == 404, r.text
+        error = r.json().get("error") or r.json()
+        assert error["code"] == "CHANNEL_SANDBOX_DISABLED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_sandbox_connection_idempotent_upsert():
+    """같은 org 재호출 = 새 행이 아니라 기존 행 갱신(AC2, story #3373 AC8 재사용)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            human_id = await _seed_human(s, org_id, project_id, role="owner")
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client:
+            r1 = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/sandbox")
+            r2 = await client.post(f"/api/v2/organizations/{org_id}/channel-connections/sandbox")
+        assert r1.json()["id"] == r2.json()["id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC3 — sandbox_publish 마커 단위 검증 ─────────────────────────────────
+
+@pytest.mark.anyio
+async def test_sandbox_publish_default_success_flow():
+    from app.services import sandbox_publish as sp
+
+    creation_id = await sp.create_container(
+        None, access_token="x", threads_user_id="u", text="마커 없는 평범한 글",
+    )
+    status, err = await sp.get_container_status(None, access_token="x", creation_id=creation_id)
+    assert status == "FINISHED"
+    assert err is None
+    media_id = await sp.publish_container(None, access_token="x", threads_user_id="u", creation_id=creation_id)
+    permalink = await sp.get_permalink(None, access_token="x", media_id=media_id)
+    assert permalink == f"https://sandbox.invalid/{media_id}"
+
+
+@pytest.mark.anyio
+async def test_sandbox_publish_429_marker():
+    from app.services import sandbox_publish as sp
+    from app.services.threads_publish import ThreadsPublishError
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await sp.create_container(None, access_token="x", threads_user_id="u", text="본문 [sandbox:429] 마커")
+    assert exc_info.value.status_code == 429
+
+
+@pytest.mark.anyio
+async def test_sandbox_publish_provider_error_marker():
+    from app.services import sandbox_publish as sp
+    from app.services.threads_publish import ThreadsPublishError
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await sp.create_container(None, access_token="x", threads_user_id="u", text="[sandbox:provider-error]")
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.anyio
+async def test_sandbox_publish_expired_token_marker():
+    from app.services import sandbox_publish as sp
+    from app.services.threads_publish import ThreadsPublishError
+
+    with pytest.raises(ThreadsPublishError) as exc_info:
+        await sp.create_container(None, access_token="x", threads_user_id="u", text="[sandbox:expired-token]")
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_sandbox_publish_container_error_marker():
+    from app.services import sandbox_publish as sp
+
+    creation_id = await sp.create_container(
+        None, access_token="x", threads_user_id="u", text="[sandbox:container-error]",
+    )
+    status, err = await sp.get_container_status(None, access_token="x", creation_id=creation_id)
+    assert status == "ERROR"
+    assert err is not None
+
+
+@pytest.mark.anyio
+async def test_sandbox_publish_container_slow_marker_two_ticks(monkeypatch):
+    """AC3 "container IN_PROGRESS→FINISHED 2 tick" — 첫 폴링(경과 0초)엔 IN_PROGRESS,
+    지연 경과 뒤엔 FINISHED. 실제 40초를 기다리지 않고 time.time()을 목으로 진행시킨다."""
+    import app.services.sandbox_publish as sp
+
+    fake_now = [1_000_000.0]
+    monkeypatch.setattr(sp.time, "time", lambda: fake_now[0])
+
+    creation_id = await sp.create_container(
+        None, access_token="x", threads_user_id="u", text="[sandbox:container-slow]",
+    )
+    status1, _ = await sp.get_container_status(None, access_token="x", creation_id=creation_id)
+    assert status1 == "IN_PROGRESS"
+
+    fake_now[0] += sp._CONTAINER_SLOW_DELAY_SECONDS + 1
+    status2, _ = await sp.get_container_status(None, access_token="x", creation_id=creation_id)
+    assert status2 == "FINISHED"
+
+
+@pytest.mark.anyio
+async def test_sandbox_publish_delete_media_always_succeeds():
+    from app.services import sandbox_publish as sp
+
+    result = await sp.delete_media(None, access_token="x", media_id="sandbox-media-abc")
+    assert result is None  # 예외 없이 반환 = 성공(threads_publish.delete_media와 동형 계약)
+
+
+# ─── AC3 — 통합: 발행 오케스트레이션을 sandbox로 실제로 태움 ──────────────────
+
+@pytest.mark.anyio
+async def test_publish_via_sandbox_default_success():
+    from app.main import app
+    from app.services.channel_posts import publish_channel_post_draft
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id, project_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client, Session() as s:
+            connection_id = await _create_sandbox_connection(client, org_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                text="평범한 샌드박스 발행",
+            )
+            publication = await publish_channel_post_draft(
+                s, org_id=org_id, draft_id=draft_id, published_by_member_id=human_id,
+            )
+        assert publication.status == "published"
+        assert publication.permalink.startswith("https://sandbox.invalid/")
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_via_sandbox_429_marker_returns_rate_limited():
+    from app.main import app
+    from app.services.channel_posts import publish_channel_post_draft, ChannelRateLimitedError
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id, project_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client, Session() as s:
+            connection_id = await _create_sandbox_connection(client, org_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                text="한도 초과 테스트 [sandbox:429]",
+            )
+            with pytest.raises(ChannelRateLimitedError):
+                await publish_channel_post_draft(
+                    s, org_id=org_id, draft_id=draft_id, published_by_member_id=human_id,
+                )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_via_sandbox_expired_token_marker_via_http():
+    """HTTP 레벨까지 — 즉시발행 엔드포인트가 CHANNEL_TOKEN_EXPIRED 409를 정확히 낸다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id, project_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client, Session() as s:
+            connection_id = await _create_sandbox_connection(client, org_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                text="토큰 만료 테스트 [sandbox:expired-token]",
+            )
+            r = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+        assert r.status_code == 409, r.text
+        error = r.json().get("error") or r.json()
+        assert error["code"] == "CHANNEL_TOKEN_EXPIRED"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_via_sandbox_container_error_marker_inert_on_text_path():
+    """TEXT 발행은 컨테이너 생성 뒤 곧바로 publish까지 진행하고 폴링 자체가 없다(story
+    620beefc B3 — IN_PROGRESS 폴링은 IMAGE 경로 전용). `[sandbox:container-error]`
+    마커는 get_container_status가 호출돼야만 관측되므로, TEXT 경로에서는 이 마커가
+    무해해야 한다(발행이 정상 성공) — 단위 테스트(test_sandbox_publish_container_error_
+    marker)가 이미 ERROR 상태 자체는 검증했으니, 여기서는 "그 상태가 TEXT 경로에선
+    아예 안 보인다"는 통합 계약을 고정한다."""
+    from app.main import app
+    from app.services.channel_posts import publish_channel_post_draft
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id, project_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client, Session() as s:
+            connection_id = await _create_sandbox_connection(client, org_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                text="TEXT 발행은 폴링이 없다 [sandbox:container-error]",
+            )
+            publication = await publish_channel_post_draft(
+                s, org_id=org_id, draft_id=draft_id, published_by_member_id=human_id,
+            )
+        assert publication.status == "published"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── AC4 실효 — cancel-scheduled·unpublish가 sandbox로 라이브 왕복 가능한지 ────
+
+@pytest.mark.anyio
+async def test_cancel_scheduled_via_sandbox():
+    from app.main import app
+    from app.services.channel_posts import cancel_scheduled_publication
+    from app.models.publication_command import PublicationCommand
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id, project_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client, Session() as s:
+            connection_id = await _create_sandbox_connection(client, org_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+            cmd = PublicationCommand(
+                id=uuid.uuid4(), org_id=org_id, gate_id=gate_id,
+                destination=connection_id, approved_version=uuid.uuid4(),
+                status="pending", requested_by_member_id=human_id,
+            )
+            s.add(cmd)
+            await s.commit()
+
+            cancelled = await cancel_scheduled_publication(
+                s, org_id=org_id, draft_id=draft_id, cancelled_by_member_id=human_id,
+            )
+        assert cancelled.status == "cancelled"
+        assert cancelled.reason_code == "CANCELLED_BY_HUMAN"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublish_via_sandbox():
+    from app.main import app
+    from app.services.channel_posts import publish_channel_post_draft, unpublish_channel_post
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            human_id = await _seed_human(s, org_id, project_id, role="owner")
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
+        async with _client_for(app) as client, Session() as s:
+            connection_id = await _create_sandbox_connection(client, org_id)
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+            await publish_channel_post_draft(s, org_id=org_id, draft_id=draft_id, published_by_member_id=human_id)
+            pub = await unpublish_channel_post(s, org_id=org_id, draft_id=draft_id, unpublished_by_member_id=human_id)
+        assert pub.status == "unpublished"
+        assert pub.external_id is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_deploy_backend_redis_secret_conflict.py
+++ b/backend/tests/test_deploy_backend_redis_secret_conflict.py
@@ -450,6 +450,23 @@ def test_deploy_backend_prod_excludes_admin_operator_env_vars():
     assert "ADMIN_OPERATOR_ALLOWLIST" not in result
 
 
+def test_deploy_backend_dev_includes_sandbox_channel_enabled():
+    """story 5b27b32f — dev는 SANDBOX_CHANNEL_ENABLED=true를 RATE_LIMIT_BACKEND와 동일하게
+    리터럴 plain env로 넘긴다(channel_adapters.py의 env 게이트가 이 값 있어야 sandbox
+    어댑터를 CHANNEL_ADAPTERS에 등재)."""
+    result = _run_env_vars_assembly("dev", "redis://10.164.120.243:6379")
+    assert "SANDBOX_CHANNEL_ENABLED=true" in result
+
+
+def test_deploy_backend_prod_excludes_sandbox_channel_enabled():
+    """⭐story 5b27b32f AC5 핵심 전제 — prod는 이 키 자체가 없어야 안전(RATE_LIMIT_BACKEND와
+    동일 게이트). 이 키가 prod에 실리면 sandbox 어댑터가 CHANNEL_ADAPTERS에 등재돼
+    assert_sandbox_channel_not_registered_in_prod()가 기동 자체를 죽인다 — 이 테스트가
+    그 전제(prod엔 애초에 이 키가 없다)를 여기서 먼저 고정한다."""
+    result = _run_env_vars_assembly("prod", "")
+    assert "SANDBOX_CHANNEL_ENABLED" not in result
+
+
 def test_deploy_backend_dev_and_prod_both_include_public_site_base_url():
     """story 194acb63 — PUBLIC_SITE_BASE_URL은 REDIS_URL/ADMIN_OPERATOR_*와 달리 dev·prod
     분기 없이 베이스 문자열에 무조건 실린다(별개 마케팅 사이트 도메인, dev/prod 백엔드 어느
@@ -602,5 +619,8 @@ def test_deploy_backend_dev_env_vars_unchanged_by_prod_branch():
         "GCS_AVATARS_BUCKET=sprintable-avatars-dev,"
         # story 620beefc — GCS_AVATARS_BUCKET 조건부 append 바로 뒤에 이어붙는다(cloudbuild.yaml
         # 삽입 순서 그대로).
-        "GCS_CHANNEL_MEDIA_BUCKET=sprintable-channel-media-dev"
+        "GCS_CHANNEL_MEDIA_BUCKET=sprintable-channel-media-dev,"
+        # story 5b27b32f — GCS_CHANNEL_MEDIA_BUCKET 조건부 append 바로 뒤(cloudbuild.yaml
+        # 삽입 순서 그대로).
+        "SANDBOX_CHANNEL_ENABLED=true"
     )

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -785,6 +785,9 @@ steps:
         if [ "${_DEPLOY_ENV}" != "prod" ]; then
           ENV_VARS="$${ENV_VARS},GCS_CHANNEL_MEDIA_BUCKET=${_GCS_CHANNEL_MEDIA_BUCKET}"
         fi
+        if [ "${_DEPLOY_ENV}" != "prod" ]; then
+          ENV_VARS="$${ENV_VARS},SANDBOX_CHANNEL_ENABLED=true"
+        fi
         # story #2141 원칙 재사용(카디르 QA 2026-08-19) — GOTENBERG_SERVICE_URL도 prod엔 키 자체가
         # 없어야 안전(dev 전용 office-converter 하드게이트).
         if [ "${_DEPLOY_ENV}" != "prod" ] && [ -n "${_GOTENBERG_SERVICE_URL}" ]; then

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,6 @@
 {
   "_snapshot_policy": "story #3383(2026-09-03) — 로컬 재측정(템플릿 DB 적용 후). 로컬 절대시간은 CI의 ~1/6이지만(실측), 파일 간 상대 비중은 LPT 배분에 유효하다. 재측정 기준은 이전과 동일: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐.",
-  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)+story-3423-scheduled-filter(CI shard(2) unweighted-guard 실측 23s, run 33849386492/job 100950217041, 2026-09-04 — PR#3775)+story-620beefc-threads-image(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 28.2s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값, 실 CI 샤드 로그로 재확認 필요)",
+  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)+story-3423-scheduled-filter(CI shard(2) unweighted-guard 실측 23s, run 33849386492/job 100950217041, 2026-09-04 — PR#3775)+story-620beefc-threads-image(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 28.2s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-5b27b32f-sandbox-channel-adapter(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 19.03s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 115s 잠정값, 실 CI 샤드 로그로 재확認 필요)",
   "measured_at": "2026-09-03",
   "files": [
     {
@@ -870,6 +870,10 @@
     {
       "file": "tests/test_620beefc_channel_post_image.py",
       "sec": 60.0
+    },
+    {
+      "file": "tests/test_5b27b32f_sandbox_channel.py",
+      "sec": 115.0
     }
   ]
 }


### PR DESCRIPTION
## 요약

dev org에 실 Meta 자격(Threads app_id/app_secret)이 아직 없어 채널 연결이 0건이고,
그래서 발행 명령(publication_command)·cron tick·cancel-scheduled·unpublish·429
transient·컨테이너 폴링·dead_letter 경로가 dev에서 한 번도 라이브로 밟힌 적이 없었다
(카디르 배포17 관측). Threads 어댑터 코드(`threads_publish.py`)는 한 글자도 건드리지
않고, 별도 결정적 가짜 provider(`sandbox_publish.py`, `channel="sandbox"`, dev 전용
env 플래그)로 같은 오케스트레이션 경로를 태워 라이브 검증 가능하게 한다.

## AC별

- **AC1**(어댑터 등재) — `CHANNEL_ADAPTERS["sandbox"]`를 `SANDBOX_CHANNEL_ENABLED=true`
  env일 때만 모듈 import 시점에 등재(Threads와 동일 이미지 규격). cloudbuild.yaml
  deploy-backend dev 분기에 리터럴로 배선(prod엔 키 자체 없음).
- **AC2**(연결) — `POST /{org_id}/channel-connections/sandbox`(owner/admin
  **휴먼 세션 전용** — 에이전트키는 403 `CHANNEL_CONNECTION_HUMAN_ONLY`, 실 OAuth
  연결과 동일 가드. ⚠️최초 PR 설명의 "OAuth 없이 agent-callable"은 오기 — 페드루
  리뷰 B1로 정정. 그라운딩 결과 발행/cancel-scheduled/unpublish/dead_letter 수동
  재시도도 전부 휴먼 세션 전용, 초안 생성/상신·cron tick(별도 CRON_SECRET 인증)만
  에이전트 가능), 기존 `upsert_channel_connection()` 재사용(신규 로직 0), 멱등
  upsert(`account_id=sandbox-{org_id}`).
- **AC3**(마커 5종) — `[sandbox:429]`/`[sandbox:provider-error]`/
  `[sandbox:expired-token]`/`[sandbox:container-error]`/`[sandbox:container-slow]`.
  상태(폴링 준비 시각·에러 모드)는 서버 메모리가 아니라 `creation_id` 문자열 자체에
  인코딩(stateless — 여러 Cloud Run 인스턴스가 각기 다른 tick에 같은 creation_id를
  다시 물어봐도 같은 답).
- **AC4**(QA 재현 가능성) — 발행 명령/cron/cancel/unpublish/429/voided/dead_letter
  수동 재시도 절차를 doc `05a772ac`(Threads 라이브 QA 런북)에 "샌드박스로 재는 항목"
  섹션으로 등재(정확한 endpoint·마커·기대 응답 포함).
- **AC5**(prod fail-closed) — env 게이트가 정상 배포에서 이미 prod 미등재를 보장하고,
  `assert_sandbox_channel_not_registered_in_prod()`가 그래도 수동 오조작으로 등재됐을
  경우 기동 자체를 RuntimeError로 죽인다(`app/main.py` lifespan에서 호출, 다른
  `check_*_config()` fail-closed 스타트업 가드와 동일 패턴).

발행 클라이언트 디스패치는 `get_publish_client_module(channel)` 단일 지점
(`channel_adapters.py`)이 유일한 개입 지점 — `channel_posts.py`의 발행/회수/한도조회
호출부는 이 함수가 돌려주는 모듈의 함수를 그대로 쓴다(신규 판정 로직 0). sandbox의
`create_container`가 429일 때 `_classify_threads_error`에 신규 429 분기를 추가했고
(Threads 실 provider도 이 단계에서 429를 낼 수 있어 일반 개선), 그 과정에서 unpublish
엔드포인트에 `ChannelRateLimitedError` 핸들러가 아예 없던 기존 결함(publish
엔드포인트만 있었음)도 발견해 같이 고쳤다.

## PO 리뷰 반영(B1·B2·N1, 2026-09-04, head 4522133c9)

- **B1**: 위 AC2 설명 정정(agent-callable 오기 → 휴먼 세션 전용) + QA 런북 05a772ac
  전체 정정(사전조건·절차 1~7 각 행에 agent/human 명시) + agent-403 회귀 테스트 1건.
- **B2**: `[sandbox:container-error]`/`[sandbox:container-slow]` 마커는 이미지 첨부
  초안 전용(TEXT 경로는 폴링 자체가 없어 무해) — docstring·런북에 명시 + container-slow
  inert 회귀 테스트 1건 추가(container-error는 이미 있었음).
- **N1**: 429 `reset_at` 하드코딩(now+60s)을 `_RATE_LIMIT_DEFAULT_RESET_SECONDS`
  명명 상수로 추출 + "실 provider가 reset 안 줄 때 기본값, story #3414 백오프 최소
  단위와 정합" 주석.

전체 채널-포스트 14파일 회귀 183 passed(신규 2 포함), 0 regression.

## 부수 발견/조치

- deploy-backend cloudbuild.yaml 스텝이 이번 배선으로 8,988B/10,000B(89%)까지 재차
  올라와 다음 env 1줄 추가가 곧바로 #3031급 배포 실패를 재현할 위험 — 페드루 확認,
  후속 스토리(0083750d)로 분리(서사주석 외부화·바이트 가드 임계 하향, 이 PR 스코프
  아님).
- story 23bf1913(PR#3777, 오늘 develop 머지)의 신규 CI 조기가드가 이 PR의 새
  destructive_schema 테스트 파일을 즉시 잡으므로, `infra/destructive-schema-shard-
  weights.json`에 선등재(로컬 실측 19.03s×CI 배율 잠정 115s).

## 테스트

- 신규 `test_5b27b32f_sandbox_channel.py` 23종(AC1~5 전부) — 100% pass.
- 채널-포스트 관련 16파일 통합 회귀 181 passed, 0 regression.
- 신규 CI 조기가드(`lint_destructive_schema_weights_registered.py`) 직접 실행 —
  "OK: 신규 미등재 destructive_schema 파일 0건" 확인.

## 뮤테이션 자체검증(3종, 전부 정확한 표적 RED 확인 후 byte-identical 복원)

1. 디스패치 always-threads(`get_publish_client_module`이 항상 threads_publish
   반환) → 6개 정밀 실패.
2. AC5 가드 조건 비활성화(`assert_sandbox_channel_not_registered_in_prod`가 항상
   no-op) → `test_prod_with_sandbox_registered_raises` 1건 정밀 실패.
3. 429 마커 조건 반전(`in`→`not in`) → `create_container`의 첫 분기가 다른 모든
   마커·기본성공 경로를 전부 선점 차단하는 구조라 11개 실패(넓은 실패 범위 자체가
   이 체크가 함수 전체의 게이트임을 재확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm
