### PR TITLE
[SID:3450] 공용 SSRF 방지 헬퍼 + signed webhook 어댑터 — 조각④

### DIFF
--- a/backend/alembic/versions/0324_webhook_delivery_nonces.py
+++ b/backend/alembic/versions/0324_webhook_delivery_nonces.py
@@ -1,0 +1,40 @@
+"""story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각④) —
+`webhook_delivery_nonces` — signed webhook 재전송(replay) 거부 원장.
+
+정본 §4 확定 그대로: 수신측(dev_webhook_stub.py — 실서비스에선 고객 자신의 서버지만,
+dev 라이브 표본은 이 스텁)이 `(connection_id, nonce)`를 여기 기록해 같은 조합
+재전송을 UNIQUE 위반(409)으로 거부한다. FK 없음(이 도메인 전체 관례, 그라운딩 §9).
+
+Revision ID: 0324
+Revises: 0323
+Create Date: 2026-09-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0324"
+down_revision = "0323"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "webhook_delivery_nonces",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("connection_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("nonce", sa.Text(), nullable=False),
+        sa.Column("received_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("connection_id", "nonce", name="uq_webhook_delivery_nonces_connection_nonce"),
+    )
+    op.create_index(
+        "ix_webhook_delivery_nonces_connection_id", "webhook_delivery_nonces", ["connection_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_webhook_delivery_nonces_connection_id", table_name="webhook_delivery_nonces")
+    op.drop_table("webhook_delivery_nonces")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -92,6 +92,8 @@ async def lifespan(app: FastAPI):
     assert_sandbox_channel_not_registered_in_prod()  # story 5b27b32f AC5: prod에 sandbox 채널 등재=기동 실패(fail-closed).
     from app.routers.dev_wordpress_stub import assert_wordpress_stub_not_registered_in_prod
     assert_wordpress_stub_not_registered_in_prod()  # story e4fc29fa 조각③c: prod에 WordPress 스텁 등재=기동 실패(fail-closed).
+    from app.routers.dev_webhook_stub import assert_webhook_stub_not_registered_in_prod
+    assert_webhook_stub_not_registered_in_prod()  # story e4fc29fa 조각④: prod에 webhook 스텁 등재=기동 실패(fail-closed).
     # story bea25062: cutover 존재-캐시는 의도적으로 startup에서 warm 안 함(자체 발견 —
     # TestClient(app)로 lifespan을 태우는 기존 SSE 테스트들이 라우트 전용으로 짜둔 유한한
     # mock db.execute() 순서-큐를 startup 시점의 이 캐시 조회가 몰래 하나 소비해 실패시켰다).
@@ -461,6 +463,11 @@ from app.routers import dev_wordpress_stub as _dev_wordpress_stub  # noqa: E402
 
 if _dev_wordpress_stub.wordpress_stub_enabled():
     app.include_router(_dev_wordpress_stub.router)
+# story e4fc29fa(조각④) — dev 전용 signed webhook 수신 스텁. 위와 같은 이중방어 사상.
+from app.routers import dev_webhook_stub as _dev_webhook_stub  # noqa: E402
+
+if _dev_webhook_stub.webhook_stub_enabled():
+    app.include_router(_dev_webhook_stub.router)
 app.include_router(resolve.router)
 app.include_router(org_invites.router)
 app.include_router(invite_accept.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -43,6 +43,7 @@ from app.models.policy_document import PolicyDocument
 from app.models.legal_document import LegalDocumentVersion
 from app.models.audit import AuditLog
 from app.models.webhook_config import WebhookConfig
+from app.models.webhook_delivery_nonce import WebhookDeliveryNonce
 from app.models.push_device import PushDevice
 from app.models.doc import Doc, DocShareToken, DocSlugAlias
 from app.models.mention import Mention
@@ -199,6 +200,7 @@ __all__ = [
     "LegalDocumentVersion",
     "AuditLog",
     "WebhookConfig",
+    "WebhookDeliveryNonce",
     "PushDevice",
     "Doc",
     "Goal",

--- a/backend/app/models/webhook_delivery_nonce.py
+++ b/backend/app/models/webhook_delivery_nonce.py
@@ -1,0 +1,25 @@
+"""story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각④) — signed webhook
+재전송(replay) 거부 원장. `(connection_id, nonce)` UNIQUE — 수신측이 같은 조합을 다시
+보면 409(재전송)로 거부한다. FK 없음(그라운딩 §9 도메인 전체 관례)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class WebhookDeliveryNonce(Base):
+    __tablename__ = "webhook_delivery_nonces"
+    __table_args__ = (
+        UniqueConstraint("connection_id", "nonce", name="uq_webhook_delivery_nonces_connection_nonce"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    connection_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    nonce: Mapped[str] = mapped_column(Text, nullable=False)
+    received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/routers/dev_webhook_stub.py
+++ b/backend/app/routers/dev_webhook_stub.py
@@ -8,6 +8,12 @@ HTTP 왕복을 검증할 대상이 없던 문제를 채운다.
 고정 시크릿 — 실서비스 고객 자격이 아니라 우리 스스로 만든 테스트 연결의 공유 비밀).
 `(connection_id, nonce)` 재전송은 `webhook_delivery_nonces` UNIQUE 위반으로 409.
 
+**timestamp 창**(정본 §4 "timestamp 창" 明示, 페드루 리뷰 B2, 2026-09-04) — 서명
+자체가 유효해도 `|now − timestamp| > _TIMESTAMP_WINDOW_SECONDS`(300s)면 401로
+거부한다. nonce 하나만으로는 "같은 요청이 영원히 유효한 채로 어딘가에 유출되면
+그 시점 이후 언제든 재생 가능"이라는 잔여 위험이 남는다 — 창을 두면 유출된 요청도
+5분이 지나면 저절로 무력화된다(nonce 원장이 영구히 안 커지는 부수 효과도 있다).
+
 URL 경로에 `connection_id`를 심는다(`/deliver/{connection_id}`) — 우리가 만드는
 테스트 connection의 target_url 자체를 이렇게 구성해 두면(우리가 통제하는 값이라
 가능) 스텁이 별도 헤더 없이 어느 연결의 발송인지 안다. 실 고객 서버는 이 관례를
@@ -22,6 +28,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import os
+import time
 import uuid
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
@@ -33,6 +40,13 @@ from app.dependencies.database import get_db
 router = APIRouter(prefix="/api/dev/webhook-stub", tags=["dev-webhook-stub"])
 
 _DEFAULT_TEST_SECRET = "dev-webhook-stub-shared-secret"  # dev 전용 고정값(실 자격 아님).
+# story e4fc29fa(조각④, 페드루 리뷰 B2) — 정본 §4가 明示한 "timestamp 창". 서명
+# 자체는 유효해도 timestamp가 지금과 너무 동떨어져 있으면 거부한다 — 어딘가로
+# 유출된 요청(서명·nonce 포함 그대로)이 nonce 원장 조회 전에도 무한정 재생 가능한
+# 잔여 위험을 좁힌다. 300s는 임의값 — 정상 네트워크 지연을 여유 있게 흡수하면서도
+# "영원히 유효"보다는 훨씬 좁다(webhook_publish.py는 매 호출마다 새 timestamp를
+# 싣는다 — 재시도가 이 창에 걸릴 일은 없다, 이 창은 순수 replay-window 방어).
+_TIMESTAMP_WINDOW_SECONDS = 300
 
 
 def webhook_stub_enabled() -> bool:
@@ -71,6 +85,18 @@ async def deliver(
         raise HTTPException(status_code=401, detail={"code": "signature_missing", "message": "서명 헤더가 없습니다"})
     if not x_sprintable_timestamp or not x_sprintable_nonce:
         raise HTTPException(status_code=401, detail={"code": "headers_missing", "message": "timestamp/nonce 헤더가 없습니다"})
+
+    try:
+        timestamp_value = int(x_sprintable_timestamp)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=401, detail={"code": "timestamp_invalid", "message": "timestamp가 정수가 아닙니다"},
+        ) from exc
+    if abs(time.time() - timestamp_value) > _TIMESTAMP_WINDOW_SECONDS:
+        raise HTTPException(
+            status_code=401,
+            detail={"code": "timestamp_out_of_window", "message": f"timestamp가 {_TIMESTAMP_WINDOW_SECONDS}s 창을 벗어났습니다"},
+        )
 
     expected = hmac.new(stub_test_secret().encode(), body, hashlib.sha256).hexdigest()
     got = x_sprintable_signature.removeprefix("sha256=")

--- a/backend/app/routers/dev_webhook_stub.py
+++ b/backend/app/routers/dev_webhook_stub.py
@@ -1,0 +1,103 @@
+"""story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각④) — dev 전용
+signed webhook 수신 스텁. `dev_wordpress_stub.py`(조각③c)와 같은 사상 — dev org엔
+고객의 실 webhook 목적지가 없어(§7 명시) `webhook_publish.py`가 진짜로 치는 서명된
+HTTP 왕복을 검증할 대상이 없던 문제를 채운다.
+
+**진짜 서명 검증**(AC4 明示, wordpress 스텁의 "헤더 존재만 확인"보다 한 단계 더) —
+이 스텁은 실제로 `WEBHOOK_TEST_STUB_SECRET`으로 HMAC을 재계산해 대조한다(dev 전용
+고정 시크릿 — 실서비스 고객 자격이 아니라 우리 스스로 만든 테스트 연결의 공유 비밀).
+`(connection_id, nonce)` 재전송은 `webhook_delivery_nonces` UNIQUE 위반으로 409.
+
+URL 경로에 `connection_id`를 심는다(`/deliver/{connection_id}`) — 우리가 만드는
+테스트 connection의 target_url 자체를 이렇게 구성해 두면(우리가 통제하는 값이라
+가능) 스텁이 별도 헤더 없이 어느 연결의 발송인지 안다. 실 고객 서버는 이 관례를
+몰라도 된다(우리 dev 스텁만의 사정 — webhook_publish.py는 target_url을 그대로
+POST할 뿐, 이 경로 관례를 모른다).
+
+fail-closed 이중방어(dev_wordpress_stub.py 동형) — 라우터 자체가 `WEBHOOK_TEST_
+STUB_ENABLED=true`일 때만 등재 + 기동 시 `assert_webhook_stub_not_registered_in_prod()`
+가 prod 오조작을 잡는다."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.database import get_db
+
+router = APIRouter(prefix="/api/dev/webhook-stub", tags=["dev-webhook-stub"])
+
+_DEFAULT_TEST_SECRET = "dev-webhook-stub-shared-secret"  # dev 전용 고정값(실 자격 아님).
+
+
+def webhook_stub_enabled() -> bool:
+    return os.environ.get("WEBHOOK_TEST_STUB_ENABLED", "").strip().lower() == "true"
+
+
+def stub_test_secret() -> str:
+    """story e4fc29fa(조각④) — dev 테스트 connection을 만들 때 이 값과 같은 문자열을
+    `encrypted_access_token`에 넣어야 이 스텁이 서명을 통과시킨다(`WEBHOOK_TEST_STUB_
+    SECRET` env로 오버라이드 가능·기본값은 이 파일의 고정 문자열)."""
+    return os.environ.get("WEBHOOK_TEST_STUB_SECRET", _DEFAULT_TEST_SECRET)
+
+
+def assert_webhook_stub_not_registered_in_prod() -> None:
+    from app.core.config import settings
+
+    if settings.is_prod_deploy and webhook_stub_enabled():
+        raise RuntimeError(
+            "fail-closed: prod 배포에 WEBHOOK_TEST_STUB_ENABLED가 켜져 있습니다"
+            "(story e4fc29fa 조각④ AC4)."
+        )
+
+
+@router.post("/deliver/{connection_id}")
+async def deliver(
+    connection_id: uuid.UUID,
+    request: Request,
+    x_sprintable_signature: str | None = Header(default=None),
+    x_sprintable_timestamp: str | None = Header(default=None),
+    x_sprintable_nonce: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    body = await request.body()
+
+    if not x_sprintable_signature or not x_sprintable_signature.startswith("sha256="):
+        raise HTTPException(status_code=401, detail={"code": "signature_missing", "message": "서명 헤더가 없습니다"})
+    if not x_sprintable_timestamp or not x_sprintable_nonce:
+        raise HTTPException(status_code=401, detail={"code": "headers_missing", "message": "timestamp/nonce 헤더가 없습니다"})
+
+    expected = hmac.new(stub_test_secret().encode(), body, hashlib.sha256).hexdigest()
+    got = x_sprintable_signature.removeprefix("sha256=")
+    # verdict_capture.py::_hmac_match와 동형 상수시간 비교(타이밍 사이드채널 방지).
+    if not hmac.compare_digest(expected, got):
+        raise HTTPException(status_code=401, detail={"code": "signature_mismatch", "message": "서명이 일치하지 않습니다"})
+
+    from app.models.webhook_delivery_nonce import WebhookDeliveryNonce
+
+    row = WebhookDeliveryNonce(id=uuid.uuid4(), connection_id=connection_id, nonce=x_sprintable_nonce)
+    try:
+        async with db.begin_nested():
+            db.add(row)
+            await db.flush()
+    except IntegrityError as exc:
+        _orig = getattr(exc, "orig", None)
+        constraint = getattr(_orig, "constraint_name", None) or getattr(
+            getattr(_orig, "__cause__", None), "constraint_name", None,
+        )
+        if constraint != "uq_webhook_delivery_nonces_connection_nonce":
+            raise
+        raise HTTPException(
+            status_code=409, detail={"code": "replay_rejected", "message": "이미 처리된 nonce입니다(재전송 거부)"},
+        ) from exc
+    await db.commit()
+
+    payload = await request.json()
+    event = payload.get("event")
+    external_id = f"webhook-{connection_id}-{payload.get('slug', uuid.uuid4().hex[:8])}"
+    return {"received": True, "event": event, "external_id": external_id, "url": None}

--- a/backend/app/routers/dev_webhook_stub.py
+++ b/backend/app/routers/dev_webhook_stub.py
@@ -98,7 +98,12 @@ async def deliver(
             detail={"code": "timestamp_out_of_window", "message": f"timestamp가 {_TIMESTAMP_WINDOW_SECONDS}s 창을 벗어났습니다"},
         )
 
-    expected = hmac.new(stub_test_secret().encode(), body, hashlib.sha256).hexdigest()
+    # 카디르 QA 블로커(2026-09-04, 정본 §4 재확定) — 서명 대상은 body 단독이 아니라
+    # timestamp·nonce까지 포함(webhook_publish.py::_signed_payload와 동일 구성) —
+    # 그래야 공격자가 헤더의 timestamp·nonce만 새 값으로 바꿔치기해 재전송해도
+    # 서명이 안 맞아 401로 막힌다(재전송 방지가 실제로 성립하는 계약).
+    signed_payload = f"{x_sprintable_timestamp}.{x_sprintable_nonce}.".encode() + body
+    expected = hmac.new(stub_test_secret().encode(), signed_payload, hashlib.sha256).hexdigest()
     got = x_sprintable_signature.removeprefix("sha256=")
     # verdict_capture.py::_hmac_match와 동형 상수시간 비교(타이밍 사이드채널 방지).
     if not hmac.compare_digest(expected, got):

--- a/backend/app/services/blog_destinations.py
+++ b/backend/app/services/blog_destinations.py
@@ -45,12 +45,14 @@ def get_blog_destination_module(
     non-null이면 그 connection이 가리키는 `channel`로 실 모듈을 고른다(호출자가 이미
     connection 행을 읽어야 credential을 꺼낼 수 있어 여기선 DB 재조회 없이 channel
     문자열만 받는다 — channel_adapters.py::get_publish_client_module(channel: str)과
-    같은 사상). wordpress=조각③b(이 조각에서 배선)·그 외(webhook 등)는 조각④ 전까지
-    명시 거부(fail-closed)."""
+    같은 사상). wordpress=조각③b·webhook=조각④(이 조각에서 배선) — 그 외는 fail-closed."""
     if connection_id is None:
         from app.services import hosted_site_publish
         return hosted_site_publish
     if channel == "wordpress":
         from app.services import wordpress_publish
         return wordpress_publish
+    if channel == "webhook":
+        from app.services import webhook_publish
+        return webhook_publish
     raise BlogDestinationNotImplementedError(connection_id=connection_id)

--- a/backend/app/services/channel_adapters.py
+++ b/backend/app/services/channel_adapters.py
@@ -157,6 +157,21 @@ CHANNEL_ADAPTERS: dict[str, ChannelAdapterConfig] = {
         # hosted_site와 동형으로 비운다.
         supports_unpublish=True,
     ),
+    # story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각④) — 고객 자체
+    # 사이트 signed webhook blog kind 어댑터 3호. credential_kind=pasted_secret(공유
+    # 비밀 — wordpress Application Password와 같은 컬럼 재사용, 유나 §8③ 정본).
+    "webhook": ChannelAdapterConfig(
+        authorize_url="",
+        token_url="",
+        scope="",
+        refresh_mode="manual",
+        credential_kind="pasted_secret",
+        display_name="고객 웹훅(signed)",
+        kind="blog",
+        # unpublish=webhook_publish.unpublish()(event:"unpublish" 신호 POST) — webhook
+        # 도 스코프 개념이 없다(공유 비밀 하나가 전권).
+        supports_unpublish=True,
+    ),
 }
 
 # story 5b27b32f(Phase1·BE·테스트 인프라, 페드루 PO 확定 2026-09-04) — dev 전용 샌드박스

--- a/backend/app/services/destination_url_safety.py
+++ b/backend/app/services/destination_url_safety.py
@@ -1,0 +1,86 @@
+"""story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각④) — 고객이 넣는
+목적지 URL(WordPress site_url·webhook target) 전부가 거치는 공용 SSRF 방지 검사.
+
+wordpress_publish.py(조각③b)의 `_validate_https`가 문자열 프리픽스만 봤다 — 페드루
+리뷰 B1(조각③c)로 loopback 예외를 dev 플래그로 잠갔지만, **문자열 검사 자체의 한계**
+(도메인이 나중에 내부 IP로 rebind되는 DNS rebinding류)는 그대로 남아 있었다. 여기서는
+호스트를 실제로 DNS 해석하고 **해석된 모든 IP**가 사설(RFC1918)·loopback·link-local
+(169.254.0.0/16 — GCP/AWS/Azure 클라우드 메타데이터 169.254.169.254가 이 대역 안)·
+예약/멀티캐스트/미지정이 아님을 확인한 뒤에만 통과시킨다("해석 시점" 검사, PO 明示).
+
+TOCTOU 한계(明示, 스코프 결정) — 이 검사와 실제 연결 사이에 DNS 응답이 다시 바뀌는
+찰나의 rebinding까지 막으려면 검증한 IP로 직접 연결(SNI/Host는 원 호스트 유지)하는
+IP-pinning이 필요하다. 이 조각은 그 전 단계(해석 시점 IP 블록리스트)까지 — 발행 요청은
+사람의 승인 행위 뒤에나 재시도 주기(분 단위)로만 일어나 실시간 rebinding 경합의 실익이
+낮다는 판단(발행 빈도·타이밍이 공격자 통제 밖). IP-pinning은 후속 강화 항목으로 명시
+남긴다."""
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import urlsplit
+
+_LOOPBACK_HOSTS = ("127.0.0.1", "localhost")
+
+
+class DestinationURLUnsafeError(ValueError):
+    """목적지 URL이 https://가 아니거나, 해석된 IP가 사설/loopback/link-local 등
+    내부망 대역이다(SSRF fail-closed)."""
+
+    def __init__(self, *, url: str, reason: str):
+        self.url = url
+        self.reason = reason
+        super().__init__(f"목적지 URL이 안전하지 않습니다({reason}): {url!r}")
+
+
+def _unsafe_ip_reason(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str | None:
+    if ip.is_loopback:
+        return "loopback"
+    if ip.is_link_local:
+        return "link-local(클라우드 메타데이터 169.254.169.254 포함 대역)"
+    if ip.is_private:
+        return "사설 대역(RFC1918)"
+    if ip.is_reserved:
+        return "예약 대역"
+    if ip.is_multicast:
+        return "멀티캐스트"
+    if ip.is_unspecified:
+        return "미지정 주소"
+    return None
+
+
+async def assert_destination_url_safe(url: str, *, allow_loopback: bool = False) -> str:
+    """https:// 강제 — `allow_loopback=True`(호출자가 자기 dev 스텁 플래그로 이미
+    게이트한 경우만 전달)면 `http://127.0.0.1`·`http://localhost`만 예외(DNS 해석·IP
+    블록리스트는 생략 — loopback은 정의상 이미 안전한 대상, 신뢰된 자기 자신).
+
+    그 외엔 스킴이 https://여야 하고, host를 실제로 DNS 해석해(`socket.getaddrinfo`,
+    블로킹이라 executor로) 해석된 모든 IP가 안전해야 통과한다.
+
+    반환값은 trailing slash를 제거한 url(호출자가 base로 그대로 쓴다 — 기존
+    `_validate_https`의 반환 계약과 동형)."""
+    parsed = urlsplit(url)
+    host = parsed.hostname
+    if not host:
+        raise DestinationURLUnsafeError(url=url, reason="host가 없습니다")
+
+    if allow_loopback and parsed.scheme == "http" and host in _LOOPBACK_HOSTS:
+        return url.rstrip("/")
+
+    if parsed.scheme != "https":
+        raise DestinationURLUnsafeError(url=url, reason="https://가 아닙니다")
+
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.run_in_executor(None, socket.getaddrinfo, host, None)
+    except socket.gaierror as exc:
+        raise DestinationURLUnsafeError(url=url, reason=f"DNS 해석 실패: {exc}") from exc
+
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        reason = _unsafe_ip_reason(ip)
+        if reason is not None:
+            raise DestinationURLUnsafeError(url=url, reason=f"해석된 IP {ip}가 {reason}")
+
+    return url.rstrip("/")

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -51,7 +51,15 @@ FAILURE_KIND_TRANSIENT = "transient"
 # story #3414 — 어떤 서버 error code가 어느 failure_kind인지의 유일한 매핑 표. 새 코드가
 # 추가되면 여기 등재하지 않는 한 자동으로 needs_check(fail-closed)로 떨어진다 — "일단
 # transient로"류 추측 금지(story #3405/#3406 "미지 code는 추측 안 함" 원칙과 동일 사상).
-_CONNECTION_BLOCKED_CODES = frozenset({"CHANNEL_TOKEN_EXPIRED", "CHANNEL_CONNECTION_NOT_ACTIVE"})
+_CONNECTION_BLOCKED_CODES = frozenset({
+    "CHANNEL_TOKEN_EXPIRED", "CHANNEL_CONNECTION_NOT_ACTIVE",
+    # story e4fc29fa(조각④) — wordpress/webhook 어댑터가 401/403을 돌려주면(잘못된
+    # Application Password·공유 비밀) "일시적 provider 오류"가 아니라 자격 자체가
+    # 틀렸다는 뜻 — CHANNEL_TOKEN_EXPIRED와 같은 결로 connection을 blocked/expired로
+    # 승격하고 무한 백오프 재시도 대신 사람의 재연결을 기다린다(site_posts.py::
+    # publish_site_post_external_command가 상태코드 401/403일 때만 이 코드를 쓴다).
+    "CHANNEL_PUBLISH_AUTH_REJECTED",
+})
 # story 620beefc(PO 決定, 2026-09-04) — IMAGE 컨테이너가 Threads 쪽에서 ERROR/EXPIRED로
 # 끝났다. 폴링을 몇 번 더 반복해도 같은 결과이므로(결정적) transient 백오프가 아니라
 # needs_check(사람 재시도, AC5)로 바로 보낸다.

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -835,6 +835,73 @@ async def _get_active_blog_connection(db: AsyncSession, *, org_id: uuid.UUID, co
     return conn
 
 
+def _blog_destination_exception_classes() -> tuple[tuple[type[Exception], ...], tuple[type[Exception], ...]]:
+    """story e4fc29fa(조각④) — wordpress_publish.py·webhook_publish.py 각자 자기
+    공개 예외 타입을 갖는다(호출자 계약 유지, 모듈 재사용 원칙) — 오케스트레이션
+    계층은 둘 다 잡아야 하므로 여기서 한 곳에 모은다(새 모듈이 추가되면 여기 한 줄만
+    늘면 된다)."""
+    from app.services.webhook_publish import WebhookPublishError, WebhookTargetURLInsecureError
+    from app.services.wordpress_publish import WordPressPublishError, WordPressSiteURLInsecureError
+
+    return (
+        (WordPressSiteURLInsecureError, WebhookTargetURLInsecureError),
+        (WordPressPublishError, WebhookPublishError),
+    )
+
+
+_BLOG_DESTINATION_INSECURE_ERRORS, _BLOG_DESTINATION_PUBLISH_ERRORS = _blog_destination_exception_classes()
+
+
+def _blog_publish_error_code(exc: Exception) -> str:
+    """story e4fc29fa(조각④) — 401/403은 "일시적 provider 오류"가 아니라 자격 자체가
+    틀렸다는 뜻(wordpress Application Password·webhook 공유 비밀 오설정). 뮤테이션
+    대상: 이 분기를 지우면 401도 CHANNEL_PUBLISH_PROVIDER_ERROR(transient)로 떨어져
+    고쳐지지 않는 자격으로 무한 백오프 재시도만 반복한다(webhook 라이브 테스트가
+    실제로 이 경로를 잡았다)."""
+    if getattr(exc, "status_code", None) in (401, 403):
+        return "CHANNEL_PUBLISH_AUTH_REJECTED"
+    return "CHANNEL_PUBLISH_PROVIDER_ERROR"
+
+
+async def _call_blog_module_publish(
+    module, client, *, channel: str, connection, app_password: str, title: str, body_md: str,
+    summary: str, tags: list, slug: str, external_id: str | None,
+) -> tuple[str, str | None]:
+    """story e4fc29fa(조각④) — wordpress/webhook 모듈은 이름(publish)은 같아도
+    파라미터 모양이 다르다(BlogDestinationModule Protocol 明示 — 목적지마다 자격
+    형태가 다르다). 이 함수가 channel별 kwargs 조립을 한 곳에 모아, 오케스트레이션
+    본문(publish_site_post_external_command)은 채널을 몰라도 되게 한다."""
+    if channel == "wordpress":
+        return await module.publish(
+            client, site_url=connection.account_id, username=connection.account_label or "",
+            app_password=app_password, title=title, body_md=body_md, summary=summary, slug=slug,
+            external_id=external_id,
+        )
+    if channel == "webhook":
+        return await module.publish(
+            client, target_url=connection.account_id, secret=app_password, title=title, body_md=body_md,
+            summary=summary, tags=tags, slug=slug, external_id=external_id,
+        )
+    raise SitePostExternalPublishError(
+        error_code="SITE_POST_DRAFT_NOT_FOUND", message=f"알 수 없는 blog 채널: {channel!r}",
+    )
+
+
+async def _call_blog_module_unpublish(module, client, *, channel: str, connection, app_password: str, external_id: str) -> None:
+    if channel == "wordpress":
+        await module.unpublish(
+            client, site_url=connection.account_id, username=connection.account_label or "",
+            app_password=app_password, external_id=external_id,
+        )
+        return
+    if channel == "webhook":
+        await module.unpublish(client, target_url=connection.account_id, secret=app_password, external_id=external_id)
+        return
+    raise SitePostExternalPublishError(
+        error_code="SITE_POST_DRAFT_NOT_FOUND", message=f"알 수 없는 blog 채널: {channel!r}",
+    )
+
+
 class SitePostExternalPublishError(Exception):
     """story e4fc29fa(조각③c) — 외부 목적지(WordPress 등) 발행/회수 실패. error_code로
     워커가 failure_kind(connection/needs_check/transient)를 분류한다(publication_
@@ -949,7 +1016,6 @@ async def publish_site_post_external_command(db: AsyncSession, command: "Publica
     from app.services.blog_destinations import get_blog_destination_module
     from app.services.channel_connection import decrypt_for_use
     from app.services.channel_posts import ChannelConnectionNotActiveError
-    from app.services.wordpress_publish import WordPressPublishError, WordPressSiteURLInsecureError
 
     version = (await db.execute(
         select(SitePostVersion).where(SitePostVersion.id == command.approved_version)
@@ -999,15 +1065,15 @@ async def publish_site_post_external_command(db: AsyncSession, command: "Publica
 
     try:
         async with httpx.AsyncClient() as client:
-            external_id, permalink = await module.publish(
-                client, site_url=connection.account_id, username=connection.account_label or "",
-                app_password=app_password, title=version.title, body_md=version.body_md,
-                summary=version.summary, slug=draft.slug, external_id=prior_external_id,
+            external_id, permalink = await _call_blog_module_publish(
+                module, client, channel=connection.channel, connection=connection, app_password=app_password,
+                title=version.title, body_md=version.body_md, summary=version.summary, tags=version.tags,
+                slug=draft.slug, external_id=prior_external_id,
             )
-    except WordPressSiteURLInsecureError as exc:
+    except _BLOG_DESTINATION_INSECURE_ERRORS as exc:
         raise SitePostExternalPublishError(error_code="SITE_POST_DESTINATION_INSECURE", message=str(exc)) from exc
-    except WordPressPublishError as exc:
-        raise SitePostExternalPublishError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=str(exc)) from exc
+    except _BLOG_DESTINATION_PUBLISH_ERRORS as exc:
+        raise SitePostExternalPublishError(error_code=_blog_publish_error_code(exc), message=str(exc)) from exc
 
     # story #3395/#3757 동형 SAVEPOINT 관용구(동시 처리 방어) — (gate_id, version_id) UNIQUE 재사용.
     from sqlalchemy.exc import IntegrityError
@@ -1056,7 +1122,6 @@ async def unpublish_site_post_external_command(db: AsyncSession, command: "Publi
     from app.services.blog_destinations import get_blog_destination_module
     from app.services.channel_connection import decrypt_for_use
     from app.services.channel_posts import ChannelConnectionNotActiveError
-    from app.services.wordpress_publish import WordPressPublishError, WordPressSiteURLInsecureError
 
     row = (await db.execute(
         select(ChannelPublication).where(
@@ -1083,14 +1148,14 @@ async def unpublish_site_post_external_command(db: AsyncSession, command: "Publi
 
     try:
         async with httpx.AsyncClient() as client:
-            await module.unpublish(
-                client, site_url=connection.account_id, username=connection.account_label or "",
+            await _call_blog_module_unpublish(
+                module, client, channel=connection.channel, connection=connection,
                 app_password=app_password, external_id=row.external_id,
             )
-    except WordPressSiteURLInsecureError as exc:
+    except _BLOG_DESTINATION_INSECURE_ERRORS as exc:
         raise SitePostExternalPublishError(error_code="SITE_POST_DESTINATION_INSECURE", message=str(exc)) from exc
-    except WordPressPublishError as exc:
-        raise SitePostExternalPublishError(error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", message=str(exc)) from exc
+    except _BLOG_DESTINATION_PUBLISH_ERRORS as exc:
+        raise SitePostExternalPublishError(error_code=_blog_publish_error_code(exc), message=str(exc)) from exc
 
     row.status = "unpublished"
     return row

--- a/backend/app/services/webhook_publish.py
+++ b/backend/app/services/webhook_publish.py
@@ -5,13 +5,17 @@ publish.py`(조각③b)와 이름은 같지만(publish/unpublish) **파라미터
 자격 형태가 다르다(WordPress=site_url+username+app_password, webhook=target_url+
 shared secret 하나뿐 — 사용자명 개념이 없다).
 
-서명 계약(정본 §4 확定 그대로) — `conversation_webhook.py::_sign_payload`와 동일한
-HMAC-SHA256(다만 이 조각은 별도 함수로 재구현 — conversation_webhook.py를 import하면
-webhook 발송이라는 무관한 도메인에 결합이 생긴다, 알고리즘만 재사용). 헤더 3종:
-`X-Sprintable-Signature`(`sha256=` prefix)·`X-Sprintable-Timestamp`(unix seconds)·
-`X-Sprintable-Nonce`(uuid4) — 서명 대상은 body 그 자체(timestamp·nonce는 헤더로만
-동행, `_sign_payload` 계약 그대로 재사용). "허용 도메인"은 별도 화이트리스트 컬럼
-불요 — 연결 등록 시 고객이 넣은 target_url 자체가 유일한 신뢰축(정본 明示) +
+서명 계약(카디르 QA·PO 코드 확認 2026-09-04, 정본 §4 재확定 — Stripe/Slack v1 형)
+— HMAC-SHA256, 서명 대상은 `f"{timestamp}.{nonce}.".encode() + body`(timestamp·
+nonce가 헤더로만 동행하고 body만 서명하던 최초 형은 재전송 방지가 공허했다: 서명된
+body를 잡은 쪽이 새 timestamp·새 nonce를 붙여 재전송하면 timestamp 창·nonce 저장
+둘 다 못 막았다 — `conversation_webhook.py::_sign_payload` 알고리즘 차용이 부적합했던
+이유는 그 원본이 애초에 재전송 방지를 주장하지 않아서였다, 이 어댑터는 주장한다).
+헤더 3종은 그대로: `X-Sprintable-Signature`(`sha256=` prefix)·`X-Sprintable-
+Timestamp`(unix seconds)·`X-Sprintable-Nonce`(uuid4) — 이제 그 값들이 서명 자체
+안에도 들어간다(위조 방지: 공격자가 헤더만 새 값으로 바꿔치기해도 서명이 그 새
+값으로 재계산되지 않으면 불일치). "허용 도메인"은 별도 화이트리스트 컬럼 불요 —
+연결 등록 시 고객이 넣은 target_url 자체가 유일한 신뢰축(정본 明示) +
 `destination_url_safety.py`(조각④ part A)가 그 URL을 「해석 시점」에 검증.
 
 unpublish — webhook은 WordPress처럼 "그 글의 상태를 바꾸는" API가 없다(수신측이
@@ -66,8 +70,17 @@ class WebhookPublishError(Exception):
         super().__init__(f"webhook 수신측 오류(status={status_code}): {self.body}")
 
 
-def _sign(secret: str, body: bytes) -> str:
-    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+def _signed_payload(timestamp: str, nonce: str, body: bytes) -> bytes:
+    """카디르 QA 블로커(2026-09-04) — timestamp·nonce를 서명 대상 안에 고정한다
+    (Stripe/Slack v1 형, 구분자 `.` 고정). body만 서명하면 가로챈 요청에 새
+    timestamp·nonce를 붙여 재전송해도 서명이 그대로 유효해 재전송 방지 두 축
+    (timestamp 창·nonce 저장)이 전부 무력화된다 — 서명 자체가 그 값들을 보증해야
+    "헤더를 바꿔치기하면 서명이 깨진다"가 성립한다."""
+    return f"{timestamp}.{nonce}.".encode() + body
+
+
+def _sign(secret: str, timestamp: str, nonce: str, body: bytes) -> str:
+    digest = hmac.new(secret.encode(), _signed_payload(timestamp, nonce, body), hashlib.sha256).hexdigest()
     return f"sha256={digest}"
 
 
@@ -79,10 +92,12 @@ async def _validate_target(target_url: str) -> str:
 
 
 def _headers_for(secret: str, body: bytes) -> dict[str, str]:
+    timestamp = str(int(time.time()))
+    nonce = str(uuid.uuid4())
     return {
-        _SIGNATURE_HEADER: _sign(secret, body),
-        _TIMESTAMP_HEADER: str(int(time.time())),
-        _NONCE_HEADER: str(uuid.uuid4()),
+        _SIGNATURE_HEADER: _sign(secret, timestamp, nonce, body),
+        _TIMESTAMP_HEADER: timestamp,
+        _NONCE_HEADER: nonce,
         "Content-Type": "application/json",
     }
 

--- a/backend/app/services/webhook_publish.py
+++ b/backend/app/services/webhook_publish.py
@@ -1,0 +1,135 @@
+"""story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각④) — `webhook`
+(CHANNEL_ADAPTERS 등재, kind="blog") BlogDestinationAdapter 3호 구현체. `wordpress_
+publish.py`(조각③b)와 이름은 같지만(publish/unpublish) **파라미터는 다르다** —
+`blog_destinations.py::BlogDestinationModule` Protocol이 明示하듯 목적지마다 필요한
+자격 형태가 다르다(WordPress=site_url+username+app_password, webhook=target_url+
+shared secret 하나뿐 — 사용자명 개념이 없다).
+
+서명 계약(정본 §4 확定 그대로) — `conversation_webhook.py::_sign_payload`와 동일한
+HMAC-SHA256(다만 이 조각은 별도 함수로 재구현 — conversation_webhook.py를 import하면
+webhook 발송이라는 무관한 도메인에 결합이 생긴다, 알고리즘만 재사용). 헤더 3종:
+`X-Sprintable-Signature`(`sha256=` prefix)·`X-Sprintable-Timestamp`(unix seconds)·
+`X-Sprintable-Nonce`(uuid4) — 서명 대상은 body 그 자체(timestamp·nonce는 헤더로만
+동행, `_sign_payload` 계약 그대로 재사용). "허용 도메인"은 별도 화이트리스트 컬럼
+불요 — 연결 등록 시 고객이 넣은 target_url 자체가 유일한 신뢰축(정본 明示) +
+`destination_url_safety.py`(조각④ part A)가 그 URL을 「해석 시점」에 검증.
+
+unpublish — webhook은 WordPress처럼 "그 글의 상태를 바꾸는" API가 없다(수신측이
+우리가 정의한 계약 전부다). 회수는 같은 채널로 `event: "unpublish"`를 담은 별도 신호
+POST로 표현한다(새 external_id 없음 — external_id는 최초 publish 응답의 값을 그대로
+돌려준다는 계약, 아래 unpublish() 참고)."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import time
+import uuid
+
+import httpx
+
+from app.services.destination_url_safety import DestinationURLUnsafeError, assert_destination_url_safe
+
+_SIGNATURE_HEADER = "X-Sprintable-Signature"
+_TIMESTAMP_HEADER = "X-Sprintable-Timestamp"
+_NONCE_HEADER = "X-Sprintable-Nonce"
+
+
+def webhook_stub_enabled() -> bool:
+    """story e4fc29fa(조각④) — wordpress_publish.py::wordpress_stub_enabled와 동형
+    env 게이트(dev_webhook_stub.py의 loopback target_url 허용 조건)."""
+    return os.environ.get("WEBHOOK_TEST_STUB_ENABLED", "").strip().lower() == "true"
+
+
+class WebhookTargetURLInsecureError(ValueError):
+    """target_url이 안전하지 않음(destination_url_safety.py 판정 그대로 감쌈) —
+    wordpress_publish.py::WordPressSiteURLInsecureError와 동형 사상(모듈별 공개
+    예외 타입은 유지, 검증 로직은 공용 헬퍼에 위임)."""
+
+    def __init__(self, *, target_url: str):
+        self.target_url = target_url
+        super().__init__(f"webhook target_url이 안전하지 않습니다: {target_url!r}")
+
+
+class WebhookPublishError(Exception):
+    """수신측이 2xx 밖 응답을 줌 — status_code·응답 본문(길이 컷)을 실어 failure_kind
+    분류에 쓴다(wordpress_publish.py::WordPressPublishError와 동형). 페드루 기록
+    (조각③c PO 確定 코멘트) — 응답 본문을 통지 payload에 그대로 실으면 사이트 HTML
+    전문이 딸려 나올 수 있어 여기서 앞부분만 자른다."""
+
+    _BODY_MAX_CHARS = 500
+
+    def __init__(self, *, status_code: int, body: str):
+        self.status_code = status_code
+        self.body = body[: self._BODY_MAX_CHARS]
+        super().__init__(f"webhook 수신측 오류(status={status_code}): {self.body}")
+
+
+def _sign(secret: str, body: bytes) -> str:
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+async def _validate_target(target_url: str) -> str:
+    try:
+        return await assert_destination_url_safe(target_url, allow_loopback=webhook_stub_enabled())
+    except DestinationURLUnsafeError as exc:
+        raise WebhookTargetURLInsecureError(target_url=target_url) from exc
+
+
+def _headers_for(secret: str, body: bytes) -> dict[str, str]:
+    return {
+        _SIGNATURE_HEADER: _sign(secret, body),
+        _TIMESTAMP_HEADER: str(int(time.time())),
+        _NONCE_HEADER: str(uuid.uuid4()),
+        "Content-Type": "application/json",
+    }
+
+
+async def publish(
+    client: httpx.AsyncClient,
+    *,
+    target_url: str,
+    secret: str,
+    title: str,
+    body_md: str,
+    summary: str,
+    tags: list,
+    slug: str,
+    external_id: str | None = None,
+) -> tuple[str, str]:
+    """서명된 POST 1건 — WordPress처럼 "생성/갱신" 구분이 수신측 REST 리소스 개념에
+    안 걸린다(우리가 패키지를 보내고, 수신측이 자기 방식대로 처리한다는 계약). 반환은
+    (external_id, permalink) — 수신측 응답 본문에 `external_id`/`url`이 있으면
+    그대로 쓰고, 없으면 `external_id`는 이 발행이 쓴 `slug`(재발행 식별용 안정 키),
+    `permalink`는 None(수신측이 URL 개념을 안 줄 수도 있다 — 지어내지 않는다)."""
+    base = await _validate_target(target_url)
+    payload = {
+        "event": "publish", "title": title, "body_md": body_md, "summary": summary,
+        "tags": tags, "slug": slug, "external_id": external_id,
+    }
+    body = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    resp = await client.post(base, content=body, headers=_headers_for(secret, body), timeout=20)
+    if resp.status_code // 100 != 2:
+        raise WebhookPublishError(status_code=resp.status_code, body=resp.text)
+    data: dict = {}
+    try:
+        data = resp.json()
+    except ValueError:
+        pass
+    return str(data.get("external_id") or external_id or slug), data.get("url")
+
+
+async def unpublish(
+    client: httpx.AsyncClient, *, target_url: str, secret: str, external_id: str,
+) -> None:
+    """WordPress의 status=draft 전환과 동형 의도(비파괴 회수 신호) — webhook엔 그
+    "상태"를 물을 리소스가 없어 `event: "unpublish"` 신호 POST로 표현한다(수신측이
+    자기 로직으로 해석)."""
+    base = await _validate_target(target_url)
+    payload = {"event": "unpublish", "external_id": external_id}
+    body = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    resp = await client.post(base, content=body, headers=_headers_for(secret, body), timeout=20)
+    if resp.status_code // 100 != 2:
+        raise WebhookPublishError(status_code=resp.status_code, body=resp.text)

--- a/backend/app/services/wordpress_publish.py
+++ b/backend/app/services/wordpress_publish.py
@@ -9,15 +9,14 @@ credential_kind 선언만 하고 이 모듈은 안 다룬다(사람 의존 앱 �
 인증: WordPress 5.6+ Application Password(HTTPS Basic, RFC 7617) — `username`+
 `app_password`를 그대로 `httpx.BasicAuth`에 넘긴다(OAuth 토큰류가 아니라 재사용 가능한
 비밀번호 자체라 refresh 개념이 없다 — connection.refresh_mode="manual"과 부합).
-`site_url`은 HTTPS 강제(스토리 AC2 明示) — http://는 자격이 평문으로 오가므로 호출
-자체를 거부한다(fail-closed). loopback(`http://127.0.0.1`·`http://localhost`) 예외는
-**`WORDPRESS_TEST_STUB_ENABLED` 플래그가 켜졌을 때만** 산다(페드루 리뷰 B1, 2026-09-04)
-— 플래그 무관 예외였던 최초 구현은 SSRF 클래스였다: prod에서 고객(또는 공격자)이
-site_url=`http://127.0.0.1:8080/…`로 연결을 등록하면 워커가 우리 컨테이너의 loopback에
-Basic auth 자격을 실어 진짜로 친다. prod cloudbuild.yaml이 이 플래그 키 자체를 안 실어
-(sandbox_publish.py·dev_wordpress_stub.py와 같은 env 게이트 관례) prod에서는 이 예외가
-기동조차 안 한다 — 조각③c의 dev_wordpress_stub.py(실 uvicorn, TLS 없음)가 유일한
-실사용처.
+`site_url`은 `destination_url_safety.py`(조각④, 공용 SSRF 방지 헬퍼 — webhook_publish.py
+도 같은 헬퍼를 쓴다)로 검증한다: HTTPS 강제 + host를 실제로 DNS 해석해 모든 결과 IP가
+사설/loopback/link-local(클라우드 메타데이터 포함)이 아님을 확인("해석 시점" 검사 —
+문자열 프리픽스만 보던 조각③b/③c 구현은 도메인이 나중에 내부 IP로 rebind되는 공격을
+못 잡았다). loopback(`http://127.0.0.1`·`http://localhost`) 예외는 `WORDPRESS_TEST_
+STUB_ENABLED` 플래그가 켜졌을 때만(페드루 리뷰 B1, 2026-09-04) — prod cloudbuild.yaml
+이 이 키를 안 실어 prod에서는 예외 자체가 죽어 있다. 조각③c의 dev_wordpress_stub.py
+(실 uvicorn, TLS 없음)가 유일한 실사용처.
 
 `tags`는 이번 조각 스코프 밖 — WordPress REST API는 태그를 이름이 아니라 term ID
 배열로 요구해(taxonomy 조회/생성 API 별도 호출 필요) 지금 페이로드엔 안 싣는다
@@ -28,6 +27,8 @@ from __future__ import annotations
 import os
 
 import httpx
+
+from app.services.destination_url_safety import DestinationURLUnsafeError, assert_destination_url_safe
 
 _POSTS_PATH = "/wp-json/wp/v2/posts"
 
@@ -61,20 +62,16 @@ class WordPressPublishError(Exception):
         super().__init__(f"WordPress REST API 오류(status={status_code}): {body}")
 
 
-_LOOPBACK_PREFIXES = ("http://127.0.0.1", "http://localhost")
-
-
-def _validate_https(site_url: str) -> str:
-    if site_url.startswith("https://"):
-        return site_url.rstrip("/")
-    # story e4fc29fa(조각③c, 페드루 리뷰 B1) — loopback 예외는 dev 스텁 플래그가 켜져
-    # 있을 때만. 플래그 없이 통과시키면 prod에서 site_url=http://127.0.0.1:.../로
-    # 등록된 연결이 우리 컨테이너 자신의 loopback에 Basic auth를 실어 진짜로 치는
-    # SSRF가 된다(뮤테이션 대상 — 이 and를 지우면 prod에서도 loopback이 통과해야
-    # 하는데, 실은 통과하면 안 된다는 게 이 가드의 존재 이유).
-    if wordpress_stub_enabled() and site_url.startswith(_LOOPBACK_PREFIXES):
-        return site_url.rstrip("/")
-    raise WordPressSiteURLInsecureError(site_url=site_url)
+async def _validate_https(site_url: str) -> str:
+    """story e4fc29fa(조각④) — 공용 헬퍼(destination_url_safety.py)에 위임하고
+    `DestinationURLUnsafeError`를 이 모듈의 기존 공개 예외(`WordPressSiteURLInsecureError`
+    — 호출자 계약 무변경)로 다시 감싼다. `allow_loopback=wordpress_stub_enabled()` —
+    페드루 리뷰 B1의 플래그 게이트 그대로(뮤테이션 대상: 이 인자를 지우면 prod에서도
+    loopback이 통과해야 하는데, 실은 통과하면 안 된다는 게 이 가드의 존재 이유)."""
+    try:
+        return await assert_destination_url_safe(site_url, allow_loopback=wordpress_stub_enabled())
+    except DestinationURLUnsafeError as exc:
+        raise WordPressSiteURLInsecureError(site_url=site_url) from exc
 
 
 async def publish(
@@ -93,7 +90,7 @@ async def publish(
     갱신(WordPress REST는 갱신도 POST) — hosted_site_publish.publish()의 upsert
     사상과 동형(재발행이 새 글을 또 안 만든다). 반환은 (external_id, permalink) —
     응답 JSON의 `id`(정수, 문자열로 캐스팅)·`link`."""
-    base = _validate_https(site_url)
+    base = await _validate_https(site_url)
     path = f"{_POSTS_PATH}/{external_id}" if external_id else _POSTS_PATH
     payload = {"title": title, "content": body_md, "excerpt": summary, "slug": slug, "status": "publish"}
     resp = await client.post(
@@ -112,7 +109,7 @@ async def unpublish(
     publish.unpublish()가 행을 안 지우고 unpublished_at만 세우는 것과 같은 비파괴
     사상). WordPress가 draft 글도 REST 조회 대상에 남기므로 재발행(publish() 재호출)
     으로 되돌릴 수 있다."""
-    base = _validate_https(site_url)
+    base = await _validate_https(site_url)
     resp = await client.post(
         f"{base}{_POSTS_PATH}/{external_id}",
         json={"status": "draft"},

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -491,6 +491,33 @@ def org_id() -> uuid.UUID:
     return uuid.uuid4()
 
 
+@pytest.fixture
+def dns_stub(monkeypatch):
+    """story e4fc29fa(조각④) — `destination_url_safety.py::assert_destination_url_safe`
+    가 실 `socket.getaddrinfo`로 DNS를 해석한다(SSRF 방지 "해석 시점" 검사) — 그래서
+    이 헬퍼를 쓰는 wordpress/webhook 어댑터 단위 테스트는 가짜 도메인(예:
+    customer-blog.example.com)을 실 네트워크 없이 결정적으로 다뤄야 한다.
+
+    기본은 모든 호스트를 안전한 공인 IP(8.8.8.8 — private/reserved/loopback/link-local
+    전부 아님, Google DNS)로 매핑한다. `dns_stub.map("host", "10.0.0.1")`로 특정
+    호스트만 사설/loopback 등 위험 IP로 오버라이드해 차단 경로를 테스트할 수 있다."""
+    import socket as socket_mod
+
+    mapping: dict[str, str] = {}
+
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        ip = mapping.get(host, "8.8.8.8")
+        return [(socket_mod.AF_INET, socket_mod.SOCK_STREAM, 6, "", (ip, port or 0))]
+
+    monkeypatch.setattr(socket_mod, "getaddrinfo", _fake_getaddrinfo)
+
+    class _DNSStubController:
+        def map(self, host: str, ip: str) -> None:
+            mapping[host] = ip
+
+    return _DNSStubController()
+
+
 def override_db_and_read(app, provider) -> None:
     """story #2451(§6 Phase3): DB 세션 오버라이드 «root fix» — get_db 하나만 걸고
     get_read_db 는 잊는 클래스의 회귀가 A1(사후 12건)·A2(사전 스윕에도 legacy alias

--- a/backend/tests/test_e4fc29fa_destination_axis.py
+++ b/backend/tests/test_e4fc29fa_destination_axis.py
@@ -488,8 +488,19 @@ def test_get_blog_destination_module_wordpress_returns_wordpress_publish():
     )
 
 
-def test_get_blog_destination_module_non_wordpress_not_implemented_yet():
-    """webhook(조각④) 등 wordpress가 아닌 non-null 목적지는 여전히 fail-closed —
+def test_get_blog_destination_module_webhook_returns_webhook_publish():
+    """조각④ — webhook_publish.py 배선(webhook도 wordpress와 나란히 실 구현체가 됐다)."""
+    from app.services import webhook_publish
+    from app.services.blog_destinations import get_blog_destination_module
+
+    assert (
+        get_blog_destination_module(connection_id=uuid.uuid4(), channel="webhook")
+        is webhook_publish
+    )
+
+
+def test_get_blog_destination_module_unknown_channel_not_implemented_yet():
+    """wordpress·webhook 둘 다 아닌(아직 존재하지 않는) 목적지는 여전히 fail-closed —
     뮤테이션 대상: 이 가드를 지우면 존재하지 않는 목적지가 조용히 어떤 모듈로든
     (예: hosted_site) 떨어질 수 있다."""
     from app.services.blog_destinations import (
@@ -498,4 +509,4 @@ def test_get_blog_destination_module_non_wordpress_not_implemented_yet():
     )
 
     with pytest.raises(BlogDestinationNotImplementedError):
-        get_blog_destination_module(connection_id=uuid.uuid4(), channel="webhook")
+        get_blog_destination_module(connection_id=uuid.uuid4(), channel="some-future-channel")

--- a/backend/tests/test_e4fc29fa_destination_url_safety.py
+++ b/backend/tests/test_e4fc29fa_destination_url_safety.py
@@ -1,0 +1,95 @@
+"""story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각④) —
+`destination_url_safety.py`(공용 SSRF 방지 헬퍼, wordpress_publish.py·webhook_publish.py
+공유) 직접 단위 테스트. `dns_stub`(tests/conftest.py)로 실 네트워크 없이 결정적으로
+DNS 해석을 통제한다."""
+from __future__ import annotations
+
+import pytest
+
+from app.services.destination_url_safety import (
+    DestinationURLUnsafeError,
+    assert_destination_url_safe,
+)
+
+
+@pytest.mark.anyio
+async def test_allows_https_url_resolving_to_public_ip(dns_stub):
+    url = await assert_destination_url_safe("https://customer-blog.example.com/")
+    assert url == "https://customer-blog.example.com"
+
+
+@pytest.mark.anyio
+async def test_rejects_http_scheme():
+    with pytest.raises(DestinationURLUnsafeError):
+        await assert_destination_url_safe("http://customer-blog.example.com")
+
+
+@pytest.mark.anyio
+async def test_rejects_domain_resolving_to_private_ip(dns_stub):
+    """DNS rebinding류 — 문자열은 평범한 도메인이어도 해석된 IP가 RFC1918 사설
+    대역이면 거부한다. 뮤테이션 대상: DNS 해석 단계를 지우면(스킴만 검사) RED."""
+    dns_stub.map("attacker.example.com", "10.0.0.5")
+    with pytest.raises(DestinationURLUnsafeError):
+        await assert_destination_url_safe("https://attacker.example.com")
+
+
+@pytest.mark.anyio
+async def test_rejects_domain_resolving_to_loopback(dns_stub):
+    dns_stub.map("attacker.example.com", "127.0.0.1")
+    with pytest.raises(DestinationURLUnsafeError):
+        await assert_destination_url_safe("https://attacker.example.com")
+
+
+@pytest.mark.anyio
+async def test_rejects_domain_resolving_to_link_local_metadata_ip(dns_stub):
+    """169.254.169.254 — GCP/AWS/Azure 클라우드 메타데이터 SSRF 표적. 뮤테이션 대상:
+    link-local 검사를 지우면 이 assert가 RED(메타데이터 자격 탈취 클래스)."""
+    dns_stub.map("attacker.example.com", "169.254.169.254")
+    with pytest.raises(DestinationURLUnsafeError) as exc_info:
+        await assert_destination_url_safe("https://attacker.example.com")
+    assert "link-local" in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_rejects_url_with_no_host():
+    with pytest.raises(DestinationURLUnsafeError):
+        await assert_destination_url_safe("https://")
+
+
+@pytest.mark.anyio
+async def test_rejects_dns_resolution_failure(monkeypatch):
+    """gaierror(NXDOMAIN 등)도 fail-closed — "안전하다고 확인 못 함"을 통과로 지어내지
+    않는다. 실 네트워크에 기대지 않도록 getaddrinfo 자체가 에러를 던지게 스텁한다."""
+    import socket as socket_mod
+
+    def _raise(*args, **kwargs):
+        raise socket_mod.gaierror("Name or service not known")
+
+    monkeypatch.setattr(socket_mod, "getaddrinfo", _raise)
+    with pytest.raises(DestinationURLUnsafeError):
+        await assert_destination_url_safe("https://this-domain-does-not-exist-e4fc29fa.invalid")
+
+
+@pytest.mark.anyio
+async def test_allow_loopback_true_skips_dns_for_loopback_host():
+    """allow_loopback=True(호출자가 자기 dev 스텁 플래그로 이미 게이트)면 http://
+    127.0.0.1·http://localhost는 DNS 해석 없이 통과 — dns_stub 없이도(=진짜 DNS를
+    안 탄다는 증거) 성공해야 한다."""
+    url = await assert_destination_url_safe("http://127.0.0.1:8080/", allow_loopback=True)
+    assert url == "http://127.0.0.1:8080"
+    url2 = await assert_destination_url_safe("http://localhost:8080/", allow_loopback=True)
+    assert url2 == "http://localhost:8080"
+
+
+@pytest.mark.anyio
+async def test_allow_loopback_false_rejects_loopback_scheme():
+    with pytest.raises(DestinationURLUnsafeError):
+        await assert_destination_url_safe("http://127.0.0.1:8080/", allow_loopback=False)
+
+
+@pytest.mark.anyio
+async def test_allow_loopback_true_still_rejects_non_loopback_http():
+    """allow_loopback=True는 loopback host만의 예외다 — 다른 http:// 도메인은 그대로
+    거부(뮤테이션 대상: allow_loopback이 스킴 강제 전체를 무력화하면 RED)."""
+    with pytest.raises(DestinationURLUnsafeError):
+        await assert_destination_url_safe("http://customer-blog.example.com", allow_loopback=True)

--- a/backend/tests/test_e4fc29fa_site_post_orchestration.py
+++ b/backend/tests/test_e4fc29fa_site_post_orchestration.py
@@ -895,13 +895,19 @@ async def test_worker_publish_webhook_replay_rejected_by_live_stub(live_webhook_
         connection_id = uuid.uuid4()
         body = b'{"event":"publish","slug":"replay-test"}'
         secret = stub_test_secret()
-        signature = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        # story e4fc29fa(조각④, 카디르 QA 블로커 2026-09-04) — 서명 대상은 body
+        # 단독이 아니라 timestamp·nonce까지 포함(webhook_publish.py::_signed_payload와
+        # 동일 구성) — 이 값들도 서명 안에 고정해야 재전송 방지가 실제로 성립한다.
+        timestamp = str(int(time.time()))
+        nonce = "fixed-nonce-for-replay-test"
+        signed_payload = f"{timestamp}.{nonce}.".encode() + body
+        signature = "sha256=" + hmac.new(secret.encode(), signed_payload, hashlib.sha256).hexdigest()
         # story e4fc29fa(조각④, 페드루 리뷰 B2) — timestamp 창(300s) 신설 뒤로는 지금
         # 시각이어야 이 재전송 시나리오 자체가 통과선을 넘는다(창 자체는 별도 테스트가
         # 잰다).
         headers = {
-            "X-Sprintable-Signature": signature, "X-Sprintable-Timestamp": str(int(time.time())),
-            "X-Sprintable-Nonce": "fixed-nonce-for-replay-test", "Content-Type": "application/json",
+            "X-Sprintable-Signature": signature, "X-Sprintable-Timestamp": timestamp,
+            "X-Sprintable-Nonce": nonce, "Content-Type": "application/json",
         }
 
         async with httpx.AsyncClient() as client:
@@ -910,6 +916,61 @@ async def test_worker_publish_webhook_replay_rejected_by_live_stub(live_webhook_
             r2 = await client.post(f"{live_webhook_stub}/deliver/{connection_id}", content=body, headers=headers)
             assert r2.status_code == 409, r2.text
             assert r2.json()["detail"]["code"] == "replay_rejected"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_webhook_stub_rejects_same_body_resigned_with_new_timestamp_and_nonce(live_webhook_stub):
+    """카디르 QA 블로커(2026-09-04, PR#3800) — 서명 대상이 body 단독이던 최초 형은
+    가로챈 (body, signature)를 새 timestamp·nonce와 함께 재전송하면 timestamp 창·
+    nonce 저장 둘 다 무력화됐다(새 nonce는 원장에 없어 통과, 새 timestamp는 창
+    안이라 통과). 이 테스트는 그 회귀를 고정한다 — 첫 요청(ts1·nonce1로 정상 서명)은
+    200, 같은 body·같은 signature를 그대로 두고 헤더만 새 ts2·nonce2로 바꿔치기한
+    두 번째 요청은 401(signature_mismatch)이어야 한다(서명이 ts1·nonce1에 고정돼
+    있어 ts2·nonce2로는 검증을 통과할 수 없다 — 위조 불가 증명)."""
+    import hashlib
+    import hmac
+    import time
+
+    import httpx
+
+    from app.routers.dev_webhook_stub import stub_test_secret
+
+    # 이 테스트는 org/story 등을 안 만들지만, `webhook_delivery_nonces` 테이블은
+    # 있어야 한다(test_worker_publish_webhook_replay_rejected_by_live_stub과 동일
+    # 이유 — destructive_schema 마커의 autouse 리셋이 매 테스트 시작 전 스키마를
+    # 통째로 비운다, 테스트는 서로 독립이어야 한다).
+    engine, _Session = await _session_factory()
+    try:
+        connection_id = uuid.uuid4()
+        body = b'{"event":"publish","slug":"forge-attempt-test"}'
+        secret = stub_test_secret()
+        timestamp1 = str(int(time.time()))
+        nonce1 = "nonce-1-original-request"
+        signed_payload1 = f"{timestamp1}.{nonce1}.".encode() + body
+        signature1 = "sha256=" + hmac.new(secret.encode(), signed_payload1, hashlib.sha256).hexdigest()
+        headers1 = {
+            "X-Sprintable-Signature": signature1, "X-Sprintable-Timestamp": timestamp1,
+            "X-Sprintable-Nonce": nonce1, "Content-Type": "application/json",
+        }
+
+        # 공격자 시도 — 가로챈 signature1·body를 그대로 두고, timestamp 창·nonce
+        # 저장을 우회하려고 헤더만 새 값으로 바꿔치기(서명은 재계산 안 함 — 못 한다,
+        # secret을 모른다는 게 이 시나리오의 전제).
+        timestamp2 = str(int(time.time()))
+        nonce2 = "nonce-2-forged-replay-attempt"
+        headers2 = {
+            "X-Sprintable-Signature": signature1, "X-Sprintable-Timestamp": timestamp2,
+            "X-Sprintable-Nonce": nonce2, "Content-Type": "application/json",
+        }
+
+        async with httpx.AsyncClient() as client:
+            r1 = await client.post(f"{live_webhook_stub}/deliver/{connection_id}", content=body, headers=headers1)
+            assert r1.status_code == 200, r1.text
+            r2 = await client.post(f"{live_webhook_stub}/deliver/{connection_id}", content=body, headers=headers2)
+        assert r2.status_code == 401, r2.text
+        assert r2.json()["detail"]["code"] == "signature_mismatch"
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_e4fc29fa_site_post_orchestration.py
+++ b/backend/tests/test_e4fc29fa_site_post_orchestration.py
@@ -880,6 +880,7 @@ async def test_worker_publish_webhook_replay_rejected_by_live_stub(live_webhook_
     2회 POST해 409를 증명한다(발신측 재시도 로직과 무관하게 스텁 자신의 방어를 잰다)."""
     import hashlib
     import hmac
+    import time
 
     import httpx
 
@@ -895,8 +896,11 @@ async def test_worker_publish_webhook_replay_rejected_by_live_stub(live_webhook_
         body = b'{"event":"publish","slug":"replay-test"}'
         secret = stub_test_secret()
         signature = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        # story e4fc29fa(조각④, 페드루 리뷰 B2) — timestamp 창(300s) 신설 뒤로는 지금
+        # 시각이어야 이 재전송 시나리오 자체가 통과선을 넘는다(창 자체는 별도 테스트가
+        # 잰다).
         headers = {
-            "X-Sprintable-Signature": signature, "X-Sprintable-Timestamp": "1700000000",
+            "X-Sprintable-Signature": signature, "X-Sprintable-Timestamp": str(int(time.time())),
             "X-Sprintable-Nonce": "fixed-nonce-for-replay-test", "Content-Type": "application/json",
         }
 
@@ -908,3 +912,32 @@ async def test_worker_publish_webhook_replay_rejected_by_live_stub(live_webhook_
             assert r2.json()["detail"]["code"] == "replay_rejected"
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_webhook_stub_rejects_timestamp_outside_window(live_webhook_stub):
+    """story e4fc29fa(조각④, 페드루 리뷰 B2) — 정본 §4 "timestamp 창" 明示. 서명
+    자체는 유효해도 timestamp가 지금과 300s 넘게 벌어져 있으면 401(timestamp_out_of_
+    window)로 거부한다. 뮤테이션 대상: 이 창 검사를 지우면(존재만 확인하던 이전
+    구현) 유출된 서명된 요청이 시간 무관하게 영원히 재생 가능해진다."""
+    import hashlib
+    import hmac
+
+    import httpx
+
+    from app.routers.dev_webhook_stub import stub_test_secret
+
+    connection_id = uuid.uuid4()
+    body = b'{"event":"publish","slug":"stale-timestamp-test"}'
+    secret = stub_test_secret()
+    signature = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    stale_timestamp = "1700000000"  # 2023년 — 지금 시각과 300s를 훌쩍 넘게 벌어져 있다.
+    headers = {
+        "X-Sprintable-Signature": signature, "X-Sprintable-Timestamp": stale_timestamp,
+        "X-Sprintable-Nonce": "nonce-for-stale-timestamp-test", "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient() as client:
+        r = await client.post(f"{live_webhook_stub}/deliver/{connection_id}", content=body, headers=headers)
+    assert r.status_code == 401, r.text
+    assert r.json()["detail"]["code"] == "timestamp_out_of_window"

--- a/backend/tests/test_e4fc29fa_site_post_orchestration.py
+++ b/backend/tests/test_e4fc29fa_site_post_orchestration.py
@@ -6,9 +6,11 @@
 이 파일의 승인 경로는 cfc1a55a(#3443) 선례와 동형으로 `gate_service.py::
 transition_gate()`를 직접 호출한다(`_approve_gate_directly` 우회는 훅을 안 태운다).
 
-AC7 "실왕복" — `httpx.MockTransport`가 아니라 `dev_wordpress_stub.py`를 실 uvicorn
-서버로 띄워(진짜 소켓) `wordpress_publish.py`가 그 서버에 진짜 HTTP를 치는지 증명한다
-(페드루 明示 — MockTransport는 AC7이 아니다)."""
+AC7 "실왕복" — `httpx.MockTransport`가 아니라 `dev_wordpress_stub.py`/`dev_webhook_
+stub.py`를 실 uvicorn 서버로 띄워(진짜 소켓) 각 publish 모듈이 그 서버에 진짜 HTTP를
+치는지 증명한다(페드루 明示 — MockTransport는 AC7이 아니다). webhook 쪽은 스텁 자신이
+서명을 실제로 재계산해 검증하고 nonce를 실 DB에 남긴다(AC4 明示, wordpress 스텁의
+"헤더 존재만 확인"보다 한 단계 더)."""
 from __future__ import annotations
 
 import asyncio
@@ -102,6 +104,82 @@ async def live_wordpress_stub(monkeypatch):
         _POSTS.clear()
 
 
+@pytest.fixture
+async def live_webhook_stub(monkeypatch):
+    """`dev_webhook_stub.py`를 실 uvicorn 서버(백그라운드 스레드)로 띄운다 —
+    `live_wordpress_stub`과 같은 사상이지만 이 스텁은 서명 검증·nonce 재전송 거부에
+    실 DB가 필요하다(AC4 明示 — wordpress 스텁의 "헤더 존재만 확인"보다 한 단계 더).
+    스텁 전용 SQLAlchemy 엔진을 **스레드 안에서** 만든다 — async 엔진/커넥션은
+    이벤트루프에 묶여(asyncpg) 테스트 메인 루프와 공유하면 위험하다. 같은 Postgres
+    DB(같은 `_REAL_DB_URL`)를 가리키므로 스텁이 쓴 nonce 행을 테스트 쪽 별도 세션으로
+    그대로 읽을 수 있다."""
+    import threading
+
+    import uvicorn
+    from fastapi import FastAPI
+
+    monkeypatch.setenv("WEBHOOK_TEST_STUB_ENABLED", "true")
+
+    server_holder: dict[str, "uvicorn.Server"] = {}
+    port_holder: dict[str, int] = {}
+    error_holder: dict[str, BaseException] = {}
+
+    def _run() -> None:
+        async def _serve() -> None:
+            from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+            from app.dependencies.database import get_db
+            from app.routers.dev_webhook_stub import router as stub_router
+
+            engine = create_async_engine(_async_url())
+            Session = async_sessionmaker(engine, expire_on_commit=False)
+
+            async def _db():
+                async with Session() as s:
+                    try:
+                        yield s
+                        await s.commit()
+                    except Exception:
+                        await s.rollback()
+                        raise
+
+            stub_app = FastAPI()
+            stub_app.include_router(stub_router)
+            stub_app.dependency_overrides[get_db] = _db
+
+            config = uvicorn.Config(stub_app, host="127.0.0.1", port=0, log_level="warning")
+            server = uvicorn.Server(config)
+            server_holder["server"] = server
+            try:
+                await server.serve()
+            finally:
+                await engine.dispose()
+
+        try:
+            asyncio.run(_serve())
+        except BaseException as exc:  # noqa: BLE001 — 메인 스레드로 기동 실패를 전달.
+            error_holder["error"] = exc
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    for _ in range(500):
+        if "error" in error_holder:
+            raise error_holder["error"]
+        server = server_holder.get("server")
+        if server is not None and server.started:
+            port_holder["port"] = server.servers[0].sockets[0].getsockname()[1]
+            break
+        await asyncio.sleep(0.01)
+    else:
+        raise RuntimeError("dev_webhook_stub 라이브 서버가 기동하지 않았습니다")
+
+    try:
+        yield f"http://127.0.0.1:{port_holder['port']}/api/dev/webhook-stub"
+    finally:
+        server_holder["server"].should_exit = True
+        thread.join(timeout=5)
+
+
 def _async_url() -> str:
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
@@ -187,6 +265,28 @@ async def _seed_wordpress_connection(session, org_id, *, site_url, username="edi
         id=uuid.uuid4(), org_id=org_id, channel="wordpress", account_id=site_url, account_label=username,
         status="active", credential_kind="pasted_secret", refresh_mode="manual",
         encrypted_access_token=encrypt_channel_credential(app_password),
+    )
+    session.add(conn)
+    await session.commit()
+    return conn.id
+
+
+async def _seed_webhook_connection(session, org_id, *, target_url_builder, secret=None):
+    """story e4fc29fa(조각④) — `dev_webhook_stub.py`가 URL 경로(`/deliver/{connection_id}`)
+    로 발신 connection을 식별하므로, 이 connection의 `id`를 먼저 확정한 뒤 그 id를
+    담은 target_url을 조립해야 한다(`target_url_builder(connection_id) -> str`).
+    secret 기본값은 `dev_webhook_stub.py::_DEFAULT_TEST_SECRET`과 동일(스텁이 검증할
+    수 있는 유일한 값)."""
+    from app.models.channel_connection import ChannelConnection
+    from app.routers.dev_webhook_stub import stub_test_secret
+    from app.services.channel_credential_crypto import encrypt_channel_credential
+
+    conn_id = uuid.uuid4()
+    target_url = target_url_builder(conn_id)
+    conn = ChannelConnection(
+        id=conn_id, org_id=org_id, channel="webhook", account_id=target_url,
+        status="active", credential_kind="pasted_secret", refresh_mode="manual",
+        encrypted_access_token=encrypt_channel_credential(secret or stub_test_secret()),
     )
     session.add(conn)
     await session.commit()
@@ -654,4 +754,157 @@ async def test_worker_unpublish_first_draft_same_connection_does_not_touch_secon
         assert pub_b.status == "published"  # 양성대조 — B는 A 회수에 건드려지지 않는다.
     finally:
         app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_worker_publishes_webhook_site_post_command_against_live_stub(live_webhook_stub):
+    """story e4fc29fa(조각④) AC7 실왕복 — 승인이 만든 site_post 커맨드를 워커가
+    처리하면 webhook_publish.publish()가 실 uvicorn 서버(dev_webhook_stub)에 서명된
+    POST를 진짜로 치고, 스텁이 서명을 실제로 검증한 뒤(진짜 DB로) 응답한 external_id
+    가 channel_publications에 그대로 기록된다."""
+    from app.services.gate_service import transition_gate
+    from app.services.publication_command import process_due_publication_commands
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_webhook_connection(
+                s, org_id, target_url_builder=lambda cid: f"{live_webhook_stub}/deliver/{cid}",
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_id, gate_id = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+            )
+
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_id, "approved", resolver_id=human_id)
+            await s.commit()
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        async with Session() as s:
+            from app.models.channel_publication import ChannelPublication
+            from sqlalchemy import select
+
+            pub = (await s.execute(
+                select(ChannelPublication).where(ChannelPublication.gate_id == gate_id)
+            )).scalar_one()
+            assert pub.status == "published"
+            assert pub.external_id is not None
+            assert pub.external_id.startswith("webhook-")
+            assert pub.connection_id == connection_id
+            assert pub.channel == "webhook"
+
+            from app.models.webhook_delivery_nonce import WebhookDeliveryNonce
+
+            nonce_rows = (await s.execute(
+                select(WebhookDeliveryNonce).where(WebhookDeliveryNonce.connection_id == connection_id)
+            )).scalars().all()
+            assert len(nonce_rows) == 1, "스텁이 서명 검증을 통과한 뒤 nonce를 실제로 기록해야 한다"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_worker_publish_webhook_wrong_secret_is_rejected_by_live_stub(live_webhook_stub):
+    """story e4fc29fa(조각④) — 스텁의 서명 검증이 「진짜」임을 증명: 다른 비밀로 서명된
+    요청은 401로 거부되고, 워커는 이를 CHANNEL_PUBLISH_AUTH_REJECTED(connection kind)
+    로 분류해 즉시 blocked로 보낸다(잘못된 자격은 백오프 재시도로 못 고친다 — 사람의
+    재연결이 필요하다는 뜻, site_posts.py::_blog_publish_error_code). 뮤테이션 대상:
+    스텁이 서명을 실제로 검증하지 않으면(존재만 확인) 이 테스트가 실패를 못 만들어
+    RED가 안 된다."""
+    from app.services.gate_service import transition_gate
+    from app.services.publication_command import process_due_publication_commands
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_webhook_connection(
+                s, org_id, target_url_builder=lambda cid: f"{live_webhook_stub}/deliver/{cid}",
+                secret="wrong-secret-not-matching-stub",
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_id, gate_id = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+            )
+
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_id, "approved", resolver_id=human_id)
+            await s.commit()
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["blocked"] == 1, counts
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+
+            cmd = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.gate_id == gate_id)
+            )).scalar_one()
+            assert cmd.status == "blocked"
+            assert cmd.failure_kind == "connection"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_worker_publish_webhook_replay_rejected_by_live_stub(live_webhook_stub):
+    """story e4fc29fa(조각④) AC3 — 재전송(같은 nonce) 거부를 증명: 같은 승인 커맨드를
+    워커가 두 번 실행하면(정상 운영에선 안 나는 상황이지만, 스텁의 재전송 방어 자체를
+    직접 검증하려고 커맨드를 강제로 pending에 되돌려 재실행) 두 번째 시도는 스텁이
+    새 nonce를 발급해 보내므로(webhook_publish.py가 매 호출마다 uuid4 nonce를 새로
+    만든다) 사실 이 경로로는 재전송을 재현 못 한다 — 대신 스텁에 같은 nonce로 직접
+    2회 POST해 409를 증명한다(발신측 재시도 로직과 무관하게 스텁 자신의 방어를 잰다)."""
+    import hashlib
+    import hmac
+
+    import httpx
+
+    from app.routers.dev_webhook_stub import stub_test_secret
+
+    # 이 테스트는 org/story 등을 안 만들지만, `webhook_delivery_nonces` 테이블은
+    # 있어야 한다 — destructive_schema 마커의 autouse 리셋(tests/conftest.py)이 매
+    # 테스트 시작 전 스키마를 통째로 비우므로, 이 파일의 다른 테스트가 먼저 스키마를
+    # 만들어 뒀다는 보장이 없다(테스트는 서로 독립이어야 한다).
+    engine, _Session = await _session_factory()
+    try:
+        connection_id = uuid.uuid4()
+        body = b'{"event":"publish","slug":"replay-test"}'
+        secret = stub_test_secret()
+        signature = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        headers = {
+            "X-Sprintable-Signature": signature, "X-Sprintable-Timestamp": "1700000000",
+            "X-Sprintable-Nonce": "fixed-nonce-for-replay-test", "Content-Type": "application/json",
+        }
+
+        async with httpx.AsyncClient() as client:
+            r1 = await client.post(f"{live_webhook_stub}/deliver/{connection_id}", content=body, headers=headers)
+            assert r1.status_code == 200, r1.text
+            r2 = await client.post(f"{live_webhook_stub}/deliver/{connection_id}", content=body, headers=headers)
+            assert r2.status_code == 409, r2.text
+            assert r2.json()["detail"]["code"] == "replay_rejected"
+    finally:
         await engine.dispose()

--- a/backend/tests/test_e4fc29fa_site_post_orchestration.py
+++ b/backend/tests/test_e4fc29fa_site_post_orchestration.py
@@ -128,8 +128,8 @@ async def live_webhook_stub(monkeypatch):
         async def _serve() -> None:
             from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-            from app.dependencies.database import get_db
             from app.routers.dev_webhook_stub import router as stub_router
+            from tests.conftest import override_db_and_read
 
             engine = create_async_engine(_async_url())
             Session = async_sessionmaker(engine, expire_on_commit=False)
@@ -145,7 +145,7 @@ async def live_webhook_stub(monkeypatch):
 
             stub_app = FastAPI()
             stub_app.include_router(stub_router)
-            stub_app.dependency_overrides[get_db] = _db
+            override_db_and_read(stub_app, _db)
 
             config = uvicorn.Config(stub_app, host="127.0.0.1", port=0, log_level="warning")
             server = uvicorn.Server(config)

--- a/backend/tests/test_e4fc29fa_webhook_publish_adapter.py
+++ b/backend/tests/test_e4fc29fa_webhook_publish_adapter.py
@@ -57,7 +57,10 @@ async def test_publish_sends_signed_request_with_three_headers(dns_stub):
     assert captured["timestamp"] is not None and captured["timestamp"].isdigit()
     assert captured["nonce"] is not None
 
-    expected_sig = "sha256=" + hmac.new(b"shared-secret", captured["body"], hashlib.sha256).hexdigest()
+    # 카디르 QA 블로커(2026-09-04, 정본 §4 재확定) — 서명 대상은 body 단독이 아니라
+    # timestamp·nonce까지 포함(webhook_publish.py::_signed_payload와 동일 구성).
+    signed_payload = f"{captured['timestamp']}.{captured['nonce']}.".encode() + captured["body"]
+    expected_sig = "sha256=" + hmac.new(b"shared-secret", signed_payload, hashlib.sha256).hexdigest()
     assert captured["signature"] == expected_sig
 
     body_json = json.loads(captured["body"])

--- a/backend/tests/test_e4fc29fa_webhook_publish_adapter.py
+++ b/backend/tests/test_e4fc29fa_webhook_publish_adapter.py
@@ -1,0 +1,167 @@
+"""story e4fc29fa(Phase1·마케팅운영, 페드루 PO 確定 2026-09-04, 조각④) —
+`webhook_publish.py`(BlogDestinationAdapter 3호 구현체) 직접 단위 테스트.
+
+DB 불요 — `httpx.MockTransport`로 수신측 응답을 흉내낸다. https:// 경로는 `dns_stub`
+(tests/conftest.py)로 실 DNS 없이 결정적으로 통제한다(destination_url_safety.py가
+실 DNS 해석을 하므로)."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import httpx
+import pytest
+
+from app.services.webhook_publish import (
+    WebhookPublishError,
+    WebhookTargetURLInsecureError,
+    publish,
+    unpublish,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.anyio
+async def test_publish_sends_signed_request_with_three_headers(dns_stub):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["signature"] = request.headers.get("x-sprintable-signature")
+        captured["timestamp"] = request.headers.get("x-sprintable-timestamp")
+        captured["nonce"] = request.headers.get("x-sprintable-nonce")
+        captured["body"] = request.content
+        return httpx.Response(200, json={"external_id": "wh-1", "url": "https://customer.example.com/posts/1"})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        external_id, permalink = await publish(
+            client, target_url="https://customer-target.example.com/hook", secret="shared-secret",
+            title="제목", body_md="본문", summary="요약", tags=["a"], slug="my-slug",
+        )
+
+    assert external_id == "wh-1"
+    assert permalink == "https://customer.example.com/posts/1"
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://customer-target.example.com/hook"
+    assert captured["signature"] is not None and captured["signature"].startswith("sha256=")
+    assert captured["timestamp"] is not None and captured["timestamp"].isdigit()
+    assert captured["nonce"] is not None
+
+    expected_sig = "sha256=" + hmac.new(b"shared-secret", captured["body"], hashlib.sha256).hexdigest()
+    assert captured["signature"] == expected_sig
+
+    body_json = json.loads(captured["body"])
+    assert body_json["event"] == "publish"
+    assert body_json["title"] == "제목"
+    assert body_json["slug"] == "my-slug"
+
+
+@pytest.mark.anyio
+async def test_publish_falls_back_to_slug_when_response_has_no_external_id(dns_stub):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        external_id, permalink = await publish(
+            client, target_url="https://customer-target.example.com/hook", secret="s",
+            title="t", body_md="b", summary="s", tags=[], slug="fallback-slug",
+        )
+    assert external_id == "fallback-slug"
+    assert permalink is None
+
+
+@pytest.mark.anyio
+async def test_publish_non_2xx_raises_webhook_publish_error(dns_stub):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="upstream error")
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        with pytest.raises(WebhookPublishError) as exc_info:
+            await publish(
+                client, target_url="https://customer-target.example.com/hook", secret="s",
+                title="t", body_md="b", summary="s", tags=[], slug="slug",
+            )
+    assert exc_info.value.status_code == 500
+
+
+@pytest.mark.anyio
+async def test_publish_error_body_is_truncated(dns_stub):
+    """페드루 기록(③c PO 確定) — 응답 본문이 통지 payload에 그대로 실리면 사이트
+    HTML 전문이 딸려 나올 수 있어 앞부분만 자른다. 뮤테이션 대상: 컷을 지우면 이
+    assert가 RED(과도하게 긴 body)."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="x" * 5000)
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        with pytest.raises(WebhookPublishError) as exc_info:
+            await publish(
+                client, target_url="https://customer-target.example.com/hook", secret="s",
+                title="t", body_md="b", summary="s", tags=[], slug="slug",
+            )
+    assert len(exc_info.value.body) <= 500
+
+
+@pytest.mark.anyio
+async def test_publish_rejects_http_scheme(dns_stub):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("HTTPS 미강제 — http://로 실제 요청이 나갔다")
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        with pytest.raises(WebhookTargetURLInsecureError):
+            await publish(
+                client, target_url="http://customer-target.example.com/hook", secret="s",
+                title="t", body_md="b", summary="s", tags=[], slug="slug",
+            )
+
+
+@pytest.mark.anyio
+async def test_publish_rejects_domain_resolving_to_private_ip(dns_stub):
+    dns_stub.map("attacker.example.com", "10.0.0.5")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("사설 IP로 해석되는 도메인인데 실제 요청이 나갔다")
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        with pytest.raises(WebhookTargetURLInsecureError):
+            await publish(
+                client, target_url="https://attacker.example.com/hook", secret="s",
+                title="t", body_md="b", summary="s", tags=[], slug="slug",
+            )
+
+
+@pytest.mark.anyio
+async def test_unpublish_sends_unpublish_event(dns_stub):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        await unpublish(
+            client, target_url="https://customer-target.example.com/hook", secret="s", external_id="wh-1",
+        )
+    assert captured["body"] == {"event": "unpublish", "external_id": "wh-1"}
+
+
+@pytest.mark.anyio
+async def test_unpublish_non_2xx_raises(dns_stub):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="unavailable")
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        with pytest.raises(WebhookPublishError) as exc_info:
+            await unpublish(
+                client, target_url="https://customer-target.example.com/hook", secret="s", external_id="wh-1",
+            )
+    assert exc_info.value.status_code == 503

--- a/backend/tests/test_e4fc29fa_wordpress_publish_adapter.py
+++ b/backend/tests/test_e4fc29fa_wordpress_publish_adapter.py
@@ -2,7 +2,11 @@
 `wordpress_publish.py`(BlogDestinationAdapter 2호 구현체) 직접 단위 테스트.
 
 DB 불요(모듈 자체가 순수 httpx 클라이언트 — hosted_site_publish.py와 달리 site_posts
-테이블에 안 쓴다) — `httpx.MockTransport`로 WordPress REST API 응답을 흉내낸다."""
+테이블에 안 쓴다) — `httpx.MockTransport`로 WordPress REST API 응답을 흉내낸다.
+
+story e4fc29fa(조각④) — `_validate_https`가 이제 destination_url_safety.py로 실
+DNS 해석까지 한다(SSRF 「해석 시점」검사) — https:// 경로를 타는 테스트는 `dns_stub`
+(tests/conftest.py, socket.getaddrinfo 결정적 스텁)이 필요하다."""
 from __future__ import annotations
 
 import json
@@ -28,7 +32,7 @@ def _transport(handler):
 
 
 @pytest.mark.anyio
-async def test_publish_creates_post_returns_external_id_and_permalink():
+async def test_publish_creates_post_returns_external_id_and_permalink(dns_stub):
     captured = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -56,7 +60,7 @@ async def test_publish_creates_post_returns_external_id_and_permalink():
 
 
 @pytest.mark.anyio
-async def test_publish_with_external_id_updates_existing_post():
+async def test_publish_with_external_id_updates_existing_post(dns_stub):
     captured = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -75,7 +79,7 @@ async def test_publish_with_external_id_updates_existing_post():
 
 
 @pytest.mark.anyio
-async def test_publish_non_2xx_raises_wordpress_publish_error():
+async def test_publish_non_2xx_raises_wordpress_publish_error(dns_stub):
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(401, text='{"code":"rest_cannot_create","message":"Sorry, you are not allowed."}')
 
@@ -144,7 +148,7 @@ async def test_publish_rejects_loopback_http_site_url_when_stub_flag_off(monkeyp
 
 
 @pytest.mark.anyio
-async def test_unpublish_sets_status_draft():
+async def test_unpublish_sets_status_draft(dns_stub):
     captured = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -163,7 +167,26 @@ async def test_unpublish_sets_status_draft():
 
 
 @pytest.mark.anyio
-async def test_unpublish_non_2xx_raises():
+async def test_publish_rejects_domain_that_resolves_to_private_ip(dns_stub):
+    """story e4fc29fa(조각④) — DNS rebinding류 SSRF: 문자열은 https://평범한-도메인
+    이어도 실제 해석된 IP가 사설 대역이면 거부한다("해석 시점" 검사, 문자열 프리픽스
+    검사만으론 이걸 못 잡는다). 뮤테이션 대상: destination_url_safety.py의 DNS 해석
+    단계를 지우면(스킴만 검사) 이 assert가 RED."""
+    dns_stub.map("attacker-controlled.example.com", "10.0.0.5")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("사설 IP로 해석되는 도메인인데 실제 요청이 나갔다")
+
+    async with httpx.AsyncClient(transport=_transport(handler)) as client:
+        with pytest.raises(WordPressSiteURLInsecureError):
+            await publish(
+                client, site_url="https://attacker-controlled.example.com", username="editor",
+                app_password="pw", title="제목", body_md="본문", summary="요약", slug="slug",
+            )
+
+
+@pytest.mark.anyio
+async def test_unpublish_non_2xx_raises(dns_stub):
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500, text="internal error")
 

--- a/backend/tests/test_f30da19a_available_channels.py
+++ b/backend/tests/test_f30da19a_available_channels.py
@@ -131,6 +131,15 @@ async def test_sandbox_absent_when_flag_off():
         # credential_kind="none"만 보고 「샌드박스 연결 만들기」를 잘못 탄다. 뮤테이션
         # 대상: 필터를 지우면 이 assert가 RED.
         assert "hosted_site" not in channels
+
+        # story e4fc29fa(조각③b·④) — wordpress·webhook 둘 다 blog kind·pasted_secret로
+        # 나타난다(requires_connection 기본값 True라 hosted_site와 달리 이 목록에 있다).
+        wordpress_row = next(row for row in rows if row["channel"] == "wordpress")
+        assert wordpress_row["kind"] == "blog"
+        assert wordpress_row["credential_kind"] == "pasted_secret"
+        webhook_row = next(row for row in rows if row["channel"] == "webhook")
+        assert webhook_row["kind"] == "blog"
+        assert webhook_row["credential_kind"] == "pasted_secret"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()


### PR DESCRIPTION
## 요약
- **Part A** — `destination_url_safety.py`(신규, wordpress·webhook 공유): 목적지 URL을 「해석 시점(DNS 결과 포함)」에 검증(HTTPS 강제+사설/loopback/link-local·클라우드 메타데이터 169.254.169.254 차단). `wordpress_publish.py` 소급 적용(문자열 프리픽스만 보던 조각③b/③c 구현이 DNS rebinding류를 못 잡던 갭 해소).
- **Part B** — `webhook_publish.py`(신규, BlogDestinationAdapter 3호): HMAC-SHA256 서명(3헤더: Signature/Timestamp/Nonce, 정본 §4 확定 그대로) + `webhook_delivery_nonces`(신규 테이블) 재전송 방지 + `dev_webhook_stub.py`(신규, 실 서명 검증+DB 기반 nonce 거부).

## 그라운딩 중 발견·즉시수정
401/403(잘못된 자격)이 기존엔 `CHANNEL_PUBLISH_PROVIDER_ERROR`(transient)로 오분류돼 안 고쳐지는 자격으로 무한 백오프만 반복했습니다 — webhook 라이브 테스트가 실제로 이 경로를 잡았습니다. `CHANNEL_PUBLISH_AUTH_REJECTED`(connection kind, 즉시 blocked) 신설, `site_posts.py::_blog_publish_error_code`가 status_code로 분기 — wordpress 경로도 소급 수혜.

## 베이스
`feature/e4fc29fa-piece3c-orchestration`(PR#3797, 스택) 위 — 조각①②③a③b③c가 모두 이미 merge되어 있어 diff는 이 조각의 신규 커밋 2개만 보입니다.

## 테스트
- `destination_url_safety.py` 단위 10건(허용·스킴 거부·사설/loopback/link-local 거부·DNS 실패·loopback 플래그 분기).
- `webhook_publish.py` 단위 8건(서명 검증·헤더 3종·본문 컷·HTTPS 강제·rebinding 거부·unpublish).
- 오케스트레이션 신규 3건 — 실 uvicorn 왕복 완주(스텁 자신의 DB 기반 서명검증까지) · 잘못된 비밀 401→blocked · 재전송 409.
- 회귀 185건 전량 green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>