### PR TITLE
[SID:3450] feat: WordPress/webhook 채널 연결 BFF 라우트 신설

### DIFF
--- a/apps/web/src/app/api/organizations/[id]/channel-connections/webhook/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-connections/webhook/route.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { proxyToFastapiWithParams } = vi.hoisted(() => ({ proxyToFastapiWithParams: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { POST } from './route';
+
+// story e4fc29fa(조각⑤) — sandbox/route.test.ts·wordpress/route.test.ts와 동형(3건:
+// 성공·403 HUMAN_ONLY 통과·422 DESTINATION_INSECURE 통과) — 검증 로직 0인
+// pass-through BFF라 새 시나리오 발명 없이 선례를 그대로 미러.
+describe('/api/organizations/[id]/channel-connections/webhook (story e4fc29fa 조각⑤)', () => {
+  it('POST — FastAPI webhook 연결 생성 엔드포인트로 id·body를 그대로 위임', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: 'c1', channel: 'webhook', account_id: 'https://hook.example.com/in', status: 'active' }),
+        { status: 201, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const request = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ target_url: 'https://hook.example.com/in', secret: 'shh' }),
+    });
+    const resp = await POST(request, { params: Promise.resolve({ id: 'org-1' }) });
+
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      request, '/api/v2/organizations/[id]/channel-connections/webhook', { id: 'org-1' },
+    );
+    expect(resp.status).toBe(201);
+  });
+
+  it('POST — 에이전트 헤더로 온 요청도 BE의 CHANNEL_CONNECTION_HUMAN_ONLY 403을 그대로 통과시킨다(삼키지 않음)', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: { code: 'CHANNEL_CONNECTION_HUMAN_ONLY' } }), {
+        status: 403, headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const request = new Request('http://test', { method: 'POST', headers: { Authorization: 'Bearer agent-key-123' } });
+    const resp = await POST(request, { params: Promise.resolve({ id: 'org-1' }) });
+    expect(resp.status).toBe(403);
+  });
+
+  it('POST — BE의 CHANNEL_CONNECTION_DESTINATION_INSECURE 422도 그대로 통과시킨다(SSRF 목적지 거부)', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: { code: 'CHANNEL_CONNECTION_DESTINATION_INSECURE' } }), {
+        status: 422, headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const request = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ target_url: 'http://localhost:1337', secret: 'shh' }),
+    });
+    const resp = await POST(request, { params: Promise.resolve({ id: 'org-1' }) });
+    expect(resp.status).toBe(422);
+  });
+});

--- a/apps/web/src/app/api/organizations/[id]/channel-connections/webhook/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-connections/webhook/route.ts
@@ -1,0 +1,19 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// story e4fc29fa(조각⑤, BE #3802 착지) — webhook 연결 생성(owner/admin 휴먼 세션
+// 전용, BE `_require_owner_or_admin`). channel-connections/sandbox/route.ts·wordpress/
+// route.ts와 동형 — FE에 대응 BFF가 없어 브라우저에서 만들 길이 없던 갭(PO 실측
+// 404). 검증 로직 0, body(target_url/secret) pass-through 그대로,
+// CHANNEL_CONNECTION_HUMAN_ONLY(403)·CHANNEL_CONNECTION_DESTINATION_INSECURE(422)·
+// WEBHOOK_FIELDS_REQUIRED(422)·401 전부 서버 응답 그대로 pass-through.
+export async function POST(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(
+    request, '/api/v2/organizations/[id]/channel-connections/webhook', { id },
+  );
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json(), undefined, _r.status);
+}

--- a/apps/web/src/app/api/organizations/[id]/channel-connections/wordpress/route.test.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-connections/wordpress/route.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { proxyToFastapiWithParams } = vi.hoisted(() => ({ proxyToFastapiWithParams: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
+
+import { POST } from './route';
+
+// story e4fc29fa(조각⑤) — sandbox/route.test.ts와 동형(3건: 성공·403 HUMAN_ONLY 통과·
+// 422 DESTINATION_INSECURE 통과) — 검증 로직 0인 pass-through BFF라 새 시나리오
+// 발명 없이 sandbox 선례를 그대로 미러.
+describe('/api/organizations/[id]/channel-connections/wordpress (story e4fc29fa 조각⑤)', () => {
+  it('POST — FastAPI WordPress 연결 생성 엔드포인트로 id·body를 그대로 위임', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: 'c1', channel: 'wordpress', account_id: 'https://blog.example.com', status: 'active' }),
+        { status: 201, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const request = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ site_url: 'https://blog.example.com', username: 'admin', app_password: 'secret' }),
+    });
+    const resp = await POST(request, { params: Promise.resolve({ id: 'org-1' }) });
+
+    expect(proxyToFastapiWithParams).toHaveBeenCalledWith(
+      request, '/api/v2/organizations/[id]/channel-connections/wordpress', { id: 'org-1' },
+    );
+    expect(resp.status).toBe(201);
+  });
+
+  it('POST — 에이전트 헤더로 온 요청도 BE의 CHANNEL_CONNECTION_HUMAN_ONLY 403을 그대로 통과시킨다(삼키지 않음)', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: { code: 'CHANNEL_CONNECTION_HUMAN_ONLY' } }), {
+        status: 403, headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const request = new Request('http://test', { method: 'POST', headers: { Authorization: 'Bearer agent-key-123' } });
+    const resp = await POST(request, { params: Promise.resolve({ id: 'org-1' }) });
+    expect(resp.status).toBe(403);
+  });
+
+  it('POST — BE의 CHANNEL_CONNECTION_DESTINATION_INSECURE 422도 그대로 통과시킨다(SSRF 목적지 거부)', async () => {
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify({ detail: { code: 'CHANNEL_CONNECTION_DESTINATION_INSECURE' } }), {
+        status: 422, headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const request = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ site_url: 'http://localhost:1337', username: 'admin', app_password: 'secret' }),
+    });
+    const resp = await POST(request, { params: Promise.resolve({ id: 'org-1' }) });
+    expect(resp.status).toBe(422);
+  });
+});

--- a/apps/web/src/app/api/organizations/[id]/channel-connections/wordpress/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/channel-connections/wordpress/route.ts
@@ -1,0 +1,19 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// story e4fc29fa(조각⑤, BE #3802 착지) — WordPress 연결 생성(owner/admin 휴먼 세션
+// 전용, BE `_require_owner_or_admin`). channel-connections/sandbox/route.ts와 동형 —
+// FE에 대응 BFF가 없어 브라우저에서 만들 길이 없던 갭(PO 실측 404). 검증 로직 0,
+// body(site_url/username/app_password) pass-through 그대로, CHANNEL_CONNECTION_
+// HUMAN_ONLY(403)·CHANNEL_CONNECTION_DESTINATION_INSECURE(422)·WORDPRESS_FIELDS_
+// REQUIRED(422)·401 전부 서버 응답 그대로 pass-through.
+export async function POST(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(
+    request, '/api/v2/organizations/[id]/channel-connections/wordpress', { id },
+  );
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json(), undefined, _r.status);
+}


### PR DESCRIPTION
## 배경
PO 실측(런북 라이브 관문, 2026-09-04 22:15Z) — BE ⑤(#3802, `POST /{org_id}/channel-connections/{channel}`, wordpress/webhook 지원)는 착지했지만 FE BFF에 대응 라우트가 없어 휴먼이 브라우저에서 그 API에 닿을 자리가 없었습니다(404).

## 변경
`channel-connections/sandbox/route.ts`와 완전히 동형(검증 로직 0, pass-through) — 2개 새 라우트, 각각 BE의 리터럴 channel 경로로 위임:
- `channel-connections/wordpress/route.ts` → `/api/v2/.../channel-connections/wordpress`
- `channel-connections/webhook/route.ts` → `/api/v2/.../channel-connections/webhook`

body(`site_url`/`username`/`app_password`·`target_url`/`secret`)는 `proxyToFastapi`가 이미 모든 non-GET 요청에 통째로 전달하므로(`fastapi-proxy.ts:73-74`) 별도 코드가 필요 없습니다. `!ok` 응답(`CHANNEL_CONNECTION_HUMAN_ONLY` 403·`CHANNEL_CONNECTION_DESTINATION_INSECURE` 422·`WORDPRESS_FIELDS_REQUIRED`/`WEBHOOK_FIELDS_REQUIRED` 422·401) 전부 그대로 pass-through — 삼키지 않습니다.

연결 "화면"(입력 폼)은 이 PR 범위 밖(유나 §3653a18c 대조 뒤 별도, PO 지시).

## 검증
- 신규 `route.test.ts` 2파일×3건(성공·403 HUMAN_ONLY 통과·422 DESTINATION_INSECURE 통과, sandbox 선례 그대로 미러) 6 tests green
- 전체 `pnpm vitest run`: 629 files / 5902 tests green
- `tsc --noEmit` clean, eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)