### PR TITLE
[SID:3450] WordPress(self-hosted) BlogDestinationAdapter — 조각③b

### DIFF
--- a/backend/app/services/blog_destinations.py
+++ b/backend/app/services/blog_destinations.py
@@ -38,11 +38,19 @@ class BlogDestinationNotImplementedError(NotImplementedError):
         )
 
 
-def get_blog_destination_module(*, connection_id: uuid.UUID | None) -> BlogDestinationModule:
+def get_blog_destination_module(
+    *, connection_id: uuid.UUID | None, channel: str | None = None,
+) -> BlogDestinationModule:
     """connection_id=None → hosted_site_publish(항상 사용 가능, credential 불요).
-    non-null은 조각③b·④ 전까지 명시 거부(동작 무변경 — 지금 이 함수를 실제로 호출하는
-    곳은 없다, 조각③b에서 site_posts.py 발행 흐름이 이 디스패치를 쓰기 시작한다)."""
+    non-null이면 그 connection이 가리키는 `channel`로 실 모듈을 고른다(호출자가 이미
+    connection 행을 읽어야 credential을 꺼낼 수 있어 여기선 DB 재조회 없이 channel
+    문자열만 받는다 — channel_adapters.py::get_publish_client_module(channel: str)과
+    같은 사상). wordpress=조각③b(이 조각에서 배선)·그 외(webhook 등)는 조각④ 전까지
+    명시 거부(fail-closed)."""
     if connection_id is None:
         from app.services import hosted_site_publish
         return hosted_site_publish
+    if channel == "wordpress":
+        from app.services import wordpress_publish
+        return wordpress_publish
     raise BlogDestinationNotImplementedError(connection_id=connection_id)

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -136,6 +136,27 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         # 자체가 없다) unpublish_required_scope는 비운다.
         supports_unpublish=True,
     ),
+    # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각③b) — WordPress
+    # self-hosted(Application Password) blog kind 어댑터 2호. WordPress.com OAuth2는
+    # 스토리 경계 明示로 이 조각 범위 밖(사람 의존 앱 등록 필요) — credential_kind만
+    # 여기 pasted_secret로 선언, authorize_url/token_url/scope는 threads류 OAuth 흐름을
+    # 안 타 sandbox/hosted_site와 동형으로 빈 문자열.
+    "wordpress": ChannelAdapterConfig(
+        authorize_url="",
+        token_url="",
+        scope="",
+        # Application Password는 만료가 없고 refresh 개념 자체가 없다(재발급=휴먼이
+        # WordPress 관리자 화면에서 새 비밀번호를 새로 붙여넣는 것뿐 — connected_by가
+        # 재연결하는 수동 경로).
+        refresh_mode="manual",
+        credential_kind="pasted_secret",
+        display_name="WordPress(self-hosted)",
+        kind="blog",
+        # unpublish=wordpress_publish.unpublish()(status=draft 전환) — Application
+        # Password는 스코프 개념이 없어(전권 아니면 credential 자체가 없다) 여기도
+        # hosted_site와 동형으로 비운다.
+        supports_unpublish=True,
+    ),
 }
 
 # story 5b27b32f(Phase1·BE·테스트 인프라, 페드루 PO 확定 2026-09-04) — dev 전용 샌드박스

--- a/backend/app/services/wordpress_publish.py
+++ b/backend/app/services/wordpress_publish.py
@@ -1,0 +1,96 @@
+"""story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각③b) — `wordpress`
+(CHANNEL_ADAPTERS 등재, kind="blog") BlogDestinationAdapter 2호 구현체. `hosted_site_
+publish.py`(조각②)와 같은 이름(publish/unpublish)의 모듈 — `blog_destinations.py::
+BlogDestinationModule` Protocol의 두 번째 실체.
+
+**self-hosted Application Password 경로만**(스토리 경계 明示) — WordPress.com OAuth2는
+credential_kind 선언만 하고 이 모듈은 안 다룬다(사람 의존 앱 등록이 필요해 후속).
+
+인증: WordPress 5.6+ Application Password(HTTPS Basic, RFC 7617) — `username`+
+`app_password`를 그대로 `httpx.BasicAuth`에 넘긴다(OAuth 토큰류가 아니라 재사용 가능한
+비밀번호 자체라 refresh 개념이 없다 — connection.refresh_mode="manual"과 부합).
+`site_url`은 HTTPS 강제(스토리 AC2 明示) — http://는 자격이 평문으로 오가므로 호출
+자체를 거부한다(fail-closed).
+
+`tags`는 이번 조각 스코프 밖 — WordPress REST API는 태그를 이름이 아니라 term ID
+배열로 요구해(taxonomy 조회/생성 API 별도 호출 필요) 지금 페이로드엔 안 싣는다
+(스모크 스코프 明示, AC 본문 "제목/본문/요약/slug" 중심 — 조각③b 결정, 후속에서
+필요하면 taxonomy 매핑을 별도로 추가)."""
+from __future__ import annotations
+
+import httpx
+
+_POSTS_PATH = "/wp-json/wp/v2/posts"
+
+
+class WordPressSiteURLInsecureError(ValueError):
+    """site_url이 https://로 시작하지 않음 — Application Password는 HTTPS Basic이라
+    http://로 보내면 자격이 평문 노출된다(AC2 「HTTPS 강제」明示). fail-closed."""
+
+    def __init__(self, *, site_url: str):
+        self.site_url = site_url
+        super().__init__(f"WordPress site_url은 https://여야 합니다: {site_url!r}")
+
+
+class WordPressPublishError(Exception):
+    """WordPress REST API가 2xx 밖 응답을 줌 — status_code·응답 본문(에러 메시지)을
+    실어 호출자가 failure_kind(transient/needs_check) 분류에 쓸 수 있게 한다
+    (threads_publish.py::ThreadsPublishError와 동형 사상 — 이 조각은 분류 자체는
+    안 한다, 오케스트레이션 배선은 후속)."""
+
+    def __init__(self, *, status_code: int, body: str):
+        self.status_code = status_code
+        self.body = body
+        super().__init__(f"WordPress REST API 오류(status={status_code}): {body}")
+
+
+def _validate_https(site_url: str) -> str:
+    if not site_url.startswith("https://"):
+        raise WordPressSiteURLInsecureError(site_url=site_url)
+    return site_url.rstrip("/")
+
+
+async def publish(
+    client: httpx.AsyncClient,
+    *,
+    site_url: str,
+    username: str,
+    app_password: str,
+    title: str,
+    body_md: str,
+    summary: str,
+    slug: str,
+    external_id: str | None = None,
+) -> tuple[str, str]:
+    """external_id가 없으면 `/wp/v2/posts`에 생성(POST), 있으면 `/wp/v2/posts/{id}`로
+    갱신(WordPress REST는 갱신도 POST) — hosted_site_publish.publish()의 upsert
+    사상과 동형(재발행이 새 글을 또 안 만든다). 반환은 (external_id, permalink) —
+    응답 JSON의 `id`(정수, 문자열로 캐스팅)·`link`."""
+    base = _validate_https(site_url)
+    path = f"{_POSTS_PATH}/{external_id}" if external_id else _POSTS_PATH
+    payload = {"title": title, "content": body_md, "excerpt": summary, "slug": slug, "status": "publish"}
+    resp = await client.post(
+        f"{base}{path}", json=payload, auth=httpx.BasicAuth(username, app_password), timeout=20,
+    )
+    if resp.status_code not in (200, 201):
+        raise WordPressPublishError(status_code=resp.status_code, body=resp.text)
+    data = resp.json()
+    return str(data["id"]), data["link"]
+
+
+async def unpublish(
+    client: httpx.AsyncClient, *, site_url: str, username: str, app_password: str, external_id: str,
+) -> None:
+    """行 삭제가 아니라 status=draft 전환(AC2가 명시한 두 선택지 중 이쪽 — hosted_site_
+    publish.unpublish()가 행을 안 지우고 unpublished_at만 세우는 것과 같은 비파괴
+    사상). WordPress가 draft 글도 REST 조회 대상에 남기므로 재발행(publish() 재호출)
+    으로 되돌릴 수 있다."""
+    base = _validate_https(site_url)
+    resp = await client.post(
+        f"{base}{_POSTS_PATH}/{external_id}",
+        json={"status": "draft"},
+        auth=httpx.BasicAuth(username, app_password),
+        timeout=20,
+    )
+    if resp.status_code not in (200, 201):
+        raise WordPressPublishError(status_code=resp.status_code, body=resp.text)

--- a/backend/tests/test_e4fc29fa_destination_axis.py
+++ b/backend/tests/test_e4fc29fa_destination_axis.py
@@ -477,13 +477,25 @@ def test_get_blog_destination_module_none_returns_hosted_site():
     assert get_blog_destination_module(connection_id=None) is hosted_site_publish
 
 
-def test_get_blog_destination_module_non_null_not_implemented_yet():
-    """조각③b·④ 전까지 fail-closed — 뮤테이션 대상: 이 가드를 지우면 존재하지 않는
-    목적지가 조용히 어떤 모듈로든(예: hosted_site) 떨어질 수 있다."""
+def test_get_blog_destination_module_wordpress_returns_wordpress_publish():
+    """조각③b — wordpress_publish.py 배선."""
+    from app.services import wordpress_publish
+    from app.services.blog_destinations import get_blog_destination_module
+
+    assert (
+        get_blog_destination_module(connection_id=uuid.uuid4(), channel="wordpress")
+        is wordpress_publish
+    )
+
+
+def test_get_blog_destination_module_non_wordpress_not_implemented_yet():
+    """webhook(조각④) 등 wordpress가 아닌 non-null 목적지는 여전히 fail-closed —
+    뮤테이션 대상: 이 가드를 지우면 존재하지 않는 목적지가 조용히 어떤 모듈로든
+    (예: hosted_site) 떨어질 수 있다."""
     from app.services.blog_destinations import (
         BlogDestinationNotImplementedError,
         get_blog_destination_module,
     )
 
     with pytest.raises(BlogDestinationNotImplementedError):
-        get_blog_destination_module(connection_id=uuid.uuid4())
+        get_blog_destination_module(connection_id=uuid.uuid4(), channel="webhook")

--- a/backend/tests/test_e4fc29fa_wordpress_publish_adapter.py
+++ b/backend/tests/test_e4fc29fa_wordpress_publish_adapter.py
@@ -1,0 +1,139 @@
+"""story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각③b) —
+`wordpress_publish.py`(BlogDestinationAdapter 2호 구현체) 직접 단위 테스트.
+
+DB 불요(모듈 자체가 순수 httpx 클라이언트 — hosted_site_publish.py와 달리 site_posts
+테이블에 안 쓴다) — `httpx.MockTransport`로 WordPress REST API 응답을 흉내낸다."""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from app.services.wordpress_publish import (
+    WordPressPublishError,
+    WordPressSiteURLInsecureError,
+    publish,
+    unpublish,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.anyio
+async def test_publish_creates_post_returns_external_id_and_permalink():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["auth_header"] = request.headers.get("authorization")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(201, json={"id": 42, "link": "https://customer-blog.example.com/2026/09/my-slug/"})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        external_id, permalink = await publish(
+            client, site_url="https://customer-blog.example.com", username="editor",
+            app_password="app-pw-abcd-1234", title="제목", body_md="# 본문", summary="요약",
+            slug="my-slug",
+        )
+
+    assert external_id == "42"
+    assert permalink == "https://customer-blog.example.com/2026/09/my-slug/"
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://customer-blog.example.com/wp-json/wp/v2/posts"
+    assert captured["auth_header"] is not None and captured["auth_header"].startswith("Basic ")
+    assert captured["body"] == {
+        "title": "제목", "content": "# 본문", "excerpt": "요약", "slug": "my-slug", "status": "publish",
+    }
+
+
+@pytest.mark.anyio
+async def test_publish_with_external_id_updates_existing_post():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json={"id": 42, "link": "https://customer-blog.example.com/2026/09/my-slug/"})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        external_id, _ = await publish(
+            client, site_url="https://customer-blog.example.com", username="editor",
+            app_password="app-pw", title="제목2", body_md="본문2", summary="요약2", slug="my-slug",
+            external_id="42",
+        )
+
+    assert external_id == "42"
+    assert captured["url"] == "https://customer-blog.example.com/wp-json/wp/v2/posts/42"
+
+
+@pytest.mark.anyio
+async def test_publish_non_2xx_raises_wordpress_publish_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text='{"code":"rest_cannot_create","message":"Sorry, you are not allowed."}')
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        with pytest.raises(WordPressPublishError) as exc_info:
+            await publish(
+                client, site_url="https://customer-blog.example.com", username="editor",
+                app_password="wrong-pw", title="제목", body_md="본문", summary="요약", slug="slug",
+            )
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_publish_rejects_http_site_url_no_call_made():
+    """AC2 「HTTPS 강제」 — http://는 자격이 평문 노출되므로 호출 자체를 안 한다.
+    뮤테이션 대상: 이 가드를 지우면 http:// site_url로도 실 요청이 나간다(핸들러가
+    호출되면 즉시 AssertionError로 잡는다)."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("HTTPS 미강제 — http://로 실제 요청이 나갔다")
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        with pytest.raises(WordPressSiteURLInsecureError):
+            await publish(
+                client, site_url="http://customer-blog.example.com", username="editor",
+                app_password="pw", title="제목", body_md="본문", summary="요약", slug="slug",
+            )
+
+
+@pytest.mark.anyio
+async def test_unpublish_sets_status_draft():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"id": 42, "status": "draft"})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        await unpublish(
+            client, site_url="https://customer-blog.example.com", username="editor",
+            app_password="pw", external_id="42",
+        )
+
+    assert captured["url"] == "https://customer-blog.example.com/wp-json/wp/v2/posts/42"
+    assert captured["body"] == {"status": "draft"}
+
+
+@pytest.mark.anyio
+async def test_unpublish_non_2xx_raises():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="internal error")
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        with pytest.raises(WordPressPublishError) as exc_info:
+            await unpublish(
+                client, site_url="https://customer-blog.example.com", username="editor",
+                app_password="pw", external_id="42",
+            )
+
+    assert exc_info.value.status_code == 500


### PR DESCRIPTION
## 요약
- e4fc29fa 조각③b: `wordpress_publish.py`(BlogDestinationAdapter 2호) — Application Password(HTTPS Basic) 인증, `/wp/v2/posts` create/update, unpublish=status draft 전환, site_url HTTPS 강제(fail-closed).
- `CHANNEL_ADAPTERS`에 `wordpress` 등재(kind=blog, credential_kind=pasted_secret).
- `blog_destinations.py::get_blog_destination_module()`에 `channel` 파라미터 추가 — `channel="wordpress"`면 이 모듈로 배선.

## 스코프 경계
이 조각은 모듈+레지스트리+디스패치 배선까지입니다. `site_posts.py`의 실제 발행 흐름(승인 시 publication_command 자동 생성·워커·재시도/dead_letter — 정본 5줄 설계 §3 "channel_posts와 같은 경로")을 이 디스패치로 연결하는 오케스트레이션 배선은 별도 확定이 필요해 이 PR에 포함하지 않았습니다.

tags는 스코프 밖(WordPress REST가 태그를 term ID 배열로 요구 — taxonomy 매핑은 후속).

## 베이스
`feature/e4fc29fa-piece3a-destination-axis`(PR#3794, 스택) 위 — 이 브랜치는 조각①②③a가 모두 이미 merge되어 있어 diff는 이 조각의 신규 커밋만 보입니다.

## 테스트
- `test_e4fc29fa_wordpress_publish_adapter.py`(신규 6건) — DB 불요, `httpx.MockTransport`로 WordPress REST 응답 흉내.
- `test_e4fc29fa_destination_axis.py`의 dispatcher 테스트 2건 갱신(channel 파라미터).
- 회귀 74건 + 신규 6건 로컬 전량 green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>