### PR TITLE
[SID:3474] feat: 워커 adapter 호출 직전 게이트 재검증 + publication_attempts 원장

### DIFF
--- a/backend/alembic/versions/0327_publication_attempts.py
+++ b/backend/alembic/versions/0327_publication_attempts.py
@@ -1,0 +1,44 @@
+"""story #3474(Phase1·마케팅운영, 페드루 PO 確定 2026-09-05) — `publication_attempts`
+원장. 블루프린트 v3 §1 구조적 차단 장치 4 「유효한 휴먼 승인 레코드가 없으면 외부
+어댑터 호출 자체를 거부」가 지금은 "커맨드 존재=승인"이라는 암묵 계약으로만 서
+있었다(디디 그라운딩 2026-09-05 — create_or_get_publication_command()가 승인
+분기 안에서만 호출되는 게 유일한 보장, 워커는 이후 gate.status를 재확인 안 함).
+이 원장은 워커가 adapter 호출 "직전" 게이트를 재조회한 결과(approval_check)와
+실제로 adapter를 호출했는지(adapter_called)를 매 시도마다 남겨 「승인 없는 호출
+0건」을 쿼리 한 줄로 셀 수 있게 한다.
+
+FK 없음(publication_commands·channel_connections와 동일 관례, 그라운딩 §9).
+
+down_revision=0326는 story #3471(#3825, org_content_rules) — 이 스토리 착수
+시점에 develop 미착지였다(gh pr list로 실물 확인, 열린 PR의 alembic/versions
+까지가 SSOT)."""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0327"
+down_revision = "0326"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "publication_attempts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("command_id", postgresql.UUID(as_uuid=True), nullable=False, index=True),
+        sa.Column("gate_id", postgresql.UUID(as_uuid=True), nullable=False, index=True),
+        # 'ok'|'missing'|'voided'|'version_mismatch' — CHECK 없는 Text(이 도메인
+        # 전체 관례, publication_commands.status와 동형 — 값 추가 시 마이그 불요).
+        sa.Column("approval_check", sa.Text(), nullable=False),
+        sa.Column("adapter_called", sa.Boolean(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("result_code", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("publication_attempts")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -144,6 +144,7 @@ from app.models.publication_command import PublicationCommand
 from app.models.channel_post_image import ChannelPostImage
 from app.models.campaign import Campaign
 from app.models.org_content_rule import OrgContentRule
+from app.models.publication_attempt import PublicationAttempt
 
 __all__ = [
     "RoleTemplate",

--- a/backend/app/models/publication_attempt.py
+++ b/backend/app/models/publication_attempt.py
@@ -1,0 +1,38 @@
+"""story #3474(Phase1·마케팅운영, 페드루 PO 確定 2026-09-05) — 워커가 adapter 호출
+직전 게이트 승인을 재검증한 결과를 매 시도마다 남기는 원장. 블루프린트 §1 구조적
+차단 장치 4 「승인 없는 adapter 호출」을 `SELECT count(*) FROM publication_attempts
+WHERE adapter_called AND approval_check <> 'ok'` 한 줄로 셀 수 있게 한다(정상
+경로에서 항상 0).
+
+`approval_check`: `ok`(재검증 통과)·`missing`(게이트가 approved가 아님)·
+`voided`(무효화됨 — void_pending_commands_for_gate가 선제 처리한 경우 이 원장엔
+안 남는다, 워커가 뒤늦게 잡은 경우만)·`version_mismatch`(sealed_content_sha256이
+지금 버전과 다름 — 승인 뒤 재편집됐는데 아직 이 command가 안 걸러짐).
+
+`finished_at`이 채워진 첫 성공(`approval_check='ok' AND adapter_called`) 행이
+dead_letter 뒤 첫 번째면 「복구시간 = 그 finished_at − dead_letter_at」이 이
+원장만으로 파생된다(디디 그라운딩 "복구 완료 시각 컬럼 없음"을 이 원장이 대신
+채운다 — publication_commands에 신규 컬럼 0)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class PublicationAttempt(Base):
+    __tablename__ = "publication_attempts"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    command_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    gate_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    approval_check: Mapped[str] = mapped_column(Text, nullable=False)
+    adapter_called: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    result_code: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -913,7 +913,7 @@ async def publish_channel_post_draft_endpoint(
     resolved = await _require_human(db, auth, org_id)
 
     from app.services.channel_posts import resolve_command_target
-    from app.services.publication_command import apply_command_failure, create_or_get_publication_command
+    from app.services.publication_command import record_publication_attempt, apply_command_failure, create_or_get_publication_command
 
     try:
         draft, latest, gate = await resolve_command_target(db, org_id=org_id, draft_id=draft_id)
@@ -945,6 +945,18 @@ async def publish_channel_post_draft_endpoint(
     )
     await db.commit()
     now = datetime.now(timezone.utc)
+    attempt_started_at = now
+
+    async def _record_this_attempt(*, approval_check: str, adapter_called: bool, result_code: str | None) -> None:
+        # story #3474(페드루 보정, 2026-09-05) — 즉시 발행은 `_process_one_command`
+        # (cron 워커)를 안 거치는 별도 동기 경로라, 그쪽에 심은 원장 기록이 이 경로엔
+        # 하나도 안 닿는다. 실제 채널 발행 트래픽 대부분이 이 경로(즉시)를 타므로
+        # 여기서 빠지면 원장이 소수(예약분)만 세는 반쪽 계측이 된다 — 워커와 같은
+        # 지점(publish_channel_post_draft 호출 전후)에 동일하게 심는다.
+        await record_publication_attempt(
+            db, command=command, approval_check=approval_check, adapter_called=adapter_called,
+            started_at=attempt_started_at, finished_at=datetime.now(timezone.utc), result_code=result_code,
+        )
 
     def _with_command_state(detail: dict) -> dict:
         # 페드루 리뷰 F(제품 의미 확定) — 즉시 발행 실패로 command가 pending(자동
@@ -962,6 +974,7 @@ async def publish_channel_post_draft_endpoint(
             db, org_id=org_id, draft_id=draft_id, published_by_member_id=resolved.id,
         )
     except ChannelPostDraftNotFoundError as exc:
+        await _record_this_attempt(approval_check="ok", adapter_called=False, result_code="CHANNEL_POST_DRAFT_NOT_FOUND")
         await apply_command_failure(
             db, command, error_code="CHANNEL_POST_DRAFT_NOT_FOUND", last_error=str(exc), now=now,
         )
@@ -971,6 +984,13 @@ async def publish_channel_post_draft_endpoint(
             detail=_with_command_state({"code": "CHANNEL_POST_DRAFT_NOT_FOUND", "message": str(exc)}),
         ) from exc
     except ExternalPublishGateNotApprovedError as exc:
+        # story #3474 — publish_channel_post_draft 내부 게이트 재검증이 여기서 막았다
+        # (adapter 미호출). 워커의 blocked_unapproved와 같은 결이지만, 이 즉시-발행
+        # 경로는 사람이 그 자리에서 받는 HTTP 실패라 command 종결 정책은 기존
+        # apply_command_failure(needs_check→dead_letter) 그대로 둔다(페드루 확定 —
+        # 이 코드 경로 자체의 재시도/종결 정책 변경은 이 스토리 스코프 밖, 원장
+        # 기록만 추가).
+        await _record_this_attempt(approval_check="missing", adapter_called=False, result_code=None)
         await apply_command_failure(
             db, command, error_code="EXTERNAL_PUBLISH_APPROVAL_REQUIRED", last_error=str(exc), now=now,
         )
@@ -983,6 +1003,7 @@ async def publish_channel_post_draft_endpoint(
         # 페드루 PO 확定(2026-09-03) — 발행 시점 재검사(UTM 태그된 링크가 붙은 실제 전송
         # 문자열 기준). draft 생성 시점의 매핑(422·max_length·current_length)과 동형 —
         # 코드 하나가 두 HTTP status를 갖지 않게 유지.
+        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="CHANNEL_TEXT_TOO_LONG")
         await apply_command_failure(
             db, command, error_code="CHANNEL_TEXT_TOO_LONG", last_error=str(exc), now=now,
         )
@@ -995,6 +1016,7 @@ async def publish_channel_post_draft_endpoint(
             }),
         ) from exc
     except ChannelPostSealMissingError as exc:
+        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="SITE_POST_SEAL_MISSING")
         await apply_command_failure(
             db, command, error_code="SITE_POST_SEAL_MISSING", last_error=str(exc), now=now,
         )
@@ -1005,7 +1027,9 @@ async def publish_channel_post_draft_endpoint(
         ) from exc
     except ChannelPostReapprovalRequiredError as exc:
         # story #3414 — 추가② 훅이 대개 이 상황 전에 command를 이미 voided로 무효화해
-        # 두지만, 놓친 경합 창은 여기서도 잡는다(이중 방어).
+        # 두지만, 놓친 경합 창은 여기서도 잡는다(이중 방어). story #3474 — 봉인 sha256
+        # 불일치라 adapter 미호출(워커의 version_mismatch와 동형).
+        await _record_this_attempt(approval_check="version_mismatch", adapter_called=False, result_code=None)
         command.status = "voided"
         command.reason_code = "CONTENT_CHANGED"
         command.last_error = str(exc)[:2000]
@@ -1015,6 +1039,7 @@ async def publish_channel_post_draft_endpoint(
             detail=_with_command_state({"code": "SITE_POST_REAPPROVAL_REQUIRED", "message": str(exc)}),
         ) from exc
     except ChannelConnectionNotActiveError as exc:
+        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="CHANNEL_CONNECTION_NOT_ACTIVE")
         await apply_command_failure(
             db, command, error_code="CHANNEL_CONNECTION_NOT_ACTIVE", last_error=str(exc), now=now,
         )
@@ -1024,6 +1049,7 @@ async def publish_channel_post_draft_endpoint(
             detail=_with_command_state({"code": "CHANNEL_CONNECTION_NOT_ACTIVE", "message": str(exc)}),
         ) from exc
     except ChannelTokenExpiredError as exc:
+        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="CHANNEL_TOKEN_EXPIRED")
         await apply_command_failure(
             db, command, error_code="CHANNEL_TOKEN_EXPIRED", last_error=str(exc), now=now,
         )
@@ -1034,6 +1060,7 @@ async def publish_channel_post_draft_endpoint(
         ) from exc
     except ChannelRateLimitedError as exc:
         retry_after_seconds = max(0, int((exc.reset_at - now).total_seconds()))
+        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="CHANNEL_RATE_LIMITED")
         await apply_command_failure(
             db, command, error_code="CHANNEL_RATE_LIMITED", last_error=str(exc), now=now,
             retry_after_seconds=retry_after_seconds,
@@ -1050,6 +1077,7 @@ async def publish_channel_post_draft_endpoint(
             headers={"Retry-After": str(retry_after_seconds)},
         ) from exc
     except ChannelPublishProviderError as exc:
+        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="CHANNEL_PUBLISH_PROVIDER_ERROR")
         await apply_command_failure(
             db, command, error_code="CHANNEL_PUBLISH_PROVIDER_ERROR", last_error=str(exc), now=now,
         )
@@ -1075,6 +1103,7 @@ async def publish_channel_post_draft_endpoint(
         # story 620beefc(AC5) — Threads가 IMAGE 컨테이너를 ERROR/EXPIRED로 끝냈다(결정적,
         # 재시도해도 안 바뀐다). needs_check 분류라 자동 재시도 없이 사람 재시도(retry
         # 엔드포인트, AC5)만 남긴다.
+        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="CHANNEL_IMAGE_CONTAINER_FAILED")
         await apply_command_failure(
             db, command, error_code="CHANNEL_IMAGE_CONTAINER_FAILED", last_error=str(exc), now=now,
         )
@@ -1091,6 +1120,7 @@ async def publish_channel_post_draft_endpoint(
         # story 620beefc(AC5) — IMAGE 컨테이너가 아직 처리 中. 예외가 안 났다는 것
         # 자체가 "지금까지는 정상, 아직 안 끝났다"는 뜻 — command는 pending에
         # 남기고(다음 cron tick이 이어 폴링) 사람에게는 "처리 中"임을 그대로 알린다.
+        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code=row.status)
         command.status = "pending"
         command.next_attempt_at = now + timedelta(seconds=30)
         command.last_error = None
@@ -1101,6 +1131,7 @@ async def publish_channel_post_draft_endpoint(
             command_id=command.id, scheduled_at=None,
         )
 
+    await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="published")
     command.status = "completed"
     command.last_error = None
     command.failure_kind = None

--- a/backend/app/routers/channel_posts.py
+++ b/backend/app/routers/channel_posts.py
@@ -1002,8 +1002,10 @@ async def publish_channel_post_draft_endpoint(
     except ChannelTextTooLongError as exc:
         # 페드루 PO 확定(2026-09-03) — 발행 시점 재검사(UTM 태그된 링크가 붙은 실제 전송
         # 문자열 기준). draft 생성 시점의 매핑(422·max_length·current_length)과 동형 —
-        # 코드 하나가 두 HTTP status를 갖지 않게 유지.
-        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="CHANNEL_TEXT_TOO_LONG")
+        # 코드 하나가 두 HTTP status를 갖지 않게 유지. story #3474(페드루 리뷰 보정①,
+        # 2026-09-05) — `_validate_text_length`는 channel_posts.py:1158, httpx 클라이언트
+        # 블록(1160) *앞* — Threads에 아무 HTTP도 안 나간 시점(adapter_called=False).
+        await _record_this_attempt(approval_check="ok", adapter_called=False, result_code="CHANNEL_TEXT_TOO_LONG")
         await apply_command_failure(
             db, command, error_code="CHANNEL_TEXT_TOO_LONG", last_error=str(exc), now=now,
         )
@@ -1016,7 +1018,9 @@ async def publish_channel_post_draft_endpoint(
             }),
         ) from exc
     except ChannelPostSealMissingError as exc:
-        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="SITE_POST_SEAL_MISSING")
+        # story #3474(페드루 리뷰 보정①) — channel_posts.py:1095, httpx 클라이언트 블록
+        # 앞(같은 이유로 adapter_called=False).
+        await _record_this_attempt(approval_check="ok", adapter_called=False, result_code="SITE_POST_SEAL_MISSING")
         await apply_command_failure(
             db, command, error_code="SITE_POST_SEAL_MISSING", last_error=str(exc), now=now,
         )
@@ -1039,7 +1043,9 @@ async def publish_channel_post_draft_endpoint(
             detail=_with_command_state({"code": "SITE_POST_REAPPROVAL_REQUIRED", "message": str(exc)}),
         ) from exc
     except ChannelConnectionNotActiveError as exc:
-        await _record_this_attempt(approval_check="ok", adapter_called=True, result_code="CHANNEL_CONNECTION_NOT_ACTIVE")
+        # story #3474(페드루 리뷰 보정①) — channel_posts.py:1129, `create_container`
+        # 호출(1255) 전이라 adapter_called=False.
+        await _record_this_attempt(approval_check="ok", adapter_called=False, result_code="CHANNEL_CONNECTION_NOT_ACTIVE")
         await apply_command_failure(
             db, command, error_code="CHANNEL_CONNECTION_NOT_ACTIVE", last_error=str(exc), now=now,
         )

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -27,6 +27,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.publication_attempt import PublicationAttempt
 from app.models.publication_command import PublicationCommand
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,32 @@ _CONNECTION_BLOCKED_CODES = frozenset({
 # needs_check(사람 재시도, AC5)로 바로 보낸다.
 _NEEDS_CHECK_CODES = frozenset({"CHANNEL_PUBLISH_IN_PROGRESS", "CHANNEL_IMAGE_CONTAINER_FAILED"})
 _TRANSIENT_CODES = frozenset({"CHANNEL_PUBLISH_PROVIDER_ERROR", "CHANNEL_RATE_LIMITED"})
+
+
+# story #3474(페드루 PO 確定 2026-09-05) — 게이트가 approved가 아니거나(missing)
+# 봉인 sha256이 지금 버전과 다르면(version_mismatch) adapter를 아예 안 부르고
+# command를 즉시 닫는다(백오프 재시도 대상 아님 — "재시도해도 안 되는" 종류가
+# 아니라 "재시도라는 개념 자체가 안 맞는" 종류: 사람이 다시 승인해야 새 커맨드가
+# 생긴다). 기존 'voided'(재승인으로 무효화)와 같은 결의 신규 terminal 상태.
+STATUS_BLOCKED_UNAPPROVED = "blocked_unapproved"
+_GATE_REVERIFY_ERROR_CODES = frozenset({"EXTERNAL_PUBLISH_APPROVAL_REQUIRED", "SITE_POST_REAPPROVAL_REQUIRED"})
+
+
+async def _record_attempt(
+    db: AsyncSession, *, command: PublicationCommand, approval_check: str, adapter_called: bool,
+    started_at: datetime, finished_at: datetime | None, result_code: str | None,
+) -> PublicationAttempt:
+    """story #3474 — 워커의 매 시도마다 1행. `SELECT count(*) FROM publication_attempts
+    WHERE adapter_called AND approval_check <> 'ok'`가 정상 경로에서 항상 0이 되는 게
+    이 원장의 존재 이유(블루프린트 §1 차단 4를 쿼리로 셀 수 있게)."""
+    row = PublicationAttempt(
+        id=uuid.uuid4(), command_id=command.id, gate_id=command.gate_id,
+        approval_check=approval_check, adapter_called=adapter_called,
+        started_at=started_at, finished_at=finished_at, result_code=result_code,
+    )
+    db.add(row)
+    await db.flush()
+    return row
 
 
 def classify_failure_kind(error_code: str | None) -> str:
@@ -233,6 +260,7 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
     error_code: str | None = None
     last_error: str | None = None
     retry_after_seconds: int | None = None
+    attempt_started_at = now
     try:
         version_row = (await db.execute(
             select(ChannelPostVersion).where(ChannelPostVersion.id == command.approved_version)
@@ -247,16 +275,27 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
             db, org_id=command.org_id, draft_id=draft.id,
             published_by_member_id=command.requested_by_member_id,
         )
+        # story #3474 — 여기 도달했다는 것 자체가 publish_channel_post_draft() 내부
+        # 게이트 재검증(status==approved·sealed sha 일치)을 통과했다는 뜻이다(코드
+        # 무변, 기존 예외 둘을 이 지점 도달 여부로 판별). adapter는 실제로 호출됐다.
         if publication.status != "published":
             # story 620beefc(AC5) — IMAGE 컨테이너가 아직 처리 中(container_created,
             # 예외 없이 정상 반환됐다는 것 자체가 "아직 안 끝났다"는 신호). 실패가
             # 아니므로 attempt_count/backoff는 안 건드리고 30초 뒤 다시 이 command를
             # 집도록 pending에 남긴다(Meta 권장 폴링 간격, threads_publish.py 참고).
+            await _record_attempt(
+                db, command=command, approval_check="ok", adapter_called=True,
+                started_at=attempt_started_at, finished_at=now, result_code=publication.status,
+            )
             command.status = "pending"
             command.next_attempt_at = now + timedelta(seconds=30)
             command.last_error = None
             command.failure_kind = None
             return
+        await _record_attempt(
+            db, command=command, approval_check="ok", adapter_called=True,
+            started_at=attempt_started_at, finished_at=now, result_code="published",
+        )
         command.status = "completed"
         command.last_error = None
         command.failure_kind = None
@@ -266,6 +305,12 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
     except ChannelPostReapprovalRequiredError as exc:
         # story #3414 추가② 이중 방어 — void_pending_commands_for_gate가 보통 이 상황을
         # 이미 선제 처리하지만(제출 시점 즉시), 놓친 경우를 워커가 마지막으로 잡는다.
+        # story #3474 — 이 경로는 adapter를 안 부른다(publish_channel_post_draft가
+        # sealed sha 불일치를 발견한 시점에 이미 예외를 던졌다).
+        await _record_attempt(
+            db, command=command, approval_check="version_mismatch", adapter_called=False,
+            started_at=attempt_started_at, finished_at=now, result_code=None,
+        )
         command.status = "voided"
         command.reason_code = "CONTENT_CHANGED"
         command.last_error = str(exc)[:2000]
@@ -273,7 +318,16 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
     except ChannelPostDraftNotFoundError as exc:
         error_code, last_error = "CHANNEL_POST_DRAFT_NOT_FOUND", str(exc)
     except ExternalPublishGateNotApprovedError as exc:
-        error_code, last_error = "EXTERNAL_PUBLISH_APPROVAL_REQUIRED", str(exc)
+        # story #3474 — 새 terminal 상태(blocked_unapproved). apply_command_failure로
+        # 안 보낸다 — "재시도해도 안 되는" 종류가 아니라 "재시도라는 개념 자체가 안
+        # 맞는" 종류(사람이 다시 승인해야 새 커맨드가 생긴다).
+        await _record_attempt(
+            db, command=command, approval_check="missing", adapter_called=False,
+            started_at=attempt_started_at, finished_at=now, result_code=None,
+        )
+        command.status = STATUS_BLOCKED_UNAPPROVED
+        command.last_error = str(exc)[:2000]
+        return
     except ChannelPostSealMissingError as exc:
         error_code, last_error = "SITE_POST_SEAL_MISSING", str(exc)
     except ChannelTextTooLongError as exc:
@@ -293,6 +347,15 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
         last_error = str(exc)
         logger.exception("publication_command 처리 중 미분류 예외 command_id=%s", command.id)
 
+    # story #3474 — 여기 도달한 실패는 전부 게이트 재검증(missing/version_mismatch)을
+    # 이미 통과한 뒤(publish_channel_post_draft 내부)의 실패다(그 둘은 위에서 별도
+    # return으로 먼저 빠졌다). DRAFT_NOT_FOUND만 예외 — 그건 gate 조회 자체보다도
+    # 먼저(버전/초안 조회 단계) 나므로 adapter가 안 불렸다.
+    await _record_attempt(
+        db, command=command, approval_check="ok",
+        adapter_called=error_code not in (None, "CHANNEL_POST_DRAFT_NOT_FOUND"),
+        started_at=attempt_started_at, finished_at=now, result_code=error_code,
+    )
     await apply_command_failure(
         db, command, error_code=error_code, last_error=last_error, now=now,
         retry_after_seconds=retry_after_seconds,
@@ -313,21 +376,52 @@ async def _process_one_site_post_command(db: AsyncSession, command: PublicationC
 
     error_code: str | None = None
     last_error: str | None = None
+    attempt_started_at = now
     try:
         if command.operation == "unpublish":
             await unpublish_site_post_external_command(db, command)
         else:
             await publish_site_post_external_command(db, command)
+        # story #3474 — 여기 도달했다는 것 자체가 site_posts.py의 신규 게이트
+        # 재검증(status==approved·sealed sha 일치)을 통과했다는 뜻이다.
+        await _record_attempt(
+            db, command=command, approval_check="ok", adapter_called=True,
+            started_at=attempt_started_at, finished_at=now, result_code="completed",
+        )
         command.status = "completed"
         command.last_error = None
         command.failure_kind = None
         return
     except SitePostExternalPublishError as exc:
         error_code, last_error = exc.error_code, str(exc)
+        if error_code in _GATE_REVERIFY_ERROR_CODES:
+            # story #3474 — adapter는 안 불렸다(게이트 재검증에서 막혔다). 재시도
+            # 백오프(apply_command_failure) 대상이 아니라 즉시 종결 — 사람이 다시
+            # 승인해야 새 커맨드가 생긴다(channel_post 쪽과 동형 처리).
+            approval_check = "missing" if error_code == "EXTERNAL_PUBLISH_APPROVAL_REQUIRED" else "version_mismatch"
+            await _record_attempt(
+                db, command=command, approval_check=approval_check, adapter_called=False,
+                started_at=attempt_started_at, finished_at=now, result_code=None,
+            )
+            if approval_check == "missing":
+                command.status = STATUS_BLOCKED_UNAPPROVED
+            else:
+                command.status = "voided"
+                command.reason_code = "CONTENT_CHANGED"
+            command.last_error = last_error[:2000]
+            return
     except Exception as exc:  # noqa: BLE001 — 미분류 실패도 이 command 하나만 막는다.
         last_error = str(exc)
         logger.exception("site_post publication_command 처리 중 미분류 예외 command_id=%s", command.id)
 
+    # story #3474 — SITE_POST_DRAFT_NOT_FOUND/SITE_POST_NOT_PUBLISHED는 게이트 조회
+    # 자체보다 먼저(버전/발행기록 조회 단계) 나므로 adapter가 안 불렸다. 그 외(연결
+    # 비활성·자격거절 등)는 게이트 재검증을 통과한 뒤의 실패라 adapter가 불렸다.
+    await _record_attempt(
+        db, command=command, approval_check="ok",
+        adapter_called=error_code not in (None, "SITE_POST_DRAFT_NOT_FOUND", "SITE_POST_NOT_PUBLISHED"),
+        started_at=attempt_started_at, finished_at=now, result_code=error_code,
+    )
     await apply_command_failure(db, command, error_code=error_code, last_error=last_error, now=now)
 
 
@@ -428,13 +522,20 @@ async def process_due_publication_commands(db: AsyncSession, *, now: datetime | 
     await db.commit()
 
     counts = {
-        "completed": 0, "pending_retry": 0, "dead_letter": 0, "blocked": 0, "voided": 0, "error": 0,
+        "completed": 0, "pending_retry": 0, "dead_letter": 0, "blocked": 0, "voided": 0,
+        # story #3474 — 게이트 재검증 실패 전용 종결 상태. "pending_retry" 버킷에
+        # 안 섞는다(재시도 대상이 아니므로 그 이름이 거짓말이 된다).
+        "blocked_unapproved": 0, "error": 0,
     }
     for command in rows:
         try:
             await _process_one_command(db, command, now=now)
             await db.commit()
-            key = command.status if command.status in ("completed", "dead_letter", "blocked", "voided") else "pending_retry"
+            key = (
+                command.status
+                if command.status in ("completed", "dead_letter", "blocked", "voided", "blocked_unapproved")
+                else "pending_retry"
+            )
             counts[key] += 1
         except Exception:  # noqa: BLE001 — 2중 방어(AC4): 진짜 미분류 예외도 이 건만 격리.
             await db.rollback()

--- a/backend/app/services/publication_command.py
+++ b/backend/app/services/publication_command.py
@@ -77,7 +77,7 @@ STATUS_BLOCKED_UNAPPROVED = "blocked_unapproved"
 _GATE_REVERIFY_ERROR_CODES = frozenset({"EXTERNAL_PUBLISH_APPROVAL_REQUIRED", "SITE_POST_REAPPROVAL_REQUIRED"})
 
 
-async def _record_attempt(
+async def record_publication_attempt(
     db: AsyncSession, *, command: PublicationCommand, approval_check: str, adapter_called: bool,
     started_at: datetime, finished_at: datetime | None, result_code: str | None,
 ) -> PublicationAttempt:
@@ -283,7 +283,7 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
             # 예외 없이 정상 반환됐다는 것 자체가 "아직 안 끝났다"는 신호). 실패가
             # 아니므로 attempt_count/backoff는 안 건드리고 30초 뒤 다시 이 command를
             # 집도록 pending에 남긴다(Meta 권장 폴링 간격, threads_publish.py 참고).
-            await _record_attempt(
+            await record_publication_attempt(
                 db, command=command, approval_check="ok", adapter_called=True,
                 started_at=attempt_started_at, finished_at=now, result_code=publication.status,
             )
@@ -292,7 +292,7 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
             command.last_error = None
             command.failure_kind = None
             return
-        await _record_attempt(
+        await record_publication_attempt(
             db, command=command, approval_check="ok", adapter_called=True,
             started_at=attempt_started_at, finished_at=now, result_code="published",
         )
@@ -307,7 +307,7 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
         # 이미 선제 처리하지만(제출 시점 즉시), 놓친 경우를 워커가 마지막으로 잡는다.
         # story #3474 — 이 경로는 adapter를 안 부른다(publish_channel_post_draft가
         # sealed sha 불일치를 발견한 시점에 이미 예외를 던졌다).
-        await _record_attempt(
+        await record_publication_attempt(
             db, command=command, approval_check="version_mismatch", adapter_called=False,
             started_at=attempt_started_at, finished_at=now, result_code=None,
         )
@@ -321,7 +321,7 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
         # story #3474 — 새 terminal 상태(blocked_unapproved). apply_command_failure로
         # 안 보낸다 — "재시도해도 안 되는" 종류가 아니라 "재시도라는 개념 자체가 안
         # 맞는" 종류(사람이 다시 승인해야 새 커맨드가 생긴다).
-        await _record_attempt(
+        await record_publication_attempt(
             db, command=command, approval_check="missing", adapter_called=False,
             started_at=attempt_started_at, finished_at=now, result_code=None,
         )
@@ -351,7 +351,7 @@ async def _process_one_command(db: AsyncSession, command: PublicationCommand, *,
     # 이미 통과한 뒤(publish_channel_post_draft 내부)의 실패다(그 둘은 위에서 별도
     # return으로 먼저 빠졌다). DRAFT_NOT_FOUND만 예외 — 그건 gate 조회 자체보다도
     # 먼저(버전/초안 조회 단계) 나므로 adapter가 안 불렸다.
-    await _record_attempt(
+    await record_publication_attempt(
         db, command=command, approval_check="ok",
         adapter_called=error_code not in (None, "CHANNEL_POST_DRAFT_NOT_FOUND"),
         started_at=attempt_started_at, finished_at=now, result_code=error_code,
@@ -384,7 +384,7 @@ async def _process_one_site_post_command(db: AsyncSession, command: PublicationC
             await publish_site_post_external_command(db, command)
         # story #3474 — 여기 도달했다는 것 자체가 site_posts.py의 신규 게이트
         # 재검증(status==approved·sealed sha 일치)을 통과했다는 뜻이다.
-        await _record_attempt(
+        await record_publication_attempt(
             db, command=command, approval_check="ok", adapter_called=True,
             started_at=attempt_started_at, finished_at=now, result_code="completed",
         )
@@ -399,7 +399,7 @@ async def _process_one_site_post_command(db: AsyncSession, command: PublicationC
             # 백오프(apply_command_failure) 대상이 아니라 즉시 종결 — 사람이 다시
             # 승인해야 새 커맨드가 생긴다(channel_post 쪽과 동형 처리).
             approval_check = "missing" if error_code == "EXTERNAL_PUBLISH_APPROVAL_REQUIRED" else "version_mismatch"
-            await _record_attempt(
+            await record_publication_attempt(
                 db, command=command, approval_check=approval_check, adapter_called=False,
                 started_at=attempt_started_at, finished_at=now, result_code=None,
             )
@@ -417,7 +417,7 @@ async def _process_one_site_post_command(db: AsyncSession, command: PublicationC
     # story #3474 — SITE_POST_DRAFT_NOT_FOUND/SITE_POST_NOT_PUBLISHED는 게이트 조회
     # 자체보다 먼저(버전/발행기록 조회 단계) 나므로 adapter가 안 불렸다. 그 외(연결
     # 비활성·자격거절 등)는 게이트 재검증을 통과한 뒤의 실패라 adapter가 불렸다.
-    await _record_attempt(
+    await record_publication_attempt(
         db, command=command, approval_check="ok",
         adapter_called=error_code not in (None, "SITE_POST_DRAFT_NOT_FOUND", "SITE_POST_NOT_PUBLISHED"),
         started_at=attempt_started_at, finished_at=now, result_code=error_code,

--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -1074,6 +1074,24 @@ async def publish_site_post_external_command(db: AsyncSession, command: "Publica
             error_code="SITE_POST_DRAFT_NOT_FOUND", message=f"draft를 찾을 수 없습니다: {version.draft_id}",
         )
 
+    # 디디 그라운딩(2026-09-05, 페드루 실물 대조) — 이 함수는 여기까지 gate를 한 번도
+    # 안 봤다(channel_posts.py::publish_channel_post_draft와 달리 재검증 0). 블루프린트
+    # §1 차단 4 "승인 없는 adapter 호출 거부"를 코드 구조로 만든다 — module.publish()
+    # 호출(아래) 직전에 gate를 다시 읽어 approved인지, 봉인 sha256이 지금 버전과
+    # 같은지 확인한다. 불일치면 adapter를 아예 안 부른다(재시도 대상 아님 — 사람이
+    # 다시 승인하면 새 커맨드).
+    gate = await db.get(Gate, command.gate_id)
+    if gate is None or gate.status != "approved":
+        raise SitePostExternalPublishError(
+            error_code="EXTERNAL_PUBLISH_APPROVAL_REQUIRED",
+            message=f"게이트가 승인 상태가 아닙니다(gate_id={command.gate_id}, status={gate.status if gate else None})",
+        )
+    if gate.sealed_content_sha256 != version.body_sha256:
+        raise SitePostExternalPublishError(
+            error_code="SITE_POST_REAPPROVAL_REQUIRED",
+            message=f"봉인된 본문과 현재 버전이 다릅니다(gate_id={gate.id})",
+        )
+
     try:
         connection = await _get_active_blog_connection(db, org_id=command.org_id, connection_id=draft.connection_id)
     except ChannelConnectionNotActiveError as exc:
@@ -1162,6 +1180,7 @@ async def unpublish_site_post_external_command(db: AsyncSession, command: "Publi
     publications 기존 3값 container_created|published|failed에 이 조각이 4번째 값을
     보탠다 — CHECK 제약 없는 Text 컬럼이라 마이그 불요)."""
     from app.models.channel_publication import ChannelPublication
+    from app.models.site_post_version import SitePostVersion
     from app.services.blog_destinations import get_blog_destination_module
     from app.services.channel_connection import decrypt_for_use
     from app.services.channel_posts import ChannelConnectionNotActiveError
@@ -1173,6 +1192,24 @@ async def unpublish_site_post_external_command(db: AsyncSession, command: "Publi
     )).scalar_one_or_none()
     if row is None or row.external_id is None:
         raise SitePostExternalPublishError(error_code="SITE_POST_NOT_PUBLISHED", message="회수할 발행 기록이 없습니다")
+
+    # story #3474(페드루 PO 確定 2026-09-05) — publish 경로와 동형 재검증. 회수도
+    # "승인 없는 adapter 호출"의 대상이다(블루프린트 §1 차단 4가 publish/unpublish를
+    # 안 가른다).
+    gate = await db.get(Gate, command.gate_id)
+    if gate is None or gate.status != "approved":
+        raise SitePostExternalPublishError(
+            error_code="EXTERNAL_PUBLISH_APPROVAL_REQUIRED",
+            message=f"게이트가 승인 상태가 아닙니다(gate_id={command.gate_id}, status={gate.status if gate else None})",
+        )
+    version = (await db.execute(
+        select(SitePostVersion).where(SitePostVersion.id == command.approved_version)
+    )).scalar_one_or_none()
+    if version is not None and gate.sealed_content_sha256 != version.body_sha256:
+        raise SitePostExternalPublishError(
+            error_code="SITE_POST_REAPPROVAL_REQUIRED",
+            message=f"봉인된 본문과 현재 버전이 다릅니다(gate_id={gate.id})",
+        )
 
     try:
         connection = await _get_active_blog_connection(db, org_id=command.org_id, connection_id=row.connection_id)

--- a/backend/tests/test_3414_publication_command.py
+++ b/backend/tests/test_3414_publication_command.py
@@ -316,6 +316,17 @@ async def test_publish_immediate_no_scheduled_at_completes_synchronously_and_mar
             )).scalar_one()
             assert cmd.status == "completed"
             assert cmd.scheduled_at is None
+
+            # story #3474(페드루 리뷰 확認②, 2026-09-05) — 이 즉시-발행 경로는
+            # `_process_one_command`(cron 워커)를 안 거치는 별도 동기 경로다. 원장이
+            # 이 경로에서도 실제로 쓰이는지(워커 전용 반쪽 계측이 아닌지)를 이 기존
+            # ok-경로 테스트에 한 줄로 고정한다.
+            from app.models.publication_attempt import PublicationAttempt
+            attempt = (await s.execute(
+                select(PublicationAttempt).where(PublicationAttempt.command_id == cmd.id)
+            )).scalar_one()
+            assert attempt.approval_check == "ok"
+            assert attempt.adapter_called is True
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_3414_publication_command.py
+++ b/backend/tests/test_3414_publication_command.py
@@ -1240,7 +1240,14 @@ async def test_cron_deterministic_failure_goes_straight_to_dead_letter_no_auto_r
     needs_check로 떨어진 것들 포함)는 transient처럼 지수 백오프 재시도 큐에 들어가지
     않고 즉시 dead_letter로 멈춘다(자동 재시도 0회 — attempt_count는 1에서 멈춘다).
     양성대조: 두 번째 cron tick을 더 돌려도 재시도 시도조차 없어야 한다(next_attempt_at
-    이 애초에 None이라 WHERE절에서 안 잡히는지)."""
+    이 애초에 None이라 WHERE절에서 안 잡히는지).
+
+    story #3474(2026-09-05) 갱신 — 이 테스트가 재현하는 정확히 그 시나리오(게이트가
+    승인을 잃은 뒤 워커가 뒤늦게 발견)가 이제는 매핑표를 거쳐 dead_letter로 가는 게
+    아니라 blocked_unapproved로 즉시 종결한다(재시도 개념 자체가 안 맞는 종류 —
+    apply_command_failure/dead_letter 경로 자체를 안 탄다, attempt_count 무변).
+    publication_attempts 원장에 approval_check='missing'·adapter_called=False 행이
+    남는지도 이 테스트에서 같이 확認한다(디디 그라운딩 대상 시나리오 그대로)."""
     from app.services.publication_command import process_due_publication_commands
 
     engine, Session = await _session_factory()
@@ -1293,11 +1300,24 @@ async def test_cron_deterministic_failure_goes_straight_to_dead_letter_no_auto_r
             from app.models.publication_command import PublicationCommand
             from sqlalchemy import select
             cmd_row = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
-            assert cmd_row.status == "dead_letter"
-            assert cmd_row.failure_kind == "needs_check"
-            assert cmd_row.attempt_count == 1
-            assert cmd_row.dead_letter_at is not None
+            # story #3474 — 게이트 재검증 실패는 이제 blocked_unapproved로 즉시
+            # 종결한다(apply_command_failure/dead_letter 경로 미진입 — attempt_count
+            # 무변).
+            assert cmd_row.status == "blocked_unapproved"
+            assert cmd_row.attempt_count == 0
+            assert cmd_row.dead_letter_at is None
             assert cmd_row.next_attempt_at is None
+
+        # story #3474 — publication_attempts 원장: 승인 없는 adapter 호출 0건을
+        # 증명하는 그 행(missing·adapter_called=False)이 실제로 남는지.
+        async with Session() as s:
+            from app.models.publication_attempt import PublicationAttempt
+            from sqlalchemy import select
+            attempt = (await s.execute(
+                select(PublicationAttempt).where(PublicationAttempt.command_id == cmd_id)
+            )).scalar_one()
+            assert attempt.approval_check == "missing"
+            assert attempt.adapter_called is False
 
         # 양성대조 — 두 번째 tick을 더 돌려도(자동으로는) 아무 것도 안 바뀐다.
         async with Session() as s:
@@ -1306,8 +1326,8 @@ async def test_cron_deterministic_failure_goes_straight_to_dead_letter_no_auto_r
             from app.models.publication_command import PublicationCommand
             from sqlalchemy import select
             cmd_row = (await s.execute(select(PublicationCommand).where(PublicationCommand.id == cmd_id))).scalar_one()
-            assert cmd_row.status == "dead_letter", "결정적 실패가 두 번째 tick에서 조용히 재시도됐다"
-            assert cmd_row.attempt_count == 1
+            assert cmd_row.status == "blocked_unapproved", "결정적 실패가 두 번째 tick에서 조용히 재시도됐다"
+            assert cmd_row.attempt_count == 0
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_3474_publication_attempts.py
+++ b/backend/tests/test_3474_publication_attempts.py
@@ -1,0 +1,235 @@
+"""story #3474(Phase1·마케팅운영, 페드루 PO 確定 2026-09-05) — 워커가 adapter 호출
+직전 게이트를 재검증하고(site_post 경로 신규, channel_post는 무변) 매 시도를
+`publication_attempts` 원장에 남긴다. 블루프린트 §1 구조적 차단 장치 4 「승인 없는
+adapter 호출 0건」을 표본 3종(양성·부정·부정)으로 고정한다.
+
+디디 그라운딩(2026-09-05, 페드루 실물 대조로 확認) — 재검증 신규 코드는 site_post
+외부 발행·발행 취소 둘뿐(publish_site_post_external_command·unpublish_site_post_
+external_command). channel_post(publish_channel_post_draft)는 이미 재검증이 있어
+무변 — 그 경로의 기존 테스트(test_3414_publication_command.py) 쪽에 원장 assert
+한 줄만 추가했다(이 파일이 아님).
+
+세팅 헬퍼는 test_e4fc29fa_site_post_orchestration.py와 동형(중복 재발명 금지)."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.test_e4fc29fa_site_post_orchestration import (
+    _client_for,
+    _create_and_submit_site_post_draft,
+    _seed_agent,
+    _seed_default_role,
+    _seed_human,
+    _seed_org,
+    _seed_story,
+    _seed_wordpress_connection,
+    _session_factory,
+    _setup_org_scoped_app,
+    live_wordpress_stub,  # noqa: F401 — pytest fixture import
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _configure_secrets(monkeypatch):
+    import importlib
+    from cryptography.fernet import Fernet
+
+    import app.core.config as config_module
+    monkeypatch.setattr(config_module.settings, "channel_credential_encryption_key", Fernet.generate_key().decode())
+
+    import app.services.channel_credential_crypto as crypto_module
+    importlib.reload(crypto_module)
+    yield
+    importlib.reload(crypto_module)
+
+
+async def _seed_and_approve(*, live_wordpress_stub_url, story_title="사이트 포스트"):
+    """org→story→wordpress connection→draft 제출→승인까지 공통 준비. 반환값으로
+    이후 검증에 필요한 전부(엔진·세션팩토리·조직·게이트·커맨드 조회용 식별자)를 준다."""
+    from app.services.gate_service import transition_gate
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    async with Session() as s:
+        org_id, project_id = await _seed_org(s)
+        await _seed_default_role(s, org_id)
+        agent_id = await _seed_agent(s, org_id, project_id)
+        human_user_id, human_id = await _seed_human(s, org_id)
+        story_id = await _seed_story(s, org_id, project_id, title=story_title)
+        connection_id = await _seed_wordpress_connection(s, org_id, site_url=live_wordpress_stub_url)
+
+    _setup_org_scoped_app(app, Session, org_id, user_id=agent_id, agent=True)
+    async with _client_for(app) as client:
+        draft_id, gate_id = await _create_and_submit_site_post_draft(
+            client, org_id=org_id, story_id=story_id, connection_id=connection_id,
+        )
+
+    async with Session() as s:
+        await transition_gate(s, org_id, gate_id, "approved", resolver_id=human_id)
+        await s.commit()
+
+    return engine, Session, app, org_id, draft_id, gate_id, human_id
+
+
+async def _command_id_for_gate(Session, gate_id):
+    from app.models.publication_command import PublicationCommand
+    from sqlalchemy import select
+
+    async with Session() as s:
+        return (await s.execute(
+            select(PublicationCommand.id).where(PublicationCommand.gate_id == gate_id)
+        )).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_approved_gate_attempt_ok_and_adapter_called_once(live_wordpress_stub):
+    """(a) 양성대조 — 정상 승인 경로는 attempt 원장에 approval_check='ok'·
+    adapter_called=True가 정확히 1행 남고, 실 스텁에 진짜 글이 생긴다(카운트=1, 항상
+    통과하는 가짜 테스트가 아님을 스텁 원장으로 증명)."""
+    from app.services.publication_command import process_due_publication_commands
+    from app.routers.dev_wordpress_stub import _POSTS
+
+    engine, Session, app, org_id, draft_id, gate_id, human_id = await _seed_and_approve(
+        live_wordpress_stub_url=live_wordpress_stub,
+    )
+    try:
+        cmd_id = await _command_id_for_gate(Session, gate_id)
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+        assert len(_POSTS) == 1, "adapter가 정확히 한 번만 실 스텁에 글을 만들어야 한다"
+
+        from app.models.publication_attempt import PublicationAttempt
+        from sqlalchemy import select
+
+        async with Session() as s:
+            attempts = (await s.execute(
+                select(PublicationAttempt).where(PublicationAttempt.command_id == cmd_id)
+            )).scalars().all()
+        assert len(attempts) == 1
+        assert attempts[0].approval_check == "ok"
+        assert attempts[0].adapter_called is True
+        assert attempts[0].gate_id == gate_id
+        assert attempts[0].finished_at is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_no_longer_approved_rejected_before_adapter_call(live_wordpress_stub):
+    """(b) 부정대조 — void_pending_commands_for_gate 훅이 보통 이 경합을 선점하지만,
+    놓친 경우를 워커가 뒤늦게 만나는 시나리오를 직접 DB 조작으로 재현한다(channel_post
+    쪽 기존 결정적-실패 테스트와 동형 기법). adapter가 아예 안 불려야 한다(스텁 원장
+    0건이 유일한 신뢰 가능한 증거 — command.status만 보면 조작 성공 여부를 못 가른다)."""
+    from app.models.gate import Gate
+    from app.services.publication_command import process_due_publication_commands
+    from app.routers.dev_wordpress_stub import _POSTS
+    from sqlalchemy import select
+
+    engine, Session, app, org_id, draft_id, gate_id, human_id = await _seed_and_approve(
+        live_wordpress_stub_url=live_wordpress_stub,
+    )
+    try:
+        cmd_id = await _command_id_for_gate(Session, gate_id)
+
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            gate.status = "pending"
+            await s.commit()
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["blocked_unapproved"] == 1, counts
+        assert _POSTS == {}, "게이트 재검증에서 막혔는데 adapter가 실제로 호출됐다"
+
+        from app.models.publication_command import PublicationCommand
+        from app.models.publication_attempt import PublicationAttempt
+
+        async with Session() as s:
+            cmd_row = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.id == cmd_id)
+            )).scalar_one()
+            assert cmd_row.status == "blocked_unapproved"
+
+            attempts = (await s.execute(
+                select(PublicationAttempt).where(PublicationAttempt.command_id == cmd_id)
+            )).scalars().all()
+        assert len(attempts) == 1
+        assert attempts[0].approval_check == "missing"
+        assert attempts[0].adapter_called is False
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_approved_but_sealed_hash_mismatch_rejected_before_adapter_call(live_wordpress_stub):
+    """(c) 부정대조 — 게이트는 approved 그대로지만 봉인된 sha256과 지금 버전의
+    body_sha256이 다르다(승인 뒤 버전이 몰래 바뀐 경합을 직접 DB 조작으로 재현 —
+    resubmit 흐름을 타면 이미 별도 테스트(#3437 계열)가 있는 재승인 로직이 선점해
+    이 지점(워커 자신의 재검증)까지 못 온다). adapter 0회·voided 종결."""
+    from app.models.site_post_version import SitePostVersion
+    from app.services.publication_command import process_due_publication_commands
+    from app.routers.dev_wordpress_stub import _POSTS
+    from sqlalchemy import select
+
+    engine, Session, app, org_id, draft_id, gate_id, human_id = await _seed_and_approve(
+        live_wordpress_stub_url=live_wordpress_stub,
+    )
+    try:
+        cmd_id = await _command_id_for_gate(Session, gate_id)
+
+        async with Session() as s:
+            version = (await s.execute(
+                select(SitePostVersion).where(SitePostVersion.draft_id == draft_id)
+            )).scalar_one()
+            version.body_sha256 = "0" * 64  # 봉인된 sha256과 절대 안 맞는 값.
+            await s.commit()
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["voided"] == 1, counts
+        assert _POSTS == {}, "봉인 sha256 불일치인데 adapter가 실제로 호출됐다"
+
+        from app.models.publication_command import PublicationCommand
+        from app.models.publication_attempt import PublicationAttempt
+
+        async with Session() as s:
+            cmd_row = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.id == cmd_id)
+            )).scalar_one()
+            assert cmd_row.status == "voided"
+            assert cmd_row.reason_code == "CONTENT_CHANGED"
+
+            attempts = (await s.execute(
+                select(PublicationAttempt).where(PublicationAttempt.command_id == cmd_id)
+            )).scalars().all()
+        assert len(attempts) == 1
+        assert attempts[0].approval_check == "version_mismatch"
+        assert attempts[0].adapter_called is False
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_3474_publication_attempts.py
+++ b/backend/tests/test_3474_publication_attempts.py
@@ -233,3 +233,76 @@ async def test_approved_but_sealed_hash_mismatch_rejected_before_adapter_call(li
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublish_gate_no_longer_approved_rejected_before_module_unpublish_call(live_wordpress_stub):
+    """(d) 페드루 리뷰 보정①(2026-09-05) — publish 경로의 부정대조(b)만으론 부족하다,
+    unpublish도 「동형으로 확인 필요」라 명시했던 자리. 발행 완료 뒤 게이트가 무효화된
+    상태에서 회수 요청 커맨드가 워커에 걸리면, `unpublish_site_post_external_command`
+    자신의 신규 재검증이 adapter(module.unpublish) 호출 자체를 막아야 한다 — 스텁
+    원장(_POSTS)의 status가 "draft"로 안 바뀌는 것이 유일한 신뢰 가능한 증거(command
+    상태만 보면 조작 성공 여부를 못 가른다)."""
+    from app.models.gate import Gate
+    from app.services.publication_command import process_due_publication_commands
+    from app.services.site_posts import request_site_post_external_unpublish
+    from app.routers.dev_wordpress_stub import _POSTS
+    from sqlalchemy import select
+
+    engine, Session, app, org_id, draft_id, gate_id, human_id = await _seed_and_approve(
+        live_wordpress_stub_url=live_wordpress_stub,
+    )
+    try:
+        # 1) 정상 발행 완료(양성대조 (a)와 동일 절차) — external_id가 실제로 생긴다.
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["completed"] == 1, counts
+        assert len(_POSTS) == 1
+        published_stub_status = next(iter(_POSTS.values()))["status"]
+
+        # 2) 회수 요청 커맨드를 만든 뒤(서비스 직접 호출 — 라우터의 owner/admin 가드는
+        # 이 테스트 관심사가 아니다) 게이트를 무효화한다(void_pending_commands_for_gate
+        # 훅이 보통 이 경합을 선점하지만, 놓친 경우를 워커가 마지막으로 잡는 시나리오를
+        # 직접 DB 조작으로 재현 — (b)와 동형 기법).
+        async with Session() as s:
+            await request_site_post_external_unpublish(
+                s, org_id=org_id, draft_id=draft_id, requested_by_member_id=human_id,
+            )
+        async with Session() as s:
+            gate = (await s.execute(select(Gate).where(Gate.id == gate_id))).scalar_one()
+            gate.status = "pending"
+            await s.commit()
+
+        from app.models.publication_command import PublicationCommand
+        async with Session() as s:
+            unpub_cmd_id = (await s.execute(
+                select(PublicationCommand.id).where(
+                    PublicationCommand.gate_id == gate_id, PublicationCommand.operation == "unpublish",
+                )
+            )).scalar_one()
+
+        async with Session() as s:
+            counts = await process_due_publication_commands(s)
+        assert counts["blocked_unapproved"] == 1, counts
+
+        # 스텁 원장 — 회수가 실제로 adapter를 안 건드렸다는 유일한 신뢰 가능한 증거.
+        assert next(iter(_POSTS.values()))["status"] == published_stub_status, (
+            "게이트 재검증에서 막혔는데 module.unpublish가 실제로 호출됐다"
+        )
+
+        from app.models.publication_attempt import PublicationAttempt
+        async with Session() as s:
+            cmd_row = (await s.execute(
+                select(PublicationCommand).where(PublicationCommand.id == unpub_cmd_id)
+            )).scalar_one()
+            assert cmd_row.status == "blocked_unapproved"
+
+            attempts = (await s.execute(
+                select(PublicationAttempt).where(PublicationAttempt.command_id == unpub_cmd_id)
+            )).scalars().all()
+        assert len(attempts) == 1
+        assert attempts[0].approval_check == "missing"
+        assert attempts[0].adapter_called is False
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_f8f7cb0f_channel_post_publish.py
+++ b/backend/tests/test_f8f7cb0f_channel_post_publish.py
@@ -926,6 +926,23 @@ async def test_publish_time_length_recheck_with_utm_link_returns_422_zero_provid
                 ChannelPublication.gate_id == gate_id,
             ))).scalars().all()
         assert rows == [], "provider 호출 전 거부됐으므로 ChannelPublication 행이 생기면 안 된다"
+
+        # story #3474(페드루 리뷰 보정①, 2026-09-05) — publication_attempts 원장의
+        # adapter_called는 「실제로 어댑터를 불렀나」의 사실이어야 한다. 이 테스트가
+        # 이미 call_count==0으로 증명한 그 사실을 원장 자신도 그대로 반영하는지 고정
+        # (raise 지점이 httpx 클라이언트 블록보다 앞이라 False가 맞다).
+        async with Session() as s:
+            from app.models.publication_attempt import PublicationAttempt
+            from app.models.publication_command import PublicationCommand
+            from sqlalchemy import select
+
+            cmd_id = (await s.execute(
+                select(PublicationCommand.id).where(PublicationCommand.gate_id == gate_id)
+            )).scalar_one()
+            attempt = (await s.execute(
+                select(PublicationAttempt).where(PublicationAttempt.command_id == cmd_id)
+            )).scalar_one()
+        assert attempt.adapter_called is False
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1164,8 +1164,8 @@
     },
     {
       "file": "tests/test_3474_publication_attempts.py",
-      "sec": 45.0,
-      "source": "story-3474-worker-approval-reverify-attempts(PR 개설 前 선제 등재 — 로컬 raw pytest 7.21s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 45s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+      "sec": 55.0,
+      "source": "story-3474-worker-approval-reverify-attempts(PR 개설 前 선제 등재 — 페드루 리뷰 보정①(unpublish 부정대조 추가) 반영 후 로컬 raw pytest 4건 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 55s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }

--- a/infra/destructive-schema-shard-weights.json
+++ b/infra/destructive-schema-shard-weights.json
@@ -1161,6 +1161,11 @@
       "file": "tests/test_3476_publish_read_surface.py",
       "sec": 55.0,
       "source": "story-3476-external-publish-read-surface(PR 개설 前 선제 등재 — 로컬 raw pytest 9.14s 실측치(6 tests, 페드루 보정①·② 반영 후)를 CI 배율(~6x, story #3383) 보수적으로 반영한 55s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
+    },
+    {
+      "file": "tests/test_3474_publication_attempts.py",
+      "sec": 45.0,
+      "source": "story-3474-worker-approval-reverify-attempts(PR 개설 前 선제 등재 — 로컬 raw pytest 7.21s 실측치를 CI 배율(~6x, story #3383) 보수적으로 반영한 45s 잠정값, 실 CI 샤드 로그로 재확認 필요)"
     }
   ]
 }


### PR DESCRIPTION
[SID:3474]

## Summary
- `publish_site_post_external_command`/`unpublish_site_post_external_command`(site_posts.py) — 둘 다 확인 결과: **뚫려 있었다 → 막았다.** adapter 호출 직전 gate 조회가 0건이었다(channel_post의 `publish_channel_post_draft`는 이미 재검증이 있었음, site_post만 갭). 이번 PR로 둘 다 gate 재조회(`status=="approved"` + `sealed_content_sha256==version.body_sha256`) 후 불일치 시 adapter 호출 없이 즉시 종결하도록 막았다.
- 신규 `publication_attempts` 원장(migration 0327, `down_revision=0326`) — `command_id·gate_id·approval_check('ok'|'missing'|'version_mismatch')·adapter_called·started_at·finished_at·result_code`. 블루프린트 §1 차단 4 "승인 없는 adapter 호출 0건"이 `SELECT count(*) FROM publication_attempts WHERE adapter_called AND approval_check <> 'ok'` 한 줄로 상시 검증 가능해진다.
- channel_post 워커 분기 — `publish_channel_post_draft` 자체는 무변경(이미 재검증 有). `ExternalPublishGateNotApprovedError`가 기존엔 매핑표 밖 error_code로 `needs_check`→`dead_letter`(백오프 재시도 큐를 거쳐)로 잘못 갔던 것을, `ChannelPostReapprovalRequiredError`와 동형으로 새 terminal 상태 `blocked_unapproved`로 즉시 종결(재시도 개념 자체가 안 맞는 종류 — 사람이 재승인해야 새 커맨드가 생긴다)하도록 바꿨다. 기존 회귀 테스트(`test_cron_deterministic_failure_goes_straight_to_dead_letter_no_auto_retry`)를 새 기대값으로 갱신.

## Test plan
- [x] `tests/test_3474_publication_attempts.py` 신규 3건(site_post 경로): (a) 승인 정상 → attempt ok+adapter 1회, 스텁 원장 1건(양성대조) (b) 게이트가 승인을 잃은 뒤 워커가 뒤늦게 발견 → blocked_unapproved+attempt missing+adapter 0회(스텁 원장 0건으로 확인) (c) 승인은 유지되지만 봉인 sha256 불일치 → voided+attempt version_mismatch+adapter 0회.
- [x] `test_3414_publication_command.py` 기존 회귀 갱신 — 결정적 실패 시나리오가 이제 blocked_unapproved로 종결되는지 + attempt 원장(missing) 행이 남는지 확인하는 assert 추가.
- [x] 마이그레이션 0327 real Postgres 왕복 검증(upgrade/downgrade 둘 다, develop 최신 0326 위).
- [x] 회귀: `test_3414_publication_command.py`(30건)·`test_e4fc29fa_site_post_orchestration.py`·`test_e4fc29fa_hosted_site_publish_adapter.py`·`test_620beefc_channel_post_image.py`·`test_5b27b32f_sandbox_channel.py`·`test_cfc1a55a_scheduled_command_on_approval.py`·`test_3423_channel_post_scheduled_filter.py`·`test_3415_channel_post_command_exposure.py`·`test_3419_cancel_unpublish.py`·`test_3471_org_content_rules_lint.py`·`test_3437_campaign_patch_no_version_no_gate_touch.py` — 135건 전부 local green(신선 disposable Postgres, alembic upgrade head 경유).
- [x] `scripts/lint_destructive_schema_weights_registered.py` — 신규 테스트 파일 weights.json 등재 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)