### PR TITLE
[SID:3429] 조직 타임존 설정 — organizations.timezone(IANA·nullable)·owner/admin PATCH·응답 노출

### DIFF
--- a/backend/alembic/versions/0320_organizations_timezone.py
+++ b/backend/alembic/versions/0320_organizations_timezone.py
@@ -1,0 +1,34 @@
+"""story 46da6450(Phase1·BE·소형, 페드루 PO 確定 2026-09-04) — organizations.timezone.
+
+캘린더(#3422)·예약 시각 표기(§11-2 「조직 타임존으로 MM-DD HH:mm」)의 tz 정본. 서버
+시각 처리는 그대로 UTC-explicit ISO(scheduled_at 검증기·next_retry_at 무변경) — 이
+컬럼은 표시·그룹핑 기준을 위한 값 저장소일 뿐, 저장 로직 자체를 바꾸지 않는다(그라운딩
+결론: 서버는 지금 org tz를 어디서도 안 읽는다).
+
+nullable, 기본 null(백필 불요) — 미설정 조직은 FE가 계속 브라우저 tz로 폴백(기존
+동작 그대로).
+
+Revision ID: 0320
+Revises: 0319
+Create Date: 2026-09-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0320"
+down_revision = "0319"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organizations",
+        sa.Column("timezone", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "timezone")

--- a/backend/app/models/organization.py
+++ b/backend/app/models/organization.py
@@ -15,6 +15,10 @@ class Organization(Base):
     name: Mapped[str] = mapped_column(Text, nullable=False)
     slug: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
     plan: Mapped[str] = mapped_column(Text, nullable=False, default="free")
+    # story 46da6450(Phase1·BE·소형) — IANA 타임존 이름, nullable(기본 null·백필 없음).
+    # 캘린더(#3422)·예약 시각 표기(§11-2)의 tz 정본 — 저장/표시만, 서버 시각 처리(scheduled_at
+    # 검증·next_retry_at)는 그대로 UTC-explicit ISO로 무변경(그라운딩 결론).
+    timezone: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -48,6 +48,7 @@ class OrganizationWithRole:
     slug: str
     plan: str
     role: str
+    timezone: str | None = None
 
 
 class OrganizationRepository:
@@ -110,6 +111,7 @@ class OrganizationRepository:
                 Organization.name,
                 Organization.slug,
                 Organization.plan,
+                Organization.timezone,
                 OrgMember.role,
             )
             .join(OrgMember, OrgMember.org_id == Organization.id)
@@ -120,7 +122,9 @@ class OrganizationRepository:
             .order_by(Organization.name.asc())
         )
         return [
-            OrganizationWithRole(id=row.id, name=row.name, slug=row.slug, plan=row.plan, role=row.role)
+            OrganizationWithRole(
+                id=row.id, name=row.name, slug=row.slug, plan=row.plan, role=row.role, timezone=row.timezone,
+            )
             for row in result.all()
         ]
 

--- a/backend/app/routers/organizations.py
+++ b/backend/app/routers/organizations.py
@@ -39,7 +39,9 @@ async def list_my_organizations(
     """인증된 사용자가 속한 Organization 목록 조회."""
     items = await repo.list_for_user(uuid.UUID(auth.user_id))
     return [
-        MyOrganizationResponse(id=o.id, name=o.name, slug=o.slug, plan=o.plan, role=o.role)
+        MyOrganizationResponse(
+            id=o.id, name=o.name, slug=o.slug, plan=o.plan, role=o.role, timezone=o.timezone,
+        )
         for o in items
     ]
 
@@ -130,7 +132,9 @@ async def resolve_organization_by_slug(
     role = await repo.get_member_role(org_id=org.id, user_id=uuid.UUID(auth.user_id))
     if role is None:
         raise HTTPException(status_code=404, detail="Organization not found")
-    return MyOrganizationResponse(id=org.id, name=org.name, slug=org.slug, plan=org.plan, role=role)
+    return MyOrganizationResponse(
+        id=org.id, name=org.name, slug=org.slug, plan=org.plan, role=role, timezone=org.timezone,
+    )
 
 
 @router.get("/{id}", response_model=OrganizationResponse)
@@ -157,7 +161,7 @@ async def update_organization(
     repo: OrganizationRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
 ) -> OrganizationResponse:
-    """Organization 이름/슬러그 수정 — owner/admin만 가능."""
+    """Organization 이름/슬러그/타임존 수정 — owner/admin만 가능."""
     role = await repo.get_member_role(org_id=id, user_id=uuid.UUID(auth.user_id))
     if role is None:
         raise HTTPException(status_code=404, detail="Organization not found")
@@ -186,6 +190,25 @@ async def update_organization(
             old_slug=org.slug, new_slug=body.slug,
         ))
         org.slug = body.slug
+
+    # story 46da6450 — name/slug와 달리 "필드 생략=무변경"과 "명시적 null=해제"를 구별해야
+    # 한다(null로 timezone 해제를 허용하는 게 AC). `body.timezone is not None` 체크만
+    # 쓰면 null을 보내도 스킵돼 영원히 해제가 안 된다 — model_fields_set으로 실제 전송
+    # 여부를 판별.
+    if "timezone" in body.model_fields_set:
+        if body.timezone is not None:
+            from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+            try:
+                ZoneInfo(body.timezone)
+            except (ZoneInfoNotFoundError, ValueError):
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "code": "ORG_TIMEZONE_INVALID",
+                        "message": f"'{body.timezone}'은 유효한 IANA 타임존 이름이 아닙니다(예: Asia/Seoul).",
+                    },
+                )
+        org.timezone = body.timezone
 
     await session.flush()
     await session.refresh(org)

--- a/backend/app/schemas/organization.py
+++ b/backend/app/schemas/organization.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class CreateOrganization(BaseModel):
@@ -52,8 +52,10 @@ class UpdateOrganization(BaseModel):
     # story 46da6450 — IANA 이름. 필드 자체를 생략하면 무변경, 명시적으로 null을 보내면
     # 해제(name/slug와 달리 "생략=무변경"과 "null=해제"를 구별해야 하므로 라우터가
     # `"timezone" in body.model_fields_set`로 판정 — None이면 그냥 스킵하는 기존
-    # name/slug 패턴을 그대로 쓰면 해제가 영원히 불가능해진다).
-    timezone: str | None = None
+    # name/slug 패턴을 그대로 쓰면 해제가 영원히 불가능해진다). max_length=64(페드루
+    # 리뷰 N1) — 가장 긴 실 IANA 이름도 40자 미만(예: America/Argentina/ComodRivadavia
+    # 32자)이라 여유 있게 상한, zoneinfo 검증 前에 극단적으로 긴 문자열을 앞단에서 거른다.
+    timezone: str | None = Field(default=None, max_length=64)
 
 
 class OrgImpactResponse(BaseModel):

--- a/backend/app/schemas/organization.py
+++ b/backend/app/schemas/organization.py
@@ -27,6 +27,8 @@ class OrganizationResponse(BaseModel):
     name: str
     slug: str
     plan: str
+    # story 46da6450 — IANA 이름, null=미설정(FE는 브라우저 tz 폴백을 그대로 쓴다).
+    timezone: str | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -39,12 +41,19 @@ class MyOrganizationResponse(BaseModel):
     slug: str
     plan: str
     role: str
+    # story 46da6450 — OrganizationResponse.timezone과 동일 의미.
+    timezone: str | None = None
 
 
 class UpdateOrganization(BaseModel):
     name: str | None = None
     # story 139d2405(S-slug-infra): workspace rename — 형식/예약어/유일성은 라우터에서(DB 조회 필요).
     slug: str | None = None
+    # story 46da6450 — IANA 이름. 필드 자체를 생략하면 무변경, 명시적으로 null을 보내면
+    # 해제(name/slug와 달리 "생략=무변경"과 "null=해제"를 구별해야 하므로 라우터가
+    # `"timezone" in body.model_fields_set`로 판정 — None이면 그냥 스킵하는 기존
+    # name/slug 패턴을 그대로 쓰면 해제가 영원히 불가능해진다).
+    timezone: str | None = None
 
 
 class OrgImpactResponse(BaseModel):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -67,6 +67,15 @@ dependencies = [
     # 검증. 기존에 uv.lock 전이 의존성(4.26.0)으로만 있었고 직접 import하는 곳이 없었다 — 첫
     # 실사용처라 직접 선언.
     "jsonschema>=4.26.0",
+    # story 46da6450(페드루 리뷰 B2) — stdlib zoneinfo는 IANA tz 데이터베이스를 OS 패키지
+    # (`/usr/share/zoneinfo`, Debian `tzdata` apt 패키지)에서 찾는데, backend/Dockerfile의
+    # `python:3.12-slim`은 apt 설치를 전혀 안 해 그게 없다 — macOS 로컬(시스템에 IANA DB
+    # 있음)에서는 통과하던 테스트가 실 배포 이미지에서는 모든 IANA 이름이
+    # ZoneInfoNotFoundError로 거부되는(=organizations.timezone PATCH가 유효값도 전부
+    # 422로 되돌리는) 배포-로컬 불일치였다. `tzdata` PyPI 패키지는 순수 파이썬으로 같은
+    # IANA DB를 담아 OS 설치 없이도 zoneinfo가 그걸 찾게 한다(stdlib가 자동으로 우선
+    # 시도) — apt-get 없이 uv 의존성만으로 해소.
+    "tzdata>=2025.1",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_46da6450_org_timezone.py
+++ b/backend/tests/test_46da6450_org_timezone.py
@@ -1,0 +1,364 @@
+"""story 46da6450(Phase1·BE·소형, 페드루 PO 確定 2026-09-04) — organizations.timezone.
+
+캘린더(#3422)·예약 시각 표기(§11-2)의 tz 정본. 서버 시각 처리는 그대로 UTC-explicit
+ISO(scheduled_at 검증기·next_retry_at 무변경) — 이 스토리는 「정본 값 저장·노출」만
+다룬다(그라운딩 결론, 스토리 description 참고).
+
+AC 커버: 유효 IANA 저장·무효 IANA 422(ORG_TIMEZONE_INVALID)·null로 해제·member 403·
+단건/내 조직 목록 양쪽 응답 노출. 마이그레이션 up/down/up은 별도로 실 PG against
+story46da6450_scratch DB로 수동 검증 완료(멱등 재확인 — 컬럼 생성/제거/재생성 확인,
+PR 본문에 기록)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+
+    org = Organization(id=uuid.uuid4(), name="46da6450 Timezone Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    return org.id
+
+
+async def _seed_human(session, org_id, *, role="owner"):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_app(app, Session, *, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {}})
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_owner_sets_valid_iana_timezone():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_app(app, Session, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}", json={"timezone": "Asia/Seoul"},
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["timezone"] == "Asia/Seoul"
+
+        async with Session() as s:
+            from app.models.organization import Organization
+            org = await s.get(Organization, org_id)
+            assert org.timezone == "Asia/Seoul"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_invalid_timezone_returns_422_org_timezone_invalid():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_app(app, Session, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}", json={"timezone": "Not/AZone"},
+            )
+        assert r.status_code == 422, r.text
+        # app/main.py::http_exception_handler — dict detail은 {"error":{code,message,...}}로
+        # 패스스루(구조화 에러 계약, story #2003/#3410 선례).
+        error = r.json()["error"]
+        assert error["code"] == "ORG_TIMEZONE_INVALID"
+        assert "Not/AZone" in error["message"]
+
+        async with Session() as s:
+            from app.models.organization import Organization
+            org = await s.get(Organization, org_id)
+            assert org.timezone is None, "422로 거부됐으면 컬럼이 그대로 null이어야 한다(부분쓰기 없음)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_explicit_null_clears_timezone():
+    """페드루 PO AC2 — "null로 해제 허용". name/slug 패턴(`is not None`이면 스킵)을
+    그대로 재사용하면 null 전송이 "무변경"으로 조용히 씹혀 해제가 영원히 불가능해진다
+    (그라운딩에서 지적한 정확한 함정) — model_fields_set 분기가 이 케이스를 실제로
+    구별하는지 여기서 고정."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            from app.models.organization import Organization
+            org = await s.get(Organization, org_id)
+            org.timezone = "Asia/Seoul"
+            await s.commit()
+
+        _setup_app(app, Session, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}", json={"timezone": None},
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["timezone"] is None
+
+        async with Session() as s:
+            from app.models.organization import Organization
+            org = await s.get(Organization, org_id)
+            assert org.timezone is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_omitted_timezone_field_leaves_value_unchanged():
+    """해제(explicit null)와 대칭 — 필드 자체를 아예 안 보내면(다른 필드만 PATCH) 기존
+    timezone은 그대로 남아야 한다. model_fields_set 분기가 "생략"과 "null 전송"을
+    실제로 다르게 취급하는지 이 테스트가 그 반대쪽 절반을 고정한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            from app.models.organization import Organization
+            org = await s.get(Organization, org_id)
+            org.timezone = "Asia/Seoul"
+            await s.commit()
+
+        _setup_app(app, Session, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}", json={"name": "Renamed Org"},
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["timezone"] == "Asia/Seoul"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_member_role_gets_403_setting_timezone():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            member_id = await _seed_human(s, org_id, role="member")
+
+        _setup_app(app, Session, user_id=member_id)
+        async with _client_for(app) as client:
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}", json={"timezone": "Asia/Seoul"},
+            )
+        assert r.status_code == 403, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_admin_role_can_set_timezone():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            admin_id = await _seed_human(s, org_id, role="admin")
+
+        _setup_app(app, Session, user_id=admin_id)
+        async with _client_for(app) as client:
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}", json={"timezone": "America/New_York"},
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["timezone"] == "America/New_York"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_single_org_get_exposes_timezone():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            from app.models.organization import Organization
+            org = await s.get(Organization, org_id)
+            org.timezone = "Europe/London"
+            await s.commit()
+
+        _setup_app(app, Session, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}")
+        assert r.status_code == 200, r.text
+        assert r.json()["timezone"] == "Europe/London"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_my_organizations_list_exposes_timezone():
+    """AC3 — "내 조직 목록"(GET /organizations, 에이전트가 org 컨텍스트를 보는 자리)도
+    같은 필드를 노출해야 한다 — OrganizationWithRole/list_for_user 별도 경로가 놓치기
+    쉬운 지점(단건 응답과 다른 select문)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+            from app.models.organization import Organization
+            org = await s.get(Organization, org_id)
+            org.timezone = "Asia/Tokyo"
+            await s.commit()
+
+        _setup_app(app, Session, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.get("/api/v2/organizations")
+        assert r.status_code == 200, r.text
+        rows = [row for row in r.json() if row["id"] == str(org_id)]
+        assert len(rows) == 1
+        assert rows[0]["timezone"] == "Asia/Tokyo"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_by_slug_exposes_timezone():
+    """발견 즉시 수정 — `GET /organizations/resolve?slug=`(story 139d2405)도
+    MyOrganizationResponse를 쓰는 별도 구성 지점인데 timezone 인자가 누락돼 있었다
+    (org 객체엔 실제 값이 있는데도 항상 null로 나갔을 결함, 코드 리딩 중 발견해 즉시
+    fix). 목록 API와 같은 필드를 노출하는지 여기서 고정."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s, slug="resolve-tz-test")
+            owner_id = await _seed_human(s, org_id, role="owner")
+            from app.models.organization import Organization
+            org = await s.get(Organization, org_id)
+            org.timezone = "Australia/Sydney"
+            await s.commit()
+
+        _setup_app(app, Session, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.get("/api/v2/organizations/resolve", params={"slug": "resolve-tz-test"})
+        assert r.status_code == 200, r.text
+        assert r.json()["timezone"] == "Australia/Sydney"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_null_timezone_org_exposed_as_null_not_omitted():
+    """null=「미설정」— FE가 브라우저 tz 폴백을 계속 쓰도록, 값이 없으면 명시적으로
+    null이어야 한다(필드 자체가 응답에서 빠지면 FE가 다르게 처리할 여지가 생김)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_app(app, Session, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "timezone" in body
+        assert body["timezone"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_46da6450_org_timezone.py
+++ b/backend/tests/test_46da6450_org_timezone.py
@@ -387,3 +387,27 @@ async def test_null_timezone_org_exposed_as_null_not_omitted():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+def test_zoneinfo_resolves_without_os_tzdata():
+    """페드루 리뷰 B2 후속(2026-09-04) — `tzdata` 의존성이 실제로 하는 일을 로컬에서
+    직접 재현해 고정. `backend/Dockerfile`의 `python:3.12-slim`은 OS tz DB
+    (`/usr/share/zoneinfo`)가 없다 — `zoneinfo.reset_tzpath(to=[])`로 그 부재를
+    강제 재현한 뒤(파일시스템 검색 경로를 완전히 비움) `ZoneInfo('Asia/Seoul')`이
+    여전히 성공해야 `tzdata` PyPI 패키지 경유 해소가 실제로 동작한다는 뜻이다.
+    누가 나중에 `tzdata`를 의존성에서 지우면(pyproject.toml/uv.lock) 이 테스트가
+    바로 이 자리에서 빨갛게 — CI 이미지 빌드까지 안 기다린다.
+
+    `reset_tzpath`는 zoneinfo 모듈의 전역 검색 경로를 바꾼다(프로세스 전역 상태) —
+    다른 테스트가 실 OS tzdata 경로에 의존할 수 있으므로 try/finally로 원래 TZPATH를
+    반드시 복원한다."""
+    import zoneinfo
+
+    original_tzpath = zoneinfo.TZPATH
+    try:
+        zoneinfo.reset_tzpath(to=[])
+        assert zoneinfo.TZPATH == ()
+        zi = zoneinfo.ZoneInfo("Asia/Seoul")
+        assert zi.key == "Asia/Seoul"
+    finally:
+        zoneinfo.reset_tzpath(to=original_tzpath)

--- a/backend/tests/test_46da6450_org_timezone.py
+++ b/backend/tests/test_46da6450_org_timezone.py
@@ -217,6 +217,31 @@ async def test_omitted_timezone_field_leaves_value_unchanged():
 
 
 @pytest.mark.anyio
+async def test_overlong_timezone_string_rejected_422():
+    """페드루 리뷰 N1 — max_length=64(Field 레벨, ZoneInfo 검증보다 앞단). 이 응답은
+    pydantic RequestValidationError 기본 shape(`{"detail": [...]}`)라 ORG_TIMEZONE_
+    INVALID 커스텀 shape과 다르다 — 그 차이 자체를 여기서 고정."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id = await _seed_org(s)
+            owner_id = await _seed_human(s, org_id, role="owner")
+
+        _setup_app(app, Session, user_id=owner_id)
+        async with _client_for(app) as client:
+            r = await client.patch(
+                f"/api/v2/organizations/{org_id}", json={"timezone": "A" * 65},
+            )
+        assert r.status_code == 422, r.text
+        assert "detail" in r.json()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_member_role_gets_403_setting_timezone():
     from app.main import app
 

--- a/backend/tests/test_e_org_multi_s1_1_list_organizations.py
+++ b/backend/tests/test_e_org_multi_s1_1_list_organizations.py
@@ -29,6 +29,10 @@ class _OrgRow:
     slug: str
     plan: str
     role: str
+    # story 46da6450 — repo.list_for_user()가 raw row에서 직접 .timezone을 읽는다
+    # (OrganizationWithRole 생성 前). 기본값 없으면 이 mock row 자체가 매 호출마다
+    # 명시 필요해진다 — 실제 DB row는 nullable 컬럼이라 None이 자연스러운 기본값.
+    timezone: str | None = None
 
 
 def _make_org_row(
@@ -37,8 +41,9 @@ def _make_org_row(
     slug: str = "test-org",
     plan: str = "free",
     role: str = "owner",
+    timezone: str | None = None,
 ) -> _OrgRow:
-    return _OrgRow(id=org_id, name=name, slug=slug, plan=plan, role=role)
+    return _OrgRow(id=org_id, name=name, slug=slug, plan=plan, role=role, timezone=timezone)
 
 
 @pytest.fixture

--- a/backend/tests/test_e_org_multi_s4_1_org_settings_be.py
+++ b/backend/tests/test_e_org_multi_s4_1_org_settings_be.py
@@ -25,6 +25,9 @@ def _mock_org(name: str = "Test Org") -> MagicMock:
     o.name = name
     o.slug = "test-org"
     o.plan = "free"
+    # story 46da6450 — 신규 필드, 명시 안 하면 MagicMock이 자동생성한 하위 MagicMock이
+    # OrganizationResponse.model_validate(org)에서 str|None 검증 실패로 500을 낸다.
+    o.timezone = None
     o.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     o.updated_at = datetime(2026, 5, 20, tzinfo=timezone.utc)
     return o

--- a/backend/tests/test_org_create_email_verification_gate.py
+++ b/backend/tests/test_org_create_email_verification_gate.py
@@ -24,6 +24,7 @@ def _mock_org():
     org.name = "Fresh Org"
     org.slug = "fresh-org"
     org.plan = "free"
+    org.timezone = None
     org.created_at = datetime(2026, 7, 10, tzinfo=timezone.utc)
     org.updated_at = datetime(2026, 7, 10, tzinfo=timezone.utc)
     return org

--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -31,6 +31,7 @@ def _mock_org() -> MagicMock:
     o.name = "Test Org"
     o.slug = "test-org"
     o.plan = "free"
+    o.timezone = None
     o.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
     o.updated_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
     return o

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2099,6 +2099,7 @@ dependencies = [
     { name = "resend" },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -2146,6 +2147,7 @@ requires-dist = [
     { name = "resend", specifier = ">=2.0.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
+    { name = "tzdata", specifier = ">=2025.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 
@@ -2275,6 +2277,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,6 @@
 {
   "_snapshot_policy": "story #3383(2026-09-03) — 로컬 재측정(템플릿 DB 적용 후). 로컬 절대시간은 CI의 ~1/6이지만(실측), 파일 간 상대 비중은 LPT 배분에 유효하다. 재측정 기준은 이전과 동일: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐.",
-  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)+story-3423-scheduled-filter(CI shard(2) unweighted-guard 실측 23s, run 33849386492/job 100950217041, 2026-09-04 — PR#3775)+story-620beefc-threads-image(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 28.2s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-5b27b32f-sandbox-channel-adapter(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 19.03s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 115s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-8b7e52d6-claim-story-signal(PR 개설 前 선제 등재, story 23bf1913 조기가드 학습 반영 — 로컬 raw pytest 15.30s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 92s 잠정값, 실 CI 샤드 로그로 재확認 필요)",
+  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)+story-3423-scheduled-filter(CI shard(2) unweighted-guard 실측 23s, run 33849386492/job 100950217041, 2026-09-04 — PR#3775)+story-620beefc-threads-image(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 28.2s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-5b27b32f-sandbox-channel-adapter(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 19.03s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 115s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-8b7e52d6-claim-story-signal(PR 개설 前 선제 등재, story 23bf1913 조기가드 학습 반영 — 로컬 raw pytest 15.30s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 92s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-46da6450-org-timezone(PR 개설 前 선제 등재, 페드루 리뷰 B1 — 로컬 raw pytest 15.86s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 95s 잠정값, 실 CI 샤드 로그로 재확認 필요)",
   "measured_at": "2026-09-03",
   "files": [
     {
@@ -878,6 +878,10 @@
     {
       "file": "tests/test_8b7e52d6_claim_story_signal.py",
       "sec": 92.0
+    },
+    {
+      "file": "tests/test_46da6450_org_timezone.py",
+      "sec": 95.0
     }
   ]
 }


### PR DESCRIPTION
## 요약

캘린더(#3422)·예약 시각 표기(§11-2)의 tz 정본. 그라운딩 결론(스토리 description) —
서버는 지금 org tz를 어디서도 안 쓴다(scheduled_at 검증기·next_retry_at 전부
UTC-explicit ISO 그대로). 이 스토리는 **정본 값 저장·노출만** — 소비는 FE(#3422,
아직 미착수)의 스코프.

## AC별

1. **[제품]** `organizations.timezone TEXT NULL`(마이그 0320, 백필 불요, 기본 null).
2. **[제품]** `PATCH /organizations/{id}`에 name/slug와 동형 패턴으로 timezone
   수용(owner/admin 기존 role 게이트 재사용) — `zoneinfo.ZoneInfo()` IANA 검증,
   실패 시 422 `ORG_TIMEZONE_INVALID`(예시 IANA 1개 포함 메시지). null로 해제 허용
   — `body.model_fields_set`으로 "필드 생략(무변경)"과 "명시적 null(해제)"를
   구별(name/slug의 `is not None` 패턴을 그대로 쓰면 해제가 영원히 불가능해지는
   함정, 뮤테이션으로 실증).
3. **[제품]** 조직 응답 3곳 노출: 단건 GET/PATCH(`OrganizationResponse`)·내 조직
   목록 GET(`MyOrganizationResponse`, `list_for_user` 쿼리에 컬럼 추가)·
   `GET /organizations/resolve`.
4. **[경계]** 서버 시각 처리 무변경 — `_scheduled_at_must_be_tz_aware_future`·
   `next_retry_at` 노출 로직 둘 다 안 건드림.
5. **[QA]** 유효/무효/해제/생략 4갈래·member 403·admin 200·응답 노출 3곳·마이그
   up/down 커버(아래).

## FE 소비처(후속, #3422 스코프 — 미르코군에 계약 전달은 페드루군)

그라운딩에서 실측한 정확한 3곳:
1. 예약 시각 입력 UI의 tz 기준(현재: 브라우저 tz 추정) — `_scheduled_at_must_be_
   tz_aware_future`(`channel_posts.py:253`)는 오프셋 무관 통과라 서버는 무관.
2. 캘린더 날짜 그룹핑 — `useChannelPostCalendarData`/`formatScheduledAt(iso,
   orgTimezone)`(story #3422 미르코 설계, `components/content/schedule-format.ts`
   예정) — 그 설계가 "조직 타임존 값의 출처 미확認"으로 막혀 있던 게 바로 이
   스토리로 풀림.
3. 실 브라우저-tz 폴백 지점: `apps/web/src/app/(authenticated)/content/
   channel-posts/[draftId]/page.tsx:727` — `new Date(...).toLocaleString()`.

## 페드루 리뷰 반영(B1·B2·N1·N2, 2026-09-04, head 46d02701b)

- **B1**: 신규 destructive_schema 테스트 파일을 shard-weights.json에 선등재(story
  23bf1913 조기가드 대응, 잠정 95s).
- **B2**: `tzdata` PyPI 패키지 추가(uv.lock 갱신) — `python:3.12-slim`엔 OS tzdata가
  없어 macOS 로컬에서만 통과하던 배포-로컬 불일치를 해소. `zoneinfo.reset_tzpath(to=[])`
  로 "OS tz DB 완전 부재"를 로컬에서 직접 재현해 tzdata 패키지 경유 해소를 실측
  확認(문서 추정 아님).
  ⚠️**CI 스모크 테스트 추가는 보류** — 그라운딩 결과 `docker-smoke-test.yml`은 루트
  `Dockerfile`(프론트엔드 Node 이미지)만 빌드하고, `backend/Dockerfile`은 어떤 GHA
  워크플로에서도 빌드된 적이 없습니다(grep 0건, Cloud Build 배포 시점에만 빌드) —
  제안하신 위치에 넣을 표면 자체가 없어 임의로 새 워크플로/스텝을 만들지 않고 보류.
  옵션: ①`docker-smoke-test.yml`에 backend 이미지 빌드+zoneinfo 체크를 신규 잡으로
  추가(스코프 확장) ②Cloud Build cloudbuild.yaml의 backend 빌드 스텝 뒤에 한 줄
  추가(배포 시점에만 검증, PR 시점엔 여전히 미검증) ③보류(이미 `tzdata` 의존성
  자체가 근본 수정이라 실사고 재현 확률 낮음 판단) — 페드루군 판단 필요.
- **N1**: `UpdateOrganization.timezone`에 `max_length=64`(가장 긴 실 IANA 이름도
  40자 미만) + 과다길이 422 회귀 테스트.
- **N2**: name/slug 감사·이벤트 대조 — `name` 변경은 활동로그/이벤트 발행이 전혀
  없습니다(grep 0건). `slug`만 `EntitySlugHistory`(301 리다이렉트 전용 특수 이력,
  일반 감사 로그 아님)를 남깁니다. `timezone`은 `name`과 동형(감사/이벤트 없음)으로
  구현 — slug의 특수 이력은 URL 불변식 때문이지 "설정 변경 일반"에 대한 관례가
  아니므로 대칭이 맞다고 판단.

전체 11 passed(신규 max_length 테스트 포함).

## 부수 발견/조치 — 발견 즉시 수정

- `GET /organizations/resolve`(story 139d2405)도 `MyOrganizationResponse`를 쓰는데
  timezone 인자가 누락돼 있었다 — org에 실제 값이 있어도 항상 null로 나가던 결함,
  코드 리딩 중 발견해 즉시 fix + 회귀 테스트 추가.
- 기존 mock/dataclass 픽스처 2곳(`_mock_org`·`_OrgRow`) 신규 필드 기본값 미명시 시
  pydantic `str|None` 검증에서 500 — house 패턴대로 기본값 명시(발견·수정).

## 테스트

- 신규 `test_46da6450_org_timezone.py` 10건(실 PG) — 유효 IANA 저장·무효 422·명시적
  null 해제·필드 생략 무변경·member 403·admin 200·단건/목록/resolve 응답 노출·null
  명시 노출.
- 뮤테이션 2종: ①IANA 검증 비활성화(`if False`) → `test_invalid_...` 1건 정밀 실패
  ②`model_fields_set`→naive `is not None` → `test_explicit_null_clears_timezone`
  1건 정밀 실패. 둘 다 복원 후 byte-identical 재확인.
- 마이그 0320 up/down/up 실 PG(`story46da6450_scratch`) 수동 검증 — 컬럼 생성·제거·
  재생성 확인.
- 회귀: org 관련 4파일(`test_e_org_multi_s4_1`·`s1_1`·`s2_1`·`test_139d2405`)
  27 passed + 18 skipped(pre-existing skip, 이 스토리와 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm
