### PR TITLE
[SID:3436] feat: 스택 PR CI에 alembic 체인-닫힘 smoke 추가(묶음 7)

### DIFF
--- a/.github/workflows/stack-pr-frontend-preview.yml
+++ b/.github/workflows/stack-pr-frontend-preview.yml
@@ -41,9 +41,21 @@ name: Frontend preview (stack PR)
 #      `ci` job(Lint/Type/Test/Build — TS/lint/vitest/next build, develop 상태에 안 걸림)
 #      **하나만** 복제한다 — 스토리가 named한 갭 중 가장 저비용·최고가치인 축.
 #
-# ⛔이 워크플로가 못 잡는 것: 백엔드 Python 변경(lint/type/pytest/alembic) 전부, Contrast
-# guard(axe e2e, story #2590 B) — 둘 다 최종 develop 재타겟 시점의 required 체크가 여전히
-# 유일한 검증처다. 이 워크플로 하나로 "스택 PR도 이제 다 검증된다"로 읽으면 안 된다.
+# story 3436(묶음 7, 2026-09-05 — 카디르 지적·PO 승인) — #3802 검수에서 베이스 브랜치의
+# 커밋이 소실되며(스택 재정렬 사고) 이 PR 자신의 마이그레이션 파일셋이 조용히 끊긴 체인이
+# 됐는데, 위 ④가 배제한 검증("develop head 대비 최신성")과는 **다른 물음**이라 안 걸렸다.
+# ⑤ `alembic-migration-chain-smoke` job — 「이 브랜치 파일셋만으로 마이그레이션 체인이
+#    닫히는가」(develop head가 그 사이 움직여도 답이 안 바뀐다, ④의 "구조적으로 의미
+#    없음" 논지와 충돌하지 않는다) 하나만 잰다: 빈 postgres에 `alembic upgrade heads` +
+#    `alembic heads`가 정확히 1개인지(다중/분기 head=끊긴·소실된 체인의 신호, #3802급
+#    사고와 같은 클래스). alembic-fresh-db(ci.yml)의 baseline parity·existing-DB no-op
+#    같은 무거운 스텝은 그대로 이관 안 함 — 순수 체인-닫힘 smoke 하나.
+#
+# ⛔이 워크플로가 못 잡는 것(갱신, alembic은 위 ⑤로 «체인 닫힘»만 좁게 커버 — develop
+# 대비 최신성·baseline parity·existing-DB no-op·실제 마이그레이션 SQL 내용은 여전히 못
+# 잡는다): 백엔드 Python lint/type/pytest 전부, Contrast guard(axe e2e, story #2590 B).
+# 이 셋은 최종 develop 재타겟 시점의 required 체크가 여전히 유일한 검증처다. 이 워크플로
+# 하나로 "스택 PR도 이제 다 검증된다"로 읽으면 안 된다.
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
@@ -153,3 +165,62 @@ jobs:
 
       - name: Verify build schema integrity (story d3dd358b regression guard)
         run: pnpm --filter web verify:build-schema-integrity
+
+  alembic-migration-chain-smoke:
+    name: "Alembic migration chain smoke (stack preview — chain-closure only, not develop-merge verification)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        # alembic-fresh-db(ci.yml)와 같은 이미지 — 베이스라인 스냅샷이 pgvector 확장을 쓴다.
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: sprintable
+          POSTGRES_PASSWORD: sprintable
+          POSTGRES_DB: sprintable_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: 'latest'
+
+      # 이 브랜치(스택 중간 base 포함) 자신의 파일셋만으로 빈 DB에서 처음부터 끝까지
+      # 재생 가능한지 — develop head 상태와 무관(위 §④/§⑤ 주석). #3802급 사고(베이스
+      # 브랜치 커밋 소실로 마이그레이션 파일 일부가 빠짐)는 여기서 alembic이 참조를
+      # 못 찾거나 체인이 갈라져 실패/다중 head로 드러난다.
+      - name: alembic upgrade heads (fresh DB → this branch's own fileset)
+        working-directory: backend
+        run: uv run alembic upgrade heads
+
+      # 다중/분기 head = 체인이 어딘가에서 끊기거나 갈라졌다는 신호(정상 상태는 항상
+      # 단일 head — 실측, 2026-09-05 기준 develop `alembic heads`도 1개). alembic-
+      # fresh-db(ci.yml)처럼 diff/집합비교가 아니라 단순 개수 검사인 것은 의도적 — 이
+      # smoke가 재는 것은 "이 브랜치가 지금 다중 head 상태로 깨져 있는가" 하나뿐이다.
+      - name: Verify exactly one migration head (chain not broken/forked)
+        working-directory: backend
+        run: |
+          set -e
+          heads=$(uv run alembic heads 2>/dev/null | grep -oE '^[0-9a-z_]+' | sort -u)
+          count=$(printf '%s\n' "$heads" | grep -c .)
+          echo "heads:"
+          echo "$heads"
+          if [ "$count" -ne 1 ]; then
+            echo "FAIL: expected exactly 1 migration head, found $count — chain broken or forked (e.g. lost base-branch commit, #3802-class incident)."
+            exit 1
+          fi
+          echo "OK: single head, chain closed."


### PR DESCRIPTION
## 배경
story [#3436](entity:story:bfc1be01-9059-4d8b-8e79-899e9977ba3b) 착수 순서 등급표 묶음 7 — 카디르 지적(#3802 검수, 2026-09-04 17:04Z): 스택 PR(base≠develop/main)은 CI 잡이 「Lint, Type Check, Test, Build (stack preview)」 하나뿐이라 alembic 체인 검증이 빠집니다 — 베이스 브랜치 커밋 소실(스택 재정렬 사고)이 CI로 안 잡혔습니다.

story #2929(2026-08-22, `stack-pr-frontend-preview.yml` §④)가 alembic 전체를 스택 프리뷰에서 "의도적으로 이관 안 함"으로 정한 것과 배치되지 않습니다 — §④가 배제한 검증은 「develop head 대비 최신성」(스택 중간 지점에서 구조적으로 무의미)이고, #3802급 사고는 「이 브랜치 파일셋 자신의 체인이 애초에 닫혀 있는가」로 develop head가 움직여도 답이 안 바뀌는 다른 물음입니다(PO 확定 2026-09-04 19:24Z).

## 변경
새 job `alembic-migration-chain-smoke`(ci.yml `alembic-fresh-db`와 같은 postgres 서비스+uv 셋업 패턴 — baseline parity·existing-DB no-op 같은 무거운 스텝은 이관 안 함, 순수 체인-닫힘만):
1. 빈 DB에 `alembic upgrade heads`(이 브랜치 파일셋만으로)
2. `alembic heads`가 정확히 1개인지 확인 — 다중/분기 head=체인이 끊기거나 갈라졌다는 신호

파일 상단 §④/⛔ 주석도 갱신 — alembic을 "이 워크플로가 못 잡는 것" 목록에서 빼고 새 §⑤로 이 smoke가 잡는 것(체인 닫힘)/못 잡는 것(develop 대비 최신성·baseline parity·existing-DB no-op·SQL 내용)을 명시 선언.

## RED→GREEN 재현(PO 조건 a)
throwaway stack-PR(#3812, base=이 브랜치·closed 후 삭제)로 실제 검증:
- **RED** — 0321을 공유 부모로 하는 포크 마이그레이션(`9999test`)을 고의 주입해 다중 head(`0322`, `9999test`) 생성 → [run 33911641190](https://github.com/moonklabs/sprintable/actions/runs/33911641190) 실패, 로그: `heads: 0322 / 9999test` → `FAIL: expected exactly 1 migration head, found 2 — chain broken or forked (e.g. lost base-branch commit, #3802-class incident).`
- **GREEN** — 그 커밋을 되돌린 뒤 → [run 33912407727](https://github.com/moonklabs/sprintable/actions/runs/33912407727) 성공, 로그: `heads: 0322` → `OK: single head, chain closed.`

## 검증
- YAML 파싱 확인(`python3 -c "import yaml; yaml.safe_load(...)"`)
- 위 RED→GREEN 실 CI 재현
- 이 PR 자체의 CI(같은 job)도 그린 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)