### PR TITLE
[SID:3436] fix: 시각 형식 정본 통일(묶음 5) + releaseNotes.whatsNew ko 번역

### DIFF
--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -4761,7 +4761,7 @@
     "artifactDetailPageLinkHint": "내보내기·정본 제안·코멘트·버전 lineage는 상세 페이지에 있습니다"
   },
   "releaseNotes": {
-    "whatsNew": "What's new",
+    "whatsNew": "새 소식",
     "openButtonAriaLabel": "새 소식",
     "title": "릴리즈 노트",
     "emptyDescription": "아직 새로운 소식이 없어요. 업데이트가 준비되면 여기에서 알려드릴게요.",

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -7,6 +7,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../../../messages/ko.json';
+import { formatScheduledAt, resolveDisplayTimezone } from '@/components/content/schedule-format';
 
 const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
 const { useParamsMock } = vi.hoisted(() => ({ useParamsMock: vi.fn() }));
@@ -690,6 +691,10 @@ describe('ContentPostEditPage — story #3386(S8 발행됨·URL·행위자)', ()
     const link = container.querySelector<HTMLAnchorElement>('a[href="https://sprintable.ai/ko/blog/2ho-blog"]');
     expect(link).not.toBeNull();
     expect(container.textContent).toContain(koMessages.content.publishedInfoAtLabel);
+    // story 3436(묶음 5) — 발행 시각이 이 화면 다른 곳(변형 목록 등)과 같은 §11-2
+    // 정본 형식(formatScheduledAt)을 쓰는지 pin — 브라우저 toLocaleString() 잔존 방지.
+    const expectedTz = resolveDisplayTimezone().tz;
+    expect(container.textContent).toContain(formatScheduledAt('2026-09-03T18:44:00Z', expectedTz).display);
 
     const publishButton = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.publishCta);
     expect(publishButton?.hasAttribute('disabled')).toBe(true);

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -926,7 +926,7 @@ export default function ContentPostEditPage() {
           </div>
           <div>
             <span className="text-xs font-medium text-muted-foreground">{t('publishedInfoAtLabel')}</span>{' '}
-            {new Date(publication.published_at).toLocaleString()}
+            {formatScheduledAt(publication.published_at, displayTimezone).display}
           </div>
           <div>
             <span className="text-xs font-medium text-muted-foreground">{t('publishedInfoByLabel')}</span>{' '}
@@ -1209,7 +1209,7 @@ export default function ContentPostEditPage() {
           <AlertDescription>
             {publishResult.type === 'success' ? (
               <>
-                {t('publishSuccess', { time: new Date(publishResult.publishedAt).toLocaleString() })}
+                {t('publishSuccess', { time: formatScheduledAt(publishResult.publishedAt, displayTimezone).display })}
                 {' '}
                 <a href={publishResult.url} target="_blank" rel="noopener noreferrer" className="underline">
                   {t('publishViewLink')}

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -8,6 +8,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../../../../messages/ko.json';
+import { formatScheduledAt, resolveDisplayTimezone } from '@/components/content/schedule-format';
 
 const { useDashboardContextMock } = vi.hoisted(() => ({ useDashboardContextMock: vi.fn() }));
 const { useParamsMock } = vi.hoisted(() => ({ useParamsMock: vi.fn() }));
@@ -1194,7 +1195,9 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
     });
     await flush();
 
-    expect(container.textContent).toContain(new Date(resetAt).toLocaleString());
+    // story 3436(묶음 5 확장, PO 지적) — §11-2 정본 형식(formatScheduledAt)으로 pin 이동
+    // (toLocaleString()은 브라우저 로케일 의존이라 이 화면의 다른 시각 표기와도 어긋났다).
+    expect(container.textContent).toContain(formatScheduledAt(resetAt, resolveDisplayTimezone().tz).display);
   });
 
   // 카디르 QA 계획(2026-09-04) ⑤ — "api-error.ts가 파싱한다"는 사실만으로 화면 렌더까지
@@ -1257,7 +1260,8 @@ describe('ChannelPostEditPage (story #3402 AC5/AC6)', () => {
 
     expect(container.querySelector('[data-testid="channel-post-published-info"]')).toBeNull();
     const result = container.querySelector('[data-testid="channel-post-publish-result"]');
-    expect(result?.textContent).toContain(new Date('2026-09-05T00:00:00Z').toLocaleString());
+    // story 3436(묶음 5 확장) — §11-2 정본 형식으로 pin 이동(회귀 아님).
+    expect(result?.textContent).toContain(formatScheduledAt('2026-09-05T00:00:00Z', resolveDisplayTimezone().tz).display);
   });
 
   // 디디군 리뷰 nit(2026-09-04 06:05Z, PR#3769 진행 중 발견) — 재발행 요청이 이번엔

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -18,7 +18,7 @@ import { ScheduleAtDialog } from '@/components/content/schedule-at-dialog';
 import { parseScheduledAtServerError } from '@/components/content/validate-scheduled-at';
 import { deriveFailureAction, type CommandStatus } from '@/components/content/failure-action';
 import { FailureActionBadge } from '@/components/content/failure-action-badge';
-import { resolveDisplayTimezone } from '@/components/content/schedule-format';
+import { formatScheduledAt, resolveDisplayTimezone } from '@/components/content/schedule-format';
 import { isSandboxChannelDraft, SandboxTestBadge } from '@/components/content/sandbox-test-badge';
 import { RawDetailsToggle } from '@/components/content/raw-details-toggle';
 import { formatFileSize } from '@/components/docs/extensions/file-node';
@@ -633,7 +633,7 @@ export default function ChannelPostEditPage() {
         const text = info.kind === 'text_too_long' && info.maxLength != null && info.currentLength != null
           ? t('channelPostsTextTooLong', { max: info.maxLength, current: info.currentLength })
           : info.kind === 'rate_limited' && info.resetAt
-            ? t('channelPostsRateLimitedUntil', { time: new Date(info.resetAt).toLocaleString() })
+            ? t('channelPostsRateLimitedUntil', { time: formatScheduledAt(info.resetAt, displayTimezone).display })
             : info.humanMessageKey ? t(info.humanMessageKey) : (info.humanMessageFallback || t('publishFailed'));
         // story #3402 AC11(doc §5-1) — "막혔다"(왜, text)와 "밖으로 나갔다"(externalImpact)
         // 는 뭉치면 안 되는 별개 사실이다. 페드루 PO 블로커 판정(2026-09-04 06:17Z) —
@@ -1040,7 +1040,7 @@ export default function ChannelPostEditPage() {
               {draft.published_at ? (
                 <div className="flex items-center justify-between">
                   <span className="text-muted-foreground">{t('publishedInfoAtLabel')}</span>
-                  <span>{new Date(draft.published_at).toLocaleString()}</span>
+                  <span>{formatScheduledAt(draft.published_at, displayTimezone).display}</span>
                 </div>
               ) : null}
               {draft.external_id ? (
@@ -1203,9 +1203,9 @@ export default function ChannelPostEditPage() {
           <Alert variant={publishResult.type === 'error' ? 'destructive' : 'default'} role={publishResult.type === 'error' ? 'alert' : 'status'} data-testid="channel-post-publish-result">
             <AlertDescription>
               {publishResult.type === 'success'
-                ? t('publishSuccess', { time: draft.published_at ? new Date(draft.published_at).toLocaleString() : '' })
+                ? t('publishSuccess', { time: draft.published_at ? formatScheduledAt(draft.published_at, displayTimezone).display : '' })
                 : publishResult.type === 'scheduled'
-                  ? t('channelPostsPublishScheduled', { time: publishResult.scheduledAt ? new Date(publishResult.scheduledAt).toLocaleString() : t('originAuthorUnknown') })
+                  ? t('channelPostsPublishScheduled', { time: publishResult.scheduledAt ? formatScheduledAt(publishResult.scheduledAt, displayTimezone).display : t('originAuthorUnknown') })
                   : (
                     // story #3402 AC11(doc §5-1) — "왜 막혔나"(text)와 "밖으로 나갔나"
                     // (externalImpact)는 서로 다른 사실이라 별도 텍스트 노드로 따로 둔다


### PR DESCRIPTION
## 배경
story [#3436](entity:story:bfc1be01-9059-4d8b-8e79-899e9977ba3b) 착수 순서 등급표 묶음 5(유나 #3799 리뷰 기록 16:47Z) — `content/[draftId]/page.tsx` 한 화면에 시각 형식이 두 벌이었습니다: `toLocaleString()`(브라우저 로케일 의존·비결정적) 2곳 ↔ `formatScheduledAt`(§11-2 정본, "MM-DD HH:mm {TZ}") 1곳.

## 변경
- 발행 정보 패널의 발행 시각(`publication.published_at`) — `new Date(...).toLocaleString()` → `formatScheduledAt(iso, displayTimezone).display`
- 발행 성공 배너 `publishSuccess` 문장 안 보간값(`publishResult.publishedAt`) — 같은 치환(문장 안이라 형식 불일치가 더 눈에 띄던 자리)

둘 다 이미 컴포넌트 스코프에 있던 `displayTimezone`(§11-2 시간대 정본 소스, `resolveDisplayTimezone().tz`)을 그대로 재사용 — 새 상태/새 계산 0.

## 추가(PO 갱신, 2026-09-04 19:12Z — #3810 대조 중 발견)
`releaseNotes.whatsNew` ko 값이 영문 "What's new" 그대로 방치돼 있었습니다(Workcell LayerLabel과 달리 "번역하지 않는 제품 어휘"로 정본에 명시된 적 없음) → "새 소식"으로 번역(묶음 4에서 신설한 버튼 aria-label `openButtonAriaLabel`과 같은 문구 — 다이얼로그 제목=버튼 접근 이름 일치). en 값은 무변경.

## 검증
- `content/[draftId]/page.test.tsx`에 §11-2 정본 형식 pin 1건 추가(51 tests green, 실 `formatScheduledAt` 재사용이라 환경 무관)
- 전체 `pnpm vitest run`: 626 files / 5874 tests green
- `tsc --noEmit` clean, eslint 변경 파일 clean
- i18n 가드(hanja·duplicate-keys) clean

base는 develop(#3808 병합 후, 클린 cherry-pick — #3810 미병합 스택 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)