### PR TITLE
[SID:3437] feat: source_title/source_site_post_version_id 배치 노출 + strip 5곳(후속 묶음)

### DIFF
--- a/backend/alembic/versions/0325_channel_post_source_version.py
+++ b/backend/alembic/versions/0325_channel_post_source_version.py
@@ -1,0 +1,41 @@
+"""story #3437(후속 묶음, 페드루 PO 確定 2026-09-05) — `channel_post_drafts.
+source_site_post_version_id` 신규 컬럼.
+
+`source_content_item_id`(0321)가 「어느 draft에서 파생됐나」(draft 축)만 가리키는
+것과 달리, 이 컬럼은 「그 draft의 몇 번 버전에서 파생됐나」(버전 축)를 초안 생성
+시점에 고정한다 — 원문이 그 뒤 새 버전을 내도 이 값은 안 바뀐다(staleness 판별의
+기준점, FE는 이 값과 원문 현재 latest version.id를 비교해 "원문이 파생 이후
+개정됨" 배지를 그린다 — 서버는 판정 라벨을 안 낸다).
+
+FK 없음(source_content_item_id와 같은 관례) — nullable(source_content_item_id가
+null이면 이것도 항상 null — 소스 없는 단독 채널 초안 회귀 유지).
+
+down_revision=0324는 story e4fc29fa 조각④(#3800, webhook_delivery_nonces) — 이
+스토리 착수 시점에 develop 미착지였다(gh api로 실물 확인). #3800이 먼저 착지해야
+이 마이그가 develop에 얹힐 수 있다.
+
+Revision ID: 0325
+Revises: 0324
+Create Date: 2026-09-05
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0325"
+down_revision = "0324"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "channel_post_drafts",
+        sa.Column("source_site_post_version_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("channel_post_drafts", "source_site_post_version_id")

--- a/backend/app/models/channel_post_draft.py
+++ b/backend/app/models/channel_post_draft.py
@@ -45,6 +45,15 @@ class ChannelPostDraft(Base):
     source_content_item_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True, index=True
     )
+    # story #3437(후속 묶음, 페드루 PO 確定 2026-09-05) — source_content_item_id가 «어느
+    # draft에서 파생됐나»(draft 축)만 가리키는 것과 달리, 이 컬럼은 «그 draft의 몇 번
+    # 버전에서 파생됐나»(버전 축)를 초안 생성 시점에 고정한다. 원문이 그 뒤 새 버전을
+    # 내도 이 값은 안 바뀐다 — staleness("원문이 파생 이후 개정됨") 판별의 기준점.
+    # FK 없음(source_content_item_id와 같은 이유) — nullable(source_content_item_id가
+    # null이면 이것도 항상 null).
+    source_site_post_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/campaigns.py
+++ b/backend/app/routers/campaigns.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -38,6 +38,16 @@ class CreateCampaignRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=300)
     starts_at: datetime | None = None
     ends_at: datetime | None = None
+
+    # story #3437(후속 묶음, 페드루 PO 確定 2026-09-05) — conversations.py:1259-1265 정본
+    # 미러(새 패턴 발명 0).
+    @field_validator("name")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
 
 
 class CampaignResponse(BaseModel):
@@ -135,11 +145,14 @@ async def get_campaign_detail_endpoint(
         variant_rows = await list_channel_post_drafts(
             db, org_id=org_id, source_content_item_id=draft.id, limit=200,
         )
+        # story #3437(후속 묶음) — 이 루프의 draft/latest_version이 이미 이 content_item의
+        # 원문+latest version이라 배치 쿼리 불요 — 그대로 조립.
+        source_titles = {draft.id: (latest_version.title, latest_version.id)}
         content_items.append(CampaignContentItemItem(
             content_item_id=draft.id, slug=draft.slug, lang=latest_version.lang,
             title=latest_version.title, current_version=latest_version.version,
             updated_at=latest_version.created_at.isoformat(),
-            variants=[_to_draft_list_item(row) for row in variant_rows],
+            variants=[_to_draft_list_item(row, source_titles) for row in variant_rows],
         ))
 
     return CampaignDetailResponse(

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -41,6 +41,7 @@ from app.services.channel_posts import (
     create_channel_post_draft_version,
     get_channel_post_draft,
     get_site_post_draft,
+    get_source_titles_and_latest_versions,
     is_agent_caller,
     list_channel_post_draft_versions,
     list_channel_post_drafts,
@@ -115,6 +116,17 @@ class CreateChannelPostDraftVersionRequest(BaseModel):
     connection_id: uuid.UUID
     text: str = Field(..., min_length=1)
     link_url: str | None = None
+
+    # story #3437(후속 묶음, 페드루 PO 確定 2026-09-05) — conversations.py:1259-1265 정본
+    # 미러(새 패턴 발명 0). 채널별 글자수 한도(_validate_text_length, 서비스 계층)는 이
+    # strip 뒤 값을 그대로 잰다 — 공백 패딩이 한도 판정을 왜곡하지 않게 된다(부수 개선).
+    @field_validator("text")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
     # story #3437(AC2·AC5, 페드루 PO 確定 2026-09-04) — 이 채널 변형이 파생된 원문
     # (content_item=site_post_drafts.id). 휴먼·에이전트 동형(둘 다 받는다) — 초안 생성
     # 시에만 반영, 편집(기존 draft) 호출은 무시된다(서비스 계층 docstring 참고).
@@ -204,6 +216,16 @@ class ChannelPostDraftListItem(BaseModel):
     # story #3437(ⓒ, 페드루 PO 確定 2026-09-04) — 단건/목록 응답에 파생 원문 노출.
     # 없으면 null(소스 없는 단독 채널 초안, 기존 회귀 그대로).
     source_content_item_id: uuid.UUID | None = None
+    # story #3437(후속 묶음, 페드루 PO 確定 2026-09-05) — 원문 제목(배치조회, campaign_name과
+    # 동일 클래스 갭 처방). source_content_item_id가 null이면 이것도 항상 null.
+    source_title: str | None = None
+    # 이 변형이 파생된 시점의 원문 latest version.id(버전 축, 초안 생성 시 고정 — 편집으로는
+    # 안 바뀐다).
+    source_site_post_version_id: uuid.UUID | None = None
+    # 원문의 **지금** latest version.id(배치조회, 매 응답마다 최신값). source_site_post_
+    # version_id와 다르면 "원문이 파생 이후 개정됨" — 서버는 판정 라벨 없이 두 값만 낸다,
+    # 비교·배지 문구는 FE 몫(§11-5).
+    source_current_site_post_version_id: uuid.UUID | None = None
 
 
 class ChannelPostVersionHistoryItem(BaseModel):
@@ -516,14 +538,26 @@ async def get_channel_post_image_for_version_endpoint(
 
 def _to_draft_list_item(
     row: tuple,
+    source_titles: dict[uuid.UUID, tuple[str, uuid.UUID]] | None = None,
 ) -> ChannelPostDraftListItem:
     """story #3403 — 목록·단건 두 엔드포인트가 공유하는 유일한 직렬화 지점. 손으로 두
     번 짜지 않는다(드리프트 원천 차단, list_channel_post_drafts()가 draft_id 필터를
-    똑같이 지원하는 것과 동형 사상)."""
+    똑같이 지원하는 것과 동형 사상).
+
+    story #3437(후속 묶음) — `source_titles`는 {content_item_id: (title, latest_
+    version_id)} 배치조회 결과(호출부가 미리 구해 넘긴다 — 이 함수 자체는 쿼리를
+    안 돈다, N+1 방지 원칙 유지). None/미스=소스 없거나 조회 결과에 없음(둘 다 null로
+    떨어진다 — "모른다≠다르다" 원칙과 달리 여긴 순수 배치 미스 표현)."""
     (
         draft, latest, origin, gate, published_pub, latest_pub, published_body_sha256,
         latest_command, latest_image,
     ) = row
+    source_title: str | None = None
+    source_current_site_post_version_id: uuid.UUID | None = None
+    if draft.source_content_item_id is not None and source_titles is not None:
+        entry = source_titles.get(draft.source_content_item_id)
+        if entry is not None:
+            source_title, source_current_site_post_version_id = entry
     command_status = latest_command.status if latest_command else None
     publication_status = latest_pub.status if latest_pub else None
     # story 620beefc(AC5·§17-15, 페드루 PO 決定) — 판정식은 이 자리 한 곳에서만.
@@ -569,6 +603,9 @@ def _to_draft_list_item(
         image_was_converted=latest_image.was_converted if latest_image else None,
         processing_kind=processing_kind,
         source_content_item_id=draft.source_content_item_id,
+        source_title=source_title,
+        source_site_post_version_id=draft.source_site_post_version_id,
+        source_current_site_post_version_id=source_current_site_post_version_id,
     )
 
 
@@ -637,7 +674,11 @@ async def list_channel_post_drafts_endpoint(
         db, org_id=org_id, limit=limit, offset=offset,
         scheduled_from=scheduled_from, scheduled_to=scheduled_to, unscheduled=unscheduled,
     )
-    return [_to_draft_list_item(row) for row in rows]
+    source_titles = await get_source_titles_and_latest_versions(
+        db, org_id=org_id,
+        content_item_ids={row[0].source_content_item_id for row in rows if row[0].source_content_item_id},
+    )
+    return [_to_draft_list_item(row, source_titles) for row in rows]
 
 
 @router.get(
@@ -661,7 +702,11 @@ async def get_channel_post_draft_detail_endpoint(
     rows = await list_channel_post_drafts(db, org_id=org_id, draft_id=draft_id, limit=1)
     if not rows:
         raise HTTPException(status_code=404, detail=f"draft를 찾을 수 없습니다: {draft_id}")
-    return _to_draft_list_item(rows[0])
+    source_titles = await get_source_titles_and_latest_versions(
+        db, org_id=org_id,
+        content_item_ids={rows[0][0].source_content_item_id} if rows[0][0].source_content_item_id else set(),
+    )
+    return _to_draft_list_item(rows[0], source_titles)
 
 
 @router.get(
@@ -689,7 +734,12 @@ async def list_content_item_variants_endpoint(
     rows = await list_channel_post_drafts(
         db, org_id=org_id, source_content_item_id=content_item_id, limit=200,
     )
-    return [_to_draft_list_item(row) for row in rows]
+    # story #3437(후속 묶음) — 이 엔드포인트는 filter 자체가 content_item_id 단건이라
+    # source_content_item_id가 전부 이 값 하나 — 배치라 해도 실질 단건 조회.
+    source_titles = await get_source_titles_and_latest_versions(
+        db, org_id=org_id, content_item_ids={content_item_id},
+    )
+    return [_to_draft_list_item(row, source_titles) for row in rows]
 
 
 @router.get(

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -92,6 +92,17 @@ class CreateSitePostDraftVersionRequest(BaseModel):
     # B1 처방과 동형 센티널 계약, 아래 엔드포인트 참고).
     connection_id: uuid.UUID | None = None
 
+    # story #3437(후속 묶음, 페드루 PO 確定 2026-09-05) — Pydantic min_length은 strip을
+    # 안 해 공백만("   ")도 통과·저장됐다. conversations.py:1259-1265 정본 패턴 그대로
+    # 미러(새 패턴 발명 0) — 공백만이면 기존 min_length과 동일하게 422.
+    @field_validator("title", "slug", "summary")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
 
 class SitePostDraftVersionResponse(BaseModel):
     draft_id: uuid.UUID
@@ -168,6 +179,16 @@ class PublishSitePostRequest(BaseModel):
     summary: str = Field(..., min_length=1, max_length=1000)
     tags: list[str] = Field(default_factory=list)
     body_md: str = Field(..., min_length=1)
+
+    # story #3437(후속 묶음) — CreateSitePostDraftVersionRequest와 같은 처방(conversations.py
+    # 정본 미러, body_md는 자유서식이라 범위 밖).
+    @field_validator("title", "slug", "summary")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
 
 
 class SitePostResponse(BaseModel):

--- a/backend/app/services/channel_posts.py
+++ b/backend/app/services/channel_posts.py
@@ -35,6 +35,8 @@ from app.models.channel_post_version import ChannelPostVersion
 from app.models.channel_publication import ChannelPublication
 from app.models.gate import Gate, set_gate_status
 from app.models.publication_command import PublicationCommand
+from app.models.site_post_draft import SitePostDraft
+from app.models.site_post_version import SitePostVersion
 from app.services.channel_adapters import get_channel_adapter
 from app.services.channel_connection import decrypt_for_use
 from app.services.gate_seal import (
@@ -393,10 +395,24 @@ async def create_channel_post_draft_version(
     connection = await _get_active_connection(db, org_id=org_id, connection_id=connection_id)
     _validate_text_length(channel=connection.channel, text=text)
 
+    resolved_source_site_post_version_id: uuid.UUID | None = None
     if source_content_item_id is not None:
         content_item = await get_site_post_draft(db, org_id=org_id, draft_id=source_content_item_id)
         if content_item is None:
             raise ChannelPostSourceContentItemNotFoundError(source_content_item_id=source_content_item_id)
+        # story #3437(후속 묶음, 페드루 PO 確定 2026-09-05) — 이 시점의 원문 latest
+        # version.id를 고정 저장(버전 축, source_content_item_id의 draft 축과 별개).
+        # source_content_item_id처럼 **초안 생성 시에만** 반영 — 편집(기존 draft) 호출은
+        # source_content_item_id 자체가 무시되므로(위 docstring) 이 값도 함께 무시된다.
+        latest_source_version = (await db.execute(
+            select(SitePostVersion)
+            .where(SitePostVersion.draft_id == source_content_item_id)
+            .order_by(SitePostVersion.version.desc())
+            .limit(1)
+        )).scalar_one_or_none()
+        resolved_source_site_post_version_id = (
+            latest_source_version.id if latest_source_version is not None else None
+        )
 
     draft = (await db.execute(
         select(ChannelPostDraft)
@@ -411,6 +427,7 @@ async def create_channel_post_draft_version(
             id=uuid.uuid4(), org_id=org_id, work_item_id=work_item_id,
             channel=connection.channel, connection_id=connection_id,
             source_content_item_id=source_content_item_id,
+            source_site_post_version_id=resolved_source_site_post_version_id,
         )
         db.add(draft)
         await db.flush()
@@ -554,6 +571,39 @@ async def list_channel_post_draft_versions(
         .order_by(ChannelPostVersion.version.asc())
     )
     return list((await db.execute(stmt)).scalars().all())
+
+
+async def get_source_titles_and_latest_versions(
+    db: AsyncSession, *, org_id: uuid.UUID, content_item_ids: set[uuid.UUID],
+) -> dict[uuid.UUID, tuple[str, uuid.UUID]]:
+    """story #3437(후속 묶음, 페드루 PO 確定 2026-09-05) — `source_content_item_id`가
+    있는 channel_post_drafts 행들의 원문(제목 + 현재 latest version.id)을 배치 1건으로
+    조회한다. `campaigns.list_content_items_for_campaign`의 latest-version 서브쿼리와
+    동형(campaign_id 필터 대신 draft_id IN 필터) — 새 조인 패턴 발명 0.
+
+    반환: {content_item_id: (title, latest_version_id)}. content_item_ids가 비어 있으면
+    쿼리 자체를 안 돈다(N+1 방지 — 소스 없는 초안만 있는 페이지에서 빈 쿼리 스킵)."""
+    if not content_item_ids:
+        return {}
+    latest_version_ids = (
+        select(
+            SitePostVersion.draft_id,
+            func.max(SitePostVersion.version).label("max_version"),
+        )
+        .group_by(SitePostVersion.draft_id)
+        .subquery()
+    )
+    stmt = (
+        select(SitePostDraft.id, SitePostVersion.title, SitePostVersion.id)
+        .join(latest_version_ids, latest_version_ids.c.draft_id == SitePostDraft.id)
+        .join(
+            SitePostVersion,
+            (SitePostVersion.draft_id == latest_version_ids.c.draft_id)
+            & (SitePostVersion.version == latest_version_ids.c.max_version),
+        )
+        .where(SitePostDraft.org_id == org_id, SitePostDraft.id.in_(content_item_ids))
+    )
+    return {row[0]: (row[1], row[2]) for row in (await db.execute(stmt)).all()}
 
 
 async def list_channel_post_drafts(

--- a/backend/tests/test_3437_followup_strip_validators.py
+++ b/backend/tests/test_3437_followup_strip_validators.py
@@ -1,0 +1,69 @@
+"""story #3437(후속 묶음, 페드루 PO 確定 2026-09-05) — title/slug/summary/text/name
+공백-only 값이 min_length=1을 통과·저장되던 결함(Pydantic min_length은 strip 안 함).
+conversations.py:1259-1265 정본 패턴 미러(field_validator + strip + 빈 문자열 ValueError).
+
+pure 유닛 — Pydantic 모델 인스턴스화만으로 검증(DB 무연결, 실 DB 필요한 라우터/서비스
+계층 회귀 테스트는 backend-test-destructive 쪽 realDB 스위트에 별도)."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.routers.campaigns import CreateCampaignRequest
+from app.routers.channel_posts import CreateChannelPostDraftVersionRequest
+from app.routers.site_posts import CreateSitePostDraftVersionRequest, PublishSitePostRequest
+
+
+class TestSitePostsStrip:
+    @pytest.mark.parametrize("field", ["title", "slug", "summary"])
+    def test_create_draft_version_whitespace_only_rejected(self, field: str) -> None:
+        kwargs = {
+            "work_item_id": uuid.uuid4(), "title": "제목", "slug": "slug", "lang": "ko",
+            "summary": "요약", "body_md": "본문",
+        }
+        kwargs[field] = "   "
+        with pytest.raises(ValidationError, match="must not be empty"):
+            CreateSitePostDraftVersionRequest(**kwargs)
+
+    def test_create_draft_version_trims_surrounding_whitespace(self) -> None:
+        req = CreateSitePostDraftVersionRequest(
+            work_item_id=uuid.uuid4(), title="  제목  ", slug="slug", lang="ko",
+            summary="요약", body_md="본문",
+        )
+        assert req.title == "제목"
+
+    @pytest.mark.parametrize("field", ["title", "slug", "summary"])
+    def test_publish_whitespace_only_rejected(self, field: str) -> None:
+        kwargs = {
+            "work_item_id": uuid.uuid4(), "title": "제목", "slug": "slug", "lang": "ko",
+            "summary": "요약", "body_md": "본문",
+        }
+        kwargs[field] = "   "
+        with pytest.raises(ValidationError, match="must not be empty"):
+            PublishSitePostRequest(**kwargs)
+
+
+class TestChannelPostsStrip:
+    def test_text_whitespace_only_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must not be empty"):
+            CreateChannelPostDraftVersionRequest(
+                work_item_id=uuid.uuid4(), connection_id=uuid.uuid4(), text="   ",
+            )
+
+    def test_text_trims_surrounding_whitespace(self) -> None:
+        req = CreateChannelPostDraftVersionRequest(
+            work_item_id=uuid.uuid4(), connection_id=uuid.uuid4(), text="  본문  ",
+        )
+        assert req.text == "본문"
+
+
+class TestCampaignsStrip:
+    def test_name_whitespace_only_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must not be empty"):
+            CreateCampaignRequest(name="   ")
+
+    def test_name_trims_surrounding_whitespace(self) -> None:
+        req = CreateCampaignRequest(name="  캠페인  ")
+        assert req.name == "캠페인"


### PR DESCRIPTION
## 배경
story [#3437](entity:story:47eca8ec-446b-45d8-bbe7-22bb80bf5648) 후속 묶음(페드루 PO 確定 2026-09-05, 미르코 인수 — 디디는 ④/⑤ 사슬에 묶여 있고 이게 3457 FE 후속의 선행이라 풀스택 배분).

## 변경

### 1. `channel_post_drafts.source_site_post_version_id: UUID NULL`(마이그 0325, down_revision=0324)
`source_content_item_id`(0321)가 "어느 draft에서 파생됐나"(draft 축)만 가리키는 것과 달리, 이 컬럼은 "그 draft의 몇 번 버전에서 파생됐나"(버전 축)를 초안 생성 시점에 고정합니다 — 원문이 그 뒤 새 버전을 내도 이 값은 안 바뀝니다(staleness 판별의 기준점). FK 없음(동일 관례).

### 2. `ChannelPostDraftListItem` 3개 필드 추가
`source_title`·`source_site_post_version_id`·`source_current_site_post_version_id`(원문의 지금 latest version.id, 배치조회). 새 서비스 함수 `get_source_titles_and_latest_versions()`(`campaigns.py::list_content_items_for_campaign`의 latest-version 서브쿼리 재사용, 새 패턴 발명 0) — `_to_draft_list_item()`이 optional lookup dict를 받아 조립(호출부가 미리 배치조회, 함수 자체는 쿼리 0).

그라운딩 결과 목록·상세(`GET drafts/{draft_id}`)·variants·campaigns 상세 4개 엔드포인트 전부 `_to_draft_list_item()` 하나를 공유해 스키마 확장 1건으로 4곳 동시 커버(PO 지적 ③에 대한 답 — 범위 확장 아님).

### 3. strip validator 5곳
site_posts(`title`/`slug`/`summary`×2클래스: `CreateSitePostDraftVersionRequest`·`PublishSitePostRequest`)·channel_posts(`text`)·campaigns(`name`) — `conversations.py:1259-1265` 정본 패턴 그대로 미러(`@field_validator`+`.strip()`+빈 문자열 ValueError). `body_md`/`tags`는 자유서식이라 범위 밖(PO 확定 그대로).

## 검증
- 로컬 postgres(brew postgresql@16)로 마이그레이션 체인 실 재현: `alembic upgrade heads`(0297→0325 전체 재생, 신규 컬럼 확인)·`alembic downgrade -1`(컬럼 제거 확인)·재-upgrade
- 신규 pure 유닛 `test_3437_followup_strip_validators.py` 11 tests green(Pydantic 인스턴스화만)
- 영향받은 기존 DB 회귀 스위트 전부 green(격리 실행, 각 파일 fresh 스키마): `test_3437_content_ledger_projection.py`(12)·`test_3403_channel_post_draft_detail.py`(7)·`test_3394_channel_post_list_be_fields.py`(10)·`test_3374_channel_posts.py`(9)·`test_3365_site_post_drafts.py`(5)·`test_3369_publish_site_post_from_draft.py`(10)·`test_3437_campaign_patch_no_version_no_gate_touch.py`(3)·`test_3457_campaigns_list_and_version_campaign_fields.py`(5) — 총 61 tests green
- 5개 모듈 import 정상

base는 develop(#3800·#3815 병합 후 rebase 완료, 충돌 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)