### PR TITLE
[SID:3430] 샌드박스 채널 연결 생성 BFF 라우트 — 배포19 갭 마감

### DIFF
--- a/apps/web/src/app/api/organizations/[id]/channel-connections/sandbox/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-connections/sandbox/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { proxyToFastapiWithParams } = vi.hoisted(() => ({ proxyToFastapiWithParams: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { POST } from './route';
+
+describe('/api/organizations/[id]/channel-connections/sandbox (story 5b27b32f)', () => {
+  it('POST — FastAPI 샌드박스 연결 생성 엔드포인트로 id를 그대로 위임', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: 'c1', channel: 'sandbox', account_id: 'sandbox-org-1', status: 'active' }),
+        { status: 201, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const request = new Request('http://test', { method: 'POST' });
+    const resp = await POST(request, { params: Promise.resolve({ id: 'org-1' }) });
+
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      request, '/api/v2/organizations/[id]/channel-connections/sandbox', { id: 'org-1' },
+    );
+    expect(resp.status).toBe(201);
+  });
+
+  it('POST — 404(CHANNEL_SANDBOX_DISABLED, 어댑터 미등재) 같은 !ok 응답은 그대로 pass-through', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: { code: 'CHANNEL_SANDBOX_DISABLED' } }), {
+        status: 404, headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const resp = await POST(new Request('http://test', { method: 'POST' }), { params: Promise.resolve({ id: 'org-1' }) });
+    expect(resp.status).toBe(404);
+  });
+
+  it('POST — 에이전트 헤더로 온 요청도 BE의 CHANNEL_CONNECTION_HUMAN_ONLY 403을 그대로 통과시킨다(삼키지 않음)', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: { code: 'CHANNEL_CONNECTION_HUMAN_ONLY' } }), {
+        status: 403, headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const request = new Request('http://test', { method: 'POST', headers: { Authorization: 'Bearer agent-key-123' } });
+    const resp = await POST(request, { params: Promise.resolve({ id: 'org-1' }) });
+    expect(resp.status).toBe(403);
+  });
+
+  it('POST — member(owner/admin 아님) 요청에 대한 BE의 OWNER_OR_ADMIN_ONLY 403도 그대로 통과시킨다', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: { code: 'CHANNEL_CONNECTION_OWNER_OR_ADMIN_ONLY' } }), {
+        status: 403, headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const resp = await POST(new Request('http://test', { method: 'POST' }), { params: Promise.resolve({ id: 'org-1' }) });
+    expect(resp.status).toBe(403);
+  });
+
+  it('POST — 무자격 요청에 대한 BE의 401도 그대로 통과시킨다', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(new Response(null, { status: 401 }));
+    const resp = await POST(new Request('http://test', { method: 'POST' }), { params: Promise.resolve({ id: 'org-1' }) });
+    expect(resp.status).toBe(401);
+  });
+});

--- a/apps/web/src/app/api/organizations/[id]/channel-connections/sandbox/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-connections/sandbox/route.ts
@@ -1,0 +1,20 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// story 5b27b32f AC2(BE #3430, PR #3779) — 샌드박스 채널 연결 생성(owner/admin 휴먼
+// 세션 전용, BE `_require_owner_or_admin`). FE에 대응 BFF가 없어(story #3419
+// cancel-scheduled/unpublish 선례와 달리 이 엔드포인트만 배선이 빠져) 배포19 서빙 뒤
+// 브라우저에서 만들 길이 없던 갭 — 검증 로직 0, CHANNEL_CONNECTION_HUMAN_ONLY(403)·
+// CHANNEL_CONNECTION_OWNER_OR_ADMIN_ONLY(403)·CHANNEL_SANDBOX_DISABLED(404, 어댑터
+// 미등재 — prod/미설정 dev)·401 전부 서버 응답 그대로 pass-through.
+export async function POST(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(
+    request, '/api/v2/organizations/[id]/channel-connections/sandbox', { id },
+  );
+  if (!_r.ok) return _r;
+  // 백엔드가 201로 신규 연결 생성을 알린다(channel-posts/drafts/route.ts와 동일 이유).
+  return apiSuccess(await _r.json(), undefined, _r.status);
+}


### PR DESCRIPTION
## 요약

story 5b27b32f AC2(BE #3430, PR #3779)의 「버튼(또는 API)」 중 API 쪽 마무리 —
`POST /api/v2/organizations/{org}/channel-connections/sandbox`에 대응하는 FE BFF가
없어(story #3419 cancel-scheduled/unpublish 선례와 달리 이 엔드포인트만 배선이
빠짐) 배포19 서빙 뒤 owner 세션(브라우저)에서 샌드박스 연결을 만들 길이 없었다
(FE 세션은 httpOnly 쿠키+기능별 BFF 라우트 구조라 `/api/v2/...` 직접 호출 불가,
페드루 PO 확인).

## 구현

`apps/web/src/app/api/organizations/[id]/channel-connections/sandbox/route.ts` —
`channel-posts/drafts/route.ts`와 동형 패턴(`proxyToFastapiWithParams` 그대로
위임, 검증 로직 0). 201 status 명시 보존(`apiSuccess`가 기본 200이라 BE의 201을
그대로 살리려면 3번째 인자 필요 — 동일 파일 POST 핸들러 선례 그대로 재사용).
`CHANNEL_CONNECTION_HUMAN_ONLY`(403)·`CHANNEL_CONNECTION_OWNER_OR_ADMIN_ONLY`
(403)·`CHANNEL_SANDBOX_DISABLED`(404, 어댑터 미등재)·401 전부 서버 응답 그대로
pass-through.

## 테스트

라우트 테스트 5건(성공 201·404·에이전트 403·member 403·무자격 401) — PR#3778
unpublish route.test.ts와 동형 mock 패턴. `vitest run`(전체 스위트 5858건) 회귀
확認 — 이 파일 밖 영향 없음. eslint 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm