### PR TITLE
[SID:3434] claim_story 응답 스코프 신호 보정 — assignee_changed/hint/participation 노출

### DIFF
--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -741,8 +741,31 @@ async def claim_story(
     # 3414b6d7: claim=일 시작=실작업자 → implementation participation 멱등 생성(게이트/verdict
     # attribution). assignee(board)는 안 건드림 — participation만(claim만 하고 done해도 평가 가능).
     from app.services.participation_helpers import ensure_implementation_participation
-    await ensure_implementation_participation(session, org_id, body.story_id, id)
-    return {"claimed": True, "story_id": str(body.story_id)}
+    participation_ensured = await ensure_implementation_participation(session, org_id, body.story_id, id)
+
+    # story 8b7e52d6(PO 재정의, 2026-09-04) — "신호 보정": claim_story의 실제 동작(위)은
+    # story 3414b6d7 결정 그대로 assignee/board를 절대 안 건드린다 — 그런데 기존 응답
+    # `{"claimed": True}` 한 줄만으로는 호출자가 "claim=내 것이 됨(assignee·board 반영)"
+    # 으로 합리적으로 오독한다(디디 그라운딩 실사례 — 0845cb03에서 본인이 그렇게 오독했다).
+    # 행동은 그대로 두고 응답에 실제 스코프(participation만 바뀌었고 assignee는 무변경)를
+    # 명시해 그 오독을 원천 차단한다.
+    from app.routers.stories import _attach_assignee_ids
+    await _attach_assignee_ids(session, org_id, [story])
+    assignee_ids = [str(a) for a in story.assignee_ids]
+
+    result: dict = {
+        "claimed": True,
+        "story_id": str(body.story_id),
+        "participation": {"ensured": participation_ensured},
+        "assignee_changed": False,
+        "assignee_ids": assignee_ids,
+    }
+    if not assignee_ids:
+        result["hint"] = (
+            "assignee는 별도입니다(update_story의 assignee_id/assignee_ids) — "
+            "보드 배정 표시·통지 수신자는 claim이 아니라 assignee 기준입니다."
+        )
+    return result
 
 
 @router.post("/{id}/unclaim")

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -741,7 +741,7 @@ async def claim_story(
     # 3414b6d7: claim=일 시작=실작업자 → implementation participation 멱등 생성(게이트/verdict
     # attribution). assignee(board)는 안 건드림 — participation만(claim만 하고 done해도 평가 가능).
     from app.services.participation_helpers import ensure_implementation_participation
-    participation_ensured = await ensure_implementation_participation(session, org_id, body.story_id, id)
+    participation_created = await ensure_implementation_participation(session, org_id, body.story_id, id)
 
     # story 8b7e52d6(PO 재정의, 2026-09-04) — "신호 보정": claim_story의 실제 동작(위)은
     # story 3414b6d7 결정 그대로 assignee/board를 절대 안 건드린다 — 그런데 기존 응답
@@ -756,7 +756,13 @@ async def claim_story(
     result: dict = {
         "claimed": True,
         "story_id": str(body.story_id),
-        "participation": {"ensured": participation_ensured},
+        # 페드루 리뷰 N1(2026-09-04) — "ensured"는 False가 실패로 읽힌다는 지적으로
+        # "created"로 개명. ⚠️정확한 의미는 "새로 만들었다"가 아니다 —
+        # ensure_implementation_participation은 이미 있던 행이든 방금 만든 행이든
+        # 똑같이 True를 반환한다(멱등, participation_helpers.py 참고). False는 "이미
+        # 있었다"가 아니라 **이 조직에 default participation role 자체가 시드 안 돼
+        # 있어 참여 보장 자체가 스킵됐다**는 뜻 — 정상 org에선 사실상 항상 True다.
+        "participation": {"created": participation_created},
         "assignee_changed": False,
         "assignee_ids": assignee_ids,
     }

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -741,7 +741,7 @@ async def claim_story(
     # 3414b6d7: claim=일 시작=실작업자 → implementation participation 멱등 생성(게이트/verdict
     # attribution). assignee(board)는 안 건드림 — participation만(claim만 하고 done해도 평가 가능).
     from app.services.participation_helpers import ensure_implementation_participation
-    participation_created = await ensure_implementation_participation(session, org_id, body.story_id, id)
+    participation_ensured = await ensure_implementation_participation(session, org_id, body.story_id, id)
 
     # story 8b7e52d6(PO 재정의, 2026-09-04) — "신호 보정": claim_story의 실제 동작(위)은
     # story 3414b6d7 결정 그대로 assignee/board를 절대 안 건드린다 — 그런데 기존 응답
@@ -756,13 +756,13 @@ async def claim_story(
     result: dict = {
         "claimed": True,
         "story_id": str(body.story_id),
-        # 페드루 리뷰 N1(2026-09-04) — "ensured"는 False가 실패로 읽힌다는 지적으로
-        # "created"로 개명. ⚠️정확한 의미는 "새로 만들었다"가 아니다 —
-        # ensure_implementation_participation은 이미 있던 행이든 방금 만든 행이든
-        # 똑같이 True를 반환한다(멱등, participation_helpers.py 참고). False는 "이미
-        # 있었다"가 아니라 **이 조직에 default participation role 자체가 시드 안 돼
-        # 있어 참여 보장 자체가 스킵됐다**는 뜻 — 정상 org에선 사실상 항상 True다.
-        "participation": {"created": participation_created},
+        # 페드루 리뷰 N1 재정정(2026-09-04) — "created"는 거짓 이름이었다(디디 지적
+        # 반영, 원래 이름이 맞았다) — ensure_implementation_participation은 이미 있던
+        # 행이든 방금 만든 행이든 똑같이 True를 반환하는 멱등 함수라 "새로 만들었다"는
+        # 뜻이 아니다. "ensured"로 되돌리고, False일 때만(=이 org에 default
+        # participation role 자체가 없어 참여 보장이 스킵된 진짜 이상 상태 — 정상
+        # org에선 안 뜨는 필드) 아래 warning으로 명시.
+        "participation": {"ensured": participation_ensured},
         "assignee_changed": False,
         "assignee_ids": assignee_ids,
     }
@@ -770,6 +770,11 @@ async def claim_story(
         result["hint"] = (
             "assignee는 별도입니다(update_story의 assignee_id/assignee_ids) — "
             "보드 배정 표시·통지 수신자는 claim이 아니라 assignee 기준입니다."
+        )
+    if not participation_ensured:
+        result["warning"] = (
+            "participation 미보장 — 이 org에 기본 participation role이 없어 "
+            "게이트/verdict attribution이 안 잡힘(관리자 확인 필요)"
         )
     return result
 

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -655,7 +655,7 @@ _TOOL_DEFS: list[tuple] = [
      "[일감] 현재 작업 중인 스토리를 claim — active_story_id 갱신, 중복 배정 방지. "
      "⚠️story 8b7e52d6: assignee/board는 안 건드립니다(participation만 생성) — "
      "보드 배정 표시·통지 수신자는 이 호출이 아니라 assignee 기준입니다(update_story의 "
-     "assignee_id/assignee_ids). 응답의 assignee_ids/hint로 현재 상태를 확認하세요.",
+     "assignee_id/assignee_ids). 응답의 assignee_ids/hint로 현재 상태를 확인하세요.",
      ClaimStoryInput, claim_story),
     ("sprintable_unclaim_story",
      "[일감] 작업 중인 스토리 claim 해제 — active_story_id = NULL.",

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -450,7 +450,10 @@ _TOOL_DEFS: list[tuple] = [
      "같이 보내라. 다른 스토리를 쪼개거나 복제한 것이면 origin_type=\"story\"·"
      "origin_id=<원본 스토리 id>. 회의에서 나온 것이면 origin_type=\"meeting\". "
      "둘 다 줘야 유효(하나만 있으면 조용히 무시된다) — 안 채우면 이 스토리의 출처는 "
-     "영원히 «미수집」으로 남는다(소급 안 됨, story #2267 AC5).",
+     "영원히 «미수집」으로 남는다(소급 안 됨, story #2267 AC5). ⚠️story 8b7e52d6: "
+     "assignee_id를 생략하면 claim_story를 나중에 아무리 호출해도 채워지지 않습니다"
+     "(claim_story는 assignee/board를 안 건드림, participation만) — 생략 시 응답에 "
+     "「통지 수신자 0」 warning이 실립니다.",
      AddStoryInput, add_story),
     ("sprintable_update_story",
      "[일감] 스토리 수정. 응답 reference_token은 sprintable_add_story와 동일.",
@@ -649,7 +652,10 @@ _TOOL_DEFS: list[tuple] = [
      " 해소됨. 지정 project_id에 접근권 없으면 403.",
      SetDefaultProjectInput, set_default_project),
     ("sprintable_claim_story",
-     "[일감] 현재 작업 중인 스토리를 claim — active_story_id 갱신, 중복 배정 방지.",
+     "[일감] 현재 작업 중인 스토리를 claim — active_story_id 갱신, 중복 배정 방지. "
+     "⚠️story 8b7e52d6: assignee/board는 안 건드립니다(participation만 생성) — "
+     "보드 배정 표시·통지 수신자는 이 호출이 아니라 assignee 기준입니다(update_story의 "
+     "assignee_id/assignee_ids). 응답의 assignee_ids/hint로 현재 상태를 확認하세요.",
      ClaimStoryInput, claim_story),
     ("sprintable_unclaim_story",
      "[일감] 작업 중인 스토리 claim 해제 — active_story_id = NULL.",

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -229,7 +229,22 @@ async def add_story(args: AddStoryInput) -> list[TextContent]:
         if args.origin_type and args.origin_id:
             body["origin_type"] = args.origin_type
             body["origin_id"] = args.origin_id
-        return ok(await client.post("/api/v2/stories", json=body))
+        result = await client.post("/api/v2/stories", json=body)
+        # story 8b7e52d6(PO 재정의, 2026-09-04) — assignee_id를 생략하고 만든 스토리는
+        # claim_story를 몇 번 호출해도 assignee가 채워지지 않는다(claim_story는
+        # participation만 건드림, story 3414b6d7 결정) — 보드 배정·통지 수신자가 영구히
+        # 비는 상태로 남을 수 있다는 걸 생성 시점에 바로 알린다(사후 수동 개입 필요했던
+        # 실사례: story 0845cb03).
+        if not args.assignee_id and isinstance(result, dict):
+            result = {
+                **result,
+                "warning": (
+                    "assignee 없음 → 통지 수신자 0. claim_story는 assignee를 채우지 "
+                    "않습니다 — 필요하면 update_story의 assignee_id/assignee_ids로 "
+                    "직접 배정하세요."
+                ),
+            }
+        return ok(result)
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/tests/test_8b7e52d6_add_story_assignee_warning.py
+++ b/backend/tests/test_8b7e52d6_add_story_assignee_warning.py
@@ -1,0 +1,48 @@
+"""story 8b7e52d6(AC2) — add_story MCP 도구가 assignee_id 생략 시 warning 필드를 응답에
+싣는지 고정. claim_story가 assignee를 절대 안 채운다(story 3414b6d7)는 걸 생성 시점에
+알려 사후 수동 개입(story 0845cb03 실사례)을 줄인다."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_add_story_without_assignee_id_gets_warning():
+    from sprintable_mcp.tools.stories import AddStoryInput, add_story
+
+    be_response = {"id": "s1", "title": "Test Story", "reference_token": "[Test Story](entity:story:s1)"}
+
+    with patch("sprintable_mcp.tools.stories.client") as mock_client:
+        mock_client.require_project_id.return_value = "p1"
+        mock_client.post = AsyncMock(return_value=be_response)
+        out = await add_story(AddStoryInput(title="Test Story"))
+
+    parsed = json.loads(out[0].text)
+    assert "warning" in parsed
+    assert "assignee" in parsed["warning"]
+    # BE가 실제로 돌려준 필드는 그대로 보존(덮어쓰지 않음).
+    assert parsed["id"] == "s1"
+    assert parsed["reference_token"] == "[Test Story](entity:story:s1)"
+
+
+@pytest.mark.anyio
+async def test_add_story_with_assignee_id_no_warning():
+    from sprintable_mcp.tools.stories import AddStoryInput, add_story
+
+    be_response = {"id": "s1", "title": "Test Story", "assignee_id": "m1"}
+
+    with patch("sprintable_mcp.tools.stories.client") as mock_client:
+        mock_client.require_project_id.return_value = "p1"
+        mock_client.post = AsyncMock(return_value=be_response)
+        out = await add_story(AddStoryInput(title="Test Story", assignee_id="m1"))
+
+    parsed = json.loads(out[0].text)
+    assert "warning" not in parsed

--- a/backend/tests/test_8b7e52d6_claim_story_signal.py
+++ b/backend/tests/test_8b7e52d6_claim_story_signal.py
@@ -56,9 +56,27 @@ async def _seed_org(session, *, slug=None):
     # 실 org 생성 경로(OrganizationRepository.create)는 default participation role을
     # 자동 시드한다 — 여기 직접 ORM construct는 그걸 건너뛰므로 명시 호출(안 하면
     # ensure_implementation_participation이 "default role 미시드"로 skip=False를 내
-    # participation.created 검증이 실제 프로덕션 경로와 다른 값을 관측하게 된다).
+    # participation.ensured 검증이 실제 프로덕션 경로와 다른 값을 관측하게 된다).
     from app.services.participation_helpers import seed_default_participation_role
     await seed_default_participation_role(session, org.id)
+    return org.id, project.id
+
+
+async def _seed_org_without_default_role(session, *, slug=None):
+    """페드루 리뷰 N1 후속 — participation.ensured=False 경로 재현용. 정상 org라면
+    존재할 default participation role을 일부러 안 심는다(실 프로덕션에서는
+    OrganizationRepository.create()가 자동 시드하므로, 이 상태는 그 경로를 우회해
+    수동 구성된 org에서만 나타나는 이상 상태 — warning 필드가 정확히 그 경우에만
+    떠야 한다는 걸 이 헬퍼로 재현)."""
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="8b7e52d6 No-Role Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
     return org.id, project.id
 
 
@@ -109,7 +127,7 @@ def _setup_app(app, Session, *, org_id, user_id):
 @pytest.mark.anyio
 async def test_claim_response_has_empty_assignee_ids_and_hint_when_unassigned():
     """AC1 — assignee 없는 스토리를 claim하면 assignee_ids=[]·hint 존재·
-    assignee_changed=False·participation.created=True."""
+    assignee_changed=False·participation.ensured=True."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -129,7 +147,7 @@ async def test_claim_response_has_empty_assignee_ids_and_hint_when_unassigned():
         assert body["claimed"] is True
         assert body["assignee_changed"] is False
         assert body["assignee_ids"] == []
-        assert body["participation"]["created"] is True
+        assert body["participation"]["ensured"] is True
         assert "hint" in body
         assert "assignee" in body["hint"]
     finally:
@@ -190,6 +208,36 @@ async def test_claim_does_not_change_assignee_regression_3414b6d7():
             from app.models.pm import Story
             story = await s.get(Story, story_id)
             assert story.assignee_id is None, "claim이 assignee_id를 채워선 안 된다(3414b6d7 결정)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_claim_response_has_warning_when_org_has_no_default_participation_role():
+    """페드루 리뷰 N1 후속 — participation.ensured=False(이 org에 default
+    participation role이 없음, 정상 org에선 안 생기는 이상 상태)일 때만 warning이
+    응답에 실려야 한다. 정상 경로(다른 테스트들, role 있음)에선 warning이 없어야
+    노이즈가 안 된다 — 그 비대칭을 여기서 고정."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org_without_default_role(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=None)
+
+        _setup_app(app, Session, org_id=org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/team-members/{agent_id}/claim", json={"story_id": str(story_id)},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["participation"]["ensured"] is False
+        assert "warning" in body
+        assert "participation" in body["warning"]
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_8b7e52d6_claim_story_signal.py
+++ b/backend/tests/test_8b7e52d6_claim_story_signal.py
@@ -56,7 +56,7 @@ async def _seed_org(session, *, slug=None):
     # 실 org 생성 경로(OrganizationRepository.create)는 default participation role을
     # 자동 시드한다 — 여기 직접 ORM construct는 그걸 건너뛰므로 명시 호출(안 하면
     # ensure_implementation_participation이 "default role 미시드"로 skip=False를 내
-    # participation.ensured 검증이 실제 프로덕션 경로와 다른 값을 관측하게 된다).
+    # participation.created 검증이 실제 프로덕션 경로와 다른 값을 관측하게 된다).
     from app.services.participation_helpers import seed_default_participation_role
     await seed_default_participation_role(session, org.id)
     return org.id, project.id
@@ -109,7 +109,7 @@ def _setup_app(app, Session, *, org_id, user_id):
 @pytest.mark.anyio
 async def test_claim_response_has_empty_assignee_ids_and_hint_when_unassigned():
     """AC1 — assignee 없는 스토리를 claim하면 assignee_ids=[]·hint 존재·
-    assignee_changed=False·participation.ensured=True."""
+    assignee_changed=False·participation.created=True."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -129,7 +129,7 @@ async def test_claim_response_has_empty_assignee_ids_and_hint_when_unassigned():
         assert body["claimed"] is True
         assert body["assignee_changed"] is False
         assert body["assignee_ids"] == []
-        assert body["participation"]["ensured"] is True
+        assert body["participation"]["created"] is True
         assert "hint" in body
         assert "assignee" in body["hint"]
     finally:

--- a/backend/tests/test_8b7e52d6_claim_story_signal.py
+++ b/backend/tests/test_8b7e52d6_claim_story_signal.py
@@ -1,0 +1,195 @@
+"""story 8b7e52d6(제품·신호, 페드루 PO 재정의 2026-09-04) — claim_story 응답 스코프 신호.
+
+story 3414b6d7 결정(claim은 participation만 건드리고 assignee/board는 절대 안 건드림)
+은 그대로 — 이 스토리는 «행동 변경»이 아니라 «신호 보정». AC 커버: 응답에 participation/
+assignee_changed(항상 False)/assignee_ids(현재값) 노출·assignee 비어있을 때만 hint·
+assignee 있으면 hint 부재·3414b6d7 회귀(assignee 실제 미변경) pin."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="8b7e52d6 Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    # 실 org 생성 경로(OrganizationRepository.create)는 default participation role을
+    # 자동 시드한다 — 여기 직접 ORM construct는 그걸 건너뛰므로 명시 호출(안 하면
+    # ensure_implementation_participation이 "default role 미시드"로 skip=False를 내
+    # participation.ensured 검증이 실제 프로덕션 경로와 다른 값을 관측하게 된다).
+    from app.services.participation_helpers import seed_default_participation_role
+    await seed_default_participation_role(session, org.id)
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="Test Story", assignee_id=None):
+    from app.models.pm import Story
+
+    s = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, assignee_id=assignee_id)
+    session.add(s)
+    await session.commit()
+    return s.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_app(app, Session, *, org_id, user_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"api_key_id": "test-agent-key", "org_id": str(org_id)}}
+        return AuthContext(user_id=str(user_id), email="agent@test", claims=claims)
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_claim_response_has_empty_assignee_ids_and_hint_when_unassigned():
+    """AC1 — assignee 없는 스토리를 claim하면 assignee_ids=[]·hint 존재·
+    assignee_changed=False·participation.ensured=True."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=None)
+
+        _setup_app(app, Session, org_id=org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/team-members/{agent_id}/claim", json={"story_id": str(story_id)},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["claimed"] is True
+        assert body["assignee_changed"] is False
+        assert body["assignee_ids"] == []
+        assert body["participation"]["ensured"] is True
+        assert "hint" in body
+        assert "assignee" in body["hint"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_claim_response_has_no_hint_when_assignee_already_set():
+    """AC1 대칭절 — assignee가 이미 있으면 hint가 응답에서 아예 빠져야 한다(항상 켜진
+    경고는 노이즈 — story 3414b6d7과 별개로 이미 알려진 것을 매번 다시 알리지 않는다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            other_member_id = uuid.uuid4()
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=other_member_id)
+
+        _setup_app(app, Session, org_id=org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/team-members/{agent_id}/claim", json={"story_id": str(story_id)},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["assignee_ids"] == [str(other_member_id)]
+        assert "hint" not in body
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_claim_does_not_change_assignee_regression_3414b6d7():
+    """story 3414b6d7 회귀 pin — claim_story가 assignee_id 컬럼 자체를 절대 안 건드린다
+    (이 스토리는 신호만 고치지 그 결정을 재통합하지 않는다). claim한 agent 자신이
+    assignee가 되는 일도 없어야 한다(합리적으로 오해하기 쉬운 방향이라 명시적으로 pin)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id, assignee_id=None)
+
+        _setup_app(app, Session, org_id=org_id, user_id=agent_id)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/team-members/{agent_id}/claim", json={"story_id": str(story_id)},
+            )
+        assert r.status_code == 200, r.text
+
+        async with Session() as s:
+            from app.models.pm import Story
+            story = await s.get(Story, story_id)
+            assert story.assignee_id is None, "claim이 assignee_id를 채워선 안 된다(3414b6d7 결정)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,6 @@
 {
   "_snapshot_policy": "story #3383(2026-09-03) — 로컬 재측정(템플릿 DB 적용 후). 로컬 절대시간은 CI의 ~1/6이지만(실측), 파일 간 상대 비중은 LPT 배분에 유효하다. 재측정 기준은 이전과 동일: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐.",
-  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)+story-3423-scheduled-filter(CI shard(2) unweighted-guard 실측 23s, run 33849386492/job 100950217041, 2026-09-04 — PR#3775)+story-620beefc-threads-image(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 28.2s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-5b27b32f-sandbox-channel-adapter(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 19.03s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 115s 잠정값, 실 CI 샤드 로그로 재확認 필요)",
+  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)+story-3423-scheduled-filter(CI shard(2) unweighted-guard 실측 23s, run 33849386492/job 100950217041, 2026-09-04 — PR#3775)+story-620beefc-threads-image(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 28.2s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-5b27b32f-sandbox-channel-adapter(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 19.03s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 115s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-8b7e52d6-claim-story-signal(PR 개설 前 선제 등재, story 23bf1913 조기가드 학습 반영 — 로컬 raw pytest 15.30s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 92s 잠정값, 실 CI 샤드 로그로 재확認 필요)",
   "measured_at": "2026-09-03",
   "files": [
     {
@@ -874,6 +874,10 @@
     {
       "file": "tests/test_5b27b32f_sandbox_channel.py",
       "sec": 115.0
+    },
+    {
+      "file": "tests/test_8b7e52d6_claim_story_signal.py",
+      "sec": 92.0
     }
   ]
 }


### PR DESCRIPTION
## 요약

story 8b7e52d6 — 최초 프레이밍("claim_story가 거짓 성공을 돌려준다·머지 게이트
participation 갭의 원인")은 페드루 PO가 철회했다. 디디 그라운딩 결과 `claim_story`
는 story 3414b6d7 결정대로 설계대로 동작 중(participation만 건드림, assignee/board는
의도적으로 무변경) — 머지 게이트도 assignee와 무관하게 정상 발화한다. 남는 결함은
**신호**뿐: `{"claimed": true}` 한 줄이 "무엇이 바뀌었나"를 말하지 않아 호출자가
"claim=assignee/board 반영"으로 합리적으로 오독한다(디디 본인이 story 0845cb03에서
실제로 이렇게 오독한 사례가 이 스토리의 출발점).

## AC별

1. **[제품]** `claim_story` 응답에 스코프 명시 — `participation: {ensured: bool}`
   (`ensure_implementation_participation` 결과)·`assignee_changed: false`(항상)·
   `assignee_ids: [...]`(현재값, `stories.py::_attach_assignee_ids` 기존 헬퍼 재사용
   — 크로스 라우터 import는 `chat_command_catalog.py`에 이미 있는 선례). 비어 있을
   때만 `hint` 추가(이미 배정돼 있으면 노이즈라 생략).
2. **[제품]** MCP 도구 설명 2곳(`sprintable_claim_story`·`sprintable_add_story`)에
   같은 문장. `add_story`는 `assignee_id` 생략 시 응답에 `warning`(「통지 수신자 0」)
   필드 추가 — story 0845cb03 실사례(생성 시 생략 → claim을 몇 번 해도 안 채워짐)의
   근본 원인을 생성 시점에 알린다.
3. **[QA]** 응답 스키마 pin(assignee 비어있을 때 hint 존재·있을 때 부재)·3414b6d7
   회귀 pin(assignee_id 컬럼 실제 미변경).

## 테스트

신규 5건(claim 응답 스코프 3건, 실 PG — `test_8b7e52d6_claim_story_signal.py` + add_story
warning 2건 — `test_8b7e52d6_add_story_assignee_warning.py`) + 뮤테이션 2종(hint 조건
반전·warning 조건 반전, 둘 다 정밀 타겟 RED 확인 후 byte-identical 복원).

기존 회귀: `test_s2_4_claim_unclaim.py` 15 passed(무변경) · MCP 도구 계약 테스트
무회귀 — `tests/mcp/test_e2e_dev.py::test_tools_list_89_tools` 1건 실패는 **이 PR과
무관**(라이브 dev 서버 매니페스트 대비 하드코딩된 "89"가 이미 stale — 실측 119개,
로컬 파일 편집이 원격 서버 상태를 바꿀 수 없어 구조적으로 이 변경과 인과관계 없음).

`shard-weights.json`에 신규 destructive_schema 파일 선등재(story 23bf1913 조기가드
대응, 잠정 92s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm