### PR TITLE
[SID:3435] feat: available-channels 엔드포인트(AC1) — CHANNEL_ADAPTERS 레지스트리 파생

### DIFF
--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -272,6 +272,40 @@ async def list_channel_connections_agent_visible_endpoint(
     return [_to_agent_visible_item(r) for r in rows]
 
 
+class AvailableChannelItem(BaseModel):
+    """story f30da19a(AC1, 페드루 PO 확定 2026-09-04) — 「연결 만들기」 버튼이 FE에서
+    하드코딩/env 분기 없이 그릴 수 있게 `CHANNEL_ADAPTERS` 레지스트리를 그대로 노출.
+    sandbox는 그 레지스트리 자체가 `SANDBOX_CHANNEL_ENABLED`일 때만 항목을 갖고 있어
+    (channel_adapters.py 상단 조건부 등재) prod에서는 자동으로 빠진다 — 이 엔드포인트에
+    별도 필터링 로직이 없다."""
+    channel: str
+    display_name: str
+    oauth: bool
+
+
+@router.get(
+    "/{org_id}/channel-connections/available-channels", response_model=list[AvailableChannelItem],
+)
+async def list_available_channels_endpoint(
+    org_id: uuid.UUID,
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> list[AvailableChannelItem]:
+    """story f30da19a(AC1) — 목록 엔드포인트(`agent-visible`)와 동형: `_require_human()`을
+    안 부른다(org 멤버면 에이전트도 조회 가능 — 이 응답엔 토큰 인접 필드가 아예 없어
+    AC6의 human-only 근거가 적용되지 않는다). DB 조회 0 — 레지스트리 자체가 SSOT라
+    org마다 다른 값이 없다(org_id는 스코프 검증에만 쓴다)."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    return [
+        AvailableChannelItem(
+            channel=channel, display_name=cfg.display_name, oauth=cfg.credential_kind == "oauth",
+        )
+        for channel, cfg in CHANNEL_ADAPTERS.items()
+    ]
+
+
 @router.post("/{org_id}/channel-connections/{channel}/authorize", response_model=AuthorizeResponse)
 async def authorize_channel_connection(
     org_id: uuid.UUID,

--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -277,10 +277,16 @@ class AvailableChannelItem(BaseModel):
     하드코딩/env 분기 없이 그릴 수 있게 `CHANNEL_ADAPTERS` 레지스트리를 그대로 노출.
     sandbox는 그 레지스트리 자체가 `SANDBOX_CHANNEL_ENABLED`일 때만 항목을 갖고 있어
     (channel_adapters.py 상단 조건부 등재) prod에서는 자동으로 빠진다 — 이 엔드포인트에
-    별도 필터링 로직이 없다."""
+    별도 필터링 로직이 없다.
+
+    페드루 리뷰 B2(2026-09-04) — 원래 AC의 `oauth: bool`을 `credential_kind: str`
+    그대로 노출으로 정정. `bool`이면 "oauth vs 그 외"만 구별되는데, 미래에
+    `credential_kind="pasted_secret"`인 채널이 추가되면 그것도 `oauth=false`가 돼
+    FE가 sandbox와 같은 BFF POST 분기(§경계 AC2)로 잘못 보낸다 — "oauth|pasted_secret|
+    none" 3값 자체가 FE 분기의 SSOT라 값을 지어내지 않고 그대로 넘긴다."""
     channel: str
     display_name: str
-    oauth: bool
+    credential_kind: str
 
 
 @router.get(
@@ -300,7 +306,7 @@ async def list_available_channels_endpoint(
 
     return [
         AvailableChannelItem(
-            channel=channel, display_name=cfg.display_name, oauth=cfg.credential_kind == "oauth",
+            channel=channel, display_name=cfg.display_name, credential_kind=cfg.credential_kind,
         )
         for channel, cfg in CHANNEL_ADAPTERS.items()
     ]

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -24,12 +24,15 @@ class ChannelAdapterConfig:
     # "refresh_token"(표준 grant) | "reissue_from_access_token"(Threads류 — 현재 유효한
     # access_token으로 재발급, refresh_token 불요) | "manual"(자동 갱신 불가 — 재인증 유도).
     refresh_mode: str
-    credential_kind: str = "oauth"  # "oauth" | "pasted_secret" | "none"
     # story f30da19a(Phase1·FE, PO 확定 2026-09-04) — 「연결 만들기」 버튼 라벨(FE는
     # 하드코딩 X, `GET .../channel-connections/available-channels`가 이 값을 그대로
     # 노출). 채널의 성질이라 여기 한 곳에 선언(max_text_length·can_auto_refresh와 동형
-    # 관례).
-    display_name: str = ""
+    # 관례). 페드루 리뷰 N1(2026-09-04) — 기본값 ""를 제거해 필수 인자로: 라벨 없는
+    # 어댑터를 등재하면 그 즉시(import 시점) TypeError로 죽는다 — 화면에 빈 버튼이
+    # 뜨는 대신 배포 자체가 안 되게(fail-closed, 다른 필수 필드 authorize_url/token_url/
+    # scope/refresh_mode와 동열).
+    display_name: str
+    credential_kind: str = "oauth"  # "oauth" | "pasted_secret" | "none"
     # story #3374(Phase1·마케팅운영, PO 결정) — 채널 포스트 초안 text 상한. 상수를 서비스/
     # 라우터에 하드코딩하지 않고 여기 한 곳에 선언(담롱 요구 — "상수 하드코딩 X·선언·표시",
     # 초안 저장 422 응답에 이 값을 그대로 실어 보낸다).

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -25,6 +25,11 @@ class ChannelAdapterConfig:
     # access_token으로 재발급, refresh_token 불요) | "manual"(자동 갱신 불가 — 재인증 유도).
     refresh_mode: str
     credential_kind: str = "oauth"  # "oauth" | "pasted_secret" | "none"
+    # story f30da19a(Phase1·FE, PO 확定 2026-09-04) — 「연결 만들기」 버튼 라벨(FE는
+    # 하드코딩 X, `GET .../channel-connections/available-channels`가 이 값을 그대로
+    # 노출). 채널의 성질이라 여기 한 곳에 선언(max_text_length·can_auto_refresh와 동형
+    # 관례).
+    display_name: str = ""
     # story #3374(Phase1·마케팅운영, PO 결정) — 채널 포스트 초안 text 상한. 상수를 서비스/
     # 라우터에 하드코딩하지 않고 여기 한 곳에 선언(담롱 요구 — "상수 하드코딩 X·선언·표시",
     # 초안 저장 422 응답에 이 값을 그대로 실어 보낸다).
@@ -70,6 +75,7 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         scope="threads_basic,threads_content_publish,threads_delete",
         refresh_mode="reissue_from_access_token",
         credential_kind="oauth",
+        display_name="Threads",
         # sprintable-agent-plugins/plugins/sprintable/connectors/threads.ts:27의
         # MAX_TEXT_LENGTH=500 그대로(story #3311, Meta 공식 문서 페이지 직접 실측 — 추정값
         # 아님).
@@ -112,6 +118,7 @@ if os.environ.get("SANDBOX_CHANNEL_ENABLED", "").strip().lower() == "true":
         scope="sandbox_publish,sandbox_delete",
         refresh_mode="manual",  # 더미 토큰이라 자동 갱신 개념 자체가 없음.
         credential_kind="none",
+        display_name="Sandbox",
         max_text_length=500,  # Threads와 동형(그라운딩 §1 실측 재사용, 새 한도를 지어내지 않는다).
         utm_source="sandbox",
         utm_medium="test",

--- a/backend/tests/test_3419_cancel_unpublish.py
+++ b/backend/tests/test_3419_cancel_unpublish.py
@@ -715,7 +715,7 @@ async def test_unpublish_unsupported_channel_returns_422():
 
     unsupported_adapter = ChannelAdapterConfig(
         authorize_url="https://example.test/oauth", token_url="https://example.test/token",
-        scope="basic", refresh_mode="manual", max_text_length=500,
+        scope="basic", refresh_mode="manual", display_name="Unsupported", max_text_length=500,
         supports_unpublish=False,
     )
 
@@ -813,7 +813,7 @@ async def test_connection_list_unpublish_blocked_reason_unsupported_for_adapter_
 
     unsupported_adapter = ChannelAdapterConfig(
         authorize_url="https://example.test/oauth", token_url="https://example.test/token",
-        scope="basic", refresh_mode="manual", max_text_length=500,
+        scope="basic", refresh_mode="manual", display_name="Unsupported", max_text_length=500,
         supports_unpublish=False,
     )
 

--- a/backend/tests/test_5b27b32f_sandbox_channel.py
+++ b/backend/tests/test_5b27b32f_sandbox_channel.py
@@ -59,7 +59,7 @@ def _enable_sandbox_adapter(monkeypatch):
 
     sandbox_config = adapters_mod.ChannelAdapterConfig(
         authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete",
-        refresh_mode="manual", credential_kind="none", max_text_length=500,
+        refresh_mode="manual", display_name="Sandbox", credential_kind="none", max_text_length=500,
         utm_source="sandbox", utm_medium="test", supports_unpublish=True,
         unpublish_required_scope="sandbox_delete",
         image_formats=("image/jpeg", "image/png"), image_max_bytes=8 * 1024 * 1024,

--- a/backend/tests/test_620beefc_channel_post_image.py
+++ b/backend/tests/test_620beefc_channel_post_image.py
@@ -484,7 +484,7 @@ async def test_upload_url_unsupported_channel_returns_422():
 
         no_image_adapter = adapters_mod.ChannelAdapterConfig(
             authorize_url="https://example.com/auth", token_url="https://example.com/token",
-            scope="basic", refresh_mode="manual",
+            scope="basic", refresh_mode="manual", display_name="No Image Channel",
         )
         _setup_org_scoped_app(app, Session, org_id, user_id=human_id, agent=False)
         with patch.dict(adapters_mod.CHANNEL_ADAPTERS, {"no-image-channel": no_image_adapter}):

--- a/backend/tests/test_f30da19a_available_channels.py
+++ b/backend/tests/test_f30da19a_available_channels.py
@@ -1,0 +1,207 @@
+"""story f30da19a(AC1, 페드루 PO 확定 2026-09-04) — `GET .../channel-connections/
+available-channels`가 `CHANNEL_ADAPTERS` 레지스트리를 그대로 파생 노출한다. FE가
+「연결 만들기」 버튼을 하드코딩/env 분기 없이 이 목록만으로 그리게(story 본문 §경계) —
+sandbox는 `SANDBOX_CHANNEL_ENABLED`일 때만 레지스트리 자체에 항목이 있어(channel_adapters.py
+상단 조건부 등재, 이 엔드포인트에 별도 필터링 로직 0) prod에서 자동으로 빠진다.
+목록(agent-visible, story #3399)과 동형: org 멤버면 에이전트도 조회 가능(`_require_human`
+안 부름) — 이 응답엔 토큰 인접 필드가 아예 없어 AC6 human-only 근거가 적용되지 않는다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="f30da19a Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="agent"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id, agent: bool = False):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if agent:
+            claims["app_metadata"]["api_key_id"] = "test-agent-key"
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_sandbox_absent_when_flag_off():
+    """플래그 off 갈래(AC1) — SANDBOX_CHANNEL_ENABLED 미설정이면 레지스트리 자체에 sandbox가
+    없어(channel_adapters.py 조건부 등재) 응답에도 없다. threads는 항상 있다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections/available-channels")
+        assert r.status_code == 200, r.text
+        rows = r.json()
+        channels = {row["channel"] for row in rows}
+        assert "sandbox" not in channels
+        assert "threads" in channels
+        threads_row = next(row for row in rows if row["channel"] == "threads")
+        assert threads_row["display_name"] == "Threads"
+        assert threads_row["oauth"] is True
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sandbox_present_when_flag_on():
+    """플래그 on 갈래(AC1) — 실 env 파싱(SANDBOX_CHANNEL_ENABLED 문자열 처리)이 아니라
+    story 5b27b32f 선례(test_5b27b32f_sandbox_channel.py::_enable_sandbox_adapter) 그대로
+    레지스트리 dict에 직접 주입해 "플래그가 켜졌을 때 레지스트리에 sandbox가 있으면 이
+    엔드포인트가 그걸 그대로 노출하는지"만 검증한다(env 파싱 자체는 그 파일이 이미 커버)."""
+    from unittest.mock import patch
+
+    from app.main import app
+    import app.services.channel_adapters as adapters_mod
+
+    sandbox_config = adapters_mod.ChannelAdapterConfig(
+        authorize_url="", token_url="", scope="sandbox_publish,sandbox_delete",
+        refresh_mode="manual", credential_kind="none", display_name="Sandbox",
+    )
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        with patch.dict(adapters_mod.CHANNEL_ADAPTERS, {"sandbox": sandbox_config}):
+            async with _client_for(app) as client:
+                r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections/available-channels")
+        assert r.status_code == 200, r.text
+        rows = r.json()
+        sandbox_row = next(row for row in rows if row["channel"] == "sandbox")
+        assert sandbox_row["display_name"] == "Sandbox"
+        assert sandbox_row["oauth"] is False, "sandbox는 credential_kind='none' — OAuth 시작 버튼이 아니라 BFF POST 분기로 가야 한다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_gets_200_not_403():
+    """AC1 — 에이전트도 읽기 가능(_require_human 안 부름). 목록(agent-visible, #3399)과
+    동일 근거: 응답에 토큰 인접 필드가 없다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections/available-channels")
+        assert r.status_code == 200, r.text
+        assert set(r.json()[0].keys()) == {"channel", "display_name", "oauth"}
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_id_mismatch_still_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            other_org_id, _ = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{other_org_id}/channel-connections/available-channels")
+        assert r.status_code == 403, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_f30da19a_available_channels.py
+++ b/backend/tests/test_f30da19a_available_channels.py
@@ -123,7 +123,7 @@ async def test_sandbox_absent_when_flag_off():
         assert "threads" in channels
         threads_row = next(row for row in rows if row["channel"] == "threads")
         assert threads_row["display_name"] == "Threads"
-        assert threads_row["oauth"] is True
+        assert threads_row["credential_kind"] == "oauth"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -159,7 +159,7 @@ async def test_sandbox_present_when_flag_on():
         rows = r.json()
         sandbox_row = next(row for row in rows if row["channel"] == "sandbox")
         assert sandbox_row["display_name"] == "Sandbox"
-        assert sandbox_row["oauth"] is False, "sandbox는 credential_kind='none' — OAuth 시작 버튼이 아니라 BFF POST 분기로 가야 한다"
+        assert sandbox_row["credential_kind"] == "none", "sandbox는 credential_kind='none' — OAuth 시작 버튼이 아니라 BFF POST 분기로 가야 한다"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -181,7 +181,7 @@ async def test_agent_gets_200_not_403():
         async with _client_for(app) as client:
             r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections/available-channels")
         assert r.status_code == 200, r.text
-        assert set(r.json()[0].keys()) == {"channel", "display_name", "oauth"}
+        assert set(r.json()[0].keys()) == {"channel", "display_name", "credential_kind"}
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,6 @@
 {
   "_snapshot_policy": "story #3383(2026-09-03) — 로컬 재측정(템플릿 DB 적용 후). 로컬 절대시간은 CI의 ~1/6이지만(실측), 파일 간 상대 비중은 LPT 배분에 유효하다. 재측정 기준은 이전과 동일: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐.",
-  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)+story-3423-scheduled-filter(CI shard(2) unweighted-guard 실측 23s, run 33849386492/job 100950217041, 2026-09-04 — PR#3775)+story-620beefc-threads-image(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 28.2s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-5b27b32f-sandbox-channel-adapter(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 19.03s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 115s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-8b7e52d6-claim-story-signal(PR 개설 前 선제 등재, story 23bf1913 조기가드 학습 반영 — 로컬 raw pytest 15.30s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 92s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-46da6450-org-timezone(PR 개설 前 선제 등재, 페드루 리뷰 B1 — 로컬 raw pytest 15.86s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 95s 잠정값, 실 CI 샤드 로그로 재확認 필요)",
+  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)+story-3423-scheduled-filter(CI shard(2) unweighted-guard 실측 23s, run 33849386492/job 100950217041, 2026-09-04 — PR#3775)+story-620beefc-threads-image(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 28.2s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-5b27b32f-sandbox-channel-adapter(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 19.03s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 115s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-8b7e52d6-claim-story-signal(PR 개설 前 선제 등재, story 23bf1913 조기가드 학습 반영 — 로컬 raw pytest 15.30s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 92s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-46da6450-org-timezone(PR 개설 前 선제 등재, 페드루 리뷰 B1 — 로컬 raw pytest 15.86s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 95s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-f30da19a-available-channels(페드루 리뷰 B1 후속, PR#3784 — 로컬 raw pytest 17.74s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 110s 잠정값, 실 CI 샤드 로그로 재확認 필요)",
   "measured_at": "2026-09-03",
   "files": [
     {
@@ -882,6 +882,10 @@
     {
       "file": "tests/test_46da6450_org_timezone.py",
       "sec": 95.0
+    },
+    {
+      "file": "tests/test_f30da19a_available_channels.py",
+      "sec": 110.0
     }
   ]
 }


### PR DESCRIPTION
## 요약
story f30da19a(#3435) AC1 — `GET /organizations/{org}/channel-connections/available-channels` → `[{channel, display_name, oauth}]`. `CHANNEL_ADAPTERS` 레지스트리를 그대로 파생 노출(DB 조회 0). sandbox는 `SANDBOX_CHANNEL_ENABLED`일 때만 레지스트리 자체에 항목이 있어(channel_adapters.py 상단 조건부 등재) prod에서 자동으로 빠진다 — 이 엔드포인트에 별도 필터링 로직 없음.

목록(agent-visible, #3399)과 동형: `_require_human()` 안 부름(org 멤버면 에이전트도 조회 가능 — 응답에 토큰 인접 필드 없음).

## 스코프 밖(별도 담당)
- AC2/AC5(FE 버튼·「테스트」표기): 미르코 담당
- AC3(QA): 카디르 QA에서 커버
- AC4(디자인): 유나 확定 완료, 이 PR과 무관

## 검증
- 신규 테스트 4건: `test_sandbox_absent_when_flag_off`·`test_sandbox_present_when_flag_on`·`test_agent_gets_200_not_403`·`test_org_id_mismatch_still_403`
- mutation check: oauth 파생 로직(`cfg.credential_kind == "oauth"`)을 `True`로 고정 → 정확히 `test_sandbox_present_when_flag_on`(oauth=False 검증) 1건만 FAIL 확인 후 byte-identical 복원
- 회귀: `test_3373_channel_connections.py`·`test_3399_agent_visible_channel_connections.py`·`test_5b27b32f_sandbox_channel.py`·`test_620beefc_channel_post_image.py`·`test_3419_cancel_unpublish.py`(ChannelAdapterConfig 직접 인스턴스화하는 파일들, display_name 필드 추가로 인한 dataclass 순서 회귀 확인) 전부 keyword-arg라 영향 없음, 65 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jxc4yzvnRyRh4CENjPhWm