### PR TITLE
[SID:3466] fix: 전역 알림 배지 「99+」 대비 미달 정정

### DIFF
--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -449,9 +449,14 @@ describe('NotificationBell — 배지 「99+」 대비(story 3466)', () => {
   it('⭐색 계산 양성대조 — globals.css 실값으로 라이트·다크 둘 다 대비비 ≥4.5(WCAG AA)', async () => {
     const { readFileSync } = await import('node:fs');
     const path = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
     const { contrastRatio } = await import('@/lib/color-contrast');
 
-    const cssPath = path.resolve(process.cwd(), 'src/app/globals.css');
+    // PO 지적(2026-09-04 22:53Z) — process.cwd() 기준 상대경로는 "검사를 어디서
+    // 돌렸나"에 값이 흔들린다(로컬 apps/web cwd에선 통과, CI 레포 루트 cwd에선
+    // ENOENT). 테스트 파일 자신의 위치 기준으로 고정 — cwd 무관(verify-tint-
+    // foreground-contrast.ts와 같은 관례).
+    const cssPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../app/globals.css');
     const css = readFileSync(cssPath, 'utf-8');
 
     function hexToRgb(hex: string): [number, number, number] {

--- a/apps/web/src/components/nav/notification-bell.test.tsx
+++ b/apps/web/src/components/nav/notification-bell.test.tsx
@@ -410,3 +410,70 @@ describe('NotificationBell — story #3074 데스크톱 브리지 notify_show', 
     delete (window as unknown as { __sprintableBridge?: unknown }).__sprintableBridge;
   });
 });
+
+// story 3466(위생, 유나 5~8회차 4연속 관측) — 「99+」 배지 대비 미달(라이트 3.55·다크
+// 3.00, AA 4.5 미달) 정정. text-destructive-foreground가 이 테마에 매핑 자체가 없는
+// 무효 Tailwind 유틸이라 조용히 no-op였던 것이 근본원인(실제 렌더 색은 상속된
+// --foreground). ⭐두 pin: (a) 실 렌더 className이 새 값(text-white dark:text-proof-bg)
+// 을 갖고 구 무효 유틸이 안 남았는지 (b) 그 값들의 WCAG 대비비가 실제로 두 테마 모두
+// ≥4.5인지(색 계산 자체의 양성대조 — globals.css의 --proof-red/--proof-bg 실값을
+// 읽어 codebase 공용 계산기(color-contrast.ts)로 잰다, 값이 나중에 바뀌어도 그 값
+// 기준으로 재검증).
+describe('NotificationBell — 배지 「99+」 대비(story 3466)', () => {
+  function stubUnreadCount(count: number) {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('/api/event-notifications/unread-count')) {
+        return new Response(JSON.stringify({ count }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url.includes('/api/event-notifications?')) {
+        return new Response(JSON.stringify({ data: [], meta: { hasMore: false } }), {
+          status: 200, headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } });
+    }));
+  }
+
+  it('⭐배지가 text-white dark:text-proof-bg를 쓰고, 무효 유틸(text-destructive-foreground)이 안 남았다', async () => {
+    stubUnreadCount(150);
+    await act(async () => { root.render(withIntl(<NotificationBell />)); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    const badge = Array.from(container.querySelectorAll('span')).find((s) => s.textContent === '99+');
+    expect(badge).toBeDefined();
+    expect(badge?.className).toContain('text-white');
+    expect(badge?.className).toContain('dark:text-proof-bg');
+    expect(badge?.className).not.toContain('text-destructive-foreground');
+  });
+
+  it('⭐색 계산 양성대조 — globals.css 실값으로 라이트·다크 둘 다 대비비 ≥4.5(WCAG AA)', async () => {
+    const { readFileSync } = await import('node:fs');
+    const path = await import('node:path');
+    const { contrastRatio } = await import('@/lib/color-contrast');
+
+    const cssPath = path.resolve(process.cwd(), 'src/app/globals.css');
+    const css = readFileSync(cssPath, 'utf-8');
+
+    function hexToRgb(hex: string): [number, number, number] {
+      const n = hex.replace('#', '');
+      return [parseInt(n.slice(0, 2), 16), parseInt(n.slice(2, 4), 16), parseInt(n.slice(4, 6), 16)];
+    }
+
+    // :root(라이트)가 먼저, .dark가 그 뒤에 온다(이 파일의 기존 구조) — 두 번째 매치가 dark 값.
+    const proofRedMatches = [...css.matchAll(/--proof-red:\s*(#[0-9a-fA-F]{6})/g)].map((m) => m[1]!);
+    const proofBgMatches = [...css.matchAll(/--proof-bg:\s*(#[0-9a-fA-F]{6})/g)].map((m) => m[1]!);
+    expect(proofRedMatches.length).toBeGreaterThanOrEqual(2);
+    expect(proofBgMatches.length).toBeGreaterThanOrEqual(2);
+
+    const lightRed = hexToRgb(proofRedMatches[0]!);
+    const darkRed = hexToRgb(proofRedMatches[1]!);
+    const darkProofBg = hexToRgb(proofBgMatches[1]!);
+    const white: [number, number, number] = [255, 255, 255];
+
+    const lightContrast = contrastRatio(lightRed, white);
+    const darkContrast = contrastRatio(darkRed, darkProofBg);
+
+    expect(lightContrast).toBeGreaterThanOrEqual(4.5);
+    expect(darkContrast).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -569,8 +569,16 @@ export function NotificationBell() {
         className="relative flex size-8 items-center justify-center rounded-md text-foreground/70 transition hover:bg-accent hover:text-foreground"
       >
         <Bell className="size-4" />
+        {/* story 3466(위생, 유나 5~8회차 4연속 관측) — `text-destructive-foreground`는
+            이 테마에 `--color-destructive-foreground` 매핑 자체가 없는 무효 유틸(조용히
+            no-op)이라 실제 렌더 색이 상속된 `--foreground`로 새 대비 미달(라이트 3.55·
+            다크 3.00, AA 4.5 미달)이었다 — bg-destructive(라이트#C33B3B·다크#E06767)에
+            흰 텍스트는 라이트만 맞고(5.24) 다크는 여전히 부족(3.33, 다크 red가 더 옅은
+            색이라). trust-seal.tsx의 선례(같은 문제 — 작은 배지 텍스트가 테마별로
+            반전돼야 함)를 그대로 따른다: 라이트=흰색(5.24)·다크=--proof-bg(거의 검정,
+            5.88) — 새 토큰 발명 없이 기존 값 재사용, 크기·자리 무변경. */}
         {unreadCount > 0 && (
-          <span className="absolute -right-0.5 -top-0.5 flex min-w-[16px] items-center justify-center rounded-full bg-destructive px-1 py-px font-mono text-[9px] font-bold leading-none text-destructive-foreground">
+          <span className="absolute -right-0.5 -top-0.5 flex min-w-[16px] items-center justify-center rounded-full bg-destructive px-1 py-px font-mono text-[9px] font-bold leading-none text-white dark:text-proof-bg">
             {badgeLabel}
           </span>
         )}


### PR DESCRIPTION
## 배경
유나 5~8회차 4회 연속 관측(PO 결정 2026-09-05 07:20 KST — "같은 것이 네 번 잡히면 자가 일을 안 하는 것", 의도된 예외 아님). 셸(전역 알림 벨) 배지 「99+」 텍스트(9px)가 판정선 AA 4.5를 라이트 3.55·다크 3.00으로 미달.

## 근본원인(그라운딩)
`text-destructive-foreground`가 이 테마의 `@theme inline` 블록에 `--color-destructive-foreground` 매핑 자체가 없는 무효 Tailwind 유틸이라 조용히 no-op였습니다. 실제 렌더 텍스트 색은 상속된 `--foreground`(라이트=거의 검정·다크=거의 흰색)로 새 — `bg-destructive`(라이트 `#C33B3B`·다크 `#E06767`, 다크가 더 옅은 red)와 조합하면 라이트 3.55·다크 3.00으로 유나 실측과 정확히 일치합니다.

## 처방(색 토큰만·크기 유지, AC2)
`trust-seal.tsx`의 선례(같은 클래스 문제 — 작은 배지 텍스트가 테마별로 반전돼야 함)를 그대로 따릅니다: `text-white dark:text-proof-bg`.
- 라이트=흰 텍스트(bg 대비 5.24)
- 다크=`--proof-bg`(거의 검정, bg 대비 5.88)

새 토큰 발명 0. `--color-destructive-foreground`처럼 다른 4개 소비처(`badge.tsx` counter 변형·`stuck-handoff-section.tsx`·`kanban-board.tsx`·`story-detail-panel.tsx`)에 영향을 주는 공유 토큰은 안 건드렸습니다(AC2 "다른 셸 요소 변화 0" — 이 4곳은 같은 무효 유틸 버그를 안고 있지만 이 스토리 범위 밖, 별도 스토리 후보로 기록).

## 검증
- 신규 pin 2건 — (a) 실 렌더 className이 새 값을 갖고 구 무효 유틸이 안 남았는지 (b) `globals.css` 실값(`--proof-red`·`--proof-bg`)을 읽어 codebase 공용 계산기(`color-contrast.ts::contrastRatio`)로 두 테마 대비비 ≥4.5 재계산(양성대조)
- 관련 파일 19 tests green(회귀 0)
- 전체 `pnpm vitest run`: 629 files / 5904 tests green
- `tsc --noEmit` clean, eslint clean
- 기존 tint/muted 대비 가드 스크립트 전부 여전히 통과(무영향 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)