### PR TITLE
[SID:3450] feat: hosted_site를 blog kind 어댑터 1호로 등재 (조각①)

### DIFF
--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -287,6 +287,10 @@ class AvailableChannelItem(BaseModel):
     channel: str
     display_name: str
     credential_kind: str
+    # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04) — "social"(짧은 글·
+    # channel_post) vs "blog"(site_post) 구분. FE가 "채널 연결" 화면과 "블로그 목적지"
+    # 화면을 이 값 하나로 분기한다(additive — 기존 필드 무변경).
+    kind: str
 
 
 @router.get(
@@ -307,6 +311,7 @@ async def list_available_channels_endpoint(
     return [
         AvailableChannelItem(
             channel=channel, display_name=cfg.display_name, credential_kind=cfg.credential_kind,
+            kind=cfg.kind,
         )
         for channel, cfg in CHANNEL_ADAPTERS.items()
     ]

--- a/backend/app/routers/channel_connections.py
+++ b/backend/app/routers/channel_connections.py
@@ -303,7 +303,12 @@ async def list_available_channels_endpoint(
     """story f30da19a(AC1) — 목록 엔드포인트(`agent-visible`)와 동형: `_require_human()`을
     안 부른다(org 멤버면 에이전트도 조회 가능 — 이 응답엔 토큰 인접 필드가 아예 없어
     AC6의 human-only 근거가 적용되지 않는다). DB 조회 0 — 레지스트리 자체가 SSOT라
-    org마다 다른 값이 없다(org_id는 스코프 검증에만 쓴다)."""
+    org마다 다른 값이 없다(org_id는 스코프 검증에만 쓴다).
+
+    story e4fc29fa(페드루 PO 리뷰 B1, 2026-09-04) — 이 목록은 "연결 만들기" 버튼 대상
+    이다(엔드포인트 자체 목적, f30da19a AC1). `requires_connection=False`인 채널
+    (hosted_site — 연결 없이 항상 사용 가능)은 목록에서 뺀다 — 안 그러면 FE(#3435
+    AC2)가 credential_kind="none"만 보고 「샌드박스 연결 만들기」 분기를 잘못 탄다."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
     from app.services.channel_adapters import CHANNEL_ADAPTERS
@@ -314,6 +319,7 @@ async def list_available_channels_endpoint(
             kind=cfg.kind,
         )
         for channel, cfg in CHANNEL_ADAPTERS.items()
+        if cfg.requires_connection
     ]
 
 

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from typing import Literal
 
 
 @dataclass(frozen=True)
@@ -32,6 +33,11 @@ class ChannelAdapterConfig:
     # 뜨는 대신 배포 자체가 안 되게(fail-closed, 다른 필수 필드 authorize_url/token_url/
     # scope/refresh_mode와 동열).
     display_name: str
+    # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04) — 이 채널이 짧은 글
+    # (channel_post·Threads류)인지 블로그(site_post·hosted_site/wordpress/webhook류)
+    # 인지. available-channels가 이 값을 그대로 노출해 FE가 "채널 연결"과 "블로그 목적지"
+    # 화면을 분기한다(kind 자체가 SSOT — 문자열 목록을 어디서도 하드코딩하지 않는다).
+    kind: Literal["social", "blog"] = "social"
     credential_kind: str = "oauth"  # "oauth" | "pasted_secret" | "none"
     # story #3374(Phase1·마케팅운영, PO 결정) — 채널 포스트 초안 text 상한. 상수를 서비스/
     # 라우터에 하드코딩하지 않고 여기 한 곳에 선언(담롱 요구 — "상수 하드코딩 X·선언·표시",
@@ -99,6 +105,26 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         image_width_max=1440,
         image_color_space="sRGB",
         image_max_count=1,
+    ),
+    # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각①) — Sprintable
+    # 호스팅 블로그를 blog kind 어댑터 1호로 등재한다. **동작 무변경** — site_posts.py의
+    # 발행 흐름(`publish_site_post_from_draft` 등)은 지금처럼 내부 `site_posts` 테이블에
+    # 직접 쓴다(어댑터 dispatch·publication_command 경로를 안 탄다, PO 確定 ③). 이 항목은
+    # 순수 선언(레지스트리 등재)일 뿐 — available-channels·kind 필드로 존재를 노출하는
+    # 것 외에 아무 기존 코드 경로도 건드리지 않는다. credential_kind="none"(연결 불요,
+    # 항상 사용 가능) — OAuth 필드는 sandbox와 동형으로 빈 문자열.
+    "hosted_site": ChannelAdapterConfig(
+        authorize_url="",
+        token_url="",
+        scope="",
+        refresh_mode="manual",
+        credential_kind="none",
+        display_name="Sprintable 호스팅 블로그",
+        kind="blog",
+        # site_posts.py::unpublish_site_post가 이미 존재(story #3381) — 선언은 그
+        # 사실을 정확히 반영할 뿐(신규 동작 아님). 외부 스코프 개념이 없어(credential
+        # 자체가 없다) unpublish_required_scope는 비운다.
+        supports_unpublish=True,
     ),
 }
 

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -38,6 +38,13 @@ class ChannelAdapterConfig:
     # 인지. available-channels가 이 값을 그대로 노출해 FE가 "채널 연결"과 "블로그 목적지"
     # 화면을 분기한다(kind 자체가 SSOT — 문자열 목록을 어디서도 하드코딩하지 않는다).
     kind: Literal["social", "blog"] = "social"
+    # story e4fc29fa(페드루 PO 리뷰 B1, 2026-09-04) — available-channels는 "연결 만들기"
+    # 버튼 목록이다(그 엔드포인트 자체 목적). credential_kind="none"을 FE(#3435 AC2)가
+    # 곧바로 "샌드박스 연결 만들기 버튼"으로 읽는다 — hosted_site도 credential_kind="none"
+    # 이라 그 목록에 그냥 나열되면 FE가 hosted_site에 대해 **샌드박스 연결을 만드는**
+    # 잘못된 액션을 탄다. "연결할 게 있는가"와 "credential이 필요한가"는 다른 축이라
+    # 별도 필드로 분리한다 — hosted_site만 False, 나머지(sandbox 포함)는 기본 True.
+    requires_connection: bool = True
     credential_kind: str = "oauth"  # "oauth" | "pasted_secret" | "none"
     # story #3374(Phase1·마케팅운영, PO 결정) — 채널 포스트 초안 text 상한. 상수를 서비스/
     # 라우터에 하드코딩하지 않고 여기 한 곳에 선언(담롱 요구 — "상수 하드코딩 X·선언·표시",
@@ -121,6 +128,9 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         credential_kind="none",
         display_name="Sprintable 호스팅 블로그",
         kind="blog",
+        # story e4fc29fa(페드루 PO 리뷰 B1) — 연결할 게 없다(항상 사용 가능) — available-
+        # channels 목록(연결 만들기 버튼 대상)에서 이 항목이 빠지는 유일한 근거.
+        requires_connection=False,
         # site_posts.py::unpublish_site_post가 이미 존재(story #3381) — 선언은 그
         # 사실을 정확히 반영할 뿐(신규 동작 아님). 외부 스코프 개념이 없어(credential
         # 자체가 없다) unpublish_required_scope는 비운다.
@@ -174,13 +184,35 @@ def can_auto_refresh(refresh_mode: str) -> bool:
     return refresh_mode in ("refresh_token", "reissue_from_access_token")
 
 
+class BlogChannelDispatchNotImplementedError(NotImplementedError):
+    """story e4fc29fa(페드루 PO 리뷰 B2, 2026-09-04) — kind="blog" 채널은 이 함수의
+    디스패치 대상이 아니다(hosted_site는 site_posts.py가 직접 처리·publication_command
+    경로를 안 탄다; wordpress/webhook은 조각②에서 별도 배선). 이 함수가 아무 분기도
+    못 찾으면 조용히 threads_publish로 떨어지던 것(수정 前 결함 — hosted_site가 Threads
+    API 호출 코드를 잘못 타는 사고)을 fail-closed로 막는다."""
+
+    def __init__(self, *, channel: str):
+        self.channel = channel
+        super().__init__(
+            f"channel={channel!r}는 kind='blog'라 get_publish_client_module 디스패치 대상이 "
+            "아닙니다(hosted_site=site_posts.py 직접 처리, wordpress/webhook=조각② 배선 예정)."
+        )
+
+
 def get_publish_client_module(channel: str):
     """story 5b27b32f — 발행 클라이언트 모듈 디스패치. `sandbox`만 `threads_publish`
     대신 `sandbox_publish`로 우회한다(같은 함수 시그니처·같은 `ThreadsPublishError`
     클래스를 그대로 재사용 — sandbox_publish.py가 신규 예외 타입을 만들지 않으므로
     channel_posts.py의 기존 except절이 그대로 먹힌다, 신규 판정 로직 0). 실 배포 채널
     (threads 등)은 전부 threads_publish 그대로 — 이 함수가 sandbox 개입의 유일한
-    지점이다(Threads 어댑터 코드 자체는 무변경)."""
+    지점이다(Threads 어댑터 코드 자체는 무변경).
+
+    story e4fc29fa(페드루 PO 리뷰 B2) — kind="blog" 채널(hosted_site 등)은 여기서
+    명시적으로 거부한다. 이 가드가 없으면 마지막 else가 threads_publish로 조용히
+    떨어져(수정 前 결함) 블로그 발행이 Threads API 코드를 잘못 탄다."""
+    adapter = get_channel_adapter(channel)
+    if adapter is not None and adapter.kind == "blog":
+        raise BlogChannelDispatchNotImplementedError(channel=channel)
     if channel == "sandbox":
         from app.services import sandbox_publish
         return sandbox_publish

--- a/backend/tests/test_f30da19a_available_channels.py
+++ b/backend/tests/test_f30da19a_available_channels.py
@@ -126,12 +126,11 @@ async def test_sandbox_absent_when_flag_off():
         assert threads_row["credential_kind"] == "oauth"
         assert threads_row["kind"] == "social"
 
-        # story e4fc29fa(조각①) — hosted_site가 blog kind로 항상(env 무관) 등재돼 있다.
-        # 뮤테이션 대상: channel_adapters.py의 hosted_site 등재를 지우면 이 assert가 RED.
-        assert "hosted_site" in channels
-        hosted_site_row = next(row for row in rows if row["channel"] == "hosted_site")
-        assert hosted_site_row["kind"] == "blog"
-        assert hosted_site_row["credential_kind"] == "none"
+        # story e4fc29fa(조각①, 페드루 PO 리뷰 B1) — hosted_site는 이 "연결 만들기"
+        # 목록에 안 나온다(requires_connection=False) — 나오면 FE(#3435 AC2)가
+        # credential_kind="none"만 보고 「샌드박스 연결 만들기」를 잘못 탄다. 뮤테이션
+        # 대상: 필터를 지우면 이 assert가 RED.
+        assert "hosted_site" not in channels
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -216,3 +215,31 @@ async def test_org_id_mismatch_still_403():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+def test_registry_kind_pin():
+    """story e4fc29fa(조각①, 페드루 PO 리뷰 N1) — CHANNEL_ADAPTERS 레지스트리의 kind
+    값을 직접 pin한다(HTTP 레이어가 아니다 — hosted_site는 B1 필터로 이제 응답 목록에
+    안 나오므로 그 경로로는 kind를 더 이상 확인할 수 없다). threads=social(기본값)·
+    hosted_site=blog·requires_connection=False."""
+    from app.services.channel_adapters import CHANNEL_ADAPTERS
+
+    assert CHANNEL_ADAPTERS["threads"].kind == "social"
+    assert CHANNEL_ADAPTERS["threads"].requires_connection is True
+    assert CHANNEL_ADAPTERS["hosted_site"].kind == "blog"
+    assert CHANNEL_ADAPTERS["hosted_site"].requires_connection is False
+    assert CHANNEL_ADAPTERS["hosted_site"].credential_kind == "none"
+
+
+def test_get_publish_client_module_rejects_blog_kind_channel():
+    """story e4fc29fa(조각①, 페드루 PO 리뷰 B2) — kind="blog" 채널은
+    `get_publish_client_module`이 명시 거부한다(수정 前엔 else 분기로 조용히
+    threads_publish로 떨어져, 블로그 발행이 Threads API 코드를 잘못 타는 결함이었다).
+    뮤테이션 대상: B2 가드를 지우면 이 assert가 threads_publish 모듈을 돌려받아 RED."""
+    from app.services.channel_adapters import (
+        BlogChannelDispatchNotImplementedError,
+        get_publish_client_module,
+    )
+
+    with pytest.raises(BlogChannelDispatchNotImplementedError):
+        get_publish_client_module("hosted_site")

--- a/backend/tests/test_f30da19a_available_channels.py
+++ b/backend/tests/test_f30da19a_available_channels.py
@@ -124,6 +124,14 @@ async def test_sandbox_absent_when_flag_off():
         threads_row = next(row for row in rows if row["channel"] == "threads")
         assert threads_row["display_name"] == "Threads"
         assert threads_row["credential_kind"] == "oauth"
+        assert threads_row["kind"] == "social"
+
+        # story e4fc29fa(조각①) — hosted_site가 blog kind로 항상(env 무관) 등재돼 있다.
+        # 뮤테이션 대상: channel_adapters.py의 hosted_site 등재를 지우면 이 assert가 RED.
+        assert "hosted_site" in channels
+        hosted_site_row = next(row for row in rows if row["channel"] == "hosted_site")
+        assert hosted_site_row["kind"] == "blog"
+        assert hosted_site_row["credential_kind"] == "none"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
@@ -181,7 +189,10 @@ async def test_agent_gets_200_not_403():
         async with _client_for(app) as client:
             r = await client.get(f"/api/v2/organizations/{org_id}/channel-connections/available-channels")
         assert r.status_code == 200, r.text
-        assert set(r.json()[0].keys()) == {"channel", "display_name", "credential_kind"}
+        # story e4fc29fa(조각①) — kind 필드 additive 추가(토큰 인접 필드 아님, 응답
+        # 계약 확장 — "no extra field" 계약이 아니라 정확한 필드 집합 계약이었으므로
+        # 여기서 함께 갱신한다).
+        assert set(r.json()[0].keys()) == {"channel", "display_name", "credential_kind", "kind"}
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()


### PR DESCRIPTION
## 요약
story e4fc29fa(WordPress·webhook 블로그 어댑터, 13pt)의 조각①. 블루프린트 §2(a)·§3 아키텍처 확定(PO 2026-09-04 13:44Z) — WordPress·webhook을 얹기 전에 Sprintable 호스팅 블로그(`hosted_site`)를 먼저 `CHANNEL_ADAPTERS` 레지스트리에 blog kind로 옮긴다.

## 변경
- `ChannelAdapterConfig`에 `kind: Literal["social","blog"] = "social"` 필드 추가.
- `CHANNEL_ADAPTERS["hosted_site"]` 등재 — `credential_kind="none"`(연결 불요, 항상 사용 가능)·`kind="blog"`.
- `GET .../channel-connections/available-channels` 응답에 `kind` additive 노출(기존 필드 무변경).

## 동작 무변경
`site_posts.py`의 발행 흐름은 지금처럼 내부 `site_posts` 테이블에 직접 쓴다 — 어댑터 dispatch·`publication_command` 경로를 전혀 안 탄다(PO 確定 ③, "hosted_site는 현행 site_posts 행 그대로"). 이 PR은 순수 선언(레지스트리 등재) + API 필드 노출뿐이다.

## AC 대응
- 신규 pin: `test_f30da19a_available_channels.py`에 hosted_site 등재·kind 값 assert 추가(기존 exact-key-set assert도 `kind` 포함하도록 갱신).
- 회귀: `test_3365_site_post_drafts`·`test_3369_publish_site_post_from_draft`·`test_3360_site_posts`·`test_3381_site_post_unpublish`·`test_3386_site_post_publication`·`test_3374_channel_posts`·`test_f30da19a_available_channels`·`test_5b27b32f_sandbox_channel`·`test_620beefc_channel_post_image` — 103건 로컬 전량 green(동작 무변경 확인).

## story
[SID:3450] entity:story:e4fc29fa-5c2b-4e5f-b9a7-37a5daa9574a

## 테스트
- `pytest tests/test_f30da19a_available_channels.py` — 4 passed
- `pytest tests/test_3365_site_post_drafts.py tests/test_3369_publish_site_post_from_draft.py tests/test_3360_site_posts.py tests/test_3381_site_post_unpublish.py tests/test_3386_site_post_publication.py tests/test_3374_channel_posts.py` — 53 passed
- `pytest tests/test_5b27b32f_sandbox_channel.py tests/test_620beefc_channel_post_image.py` — 46 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)