### PR TITLE
[SID:3457] feat: 파생 표기(캘린더·목록·상세) + AC3 staleness 배지

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2275,6 +2275,7 @@
     "channelPostsSandboxTestBadge": "Test",
     "channelPostsSourceLabel": "Same story as",
     "channelPostsSourceLinkText": "“{title}” (blog)",
+    "channelPostsSourceChangedBadge": "Changed since",
     "channelPostsCreateVariantLabel": "Create a channel variant from this post",
     "channelPostsCreateVariantSelectPlaceholder": "Choose a connection",
     "channelPostsCreateVariantCta": "Create variant",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2275,6 +2275,7 @@
     "channelPostsSandboxTestBadge": "테스트",
     "channelPostsSourceLabel": "같은 스토리의 글",
     "channelPostsSourceLinkText": "「{title}」(블로그)",
+    "channelPostsSourceChangedBadge": "만든 뒤 바뀜",
     "channelPostsCreateVariantLabel": "이 글에서 채널 변형 만들기",
     "channelPostsCreateVariantSelectPlaceholder": "연결 선택",
     "channelPostsCreateVariantCta": "변형 만들기",

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -84,6 +84,10 @@ const DRAFT_DETAIL = {
   command_id: null as string | null,
   // story 15e481ce(#3453 AC2) — 이 채널 변형이 파생된 원문.
   source_content_item_id: null as string | null,
+  // story #3457 후속(BE #3817 착지분) — 원문 제목 + staleness 판정용 버전 id 2종.
+  source_title: null as string | null,
+  source_site_post_version_id: null as string | null,
+  source_current_site_post_version_id: null as string | null,
 };
 const VERSION_1 = {
   version_id: 'v1', version: 1, draft_id: DRAFT_ID, text: '초안 본문입니다', link_url: null,
@@ -134,9 +138,6 @@ function stubFetch(opts: {
   // command_status='pending').
   onRetry?: (commandId: string) => { status: number; body?: unknown };
   draftAfterRetry?: Record<string, unknown>;
-  // story 15e481ce(#3453 AC2) — draft.source_content_item_id가 있을 때 그 원문의 제목을
-  // 읽는 versions 조회(마지막 버전의 title).
-  sourceVersions?: { title: string }[];
 }) {
   const versions = opts.versions ?? [VERSION_1];
   const draftDetail: Record<string, unknown> = { ...DRAFT_DETAIL, ...opts.draftDetail };
@@ -157,10 +158,6 @@ function stubFetch(opts: {
       }
       if (url === `/api/organizations/${ORG_ID}/channel-posts/drafts/${DRAFT_ID}/versions`) {
         return { ok: true, status: 200, json: async () => ({ data: versions, error: null, meta: null }) };
-      }
-      if (opts.draftDetail?.source_content_item_id
-        && url === `/api/organizations/${ORG_ID}/site-posts/drafts/${opts.draftDetail.source_content_item_id}/versions`) {
-        return { ok: true, status: 200, json: async () => ({ data: opts.sourceVersions ?? [{ title: '9월 실험 회고' }], error: null, meta: null }) };
       }
       if (url === `/api/organizations/${ORG_ID}/channel-connections`) {
         // 페드루 PO nit(2026-09-04 09:07Z) — 연결 조회 자체가 실패하면 unpublishGate가
@@ -1999,7 +1996,11 @@ describe('ChannelPostEditPage — §17-15 processing_kind 오버레이 우선순
 });
 
 // story 15e481ce(#3453 AC2, 유나 §14-2) — "같은 스토리의 글"(정방향, 상세 머리).
-describe('ChannelPostEditPage — 같은 스토리의 글(story 15e481ce AC2, §14-2)', () => {
+// story #3457 후속(BE #3817 착지분) — source_title이 이제 단건 GET 응답에 직접
+// 실려 별도 왕복(구 site-posts/drafts/{id}/versions)이 없다 — 이 스위트가 그 제거를
+// pin한다(네트워크 호출 수 assert). staleness 배지(유나 정본 2026-09-04 20:57Z)는
+// source_site_post_version_id/source_current_site_post_version_id 4개 상태 조합.
+describe('ChannelPostEditPage — 같은 스토리의 글 + 배지(story 15e481ce AC2·#3457 후속, §14-2/§11-5)', () => {
   it('source_content_item_id가 없으면(정상값) 이 줄 자체가 안 그려진다', async () => {
     stubFetch({});
     await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
@@ -2007,10 +2008,9 @@ describe('ChannelPostEditPage — 같은 스토리의 글(story 15e481ce AC2, §
     expect(container.querySelector('[data-testid="channel-post-source-link"]')).toBeNull();
   });
 
-  it('⭐source_content_item_id가 있으면 원문 제목을 읽어 "같은 스토리의 글" 링크로 보인다("원문" 단정 아님)', async () => {
+  it('⭐source_title이 응답에 직접 실려 오면 별도 왕복 없이 "같은 스토리의 글" 링크로 보인다("원문" 단정 아님)', async () => {
     stubFetch({
-      draftDetail: { source_content_item_id: 'site-1' },
-      sourceVersions: [{ title: '9월 실험 회고' }],
+      draftDetail: { source_content_item_id: 'site-1', source_title: '9월 실험 회고' },
     });
     await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
     await flush();
@@ -2019,6 +2019,53 @@ describe('ChannelPostEditPage — 같은 스토리의 글(story 15e481ce AC2, §
     expect(el?.textContent).toContain(koMessages.content.channelPostsSourceLabel);
     expect(el?.textContent).toContain('9월 실험 회고');
     expect(el?.querySelector('a')?.getAttribute('href')).toBe('/content/site-1');
+    // 구 워크어라운드(site-posts/drafts/{id}/versions)로의 호출이 0건 — 왕복 제거 pin.
+    const urls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(urls.some((u) => u.includes('/site-posts/drafts/site-1/versions'))).toBe(false);
+  });
+
+  it('source_site_post_version_id가 null(레거시 파생분)이면 배지를 안 그린다(모른다≠다르다)', async () => {
+    stubFetch({
+      draftDetail: {
+        source_content_item_id: 'site-1', source_title: '9월 실험 회고',
+        source_site_post_version_id: null, source_current_site_post_version_id: 'v-current',
+      },
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+    expect(container.querySelector('[data-testid="channel-post-source-changed-badge"]')).toBeNull();
+  });
+
+  it('두 버전 id가 같으면(원문 안 바뀜) 배지를 안 그린다', async () => {
+    stubFetch({
+      draftDetail: {
+        source_content_item_id: 'site-1', source_title: '9월 실험 회고',
+        source_site_post_version_id: 'v-same', source_current_site_post_version_id: 'v-same',
+      },
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+    expect(container.querySelector('[data-testid="channel-post-source-changed-badge"]')).toBeNull();
+  });
+
+  it('⭐두 버전 id가 다르면(원문이 파생 이후 개정됨) 배지가 "같은 스토리의 글" 줄 옆에 뜬다', async () => {
+    stubFetch({
+      draftDetail: {
+        source_content_item_id: 'site-1', source_title: '9월 실험 회고',
+        source_site_post_version_id: 'v-old', source_current_site_post_version_id: 'v-new',
+      },
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const sourceLine = container.querySelector('[data-testid="channel-post-source-link"]');
+    const badge = sourceLine?.querySelector('[data-testid="channel-post-source-changed-badge"]');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toBe(koMessages.content.channelPostsSourceChangedBadge);
+    // 유나 정본 — StatusChip 색 톤이 아니라 SandboxTestBadge와 같은 무채 테두리(border-border).
+    expect(badge?.className).toContain('border-border');
+    expect(badge?.className).not.toContain('bg-warning');
+    expect(badge?.className).not.toContain('bg-destructive');
   });
 });
 

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -89,6 +89,15 @@ interface ChannelPostDraftDetail {
   // story 15e481ce(#3453 AC2, 3437 위) — 이 채널 변형이 파생된 원문(site-posts draft
   // id). 없으면 null(소스 없는 단독 채널 초안, 정상값 — 유나 §14-3 "null이 정상값").
   source_content_item_id?: string | null;
+  // story #3457 후속(BE #3817 착지분) — 원문 제목(배치조회, 이 필드 하나로 별도 왕복
+  // 제거). source_content_item_id가 null이면 이것도 항상 null.
+  source_title?: string | null;
+  // 이 변형이 파생된 시점의 원문 latest version.id(버전 축, 초안 생성 시 고정).
+  source_site_post_version_id?: string | null;
+  // 원문의 지금 latest version.id(배치조회, 매 응답마다 최신값). 두 값이 다르면(둘 다
+  // non-null일 때만 판정 — "모른다≠다르다") "원문이 파생 이후 개정됨" — 서버는 판정
+  // 라벨 없이 두 값만 낸다, 배지는 화면 몫(§11-5).
+  source_current_site_post_version_id?: string | null;
 }
 
 interface ChannelPostVersion {
@@ -198,11 +207,6 @@ export default function ChannelPostEditPage() {
   const [limit, setLimit] = useState<PublishingLimitState>({ status: 'loading' });
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
-  // story 15e481ce(#3453 AC2) — 유나 §14-2 안전 표기("같은 스토리의 글", "원문" 단정
-  // 아님). source_content_item_id가 있을 때만 그 원문의 제목을 하나 더 읽는다(단건
-  // GET이 없어 versions BFF의 최신판 title로 — 이미 있는 라우트 재사용, 신규 왕복 1개
-  // 뿐 — 목록이 아니라 상세라 §3-2 "행마다 왕복" 금지 대상이 아니다).
-  const [sourceTitle, setSourceTitle] = useState<string | undefined>(undefined);
 
   // story #3428(T3-M·§17-16) — 어댑터가 선언한 이미지 규격(연결 응답에서 읽음).
   // undefined="아직 모른다"(연결 조회 전/실패) — maxCount<=0과 동형으로 첨부 칸을
@@ -302,16 +306,6 @@ export default function ChannelPostEditPage() {
         if (latest) {
           setText(latest.text);
           setLinkUrl(latest.link_url ?? '');
-        }
-        if (d?.source_content_item_id) {
-          fetchWithAuth(`/api/organizations/${orgId}/site-posts/drafts/${d.source_content_item_id}/versions`)
-            .then(async (r) => {
-              if (cancelled || !r.ok) return;
-              const json = (await r.json().catch(() => null)) as { data?: { title: string }[] } | null;
-              const sourceLatest = json?.data?.[json.data.length - 1];
-              if (sourceLatest) setSourceTitle(sourceLatest.title);
-            })
-            .catch(() => {});
         }
         if (d) {
           const connRes = await fetchWithAuth(`/api/organizations/${orgId}/channel-connections`);
@@ -891,14 +885,30 @@ export default function ChannelPostEditPage() {
         </p>
         {/* story 15e481ce(#3453 AC2, 유나 §14-2 안전 표기) — "원문" 단정이 아니라 "같은
             스토리의 글". source_content_item_id 없으면(정상값) 이 줄 자체를 안 그린다.
-            제목을 아직 못 읽었으면(sourceTitle undefined) id 자체는 있지만 이 왕복이
-            느릴 뿐이라 조용히 넘긴다(빈 문장을 지어내지 않는다). */}
-        {draft.source_content_item_id && sourceTitle ? (
-          <p className="text-sm text-muted-foreground" data-testid="channel-post-source-link">
-            {t('channelPostsSourceLabel')}{' '}
-            <Link href={`/content/${draft.source_content_item_id}`} className="underline">
-              {t('channelPostsSourceLinkText', { title: sourceTitle })}
-            </Link>
+            #3457 후속(BE #3817 착지분) — source_title이 이제 이 응답에 직접 실려 별도
+            왕복이 없다.
+            §11-5 staleness 배지(유나 정본 2026-09-04 20:57Z) — 이 줄 옆에만(칩 열이
+            아니라, "원문 줄 없는데 배지만"이 구조적으로 안 나오게). source_site_post_
+            version_id·source_current_site_post_version_id 둘 중 하나라도 null이면
+            "모른다≠다르다" 원칙으로 안 그린다(레거시 파생분=#3817 前 생성, 값 자체가
+            없다). */}
+        {draft.source_content_item_id && draft.source_title ? (
+          <p className="flex flex-wrap items-center gap-1.5 text-sm text-muted-foreground" data-testid="channel-post-source-link">
+            <span>
+              {t('channelPostsSourceLabel')}{' '}
+              <Link href={`/content/${draft.source_content_item_id}`} className="underline">
+                {t('channelPostsSourceLinkText', { title: draft.source_title })}
+              </Link>
+            </span>
+            {draft.source_site_post_version_id && draft.source_current_site_post_version_id
+              && draft.source_site_post_version_id !== draft.source_current_site_post_version_id ? (
+              <span
+                className="inline-flex items-center rounded-full border border-border px-1.5 py-0.5 text-xs text-muted-foreground"
+                data-testid="channel-post-source-changed-badge"
+              >
+                {t('channelPostsSourceChangedBadge')}
+              </span>
+            ) : null}
           </p>
         ) : null}
       </div>

--- a/apps/web/src/app/(authenticated)/content/channel-posts/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/page.test.tsx
@@ -236,4 +236,26 @@ describe('ChannelPostListPage (story #3402)', () => {
 
     expect(container.textContent).toContain(koMessages.content.channelPostsLoadFailed);
   });
+
+  // story #3457 후속(유나 §14-2 안전 표기, PO 확定 2026-09-04 20:54Z) — 캘린더 카드·목록
+  // 행·상세 3곳이 같은 어휘. 목록 행은 파생 표기만(배지는 상세 전용, 유나 정본).
+  describe('같은 스토리의 글(목록 행, §14-2)', () => {
+    it('source_content_item_id가 없으면(정상값) 이 줄 자체가 안 그려진다', async () => {
+      stubFetch([DRAFT_A]);
+      await act(async () => { root.render(wrap(<ChannelPostListPage />)); });
+      await flush();
+      expect(container.querySelector('[data-testid="channel-post-source-link"]')).toBeNull();
+    });
+
+    it('⭐source_title이 있으면 "같은 스토리의 글" 링크가 행 안에 보인다', async () => {
+      stubFetch([{ ...DRAFT_A, source_content_item_id: 'site-1', source_title: '9월 실험 회고' }]);
+      await act(async () => { root.render(wrap(<ChannelPostListPage />)); });
+      await flush();
+
+      const el = container.querySelector('[data-testid="channel-post-source-link"]');
+      expect(el?.textContent).toContain(koMessages.content.channelPostsSourceLabel);
+      expect(el?.textContent).toContain('9월 실험 회고');
+      expect(el?.querySelector('a')?.getAttribute('href')).toBe('/content/site-1');
+    });
+  });
 });

--- a/apps/web/src/app/(authenticated)/content/channel-posts/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/page.tsx
@@ -54,6 +54,10 @@ interface ChannelPostDraftListItem {
   // 임시 표시가 착지 즉시 자동으로 실제 본문 미리보기로 바뀐다, 이 페이지는 수정 불필요).
   text_preview?: string | null;
   text_length?: number | null;
+  // story #3457 후속(BE #3817 착지분) — "같은 스토리의 글"(§14-2 안전 표기) 보조줄.
+  // source_content_item_id가 없으면(정상값) 그 줄 자체를 안 그린다.
+  source_content_item_id?: string | null;
+  source_title?: string | null;
 }
 
 // content/page.tsx::toGateStatus와 동형.
@@ -194,6 +198,17 @@ export default function ChannelPostListPage() {
                         >
                           {t('channelPostsPublicationFailed')}
                         </span>
+                      ) : null}
+                      {/* story #3457 후속(유나 §14-2 안전 표기, PO 확定 2026-09-04 20:54Z) —
+                          캘린더 카드·목록 행·상세 3곳이 같은 어휘. source_title 없으면(정상값,
+                          단독 글 또는 아직 못 읽음) 이 줄 자체를 안 그린다. */}
+                      {draft.source_content_item_id && draft.source_title ? (
+                        <p className="mt-0.5 truncate text-xs text-muted-foreground" data-testid="channel-post-source-link">
+                          {t('channelPostsSourceLabel')}{' '}
+                          <Link href={`/content/${draft.source_content_item_id}`} className="underline">
+                            {t('channelPostsSourceLinkText', { title: draft.source_title })}
+                          </Link>
+                        </p>
                       ) : null}
                     </td>
                     <td className="px-3 py-2.5 text-muted-foreground">

--- a/apps/web/src/components/content/channel-post-card.test.tsx
+++ b/apps/web/src/components/content/channel-post-card.test.tsx
@@ -164,4 +164,29 @@ describe('ChannelPostCard — story #3422, 격자·레인 공용 렌더 단위',
     });
     expect(container.querySelector('[data-testid="channel-post-sandbox-test-badge"]')).toBeNull();
   });
+
+  // story #3457 후속(유나 §14-2 안전 표기, PO 확定 2026-09-04 20:54Z) — 카드 전체가 이미
+  // <Link>라 원문 링크는 중첩 불가(a>a 무효 HTML) — 평문으로만. 배지는 상세 전용(유나
+  // 정본) — 카드엔 안 그린다.
+  it('source_content_item_id가 없으면(정상값) "같은 스토리의 글" 줄이 안 그려진다', async () => {
+    await act(async () => {
+      root.render(wrap(<ChannelPostCard item={BASE_ITEM} displayTimezone="Asia/Seoul" />));
+    });
+    expect(container.querySelector('[data-testid="channel-post-calendar-card-source"]')).toBeNull();
+  });
+
+  it('⭐source_title이 있으면 "같은 스토리의 글" 평문(링크 아님, 카드 자체가 이미 링크)이 보인다', async () => {
+    await act(async () => {
+      root.render(wrap(
+        <ChannelPostCard
+          item={{ ...BASE_ITEM, source_content_item_id: 'site-1', source_title: '9월 실험 회고' }}
+          displayTimezone="Asia/Seoul"
+        />,
+      ));
+    });
+    const el = container.querySelector('[data-testid="channel-post-calendar-card-source"]');
+    expect(el?.textContent).toContain(koMessages.content.channelPostsSourceLabel);
+    expect(el?.textContent).toContain('9월 실험 회고');
+    expect(el?.querySelector('a')).toBeNull();
+  });
 });

--- a/apps/web/src/components/content/channel-post-card.tsx
+++ b/apps/web/src/components/content/channel-post-card.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { deriveChannelPostView, type ChannelPublicationStatus } from '@/components/content/channel-post-status';
 import { StatusChip } from '@/components/content/status-chip';
 import { formatScheduledAt } from '@/components/content/schedule-format';
@@ -19,6 +20,7 @@ export interface ChannelPostCardProps {
 }
 
 export function ChannelPostCard({ item, displayTimezone }: ChannelPostCardProps) {
+  const t = useTranslations('content');
   const hasGateContract = 'gate_status' in item;
   const view = hasGateContract
     ? deriveChannelPostView({
@@ -69,6 +71,15 @@ export function ChannelPostCard({ item, displayTimezone }: ChannelPostCardProps)
       {failureAction ? <FailureActionBadge action={failureAction} displayTimezone={displayTimezone} compact /> : null}
       {item.text_preview ? (
         <p className="truncate text-foreground" data-testid="channel-post-calendar-card-preview">{item.text_preview}</p>
+      ) : null}
+      {/* story #3457 후속(유나 §14-2 안전 표기, PO 확定 2026-09-04 20:54Z) — 카드 전체가
+          이미 <Link>라 원문 페이지로 가는 중첩 링크는 못 넣는다(a>a 무효 HTML) — 목록/상세와
+          같은 어휘를 평문으로만(카드 클릭 → 상세에서 실제 링크). source_title 없으면
+          (정상값) 이 줄 자체를 안 그린다. */}
+      {item.source_content_item_id && item.source_title ? (
+        <p className="truncate text-muted-foreground" data-testid="channel-post-calendar-card-source">
+          {t('channelPostsSourceLabel')} {t('channelPostsSourceLinkText', { title: item.source_title })}
+        </p>
       ) : null}
     </Link>
   );

--- a/apps/web/src/components/content/use-channel-post-calendar-data.ts
+++ b/apps/web/src/components/content/use-channel-post-calendar-data.ts
@@ -30,6 +30,10 @@ export interface ChannelPostCalendarItem {
   next_retry_at?: string | null;
   processing_kind?: string | null;
   text_preview?: string;
+  // story #3457 후속(BE #3817 착지분) — "같은 스토리의 글"(§14-2 안전 표기), 목록/상세와
+  // 같은 어휘. source_content_item_id 없으면(정상값) 카드가 이 줄 자체를 안 그린다.
+  source_content_item_id?: string | null;
+  source_title?: string | null;
 }
 
 export interface ChannelPostCalendarData {


### PR DESCRIPTION
## 배경
story #3457 계열 FE 후속(PO 확定 2026-09-04 20:54Z·20:57Z, 유나 배지 정본 병행) — BE #3817(`source_title`/`source_site_post_version_id`/`source_current_site_post_version_id`) 소비.

## 변경

### 파생 표기(§14-2 안전 표기 "같은 스토리의 글", 새 키 불요 — 기존 `channelPostsSourceLabel`/`channelPostsSourceLinkText` 재사용) 3곳 동일 어휘
- `channel-posts/[draftId]/page.tsx` — 구 워크어라운드(`source_content_item_id`가 있으면 `GET site-posts/drafts/{id}/versions`로 별도 왕복해 제목을 읽던 것)를 제거, `source_title`을 단건 GET 응답에서 직접 읽습니다(BFF 왕복 1건 감소).
- `content/channel-posts/page.tsx`(목록 행) — `source_title` 있으면 제목 아래 보조줄, 없으면(정상값) 안 그립니다.
- `channel-post-card.tsx`(캘린더 카드) — 카드 전체가 이미 `<Link>`라 원문 링크는 중첩 불가(`a>a` 무효 HTML) — 같은 어휘를 평문으로만 표시합니다.

### AC3 staleness 배지(유나 정본 2026-09-04 20:57Z, 상세 전용 — 목록·캘린더는 파생 표기만)
새 키 `channelPostsSourceChangedBadge`(ko 「만든 뒤 바뀜」/en "Changed since"). 자리=§14-2 줄 옆(칩 열 아님 — "원문 줄 없는데 배지만"이 구조적으로 안 나오게). 형태=`SandboxTestBadge`와 같은 무채 테두리(`border-border`+`text-muted-foreground`) — StatusChip·경고색 금지.

산식: `source_site_post_version_id`·`source_current_site_post_version_id` 둘 다 non-null이고 서로 다를 때만("모른다≠다르다" — 레거시 파생분은 null이라 안 그림).

## 검증
- 신규/갱신 pin — 상세 5건(`source_title` 직접 소비+구 왕복 0건 assert 포함·staleness 4상태 조합)·목록 2건·캘린더 카드 2건, 총 9건 신규 — 관련 4개 테스트 파일 155 tests green(회귀 0)
- 전체 `pnpm vitest run`: 627 files / 5896 tests green
- `tsc --noEmit` clean, eslint clean
- i18n 가드(hanja·duplicate-keys·phrase-collision) clean

base는 develop(#3817 병합 후 rebase 완료, 충돌 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)