### PR TITLE
[SID:3476] feat: 외부 목적지 발행 결과 읽기 표면 + 공용 retry 엔드포인트

### DIFF
--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -1118,6 +1118,45 @@ class RetryPublicationCommandResponse(BaseModel):
     status: str
 
 
+async def _retry_publication_command(
+    db: AsyncSession, *, org_id: uuid.UUID, command_id: uuid.UUID, auth: AuthContext,
+) -> RetryPublicationCommandResponse:
+    """story #3414 AC5·#3476(페드루 보정②, 미르코 FE 그라운딩 2026-09-05) — 휴먼
+    전용, `dead_letter`/`blocked` 상태인 command만 `pending`으로 되돌린다(그 외는
+    404로 존재 비노출). `retry_dead_letter_command` 자체가 `content_kind`를 안
+    본다(org_id+command_id로만 조회) — channel_post·site_post 양쪽 어느 경로에서
+    호출돼도 그대로 맞는다, 이 함수 자체엔 분기 코드가 없다(불필요)."""
+    await _require_human(db, auth, org_id)
+
+    from app.services.publication_command import retry_dead_letter_command
+
+    command = await retry_dead_letter_command(db, org_id=org_id, command_id=command_id)
+    if command is None:
+        raise HTTPException(status_code=404, detail="command를 찾을 수 없거나 재시도 대상이 아닙니다")
+    await db.commit()
+    return RetryPublicationCommandResponse(id=command.id, status=command.status)
+
+
+@router.post(
+    "/{org_id}/publication-commands/{command_id}/retry",
+    response_model=RetryPublicationCommandResponse,
+)
+async def retry_publication_command_shared_endpoint(
+    org_id: uuid.UUID,
+    command_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> RetryPublicationCommandResponse:
+    """story #3476(페드루 보정②) — content_kind 무관 공용 경로. 기존
+    `/channel-posts/publication-commands/{id}/retry`는 경로 자체에 channel-posts가
+    박혀 있어 site_post 화면이 재사용할 수 없었다(미르코 FE 그라운딩). FE의
+    새 호출은 전부 이 경로로 옮긴다 — 구 경로는 하위호환으로 이 함수에 위임만."""
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    return await _retry_publication_command(db, org_id=org_id, command_id=command_id, auth=auth)
+
+
 @router.post(
     "/{org_id}/channel-posts/publication-commands/{command_id}/retry",
     response_model=RetryPublicationCommandResponse,
@@ -1136,18 +1175,13 @@ async def retry_publication_command_endpoint(
     (카디르 QA와 동형 관례, 상태를 굳이 구별해 알려주지 않는다).
     `next_attempt_at`을 null로 되돌려야 다음 cron tick이 이 행을 실제로 다시 집는다
     (status만 바뀌고 next_attempt_at이 미래에 멈춰 있으면 WHERE절에서 계속 빠지는
-    결함 — 카디르 QA⑤ 지적 그대로 반영)."""
+    결함 — 카디르 QA⑤ 지적 그대로 반영).
+
+    story #3476 — 공용 엔드포인트(`retry_publication_command_shared_endpoint`)로
+    위임만(동작 무변, 구 경로 호환 유지 — FE 마이그레이션 전까지 죽이지 않는다)."""
     if org_id != verified_org_id:
         raise HTTPException(status_code=403, detail="org_id mismatch")
-    await _require_human(db, auth, org_id)
-
-    from app.services.publication_command import retry_dead_letter_command
-
-    command = await retry_dead_letter_command(db, org_id=org_id, command_id=command_id)
-    if command is None:
-        raise HTTPException(status_code=404, detail="command를 찾을 수 없거나 재시도 대상이 아닙니다")
-    await db.commit()
-    return RetryPublicationCommandResponse(id=command.id, status=command.status)
+    return await _retry_publication_command(db, org_id=org_id, command_id=command_id, auth=auth)
 
 
 class CancelScheduledCommandResponse(BaseModel):

--- a/backend/app/routers/site_posts.py
+++ b/backend/app/routers/site_posts.py
@@ -34,6 +34,7 @@ from app.services.site_posts import (
     create_site_post_draft_version,
     get_campaign,
     get_site_post_draft,
+    get_site_post_external_publication_state,
     get_site_post_publication_info,
     is_agent_caller,
     list_site_post_draft_versions,
@@ -514,6 +515,58 @@ async def submit_site_post_draft_endpoint(
     )
 
 
+class ChannelPublicationView(BaseModel):
+    """story #3476 — `channel_publications` 최신 1행을 그대로 실은 것(서버 값 그대로,
+    FE 조립 X). `unpublished_at`은 전용 컬럼이 없다 — status가 "unpublished"일 때만
+    updated_at을 그 의미로 재사용한다(신규 마이그 없이, 이 스토리 스코프가 "읽기
+    표면"뿐이라 스키마 확장은 별도 판단 대상)."""
+    status: str
+    external_id: str | None = None
+    permalink: str | None = None
+    published_at: str | None = None
+    unpublished_at: str | None = None
+    last_error: str | None = None
+
+
+class PublicationCommandView(BaseModel):
+    """story #3476 보정①(페드루, 미르코 FE 그라운딩 2026-09-05) — 필드명은 새로
+    안 짓는다. FE의 기존 순수 판정 함수 `components/content/failure-action.ts::
+    deriveFailureAction`이 channel_post 상세에서 이미 먹는 그 shape 그대로 —
+    site_post에도 같은 이름으로 붙여야 `FailureActionBadge`를 재사용할 수 있다."""
+    id: uuid.UUID
+    command_status: str
+    attempt_count: int
+    failure_kind: str | None = None
+    next_retry_at: str | None = None
+    dead_letter_at: str | None = None
+    command_reason_code: str | None = None
+    last_error: str | None = None
+
+
+def _channel_publication_view(pub) -> ChannelPublicationView | None:
+    if pub is None:
+        return None
+    return ChannelPublicationView(
+        status=pub.status, external_id=pub.external_id, permalink=pub.permalink,
+        published_at=pub.published_at.isoformat() if pub.published_at else None,
+        unpublished_at=pub.updated_at.isoformat() if pub.status == "unpublished" else None,
+        last_error=pub.last_error,
+    )
+
+
+def _publication_command_view(cmd) -> PublicationCommandView | None:
+    if cmd is None:
+        return None
+    return PublicationCommandView(
+        id=cmd.id, command_status=cmd.status, attempt_count=cmd.attempt_count,
+        failure_kind=cmd.failure_kind,
+        next_retry_at=cmd.next_attempt_at.isoformat() if cmd.next_attempt_at else None,
+        dead_letter_at=cmd.dead_letter_at.isoformat() if cmd.dead_letter_at else None,
+        command_reason_code=cmd.reason_code,
+        last_error=cmd.last_error,
+    )
+
+
 class PublishSitePostFromDraftResponse(BaseModel):
     # story e4fc29fa(조각③c) — 외부 목적지(connection_id != None)는 이 요청 시점엔 아직
     # 결과가 없다(url/published_at은 워커가 나중에 채우는 channel_publications 몫이지
@@ -525,6 +578,10 @@ class PublishSitePostFromDraftResponse(BaseModel):
     version_id: uuid.UUID
     command_id: uuid.UUID | None = None
     status: str | None = None  # "pending" — 외부 목적지 경로에서만 채워진다.
+    # story #3476 — 외부 목적지 분기에서만 채워진다(hosted_site는 이 요청으로 이미
+    # 동기 완결이라 "지금 어디까지 왔나" 자체가 무의미 — None 유지, 회귀 0).
+    channel_publication: ChannelPublicationView | None = None
+    command: PublicationCommandView | None = None
 
 
 @router.post(
@@ -583,8 +640,13 @@ async def publish_site_post_from_draft_endpoint(
         command = await request_site_post_external_publish(
             db, org_id=org_id, draft_id=draft_id, requested_by_member_id=resolved.id,
         )
+        _destination, publication, _cmd_latest = await get_site_post_external_publication_state(
+            db, org_id=org_id, draft_id=draft_id,
+        )
         return PublishSitePostFromDraftResponse(
             version_id=command.approved_version, command_id=command.id, status=command.status,
+            channel_publication=_channel_publication_view(publication),
+            command=_publication_command_view(command),
         )
     except SitePostDraftNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -609,6 +671,11 @@ class SitePostPublicationResponse(BaseModel):
     url: str | None
     published_by_member_id: uuid.UUID | None
     published_body_sha256: str | None
+    # story #3476 — destination은 hosted_site/wordpress/webhook 3종(기본값 hosted_site
+    # 유지 — 기존 필드 넷은 hosted_site에서 이미 그대로 채워지던 값, 회귀 0).
+    destination: str = "hosted_site"
+    channel_publication: ChannelPublicationView | None = None
+    command: PublicationCommandView | None = None
 
 
 @router.get(
@@ -633,6 +700,9 @@ async def get_site_post_publication_endpoint(
 
     try:
         info = await get_site_post_publication_info(db, org_id=org_id, draft_id=draft_id)
+        destination, publication, command = await get_site_post_external_publication_state(
+            db, org_id=org_id, draft_id=draft_id,
+        )
     except SitePostDraftNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -640,6 +710,9 @@ async def get_site_post_publication_endpoint(
         published_at=info.published_at.isoformat() if info.published_at else None,
         url=info.url, published_by_member_id=info.published_by_member_id,
         published_body_sha256=info.published_body_sha256,
+        destination=destination,
+        channel_publication=_channel_publication_view(publication),
+        command=_publication_command_view(command),
     )
 
 
@@ -651,6 +724,9 @@ class UnpublishSitePostResponse(BaseModel):
     unpublished_at: str | None = None
     command_id: uuid.UUID | None = None
     status: str | None = None
+    # story #3476 — publish 응답과 동형(외부 목적지 분기에서만 채워진다).
+    channel_publication: ChannelPublicationView | None = None
+    command: PublicationCommandView | None = None
 
 
 @router.post(
@@ -691,7 +767,14 @@ async def unpublish_site_post_endpoint(
         command = await request_site_post_external_unpublish(
             db, org_id=org_id, draft_id=draft_id, requested_by_member_id=resolved.id,
         )
-        return UnpublishSitePostResponse(command_id=command.id, status=command.status)
+        _destination, publication, _cmd_latest = await get_site_post_external_publication_state(
+            db, org_id=org_id, draft_id=draft_id,
+        )
+        return UnpublishSitePostResponse(
+            command_id=command.id, status=command.status,
+            channel_publication=_channel_publication_view(publication),
+            command=_publication_command_view(command),
+        )
     except SitePostDraftNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except SitePostNotPublishedError as exc:

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -1264,6 +1264,60 @@ async def get_site_post_publication_info(
     )
 
 
+async def get_site_post_external_publication_state(
+    db: AsyncSession, *, org_id: uuid.UUID, draft_id: uuid.UUID,
+) -> "tuple[str, ChannelPublication | None, PublicationCommand | None]":
+    """story #3476(Phase1·BE·결함, 런북 A-7 FAIL 2026-09-05) — 외부 목적지(WordPress·
+    webhook)로 발행된 draft의 상태를 읽는 유일한 자리. `publish_site_post_external_
+    command`(워커)는 `channel_publications`에 결과를 잘 쓰지만(성공 분기 확認됨),
+    그걸 읽는 API가 하나도 없었다 — 런북 실측: 워커 로그엔 200이 찍히는데 제품 어디서도
+    permalink·external_id·상태를 확認할 수 없었다.
+
+    `destination`: draft.connection_id가 None이면 "hosted_site", 아니면 그 connection의
+    `channel` 값("wordpress"/"webhook") — connection 행이 지워졌으면(FK 없음, 그라운딩
+    §9) "unknown"(지어내지 않는다).
+
+    `channel_publication`/`command` 둘 다 이 draft 자신의 `site_post_versions`로 좁혀
+    조회한다(`version_id.in_(own_version_ids)`/`approved_version.in_(own_version_ids)`)
+    — request_site_post_external_unpublish가 이미 쓰는 그 축 그대로(cross-draft 유출
+    방지, PR#3797 블로커와 동형 사고를 읽기 경로에서 재발시키지 않는다). 최신 1건(없으면
+    둘 다 None — 아직 한 번도 시도 안 됐다는 뜻, 지어내지 않는다)."""
+    from app.models.channel_connection import ChannelConnection
+    from app.models.channel_publication import ChannelPublication
+    from app.models.publication_command import PublicationCommand
+    from app.models.site_post_version import SitePostVersion
+
+    draft = await get_site_post_draft(db, org_id=org_id, draft_id=draft_id)
+    if draft is None:
+        raise SitePostDraftNotFoundError(draft_id)
+    if draft.connection_id is None:
+        return "hosted_site", None, None
+
+    connection = await db.get(ChannelConnection, draft.connection_id)
+    destination = connection.channel if connection is not None else "unknown"
+
+    own_version_ids = select(SitePostVersion.id).where(SitePostVersion.draft_id == draft_id)
+    publication = (await db.execute(
+        select(ChannelPublication)
+        .where(ChannelPublication.org_id == org_id, ChannelPublication.version_id.in_(own_version_ids))
+        .order_by(ChannelPublication.created_at.desc())
+        .limit(1)
+    )).scalar_one_or_none()
+
+    command = (await db.execute(
+        select(PublicationCommand)
+        .where(
+            PublicationCommand.org_id == org_id,
+            PublicationCommand.content_kind == "site_post",
+            PublicationCommand.approved_version.in_(own_version_ids),
+        )
+        .order_by(PublicationCommand.created_at.desc())
+        .limit(1)
+    )).scalar_one_or_none()
+
+    return destination, publication, command
+
+
 # ─── story #3381(Phase0 후속·결함) — 발행 취소(비공개) ─────────────────────────────
 
 async def unpublish_site_post(

--- a/backend/tests/test_3386_site_post_publication.py
+++ b/backend/tests/test_3386_site_post_publication.py
@@ -315,6 +315,7 @@ async def test_publication_info_all_null_when_never_published_not_404():
         assert r_info.status_code == 200, r_info.text
         assert r_info.json() == {
             "published_at": None, "url": None, "published_by_member_id": None, "published_body_sha256": None,
+            "destination": "hosted_site", "channel_publication": None, "command": None,
         }
     finally:
         app.dependency_overrides.clear()
@@ -387,6 +388,7 @@ async def test_publication_info_all_null_after_unpublish():
         assert r_info.status_code == 200, r_info.text
         assert r_info.json() == {
             "published_at": None, "url": None, "published_by_member_id": None, "published_body_sha256": None,
+            "destination": "hosted_site", "channel_publication": None, "command": None,
         }
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_3476_publish_read_surface.py
+++ b/backend/tests/test_3476_publish_read_surface.py
@@ -1,0 +1,402 @@
+"""story #3476(Phase1·BE·결함, 런북 A-7 FAIL 2026-09-05) — 외부 목적지(WordPress·
+webhook) 발행 결과를 읽는 표면 신설. `/site-posts/drafts/{id}/publication`·
+`/publish`·`/unpublish`가 `channel_publications`/`publication_commands`에 이미
+쓰인 값(permalink·external_id·status·attempt_count·dead_letter_at 등)을 destination
+축과 함께 실어 반환한다 — 전용 엔드포인트 신설 없음, 기존 표면 확장뿐(페드루 5줄
+確定 그대로).
+
+세팅 헬퍼는 test_e4fc29fa_site_post_orchestration.py와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import (
+    _client_for,
+    _create_and_submit_site_post_draft,
+    _seed_agent,
+    _seed_default_role,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _seed_wordpress_connection,
+    _session_factory,
+    _setup_org_scoped_app,
+    live_wordpress_stub,  # noqa: F401 — pytest fixture import
+)
+
+import os
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+@pytest.mark.anyio
+async def test_publication_view_shows_wordpress_permalink_and_external_id_after_worker_run(live_wordpress_stub):
+    """(1) 양성대조 — 승인·워커 처리 뒤 GET /publication이 destination="wordpress"·
+    channel_publication.permalink(dev-wordpress-stub.internal/{slug}/)·external_id·
+    status="published"을 실제로 실어 준다(런북 A-7이 요구하는 그 값)."""
+    from app.services.gate_service import transition_gate
+    from app.services.publication_command import process_due_publication_commands
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_wordpress_connection(s, org_id, site_url=live_wordpress_stub)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_id, gate_id = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id, slug="perm-test",
+            )
+
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_id, "approved", resolver_id=human_id)
+            await s.commit()
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_user_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publication")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["destination"] == "wordpress"
+        pub = body["channel_publication"]
+        assert pub is not None
+        assert pub["status"] == "published"
+        assert pub["external_id"] is not None
+        assert pub["permalink"] == "https://dev-wordpress-stub.internal/perm-test/"
+        assert pub["last_error"] is None
+        cmd = body["command"]
+        assert cmd is not None
+        assert cmd["command_status"] == "completed"
+        assert cmd["attempt_count"] == 0  # 성공은 attempt_count를 안 건드린다(실패 카운터).
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_hosted_site_publication_view_regression_unchanged():
+    """(2) 양성대조 — hosted_site(connection_id=None) draft는 destination="hosted_site"
+    고정·channel_publication/command 둘 다 null(회귀 0, 새 필드 추가가 기존 4필드
+    계약을 안 건드린다)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            story_id = await _seed_story(s, org_id, project_id)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            r = await client.post(
+                f"/api/v2/organizations/{org_id}/site-posts/drafts",
+                json={
+                    "work_item_id": str(story_id), "title": "제목", "slug": "hosted-view-test",
+                    "lang": "ko", "summary": "요약", "tags": [], "body_md": "본문", "media_manifest": [],
+                },
+            )
+            assert r.status_code == 201, r.text
+            draft_id = uuid.UUID(r.json()["draft_id"])
+
+            r2 = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publication")
+        assert r2.status_code == 200, r2.text
+        body = r2.json()
+        assert body["destination"] == "hosted_site"
+        assert body["channel_publication"] is None
+        assert body["command"] is None
+        assert body["published_at"] is None
+        assert body["url"] is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_dead_letter_command_shows_last_error_and_dead_letter_at():
+    """(3) — 결정적 실패로 dead_letter된 커맨드도 last_error·dead_letter_at이 읽기
+    표면에 그대로 실린다(카디르가 로그 없이 원인을 볼 수 있어야 한다는 런북 요구)."""
+    from app.services.gate_service import transition_gate
+    from app.services.publication_command import process_due_publication_commands
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            # 스텁이 아닌 도달 불가 URL — adapter 호출이 결정적으로 실패한다(연결
+            # 자체가 없다는 뜻이 아니라 provider 자체가 존재하지 않는 host, 재시도
+            # 자체는 이 테스트 관심사가 아니라 강제로 dead_letter 상태를 만든다).
+            connection_id = await _seed_wordpress_connection(
+                s, org_id, site_url="http://127.0.0.1:1/unreachable-test-host",
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_id, gate_id = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+            )
+
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_id, "approved", resolver_id=human_id)
+            await s.commit()
+
+        # publication_command.py::apply_command_failure — 매핑표 밖 error_code(이
+        # 시나리오는 httpx 연결 실패라 SitePostExternalPublishError 자체를 안 거친다,
+        # error_code=None)는 needs_check로 fail-closed → 백오프 없이 첫 tick에서
+        # 바로 dead_letter(재시도해도 똑같이 실패할 결정적 실패로 취급).
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd_id = (await s.execute(
+                select(PublicationCommand.id).where(PublicationCommand.gate_id == gate_id)
+            )).scalar_one()
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["dead_letter"] == 1, counts
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.id == cmd_id)
+            )).scalar_one()
+        assert cmd.status == "dead_letter", f"강제 재시도 루프로도 dead_letter를 못 만들었다(현재={cmd.status})"
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_user_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publication")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        cmd_view = body["command"]
+        assert cmd_view is not None
+        assert cmd_view["command_status"] == "dead_letter"
+        assert cmd_view["failure_kind"] == "needs_check"
+        assert cmd_view["dead_letter_at"] is not None
+        assert cmd_view["last_error"] is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publication_view_org_isolated(live_wordpress_stub):
+    """(4) — org A의 발행 결과가 org B의 draft 조회로 안 새어 나온다(cross-tenant
+    유출 부정대조 — get_site_post_external_publication_state의 org_id 필터가 실제로
+    막는지)."""
+    from app.services.gate_service import transition_gate
+    from app.services.publication_command import process_due_publication_commands
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a, project_a = await _seed_org(s)
+            await _seed_default_role(s, org_a)
+            agent_a = await _seed_agent(s, org_a, project_a)
+            human_user_a, human_a = await _seed_human(s, org_a)
+            story_a = await _seed_story(s, org_a, project_a)
+            connection_a = await _seed_wordpress_connection(s, org_a, site_url=live_wordpress_stub)
+
+            org_b, project_b = await _seed_org(s)
+            agent_b = await _seed_agent(s, org_b, project_b)
+
+        _setup_org_scoped_app(app, Session, org_a, user_id=agent_a, agent=True)
+        async with _client_for(app) as client:
+            draft_id, gate_id = await _create_and_submit_site_post_draft(
+                client, org_id=org_a, story_id=story_a, connection_id=connection_a, slug="org-a-post",
+            )
+        async with Session() as s:
+            await transition_gate(s, org_a, gate_id, "approved", resolver_id=human_a)
+            await s.commit()
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        # org B가 org A의 draft_id로 조회 — draft 자체가 org B 소속이 아니므로 404.
+        _setup_org_scoped_app(app, Session, org_b, user_id=agent_b, agent=True)
+        async with _client_for(app) as client:
+            r = await client.get(f"/api/v2/organizations/{org_b}/site-posts/drafts/{draft_id}/publication")
+        assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_publish_and_unpublish_external_responses_carry_channel_publication_and_command(
+    live_wordpress_stub,
+):
+    """(5) — `/publish` 외부 분기 응답도 command(pending 상태) 를 즉시 싣는다(워커
+    실행 前 시점 — channel_publication은 아직 없어 null이 정상). unpublish 이후
+    재조회하면 channel_publication.status가 "unpublished"로 바뀐 걸 GET에서 본다."""
+    from app.services.gate_service import transition_gate
+    from app.services.publication_command import process_due_publication_commands
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_wordpress_connection(s, org_id, site_url=live_wordpress_stub)
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_id, gate_id = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+            )
+
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_id, "approved", resolver_id=human_id)
+            await s.commit()
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_user_id, agent=False)
+        async with _client_for(app) as client:
+            r_pub = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publish")
+        assert r_pub.status_code == 200, r_pub.text
+        pub_body = r_pub.json()
+        assert pub_body["status"] == "pending"
+        assert pub_body["command"] is not None
+        assert pub_body["command"]["command_status"] == "pending"
+        assert pub_body["channel_publication"] is None  # 워커가 아직 안 돌았다.
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        async with _client_for(app) as client:
+            r_unpub = await client.post(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/unpublish")
+        assert r_unpub.status_code == 200, r_unpub.text
+        unpub_body = r_unpub.json()
+        assert unpub_body["command"] is not None
+        # unpublish 요청 시점의 channel_publication은 아직 "published"(회수 워커가
+        # 아직 안 돌았다 — publish와 동형으로 워커 완료 후에야 상태가 바뀐다).
+        assert unpub_body["channel_publication"]["status"] == "published"
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+
+        async with _client_for(app) as client:
+            r_get = await client.get(f"/api/v2/organizations/{org_id}/site-posts/drafts/{draft_id}/publication")
+        assert r_get.status_code == 200, r_get.text
+        assert r_get.json()["channel_publication"]["status"] == "unpublished"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_shared_retry_endpoint_requeues_site_post_dead_letter_command():
+    """(6) 페드루 보정② — 신규 공용 `POST .../publication-commands/{id}/retry`가
+    site_post 커맨드도 되돌린다(기존 `/channel-posts/publication-commands/{id}/retry`는
+    경로 자체에 channel-posts가 박혀 있어 이 시나리오를 애초에 못 태웠다).
+    `retry_dead_letter_command`가 content_kind를 안 본다는 그라운딩을 이 경로로
+    직접 증명한다."""
+    from app.services.gate_service import transition_gate
+    from app.services.publication_command import process_due_publication_commands
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id = await _seed_org(s)
+            await _seed_default_role(s, org_id)
+            agent_id = await _seed_agent(s, org_id, project_id)
+            human_user_id, human_id = await _seed_human(s, org_id)
+            story_id = await _seed_story(s, org_id, project_id)
+            connection_id = await _seed_wordpress_connection(
+                s, org_id, site_url="http://127.0.0.1:1/unreachable-test-host-2",
+            )
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+        async with _client_for(app) as client:
+            draft_id, gate_id = await _create_and_submit_site_post_draft(
+                client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+            )
+
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_id, "approved", resolver_id=human_id)
+            await s.commit()
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd_id = (await s.execute(
+                select(PublicationCommand.id).where(PublicationCommand.gate_id == gate_id)
+            )).scalar_one()
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["dead_letter"] == 1, counts
+
+        _setup_org_scoped_app(app, Session, org_id, user_id=human_user_id, agent=False)
+        async with _client_for(app) as client:
+            r = await client.post(f"/api/v2/organizations/{org_id}/publication-commands/{cmd_id}/retry")
+        assert r.status_code == 200, r.text
+        assert r.json() == {"id": str(cmd_id), "status": "pending"}
+
+        async with Session() as s:
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+            cmd = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.id == cmd_id)
+            )).scalar_one()
+            assert cmd.status == "pending"
+            assert cmd.next_attempt_at is None
+            assert cmd.dead_letter_at is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1156,6 +1156,11 @@
       "file": "tests/test_3471_org_content_rules_lint.py",
       "sec": 40.0,
       "source": "story-3471-org-content-rules-lint(PR 개설 前 선제 등재 — 로컬 raw pytest 7.34s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 40s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3476_publish_read_surface.py",
+      "sec": 55.0,
+      "source": "story-3476-external-publish-read-surface(PR 개설 前 선제 등재 — 로컬 raw pytest 9.14s 실측치(6 tests, 페드루 보정①·② 반영 후)를 CI 배율(~6x, story #3383) 보수적으로 반영한 55s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
[SID:3476]

## Summary
- `GET/POST .../site-posts/drafts/{id}/publication|publish|unpublish` 응답에 `destination`(hosted_site|wordpress|webhook) + 최신 `channel_publication`(status/external_id/permalink/published_at/unpublished_at/last_error) + `command`(id/command_status/attempt_count/failure_kind/next_retry_at/dead_letter_at/command_reason_code/last_error)를 싣는다. 전용 엔드포인트 신설 없음 — 기존 3개 표면 확장뿐. hosted_site 경로는 무변경(회귀 0).
- `POST /api/v2/organizations/{org_id}/publication-commands/{command_id}/retry` 신설 — `retry_dead_letter_command`가 원래 content_kind를 안 보므로 site_post 커맨드도 그대로 재시도 가능. 기존 `POST .../channel-posts/publication-commands/{command_id}/retry`는 이 공용 엔드포인트로 위임만(동작 무변, 하위호환 유지).
- `command{...}` 필드명은 FE 기존 `deriveFailureAction`이 먹는 shape 그대로(페드루 PO 보정, 미르코 FE 그라운딩) — 새 이름 안 지음.

## Background
런북 A-7 FAIL(2026-09-05) — WordPress 스텁 발행이 워커 레벨에서는 성공(`channel_publications`에 정상 기록)했지만, 어떤 API 응답도 그 결과(permalink·external_id·status)를 읽지 못해 사람이 로그 없이 발행 성공 여부를 확인할 길이 없었다. Phase 1 AC 원문 "외부 URL을 확認한다"가 제품 안에서 성립하지 않는 상태.

## Test plan
- [x] `tests/test_3476_publish_read_surface.py` 신규 6건: wordpress 스텁 발행 후 permalink/external_id 노출(양성) · hosted_site 회귀 0 · dead_letter 커맨드 last_error/dead_letter_at/failure_kind 노출 · org 격리(cross-tenant 404) · publish/unpublish 외부 분기 응답에 channel_publication/command 동봉 · 신규 공용 retry 엔드포인트가 site_post dead_letter 커맨드를 실제로 되돌림.
- [x] 회귀: `test_3414_publication_command.py`(30건, 기존 retry 엔드포인트 포함) + `test_0e960006_command_id_exposure.py` + `test_e4fc29fa_site_post_orchestration.py`/`test_e4fc29fa_hosted_site_publish_adapter.py`/`test_e4fc29fa_wordpress_publish_adapter.py` 등 site_posts 표면 전체(72+20건) 로컬 raw pytest 전부 green(신선 disposable Postgres, alembic upgrade head로 마이그레이션 실행).
- [x] `scripts/lint_destructive_schema_weights_registered.py` — 신규 테스트 파일 weights.json 등재 확인(0 미등재).

🤖 Generated with [Claude Code](https://claude.com/claude-code)