### PR TITLE
[SID:3466] fix: 무효 유틸 text-destructive-foreground 잔존 4곳(후속)

### DIFF
--- a/apps/web/src/components/cage/stuck-handoff-section.test.tsx
+++ b/apps/web/src/components/cage/stuck-handoff-section.test.tsx
@@ -120,4 +120,15 @@ describe('StuckHandoffSection — withdraw(story #2272)', () => {
     expect(container.textContent).toContain('철회에 실패했습니다');
     expect(findButtonByText('요청 철회')).toBeDefined();
   });
+
+  // story 3466 후속(무효 유틸 4곳) — idle 버튼(「소유자에게 재전달」)이 no-op
+  // text-destructive-foreground 대신 실 렌더 색을 갖는지.
+  it('⭐idle 버튼(소유자에게 재전달)이 text-white dark:text-proof-bg를 쓰고 무효 유틸이 안 남았다', async () => {
+    stubFetch(stuckStep(), () => new Response('{}', { status: 200 }));
+    await renderSection();
+    const btn = findButtonByText('소유자에게 재전달');
+    expect(btn?.className).toContain('text-white');
+    expect(btn?.className).toContain('dark:text-proof-bg');
+    expect(btn?.className).not.toContain('text-destructive-foreground');
+  });
 });

--- a/apps/web/src/components/cage/stuck-handoff-section.tsx
+++ b/apps/web/src/components/cage/stuck-handoff-section.tsx
@@ -96,7 +96,9 @@ export function StuckHandoffSection({ storyId, memberMap = {} }: StuckHandoffSec
   };
 
   const btn = {
-    idle: { cls: 'bg-destructive text-destructive-foreground hover:bg-destructive/90', Icon: AlertTriangle, label: t('fallbackNotifyOwner'), disabled: false },
+    // story 3466 후속(무효 유틸 4곳) — text-destructive-foreground는 이 테마에 매핑이
+    // 없는 no-op(라이트 3.55·다크 3.00, AA 미달). trust-seal.tsx 선례와 같은 처방.
+    idle: { cls: 'bg-destructive text-white dark:text-proof-bg hover:bg-destructive/90', Icon: AlertTriangle, label: t('fallbackNotifyOwner'), disabled: false },
     notifying: { cls: 'bg-destructive-tint text-destructive', Icon: Loader2, label: t('fallbackNotifying'), disabled: true },
     notified: { cls: 'bg-muted text-muted-foreground', Icon: Check, label: t('fallbackNotified'), disabled: true },
     failed: { cls: 'border border-destructive text-destructive hover:ring-1 hover:ring-inset hover:ring-destructive/60', Icon: RotateCcw, label: t('fallbackRetry'), disabled: false },

--- a/apps/web/src/components/kanban/kanban-board.test.tsx
+++ b/apps/web/src/components/kanban/kanban-board.test.tsx
@@ -300,6 +300,11 @@ describe('KanbanBoard — 스토리 생성 실패 접근성(story #2105 2차)', 
     expect(alertEl).not.toBeNull();
     expect(alertEl?.textContent).toContain('스토리 추가에 실패했습니다');
     expect(alertEl?.getAttribute('aria-live')).toBe('assertive');
+    // story 3466 후속(무효 유틸 4곳) — 이 배너가 no-op text-destructive-foreground
+    // 대신 실 렌더 색을 갖는지.
+    expect(alertEl?.className).toContain('text-white');
+    expect(alertEl?.className).toContain('dark:text-proof-bg');
+    expect(alertEl?.className).not.toContain('text-destructive-foreground');
   });
 
   // story #2154 — transitionError는 4초 후 자동 setTransitionError(null)로만 해소되고, 재시도

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1144,7 +1144,9 @@ export function KanbanBoard({ projectId, wsSlug, projSlug }: KanbanBoardProps) {
         // bumpTransitionErrorNonce()를 함께 호출해, 4초 내 동일 사유가 재발해도 key가 바뀌어
         // 항상 새 DOM 노드로 재낭독된다(#2400이 남긴 latent gap 해소).
         // story #3007(로드맵 P2·PR-E, L1) — 토스트성 배너는 floating이라 --elev-overlay.
-        <div key={transitionErrorNonce} role="alert" aria-live="assertive" aria-atomic="true" className="fixed bottom-4 right-4 z-50 rounded-md border border-destructive bg-destructive px-4 py-3 text-sm text-destructive-foreground shadow-[var(--elev-overlay)]">
+        // story 3466 후속(무효 유틸 4곳) — text-destructive-foreground는 이 테마에
+        // 매핑이 없는 no-op(라이트 3.55·다크 3.00, AA 미달). trust-seal.tsx 선례.
+        <div key={transitionErrorNonce} role="alert" aria-live="assertive" aria-atomic="true" className="fixed bottom-4 right-4 z-50 rounded-md border border-destructive bg-destructive px-4 py-3 text-sm text-white dark:text-proof-bg shadow-[var(--elev-overlay)]">
           ⚠️ {transitionError}
         </div>
       )}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1818,7 +1818,10 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                             type="button"
                             variant="ghost"
                             onClick={() => void handleDetachLabel(label.itemLabelId)}
-                            className="h-3.5 min-h-0 w-3.5 min-w-0 absolute -right-1 -top-1 hidden items-center justify-center rounded-full bg-muted-foreground/20 p-0 text-foreground hover:bg-destructive/80 hover:text-destructive-foreground group-hover:flex"
+                            // story 3466 후속(무효 유틸 4곳) — text-destructive-foreground는
+                            // 이 테마에 매핑이 없는 no-op. trust-seal.tsx 선례로 hover 상태도
+                            // 테마별 반전(dark:hover:).
+                            className="h-3.5 min-h-0 w-3.5 min-w-0 absolute -right-1 -top-1 hidden items-center justify-center rounded-full bg-muted-foreground/20 p-0 text-foreground hover:bg-destructive/80 hover:text-white dark:hover:text-proof-bg group-hover:flex"
                             aria-label={`Remove ${label.name}`}
                           >
                             <X className="size-2" />

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -58,7 +58,6 @@ const badgeVariants = cva(
         // de-emphasis는 색이 아니라 tint 배경+작은 크기+pill 형태가 담당(다른 tint 변형이
         // 이미 증명) — 무회귀.
         chip: "border-border/80 bg-muted/70 text-foreground",
-        counter: "border-transparent bg-destructive text-destructive-foreground",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## 배경
PO 지시(2026-09-04 23:31Z) — story 3466(c2bb0acd) 본문에 적힌 잔존 4곳을 "코드에 있다≠쓰이는 것" 원칙으로 재고한 뒤 처리합니다. 근본원인은 #3822에서 이미 확立: `text-destructive-foreground`가 이 테마의 `@theme inline`에 매핑 자체가 없는 무효 Tailwind 유틸(조용히 no-op, 실제 렌더 색은 상속된 `--foreground`) — 라이트 3.55·다크 3.00, AA 4.5 미달.

## 각 자리 실사용 확認 결과
| 자리 | 실사용? | 처리 |
|---|---|---|
| `badge.tsx:61` `counter` variant | **아니오** — `variant="counter"`(리터럴·동적 모두) 소비처 0건(grep) | **삭제**(정본 치환이 아니라 죽은 코드 제거) |
| `stuck-handoff-section.tsx:99` | 예 — idle 상태 CTA 버튼(텍스트+아이콘 가시) | `bg-destructive text-white dark:text-proof-bg`로 치환(#3822 trust-seal.tsx 선례) |
| `kanban-board.tsx:1147` | 예 — 스토리 생성 실패 배너(`role="alert"`) | 같은 치환 |
| `story-detail-panel.tsx:1821` | 예 — 라벨 제거 아이콘 버튼(hover 전용·아이콘 전용, WCAG 비텍스트 3:1 대상) | `hover:text-white dark:hover:text-proof-bg`로 치환 |

## 검증
- 신규 pin 2건 — stuck-handoff idle 버튼·kanban-board 실패 배너 className 실측(회귀 가드)
- story-detail-panel의 라벨 제거 버튼은 hover 전용·아이콘 전용(3:1 대상)이라 전체 패널 렌더 하네스 신설 비용 대비 낮은 값으로 판단, 정적 diff로만 처리(별도 렌더 pin 없음 — 투명하게 명시)
- 관련 3파일 53 tests green(회귀 0)
- 전체 `pnpm vitest run`: 629 files / 5906 tests green
- `tsc --noEmit` clean, eslint clean
- tint/muted 대비 가드 스크립트 전부 무영향 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)