### PR TITLE
[SID:3450] feat: WordPress/webhook 연결 화면(pasted_secret 카드)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2125,7 +2125,21 @@
     "appCredentialsAppSecretLabel": "App Secret",
     "appCredentialsSaveAction": "Save",
     "appCredentialsCancelAction": "Cancel",
-    "appCredentialsSaveFailed": "Couldn't save. Please try again in a moment."
+    "appCredentialsSaveFailed": "Couldn't save. Please try again in a moment.",
+    "channelConnectErrorWordpressFieldsRequired": "Please fill in all required fields (site URL, username, app password).",
+    "channelConnectErrorWebhookFieldsRequired": "Please fill in all required fields (target URL, secret).",
+    "channelConnectErrorDestinationInsecure": "This address isn't safe to connect to — please use a different address.",
+    "channelConnectFieldSiteUrl": "Site URL",
+    "channelConnectFieldUsername": "Username",
+    "channelConnectFieldAppPassword": "App password",
+    "channelConnectFieldTargetUrl": "Target URL",
+    "channelConnectFieldSecret": "Secret",
+    "channelConnectPastedSecretAction": "Connect {channel}",
+    "channelConnectPastedSecretSubmitAction": "Connect",
+    "channelConnectPastedSecretPendingCta": "Connecting…",
+    "channelConnectPastedSecretHintWordpress": "Create this in WordPress under Users → Application Passwords, then paste it here.",
+    "channelConnectPastedSecretHintWebhook": "Create this on the receiving server's side (the value it will use to verify requests), then paste it here.",
+    "channelConnectPastedSecretRewriteNote": "You won't be able to see this again after saving — paste a new value to change it."
   },
   "content": {
     "title": "Content",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2125,7 +2125,21 @@
     "appCredentialsAppSecretLabel": "App Secret",
     "appCredentialsSaveAction": "저장",
     "appCredentialsCancelAction": "취소",
-    "appCredentialsSaveFailed": "저장하지 못했습니다. 잠시 후 다시 시도해 주세요."
+    "appCredentialsSaveFailed": "저장하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    "channelConnectErrorWordpressFieldsRequired": "필수값을 모두 입력해 주세요(사이트 주소·아이디·앱 비밀번호).",
+    "channelConnectErrorWebhookFieldsRequired": "필수값을 모두 입력해 주세요(대상 주소·시크릿).",
+    "channelConnectErrorDestinationInsecure": "안전하지 않은 주소입니다 — 다른 주소를 입력해 주세요.",
+    "channelConnectFieldSiteUrl": "사이트 주소",
+    "channelConnectFieldUsername": "아이디",
+    "channelConnectFieldAppPassword": "앱 비밀번호",
+    "channelConnectFieldTargetUrl": "대상 주소",
+    "channelConnectFieldSecret": "시크릿",
+    "channelConnectPastedSecretAction": "{channel} 연결",
+    "channelConnectPastedSecretSubmitAction": "연결",
+    "channelConnectPastedSecretPendingCta": "연결하는 중…",
+    "channelConnectPastedSecretHintWordpress": "WordPress 관리자 → 사용자 → 애플리케이션 비밀번호에서 만들어 붙여넣습니다.",
+    "channelConnectPastedSecretHintWebhook": "받는 서버가 검증에 쓸 비밀값을 그쪽 설정에서 만들어 붙여넣습니다.",
+    "channelConnectPastedSecretRewriteNote": "저장한 뒤에는 다시 볼 수 없습니다 — 바꾸려면 새로 붙여넣습니다."
   },
   "content": {
     "title": "글 관리",

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -289,16 +289,77 @@ describe('OrganizationChannelsPage — available-channels 목록 기반 렌더(s
       .toBe(koMessages.channelConnect.channelSandboxDisabledReason);
   });
 
-  // story f30da19a(PO 보정 2026-09-04 13:52Z) — kind='blog'는 이 화면 범위 밖.
-  it('kind=blog 항목은(미래 등재 대비) 렌더 대상에서 빠진다', async () => {
+  // story #3450 후속(페드루 PO 確定 2026-09-05) — f30da19a(2026-09-04 13:52Z)의
+  // "kind='blog'는 이 화면 범위 밖" 결정을 PO가 직접 뒤집었다. 연결 필요 여부는
+  // BE requires_connection 하나가 결정하고(hosted_site가 그래서 애초에 이 목록에
+  // 안 옴, BE 몫이라 여기서 pin 안 함), FE는 kind로 더는 안 거른다 — kind='blog'
+  // (WordPress·webhook)도 credential_kind에 맞는 카드로 그려져야 정상이다.
+  it('⭐kind=blog+credential_kind=pasted_secret(WordPress) — PastedSecretConnectCard로 그려진다(더는 안 걸러짐)', async () => {
     stubFetch({
       connections: [],
       availableChannels: [
         { channel: 'threads', display_name: 'Threads', credential_kind: 'oauth', kind: 'social' },
-        { channel: 'wordpress', display_name: 'WordPress', credential_kind: 'oauth', kind: 'blog' },
+        { channel: 'wordpress', display_name: 'WordPress', credential_kind: 'pasted_secret', kind: 'blog' },
       ],
     });
     await mount('owner');
-    expect(container.textContent).not.toContain('WordPress');
+    expect(container.textContent).toContain('WordPress');
+    expect(container.querySelector('[data-testid="channel-connect-pasted-secret-button-wordpress"]')).not.toBeNull();
+  });
+
+  it('kind=blog+credential_kind=oauth(WordPress.com류 대비) — oauth 카드로 그려진다', async () => {
+    stubFetch({
+      connections: [],
+      availableChannels: [
+        { channel: 'wordpress', display_name: 'WordPress', credential_kind: 'oauth', kind: 'blog' },
+      ],
+      credentials: { configured: false, app_id_suffix: null, effective_source: 'platform' },
+    });
+    await mount('owner');
+    expect(container.textContent).toContain('WordPress');
+    expect(container.querySelector('[data-testid="channel-connect-pasted-secret-button-wordpress"]')).toBeNull();
+  });
+});
+
+// story #3450 FE 후속(3653a18c §2, 페드루 PO 確定 2026-09-04 23:13Z·23:20Z) —
+// pasted_secret(WordPress·webhook) 자리 채움이 실제로 이 화면에 배선됐는지.
+// 필드 단위 pin은 pasted-secret-connect-card.test.tsx가 다룬다 — 여기서는 이
+// 페이지가 그 컴포넌트를 credential_kind==='pasted_secret'에 정확히 얹는지와
+// AC5(재방문 화면에 secret 끝 4자리조차 없음)만 확인한다.
+describe('OrganizationChannelsPage — pasted_secret 자리 채움(story #3450 FE 후속)', () => {
+  const WORDPRESS_AVAILABLE = [
+    { channel: 'wordpress', display_name: 'WordPress', credential_kind: 'pasted_secret', kind: 'blog' },
+  ];
+
+  it('⭐credential_kind===pasted_secret 채널에 PastedSecretConnectCard 토글 버튼이 뜬다(owner)', async () => {
+    stubFetch({ connections: [], availableChannels: WORDPRESS_AVAILABLE });
+    await mount('owner');
+    expect(container.querySelector('[data-testid="channel-connect-pasted-secret-button-wordpress"]')).not.toBeNull();
+  });
+
+  it('member는 버튼 대신 owner 전용 사유만 본다(§5·AC4)', async () => {
+    stubFetch({ connections: [], availableChannels: WORDPRESS_AVAILABLE });
+    await mount('member');
+    expect(container.querySelector('[data-testid="channel-connect-pasted-secret-button-wordpress"]')).toBeNull();
+    expect(container.textContent).toContain(koMessages.channelConnect.channelOwnerOnlyReason);
+  });
+
+  it('⭐(AC5) 이미 연결된 WordPress 행에 secret 값·끝 4자리 어느 것도 안 그려진다 — BFF 응답(ChannelConnectionResponse)에 그 필드가 없다', async () => {
+    stubFetch({
+      connections: [{
+        id: 'conn-wp-1', channel: 'wordpress', account_id: 'https://blog.example.com', account_label: 'admin',
+        credential_kind: 'pasted_secret', status: 'active', token_expires_at: null, last_refreshed_at: null,
+        last_error: null, can_auto_refresh: false, connected_by: 'member-1',
+        created_at: '2026-09-01T00:00:00Z', updated_at: '2026-09-01T00:00:00Z',
+      }],
+      availableChannels: WORDPRESS_AVAILABLE,
+    });
+    await mount('owner');
+    // 계정 라벨(username)만 보이고(ConnectionRow는 account_label이 있으면 account_id
+    // 대신 그것만 그린다, 정상 기존 동작) — app_password류 흔적(마스킹 문자열 포함)이
+    // 어디에도 없다. 스키마 자체가 그 필드를 안 주므로(types.ts) 이 화면이 지어낼 값
+    // 자체가 없다.
+    expect(container.textContent).toContain('admin');
+    expect(container.textContent).not.toMatch(/•{2,}|\*{2,}/);
   });
 });

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -12,6 +12,7 @@ import { channelLabel } from '@/lib/channel-label';
 import { ChannelStatusChip } from '@/components/channel-connect/channel-status-chip';
 import { deriveChannelConnectionStatus, worstChannelConnectionStatus } from '@/components/channel-connect/connection-status';
 import { AppCredentialsCard } from '@/components/channel-connect/app-credentials-card';
+import { PastedSecretConnectCard } from '@/components/channel-connect/pasted-secret-connect-card';
 import { connectErrorLabelKey } from '@/components/channel-connect/connect-error';
 import type { AppCredentialsStatusResponse, ChannelConnectionResponse, TestConnectionResponse } from '@/components/channel-connect/types';
 
@@ -253,8 +254,12 @@ function ChannelSection({
                 {creatingSandbox ? t('channelConnectSandboxPendingCta') : t('channelConnectSandboxAction', { channel: channelLabel(channel, t) })}
               </Button>
             ) : null
-            // credential_kind==='pasted_secret' — 아직 이 흐름이 없다. 버튼을 disabled로
-            // 두면 "곧 됩니다"로 읽힌다(유나 §13-4) — 자리 자체를 안 그린다.
+          ) : credential_kind === 'pasted_secret' ? (
+            // story #3450 FE 후속(3653a18c §2 "②발급해서 붙여넣기", PO 確定
+            // 2026-09-04 23:13Z) — 자리 채움. isOwner는 이 파일의 owner-or-admin
+            // 상수(oauth/sandbox와 동일 게이팅, §5 "연결·해제는 owner" 취지에 admin
+            // 까지 넓힌 기존 결정 그대로 재사용).
+            <PastedSecretConnectCard channel={channel} orgId={orgId} isOwner={isOwner} onConnected={onRefresh} t={t} />
           ) : null}
           {credential_kind === 'oauth' && !canStartConnect ? (
             <p className="text-xs text-muted-foreground">{t('channelConfigIncompleteReason')}</p>
@@ -298,12 +303,12 @@ export default function OrganizationChannelsPage() {
         return;
       }
       const availableJson = (await availableRes.json().catch(() => null)) as { data?: AvailableChannelItem[] } | null;
-      // story f30da19a(AC2, 페드루 PO 확定 2026-09-04 13:52Z) — kind='blog'(hosted_site·
-      // wordpress·webhook류)는 이 "채널 연결" 화면 범위 밖(그리지 않는다). hosted_site는
-      // BE가 requires_connection=False라 애초에 이 목록에 안 오지만, 후속 blog kind
-      // 채널이 requires_connection=True로 추가될 경우까지 대비해 FE도 kind로 한 번 더
-      // 거른다.
-      const items = (availableJson?.data ?? []).filter((it) => it.kind === 'social');
+      // story #3450 후속(페드루 PO 確定 2026-09-05, f30da19a 2026-09-04 13:52Z 결정을
+      // PO가 직접 뒤집음) — 연결 필요 여부는 BE `requires_connection`이 결정한다
+      // (f30da19a AC1, hosted_site=False라 이 목록에 애초에 안 옴). FE는 kind로 한 번
+      // 더 거르지 않는다 — kind='blog'+credential_kind='pasted_secret'(WordPress·
+      // webhook)이 블루프린트 §2(a) 대상인데 그 필터가 조용히 삼키고 있었다.
+      const items = availableJson?.data ?? [];
       setAvailableChannels(items);
       const connsJson = (await connsRes.json().catch(() => null)) as { data?: ChannelConnectionResponse[] } | null;
       setConnections(connsJson?.data ?? []);

--- a/apps/web/src/components/channel-connect/connect-error.test.ts
+++ b/apps/web/src/components/channel-connect/connect-error.test.ts
@@ -32,4 +32,11 @@ describe('connectErrorLabelKey (story #3409)', () => {
     expect(connectErrorLabelKey('SOME_UNKNOWN_CODE', true)).toBe('channelConnectErrorGeneric');
     expect(connectErrorLabelKey('SOME_UNKNOWN_CODE', false)).toBe('channelConnectErrorGeneric');
   });
+
+  // story #3450 FE 후속(3653a18c §2·§3-0) — WordPress·webhook 붙여넣기 폼의 422 3종.
+  it('⭐WORDPRESS_FIELDS_REQUIRED·WEBHOOK_FIELDS_REQUIRED·DESTINATION_INSECURE — 신규 3키', () => {
+    expect(connectErrorLabelKey('WORDPRESS_FIELDS_REQUIRED', true)).toBe('channelConnectErrorWordpressFieldsRequired');
+    expect(connectErrorLabelKey('WEBHOOK_FIELDS_REQUIRED', true)).toBe('channelConnectErrorWebhookFieldsRequired');
+    expect(connectErrorLabelKey('CHANNEL_CONNECTION_DESTINATION_INSECURE', true)).toBe('channelConnectErrorDestinationInsecure');
+  });
 });

--- a/apps/web/src/components/channel-connect/connect-error.ts
+++ b/apps/web/src/components/channel-connect/connect-error.ts
@@ -18,6 +18,13 @@ const KNOWN_CONNECT_ERROR_KEYS: Record<string, string> = {
   INVALID_REQUEST: 'channelConnectErrorGeneric',
   CHANNEL_AUTHORIZE_FAILED: 'channelConnectErrorGeneric',
   CHANNEL_CALLBACK_FAILED: 'channelConnectErrorGeneric',
+  // story #3450 FE 후속(3653a18c §2 "②발급해서 붙여넣기") — WordPress·webhook 연결
+  // 폼(POST .../channel-connections/{wordpress|webhook})의 422/403 응답.
+  WORDPRESS_FIELDS_REQUIRED: 'channelConnectErrorWordpressFieldsRequired',
+  WEBHOOK_FIELDS_REQUIRED: 'channelConnectErrorWebhookFieldsRequired',
+  // 3653a18c §3-0 "사람 말을 위에, 원문은 접어" — SSRF 목적지 거부는 provider 원문
+  // (DestinationURLUnsafeError 메시지, 영문·기술 용어)을 그대로 안 보여준다.
+  CHANNEL_CONNECTION_DESTINATION_INSECURE: 'channelConnectErrorDestinationInsecure',
 };
 
 // story #3409 — CHANNEL_APP_CREDENTIALS_MISSING은 owner에게도 뜬다(앱 자격이 없으면

--- a/apps/web/src/components/channel-connect/pasted-secret-connect-card.test.tsx
+++ b/apps/web/src/components/channel-connect/pasted-secret-connect-card.test.tsx
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+//
+// story #3450 FE 후속(3653a18c §2 "②발급해서 붙여넣기", PO 確定 2026-09-04 23:13Z·
+// 유나 카드 형태 판정 23:20Z) — WordPress·webhook 연결 카드. pin (a)~(e):
+// (a) 성공 제출→onConnected 호출 (b) 3개 에러 코드별 인라인 문구 (c) owner-or-admin
+// 아니면 폼 자체 비노출(버튼 없이 사유 한 줄) (d) 제출 성공 후 secret 필드 값이
+// 아무 데도 안 남는지(§2 "다시 못 봄") (e) 문구="OO 연결"("만들기" 아님)·도움말
+// 두 줄(필드 위=출처, 필드 아래=재입력 원칙).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider, useTranslations } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+
+const { fetchWithAuthMock } = vi.hoisted(() => ({ fetchWithAuthMock: vi.fn() }));
+vi.mock('@/lib/db/client', () => ({ fetchWithAuth: fetchWithAuthMock }));
+
+import { PastedSecretConnectCard } from './pasted-secret-connect-card';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  fetchWithAuthMock.mockReset();
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+function jsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+function TestHarness({ channel, isOwner, onConnected }: { channel: string; isOwner: boolean; onConnected: () => void }) {
+  const t = useTranslations('channelConnect');
+  return <PastedSecretConnectCard channel={channel} orgId="org-1" isOwner={isOwner} onConnected={onConnected} t={t} />;
+}
+
+describe('PastedSecretConnectCard(story #3450 FE 후속)', () => {
+  it('⭐(c) owner-or-admin이 아니면 폼/버튼 자체가 안 그려지고 사유 한 줄만', async () => {
+    await act(async () => { root.render(wrap(<TestHarness channel="wordpress" isOwner={false} onConnected={vi.fn()} />)); });
+    await flush();
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.querySelector('[data-testid^="channel-connect-pasted-secret-form-"]')).toBeNull();
+    expect(container.textContent).toContain(koMessages.channelConnect.channelOwnerOnlyReason);
+  });
+
+  it('필드를 다 채우기 전에는 제출 버튼이 비활성', async () => {
+    await act(async () => { root.render(wrap(<TestHarness channel="wordpress" isOwner onConnected={vi.fn()} />)); });
+    await flush();
+    const openBtn = container.querySelector('[data-testid="channel-connect-pasted-secret-button-wordpress"]') as HTMLButtonElement;
+    await act(async () => { openBtn.click(); });
+    await flush();
+
+    const submitBtn = container.querySelector('[data-testid="channel-connect-pasted-secret-submit-wordpress"]') as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(true);
+
+    const siteUrlInput = container.querySelector('#wordpress-site_url') as HTMLInputElement;
+    const usernameInput = container.querySelector('#wordpress-username') as HTMLInputElement;
+    const passwordInput = container.querySelector('#wordpress-app_password') as HTMLInputElement;
+    expect(passwordInput.type).toBe('password');
+
+    // React controlled input는 순수 .value 대입으론 onChange가 안 붙는다 — 네이티브
+    // setter로 값을 밀어넣고 input 이벤트를 직접 디스패치한다.
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(siteUrlInput, 'https://blog.example.com'); siteUrlInput.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(usernameInput, 'admin'); usernameInput.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(passwordInput, 'app-pw'); passwordInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await flush();
+    expect(submitBtn.disabled).toBe(false);
+  });
+
+  async function fillAndSubmitWordpress() {
+    const openBtn = container.querySelector('[data-testid="channel-connect-pasted-secret-button-wordpress"]') as HTMLButtonElement;
+    await act(async () => { openBtn.click(); });
+    await flush();
+
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    const siteUrlInput = container.querySelector('#wordpress-site_url') as HTMLInputElement;
+    const usernameInput = container.querySelector('#wordpress-username') as HTMLInputElement;
+    const passwordInput = container.querySelector('#wordpress-app_password') as HTMLInputElement;
+    await act(async () => {
+      setter.call(siteUrlInput, 'https://blog.example.com'); siteUrlInput.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(usernameInput, 'admin'); usernameInput.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(passwordInput, 'app-pw'); passwordInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await flush();
+
+    const submitBtn = container.querySelector('[data-testid="channel-connect-pasted-secret-submit-wordpress"]') as HTMLButtonElement;
+    await act(async () => { submitBtn.click(); });
+    await flush();
+    return { passwordInput };
+  }
+
+  it('⭐(a) 성공 제출 — onConnected 호출·폼이 닫힌다', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(201, { data: { id: 'c1', channel: 'wordpress' } }));
+    const onConnected = vi.fn();
+    await act(async () => { root.render(wrap(<TestHarness channel="wordpress" isOwner onConnected={onConnected} />)); });
+    await flush();
+
+    await fillAndSubmitWordpress();
+
+    expect(onConnected).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="channel-connect-pasted-secret-form-wordpress"]')).toBeNull();
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      '/api/organizations/org-1/channel-connections/wordpress',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('⭐(d) 성공 뒤에도 실패 뒤에도 secret 필드 값이 폼에 남지 않는다("다시 못 봄")', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(201, { data: { id: 'c1' } }));
+    await act(async () => { root.render(wrap(<TestHarness channel="wordpress" isOwner onConnected={vi.fn()} />)); });
+    await flush();
+    await fillAndSubmitWordpress();
+    // 성공 뒤 폼 자체가 닫히므로(=values state가 리마운트로도 안 남는다) 재오픈해서 확인.
+    const reopenBtn = container.querySelector('[data-testid="channel-connect-pasted-secret-button-wordpress"]') as HTMLButtonElement;
+    await act(async () => { reopenBtn.click(); });
+    await flush();
+    const passwordInput = container.querySelector('#wordpress-app_password') as HTMLInputElement;
+    expect(passwordInput.value).toBe('');
+
+    // 실패 케이스 — 폼은 열린 채로 남으므로 그 자리에서 직접 값 잔존을 확인.
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(422, { error: { code: 'WORDPRESS_FIELDS_REQUIRED' } }));
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    const siteUrlInput = container.querySelector('#wordpress-site_url') as HTMLInputElement;
+    const usernameInput = container.querySelector('#wordpress-username') as HTMLInputElement;
+    await act(async () => {
+      setter.call(siteUrlInput, 'https://blog.example.com'); siteUrlInput.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(usernameInput, 'admin'); usernameInput.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(passwordInput, 'app-pw-2'); passwordInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await flush();
+    const submitBtn = container.querySelector('[data-testid="channel-connect-pasted-secret-submit-wordpress"]') as HTMLButtonElement;
+    await act(async () => { submitBtn.click(); });
+    await flush();
+    const passwordInputAfterFail = container.querySelector('#wordpress-app_password') as HTMLInputElement;
+    expect(passwordInputAfterFail.value).toBe('');
+  });
+
+  it('⭐(b) 422 WORDPRESS_FIELDS_REQUIRED — 인라인 문구', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(422, { error: { code: 'WORDPRESS_FIELDS_REQUIRED' } }));
+    await act(async () => { root.render(wrap(<TestHarness channel="wordpress" isOwner onConnected={vi.fn()} />)); });
+    await flush();
+    await fillAndSubmitWordpress();
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(koMessages.channelConnect.channelConnectErrorWordpressFieldsRequired);
+  });
+
+  it('⭐(b) 422 CHANNEL_CONNECTION_DESTINATION_INSECURE — 인라인 문구(원문 노출 안 함)', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(422, { error: { code: 'CHANNEL_CONNECTION_DESTINATION_INSECURE', message: 'loopback address rejected' } }));
+    await act(async () => { root.render(wrap(<TestHarness channel="wordpress" isOwner onConnected={vi.fn()} />)); });
+    await flush();
+    await fillAndSubmitWordpress();
+    const alertText = container.querySelector('[role="alert"]')?.textContent;
+    expect(alertText).toBe(koMessages.channelConnect.channelConnectErrorDestinationInsecure);
+    expect(alertText).not.toContain('loopback');
+  });
+
+  it('⭐(e) 문구="WordPress 연결"("연결 만들기" 아님) · 도움말 두 줄(필드 위=출처, 아래=재입력 원칙)', async () => {
+    await act(async () => { root.render(wrap(<TestHarness channel="wordpress" isOwner onConnected={vi.fn()} />)); });
+    await flush();
+
+    const toggleBtn = container.querySelector('[data-testid="channel-connect-pasted-secret-button-wordpress"]') as HTMLButtonElement;
+    expect(toggleBtn.textContent).toBe(koMessages.channelConnect.channelConnectPastedSecretAction.replace('{channel}', 'WordPress'));
+    expect(toggleBtn.textContent).not.toContain('만들기');
+
+    await act(async () => { toggleBtn.click(); });
+    await flush();
+
+    const hint = container.querySelector('[data-testid="channel-connect-pasted-secret-hint-wordpress"]');
+    expect(hint?.textContent).toBe(koMessages.channelConnect.channelConnectPastedSecretHintWordpress);
+    const rewriteNote = container.querySelector('[data-testid="channel-connect-pasted-secret-rewrite-note-wordpress"]');
+    expect(rewriteNote?.textContent).toBe(koMessages.channelConnect.channelConnectPastedSecretRewriteNote);
+    // 필드 위/아래 순서 — hint가 첫 필드 label보다 앞서고, rewrite-note가 마지막 필드보다 뒤에 온다.
+    const form = container.querySelector('[data-testid="channel-connect-pasted-secret-form-wordpress"]')!;
+    const order = Array.from(form.children).map((el) => el.getAttribute('data-testid') ?? el.tagName);
+    expect(order.indexOf('channel-connect-pasted-secret-hint-wordpress')).toBeLessThan(order.indexOf('channel-connect-pasted-secret-rewrite-note-wordpress'));
+  });
+
+  it('⭐(b) webhook 채널 — 403 CHANNEL_CONNECTION_HUMAN_ONLY는 제네릭 폴백(방어적 pass-through)', async () => {
+    fetchWithAuthMock.mockResolvedValue(jsonResponse(403, { error: { code: 'CHANNEL_CONNECTION_HUMAN_ONLY' } }));
+    await act(async () => { root.render(wrap(<TestHarness channel="webhook" isOwner onConnected={vi.fn()} />)); });
+    await flush();
+
+    const openBtn = container.querySelector('[data-testid="channel-connect-pasted-secret-button-webhook"]') as HTMLButtonElement;
+    await act(async () => { openBtn.click(); });
+    await flush();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    const targetUrlInput = container.querySelector('#webhook-target_url') as HTMLInputElement;
+    const secretInput = container.querySelector('#webhook-secret') as HTMLInputElement;
+    expect(secretInput.type).toBe('password');
+    await act(async () => {
+      setter.call(targetUrlInput, 'https://hook.example.com'); targetUrlInput.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(secretInput, 'shh'); secretInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await flush();
+    const submitBtn = container.querySelector('[data-testid="channel-connect-pasted-secret-submit-webhook"]') as HTMLButtonElement;
+    await act(async () => { submitBtn.click(); });
+    await flush();
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(koMessages.channelConnect.channelConnectErrorGeneric);
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      '/api/organizations/org-1/channel-connections/webhook',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});

--- a/apps/web/src/components/channel-connect/pasted-secret-connect-card.tsx
+++ b/apps/web/src/components/channel-connect/pasted-secret-connect-card.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { fetchWithAuth } from '@/lib/db/client';
+import { channelLabel } from '@/lib/channel-label';
+import { connectErrorLabelKey } from '@/components/channel-connect/connect-error';
+
+/**
+ * story #3450 FE 후속(3653a18c §2 "②발급해서 붙여넣기" 방식, 페드루 PO 確定
+ * 2026-09-04 23:13Z) — WordPress·webhook 연결 카드. BFF #3820(`POST .../channel-
+ * connections/{wordpress|webhook}`, BE `CreatePastedSecretConnectionRequest`
+ * 그대로)로 붙여넣기 폼을 잇는다. 필드는 채널마다 다르므로 하드코딩하지 않고
+ * 표로 뺀다(담롱군 §4-6 재발 방지 원칙과 동형 — 채널이 늘어도 이 표만 는다).
+ *
+ * §2 "한 번 지나간다(저장 뒤 마스킹, 다시 못 봄)" — secret류 필드는 성공·실패
+ * 무관하게 제출 직후 폼에서 비운다(app-credentials-card.tsx와 동일 원칙).
+ * §2 "재입력은 덮어쓰기" — 부분 수정 UI가 없다, 취소하면 전부 비워지고 처음부터.
+ *
+ * 유나 판정(PO 전언 2026-09-04 23:20Z, 카드 형태) — ①레이아웃=카드 안 인라인
+ * 펼침(다이얼로그 아님, oauth·sandbox 버튼과 같은 자리) ②문구=「WordPress 연결」·
+ * 「웹훅 연결」(oauth 「Threads 계정 연결」과 같은 낱말 축 — "만들기"는 진짜로 짓는
+ * sandbox 전용, 여기 안 씀) ③도움말 두 줄·다른 자리(필드 위=어디서 오나, 필드
+ * 아래=재입력 원칙) ④owner 전용(비owner는 폼 자체 비노출) ⑤재방문 화면에 secret
+ * 끝 4자리조차 없음(BFF 응답 스키마에 그 필드가 아예 없다 — types.ts 참고).
+ */
+interface PastedSecretField {
+  name: string;
+  labelKey: string;
+  type: 'text' | 'password';
+}
+
+const PASTED_SECRET_FIELDS: Record<string, PastedSecretField[]> = {
+  wordpress: [
+    { name: 'site_url', labelKey: 'channelConnectFieldSiteUrl', type: 'text' },
+    { name: 'username', labelKey: 'channelConnectFieldUsername', type: 'text' },
+    { name: 'app_password', labelKey: 'channelConnectFieldAppPassword', type: 'password' },
+  ],
+  webhook: [
+    { name: 'target_url', labelKey: 'channelConnectFieldTargetUrl', type: 'text' },
+    { name: 'secret', labelKey: 'channelConnectFieldSecret', type: 'password' },
+  ],
+};
+
+// 유나 판정(PO 전언 2026-09-04 23:20Z) — "어디서 오나"는 채널마다 다른 문구라 표로 뺀다
+// (필드 값 constraints와 같은 원칙, 하드코딩 회피).
+const PASTED_SECRET_HINT_KEY: Record<string, string> = {
+  wordpress: 'channelConnectPastedSecretHintWordpress',
+  webhook: 'channelConnectPastedSecretHintWebhook',
+};
+
+export function PastedSecretConnectCard({
+  channel, orgId, isOwner, onConnected, t,
+}: {
+  channel: string;
+  orgId: string;
+  isOwner: boolean;
+  onConnected: () => void;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const fields = PASTED_SECRET_FIELDS[channel];
+  const [editing, setEditing] = useState(false);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!fields) return null;
+
+  // §5 정본(2026-09-04) — 비소유자는 버튼 자체를 안 그리고 사유 한 줄만(disabled
+  // 버튼은 탭 순서 밖이라 스크린리더가 사유에 못 닿는다).
+  if (!isOwner) {
+    return <p className="text-xs text-muted-foreground">{t('channelOwnerOnlyReason')}</p>;
+  }
+
+  const allFilled = fields.every((f) => (values[f.name] ?? '').trim().length > 0);
+
+  const handleSubmit = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetchWithAuth(`/api/organizations/${orgId}/channel-connections/${channel}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      // §2 "다시 못 봄" — 성공/실패 무관하게 여기서 비운다(app-credentials-card.tsx와
+      // 동일 이유 — 로그·상태에 secret을 남기지 않는다).
+      setValues({});
+      if (res.ok) {
+        setEditing(false);
+        onConnected();
+      } else {
+        const body = (await res.json().catch(() => null)) as { error?: { code?: string } } | null;
+        const code = body?.error?.code;
+        setError(t(code ? connectErrorLabelKey(code, isOwner) : 'channelConnectErrorGeneric'));
+      }
+    } catch {
+      setValues({});
+      setError(t('channelConnectErrorGeneric'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col items-start gap-2">
+      {!editing ? (
+        <Button
+          size="sm"
+          onClick={() => setEditing(true)}
+          data-testid={`channel-connect-pasted-secret-button-${channel}`}
+        >
+          {t('channelConnectPastedSecretAction', { channel: channelLabel(channel, t) })}
+        </Button>
+      ) : (
+        <div className="w-full space-y-2" data-testid={`channel-connect-pasted-secret-form-${channel}`}>
+          {error ? (
+            <Alert variant="destructive" role="alert" aria-live="assertive" aria-atomic="true">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : null}
+          {/* 유나 판정 §③ — 도움말 두 줄·다른 자리. 필드 위=어디서 오나(채널별). */}
+          <p className="text-xs text-muted-foreground" data-testid={`channel-connect-pasted-secret-hint-${channel}`}>
+            {t(PASTED_SECRET_HINT_KEY[channel])}
+          </p>
+          {fields.map((f) => (
+            <div key={f.name} className="space-y-1">
+              <label className="text-xs font-medium text-muted-foreground" htmlFor={`${channel}-${f.name}`}>
+                {t(f.labelKey)}
+              </label>
+              <input
+                id={`${channel}-${f.name}`}
+                type={f.type}
+                className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+                value={values[f.name] ?? ''}
+                onChange={(e) => setValues((v) => ({ ...v, [f.name]: e.target.value }))}
+                autoComplete="off"
+              />
+            </div>
+          ))}
+          {/* 필드 아래=재입력 원칙(§2 "다시 못 봄"·"재입력은 덮어쓰기" 그대로 사람 말로). */}
+          <p className="text-xs text-muted-foreground" data-testid={`channel-connect-pasted-secret-rewrite-note-${channel}`}>
+            {t('channelConnectPastedSecretRewriteNote')}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              onClick={() => void handleSubmit()}
+              disabled={saving || !allFilled}
+              data-testid={`channel-connect-pasted-secret-submit-${channel}`}
+            >
+              {saving ? t('channelConnectPastedSecretPendingCta') : t('channelConnectPastedSecretSubmitAction')}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => { setEditing(false); setValues({}); setError(null); }}
+            >
+              {t('appCredentialsCancelAction')}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 배경
3653a18c §2 "②발급해서 붙여넣기" 방식(페드루 PO 確定 2026-09-04 23:13Z·유나 카드 형태 판정 23:20Z) — `organization/channels/page.tsx`의 `credential_kind==='pasted_secret'` 빈 자리를 채웁니다. BFF #3820을 소비합니다.

## 착수 중 발견한 충돌 · PO 재확定(2026-09-05)
착수 중 f30da19a(2026-09-04 13:52Z)의 FE `kind==='social'` 필터가 wordpress·webhook(둘 다 BE `kind="blog"`)을 이 화면에서 원천 배제하고 있음을 발견 — 오늘 지시와 정면 충돌했습니다. **PO가 그 결정을 직접 뒤집었습니다**: 연결 필요 여부는 BE `requires_connection` 하나가 결정하고(hosted_site가 그래서 이 목록에 안 옴, BE 몫) FE는 kind로 더는 안 거릅니다(WordPress.com OAuth류가 나중에 `kind='blog'+credential_kind='oauth'`로 올 것을 이 필터가 또 숨기게 되므로). `page.tsx`의 `items = availableJson?.data ?? []`로 필터를 통째로 제거했습니다.

## AC(PO 지시 5줄 그대로, 채우는 파일)
| AC | 내용 | 채우는 파일 |
|---|---|---|
| AC1 | 자리 — 카드 안 인라인 펼침, oauth·sandbox 버튼과 같은 자리 | `pasted-secret-connect-card.tsx`(신규) + `page.tsx`의 `credential_kind==='pasted_secret'` 분기 |
| AC2 | 문구 — 「WordPress 연결」·「웹훅 연결」("만들기" 아님) | `messages/{ko,en}.json`의 `channelConnectPastedSecretAction` |
| AC3 | 도움말 두 줄·다른 자리 — 필드 위=출처, 필드 아래=재입력 원칙 | `pasted-secret-connect-card.tsx`의 `channelConnectPastedSecretHint{Wordpress,Webhook}` / `channelConnectPastedSecretRewriteNote` |
| AC4 | owner 전용 폼 | `pasted-secret-connect-card.tsx`의 `!isOwner` 분기(폼 자체 비노출, 사유 한 줄) |
| AC5 | 재방문 화면에 secret 끝 4자리조차 없음 | `types.ts`(`ChannelConnectionResponse`에 그 필드 자체가 없음, 스키마 레벨 보장) + `page.test.tsx` pin |

에러 표면(3개 신규 문구 키) — `connect-error.ts`에 `WORDPRESS_FIELDS_REQUIRED`·`WEBHOOK_FIELDS_REQUIRED`·`CHANNEL_CONNECTION_DESTINATION_INSECURE` 매핑(원문 미노출, 3653a18c §3-0 원칙). 성공 뒤 목록 갱신은 `onRefresh` 재사용(`?connected=`는 OAuth 리다이렉트 전용이라 이 방식엔 안 맞음, PO 確定 — 인라인 성공 상태로 대체).

## 검증
- 신규 pin — 카드 컴포넌트 8건(a~e)·에러맵 3건·페이지 배선 4건(kind 필터 제거 회귀 포함) 전부 green(회귀 0)
- 전체 `pnpm vitest run`: 630 files / 5918 tests green
- `tsc --noEmit` clean, eslint clean
- i18n 가드(hanja·duplicate-keys·phrase-collision) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)