### PR TITLE
[SID:3445] 채널 포스트 상세 BFF 단건 GET route.ts 신설 + 정적 가드

### DIFF
--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/route.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { proxyToFastapiWithParams } = vi.hoisted(() => ({ proxyToFastapiWithParams: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { GET } from './route';
+
+describe('/api/organizations/[id]/channel-posts/drafts/[draftId] (story #3445)', () => {
+  it('GET — FastAPI 단건 GET 엔드포인트로 draftId를 그대로 위임', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ draft_id: 'd1', channel: 'threads', current_version: 1 }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const request = new Request('http://test');
+    const resp = await GET(request, { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) });
+
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      request, '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]', { id: 'org-1', draftId: 'd1' },
+    );
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({
+      data: { draft_id: 'd1', channel: 'threads', current_version: 1 }, error: null, meta: null,
+    });
+  });
+
+  it('GET — 존재하지 않는 draftId의 404를 그대로 통과시킨다', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'draft를 찾을 수 없습니다: d-missing' }), { status: 404, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const resp = await GET(new Request('http://test'), { params: Promise.resolve({ id: 'org-1', draftId: 'd-missing' }) });
+    expect(resp.status).toBe(404);
+  });
+
+  it('GET — 무자격 요청에 대한 BE의 401도 그대로 통과시킨다', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(new Response(null, { status: 401 }));
+    const resp = await GET(new Request('http://test'), { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) });
+    expect(resp.status).toBe(401);
+  });
+
+  it('GET — 다른 org의 draft 접근 403도 그대로 통과시킨다', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const resp = await GET(new Request('http://test'), { params: Promise.resolve({ id: 'org-1', draftId: 'd1' }) });
+    expect(resp.status).toBe(403);
+  });
+});

--- a/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/route.ts
@@ -1,0 +1,16 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; draftId: string }> };
+
+// story #3445 — 상세 page.tsx(`…/drafts/${draftId}`)가 부르는 단건 GET BFF가 애초에
+// 없어(형제 폴더 cancel-scheduled·publish·submit·unpublish·versions 5개는 있음) 상세
+// 첫 로드가 항상 404였다. drafts/route.ts(목록)와 동형 패턴 — 검증 로직 0, 그대로 위임.
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id, draftId } = await params;
+  const _r = await proxyToFastapiWithParams(
+    request, '/api/v2/organizations/[id]/channel-posts/drafts/[draftId]', { id, draftId },
+  );
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/app/api/organizations/content-bff-route-coverage.guard.test.ts
+++ b/apps/web/src/app/api/organizations/content-bff-route-coverage.guard.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * story #3445 — content 화면이 fetchWithAuth로 부르는 `/api/organizations/...` 경로마다
+ * 대응하는 BFF route.ts+메서드가 실제로 존재하는지 소스를 훑어 대조한다. 채널 포스트 상세
+ * 단건 GET(drafts/[draftId])이 형제 5개(cancel-scheduled·publish·submit·unpublish·versions)
+ * 만 있고 정작 이 라우트가 없어 상세 첫 로드가 항상 404였던 결함 — page.test는 fetchWithAuth를
+ * 목킹해 이 클래스의 결함을 원천적으로 못 잡는다(project_built_but_nowhere_to_run_class).
+ *
+ * ⛔이 가드가 못 잡는 것:
+ * - fetchWithAuth 호출이 아닌 곳(별도 헬퍼로 감싼 호출, 서버 컴포넌트의 직접 fetch)
+ * - 템플릿 리터럴이 아닌 동적 문자열 조립(`'/api/organizations/' + orgId + ...`)
+ * - `/api/organizations/` 밖의 BFF 경로(예: `/api/gates`) — 스코프 밖
+ * - fetchWithAuth 호출부터 200자 밖에 있는 `method:` 옵션(위양성 방지용 탐색 폭 제한 —
+ *   해당 클래스는 지금까지 전부 같은 줄이거나 바로 다음 줄이라 실측상 미발생)
+ */
+
+const CONTENT_DIRS = [
+  join(__dirname, '../../../app/(authenticated)/content'),
+  join(__dirname, '../../../components/content'),
+];
+const API_ROOT = join(__dirname, '../../../app/api');
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...listSourceFiles(full));
+    } else if (/\.tsx?$/.test(entry) && !entry.includes('.test.')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+interface CallSite {
+  file: string;
+  template: string;
+  method: string;
+}
+
+function extractCalls(files: string[]): CallSite[] {
+  const calls: CallSite[] = [];
+  const callRe = /fetchWithAuth\(\s*`(\/api\/organizations\/[^`]*)`/g;
+  for (const file of files) {
+    const src = readFileSync(file, 'utf8');
+    let m: RegExpExecArray | null;
+    while ((m = callRe.exec(src))) {
+      const template = m[1];
+      const window = src.slice(m.index, m.index + 200);
+      const methodMatch = window.match(/method:\s*['"]([A-Z]+)['"]/);
+      calls.push({ file, template, method: methodMatch ? methodMatch[1] : 'GET' });
+    }
+  }
+  return calls;
+}
+
+/** `${orgId}` 등 인터폴레이션을 dynamic 마커로, 나머지는 리터럴 세그먼트로 쪼갠다. */
+function templateSegments(template: string): { value: string; dynamic: boolean }[] {
+  const withoutQuery = template.split('?')[0];
+  return withoutQuery
+    .split('/')
+    .filter(Boolean)
+    .map((seg) => (/^\$\{.*\}$/.test(seg) ? { value: seg, dynamic: true } : { value: seg, dynamic: false }));
+}
+
+/** 세그먼트를 apps/web/src/app/api 트리에서 순서대로 내려가며 route.ts 디렉터리를 찾는다. */
+function resolveRouteDir(segments: { value: string; dynamic: boolean }[]): string | null {
+  // 첫 세그먼트 'api'는 API_ROOT가 이미 흡수했다.
+  let dir = API_ROOT;
+  const rest = segments.slice(1);
+  for (const seg of rest) {
+    const entries = readdirSync(dir, { withFileTypes: true }).filter((e) => e.isDirectory());
+    const literalMatch = !seg.dynamic && entries.find((e) => e.name === seg.value);
+    const dynamicMatch = seg.dynamic && entries.find((e) => /^\[.+\]$/.test(e.name));
+    const next = literalMatch || dynamicMatch;
+    if (!next) return null;
+    dir = join(dir, next.name);
+  }
+  return dir;
+}
+
+function exportsMethod(routeTsPath: string, method: string): boolean {
+  const src = readFileSync(routeTsPath, 'utf8');
+  return new RegExp(`export\\s+async\\s+function\\s+${method}\\b`).test(src)
+    || new RegExp(`export\\s+function\\s+${method}\\b`).test(src);
+}
+
+describe('content BFF 경로 커버리지 가드(story #3445)', () => {
+  const files = CONTENT_DIRS.flatMap((d) => listSourceFiles(d));
+  const calls = extractCalls(files);
+
+  it('스캔 대상이 비어있지 않다(가드 자체가 죽은 채 항상 통과하는 것 방지)', () => {
+    expect(files.length).toBeGreaterThan(0);
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  const seen = new Set<string>();
+  for (const call of calls) {
+    const segments = templateSegments(call.template);
+    const key = `${segments.map((s) => (s.dynamic ? '*' : s.value)).join('/')} ${call.method}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    it(`${call.template} [${call.method}] → route.ts 존재 + 메서드 export (${call.file.split('/src/')[1]})`, () => {
+      const dir = resolveRouteDir(segments);
+      expect(dir, `${call.template} 에 대응하는 BFF 디렉터리를 찾지 못함`).not.toBeNull();
+      const routeTs = join(dir as string, 'route.ts');
+      let exists = true;
+      try {
+        statSync(routeTs);
+      } catch {
+        exists = false;
+      }
+      expect(exists, `route.ts 없음: ${routeTs}`).toBe(true);
+      expect(exportsMethod(routeTs, call.method), `${routeTs} 가 ${call.method} export 안 함`).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## 배경
story [#3445](entity:story:952b7f32-c741-49e6-a4e8-82bd192179de) — 유나 4회차 실측·PO 재확認(13:03Z): `/content/channel-posts/{draftId}` 상세가 dev에서 전부 「글을 불러오지 못했습니다」. 원인은 BFF `GET /api/organizations/{id}/channel-posts/drafts/{draftId}`가 404(Next.js not-found) — 형제 폴더 cancel-scheduled·publish·submit·unpublish·versions 5개는 있는데 이 라우트만 애초에 없었다. 백엔드 단건 GET(`/api/v2/.../drafts/{draft_id}`)은 이미 200.

## 변경
- **AC1** `apps/web/src/app/api/organizations/[id]/channel-posts/drafts/[draftId]/route.ts` — PR#3782(샌드박스 BFF)·`drafts/route.ts`(목록)와 동형 패턴. `proxyToFastapiWithParams` 그대로 위임, 검증 로직 0. route.test.ts로 200/403/404/401 pin(형제 route 테스트 형식 그대로).
- **AC2** `apps/web/src/app/api/organizations/content-bff-route-coverage.guard.test.ts` — content 화면·컴포넌트가 `fetchWithAuth`로 부르는 `/api/organizations/...` 경로를 소스에서 전수 추출해, 대응 BFF `route.ts` + HTTP 메서드 export 존재를 파일시스템 대조. 못 잡는 표면(동적 문자열 조립, `/api/organizations` 밖 경로 등)은 파일 상단 docstring에 선언.

### RED→GREEN 재현(로컬 확認)
route.ts를 일시 제거하고 가드만 실행:
```
 FAIL  .../content-bff-route-coverage.guard.test.ts > ... > /api/organizations/${orgId}/channel-posts/drafts/${draftId} [GET] → route.ts 존재 + 메서드 export (app/(authenticated)/content/channel-posts/[draftId]/page.tsx)
AssertionError: route.ts 없음: .../channel-posts/drafts/[draftId]/route.ts
```
정확히 이번 결함의 경로·파일을 짚어 RED. route.ts 복원 후 18/18 GREEN.

## 검증
- `pnpm vitest run` (apps/web): 602 files / 5631 tests 전부 green
- `tsc --noEmit`: clean
- `eslint` (변경 파일): clean
- BE/상세 화면 로직 무변경 — 라우트 파일 신설 + 가드 테스트만

## 경계
- AC3(라이브 dev 확認)은 머지→dev 배포 뒤 유나 실픽셀 1회차로 갈음(`/content/channel-posts/1ea0763b-7fa0-4f75-b779-e5eb790a2b3a`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)