### PR TITLE
[SID:3453] fix: source_changed 서버 판정 이관 + 발행 상태별 배지 문구(AC3 후속)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2276,6 +2276,7 @@
     "channelPostsSourceLabel": "Same story as",
     "channelPostsSourceLinkText": "“{title}” (blog)",
     "channelPostsSourceChangedBadge": "Changed since",
+    "channelPostsSourceChangedBadgePublished": "As created",
     "channelPostsCreateVariantLabel": "Create a channel variant from this post",
     "channelPostsCreateVariantSelectPlaceholder": "Choose a connection",
     "channelPostsCreateVariantCta": "Create variant",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2276,6 +2276,7 @@
     "channelPostsSourceLabel": "같은 스토리의 글",
     "channelPostsSourceLinkText": "「{title}」(블로그)",
     "channelPostsSourceChangedBadge": "만든 뒤 바뀜",
+    "channelPostsSourceChangedBadgePublished": "만들 때 판 그대로",
     "channelPostsCreateVariantLabel": "이 글에서 채널 변형 만들기",
     "channelPostsCreateVariantSelectPlaceholder": "연결 선택",
     "channelPostsCreateVariantCta": "변형 만들기",

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.test.tsx
@@ -88,6 +88,8 @@ const DRAFT_DETAIL = {
   source_title: null as string | null,
   source_site_post_version_id: null as string | null,
   source_current_site_post_version_id: null as string | null,
+  // story #3453 AC3 후속(BE 판정 이관) — null=모른다(기본값).
+  source_changed: null as boolean | null,
 };
 const VERSION_1 = {
   version_id: 'v1', version: 1, draft_id: DRAFT_ID, text: '초안 본문입니다', link_url: null,
@@ -1998,9 +2000,9 @@ describe('ChannelPostEditPage — §17-15 processing_kind 오버레이 우선순
 // story 15e481ce(#3453 AC2, 유나 §14-2) — "같은 스토리의 글"(정방향, 상세 머리).
 // story #3457 후속(BE #3817 착지분) — source_title이 이제 단건 GET 응답에 직접
 // 실려 별도 왕복(구 site-posts/drafts/{id}/versions)이 없다 — 이 스위트가 그 제거를
-// pin한다(네트워크 호출 수 assert). staleness 배지(유나 정본 2026-09-04 20:57Z)는
-// source_site_post_version_id/source_current_site_post_version_id 4개 상태 조합.
-describe('ChannelPostEditPage — 같은 스토리의 글 + 배지(story 15e481ce AC2·#3457 후속, §14-2/§11-5)', () => {
+// pin한다(네트워크 호출 수 assert). staleness 배지(유나 정본 2026-09-04 20:57Z, #3453
+// AC3 후속 페드루 PO 確定 2026-09-05로 판정 서버 이관) — source_changed 하나만 본다.
+describe('ChannelPostEditPage — 같은 스토리의 글 + 배지(story 15e481ce AC2·#3457/#3453 AC3 후속, §14-2/§11-5)', () => {
   it('source_content_item_id가 없으면(정상값) 이 줄 자체가 안 그려진다', async () => {
     stubFetch({});
     await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
@@ -2024,11 +2026,10 @@ describe('ChannelPostEditPage — 같은 스토리의 글 + 배지(story 15e481c
     expect(urls.some((u) => u.includes('/site-posts/drafts/site-1/versions'))).toBe(false);
   });
 
-  it('source_site_post_version_id가 null(레거시 파생분)이면 배지를 안 그린다(모른다≠다르다)', async () => {
+  it('source_changed가 null(모른다, 레거시 파생분)이면 배지를 안 그린다', async () => {
     stubFetch({
       draftDetail: {
-        source_content_item_id: 'site-1', source_title: '9월 실험 회고',
-        source_site_post_version_id: null, source_current_site_post_version_id: 'v-current',
+        source_content_item_id: 'site-1', source_title: '9월 실험 회고', source_changed: null,
       },
     });
     await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
@@ -2036,11 +2037,10 @@ describe('ChannelPostEditPage — 같은 스토리의 글 + 배지(story 15e481c
     expect(container.querySelector('[data-testid="channel-post-source-changed-badge"]')).toBeNull();
   });
 
-  it('두 버전 id가 같으면(원문 안 바뀜) 배지를 안 그린다', async () => {
+  it('source_changed가 false(원문 안 바뀜)면 배지를 안 그린다', async () => {
     stubFetch({
       draftDetail: {
-        source_content_item_id: 'site-1', source_title: '9월 실험 회고',
-        source_site_post_version_id: 'v-same', source_current_site_post_version_id: 'v-same',
+        source_content_item_id: 'site-1', source_title: '9월 실험 회고', source_changed: false,
       },
     });
     await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
@@ -2048,11 +2048,11 @@ describe('ChannelPostEditPage — 같은 스토리의 글 + 배지(story 15e481c
     expect(container.querySelector('[data-testid="channel-post-source-changed-badge"]')).toBeNull();
   });
 
-  it('⭐두 버전 id가 다르면(원문이 파생 이후 개정됨) 배지가 "같은 스토리의 글" 줄 옆에 뜬다', async () => {
+  it('⭐source_changed=true(미발행)면 「만든 뒤 바뀜」 배지가 "같은 스토리의 글" 줄 옆에 뜬다', async () => {
     stubFetch({
       draftDetail: {
-        source_content_item_id: 'site-1', source_title: '9월 실험 회고',
-        source_site_post_version_id: 'v-old', source_current_site_post_version_id: 'v-new',
+        source_content_item_id: 'site-1', source_title: '9월 실험 회고', source_changed: true,
+        publication_status: null,
       },
     });
     await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
@@ -2066,6 +2066,21 @@ describe('ChannelPostEditPage — 같은 스토리의 글 + 배지(story 15e481c
     expect(badge?.className).toContain('border-border');
     expect(badge?.className).not.toContain('bg-warning');
     expect(badge?.className).not.toContain('bg-destructive');
+  });
+
+  it('⭐source_changed=true(발행됨)면 기록형 「만들 때 판 그대로」 배지로 갈린다(유나 §14-4 — "바뀌었습니다"는 고치려 든다)', async () => {
+    stubFetch({
+      draftDetail: {
+        source_content_item_id: 'site-1', source_title: '9월 실험 회고', source_changed: true,
+        publication_status: 'published',
+      },
+    });
+    await act(async () => { root.render(wrap(<ChannelPostEditPage />)); });
+    await flush();
+
+    const badge = container.querySelector('[data-testid="channel-post-source-changed-badge"]');
+    expect(badge?.textContent).toBe(koMessages.content.channelPostsSourceChangedBadgePublished);
+    expect(badge?.textContent).not.toBe(koMessages.content.channelPostsSourceChangedBadge);
   });
 });
 

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -94,10 +94,12 @@ interface ChannelPostDraftDetail {
   source_title?: string | null;
   // 이 변형이 파생된 시점의 원문 latest version.id(버전 축, 초안 생성 시 고정).
   source_site_post_version_id?: string | null;
-  // 원문의 지금 latest version.id(배치조회, 매 응답마다 최신값). 두 값이 다르면(둘 다
-  // non-null일 때만 판정 — "모른다≠다르다") "원문이 파생 이후 개정됨" — 서버는 판정
-  // 라벨 없이 두 값만 낸다, 배지는 화면 몫(§11-5).
+  // 원문의 지금 latest version.id(배치조회, 매 응답마다 최신값).
   source_current_site_post_version_id?: string | null;
+  // story #3453 AC3 후속(페드루 PO 確定 2026-09-05) — 위 두 값의 비교 판정을 서버가
+  // 한 곳에서 낸다(FE가 직접 비교하지 않는다 — id 비교식은 서버 전용, 이 필드만 본다).
+  // true=원문이 파생 이후 개정됨 · false=안 바뀜 · null=모른다(레거시 파생분).
+  source_changed?: boolean | null;
 }
 
 interface ChannelPostVersion {
@@ -887,11 +889,14 @@ export default function ChannelPostEditPage() {
             스토리의 글". source_content_item_id 없으면(정상값) 이 줄 자체를 안 그린다.
             #3457 후속(BE #3817 착지분) — source_title이 이제 이 응답에 직접 실려 별도
             왕복이 없다.
-            §11-5 staleness 배지(유나 정본 2026-09-04 20:57Z) — 이 줄 옆에만(칩 열이
-            아니라, "원문 줄 없는데 배지만"이 구조적으로 안 나오게). source_site_post_
-            version_id·source_current_site_post_version_id 둘 중 하나라도 null이면
-            "모른다≠다르다" 원칙으로 안 그린다(레거시 파생분=#3817 前 생성, 값 자체가
-            없다). */}
+            §11-5 staleness 배지(유나 정본 2026-09-04 20:57Z, #3453 AC3 후속 페드루 PO
+            確定 2026-09-05로 판정 이관) — 이 줄 옆에만(칩 열이 아니라, "원문 줄 없는데
+            배지만"이 구조적으로 안 나오게). source_changed는 서버가 이미 판정한 값만
+            본다(true일 때만 렌더 — null/false는 "모른다"·"안 바뀜" 둘 다 무배지).
+            문구는 발행 상태로 갈린다(유나 §14-4 — 발행됨에 "바뀌었습니다"만 적으면
+            고치려 든다, 기록형 문구로): publication_status==='published'면
+            channelPostsSourceChangedBadgePublished(「만들 때 판 그대로」류 아니라
+            그 반대 — 판이 바뀐 기록), 그 외 기존 channelPostsSourceChangedBadge. */}
         {draft.source_content_item_id && draft.source_title ? (
           <p className="flex flex-wrap items-center gap-1.5 text-sm text-muted-foreground" data-testid="channel-post-source-link">
             <span>
@@ -900,13 +905,14 @@ export default function ChannelPostEditPage() {
                 {t('channelPostsSourceLinkText', { title: draft.source_title })}
               </Link>
             </span>
-            {draft.source_site_post_version_id && draft.source_current_site_post_version_id
-              && draft.source_site_post_version_id !== draft.source_current_site_post_version_id ? (
+            {draft.source_changed === true ? (
               <span
                 className="inline-flex items-center rounded-full border border-border px-1.5 py-0.5 text-xs text-muted-foreground"
                 data-testid="channel-post-source-changed-badge"
               >
-                {t('channelPostsSourceChangedBadge')}
+                {draft.publication_status === 'published'
+                  ? t('channelPostsSourceChangedBadgePublished')
+                  : t('channelPostsSourceChangedBadge')}
               </span>
             ) : null}
           </p>

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -222,10 +222,14 @@ class ChannelPostDraftListItem(BaseModel):
     # 이 변형이 파생된 시점의 원문 latest version.id(버전 축, 초안 생성 시 고정 — 편집으로는
     # 안 바뀐다).
     source_site_post_version_id: uuid.UUID | None = None
-    # 원문의 **지금** latest version.id(배치조회, 매 응답마다 최신값). source_site_post_
-    # version_id와 다르면 "원문이 파생 이후 개정됨" — 서버는 판정 라벨 없이 두 값만 낸다,
-    # 비교·배지 문구는 FE 몫(§11-5).
+    # 원문의 **지금** latest version.id(배치조회, 매 응답마다 최신값).
     source_current_site_post_version_id: uuid.UUID | None = None
+    # story #3453 AC3 후속(유나 §14-4/§14-5, 페드루 PO 確定 2026-09-05) — source_site_
+    # post_version_id/source_current_site_post_version_id 비교 판정을 서버가 한 곳에서
+    # 낸다(FE 4곳이 각자 비교식을 들고 있으면 어긋날 표면이라 위 "비교는 FE 몫" 결정을
+    # 뒤집는다). true=둘 다 non-null이고 서로 다름(원문이 파생 이후 개정됨) · false=둘 다
+    # non-null이고 같음 · None=하나라도 null("모른다" — 레거시 파생분).
+    source_changed: bool | None = None
 
 
 class ChannelPostVersionHistoryItem(BaseModel):
@@ -558,6 +562,12 @@ def _to_draft_list_item(
         entry = source_titles.get(draft.source_content_item_id)
         if entry is not None:
             source_title, source_current_site_post_version_id = entry
+    # story #3453 AC3 후속 — 판정은 여기 한 곳에서만(FE 4곳이 각자 비교식을 안 들고
+    # 다니게). 하나라도 null이면 "모른다"(레거시 파생분 — source_site_post_version_id가
+    # #3437 후속 착지 前에 만들어진 초안은 항상 null).
+    source_changed: bool | None = None
+    if draft.source_site_post_version_id is not None and source_current_site_post_version_id is not None:
+        source_changed = draft.source_site_post_version_id != source_current_site_post_version_id
     command_status = latest_command.status if latest_command else None
     publication_status = latest_pub.status if latest_pub else None
     # story 620beefc(AC5·§17-15, 페드루 PO 決定) — 판정식은 이 자리 한 곳에서만.
@@ -606,6 +616,7 @@ def _to_draft_list_item(
         source_title=source_title,
         source_site_post_version_id=draft.source_site_post_version_id,
         source_current_site_post_version_id=source_current_site_post_version_id,
+        source_changed=source_changed,
     )
 
 

--- a/backend/tests/test_3437_content_ledger_projection.py
+++ b/backend/tests/test_3437_content_ledger_projection.py
@@ -678,3 +678,136 @@ async def test_agent_can_set_source_but_still_cannot_approve_or_publish():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+# --- #3453 AC3 후속(유나 §14-4/§14-5, 페드루 PO 確定 2026-09-05) — source_changed ------
+
+
+@pytest.mark.anyio
+async def test_source_changed_false_when_source_not_revised_since_derivation():
+    """원문이 파생 이후 개정 안 됨 — source_site_post_version_id == source_current_
+    site_post_version_id → source_changed=False(같음, "모른다" 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            blog_story_id = await _seed_story(s, org_id, project_id, title="블로그")
+            channel_story_id = await _seed_story(s, org_id, project_id, title="채널")
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            content_item_id = await _create_site_post_draft(
+                client, org_id=org_id, work_item_id=blog_story_id, slug="unrevised-post",
+            )
+            r_variant = await _create_channel_post_draft(
+                client, org_id=org_id, work_item_id=channel_story_id, connection_id=connection_id,
+                source_content_item_id=content_item_id,
+            )
+            assert r_variant.status_code == 201, r_variant.text
+            channel_draft_id = r_variant.json()["draft_id"]
+
+            r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{channel_draft_id}")
+            assert r_detail.status_code == 200, r_detail.text
+            body = r_detail.json()
+            assert body["source_site_post_version_id"] is not None
+            assert body["source_site_post_version_id"] == body["source_current_site_post_version_id"]
+            assert body["source_changed"] is False
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_source_changed_true_when_source_revised_since_derivation():
+    """원문이 파생 이후 새 버전을 냄 — source_site_post_version_id(파생 시점 고정)
+    != source_current_site_post_version_id(지금 최신) → source_changed=True."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            blog_story_id = await _seed_story(s, org_id, project_id, title="블로그")
+            channel_story_id = await _seed_story(s, org_id, project_id, title="채널")
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            content_item_id = await _create_site_post_draft(
+                client, org_id=org_id, work_item_id=blog_story_id, slug="revised-post",
+            )
+            r_variant = await _create_channel_post_draft(
+                client, org_id=org_id, work_item_id=channel_story_id, connection_id=connection_id,
+                source_content_item_id=content_item_id,
+            )
+            assert r_variant.status_code == 201, r_variant.text
+            channel_draft_id = r_variant.json()["draft_id"]
+
+            # 원문 새 버전(같은 work_item_id → 같은 draft에 v2 upsert, story #3369 계약).
+            await _create_site_post_draft(
+                client, org_id=org_id, work_item_id=blog_story_id, slug="revised-post",
+            )
+
+            r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{channel_draft_id}")
+            assert r_detail.status_code == 200, r_detail.text
+            body = r_detail.json()
+            assert body["source_site_post_version_id"] is not None
+            assert body["source_current_site_post_version_id"] is not None
+            assert body["source_site_post_version_id"] != body["source_current_site_post_version_id"]
+            assert body["source_changed"] is True
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_source_changed_none_when_source_site_post_version_id_unknown():
+    """레거시 파생분(#3437 후속 착지 前 생성 — source_site_post_version_id가 null)은
+    "모른다≠다르다" 원칙으로 source_changed=None(True/False 어느 쪽도 단정 안 함)."""
+    from app.main import app
+    from sqlalchemy import text as sa_text
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            blog_story_id = await _seed_story(s, org_id, project_id, title="블로그")
+            channel_story_id = await _seed_story(s, org_id, project_id, title="채널")
+            connection_id = await _seed_connection(s, org_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            content_item_id = await _create_site_post_draft(
+                client, org_id=org_id, work_item_id=blog_story_id, slug="legacy-post",
+            )
+            r_variant = await _create_channel_post_draft(
+                client, org_id=org_id, work_item_id=channel_story_id, connection_id=connection_id,
+                source_content_item_id=content_item_id,
+            )
+            assert r_variant.status_code == 201, r_variant.text
+            channel_draft_id = r_variant.json()["draft_id"]
+
+        # 레거시 재현 — 직접 DDL로 source_site_post_version_id를 null화(API 경로엔 없음,
+        # #3437 후속 이전에 만들어진 실제 옛 행의 상태를 시뮬레이션).
+        async with Session() as s:
+            await s.execute(sa_text(
+                "UPDATE channel_post_drafts SET source_site_post_version_id = NULL WHERE id = :id",
+            ), {"id": channel_draft_id})
+            await s.commit()
+
+        async with _client_for(app) as client:
+            r_detail = await client.get(f"/api/v2/organizations/{org_id}/channel-posts/drafts/{channel_draft_id}")
+            assert r_detail.status_code == 200, r_detail.text
+            body = r_detail.json()
+            assert body["source_site_post_version_id"] is None
+            assert body["source_current_site_post_version_id"] is not None
+            assert body["source_changed"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## 배경
story #3453 AC3 후속(유나 §14-4/§14-5 대조 결과, 페드루 PO 確定 2026-09-05) — #3818에서 FE가 `source_site_post_version_id`/`source_current_site_post_version_id`를 직접 비교하던 방식을 서버 판정으로 이관하고, 발행 상태에 따라 배지 문구를 가릅니다.

## 변경

### BE(`_to_draft_list_item`, `routers/channel_posts.py:539`)
`ChannelPostDraftListItem`에 `source_changed: bool | None` 추가 — true=둘 다 non-null이고 다름(원문이 파생 이후 개정됨) · false=둘 다 non-null이고 같음 · None=하나라도 null("모른다", 레거시 파생분). 기존 두 필드는 그대로 유지(값 노출은 변화 없음, 판정만 서버로 이관). 목록·상세·variants·campaign 상세 4곳이 `_to_draft_list_item()` 공유라 스키마 확장 1건으로 자동 커버(#3817과 동일 패턴).

### FE(`channel-posts/[draftId]/page.tsx`)
- 배지 조건을 `draft.source_changed === true`로 단순화(id 비교식 제거 — 서버 판정 하나만 봅니다).
- 문구를 발행 상태로 분기: `publication_status === 'published'`면 새 키 `channelPostsSourceChangedBadgePublished`(ko 「만들 때 판 그대로」/en "As created" — 유나 §14-4 "발행됨에 «바뀌었습니다»만 적으면 고치려 든다"는 지적에 대한 기록형 문구), 그 외 기존 `channelPostsSourceChangedBadge`(「만든 뒤 바뀜」/"Changed since").

목록·캘린더 파생 표기(§14-2)는 #3818 그대로 무변경(유나 오독 정정 済 — BE 배치는 그때 이미 있었습니다).

## 검증
- BE — `test_3437_content_ledger_projection.py`에 `source_changed` 3상태(true/false/None, 레거시는 직접 SQL로 재현) 신규 3 tests + 기존 12 tests 전부 green(실 postgres, alembic 0297→0325 전체 재생)
- FE — 기존 4상태 테스트를 `source_changed` 직접 소비로 재작성 + 발행 상태 분기 신규 1건, 관련 파일 119 tests green(회귀 0)
- 전체 `pnpm vitest run`: 627 files / 5897 tests green
- `tsc --noEmit` clean, eslint clean
- i18n 가드(hanja·duplicate-keys) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)