### PR TITLE
[SID:3436] fix: BE 사람-대면 문구 한자 잔존 7건 → 한글(묶음 2)

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1377,7 +1377,7 @@ async def _render_gate_verdict_message(db: AsyncSession, *, org_id: uuid.UUID, p
     elif verdict == "approved":
         lines.append(
             "- 다음 행동: 이 정의의 다음 stage 이벤트를 발행하세요(publish 단계라면 이 "
-            "승인 게이트를 확認하는 발행 도구를 쓰세요)."
+            "승인 게이트를 확인하는 발행 도구를 쓰세요)."
         )
 
     return "\n".join(lines)

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -426,7 +426,7 @@ _HTTP_MCP_CLI_SETUP_TEXT: dict[str, dict[str, str]] = {
         "title": "# Hermes MCP 연결",
         "intro": (
             "hermes는 `.mcp.json` 파일을 자동으로 읽지 않습니다 — 자체 CLI로 MCP 서버를 등록해야\n"
-            "합니다(라이브 왕복 실측 완료: story #2466, 실제 도구 110개 수신 확認)."
+            "합니다(라이브 왕복 실측 완료: story #2466, 실제 도구 110개 수신 확인)."
         ),
         "command_heading": "## 등록 명령",
         "command_note": "실행 중 인증 방식을 물으면 header를 선택하고, API key를 물으면 아래 값을 입력하세요.",

--- a/backend/app/services/approval_delivery.py
+++ b/backend/app/services/approval_delivery.py
@@ -1115,7 +1115,7 @@ async def maybe_nudge_draft_doc_shared_in_chat(
                     db, org_id=org_id, event_type="doc_draft_discussed_in_chat",
                     target_member_ids=[doc_author_id],
                     title="draft 문서가 채팅에서 논의됐습니다",
-                    body=f"'{doc_title}' — 결재 상신 여부를 확認해 주세요.",
+                    body=f"'{doc_title}' — 결재 상신 여부를 확인해 주세요.",
                     reference_type="doc", reference_id=doc_id,
                     source_project_id=project_id, via_outbox=True,
                 )

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -1797,8 +1797,8 @@ async def _resolve_artifact_canonicalize_gate(session: AsyncSession, gate: Gate,
             await dispatch_notification(
                 session, org_id=gate.org_id, event_type="artifact.canonicalized",
                 target_member_ids=list(target_ids),
-                title=f"정본 확定: {artifact.title}",
-                body=f"v{version_number}이(가) 정본으로 확定됐습니다." if version_number else None,
+                title=f"정본 확정: {artifact.title}",
+                body=f"v{version_number}이(가) 정본으로 확정됐습니다." if version_number else None,
                 reference_type="visual_artifact", reference_id=artifact.id,
                 source_project_id=artifact.project_id,
                 # story #2694: #2688(create_gate 2콜)과 동일 결함 클래스 — 이 호출부(transition_gate

--- a/backend/app/services/org_subscription_checkout.py
+++ b/backend/app/services/org_subscription_checkout.py
@@ -192,7 +192,7 @@ async def checkout_subscription(
     claim_result = await session.execute(claim_stmt)
     await session.commit()
     if claim_result.rowcount == 0:
-        raise CheckoutInProgress(f"org_id={org_id}에 다른 checkout이 이미 진행 中 — 완료 후 재시도")
+        raise CheckoutInProgress(f"org_id={org_id}에 다른 checkout이 이미 진행 중 — 완료 후 재시도")
 
     try:
         # ① 빌링키 발급(C1 재사용) — 카드 인증 완료.

--- a/backend/app/services/org_subscription_tier_change.py
+++ b/backend/app/services/org_subscription_tier_change.py
@@ -185,7 +185,7 @@ async def change_tier(session: AsyncSession, *, org_id: uuid.UUID, new_tier: str
     )
     await session.commit()
     if claim_result.rowcount == 0:
-        raise TierChangeInProgress(f"org_id={org_id}에 다른 결제 작업이 이미 진행 中 — 완료 후 재시도")
+        raise TierChangeInProgress(f"org_id={org_id}에 다른 결제 작업이 이미 진행 중 — 완료 후 재시도")
 
     try:
         # ⛔카디르 MEDIUM(2026-08-21, PR#3306 리뷰) — 이전 버전은 이 조회가 try 밖이라


### PR DESCRIPTION
## 배경
story [#3436](entity:story:bfc1be01-9059-4d8b-8e79-899e9977ba3b) 착수 순서 등급표 묶음 2 — 3432/PR#3786이 닫은 `apps/web/messages/*.json` 한자 가드 범위 밖의 BE 사람-대면 문구를 마저 닫습니다.

## 변경(전/후 7건, 뜻·길이 무변경)
| 자리 | 전 | 후 |
|---|---|---|
| `gate_service.py:1800`(알림 title) | 「정본 확定:」 | 「정본 확정:」 |
| `gate_service.py:1801`(알림 body) | 「...확定됐습니다.」 | 「...확정됐습니다.」 |
| `approval_delivery.py:1118`(알림 body) | 「...확認해 주세요.」 | 「...확인해 주세요.」 |
| `events.py:1380`(게이트 verdict "다음 행동" 안내) | 「...확認하는 발행 도구를...」 | 「...확인하는 발행 도구를...」 |
| `agent_onboarding_config.py:429`(`_HTTP_MCP_CLI_SETUP_TEXT["ko"]["intro"]`) | 「...110개 수신 확認).」 | 「...110개 수신 확인).」 |
| `services/org_subscription_checkout.py:195`(`CheckoutInProgress`) | 「...진행 中 — 완료 후...」 | 「...진행 중 — 완료 후...」 |
| `org_subscription_tier_change.py:188`(`TierChangeInProgress`) | 「...진행 中 — 완료 후...」 | 「...진행 중 — 완료 후...」 |

전부 1문자 한자→한글 치환(확定→확정·확認→확인·中→중).

## 그라운딩 정정(착수 前 코멘트, PO 확定)
스토리 원안의 "묶음 3(MCP 도구 설명 12자/10파일)"은 실물과 어긋나 이 PR에서 뺐습니다 — `server.py` 도구 등록부의 `(name, description, InputModel, fn)` 튜플에서 실제로 에이전트에 노출되는 것은 `description` 문자열 리터럴이고(전수 확인 — 한자 0건), `tools/*.py` 함수 자신의 docstring은 이 등록에 안 쓰여 도구 목록에 안 실립니다 — 원칙("코드 주석·docstring...범위 밖")의 예외 조건 자체가 안 걸립니다. PO가 3436 본문에 C등급 재분류를 직접 기록했습니다.

AC3(파이썬 pin 가드 pytest)는 PO 지시대로 별도 후속 PR로 분리합니다.

## 검증
- 6개 모듈 import 정상(`uv run python -c "import ..."`)
- 관련 backend pytest(`test_e_2506_subscription_checkout`·`test_2466_hermes_http_reclassification`·`test_ob1_agent_onboarding_config`·`test_2624_approval_result_reply`·`test_2637_gate_verdict_title_fix` 등) 전부 green(`destructive_schema` 마커 분리 실행)
- 기존 테스트 중 변경된 리터럴 문자열을 assert하는 곳 0건(전수 grep 확인, 회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)