### PR TITLE
[SID:3486] fix: 채널 연결 「연결 시각」 상대시각 정본 적용 + 재발 가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1277,6 +1277,16 @@ jobs:
       - name: "Verify no hanja in i18n message values (story #3432 regression guard)"
         run: pnpm --filter web verify:no-hanja-in-i18n
 
+      # story #3486 회귀가드: 마케팅 콘텐츠·채널 연결 표면(content/**·organization/
+      # channels/**·components/content/**·components/channel-connect/**)에 브라우저
+      # 로케일 의존 날짜 toLocaleString/toLocaleDateString/toLocaleTimeString이 새로
+      # 생기면 실패한다 — 3436 묶음 8 정본(formatRelativeTime/formatScheduledAt)이
+      # 있는데 세 번째로 새던 자리(유나 10회차 관찰) 재발 방지. 스코프는 이 네
+      # 디렉터리뿐(하우스 전체 20+곳은 각자 다른 기능 영역이라 범위 밖 — PR #3834
+      # 본문 참조).
+      - name: "Verify no date toLocaleString on marketing/channel surfaces (story #3486 regression guard)"
+        run: pnpm --filter web verify:no-date-tolocalestring-marketing-surface
+
       # story #2420 AC3 회귀가드: globals.css의 `--<family>-tint` 배경 위에서 --foreground가
       # AA(4.5)를 넘는지 «정의 시점»에 계산한다(oklch→sRGB 변환은 Yuna의 실 Chromium canvas
       # 캡처값과 대조 검증된 순수함수 — 브라우저 불요, 빠르고 결정적). 새 계열(예: --info-tint)이

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "verify:migrated-resources-sync": "tsx scripts/verify-migrated-resources-sync.ts",
     "verify:no-new-raw-fetch-api": "tsx scripts/verify-no-new-raw-fetch-api.ts",
     "verify:no-direct-backend-v2-call": "tsx scripts/verify-no-direct-backend-v2-call.ts",
+    "verify:no-date-tolocalestring-marketing-surface": "tsx scripts/verify-no-date-tolocalestring-marketing-surface.ts",
     "verify:tint-foreground-contrast": "tsx scripts/verify-tint-foreground-contrast.ts",
     "verify:no-new-tint-color-text": "tsx scripts/verify-no-new-tint-color-text.ts",
     "verify:cross-element-tint-text": "tsx scripts/verify-cross-element-tint-text.ts",

--- a/apps/web/scripts/verify-no-date-tolocalestring-marketing-surface.test.ts
+++ b/apps/web/scripts/verify-no-date-tolocalestring-marketing-surface.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { extractHits } from './verify-no-date-tolocalestring-marketing-surface';
+
+describe('extractHits — 순수 판정 함수(story #3486 재발 가드)', () => {
+  it('⭐#3486 실사고 픽스처 — 고치기 前 channels/page.tsx 원문을 그대로 잡는다', () => {
+    const hits = extractHits(
+      "{t('channelConnectedBy', { time: new Date(conn.created_at).toLocaleString() })}",
+      'app/(authenticated)/organization/channels/page.tsx',
+    );
+    expect(hits).toEqual([{ file: 'app/(authenticated)/organization/channels/page.tsx', line: 1 }]);
+  });
+
+  it('toLocaleDateString·toLocaleTimeString도 잡는다', () => {
+    expect(extractHits('new Date(x).toLocaleDateString()', 'f.tsx')).toHaveLength(1);
+    expect(extractHits('new Date(x).toLocaleTimeString()', 'f.tsx')).toHaveLength(1);
+  });
+
+  it('formatRelativeTime로 고친 뒤에는 안 잡는다(회귀 0)', () => {
+    const hits = extractHits(
+      "{t('channelConnectedBy', { time: formatRelativeTime(conn.created_at, locale, displayTimezone) })}",
+      'app/(authenticated)/organization/channels/page.tsx',
+    );
+    expect(hits).toEqual([]);
+  });
+
+  it('여러 줄에 걸쳐 있으면 줄 번호를 정확히 낸다', () => {
+    const content = [
+      'const a = 1;',
+      'const b = new Date(x).toLocaleString();',
+      'const c = 2;',
+    ].join('\n');
+    expect(extractHits(content, 'f.tsx')).toEqual([{ file: 'f.tsx', line: 2 }]);
+  });
+});

--- a/apps/web/scripts/verify-no-date-tolocalestring-marketing-surface.ts
+++ b/apps/web/scripts/verify-no-date-tolocalestring-marketing-surface.ts
@@ -1,0 +1,104 @@
+/**
+ * story #3486(3436 묶음 8 잔여, 유나 10회차 관찰 2026-09-05) — 「연결 시각」이
+ * `new Date(...).toLocaleString()`(브라우저 로케일 의존)으로 남아 있던 자리를
+ * 묶음 8 정본(`formatRelativeTime`, PR #3814)으로 정정한 뒤, 같은 결함이 이
+ * 표면(마케팅 콘텐츠·채널 연결)에 다시 새지 않게 가드한다.
+ *
+ * ⚠️PO 정정(2026-09-05) — 원래 AC2는 "apps/web/src 안 toLocaleString( 호출 0"으로
+ * 하우스 전체를 가리키는 것처럼 읽혔으나, 유나 10회차의 「하우스」는 묶음 8이 다룬
+ * 마케팅 표면 하나를 가리킨 것이었다(오기). 아래 네 디렉터리 밖(문서·칸반·활동
+ * 로그·설정·인박스·리워드 등 20+곳)은 각자 다른 기능 영역이라 이 스토리 범위
+ * 밖이다 — 그 목록은 PR 본문에 "범위 밖·미착수"로 남긴다(후속 스토리 여부는 PO
+ * 별도 판단).
+ *
+ * 가드 범위(마케팅운영 콘텐츠·채널 연결 표면만):
+ *   - app/(authenticated)/content/**
+ *   - app/(authenticated)/organization/channels/**
+ *   - components/content/**
+ *   - components/channel-connect/**
+ *
+ * ⛔이 가드가 못 보는 것(선언) — ①위 네 디렉터리 밖의 모든 파일(하우스 전체
+ * 20+곳, 스코프 밖) ②숫자 포맷 `.toLocaleString('ko-KR')`류(날짜가 아니다 —
+ * 이 가드는 `toLocaleString`/`toLocaleDateString`/`toLocaleTimeString` 어떤
+ * 호출이든 이 네 디렉터리 안에서는 전부 날짜 포맷으로 간주해 막는다. 이 범위
+ * 안에 지금 숫자 포맷 소비처가 없다는 것을 이 스토리 작성 시점 grep으로 확認
+ * 했다 — 나중에 정말 숫자 포맷이 필요해지면 이 가드에 예외를 등재할 것) ③주석·
+ * 문자열 리터럴 안의 언급(테스트 파일은 이미 제외).
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src');
+const EXT_RE = /\.(tsx?|ts)$/;
+const TEST_RE = /\.test\.[tj]sx?$/;
+
+const SCOPED_DIRS = [
+  'app/(authenticated)/content',
+  'app/(authenticated)/organization/channels',
+  'components/content',
+  'components/channel-connect',
+];
+
+const LOCALE_DATE_CALL_RE = /\.(toLocaleString|toLocaleDateString|toLocaleTimeString)\(/g;
+
+export interface DateToLocaleStringHit {
+  file: string;
+  line: number;
+}
+
+export function extractHits(content: string, file: string): DateToLocaleStringHit[] {
+  const hits: DateToLocaleStringHit[] = [];
+  const lines = content.split('\n');
+  lines.forEach((lineText, i) => {
+    LOCALE_DATE_CALL_RE.lastIndex = 0;
+    if (LOCALE_DATE_CALL_RE.test(lineText)) hits.push({ file, line: i + 1 });
+  });
+  return hits;
+}
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walk(full, out);
+    } else if (EXT_RE.test(entry) && !TEST_RE.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+function main(): number {
+  const files: string[] = [];
+  for (const dir of SCOPED_DIRS) {
+    const abs = path.join(SRC_ROOT, dir);
+    try {
+      walk(abs, files);
+    } catch {
+      // 디렉터리 자체가 없으면(개편 등) 스킵 — 있는 범위만 검사.
+    }
+  }
+
+  const hits: DateToLocaleStringHit[] = [];
+  for (const abs of files) {
+    const content = readFileSync(abs, 'utf8');
+    const rel = path.relative(SRC_ROOT, abs).split(path.sep).join('/');
+    hits.push(...extractHits(content, rel));
+  }
+
+  if (hits.length > 0) {
+    console.log(`\n❌ 마케팅 콘텐츠·채널 연결 표면에 날짜 toLocaleString류 ${hits.length}건(story #3486 재발 — formatRelativeTime/formatScheduledAt 정본을 쓸 것):`);
+    for (const h of hits.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
+      console.log(`  - ${h.file}:${h.line}`);
+    }
+    return 1;
+  }
+
+  console.log('OK: 마케팅 콘텐츠·채널 연결 표면(content/**·organization/channels/**·components/content/**·components/channel-connect/**) 안 날짜 toLocaleString류 0건');
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.test.tsx
@@ -416,3 +416,37 @@ describe('OrganizationChannelsPage — pasted_secret 자리 채움(story #3450 F
     expect(container.textContent).not.toMatch(/•{2,}|\*{2,}/);
   });
 });
+
+// story #3486(3436 묶음 8 잔여, 유나 10회차 관찰 2026-09-05) — 「연결 시각」이
+// new Date(...).toLocaleString()(브라우저 로케일 의존)이던 것을 묶음 8 정본
+// (formatRelativeTime)으로 정정. "지금"을 고정해(vi.setSystemTime) 결정적으로 잰다.
+describe('OrganizationChannelsPage — 연결 시각 상대시각 정본(story #3486)', () => {
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('⭐연결 3일 전 — 상대시각(브라우저 로케일 절대 포맷 아님)으로 보인다', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-04T00:00:00Z'));
+    stubFetch({ connections: [{ ...CONNECTION_ACTIVE, created_at: '2026-09-01T00:00:00Z' }] });
+    await mount('owner');
+
+    // 브라우저 로케일 절대 포맷(toLocaleString 특유의 "2026. 9. 1." 류 마침표 구분·
+    // 오전/오후)이 하나도 안 남는다 — 이게 바로 이 스토리가 잡는 회귀 모양이다.
+    expect(container.textContent).not.toMatch(/\d{4}\. \d{1,2}\. \d{1,2}\./);
+    expect(container.textContent).not.toContain('오전');
+    expect(container.textContent).not.toContain('오후');
+    // 7일 이내라 formatRelativeTime의 상대 분기("전")로 떨어진다.
+    expect(container.textContent).toContain('전');
+  });
+
+  it('연결 10일 전(7일 폴백 경계 밖) — formatRelativeTime의 절대 포맷(§11-2)으로 정상 폴백한다', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-11T00:00:00Z'));
+    stubFetch({ connections: [{ ...CONNECTION_ACTIVE, created_at: '2026-09-01T00:00:00Z' }] });
+    await mount('owner');
+
+    // 폴백도 formatScheduledAt(§11-2 정본)이지 브라우저 toLocaleString이 아니다 —
+    // "MM-DD HH:mm TZ" 꼴(마침표 구분자 없음).
+    expect(container.textContent).toMatch(/09-01 \d{2}:\d{2}/);
+    expect(container.textContent).not.toMatch(/\d{4}\. \d{1,2}\. \d{1,2}\./);
+  });
+});

--- a/apps/web/src/app/(authenticated)/organization/channels/page.tsx
+++ b/apps/web/src/app/(authenticated)/organization/channels/page.tsx
@@ -2,13 +2,15 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { fetchWithAuth } from '@/lib/db/client';
 import { channelLabel } from '@/lib/channel-label';
+import { formatRelativeTime } from '@/lib/storage/format';
+import { resolveDisplayTimezone } from '@/components/content/schedule-format';
 import { ChannelStatusChip } from '@/components/channel-connect/channel-status-chip';
 import { deriveChannelConnectionStatus, worstChannelConnectionStatus } from '@/components/channel-connect/connection-status';
 import { AppCredentialsCard } from '@/components/channel-connect/app-credentials-card';
@@ -60,6 +62,10 @@ function ConnectionRow({
     serverStatus: conn.status, tokenExpiresAt: conn.token_expires_at,
     canAutoRefresh: conn.can_auto_refresh, lastError: conn.last_error,
   });
+  // story #3486(유나 10회차, 3436 묶음 8 정본 재사용) — 「연결 시각」은 약속이 아니라
+  // 기록이라 상대시각이 맞다(묶음 8 판정 그대로). 새 포맷 함수를 신설하지 않는다.
+  const locale = useLocale();
+  const displayTimezone = resolveDisplayTimezone().tz;
   const [testResult, setTestResult] = useState<TestConnectionResponse | null>(null);
   const [testing, setTesting] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
@@ -106,7 +112,7 @@ function ConnectionRow({
             ) : null}
           </p>
           <p className="text-xs text-muted-foreground">
-            {t('channelConnectedBy', { time: new Date(conn.created_at).toLocaleString() })}
+            {t('channelConnectedBy', { time: formatRelativeTime(conn.created_at, locale, displayTimezone) })}
           </p>
         </div>
         <ChannelStatusChip status={derived.status} />


### PR DESCRIPTION
## 배경
유나 10회차 라이브(2026-09-05) — `organization/channels/page.tsx:109`가 `new Date(conn.created_at).toLocaleString()`(브라우저 로케일 의존, 「2026. 9. 5. 오전 9:19:14」)로 남아 3436 묶음 8(#3814) 상대시각 정본이 빠졌던 세 번째 자리.

## 처방
`formatRelativeTime`(정본, #3814)로 교체 — 새 포맷 함수 신설 없음.

## ⚠️ 스코프 정정(PO 確定)
원래 AC2 "apps/web/src 안 toLocaleString( 호출 0"을 문자 그대로 grep하면 **하우스 전체에 날짜 toLocaleString류가 20곳 이상**(docs·kanban·activity·settings·inbox·support-widget 등, 전부 이 스토리와 무관한 기능 영역) 나왔습니다 — 서술("세 번째 자리", 단수)과 AC 문구가 어긋난 것을 보고했고, PO가 "유나 10회차의 「하우스」=묶음 8이 다룬 마케팅 표면 하나"로 확定했습니다.

**가드 범위를 좁혔습니다:**
- `app/(authenticated)/content/**`
- `app/(authenticated)/organization/channels/**`
- `components/content/**`
- `components/channel-connect/**`

**그 밖 20+곳(범위 밖·미착수, 이번에 손대지 않음, 후속 스토리 여부는 PO 별도 판단):**
docs/doc-gate-section.tsx · doc-status-rail.tsx · policy-doc-browser.tsx · kanban/story-detail-panel.tsx(2곳) · story-card.tsx · activity/activity-log-view.tsx · cage/gate-evidence.tsx · stuck-handoff-detail.tsx · settings/recurring-recipes-section.tsx · workflow-execution-history-section.tsx · workflow-line-editor-section.tsx · mcp-connection-settings.tsx · support-widget-panel.tsx · agents/agent-run-detail.tsx · flow-map-canvas.tsx · inbox/page.tsx(3곳) · events/page.tsx · [slug]/page.tsx

숫자 포맷(`.toLocaleString('ko-KR')`류, krw/balance/amount)은 애초에 스코프 밖(날짜가 아님).

## 신설
`scripts/verify-no-date-tolocalestring-marketing-surface.ts` — 위 네 디렉터리 안 `toLocaleString`/`toLocaleDateString`/`toLocaleTimeString` 0을 지키는 회귀 가드(새로 생기면 빨강). 가드가 못 보는 범위(그 밖 디렉터리·숫자 포맷·주석)를 파일 상단에 선언.

## 검증
- **양성대조(실측)**: 가드를 원래 toLocaleString 코드로 되돌려 정확히 RED(정확한 파일:줄 지목) 확認 → 원복 후 GREEN.
- 신규 pin 6건(가드 순수함수 4 + 화면 2 — 상대시각 표기·7일 폴백 절대포맷, `vi.setSystemTime`으로 결정적으로 잼) + 기존 25 tests green(회귀 0)
- 전체 `pnpm vitest run`: 634 files / 5961 tests green
- `tsc --noEmit` clean, eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)