### PR TITLE
[SID:3448] feat: 채널 포스트 목록/단건 응답에 command_id 노출

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -169,6 +169,11 @@ class ChannelPostDraftListItem(BaseModel):
     # body의 `command_status`와 동일(같은 latest_command 행, 같은 뜻).
     command_status: str | None = None
     command_reason_code: str | None = None
+    # story 0e960006(#3448, 페드루 PO 확定 2026-09-04) — dead_letter 수동 재시도
+    # (POST .../publication-commands/{command_id}/retry)를 화면이 부르려면 어느 명령
+    # 행인지 알아야 한다 — command_status와 같은 latest_command 행에서 id만 additive로
+    # 꺼낸다(신규 조회 0, N+1 없음).
+    command_id: uuid.UUID | None = None
     # gate.sealed_scheduled_at — publication_command.scheduled_at이 아니다(그 값은 요청
     # 시점 스냅샷이라 재승인 뒤 갱신 안 됨, story #3414). 화면 캘린더(§11-1)가 보는 "지금
     # 승인된 예약 시각"은 이 값.
@@ -540,6 +545,7 @@ def _to_draft_list_item(
         scheduled_at=gate.sealed_scheduled_at.isoformat() if gate and gate.sealed_scheduled_at else None,
         command_status=command_status,
         command_reason_code=latest_command.reason_code if latest_command else None,
+        command_id=latest_command.id if latest_command else None,
         thumbnail_url=public_url_for_object_path(latest_image.final_object_path) if latest_image else None,
         image_original_width=latest_image.original_width if latest_image else None,
         image_original_bytes=latest_image.original_bytes if latest_image else None,

--- a/backend/tests/test_0e960006_command_id_exposure.py
+++ b/backend/tests/test_0e960006_command_id_exposure.py
@@ -1,0 +1,343 @@
+"""story 0e960006/#3448(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04) — 채널 포스트
+목록/단건 응답에 `command_id` 노출. 화면의 dead_letter 수동 재시도 버튼(POST
+.../publication-commands/{command_id}/retry)이 어느 명령을 재시도할지 알 길이
+없었다(command_status/next_retry_at/dead_letter_at만 있고 id가 없음, 샌드박스
+라이브 절차 7 발견). additive — `_to_draft_list_item`의 기존 `latest_command`
+배치에서 id만 더 꺼낸다(신규 조회 0)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy import text as sa_text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    engine = create_async_engine(_async_url())
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(sa_text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_org_system_publisher "
+            "ON members (org_id) WHERE (runtime_type = 'system-publisher' AND type = 'agent')"
+        ))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Command Id Exposure Test Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    return org.id, project.id
+
+
+async def _seed_agent(session, org_id, project_id, *, name="담롱"):
+    from app.models.team import TeamMember
+
+    m = TeamMember(id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent", name=name, is_active=True)
+    session.add(m)
+    await session.commit()
+    return m.id
+
+
+async def _seed_human(session, org_id, *, role="owner"):
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user = User(id=uuid.uuid4(), email=f"human-{uuid.uuid4().hex[:8]}@test.dev", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user.id, role=role)
+    session.add(om)
+    await session.commit()
+    return user.id
+
+
+async def _seed_story(session, org_id, project_id, *, title="채널 포스트"):
+    from app.models.pm import Story
+
+    story = Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+    session.add(story)
+    await session.commit()
+    return story.id
+
+
+async def _seed_default_role(session, org_id):
+    from app.models.participation import ParticipationRole
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="approver", label="Approver", is_default=True)
+    session.add(role)
+    await session.commit()
+    return role.id
+
+
+async def _seed_connection(session, org_id, *, channel="threads", account_id=None, token="plain-access-token"):
+    from app.models.channel_connection import ChannelConnection
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    conn = ChannelConnection(
+        id=uuid.uuid4(), org_id=org_id, channel=channel,
+        account_id=account_id or f"acct-{uuid.uuid4().hex[:8]}", status="active",
+        credential_kind="oauth", refresh_mode="reissue_from_access_token",
+        encrypted_access_token=encrypt_channel_credential(token),
+    )
+    session.add(conn)
+    await session.commit()
+    return conn.id
+
+
+async def _approve_gate_directly(session, gate_id):
+    from app.models.gate import Gate
+    from sqlalchemy import select
+
+    gate = (await session.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+    gate.status = "approved"
+    gate.resolver_id = uuid.uuid4()
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.commit()
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _setup_org_scoped_app(app, Session, org_id, *, user_id, agent: bool = False):
+    from app.dependencies.auth import AuthContext, get_current_user
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if agent:
+            claims["app_metadata"]["api_key_id"] = "test-agent-key"
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    from tests.conftest import override_db_and_read
+    override_db_and_read(app, _db)
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _create_draft_submit_approve(
+    client, session, *, org_id, connection_id, story_id, text="채널 포스트 본문입니다.",
+    scheduled_at: datetime | None = None,
+):
+    r_draft = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+        json={"work_item_id": str(story_id), "connection_id": str(connection_id), "text": text},
+    )
+    assert r_draft.status_code == 201, r_draft.text
+    draft_id = r_draft.json()["draft_id"]
+    submit_body = {}
+    if scheduled_at is not None:
+        submit_body["scheduled_at"] = scheduled_at.isoformat()
+    r_submit = await client.post(
+        f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/submit", json=submit_body,
+    )
+    assert r_submit.status_code == 200, r_submit.text
+    gate_id = uuid.UUID(r_submit.json()["gate_id"])
+    await _approve_gate_directly(session, gate_id)
+    return draft_id, gate_id
+
+
+@pytest.mark.anyio
+async def test_command_id_null_when_no_command_yet():
+    """AC1 — 명령이 아직 없는(초안·상신만 한) draft는 목록·단건 둘 다 command_id=null."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, _gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+
+            r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+            assert r_detail.status_code == 200, r_detail.text
+            assert r_detail.json()["command_id"] is None
+
+            r_list = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+            assert r_list.status_code == 200, r_list.text
+            item = next(i for i in r_list.json() if i["draft_id"] == draft_id)
+            assert item["command_id"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_command_id_matches_latest_command_after_publish_request():
+    """AC1 — 발행 요청(즉시 경로) 뒤 목록·단건 command_id가 실제 생성된 command 행의
+    id와 정확히 일치하고, 기존 command_status와 같은 행을 가리킨다."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+            )
+
+        with (
+            patch.object(tp, "create_container", AsyncMock(return_value="creation-1")),
+            patch.object(tp, "publish_container", AsyncMock(return_value="media-1")),
+            patch.object(tp, "get_publishing_limit", AsyncMock(return_value=(1, 250, 86400))),
+            patch.object(tp, "get_permalink", AsyncMock(return_value="https://www.threads.net/@demo/post/media-1")),
+        ):
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client:
+                r_pub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+                assert r_pub.status_code == 200, r_pub.text
+                expected_command_id = (r_pub.json().get("data") or r_pub.json())["command_id"]
+
+                r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+                assert r_detail.status_code == 200, r_detail.text
+                detail = r_detail.json()
+                assert detail["command_id"] == expected_command_id
+                assert detail["command_status"] == "completed"
+
+                r_list = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts")
+                assert r_list.status_code == 200, r_list.text
+                item = next(i for i in r_list.json() if i["draft_id"] == draft_id)
+                assert item["command_id"] == expected_command_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_command_id_reflects_latest_command_after_reapproval_voids_prior_one():
+    """AC1 — voided 뒤 재승인으로 새 command가 생기면 command_id는 **최신** 명령(새
+    pending 행)을 가리킨다(옛 voided 행이 아니다) — latest_command_by_gate 배치가
+    created_at desc로 이미 이 순서를 보장한다(story #3415 관례 재확인)."""
+    from unittest.mock import AsyncMock, patch
+    import app.services.threads_publish as tp
+    from app.main import app
+
+    scheduled_at = datetime.now(timezone.utc) + timedelta(days=1)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            draft_id, gate_id = await _create_draft_submit_approve(
+                client, s, org_id=org_id, connection_id=connection_id, story_id=story_id,
+                scheduled_at=scheduled_at,
+            )
+
+        with (patch.object(tp, "create_container", AsyncMock()), patch.object(tp, "publish_container", AsyncMock())):
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client:
+                r_pub = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+                assert r_pub.status_code == 200, r_pub.text
+                voided_command_id = (r_pub.json().get("data") or r_pub.json())["command_id"]
+
+        # 본문 편집(재승인 트리거) → 기존 pending command voided.
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client, Session() as s:
+            r_edit = await client.post(
+                f"/api/v2/organizations/{org_id}/channel-posts/drafts",
+                json={"work_item_id": str(story_id), "connection_id": str(connection_id), "text": "수정된 본문."},
+            )
+            assert r_edit.status_code == 201, r_edit.text
+            await _approve_gate_directly(s, gate_id)
+
+        with (patch.object(tp, "create_container", AsyncMock()), patch.object(tp, "publish_container", AsyncMock())):
+            _setup_org_scoped_app(app, Session, org_id, user_id=human_id)
+            async with _client_for(app) as client:
+                r_pub2 = await client.post(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}/publish")
+                assert r_pub2.status_code == 200, r_pub2.text
+                new_command_id = (r_pub2.json().get("data") or r_pub2.json())["command_id"]
+                assert new_command_id != voided_command_id
+
+                r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{draft_id}")
+                assert r_detail.status_code == 200, r_detail.text
+                assert r_detail.json()["command_id"] == new_command_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1,6 +1,6 @@
 {
   "_snapshot_policy": "story #3383(2026-09-03) — 로컬 재측정(템플릿 DB 적용 후). 로컬 절대시간은 CI의 ~1/6이지만(실측), 파일 간 상대 비중은 LPT 배분에 유효하다. 재측정 기준은 이전과 동일: (a) discover 파일 수가 이 스냅샷 대비 +20% 이상, (b) 샤드 간 CI 벽시계가 1.5배 이상 벌어짐, (c) 25분 천장 대비 여유가 다시 좁아짐.",
-  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)+story-3423-scheduled-filter(CI shard(2) unweighted-guard 실측 23s, run 33849386492/job 100950217041, 2026-09-04 — PR#3775)+story-620beefc-threads-image(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 28.2s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-5b27b32f-sandbox-channel-adapter(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 19.03s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 115s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-8b7e52d6-claim-story-signal(PR 개설 前 선제 등재, story 23bf1913 조기가드 학습 반영 — 로컬 raw pytest 15.30s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 92s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-46da6450-org-timezone(PR 개설 前 선제 등재, 페드루 리뷰 B1 — 로컬 raw pytest 15.86s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 95s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-f30da19a-available-channels(페드루 리뷰 B1 후속, PR#3784 — 로컬 raw pytest 17.74s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 110s 잠정값, 실 CI 샤드 로그로 재확認 필요)",
+  "source_run": "local-post-template-optimization+story-3392-unweighted-additions+story-3384-merge+story-3375-merge+story-3394-merge+story-3399-agent-visible-connections+fix-f6d14476-unweighted-guard+story-3403-channel-post-draft-detail+story-3404-channel-post-gate-already-held+story-3414-publication-command(로컬 raw pytest 실측, 템플릿 DB 스크립트 아님 — 페드루 리뷰 nit N)+story-3415-command-exposure(CI shard(6) unweighted-guard 실측 19s, run 33845555857/job 100939581435, 2026-09-04 — PR#3773 리뷰)+story-3419-cancel-unpublish(CI shard(6) unweighted-guard 실측 31s, run 33847827818/job 100943850339, 2026-09-04 — PR#3774)+story-3423-scheduled-filter(CI shard(2) unweighted-guard 실측 23s, run 33849386492/job 100950217041, 2026-09-04 — PR#3775)+story-620beefc-threads-image(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 28.2s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 60s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-5b27b32f-sandbox-channel-adapter(PR 개설 前 선제 등재, 페드루 체크리스트 — 로컬 raw pytest 19.03s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 115s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-8b7e52d6-claim-story-signal(PR 개설 前 선제 등재, story 23bf1913 조기가드 학습 반영 — 로컬 raw pytest 15.30s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 92s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-46da6450-org-timezone(PR 개설 前 선제 등재, 페드루 리뷰 B1 — 로컬 raw pytest 15.86s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 95s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-f30da19a-available-channels(페드루 리뷰 B1 후속, PR#3784 — 로컬 raw pytest 17.74s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 110s 잠정값, 실 CI 샤드 로그로 재확認 필요)+story-0e960006-command-id-exposure(PR 개설 前 선제 등재 — 로컬 raw pytest 6.62s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)",
   "measured_at": "2026-09-03",
   "files": [
     {
@@ -886,6 +886,10 @@
     {
       "file": "tests/test_f30da19a_available_channels.py",
       "sec": 110.0
+    },
+    {
+      "file": "tests/test_0e960006_command_id_exposure.py",
+      "sec": 40.0
     }
   ]
 }


### PR DESCRIPTION
## 요약
- dead_letter 수동 재시도(`POST .../publication-commands/{command_id}/retry`)를 화면이 부르려면 어느 명령 행인지 알아야 하는데, 목록(`ChannelPostDraftListItem`)·단건 응답에는 `command_status`/`command_reason_code`/`next_retry_at`/`dead_letter_at`만 있고 `command_id`가 없었다(2026-09-04 13:10Z 샌드박스 라이브 절차 7 발견).
- `_to_draft_list_item`의 기존 `latest_command` 배치 조회(story #3415)에서 id만 additive로 꺼낸다 — 신규 조회 0, N+1 없음, 기존 필드 무변경.

## AC 대응
- AC1: 목록/단건 `command_id`(없으면 null) — `test_0e960006_command_id_exposure.py` 3건(명령 없음 null·있음 id 일치·재승인 뒤 최신 명령 id로 갱신).
- AC2 회귀: 기존 `test_3414_publication_command.py` 24건(신규 3건 포함) 로컬 전량 green, 응답 필드/순서 무변경.
- AC3 라이브: dev 배포 뒤 카디르군 런북 절차 7 재현은 배포 후 별도 기록.

## story
[SID:3448] entity:story:0e960006-d1eb-4952-9166-7a56a2d27e43

## 테스트
- `pytest tests/test_0e960006_command_id_exposure.py tests/test_3414_publication_command.py` — 24 passed (로컬 실PG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)