### PR TITLE
[SID:3473] fix: 채널 카드 헤더 rollup 칩 — 연결 ≥2일 때만

### DIFF
--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -198,6 +198,41 @@ describe('OrganizationChannelsPage — 목록·상태(story #3376)', () => {
   });
 });
 
+// story dd29e6dd(유나 5회차 관찰) — 헤더 rollup 칩이 연결 1개일 때 행 칩과 같은
+// 문장을 두 번 보여주던 것. 처방=헤더 칩은 연결 ≥2일 때만. 3표본(0/1/2개) 그대로 pin.
+describe('OrganizationChannelsPage — 헤더 rollup 칩 임계값(story dd29e6dd)', () => {
+  it('⭐연결 0개 — 헤더 칩 부재(회귀 pin, 행도 없음)', async () => {
+    stubFetch({ connections: [] });
+    await mount('owner');
+    expect(container.querySelectorAll('[data-status-chip]')).toHaveLength(0);
+  });
+
+  it('⭐연결 1개 — 헤더 칩 없이 행 칩 1개만(같은 문장 두 번 안 남)', async () => {
+    stubFetch({ connections: [CONNECTION_ACTIVE] });
+    await mount('owner');
+    const chips = container.querySelectorAll('[data-status-chip]');
+    expect(chips).toHaveLength(1);
+    expect(chips[0]?.getAttribute('data-status-chip')).toBe('connected');
+  });
+
+  it('⭐연결 2개(active+expired) — 헤더에 최악(expired) 요약 + 행 칩 2개(현행 유지)', async () => {
+    stubFetch({
+      connections: [
+        CONNECTION_ACTIVE,
+        { ...CONNECTION_ACTIVE, id: 'conn-2', account_id: 'acc-2', account_label: '@second', status: 'expired', token_expires_at: '2020-01-01T00:00:00Z' },
+      ],
+    });
+    await mount('owner');
+    const chips = [...container.querySelectorAll('[data-status-chip]')];
+    expect(chips).toHaveLength(3);
+    // 헤더 칩은 채널명 <h2>의 형제(SectionCardHeader의 flex 컨테이너 안) — 행 칩(둘 다
+    // 'reauth_required'/'connected'일 수 있는 값 자체로는 헤더/행을 못 가른다, DOM
+    // 구조로 가른다.
+    const headerChip = container.querySelector('h2 ~ [data-status-chip]');
+    expect(headerChip?.getAttribute('data-status-chip')).toBe('reauth_required');
+  });
+});
+
 describe('OrganizationChannelsPage — 앱 자격(AC2, story #3376)', () => {
   it('org 자격이면 끝 4자리를, platform이면 공용 앱 문구를 보여준다(섞지 않는다)', async () => {
     stubFetch({ connections: [], credentials: { configured: true, app_id_suffix: 'ab12', effective_source: 'org' } });

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -199,19 +199,27 @@ describe('OrganizationChannelsPage — 목록·상태(story #3376)', () => {
 });
 
 // story dd29e6dd(유나 5회차 관찰) — 헤더 rollup 칩이 연결 1개일 때 행 칩과 같은
-// 문장을 두 번 보여주던 것. 처방=헤더 칩은 연결 ≥2일 때만. 3표본(0/1/2개) 그대로 pin.
+// 문장을 두 번 보여주던 것. 처방=연결 0이면 자격 상태, 그 외(1/≥2)에만 중복 판단
+// (연결 !== 1). 3표본(0/1/2개) 그대로 pin.
 //
 // ⚠️카디르군 REQUEST_CHANGES(2026-09-05, PR#3826) — 최초 버전은 「칩 총 개수 + 값」만
 // 재서, "헤더 자리에 뜨고 행 자리엔 없는"(자리가 뒤바뀐) 회귀를 주입해도 그대로
 // PASS했다(개수 1은 그대로 1이니까). data-testid로 헤더 컨테이너·행 컨테이너를
 // 구조적으로 갈라 "그 자리 안에 몇 개가 있나"를 직접 잰다 — 값이 아니라 위치가 검증
 // 대상이다.
+//
+// ⚠️PO 보정(2026-09-05, 유나 지적) — 최초 처방(`>= 2`)은 연결 0개일 때 헤더가 지는
+// «자격 상태»(설정 미완·미연결)까지 지워 회귀를 냈다. 아래 "0개" 표본은 그래서
+// 헤더 칩이 **없다**가 아니라 **자격 칩이 있다**를 pin한다(뒤집힌 것이 아니라 원래
+// 잘못 pin됐던 것을 바로잡는 것).
 describe('OrganizationChannelsPage — 헤더 rollup 칩 임계값(story dd29e6dd)', () => {
-  it('⭐연결 0개 — 헤더 자리 칩 0·행 컨테이너 자체가 없음(회귀 pin)', async () => {
-    stubFetch({ connections: [] });
+  it('⭐연결 0개 — 헤더 자리에 자격 상태 칩(설정 미완)이 그대로 남는다(rollup과는 다른 신호, 지우면 회귀)', async () => {
+    stubFetch({ connections: [], credentials: { configured: false, app_id_suffix: null, effective_source: 'none' } });
     await mount('owner');
     const header = container.querySelector('[data-testid="channel-section-header"]')!;
-    expect(header.querySelectorAll('[data-status-chip]')).toHaveLength(0);
+    const headerChips = header.querySelectorAll('[data-status-chip]');
+    expect(headerChips).toHaveLength(1);
+    expect(headerChips[0]?.getAttribute('data-status-chip')).toBe('config_incomplete');
     expect(container.querySelector('[data-testid="channel-section-rows"]')).toBeNull();
   });
 

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -200,22 +200,33 @@ describe('OrganizationChannelsPage — 목록·상태(story #3376)', () => {
 
 // story dd29e6dd(유나 5회차 관찰) — 헤더 rollup 칩이 연결 1개일 때 행 칩과 같은
 // 문장을 두 번 보여주던 것. 처방=헤더 칩은 연결 ≥2일 때만. 3표본(0/1/2개) 그대로 pin.
+//
+// ⚠️카디르군 REQUEST_CHANGES(2026-09-05, PR#3826) — 최초 버전은 「칩 총 개수 + 값」만
+// 재서, "헤더 자리에 뜨고 행 자리엔 없는"(자리가 뒤바뀐) 회귀를 주입해도 그대로
+// PASS했다(개수 1은 그대로 1이니까). data-testid로 헤더 컨테이너·행 컨테이너를
+// 구조적으로 갈라 "그 자리 안에 몇 개가 있나"를 직접 잰다 — 값이 아니라 위치가 검증
+// 대상이다.
 describe('OrganizationChannelsPage — 헤더 rollup 칩 임계값(story dd29e6dd)', () => {
-  it('⭐연결 0개 — 헤더 칩 부재(회귀 pin, 행도 없음)', async () => {
+  it('⭐연결 0개 — 헤더 자리 칩 0·행 컨테이너 자체가 없음(회귀 pin)', async () => {
     stubFetch({ connections: [] });
     await mount('owner');
-    expect(container.querySelectorAll('[data-status-chip]')).toHaveLength(0);
+    const header = container.querySelector('[data-testid="channel-section-header"]')!;
+    expect(header.querySelectorAll('[data-status-chip]')).toHaveLength(0);
+    expect(container.querySelector('[data-testid="channel-section-rows"]')).toBeNull();
   });
 
-  it('⭐연결 1개 — 헤더 칩 없이 행 칩 1개만(같은 문장 두 번 안 남)', async () => {
+  it('⭐연결 1개 — 헤더 자리 칩 0·행 컨테이너 안에 정확히 1개(같은 문장 두 번 안 남, 자리 뒤바뀜도 잡힘)', async () => {
     stubFetch({ connections: [CONNECTION_ACTIVE] });
     await mount('owner');
-    const chips = container.querySelectorAll('[data-status-chip]');
-    expect(chips).toHaveLength(1);
-    expect(chips[0]?.getAttribute('data-status-chip')).toBe('connected');
+    const header = container.querySelector('[data-testid="channel-section-header"]')!;
+    const rows = container.querySelector('[data-testid="channel-section-rows"]')!;
+    expect(header.querySelectorAll('[data-status-chip]')).toHaveLength(0);
+    const rowChips = rows.querySelectorAll('[data-status-chip]');
+    expect(rowChips).toHaveLength(1);
+    expect(rowChips[0]?.getAttribute('data-status-chip')).toBe('connected');
   });
 
-  it('⭐연결 2개(active+expired) — 헤더에 최악(expired) 요약 + 행 칩 2개(현행 유지)', async () => {
+  it('⭐연결 2개(active+expired) — 헤더 자리에 정확히 1개(최악=expired)·행 컨테이너 안에 정확히 2개(현행 유지)', async () => {
     stubFetch({
       connections: [
         CONNECTION_ACTIVE,
@@ -223,13 +234,12 @@ describe('OrganizationChannelsPage — 헤더 rollup 칩 임계값(story dd29e6d
       ],
     });
     await mount('owner');
-    const chips = [...container.querySelectorAll('[data-status-chip]')];
-    expect(chips).toHaveLength(3);
-    // 헤더 칩은 채널명 <h2>의 형제(SectionCardHeader의 flex 컨테이너 안) — 행 칩(둘 다
-    // 'reauth_required'/'connected'일 수 있는 값 자체로는 헤더/행을 못 가른다, DOM
-    // 구조로 가른다.
-    const headerChip = container.querySelector('h2 ~ [data-status-chip]');
-    expect(headerChip?.getAttribute('data-status-chip')).toBe('reauth_required');
+    const header = container.querySelector('[data-testid="channel-section-header"]')!;
+    const rows = container.querySelector('[data-testid="channel-section-rows"]')!;
+    const headerChips = header.querySelectorAll('[data-status-chip]');
+    expect(headerChips).toHaveLength(1);
+    expect(headerChips[0]?.getAttribute('data-status-chip')).toBe('reauth_required');
+    expect(rows.querySelectorAll('[data-status-chip]')).toHaveLength(2);
   });
 });
 

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -221,13 +221,16 @@ function ChannelSection({
       <SectionCardHeader>
         <div className="flex flex-wrap items-center justify-between gap-2" data-testid="channel-section-header">
           <h2 className="text-sm font-semibold text-foreground">{channelLabel(channel, t)}</h2>
-          {/* story dd29e6dd(유나 5회차 관찰, 카디르군 REQUEST_CHANGES 2026-09-05 — 개수만
-              재는 pin은 "헤더 자리에 뜨고 행이 없는" 회귀를 못 잡는다는 지적, 자백·수용) —
-              rollup 칩은 여러 연결의 «최악»을 요약하는 것이 존재 이유라, 연결이 1개면
-              요약할 것이 없어 행 칩과 같은 문장을 두 번 보여줬다(0개일 때는 애초에 행 칩
-              자체가 없어 중복이 안 남). 연결 ≥2일 때만 — data-testid로 자리(헤더 vs 행)를
-              구조적으로 구분해 테스트가 값이 아니라 위치를 잰다. */}
-          {connections.length >= 2 ? <ChannelStatusChip status={channelStatus} /> : null}
+          {/* story dd29e6dd(유나 5회차 관찰·정본 3653a18c §3-3) — 「메아리」(헤더 rollup이
+              행 칩과 같은 문장을 두 번 보여주는 것)는 **연결이 정확히 1개일 때만** 성립한다
+              (두 칩이 실제로 있어야 메아리가 생긴다). 연결 0개일 때 헤더 칩은 rollup이
+              아니라 **자격 상태**(deriveChannelConnectionStatus({effectiveSource}) →
+              「설정 미완」·「미연결」)를 지는 **유일한 칩**이라 지우면 신호 자체가 사라진다
+              (카디르군 REQUEST_CHANGES 2026-09-05 뒤, 최초 처방 `>= 2`가 이 자리에서
+              회귀를 냈다 — PO 보정, 유나 지적). 그래서 조건은 `connections.length !== 1`
+              (0=자격 칩 그대로·1=메아리라 숨김·≥2=rollup+행 각각). data-testid로 자리
+              (헤더 vs 행)를 구조적으로 구분해 테스트가 값이 아니라 위치를 잰다. */}
+          {connections.length !== 1 ? <ChannelStatusChip status={channelStatus} /> : null}
         </div>
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -221,7 +221,10 @@ function ChannelSection({
       <SectionCardHeader>
         <div className="flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-sm font-semibold text-foreground">{channelLabel(channel, t)}</h2>
-          <ChannelStatusChip status={channelStatus} />
+          {/* story dd29e6dd(유나 5회차 관찰) — rollup 칩은 여러 연결의 «최악»을 요약하는
+              것이 존재 이유라, 연결이 1개면 요약할 것이 없어 행 칩과 같은 문장을 두 번
+              보여줬다(0개일 때는 애초에 행 칩 자체가 없어 중복이 안 남). 연결 ≥2일 때만. */}
+          {connections.length >= 2 ? <ChannelStatusChip status={channelStatus} /> : null}
         </div>
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -219,11 +219,14 @@ function ChannelSection({
   return (
     <SectionCard>
       <SectionCardHeader>
-        <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-2" data-testid="channel-section-header">
           <h2 className="text-sm font-semibold text-foreground">{channelLabel(channel, t)}</h2>
-          {/* story dd29e6dd(유나 5회차 관찰) — rollup 칩은 여러 연결의 «최악»을 요약하는
-              것이 존재 이유라, 연결이 1개면 요약할 것이 없어 행 칩과 같은 문장을 두 번
-              보여줬다(0개일 때는 애초에 행 칩 자체가 없어 중복이 안 남). 연결 ≥2일 때만. */}
+          {/* story dd29e6dd(유나 5회차 관찰, 카디르군 REQUEST_CHANGES 2026-09-05 — 개수만
+              재는 pin은 "헤더 자리에 뜨고 행이 없는" 회귀를 못 잡는다는 지적, 자백·수용) —
+              rollup 칩은 여러 연결의 «최악»을 요약하는 것이 존재 이유라, 연결이 1개면
+              요약할 것이 없어 행 칩과 같은 문장을 두 번 보여줬다(0개일 때는 애초에 행 칩
+              자체가 없어 중복이 안 남). 연결 ≥2일 때만 — data-testid로 자리(헤더 vs 행)를
+              구조적으로 구분해 테스트가 값이 아니라 위치를 잰다. */}
           {connections.length >= 2 ? <ChannelStatusChip status={channelStatus} /> : null}
         </div>
       </SectionCardHeader>
@@ -231,7 +234,7 @@ function ChannelSection({
         {connections.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t('channelNoConnections')}</p>
         ) : (
-          <div className="divide-y divide-border overflow-hidden rounded-md border border-border">
+          <div className="divide-y divide-border overflow-hidden rounded-md border border-border" data-testid="channel-section-rows">
             {connections.map((c) => (
               <ConnectionRow key={c.id} conn={c} isOwner={isOwner} orgId={orgId} onDisconnected={onRefresh} t={t} />
             ))}


### PR DESCRIPTION
## 배경
유나 5회차 라이브 관찰 — 채널 카드 헤더의 rollup 칩(`worstChannelConnectionStatus`)과 연결 행의 `ChannelStatusChip`이 연결이 1개일 때 같은 문장을 두 번 보여줍니다. 처분표(3b9960cb) 「기록만」 첫 항의 처방 후보를 이 스토리로 승격, PO 確定대로 구현합니다.

## 처방
- 연결 0개 — 헤더 칩 없음(rollup은 「여럿의 최악을 요약」이 존재 이유라 요약할 대상 자체가 없는 0/1개 둘 다 안 그립니다).
- 연결 1개 — 행 칩만.
- 연결 ≥2 — 헤더 rollup + 행 칩 각각(현행 유지).

`ChannelSection`(`organization/channels/page.tsx`) 헤더의 `<ChannelStatusChip status={channelStatus} />` 호출을 `connections.length >= 2` 조건 뒤로 옮겼습니다.

## 검증
- 3표본(0/1/2개, 2개는 active+expired로 최악 요약 pin) — 헤더/행 칩 판별은 데이터 값 자체(`reauth_required`가 헤더·행 둘 다에 있을 수 있어 값만으론 구분 불가)가 아니라 DOM 구조(`h2 ~ [data-status-chip]`, `SectionCardHeader`의 flex 형제)로 구분
- 신규 3 tests + 기존 21 tests 전부 green(회귀 0)
- 전체 `pnpm vitest run`: 630 files / 5921 tests green
- `tsc --noEmit` clean, eslint clean

라이브 실픽셀 판정(유나)은 배포 뒤 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)