### PR TITLE
[SID:3436] fix: 전역 셸 접근 이름 5건 하드코딩 영문 → i18n(묶음 1)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -98,6 +98,7 @@
     "search": "Search…",
     "help": "Help",
     "openGlobalNav": "Open menu",
+    "toggleSidebar": "Toggle sidebar",
     "chats": "Chats",
     "activity": "Activity Log",
     "goals": "Goals",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -98,6 +98,7 @@
     "search": "검색…",
     "help": "도움말",
     "openGlobalNav": "전체 메뉴 열기",
+    "toggleSidebar": "사이드바 접기·펼치기",
     "chats": "채팅",
     "activity": "활동 로그",
     "goals": "목표",

--- a/apps/web/src/components/chat/embed-card.link-states.test.tsx
+++ b/apps/web/src/components/chat/embed-card.link-states.test.tsx
@@ -13,13 +13,24 @@ import { NextIntlClientProvider } from 'next-intl';
 import { EmbedCard, getEntityHref } from './embed-card';
 import { translateEntityStatus } from './entity-status-labels';
 // story #2614 — artifact 몸통이 이제 ArtifactThumbnail(canvas 네임스페이스 useTranslations)을
-// 렌더하므로, 그 경로를 태우는 테스트만 NextIntlClientProvider로 감싼다(다른 기존 테스트는
-// i18n을 안 타 무변경).
+// 렌더한다.
+// story 3436(묶음 1, 2026-09-04) — EmbedCard가 내부적으로 항상 마운트하는 Dialog가 이제
+// DialogContent에서 useTranslations('common')을 쓴다(base-ui Dialog.Popup은 닫힌
+// 상태에서도 렌더 함수 자체는 돈다) — 그래서 이제 EmbedCard를 렌더하는 모든 테스트가
+// NextIntlClientProvider를 필요로 한다(예전엔 ArtifactThumbnail 경로만 필요했다).
 import koMessages from '../../../messages/ko.json';
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
 
 let container: HTMLDivElement;
 let root: Root;
@@ -69,7 +80,7 @@ describe('story #2642 — own-href(story/epic/asset)도 크로스프로젝트 �
   it('story — org_slug/project_slug가 실려 오면 뷰어 현재 프로젝트 대신 그 project로 직행한다', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: { org_slug: 'acme', project_slug: 'content' } }) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="story" entity_id="s-cross" title="스토리 X" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="story" entity_id="s-cross" title="스토리 X" status={null} />));
     });
     await openCard();
     await flush();
@@ -82,7 +93,7 @@ describe('story #2642 — own-href(story/epic/asset)도 크로스프로젝트 �
   it('story — fetch 실패/미도착 시 기존 bare href로 우아하게 폴백한다(회귀 아님)', async () => {
     stubFetch(async () => ({ ok: false, json: async () => ({}) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="story" entity_id="s-fail" title="스토리 Y" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="story" entity_id="s-fail" title="스토리 Y" status={null} />));
     });
     await openCard();
     await flush();
@@ -92,7 +103,7 @@ describe('story #2642 — own-href(story/epic/asset)도 크로스프로젝트 �
   it('epic — org_slug/project_slug가 실려 오면 그 project의 /goals/{id}로 직행한다', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: { org_slug: 'acme', project_slug: 'content' } }) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="epic" entity_id="e-cross" title="에픽 X" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="epic" entity_id="e-cross" title="에픽 X" status={null} />));
     });
     await openCard();
     await flush();
@@ -103,7 +114,7 @@ describe('story #2642 — own-href(story/epic/asset)도 크로스프로젝트 �
   it('asset — org_slug/project_slug가 실려 오면 그 project의 storage로 직행한다', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: { org_slug: 'acme', project_slug: 'content' } }) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="asset" entity_id="ast-cross" title="자산 X" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="asset" entity_id="ast-cross" title="자산 X" status={null} />));
     });
     await openCard();
     await flush();
@@ -114,7 +125,7 @@ describe('story #2642 — own-href(story/epic/asset)도 크로스프로젝트 �
   it('asset — org-level asset(project_id null→project_slug null)은 bare href로 폴백한다(④ 원칙, org-level은 project 스코프가 없다)', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: { org_slug: 'acme', project_slug: null } }) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="asset" entity_id="ast-org" title="자산 Y" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="asset" entity_id="ast-org" title="자산 Y" status={null} />));
     });
     await openCard();
     await flush();
@@ -129,7 +140,7 @@ describe('AC3/AC4 — task는 부모 story로("담긴 곳으로 갑니다")', ()
       return { ok: true, json: async () => ({ data: { story_id: 's-parent-1' } }) };
     });
     await act(async () => {
-      root.render(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status={null} />));
     });
     await openCard();
     await flush();
@@ -146,7 +157,7 @@ describe('AC3/AC4 — task는 부모 story로("담긴 곳으로 갑니다")', ()
       json: async () => ({ data: { story_id: 's-parent-2', org_slug: 'acme', project_slug: 'content' } }),
     }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="task" entity_id="t2" title="작업 B" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="task" entity_id="t2" title="작업 B" status={null} />));
     });
     await openCard();
     await flush();
@@ -179,7 +190,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
       json: async () => ({ data: { story_id: 's-1', epic_id: null, doc_id: null } }),
     }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="artifact" entity_id="a1" title="목업 A" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="artifact" entity_id="a1" title="목업 A" status={null} />));
     });
     await openCard();
     await flush();
@@ -200,7 +211,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
       return { ok: true, json: async () => ({ data: { story_id: null, epic_id: null, doc_id: null } }) };
     }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="artifact" entity_id="a-cross" title="크로스 목업" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="artifact" entity_id="a-cross" title="크로스 목업" status={null} />));
     });
     await openCard();
     await flush();
@@ -216,7 +227,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
       json: async () => ({ data: { story_id: null, epic_id: 'e-9', doc_id: null } }),
     }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="artifact" entity_id="a2" title="목업 B" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="artifact" entity_id="a2" title="목업 B" status={null} />));
     });
     await openCard();
     await flush();
@@ -231,7 +242,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
       json: async () => ({ data: { story_id: 's-1', epic_id: null, doc_id: null, org_slug: 'acme', project_slug: 'content' } }),
     }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="artifact" entity_id="a6" title="목업 E" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="artifact" entity_id="a6" title="목업 E" status={null} />));
     });
     await openCard();
     await flush();
@@ -245,7 +256,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
       json: async () => ({ data: { story_id: null, epic_id: 'e-9', doc_id: null, org_slug: 'acme', project_slug: 'content' } }),
     }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="artifact" entity_id="a7" title="목업 F" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="artifact" entity_id="a7" title="목업 F" status={null} />));
     });
     await openCard();
     await flush();
@@ -274,7 +285,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
       return { ok: false, json: async () => ({}) };
     });
     await act(async () => {
-      root.render(<EmbedCard entity_type="artifact" entity_id="a4" title="목업 C" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="artifact" entity_id="a4" title="목업 C" status={null} />));
     });
     await openCard();
     await flush(8);
@@ -298,7 +309,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
       return { ok: false, json: async () => ({}) }; // /api/docs/preview 도 이걸로 실패.
     });
     await act(async () => {
-      root.render(<EmbedCard entity_type="artifact" entity_id="a5" title="목업 D" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="artifact" entity_id="a5" title="목업 D" status={null} />));
     });
     await openCard();
     await flush(8);
@@ -313,7 +324,7 @@ describe('AC3/AC4 — artifact는 레코드마다 갈린다(FK 있으면 ②, �
       json: async () => ({ data: { story_id: null, epic_id: null, doc_id: null } }),
     }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="artifact" entity_id="a3" title="독립 목업" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="artifact" entity_id="a3" title="독립 목업" status={null} />));
     });
     await openCard();
     await flush();
@@ -330,7 +341,7 @@ describe('story #2614 — hypothesis는 풋터(담긴 곳)는 여전히 없지�
       return { ok: true, json: async () => ({ data: { statement: '이 가설은 검증되면 전환율이 오른다', status: 'proposed' } }) };
     });
     await act(async () => {
-      root.render(<EmbedCard entity_type="hypothesis" entity_id="h1" title="가설 A" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="hypothesis" entity_id="h1" title="가설 A" status={null} />));
     });
     await openCard();
     await flush();
@@ -344,7 +355,7 @@ describe('story #2614 — hypothesis는 풋터(담긴 곳)는 여전히 없지�
   it('hypothesis 조회가 실패하면(대상 사라짐) 여전히 "대상이 없습니다"로 정직하게 갈린다(무한 스피너였던 자체발견 회귀 재확認)', async () => {
     stubFetch(async () => ({ ok: false, json: async () => ({}) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="hypothesis" entity_id="h-gone" title="사라진 가설" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="hypothesis" entity_id="h-gone" title="사라진 가설" status={null} />));
     });
     await openCard();
     await flush();
@@ -399,7 +410,7 @@ describe('story #2780 — "미리보기 없음" 문구는 "실제로 보여줄 �
   it('sprint(#2780로 RICH 편입) — title 없는 옛 응답 모양(미백필 등)이면 몸통이 공백 아닌 "미리보기 없음"+bare href로 우아하게 폴백한다', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: {} }) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="sprint" entity_id="sp1" title="스프린트 3" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="sprint" entity_id="sp1" title="스프린트 3" status={null} />));
     });
     await openCard();
     await flush();
@@ -413,7 +424,7 @@ describe('story #2780 — "미리보기 없음" 문구는 "실제로 보여줄 �
       json: async () => ({ data: { title: '스프린트 5', status: 'active', start_date: '2026-08-01', end_date: '2026-08-14' } }),
     }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="sprint" entity_id="sp3" title="스프린트 5" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="sprint" entity_id="sp3" title="스프린트 5" status={null} />));
     });
     await openCard();
     await flush();
@@ -424,7 +435,7 @@ describe('story #2780 — "미리보기 없음" 문구는 "실제로 보여줄 �
   it('sprint — fetch 자체가 실패하면(대상 사라짐 등) "대상을 찾을 수 없습니다"로 정직하게 갈린다(#2642로 sprint도 fetch-eligible 승격 — 이전엔 이 갈래가 아예 없었다)', async () => {
     stubFetch(async () => ({ ok: false, json: async () => ({}) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="sprint" entity_id="sp-gone" title="사라진 스프린트" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="sprint" entity_id="sp-gone" title="사라진 스프린트" status={null} />));
     });
     await openCard();
     await flush();
@@ -437,7 +448,7 @@ describe('story #2780 — "미리보기 없음" 문구는 "실제로 보여줄 �
       return { ok: true, json: async () => ({ data: { org_slug: 'acme', project_slug: 'content' } }) };
     });
     await act(async () => {
-      root.render(<EmbedCard entity_type="sprint" entity_id="sp2" title="스프린트 4" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="sprint" entity_id="sp2" title="스프린트 4" status={null} />));
     });
     await openCard();
     await flush();
@@ -453,7 +464,7 @@ describe('AC3/AC4 — evidence는 부모 story로("담긴 곳으로 갑니다", 
       return { ok: true, json: async () => ({ data: { resolved_story_id: 's-parent-2' } }) };
     });
     await act(async () => {
-      root.render(<EmbedCard entity_type="evidence" entity_id="ev1" title="증거 A" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="evidence" entity_id="ev1" title="증거 A" status={null} />));
     });
     await openCard();
     await flush();
@@ -465,7 +476,7 @@ describe('AC3/AC4 — evidence는 부모 story로("담긴 곳으로 갑니다", 
   it('resolved_story_id가 없으면(예: 부모 task가 사라짐) 회색·행동0 "열 수 있는 화면이 없습니다"(거짓 링크 금지)', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: { resolved_story_id: null } }) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="evidence" entity_id="ev2" title="증거 B" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="evidence" entity_id="ev2" title="증거 B" status={null} />));
     });
     await openCard();
     await flush();
@@ -481,7 +492,7 @@ describe('AC3/AC4 — evidence는 부모 story로("담긴 곳으로 갑니다", 
       json: async () => ({ data: { resolved_story_id: 's-parent-3', org_slug: 'acme', project_slug: 'content' } }),
     }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="evidence" entity_id="ev3" title="증거 C" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="evidence" entity_id="ev3" title="증거 C" status={null} />));
     });
     await openCard();
     await flush();
@@ -496,7 +507,7 @@ describe('AC4 — 조회 실패(대상 사라짐)는 "대상이 없습니다"로
   it('task 상세 fetch가 실패하면 ㉠ "대상이 없습니다"를 보인다(㉡-b "열 수 있는 화면이 없습니다"와 문구가 다르다)', async () => {
     stubFetch(async () => ({ ok: false, json: async () => ({}) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="task" entity_id="t-gone" title="사라진 작업" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="task" entity_id="t-gone" title="사라진 작업" status={null} />));
     });
     await openCard();
     await flush();
@@ -517,7 +528,7 @@ describe('story #2262 AC2(2026-08-08, 쉬운 절반) — 모달이 자기 fetch�
       return { ok: true, json: async () => ({ data: { status: 'in-progress', story_id: 's-parent' } }) };
     });
     await act(async () => {
-      root.render(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status={null} />));
     });
     await openCard();
     await flush();
@@ -528,7 +539,7 @@ describe('story #2262 AC2(2026-08-08, 쉬운 절반) — 모달이 자기 fetch�
   it('status prop이 이미 실려 있으면(EmbedCard 자신의 write-response 경로) 그 값을 번역해 헤더가 우선한다', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: { status: 'done', story_id: 's-parent' } }) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status="todo" />);
+      root.render(wrap(<EmbedCard entity_type="task" entity_id="t1" title="작업 A" status="todo" />));
     });
     await openCard();
     await flush();
@@ -544,7 +555,7 @@ describe('story #2262 AC2(2026-08-08, 쉬운 절반) — 모달이 자기 fetch�
   it('fetch가 실패해도(대상 없음) status 뱃지를 지어내지 않는다 — 모르는 것을 단정하지 않는다', async () => {
     stubFetch(async () => ({ ok: false, json: async () => ({}) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="task" entity_id="t-gone" title="사라진 작업" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="task" entity_id="t-gone" title="사라진 작업" status={null} />));
     });
     await openCard();
     await flush();
@@ -559,7 +570,7 @@ describe('story #2522 — EntityDetail(모달 본문) story·epic 자기 status 
   it('story 본문 status 뱃지가 번역된 말로 뜬다(원시값 in-review 안 남음)', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: { status: 'in-review', description: '설명' } }) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="story" entity_id="s1" title="스토리 A" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="story" entity_id="s1" title="스토리 A" status={null} />));
     });
     await openCard();
     await flush();
@@ -570,7 +581,7 @@ describe('story #2522 — EntityDetail(모달 본문) story·epic 자기 status 
   it('epic 본문 status 뱃지가 번역된 말로 뜬다(원시값 active 자체는 겹치므로 archived로 격리해 확認)', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: { status: 'archived', objective: '목표' } }) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="epic" entity_id="e1" title="에픽 A" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="epic" entity_id="e1" title="에픽 A" status={null} />));
     });
     await openCard();
     await flush();
@@ -583,7 +594,7 @@ describe('story #2522 — EntityDetail(모달 본문) story·epic 자기 status 
   it('맵에 없는(미매핑) status는 원시값도 새 라벨도 안 뜬다 — 빈칸', async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ data: { status: 'some-brand-new-status', description: '설명' } }) }));
     await act(async () => {
-      root.render(<EmbedCard entity_type="story" entity_id="s2" title="스토리 B" status={null} />);
+      root.render(wrap(<EmbedCard entity_type="story" entity_id="s2" title="스토리 B" status={null} />));
     });
     await openCard();
     await flush();

--- a/apps/web/src/components/chat/entity-chip.test.tsx
+++ b/apps/web/src/components/chat/entity-chip.test.tsx
@@ -6,8 +6,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
 import { EntityChip } from './embed-card';
 import { ReadingPanelProvider } from './reading-panel-context';
+// story 3436(묶음 1) — DialogContent가 이제 useTranslations('common')을 쓴다. 클릭이
+// 모달(Dialog 기반)을 여는 테스트만 감싼다(embed-card.link-states.test.tsx와 같은 관례).
+import koMessages from '../../../messages/ko.json';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
 
 vi.mock('@/app/dashboard/dashboard-shell', () => ({
   useDashboardContext: () => ({ projectMemberships: [] }),
@@ -131,7 +143,7 @@ describe('EntityChip — story #3208(PO customer-zero, 카디르 QA #3611 지적
       return { ok: true, json: async () => ({ data: {} }) };
     }));
     await act(async () => {
-      root.render(<EntityChip entityType="artifact" entityId="art-cross" label="크로스 목업" href={null} />);
+      root.render(wrap(<EntityChip entityType="artifact" entityId="art-cross" label="크로스 목업" href={null} />));
     });
     await act(async () => { container.querySelector('button')!.click(); });
     await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
@@ -162,7 +174,7 @@ describe('EntityChip — story #461e9a54 ReadingPanel 라우팅', () => {
 
   it('Provider 밖(doc-content-renderer·story-detail-panel 등)에서 클릭하면 기존 Dialog 모달이 뜬다(회귀 0)', async () => {
     await act(async () => {
-      root.render(<EntityChip entityType="story" entityId="s-1" label="스토리 제목" href="/board?story=s-1" />);
+      root.render(wrap(<EntityChip entityType="story" entityId="s-1" label="스토리 제목" href="/board?story=s-1" />));
     });
     await act(async () => { container.querySelector('button')!.click(); });
     expect(document.body.querySelector('[role="dialog"]')).not.toBeNull();

--- a/apps/web/src/components/kanban/description-viewer.test.tsx
+++ b/apps/web/src/components/kanban/description-viewer.test.tsx
@@ -8,9 +8,22 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
 import { DescriptionViewer } from './story-detail-panel';
+// story 3436(묶음 1) — DialogContent가 이제 useTranslations('common')을 쓴다. 이
+// 파일에서 칩 클릭이 EntityPreviewModal(Dialog 기반)을 여는 두 테스트만 감싼다
+// (embed-card.link-states.test.tsx와 같은 관례 — 안 여는 나머지는 그대로 무변경).
+import koMessages from '../../../messages/ko.json';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
 
 let container: HTMLDivElement;
 let root: Root;
@@ -122,14 +135,14 @@ describe('DescriptionViewer — entity: 링크가 EntityChip으로 그려지는�
   it('entity: 링크 클릭도 부모(편집모드 진입) onClick으로 안 샌다', async () => {
     let parentClicked = false;
     await act(async () => {
-      root.render(
+      root.render(wrap(
         <div onClick={() => { parentClicked = true; }}>
           <DescriptionViewer
             description={`[스토리 제목](entity:story:${STORY_ID})`}
             references={[{ target_type: 'story', target_id: STORY_ID }]}
           />
         </div>,
-      );
+      ));
     });
 
     const button = container.querySelector('button') as HTMLButtonElement;
@@ -263,11 +276,11 @@ describe('DescriptionViewer — bare #<번호>가 bareNumberTargets로 렌더되
   it('bare-number: 링크 클릭도 부모(편집모드 진입) onClick으로 안 샌다', async () => {
     let parentClicked = false;
     await act(async () => {
-      root.render(
+      root.render(wrap(
         <div onClick={() => { parentClicked = true; }}>
           <DescriptionViewer description="#2258" bareNumberTargets={{ '2258': TARGET_ID }} />
         </div>,
-      );
+      ));
     });
 
     const button = container.querySelector('button') as HTMLButtonElement;

--- a/apps/web/src/components/ui/dialog.test.tsx
+++ b/apps/web/src/components/ui/dialog.test.tsx
@@ -5,9 +5,21 @@
 import { describe, expect, it, afterEach } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
 import { Dialog, DialogContent, DialogTitle } from './dialog';
+// story 3436(묶음 1) — DialogContent가 이제 useTranslations('common')을 쓴다
+// (sr-only "Close" i18n화) — 렌더 트리에 NextIntlClientProvider가 있어야 한다.
+import koMessages from '../../../messages/ko.json';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
 
 let container: HTMLDivElement;
 let root: Root;
@@ -23,13 +35,13 @@ describe('DialogContent — --elev-overlay + proof-line-strong(story #2969 PR-4)
     document.body.appendChild(container);
     root = createRoot(container);
     await act(async () => {
-      root.render(
+      root.render(wrap(
         <Dialog open>
           <DialogContent>
             <DialogTitle>제목</DialogTitle>
           </DialogContent>
         </Dialog>,
-      );
+      ));
     });
     const popup = document.querySelector('[data-slot="dialog-content"]');
     expect(popup).not.toBeNull();
@@ -38,5 +50,26 @@ describe('DialogContent — --elev-overlay + proof-line-strong(story #2969 PR-4)
     expect(popup?.className).not.toContain('ring-foreground/10');
     expect(popup?.className).toContain('rounded-lg');
     expect(popup?.className).not.toContain('rounded-xl');
+  });
+});
+
+// story 3436(묶음 1) — sr-only "Close" 하드코딩 정정.
+describe('DialogContent — 닫기 버튼 sr-only 접근 이름(story 3436)', () => {
+  it('⭐기본(showCloseButton) 닫기 버튼의 sr-only 텍스트가 한국어다', async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(wrap(
+        <Dialog open>
+          <DialogContent>
+            <DialogTitle>제목</DialogTitle>
+          </DialogContent>
+        </Dialog>,
+      ));
+    });
+    const closeBtn = document.querySelector('[data-slot="dialog-close"]');
+    expect(closeBtn?.querySelector('.sr-only')?.textContent).toBe(koMessages.common.close);
+    expect(closeBtn?.textContent).not.toContain('Close');
   });
 });

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+import { useTranslations } from "next-intl"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -47,6 +48,10 @@ function DialogContent({
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
 }) {
+  // story 3436(묶음 1) — 전역 셸 접근 이름이 한국어 화면에서도 영문 하드코딩이라
+  // 스크린리더가 "Close"를 그대로 읽었다. common.close는 이미 toast.tsx·
+  // command-palette.tsx의 aria-label로 쓰이는 정본 키(새 키 0).
+  const t = useTranslations("common")
   return (
     <DialogPortal>
       <DialogOverlay />
@@ -75,7 +80,7 @@ function DialogContent({
           >
             <XIcon
             />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{t("close")}</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Popup>

--- a/apps/web/src/components/ui/sheet.test.tsx
+++ b/apps/web/src/components/ui/sheet.test.tsx
@@ -5,9 +5,21 @@
 import { describe, expect, it, afterEach } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
 import { Sheet, SheetContent, SheetTitle } from './sheet';
+// story 3436(묶음 1) — SheetContent가 이제 useTranslations('common')을 쓴다
+// (sr-only "Close" i18n화) — 렌더 트리에 NextIntlClientProvider가 있어야 한다.
+import koMessages from '../../../messages/ko.json';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
 
 let container: HTMLDivElement;
 let root: Root;
@@ -23,13 +35,13 @@ describe('SheetContent — --elev-overlay + proof-line-strong(story #2969 PR-4)'
     document.body.appendChild(container);
     root = createRoot(container);
     await act(async () => {
-      root.render(
+      root.render(wrap(
         <Sheet open>
           <SheetContent side="right">
             <SheetTitle>제목</SheetTitle>
           </SheetContent>
         </Sheet>,
-      );
+      ));
     });
     const popup = document.querySelector('[data-slot="sheet-content"]');
     expect(popup).not.toBeNull();
@@ -47,13 +59,13 @@ describe('SheetContent — --elev-overlay + proof-line-strong(story #2969 PR-4)'
       document.body.appendChild(container);
       root = createRoot(container);
       await act(async () => {
-        root.render(
+        root.render(wrap(
           <Sheet open>
             <SheetContent side={side}>
               <SheetTitle>제목</SheetTitle>
             </SheetContent>
           </Sheet>,
-        );
+        ));
       });
       const popup = document.querySelector('[data-slot="sheet-content"]');
       expect(popup).not.toBeNull();
@@ -66,4 +78,25 @@ describe('SheetContent — --elev-overlay + proof-line-strong(story #2969 PR-4)'
       expect(popup?.className).toContain(borderSideClass);
     },
   );
+});
+
+// story 3436(묶음 1) — sr-only "Close" 하드코딩 정정(dialog.tsx와 같은 결함).
+describe('SheetContent — 닫기 버튼 sr-only 접근 이름(story 3436)', () => {
+  it('⭐기본(showCloseButton) 닫기 버튼의 sr-only 텍스트가 한국어다', async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(wrap(
+        <Sheet open>
+          <SheetContent side="right">
+            <SheetTitle>제목</SheetTitle>
+          </SheetContent>
+        </Sheet>,
+      ));
+    });
+    const closeBtn = document.querySelector('[data-slot="sheet-close"]');
+    expect(closeBtn?.querySelector('.sr-only')?.textContent).toBe(koMessages.common.close);
+    expect(closeBtn?.textContent).not.toContain('Close');
+  });
 });

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
+import { useTranslations } from "next-intl"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -46,6 +47,8 @@ function SheetContent({
   side?: "top" | "right" | "bottom" | "left"
   showCloseButton?: boolean
 }) {
+  // story 3436(묶음 1) — dialog.tsx와 같은 결함·같은 정본 키(common.close).
+  const t = useTranslations("common")
   return (
     <SheetPortal>
       <SheetOverlay />
@@ -75,7 +78,7 @@ function SheetContent({
             }
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{t("close")}</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Popup>

--- a/apps/web/src/components/ui/sidebar-toggle-labels.test.tsx
+++ b/apps/web/src/components/ui/sidebar-toggle-labels.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+//
+// story 3436(묶음 1) — 전역 셸 접근 이름 하드코딩 영문 정정. SidebarTrigger(sr-only)·
+// SidebarRail(aria-label·title) 둘 다 기본값(override 없음)이 한국어로 뜨는지 pin —
+// dialog.tsx·sheet.tsx의 「Close」와 같은 클래스 결함, 같은 PR.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { SidebarProvider, SidebarTrigger, SidebarRail } from './sidebar';
+import koMessages from '../../../messages/ko.json';
+import enMessages from '../../../messages/en.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function wrap(locale: 'ko' | 'en', node: React.ReactNode) {
+  const messages = locale === 'ko' ? koMessages : enMessages;
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages} timeZone="Asia/Seoul">
+      <SidebarProvider>{node}</SidebarProvider>
+    </NextIntlClientProvider>
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+    matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn(),
+  }));
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+  });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('SidebarTrigger — sr-only 접근 이름(story 3436)', () => {
+  it('⭐ko 로케일에서 sr-only 텍스트가 한국어다(하드코딩 "Close"류 결함과 같은 클래스)', async () => {
+    await act(async () => { root.render(wrap('ko', <SidebarTrigger />)); });
+    const srOnly = container.querySelector('.sr-only');
+    expect(srOnly?.textContent).toBe(koMessages.nav.toggleSidebar);
+    expect(srOnly?.textContent).not.toContain('Toggle Sidebar');
+  });
+
+  it('en 로케일에서는 영문 그대로다(회귀 0 — en 사용자는 원래도 맞았다)', async () => {
+    await act(async () => { root.render(wrap('en', <SidebarTrigger />)); });
+    const srOnly = container.querySelector('.sr-only');
+    expect(srOnly?.textContent).toBe(enMessages.nav.toggleSidebar);
+  });
+});
+
+describe('SidebarRail — aria-label·title(story 3436)', () => {
+  it('⭐ko 로케일에서 aria-label·title이 한국어다', async () => {
+    await act(async () => { root.render(wrap('ko', <SidebarRail />)); });
+    const rail = container.querySelector('[data-slot="sidebar-rail"]');
+    expect(rail?.getAttribute('aria-label')).toBe(koMessages.nav.toggleSidebar);
+    expect(rail?.getAttribute('title')).toBe(koMessages.nav.toggleSidebar);
+  });
+});

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { mergeProps } from "@base-ui/react/merge-props"
 import { useRender } from "@base-ui/react/use-render"
 import { cva, type VariantProps } from "class-variance-authority"
+import { useTranslations } from "next-intl"
 
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
@@ -260,6 +261,9 @@ function SidebarTrigger({
   ...props
 }: React.ComponentProps<typeof Button>) {
   const { toggleSidebar } = useSidebar()
+  // story 3436(묶음 1) — nav.toggleSidebar는 새 키(공용) — 묶음 4 #13(settings:800
+  // 「Toggle navigation」)이 같은 행동이라 같은 키로 잇는다(페드루 PO 지시).
+  const t = useTranslations("nav")
 
   return (
     <Button
@@ -275,13 +279,15 @@ function SidebarTrigger({
       {...props}
     >
       <PanelLeftIcon />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">{t("toggleSidebar")}</span>
     </Button>
   )
 }
 
 function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   const { toggleSidebar, setWidth, setIsResizing } = useSidebar()
+  // story 3436(묶음 1) — SidebarTrigger와 같은 정본 키(nav.toggleSidebar).
+  const t = useTranslations("nav")
   const didDragRef = React.useRef(false)
   const dragRef = React.useRef<{ startX: number; startWidth: number } | null>(null)
 
@@ -325,11 +331,11 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
     <button
       data-sidebar="rail"
       data-slot="sidebar-rail"
-      aria-label="Toggle Sidebar"
+      aria-label={t("toggleSidebar")}
       tabIndex={-1}
       onClick={handleClick}
       onMouseDown={onMouseDown}
-      title="Toggle Sidebar"
+      title={t("toggleSidebar")}
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
         "in-data-[side=left]:cursor-col-resize in-data-[side=right]:cursor-col-resize",


### PR DESCRIPTION
## 배경
story [#3436](entity:story:bfc1be01-9059-4d8b-8e79-899e9977ba3b) — 착수 순서 등급표 묶음 1. 유나 1~3회차 실측(2026-09-04 14:51Z): 다이얼로그·시트·사이드바의 가장 흔한 조작이 한국어 화면에서도 스크린리더에 영어로 읽혔습니다(`sr-only`·`aria-label`·`title`이 `messages/*.json` 밖 하드코딩 — 3432/PR#3786 한자 가드가 못 잡는 표면의 다른 얼굴).

## 변경(전/후 5건, 뜻·범위 무변경)
| 자리 | 전 | 후 |
|---|---|---|
| `dialog.tsx:78` | `<span className="sr-only">Close</span>` | `{t('close')}` — `common.close`(이미 toast.tsx·command-palette.tsx가 쓰는 정본 키, 새 키 0) |
| `sheet.tsx:78` | 동일 | 동일(같은 키) |
| `sidebar.tsx:278`(SidebarTrigger sr-only) | `Toggle Sidebar` | `{t('toggleSidebar')}` — 새 공용 키 `nav.toggleSidebar` |
| `sidebar.tsx:328`(SidebarRail aria-label) | `Toggle Sidebar` | 동일(같은 키) |
| `sidebar.tsx:332`(SidebarRail title) | `Toggle Sidebar` | 동일(같은 키) |

`nav.toggleSidebar`는 새 키입니다 — PO 지시대로 이 PR은 그 소비처를 이것뿐이지만, 묶음 4 #13(`settings:800` "Toggle navigation")이 같은 행동이라 후속 PR에서 같은 키로 잇습니다.

## 부수 발견·수정(회귀 0 유지 비용)
`DialogContent`/`SheetContent`가 이제 `useTranslations`를 씁니다 — base-ui `Dialog.Popup`은 **닫힌 상태에서도 렌더 함수 자체가 돌아** 이 두 컴포넌트를 렌더하는 기존 테스트가 `NextIntlClientProvider` 없이는 전부 깨졌습니다(5개 파일·40건). 전부 wrap 처리:
- `embed-card.link-states.test.tsx`(31건 — 기계적 일괄 치환)
- `entity-chip.test.tsx`·`description-viewer.test.tsx`·`dialog.test.tsx`·`sheet.test.tsx`

## 검증
- `pnpm vitest run`(apps/web): 622 files / 5840 tests green(신규 6건 — `sidebar-toggle-labels.test.tsx` ko/en 양쪽 확인 + `dialog.test.tsx`·`sheet.test.tsx`에 "Close" 미노출 pin — + 기존 40건 갱신)
- `tsc --noEmit` clean
- `eslint` 변경 파일 clean
- i18n 가드(hanja·phrase-collision·duplicate-keys) 전부 clean

## 범위 밖
- 묶음 2~7(BE 사람-대면 문구·MCP 도구 설명·앱 표면 영문 접근 이름 등)은 스토리 본문대로 backlog 유지, 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)