### PR TITLE
[SID:3482] feat: site_post 초안 lint를 필드별로(title/summary/body_md)

### DIFF
--- a/backend/app/services/site_posts.py
+++ b/backend/app/services/site_posts.py
@@ -36,6 +36,23 @@ _LANG_RE = re.compile(r"^[a-z]{2}(-[A-Z]{2})?$")
 _APPROVED_STATUSES = ("approved", "auto_passed")
 
 
+def _lint_site_post_fields(
+    rules: dict | None, *, title: str, summary: str, body_md: str,
+) -> list[dict]:
+    """story #3482 — `lint_content` 자체는 무변(순수 함수, 결합 텍스트 한 덩이라는
+    전제가 없다). 이 함수가 title·summary·body_md를 **각각** 별도로 lint해 위반의
+    `field`를 호출부가 진짜 필드명으로 덮어쓴다 — #3471의 `f"{title}\\n{summary}\\n
+    {body_md}"` 결합 방식은 위반 field가 항상 "text"로 와 site_post 화면(text 필드
+    자체가 없다)이 「어느 필드 아래」를 못 정했다(미르코 3472 2부 범위 밖 처리).
+    link_url은 site_post에 구조적으로 없다(UTM 축은 세 호출 다 no-op) — channel_post
+    경로(link_url 있음)는 이 함수를 안 쓴다(무변)."""
+    violations: list[dict] = []
+    for field_name, text in (("title", title), ("summary", summary), ("body_md", body_md)):
+        for v in lint_content(rules, text=text, link_url=None):
+            violations.append({**v, "field": field_name})
+    return violations
+
+
 class InvalidSitePostInputError(ValueError):
     """slug/lang이 서버 형식 규칙을 어김(422)."""
 
@@ -399,14 +416,17 @@ async def create_site_post_draft_version(
     #     길 자체를 차단한다).
     await _reseal_gate_on_new_version(db, org_id=org_id, work_item_id=work_item_id, version=version, draft=draft)
 
-    # story #3471(페드루 PO 確定 2026-09-05) — channel_posts.py::create_channel_post_
-    # draft_version과 동형(비차단, draft에 스냅샷 저장). site_post는 link_url 필드가
-    # 없어 UTM 필수 검사는 구조적으로 no-op(lint_content가 link_url=None이면 그 축을
-    # 건너뛴다) — banned_terms만 title+summary+body_md 결합 텍스트에 적용한다(제목에
-    # 금칙어가 있어도 잡아야 한다, body_md만 보면 놓친다).
+    # story #3471(페드루 PO 確定 2026-09-05)·#3482(필드별, 2026-09-05 후속) —
+    # channel_posts.py::create_channel_post_draft_version과 동형(비차단, draft에
+    # 스냅샷 저장). site_post는 link_url 필드가 없어 UTM 필수 검사는 구조적으로
+    # no-op(lint_content가 link_url=None이면 그 축을 건너뛴다) — banned_terms를
+    # title·summary·body_md 각각에 적용한다(#3471의 결합 텍스트 한 덩이는 위반
+    # field가 항상 "text"로 와 site_post 화면이 «어느 필드 아래»를 못 정했다 —
+    # 미르코 3472 2부 범위 밖 처리, #3482 그라운딩).
     rule_row = await get_org_content_rules(db, org_id=org_id)
-    combined_text = f"{title}\n{summary}\n{body_md}"
-    violations = lint_content(rule_row.rules if rule_row else None, text=combined_text, link_url=None)
+    violations = _lint_site_post_fields(
+        rule_row.rules if rule_row else None, title=title, summary=summary, body_md=body_md,
+    )
     draft.lint_result = {"rules_version": rule_row.version if rule_row else 0, "violations": violations}
 
     await db.commit()
@@ -617,11 +637,13 @@ async def submit_site_post_draft(
         raise SitePostVersionNotFoundError(version_id)
     origin_author_member_id = versions[0].author_member_id
 
-    # story #3471(페드루 PO 確定 2026-09-05) — channel_posts.py::submit_channel_post_
-    # draft와 동형(제목·요약·본문 결합 재검사, link_url 없어 UTM 축은 no-op).
+    # story #3471(페드루 PO 確定 2026-09-05)·#3482(필드별) — channel_posts.py::
+    # submit_channel_post_draft와 동형 재검사(link_url 없어 UTM 축은 no-op), 필드별로
+    # 갈라 상신 422 body의 violations[].field도 title/summary/body_md 중 하나로 온다.
     rule_row = await get_org_content_rules(db, org_id=org_id)
-    submit_combined_text = f"{target.title}\n{target.summary}\n{target.body_md}"
-    submit_violations = lint_content(rule_row.rules if rule_row else None, text=submit_combined_text, link_url=None)
+    submit_violations = _lint_site_post_fields(
+        rule_row.rules if rule_row else None, title=target.title, summary=target.summary, body_md=target.body_md,
+    )
     if submit_violations:
         raise ContentRuleViolationError(
             rules_version=rule_row.version if rule_row else 0, violations=submit_violations,

--- a/backend/tests/test_3471_content_rules_lint_unit.py
+++ b/backend/tests/test_3471_content_rules_lint_unit.py
@@ -98,3 +98,47 @@ def test_lint_multiple_violations_all_reported():
     violations = lint_content(rules, text="대출 안내", link_url="https://example.com/no-utm")
     codes = {v["code"] for v in violations}
     assert codes == {"banned_term", "utm_missing"}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 단위 테스트 — _lint_site_post_fields() 순수 함수(DB 불요, story #3482)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_site_post_field_lint_banned_term_only_in_title_reports_title_field():
+    from app.services.site_posts import _lint_site_post_fields
+
+    violations = _lint_site_post_fields(
+        {"banned_terms": ["대출"]}, title="대출 광고 제목", summary="요약", body_md="본문",
+    )
+    assert [v["field"] for v in violations] == ["title"]
+
+
+def test_site_post_field_lint_banned_term_only_in_body_md_reports_body_md_field():
+    from app.services.site_posts import _lint_site_post_fields
+
+    violations = _lint_site_post_fields(
+        {"banned_terms": ["대출"]}, title="제목", summary="요약", body_md="대출 안내 본문",
+    )
+    assert [v["field"] for v in violations] == ["body_md"]
+
+
+def test_site_post_field_lint_same_term_in_two_fields_reports_two_violations_not_merged():
+    """story #3482 5줄 確定④ — 합치지 않는다(필드마다 위반 1건씩, 총 2건)."""
+    from app.services.site_posts import _lint_site_post_fields
+
+    violations = _lint_site_post_fields(
+        {"banned_terms": ["대출"]}, title="대출 제목", summary="요약", body_md="대출 본문",
+    )
+    assert len(violations) == 2
+    assert {v["field"] for v in violations} == {"title", "body_md"}
+
+
+def test_site_post_field_lint_require_utm_is_structural_noop_all_fields():
+    """site_post에 link_url 필드 자체가 없다 — 세 호출 다 link_url=None 고정."""
+    from app.services.site_posts import _lint_site_post_fields
+
+    violations = _lint_site_post_fields(
+        {"require_utm": True}, title="제목", summary="요약", body_md="본문",
+    )
+    assert violations == []

--- a/backend/tests/test_3471_org_content_rules_lint.py
+++ b/backend/tests/test_3471_org_content_rules_lint.py
@@ -404,7 +404,9 @@ async def test_channel_post_draft_create_reports_violation_then_submit_422_then_
 
 @pytest.mark.anyio
 async def test_site_post_draft_banned_term_in_title_blocks_submit():
-    """site_post는 title+summary+body_md 결합 텍스트로 lint — 제목에 금칙어가 있어도
+    """story #3482(2026-09-05 후속) — site_post는 title·summary·body_md 각각 lint한다
+    (#3471의 결합 텍스트 한 덩이 방식은 폐기 — field가 항상 "text"로 와 site_post
+    화면이 어느 필드 아래인지 못 정했다). 제목에 금칙어가 있으면 field="title"로
     잡혀야 한다(body_md만 보면 놓친다)."""
     from app.main import app
 
@@ -436,6 +438,7 @@ async def test_site_post_draft_banned_term_in_title_blocks_submit():
             )
             assert r_draft.status_code == 201, r_draft.text
             assert len(r_draft.json()["violations"]) == 1
+            assert r_draft.json()["violations"][0]["field"] == "title"
             draft_id = r_draft.json()["draft_id"]
 
             r_submit = await client.post(
@@ -443,6 +446,7 @@ async def test_site_post_draft_banned_term_in_title_blocks_submit():
             )
         assert r_submit.status_code == 422, r_submit.text
         assert r_submit.json()["error"]["code"] == "CONTENT_RULE_VIOLATION"
+        assert r_submit.json()["error"]["violations"][0]["field"] == "title"
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()


### PR DESCRIPTION
[SID:3482]

## Summary
- `create_site_post_draft_version`·`submit_site_post_draft` — 결합 텍스트 한 덩이(`f"{title}\n{summary}\n{body_md}"`)를 `lint_content`에 넣던 것을 title·summary·body_md 각각 별도 호출로 바꾸고, 위반의 `field`를 호출부가 실제 필드명으로 덮어쓴다. `lint_content` 자체는 무변(순수 함수).
- 같은 금칙어가 두 필드에 있으면 위반 2건(합치지 않음).
- `link_url`은 site_post에 구조적으로 없어 세 호출 다 `link_url=None`(UTM 축 no-op, 무변).
- channel_post 경로(`create_channel_post_draft_version`/`submit_channel_post_draft`)는 무변 — 이 PR의 diff는 `site_posts.py` + 테스트뿐.

## Background
#3471은 결합 텍스트 방식이라 위반 `field`가 항상 `"text"`로 왔다 — site_post 초안 화면엔 `text`라는 필드 자체가 없어 미르코군이 #3472 2부에서 원문 화면 위반 표시를 범위 밖으로 미뤘다(#3483가 이 PR을 기다리는 유일한 BE 선행).

## Test plan
- [x] 신규 단위 테스트 4건(`test_3471_content_rules_lint_unit.py`, DB 불요): 제목만 위반 → `field:"title"` · 본문만 → `field:"body_md"` · 둘 다 → 2건(병합 안 됨) · UTM 구조적 no-op.
- [x] 기존 `test_site_post_draft_banned_term_in_title_blocks_submit`에 `field == "title"` 단언 추가(create·submit 422 둘 다).
- [x] 회귀: `test_3471_org_content_rules_lint.py`(9건)·`test_3471_content_rules_lint_unit.py`(14건) 전부 local green.
- [x] `scripts/lint_destructive_schema_weights_registered.py` — 신규 destructive 파일 0(신규 테스트 파일 없음, 기존 파일에만 추가).

🤖 Generated with [Claude Code](https://claude.com/claude-code)