### PR TITLE
[SID:3436] fix: sidebar aria-expanded + channelOwnerOnlyReason 서술문화(묶음 9)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2098,7 +2098,7 @@
     "channelTestOk": "OK · {account}",
     "channelTestFailed": "Failed · {error}",
     "channelLastErrorToggle": "View server response",
-    "channelOwnerOnlyReason": "Ask an owner — only owners can do this.",
+    "channelOwnerOnlyReason": "Only owners can do this.",
     "channelConfigIncompleteReason": "App credentials must be set up before you can start connecting.",
     "channelExpiringInfoNote": "This renews automatically.",
     "channelExpiringActionNote": "This does not renew automatically — you'll need to reconnect it yourself.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2098,7 +2098,7 @@
     "channelTestOk": "정상 · {account}",
     "channelTestFailed": "실패 · {error}",
     "channelLastErrorToggle": "서버 응답 보기",
-    "channelOwnerOnlyReason": "owner에게 알리기 — 이 작업은 owner만 할 수 있습니다.",
+    "channelOwnerOnlyReason": "owner만 할 수 있는 작업입니다.",
     "channelConfigIncompleteReason": "먼저 앱 자격을 설정해야 연결을 시작할 수 있습니다.",
     "channelExpiringInfoNote": "자동 갱신됩니다.",
     "channelExpiringActionNote": "자동으로 갱신되지 않습니다 — 직접 다시 연결해야 합니다.",

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -138,7 +138,7 @@ describe('OrganizationChannelsPage — 목록·상태(story #3376)', () => {
     await mount('member');
     const disconnectBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '해제');
     expect(disconnectBtn).toBeUndefined();
-    expect(container.textContent).toContain('owner에게 알리기');
+    expect(container.textContent).toContain('owner만 할 수 있는 작업입니다');
   });
 
   it('member도 연결 시험은 할 수 있다', async () => {
@@ -227,7 +227,7 @@ describe('OrganizationChannelsPage — 앱 자격(AC2, story #3376)', () => {
     await mount('member');
     const registerBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '우리 조직 앱을 쓰려면 등록');
     expect(registerBtn).toBeUndefined();
-    expect(container.textContent).toContain('owner에게 알리기');
+    expect(container.textContent).toContain('owner만 할 수 있는 작업입니다');
   });
 });
 
@@ -259,7 +259,7 @@ describe('OrganizationChannelsPage — available-channels 목록 기반 렌더(s
     stubFetch({ connections: [], availableChannels: AVAILABLE_WITH_SANDBOX });
     await mount('member');
     expect(container.querySelector('[data-testid="channel-connect-sandbox-button"]')).toBeNull();
-    expect(container.textContent).toContain('owner에게 알리기');
+    expect(container.textContent).toContain('owner만 할 수 있는 작업입니다');
   });
 
   it('⭐sandbox 「연결 만들기」를 누르면 BFF POST 성공 뒤 리로드 없이 새 연결 행이 추가된다', async () => {

--- a/apps/web/src/components/ui/sidebar-toggle-labels.test.tsx
+++ b/apps/web/src/components/ui/sidebar-toggle-labels.test.tsx
@@ -13,11 +13,11 @@ import enMessages from '../../../messages/en.json';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-function wrap(locale: 'ko' | 'en', node: React.ReactNode) {
+function wrap(locale: 'ko' | 'en', node: React.ReactNode, open?: boolean) {
   const messages = locale === 'ko' ? koMessages : enMessages;
   return (
     <NextIntlClientProvider locale={locale} messages={messages} timeZone="Asia/Seoul">
-      <SidebarProvider>{node}</SidebarProvider>
+      <SidebarProvider open={open}>{node}</SidebarProvider>
     </NextIntlClientProvider>
   );
 }
@@ -67,5 +67,25 @@ describe('SidebarRail — aria-label·title(story 3436)', () => {
     const rail = container.querySelector('[data-slot="sidebar-rail"]');
     expect(rail?.getAttribute('aria-label')).toBe(koMessages.nav.toggleSidebar);
     expect(rail?.getAttribute('title')).toBe(koMessages.nav.toggleSidebar);
+  });
+});
+
+// story 3436(묶음 9, PO 지적 2026-09-04 20:29Z) — 접근 이름은 있었지만 펼침/접힘 상태를
+// 스크린리더가 못 읽었다. open true/false 두 상태 aria-expanded 값 pin.
+describe('SidebarTrigger/SidebarRail — aria-expanded(story 3436 묶음 9)', () => {
+  it('⭐open=true(기본값)면 SidebarTrigger·SidebarRail 둘 다 aria-expanded="true"', async () => {
+    await act(async () => { root.render(wrap('ko', <><SidebarTrigger /><SidebarRail /></>, true)); });
+    const trigger = container.querySelector('[data-slot="sidebar-trigger"]');
+    const rail = container.querySelector('[data-slot="sidebar-rail"]');
+    expect(trigger?.getAttribute('aria-expanded')).toBe('true');
+    expect(rail?.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('open=false면 SidebarTrigger·SidebarRail 둘 다 aria-expanded="false"', async () => {
+    await act(async () => { root.render(wrap('ko', <><SidebarTrigger /><SidebarRail /></>, false)); });
+    const trigger = container.querySelector('[data-slot="sidebar-trigger"]');
+    const rail = container.querySelector('[data-slot="sidebar-rail"]');
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+    expect(rail?.getAttribute('aria-expanded')).toBe('false');
   });
 });

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -260,7 +260,7 @@ function SidebarTrigger({
   onClick,
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar } = useSidebar()
+  const { toggleSidebar, open, openMobile, isMobile } = useSidebar()
   // story 3436(묶음 1) — nav.toggleSidebar는 새 키(공용) — 묶음 4 #13(settings:800
   // 「Toggle navigation」)이 같은 행동이라 같은 키로 잇는다(페드루 PO 지시).
   const t = useTranslations("nav")
@@ -271,6 +271,11 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon-sm"
+      // story 3436(묶음 9, PO 지적) — 접근 이름은 있었지만 펼침/접힘 상태를 스크린리더가
+      // 못 읽었다(아침 sr-only "Close"류와 같은 클래스, 다른 얼굴). toggleSidebar()가
+      // 모바일/데스크톱에서 다른 state를 토글하므로(107행) isMobile로 어느 쪽을 읽을지 갈라야
+      // 이 버튼이 실제로 제어하는 state와 aria-expanded가 일치한다.
+      aria-expanded={isMobile ? openMobile : open}
       className={cn(className)}
       onClick={(event) => {
         onClick?.(event)
@@ -285,7 +290,7 @@ function SidebarTrigger({
 }
 
 function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
-  const { toggleSidebar, setWidth, setIsResizing } = useSidebar()
+  const { toggleSidebar, setWidth, setIsResizing, open, openMobile, isMobile } = useSidebar()
   // story 3436(묶음 1) — SidebarTrigger와 같은 정본 키(nav.toggleSidebar).
   const t = useTranslations("nav")
   const didDragRef = React.useRef(false)
@@ -332,6 +337,8 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       data-sidebar="rail"
       data-slot="sidebar-rail"
       aria-label={t("toggleSidebar")}
+      // story 3436(묶음 9) — SidebarTrigger와 같은 이유·같은 처방.
+      aria-expanded={isMobile ? openMobile : open}
       tabIndex={-1}
       onClick={handleClick}
       onMouseDown={onMouseDown}


### PR DESCRIPTION
## 배경
story [#3436](entity:story:bfc1be01-9059-4d8b-8e79-899e9977ba3b) — PO 확定(2026-09-04 20:29Z), 미르코 자체 그라운딩 후 제안한 2건.

## 변경

### 1. sidebar.tsx `SidebarTrigger`·`SidebarRail` — aria-expanded
묶음 1이 접근 이름(`nav.toggleSidebar`)은 고쳤지만 펼침/접힘 상태는 스크린리더가 못 읽었습니다. `useSidebar()`가 이미 노출하는 `open`/`openMobile`/`isMobile`을 받아 `aria-expanded={isMobile ? openMobile : open}` 부착 — `toggleSidebar()` 자체가 모바일/데스크톱에서 다른 state를 토글하므로 이 버튼이 실제로 제어하는 state와 `aria-expanded`가 일치하도록 갈랐습니다.

### 2. `channelOwnerOnlyReason` — 서술문화
묶음 4 부록에서 유나가 지적한 문구(「owner에게 알리기 — 이 작업은 owner만 할 수 있습니다.」 앞부분이 행동 이름인데 화면에 그 수단이 없음)를 서술문으로:
| | 전 | 후 |
|---|---|---|
| ko | 「owner에게 알리기 — 이 작업은 owner만 할 수 있습니다.」 | 「owner만 할 수 있는 작업입니다.」 |
| en | "Ask an owner — only owners can do this." | "Only owners can do this." |

「owner」 표기는 같은 `channelConnect` 네임스페이스의 정본(`channelConnectErrorOwnerOnly` = 「owner만 할 수 있는 동작입니다 — 조직 owner에게 요청해 주세요.」)과 동일 어휘(영문 소문자 owner — `organization` 네임스페이스의 「소유자」와는 다른 도메인 관례).

## 검증
- `sidebar-toggle-labels.test.tsx`에 `aria-expanded` pin 2건(open true/false 두 상태) 추가
- 기존 assertion 3건(`page.test.tsx`) 새 문구로 갱신(회귀 아님)
- 전체 `pnpm vitest run`: 627 files / 5889 tests green
- `tsc --noEmit` clean, eslint clean
- i18n 가드(hanja·duplicate-keys) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)