### PR TITLE
[SID:3483] refactor: 콘텐츠 규칙 위반 표시 공용 컴포넌트 추출(1부 — 준비)

### DIFF
--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.test.tsx
@@ -1328,3 +1328,79 @@ describe('ContentPostEditPage — 캠페인 변경/해제(story 1db41045 B2)', (
     expect(container.querySelector('[data-testid="content-campaign-current"]')).toBeNull();
   });
 });
+
+// story #3483(BE 3482 계약, 유나 §16-7 정본) — 원문(site_post) 초안 화면 규칙 위반.
+// BE 3482가 아직 병합 前이라 stub fetch로 계약(violations[].field ∈ {title,summary,
+// body_md}, 나머지 shape은 3472 2부와 동일)만 먼저 검증한다. 라이브는 3482 착지 뒤.
+describe('ContentPostEditPage — 콘텐츠 규칙 위반 표시(story #3483, §16-7)', () => {
+  it('⭐저장 응답의 violations[] — title/summary/body_md 세 갈래로 각각 그 필드 아래에만', async () => {
+    stubFetchWithVersions([VERSION_1], () => ({
+      status: 201,
+      body: {
+        draft_id: DRAFT_ID, version_id: 'v2', version: 2,
+        violations: [
+          { code: 'banned_term', field: 'title', value: '무료체험', hint_key: 'x', settings_path: '/organization/content-rules' },
+          { code: 'banned_term', field: 'summary', value: '광고', hint_key: 'x', settings_path: '/organization/content-rules' },
+          { code: 'banned_term', field: 'body_md', value: '즉시할인', hint_key: 'x', settings_path: '/organization/content-rules' },
+        ],
+      },
+    }));
+    await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+    await flush();
+
+    const saveBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.editSaveCta) as HTMLButtonElement;
+    await act(async () => { saveBtn.click(); });
+    await flush();
+
+    const titleViolation = container.querySelector('[data-testid="content-rule-violation-title"]');
+    const summaryViolation = container.querySelector('[data-testid="content-rule-violation-summary"]');
+    const bodyViolation = container.querySelector('[data-testid="content-rule-violation-body-md"]');
+    expect(titleViolation?.textContent).toContain('무료체험');
+    expect(summaryViolation?.textContent).toContain('광고');
+    expect(bodyViolation?.textContent).toContain('즉시할인');
+    // 서로 새지 않는다(제목 위반이 요약 자리에 안 뜸 등).
+    expect(titleViolation?.textContent).not.toContain('광고');
+  });
+
+  it('⭐위반이 있으면 상신 버튼이 비활성이고, 버튼 밖에 개수가 뜬다', async () => {
+    stubFetchWithVersions([VERSION_1], () => ({
+      status: 201,
+      body: { violations: [{ code: 'banned_term', field: 'title', value: 'x', hint_key: 'x', settings_path: '/organization/content-rules' }] },
+    }));
+    await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+    await flush();
+    const saveBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.editSaveCta) as HTMLButtonElement;
+    await act(async () => { saveBtn.click(); });
+    await flush();
+
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.submitCta) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(true);
+    expect(container.querySelector('[data-testid="content-rule-violation-blocked-reason"]')?.textContent)
+      .toBe(koMessages.content.contentRuleSubmitBlockedHint.replace('{count}', '1'));
+  });
+
+  it('⭐상신 422 CONTENT_RULE_VIOLATION — 새 배너를 안 만들고 필드 옆 목록만 갱신한다', async () => {
+    stubFetchWithVersions([VERSION_1], undefined, () => ({
+      status: 422,
+      body: { error: { code: 'CONTENT_RULE_VIOLATION', rules_version: 3, violations: [{ code: 'banned_term', field: 'body_md', value: 'y', hint_key: 'x', settings_path: '/organization/content-rules' }] } },
+    }));
+    await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+    await flush();
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.submitCta) as HTMLButtonElement;
+    await act(async () => { submitBtn.click(); });
+    await flush();
+
+    expect(container.querySelector('[data-testid="content-rule-violation-body-md"]')?.textContent).toContain('y');
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('위반이 없으면 저장·상신이 평소대로(회귀 0)', async () => {
+    stubFetchWithVersions([VERSION_1]);
+    await act(async () => { root.render(wrap(<ContentPostEditPage />)); });
+    await flush();
+    expect(container.querySelector('[data-testid="content-rule-violation-title"]')).toBeNull();
+    expect(container.querySelector('[data-testid="content-rule-violation-blocked-reason"]')).toBeNull();
+    const submitBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === koMessages.content.submitCta) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(false);
+  });
+});

--- a/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/[draftId]/page.tsx
@@ -21,6 +21,12 @@ import { parseSitePostApiError } from '@/components/content/api-error';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { formatScheduledAt, resolveDisplayTimezone } from '@/components/content/schedule-format';
 import { RawDetailsToggle } from '@/components/content/raw-details-toggle';
+// story #3483(BE 3482 계약, 3472 2부/§16-7과 동형) — 원문(site_post) 초안의 규칙
+// 위반. field는 title|summary|body_md(channel_post의 text|link_url과 다른 축이라
+// 컴포넌트는 field를 모른다 — 호출부가 이미 걸러 넘긴다).
+import {
+  ContentRuleViolationList, ContentRuleSubmitBlockedReason, type ContentRuleViolation,
+} from '@/components/content/content-rule-violation';
 
 /**
  * story #3368(Phase0·마케팅운영 S4, doc phase0-post-manager-screen-design §8-1 순서 3번) —
@@ -154,6 +160,12 @@ export default function ContentPostEditPage() {
   const [saveMessage, setSaveMessage] = useState<
     { type: 'success'; text: string } | { type: 'error'; text: string; raw?: string } | null
   >(null);
+  // story #3483(BE 3482, §16-7) — 저장/상신 응답이 채우는 하나의 목록. 상신 422는
+  // 새 배너를 안 만들고 이 state를 서버 응답으로 갱신한다(channel-posts 상세와 동형).
+  const [violations, setViolations] = useState<ContentRuleViolation[]>([]);
+  // "편집 중에도 같은 강도" — severity가 없어 위반이 있으면 전부 차단(channel-posts
+  // 상세와 동형).
+  const hasBlockingViolations = violations.length > 0;
 
   const [submitting, setSubmitting] = useState(false);
   const [submitResult, setSubmitResult] = useState<
@@ -570,6 +582,11 @@ export default function ContentPostEditPage() {
       });
       if (res.ok) {
         setSaveMessage({ type: 'success', text: t('editSaved') });
+        // story #3483 — create 응답의 violations[]로 필드 옆 목록을 갱신(§16-7 "기본
+        // 처리는 필드 옆 목록을 서버 응답으로 갱신"). 계약에 없으면(BE 미착지) 빈
+        // 배열 — 화면은 아무것도 지어내지 않는다.
+        const saveJson = (await res.json().catch(() => null)) as { data?: { violations?: ContentRuleViolation[] } } | null;
+        setViolations(saveJson?.data?.violations ?? []);
         // 새 버전이 생겼다 — 이력을 다시 읽어 새 버전 번호·"미상신" 상태를 반영한다(AC2).
         const versionsRes = await fetchWithAuth(`/api/organizations/${orgId}/site-posts/drafts/${draftId}/versions`);
         if (versionsRes.ok) {
@@ -601,7 +618,7 @@ export default function ContentPostEditPage() {
   // 404가 정상 응답이다 — 그 경우도 다른 에러와 동일하게 "사람 말+원문 보존"으로 렌더한다
   // (지어낸 성공 메시지로 덮지 않는다, AC7).
   const handleSubmitForApproval = async () => {
-    if (!orgId || !latest) return;
+    if (!orgId || !latest || hasBlockingViolations) return;
     setSubmitting(true);
     setSubmitResult(null);
     try {
@@ -625,6 +642,14 @@ export default function ContentPostEditPage() {
         }
       } else {
         const body = await res.json().catch(() => null);
+        // story #3483(§16-7) — "상신 422는 새 배너를 만들지 않는다". 위반은 이미
+        // 필드 옆에 서 있던 것이라 여기서는 그 목록을 서버 응답으로 갱신만 하고
+        // 끝낸다(submitResult 일반 오류 배너로 안 떨어뜨린다).
+        const ruleViolationBody = body as { error?: { code?: string; violations?: ContentRuleViolation[] } } | null;
+        if (ruleViolationBody?.error?.code === 'CONTENT_RULE_VIOLATION') {
+          setViolations(ruleViolationBody.error.violations ?? []);
+          return;
+        }
         const info = parseSitePostApiError(body);
         // story f6d14476(AC3) — SITE_POST_GATE_ALREADY_HELD 전용 분기. 서버는 상대 초안의
         // draft_id·lang·slug만 준다(title 없음) — 여기서 그 초안의 최신 버전을 별도
@@ -1111,6 +1136,8 @@ export default function ContentPostEditPage() {
             disabled={saving}
             className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
           />
+          {/* story #3483(§16-7) — "그 필드 아래" 그 필드 것만 목록. */}
+          <ContentRuleViolationList violations={violations.filter((v) => v.field === 'title')} testId="content-rule-violation-title" t={t} />
         </div>
 
         <div className="space-y-1">
@@ -1123,6 +1150,7 @@ export default function ContentPostEditPage() {
             disabled={saving}
             className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
           />
+          <ContentRuleViolationList violations={violations.filter((v) => v.field === 'summary')} testId="content-rule-violation-summary" t={t} />
         </div>
 
         <div className="space-y-1">
@@ -1148,6 +1176,7 @@ export default function ContentPostEditPage() {
             rows={16}
             className="w-full rounded-md border border-border bg-background px-3 py-2 font-mono text-sm text-foreground"
           />
+          <ContentRuleViolationList violations={violations.filter((v) => v.field === 'body_md')} testId="content-rule-violation-body-md" t={t} />
         </div>
 
         <div className="space-y-1">
@@ -1174,7 +1203,7 @@ export default function ContentPostEditPage() {
             <Button type="button" onClick={() => void handleSave()} disabled={saving}>
               {saving ? t('editSavingCta') : t('editSaveCta')}
             </Button>
-            <Button type="button" variant="outline" onClick={() => void handleSubmitForApproval()} disabled={saving || submitting}>
+            <Button type="button" variant="outline" onClick={() => void handleSubmitForApproval()} disabled={saving || submitting || hasBlockingViolations}>
               {submitting ? t('submitPendingCta') : t('submitCta')}
             </Button>
             {/* story #3386 AC2 — 발행된 글은 기본 잠금(canPublish=false), 재승인된 새
@@ -1185,6 +1214,11 @@ export default function ContentPostEditPage() {
                 : (isRepublish ? t('publishRepublishCta') : t('publishCta'))}
             </Button>
           </div>
+          {/* story #3483(§16-7) — "그래서 못 한다"는 버튼 밖·비활성. "필드 아래"(무엇이
+              걸렸나)와 자리가 다르다 — 여기는 개수만 세고 가리킨다. */}
+          {hasBlockingViolations ? (
+            <ContentRuleSubmitBlockedReason count={violations.length} testId="content-rule-violation-blocked-reason" t={t} />
+          ) : null}
           {/* §6-2-1 — 비활성 발행 버튼 라벨 자체는 WCAG 면제 대상이지만, "눌리지 않는
               이유"를 옆에 두는 이 문구는 실제 정보라 4.5:1 판정 대상이다(text-muted-
               foreground on card 실측 5.92 — 통과, doc §6-2-1 그대로). */}

--- a/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/content/channel-posts/[draftId]/page.tsx
@@ -22,6 +22,11 @@ import { FailureActionBadge } from '@/components/content/failure-action-badge';
 import { formatScheduledAt, resolveDisplayTimezone } from '@/components/content/schedule-format';
 import { isSandboxChannelDraft, SandboxTestBadge } from '@/components/content/sandbox-test-badge';
 import { RawDetailsToggle } from '@/components/content/raw-details-toggle';
+// story #3483 — 3472 2부에서 이 페이지에 있던 위반 표시 로직을 공용으로 뺐다
+// (site-posts 상세와 재사용, 동작 무변).
+import {
+  ContentRuleViolationList, ContentRuleSubmitBlockedReason, type ContentRuleViolation,
+} from '@/components/content/content-rule-violation';
 import { formatFileSize } from '@/components/docs/extensions/file-node';
 
 /**
@@ -100,18 +105,6 @@ interface ChannelPostDraftDetail {
   // 한 곳에서 낸다(FE가 직접 비교하지 않는다 — id 비교식은 서버 전용, 이 필드만 본다).
   // true=원문이 파생 이후 개정됨 · false=안 바뀜 · null=모른다(레거시 파생분).
   source_changed?: boolean | null;
-}
-
-// story #3472 2부(BE 3471/#3825 계약, 유나 §16-7 정본 2026-09-05) — 초안 create/
-// update 응답과 상신 422 CONTENT_RULE_VIOLATION이 공유하는 shape. field는 이 화면의
-// 두 입력(text/link_url)과 정확히 일치한다. severity가 계약에 없는 것은 "알고 줄인
-// 것"(첫 슬라이스=기계 검사 둘 다 차단) — 그래서 문구 키를 …BlockedHint 꼴로 짓는다.
-interface ContentRuleViolation {
-  code: string;
-  field: 'text' | 'link_url';
-  value: string;
-  hint_key: string;
-  settings_path: string;
 }
 
 interface ChannelPostVersion {
@@ -198,19 +191,6 @@ function describeChannelImageError(info: SitePostApiErrorInfo, t: (key: string, 
       return info.humanMessageKey ? t(info.humanMessageKey) : (info.humanMessageFallback || t('errorChannelImageUploadFailed'));
   }
 }
-
-// story #3472 2부(§16-7) — code로 사람 문구를 고른다(hint_key는 BE 계약에 있으나
-// 값 자체가 아직 정해지지 않아 code를 1차 판정축으로 쓴다 — code는 그라운딩된 두
-// 값(banned_term·utm_missing)이 확실하다). 미지 code는 지어내지 않고 제네릭으로.
-function contentRuleViolationHint(code: string, value: string, t: (key: string, values?: Record<string, string | number>) => string): string {
-  if (code === 'banned_term') return t('contentRuleBannedTermBlockedHint', { value });
-  if (code === 'utm_missing') return t('contentRuleUtmMissingBlockedHint');
-  return t('contentRuleGenericBlockedHint');
-}
-
-// ⛔§16-7 "settings_path를 그대로 href로 쓰지 않는다" — FE가 아는 값만 라우트로
-// 매핑하고, 모르는 값이면 링크를 그리지 않는다(경로 결정권을 BE로 넘기지 않는다).
-const KNOWN_CONTENT_RULES_SETTINGS_PATH = '/organization/content-rules';
 
 export default function ChannelPostEditPage() {
   const { orgId, role } = useDashboardContext();
@@ -1387,15 +1367,12 @@ export default function ChannelPostEditPage() {
         {/* story #3472 2부(유나 §16-7) — "그 필드 아래" 그 필드 것만 목록. 경고색
             없음(아직 아무것도 실패하지 않았다·사람이 고치는 중). FailureActionBadge
             동형 아님(하우스 폼 검증 관례=필드 아래 한 줄, channel-post-text-field-
-            empty-reason과 같은 톤). */}
-        {violations.filter((v) => v.field === 'text').map((v, i) => (
-          <p key={`${v.code}-${i}`} className="text-xs text-muted-foreground" data-testid="channel-post-rule-violation-text">
-            {contentRuleViolationHint(v.code, v.value, t)}{' '}
-            {v.settings_path === KNOWN_CONTENT_RULES_SETTINGS_PATH ? (
-              <Link href={v.settings_path} className="underline">{t('contentRuleLinkLabel')}</Link>
-            ) : null}
-          </p>
-        ))}
+            empty-reason과 같은 톤). story #3483 — 공용 컴포넌트로(site-posts 재사용). */}
+        <ContentRuleViolationList
+          violations={violations.filter((v) => v.field === 'text')}
+          testId="channel-post-rule-violation-text"
+          t={t}
+        />
         <input
           value={linkUrl}
           onChange={(e) => setLinkUrl(e.target.value)}
@@ -1403,14 +1380,11 @@ export default function ChannelPostEditPage() {
           className="w-full rounded-md border border-border p-2 text-sm"
           data-testid="channel-post-link-field"
         />
-        {violations.filter((v) => v.field === 'link_url').map((v, i) => (
-          <p key={`${v.code}-${i}`} className="text-xs text-muted-foreground" data-testid="channel-post-rule-violation-link">
-            {contentRuleViolationHint(v.code, v.value, t)}{' '}
-            {v.settings_path === KNOWN_CONTENT_RULES_SETTINGS_PATH ? (
-              <Link href={v.settings_path} className="underline">{t('contentRuleLinkLabel')}</Link>
-            ) : null}
-          </p>
-        ))}
+        <ContentRuleViolationList
+          violations={violations.filter((v) => v.field === 'link_url')}
+          testId="channel-post-rule-violation-link"
+          t={t}
+        />
       </div>
 
       {/* story #3428(T3-M·§17-16) — image_max_count<=0(미지원 채널, 또는 아직 모른다)
@@ -1551,11 +1525,10 @@ export default function ChannelPostEditPage() {
         </p>
       ) : null}
       {/* story #3472 2부(§16-7) — "그래서 못 한다"는 버튼 밖·비활성(§17-13과 같은 규율).
-          "필드 아래"(무엇이 걸렸나)와 자리가 다르다 — 여기는 개수만 세고 가리킨다. */}
+          "필드 아래"(무엇이 걸렸나)와 자리가 다르다 — 여기는 개수만 세고 가리킨다.
+          story #3483 — 공용 컴포넌트로. */}
       {!isOverLimit && hasBlockingViolations ? (
-        <p className="text-xs text-muted-foreground" data-testid="channel-post-rule-violation-blocked-reason">
-          {t('contentRuleSubmitBlockedHint', { count: violations.length })}
-        </p>
+        <ContentRuleSubmitBlockedReason count={violations.length} testId="channel-post-rule-violation-blocked-reason" t={t} />
       ) : null}
       {/* B2(페드루 PO, 2026-09-04 13:27Z) — 이미지 업로드 진행 중엔 저장/상신이 왜
           막혔는지 버튼 밖에 밝힌다(isOverLimit과 동시에 뜰 수 있어 둘 다 없을 때만). */}

--- a/apps/web/src/components/content/content-rule-violation.test.tsx
+++ b/apps/web/src/components/content/content-rule-violation.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+//
+// story #3483 — content-rule-violation.tsx가 channel-posts 상세(3472 2부)에서
+// 빠져나온 공용 컴포넌트라 이 파일이 회귀 0의 유일한 pin이다(소비 화면 각각의
+// 테스트는 여전히 배선만 검증한다).
+import { describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  ContentRuleViolationList, ContentRuleSubmitBlockedReason,
+  contentRuleViolationHint, KNOWN_CONTENT_RULES_SETTINGS_PATH,
+  type ContentRuleViolation,
+} from './content-rule-violation';
+
+const MESSAGES: Record<string, string> = {
+  contentRuleBannedTermBlockedHint: '「{value}」은 쓸 수 없습니다.',
+  contentRuleUtmMissingBlockedHint: '링크에 UTM 3종이 있어야 합니다.',
+  contentRuleGenericBlockedHint: '이 값은 콘텐츠 규칙에 맞지 않습니다.',
+  contentRuleSubmitBlockedHint: '규칙 위반 {count}건을 고쳐야 상신할 수 있습니다.',
+  contentRuleLinkLabel: '콘텐츠 규칙',
+};
+
+function t(key: string, values?: Record<string, string | number>): string {
+  let s = MESSAGES[key] ?? key;
+  if (values) for (const [k, v] of Object.entries(values)) s = s.replace(`{${k}}`, String(v));
+  return s;
+}
+
+function violation(overrides: Partial<ContentRuleViolation> = {}): ContentRuleViolation {
+  return {
+    code: 'banned_term', field: 'text', value: '무료체험', hint_key: 'content_rules.banned_term',
+    settings_path: KNOWN_CONTENT_RULES_SETTINGS_PATH, ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+describe('contentRuleViolationHint', () => {
+  it('banned_term — 걸린 낱말을 문구에 보간한다', () => {
+    expect(contentRuleViolationHint('banned_term', '무료체험', t)).toBe('「무료체험」은 쓸 수 없습니다.');
+  });
+  it('utm_missing — 고정 문구(값 보간 없음)', () => {
+    expect(contentRuleViolationHint('utm_missing', '', t)).toBe('링크에 UTM 3종이 있어야 합니다.');
+  });
+  it('⭐미지 code — 지어내지 않고 제네릭 폴백', () => {
+    expect(contentRuleViolationHint('unknown_future_code', 'x', t)).toBe('이 값은 콘텐츠 규칙에 맞지 않습니다.');
+  });
+});
+
+describe('ContentRuleViolationList', () => {
+  it('빈 배열 — 아무것도 안 그린다', () => {
+    container = document.createElement('div');
+    root = createRoot(container);
+    act(() => { root.render(<ContentRuleViolationList violations={[]} testId="x" t={t} />); });
+    expect(container.querySelectorAll('[data-testid="x"]')).toHaveLength(0);
+    act(() => { root.unmount(); });
+  });
+
+  it('⭐settings_path가 FE-known 값이면 「콘텐츠 규칙」 링크를 함께 그린다', () => {
+    container = document.createElement('div');
+    root = createRoot(container);
+    act(() => { root.render(<ContentRuleViolationList violations={[violation()]} testId="x" t={t} />); });
+    const el = container.querySelector('[data-testid="x"]');
+    expect(el?.textContent).toBe('「무료체험」은 쓸 수 없습니다. 콘텐츠 규칙');
+    expect(el?.querySelector('a')?.getAttribute('href')).toBe(KNOWN_CONTENT_RULES_SETTINGS_PATH);
+    act(() => { root.unmount(); });
+  });
+
+  it('⭐settings_path가 미지 값이면 링크를 안 그린다(경로 결정권을 BE로 안 넘김)', () => {
+    container = document.createElement('div');
+    root = createRoot(container);
+    act(() => { root.render(<ContentRuleViolationList violations={[violation({ settings_path: '/some/other/path' })]} testId="x" t={t} />); });
+    expect(container.querySelector('[data-testid="x"] a')).toBeNull();
+    act(() => { root.unmount(); });
+  });
+
+  it('여러 건 — 각각 별도 줄로 전부 그린다', () => {
+    container = document.createElement('div');
+    root = createRoot(container);
+    act(() => {
+      root.render(<ContentRuleViolationList
+        violations={[violation({ value: 'a' }), violation({ value: 'b', code: 'utm_missing' })]}
+        testId="x" t={t}
+      />);
+    });
+    expect(container.querySelectorAll('[data-testid="x"]')).toHaveLength(2);
+    act(() => { root.unmount(); });
+  });
+});
+
+describe('ContentRuleSubmitBlockedReason', () => {
+  it('개수를 문구에 보간한다', () => {
+    container = document.createElement('div');
+    root = createRoot(container);
+    act(() => { root.render(<ContentRuleSubmitBlockedReason count={3} testId="x" t={t} />); });
+    expect(container.querySelector('[data-testid="x"]')?.textContent).toBe('규칙 위반 3건을 고쳐야 상신할 수 있습니다.');
+    act(() => { root.unmount(); });
+  });
+});

--- a/apps/web/src/components/content/content-rule-violation.tsx
+++ b/apps/web/src/components/content/content-rule-violation.tsx
@@ -1,0 +1,78 @@
+import Link from 'next/link';
+
+/**
+ * story #3472 2부(BE 3471/#3825 계약, 유나 §16-7 정본 2026-09-05) — 초안 create/
+ * update 응답과 상신 422 CONTENT_RULE_VIOLATION이 공유하는 shape. field는 소비
+ * 화면의 실제 입력 필드 이름과 정확히 일치해야 한다(channel_post: text|link_url,
+ * site_post: title|summary|body_md — story #3483, BE 필드별 lint 뒤).
+ *
+ * story #3483 — channel-posts 상세(3472 2부)에서 site-posts 상세(3483)로 재사용
+ * 하기 위해 공용으로 뺀다(동작 무변, 중복 0). severity가 계약에 없는 것은 "알고
+ * 줄인 것"(첫 슬라이스=기계 검사 전부 차단) — 문구 키를 …BlockedHint 꼴로 짓는다.
+ */
+export interface ContentRuleViolation {
+  code: string;
+  field: string;
+  value: string;
+  hint_key: string;
+  settings_path: string;
+}
+
+// ⛔§16-7 "settings_path를 그대로 href로 쓰지 않는다" — FE가 아는 값만 라우트로
+// 매핑하고, 모르는 값이면 링크를 그리지 않는다(경로 결정권을 BE로 넘기지 않는다).
+export const KNOWN_CONTENT_RULES_SETTINGS_PATH = '/organization/content-rules';
+
+// story #3472 2부(§16-7) — code로 사람 문구를 고른다(hint_key는 BE 계약에 있으나
+// 값 자체가 아직 정해지지 않아 code를 1차 판정축으로 쓴다 — code는 그라운딩된 두
+// 값(banned_term·utm_missing)이 확실하다). 미지 code는 지어내지 않고 제네릭으로.
+export function contentRuleViolationHint(
+  code: string,
+  value: string,
+  t: (key: string, values?: Record<string, string | number>) => string,
+): string {
+  if (code === 'banned_term') return t('contentRuleBannedTermBlockedHint', { value });
+  if (code === 'utm_missing') return t('contentRuleUtmMissingBlockedHint');
+  return t('contentRuleGenericBlockedHint');
+}
+
+/**
+ * story #3483 — "그 필드 아래" 목록(§16-7). 호출부가 `violations`를 이미 해당
+ * field로 필터해 넘긴다(이 컴포넌트는 필터링을 모른다 — 어느 필드축이 있는지는
+ * 소비 화면(channel_post: text/link_url, site_post: title/summary/body_md)마다
+ * 달라 여기서 안 정한다).
+ */
+export function ContentRuleViolationList({
+  violations, testId, t,
+}: {
+  violations: ContentRuleViolation[];
+  testId: string;
+  t: (key: string, values?: Record<string, string | number>) => string;
+}) {
+  return (
+    <>
+      {violations.map((v, i) => (
+        <p key={`${v.code}-${i}`} className="text-xs text-muted-foreground" data-testid={testId}>
+          {contentRuleViolationHint(v.code, v.value, t)}{' '}
+          {v.settings_path === KNOWN_CONTENT_RULES_SETTINGS_PATH ? (
+            <Link href={v.settings_path} className="underline">{t('contentRuleLinkLabel')}</Link>
+          ) : null}
+        </p>
+      ))}
+    </>
+  );
+}
+
+/** story #3483 — "그래서 못 한다"는 버튼 밖·비활성(§17-13과 같은 규율). */
+export function ContentRuleSubmitBlockedReason({
+  count, testId, t,
+}: {
+  count: number;
+  testId: string;
+  t: (key: string, values?: Record<string, string | number>) => string;
+}) {
+  return (
+    <p className="text-xs text-muted-foreground" data-testid={testId}>
+      {t('contentRuleSubmitBlockedHint', { count })}
+    </p>
+  );
+}


### PR DESCRIPTION
## 배경
3472 2부(#3827)가 channel-posts 상세에 심은 위반 표시 로직(필드 아래 목록·상신 버튼 밖 사유)을 site-posts 상세(3483 본 작업, BE 3482 필드별 lint 뒤)에서 재사용하기 위해 먼저 뺐고, 이 PR 2번째 커밋에서 site-posts 상세 배선(본 스토리 AC)까지 이어서 얹었습니다.

**라이브는 BE 3482 착지 뒤** — 이 PR의 CI/유닛 테스트는 stub fetch라 BE 머지와 무관하게 지금 그린입니다.

## 1부 — 공용 컴포넌트 추출(리팩터, 동작 무변)
`components/content/content-rule-violation.tsx`(신규):
- `ContentRuleViolation` 타입 — `field`를 `'text' | 'link_url'`(channel_post 전용)에서 `string`으로 완화(site_post는 title|summary|body_md).
- `contentRuleViolationHint()` — code→사람 문구.
- `KNOWN_CONTENT_RULES_SETTINGS_PATH` — FE-known 라우트 상수.
- `ContentRuleViolationList` — "그 필드 아래" 목록.
- `ContentRuleSubmitBlockedReason` — 버튼 밖 사유(개수).

channel-posts 상세는 로컬 정의 3개를 지우고 이 모듈을 import — 동작 무변(기존 125 tests 그대로 green).

## 2부 — 원문(site_post) 상세 배선(본 AC)
정본 a0da40c9 §16-7 그대로:
- title·summary·body_md 세 필드 각각 아래에 그 필드 위반만(서로 안 샘).
- 저장(`POST .../site-posts/drafts`) 응답의 `violations[]`로 갱신.
- 상신(`POST .../submit`) 422 `CONTENT_RULE_VIOLATION`은 새 배너 없이 같은 목록 갱신만.
- 위반이 있으면(severity 없음=전부 차단) 상신 버튼 disabled+버튼 밖 사유(개수) — 편집 중에도 같은 강도.
- 저장은 안 막는다(위반은 상신만 막습니다 — channel-posts 상세와 동형).

## 검증
- 컴포넌트 단위테스트 8건 + channel-posts 상세 기존 125 tests 전부 green(리팩터 회귀 0 직접 증거)
- site-posts 상세 신규 pin 4건(title/summary/body_md 세 갈래 분리·상신 버튼 비활성+개수 문구·422 새 배너 없이 필드 갱신·회귀 0 기본 케이스) + 기존 51 tests 전부 green
- 전체 `pnpm vitest run`: 633 files / 5955 tests green
- `tsc --noEmit` clean, eslint clean
- i18n 가드(hanja·duplicate-keys·phrase-collision) clean — 신규 키 0(기존 `content` 네임스페이스 재사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)